### PR TITLE
Disable getHipblasltKernelName to fix tune error

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -518,7 +518,7 @@ MANUAL_SCHEMA_OPS = [
 NONE_WRAPPED_OP = [
     # "hipb_create_extension",
     # "hipb_destroy_extension",
-    # "getHipblasltKernelName",
+    "getHipblasltKernelName",
     # "rocb_create_extension",
     # "rocb_destroy_extension",
     "get_meta_buffer_ipc_handle",


### PR DESCRIPTION
## Motivation
When running gemm_tuner, there are some errors with getHipblasltKernelName. 
We found getHipblasltKernelName define in python side do not have input/return annotation, but in kernel, it returns **string** witch not supported by custom op. Disable it in wrapper.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
