### PR TITLE
fix test_fused_fp8_quant

### DIFF
--- a/aiter/utility/dtypes.py
+++ b/aiter/utility/dtypes.py
@@ -8,6 +8,7 @@ import argparse
 defaultDtypes = {
     "gfx942": {"fp8": torch.float8_e4m3fnuz},
     "gfx950": {"fp8": torch.float8_e4m3fn},
+    "gfx1250": {"fp8": torch.float8_e4m3fn},
 }
 
 _8bit_fallback = torch.uint8


### PR DESCRIPTION
## Motivation

changed test_silu_mul_quant_fuse and test_rsnorm_quant_fuse to use pytorch kernels in reference function instead of aiter non-triton kernels