### PR TITLE
    feat(mha): Add sequence padding support for CK FMHA forward

### DIFF
--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -542,23 +542,25 @@
           py::arg("alibi_slopes") = std::nullopt, \
           py::arg("gen")          = std::nullopt);
 
-#define MHA_FWD_PYBIND                            \
-    m.def("mha_fwd",                              \
-          &aiter::torch_itfs::mha_fwd,            \
-          py::arg("q"),                           \
-          py::arg("k"),                           \
-          py::arg("v"),                           \
-          py::arg("dropout_p"),                   \
-          py::arg("softmax_scale"),               \
-          py::arg("is_causal"),                   \
-          py::arg("window_size_left"),            \
-          py::arg("window_size_right"),           \
-          py::arg("return_softmax_lse"),          \
-          py::arg("return_dropout_randval"),      \
-          py::arg("out")          = std::nullopt, \
-          py::arg("bias")         = std::nullopt, \
-          py::arg("alibi_slopes") = std::nullopt, \
-          py::arg("gen")          = std::nullopt);
+#define MHA_FWD_PYBIND                             \
+    m.def("mha_fwd",                               \
+          &aiter::torch_itfs::mha_fwd,             \
+          py::arg("q"),                            \
+          py::arg("k"),                            \
+          py::arg("v"),                            \
+          py::arg("dropout_p"),                    \
+          py::arg("softmax_scale"),                \
+          py::arg("is_causal"),                    \
+          py::arg("window_size_left"),             \
+          py::arg("window_size_right"),            \
+          py::arg("return_softmax_lse"),           \
+          py::arg("return_dropout_randval"),       \
+          py::arg("cu_seqlens_q")  = std::nullopt, \
+          py::arg("cu_seqlens_kv") = std::nullopt, \
+          py::arg("out")           = std::nullopt, \
+          py::arg("bias")          = std::nullopt, \
+          py::arg("alibi_slopes")  = std::nullopt, \
+          py::arg("gen")           = std::nullopt);
 
 #define MHA_VARLEN_FWD_ASM_PYBIND                 \
     m.def("fmha_v3_varlen_fwd",                   \
@@ -651,31 +653,33 @@
           py::arg("quant_type")     = 0,            \
           py::arg("activation")     = 0);
 
