### PR TITLE
Revert "fix a8w8 kernel name"

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -291,7 +291,6 @@ def fused_moe_1stage(
                 aiter.fmoe_fp8_blockscale_g1u1,
                 fc_scale_blkn=128,
                 fc_scale_blkk=128,
-                kernel_name="",
             )
         elif isG1U1:
             fmoe_func = aiter.fmoe_g1u1


### PR DESCRIPTION
This reverts commit 5abb2d059392484549f52f158119c9eb19022476.

This is causing errors on vllm 
```
   File "/opt/venv/lib/python3.10/site-packages/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py", line 196, in rocm_aiter_fused_moe_impl
     return fused_moe(hidden_states, w1, w2, topk_weight, topk_ids, expert_mask,
   File "/opt/venv/lib/python3.10/site-packages/aiter/fused_moe.py", line 165, in fused_moe
     return fused_moe_1stage(
   File "/opt/venv/lib/python3.10/site-packages/aiter/fused_moe.py", line 301, in fused_moe_1stage
     fmoe_func(
   File "/opt/venv/lib/python3.10/site-packages/aiter/jit/core.py", line 628, in wrapper
     func.arg_checked = check_args()
   File "/opt/venv/lib/python3.10/site-packages/aiter/jit/core.py", line 591, in check_args
     callargs = inspect.getcallargs(func, *args, **kwargs)
   File "/usr/lib/python3.10/inspect.py", line 1517, in getcallargs
     raise TypeError("%s() got an unexpected keyword argument %r" %
 TypeError: fmoe_fp8_blockscale_g1u1() got an unexpected keyword argument 'kernel_name'
```