### PR TITLE
Fix old torch version not support ignore_method

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -28,14 +28,15 @@ def getLogger():
         console_handler.setLevel(logging.INFO)
 
         logger.addHandler(console_handler)
-        torch._dynamo.config.ignore_logger_methods = (
-            logging.Logger.info,
-            logging.Logger.warning,
-            logging.Logger.debug,
-            logger.warning,
-            logger.info,
-            logger.debug,
-        )
+        if hasattr(torch._dynamo.config, "ignore_logger_methods"):
+            torch._dynamo.config.ignore_logger_methods = (
+                logging.Logger.info,
+                logging.Logger.warning,
+                logging.Logger.debug,
+                logger.warning,
+                logger.info,
+                logger.debug,
+            )
 
     return logger
 


### PR DESCRIPTION
## Motivation

Torch not support ignore_logger_methods api in older version, we disable it
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
