### PR TITLE
Temp skip batch prefill tests for causal/logits=False

### DIFF
--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -726,6 +726,14 @@ def test_batch_prefill(
         is_input_fp8, dtype, causal, kv_len, qo_len, contiguous_kv
     ):
         return {"status": "skipped"}
+
+    # Temporarily skip test for causal=True, logits_soft_cap=0.0
+    if skip_test_if(
+        causal and logits_soft_cap == 0.0,
+        "Temporarily skip test for causal=True, logits_soft_cap=0.0",
+    ):
+        return {"status": "skipped"}
+
     if check_layout_skip_conditions(
         kvcache_layout,
         head_dim,


### PR DESCRIPTION
Temporarily skip specific batch prefill test cases (causal=True, logits_soft_cap=0.0). 
This is due to a known issue with the ROCm 7.2 compiler in certain batch prefill kernel scenarios.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
