### PR TITLE
CI: Skip triton in Aiter standard and multigpu tests

### DIFF
--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - "aiter/ops/triton/**"
       - "op_tests/triton_tests/**"
+      - ".github/workflows/triton-test.yaml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Triton tests will only run when changing file under:

-  aiter/ops/triton
-  op_tests/triton_tests