### PR TITLE
use regex to extract arch from rocminfo string

### DIFF
--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -69,7 +69,7 @@ def get_gfx_custom_op_core() -> int:
             for line in output.split("\n"):
                 match = re.search(r"\b(gfx\w+)\b", line, re.IGNORECASE)
                 if match:
-                    gfx_arch = match.group(1)
+                    gfx_arch = match.group(1).lower()
                     try:
                         return gfx_mapping[gfx_arch]
                     except KeyError:


### PR DESCRIPTION
## Motivation
Fails to extract arch from rocminfo string in some cases and throws error

## Testing
Tested on gfx950 to make sure change doesn't break anything
