### PR TITLE
Fix inconsistent tensor shapes between `shuffle_scale_a16w4` and `shuffle_weight_a16w4`

### DIFF
--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -348,7 +348,8 @@ parser.add_argument(
     2: aiter.QuantType.per_Token, dtypes.fp8, dtypes.fp8  # a8w8
     3: aiter.QuantType.per_Token, dtypes.fp8, torch.int4  # a8w4
     4: aiter.QuantType.per_1x32, dtypes.fp4x2, dtypes.fp4x2  # a4w4
-    5: aiter.QuantType.per_128x128, dtypes.fp8, dtypes.fp8,  # a8w8""",
+    5: aiter.QuantType.per_128x128, dtypes.fp8, dtypes.fp8,  # a8w8
+    6: aiter.QuantType.per_1x32, dtypes.bf16, dtypes.fp4x2  # a16w4""",
 )
 
 parser.add_argument(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The expected `src` input tensor shapes for shuffle_weight_a16w4 (e, n, k) and shuffle_scale_a16w4 (e * n, k) are internally inconsistent: https://github.com/ROCm/aiter/blob/main/aiter/ops/shuffle.py

This requires the caller in vllm to add an extra view function for the scales to reshape them to match the function calls: https://github.com/ROCm/vllm/pull/808/files#diff-c73528091f2176f6547e24074950962deec4311315fa5e99ef2ca7682680708c

In aiter/355_wip, the shuffle_mxfp4_weight and shuffle_mxfp4_scale functions had matching `src` input shapes: https://github.com/ROCm/aiter/blob/355_wip/aiter/ops/shuffle.py


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
