### PR TITLE
Refactor MLA Reduce

### DIFF
--- a/csrc/kernels/mla/reduce.cu
+++ b/csrc/kernels/mla/reduce.cu
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-#include "aiter_hip_common.h"
-#include "custom_all_reduce.cuh"
-#include "mla.h"
 #include <ATen/hip/HIPContext.h>
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <sstream>
 #include <torch/python.h>
+#include "aiter_hip_common.h"
+#include "custom_all_reduce.cuh"
+#include "mla.h"
 
 template <int32_t kSizeDV_, int32_t kNumHeadQ_, int32_t kNumThreadGroupPerSeq_>
 struct MlaReduceKernelV1Traits


### PR DESCRIPTION
In test case `test_mla_sparse -b 1 -c 4000 -n 16,2 -d bf16 -kvd bf16`, perf get from 18.2us to 12.2us.

Since I manually applied *clang-format* which hadn't applied on this file for unknown reason, there is great amount of changes in this file. Thus, I'd like to conclude the main changes of this PR in description:
* In massive pipeline, a new template parameter is added limit the upbound of #splits. In this way, we can do less comp on the case that there is no more than 64 splits as well as avoid using LDS in some places when splits is no more than 256.
* Load reduce partial map to LDS at the beginning. This will reduce great amount of waiting time.
* Load and compute instructions in `reduce_output_massive()` are re-orgnized for further overlapping between comp and buffer op.