### PR TITLE
Multinode_build

### DIFF
--- a/aiter/jit/utils/file_baton.py
+++ b/aiter/jit/utils/file_baton.py
@@ -50,8 +50,11 @@ class FileBaton:
             time.sleep(self.wait_seconds)
 
     def release(self):
-        """Release the baton and removes its file."""
+        """Release the baton and remove its file (idempotent)."""
         if self.fd is not None:
             os.close(self.fd)
-
-        os.remove(self.lock_file_path)
+        try:
+            os.remove(self.lock_file_path)
+        except FileNotFoundError:
+            # Another process may have removed the lock already; treat as success
+            pass


### PR DESCRIPTION
- Fsync on parent directory
- Fallback to loading by absolute path
- Visibility via delay and polling

## Motivation

-fix bugs for multinode build https://ontrack-internal.amd.com/browse/SWDEV-565283
-On a single node, even a large number of concurrent processes (tested upto 1024) works fine. One process performs the compilation while all others wait and then load from the cache.
In a multi-node setup (tested 2 and 4 nodes) with all nodes pointing to the same JIT cache directory on NFS, some nodes often fail with `ModuleNotFoundError: No module named 'module_aiter_enum'`. The error occurs non-deterministically and is easier to repro with more nodes.

## Test Plan

more nodes need to test

## Test Result

4 node build passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
