### PR TITLE
fix smoothquant hip kernel exceed int32's maximum.

### DIFF
--- a/csrc/kernels/quant_kernels.cu
+++ b/csrc/kernels/quant_kernels.cu
@@ -457,7 +457,7 @@ smooth_data_to_per_row_scale(const DTYPE_I* __restrict__ input,
         std::is_same_v<DTYPE_O, ck_tile::fp4x2_t>
             ? 0.25
             : (1. / ck_tile::type_convert<float>(ck_tile::numeric<DTYPE_O>::max()));
-    const int64_t row_offset      = token_idx * cols;
+    const int64_t row_offset      = (int64_t)token_idx * cols;
     auto const* ptr_i             = reinterpret_cast<DTYPE_I const*>(input + row_offset);
     auto const* input_vecs        = reinterpret_cast<vec_i const*>(ptr_i);
     static constexpr int32_t ooba_i = 4 / sizeof(DTYPE_I);
@@ -582,8 +582,7 @@ __global__ void smooth_per_token_scaled_quant_kernel(DTYPE_O* __restrict__ out,
                 scale[out_token_idx] = row_scale;
             }
         }
-
-        int64_t out_offset = out_token_idx * cols;    
+        int64_t out_offset = (int64_t)out_token_idx * cols;
         scaled_quant_vgpr_impl<float, DTYPE_O, thread_data_size>(out, vec_ptr, &row_scale, cols, out_offset);
     }
 }

--- a/op_tests/test_moe.py
+++ b/op_tests/test_moe.py
@@ -190,7 +190,9 @@ def test_fmoe(
             avg_b = 9999
             print("asm g1u1 only support quant/smoothquant Now")
         else:
-            out_b, avg_b = asm_moe_test(input, w1b, w2b, topk_weights, topk_ids)
+            out_b, avg_b = asm_moe_test(
+                input, w1b, w2b, topk_weights, topk_ids, activation=activation
+            )
 
         msg = f"[perf] {token=}, quant={quantstr}, {model_dim=}, {inter_dim=}, {E=}, {topk=}, dtype: {dtype}, torch_avg: {avg_c:<8.2f} us, asm_avg: {avg_b:>8.2f} us, uplift: {avg_c/avg_b-1:.1%}"
         checkAllclose(ref2, out_b, rtol=0.01, atol=100, msg=msg)
@@ -436,7 +438,16 @@ for test in l_test:
                     for idim in [1024] if args.inter_dim is None else args.inter_dim:
                         expert = 32 if args.expert is None else args.expert
                         topk = 5 if args.topk is None else args.topk
-                        test_fmoe(dtype, m, hdim, idim, expert, topk, quant="No")
+                        test_fmoe(
+                            dtype,
+                            m,
+                            hdim,
+                            idim,
+                            expert,
+                            topk,
+                            quant="No",
+                            activation=args.activation,
+                        )
     elif test == "g1u1_no_quant":
         for dtype in (
             [dtypes.fp16, dtypes.bf16]
@@ -459,6 +470,7 @@ for test in l_test:
                             topk,
                             quant="No",
                             use_g1u1=True,
+                            activation=args.activation,
                         )
     elif test == "g1u1_int8quant":
         for dtype in (
@@ -481,6 +493,7 @@ for test in l_test:
                             #   quant='int8quant', use_g1u1=True, shared_E=0, activation=ActivationType.Gelu)
                             quant="int8quant",
                             use_g1u1=True,
+                            activation=args.activation,
                         )
 
     elif test == "g1u1_fp8quant":
@@ -530,6 +543,7 @@ for test in l_test:
                             topk,
                             quant="int8smoothquant",
                             use_g1u1=False,
+                            activation=args.activation,
                         )
 
     elif test == "g1u1_int8smoothquant":
@@ -556,6 +570,7 @@ for test in l_test:
                             topk,
                             quant="int8smoothquant",
                             use_g1u1=True,
+                            activation=args.activation,
                         )
 
     elif test == "g1u1_fp8smoothquant":
@@ -580,6 +595,7 @@ for test in l_test:
                             topk,
                             quant="fp8smoothquant",
                             use_g1u1=True,
+                            activation=args.activation,
                         )
     elif test == "g1u1_int4":
         for dtype in (
@@ -603,6 +619,7 @@ for test in l_test:
                             topk,
                             quant="wint4afp8smoothquant",
                             use_g1u1=True,
+                            activation=args.activation,
                         )
     else:
         raise ValueError(f"Unknown test: {test}")


### PR DESCRIPTION
## Motivation
``` bash
python3 op_tests/test_moe.py -t g1u0_int8smoothquant -d bf16 -m 80000 -hd 4096 -id 192 -e 400 -k 20
```
Above test has core dump. When m is large, out_token_idx * cols can exceed int32_t's maximum (2,147,483,647). Overflow produces a negative or invalid value for out_offset, leading to invalid memory access and a core dump.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
