### PR TITLE
Support profiler pa and reduce kernel and remove p99 to use test_common

### DIFF
--- a/op_tests/test_pa_ps.py
+++ b/op_tests/test_pa_ps.py
@@ -881,5 +881,5 @@ for dtype in l_dtype:
     df_md = df.to_markdown(index=False)
     aiter.logger.info("pa_ps summary (markdown):\n%s", df_md)
     df.to_csv("pa_ps.csv")
-    pd.set_option ("display.max_columns", None)
+    pd.set_option("display.max_columns", None)
     print(df)


### PR DESCRIPTION
## Motivation
To better breakdown Pa kernel time and reduce kernel time, we use profile to breakdown
python op_tests/test_pa_ps.py --profile

```
PERFORMANCE COMPARISON
========================================================================================================================
Sequence Lengths: 90002
------------------------------------------------------------------------------------------------------------------------
Metadata (get_pa_metadata_v1)            167.64us
------------------------------------------------------------------------------------------------------------------------
Method                                 Time (us)            PA Kernel               Reduce
------------------------------------------------------------------------------------------------------------------------
PA with Persistent Scheduling           1091.04us   1074.32us ( 98.5%)     15.87us (  1.5%)
PA without Persistent Scheduling        1303.82us   1303.78us (100.0%)      0.00us (  0.0%)
------------------------------------------------------------------------------------------------------------------------
Speedup                                       1.20x
========================================================================================================================
```