### PR TITLE
Enabling FPMX4 GEMM on non-FPMX4 devices (Navi31 in particular)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_afp4wfp4.py
@@ -8,6 +8,46 @@ from aiter.ops.triton.utils.gemm_config_utils import get_gemm_config
 
 import triton
 
+@triton.jit
+def packed_nonzero(x):
+    low = (x & 0xFFFF)
+    high = (x >> 16)
+    _1u = tl.full([],1,dtype=tl.uint16)
+    combined = tl.join(low, high).to(tl.uint16)
+    combined = tl.minimum(combined, _1u)
+    combined -= _1u
+    low, high = tl.split(combined.to(tl.uint32))
+    y = (high<<16) | low
+    return y.to(tl.uint32, bitcast=True)
+
+@triton.jit
+def dequant_fp4_fp8e5m2_with_scale(x, sc):
+    # 'x' is a tensor of dtype uint8, packed two fp4 values per byte.
+    # 'sc' is a tensor of e8m0 scale values (uint8).
+    # Returns a tensor of float8e5 values, two per input byte.
+    x = x.to(tl.uint32)
+    x = (x*0x2002) & 0x1E001E
+    x = ((x & 0x100010)<<3) + (x & 0x0E000E)
+
+    bias = (sc.to(tl.uint32)-113)*0x40004
+    y = x+bias
+
+    mask0 = packed_nonzero(x & (0x60006<<1))
+    mask1 = packed_nonzero(x & (0x70007<<1))
+    signed_05 = (y & 0x800080) | bias
+    # ?001 -> +/-0.5
+    y = (y & ~mask0) | (signed_05 & mask0)
+
+    # ?000 -> +/-0
+    y = (y & ~mask1)
+
+    low_u8 = (y & 0xFF).to(tl.uint8)
+    high_u8 = (y >> 16).to(tl.uint8)
+    combined = tl.join(low_u8, high_u8)
+    return combined.to(tl.float8e5, bitcast=True)
+
+
+
 _gemm_afp4wfp4_repr = make_kernel_repr(
     "_gemm_afp4wfp4_kernel",
     [
@@ -53,6 +93,7 @@ def _gemm_afp4wfp4_kernel(
     stride_ask,
     stride_bsn,
     stride_bsk,
+    emu: tl.constexpr,
     # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -161,9 +202,20 @@ def _gemm_afp4wfp4_kernel(
                     cache_modifier=cache_modifier,
                 )
 
-            accumulator = tl.dot_scaled(
-                a, a_scales, "e2m1", b, b_scales, "e2m1", accumulator
-            )
+            if emu:
+                # FP4 -> FP8E5M2 dequantization, then tl.dot
+                a_scales = tl.minimum(tl.maximum(a_scales, 114), 140)
+                b_scales = tl.minimum(tl.maximum(b_scales, 114), 140)
+                a8 = dequant_fp4_fp8e5m2_with_scale(a.reshape([BLOCK_SIZE_M, BLOCK_SIZE_K//SCALE_GROUP_SIZE, SCALE_GROUP_SIZE//2]), a_scales[:, :, None])
+                b8 = dequant_fp4_fp8e5m2_with_scale(b.reshape([BLOCK_SIZE_K//SCALE_GROUP_SIZE, SCALE_GROUP_SIZE//2, BLOCK_SIZE_N]), b_scales.T[:,None,:])
+                b8 = b8.permute([0,1,3,2])
+                a8 = a8.reshape([BLOCK_SIZE_M, BLOCK_SIZE_K])
+                b8 = b8.reshape([BLOCK_SIZE_K, BLOCK_SIZE_N])
+                accumulator = tl.dot(a8, b8, accumulator)
+            else:
+                accumulator = tl.dot_scaled(
+                    a, a_scales, "e2m1", b, b_scales, "e2m1", accumulator
+                )
 
             # Advance the ptrs to the next K block.
             a_ptrs += (BLOCK_SIZE_K // 2) * stride_ak

--- a/aiter/ops/triton/configs/gemm/gfx1100-GEMM-AFP4WFP4.json
+++ b/aiter/ops/triton/configs/gemm/gfx1100-GEMM-AFP4WFP4.json
@@ -1,0 +1,62 @@
+{
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "any": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-AFP4WFP4.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-AFP4WFP4.json
@@ -1,0 +1,62 @@
+{
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 16,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 16,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 16,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 16,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 16,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/gfx942-GEMM-AFP4WFP4.json
+++ b/aiter/ops/triton/configs/gemm/gfx942-GEMM-AFP4WFP4.json
@@ -1,0 +1,62 @@
+{
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 4
+  },
+  "any": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 3,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
@@ -136,7 +136,7 @@ def gemm_afp4wfp4_(
         f"GEMM_AFPWFP4: x.shape={tuple(x.shape)} w.shape={tuple(w.shape)} x_scale={tuple(x_scales.shape)} w_scale={tuple(w_scales.shape)} "
     )
 
-    assert arch_info.is_fp4_avail(), "MXFP4 is not available on your device"
+    emu = arch_info.get_arch() in ("gfx1200", "gfx1201")
 
     M, K = x.shape
     N, K = w.shape
@@ -212,6 +212,7 @@ def gemm_afp4wfp4_(
         x_scales.stride(1),
         w_scales.stride(0),
         w_scales.stride(1),
+        emu,
         **config,
     )
 

--- a/aiter/ops/triton/gluon/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gluon/gemm_afp4wfp4.py
@@ -9,6 +9,7 @@ from aiter.ops.triton.utils.logger import AiterTritonLogger
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
+from packaging.version import Version
 
 _LOGGER = AiterTritonLogger()
 
@@ -523,7 +524,13 @@ def gemm_afp4wfp4(
         f"GEMM_AFPWFP4: x.shape={tuple(x.shape)} w.shape={tuple(w.shape)} x_scale={tuple(x_scales.shape)} w_scale={tuple(w_scales.shape)} "
     )
 
-    assert arch_info.is_fp4_avail(), "MXFP4 is not available on your device"
+    # only enables a custom version for GPUs with wmma, but without scaled_wmma.
+    #
+    # Everyone else will get Triton's internal emulation.
+    #
+    emu = arch_info.get_arch() in ("gfx1200", "gfx1201")
+    if Version(triton.__version__) < Version("3.6.0"):
+        assert emu or arch_info.is_fp4_avail(), "MXFP4 is not available on your device"
 
     M, K = x.shape
     N, K = w.shape
@@ -592,6 +599,7 @@ def gemm_afp4wfp4(
         x_scales.stride(1),
         w_scales.stride(0),
         w_scales.stride(1),
+        emu,
         **config,
     )
 

--- a/aiter/ops/triton/utils/gemm_config_utils.py
+++ b/aiter/ops/triton/utils/gemm_config_utils.py
@@ -71,6 +71,14 @@ def _get_gemm_config_cached(
         _get_gemm_config_cached._config_cache = {}
 
     dev = arch_info.get_arch()
+
+    dev_fallback_map = {
+        "gfx1101": "gfx1100",
+        "gfx1200": "gfx1201",
+    }
+    if (dev in dev_fallback_map) and \
+        not os.path.exists(f"{AITER_TRITON_CONFIGS_PATH}/gemm/{dev}-{config_name}.json"):
+        dev = dev_fallback_map[dev]
     cache_key = f"{dev}_{config_name}"
 
     if cache_key not in _get_gemm_config_cached._config_cache:


### PR DESCRIPTION
This enables the gemm_afp4wfp4 Triton kernel (with on-the-fly casting to bfloat16) on non-MXFP4 enabled hardware, specifically  targeting Navi31.

With this PR, I've been able to run Llama-3.3-70B-Instruct-MXFP4-Preview using vllm on 2x Radeon 7900 XTX, achieving generating speed of ~14 tokens/s (the model is almost entirely memory-bound on that hardware and it greatly benefits from having all weights in MXFP4.)