### PR TITLE
[Triton] Fix gemm mxfp4 for memory access error due to parsing faulty EVEN_K

### DIFF
--- a/op_tests/triton_tests/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/test_gemm_afp4wfp4.py
@@ -64,6 +64,7 @@ def get_x_vals():
     ]
     x_vals += [(2 ** (v - 1), 4096 * v, 4096 * v) for v in range(1, 6)]
     # x_vals = [(128, 1024, 4096)]
+    x_vals += [(16, 16384, 3328 * 2), (128, 16384, 3328 * 2)]
     return x_vals
 
 


### PR DESCRIPTION
This PR fixes memory access error due to parsing faulty `EVEN_K`, which originates from checking only `K % BLOCK_SIZE_K == 0` for `EVEN_K`.
This PR also includes a heuristic function `get_splitk`, of determining `SPLITK_BLOCK_SIZE, BLOCK_SIZE_K, NUM_KSPLIT` such that it makes `EVEN_K == True` as much as possible