### PR TITLE
[TRITON] Optimize per token fp8 quant kernel

### DIFF
--- a/op_tests/triton/test_quant.py
+++ b/op_tests/triton/test_quant.py
@@ -24,23 +24,23 @@ def test_static_per_tensor_fp8_quant(M: int, N: int, dtype):
     torch_out = torch_static_per_tensor_fp8_quant(torch_out, x, scale)
 
     triton_out = torch.empty_like(x, dtype=torch.float8_e4m3fnuz, device='cuda')
-    triton_out = static_per_tensor_fp8_quant(triton_out, x, scale)    
+    triton_out = static_per_tensor_fp8_quant(triton_out, x, scale)
 
     #Note: Torch doesn't support comparing fp8 type
     torch.testing.assert_close(triton_out.to(dtype=torch.float32), torch_out.to(dtype=torch.float32), atol=1e-02, rtol=1e-02) 
 
 def torch_dynamic_per_tensor_fp8_quant(x):
-    x_max = torch.max(torch.abs(x))
+    # Triton does max and scale in f32 so we need to match precision here.
+    x_f32 = x.to(torch.float32)
+    x_max = torch.max(torch.abs(x_f32))
     scale_out = x_max  / torch.finfo(torch.float8_e4m3fnuz).max
 
-    out = (x / scale_out).to(torch.float8_e4m3fnuz)    
+    out = (x_f32 / scale_out).to(torch.float8_e4m3fnuz)
     
     return out, torch.tensor([scale_out], dtype=x.dtype, device=x.device)
 
-#@pytest.mark.parametrize('M, N', [(1,32), (32,32), (2,16), (10,128), (32, 8192), (93,75)]) #Bigger sizes have accuracy issues
-#@pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16, torch.float32]) #TODO Fix accuracy issues with fp16 and bf16
-@pytest.mark.parametrize('M, N', [(1,32), (32,32), (2,16), (10,128)])
-@pytest.mark.parametrize('dtype', [torch.float32])
+@pytest.mark.parametrize('M, N', [(1,32), (32,32), (2,16), (10,128), (32, 8192), (93,75)])
+@pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16, torch.float32])
 def test_dynamic_per_tensor_fp8_quant(M: int, N: int, dtype):
     torch.manual_seed(20)
     x = torch.randn((M, N), dtype=dtype, device='cuda')
@@ -60,15 +60,16 @@ def torch_dynamic_per_token_fp8_quant(x):
     scale_out = x_max / torch.finfo(torch.float8_e4m3fnuz).max
     
     out = (x / scale_out[:, None])
-    out = out.to(torch.float8_e4m3fnuz)    
+    out = out.to(torch.float8_e4m3fnuz)
 
     return out, scale_out
 
-#TODO: Bigger sizes have accuracy issues
-#@pytest.mark.parametrize('M, N', [(1,32), (32,32), (2,16), (10,128), (32, 4096), (1024,128), (2048,1024), (193,76), (256,13), (400,400)])
-#@pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16, torch.float32]) #TODO Fix accuracy issues with fp16 and bf16
 @pytest.mark.parametrize('M, N', [(1,32), (32,32), (2,16), (10,128), (32, 4096), (1024,128), (193,76), (256,13), (400,400)])
 @pytest.mark.parametrize('dtype', [torch.float32])
+#TODO Fix accuracy issues. Some shapes produce very close but not
+# exact values in Triton vs pytorch. The quant to fp8 then produces a large difference.
+#@pytest.mark.parametrize('M, N', [(1,32), (32,32), (2,16), (10,128), (32, 4096), (1024,128), (193,76), (256,13), (400,400)])
+#@pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16, torch.float32])
 def test_dynamic_per_token_fp8_quant(M: int, N: int, dtype):
     torch.manual_seed(20)
     torch.set_printoptions(precision=7, threshold=4000)


### PR DESCRIPTION
1) Made the grid equal to num rows. Previously it was one WG every 32 rows. (60us -> 5.5us)
2) Added cache modifiers for ld/st (5.5us -> 4.7us) 
3) Explicit reciprocal to avoid Newton Raphson steps on result (4.7 -> 3.5us)

Results on 128 x 8192 tensor. Roofline ~1us.

This is now exposing HBM latency. Can't really optimize more without significant effort.