### PR TITLE
TRITON: Tune mxfp4 quantization kernel

### DIFF
--- a/aiter/ops/triton/quant.py
+++ b/aiter/ops/triton/quant.py
@@ -180,8 +180,8 @@ def _dynamic_mxfp4_quant_kernel(
     stride_x_fp4_n_in,
     stride_bs_m_in,
     stride_bs_n_in,
-    M: tl.constexpr,
-    N: tl.constexpr,
+    M,
+    N,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     NUM_ITER: tl.constexpr,
@@ -345,9 +345,9 @@ def dynamic_mxfp4_quant(
             BLOCK_SIZE_M = 32
             BLOCK_SIZE_N = 128
 
-    grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]),
-        triton.cdiv(N, META["BLOCK_SIZE_N"] * META["NUM_ITER"]),
+    grid = (
+        triton.cdiv(M, BLOCK_SIZE_M),
+        triton.cdiv(N, BLOCK_SIZE_N * NUM_ITER),
     )
 
     _dynamic_mxfp4_quant_kernel[grid](

--- a/aiter/ops/triton/quant.py
+++ b/aiter/ops/triton/quant.py
@@ -217,8 +217,8 @@ def _dynamic_mxfp4_quant_kernel(
         x = x.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS, MXFP4_QUANT_BLOCK_SIZE)
         # Calculate scale
         amax = tl.max(tl.abs(x), axis=-1, keep_dims=True)
-        amax = amax.to(tl.uint32, bitcast=True)
-        amax = (amax + 0x200000) & 0xFF800000
+        amax = amax.to(tl.int32, bitcast=True)
+        amax = (amax + 0x200000).to(tl.uint32, bitcast=True) & 0xFF800000
         amax = amax.to(tl.float32, bitcast=True)
         scale_e8m0_unbiased = tl.log2(amax).floor() - 2
         scale_e8m0_unbiased = tl.clamp(scale_e8m0_unbiased, min=-127, max=127)

--- a/aiter/ops/triton/quant.py
+++ b/aiter/ops/triton/quant.py
@@ -191,7 +191,7 @@ def _dynamic_mxfp4_quant_kernel(
     SCALING_MODE: tl.constexpr,
 ):
     pid_m = tl.program_id(0)
-    _start_n = tl.program_id(1) * NUM_ITER
+    start_n = tl.program_id(1) * NUM_ITER
     # cast strides to int64, in case M*N > max int32
     stride_x_m = tl.cast(stride_x_m_in, tl.int64)
     stride_x_n = tl.cast(stride_x_n_in, tl.int64)
@@ -200,7 +200,7 @@ def _dynamic_mxfp4_quant_kernel(
     stride_bs_m = tl.cast(stride_bs_m_in, tl.int64)
     stride_bs_n = tl.cast(stride_bs_n_in, tl.int64)
 
-    for pid_n in tl.range(_start_n, min(_start_n + NUM_ITER, N), num_stages=NUM_STAGES):
+    for pid_n in tl.range(start_n, min(start_n + NUM_ITER, N), num_stages=NUM_STAGES):
         x_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         x_offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         x_offs = x_offs_m[:, None] * stride_x_m + x_offs_n[None, :] * stride_x_n

--- a/aiter/ops/triton/quant.py
+++ b/aiter/ops/triton/quant.py
@@ -163,102 +163,137 @@ def dynamic_per_token_fp8_quant(
     return qx, scale_out
 
 
+@triton.heuristics(
+    {
+        "EVEN_M_N": lambda args: args["M"] % args["BLOCK_SIZE_M"] == 0
+        and args["N"] % (args["BLOCK_SIZE_N"] * args["NUM_ITER"]) == 0,
+    }
+)
 @triton.jit
 def _dynamic_mxfp4_quant_kernel(
     x_ptr,
     x_fp4_ptr,
     bs_ptr,
-    stride_x_m,
+    stride_x_m_in,
     stride_x_n,
-    stride_x_fp4_m,
+    stride_x_fp4_m_in,
     stride_x_fp4_n,
-    stride_bs_m,
+    stride_bs_m_in,
     stride_bs_n,
     M: tl.constexpr,
     N: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    NUM_ITER: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
     MXFP4_QUANT_BLOCK_SIZE: tl.constexpr,
+    EVEN_M_N: tl.constexpr,
     SCALING_MODE: tl.constexpr,
 ):
     pid_m = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    _pid_n = tl.program_id(1) * NUM_ITER
+    # cast strides to int64 in case M*N > max int32
+    stride_x_m = tl.cast(stride_x_m_in, tl.int64)
+    stride_x_fp4_m = tl.cast(stride_x_fp4_m_in, tl.int64)
+    stride_bs_m = tl.cast(stride_bs_m_in, tl.int64)
 
-    x_offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    x_offs_n = pid_n * MXFP4_QUANT_BLOCK_SIZE + tl.arange(0, MXFP4_QUANT_BLOCK_SIZE)
-    x_offs = x_offs_m[:, None] * stride_x_m + x_offs_n[None, :] * stride_x_n
-    x_mask = (x_offs_m < M)[:, None] & (x_offs_n < N)[None, :]
-    x = tl.load(x_ptr + x_offs, mask=x_mask).to(tl.float32)
+    for pid_n in tl.range(_pid_n, min(_pid_n + NUM_ITER, N), num_stages=NUM_STAGES):
+        x_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        x_offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        x_offs = x_offs_m[:, None] * stride_x_m + x_offs_n[None, :] * stride_x_n
 
-    # Calculate scale
-    amax = tl.max(tl.abs(x), axis=1, keep_dims=True)
-    amax = amax.to(tl.int32, bitcast=True)
-    amax = (amax + 0x200000).to(tl.uint32, bitcast=True) & 0xFF800000
-    amax = amax.to(tl.float32, bitcast=True)
-    scale_e8m0_unbiased = tl.log2(amax).floor() - 2
-    scale_e8m0_unbiased = tl.clamp(scale_e8m0_unbiased, min=-127, max=127)
-    quant_scale = tl.exp2(-scale_e8m0_unbiased)
+        if EVEN_M_N:
+            x = tl.load(x_ptr + x_offs, cache_modifier=".cg").to(tl.float32)
+        else:
+            x_mask = (x_offs_m < M)[:, None] & (x_offs_n < N)[None, :]
+            x = tl.load(x_ptr + x_offs, mask=x_mask, cache_modifier=".cg").to(
+                tl.float32
+            )
 
-    # Compute quantized x
-    qx = x * quant_scale
+        NUM_QUANT_BLOCKS: tl.constexpr = BLOCK_SIZE_N // MXFP4_QUANT_BLOCK_SIZE
+        x = x.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS, MXFP4_QUANT_BLOCK_SIZE)
+        # Calculate scale
+        amax = tl.max(tl.abs(x), axis=-1, keep_dims=True)
+        amax = amax.to(tl.uint32, bitcast=True)
+        amax = (amax + 0x200000) & 0xFF800000
+        amax = amax.to(tl.float32, bitcast=True)
+        scale_e8m0_unbiased = tl.log2(amax).floor() - 2
+        scale_e8m0_unbiased = tl.clamp(scale_e8m0_unbiased, min=-127, max=127)
 
-    # blockscale_e8m0
-    bs_e8m0 = scale_e8m0_unbiased.to(tl.uint8) + 127
+        # blockscale_e8m0
+        bs_e8m0 = scale_e8m0_unbiased.to(tl.uint8) + 127  # in fp32, we have 2&(e - 127)
 
-    # Convert quantized fp32 tensor to uint32 before converting to mxfp4 format
-    # Note: MXFP4  S:1-bit, E:2-bit, M:1-bit
-    #   Zeros: S000 -> +/-0
-    #   Denormal Numbers: S001 -> +/- 0.5
-    #   Normal Numbers:
-    #           S010 -> +/- 1.0
-    #           S011 -> +/- 1.5
-    #           S100 -> +/- 2.0
-    #           S101 -> +/- 3.0
-    #           S110 -> +/- 4.0
-    #           S111 -> +/- 6.0
-    qx = qx.to(tl.uint32, bitcast=True)
+        quant_scale = tl.exp2(-scale_e8m0_unbiased)
 
-    # Extract sign, exponents and mantissa fields from FP32
-    s = qx & 0x80000000
-    e = (qx >> 23) & 0xFF
-    m = qx & 0x7FFFFF
+        # Compute quantized x
+        qx = x * quant_scale
 
-    E8_BIAS: tl.constexpr = 127
-    E2_BIAS: tl.constexpr = 1
+        # Convert quantized fp32 tensor to uint32 before converting to mxfp4 format
+        # Note: MXFP4  S:1-bit, E:2-bit, M:1-bit
+        #   Zeros: S000 -> +/-0
+        #   Denormal Numbers: S001 -> +/- 0.5
+        #   Normal Numbers:
+        #           S010 -> +/- 1.0
+        #           S011 -> +/- 1.5
+        #           S100 -> +/- 2.0
+        #           S101 -> +/- 3.0
+        #           S110 -> +/- 4.0
+        #           S111 -> +/- 6.0
+        qx = qx.to(tl.uint32, bitcast=True)
 
-    # Denormal numbers
-    # If exponent is less than 127, then it's a denormal number
-    # See above, for denormal number mantissa is always 1 and we set bit 1 of mantissa
-    adjusted_exponents = tl.core.sub(E8_BIAS, e + 1, sanitize_overflow=False)
-    m = tl.where(e < E8_BIAS, (0x400000 | (m >> 1)) >> adjusted_exponents, m)
+        # Extract sign, exponents and mantissa fields from FP32
+        s = qx & 0x80000000
+        e = (qx >> 23) & 0xFF
+        m = qx & 0x7FFFFF
+        E8_BIAS: tl.constexpr = 127
+        E2_BIAS: tl.constexpr = 1
 
-    # For normal numbers, bias is changed from 127 to 1, and for subnormals, we keep exponent as 0.
-    # Note: E8_BIAS - E2_BIAS = 126, so for normals we subtract that.
-    e = tl.maximum(e, E8_BIAS - E2_BIAS) - (E8_BIAS - E2_BIAS)
+        # Denormal numbers
+        # If exponent is less than 127, then it's a denormal number
+        # See above, for denormal number mantissa is always 1 and we set bit 1 of mantissa
+        adjusted_exponents = tl.core.sub(E8_BIAS, e + 1, sanitize_overflow=False)
+        m = tl.where(e < E8_BIAS, (0x400000 | (m >> 1)) >> adjusted_exponents, m)
+        # For normal numbers, bias is changed from 127 to 1, and for subnormals, we keep exponent as 0.
+        # Note: E8_BIAS - E2_BIAS = 126, so for normals we subtract that.
+        e = tl.maximum(e, E8_BIAS - E2_BIAS) - (E8_BIAS - E2_BIAS)
 
-    # Combine sign, exponent, and mantissa, while saturating
-    # rounding nearest with tie breaking up by adding +1 to one bit right of the LSB, then shift right
-    e2m1_tmp = tl.minimum((((e << 2) | (m >> 21)) + 1) >> 1, 0x7)
-    e2m1_value = ((s >> 28) | e2m1_tmp).to(tl.uint8)
+        # Combine sign, exponent, and mantissa, while saturating
+        # rounding nearest with tie breaking up by adding +1 to one bit right of the LSB, then shift right
+        e2m1_tmp = tl.minimum((((e << 2) | (m >> 21)) + 1) >> 1, 0x7)
+        e2m1_value = ((s >> 28) | e2m1_tmp).to(tl.uint8)
+        e2m1_value = tl.reshape(
+            e2m1_value, [BLOCK_SIZE_M, NUM_QUANT_BLOCKS, MXFP4_QUANT_BLOCK_SIZE // 2, 2]
+        )
+        evens, odds = tl.split(e2m1_value)
+        out_tensor = evens | (odds << 4)
+        out_tensor = out_tensor.reshape(BLOCK_SIZE_M, BLOCK_SIZE_N // 2)
 
-    e2m1_value = tl.reshape(e2m1_value, [BLOCK_SIZE, MXFP4_QUANT_BLOCK_SIZE // 2, 2])
-    evens, odds = tl.split(e2m1_value)
-    out_tensor = evens | (odds << 4)
+        out_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        out_offs_n = pid_n * BLOCK_SIZE_N // 2 + tl.arange(0, BLOCK_SIZE_N // 2)
+        out_offs = (
+            out_offs_m[:, None] * stride_x_fp4_m + out_offs_n[None, :] * stride_x_fp4_n
+        )
 
-    out_offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    out_offs_n = pid_n * MXFP4_QUANT_BLOCK_SIZE // 2 + tl.arange(
-        0, MXFP4_QUANT_BLOCK_SIZE // 2
-    )
-    out_offs = (
-        out_offs_m[:, None] * stride_x_fp4_m + out_offs_n[None, :] * stride_x_fp4_n
-    )
-    out_mask = (out_offs_m < M)[:, None] & (out_offs_n < (N // 2))[None, :]
-    tl.store(x_fp4_ptr + out_offs, out_tensor, mask=out_mask)
+        if EVEN_M_N:
+            tl.store(x_fp4_ptr + out_offs, out_tensor)
+        else:
+            out_mask = (out_offs_m < M)[:, None] & (out_offs_n < (N // 2))[None, :]
+            tl.store(x_fp4_ptr + out_offs, out_tensor, mask=out_mask)
 
-    bs_offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    bs_offs_n = pid_n
-    bs_offs = bs_offs_m[:, None] * stride_bs_m + bs_offs_n[None, :] * stride_bs_n
-    bs_mask = (bs_offs_m < M)[:, None] & (bs_offs_n < N)[None, :]
-    tl.store(bs_ptr + bs_offs, bs_e8m0, mask=bs_mask)
+        bs_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        bs_offs_n = pid_n * NUM_QUANT_BLOCKS + tl.arange(0, NUM_QUANT_BLOCKS)
+        bs_offs = bs_offs_m[:, None] * stride_bs_m + bs_offs_n[None, :] * stride_bs_n
+        if EVEN_M_N:
+            tl.store(bs_ptr + bs_offs, bs_e8m0.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS))
+        else:
+            bs_mask = (bs_offs_m < M)[:, None] & (
+                bs_offs_n < (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
+            )[None, :]
+            tl.store(
+                bs_ptr + bs_offs,
+                bs_e8m0.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS),
+                mask=bs_mask,
+            )
 
 
 def dynamic_mxfp4_quant(
@@ -281,19 +316,37 @@ def dynamic_mxfp4_quant(
     assert (N // 2) % 2 == 0
 
     # This is fixed by spec for MXFP4. Do not tune this.
-    # For performance, perhaps, we should look at passing multiple of 32 column blocks
-    # that a triton program can process
     MXFP4_QUANT_BLOCK_SIZE = 32
-
     x_fp4 = torch.empty((M, N // 2), dtype=torch.uint8, device=x.device)
     blockscale_e8m0 = torch.empty(
         ((N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE, M),
+        # (M, (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE),
         dtype=torch.uint8,
         device=x.device,
     ).T
 
-    BLOCK_SIZE = 128
-    grid = (triton.cdiv(M, BLOCK_SIZE), triton.cdiv(N, MXFP4_QUANT_BLOCK_SIZE))
+    if M <= 32:
+        NUM_ITER = 1
+        BLOCK_SIZE_M = triton.next_power_of_2(M)
+        BLOCK_SIZE_N = 32
+        NUM_WARPS = 1
+        NUM_STAGES = 1
+    else:
+        NUM_ITER = 4
+        BLOCK_SIZE_M = 64
+        BLOCK_SIZE_N = 64
+        NUM_WARPS = 4
+        NUM_STAGES = 2
+
+        if N <= 16384:
+            BLOCK_SIZE_M = 32
+            BLOCK_SIZE_N = 128
+
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]),
+        triton.cdiv(N, META["BLOCK_SIZE_N"] * META["NUM_ITER"]),
+    )
+
     _dynamic_mxfp4_quant_kernel[grid](
         x,
         x_fp4,
@@ -303,9 +356,15 @@ def dynamic_mxfp4_quant(
         *blockscale_e8m0.stride(),
         M=M,
         N=N,
-        BLOCK_SIZE=BLOCK_SIZE,
         MXFP4_QUANT_BLOCK_SIZE=MXFP4_QUANT_BLOCK_SIZE,
-        SCALING_MODE=0
+        SCALING_MODE=0,
+        NUM_ITER=NUM_ITER,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        NUM_STAGES=NUM_STAGES,
+        num_warps=NUM_WARPS,
+        waves_per_eu=0,
+        num_stages=1,
     )
 
     return (x_fp4, blockscale_e8m0)

--- a/aiter/ops/triton/quant.py
+++ b/aiter/ops/triton/quant.py
@@ -175,11 +175,11 @@ def _dynamic_mxfp4_quant_kernel(
     x_fp4_ptr,
     bs_ptr,
     stride_x_m_in,
-    stride_x_n,
+    stride_x_n_in,
     stride_x_fp4_m_in,
-    stride_x_fp4_n,
+    stride_x_fp4_n_in,
     stride_bs_m_in,
-    stride_bs_n,
+    stride_bs_n_in,
     M: tl.constexpr,
     N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
@@ -192,10 +192,13 @@ def _dynamic_mxfp4_quant_kernel(
 ):
     pid_m = tl.program_id(0)
     _pid_n = tl.program_id(1) * NUM_ITER
-    # cast strides to int64 in case M*N > max int32
+    # cast strides to int64, in case M*N > max int32
     stride_x_m = tl.cast(stride_x_m_in, tl.int64)
+    stride_x_n = tl.cast(stride_x_n_in, tl.int64)
     stride_x_fp4_m = tl.cast(stride_x_fp4_m_in, tl.int64)
+    stride_x_fp4_n = tl.cast(stride_x_fp4_n_in, tl.int64)
     stride_bs_m = tl.cast(stride_bs_m_in, tl.int64)
+    stride_bs_n = tl.cast(stride_bs_n_in, tl.int64)
 
     for pid_n in tl.range(_pid_n, min(_pid_n + NUM_ITER, N), num_stages=NUM_STAGES):
         x_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)

--- a/aiter/ops/triton/quant.py
+++ b/aiter/ops/triton/quant.py
@@ -323,7 +323,6 @@ def dynamic_mxfp4_quant(
     x_fp4 = torch.empty((M, N // 2), dtype=torch.uint8, device=x.device)
     blockscale_e8m0 = torch.empty(
         ((N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE, M),
-        # (M, (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE),
         dtype=torch.uint8,
         device=x.device,
     ).T


### PR DESCRIPTION
This PR tunes the Triton mxfp4 quantization kernel and adds the workaround for the 32-bit stride issue where (M*N) > (2^31 - 1) causes integer overflow in pointer arithmetic. The pointer arithmetic for the kernel is now in int64.

The update includes larger block size for the N dimension (multiple blocks of 32), multiple iterations per program with pipelining and parameter tuning. 

Performance numbers for bfloat16 to mxfp4 on mi350:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">



<body link="#0563C1" vlink="#954F72">


M | N | Orig. GB/s | New Code GB/s | Speedup
-- | -- | -- | -- | --
1 | 16384 | 10.9 | 15.3 | 1.41
4 | 16384 | 40.9 | 57.3 | 1.40
8 | 16384 | 79.7 | 109.8 | 1.38
16 | 16384 | 157.2 | 212.5 | 1.35
2048 | 16384 | 2391.0 | 2624.6 | 1.10
4096 | 16384 | 2264.1 | 2899.1 | 1.28
8192 | 16384 | 2061.1 | 3140.6 | 1.52
1 | 53248 | 17.3 | 39.2 | 2.26
4 | 53248 | 65.9 | 158.3 | 2.40
8 | 53248 | 136.0 | 300.0 | 2.21
16 | 53248 | 263.3 | 529.6 | 2.01
2048 | 53248 | 2548.1 | 3071.2 | 1.21
4096 | 53248 | 2784.5 | 3243.9 | 1.17
8192 | 53248 | 2869.5 | 3346.9 | 1.17



</body>

</html>























































