### PR TITLE
feat - pa_fwd support block map with stride in num_kv_heads_dim

### DIFF
--- a/csrc/py_itfs_cu/asm_pa.cu
+++ b/csrc/py_itfs_cu/asm_pa.cu
@@ -120,8 +120,8 @@ torch::Tensor pa_fwd(torch::Tensor& Q, //   [num_seqs, num_heads, head_size]
 
     int dim            = head_size;
     int stride_Q       = Q.stride(0) * Q.itemsize();
-    int stride_KV_head = block_size * dim * K.itemsize();
-    int stride_KV_blk  = stride_KV_head * num_kv_heads;
+    int stride_KV_head = K.stride(1) * K.itemsize();
+    int stride_KV_blk  = K.stride(0) * K.itemsize();
     float k_log2e      = f_log2E;
     float k_scalar     = sqrt(dim);
     k_scalar           = (float)((double)k_log2e / (double)k_scalar);


### PR DESCRIPTION
## Motivation

Currently pa_fwd  only support input KV as contiguous tensor, but if K,V tensor is organized as `[block_num, 2, kv_head, num, page_size, head_dim]`, where 2 stands for KV,  pa_fwd doesn't work anymore.

## Technical Details

Like https://github.com/ROCm/aiter/blob/d00df698276c12017e8cd7850a4650eb7d414127/csrc/kernels/attention.cu#L2216,
using stride to get correct offset

## Test Plan

Test pa_fwd with both contiguous tensor and KV fused tensor

## Test Result

all passed

## Submission Checklist

- [✅] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
