### PR TITLE
Fused multihead attention backward kernel

### DIFF
--- a/aiter/ops/triton/mha.py
+++ b/aiter/ops/triton/mha.py
@@ -1496,7 +1496,6 @@ def _bwd_kernel_dkdvdq_causal(
 
     start_m += num_steps * MASK_BLOCK_M
     num_steps = tl.cdiv(seqlen_q - start_m, BLOCK_M)
-    end_m = start_m + num_steps * BLOCK_M
 
     
 

--- a/aiter/ops/triton/mha.py
+++ b/aiter/ops/triton/mha.py
@@ -1148,8 +1148,6 @@ def _bwd_dkdvdq_inner(
     curr_m = start_m
     step_m = BLOCK_M
     curr_philox_offset = batch_philox_offset
-    curr_dropout_offset = dropout_offset
-    RCP_LN2: tl.constexpr = 1.4426950408889634
 
     #Iterate over blocks(BLOCK_M size) of Q while calculating 
     #a fixed block(BLOCK_N) of dk and dv. Note, during backward

--- a/aiter/ops/triton/mha.py
+++ b/aiter/ops/triton/mha.py
@@ -1377,7 +1377,6 @@ def _bwd_kernel_dkdvdq_causal(
     delta_qk = seqlen_q - seqlen_k
 
     # q > k: diretcly skip all the way until the start of causal block
-    start_delta_q_gt_k = delta_qk
 
     # q < k: some blocks will have no Masked block, other needs to re-calc
     # starting position

--- a/aiter/ops/triton/mha.py
+++ b/aiter/ops/triton/mha.py
@@ -221,24 +221,17 @@ def _attn_fwd_inner(
         # We start from end of seqlen_k so only the first iteration would need
         # to be checked for padding if it is not a multiple of block_n
         # TODO: This can be optimized to only be true for the padded block.
-        mask = tl.full([BLOCK_M, BLOCK_N], True, dtype=tl.int1)
         if MASK_STEPS:
             # If this is the last block / iteration, we want to
             # mask if the sequence length is not a multiple of block size
             # a solution is to always do BLOCK_M // BLOCK_N + 1 steps if not is_modulo_mn.
             # last step might get wasted but that is okay. check if this masking works For
             # that case.
-
-            # remove the old if condition
-            # if (start_n + BLOCK_N == block_max) and (n_extra_tokens != 0):
-            # Though this will unconditionally compute mask_partial at runtime,
-            # the causal for loop does not have the if-else block any more, which
-            # helps instruction scheduling and register pressure.
-            bound_cond = (start_n + BLOCK_N == block_max) and (n_extra_tokens != 0)
-            boundary_m = tl.full([BLOCK_M], seqlen_k, dtype=tl.int32)
-            size_n = start_n + OFFS_N[None, :]
-            mask_partial = size_n < boundary_m[:, None]
-            mask = tl.where(bound_cond, mask_partial, mask)
+            if (start_n + BLOCK_N == block_max) and (n_extra_tokens != 0):
+                boundary_m = tl.full([BLOCK_M], seqlen_k, dtype=tl.int32)
+                size_n = start_n + OFFS_N[None, :]
+                mask = size_n < boundary_m[:, None]
+                qk = tl.where(mask, qk, float("-inf"))
 
         # compute masks
         q_mask = (OFFS_M[:, None] < seqlen_q)
@@ -250,13 +243,11 @@ def _attn_fwd_inner(
             qk += (tl.dot(q, k) * descale_q * descale_k)
         else:
             qk += tl.dot(q, k)
-
+        qk_scaled =  qk * SM_SCALE
         if IS_CAUSAL:
             causal_boundary = start_n + offs_n_causal
             causal_mask = OFFS_M[:, None] >= causal_boundary[None, :]
-            mask = mask and causal_mask
-
-        qk = tl.where(mask, qk, float("-inf"))
+            qk_scaled = tl.where(causal_mask, qk_scaled, float("-inf"))
 
         if alibi_slope is not None:
             # Compute the global position of each token within the sequence
@@ -264,16 +255,15 @@ def _attn_fwd_inner(
             global_n_positions = start_n + tl.arange(0, BLOCK_N)
             alibi_block = compute_alibi_block(alibi_slope, seqlen_q, seqlen_k, global_m_positions,
                                               global_n_positions)
-            qk += alibi_block / SM_SCALE
+            qk_scaled += alibi_block
         # get max scores so far
-        m_ij = tl.maximum(m_i, tl.max(qk, 1))
-        m_ij_scaled = m_ij * SM_SCALE * RCP_LN2
+        m_ij = tl.maximum(m_i, tl.max(qk_scaled, 1))
 
         # scale and subtract max
-        q_shifted = qk * SM_SCALE * RCP_LN2 - m_ij_scaled[:, None]
-
+        q_shifted = qk_scaled - m_ij[:, None]
+        
         # Compute scaled QK and softmax probabilities
-        p = tl.math.exp2(q_shifted)
+        p = tl.math.exp2(q_shifted * RCP_LN2)
 
         # CAVEAT: Must update l_ij before applying dropout
         l_ij = tl.sum(p, 1)
@@ -291,12 +281,12 @@ def _attn_fwd_inner(
         elif RETURN_SCORES:
             # NOTE: the returned score is not the same as the reference because we need to adjust as we find new maxes per block. We are not doing that
             tl.store(sd_mask_ptrs, p, mask=p_mask)
-
+        
         # -- update output accumulator --
         # alpha is an adjustment factor for acc and li as we loop and find new maxes
         # store the diff in maxes to adjust acc and li as we discover new maxes
-        m_diff_scaled = m_i * SM_SCALE * RCP_LN2 - m_ij_scaled
-        alpha = tl.math.exp2(m_diff_scaled)
+        m_diff = m_i - m_ij
+        alpha = tl.math.exp2(m_diff * RCP_LN2)
         acc = acc * alpha[:, None]
         v = load_fn(v_ptrs, k_offs_n, k_offs_k, seqlen_k, BLOCK_DMODEL)
         # -- update m_i and l_i
@@ -365,7 +355,7 @@ def _attn_fwd(q_ptr: torch.Tensor,
 ):
     #calculate offsets
     off_z = tl.program_id(0) #batch
-    off_q_head = tl.program_id(1)  #num_q_heads
+    off_q_head = tl.program_id(1) #num_q_heads
     start_m = tl.program_id(2) #seqlen_q
 
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -737,7 +727,6 @@ def _flash_attn_forward(
 
 
     # Best config from ROCm/triton/python/perf-kernels/flash_attention.py::attn_fwd autotuning is BLOCK_M: 128, BLOCK_N: 64, waves_per_eu: 2, num_warps: 4, num_ctas: 1, num_stages: 1
-    # BLOCK_N=64 spills but has higher performance
     # Tuned for MI300x
     config = {
         'BLOCK_M': 128,
@@ -1109,6 +1098,442 @@ def _bwd_dkdv_inner(
         do_ptrs += step_m * stride_do_m
 
     return dk, dv
+
+
+@triton.jit
+def _bwd_dkdvdq_inner(
+    dk, dv,
+    Q, k, v, DO, DQ, M, D, sm_scale,
+    stride_q_m, stride_q_k,
+    stride_dq_m, stride_dq_k,
+    stride_do_m, stride_do_k,
+    stride_dropout_m, stride_dropout_n,
+    stride_deltam,
+    dropout_p, philox_seed, batch_philox_offset, dropout_offset,
+    seqlen_q, seqlen_k,
+    start_n, start_m, num_steps,
+    descale_q, descale_k, descale_v, descale_do,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D_MODEL: tl.constexpr,
+    BLOCK_D_MODEL_POW2: tl.constexpr,
+    MASK: tl.constexpr,
+    ENABLE_DROPOUT: tl.constexpr,
+    IS_FP8: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    workgroup_id: tl.int32,
+    num_atomics_concurrent: tl.constexpr,
+):
+    tl.assume(stride_q_m >= 0)
+    tl.assume(stride_q_k >= 0)
+    tl.assume(stride_dq_m >= 0)
+    tl.assume(stride_dq_k >= 0)
+    tl.assume(stride_do_m >= 0)
+    tl.assume(stride_do_k >= 0)
+    tl.assume(stride_deltam >= 0)
+
+    PADDED_HEAD: tl.constexpr = (BLOCK_D_MODEL != BLOCK_D_MODEL_POW2)
+    delta_qk = seqlen_q - seqlen_k
+    offs_m = start_m + tl.arange(0, BLOCK_M)
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_D_MODEL_POW2)
+
+    # mask to make sure not OOB of seqlen_q
+    mask_n = offs_n < seqlen_k
+    
+    qT_ptrs_start = Q + offs_m[None, :] * stride_q_m + offs_k[:, None] * stride_q_k #[BLOCK_D_MODEL_POW2, BLOCK_M]
+    dq_ptrs_start = DQ + offs_m[:, None] * stride_dq_m + offs_k[None,:] * stride_dq_k #[BLOCK_M, BLOCK_D_MODEL_POW2]
+    
+    do_ptrs_start = DO + offs_m[:, None] * stride_do_m + offs_k[None,: ] * stride_do_k
+    curr_m = start_m
+    step_m = BLOCK_M
+    curr_philox_offset = batch_philox_offset
+    curr_dropout_offset = dropout_offset
+    RCP_LN2: tl.constexpr = 1.4426950408889634
+
+    #Iterate over blocks(BLOCK_M size) of Q while calculating 
+    #a fixed block(BLOCK_N) of dk and dv. Note, during backward
+    #pass P has to be recomputed. However, this kernel computes 
+    #dV and dK, so we compute we need P^T and S^T. See backward pass
+    #equations
+    # 
+    #From Flash Attention Paper:
+    #ForwardPass: S = QkT, P=softmax(S), O=PV
+    #
+    #BackwardPass equations
+    #dV = P^TdO 
+    #dP = dOV^T
+    #dS = dsoftmax(dP)
+    #dQ = dSK
+    #dK = QdS^T
+
+
+    offset_factor = num_steps // num_atomics_concurrent # 3 if num_steps > 1 or num_steps==3 else 1 # coprime with num_steps
+    # Compute a starting index and step based on workgroup_id
+    # Use a simple hash-like function to spread out the starting points
+    start_idx = (workgroup_id * offset_factor) % num_steps  # 17 is an arbitrary prime to spread indices
+
+    for iter in range(num_steps):
+        # Compute the permuted block index
+        blk_idx = (start_idx + iter) % num_steps
+
+        curr_m = start_m + blk_idx * step_m
+        qT_ptrs = qT_ptrs_start + blk_idx * step_m * stride_q_m
+        dq_ptrs = dq_ptrs_start + blk_idx * step_m * stride_dq_m
+        do_ptrs = do_ptrs_start + blk_idx * step_m * stride_do_m
+
+        offs_m = curr_m + tl.arange(0, BLOCK_M)
+        mask_m = offs_m < seqlen_q
+        mask_qT = mask_m[None, :]
+        mask_do = mask_m[:, None]
+        mask_nm = mask_n[:, None] & (offs_m[None, :] < seqlen_q)
+        
+        if PADDED_HEAD:
+            mask_qT &= offs_k[:, None] < BLOCK_D_MODEL
+            mask_do &= offs_k[None, :] < BLOCK_D_MODEL
+
+        #load qT
+        qT = tl.load(qT_ptrs, mask=mask_qT, other=0.0)
+        
+        #dropout
+        if ENABLE_DROPOUT:
+             # NOTE: dropout is transposed because it is used to mask pT
+            philox_offs = (curr_philox_offset + 
+                            offs_m[None, :] * stride_dropout_m +
+                            offs_n[:, None] * stride_dropout_n)
+            rand_vals = tl.rand(philox_seed, philox_offs)
+            dropout_mask = rand_vals > dropout_p
+            dropout_scale = 1.0 / (1 - dropout_p)
+
+        #Load M
+        m = tl.load(M + offs_m * stride_deltam, mask=mask_m, other=0.0)
+
+        #Compute qkT
+        if IS_FP8:
+            qkT = (tl.dot(k, qT) * descale_q * descale_k)
+        else:
+            qkT = tl.dot(k, qT)
+        
+        #Compute pT(use m and also apply sm_scale)
+        pT = tl.math.exp(qkT * sm_scale - m[None, :])
+
+        if MASK:
+            causal_mask = (offs_m[None, :] - delta_qk) >= (offs_n[:, None])
+            mask = causal_mask & mask_nm
+            pT = tl.where(mask, pT, 0.0)
+
+        #load DO
+        do = tl.load(do_ptrs, mask=mask_do, other=0.0)
+        
+        #dV
+        if ENABLE_DROPOUT:
+            pT_dropout = tl.where(dropout_mask, pT, 0.0) * dropout_scale
+            if IS_FP8:
+                scale_p_dropout, descale_p_dropout = compute_fp8_scaling_factors(pT_dropout, FP8_MAX)
+                dv += (tl.dot((pT_dropout * scale_p_dropout).to(do.type.element_ty), do) * descale_p_dropout * descale_do)
+            else:
+                dv += tl.dot(pT_dropout.to(do.type.element_ty), do)
+        else:
+            if IS_FP8:
+                scale_pT, descale_pT = compute_fp8_scaling_factors(pT, FP8_MAX)
+                dv += (tl.dot((pT * scale_pT).to(do.type.element_ty), do) * descale_pT * descale_do)
+            else:
+                dv += tl.dot(pT.to(do.type.element_ty), do)
+
+        #Load delta
+        Di = tl.load(D + offs_m * stride_deltam, mask=mask_m)
+
+        #Compute dP and dS
+        if IS_FP8:
+            dpT = tl.dot(v, tl.trans(do)) * descale_v * descale_do
+        else:
+            dpT = tl.dot(v, tl.trans(do))
+
+        if ENABLE_DROPOUT:
+            dpT = tl.where(dropout_mask, dpT, 0.0) * dropout_scale
+
+        delta_i = Di[None, :]
+        dsT = pT * (dpT - delta_i)
+        
+        #compute dk
+        if IS_FP8:
+            scale_dsT, descale_dsT = compute_fp8_scaling_factors(dsT, FP8_MAX)
+            dk += (tl.dot((dsT * scale_dsT).to(qT.type.element_ty), tl.trans(qT)) * descale_dsT * descale_q)
+        else:
+            dk += tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT)) 
+
+
+        # We can compute the dq_partial here and do a atomic add to the correct memory location
+        # NOTE: Possible problems with the atomic add: contention, is inside a loop which has achieved bad perf before
+        # (BLOCK_M, BLOCK_N) x (BLOCK_N, D)
+        if IS_FP8:
+            dq_partial = tl.dot((dsT * scale_dsT).to(k.dtype).T, k) * descale_dsT * descale_k
+        else:
+            dq_partial = tl.dot(dsT.to(k.dtype).T, k) 
+        tl.atomic_add(
+            dq_ptrs,
+            dq_partial * sm_scale,
+            mask=mask_m[:, None],
+            sem="relaxed",
+        )
+
+    return dk, dv
+
+
+@triton.jit
+def _bwd_kernel_dkdvdq_causal(
+    q_ptr, k_ptr, v_ptr, sm_scale, do_ptr, dk_ptr, dv_ptr, dq_ptr,
+    m_ptr, delta_ptr,
+    stride_q_b, stride_q_h, stride_q_m, stride_q_k,
+    stride_k_b, stride_k_h, stride_k_n, stride_k_k,
+    stride_v_b, stride_v_h, stride_v_n, stride_v_k,
+    stride_dk_b, stride_dk_h, stride_dk_n, stride_dk_k,
+    stride_dq_b, stride_dq_h, stride_dq_m, stride_dq_k,
+    stride_delta_b, stride_delta_h, stride_delta_m,
+    stride_do_b, stride_do_h, stride_do_m, stride_do_k,
+    stride_dropout_b, stride_dropout_h, stride_dropout_m, stride_dropout_n,
+    stride_descale_q_z, stride_descale_k_z, stride_descale_v_z, stride_descale_do_z,
+    cu_seqlens_q, cu_seqlens_k,
+    max_seqlen_q, max_seqlen_k,
+    dropout_mask, dropout_p, philox_seed, philox_offset_base,
+    descale_q_ptr, descale_k_ptr, descale_v_ptr, descale_do_ptr,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_K_HEADS: tl.constexpr,
+    BATCH,
+    NUM_K_PIDS, 
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLK_SLICE_FACTOR: tl.constexpr,
+    BLOCK_D_MODEL: tl.constexpr,
+    BLOCK_D_MODEL_POW2: tl.constexpr,
+    ENABLE_DROPOUT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    IS_FP8: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    tl.assume(stride_q_b >= 0)
+    tl.assume(stride_q_h >= 0)
+    tl.assume(stride_q_m >= 0)
+    tl.assume(stride_q_k >= 0)
+    tl.assume(stride_k_b >= 0)
+    tl.assume(stride_k_h >= 0)
+    tl.assume(stride_k_n >= 0)
+    tl.assume(stride_k_k >= 0)
+    tl.assume(stride_v_b >= 0)
+    tl.assume(stride_v_h >= 0)
+    tl.assume(stride_v_n >= 0)
+    tl.assume(stride_v_k >= 0)
+    tl.assume(stride_dk_b >= 0)
+    tl.assume(stride_dk_h >= 0)
+    tl.assume(stride_dk_n >= 0)
+    tl.assume(stride_dk_k >= 0)
+    tl.assume(stride_dq_b >= 0)
+    tl.assume(stride_dq_h >= 0)
+    tl.assume(stride_dq_m >= 0)
+    tl.assume(stride_dq_k >= 0)
+    tl.assume(stride_delta_b >= 0)
+    tl.assume(stride_delta_h >= 0)
+    tl.assume(stride_delta_m >= 0)
+    tl.assume(stride_do_b >= 0)
+    tl.assume(stride_do_h >= 0)
+    tl.assume(stride_do_m >= 0)
+    tl.assume(stride_do_k >= 0)
+
+    wid = tl.program_id(0) # workgoup id: 0, ..., NUM_Q_PIDS * BATCH * NUM_K_HEADS - 1
+
+    # workgroups get launched first along batch dim, then in head_q dim, and then in seq k block dim
+    
+    num_atomics_concurrent = NUM_SMS // (NUM_Q_HEADS *  BATCH)
+    
+    GROUP_SIZE = NUM_Q_HEADS // NUM_K_HEADS
+
+    batch_idx = wid % BATCH 
+    head_q_idx = wid // BATCH % NUM_Q_HEADS 
+    head_k_idx = head_q_idx // GROUP_SIZE
+
+    seq_k_blk_idx = wid // (BATCH * NUM_Q_HEADS) % NUM_K_PIDS
+
+    #Determine q and k start along with seqlen_q and seqlen_k
+    q_start = 0
+    k_start = 0
+    seqlen_q = max_seqlen_q
+    seqlen_k = max_seqlen_k
+    if IS_VARLEN:
+        q_start = tl.load(cu_seqlens_q + batch_idx)
+        q_end = tl.load(cu_seqlens_q + batch_idx + 1)
+        k_start = tl.load(cu_seqlens_k + batch_idx)
+        k_end = tl.load(cu_seqlens_k + batch_idx + 1)
+        seqlen_q = q_end - q_start
+        seqlen_k = k_end - k_start
+
+    dk = tl.zeros([BLOCK_N, BLOCK_D_MODEL_POW2], dtype=tl.float32)
+    dv = tl.zeros([BLOCK_N, BLOCK_D_MODEL_POW2], dtype=tl.float32)
+
+    # Figure out causal starting block since we have seqlen_q >=< seqlen_k.
+    # Unlike forward pass where we tile on M dim and iterate on N dim, so that
+    # we can skip some M blocks, in backward pass, we tile on the N dim for kv
+    # and iterate over the M. In this way, we cannot skip N blocks, but only to
+    # determine the starting M blocks to skip some initial blocks masked by
+    # causal.
+    delta_qk = seqlen_q - seqlen_k
+
+    # q > k: diretcly skip all the way until the start of causal block
+    start_delta_q_gt_k = delta_qk
+
+    # q < k: some blocks will have no Masked block, other needs to re-calc
+    # starting position
+    # delta_qk is negative so flip it, only multiple of BLOCK_N can skip the
+    # masked op
+    num_blocks_skip = -delta_qk // BLOCK_N
+    delta_aligned = (num_blocks_skip + 1) * BLOCK_N + delta_qk
+    start_delta_q_lt_k = delta_aligned // BLOCK_M * BLOCK_M
+    if delta_qk >= 0:
+        start_delta = delta_qk
+    else:
+        start_delta = start_delta_q_lt_k
+    
+    start_n =  seq_k_blk_idx * BLOCK_N
+
+    offs_k = tl.arange(0, BLOCK_D_MODEL_POW2)
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+    # Mask for loading K and V
+    mask_kv = offs_n[:, None] < seqlen_k
+    PADDED_HEAD: tl.constexpr = (BLOCK_D_MODEL != BLOCK_D_MODEL_POW2)
+    if PADDED_HEAD:
+        mask_k = offs_k < BLOCK_D_MODEL
+        mask_kv &= mask_k[None, :]
+    
+    GROUP_SIZE = NUM_Q_HEADS // NUM_K_HEADS
+    adj_k = (batch_idx * stride_k_b + 
+            head_k_idx * stride_k_h + 
+            k_start * stride_k_n + offs_n[:, None] * stride_k_n + 
+            offs_k[None, :] * stride_k_k)
+    adj_v = (batch_idx * stride_v_b + 
+            head_k_idx * stride_v_h + 
+            k_start * stride_v_n + offs_n[:, None] * stride_v_n + 
+            offs_k[None, :] * stride_v_k)
+    # load K and V: they stay in SRAM throughout the inner loop.
+    k = tl.load(k_ptr + adj_k , mask=mask_kv, other=0.0)
+    v = tl.load(v_ptr + adj_v, mask=mask_kv, other=0.0) 
+
+    # If MQA / GQA, set the K and V head offsets appropriately.
+    # for head_q_idx in range(head_k_idx * GROUP_SIZE, head_k_idx * GROUP_SIZE + GROUP_SIZE):
+    if delta_qk >= 0:
+        start_m = start_n + start_delta
+        len_m = BLOCK_N
+    else:
+        start_m = max(start_n + delta_qk, 0)
+        start_m = (start_m // BLOCK_M) * BLOCK_M
+        # because we might shift the masked blocks up, we are deeper into
+        # the masked out region, so we would potentially increase the total
+        # steps with masked operation to get out of it
+        residue_m = max(start_n + delta_qk - start_m, 0)
+        len_m = BLOCK_N + residue_m
+
+    # offset input and output tensor by batch and Q/K heads
+    adj_q = batch_idx * stride_q_b + head_q_idx * stride_q_h + q_start * stride_q_m
+    adj_dq = batch_idx * stride_dq_b + head_q_idx * stride_dq_h + q_start * stride_dq_m
+    
+    q_ptr_adj = q_ptr + adj_q
+    dq_ptr_adj = dq_ptr + adj_dq
+    
+    adj_do = batch_idx * stride_do_b + head_q_idx * stride_do_h + q_start * stride_do_m
+    do_ptr_adj = do_ptr + adj_do
+    adj_delta = batch_idx * stride_delta_b + head_q_idx * stride_delta_h + q_start * stride_delta_m
+    m_ptr_adj = m_ptr + adj_delta
+    delta_ptr_adj = delta_ptr + adj_delta
+
+    # batch_philox_offset is the ACTUALLY dropout offset
+    # dropout_offset is for debug purpose and will be removed later
+    batch_philox_offset = 0
+    dropout_offset = 0
+    if ENABLE_DROPOUT:
+        batch_philox_offset = (philox_offset_base + batch_idx * stride_dropout_b + 
+                                head_q_idx * stride_dropout_h)
+        dropout_offset = (dropout_mask + batch_idx * stride_dropout_b + 
+                            head_q_idx * stride_dropout_h)
+
+    MASK_BLOCK_M: tl.constexpr = BLOCK_M // BLK_SLICE_FACTOR
+    # bound the masked operation to q len so it does not have to wast cycles
+    len_m = min(len_m, seqlen_q)
+    num_steps = tl.cdiv(len_m, MASK_BLOCK_M)
+    
+    
+    # when q < k, we may skip the initial masked op
+    # if seq_k_blk_idx < num_blocks_skip:
+    #     num_steps = 0
+
+    if IS_FP8:
+        descale_q = tl.load(descale_q_ptr + batch_idx * stride_descale_q_z + head_q_idx)
+        descale_k = tl.load(descale_k_ptr + batch_idx * stride_descale_k_z + head_k_idx)
+        descale_v = tl.load(descale_v_ptr + batch_idx * stride_descale_v_z + head_k_idx)
+        descale_do = tl.load(descale_do_ptr + batch_idx * stride_descale_do_z + head_q_idx)
+    else:
+        descale_q, descale_k, descale_v, descale_do = 1.0, 1.0, 1.0, 1.0
+
+    # if unaligned start_m is negative, the current N-tile has no block on the
+    #   diagonal of causal mask, so everything have no causal mask
+    dk, dv = _bwd_dkdvdq_inner(
+        dk, dv,  # output tensors
+        q_ptr_adj, k, v, do_ptr_adj, dq_ptr_adj, m_ptr_adj, delta_ptr_adj, sm_scale, # input tensors
+        stride_q_m, stride_q_k,  # strides for q
+        stride_dq_m, stride_dq_k,  # strides for q
+        stride_do_m, stride_do_k,  # strides for o
+        stride_dropout_m, stride_dropout_n,  # strides for dropout
+        stride_delta_m,
+        dropout_p, philox_seed, batch_philox_offset, dropout_offset,  #
+        seqlen_q, seqlen_k,  # max sequence length for q and k
+        start_n, start_m, num_steps,  # iteration numbers
+        descale_q, descale_k, descale_v, descale_do, # fp8 descale factors from user 
+        MASK_BLOCK_M, BLOCK_N,  # block dim
+        BLOCK_D_MODEL, BLOCK_D_MODEL_POW2,  # head dim
+        MASK=True,  # causal masking
+        ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
+        IS_FP8=IS_FP8,
+        FP8_MAX=FP8_MAX,
+        workgroup_id=seq_k_blk_idx,
+        num_atomics_concurrent=num_atomics_concurrent
+    )
+
+
+    start_m += num_steps * MASK_BLOCK_M
+    num_steps = tl.cdiv(seqlen_q - start_m, BLOCK_M)
+    end_m = start_m + num_steps * BLOCK_M
+
+    
+
+    dk, dv = _bwd_dkdvdq_inner(
+        dk, dv,  # output tensors
+        q_ptr_adj, k, v, do_ptr_adj, dq_ptr_adj, m_ptr_adj, delta_ptr_adj, sm_scale, # input tensors
+        stride_q_m, stride_q_k,  # strides for q
+        stride_dq_m, stride_dq_k,  # strides for dq
+        stride_do_m, stride_do_k,  # strides for o
+        stride_dropout_m, stride_dropout_n,  # strides for dropout
+        stride_delta_m,
+        dropout_p, philox_seed, batch_philox_offset, dropout_offset,  #
+        seqlen_q, seqlen_k,  # max sequence length for q and k
+        start_n, start_m, num_steps,  # iteration numbers
+        descale_q, descale_k, descale_v, descale_do, # fp8 descale factors from user
+        BLOCK_M, BLOCK_N,  # block dim
+        BLOCK_D_MODEL, BLOCK_D_MODEL_POW2,  # head dim
+        MASK=False,  # causal masking
+        ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
+        IS_FP8=IS_FP8,
+        FP8_MAX=FP8_MAX,
+        workgroup_id=seq_k_blk_idx,
+        num_atomics_concurrent=num_atomics_concurrent
+    )
+
+    # Write back dV and dK.
+    offs_dkdv = (batch_idx * stride_dk_b + 
+                head_k_idx * stride_dk_h + 
+                k_start * stride_dk_n + offs_n[:, None] * stride_dk_n + 
+                offs_k[None, :] * stride_dk_k)
+    tl.atomic_add(dv_ptr + offs_dkdv, dv, mask=mask_kv, sem="relaxed")
+    dk *= sm_scale
+    tl.atomic_add(dk_ptr + offs_dkdv, dk, mask=mask_kv, sem="relaxed")
+
 
 @triton.jit
 def _bwd_kernel_dkdv_causal(
@@ -1486,6 +1911,152 @@ def _bwd_kernel_dq_causal(
         dq *= sm_scale
         tl.store(dq_ptr + offs_dq, dq, mask=mask_q)
 
+
+@triton.jit
+def _bwd_kernel_dkdvdq_noncausal(
+    Q, K, V, sm_scale, DO, DK, DV, DQ,
+    M, Delta,
+    stride_qb, stride_qh, stride_qm, stride_qk,
+    stride_kb, stride_kh, stride_kn, stride_kk,
+    stride_vb, stride_vh, stride_vn, stride_vk,
+    stride_dkb, stride_dkh, stride_dkn, stride_dkk,
+    stride_dqb, stride_dqh, stride_dqm, stride_dqk,
+    stride_deltab, stride_deltah, stride_deltam,
+    stride_dob, stride_doh, stride_dom, stride_dok,
+    stride_dropoutb, stride_dropouth, stride_dropoutm, stride_dropoutn,
+    stride_descale_q_z, stride_descale_k_z, stride_descale_v_z, stride_descale_do_z,
+    cu_seqlens_q, cu_seqlens_k,
+    max_seqlen_q, max_seqlen_k,
+    dropout_mask, dropout_p, philox_seed, philox_offset,
+    descale_q_ptr, descale_k_ptr, descale_v_ptr, descale_do_ptr,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_K_HEADS: tl.constexpr,
+    BATCH,
+    NUM_K_PIDS,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLK_SLICE_FACTOR: tl.constexpr,
+    BLOCK_D_MODEL: tl.constexpr,
+    BLOCK_D_MODEL_POW2: tl.constexpr,
+    ENABLE_DROPOUT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    IS_FP8: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    # workgroup id
+    wid = tl.program_id(0) # 0, ..., NUM_K_PIDS * BATCH * NUM_K_HEADS - 1
+
+    # Workgroups get launched first along batch dim, then in head_k dim, and then in seq k block dim
+    # This is in order to avoid contention for the tl.atomic_add (inside _bwd_dkdvdq_inner) that happens between workgroups that share the same batch and head_k. 
+    bid = wid % BATCH 
+    hkid = wid // BATCH % NUM_K_HEADS 
+    pid = wid // (BATCH * NUM_K_HEADS) % NUM_K_PIDS 
+
+    q_start = 0
+    k_start = 0
+    seqlen_q = max_seqlen_q
+    seqlen_k = max_seqlen_k
+
+    if IS_VARLEN:
+        q_start = tl.load(cu_seqlens_q + bid)
+        q_end = tl.load(cu_seqlens_q + bid + 1)
+        k_start = tl.load(cu_seqlens_k + bid)
+        k_end = tl.load(cu_seqlens_k + bid + 1)
+        seqlen_q = q_end - q_start
+        seqlen_k = k_end - k_start
+
+
+    dk = tl.zeros([BLOCK_N, BLOCK_D_MODEL_POW2], dtype=tl.float32)
+    dv = tl.zeros([BLOCK_N, BLOCK_D_MODEL_POW2], dtype=tl.float32)
+
+    start_n = pid * BLOCK_N
+
+    offs_k = tl.arange(0, BLOCK_D_MODEL_POW2)
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+    mask_kv = offs_n[:, None] < seqlen_k
+    PADDED_HEAD: tl.constexpr = (BLOCK_D_MODEL != BLOCK_D_MODEL_POW2)
+    if PADDED_HEAD:
+        mask_kv &= offs_k < BLOCK_D_MODEL
+
+    GROUP_SIZE = NUM_Q_HEADS // NUM_K_HEADS
+    adj_k = (bid * stride_kb + 
+            hkid * stride_kh + 
+            k_start * stride_kn + 
+            offs_n[:, None] * stride_kn + 
+            offs_k[None, :] * stride_kk)
+    adj_v = (bid * stride_vb + 
+            hkid * stride_vh + 
+            k_start * stride_vn + 
+            offs_n[:, None] * stride_vn + 
+            offs_k[None, :] * stride_vk)
+
+    k = tl.load(K + adj_k, mask=mask_kv, other=0.0)
+    v = tl.load(V + adj_v, mask=mask_kv, other=0.0)
+
+    for hqid in range(hkid * GROUP_SIZE, hkid * GROUP_SIZE + GROUP_SIZE):
+        adj_q = (bid * stride_qb + hqid * stride_qh + q_start * stride_qm)
+        adj_dq = (bid * stride_dqb + hqid * stride_dqh + q_start * stride_dqm)
+
+        Q_ptr = Q + adj_q
+        DQ_ptr = DQ  + adj_dq
+        
+        adj_do = (bid * stride_dob + hqid * stride_doh + q_start * stride_dom)
+        DO_ptr = DO + adj_do
+        adj_delta = (bid * stride_deltab + hqid * stride_deltah + q_start * stride_deltam)
+        M_ptr = M + adj_delta
+        Delta_ptr = Delta + adj_delta
+
+        #dropout 
+        batch_philox_offset = 0
+        dropout_offset = 0
+        if ENABLE_DROPOUT:
+            batch_philox_offset = philox_offset + bid * stride_dropoutb + \
+                                  hqid * stride_dropouth
+            dropout_offset = dropout_mask + bid * stride_dropoutb + \
+                             hqid * stride_dropouth
+
+        if IS_FP8:
+            descale_q = tl.load(descale_q_ptr + bid * stride_descale_q_z + hqid)
+            descale_k = tl.load(descale_k_ptr + bid * stride_descale_k_z + hkid)
+            descale_v = tl.load(descale_v_ptr + bid * stride_descale_v_z + hkid)
+            descale_do = tl.load(descale_do_ptr + bid * stride_descale_do_z + hqid)
+        else:
+            descale_q, descale_k, descale_v, descale_do = 1.0, 1.0, 1.0, 1.0
+
+        start_m = 0
+        num_steps = tl.cdiv(seqlen_q, BLOCK_M)
+
+        dk, dv = _bwd_dkdvdq_inner(
+            dk, dv,
+            Q_ptr, k, v, DO_ptr, DQ_ptr, M_ptr, Delta_ptr, sm_scale,
+            stride_qm, stride_qk,
+            stride_dqm, stride_dqk,
+            stride_dom, stride_dok,
+            stride_dropoutm, stride_dropoutn,
+            stride_deltam,
+            dropout_p, philox_seed, batch_philox_offset, dropout_offset,
+            seqlen_q, seqlen_k,
+            start_n, start_m, num_steps,
+            descale_q, descale_k, descale_v, descale_do,
+            BLOCK_M, BLOCK_N,
+            BLOCK_D_MODEL, BLOCK_D_MODEL_POW2,
+            MASK=False,
+            ENABLE_DROPOUT=ENABLE_DROPOUT,
+            IS_FP8=IS_FP8,
+            FP8_MAX=FP8_MAX,
+            workgroup_id=pid,
+        )
+
+    adj_dkdv = (bid * stride_dkb +
+                hkid * stride_dkh +
+                k_start * stride_dkn + offs_n[:, None] * stride_dkn + 
+                offs_k[None, :] * stride_dkk)
+    tl.store(DV + adj_dkdv, dv, mask=mask_kv)
+    dk *= sm_scale
+    tl.store(DK + adj_dkdv, dk, mask=mask_kv)
+
+
+
 @triton.jit
 def _bwd_kernel_dkdv_noncausal(
     Q, K, V, sm_scale, DO, DK, DV,
@@ -1760,8 +2331,8 @@ def _flash_attn_backward(
     descale_k: Optional[torch.Tensor] = None,
     descale_v: Optional[torch.Tensor] = None,
     descale_do: Optional[torch.Tensor] = None,
+    fused: bool = False,
 ):
-
     IS_FP8 = is_fp8(q)
     if IS_FP8:
         FP8_MAX = torch.finfo(q.dtype).max
@@ -1812,7 +2383,7 @@ def _flash_attn_backward(
     WAVES_PER_EU = 1
     PRE_BLOCK = 128
     #BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 32, 128, 128, 32
-    BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 16, 64, 64, 16 
+    BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 64, 64, 64, 16 
     BLK_SLICE_FACTOR = 2
 
     #init delta
@@ -1856,6 +2427,94 @@ def _flash_attn_backward(
 
     grid_dkdv = ((max_seqlen_k + BLOCK_N1 - 1) // BLOCK_N1, batch, num_k_heads)
     grid_dq = ((max_seqlen_q + BLOCK_M2 - 1) // BLOCK_M2, batch, num_k_heads)
+    
+    if fused: # fuses dk, dv, dq computations into one kernel by computing the dq using atomic adds between workgroups
+        
+        BLOCK_N = 128 if BLOCK_D_MODEL_POW2 < 160 else 64 # larger head sizes lead to oom
+        config = {
+            "BLOCK_M": 32,
+            "BLOCK_N": BLOCK_N,
+            "num_warps": 4,
+            "num_stages": 1,
+            "waves_per_eu": 1,
+            "BLK_SLICE_FACTOR": 2,
+        }
+        
+        num_k_pids = (max_seqlen_k + BLOCK_N - 1) // BLOCK_N
+        grid_dkdvdq = (batch * num_k_heads * num_k_pids,) 
+
+        if causal:
+            NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+            # change to parallelize over q heads.
+            # We can incur the cost of atomic adds for dk and dv, because they are not in the loop.
+            # Avoiding contention for dq atomic add (inside the loop) is critical. 
+            # We can reduce the risk by mapping the workgroups ids (0,1,2... batch * num_q_heads * num_k_pids-1) so that concurrent workgroups are (if possible) at different batch, or head_q or inner loop m_idx.
+            grid_dkdvdq = (batch * num_q_heads * num_k_pids,) 
+            _bwd_kernel_dkdvdq_causal[grid_dkdvdq](
+                q, k, v, sm_scale, do, dk, dv, dq,
+                softmax_lse, delta,
+                *q_strides,
+                *k_strides,
+                *v_strides,
+                *dk_strides,
+                *dq_strides,
+                *delta_strides,
+                *do_strides,
+                *dropout_strides,
+                *descale_strides,
+                cu_seqlens_q, cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                dropout_mask,dropout_p, philox_seed, philox_offset,
+                descale_q, descale_k, descale_v, descale_do,
+                NUM_Q_HEADS=num_q_heads,
+                NUM_K_HEADS=num_k_heads,
+                BATCH=batch,
+                NUM_K_PIDS=num_k_pids, 
+                BLOCK_D_MODEL=head_sz,
+                BLOCK_D_MODEL_POW2=BLOCK_D_MODEL_POW2,
+                ENABLE_DROPOUT=use_dropout,
+                IS_VARLEN=IS_VARLEN,
+                IS_FP8=IS_FP8,
+                FP8_MAX=FP8_MAX,
+                NUM_SMS=NUM_SMS,
+                **config,
+            )
+        else:
+            _bwd_kernel_dkdvdq_noncausal[grid_dkdvdq](
+                q, k, v, sm_scale, do, dk, dv, dq,
+                softmax_lse, delta,
+                *q_strides,
+                *k_strides,
+                *v_strides,
+                *dk_strides,
+                *dq_strides,
+                *delta_strides,
+                *do_strides,
+                *dropout_strides,
+                *descale_strides,
+                cu_seqlens_q, cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                dropout_mask,dropout_p, philox_seed, philox_offset,
+                descale_q, descale_k, descale_v, descale_do,
+                NUM_Q_HEADS=num_q_heads,
+                NUM_K_HEADS=num_k_heads,
+                BATCH=batch,
+                NUM_K_PIDS=num_k_pids,
+                BLOCK_D_MODEL=head_sz,
+                BLOCK_D_MODEL_POW2=BLOCK_D_MODEL_POW2,
+                ENABLE_DROPOUT=use_dropout,
+                IS_VARLEN=IS_VARLEN,
+                IS_FP8=IS_FP8,
+                FP8_MAX=FP8_MAX,
+                **config,
+            )
+        
+        return delta
+    
+    # split kernels solution: one kernel computes dk, dv and the other computes dq
+
     if causal:
         _bwd_kernel_dkdv_causal[grid_dkdv](
             q, k, v, sm_scale, do, dk, dv,
@@ -2001,13 +2660,16 @@ class FlashAttnFunc(torch.autograd.Function):
         deterministic,
         return_lse,
         return_softmax,
-        is_grad_enabled, 
+        is_grad_enabled,
+        fused_backward,
     ):
         is_grad = is_grad_enabled and any(
             x.requires_grad for x in [q,k,v]
         )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
+    
+        
         head_size_og = q.size(3)
         if head_size_og % 8 != 0:
             q = torch.nn.functional.pad(q, [0, 8 - head_size_og % 8])
@@ -2039,6 +2701,8 @@ class FlashAttnFunc(torch.autograd.Function):
             ctx.window_size = window_size
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
+            ctx.fused_backward = fused_backward
+
 
         out = out_padded[..., :head_size_og]
         result = [out]
@@ -2076,12 +2740,13 @@ class FlashAttnFunc(torch.autograd.Function):
             max_seqlen_k=k.shape[1],
             dropout_p=ctx.dropout_p,
             philox_seed=ctx.philox_seed,
-            philox_offset=ctx.philox_offset
+            philox_offset=ctx.philox_offset,
+            fused=ctx.fused_backward,
         )
         dq = dq[..., : q.shape[-1]]  # We could have padded the head dimension
         dk = dk[..., : k.shape[-1]]
         dv = dv[..., : v.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 def flash_attn_func(
     q,
@@ -2095,6 +2760,7 @@ def flash_attn_func(
     deterministic=True,
     return_lse=False,
     return_attn_probs=False,
+    fused_backward=False,
 ):
     """dropout_p should be set to 0.0 during evaluation
     Supports multi-query and grouped-query attention (MQA/GQA) by passing in KV with fewer heads
@@ -2156,7 +2822,8 @@ def flash_attn_func(
         deterministic,
         return_lse,
         return_attn_probs,
-        torch.is_grad_enabled()
+        torch.is_grad_enabled(),
+        fused_backward,
     )
 
 
@@ -2176,6 +2843,7 @@ class FlashAttnFP8Func(torch.autograd.Function):
         return_lse,
         return_softmax,
         is_grad_enabled, 
+        fused_backward,
     ):
         is_grad = is_grad_enabled and any(
             x.requires_grad for x in [q,k,v]
@@ -2212,7 +2880,7 @@ class FlashAttnFP8Func(torch.autograd.Function):
             cu_seqlens_k=None,
             descale_q=descale_q,
             descale_k=descale_k,
-            descale_v=descale_v
+            descale_v=descale_v,
         )
 
         if is_grad:
@@ -2224,6 +2892,7 @@ class FlashAttnFP8Func(torch.autograd.Function):
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.alibi_slopes = alibi_slopes
+            ctx.fused_backward = fused_backward
         
         out = out_padded[..., :head_size_og]
         result = [out]
@@ -2269,11 +2938,12 @@ class FlashAttnFP8Func(torch.autograd.Function):
             descale_k=descale_k,
             descale_v=descale_v,
             descale_do=descale_do,
+            fused=ctx.fused_backward,
         )
         #dq = dq[..., : q_fp8.shape[-1]]  # We could have padded the head dimension
         #dk = dk[..., : k_fp8.shape[-1]]
         #dv = dv[..., : v_fp8.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None
 
 def flash_attn_fp8_func(
     q,
@@ -2286,7 +2956,8 @@ def flash_attn_fp8_func(
     alibi_slopes=None,
     deterministic=False,
     return_lse=False,
-    return_attn_probs=False
+    return_attn_probs=False,
+    fused_backward=False,
 ):
     return FlashAttnFP8Func.apply(
         q,
@@ -2300,7 +2971,8 @@ def flash_attn_fp8_func(
         deterministic,
         return_lse,
         return_attn_probs,
-        torch.is_grad_enabled()
+        torch.is_grad_enabled(),
+        fused_backward,
     ) 
 
 class FlashAttnVarlenFunc(torch.autograd.Function):
@@ -2324,6 +2996,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         return_softmax,
         block_table,
         is_grad_enabled,
+        fused_backward,
     ):
         is_grad = is_grad_enabled and any(
             x.requires_grad for x in [q, k, v]
@@ -2363,6 +3036,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.alibi_slopes = alibi_slopes
+            ctx.fused_backward = fused_backward
         out = out_padded[..., :head_size_og]
 
         result = [out]
@@ -2400,12 +3074,13 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             max_seqlen_k=ctx.max_seqlen_k,
             dropout_p=ctx.dropout_p,
             philox_seed=ctx.philox_seed,
-            philox_offset=ctx.philox_offset
+            philox_offset=ctx.philox_offset,
+            fused=ctx.fused_backward,
         )
         dq = dq[..., : q.shape[-1]]  # We could have padded the head dimension
         dk = dk[..., : k.shape[-1]]
         dv = dv[..., : v.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def flash_attn_varlen_func(
@@ -2425,6 +3100,7 @@ def flash_attn_varlen_func(
     return_lse=False,
     return_attn_probs=False,
     block_table=None,
+    fused_backward=False,
 ):
     """dropout_p should be set to 0.0 during evaluation
     Supports multi-query and grouped-query attention (MQA/GQA) by passing in K, V with fewer heads
@@ -2498,6 +3174,7 @@ def flash_attn_varlen_func(
         return_attn_probs,
         block_table,
         torch.is_grad_enabled(),
+        fused_backward,
     )
 
 
@@ -2522,6 +3199,7 @@ class FlashAttnVarlenFP8Func(torch.autograd.Function):
         return_softmax,
         block_table,
         is_grad_enabled,
+        fused_backward,
     ):
         is_grad = is_grad_enabled and any(
             x.requires_grad for x in [q, k, v]
@@ -2558,7 +3236,8 @@ class FlashAttnVarlenFP8Func(torch.autograd.Function):
             cu_seqlens_k=cu_seqlens_k,
             descale_q=descale_q,
             descale_k=descale_k,
-            descale_v=descale_v
+            descale_v=descale_v,
+            fused_backward=fused_backward,
         )
         if is_grad:
             ctx.save_for_backward(q_fp8, k_fp8, v_fp8, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, descale_q, descale_k, descale_v)
@@ -2571,6 +3250,7 @@ class FlashAttnVarlenFP8Func(torch.autograd.Function):
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.alibi_slopes = alibi_slopes
+            ctx.fused_backward = fused_backward
         out = out_padded[..., :head_size_og]
         result = [out]
         if return_lse:
@@ -2582,15 +3262,15 @@ class FlashAttnVarlenFP8Func(torch.autograd.Function):
     
     @staticmethod
     def backward(ctx, do, *args):
-        q_fp8, k_fp8, v_fp8, out, softmax_lse, cu_seqlens_q, cu_seqlens_q, descale_q, descale_k, descale_v = ctx.saved_tensors
-        dq, dk, dv = torch.zeros_like(q, dtype=torch.float32), torch.zeros_like(k, dtype=torch.float32), torch.zeros_like(v, dtype=torch.float32)
+        q_fp8, k_fp8, v_fp8, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, descale_q, descale_k, descale_v = ctx.saved_tensors
+        dq, dk, dv = torch.zeros_like(q_fp8, dtype=torch.float32), torch.zeros_like(k_fp8, dtype=torch.float32), torch.zeros_like(v_fp8, dtype=torch.float32)
         head_size_v_og = do.size(3)
         do_padded = do
         if head_size_v_og % 8 != 0:
             do_padded = torch.nn.functional.pad(do, [0, 8 - head_size_v_og % 8])
         
         fp8_dtype = torch.float8_e4m3fnuz 
-        do_padded_fp8, descale_do = cast_varlen_to_fp8(dout_padded, fp8_dtype, "thd", cu_seqlens_q)
+        do_padded_fp8, descale_do = cast_varlen_to_fp8(do_padded, fp8_dtype, "thd", cu_seqlens_q)
         
         _flash_attn_backward(
             do_padded_fp8,
@@ -2607,8 +3287,8 @@ class FlashAttnVarlenFP8Func(torch.autograd.Function):
             ctx.causal,
             cu_seqlens_q,
             cu_seqlens_k,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_k=max_seqlen_k,
+            max_seqlen_q=ctx.max_seqlen_q,
+            max_seqlen_k=ctx.max_seqlen_k,
             dropout_p=ctx.dropout_p,
             philox_seed=ctx.philox_seed,
             philox_offset=ctx.philox_offset,
@@ -2617,10 +3297,10 @@ class FlashAttnVarlenFP8Func(torch.autograd.Function):
             descale_v=descale_v,
             descale_do=descale_do
         )
-        dq = dq[..., : q.shape[-1]]  # We could have padded the head dimension
-        dk = dk[..., : k.shape[-1]]
-        dv = dv[..., : v.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None
+        dq = dq[..., : q_fp8.shape[-1]]  # We could have padded the head dimension
+        dk = dk[..., : k_fp8.shape[-1]]
+        dv = dv[..., : v_fp8.shape[-1]]
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
 
 def flash_attn_varlen_fp8_func(
     q,
@@ -2638,7 +3318,8 @@ def flash_attn_varlen_fp8_func(
     deterministic=False,
     return_lse=False,
     return_attn_probs=False,
-    block_table=None
+    block_table=None,
+    fused_backward=False,
 ):
     return FlashAttnVarlenFP8Func.apply(
         q,
@@ -2657,5 +3338,6 @@ def flash_attn_varlen_fp8_func(
         return_lse,
         return_attn_probs,
         block_table,
-        torch.is_grad_enabled()
+        torch.is_grad_enabled(),
+        fused_backward,
     )

--- a/op_benchmarks/triton/bench_mha.py
+++ b/op_benchmarks/triton/bench_mha.py
@@ -10,7 +10,7 @@ import warnings
 import argparse
 
 from aiter.ops.triton.mha import flash_attn_func, flash_attn_fp8_func, flash_attn_varlen_func, flash_attn_varlen_fp8_func
-from aiter.test_mha_common import attention_ref, generate_random_padding_mask, generate_qkv, pad_rearrange_dropout_mask_hts_to_bhss
+from aiter.test_mha_common import attention_ref, generate_random_padding_mask, generate_qkv
 import sys
 
 # thd layout

--- a/op_benchmarks/triton/bench_mha.py
+++ b/op_benchmarks/triton/bench_mha.py
@@ -1,3 +1,4 @@
+import torch.test
 import triton
 import triton.language as tl
 from utils.benchmark_utils import get_model_configs, get_available_models, print_vgpr
@@ -13,10 +14,11 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(os.path.dirname(current_dir))
 sys.path.append(parent_dir)
 
-from aiter.ops.triton.mha import flash_attn_varlen_func, flash_attn_func, flash_attn_varlen_fp8_func, flash_attn_fp8_func
+from aiter.ops.triton.mha import flash_attn_func, flash_attn_fp8_func, flash_attn_varlen_func, flash_attn_varlen_fp8_func
+from aiter.test_mha_common import attention_ref, generate_random_padding_mask, generate_qkv, pad_rearrange_dropout_mask_hts_to_bhss 
 import sys
 
-
+# thd layout
 def mha_varlen_input_helper(Z, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, equal_seqlens=False, requires_grad=True):
     torch.manual_seed(20)
 
@@ -50,12 +52,11 @@ def mha_varlen_input_helper(Z, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, equal_se
     sm_scale = D_HEAD**-0.5
     return q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale
 
-
+# bshd layout
 def mha_input_helper(Z, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, requires_grad=True):
     torch.manual_seed(20)
 
     # Initialize q, k, v
-    # bshd layout supported
     q_tensor_shape = (Z, N_CTX_Q, HQ, D_HEAD)
     k_tensor_shape = (Z, N_CTX_K, HK, D_HEAD)
 
@@ -64,8 +65,6 @@ def mha_input_helper(Z, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, requires_grad=T
     v = torch.randn(k_tensor_shape, dtype=dtype, device="cuda", requires_grad=requires_grad)
 
     sm_scale = D_HEAD**-0.5
-    # max_seqlens_q = N_CTX_Q
-    # max_seqlens_k = N_CTX_K
 
     return q, k, v, sm_scale
 
@@ -76,7 +75,8 @@ def nonvarlen_benchmark_configs():
         (8, 16, 16, 2048, 2048),
         (4, 16, 16, 4096, 4096),
         (2, 16, 16, 8192, 8192),
-        (1, 16, 16, 16384, 16384),
+        (8, 16, 16, 1024, 4096),
+        (1, 16, 16, 4096, 16384),
         (2, 48, 48, 1024, 1024),
         (2, 48, 48, 2048, 1024),
         (2, 48, 48, 4096, 8192),
@@ -130,134 +130,48 @@ def model_benchmark_configs(args):
 
     return fa_configs
 
-def test_correctness(custom, args):
+
+
+def pad_rearrange_dropout_mask(S_dmask, cu_seqlens_q, cu_seqlens_k,  max_seqlen_q, max_seqlen_k, seqlen_q, seqlen_k, num_q_heads):
+    batch_size = cu_seqlens_q.numel() - 1
+    
+    padded_dropout_mask = torch.ones((batch_size, num_q_heads, seqlen_q, seqlen_k), device="cuda")
+    for b in range(batch_size):
+        start_q = cu_seqlens_q[b].item()
+        end_q = cu_seqlens_q[b + 1].item()
+        start_k = cu_seqlens_k[b].item()
+        end_k = cu_seqlens_k[b + 1].item()
+
+        seqlen_q = end_q - start_q
+        seqlen_k = end_k - start_k
+        for h in range(S_dmask.shape[1]):
+                padded_dropout_mask[b, h, :max_seqlen_q, :max_seqlen_k] = S_dmask[b, h, : ,:]
+    
+    
+    return padded_dropout_mask
+
+
+def create_benchmark_configs(custom, args):
     dtype = arg_to_torch_dtype[args.dtype]
     hk = args.hq if not args.hk else args.hk
     sk = args.sq if not args.sk else args.sk
     head_size = 128 if not args.d else args.d
-    mode = 'fwd'
+    mode = args.mode
     x_names = ['BATCH', 'HQ', 'HK', 'N_CTX_Q', 'N_CTX_K']
     causal = args.causal
     varlen = args.layout == 'thd'
 
-    if custom:
-        x_vals_list = [(args.b, args.hq, hk, args.sq, sk)]
-    else:
-        if varlen:
-            x_vals_list = varlen_benchmark_configs()
-        else:
-            x_vals_list = nonvarlen_benchmark_configs()
-
-        if args.model:
-            x_vals_list = model_benchmark_configs(args)
-            x_names = ['model', 'BATCH', 'HQ', 'HK', 'N_CTX_Q', 'N_CTX_K', 'D_HEAD']
-
-
-    def bench_flash_attention(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, causal, mode, provider, device="cuda",
-                              model=None):
-        assert mode in ["fwd", "bwd"]
-        requires_grad = False
-        # Bwd pass only supports causal=True right now
-        if mode == 'bwd':
-            causal = True
-            requires_grad = True
-
-        if varlen:
-            q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale = mha_varlen_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype,
-                                                            equal_seqlens=args.equal_seqlens, requires_grad=requires_grad)
-        else:
-            q, k, v, sm_scale = mha_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, requires_grad=requires_grad)
-        
-        if "Torch" in provider:
-            assert not varlen or args.equal_seqlens, "Torch sdpa does not support variable sequence lengths."
-            q = q.view(BATCH, N_CTX_Q, HQ, D_HEAD).transpose(1, 2)
-            k = k.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
-            v = v.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
-            if HQ != HK:  # TODO: sdpa(..., enable_gqa=True) works but gives very bad perf
-                k = k.repeat_interleave(q.size(-3) // k.size(-3), -3)
-                v = v.repeat_interleave(q.size(-3) // v.size(-3), -3)
-            fn = lambda: torch.nn.functional.scaled_dot_product_attention(
-                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=causal, scale=sm_scale)
-        else:
-            o = torch.empty_like(q)
-            if varlen:
-                if args.fp8:
-                    fn = lambda: flash_attn_varlen_fp8_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
-                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
-                else:
-                    fn = lambda: flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
-                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
-            else:
-                if args.fp8:
-                    fn = lambda: flash_attn_fp8_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
-                else:
-                    fn = lambda: flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
-
-            if mode == 'bwd':
-                o, _ = fn()
-                do = torch.randn_like(o)
-                fn = lambda: o.backward(do, retain_graph=True)
-
-        return fn()
-
-    # Test correctness of the triton kernel by comparing the output to the torch sdpa output
-    for config in x_vals_list:
-        # Build a dictionary from x_names and config values, and add D_HEAD
-        cfg = {name: value for name, value in zip(x_names, config)}
-        cfg["D_HEAD"] = head_size  # head size computed above
-
-        # Run benchmark with Triton provider
-        triton_result = bench_flash_attention(
-            **cfg,
-            dtype=dtype,
-            causal=causal,
-            mode=mode,
-            provider="Triton"
-        )
-        triton_result = triton_result[0]
-
-        # Run benchmark with Torch provider
-        torch_result = bench_flash_attention(
-            **cfg,
-            dtype=dtype,
-            causal=causal,
-            mode=mode,
-            provider="Torch"
-        )
-
-        torch_result = torch_result.transpose(1,2)
-        if varlen:
-            torch_result = torch_result.flatten(0,1) # Triton kernel flattens batch and sequence length dims
-
-        # Check that the results are close
-        torch.testing.assert_close(triton_result, torch_result, rtol=2e-2, atol=2e-2)
-        print(f"Results are close for config: {cfg} for triton kernel and torch.sdpa!")
-
-
-def run_benchmark(custom, args):
-    dtype = arg_to_torch_dtype[args.dtype]
-    hk = args.hq if not args.hk else args.hk
-    sk = args.sq if not args.sk else args.sk
-    head_size = 128 if not args.d else args.d
-    mode = 'fwd'
-    x_names = ['BATCH', 'HQ', 'HK', 'N_CTX_Q', 'N_CTX_K']
-    causal = args.causal 
-    varlen = args.layout == 'thd'
-    
     configs = []
     plot_name = f'fused-attention-{mode}-D_HEAD-{head_size}-layout-{args.layout}-fp8-{args.fp8}-causal-{causal}'
     extra_args = {'D_HEAD': head_size, 'dtype': dtype, 'causal': causal, 'mode': mode}
+
     if custom:
         x_vals_list = [(args.b, args.hq, hk, args.sq, sk)]
     else:
         if varlen:
-            x_vals_list = varlen_benchmark_configs()
+            x_vals_list = varlen_benchmark_configs()  # Assume this exists
         else:
-            x_vals_list = nonvarlen_benchmark_configs()
+            x_vals_list = nonvarlen_benchmark_configs()  # Assume this exists
 
         if args.model:
             x_vals_list = model_benchmark_configs(args)
@@ -265,126 +179,218 @@ def run_benchmark(custom, args):
             plot_name = f'fused-attention-{mode}-layout-{args.layout}-fp8-{args.fp8}-causal-{causal}'
             extra_args = {'dtype': dtype, 'causal': causal, 'mode': mode}
 
+
     unit = "TFLOPS"
     if args.return_time:
         unit = "ms"
     if args.return_bandwidth:
         unit = "GB/s"
+    # unit = "ms"
+
+    if mode=="bwd":
+        line_vals = [f'fused-bwd({unit})', f'bwd({unit})']
+    else:
+        line_vals = [f'fwd({unit})']
 
     if args.bench_torch:
-        if args.return_all:
-            line_vals = [f"{provider} ({unit})" for provider in ["Triton", "Torch"] for unit in ["ms", "TFLOPS", "TB/s"] ]
-        else:
-            line_vals = [f'Triton ({unit})', f'Torch ({unit})']
-    else:
-        line_vals = [unit]
-        if args.return_all:
-            line_vals = ["ms", "TFLOPS", "GB/s"]
-    
+        line_vals = [f'Triton({unit})', f'Torch({unit})']
+
+    if args.test_mode:
+        line_vals = ["test_mode"]
+
     configs.append(
-        triton.testing.Benchmark(x_names=x_names, x_vals=x_vals_list, line_arg='provider', line_vals=line_vals,
-                                 line_names=line_vals, styles=[('red', '-'), ('green', '-'), ('blue', '-')]*2,
-                                 ylabel=unit, plot_name=plot_name, args=extra_args))
+        triton.testing.Benchmark(
+            x_names=x_names,
+            x_vals=x_vals_list,
+            line_arg='provider',
+            line_vals=line_vals,
+            line_names=line_vals,
+            styles=[('red', '-'), ('green', '-')],
+            ylabel=unit,
+            plot_name=plot_name,
+            args=extra_args
+        )
+    )
+    return configs
 
-    @triton.testing.perf_report(configs)
-    def bench_flash_attention(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, causal, mode, provider, device="cuda",
-                              model=None):
-        assert mode in ["fwd", "bwd"]
+def run_benchmark(custom, args):
+    torch.manual_seed(20)
 
+    @triton.testing.perf_report(create_benchmark_configs(custom, args))
+    def bench_mha_backward(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, causal, mode, provider, dropout=0.0, model=None, sm_scale=None, device="cuda"):
+        """
+        Benchmark or test function for multi-head attention backward pass.
+        In test_mode, verifies output matching with non-varlen inputs.
+        """
+        # assert mode == "bwd"
+        requires_grad = True
+        return_lse = True
+        return_attn_probs = True
         warmup = 25
         rep = 100
+        varlen = args.layout == 'thd' if not (hasattr(args, 'test_mode') and args.test_mode) else False  # Force non-varlen in test mode
 
-        requires_grad = False
-        # Bwd pass only supports causal=True right now
-        if mode == 'bwd':
-            causal = True
-            requires_grad = True
+        fused_backward = args.fused_bwd or ("fused" in provider)
 
+        # Default softmax scale to match standard attention
+        if sm_scale is None:
+            sm_scale = 1.0 / (D_HEAD ** 0.5)
+
+        torch.manual_seed(20)
+
+        # Generate base inputs
+        q = torch.randn((BATCH, N_CTX_Q, HQ, D_HEAD), device=device, dtype=dtype)
+        k = torch.randn((BATCH, N_CTX_K, HK, D_HEAD), device=device, dtype=dtype)
+        v = torch.randn((BATCH, N_CTX_K, HK, D_HEAD), device=device, dtype=dtype)
+        q.requires_grad = requires_grad
+        k.requires_grad = requires_grad
+        v.requires_grad = requires_grad
+        do = torch.randn_like(q)
+
+        # FLOPS calculation variables
         flops_per_matmul = 0
+
+        # Input preparation
         if varlen:
-            q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale = mha_varlen_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype,
-                                                            equal_seqlens=args.equal_seqlens, requires_grad=requires_grad)
+            query_padding_mask = generate_random_padding_mask(N_CTX_Q, BATCH, device, mode="random")
+            key_padding_mask = generate_random_padding_mask(N_CTX_K, BATCH, device, mode="random")
+            (
+                q_unpad, k_unpad, v_unpad, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+                q, k, v, output_pad_fn, dq_pad_fn, dk_pad_fn,
+            ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask, kvpacked=False)
+            q_unpad.requires_grad = True
+            k_unpad.requires_grad = True
+            v_unpad.requires_grad = True
+            q_input, k_input, v_input = q_unpad, k_unpad, v_unpad
+
             num_contexts = len(cu_seqlens_q) - 1
-            for i in range(0, num_contexts):
+            for i in range(num_contexts):
                 seqlen_q = (cu_seqlens_q[i + 1] - cu_seqlens_q[i]).item()
                 seqlen_k = (cu_seqlens_k[i + 1] - cu_seqlens_k[i]).item()
-                # x2 in both cases for 2 GEMMs
                 if causal:
                     valid_out_elements = ((seqlen_k**2 + seqlen_k) / 2) if seqlen_q > seqlen_k else \
-                            (seqlen_q * seqlen_k - ((seqlen_q**2 - seqlen_q) / 2))
+                                        (seqlen_q * seqlen_k - ((seqlen_q**2 - seqlen_q) / 2))
                     flops_per_matmul += valid_out_elements * HQ * D_HEAD * 2
                 else:
                     flops_per_matmul += seqlen_q * seqlen_k * HQ * D_HEAD * 2
         else:
-            q, k, v, sm_scale = mha_input_helper(BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, dtype, requires_grad=requires_grad)
+            q_input, k_input, v_input = q, k, v
+            output_pad_fn = dq_pad_fn = dk_pad_fn = lambda x: x
+
             if causal:
-                # Same calculation as if varlen/if causal above
                 valid_out_elements = ((N_CTX_K**2 + N_CTX_K) / 2) if N_CTX_Q > N_CTX_K else \
-                        (N_CTX_Q * N_CTX_K - ((N_CTX_Q**2 - N_CTX_Q) / 2))
+                                    (N_CTX_Q * N_CTX_K - ((N_CTX_Q**2 - N_CTX_Q) / 2))
                 flops_per_matmul = 2.0 * BATCH * HQ * valid_out_elements * D_HEAD
             else:
                 flops_per_matmul = 2.0 * BATCH * HQ * N_CTX_Q * N_CTX_K * D_HEAD
-        
+
+        # Test mode: Verify outputs match
+        if hasattr(args, 'test_mode') and args.test_mode:
+            # Triton
+            if varlen:
+                triton_fn = lambda: flash_attn_varlen_func(
+                    q_input, k_input, v_input, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+                    dropout_p=dropout, softmax_scale=sm_scale, causal=causal,
+                    return_lse=return_lse, return_attn_probs=return_attn_probs, fused_backward=fused_backward
+                )
+            else:
+                triton_fn = lambda: flash_attn_func(
+                    q_input, k_input, v_input, dropout_p=dropout, softmax_scale=sm_scale, causal=causal,
+                    return_lse=return_lse, return_attn_probs=return_attn_probs, fused_backward=fused_backward 
+                )
+            with torch.enable_grad():
+                triton_out, _, sd_mask = triton_fn()
+                dropout_mask = sd_mask >= 0 if dropout > 0.0 else None
+                triton_dq, triton_dk, triton_dv = torch.autograd.grad(triton_out, (q_input, k_input, v_input), do.clone())
+
+            triton_dq = dq_pad_fn(triton_dq)
+            triton_dk = dk_pad_fn(triton_dk)
+            triton_dv = dk_pad_fn(triton_dv)
+
+            # Torch
+            torch_fn = lambda: attention_ref(q, k, v, dropout_p=dropout, dropout_mask=dropout_mask, causal=causal)
+            with torch.enable_grad():
+                torch_out, _ = torch_fn()
+                torch_dq, torch_dk, torch_dv = torch.autograd.grad(torch_out, (q, k, v), do)
+
+            # compare forward outputs
+            torch.testing.assert_close(triton_out, torch_out, atol=1e-2, rtol=1e-2)
+            print("Forward outputs match!")
+            # Compare gradients
+            torch.testing.assert_close(triton_dk, torch_dk, atol=1e-2, rtol=1e-2)
+            torch.testing.assert_close(triton_dv, torch_dv, atol=1e-2, rtol=1e-2)
+            torch.testing.assert_close(triton_dq, torch_dq, atol=1e-2, rtol=1e-2)
+            print(f"Backward gradients match for shape: BATCH={BATCH}, HQ={HQ}, HK={HK}, N_CTX_Q={N_CTX_Q}, N_CTX_K={N_CTX_K}, D_HEAD={D_HEAD}")
+            return 0
+
+        # Benchmark mode
         if "Torch" in provider:
-            assert not varlen or args.equal_seqlens, "Torch sdpa does not support variable sequence lengths. Hint: if you are using -layout thd, set -equal_seqlens aswell."
-            # torch.sdpa assumes bhsd layout
-            q = q.view(BATCH, N_CTX_Q, HQ, D_HEAD).transpose(1, 2)
-            k = k.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
-            v = v.view(BATCH, N_CTX_K, HK, D_HEAD).transpose(1, 2)
-            if HQ != HK:  # TODO: sdpa(..., enable_gqa=True) works but gives very bad perf
-                k = k.repeat_interleave(q.size(-3) // k.size(-3), -3)
-                v = v.repeat_interleave(q.size(-3) // v.size(-3), -3)
-            fn = lambda: torch.nn.functional.scaled_dot_product_attention(
-                q, k, v, attn_mask=None, dropout_p=0.0, is_causal=causal, scale=sm_scale)
-        else:
-            o = torch.empty_like(q)
+            fn = lambda: attention_ref(q, k, v, dropout_p=dropout, causal=causal)
+            if mode=="bwd":
+                with torch.enable_grad():
+                    torch_out, _ = fn()
+                    fn = lambda: torch.autograd.grad(torch_out, (q, k, v), do, retain_graph=True)
+        else:  # Triton
             if varlen:
                 if args.fp8:
-                    fn = lambda: flash_attn_varlen_fp8_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
-                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
+                    fn = lambda: flash_attn_varlen_fp8_func(
+                        q_input, k_input, v_input, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+                        dropout_p=dropout, softmax_scale=sm_scale, causal=causal,
+                        return_lse=return_lse, return_attn_probs=return_attn_probs, fused_backward=fused_backward
+                    )
                 else:
-                    fn = lambda: flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k,
-                                                        N_CTX_Q, N_CTX_K, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
+                    fn = lambda: flash_attn_varlen_func(
+                        q_input, k_input, v_input, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+                        dropout_p=dropout, softmax_scale=sm_scale, causal=causal,
+                        return_lse=return_lse, return_attn_probs=return_attn_probs, fused_backward=fused_backward
+                    )
             else:
                 if args.fp8:
-                    fn = lambda: flash_attn_fp8_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
+                    fn = lambda: flash_attn_fp8_func(
+                        q_input, k_input, v_input, dropout_p=dropout, softmax_scale=sm_scale, causal=causal,
+                        return_lse=return_lse, return_attn_probs=return_attn_probs, fused_backward=fused_backward
+                    )
                 else:
-                    fn = lambda: flash_attn_func(q, k, v, dropout_p=0.0, softmax_scale=sm_scale,
-                                                        causal=causal)
-
-            if mode == 'bwd':
-                o, _ = fn()
-                do = torch.randn_like(o)
-                fn = lambda: o.backward(do, retain_graph=True)
+                    fn = lambda: flash_attn_func(
+                        q_input, k_input, v_input, dropout_p=dropout, softmax_scale=sm_scale, causal=causal,
+                        return_lse=return_lse, return_attn_probs=return_attn_probs, fused_backward=fused_backward 
+                    )
+            if mode=="bwd":
+                with torch.enable_grad():
+                    triton_out, _, _ = fn()
+                    if varlen:
+                        triton_out = output_pad_fn(triton_out)
+                    fn = lambda: torch.autograd.grad(triton_out, (q_input, k_input, v_input), do.clone(), retain_graph=True)
 
         ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
         total_flops = 2 * flops_per_matmul
         if mode == "bwd":
             total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
 
-        input_bytes = 1 if args.fp8 else q.element_size() # size of element in q,k,v in bytes
+
+        input_bytes = q.element_size()
         output_bytes = q.element_size()
         if varlen:
             total_num_tokens_q = cu_seqlens_q[-1].item()
             total_num_tokens_k = cu_seqlens_k[-1].item()
-            mem = total_num_tokens_q * HQ * D_HEAD * input_bytes + 2 * total_num_tokens_k * HK * D_HEAD * input_bytes + total_num_tokens_q * HQ * D_HEAD * output_bytes
         else:
             total_num_tokens_q = BATCH * N_CTX_Q
             total_num_tokens_k = BATCH * N_CTX_K
-            mem = total_num_tokens_q * HQ * D_HEAD * input_bytes + 2 * total_num_tokens_k * HK * D_HEAD * input_bytes + total_num_tokens_q * HQ * D_HEAD * output_bytes
+        mem = (total_num_tokens_q * HQ * D_HEAD * input_bytes +
+               2 * total_num_tokens_k * HK * D_HEAD * input_bytes +
+               total_num_tokens_q * HQ * D_HEAD * output_bytes)
 
+        # return ms
+        
         if "ms" in provider:
             return ms
         elif "TFLOPS" in provider:
             return total_flops / ms * 1e-9
-        else: # bandwidth GB/s
+        else:  # GB/s
             return mem / ms * 1e-3
 
-
-    bench_flash_attention.run(save_path=".", print_data=True, show_plots=True)
+    bench_mha_backward.run(save_path=None, print_data=True, show_plots=False)
 
 
 def supported_layouts():
@@ -417,6 +423,7 @@ def parse_args():
         "]. Use 'all' to benchmark all models. Provide model family (the part before -) to benchmark all models in that family. One can provide multiple as -model \"llama3,mistral_7B\""
     )
     parser.add_argument('-model', type=str, default="", help=model_help)
+    parser.add_argument('-mode', type=str, default="fwd", help="fwd:forward kernel, bwd:backward kernel")
     parser.add_argument("-b", type=int, default=0)
     parser.add_argument("-hq", type=int, default=0)
     parser.add_argument("-hk", type=int, default=0)
@@ -430,14 +437,17 @@ def parse_args():
     parser.add_argument("-quantize_p", action='store_true', default=False)
     parser.add_argument("-dtype", default='fp16')
     parser.add_argument("-bench_torch", action='store_true', default=False)
+    parser.add_argument("-fused_bwd", action='store_true', default=False)
     parser.add_argument("-print_vgpr", action='store_true', default=False)
     parser.add_argument("-return_all", action='store_true', default=False, help="Prints TFLOPS, walltime, bandwidth.")
+    parser.add_argument("-test_mode", action='store_true', default=False, help="Tests correctness of the Triton provider comparing the output to the Torch sdpa.")
     # prints TFLOPS without setting the following
     parser.add_argument("-return_time", action='store_true', default=False, help="Prints only walltime.")
     parser.add_argument("-return_bandwidth", action='store_true', default=False, help="Prints only memory bandwidth.")
-    parser.add_argument("-test_correctness", action='store_true', default=False,
-                         help="Tests correctness of the Triton provider comparing the output to the Torch sdpa.")
+    
     parser.add_argument("-layout", type=str, default=None, help=supported_layouts())
+    
+
     parser.add_argument(
         "-persistent", nargs='?', const='fixed', choices=['fixed', 'dynamic'], default=None,
         help="Enable persistent kernels. Use '-persistent dynamic' for dynamic scheduling of the tiles.")
@@ -455,7 +465,7 @@ def main():
             args.causal = True
         if args.layout is None:  # User didn’t specify -layout
             args.layout = 'thd'
-        print(f"Note: using -model config defaults: causal={args.causal}, layout={args.layout}. This is the most common real life scenario, but can be overridden with -causal and -layout flags.")
+        print(f"Note: using -model config defaults: causal={True}, layout={'thd'}. This is the most common real life scenario, but can be overridden with -causal and -layout flags.")
     else:
         # the defaults for causal and varlen when not using the -model
         if args.causal is None:  # User didn’t specify -causal
@@ -464,8 +474,6 @@ def main():
             args.layout = 'bshd'
     
     custom_config = False
-    assert not args.test_correctness or (not args.layout=="thd") or args.equal_seqlens, \
-        "Varlen not supported for -test_correctness, so use -equal_seqlens if using thd layout."
 
     assert args.layout == 'thd' or not args.equal_seqlens or args.model, \
            "Equal sequence lengths arg must be used with the thd layout or a model config."
@@ -484,9 +492,6 @@ def main():
            "Only fp16, bf16 and f32 types currently supported."
 
     assert args.layout in supported_layouts(), f"{args.layout} is not in supported layouts: {supported_layouts()}."
-
-    if args.test_correctness:
-        test_correctness(custom_config, args)
 
     if args.layout == "thd" and args.equal_seqlens:
         warnings.warn(


### PR DESCRIPTION
This PR adds a fused version of the multihead attention backward kernel at aiter/ops/triton/mha.py. Previously we launched 2 kernels, _bwd_kernel_dkdv_causal and _bwd_kernel_dq_causal, to first compute the dk & dv and then the dq gradients (key, value and query tensor gradients). Now we fuse them all into a single kernel _bwd_kernel_dkdvdq_causal. The key idea is that we can use atomic adds to compute the dq during the inner loop of the _bwd_kernel_dkdv_causal. Because these kernels are compute-bound, the extra memory latency we get from the atomics is not that bad. And we remove extra compute of ds, which would have otherwise be necessary with the separate launch of  _bwd_kernel_dq_causal.

Some performance measures:

MI300X

![image](https://github.com/user-attachments/assets/38bbf3b3-2ff2-461f-bcdd-2c677f530fb1)

MI350X

![image](https://github.com/user-attachments/assets/14615453-e32b-4afd-ae01-80b432f0e2b4)

TODOs:

- ATTViewer shows unneccessary waits at the end of inner loop iterations, waiting for the atomic add writebacks:
![image](https://github.com/user-attachments/assets/87def5d6-adfb-44ec-93ed-ec8be60c8104)
This is a recurring problem with the atomics. Probably no easy fix in sight, but marking at least as a known issue that causes extra latency.
- BLK_SLICE_FACTOR=1 performs better, but produces mismatches on tests. It shouldn't, so go through the corresponding code.




