### PR TITLE
complex number multiplication that supports 3D ROPE triton kernel

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -74,3 +74,4 @@ from .ops.mha import *
 from .ops.gradlib import *
 from .ops.trans_ragged_layout import *
 from . import mla
+from .ops.groupnorm import *

--- a/aiter/install_mode
+++ b/aiter/install_mode
@@ -1,0 +1,1 @@
+develop

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -913,5 +913,17 @@
         ],
         "verbose": "False",
         "blob_gen_cmd": "''"
+    },
+    "module_groupnorm": {
+	"srcs": [
+	    "f'{AITER_CSRC_DIR}/pybind/groupnorm_pybind.cu'",
+	    "f'{AITER_CSRC_DIR}/kernels/groupnorm.cu'"
+	],
+	"flags_extra_cc": [],
+	"flags_extra_hip": [], 
+	"extra_ldflags": "None",
+	"extra_include": [],
+	"verbose": "True",
+	"blob_gen_cmd": "''"
     }
 }

--- a/aiter/ops/groupnorm.py
+++ b/aiter/ops/groupnorm.py
@@ -1,0 +1,55 @@
+from ..jit.core import compile_ops
+import torch
+from typing import Optional
+
+
+@compile_ops("module_groupnorm")
+def _groupnorm_run(
+    input: torch.Tensor,
+    num_groups: int,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Placeholder function, will be replaced by JIT."""
+    pass
+
+
+class GroupNorm(torch.nn.Module):
+    def __init__(
+        self,
+        num_groups: int,
+        num_channels: int,
+        eps: float = 1e-5,
+        affine: bool = True,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        super().__init__()
+        self.num_groups = num_groups
+        self.eps = eps
+        self.affine = affine
+
+        if affine:
+            self.weight = torch.nn.Parameter(
+                torch.ones(num_channels, device=device, dtype=dtype)
+            )
+            self.bias = torch.nn.Parameter(
+                torch.zeros(num_channels, device=device, dtype=dtype)
+            )
+        else:
+            self.register_parameter("weight", None)
+            self.register_parameter("bias", None)
+
+    def forward(self, x: torch.Tensor, use_torch: bool = False) -> torch.Tensor:
+        if use_torch or not self.affine:
+            # fallback to PyTorch for non-affine or debug mode
+            return torch.nn.functional.group_norm(
+                x,
+                self.num_groups,
+                weight=self.weight if self.affine else None,
+                bias=self.bias if self.affine else None,
+                eps=self.eps,
+            )
+        else:
+            return _groupnorm_run(x, self.num_groups, self.weight, self.bias, self.eps)

--- a/aiter/ops/triton/_triton_kernels/rope.py
+++ b/aiter/ops/triton/_triton_kernels/rope.py
@@ -1934,3 +1934,84 @@ def _rope_fwd_2d_kernel_neox(
 
     # store output
     tl.store(out_ptr + offs_x, out)
+
+@triton.jit
+def _rope_fwd_3d_kernel(
+    x_ptr, freqs_real_ptr, freqs_imag_ptr, grid_sizes_ptr, out_ptr,
+    stride_x_b, stride_x_l, stride_x_n, stride_x_c,
+    stride_freqs_s, stride_freqs_c,
+    stride_grid_b, stride_grid_d,
+    stride_out_b, stride_out_l, stride_out_n, stride_out_c,
+    L: tl.constexpr, N_HEADS: tl.constexpr, C: tl.constexpr, c_total: tl.constexpr,
+    sp_size: tl.constexpr, sp_rank: tl.constexpr,
+    max_freq_seq_len: tl.constexpr, s_per_rank: tl.constexpr,
+    pad_freq_val_r: tl.constexpr, pad_freq_val_i: tl.constexpr,
+    BLOCK_L: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_C: tl.constexpr,
+    C1: tl.constexpr, C2: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    pid_l = tl.program_id(2)
+
+    l_start = pid_l * BLOCK_L
+    l_off = l_start + tl.arange(0, BLOCK_L)
+    s_mask = l_off < L
+
+    c_off = tl.arange(0, BLOCK_C)
+    c_mask = c_off < c_total
+
+    # head mask
+    n_mask = pid_n < N_HEADS
+
+    # broadcast to  (BLOCK_L, 1, BLOCK_C) 
+    l_b = tl.broadcast_to(l_off[:, None], (BLOCK_L, BLOCK_C))
+    c_b = tl.broadcast_to(c_off[None, :], (BLOCK_L, BLOCK_C))
+
+    # read grid_sizes
+    f_grid = tl.load(grid_sizes_ptr + pid_b * stride_grid_b + 0 * stride_grid_d,
+                    mask=n_mask, other=0)
+    h_grid = tl.load(grid_sizes_ptr + pid_b * stride_grid_b + 1 * stride_grid_d,
+                    mask=n_mask, other=0)
+    w_grid = tl.load(grid_sizes_ptr + pid_b * stride_grid_b + 2 * stride_grid_d,
+                    mask=n_mask, other=0)
+    h_w = h_grid * w_grid
+
+    global_tid = sp_rank * s_per_rank + l_b
+    valid_global_tid = global_tid < f_grid * h_w
+
+    # caculate f h w
+    f_idx = tl.where(valid_global_tid, global_tid // h_w, 0)
+    rem = tl.where(valid_global_tid, global_tid % h_w, 0)
+    h_idx = tl.where(valid_global_tid, rem // w_grid, 0)
+    w_idx = tl.where(valid_global_tid, rem % w_grid, 0)
+
+    freq_row = tl.where(c_b < C1, f_idx,
+                       tl.where(c_b < C1 + C2, h_idx, w_idx))
+    freq_row = tl.where(freq_row >= max_freq_seq_len, max_freq_seq_len - 1, freq_row)
+
+    mask_rope = s_mask[:, None] & c_mask[None, :] & n_mask & valid_global_tid[:, :]
+
+    # load freqs_real and freqs_imag
+    off_freq = freq_row * stride_freqs_s + c_b * stride_freqs_c
+    freq_r = tl.load(freqs_real_ptr + off_freq, mask=mask_rope, other=pad_freq_val_r)
+    freq_i = tl.load(freqs_imag_ptr + off_freq, mask=mask_rope, other=pad_freq_val_i)
+
+    off_x_base = pid_b * stride_x_b + pid_n * stride_x_n
+    off_x_r = off_x_base + l_b * stride_x_l + (2 * c_b) * stride_x_c
+    off_x_i = off_x_base + l_b * stride_x_l + (2 * c_b + 1) * stride_x_c
+
+    x_r = tl.load(x_ptr + off_x_r, mask=mask_rope, other=0.0)
+    x_i = tl.load(x_ptr + off_x_i, mask=mask_rope, other=0.0)
+
+    # complex number multiplication
+    out_r = x_r * freq_r - x_i * freq_i
+    out_i = x_r * freq_i + x_i * freq_r
+
+    # write result
+    off_out_base = pid_b * stride_out_b + pid_n * stride_out_n
+    off_out_r = off_out_base + l_b * stride_out_l + (2 * c_b) * stride_out_c
+    off_out_i = off_out_base + l_b * stride_out_l + (2 * c_b + 1) * stride_out_c
+
+    tl.store(out_ptr + off_out_r, out_r, mask=mask_rope)
+    tl.store(out_ptr + off_out_i, out_i, mask=mask_rope)
+

--- a/aiter/ops/triton/rope3d.py
+++ b/aiter/ops/triton/rope3d.py
@@ -1,0 +1,161 @@
+import torch
+import triton
+import triton.language as tl
+from aiter.ops.triton._triton_kernels.rope import _rope_fwd_3d_kernel
+
+def rope_params(max_seq_len, dim, theta=10000):
+    assert dim % 2 == 0
+    freqs = torch.outer(
+        torch.arange(max_seq_len),
+        1.0 / torch.pow(theta,
+                        torch.arange(0, dim, 2).to(torch.float32).div(dim))
+    )
+    freqs = torch.polar(torch.ones_like(freqs), freqs)  # complex
+    return freqs
+
+def pad_freqs(original_tensor, target_len):
+    seq_len, s1, s2 = original_tensor.shape
+    pad_size = target_len - seq_len
+    padding_tensor = torch.ones(
+        pad_size, s1, s2, dtype=original_tensor.dtype, device=original_tensor.device)
+    padded_tensor = torch.cat([original_tensor, padding_tensor], dim=0)
+    return padded_tensor
+
+
+def rope_apply_triton(x, grid_sizes: tl.constexpr, freqs: tl.constexpr, sp_size: tl.constexpr, sp_rank: tl.constexpr):
+    B, s, n_heads, C = x.shape
+    c_total = C // 2  # 64
+    c1 = c_total - 2 * (c_total // 3)  # 22
+    c2 = c_total // 3                  # 21
+    c3 = c_total // 3                  # 21
+    device = x.device
+
+    grid_sizes = grid_sizes.to(device=device, dtype=torch.int32).contiguous()
+
+    freqs_real = freqs.real.to(dtype=torch.float32, device=device).contiguous()
+    freqs_imag = freqs.imag.to(dtype=torch.float32, device=device).contiguous()
+    out = torch.empty_like(x, dtype=torch.float32, device=device)
+
+    BLOCK_L, BLOCK_N, BLOCK_C = 32, 4, 64
+
+    grid = (
+        B,
+        n_heads,  
+        triton.cdiv(s, BLOCK_L)
+    )
+
+    num_warps = 4
+    waves_per_eu = 1
+
+    _rope_fwd_3d_kernel[grid](
+        x, freqs_real, freqs_imag, grid_sizes, out, 
+        *x.stride(),
+        freqs_real.stride(0), freqs_real.stride(1),
+        *grid_sizes.stride(),
+        *out.stride(),
+        s, n_heads, C, c_total,
+        sp_size, sp_rank,
+        freqs.shape[0], s,
+        1.0, 0.0,
+        BLOCK_L=BLOCK_L, BLOCK_N=BLOCK_N, BLOCK_C=BLOCK_C,
+        C1=c1, C2=c2,
+        num_warps=num_warps,
+        waves_per_eu=waves_per_eu,
+    )
+
+    return out
+
+def rope_apply_original(x, grid_sizes, freqs, sp_size, sp_rank):
+    B = x.size(0)
+    s = x.size(1)
+    n = x.size(2)
+    c = x.size(3) // 2
+
+    c1 = c - 2 * (c // 3)
+    c2 = (c // 3)
+    c3 = (c // 3)
+    freqs = freqs.split([c1, c2, c3], dim=1)
+
+    output = []
+    for i, (f, h, w) in enumerate(grid_sizes.tolist()):
+        seq_len = f * h * w
+
+        x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(s, n, -1, 2))
+
+        freqs_i = torch.cat([
+            freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),
+            freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
+            freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1)
+        ], dim=-1).reshape(seq_len, 1, -1)
+        merged_real_sum = freqs_i.real.sum()
+        freqs_i = pad_freqs(freqs_i, s * sp_size)
+        s_per_rank = s
+        freqs_i_rank = freqs_i[(sp_rank * s_per_rank):((sp_rank + 1) * s_per_rank), :, :]
+
+        x_i = torch.view_as_real(x_i * freqs_i_rank).flatten(2)
+        x_i = torch.cat([x_i, x[i, s:]])
+        output.append(x_i)
+
+    out = torch.stack(output).float()
+    return out
+
+def test_rope_consistency():
+    B, s, n, C = 1, 9450, 40, 128
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    sp_size = 8
+    max_seq_len = 1024
+
+    x = torch.arange(B*s*n*C, dtype=torch.float32, device=device).reshape(B, s, n, C)
+    x = x / (B*s*n*C)
+
+    grid_sizes = torch.tensor([[21, 45, 80]], dtype=torch.int32, device=device)
+
+    d_total = 128
+    d1 = d_total - 4 * (d_total // 6)
+    d2 = 2 * (d_total // 6)
+    d3 = 2 * (d_total // 6)
+
+    freqs_f = rope_params(max_seq_len, d1)
+    freqs_h = rope_params(max_seq_len, d2)
+    freqs_w = rope_params(max_seq_len, d3)
+    freqs = torch.cat([freqs_f, freqs_h, freqs_w], dim=1).to(device)
+
+    sp_rank = 0
+    out_orig = rope_apply_original(x.clone(), grid_sizes.clone(), freqs.clone(), sp_size, sp_rank)
+
+
+    out_triton = rope_apply_triton(x.clone(), grid_sizes.clone(), freqs.clone(), sp_size, sp_rank)
+
+    print(f"the result compare: sp_rank={sp_rank}")
+    print("="*50)
+    shape_ok = (out_orig.shape == out_triton.shape)
+    sum_orig = out_orig.sum().item()
+    sum_triton = out_triton.sum().item()
+    sum_diff = abs(sum_orig - sum_triton) / abs(sum_orig)
+    sum_ok = sum_diff < 1e-2
+    feat_orig = out_orig[0,0,0,:4]
+    feat_triton = out_triton[0,0,0,:4]
+    feat_diff = torch.abs(feat_orig - feat_triton).max().item()
+    feat_ok = feat_diff < 1e-3
+
+    print(f"shape same {'yes' if shape_ok else 'no'}")
+    print(f"(sum diff<1%): {'yes' if sum_ok else 'no'}")
+    print(f"   - Original sum: {sum_orig:.6f}")
+    print(f"   - Triton sum:   {sum_triton:.6f}")
+    print(f"   - corellation diff %:     {sum_diff*100:.2f}%")
+    print(f"fisrt 4 tensor same {'yes' if feat_ok else 'no'}")
+    print(f"   - Original: {feat_orig.cpu().numpy()}")
+    print(f"   - Triton:   {feat_triton.cpu().numpy()}")
+    print(f"   - max diff: {feat_diff:.6f}")
+
+
+    if shape_ok and sum_ok and feat_ok:
+        print(f"\n sp_rank={sp_rank} test success")
+    else:
+        print(f"\n sp_rank={sp_rank} test failed")
+    print("="*60)
+
+
+if __name__ == "__main__":
+    test_rope_consistency()
+

--- a/csrc/include/common.hpp
+++ b/csrc/include/common.hpp
@@ -1,0 +1,28 @@
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <iostream>
+#include <exception>
+
+#define CHECK_COND(x) \
+    do { \
+        if (!(x)) { \
+            std::cerr << "check failed, file=" \
+                << __FILE__ << ", line=" \
+                << __LINE__ << std::endl; \
+            std::terminate(); \
+        } \
+    } while(false)
+
+#define CHECK_HIP(x) \
+    do { \
+        hipError_t __err_code = (x); \
+        if( __err_code != hipSuccess ) { \
+            std::cerr << "call hip api failed, file=" \
+                << __FILE__ << ", line=" \
+                << __LINE__ << ", name=" \
+                << hipGetErrorName(__err_code) \
+                << std::endl; \
+            std::terminate(); \
+        } \
+    } while(false)

--- a/csrc/include/groupnorm.hpp
+++ b/csrc/include/groupnorm.hpp
@@ -1,0 +1,32 @@
+#include <torch/extension.h>
+
+#include "common.hpp"
+
+#include <optional>
+
+namespace rocm_torch_x {
+
+class __attribute__ ((visibility("hidden"))) GroupNorm final
+{
+public:
+    explicit GroupNorm() = default;
+    ~GroupNorm() = default;
+public:
+    // return empty if not supported
+    std::optional<torch::Tensor> Run(
+        torch::Tensor x,
+        int num_groups,
+        torch::Tensor weights,
+        torch::Tensor bias,
+        float epsilon);
+private:
+    template<typename T>
+    torch::Tensor launchGroupNormKernel(uint32_t num_groups, float epsilon,
+        const torch::Tensor x, const torch::Tensor weights, const torch::Tensor bias, hipStream_t stream);
+
+    void reserveMeanAccumulator(uint32_t nums_to_reserve, torch::Device device);
+private:
+    torch::Tensor mean_accumulator_;
+};
+
+} // namespace rocm_torch_x

--- a/csrc/kernels/groupnorm.cu
+++ b/csrc/kernels/groupnorm.cu
@@ -1,0 +1,398 @@
+#include "groupnorm.hpp"
+
+#include <c10/hip/HIPStream.h>
+#include <c10/hip/HIPGuard.h>
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+
+#include <sstream>
+#include <vector>
+#include <string>
+#include <cstdlib>
+#include <cstdio>
+#include <type_traits>
+
+namespace {
+
+template<typename T> __forceinline__ __device__ float dtype2acctype(T x) {return x;};
+template<> __forceinline__ __device__ float dtype2acctype<__half>(__half x) {return __half2float(x);}
+template<> __forceinline__ __device__ float dtype2acctype<__hip_bfloat16>(__hip_bfloat16 x) {return __bfloat162float(x);}
+
+template<typename T> __forceinline__ __device__ T acctype2dtype(float x) {return x;};
+template<> __forceinline__ __device__ __half acctype2dtype<__half>(float x) {return __float2half(x);}
+template<> __forceinline__ __device__ __hip_bfloat16 acctype2dtype<__hip_bfloat16>(float x) {return __float2bfloat16(x);}
+
+template<typename T,
+    typename std::enable_if<sizeof(T) == sizeof(uint64_t)>::type* = nullptr>
+__inline__ __device__ T warp_reduce(T value)
+{
+#pragma unroll
+    for(uint32_t offset=(warpSize>>1); offset!=0; offset>>=1) {
+        uint64_t value_u64 = *reinterpret_cast<uint64_t*>(&value);
+        value_u64 = __shfl_down(value_u64, offset);
+        value += *reinterpret_cast<T*>(&value_u64);
+    }
+    return value;
+}
+
+template<typename T, uint32_t NUM_WARPS>
+__inline__ __device__ T block_reduce(T value, T identity_element, T *smem)
+{
+    uint32_t warp_id = threadIdx.x / warpSize;
+    uint32_t lane_id = threadIdx.x % warpSize;
+    value = warp_reduce(value);
+    //__syncthreads();
+    if(lane_id == 0) {
+        smem[warp_id] = value;
+    }
+    __syncthreads();
+    value = (threadIdx.x < NUM_WARPS) ? smem[lane_id] : identity_element;
+    if(warp_id == 0) {
+        value = warp_reduce(value);
+    }
+    return value;
+}
+
+struct Element final
+{
+    float mean;
+    float var;
+    __device__ Element & operator += (const Element & other) {
+        mean += other.mean;
+        var += other.var;
+        return *this;
+    }
+};
+
+template<typename T, uint32_t N>
+struct Vec
+{
+    T value[N];
+    __forceinline__ __device__ void load(const void *src) {
+        *this = *reinterpret_cast<const Vec<T, N>*>(src);
+    }
+    __forceinline__ __device__ void store(void *dst) const {
+        *reinterpret_cast<Vec<T, N>*>(dst) = *this;
+    }
+};
+
+template<typename T, uint32_t THREADS_PER_BLOCK, uint32_t warpSize>
+__device__ void groupnorm_kernel_up(uint32_t num_groups, uint32_t num_channels, int64_t numel_per_channel, 
+    bool align4, const T *x, float *mean_acc, float *square_mean_acc)
+{
+    uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    uint32_t inner_size = numel_per_channel * num_channels / num_groups;
+
+    Element el{0.0f, 0.0f};
+
+    if(align4) {
+        // the NVIDIA GPU arch can do a vectorized load of 128bits several years ago
+        // i'm not sure about the latest data, but loading 64 bits at a time should be sufficient
+        Vec<T, 4> vec;
+        for(uint32_t i = tid*4; i < inner_size; i += (gridDim.x * THREADS_PER_BLOCK)*4) {
+            uint32_t idx = blockIdx.y * inner_size + i;
+            vec.load(x+idx);
+
+            float value = dtype2acctype(vec.value[0]);
+            el.mean += value;
+            el.var += value * value;
+
+            value = dtype2acctype(vec.value[1]);
+            el.mean += value;
+            el.var += value * value;
+
+            value = dtype2acctype(vec.value[2]);
+            el.mean += value;
+            el.var += value * value;
+
+            value = dtype2acctype(vec.value[3]);
+            el.mean += value;
+            el.var += value * value;
+        }
+    }
+    else {
+        for(uint32_t i = tid; i < inner_size; i += (gridDim.x * THREADS_PER_BLOCK)) {
+            uint32_t idx = blockIdx.y * inner_size + i;
+            float value = dtype2acctype(x[idx]);
+            el.mean += value;
+            el.var += value * value;
+        }
+    }
+
+    static_assert(THREADS_PER_BLOCK % warpSize == 0, "");
+    constexpr uint32_t NUM_WARPS = THREADS_PER_BLOCK / warpSize;
+    __shared__ Element smem[NUM_WARPS];
+    el = block_reduce<Element, NUM_WARPS>(el, Element{0.0f, 0.0f}, smem);
+
+    if (threadIdx.x == 0) {
+        mean_acc[blockIdx.y*gridDim.x+blockIdx.x] = el.mean;
+        square_mean_acc[blockIdx.y*gridDim.x+blockIdx.x] = el.var;
+    }
+}
+
+template<typename T, uint32_t THREADS_PER_BLOCK, uint32_t warpSize>
+__device__ void groupnorm_kernel_down(uint32_t num_groups, uint32_t num_channels,
+    int64_t numel_per_channel, float epsilon, bool align4,
+    const T *x, const T *weights, const T *bias,
+    const float *mean_acc, const float *square_mean_acc,
+    T *y)
+{
+    uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    uint32_t inner_size = numel_per_channel * num_channels / num_groups;
+
+    Element el{0.0f, 0.0f};
+    for(uint32_t i = threadIdx.x; i < gridDim.x; i += THREADS_PER_BLOCK) {
+        uint32_t idx = blockIdx.y * gridDim.x + i;
+        el.mean += mean_acc[idx];
+        el.var += square_mean_acc[idx];
+    }
+
+    static_assert(THREADS_PER_BLOCK % warpSize == 0, "");
+    constexpr uint32_t NUM_WARPS = THREADS_PER_BLOCK / warpSize;
+    __shared__ Element smem[NUM_WARPS];
+    el = block_reduce<Element, NUM_WARPS>(el, Element{0.0f, 0.0f}, smem);
+    if(threadIdx.x == 0) {
+        smem[0] = el;
+    }
+    __syncthreads();
+    float mean = smem[0].mean / inner_size;
+    float var = smem[0].var / inner_size - mean * mean;
+    float rstd = rsqrt(var + epsilon);
+
+    if(align4) {
+        Vec<float, 4> vec_x;
+        float weights_value{1.0f}, bias_value{0.0f};
+        Vec<T, 4> tmp;
+        for(uint32_t i = tid*4; i < inner_size; i += (gridDim.x * THREADS_PER_BLOCK)*4)
+        {
+            uint32_t idx = blockIdx.y * inner_size + i;
+            uint32_t channel_idx = (idx / numel_per_channel) % num_channels;
+            tmp.load(x+idx);
+            vec_x.value[0] = dtype2acctype(tmp.value[0]);
+            vec_x.value[1] = dtype2acctype(tmp.value[1]);
+            vec_x.value[2] = dtype2acctype(tmp.value[2]);
+            vec_x.value[3] = dtype2acctype(tmp.value[3]);
+            if(weights != nullptr) {
+                weights_value = dtype2acctype(weights[channel_idx]);
+            }
+            if(bias != nullptr) {
+                bias_value = dtype2acctype(bias[channel_idx]);
+            }
+
+            float value0 = (vec_x.value[0] - mean) * rstd * weights_value + bias_value;
+            float value1 = (vec_x.value[1] - mean) * rstd * weights_value + bias_value;
+            float value2 = (vec_x.value[2] - mean) * rstd * weights_value + bias_value;
+            float value3 = (vec_x.value[3] - mean) * rstd * weights_value + bias_value;
+            Vec<T, 4> vec_y{
+                acctype2dtype<T>(value0), acctype2dtype<T>(value1),
+                acctype2dtype<T>(value2), acctype2dtype<T>(value3)
+            };
+            vec_y.store(y+idx);
+        }
+    }
+    else {
+        for(uint32_t i = tid; i < inner_size; i += (gridDim.x * THREADS_PER_BLOCK))
+        {
+            uint32_t idx = blockIdx.y * inner_size + i;
+            uint32_t channel_idx = (idx / numel_per_channel) % num_channels;
+            float weight_value = (weights == nullptr) ? 1.0f : dtype2acctype(weights[channel_idx]);
+            float bias_value = (bias == nullptr) ? 0.0f : dtype2acctype(bias[channel_idx]);
+            float value = (dtype2acctype(x[idx]) - mean) * rstd * weight_value + bias_value;
+            y[idx] = acctype2dtype<T>(value);
+        }
+    }
+}
+
+template<typename T, uint32_t THREADS_PER_BLOCK>
+__global__ void groupnorm_kernel_dispatch_up(uint32_t num_groups, uint32_t num_channels, int64_t numel_per_channel,
+    bool align4, const T *x, float *mean_acc, float *square_mean_acc) {
+    if (warpSize == 32) {
+        groupnorm_kernel_up<T, THREADS_PER_BLOCK, 32>(
+            num_groups,
+            num_channels,
+            numel_per_channel,
+            align4,
+            x,
+            mean_acc,
+            square_mean_acc);
+    } else if (warpSize == 64) {
+        groupnorm_kernel_up<T, THREADS_PER_BLOCK, 64>(
+            num_groups,
+            num_channels,
+            numel_per_channel,
+            align4,
+            x,
+            mean_acc,
+            square_mean_acc);
+    } else {
+        uint32_t size = warpSize;
+        printf("Error: Unsupported warpSize = %d. Only 32 and 64 are supported.\n", size);
+        assert(false);
+    }
+}
+
+template<typename T, uint32_t THREADS_PER_BLOCK>
+__global__ void groupnorm_kernel_dispatch_down(uint32_t num_groups, uint32_t num_channels,
+    int64_t numel_per_channel, float epsilon, bool align4,
+    const T *x, const T *weights, const T *bias,
+    const float *mean_acc, const float *square_mean_acc,
+    T *y) {
+    if (warpSize == 32) {
+        groupnorm_kernel_down<T, THREADS_PER_BLOCK, 32>(
+            num_groups,
+            num_channels,
+            numel_per_channel,
+            epsilon,
+            align4,
+            x,
+            weights,
+            bias,
+            mean_acc,
+            square_mean_acc,
+            y);
+    } else if (warpSize == 64) {
+        groupnorm_kernel_down<T, THREADS_PER_BLOCK, 64>(
+            num_groups,
+            num_channels,
+            numel_per_channel,
+            epsilon,
+            align4,
+            x,
+            weights,
+            bias,
+            mean_acc,
+            square_mean_acc,
+            y);
+    } else {
+        uint32_t size = warpSize;
+        printf("Error: Unsupported warpSize = %d. Only 32 and 64 are supported.\n", size);
+        assert(false);
+    }
+}
+
+} // namespace
+
+namespace rocm_torch_x {
+
+template<typename T>
+torch::Tensor GroupNorm::launchGroupNormKernel(uint32_t num_groups, float epsilon,
+    const torch::Tensor x, const torch::Tensor weights, const torch::Tensor bias, hipStream_t stream)
+{
+    torch::Tensor y = torch::empty_like(x);
+    const std::vector<int64_t> & dims = x.sizes().vec();
+    int64_t numel = std::accumulate(dims.begin(), dims.end(), 1LL, std::multiplies<int64_t>());
+    int64_t numel_per_channel = numel / dims[0] / dims[1];
+    uint32_t num_channels = dims[1];
+
+    uint32_t outer_size = dims[0] * num_groups;
+    int64_t inner_size = numel / outer_size;
+
+    constexpr uint32_t THREADS_PER_BLOCK = 1024;
+    constexpr uint32_t STEPS_PER_THREAD = 8;
+    uint32_t gridx = (inner_size + (STEPS_PER_THREAD * THREADS_PER_BLOCK) - 1) / (STEPS_PER_THREAD * THREADS_PER_BLOCK);
+
+    bool align4 = false;
+    if(inner_size % 4 == 0 && gridx >= 16) {
+        gridx = std::max<uint32_t>(1, gridx / 4);
+        align4 = true;
+    }
+    gridx = std::min<uint32_t>((4096+outer_size-1)/outer_size, gridx);
+
+    const dim3 grid_dim(gridx, outer_size, 1);
+    constexpr dim3 block_dim(THREADS_PER_BLOCK, 1, 1);
+
+    uint32_t num_acc_slots = gridx * outer_size;
+    reserveMeanAccumulator(num_acc_slots*2, x.device());
+
+    // there are some other ways:
+    //    1) use sequential atomicAdd in the first function to reduce, this may influence precision, and need an another memset kenrel
+    //    2) use cooperative groups to sync grid, results in hipErrorCooperativeLaunchTooLarge
+    // so i launch 2 differnt kernels(up && down)
+    // in fact, the second kernel is not needed if gridx==1
+    // but this is definitely a case with a small amount of data, so the overall difference seems minimal.
+    groupnorm_kernel_dispatch_up<T, THREADS_PER_BLOCK><<<grid_dim, block_dim, 0, stream>>>(
+        num_groups,
+        num_channels,
+        numel_per_channel,
+        align4,
+        static_cast<const T*>(x.data_ptr()),
+        mean_accumulator_.mutable_data_ptr<float>(),
+        mean_accumulator_.mutable_data_ptr<float>()+num_acc_slots);
+    CHECK_HIP(hipGetLastError());
+
+    groupnorm_kernel_dispatch_down<T, THREADS_PER_BLOCK><<<grid_dim, block_dim, 0, stream>>>(
+        num_groups,
+        num_channels,
+        numel_per_channel,
+        epsilon,
+        align4,
+        static_cast<const T*>(x.data_ptr()),
+        static_cast<const T*>(weights.data_ptr()),
+        static_cast<const T*>(bias.data_ptr()),
+        mean_accumulator_.data_ptr<float>(),
+        mean_accumulator_.data_ptr<float>()+num_acc_slots,
+        static_cast<T*>(y.mutable_data_ptr()));
+    CHECK_HIP(hipGetLastError());
+
+    return y;
+}
+
+std::optional<torch::Tensor> GroupNorm::Run(
+    torch::Tensor x,
+    int num_groups,
+    torch::Tensor weights,
+    torch::Tensor bias,
+    float epsilon)
+{
+    at::DeviceGuard device_guard(x.device());
+
+    auto hip_stream = c10::hip::getCurrentHIPStream();
+
+    if (x.requires_grad()) {
+        return std::nullopt;
+    }
+
+    if(weights.numel() == 0 || bias.numel() == 0) {
+        return std::nullopt;
+    }
+
+    // TODO(limou) :
+    if(!x.is_contiguous()) {
+        x = x.contiguous();
+    }
+    weights = weights.contiguous();
+    bias = bias.contiguous();
+
+    torch::Tensor y;
+    switch(x.scalar_type()) {
+        case c10::ScalarType::Float:
+            y = launchGroupNormKernel<float>(num_groups, epsilon, x, weights, bias, hip_stream.stream());
+            break;
+        case c10::ScalarType::Half:
+            y = launchGroupNormKernel<__half>(num_groups, epsilon, x, weights, bias, hip_stream.stream());
+            break;
+        case c10::ScalarType::BFloat16:
+            y = launchGroupNormKernel<__hip_bfloat16>(num_groups, epsilon, x, weights, bias, hip_stream.stream());
+            break;
+        default:
+            return std::nullopt;
+    }
+    return y;
+}
+
+void GroupNorm::reserveMeanAccumulator(uint32_t nums_to_reserve, torch::Device device)
+{
+    if(nums_to_reserve <= mean_accumulator_.numel()) {
+        return;
+    }
+    auto options = torch::TensorOptions()
+        .dtype(c10::ScalarType::Float)
+        .device(device)
+        .requires_grad(false);
+
+    mean_accumulator_ = at::empty({nums_to_reserve}, options);
+}
+
+} // rocm_torch_x
+

--- a/csrc/pybind/groupnorm_pybind.cu
+++ b/csrc/pybind/groupnorm_pybind.cu
@@ -1,0 +1,25 @@
+#include <torch/extension.h>
+#include "../include/groupnorm.hpp"
+
+torch::Tensor _groupnorm_run_wrapper(
+    torch::Tensor input,
+    int64_t num_groups,
+    torch::Tensor weight,
+    torch::Tensor bias,
+    double eps
+) {
+    rocm_torch_x::GroupNorm gn;
+    auto result = gn.Run(
+        input,
+        static_cast<int>(num_groups),
+        weight,
+        bias,
+        static_cast<float>(eps)
+    );
+    TORCH_CHECK(result.has_value(), "GroupNorm kernel returned nullopt");
+    return result.value();
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("_groupnorm_run", &_groupnorm_run_wrapper);  
+}

--- a/csrc/rocm_ops.cpp
+++ b/csrc/rocm_ops.cpp
@@ -34,6 +34,7 @@
 #include "rocsolgemm.cuh"
 #include "rope.h"
 #include "smoothquant.h"
+#include "groupnorm.hpp"
 #include <torch/extension.h>
 
 // #include "torch/mha_batch_prefill.h"
@@ -87,6 +88,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     ROPE_GENERAL_FWD_PYBIND;
     ROPE_GENERAL_BWD_PYBIND;
     ROPE_POS_FWD_PYBIND;
+    GROUPNORM_PYBIND;
     // GEMM_A8W8_BLOCKSCALE_TUNE_PYBIND;
     GEMM_A4W4_BLOCKSCALE_PYBIND;
     GEMM_A8W8_BLOCKSCALE_PYBIND;

--- a/op_tests/test_groupnorm.py
+++ b/op_tests/test_groupnorm.py
@@ -1,0 +1,146 @@
+import sys
+import random
+import numpy as np
+
+import torch
+from torch.profiler import ProfilerActivity
+
+from aiter.ops.groupnorm import GroupNorm
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ["TORCH_CPP_EXTENSION_WARNING_LEVEL"] = "2"
+
+random.seed(0)
+torch.manual_seed(0)
+np.random.seed(0)
+
+DEVICE = torch.device("cuda")
+DTYPE = torch.float16
+
+
+class GroupNormTimer:
+
+    def __init__(self, num_groups, num_channels):
+        self.norm = GroupNorm(
+            num_groups, num_channels, eps=1e-6, affine=True, device=DEVICE, dtype=DTYPE
+        )
+        self.norm.weight = torch.nn.Parameter(
+            torch.randn((num_channels,), dtype=DTYPE, device=DEVICE)
+        )
+        self.norm.bias = torch.nn.Parameter(
+            torch.randn((num_channels,), dtype=DTYPE, device=DEVICE)
+        )
+        self.num_channels = num_channels
+
+    @torch.inference_mode()
+    def run_and_get_time(self, input_dims: list, print_tensors: bool = False):
+        num_warmups = 5
+        num_iters = 25
+
+        assert len(input_dims) >= 3
+        assert input_dims[1] == self.num_channels
+
+        x = torch.randn(tuple(input_dims), dtype=DTYPE, device=DEVICE)
+        if print_tensors:
+            print("x :")
+            print(x)
+
+        # torch
+        with torch.no_grad():
+            for _ in range(num_warmups):
+                y = self.norm(x, use_torch=True)
+        e_start = torch.cuda.Event(enable_timing=True)
+        e_end = torch.cuda.Event(enable_timing=True)
+        e_start.record()
+        with torch.no_grad():
+            for _ in range(num_iters):
+                y = self.norm(x, use_torch=True)
+        e_end.record()
+        e_end.synchronize()
+        time_elapsed_torch = e_start.elapsed_time(e_end) / num_iters
+        if print_tensors:
+            print("y :")
+            print(y)
+
+        # opt
+        for _ in range(num_warmups):
+            z = self.norm(x, use_torch=False)
+        e_start = torch.cuda.Event(enable_timing=True)
+        e_end = torch.cuda.Event(enable_timing=True)
+        e_start.record()
+        for _ in range(num_iters):
+            z = self.norm(x, use_torch=False)
+        e_end.record()
+        e_end.synchronize()
+        time_elapsed_opt = e_start.elapsed_time(e_end) / num_iters
+        if print_tensors:
+            print("z :")
+            print(z)
+
+        is_equal = torch.allclose(y, z, rtol=1e-3, atol=1e-2)
+        return (time_elapsed_torch, time_elapsed_opt, is_equal)
+
+
+def main():
+    torch.set_printoptions(precision=6)
+    bench_shapes = [
+        [1, 1, 1, 2],  # [num_groups, n, c, ...]
+        [4, 1, 4, 4],
+        [8, 1, 512, 1728],
+        [16, 1, 128, 9, 144, 256],
+        [32, 1, 512, 1728],
+        [32, 1, 512, 5120],
+        [32, 1, 128, 9, 144, 256],
+        [32, 1, 128, 17, 256, 128],
+        [32, 1, 128, 17, 256, 256],
+        [32, 1, 256, 9, 128, 128],
+        [32, 1, 256, 9, 144, 256],
+        [32, 1, 256, 17, 144, 256],
+        [32, 1, 256, 17, 256, 256],
+        [32, 1, 512, 3, 18, 32],
+        [32, 1, 512, 3, 64, 64],
+        [32, 1, 512, 5, 32, 32],
+        [32, 1, 512, 5, 64, 64],
+        [32, 1, 512, 9, 128, 128],
+        # add extra cases with batch_size>1
+        [32, 4, 256, 17, 144, 256],
+        [32, 7, 512, 3, 18, 32],
+        [32, 3, 512, 5, 64, 64],
+        # add extra cases with prime or odd hw value
+        [16, 3, 256, 5, 7, 11],
+        [16, 1, 32, 15, 17, 11],
+        [16, 5, 32, 2, 5, 3],
+    ]
+
+    speedups = []
+    for shape in bench_shapes:
+        norm_timer = GroupNormTimer(shape[0], shape[2])
+        torch_time, opt_time, is_equal = norm_timer.run_and_get_time(
+            shape[1:], print_tensors=False
+        )
+        speedup = torch_time / opt_time if opt_time > 0 else float("inf")
+        speedups.append(speedup)
+
+        print(
+            "shape={} torch_time={:.4f} ms, opt_time={:.4f} ms, speedup={:.4f} is_equal={}".format(
+                shape, torch_time, opt_time, speedup, is_equal
+            ),
+            flush=True,
+        )
+
+    print("Speedups with all shapes, including batch_size > 1 and odd hw values:")
+    print("Average speedup: {:.4f}".format(np.mean(speedups)), flush=True)
+    print("Median speedup: {:.4f}".format(np.median(speedups)), flush=True)
+
+    print("Speedups with batch_size == 1 only")
+    speedups = speedups[:-6]
+    print("Average speedup: {:.4f}".format(np.mean(speedups)), flush=True)
+    print("Median speedup: {:.4f}".format(np.median(speedups)), flush=True)
+
+
+if __name__ == "__main__":
+    print("main start", flush=True)
+    main()
+    print("main end", flush=True)


### PR DESCRIPTION
## Motivation

Text-to-image models (Stable Diffusion, SDXL, etc.) spend more than 30% of total wall-time inside 

## Technical Details



## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

The end-to-end execution time on SDXL speedup 1.1x.
UT tests:
Loading extension module module_groupnorm...
[aiter] finish build [module_groupnorm], cost 42.22851262s
[aiter] type hints mismatch, override to --> _groupnorm_run(arg0: torch.Tensor, arg1: int, arg2: torch.Tensor, arg3: torch.Tensor, arg4: float) -> torch.Tensor
shape=[1, 1, 1, 2] torch_time=0.0297 ms, opt_time=0.0217 ms, speedup=1.3690 is_equal=True
shape=[4, 1, 4, 4] torch_time=0.0283 ms, opt_time=0.0206 ms, speedup=1.3746 is_equal=True
shape=[8, 1, 512, 1728] torch_time=0.0632 ms, opt_time=0.0243 ms, speedup=2.5952 is_equal=True
shape=[16, 1, 128, 9, 144, 256] torch_time=2.1253 ms, opt_time=0.1918 ms, speedup=11.0787 is_equal=True
shape=[32, 1, 512, 1728] torch_time=0.0284 ms, opt_time=0.0230 ms, speedup=1.2346 is_equal=True
shape=[32, 1, 512, 5120] torch_time=0.0597 ms, opt_time=0.0436 ms, speedup=1.3690 is_equal=True
shape=[32, 1, 128, 9, 144, 256] torch_time=1.1629 ms, opt_time=0.1863 ms, speedup=6.2424 is_equal=True
shape=[32, 1, 128, 17, 256, 128] torch_time=2.0499 ms, opt_time=0.3111 ms, speedup=6.5896 is_equal=True
shape=[32, 1, 128, 17, 256, 256] torch_time=4.9001 ms, opt_time=0.6969 ms, speedup=7.0314 is_equal=True
shape=[32, 1, 256, 9, 128, 128] torch_time=1.0338 ms, opt_time=0.1703 ms, speedup=6.0710 is_equal=True
shape=[32, 1, 256, 9, 144, 256] torch_time=2.8831 ms, opt_time=0.3730 ms, speedup=7.7294 is_equal=True
shape=[32, 1, 256, 17, 144, 256] torch_time=5.5148 ms, opt_time=0.7639 ms, speedup=7.2194 is_equal=True
shape=[32, 1, 256, 17, 256, 256] torch_time=9.8392 ms, opt_time=1.2473 ms, speedup=7.8886 is_equal=True
shape=[32, 1, 512, 3, 18, 32] torch_time=0.0293 ms, opt_time=0.0232 ms, speedup=1.2608 is_equal=True
shape=[32, 1, 512, 3, 64, 64] torch_time=0.1813 ms, opt_time=0.0406 ms, speedup=4.4595 is_equal=True
shape=[32, 1, 512, 5, 32, 32] torch_time=0.0597 ms, opt_time=0.0432 ms, speedup=1.3809 is_equal=True
shape=[32, 1, 512, 5, 64, 64] torch_time=0.2945 ms, opt_time=0.0523 ms, speedup=5.6367 is_equal=True
shape=[32, 1, 512, 9, 128, 128] torch_time=2.1918 ms, opt_time=0.3242 ms, speedup=6.7602 is_equal=True
shape=[32, 4, 256, 17, 144, 256] torch_time=8.1419 ms, opt_time=2.6362 ms, speedup=3.0885 is_equal=True
shape=[32, 7, 512, 3, 18, 32] torch_time=0.0673 ms, opt_time=0.1112 ms, speedup=0.6051 is_equal=True
shape=[32, 3, 512, 5, 64, 64] torch_time=0.4101 ms, opt_time=0.1387 ms, speedup=2.9578 is_equal=True
shape=[16, 3, 256, 5, 7, 11] torch_time=0.0292 ms, opt_time=0.0207 ms, speedup=1.4094 is_equal=True
shape=[16, 1, 32, 15, 17, 11] torch_time=0.0281 ms, opt_time=0.0210 ms, speedup=1.3417 is_equal=True
shape=[16, 5, 32, 2, 5, 3] torch_time=0.0284 ms, opt_time=0.0265 ms, speedup=1.0744 is_equal=True
Speedups with all shapes, including batch_size > 1 and odd hw values:
Average speedup: 4.0737
Median speedup: 3.0231
Speedups with batch_size == 1 only
Average speedup: 4.8495
Median speedup: 5.8539
main end


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
