### PR TITLE
drop redundant includes for ck_gemm folders in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,23 +126,6 @@ if IS_ROCM:
         with ThreadPoolExecutor(max_workers=prebuid_thread_num) as executor:
             list(executor.map(build_one_module, all_opts_args_build))
 
-        ck_batched_gemm_folders = [
-            f"{this_dir}/csrc/{name}/include"
-            for name in os.listdir(f"{this_dir}/csrc")
-            if os.path.isdir(os.path.join(f"{this_dir}/csrc", name))
-            and name.startswith("ck_batched_gemm")
-        ]
-        ck_gemm_folders = [
-            f"{this_dir}/csrc/{name}/include"
-            for name in os.listdir(f"{this_dir}/csrc")
-            if os.path.isdir(os.path.join(f"{this_dir}/csrc", name))
-            and name.startswith("ck_gemm_a")
-        ]
-        ck_gemm_inc = ck_batched_gemm_folders + ck_gemm_folders
-        for src in ck_gemm_inc:
-            dst = f"{prebuild_dir}/include"
-            shutil.copytree(src, dst, dirs_exist_ok=True)
-
         shutil.copytree(
             f"{this_dir}/csrc/include", f"{prebuild_dir}/include", dirs_exist_ok=True
         )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

https://github.com/ROCm/aiter/pull/830/files/b79c6d3eeaf4588ad495a5c48b0d35ef9ec3ed58 explicitly copies the headers from the ck gemm include folders e.g. `aiter/csrc/ck_batched_gemm_a8w8/include` into `{prebuild_dir}/include`.

However, https://github.com/ROCm/aiter/pull/1159 added the corresponding include directories for each module into the `extra_include` field in [optCompilerConfig.json](https://github.com/ROCm/aiter/blob/main/aiter/jit/optCompilerConfig.json), so we don't actually need the redundant copy; the folders are already included in the final build as part of `prebuild_link_param["extras_include"]` [here](https://github.com/ROCm/aiter/blob/main/setup.py#L159).

Mildly relevant copilot comment: https://github.com/ROCm/aiter/pull/1423#discussion_r2536700360

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
