### PR TITLE
Fix rmsnorm2dFusedAddQuant error since custom op SymInt issue

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -166,9 +166,7 @@ def check_and_set_ninja_worker():
     import psutil
 
     # calculate the maximum allowed NUM_JOBS based on free memory
-    free_memory_gb = psutil.virtual_memory().available / (
-        1024**3
-    )  # free memory in GB
+    free_memory_gb = psutil.virtual_memory().available / (1024**3)  # free memory in GB
     max_num_jobs_memory = int(free_memory_gb / 0.5)  # assuming 0.5 GB per job
 
     # pick lower value of jobs based on cores vs memory metric to minimize oom and swap usage during compilation

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -943,6 +943,13 @@ def compile_ops(
             return_int = True
 
         schema = f"{new_input} -> {output_part}".strip()
+        def rewrite_symint_schema(schema: str) -> str:
+            pattern = re.compile(r'(SymInt\s+\w+)=0')
+            modified_schema = pattern.sub(r'\1=None', schema)
+            return modified_schema
+
+        schema = rewrite_symint_schema(schema)
+
         loadName = func.__name__
 
         def abstract_impl(dummy, *args, custom_build_args={}, **kwargs):

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -166,7 +166,9 @@ def check_and_set_ninja_worker():
     import psutil
 
     # calculate the maximum allowed NUM_JOBS based on free memory
-    free_memory_gb = psutil.virtual_memory().available / (1024**3)  # free memory in GB
+    free_memory_gb = psutil.virtual_memory().available / (
+        1024**3
+    )  # free memory in GB
     max_num_jobs_memory = int(free_memory_gb / 0.5)  # assuming 0.5 GB per job
 
     # pick lower value of jobs based on cores vs memory metric to minimize oom and swap usage during compilation
@@ -943,9 +945,10 @@ def compile_ops(
             return_int = True
 
         schema = f"{new_input} -> {output_part}".strip()
+
         def rewrite_symint_schema(schema: str) -> str:
-            pattern = re.compile(r'(SymInt\s+\w+)=0')
-            modified_schema = pattern.sub(r'\1=None', schema)
+            pattern = re.compile(r"(SymInt\s+\w+)=0")
+            modified_schema = pattern.sub(r"\1=None", schema)
             return modified_schema
 
         schema = rewrite_symint_schema(schema)


### PR DESCRIPTION
## Motivation

Custom op will miss passing the args when SymInt=0, leading error. We make SymInt=None in custom op schema to solve it

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
