### PR TITLE
Revert "Enable structured imports for op_tests.triton.utils"

### DIFF
--- a/op_tests/__init__.py
+++ b/op_tests/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.

--- a/op_tests/triton/__init__.py
+++ b/op_tests/triton/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
-from .utils import *

--- a/op_tests/triton/utils/__init__.py
+++ b/op_tests/triton/utils/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.


### PR DESCRIPTION
Reverts ROCm/aiter#293

this one break all functions in aiter