### PR TITLE
Enable structured imports for op_tests.triton.utils

### DIFF
--- a/op_tests/__init__.py
+++ b/op_tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.

--- a/op_tests/triton/__init__.py
+++ b/op_tests/triton/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+from .utils import *

--- a/op_tests/triton/utils/__init__.py
+++ b/op_tests/triton/utils/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.


### PR DESCRIPTION
Enable modular imports for op_tests.triton. 

This change improves test modularity and allows clean imports like:

`from op_tests.triton import mla_decode_ref_fn`

