### PR TITLE
[Fix] aiter installed/usable with gfx950

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -127,7 +127,7 @@ CK_DIR = f"{bd_dir}/ck"
 def validate_and_update_archs():
     archs = os.getenv("GPU_ARCHS", "native").split(";")
     # List of allowed architectures
-    allowed_archs = ["native", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx1100"]
+    allowed_archs = ["native", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx1100", "gfx950"]
 
     # Validate if each element in archs is in allowed_archs
     assert all(

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -127,7 +127,15 @@ CK_DIR = f"{bd_dir}/ck"
 def validate_and_update_archs():
     archs = os.getenv("GPU_ARCHS", "native").split(";")
     # List of allowed architectures
-    allowed_archs = ["native", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx1100", "gfx950"]
+    allowed_archs = [
+        "native",
+        "gfx90a",
+        "gfx940",
+        "gfx941",
+        "gfx942",
+        "gfx1100",
+        "gfx950",
+    ]
 
     # Validate if each element in archs is in allowed_archs
     assert all(

--- a/aiter/ops/triton/mha.py
+++ b/aiter/ops/triton/mha.py
@@ -126,7 +126,7 @@ def is_hip():
 
 
 def arch_supports_fp8():
-    return is_hip() and get_arch() in ("gfx942")
+    return is_hip() and get_arch() in ("gfx942", "gfx950")
 
 
 @triton.jit


### PR DESCRIPTION
As per title.

Aiter should be installable/usable with `GPU_ARCHS="gfx950"`.