### PR TITLE
fix crash issue on triton `paged_pa_mqa`

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
@@ -207,20 +207,20 @@ def _deepgemm_fp8_paged_mqa_logits_stage1(
     next_n,
     heads_num,
     Q_buffer,
-    stride_q_batch,
-    stride_q_next_n,
-    stride_q_heads,
+    stride_q_batch: tl.int64,
+    stride_q_next_n: tl.int64,
+    stride_q_heads: tl.int64,
     KV_buffer,
-    stride_k_seq,
+    stride_k_seq: tl.int64,
     scale_buffer,
-    stride_scale_seq,
+    stride_scale_seq: tl.int64,
     context_len_ptr,
     kv_indices,
     weights,
-    stride_w_batch,
+    stride_w_batch: tl.int64,
     Out_buffer,
-    stride_out_heads,
-    stride_out_batch,
+    stride_out_heads: tl.int64,
+    stride_out_batch: tl.int64,
     max_model_len,
     max_blk_len,
     ChunkQ: tl.constexpr,
@@ -292,7 +292,7 @@ def _deepgemm_fp8_paged_mqa_logits_stage1(
             Out_buffer
             + (pid_batch * next_n + pid_next_n) * stride_out_batch
             + (pid_q_head * ChunkQ + tl.arange(0, ChunkQ)[:, None, None])
-            * stride_out_heads.to(tl.int64)
+            * stride_out_heads
             + (context_idx + tl.arange(0, ChunkK)[None, None, :]),
             o[:, None, :],
         )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Since vllm's nightly docker still remains in triton 3.4.0, We might still use this kernel until new triton version available. This PR fix the overflow issue of `deepgemm_fp8_paged_mqa_logits_stage1`. And after the triton upgraded to 3.5.0, vllm will fully adopt gluon implementation

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
