### PR TITLE
Ninja build non-determinism fix

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -359,7 +359,7 @@ def build_module(
         flags_hip += flags_extra_hip
         archs = validate_and_update_archs()
         flags_hip += [f"--offload-arch={arch}" for arch in archs]
-        flags_hip = list(set(flags_hip))  # remove same flags
+        flags_hip = sorted(set(flags_hip))  # remove same flags
         flags_hip = [el for el in flags_hip if hip_flag_checker(el)]
         check_and_set_ninja_worker()
 

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -1337,7 +1337,7 @@ def _write_ninja_file_and_build_library(
     _write_ninja_file_to_build_library(
         path=build_file_path,
         name=name,
-        sources=list(set(sources)),
+        sources=sorted(set(sources)),
         extra_cflags=extra_cflags or [],
         extra_cuda_cflags=extra_cuda_cflags or [],
         extra_ldflags=extra_ldflags or [],


### PR DESCRIPTION
## Motivation

Using unordered sets instead of a ordered (sorted list for e.g.) produces non-determinism in the build system. This patch avoids that.

## Submission Checklist

- [+] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
