### PR TITLE
fix aiter.ops.triton.rope import

### DIFF
--- a/aiter/ops/triton/__init__.py
+++ b/aiter/ops/triton/__init__.py
@@ -119,6 +119,8 @@ _BACKWARD_COMPAT_MAP = {
     "fused_add_rmsnorm_pad": "normalization.fused_add_rmsnorm_pad",
     "norm": "normalization.norm",
     "rmsnorm": "normalization.rmsnorm",
+    # RoPE modules (rope/)
+    "rope": "rope.rope",
     "fused_qkv_split_qk_rope": "rope.fused_qkv_split_qk_rope",
     # Utils modules (utils/)
     "common_utils": "utils.common_utils",


### PR DESCRIPTION
## Motivation

https://github.com/vllm-project/vllm/blob/dc5fa77a4eb6680339cb77abe713fb22d7795560/vllm/_aiter_ops.py#L1495 is currently broken

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
