### PR TITLE
Add `FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON` env var support

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -5,8 +5,9 @@ import triton.language as tl
 from typing import Literal, Optional
 from .common import compute_alibi_block, compute_fp8_scaling_factors, apply_rotary
 from .utils import (
-    DEBUG,
     AUTOTUNE,
+    CONF_OVERRIDE,
+    DEBUG,
     get_arch,
     is_fp8,
 )
@@ -31,6 +32,9 @@ def get_fwd_prefill_configs(autotune: bool):
     #   - RDNA: BLOCK_N=32
     # See _get_block_size_n_triton() in test_flash_attn_triton_amd.py
     if not autotune:
+        if CONF_OVERRIDE:
+            return [CONF_OVERRIDE]
+
         arch = get_arch()
         if arch.name == "gfx950":
             return [

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
@@ -10,11 +10,16 @@ This module contains essential runtime utilities:
 
 import functools
 import os
+import json
+import logging
 from dataclasses import dataclass
 from typing import Literal, Optional, Union
 
 import torch
 import triton
+
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     # Runtime info
@@ -106,6 +111,23 @@ AUTOTUNE = os.environ.get("FLASH_ATTENTION_TRITON_AMD_AUTOTUNE", "0").lower() in
     "true",
     "yes",
 )
+
+# User override config json.
+# Note: Ignored if FLASH_ATTENTION_TRITON_AMD_AUTOTUNE is enabled.
+#
+# e.g. FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":32,"BLOCK_N":32,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":4}'
+CONF_OVERRIDE = None
+try:
+    conf_json = os.getenv("FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON")
+    if conf_json:
+        conf = json.loads(conf_json)
+        CONF_OVERRIDE = triton.Config(
+            conf,
+            num_stages=conf.pop("num_stages", 1),
+            num_warps=conf.pop("num_warps", 4),
+        )
+except Exception as e:
+    logger.warning(f'FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON parse error: {e}')
 
 # Unified debug level:
 #   0 = off (default)


### PR DESCRIPTION
Add an env var for configuring `attn_fwd` triton.Config. This allows setting of more optimal config without having to enable autotuning, which has issues.

## Motivation

With autotuning disabled the current default configs are sub-optimal, at least for my gfx1100 but probably for other cards too.

I get roughly 2x faster wan2.2 workflow performance using config `FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":128,"BLOCK_N":64,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":8}'`

Autotuning itself is very slow to run (e.g. takes 82 minutes) and needs to re-run on any param change (it also isn't persisting maybe?). So it is helpful to be able to override the !autotune config.

## Technical Details

Relates to https://github.com/Dao-AILab/flash-attention/pull/2239 I raised it here too since it looks like your planning on having this code here rather than in flash-attention repo.

## Test Plan

Manual tests of https://github.com/Dao-AILab/flash-attention/pull/2239

## Test Result

:white_check_mark: 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
