### PR TITLE
Triton kernel benchmarking

### DIFF
--- a/op_benchmarks/triton/bench_mha.py
+++ b/op_benchmarks/triton/bench_mha.py
@@ -1,0 +1,511 @@
+import triton
+import triton.language as tl
+from utils.benchmark_utils import get_model_configs, get_available_models, print_vgpr
+import torch
+
+import os
+import sys
+import warnings
+import argparse
+
+# Add two parent directories to sys.path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(os.path.dirname(current_dir))
+sys.path.append(parent_dir)
+
+from aiter.ops.triton.mha import flash_attn_varlen_func, flash_attn_func, flash_attn_varlen_fp8_func, flash_attn_fp8_func
+import sys
+
+
+def mha_varlen_input_helper(Z, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, equal_seqlens=False, requires_grad=True):
+    torch.manual_seed(20)
+
+    # Random sequence lengths. Using N_CTX * Z as kind of maximum possible sum of individual seqs
+    if not equal_seqlens:
+        max_seqlens_q = N_CTX_Q
+        max_seqlens_k = N_CTX_K
+        if N_CTX_Q == N_CTX_K:
+            seqlens_q = torch.randint(1, max_seqlens_q + 1, (Z, ), dtype=torch.int32)
+            seqlens_k = seqlens_q
+        else:
+            seqlens_q = torch.randint(1, max_seqlens_q + 1, (Z, ), dtype=torch.int32)
+            seqlens_k = torch.randint(1, max_seqlens_k + 1, (Z, ), dtype=torch.int32)
+    else:
+        seqlens_q = torch.full((Z, ), N_CTX_Q)
+        seqlens_k = torch.full((Z, ), N_CTX_K)
+
+    # Calculate cumulative sequence lengths
+    cu_seqlens_q = torch.cat([torch.tensor([0], dtype=torch.int32), seqlens_q.cumsum(dim=0, dtype=torch.int32)])
+    cu_seqlens_k = torch.cat([torch.tensor([0], dtype=torch.int32), seqlens_k.cumsum(dim=0, dtype=torch.int32)])
+
+    cu_seqlens_q = cu_seqlens_q.to(device="cuda")
+    cu_seqlens_k = cu_seqlens_k.to(device="cuda")
+    # Initialize q, k, v with variable lengths
+    total_q = cu_seqlens_q[-1].item()
+    total_k = cu_seqlens_k[-1].item()
+
+    q = torch.randn((total_q, HQ, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_(requires_grad)
+    k = torch.randn((total_k, HK, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_(requires_grad)
+    v = torch.randn((total_k, HK, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_(requires_grad)
+    sm_scale = D_HEAD**-0.5
+    return q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale
+
+
+def mha_input_helper(Z, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, requires_grad=True):
+    torch.manual_seed(20)
+
+    # Initialize q, k, v
+    # bshd layout supported
+    q_tensor_shape = (Z, N_CTX_Q, HQ, D_HEAD)
+    k_tensor_shape = (Z, N_CTX_K, HK, D_HEAD)
+
+    q = torch.randn(q_tensor_shape, dtype=dtype, device="cuda", requires_grad=requires_grad)
+    k = torch.randn(k_tensor_shape, dtype=dtype, device="cuda", requires_grad=requires_grad)
+    v = torch.randn(k_tensor_shape, dtype=dtype, device="cuda", requires_grad=requires_grad)
+
+    sm_scale = D_HEAD**-0.5
+    # max_seqlens_q = N_CTX_Q
+    # max_seqlens_k = N_CTX_K
+
+    return q, k, v, sm_scale
+
+
+def nonvarlen_benchmark_configs():
+    configs = [
+        (16, 16, 16, 1024, 1024),
+        (8, 16, 16, 2048, 2048),
+        (4, 16, 16, 4096, 4096),
+        (2, 16, 16, 8192, 8192),
+        (1, 16, 16, 16384, 16384),
+        (2, 48, 48, 1024, 1024),
+        (2, 48, 48, 2048, 1024),
+        (2, 48, 48, 4096, 8192),
+        (2, 48, 48, 8192, 4096),
+        (2, 48, 48, 16384, 8192),
+        (8, 16, 16, 1989, 15344),
+        (4, 16, 16, 4097, 163),
+        (2, 16, 16, 8122, 2159),
+        (1, 16, 16, 16281, 7),
+        (2, 48, 48, 1021, 1020),
+        (2, 48, 48, 2001, 2048),
+        (2, 48, 48, 3996, 9639),
+        (2, 48, 48, 8181, 1021),
+    ]
+    return configs
+
+
+def varlen_benchmark_configs():
+    configs = [
+        (2, 16, 4, 1024, 1024),
+        (8, 16, 2, 2048, 2048),
+        (4, 16, 8, 4096, 4096),
+        (2, 16, 4, 8192, 8192),
+        (2, 16, 8, 16384, 16384),
+        (2, 48, 12, 1024, 1024),
+        (2, 48, 24, 2048, 2048),
+        (2, 48, 8, 4096, 4096),
+        (2, 48, 4, 8192, 8192),
+        (2, 48, 2, 16384, 16384),
+        (2, 64, 32, 1024, 1024),
+        (4, 64, 16, 2048, 2048),
+        (4, 64, 8, 4096, 4096),
+        (4, 64, 32, 8192, 8192),
+        (4, 128, 16, 16384, 16384),
+    ]
+    return configs
+
+def model_benchmark_configs(args):
+    config_file = args.model_configs
+    configs = get_model_configs(config_path=config_file, models=args.model)
+    fa_configs = []
+    batch_size = args.b if args.b else 1
+
+    for model_name, config in configs.items():
+        HQ = config["num_attention_heads"]
+        HK = HQ if config["num_key_value_heads"] is None else config["num_key_value_heads"]
+        N_CTX_Q = args.sq if args.sq else 8192
+        N_CTX_K = args.sk if args.sk else N_CTX_Q
+        HEAD_DIM = config["hidden_size"] // HQ
+        fa_configs.append((model_name, batch_size, HQ, HK, N_CTX_Q, N_CTX_K, HEAD_DIM))
+
+    return fa_configs
+
+def test_correctness(custom, args):
+    dtype = arg_to_torch_dtype[args.dtype]
+    hk = args.hq if not args.hk else args.hk
+    sk = args.sq if not args.sk else args.sk
+    head_size = 128 if not args.d else args.d
+    mode = 'fwd'
+    x_names = ['BATCH', 'HQ', 'HK', 'N_CTX_Q', 'N_CTX_K']
+    causal = args.causal
+    varlen = args.layout == 'thd'
+
+    if custom:
+        x_vals_list = [(args.b, args.hq, hk, args.sq, sk)]
+    else:
+        if varlen:
+            x_vals_list = varlen_benchmark_configs()
+        else:
+            x_vals_list = nonvarlen_benchmark_configs()
+
+        if args.model:
+            x_vals_list = model_benchmark_configs(args)
+            x_names = ['model', 'BATCH', 'HQ', 'HK', 'N_CTX_Q', 'N_CTX_K', 'D_HEAD']
+
+
+    def bench_flash_attention(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, causal, mode, provider, device="cuda",
+                              model=None):
+        assert mode in ["fwd", "bwd"]
+        requires_grad = False
+        # Bwd pass only supports causal=True right now
+        if mode == 'bwd':
+            causal = True
+            requires_grad = True
+
+        if varlen:
+            q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale = mha_varlen_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype,
+                                                            equal_seqlens=args.equal_seqlens, requires_grad=requires_grad)
+        else:
+            q, k, v, sm_scale = mha_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, requires_grad=requires_grad)
+        
+        if "Torch" in provider:
+            assert not varlen or args.equal_seqlens, "Torch sdpa does not support variable sequence lengths."
+            q = q.view(BATCH, N_CTX_Q, HQ, D_HEAD).transpose(1, 2)
+            k = k.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
+            v = v.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
+            if HQ != HK:  # TODO: sdpa(..., enable_gqa=True) works but gives very bad perf
+                k = k.repeat_interleave(q.size(-3) // k.size(-3), -3)
+                v = v.repeat_interleave(q.size(-3) // v.size(-3), -3)
+            fn = lambda: torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=causal, scale=sm_scale)
+        else:
+            o = torch.empty_like(q)
+            if varlen:
+                if args.fp8:
+                    fn = lambda: flash_attn_varlen_fp8_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
+                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+                else:
+                    fn = lambda: flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
+                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+            else:
+                if args.fp8:
+                    fn = lambda: flash_attn_fp8_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+                else:
+                    fn = lambda: flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+
+            if mode == 'bwd':
+                o, _ = fn()
+                do = torch.randn_like(o)
+                fn = lambda: o.backward(do, retain_graph=True)
+
+        return fn()
+
+    # Test correctness of the triton kernel by comparing the output to the torch sdpa output
+    for config in x_vals_list:
+        # Build a dictionary from x_names and config values, and add D_HEAD
+        cfg = {name: value for name, value in zip(x_names, config)}
+        cfg["D_HEAD"] = head_size  # head size computed above
+
+        # Run benchmark with Triton provider
+        triton_result = bench_flash_attention(
+            **cfg,
+            dtype=dtype,
+            causal=causal,
+            mode=mode,
+            provider="Triton"
+        )
+        triton_result = triton_result[0]
+
+        # Run benchmark with Torch provider
+        torch_result = bench_flash_attention(
+            **cfg,
+            dtype=dtype,
+            causal=causal,
+            mode=mode,
+            provider="Torch"
+        )
+
+        torch_result = torch_result.transpose(1,2)
+        if varlen:
+            torch_result = torch_result.flatten(0,1) # Triton kernel flattens batch and sequence length dims
+
+        # Check that the results are close
+        torch.testing.assert_close(triton_result, torch_result, rtol=2e-2, atol=2e-2)
+        print(f"Results are close for config: {cfg} for triton kernel and torch.sdpa!")
+
+
+def run_benchmark(custom, args):
+    dtype = arg_to_torch_dtype[args.dtype]
+    hk = args.hq if not args.hk else args.hk
+    sk = args.sq if not args.sk else args.sk
+    head_size = 128 if not args.d else args.d
+    mode = 'fwd'
+    x_names = ['BATCH', 'HQ', 'HK', 'N_CTX_Q', 'N_CTX_K']
+    causal = args.causal 
+    varlen = args.layout == 'thd'
+    
+    configs = []
+    plot_name = f'fused-attention-{mode}-D_HEAD-{head_size}-layout-{args.layout}-fp8-{args.fp8}-causal-{causal}'
+    extra_args = {'D_HEAD': head_size, 'dtype': dtype, 'causal': causal, 'mode': mode}
+    if custom:
+        x_vals_list = [(args.b, args.hq, hk, args.sq, sk)]
+    else:
+        if varlen:
+            x_vals_list = varlen_benchmark_configs()
+        else:
+            x_vals_list = nonvarlen_benchmark_configs()
+
+        if args.model:
+            x_vals_list = model_benchmark_configs(args)
+            x_names = ['model', 'BATCH', 'HQ', 'HK', 'N_CTX_Q', 'N_CTX_K', 'D_HEAD']
+            plot_name = f'fused-attention-{mode}-layout-{args.layout}-fp8-{args.fp8}-causal-{causal}'
+            extra_args = {'dtype': dtype, 'causal': causal, 'mode': mode}
+
+    unit = "TFLOPS"
+    if args.return_time:
+        unit = "ms"
+    if args.return_bandwidth:
+        unit = "GB/s"
+
+    if args.bench_torch:
+        if args.return_all:
+            line_vals = [f"{provider} ({unit})" for provider in ["Triton", "Torch"] for unit in ["ms", "TFLOPS", "TB/s"] ]
+        else:
+            line_vals = [f'Triton ({unit})', f'Torch ({unit})']
+    else:
+        line_vals = [unit]
+        if args.return_all:
+            line_vals = ["ms", "TFLOPS", "GB/s"]
+    
+    configs.append(
+        triton.testing.Benchmark(x_names=x_names, x_vals=x_vals_list, line_arg='provider', line_vals=line_vals,
+                                 line_names=line_vals, styles=[('red', '-'), ('green', '-'), ('blue', '-')]*2,
+                                 ylabel=unit, plot_name=plot_name, args=extra_args))
+
+    @triton.testing.perf_report(configs)
+    def bench_flash_attention(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, causal, mode, provider, device="cuda",
+                              model=None):
+        assert mode in ["fwd", "bwd"]
+
+        warmup = 25
+        rep = 100
+
+        requires_grad = False
+        # Bwd pass only supports causal=True right now
+        if mode == 'bwd':
+            causal = True
+            requires_grad = True
+
+        flops_per_matmul = 0
+        if varlen:
+            q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale = mha_varlen_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype,
+                                                            equal_seqlens=args.equal_seqlens, requires_grad=requires_grad)
+            num_contexts = len(cu_seqlens_q) - 1
+            for i in range(0, num_contexts):
+                seqlen_q = (cu_seqlens_q[i + 1] - cu_seqlens_q[i]).item()
+                seqlen_k = (cu_seqlens_k[i + 1] - cu_seqlens_k[i]).item()
+                # x2 in both cases for 2 GEMMs
+                if causal:
+                    valid_out_elements = ((seqlen_k**2 + seqlen_k) / 2) if seqlen_q > seqlen_k else \
+                            (seqlen_q * seqlen_k - ((seqlen_q**2 - seqlen_q) / 2))
+                    flops_per_matmul += valid_out_elements * HQ * D_HEAD * 2
+                else:
+                    flops_per_matmul += seqlen_q * seqlen_k * HQ * D_HEAD * 2
+        else:
+            q, k, v, sm_scale = mha_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, requires_grad=requires_grad)
+            if causal:
+                # Same calculation as if varlen/if causal above
+                valid_out_elements = ((N_CTX_K**2 + N_CTX_K) / 2) if N_CTX_Q > N_CTX_K else \
+                        (N_CTX_Q * N_CTX_K - ((N_CTX_Q**2 - N_CTX_Q) / 2))
+                flops_per_matmul = 2.0 * BATCH * HQ * valid_out_elements * D_HEAD
+            else:
+                flops_per_matmul = 2.0 * BATCH * HQ * N_CTX_Q * N_CTX_K * D_HEAD
+        
+        if "Torch" in provider:
+            assert not varlen or args.equal_seqlens, "Torch sdpa does not support variable sequence lengths. Hint: if you are using -layout thd, set -equal_seqlens aswell."
+            # torch.sdpa assumes bhsd layout
+            q = q.view(BATCH, N_CTX_Q, HQ, D_HEAD).transpose(1, 2)
+            k = k.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
+            v = v.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
+            if HQ != HK:  # TODO: sdpa(..., enable_gqa=True) works but gives very bad perf
+                k = k.repeat_interleave(q.size(-3) // k.size(-3), -3)
+                v = v.repeat_interleave(q.size(-3) // v.size(-3), -3)
+            fn = lambda: torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=causal, scale=sm_scale)
+        else:
+            o = torch.empty_like(q)
+            if varlen:
+                if args.fp8:
+                    fn = lambda: flash_attn_varlen_fp8_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
+                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+                else:
+                    fn = lambda: flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
+                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+            else:
+                if args.fp8:
+                    fn = lambda: flash_attn_fp8_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+                else:
+                    fn = lambda: flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
+                                                        causal=causal)
+
+            if mode == 'bwd':
+                o, _ = fn()
+                do = torch.randn_like(o)
+                fn = lambda: o.backward(do, retain_graph=True)
+
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+        total_flops = 2 * flops_per_matmul
+        if mode == "bwd":
+            total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
+
+        input_bytes = 1 if args.fp8 else q.element_size() # size of element in q,k,v in bytes
+        output_bytes = q.element_size()
+        if varlen:
+            total_num_tokens_q = cu_seqlens_q[-1].item()
+            total_num_tokens_k = cu_seqlens_k[-1].item()
+            mem = total_num_tokens_q * HQ * D_HEAD * input_bytes + 2 * total_num_tokens_k * HK * D_HEAD * input_bytes + total_num_tokens_q * HQ * D_HEAD * output_bytes
+        else:
+            total_num_tokens_q = BATCH * N_CTX_Q
+            total_num_tokens_k = BATCH * N_CTX_K
+            mem = total_num_tokens_q * HQ * D_HEAD * input_bytes + 2 * total_num_tokens_k * HK * D_HEAD * input_bytes + total_num_tokens_q * HQ * D_HEAD * output_bytes
+
+        if "ms" in provider:
+            return ms
+        elif "TFLOPS" in provider:
+            return total_flops / ms * 1e-9
+        else: # bandwidth GB/s
+            return mem / ms * 1e-3
+
+
+    bench_flash_attention.run(save_path=".", print_data=True, show_plots=True)
+
+
+def supported_layouts():
+    layouts = \
+        'bshd: Q, K, V are individual tensors of [batch, seqlen_q/k, num_heads, head_size]. ' \
+        'thd: Q, K, V are individual tensors of [total_q/k, num_heads, head_size]. '
+    return layouts
+
+# argparse lacks support for boolean argument type (sigh...)
+def str2bool(v):
+    if isinstance(v, bool) or v is None:
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+def parse_args():
+    
+    parser = argparse.ArgumentParser(
+        prog="Benchmark FlashAttention",
+        allow_abbrev=False,
+    )
+    parser.add_argument('-model_configs', type=str, default="utils/model_configs.json", help="Model config json file.")
+    available_models = get_available_models()  # Dynamically load model names
+    model_help = (
+        "Model name to benchmark. Select from: [" + ", ".join(available_models) +
+        "]. Use 'all' to benchmark all models. Provide model family (the part before -) to benchmark all models in that family. One can provide multiple as -model \"llama3,mistral_7B\""
+    )
+    parser.add_argument('-model', type=str, default="", help=model_help)
+    parser.add_argument("-b", type=int, default=0)
+    parser.add_argument("-hq", type=int, default=0)
+    parser.add_argument("-hk", type=int, default=0)
+    parser.add_argument("-sq", type=int, default=0)
+    parser.add_argument("-sk", type=int, default=0)
+    parser.add_argument("-equal_seqlens", action='store_true', default=False,
+                        help='If specified, uses equal sequence lengths with thd layout, i.e t = b * sq')
+    parser.add_argument("-d", type=int, default=0)
+    parser.add_argument("-causal", type=str2bool, default=None)
+    parser.add_argument("-fp8", action='store_true', default=False)
+    parser.add_argument("-quantize_p", action='store_true', default=False)
+    parser.add_argument("-dtype", default='fp16')
+    parser.add_argument("-bench_torch", action='store_true', default=False)
+    parser.add_argument("-print_vgpr", action='store_true', default=False)
+    parser.add_argument("-return_all", action='store_true', default=False, help="Prints TFLOPS, walltime, bandwidth.")
+    # prints TFLOPS without setting the following
+    parser.add_argument("-return_time", action='store_true', default=False, help="Prints only walltime.")
+    parser.add_argument("-return_bandwidth", action='store_true', default=False, help="Prints only memory bandwidth.")
+    parser.add_argument("-test_correctness", action='store_true', default=False,
+                         help="Tests correctness of the Triton provider comparing the output to the Torch sdpa.")
+    parser.add_argument("-layout", type=str, default=None, help=supported_layouts())
+    parser.add_argument(
+        "-persistent", nargs='?', const='fixed', choices=['fixed', 'dynamic'], default=None,
+        help="Enable persistent kernels. Use '-persistent dynamic' for dynamic scheduling of the tiles.")
+    return parser.parse_args()
+
+
+arg_to_torch_dtype = {'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32}
+
+
+def main():
+    args = parse_args()
+    
+    if args.model:
+        if args.causal is None:  # User didn’t specify -causal
+            args.causal = True
+        if args.layout is None:  # User didn’t specify -layout
+            args.layout = 'thd'
+        print(f"Note: using -model config defaults: causal={args.causal}, layout={args.layout}. This is the most common real life scenario, but can be overridden with -causal and -layout flags.")
+    else:
+        # the defaults for causal and varlen when not using the -model
+        if args.causal is None:  # User didn’t specify -causal
+            args.causal = False
+        if args.layout is None:  # User didn’t specify -layout
+            args.layout = 'bshd'
+    
+    custom_config = False
+    assert not args.test_correctness or (not args.layout=="thd") or args.equal_seqlens, \
+        "Varlen not supported for -test_correctness, so use -equal_seqlens if using thd layout."
+
+    assert args.layout == 'thd' or not args.equal_seqlens or args.model, \
+           "Equal sequence lengths arg must be used with the thd layout or a model config."
+    if args.hq or args.hk or args.d:
+        custom_config = True
+        assert args.b and args.hq and args.sq and args.d, \
+               "If custom config is specified, please provide \
+                all of batch, number of Q heads, Q sequence length \
+                and head size."
+
+    if args.model:
+        assert not (args.hq or args.hk or args.d), \
+                "Specifying model fixes hq, hk and d already. Do not provide them!"
+
+    assert args.dtype in arg_to_torch_dtype, \
+           "Only fp16, bf16 and f32 types currently supported."
+
+    assert args.layout in supported_layouts(), f"{args.layout} is not in supported layouts: {supported_layouts()}."
+
+    if args.test_correctness:
+        test_correctness(custom_config, args)
+
+    if args.layout == "thd" and args.equal_seqlens:
+        warnings.warn(
+            "Using 'thd' layout with equal_seqlen=True incurs an extra sequence length lookup cost "
+            "compared to 'bshd' layout. Consider using 'bshd' for better performance.",
+            category=RuntimeWarning
+        )
+
+    if args.print_vgpr:
+        assert not args.bench_torch, "Do not use -bench_torch with -print_vgpr."
+        print("Retrieving VGPR usage for Triton kernels...")
+        fun = lambda: run_benchmark(custom_config, args)
+        print_vgpr(fun, "fused-attention")        
+        return 0
+
+
+    run_benchmark(custom_config, args)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())

--- a/op_benchmarks/triton/bench_moe.py
+++ b/op_benchmarks/triton/bench_moe.py
@@ -1,0 +1,159 @@
+import triton
+import triton.language as tl
+from utils.benchmark_utils import get_model_configs, get_available_models, torch_to_tl_dtype
+from op_tests.triton.test_moe import input_helper, input_helper_int4_w4a16
+import torch
+import argparse
+from aiter.ops.triton.moe_op import fused_moe as triton_moe
+import sys
+
+def model_benchmark_configs(args):
+    config_file = args.model_configs
+    configs = get_model_configs(config_path=config_file, models="mistral" if args.model == None else args.model)
+    moe_configs = []
+    M = args.M if args.M else 4096  # check size
+    # M, K, N, E, top_k
+
+    for model_name, config in configs.items():
+        N1 = config["intermediate_size"]
+        K1 = config["hidden_size"]
+
+        N2 = config["hidden_size"]
+        K2 = config["intermediate_size"] // 2
+
+        E = 8
+        top_k = 2
+
+        moe_configs.append((model_name, M, N1, K1, E, top_k))
+        moe_configs.append((model_name, M, N2, K2, E, top_k))
+
+    return moe_configs
+
+
+def fused_moe(M, N, K, top_k, E, routed_weight=False, dtype=torch.float16, int4_w4a16=False,
+                fp8_w8a8=False, int8_w8a16=False, group_size=128, has_zp=True):
+    if int4_w4a16:
+        a, b, triton_out, b_zp, b_scale, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config = input_helper_int4_w4a16(
+        M, N, K, top_k, E, routed_weight=routed_weight, dtype=dtype, group_size=group_size, has_zp=has_zp)
+
+        return lambda: triton_moe(a, b, triton_out, None, b_scale, b_zp, topk_weights, topk_ids, sorted_token_ids, expert_ids,
+                        num_tokens_post_padded, routed_weight, top_k, config, torch_to_tl_dtype[dtype], use_fp8_w8a8=False, use_int8_w8a16=False, use_int4_w4a16=True, block_shape=(0, group_size))
+    else:
+        a, b, triton_out, b_zp, a_scale, b_scale, topk_weights, topk_ids, sorted_token_ids, expert_ids, num_tokens_post_padded, config = input_helper(
+            M, N, K, top_k, E, routed_weight=routed_weight, dtype=dtype, fp8_w8a8=fp8_w8a8, int8_w8a16=int8_w8a16)
+
+        return lambda: triton_moe(a, b, triton_out, a_scale, b_scale, b_zp, topk_weights, topk_ids, sorted_token_ids, expert_ids,
+                        num_tokens_post_padded, routed_weight, top_k, config, torch_to_tl_dtype[dtype], fp8_w8a8, int8_w8a16, use_int4_w4a16=False)
+
+
+def run_benchmark(args):
+    routed_weight = args.routed_weight
+    int8_w8a16 = args.int8_w8a16
+    fp8_w8a8 = args.fp8_w8a8
+    int4_w4a16 = args.int4_w4a16
+    group_size = args.group_size
+    has_zp = args.has_zp
+    dtype = arg_to_torch_dtype[args.dtype]
+    fp8_type = arg_to_torch_dtype[args.fp8_type]
+
+    if int4_w4a16:
+        assert group_size != None, "set group_size with -group_size"
+
+    kernel_name = "_fused_moe_kernel"
+    if (int8_w8a16 or int4_w4a16) and \
+            (group_size is not None) and group_size > 0:
+        kernel_name = "_fused_moe_kernel_gptq_awq"
+
+    x_vals_list = model_benchmark_configs(args)
+    x_names = ['model', 'M', 'N', 'K', 'E', 'top_k']
+
+    line_names = ['Time (ms)', 'TFLOPS', 'Bandwidth (GB/s)']
+    line_vals = ['time', 'tflops', 'bandwidth']
+
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names, x_vals=x_vals_list, line_arg='metric', line_vals=line_vals, line_names=line_names,
+        styles=[('red', '-'), ('blue', '-'),
+                ('yellow', '-')], ylabel='ms / TFLOPS / GB/s', plot_name=f'{kernel_name}-benchmark', args={})
+
+    @triton.testing.perf_report([benchmark])
+    def bench_moe_gemm(M, N, K, E, top_k, metric, model=None):
+
+        # (M, K) * (top_k, N, K) -> (M, top_k, N). 2 for multiplication and accumulation
+        flops = 2.0 * M * top_k * K * N
+        # The weight is applied on the gemm product which has the shape of (M, top_k, N)
+        if routed_weight:
+            flops += M * top_k * N
+
+        if fp8_w8a8:
+            a_bytes = b_bytes = torch.tensor([], dtype=fp8_type).element_size()
+            c_bytes = torch.tensor([], dtype=dtype).element_size()
+        elif int8_w8a16:
+            b_bytes = torch.tensor([], dtype=torch.int8).element_size()
+            a_bytes = c_bytes = torch.tensor([], dtype=dtype).element_size()
+        else:
+            a_bytes = b_bytes = c_bytes = torch.tensor([], dtype=dtype).element_size()
+        # TODO add the int4 case
+
+        # (M, K) memory load for A (E,  N,  K) for B not (top_k,  N,  K) because we are in total bringing in all expert matrices into the chip from memory. It's just that not all multiply the same A.
+        mem_read = (M * K) * a_bytes + (E * N * K) * b_bytes
+
+        mem_write = (M * top_k * N) * c_bytes
+        mem = mem_read + mem_write
+
+        fn = fused_moe(M, N, K, top_k, E, routed_weight=routed_weight, dtype=torch.float16, int4_w4a16=int4_w4a16,
+                fp8_w8a8=fp8_w8a8, int8_w8a16=int8_w8a16, group_size=group_size, has_zp=has_zp)
+
+        ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+
+        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        tflops = flops / ms * 1e-9
+
+        # Return exactly one scalar depending on which metric is active
+        if metric == 'time':
+            return ms
+        elif metric == 'tflops':
+            return tflops
+        elif metric == 'bandwidth':
+            return bandwidth
+        else:
+            raise ValueError("Unknown metric: " + metric)
+
+    bench_moe_gemm.run(save_path=".", print_data=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark MoE GEMM",
+        allow_abbrev=False,
+    )
+    parser.add_argument('-model_configs', type=str, default="utils/model_configs.json", help="Model config json file.")
+    available_models = get_available_models()  # Dynamically load model names
+    model_help = ("Model name to benchmark. Select from: [" + ", ".join(available_models) +
+                  "]. Use 'all' to benchmark all models or leave blank for the default benchmark script.")
+    parser.add_argument('-model', type=str, default=None, help=model_help)
+    parser.add_argument("-M", type=int, default=0, help="M dimension")
+    parser.add_argument("-group_size", type=int, default=None, help="group_size for in4")
+    parser.add_argument("-routed_weight", action='store_true', default=False)
+    parser.add_argument("-int8_w8a16", action='store_true', default=False)
+    parser.add_argument("-fp8_w8a8", action='store_true', default=False)
+    parser.add_argument("-int4_w4a16", action='store_true', default=False)
+    parser.add_argument("-has_zp", action='store_true', default=False)
+    parser.add_argument("-dtype", default='fp16')
+    parser.add_argument("-fp8_type", default='e5m2fnuz')
+    args = parser.parse_args()
+    return args
+
+
+arg_to_torch_dtype = {
+    'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32, "e5m2fnuz": torch.float8_e5m2fnuz, "e4m3fnuz":
+    torch.float8_e4m3fnuz
+}
+
+
+def main():
+    args = parse_args()
+    run_benchmark(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/op_benchmarks/triton/bench_moe_align_block_size.py
+++ b/op_benchmarks/triton/bench_moe_align_block_size.py
@@ -1,0 +1,134 @@
+import triton
+import triton.language as tl
+from utils.benchmark_utils import get_model_configs, get_available_models
+from op_tests.triton.test_moe_align_block_size import input_helper
+import torch
+import argparse
+from aiter.ops.triton.moe_align_block_size import moe_align_block_size_triton
+import sys
+
+def model_benchmark_configs(args):
+    config_file = args.model_configs
+    configs = get_model_configs(config_path=config_file, models="mistral")
+    moe_configs = []
+    M = args.M if args.M else 4096  # check size
+    # M, K, N, E, top_k
+
+    for model_name, config in configs.items():
+        N1 = config["intermediate_size"]
+        K1 = config["hidden_size"]
+
+        N2 = config["hidden_size"]
+        K2 = config["intermediate_size"] // 2
+
+        E = 8
+        top_k = 2
+
+        moe_configs.append((model_name, M, N1, K1, E, top_k))
+        moe_configs.append((model_name, M, N2, K2, E, top_k))
+
+    return moe_configs
+
+def fused_moe_align_block_size(M: int, E: int, top_k: int, block_size: int):
+    topk_ids = input_helper(M, E, top_k)
+
+    max_num_tokens_padded = topk_ids.numel() + E * (block_size - 1)
+    sorted_ids = torch.empty((max_num_tokens_padded, ),
+                                dtype=torch.int32,
+                                device=topk_ids.device)
+    sorted_ids.fill_(topk_ids.numel())
+    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
+    expert_ids = torch.empty((max_num_m_blocks, ),
+                                dtype=torch.int32,
+                                device=topk_ids.device)
+    num_tokens_post_pad = torch.empty((1),
+                                        dtype=torch.int32,
+                                        device=topk_ids.device)
+
+    return lambda: moe_align_block_size_triton(topk_ids,
+    E,
+    block_size,
+    sorted_ids,
+    expert_ids,
+    num_tokens_post_pad)
+
+
+def run_benchmark(custom, args):
+    block_size = args.block_size
+    x_names = ['M', 'N', 'K', 'E', 'top_k']
+
+    x_vals_list = model_benchmark_configs(args)
+    x_names = ['model', 'M', 'N', 'K', 'E', 'top_k']
+
+
+    line_names = ['Time (ms)', 'Bandwidth (GB/s)']
+    line_vals = ['time', 'bandwidth']
+
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names, x_vals=x_vals_list, line_arg='metric', line_vals=line_vals, line_names=line_names,
+        styles=[('red', '-'), ('blue', '-')], ylabel='ms / GB/s', plot_name='moe-align-block-size', args={})
+
+    @triton.testing.perf_report([benchmark])
+    def bench_moe_align_block_size(M, N, K, E, top_k, metric, model=None):
+        max_num_tokens_padded = M * K + E * (block_size - 1)
+        max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
+
+        # topk_ids, int64
+        mem_read = (M * K) * 8
+
+        mem_write = (max_num_tokens_padded + max_num_m_blocks + 1) * 4
+        mem = mem_read + mem_write
+
+        fn = fused_moe_align_block_size(M, E, top_k, block_size)
+
+        ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+
+        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        # tflops = flops / ms * 1e-9
+
+        # Return exactly one scalar depending on which metric is active
+        if metric == 'time':
+            return ms
+        # elif metric == 'tflops':
+        #     return tflops
+        elif metric == 'bandwidth':
+            return bandwidth
+        else:
+            raise ValueError("Unknown metric: " + metric)
+
+    bench_moe_align_block_size.run(save_path=".", print_data=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark MoE align block size",
+        allow_abbrev=False,
+    )
+    parser.add_argument('-model_configs', type=str, default="utils/model_configs.json", help="Model config json file.")
+    available_models = get_available_models()  # Dynamically load model names
+    model_help = ("Model name to benchmark. Select from: [" + ", ".join(available_models) +
+                  "]. Use 'all' to benchmark all models or leave blank for the default benchmark script.")
+    parser.add_argument('-model', type=str, default=None, help=model_help)
+    parser.add_argument("-M", type=int, default=0, help="M dimension")
+    parser.add_argument("-block_size", type=int, default=128)
+    args = parser.parse_args()
+    return args
+
+
+arg_to_torch_dtype = {
+    'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32, "e5m2fnuz": torch.float8_e5m2fnuz, "e4m3fnuz":
+    torch.float8_e4m3fnuz
+}
+
+
+def main():
+    args = parse_args()
+    custom_config = False
+    # If user provides all M,K,N,E,top_k we consider it custom
+    if args.M and args.K and args.N and args.E and args.top_k:
+        custom_config = True
+    run_benchmark(custom_config, args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/op_benchmarks/triton/bench_pa_decode.py
+++ b/op_benchmarks/triton/bench_pa_decode.py
@@ -1,0 +1,192 @@
+import triton
+import triton.language as tl
+from utils.benchmark_utils import get_model_configs, get_available_models, get_dtype_bytes, torch_to_tl_dtype
+import torch
+import argparse
+from aiter.ops.triton.pa_decode import paged_attention_decode
+import sys
+import random
+
+def input_helper(B, H_Q, H_KV, D, KV_BLK_SZ, SEQ_LEN, dtype, kv_cache_dtype, output_type, num_blocks=4):
+    """Helper function to generate input tensors for paged attention testing."""
+    # Query tensor generation
+    if dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        query = torch.randn(
+            B, H_Q, D, dtype=torch.float16, device="cuda"
+        )  # assumption dtype is 8bits or lower
+        query = query.to(dtype=dtype, device="cuda")
+    else:
+        query = torch.randn(B, H_Q, D, dtype=dtype, device="cuda")
+
+    if kv_cache_dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        x = min(D, 16 // torch.tensor([], dtype=torch.float16).element_size())
+        key_cache = torch.randn(
+            num_blocks, H_KV, D // x, KV_BLK_SZ, x, dtype=torch.float16, device="cuda"
+        )
+        value_cache = torch.randn(
+            num_blocks, H_KV, D, KV_BLK_SZ, dtype=torch.float16, device="cuda"
+        )
+        key_cache = torch.clamp(key_cache, min=1e-3) #For FP8 case, this is needed to prevent NANs
+        value_cache = torch.clamp(value_cache, min=1e-3) #For FP8 case, this is needed to prevent NANs
+
+        # torch doesn't have randn for fp8 data type, so we convert here
+        key_cache = key_cache.to(dtype=kv_cache_dtype)
+        value_cache = value_cache.to(dtype=kv_cache_dtype)
+    else:
+        x = min(D, 16 // torch.tensor([], dtype=kv_cache_dtype).element_size())
+        key_cache = torch.randn(
+            num_blocks, H_KV, D // x, KV_BLK_SZ, x, dtype=kv_cache_dtype, device="cuda"
+        )
+        value_cache = torch.randn(
+            num_blocks, H_KV, D, KV_BLK_SZ, dtype=kv_cache_dtype, device="cuda"
+        )
+        key_cache = torch.clamp(key_cache, min=1e-3) #For FP8 case, this is needed to prevent NANs
+        value_cache = torch.clamp(value_cache, min=1e-3) #For FP8 case, this is needed to prevent NANs
+
+    key_cache_tri = key_cache.permute(0, 1, 3, 2, 4).flatten(3, 4).contiguous().cuda()
+    value_cache_tri = value_cache.permute(0, 1, 3, 2).contiguous().cuda()
+
+    context_lens = torch.full((B,), SEQ_LEN, device="cuda")
+    max_context_len = max(context_lens)
+    max_num_blks_per_seq = (max_context_len + KV_BLK_SZ - 1) // KV_BLK_SZ
+
+    block_tables = []
+    for i in range(B):
+        block_table = [
+            random.randint(0, num_blocks - 1) for _ in range(max_num_blks_per_seq)
+        ]
+        block_tables.append(block_table)
+    block_tables = torch.tensor(block_tables, dtype=torch.int32, device="cuda")
+
+    output = torch.zeros(B, H_Q, D, dtype=output_type, device="cuda")
+
+    return query, output, key_cache, value_cache, key_cache_tri, value_cache_tri, context_lens, block_tables, max_context_len
+
+
+def model_benchmark_configs(args):
+    config_file = args.model_configs
+    configs = get_model_configs(config_path=config_file, models="llama3,deepseek" if args.model == None else args.model)
+    fa_configs = []
+    BS = args.b if args.b else 1024
+
+    for model_name, config in configs.items():
+        HQ = config["num_attention_heads"]
+        HK = HQ if config["num_key_value_heads"] is None else config["num_key_value_heads"]
+        SEQ_LEN = args.sq if args.sq else 8192
+        HEAD_DIM = config["hidden_size"] // HQ
+        fa_configs.append((model_name, BS, HQ, HK, SEQ_LEN, HEAD_DIM))
+
+    return fa_configs
+
+def paged_attn_decode(BS, H_Q, H_KV, D, KV_BLK_SZ, SEQ_LEN, num_blocks, dtype, kv_cache_dtype, compute_type, output_type):
+    query, triton_output, _, _, key_cache_tri, value_cache_tri, context_lens, block_tables, max_context_len = input_helper(BS, H_Q, H_KV, D, KV_BLK_SZ, SEQ_LEN, dtype, kv_cache_dtype, output_type, num_blocks)
+    attn_scale = 1.0 / (D**0.5)
+    k_scale=torch.tensor([1.0])
+    v_scale=torch.tensor([1.0])
+
+    return lambda: paged_attention_decode(
+        output=triton_output,
+        query=query,
+        key_cache=key_cache_tri,
+        value_cache=value_cache_tri,
+        seq_lens=context_lens,
+        block_tables=block_tables,
+        attn_scale=attn_scale,
+        max_seq_len=max_context_len,
+        compute_type=compute_type,
+        k_scale=k_scale,
+        v_scale=v_scale
+    )
+
+def run_benchmark(args):
+    dtype = arg_to_torch_dtype[args.dtype]
+    kv_cache_dtype = arg_to_torch_dtype[args.kv_cache_dtype]
+    compute_type = torch_to_tl_dtype[arg_to_torch_dtype[args.compute_type]]
+    output_type = arg_to_torch_dtype[args.output_type]
+
+    x_vals_list = model_benchmark_configs(args)
+    x_names = ['model', 'BS', 'HQ', 'HK', 'SEQ_LEN', "HEAD_DIM"]
+
+    model_name = "paged-attn-decode"
+
+    line_names = ['Time (ms)', 'TFLOPS', 'Bandwidth (GB/s)']
+    line_vals = ['time', 'tflops', 'bandwidth']
+
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names, x_vals=x_vals_list, line_arg='metric', line_vals=line_vals, line_names=line_names,
+        styles=[('red', '-'), ('blue', '-'),
+                ('yellow', '-')], ylabel='ms / TFLOPS / GB/s', plot_name=f'{model_name}-benchmark', args={})
+
+    @triton.testing.perf_report([benchmark])
+    def bench_paged_attn_decode(BS, HQ, HK, SEQ_LEN, HEAD_DIM, metric, model=None):
+        # TODO tune this
+        KV_BLK_SZ = 128
+        num_blocks = 4
+        fn = paged_attn_decode(BS, HQ, HK, HEAD_DIM, KV_BLK_SZ, SEQ_LEN, num_blocks, dtype, kv_cache_dtype, compute_type, output_type)
+
+        ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+
+        # query and output
+        mem = (BS * HQ * HEAD_DIM) * (get_dtype_bytes(dtype) + get_dtype_bytes(output_type))
+        # kv_cache
+        mem += (num_blocks * HK * KV_BLK_SZ * HEAD_DIM * get_dtype_bytes(kv_cache_dtype) * 2)
+        # block_tables int32
+        mem += BS * ((SEQ_LEN + KV_BLK_SZ - 1) // KV_BLK_SZ) * 4
+        # context_lens fp32
+        mem += BS * 4
+
+        # bhd bhsd => bhs bhsd => bhs, 2 for multiplication and accumulation. and there are 2 gemms
+        flops = (2.0 * BS * HQ * SEQ_LEN * HEAD_DIM) * 2
+
+        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        # bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        tflops = flops / ms * 1e-9
+
+        # Return exactly one scalar depending on which metric is active
+        if metric == 'time':
+            return ms
+        elif metric == 'tflops':
+            return tflops
+        elif metric == 'bandwidth':
+            return bandwidth
+        else:
+            raise ValueError("Unknown metric: " + metric)
+
+    bench_paged_attn_decode.run(save_path=".", print_data=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark Paged Attention decode",
+        allow_abbrev=False,
+    )
+    parser.add_argument('-model_configs', type=str, default="utils/model_configs.json", help="Model config json file.")
+    available_models = get_available_models()  # Dynamically load model names
+    model_help = ("Model name to benchmark. Select from: [" + ", ".join(available_models) +
+                  "]. Use 'all' to benchmark all models or leave blank for the default benchmark script.")
+    parser.add_argument('-model', type=str, default=None, help=model_help)
+    parser.add_argument("-b", type=int, default=0)
+    parser.add_argument("-hq", type=int, default=0)
+    parser.add_argument("-hk", type=int, default=0)
+    parser.add_argument("-sq", type=int, default=0)
+    parser.add_argument("-dtype", default='fp16')
+    parser.add_argument("-kv_cache_dtype", default='fp16')
+    parser.add_argument("-compute_type", default='fp16')
+    parser.add_argument("-output_type", default='fp16')
+    args = parser.parse_args()
+    return args
+
+
+arg_to_torch_dtype = {
+    'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32, "e5m2fnuz": torch.float8_e5m2fnuz, "e4m3fnuz":
+    torch.float8_e4m3fnuz
+}
+
+
+def main():
+    args = parse_args()
+    run_benchmark(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/op_benchmarks/triton/bench_pa_prefill.py
+++ b/op_benchmarks/triton/bench_pa_prefill.py
@@ -1,0 +1,298 @@
+import triton
+import triton.language as tl
+from utils.benchmark_utils import get_model_configs, get_available_models, get_dtype_bytes, torch_to_tl_dtype
+from op_tests.triton.test_pa_prefill import seed_everything, STR_DTYPE_TO_TORCH_DTYPE
+import torch
+import argparse
+from aiter.ops.triton.pa_prefill import context_attention_fwd
+import sys
+import math
+import random
+
+def _get_alibi_slopes(total_num_heads: int) -> torch.Tensor:
+    closest_power_of_2 = 2 ** math.floor(math.log2(total_num_heads))
+    base = torch.tensor(
+        2 ** (-(2 ** -(math.log2(closest_power_of_2) - 3))),
+        dtype=torch.float32,
+    )
+    powers = torch.arange(1, 1 + closest_power_of_2, dtype=torch.int32)
+    slopes = torch.pow(base, powers)
+
+    if closest_power_of_2 != total_num_heads:
+        extra_base = torch.tensor(
+            2 ** (-(2 ** -(math.log2(2 * closest_power_of_2) - 3))),
+            dtype=torch.float32,
+        )
+        num_remaining_heads = min(
+            closest_power_of_2, total_num_heads - closest_power_of_2
+        )
+        extra_powers = torch.arange(
+            start=1, end=1 + 2 * num_remaining_heads, step=2, dtype=torch.int32
+        )
+        slopes = torch.cat([slopes, torch.pow(extra_base, extra_powers)], dim=0)
+    return slopes
+
+def input_helper(
+    BS,
+    MAX_SEQ_LEN,
+    MAX_CTX_LEN,
+    cache_size,
+    block_size,
+    max_block_per_request,
+    num_heads: int,
+    head_size: int,
+    num_queries_per_kv: int,
+    dtype: torch.dtype,
+    kv_cache_dtype: str,
+    device: str,
+    use_alibi_slope: bool,
+):
+    seed_everything(0)
+    torch.set_default_device(device)
+
+    # Need this, otherwise when we capture the graph the process
+    # for GPU 1 would run on both GPU0 and GPU1 and things would hang
+    #
+    # see also similar issue: https://github.com/Dao-AILab/flash-attention/issues/523
+    torch.cuda.set_device(device)
+
+    if use_alibi_slope:
+        alibi_slopes = _get_alibi_slopes(num_heads).to(device)
+
+    query_lens = [random.randint(16, MAX_SEQ_LEN) for _ in range(BS)]
+    ctx_lens = [random.randint(16, MAX_CTX_LEN) for _ in range(BS)]
+    seq_lens = [a + b for a, b in zip(query_lens, ctx_lens)]
+    num_kv_heads = num_heads // num_queries_per_kv
+
+    num_tokens = sum(query_lens)
+    query = torch.empty(num_tokens, num_heads, head_size, dtype=dtype)
+    query.uniform_(-1e-3, 1e-3)
+    output = torch.empty(num_tokens, num_heads, head_size, dtype=dtype)
+
+    kv = torch.empty(sum(seq_lens), 2, num_kv_heads, head_size, dtype=dtype)
+    kv.uniform_(-1e-3, 1e-3)
+    key, value = kv.unbind(dim=1)
+
+    if kv_cache_dtype == "auto":
+        cache_dtype = dtype
+    else:
+        cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[kv_cache_dtype]
+    k_cache = torch.zeros(
+        cache_size, block_size, num_kv_heads, head_size, dtype=cache_dtype
+    )
+    v_cache = torch.zeros(
+        cache_size, block_size, num_kv_heads, head_size, dtype=cache_dtype
+    )
+    k = torch.zeros(sum(query_lens), num_kv_heads, head_size, dtype=dtype)
+    v = torch.zeros(sum(query_lens), num_kv_heads, head_size, dtype=dtype)
+    values = torch.arange(0, cache_size, dtype=torch.long)
+    values = values[torch.randperm(cache_size)]
+    block_table = values[: BS * max_block_per_request].view(BS, max_block_per_request)
+    b_seq_len = torch.tensor(seq_lens, dtype=torch.long)
+    b_ctx_len = torch.tensor(ctx_lens, dtype=torch.long)
+    b_start_loc = torch.cumsum(torch.tensor([0] + query_lens, dtype=torch.long), dim=0)
+    max_input_len = MAX_SEQ_LEN
+    # copy kv to cache
+    b_seq_start_loc = torch.cumsum(
+        torch.tensor([0] + seq_lens[:-1], dtype=torch.long), dim=0
+    )
+    for i in range(BS):
+        for j in range(query_lens[i]):
+            k[b_start_loc[i] + j].copy_(key[b_seq_start_loc[i] + b_ctx_len[i] + j])
+            v[b_start_loc[i] + j].copy_(value[b_seq_start_loc[i] + b_ctx_len[i] + j])
+        cur_ctx = 0
+        block_id = 0
+        while cur_ctx < b_ctx_len[i]:
+            start_loc = b_seq_start_loc[i] + cur_ctx
+            if cur_ctx + block_size > b_ctx_len[i]:
+                end_loc = b_seq_start_loc[i] + b_ctx_len[i]
+            else:
+                end_loc = start_loc + block_size
+            start_slot = block_table[i, block_id] * block_size
+            end_slot = start_slot + end_loc - start_loc
+            k_cache.view(-1, num_kv_heads, head_size)[start_slot:end_slot].copy_(
+                key[start_loc:end_loc]
+            )
+            v_cache.view(-1, num_kv_heads, head_size)[start_slot:end_slot].copy_(
+                value[start_loc:end_loc]
+            )
+            cur_ctx += block_size
+            block_id += 1
+    # transpose K_cache[num_blocks, block_size, num_kv_heads, head_size]
+    # to K_cache[num_blocks, num_kv_heads, head_size/8, block_size, 8]
+    k_cache = (
+        k_cache.view(-1, block_size, num_kv_heads, head_size // 8, 8)
+        .permute(0, 2, 3, 1, 4)
+        .contiguous()
+    )
+    # transpose V_cache[num_blocks, block_size, num_kv_heads, head_size]
+    # to V_cache[num_blocks, num_kv_heads, head_size, block_size]
+    v_cache = (
+        v_cache.view(-1, block_size, num_kv_heads, head_size)
+        .permute(0, 2, 3, 1)
+        .contiguous()
+    )
+    k_scale = v_scale = torch.tensor(1.0, dtype=torch.float32, device=device)
+
+    if use_alibi_slope:
+        return query, k, v, output, k_cache, v_cache, block_table, b_start_loc, b_seq_len, max_input_len, k_scale, v_scale, alibi_slopes
+    else:
+        return query, k, v, output, k_cache, v_cache, block_table, b_start_loc, b_seq_len, max_input_len, k_scale, v_scale, None
+
+
+def model_benchmark_configs(args):
+    config_file = args.model_configs
+    configs = get_model_configs(config_path=config_file, models="llama3,deepseek" if args.model == None else args.model)
+    fa_configs = []
+    BS = args.b if args.b else 16
+
+    for model_name, config in configs.items():
+        HQ = config["num_attention_heads"]
+        HK = HQ if config["num_key_value_heads"] is None else config["num_key_value_heads"]
+        SEQ_LEN = args.sq if args.sq else 1024
+        HEAD_DIM = config["hidden_size"] // HQ
+        fa_configs.append((model_name, BS, HQ, HK, SEQ_LEN, HEAD_DIM))
+
+    return fa_configs
+
+def run_benchmark(args):
+    dtype = arg_to_torch_dtype[args.dtype]
+    kv_cache_dtype = args.kv_cache_dtype
+    use_alibi_slope = args.use_alibi_slope
+
+    x_vals_list = model_benchmark_configs(args)
+    x_names = ['model', 'BS', 'HQ', 'HK', 'MAX_SEQ_LEN', "HEAD_DIM"]
+
+    model_name = "paged-attn-decode"
+
+    line_names = ['Time (ms)', 'TFLOPS', 'Bandwidth (GB/s)']
+    line_vals = ['time', 'tflops', 'bandwidth']
+
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names, x_vals=x_vals_list, line_arg='metric', line_vals=line_vals, line_names=line_names,
+        styles=[('red', '-'), ('blue', '-'),
+                ('yellow', '-')], ylabel='ms / TFLOPS / GB/s', plot_name=f'{model_name}-benchmark', args={})
+
+    @triton.testing.perf_report([benchmark])
+    def bench_paged_attn_decode(BS, HQ, HK, MAX_SEQ_LEN, HEAD_DIM, metric, model=None):
+        # TODO tune this
+        MAX_CTX_LEN = MAX_SEQ_LEN
+        max_block_per_request = 1024
+
+        block_size = MAX_SEQ_LEN // max_block_per_request
+
+        cache_size = max_block_per_request * BS
+
+        if kv_cache_dtype == "auto":
+            torch_kv_cache_dtype = dtype
+        else:
+            torch_kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[kv_cache_dtype]
+
+        num_queries_per_kv = HQ // HK
+
+        query, k, v, output, k_cache, v_cache, block_table, b_start_loc, b_seq_len, max_input_len, k_scale, v_scale, alibi_slopes = input_helper(
+            BS=BS,
+            MAX_SEQ_LEN=MAX_SEQ_LEN,
+            MAX_CTX_LEN=MAX_CTX_LEN,
+            cache_size=cache_size,
+            block_size=block_size,
+            max_block_per_request=max_block_per_request,
+            num_heads=HQ,
+            head_size=HEAD_DIM,
+            num_queries_per_kv=num_queries_per_kv,
+            dtype=dtype,
+            kv_cache_dtype=kv_cache_dtype,
+            device=[f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)][0],
+            use_alibi_slope=use_alibi_slope,
+        )
+
+        num_tokens = query.shape[0]
+        fn = lambda: context_attention_fwd(
+            query,
+            k,
+            v,
+            output,
+            kv_cache_dtype,
+            k_cache,
+            v_cache,
+            block_table,
+            b_start_loc,
+            b_seq_len,
+            max_input_len,
+            k_scale,
+            v_scale,
+            alibi_slopes=alibi_slopes,
+        )
+        ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+
+        # query and output
+        mem = (num_tokens * HQ * HEAD_DIM) * get_dtype_bytes(dtype) * 2
+        # kv_cache
+        mem += (cache_size * block_size * HK * HEAD_DIM * get_dtype_bytes(torch_kv_cache_dtype) * 2)
+        # k, v
+        mem += (num_tokens * HK * HEAD_DIM * get_dtype_bytes(dtype) * 2)
+        # block_tables int32
+        mem += BS * max_block_per_request * 4
+        # b_seq_len int32
+        mem += BS * 4
+        # b_start_loc int32
+        mem += BS * 4
+
+        # cache
+        flops = (2.0 * BS * HQ * (num_tokens // BS) * (num_tokens // BS) * HEAD_DIM) * 2
+        # casual
+        flops += (2.0 * BS * HQ * max_block_per_request * (num_tokens // BS) * HEAD_DIM) * 2 // 2
+
+        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        # bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        tflops = flops / ms * 1e-9
+
+        # Return exactly one scalar depending on which metric is active
+        if metric == 'time':
+            return ms
+        elif metric == 'tflops':
+            return tflops
+        elif metric == 'bandwidth':
+            return bandwidth
+        else:
+            raise ValueError("Unknown metric: " + metric)
+
+    bench_paged_attn_decode.run(save_path=".", print_data=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark Paged Attention decode",
+        allow_abbrev=False,
+    )
+    parser.add_argument('-model_configs', type=str, default="utils/model_configs.json", help="Model config json file.")
+    available_models = get_available_models()  # Dynamically load model names
+    model_help = ("Model name to benchmark. Select from: [" + ", ".join(available_models) +
+                  "]. Use 'all' to benchmark all models or leave blank for the default benchmark script.")
+    parser.add_argument('-model', type=str, default=None, help=model_help)
+    parser.add_argument("-b", type=int, default=0)
+    parser.add_argument("-hq", type=int, default=0)
+    parser.add_argument("-hk", type=int, default=0)
+    parser.add_argument("-sq", type=int, default=0)
+    parser.add_argument("-use_alibi_slope", action='store_true', default=False)
+    parser.add_argument("-dtype", default='fp16')
+    parser.add_argument("-kv_cache_dtype", default='auto')
+    parser.add_argument("-compute_type", default='fp16')
+
+    args = parser.parse_args()
+    return args
+
+
+arg_to_torch_dtype = {
+    'fp16': torch.float16, 'bf16': torch.bfloat16, 'fp32': torch.float32, "e5m2fnuz": torch.float8_e5m2fnuz, "e4m3fnuz":
+    torch.float8_e4m3fnuz
+}
+
+
+def main():
+    args = parse_args()
+    run_benchmark(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/op_benchmarks/triton/utils/benchmark_utils.py
+++ b/op_benchmarks/triton/utils/benchmark_utils.py
@@ -1,0 +1,165 @@
+import os
+import json
+import torch
+import triton.language as tl
+import sys
+import time
+import os
+import tempfile
+import re
+from prettytable import PrettyTable
+
+
+# Base directory where configs are located
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
+
+torch_to_tl_dtype = {torch.float16 : tl.float16, torch.bfloat16 : tl.bfloat16, torch.float32 : tl.float32}
+
+def get_model_configs(config_path='./utils/model_configs.json', models="llama3,mistral_7B"):
+    """
+    Load model names from the configuration file.
+
+    Args:
+        config_path (str): User-provided path to the configuration JSON file.
+        models: List of model names to retrieve, with pattern <modelfamily_modelsize>. If modelfamily specified only, retrieves all the modelsizes.
+
+    Returns:
+        dict: A dictionary of available models and their configurations for the specified families.
+    """
+    # Resolve config path relative to ./perf-kernels/
+    config_path = os.path.join(BASE_DIR, config_path)
+
+    with open(config_path, 'r') as f:
+        configs = json.load(f)
+
+    # Extract models and their configurations for the specified families
+    filtered_configs = {}
+
+    if models=="all":
+        models = [model for model in configs]
+    else:
+        models = models.replace(" ", "").split(',')
+
+    for model in models:
+        delimiter = "_" if "_" in model else "-"
+        model_specs = model.split(delimiter)
+        model_family = model_specs[0] 
+        
+        if model_family in configs:
+            model_size = model_specs[1] if len(model_specs) > 1 else None
+            # Check if model filtering is required
+            if model_size is None: # Include all models in the family
+                # Include all models in the family
+                for model_size, model_configs in configs[model_family].items():
+                    filtered_configs[f"{model_family}-{model_size}"] = model_configs
+            else:
+                if model_size in configs[model_family]:
+                    filtered_configs[f"{model_family}-{model_size}"] = configs[model_family][model_size]
+
+    if not filtered_configs:
+        print(f"Warning: No models selected with the provided model names: {models}")
+
+    return filtered_configs
+
+
+def get_available_models(config_file='utils/model_configs.json', filter=None):
+    """
+    Load model names from the configuration file.
+
+    Args:
+        config_file (str): Path to the configuration JSON file.
+
+    Returns:
+        list: A list of available model configs.
+    """
+    # Resolve config path relative to ./perf-kernels/
+    config_path = os.path.join(BASE_DIR, config_file)
+
+    with open(config_path, 'r') as f:
+        configs = json.load(f)
+
+    models = [f"{family}-{model}" for family in configs for model in configs[family] if filter is None or filter in f"{family}-{model}"]
+
+    return models
+
+
+def parse_vgpr_usage(file_path, table_start="result-table-name"):
+    with open(file_path, "r") as f:
+        lines = f.readlines()
+    
+    # Extract VGPR-related information
+    vgpr_info = []
+    table_lines = []
+    in_table = False
+
+    for line in lines:
+        # Parse autotuning outputs
+        if re.search(r"Autotuning kernel", line):
+            vgpr_info.append(line.strip())
+        if re.search(r"Triton autotuning for function", line):
+            vgpr_info.append(line.strip())
+
+        if re.search(r"\.name:", line):
+            vgpr_info.append(line.strip())
+        if re.search(r"\.vgpr_count:", line) or re.search(r"\.vgpr_spill_count:", line):
+            vgpr_info.append(line.strip())
+        # Detect start of table
+        if re.match(rf"^\s*{table_start}", line):
+            vgpr_info.append(line.strip())
+            in_table = True
+        elif in_table:
+            table_lines.append(line.strip())
+
+    # Print extracted information
+    print("\n".join(vgpr_info))
+
+    table = PrettyTable()
+    table.field_names = table_lines[0].split()
+    [table.add_row(line.split()[1:]) for line in table_lines[1:]]
+    
+    print(table)
+
+def print_vgpr(fun, table_start="result-table-name"):
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as temp_file:
+        output_file = temp_file.name
+
+        # Redirect stdout and stderr to the temporary file
+        sys.stdout = temp_file
+        sys.stderr = temp_file
+        
+        os.environ["AMDGCN_ENABLE_DUMP"] = "1"
+        os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+        os.environ["TRITON_PRINT_AUTOTUNING"] = "1"
+        fun() # run the function
+        
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+    # Restore stdout and stderr to normal
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+
+    time.sleep(0.5)  # Ensure everything is written before reading
+
+    # Parse and print relevant output
+    parse_vgpr_usage(output_file, table_start)
+
+    # Remove the temporary file
+    os.unlink(output_file)
+
+def get_dtype_bytes(dtype):
+    if dtype in [torch.float16, tl.float16]:
+        return 2
+    elif dtype in [torch.bfloat16, tl.bfloat16]:
+        return 2
+    elif dtype in [torch.float32, tl.float32]:
+        return 4
+    elif dtype == torch.int32:
+        return 4
+    elif dtype == torch.int64:
+        return 8
+    elif dtype in [torch.float8_e4m3fnuz, torch.float8_e5m2fnuz, tl.float8e4, tl.float8e5]:
+        return 1
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")

--- a/op_benchmarks/triton/utils/model_configs.json
+++ b/op_benchmarks/triton/utils/model_configs.json
@@ -1,0 +1,54 @@
+{
+  "llama3": {
+    "8B": {
+      "num_attention_heads": 32,
+      "num_key_value_heads": 8,
+      "hidden_size": 4096,
+      "intermediate_size": 14336,
+      "vocab_size": 128256
+    },
+    "70B": {
+      "num_attention_heads": 64,
+      "num_key_value_heads": 8,
+      "hidden_size": 8192,
+      "intermediate_size": 28672,
+      "vocab_size": 128256
+    },
+    "405B": {
+      "num_attention_heads": 128,
+      "num_key_value_heads": 8,
+      "hidden_size": 16384,
+      "intermediate_size": 53248,
+      "vocab_size": 128256
+    }
+  },
+  "mistral": {
+    "7B": {
+      "hidden_size": 4096,
+      "intermediate_size": 14336,
+      "num_attention_heads": 32,
+      "num_key_value_heads": 8,
+      "vocab_size": 32000
+    },
+    "22B": {
+      "hidden_size": 6144,
+      "intermediate_size": 16384,
+      "num_attention_heads": 48,
+      "num_key_value_heads": 8,
+      "vocab_size": 32000
+    }
+
+  },
+  "deepseek": {
+    "V3": {
+      "hidden_size": 7168,
+      "intermediate_size": 18432,
+      "num_attention_heads": 128,
+      "num_key_value_heads": 128,
+      "vocab_size": 129280
+    }
+  }
+}
+    
+    
+  

--- a/op_tests/triton/test_moe_align_block_size.py
+++ b/op_tests/triton/test_moe_align_block_size.py
@@ -80,7 +80,7 @@ def input_helper(M: int, E: int, top_k: int):
     values = torch.randn(M, E, dtype=torch.float16, device='cuda')
 
     softmax_vals = torch.softmax(values, dim=1)
-    _, topk_ids = torch.topk(softmax_vals, k=top_k, dim=1) 
+    _, topk_ids = torch.topk(softmax_vals, k=top_k, dim=1)
 
     return topk_ids
 


### PR DESCRIPTION
Coauthored with @Chi-Chu319 

This PR adds benchmarking for triton kernels with scripts located at op_benchmarks/triton. Benchmarking ready for mha kernel (aiter.ops.triton.mha) and moe kernel (aiter.ops.triton.moe_op) with scripts bench_mha.py and bench_moe.py. 

Easy way to get realistic benchmarking results (with shapes from existing models) with the kernels is to use the -model "model_name(s)" command line argument with both of these scripts. For example:

python $AITERDIR/op_benchmarks/triton/bench_mha.py -model llama3

gives results:

![image](https://github.com/user-attachments/assets/cb258496-598b-44a4-8eff-d1554367804d)

use -help to get information about the available model configs additional command line options. One can add new model configs by modifying the op_benchmarks/triton/utils/model_configs.json.