### PR TITLE
Fix random file not found error

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -102,8 +102,8 @@ bd_dir = f"{get_user_jit_dir()}/build"
 # copy ck to build, thus hippify under bd_dir
 if multiprocessing.current_process().name == "MainProcess":
     shutil.copytree(CK_DIR, f"{bd_dir}/ck", dirs_exist_ok=True)
-    if os.path.exists(f"{bd_dir}/ck/library"):
-        shutil.rmtree(f"{bd_dir}/ck/library")
+    # if os.path.exists(f"{bd_dir}/ck/library"):
+    #     shutil.rmtree(f"{bd_dir}/ck/library")
 CK_DIR = f"{bd_dir}/ck"
 
 


### PR DESCRIPTION
when using "ray", it may has multiple MainProcess
this code may cause file not found issue
( one process remove library, and the other need the library ) so remove it to fix the problem