### PR TITLE
Add runner-config.yml for runner->GPU mapping used by frameworks-devops-dashboard to display GPU architecture

### DIFF
--- a/.github/runner-config.yml
+++ b/.github/runner-config.yml
@@ -1,0 +1,19 @@
+# Runner label → GPU hardware mapping
+# Used by frameworks-devops-dashboard to display GPU architecture
+# Update this when runners are added/changed in CI workflows
+runners:
+  aiter-1gpu-runner:
+    gpu_arch: MI325
+    gpu_count: 1
+
+  aiter-8gpu-runner:
+    gpu_arch: MI325
+    gpu_count: 8
+
+  linux-aiter-mi355-1:
+    gpu_arch: MI355
+    gpu_count: 1
+
+  linux-aiter-mi355-8:
+    gpu_arch: MI355
+    gpu_count: 8


### PR DESCRIPTION
Fix: https://github.com/ROCm/frameworks-devops-dashboard/issues/27