### PR TITLE
Improved detection of setup.py install

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -74,9 +74,10 @@ if find_aiter is not None:
 
     site_packages_dirs = site.getsitepackages()
     # develop mode
-    if (package_path not in site_packages_dirs) and (
+    isDevelopMode = (package_path not in site_packages_dirs) and (
         package_parent_path not in site_packages_dirs
-    ):
+    )
+    if isDevelopMode:
         AITER_META_DIR = AITER_ROOT_DIR
     # install mode
     else:

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -69,11 +69,14 @@ if find_aiter is not None:
     elif find_aiter.origin:
         package_path = find_aiter.origin
     package_path = os.path.dirname(package_path)
+    package_parent_path = os.path.dirname(package_path)
     import site
 
     site_packages_dirs = site.getsitepackages()
     # develop mode
-    if package_path not in site_packages_dirs:
+    if (package_path not in site_packages_dirs) and (
+        package_parent_path not in site_packages_dirs
+    ):
         AITER_META_DIR = AITER_ROOT_DIR
     # install mode
     else:


### PR DESCRIPTION
Without this change, I am seeing system-wide install of aiter (python3 setup.py install) misidentified as setup.py develop. This leads to AITER_ASM_DIR being incorrectly set, which leads to a general failure when aiter can't find precompiled kernel .co objects.