### PR TITLE
Fix how to update accumulator for dot_scaled

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm_afp4wfp4.py
@@ -142,7 +142,7 @@ def _gemm_afp4_wfp4_kernel(
                     cache_modifier=cache_modifier,
                 )
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1", accumulator)
 
             # Advance the ptrs to the next K block.
             a_ptrs += (BLOCK_SIZE_K // 2) * stride_ak
@@ -320,7 +320,7 @@ def _gemm_afp4_wfp4_kernel_preshuffled_scales(
                     b_ptrs, mask=offs_k[:, None] < K - k * (BLOCK_SIZE_K // 2), other=0
                 )
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1", accumulator)
 
             # Advance the ptrs to the next K block.
             a_ptrs += (BLOCK_SIZE_K // 2) * stride_ak


### PR DESCRIPTION
This PR changes how accumulator is updated for dot_scaled.
The old way
```
accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
```
is lowered to
```
%res = dot_scaled %a, %b, %zero
%acc_new = arith.addf %res, %acc
yield %acc_new
```
This leads to register spills since the backend tries to use a separate set of vgprs for acc and the partial acc for the current iteration.

The new way
```
accumulator = tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1", accumulator)
```
is lowered to
```
%acc_new = dot_scaled %a, %b, %acc
yield %acc_new
```
Now the backend only needs a single set of vgprs for acc.

Note that this can also be fixed on the triton compiler side (see this PR: https://github.com/ROCm/triton/pull/897)