### PR TITLE
[FIX] fix a16 causal mha bwd case for python api

### DIFF
--- a/csrc/cpp_itfs/mha_bwd.cu
+++ b/csrc/cpp_itfs/mha_bwd.cu
@@ -432,7 +432,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         return 1;
 
     fmha_bwd_odo_args odo_args;
-    arg_size                 = sizeof(odo_args);
+
     odo_args.ptr_o           = a.o_ptr;
     odo_args.ptr_do          = a.do_ptr;
     odo_args.ptr_d           = a.d_ptr;
@@ -449,6 +449,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         (a.cu_seqlen_q_ptr && a.seqstart_q_ptr) ? a.cu_seqlen_q_ptr : a.seqstart_q_ptr;
 
     auto pre_kernel_launch = [&]() {
+        arg_size = sizeof(odo_args);
         int bdx = 256;
         int gdx = (a.max_seqlen_q + ts_odo - 1) / ts_odo;
         int gdy = a.nhead_q;
@@ -536,8 +537,8 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         dqdkdv_args.mask_x = generic_mask.at(ck_tile::number<1>{});
     }
 
-    arg_size                  = sizeof(dqdkdv_args);
     auto dqdkdv_kernel_launch = [&]() {
+        arg_size                  = sizeof(dqdkdv_args);
         int bdx = 256;
         int gdx = (a.max_seqlen_k + ts_kv - 1) / ts_kv;
         int gdy = a.nhead_q;
@@ -562,7 +563,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
 
     int dq_acc_element_size = a.v3_atomic_fp32 ? 4 : 2;
     fmha_bwd_post_kernel_args post_args;
-    arg_size                  = sizeof(post_args);
+
     post_args.ptr_dq_acc      = a.dq_acc_ptr;
     post_args.ptr_dq          = a.dq_ptr;
     post_args.Hs_dq_acc       = a.nhead_stride_dq_acc * dq_acc_element_size;
@@ -578,6 +579,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         (a.cu_seqlen_q_ptr && a.seqstart_q_ptr) ? a.cu_seqlen_q_ptr : a.seqstart_q_ptr;
 
     auto post_kernel_launch = [&]() {
+        arg_size                  = sizeof(post_args);
         int bdx = 256;
         int gdx = (a.max_seqlen_q + ts_dq - 1) / ts_dq;
         int gdy = a.nhead_q;


### PR DESCRIPTION
## Motivation

case failed when causal and a16 on gfx942

## Technical Details

For gfx942, a16 and causal only supported on seqlenq==seqlenk
And in python api, --causal will be deduced to mask bottom right.
So we use the top left mask kernel for a16&causal&gfx942.

## Test Plan

test a16 and causal case passed on mi300

## Test Result

test a16 and causal case passed on mi300

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
