### PR TITLE
fmha: switch to FAv2 CK when soft-capping value is non-zero

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -1960,6 +1960,7 @@ def _flash_attn_varlen_forward(
         ret = ret and (not swa)
         ret = ret and (q.dtype == dtypes.bf16)
         ret = ret and (cu_seqlens_q_padded is None and cu_seqlens_k_padded is None)
+        ret = ret and logits_soft_cap == 0.0
         return ret
 
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]


### PR DESCRIPTION
## Motivation

So far, neither FAv3 ASM nor FAv3 CK supports logit soft-capping. Before that is supported, let FAv2 CK handle it.

## Technical Details

Different models have different logits soft-capping values to be assigned for flash attention. 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
