### PR TITLE
fix(build): force platform-specific wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import sys
 import shutil
 
-from setuptools import setup
+from setuptools import Distribution, setup
 
 # !!!!!!!!!!!!!!!! never import aiter
 # from aiter.jit import core
@@ -206,6 +206,12 @@ setup_requires = [
 if PREBUILD_KERNELS == 1:
     setup_requires.append("pandas")
 
+
+class ForcePlatlibDistribution(Distribution):
+    def has_ext_modules(self):
+        return True
+
+
 setup(
     name=PACKAGE_NAME,
     use_scm_version=True,
@@ -230,6 +236,7 @@ setup(
         "psutil",
     ],
     setup_requires=setup_requires,
+    distclass=ForcePlatlibDistribution,
 )
 
 if os.path.exists("aiter_meta") and os.path.isdir("aiter_meta"):


### PR DESCRIPTION
- Add ForcePlatlibDistribution that overrides has_ext_modules() to return True
- Use distclass parameter to force setuptools to generate platform-specific wheel tags
- Fixes incorrect wheel metadata generation (py3-none-any → cp3XX-cp3XX-linux_x86_64)

## Motivation

aiter currently generates incorrect wheel metadata despite containing compiled GPU kernels. 
Wheels are tagged as `py3-none-any` (pure Python) instead of platform-specific tags like 
`cp312-cp312-linux_x86_64`. This causes issues with:

- Package managers installing on incompatible platforms
- Missing performance optimization detection
- Confusion about package contents (appears pure Python)
- Potential runtime failures on platforms without ROCm

The root cause is that `ext_modules` was commented out in setup.py due to being undefined,
causing setuptools to treat the package as pure Python.

## Technical Details

This implements a clean solution using setuptools' `distclass` parameter:

1. **Custom Distribution Class**: `ForcePlatlibDistribution` overrides `has_ext_modules()` 
   to return `True`, telling setuptools this package contains compiled extensions
2. **Minimal Approach**: No actual Extension objects that external builders might 
   try to compile, avoiding build conflicts
3. **Preserves Existing Build System**: Custom NinjaBuildExtension and kernel 
   compilation pipeline remain unchanged

Alternative approaches considered but rejected:
- Defining ext_modules with empty sources (can cause external builder issues)
- Complex build system modifications (should be handled upstream)

## Test Plan

1. **Wheel Generation**: Built wheel using `python setup.py bdist_wheel`
2. **Filename Verification**: Confirmed platform-specific naming
3. **Content Verification**: Verified GPU kernels (.co files) are included
4. **Size Check**: 18MB wheel size confirms compiled content present

## Test Result
**Before**: `aiter-X.Y.Z-py3-none-any.whl` (incorrect)
**After**: `aiter-X.Y.Z-cp313-cp313-linux_x86_64.whl` (correct)

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
