### PR TITLE
Use torch.zeros_like instead of empty_like to prevent accuracy drop in CAR

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -300,7 +300,7 @@ class CustomAllreduce:
             else:
                 # if warm up, mimic the allocation pattern
                 # since custom allreduce is out-of-place
-                return torch.empty_like(input)
+                return torch.zeros_like(input)
         else:
             # note: outside of cuda graph context,
             # custom allreduce incurs a cost of cudaMemcpy, which should
@@ -332,7 +332,7 @@ class CustomAllreduce:
                 return self.all_gather_reg(inp)
             else:
                 print("allgather capture hipgraph error")
-                return torch.empty_like(inp)
+                return torch.zeros_like(inp)
         else:
             return self.all_gather_unreg(inp)
 
@@ -371,7 +371,7 @@ class CustomAllreduce:
             if torch.cuda.is_current_stream_capturing():
                 return self.fused_ar_rms(input, w=weight, eps=eps, registered=True)
             else:
-                return torch.empty_like(input), torch.empty_like(input)
+                return torch.zeros_like(input), torch.zeros_like(input)
         else:
             return self.fused_ar_rms(input, w=weight, eps=eps, registered=False)
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Use torch.zeros_like instead of empty_like to prevent accuracy drop in e2e workloads

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Credit: @kkHuang-amd 

@HaiShaw @TennyWang1223