### PR TITLE
fix torch compile when using fp8 fla

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -111,12 +111,20 @@ def common_mha_fwd_fake_tensors(
             head_size_v,
         ), "Output tensor has incorrect shape"
     else:
-        out = torch.empty(
-            (batch_size, seqlen_q, num_heads, head_size_v),
-            dtype=q.dtype,
-            device=q.device,
-            requires_grad=q.requires_grad,
-        )
+        if q.dtype == dtypes.fp8:
+            out = torch.empty(
+                (batch_size, seqlen_q, num_heads, head_size_v),
+                dtype=dtypes.bf16,
+                device=q.device,
+                requires_grad=q.requires_grad,
+            )
+        else:
+            out = torch.empty(
+                (batch_size, seqlen_q, num_heads, head_size_v),
+                dtype=q.dtype,
+                device=q.device,
+                requires_grad=q.requires_grad,
+            )
 
     if return_softmax_lse:
         softmax_lse = torch.empty(


### PR DESCRIPTION
## Motivation

Found bug when using fp8 fla + torch compile

## Technical Details

When datatype for QKV is FP8, datatype for out should be bf16

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
