### PR TITLE
Exclude rocm 6.4+ for hipcc flag -amdgpu-coerce-illegal-types

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -246,7 +246,7 @@ def build_module(
                 "-mllvm",
                 "-amdgpu-function-calls=false",
             ]
-        if hip_version > Version("6.2.41133"):
+        if Version("6.4") >= hip_version > Version("6.2.41133"):
             flags_hip += ["-mllvm", "-amdgpu-coerce-illegal-types=1"]
 
         flags_cc += flags_extra_cc
@@ -378,7 +378,7 @@ def get_args_of_build(ops_name: str, exclue=[]):
                 d_ops[k] = eval(val)
             else:
                 pass
-            
+
         # undefined compile features will be replaced with default value
         d_opt_build_args.update(d_ops)
         return d_opt_build_args


### PR DESCRIPTION
Running Triton MoE code (not necessary limited to MoE) causes a compilation failure, throwing errror that `-amdgpu-coerce-illegal-types` flag for `hipcc` cannot be found.

CK uses this flag but it also checks if it is available in its own cmake file. AITER, however, only checks for `hipcc` version. Excluding version >= 6.4 fix the problem.

Using a docker from 6.5 does not have this problem at all and I don't know why it does not have issue at 6.5. 

If the reviewer knows the exact reason, I can update this PR to make it flexible