-#define MHA_VARLEN_FWD_PYBIND                     \
-    m.def("mha_varlen_fwd",                       \
-          &aiter::torch_itfs::mha_varlen_fwd,     \
-          py::arg("q"),                           \
-          py::arg("k"),                           \
-          py::arg("v"),                           \
-          py::arg("cu_seqlens_q"),                \
-          py::arg("cu_seqlens_k"),                \
-          py::arg("max_seqlen_q"),                \
-          py::arg("max_seqlen_k"),                \
-          py::arg("min_seqlen_q"),                \
-          py::arg("dropout_p"),                   \
-          py::arg("softmax_scale"),               \
-          py::arg("logits_soft_cap"),             \
-          py::arg("zero_tensors"),                \
-          py::arg("is_causal"),                   \
-          py::arg("window_size_left"),            \
-          py::arg("window_size_right"),           \
-          py::arg("return_softmax_lse"),          \
-          py::arg("return_dropout_randval"),      \
-          py::arg("out")          = std::nullopt, \
-          py::arg("block_table")  = std::nullopt, \
-          py::arg("bias")         = std::nullopt, \
-          py::arg("alibi_slopes") = std::nullopt, \
-          py::arg("gen")          = std::nullopt);
+#define MHA_VARLEN_FWD_PYBIND                            \
+    m.def("mha_varlen_fwd",                              \
+          &aiter::torch_itfs::mha_varlen_fwd,            \
+          py::arg("q"),                                  \
+          py::arg("k"),                                  \
+          py::arg("v"),                                  \
+          py::arg("cu_seqlens_q"),                       \
+          py::arg("cu_seqlens_k"),                       \
+          py::arg("max_seqlen_q"),                       \
+          py::arg("max_seqlen_k"),                       \
+          py::arg("min_seqlen_q"),                       \
+          py::arg("dropout_p"),                          \
+          py::arg("softmax_scale"),                      \
+          py::arg("logits_soft_cap"),                    \
+          py::arg("zero_tensors"),                       \
+          py::arg("is_causal"),                          \
+          py::arg("window_size_left"),                   \
+          py::arg("window_size_right"),                  \
+          py::arg("return_softmax_lse"),                 \
+          py::arg("return_dropout_randval"),             \
+          py::arg("out")                 = std::nullopt, \
+          py::arg("block_table")         = std::nullopt, \
+          py::arg("bias")                = std::nullopt, \
+          py::arg("alibi_slopes")        = std::nullopt, \
+          py::arg("gen")                 = std::nullopt, \
+          py::arg("cu_seqlens_q_padded") = std::nullopt, \
+          py::arg("cu_seqlens_k_padded") = std::nullopt);
 
 #define MHA_BATCH_PREFILL_PYBIND                  \
     m.def("mha_batch_prefill",                    \

--- a/csrc/include/torch/mha_fwd.h
+++ b/csrc/include/torch/mha_fwd.h
@@ -1,6 +1,6 @@
 #pragma once
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include <torch/extension.h>
 
 namespace aiter {
@@ -15,6 +15,8 @@ std::vector<at::Tensor> mha_fwd(at::Tensor& q,       // [b, sq, hq, d]
                                 int window_size_right,
                                 bool return_softmax_lse,
                                 bool return_dropout_randval,
+                                std::optional<at::Tensor> cu_seqlens_q,
+                                std::optional<at::Tensor> cu_seqlens_kv,
                                 std::optional<at::Tensor> out,                // [b, sq, hq, d]
                                 std::optional<const at::Tensor> bias,         // [sq, sk]
                                 std::optional<const at::Tensor> alibi_slopes, // [hq] or [b, hq]

--- a/csrc/include/torch/mha_varlen_fwd.h
+++ b/csrc/include/torch/mha_varlen_fwd.h
@@ -6,20 +6,29 @@
 namespace aiter {
 namespace torch_itfs {
 std::vector<at::Tensor>
-mha_varlen_fwd(at::Tensor &q,                  // [total_q, hq, d]
-               const at::Tensor &k,            // [total_k, hk, d]
-               const at::Tensor &v,            // [total_k, hk, d]
-               const at::Tensor &cu_seqlens_q, // [b+1]
-               std::optional<const at::Tensor> &cu_seqlens_k, // [b+1]
-               int max_seqlen_q, int max_seqlen_k, int min_seqlen_q,
-               float p_dropout,  float softmax_scale, float logits_soft_cap,
-               bool zero_tensors, bool is_causal, int window_size_left,
-               int window_size_right,  bool return_softmax_lse,
+mha_varlen_fwd(at::Tensor& q,                                 // [total_q, hq, d]
+               const at::Tensor& k,                           // [total_k, hk, d]
+               const at::Tensor& v,                           // [total_k, hk, d]
+               const at::Tensor& cu_seqlens_q,                // [b+1]
+               std::optional<const at::Tensor>& cu_seqlens_k, // [b+1]
+               int max_seqlen_q,
+               int max_seqlen_k,
+               int min_seqlen_q,
+               float p_dropout,
+               float softmax_scale,
+               float logits_soft_cap,
+               bool zero_tensors,
+               bool is_causal,
+               int window_size_left,
+               int window_size_right,
+               bool return_softmax_lse,
                bool return_dropout_randval,
-               std::optional<at::Tensor> out,               // [total_q, hq, d]
-               std::optional<const at::Tensor> block_table, // [hq] or [b, hq]
-               std::optional<const at::Tensor> bias, // [total_q, max_seqlen_k]
+               std::optional<at::Tensor> out,                // [total_q, hq, d]
+               std::optional<const at::Tensor> block_table,  // [hq] or [b, hq]
+               std::optional<const at::Tensor> bias,         // [total_q, max_seqlen_k]
                std::optional<const at::Tensor> alibi_slopes, // [hq] or [b, hq]
-               std::optional<at::Generator> gen);
+               std::optional<at::Generator> gen,
+               std::optional<const at::Tensor> cu_seqlens_q_padded = std::nullopt,
+               std::optional<const at::Tensor> cu_seqlens_k_padded = std::nullopt);
 } // namespace torch_itfs
 } // namespace aiter

--- a/csrc/py_itfs_ck/mha_varlen_fwd_kernels.cu
+++ b/csrc/py_itfs_ck/mha_varlen_fwd_kernels.cu
@@ -36,7 +36,10 @@ mha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                                           float softmax_scale,
                                           float logits_soft_cap,
                                           float p_dropout,
-                                          std::pair<uint64_t*, uint64_t*> drop_seed_offset)
+                                          std::pair<uint64_t*, uint64_t*> drop_seed_offset,
+                                          // optional padded physical seqstarts (including PAD)
+                                          std::optional<const at::Tensor> &cu_seqlens_q_padded_,
+                                          std::optional<const at::Tensor> &cu_seqlens_k_padded_)
 {
     // q: (total_q, nheads, d)
     // k: (total_k, nheads_k, d)
@@ -93,6 +96,31 @@ mha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
         bias_ptr = alibi_slopes.data_ptr();
         stride_bias = alibi_slopes.dim() == 2 ? alibi_slopes.stride(0) : 0;
     }
+    
+    // Validate padded seqstart arrays if provided: shape [b+1], 1D, contiguous, int32/int64, monotonic
+    auto validate_and_maybe_convert = [&](std::optional<const at::Tensor> &opt_seqstarts,
+                                          const char *name) -> const ck_tile::index_t* {
+        if (!opt_seqstarts.has_value()) return nullptr;
+        const at::Tensor &t = opt_seqstarts.value();
+        CHECK_DEVICE(t);
+        TORCH_CHECK(t.dim() == 1, name, " must be 1D");
+        TORCH_CHECK(t.numel() == b + 1, name, " must have length batch+1");
+        TORCH_CHECK(t.is_contiguous(), name, " must be contiguous");
+        TORCH_CHECK(t.dtype() == torch::kInt32, name, " must be int32, actual: ", t.dtype());
+        auto ptr = reinterpret_cast<const ck_tile::index_t*>(t.data_ptr<int32_t>());
+        auto acc = t.index({0}).item<int32_t>();
+        TORCH_CHECK(acc == 0, name, " first element must be 0");
+        auto data_ptr32 = t.data_ptr<int32_t>();
+        for (int i = 1; i < t.numel(); ++i) {
+            int v = data_ptr32[i];
+            TORCH_CHECK(v >= acc, name, " must be non-decreasing");
+            acc = v;
+        }
+        return ptr;
+    };
+
+    const ck_tile::index_t *seqstart_padded_q_ptr = validate_and_maybe_convert(cu_seqlens_q_padded_, "cu_seqlens_q_padded");
+    const ck_tile::index_t *seqstart_padded_k_ptr = validate_and_maybe_convert(cu_seqlens_k_padded_, "cu_seqlens_k_padded");
 
     return mha_fwd_args{q.data_ptr(),
                          k.data_ptr(),
@@ -101,9 +129,13 @@ mha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                          has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
                          has_lse ? softmax_lse.data_ptr() : nullptr,
                          out.data_ptr(),
+                         nullptr, // cu_seqlen_q_ptr (batch mode only)
+                         nullptr, // cu_seqlen_kv_ptr (batch mode only)
                          cu_seqlens_q.data_ptr(), // seqstart_q
                          cu_seqlens_k.has_value() ? cu_seqlens_k.value().data_ptr() : nullptr, // seqstart_k
                          seqlens_k.has_value() ? seqlens_k.value().data_ptr() : nullptr, // seqlen_kpads
+                         seqstart_padded_q_ptr,
+                         seqstart_padded_k_ptr,
                          total_q,
                          total_k,
                          b,
@@ -317,7 +349,9 @@ mha_varlen_fwd(at::Tensor &q,                  // [total_q, hq, d]
                std::optional<const at::Tensor> block_table_,  // [hq] or [b, hq]
                std::optional<const at::Tensor> bias_,         // [total_q, max_seqlen_k]
                std::optional<const at::Tensor> alibi_slopes_, // [hq] or [b, hq]
-               std::optional<at::Generator> gen_)
+               std::optional<at::Generator> gen_,
+               std::optional<const at::Tensor> cu_seqlens_q_padded_, // [b+1] physical starts with PAD
+               std::optional<const at::Tensor> cu_seqlens_k_padded_) // [b+1]
 {
     auto q_dtype = q.scalar_type();
     bool isQKVFp8 = q_dtype == at::ScalarType::Float8_e4m3fn || q_dtype == at::ScalarType::Float8_e4m3fnuz;
@@ -352,6 +386,9 @@ mha_varlen_fwd(at::Tensor &q,                  // [total_q, hq, d]
     at::Tensor block_table;
     const bool paged_KV = block_table_.has_value();
     if (paged_KV) {
+        if (cu_seqlens_q_padded_.has_value() || cu_seqlens_k_padded_.has_value()) {
+            TORCH_CHECK(false, "Paged KV (splitkv, pagekv) does not support sequence padding.");
+        }
         block_table = block_table_.value();
         CHECK_DEVICE(block_table);
         TORCH_CHECK(block_table.dtype() == torch::kInt32, "block_table must have dtype torch.int32");
@@ -575,7 +612,9 @@ mha_varlen_fwd(at::Tensor &q,                  // [total_q, hq, d]
                     softmax_scale,
                     logits_soft_cap,
                     p_dropout,
-                    drop_seed_offset);
+                    drop_seed_offset,
+                    const_cast<std::optional<const at::Tensor>&>(cu_seqlens_q_padded_),
+                    const_cast<std::optional<const at::Tensor>&>(cu_seqlens_k_padded_));
 
             float t = aiter::mha_fwd(args,
                                      stream_config,
@@ -584,7 +623,10 @@ mha_varlen_fwd(at::Tensor &q,                  // [total_q, hq, d]
                                      mask.type,
                                      bias_type,
                                      has_lse,
-                                     false);
+                                     false, // use_ext_asm
+                                     1,     // how_v3_bf16_cvt
+                                     args.seqstart_padded_q_ptr,
+                                     args.seqstart_padded_k_ptr);
             TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
         }
     }

--- a/csrc/py_itfs_cu/asm_mha_fwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_fwd.cu
@@ -92,9 +92,13 @@ mha_fwd_args get_asm_fmha_fwd_args(bool has_lse,
                          has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
                          has_lse ? softmax_lse.data_ptr() : nullptr,
                          out.data_ptr(),
+                         nullptr, // cu_seqlen_q_ptr
+                         nullptr, // cu_seqlen_kv_ptr
                          nullptr, // seqstart_q
                          nullptr, // seqstart_k
-                         nullptr,
+                         nullptr, // seqlen_k_ptr
+                         nullptr, // seqstart_padded_q_ptr
+                         nullptr, // seqstart_padded_k_ptr
                          seqlen_q,
                          seqlen_k,
                          b,

--- a/csrc/py_itfs_cu/asm_mha_varlen_fwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_varlen_fwd.cu
@@ -101,9 +101,13 @@ mha_fwd_args get_asm_mha_varlen_fwd_args(bool has_lse,
                          has_dropout_randval ? dropout_randval.data_ptr() : nullptr,
                          has_lse ? softmax_lse.data_ptr() : nullptr,
                          out.data_ptr(),
+                         nullptr,
+                         nullptr,
                          cu_seqlens_q.data_ptr(), // seqstart_q
                          cu_seqlens_k.has_value() ? cu_seqlens_k.value().data_ptr() : nullptr, // seqstart_k
                          seqlens_k.has_value() ? seqlens_k.value().data_ptr() : nullptr, // seqlen_kpads
+                         nullptr,
+                         nullptr,
                          total_q,
                          total_k,
                          b,


### PR DESCRIPTION
## Motivation

Sequence Padding for FMHA Forward - Adapts to the new Composable Kernel (CK) padding API to support sequence padding. - Enables efficient attention computation for batches with variable sequence lengths by ignoring padded tokens.

## Technical Details

- Batch Mode (mha_fwd)
    - Adds two new optional parameters to control padding:
      - cu_seqlens_q: Specifies the cumulative sequence lengths for query tensors.
      - cu_seqlens_kv: Specifies the cumulative sequence lengths for key/value tensors.

 - Group Mode (mha_varlen_fwd) 
   - Adds two new optional parameters to manage padding based on physical length (including padded tokens): 
   - cu_seqlens_q_padded: The cumulative physical sequence lengths for the query. - cu_seqlens_k_padded: The cumulative physical sequence lengths for the key/value.

 - Limitations
    - Forward Pass Only: Padding is only implemented for the fmha_fwd operation. The backward pass is not supported.
    - Unsupported Kernels: The padding API is not available for:
      - Paged/Split-KV attention (pagedkv, splitkv).
      - The fmha_fwd_v3 kernel.
## Test Plan

Adds test_flash_attn_padding and test_varlen_flash_attn_padding to validate the implementation against a PyTorch reference.

## Test Result

All tests in test_flash_attn_padding and test_varlen_flash_attn_padding are passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
