### PR TITLE
Fix scale preshuffling 

### DIFF
--- a/aiter/ops/triton/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gemm_afp4wfp4.py
@@ -342,14 +342,6 @@ def _gemm_afp4_wfp4_kernel_preshuffled_scales(
                 .reshape(BLOCK_SIZE_N, BLOCK_SIZE_K // SCALE_GROUP_SIZE)
             )
 
-            if BLOCK_SIZE_M >= 32:
-                a_scales = tl.reshape(
-                    a_scales, (BLOCK_SIZE_M, BLOCK_SIZE_K // SCALE_GROUP_SIZE)
-                )
-            b_scales = tl.reshape(
-                b_scales, (BLOCK_SIZE_N, BLOCK_SIZE_K // SCALE_GROUP_SIZE)
-            )
-
             # Load the next block of A and B, generate a mask by checking the K dimension.
             # If it is out of bounds, set it to 0.
             if EVEN_K:

--- a/op_tests/triton_tests/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/test_gemm_afp4wfp4.py
@@ -192,6 +192,9 @@ def test_gemm_afp4_wfp4(M: int, N: int, K: int, dtype, output):
         pytest.skip("MXFP4 not supported on this architecture")
 
     if TRITON_HIP_PRESHUFFLE_SCALES:
+        if M < 32:
+            pytest.skip("Minimal tile size for preshuffling is 32x32x256")
+
         if N % 32 > 0:
             pytest.skip(
                 f"N = {N} is not divisible by 32, skip this test for preshuffled scales tests"


### PR DESCRIPTION
This PR changes preshuffling kernel to "unshuffle" scales which are preshuffled in global memory.
This way no compiler changes are needed. This PR also adds efficient shuffling for mfma32 instructions.