### PR TITLE
use FAV3_ON and FAV2_ON for mha bwd instead of ONLY_FAV3

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -917,7 +917,7 @@
             "f'{AITER_CSRC_DIR}/pybind/mha_bwd_asm_pybind.cu'"
         ],
         "flags_extra_cc": [
-            "'-DONLY_FAV3=1'"
+            "'-DFAV3_ON=1'"
         ],
         "flags_extra_hip": [
             "'-DCK_TILE_FMHA_FWD_FAST_EXP2=1'"
@@ -939,7 +939,7 @@
             "f'{AITER_CSRC_DIR}/pybind/mha_varlen_bwd_asm_pybind.cu'"
         ],
         "flags_extra_cc": [
-            "'-DONLY_FAV3=1'"
+            "'-DFAV3_ON=1'"
         ],
         "flags_extra_hip": [
             "'-DCK_TILE_FMHA_FWD_FAST_EXP2=1'"
@@ -982,7 +982,10 @@
             "f'{AITER_CSRC_DIR}/cpp_itfs/mha_bwd.cu'",
             "f'{AITER_CSRC_DIR}/pybind/mha_bwd_pybind.cu'"
         ],
-        "flags_extra_cc": [],
+        "flags_extra_cc": [
+            "'-DFAV3_ON=1'",
+            "'-DFAV2_ON=1'"
+        ],
         "flags_extra_hip": [
             "'-DCK_TILE_FMHA_FWD_FAST_EXP2=1'",
             "f'-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={os.environ.get(\"CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\", 2)}'"
@@ -1005,7 +1008,10 @@
             "f'{AITER_CSRC_DIR}/cpp_itfs/mha_bwd.cu'",
             "f'{AITER_CSRC_DIR}/pybind/mha_varlen_bwd_pybind.cu'"
         ],
-        "flags_extra_cc": [],
+        "flags_extra_cc": [
+            "'-DFAV3_ON=1'",
+            "'-DFAV2_ON=1'"
+        ],
         "flags_extra_hip": [
             "'-DCK_TILE_FMHA_FWD_FAST_EXP2=1'",
             "f'-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={os.environ.get(\"CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\", 2)}'"
@@ -1027,7 +1033,9 @@
             "f'{AITER_CSRC_DIR}/cpp_itfs/mha_fwd_split.cu'",
             "f'{AITER_CSRC_DIR}/cpp_itfs/mha_fwd_batch_prefill.cu'"
         ],
-        "flags_extra_cc": [],
+        "flags_extra_cc": [
+            "'-DFAV2_ON=1'"
+        ],
         "flags_extra_hip": [
             "'-DCK_TILE_FMHA_FWD_FAST_EXP2=1'",
             "f'-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={os.environ.get(\"CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\", 2)}'",
@@ -1051,7 +1059,9 @@
         "srcs": [
             "f'{AITER_CSRC_DIR}/cpp_itfs/mha_bwd.cu'"
         ],
-        "flags_extra_cc": [],
+        "flags_extra_cc": [
+            "'-DFAV2_ON=1'"
+        ],
         "flags_extra_hip": [
             "f'-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={os.environ.get(\"CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\", 0)}'"
         ],

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -674,7 +674,7 @@ def cmdGenFunc_mha_bwd(
     return {
         "md_name": md_name,
         "blob_gen_cmd": blob_gen_cmd,
-        "flags_extra_cc": ["'-DONLY_FAV3=0'"],
+        "flags_extra_cc": ["'-DFAV3_ON=1'", "'-DFAV2_ON=1'"],
     }
 
 
@@ -929,7 +929,7 @@ def cmdGenFunc_mha_varlen_bwd(
     return {
         "md_name": md_name,
         "blob_gen_cmd": blob_gen_cmd,
-        "flags_extra_cc": ["'-DONLY_FAV3=0'"],
+        "flags_extra_cc": ["'-DFAV3_ON=1'", "'-DFAV2_ON=1'"],
     }
 
 

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -1,10 +1,16 @@
-#include "mha_fwd.h"
 #include "aiter_hip_common.h"
+#include "mha_fwd.h"
+#include <memory>
+#include <string>
+
+#if !defined(FAV3_ON) && !defined(FAV2_ON)
+#define FAV3_ON 1
+#define FAV2_ON 1
+#endif
+
 #if FAV3_ON
 #include "asm_fmha_v3_fwd_configs.hpp"
 #endif
-#include <memory>
-#include <string>
 
 namespace aiter {
 #if FAV3_ON

--- a/op_tests/cpp/mha/compile.py
+++ b/op_tests/cpp/mha/compile.py
@@ -55,7 +55,7 @@ def cmdGenFunc_mha_bwd(ck_exclude: bool):
             f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d bwd --receipt 600 --output_dir {{}}",
         ]
     blob_gen_cmd.extend(BWD_CODEGEN_CMD)
-    flags_extra_cc = ["-DONLY_FAV3"] if ck_exclude else []
+    flags_extra_cc = ["-DFAV3_ON=1"] if ck_exclude else ["-DFAV3_ON=1", "-DFAV2_ON=1"]
     return {
         "md_name": "libmha_bwd",
         "blob_gen_cmd": blob_gen_cmd,


### PR DESCRIPTION
## Motivation

this change makes mha_bwd consistent with mha_fwd, also provides the option to disable bwd FAV3 if necessary (e.g., in OSS PyTorch).
 
also set both FAV3_ON and FAV2_ON to 1 if they are not defined. On trunk if neither is set the mha_fwd kernel would return -1.

also it seems modules libmha_fwd and libmha_bwd are missing -DFAV2_ON=1, and this PR adds it for bwd. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
