### PR TITLE
CI: Add parallel GPU test runner for triton tests

### DIFF
--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -136,7 +136,7 @@ jobs:
           echo "Running Triton Tests..."
           docker exec -w /workspace triton_test mkdir -p test-reports
           docker exec -w /workspace triton_test bash op_tests/run_triton_tests_parallel.sh \
-            --ngpus 1 -v --junit-dir test-reports --test-dir ${TRITON_TEST}
+            --ngpus 1 -v --junit-dir test-reports --test-dir "${TRITON_TEST%/}"
 
       - name: Upload test logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add `op_tests/run_triton_tests_parallel.sh` that distributes 66 triton test files across available GPUs using LPT (Longest Processing Time First) bin-packing based on measured per-file timings
- With 8 GPUs, projected wall time drops from **~55 min to ~10 min** (~5.5x speedup)
- CI workflow updated to use the new script with `--ngpus 1` for backward compatibility on the current 1-GPU runner

## Details
The script:
- Auto-detects available GPUs via `rocm-smi` or accepts `--ngpus N`
- Uses hardcoded timing measurements for 30 known-slow files; defaults to 15s for the rest
- Runs one `pytest` process per GPU with `HIP_VISIBLE_DEVICES=N`
- Supports `--junit-dir` for per-GPU JUnit XML reports
- Supports `--dry-run` to preview GPU assignments without running tests
- Prints per-GPU pass/fail summary and full logs only for failed GPUs
- Exit 0 only if all GPUs pass

To enable multi-GPU parallelism, change `--ngpus 1` to `--ngpus 8` (or remove the flag for auto-detection) in the CI workflow.

## Test plan
- [x] `--dry-run` with 1, 4, and 8 GPUs shows correct load-balanced assignments
- [ ] Run on 1-GPU runner to verify backward compatibility (no behavior change)
- [ ] Run on 8-GPU runner to validate parallel execution and speedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)