### PR TITLE
Add openpyxl to optional deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ pytest
 psutil
 matplotlib
 pyyaml
-openpyxl
 einops
 pybind11>=3.0.1


### PR DESCRIPTION
## Motivation

openpyxl is currently used in https://github.com/ROCm/aiter/blob/82438b0c90a68775276cf939092294e71d925456/aiter/configs/model_configs/script/config_convert.py#L1

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
