### PR TITLE
Fix displaying supported architectures

### DIFF
--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -64,7 +64,7 @@ def get_gfx_custom_op_core() -> int:
                     except KeyError:
                         raise KeyError(
                             f'Unknown GPU architecture: {line.split(":")[-1].strip()}. '
-                            f"Supported architectures: {list(gfx_mapping.values())}"
+                            f"Supported architectures: {list(gfx_mapping.keys())}"
                         )
 
         except Exception as e:
@@ -76,7 +76,7 @@ def get_gfx_custom_op_core() -> int:
     except KeyError:
         raise KeyError(
             f"Unknown GPU architecture: {gfx}. "
-            f"Supported architectures: {list(gfx_mapping.values())}"
+            f"Supported architectures: {list(gfx_mapping.keys())}"
         )
 
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently it will look like this:
```log
File "TransformerEngine/3rdparty/aiter/aiter/jit/utils/chip_info.py", line 77, in get_gfx_custom_op_core
  raise KeyError(
KeyError: 'Unknown GPU architecture: . Supported architectures: [0, 1, 2, 3, 4, 5, 6, 7, 8]'
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Confusion of keys and values here

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Run again

## Test Result

<!-- Briefly summarize test outcomes. -->

KeyError: 'Unknown GPU architecture: . Supported architectures: ['native', 'gfx90a', 'gfx908', 'gfx940', 'gfx941', 'gfx942', 'gfx945', 'gfx1100', 'gfx950']'

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
