### PR TITLE
[torch 2.4]Fix unsupported default dtype for gemm_a8w8_blockscale op

### DIFF
--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -425,13 +425,17 @@ def gemm_a8w8_blockscale(
     WQ: Tensor,
     x_scale: Tensor,
     w_scale: Tensor,
-    dtype: torch.dtype = dtypes.bf16,
+    dtype: torch.dtype = None,
     isBpreshuffled: bool = False,
 ) -> torch.Tensor:
     assert dtype in [
         dtypes.bf16,
         dtypes.fp16,
     ], f"Output {dtype=} is currently not supported in gemm_a8w8"
+
+    if dtype is None:
+        dtype = torch.bfloat16
+
     m = XQ.shape[0]
     n = WQ.shape[0]
     k = XQ.shape[1]

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -428,14 +428,12 @@ def gemm_a8w8_blockscale(
     dtype: torch.dtype = None,
     isBpreshuffled: bool = False,
 ) -> torch.Tensor:
+    if dtype is None:
+        dtype = torch.bfloat16
     assert dtype in [
         dtypes.bf16,
         dtypes.fp16,
     ], f"Output {dtype=} is currently not supported in gemm_a8w8"
-
-    if dtype is None:
-        dtype = torch.bfloat16
-
     m = XQ.shape[0]
     n = WQ.shape[0]
     k = XQ.shape[1]


### PR DESCRIPTION
Pytorch's schema inference does not support using
torch.dtype objects (like torch.bfloat16) as default parameter values

## Motivation

We find the error while executing test_custom_allreduce.py
`
/opt/conda310/lib/python3.10/site-packages/torch/cuda/__init__.py:58: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
[aiter] import [module_aiter_enum] under /workspace/aiter_debug/aiter/aiter/jit/module_aiter_enum.so
Traceback (most recent call last):
  File "/workspace/aiter_debug/aiter/op_tests/multigpu_tests/test_custom_allreduce.py", line 12, in <module>
    from aiter import dtypes
  File "/workspace/aiter_debug/aiter/aiter/__init__.py", line 55, in <module>
    from .ops.gemm_op_a8w8 import *
  File "/workspace/aiter_debug/aiter/aiter/ops/gemm_op_a8w8.py", line 424, in <module>
    def gemm_a8w8_blockscale(
  File "/workspace/aiter_debug/aiter/aiter/jit/utils/torch_guard.py", line 79, in decorator
    schema_str = torch._custom_op.impl.infer_schema(
  File "/opt/conda310/lib/python3.10/site-packages/torch/_library/infer_schema.py", line 61, in infer_schema
    error_fn(
  File "/opt/conda310/lib/python3.10/site-packages/torch/_library/infer_schema.py", line 21, in error_fn
    raise ValueError(
ValueError: infer_schema(func): Parameter dtype has an unsupported default value (we only support int, float, bool, None). Please file an issue on GitHub so we can prioritize this. Got func with signature (XQ: torch.Tensor, WQ: torch.Tensor, x_scale: torch.Tensor, w_scale: torch.Tensor, dtype: torch.dtype = torch.bfloat16, isBpreshuffled: bool = False) -> torch.Tensor)
`

## Technical Details

    Pytorch's schema inference does not support using
    torch.dtype objects (like torch.bfloat16) as default
    parameter values

## Test Plan
Run test_custom_allreduce.py 

## Test Result
Run test_custom_allreduce.py without any errors.

## Submission Checklist

- [ ✅ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
