### PR TITLE
Fix sgl deepseek error with cudagraph plus torch.compile

### DIFF
--- a/aiter/jit/utils/torch_guard.py
+++ b/aiter/jit/utils/torch_guard.py
@@ -3,6 +3,7 @@
 from packaging import version
 from packaging.version import Version
 import importlib
+from typing import Any, Callable, Optional
 
 
 aiter_lib = None
@@ -32,7 +33,11 @@ def _is_torch_equal_or_newer(torch_version: str, target: str) -> bool:
     return torch_version >= version.parse(target)
 
 
-def torch_compile_guard(mutates_args: list[str] = [], device: str = "cpu"):
+def torch_compile_guard(
+    mutates_args: list[str] = [],
+    device: str = "cpu",
+    gen_fake: Optional[Callable[..., Any]] = None,
+):
     def decorator(func):
         try:
             import torch
@@ -98,6 +103,8 @@ def torch_compile_guard(mutates_args: list[str] = [], device: str = "cpu"):
         def fake_impl(dummy_tensor, *args, **kwargs):
             out = torch.empty(1, device=device)
             if not return_non_tensor:
+                if gen_fake is not None:
+                    return gen_fake(*args, **kwargs)
                 return func(*args, **kwargs)
             default_values = {int: 0, bool: True, float: 0.0}
 

--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -3,7 +3,7 @@
 
 # user interface
 
-from typing import List
+from typing import Tuple
 import torch
 from ..jit.core import (
     compile_ops,
@@ -48,7 +48,7 @@ def gen_moe_fused_gate_fake_tensor(
     topk: int,
     n_share_experts_fusion: int,
     routed_scaling_factor: float = 1.0,
-) -> List[torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor]:
     output = torch.empty_like(
         topk_weights, dtype=topk_weights.dtype, device=topk_weights.device
     )
@@ -69,7 +69,7 @@ def moe_fused_gate(
     topk: int,
     n_share_experts_fusion: int,
     routed_scaling_factor: float = 1.0,
-) -> List[torch.Tensor]: ...
+) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
 
 def biased_grouped_topk(


### PR DESCRIPTION
## Motivation
Only torch.compile or Cuda graph enabled is ok in sglang deepseek. But cuda_graph + torch compile will assert error in fused_moe

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
