### PR TITLE
Adding double buffer option to cross_device_reduce_1stage

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -2259,7 +2259,7 @@ class CustomAllreduce
         }                                                                     \
     } while(0)
 
-#define dispatch(ngpus, name)              \
+#define dispatch(ngpus, name)                             \
     do                                                    \
     {                                                     \
         if(bytes % (ngpus * 16) == 0 && world_size_ != 6) \
@@ -2275,7 +2275,7 @@ class CustomAllreduce
         }                                                 \
         else                                              \
         {                                                 \
-            KL(ngpus, name##_naive);       \
+            KL(ngpus, name##_naive);                      \
         }                                                 \
     } while(0)
 
@@ -2283,7 +2283,7 @@ class CustomAllreduce
     case ngpus: {                                        \
         if(call_1stage)                                  \
         {                                                \
-            KL(ngpus, cross_device_reduce_1stage); \
+            KL(ngpus, cross_device_reduce_1stage);       \
         }                                                \
         else if(call_2stage)                             \
         {                                                \
@@ -2312,7 +2312,7 @@ class CustomAllreduce
     case ngpus: {                                            \
         if(world_size_ == 2)                                 \
         {                                                    \
-            KL(ngpus, cross_device_reduce_1stage);     \
+            KL(ngpus, cross_device_reduce_1stage);           \
         }                                                    \
         else if(full_nvlink_)                                \
         {                                                    \


### PR DESCRIPTION
## Motivation

Improve performance of GPT OSS 120b

## Technical Details

Optimised *custom_all_reduce_1stage* kernel to use double buffering and hide latency of P2P communications.

## Test Plan

Functional testing using...

python op_tests/multigpu_tests/test_custom_allreduce.py  ✅
python test_custom_allreduce.py -s 32,128 -d fp16 ✅
python test_custom_allreduce.py -s 32,256 -d fp16 ✅

## Test Result

GPT OSS 120b 
Input size 1024, output size 8192, tp 8, concurrency (4 8 16 32 64 128). Throughput performance up tick between. 0.7 - 10%

<img width="1881" height="676" alt="image" src="https://github.com/user-attachments/assets/c1ce39d1-764c-4e1c-905b-89885d2da7a9" />

input size 8192 output size 1024
The following shows the GPT OSS 120b percentage improvement resulting from double buffering...

<img width="1529" height="452" alt="image" src="https://github.com/user-attachments/assets/22363ba6-26f8-428e-8b33-dea29a9b23a8" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
