### PR TITLE
Add HF_TOKEN as workflow-level env var to all CI workflows

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -14,6 +14,7 @@ concurrency:
 env:
   DOCKER_IMAGE: "rocm/pytorch:latest@sha256:683765a52c61341e1674fe730ab3be861a444a45a36c0a8caae7653a08a0e208"
   GPU_ARCH_LIST: "gfx942;gfx950"
+  HF_TOKEN: ${{ secrets.HF_TOKEN_TEST }}
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
 

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -15,6 +15,7 @@ env:
   ATOM_BRANCH: "main"
   ATOM_REPOSITORY_URL: "ROCm/ATOM"
   BASE_IMAGE: "rocm/atom-dev:latest"
+  HF_TOKEN: ${{ secrets.HF_TOKEN_TEST }}
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/Aiter.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
 

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN_TEST }}
+
 jobs:
   check-signal:
     runs-on: ubuntu-latest

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -15,6 +15,7 @@ env:
   VLLM_BRANCH: "main"
   VLLM_REPOSITORY_URL: "https://github.com/vllm-project/vllm"
   BASE_IMAGE: rocm/vllm-dev:nightly@sha256:3c611f72843f172d5aea9c05a4c956294184103778d3ef179ffff775287ab89d
+  HF_TOKEN: ${{ secrets.HF_TOKEN_TEST }}
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
 


### PR DESCRIPTION
## Summary
- Adds `HF_TOKEN` (from `secrets.HF_TOKEN_TEST`) as a workflow-level `env` var in all 4 CI workflows: `aiter-test`, `atom-test`, `sglang_downstream`, `vllm_benchmark`
- This ensures all jobs and containers automatically inherit the token, preventing unauthenticated HuggingFace API requests that hit 429 rate limits
- Previously only some containers had it passed explicitly via `-e` flag, and the Atom Test workflow was missing it entirely (caused a CI failure: `httpx.HTTPStatusError: Client error '429 Too Many Requests'`)

## Test plan
- [ ] Verify Atom Test no longer shows "You are sending unauthenticated requests to the HF Hub" warning
- [ ] Verify all workflows can download models/tokenizers without 429 errors