### PR TITLE
Add core operator documentation guides and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # aiter
 ![image](https://github.com/user-attachments/assets/9457804f-77cd-44b0-a088-992e4b9971c6)
 
-
-AITER is AMD’s centralized repository that support various of high performance AI operators for AI workloads acceleration, where a good unified place for all the customer operator-level requests, which can match different customers' needs. Developers can focus on operators, and let the customers integrate this op collection into their own private/public/whatever framework.
- 
+AITER is AMD's centralized repository that supports various high-performance AI operators for accelerating AI workloads. It provides a unified place for all customer operator-level requests, helping to match different customers' needs. Developers can focus on implementing operators, while customers integrate this operator collection into their own private, public, or custom frameworks.
 
 Some summary of the features:
 * C++ level API
@@ -11,52 +9,62 @@ Some summary of the features:
 * The underneath kernel could come from triton/ck/asm
 * Not just inference kernels, but also training kernels and GEMM+communication kernels—allowing for workarounds in any kernel-framework combination for any architecture limitation.
 
-
-
 ## Installation
-```
+
+```bash
 git clone --recursive https://github.com/ROCm/aiter.git
 cd aiter
-python3 setup.py develop
 ```
 
-If you happen to forget the `--recursive` during `clone`, you can use the following command after `cd aiter`
-```
+If you forgot `--recursive` during clone:
+```bash
 git submodule sync && git submodule update --init --recursive
 ```
 
+### Development Mode (JIT)
 
-### Triton-based Communication (Iris)
-
-AITER supports GPU-initiated communication using the [Iris library](https://github.com/ROCm/iris). This enables high-performance Triton-based communication primitives like reduce-scatter and all-gather.
-
-**Installation**
-
-Install with Triton communication support:
-
+Kernels are compiled on first use — fastest to get started:
 ```bash
-# Install AITER with Triton communication dependencies
+python3 setup.py develop
+```
+
+### Install with Precompiled Kernels
+
+Precompile kernels at install time so there is no JIT overhead at runtime:
+```bash
+PREBUILD_KERNELS=2 GPU_ARCHS="gfx942" python3 setup.py install
+```
+
+| Variable | Description |
+|---|---|
+| `GPU_ARCHS` | Target GPU architecture(s), semicolon-separated. Use `"native"` to auto-detect. Common values: `gfx942` (MI300X), `gfx950` (MI350X), `gfx90a` (MI250X). Multi-target example: `"gfx942;gfx950"` |
+| `PREBUILD_KERNELS` | `0` — no precompilation (JIT only, default). `1` — precompile core kernels (excludes tuning and most MHA variants). `2` — precompile inference kernels (excludes backward and tuning). `3` — precompile MHA kernels only (minimal build). |
+| `MAX_JOBS` | Max parallel compilation threads (auto-calculated from CPU cores and memory if not set) |
+
+### Triton Communication Support (Optional)
+
+For multi-GPU communication primitives (reduce-scatter, all-gather) using the [Iris](https://github.com/ROCm/iris) library:
+```bash
 pip install -e .
 pip install -r requirements-triton-comms.txt
- ```
+```
+See the [Triton Comms Guide](docs/triton_comms.md) for usage details.
 
-For more details, see [docs/triton_comms.md](docs/triton_comms.md).
+## Supported Operators
 
-## Run operators supported by aiter
+| **Operator** | **Description** | **Guide** |
+|---|---|---|
+| Attention (MHA, PA) | Multi-Head Attention, Paged Attention (decode & prefill), Unified Attention, chunked prefill, GQA/MQA | [Attention Guide](docs/attention_variants_guide.md) |
+| MLA | Multi-head Latent Attention — standard decode, persistent decode, prefill, sparse MLA, fused ops | [MLA Guide](docs/mla_kernel_support_report.md) |
+| Fused MOE | Mixture of Experts — A8W8, A16W8, FP8 block-scale, MXFP4, 2-stage MOE, topK routing | [MOE Guide](docs/moe_variants_guide.md) |
+| GEMM | Matrix multiply (A8W8, A16W16, A4W4, batched), DeepGEMM, Triton FFN fusions, CSV-based tuning | [GEMM Guide](docs/gemm_variants_guide.md) |
+| Quantization | BF16/FP16 to FP8/MXFP4/INT4, per-tensor/token/block strategies, fused quant ops, SmoothQuant | [Quantization Guide](docs/quantization_guide.md) |
+| Normalization (RMSNorm, LayerNorm) | RMSNorm, LayerNorm, GroupNorm — fused add/quant variants, SmoothQuant, distributed fusion | [Normalization Guide](docs/normalization_guide.md) |
+| RoPE | Rotary Position Embedding — SBHD/THD/2D/3D formats, NeoX & GPT-J styles, scaling methods | [RoPE Guide](docs/rope_guide.md) |
+| KV-Cache | Paged/flash/MLA cache layouts, quantized cache (FP8/INT8), fused RoPE + cache write | [KV-Cache Guide](docs/kv_cache_guide.md) |
+| Elementwise & Activations | SiLU/GELU/sigmoid/tanh, SwiGLU gates, fused activation + quantize, binary arithmetic (+−×÷) | [Elementwise Guide](docs/elementwise_activation_guide.md) |
+| Sampling | Greedy, random, mixed, top-k, top-p token sampling for LLM generation | [Sampling Guide](docs/sampling_guide.md) |
 
-There are number of op test, you can run them with: `python3 op_tests/test_layernorm2d.py`
-|  **Ops**                      | **Description**                                                                                                                                                   |
-|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|ELEMENT WISE                   | ops: + - * /                                                                                                                                                      |
-|SIGMOID                        | (x) = 1 / (1 + e^-x)                                                                                                                                              |
-|AllREDUCE                      | Reduce + Broadcast                                                                                                                                                |
-|KVCACHE                        | W_K W_V                                                                                                                                                           |
-|MHA                            | Multi-Head Attention                                                                                                                                              |
-|MLA                            | Multi-head Latent Attention with [KV-Cache layout](https://docs.flashinfer.ai/tutorials/kv_layout.html#page-table-layout )                                        |
-|PA                             | Paged Attention                                                                                                                                                   |
-|FusedMoe                       | Mixture of Experts                                                                                                                                                |
-|QUANT                          | BF16/FP16 -> FP8/INT4                                                                                                                                             |
-|RMSNORM                        | root mean square                                                                                                                                                  |
-|LAYERNORM                      | x = (x - u) / (σ2 + ϵ) e*0.5                                                                                                                                      |
-|ROPE                           | Rotary Position Embedding                                                                                                                                         |
-|GEMM                           | D=αAβB+C                                                                                                                                                          |
+Each guide covers available variants, backend support (ASM / CK / Triton), Python API examples, and performance tuning advice.
+
+Run operator tests with: `python3 op_tests/<test_file>.py` (e.g. `python3 op_tests/test_pa.py`)

--- a/docs/attention_variants_guide.md
+++ b/docs/attention_variants_guide.md
@@ -1,0 +1,413 @@
+# AITER Attention Variants & Backend Guide
+
+This guide documents all attention variants available in AITER, their backend support, and how to choose the right one for your use case.
+
+---
+
+## Quick Reference: Which Attention Should I Use?
+
+| Use Case | Recommended Variant | Backend | Why |
+|----------|-------------------|---------|-----|
+| **Standard training/inference** | MHA (Flash Attention) | CK (C++) | Mature, supports fwd+bwd, broadest dtype support |
+| **LLM inference (decode)** | Paged Attention Decode | ASM | Best latency, memory-efficient KV cache |
+| **LLM inference (prefill)** | PA Prefill / MHA varlen | CK (C++) or Triton | High throughput for long contexts |
+| **DeepSeek-style models** | MLA | ASM (decode) + CK (prefill) | Purpose-built for latent attention |
+| **Mixed prefill+decode batches** | Unified Attention | Triton | Handles heterogeneous batches in one kernel |
+| **Sparse/TopK attention** | Sparse MLA | Triton | Only backend with sparse support |
+| **Prototyping / new GPUs** | Any Triton variant | Triton | Portable, easy to modify |
+
+---
+
+## 1. Multi-Head Attention (MHA / Flash Attention)
+
+Standard scaled dot-product attention with multiple parallel heads. This is the foundational attention operation used in most transformer models.
+
+### Backend Support
+
+| Feature | CK (C++) | Triton | ASM |
+|---------|:---:|:---:|:---:|
+| **Forward pass** | Yes | Yes | Yes |
+| **Backward pass** | Yes | Yes (varlen) | Yes |
+| **BF16** | Yes | Yes | Yes |
+| **FP16** | Yes | Yes | Yes |
+| **FP8** | Yes | Yes | - |
+| **Causal masking** | Yes | Yes | Yes |
+| **ALiBi bias** | Yes | Yes | - |
+| **Sliding window** | Yes | Yes | - |
+| **Dropout** | Yes | Yes | - |
+| **Variable-length (varlen)** | Yes | Yes | Yes |
+| **GQA (any ratio)** | Yes | Yes | Yes |
+| **GFX942 (MI300X)** | Yes | Yes | Yes |
+| **GFX950 (MI350)** | Yes | Yes | Limited |
+
+### Key API Functions
+
+```python
+from aiter.ops.triton.attention.mha import (
+    flash_attn_func,              # Standard forward
+    flash_attn_varlen_func,       # Variable-length forward
+)
+from aiter.ops.triton.attention.mha_v3 import (
+    flash_attn_fp8_func,          # FP8 forward
+    flash_attn_varlen_fp8_func,   # FP8 variable-length forward
+)
+```
+
+### When to Use
+
+- General-purpose attention for training and inference
+- When you need backward pass support
+- When you need ALiBi, sliding window, or dropout
+- Models: GPT, LLaMA, Mistral, Qwen, and most standard transformers
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/mha.py` | Top-level MHA operations |
+| `aiter/ops/triton/attention/mha.py` | Triton wrapper |
+| `aiter/ops/triton/_triton_kernels/attention/mha.py` | Triton kernel implementation |
+| `csrc/cpp_itfs/mha_fwd.cu` | CK forward pass |
+| `csrc/cpp_itfs/mha_bwd.cu` | CK backward pass |
+| `csrc/py_itfs_cu/asm_mha_bwd.cu` | ASM backward pass |
+| `csrc/py_itfs_cu/asm_mha_varlen_bwd.cu` | ASM variable-length backward pass |
+
+---
+
+## 2. Paged Attention (PA)
+
+Memory-efficient attention for LLM inference with block-wise KV cache storage. Eliminates memory fragmentation by storing KV cache in fixed-size pages.
+
+### Two Execution Phases
+
+| Phase | Description | Optimized For |
+|-------|-------------|---------------|
+| **PA Decode** | Single-token generation (autoregressive) | Latency (one token at a time) |
+| **PA Prefill** | Multi-token context processing | Throughput (long prompt ingestion) |
+
+### Backend Support
+
+| Feature | CK (C++) | Triton | ASM (GFX942) |
+|---------|:---:|:---:|:---:|
+| **Decode V1** (short seq) | Yes | Yes | Yes |
+| **Decode V2** (long seq, partitioned) | Yes | Yes | Yes |
+| **Prefill** | Yes | Yes | - |
+| **Extend (prefix caching)** | Yes | Yes | - |
+| **Ragged layout** | Yes | - | - |
+| **Persistent scheduling** | - | - | Yes |
+| **Multi-Token Processing (MTP)** | - | - | Yes |
+| **BF16 Q + BF16 KV** | Yes | Yes | Yes |
+| **FP16 Q + FP16 KV** | Yes | Yes | - |
+| **BF16 Q + FP8 KV** | Yes | Yes | Yes |
+| **BF16 Q + INT8 KV** | Yes | - | Yes |
+| **GQA ratios** | Any | Any | 8, 10, 16 |
+| **Block sizes** | Configurable | Configurable | 16, 1024 |
+| **GFX942 (MI300X)** | Yes | Yes | Yes |
+| **GFX950 (MI350)** | Yes | Yes | Limited |
+
+### KV Cache Quantization Methods
+
+| Method | Description | Memory Savings | Accuracy Impact |
+|--------|-------------|---------------|-----------------|
+| `NO` | No quantization (BF16/FP16) | Baseline | None |
+| `KV_8BIT_PER_TENSOR` | FP8 per-tensor scale | ~50% | Low |
+| `KV_8BIT_PER_TOKEN` | FP8 per-token scale | ~50% | Very low |
+| `KV_8BIT_PER_HEAD` | FP8/INT8 per-head scale | ~50% | Very low |
+| `KV_4BIT_PER_TOKEN` | INT4 per-token scale | ~75% | Moderate |
+
+For FP8 KV cache, three precision levels control accuracy vs speed:
+- `high_precision=0` — Fastest, lowest accuracy
+- `high_precision=1` — Balanced (default)
+- `high_precision=2` — Slowest, highest accuracy
+
+### Key API Functions
+
+```python
+from aiter.paged_attn import paged_attention_decode
+
+# Decode phase (single-token generation)
+paged_attention_decode(
+    output, query, key_cache, value_cache,
+    seq_lens, block_tables,
+    attn_scale=1.0 / math.sqrt(head_dim),
+    max_seq_len=max_context,
+    k_scale=k_quant_scale,    # optional: for quantized KV cache
+    v_scale=v_quant_scale,    # optional: for quantized KV cache
+)
+
+# Prefill phase (context processing)
+from aiter.ops.triton.attention import context_attention_fwd
+context_attention_fwd(query, key, value, output, ...)
+
+# Extend with prefix caching
+from aiter.ops.triton.attention import extend_attention_fwd
+extend_attention_fwd(query, key, value, output, ...)
+```
+
+### Automatic Kernel Selection
+
+AITER automatically selects the optimal backend based on workload:
+
+```python
+# Internal heuristic: ASM preferred for large batch * heads
+total_heads = num_seqs * num_heads
+use_asm = total_heads > 2 * num_compute_units
+```
+
+### When to Use
+
+- LLM inference serving with dynamic batching (e.g., vLLM-style)
+- When memory efficiency for KV cache is critical
+- When serving many concurrent sequences
+- Models: Any autoregressive LLM
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/paged_attn.py` | Public API |
+| `aiter/ops/attention.py` | Wrapper and dispatch logic |
+| `aiter/ops/triton/attention/pa_decode.py` | Triton decode wrapper |
+| `aiter/ops/triton/attention/pa_prefill.py` | Triton prefill wrapper |
+| `csrc/cpp_itfs/pa/pa.py` | C++ interface |
+| `hsa/gfx942/pa/` | ASM kernel binaries |
+
+---
+
+## 3. Multi-head Latent Attention (MLA)
+
+Latent projection-based attention from DeepSeek-V2/V3, which compresses KV representations into a low-rank latent space. Significantly reduces KV cache size and memory bandwidth requirements.
+
+### Backend Support
+
+| Feature | ASM | Triton | CK (C++) |
+|---------|:---:|:---:|:---:|
+| **Decode (seqlen_q=1)** | Yes (22+ kernels) | Yes | - |
+| **Decode (seqlen_q=2,4,8)** | Yes | - | - |
+| **Prefill** | Yes | - | - |
+| **Persistent scheduling** | Yes | - | - |
+| **Sparse (Top-K)** | - | Yes | - |
+| **BF16 Q x BF16 KV** | Yes | Yes | - |
+| **FP8 Q x FP8 KV** | Yes | - | - |
+| **BF16 Q x FP8 KV** | Yes | - | - |
+| **RoPE fusion** | Yes (native) | Yes (in-kernel) | - |
+| **Arbitrary GQA ratio** | No (1,16,32,64,128) | Yes | - |
+| **Page size > 1** | Yes | No (page_size=1 only) | - |
+| **GFX942 (MI300X)** | Yes | Yes | - |
+| **GFX950 (MI350)** | Yes | Yes | - |
+
+### Key API Functions
+
+```python
+from aiter.mla import mla_decode_fwd, mla_prefill_fwd
+
+# Decode (single-token generation)
+output, lse = mla_decode_fwd(
+    q, kv_buffer, o,
+    qo_indptr, kv_indptr, kv_indices, kv_last_page_lens,
+    max_seqlen_q=1, page_size=1,
+    nhead_kv=num_heads,
+    sm_scale=1.0 / math.sqrt(qk_head_dim),
+)
+
+# Prefill
+output = mla_prefill_fwd(
+    q, kv_buffer, o,
+    qo_indptr, kv_indptr, kv_indices, kv_last_page_lens,
+    max_seqlen_q=seq_len, page_size=page_size,
+    nhead_kv=num_heads,
+    sm_scale=1.0 / math.sqrt(qk_head_dim),
+)
+```
+
+### When to Use
+
+- DeepSeek-V2, DeepSeek-V3, and other MLA-based models
+- When KV cache memory is a bottleneck
+- When latent compression is part of the model architecture
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/mla.py` | Main MLA interface (decode, prefill, persistent) |
+| `aiter/ops/attention.py` | Metadata generation and reduce functions |
+| `aiter/ops/triton/attention/mla_decode_rope.py` | Triton decode with RoPE |
+| `aiter/ops/triton/attention/unified_attention_sparse_mla.py` | Triton sparse MLA |
+| `csrc/kernels/mla/` | C++ metadata and reduce kernels |
+| `hsa/gfx942/mla/` | ASM kernel binaries for MI300X |
+| `hsa/gfx950/mla/` | ASM kernel binaries for MI350 |
+
+---
+
+## 4. Unified Attention (UA)
+
+A flexible kernel that handles mixed prefill and decode batches in a single launch, avoiding the overhead of dispatching separate kernels.
+
+### Backend Support
+
+| Feature | Triton |
+|---------|:---:|
+| **Mixed prefill+decode** | Yes |
+| **BF16, FP16** | Yes |
+| **Causal masking** | Yes |
+| **Sliding window** | Yes |
+| **GQA (any ratio)** | Yes |
+| **2D kernel** (shorter seqs) | Yes |
+| **3D kernel** (longer seqs) | Yes |
+
+### Key API Functions
+
+```python
+from aiter.ops.triton.attention import unified_attention
+
+unified_attention(query, key, value, output, ...)
+```
+
+### When to Use
+
+- Serving systems with continuous batching where prefill and decode requests coexist
+- When you want to avoid separate kernel dispatches for prefill vs decode
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/attention/unified_attention.py` | Wrapper |
+| `aiter/ops/triton/_triton_kernels/attention/unified_attention.py` | Kernel |
+
+---
+
+## 5. Specialized Attention Variants
+
+### Lean Attention
+
+Persistent kernel variant for improved SM utilization with variable batch sizes.
+
+- **Backend:** Triton
+- **Features:** Paged KV cache, variable-length sequences
+- **Source:** `aiter/ops/triton/attention/lean_atten.py`
+
+### HSTU Attention (Hierarchical Softmax Truncated Unit)
+
+Attention variant with SiLU activation on attention logits instead of softmax.
+
+- **Backend:** Triton
+- **Features:** SiLU activation, variable-length, forward and backward
+- **Source:** `aiter/ops/triton/attention/hstu_attention.py`
+
+### POD Attention
+
+Specialized paged attention variant.
+
+- **Backend:** Triton
+- **Source:** `aiter/ops/triton/attention/pod_attention.py`
+
+### Chunked Prefill with Paged Decode
+
+Breaks long prefill sequences into chunks to interleave with decode operations.
+
+- **Backend:** Triton
+- **Source:** `aiter/ops/triton/attention/chunked_pa_prefill.py`
+
+### FP8 MQA Logits (DeepGemm-style)
+
+Advanced logits computation for FP8 multi-query attention.
+
+- **Backend:** Triton
+- **Source:** `aiter/ops/triton/attention/pa_mqa_logits.py`, `aiter/ops/triton/attention/fav3_sage.py`
+
+---
+
+## 6. Fused Operations with Attention
+
+AITER provides several fused kernels that combine attention-adjacent operations to reduce memory round-trips.
+
+### RoPE + Cache Fusion
+
+| Operation | Backend | Description |
+|-----------|---------|-------------|
+| `fused_qk_rope_cat_and_cache_mla` | Triton | Fuse RoPE + Q/K concatenation + KV cache write |
+| `fused_fp8_bmm_rope_cat_and_cache_mla` | Triton | + FP8 GEMM for latent projection |
+| `fused_fp4_bmm_rope_cat_and_cache_mla` | Triton | + FP4 GEMM for latent projection |
+| `fused_qk_rope_concat_and_cache_mla` | CK (C++) | CK version of RoPE + cache fusion |
+| `fused_qk_norm_rope_cache_quant` | CK (C++) | + LayerNorm + quantization |
+
+### Cache Management
+
+```python
+from aiter.ops.cache import (
+    reshape_and_cache,                        # Standard cache update
+    reshape_and_cache_flash,                  # Flash-optimized layout
+    reshape_and_cache_with_pertoken_quant,    # Per-token FP8 cache
+    reshape_and_cache_with_block_quant,       # Block-wise quantized cache
+    concat_and_cache_mla,                     # MLA-specific cache
+)
+```
+
+---
+
+## 7. Backend Comparison: How to Choose
+
+### Performance Characteristics
+
+| Backend | Strengths | Weaknesses |
+|---------|-----------|------------|
+| **ASM** | Best raw performance, hand-tuned for MI300X/MI350, forward+backward | Fixed configs, arch-specific |
+| **CK (C++)** | Good performance, forward+backward, broad dtype | Requires ROCm, arch-specific compilation |
+| **Triton** | Portable, easy to modify, flexible configs | Slightly lower peak perf than ASM |
+
+### Decision Tree
+
+```
+Is this for training (need backward pass)?
+├── Yes → Use MHA (ASM if MI300X/MI350, else CK C++)
+└── No (inference only)
+    ├── Standard transformer model?
+    │   ├── Decode phase → Paged Attention (ASM if MI300X, else Triton)
+    │   └── Prefill phase → PA Prefill (CK C++) or MHA varlen (Triton)
+    ├── DeepSeek-style (MLA)?
+    │   ├── Decode → MLA (ASM)
+    │   ├── Prefill → MLA Prefill (ASM)
+    │   └── Need sparse attention → Sparse MLA (Triton)
+    ├── Mixed prefill+decode batches?
+    │   └── Unified Attention (Triton)
+    └── New/unsupported GPU?
+        └── Any Triton variant
+```
+
+---
+
+## 8. GPU Architecture Support Summary
+
+| Attention Variant | MI300X (GFX942) | MI350 (GFX950) | Other GPUs |
+|-------------------|:---:|:---:|:---:|
+| MHA (Flash) | All backends (fwd+bwd) | CK + Triton | Triton only |
+| PA Decode | ASM + CK + Triton | CK + Triton | Triton only |
+| PA Prefill | CK + Triton | CK + Triton | Triton only |
+| MLA Decode | ASM + Triton | ASM + Triton | Triton only |
+| MLA Prefill | ASM | ASM | - |
+| Unified Attention | Triton | Triton | Triton |
+| Sparse MLA | Triton | Triton | Triton |
+
+---
+
+## 9. Test Files Reference
+
+| Test File | Covers |
+|-----------|--------|
+| `op_tests/test_mha.py` | MHA: BF16, FP16, FP8 |
+| `op_tests/test_mha_fp8.py` | MHA FP8 precision |
+| `op_tests/test_mha_varlen.py` | MHA variable-length sequences |
+| `op_tests/test_mha_varlen_fp8.py` | MHA varlen + FP8 |
+| `op_tests/test_pa.py` | PA decode + prefill, multiple dtypes |
+| `op_tests/test_pa_v1.py` | PA V1 (short sequences) |
+| `op_tests/test_pa_ps.py` | PA persistent scheduling |
+| `op_tests/test_pa_mtp.py` | PA multi-token processing |
+| `op_tests/test_pa_ragged.py` | PA ragged layout |
+| `op_tests/test_mla.py` | MLA decode |
+| `op_tests/test_mla_persistent.py` | MLA persistent mode |
+| `op_tests/test_mla_prefill_ps.py` | MLA prefill |
+| `op_tests/test_mla_sparse.py` | MLA sparse attention |
+| `op_tests/test_batch_prefill.py` | Batch prefill |
+| `op_tests/triton_tests/attention/` | All Triton attention tests |

--- a/docs/elementwise_activation_guide.md
+++ b/docs/elementwise_activation_guide.md
@@ -1,0 +1,277 @@
+# AITER Elementwise & Activation Operators Guide
+
+This guide documents all element-wise arithmetic and activation operators available in AITER, including fused gating variants and activation-quantization fusions.
+
+---
+
+## Quick Reference
+
+| Use Case | Recommended Operation | Backend | Why |
+|----------|---------------------|---------|-----|
+| **SwiGLU gate (LLM FFN)** | `silu_and_mul` | HIP/CK | Standard gated activation for LLaMA/Mistral |
+| **SwiGLU + FP8 quantize** | `act_mul_and_fp8_group_quant` | Triton | Fused activation + quantize for inference |
+| **SwiGLU + MXFP4 quantize** | `act_mul_and_mxfp4_quant` | Triton | Fused activation + MXFP4 for GFX950 |
+| **GELU gate** | `gelu_and_mul` | HIP/CK | GPT-2/BERT-style gated activation |
+| **Scaled SiLU (quantized input)** | `scaled_silu_and_mul` | HIP/CK | SiLU with input scale for quantized models |
+| **Element-wise arithmetic** | `aiter.add/sub/mul/div` | HIP/CK | Optimized binary ops with broadcasting |
+| **Sigmoid / Tanh** | `aiter.sigmoid/tanh` | HIP/CK | AMD-optimized fast math intrinsics |
+| **Fused multiply-add** | `fused_mul_add` | Triton | `a * x + b` in one kernel |
+
+---
+
+## 1. Gated Activation Functions (SwiGLU / GeGLU)
+
+The primary activation pattern in modern LLMs. The input tensor has shape `[M, 2*N]` and is split in half: one half is the gate (activation applied), the other is the value. The output is `activation(gate) * value` with shape `[M, N]`.
+
+### Backend Support
+
+| Activation | HIP/CK | Triton | Fused + FP8 Quant | Fused + MXFP4 Quant |
+|-----------|:---:|:---:|:---:|:---:|
+| **SiLU (SwiGLU)** | Yes | Yes | Yes | Yes |
+| **GELU** | Yes | Yes | Yes | Yes |
+| **GELU Tanh** | Yes | Yes | Yes | Yes |
+| **Scaled SiLU** | Yes | - | - | - |
+
+### Key API Functions
+
+```python
+import aiter
+
+# SiLU-and-Mul (SwiGLU gate) — most common for LLaMA/Mistral/DeepSeek
+out = torch.empty(M, N, dtype=dtype, device="cuda")
+aiter.silu_and_mul(out, input)  # input shape: [M, 2*N]
+
+# Scaled SiLU-and-Mul (for quantized inference with input scale)
+aiter.scaled_silu_and_mul(out, input, scale)
+
+# GELU-and-Mul (GeGLU gate)
+aiter.gelu_and_mul(out, input)
+
+# GELU-Tanh-and-Mul (approximate GELU gate)
+aiter.gelu_tanh_and_mul(out, input)
+```
+
+### Fused Activation + Quantization (Triton)
+
+These fuse the gated activation with quantization in a single kernel, avoiding an extra memory round-trip:
+
+```python
+from aiter.ops.triton.activation import (
+    act_mul_and_fp8_group_quant,    # Activation + FP8 group quantize
+    act_mul_and_mxfp4_quant,        # Activation + MXFP4 block-scale quantize
+)
+
+# SiLU gate + FP8 group quantization
+out, scales = act_mul_and_fp8_group_quant(
+    input,                  # [M, 2*N]
+    activation="silu",      # "silu", "gelu", or "gelu_tanh"
+    group_size=128,
+    dtype_quant=torch.float8_e4m3fnuz,
+)
+
+# SiLU gate + MXFP4 block-scale quantization
+out, scales = act_mul_and_mxfp4_quant(
+    input,
+    activation="silu",
+    scaling_mode="even",    # Scale computation mode
+    shuffle=True,           # Shuffle output layout
+)
+```
+
+---
+
+## 2. Unary Activations
+
+### Sigmoid
+
+Uses AMD fast math intrinsics (`__builtin_amdgcn_exp2f`, `__builtin_amdgcn_rcpf`) for optimized computation.
+
+```python
+import aiter
+
+output = aiter.sigmoid(input)
+```
+
+### Tanh
+
+```python
+output = aiter.tanh(input)
+```
+
+### Supported Data Types
+
+| Data Type | Sigmoid | Tanh |
+|-----------|:---:|:---:|
+| FP16 | Yes | Yes |
+| BF16 | Yes | Yes |
+| FP32 | Yes | Yes |
+
+---
+
+## 3. Element-wise Binary Arithmetic
+
+Optimized binary operations with full broadcasting support. Uses JIT-compiled kernels that are specialized for the input dtype combination.
+
+### Operations
+
+```python
+import aiter
+
+# Out-of-place (return new tensor)
+c = aiter.add(a, b)   # c = a + b
+c = aiter.sub(a, b)   # c = a - b
+c = aiter.mul(a, b)   # c = a * b
+c = aiter.div(a, b)   # c = a / b
+
+# In-place (modify first tensor)
+aiter.add_(a, b)      # a += b
+aiter.sub_(a, b)      # a -= b
+aiter.mul_(a, b)      # a *= b
+aiter.div_(a, b)      # a /= b
+```
+
+### Broadcasting
+
+All binary ops support NumPy-style broadcasting:
+
+```python
+# Scalar broadcast
+c = aiter.add(tensor_2d, scalar_tensor)
+
+# Dimension broadcast
+a = torch.randn(4, 1, device="cuda")
+b = torch.randn(1, 8, device="cuda")
+c = aiter.mul(a, b)  # → shape [4, 8]
+```
+
+### Auto Type Promotion
+
+Output dtype is automatically promoted via `torch.promote_types()`:
+
+```python
+a = torch.randn(4, 4, dtype=torch.float16, device="cuda")
+b = torch.randn(4, 4, dtype=torch.float32, device="cuda")
+c = aiter.add(a, b)  # c.dtype == torch.float32
+```
+
+---
+
+## 4. Fused Multiply-Add
+
+Single-kernel element-wise `out = a * x + b` where `a` and `b` can be scalars or tensors:
+
+```python
+from aiter.ops.triton.fusions.fused_mul_add import fused_mul_add
+
+# Tensor * tensor + tensor
+out = torch.empty_like(x)
+fused_mul_add(x, a_tensor, b_tensor, out)
+
+# Scalar * tensor + scalar
+fused_mul_add(x, 2.0, 1.0, out)  # out = 2*x + 1
+```
+
+---
+
+## 5. GEMM-Fused Activations
+
+Activations can be fused directly into GEMM (matrix multiply) operations, eliminating the need for a separate activation kernel:
+
+### GEMM + Activation
+
+```python
+from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
+
+# Matrix multiply with post-GEMM activation
+y = gemm_a16w16(x, weight, bias=None, dtype=torch.bfloat16,
+                activation="silu")  # Applied after matmul
+```
+
+### GEMM + Gated Activation (SwiGLU FFN)
+
+```python
+from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16_gated
+
+# Gated matmul: splits output, applies activation to gate half
+y = gemm_a16w16_gated(x, weight, dtype=torch.bfloat16,
+                      activation="silu")
+```
+
+### Feed-Forward Blocks
+
+Complete FFN blocks with gating built in:
+
+```python
+from aiter.ops.triton.gemm.feed_forward.ff_a16w16 import (
+    ff_a16w16_gated,    # SwiGLU: x → up_proj → gate*value → down_proj
+    ff_a16w16_nogate,   # Standard: x → up_proj → activation → down_proj
+)
+```
+
+---
+
+## 6. Triton Activation Kernels
+
+Available activation functions in Triton kernels (used internally by fused operations):
+
+| Function | Formula | Usage |
+|----------|---------|-------|
+| `_silu(x)` | `x * sigmoid(x)` | SwiGLU gates |
+| `_gelu(x)` | `0.5 * x * (1 + erf(x / sqrt(2)))` | Standard GELU |
+| `_gelu_tanh(x)` | `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))` | Approximate GELU |
+| `_tanh(x)` | `2 * sigmoid(2x) - 1` | Tanh |
+| `_relu(x)` | `max(0, x)` | ReLU |
+
+---
+
+## 7. Decision Tree
+
+```
+Need activation?
+├── Gated FFN (SwiGLU/GeGLU)?
+│   ├── Standard inference → aiter.silu_and_mul()
+│   ├── With input scaling → aiter.scaled_silu_and_mul()
+│   ├── Need FP8 output → act_mul_and_fp8_group_quant()
+│   ├── Need MXFP4 output → act_mul_and_mxfp4_quant()
+│   └── Fused with GEMM → gemm_a16w16_gated() or ff_a16w16_gated()
+├── Standalone activation?
+│   ├── Sigmoid → aiter.sigmoid()
+│   └── Tanh → aiter.tanh()
+├── Element-wise arithmetic?
+│   ├── Standard ops → aiter.add/sub/mul/div()
+│   ├── In-place → aiter.add_/sub_/mul_/div_()
+│   └── Fused a*x+b → fused_mul_add()
+└── GELU variant?
+    ├── Standard → aiter.gelu_and_mul()
+    └── Tanh approx → aiter.gelu_tanh_and_mul()
+```
+
+---
+
+## 8. Source Files
+
+| Component | Path |
+|-----------|------|
+| Gated activation API | `aiter/ops/activation.py` |
+| Binary/unary ops API | `aiter/ops/aiter_operator.py` |
+| Triton activation wrappers | `aiter/ops/triton/activation.py` |
+| Triton activation kernels | `aiter/ops/triton/_triton_kernels/activation.py` |
+| Triton fused mul-add | `aiter/ops/triton/fusions/fused_mul_add.py` |
+| Triton GEMM + activation | `aiter/ops/triton/gemm/basic/gemm_a16w16.py` |
+| Triton gated FFN | `aiter/ops/triton/gemm/feed_forward/ff_a16w16.py` |
+| HIP activation kernels | `csrc/kernels/activation_kernels.cu` |
+| HIP unary operators | `csrc/kernels/unary_operator.cu` |
+| HIP binary operators | `csrc/kernels/binary_operator.cu` |
+
+---
+
+## 9. Test Files
+
+| Test | Path |
+|------|------|
+| Activation (SiLU, scaled) | `op_tests/test_activation.py` |
+| Triton activation + quant | `op_tests/triton_tests/test_activation.py` |
+| Add | `op_tests/test_aiter_add.py` |
+| Add in-place | `op_tests/test_aiter_addInp.py` |
+| Sigmoid | `op_tests/test_aiter_sigmoid.py` |
+| Fused mul-add | `op_tests/triton_tests/fusions/test_fused_mul_add.py` |

--- a/docs/gemm_variants_guide.md
+++ b/docs/gemm_variants_guide.md
@@ -1,0 +1,603 @@
+# AITER GEMM Variants & Tuning Guide
+
+This guide documents all GEMM variants available in AITER, their backend support, tuning system, and how to choose the right one for your use case.
+
+---
+
+## Quick Reference: Which GEMM Should I Use?
+
+| Use Case | Recommended Variant | Backend | Why |
+|----------|-------------------|---------|-----|
+| **FP8 inference (production)** | `gemm_a8w8` | ASM or CK | Pre-tuned for MI300X/MI350, best throughput |
+| **FP8 with block-scale (high accuracy)** | `gemm_a8w8_blockscale` | CK/ASM | Per-128x128 block scales reduce quant error |
+| **BF16 inference (no quantization)** | `gemm_a16w16` (via `tuned_gemm`) | ASM/HipBLASLt | Auto-selects best backend per shape |
+| **FP4 inference (max compression)** | `gemm_a4w4` | ASM/CK | 4x weight compression; MI350 native FP4 |
+| **Batched GEMM (MLA projections)** | `batched_gemm_a8w8` / `batched_gemm_bf16` | CK | Batched (B, M, K) x (B, N, K) |
+| **Group-wise GEMM** | `deepgemm` | CK | Variable M per group |
+| **FFN blocks (fused gate+up)** | `ff_a16w16_gated` | Triton | SwiGLU/GELU fused in one kernel |
+| **Fused GEMM + element-wise** | `fused_gemm_*_mul_add` | Triton | GEMM + a*x+b in one launch |
+| **Prototyping / custom shapes** | Triton GEMM variants | Triton | Portable, configurable, easy to tune |
+
+---
+
+## 1. GEMM Architecture in AITER
+
+AITER provides GEMM operators across three backend tiers:
+
+```
+                    ┌──────────────────────────────────────────┐
+  User API          │  gemm_a8w8()  gemm_a16w16()  gemm_a4w4()│
+                    └──────────┬───────────────────────────────┘
+                               │ auto-dispatch
+                    ┌──────────▼───────────────────────────────┐
+  Backend Selection │  Tuned CSV lookup → kernel + splitK      │
+                    │  Shape padding → fallback selection       │
+                    └──┬──────────┬──────────┬─────────────────┘
+                       │          │          │
+                 ┌─────▼──┐ ┌────▼───┐ ┌────▼────┐
+  Backends       │  ASM   │ │   CK   │ │ Triton  │
+                 │(MI300X)│ │(CKTile)│ │(portable)│
+                 └────────┘ └────────┘ └─────────┘
+```
+
+### Key Concepts
+
+- **CK (Composable Kernel)**: AMD's template-based GPU kernel library. Variants include CK (classic) and CKTile (newer tile-based).
+- **ASM**: Hand-tuned assembly kernels for specific GPU architectures. Best performance but fixed configurations.
+- **Triton**: Python-based JIT-compiled kernels. Portable and easy to customize.
+- **SplitK**: Splits the K (reduction) dimension across multiple thread groups for better parallelism on small-M problems.
+- **Bpreshuffle**: Weight pre-shuffling for optimized memory access patterns. Requires one-time weight transformation.
+- **Block-scale**: Per-block quantization scales (e.g., 128x128 blocks) for higher accuracy than per-tensor scaling.
+
+### Tensor Shape Conventions
+
+```
+Input A:    (M, K)           # activations (row-major)
+Input B:    (N, K)           # weights (pre-transposed)
+Output:     (M, N)           # result (row-major)
+Scales:     varies by variant (per-tensor, per-row, per-block)
+```
+
+For batched variants: `(B, M, K) x (B, N, K) → (B, M, N)`
+
+---
+
+## 2. A8W8 — INT8/FP8 Activations x INT8/FP8 Weights
+
+The primary quantized GEMM for inference. Supports per-tensor and per-block scaling.
+
+### Backend Support
+
+| Feature | CK | CKTile | ASM | Triton |
+|---------|:---:|:---:|:---:|:---:|
+| **Per-tensor scale** | Yes | - | Yes | Yes |
+| **Block-scale (128x128)** | Yes | Yes | Yes | Yes |
+| **Bpreshuffle** | Yes | Yes | Yes | - |
+| **Block-scale + bpreshuffle** | Yes | - | Yes | - |
+| **SplitK** | Yes | - | Yes | Yes |
+| **Bias** | Yes | - | Yes | Yes |
+| **FP8 (E4M3)** | Yes | Yes | Yes | Yes |
+| **INT8** | Yes | - | Yes | Yes |
+| **GFX942 (MI300X)** | Yes | Yes | Yes | Yes |
+| **GFX950 (MI350)** | Yes | Yes | Yes | Yes |
+
+### Key API Functions
+
+```python
+from aiter import gemm_a8w8, gemm_a8w8_blockscale
+
+# Standard per-tensor A8W8
+output = gemm_a8w8(
+    XQ,             # (M, K) INT8/FP8 activations
+    WQ,             # (N, K) INT8/FP8 weights
+    x_scale,        # per-token or per-tensor activation scale
+    w_scale,        # per-tensor weight scale
+    bias=None,      # optional (N,) bias
+    dtype=torch.bfloat16,  # output dtype
+    splitK=None,    # auto-select
+)
+
+# Block-scale A8W8 (higher accuracy)
+output = gemm_a8w8_blockscale(
+    XQ,             # (M, K) INT8/FP8 activations
+    WQ,             # (N, K) INT8/FP8 weights
+    x_scale,        # (M, ceil(K/128)) block scales
+    w_scale,        # (N, ceil(K/128)) block scales
+    dtype=torch.bfloat16,
+    isBpreshuffled=False,
+)
+```
+
+### Pre-Shuffle Optimization
+
+```python
+from aiter import gemm_a8w8_bpreshuffle
+
+# Requires one-time weight preparation (layout=(32,16) shuffle)
+# Then use for repeated inference:
+output = gemm_a8w8_bpreshuffle(
+    XQ, WQ_shuffled, x_scale, w_scale,
+    dtype=torch.bfloat16,
+)
+```
+
+### Tuning
+
+**Config files** (auto-loaded, override via environment):
+
+| Config | Entries | Env Override |
+|--------|---------|-------------|
+| `aiter/configs/a8w8_tuned_gemm.csv` | 551 | `AITER_CONFIG_GEMM_A8W8` |
+| `aiter/configs/a8w8_bpreshuffle_tuned_gemm.csv` | 702 | `AITER_CONFIG_GEMM_A8W8_BPRESHUFFLE` |
+| `aiter/configs/a8w8_blockscale_tuned_gemm.csv` | 79 | `AITER_CONFIG_GEMM_A8W8_BLOCKSCALE` |
+| `aiter/configs/a8w8_blockscale_bpreshuffle_tuned_gemm.csv` | 118 | `AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE` |
+
+### When to Use
+
+- FP8/INT8 quantized inference (majority of production LLM deployments)
+- Block-scale variant when accuracy matters more than raw throughput
+- Bpreshuffle when weights are static and inference is latency-critical
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/gemm_op_a8w8.py` | All A8W8 variants and tuning interfaces |
+| `aiter/ops/triton/gemm/basic/gemm_a8w8.py` | Triton A8W8 |
+| `aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py` | Triton block-scale |
+| `aiter/ops/triton/gemm/basic/gemm_a8w8_per_token_scale.py` | Triton per-token |
+
+---
+
+## 3. A16W16 — BF16/FP16 Full-Precision GEMM
+
+Full-precision GEMM with automatic backend selection. The recommended high-level entry point is `tuned_gemm.gemm_a16w16`.
+
+### Backend Support
+
+| Feature | ASM | HipBLASLt | CK | Triton | PyTorch |
+|---------|:---:|:---:|:---:|:---:|:---:|
+| **BF16** | Yes | Yes | Yes | Yes | Yes |
+| **FP16** | Yes | Yes | Yes | Yes | Yes |
+| **Bias** | Yes | Yes | - | Yes | Yes |
+| **SplitK** | Yes | - | - | Yes | - |
+| **Bpreshuffle** | Yes | Yes | - | - | - |
+| **Output scaling** | - | - | - | - | Yes (`torch._scaled_mm`) |
+
+### Key API Functions
+
+```python
+from aiter.tuned_gemm import gemm_a16w16
+
+# High-level (auto-selects best backend)
+output = gemm_a16w16(
+    A,              # (M, K) BF16/FP16
+    B,              # (N, K) BF16/FP16
+    bias=None,      # optional (N,)
+    otype=None,     # output dtype (default: same as input)
+    scale_a=None,   # optional per-tensor scale
+    scale_b=None,
+    scale_c=None,
+)
+```
+
+### Automatic Backend Selection
+
+```
+Bpreshuffle weights? → HipBLASLt
+BF16 + N%64==0 + K%64==0? → ASM
+M ≤ 4 + K ≤ 9216? → Skinny kernel
+Else → PyTorch fallback
+```
+
+### Tuning
+
+| Config | Env Override |
+|--------|-------------|
+| `aiter/configs/bf16_tuned_gemm.csv` | `AITER_CONFIG_GEMM_BF16` |
+
+### When to Use
+
+- Training workloads (no quantization)
+- Inference when accuracy is paramount
+- As fallback when quantized models aren't available
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/tuned_gemm.py` | High-level `gemm_a16w16` with auto-dispatch |
+| `aiter/ops/gemm_op_a16w16.py` | Low-level ASM interface |
+| `aiter/ops/triton/gemm/basic/gemm_a16w16.py` | Triton BF16 GEMM |
+
+---
+
+## 4. A4W4 — FP4 Activations x FP4 Weights
+
+Maximum weight compression using MXFP4 (Microscaling FP4) format with E8M0 block scales.
+
+### Backend Support
+
+| Feature | ASM | CK |
+|---------|:---:|:---:|
+| **MXFP4 (E2M1 packed)** | Yes | Yes |
+| **Block-scale (per 32 elements)** | Yes | Yes |
+| **Bpreshuffle** | Yes | - |
+| **Alpha/beta scaling** | Yes | Yes |
+| **GFX942 (MI300X)** | - | - |
+| **GFX950 (MI350)** | Yes | Yes |
+
+**Note:** A4W4 is **not supported on GFX942 (MI300X)**. It requires GFX950's native FP4 hardware.
+
+### Key API Functions
+
+```python
+from aiter import gemm_a4w4
+
+output = gemm_a4w4(
+    A,              # (M, K//2) FP4 packed activations
+    B,              # (N, K//2) FP4 packed weights
+    A_scale,        # (M, K//32) E8M0 block scales
+    B_scale,        # (N, K//32) E8M0 block scales
+    bias=None,
+    dtype=torch.bfloat16,
+    alpha=1.0,
+    beta=0.0,
+    bpreshuffle=True,
+)
+```
+
+### Tuning
+
+| Config | Entries | Env Override |
+|--------|---------|-------------|
+| `aiter/configs/a4w4_blockscale_tuned_gemm.csv` | 925 | `AITER_CONFIG_GEMM_A4W4` |
+
+### When to Use
+
+- MI350 (GFX950) deployments with native FP4 support
+- When 4x weight compression is needed
+- Models pre-quantized to MXFP4 format
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/gemm_op_a4w4.py` | A4W4 variants |
+| `aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py` | Triton FP4xFP4 |
+| `aiter/ops/triton/gemm/basic/gemm_a16wfp4.py` | Triton BF16xFP4 |
+| `aiter/ops/triton/gemm/basic/gemm_a8wfp4.py` | Triton FP8xFP4 |
+
+---
+
+## 5. Batched GEMM
+
+Batched matrix multiplication for operations like MLA latent projections where multiple independent GEMMs run in parallel.
+
+### Variants
+
+| Variant | Function | Data Types | Config |
+|---------|----------|-----------|--------|
+| **Batched A8W8** | `batched_gemm_a8w8_CK()` | INT8/FP8 | `a8w8_tuned_batched_gemm.csv` |
+| **Batched BF16** | `batched_gemm_bf16_CK()` | BF16/FP16 | `bf16_tuned_batched_gemm.csv` |
+
+### Key API Functions
+
+```python
+from aiter import batched_gemm_a8w8_CK, batched_gemm_bf16_CK
+
+# Batched INT8 GEMM
+output = batched_gemm_a8w8_CK(
+    XQ,             # (B, M, K) INT8
+    WQ,             # (B, N, K) INT8
+    x_scale,        # (B, 1, 1) or broadcast
+    w_scale,        # (B, 1, 1) or broadcast
+    dtype=torch.bfloat16,
+)
+
+# Batched BF16 GEMM
+output = batched_gemm_bf16_CK(
+    X,              # (B, M, K) BF16
+    W,              # (B, N, K) BF16
+    dtype=torch.bfloat16,
+)
+```
+
+### Triton Batched Variants
+
+| Function | File | Data Types |
+|----------|------|-----------|
+| `batched_gemm_bf16` | `triton/gemm/batched/batched_gemm_bf16.py` | BF16 |
+| `batched_gemm_a8w8` | `triton/gemm/batched/batched_gemm_a8w8.py` | INT8/FP8 |
+| `batched_gemm_afp4wfp4` | `triton/gemm/batched/batched_gemm_afp4wfp4.py` | FP4 |
+| `batched_gemm_a16wfp4` | `triton/gemm/batched/batched_gemm_a16wfp4.py` | BF16 x FP4 |
+
+### When to Use
+
+- MLA latent projections (B = num_heads)
+- Any workload with independent parallel GEMMs sharing the same shape
+- Multi-head operations that can't be reshaped into a single large GEMM
+
+---
+
+## 6. DeepGEMM — Group-wise GEMM
+
+Group-wise matrix multiplication where each group can have a different effective M dimension.
+
+### Key API Functions
+
+```python
+from aiter import deepgemm
+
+output = deepgemm(
+    XQ,             # (num_groups, max_m, K) quantized activations
+    WQ,             # (num_groups, N, K) quantized weights
+    Y,              # (num_groups, max_m, N) output buffer
+    group_layout,   # (num_groups,) actual M per group
+    x_scale=None,   # optional quantization scales
+    w_scale=None,
+)
+```
+
+### When to Use
+
+- Variable-size group operations (e.g., MOE with different token counts per expert)
+- GFX942 only (checked at runtime)
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/deepgemm.py` | DeepGEMM wrapper |
+
+---
+
+## 7. Triton Feed-Forward Fusions
+
+Fused two-GEMM feed-forward blocks that combine the up-projection and down-projection with activation in fewer kernel launches.
+
+### Variants
+
+| Function | Description | Activation |
+|----------|-------------|-----------|
+| `ff_a16w16_nogate` | FFN: `down(act(up(x)))` | SiLU, GELU |
+| `ff_a16w16_gated` | Gated FFN: `down(act(gate(x)) * up(x))` | SwiGLU |
+| `ff_a16w16_fused_gated` | Fully fused gated variant | SwiGLU |
+| `ff_a16w16_fused_ungated` | Fully fused ungated variant | SiLU, GELU |
+
+### Key API Functions
+
+```python
+from aiter.ops.triton.gemm.feed_forward.ff_a16w16 import ff_a16w16_gated
+
+# Fused gated FFN (SwiGLU style)
+output = ff_a16w16_gated(
+    x,              # (M, K) input
+    w_gate,         # (inter_dim, K) gate weights
+    w_up,           # (inter_dim, K) up-projection weights
+    w_down,         # (K, inter_dim) down-projection weights
+    dtype=torch.bfloat16,
+    activation="silu",
+)
+```
+
+### When to Use
+
+- Transformer FFN blocks (MLP layers)
+- When kernel launch overhead matters (small batch sizes)
+- Gated architectures (LLaMA, Mistral, DeepSeek)
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/gemm/feed_forward/ff_a16w16.py` | Gated/ungated FFN |
+| `aiter/ops/triton/gemm/feed_forward/ff_a16w16_fused_gated.py` | Fully fused gated |
+| `aiter/ops/triton/gemm/feed_forward/ff_a16w16_fused_ungated.py` | Fully fused ungated |
+
+---
+
+## 8. Triton Fused GEMM Operations
+
+Combine GEMM with subsequent element-wise operations in a single kernel.
+
+### Variants
+
+| Function | Operation | Data Types |
+|----------|-----------|-----------|
+| `fused_gemm_a8w8_blockscale_mul_add` | `Y = a * GEMM + b` or `Y = a * b + GEMM` | INT8 block-scale |
+| `fused_gemm_afp4wfp4_mul_add` | `Y = a * GEMM + b` | FP4 |
+| `fused_gemm_a8w8_blockscale_split_cat` | GEMM with split + concatenation | INT8 block-scale |
+| `fused_gemm_afp4wfp4_split_cat` | GEMM with split + concatenation | FP4 |
+| `fused_gemm_a8w8_blockscale_a16w16` | Chained: A8W8 GEMM → A16W16 GEMM | INT8 → BF16 |
+| `fused_gemm_afp4wfp4_a16w16` | Chained: FP4 GEMM → A16W16 GEMM | FP4 → BF16 |
+
+### When to Use
+
+- Residual connections after GEMM (`a * gemm_out + bias`)
+- Split-K with concatenation for parallel heads
+- Chained projections (e.g., QKV projection → output projection)
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py` | INT8 GEMM + mul_add |
+| `aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_mul_add.py` | FP4 GEMM + mul_add |
+| `aiter/ops/triton/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py` | INT8 GEMM + split_cat |
+| `aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_split_cat.py` | FP4 GEMM + split_cat |
+| `aiter/ops/triton/gemm/fused/fused_gemm_a8w8_blockscale_a16w16.py` | Chained INT8 + BF16 |
+| `aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_a16w16.py` | Chained FP4 + BF16 |
+
+---
+
+## 9. Tuning System
+
+AITER ships with pre-tuned kernel configurations for common model shapes. The tuning system selects the optimal kernel and SplitK factor for each (M, N, K) shape.
+
+### How Tuning Works
+
+```
+1. User calls gemm_a8w8(XQ, WQ, ...)
+2. System extracts (M, N, K) from tensor shapes
+3. Looks up (cu_num, M, N, K) in tuned CSV
+4. If found → uses specified kernelName + splitK
+5. If not → pads M to next tile boundary, retries
+6. If still not → falls back to default backend
+```
+
+### CSV Format
+
+All tuning CSVs share a common schema:
+
+```csv
+cu_num,M,N,K,kernelId,splitK,us,kernelName,tflops,bw,errRatio
+304,1,3584,512,0,0,4.5,ck_gemm_f8_f8_f16_0,15.2,890.1,0.001
+```
+
+| Column | Description |
+|--------|-------------|
+| `cu_num` | GPU compute unit count (304 for MI300X) |
+| `M,N,K` | Problem dimensions |
+| `kernelId` | CK kernel variant index |
+| `splitK` | K-split factor (0 = no split) |
+| `us` | Measured execution time (microseconds) |
+| `kernelName` | CK/ASM kernel identifier |
+| `tflops` | Achieved TFLOPS |
+| `bw` | Memory bandwidth (GB/s) |
+| `errRatio` | Numerical error ratio vs reference |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AITER_TUNE_GEMM` | 0 | Set to 1 to collect untuned shapes for offline tuning |
+| `AITER_LOG_TUNED_CONFIG` | 0 | Log when tuned configs are loaded |
+| `AITER_CONFIG_GEMM_A8W8` | built-in | Override A8W8 tuning CSV path |
+| `AITER_CONFIG_GEMM_A8W8_BPRESHUFFLE` | built-in | Override A8W8 pre-shuffle CSV |
+| `AITER_CONFIG_GEMM_A8W8_BLOCKSCALE` | built-in | Override A8W8 block-scale CSV |
+| `AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE` | built-in | Override combined CSV |
+| `AITER_CONFIG_GEMM_A4W4` | built-in | Override A4W4 CSV |
+| `AITER_CONFIG_GEMM_BF16` | built-in | Override BF16 CSV |
+| `AITER_CONFIG_A8W8_BATCHED_GEMM` | built-in | Override batched A8W8 CSV |
+| `AITER_CONFIG_BF16_BATCHED_GEMM` | built-in | Override batched BF16 CSV |
+
+### Model-Specific Configs
+
+Pre-tuned configs for popular models in `aiter/configs/model_configs/`:
+
+| Config | Model |
+|--------|-------|
+| `dsv3_bf16_tuned_gemm.csv` | DeepSeek-V3 |
+| `a8w8_blockscale_tuned_gemm_qwen3_235b.csv` | Qwen3-235B |
+| `a8w8_blockscale_bpreshuffle_tuned_gemm_qwen3_235b.csv` | Qwen3-235B (preshuffle) |
+
+### SplitK Tuning
+
+SplitK divides the K dimension across multiple thread groups for better GPU utilization on small-M (decode) problems:
+
+```python
+# Auto-computed based on CU count and tile sizes:
+# splitK = max(1, cu_count // (ceil(M/tile_m) * ceil(N/tile_n)))
+# Capped at K // tile_k
+```
+
+Override: pass `splitK=N` explicitly to any GEMM function.
+
+---
+
+## 10. Backend Comparison: How to Choose
+
+### Performance Characteristics
+
+| Backend | Strengths | Weaknesses |
+|---------|-----------|------------|
+| **ASM** | Best peak throughput, hand-tuned per arch | Fixed shapes, arch-locked |
+| **CK/CKTile** | Good performance, broadest variant coverage | Requires ROCm compilation |
+| **HipBLASLt** | Good for BF16, auto-tuned | Limited to standard GEMM |
+| **Triton** | Portable, fused ops, configurable | Slightly lower peak perf |
+| **PyTorch** | Universal fallback | Lowest performance |
+
+### Decision Tree
+
+```
+Need quantized GEMM?
+├── FP8/INT8?
+│   ├── Per-tensor scale → gemm_a8w8 (ASM/CK)
+│   ├── Block-scale → gemm_a8w8_blockscale (CK/ASM)
+│   └── Pre-shuffled weights → gemm_a8w8_bpreshuffle (CK/CKTile)
+├── FP4?
+│   └── gemm_a4w4 (MI350 only)
+└── No quantization?
+    ├── Standard GEMM → gemm_a16w16 (auto-dispatch)
+    ├── FFN block → ff_a16w16_gated / ff_a16w16_nogate (Triton)
+    └── Batched → batched_gemm_bf16_CK
+```
+
+---
+
+## 11. GPU Architecture Support
+
+| Variant | MI300X (GFX942) | MI350 (GFX950) | Other GPUs |
+|---------|:---:|:---:|:---:|
+| A8W8 (per-tensor) | ASM + CK + Triton | CK + Triton | Triton |
+| A8W8 (block-scale) | ASM + CK + Triton | ASM + CK + Triton | Triton |
+| A16W16 | ASM + HipBLASLt + Triton | CK + Triton | Triton + PyTorch |
+| A4W4 | - | ASM + CK | Triton |
+| Batched A8W8 | CK + Triton | CK + Triton | Triton |
+| Batched BF16 | CK + Triton | CK + Triton | Triton |
+| DeepGEMM | CK | - | - |
+| Feed-forward fusions | Triton | Triton | Triton |
+| Fused GEMM ops | Triton | Triton | Triton |
+
+---
+
+## 12. Test Files Reference
+
+| Test File | Covers |
+|-----------|--------|
+| `op_tests/test_gemm_a8w8.py` | A8W8: per-tensor, block-scale, bpreshuffle |
+| `op_tests/test_gemm_a16w16.py` | A16W16: BF16/FP16, all backends |
+| `op_tests/test_gemm_a4w4.py` | A4W4: FP4 on MI350 |
+| `op_tests/test_batched_gemm_a8w8.py` | Batched INT8 GEMM |
+| `op_tests/test_batched_gemm_bf16.py` | Batched BF16 GEMM |
+| `op_tests/test_deepgemm.py` | Group-wise GEMM |
+| `op_tests/triton_tests/gemm/` | All Triton GEMM variants (23+ test files) |
+
+---
+
+## 13. Source Files Reference
+
+### Main API
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/gemm_op_a8w8.py` | All A8W8 variants, tuning interfaces |
+| `aiter/ops/gemm_op_a16w16.py` | Low-level A16W16 ASM interface |
+| `aiter/tuned_gemm.py` | High-level A16W16 with auto-dispatch |
+| `aiter/ops/gemm_op_a4w4.py` | All A4W4 variants |
+| `aiter/ops/batched_gemm_op_a8w8.py` | Batched A8W8 |
+| `aiter/ops/batched_gemm_op_bf16.py` | Batched BF16 |
+| `aiter/ops/deepgemm.py` | Group-wise GEMM |
+
+### Triton Kernels
+
+| Directory | Contents |
+|-----------|----------|
+| `aiter/ops/triton/gemm/basic/` | 11 basic GEMM variants (a8w8, a16w16, afp4wfp4, etc.) |
+| `aiter/ops/triton/gemm/batched/` | 5 batched variants |
+| `aiter/ops/triton/gemm/feed_forward/` | 3 FFN fusions |
+| `aiter/ops/triton/gemm/fused/` | 6 fused GEMM+element-wise ops |
+
+### Configuration
+
+| File | Purpose |
+|------|---------|
+| `aiter/configs/a8w8_tuned_gemm.csv` | A8W8 per-tensor tuning (551 entries) |
+| `aiter/configs/a8w8_bpreshuffle_tuned_gemm.csv` | A8W8 pre-shuffle tuning (702 entries) |
+| `aiter/configs/a8w8_blockscale_tuned_gemm.csv` | A8W8 block-scale tuning (79 entries) |
+| `aiter/configs/a8w8_blockscale_bpreshuffle_tuned_gemm.csv` | Combined tuning (118 entries) |
+| `aiter/configs/a4w4_blockscale_tuned_gemm.csv` | A4W4 tuning (925 entries) |
+| `aiter/configs/bf16_tuned_gemm.csv` | BF16 tuning |
+| `aiter/configs/a8w8_tuned_batched_gemm.csv` | Batched A8W8 (27 entries) |
+| `aiter/configs/bf16_tuned_batched_gemm.csv` | Batched BF16 (26 entries) |

--- a/docs/kv_cache_guide.md
+++ b/docs/kv_cache_guide.md
@@ -1,0 +1,390 @@
+# AITER KV-Cache Management Guide
+
+This guide documents all KV-cache operators available in AITER, including cache layouts, quantized cache support, fused operations, and integration with attention kernels.
+
+---
+
+## Quick Reference: Which Cache Operation Should I Use?
+
+| Use Case | Recommended Operation | Backend | Why |
+|----------|---------------------|---------|-----|
+| **Standard paged attention** | `reshape_and_cache` | CUDA/HIP | Default write to paged KV cache |
+| **Flash attention layout** | `reshape_and_cache_flash` | CUDA/HIP | Contiguous [block, page, head, dim] layout |
+| **FP8 quantized cache** | `reshape_and_cache_with_pertoken_quant` | CUDA/HIP | Per-token quantize during write |
+| **Block-quantized cache** | `reshape_and_cache_with_block_quant` | CUDA/HIP | Block-level quantize for ASM PA |
+| **MLA models (DeepSeek)** | `concat_and_cache_mla` | CUDA/HIP | Concatenates kv_c + k_pe |
+| **MLA + RoPE fused** | `fused_qk_rope_cat_and_cache_mla` | Triton | RoPE + concat + cache in one kernel |
+| **MLA + quantized BMM** | `fused_fp8_bmm_rope_cat_and_cache_mla` | Triton | BMM + RoPE + cache fully fused |
+| **Cache migration** | `swap_blocks` | CUDA/HIP | Block-level swap (H2D, D2H, D2D) |
+| **Multi-layer copy** | `copy_blocks` | CUDA/HIP | Copy blocks across cache layers |
+
+---
+
+## 1. Cache Layouts
+
+### Paged Cache Layout (Default)
+
+The standard layout for paged attention. Key and value caches use different memory layouts optimized for their access patterns.
+
+```
+Key cache:   [num_blocks, num_heads, head_size/x, block_size, x]
+Value cache: [num_blocks, num_heads, head_size, block_size]
+
+where x = 16 / sizeof(dtype)
+  - x = 8  for BF16/FP16
+  - x = 16 for INT8/FP8
+```
+
+The key cache uses a vectorized layout (the innermost `x` dimension) for cache-line-friendly memory access during attention dot products.
+
+### ASM Layout
+
+An alternative value cache layout optimized for ASM (hand-tuned assembly) attention kernels:
+
+```
+Key cache:   [num_blocks, num_heads, head_size/x, block_size, x]  (same)
+Value cache: [num_blocks, num_heads, block_size/x, head_size, x]  (transposed)
+```
+
+Enable with `asm_layout=True` in cache write operations.
+
+### Flash Attention Layout
+
+A contiguous layout compatible with flash attention implementations:
+
+```
+Key cache:   [num_blocks, block_size, num_heads, head_size]
+Value cache: [num_blocks, block_size, num_heads, head_size]
+```
+
+### MLA Cache Layout
+
+Multi-head Latent Attention uses a unified cache storing concatenated KV projections:
+
+```
+KV cache: [num_blocks, block_size, kv_lora_rank + pe_dim]
+# or multi-head variant:
+KV cache: [num_blocks, block_size, num_kv_heads, kv_lora_rank + pe_dim]
+```
+
+---
+
+## 2. Core Cache Write Operations
+
+### Standard Write
+
+```python
+import aiter
+
+# Write new KV pairs into paged cache
+aiter.reshape_and_cache(
+    key,          # [num_tokens, num_heads, head_size]
+    value,        # [num_tokens, num_heads, head_size]
+    key_cache,    # [num_blocks, num_heads, head_size/x, block_size, x]
+    value_cache,  # [num_blocks, num_heads, head_size, block_size]
+    slot_mapping, # [num_tokens] -> block slot index
+    kv_cache_dtype="auto",  # "auto", "fp8", "fp8_e4m3"
+    k_scale=None,           # Optional FP8 scale
+    v_scale=None,           # Optional FP8 scale
+    asm_layout=False,       # Use ASM value cache layout
+)
+```
+
+### Flash Layout Write
+
+```python
+aiter.reshape_and_cache_flash(
+    key, value,
+    key_cache,    # [num_blocks, block_size, num_heads, head_size]
+    value_cache,  # [num_blocks, block_size, num_heads, head_size]
+    slot_mapping,
+    kv_cache_dtype,
+    k_scale, v_scale,
+)
+```
+
+### Per-Token Quantized Write
+
+Quantizes KV pairs per-token during cache write, computing dequantization scales on the fly:
+
+```python
+aiter.reshape_and_cache_with_pertoken_quant(
+    key, value,
+    key_cache,          # Quantized cache (FP8/INT8)
+    value_cache,        # Quantized cache (FP8/INT8)
+    k_dequant_scales,   # [num_heads, max_tokens] per-token scales
+    v_dequant_scales,   # [num_heads, max_tokens] per-token scales
+    slot_mapping,
+    asm_layout=False,
+)
+```
+
+### Block-Level Quantized Write
+
+Quantizes at block granularity for better scale sharing:
+
+```python
+aiter.reshape_and_cache_with_block_quant(
+    key, value,
+    key_cache, value_cache,
+    k_dequant_scales,   # [num_heads, num_blocks]
+    v_dequant_scales,   # [num_heads, num_blocks]
+    slot_mapping,
+    asm_layout=False,
+)
+
+# ASM PA variant with configurable block size
+aiter.reshape_and_cache_with_block_quant_for_asm_pa(
+    key, value,
+    key_cache, value_cache,
+    k_dequant_scales, v_dequant_scales,
+    slot_mapping,
+    asm_layout=True,
+    ori_block_size=128,  # 128 or 256
+)
+```
+
+---
+
+## 3. MLA Cache Operations
+
+### Basic MLA Concat + Cache
+
+```python
+# Concatenate kv_c (latent) and k_pe (positional encoding), write to cache
+aiter.concat_and_cache_mla(
+    kv_c,          # [num_tokens, kv_lora_rank]
+    k_pe,          # [num_tokens, pe_dim]
+    kv_cache,      # [num_blocks, block_size, kv_lora_rank + pe_dim]
+    slot_mapping,
+    kv_cache_dtype,
+    scale,          # FP8 scale tensor
+)
+```
+
+### Fused RoPE + Concat + MLA Cache
+
+Applies RoPE to Q and K, concatenates, and writes to cache in a single kernel:
+
+```python
+aiter.fused_qk_rope_concat_and_cache_mla(
+    q_nope,       # [num_tokens, num_heads, nope_dim]
+    q_pe,         # [num_tokens, num_heads, pe_dim]
+    kv_c,         # [num_tokens, kv_lora_rank]
+    k_pe,         # [num_tokens, pe_dim]
+    kv_cache,     # [num_blocks, block_size, kv_lora_rank + pe_dim]
+    q_out,        # [num_tokens, num_heads, qk_lora_rank + pe_dim]
+    slot_mapping,
+    k_scale, q_scale,
+    positions,     # [num_tokens] position IDs
+    cos_cache, sin_cache,  # RoPE cos/sin tables
+    is_neox=True,
+    is_nope_first=False,
+)
+```
+
+### Indexed K Quantization + Cache
+
+SGLang-style indexed cache write with per-block quantization:
+
+```python
+# Write K with quantization at arbitrary slots
+aiter.indexer_k_quant_and_cache(
+    k,             # [num_tokens, head_dim]
+    kv_cache,      # Cache tensor
+    slot_mapping,
+    quant_block_size=64,
+    scale_fmt="ue8m0",    # or "" for direct float
+)
+
+# Gather K from cache with dequantization
+aiter.cp_gather_indexer_k_quant_cache(
+    kv_cache,
+    dst_k,         # Output tensor
+    dst_scale,     # Output scales
+    block_table,   # [batch, max_blocks_per_seq]
+    cu_seq_lens,   # Cumulative sequence lengths
+)
+```
+
+---
+
+## 4. Cache Management Operations
+
+### Block Swap
+
+Swaps cache blocks between devices (host-to-device, device-to-host, device-to-device):
+
+```python
+aiter.swap_blocks(
+    src,            # Source cache tensor
+    dst,            # Destination cache tensor
+    block_mapping,  # [N, 2] tensor of (src_block, dst_block) pairs
+)
+```
+
+### Block Copy
+
+Copies blocks across multiple cache layers (used for beam search, speculative decoding):
+
+```python
+aiter.copy_blocks(
+    key_caches,     # List of key cache tensors (all layers)
+    value_caches,   # List of value cache tensors (all layers)
+    block_mapping,  # [N, 2] tensor of (src_block, dst_block) pairs
+)
+```
+
+---
+
+## 5. Triton Fused Cache Operations
+
+### Fused QK RoPE + Reshape + Cache (Standard Attention)
+
+```python
+from aiter.ops.triton.fusions.fused_kv_cache import (
+    fused_qk_rope_reshape_and_cache,
+    fused_qk_rope_cosine_cache_llama,
+)
+
+# RoPE + reshape + cache write in one kernel
+fused_qk_rope_reshape_and_cache(...)
+```
+
+### Fused QK RoPE + Concat + MLA Cache
+
+```python
+from aiter.ops.triton.fusions.fused_kv_cache import fused_qk_rope_cat_and_cache_mla
+
+# Triton implementation of RoPE + MLA concat + cache
+fused_qk_rope_cat_and_cache_mla(...)
+```
+
+### Fused BMM + RoPE + MLA Cache (Quantized)
+
+Maximum fusion for quantized MLA inference - combines matrix multiply with RoPE application and cache write:
+
+```python
+from aiter.ops.triton.fusions.fused_bmm_rope_kv_cache import (
+    fused_fp8_bmm_rope_cat_and_cache_mla,  # FP8 quantized BMM
+    fused_fp4_bmm_rope_cat_and_cache_mla,  # FP4/MXFP4 quantized BMM
+)
+```
+
+---
+
+## 6. Quantized Cache Support
+
+### Supported Quantization Types
+
+| Cache Dtype | Key Cache | Value Cache | Scale Shape | Notes |
+|------------|-----------|-------------|-------------|-------|
+| **auto** (BF16/FP16) | Same as input | Same as input | None | No quantization |
+| **FP8 (e4m3fn)** | FP8 | FP8 | Per-token or per-block | GFX950 (MI350) |
+| **FP8 (e4m3fnuz)** | FP8 | FP8 | Per-token or per-block | GFX942 (MI300X) |
+| **INT8** | INT8 | INT8 | Per-token or per-block | Universal support |
+| **FP4 (MXFP4)** | FP4 | FP4 | E8M0 block scales | GFX950 only |
+
+### Scale Tensor Shapes
+
+| Quantization Mode | Scale Shape | Description |
+|------------------|-------------|-------------|
+| Per-token (non-ASM) | `[num_heads, max_tokens]` | One scale per head per token |
+| Per-block | `[num_heads, num_blocks]` | One scale per head per block |
+| Per-block (ASM) | `[num_blocks, num_heads, block_size]` | Transposed for ASM access |
+| UE8M0 (MXFP4) | Block-based | Saturating FP32 format |
+
+---
+
+## 7. Integration with Attention Operators
+
+### Paged Attention
+
+Cache is read during attention computation via block table indirection:
+
+```python
+# PA reads from paged KV cache
+attention_output = aiter.paged_attention_v1(
+    query,
+    key_cache,           # Paged key cache
+    value_cache,         # Paged value cache
+    block_tables,        # [batch, max_blocks_per_seq]
+    seq_lens,
+    k_dequant_scales,    # For quantized cache
+    v_dequant_scales,
+)
+```
+
+### MLA Decode
+
+MLA reads from unified KV cache with separate latent and positional components:
+
+```python
+output = aiter.mla_decode_fwd(
+    query, kv_buffer, kv_indptr, kv_indices,
+    ...
+)
+```
+
+### Page Table Formats
+
+| Format | Shape | Used By |
+|--------|-------|---------|
+| VLLM Block Table | `[batch_size, max_blocks_per_seq]` | vLLM, most frameworks |
+| SGLang Page Table | 1D with `kv_indptr` indexing | SGLang |
+
+---
+
+## 8. Decision Tree
+
+```
+Need to write KV to cache?
+├── Standard attention model?
+│   ├── No quantization → reshape_and_cache()
+│   ├── FP8 per-token → reshape_and_cache_with_pertoken_quant()
+│   ├── FP8 per-block → reshape_and_cache_with_block_quant()
+│   └── Flash layout → reshape_and_cache_flash()
+├── MLA model (DeepSeek)?
+│   ├── Basic → concat_and_cache_mla()
+│   ├── With RoPE → fused_qk_rope_concat_and_cache_mla()
+│   └── With BMM + RoPE → fused_fp8_bmm_rope_cat_and_cache_mla()
+├── Need block management?
+│   ├── Swap blocks (beam search) → swap_blocks()
+│   └── Copy blocks (speculative) → copy_blocks()
+└── SGLang indexed access?
+    ├── Write → indexer_k_quant_and_cache()
+    └── Read → cp_gather_indexer_k_quant_cache()
+```
+
+---
+
+## 9. Source Files
+
+| Component | Path |
+|-----------|------|
+| Cache Python API | `aiter/ops/cache.py` |
+| CUDA/HIP cache kernels | `csrc/kernels/cache_kernels.cu` |
+| Cache header | `csrc/include/cache.h` |
+| Triton fused KV cache | `aiter/ops/triton/fusions/fused_kv_cache.py` |
+| Triton KV cache kernels | `aiter/ops/triton/_triton_kernels/fusions/fused_kv_cache.py` |
+| Triton fused BMM + cache | `aiter/ops/triton/fusions/fused_bmm_rope_kv_cache.py` |
+| Fused QK Norm + RoPE + Cache | `aiter/ops/fused_qk_norm_rope_cache_quant.py` |
+| MLA decode | `aiter/mla.py` |
+| MLA Triton decode | `aiter/ops/triton/attention/mla_decode_rope.py` |
+
+---
+
+## 10. Test Files
+
+| Test | Path |
+|------|------|
+| Basic cache ops | `op_tests/test_kvcache.py` |
+| Block-scale cache | `op_tests/test_kvcache_blockscale.py` |
+| MLA concat cache | `op_tests/test_concat_cache_mla.py` |
+| Indexed K quant cache | `op_tests/test_indexer_k_quant_and_cache.py` |
+| Triton fused KV cache | `op_tests/triton_tests/fusions/test_fused_kv_cache.py` |
+| Triton fused BMM cache | `op_tests/triton_tests/fusions/test_fused_bmm_rope_kv_cache.py` |
+| Fused QK Norm + Cache | `op_tests/test_fused_qk_norm_rope_cache_quant.py` |
+| PA with cache | `op_tests/test_pa.py` |
+| MLA persistent | `op_tests/test_mla_persistent.py` |
+| Batch prefill | `op_tests/test_batch_prefill.py` |

--- a/docs/mla_kernel_support_report.md
+++ b/docs/mla_kernel_support_report.md
@@ -1,0 +1,666 @@
+# AITER MLA (Multi-head Latent Attention) Variants & Backend Guide
+
+This guide documents all MLA variants available in AITER, their backend support, and how to choose the right one for your use case.
+
+---
+
+## Quick Reference: Which MLA Configuration Should I Use?
+
+| Use Case | Recommended Variant | Backend | Why |
+|----------|-------------------|---------|-----|
+| **DeepSeek-V2/V3 decode (production)** | Persistent Decode | ASM | Best latency, constant GPU occupancy |
+| **DeepSeek-V2/V3 decode (single-token)** | Standard Decode | ASM | Mature, 21 kernel variants (GFX942) |
+| **DeepSeek-V2/V3 prefill** | Persistent Prefill | ASM | Causal mask, tile-based parallelism |
+| **Multi-token prediction (MTP)** | Persistent Decode (seqlen_q=2,4) | ASM | Only backend with seqlen_q>1 |
+| **FP8 inference (latency)** | Standard/Persistent Decode (FP8) | ASM | Native FP8xFP8 attention |
+| **Sparse/TopK attention** | Sparse MLA | Triton | Only backend with sparse support |
+| **FP4 latent projection** | Fused BMM+RoPE+Cache | Triton | Fused FP4 GEMM + cache write |
+| **Custom GQA ratios** | Triton Decode RoPE | Triton | Arbitrary GQA via runtime param |
+| **Prototyping / new GPUs** | Triton Decode RoPE | Triton | Portable, easy to modify |
+
+---
+
+## 1. MLA Architecture in AITER
+
+MLA compresses Key-Value representations into a low-rank latent space, significantly reducing KV cache size and memory bandwidth. The KV cache stores a concatenated vector per token:
+
+```
+KV cache per token = [kv_latent (kv_lora_rank) | rope_embedding (qk_rope_head_dim)]
+                      └─── typically 512 ───┘   └──── typically 64 ────┘
+
+Standard MHA KV cache:  num_heads x head_dim  per token  (e.g., 128 x 128 = 16,384)
+MLA KV cache:           kv_lora_rank + qk_rope_head_dim  (e.g., 512 + 64 = 576)
+                        → ~28x compression
+```
+
+### Two-Stage Execution
+
+All MLA backends use a split-K two-stage pipeline:
+
+```
+Stage 1: Parallel Attention                  Stage 2: Reduction
+┌─────────────────────────┐                 ┌──────────────────┐
+│ Split KV into K chunks  │                 │ Log-sum-exp      │
+│ Each chunk computes:    │ ──────────────► │ reduction across  │
+│   QK^T → softmax → V   │  partial        │ all K partials   │
+│   + partial LSE         │  outputs        │ → final output   │
+└─────────────────────────┘                 └──────────────────┘
+     (ASM or Triton)                          (always Triton)
+```
+
+### Key Concepts
+
+- **kv_lora_rank**: Dimension of the latent KV projection (typically 512)
+- **qk_rope_head_dim**: Dimension of the RoPE component (typically 64)
+- **Split-K**: KV sequence partitioned across CUs for parallelism (1-16 splits, auto-tuned)
+- **Persistent mode**: Kernel stays resident on CUs with metadata-driven scheduling for better load balancing
+- **Page size**: KV cache page granularity (1 = token-level, 64 = block-level)
+
+---
+
+## 2. Standard Decode (Non-Persistent)
+
+Single-token autoregressive generation. The most common MLA operation for LLM inference serving.
+
+### Backend Support
+
+| Feature | ASM (GFX942/GFX950) | Triton |
+|---------|:---:|:---:|
+| **seqlen_q = 1** | Yes | Yes |
+| **seqlen_q = 2, 4, 8** | Yes (GQA=16 only) | - |
+| **BF16 Q x BF16 KV** | Yes | Yes |
+| **FP8 Q x FP8 KV** | Yes (GQA=16, 128) | - |
+| **BF16 Q x FP8 KV** | Yes (GQA=16, persistent) | - |
+| **RoPE fusion** | Yes (native in-kernel) | Yes (in-kernel) |
+| **Logit capping** | - | Yes |
+| **GQA ratios** | 16, 32, 64, 128 | Any (runtime param) |
+| **Page sizes** | 1, 64 | 1 only |
+| **Split-K (auto-tuned)** | 1-16 | 1-16 |
+| **GFX942 (MI300X)** | Yes | Yes |
+| **GFX950 (MI350)** | Yes | Yes |
+| **Other GPUs** | - | Yes (portable) |
+
+### Key API Functions
+
+```python
+from aiter.mla import mla_decode_fwd
+
+# ASM decode (production path)
+output, lse = mla_decode_fwd(
+    q,                          # [total_s, num_heads, qk_head_dim]
+    kv_buffer,                  # [num_pages, page_size, num_kv_heads, kv_lora_rank + qk_rope_head_dim]
+    o,                          # [total_s, num_heads, v_head_dim]
+    qo_indptr,                  # [batch_size + 1]
+    kv_indptr,                  # [batch_size + 1]
+    kv_indices,                 # page indices
+    kv_last_page_lens,          # [batch_size]
+    max_seqlen_q=1,
+    page_size=1,
+    nhead_kv=1,                 # number of KV heads
+    sm_scale=1.0 / math.sqrt(qk_head_dim),
+)
+```
+
+```python
+from aiter.ops.triton.attention.mla_decode_rope import decode_attention_fwd_grouped_rope
+
+# Triton decode with RoPE (flexible path)
+output = decode_attention_fwd_grouped_rope(
+    q, k_buffer, v_buffer, o,
+    kv_indptr, kv_indices,
+    k_pe_tokens,                # keys with RoPE applied
+    kv_lora_rank=512,
+    rotary_dim=64,
+    cos_sin_cache=cos_sin_cache,
+    positions=positions,
+    attn_logits=attn_logits,    # intermediate buffer
+    num_kv_splits=8,
+    sm_scale=sm_scale,
+    use_rope=True,
+    is_neox_style=True,
+)
+```
+
+### When to Use
+
+- LLM inference serving with DeepSeek-V2/V3 or similar MLA models
+- Standard autoregressive token generation (seqlen_q=1)
+- Multi-token prediction with seqlen_q=2,4 (ASM only)
+- Models: DeepSeek-V2, DeepSeek-V3, DeepSeek-R1
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/mla.py` | Main MLA interface (decode, prefill, persistent) |
+| `aiter/ops/attention.py` | ASM kernel dispatch and metadata |
+| `aiter/ops/triton/attention/mla_decode_rope.py` | Triton decode wrapper |
+| `aiter/ops/triton/_triton_kernels/attention/mla_decode_rope.py` | Triton kernel implementation |
+
+---
+
+## 3. Persistent Decode
+
+Persistent-mode decode keeps kernels resident on CUs with metadata-driven scheduling. Provides better load balancing across variable-length sequences.
+
+### Backend Support
+
+| Feature | ASM (GFX942/GFX950) |
+|---------|:---:|
+| **seqlen_q = 1** | Yes |
+| **seqlen_q = 2, 4** | Yes |
+| **BF16 Q x BF16 KV** | Yes |
+| **FP8 Q x FP8 KV** | Yes (GQA=16, 128) |
+| **BF16 Q x FP8 KV** | Yes (GQA=16) |
+| **GQA = 16** | Yes (native) |
+| **GQA = 32-112 (step 16)** | Yes (simulated via metadata reshaping) |
+| **GQA = 128** | Yes (FP8 only, native kernel) |
+| **Page sizes** | 1, 64 |
+| **Intra-batch mode** | Yes |
+
+### Key API Functions
+
+```python
+from aiter.mla import mla_decode_fwd
+from aiter.ops.attention import get_mla_metadata_v1
+
+# Step 1: Generate persistent-mode metadata
+metadata = get_mla_metadata_v1(
+    seqlens_qo_indptr, seqlens_kv_indptr,
+    kv_last_page_lens,
+    page_size=1,
+    max_seqlen_qo=1,
+    dtype_q=torch.bfloat16,
+    dtype_kv=torch.bfloat16,
+)
+work_meta_data, work_indptr, work_info_set, \
+    reduce_indptr, reduce_final_map, reduce_partial_map = metadata
+
+# Step 2: Run persistent decode
+output, lse = mla_decode_fwd(
+    q, kv_buffer, o,
+    qo_indptr, kv_indptr, kv_indices, kv_last_page_lens,
+    max_seqlen_q=1,
+    nhead_kv=1,
+    sm_scale=sm_scale,
+    work_meta_data=work_meta_data,
+    work_indptr=work_indptr,
+    work_info_set=work_info_set,
+    reduce_indptr=reduce_indptr,
+    reduce_final_map=reduce_final_map,
+    reduce_partial_map=reduce_partial_map,
+)
+```
+
+### When to Use
+
+- Production inference with highly variable sequence lengths (better load balancing)
+- When GPU occupancy matters (persistent kernels avoid launch overhead)
+- Multi-token prediction (MTP) with seqlen_q > 1
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/mla.py` | Persistent decode logic (lines 283-350) |
+| `aiter/ops/attention.py` | Metadata generation (`get_mla_metadata_v1`) |
+| `csrc/kernels/mla/` | C++ metadata and reduce kernels |
+
+---
+
+## 4. Prefill
+
+Context processing for the prompt phase. Two sub-variants: standard prefill and persistent prefill.
+
+### Backend Support
+
+| Feature | ASM Standard Prefill | ASM Persistent Prefill |
+|---------|:---:|:---:|
+| **BF16 Q x BF16 KV** | Yes | Yes |
+| **FP8 Q x FP8 KV** | Yes (GQA=1, 128) | Yes |
+| **Causal masking** | Yes | Yes |
+| **Non-causal** | Yes (FP8, GQA=1) | - |
+| **GQA = 1** | Yes | Yes (192/128 variant) |
+| **GQA = 16** | Yes | - |
+| **GQA = 128** | Yes | - |
+| **3-buffer KV cache** | - | Yes (nope + scale + rope) |
+| **Tile-based parallelism** | - | Yes (256-token tiles) |
+
+### Key API Functions
+
+```python
+from aiter.mla import mla_prefill_fwd
+
+# Standard prefill
+output, lse = mla_prefill_fwd(
+    q, kv_buffer, o,
+    qo_indptr, kv_indptr, kv_indices, kv_last_page_lens,
+    max_seqlen_q=seq_len,
+    sm_scale=sm_scale,
+)
+```
+
+```python
+from aiter.mla import mla_prefill_ps_fwd
+
+# Persistent prefill (with causal masking)
+output, lse = mla_prefill_ps_fwd(
+    Q, K, V, output,
+    qo_indptr, kv_indptr, kv_page_indices,
+    work_indptr, work_info_set,
+    max_seqlen_q=seq_len,
+    is_causal=True,
+    reduce_indptr=reduce_indptr,
+    reduce_final_map=reduce_final_map,
+    reduce_partial_map=reduce_partial_map,
+    softmax_scale=sm_scale,
+)
+```
+
+### 3-Buffer KV Cache Layout (Persistent Prefill with FP8)
+
+For FP8 persistent prefill, the KV cache splits into three separate buffers:
+
+```
+kv_nope_buffer_fp8:         [num_page, page_size, 1, kv_lora_rank]       # FP8 latent
+kv_nope_scale_factors_fp32: [num_page, page_size, 1, scale_dim]          # FP32 scales
+kv_rope_buffer_bf16:        [num_page, page_size, 1, qk_rope_head_dim]   # BF16 rope
+```
+
+### When to Use
+
+- Prompt ingestion for DeepSeek-style models
+- Persistent prefill preferred for long contexts (better parallelism)
+- 3-buffer layout required for FP8 persistent prefill
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/mla.py` | Prefill functions (standard + persistent) |
+| `aiter/ops/attention.py` | `mla_prefill_asm_fwd`, `mla_prefill_ps_asm_fwd` |
+
+---
+
+## 5. Sparse MLA (Top-K Attention)
+
+Sparse attention using top-K token selection. Reduces computation by only attending to the K most relevant tokens per query.
+
+### Backend Support
+
+| Feature | Triton |
+|---------|:---:|
+| **BF16** | Yes |
+| **Top-K selection** | Yes (configurable K) |
+| **Block tables** | Yes |
+| **Variable-length** | Yes |
+| **GQA** | Yes (single KV head) |
+
+### Key API Functions
+
+```python
+from aiter.ops.triton.attention import unified_attention_sparse_mla
+
+unified_attention_sparse_mla(
+    q,                  # [seq_len, NUM_HEADS, kv_lora_rank + rope_rank]
+    kv,                 # [seq_len_kv, 1, kv_lora_rank + rope_rank]
+    out,                # [seq_len, NUM_HEADS, kv_lora_rank]
+    cu_seqlens_q,       # [BATCH + 1]
+    max_seqlen_q,
+    seqused_k,          # [BATCH]
+    max_seqlen_k,
+    softmax_scale,
+    topk_indices,       # [seq_len, TOP_K]
+    block_table,        # [BATCH, MAX_NUM_BLOCKS_PER_BATCH]
+    kv_lora_rank=512,
+)
+```
+
+### When to Use
+
+- When full attention is too expensive and approximate attention is acceptable
+- Speculative decoding with sparse token selection
+- Research on efficient MLA attention patterns
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/attention/unified_attention_sparse_mla.py` | Sparse MLA wrapper |
+| `aiter/ops/triton/_triton_kernels/attention/unified_attention_sparse_mla.py` | Triton kernel |
+
+---
+
+## 6. Fused Operations with MLA
+
+AITER provides fused kernels that combine MLA-adjacent operations to reduce memory round-trips and kernel launch overhead.
+
+### RoPE + Cache Fusion
+
+| Operation | Backend | Description |
+|-----------|---------|-------------|
+| `concat_and_cache_mla` | ASM | Concatenate kv_latent + k_rope into paged cache |
+| `fused_qk_rope_concat_and_cache_mla` | ASM | Fuse RoPE + Q/K concatenation + cache write |
+| `fused_qk_rope_cat_and_cache_mla` | Triton | Triton version of RoPE + cache fusion |
+| `fused_fp8_bmm_rope_cat_and_cache_mla` | Triton | + FP8 GEMM for latent projection |
+| `fused_fp4_bmm_rope_cat_and_cache_mla` | Triton | + FP4 (MXFP4) GEMM for latent projection |
+
+### Fused BMM + RoPE + Cache (Triton)
+
+Combines the latent projection GEMM (FP4/FP8), RoPE application, and KV cache write into a single kernel launch:
+
+```python
+from aiter.ops.triton.fusions.fused_bmm_rope_kv_cache import (
+    fused_fp4_bmm_rope_cat_and_cache_mla,
+)
+
+# FP4 latent projection + RoPE + cache write in one kernel
+q_out, decode_q_pe_out, k_pe_out, _ = fused_fp4_bmm_rope_cat_and_cache_mla(
+    q_nope,             # (QH, B, P)
+    w_k,                # FP4 weights: (QH, kv_lora_rank, P//2)
+    w_k_scale,          # E8M0 scales: (QH, kv_lora_rank, P//32)
+    q_pe, k_nope, k_rope,
+    kv_cache, slot_mapping,
+    positions, cos, sin,
+)
+```
+
+### ASM Cache Operations
+
+```python
+from aiter.ops.cache import (
+    concat_and_cache_mla,                       # Basic MLA cache write
+    fused_qk_rope_concat_and_cache_mla,        # + RoPE fusion
+)
+
+# Basic: concatenate latent + rope and write to paged cache
+concat_and_cache_mla(
+    kv_c,               # [num_tokens, kv_heads, kv_lora_rank]
+    k_pe,               # [num_tokens, kv_heads, qk_rope_head_dim]
+    kv_cache,            # [num_pages, page_size, kv_heads, kv_lora_rank + qk_rope_head_dim]
+    slot_mapping,
+    kv_cache_dtype="auto",
+    scale=1.0,
+)
+
+# Fused: RoPE + concat + cache in one kernel
+fused_qk_rope_concat_and_cache_mla(
+    q_nope, q_pe, kv_c, k_pe,
+    kv_cache, q_out,
+    slot_mapping, k_scale, q_scale,
+    positions, cos_cache, sin_cache,
+    is_neox=True, is_nope_first=True,
+)
+```
+
+### When to Use
+
+- Always prefer fused operations over separate RoPE + cache write
+- FP4/FP8 fused BMM is unique to Triton and not available in ASM
+- ASM fused cache is preferred for production BF16/FP8 workloads
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/cache.py` | ASM cache operations |
+| `aiter/ops/triton/fusions/fused_kv_cache.py` | Triton RoPE + cache |
+| `aiter/ops/triton/fusions/fused_bmm_rope_kv_cache.py` | Triton BMM + RoPE + cache |
+
+---
+
+## 7. Data Type & Quantization Support Matrix
+
+### By Backend and Variant
+
+| Configuration | ASM Decode | ASM Prefill | Triton Decode | Triton Fused BMM |
+|--------------|:---:|:---:|:---:|:---:|
+| **BF16 Q x BF16 KV** | Yes | Yes | Yes | Yes (activation) |
+| **FP8 Q x FP8 KV** | Yes (GQA=16,128) | Yes (GQA=1,128) | - | Yes (GEMM weights) |
+| **BF16 Q x FP8 KV** | Yes (GQA=16, persistent) | - | - | - |
+| **FP4 (MXFP4) GEMM** | - | - | - | Yes |
+| **FP16** | - | - | Yes (implicit) | - |
+| **FP32 accumulator** | - | - | Yes | - |
+
+### Choosing the Right Data Type
+
+```
+Need maximum accuracy?
+├── Yes → BF16 Q x BF16 KV (any backend)
+└── No
+    ├── Need reduced KV cache memory?
+    │   ├── FP8 Q x FP8 KV → ASM (native attention)
+    │   └── BF16 Q x FP8 KV → ASM persistent (mixed precision)
+    ├── Need compressed latent projection?
+    │   ├── FP8 GEMM + BF16 attention → Triton fused BMM
+    │   └── FP4 GEMM + BF16 attention → Triton fused BMM (max compression)
+    └── Need portability?
+        └── BF16 Triton decode (works on any GPU)
+```
+
+---
+
+## 8. GQA (Grouped Query Attention) Ratio Support
+
+| GQA Ratio | ASM Decode | ASM Persistent | ASM Prefill | Triton |
+|-----------|:---:|:---:|:---:|:---:|
+| **1 (full MHA)** | - | - | Yes (FP8 prefill) | Yes |
+| **16** | Yes (all dtypes) | Yes (native) | Yes | Yes |
+| **32** | Yes (BF16 only) | Yes (simulated) | - | Yes |
+| **48, 64, 80, 96, 112** | Yes (BF16, select) | Yes (simulated, step 16) | - | Yes |
+| **128** | Yes (FP8 only) | Yes (FP8 native) | Yes | Yes |
+| **Arbitrary** | - | - | - | Yes (runtime param) |
+
+**Note:** ASM persistent mode simulates GQA ratios 32-112 by viewing `nhead_kv` heads as `nhead_kv * (gqa/16)` heads with adjusted dimensions, then dispatching to the GQA=16 kernel.
+
+---
+
+## 9. KV Cache Layouts
+
+### Standard Layout (All Variants)
+
+```
+kv_cache: [num_pages, page_size, num_kv_heads, kv_lora_rank + qk_rope_head_dim]
+```
+
+### 3-Buffer Layout (FP8 Persistent Prefill)
+
+```
+kv_nope_buffer_fp8:         [num_pages, page_size, 1, kv_lora_rank]        # FP8
+kv_nope_scale_factors_fp32: [num_pages, page_size, 1, scale_dim]           # FP32
+kv_rope_buffer_bf16:        [num_pages, page_size, 1, qk_rope_head_dim]    # BF16
+```
+
+### Page Size Support
+
+| Page Size | ASM | Triton Decode | Triton Fused Cache |
+|-----------|:---:|:---:|:---:|
+| **1** (token-level) | Yes | Yes | Yes |
+| **64** (block-level) | Yes (select kernels) | - | Yes |
+
+---
+
+## 10. RoPE (Rotary Position Encoding) Support
+
+### Styles
+
+| Style | Description | Backend Support |
+|-------|-------------|----------------|
+| **GPT-J** (block) | Pairs consecutive dimensions: (0,1), (2,3), ... | ASM + Triton |
+| **NeoX** (interleaved) | Pairs split dimensions: (0, N/2), (1, N/2+1), ... | ASM + Triton |
+
+### RoPE Application Points
+
+1. **In-kernel** (during attention): Both ASM and Triton fuse RoPE into the attention kernel, applying it to q_pe and k_pe before QK^T
+2. **During caching** (fused cache write): `fused_qk_rope_concat_and_cache_mla` (ASM) and `fused_qk_rope_cat_and_cache_mla` (Triton) apply RoPE while writing to the KV cache
+
+### Configuration
+
+```python
+# RoPE parameters
+qk_rope_head_dim = 64           # rotary dimension
+cos_sin_cache.shape              # [max_seq_len, rotary_dim] or [max_seq_len, rotary_dim//2]
+is_neox_style = True             # NeoX vs GPT-J
+```
+
+---
+
+## 11. Backend Comparison: How to Choose
+
+### Performance Characteristics
+
+| Backend | Strengths | Weaknesses |
+|---------|-----------|------------|
+| **ASM** | Best raw performance, decode+prefill+persistent, FP8 native | Fixed configs, arch-specific, no portability |
+| **Triton** | Portable, arbitrary GQA, sparse support, FP4 GEMM fusion | No prefill, seqlen_q=1 only, page_size=1 only |
+
+### Decision Tree
+
+```
+Is this for prefill (context processing)?
+├── Yes → ASM Prefill (standard or persistent)
+└── No (decode / token generation)
+    ├── Need persistent scheduling (production)?
+    │   └── ASM Persistent Decode
+    ├── Need multi-token prediction (seqlen_q > 1)?
+    │   └── ASM Decode (seqlen_q=2,4,8)
+    ├── Need sparse / Top-K attention?
+    │   └── Triton Sparse MLA
+    ├── Need FP4 latent projection?
+    │   └── Triton Fused BMM+RoPE+Cache
+    ├── Need arbitrary GQA ratio?
+    │   └── Triton Decode RoPE
+    ├── Need portability (non-MI300X/MI350)?
+    │   └── Triton Decode RoPE
+    └── Standard decode (production)?
+        └── ASM Standard Decode
+```
+
+---
+
+## 12. GPU Architecture Support Summary
+
+| MLA Variant | MI300X (GFX942) | MI350 (GFX950) | Other GPUs |
+|-------------|:---:|:---:|:---:|
+| Standard Decode (ASM) | Yes (21 kernels) | Yes (20 kernels) | - |
+| Persistent Decode (ASM) | Yes | Yes | - |
+| Standard Prefill (ASM) | Yes | Yes | - |
+| Persistent Prefill (ASM) | Yes | Yes | - |
+| Triton Decode RoPE | Yes (tuned) | Yes (tuned) | Yes (portable) |
+| Sparse MLA (Triton) | Yes | Yes | Yes (portable) |
+| Fused BMM+Cache (Triton) | Yes | Yes | Yes (portable) |
+
+### ASM Kernel Inventory
+
+| Architecture | Decode Kernels | Persistent Kernels | Prefill Kernels | Total |
+|-------------|:-:|:-:|:-:|:-:|
+| **GFX942 (MI300X)** | 10 | 7 | 4 | 21 |
+| **GFX950 (MI350)** | 10 | 6 | 4 | 20 |
+
+Kernel configurations are cataloged in `hsa/gfx942/mla/mla_asm.csv` and `hsa/gfx950/mla/mla_asm.csv` with columns: `qType, kvType, Gqa, ps, qSeqLen, prefill, causal, knl_name, co_name`.
+
+---
+
+## 13. Performance Tuning
+
+### Split-K Auto-Tuning
+
+MLA automatically selects the optimal split-K count based on:
+
+```python
+# Factors considered:
+# - Batch size (bs)
+# - Total KV sequence length (total_kv)
+# - Number of CUs
+# - Data type
+# - Overhead constant (empirically 84.1)
+
+# Tests splits 1-16 and picks best using:
+# throughput = (bs * i) / ceil(bs * i / cu_num) * avg_kv / (avg_kv + overhead * i)
+```
+
+Override by passing `num_kv_splits` explicitly to `mla_decode_fwd()`.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AITER_LOG_LEVEL` | Logging verbosity (DEBUG, INFO, WARNING, ERROR) | INFO |
+| `AITER_LOG_MORE` | Enable detailed logging with line numbers | 0 |
+| `AITER_TRITON_CONFIGS_PATH` | Path to Triton kernel config JSONs | Built-in |
+
+### Key Parameters
+
+- **num_kv_splits**: Split-K count (1-16). Higher values improve parallelism for long sequences but add reduction overhead.
+- **page_size**: KV cache page granularity. page_size=1 (default) for token-level, page_size=64 for block-level (fewer metadata, better for long contexts).
+- **intra_batch_mode**: When True, enables intra-batch parallelism for persistent mode (useful when batch size < num_CUs).
+- **fast_mode**: Metadata generation mode. True (default) optimizes for speed.
+
+---
+
+## 14. Test Files Reference
+
+| Test File | Covers |
+|-----------|--------|
+| `op_tests/test_mla.py` | Standard decode: BF16/FP8, GQA=16/128, variable contexts |
+| `op_tests/test_mla_persistent.py` | Persistent decode: BF16/FP8, GQA=16/128, page_size=1/64 |
+| `op_tests/test_mla_sparse.py` | Sparse attention: Top-K, block tables, FP8 |
+| `op_tests/test_mla_prefill_ps.py` | Persistent prefill: causal, 3-buffer, FP8 (GFX950) |
+| `op_tests/test_concat_cache_mla.py` | Cache concatenation operations |
+| `op_tests/triton_tests/attention/test_mla_decode_rope.py` | Triton RoPE decode, split-K, paged cache |
+| `op_tests/triton_tests/attention/test_unified_attention_sparse_mla.py` | Triton sparse: Top-K, block tables |
+| `op_tests/triton_tests/utils/mla_decode_ref.py` | Reference decode implementation |
+| `op_tests/triton_tests/utils/mla_extend_ref.py` | Reference extend/prefill implementation |
+
+### Benchmarks
+
+| Benchmark File | Coverage |
+|----------------|----------|
+| `op_tests/op_benchmarks/triton/bench_mla_decode.py` | Model-level decode performance |
+| `op_tests/op_benchmarks/triton/bench_mla_decode_rope.py` | RoPE decode performance |
+
+---
+
+## 15. Source Files Reference
+
+### Main API
+
+| File | Purpose |
+|------|---------|
+| `aiter/mla.py` | Primary MLA API: decode, prefill, persistent, reduction |
+| `aiter/ops/attention.py` | ASM kernel dispatch, metadata generation, reduce functions |
+| `aiter/ops/cache.py` | KV cache operations (concat, fused RoPE + cache) |
+
+### Triton Kernels
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/attention/mla_decode_rope.py` | Triton decode with RoPE wrapper |
+| `aiter/ops/triton/attention/unified_attention_sparse_mla.py` | Sparse MLA wrapper |
+| `aiter/ops/triton/_triton_kernels/attention/mla_decode_rope.py` | Triton decode kernel implementation |
+| `aiter/ops/triton/_triton_kernels/attention/unified_attention_sparse_mla.py` | Sparse MLA kernel implementation |
+
+### Fused Operations (Triton)
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/fusions/fused_kv_cache.py` | RoPE + KV cache fusion |
+| `aiter/ops/triton/fusions/fused_bmm_rope_kv_cache.py` | FP4/FP8 BMM + RoPE + cache fusion |
+| `aiter/ops/triton/_triton_kernels/fusions/fused_kv_cache.py` | Fused cache kernel |
+| `aiter/ops/triton/_triton_kernels/fusions/fused_bmm_rope_kv_cache.py` | Fused BMM kernel |
+
+### ASM Kernels
+
+| File | Purpose |
+|------|---------|
+| `hsa/gfx942/mla/mla_asm.csv` | MI300X kernel dispatch catalog |
+| `hsa/gfx942/mla/*.co` | MI300X compiled kernel binaries |
+| `hsa/gfx950/mla/mla_asm.csv` | MI350 kernel dispatch catalog |
+| `hsa/gfx950/mla/*.co` | MI350 compiled kernel binaries |
+| `csrc/kernels/mla/` | C++ metadata and reduce kernels |
+
+### AOT Compilation
+
+| File | Purpose |
+|------|---------|
+| `aiter/aot/triton/decode_mla.py` | Ahead-of-time compilation for Triton MLA |

--- a/docs/moe_variants_guide.md
+++ b/docs/moe_variants_guide.md
@@ -1,0 +1,439 @@
+# AITER MOE (Mixture of Experts) Variants & Backend Guide
+
+This guide documents all MOE variants available in AITER, their backend support, and how to choose the right configuration for your use case.
+
+---
+
+## Quick Reference: Which MOE Configuration Should I Use?
+
+| Use Case | Recommended Config | Backend | Why |
+|----------|-------------------|---------|-----|
+| **BF16 inference (best accuracy)** | Standard FusedMOE, `QuantType.No` | ASM or CK | No quantization loss |
+| **FP8 inference (balanced)** | FP8 W8A8 per-token | ASM | Good accuracy/perf tradeoff |
+| **FP8 inference (high accuracy)** | FP8 block-scale (128x128) | CK or ASM | Per-block scales reduce error |
+| **Maximum compression** | MXFP4 W4A16 | Triton (MXFP4) or CK | 4x weight reduction |
+| **DeepSeek-V3 style** | 256 experts, TopK=8 | ASM | Optimized topk_softmax for (256,8) |
+| **Distributed (multi-GPU)** | EP MOE with expert_mask | ASM or CK | Experts split across GPUs |
+| **Shared experts (DP)** | DP Shared Expert MOE | ASM or CK | All experts replicated |
+| **Prototyping / new models** | Triton FusedMOE | Triton | Easy to modify, broadest dtype |
+
+---
+
+## 1. MOE Architecture in AITER
+
+AITER implements a two-stage Fused MOE pipeline:
+
+```
+Input Tokens                    Output Tokens
+     │                               ▲
+     ▼                               │
+┌─────────┐                    ┌─────────┐
+│ Routing  │ (TopK Softmax     │ Stage 2 │ GEMM: intermediate → output
+│ + Sort   │  or Sigmoid)      │  (w2)   │ + routing weight application
+└────┬────┘                    └────┬────┘
+     │                               ▲
+     ▼                               │
+┌─────────┐                    ┌──────────┐
+│ Stage 1 │ GEMM: input →     │Activation│ SiLU, GELU, or Swiglu
+│  (w1)   │ intermediate      │  Fusion  │ (fused in Stage 1 kernel)
+└─────────┘                    └──────────┘
+```
+
+### Key Concepts
+
+- **G1U1 mode**: Gate and Up projections are combined in a single weight matrix. Stage 1 produces `gate * up` in one GEMM. This is the standard for most MOE models.
+- **G1U0 mode**: Gate-only projection. Stage 1 produces just the gated output.
+- **Routing weights**: TopK expert selection weights, applied either at Stage 1 (`doweight_stage1=True`) or Stage 2.
+- **Token sorting**: Tokens are reordered by expert assignment before GEMM to improve cache locality.
+
+---
+
+## 2. MOE Variants
+
+### 2.1 Standard Fused MOE
+
+The default and most commonly used variant. Supports the full range of quantization types and backends.
+
+**Backends:** ASM, CK (C++), Triton
+
+```python
+from aiter.fused_moe import fused_moe, fused_topk
+from aiter import ActivationType, QuantType
+
+# Step 1: Route tokens to experts
+topk_weights, topk_ids = fused_topk(
+    hidden_states, gating_output,
+    topk=2, renormalize=True
+)
+
+# Step 2: Execute MOE
+output = fused_moe(
+    hidden_states, w1, w2,
+    topk_weights, topk_ids,
+    activation=ActivationType.Silu,
+    quant_type=QuantType.No,
+)
+```
+
+---
+
+### 2.2 Expert Parallel (EP) MOE
+
+Distributes experts across multiple GPUs. Each GPU holds a subset of experts and only processes tokens routed to its local experts.
+
+**Backends:** ASM, CK (C++)
+
+```python
+# Define which experts are local to this GPU
+expert_mask = torch.zeros(global_num_experts, dtype=torch.bool, device=device)
+expert_mask[local_start:local_end] = True
+
+output = fused_moe(
+    hidden_states, w1, w2,
+    topk_weights, topk_ids,
+    expert_mask=expert_mask,
+)
+```
+
+**When to use:** When the total expert weights exceed single-GPU memory, or when you want to scale to more experts than one GPU can handle.
+
+---
+
+### 2.3 Data Parallel (DP) MOE with Shared Experts
+
+All experts are replicated across GPUs. Each GPU processes a subset of tokens (split by DP rank) and accumulates results via atomic operations.
+
+**Backends:** ASM, CK (C++), Triton
+
+```python
+from aiter.fused_moe_dp_shared_expert import fused_moe_dp_share_expert
+
+output = fused_moe_dp_share_expert(
+    hidden_states, w1, w2,
+    quant_type=QuantType.per_Token,
+    dp_size=world_size,
+    dp_rank=rank,
+    moe_buf=output_buffer,  # optional pre-allocated buffer for accumulation
+)
+```
+
+**When to use:** When expert weights fit on each GPU and you want simpler communication patterns than EP.
+
+---
+
+### 2.4 Block-Scale FP8 MOE
+
+Uses per-block quantization (typically 128x128 blocks) for FP8, reducing quantization error compared to per-tensor FP8.
+
+**Backends:** CK (preferred), ASM
+
+```python
+output = fused_moe(
+    hidden_states, w1_fp8, w2_fp8,
+    topk_weights, topk_ids,
+    w1_scale=fc1_block_scale,  # shape: [E, inter_dim/128, model_dim/128]
+    w2_scale=fc2_block_scale,  # shape: [E, model_dim/128, inter_dim/128]
+    quant_type=QuantType.per_1x128,
+    activation=ActivationType.Silu,
+)
+```
+
+**When to use:** When you want FP8 performance with better accuracy than per-tensor quantization.
+
+---
+
+### 2.5 MXFP4 MOE
+
+Microscaling FP4 quantization with per-32-element scaling. Provides 4x weight compression with E8M0 scale format.
+
+**Backends:** Triton (primary), CK (gfx950 preferred)
+
+```python
+output = fused_moe(
+    hidden_states, w1_mxfp4, w2_mxfp4,
+    topk_weights, topk_ids,
+    w1_scale=fc1_e8m0_scale,  # E8M0 format scales
+    w2_scale=fc2_e8m0_scale,
+    quant_type=QuantType.per_1x32,
+    activation=ActivationType.Silu,
+)
+```
+
+**When to use:** When maximum weight compression is needed (4x savings), especially on MI350 (gfx950) which has native FP4 support.
+
+---
+
+### 2.6 End-to-End (E2E) MOE
+
+Combines routing, GEMM, activation, and output permutation into a single kernel launch, reducing kernel launch overhead.
+
+**Backends:** Triton (experimental)
+
+```python
+from aiter.ops.triton.moe.moe_op_e2e import e2e_moe
+
+output = e2e_moe(
+    hidden_states, w1, w2,
+    topk_weights, topk_ids,
+    ...
+)
+```
+
+**When to use:** Experimental; may help with small batch sizes where kernel launch overhead is significant.
+
+---
+
+## 3. Routing / Expert Selection
+
+### TopK Softmax
+
+Standard routing: apply softmax to gating logits, then select top-K experts.
+
+**Backends:** ASM (optimized), HIP/CUDA (fallback)
+
+```python
+from aiter.ops.moe_op import topk_softmax
+
+topk_weights, topk_ids = topk_softmax(
+    gating_output,  # [num_tokens, num_experts]
+    topk=2,
+    renormalize=True,
+)
+```
+
+**ASM-optimized configurations:**
+| (num_experts, topk) | ASM Optimized |
+|---------------------|:---:|
+| (128, 4) | Yes |
+| (128, 6) | Yes |
+| (128, 8) | Yes |
+| (256, 6) | Yes |
+| (256, 8) | Yes |
+| Other | Falls back to HIP/CUDA |
+
+### TopK Sigmoid
+
+Alternative routing using sigmoid activation. Used in some model architectures for binary-like expert selection.
+
+**Backends:** Triton, HIP/CUDA
+
+```python
+from aiter.ops.moe_op import topk_sigmoid
+
+topk_weights, topk_ids = topk_sigmoid(
+    gating_output,
+    topk=1,
+)
+```
+
+---
+
+## 4. Data Type & Quantization Support Matrix
+
+### By Backend
+
+| Quantization | ASM (GFX942) | CK (C++) | Triton | Description |
+|-------------|:---:|:---:|:---:|-------------|
+| **No (BF16/FP16)** | Yes | Yes | Yes | Full precision, no quantization |
+| **FP8 W8A8 per-token** | Yes | Yes | Yes | Per-token FP8 quantization |
+| **FP8 block-scale (per 128x128)** | Yes | Yes | Yes | Per-block FP8 quantization |
+| **INT8 W8A8** | Yes | Yes | Yes | Per-token INT8, both weights and activations |
+| **INT8 W8A16** | Yes | Yes | - | INT8 weights, BF16 activations |
+| **MXFP4 W4A16** | - | - | Yes | MXFP4 weights, BF16 activations |
+| **MXFP4 W4A4** | - | - | Yes | MXFP4 weights and activations |
+| **MXFP4 (per 32-element)** | Yes | Yes | Yes | Microscaling FP4 with E8M0 scales |
+
+### Choosing the Right Quantization
+
+```
+Need maximum accuracy?
+├── Yes → QuantType.No (BF16)
+└── No
+    ├── Need good accuracy with 2x compression?
+    │   ├── FP8 block-scale (QuantType.per_1x128) — best accuracy/compression
+    │   └── FP8 per-token (QuantType.per_Token) — simpler, slightly less accurate
+    ├── Need 4x compression?
+    │   ├── MXFP4 (QuantType.per_1x32) — best for MI350
+    │   └── MXFP4 W4A16 — Triton only, good accuracy
+    └── Need INT8 compatibility?
+        ├── INT8 W8A8 — both quantized
+        └── INT8 W8A16 — keep activations in BF16
+```
+
+---
+
+## 5. Activation Function Support
+
+| Activation | ASM | CK | Triton | Typical Use |
+|-----------|:---:|:---:|:---:|-------------|
+| **SiLU** (Swish + Gate) | Yes | Yes | Yes | LLaMA, Mistral, DeepSeek, most modern LLMs |
+| **GELU** | Yes | Yes | Yes | GPT, OPT, BLOOM |
+| **Swiglu** | - | Yes (FP4 preshuffle) | Limited | Some specialized architectures |
+
+```python
+from aiter import ActivationType
+
+# Select activation
+activation = ActivationType.Silu   # Most common
+activation = ActivationType.Gelu   # For GPT-style models
+```
+
+---
+
+## 6. Backend Comparison
+
+### Performance Characteristics
+
+| Backend | Strengths | Best For |
+|---------|-----------|----------|
+| **ASM** | Highest throughput, hand-tuned for MI300X | Production inference on MI300X |
+| **CK (C++)** | Good performance, broad dtype, 2-stage pipeline | Production on MI300X/MI350 |
+| **Triton** | Most flexible, broadest quantization support | Prototyping, MXFP4, new GPUs |
+
+### Automatic Backend Selection
+
+AITER automatically selects the best backend based on your configuration:
+
+1. **Tuned configs**: AITER ships with pre-tuned kernel configurations for common model shapes in `aiter/configs/tuned_fmoe.csv`. These specify the optimal kernel for each (token_count, model_dim, inter_dim, expert_count, topk, dtype) combination.
+
+2. **Fallback**: If no tuned config matches, AITER uses heuristics to pick a reasonable default.
+
+3. **Override**: You can control backend selection via environment variables:
+   ```bash
+   AITER_BYPASS_TUNE_CONFIG=1   # Skip tuned configs, use defaults
+   AITER_ONLINE_TUNE=1          # Auto-tune at runtime for untuned configs
+   ```
+
+### Kernel Naming Convention (CK 2-Stage)
+
+CK kernel names encode their configuration:
+```
+moe_ck2stages_gemm1_256x64x128x64_1x4_TypeCast_v3_silu_B16_B16_B16
+         │      │        │         │     │        │    │    │    │
+         │      │   tile sizes     │  variant  activation │  dtype_c
+         │    stage            grouping             dtype_a  dtype_b
+       backend
+```
+
+---
+
+## 7. GPU Architecture Support
+
+### MI300X (GFX942)
+
+- **Compute Units:** 304
+- **Memory:** 192 GB HBM3, ~5.3 TB/s bandwidth
+- **Preferred backends:** ASM (hand-tuned), CK
+- **Optimal block sizes:** M=64, N=128, K=256
+- **Best for:** High-throughput inference, all quantization types
+
+### MI350 (GFX950)
+
+- **Compute Units:** 256+
+- **Memory:** HBM3E
+- **Preferred backends:** CK, Triton (MXFP4)
+- **Native FP4 support:** Yes (hardware acceleration for MXFP4)
+- **Best for:** MXFP4 quantized models, next-gen deployments
+
+### Support Matrix
+
+| Feature | MI300X (GFX942) | MI350 (GFX950) | Other GPUs |
+|---------|:---:|:---:|:---:|
+| ASM kernels | Yes (full) | Yes (full) | No |
+| CK kernels | Yes | Yes | No |
+| Triton kernels | Yes | Yes | Yes (portable) |
+| TopK Softmax ASM | Yes | Yes | No |
+| MXFP4 native | Software | Hardware | Triton only |
+
+---
+
+## 8. Common Model Configurations
+
+AITER includes pre-tuned configurations for popular MOE models:
+
+| Model | Experts | TopK | Hidden | Intermediate | Recommended |
+|-------|---------|------|--------|-------------|-------------|
+| Mixtral 8x7B | 8 | 2 | 4096 | 14336 | BF16 or FP8 W8A8 |
+| Mixtral 8x22B | 8 | 2 | 6144 | 16384 | BF16 or FP8 W8A8 |
+| DeepSeek-V2 | 160 | 6 | 5120 | 1536 | FP8 block-scale |
+| DeepSeek-V3 | 256 | 8 | 7168 | 2048 | FP8 block-scale |
+| Qwen3-235B | 128 | 8 | 4096 | 12288 | FP8 or MXFP4 |
+
+---
+
+## 9. Performance Tuning
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AITER_CONFIG_FMOE=<path>` | Override tuned config CSV | Built-in |
+| `AITER_USE_NT=1` | Enable non-temporal memory loads | 0 |
+| `AITER_KSPLIT=<value>` | Override K-split factor | Auto |
+| `AITER_ONLINE_TUNE=1` | Auto-tune untuned configurations | 0 |
+| `AITER_BYPASS_TUNE_CONFIG=1` | Skip tuned configs | 0 |
+
+### Key Tuning Parameters
+
+- **block_size_M**: Token batch per kernel block (16, 32, 64, 128). Larger = better throughput, but more padding waste for small batches.
+- **ksplit**: K-dimension splitting (0-8). Higher values improve parallelism for compute-bound cases.
+- **doweight_stage1**: Apply routing weights in Stage 1 instead of Stage 2. Reduces memory bandwidth at the cost of slightly different numerics.
+- **use_non_temporal_load**: Skip L2 cache for weight loads. Helps when weights are large and won't be reused.
+
+---
+
+## 10. Test Files Reference
+
+| Test File | Covers |
+|-----------|--------|
+| `op_tests/test_moe.py` | Standard FusedMOE, all backends |
+| `op_tests/test_moe_2stage.py` | 2-stage pipeline |
+| `op_tests/test_moe_ep.py` | Expert Parallel |
+| `op_tests/test_moe_dp_share_expert.py` | DP Shared Expert |
+| `op_tests/test_moe_blockscale.py` | FP8 block-scale |
+| `op_tests/test_moeTopkSoftmax.py` | TopK Softmax routing |
+| `op_tests/test_moe_topk_sigmoid.py` | TopK Sigmoid routing |
+| `op_tests/test_moe_sorting.py` | Token sorting/permutation |
+| `op_tests/test_moe_sorting_mxfp4.py` | MXFP4 sorting |
+| `op_tests/test_moe_tkw1.py` | Weight-at-Stage-1 variant |
+| `op_tests/triton_tests/moe/test_moe.py` | Triton MOE (all dtypes) |
+| `op_tests/triton_tests/moe/test_moe_gemm_a8w8.py` | Triton FP8 W8A8 |
+| `op_tests/triton_tests/moe/test_moe_gemm_a8w8_blockscale.py` | Triton FP8 block-scale |
+| `op_tests/triton_tests/moe/test_moe_gemm_a4w4.py` | Triton MXFP4 |
+
+---
+
+## 11. Source Files Reference
+
+### Main API
+
+| File | Purpose |
+|------|---------|
+| `aiter/fused_moe.py` | Primary FusedMOE API, backend dispatch |
+| `aiter/fused_moe_bf16_asm.py` | ASM backend wrapper |
+| `aiter/fused_moe_dp_shared_expert.py` | DP Shared Expert variant |
+| `aiter/ops/moe_op.py` | TopK routing and MOE utilities |
+| `aiter/ops/moe_sorting.py` | Token sorting operations |
+
+### Triton Kernels
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/moe/moe_op.py` | Standard fused GEMM |
+| `aiter/ops/triton/moe/moe_op_silu_fused.py` | Fused SiLU activation |
+| `aiter/ops/triton/moe/moe_op_gelu.py` | Fused GELU activation |
+| `aiter/ops/triton/moe/moe_op_e2e.py` | End-to-End MOE |
+| `aiter/ops/triton/moe/moe_op_mxfp4.py` | MXFP4 quantized MOE |
+| `aiter/ops/triton/moe/moe_op_mxfp4_silu_fused.py` | MXFP4 + SiLU fused |
+| `aiter/ops/triton/moe/moe_routing_sigmoid_top1_fused.py` | TopK Sigmoid routing |
+
+### Configuration
+
+| File | Purpose |
+|------|---------|
+| `aiter/configs/tuned_fmoe.csv` | Pre-tuned kernel configurations |
+| `aiter/configs/untuned_fmoe.csv` | Fallback configurations |
+| `hsa/gfx942/fmoe/` | MI300X single-stage ASM configs |
+| `hsa/gfx942/fmoe_2stages/` | MI300X 2-stage ASM configs |
+| `hsa/gfx950/fmoe/` | MI350 single-stage ASM configs |
+| `hsa/gfx950/fmoe_2stages/` | MI350 2-stage ASM configs |

--- a/docs/normalization_guide.md
+++ b/docs/normalization_guide.md
@@ -1,0 +1,405 @@
+# AITER Normalization Variants & Backend Guide
+
+This guide documents all normalization operators available in AITER (RMSNorm, LayerNorm, GroupNorm), their fused variants, backend support, and how to choose the right one for your use case.
+
+---
+
+## Quick Reference: Which Normalization Should I Use?
+
+| Use Case | Recommended Variant | Backend | Why |
+|----------|-------------------|---------|-----|
+| **Standard LLM inference** | RMSNorm | ASM | Best latency, used by LLaMA/Mistral/DeepSeek |
+| **LLM with residual stream** | Fused Add + RMSNorm | CK or ASM | One kernel for residual add + normalize |
+| **Quantized inference (FP8)** | RMSNorm + Dynamic Quant | ASM | Fused normalize + per-token FP8 quantize |
+| **SmoothQuant inference** | RMSNorm + SmoothQuant | CK | Fused normalize + two-scale quantize |
+| **BERT/GPT-2 style models** | LayerNorm | CK | Full LayerNorm with bias support |
+| **Vision models (ViT, UNet)** | GroupNorm | CK | Group-wise normalization |
+| **Distributed inference** | RS + RMSNorm + Quant + AG | Triton (Iris) | Fused communication + normalize + quantize |
+| **Prototyping / new models** | Triton variants | Triton | Portable, supports training (backward pass) |
+
+---
+
+## 1. RMSNorm (Root Mean Square Normalization)
+
+The primary normalization used in modern LLMs (LLaMA, Mistral, DeepSeek, Qwen). Simpler and faster than LayerNorm since it omits the mean-centering step.
+
+**Formula**: `output = input * weight / sqrt(mean(input^2) + epsilon)`
+
+### Backend Support
+
+| Feature | CK | ASM | Triton |
+|---------|:---:|:---:|:---:|
+| **Basic RMSNorm** | Yes | Yes | Yes |
+| **Fused Add + RMSNorm** | Yes | Yes | Yes |
+| **+ SmoothQuant** | Yes | - | Yes |
+| **+ Dynamic Quant (per-token)** | Yes | Yes | Yes |
+| **+ Dynamic Quant (per-group)** | - | Yes | Yes |
+| **+ Pad to multiple** | - | - | Yes |
+| **Backward pass (training)** | - | - | Yes |
+| **BF16 / FP16 input** | Yes | Yes | Yes |
+| **FP32 input** | - | - | Yes |
+| **Model-sensitive mode** | Yes | - | - |
+| **N > 8192** | Yes | - | Yes |
+| **Shuffle layout scales** | - | Yes | - |
+
+### Key API Functions
+
+```python
+import aiter
+
+# Basic RMSNorm
+out = aiter.rmsnorm2d_fwd(input, weight, epsilon)
+
+# Fused Add + RMSNorm (residual connection)
+aiter.rmsnorm2d_fwd_with_add(out, input, residual_in, residual_out, weight, epsilon)
+
+# RMSNorm + SmoothQuant (two-scale quantization)
+aiter.rmsnorm2d_fwd_with_smoothquant(out, input, xscale, yscale, weight, epsilon)
+
+# Fused Add + RMSNorm + SmoothQuant
+aiter.rmsnorm2d_fwd_with_add_smoothquant(
+    out, input, residual_in, residual_out,
+    xscale, yscale, weight, epsilon
+)
+
+# RMSNorm + Dynamic Quantization (per-token)
+aiter.rmsnorm2d_fwd_with_dynamicquant(
+    out, input, yscale, weight, epsilon,
+    group_size=0, shuffle_scale=False
+)
+
+# Fused Add + RMSNorm + Dynamic Quantization
+aiter.rmsnorm2d_fwd_with_add_dynamicquant(
+    out, input, residual_in, residual_out,
+    yscale, weight, epsilon
+)
+```
+
+### ASM Backend (Direct)
+
+```python
+# ASM-optimized basic RMSNorm
+aiter.rmsnorm(out, input, weight, epsilon)
+
+# ASM: Add + RMSNorm
+aiter.add_rmsnorm(out, input, residual_in, residual_out, weight, epsilon)
+
+# ASM: RMSNorm + Quantize (per-token or per-group)
+aiter.rmsnorm_quant(out, input, scale, weight, epsilon,
+                    group_size=0, shuffle_scale=False)
+
+# ASM: Add + RMSNorm + Quantize
+aiter.add_rmsnorm_quant(out, input, residual_in, residual_out,
+                        scale, weight, epsilon,
+                        group_size=0, shuffle_scale=False)
+```
+
+### Triton Backend
+
+```python
+from aiter.ops.triton.normalization.rmsnorm import (
+    rms_norm,                           # Basic forward
+    rmsnorm2d_fwd_with_add,             # Fused add
+    rmsnorm2d_fwd_with_smoothquant,     # SmoothQuant
+    rmsnorm2d_fwd_with_dynamicquant,    # Dynamic quant
+    rmsnorm2d_fwd_with_add_smoothquant, # Add + SmoothQuant
+    rmsnorm2d_fwd_with_add_dynamicquant,# Add + dynamic quant
+)
+```
+
+### Backend Dispatch Logic
+
+The dispatcher in `rmsnorm2d_fwd` and `rmsnorm2d_fwd_with_dynamicquant` selects the backend automatically:
+
+- **CK backend** when `use_model_sensitive_rmsnorm > 0` or `N > 8192`
+- **ASM backend** otherwise (for standard sizes, best latency)
+- **Triton** must be called explicitly via `aiter.ops.triton.normalization.rmsnorm`
+
+### Performance Notes
+
+- **Large M, small N** (M > 8192, N <= 2048): Triton has a specialized kernel path `_rmsnorm_kernel_large_m_small_n` with configurable BLOCK_M/BLOCK_N
+- **Per-group quantization** (`group_size > 0`): Only available on ASM backend; use group sizes 32 or 128
+- **Shuffle scale layout**: Optimizes scale tensor layout for downstream ASM kernels; only available on ASM
+
+---
+
+## 2. LayerNorm (Layer Normalization)
+
+Standard LayerNorm with learnable weight and bias. Used in BERT, GPT-2, and other architectures that require mean-centering.
+
+**Formula**: `output = (input - mean) / sqrt(variance + epsilon) * weight + bias`
+
+### Backend Support
+
+| Feature | CK | ASM | Triton |
+|---------|:---:|:---:|:---:|
+| **Basic LayerNorm** | Yes | - | Yes |
+| **Fused Add + LayerNorm** | Yes | Yes | Yes |
+| **+ SmoothQuant** | Yes | Yes | Yes |
+| **+ Dynamic Quant** | - | - | Yes |
+| **Backward pass (training)** | - | - | Yes |
+| **BF16 / FP16 input** | Yes | Yes | Yes |
+| **FP32 input** | - | - | Yes |
+| **x_bias (pre-norm bias)** | Yes | Yes | Yes |
+
+### Key API Functions
+
+```python
+import aiter
+
+# Basic LayerNorm
+out = aiter.layer_norm(input, weight, bias, epsilon)
+# or
+out = aiter.layernorm2d_fwd(input, weight, bias, epsilon)
+
+# Fused Add + LayerNorm
+aiter.layernorm2d_fwd_with_add(
+    out, input, residual_in, residual_out, weight, bias, epsilon
+)
+
+# LayerNorm + SmoothQuant
+aiter.layernorm2d_fwd_with_smoothquant(
+    out, input, xscale, yscale, weight, bias, epsilon
+)
+
+# Fused Add + LayerNorm + SmoothQuant
+aiter.layernorm2d_fwd_with_add_smoothquant(
+    out, input, residual_in, residual_out,
+    xscale, yscale, weight, bias, epsilon
+)
+```
+
+### ASM Backend (Direct)
+
+```python
+# ASM: Add + LayerNorm (residual)
+aiter.layernorm2d_with_add_asm(
+    out, input, residual_in, residual_out, weight, bias, epsilon
+)
+
+# ASM: Add + LayerNorm + SmoothQuant
+aiter.layernorm2d_with_add_smoothquant_asm(
+    out, input, residual_in, residual_out,
+    xscale, yscale, weight, bias, epsilon
+)
+```
+
+### Triton Backend
+
+```python
+from aiter.ops.triton.normalization.norm import (
+    layer_norm,                              # Basic forward
+    layernorm2d_fwd_with_add,                # Fused add
+    layernorm2d_fwd_with_dynamicquant,       # Dynamic quant
+    layernorm2d_fwd_with_smoothquant,        # SmoothQuant
+    layernorm2d_fwd_with_add_dynamicquant,   # Add + dynamic quant
+    layernorm2d_fwd_with_add_smoothquant,    # Add + SmoothQuant
+)
+```
+
+### x_bias Parameter
+
+LayerNorm supports an optional `x_bias` tensor that is added to the input before normalization. This is used in some model architectures that require a pre-normalization bias.
+
+```python
+# LayerNorm with pre-norm bias
+out = aiter.layer_norm(input, weight, bias, epsilon, x_bias=pre_bias)
+```
+
+---
+
+## 3. GroupNorm
+
+Group normalization divides channels into groups and normalizes within each group. Commonly used in vision models (UNet, ViT) where batch normalization is not suitable.
+
+### Backend Support
+
+| Feature | CK |
+|---------|:---:|
+| **Basic GroupNorm** | Yes |
+| **BF16 / FP16 input** | Yes |
+| **Affine (weight + bias)** | Yes |
+
+### Key API Functions
+
+```python
+from aiter import GroupNorm
+
+# Module-based API (drop-in replacement for torch.nn.GroupNorm)
+gn = GroupNorm(num_groups=32, num_channels=256)
+out = gn(input)
+
+# Functional API
+from aiter.ops.groupnorm import _groupnorm_run
+out = _groupnorm_run(input, num_groups, weight, bias, eps)
+```
+
+---
+
+## 4. Fused Add + RMSNorm + Pad
+
+A Triton-only variant that combines residual addition, RMS normalization, and output padding to a specified multiple. Useful for models that require dimension alignment.
+
+```python
+from aiter.ops.triton.normalization.fused_add_rmsnorm_pad import fused_add_rmsnorm_pad
+
+# RMSNorm with optional residual and padding
+output = fused_add_rmsnorm_pad(
+    x, weight, epsilon,
+    res=None,               # Optional residual tensor
+    x_pad_to_multiple=256   # Pad output N to multiple of this
+)
+# Returns (output,) or (output, residual_out) if residual provided
+```
+
+---
+
+## 5. Fused Q/K Norm + RoPE + Cache + Quantization
+
+Mega-fused kernels that combine head splitting, RMSNorm on Q and K, rotary position embedding, KV cache write, and quantization in a single kernel launch. These are the highest-performance path for LLM inference.
+
+### Standard RoPE Variant
+
+```python
+import aiter
+
+# Fused: split QKV → norm Q,K → apply RoPE → write KV cache → quantize
+aiter.fused_qk_norm_rope_cache_quant_shuffle(
+    qkv, num_heads_q, num_heads_k, num_heads_v, head_dim, eps,
+    qw, kw,                    # Q and K norm weights
+    cos_sin_cache,             # Pre-computed RoPE cos/sin
+    is_neox_style,             # True for NeoX rotation
+    pos_ids,                   # Position IDs for RoPE
+    k_cache, v_cache,          # KV cache tensors
+    slot_mapping,              # Cache slot mapping
+    kv_cache_dtype,            # "auto", "fp8", "int8"
+    k_scale, v_scale           # Quantization scales
+)
+
+# Per-token scaling variant
+aiter.fused_qk_norm_rope_cache_pts_quant_shuffle(...)
+
+# Dual-stream variant
+aiter.fused_qk_norm_rope_2way(...)
+```
+
+### Multimodal RoPE (MRoPE) Variant
+
+```python
+# 3D MRoPE for vision-language models
+aiter.fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(...)
+```
+
+---
+
+## 6. Distributed: Reduce-Scatter + RMSNorm + Quant + All-Gather
+
+For multi-GPU inference, this fused kernel combines distributed communication with normalization and quantization, minimizing inter-GPU synchronization overhead.
+
+```python
+from aiter.ops.triton.comms.fused.reduce_scatter_rmsnorm_quant_all_gather import (
+    reduce_scatter_rmsnorm_quant_all_gather,
+)
+```
+
+Requires the [Iris library](https://github.com/ROCm/iris) for GPU-initiated communication.
+
+---
+
+## 7. Quantization Integration
+
+### SmoothQuant
+
+Two-scale quantization that reduces quantization error by smoothing the activation distribution:
+
+- **xscale** `[N]` (per-column): Applied to input before normalization
+- **yscale** `[M, 1]` (per-row): Computed during normalization, output per-token scale
+
+```python
+# Pattern: input → (input * xscale) → norm → quantize → (output, yscale)
+aiter.rmsnorm2d_fwd_with_smoothquant(out, input, xscale, yscale, weight, epsilon)
+```
+
+### Dynamic Quantization
+
+Per-token quantization with scale computed on-the-fly:
+
+```python
+# Per-token: one scale per row
+aiter.rmsnorm2d_fwd_with_dynamicquant(out, input, yscale, weight, epsilon)
+
+# Per-group: group_size=32 or 128, scales per group
+aiter.rmsnorm2d_fwd_with_dynamicquant(
+    out, input, yscale, weight, epsilon,
+    group_size=128, shuffle_scale=False
+)
+```
+
+### Output Data Types
+
+| Backend | Output Types |
+|---------|-------------|
+| CK SmoothQuant | INT8 |
+| CK Dynamic Quant | INT8, FP8 |
+| ASM Quant | INT8, FP8, FP4x2 (GFX950) |
+| Triton Dynamic Quant | INT8, FP8 |
+
+---
+
+## 8. Decision Tree
+
+```
+Need normalization?
+├── LLM model (no bias needed)?
+│   ├── Standard inference → aiter.rmsnorm2d_fwd()
+│   ├── With residual connection → aiter.rmsnorm2d_fwd_with_add()
+│   ├── Need quantized output?
+│   │   ├── SmoothQuant → rmsnorm2d_fwd_with_smoothquant()
+│   │   ├── Per-token FP8 → rmsnorm2d_fwd_with_dynamicquant()
+│   │   └── Per-group FP8 → rmsnorm_quant(group_size=128)
+│   ├── Need training (backward) → Triton rms_norm()
+│   └── Multi-GPU → reduce_scatter_rmsnorm_quant_all_gather()
+├── Model with bias (BERT, GPT-2)?
+│   └── LayerNorm → aiter.layer_norm()
+└── Vision model?
+    └── GroupNorm → aiter.GroupNorm()
+```
+
+---
+
+## 9. Source Files
+
+| Component | Path |
+|-----------|------|
+| RMSNorm Python API | `aiter/ops/rmsnorm.py` |
+| LayerNorm Python API | `aiter/ops/norm.py` |
+| GroupNorm Python API | `aiter/ops/groupnorm.py` |
+| Triton RMSNorm kernels | `aiter/ops/triton/_triton_kernels/normalization/rmsnorm.py` |
+| Triton LayerNorm kernels | `aiter/ops/triton/_triton_kernels/normalization/norm.py` |
+| Triton Fused Add RMSNorm Pad | `aiter/ops/triton/_triton_kernels/normalization/fused_add_rmsnorm_pad.py` |
+| CK RMSNorm kernels | `csrc/py_itfs_ck/rmsnorm_ck_kernels.cu` |
+| CK LayerNorm kernels | `csrc/py_itfs_ck/norm_kernels.cu` |
+| ASM RMSNorm kernels | `csrc/kernels/rmsnorm_kernels.cu`, `csrc/kernels/rmsnorm_quant_kernels.cu` |
+| ASM LayerNorm kernels | `csrc/py_itfs_cu/asm_layernorm.cu` |
+| Fused QK Norm + RoPE | `aiter/ops/fused_qk_norm_rope_cache_quant.py` |
+| Fused QK Norm + MRoPE | `aiter/ops/fused_qk_norm_mrope_cache_quant.py` |
+| Distributed Fused Norm | `aiter/ops/triton/comms/fused/reduce_scatter_rmsnorm_quant_all_gather.py` |
+
+---
+
+## 10. Test Files
+
+| Test | Path |
+|------|------|
+| RMSNorm basic | `op_tests/test_rmsnorm2d.py` |
+| RMSNorm + quant | `op_tests/test_rmsnorm2dFusedAddQuant.py` |
+| LayerNorm basic | `op_tests/test_layernorm2d.py` |
+| LayerNorm + quant | `op_tests/test_layernorm2dFusedAddQuant.py` |
+| GroupNorm | `op_tests/test_groupnorm.py` |
+| Triton RMSNorm | `op_tests/triton_tests/normalization/test_rmsnorm.py` |
+| Triton LayerNorm | `op_tests/triton_tests/normalization/test_layernorm.py` |
+| Triton Fused Add Pad | `op_tests/triton_tests/normalization/test_fused_add_rmsnorm_pad.py` |
+| Fused QK Norm + RoPE | `op_tests/test_fused_qk_norm_rope_cache_quant.py` |
+| Fused QK Norm + MRoPE | `op_tests/test_fused_qk_norm_mrope_cache_quant.py` |
+| Distributed Norm | `op_tests/multigpu_tests/triton_test/test_fused_rs_rmsnorm_quant_ag.py` |
+| Benchmark | `op_tests/op_benchmarks/triton/bench_rmsnorm.py` |

--- a/docs/quantization_guide.md
+++ b/docs/quantization_guide.md
@@ -1,0 +1,586 @@
+# AITER Quantization & Precision Guide
+
+This guide documents all quantization strategies available in AITER, their backend support, fused operations, and how to choose the right precision for your use case.
+
+---
+
+## Quick Reference: Which Quantization Should I Use?
+
+| Use Case | Strategy | QuantType | Target Dtype | Why |
+|----------|----------|-----------|-------------|-----|
+| **Best accuracy (no quant)** | None | `QuantType.No` | BF16 | No quantization loss |
+| **FP8 inference (simple)** | Per-tensor | `QuantType.per_Tensor` | FP8 | Single scale, lowest overhead |
+| **FP8 inference (balanced)** | Per-token | `QuantType.per_Token` | FP8 | Per-row scales, good accuracy/perf |
+| **FP8 inference (high accuracy)** | Block-scale (1x128) | `QuantType.per_1x128` | FP8 | Per-block scales, best FP8 accuracy |
+| **MXFP4 (max compression)** | Block-scale (1x32) | `QuantType.per_1x32` | FP4 | 4x compression, E8M0 scales |
+| **Outlier-aware** | SmoothQuant | per-token + channel scale | FP8/INT8 | Handles activation outliers |
+| **KV cache compression** | Per-token/block cache | N/A | FP8/INT8 | Reduces KV cache memory |
+| **Fused norm + quant** | RMSNorm + FP8/FP4 | N/A | FP8/FP4 | Saves kernel launches |
+
+---
+
+## 1. QuantType Enum
+
+All quantization strategies in AITER are identified by the `QuantType` enum:
+
+```python
+from aiter import QuantType
+
+QuantType.No            # No quantization (pass-through)
+QuantType.per_Tensor    # Single scale for entire tensor
+QuantType.per_Token     # One scale per token (row)
+QuantType.per_1x32      # Block-scale with 32-element groups (for MXFP4)
+QuantType.per_1x128     # Block-scale with 128-element groups (for FP8)
+QuantType.per_128x128   # Large 2D block quantization (enum defined, not yet implemented in Python)
+```
+
+### Supported Data Types
+
+| Type | Format | Bits | Usage |
+|------|--------|------|-------|
+| **FP8 (E4M3)** | E4M3FNUZ (GFX942) / E4M3FN (GFX950) | 8 | Default quantized dtype |
+| **FP4 (MXFP4)** | E2M1 packed as `fp4x2` (2 values per byte) | 4 | Maximum compression |
+| **INT8** | Symmetric integer | 8 | Legacy quantization |
+| **FP8 E8M0** | Exponent-only float | 8 | Block scale storage for MXFP4 |
+| **BF16/FP16** | Standard floats | 16 | Input/output precision |
+| **FP32** | Single precision | 32 | Scale computation, accumulation |
+
+---
+
+## 2. Per-Tensor Quantization
+
+Single scale factor for the entire tensor. Simplest strategy with lowest overhead.
+
+```
+scale = max(|x|) / dtype_max
+x_quant = round(x / scale)
+```
+
+### Backend Support
+
+| Backend | Function | Data Types |
+|---------|----------|-----------|
+| **PyTorch** | `per_tensor_quant(x)` | FP8, INT8 |
+| **HIP** | `per_tensor_quant_hip(x)` | FP8, INT8 |
+| **Triton** | `static_per_tensor_quant_fp8_i8()` / `dynamic_per_tensor_quant_fp8_i8()` | FP8, INT8 |
+
+### Key API
+
+```python
+from aiter.ops.quant import per_tensor_quant
+
+x_quant, scale = per_tensor_quant(
+    x,                  # (M, N) input tensor
+    scale=None,         # None = dynamic (compute from data)
+    scale_dtype=torch.float32,
+    quant_dtype=torch.int8,
+)
+# x_quant: (M, N) quantized tensor
+# scale: scalar
+```
+
+### When to Use
+
+- Weight quantization (weights don't change at inference time)
+- When simplicity matters more than accuracy
+- As a baseline for comparing other strategies
+
+---
+
+## 3. Per-Token Quantization
+
+One scale factor per row (token). The standard strategy for activation quantization in LLM inference.
+
+```
+scale[i] = max(|x[i, :]|) / dtype_max    # per row
+x_quant[i, :] = round(x[i, :] / scale[i])
+```
+
+### Backend Support
+
+| Backend | Function | Data Types |
+|---------|----------|-----------|
+| **PyTorch** | `pertoken_quant(x)` | FP8, INT8 |
+| **HIP** | `per_token_quant_hip(x)` | FP8, INT8 |
+| **Triton** | `dynamic_per_token_quant_fp8_i8()` | FP8, INT8 |
+
+### Key API
+
+```python
+from aiter.ops.quant import pertoken_quant
+
+x_quant, scale = pertoken_quant(
+    x,                  # (M, N) input
+    scale=None,         # None = dynamic
+    x_scale=None,       # optional SmoothQuant channel scale
+    scale_dtype=torch.float32,
+    quant_dtype=torch.int8,
+)
+# x_quant: (M, N) quantized
+# scale: (M, 1) per-token scales
+```
+
+### When to Use
+
+- Activation quantization during inference (most common)
+- When different tokens have different magnitude distributions
+- Pairs with per-tensor weight quantization: `gemm_a8w8(act_quant, weight_quant, act_scale, weight_scale)`
+
+---
+
+## 4. Block-Scale Quantization
+
+Per-block scales for fine-grained quantization. Two block sizes are supported.
+
+### Per-1x128 (FP8 Block-Scale)
+
+```
+For each block of 128 elements along K:
+    scale[m, k//128] = max(|x[m, k:k+128]|) / dtype_max
+    x_quant[m, k:k+128] = round(x[m, k:k+128] / scale[m, k//128])
+```
+
+### Per-1x32 (MXFP4 Block-Scale)
+
+```
+For each block of 32 elements along K:
+    scale[m, k//32] = max(|x[m, k:k+32]|) → E8M0 format
+    x_quant[m, k:k+32] = round(x[m, k:k+32] / scale[m, k//32]) → E2M1 packed
+```
+
+### Backend Support
+
+| Feature | PyTorch | HIP | Triton |
+|---------|:---:|:---:|:---:|
+| **per_1x128 (FP8)** | Yes | Yes | Yes |
+| **per_1x32 (MXFP4)** | Yes | Yes | Yes |
+| **E8M0 scale format** | Yes | Yes | Yes |
+| **E8M0 shuffle** | Yes | Yes | Yes |
+| **Dynamic scale** | Yes | Yes | Yes |
+
+### Key API
+
+```python
+from aiter import dtypes
+from aiter.ops.quant import per_1x32_f4_quant
+
+# MXFP4 quantization
+x_fp4, scale_e8m0 = per_1x32_f4_quant(
+    x,                  # (M, N) input
+    scale=None,         # None = dynamic
+    quant_dtype=dtypes.fp4x2,  # packed FP4 (fp4x2)
+    shuffle=False,      # E8M0 shuffle for cache optimization
+)
+# x_fp4: (M, N//2) packed FP4
+# scale_e8m0: (M, N//32) E8M0 block scales
+```
+
+```python
+from aiter.ops.triton.quant.quant import dynamic_mxfp4_quant
+
+# Triton MXFP4 (optimized)
+x_fp4, blockscale = dynamic_mxfp4_quant(
+    x,                  # (M, N) input
+    scaling_mode="even",
+)
+```
+
+### When to Use
+
+- FP8 block-scale (per_1x128): Best accuracy for FP8 GEMM, pairs with `gemm_a8w8_blockscale`
+- MXFP4 block-scale (per_1x32): Maximum compression (4x), pairs with `gemm_a4w4` on MI350
+- When per-tensor/per-token scales are too coarse for your accuracy requirements
+
+---
+
+## 5. SmoothQuant
+
+Reduces per-channel activation outliers by pre-multiplying with a learned channel-wise scale before quantization. Moves quantization difficulty from activations to weights.
+
+```
+x_smooth = x * smooth_scale        # per-channel scaling
+x_quant = quantize(x_smooth)       # now easier to quantize
+w_quant = quantize(w / smooth_scale)  # absorb inverse into weights
+```
+
+### Backend Support
+
+| Backend | Function |
+|---------|----------|
+| **PyTorch** | `pertoken_quant(x, x_scale=smooth_scale)` |
+| **HIP** | `smooth_per_token_scaled_quant(out, input, scales, smooth_scale)` |
+| **CK** | `moe_smoothquant_fwd(out, input, x_scale, topk_ids, y_scale)` |
+| **Fused Norm** | `layernorm2d_fwd_with_smoothquant(out, input, xscale, yscale, ...)` |
+
+### Key API
+
+```python
+from aiter.ops.quant import pertoken_quant
+
+# SmoothQuant via per-token quantization
+x_quant, scale = pertoken_quant(
+    x,
+    x_scale=smooth_scale,  # (1, N) learned channel scales
+    quant_dtype=torch.int8,
+)
+```
+
+### When to Use
+
+- Models with significant activation outliers (e.g., OPT, BLOOM)
+- When per-token FP8 alone doesn't meet accuracy requirements
+- Requires offline calibration to compute `smooth_scale`
+
+---
+
+## 6. Fused Quantization Operations
+
+AITER provides fused kernels that combine normalization, activation, and quantization to reduce memory round-trips.
+
+### FP8 Fused Operations
+
+| Function | Pipeline | Backend |
+|----------|----------|---------|
+| `fused_rms_fp8_per_tensor_static_quant` | [Add residual] → RMSNorm → FP8 quant | Triton |
+| `fused_rms_fp8_group_quant` | RMSNorm → per-group FP8 quant | Triton |
+| `fused_reduce_act_mul_fp8_group_quant` | SplitK reduce → activation → mul → FP8 quant | Triton |
+| `fused_reduce_rms_fp8_group_quant` | SplitK reduce → RMSNorm → FP8 group quant | Triton |
+| `fused_silu_mul_fp8_per_tensor_static_quant` | SiLU(gate) * up → FP8 quant | Triton |
+| `fused_flatten_fp8_group_quant` | 3D→2D flatten → group quant | Triton |
+
+### MXFP4 Fused Operations
+
+| Function | Pipeline | Backend |
+|----------|----------|---------|
+| `fused_rms_mxfp4_quant` | RMSNorm → MXFP4 quant | Triton |
+| `fused_reduce_act_mul_and_mxfp4_quant` | SplitK reduce → activation → MXFP4 quant | Triton |
+| `fused_reduce_rms_mxfp4_quant` | SplitK reduce → RMSNorm → MXFP4 quant | Triton |
+| `fused_flatten_mxfp4_quant` | 3D→2D flatten → MXFP4 quant | Triton |
+| `fused_dynamic_mxfp4_quant_moe_sort` | MXFP4 quant → MOE token sorting | Triton |
+
+### Key API Examples
+
+```python
+from aiter.ops.triton.quant.fused_fp8_quant import (
+    fused_rms_fp8_group_quant,
+)
+
+# Fused RMSNorm + FP8 group quantization
+out_fp8, out_scales = fused_rms_fp8_group_quant(
+    inp1,               # (M, N) input
+    inp1_weight,        # (N,) RMSNorm weight
+    inp1_epsilon,       # RMSNorm epsilon
+    group_size=128,     # quantization group size
+    inp2=None,          # optional second input
+    res1=None,          # optional residual
+)
+# out_fp8: (M, N) FP8 quantized
+# out_scales: (M, N//128) per-group scales
+```
+
+```python
+from aiter.ops.triton.quant.fused_mxfp4_quant import (
+    fused_rms_mxfp4_quant,
+)
+
+# Fused RMSNorm + MXFP4 quantization
+out_fp4, out_scales = fused_rms_mxfp4_quant(
+    x1,                 # (M, N) input
+    x1_weight,          # (N,) RMSNorm weight
+    x1_epsilon,         # RMSNorm epsilon
+    shuffle=False,      # E8M0 shuffle optimization
+)
+# out_fp4: (M, N//2) packed FP4
+# out_scales: (M, N//32) E8M0 block scales
+```
+
+### When to Use
+
+- Always prefer fused ops over separate norm → quant when available
+- Reduces kernel launches and memory traffic
+- Critical path in LLM inference: norm → quant → GEMM
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/quant/fused_fp8_quant.py` | All FP8 fused operations |
+| `aiter/ops/triton/quant/fused_mxfp4_quant.py` | All MXFP4 fused operations |
+
+---
+
+## 7. Quantized KV Cache
+
+AITER supports writing quantized values directly to the KV cache, reducing memory footprint for long-context inference.
+
+### Cache Quantization Methods
+
+| Function | Strategy | Layout |
+|----------|----------|--------|
+| `reshape_and_cache` | No quantization (BF16) | Standard |
+| `reshape_and_cache_with_pertoken_quant` | Per-token FP8 | Standard |
+| `reshape_and_cache_with_block_quant` | Block-wise FP8 | Standard |
+| `reshape_and_cache_with_block_quant_for_asm_pa` | Block-wise for ASM PA | `[blocks, heads, D/x, 16, x]` |
+| `indexer_k_quant_and_cache` | On-demand K quantization | Indexed |
+
+### Key API
+
+```python
+from aiter.ops.cache import (
+    reshape_and_cache_with_pertoken_quant,
+    reshape_and_cache_with_block_quant,
+)
+
+# Per-token FP8 KV cache write
+reshape_and_cache_with_pertoken_quant(
+    key, value,
+    key_cache, value_cache,
+    k_dequant_scales, v_dequant_scales,
+    slot_mapping,
+)
+
+# Block-quantized KV cache write
+reshape_and_cache_with_block_quant(
+    key, value,
+    key_cache, value_cache,
+    k_dequant_scales, v_dequant_scales,
+    slot_mapping,
+)
+```
+
+### When to Use
+
+- Long-context inference where KV cache is the memory bottleneck
+- Per-token: simpler, ~50% memory savings
+- Block-quant: more complex, better accuracy for long sequences
+
+---
+
+## 8. MOE Quantization Integration
+
+Quantization is deeply integrated with MOE (Mixture of Experts) operations.
+
+### MOE SmoothQuant
+
+```python
+from aiter.ops.quant import moe_smoothquant_fwd
+
+# Apply SmoothQuant with expert routing
+moe_smoothquant_fwd(
+    out,                # output buffer
+    input,              # (M, N) activations
+    x_scale,            # (N,) channel scales
+    topk_ids,           # (M, topk) expert indices
+    y_scale,            # per-token output scales
+)
+```
+
+### MXFP4 + MOE Sorting
+
+```python
+from aiter.ops.triton.quant.fused_mxfp4_quant import (
+    fused_dynamic_mxfp4_quant_moe_sort,
+)
+
+# Fused: MXFP4 quantization + MOE token sorting
+x_fp4, blockscale = fused_dynamic_mxfp4_quant_moe_sort(
+    x,                  # (M, N) activations
+    sorted_ids,         # MOE sorted token indices
+    num_valid_ids,      # number of valid tokens
+    token_num,          # total tokens
+    topk,               # top-K experts per token
+)
+```
+
+### Interaction with MOE GEMM
+
+```
+Tokens → [Routing] → [Sort by Expert] → [Quantize] → [Expert GEMM] → [Unsort]
+                                            ↑
+                          QuantType determines precision:
+                          - No: BF16 GEMM
+                          - per_Token: FP8 A8W8
+                          - per_1x128: FP8 block-scale
+                          - per_1x32: MXFP4 A4W4
+```
+
+---
+
+## 9. Backend Dispatch
+
+AITER provides factory functions that return the appropriate quantization implementation for each backend:
+
+```python
+from aiter.ops.quant import get_torch_quant, get_hip_quant, get_triton_quant
+
+# Get per-token quant function for Triton backend
+quant_fn = get_triton_quant(QuantType.per_Token)
+x_quant, scale = quant_fn(x)
+
+# Get per-block quant function for HIP backend
+quant_fn = get_hip_quant(QuantType.per_1x32)
+x_quant, scale = quant_fn(x)
+```
+
+### Backend Selection
+
+| QuantType | PyTorch | HIP | Triton |
+|-----------|:---:|:---:|:---:|
+| `No` | pass-through | pass-through | pass-through |
+| `per_Tensor` | Yes | Yes | Yes |
+| `per_Token` | Yes | Yes | Yes |
+| `per_1x32` | Yes | Yes | Yes |
+| `per_1x128` | Yes (wrapped) | Yes (wrapped) | Yes (wrapped) |
+| `per_128x128` | Yes (wrapped) | - | - |
+
+---
+
+## 10. Data Type Flow
+
+### Typical Inference Quantization Pipeline
+
+```
+Input (BF16/FP16)
+    │
+    ▼
+[Optional: Fused RMSNorm + Add Residual]
+    │
+    ▼
+[Optional: SmoothQuant (x * channel_scale)]
+    │
+    ▼
+Scale Computation (dynamic):
+    ├── per_Tensor:  max(|x|) → 1 scale
+    ├── per_Token:   max(|x|, dim=-1) → M scales
+    ├── per_1x128:   max(|x|, groups of 128) → M × (N/128) scales
+    └── per_1x32:    max(|x|, groups of 32) → M × (N/32) E8M0 scales
+    │
+    ▼
+Quantization:
+    ├── FP8:  x_quant = round(x / scale * fp8_max)
+    ├── INT8: x_quant = round(x / scale * 127)
+    └── FP4:  x_quant = nearest_fp4(x / scale) → packed 2 per byte
+    │
+    ▼
+GEMM (with on-the-fly dequantization):
+    output = (x_quant @ w_quant^T) * x_scale * w_scale
+    │
+    ▼
+Output (BF16/FP16, accumulated in FP32)
+```
+
+### Choosing the Right Precision
+
+```
+Need maximum accuracy?
+├── Yes → QuantType.No (BF16, no quantization)
+└── No
+    ├── Need 2x compression?
+    │   ├── Best accuracy → per_1x128 (FP8 block-scale)
+    │   ├── Good accuracy → per_Token (FP8 per-row)
+    │   └── Simplest → per_Tensor (FP8 global scale)
+    ├── Need 4x compression?
+    │   └── per_1x32 (MXFP4) — MI350 preferred
+    └── Have activation outliers?
+        └── SmoothQuant + per_Token
+```
+
+---
+
+## 11. FP4/MXFP4 Utilities
+
+Low-level utilities for working with MXFP4 format.
+
+```python
+from aiter.utility.fp4_utils import (
+    f32_to_mxfp4,      # FP32 → MXFP4 (packed uint8)
+    mxfp4_to_f32,      # MXFP4 → FP32
+    f32_to_e8m0,       # FP32 → E8M0 (exponent-only scale)
+    e8m0_to_f32,       # E8M0 → FP32
+    e8m0_shuffle,      # Cache-optimized E8M0 layout
+)
+
+from aiter.int4_utils import (
+    convert_int8_to_uint32_int4,  # Pack 8 INT4 → 1 UINT32
+    rearrange_4bit_elements,       # Reorder for memory access
+)
+```
+
+### E8M0 Shuffle
+
+E8M0 shuffle reorders block scales for optimal cache prefetch alignment:
+
+```python
+# Pads to (256, 8) multiples and permutes for sequential access
+shuffled_scale = e8m0_shuffle(scale)  # (M, N//32) → (M_padded, N//32_padded)
+```
+
+---
+
+## 12. Fused Communication + Quantization
+
+For multi-GPU deployments, AITER fuses all-reduce with normalization and quantization:
+
+```python
+from aiter.ops.communication import all_reduce_rmsnorm_quant
+
+# Fused: AllReduce + RMSNorm + SmoothQuant
+all_reduce_rmsnorm_quant(
+    input, residual_in,
+    xscale,             # smooth channel scales
+    weight, bias,       # RMSNorm parameters
+    epsilon,
+)
+```
+
+---
+
+## 13. Test Files Reference
+
+| Test File | Covers |
+|-----------|--------|
+| `op_tests/test_quant.py` | Core quantization: per-tensor, per-token, per-block |
+| `op_tests/test_smoothquant.py` | SmoothQuant: Torch vs CK vs HIP |
+| `op_tests/test_rmsnorm2dFusedAddQuant.py` | Fused RMSNorm + quantization |
+| `op_tests/test_layernorm2dFusedAddQuant.py` | Fused LayerNorm + quantization |
+| `op_tests/test_fused_qk_norm_rope_cache_quant.py` | Fused QK norm + RoPE + cache + quant |
+| `op_tests/test_fused_qk_norm_mrope_cache_quant.py` | Multi-dim RoPE + quant |
+| `op_tests/triton_tests/quant/test_quant.py` | Triton quantization kernels |
+| `op_tests/triton_tests/quant/test_fused_fp8_quant.py` | Triton FP8 fused ops |
+| `op_tests/triton_tests/quant/test_fused_mxfp4_quant.py` | Triton MXFP4 fused ops |
+
+---
+
+## 14. Source Files Reference
+
+### Core Quantization
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/quant.py` | All quantization strategies, backend dispatch |
+| `aiter/ops/enum.py` | `QuantType` enum definition |
+| `aiter/utility/dtypes.py` | Data type mappings and utilities |
+| `aiter/utility/fp4_utils.py` | FP4/E8M0 conversion utilities |
+| `aiter/int4_utils.py` | INT4 packing utilities |
+
+### Triton Quantization
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/triton/quant/quant.py` | Per-tensor, per-token, MXFP4 Triton implementations |
+| `aiter/ops/triton/quant/fused_fp8_quant.py` | FP8 fused operations |
+| `aiter/ops/triton/quant/fused_mxfp4_quant.py` | MXFP4 fused operations |
+
+### Fused Norm + Quantization
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/norm.py` | LayerNorm/RMSNorm with SmoothQuant fusion |
+| `aiter/ops/fused_qk_norm_rope_cache_quant.py` | QK norm + RoPE + cache + quant |
+| `aiter/ops/fused_qk_norm_mrope_cache_quant.py` | Multi-dim RoPE variant |
+
+### Cache Quantization
+
+| File | Purpose |
+|------|---------|
+| `aiter/ops/cache.py` | Quantized KV cache write operations |

--- a/docs/rope_guide.md
+++ b/docs/rope_guide.md
@@ -1,0 +1,352 @@
+# AITER RoPE (Rotary Position Embedding) Guide
+
+This guide documents all RoPE variants available in AITER, their tensor formats, rotation styles, scaling methods, and backend support.
+
+---
+
+## Quick Reference: Which RoPE Variant Should I Use?
+
+| Use Case | Recommended Variant | Backend | Why |
+|----------|-------------------|---------|-----|
+| **Standard LLM inference** | `rope_cached_positions_2c_fwd` | HIP (default) | Cached cos/sin, processes Q and K together |
+| **LLM training** | `RoPECached` autograd class | Triton | Full forward + backward support |
+| **Packed sequences (variable length)** | `rope_thd_fwd` | HIP or Triton | THD format handles cumulative seq lengths |
+| **Vision models (ViT)** | `rope_2d_fwd` | HIP | 2D height/width position encoding |
+| **Vision-language models** | `rope_fwd_3d` | Triton | 3D temporal + spatial encoding |
+| **DeepSeek / Qwen VL** | `MRotaryEmbedding` | HIP | Multimodal section-based splitting |
+| **Fused with QK norm + cache** | `fused_qk_norm_rope_cache_*` | HIP | Maximum fusion for inference |
+| **Prototyping / new architectures** | Triton variants | Triton | Portable, easy to modify |
+
+---
+
+## 1. Rotation Styles
+
+AITER supports two standard rotation styles:
+
+| Style | Enum Value | Description | Used By |
+|-------|-----------|-------------|---------|
+| **NeoX** | `RotateStyle.NEOX` (0) | Splits dimension in half, rotates second half | LLaMA, Mistral, Qwen |
+| **GPT-J** | `RotateStyle.GPTJ` (1) | Interleaved rotation of odd-indexed elements | GPT-J, GPT-NeoX |
+
+**NeoX style**: `[x1, x2] → [x1*cos - x2*sin, x2*cos + x1*sin]` where x1 = first half, x2 = second half
+
+**GPT-J style**: `[x0, x1, x2, x3, ...] → rotated pairs at interleaved positions`
+
+---
+
+## 2. Tensor Formats
+
+### SBHD Format (Sequence-Batch-Head-Dim)
+
+The default format for most RoPE operations.
+
+```
+Input/Output:  (S, B, H, D)    # seq_len, batch, num_heads, head_dim
+Frequencies:   (S, 1, 1, D//2) # if reuse_freqs_front_part=True
+               (S, 1, 1, D)    # if reuse_freqs_front_part=False
+Cos/Sin cache: (max_seq, D//2) # pre-computed
+Positions:     (S, B)          # position indices
+```
+
+### THD Format (Token-Head-Dim)
+
+Packed sequence format for variable-length batches (no padding).
+
+```
+Input/Output:  (T, H, D)       # T = sum of all sequence lengths
+Cu_seqlens:    (B+1,)          # cumulative sequence lengths
+Frequencies:   (max_seq, D//2) # or (max_seq, D)
+```
+
+### 2D Format (Image Positions)
+
+For vision transformers with 2D spatial positions.
+
+```
+Input/Output:  (B, S, H, D)    # S = height * width
+Cos_h/Sin_h:  height cos/sin   # height-dimension embeddings
+Cos_w/Sin_w:  width cos/sin    # width-dimension embeddings
+```
+
+### 3D Format (Multimodal)
+
+For vision-language models with temporal + spatial dimensions.
+
+```
+Input/Output:  (B, S, H, D)    # S = time * height * width
+```
+
+---
+
+## 3. Backend Support
+
+| Feature | HIP/ASM | Triton | CK |
+|---------|:---:|:---:|:---:|
+| **SBHD forward** | Yes | Yes | Ref only |
+| **SBHD backward** | Yes | Yes | - |
+| **THD forward** | Yes | Yes | - |
+| **THD backward** | Yes | Yes | - |
+| **2D forward** | Yes | Yes | - |
+| **2D backward** | Yes | - | - |
+| **3D forward** | - | Yes | - |
+| **Cached cos/sin** | Yes | Yes | - |
+| **Position indices** | Yes | Yes | - |
+| **Position offsets** | Yes | Yes | - |
+| **Two-channel (Q+K)** | Yes | Yes | - |
+| **GQA support** | Yes (via 2c APIs) | Yes | - |
+| **In-place** | Yes | Yes | - |
+| **BF16** | Yes | Yes | Yes |
+| **FP16** | Yes | Yes | Yes |
+| **FP32** | Yes | Yes | - |
+
+---
+
+## 4. Core API Functions
+
+### Single-Input Forward
+
+```python
+import aiter
+
+# With on-the-fly frequencies (SBHD format)
+output = aiter.rope_fwd(input, freqs, rotate_style=0,
+                        reuse_freqs_front_part=True, nope_first=False)
+
+# In-place variant
+aiter.rope_fwd_inplace(input, freqs, rotate_style=0,
+                       reuse_freqs_front_part=True, nope_first=False)
+
+# Backward
+input_grads = aiter.rope_bwd(output_grads, freqs, rotate_style=0,
+                             reuse_freqs_front_part=True, nope_first=False)
+```
+
+### Two-Channel (Q and K Together)
+
+```python
+# Process Q and K with same frequencies
+out_q, out_k = aiter.rope_2c_fwd(
+    input_q, input_k, freqs,
+    rotate_style=0, reuse_freqs_front_part=True, nope_first=False
+)
+
+# In-place
+aiter.rope_2c_fwd_inplace(input_q, input_k, freqs, ...)
+```
+
+### With Cached Cos/Sin
+
+```python
+# Pre-computed cos/sin (most common for inference)
+output = aiter.rope_cached_fwd(input, cos, sin, rotate_style=0, ...)
+
+# Two-channel with cache
+out_q, out_k = aiter.rope_cached_2c_fwd(input_q, input_k, cos, sin, ...)
+```
+
+### With Position Indices
+
+```python
+# Position-indexed (for non-contiguous sequences)
+output = aiter.rope_cached_positions_fwd(input, cos, sin, positions, ...)
+
+# Two-channel with positions
+out_q, out_k = aiter.rope_cached_positions_2c_fwd(
+    input_q, input_k, cos, sin, positions, ...
+)
+```
+
+### With Position Offsets
+
+```python
+# Positions + batch-specific offsets
+output = aiter.rope_cached_positions_offsets_fwd(
+    input, cos, sin, positions, offsets, ...
+)
+
+# Two-channel with offsets
+out_q, out_k = aiter.rope_cached_positions_offsets_2c_fwd(
+    input_q, input_k, cos, sin, positions, offsets, ...
+)
+```
+
+### THD Format (Packed Sequences)
+
+```python
+# Packed variable-length sequences
+output = aiter.rope_thd_fwd(input, cu_seqlens, freqs, rotate_style=0, ...)
+aiter.rope_thd_fwd_inplace(input, cu_seqlens, freqs, ...)
+grads = aiter.rope_thd_bwd(output_grads, cu_seqlens, freqs, ...)
+```
+
+### 2D/3D Formats (Vision)
+
+```python
+# 2D for vision models
+output = aiter.rope_2d_fwd(input, cos_h, sin_h, cos_w, sin_w,
+                           img_height, img_width, ...)
+aiter.rope_2d_fwd_inplace(input, cos_h, sin_h, cos_w, sin_w,
+                          img_height, img_width, ...)
+
+# 3D for vision-language models (Triton only)
+from aiter.ops.triton.rope.rope import rope_fwd_3d
+output = rope_fwd_3d(x, grid_sizes, freqs, sp_size, sp_rank)
+```
+
+---
+
+## 5. Autograd Classes (Training)
+
+For models that need backward pass support:
+
+```python
+from aiter.ops.rope import RoPE, RoPECached, RoPETHD, RoPE2D
+
+# Standard RoPE with autograd
+output = RoPE.apply(input, freqs, rotate_style, reuse_freqs_front_part, nope_first)
+
+# Cached RoPE with autograd
+output = RoPECached.apply(input, cos, sin, rotate_style,
+                          reuse_freqs_front_part, nope_first)
+
+# THD format with autograd
+output = RoPETHD.apply(input, cu_seqlens, freqs, rotate_style,
+                       reuse_freqs_front_part, nope_first)
+
+# 2D format with autograd
+output = RoPE2D.apply(input, cos_h, sin_h, cos_w, sin_w,
+                      img_height, img_width, rotate_style,
+                      reuse_freqs_front_part)
+```
+
+---
+
+## 6. Partial RoPE (nope_first)
+
+Some models only apply rotation to a subset of the head dimension. The `nope_first` parameter controls the layout:
+
+| nope_first | Layout | Used By |
+|-----------|--------|---------|
+| `False` (default) | `[rope_dims, nope_dims]` | Most models |
+| `True` | `[nope_dims, rope_dims]` | Some custom architectures |
+
+The rotate dimension is determined by the frequency tensor shape:
+- `rotate_dim = freqs.shape[-1] * 2` if `reuse_freqs_front_part=True`
+- `rotate_dim = freqs.shape[-1]` otherwise
+
+Non-rotated dimensions are passed through unchanged.
+
+---
+
+## 7. RoPE Scaling Methods
+
+The high-level `RotaryEmbedding` module (`aiter/rotary_embedding.py`) supports multiple scaling strategies for extending context length:
+
+| Scaling Method | Class | Used By |
+|---------------|-------|---------|
+| **None (standard)** | `RotaryEmbedding` | Default, up to trained context |
+| **Linear** | `LinearScalingRotaryEmbedding` | Simple frequency scaling |
+| **Dynamic NTK** | `DynamicNTKScalingRotaryEmbedding` | Adaptive base frequency |
+| **YaRN** | `YaRNScalingRotaryEmbedding` | Attention scaling + NTK |
+| **Phi-3 Long RoPE** | `Phi3LongRoPEScaledRotaryEmbedding` | Phi-3 models |
+| **DeepSeek** | `DeepseekScalingRotaryEmbedding` | DeepSeek YaRN variant |
+| **LLaMA 3** | `Llama3RotaryEmbedding` | LLaMA 3 low/high freq scaling |
+| **Multimodal (MRoPE)** | `MRotaryEmbedding` | Qwen-VL, vision-language |
+| **Dual Chunk** | `DualChunkRotaryEmbedding` | Dual Chunk Attention |
+
+---
+
+## 8. Backend Selection (Environment Variables)
+
+```bash
+# Use Triton backend (default: 0, use HIP)
+export AITER_ROPE_TRITON_BACKEND=1
+
+# Use native PyTorch (slowest, for debugging)
+export AITER_ROPE_NATIVE_BACKEND=1
+
+# Enable fused QK norm + RoPE path
+export AITER_ROPE_FUSED_QKNORM=1
+```
+
+Priority: Native > Triton > HIP (default)
+
+---
+
+## 9. Fused Operations
+
+### Fused QKV Split + QK RoPE
+
+```python
+from aiter.ops.triton.rope.fused_qkv_split_qk_rope import fused_qkv_split_qk_rope
+# Splits QKV tensor and applies RoPE to Q and K in one kernel
+```
+
+### Fused BMM + RoPE + KV Cache (MLA)
+
+```python
+from aiter.ops.triton.fusions.fused_bmm_rope_kv_cache import (
+    fused_fp8_bmm_rope_cat_and_cache_mla,  # FP8 BMM + RoPE + cache
+    fused_fp4_bmm_rope_cat_and_cache_mla,  # FP4 BMM + RoPE + cache
+)
+```
+
+### Fused QK Norm + RoPE + Cache + Quantize
+
+See [Normalization Guide](normalization_guide.md) Section 5 for the mega-fused kernels that combine QK norm, RoPE, KV cache write, and quantization.
+
+---
+
+## 10. Decision Tree
+
+```
+Need RoPE?
+├── Standard LLM inference?
+│   ├── Fixed positions → rope_cached_fwd() or rope_cached_2c_fwd()
+│   ├── Variable positions → rope_cached_positions_2c_fwd()
+│   └── With batch offsets → rope_cached_positions_offsets_2c_fwd()
+├── Variable-length packed sequences?
+│   └── rope_thd_fwd()
+├── Vision model?
+│   ├── 2D spatial → rope_fwd_2d()
+│   └── 3D temporal+spatial → rope_fwd_3d()
+├── Need backward pass?
+│   └── Use autograd classes: RoPE, RoPECached, RoPETHD, RoPE2D
+├── Maximum inference fusion?
+│   └── fused_qk_norm_rope_cache_quant_shuffle()
+└── Multimodal model?
+    └── MRotaryEmbedding class
+```
+
+---
+
+## 11. Source Files
+
+| Component | Path |
+|-----------|------|
+| RoPE Python API | `aiter/ops/rope.py` |
+| RoPE Triton wrappers | `aiter/ops/triton/rope/rope.py` |
+| RoPE Triton kernels | `aiter/ops/triton/_triton_kernels/rope/rope.py` |
+| Rotary Embedding module | `aiter/rotary_embedding.py` |
+| Fused QKV Split + RoPE | `aiter/ops/triton/rope/fused_qkv_split_qk_rope.py` |
+| Fused BMM + RoPE + Cache | `aiter/ops/triton/fusions/fused_bmm_rope_kv_cache.py` |
+| Fused QK Norm + RoPE | `aiter/ops/fused_qk_norm_rope_cache_quant.py` |
+| Fused QK Norm + MRoPE | `aiter/ops/fused_qk_norm_mrope_cache_quant.py` |
+| HIP forward kernel | `csrc/pybind/rope_general_fwd_pybind.cu` |
+| HIP backward kernel | `csrc/pybind/rope_general_bwd_pybind.cu` |
+| HIP position kernel | `csrc/pybind/rope_pos_fwd_pybind.cu` |
+
+---
+
+## 12. Test Files
+
+| Test | Path |
+|------|------|
+| RoPE main tests | `op_tests/test_rope.py` |
+| Triton RoPE tests | `op_tests/triton_tests/rope/test_rope.py` |
+| Fused QKV Split + RoPE | `op_tests/triton_tests/rope/test_fused_qkv_split_qk_rope.py` |
+| Fused QK Norm + RoPE + Cache | `op_tests/test_fused_qk_norm_rope_cache_quant.py` |
+| Fused QK Norm + MRoPE | `op_tests/test_fused_qk_norm_mrope_cache_quant.py` |
+| Fused BMM + RoPE + Cache | `op_tests/triton_tests/fusions/test_fused_bmm_rope_kv_cache.py` |
+| MLA Decode + RoPE | `op_tests/triton_tests/attention/test_mla_decode_rope.py` |
+| RoPE benchmarks | `op_tests/op_benchmarks/triton/bench_rope.py` |

--- a/docs/sampling_guide.md
+++ b/docs/sampling_guide.md
@@ -1,0 +1,259 @@
+# AITER Sampling Operators Guide
+
+This guide documents all sampling operators available in AITER for LLM token generation, including greedy, random, mixed, top-k, and top-p sampling strategies.
+
+---
+
+## Quick Reference
+
+| Use Case | Recommended Operation | Backend | Why |
+|----------|---------------------|---------|-----|
+| **Greedy decoding** | `aiter.greedy_sample` | HIP | Fused argmax |
+| **Random sampling** | `aiter.random_sample` | HIP | Fused temperature + softmax + Gumbel-max |
+| **Batch with mixed strategies** | `aiter.mixed_sample` | HIP | Per-row greedy/random dispatch |
+| **Top-k filtering** | `top_k_renorm_probs` | HIP | Renormalize to top-k tokens |
+| **Top-p (nucleus) sampling** | `top_p_sampling_from_probs` | HIP | Sample from cumulative probability threshold |
+| **Joint top-k + top-p** | `top_k_top_p_sampling_from_probs` | HIP | Both constraints simultaneously |
+| **Generate exponential RNG** | `aiter.exponential` | HIP | Pre-generate for outer-exponential variants |
+
+---
+
+## 1. Two Sampling Families
+
+AITER provides two families of sampling operators targeting different pipeline stages:
+
+### Family A: Logit-Level (Fused)
+
+Operates on raw logits. Fuses temperature scaling, softmax, randomness, and token selection into a single kernel.
+
+```python
+import aiter
+
+# Greedy: argmax over logits
+out = torch.empty(batch_size, dtype=torch.int32, device="cuda")
+aiter.greedy_sample(out, logits)  # logits: [M, vocab_size]
+
+# Random: temperature-scaled stochastic sampling
+aiter.random_sample(out, logits, temperatures)  # temperatures: [M], float32
+
+# Mixed: greedy where temperature==0, random elsewhere
+aiter.mixed_sample(out, logits, temperatures)
+```
+
+### Family B: Probability-Level
+
+Operates on pre-computed probabilities (after softmax). Implements top-k/top-p filtering.
+
+```python
+import torch
+
+# Top-k renormalization
+renormed = torch.ops.aiter.top_k_renorm_probs(probs, None, top_k_val=50)
+
+# Top-p sampling
+samples = torch.ops.aiter.top_p_sampling_from_probs(probs, None, None, top_p_val=0.9)
+
+# Joint top-k + top-p
+samples = torch.ops.aiter.top_k_top_p_sampling_from_probs(
+    probs, None, None, 50, None, 0.9
+)
+```
+
+---
+
+## 2. Family A: Logit-Level Operators
+
+### `greedy_sample`
+
+```python
+aiter.greedy_sample(
+    out: Tensor,    # [M], int32 — sampled token indices
+    input: Tensor,  # [M, N] — logits (float32/float16/bfloat16)
+) -> None
+```
+
+Pure argmax — selects the highest-logit token per row.
+
+### `random_sample`
+
+```python
+aiter.random_sample(
+    out: Tensor,                        # [M], int32
+    input: Tensor,                      # [M, N] logits
+    temperatures: Tensor,               # [M], float32 — per-row temperature
+    lambd: float = 1.0,                 # Exponential distribution rate
+    generator: Optional[Generator] = None,  # For reproducible RNG
+    eps: float = 1e-10,                 # Numerical stability
+) -> None
+```
+
+Uses the Gumbel-max trick: `argmax(softmax(logit/T) / exp_sample)`. Fuses temperature scaling, online softmax, exponential RNG, and argmax in one kernel.
+
+### `mixed_sample`
+
+```python
+aiter.mixed_sample(
+    out: Tensor,           # [M], int32
+    input: Tensor,         # [M, N] logits
+    temperature: Tensor,   # [M], float32
+    lambd: float = 1.0,
+    generator: Optional[Generator] = None,
+    eps: float = 1e-10,
+) -> None
+```
+
+Per-row dispatch: `temperature == 0` → greedy, otherwise → random. Ideal for batched inference where some requests use greedy and others use sampling.
+
+### Outer-Exponential Variants
+
+For deterministic control over randomness:
+
+```python
+# Pre-generate exponential samples
+exponentials = torch.empty_like(logits, dtype=torch.float32)
+aiter.exponential(exponentials, lambd=1.0)
+
+# Use pre-generated samples
+aiter.random_sample_outer_exponential(out, logits, exponentials, temperatures)
+aiter.mixed_sample_outer_exponential(out, logits, exponentials, temperature)
+```
+
+---
+
+## 3. Family B: Probability-Level Operators
+
+### `top_k_renorm_probs`
+
+```python
+torch.ops.aiter.top_k_renorm_probs(
+    probs: Tensor,                          # [M, vocab_size], float32
+    maybe_top_k_arr: Optional[Tensor],      # [M], int32 — per-row k (or None)
+    top_k_val: int,                         # Scalar fallback k
+) -> Tensor                                  # [M, vocab_size], renormalized
+```
+
+Zeros out all probabilities outside the top-k and renormalizes. Uses binary search over probability thresholds.
+
+### `top_p_sampling_from_probs`
+
+```python
+torch.ops.aiter.top_p_sampling_from_probs(
+    probs: Tensor,                          # [M, vocab_size], float32
+    indices: Optional[Tensor],              # Index mapping (or None)
+    maybe_top_p_arr: Optional[Tensor],      # [M], float32 — per-row p (or None)
+    top_p_val: float,                       # Scalar fallback p
+    deterministic: bool = False,            # Bitwise reproducible scan
+) -> Tensor                                  # [M], int32 — sampled indices
+```
+
+Nucleus sampling — samples from the minimal set of tokens whose cumulative probability exceeds `p`.
+
+### `top_k_top_p_sampling_from_probs`
+
+```python
+torch.ops.aiter.top_k_top_p_sampling_from_probs(
+    probs: Tensor,                          # [M, vocab_size], float32
+    indices: Optional[Tensor],
+    maybe_top_k_arr: Optional[Tensor],      # [M], int32
+    top_k_val: int,
+    maybe_top_p_arr: Optional[Tensor],      # [M], float32
+    top_p_val: float,
+    deterministic: bool = False,
+) -> Tensor                                  # [M], int32
+```
+
+Joint filtering: accepts tokens only if **both** top-k count and top-p cumulative probability constraints are satisfied.
+
+---
+
+## 4. How Temperature, Top-K, and Top-P Interact
+
+### Family A Pipeline (fused)
+
+```
+logits → [temperature + softmax + RNG + argmax] → token_id
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         Single fused kernel (no top-k/top-p)
+```
+
+### Family B Pipeline (composable)
+
+```
+logits
+  → logits / temperature              # Caller applies
+  → softmax(logits)                   # Caller applies
+  → top_k_renorm_probs(probs, k)     # Zero out non-top-k
+  → top_p_sampling_from_probs(probs, p)  # Sample with nucleus
+```
+
+Or use the joint variant:
+```
+  → top_k_top_p_sampling_from_probs(probs, k, p)  # Both at once
+```
+
+---
+
+## 5. Supported Data Types
+
+### Family A (logit-level)
+
+| Input | Temperature | Output |
+|-------|-------------|--------|
+| float32, float16, bfloat16 | float32 | int32 |
+
+### Family B (probability-level)
+
+| Input | Top-k | Top-p | Output |
+|-------|-------|-------|--------|
+| float32 (auto-cast) | int32 | float32 | int32 |
+
+---
+
+## 6. Performance Notes
+
+- **Family A fusion**: Avoids materializing the full softmax output — uses online softmax with running max. Single kernel = single global memory round-trip.
+- **Block size**: All kernels use 1024 threads (max for AMD GPUs).
+- **Vectorized loads**: 4–16 elements per thread per iteration.
+- **Inner vs outer exponential**: Inner generates RNG in-kernel (saves a launch); outer takes pre-generated samples (useful for reproducibility).
+- **Deterministic mode**: Family B supports `deterministic=True` for bitwise reproducibility using a custom Belloch-style scan (at slight performance cost).
+
+---
+
+## 7. Decision Tree
+
+```
+Need token sampling?
+├── Single fused kernel (logits in, tokens out)?
+│   ├── All greedy → aiter.greedy_sample()
+│   ├── All random → aiter.random_sample()
+│   ├── Mixed batch → aiter.mixed_sample()
+│   └── Need reproducibility → *_outer_exponential() variants
+├── Composable pipeline (probabilities)?
+│   ├── Top-k only → top_k_renorm_probs() + multinomial
+│   ├── Top-p only → top_p_sampling_from_probs()
+│   └── Both → top_k_top_p_sampling_from_probs()
+└── Pre-generate randomness?
+    └── aiter.exponential()
+```
+
+---
+
+## 8. Source Files
+
+| Component | Path |
+|---|---|
+| Logit-level Python API | `aiter/ops/sample.py` |
+| Probability-level Python API | `aiter/ops/sampling.py` |
+| HIP sampling kernels | `csrc/kernels/sample_kernels.cu` |
+| C++ sampling interfaces | `csrc/cpp_itfs/sampling/` |
+| Sampling HIP header | `csrc/cpp_itfs/sampling/sampling.cuh` |
+| Pybind registration | `csrc/pybind/sample_pybind.cu` |
+
+---
+
+## 9. Test Files
+
+| Test | Path |
+|------|------|
+| Logit-level sampling | `op_tests/test_sample.py` |
+| Probability-level sampling | `op_tests/test_sampling.py` |


### PR DESCRIPTION
## Summary
- Add comprehensive documentation guides for 10 core AITER operators: Attention (MHA/PA), MLA, Fused MOE, GEMM, Quantization, Normalization, RoPE, KV-Cache, Elementwise/Activations, and Sampling
- Each guide covers available variants, backend support (ASM / CK / Triton), Python API examples, and performance tuning advice
- Update README with improved installation instructions (JIT dev mode, precompiled kernels, build variables) and a new Supported Operators table linking to each guide

## Files
| Guide | Operator |
|-------|----------|
| `docs/attention_variants_guide.md` | Multi-Head Attention, Paged Attention, Unified Attention, GQA/MQA |
| `docs/mla_kernel_support_report.md` | Multi-head Latent Attention — Triton vs ASM backends |
| `docs/moe_variants_guide.md` | Fused MOE — A8W8, A16W8, FP8 block-scale, MXFP4, 2-stage |
| `docs/gemm_variants_guide.md` | GEMM — A8W8, A16W16, A4W4, batched, DeepGEMM, Triton FFN |
| `docs/quantization_guide.md` | Quantization — FP8/MXFP4/INT4, per-tensor/token/block, SmoothQuant |
| `docs/normalization_guide.md` | RMSNorm, LayerNorm, GroupNorm — fused add/quant variants |
| `docs/rope_guide.md` | Rotary Position Embedding — SBHD/THD/2D/3D, NeoX & GPT-J |
| `docs/kv_cache_guide.md` | KV-Cache — paged/flash/MLA layouts, FP8/INT8, fused RoPE |
| `docs/elementwise_activation_guide.md` | Activations & elementwise — SiLU/GELU/SwiGLU, fused quant |
| `docs/sampling_guide.md` | Token sampling — greedy, random, top-k, top-p |
| `README.md` | Updated installation + Supported Operators table |

## Guide Structure
Each guide follows a consistent format:
1. **Quick Reference** table for fast lookup
2. **Numbered sections** covering variants, API, backends, data types
3. **Decision tree** for variant selection
4. **Source files** and **test files** tables for code navigation