### PR TITLE
[MoE] refine moe ep test

### DIFF
--- a/op_tests/test_moe_ep.py
+++ b/op_tests/test_moe_ep.py
@@ -131,7 +131,7 @@ def test_fmoe_ep(
     # total_expert = unshared_expert + shared_expert + fake_expert(only use this fake expert id to mask)
     # expert_mask = torch.randint(0, 2, (E+shared_E+1,), dtype=torch.int32, device="cuda")
     expert_mask = torch.zeros((E + shared_E + 1,), dtype=torch.int32, device="cuda")
-    expert_mask[: E // ep] = 1
+    expert_mask[ep_id * (E // ep) : (ep_id + 1) * E // ep] = 1
     # The last expert
     fake_expertid = expert_mask.numel() - 1
     # Ensure fake expert to be masked
@@ -154,19 +154,19 @@ def test_fmoe_ep(
     if use_g1u1:
         w1 = (
             torch.randn(
-                (E + shared_E, inter_dim * 2, model_dim), dtype=dtype, device="cuda"
+                (E // ep + shared_E, inter_dim * 2, model_dim), dtype=dtype, device="cuda"
             )
             / 10
         )
     else:
         w1 = (
             torch.randn(
-                (E + shared_E, inter_dim, model_dim), dtype=dtype, device="cuda"
+                (E // ep + shared_E, inter_dim, model_dim), dtype=dtype, device="cuda"
             )
             / 10
         )
     w2 = (
-        torch.randn((E + shared_E, model_dim, inter_dim), dtype=dtype, device="cuda")
+        torch.randn((E // ep + shared_E, model_dim, inter_dim), dtype=dtype, device="cuda")
         / 10
     )
     score = torch.randn((token, E), device="cuda", dtype=dtype)


### PR DESCRIPTION
This test mainly simulates the ep test on a GPU with gpu rank `ep-1`, so the mask should set the **last ep size** experts to 1. In addition, when constructing the weight, each GPU should only need to allocate the weight of **ep size experts**.