### PR TITLE
MLA Tests Fail to Pass Correct dtype to Metadata Kernels.

### DIFF
--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -277,8 +277,8 @@ def test_mla(
         uni_seqlen_qo=decode_qlen,
         fast_mode=True,
         max_split_per_batch=max_split_per_batch,
-        dtype_q=q.dtype,
-        dtype_kv=kv_buffer.dtype,
+        dtype_q=dtype,
+        dtype_kv=kvtype,
     )
 
     def test_absorb_decode_bf16():

--- a/op_tests/test_mla_sparse.py
+++ b/op_tests/test_mla_sparse.py
@@ -452,8 +452,8 @@ def test_mla(
         uni_seqlen_qo=decode_qlen,
         fast_mode=True,
         topk=2048,
-        dtype_q=q.dtype,
-        dtype_kv=kv_buffer.dtype,
+        dtype_q=dtype,
+        dtype_kv=kvtype,
     )
 
     # generate kv topk per token & convert indices into per token


### PR DESCRIPTION
The `q` and `kv_buffer` tensors are both initialized as bf16 and only convert to target dtype later after metadata get called. So that the dtypes provided to metadata are wrong here. 
