### PR TITLE
[fix]: Resolve perf regression of fused_ar_rms on MI300 and MI355

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -935,13 +935,15 @@ namespace aiter
         {
           add_rslt.data[i] = ck_tile::type_convert<T>(add_reg.data[i]);
         }
-        *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id) = add_rslt;
+        tmps[rank][rank * part + idx] = add_rslt;
       }
       __syncthreads();
+    }
 
-      // cross device store
-      P rslt = *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id);
-      tmps[warp_id][rank * part + idx] = rslt;
+    // cross device store
+    for (int idx = tid; idx < part; idx += gridDim.x * tnum_gpu)
+    {
+      tmps[warp_id][rank * part + idx] = tmps[rank][rank * part + idx];
     }
     end_sync<ngpus, true>(sg, self_sg, rank);
   }


### PR DESCRIPTION
## Motivation

Fix the performance regression of fused_allreduce_rmsnorm on MI300 and MI355.

## Technical Details

Split the cross-device reads and writes within a single persistent into two separate persistent to avoid bandwidth contention on XMGI.

## Test Plan

case (256, 16384), run with AITER_LOG_MORE=1

## Test Result

The performance of fused_allreduce_rmsnorm on MI300 and MI355 is no longer worse than that of the separated operators, although the optimization effect is not as significant as on MI308.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
