### PR TITLE
fix PREBUILD_KERNELS=1 build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,13 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = [
+    "setuptools>=45",
+    "setuptools_scm[toml]>=6.2",
+    "wheel",
+    "packaging",
+    "psutil",
+    "ninja",
+    "pandas"
+]
 
 [tool.setuptools_scm]
 write_to = "aiter/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,14 @@ else:
 
 FORCE_CXX11_ABI = False
 
+PREBUILD_KERNELS = int(os.environ.get("PREBUILD_KERNELS", 0))
+
 if IS_ROCM:
     assert os.path.exists(
         ck_dir
     ), 'CK is needed by aiter, please make sure clone by "git clone --recursive https://github.com/ROCm/aiter.git" or "git submodule sync ; git submodule update --init --recursive"'
 
-    if int(os.environ.get("PREBUILD_KERNELS", 0)) == 1:
+    if PREBUILD_KERNELS == 1:
         exclude_ops = ["libmha_fwd", "libmha_bwd"]
         all_opts_args_build = core.get_args_of_build("all", exclue=exclude_ops)
         # remove pybind, because there are already duplicates in rocm_opt
@@ -94,6 +96,15 @@ class NinjaBuildExtension(BuildExtension):
         super().__init__(*args, **kwargs)
 
 
+setup_requires = [
+    "packaging",
+    "psutil",
+    "ninja",
+    "setuptools_scm",
+]
+if PREBUILD_KERNELS == 1:
+    setup_requires.append("pandas")
+
 setup(
     name=PACKAGE_NAME,
     use_scm_version=True,
@@ -116,12 +127,7 @@ setup(
         "pandas",
         "einops",
     ],
-    setup_requires=[
-        "packaging",
-        "psutil",
-        "ninja",
-        "setuptools_scm",
-    ],
+    setup_requires=setup_requires,
 )
 
 if os.path.exists("aiter_meta") and os.path.isdir("aiter_meta"):


### PR DESCRIPTION

When building this module with `PREBUILD_KERNELS=1`, the following import errors come up, although they don't break the build process.

```shell
$ uv venv
$ source .venv/bin/activate
$ uv pip install setuptools-scm packaging psutil ninja
...
$ PREBUILD_KERNELS=1 python setup.py bdist_wheel
...
Traceback (most recent call last):
  File "/home/runner/_work/aiter/csrc/ck_batched_gemm_bf16/gen_instances.py", line 8, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
Traceback (most recent call last):
  File "/home/runner/_work/aiter/csrc/ck_batched_gemm_a8w8/gen_instances.py", line 8, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
Traceback (most recent call last):
  File "/home/runner/_work/aiter/csrc/ck_gemm_a8w8/gen_instances.py", line 8, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
Traceback (most recent call last):
  File "/home/runner/_work/aiter/csrc/ck_gemm_a8w8_blockscale/gen_instances.py", line 8, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
Traceback (most recent call last):
  File "/home/runner/_work/aiter/hsa//fmoe_2stages/codegen.py", line 7, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
...
```

Installing `pandas` solves the issue:

```shell
$ uv pip install pandas
...
$ PREBUILD_KERNELS=1 python setup.py bdist_wheel
...
Successfully preprocessed all matching files.
...

```

And the build continues (failing with another error :) .
