### PR TITLE
Fix issue: Add nhead=128 support to bf16 and align restrictions

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -272,7 +272,7 @@ def mla_decode_fwd(
         if nhead == 16 or (nhead == 128 and kv_buffer.dtype == dtypes.fp8):
             # Natively support cases
             pass
-        elif nhead in range(32, 512 + 1, 16) and persistent_mode and max_seqlen_q == 1:
+        elif nhead in range(32, 128 + 1, 16) and persistent_mode and max_seqlen_q == 1:
             # we use nhead=16 to simulate such cases by customized metadata
             # metadata also views qo's tensor as shape (total_s * (nhead // 16), 16, ...)
             total_s = ori_total_s * (ori_nhead // 16)

--- a/aiter/ops/attention.py
+++ b/aiter/ops/attention.py
@@ -407,6 +407,8 @@ def get_mla_metadata_v1(
     fast_mode: bool = True,
     topk: int = -1,
     max_split_per_batch: int = -1,
+    dtype_q: Optional[torch.dtype] = None,
+    dtype_kv: Optional[torch.dtype] = None,
 ) -> None:
     """
     Inputs:

--- a/csrc/include/mla.h
+++ b/csrc/include/mla.h
@@ -49,9 +49,11 @@ void get_mla_metadata_v1(const torch::Tensor& seqlens_qo_indptr, // [batch size 
                          const int32_t kv_granularity,
                          const int32_t max_seqlen_qo,
                          const int32_t uni_seqlen_qo,
-                         const bool    fast_mode,
+                         const bool fast_mode,
                          const int32_t topk,
-                         const int32_t max_split_per_batch);
+                         const int32_t max_split_per_batch,
+                         const std::optional<at::ScalarType> dtype_q,
+                         const std::optional<at::ScalarType> dtype_kv);
 
 std::vector<torch::Tensor>
 get_mla_metadata_v1_no_redundant(const torch::Tensor& seqlens_qo_indptr, // [batch size + 1]

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1351,27 +1351,29 @@ namespace py = pybind11;
           py::arg("stride0"),      \
           py::arg("stride1"));
 
-#define MLA_METADATA_PYBIND                     \
-    m.def("get_mla_metadata_v1",                \
-          &get_mla_metadata_v1,                 \
-          "get_mla_metadata_v1",                \
-          py::arg("seqlens_qo_indptr"),         \
-          py::arg("seqlens_kv_indptr"),         \
-          py::arg("num_heads_per_head_k"),      \
-          py::arg("num_heads_k"),               \
-          py::arg("is_causal"),                 \
-          py::arg("work_metadata_ptrs"),        \
-          py::arg("work_info_set"),             \
-          py::arg("work_indptr"),               \
-          py::arg("reduce_indptr"),             \
-          py::arg("reduce_final_map"),          \
-          py::arg("reduce_partial_map"),        \
-          py::arg("kv_granularity") = 16,       \
-          py::arg("max_seqlen_qo")  = -1,       \
-          py::arg("uni_seqlen_qo")  = -1,       \
-          py::arg("fast_mode")      = true,     \
-          py::arg("topk")           = -1,       \
-          py::arg("max_split_per_batch") = -1); \
+#define MLA_METADATA_PYBIND                              \
+    m.def("get_mla_metadata_v1",                         \
+          &get_mla_metadata_v1,                          \
+          "get_mla_metadata_v1",                         \
+          py::arg("seqlens_qo_indptr"),                  \
+          py::arg("seqlens_kv_indptr"),                  \
+          py::arg("num_heads_per_head_k"),               \
+          py::arg("num_heads_k"),                        \
+          py::arg("is_causal"),                          \
+          py::arg("work_metadata_ptrs"),                 \
+          py::arg("work_info_set"),                      \
+          py::arg("work_indptr"),                        \
+          py::arg("reduce_indptr"),                      \
+          py::arg("reduce_final_map"),                   \
+          py::arg("reduce_partial_map"),                 \
+          py::arg("kv_granularity")      = 16,           \
+          py::arg("max_seqlen_qo")       = -1,           \
+          py::arg("uni_seqlen_qo")       = -1,           \
+          py::arg("fast_mode")           = true,         \
+          py::arg("topk")                = -1,           \
+          py::arg("max_split_per_batch") = -1,           \
+          py::arg("dtype_q")             = std::nullopt, \
+          py::arg("dtype_kv")            = std::nullopt);           \
     m.def("get_mla_metadata_v1_no_redundant", &get_mla_metadata_v1_no_redundant);
 
 #define MLA_REDUCE_PYBIND                \

--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -8,7 +8,6 @@ from aiter import dtypes
 import random
 import itertools
 import argparse
-from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
 
 torch.set_default_device("cuda")
 torch.set_printoptions(sci_mode=False)
@@ -278,6 +277,8 @@ def test_mla(
         uni_seqlen_qo=decode_qlen,
         fast_mode=True,
         max_split_per_batch=max_split_per_batch,
+        dtype_q=q.dtype,
+        dtype_kv=kv_buffer.dtype,
     )
 
     def test_absorb_decode_bf16():
@@ -389,7 +390,7 @@ def test_mla(
     err = None
     us_asm_decode = 1e12
     if (dtype == torch.bfloat16 and kvtype == torch.bfloat16) and (
-        nhead == 16 or (nhead in range(32, 128, 16) and decode_qlen == 1)
+        (nhead in [16]) or (decode_qlen == 1 and nhead in range(32, 128 + 1, 16))
     ):
         err, us_asm_decode = test_absorb_decode_bf16()
     elif kvtype == dtypes.fp8 and nhead in [16, 128]:

--- a/op_tests/test_mla_sparse.py
+++ b/op_tests/test_mla_sparse.py
@@ -452,6 +452,8 @@ def test_mla(
         uni_seqlen_qo=decode_qlen,
         fast_mode=True,
         topk=2048,
+        dtype_q=q.dtype,
+        dtype_kv=kv_buffer.dtype,
     )
 
     # generate kv topk per token & convert indices into per token
@@ -589,13 +591,13 @@ def test_mla(
         return err, us_asm_decode
 
     err = None
-    us_asm_decode = 10000000000
+    us_asm_decode = 1e12
     if (dtype == torch.bfloat16 and kvtype == torch.bfloat16) and (
-        (nhead in [16]) or (max_seqlen_qo == 1 and nhead in range(32, 512 + 1, 16))
+        (nhead in [16]) or (max_seqlen_qo == 1 and nhead in range(32, 128 + 1, 16))
     ):
         err, us_asm_decode = test_sparse_mla_bf16()
     elif kvtype == dtypes.fp8 and (
-        (nhead in [16, 128]) or (max_seqlen_qo == 1 and nhead in range(32, 512 + 1, 16))
+        (nhead in [16, 128]) or (max_seqlen_qo == 1 and nhead in range(32, 128 + 1, 16))
     ):
         err, us_asm_decode = test_absorb_decode_fp8()
     ret["decode:err"] = err


### PR DESCRIPTION
## Motivation

Fix issue 3 and 5 reported in https://github.com/ROCm/aiter/issues/1420

## Details

1. Create correct metadata for nhead=128 with bf16 so as the transformation for simulation can work properly.
2. Align the restrictions of transformation according to the code. It is only supported when nhead <=128 now.
