### PR TITLE
[CK_TILE] FMHA BWD Avoid SetZero

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -1383,6 +1383,8 @@ def _flash_attn_backward(
         can_impl_fmha_v3_bwd_ and seqlen_q > 16
     ):  # ck fmha bwd has optimization for seqlen_q <= 16
         is_950_1block = get_gfx() == "gfx950" and seqlen_k <= 256
+        if dq is not None:
+            dq.zero_()
         (
             dq,
             dk,
@@ -1512,7 +1514,7 @@ class FlashAttnFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout, *args):
         q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
-        dq, dk, dv = torch.zeros_like(q), torch.empty_like(k), torch.empty_like(v)
+        dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
         bias = ctx.bias
         dbias = torch.empty_like(bias) if bias is not None else None
         head_size_q_og = ctx.head_size_q_og

--- a/csrc/py_itfs_ck/mha_bwd_kernels.cu
+++ b/csrc/py_itfs_ck/mha_bwd_kernels.cu
@@ -333,7 +333,10 @@ mha_bwd(const at::Tensor &dout,         // [b, sq, hq, d_v]
     } else {
         const ck_tile::index_t kN0 = head_size_v <= 128 ? 128 : 64;
         const ck_tile::index_t nsplits = ck_tile::integer_divide_ceil(seqlen_k, kN0);
-        dq_accum = torch::zeros({nsplits, batch_size, seqlen_q, num_heads, head_size_v}, opts.dtype(at::kFloat));
+        if (mask.type == mask_enum::no_mask) 
+            dq_accum = torch::empty({nsplits, batch_size, seqlen_q, num_heads, head_size_v}, opts.dtype(at::kFloat));
+        else  // Some block may be skiped with casual mask and dq are not set to zeros
+            dq_accum = torch::zeros({nsplits, batch_size, seqlen_q, num_heads, head_size_v}, opts.dtype(at::kFloat));
     }
 
     at::Tensor dk_expanded, dv_expanded;


### PR DESCRIPTION
## Motivation

As Title. In some cases, the cost of set-zero can reach 0.5 ms out of 3.5 ms. (which is 15%) of the total time.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
