### PR TITLE
[Triton] fused routing and fused quant kernels

### DIFF
--- a/aiter/ops/triton/rmsnorm.py
+++ b/aiter/ops/triton/rmsnorm.py
@@ -337,7 +337,7 @@ def rmsnorm2d_fwd_with_add(
 
 
 @triton.jit
-def _rms_norm_dynamic_fp8_per_token_quant_kernel(
+def _rms_norm_dynamic_per_token_fp8_quant_kernel(
     x_ptr,
     o_ptr,
     w_ptr,
@@ -395,7 +395,7 @@ def _rms_norm_dynamic_fp8_per_token_quant_kernel(
             mask=mask,
         )
 
-def rms_norm_dynamic_fp8_per_token_quant(
+def rms_norm_dynamic_per_token_fp8_quant(
     x: torch.Tensor,
     w: torch.Tensor,
     eps: float = 1.0e-5,
@@ -422,7 +422,7 @@ def rms_norm_dynamic_fp8_per_token_quant(
     if dump_rms_norm:
         out_rms_norm = torch.empty_like(x)
 
-    _rms_norm_dynamic_fp8_per_token_quant_kernel[(B_T,)](
+    _rms_norm_dynamic_per_token_fp8_quant_kernel[(B_T,)](
         x,
         out,
         w,

--- a/aiter/ops/triton/rmsnorm.py
+++ b/aiter/ops/triton/rmsnorm.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+from typing import Optional, Tuple
+
 import torch
 import triton
 import triton.language as tl
-from typing import Tuple, Optional
+
 
 @triton.jit
 def _rms_norm_kernel(
@@ -394,6 +396,7 @@ def _rms_norm_dynamic_per_token_fp8_quant_kernel(
             o_rms_norm,
             mask=mask,
         )
+
 
 def rms_norm_dynamic_per_token_fp8_quant(
     x: torch.Tensor,

--- a/aiter/ops/triton/rmsnorm.py
+++ b/aiter/ops/triton/rmsnorm.py
@@ -4,7 +4,7 @@
 import torch
 import triton
 import triton.language as tl
-
+from typing import Tuple, Optional
 
 @triton.jit
 def _rms_norm_kernel(
@@ -334,3 +334,113 @@ def rmsnorm2d_fwd_with_add(
     )
 
     return out, residual_out
+
+
+@triton.jit
+def _rms_norm_dynamic_fp8_per_token_quant_kernel(
+    x_ptr,
+    o_ptr,
+    w_ptr,
+    o_scale_ptr,
+    scale_ub,
+    o_rms_norm_ptr,
+    EPS: tl.constexpr,
+    EPS_FP8: tl.constexpr,
+    D: tl.constexpr,
+    MAX_FP8: tl.constexpr,
+    CLAMP_MAX: tl.constexpr,
+    TL_FP8_DTYPE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    DUMP_INTERMEDIATE: tl.constexpr,
+):
+    row_idx = tl.program_id(axis=0).to(tl.int64)
+    variance = tl.zeros([1], dtype=tl.float32)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < D
+
+    row_start_ptr = x_ptr + row_idx * D
+    out_start_ptr = o_ptr + row_idx * D
+    input_ptrs = row_start_ptr + col_offsets
+    output_ptrs = out_start_ptr + col_offsets
+
+    row = tl.load(input_ptrs, mask=mask, other=0.0, eviction_policy="evict_last").to(
+        tl.float32
+    )
+    variance = tl.sum(row * row, axis=0) / D
+    rstd = tl.rsqrt(variance + EPS)
+
+    w = tl.load(w_ptr + col_offsets, mask=mask, eviction_policy="evict_first").to(
+        tl.float32
+    )
+    o_rms_norm = row * rstd * w
+
+    # FP8 rowwise quantize
+    cur_max = tl.max(tl.abs(o_rms_norm))
+
+    if CLAMP_MAX:
+        ub = tl.load(scale_ub)
+        cur_max = tl.clamp(cur_max, EPS_FP8, ub)
+    else:
+        cur_max = tl.maximum(cur_max, EPS_FP8)
+    o_scale = MAX_FP8 / cur_max
+    tl.store(o_scale_ptr + row_idx, 1.0 / o_scale)
+    o_fp8 = tl.clamp(o_rms_norm * o_scale, -MAX_FP8, MAX_FP8)
+    o_fp8.to(TL_FP8_DTYPE)
+    tl.store(output_ptrs, o_fp8, mask=mask)
+
+    if DUMP_INTERMEDIATE:
+        tl.store(
+            o_rms_norm_ptr + row_idx * D + col_offsets,
+            o_rms_norm,
+            mask=mask,
+        )
+
+def rms_norm_dynamic_fp8_per_token_quant(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    eps: float = 1.0e-5,
+    scale_ub: Optional[torch.Tensor] = None,
+    dump_rms_norm: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    assert x.is_contiguous()
+    assert w.is_contiguous()
+    x_shape = x.shape
+    x = x.view(-1, x.size(-1))
+    (B_T, D) = x.shape
+
+    pt_dtype = torch.float8_e4m3fnuz
+    tl_dtype = tl.float8e4b8
+    max_fp8 = torch.finfo(pt_dtype).max
+    eps_fp8 = 1e-12
+
+    out = torch.empty((B_T, D), device=x.device, dtype=pt_dtype)
+    out_scale = torch.empty((B_T), device=x.device, dtype=torch.float32)
+    assert w.shape == (D,)
+    assert out.shape == x.shape
+
+    out_rms_norm = None
+    if dump_rms_norm:
+        out_rms_norm = torch.empty_like(x)
+
+    _rms_norm_dynamic_fp8_per_token_quant_kernel[(B_T,)](
+        x,
+        out,
+        w,
+        out_scale,
+        scale_ub,
+        out_rms_norm,
+        eps,
+        eps_fp8,
+        D,
+        MAX_FP8=max_fp8,
+        CLAMP_MAX=scale_ub is not None,
+        TL_FP8_DTYPE=tl_dtype,
+        BLOCK_SIZE=triton.next_power_of_2(D),
+        DUMP_INTERMEDIATE=dump_rms_norm,
+    )
+
+    if dump_rms_norm:
+        assert out_rms_norm is not None
+        out_rms_norm = out_rms_norm.view(x_shape)
+
+    return out.view(x_shape), out_scale, out_rms_norm

--- a/aiter/ops/triton/routing.py
+++ b/aiter/ops/triton/routing.py
@@ -1,8 +1,7 @@
-from functools import partial
-
 import torch
 import triton
 import triton.language as tl
+
 
 def get_config_heuristic(M, K, N):
     """
@@ -21,11 +20,7 @@ def get_config_heuristic(M, K, N):
     m_bucket = (
         "very_large"
         if M >= 8192
-        else "large"
-        if M >= 4096
-        else "medium"
-        if M >= 2048
-        else "small"
+        else "large" if M >= 4096 else "medium" if M >= 2048 else "small"
     )
 
     # Create parameter configuration using nested dictionaries
@@ -136,7 +131,8 @@ def _routing_sigmoid_top1_kernel(
 
         X_ptrs = X_ptr + (
             # pyre-ignore
-            offs_m[:, None] * stride_xm + offs_k_iter[None, :] * stride_xk
+            offs_m[:, None] * stride_xm
+            + offs_k_iter[None, :] * stride_xk
         )
         W_ptrs = W_ptr + (
             offs_k_iter[:, None] * stride_wk + offs_n[None, :] * stride_wn

--- a/aiter/ops/triton/routing.py
+++ b/aiter/ops/triton/routing.py
@@ -1,0 +1,271 @@
+from functools import partial
+
+import torch
+import triton
+import triton.language as tl
+
+def get_config_heuristic(M, K, N):
+    """
+    Return the best Triton configuration based on input dimensions.
+
+    Args:
+        M: Batch dimension
+        K: Hidden dimension
+        N: Number of experts (16 or 128)
+        TOPK: Top-k value (default: 1)
+
+    Returns:
+        triton.Config: Configuration for the Triton kernel
+    """
+    # Determine M bucket (small: <2048, medium: 2048-4095, large: 4096-8191, very_large: 8192+)
+    m_bucket = (
+        "very_large"
+        if M >= 8192
+        else "large"
+        if M >= 4096
+        else "medium"
+        if M >= 2048
+        else "small"
+    )
+
+    # Create parameter configuration using nested dictionaries
+    configs = {
+        # Format: {N: {m_bucket: (BLOCK_M, BLOCK_K, num_warps, num_stages, waves_per_eu, kpack)}}
+        16: {
+            "small": (16, 256, 4, 2, 3, 1),
+            "medium": (16, 256, 4, 2, 3, 1),
+            "large": (16, 256, 4, 2, 3, 2),
+            "very_large": (32, 256, 4, 2, 0, 1),
+        },
+        128: {
+            "small": (16, 256, 8, 1, 0, 1),
+            "medium": (16, 256, 8, 1, 0, 2),
+            "large": (16, 256, 8, 1, 2, 2),
+            "very_large": (32, 128, 8, 2, 2, 2),
+        },
+    }
+
+    # Get configuration parameters
+    BLOCK_M, BLOCK_K, num_warps, num_stages, waves_per_eu, kpack = configs[N][m_bucket]
+
+    # Return Triton configuration
+    return triton.Config(
+        {
+            "BLOCK_M": BLOCK_M,
+            "BLOCK_K": BLOCK_K,
+            "matrix_instr_nonkdim": 16,  # Always 16
+            "waves_per_eu": waves_per_eu,
+            "kpack": kpack,
+        },
+        num_warps=num_warps,
+        num_stages=num_stages,
+        num_ctas=1,
+    )
+
+
+# @triton.autotune(
+#     configs=[
+#         triton.Config(
+#             {
+#                 "BLOCK_M": bm,
+#                 "BLOCK_K": bk,
+#                 "matrix_instr_nonkdim": matrix_instr_nonkdim,
+#                 "waves_per_eu": waves_per_eu,
+#                 "kpack": kpack,
+#             },
+#             num_warps=num_warps,
+#             num_stages=num_stages,
+#         )
+#         for bm in [16, 32, 64]  # [32, 64, 128, 256]
+#         for bk in [64, 128, 256]  # [32, 64, 128, 256]
+#         for num_warps in [4, 8]  # [4, 8]
+#         for matrix_instr_nonkdim in [16]
+#         for waves_per_eu in [0, 2, 3]  # [0, 2, 3]
+#         for kpack in [1, 2]  # [1, 2]
+#         for num_stages in [1, 2]  # [1, 2]
+#     ],
+#     key=["M", "N", "K"],
+# )
+@triton.jit
+def _routing_sigmoid_top1_kernel(
+    X_ptr,
+    W_ptr,
+    topk_ids_ptr,
+    topk_weights_ptr,
+    M,
+    N,
+    K,
+    stride_xm,
+    stride_xk,
+    stride_wk,
+    stride_wn,
+    stride_topk_ids_m,
+    stride_topk_ids_n,
+    stride_topk_weights_m,
+    stride_topk_weights_n,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    TOPK: tl.constexpr,
+    FUSED_SHARED_EXPERTS: tl.constexpr,
+):
+    # Program ID corresponds to the block index in M dimension
+    pid_m = tl.program_id(axis=0)
+
+    # Offsets for the current block
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    _TOPK: tl.constexpr = TOPK + 1 if FUSED_SHARED_EXPERTS else TOPK
+
+    offs_topk = tl.arange(0, _TOPK)
+
+    # Masks for bounds checking
+    mask_m = offs_m < M
+    mask_n = offs_n < N
+
+    # Initialize accumulator for matmul (will be in float32 due to default acc_type)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Loop over K dimension in chunks of BLOCK_K
+    for k in range(0, K, BLOCK_K):
+        # Compute pointers for A and B
+        offs_k_iter = k + offs_k
+        mask_k = offs_k_iter < K
+
+        X_ptrs = X_ptr + (
+            # pyre-ignore
+            offs_m[:, None] * stride_xm + offs_k_iter[None, :] * stride_xk
+        )
+        W_ptrs = W_ptr + (
+            offs_k_iter[:, None] * stride_wk + offs_n[None, :] * stride_wn
+        )
+
+        # Load A and B tiles
+        # pyre-ignore
+        x = tl.load(X_ptrs, mask=(mask_m[:, None] & mask_k[None, :]), other=0.0)
+        w = tl.load(W_ptrs, mask=(mask_k[:, None] & mask_n[None, :]), other=0.0)
+
+        # Compute partial matmul for the current block using FP16 inputs and FP32 accumulation
+        acc = tl.dot(x, w, acc=acc)
+
+    acc = tl.sigmoid(acc)
+    # Get topk results
+    topk_ids = tl.argmax(acc, axis=1, tie_break_left=True)  # Shape: (BLOCK_M,)
+    topk_weights = tl.max(acc, axis=1)  # Shape: (BLOCK_M,)
+
+    # Create buffers for results
+    topk_ids_buffer = tl.zeros((BLOCK_M, _TOPK), dtype=tl.int32)
+    topk_weights_buffer = tl.zeros((BLOCK_M, _TOPK), dtype=tl.float32)
+
+    if FUSED_SHARED_EXPERTS:
+        # Set the first column with broadcasting
+        topk_ids_buffer = tl.where(
+            (offs_topk[None, :] < _TOPK - 1), topk_ids[:, None], N
+        )
+        topk_weights_buffer = tl.where(
+            (offs_topk[None, :] < _TOPK - 1), topk_weights[:, None], 1.0
+        )
+    else:
+        topk_ids_buffer = topk_ids[:, None]
+        topk_weights_buffer = topk_weights[:, None]
+
+    topk_ids_ptrs = (
+        topk_ids_ptr
+        + offs_m[:, None] * stride_topk_ids_m
+        + offs_topk[None, :] * stride_topk_ids_n
+    )
+
+    topk_weights_ptrs = (
+        topk_weights_ptr
+        + offs_m[:, None] * stride_topk_weights_m
+        + offs_topk[None, :] * stride_topk_weights_n
+    )
+
+    tl.store(topk_ids_ptrs, topk_ids_buffer)
+    tl.store(topk_weights_ptrs, topk_weights_buffer)
+
+
+def routing_sigmoid_top1(x, w, topk, fused_shared_experts=False):
+    # assert x.dtype == torch.bfloat16
+    # assert w.dtype == torch.bfloat16
+    x = x.view(-1, x.shape[-1])
+
+    assert topk == 1
+
+    # M: batch_size x seq_len, K: hidden_dim, N: num_experts
+    M, K = x.shape
+    Kb, N = w.shape
+    assert K == Kb
+
+    _topk = topk
+    if fused_shared_experts:
+        _topk += 1
+
+    # Output tensor
+    topk_ids = torch.empty((M, _topk), device=x.device, dtype=torch.int32)
+    topk_weights = torch.empty((M, _topk), device=x.device, dtype=torch.float32)
+
+    heuristc_config = get_config_heuristic(M, K, N)
+
+    # Grid size
+    def grid(META):
+        return (triton.cdiv(M, META["BLOCK_M"]),)
+
+    _routing_sigmoid_top1_kernel[grid](
+        x,
+        w,
+        topk_ids,
+        topk_weights,
+        M,
+        N,
+        K,
+        x.stride(0),
+        x.stride(1),
+        w.stride(0),
+        w.stride(1),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        BLOCK_N=N,  # Set BLOCK_N to N (16)
+        TOPK=topk,
+        FUSED_SHARED_EXPERTS=fused_shared_experts,
+        num_warps=heuristc_config.num_warps,
+        num_stages=heuristc_config.num_stages,
+        num_ctas=heuristc_config.num_ctas,
+        **heuristc_config.kwargs,
+    )
+
+    return topk_ids, topk_weights
+
+
+def torch_routing_sigmoid_top1(
+    x, w, topk, fused_shared_experts=False, dummy_ids=None, dummy_weights=None
+):
+    scores = torch.matmul(x, w)  # [M, N]
+
+    scores = torch.sigmoid(scores.to(torch.float32))  # [M, N]
+
+    assert topk == 1
+
+    topk_weights, topk_ids = torch.topk(scores, topk, dim=1)  # [M, topk]
+
+    topk_ids = topk_ids.to(torch.int32)
+    topk_weights = topk_weights.to(torch.float32)
+
+    if fused_shared_experts:
+        topk_ids = torch.cat(
+            [
+                topk_ids,
+                dummy_ids,
+            ],
+            dim=1,
+        )
+        topk_weights = torch.cat(
+            [topk_weights, dummy_weights],
+            dim=1,
+        )
+
+    return topk_ids, topk_weights

--- a/op_benchmarks/triton/bench_routing.py
+++ b/op_benchmarks/triton/bench_routing.py
@@ -1,0 +1,96 @@
+from functools import partial
+
+import torch
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.routing import (
+    _routing_sigmoid_top1_kernel,
+    routing_sigmoid_top1,
+    torch_routing_sigmoid_top1,
+)
+
+
+def _get_compiled(fn):
+    compiled_fn = torch.compile(
+        fn, backend="inductor", fullgraph=True, options={"max_autotune": True}
+    )
+    return compiled_fn
+
+
+def benchmark(M, N, K):
+    TOPK = 1
+
+    torch.manual_seed(7)
+
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    x = torch.randn((M, K), dtype=dtype, device=device)
+    w = torch.randn((K, N), dtype=dtype, device=device) * 0.1
+
+    dummy_ids = torch.ones((M, 1), dtype=torch.int32, device="cuda") * N
+    dummy_weights = torch.ones((M, 1), dtype=torch.float32, device="cuda")
+    _eager = partial(
+        torch_routing_sigmoid_top1, dummy_ids=dummy_ids, dummy_weights=dummy_weights
+    )
+    _compiled = _get_compiled(_eager)
+
+    eager_fn = lambda: _eager(x, w, TOPK)
+    triton_fn = lambda: routing_sigmoid_top1(x, w, TOPK)
+    compile_fn = lambda: _compiled(x, w, TOPK)
+
+    # warmup
+    for _ in range(5):
+        eager_fn()
+        triton_fn()
+        compile_fn()
+
+    with torch.cuda.stream(torch.cuda.Stream()):
+        ms_eager_time = triton.testing.do_bench_cudagraph(eager_fn)
+
+    with torch.cuda.stream(torch.cuda.Stream()):
+        ms_triton_time = triton.testing.do_bench_cudagraph(triton_fn)
+
+    with torch.cuda.stream(torch.cuda.Stream()):
+        ms_compile_time = triton.testing.do_bench_cudagraph(compile_fn)
+
+    print(
+        f"{M=} {K=} {N=} {TOPK=}, "
+        f"{ms_eager_time=:.3f}, {ms_triton_time=:.3f}, {ms_compile_time=:.3f}, "
+        f"speedup_vs_eager: {ms_eager_time / ms_triton_time:.3f}, "
+        f"speedup_vs_compile: {ms_compile_time / ms_triton_time:.3f}\n"
+        f"best triton config: {getattr(_routing_sigmoid_top1_kernel, 'best_config', "")}"
+    )
+
+
+def benchmkar_prefill():
+    print("=== PREFILL SHAPEs ===")
+    benchmark(M=1024, K=5120, N=128)
+    benchmark(M=1024, K=5120, N=16)
+    benchmark(M=2048, K=5120, N=128)
+    benchmark(M=2048, K=5120, N=16)
+    benchmark(M=4096, K=5120, N=128)
+    benchmark(M=4096, K=5120, N=16)
+    benchmark(M=8192, K=5120, N=128)
+    benchmark(M=8192, K=5120, N=16)
+
+
+def benchmark_decode():
+    print("=== DECODE SHAPEs ===")
+    benchmark(M=64, K=5120, N=128)
+    benchmark(M=64, K=5120, N=16)
+    benchmark(M=128, K=5120, N=128)
+    benchmark(M=128, K=5120, N=16)
+    benchmark(M=256, K=5120, N=128)
+    benchmark(M=256, K=5120, N=16)
+
+
+def main():
+    benchmkar_prefill()
+    # no gain for decode shape
+    benchmark_decode()
+
+
+if __name__ == "__main__":
+    main()

--- a/op_benchmarks/triton/bench_routing.py
+++ b/op_benchmarks/triton/bench_routing.py
@@ -2,7 +2,6 @@ from functools import partial
 
 import torch
 import triton
-import triton.language as tl
 
 from aiter.ops.triton.routing import (
     _routing_sigmoid_top1_kernel,
@@ -36,9 +35,14 @@ def benchmark(M, N, K):
     )
     _compiled = _get_compiled(_eager)
 
-    eager_fn = lambda: _eager(x, w, TOPK)
-    triton_fn = lambda: routing_sigmoid_top1(x, w, TOPK)
-    compile_fn = lambda: _compiled(x, w, TOPK)
+    def eager_fn():
+        return _eager(x, w, TOPK)
+
+    def triton_fn():
+        return routing_sigmoid_top1(x, w, TOPK)
+
+    def compile_fn():
+        return _compiled(x, w, TOPK)
 
     # warmup
     for _ in range(5):

--- a/op_tests/triton_tests/test_rmsnorm.py
+++ b/op_tests/triton_tests/test_rmsnorm.py
@@ -4,7 +4,17 @@ import triton
 import torch.nn.functional as F
 from aiter.ops.triton.rmsnorm import rms_norm
 from aiter.ops.triton.rmsnorm import rmsnorm2d_fwd_with_add
+from aiter.ops.triton.rmsnorm import rms_norm_dynamic_fp8_per_token_quant
 
+#TODO: Move to a share utils file to avoid duplication for other tests
+def torch_dynamic_per_token_fp8_quant(x):
+    x_max, _ = torch.max(torch.abs(x),axis=-1)
+    scale_out = x_max / torch.finfo(torch.float8_e4m3fnuz).max
+    
+    out = (x / scale_out[:, None])
+    out = out.to(torch.float8_e4m3fnuz)
+
+    return out, scale_out
 
 def generate_rmsnorm_inputs(M, N, dtype):
     x = torch.randn((M, N), dtype=dtype).cuda()
@@ -143,3 +153,44 @@ def test_fused_add_rmsnorm(M, N, in_dtype_str):
 
     triton.testing.assert_close(y_triton, y_torch, atol=atol, rtol=rtol)
     triton.testing.assert_close(res_triton, res_torch, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("B", [1, 4, 8])
+@pytest.mark.parametrize("T", [128, 512, 2048])
+@pytest.mark.parametrize("D", [64, 4096])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_rms_norm_fp8_rowwise_quant(
+    B: int, T: int, D: int, dtype: torch.dtype
+) -> None:
+    B_T = B * T
+    # Use integers to ensure consistent results across layouts,
+    # avoiding discrepancies in floating-point reductions with varying data layouts
+    x = torch.floor(torch.distributions.Uniform(-3, 3).sample((B_T, D))).to(
+        dtype=dtype, device="cuda"
+    )
+    w = torch.floor(torch.distributions.Uniform(-3, 3).sample((D,))).to(
+        dtype=dtype, device="cuda"
+    )
+
+    EPS = 1e-5
+
+    xq_fused_triton, x_scale_fused, x_normed = (
+        rms_norm_dynamic_fp8_per_token_quant(x, w, dump_rms_norm=True)
+    )
+    ref_x_normed, _ = run_torch(x, w, EPS)
+    ref_xq, ref_x_scale = torch_dynamic_per_token_fp8_quant(x)
+
+    xq_dequant = xq_fused_triton.to(torch.float32) * x_scale_fused[:, None]
+    xq_dequant = xq_dequant.to(dtype)
+    ref_xq_dequant = ref_xq.to(torch.float32) * ref_x_scale[:, None]
+    ref_xq_dequant = xq_dequant.to(dtype)
+
+    if dtype == torch.float32:
+        atol = 1e-5
+        rtol = 1e-5
+    else:
+        atol = 1e-2
+        rtol = 1e-2
+
+    torch.testing.assert_close(xq_dequant, ref_xq_dequant, atol=atol, rtol=rtol)
+    torch.testing.assert_close(x_normed, ref_x_normed, atol=atol, rtol=rtol)

--- a/op_tests/triton_tests/test_rmsnorm.py
+++ b/op_tests/triton_tests/test_rmsnorm.py
@@ -4,7 +4,7 @@ import triton
 import torch.nn.functional as F
 from aiter.ops.triton.rmsnorm import rms_norm
 from aiter.ops.triton.rmsnorm import rmsnorm2d_fwd_with_add
-from aiter.ops.triton.rmsnorm import rms_norm_dynamic_fp8_per_token_quant
+from aiter.ops.triton.rmsnorm import rms_norm_dynamic_per_token_fp8_quant
 
 #TODO: Move to a share utils file to avoid duplication for other tests
 def torch_dynamic_per_token_fp8_quant(x):
@@ -159,7 +159,7 @@ def test_fused_add_rmsnorm(M, N, in_dtype_str):
 @pytest.mark.parametrize("T", [128, 512, 2048])
 @pytest.mark.parametrize("D", [64, 4096])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_rms_norm_fp8_rowwise_quant(
+def test_rms_norm_dynamic_per_token_fp8_quant(
     B: int, T: int, D: int, dtype: torch.dtype
 ) -> None:
     B_T = B * T
@@ -175,7 +175,7 @@ def test_rms_norm_fp8_rowwise_quant(
     EPS = 1e-5
 
     xq_fused_triton, x_scale_fused, x_normed = (
-        rms_norm_dynamic_fp8_per_token_quant(x, w, dump_rms_norm=True)
+        rms_norm_dynamic_per_token_fp8_quant(x, w, dump_rms_norm=True)
     )
     ref_x_normed, _ = run_torch(x, w, EPS)
     ref_xq, ref_x_scale = torch_dynamic_per_token_fp8_quant(x)

--- a/op_tests/triton_tests/test_routing.py
+++ b/op_tests/triton_tests/test_routing.py
@@ -1,0 +1,28 @@
+import torch
+import pytest
+from aiter.ops.triton.routing import routing_sigmoid_top1, torch_routing_sigmoid_top1
+from functools import partial
+
+@pytest.mark.parametrize("M", [128, 1024, 2048, 4096, 8192])
+@pytest.mark.parametrize("N", [16, 128])
+@pytest.mark.parametrize("K", [16, 128])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_routing_sigmoid_top1(M, N, K, dtype):
+    TOPK = 1
+
+    torch.manual_seed(7)
+
+    device = "cuda"
+
+    x = torch.randint(-2, 3, (M, K), device=device).to(dtype)
+    w = torch.randint(-2, 3, (K, N), device=device).to(dtype)
+
+    dummy_ids = torch.ones((M, 1), dtype=torch.int32, device="cuda") * N
+    dummy_weights = torch.ones((M, 1), dtype=torch.float32, device="cuda")
+    _eager = partial(torch_routing_sigmoid_top1, dummy_ids=dummy_ids, dummy_weights=dummy_weights)
+
+    topk_ids, topk_weights = routing_sigmoid_top1(x, w, TOPK, fused_shared_experts=True)
+    _eager_topk_ids, _eager_topk_weights = _eager(x, w, TOPK, fused_shared_experts=True)
+
+    torch.testing.assert_close(_eager_topk_ids, topk_ids, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(_eager_topk_weights, topk_weights, atol=1e-5, rtol=1e-5)

--- a/op_tests/triton_tests/test_routing.py
+++ b/op_tests/triton_tests/test_routing.py
@@ -1,7 +1,9 @@
-import torch
-import pytest
-from aiter.ops.triton.routing import routing_sigmoid_top1, torch_routing_sigmoid_top1
 from functools import partial
+
+import pytest
+import torch
+from aiter.ops.triton.routing import routing_sigmoid_top1, torch_routing_sigmoid_top1
+
 
 @pytest.mark.parametrize("M", [128, 1024, 2048, 4096, 8192])
 @pytest.mark.parametrize("N", [16, 128])
@@ -19,7 +21,9 @@ def test_routing_sigmoid_top1(M, N, K, dtype):
 
     dummy_ids = torch.ones((M, 1), dtype=torch.int32, device="cuda") * N
     dummy_weights = torch.ones((M, 1), dtype=torch.float32, device="cuda")
-    _eager = partial(torch_routing_sigmoid_top1, dummy_ids=dummy_ids, dummy_weights=dummy_weights)
+    _eager = partial(
+        torch_routing_sigmoid_top1, dummy_ids=dummy_ids, dummy_weights=dummy_weights
+    )
 
     topk_ids, topk_weights = routing_sigmoid_top1(x, w, TOPK, fused_shared_experts=True)
     _eager_topk_ids, _eager_topk_weights = _eager(x, w, TOPK, fused_shared_experts=True)


### PR DESCRIPTION
## Tests

```
python3 -m pytest op_tests/triton_tests/test_routing.py -k test_routing_sigmoid_top1

python3 -m pytest op_tests/triton_tests/test_rmsnorm.py -k test_rms_norm_dynamic_per_token_fp8_quant
```

## Benchmark

fused routing
```
python3 op_benchmarks/triton/bench_routing.py

(vllm) sijiac@devgpu013:aiter  (main)$ python3 op_benchmarks/triton/bench_routing.py
=== PREFILL SHAPEs ===
M=1024 K=5120 N=128 TOPK=1, ms_eager_time=0.048, ms_triton_time=0.049, ms_compile_time=0.051, speedup_vs_eager: 0.979, speedup_vs_compile: 1.043
best triton config:
M=1024 K=5120 N=16 TOPK=1, ms_eager_time=0.035, ms_triton_time=0.023, ms_compile_time=0.079, speedup_vs_eager: 1.485, speedup_vs_compile: 3.374
best triton config:
M=2048 K=5120 N=128 TOPK=1, ms_eager_time=0.058, ms_triton_time=0.052, ms_compile_time=0.055, speedup_vs_eager: 1.110, speedup_vs_compile: 1.058
best triton config:
M=2048 K=5120 N=16 TOPK=1, ms_eager_time=0.047, ms_triton_time=0.024, ms_compile_time=0.046, speedup_vs_eager: 1.982, speedup_vs_compile: 1.953
best triton config:
M=4096 K=5120 N=128 TOPK=1, ms_eager_time=0.087, ms_triton_time=0.055, ms_compile_time=0.086, speedup_vs_eager: 1.567, speedup_vs_compile: 1.545
best triton config:
M=4096 K=5120 N=16 TOPK=1, ms_eager_time=0.060, ms_triton_time=0.024, ms_compile_time=0.057, speedup_vs_eager: 2.472, speedup_vs_compile: 2.367
best triton config:
M=8192 K=5120 N=128 TOPK=1, ms_eager_time=0.129, ms_triton_time=0.065, ms_compile_time=0.125, speedup_vs_eager: 1.989, speedup_vs_compile: 1.927
best triton config:
M=8192 K=5120 N=16 TOPK=1, ms_eager_time=0.066, ms_triton_time=0.031, ms_compile_time=0.064, speedup_vs_eager: 2.137, speedup_vs_compile: 2.063
best triton config:
=== DECODE SHAPEs ===
M=64 K=5120 N=128 TOPK=1, ms_eager_time=0.033, ms_triton_time=0.048, ms_compile_time=0.031, speedup_vs_eager: 0.675, speedup_vs_compile: 0.643
best triton config:
M=64 K=5120 N=16 TOPK=1, ms_eager_time=0.030, ms_triton_time=0.023, ms_compile_time=0.028, speedup_vs_eager: 1.284, speedup_vs_compile: 1.193
best triton config:
M=128 K=5120 N=128 TOPK=1, ms_eager_time=0.034, ms_triton_time=0.059, ms_compile_time=0.033, speedup_vs_eager: 0.577, speedup_vs_compile: 0.558
best triton config:
M=128 K=5120 N=16 TOPK=1, ms_eager_time=0.069, ms_triton_time=0.030, ms_compile_time=0.028, speedup_vs_eager: 2.315, speedup_vs_compile: 0.937
best triton config:
M=256 K=5120 N=128 TOPK=1, ms_eager_time=0.036, ms_triton_time=0.048, ms_compile_time=0.035, speedup_vs_eager: 0.754, speedup_vs_compile: 0.724
best triton config:
M=256 K=5120 N=16 TOPK=1, ms_eager_time=0.032, ms_triton_time=0.023, ms_compile_time=0.031, speedup_vs_eager: 1.392, speedup_vs_compile: 1.321
best triton config:
```
fused quant

rms_norm fused kernel is around 1.5x, compared with torch_compiled kernel based on the offline benchmark

cc @carlushuang, @zjing14 