### PR TITLE
[TRITON] Add non-TN layout tests to Triton GEMMs

### DIFF
--- a/op_tests/triton_tests/test_batched_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/test_batched_gemm_afp4wfp4.py
@@ -188,14 +188,15 @@ def run_torch(x, w, x_scales, w_scales, dtype):
 
 @pytest.mark.parametrize("B, M, N, K", get_x_vals())
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_batched_gemm_afp4_wfp4(B: int, M: int, N: int, K: int, dtype):
+@pytest.mark.parametrize("layout", ["TN", "TT", "NN", "NT"])
+def test_batched_gemm_afp4_wfp4(B: int, M: int, N: int, K: int, dtype, layout):
     if not (arch_info.is_fp4_avail()):
         pytest.skip("MXFP4 not supported on this architecture")
 
     torch.cuda.empty_cache()  # Helps avoid hangs in large tests
 
     x, w, x_scales, w_scales, out = generate_batched_gemm_afp4wfp4_inputs(
-        B, M, N, K, dtype, output=True
+        B, M, N, K, dtype, layout=layout, output=True
     )
 
     torch_out = run_torch(x, w, x_scales, w_scales, dtype).to(dtype)

--- a/op_tests/triton_tests/test_batched_gemm_afp4wfp4_pre_quant.py
+++ b/op_tests/triton_tests/test_batched_gemm_afp4wfp4_pre_quant.py
@@ -174,14 +174,17 @@ def run_torch(x, w, w_scales, dtype):
 
 @pytest.mark.parametrize("B, M, N, K", get_x_vals())
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_batched_gemm_afp4_wfp4_pre_quant(B: int, M: int, N: int, K: int, dtype):
+@pytest.mark.parametrize("layout", ["TN", "TT", "NN", "NT"])
+def test_batched_gemm_afp4_wfp4_pre_quant(
+    B: int, M: int, N: int, K: int, layout, dtype
+):
     if not (arch_info.is_fp4_avail()):
         pytest.skip("MXFP4 not supported on this architecture")
 
     torch.cuda.empty_cache()  # Helps avoid hangs in large tests
 
     x, w, x_scales, w_scales, out = generate_batched_gemm_afp4wfp4_pre_quant_inputs(
-        B, M, N, K, dtype, output=True
+        B, M, N, K, dtype, layout=layout, output=True
     )
 
     torch_out = run_torch(x, w, w_scales, dtype).to(dtype)

--- a/op_tests/triton_tests/test_gemm_a16w16_gated.py
+++ b/op_tests/triton_tests/test_gemm_a16w16_gated.py
@@ -40,12 +40,17 @@ def generate_gemm_a16w16_gated_inputs(M, N, K, dtype, layout="TN", output=True):
 )
 @pytest.mark.parametrize("M, N, K", minimal_x_vals())
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("layout", ["TN", "TT", "NN", "NT"])
 @pytest.mark.parametrize("output", [True, False])
-def test_gemm_a16_w16_gated(M: int, N: int, K: int, dtype, output, activation):
+def test_gemm_a16_w16_gated(M: int, N: int, K: int, dtype, output, layout, activation):
     if N % 2 != 0:
         pytest.skip("Skipping shape incompatible w/gating")
+    # This is done to reduce CI execution time
+    if layout != "TN" and activation != "relu":
+        pytest.skip("Skipping non-TN layouts when activation isn't ReLU")
+
     x, w, out_dtype, y = generate_gemm_a16w16_gated_inputs(
-        M, N, K, dtype, output=output
+        M, N, K, dtype, layout=layout, output=output
     )
 
     torch_out = F.linear(x, w, bias=None)

