### PR TITLE
LLfp4 qr cap for atom

### DIFF
--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -149,7 +149,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             qr_comm is not None
             and not qr_comm.disabled
             and qr_comm.should_quick_allreduce(input_)
-            and (input_.nelement() * input_.element_size()) > 4000000 # input shape should be such that quick reduce will show benefits.
+            and (input_.nelement() * input_.element_size()) >= 4*1024*1024 # input shape should be such that quick reduce will show benefits.
             # input shape estimated at 2 * max concurrency for now. if performance issues, subject to change
         ):
             out = qr_comm.quick_all_reduce(input_)


### PR DESCRIPTION
## Motivation

Enables QR when QR will help improve performance (>4MB of data)

## Technical Details

Creates a cap that will enable QR when the matrix size and datatype are below 4MB of data

## Test Plan

Manual trace review on ATOM to see which comm kernel it uses, lm_eval.

## Test Result

Performed as expected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
