### PR TITLE
[Triton] e2e fused MoE for small N and fp8 blockscale MoE benching

### DIFF
--- a/aiter/ops/triton/_triton_kernels/moe_op_e2e.py
+++ b/aiter/ops/triton/_triton_kernels/moe_op_e2e.py
@@ -93,7 +93,7 @@ def e2e_moe_kernel(
     EVEN_K: tl.constexpr,
     EVEN_K2: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
-    use_block_scale: tl.constexpr, 
+    use_block_scale: tl.constexpr,
     use_fp8_w8a8: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -214,7 +214,6 @@ def e2e_moe_kernel(
                 other=0.0,
             )
 
-
         silu_acc = tl.dot(a, w1, acc=silu_acc)
 
         # mul acc
@@ -235,7 +234,7 @@ def e2e_moe_kernel(
     if return_intermediate:
         offs_in = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         i_ptrs = Intermediate + stride_im * offs_token[:, None] + offs_in[None, :]
-        i_mask = token_mask[:, None] & (offs_in[None, :] < N )
+        i_mask = token_mask[:, None] & (offs_in[None, :] < N)
         tl.store(i_ptrs, acc.to(out_dtype), mask=i_mask)
 
     acc = tl.where(
@@ -246,7 +245,7 @@ def e2e_moe_kernel(
 
     acc = acc.to(dtype)
 
-    offs_w2n = (tl.arange(0, BLOCK_SIZE_N) + pid_n * (BLOCK_SIZE_N)) % (N )
+    offs_w2n = (tl.arange(0, BLOCK_SIZE_N) + pid_n * (BLOCK_SIZE_N)) % (N)
 
     w2_ptrs = (
         W2
@@ -273,7 +272,7 @@ def e2e_moe_kernel(
             out_mask = token_mask[:, None] & (
                 offs_k2[None, :] < (K - k2 * BLOCK_SIZE_K2)
             )
-        
+
         if SKINNY:
             # Skinny means that there is only one pid along N (i.e. BLOCK_SIZE_N >= N).
             # Thus we don't need atomics, as there is only workgroup updating a output location.
@@ -281,13 +280,7 @@ def e2e_moe_kernel(
             tl.store(out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok, out, mask=out_mask)
         else:
             out = out.to(tl.float32)  # atomics need to be done in fp32
-            tl.atomic_add(
-                out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok,
-                out,
-                mask=out_mask
-            )
-
-        
+            tl.atomic_add(out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok, out, mask=out_mask)
 
 
 @triton.heuristics(
@@ -339,7 +332,7 @@ def e2e_moe_kernel_fp8(
     EVEN_K: tl.constexpr,
     EVEN_K2: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
-    use_block_scale: tl.constexpr, 
+    use_block_scale: tl.constexpr,
     use_fp8_w8a8: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -496,7 +489,7 @@ def e2e_moe_kernel_fp8(
     if return_intermediate:
         offs_in = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         i_ptrs = Intermediate + stride_im * offs_token[:, None] + offs_in[None, :]
-        i_mask = token_mask[:, None] & (offs_in[None, :] < N )
+        i_mask = token_mask[:, None] & (offs_in[None, :] < N)
         tl.store(i_ptrs, acc.to(out_dtype), mask=i_mask)
 
     acc = tl.where(
@@ -507,7 +500,7 @@ def e2e_moe_kernel_fp8(
 
     acc = acc.to(tl.bfloat16)
 
-    offs_w2n = (tl.arange(0, BLOCK_SIZE_N) + pid_n * (BLOCK_SIZE_N)) % (N )
+    offs_w2n = (tl.arange(0, BLOCK_SIZE_N) + pid_n * (BLOCK_SIZE_N)) % (N)
 
     w2_ptrs = (
         W2
@@ -543,7 +536,7 @@ def e2e_moe_kernel_fp8(
             out_mask = token_mask[:, None] & (
                 offs_k2[None, :] < (K - k2 * BLOCK_SIZE_K2)
             )
-        
+
         if SKINNY:
             # Skinny means that there is only one pid along N (i.e. BLOCK_SIZE_N >= N).
             # Thus we don't need atomics, as there is only workgroup updating a output location.
@@ -551,13 +544,8 @@ def e2e_moe_kernel_fp8(
             tl.store(out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok, out, mask=out_mask)
         else:
             out = out.to(tl.float32)  # atomics need to be done in fp32
-            tl.atomic_add(
-                out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok,
-                out,
-                mask=out_mask
-            )
+            tl.atomic_add(out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok, out, mask=out_mask)
 
-        
 
 @triton.heuristics(
     {
@@ -608,7 +596,7 @@ def e2e_moe_kernel_fp8_blockscale(
     EVEN_K: tl.constexpr,
     EVEN_K2: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
-    use_block_scale: tl.constexpr, 
+    use_block_scale: tl.constexpr,
     use_fp8_w8a8: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -700,7 +688,7 @@ def e2e_moe_kernel_fp8_blockscale(
         tl.static_assert(
             group_k == K,
             "per-token quantization requires group k to be K",
-            )
+        )
 
     offs_i0 = tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
     offs_i1 = (tl.arange(0, BLOCK_SIZE_N) + N).to(tl.int64)
@@ -729,41 +717,41 @@ def e2e_moe_kernel_fp8_blockscale(
 
     # if use_fp8_w8a8 and use_block_scale:
     a_scale_ptrs = A_scale + (offs_token[:, None] // top_k * stride_asm)
-    
-    i0s = (pid_n * (BLOCK_SIZE_N // group_n) + tl.arange(0, num_scales_along_bn))
-    i0s = i0s % num_scales_along_n # wrap around if N is not multiple of group_n
-    i1s = (i0s + (N // group_n)) 
-    
-    w1_i0_scale_ptrs = (
-        W1_scale + off_experts * stride_w1se + i0s[None, :] * stride_w1sn
-    )
-    w1_i1_scale_ptrs = (
-        W1_scale + off_experts * stride_w1se + i1s[None, :] * stride_w1sn
-    )
+
+    i0s = pid_n * (BLOCK_SIZE_N // group_n) + tl.arange(0, num_scales_along_bn)
+    i0s = i0s % num_scales_along_n  # wrap around if N is not multiple of group_n
+    i1s = i0s + (N // group_n)
+
+    w1_i0_scale_ptrs = W1_scale + off_experts * stride_w1se + i0s[None, :] * stride_w1sn
+    w1_i1_scale_ptrs = W1_scale + off_experts * stride_w1se + i1s[None, :] * stride_w1sn
     # We only need to descale inside the loop if loop K has varying scales
     VARYING_K_SCALE: tl.constexpr = (not PER_TOKEN_QUANT_A) and (K > group_k)
-    if not VARYING_K_SCALE: # otherwise load the scales and descale outside the loop
-        w1_i0_scale = tl.load(
-            w1_i0_scale_ptrs
+    if not VARYING_K_SCALE:  # otherwise load the scales and descale outside the loop
+        w1_i0_scale = tl.load(w1_i0_scale_ptrs)
+        w1_i0_scale = repeat_interleave_triton(
+            w1_i0_scale, 1, num_scales_along_bn, group_n, 1
         )
-        w1_i0_scale = repeat_interleave_triton(w1_i0_scale, 1, num_scales_along_bn, group_n, 1)
-        w1_i1_scale = tl.load(
-            w1_i1_scale_ptrs
+        w1_i1_scale = tl.load(w1_i1_scale_ptrs)
+        w1_i1_scale = repeat_interleave_triton(
+            w1_i1_scale, 1, num_scales_along_bn, group_n, 1
         )
-        w1_i1_scale = repeat_interleave_triton(w1_i1_scale, 1, num_scales_along_bn, group_n, 1)
         if PER_TOKEN_QUANT_A:
             a_scale = tl.load(a_scale_ptrs, mask=token_mask[:, None], other=0.0)
         else:
             a_scale = tl.load(A_scale)
-    
+
     num_k1 = tl.cdiv(K, BLOCK_SIZE_K1)
     for k1 in tl.range(0, num_k1):
         a_ptrs_k = a_ptrs + k1 * BLOCK_SIZE_K1 * stride_ak
         w1_ptrs_i0_k = w1_ptrs_i0 + k1 * BLOCK_SIZE_K1 * stride_w1k
         w1_ptrs_i1_k = w1_ptrs_i1 + k1 * BLOCK_SIZE_K1 * stride_w1k
         # scale ptrs
-        w1_i0_scale_ptrs_k = w1_i0_scale_ptrs + k1 * BLOCK_SIZE_K1 // group_k * stride_w1sk
-        w1_i1_scale_ptrs_k = w1_i1_scale_ptrs + k1 * BLOCK_SIZE_K1 // group_k * stride_w1sk
+        w1_i0_scale_ptrs_k = (
+            w1_i0_scale_ptrs + k1 * BLOCK_SIZE_K1 // group_k * stride_w1sk
+        )
+        w1_i1_scale_ptrs_k = (
+            w1_i1_scale_ptrs + k1 * BLOCK_SIZE_K1 // group_k * stride_w1sk
+        )
         a_scale_ptrs_k = a_scale_ptrs + k1 * BLOCK_SIZE_K1 // group_k * stride_ask
 
         # pipeline silu acc and mul acc so they can use the same LDS for weight loading
@@ -787,10 +775,10 @@ def e2e_moe_kernel_fp8_blockscale(
 
         if VARYING_K_SCALE:
             w1_scale = tl.load(w1_i0_scale_ptrs_k)
-            w1_scale = repeat_interleave_triton(w1_scale, 1, num_scales_along_bn, group_n, 1)
-            a_scale = tl.load(
-                a_scale_ptrs_k, mask=token_mask[:, None], other=0.0
+            w1_scale = repeat_interleave_triton(
+                w1_scale, 1, num_scales_along_bn, group_n, 1
             )
+            a_scale = tl.load(a_scale_ptrs_k, mask=token_mask[:, None], other=0.0)
             silu_acc += tl.dot(a, w1, out_dtype=tl.float32) * a_scale * w1_scale
         else:
             silu_acc = tl.dot(a, w1, acc=silu_acc)
@@ -806,7 +794,9 @@ def e2e_moe_kernel_fp8_blockscale(
             )
         if VARYING_K_SCALE:
             w1_scale = tl.load(w1_i1_scale_ptrs_k)
-            w1_scale = repeat_interleave_triton(w1_scale, 1, num_scales_along_bn, group_n, 1)
+            w1_scale = repeat_interleave_triton(
+                w1_scale, 1, num_scales_along_bn, group_n, 1
+            )
             mul_acc += tl.dot(a, w1, out_dtype=tl.float32) * a_scale * w1_scale
         else:
             mul_acc = tl.dot(a, w1, acc=mul_acc)
@@ -833,7 +823,7 @@ def e2e_moe_kernel_fp8_blockscale(
 
     acc = acc.to(tl.bfloat16)
 
-    offs_w2n = (tl.arange(0, BLOCK_SIZE_N) + pid_n * (BLOCK_SIZE_N)) % (N )
+    offs_w2n = (tl.arange(0, BLOCK_SIZE_N) + pid_n * (BLOCK_SIZE_N)) % (N)
 
     w2_ptrs = (
         W2
@@ -843,9 +833,7 @@ def e2e_moe_kernel_fp8_blockscale(
 
     # offs_w2_sn = offs_w2n // group_n
     # instead load only the unique scaling factors and broadcast.
-    offs_w2_sn = (pid_n * BLOCK_SIZE_N) // group_n + tl.arange(
-        0, num_scales_along_bn
-    )
+    offs_w2_sn = (pid_n * BLOCK_SIZE_N) // group_n + tl.arange(0, num_scales_along_bn)
     # ... + tl.arange(0, num_scales_along_bn) * group_n // group_n = ... + tl.arange(0, num_scales_along_bn)
     w2_scale_ptrs = (
         W2_scale + off_experts * stride_w2se + offs_w2_sn[:, None] * stride_w2sn
@@ -879,7 +867,9 @@ def e2e_moe_kernel_fp8_blockscale(
             )
             w2 = w2.to(tl.float32) * w2_scale.to(tl.float32)
         else:
-            w2_scale = repeat_interleave_triton(w2_scale, 1, num_scales_along_bk2, group_k, 1)
+            w2_scale = repeat_interleave_triton(
+                w2_scale, 1, num_scales_along_bk2, group_k, 1
+            )
 
         w2 = w2.to(tl.bfloat16)
         out = tl.dot(acc, w2)
@@ -899,7 +889,7 @@ def e2e_moe_kernel_fp8_blockscale(
             out_mask = token_mask[:, None] & (
                 offs_k2[None, :] < (K - k2 * BLOCK_SIZE_K2)
             )
-        
+
         if SKINNY:
             # Skinny means that there is only one pid along N (i.e. BLOCK_SIZE_N >= N).
             # Thus we don't need atomics, as there is only workgroup updating a output location.
@@ -907,9 +897,4 @@ def e2e_moe_kernel_fp8_blockscale(
             tl.store(out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok, out, mask=out_mask)
         else:
             out = out.to(tl.float32)  # atomics need to be done in fp32
-            tl.atomic_add(
-                out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok,
-                out,
-                mask=out_mask
-            )
-
+            tl.atomic_add(out_ptrs + k2 * BLOCK_SIZE_K2 * stride_ok, out, mask=out_mask)

--- a/op_tests/op_benchmarks/triton/bench_moe.py
+++ b/op_tests/op_benchmarks/triton/bench_moe.py
@@ -278,8 +278,6 @@ def run_benchmark(args):
 
     assert not (e2e_fused and silu_fused)
 
-
-
     if silu_fused or e2e_fused:
         args.no_bench_stage2 = True
 
@@ -456,7 +454,11 @@ def parse_args():
         "-block_shape", nargs=2, type=int, default=None, help="block shape n and k"
     )
     parser.add_argument(
-        "-per_token_quant_a", action="store_true", default=False, help="Per-token quantization for input. Per tensor for weights (or blockscale if -block_shape is set).")
+        "-per_token_quant_a",
+        action="store_true",
+        default=False,
+        help="Per-token quantization for input. Per tensor for weights (or blockscale if -block_shape is set).",
+    )
 
     parser.add_argument("-routed_weight", action="store_true", default=False)
     parser.add_argument("-int8_w8a16", action="store_true", default=False)

--- a/op_tests/op_benchmarks/triton/utils/benchmark_utils.py
+++ b/op_tests/op_benchmarks/triton/utils/benchmark_utils.py
@@ -331,7 +331,7 @@ def print_vgpr(fun, table_start="result-table-name"):
             # Redirect stdout and stderr to the temporary file
             sys.stdout = temp_file
             sys.stderr = temp_file
-        
+
             os.environ["AMDGCN_ENABLE_DUMP"] = "1"
             os.environ["TRITON_ALWAYS_COMPILE"] = "1"
             os.environ["TRITON_PRINT_AUTOTUNING"] = "1"
@@ -352,10 +352,10 @@ def print_vgpr(fun, table_start="result-table-name"):
         os.unlink(output_file)
 
     except Exception as e:
-            # Restore stdout and stderr to normal before printing error
-            sys.stdout = sys.__stdout__
-            sys.stderr = sys.__stderr__
-            print(f"Error occurred during function execution: {e}")
+        # Restore stdout and stderr to normal before printing error
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+        print(f"Error occurred during function execution: {e}")
 
 
 def get_dtype_bytes(dtype):


### PR DESCRIPTION
Authors: @juuso-oskari @Chi-Chu319 

# e2e fused MoE for small N

This PR adds end to end implementation of MoE optimized for short intermediate representation (N <= 1024). The idea is that because the intermediate dimension is so small, we can fit the whole intermediate token representation to shared memory and fuse the two gemms of MoE efficiently as two Triton tl.dot operations.

The benefit of the fusion is that we avoid having to store and load the intermediate tensor of size (M, topk, intermediate_size). For large M, this starts to be a significant part of the memory traffic.

We provide the default fp16 and the blockscaled fp8 version. Some implementation details for the blockscaled fp8 version:

- we don't do the second gemm in fp8, but rather descale the second weight matrix. We are forced to do this as BLOCK_SIZE_N // 2 > group_n (block size is larger than the quantization group size along n) and N is the inner dimension for the second tl.dot. This however allows us to skip the quantization / dequantization of the intermediate. 
- we load only the unique scaling factors and then broadcast to the block dimension. This differs from other quantized Triton kernels, where we usually just do a block sized load along the outer block dimensions for scaling factors. We found that this offers a slight perf boost for the loading of the w1 scale factors. And actually for the w2 scale factors this is necessary so we won't overflow the LDS usage: without it the w2_scale load would have size (BLOCK_SIZE_HALF, BLOCK_SIZE_K2) in fp32, which is enough to overflow the LDS. But doing it the broadcast way, the LDS requirement is only (BLOCK_SIZE_HALF/group_n, BLOCK_SIZE_K2/group_k) as the broadcast happens in registers.

```python
# num_scales_along_n = BLOCK_SIZE_HALF // group_n
# num_scales_along_k2 = BLOCK_SIZE_K2 // group_k
w2_scale = tl.load(w2_scale_ptrs + k2 * BLOCK_SIZE_K2 // group_k * stride_w2sk) 
# w2_scale is of size (num_scales_along_n, num_scales_along_k2) compared to (BLOCK_SIZE_HALF , BLOCK_SIZE_K2)
# do the broadcasts in register memory
w2_scale = group_broadcast(w2_scale, num_scales_along_n, num_scales_along_k2, group_n, 0)  
w2_scale = group_broadcast(w2_scale, num_scales_along_n * group_n, num_scales_along_k2, group_k, 1)
# (BLOCK_SIZE_N, BLOCK_SIZE_K2)
```

# fp8 blockscale MoE benching

This PR also modifies the benching script of MoE to enable benching of blockscaled fp8 MoE.

# Reasoning why this works

MoE is comparable to two layer MLP (after alignment of the tokens). Small N (i.e. intermediate size after the first gemm) makes it a special case, that can be efficiently fully fused (this has been observed in papers [1](https://tom94.net/data/publications/mueller21realtime/mueller21realtime.pdf) and [2](https://arxiv.org/html/2403.17607v1#bib.bib8)). The gated activation unit, which essentially halves the intermediate size, makes it even more plausible.

Small N arises if the intermediate size (e.g. the moe_intermediate_size in Qwen3-235B [configs.json](https://huggingface.co/Qwen/Qwen3-235B-A22B/blob/main/config.json)) itself is small, or we are running these models in Tensor Parallel mode. 

Running in Tensor Parallel mode distributes the first weight in column parallel and the second weight in row parallel. For example, in TP=8 the N becomes N=moe_intemediate_size/8 (e.g. 192 for Qwen3-235B), which is usually small. 

## Concern: Limited parallelism

We end up only parallelizing along sorted_token_ids length which is max_num_tokens_padded= topk * M + E * (BLOCK_SIZE_M – 1), but in the newer MoE models (like Qwen3) this is sufficiently large due to large topk and E. Also this fusion is meant to be enabled in high M realm.

 # Bench results
Initial performance results for small M (M=32), which is a typical case in inference and when the Tensor Parallel mode would be used.

## FP8 blockscale

baseline (aka the two kernels launched for the two gemms):
```console
(py_3.10) jukorhon@asrock-1w300-e0-3:~/aiter$ python op_tests/op_benchmarks/triton/bench_moe.py --model qwen3-235B -M 32 -block_shape 128 128 -fp8_w8a8 -tp 8
        model   M     N     K    E  top_k   stage  Time_(ms)    TFLOPS  Bandwidth_(GB/s)  Arithmetic_Intensity_(Flops/Byte)
0  qwen3-235B  32  1536  4096  128      8  stage1   0.050151  7.883703       1794.779303                           4.559555
1  qwen3-235B  32  4096   768  128      8  stage2   0.079436  2.526791        594.865322                           4.363346
```
e2e fused moe:
```console
(py_3.10) jukorhon@asrock-1w300-e0-3:~/aiter$ python op_tests/op_benchmarks/triton/bench_moe.py --model qwen3-235B -M 32 -block_shape 128 128 -fp8_w8a8 -tp 8 -e2e_fused
        model   M     N     K    E  top_k stage  Time_(ms)   TFLOPS  Bandwidth_(GB/s)  Arithmetic_Intensity_(Flops/Byte)
0  qwen3-235B  32  1536  4096  128      8  both   0.089938  6.73412       1477.348965                           4.690146
```

## BF16

baseline (aka the two kernels launched for the two gemms):
```console
(py_3.10) jukorhon@asrock-1w300-e0-3:~/aiter$ python op_tests/op_benchmarks/triton/bench_moe.py --model qwen3-235B -M 32 -tp 8
        model   M     N     K    E  top_k   stage  Time_(ms)    TFLOPS  Bandwidth_(GB/s)  Arithmetic_Intensity_(Flops/Byte)
0  qwen3-235B  32  1536  4096  128      8  stage1   0.132614  3.013753       1362.816432                           2.165286
1  qwen3-235B  32  4096   768  128      8  stage2   0.199044  0.980681        454.342720                           2.313090
```
e2e fused moe:
```console
(py_3.10) jukorhon@asrock-1w300-e0-3:~/aiter$ python op_tests/op_benchmarks/triton/bench_moe.py --model qwen3-235B -M 32 -tp 8 -e2e_fused
        model   M     N     K    E  top_k stage  Time_(ms)    TFLOPS  Bandwidth_(GB/s)  Arithmetic_Intensity_(Flops/Byte)
0  qwen3-235B  32  1536  4096  128      8  both   0.117582  5.148464       2304.340945                           2.264457
```

## On the limits: N=1024

N=1024 starts to be on the limit where the e2e fusion works. We can test it for example by running llama4-maverick in TP=8 mode:

```
(py_3.10) jukorhon@asrock-1w300-e0-3:~/aiter$ python op_tests/op_benchmarks/triton/bench_moe.py --model llama4-maverick -M 32 -tp 8
[aiter] import [module_aiter_enum] under /home/jukorhon/aiter/aiter/jit/module_aiter_enum.so
bench_moe:
             model   M     N     K    E  top_k   stage  Time_(ms)    TFLOPS  Bandwidth_(GB/s)  Arithmetic_Intensity_(Flops/Byte)
0  llama4-maverick  32  8192  5120  128      1  stage1   0.164548  2.038522       1980.474932                           1.102023
1  llama4-maverick  32  5120  4096  128      1  stage2   0.330458  0.506098        470.929295                           1.100839
(py_3.10) jukorhon@asrock-1w300-e0-3:~/aiter$ python op_tests/op_benchmarks/triton/bench_moe.py --model llama4-maverick -M 32 -tp 8 -e2e_fused
[aiter] import [module_aiter_enum] under /home/jukorhon/aiter/aiter/jit/module_aiter_enum.so
bench_moe:
             model   M     N     K    E  top_k stage  Time_(ms)   TFLOPS  Bandwidth_(GB/s)  Arithmetic_Intensity_(Flops/Byte)
0  llama4-maverick  32  8192  5120  128      1  both    0.43835  1.15351       1041.136359                           1.000358
```

To be noted, we expect that the baseline is underperforming to some degree because it lacks tuning for these specific shapes.