### PR TITLE
[PA] fix: use dynamic FP8 type signature in AOT compilation for MI350 compatibility

### DIFF
--- a/csrc/cpp_itfs/pa_gluon_aot/pa_decode_gluon_aot_prebuild.py
+++ b/csrc/cpp_itfs/pa_gluon_aot/pa_decode_gluon_aot_prebuild.py
@@ -62,12 +62,14 @@ STR_DTYPE_TO_TORCH_DTYPE = {
 
 # Triton to PyTorch dtype mapping
 TL_TO_TORCH_DTYPE = {
-    tl.float8e4b8: aiter.dtypes.fp8,
+    tl.float8e4b8: torch.float8_e4m3fnuz,
+    tl.float8e4nv: torch.float8_e4m3fn,
     tl.bfloat16: torch.bfloat16,
     tl.float16: torch.float16,
 }
 TORCH_TO_TL_DTYPE = {
-    aiter.dtypes.fp8: tl.float8e4b8,
+    torch.float8_e4m3fnuz: tl.float8e4b8,
+    torch.float8_e4m3fn: tl.float8e4nv,
     torch.bfloat16: tl.bfloat16,
     torch.float16: tl.float16,
 }


### PR DESCRIPTION
### Summary

This PR fixes a compatibility issue on MI350 GPUs by making FP8 type signatures dynamic instead of hardcoded.

### Problem

The AOT compilation code previously hardcoded `fp8e4b8` as the FP8 type signature, which caused errors on MI350 GPUs that use a different FP8 format (`fp8e4nv`).

### Solution

- Added a `TORCH_TO_TL_DTYPE_SIG` mapping dictionary to convert PyTorch FP8 dtypes to their corresponding Triton signature strings:
  - `torch.float8_e4m3fnuz` → `fp8e4b8`
  - `torch.float8_e4m3fn` → `fp8e4nv`
- Replaced all hardcoded `"*fp8e4b8:16"` signatures with dynamic lookup using `aiter.dtypes.fp8`

### Files Changed

- `csrc/cpp_itfs/pa_gluon_aot/pa_decode_gluon_aot.py`
- `csrc/cpp_itfs/pa_gluon_aot/transpose_query_output_gluon_aot.py`