### PR TITLE
[TRITON] Update triton gemm tuning config file for deepseekR1-mxfp4 bs64

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-AFP4WFP4-N=4608-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-AFP4WFP4-N=4608-K=7168.json
@@ -24,13 +24,13 @@
         "NUM_KSPLIT": 4
     },
     "M_LEQ_64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 256,
-        "BLOCK_SIZE_K": 256,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 4,
-        "num_stages": 3,
-        "waves_per_eu": 1,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg",
         "NUM_KSPLIT": 1

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=2304.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=2304.json
@@ -24,13 +24,13 @@
         "NUM_KSPLIT": 4
     },
     "M_LEQ_64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 256,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 4,
-        "num_stages": 3,
-        "waves_per_eu": 1,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg",
         "NUM_KSPLIT": 1


### PR DESCRIPTION
## Motivation

This PR updates Triton GEMM tuning configurations for DeepSeek-R1 MXFP4 to improve MLP layer performance during the decode phase.

The motivation is to reduce decode latency by optimizing the dominant GEMM kernels in the MLP path. The new configurations are derived from an AI-assisted tuning workflow, targeting real decode-phase shapes observed in production workloads.

## Technical Details

- Updated two Triton GEMM configurations used by the MXFP4 MLP kernels.
- The tuning focuses on the _gemm_afp4wfp4_kernel used by:
   - MLP down projection
   - MLP up projection
- The new configs are selected for decode-phase shapes and improve memory access patterns and instruction-level efficiency.
- No functional changes to kernel logic; only configuration-level tuning is applied.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Module          | Kernel Name                         | Original (µs)    | Optimized (µs) | Speedup
down_proj     | _gemm_afp4wfp4_kernel      | 57.44                | 16                    | 3.59×
up_proj          | _gemm_afp4wfp4_kernel      | 19.68                | 9                      | 2.18×

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
