### PR TITLE
Optimize the performance of quick_allreduce

### DIFF
--- a/csrc/include/quick_all_reduce.cuh
+++ b/csrc/include/quick_all_reduce.cuh
@@ -600,6 +600,10 @@ struct AllReduceTwoshot
         uint8_t* rank_buffer = buffer_list[rank];
         Codec codec(thread, rank);
         int block_id = blockIdx.x;
+        uint8_t* buffer_ptr[kWorldSize];
+        for (int i = 0; i < kWorldSize; ++i) {
+            buffer_ptr[i] = buffer_list[i];
+        }
         // --------------------------------------------------------
         // Read input into registers
         int32x4_t tA[kAtoms];
@@ -637,7 +641,7 @@ struct AllReduceTwoshot
         for(int r = 0; r < kWorldSize; r++)
         {
             int32x4_t* send_buffer = reinterpret_cast<int32x4_t*>(
-                buffer_list[r] + comm_data0_offset + rank * Codec::kRankTransmittedTileSize);
+                buffer_ptr[r] + comm_data0_offset + rank * Codec::kRankTransmittedTileSize);
             codec.send(send_buffer, &tA[r * Codec::kRankAtoms]);
         }
 
@@ -645,7 +649,7 @@ struct AllReduceTwoshot
         if(thread < kWorldSize)
         {
             int r              = thread;
-            uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_list[r] + comm_flags0_offset +
+            uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_ptr[r] + comm_flags0_offset +
                                                              rank * sizeof(uint32_t));
             set_sync_flag(flag_ptr, flag_color);
         }
@@ -680,7 +684,7 @@ struct AllReduceTwoshot
         for(int r = 0; r < kWorldSize; r++)
         {
             int32x4_t* send_buffer = reinterpret_cast<int32x4_t*>(
-                buffer_list[r] + comm_data1_offset + rank * Codec::kRankTransmittedTileSize);
+                buffer_ptr[r] + comm_data1_offset + rank * Codec::kRankTransmittedTileSize);
             codec.send(send_buffer, tR);
         }
 
@@ -688,7 +692,7 @@ struct AllReduceTwoshot
         if(thread < kWorldSize)
         {
             int r              = thread;
-            uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_list[r] + comm_flags1_offset +
+            uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_ptr[r] + comm_flags1_offset +
                                                              rank * sizeof(uint32_t));
             set_sync_flag(flag_ptr, flag_color);
         }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
In the kernel, the calculation of offsets involves prolonged local HBM access.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The communication temporary buffer address of the peer GPU is stored in HBM. This address is constant and frequently accessed by each thread, so it is loaded into VGPRs at the beginning of the kernel.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->
Dtype: bfloat16
Cudagraph: on
Device: Mi325 * 8
| shape| before optimization(us) | after optimization(us) | ratio|
| ------- | ------- | ------- | ------- |
| (632,5120) | 39.15 | 32.82 |16.16%|
| (680,5120) | 40.55 | 34.32 |15.36%|

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
