### PR TITLE
[TRITON] Benchmarking improvements

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_batch_prefill.py
+++ b/op_tests/op_benchmarks/triton/bench_batch_prefill.py
@@ -155,6 +155,14 @@ def run_benchmark(args):
     line_names = ["Time_(ms)", "TFLOPS", "Bandwidth_(GB/s)"]
     line_vals = ["time", "tflops", "bandwidth"]
 
+    # FIXME: The Triton benchmark infrastructure has been changed so that the provided
+    # 'ylabel' is appended to each of the column names in the output table.
+    # In this benchmark, the table would have columns like:
+    # - Time_(ms) (ms / TFLOPS / GB/s)
+    # - TFLOPS (ms / TFLOPS / GB/s)
+    # - Bandwidth_(GB/s) (ms / TFLOPS / GB/s)
+    # This is probably not the desired behavior, but Triton does not seem to support separate
+    # 'ylabel's for each of the provided line values.
     benchmark = triton.testing.Benchmark(
         x_names=x_names,
         x_vals=x_vals_list,

--- a/op_tests/op_benchmarks/triton/bench_extend_attention.py
+++ b/op_tests/op_benchmarks/triton/bench_extend_attention.py
@@ -3,7 +3,6 @@ from aiter.ops.triton import extend_attention, prefill_attention
 import triton
 
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
-    get_evaluation_label,
     get_model_configs,
     get_available_models,
     print_vgpr,
@@ -177,7 +176,7 @@ def benchmark(args):
             x_names, x_vals_list = get_prefill_benchmark_configs()
 
     line_vals = ["time"]
-    line_names = [get_evaluation_label("time", prefix="fwd")]
+    line_names = ["fwd_time"]
 
     configs.append(
         triton.testing.Benchmark(

--- a/op_tests/op_benchmarks/triton/bench_ff_a16w16_fused.py
+++ b/op_tests/op_benchmarks/triton/bench_ff_a16w16_fused.py
@@ -18,7 +18,6 @@ from op_tests.op_benchmarks.triton.utils.argparse import (
 
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_evaluation_unit,
-    get_evaluation_label,
     model_benchmark_shapes,
     get_gemm_shape_benchmark_object,
     print_vgpr,
@@ -40,17 +39,12 @@ def get_gemm_model_benchmark_object(
         x_names = ["M", "hidden_dim", "intermediate_dim", "model_name"]
     x_vals_list = model_benchmark_shapes(args)
 
-    ylabel = get_evaluation_label(args.metric, space=True)
+    ylabel = get_evaluation_unit(args.metric)
 
-    line_names = []
-    line_vals = []
-    if not args.bench_torch:
-        line_names.append(get_evaluation_label(args.metric))
-        line_vals.append("triton")
-    else:
-        line_names.append(get_evaluation_label(args.metric, prefix="triton"))
-        line_vals.append("triton")
-        line_names.append(get_evaluation_label(args.metric, prefix="torch"))
+    line_names = ["triton"]
+    line_vals = ["triton"]
+    if args.bench_torch:
+        line_names.append("torch")
         line_vals.append("torch")
 
     mpl_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]

--- a/op_tests/op_benchmarks/triton/bench_fp8_mqa_logits.py
+++ b/op_tests/op_benchmarks/triton/bench_fp8_mqa_logits.py
@@ -32,14 +32,14 @@ def run_benchmark(args):
     x_names = ["seq_q_l", "seq_kv_l", "num_heads_q", "head_dim"]
     x_vals_list = [[args.seq_q_l, args.seq_kv_l, args.num_heads_q, args.head_dim]]
     if args.metric == "time":
-        ylabel = "Time (ms)"
+        ylabel = "ms"
     elif args.metric == "throughput":
         ylabel = "TFLOPs"
     else:
         raise NotImplementedError(f"{args.metric} is not supported")
 
-    line_names = [ylabel]
-    line_vals = [ylabel]
+    line_names = [args.metric]
+    line_vals = [args.metric]
     benchmark = triton.testing.Benchmark(
         x_names=x_names,
         x_vals=x_vals_list,

--- a/op_tests/op_benchmarks/triton/bench_gemm_a16w16_gating.py
+++ b/op_tests/op_benchmarks/triton/bench_gemm_a16w16_gating.py
@@ -13,10 +13,10 @@ from op_tests.op_benchmarks.triton.utils.argparse import (
 )
 
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    get_evaluation_unit,
     model_benchmark_shapes,
     get_gemm_shape_benchmark_object,
     print_vgpr,
-    get_evaluation_label,
 )
 import matplotlib.pyplot as plt
 
@@ -35,17 +35,17 @@ def get_gemm_model_benchmark_object(
         x_names = ["M", "hidden_dim", "intermediate_dim", "model_name"]
     x_vals_list = model_benchmark_shapes(args)
 
-    ylabel = get_evaluation_label(args.metric, space=True)
+    ylabel = get_evaluation_unit(args.metric)
 
     line_names = []
     line_vals = []
     if not args.bench_torch:
-        line_names.append(get_evaluation_label(args.metric, prefix="fc1"))
+        line_names.append(f"fc1_{args.metric}")
         line_vals.append(("triton", "fc1"))
     else:
-        line_names.append(get_evaluation_label(args.metric, prefix="triton_fc1"))
+        line_names.append(f"triton_fc1_{args.metric}")
         line_vals.append(("triton", "fc1"))
-        line_names.append(get_evaluation_label(args.metric, prefix="torch_fc1"))
+        line_names.append(f"torch_fc1_{args.metric}")
         line_vals.append(("torch", "fc1"))
 
     mpl_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]

--- a/op_tests/op_benchmarks/triton/bench_hstu_attn.py
+++ b/op_tests/op_benchmarks/triton/bench_hstu_attn.py
@@ -13,7 +13,6 @@ from op_tests.triton_tests.test_hstu_attn import (
     get_bytes,
 )
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
-    get_evaluation_label,
     get_evaluation_unit,
     print_vgpr,
     get_caller_name_no_ext,
@@ -59,11 +58,9 @@ def run_benchmark(args):
     else:
         x_val_list = get_x_values()
 
-    ylabel = get_evaluation_label(args.metric, space=True)
+    ylabel = get_evaluation_unit(args.metric)
 
-    line_names = [
-        get_evaluation_label(args.metric, only_unit=(args.metric == "throughput"))
-    ]
+    line_names = [args.metric]
     line_vals = [get_evaluation_unit(args.metric)]
     modes = [args.mode]
     if args.mode == "both":

--- a/op_tests/op_benchmarks/triton/bench_la.py
+++ b/op_tests/op_benchmarks/triton/bench_la.py
@@ -8,7 +8,7 @@ from aiter.ops.triton.lean_atten import (
 )
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_caller_name_no_ext,
-    get_evaluation_label,
+    get_evaluation_unit,
 )
 import torch
 
@@ -290,9 +290,9 @@ configs.append(
         ],
         line_arg="provider",
         line_vals=["triton"],
-        line_names=[get_evaluation_label("time", prefix="triton")],
+        line_names=["triton_time"],
         # styles=[('red', '-'), ('blue', '-')],
-        ylabel=get_evaluation_label("time", space=True),
+        ylabel=get_evaluation_unit("time"),
         plot_name=get_caller_name_no_ext(),
         args={
             # "causal": causal,

--- a/op_tests/op_benchmarks/triton/bench_la_paged_decode.py
+++ b/op_tests/op_benchmarks/triton/bench_la_paged_decode.py
@@ -1,7 +1,7 @@
 import triton
 import triton.language as tl
-from utils.benchmark_utils import (
-    get_evaluation_label,
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    get_evaluation_unit,
     get_model_configs,
     get_available_models,
     get_dtype_bytes,
@@ -345,7 +345,7 @@ def run_benchmark(args):
 
     x_names = ["OP", "BS", "HQ", "HK", "SEQ_LEN", "HEAD_DIM"]
 
-    line_names = [get_evaluation_label("time")]
+    line_names = ["time"]
     line_vals = ["time"]
 
     benchmark = triton.testing.Benchmark(
@@ -355,7 +355,7 @@ def run_benchmark(args):
         line_vals=line_vals,
         line_names=line_names,
         styles=[("red", "-")],
-        ylabel=get_evaluation_label("time", space=True),
+        ylabel=get_evaluation_unit("time"),
         plot_name=get_caller_name_no_ext(),
         args={},
     )

--- a/op_tests/op_benchmarks/triton/bench_mha.py
+++ b/op_tests/op_benchmarks/triton/bench_mha.py
@@ -23,7 +23,6 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_model_configs,
     print_vgpr,
     get_caller_name_no_ext,
-    get_evaluation_label,
 )
 
 
@@ -148,24 +147,22 @@ def create_benchmark_configs(custom, args):
             plot_name = f"fused-attention-{mode}-layout-{args.layout}-fp8-{args.fp8}-causal-{causal}"
             extra_args = {"dtype": dtype, "causal": causal, "mode": mode}
 
-    unit = get_evaluation_unit(args.metric)
-
     if mode == "bwd":
         if args.fused_bwd:
-            line_vals = [f"fused-bwd({unit})"]
+            line_vals = [f"fused-bwd"]
         else:
-            line_vals = [f"onekernel-bwd({unit})"]
+            line_vals = [f"onekernel-bwd"]
     else:
-        line_vals = [f"fwd({unit})"]
+        line_vals = [f"fwd"]
 
     if args.bench_torch:
-        line_vals = [f"Triton({unit})", f"Torch({unit})"]
+        line_vals = [f"triton", f"torch"]
 
     if args.test_mode:
         if args.fused_bwd:
-            line_vals = [f"fused-bwd({unit})"]
+            line_vals = [f"fused-bwd"]
         else:
-            line_vals = [f"onekernel-bwd({unit})"]
+            line_vals = [f"onekernel-bwd"]
 
     configs.append(
         triton.testing.Benchmark(
@@ -175,7 +172,7 @@ def create_benchmark_configs(custom, args):
             line_vals=line_vals,
             line_names=line_vals,
             styles=[("red", "-"), ("green", "-"), ("yellow", "-")],
-            ylabel=get_evaluation_label(args.metric, space=True),
+            ylabel=get_evaluation_unit(args.metric),
             plot_name=plot_name,
             args=extra_args,
         )

--- a/op_tests/op_benchmarks/triton/bench_mla_decode.py
+++ b/op_tests/op_benchmarks/triton/bench_mla_decode.py
@@ -2,11 +2,11 @@ import triton
 from aiter.ops.triton.mla_decode_rope import decode_attention_fwd_grouped_rope
 from aiter.ops.triton.utils.types import str_to_torch_dtype
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    get_evaluation_unit,
     get_model_configs,
     get_available_models,
     print_vgpr,
     get_caller_name_no_ext,
-    get_evaluation_label,
 )
 import torch
 import argparse
@@ -67,7 +67,7 @@ def benchmark(args):
         x_names, x_vals_list = model_benchmark_configs(args)
 
     line_vals = ["mla_decode_fwd"]
-    line_names = [get_evaluation_label("time", prefix="mla_decode_fwd")]
+    line_names = ["mla_decode_fwd_time"]
 
     configs.append(
         triton.testing.Benchmark(
@@ -77,7 +77,7 @@ def benchmark(args):
             line_vals=line_vals,
             line_names=line_names,
             styles=[("red", "-"), ("green", "-")],
-            ylabel=get_evaluation_label("time", space=True),
+            ylabel=get_evaluation_unit("time"),
             plot_name=get_caller_name_no_ext(),
             args={"sm_scale": 1.0, "logit_cap": 0.0, "device": args.device},
         )

--- a/op_tests/op_benchmarks/triton/bench_mla_decode_rope.py
+++ b/op_tests/op_benchmarks/triton/bench_mla_decode_rope.py
@@ -6,7 +6,6 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_model_configs,
     print_vgpr,
     get_caller_name_no_ext,
-    get_evaluation_label,
     get_evaluation_unit,
 )
 import torch
@@ -107,7 +106,7 @@ def create_benchmark_configs(args: argparse.Namespace):
         x_vals_list = nonvarlen_benchmark_configs(args)
 
     line_vals = [get_evaluation_unit(args.metric)]
-    line_names = [get_evaluation_label(args.metric)]
+    line_names = [args.metric]
     configs.append(
         triton.testing.Benchmark(
             x_names=x_names,
@@ -116,7 +115,7 @@ def create_benchmark_configs(args: argparse.Namespace):
             line_vals=line_vals,
             line_names=line_names,
             styles=[("red", "-"), ("green", "-"), ("yellow", "-")],
-            ylabel=get_evaluation_label(args.metric, space=True),
+            ylabel=get_evaluation_unit(args.metric),
             plot_name=get_caller_name_no_ext(),
             args=extra_args,
         )

--- a/op_tests/op_benchmarks/triton/bench_moe.py
+++ b/op_tests/op_benchmarks/triton/bench_moe.py
@@ -11,7 +11,7 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_available_models,
     print_vgpr,
     get_caller_name_no_ext,
-    get_evaluation_label,
+    get_evaluation_unit,
 )
 
 
@@ -184,16 +184,14 @@ def run_benchmark(args):
     x_names = ["model", "M", "N", "K", "E", "top_k"]
 
     if print_time:
-        line_names = [get_evaluation_label("time")]
+        line_names = ["time"]
         line_vals = ["time"]
     else:
-        line_names = [
-            get_evaluation_label("time"),
-            get_evaluation_label("throughput", only_unit=True),
-            get_evaluation_label("bandwidth"),
-        ]
+        line_names = ["time", "throughput", "bandwidth"]
         line_vals = ["time", "throughput", "bandwidth"]
 
+    # FIXME: Refer to the FIXME comment in op_tests/op_benchmarks/triton/bench_batch_prefill.py"
+    # to understand the problem here.
     benchmark = triton.testing.Benchmark(
         x_names=x_names,
         x_vals=x_vals_list,
@@ -201,9 +199,9 @@ def run_benchmark(args):
         line_vals=line_vals,
         line_names=line_names,
         styles=[("red", "-"), ("blue", "-"), ("yellow", "-")],
-        ylabel=f"{get_evaluation_label("time", space=True)} / "
-        + f"{get_evaluation_label("throughput", space=True)} / "
-        + f"{get_evaluation_label("bandwidth", space=True)}",
+        ylabel=f"{get_evaluation_unit("time")} / "
+        + f"{get_evaluation_unit("throughput")} / "
+        + f"{get_evaluation_unit("bandwidth")}",
         plot_name=get_caller_name_no_ext(),
         args={},
     )

--- a/op_tests/op_benchmarks/triton/bench_moe_align_block_size.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_align_block_size.py
@@ -1,11 +1,11 @@
 import triton
 from aiter.ops.triton.moe_align_block_size import moe_align_block_size_triton
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    get_evaluation_unit,
     get_model_configs,
     get_available_models,
     get_caller_name_no_ext,
     print_vgpr,
-    get_evaluation_label,
 )
 from op_tests.triton_tests.test_moe_align_block_size import input_helper
 import torch
@@ -62,7 +62,7 @@ def run_benchmark(custom, args):
     x_vals_list = model_benchmark_configs(args)
     x_names = ["model", "M", "N", "K", "E", "top_k"]
 
-    line_names = [get_evaluation_label("time"), get_evaluation_label("bandwidth")]
+    line_names = ["time", "bandwidth"]
     line_vals = ["time", "bandwidth"]
 
     benchmark = triton.testing.Benchmark(
@@ -72,7 +72,7 @@ def run_benchmark(custom, args):
         line_vals=line_vals,
         line_names=line_names,
         styles=[("red", "-"), ("blue", "-")],
-        ylabel=f"{get_evaluation_label("time", space=True)} / {get_evaluation_label("bandwidth", space=True)}",
+        ylabel=f"{get_evaluation_unit("time")} / {get_evaluation_unit("bandwidth")}",
         plot_name=get_caller_name_no_ext(),
         args={},
     )

--- a/op_tests/op_benchmarks/triton/bench_moe_mx.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_mx.py
@@ -8,10 +8,10 @@ from aiter.ops.triton.moe_op_mxfp4_silu_fused import fused_moe_mxfp4_silu
 from op_tests.triton_tests.test_moe_mx import input_helper
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_available_models,
+    get_evaluation_unit,
     get_model_configs,
     get_caller_name_no_ext,
     print_vgpr,
-    get_evaluation_label,
 )
 
 
@@ -51,13 +51,11 @@ def run_benchmark(args):
     x_vals_list = model_benchmark_configs(args)
     x_names = ["model", "M", "N", "K", "E", "top_k"]
 
-    line_names = [
-        get_evaluation_label("time"),
-        get_evaluation_label("throughput", only_unit=True),
-        get_evaluation_label("bandwidth"),
-    ]
+    line_names = ["time", "throughput", "bandwidth"]
     line_vals = ["time", "throughput", "bandwidth"]
 
+    # FIXME: Refer to the FIXME comment in op_tests/op_benchmarks/triton/bench_batch_prefill.py"
+    # to understand the problem here.
     benchmark = triton.testing.Benchmark(
         x_names=x_names,
         x_vals=x_vals_list,
@@ -65,9 +63,9 @@ def run_benchmark(args):
         line_vals=line_vals,
         line_names=line_names,
         styles=[("red", "-"), ("blue", "-"), ("yellow", "-")],
-        ylabel=f"{get_evaluation_label("time", space=True)} / "
-        + f"{get_evaluation_label("throughput", space=True)} / "
-        + f"{get_evaluation_label("bandwidth", space=True)}",
+        ylabel=f"{get_evaluation_unit("time")} / "
+        + f"{get_evaluation_unit("throughput")} / "
+        + f"{get_evaluation_unit("bandwidth")}",
         plot_name=get_caller_name_no_ext(),
         args={"a_dtype": a_dtype_str, "swizzle_mx": swizzle_mx},
     )

--- a/op_tests/op_benchmarks/triton/bench_moe_routing_sigmoid_top1_fused.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_routing_sigmoid_top1_fused.py
@@ -12,7 +12,6 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_available_models,
     get_model_configs,
     get_caller_name_no_ext,
-    get_evaluation_label,
     get_evaluation_unit,
 )
 from op_tests.triton_tests.test_moe_routing_sigmoid_top1_fused import (
@@ -33,13 +32,11 @@ def run_benchmark(args, x_vals_list):
     """
     x_names = ["M", "N", "K"]
 
-    line_names = [
-        get_evaluation_label("time"),
-        get_evaluation_label("throughput", only_unit=True),
-        get_evaluation_label("bandwidth"),
-    ]
+    line_names = ["time", "throughput", "bandwidth"]
     line_vals = ["time", "throughput", "bandwidth"]
 
+    # FIXME: Refer to the FIXME comment in op_tests/op_benchmarks/triton/bench_batch_prefill.py"
+    # to understand the problem here.
     benchmark = triton.testing.Benchmark(
         x_names=x_names,
         x_vals=x_vals_list,
@@ -47,9 +44,9 @@ def run_benchmark(args, x_vals_list):
         line_vals=line_vals,
         line_names=line_names,
         styles=[("red", "-"), ("blue", "-"), ("yellow", "-")],
-        ylabel=f"{get_evaluation_label("time", space=True)} / "
-        + f"{get_evaluation_label("throughput", space=True)} / "
-        + f"{get_evaluation_label("bandwidth", space=True)}",
+        ylabel=f"{get_evaluation_unit("time")} / "
+        + f"{get_evaluation_unit("throughput")} / "
+        + f"{get_evaluation_unit("bandwidth")}",
         plot_name=get_caller_name_no_ext(),
         args={},
     )

--- a/op_tests/op_benchmarks/triton/bench_pa_decode.py
+++ b/op_tests/op_benchmarks/triton/bench_pa_decode.py
@@ -10,7 +10,7 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_dtype_bytes,
     get_caller_name_no_ext,
     print_vgpr,
-    get_evaluation_label,
+    get_evaluation_unit,
 )
 from aiter.ops.triton.utils.types import torch_to_triton_dtype
 
@@ -188,13 +188,11 @@ def run_benchmark(args):
 
     model_name = "paged-attn-decode"
 
-    line_names = [
-        get_evaluation_label("time"),
-        get_evaluation_label("throughput", only_unit=True),
-        get_evaluation_label("bandwidth"),
-    ]
+    line_names = ["time", "throughput", "bandwidth"]
     line_vals = ["time", "throughput", "bandwidth"]
 
+    # FIXME: Refer to the FIXME comment in op_tests/op_benchmarks/triton/bench_batch_prefill.py"
+    # to understand the problem here.
     benchmark = triton.testing.Benchmark(
         x_names=x_names,
         x_vals=x_vals_list,
@@ -202,9 +200,9 @@ def run_benchmark(args):
         line_vals=line_vals,
         line_names=line_names,
         styles=[("red", "-"), ("blue", "-"), ("yellow", "-")],
-        ylabel=f"{get_evaluation_label("time", space=True)} / "
-        + f"{get_evaluation_label("throughput", space=True)} / "
-        + f"{get_evaluation_label("bandwidth", space=True)}",
+        ylabel=f"{get_evaluation_unit("time")} / "
+        + f"{get_evaluation_unit("throughput")} / "
+        + f"{get_evaluation_unit("bandwidth")}",
         plot_name=get_caller_name_no_ext(),
         args={},
     )

--- a/op_tests/op_benchmarks/triton/bench_pa_prefill.py
+++ b/op_tests/op_benchmarks/triton/bench_pa_prefill.py
@@ -11,7 +11,7 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_dtype_bytes,
     get_caller_name_no_ext,
     print_vgpr,
-    get_evaluation_label,
+    get_evaluation_unit,
 )
 from op_tests.op_benchmarks.triton.utils.argparse import get_parser
 from op_tests.triton_tests.test_pa_prefill import (
@@ -212,13 +212,11 @@ def run_benchmark(args):
 
     model_name = "paged-attn-decode"
 
-    line_names = [
-        get_evaluation_label("time"),
-        get_evaluation_label("throughput", only_unit=True),
-        get_evaluation_label("bandwidth"),
-    ]
+    line_names = ["time", "throughput", "bandwidth"]
     line_vals = ["time", "throughput", "bandwidth"]
 
+    # FIXME: Refer to the FIXME comment in op_tests/op_benchmarks/triton/bench_batch_prefill.py"
+    # to understand the problem here.
     benchmark = triton.testing.Benchmark(
         x_names=x_names,
         x_vals=x_vals_list,
@@ -226,9 +224,9 @@ def run_benchmark(args):
         line_vals=line_vals,
         line_names=line_names,
         styles=[("red", "-"), ("blue", "-"), ("yellow", "-")],
-        ylabel=f"{get_evaluation_label("time", space=True)} / "
-        + f"{get_evaluation_label("throughput", space=True)} / "
-        + f"{get_evaluation_label("bandwidth", space=True)}",
+        ylabel=f"{get_evaluation_unit("time")} / "
+        + f"{get_evaluation_unit("throughput")} / "
+        + f"{get_evaluation_unit("bandwidth")}",
         plot_name=get_caller_name_no_ext(),
         args={},
     )

--- a/op_tests/op_benchmarks/triton/bench_rmsnorm.py
+++ b/op_tests/op_benchmarks/triton/bench_rmsnorm.py
@@ -9,7 +9,6 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_available_models,
     get_caller_name_no_ext,
     print_vgpr,
-    get_evaluation_label,
     get_evaluation_unit,
 )
 
@@ -56,9 +55,9 @@ def run_benchmark(args):
     x_names = ["model_name", "M", "N"]
     x_vals_list = model_benchmark_shapes(args)
 
-    ylabel = get_evaluation_label(args.metric, space=True)
+    ylabel = get_evaluation_unit(args.metric)
 
-    line_names = [get_evaluation_label(args.metric)]
+    line_names = [args.metric]
     line_vals = [get_evaluation_unit(args.metric)]
     benchmark = triton.testing.Benchmark(
         x_names=x_names,

--- a/op_tests/op_benchmarks/triton/bench_schema.yaml
+++ b/op_tests/op_benchmarks/triton/bench_schema.yaml
@@ -1,3 +1,4 @@
+# FIXME: Update this schema to match the actual benchmark implementations
 benchmarks:
   batched_gemm_a8w8:
     input_columns: [batch, M, N, K]

--- a/op_tests/op_benchmarks/triton/bench_topk.py
+++ b/op_tests/op_benchmarks/triton/bench_topk.py
@@ -15,7 +15,6 @@ import triton
 from triton.testing import runtime
 from aiter.ops.triton.topk import topk as triton_topk
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
-    get_evaluation_label,
     get_evaluation_unit,
     get_model_configs,
     get_available_models,
@@ -155,11 +154,11 @@ def _plot_roofline(points: List[RoofDot], M: int, K: int, out_dir: Path) -> None
         line_arg="provider",
         line_vals=["triton", "torch"],
         line_names=[
-            get_evaluation_label("latency", prefix="triton"),
-            get_evaluation_label("latency", prefix="torch"),
+            "triton_latency",
+            "torch_latency",
         ],
         styles=[("blue", "-"), ("green", "-")],
-        ylabel=get_evaluation_label("latency", space=True),
+        ylabel=get_evaluation_unit("latency"),
         plot_name="topk_latency",
         args={},
     )
@@ -197,11 +196,11 @@ def bench_latency(batch, provider, *, dim2: int, k: int):
         line_arg="provider",
         line_vals=["triton", "torch"],
         line_names=[
-            get_evaluation_label("memory", prefix="triton"),
-            get_evaluation_label("memory", prefix="torch"),
+            "triton_memory",
+            "torch_memory",
         ],
         styles=[("blue", "--"), ("green", "--")],
-        ylabel=get_evaluation_label("memory", space=True),
+        ylabel=get_evaluation_unit("memory"),
         plot_name="topk_memory",
         args={},
     )
@@ -273,8 +272,8 @@ def run_benchmark(args, x_vals_list):
     """
     x_names = ["M", "N", "topk"]
 
-    ylabel = get_evaluation_label(args.metric, space=True)
-    line_names = [get_evaluation_label(args.metric)]
+    ylabel = get_evaluation_unit(args.metric)
+    line_names = [args.metric]
     line_vals = [get_evaluation_unit(args.metric)]
     benchmark = triton.testing.Benchmark(
         x_names=x_names,

--- a/op_tests/op_benchmarks/triton/utils/benchmark_utils.py
+++ b/op_tests/op_benchmarks/triton/utils/benchmark_utils.py
@@ -39,42 +39,6 @@ def get_evaluation_unit(metric):
         raise NotImplementedError(f"{metric} is not supported")
 
 
-def get_evaluation_label(metric, space=False, prefix=None, only_unit=False):
-    """
-    Utility function for returning a column label given the evaluation metric
-
-    Args:
-        metric (str): User-provided metric to produce a label for
-        space (bool): Whether to use a space or hyphen delimiter
-        prefix (Optional[str]): Optional prefix to append to the label
-        only_unit (bool): Whether only units are included in the label
-                               (ex: 'TFLOPS' instead of 'Throughput_(TFLOPS)')
-                               (ex: 'fwd(TFLOPS)' instead of 'fwd_Throughput_(TFLOPS)')
-    """
-
-    if only_unit:
-        if prefix:
-            return f"{prefix}({get_evaluation_unit(metric)})"
-        else:
-            return get_evaluation_unit(metric)
-    if space:
-        return (
-            (prefix + " " if prefix else "")
-            + metric.capitalize()
-            + " ("
-            + get_evaluation_unit(metric)
-            + ")"
-        )
-    else:
-        return (
-            (prefix + "_" if prefix else "")
-            + metric.capitalize()
-            + "_("
-            + get_evaluation_unit(metric)
-            + ")"
-        )
-
-
 def get_torch_activation_from_str(activation: str):
     """
     Utility function for returning PyTorch analogues for the given activation function.
@@ -120,19 +84,18 @@ def get_gemm_shape_benchmark_object(plot_name, args, x_names=None):
     else:
         x_vals_list = get_x_vals(dims=len(x_names), args=args)
 
-    ylabel = get_evaluation_label(args.metric, space=True)
+    ylabel = get_evaluation_unit(args.metric)
 
+    line_names = []
+    line_vals = []
     if not args.bench_torch:
-        line_vals = [get_evaluation_unit(args.metric)]
-        line_names = [
-            get_evaluation_label(args.metric, only_unit=(args.metric == "throughput"))
-        ]
+        line_vals.append(args.metric)
+        line_names.append(args.metric)
     else:
-        line_vals = ["triton", "torch"]
-        line_names = [
-            get_evaluation_label(args.metric, prefix="triton"),
-            get_evaluation_label(args.metric, prefix="torch"),
-        ]
+        line_vals.append("triton")
+        line_names.append(f"triton_{args.metric}")
+        line_vals.append("torch")
+        line_names.append(f"torch_{args.metric}")
 
     mpl_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     benchmark = triton.testing.Benchmark(
@@ -172,28 +135,28 @@ def get_gemm_model_benchmark_object(
         args.fc2 = True
     x_vals_list = model_benchmark_shapes_fn(args)
 
-    ylabel = get_evaluation_label(args.metric, space=True)
+    ylabel = get_evaluation_unit(args.metric)
 
     line_names = []
     line_vals = []
     if args.fc1:
         if not args.bench_torch:
-            line_names.append(get_evaluation_label(args.metric, prefix="fc1"))
+            line_names.append(f"fc1_{args.metric}")
             line_vals.append(("triton", "fc1"))
         else:
-            line_names.append(get_evaluation_label(args.metric, prefix="triton_fc1"))
             line_vals.append(("triton", "fc1"))
-            line_names.append(get_evaluation_label(args.metric, prefix="torch_fc1"))
+            line_names.append(f"triton_fc1_{args.metric}")
             line_vals.append(("torch", "fc1"))
+            line_names.append(f"torch_fc1_{args.metric}")
     if args.fc2:
         if not args.bench_torch:
-            line_names.append(get_evaluation_label(args.metric, prefix="fc2"))
+            line_names.append(f"fc2_{args.metric}")
             line_vals.append(("triton", "fc2"))
         else:
-            line_names.append(get_evaluation_label(args.metric, prefix="triton_fc2"))
             line_vals.append(("triton", "fc2"))
-            line_names.append(get_evaluation_label(args.metric, prefix="torch_fc2"))
+            line_names.append(f"triton_fc2_{args.metric}")
             line_vals.append(("torch", "fc2"))
+            line_names.append(f"torch_fc2_{args.metric}")
 
     mpl_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     benchmark = triton.testing.Benchmark(


### PR DESCRIPTION
## Changes
- [x] When running with a given model, all benchmark scripts now always output the metric evaluated. Previously, table columns would only show "fc1" and/or "fc2", which is not helpful when reading from the terminal.
- [x] Standardize table/graph labelling across Triton benchmarking scripts (standard formatting: `<Provider>_<Layer>_<Metric>_(<Unit>)`). Provider describes whether the bench was performed using the Triton kernel or Torch functions. Layer is either `fc1` or `fc2` for model benchmarks. Both are optional. Metric is either time (ms), throughput (TFLOPS), or bandwidth (GB/s).
- [x] Modify benchmark outputs to match table schema in `op_tests/op_benchmarks/triton/bench_schema.yaml`.
- [x] Implement comparisons with PyTorch for the Triton GEMM kernels, using the `-bench_torch` flag.
- [x] Resolve `arch_info` and `get_splitk` import issues in `triton/bench_batched_gemm_afp4wfp4.py`, `triton/bench_batched_gemm_afp4wfp4_pre_quant.py` and `triton/bench_gemm_a8wfp4.py`.
- [x] Resolve `STR_DTYPE_TO_TORCH_DTYPE` import issue in `triton/bench_pa_prefill.py`.
- [x] Fix default parameters in `op_tests/op_benchmarks/triton/utils/model_configs.json` (removing MoE parameters from llama models, changing top_k parameter from 4 to 8 in deepseek-v3).
- [x] Add gpt-oss model family to Triton benchmarking model config (parameters are determined from the [model card](https://arxiv.org/pdf/2508.10925)).

## Testing
Manuel tests were performed on both MI300 and MI350, across both shape and model benchmarks. Please see these [metrics](https://amd.atlassian.net/wiki/x/3Sr5Qw) for fixed shape parameters, comparing the Triton kernels and PyTorch. Below are some sample outputs, from running `triton/bench_gemm_a8w8_blockscale.py` with llama3-8B.

Before:
<img width="940" height="313" alt="Before" src="https://github.com/user-attachments/assets/8e5afe98-4c91-44c0-9a81-e3333f45b212" />
After:
<img width="943" height="314" alt="After" src="https://github.com/user-attachments/assets/7251b0ec-5d6e-4765-b9db-8d58d1f073b1" />

Triton vs Torch:
<img width="944" height="308" alt="Bench Example" src="https://github.com/user-attachments/assets/5f0c8796-3da0-4ef4-a5a7-aece0dc52133" />

Below is a sample run of `op_tests/op_benchmarks/triton/bench_moe.py`, using the new gptoss model family.
<img width="457" height="105" alt="image" src="https://github.com/user-attachments/assets/f4c0c55e-50ca-49b0-a79d-5fe6d0c6aff0" />
Compared with deepseek-V3:
<img width="455" height="59" alt="image" src="https://github.com/user-attachments/assets/e25f054f-9631-48f1-bbc5-70c2e10dcb3f" />

Attempting to benchmark MoE with the llama3 family of models now accurately throws an error.
<img width="455" height="134" alt="image" src="https://github.com/user-attachments/assets/dc036710-e317-4f83-a285-0e1b5ff7283f" />
