### PR TITLE
add module_gemm_a8w8_blockscale in aot_build list

### DIFF
--- a/aiter/aot/aot.py
+++ b/aiter/aot/aot.py
@@ -108,6 +108,7 @@ def main():
         "module_mla_metadata",
         "module_mla_reduce",
         "module_mla_asm",
+        "module_gemm_a8w8_blockscale",
         # "module_moe_ck2stages",
     ]
     print(f"modules_to_build: {modules_to_build}")


### PR DESCRIPTION
for single gemm_a8w8_blockscale test , can simply run as following

```sh
cd aiter
python3 -m aiter.aot.aot --modules module_gemm_a8w8_blockscale --out-dir  /opt/aiter/aiter/jit/ 
python3 op_tests/test_gemm_a8w8_blockscale.py 
```

for all aot kernels test, run :

```sh
cd aiter
python3 -m aiter.aot.aot  --out-dir  /opt/aiter/aiter/jit/ 

```
