### PR TITLE
fix missing-braces warning

### DIFF
--- a/csrc/cpp_itfs/pa/pa_kernels.cuh
+++ b/csrc/cpp_itfs/pa/pa_kernels.cuh
@@ -407,8 +407,8 @@ __inline__ __device__ void _paged_attention_kernel(
     }
 
     // calculate qk_max and exp_sum per warp and write to shared memory
-    float qk_max[GQA_RATIO_LOOP][MTP_PER_THREAD] = {-FLT_MAX};
-    float exp_sum[GQA_RATIO_LOOP][MTP_PER_THREAD] = {0.0f};
+    float qk_max[GQA_RATIO_LOOP][MTP_PER_THREAD] = {{-FLT_MAX}};
+    float exp_sum[GQA_RATIO_LOOP][MTP_PER_THREAD] = {{0.0f}};
 
     for (int mtp = 0; mtp < mtp_loop; mtp++) {
         for (int gqa_ratio_loop = 0; gqa_ratio_loop < GQA_RATIO_LOOP; gqa_ratio_loop++) {
@@ -459,9 +459,9 @@ __inline__ __device__ void _paged_attention_kernel(
     __syncthreads();
 
     // calculate partition qk_max and exp_sum
-    float inv_sum_scale[GQA_RATIO_LOOP][MTP_PER_THREAD] = {0.0f};
-    float partition_qk_max[GQA_RATIO_LOOP][MTP_PER_THREAD] = {-FLT_MAX};
-    float partition_exp_sum[GQA_RATIO_LOOP][MTP_PER_THREAD] = {0.0f};
+    float inv_sum_scale[GQA_RATIO_LOOP][MTP_PER_THREAD] = {{0.0f}};
+    float partition_qk_max[GQA_RATIO_LOOP][MTP_PER_THREAD] = {{-FLT_MAX}};
+    float partition_exp_sum[GQA_RATIO_LOOP][MTP_PER_THREAD] = {{0.0f}};
 
     for(int mtp = 0; mtp < mtp_loop; mtp++) {
         for(int gqa_ratio_loop = 0; gqa_ratio_loop < GQA_RATIO_LOOP; gqa_ratio_loop++) {

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -34,6 +34,7 @@ AITER_ROOT_DIR = os.environ.get("AITER_ROOT_DIR", f"{HOME_PATH}/.aiter")
 BUILD_DIR = os.path.abspath(os.path.join(AITER_ROOT_DIR, "build"))
 AITER_LOG_MORE = int(os.getenv("AITER_LOG_MORE", 0))
 AITER_DEBUG = int(os.getenv("AITER_DEBUG", 0))
+AITER_PREBUILT_SO_DIR = os.environ.get("AITER_PREBUILT_SO_DIR", None)
 
 if AITER_REBUILD >= 1:
     subprocess.run(f"rm -rf {BUILD_DIR}/*", shell=True)
@@ -213,7 +214,11 @@ def compile_lib(src_file, folder, includes=None, sources=None, cxxflags=None):
 def run_lib(func_name, folder=None):
     if folder is None:
         folder = func_name
-    lib = ctypes.CDLL(f"{BUILD_DIR}/{folder}/lib.so", os.RTLD_LAZY)
+    if AITER_PREBUILT_SO_DIR is not None:
+        lib_path = f"{AITER_PREBUILT_SO_DIR}/{func_name}.so"
+    else:
+        lib_path = f"{BUILD_DIR}/{folder}/lib.so"
+    lib = ctypes.CDLL(lib_path, os.RTLD_LAZY)
     return getattr(lib, func_name)
 
 
@@ -228,6 +233,8 @@ def get_default_func_name(md_name, args: tuple):
 
 
 def not_built(folder):
+    if AITER_PREBUILT_SO_DIR is not None:
+        return not os.path.exists(f"{AITER_PREBUILT_SO_DIR}/{folder}.so")
     return not os.path.exists(f"{BUILD_DIR}/{folder}/lib.so")
 
 


### PR DESCRIPTION
Fix the following warning/error during build.
```
csrc/cpp_itfs/pa/pa_kernels.cuh:403:54: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
  403 |     float exp_sum[GQA_RATIO_LOOP][MTP_PER_THREAD] = {0.0f};
      |                                                      ^~~~
      |
```