### PR TITLE
add compile macros to embed hsa .co files

### DIFF
--- a/csrc/py_itfs_cu/asm_fmoe.cu
+++ b/csrc/py_itfs_cu/asm_fmoe.cu
@@ -87,13 +87,7 @@ class FMoeKernel
                uint32_t sub_GU             = 512,
                uint32_t num_persistent_tgs = 0)
     {
-        const char* AITER_ASM_DIR = std::getenv("AITER_ASM_DIR");
-        std::string arch_name     = get_gpu_arch();
-        std::string hsa_path      = std::string(AITER_ASM_DIR) + "/" + arch_name + "/" + hsaco;
-        std::cout << "[aiter] hipModuleLoad: " << hsa_path.c_str() << " GetFunction: " << name;
-        HIP_CALL(hipModuleLoad(&module, hsa_path.c_str()));
-        HIP_CALL(hipModuleGetFunction(&kernel_func, module, name));
-        std::cout << " Success" << std::endl;
+        load_asm_kernel(name, hsaco, module, kernel_func);
         this->sub_GU             = sub_GU;
         this->num_persistent_tgs = num_persistent_tgs;
         this->name               = name;


### PR DESCRIPTION
## Motivation

add compile macros AITER_EMBEDDED_HSA_HEADER and AITER_EMBEDDED_HSA_MAP and use them only when the env var AITER_ASM_DIR is not set. 
Therefore we can set it at compile time to embed the .co files to the binary.  

This is useful for enabling aiter in PyTorch, see https://github.com/pytorch/pytorch/pull/172592#discussion_r2700308174. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
