### PR TITLE
revert triton gemm kernel config due to core dump.

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE-N=7168-K=2048.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE-N=7168-K=2048.json
@@ -13,16 +13,16 @@
   },
   "M_LEQ_16": {
     "BLOCK_SIZE_M": 16,
-    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_N": 32,
     "BLOCK_SIZE_K": 128,
     "GROUP_SIZE_M": 1,
     "num_warps": 2,
-    "num_stages": 2,
+    "num_stages": 1,
     "waves_per_eu": 2,
     "matrix_instr_nonkdim": 16,
     "cache_modifier": ".cg",
-    "NUM_KSPLIT": 14
-},
+    "NUM_KSPLIT": 4
+  },
   "M_LEQ_32": {
     "BLOCK_SIZE_M": 16,
     "BLOCK_SIZE_N": 16,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This GEMM tuned configuration was introduced in https://github.com/ROCm/aiter/pull/2016. When rebased onto the latest AITER code, it causes a core dump. Therefore, revert this change.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
