### PR TITLE
[FMHA] Add Architecture safety check for enable_gluon_pa_mqa_logits

### DIFF
--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -56,7 +56,9 @@ if triton_version >= Version("3.5.0"):
         _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx,
     )
 
-    enable_gluon_pa_mqa_logits = True
+    gluon_pa_mqa_logits_supported_arch = {"gfx940", "gfx941", "gfx942"}
+    gfx_version = get_gfx()
+    enable_gluon_pa_mqa_logits = gfx_version in gluon_pa_mqa_logits_supported_arch
     enable_jit_gluon_pa_mqa_logits_kernel = not enable_aot_gluon_pa_mqa_logits
 else:
     from triton.compiler import ASTSource


### PR DESCRIPTION
## Motivation

Currently, `gluon_pa_mqa_logits` is only supported on CDNA3, This PR adds a safety check to ensure we do not break when we have Triton Version >3.5.0 and is not on CDNA3 GPUs.

This is evident when using latest aiter on CDNA4 kernel on SGLang. Which required a workaround fix in https://github.com/sgl-project/sglang/pull/17962

