### PR TITLE
[WIP] [TRITON] MHA reverse pid order

### DIFF
--- a/aiter/ops/triton/_triton_kernels/mha.py
+++ b/aiter/ops/triton/_triton_kernels/mha.py
@@ -351,6 +351,8 @@ def _attn_fwd(
         0
     )  # workgroup id ranging: 0,1,2,...., (BATCH * NUM_Q_HEADS * NUM_BLOCKS - 1)
     # num blocks along seqlen
+    # reverse the order of the workgroups to process the longer tasks first to reduce the tail effect
+    wid = tl.num_programs(0) - wid - 1
 
     off_q_head = wid % NUM_Q_HEADS
     off_q_head = remap_xcd(off_q_head, NUM_Q_HEADS, NUM_XCD)


### PR DESCRIPTION
This PR optimizes the causal case for MHA by inverting the row process order so that longer tasks are handled first to reduce the tail latency.

Will add benchmarks soon.