### PR TITLE
Add fused activation and mxfp4 quantization kernel

### DIFF
--- a/aiter/ops/triton/activation.py
+++ b/aiter/ops/triton/activation.py
@@ -1,0 +1,230 @@
+from .quant import _mxfp4_quant_op
+from typing import Literal
+import triton
+import triton.language as tl
+import torch
+
+
+@triton.jit
+def _silu(x):
+    return x * tl.sigmoid(x)
+
+
+@triton.jit
+def _tanh(x):
+    return 2 * tl.sigmoid(2 * x) - 1
+
+
+@triton.jit
+def _gelu(x):
+    M_SQRT1_2 = 0.70710678118654752440
+    ALPHA = M_SQRT1_2
+    return 0.5 * x * (1.0 + tl.erf(x * ALPHA))
+
+
+@triton.jit
+def _gelu_tanh(x):
+    M_SQRT2 = 1.41421356237309504880
+    M_2_SQRTPI = 1.12837916709551257390
+    BETA = M_SQRT2 * M_2_SQRTPI * 0.5
+    KAPPA = 0.044715
+    x_cube = x * x * x
+    inner = BETA * (x + KAPPA * x_cube)
+    return 0.5 * x * (1.0 + _tanh(inner))
+
+
+@tl.constexpr_function
+def _get_activation_from_str(activation: str):
+    mapping = {
+        "gelu": _gelu,
+        "gelu_tanh": _gelu_tanh,
+        "silu": _silu,
+    }
+    return mapping[activation]
+
+
+@triton.heuristics(
+    {
+        "EVEN_M_N": lambda args: args["M"] % args["BLOCK_SIZE_M"] == 0
+        and args["N"] % (args["BLOCK_SIZE_N"] * args["NUM_ITER"]) == 0,
+    }
+)
+@triton.jit
+def _act_mul_and_dynamic_mxfp4_quant_kernel(
+    x_ptr,
+    x_fp4_ptr,
+    bs_ptr,
+    stride_x_m_in,
+    stride_x_n_in,
+    stride_x_fp4_m_in,
+    stride_x_fp4_n_in,
+    stride_bs_m_in,
+    stride_bs_n_in,
+    M,
+    N,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    NUM_ITER: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    MXFP4_QUANT_BLOCK_SIZE: tl.constexpr,
+    EVEN_M_N: tl.constexpr,
+    SCALING_MODE: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    start_n = tl.program_id(1) * NUM_ITER
+    # cast strides to int64, in case M*N > max int32
+    stride_x_m = tl.cast(stride_x_m_in, tl.int64)
+    stride_x_n = tl.cast(stride_x_n_in, tl.int64)
+    stride_x_fp4_m = tl.cast(stride_x_fp4_m_in, tl.int64)
+    stride_x_fp4_n = tl.cast(stride_x_fp4_n_in, tl.int64)
+    stride_bs_m = tl.cast(stride_bs_m_in, tl.int64)
+    stride_bs_n = tl.cast(stride_bs_n_in, tl.int64)
+
+    NUM_QUANT_BLOCKS: tl.constexpr = BLOCK_SIZE_N // MXFP4_QUANT_BLOCK_SIZE
+
+    for pid_n in tl.range(start_n, min(start_n + NUM_ITER, N), num_stages=NUM_STAGES):
+        x_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        x_offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        x_offs = x_offs_m[:, None] * stride_x_m + x_offs_n[None, :] * stride_x_n
+
+        if EVEN_M_N:
+            a = tl.load(x_ptr + x_offs, cache_modifier=".cg").to(tl.float32)
+            b = tl.load(x_ptr + x_offs + stride_x_n * N, cache_modifier=".cg").to(
+                tl.float32
+            )
+        else:
+            x_mask = (x_offs_m < M)[:, None] & (x_offs_n < N)[None, :]
+            a = tl.load(x_ptr + x_offs, mask=x_mask, cache_modifier=".cg").to(
+                tl.float32
+            )
+            # a and b can share the same mask
+            b = tl.load(
+                x_ptr + x_offs + stride_x_n * N, mask=x_mask, cache_modifier=".cg"
+            ).to(tl.float32)
+
+        x = _get_activation_from_str(ACTIVATION)(a) * b
+
+        out_tensor, bs_e8m0 = _mxfp4_quant_op(
+            x, BLOCK_SIZE_N, BLOCK_SIZE_M, MXFP4_QUANT_BLOCK_SIZE
+        )
+
+        out_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        out_offs_n = pid_n * BLOCK_SIZE_N // 2 + tl.arange(0, BLOCK_SIZE_N // 2)
+        out_offs = (
+            out_offs_m[:, None] * stride_x_fp4_m + out_offs_n[None, :] * stride_x_fp4_n
+        )
+
+        if EVEN_M_N:
+            tl.store(x_fp4_ptr + out_offs, out_tensor)
+        else:
+            out_mask = (out_offs_m < M)[:, None] & (out_offs_n < (N // 2))[None, :]
+            tl.store(x_fp4_ptr + out_offs, out_tensor, mask=out_mask)
+
+        bs_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        bs_offs_n = pid_n * NUM_QUANT_BLOCKS + tl.arange(0, NUM_QUANT_BLOCKS)
+        bs_offs = bs_offs_m[:, None] * stride_bs_m + bs_offs_n[None, :] * stride_bs_n
+        if EVEN_M_N:
+            tl.store(bs_ptr + bs_offs, bs_e8m0.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS))
+        else:
+            bs_mask = (bs_offs_m < M)[:, None] & (
+                bs_offs_n < (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
+            )[None, :]
+            tl.store(
+                bs_ptr + bs_offs,
+                bs_e8m0.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS),
+                mask=bs_mask,
+            )
+
+
+def act_mul_and_mxfp4_quant(
+    x: torch.Tensor,
+    activation: Literal["silu", "gelu", "gelu_tanh"],
+    scaling_mode: str = "even",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Apply the activation function and quantize the result to MX FP4 format.
+
+    Args:
+        x: The input tensor, typically fp16 or bf16.
+        activation: activation function to apply before quantization.
+            - It splits the features into two parts and applies the activation to the first part.
+            - Then, it adds the results together before quantization.
+            - Supports the following activations:
+                - "silu"
+                - "gelu"
+                - "gelu_tanh"
+
+        scaling_mode: The method to calculate MX block scaling.
+            - "even" (default): `even_round` in `quark.torch.quantization.utils`.
+            - etc.
+    Returns:
+        A tuple of (x_fp4, blockscale_e8m0).
+    """
+    # Assume x is 2D-Tensor for now
+    M, N = x.shape
+    # Activating and storing results in uint8 results in a feature dimension of N/4
+    assert N % 4 == 0
+
+    # This is fixed by spec for MXFP4. Do not tune this.
+    # For performance, perhaps, we should look at passing multiple of 32 column blocks
+    # that a triton program can process
+    MXFP4_QUANT_BLOCK_SIZE = 32
+    N_half = N // 2
+    x_fp4 = torch.empty((M, N_half // 2), dtype=torch.uint8, device=x.device)
+    blockscale_e8m0 = torch.empty(
+        ((N_half + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE, M),
+        dtype=torch.uint8,
+        device=x.device,
+    ).T
+
+    # for large N values
+    if M <= 32:
+        NUM_ITER = 1
+        BLOCK_SIZE_M = min(8, triton.next_power_of_2(M))
+        BLOCK_SIZE_N = 128
+        NUM_WARPS = 1 if BLOCK_SIZE_M < 4 else 4
+        NUM_STAGES = 1
+    else:
+        NUM_ITER = 1
+        BLOCK_SIZE_M = 16
+        BLOCK_SIZE_N = 256
+        NUM_WARPS = 4
+        NUM_STAGES = 1
+
+    # for small N values
+    if N_half <= 1024:
+        NUM_ITER = 1
+        NUM_STAGES = 1
+        NUM_WARPS = 4
+        BLOCK_SIZE_N = min(256, triton.next_power_of_2(N_half))
+        # BLOCK_SIZE_N needs to be multiple of 32
+        BLOCK_SIZE_N = max(32, BLOCK_SIZE_N)
+        BLOCK_SIZE_M = min(8, triton.next_power_of_2(N_half))
+
+    grid = (
+        triton.cdiv(M, BLOCK_SIZE_M),
+        triton.cdiv(N_half, BLOCK_SIZE_N * NUM_ITER),
+    )
+    _act_mul_and_dynamic_mxfp4_quant_kernel[grid](
+        x,
+        x_fp4,
+        blockscale_e8m0,
+        *x.stride(),
+        *x_fp4.stride(),
+        *blockscale_e8m0.stride(),
+        M=M,
+        N=N_half,
+        MXFP4_QUANT_BLOCK_SIZE=MXFP4_QUANT_BLOCK_SIZE,
+        SCALING_MODE=0,
+        ACTIVATION=activation,
+        NUM_ITER=NUM_ITER,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        NUM_STAGES=NUM_STAGES,
+        num_warps=NUM_WARPS,
+        waves_per_eu=0,
+        num_stages=1,
+    )
+
+    return x_fp4, blockscale_e8m0

--- a/aiter/ops/triton/activation.py
+++ b/aiter/ops/triton/activation.py
@@ -163,7 +163,7 @@ def act_mul_and_mxfp4_quant(
     """
     # Assume x is 2D-Tensor for now
     M, N = x.shape
-    # Activating and storing results in uint8 results in a feature dimension of N/4
+    # Activation (N/2) and storing results in uint8 (N/2) results in a feature dimension of N/4
     assert N % 4 == 0
 
     # This is fixed by spec for MXFP4. Do not tune this.

--- a/aiter/ops/triton/quant.py
+++ b/aiter/ops/triton/quant.py
@@ -163,6 +163,79 @@ def dynamic_per_token_fp8_quant(
     return qx, scale_out
 
 
+@triton.jit
+def _mxfp4_quant_op(
+    x,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_M,
+    MXFP4_QUANT_BLOCK_SIZE,
+):
+    """
+    Converts given x (in fp32) to mxfp4 format.
+    x: [BLOCK_SIZE_M, BLOCK_SIZE_N], fp32
+
+    """
+    NUM_QUANT_BLOCKS: tl.constexpr = BLOCK_SIZE_N // MXFP4_QUANT_BLOCK_SIZE
+    x = x.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS, MXFP4_QUANT_BLOCK_SIZE)
+    # Calculate scale
+    amax = tl.max(tl.abs(x), axis=-1, keep_dims=True)
+    amax = amax.to(tl.int32, bitcast=True)
+    amax = (amax + 0x200000).to(tl.uint32, bitcast=True) & 0xFF800000
+    amax = amax.to(tl.float32, bitcast=True)
+    scale_e8m0_unbiased = tl.log2(amax).floor() - 2
+    scale_e8m0_unbiased = tl.clamp(scale_e8m0_unbiased, min=-127, max=127)
+
+    # blockscale_e8m0
+    bs_e8m0 = scale_e8m0_unbiased.to(tl.uint8) + 127  # in fp32, we have 2&(e - 127)
+
+    quant_scale = tl.exp2(-scale_e8m0_unbiased)
+
+    # Compute quantized x
+    qx = x * quant_scale
+
+    # Convert quantized fp32 tensor to uint32 before converting to mxfp4 format
+    # Note: MXFP4  S:1-bit, E:2-bit, M:1-bit
+    #   Zeros: S000 -> +/-0
+    #   Denormal Numbers: S001 -> +/- 0.5
+    #   Normal Numbers:
+    #           S010 -> +/- 1.0
+    #           S011 -> +/- 1.5
+    #           S100 -> +/- 2.0
+    #           S101 -> +/- 3.0
+    #           S110 -> +/- 4.0
+    #           S111 -> +/- 6.0
+    qx = qx.to(tl.uint32, bitcast=True)
+
+    # Extract sign, exponents and mantissa fields from FP32
+    s = qx & 0x80000000
+    e = (qx >> 23) & 0xFF
+    m = qx & 0x7FFFFF
+    E8_BIAS: tl.constexpr = 127
+    E2_BIAS: tl.constexpr = 1
+
+    # Denormal numbers
+    # If exponent is less than 127, then it's a denormal number
+    # See above, for denormal number mantissa is always 1 and we set bit 1 of mantissa
+    adjusted_exponents = tl.core.sub(E8_BIAS, e + 1, sanitize_overflow=False)
+    m = tl.where(e < E8_BIAS, (0x400000 | (m >> 1)) >> adjusted_exponents, m)
+    # For normal numbers, bias is changed from 127 to 1, and for subnormals, we keep exponent as 0.
+    # Note: E8_BIAS - E2_BIAS = 126, so for normals we subtract that.
+    e = tl.maximum(e, E8_BIAS - E2_BIAS) - (E8_BIAS - E2_BIAS)
+
+    # Combine sign, exponent, and mantissa, while saturating
+    # rounding nearest with tie breaking up by adding +1 to one bit right of the LSB, then shift right
+    e2m1_tmp = tl.minimum((((e << 2) | (m >> 21)) + 1) >> 1, 0x7)
+    e2m1_value = ((s >> 28) | e2m1_tmp).to(tl.uint8)
+    e2m1_value = tl.reshape(
+        e2m1_value, [BLOCK_SIZE_M, NUM_QUANT_BLOCKS, MXFP4_QUANT_BLOCK_SIZE // 2, 2]
+    )
+    evens, odds = tl.split(e2m1_value)
+    x_fp4 = evens | (odds << 4)
+    x_fp4 = x_fp4.reshape(BLOCK_SIZE_M, BLOCK_SIZE_N // 2)
+
+    return x_fp4, bs_e8m0.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS)
+
+
 @triton.heuristics(
     {
         "EVEN_M_N": lambda args: args["M"] % args["BLOCK_SIZE_M"] == 0
@@ -200,6 +273,8 @@ def _dynamic_mxfp4_quant_kernel(
     stride_bs_m = tl.cast(stride_bs_m_in, tl.int64)
     stride_bs_n = tl.cast(stride_bs_n_in, tl.int64)
 
+    NUM_QUANT_BLOCKS: tl.constexpr = BLOCK_SIZE_N // MXFP4_QUANT_BLOCK_SIZE
+
     for pid_n in tl.range(start_n, min(start_n + NUM_ITER, N), num_stages=NUM_STAGES):
         x_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         x_offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
@@ -213,63 +288,9 @@ def _dynamic_mxfp4_quant_kernel(
                 tl.float32
             )
 
-        NUM_QUANT_BLOCKS: tl.constexpr = BLOCK_SIZE_N // MXFP4_QUANT_BLOCK_SIZE
-        x = x.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS, MXFP4_QUANT_BLOCK_SIZE)
-        # Calculate scale
-        amax = tl.max(tl.abs(x), axis=-1, keep_dims=True)
-        amax = amax.to(tl.int32, bitcast=True)
-        amax = (amax + 0x200000).to(tl.uint32, bitcast=True) & 0xFF800000
-        amax = amax.to(tl.float32, bitcast=True)
-        scale_e8m0_unbiased = tl.log2(amax).floor() - 2
-        scale_e8m0_unbiased = tl.clamp(scale_e8m0_unbiased, min=-127, max=127)
-
-        # blockscale_e8m0
-        bs_e8m0 = scale_e8m0_unbiased.to(tl.uint8) + 127  # in fp32, we have 2&(e - 127)
-
-        quant_scale = tl.exp2(-scale_e8m0_unbiased)
-
-        # Compute quantized x
-        qx = x * quant_scale
-
-        # Convert quantized fp32 tensor to uint32 before converting to mxfp4 format
-        # Note: MXFP4  S:1-bit, E:2-bit, M:1-bit
-        #   Zeros: S000 -> +/-0
-        #   Denormal Numbers: S001 -> +/- 0.5
-        #   Normal Numbers:
-        #           S010 -> +/- 1.0
-        #           S011 -> +/- 1.5
-        #           S100 -> +/- 2.0
-        #           S101 -> +/- 3.0
-        #           S110 -> +/- 4.0
-        #           S111 -> +/- 6.0
-        qx = qx.to(tl.uint32, bitcast=True)
-
-        # Extract sign, exponents and mantissa fields from FP32
-        s = qx & 0x80000000
-        e = (qx >> 23) & 0xFF
-        m = qx & 0x7FFFFF
-        E8_BIAS: tl.constexpr = 127
-        E2_BIAS: tl.constexpr = 1
-
-        # Denormal numbers
-        # If exponent is less than 127, then it's a denormal number
-        # See above, for denormal number mantissa is always 1 and we set bit 1 of mantissa
-        adjusted_exponents = tl.core.sub(E8_BIAS, e + 1, sanitize_overflow=False)
-        m = tl.where(e < E8_BIAS, (0x400000 | (m >> 1)) >> adjusted_exponents, m)
-        # For normal numbers, bias is changed from 127 to 1, and for subnormals, we keep exponent as 0.
-        # Note: E8_BIAS - E2_BIAS = 126, so for normals we subtract that.
-        e = tl.maximum(e, E8_BIAS - E2_BIAS) - (E8_BIAS - E2_BIAS)
-
-        # Combine sign, exponent, and mantissa, while saturating
-        # rounding nearest with tie breaking up by adding +1 to one bit right of the LSB, then shift right
-        e2m1_tmp = tl.minimum((((e << 2) | (m >> 21)) + 1) >> 1, 0x7)
-        e2m1_value = ((s >> 28) | e2m1_tmp).to(tl.uint8)
-        e2m1_value = tl.reshape(
-            e2m1_value, [BLOCK_SIZE_M, NUM_QUANT_BLOCKS, MXFP4_QUANT_BLOCK_SIZE // 2, 2]
+        out_tensor, bs_e8m0 = _mxfp4_quant_op(
+            x, BLOCK_SIZE_N, BLOCK_SIZE_M, MXFP4_QUANT_BLOCK_SIZE
         )
-        evens, odds = tl.split(e2m1_value)
-        out_tensor = evens | (odds << 4)
-        out_tensor = out_tensor.reshape(BLOCK_SIZE_M, BLOCK_SIZE_N // 2)
 
         out_offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         out_offs_n = pid_n * BLOCK_SIZE_N // 2 + tl.arange(0, BLOCK_SIZE_N // 2)
@@ -287,14 +308,14 @@ def _dynamic_mxfp4_quant_kernel(
         bs_offs_n = pid_n * NUM_QUANT_BLOCKS + tl.arange(0, NUM_QUANT_BLOCKS)
         bs_offs = bs_offs_m[:, None] * stride_bs_m + bs_offs_n[None, :] * stride_bs_n
         if EVEN_M_N:
-            tl.store(bs_ptr + bs_offs, bs_e8m0.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS))
+            tl.store(bs_ptr + bs_offs, bs_e8m0)
         else:
             bs_mask = (bs_offs_m < M)[:, None] & (
                 bs_offs_n < (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
             )[None, :]
             tl.store(
                 bs_ptr + bs_offs,
-                bs_e8m0.reshape(BLOCK_SIZE_M, NUM_QUANT_BLOCKS),
+                bs_e8m0,
                 mask=bs_mask,
             )
 

--- a/op_tests/triton_tests/test_activation.py
+++ b/op_tests/triton_tests/test_activation.py
@@ -1,0 +1,72 @@
+import torch
+import torch.nn.functional as F
+import pytest
+from .test_quant_mxfp4 import torch_dynamic_mxfp4_quant
+from aiter.ops.triton.activation import act_mul_and_mxfp4_quant
+
+DEBUG_MODE = True
+
+
+def torch_silu_mul_and_mxfp4_quant(
+    input: torch.Tensor, activation: str
+) -> torch.Tensor:
+    """
+    The fused kernel casts the original input to float32 and does all the arithmetic
+    and bit operations in float32.
+    """
+    input = input.to(torch.float32)
+    d = input.shape[-1] // 2
+    x, y = input.split([d, d], dim=-1)
+    if activation == "silu":
+        out = F.silu(x) * y
+    elif activation == "gelu":
+        out = F.gelu(x) * y
+    else:
+        out = F.gelu(x, approximate="tanh") * y
+    return torch_dynamic_mxfp4_quant(out)
+
+
+@pytest.mark.parametrize(
+    "M, N",
+    [
+        (1, 4),
+        (1, 28),
+        (1, 32),
+        (1, 64),
+        (1, 68),
+        (2, 4),
+        (2, 28),
+        (2, 32),
+        (2, 64),
+        (2, 68),
+        (128, 4),
+        (128, 28),
+        (128, 32),
+        (128, 64),
+        (128, 68),
+        (256, 32),
+        (160, 40),
+        (280, 20),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("activation", ["silu", "gelu", "gelu_tanh"])
+def test_act_mul_and_mxfp4_quant(M: int, N: int, dtype, activation: str):
+    torch.manual_seed(20)
+    x = torch.randn((M, N), dtype=dtype, device="cuda")
+
+    if DEBUG_MODE:
+        print(f"x.shape={x.shape} x={x}")
+
+    triton_out, triton_scale = act_mul_and_mxfp4_quant(x, activation=activation)
+    if DEBUG_MODE:
+        print(f"triton_out.shape={triton_out.shape} triton_out={triton_out}")
+        print(f"triton_scale.shape={triton_scale.shape} triton_scale={triton_scale}")
+
+    torch_out, torch_scale = torch_silu_mul_and_mxfp4_quant(x, activation=activation)
+    if DEBUG_MODE:
+        print(f"torch_out.shape={torch_out.shape} torch_out={torch_out}")
+        print(f"torch_scale.shape={torch_scale.shape} torch_scale={torch_scale}")
+
+    torch.testing.assert_close(triton_out, torch_out)
+    torch.testing.assert_close(triton_scale, torch_scale)


### PR DESCRIPTION
This PR adds a new triton kernel (aiter/ops/triton/activation.py) that supports fused activation and mxfp4 quantization.
Related tests are also added.