### PR TITLE
Fix Triton compilation error in remap_xcd function

### DIFF
--- a/aiter/ops/triton/utils/pid_preprocessing.py
+++ b/aiter/ops/triton/utils/pid_preprocessing.py
@@ -42,14 +42,9 @@ def remap_xcd(pid, GRID_MN, NUM_XCDS: tl.constexpr = 8):
     # Note that we need to consider the following two cases:
     # 1. the current pid is on a tall xcd
     # 2. the current pid is on a short xcd
-    if xcd < tall_xcds:
-        pid = xcd * pids_per_xcd + local_pid
-    else:
-        pid = (
-            tall_xcds * pids_per_xcd
-            + (xcd - tall_xcds) * (pids_per_xcd - 1)
-            + local_pid
-        )
+    # FIX compilation issue
+    u = min(xcd, tall_xcds)
+    pid = u * pids_per_xcd + (xcd - u) * (pids_per_xcd - 1) + local_pid
 
     return pid
 


### PR DESCRIPTION
# Fix Triton compilation error on Triton 3.0.0 in remap_xcd function

## Problem
The current `remap_xcd` function causes a Triton compilation error in Triton v3.0.0:
```
error: operand #1 does not dominate this use
```

This error occurs because the variable `pid` is assigned in different conditional branches.

## Solution
Replace the if/else conditional assignment with a single mathematical expression using the `min()` function, similar to the approach used in the original `remap_XCD` function.

### Before:
```python
if xcd < tall_xcds:
    pid = xcd * pids_per_xcd + local_pid
else:
    pid = (
        tall_xcds * pids_per_xcd
        + (xcd - tall_xcds) * (pids_per_xcd - 1)
        + local_pid
    )
```

### After:
```python
u = min(xcd, tall_xcds)
pid = u * pids_per_xcd + (xcd - u) * (pids_per_xcd - 1) + local_pid
```

## Testing
- [x] Tested with the original failing case
- [x] Confirms compilation now succeeds
- [x] Verified identical mathematical behavior

## Logic Verification
The single expression maintains identical behavior:
- When `xcd < tall_xcds`: `u = xcd`, so `(xcd - u) = 0`, giving us `xcd * pids_per_xcd + local_pid`
- When `xcd >= tall_xcds`: `u = tall_xcds`, so we get `tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid`

## Related Issues
Fixes compilation errors in MHA operations when using Triton JIT compilation.

## Environment Tested
- Triton: 3.0.0
