### PR TITLE
Test gemm_afp4wfp4 with mfma16 by setting kdim as 16 when M>=256

### DIFF
--- a/aiter/ops/triton/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gemm_afp4wfp4.py
@@ -250,6 +250,7 @@ def gemm_afp4wfp4(
     x_scales,
     w_scales,
     dtype: Optional[float] = torch.bfloat16,
+    nonkdim: int = 32,
 ):
     """
     Computes the matmul Y = X x W
@@ -337,7 +338,7 @@ def gemm_afp4wfp4(
         kpack = 1
         num_warps = 8
         num_stages = 2
-        matrix_instr_nonkdim = 32
+        matrix_instr_nonkdim = nonkdim
         cache_modifier = None
 
         NUM_KSPLIT = 1

--- a/op_tests/triton_tests/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/test_gemm_afp4wfp4.py
@@ -31,7 +31,6 @@ def generate_gemm_afp4wfp4_inputs(M, N, K):
 
 
 def get_x_vals():
-
     x_vals = [(1024 * v, 1024 * v, 1024 * v) for v in range(1, 9)]
     x_vals += [(4864, 4096, 8192), (9728, 8192, 65536), (4864, 8192, 4160)]
     x_vals += [
@@ -128,5 +127,7 @@ def test_gemm_afp4_wfp4(M: int, N: int, K: int, dtype):
     torch_out = run_torch(x, w, x_scales, w_scales, dtype).to(dtype)
 
     gemm_afp4wfp4(x, w, out, x_scales, w_scales, dtype)
+    # to test with mfma16, please enable the line below
+    gemm_afp4wfp4(x, w, out, x_scales, w_scales, dtype, nonkdim=16)
 
     torch.testing.assert_close(torch_out, out)


### PR DESCRIPTION
Test gemm_afp4wfp4 with mfma16 by setting kdim as 16 when M>=256
The test method is to run
 pytest ../aiter/op_tests/triton_tests/test_gemm_afp4wfp4.py
in the root of triton dir.
