### PR TITLE
[fix]: access dangling ptr in ar interface

### DIFF
--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -176,7 +176,7 @@ std::vector<at::Tensor> get_graph_buffer_ipc_meta(
       torch::empty({static_cast<int64_t>(handle_bytes.size())}, options);
   std::memcpy(handles.data_ptr(), handle_bytes.data(), handle_bytes.size());
 
-  torch::Tensor offset_tensor = torch::from_blob(offsets.data(), {static_cast<int64_t>(offsets.size())}, torch::kInt64);
+  torch::Tensor offset_tensor = torch::from_blob(offsets.data(), {static_cast<int64_t>(offsets.size())}, torch::kInt64).clone();
   return {handles, offset_tensor};
 }
 


### PR DESCRIPTION
## Motivation

allreduce coredump after using torch::from_blob without clone()

## Technical Details

add clone() back

## Test Plan

run ut test

## Test Result

pass, no coredump

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
