### PR TITLE
fix get_gfx_list import error

### DIFF
--- a/csrc/cpp_itfs/mha_bwd_generate.py
+++ b/csrc/cpp_itfs/mha_bwd_generate.py
@@ -18,7 +18,7 @@ else:
     )  # develop mode
 sys.path.insert(0, AITER_CORE_DIR)
 
-from chip_info import get_gfx_list  # noqa: E402
+from aiter.jit.utils.chip_info import get_gfx_list
 
 GEN_DIR = ""  # in Cmake, have to generate files in same folder
 

--- a/csrc/cpp_itfs/mha_fwd_generate.py
+++ b/csrc/cpp_itfs/mha_fwd_generate.py
@@ -18,7 +18,7 @@ else:
     )  # develop mode
 sys.path.insert(0, AITER_CORE_DIR)
 
-from chip_info import get_gfx_list  # noqa: E402
+from aiter.jit.utils.chip_info import get_gfx_list
 
 GEN_DIR = ""  # in Cmake, have to generate files in same folder
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
[aiter] start build [module_aiter_enum] under /opt/conda/envs/py_3.9/lib/python3.9/site-packages/aiter/jit/build/module_aiter_enum
Successfully preprocessed all matching files.
[aiter] finish build [module_aiter_enum], cost 19.73237073s
/opt/conda/envs/py_3.9/lib/python3.9/site-packages/torch/_dynamo/variables/functions.py:1652: UserWarning: Dynamo detected a call to a `functools.lru_cache`-wrapped function. Dynamo ignores the cache wrapper and directly traces the wrapped function. Silent incorrectness is only a *potential* risk, not something we have observed. Enable TORCH_LOGS="+dynamo" for a DEBUG stack trace.
  torch._dynamo.utils.warn_once(msg)
[aiter] start build [mha_fwd_bf16_nbias_nmask_lse_ndropout] under /opt/conda/envs/py_3.9/lib/python3.9/site-packages/aiter/jit/build/mha_fwd_bf16_nbias_nmask_lse_ndropout
Traceback (most recent call last):
  File "/opt/conda/envs/py_3.9/lib/python3.9/site-packages/aiter_meta/csrc/cpp_itfs/mha_fwd_generate.py", line 21, in <module>
  from chip_info import get_gfx_list  # noqa: E402
**ModuleNotFoundError: No module named 'chip_info'**

