### PR TITLE
[fix]: elementwise prebuild slow

### DIFF
--- a/csrc/kernels/generate_binaryop.py
+++ b/csrc/kernels/generate_binaryop.py
@@ -431,10 +431,7 @@ if __name__ == "__main__":
             "float32",
             "bfloat16",
             "float16",
-            "float64",
-            "bool",
             "int32",
-            "int64",
         ]
         tmp_str = ""
         for input_dtype in all_type:


### PR DESCRIPTION
delete bool, int64, float64 dtypes in prebuild