### PR TITLE
[TRITON]: Bias and backward support in AITER

### DIFF
--- a/aiter/ops/triton/configs/MI350X-REDUCE-DB.json
+++ b/aiter/ops/triton/configs/MI350X-REDUCE-DB.json
@@ -1,0 +1,10 @@
+{
+  "any": {
+    "BLOCK_SIZE_M": 512,
+    "BLOCK_SIZE_N": 64,
+    "NUM_MSPLIT": 8,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2
+  }
+}

--- a/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-ATOMIC-M=1536-N=512.json
+++ b/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-ATOMIC-M=1536-N=512.json
@@ -1,0 +1,15 @@
+{
+  "any": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 4,
+    "NUM_KSPLIT": 20,
+    "cache_modifier": null,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-ATOMIC-M=512-N=2048.json
+++ b/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-ATOMIC-M=512-N=2048.json
@@ -1,0 +1,16 @@
+{
+  "any": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 4,
+    "NUM_KSPLIT": 16,
+    "cache_modifier": null,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 1,
+    "DISABLE_BUFFER_LOADS": true
+  }
+}

--- a/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-N=1536-K=512.json
+++ b/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-N=1536-K=512.json
@@ -1,0 +1,74 @@
+{
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_2048": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "kpack": 1
+  },
+  "M_GEQ_4096": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 32,
+    "cache_modifier": null,
+    "kpack": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-N=2048-K=512.json
+++ b/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-N=2048-K=512.json
@@ -1,0 +1,74 @@
+{
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_2048": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "kpack": 1
+  },
+  "M_GEQ_4096": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 32,
+    "cache_modifier": null,
+    "kpack": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-N=2048-K=971541.json
+++ b/aiter/ops/triton/configs/gemm/MI350X-GEMM-A16W16-N=2048-K=971541.json
@@ -1,0 +1,75 @@
+{
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "kpack": 1,
+    "DISABLE_BUFFER_LOADS": true
+  },
+  "M_LEQ_2048": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "kpack": 1
+  },
+  "M_GEQ_4096": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "kpack": 1
+  }
+}