--- a/op_tests/triton_tests/test_gemm_a8w8.py
+++ b/op_tests/triton_tests/test_gemm_a8w8.py
@@ -118,23 +118,30 @@ def generate_gemm_a8w8_inputs(
 
 
 @pytest.mark.parametrize(
-    "in_dtype, out_dtype, m, n, k, output",
+    "in_dtype, out_dtype, m, n, k, layout, output",
     [
-        (in_dtype, out_dtype, *shape, output)
+        (in_dtype, out_dtype, *shape, layout, output)
         for in_dtype in ["fp8e4m3", "fp8e5m2", "int8"]
         for out_dtype in ["bf16"]
         for shape in get_x_vals()
+        for layout in ["TN", "TT", "NN", "NT"]
         for output in [True, False]
     ],
 )
-def test_gemm(in_dtype, out_dtype, m, n, k, output):
+def test_gemm(in_dtype, out_dtype, m, n, k, layout, output):
 
     torch.cuda.empty_cache()  # Helps avoid hangs in large tests
 
     in_dtype = str_to_torch_dtype[in_dtype]
     out_dtype = str_to_torch_dtype[out_dtype]
     x, weight, x_scale, w_scale, bias, y = generate_gemm_a8w8_inputs(
-        M=m, N=n, K=k, in_dtype=in_dtype, out_dtype=out_dtype, output=output
+        M=m,
+        N=n,
+        K=k,
+        in_dtype=in_dtype,
+        out_dtype=out_dtype,
+        layout=layout,
+        output=output,
     )
 
     a = run_torch(x, weight, x_scale, w_scale, bias, out_dtype)

--- a/op_tests/triton_tests/test_gemm_a8w8_blockscale.py
+++ b/op_tests/triton_tests/test_gemm_a8w8_blockscale.py
@@ -133,15 +133,16 @@ def generate_gemm_a8w8_blockscale_inputs(
 
 
 @pytest.mark.parametrize(
-    "dtype, M, N, K, output",
+    "dtype, M, N, K, layout, output",
     [
-        (dtype, *shape, output)
+        (dtype, *shape, layout, output)
         for output in [True, False]
         for dtype in ["bf16"]
+        for layout in ["TN", "TT", "NN", "NT"]
         for shape in get_x_vals()
     ],
 )
-def test_gemm(dtype, M, N, K, output):
+def test_gemm(dtype, M, N, K, layout, output):
     torch.cuda.empty_cache()  # Helps avoid hangs in large tests
 
     block_shape_n, block_shape_k = block_shape
@@ -154,6 +155,7 @@ def test_gemm(dtype, M, N, K, output):
         block_shape_n,
         block_shape_k,
         dtype=dtype,
+        layout=layout,
         output=output,
     )
 

--- a/op_tests/triton_tests/test_gemm_a8w8_per_token_scale.py
+++ b/op_tests/triton_tests/test_gemm_a8w8_per_token_scale.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import torch
 import triton
@@ -109,15 +109,16 @@ def generate_gemm_a8w8_per_token_scale_inputs(
 
 
 @pytest.mark.parametrize(
-    "dtype, M, N, K, output",
+    "dtype, M, N, K, layout, output",
     [
-        (dtype, *shape, output)
+        (dtype, *shape, layout, output)
         for output in [True, False]
         for dtype in ["bf16"]
+        for layout in ["TN", "TT", "NN", "NT"]
         for shape in get_x_vals()
     ],
 )
-def test_gemm(dtype, M, N, K, output):
+def test_gemm(dtype, M, N, K, layout, output):
     torch.cuda.empty_cache()  # Helps avoid hangs in large tests
 
     dtype = str_to_torch_dtype[dtype]
@@ -126,6 +127,7 @@ def test_gemm(dtype, M, N, K, output):
         N,
         K,
         dtype=dtype,
+        layout=layout,
         output=output,
     )
 

--- a/op_tests/triton_tests/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/test_gemm_afp4wfp4.py
@@ -186,8 +186,9 @@ def run_torch(x, w, x_scales, w_scales, dtype):
 
 @pytest.mark.parametrize("M, N, K", get_x_vals())
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("layout", ["TN", "TT", "NN", "NT"])
 @pytest.mark.parametrize("output", [True, False])
-def test_gemm_afp4_wfp4(M: int, N: int, K: int, dtype, output):
+def test_gemm_afp4_wfp4(M: int, N: int, K: int, dtype, layout, output):
     if not (arch_info.is_fp4_avail()):
         pytest.skip("MXFP4 not supported on this architecture")
 
@@ -203,9 +204,16 @@ def test_gemm_afp4_wfp4(M: int, N: int, K: int, dtype, output):
                 f"K = {K} is not divisible by 256, skip this test for preshuffled scales tests"
             )
 
-    x, w, x_scales, w_scales, x_scales_triton, w_scales_triton, out_dtype, y = (
-        generate_gemm_afp4wfp4_inputs(M, N, K, dtype, output=output)
-    )
+    (
+        x,
+        w,
+        x_scales,
+        w_scales,
+        x_scales_triton,
+        w_scales_triton,
+        out_dtype,
+        y,
+    ) = generate_gemm_afp4wfp4_inputs(M, N, K, dtype, layout=layout, output=output)
 
     torch_out = run_torch(x, w, x_scales, w_scales, dtype).to(dtype)
 

--- a/op_tests/triton_tests/test_gemm_afp4wfp4_pre_quant_atomic.py
+++ b/op_tests/triton_tests/test_gemm_afp4wfp4_pre_quant_atomic.py
@@ -1,5 +1,4 @@
 import torch
-import triton
 import pytest
 from aiter.ops.triton.gemm_afp4wfp4_pre_quant_atomic import gemm_afp4wfp4_pre_quant
 import aiter.ops.triton.utils.arch_info as arch_info
@@ -142,8 +141,9 @@ def run_torch(x, w, w_scales, dtype):
 
 @pytest.mark.parametrize("M, N, K", get_x_vals())
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("layout", ["TN", "TT", "NN", "NT"])
 @pytest.mark.parametrize("output", [True, False])
-def test_gemm_afp4_wfp4_pre_quant(M: int, N: int, K: int, dtype, output: bool):
+def test_gemm_afp4_wfp4_pre_quant(M: int, N: int, K: int, dtype, layout, output: bool):
     if not (arch_info.is_fp4_avail()):
         pytest.skip("MXFP4 not supported on this architecture")
 
@@ -154,7 +154,7 @@ def test_gemm_afp4_wfp4_pre_quant(M: int, N: int, K: int, dtype, output: bool):
         pytest.skip("Skipping this config. due to compilation error.")
 
     x, w, _, w_scales, y = generate_gemm_afp4wfp4_pre_quant_inputs(
-        M, N, K, output=output
+        M, N, K, layout=layout, output=output
     )
     if output:
         y = gemm_afp4wfp4_pre_quant(x, w, w_scales, torch.float32, y).to(dtype)


### PR DESCRIPTION
## Motivation

Add test cases covering non-TN layout scenarios to Triton GEMMS.

## Technical Details

Tests for TT, NN and NT layouts have been added. For some GEMMS, those layouts are tested on a smaller test suite to reduce CI runtime.

## Test Plan



## Test Result

Pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
