### PR TITLE
Add AITER_ASM_ROOT env to specify HSA path w/o GPU arch

### DIFF
--- a/csrc/cpp_itfs/mha_bwd.cpp
+++ b/csrc/cpp_itfs/mha_bwd.cpp
@@ -315,7 +315,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         auto result = impl_ptr_map.emplace(name, nullptr);
         if(result.second)
         {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
+            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name, arch_id.c_str());
         }
 
         impl_ptr_pre = result.first->second.get();
@@ -336,7 +336,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         auto result = impl_ptr_map.emplace(name, nullptr);
         if(result.second)
         {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
+            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name, arch_id.c_str());
         }
 
         impl_ptr_dqdkdv = result.first->second.get();
@@ -359,7 +359,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
             auto result = impl_ptr_map.emplace(name, nullptr);
             if(result.second)
             {
-                result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
+                result.first->second = std::make_unique<AiterAsmKernel>(name, co_name, arch_id.c_str());
             }
 
             impl_ptr_post = result.first->second.get();

--- a/csrc/cpp_itfs/mha_fwd.cpp
+++ b/csrc/cpp_itfs/mha_fwd.cpp
@@ -223,7 +223,7 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
     auto result = impl_ptr_map.emplace(name, nullptr);
     if(result.second)
     {
-        result.first->second = std::make_unique<AiterAsmKernel>(name, co_name.c_str());
+        result.first->second = std::make_unique<AiterAsmKernel>(name, co_name.c_str(), arch_id.c_str());
     }
     impl_ptr = result.first->second.get();
     fmha_fwd_v3_args args;

--- a/csrc/include/aiter_hip_common.h
+++ b/csrc/include/aiter_hip_common.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
 #include "ck_tile/core.hpp"
 #include <hip/hip_runtime.h>
@@ -74,12 +74,21 @@ class AiterAsmKernel
     hipFunction_t kernel_func;
 
     public:
-    AiterAsmKernel(const char* name, const char* hsaco)
+    AiterAsmKernel(const char* name, const char* hsaco, const char* arch_id=nullptr)
     {
         const char* AITER_ASM_DIR = std::getenv("AITER_ASM_DIR");
-        std::cout << "[aiter] hipModuleLoad: " << (std::string(AITER_ASM_DIR) + hsaco).c_str()
-                  << " GetFunction: " << name;
-        HIP_CALL(hipModuleLoad(&module, (std::string(AITER_ASM_DIR) + hsaco).c_str()));
+        std::string module_path;
+        if (AITER_ASM_DIR != nullptr) {
+            module_path = std::string(AITER_ASM_DIR) + hsaco;
+        } else if (arch_id != nullptr)
+        {
+            AITER_ASM_DIR = std::getenv("AITER_ASM_ROOT");
+            module_path = std::string(AITER_ASM_DIR ? AITER_ASM_DIR : "") + arch_id + "/" + hsaco;
+        } else {
+            module_path = hsaco;
+        }
+        std::cout << "[aiter] hipModuleLoad: " << module_path << " GetFunction: " << name;
+        HIP_CALL(hipModuleLoad(&module, module_path.c_str()));
         HIP_CALL(hipModuleGetFunction(&kernel_func, module, name));
         std::cout << " Success" << std::endl;
     };

--- a/op_tests/cpp/mha/README.md
+++ b/op_tests/cpp/mha/README.md
@@ -27,6 +27,9 @@ To benchmark asm kernel, try following commands:
 
 # Set this env before you run
 export AITER_ASM_DIR={path_to_aiter}/hsa/{arch_name}/
+# or to make it automatically detecting GPU architecture
+export AITER_ASM_ROOT={path_to_aiter}/hsa/
+
 
 # fwd_v3
 ./benchmark_mha_fwd -prec=bf16 -b=1 -h=64 -d=128 -s=8192 -iperm=1 -operm=1 -mask=1 -lse=1 -fwd_v3=1 -mode=0 -kname=1 -v=0


### PR DESCRIPTION
## Motivation

AITER_ASM_DIR has some problems when used from C-code:
- it requires specifying GPU arch and cannot be statically programmed for apps working on multiple platforms
- dynamic setting of env variable in C-code during the app execution is undesired because setenv() is not thread safe and may result in crash of multi-threading apps using variety of ROCm libraries and frameworks: [SWDEV-565755](https://ontrack-internal.amd.com/browse/SWDEV-565755)

## Technical Details

To keep compatibility with existing code AITER_ASM_DIR behaviour is not touched. Instead, new env variable AITER_ASM_ROOT is added that specifies path to AITER hsa directory w/o adding GPU arch, i.e. AITER_ASM_DIR = AITER_ASM_ROOT/{arch}/. 
If AITER_ASM_DIR is not specified, the code checks for AITER_ASM_ROOT and adds {arch} to it to get HSACO path.

## Test Plan

Run fwd.exe/bwd.exe specifying AITER_ASM_DIR and AITER_ASM_ROOT

## Test Result

Tests pass with properly set variables.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[SWDEV-565755]: https://amd.atlassian.net/browse/SWDEV-565755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