### PR TITLE
[TRITON] Simplify dim_mask in pa_prefill kernel

### DIFF
--- a/aiter/ops/triton/_triton_kernels/pa_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/pa_prefill.py
@@ -110,9 +110,7 @@ def _fwd_kernel(
         + offs_d[None, :] * stride_qd
     )
 
-    dim_mask = tl.where(tl.arange(0, BLOCK_DMODEL_PADDED) < BLOCK_DMODEL, 1, 0).to(
-        tl.int1
-    )  # [D]
+    dim_mask = tl.arange(0, BLOCK_DMODEL_PADDED) < BLOCK_DMODEL  # [D]
 
     q = tl.load(
         Q + off_q,
@@ -399,9 +397,7 @@ def _fwd_kernel_alibi(
         + offs_d[None, :] * stride_qd
     )
 
-    dim_mask = tl.where(tl.arange(0, BLOCK_DMODEL_PADDED) < BLOCK_DMODEL, 1, 0).to(
-        tl.int1
-    )
+    dim_mask = tl.arange(0, BLOCK_DMODEL_PADDED) < BLOCK_DMODEL
 
     q = tl.load(
         Q + off_q,


### PR DESCRIPTION
Remove unnecessary select and cast in dim_mask.

## Motivation

Allow [MaskAnalysis ](https://github.com/microsoft/triton-shared/blob/main/include/triton-shared/Analysis/MaskAnalysis.h) in [triton-shared](https://github.com/microsoft/triton-shared) to identify dim_mask as structured mask.

## Technical Details

The ttir for original code will be like
```
    %cst_0 = arith.constant dense<128> : tensor<128xi32>
    %cst_1 = arith.constant dense<1> : tensor<128xi32>
    %cst_2 = arith.constant dense<0> : tensor<128xi32>
    %16 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
    %28 = arith.cmpi slt, %16, %cst_0 : tensor<128xi32>
    %29 = arith.select %28, %cst_1, %cst_2 : tensor<128xi1>, tensor<128xi32>
    %30 = arith.cmpi ne, %29, %cst_2 : tensor<128xi32>
```
which is equal to
```
    %cst_0 = arith.constant dense<128> : tensor<128xi32>
    %16 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
    %28 = arith.cmpi slt, %16, %cst_0 : tensor<128xi32>
```
## Test Plan

test_pa_prefill.py

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
