### PR TITLE
Find executable in rocm home when not found in PATH

### DIFF
--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
-import os
 import functools
+import os
 import subprocess
 
-from aiter.jit.utils.cpp_extension import executable_path
+from cpp_extension import executable_path
 
 
 @functools.lru_cache(maxsize=1)
@@ -13,7 +13,9 @@ def get_gfx():
     if gfx == "native":
         try:
             rocminfo = executable_path("rocminfo")
-            result = subprocess.run([rocminfo], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            result = subprocess.run(
+                [rocminfo], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
             output = result.stdout
             for line in output.split("\n"):
                 if "gfx" in line.lower():

--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -4,15 +4,16 @@ import os
 import functools
 import subprocess
 
+from aiter.jit.utils.cpp_extension import executable_path
+
 
 @functools.lru_cache(maxsize=1)
 def get_gfx():
     gfx = os.getenv("GPU_ARCHS", "native")
     if gfx == "native":
         try:
-            result = subprocess.run(
-                ["rocminfo"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
+            rocminfo = executable_path("rocminfo")
+            result = subprocess.run([rocminfo], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
             output = result.stdout
             for line in output.split("\n"):
                 if "gfx" in line.lower():

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -64,9 +64,31 @@ __all__ = [
 ]
 
 
+def executable_path(executable: str) -> str:
+    """
+    Return the path to the executable.
+
+    Args:
+        executable (str): The name of the executable.
+
+    Returns:
+        The path to the executable.
+    """
+    path = shutil.which(executable)
+    if not path:
+        home = _find_rocm_home()
+        if home:
+            path = shutil.which(os.path.join(home, "bin", executable))
+        assert (
+            path is not None
+        ), f"Could not find {executable} in PATH or ROCM_HOME({home})"
+    return os.path.realpath(path)
+
+
 def get_hip_version():
     try:
-        output = subprocess.check_output(["hipconfig", "--version"], text=True)
+        hipconfig = executable_path("hipconfig")
+        output = subprocess.check_output([hipconfig, "--version"], text=True)
         return output
     except Exception:
         raise RuntimeError("ROCm version file not found")


### PR DESCRIPTION
In my production environment, we don't have rocm/bin in PATH, but the rocm is installed at the place _find_rocm_home can find it.
So add executable_path function to lookup the executable in ROCM/bin dir when it is not found in the PATH