### PR TITLE
Remove uses of AITER_ASM_DIR

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -170,7 +170,7 @@
         "extra_ldflags": "None",
         "extra_include": [],
         "verbose": "False",
-        "blob_gen_cmd": "''"
+        "blob_gen_cmd": "f'{AITER_META_DIR}/hsa/codegen.py --code-objects -m custom_all_reduce --glob=all_reduce.co --glob=allreduce*.co --output_dir {{}}'"
     },
     "module_quick_all_reduce": {
         "srcs": [
@@ -413,7 +413,7 @@
         "extra_ldflags": "None",
         "extra_include": [],
         "verbose": "False",
-        "blob_gen_cmd": "''"
+        "blob_gen_cmd": "f'{AITER_META_DIR}/hsa/codegen.py --code-objects -m flatmm_fp8gemm_blockscale --glob=flatmm_uk_gfx9_f16f8_128x256x128_1x4x1_16x16x32.co --output_dir {{}}'"
     },
     "module_gemm_a8w8_blockscale_bpreshuffle_asm": {
         "srcs": [
@@ -437,7 +437,7 @@
         "extra_ldflags": "None",
         "extra_include": [],
         "verbose": "False",
-        "blob_gen_cmd": "''"
+        "blob_gen_cmd": "f'{AITER_META_DIR}/hsa/codegen.py --code_objects -m fp8gemm_blockscale_mi350 --glob=f8_block_scale_mi350*.co --output_dir {{}}'"
     },
     "module_moe_asm": {
         "srcs": [
@@ -460,7 +460,8 @@
         "blob_gen_cmd": [
             "f'{AITER_META_DIR}/hsa/codegen.py -m fmoe_2stages --output_dir {{}}'",
             "f'{AITER_META_DIR}/hsa/codegen.py -m fmoe --output_dir {{}}'",
-            "f'{AITER_META_DIR}/hsa/codegen.py -m topksoftmax --output_dir {{}}'"
+            "f'{AITER_META_DIR}/hsa/codegen.py -m topksoftmax --output_dir {{}}'",
+            "f'{AITER_META_DIR}/hsa/codegen.py --code-objects -m fmoe --glob=fmoe_*16.co --glob=fmoe/gelu/fmoe_int8_g1u0_subGU_*.co --glob=fmoe/silu/fmoe_int8_g1u0_subGU_*.co --glob=fmoe_int4fp8_g1u1_subGU_*.co --glob=fmoe_int8_g1u0_smf.co --output_dir {{}}'"
         ]
     },
     "module_moe_ck2stages": {
@@ -565,7 +566,10 @@
             "f'{CK_DIR}/example/ck_tile/02_layernorm2d'"
         ],
         "verbose": "False",
-        "blob_gen_cmd": "f'{CK_DIR}/example/ck_tile/02_layernorm2d/generate.py --api fwd --gen_blobs --working_path {{}}'"
+        "blob_gen_cmd": [
+            "f'{CK_DIR}/example/ck_tile/02_layernorm2d/generate.py --api fwd --gen_blobs --working_path {{}}'",
+            "f'{AITER_META_DIR}/hsa/codegen.py --code-objects -m norm --glob=layer_norm.co --glob=layer_norm_qnt.co --output_dir {{}}'"
+        ]
     },
     "module_pos_encoding": {
         "srcs": [
@@ -1186,7 +1190,10 @@
         "extra_ldflags": "None",
         "extra_include": [],
         "verbose": "False",
-        "blob_gen_cmd": "''"
+        "blob_gen_cmd": [
+            "f'{AITER_META_DIR}/hsa/codegen.py --code-objects -m topk_per_row_decode --output_dir {{}}'",
+            "f'{AITER_META_DIR}/hsa/codegen.py --code-objects -m topk_per_row_prefill --output_dir {{}}'"
+        ]
     },
     "module_mla_metadata": {
         "srcs": [

--- a/csrc/cpp_itfs/mha_bwd.cu
+++ b/csrc/cpp_itfs/mha_bwd.cu
@@ -5,9 +5,9 @@
 #include <string>
 
 namespace aiter {
-std::tuple<int, int> get_padded_hdim(int hdim_q, int hdim_v, std::string arch_id)
+std::tuple<int, int> get_padded_hdim(int hdim_q, int hdim_v, GPUArchId arch_id)
 {
-    if(hdim_q == 192 && hdim_v == 128 && arch_id == "gfx950")
+    if(hdim_q == 192 && hdim_v == 128 && arch_id == GPUArchId::gfx950)
         return std::make_tuple(hdim_q, hdim_v);
         
     if(hdim_q == hdim_v)
@@ -29,53 +29,44 @@ std::tuple<int, int> get_padded_hdim(int hdim_q, int hdim_v, std::string arch_id
     return std::make_tuple(hdim_q, hdim_v);
 }
 
-std::tuple<std::string, std::string, std::string> get_heuristic_kernel(std::string data_type,
-                                                                       std::string arch_id,
-                                                                       int seqlen_q,
-                                                                       int seqlen_k,
-                                                                       int hdim_q,
-                                                                       int hdim_v,
-                                                                       int mask_type,
-                                                                       bool atomic32,
-                                                                       int bf16_cvt,
-                                                                       bool mode,
-                                                                       CFG* pre_cfgs,
-                                                                       CFG* cfgs,
-                                                                       CFG* post_cfgs)
+std::tuple<const CFG::Entry*, const CFG::Entry*, const CFG::Entry*>
+get_heuristic_kernel(std::string data_type,
+                     GPUArchId arch_id,
+                     int seqlen_q,
+                     int seqlen_k,
+                     int hdim_q,
+                     int hdim_v,
+                     int mask_type,
+                     bool atomic32,
+                     int bf16_cvt,
+                     bool mode,
+                     const CFG* pre_cfgs,
+                     const CFG* cfgs,
+                     const CFG* post_cfgs)
 {
     auto [padded_hdim_q, padded_hdim_v] = get_padded_hdim(hdim_q, hdim_v, arch_id);
     int pddv                            = (padded_hdim_q != hdim_q) || (padded_hdim_v != hdim_v);
     int pssk;
     int ts_kv = 0;
 
-    std::string preProcessingKernelName  = "";
-    std::string dQdKdVKernelName         = "";
-    std::string postProcessingKernelName = "";
+    const CFG::Entry* preProcessingCfg  = nullptr;
+    const CFG::Entry* dQdKdVCfg         = nullptr;
+    const CFG::Entry* postProcessingCfg = nullptr;
 
-    for(const auto& el : *pre_cfgs)
+    for(const auto& cfg : pre_cfgs->get_configs_for_arch(arch_id))
     {
-        if(el.first.find(arch_id) != 0)
-            continue;
-        const auto& cfg = el.second;
-
         if((cfg.dtype == data_type) && (cfg.hdim_v == padded_hdim_v) && (cfg.mode == mode))
         {
-            preProcessingKernelName = el.first;
+            preProcessingCfg = &cfg;
             break;
         }
     }
 
-    for(const auto& el : *cfgs)
+    for(const auto& cfg : cfgs->get_configs_for_arch(arch_id))
     {
-        if(el.first.find(arch_id) != 0)
-        {
-            continue;
-        }
-        const auto& cfg = el.second;
-
         if((cfg.dtype == data_type) && (cfg.hdim_q == padded_hdim_q) &&
            (cfg.hdim_v == padded_hdim_v) && (cfg.mask == mask_type) && (cfg.atomic32 == atomic32) &&
-           ((arch_id == "gfx950") || ((data_type == "fp16") || (cfg.bf16_cvt == bf16_cvt))) &&
+           ((arch_id == GPUArchId::gfx950) || ((data_type == "fp16") || (cfg.bf16_cvt == bf16_cvt))) &&
            (cfg.mode == mode))
         {
             int tmp_ts_kv = 0;
@@ -84,7 +75,7 @@ std::tuple<std::string, std::string, std::string> get_heuristic_kernel(std::stri
                 ts_kv     = cfg.ts;
                 tmp_ts_kv = ts_kv;
                 if(cfg.atomic32 == 0 &&
-                   ((arch_id == "gfx942") || (el.first.find("recompile") != std::string::npos)))
+                   ((arch_id == GPUArchId::gfx942) || (cfgs->get_kernel_name_for_config(&cfg).find("recompile") != std::string::npos)))
                 {
 
                     tmp_ts_kv = 64;
@@ -93,38 +84,34 @@ std::tuple<std::string, std::string, std::string> get_heuristic_kernel(std::stri
             }
             if((cfg.pssk == pssk) && (cfg.pddv == pddv))
             {
-                dQdKdVKernelName = el.first;
+                dQdKdVCfg = &cfg;
                 break;
             }
             else if((cfg.pssk >= pssk) && (cfg.pddv >= pddv))
             {
-                dQdKdVKernelName = el.first;
+                dQdKdVCfg = &cfg;
             }
         }
     }
 
     if(!post_cfgs)
     {
-        return std::make_tuple(preProcessingKernelName, dQdKdVKernelName, postProcessingKernelName);
+        return std::make_tuple(preProcessingCfg, dQdKdVCfg, nullptr);
     }
 
-    for(const auto& el : *post_cfgs)
+    for(const auto& cfg : post_cfgs->get_configs_for_arch(arch_id))
     {
-        if(el.first.find(arch_id) != 0)
-            continue;
-        const auto& cfg = el.second;
-
         if((cfg.hdim_q == padded_hdim_q) && (cfg.mode == mode) &&
-           ((arch_id == "gfx950") || ((data_type == "fp16") || (cfg.bf16_cvt == bf16_cvt))))
+           ((arch_id == GPUArchId::gfx950) || ((data_type == "fp16") || (cfg.bf16_cvt == bf16_cvt))))
         {
             if((cfg.dtype == data_type) || (atomic32 == 0))
             {
-                postProcessingKernelName = el.first;
+                postProcessingCfg = &cfg;
                 break;
             }
         }
     }
-    return std::make_tuple(preProcessingKernelName, dQdKdVKernelName, postProcessingKernelName);
+    return std::make_tuple(preProcessingCfg, dQdKdVCfg, postProcessingCfg);
 }
 
 float mha_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
@@ -243,10 +230,10 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         return -1;  // dq_acc only support BHSD layout
     }
 
-    std::string arch_id = get_gpu_arch();
+    auto arch_id = get_gpu_arch();
     if((!a.use_asm_v3) || (a.hdim_q % 8 != 0) || (a.hdim_v % 8 != 0) || (a.has_dbias) ||
        (a.bias_type != 0) || (a.has_dropout) || (a.is_deterministic) ||
-       ((arch_id != "gfx942") && (arch_id != "gfx950")))
+       ((arch_id != GPUArchId::gfx942) && (arch_id != GPUArchId::gfx950)))
     {
         return -1;
     }
@@ -289,7 +276,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
     auto pre_cfgs    = &cfg_fmha_bwd_odo;
     auto dqdkdv_cfgs = &cfg_fmha_bwd_dqdkdv;
     auto post_cfgs   = [&]() {
-        if(arch_id == "gfx950")
+        if(arch_id == GPUArchId::gfx950)
         {
             if(a.v3_atomic_fp32)
             {
@@ -308,13 +295,13 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
             }
             else
             {
-                return static_cast<CFG*>(nullptr);
+                return static_cast<const CFG*>(nullptr);
             }
         }
     }();
 
     bool need_post_processing =
-        ((arch_id == "gfx950") && (a.hdim_q != 64)) || (a.v3_atomic_fp32 == 1);
+        ((arch_id == GPUArchId::gfx950) && (a.hdim_q != 64)) || (a.v3_atomic_fp32 == 1);
 
     int mt = asm_mask_type();
 
@@ -333,21 +320,21 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         mt = 1;  // bottom-right → top-left (equivalent when sq == sk)
     }
 
-    auto [pre_kernel, dqdkdv_kernel, post_kernel] = get_heuristic_kernel(a.data_type,
-                                                                         arch_id,
-                                                                         a.seqlen_q,
-                                                                         a.seqlen_k,
-                                                                         a.hdim_q,
-                                                                         a.hdim_v,
-                                                                         mt,
-                                                                         a.v3_atomic_fp32,
-                                                                         a.v3_bf16_cvt,
-                                                                         a.is_group_mode,
-                                                                         pre_cfgs,
-                                                                         dqdkdv_cfgs,
-                                                                         post_cfgs);
+    auto [pre_cfg, dqdkdv_cfg, post_cfg] = get_heuristic_kernel(a.data_type,
+                                                                arch_id,
+                                                                a.seqlen_q,
+                                                                a.seqlen_k,
+                                                                a.hdim_q,
+                                                                a.hdim_v,
+                                                                mt,
+                                                                a.v3_atomic_fp32,
+                                                                a.v3_bf16_cvt,
+                                                                a.is_group_mode,
+                                                                pre_cfgs,
+                                                                dqdkdv_cfgs,
+                                                                post_cfgs);
 
-    if((pre_kernel == "") || (dqdkdv_kernel == "") || (need_post_processing && (post_kernel == "")))
+    if((pre_cfg == nullptr) || (dqdkdv_cfg == nullptr) || (need_post_processing && (post_cfg == nullptr)))
     {
         return -1;
     }
@@ -356,76 +343,18 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
     int ts_kv;
     int ts_dq;
     int arg_size;
+    AiterAsmKernel<>* impl_ptr_pre    = nullptr;
+    AiterAsmKernel<>* impl_ptr_dqdkdv = nullptr;
+    AiterAsmKernel<>* impl_ptr_post   = nullptr;
 
-    AiterAsmKernel* impl_ptr_pre    = nullptr;
-    AiterAsmKernel* impl_ptr_dqdkdv = nullptr;
-    AiterAsmKernel* impl_ptr_post   = nullptr;
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
-
-    auto it_pre = pre_cfgs->find(pre_kernel);
-    if(it_pre != pre_cfgs->end())
+    impl_ptr_pre    = pre_cfgs->load_kernel_for_config(pre_cfg);
+    ts_odo          = pre_cfg->ts;
+    impl_ptr_dqdkdv = dqdkdv_cfgs->load_kernel_for_config(dqdkdv_cfg);
+    ts_kv           = dqdkdv_cfg->ts;
+    if(post_cfg != nullptr)
     {
-        const auto& cfg     = it_pre->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        ts_odo              = cfg.ts;
-
-        auto result = impl_ptr_map.emplace(name, nullptr);
-        if(result.second)
-        {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-        }
-
-        impl_ptr_pre = result.first->second.get();
-    }
-    else
-    {
-        return -1;
-    }
-
-    auto it_dqdkdv = dqdkdv_cfgs->find(dqdkdv_kernel);
-    if(it_dqdkdv != dqdkdv_cfgs->end())
-    {
-        const auto& cfg     = it_dqdkdv->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        ts_kv               = cfg.ts;
-
-        auto result = impl_ptr_map.emplace(name, nullptr);
-        if(result.second)
-        {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-        }
-
-        impl_ptr_dqdkdv = result.first->second.get();
-    }
-    else
-    {
-        return -1;
-    }
-
-    if(need_post_processing)
-    {
-        auto it_post = post_cfgs->find(post_kernel);
-        if(it_post != post_cfgs->end())
-        {
-            const auto& cfg     = it_post->second;
-            const char* name    = cfg.knl_name.c_str();
-            const char* co_name = cfg.co_name.c_str();
-            ts_dq               = cfg.ts;
-
-            auto result = impl_ptr_map.emplace(name, nullptr);
-            if(result.second)
-            {
-                result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-            }
-
-            impl_ptr_post = result.first->second.get();
-        }
-        else
-        {
-            return -1;
-        }
+        impl_ptr_post = post_cfgs->load_kernel_for_config(post_cfg);
+        ts_dq         = post_cfg->ts;
     }
 
     if(a.v3_api_check)

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -23,66 +23,40 @@ int get_cfg_mask_type(const mha_fwd_args& a)
     return -1;
 }
 
-std::string get_kernel_name_key(const std::string& arch_id,
-                                const std::string& data_type,
-                                int hdim_q,
-                                int hdim_v,
-                                int mask_type,
-                                int bf16_cvt,
-                                bool mode,
-                                const CFG* cfgs)
+AiterAsmKernel<>* get_kernel(GPUArchId arch_id,
+                               const std::string& data_type,
+                               int hdim_q,
+                               int hdim_v,
+                               int mask_type,
+                               int bf16_cvt,
+                               bool mode,
+                               const CFG* cfgs,
+                               int& ts_qo)
 {
-    std::string kernel_name_key{};
-    for(const auto& el : *cfgs)
+    for(const auto& cfg : cfgs->get_configs_for_arch(arch_id))
     {
-        const auto& cfg = el.second;
-        if(cfg.arch != arch_id)
-        {
-            continue;
-        }
-
         if(cfg.dtype == data_type && cfg.hdim_q == hdim_q && cfg.hdim_v == hdim_v &&
            cfg.mask == mask_type && cfg.mode == mode)
         {
-            if(arch_id == "gfx950")
+            if(arch_id == GPUArchId::gfx950)
             {
-                kernel_name_key = el.first;
-                break;
+                ts_qo = cfg.ts_qo;
+                return cfgs->load_kernel_for_config(&cfg);
             }
-            else if(arch_id == "gfx942" && cfg.bf16_cvt == bf16_cvt)
+            else if(arch_id == GPUArchId::gfx942 && cfg.bf16_cvt == bf16_cvt)
             {
-                kernel_name_key = el.first;
-                break;
+                ts_qo = cfg.ts_qo;
+                return cfgs->load_kernel_for_config(&cfg);
             }
         }
     }
-
-    return kernel_name_key;
-}
-
-std::string get_kernel_co_name(const std::string& cfg_co_name, const std::string& arch_id)
-{
-    std::string co_name = cfg_co_name;
-    if(arch_id == "gfx942")
-    {
-        auto pos        = cfg_co_name.rfind('/');
-        uint32_t cu_num = get_num_cu_func();
-        if(cu_num == 304)
-        {
-            co_name = cfg_co_name.substr(0, pos + 1) + "MI300/" + cfg_co_name.substr(pos + 1);
-        }
-        else if(cu_num == 80 || cu_num == 64)
-        {
-            co_name = cfg_co_name.substr(0, pos + 1) + "MI308/" + cfg_co_name.substr(pos + 1);
-        }
-    }
-    return co_name;
+    return nullptr;
 }
 
 void init_fmha_fwd_v3_args(fmha_fwd_v3_args& args,
                            const mha_fwd_args& a,
                            int ts_qo,
-                           const std::string& arch_id)
+                           GPUArchId arch_id)
 {
     int tune_opt = 5;
     // if num_head is not 8N, or seqlen is bigger than 16K, downgrade to 2and3
@@ -90,7 +64,7 @@ void init_fmha_fwd_v3_args(fmha_fwd_v3_args& args,
     {
         tune_opt -= 2;
     }
-    if(a.hdim_q == 192 && a.hdim_v == 128 && arch_id == "gfx942")
+    if(a.hdim_q == 192 && a.hdim_v == 128 && arch_id == GPUArchId::gfx942)
     {
         tune_opt = 0;
     }
@@ -176,11 +150,11 @@ void init_fmha_fwd_v3_args(fmha_fwd_v3_args& args,
     }
 }
 
-std::tuple<int, int, int> get_grid_dim(const mha_fwd_args& a, int ts_qo, const std::string& arch_id)
+std::tuple<int, int, int> get_grid_dim(const mha_fwd_args& a, int ts_qo, GPUArchId arch_id)
 {
 
     int tg_div = (a.mask_type != 0) ? 2 : 1;
-    if(arch_id == "gfx942" && a.is_group_mode && a.hdim_q == 192 && a.hdim_v == 128)
+    if(arch_id == GPUArchId::gfx942 && a.is_group_mode && a.hdim_q == 192 && a.hdim_v == 128)
     {
         tg_div = 1; // do not merge the head and tail in seqlen_q direction
     }
@@ -188,7 +162,7 @@ std::tuple<int, int, int> get_grid_dim(const mha_fwd_args& a, int ts_qo, const s
     int gdx = ((a.seqlen_q + ts_qo - 1) / ts_qo + tg_div - 1) / tg_div;
     int gdy = a.nhead_q;
     int gdz = a.batch;
-    if(arch_id == "gfx942" && a.hdim_q == 192 && a.hdim_v == 128)
+    if(arch_id == GPUArchId::gfx942 && a.hdim_q == 192 && a.hdim_v == 128)
     {
         gdx = a.nhead_q;
         gdy = (a.seqlen_q + ts_qo - 1) /
@@ -208,58 +182,44 @@ std::tuple<int, int, int> get_grid_dim(const mha_fwd_args& a, int ts_qo, const s
 
 float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
 {
-    std::string arch_id = get_gpu_arch();
+    auto arch_id = get_gpu_arch();
 
     if((!a.use_asm_v3) || (a.hdim_q != 192 && a.hdim_q != 128) || (a.hdim_v != 128) ||
        (a.data_type != "bf16" && a.data_type != "fp8bf16") || (a.bias_type != 0) || (a.p_drop > 0.f) ||
-       ((arch_id != "gfx942") && (arch_id != "gfx950")))
+       ((arch_id != GPUArchId::gfx942) && (arch_id != GPUArchId::gfx950)))
     {
         AITER_LOG_WARNING("unsupported condition in fwd_v3!!! data type: " << a.data_type);
         return -1;
     }
 
-    auto fwd_cfgs               = &cfg_fmha_fwd;
     int cfg_mask_type           = get_cfg_mask_type(a);
-    std::string kernel_name_key = get_kernel_name_key(arch_id,
-                                                      a.data_type,
-                                                      a.hdim_q,
-                                                      a.hdim_v,
-                                                      cfg_mask_type,
-                                                      a.how_v3_bf16_cvt,
-                                                      a.is_group_mode,
-                                                      fwd_cfgs);
-    auto it                     = fwd_cfgs->find(kernel_name_key);
-    if(it == fwd_cfgs->end())
-    {
+    int ts_qo;
+    auto impl_ptr = get_kernel(arch_id,
+                               a.data_type,
+                               a.hdim_q,
+                               a.hdim_v,
+                               cfg_mask_type,
+                               a.how_v3_bf16_cvt,
+                               a.is_group_mode,
+                               &cfg_fmha_fwd,
+                               ts_qo);
+
+    if (impl_ptr == nullptr) {
         return -1;
-    };
+    }
+
 
     if(a.v3_api_check)
     {
         return 1;
     };
 
-    AiterAsmKernel* impl_ptr = nullptr;
-    static thread_local std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
-        impl_ptr_map;
-
-    const auto& cfg     = it->second;
-    const char* name    = cfg.knl_name.c_str();
-    std::string co_name = get_kernel_co_name(cfg.co_name, arch_id);
-
-    auto result = impl_ptr_map.emplace(name, nullptr);
-    if(result.second)
-    {
-        result.first->second = std::make_unique<AiterAsmKernel>(name, co_name.c_str());
-    }
-    impl_ptr = result.first->second.get();
-
     fmha_fwd_v3_args args;
     int arg_size = sizeof(args);
-    init_fmha_fwd_v3_args(args, a, cfg.ts_qo, arch_id);
+    init_fmha_fwd_v3_args(args, a, ts_qo, arch_id);
 
     int bdx              = (a.hdim_q == 192 && a.hdim_v == 128) ? 256 : 512;
-    auto [gdx, gdy, gdz] = get_grid_dim(a, cfg.ts_qo, arch_id);
+    auto [gdx, gdy, gdz] = get_grid_dim(a, ts_qo, arch_id);
 
     return ck_tile::launch_kernel(s, [=](const ck_tile::stream_config& s_) mutable {
         // Explicit assignment forces evaluation order and prevents compiler from

--- a/csrc/cpp_itfs/mla/asm_mla_decode_fwd.cpp.jinja
+++ b/csrc/cpp_itfs/mla/asm_mla_decode_fwd.cpp.jinja
@@ -36,7 +36,7 @@ struct __attribute__((packed)) KernelArgs
     p2 _p18;
 };
 
-unsigned char hsaco[{{bin_size}}] = { {{bin_data}} };
+constexpr unsigned char hsaco[{{bin_size}}] = { {{bin_data}} };
 
 extern "C" {
 void {{func_name}}(void* Q,                 //   [num_seqs, num_heads, head_size]
@@ -90,7 +90,7 @@ void {{func_name}}(void* Q,                 //   [num_seqs, num_heads, head_size
                     int output_stride_1,
                     void* stream
                     ){
-    static AiterAsmKernelFast impl("{{kernel_name}}", hsaco);
+    static AiterAsmKernel<{"{{kernel_name}}", hsaco}> impl;
     constexpr int page_size = {{page_size}};
     uint32_t log2_page = (uint32_t)log2f(page_size);
     const int gqa_ratio = num_heads / num_kv_heads;

--- a/csrc/cpp_itfs/moe/asm_moe.cpp.jinja
+++ b/csrc/cpp_itfs/moe/asm_moe.cpp.jinja
@@ -63,19 +63,18 @@ struct __attribute__((packed)) KernelArgs
 };
 
 
-unsigned char hsaco[{{bin_size}}] = { {{bin_data}} };
+constexpr unsigned char hsaco[{{bin_size}}] = { {{bin_data}} };
 
 class FMoeKernel
 {
 private:
-    std::unique_ptr<AiterAsmKernelFast> asm_kernel=nullptr;
+    AiterAsmKernel<{"{{kernel_name}}", hsaco}> asm_kernel;
     uint32_t sub_GU = 512;
     bool is_int4 = false;
 
 public:
     FMoeKernel()
     {
-        asm_kernel=std::make_unique<AiterAsmKernelFast>("{{kernel_name}}", hsaco);
         this->sub_GU = {{selected_tile}};
     };
 
@@ -181,11 +180,11 @@ public:
 
         if constexpr (switchGxy)
         {
-            asm_kernel->launch_kernel({&args, &arg_size, gdy, gdx, gdz, bdx, 1, 1, stream});
+            asm_kernel.launch_kernel({&args, &arg_size, gdy, gdx, gdz, bdx, 1, 1, stream});
         }
         else
         {
-            asm_kernel->launch_kernel({&args, &arg_size, gdx, gdy, gdz, bdx, 1, 1, stream});
+            asm_kernel.launch_kernel({&args, &arg_size, gdx, gdy, gdz, bdx, 1, 1, stream});
         }
     };
 };

--- a/csrc/include/aiter_hip_common.h
+++ b/csrc/include/aiter_hip_common.h
@@ -3,42 +3,37 @@
 #pragma once
 #include "aiter_logger.h"
 #include "ck_tile/core.hpp"
+
+#include <atomic>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <span>
+#include <string_view>
+
+#include <c10/util/Exception.h>
 #include <hip/hip_runtime.h>
-#include <iostream>
-#ifdef AITER_EMBEDDED_HSA_HEADER
-#include AITER_EMBEDDED_HSA_HEADER
-#endif
 
-enum class GPUArch
-{
-    gfx942,
-    gfx950
-};
-
-#define CHECK_COND(x)                                                                             \
-    do                                                                                            \
-    {                                                                                             \
-        if(!(x))                                                                                  \
-        {                                                                                         \
-            std::cerr << "check failed, file=" << __FILE__ << ", line=" << __LINE__ << std::endl; \
-            std::terminate();                                                                     \
-        }                                                                                         \
+#define CHECK_COND(x)                                                                          \
+    do                                                                                         \
+    {                                                                                          \
+        if(C10_UNLIKELY(!(x)))                                                                 \
+        {                                                                                      \
+            std::fprintf(stderr, "\n[AITER] %s:%d %s check failed\n", __FILE__, __LINE__, #x); \
+            std::abort();                                                                      \
+        }                                                                                      \
     } while(0)
 
-#define HIP_CALL(call)                                                       \
-    do                                                                       \
-    {                                                                        \
-        hipError_t err = call;                                               \
-        if(err != hipSuccess)                                                \
-        {                                                                    \
-            printf("\n[AITER] %s:%d fail to call %s ---> [HIP error](%s)\n", \
-                   __FILE__,                                                 \
-                   __LINE__,                                                 \
-                   #call,                                                    \
-                   hipGetErrorString(err));                                  \
-            exit(0);                                                         \
-        }                                                                    \
+#define HIP_CALL(call)                       \
+    do                                       \
+    {                                        \
+        hipError_t err = call;               \
+        TORCH_CHECK(err == hipSuccess,       \
+                    "Hip call ",             \
+                    #call,                   \
+                    " failed with error: ",  \
+                    hipGetErrorString(err)); \
     } while(0)
 
 struct p3
@@ -70,57 +65,267 @@ struct AiterAsmKernelArgs
     const hipStream_t stream;
 };
 
-static const std::string get_gpu_arch();
-
-inline void load_asm_kernel(const char* name,
-                            const char* hsaco,
-                            hipModule_t& module,
-                            hipFunction_t& kernel_func)
+enum class GPUArchId
 {
-    const char* AITER_ASM_DIR = std::getenv("AITER_ASM_DIR");
-    std::string arch_name     = get_gpu_arch();
-    if(AITER_ASM_DIR != nullptr)
+    gfx942,
+    gfx950,
+    gfxLastKnown = gfx950,
+    gfxUnknown   = -1,
+};
+
+namespace detail {
+struct GpuArchHelper
+{
+    static inline const std::tuple<GPUArchId, uint32_t>& get_arch_data()
     {
-        std::string hsa_path = std::string(AITER_ASM_DIR) + "/" + arch_name + "/" + hsaco;
-        AITER_LOG_INFO("hipModuleLoad: " << hsa_path << " GetFunction: " << name);
-        HIP_CALL(hipModuleLoad(&module, hsa_path.c_str()));
+        static const auto data = []() -> std::tuple<GPUArchId, uint32_t> {
+            hipDeviceProp_t prop{};
+            if(hipGetDeviceProperties(&prop, 0) != hipSuccess)
+            {
+                return {GPUArchId::gfxUnknown, 0};
+            }
+
+            auto num_cu = static_cast<uint32_t>(prop.multiProcessorCount);
+
+            auto match = [&]<size_t N>(const char (&name)[N]) -> bool {
+                static_assert(sizeof(prop.gcnArchName) >= N);
+                return std::memcmp(prop.gcnArchName, name, N - 1) == 0 &&
+                       (prop.gcnArchName[N - 1] == '\0' || prop.gcnArchName[N - 1] == ':');
+            };
+
+            if(match("gfx942"))
+            {
+                return {GPUArchId::gfx942, num_cu};
+            }
+
+            if(match("gfx950"))
+            {
+                return {GPUArchId::gfx950, num_cu};
+            }
+
+            return {GPUArchId::gfxUnknown, num_cu};
+        }();
+        return data;
     }
-    else
-    {
-#if defined(AITER_EMBEDDED_HSA_HEADER) && defined(AITER_EMBEDDED_HSA_MAP)
-        std::string fname = "hsa/" + arch_name + "/" + hsaco;
-        auto hasco_obj    = AITER_EMBEDDED_HSA_MAP.find(fname);
-        CHECK_COND(hasco_obj != AITER_EMBEDDED_HSA_MAP.end());
-        CHECK_COND(hasco_obj->second.data() != nullptr);
-        AITER_LOG_INFO("hipModuleLoad: " << fname << " GetFunction: " << name);
-        HIP_CALL(hipModuleLoadData(&module, hasco_obj->second.data()));
-#endif
-    }
-    HIP_CALL(hipModuleGetFunction(&kernel_func, module, name));
-    AITER_LOG_INFO("hipModuleGetFunction: " << name << " Success");
+};
+} // namespace detail
+
+static inline GPUArchId get_gpu_arch()
+{
+    return std::get<0>(detail::GpuArchHelper::get_arch_data());
 }
 
-class AiterAsmKernel
-{
-    private:
-    hipModule_t module;
-    hipFunction_t kernel_func;
+static inline uint32_t get_num_cu() { return std::get<1>(detail::GpuArchHelper::get_arch_data()); }
 
-    public:
-    AiterAsmKernel(const char* name, const char* hsaco)
+struct __attribute__((packed)) AiterAsmKernelCodeObjectWrapper
+{
+    static constexpr char magic = '#';
+    char header;
+    int32_t gfx942_offset;
+    int32_t gfx942_MI308_offset;
+    int32_t gfx950_offset;
+    uint8_t hsaco[];
+};
+
+namespace detail {
+struct FatBinaryWrapper
+{
+    uint32_t magic        = 0x48495046; // "HIPF";
+    uint32_t version      = 1;
+    const uint8_t* binary = nullptr;
+    intptr_t __pad        = 0;
+};
+
+extern "C" void* __hipRegisterFatBinary(const FatBinaryWrapper* data) noexcept;
+extern "C" void __hipUnregisterFatBinary(void* module) noexcept;
+extern "C" void __hipRegisterFunction(void* module,
+                                      const void* hostFunction,
+                                      const char* deviceFunction,
+                                      const char* deviceName,
+                                      int threadLimit,
+                                      void* tid,
+                                      void* bid,
+                                      void* blockDim,
+                                      void* gridDim,
+                                      void* wSize) noexcept;
+extern "C" __attribute__((visibility("hidden"))) void* __dso_handle;
+extern "C" int __cxa_atexit(void (*f)(void*), void* p, void* dso) noexcept;
+
+} // namespace detail
+
+template <size_t N, size_t M>
+struct StaticKernelDescriptor
+{
+    uint8_t data[N + M + 1];
+    consteval StaticKernelDescriptor(const char (&kernel_name)[N],
+                                     const uint8_t (&kernel_code_object)[M])
     {
-        load_asm_kernel(name, hsaco, module, kernel_func);
+        data[0] = N - 1;
+        std::copy_n(kernel_name, N, data + 1);
+        std::copy_n(kernel_code_object, M, data + N + 1);
+    }
+};
+
+namespace detail {
+constexpr uint8_t NoImage[1] = {0};
+constexpr StaticKernelDescriptor NoStaticDescriptor{"", NoImage};
+} // namespace detail
+
+template <StaticKernelDescriptor Desc = detail::NoStaticDescriptor>
+class AiterAsmKernel;
+
+template <typename T,
+          AiterAsmKernel<>* Kernels,
+          const uint32_t* KernelDescriptorOffsets,
+          const uint8_t* KernelDescriptors>
+struct AiterAsmKernelConfigMap;
+
+template <>
+class AiterAsmKernel<detail::NoStaticDescriptor>
+{
+    enum class State : uint8_t
+    {
+        NotLoaded,
+        Loading,
+        Loaded
     };
 
-    ~AiterAsmKernel() { HIP_CALL(hipModuleUnload(module)); }
+    std::atomic<State> state = State::NotLoaded;
+
+    static inline const uint8_t* select_code_object(const uint8_t* kernel_data)
+    {
+        if(static_cast<char>(kernel_data[0]) != AiterAsmKernelCodeObjectWrapper::magic)
+        {
+            // Assume plain hsaco object
+            return kernel_data;
+        }
+
+        auto archive   = reinterpret_cast<const AiterAsmKernelCodeObjectWrapper*>(kernel_data);
+        int32_t offset = -1;
+        auto arch_id = get_gpu_arch();
+        switch(arch_id)
+        {
+        case GPUArchId::gfxUnknown: break;
+        case GPUArchId::gfx942:
+            switch(get_num_cu())
+            {
+            default:
+            case 304: offset = archive->gfx942_offset; break;
+            case 80:
+            case 64:
+                offset = archive->gfx942_MI308_offset >= 0 ? archive->gfx942_MI308_offset
+                                                           : archive->gfx942_offset;
+                break;
+            }
+            break;
+        case GPUArchId::gfx950: offset = archive->gfx950_offset; break;
+        }
+
+        TORCH_CHECK(offset >= 0, "No kernel found for arch_id: ", arch_id);
+        return &archive->hsaco[offset];
+    }
+
+    protected:
+    void launch_kernel_with_descriptor(const AiterAsmKernelArgs& kargs,
+                                       const uint8_t* desc) noexcept
+    {
+        void* config[]            = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                                     kargs.args_ptr,
+                                     HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                                     kargs.arg_size_ptr,
+                                     HIP_LAUNCH_PARAM_END};
+        hipFunction_t kernel_func = nullptr;
+        (void)hipGetFuncBySymbol(&kernel_func, reinterpret_cast<void*>(this));
+
+        auto error = hipModuleLaunchKernel(kernel_func,
+                                           kargs.gdx,
+                                           kargs.gdy,
+                                           kargs.gdz,
+                                           kargs.bdx,
+                                           kargs.bdy,
+                                           kargs.bdz,
+                                           0,
+                                           kargs.stream,
+                                           nullptr,
+                                           (void**)&config);
+
+        if(C10_UNLIKELY(error != hipSuccess))
+        {
+            if(C10_LIKELY(error == hipErrorInvalidResourceHandle))
+            {
+                (void)hipGetLastError(); // clear the error state
+                init_with_descriptor(desc)->launch_kernel(kargs);
+                return;
+            }
+            HIP_CALL(error /* hipModuleLaunchKernel */);
+            __builtin_unreachable();
+        }
+    }
+
+    AiterAsmKernel<>* init_with_descriptor(const uint8_t* desc)
+    {
+        if(C10_LIKELY(this->state.load(std::memory_order_acquire) == State::Loaded))
+        {
+            return this;
+        }
+
+        auto old = State::NotLoaded;
+        if(this->state.compare_exchange_strong(old, State::Loading, std::memory_order_acq_rel))
+        {
+            auto kernel_name = reinterpret_cast<const char*>(&desc[1]);
+            auto kernel_co   = select_code_object(desc + static_cast<uint32_t>(desc[0]) + 2);
+            detail::FatBinaryWrapper fat_bin{};
+            fat_bin.binary = kernel_co;
+            auto module    = detail::__hipRegisterFatBinary(&fat_bin);
+            CHECK_COND(module != nullptr);
+            CHECK_COND(detail::__cxa_atexit(detail::__hipUnregisterFatBinary,
+                                            module,
+                                            static_cast<void*>(&detail::__dso_handle)) == 0);
+            detail::__hipRegisterFunction(module,
+                                          static_cast<void*>(this),
+                                          kernel_name,
+                                          kernel_name,
+                                          -1,
+                                          nullptr,
+                                          nullptr,
+                                          nullptr,
+                                          nullptr,
+                                          nullptr);
+            this->state.store(State::Loaded, std::memory_order_release);
+            this->state.notify_all();
+        }
+        else
+        {
+            if(old == State::Loading)
+            {
+                this->state.wait(State::Loading, std::memory_order_acquire);
+                old = this->state.load(std::memory_order_relaxed);
+            }
+            CHECK_COND(old == State::Loaded);
+        }
+
+        return this;
+    }
+
+    public:
+    consteval AiterAsmKernel()                  = default;
+    AiterAsmKernel(AiterAsmKernel&)             = delete;
+    AiterAsmKernel(AiterAsmKernel&&)            = delete;
+    AiterAsmKernel& operator=(AiterAsmKernel&)  = delete;
+    AiterAsmKernel& operator=(AiterAsmKernel&&) = delete;
 
     void launch_kernel(const AiterAsmKernelArgs& kargs)
     {
-        void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
-                          kargs.args_ptr,
-                          HIP_LAUNCH_PARAM_BUFFER_SIZE,
-                          kargs.arg_size_ptr,
-                          HIP_LAUNCH_PARAM_END};
+        void* config[]            = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                                     kargs.args_ptr,
+                                     HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                                     kargs.arg_size_ptr,
+                                     HIP_LAUNCH_PARAM_END};
+        hipFunction_t kernel_func = nullptr;
+        // TODO Ask runtime folks to provide an API for hipLaunchKernel with extra arg
+        // Don't error check here.
+        // Failure to load the func would cause hipModuleLaunchKernel to fail anyways.
+        (void)hipGetFuncBySymbol(&kernel_func, reinterpret_cast<void*>(this));
 
         HIP_CALL(hipModuleLaunchKernel(kernel_func,
                                        kargs.gdx,
@@ -133,82 +338,172 @@ class AiterAsmKernel
                                        kargs.stream,
                                        nullptr,
                                        (void**)&config));
-    };
+    }
+
+    template <typename T,
+              AiterAsmKernel<>* Kernels,
+              const uint32_t* KernelDescriptorOffsets,
+              const uint8_t* KernelDescriptors>
+    friend struct AiterAsmKernelConfigMap;
 };
 
-class AiterAsmKernelFast
+template <StaticKernelDescriptor Desc>
+class AiterAsmKernel : private AiterAsmKernel<>
 {
-    private:
-    hipModule_t module;
-    hipFunction_t kernel_func;
-
     public:
-    AiterAsmKernelFast(const char* name, void* hsaco)
+    void __attribute__((always_inline)) launch_kernel(const AiterAsmKernelArgs& kargs)
     {
+<<<<<<< HEAD
         HIP_CALL(hipModuleLoadData(&module, hsaco));
         HIP_CALL(hipModuleGetFunction(&kernel_func, module, name));
         AITER_LOG_INFO("hipModuleGetFunction: " << name << " Success");
     };
+=======
+        launch_kernel_with_descriptor(kargs, &Desc.data[0]);
+    }
+>>>>>>> beed7a148 (Remove uses of AITER_ASM_DIR)
 
-    ~AiterAsmKernelFast() { HIP_CALL(hipModuleUnload(module)); }
-
-    void launch_kernel(const AiterAsmKernelArgs& kargs)
-    {
-        void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
-                          kargs.args_ptr,
-                          HIP_LAUNCH_PARAM_BUFFER_SIZE,
-                          kargs.arg_size_ptr,
-                          HIP_LAUNCH_PARAM_END};
-
-        HIP_CALL(hipModuleLaunchKernel(kernel_func,
-                                       kargs.gdx,
-                                       kargs.gdy,
-                                       kargs.gdz,
-                                       kargs.bdx,
-                                       kargs.bdy,
-                                       kargs.bdz,
-                                       0,
-                                       kargs.stream,
-                                       nullptr,
-                                       (void**)&config));
-    };
+    AiterAsmKernel<>* operator&() { return init_with_descriptor(&Desc.data[0]); }
 };
 
-static const std::string get_gpu_arch()
+template <typename T,
+          AiterAsmKernel<>* Kernels,
+          const uint32_t* KernelDescriptorOffsets,
+          const uint8_t* KernelDescriptors>
+struct AiterAsmKernelConfigMap
 {
-    int device_count;
-    HIP_CALL(hipGetDeviceCount(&device_count));
-    if(device_count == 0)
+    using Entry = T;
+    uint16_t kernel_index_bias;
+    uint16_t entry_count;
+    std::pair<const uint16_t, const uint16_t>
+        per_arch_offsets[static_cast<int>(GPUArchId::gfxLastKnown) + 1];
+    // T entries[];
+    bool empty() const { return entry_count == 0; }
+    std::span<const Entry> get_configs_for_arch(GPUArchId arch_id) const
     {
-        return "No GPU Found";
+        auto entries          = reinterpret_cast<const Entry*>(&this[1]);
+        uint16_t begin_offset = arch_id != GPUArchId::gfxUnknown
+                                    ? per_arch_offsets[static_cast<int>(arch_id)].first
+                                    : 0;
+        uint16_t end_offset   = arch_id != GPUArchId::gfxUnknown
+                                    ? per_arch_offsets[static_cast<int>(arch_id)].second
+                                    : 0;
+        __builtin_assume(end_offset <= entry_count);
+        return {&entries[begin_offset], &entries[end_offset]};
     }
 
-    hipDevice_t dev;
-    hipDeviceProp_t dev_prop;
-    HIP_CALL(hipGetDevice(&dev));
-    HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
-
-    std::string arch_full = dev_prop.gcnArchName;
-    size_t colon_pos      = arch_full.find(':');
-    if(colon_pos != std::string::npos)
+    std::string_view get_kernel_name_for_config(const T* entry) const
     {
-        return arch_full.substr(0, colon_pos);
+        if(C10_UNLIKELY(entry == nullptr))
+        {
+            return {};
+        }
+        auto entries = reinterpret_cast<const Entry*>(&this[1]);
+        CHECK_COND(entry >= entries && entry < &entries[entry_count]);
+        auto index = static_cast<uint32_t>(entry - entries);
+        const uint8_t* descriptor =
+            &KernelDescriptors[KernelDescriptorOffsets[kernel_index_bias + index]];
+        return {reinterpret_cast<const char*>(&descriptor[1]), static_cast<size_t>(descriptor[0])};
     }
-    else
-    {
-        return arch_full;
-    }
-}
 
-static uint32_t get_num_cu_func()
+    AiterAsmKernel<>* load_kernel_for_config(const T* entry) const
+    {
+        if(C10_UNLIKELY(entry == nullptr))
+        {
+            return nullptr;
+        }
+        auto entries = reinterpret_cast<const Entry*>(&this[1]);
+        CHECK_COND(entry >= entries && entry < &entries[entry_count]);
+        auto index                = static_cast<uint32_t>(entry - entries);
+        uint32_t kernel_index     = kernel_index_bias + index;
+        const uint8_t* descriptor = &KernelDescriptors[KernelDescriptorOffsets[kernel_index]];
+        return Kernels[kernel_index].init_with_descriptor(descriptor);
+    }
+
+    const Entry* find_config_by_kernel_name(GPUArchId arch_id, std::string_view name) const
+    {
+        auto entries          = reinterpret_cast<const Entry*>(&this[1]);
+        uint16_t begin_offset = arch_id != GPUArchId::gfxUnknown
+                                    ? per_arch_offsets[static_cast<int>(arch_id)].first
+                                    : 0;
+        uint16_t end_offset   = arch_id != GPUArchId::gfxUnknown
+                                    ? per_arch_offsets[static_cast<int>(arch_id)].second
+                                    : 0;
+        __builtin_assume(end_offset <= entry_count);
+        for(int i = begin_offset; i < end_offset; i++)
+        {
+            const uint8_t* descriptor =
+                &KernelDescriptors[KernelDescriptorOffsets[kernel_index_bias + i]];
+            if(std::string_view(reinterpret_cast<const char*>(&descriptor[1]),
+                                static_cast<size_t>(descriptor[0])) == name)
+            {
+                return &entries[i];
+            }
+        }
+
+        return nullptr;
+    }
+};
+
+// Hack around missing flexible array initalizer support
+template <typename T, size_t EntryCount>
+struct AiterAsmKernelConfigMapSized : public T
 {
-    auto get_num_cu_local = []() {
-        hipDevice_t dev;
-        hipDeviceProp_t dev_prop;
-        HIP_CALL(hipGetDevice(&dev));
-        HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
-        return dev_prop.multiProcessorCount;
-    };
-    static const uint32_t num_cu = get_num_cu_local();
-    return num_cu;
-}
+    typename T::Entry entries[EntryCount];
+    const T* operator&() const { return this; }
+};
+
+template <size_t MinSize, size_t MaxSize>
+struct FixedString
+{
+    template <size_t N>
+    consteval FixedString(const char (&str)[N])
+    {
+        constexpr size_t size = N - 1;
+        static_assert(size >= MinSize && size <= MaxSize);
+        std::copy_n(str, size, data);
+    }
+
+    constexpr size_t size() const
+    {
+        for(int i = MinSize; i < MaxSize; i++)
+        {
+            if(data[i] == '\0')
+            {
+                return i;
+            }
+        }
+        return MaxSize;
+    }
+
+    operator std::string_view() const { return {data, size()}; }
+
+    friend bool operator==(const FixedString& lhs, const std::string_view& rhs)
+    {
+        return std::string_view(lhs) == rhs;
+    }
+
+    private:
+    char data[MaxSize] = {0};
+};
+
+template <class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>>
+struct SynchronizedCache
+{
+    template <typename F>
+    T& get_or_create(const Key& k, F&& factory)
+    {
+        std::lock_guard<std::mutex> map_mu_guard(map_mu);
+        auto [it, inserted] = map.try_emplace(k);
+        if(C10_LIKELY(!inserted))
+        {
+            return it->second;
+        }
+
+        return (it->second = factory());
+    }
+
+    private:
+    std::mutex map_mu;
+    std::unordered_map<Key, T, Hash, KeyEqual> map;
+};

--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -406,8 +406,10 @@ void get_mla_metadata_v1_2_device(const torch::Tensor& seqlens_qo_indptr, // [ba
                                   torch::Tensor& reduce_partial_map)
 {
     constexpr int32_t kPackedQoLenPerWg = 128;
+    // TODO(rocm): No device guard?
     const hipStream_t stream            = at::hip::getCurrentHIPStream();
 
+    // TODO(rocm): get_num_cu?
     hipDevice_t dev;
     hipDeviceProp_t dev_prop;
     hipGetDevice(&dev);
@@ -431,7 +433,7 @@ void get_mla_metadata_v1_2_device(const torch::Tensor& seqlens_qo_indptr, // [ba
         (kv_dtype == at::ScalarType::Float8_e4m3fnuz || kv_dtype == at::ScalarType::Float8_e4m3fn);
 
     const bool natively_supported = (num_heads == 16) ||
-                                    ((arch_id == "gfx950") && (num_heads == 32) && q_is_fp8 &&
+                                    ((arch_id == GPUArchId::gfx950) && (num_heads == 32) && q_is_fp8 &&
                                      kv_is_fp8 && (max_seqlen_qo == 4)) ||
                                     ((num_heads == 128) && q_is_fp8 && kv_is_fp8);
 

--- a/csrc/kernels/quant_kernels.cu
+++ b/csrc/kernels/quant_kernels.cu
@@ -1062,7 +1062,7 @@ void partial_transpose(torch::Tensor& out,         // [rows, d]
     TORCH_CHECK(out.is_contiguous());
     TORCH_CHECK(input.is_contiguous());
 
-    uint32_t num_cu       = get_num_cu_func();
+    uint32_t num_cu       = get_num_cu();
     int const cols        = input.size(-1);
     int const rows        = input.numel() / cols;
     int32_t* num_rows_ptr = num_rows.data_ptr<int32_t>();

--- a/csrc/kernels/rmsnorm_quant_kernels.cu
+++ b/csrc/kernels/rmsnorm_quant_kernels.cu
@@ -370,7 +370,7 @@ __global__ void add_rmsnorm_quant_kernel(
 
         const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
         const hipStream_t stream = at::hip::getCurrentHIPStream();
-        const int cu_num = get_num_cu_func();
+        const int cu_num = get_num_cu();
 
         if(out.dtype() == torch_fp8)
         {
@@ -432,7 +432,7 @@ __global__ void add_rmsnorm_quant_kernel(
 
         const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
         const hipStream_t stream = at::hip::getCurrentHIPStream();
-        const int cu_num = get_num_cu_func();
+        const int cu_num = get_num_cu();
 
         if(out.dtype() == torch_fp8)
         {
@@ -495,7 +495,7 @@ __global__ void add_rmsnorm_quant_kernel(
 
         const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
         const hipStream_t stream = at::hip::getCurrentHIPStream();
-        const int cu_num = get_num_cu_func();
+        const int cu_num = get_num_cu();
 
         if(out.dtype() == torch::kBFloat16)
         {
@@ -550,7 +550,7 @@ __global__ void add_rmsnorm_quant_kernel(
 
         const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
         const hipStream_t stream = at::hip::getCurrentHIPStream();
-        const int cu_num = get_num_cu_func();
+        const int cu_num = get_num_cu();
 
         if(out.dtype() == torch::kBFloat16)
         {

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -1787,7 +1787,7 @@ void standalone_stable_radix_11bits(void* buf,
     }
     else
     {
-        int sm_cnt = get_num_cu_func();
+        int sm_cnt = get_num_cu();
 
         unsigned grid_dim = calc_grid_dim<T, IdxT, 11, block_dim, WRITE_TOPK_VALUES, phase>(
             batch_size, len, sm_cnt);
@@ -2422,7 +2422,7 @@ int64_t invokeComputeTopkLastDimWorkspaceSize(int32_t numRows, int32_t stride0)
     constexpr bool is_largest        = true;
     constexpr int k                  = 2048;
 
-    int sm_cnt = get_num_cu_func();
+    int sm_cnt = get_num_cu();
     unsigned grid_dim =
         aiter::calc_grid_dim<T, IdxT, 11, block_dim, false, phase>(numRows, stride0, sm_cnt);
 

--- a/csrc/py_itfs_cu/asm_a8w8_blockscale_bpreshuffle.cu
+++ b/csrc/py_itfs_cu/asm_a8w8_blockscale_bpreshuffle.cu
@@ -50,7 +50,7 @@ struct __attribute__((packed)) KernelArgs {
 
 using namespace hip_fp8_impl;
 
-static CFG* get_cfg(torch::Tensor& inp, torch::Tensor& out) {
+static const CFG* get_cfg(torch::Tensor& inp, torch::Tensor& out) {
     if (inp.dtype() == torch_fp8 && out.scalar_type() == at::ScalarType::BFloat16) {
         return &cfg_fp8gemm_bf16_blockscale;
     }
@@ -77,28 +77,26 @@ static void validate_inputs(const torch::Tensor& A, const torch::Tensor& B, cons
 }
 
 // Heuristic kernel selection
-std::tuple<std::string, int> get_heuristic_fp8_kernel(int M, int N, int K, std::string arch_id,
-                                                      std::optional<int> splitK, std::optional<bool> bpreshuffle,
-                                                      CFG* cfgs) {
-    hipDevice_t dev;
-    hipDeviceProp_t dev_prop;
-    HIP_CALL(hipGetDevice(&dev));
-    HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
-    
-    uint32_t num_cu = dev_prop.multiProcessorCount;
+std::tuple<const CFG::Entry*, int>
+get_heuristic_fp8_kernel(int M,
+                         int N,
+                         int K,
+                         GPUArchId arch_id,
+                         std::optional<int> splitK,
+                         std::optional<bool> bpreshuffle,
+                         const CFG* cfgs)
+{
+    uint32_t num_cu = get_num_cu();
     uint32_t empty_cu = num_cu;
     uint32_t round = 0xffffffff;
     float compute2mem_effi = 1.0;
     
     int splitK_en = (splitK.has_value() && splitK.value() != 1) ? 1 : 0;
     int bpreshuffle_en = (bpreshuffle.has_value() && !bpreshuffle.value()) ? 0 : 1;
-    std::string selectedKernelName = "";
-    int selectedsplitK = 1;
+    const CFG::Entry* selectedCfg = nullptr;
+    int selectedsplitK      = 1;
 
-    for (const auto& el : *cfgs) {
-        if (el.first.find(arch_id) != 0) continue;
-        
-        const auto& cfg = el.second;
+    for (const auto& cfg : cfgs->get_configs_for_arch(arch_id)) {
         if (cfg.bpreshuffle == bpreshuffle_en && ((cfg.splitK == splitK_en) || !splitK.has_value())) {
             if ((N % cfg.tile_n) == 0) {
                 std::vector<int> splitK_list = (splitK.has_value() && cfg.splitK) 
@@ -120,7 +118,7 @@ std::tuple<std::string, int> get_heuristic_fp8_kernel(int M, int N, int K, std::
                     if (is_earlier_round || (is_same_round && (has_sufficient_empty_cu || has_better_efficiency))) {
                         round = local_round;
                         empty_cu = local_round * num_cu - tg_num;
-                        selectedKernelName = el.first;
+                        selectedCfg =  &cfg;
                         selectedsplitK = split_k;
                         compute2mem_effi = local_compute2mem_effi;
                     }
@@ -129,8 +127,8 @@ std::tuple<std::string, int> get_heuristic_fp8_kernel(int M, int N, int K, std::
         }
     }
 
-    TORCH_CHECK(selectedKernelName != "", __func__, ": cannot get heuristic kernel!");
-    return std::make_tuple(selectedKernelName, selectedsplitK);
+    TORCH_CHECK(selectedCfg != nullptr, __func__, ": cannot get heuristic kernel!");
+    return std::make_tuple(selectedCfg, selectedsplitK);
 }
 
 struct KernelSelector {
@@ -145,39 +143,34 @@ struct KernelSelector {
         }
     };
     
-    static std::unordered_map<DictKey, std::tuple<std::string, int>, SimpleHash> heuristic_cache;
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> kernel_cache;
-    
-    static std::tuple<std::string, int> select_kernel(int M, int N, int K, const std::string& arch_id,
-                                                     std::optional<int> splitK, std::optional<bool> bpreshuffle,
-                                                     std::optional<std::string> kernelName, CFG* config_map) {
+    static SynchronizedCache<DictKey, std::tuple<const CFG::Entry*, int>, SimpleHash> heuristic_cache;
+
+    static std::tuple<const CFG::Entry*, int>
+    select_kernel(int M,
+                  int N,
+                  int K,
+                  GPUArchId arch_id,
+                  std::optional<int> splitK,
+                  std::optional<bool> bpreshuffle,
+                  std::optional<std::string> kernelName,
+                  const CFG* config_map)
+    {
         if (kernelName.has_value()) {
-            return std::make_tuple(arch_id + kernelName.value(), splitK.value_or(1));
+            const auto* cfg = config_map->find_config_by_kernel_name(arch_id, kernelName.value());
+            return std::make_tuple(cfg, splitK.value_or(1));
         }
         
         DictKey key(M, N, K, splitK, bpreshuffle);
-        auto it = heuristic_cache.find(key);
-        if (it != heuristic_cache.end()) {
-            return it->second;  // find it and return
-        }
-        auto result = get_heuristic_fp8_kernel(M, N, K, arch_id, splitK, bpreshuffle, config_map);
-        heuristic_cache[key] = result;
-        return result;
-    }
-    
-    static AiterAsmKernel* get_kernel(const std::string& kernel_name, const std::string& co_name) {
-        auto result = kernel_cache.emplace(kernel_name, nullptr);
-        if (result.second) {
-            result.first->second = std::make_unique<AiterAsmKernel>(kernel_name.c_str(), co_name.c_str());
-        }
-        return result.first->second.get();
+        return heuristic_cache.get_or_create(key, [&](){
+            return get_heuristic_fp8_kernel(M, N, K, arch_id, splitK, bpreshuffle, config_map);
+        });
     }
 };
 
-
-std::unordered_map<KernelSelector::DictKey, std::tuple<std::string, int>, KernelSelector::SimpleHash> 
+SynchronizedCache<KernelSelector::DictKey,
+                  std::tuple<const CFG::Entry*, int>,
+                  KernelSelector::SimpleHash>
     KernelSelector::heuristic_cache;
-std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> KernelSelector::kernel_cache;
 
 static KernelArgs setup_kernel_args(const torch::Tensor& A, const torch::Tensor& B, const torch::Tensor& out,
                                    const torch::Tensor& A_scale, const torch::Tensor& B_scale,
@@ -238,24 +231,23 @@ torch::Tensor gemm_a8w8_blockscale_bpreshuffle_asm(
     std::optional<bool> bpreshuffle) {
     
     validate_inputs(A, B, out, A_scale, B_scale);
-    std::string arch_id = get_gpu_arch();
-    CFG* config_map = get_cfg(A, out);
+    auto arch_id          = get_gpu_arch();
+    const CFG* config_map = get_cfg(A, out);
 
     TORCH_CHECK(!config_map->empty(), __func__, " no kernel support a8w8 blockscale for GPU arch: ", arch_id);
 
-    auto [selectedKernelName, selectedsplitK] = KernelSelector::select_kernel(
+    auto [cfg, selectedsplitK] = KernelSelector::select_kernel(
         A.size(0), B.size(0), A.size(1), arch_id, splitK, bpreshuffle, kernelName, config_map);
     torch::Tensor bias_tensor = bias.has_value() ? bias.value() 
         : torch::zeros({1, B.size(0)}, torch::TensorOptions().dtype(torch::kFloat32).device(A.device()));
     const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(A));
     const hipStream_t stream = at::hip::getCurrentHIPStream();
-    auto it = config_map->find(selectedKernelName);
-    TORCH_CHECK(it != config_map->end(), __func__, " not find kernel " + selectedKernelName);
+    AiterAsmKernel<>* impl_ptr = config_map->load_kernel_for_config(cfg);
+    TORCH_CHECK(impl_ptr != nullptr, __func__, " not find kernel " + kernelName.value_or(""));
     
-    const auto& cfg = it->second;
     constexpr int TileK = 128;  
     
-    if (cfg.splitK == 1 && selectedsplitK > 1) {
+    if (cfg->splitK == 1 && selectedsplitK > 1) {
         int k_per_split = (A.size(1) + selectedsplitK - 1) / selectedsplitK;
         int k_per_split_aligned = ((k_per_split + TileK - 1) / TileK) * TileK;
         int actual_ksplit = (A.size(1) + k_per_split_aligned - 1) / k_per_split_aligned;
@@ -268,16 +260,15 @@ torch::Tensor gemm_a8w8_blockscale_bpreshuffle_asm(
         out.zero_();
     }
     
-    AiterAsmKernel* impl_ptr = KernelSelector::get_kernel(cfg.knl_name, cfg.co_name);
     KernelArgs args = setup_kernel_args(A, B, out, A_scale, B_scale, bias_tensor, selectedsplitK);
     size_t arg_size = sizeof(args);
     
-    int gdx = (B.size(0) + cfg.tile_n - 1) / cfg.tile_n;
-    int gdy = (A.size(0) + cfg.tile_m - 1) / cfg.tile_m;
+    int gdx = (B.size(0) + cfg->tile_n - 1) / cfg->tile_n;
+    int gdy = (A.size(0) + cfg->tile_m - 1) / cfg->tile_m;
     int gdz = 1;
     gdx = gdx * selectedsplitK;
     if (DebugPrint) {
-        print_debug_info(args, selectedKernelName, selectedsplitK, gdx, gdy, gdz, stream, bias);
+        print_debug_info(args, std::string(config_map->get_kernel_name_for_config(cfg)), selectedsplitK, gdx, gdy, gdz, stream, bias);
     }
     impl_ptr->launch_kernel({&args, &arg_size, gdx, gdy, gdz, 256, 1, 1, stream});
     

--- a/csrc/py_itfs_cu/asm_communication.cu
+++ b/csrc/py_itfs_cu/asm_communication.cu
@@ -9,6 +9,7 @@
 #include "aiter_hip_common.h"
 #include "communication_asm.h"
 #include "custom_all_reduce.cuh"
+#include "asm_custom_all_reduce_code_objects.hpp"
 
 torch::Tensor all_reduce_asm(torch::Tensor& input,
                              int64_t _ca,
@@ -101,7 +102,7 @@ torch::Tensor all_reduce_asm(torch::Tensor& input,
     args.stride_wave   = stride_WV;
     args.loopcnt       = 10;
 
-    static AiterAsmKernel impl("allreduce_kernel_func", "all_reduce.co");
+    static AiterAsmKernel<{"allreduce_kernel_func", all_reduce_co}> impl;
     impl.launch_kernel({&args,
                         &arg_size,
                         gdx, // gdx
@@ -243,7 +244,7 @@ std::tuple<torch::Tensor, torch::Tensor> all_reduce_rmsnorm(torch::Tensor& input
     args.tgs           = TGs;
     args.loopcnt       = 0;
 
-    static AiterAsmKernel impl("allreduce_rmsnorm_N8192_kernel", "allreduce_rmsnorm_N8192.co");
+    static AiterAsmKernel<{"allreduce_rmsnorm_N8192_kernel", allreduce_rmsnorm_N8192_co}> impl;
 
     impl.launch_kernel({&args,
                         &arg_size,
@@ -392,8 +393,8 @@ all_reduce_rmsnorm_quant(torch::Tensor& input,       // [m ,n]
     args.tgs           = TGs;
     args.loopcnt       = 0;
 
-    static AiterAsmKernel impl("allreduce_rmsnorm_qnt_N8192_kernel",
-                               "allreduce_rmsnorm_qnt_N8192.co");
+    static AiterAsmKernel<{"allreduce_rmsnorm_qnt_N8192_kernel", allreduce_rmsnorm_qnt_N8192_co}>
+        impl;
 
     impl.launch_kernel({&args,
                         &arg_size,

--- a/csrc/py_itfs_cu/asm_fmoe.cu
+++ b/csrc/py_itfs_cu/asm_fmoe.cu
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #include "aiter_hip_common.h"
 #include "asm_fmoe_configs.hpp"
+#include "asm_fmoe_code_objects.hpp"
 #include "moe_op.h"
 #include "py_itfs_common.h"
 #include <ATen/hip/HIPContext.h>
@@ -74,26 +75,21 @@ struct __attribute__((packed)) KernelArgs
 class FMoeKernel
 {
     private:
-    hipModule_t module;
-    hipFunction_t kernel_func;
+    AiterAsmKernel<>* kernel_impl;
     uint32_t sub_GU             = 512;
     bool is_int4                = false;
     uint32_t num_persistent_tgs = 0;
-    const char* name            = nullptr;
 
     public:
-    FMoeKernel(const char* name,
-               const char* hsaco,
+    FMoeKernel(AiterAsmKernel<>* impl,
                uint32_t sub_GU             = 512,
                uint32_t num_persistent_tgs = 0)
     {
-        load_asm_kernel(name, hsaco, module, kernel_func);
+        this->kernel_impl = impl;
         this->sub_GU             = sub_GU;
         this->num_persistent_tgs = num_persistent_tgs;
-        this->name               = name;
     };
 
-    const char* get_name() const { return name; }
     int get_num_persistent_tgs() { return num_persistent_tgs; }
     int get_sub_GU() { return sub_GU; }
     void set_4bit(bool is_4bit_) { is_int4 = is_4bit_; }
@@ -186,11 +182,6 @@ class FMoeKernel
         args.ps_deno   = ((inter_dim + sub_GU - 1) / sub_GU);
         args.total_tgs = this->num_persistent_tgs / args.ps_deno * args.ps_deno;
 
-        void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
-                          &args,
-                          HIP_LAUNCH_PARAM_BUFFER_SIZE,
-                          &arg_size,
-                          HIP_LAUNCH_PARAM_END};
         int bdx;
         int gdx;
         int gdy;
@@ -235,41 +226,50 @@ class FMoeKernel
         const hipStream_t stream = at::hip::getCurrentHIPStream();
         if constexpr(switchGxy)
         {
-            HIP_CALL(hipModuleLaunchKernel(
-                kernel_func, gdy, gdx, gdz, bdx, 1, 1, 0, stream, nullptr, (void**)&config));
+            kernel_impl->launch_kernel({&args,
+                                        &arg_size,
+                                        gdy, // gdx
+                                        gdx, // gdy
+                                        gdz, // gdz
+                                        bdx, // bdx
+                                        1,   // bdy
+                                        1,   // bdz
+                                        stream});
         }
         else
         {
-            HIP_CALL(hipModuleLaunchKernel(
-                kernel_func, gdx, gdy, gdz, bdx, 1, 1, 0, stream, nullptr, (void**)&config));
+            kernel_impl->launch_kernel({&args,
+                                        &arg_size,
+                                        gdx, // gdx
+                                        gdy, // gdy
+                                        gdz, // gdz
+                                        bdx, // bdx
+                                        1,   // bdy
+                                        1,   // bdz
+                                        stream});
         }
     };
 };
 
-FMoeKernel* get_heuristic_kernel(
-    int inter_dim, int sub_X_cnt, CFG* cfgs, int smf = 0, std::string kernel_name = "")
+std::optional<FMoeKernel> get_heuristic_kernel(
+    int inter_dim, int sub_X_cnt, const CFG* cfgs, int smf = 0, std::string kernel_name = "")
 {
-    FMoeKernel* impl_ptr        = nullptr;
-    uint32_t num_cu             = get_num_cu_func();
-    uint32_t empty_cu           = num_cu;
-    uint32_t tg_num             = 0;
-    uint32_t num_persistent_tgs = 0;
-    uint32_t round              = 0xffffffff;
-    std::string arch_id         = get_gpu_arch();
-    std::string selectedKl      = kernel_name.empty() ? "" : arch_id + kernel_name;
-    int vskip                   = 1;
-    static std::unordered_map<std::string, std::unique_ptr<FMoeKernel>> impl_ptr_map;
+    uint32_t num_cu               = get_num_cu();
+    uint32_t empty_cu             = num_cu;
+    uint32_t tg_num               = 0;
+    uint32_t num_persistent_tgs   = 0;
+    uint32_t round                = 0xffffffff;
+    auto arch_id                  = get_gpu_arch();
+    const CFG::Entry* selectedCfg = nullptr;
+    int vskip                     = 1;
 
     const char* vs_env_value = std::getenv("AITER_ENABLE_VSKIP");
     if(vs_env_value != nullptr && std::string(vs_env_value) == "0")
         vskip = 0;
-    if(selectedKl.empty())
+    if(kernel_name.empty())
     {
-        for(const auto& el : *cfgs)
+        for(const auto& cfg : cfgs->get_configs_for_arch(arch_id))
         {
-            if(el.first.find(arch_id) != 0)
-                continue;
-            const auto& cfg = el.second;
             if(cfg.vskip == vskip && cfg.smf == smf)
             {
                 if((inter_dim % cfg.subGU_n) == 0)
@@ -285,7 +285,7 @@ FMoeKernel* get_heuristic_kernel(
                     {
                         round      = local_round;
                         empty_cu   = local_round * num_cu - tg_num;
-                        selectedKl = el.first;
+                        selectedCfg = &cfg;
                         if(cfg.ps == 1)
                             num_persistent_tgs = cfg.tg_num_perCU * num_cu;
                         else
@@ -295,7 +295,7 @@ FMoeKernel* get_heuristic_kernel(
             }
         }
 
-        TORCH_CHECK(selectedKl != "",
+        TORCH_CHECK(selectedCfg != nullptr,
                     __func__,
                     ": No suitable kernel found for inter_dim: ",
                     inter_dim,
@@ -305,32 +305,28 @@ FMoeKernel* get_heuristic_kernel(
                     smf,
                     ", vskip: ",
                     vskip);
+    } else {
+        selectedCfg = cfgs->find_config_by_kernel_name(arch_id, kernel_name);
     }
-    auto it = cfgs->find(selectedKl);
-    if(it != cfgs->end())
+    auto kernel_impl = cfgs->load_kernel_for_config(selectedCfg);
+    if(kernel_impl != nullptr)
     {
-        const auto& cfg     = it->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        auto result         = impl_ptr_map.emplace(name, nullptr);
+        const auto& cfg     = *selectedCfg;
         if(cfg.ps == 1)
             num_persistent_tgs = cfg.tg_num_perCU * num_cu;
         else
             num_persistent_tgs = 0;
-        if(result.second)
-            result.first->second =
-                std::make_unique<FMoeKernel>(name, co_name, cfg.subGU_n, num_persistent_tgs);
-        impl_ptr = result.first->second.get();
+
+        return FMoeKernel(kernel_impl, cfg.subGU_n, num_persistent_tgs);
     }
-    else
-        TORCH_CHECK(false, __func__, " not find kernel " + selectedKl);
-    return impl_ptr;
+
+    TORCH_CHECK(false, __func__, " not find kernel " + kernel_name);
 }
 
 int get_heuristic_tile(int inter_dim, int sub_X_cnt, const std::vector<int>& available_tiles)
 {
     // int tiles[7] = {512, 448, 384, 320, 256, 192, 128};
-    uint32_t num_cu   = get_num_cu_func();
+    uint32_t num_cu   = get_num_cu();
     uint32_t empty_cu = num_cu;
     uint32_t tg_num   = 0;
     uint32_t round    = 0xffffffff;
@@ -373,19 +369,18 @@ void fmoe(torch::Tensor& out,               // [token_cnt, dim]
           uint32_t topk)
 {
     // g1u0
-    FMoeKernel* impl_ptr = nullptr;
+    std::optional<FMoeKernel> impl_ptr;
     if(input.dtype() == at::ScalarType::Half)
     {
-        static FMoeKernel impl_f16("fmoe_kernel_func", "fmoe_f16.co");
-        impl_ptr = &impl_f16;
+        static AiterAsmKernel<{"fmoe_kernel_func", fmoe_f16_co}> impl_f16;
+        impl_ptr = FMoeKernel(&impl_f16);
     }
     else if(input.dtype() == at::ScalarType::BFloat16)
     {
-        static FMoeKernel impl_b16("fmoe_kernel_func", "fmoe_b16.co");
-        impl_ptr = &impl_b16;
+        static AiterAsmKernel<{"fmoe_kernel_func", fmoe_b16_co}> impl_b16;
+        impl_ptr = FMoeKernel(&impl_b16);
     }
-    TORCH_CHECK(
-        impl_ptr != nullptr, __func__, ": unsupport current input type:", input.scalar_type());
+    TORCH_CHECK(impl_ptr, __func__, ": unsupport current input type:", input.scalar_type());
     impl_ptr->launch_kernel<uint16_t, uint16_t>(out,
                                                 input,
                                                 gate,
@@ -412,44 +407,47 @@ void fmoe_int8_g1u0(torch::Tensor& out,               // [token_cnt, dim]
                     torch::Tensor& fc2_smooth_scale,  // [expert, 1, inter_dim],
                     ActivationType activation)
 {
-    FMoeKernel* impl_ptr = nullptr;
+    std::optional<FMoeKernel> impl_ptr;
     int inter_dim        = down.size(2);
-    static std::unordered_map<std::string, std::unique_ptr<FMoeKernel>> impl_ptr_map;
-
     struct FMoeKernelConfig
     {
-        std::string name;
-        std::string co_name;
+        AiterAsmKernel<>* (*kernel_factory)();
         int tile_size;
     };
+
+#define FACTORY(name, data)                       \
+    +[]() -> AiterAsmKernel<>* {                  \
+        static AiterAsmKernel<{name, data}> impl; \
+        return &impl;                             \
+    }
 
     if(input.dtype() == at::ScalarType::Char || input.dtype() == at::ScalarType::Byte)
     {
         static std::unordered_map<int, FMoeKernelConfig> gelu_kernel_int8_configs = {
             {512,
-             {"fmoe_int8_g1u0_subGU_512_gelu", "fmoe/gelu/fmoe_int8_g1u0_subGU_512_gelu.co", 512}},
+             {FACTORY("fmoe_int8_g1u0_subGU_512_gelu", fmoe_int8_g1u0_subGU_512_gelu_co), 512}},
             {448,
-             {"fmoe_int8_g1u0_subGU_448_gelu", "fmoe/gelu/fmoe_int8_g1u0_subGU_448_gelu.co", 448}},
+             {FACTORY("fmoe_int8_g1u0_subGU_448_gelu", fmoe_int8_g1u0_subGU_448_gelu_co), 448}},
             {384,
-             {"fmoe_int8_g1u0_subGU_384_gelu", "fmoe/gelu/fmoe_int8_g1u0_subGU_384_gelu.co", 384}},
+             {FACTORY("fmoe_int8_g1u0_subGU_384_gelu", fmoe_int8_g1u0_subGU_384_gelu_co), 384}},
             {320,
-             {"fmoe_int8_g1u0_subGU_320_gelu", "fmoe/gelu/fmoe_int8_g1u0_subGU_320_gelu.co", 320}},
+             {FACTORY("fmoe_int8_g1u0_subGU_320_gelu", fmoe_int8_g1u0_subGU_320_gelu_co), 320}},
             {256,
-             {"fmoe_int8_g1u0_subGU_256_gelu", "fmoe/gelu/fmoe_int8_g1u0_subGU_256_gelu.co", 256}},
+             {FACTORY("fmoe_int8_g1u0_subGU_256_gelu", fmoe_int8_g1u0_subGU_256_gelu_co), 256}},
             {192,
-             {"fmoe_int8_g1u0_subGU_192_gelu", "fmoe/gelu/fmoe_int8_g1u0_subGU_192_gelu.co", 192}},
+             {FACTORY("fmoe_int8_g1u0_subGU_192_gelu", fmoe_int8_g1u0_subGU_192_gelu_co), 192}},
             {128,
-             {"fmoe_int8_g1u0_subGU_128_gelu", "fmoe/gelu/fmoe_int8_g1u0_subGU_128_gelu.co", 128}}};
+             {FACTORY("fmoe_int8_g1u0_subGU_128_gelu", fmoe_int8_g1u0_subGU_128_gelu_co), 128}}};
 
         static std::unordered_map<int, FMoeKernelConfig> silu_kernel_int8_configs = {
-            {512, {"fmoe_int8_g1u0_subGU_512", "fmoe/silu/fmoe_int8_g1u0_subGU_512.co", 512}},
-            {448, {"fmoe_int8_g1u0_subGU_448", "fmoe/silu/fmoe_int8_g1u0_subGU_448.co", 448}},
-            {384, {"fmoe_int8_g1u0_subGU_384", "fmoe/silu/fmoe_int8_g1u0_subGU_384.co", 384}},
-            {320, {"fmoe_int8_g1u0_subGU_320", "fmoe/silu/fmoe_int8_g1u0_subGU_320.co", 320}},
-            {256, {"fmoe_int8_g1u0_subGU_256", "fmoe/silu/fmoe_int8_g1u0_subGU_256.co", 256}},
-            {192, {"fmoe_int8_g1u0_subGU_192", "fmoe/silu/fmoe_int8_g1u0_subGU_192.co", 192}},
-            {128, {"fmoe_int8_g1u0_subGU_128", "fmoe/silu/fmoe_int8_g1u0_subGU_128.co", 128}}};
-
+            {512, {FACTORY("fmoe_int8_g1u0_subGU_512", fmoe_int8_g1u0_subGU_512_co), 512}},
+            {448, {FACTORY("fmoe_int8_g1u0_subGU_448", fmoe_int8_g1u0_subGU_448_co), 448}},
+            {384, {FACTORY("fmoe_int8_g1u0_subGU_384", fmoe_int8_g1u0_subGU_384_co), 384}},
+            {320, {FACTORY("fmoe_int8_g1u0_subGU_320", fmoe_int8_g1u0_subGU_320_co), 320}},
+            {256, {FACTORY("fmoe_int8_g1u0_subGU_256", fmoe_int8_g1u0_subGU_256_co), 256}},
+            {192, {FACTORY("fmoe_int8_g1u0_subGU_192", fmoe_int8_g1u0_subGU_192_co), 192}},
+            {128, {FACTORY("fmoe_int8_g1u0_subGU_128", fmoe_int8_g1u0_subGU_128_co), 128}}};
+#undef FACTORY
         std::unordered_map<int, FMoeKernelConfig>* config_map = nullptr;
         if(activation == ActivationType::Gelu)
         {
@@ -487,16 +485,7 @@ void fmoe_int8_g1u0(torch::Tensor& out,               // [token_cnt, dim]
         if(it != config_map->end())
         {
             const auto& config  = it->second;
-            const char* name    = config.name.c_str();
-            const char* co_name = config.co_name.c_str();
-
-            auto result = impl_ptr_map.emplace(name, nullptr);
-            if(result.second)
-            {
-                result.first->second =
-                    std::make_unique<FMoeKernel>(name, co_name, config.tile_size);
-            }
-            impl_ptr = result.first->second.get();
+            impl_ptr = FMoeKernel(config.kernel_factory(), config.tile_size);
         }
     }
     impl_ptr->launch_kernel<uint8_t, uint16_t>(out,
@@ -530,42 +519,37 @@ void fmoe_g1u1(torch::Tensor& out,               // [token_cnt, dim]
                std::optional<torch::Tensor> fc2_smooth_scale, // [expert, 1, inter_dim]
                ActivationType activation)
 {
-    struct FMoeKernelConfig
-    {
-        std::string name;
-        std::string co_name;
-        int tile_size;
-    };
-
-    FMoeKernel* impl_ptr = nullptr;
-    CFG* config_map      = nullptr;
+    std::optional<FMoeKernel> impl_ptr;
+    const CFG* config_map      = nullptr;
     int smf              = 0;
     int model_dim        = down.size(1);
     int inter_dim        = down.size(2);
     inter_dim *= model_dim / gate.size(2);
     int sub_X_cnt = sorted_expert_ids.size(0);
-    static std::unordered_map<std::string, std::unique_ptr<FMoeKernel>> impl_ptr_map;
     if(gate.dtype() == at::ScalarType::UInt32 || gate.dtype() == at::ScalarType::Int) // int4
     {
         int selectedTile = get_heuristic_tile(
             inter_dim, sub_X_cnt, {512, 256, 128}); // todo,add tune interface here
         if(selectedTile == 512)
         {
-            static FMoeKernel impl_int4_512(
-                "fmoe_int4fp8_g1u1_subGU_512_gelu", "fmoe_int4fp8_g1u1_subGU_512_gelu.co", 512);
-            impl_ptr = &impl_int4_512;
+            static AiterAsmKernel<{"fmoe_int4fp8_g1u1_subGU_512_gelu",
+                                   fmoe_int4fp8_g1u1_subGU_512_gelu_co}>
+                impl_int4_512;
+            impl_ptr = FMoeKernel(&impl_int4_512, 512);
         }
         else if(selectedTile == 256)
         {
-            static FMoeKernel impl_int4_256(
-                "fmoe_int4fp8_g1u1_subGU_256_gelu", "fmoe_int4fp8_g1u1_subGU_256_gelu.co", 256);
-            impl_ptr = &impl_int4_256;
+            static AiterAsmKernel<{"fmoe_int4fp8_g1u1_subGU_256_gelu",
+                                   fmoe_int4fp8_g1u1_subGU_256_gelu_co}>
+                impl_int4_256;
+            impl_ptr = FMoeKernel(&impl_int4_256, 256);
         }
         else if(selectedTile == 128)
         {
-            static FMoeKernel impl_int4_128(
-                "fmoe_int4fp8_g1u1_subGU_128_gelu", "fmoe_int4fp8_g1u1_subGU_128_gelu.co", 128);
-            impl_ptr = &impl_int4_128;
+            static AiterAsmKernel<{"fmoe_int4fp8_g1u1_subGU_128_gelu",
+                                   fmoe_int4fp8_g1u1_subGU_128_gelu_co}>
+                impl_int4_128;
+            impl_ptr = FMoeKernel(&impl_int4_128, 128);
         }
         else
         {
@@ -664,8 +648,8 @@ void fmoe_g1u1_tkw1(torch::Tensor& out,               // [token_cnt, dim]
                     std::optional<torch::Tensor> fc2_smooth_scale, // [expert, 1, inter_dim]
                     ActivationType activation)
 {
-    FMoeKernel* impl_ptr = nullptr;
-    CFG* config_map      = nullptr;
+    std::optional<FMoeKernel> impl_ptr;
+    const CFG* config_map      = nullptr;
 
     const int token_cnt = input.size(0);
     const int block_m   = 32; // fmoe sorting kernel and fmoe kernel only support 32 for now
@@ -724,7 +708,8 @@ void fmoe_int8_g1u0_a16(torch::Tensor& out,               // [token_cnt, dim]
                         torch::Tensor& fc2_smooth_scale   // [expert, 1, inter_dim]
 )
 {
-    static FMoeKernel impl("fmoe_kernel_func", "fmoe_int8_g1u0_smf.co");
+    static AiterAsmKernel<{"fmoe_kernel_func", fmoe_int8_g1u0_smf_co}> _impl;
+    FMoeKernel impl(&_impl);
     impl.launch_kernel<uint8_t, uint16_t, true>(out,
                                                 input,
                                                 gate,
@@ -756,11 +741,11 @@ void fmoe_g1u1_a16(torch::Tensor& out,               // [token_cnt, dim]
                    torch::Tensor& fc2_smooth_scale,  // [expert, 1, inter_dim]
                    ActivationType activation)
 {
-    FMoeKernel* impl_ptr = nullptr;
+    std::optional<FMoeKernel> impl_ptr;
     int inter_dim        = down.size(2);
     int sub_X_cnt        = sorted_expert_ids.size(0);
 
-    CFG* config_map = nullptr;
+    const CFG* config_map = nullptr;
     if(gate.dtype() == at::ScalarType::Char || gate.dtype() == at::ScalarType::Byte) // int8
     {
         if(out.dtype() == at::ScalarType::Half && activation == ActivationType::Silu)
@@ -827,9 +812,9 @@ void fmoe_fp8_blockscale_g1u1(torch::Tensor& out,               // [token_cnt, d
                               std::optional<torch::Tensor> fc2_smooth_scale,
                               ActivationType activation)
 {
-    FMoeKernel* impl_ptr     = nullptr;
-    CFG* config_map          = nullptr;
-    uint32_t num_cu          = get_num_cu_func();
+    std::optional<FMoeKernel> impl_ptr;
+    const CFG* config_map          = nullptr;
+    uint32_t num_cu          = get_num_cu();
     int inter_dim            = down.size(2);
     int sub_X_cnt            = sorted_expert_ids.size(0);
     const char* enable_vskip = std::getenv("AITER_ENABLE_VSKIP");

--- a/csrc/py_itfs_cu/asm_gemm_a8w8.cu
+++ b/csrc/py_itfs_cu/asm_gemm_a8w8.cu
@@ -41,7 +41,7 @@ struct __attribute__((packed)) KernelArgs
     p3 _p18;
 };
 
-static CFG* get_cfg(torch::Tensor& inp, torch::Tensor& out)
+static const CFG* get_cfg(torch::Tensor& inp, torch::Tensor& out)
 {
     if((inp.dtype() == torch::kInt8) && out.scalar_type() == at::ScalarType::BFloat16)
 
@@ -59,15 +59,11 @@ static CFG* get_cfg(torch::Tensor& inp, torch::Tensor& out)
     }
 };
 
-std::tuple<std::string, int> get_heuristic_kernel(
-    int M, int N, int K, std::string arch_id, std::optional<int> k_split, std::optional<bool> bpreshuffle, CFG* cfgs)
+std::tuple<const CFG::Entry*, int> get_heuristic_kernel(
+    int M, int N, int K, GPUArchId arch_id, std::optional<int> k_split, std::optional<bool> bpreshuffle, const CFG* cfgs)
 {
     k_split = k_split.value_or(0) ?: 1;
-    hipDevice_t dev;
-    hipDeviceProp_t dev_prop;
-    HIP_CALL(hipGetDevice(&dev));
-    HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
-    uint32_t num_cu        = dev_prop.multiProcessorCount;
+    uint32_t num_cu        = get_num_cu();
     uint32_t empty_cu      = num_cu;
     uint32_t tg_num        = 0;
     uint32_t round         = 0xffffffff;
@@ -75,14 +71,11 @@ std::tuple<std::string, int> get_heuristic_kernel(
     // int k_split_en                 = (k_split.has_value() && k_split.value() != 0) ? 1 : 0;
     int k_split_en                 = 1;
     int bpreshuffle_en             = (bpreshuffle.has_value() && !bpreshuffle) ? 0 : 1;
-    std::string selectedKernelName = "";
+    const CFG::Entry* selectedCfg  = nullptr;
     int selectedsplitK             = 1;
 
-    for(const auto& el : *cfgs)
+    for(const auto& cfg : cfgs->get_configs_for_arch(arch_id))
     {
-        if(el.first.find(arch_id) != 0)
-            continue;
-        const auto& cfg = el.second;
         if(cfg.bpreshuffle == bpreshuffle_en &&
            ((cfg.splitK == k_split_en) || !k_split.has_value()))
         {
@@ -116,7 +109,7 @@ std::tuple<std::string, int> get_heuristic_kernel(
                     {
                         round              = local_round;
                         empty_cu           = local_round * num_cu - tg_num;
-                        selectedKernelName = el.first;
+                        selectedCfg        = &cfg;
                         selectedsplitK     = splitK;
                     }
                 }
@@ -124,8 +117,8 @@ std::tuple<std::string, int> get_heuristic_kernel(
         }
     }
 
-    TORCH_CHECK(selectedKernelName != "", __func__, ": cannot get heuristic kernel!");
-    return std::make_tuple(selectedKernelName, selectedsplitK);
+    TORCH_CHECK(selectedCfg != nullptr, __func__, ": cannot get heuristic kernel!");
+    return std::make_tuple(selectedCfg, selectedsplitK);
 }
 
 torch::Tensor gemm_a8w8_asm(torch::Tensor& A,       // A:[M, K] i8
@@ -167,7 +160,7 @@ torch::Tensor gemm_a8w8_asm(torch::Tensor& A,       // A:[M, K] i8
 
     const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(A));
     const hipStream_t stream = at::hip::getCurrentHIPStream();
-    CFG* config_map           = get_cfg(A, out);
+    const CFG* config_map           = get_cfg(A, out);
     using DictKey             = std::tuple<int, int, int, std::optional<int>, std::optional<bool>>;
     struct SimpleHash
     {
@@ -180,57 +173,47 @@ torch::Tensor gemm_a8w8_asm(torch::Tensor& A,       // A:[M, K] i8
                    std::hash<int>()(splitk_key) ^ std::hash<bool>()(shuffle_key);
         }
     };
-    static std::unordered_map<DictKey, std::tuple<std::string, int>, SimpleHash>
-        heuristic_kernel_dict;
+    static SynchronizedCache<DictKey, std::tuple<const CFG::Entry*, int>, SimpleHash>
+        heuristic_kernel_cache;
 
     if(config_map->empty())
     {
         TORCH_CHECK(false, __func__, " no kernel support a8w8 for this gpu arch");
     }
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
-    std::string arch_id = get_gpu_arch();
-    kernelName          = kernelName.empty() ? "" : arch_id + kernelName;
-    int selectedksplit = splitK.value_or(0) ?: 1;
+
+    auto arch_id = get_gpu_arch();
+    const CFG::Entry* cfg      = nullptr;
+    int selectedksplit         = splitK.value_or(0) ?: 1;
     if(kernelName.empty())
     {
-        auto it = heuristic_kernel_dict.find(DictKey(Mdim, Ndim, Kdim, splitK, bpreshuffle));
-        if(it != heuristic_kernel_dict.end())
-        {
-            auto res       = it->second;
-            kernelName     = std::get<0>(res);
-            selectedksplit = std::get<1>(res);
-        }
-        else
-        {
-            auto it = get_heuristic_kernel(Mdim, Ndim, Kdim, arch_id, splitK, bpreshuffle, config_map);
-
-            kernelName     = std::get<0>(it);
-            selectedksplit = std::get<1>(it);
-            heuristic_kernel_dict[{Mdim, Ndim, Kdim, splitK, bpreshuffle}] =
-                std::make_tuple(kernelName, selectedksplit);
-        }
+        std::tie(cfg, selectedksplit) = heuristic_kernel_cache.get_or_create(
+            DictKey(Mdim, Ndim, Kdim, splitK, bpreshuffle), [&]() {
+                return get_heuristic_kernel(
+                    Mdim, Ndim, Kdim, arch_id, splitK, bpreshuffle, config_map);
+            });
+    }
+    else
+    {
+        cfg      = config_map->find_config_by_kernel_name(arch_id, kernelName);
     }
 
-    AiterAsmKernel* impl_ptr = nullptr;
+    AiterAsmKernel<>* impl_ptr = nullptr;
     int SUBM                 = 0;
     int SUBN                 = 0;
-    auto it                  = config_map->find(kernelName);
     int gdx                  = 0;
     int gdy                  = 0;
     int gdz                  = 0;
     int blockSizeX           = 256;
-    if(it != config_map->end())
+    impl_ptr = config_map->load_kernel_for_config(cfg);
+    if(impl_ptr != nullptr)
     {
-        const auto& cfg     = it->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        SUBM                = cfg.tile_m;
-        SUBN                = cfg.tile_n;
+        SUBM                = cfg->tile_m;
+        SUBN                = cfg->tile_n;
         gdx                 = (Ndim / SUBN) * blockSizeX;
         gdy                 = (Mdim % SUBM == 0) ? Mdim / SUBM : Mdim / SUBM + 1;
         gdz                 = 1;
 
-        if(cfg.splitK == 1 && selectedksplit > 0)
+        if(cfg->splitK == 1 && selectedksplit > 0)
         {
             int k_per_split         = (Kdim + ks - 1) / selectedksplit;
             int k_per_split_aligned = ((k_per_split + 127) / 128) * 128;
@@ -257,12 +240,6 @@ torch::Tensor gemm_a8w8_asm(torch::Tensor& A,       // A:[M, K] i8
                 out.zero_();
         }
         gdx         = gdx * selectedksplit;
-        auto result = impl_ptr_map.emplace(name, nullptr);
-        if(result.second)
-        {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-        }
-        impl_ptr = result.first->second.get();
     }
     else
         TORCH_CHECK(false, __func__, " not find kernel " + kernelName);

--- a/csrc/py_itfs_cu/asm_layernorm.cu
+++ b/csrc/py_itfs_cu/asm_layernorm.cu
@@ -6,6 +6,7 @@
 #include <ATen/hip/HIPContext.h>
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include "aiter_hip_common.h"
+#include "asm_norm_code_objects.hpp"
 
 struct __attribute__((packed)) KernelArgs
 {
@@ -69,8 +70,7 @@ void layernorm2d_with_add_asm(torch::Tensor &out,          // [m ,n]
     const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
     const hipStream_t stream = at::hip::getCurrentHIPStream();
     int sub_M = 2;
-    static AiterAsmKernel impl("layer_norm_kernel_func", "layer_norm.co");
-
+    static AiterAsmKernel<{"layer_norm_kernel_func", layer_norm_co}> impl;
     impl.launch_kernel({&args,
                         &arg_size,
                         ((m + sub_M - 1) / sub_M), // gdx
@@ -122,7 +122,7 @@ void layernorm2d_with_add_smoothquant_asm(torch::Tensor &out,          // [m ,n]
     const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
     const hipStream_t stream = at::hip::getCurrentHIPStream();
     int sub_M = 2;
-    static AiterAsmKernel impl("layer_norm_qnt", "layer_norm_qnt.co");
+    static AiterAsmKernel<{"layer_norm_qnt", layer_norm_qnt_co}> impl;
 
     impl.launch_kernel({&args,
                         &arg_size,

--- a/csrc/py_itfs_cu/asm_mi350_a8w8_blockscale.cu
+++ b/csrc/py_itfs_cu/asm_mi350_a8w8_blockscale.cu
@@ -6,6 +6,7 @@
 #include <ATen/hip/HIPContext.h>
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include "aiter_hip_common.h"
+#include "asm_fp8gemm_blockscale_mi350_code_objects.hpp"
 #include "hip_float8.h"
 
 struct __attribute__((packed)) KernelArgs
@@ -109,9 +110,9 @@ torch::Tensor mi350_a8w8_blockscale_asm(
     // printf("ptr_GUQ: %p\n", args.ptr_GUQ);
     // printf("args.Xs: %d\n", args.Xs);
     // printf("args.token_cnt: %d\n", args.token_cnt);
-    AiterAsmKernel *impl_ptr = nullptr;
-    static AiterAsmKernel impl_kenrel_x128("f8_block_scale_mi350_x128", "f8_block_scale_mi350_x128.co");
-    static AiterAsmKernel impl_kenrel_x32("f8_block_scale_mi350_x32", "f8_block_scale_mi350_x32.co");
+    AiterAsmKernel<> *impl_ptr = nullptr;
+    static AiterAsmKernel<{"f8_block_scale_mi350_x128", f8_block_scale_mi350_x128_co}> impl_kenrel_x128;
+    static AiterAsmKernel<{"f8_block_scale_mi350_x32", f8_block_scale_mi350_x32_co}> impl_kenrel_x32;
     impl_ptr = (m <= 32)?&impl_kenrel_x32:&impl_kenrel_x128;
     int gdx = (n + TileN*2 - 1) / (TileN*2);
     int gdy = (m + TileM - 1) / TileM;

--- a/csrc/py_itfs_cu/asm_mla.cu
+++ b/csrc/py_itfs_cu/asm_mla.cu
@@ -51,29 +51,26 @@ struct __attribute__((packed)) KernelArgs
     p3 _p23;
 };
 
-std::string get_heuristic_kernel_mla(std::string q_type,
-                                     std::string kv_type,
-                                     int gqa,
-                                     int ps,
-                                     int prefill,
-                                     int causal,
-                                     int qseqlen,
-                                     std::string arch_id,
-                                     CFG* cfgs)
+const CFG::Entry* get_heuristic_kernel_mla(std::string q_type,
+                                           std::string kv_type,
+                                           int gqa,
+                                           int ps,
+                                           int prefill,
+                                           int causal,
+                                           int qseqlen,
+                                           GPUArchId arch_id,
+                                           const CFG* cfgs)
 {
-    for(const auto& el : *cfgs)
+    for(const auto& cfg : cfgs->get_configs_for_arch(arch_id))
     {
-        if (el.first.find(arch_id) != 0)
-            continue;
-        const auto& cfg = el.second;
-        
         if (cfg.qType != q_type || cfg.kvType != kv_type)
             continue;
         if (cfg.Gqa != gqa || cfg.ps != ps || cfg.prefill != prefill)
             continue;
         if (cfg.causal != causal || cfg.qSeqLen != qseqlen)
             continue;
-        return el.first;
+
+        return &cfg;
     }
     
     TORCH_CHECK(false,
@@ -86,7 +83,7 @@ std::string get_heuristic_kernel_mla(std::string q_type,
                 " prefill:", prefill,
                 " causal:", causal,
                 " qseqlen:", qseqlen);
-    return "";
+    return nullptr;
 }
 
 void mla_decode_stage1_asm_fwd(
@@ -111,7 +108,7 @@ void mla_decode_stage1_asm_fwd(
     std::optional<torch::Tensor> q_scale  = std::nullopt, //   [1]
     std::optional<torch::Tensor> kv_scale = std::nullopt  //   [1]
 )
-{    
+{
     int batch           = qo_indptr.size(0) - 1;
     int num_heads       = Q.size(1);
     int head_size       = Q.size(2);
@@ -126,42 +123,43 @@ void mla_decode_stage1_asm_fwd(
     uint32_t log2_page = (uint32_t)log2f(page_size);
 
     KernelArgs args;
-    size_t arg_size  = sizeof(args);
-    args.ptr_R       = splitData.data_ptr();
-    args.ptr_LSE     = splitLse.data_ptr();
-    args.ptr_Q       = Q.data_ptr();
-    args.ptr_KV      = KV.data_ptr();
-    args.ptr_LTP     = kv_indptr.data_ptr();
-    args.ptr_LTD     = kv_page_indices.data_ptr();
-    args.ptr_LTL     = kv_last_page_lens.data_ptr();
-    args.ptr_QTP     = qo_indptr.data_ptr();
-    args.scalar      = softmax_scale;
-    args.s_MQA       = gqa_ratio * max_seqlen_q;
-    args.s_kv_split  = kv_split;
-    args.s_Q_Bs      = stride_Q;
-    args.s_Bs        = stride_Page;
-    args.s_log2_plen = log2_page;
+    size_t arg_size     = sizeof(args);
+    args.ptr_R          = splitData.data_ptr();
+    args.ptr_LSE        = splitLse.data_ptr();
+    args.ptr_Q          = Q.data_ptr();
+    args.ptr_KV         = KV.data_ptr();
+    args.ptr_LTP        = kv_indptr.data_ptr();
+    args.ptr_LTD        = kv_page_indices.data_ptr();
+    args.ptr_LTL        = kv_last_page_lens.data_ptr();
+    args.ptr_QTP        = qo_indptr.data_ptr();
+    args.scalar         = softmax_scale;
+    args.s_MQA          = gqa_ratio * max_seqlen_q;
+    args.s_kv_split     = kv_split;
+    args.s_Q_Bs         = stride_Q;
+    args.s_Bs           = stride_Page;
+    args.s_log2_plen    = log2_page;
     args.out_16_nosplit = kv_split;
 
-    if (persistent)
+    if(persistent)
     {
-        if (work_meta_data.has_value())
+        if(work_meta_data.has_value())
         {
             args.ptr_STP = work_meta_data.value().data_ptr();
         }
         else
         {
             assert(work_indptr.has_value() && work_info_set.has_value());
-            assert(work_indptr.value().data_ptr() != nullptr && work_info_set.value().data_ptr() != nullptr);
+            assert(work_indptr.value().data_ptr() != nullptr &&
+                   work_info_set.value().data_ptr() != nullptr);
 
-            uint64_t* persistent_meta_data = new uint64_t[10];
-            persistent_meta_data[0] = (uint64_t)work_indptr.value().data_ptr();
-            persistent_meta_data[1] = (uint64_t)work_info_set.value().data_ptr();
+            uint64_t persistent_meta_data[10] = {0};
+            persistent_meta_data[0]        = (uint64_t)work_indptr.value().data_ptr();
+            persistent_meta_data[1]        = (uint64_t)work_info_set.value().data_ptr();
             uint32_t* dev_PS_META_DATA;
 
             unsigned long buf_size_META = 10 * sizeof(uint64_t);
-            hipMalloc(&dev_PS_META_DATA, buf_size_META);
-            hipMemcpy(dev_PS_META_DATA, persistent_meta_data, buf_size_META, hipMemcpyHostToDevice);
+            hipMalloc(&dev_PS_META_DATA, buf_size_META); // TODO(rocm) mem leak!
+            hipMemcpy(dev_PS_META_DATA, &persistent_meta_data[0], buf_size_META, hipMemcpyHostToDevice);
 
             args.ptr_STP = dev_PS_META_DATA;
         }
@@ -170,8 +168,7 @@ void mla_decode_stage1_asm_fwd(
     {
         args.ptr_STP = num_kv_splits_indptr.value().data_ptr();
     }
-    args.ptr_RP = output.data_ptr(); //final output
-    
+    args.ptr_RP = output.data_ptr(); // final output
 
     // std::cout << "mla args" << std::endl;
     // std::cout << "ptr_R: " << args.ptr_R << std::endl;
@@ -233,9 +230,8 @@ void mla_decode_stage1_asm_fwd(
         TORCH_CHECK(false, __func__, ": unsupport KV dtype:", KV.scalar_type());
 
     // Get kernel using config dispatch
-    std::string arch_id = get_gpu_arch();
-    CFG* config_map = &cfg_mla_asm;
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
+    auto arch_id          = get_gpu_arch();
+    const CFG* config_map = &cfg_mla_asm;
     
     int ps = persistent ? 1 : 0;
     int prefill = 0; // decode stage
@@ -309,31 +305,15 @@ void mla_decode_stage1_asm_fwd(
         }
     }
 
-    std::string kernelName = get_heuristic_kernel_mla(q_type, kv_type, gqa_ratio, ps, prefill, causal, config_max_seqlen_q, arch_id, config_map);
+    const auto* cfg = get_heuristic_kernel_mla(q_type, kv_type, gqa_ratio, ps, prefill, causal, config_max_seqlen_q, arch_id, config_map);
     
-    TORCH_CHECK(!kernelName.empty(), __func__, ": cannot find suitable kernel");
+    TORCH_CHECK(cfg != nullptr, __func__, ": cannot find suitable kernel");
     
-    AiterAsmKernel* impl_ptr = nullptr;
+    AiterAsmKernel<>* impl_ptr = config_map->load_kernel_for_config(cfg);
     
-    auto it = config_map->find(kernelName);
-    if(it != config_map->end())
-    {
-        const auto& cfg     = it->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        auto result         = impl_ptr_map.emplace(name, nullptr);
-        if(result.second)
-        {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-        }
-        impl_ptr = result.first->second.get();
-        
-    }
-    else
-        TORCH_CHECK(false, __func__, " not find kernel " + kernelName);
-
-    TORCH_CHECK(impl_ptr != nullptr, __func__,
-        ": unsupport current data type or shape. please refer to asm_mla.cu");
+    TORCH_CHECK(impl_ptr != nullptr,
+                __func__,
+                ": unsupport current data type or shape. please refer to asm_mla.cu");
 
     int bdx = 256;
     int gdx = (max_seqlen_q * gqa_ratio + sub_Q - 1) / sub_Q;
@@ -350,12 +330,12 @@ void mla_decode_stage1_asm_fwd(
 
     impl_ptr->launch_kernel({&args,
                              &arg_size,
-                             gdx,       // gdx
-                             gdy,       // gdy
-                             gdz,       // gdz
-                             256,       // bdx: 4 wv64
-                             1,         // bdy
-                             1,         // bdz
+                             gdx, // gdx
+                             gdy, // gdy
+                             gdz, // gdz
+                             256, // bdx: 4 wv64
+                             1,   // bdy
+                             1,   // bdz
                              stream});
 }
 
@@ -484,44 +464,29 @@ void mla_prefill_ps_asm_fwd(
         TORCH_CHECK(false, __func__, ": unsupport K dtype:", K.scalar_type());
 
     // Get kernel using config dispatch
-    std::string arch_id = get_gpu_arch();
-    if(arch_id == "gfx942"){
+    auto arch_id = get_gpu_arch();
+    if(arch_id == GPUArchId::gfx942){
         TORCH_CHECK(false, __func__, ": fp8 mla persistent prefill is not supported on gfx942");
     }
-    CFG* config_map = &cfg_mla_asm;
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
+    const CFG* config_map = &cfg_mla_asm;
     
     int ps = 1; // ps_prefill always uses persistent scheduling
     int prefill = 1; // prefill stage
     int causal_flag = is_causal ? 1 : 0;
     int qseqlen = 0; // not used for prefill
     
-    std::string kernelName = get_heuristic_kernel_mla(q_type, k_type, gqa_ratio, ps, prefill, causal_flag, qseqlen, arch_id, config_map);
+    const auto* cfg = get_heuristic_kernel_mla(q_type, k_type, gqa_ratio, ps, prefill, causal_flag, qseqlen, arch_id, config_map);
     
-    TORCH_CHECK(!kernelName.empty(), __func__, ": cannot find suitable kernel");
+    TORCH_CHECK(cfg != nullptr, __func__, ": cannot find suitable kernel");
     
-    AiterAsmKernel* impl_ptr = nullptr;
+    AiterAsmKernel<>* impl_ptr = config_map->load_kernel_for_config(cfg);
     int wave_per_tg = 8;
     
-    auto it = config_map->find(kernelName);
-    if(it != config_map->end())
-    {
-        const auto& cfg     = it->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        auto result         = impl_ptr_map.emplace(name, nullptr);
-        if(result.second)
-        {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-        }
-        impl_ptr = result.first->second.get();
-    }
-    else
-        TORCH_CHECK(false, __func__, " not find kernel " + kernelName);
+    TORCH_CHECK(impl_ptr != nullptr, __func__, " not find kernel");
     
     // Launch kernel
     int block_size_x = wave_per_tg * 64;  // 8 * 64 = 512
-    // int grid_size_x  = get_num_cu_func();
+    // int grid_size_x  = get_num_cu();
     // std::cout << "grid_size_x" << grid_size_x << std::endl;
     int grid_size_x = work_indptr.value().size(0) - 1;
     // std::cout << "grid_size_x" << grid_size_x << std::endl;
@@ -606,36 +571,19 @@ void mla_prefill_asm_fwd(
         TORCH_CHECK(false, __func__, ": unsupport KV dtype:", KV.scalar_type());
 
     // Get kernel using config dispatch
-    std::string arch_id = get_gpu_arch();
-    CFG* config_map = &cfg_mla_asm;
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
+    auto arch_id          = get_gpu_arch();
+    const CFG* config_map = &cfg_mla_asm;
     
     int ps = 0; // prefill without persistent scheduling
     int prefill = 1; // prefill stage
     int causal_flag = 0;
     int qseqlen = 0;
-    std::string kernelName = get_heuristic_kernel_mla(q_type, kv_type, gqa_ratio, ps, prefill, causal_flag, qseqlen, arch_id, config_map);
+    const auto* cfg = get_heuristic_kernel_mla(q_type, kv_type, gqa_ratio, ps, prefill, causal_flag, qseqlen, arch_id, config_map);
     
-    TORCH_CHECK(!kernelName.empty(), __func__, ": cannot find suitable kernel");
+    TORCH_CHECK(cfg != nullptr, __func__, ": cannot find suitable kernel");
     
-    AiterAsmKernel* impl_ptr = nullptr;
+    AiterAsmKernel<>* impl_ptr = config_map->load_kernel_for_config(cfg);
     
-    auto it = config_map->find(kernelName);
-    if(it != config_map->end())
-    {
-        const auto& cfg     = it->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        auto result         = impl_ptr_map.emplace(name, nullptr);
-        if(result.second)
-        {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-        }
-        impl_ptr = result.first->second.get();
-    }
-    else
-        TORCH_CHECK(false, __func__, " not find kernel " + kernelName);
-
     TORCH_CHECK(impl_ptr != nullptr, __func__, ": unsupport current Q_type:", Q.scalar_type());
     impl_ptr->launch_kernel({&args,
                              &arg_size,

--- a/csrc/py_itfs_cu/asm_topksoftmax.cu
+++ b/csrc/py_itfs_cu/asm_topksoftmax.cu
@@ -27,31 +27,26 @@ struct __attribute__((packed)) KernelArgs
     p3 _p8;
 };
 
-std::pair<std::string, int> get_heuristic_kernel_topksoftmax(std::string arch_id,
+const CFG::Entry* get_heuristic_kernel_topksoftmax(GPUArchId arch_id,
     std::string dtype,
     int max_subm,
     int num_experts,
     int topk,
-    CFG* cfgs)
+    const CFG* cfgs)
 {
-    int subm = -1;
-    std::string kernelName = "";
-    for(const auto& el : *cfgs)
+    const CFG::Entry* entry = nullptr;
+    for(const auto& cfg : cfgs->get_configs_for_arch(arch_id))
     {
-        if (el.first.find(arch_id) != 0)
-            continue;
-        const auto& cfg = el.second;
         if (cfg.dtype != dtype || cfg.subm > max_subm || cfg.num_experts != num_experts || cfg.topk != topk)
             continue;
         
         if (cfg.subm > subm)
         {
-            kernelName = el.first;
-            subm = cfg.subm;
+            entry = &cfg;
         }
     }
 
-    TORCH_CHECK(!kernelName.empty(),
+    TORCH_CHECK(entry != nullptr,
     __func__,
     ": cannot get heuristic kernel!"
     " arch_id:", arch_id,
@@ -59,7 +54,7 @@ std::pair<std::string, int> get_heuristic_kernel_topksoftmax(std::string arch_id
     " max_subm:", max_subm,
     " num_experts:", num_experts,
     " topk:", topk);
-    return {kernelName, subm};
+    return entry;
 }
 
 void topk_softmax_asm(torch::Tensor& topk_weights,         // [num_tokens, topk]
@@ -68,7 +63,7 @@ void topk_softmax_asm(torch::Tensor& topk_weights,         // [num_tokens, topk]
                       torch::Tensor& gating_output,        // [num_tokens, num_experts]
                       bool need_renorm)
 {
-    std::string arch_id = get_gpu_arch();
+    auto arch_id           = get_gpu_arch();
     const uint num_experts = gating_output.size(-1);
     const uint num_tokens  = gating_output.numel() / num_experts;
     const uint topk        = topk_weights.size(-1);
@@ -94,31 +89,18 @@ void topk_softmax_asm(torch::Tensor& topk_weights,         // [num_tokens, topk]
     args.renormalize = need_renorm ? 1 : 0;
     args.out_stride  = out_stride * 4;
 
-    CFG* config_map = &cfg_topksoftmax;
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
-    AiterAsmKernel* impl_ptr = nullptr;
-    auto [kernelName, subm] = get_heuristic_kernel_topksoftmax(arch_id, dtype, MAX_SUBM, num_experts, topk, config_map);
+    const CFG* config_map = &cfg_topksoftmax;
 
-    auto it = config_map->find(kernelName);
-    if(it != config_map->end())
-    {
-        const auto& cfg     = it->second;
-        const char* name    = cfg.knl_name.c_str();
-        const char* co_name = cfg.co_name.c_str();
-        auto result         = impl_ptr_map.emplace(name, nullptr);
-        if(result.second)
-        {
-            result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
-        }
-        impl_ptr = result.first->second.get();
-    }
-    else
-        TORCH_CHECK(false, __func__, " not find kernel " + kernelName);
+    const auto* cfg = get_heuristic_kernel_topksoftmax(arch_id, dtype, MAX_SUBM, num_experts, topk, config_map);
+
+    AiterAsmKernel<>* impl_ptr = config_map->load_kernel_for_config(cfg);
+
+    TORCH_CHECK(impl_ptr != nullptr, __func__, " not find kernel");
 
     const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
     const hipStream_t stream = at::hip::getCurrentHIPStream();
 
-    uint gdx = (num_tokens + subm - 1) / subm;
+    uint gdx = (num_tokens + cfg->subm - 1) / cfg->subm;
     TORCH_CHECK(gdx >> 31 == 0, "num_tokens too large: ", num_tokens);
     impl_ptr->launch_kernel({&args,
                              &arg_size,

--- a/hsa/codegen.py
+++ b/hsa/codegen.py
@@ -4,11 +4,11 @@
 import argparse
 import glob
 import os
-import sys
 from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+from itertools import chain
 
 pd.set_option("future.no_silent_downcasting", True)
 
@@ -19,18 +19,319 @@ archs_supported = [
     os.path.basename(os.path.normpath(path)) for path in glob.glob(f"{this_dir}/*/")
 ]
 
+code_object_arch_map = {
+    ("gfx942", ""): "gfx942",
+    ("gfx942", "MI300"): "gfx942",
+    ("gfx942", "MI308"): "gfx942_MI308",
+    ("gfx950", ""): "gfx950",
+}
 
-content = """// SPDX-License-Identifier: MIT
-// Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+code_object_arch_layout = dict.fromkeys(code_object_arch_map.values()).keys()
+code_object_valid_subarch = set(el[1] for el in code_object_arch_map)
+
+
+code_object_wrapper_magic = ord("#")
+
+
+header = """// SPDX-License-Identifier: MIT
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
-#include <unordered_map>
+
+#include "aiter_hip_common.h"
 
 """
+
+
+def create_co_objects_column(row, args, arch):
+    co_objects = []
+    base_dir = f"{this_dir}/{arch}/{args.module}/"
+    for el in glob.glob(
+        f"{this_dir}/{arch}/{args.module}/**/{row['co_name']}", recursive=True
+    ):
+        subarch_dir = os.path.relpath(os.path.dirname(el), base_dir)
+        subarch = "" if subarch_dir not in code_object_valid_subarch else subarch_dir
+        co_objects.append({"file_path": el, "arch": (arch, subarch)})
+    return co_objects
+
+
+def generate_struct_definition(args, dfs):
+    fields = []
+    master = dfs[0]
+    for column in master.columns:
+        if (
+            column == "co_objects"
+            or column == "co_name"
+            or column == "knl_name"
+            or column == "arch"
+        ):
+            continue
+        if pd.api.types.is_integer_dtype(master[column]):
+            min_int = min(df[column].min() if not df.empty else 0 for df in dfs)
+            max_int = max(df[column].max() if not df.empty else 0 for df in dfs)
+
+            mag_int = max(abs(min_int), abs(max_int)) * (-1 if min_int < 0 else 1)
+            container_type = np.min_scalar_type(mag_int)
+            bit_length = max(1, int(mag_int).bit_length() + int(mag_int < 0))
+            fields.append(f"{container_type}_t {column}: {bit_length};")
+            continue
+        else:
+            max_len = max(
+                df[column].str.len().max() if not df.empty else 1 for df in dfs
+            )
+
+            min_len = min(
+                df[column].str.len().min() if not df.empty else max_len for df in dfs
+            )
+
+            fields.append(f"FixedString<{min_len}, {max_len}> {column};")
+            continue
+    fields_str = "\n".join(fields)
+    return f"""struct __attribute__((packed)) {args.module}Config {{
+{fields_str}
+}};
+"""
+
+
+def generate_code_object_data_with_len(co_objects):
+    data = None
+    debug_force_code_object_wrapper = True
+    if (
+        len(co_objects) == 1
+        and co_objects[0]["arch"][0] in archs
+        and not debug_force_code_object_wrapper
+    ):
+        data = np.fromfile(co_objects[0]["file_path"], dtype=np.uint8)
+    else:
+        object_map = dict()
+        for co_object in co_objects:
+            if co_object["arch"][0] in archs:
+                key = code_object_arch_map.get(co_object["arch"])
+                if key is None:
+                    raise ValueError(
+                        f"arch {co_object['arch']} not supported for code object wrapper"
+                    )
+                if key in object_map:
+                    raise ValueError(f"duplicate key {key} found")
+                object_map[key] = np.fromfile(co_object["file_path"], dtype=np.uint8)
+        offsets = []
+        current_offset = 0
+        for key in code_object_arch_layout:
+            if key in object_map:
+                offsets.append(current_offset)
+                current_offset += len(object_map[key])
+            else:
+                offsets.append(-1)
+        data = np.concatenate(
+            [
+                np.array([code_object_wrapper_magic], dtype=np.uint8),
+                np.array(offsets, dtype=np.int32).view(dtype=np.uint8),
+                *(
+                    object_map[key]
+                    for key in code_object_arch_layout
+                    if key in object_map
+                ),
+            ]
+        )
+
+    return len(data), ", ".join(map("0x{:02x}".format, data))
+
+
+def generate_common():
+    return "\n".join(
+        [
+            header,
+            f"static_assert(AiterAsmKernelCodeObjectWrapper::magic == {code_object_wrapper_magic});",
+            f"static_assert(sizeof(AiterAsmKernelCodeObjectWrapper) == {1 + 4 * len(code_object_arch_layout)});",
+            *(
+                f"static_assert(offsetof(AiterAsmKernelCodeObjectWrapper,{arch}_offset) == {1 + 4 * i});"
+                for i, arch in enumerate(code_object_arch_layout)
+            ),
+            "\n",
+        ]
+    )
+
+
+def generate_configs(args):
+    content = ""
+
+    csv_groups = defaultdict(list)
+    for arch in archs_supported:
+        for el in glob.glob(
+            f"{this_dir}/{arch}/{args.module}/**/*.csv", recursive=True
+        ):
+            cfgname = os.path.basename(el).split(".")[0]
+            csv_groups[cfgname].append({"file_path": el, "arch": arch})
+
+    ## deal with same name csv
+    cfgs = []
+    for cfgname, file_info_list in csv_groups.items():
+        dfs = []
+        for file_info in file_info_list:
+            single_file = file_info["file_path"]
+            arch = file_info["arch"]
+            df = pd.read_csv(single_file)
+            # check headers
+            headers_list = df.columns.tolist()
+            required_columns = {"knl_name", "co_name"}
+            if not required_columns.issubset(headers_list):
+                missing = required_columns - set(headers_list)
+                raise ValueError(
+                    f"Invalid assembly CSV format -- {single_file}. Missing required columns: {', '.join(missing)}"
+                )
+
+            df["arch"] = arch  # add arch into df
+            if arch in archs:
+                df["co_objects"] = df.apply(
+                    create_co_objects_column, axis=1, args=(args, arch)
+                )
+            else:
+                df["co_objects"] = df.apply(lambda _: [], axis=1)
+            dfs.append(df)
+
+        df = pd.concat(dfs, ignore_index=True).fillna(0).infer_objects(copy=False)
+        if cfgs:
+            df = df[cfgs[0]["table"].columns]  # make sure all have same columns
+        cfgs.append({"cfgname": cfgname, "table": df})
+
+    if cfgs:
+        dfs = [el["table"] for el in cfgs]
+        content = generate_struct_definition(args, dfs)
+        for df in dfs:
+            df.drop(df[~df["arch"].isin(archs)].index, inplace=True)
+            df.reset_index(drop=True, inplace=True)
+        offsets = []
+        kernel_data = []
+        offset = 0
+        for df in dfs:
+            for _, knl_name, co_objects in df[["knl_name", "co_objects"]].itertuples():
+                co_len, co_data = generate_code_object_data_with_len(co_objects)
+                offsets.append(offset)
+                kernel_data.append(f"0x{len(knl_name):02x}")
+                kernel_data.append(
+                    ", ".join(f"0x{b:02x}" for b in knl_name.encode("utf8"))
+                )
+                kernel_data.append("0x00")
+                kernel_data.append(co_data)
+                offset += len(knl_name) + 2 + co_len
+
+        content += "\n".join(
+            [
+                f"constexpr uint8_t kernels_descriptors_{args.module}[] = {{{', '.join(kernel_data)}}};",
+                f"constexpr uint32_t kernels_descriptor_offsets_{args.module}[] = {{{', '.join(str(off) for off in offsets)}}};",
+                f"AiterAsmKernel<> kernels_{args.module}[{len(offsets)}] = {{}};",
+                f"using CFG = AiterAsmKernelConfigMap<{args.module}Config, kernels_{args.module}, kernels_descriptor_offsets_{args.module}, kernels_descriptors_{args.module}>;\n",
+            ]
+        )
+
+        tables = []
+        bias = 0
+
+        for cfg in cfgs:
+            df = cfg["table"]
+            offsets = []
+
+            for arch in df["arch"].unique():
+                mask = df["arch"] == arch
+                first_idx = df.index[mask].min()
+                last_idx = df.index[mask].max() + 1
+                offsets.append((arch, first_idx, last_idx))
+
+            if not df.empty:
+                df["comment"] = df.apply(
+                    lambda row: f"/* {row.name + bias} {row['arch']} {row['knl_name']} {row['co_name']} */",
+                    axis=1,
+                )
+            df = df.drop(["co_objects", "knl_name", "co_name", "arch"], axis=1)
+
+            for col in df.select_dtypes(exclude=["integer"]).columns:
+                if col != "comment":
+                    df[col] = '"' + df[col].astype(str) + '"'
+
+            df = df.astype(str)
+
+            comment = (
+                f"/* {', '.join(col for col in df.columns if col != 'comment')} */"
+            )
+
+            cfgname = cfg["cfgname"]
+            entries_str = ", \n".join(
+                f"{{{', '.join(row)}}}" for row in df.itertuples(index=False)
+            )
+            tables.append(
+                f"""constexpr AiterAsmKernelConfigMapSized<CFG, {len(df)}> cfg_{cfgname} = {{
+{{.kernel_index_bias = {bias}, .entry_count = {len(df)}, .per_arch_offsets = {{{", ".join(f"[static_cast<int>(GPUArchId::{el[0]})] = {{{el[1]}, {el[2]}}}" for el in offsets)}}}}},
+/*.entries = */{{
+{comment}
+{entries_str}}},
+}};"""
+            )
+            bias += len(df)
+
+        content += "\n".join(tables)
+    with open(f"{args.output_dir}/asm_{args.module}_configs.hpp", "w") as f:
+        f.write(generate_common())
+        f.write(content)
+
+
+def generate_code_objects(args):
+    filters = (
+        [f"{this_dir}/{{arch}}/{glob_pat}" for glob_pat in args.glob]
+        if args.glob
+        else [f"{this_dir}/{{arch}}/{args.module}/**/*.co"]
+    )
+    base = (
+        f"{this_dir}/{{arch}}/" if args.glob else f"{this_dir}/{{arch}}/{args.module}/"
+    )
+    co_groups = defaultdict(list)
+    for arch in archs_supported:
+        base_dir = base.format(arch=arch)
+        for el in set(
+            chain.from_iterable(
+                glob.glob(filter.format(arch=arch), recursive=True)
+                for filter in filters
+            )
+        ):
+            co_name = os.path.basename(el).split(".")[0]
+            subarch_dir = os.path.relpath(os.path.dirname(el), base_dir)
+            subarch = (
+                "" if subarch_dir not in code_object_valid_subarch else subarch_dir
+            )
+            co_groups[co_name].append({"file_path": el, "arch": (arch, subarch)})
+
+    content = "\n".join(
+        [
+            f"constexpr uint8_t {co_name}_co[] = {{{generate_code_object_data_with_len(co_objects)[1]}}};"
+            for co_name, co_objects in co_groups.items()
+        ]
+    )
+
+    with open(f"{args.output_dir}/asm_{args.module}_code_objects.hpp", "w") as f:
+        f.write(generate_common())
+        f.write(content)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="generate",
-        description="gen API for asm Bf16_gemm kernel",
+        description="gen API for asm kernel",
+    )
+    mode_group = parser.add_mutually_exclusive_group()
+
+    mode_group.add_argument(
+        "--configs",
+        action="store_const",
+        const="configs",
+        dest="mode",
+        default="configs",
+        help="Generate config tables header file",
+    )
+
+    mode_group.add_argument(
+        "--code-objects",
+        action="store_const",
+        const="code_objects",
+        dest="mode",
+        help="Generate kernel co header file",
     )
     parser.add_argument(
         "-m",
@@ -47,97 +348,17 @@ if __name__ == "__main__":
         required=False,
         help="write all the blobs into a directory",
     )
+    parser.add_argument(
+        "--glob",
+        required=False,
+        action="append",
+        help="glob match for objects when generating blobs header ",
+    )
     args = parser.parse_args()
-    cfgs = []
+    if args.glob and args.mode != "code_objects":
+        parser.error("Argument --glob is only allowed with --code-objects")
 
-    csv_groups = defaultdict(list)
-    for arch in archs_supported:
-        for el in glob.glob(
-            f"{this_dir}/{arch}/{args.module}/**/*.csv", recursive=True
-        ):
-            cfgname = os.path.basename(el).split(".")[0]
-            csv_groups[cfgname].append({"file_path": el, "arch": arch})
-
-    ## deal with same name csv
-    cfgs = []
-    have_get_header = False
-    for cfgname, file_info_list in csv_groups.items():
-        dfs = []
-        for file_info in file_info_list:
-            single_file = file_info["file_path"]
-            arch = file_info["arch"]
-            df = pd.read_csv(single_file)
-            # check headers
-            headers_list = df.columns.tolist()
-            required_columns = {"knl_name", "co_name"}
-            if not required_columns.issubset(headers_list):
-                missing = required_columns - set(headers_list)
-                print(
-                    f"ERROR: Invalid assembly CSV format -- {single_file}. Missing required columns: {', '.join(missing)}"
-                )
-                sys.exit(1)
-            df["arch"] = arch  # add arch into df
-            dfs.append(df)
-        if dfs:
-            relpath = os.path.relpath(
-                os.path.dirname(single_file), f"{this_dir}/{arch}"
-            )
-            combine_df = (
-                pd.concat(dfs, ignore_index=True).fillna(0).infer_objects(copy=False)
-            )
-            if not have_get_header:
-                headers_list = combine_df.columns.tolist()
-                required_columns = {"knl_name", "co_name", "arch"}
-                other_columns = [
-                    col for col in headers_list if col not in required_columns
-                ]
-                other_columns_comma = ", ".join(other_columns)
-                sample_row = combine_df.iloc[0]
-                other_columns_cpp_def = "\n".join(
-                    [
-                        f"    {'int' if isinstance(sample_row[col], (int, float, np.integer)) else 'std::string'} {col};"
-                        for col in other_columns
-                    ]
-                )
-                content += f"""
-#define ADD_CFG({other_columns_comma}, arch, path, knl_name, co_name)         \\
-    {{                                         \\
-        arch knl_name, {{ knl_name, path co_name, arch, {other_columns_comma} }}         \\
-    }}
-
-struct {args.module}Config
-{{
-    std::string knl_name;
-    std::string co_name;
-    std::string arch;
-{other_columns_cpp_def}
-}};
-
-using CFG = std::unordered_map<std::string, {args.module}Config>;
-
-"""
-                have_get_header = True
-            cfg = [
-                "ADD_CFG("
-                + ", ".join(
-                    (
-                        f"{int(getattr(row, col)):>4}"
-                        if str(getattr(row, col)).replace(".", "", 1).isdigit()
-                        else f'"{getattr(row, col)}"'
-                    )
-                    for col in other_columns
-                )
-                + f', "{row.arch}", "{relpath}/", "{row.knl_name}", "{row.co_name}"),'
-                for row in combine_df.itertuples(index=False)
-                if row.arch in archs
-            ]
-            cfg_txt = "\n    ".join(cfg) + "\n"
-
-            txt = f"""static CFG cfg_{cfgname} = {{
-    {cfg_txt}}};"""
-            cfgs.append(txt)
-
-    content += "\n".join(cfgs) + "\n"
-
-    with open(f"{args.output_dir}/asm_{args.module}_configs.hpp", "w") as f:
-        f.write(content)
+    if args.mode == "code_objects":
+        generate_code_objects(args)
+    else:
+        generate_configs(args)

--- a/op_tests/cpp/mha/README.md
+++ b/op_tests/cpp/mha/README.md
@@ -24,10 +24,6 @@ Device library `libmha_fwd.so` and `libmha_bwd.so` will be built under current f
 
 To benchmark asm kernel, try following commands:
 ```
-
-# Set this env before you run
-export AITER_ASM_DIR={path_to_aiter}/hsa/
-
 # fwd_v3
 ./benchmark_mha_fwd -prec=bf16 -b=1 -h=64 -d=128 -s=8192 -iperm=1 -operm=1 -mask=1 -lse=1 -fwd_v3=1 -mode=0 -kname=1 -v=0
 


### PR DESCRIPTION
## Motivation

Makes sure that user doesn't have to distribute kernels nor set up AITER_ASM_DIR.

## Technical Details

Embed code objects into binary. Use hipRegisterFatBinary to make it seamlessly work on multiple gpus. Make CFG tables read-only and AiterAsmKernels statically allocated.

## Test Plan

Selected tests from op_tests on gfx942
