### PR TITLE
[OPUS] Add f32 MFMA support

### DIFF
--- a/op_tests/opus/device/opus_device_test_ext.cpp
+++ b/op_tests/opus/device/opus_device_test_ext.cpp
@@ -57,6 +57,10 @@ static void run_mfma_torch(
         dtype_ok = (A.dtype() == torch::kBFloat16);
         expected_out_dtype = torch::kBFloat16;
         in_dtype_name = "bfloat16";
+    } else if (variant.find("_f32") != std::string::npos) {
+        dtype_ok = (A.dtype() == torch::kFloat32);
+        expected_out_dtype = torch::kFloat32;
+        in_dtype_name = "float32";
     } else {
         dtype_ok = (A.dtype() == torch::kFloat16);
         expected_out_dtype = torch::kFloat16;
@@ -71,7 +75,17 @@ static void run_mfma_torch(
     int stride_b = static_cast<int>(B.stride(0));
     int stride_c = static_cast<int>(C.stride(0));
 
-    if (variant == "32x32x8_f16") {
+    if (variant == "32x32x2_f32") {
+        TORCH_CHECK((A.sizes() == torch::IntArrayRef{32, 2}),  "A must be 32x2 for variant ", variant);
+        TORCH_CHECK((B.sizes() == torch::IntArrayRef{32, 2}),  "B must be 32x2 for variant ", variant);
+        TORCH_CHECK((C.sizes() == torch::IntArrayRef{32, 32}), "C must be 32x32 for variant ", variant);
+        run_mfma_32x32x2_f32(A.data_ptr(), B.data_ptr(), C.data_ptr(), stride_a, stride_b, stride_c);
+    } else if (variant == "16x16x4_f32") {
+        TORCH_CHECK((A.sizes() == torch::IntArrayRef{16, 4}),  "A must be 16x4 for variant ", variant);
+        TORCH_CHECK((B.sizes() == torch::IntArrayRef{16, 4}),  "B must be 16x4 for variant ", variant);
+        TORCH_CHECK((C.sizes() == torch::IntArrayRef{16, 16}), "C must be 16x16 for variant ", variant);
+        run_mfma_16x16x4_f32(A.data_ptr(), B.data_ptr(), C.data_ptr(), stride_a, stride_b, stride_c);
+    } else if (variant == "32x32x8_f16") {
         TORCH_CHECK((A.sizes() == torch::IntArrayRef{32, 8}),  "A must be 32x8 for variant ", variant);
         TORCH_CHECK((B.sizes() == torch::IntArrayRef{32, 8}),  "B must be 32x8 for variant ", variant);
         TORCH_CHECK((C.sizes() == torch::IntArrayRef{32, 32}), "C must be 32x32 for variant ", variant);

--- a/op_tests/opus/device/test_mfma.h
+++ b/op_tests/opus/device/test_mfma.h
@@ -11,6 +11,12 @@ extern "C" {
 // All functions: d_a, d_b, d_c are device pointers; strides in elements.
 // C = A @ B^T  (swap_ab adaptor).
 
+// --- f32 MFMA: gfx942 + gfx950 ---
+void run_mfma_32x32x2_f32(const void* d_a, const void* d_b, void* d_c,
+                           int stride_a, int stride_b, int stride_c);
+void run_mfma_16x16x4_f32(const void* d_a, const void* d_b, void* d_c,
+                           int stride_a, int stride_b, int stride_c);
+
 // --- gfx942 only ---
 void run_mfma_32x32x8_f16(const void* d_a, const void* d_b, void* d_c,
                            int stride_a, int stride_b, int stride_c);

--- a/op_tests/opus/device/test_opus_device.py
+++ b/op_tests/opus/device/test_opus_device.py
@@ -3,6 +3,8 @@
 """
 Test OPUS device kernels via a single PyTorch extension (opus_device_test).
 Covers:
+  - MFMA 32x32x2   fp32      (gfx942 + gfx950)
+  - MFMA 16x16x4   fp32      (gfx942 + gfx950)
   - MFMA 32x32x8   fp16/bf16 (gfx942 only)
   - MFMA 16x16x16  fp16/bf16 (gfx942 only)
   - MFMA 32x32x16  fp16/bf16 (gfx942 + gfx950)
@@ -184,6 +186,20 @@ def _test_mfma_variant(mod, variant, M, N, K, dtype, supported_archs):
         return 1
     print(f"  PASS: mfma_{variant}, max_diff={max_diff:.4f}")
     return 0
+
+
+def test_mfma_32x32x2_f32(mod):
+    """Test MFMA 32x32x2 fp32 kernel (gfx942 + gfx950)."""
+    return _test_mfma_variant(
+        mod, "32x32x2_f32", 32, 32, 2, torch.float32, _MFMA_ARCHS_GFX942_GFX950
+    )
+
+
+def test_mfma_16x16x4_f32(mod):
+    """Test MFMA 16x16x4 fp32 kernel (gfx942 + gfx950)."""
+    return _test_mfma_variant(
+        mod, "16x16x4_f32", 16, 16, 4, torch.float32, _MFMA_ARCHS_GFX942_GFX950
+    )
 
 
 def test_mfma_32x32x8_f16(mod):
@@ -801,6 +817,8 @@ def main():
     mod = __import__(_MODULE_NAME)
 
     failures = 0
+    failures += test_mfma_32x32x2_f32(mod)
+    failures += test_mfma_16x16x4_f32(mod)
     failures += test_mfma_32x32x8_f16(mod)
     failures += test_mfma_32x32x8_bf16(mod)
     failures += test_mfma_16x16x16_f16(mod)


### PR DESCRIPTION
Add f32 MFMA support: __builtin_amdgcn_mfma_f32_32x32x2f32 and __buittin_amdgcn_mfma_f32_16x16x4f32

These are the classic f32-input MFMA instructions available on gfx942+. A specialized DISPATCH_MFMA_F32_ macro extracts scalar floats from vector_t<fp32_t, 1> since the builtins take scalar (not vector) inputs. Verified on gfx942 and gfx950 with both ROCm 7.1.1 and ROCm 6.4.4 containers.

