### PR TITLE
Fix torch contiguous issue

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -1056,13 +1056,8 @@ def fmha_v3_varlen_bwd(
 ) -> List[Tensor]: ...
 
 
-@torch_compile_guard()
-def maybe_contiguous_custom_op(x: torch.Tensor) -> torch.Tensor:
-    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
-
-
 def maybe_contiguous(x):
-    return maybe_contiguous_custom_op(x)
+    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
 
 def _flash_attn_forward(


### PR DESCRIPTION
## Motivation

Torch did not correctly allocate as contiguous before the custom op calls, we got un-contiguous tensor in custom op, and triton kernel convert it to fp32 to cause accuracy issue. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
