### PR TITLE
fix: add missing column `cu_num` for `gemm_a8w8_blockscale_tune.py`

### DIFF
--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py
@@ -70,7 +70,7 @@ def get_tuned_gemm_list(tuned_gemm_file):
         tunedf = pd.read_csv(tuned_gemm_file)
     else:
         tunedf = pd.DataFrame(
-            columns=["M", "N", "K", "kernelId", "splitK", "us", "kernelName"]
+            columns=["cu_num", "M", "N", "K", "kernelId", "splitK", "us", "kernelName"]
         )
     return tunedf
 


### PR DESCRIPTION
Per title. When `tuned_gemm_file` does not exist, the returned dataframe is missing column `cu_num`, which is present in `a8w8_blockscale_tuned_gemm.csv`. This makes the script fails to run.

This PR fixes the issue.