### PR TITLE
Fix INT4 QR TP8 boundary condition

### DIFF
--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -155,10 +155,6 @@ class CudaCommunicator(DeviceCommunicatorBase):
             qr_comm is not None
             and not qr_comm.disabled
             and qr_comm.should_quick_allreduce(input_)
-            and (input_.nelement() * input_.element_size())
-            >= 4
-            * 1024
-            * 1024  # input shape should be such that quick reduce will show benefits.
             # input shape estimated at 2 * max concurrency for now. if performance issues, subject to change
         ):
             out = qr_comm.quick_all_reduce(input_)

--- a/aiter/dist/device_communicators/quick_all_reduce.py
+++ b/aiter/dist/device_communicators/quick_all_reduce.py
@@ -66,7 +66,7 @@ class QuickAllReduce:
     _QR_MIN_SIZE = {
         (torch.float16, 2): [1 * MB, 2 * MB, 2 * MB, 1 * MB],
         (torch.float16, 4): [1 * MB, 16 * MB, 4 * MB, 2 * MB],
-        (torch.float16, 8): [16 * MB, 4 * MB, 4 * MB, 2 * MB],
+        (torch.float16, 8): [16 * MB, 4 * MB, 4 * MB, 8 * MB],
         (torch.bfloat16, 2): [2 * MB, 8 * MB, 8 * MB, 8 * MB],
         (torch.bfloat16, 4): [8 * MB, 64 * MB, 64 * MB, 16 * MB],
         (torch.bfloat16, 8): [16 * MB, 2048 * MB, 2048 * MB, 2048 * MB],


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
#1673 added a broad condition to use QR when input size > 4MB. This PR attempts to narrow the scope down to fp16/TP8/INT4 QR. The performance of QR is better than AR only above 8 MB. At 4MB QR achieves 32 us as opposed to 27 us for AR.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
