### PR TITLE
add asser to check topk-weights dtype

### DIFF
--- a/csrc/py_itfs_ck/moe_sorting_kernels.cu
+++ b/csrc/py_itfs_ck/moe_sorting_kernels.cu
@@ -18,6 +18,10 @@ void moe_sorting_fwd(torch::Tensor &topk_ids,          // [m, topk]
                      int unit_size,
                      std::optional<torch::Tensor> local_expert_mask = std::nullopt)
 {
+    // Ensure that the incoming top‑k weights tensor is FP32
+    TORCH_CHECK(topk_weights.scalar_type() == at::ScalarType::Float,
+                "topk_weights must be FP32 (float32)");
+    
     auto dtype = topk_ids.dtype();
 
     auto dtype_str = torchDTypeToStr(topk_ids.dtype());


### PR DESCRIPTION
topk-weights in dtype bf16 will cause numeric issues silently. This PR adds the check


cc @carlushuang 