### PR TITLE
[fix]: reduce_scatter rollback

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -935,15 +935,13 @@ namespace aiter
         {
           add_rslt.data[i] = ck_tile::type_convert<T>(add_reg.data[i]);
         }
-        tmps[rank][rank * part + idx] = add_rslt;
+        *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id) = add_rslt;
       }
       __syncthreads();
-    }
 
-    // cross device store
-    for (int idx = tid; idx < part; idx += gridDim.x * tnum_gpu)
-    {
-      tmps[warp_id][rank * part + idx] = tmps[rank][rank * part + idx];
+      // cross device store
+      P rslt = *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id);
+      tmps[warp_id][rank * part + idx] = rslt;
     }
     end_sync<ngpus, true>(sg, self_sg, rank);
   }


### PR DESCRIPTION
## Motivation

rollback reduce_scatter_cross_device_store to fix deepseek perf drop on 355
## Technical Details


## Test Plan

run deepseek case with n=7168

## Test Result

kernel ut perf ok

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
