### PR TITLE
add rmsnorm CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT compile config

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -538,7 +538,9 @@
             "f'{AITER_CSRC_DIR}/pybind/rmsnorm_pybind.cu'"
         ],
         "flags_extra_cc": [],
-        "flags_extra_hip": [],
+        "flags_extra_hip": [
+            "f'-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={os.environ.get(\"CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\", 2)}'"
+        ],
         "extra_ldflags": "None",
         "extra_include": [
             "f'{CK_DIR}/example/ck_tile/10_rmsnorm2d'"


### PR DESCRIPTION
## Summary

Add compile-time configuration for FP32 to BF16 rounding mode in RMSNorm CK kernel.

This PR allows users to control the FP32 to BF16 conversion behavior in CK RMSNorm kernel via the `CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT` environment variable.

## Changes

- Add `-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT` compile flag to `module_rmsnorm` in `optCompilerConfig.json`
- Default value is `2` (Truncate mode, same as CK default)

## Rounding Mode Options

| Value | Mode | Description |
|-------|------|-------------|
| 0 | STANDARD | RNE (Round to Nearest Even) - software implementation |
| 1 | TRUNCATE_WITH_NAN | Truncate with NaN preservation |
| 2 | TRUNCATE | Fast truncate (default) |
| 3 | STANDARD_ASM | RNE - optimized asm implementation |
| 4 | RTA_ASM | Round to Nearest Away - asm implementation |

## Usage

To use RNE (Round to Nearest Even) rounding mode:

```bash
export CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT=0
# rebuild aiter
```

## Motivation

Different rounding modes may affect numerical precision in model inference. RNE is the IEEE 754 default and provides better numerical stability for precision-sensitive workloads.
