### PR TITLE
Tuning Utility update

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -31,9 +31,9 @@ aiter_lib = None
 
 def mp_lock(
     lockPath: str,
-    MainFunc: callable,
-    FinalFunc: callable = None,
-    WaitFunc: callable = None,
+    MainFunc: Callable,
+    FinalFunc: Optional[Callable] = None,
+    WaitFunc: Optional[Callable] = None,
 ):
     """
     Using FileBaton for multiprocessing.
@@ -65,6 +65,7 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 
 AITER_ROOT_DIR = os.path.abspath(f"{this_dir}/../../")
 AITER_LOG_MORE = int(os.getenv("AITER_LOG_MORE", 0))
+AITER_LOG_TUNED_CONFIG = int(os.getenv("AITER_LOG_TUNED_CONFIG", 0))
 
 find_aiter = importlib.util.find_spec("aiter")
 if find_aiter is not None:

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -269,7 +269,7 @@
         "extra_include": [],
         "verbose": "False",
         "hip_clang_path": "os.environ.get('GEMM_A4W4_BLOCKWISE_HIP_CLANG_PATH')",
-        "blob_gen_cmd": "f'{AITER_CSRC_DIR}/ck_gemm_a4w4_blockscale/gen_instances.py --working_path {{}} --tune_file {AITER_ROOT_DIR}/aiter/configs/a4w4_blockscale_tuned_gemm.csv'"
+        "blob_gen_cmd": "f'{AITER_CSRC_DIR}/ck_gemm_a4w4_blockscale/gen_instances.py --working_path {{}} --tune_file {AITER_ROOT_DIR}/aiter/configs/{AITER_CONFIG_GEMM_A4W4}.csv'"
     },
     "module_gemm_a8w8_bpreshuffle": {
         "srcs": [

--- a/aiter/ops/gemm_op_a4w4.py
+++ b/aiter/ops/gemm_op_a4w4.py
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+import functools
+import os
+from typing import Optional
+
+import pandas as pd
 import torch
 from torch import Tensor
-from typing import Optional
+
 from aiter import logger
-from ..jit.core import (
-    compile_ops,
-    AITER_ROOT_DIR,
-)
-from ..jit.utils.chip_info import get_cu_num
-from ..jit.utils.chip_info import get_gfx
-import functools
-import pandas as pd
+
+from ..jit.core import AITER_LOG_TUNED_CONFIG, AITER_ROOT_DIR, compile_ops
+from ..jit.utils.chip_info import get_cu_num, get_gfx
 from ..ops.gemm_op_common import get_padded_m
 
 
@@ -29,12 +29,16 @@ def compute_gemm_SplitK(M: int, N: int, K: int, tile_m: int, tile_n: int, tile_k
     return 3
 
 
+AITER_CONFIG_GEMM_A4W4 = os.getenv(
+    "AITER_CONFIG_GEMM_A4W4",
+    f"{AITER_ROOT_DIR}/aiter/configs/a4w4_blockscale_tuned_gemm.csv",
+)
+
+
 @functools.lru_cache(maxsize=1024)
 def get_GEMM_config(M: int, N: int, K: int):
     if not hasattr(get_GEMM_config, "gemm_dict"):
-        gemm_dict = pd.read_csv(
-            f"{AITER_ROOT_DIR}/aiter/configs/a4w4_blockscale_tuned_gemm.csv"
-        ).drop_duplicates()
+        gemm_dict = pd.read_csv(AITER_CONFIG_GEMM_A4W4).drop_duplicates()
         get_GEMM_config.gemm_dict = gemm_dict.set_index(
             ["cu_num", "M", "N", "K"]
         ).to_dict("index")
@@ -44,12 +48,12 @@ def get_GEMM_config(M: int, N: int, K: int):
     for gl in [None, 0, 1]:
         padded_M = M if gl is None else get_padded_m(M, N, K, gl)
         config = get_GEMM_config.gemm_dict.get((cu_num, padded_M, N, K), None)
-        if config is not None:
+        if AITER_LOG_TUNED_CONFIG and config is not None:
             logger.info(
                 f"shape is M:{M}, N:{N}, K:{K}, found padded_M: {padded_M}, N:{N}, K:{K} is tuned on cu_num = {cu_num} in CKGEMM or asmGEMM, kernel name is {config['kernelName']}, splitK is {config['splitK']}!"
             )
             break
-    if config is None:
+    else:
         logger.info(
             f"shape is M:{M}, N:{N}, K:{K}, not found tuned config in CKGEMM or asmGEMM, will use default config!"
         )

--- a/csrc/ck_gemm_a4w4_blockscale/gemm_a4w4_blockscale_tune.py
+++ b/csrc/ck_gemm_a4w4_blockscale/gemm_a4w4_blockscale_tune.py
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+import argparse
 import os
-import aiter
+
 import pandas as pd
 import torch
-from aiter import dtypes
-from aiter.utility import fp4_utils
-from aiter.test_common import perftest
-from aiter.utility.base_tuner import GemmCommonTuner
-from aiter.ops.shuffle import shuffle_weight
 from gemm_a4w4_blockscale_common import kernels_list
-import argparse
-from aiter.utility.mp_tuner import mp_tuner
+
+import aiter
+from aiter import dtypes
 from aiter.jit.core import get_asm_dir
+from aiter.ops.gemm_op_a4w4 import AITER_CONFIG_GEMM_A4W4
+from aiter.ops.shuffle import shuffle_weight
+from aiter.test_common import perftest
+from aiter.utility import fp4_utils
+from aiter.utility.base_tuner import GemmCommonTuner
+from aiter.utility.mp_tuner import mp_tuner
 
 # torch.set_default_device("cuda")
 torch.set_printoptions(sci_mode=False)
@@ -129,7 +132,7 @@ def generate_data(m, n, k, seed, device="cuda", dtype=dtypes.bf16):
 class GemmA4W4BlockScaleTuner(GemmCommonTuner):
     ARG_DEFAULTS = {
         **GemmCommonTuner.ARG_DEFAULTS,
-        "tune_file": "aiter/configs/a4w4_blockscale_tuned_gemm.csv",
+        "tune_file": f"aiter/configs/{AITER_CONFIG_GEMM_A4W4}.csv",
         "untune_file": "aiter/configs/a4w4_blockscale_untuned_gemm.csv",
     }
 

--- a/csrc/ck_gemm_a4w4_blockscale/gen_instances.py
+++ b/csrc/ck_gemm_a4w4_blockscale/gen_instances.py
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
-import os
-from pathlib import Path
-import pandas as pd
 import argparse
+import os
 import shutil
+from pathlib import Path
+
+import pandas as pd
 import torch
 from gemm_a4w4_blockscale_common import (
+    default_kernels_dict,
     kernelInstance,
     kernels_list,
-    default_kernels_dict,
 )
 
+from aiter.ops.gemm_op_a4w4 import AITER_CONFIG_GEMM_A4W4
 
 """
 
@@ -260,7 +262,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-f",
         "--tune_file",
-        default="aiter/configs/a4w4_blockscale_tuned_gemm.csv",
+        default=f"aiter/configs/{AITER_CONFIG_GEMM_A4W4}.csv",
         required=False,
         help="tune_file include the result after run gemm_a4w4_tune.py",
     )


### PR DESCRIPTION
## Motivation

1. add env "AITER_LOG_TUNED_CONFIG" to contral log for tuned shape
2. add env "AITER_CONFIG_GEMM_A4W4" for load specified config by User, like  AITER_CONFIG_GEMM_A4W4=xxxx/llama_a4w4_config.csv for llama, AITER_CONFIG_GEMM_A4W4=xxxx/qwen.csv for qwen

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
