### PR TITLE
[TRITON] Disable Triton MHA broken test cases on gfx942

### DIFF
--- a/op_tests/triton_tests/test_mha.py
+++ b/op_tests/triton_tests/test_mha.py
@@ -21,6 +21,10 @@ from aiter.test_mha_common import (
     generate_qkv,
 )
 
+from aiter.ops.triton.utils._triton.arch_info import get_arch
+
+arch = get_arch()
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 DEBUG_MODE = False
@@ -819,6 +823,12 @@ def test_mha_with_pe(
     device: str = "cuda"
     dtype: torch.dtype = torch.bfloat16
 
+    # TODO: Enable these test cases once this is fixed
+    if arch == "gfx942" and (CAUSAL or HAS_DROPOUT):
+        pytest.skip(
+            "Causal or Dropout use case isn't currently working with Positional Encoding on gfx942 archictecture."
+        )
+
     # Generate tensors
     torch.cuda.empty_cache()
     torch.manual_seed(20)
@@ -886,6 +896,12 @@ def test_mha_varlen_with_pe(
     HAS_DROPOUT: bool = DROPOUT > 0.0
     device: str = "cuda"
     dtype: torch.dtype = torch.bfloat16
+
+    # TODO: Enable these test cases once this is fixed
+    if arch == "gfx942" and (CAUSAL or HAS_DROPOUT):
+        pytest.skip(
+            "Causal or Dropout use case isn't currently working with Positional Encoding on gfx942 archictecture."
+        )
 
     # Generate tensors
     torch.cuda.empty_cache()
@@ -988,6 +1004,12 @@ def test_mha_backward_with_pe(
     CAUSAL: bool,
 ):
     HAS_DROPOUT: bool = DROPOUT > 0.0
+
+    # TODO: Enable these test cases once this is fixed
+    if arch == "gfx942" and (CAUSAL or HAS_DROPOUT):
+        pytest.skip(
+            "Causal or Dropout use case isn't currently working with Positional Encoding on gfx942 archictecture."
+        )
 
     # Causal + Dropout use case is disabled in `test_mha_backward` and `test_mha_backward_varlen`.
     # FIXME: We should fix it in the base implementation before adding PE to the mix.
@@ -1111,6 +1133,12 @@ def test_mha_backward_varlen_with_pe(
     CAUSAL: bool,
 ):
     HAS_DROPOUT: bool = DROPOUT > 0.0
+
+    # TODO: Enable these test cases once this is fixed
+    if arch == "gfx942" and (CAUSAL or HAS_DROPOUT):
+        pytest.skip(
+            "Causal or Dropout use case isn't currently working with Positional Encoding on gfx942 archictecture."
+        )
 
     # Causal + Dropout use case is disabled in `test_mha_backward` and `test_mha_backward_varlen`.
     # FIXME: We should fix it in the base implementation before adding PE to the mix.


### PR DESCRIPTION
## Motivation

Some Triton MHA tests are failing specifically when running on the gfx942 architecture, this PR disables them so that the CI doesn't stay blocked.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
