### PR TITLE
Silence certain warnings stemming from CK

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -556,7 +556,7 @@ def build_module(
 
         sources = rename_cpp_to_cu(srcs, src_dir, hipify)
 
-        flags_cc = ["-O3", "-std=c++20"]
+        flags_cc = ["-O3", "-std=c++20", "-Wno-unknown-warning-option"]
         flags_hip = [
             "-DLEGACY_HIPBLAS_DIRECT",
             "-DUSE_PROF_API=1",


### PR DESCRIPTION
## Motivation

TE builds CK kernels AOT and build logs are drowned out by repeated cases of "unknown-warning-option". This silences those warnings.

## Technical Details

Silence warnings stemming from CK

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