--- a/aiter/ops/triton/gemm_a16w16_atomic.py
+++ b/aiter/ops/triton/gemm_a16w16_atomic.py
@@ -18,9 +18,7 @@ _LOGGER = AiterTritonLogger()
 
 @triton.heuristics(
     {
-        "EVEN_K": lambda args: (args["K"] % (args["BLOCK_SIZE_K"]) == 0)
-        and (args["SPLITK_BLOCK_SIZE"] % args["BLOCK_SIZE_K"] == 0)
-        and (args["K"] % (args["SPLITK_BLOCK_SIZE"]) == 0),
+        "EVEN_K": lambda args: (args["K"] % (args["BLOCK_SIZE_K"]) == 0),
         "GRID_MN": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
         * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
     }
@@ -45,7 +43,7 @@ def _gemm_a16_w16_atomic_kernel(
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     NUM_KSPLIT: tl.constexpr,
-    SPLITK_BLOCK_SIZE: tl.constexpr,
+    DISABLE_BUFFER_LOADS: tl.constexpr,
     cache_modifier: tl.constexpr,
     EVEN_K: tl.constexpr,
     GRID_MN: tl.constexpr,
@@ -54,12 +52,13 @@ def _gemm_a16_w16_atomic_kernel(
     A has shape (M, K), B has shape (K, N) and C has shape (M, N)
     """
 
-    tl.assume(stride_am > 0)
-    tl.assume(stride_ak > 0)
-    tl.assume(stride_bk > 0)
-    tl.assume(stride_bn > 0)
-    tl.assume(stride_cm > 0)
-    tl.assume(stride_cn > 0)
+    if not DISABLE_BUFFER_LOADS:
+        tl.assume(stride_am > 0)
+        tl.assume(stride_ak > 0)
+        tl.assume(stride_bk > 0)
+        tl.assume(stride_bn > 0)
+        tl.assume(stride_cm > 0)
+        tl.assume(stride_cn > 0)
 
     # -----------------------------------------------------------
     # Map program ids `pid` to the block of C it should compute.
@@ -80,55 +79,54 @@ def _gemm_a16_w16_atomic_kernel(
     tl.assume(pid_m >= 0)
     tl.assume(pid_n >= 0)
     tl.assume(pid_k >= 0)
-    if (pid_k * SPLITK_BLOCK_SIZE) < K:
-        num_k_iter = tl.cdiv(SPLITK_BLOCK_SIZE, BLOCK_SIZE_K)
 
-        # Create pointers for first block of A and B input matrices
-        offs_k = tl.arange(0, BLOCK_SIZE_K)
-        offs_k_split = pid_k * (SPLITK_BLOCK_SIZE) + offs_k
-        offs_am = (pid_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
-        offs_bn = (pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
-        a_ptrs = a_ptr + (
-            offs_am[:, None] * stride_am + offs_k_split[None, :] * stride_ak
-        )
-        b_ptrs = b_ptr + (
-            offs_k_split[:, None] * stride_bk + offs_bn[None, :] * stride_bn
-        )
+    num_k_iter = tl.cdiv(K, NUM_KSPLIT * BLOCK_SIZE_K)
 
-        acc_dtype = tl.float32 if c_ptr.type.element_ty != tl.int8 else tl.int32
-        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+    # Create pointers for first block of A and B input matrices
+    offs_k = pid_k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+    offs_am = (pid_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    a_ptrs = a_ptr + (
+        offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+    ).to(tl.int64)
+    b_ptrs = b_ptr + (
+        offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+    ).to(tl.int64)
 
-        for k in range(pid_k * num_k_iter, (pid_k + 1) * num_k_iter):
-            # Load the next block of A and B, generate a mask by checking the K dimension.
-            # If it is out of bounds, set it to 0.
-            if EVEN_K:
-                a = tl.load(a_ptrs)
-                b = tl.load(b_ptrs, cache_modifier=cache_modifier)
-            else:
-                a = tl.load(
-                    a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0
-                )
-                b = tl.load(
-                    b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
-                )
+    acc_dtype = tl.float32 if c_ptr.type.element_ty != tl.int8 else tl.int32
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
-            accumulator += tl.dot(a, b, input_precision="ieee")
+    for k in range(num_k_iter - 1):
+        # Load the next block of A and B, generate a mask by checking the K dimension.
+        # If it is out of bounds, set it to 0.
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs, cache_modifier=cache_modifier)
 
-            # Advance the ptrs to the next K block.
-            a_ptrs += BLOCK_SIZE_K * stride_ak
-            b_ptrs += BLOCK_SIZE_K * stride_bk
+        accumulator += tl.dot(a, b, input_precision="ieee")
 
-        c = accumulator.to(c_ptr.type.element_ty)
+        # Advance the ptrs to the next K block.
+        a_ptrs += (NUM_KSPLIT * BLOCK_SIZE_K) * stride_ak
+        b_ptrs += (NUM_KSPLIT * BLOCK_SIZE_K) * stride_bk
 
-        # Write back the block of the output matrix C with masks.
-        offs_cm = pid_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-        offs_cn = pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-        if NUM_KSPLIT == 1:
-            tl.store(c_ptrs, c, mask=c_mask)
-        else:
-            tl.atomic_add(c_ptrs, c, mask=c_mask, sem="relaxed")
+    a = tl.load(
+        a_ptrs, mask=offs_k[None, :] < K - (num_k_iter - 1) * (NUM_KSPLIT * BLOCK_SIZE_K), other=0.0
+    )
+    b = tl.load(
+        b_ptrs, mask=offs_k[:, None] < K - (num_k_iter - 1) * (NUM_KSPLIT * BLOCK_SIZE_K), other=0.0
+    )
+    accumulator += tl.dot(a, b, input_precision="ieee")
+
+    c = accumulator.to(c_ptr.type.element_ty)
+
+    # Write back the block of the output matrix C with masks.
+    offs_cm = pid_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    if NUM_KSPLIT == 1:
+        tl.store(c_ptrs, c, mask=c_mask)
+    else:
+        tl.atomic_add(c_ptrs, c, mask=c_mask, sem="relaxed")
 
 
 @functools.lru_cache(maxsize=1024)
@@ -155,22 +153,35 @@ def _get_config(
                 _get_config._config_dict[key] = config
         else:
             key = "default"  # fall back to default config
-            # single config. for the default path
-            return _get_config._config_dict[key]["any"]
-    if M < 32:
+
+    if key == "default":
+        key = f"{M}_{N}"
+        if key not in _get_config._config_dict.keys():
+            dev = arch_info.get_device()
+            fpath = f"{AITER_TRITON_CONFIGS_PATH}/gemm/{dev}-GEMM-A16W16-ATOMIC-M={M}-N={N}.json"
+            if os.path.exists(fpath):
+                with open(fpath, "r") as file:
+                    config = json.load(file)
+                    _get_config._config_dict[key] = config
+            else:
+                key = "default"  # fall back to default config
+
+    if M < 32 and "small" in _get_config._config_dict[key]:
         return _get_config._config_dict[key]["small"]
-    elif M <= 128:
+    elif M >= 32 and M <= 128 and ("medium_M32" in _get_config._config_dict[key] or "medium_M64" in _get_config._config_dict[key] or "medium_M128" in _get_config._config_dict[key]):
         BLK_M = triton.next_power_of_2(M)
-        if BLK_M == 32:
+        if BLK_M == 32 and "medium_M32" in _get_config._config_dict[key]:
             return _get_config._config_dict[key]["medium_M32"]
-        elif BLK_M == 64:
+        elif BLK_M == 64 and "medium_M64" in _get_config._config_dict[key]:
             return _get_config._config_dict[key]["medium_M64"]
-        elif BLK_M == 128:
+        elif BLK_M == 128 and "medium_M128" in _get_config._config_dict[key]:
             return _get_config._config_dict[key]["medium_M128"]
-    elif M <= 256:
+    elif M > 128 and M <= 256 and "large" in _get_config._config_dict[key]:
         return _get_config._config_dict[key]["large"]
-    else:
+    elif M > 256 and "xlarge" in _get_config._config_dict[key]:
         return _get_config._config_dict[key]["xlarge"]
+    else:
+        return _get_config._config_dict[key]["any"]
 
 
 def gemm_a16w16_atomic(
@@ -210,6 +221,8 @@ def gemm_a16w16_atomic(
         config["NUM_KSPLIT"] = 1
     if "cache_modifier" not in config:
         config["cache_modifier"] = ""
+    if "DISABLE_BUFFER_LOADS" not in config:
+        config["DISABLE_BUFFER_LOADS"] = False
 
     if y is None:
         # atomic add requires 0 tensor
@@ -223,10 +236,7 @@ def gemm_a16w16_atomic(
         * triton.cdiv(N, META["BLOCK_SIZE_N"])
         * META["NUM_KSPLIT"],
     )
-    # NOTE: if k split doesnt divide K evenly, this will waste compute
-    SPLITK_BLOCK_SIZE = triton.cdiv(K, config["NUM_KSPLIT"])
-    config["SPLITK_BLOCK_SIZE"] = SPLITK_BLOCK_SIZE
-    _gemm_a16_w16_atomic_kernel[grid](
+    kernel = _gemm_a16_w16_atomic_kernel[grid](
         x,
         w,
         y,

--- a/aiter/ops/triton/gemm_a16w16_autograd.py
+++ b/aiter/ops/triton/gemm_a16w16_autograd.py
@@ -1,0 +1,37 @@
+import torch
+import triton
+from aiter.ops.triton.gemm_a16w16 import gemm_a16w16
+from aiter.ops.triton.gemm_a16w16_atomic import gemm_a16w16_atomic
+from aiter.ops.triton.gemm_a16w16_atomic_fused_db import gemm_a16w16_atomic_fused_db
+from aiter.ops.triton.reduce_db import reduce_db
+
+class TritonGemm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w, b):
+        y = gemm_a16w16(x, w.t(), b)
+        
+        ctx.save_for_backward(x, w, b)
+
+        return y
+
+    @staticmethod
+    def backward(ctx, dy):
+        x, w, b = ctx.saved_tensors
+        dx = dw = db = None
+
+        if ctx.needs_input_grad[0]:
+            dx = gemm_a16w16(dy, w)
+        if ctx.needs_input_grad[1]:
+            dw = gemm_a16w16_atomic(x.t(), dy.t(), dtype=torch.float32).to(torch.bfloat16)
+        if ctx.needs_input_grad[2]:
+            if b.dim() == 1:
+                db = reduce_db(dy).to(torch.bfloat16)
+                #db = dy.sum(0)
+            elif b.dim() == 2:
+                db = dy
+
+        return dx, dw, db
+
+
+def gemm_a16w16_autograd(x, w, b):
+    return TritonGemm.apply(x, w, b)

--- a/aiter/ops/triton/reduce_db.py
+++ b/aiter/ops/triton/reduce_db.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+from typing import Optional
+import functools
+import json
+import os
+import torch
+import triton
+import triton.language as tl
+from aiter.ops.triton.utils.pid_preprocessing import pid_grid, remap_xcd
+import aiter.ops.triton.utils.arch_info as arch_info
+from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+_LOGGER = AiterTritonLogger()
+
+
+@triton.heuristics(
+    {
+        "EVEN_M": lambda args: args["M"] % (args["NUM_MSPLIT"] * args["BLOCK_SIZE_M"]) == 0
+    }
+)
+@triton.jit
+def _reduce_db_kernel(
+    x_ptr,
+    y_ptr,
+    M,
+    N,
+    stride_xm,
+    stride_xn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    NUM_MSPLIT: tl.constexpr,
+    num_stages: tl.constexpr,
+    EVEN_M: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+
+    tl.assume(stride_xm > 0)
+    tl.assume(stride_xn > 0)
+
+    pid_unified = tl.program_id(axis=0)
+    pid_m = pid_unified % NUM_MSPLIT
+    pid_n = pid_unified // NUM_MSPLIT
+
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+
+    num_m_iter = tl.cdiv(M, NUM_MSPLIT * BLOCK_SIZE_M)
+
+    # Create pointers for first block of X
+    offs_xm = pid_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_xn = (pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    x_ptrs = x_ptr + (offs_xm[:, None] * stride_xm + offs_xn[None, :] * stride_xn)
+
+    acc_dtype = tl.float32 if y_ptr.type.element_ty != tl.int8 else tl.int32
+    accumulator = tl.zeros((BLOCK_SIZE_N,), dtype=acc_dtype)
+
+    for m in tl.range(0, num_m_iter, num_stages=num_stages):
+        # Load the next block of X, generate a mask by checking the M dimension.
+        # If M is out of bounds, set it to 0.
+        if EVEN_M:
+            x = tl.load(x_ptrs, cache_modifier=".cg")
+        else:
+            x = tl.load(
+                x_ptrs,
+                mask=offs_xm[:, None] < M - m * (NUM_MSPLIT * BLOCK_SIZE_M),
+                other=0.0,
+                cache_modifier=".cg",
+            )
+
+        accumulator += tl.sum(x, 0, dtype=tl.float32)
+
+        # Advance the ptrs to the next block.
+        x_ptrs += (NUM_MSPLIT * BLOCK_SIZE_M) * stride_xm
+
+    y = accumulator.to(y_ptr.type.element_ty)
+
+    # Write back the block of the output vector Y with masks.
+    offs_yn = pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    y_ptrs = y_ptr + offs_yn
+    y_mask = offs_yn < N
+    if NUM_MSPLIT > 1:
+        tl.atomic_add(y_ptrs, y, mask=y_mask, sem="relaxed")
+    else:
+        tl.store(y_ptrs, y, mask=y_mask)
+ 
+
+@functools.lru_cache(maxsize=1024)
+def _get_config(
+    M: int,
+    N: int,
+):
+    if not hasattr(_get_config, "_config_dict"):
+        dev = arch_info.get_device()
+        _get_config._config_dict = {}
+        fpath = f"{AITER_TRITON_CONFIGS_PATH}/{dev}-REDUCE-DB.json"
+        with open(fpath, "r") as file:
+            config = json.load(file)
+        _get_config._config_dict["default"] = config
+
+    key = "default"
+
+    return _get_config._config_dict[key]["any"]
+
+
+def reduce_db(
+    x,
+    dtype: Optional[float] = torch.float32,
+    y: Optional[torch.Tensor] = None,
+    config: Optional[dict] = None,
+):
+    """
+    Computes the bias reduction across the batch dimension
+
+    Key parameters:
+    - X: Matrix X with shape (M, N).
+    - dtype: Optional parameter to specify datatype. Default is fp32
+    - Y: Output Matrix Y with shape (N,). If this is none, then it's created by this API and returned as output
+
+    Returns:
+    - Y: The output matrix with shape (M, N).
+    """
+
+    _LOGGER.info(f"REDUCE DB: x={tuple(x.shape)}")
+
+    M, N = x.shape
+
+    if y is None:
+        y = torch.zeros((N,), dtype=dtype, device=x.device)
+
+    if config is None:
+        config = _get_config(M, N)
+
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(N, META["BLOCK_SIZE_N"]) * META["NUM_MSPLIT"],
+    )
+    kernel = _reduce_db_kernel[grid](
+        x,
+        y,
+        M,
+        N,
+        x.stride(0),
+        x.stride(1),
+        **config,
+    )
+    #print(kernel.asm['amdgcn'])
+
+    return y
+
+

--- a/op_tests/op_benchmarks/triton/bench_gemm_a16w16.py
+++ b/op_tests/op_benchmarks/triton/bench_gemm_a16w16.py
@@ -38,10 +38,18 @@ def bench_gemm_fn(
     )
     # flops
     flops = 2.0 * M * N * K
+    if BIAS_DIM == 2:
+        flops += M * N
     if activation is not None:
         flops += M * N  # elementwise ops on the GEMM output
     # memory transfer
-    mem_read = (M * K) * x.element_size() + (N * K) * w.element_size()
+    if BIAS_DIM == 1:
+        mem_read_bias = N * b.element_size()
+    elif BIAS_DIM == 2:
+        mem_read_bias = M * N * b.element_size()
+    else:
+        mem_read_bias = 0
+    mem_read = (M * K) * x.element_size() + (N * K) * w.element_size() + mem_read_bias
     mem_write = (M * N) * x.element_size()
     mem = mem_read + mem_write
 

--- a/op_tests/op_benchmarks/triton/bench_gemm_a16w16.py
+++ b/op_tests/op_benchmarks/triton/bench_gemm_a16w16.py
@@ -24,6 +24,7 @@ def bench_gemm_fn(
     M: int,
     N: int,
     K: int,
+    BIAS_DIM: int,
     metric: str,
     layout: str,
     atomic: bool = False,
@@ -32,8 +33,8 @@ def bench_gemm_fn(
 ):
     # NOTE: Assume bias and output has the same dtype
     c_dtype = torch.bfloat16
-    x, w, out_dtype, y = generate_gemm_a16w16_inputs(
-        M, N, K, c_dtype, layout=layout, output=True
+    x, w, b, out_dtype, y = generate_gemm_a16w16_inputs(
+        M, N, K, BIAS_DIM, c_dtype, layout=layout, output=True
     )
     # flops
     flops = 2.0 * M * N * K
@@ -57,7 +58,7 @@ def bench_gemm_fn(
         )
     else:
         ms = triton.testing.do_bench(
-            lambda: gemm_a16w16(x, w, c_dtype, y, activation=activation),
+            lambda: gemm_a16w16(x, w, b, c_dtype, y, activation=activation),
             warmup=25,
             rep=100,  # noqa: E731
         )
@@ -105,10 +106,11 @@ def run_model_benchmark(args):
             N, K = hidden_dim, intermediate_dim
             # Divide K by tensor parallel
             K = math.ceil(K / args.tp)
+        BIAS_DIM = args.bias_dim
         # print(f"Layer: {layer}, M: {M}, N: {N}, K: {K}, hidden_dim: {hidden_dim}, intermediate_dim: {intermediate_dim}")
 
         return bench_gemm_fn(
-            M, N, K, metric, args.layout, atomic=args.atomic, activation=args.activation
+            M, N, K, BIAS_DIM, metric, args.layout, atomic=args.atomic, activation=args.activation
         )
 
     bench_gemm_a16w16.run(save_path="." if args.o else None, print_data=True)
@@ -124,7 +126,8 @@ def run_shape_benchmark(args):
     def bench_gemm_a16w16(M, N, K, metric, **kwargs):
         # Divide N by tensor parallel
         N = math.ceil(N / args.tp)
-        return bench_gemm_fn(M, N, K, metric, args.layout, atomic=args.atomic)
+        BIAS_DIM = args.bias_dim
+        return bench_gemm_fn(M, N, K, BIAS_DIM, metric, args.layout, atomic=args.atomic)
 
     bench_gemm_a16w16.run(save_path="." if args.o else None, print_data=True)
 
@@ -163,6 +166,12 @@ def parse_args():
         action="store_true",
         default=False,
         help="Use the atomic kernel (split-k with atomic_add) instead of the standard a16w16 kernel.",
+    )
+    parser.add_argument(
+        "--bias-dim",
+        type=int,
+        default=0,
+        help="Add bias to result of matmul.",
     )
     parser.add_argument(
         "--activation",

--- a/op_tests/op_benchmarks/triton/bench_reduce_db.py
+++ b/op_tests/op_benchmarks/triton/bench_reduce_db.py
@@ -1,0 +1,137 @@
+import argparse
+import sys
+import torch
+import triton
+import math
+from aiter.ops.triton.reduce_db import reduce_db
+from op_tests.op_benchmarks.triton.utils.argparse import (
+    get_parser
+)
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    print_vgpr
+)
+
+
+def get_shape_benchmark_object(plot_name, args, x_names=None):
+    """
+    Utility function for returning a triton.testing.Benchmark object to populate.
+
+    Note: This is for benchmarking GEMM kernels without the --model flag. The distinction
+    comes in the x_names and x_vals: For models, we use hidden_dim and intermediate_dim
+    as args, but if we're just given a shape, we use M, N, K.
+    """
+    if x_names is None:
+        x_names = ["M", "N"]
+
+    if len(x_names) == len(args.shape):
+        x_vals_list = [args.shape]
+    else:
+        raise ValueError(
+            f"Incompatible --shape provided: {args.shape}. Expected a shape that matches {x_names}."
+        )
+
+    if args.metric == "time":
+        ylabel = "Time (ms)"
+    elif args.metric == "throughput":
+        ylabel = "Throughput (TFLOPS)"
+    elif args.metric == "bandwidth":
+        ylabel = "Bandwidth (GB/s)"
+    else:
+        raise NotImplementedError(f"{args.metric} is not supported")
+
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names,
+        x_vals=x_vals_list,
+        x_log=True,
+        y_log=True,
+        line_arg="provider",
+        line_vals=["Triton"],
+        line_names=["Triton"],
+        styles=[("green", "-")],
+        ylabel=ylabel,
+        plot_name=plot_name,
+        args={"metric": args.metric},
+    )
+    return benchmark
+
+
+def bench_reduce_db_fn(
+    M: int, N: int, metric: str, **kwargs
+):
+    xdtype = torch.bfloat16
+    ydtype = torch.float32
+    x = torch.randn((M, N), dtype=xdtype).cuda()
+    y = torch.zeros((N,), dtype=ydtype).cuda()
+    # flops
+    flops = M * N
+    # memory transfer
+    mem_read = (M * N) * x.element_size()
+    mem_write = N * y.element_size()
+    mem = mem_read + mem_write
+
+    ms = triton.testing.do_bench(
+        lambda: reduce_db(x, ydtype, y), warmup=25, rep=100  # noqa: E731
+    )
+
+    # Return exactly one scalar depending on which metric is active
+    if metric == "time":
+        return ms
+    elif metric == "throughput":
+        tflops = flops / ms * 1e-9
+        return tflops
+    elif metric == "bandwidth":
+        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        return bandwidth
+    else:
+        raise ValueError("Unknown metric: " + metric)
+
+
+def run_shape_benchmark(args):
+    """
+    Runs a benchmark with given tensor shapes.
+    """
+    benchmark = get_shape_benchmark_object("REDUCE DB Benchmark", args)
+
+    @triton.testing.perf_report([benchmark])
+    def bench_reduce_db(M, N, metric, **kwargs):
+        return bench_reduce_db_fn(M, N, metric)
+
+    bench_reduce_db.run(save_path="." if args.o else None, print_data=True)
+
+
+def run_benchmark(args):
+    run_shape_benchmark(args)
+
+
+def parse_args():
+    parser = get_parser(kernel_name="REDUCE DB")
+    parser.add_argument(
+        "--shape",
+        type=int,
+        nargs="+",
+        metavar=("DIM"),
+        help="user-defined shape to benchmark",
+    )
+    parser.add_argument(
+        "-print_vgpr",
+        action="store_true",
+        help="Print VGPR usage for Triton kernels.",
+    )
+    parser.add_argument(
+        "-o", action="store_true", help="Write performance results to CSV file"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.print_vgpr:
+        print("Retrieving VGPR usage for Triton kernels...")
+        fun = lambda: run_benchmark(args, defaults)  # noqa: E731
+        print_vgpr(fun, "GEMM")
+        return 0
+    run_benchmark(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds several features to AITER:

- 1D bias and 2D bias/residual support for gemm kernels + correctness tests
- new atomic gemm implementation that works for uneven K + a couple tuned configs
- db reduction kernel + microbench
- gemm autograd wrapper that computes all of y, dx, dw, db in AITER/triton + correctness tests