### PR TITLE
Handle readonly BUILD_DIR and add log for pre-compile ops in utils.py

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -41,7 +41,9 @@ AITER_DEBUG = int(os.getenv("AITER_DEBUG", 0))
 
 if AITER_REBUILD >= 1:
     subprocess.run(f"rm -rf {BUILD_DIR}/*", shell=True)
-os.makedirs(BUILD_DIR, exist_ok=True)
+
+if not os.path.exists(BUILD_DIR):
+    os.makedirs(BUILD_DIR, exist_ok=True)
 
 CK_DIR = os.environ.get("CK_DIR", f"{AITER_CORE_DIR}/3rdparty/composable_kernel")
 
@@ -259,6 +261,7 @@ def compile_template_op(
         if cxxflags is None:
             cxxflags = []
         src_file = src_template.render(func_name=func_name, **kwargs)
+        logger.info(f"compile_template_op {func_name = } with {locals()}...")
         compile_lib(src_file, folder, includes, sources, cxxflags)
     return run_lib(func_name, folder)
 


### PR DESCRIPTION

## Motivation

Our production environment does not support JIT yet, thus we pre-compile all ops required for our production use cases.
In the production environment, the install directory is readyonly, thus calling os.makedirs(BUILD_DIR) will fail.

What we do is generate all ops and compile them, then package the so file with the server binary and install in production environment.
So adding a log to print the compile_template_op params, so that when a new use case requires a new op, it will fail and we can find the required params for generating and compile the op during building process.

## Test Plan

The change is simple, I think any existing test covers the utils.py should cover it as well.

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
