### PR TITLE
Sixifang/main pa kv fi v lds trans

### DIFF
--- a/csrc/kernels/attention.cu
+++ b/csrc/kernels/attention.cu
@@ -376,7 +376,7 @@ __device__ __forceinline__ _B16x8 convert_b8x8_custom(const _B8x8 input) {
 template <typename scalar_t, typename cache_t,
           vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT, int BLOCK_SIZE,
           int HEAD_SIZE, int NUM_THREADS,
-          int GQA_RATIO, bool VLLM_K_LAYOUT=false>
+          int GQA_RATIO, bool VLLM_K_LAYOUT>
 __global__ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const scalar_t* __restrict__ q,       // [num_seqs, num_heads, head_size]
     const cache_t* __restrict__ k_cache,  // [num_blocks, num_kv_heads,
@@ -2094,7 +2094,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
 template <typename scalar_t, typename cache_t,
           vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT, int BLOCK_SIZE,
           int HEAD_SIZE, int NUM_THREADS,
-          int GQA_RATIO, bool VLLM_K_LAYOUT=false>
+          int GQA_RATIO, bool VLLM_K_LAYOUT>
 __global__ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const scalar_t* __restrict__ q,       // [num_seqs, num_heads, head_size]
     const cache_t* __restrict__ k_cache,  // [num_blocks, num_kv_heads,
@@ -2166,7 +2166,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
 
 #define LAUNCH_CUSTOM_ATTENTION_MFMA16(GQA_RATIO)                                    \
   paged_attention_ll4mi_QKV_mfma16_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,        \
-                                   HEAD_SIZE, NTHR, GQA_RATIO>                \
+                                   HEAD_SIZE, NTHR, GQA_RATIO, false>                \
       <<<grid, block, 0, stream>>>(                                           \
           query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,     \
           block_tables_ptr, context_lens_ptr, max_num_blocks_per_seq,         \


### PR DESCRIPTION
Original:
golden vs ater:23.981710000000042[checkAllclose atol=0.01 rtol=0.01 passed~]
hipModuleLoad: /mnt/raid0/sixifang/ater/hsa/pa_a16w16.co GetFunction: pa_kernel_func Success
hipModuleLoad: /mnt/raid0/sixifang/ater/hsa/pa_a16w8.co GetFunction: pa_kernel_func Success
golden vs ater_asm:11.669250000000025[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):10.231319999999974[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater:23.800070000000034[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm:11.456050000000007[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):10.25007000000001[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater:24.173660000000027[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm:11.452020000000067[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):10.263670000000015[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater:134.81283000000002[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm:72.42938000000004[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):59.46220000000001[checkAllclose atol=0.01 rtol=0.01 passed~]

Now:
golden vs ater:21.066860000000037[checkAllclose atol=0.01 rtol=0.01 passed~]
hipModuleLoad: /mnt/raid0/sixifang/ater/hsa/pa_a16w16.co GetFunction: pa_kernel_func Success
hipModuleLoad: /mnt/raid0/sixifang/ater/hsa/pa_a16w8.co GetFunction: pa_kernel_func Success
golden vs ater_asm:12.142440000000015[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):10.607239999999983[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater:20.952859999999973[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm:11.787630000000014[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):10.622409999999968[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater:20.906039999999983[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm:11.78482000000002[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):10.660409999999983[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater:119.18756000000005[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm:72.65019999999993[checkAllclose atol=0.01 rtol=0.01 passed~]
golden vs ater_asm(quant:2, kvcache:torch.int8):59.457380000000015[checkAllclose atol=0.01 rtol=0.01 passed~]
