### PR TITLE
[BugFix] Change Vskip Selection Logic

### DIFF
--- a/csrc/py_itfs_cu/asm_fmoe.cu
+++ b/csrc/py_itfs_cu/asm_fmoe.cu
@@ -265,7 +265,7 @@ FMoeKernel* get_heuristic_kernel(
     static std::unordered_map<std::string, std::unique_ptr<FMoeKernel>> impl_ptr_map;
 
     const char* vs_env_value = std::getenv("AITER_ENABLE_VSKIP");
-    if(vs_env_value != nullptr && std::string(vs_env_value) == "0")
+    if(vs_env_value == nullptr || std::string(vs_env_value) == "0")
         vskip = 0;
     if(selectedKl.empty())
     {


### PR DESCRIPTION
## Motivation
FIX #1143 
## Technical Details
This PR changes the env flag check to default to false if `AITER_ENABLE_VSKIP` is not set


## Test Plan
Run `aiter/op_tests/test_moe.py`

## Test Result
Al tests that pass before the change pass after the change

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
