### PR TITLE
Issue-1830: Add packaging to aiter runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -283,6 +283,7 @@ setup(
         "pandas",
         "einops",
         "psutil",
+        "packaging",
     ],
     extras_require={
         # Triton-based communication using Iris


### PR DESCRIPTION
## Motivation
Aiter fails import test with error ModuleNotFoundError: No module named 'packaging'

The aiter package imports and uses 'packaging' module at runtime in multiple files, but only declares it in setup_requires (build-time) instead of also declaring in install_requires (runtime). This causes "ModuleNotFoundError: No module named 'packaging'" when importing aiter in environments where 'packaging' is not already installed.

This PR looks to fix issue-1830 by updating setup.py to include packaging as a runtime dependency.

## Technical Details

```
@@ -252,6 +252,7 @@ setup(
         "pandas",
         "einops",
         "psutil",
+        "packaging",
     ],
     setup_requires=setup_requires,
     distclass=ForcePlatlibDistribution,
```

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
