### PR TITLE
[Triton] Sync Flash Attention Package #2

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -5,8 +5,9 @@ import triton.language as tl
 from typing import Literal, Optional
 from .common import compute_alibi_block, compute_fp8_scaling_factors, apply_rotary
 from .utils import (
-    DEBUG,
     AUTOTUNE,
+    DEBUG,
+    FWD_CONF_OVERRIDE,
     get_arch,
     is_fp8,
 )
@@ -31,6 +32,9 @@ def get_fwd_prefill_configs(autotune: bool):
     #   - RDNA: BLOCK_N=32
     # See _get_block_size_n_triton() in test_flash_attn_triton_amd.py
     if not autotune:
+        if FWD_CONF_OVERRIDE:
+            return [FWD_CONF_OVERRIDE]
+
         arch = get_arch()
         if arch.name == "gfx950":
             return [

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
@@ -9,12 +9,16 @@ This module contains essential runtime utilities:
 """
 
 import functools
+import json
+import logging
 import os
 from dataclasses import dataclass
 from typing import Literal, Optional, Union
 
 import torch
 import triton
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     # Runtime info
@@ -115,6 +119,23 @@ AUTOTUNE = os.environ.get("FLASH_ATTENTION_TRITON_AMD_AUTOTUNE", "0").lower() in
     "true",
     "yes",
 )
+
+# User override config json.
+# Note: Ignored if FLASH_ATTENTION_TRITON_AMD_AUTOTUNE is enabled.
+#
+# e.g. FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":32,"BLOCK_N":32,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":4}'
+FWD_CONF_OVERRIDE = None
+try:
+    conf_json = os.getenv("FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON")
+    if conf_json:
+        conf = json.loads(conf_json)
+        FWD_CONF_OVERRIDE = triton.Config(
+            conf,
+            num_stages=conf.pop("num_stages", 1),
+            num_warps=conf.pop("num_warps", 4),
+        )
+except Exception as e:
+    logger.warning(f"FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON parse error: {e}")
 
 # Unified debug level:
 #   0 = off (default)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This is a follow up to https://github.com/ROCm/aiter/pull/1942. It is just making sure the flash attention in aiter has all the upstream changes. This will make the process of switching to aiter easier.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
