### PR TITLE
Multinode_aot_prebuild_all

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,15 +77,43 @@ if IS_ROCM:
         exclude_ops = [
             "libmha_fwd",
             "libmha_bwd",
-            # "module_fmha_v3_fwd",
+            "module_fmha_v3_fwd",
             "module_mha_fwd",
             "module_mha_varlen_fwd",
             "module_mha_batch_prefill",
-            # "module_fmha_v3_bwd",
+            "module_fmha_v3_bwd",
             "module_fmha_v3_varlen_bwd",
             "module_fmha_v3_varlen_fwd",
             "module_mha_bwd",
             "module_mha_varlen_bwd",
+        ]
+    elif PREBUILD_KERNELS == 2:
+        exclude_ops = [
+            # "libmha_fwd",
+            "libmha_bwd",
+            # "module_fmha_v3_fwd",
+            # "module_mha_fwd",
+            # "module_mha_varlen_fwd",
+            "module_mha_batch_prefill",
+            "module_fmha_v3_bwd",
+            "module_fmha_v3_varlen_bwd",
+            # "module_fmha_v3_varlen_fwd",
+            "module_mha_bwd",
+            "module_mha_varlen_bwd",
+        ]
+    elif PREBUILD_KERNELS == 3:
+        exclude_ops = [
+            # "libmha_fwd",
+            # "libmha_bwd",
+            # "module_fmha_v3_fwd",
+            # "module_mha_fwd",
+            # "module_mha_varlen_fwd",
+            # "module_mha_batch_prefill",
+            # "module_fmha_v3_bwd",
+            # "module_fmha_v3_varlen_bwd",
+            # "module_fmha_v3_varlen_fwd",
+            # "module_mha_bwd",
+            # "module_mha_varlen_bwd",
         ]
 
         all_opts_args_build, prebuild_link_param = core.get_args_of_build(


### PR DESCRIPTION
## Motivation

add more PREBUILD_KERNELS option for prebuild kernel so

## Technical Details

PREBUILD_KERNELS == 1/2/3

ex:
PREBUILD_KERNELS=1 GPU_ARCHS="gfx942;gfx950" python3 setup.py install
## Test Plan

308/355

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
