### PR TITLE
[fix]: dispatch logic of ar_1stage

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -1523,17 +1523,17 @@ namespace aiter
   name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, \
                                                  rank_, size);
 
-#define dispatch(ngpus, name)                   \
-    do                                          \
-    {                                           \
-      if (bytes % 128 == 0 && world_size_ != 6) \
-      {                                         \
-        KL(ngpus, name)                         \
-      }                                         \
-      else                                      \
-      {                                         \
-        KL(ngpus, name##_naive)                 \
-      }                                         \
+#define dispatch(ngpus, name)                            \
+    do                                                   \
+    {                                                    \
+      if (bytes % (ngpus * 16) == 0 && world_size_ != 6) \
+      {                                                  \
+        KL(ngpus, name)                                  \
+      }                                                  \
+      else                                               \
+      {                                                  \
+        KL(ngpus, name##_naive)                          \
+      }                                                  \
     } while(0)
 
 #define REDUCE_CASE(ngpus)                         \
@@ -1541,7 +1541,7 @@ namespace aiter
   {                                                \
     if (call_1stage)                               \
     {                                              \
-      dispatch(ngpus, cross_device_reduce_1stage); \
+      KL(ngpus, cross_device_reduce_1stage);       \
     }                                              \
     else if (call_2stage)                          \
     {                                              \


### PR DESCRIPTION
## Motivation

avoid using naive kernel(1stage) of vllm

## Technical Details

replace by aiter new ar_1stage kernel unless use_new=false

## Test Plan

with test case (13, 8184), and run test script by AITER_LOG_MORE=1, see which kernel was launched

## Test Result

cross_device_reduce_1stage was launched, cross_device_reduce_1stage_naive was not launched

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
