### PR TITLE
revert use ck rmsnorm because of residual_out accuracy

### DIFF
--- a/aiter/ops/rmsnorm.py
+++ b/aiter/ops/rmsnorm.py
@@ -82,18 +82,15 @@ def rmsnorm2d_fwd_with_add(
     epsilon: float,
     use_model_sensitive_rmsnorm: int = 0,
 ) -> None:
-    if use_model_sensitive_rmsnorm > 0 or input.shape[-1] > 8192:
-        rmsnorm2d_fwd_with_add_ck(
-            out,
-            input,
-            residual_in,
-            residual_out,
-            weight,
-            epsilon,
-            use_model_sensitive_rmsnorm,
-        )
-    else:
-        add_rmsnorm(out, input, residual_in, residual_out, weight, epsilon)
+    rmsnorm2d_fwd_with_add_ck(
+        out,
+        input,
+        residual_in,
+        residual_out,
+        weight,
+        epsilon,
+        use_model_sensitive_rmsnorm,
+    )
 
 
 @compile_ops("module_rmsnorm")
@@ -155,31 +152,18 @@ def rmsnorm2d_fwd_with_add_dynamicquant(
     group_size: int = 0,
     shuffle_scale: bool = False,
 ) -> None:
-    if use_model_sensitive_rmsnorm > 0 or input.shape[-1] > 8192:
-        assert group_size == 0, "group_size is not supported for ck rmsnorm"
-        assert not shuffle_scale, "shuffle_scale is not supported for ck rmsnorm"
-        rmsnorm2d_fwd_with_add_dynamicquant_ck(
-            out,
-            input,
-            residual_in,
-            residual_out,
-            yscale,
-            weight,
-            epsilon,
-            use_model_sensitive_rmsnorm,
-        )
-    else:
-        add_rmsnorm_quant(
-            out,
-            input,
-            residual_in,
-            residual_out,
-            yscale,
-            weight,
-            epsilon,
-            group_size,
-            shuffle_scale,
-        )
+    assert group_size == 0, "group_size is not supported for ck rmsnorm"
+    assert not shuffle_scale, "shuffle_scale is not supported for ck rmsnorm"
+    rmsnorm2d_fwd_with_add_dynamicquant_ck(
+        out,
+        input,
+        residual_in,
+        residual_out,
+        yscale,
+        weight,
+        epsilon,
+        use_model_sensitive_rmsnorm,
+    )
 
 
 @compile_ops(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
