### PR TITLE
Adding gfx1150/51 to RDNA arch

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
@@ -47,7 +47,16 @@ ArchFamily = Literal["cdna", "rdna"]
 
 CDNA_ARCHS = frozenset({"gfx908", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"})
 RDNA_ARCHS = frozenset(
-    {"gfx1030", "gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200", "gfx1201"}
+    {
+        "gfx1030",
+        "gfx1100",
+        "gfx1101",
+        "gfx1102",
+        "gfx1150",
+        "gfx1151",
+        "gfx1200",
+        "gfx1201",
+    }
 )
 FP8_ARCHS = frozenset({"gfx942", "gfx950"})
 


### PR DESCRIPTION
## Motivation
This PR adds gfx1150 and gfx1151 to RDNA arch list.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This helps to better autotune and any kind of optimizations for strix-halo.
## Technical Details
gfx1150/51 added to RDNA_ARCHS at FA utils
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
amd unit tests
## Test Result
  - Passed: 60,575                                                                                                                                                                                                
  - Failed: 0                                                                                                                                                                                                     
  - Skipped: 27,005                                                                                                                                                                                               
  - Duration: 4 hours 46 minutes  
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
