### PR TITLE
Fix sink error for asm fmha

### DIFF
--- a/csrc/py_itfs_cu/asm_mha_fwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_fwd.cu
@@ -321,6 +321,7 @@ std::vector<at::Tensor> fmha_v3_fwd(at::Tensor &q, // [b, sq, hq, d]
                                  has_lse,
                                  quant_scale_enum::no_scale,
                                  true,
+                                 false,
                                  how_v3_bf16_cvt);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
     }

--- a/csrc/py_itfs_cu/asm_mha_varlen_fwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_varlen_fwd.cu
@@ -399,6 +399,7 @@ fmha_v3_varlen_fwd(at::Tensor &q,                  // [total_q, hq, d]
                                 has_lse,
                                 quant_scale_enum::no_scale,
                                 true,
+                                false,
                                 how_v3_bf16_cvt);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_v3_varlen_fwd 3");
     }


### PR DESCRIPTION
## Motivation

This PR fixes a sink error in the assembly-based FMHA (Fused Multi-Head Attention) implementation by adding a missing boolean parameter to function calls.

## Technical Details

Adds a false parameter to two function calls in the FMHA v3 forward implementations

## Test Plan

None

## Test Result

local test passed
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
