### PR TITLE
Workaround for failing Fmoe-g1u1 fp8smoothquant test

### DIFF
--- a/csrc/py_itfs_cu/asm_fmoe.cpp
+++ b/csrc/py_itfs_cu/asm_fmoe.cpp
@@ -640,7 +640,8 @@ void fmoe_fp8_g1u1_a16(torch::Tensor &out,                    // [token_cnt, dim
     FMoeKernel *impl_ptr = nullptr;
     int inter_dim = down.size(2);
     int sub_X_cnt = sorted_expert_ids.size(0);
-    int selectedTile = get_heuristic_tile(inter_dim, sub_X_cnt); // todo,add tune interface here
+    //int selectedTile = get_heuristic_tile(inter_dim, sub_X_cnt); // todo,add tune interface here
+    int selectedTile = 512;
 
     if (selectedTile == 512)
     {
@@ -653,7 +654,7 @@ void fmoe_fp8_g1u1_a16(torch::Tensor &out,                    // [token_cnt, dim
         impl_ptr = &impl_320;
     }
     else
-        TORCH_CHECK(false, __func__, " Unsupported inter_dim " + std::to_string(inter_dim) + ", which should be divisible by 128, 192, 256, 320, 384, 448 or 512");
+        TORCH_CHECK(false, __func__, " Unsupported selectedTile " + std::to_string(selectedTile) + ", which should be divisible by 320 or 512");
 
     impl_ptr->launch_kernel<uint8_t, uint16_t, true>(out,
                                                      input,

--- a/csrc/py_itfs_cu/asm_fmoe.cpp
+++ b/csrc/py_itfs_cu/asm_fmoe.cpp
@@ -641,14 +641,13 @@ void fmoe_fp8_g1u1_a16(torch::Tensor &out,                    // [token_cnt, dim
     int inter_dim = down.size(2);
     int sub_X_cnt = sorted_expert_ids.size(0);
     //int selectedTile = get_heuristic_tile(inter_dim, sub_X_cnt); // todo,add tune interface here
-    int selectedTile = 512;
 
-    if (selectedTile == 512)
+    if (inter_dim %512==0)
     {
         static FMoeKernel impl_512("fmoe_fp8_g1u1_smf_subGU_512", "fmoe_fp8_g1u1_smf_subGU_512.co", 512);
         impl_ptr = &impl_512;
     }
-    else if (selectedTile == 320)
+    else if (inter_dim %320==0)
     {
         static FMoeKernel impl_320("fmoe_fp8_g1u1_smf_subGU_320", "fmoe_fp8_g1u1_smf_subGU_320.co", 320);
         impl_ptr = &impl_320;


### PR DESCRIPTION
The MOE fp8 smoothquant test was failing. I traced to this tile size heuristic which returns SelectTile sizes that do not currently have an implementation.
The workaround here is to force 512 size for now but this heuristic will need to be reworked to be more flexible based on the currently available range of implementations.