### PR TITLE
fix missing return in mha_bwd

### DIFF
--- a/csrc/cpp_itfs/mha_bwd.cpp
+++ b/csrc/cpp_itfs/mha_bwd.cpp
@@ -127,8 +127,9 @@ std::tuple<std::string, std::string, std::string> get_heuristic_kernel(std::stri
 
 float mha_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
 {
+    float asm_ret = fmha_v3_bwd(a, s);
 #if ONLY_FAV3
-    return fmha_v3_bwd(a, s);
+    return asm_ret;
 #else
     fmha_bwd_traits traits{a.hdim_q,
                            a.hdim_v,
@@ -225,11 +226,11 @@ float mha_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         /* drop_seed_offset   */ a.drop_seed_offset,
     };
 
-    float asm_ret = fmha_v3_bwd(a, s);
     if(asm_ret == -1)
     {
         return fmha_bwd(traits, ck_args, s);
     }
+    return asm_ret;
 #endif
 }
 


### PR DESCRIPTION
## Motivation

the return value is missing if not ONLY_FAV3, causing error
```
mha_bwd.hip:234:1: error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
