### PR TITLE
[Triton] Remove mod N in ptr offsets for preshuffle gemms

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
@@ -345,9 +345,10 @@ def _gemm_a8w8_blockscale_preshuffle_kernel(
         offs_k_shuffle = pid_k * SPLITK_BLOCK_SIZE * 16 + offs_k_shuffle_arr
 
         offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
-        offs_bn = (pid_n * (BLOCK_SIZE_N // 16) + tl.arange(0, BLOCK_SIZE_N // 16)) % (
-            N // 16
-        )
+        # because weight has to be padded to multiple of 16, so that % (N // 16) is no longer required for weight
+        offs_bn = pid_n * (BLOCK_SIZE_N // 16) + tl.arange(
+            0, BLOCK_SIZE_N // 16
+        )  # % (N // 16)
         a_ptrs = a_ptr + (
             offs_am[:, None] * stride_am + offs_k_split[None, :] * stride_ak
         )

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_afp4wfp4.py
@@ -186,232 +186,6 @@ def _gemm_afp4wfp4_kernel(
         tl.store(c_ptrs, c, mask=c_mask)
 
 
-_gemm_afp4wfp4_preshuffle_scales_repr = make_kernel_repr(
-    "_gemm_afp4wfp4_preshuffle_kernel",
-    [
-        "BLOCK_SIZE_M",
-        "BLOCK_SIZE_N",
-        "BLOCK_SIZE_K",
-        "GROUP_SIZE_M",
-        "num_warps",
-        "num_stages",
-        "waves_per_eu",
-        "matrix_instr_nonkdim",
-        "cache_modifier",
-        "NUM_KSPLIT",
-    ],
-)
-
-
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: (args["K"] % (args["BLOCK_SIZE_K"] // 2) == 0)
-        and (args["SPLITK_BLOCK_SIZE"] % args["BLOCK_SIZE_K"] == 0)
-        and (args["K"] % (args["SPLITK_BLOCK_SIZE"] // 2) == 0),
-    }
-)
-@triton.jit(repr=_gemm_afp4wfp4_preshuffle_scales_repr)
-def _gemm_afp4wfp4_kernel_preshuffle_scales(
-    a_ptr,
-    b_ptr,
-    c_ptr,
-    a_scales_ptr,
-    b_scales_ptr,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_ck,
-    stride_cm,
-    stride_cn,
-    stride_asm,
-    stride_ask,
-    stride_bsn,
-    stride_bsk,
-    # Meta-parameters
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    NUM_KSPLIT: tl.constexpr,
-    SPLITK_BLOCK_SIZE: tl.constexpr,
-    EVEN_K: tl.constexpr,
-    num_warps: tl.constexpr,
-    num_stages: tl.constexpr,
-    waves_per_eu: tl.constexpr,
-    matrix_instr_nonkdim: tl.constexpr,
-    cache_modifier: tl.constexpr,
-):
-    """
-    Kernel for computing the matmul C = A x B.
-    A and B inputs are in the microscale fp4 (mxfp4) format.
-    A_scales and B_scales are in e8m0 format.
-    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
-    """
-
-    tl.assume(stride_am > 0)
-    tl.assume(stride_ak > 0)
-    tl.assume(stride_bk > 0)
-    tl.assume(stride_bn > 0)
-    tl.assume(stride_cm > 0)
-    tl.assume(stride_cn > 0)
-    tl.assume(stride_asm > 0)
-    tl.assume(stride_ask > 0)
-    tl.assume(stride_bsk > 0)
-    tl.assume(stride_bsn > 0)
-
-    GRID_MN = tl.cdiv(M, BLOCK_SIZE_M) * tl.cdiv(N, BLOCK_SIZE_N)
-
-    # -----------------------------------------------------------
-    # Map program ids `pid` to the block of C it should compute.
-    # This is done in a grouped ordering to promote L2 data reuse.
-    pid_unified = tl.program_id(axis=0)
-    pid_unified = remap_xcd(pid_unified, GRID_MN * NUM_KSPLIT, NUM_XCDS=8)
-    pid_k = pid_unified % NUM_KSPLIT
-    pid = pid_unified // NUM_KSPLIT
-    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
-    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-
-    if NUM_KSPLIT == 1:
-        pid_m, pid_n = pid_grid(pid, num_pid_m, num_pid_n, GROUP_SIZE_M=GROUP_SIZE_M)
-    else:
-        pid_m = pid // num_pid_n
-        pid_n = pid % num_pid_n
-
-    tl.assume(pid_m >= 0)
-    tl.assume(pid_n >= 0)
-    # We assume 32 elements along K share the same scale.
-    SCALE_GROUP_SIZE: tl.constexpr = 32
-
-    if (pid_k * SPLITK_BLOCK_SIZE // 2) < K:
-
-        num_k_iter = tl.cdiv(SPLITK_BLOCK_SIZE // 2, BLOCK_SIZE_K // 2)
-
-        # Create pointers for first block of A and B input matrices
-        # The BLOCK sizes are of the elements and in fp4 we pack 2 per uint8 container.
-        offs_k = tl.arange(0, BLOCK_SIZE_K // 2)
-        offs_k_split = pid_k * (SPLITK_BLOCK_SIZE // 2) + offs_k
-        offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
-        offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
-        a_ptrs = a_ptr + (
-            offs_am[:, None] * stride_am + offs_k_split[None, :] * stride_ak
-        )
-        b_ptrs = b_ptr + (
-            offs_k_split[:, None] * stride_bk + offs_bn[None, :] * stride_bn
-        )
-        # Create pointers for the first block of A and B scales
-
-        offs_asn = (
-            pid_n * (BLOCK_SIZE_N // 32) + tl.arange(0, (BLOCK_SIZE_N // 32))
-        ) % N
-        offs_ks = (pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE) * 32) + tl.arange(
-            0, BLOCK_SIZE_K // SCALE_GROUP_SIZE * 32
-        )
-        # B scales are N x K even though B operand is K x N.
-        b_scale_ptrs = (
-            b_scales_ptr
-            + offs_asn[:, None] * stride_bsn
-            + offs_ks[None, :] * stride_bsk
-        )
-
-        if BLOCK_SIZE_M < 32:
-            offs_ks_non_shufl = (
-                pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE)
-            ) + tl.arange(0, BLOCK_SIZE_K // SCALE_GROUP_SIZE)
-            a_scale_ptrs = (
-                a_scales_ptr
-                + offs_am[:, None] * stride_asm
-                + offs_ks_non_shufl[None, :] * stride_ask
-            )
-        else:
-            offs_asm = (
-                pid_m * (BLOCK_SIZE_M // 32) + tl.arange(0, (BLOCK_SIZE_M // 32))
-            ) % M
-            a_scale_ptrs = (
-                a_scales_ptr
-                + offs_asm[:, None] * stride_asm
-                + offs_ks[None, :] * stride_ask
-            )
-
-        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-
-        for k in range(pid_k * num_k_iter, (pid_k + 1) * num_k_iter):
-            if BLOCK_SIZE_M < 32:
-                a_scales = tl.load(a_scale_ptrs)
-            else:
-                a_scales = (
-                    tl.load(a_scale_ptrs)
-                    .reshape(
-                        BLOCK_SIZE_M // 32,
-                        BLOCK_SIZE_K // SCALE_GROUP_SIZE // 8,
-                        4,
-                        16,
-                        2,
-                        2,
-                        1,
-                    )
-                    .permute(0, 5, 3, 1, 4, 2, 6)
-                    .reshape(BLOCK_SIZE_M, BLOCK_SIZE_K // SCALE_GROUP_SIZE)
-                )
-            b_scales = (
-                tl.load(b_scale_ptrs, cache_modifier=cache_modifier)
-                .reshape(
-                    BLOCK_SIZE_N // 32,
-                    BLOCK_SIZE_K // SCALE_GROUP_SIZE // 8,
-                    4,
-                    16,
-                    2,
-                    2,
-                    1,
-                )
-                .permute(0, 5, 3, 1, 4, 2, 6)
-                .reshape(BLOCK_SIZE_N, BLOCK_SIZE_K // SCALE_GROUP_SIZE)
-            )
-
-            # Load the next block of A and B, generate a mask by checking the K dimension.
-            # If it is out of bounds, set it to 0.
-            if EVEN_K:
-                a = tl.load(a_ptrs)
-                b = tl.load(b_ptrs, cache_modifier=cache_modifier)
-            else:
-                a = tl.load(
-                    a_ptrs, mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K // 2), other=0
-                )
-                b = tl.load(
-                    b_ptrs, mask=offs_k[:, None] < K - k * (BLOCK_SIZE_K // 2), other=0
-                )
-
-            accumulator = tl.dot_scaled(
-                a, a_scales, "e2m1", b, b_scales, "e2m1", accumulator
-            )
-
-            # Advance the ptrs to the next K block.
-            a_ptrs += (BLOCK_SIZE_K // 2) * stride_ak
-            b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
-            if BLOCK_SIZE_M < 32:
-                a_scale_ptrs += (BLOCK_SIZE_K // SCALE_GROUP_SIZE) * stride_ask
-            else:
-                a_scale_ptrs += BLOCK_SIZE_K * stride_ask
-            b_scale_ptrs += BLOCK_SIZE_K * stride_bsk
-
-        c = accumulator.to(c_ptr.type.element_ty)
-
-        # Write back the block of the output matrix C with masks.
-        offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
-        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
-        c_ptrs = (
-            c_ptr
-            + stride_cm * offs_cm[:, None]
-            + stride_cn * offs_cn[None, :]
-            + pid_k * stride_ck
-        )
-        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-        tl.store(c_ptrs, c, mask=c_mask, cache_modifier=".wt")
-
-
 _gemm_afp4wfp4_preshuffle_repr = make_kernel_repr(
     "_gemm_afp4wfp4_preshuffle_kernel",
     [
@@ -524,7 +298,10 @@ def _gemm_afp4wfp4_preshuffle_kernel(
         offs_k_shuffle = pid_k * (SPLITK_BLOCK_SIZE // 2) * 16 + offs_k_shuffle_arr
 
         offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
-        offs_bn = (pid_n * (BLOCK_SIZE_N // 16) + tl.arange(0, BLOCK_SIZE_N // 16)) % N
+        # because weight has to be padded to multiple of 32, so that % (N // 16) is no longer required for weight
+        offs_bn = pid_n * (BLOCK_SIZE_N // 16) + tl.arange(
+            0, BLOCK_SIZE_N // 16
+        )  # % (N // 16)
         a_ptrs = a_ptr + (
             offs_am[:, None] * stride_am + offs_k_split[None, :] * stride_ak
         )
@@ -533,16 +310,17 @@ def _gemm_afp4wfp4_preshuffle_kernel(
         )
 
         # Create pointers for the first block of A and B scales
-        offs_asn = (
-            pid_n * (BLOCK_SIZE_N // 32) + tl.arange(0, (BLOCK_SIZE_N // 32))
-        ) % N
+        # because weight has to be padded to multiple of 32, so that % (N // 32) is no longer required for weight_scale
+        offs_bsn = pid_n * (BLOCK_SIZE_N // 32) + tl.arange(
+            0, (BLOCK_SIZE_N // 32)
+        )  # % (N // 32)
         offs_ks = (pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE) * 32) + tl.arange(
             0, BLOCK_SIZE_K // SCALE_GROUP_SIZE * 32
         )
         # B scales are N x K even though B operand is K x N.
         b_scale_ptrs = (
             b_scales_ptr
-            + offs_asn[:, None] * stride_bsn
+            + offs_bsn[:, None] * stride_bsn
             + offs_ks[None, :] * stride_bsk
         )
 

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
@@ -356,7 +356,10 @@ def _fused_gemm_a8w8_blockscale_preshuffle_split_cat(
         offs_k_shuffle = pid_k * SPLITK_BLOCK_SIZE * 16 + offs_k_shuffle_arr
 
         offs_a_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
-        offs_b_n = (pid_n * (BLOCK_SIZE_N // 16) + tl.arange(0, BLOCK_SIZE_N // 16)) % N
+        # because weight has to be padded to multiple of 16, so that % (N // 16) is no longer required for weight
+        offs_b_n = pid_n * (BLOCK_SIZE_N // 16) + tl.arange(
+            0, BLOCK_SIZE_N // 16
+        )  # % (N // 16)
         a_ptrs = a_ptr + (
             offs_a_m[:, None] * stride_a_m + offs_k_split[None, :] * stride_a_k
         )

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_a16w16.py
@@ -445,9 +445,10 @@ def _fused_gemm_afp4wfp4_preshuffle_a16w16_kernel(
                 pid_k * (SPLITK_BLOCK_SIZE // 2) * 16 + offs_k_fp4_shuffle_arr
             )
 
-            offs_b_fp4_n = (
-                pid_n * (BLOCK_SIZE_N // 16) + tl.arange(0, BLOCK_SIZE_N // 16)
-            ) % N_fp4
+            # because weight has to be padded to multiple of 32, so that % (N // 16) is no longer required for weight
+            offs_b_fp4_n = pid_n * (BLOCK_SIZE_N // 16) + tl.arange(
+                0, BLOCK_SIZE_N // 16
+            )  # % (N_fp4 // 16)
             a_fp4_ptrs = a_fp4_ptr + (
                 offs_am[:, None] * stride_a_fp4_m
                 + offs_k_fp4_split[None, :] * stride_a_fp4_k
@@ -457,9 +458,10 @@ def _fused_gemm_afp4wfp4_preshuffle_a16w16_kernel(
                 + offs_k_fp4_shuffle[None, :] * stride_b_fp4_k
             )
 
-            offs_b_fp4_scale_n = (
-                pid_n * (BLOCK_SIZE_N // 32) + tl.arange(0, (BLOCK_SIZE_N // 32))
-            ) % N_fp4
+            # because weight has to be padded to multiple of 32, so that % (N // 32) is no longer required for weight_scale
+            offs_b_fp4_scale_n = pid_n * (BLOCK_SIZE_N // 32) + tl.arange(
+                0, (BLOCK_SIZE_N // 32)
+            )  # % (N_fp4 // 32)
             offs_k_fp4_scale = (
                 pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE) * 32
             ) + tl.arange(0, BLOCK_SIZE_K // SCALE_GROUP_SIZE * 32)

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
@@ -352,7 +352,10 @@ def _fused_gemm_afp4wfp4_preshuffle_mul_add_kernel(
         offs_k_shuffle = pid_k * (SPLITK_BLOCK_SIZE // 2) * 16 + offs_k_shuffle_arr
 
         offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
-        offs_bn = (pid_n * (BLOCK_SIZE_N // 16) + tl.arange(0, BLOCK_SIZE_N // 16)) % N
+        # because weight has to be padded to multiple of 32, so that % (N // 16) is no longer required for weight
+        offs_bn = pid_n * (BLOCK_SIZE_N // 16) + tl.arange(
+            0, BLOCK_SIZE_N // 16
+        )  # % (N // 16)
         a_ptrs = a_ptr + (
             offs_am[:, None] * stride_am + offs_k_split[None, :] * stride_ak
         )
@@ -361,9 +364,10 @@ def _fused_gemm_afp4wfp4_preshuffle_mul_add_kernel(
         )
 
         # Create pointers for the first block of A and B scales
-        offs_asn = (
-            pid_n * (BLOCK_SIZE_N // 32) + tl.arange(0, (BLOCK_SIZE_N // 32))
-        ) % N
+        # because weight has to be padded to multiple of 32, so that % (N // 32) is no longer required for weight_scale
+        offs_asn = pid_n * (BLOCK_SIZE_N // 32) + tl.arange(
+            0, (BLOCK_SIZE_N // 32)
+        )  # % (N // 32)
         offs_ks = (pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE) * 32) + tl.arange(
             0, BLOCK_SIZE_K // SCALE_GROUP_SIZE * 32
         )

--- a/aiter/ops/triton/gemm/basic/gemm_a16wfp4.py
+++ b/aiter/ops/triton/gemm/basic/gemm_a16wfp4.py
@@ -259,6 +259,9 @@ def gemm_a16wfp4_preshuffle_(
     N = N * 16
     K = K // 16
 
+    assert N % 32 == 0, f"{N=} has to be divisible by 32"
+    assert K % (256 // 2) == 0, f"{K=} has to be divisible by (256 // 2)"
+
     if config is None:
         config, _ = _get_config(M, N, K, True)
     else:

--- a/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
@@ -193,7 +193,7 @@ def gemm_a8w8_blockscale_preshuffle(
     N = N * 16
     K = K // 16
 
-    assert N % 16 == 0, f"{N=} has to be divisible by 16"
+    # assert N % 16 == 0, f"{N=} has to be divisible by 16"
     assert K % 128 == 0, f"{K=} has to be divisible by 128"
 
     # Check constraints.

--- a/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
@@ -193,6 +193,9 @@ def gemm_a8w8_blockscale_preshuffle(
     N = N * 16
     K = K // 16
 
+    assert N % 16 == 0, f"{N=} has to be divisible by 16"
+    assert K % 128 == 0, f"{K=} has to be divisible by 128"
+
     # Check constraints.
     assert x.shape[1] == w.shape[1] // 16, "Incompatible dimensions!!!"
 

--- a/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 from typing import Optional
 import torch
@@ -438,8 +438,12 @@ def gemm_afp4wfp4_preshuffle(
 
     M, K = x.shape
     N, K = w.shape
+    # recover true N, K shape
     N = N * 16
     K = K // 16
+
+    assert N % 32 == 0, f"{N=} has to be divisible by 32"
+    assert K % (256 // 2) == 0, f"{K=} has to be divisible by (256 // 2)"
 
     if config is None:
         config, _ = _get_config(M, N, K, True)

--- a/aiter/ops/triton/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
+++ b/aiter/ops/triton/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
@@ -252,6 +252,9 @@ def fused_gemm_a8w8_blockscale_preshuffle_split_cat(
     K = K // 16
     M, D, S3 = y.shape
 
+    # assert N % 16 == 0, f"{N=} has to be divisible by 16"
+    assert K % 128 == 0, f"{K=} has to be divisible by 128"
+
     # Check constraints.
     assert x.shape[1] == w.shape[1] // 16, "Incompatible dimensions!!!"
     assert y.shape[0] == x.shape[0], "Incompatible dimensions!!!"

--- a/aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
+++ b/aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
@@ -302,6 +302,9 @@ def fused_gemm_afp4wfp4_preshuffle_add_mul(
     N = N * 16
     K = K // 16
 
+    assert N % 32 == 0, f"{N=} has to be divisible by 32"
+    assert K % (256 // 2) == 0, f"{K=} has to be divisible by (256 // 2)"
+
     if y is None:
         y = torch.empty((M, N), dtype=dtype, device=x.device)
 

--- a/op_tests/triton_tests/gemm/basic/test_gemm_a8w8_blockscale.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_a8w8_blockscale.py
@@ -173,7 +173,6 @@ def generate_gemm_a8w8_blockscale_inputs(
         y = torch.empty((M, N), dtype=dtype, device="cuda").cuda()
 
     return x, weight, weight_shuffled, x_scale, x_scale_shuffled, w_scale, y
-    return x, weight, weight_shuffled, x_scale, x_scale_shuffled, w_scale, y
 
 
 @pytest.mark.parametrize(
@@ -206,10 +205,10 @@ def test_gemm(dtype, M, N, K, layout, output, impl: str):
         )
 
     if impl == "triton_shuffle":
-        if N % 16 > 0 or K % 32 > 0:
-            pytest.skip(
-                "N has to be multiple of 16 and K has to be multiple of 32 for preshuffle cases"
-            )
+        if N % 16 > 0:
+            pytest.skip("N has to be multiple of 16 for preshuffle cases")
+        if K % 128 > 0:
+            pytest.skip("K has to be multiple of 128 for preshuffle cases")
 
     dtype = str_to_torch_dtype[dtype]
     x, weight, weight_triton, x_scale, x_scale_shuffled, w_scale, y = (

--- a/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
@@ -243,7 +243,7 @@ def test_gemm_afp4_wfp4(
             pytest.skip(
                 f"N = {N} is not divisible by 32, skip this test for preshuffled weight/scales tests"
             )
-        elif K % 256 > 0:
+        if K % 256 > 0:
             pytest.skip(
                 f"K = {K} is not divisible by 256, skip this test for preshuffled weight/scales tests"
             )
@@ -293,15 +293,6 @@ def test_gemm_afp4_wfp4(
                 use_aot=(dtype == torch.bfloat16 and layout == "TN"),
                 skip_reduce=skip_reduce,
             )
-        # TODO: remove in the future
-        # if output:
-        #     triton_out = gemm_afp4wfp4_preshuffled_scales(
-        #         x, w_triton, x_scales_triton, w_scales_triton, dtype, y
-        #     )
-        # else:
-        #     triton_out = gemm_afp4wfp4_preshuffled_scales(
-        #         x, w_triton, x_scales_triton, w_scales_triton, dtype
-        #     )
     else:
         if output:
             triton_out = gemm_afp4wfp4(

--- a/op_tests/triton_tests/gemm/fused/test_fused_gemm_a8w8_blockscale_split_cat.py
+++ b/op_tests/triton_tests/gemm/fused/test_fused_gemm_a8w8_blockscale_split_cat.py
@@ -177,13 +177,15 @@ def test_fused_gemm_a8w8_blockscale_split_cat(dtype, M, N, K, D, S3, layout, imp
             "Latest upstream compiler as of Aug 22 (necessary for Gluon) causes"
             " infinite hang when EVEN_K is false. Try seeing if it's fixed if it's been a while."
         )
+
     if N % D != 0:
         pytest.skip("N must be divisible by D as N = D * (S1 + S2)")
+
     if impl == "triton_shuffle":
-        if N % 16 > 0 or K % 32 > 0:
-            pytest.skip(
-                "N has to be multiple of 16 and K has to be multiple of 32 for preshuffle cases"
-            )
+        if N % 16 > 0:
+            pytest.skip("N has to be multiple of 16 for preshuffle cases")
+        if K % 128 > 0:
+            pytest.skip("K has to be multiple of 128 for preshuffle cases")
 
     # deconstruct N
     S = N // D

--- a/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_a16w16.py
+++ b/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_a16w16.py
@@ -92,6 +92,16 @@ def test_gemm(dtype, M, N1, N2, K, output, skip_reduce, fp4_shuffle):
     if not (arch_info.is_fp4_avail()):
         pytest.skip("MXFP4 not supported on this architecture")
 
+    if fp4_shuffle:
+        if N1 % 32 > 0:
+            pytest.skip(
+                f"N1 = {N1} is not divisible by 32, skip this test for preshuffled weight/scales tests"
+            )
+        if K % 256 > 0:
+            pytest.skip(
+                f"K = {K} is not divisible by 256, skip this test for preshuffled weight/scales tests"
+            )
+
     (
         x_fp4,
         w_fp4,

--- a/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_mul_add.py
+++ b/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_mul_add.py
@@ -68,7 +68,7 @@ def test_fused_gemm_afp4wfp4_mul_add(
             pytest.skip(
                 f"N = {N} is not divisible by 32, skip this test for preshuffled weight/scales tests"
             )
-        elif K % 256 > 0:
+        if K % 256 > 0:
             pytest.skip(
                 f"K = {K} is not divisible by 256, skip this test for preshuffled weight/scales tests"
             )

--- a/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_split_cat.py
+++ b/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_split_cat.py
@@ -186,6 +186,16 @@ def test_fused_gemm_afp4wfp4_split_cat(dtype, M, N, K, D, S3, layout, shuffle):
     if not (arch_info.is_fp4_avail()):
         pytest.skip("MXFP4 not supported on this architecture")
 
+    if shuffle:
+        if N % 32 > 0:
+            pytest.skip(
+                f"N = {N} is not divisible by 32, skip this test for preshuffled weight/scales tests"
+            )
+        if K % 256 > 0:
+            pytest.skip(
+                f"K = {K} is not divisible by 256, skip this test for preshuffled weight/scales tests"
+            )
+
     torch.cuda.empty_cache()  # Helps avoid hangs in large tests
     torch.cuda.synchronize()
     # skip tests


### PR DESCRIPTION
This PR removes the `% (N // 16)` in weight shuffled kernels as weight has to be padded to a multiple of 16 and 32 for FP8 blockscale and FP4 GEMMs, respectively, the mod in pointer offset is no longer required along N dim. This also applies to the shuffled weight scales in FP4 GEMM but not for FP8 blockscale GEMM because its weight scale is not shuffled.

This PR also includes:
1. some extra assertions in the helper function.
2. remove _gemm_afp4wfp4_kernel_preshuffle_scales as it has been deprecated for a long time