### PR TITLE
Update Installation Step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ Some summary of the features:
 
 
 ## Installation
-`git clone --recursive https://github.com/ROCm/aiter.git`
-
-or
-
-`git submodule sync ; git submodule update --init --recursive`
-
-Then
 ```
+git clone --recursive https://github.com/ROCm/aiter.git
 cd aiter
 python3 setup.py develop
+```
+
+If you happen to forget the `--recursive` during `clone`, you can use the following command after `cd aiter`
+```
+git submodule sync && git submodule update --init --recursive
 ```
 
 ## Run operators supported by aiter


### PR DESCRIPTION
The installation section is slightly misleading about pulling the submodule and which directory to step into for building the python wheel.

### 1. Where to run submodule update

Though it might be trivial, the command
```
git submodule sync ; git submodule update --init --recursive
```
can only be run after stepping into the base repo. The existing steps are written as if it is run outside of the base.

### 2. Which directory to step into in order to build python wheel

It seems to suggest that we need to step into `aiter/aiter` to build but actually `cd aiter` refers to the base aiter git repo.

### 3. Changed ";" to "&&" in submodule sync

Make sure the the 2nd command will not be run if 1st one is not successful.