### PR TITLE
[Triton] Disable failing lean attention tests

### DIFF
--- a/op_tests/triton_tests/test_la.py
+++ b/op_tests/triton_tests/test_la.py
@@ -13,6 +13,7 @@ from aiter.ops.triton._triton_kernels.lean_atten import _get_config
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 import pytest
 
+
 def get_lean_attn_inputs(
     batch: int,
     n_ctx_q: int,


### PR DESCRIPTION
This PR disables persistent lean attention tests under `triton_tests/test_la.py` while the underlying cause is being investigated.