### PR TITLE
Add namespace to avoid vllm symbol conflict

### DIFF
--- a/csrc/include/custom.h
+++ b/csrc/include/custom.h
@@ -3,6 +3,8 @@
 // Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 #include <torch/extension.h>
 
+namespace aiter {
+
 void wvSpltK(at::Tensor& in_a,
              at::Tensor& in_b,
              at::Tensor& out_c,
@@ -23,3 +25,4 @@ void wvSplitKQ(at::Tensor& in_a,
                at::Tensor& scale_a,
                at::Tensor& scale_b,
                const int64_t CuCount);
+} // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -265,19 +265,19 @@
 
 #define CUSTOM_PYBIND                                                                           \
     m.def("wvSpltK",                                                                            \
-          &wvSpltK,                                                                             \
+          &aiter::wvSpltK,                                                                             \
           "wvSpltK(Tensor in_a, Tensor in_b, Tensor! out_c, int N_in,"                          \
           "        int CuCount) -> ()");                                                        \
     m.def("wv_splitk_small_fp16_bf16",                                                          \
-          &wv_splitk_small_fp16_bf16_wrapper,                                                   \
+          &aiter::wv_splitk_small_fp16_bf16_wrapper,                                                   \
           "wv_splitk_small_fp16_bf16(Tensor in_a, Tensor in_b, Tensor! out_c, int N_in,"        \
           "        int CuCount) -> ()");                                                        \
     m.def("LLMM1",                                                                              \
-          &LLMM1,                                                                               \
+          &aiter::LLMM1,                                                                               \
           "LLMM1(Tensor in_a, Tensor in_b, Tensor! out_c, int rows_per_block) -> "              \
           "()");                                                                                \
     m.def("wvSplitKQ",                                                                          \
-          &wvSplitKQ,                                                                           \
+          &aiter::wvSplitKQ,                                                                           \
           "wvSplitKQ(Tensor in_a, Tensor in_b, Tensor! out_c, Tensor scale_a, Tensor scale_b, " \
           "int CuCount) -> ()");
 
@@ -549,7 +549,7 @@
           py::arg("a2_scale")       = std::nullopt,  \
           py::arg("block_m")        = 32,            \
           py::arg("sorted_weights") = std::nullopt); \
-                                                  
+
 #define MHA_VARLEN_FWD_PYBIND                        \
       m.def("mha_varlen_fwd",                        \
           &aiter::torch_itfs::mha_varlen_fwd,        \

--- a/csrc/kernels/custom_kernels.cu
+++ b/csrc/kernels/custom_kernels.cu
@@ -37,6 +37,8 @@
 #define UNREACHABLE_CODE assert(false);
 #endif
 
+namespace aiter {
+
 template <typename T>
 struct scalar
 {
@@ -2473,3 +2475,4 @@ void MMGPUKernel(float* in_a,
     if(cudaSuccess != err)
         throw std::runtime_error("CUDA kernel failed : " + std::to_string(err));
 }
+} // namespace aiter

--- a/csrc/py_itfs_cu/custom.cu
+++ b/csrc/py_itfs_cu/custom.cu
@@ -21,6 +21,8 @@
 #include <cuda_runtime.h>
 #include "py_itfs_common.h"
 
+namespace aiter {
+
 // declare templates for front (cpp) and back (cuda) sides of function:
 // template <typename T>
 
@@ -239,3 +241,4 @@ void MMCustomGPU(at::Tensor& in_a, at::Tensor& in_b, at::Tensor& out_c)
                 matO_sizes[1],
                 at::cuda::getCurrentCUDAStream());
 }
+} // namespace aiter


### PR DESCRIPTION
Again, symbol conflict with vllm. 

I think we should add proper namespace to all symbols to avoid conflict. 