### PR TITLE
[Gluon] Unified Attention 3D development for gfx12

### DIFF
--- a/aiter/ops/triton/gluon/unified_attention_3d_kernel.py
+++ b/aiter/ops/triton/gluon/unified_attention_3d_kernel.py
@@ -266,6 +266,638 @@ def _perform_PV_wmma(
 
 
 @gluon.jit
+def _tdm_async_gather_load_to_lds(
+    j,
+    desc,
+    src_row_indices,
+    src_col_offset,
+    dst,
+    num_stages: ttgl.constexpr,
+):
+    ttgl.amd.gfx1250.tdm.async_gather(
+        desc=desc,
+        src_row_indices=src_row_indices,
+        src_col_offset=0,
+        dst=dst.index(j % num_stages),
+    )
+
+    return j + 1
+
+
+@gluon.jit
+def _tdm_gather_request_from_lds(
+    j,
+    kv_scale,
+    Q_dtype,
+    smem,
+    asycn_wait: ttgl.constexpr,
+    layout: ttgl.constexpr,
+    transpose: ttgl.constexpr,
+    num_ctas: ttgl.constexpr,
+    num_stages: ttgl.constexpr,
+    TILE_SIZE: ttgl.constexpr,
+    HEAD_SIZE_PADDED: ttgl.constexpr,
+):
+    if num_ctas > 1:
+        ttgl.amd.gfx1250.cluster.arrive()
+    ttgl.amd.gfx1250.tdm.async_wait(asycn_wait)
+    if num_ctas > 1:
+        ttgl.amd.gfx1250.cluster.wait()
+    if transpose:
+        X = (
+            smem.index(j % num_stages)
+            .reshape([TILE_SIZE, HEAD_SIZE_PADDED])
+            .permute([1, 0])
+            .load(layout=layout)
+        )
+    else:
+        X = (
+            smem.index(j % num_stages)
+            .reshape([TILE_SIZE, HEAD_SIZE_PADDED])
+            .load(layout=layout)
+        )
+
+    if X.dtype.is_fp8() and not Q_dtype.is_fp8():
+        X = (X.to(ttgl.float32) * ttgl.load(kv_scale)).to(Q_dtype)
+
+    return j + 1, X
+
+
+@gluon.jit
+def _tdm_gather_get_kv_offsets(
+    j,
+    offs_j,
+    kv_head_idx,
+    block_tables_sorted_ptr,
+    block_table_offset,
+    stride_k_cache_h: ttgl.int64,
+    stride_v_cache_h: ttgl.int64,
+    NUM_BLOCKS_GATHER_PER_TILE: ttgl.constexpr,
+):
+    physical_block_idx = ttgl.load(
+        block_tables_sorted_ptr
+        + block_table_offset
+        + j * NUM_BLOCKS_GATHER_PER_TILE
+        + offs_j
+    )
+
+    offs_k_gather_idx = (physical_block_idx * stride_k_cache_h + kv_head_idx).to(
+        tl.int32
+    )
+    offs_v_gather_idx = (physical_block_idx * stride_v_cache_h + kv_head_idx).to(
+        tl.int32
+    )
+
+    return j + 1, offs_k_gather_idx, offs_v_gather_idx
+
+
+@gluon.jit
+def _tdm_gather_create_tensor_descriptors_and_allocate_lds(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    stride_q_m: ttgl.int64,  # int
+    stride_q_d: ttgl.constexpr,  # int
+    stride_k_t: ttgl.int64,  # int
+    stride_k_d: ttgl.constexpr,  # int
+    stride_v_t: ttgl.int64,  # int
+    stride_v_d: ttgl.constexpr,  # int
+    q_shared_layout: ttgl.constexpr,
+    k_shared_layout: ttgl.constexpr,
+    v_shared_layout: ttgl.constexpr,
+    NUM_BLOCKS: ttgl.constexpr,
+    NUM_KV_HEADS: ttgl.constexpr,
+    BLOCK_M: ttgl.constexpr,
+    HEAD_SIZE: ttgl.constexpr,
+    BLOCK_SIZE: ttgl.constexpr,
+    TILE_SIZE: ttgl.constexpr,
+    HEAD_SIZE_PADDED: ttgl.constexpr,
+    NUM_BLOCKS_GATHER_PER_TILE: ttgl.constexpr,
+    num_stages: ttgl.constexpr,
+):
+    ttgl.static_assert(stride_k_d == 1, "stride_k_d must be 1")
+    ttgl.static_assert(stride_v_d == 1, "stride_v_d must be 1")
+    # ttgl.static_assert(stride_k_t == BLOCK_SIZE * HEAD_SIZE, "stride_k_t must be BLOCK_SIZE * HEAD_SIZE")
+    # ttgl.static_assert(stride_v_t == BLOCK_SIZE * HEAD_SIZE, "stride_v_t must be BLOCK_SIZE * HEAD_SIZE")
+
+    k_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(
+        base=k_ptr,
+        shape=(NUM_BLOCKS * NUM_KV_HEADS, BLOCK_SIZE * HEAD_SIZE),
+        strides=(stride_k_t, stride_k_d),
+        block_shape=(NUM_BLOCKS_GATHER_PER_TILE, BLOCK_SIZE * HEAD_SIZE_PADDED),
+        layout=k_shared_layout,
+    )
+
+    v_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(
+        base=v_ptr,
+        shape=(NUM_BLOCKS * NUM_KV_HEADS, BLOCK_SIZE * HEAD_SIZE),
+        strides=(stride_v_t, stride_v_d),
+        block_shape=(NUM_BLOCKS_GATHER_PER_TILE, BLOCK_SIZE * HEAD_SIZE_PADDED),
+        layout=v_shared_layout,
+    )
+
+    smem_Q = ttgl.allocate_shared_memory(
+        q_ptr.type.element_ty,
+        shape=[BLOCK_M, HEAD_SIZE_PADDED],
+        layout=q_shared_layout,
+    )
+    smem_K = ttgl.allocate_shared_memory(
+        k_desc.dtype,
+        shape=[num_stages] + k_desc.block_shape,
+        layout=k_desc.layout,
+    )
+    smem_V = ttgl.allocate_shared_memory(
+        v_desc.dtype,
+        shape=[num_stages] + v_desc.block_shape,
+        layout=v_desc.layout,
+    )
+
+    return k_desc, v_desc, smem_Q, smem_K, smem_V
+
+
+@gluon.jit
+def gluon_kernel_unified_attention_3d_tdm_gather_pipelined(
+    segm_output_ptr,
+    # [num_tokens, num_query_heads, num_segments, head_size]
+    segm_max_ptr,  # [num_tokens, num_query_heads, num_segments]
+    segm_expsum_ptr,  # [num_tokens, num_query_heads, num_segments]
+    query_ptr,  # [num_tokens, num_query_heads, head_size]
+    key_cache_ptr,  # [num_blks, num_kv_heads, blk_size, head_size]
+    value_cache_ptr,  # [num_blks, num_kv_heads, blk_size, head_size]
+    sink_ptr,  # [num_query_heads]
+    block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
+    # block_table_sorted_indices_ptr,  # [num_seqs, max_num_blocks_per_seq]
+    seq_lens_ptr,  # [num_seqs]
+    alibi_slopes_ptr,  # [num_query_heads]
+    qq_bias_ptr,  # [num_query_tokens, num_query_tokens]
+    scale,  # float32
+    k_scale,  # float32
+    v_scale,  # float32
+    softcap,  # float32
+    num_tokens,  # int
+    num_query_heads: ttgl.constexpr,  # int
+    num_queries_per_kv: ttgl.constexpr,  # int
+    block_table_stride: ttgl.int64,  # int
+    # block_table_sorted_indices_stride: ttgl.int64,  # int
+    query_stride_0: ttgl.int64,  # int
+    query_stride_1: ttgl.int64,  # int, should be equal to head_size
+    qq_bias_stride_0: ttgl.int64,  # int
+    NUM_BLOCKS: ttgl.constexpr,  # int
+    BLOCK_SIZE: ttgl.constexpr,  # int
+    TILE_SIZE: ttgl.constexpr,  # int, must be power of 2
+    HEAD_SIZE: ttgl.constexpr,  # int
+    HEAD_SIZE_PADDED: ttgl.constexpr,  # int, must be power of 2
+    USE_ALIBI_SLOPES: ttgl.constexpr,  # bool
+    USE_QQ_BIAS: ttgl.constexpr,  # bool
+    USE_SOFTCAP: ttgl.constexpr,  # bool
+    USE_SINKS: ttgl.constexpr,  # bool
+    SLIDING_WINDOW: ttgl.constexpr,  # int
+    stride_k_cache_0: ttgl.int64,  # int
+    stride_k_cache_1: ttgl.int64,  # int
+    stride_k_cache_2: ttgl.int64,  # int
+    stride_k_cache_3: ttgl.constexpr,  # int
+    stride_v_cache_0: ttgl.int64,  # int
+    stride_v_cache_1: ttgl.int64,  # int
+    stride_v_cache_2: ttgl.int64,  # int
+    stride_v_cache_3: ttgl.constexpr,  # int
+    query_start_len_ptr,  # [num_seqs+1]
+    BLOCK_Q: ttgl.constexpr,  # int
+    num_seqs: ttgl.int32,
+    BLOCK_M: ttgl.constexpr,  # int
+    NUM_SEGMENTS_PER_SEQ: ttgl.constexpr,  # int
+    num_warps: ttgl.constexpr,  # int
+    num_stages: ttgl.constexpr,  # int
+    QK_WMMA_LAYOUT: ttgl.constexpr,
+    PV_WMMA_LAYOUT: ttgl.constexpr,
+    Q_DOT_LAYOUT: ttgl.constexpr,
+    K_DOT_LAYOUT: ttgl.constexpr,
+    P_DOT_LAYOUT: ttgl.constexpr,
+    V_DOT_LAYOUT: ttgl.constexpr,
+    Q_SHARED_LAYOUT: ttgl.constexpr,
+    K_SHARED_LAYOUT: ttgl.constexpr,
+    V_SHARED_LAYOUT: ttgl.constexpr,
+    Q_BLOCKED_LAYOUT: ttgl.constexpr,
+    K_BLOCKED_LAYOUT: ttgl.constexpr,
+    num_ctas: ttgl.constexpr = 1,  # int
+    ALL_DECODE: ttgl.constexpr = False,  # bool
+):
+    q_block_global_idx = ttgl.program_id(0)
+    kv_head_idx = ttgl.program_id(1)
+    segm_idx = ttgl.program_id(2)
+    # num_ctas: ttgl.constexpr = ttgl.num_ctas()
+    pred = 1
+    pred_i32 = pred.to(ttgl.int32) if hasattr(pred, "to") else pred
+
+    ttgl.static_assert(
+        TILE_SIZE % BLOCK_SIZE == 0, "TILE_SIZE must be multiple of BLOCK_SIZE"
+    )
+    NUM_BLOCKS_GATHER_PER_TILE: ttgl.constexpr = TILE_SIZE // BLOCK_SIZE
+    ttgl.static_assert(
+        NUM_BLOCKS_GATHER_PER_TILE == 4 or NUM_BLOCKS_GATHER_PER_TILE == 8,
+        "NUM_BLOCKS_GATHER_PER_TILE must be 4 or 8",
+    )
+
+    # needed to use exp2 (exp2 -> exp conversion)
+    RCP_LN2 = 1.4426950408889634
+    qk_scale = scale * RCP_LN2
+
+    seq_idx = _find_seq_idx(
+        query_start_len_ptr, q_block_global_idx, num_seqs, BLOCK_Q, True
+    )
+
+    q_block_local_idx, cur_batch_query_len, cur_batch_in_all_start_index = (
+        _get_q_metadata(
+            query_start_len_ptr,
+            seq_idx,
+            q_block_global_idx,
+            BLOCK_Q,
+        )
+    )
+
+    if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
+        return
+
+    seq_len, tiles_per_segment = _get_seq_metadata(
+        seq_lens_ptr,
+        seq_idx,
+        TILE_SIZE,
+        NUM_SEGMENTS_PER_SEQ,
+    )
+
+    if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
+        return
+
+    # block table offset for this particular sequence
+    block_table_offset = seq_idx * block_table_stride
+
+    # context length for this particular sequence
+    context_len = seq_len - cur_batch_query_len
+
+    offs_q_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, Q_BLOCKED_LAYOUT))
+    offs_q_d = ttgl.arange(
+        0, HEAD_SIZE_PADDED, layout=ttgl.SliceLayout(0, Q_BLOCKED_LAYOUT)
+    )
+
+    query_pos = q_block_local_idx * BLOCK_Q + offs_q_m // num_queries_per_kv
+
+    query_offset_0 = cur_batch_in_all_start_index + query_pos
+    query_offset_1 = kv_head_idx * num_queries_per_kv + offs_q_m % num_queries_per_kv
+    query_offset = (
+        query_offset_0[:, None] * query_stride_0
+        + query_offset_1[:, None] * query_stride_1
+        + offs_q_d[None, :]
+    )
+
+    if HEAD_SIZE_PADDED != HEAD_SIZE:
+        dim_mask = offs_q_d < HEAD_SIZE
+    else:
+        dim_mask = ttgl.full((1,), 1, dtype=tl.int1)
+
+    query_mask_0 = query_pos < cur_batch_query_len
+    query_mask_1 = query_offset_1 < num_query_heads
+
+    NUM_KV_HEADS: ttgl.constexpr = num_query_heads // num_queries_per_kv
+
+    k_desc, v_desc, smem_Q, smem_K, smem_V = (
+        _tdm_gather_create_tensor_descriptors_and_allocate_lds(
+            query_ptr,
+            key_cache_ptr,
+            value_cache_ptr,
+            query_stride_1,
+            1,
+            stride_k_cache_1,  # stride_k_cache_1 = BLOCK_SIZE * HEAD_SIZE
+            stride_k_cache_3,
+            stride_v_cache_1,  # stride_v_cache_1 = BLOCK_SIZE * HEAD_SIZE
+            stride_v_cache_3,
+            Q_SHARED_LAYOUT,
+            K_SHARED_LAYOUT,
+            V_SHARED_LAYOUT,
+            NUM_BLOCKS,
+            NUM_KV_HEADS,
+            BLOCK_M,
+            HEAD_SIZE,
+            BLOCK_SIZE,
+            TILE_SIZE,
+            HEAD_SIZE_PADDED,
+            NUM_BLOCKS_GATHER_PER_TILE,
+            num_stages=num_stages,
+        )
+    )
+
+    # Q_load : shape = (BLOCK_M, HEAD_SIZE_PADDED), layout = Q_BLOCKED_LAYOUT
+    Q_load = ttgl.amd.cdna4.buffer_load(
+        ptr=query_ptr,
+        offsets=query_offset.to(ttgl.int32),
+        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
+        other=0.0,
+    )
+    smem_Q.store(Q_load)
+    # Q : shape = (BLOCK_M, HEAD_SIZE_PADDED), layout = Q_DOT_LAYOUT
+    Q = smem_Q.load(layout=Q_DOT_LAYOUT)
+
+    L, M, acc = _allocate_L_M_acc(
+        sink_ptr,
+        segm_idx,
+        query_offset_1,
+        query_mask_1,
+        RCP_LN2,
+        BLOCK_M,
+        Q_BLOCKED_LAYOUT,
+        HEAD_SIZE_PADDED,
+        PV_WMMA_LAYOUT,
+        USE_SINKS,
+    )
+
+    # alibi slope for this head
+    alibi_slope = None
+    if USE_ALIBI_SLOPES:
+        alibi_slope = tl.load(
+            alibi_slopes_ptr + query_offset_1, mask=query_mask_1, other=0.0
+        )
+
+    # query-query attention bias
+    qq_bias_row_ptrs = None
+    if USE_QQ_BIAS:
+        qq_bias_row_ptrs = (
+            qq_bias_ptr + query_pos[:, None] * qq_bias_stride_0
+        )  # shape: [BLOCK_M]
+
+    # compute the length of the longest sequence prefix spanned by any
+    # query token in the current q_block (q_block_local_idx)
+    max_seq_prefix_len = (
+        context_len
+        + q_block_local_idx * BLOCK_Q
+        + (BLOCK_M - 1) // num_queries_per_kv
+        + 1
+    )
+
+    # adjust for potential padding in the last q_block by considering the
+    # actual sequence length
+    max_seq_prefix_len = ttgl.minimum(max_seq_prefix_len, seq_len)
+
+    # calculate the number of tiles that need to be processed to
+    # cover the longest sequence prefix (due to causal masking, tiles beyond
+    # this prefix can be skipped)
+    num_tiles = cdiv_fn(max_seq_prefix_len, TILE_SIZE)
+
+    # KV_cache_modifier: ttgl.constexpr = ".cg" if ALL_DECODE else ""
+
+    k_producer = 0
+    k_consumer = 0
+    v_producer = 0
+    v_consumer = 0
+    GATHER_BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout(
+        size_per_thread=[NUM_BLOCKS_GATHER_PER_TILE],
+        threads_per_warp=[32],
+        warps_per_cta=[num_warps],
+        order=[0],
+    )
+    offs_j = ttgl.arange(0, NUM_BLOCKS_GATHER_PER_TILE, layout=GATHER_BLOCKED_LAYOUT)
+    j_producer = segm_idx * tiles_per_segment
+    j_consumer = segm_idx * tiles_per_segment
+    seq_offset = j_consumer * TILE_SIZE + ttgl.arange(
+        0, TILE_SIZE, layout=ttgl.SliceLayout(0, Q_BLOCKED_LAYOUT)
+    )
+
+    for _ in range(num_stages - 1):
+        j_producer, offs_k_gather_idx, offs_v_gather_idx = _tdm_gather_get_kv_offsets(
+            j_producer,
+            offs_j,
+            kv_head_idx,
+            block_tables_ptr,
+            block_table_offset,
+            stride_k_cache_0 // stride_k_cache_1,  # = NUM_KV_HEADS
+            stride_v_cache_0 // stride_v_cache_1,  # = NUM_KV_HEADS
+            NUM_BLOCKS_GATHER_PER_TILE,
+        )
+        k_producer = _tdm_async_gather_load_to_lds(
+            k_producer,
+            desc=k_desc,
+            src_row_indices=offs_k_gather_idx,
+            src_col_offset=0,
+            dst=smem_K,
+            num_stages=num_stages,
+        )
+        v_producer = _tdm_async_gather_load_to_lds(
+            v_producer,
+            desc=v_desc,
+            src_row_indices=offs_v_gather_idx,
+            src_col_offset=0,
+            dst=smem_V,
+            num_stages=num_stages,
+        )
+
+    # iterate through tiles within current segment
+    for _ in range(tiles_per_segment - (num_stages - 1)):
+        if j_producer < num_tiles:
+            j_producer, offs_k_gather_idx, offs_v_gather_idx = (
+                _tdm_gather_get_kv_offsets(
+                    j_producer,
+                    offs_j,
+                    kv_head_idx,
+                    block_tables_ptr,
+                    block_table_offset,
+                    stride_k_cache_0 // stride_k_cache_1,  # = NUM_KV_HEADS
+                    stride_v_cache_0 // stride_v_cache_1,  # = NUM_KV_HEADS
+                    NUM_BLOCKS_GATHER_PER_TILE,
+                )
+            )
+            k_producer = _tdm_async_gather_load_to_lds(
+                k_producer,
+                desc=k_desc,
+                src_row_indices=offs_k_gather_idx,
+                src_col_offset=0,
+                dst=smem_K,
+                num_stages=num_stages,
+            )
+            v_producer = _tdm_async_gather_load_to_lds(
+                v_producer,
+                desc=v_desc,
+                src_row_indices=offs_v_gather_idx,
+                src_col_offset=0,
+                dst=smem_V,
+                num_stages=num_stages,
+            )
+
+        if j_consumer < num_tiles:
+            # K : shape = (HEAD_SIZE_PADDED, TILE_SIZE), layout = K_DOT_LAYOUT
+            k_consumer, K = _tdm_gather_request_from_lds(
+                k_consumer,
+                k_scale,
+                Q.dtype,
+                smem_K,
+                asycn_wait=(num_stages - 1) * 2 + 1,
+                layout=K_DOT_LAYOUT,
+                transpose=True,
+                num_ctas=num_ctas,
+                num_stages=num_stages,
+                TILE_SIZE=TILE_SIZE,
+                HEAD_SIZE_PADDED=HEAD_SIZE_PADDED,
+            )
+
+            # P : shape = (BLOCK_M, TILE_SIZE), layout = Q_BLOCKED_LAYOUT
+            # L : shape = (BLOCK_M, ), layout = ttgl.SliceLayout(1, Q_BLOCKED_LAYOUT)
+            # M : shape = (BLOCK_M, ), layout = ttgl.SliceLayout(1, Q_BLOCKED_LAYOUT)
+            # acc : shape = (BLOCK_M, HEAD_SIZE_PADDED), layout = PV_WMMA_LAYOUT
+            P, L, M, acc = _perform_QK_wmma_and_update_L_M(
+                Q,
+                K,
+                L,
+                M,
+                acc,
+                qq_bias_row_ptrs,
+                seq_offset,
+                query_mask_1,
+                query_mask_0,
+                context_len,
+                query_pos,
+                alibi_slope,
+                qq_bias_stride_0,
+                qk_scale,
+                softcap,
+                RCP_LN2,
+                BLOCK_M,
+                TILE_SIZE,
+                USE_SOFTCAP,
+                SLIDING_WINDOW,
+                USE_ALIBI_SLOPES,
+                USE_QQ_BIAS,
+                Q_BLOCKED_LAYOUT,
+                QK_WMMA_LAYOUT,
+                PV_WMMA_LAYOUT,
+            )
+
+            # V : shape = (TILE_SIZE, HEAD_SIZE_PADDED), layout = V_DOT_LAYOUT
+            v_consumer, V = _tdm_gather_request_from_lds(
+                v_consumer,
+                v_scale,
+                Q.dtype,
+                smem_V,
+                asycn_wait=(num_stages - 1) * 2,
+                layout=V_DOT_LAYOUT,
+                transpose=False,
+                num_ctas=num_ctas,
+                num_stages=num_stages,
+                TILE_SIZE=TILE_SIZE,
+                HEAD_SIZE_PADDED=HEAD_SIZE_PADDED,
+            )
+
+            # acc : shape = (BLOCK_M, HEAD_SIZE_PADDED), layout = PV_WMMA_LAYOUT
+            acc = _perform_PV_wmma(P, V, acc, P_DOT_LAYOUT)
+
+            j_consumer = j_consumer + 1
+            seq_offset += TILE_SIZE
+
+    for _ in range(num_stages - 1):
+        if j_consumer < num_tiles:
+            # K : shape = (HEAD_SIZE_PADDED, TILE_SIZE), layout = K_DOT_LAYOUT
+            k_consumer, K = _tdm_gather_request_from_lds(
+                k_consumer,
+                k_scale,
+                Q.dtype,
+                smem_K,
+                asycn_wait=(num_stages - 1) * 2 + 1,
+                layout=K_DOT_LAYOUT,
+                transpose=True,
+                num_ctas=num_ctas,
+                num_stages=num_stages,
+                TILE_SIZE=TILE_SIZE,
+                HEAD_SIZE_PADDED=HEAD_SIZE_PADDED,
+            )
+
+            # P : shape = (BLOCK_M, TILE_SIZE), layout = Q_BLOCKED_LAYOUT
+            # L : shape = (BLOCK_M, ), layout = ttgl.SliceLayout(1, Q_BLOCKED_LAYOUT)
+            # M : shape = (BLOCK_M, ), layout = ttgl.SliceLayout(1, Q_BLOCKED_LAYOUT)
+            # acc : shape = (BLOCK_M, HEAD_SIZE_PADDED), layout = PV_WMMA_LAYOUT
+            P, L, M, acc = _perform_QK_wmma_and_update_L_M(
+                Q,
+                K,
+                L,
+                M,
+                acc,
+                qq_bias_row_ptrs,
+                seq_offset,
+                query_mask_1,
+                query_mask_0,
+                context_len,
+                query_pos,
+                alibi_slope,
+                qq_bias_stride_0,
+                qk_scale,
+                softcap,
+                RCP_LN2,
+                BLOCK_M,
+                TILE_SIZE,
+                USE_SOFTCAP,
+                SLIDING_WINDOW,
+                USE_ALIBI_SLOPES,
+                USE_QQ_BIAS,
+                Q_BLOCKED_LAYOUT,
+                QK_WMMA_LAYOUT,
+                PV_WMMA_LAYOUT,
+            )
+
+            # V : shape = (TILE_SIZE, HEAD_SIZE_PADDED), layout = V_DOT_LAYOUT
+            v_consumer, V = _tdm_gather_request_from_lds(
+                v_consumer,
+                v_scale,
+                Q.dtype,
+                smem_V,
+                asycn_wait=(num_stages - 1) * 2,
+                layout=V_DOT_LAYOUT,
+                transpose=False,
+                num_ctas=num_ctas,
+                num_stages=num_stages,
+                TILE_SIZE=TILE_SIZE,
+                HEAD_SIZE_PADDED=HEAD_SIZE_PADDED,
+            )
+
+            # acc : shape = (BLOCK_M, HEAD_SIZE_PADDED), layout = PV_WMMA_LAYOUT
+            acc = _perform_PV_wmma(P, V, acc, P_DOT_LAYOUT)
+
+            j_consumer = j_consumer + 1
+            seq_offset += TILE_SIZE
+
+    # store segm_output
+    # acc : shape = (BLOCK_M, HEAD_SIZE_PADDED), layout = Q_BLOCKED_LAYOUT
+    acc = ttgl.convert_layout(acc, layout=Q_BLOCKED_LAYOUT)
+    segm_output_offset = (
+        query_offset_0[:, None]
+        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + query_offset_1[:, None] * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + segm_idx * HEAD_SIZE_PADDED
+        + offs_q_d[None, :]
+    )
+    ttgl.amd.cdna4.buffer_store(
+        stored_value=acc,
+        ptr=segm_output_ptr,
+        offsets=segm_output_offset,
+        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
+    )
+
+    # store segm_max and segm_expsum
+    # L : shape = (BLOCK_M, ), layout = ttgl.SliceLayout(1, Q_BLOCKED_LAYOUT)
+    # M : shape = (BLOCK_M, ), layout = ttgl.SliceLayout(1, Q_BLOCKED_LAYOUT)
+    segm_offset = (
+        query_offset_0 * (num_query_heads * NUM_SEGMENTS_PER_SEQ)
+        + query_offset_1 * NUM_SEGMENTS_PER_SEQ
+        + segm_idx
+    )
+    ttgl.amd.cdna4.buffer_store(
+        stored_value=M,
+        ptr=segm_max_ptr,
+        offsets=segm_offset,
+        mask=query_mask_0 & query_mask_1,
+    )
+    ttgl.amd.cdna4.buffer_store(
+        stored_value=L,
+        ptr=segm_expsum_ptr,
+        offsets=segm_offset,
+        mask=query_mask_0 & query_mask_1,
+    )
+
+
+@gluon.jit
 def _tdm_get_kv_offsets(
     j,
     kv_head_idx,
@@ -487,7 +1119,9 @@ def gluon_kernel_unified_attention_3d_tdm_pipelined(
     pred = 1
     pred_i32 = pred.to(ttgl.int32) if hasattr(pred, "to") else pred
 
-    assert TILE_SIZE == BLOCK_SIZE, "TILE_SIZE must be identical to BLOCK_SIZE"
+    ttgl.static_assert(
+        TILE_SIZE == BLOCK_SIZE, "TILE_SIZE must be the same as BLOCK_SIZE"
+    )
 
     # needed to use exp2 (exp2 -> exp conversion)
     RCP_LN2 = 1.4426950408889634


### PR DESCRIPTION
This PR provides Unified Attention 3D with baseline, async_copy, tdm.async_copy, and tdm.async_gather version.

The tdm.async_gather version requires reordering of key_cache and value_cache, it doesn't not require sorting the block_table but the random gather feature is not hardware verified yet. Another issue with tdm.async_gather hits OOB LDS write if block_size * head_size >= 1024, so for now the UT only tested block_size * head_size = 512. The ticket related to this issue is https://github.com/ROCm/triton-internal/issues/1643