### PR TITLE
fix the error in the fwd v3 api when the group mode not supported swa yet

### DIFF
--- a/hsa/gfx942/fmha_v3_fwd/codegen.py
+++ b/hsa/gfx942/fmha_v3_fwd/codegen.py
@@ -347,7 +347,7 @@ float fmha_fwd_v3(mha_fwd_traits t, mha_fwd_args a, const ck_tile::stream_config
                     }
                 }
                 else {
-                    if (t.mask_type == mask_enum::mask_bottom_right) {
+                    if (t.mask_type == mask_enum::mask_bottom_right && ((a.window_size_left == -1) && (a.window_size_right == 0))) {
                         if (t.how_v3_bf16_cvt == 0) {
                             if (t.has_lse == false) {
                                 using fmha_fwd_kernel = fmha_fwd_kernel_selector<FmhaFwdBf16, 128, 1, false, false, 0, GPUArch::gfx942, 0, true>;

--- a/hsa/gfx950/fmha_v3_fwd/codegen.py
+++ b/hsa/gfx950/fmha_v3_fwd/codegen.py
@@ -226,7 +226,7 @@ float fmha_fwd_v3(mha_fwd_traits t, mha_fwd_args a, const ck_tile::stream_config
                     }
                 }
                 else {
-                    if (t.mask_type == mask_enum::mask_bottom_right) {
+                    if (t.mask_type == mask_enum::mask_bottom_right && ((a.window_size_left == -1) && (a.window_size_right == 0))) {
                         if (t.has_lse == false) {
                             using fmha_fwd_kernel = fmha_fwd_kernel_selector<FmhaFwdBf16, 128, 1, false, false, 0, GPUArch::gfx950, 1, true>;
                             if (is_v3_api_check) {


### PR DESCRIPTION
## Motivation

fix the error in the fwd v3 api when the group mode not supported swa

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
./benchmark_mha_fwd -fwd_v3=1 -mode=1 -b=2 -h=24 -h_k=4 -s=2048 -d=128  -iperm=0 -operm=0 -mask=b:2,2 -kname=1 -lse=1 -prec=bf16

## Test Result

<img width="1508" height="99" alt="image" src="https://github.com/user-attachments/assets/d1f8407c-ec6b-4361-80d0-d09daa751d8a" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
