### PR TITLE
allow passing in AITER_CORE_DIR as env var

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -16,6 +16,7 @@ import time
 logger = logging.getLogger("aiter")
 this_dir = os.path.dirname(os.path.abspath(__file__))
 AITER_CORE_DIR = os.path.abspath(f"{this_dir}/../../")
+AITER_CORE_DIR = os.environ.get("AITER_CORE_DIR", AITER_CORE_DIR)
 if os.path.exists(os.path.join(AITER_CORE_DIR, "aiter_meta")):
     AITER_CORE_DIR = os.path.join(AITER_CORE_DIR, "aiter_meta")
 DEFAULT_GPU_ARCH = (


### PR DESCRIPTION
Due to python package packing, we need to specify a different dir as the core dir in our prod env.