### PR TITLE
Add aiter namespace to avoid symbol conflict with vllm

### DIFF
--- a/csrc/include/activation.h
+++ b/csrc/include/activation.h
@@ -3,7 +3,11 @@
 // Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 #include <torch/extension.h>
 
+namespace aiter {
+
 void silu_and_mul(torch::Tensor &out, torch::Tensor &input);
 void scaled_silu_and_mul(torch::Tensor &out, torch::Tensor &input, torch::Tensor &scale);
 void gelu_and_mul(torch::Tensor &out, torch::Tensor &input);
 void gelu_tanh_and_mul(torch::Tensor &out, torch::Tensor &input);
+
+} // namespace aiter

--- a/csrc/include/cache.h
+++ b/csrc/include/cache.h
@@ -6,6 +6,8 @@
 #include <map>
 #include <vector>
 
+namespace aiter {
+
 void swap_blocks(torch::Tensor &src, torch::Tensor &dst,
                  const torch::Tensor &block_mapping);
 
@@ -44,3 +46,5 @@ void reshape_and_cache_with_block_quant(torch::Tensor &key, torch::Tensor &value
 // Just for unittest
 void convert_fp8(torch::Tensor &dst_cache, torch::Tensor &src_cache,
                  const double scale, const std::string &kv_cache_dtype);
+
+} // namespace aiter

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -19,6 +19,9 @@
 
 // all reduce
 using fptr_t = int64_t;
+
+namespace aiter {
+
 fptr_t init_custom_ar(torch::Tensor &meta, torch::Tensor &rank_data,
                       const std::vector<std::string> &handles,
                       const std::vector<int64_t> &offsets, int64_t rank,
@@ -40,3 +43,5 @@ void register_graph_buffers(fptr_t _fa, const std::vector<std::string> &handles,
 torch::Tensor allocate_meta_buffer(int64_t size);
 torch::Tensor get_meta_buffer_ipc_handle(torch::Tensor &inp);
 #endif
+
+} // namespace aiter

--- a/csrc/include/moe_op.h
+++ b/csrc/include/moe_op.h
@@ -4,11 +4,6 @@
 #include <torch/extension.h>
 #include "aiter_enum.h"
 
-void topk_softmax(torch::Tensor &topk_weights, torch::Tensor &topk_indices,
-                  torch::Tensor &token_expert_indices,
-                  torch::Tensor &gating_output,
-                  bool need_renorm);
-
 void biased_grouped_topk(
     torch::Tensor &gating_output,   // [num_tokens, num_experts]
     torch::Tensor &correction_bias, // [num_expert]
@@ -28,12 +23,6 @@ void grouped_topk(
     bool need_renorm,
     std::string scoring_func = "softmax",
     const float routed_scaling_factor = 1.);
-
-void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
-                          int64_t block_size, torch::Tensor sorted_token_ids,
-                          torch::Tensor experts_ids,
-                          torch::Tensor token_nums,
-                          torch::Tensor num_tokens_post_pad);
 
 void fmoe(torch::Tensor &out,               // [token_cnt, dim]
           torch::Tensor &input,             // [token_cnt, dim] M,K
@@ -154,4 +143,20 @@ void moe_stage1_g1u1(torch::Tensor &input,             // [token_cnt, model_dim]
                      std::optional<torch::Tensor> w1_scale, // [expert, 1, inter_dim], gate(up) scale
                      std::optional<torch::Tensor> sorted_weights);
 
+
+namespace aiter {
+
+void topk_softmax(torch::Tensor &topk_weights, torch::Tensor &topk_indices,
+                  torch::Tensor &token_expert_indices,
+                  torch::Tensor &gating_output,
+                  bool need_renorm);
+
+void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
+                          int64_t block_size, torch::Tensor sorted_token_ids,
+                          torch::Tensor experts_ids,
+                          torch::Tensor token_nums,
+                          torch::Tensor num_tokens_post_pad);
+
 void moe_sum(torch::Tensor &input, torch::Tensor &output);
+
+} // namespace aiter

--- a/csrc/include/quant.h
+++ b/csrc/include/quant.h
@@ -4,6 +4,8 @@
 
 #include <torch/torch.h>
 
+namespace aiter {
+
 void static_per_tensor_quant(torch::Tensor &out,          // [..., d]
                              torch::Tensor const &input,  // [..., d]
                              torch::Tensor const &scale); // [1]
@@ -16,3 +18,5 @@ void dynamic_per_token_scaled_quant(
     torch::Tensor &out,         // [..., d]
     torch::Tensor const &input, // [..., d]
     torch::Tensor &scales, std::optional<at::Tensor> const &scale_ub);
+
+} // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2,10 +2,10 @@
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #define ACTIVATION_PYBIND                                                                               \
-      m.def("silu_and_mul", &silu_and_mul, "Activation function used in SwiGLU.");                      \
-      m.def("scaled_silu_and_mul", &scaled_silu_and_mul, "Activation function used in scaled SwiGLU."); \
-      m.def("gelu_and_mul", &gelu_and_mul, "Activation function used in GELU.");                        \
-      m.def("gelu_tanh_and_mul", &gelu_tanh_and_mul, "Activation function used in GELU tanh.");
+      m.def("silu_and_mul", &aiter::silu_and_mul, "Activation function used in SwiGLU.");                      \
+      m.def("scaled_silu_and_mul", &aiter::scaled_silu_and_mul, "Activation function used in scaled SwiGLU."); \
+      m.def("gelu_and_mul", &aiter::gelu_and_mul, "Activation function used in GELU.");                        \
+      m.def("gelu_tanh_and_mul", &aiter::gelu_tanh_and_mul, "Activation function used in GELU tanh.");
 
 #define AITER_OPERATOR_PYBIND                                                     \
       m.def("add", &aiter_add, "apply for add with transpose and broadcast.");    \
@@ -111,29 +111,29 @@
             py::arg("splitK") = 0);
 
 #define CACHE_PYBIND                                                                         \
-      m.def("swap_blocks", &swap_blocks,                                                     \
+      m.def("swap_blocks", &aiter::swap_blocks,                                                     \
             "swap_blocks(Tensor src, Tensor! dst, Tensor block_mapping) -> ()");             \
-      m.def("copy_blocks", &copy_blocks,                                                     \
+      m.def("copy_blocks", &aiter::copy_blocks,                                                     \
             "copy_blocks(Tensor(a!)[] key_caches, Tensor[](b!) value_caches, "               \
             "Tensor block_mapping) -> ()");                                                  \
                                                                                              \
-      m.def("reshape_and_cache", &reshape_and_cache,                                         \
+      m.def("reshape_and_cache", &aiter::reshape_and_cache,                                         \
             "reshape_and_cache");                                                            \
-      m.def("reshape_and_cache_flash", &reshape_and_cache_flash,                             \
+      m.def("reshape_and_cache_flash", &aiter::reshape_and_cache_flash,                             \
             "reshape_and_cache_flash(Tensor key, Tensor value,"                              \
             "                        Tensor! key_cache,"                                     \
             "                        Tensor! value_cache,"                                   \
             "                        Tensor slot_mapping,"                                   \
             "                        str kv_cache_dtype,"                                    \
             "                        float k_scale, float v_scale) -> ()");                  \
-      m.def("reshape_and_cache_with_pertoken_quant", &reshape_and_cache_with_pertoken_quant, \
+      m.def("reshape_and_cache_with_pertoken_quant", &aiter::reshape_and_cache_with_pertoken_quant, \
             "reshape_and_cache_with_pertoken_quant(Tensor key, Tensor value,"                \
             "                        Tensor! key_cache,"                                     \
             "                        Tensor! value_cache,"                                   \
             "                        Tensor! k_dequant_scales,"                              \
             "                        Tensor! v_dequant_scales,"                              \
             "                        Tensor slot_mapping) -> ()");                           \
-      m.def("reshape_and_cache_with_block_quant", &reshape_and_cache_with_block_quant,       \
+      m.def("reshape_and_cache_with_block_quant", &aiter::reshape_and_cache_with_block_quant,       \
             "reshape_and_cache_with_block_quant(Tensor key, Tensor value,"                   \
             "                        Tensor! key_cache,"                                     \
             "                        Tensor! value_cache,"                                   \
@@ -141,36 +141,36 @@
             "                        Tensor! v_dequant_scales,"                              \
             "                        Tensor slot_mapping,"                                   \
             "                        const bool asm_layout) -> ()");                         \
-      m.def("convert_fp8", &convert_fp8,                                                     \
+      m.def("convert_fp8", &aiter::convert_fp8,                                                     \
             "convert_fp8(Tensor! dst_cache, Tensor src_cache, float scale, "                 \
             "str kv_cache_dtype) -> ()");
 
 #define CUSTOM_ALL_REDUCE_PYBIND                                                                        \
-      m.def("init_custom_ar", &init_custom_ar,                                                          \
+      m.def("init_custom_ar", &aiter::init_custom_ar,                                                          \
             "init_custom_ar(Tensor meta, Tensor rank_data, "                                            \
             "str[] handles, int[] offsets, int rank, "                                                  \
             "bool full_nvlink) -> int",                                                                 \
             py::arg("meta"), py::arg("rank_data"),                                                      \
             py::arg("handles"), py::arg("offsets"),                                                     \
             py::arg("rank"), py::arg("full_nvlink"));                                                   \
-      m.def("all_reduce_reg", &all_reduce_reg, "all_reduce_reg(int fa, Tensor inp, Tensor! out) -> ()", \
+      m.def("all_reduce_reg", &aiter::all_reduce_reg, "all_reduce_reg(int fa, Tensor inp, Tensor! out) -> ()", \
             py::arg("_fa"), py::arg("inp"), py::arg("out"));                                            \
-      m.def("all_reduce_unreg", &all_reduce_unreg,                                                      \
+      m.def("all_reduce_unreg", &aiter::all_reduce_unreg,                                                      \
             "all_reduce_unreg(int fa, Tensor inp, Tensor reg_buffer, Tensor! out) -> ()",               \
             py::arg("_fa"), py::arg("inp"), py::arg("reg_buffer"), py::arg("out"));                     \
       m.def("all_reduce_asm_", &all_reduce_asm, "");                                                    \
       m.def("all_reduce_rmsnorm_", &all_reduce_rmsnorm, "all_reduce_rmsnorm");                          \
       m.def("all_reduce_rmsnorm_quant_", &all_reduce_rmsnorm_quant, "all_reduce_rmsnorm_quant");        \
-      m.def("dispose", &dispose, py::arg("_fa"));                                                       \
-      m.def("meta_size", &meta_size);                                                                   \
-      m.def("register_buffer", &register_buffer,                                                        \
+      m.def("dispose", &aiter::dispose, py::arg("_fa"));                                                       \
+      m.def("meta_size", &aiter::meta_size);                                                                   \
+      m.def("register_buffer", &aiter::register_buffer,                                                        \
             "register_buffer(int fa, Tensor t, str[] handles, int[] offsets) -> ()",                    \
             py::arg("_fa"), py::arg("t"), py::arg("handles"), py::arg("offsets"));                      \
-      m.def("get_graph_buffer_ipc_meta", &get_graph_buffer_ipc_meta, py::arg("_fa"));                   \
-      m.def("register_graph_buffers", &register_graph_buffers,                                          \
+      m.def("get_graph_buffer_ipc_meta", &aiter::get_graph_buffer_ipc_meta, py::arg("_fa"));                   \
+      m.def("register_graph_buffers", &aiter::register_graph_buffers,                                          \
             py::arg("_fa"), py::arg("handles"), py::arg("offsets"));                                    \
-      m.def("allocate_meta_buffer", &allocate_meta_buffer, py::arg("size"));                            \
-      m.def("get_meta_buffer_ipc_handle", &get_meta_buffer_ipc_handle, py::arg("inp"));
+      m.def("allocate_meta_buffer", &aiter::allocate_meta_buffer, py::arg("size"));                            \
+      m.def("get_meta_buffer_ipc_handle", &aiter::get_meta_buffer_ipc_handle, py::arg("inp"));
 
 #define CUSTOM_PYBIND                                                                                 \
       m.def("wvSpltK", &wvSpltK, "wvSpltK(Tensor in_a, Tensor in_b, Tensor! out_c, int N_in,"         \
@@ -413,7 +413,7 @@
             py::arg("expert_mask") = std::nullopt);
 
 #define MOE_OP_PYBIND                                                            \
-      m.def("topk_softmax", &topk_softmax,                                       \
+      m.def("topk_softmax", &aiter::topk_softmax,                                       \
             "Apply topk softmax to the gating outputs.");                        \
       m.def("grouped_topk", &grouped_topk,                                       \
             py::arg("gating_output"),                                            \
@@ -429,7 +429,7 @@
             py::arg("need_renorm"),                                              \
             py::arg("routed_scaling_factor") = 1.0f,                             \
             "Apply biased grouped topk softmax to the gating outputs.");         \
-      m.def("moe_align_block_size", &moe_align_block_size,                       \
+      m.def("moe_align_block_size", &aiter::moe_align_block_size,                       \
             "Aligning the number of tokens to be processed by each expert such " \
             "that it is divisible by the block size.");                          \
       m.def("fmoe", &fmoe);                                                      \
@@ -488,7 +488,7 @@
             py::arg("a1_scale") = std::nullopt,                                  \
             py::arg("w1_scale") = std::nullopt,                                  \
             py::arg("sorted_weights") = std::nullopt);                           \
-      m.def("moe_sum", &moe_sum, "moe_sum(Tensor! input, Tensor output) -> ()");
+      m.def("moe_sum", &aiter::moe_sum, "moe_sum(Tensor! input, Tensor output) -> ()");
 
 #define MOE_SORTING_PYBIND                                          \
       m.def("moe_sorting_fwd", &moe_sorting_fwd,                    \
@@ -535,9 +535,9 @@
       m.def("batched_rotary_embedding", &batched_rotary_embedding, "batched_rotary_embedding");
 
 #define QUANT_PYBIND                                                                   \
-      m.def("static_per_tensor_quant", &static_per_tensor_quant);                      \
-      m.def("dynamic_per_tensor_quant", &dynamic_per_tensor_quant);                    \
-      m.def("dynamic_per_token_scaled_quant", &dynamic_per_token_scaled_quant, \
+      m.def("static_per_tensor_quant", &aiter::static_per_tensor_quant);                      \
+      m.def("dynamic_per_tensor_quant", &aiter::dynamic_per_tensor_quant);                    \
+      m.def("dynamic_per_token_scaled_quant", &aiter::dynamic_per_token_scaled_quant, \
             py::arg("out"), py::arg("input"),                                          \
             py::arg("scales"), py::arg("scale_ub") = std::nullopt);
 

--- a/csrc/kernels/activation_kernels.cu
+++ b/csrc/kernels/activation_kernels.cu
@@ -132,6 +132,8 @@ namespace vllm
         });
 #endif
 
+namespace aiter {
+
 void silu_and_mul(torch::Tensor &out,   // [..., d]
                   torch::Tensor &input) // [..., 2 * d]
 {
@@ -156,6 +158,8 @@ void gelu_tanh_and_mul(torch::Tensor &out,   // [..., d]
 {
   LAUNCH_ACTIVATION_GATE_KERNEL(vllm::gelu_tanh_kernel);
 }
+
+} // namespace aiter
 
 namespace vllm
 {
@@ -211,6 +215,8 @@ namespace vllm
 
 } // namespace vllm
 
+namespace aiter {
+
 void gelu_new(torch::Tensor &out,   // [..., d]
               torch::Tensor &input) // [..., d]
 {
@@ -222,3 +228,5 @@ void gelu_fast(torch::Tensor &out,   // [..., d]
 {
   LAUNCH_ACTIVATION_KERNEL(vllm::gelu_fast_kernel);
 }
+
+} // namespace aiter

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -25,6 +25,8 @@
 using fptr_t = int64_t;
 static_assert(sizeof(void *) == sizeof(fptr_t));
 
+namespace aiter {
+
 fptr_t init_custom_ar(torch::Tensor &meta, torch::Tensor &rank_data,
                       const std::vector<std::string> &handles,
                       const std::vector<int64_t> &offsets, int64_t rank,
@@ -205,3 +207,5 @@ torch::Tensor allocate_meta_buffer(int64_t size)
 }
 
 #endif
+
+} // namespace aiter

--- a/csrc/kernels/moe_align_block_size_kernels.cu
+++ b/csrc/kernels/moe_align_block_size_kernels.cu
@@ -138,6 +138,8 @@ namespace vllm
   }
 } // namespace vllm
 
+namespace aiter {
+
 void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
                           int64_t block_size, torch::Tensor sorted_token_ids,
                           torch::Tensor experts_ids,
@@ -166,3 +168,5 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
             num_tokens_post_pad.data_ptr<int32_t>(), num_experts, block_size,
             topk_ids.numel()); });
 }
+
+} // namespace aiter

--- a/csrc/kernels/quant_kernels.cu
+++ b/csrc/kernels/quant_kernels.cu
@@ -9,87 +9,7 @@
 #include <hipcub/hipcub.hpp>
 #include "vec_convert.h"
 
-namespace vllm {
-
-template <typename scalar_t>
-__global__ void scaled_fp8_quant_kernel(FP8_TYPE* __restrict__ out,
-                                        const scalar_t* __restrict__ input,
-                                        const float* __restrict__ scale,
-                                        int64_t num_elems) {
-  int tid = blockDim.x * blockIdx.x + threadIdx.x;
-
-  // Invert the scale so that we can use multiplications to avoid expensive
-  // division.
-  const float inverted_scale = 1.0f / (*scale);
-  scaled_fp8_conversion_vec<scalar_t, true>(
-      out, input, inverted_scale, num_elems, tid, blockDim.x * gridDim.x);
-}
-
-template <typename scalar_t>
-__global__ void dynamic_per_token_scaled_fp8_quant_kernel(
-    FP8_TYPE* __restrict__ out, float* __restrict__ scale,
-    scalar_t const* __restrict__ input, float const* __restrict__ scale_ub,
-    const int hidden_size) {
-  float const min_scaling_factor = 1.0f / (FP8_MAX * 512.f);
-
-  int const tid = threadIdx.x;
-  int const token_idx = blockIdx.x;
-
-  // Use int64 to avoid overflowing an int32 when calculating this offset
-  int64_t offset = static_cast<int64_t>(token_idx) * hidden_size;
-  scalar_t const* __restrict__ token_input = &input[offset];
-  FP8_TYPE* __restrict__ token_output = &out[offset];
-
-  // For vectorization, token_input and token_output pointers need to be
-  // aligned at 8-byte and 4-byte addresses respectively.
-  bool const can_vectorize = hidden_size % 4 == 0;
-
-  float absmax_val = 0.0f;
-  if (can_vectorize) {
-    absmax_val = thread_max_vec(token_input, hidden_size, tid, blockDim.x);
-  } else {
-    for (int i = tid; i < hidden_size; i += blockDim.x) {
-      float const x = static_cast<float>(token_input[i]);
-      absmax_val = max(absmax_val, fabs(x));
-    }
-  }
-
-  using BlockReduce = cub::BlockReduce<float, 1024>;
-  __shared__ typename BlockReduce::TempStorage reduceStorage;
-  float const block_absmax_val_maybe =
-      BlockReduce(reduceStorage).Reduce(absmax_val, cub::Max{}, blockDim.x);
-  __shared__ float token_scale;
-  if (tid == 0) {
-    if (scale_ub) {
-      token_scale = min(block_absmax_val_maybe, *scale_ub);
-    } else {
-      token_scale = block_absmax_val_maybe;
-    }
-    // token scale computation
-    token_scale = max(token_scale / FP8_MAX, min_scaling_factor);
-    scale[token_idx] = token_scale;
-  }
-  __syncthreads();
-
-  // Note that we don't use inverted scales so we can match FBGemm impl.
-  if (can_vectorize) {
-    scaled_fp8_conversion_vec<scalar_t, false>(
-        token_output, token_input, token_scale, hidden_size, tid, blockDim.x);
-  } else {
-    for (int i = tid; i < hidden_size; i += blockDim.x) {
-      token_output[i] = scaled_fp8_conversion<false>(
-          static_cast<float>(token_input[i]), token_scale);
-    }
-  }
-}
-
-}  // namespace vllm
-
-namespace aiter {
-
-void static_scaled_fp8_quant(torch::Tensor& out,          // [..., d]
-                             torch::Tensor const& input,  // [..., d]
-                             torch::Tensor const& scale)  // [1]
+namespace aiter
 {
   template <typename DTYPE_I, typename DTYPE_O>
   __device__ float data_to_per_row_scale(const DTYPE_I *__restrict__ input,
@@ -269,7 +189,6 @@ void static_scaled_fp8_quant(torch::Tensor& out,          // [..., d]
 
     scaled_quant_impl<DTYPE_I>(out, input, &token_scale, cols);
   }
-}
 
 void static_per_tensor_quant(torch::Tensor &out,         // [..., d]
                              torch::Tensor const &input, // [..., d]
@@ -355,4 +274,4 @@ void dynamic_per_token_scaled_quant(
   }
 }
 
-}  // namespace aiter
+} // namespace aiter

--- a/csrc/kernels/quant_kernels.cu
+++ b/csrc/kernels/quant_kernels.cu
@@ -9,7 +9,87 @@
 #include <hipcub/hipcub.hpp>
 #include "vec_convert.h"
 
-namespace aiter
+namespace vllm {
+
+template <typename scalar_t>
+__global__ void scaled_fp8_quant_kernel(FP8_TYPE* __restrict__ out,
+                                        const scalar_t* __restrict__ input,
+                                        const float* __restrict__ scale,
+                                        int64_t num_elems) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+
+  // Invert the scale so that we can use multiplications to avoid expensive
+  // division.
+  const float inverted_scale = 1.0f / (*scale);
+  scaled_fp8_conversion_vec<scalar_t, true>(
+      out, input, inverted_scale, num_elems, tid, blockDim.x * gridDim.x);
+}
+
+template <typename scalar_t>
+__global__ void dynamic_per_token_scaled_fp8_quant_kernel(
+    FP8_TYPE* __restrict__ out, float* __restrict__ scale,
+    scalar_t const* __restrict__ input, float const* __restrict__ scale_ub,
+    const int hidden_size) {
+  float const min_scaling_factor = 1.0f / (FP8_MAX * 512.f);
+
+  int const tid = threadIdx.x;
+  int const token_idx = blockIdx.x;
+
+  // Use int64 to avoid overflowing an int32 when calculating this offset
+  int64_t offset = static_cast<int64_t>(token_idx) * hidden_size;
+  scalar_t const* __restrict__ token_input = &input[offset];
+  FP8_TYPE* __restrict__ token_output = &out[offset];
+
+  // For vectorization, token_input and token_output pointers need to be
+  // aligned at 8-byte and 4-byte addresses respectively.
+  bool const can_vectorize = hidden_size % 4 == 0;
+
+  float absmax_val = 0.0f;
+  if (can_vectorize) {
+    absmax_val = thread_max_vec(token_input, hidden_size, tid, blockDim.x);
+  } else {
+    for (int i = tid; i < hidden_size; i += blockDim.x) {
+      float const x = static_cast<float>(token_input[i]);
+      absmax_val = max(absmax_val, fabs(x));
+    }
+  }
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStorage;
+  float const block_absmax_val_maybe =
+      BlockReduce(reduceStorage).Reduce(absmax_val, cub::Max{}, blockDim.x);
+  __shared__ float token_scale;
+  if (tid == 0) {
+    if (scale_ub) {
+      token_scale = min(block_absmax_val_maybe, *scale_ub);
+    } else {
+      token_scale = block_absmax_val_maybe;
+    }
+    // token scale computation
+    token_scale = max(token_scale / FP8_MAX, min_scaling_factor);
+    scale[token_idx] = token_scale;
+  }
+  __syncthreads();
+
+  // Note that we don't use inverted scales so we can match FBGemm impl.
+  if (can_vectorize) {
+    scaled_fp8_conversion_vec<scalar_t, false>(
+        token_output, token_input, token_scale, hidden_size, tid, blockDim.x);
+  } else {
+    for (int i = tid; i < hidden_size; i += blockDim.x) {
+      token_output[i] = scaled_fp8_conversion<false>(
+          static_cast<float>(token_input[i]), token_scale);
+    }
+  }
+}
+
+}  // namespace vllm
+
+namespace aiter {
+
+void static_scaled_fp8_quant(torch::Tensor& out,          // [..., d]
+                             torch::Tensor const& input,  // [..., d]
+                             torch::Tensor const& scale)  // [1]
 {
   template <typename DTYPE_I, typename DTYPE_O>
   __device__ float data_to_per_row_scale(const DTYPE_I *__restrict__ input,
@@ -189,8 +269,7 @@ namespace aiter
 
     scaled_quant_impl<DTYPE_I>(out, input, &token_scale, cols);
   }
-
-} // namespace aiter
+}
 
 void static_per_tensor_quant(torch::Tensor &out,         // [..., d]
                              torch::Tensor const &input, // [..., d]
@@ -275,3 +354,5 @@ void dynamic_per_token_scaled_quant(
     TORCH_CHECK(false, __func__, "Unsupported output type for dynamic_per_token_scaled_quant");
   }
 }
+
+}  // namespace aiter

--- a/csrc/kernels/topk_softmax_kernels.cu
+++ b/csrc/kernels/topk_softmax_kernels.cu
@@ -440,8 +440,8 @@ struct TopkConstants
 
 template <int EXPERTS, int WARPS_PER_TB>
 void topkGatingSoftmaxLauncherHelper(const float *input, const bool *finished, float *output, int *indices,
-                                     int *source_row, const int num_rows, const int k, 
-                                     const int start_expert, const int end_expert, 
+                                     int *source_row, const int num_rows, const int k,
+                                     const int start_expert, const int end_expert,
                                      const int output_stride, const int indices_stride,
                                      const bool need_renorm, cudaStream_t stream)
 {
@@ -465,7 +465,7 @@ void topkGatingSoftmaxLauncherHelper(const float *input, const bool *finished, f
         topkGatingSoftmax<VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, false><<<num_blocks, block_dim, 0, stream>>>(
             input, finished, output, num_rows, indices, source_row, k, start_expert, end_expert, output_stride, indices_stride);
     }
-    
+
 
 }
 
@@ -535,7 +535,7 @@ template <typename scalar_t, int TOPK>
 __global__ void moe_sum_kernel(
     scalar_t* __restrict__ out,           // [..., d]
     const scalar_t* __restrict__ input,   // [..., topk, d]
-    const int d) 
+    const int d)
 {
     const int64_t token_idx = blockIdx.x;
     for (int64_t idx = threadIdx.x; idx < d; idx += blockDim.x) {
@@ -543,7 +543,7 @@ __global__ void moe_sum_kernel(
         #pragma unroll
         for (int k = 0; k < TOPK; ++k) {
             x += VLLM_LDG(&input[token_idx * TOPK * d + k * d + idx]);
-        }        
+        }
         out[token_idx * d + idx] = x;
     }
 }
@@ -551,12 +551,14 @@ __global__ void moe_sum_kernel(
 } // namespace moe
 } // namespace vllm
 
+namespace aiter {
+
 void topk_softmax(
     torch::Tensor& topk_weights,                // [num_tokens, topk]
     torch::Tensor& topk_indices,                // [num_tokens, topk]
     torch::Tensor& token_expert_indices,        // [num_tokens, topk]
     torch::Tensor& gating_output,               // [num_tokens, num_experts]
-    bool need_renorm)               
+    bool need_renorm)
 {
     const int num_experts = gating_output.size(-1);
     const int num_tokens = gating_output.numel() / num_experts;
@@ -594,29 +596,29 @@ void moe_sum(
     const int hidden_size = input.size(-1);
     const int num_tokens = output.numel() / hidden_size;
     const int topk = input.size(1);
-    
+
     dim3 grid(num_tokens);
     dim3 block(std::min(hidden_size, 1024));
 
     const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
     const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    
+
     switch (topk) {
     case 2:
         VLLM_DISPATCH_FLOATING_TYPES(
             input.scalar_type(), "moe_sum_kernel", [&] {
                 vllm::moe::moe_sum_kernel<scalar_t, 2>
-                    <<<grid, block, 0, stream>>>(output.data_ptr<scalar_t>(), 
-                    input.data_ptr<scalar_t>(), hidden_size);                
+                    <<<grid, block, 0, stream>>>(output.data_ptr<scalar_t>(),
+                    input.data_ptr<scalar_t>(), hidden_size);
             });
         break;
-    
+
     case 4:
         VLLM_DISPATCH_FLOATING_TYPES(
             input.scalar_type(), "moe_sum_kernel", [&] {
                 vllm::moe::moe_sum_kernel<scalar_t, 4>
-                    <<<grid, block, 0, stream>>>(output.data_ptr<scalar_t>(), 
-                    input.data_ptr<scalar_t>(), hidden_size);                
+                    <<<grid, block, 0, stream>>>(output.data_ptr<scalar_t>(),
+                    input.data_ptr<scalar_t>(), hidden_size);
             });
         break;
 
@@ -632,3 +634,5 @@ void moe_sum(
         break;
     }
 }
+
+} // namespace aiter

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -15,7 +15,7 @@
 #include <ATen/hip/HIPContext.h>
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include "dispatch_utils.h"
-#include "py_itfs_common_hip.h"
+#include "py_itfs_common.h"
 #include <hipcub/util_type.hpp>
 #include <hipcub/hipcub.hpp>
 


### PR DESCRIPTION
As title - those symbols are in vllm too which will cause symbol conflict if compile with vllm.