### PR TITLE
Fix racing between different devices when read/write combined config …

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -14,6 +14,7 @@ import time
 import traceback
 import types
 import typing
+import torch
 from typing import Any, Callable, List, Optional
 
 from packaging.version import Version, parse
@@ -226,8 +227,10 @@ class AITER_CONFIG(object):
         config_path = Path("/tmp/aiter_configs/")
         if not config_path.exists():
             config_path.mkdir(parents=True, exist_ok=True)
-        new_file_path = f"{config_path}/{merge_name}.csv"
-        lock_path = f"{new_file_path}.lock"
+        # avoid read/write racing between different devices
+        current_deivce_id = torch.cuda.current_device()
+        new_file_path = f"{config_path}/{merge_name}_{current_deivce_id}.csv"
+        lock_path = f"{new_file_path}_{current_deivce_id}.lock"
 
         def write_config():
             merge_df.to_csv(new_file_path, index=False)


### PR DESCRIPTION
## Motivation

Fix the racing problem when mulitple process might race when read and write same merged config file.
When rank 0 finish writing config file and begin reading this file, other rank might writing same file again. In this situation rank 0 might read incomplete file and report following erros. Current mp_lock can avoid multiple process write at same time but not read/write at same time.

```
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/disc/data1/kalinshi/v32/pd/abo_aiter_merge/aiter/jit/utils/torch_guard.py", line 302, in outer_wrapper^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     wrapper(*args, **kwargs)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/disc/data1/kalinshi/v32/pd/abo_aiter_merge/aiter/jit/utils/torch_guard.py", line 197, in wrapper^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     return func(*args, **kwargs)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]            ^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/disc/data1/kalinshi/v32/pd/abo_aiter_merge/aiter/tuned_gemm.py", line 242, in gemm_a16w16^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     config = get_GEMM_A16W16_config(^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]              ^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/disc/data1/kalinshi/v32/pd/abo_aiter_merge/aiter/tuned_gemm.py", line 86, in get_GEMM_A16W16_config^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     cfg = get_GEMM_A16W16_config_()^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]           ^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/disc/data1/kalinshi/v32/pd/abo_aiter_merge/aiter/tuned_gemm.py", line 58, in get_GEMM_A16W16_config_^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     gemm_dict = pd.read_csv(f"{tuned_file}").drop_duplicates()^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/usr/local/lib/python3.12/dist-packages/pandas/io/parsers/readers.py", line 1026, in read_csv^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     return _read(filepath_or_buffer, kwds)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/usr/local/lib/python3.12/dist-packages/pandas/io/parsers/readers.py", line 620, in _read^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     parser = TextFileReader(filepath_or_buffer, **kwds)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/usr/local/lib/python3.12/dist-packages/pandas/io/parsers/readers.py", line 1620, in __init__^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     self._engine = self._make_engine(f, self.engine)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/usr/local/lib/python3.12/dist-packages/pandas/io/parsers/readers.py", line 1898, in _make_engine^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     return mapping[engine](f, **self.options)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "/usr/local/lib/python3.12/dist-packages/pandas/io/parsers/c_parser_wrapper.py", line 93, in __init__^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]     self._reader = parsers.TextReader(src, **kwds)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146]   File "pandas/_libs/parsers.pyx", line 581, in pandas._libs.parsers.TextReader.__cinit__^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=32375)^[[0;0m ERROR 12-08 07:48:58 [logger.py:146] pandas.errors.EmptyDataError: No columns to parse from file^M
```

## Technical Details

add device index as suffix in merged config file.

## Test Plan

above errors gone with this fix.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
