### PR TITLE
Fix compiled_ops argument checking for enum arguments when AITER_JIT_DIR is set

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -891,7 +891,7 @@ def compile_ops(
                     pattern = r"([\w\.]+(?:\[[^\]]+\])?)\s*\|\s*None"
                     doc_str = re.sub(pattern, r"Optional[\1]", doc_str)
                     for el in enum_types:
-                        doc_str = re.sub(f" aiter.*{el} ", f" {el} ", doc_str)
+                        doc_str = re.sub(f" (module_)?aiter.*{el} ", f" {el} ", doc_str)
                     namespace = {
                         "List": List,
                         "Optional": Optional,

--- a/op_tests/test_jit_dir_with_enum.py
+++ b/op_tests/test_jit_dir_with_enum.py
@@ -1,0 +1,114 @@
+import contextlib
+import os
+import tempfile
+import torch
+
+
+@contextlib.contextmanager
+def TemporaryEnvironmentVariable(var_name, value):
+    original_value = os.environ.get(var_name)
+    os.environ[var_name] = value
+    yield
+    if original_value is not None:
+        os.environ[var_name] = original_value
+    elif var_name in os.environ:
+        del os.environ[var_name]
+
+
+def test_aiter_jit_dir_with_enum():
+    # Create a temporary directory for AITER_JIT_DIR
+    with tempfile.TemporaryDirectory() as temp_dir, TemporaryEnvironmentVariable(
+        "AITER_JIT_DIR", temp_dir
+    ):
+        # Import aiter only after we set AITER_JIT_DIR
+        from aiter import ActivationType, QuantType
+
+        # Using moe_stage1_g1u1 as an example of a compiled function with enum types in its signature
+        from aiter.ops.moe_op import moe_stage1_g1u1
+        from aiter.utility import dtypes
+        from aiter.fused_moe_bf16_asm import moe_sorting_ck
+
+        # Create dummy tensors for testing
+        torch.set_default_device("cuda")
+        fp8_dtype = dtypes.fp8
+
+        # Setup parameters
+        num_tokens = 4
+        model_dim = 128
+        inter_dim = 256  # Must be divisible by tile_n (64 or 128)
+        num_experts = 2
+        topk = 2
+
+        hidden_states = torch.randn(
+            num_tokens, model_dim, dtype=torch.bfloat16, device="cuda"
+        )
+        hidden_states_fp8 = hidden_states.to(fp8_dtype)
+
+        w1 = torch.randn(
+            num_experts, inter_dim * 2, model_dim, dtype=torch.bfloat16, device="cuda"
+        )
+        w1_fp8 = w1.to(fp8_dtype)
+
+        w2 = torch.randn(
+            num_experts, model_dim, inter_dim, dtype=torch.bfloat16, device="cuda"
+        )
+        w2_fp8 = w2.to(fp8_dtype)
+
+        # Create topk_ids and topk_weights for sorting
+        topk_ids = torch.randint(
+            0, num_experts, (num_tokens, topk), dtype=torch.int32, device="cuda"
+        )
+        topk_weights = torch.rand(num_tokens, topk, dtype=torch.float32, device="cuda")
+
+        # Use moe_sorting_ck to prepare sorted data (required by the kernel)
+        sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, moe_buf = (
+            moe_sorting_ck(
+                topk_ids,
+                topk_weights,
+                num_experts,
+                model_dim,
+                torch.bfloat16,
+                block_size=32,
+                expert_mask=None,
+            )
+        )
+
+        # Create output tensor
+        out = torch.empty(
+            (num_tokens, topk, inter_dim * 2), dtype=torch.bfloat16, device="cuda"
+        )
+
+        a1_scale = torch.rand(num_tokens, 1, dtype=torch.float32, device="cuda")
+        w1_scale = torch.rand(
+            num_experts, 1, inter_dim, dtype=torch.float32, device="cuda"
+        )
+
+        moe_stage1_g1u1(
+            hidden_states_fp8,
+            w1_fp8,
+            w2_fp8,
+            sorted_ids,
+            sorted_expert_ids,
+            num_valid_ids,
+            out,
+            inter_dim=inter_dim,
+            kernelName="",
+            block_m=32,
+            activation=ActivationType.Silu.value,
+            quant_type=QuantType.per_Token.value,
+            a1_scale=a1_scale,
+            w1_scale=w1_scale,
+        )
+
+        torch.cuda.synchronize()
+
+        out_cpu = out.cpu()
+        assert out_cpu is not None, "moe_stage1_g1u1 should have written to out"
+        assert out_cpu.numel() > 0, "Output tensor should not be empty"
+        assert not torch.all(
+            out_cpu == 0
+        ), "Output tensor should contain non-zero values (kernel should have computed results)"
+
+
+if __name__ == "__main__":
+    test_aiter_jit_dir_with_enum()


### PR DESCRIPTION
## Motivation

When AITER_JIT_DIR is set, calling compiled functions that accept enum arguments fails.

One example stack from running sglang with aiter (trimmed to show just the relevant parts in aiter)
```
  File "/sgl-workspace/sglang/python/sglang/srt/layers/quantization/fp8.py", line 1449, in maybe_apply_hip_fused_experts
    return fused_moe(
  File "/sgl-workspace/aiter/aiter/fused_moe.py", line 116, in fused_moe
    return fused_moe_(
  File "/sgl-workspace/aiter/aiter/jit/utils/torch_guard.py", line 279, in wrapper_custom
    getattr(torch.ops.aiter, f"{loadName}")(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/torch/_ops.py", line 1254, in __call__
    return self._op(*args, **kwargs)
  File "/sgl-workspace/aiter/aiter/jit/utils/torch_guard.py", line 302, in outer_wrapper
    wrapper(*args, **kwargs)
  File "/sgl-workspace/aiter/aiter/jit/utils/torch_guard.py", line 197, in wrapper
    return func(*args, **kwargs)
  File "/sgl-workspace/aiter/aiter/fused_moe.py", line 262, in fused_moe_
    return metadata.stage1(
  File "/sgl-workspace/aiter/aiter/fused_moe.py", line 444, in fused_moe_1stage
    fmoe_func(
  File "/sgl-workspace/aiter/aiter/jit/utils/torch_guard.py", line 279, in wrapper_custom
    getattr(torch.ops.aiter, f"{loadName}")(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/torch/_ops.py", line 1254, in __call__
    return self._op(*args, **kwargs)
  File "/sgl-workspace/aiter/aiter/jit/utils/torch_guard.py", line 302, in outer_wrapper
    wrapper(*args, **kwargs)
  File "/sgl-workspace/aiter/aiter/jit/utils/torch_guard.py", line 197, in wrapper
    return func(*args, **kwargs)
  File "/sgl-workspace/aiter/aiter/jit/core.py", line 944, in custom_wrapper
    return wrapper(*args, **kwargs)
  File "/sgl-workspace/aiter/aiter/jit/core.py", line 933, in wrapper
    func.arg_checked = check_args()
  File "/sgl-workspace/aiter/aiter/jit/core.py", line 882, in check_args
    exec(
  File "<string>", line 2, in <module>
NameError: name 'module_aiter_enum' is not defined
```

## Technical Details

When AITER_JIT_DIR is defined the enum module is loaded as "module_aiter_enum" rather than "aiter.jit.module_aiter_enum".
This makes the docstring cleanup code for enums to not work properly because the enum is loaded as `module_aiter_enum.ActivationType` rather than `aiter.jit.module_aiter_enum.ActivationType`.
the old regex would not match and therefore not remove the prefix, which caused the NameError when the dummy function definition was executed.

## Test Plan

Added a test that runs one of the existing compiled functions that get an enum as a parameter with temporary AITER_JIT_DIR set.
This test fails without the changed regex in this PR and passes with it.
This was also validated on the original use case of running sglang.

## Test Result

```
pytest op_tests/test_jit_dir_with_enum.py
=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/orimo/code/aiter
configfile: pyproject.toml
collected 1 item

op_tests/test_jit_dir_with_enum.py .                                                                                                                 [100%]

==================================================================== 1 passed in 57.21s ====================================================================
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
