### PR TITLE
fix the python mha test run_perftest error

### DIFF
--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -108,6 +108,7 @@ def run_ck(
         return_attn_probs,
         cu_seqlens_q,
         cu_seqlens_kv,
+        num_rotate_args=1,
     )
 
     if dropout_p > 0.0:

--- a/op_tests/test_mha_varlen.py
+++ b/op_tests/test_mha_varlen.py
@@ -154,6 +154,7 @@ def run_ck(
         return_attn_probs=return_attn_probs,
         cu_seqlens_q_padded=cu_seqlens_q_padded,
         cu_seqlens_k_padded=cu_seqlens_k_padded,
+        num_rotate_args=1,
     )
 
     if type(outputs) is tuple:


### PR DESCRIPTION
## Motivation
fix the python test_mha test run_perftest error

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
python3 op_tests/test_mha.py -b 32 -n 128 -q 1024 -k 1024 -d_qk_v 128,128 -c --no-local -bt no --no-deterministic -m mha -d bf16
python3 op_tests/test_mha.py
python3 op_tests/test_mha_varlen.py

## Test Result

<img width="1460" height="281" alt="image" src="https://github.com/user-attachments/assets/2ed0e784-3c0a-47bf-b3b3-c99386cfcd14" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
