### PR TITLE
Generate instance for MoE CK 2-stage

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -314,7 +314,7 @@
         "extra_ldflags": "None",
         "extra_include": [],
         "verbose": "False",
-        "blob_gen_cmd": "''"
+        "blob_gen_cmd": "f'{AITER_CSRC_DIR}//ck_gemm_moe_2stages_codegen/gen_instances.py --working_path {{}}'"
     },
     "module_moe_sorting": {
         "srcs": [


### PR DESCRIPTION
Gen command is missed, for MoE module.