### PR TITLE
add custom_allreduce write mode

### DIFF
--- a/op_tests/multigpu_tests/test_custom_allreduce.py
+++ b/op_tests/multigpu_tests/test_custom_allreduce.py
@@ -139,6 +139,13 @@ parser.add_argument(
     default=None,
     help="shape. e.g. -s 128,8192",
 )
+parser.add_argument(
+    "-g",
+    "--with-graph",
+    type=lambda x: str(x).lower() in ["true", "1", "yes"],
+    default=True,
+    help="use CUDA graph (default: True). e.g. -g true or -g false",
+)
 
 
 if __name__ == "__main__":
@@ -157,7 +164,7 @@ if __name__ == "__main__":
                 1,
                 shape,
                 dtype,
-                withGraph=True,
+                withGraph=args.with_graph,
                 distributed_init_method=get_distributed_init_method(
                     get_ip(), get_open_port()
                 ),


### PR DESCRIPTION
## Motivation

Optimize the allreduce operator.

## Technical Details

Under large data volumes, using the write mode allreduce instead of the read mode.

## Test Plan



## Test Result

Dtype: bfloat16
CudaGraph: on
Device: Mi308 * 8

| Shape | before optimization(us) | after optimization(us) | ratio |
|-------|----------|----------|--------|
| 512,5120 | 49.71 | 46.88 | +5.69% |
| 512,7168 | 68.40 | 63.31 | +7.44% |
| 512,8192 | 75.12 | 67.45 | +10.21% |
| 632,5120 | 59.96 | 54.46 | +9.17% |
| 680,5120 | 63.22 | 59.09 | +6.52% |

Dtype: bfloat16
CudaGraph: on
Device: Mi325 * 8

| Shape | before optimization(us) | after optimization(us) | ratio |
|-------|----------|----------|--------|
| 512,5120 | 46.42 | 37.65 | +18.91% |
| 512,7168 | 61.34 | 52.49 | +14.44% |
| 512,8192 | 67.52 | 56.75 | +15.94% |
| 632,5120 | 54.47 | 45.97 | +15.59% |
| 680,5120 | 58.30 | 49.94 | +14.35% |
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
