### PR TITLE
CI: Temporarily switch Aiter tests back to ROCm 7.1 as CK does not support 7.2

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
+  # TODO: Revert to rocm/pytorch:latest once CK adds ROCm 7.2 support
   DOCKER_IMAGE: "rocm/pytorch:latest@sha256:683765a52c61341e1674fe730ab3be861a444a45a36c0a8caae7653a08a0e208"
 
 jobs:


### PR DESCRIPTION
Temporarily switch Aiter tests back to ROCm 7.1 as CK does not support 7.2, will upgrade again once CK adds 7.2 support.