### PR TITLE
Fix global variable torch_fp8 initialization caused issue

### DIFF
--- a/csrc/include/py_itfs_common.h
+++ b/csrc/include/py_itfs_common.h
@@ -29,7 +29,12 @@ const constexpr auto torch_fp8 = at::ScalarType::Float8_e4m3fn;
 const constexpr auto torch_fp8 = at::ScalarType::Float8_e4m3fnuz;
 #endif
 #else
-const auto torch_fp8 = isGPUArch({"gfx94"}) ? at::ScalarType::Float8_e4m3fnuz : at::ScalarType::Float8_e4m3fn;
+inline at::ScalarType get_torch_fp8()
+{
+    static const auto value = isGPUArch({"gfx94"}) ? at::ScalarType::Float8_e4m3fnuz : at::ScalarType::Float8_e4m3fn;
+    return value;
+}
+#define torch_fp8 get_torch_fp8()
 #endif
 
 #ifdef TORCH_Float4_e2m1fn_x2


### PR DESCRIPTION
`hipGetDeviceProperties` is called by the `torch_fp8` initialization. It will trigger all the HIP runtime initialization in global variable initialization. There are two issues:

- There are several global variables involved in the runtime initialization too. The initialization order of global variables is not guaranteed. So it may use uninitialized global variables for the runtime initialization.

- When there is a forked child process, needs to initialize its own HIP runtime to get proper GPU driver kernel context and handles. But since there is a runtime initialized globally in the parent process, the forked process will just consider the runtime is initialized and use it directly. But it is actually invalid.

The fix is to ensure `hipGetDeviceProperties` is only called when actually needed, not during static initialization

To repro the issue:
1. fork a child process
2. call `torch.empty` on the child process

It will get a `hipErrorInvalidValue` error.

