### PR TITLE
fix: quant dispatch bugs and dead code cleanup in quant.py

### DIFF
--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -33,7 +33,7 @@ def moe_smoothquant_fwd(
 def get_dtype_max(dtype):
     try:
         dtypeMax = torch.finfo(dtype).max
-    except:
+    except TypeError:
         dtypeMax = torch.iinfo(dtype).max
     return dtypeMax
 
@@ -190,19 +190,17 @@ def get_torch_quant(qType):
 @functools.lru_cache()
 def get_hip_quant(qType):
     tmp = {
-        QuantType.No.value: lambda *a, **k: (a[0], None),
-        QuantType.per_Tensor.value: per_tensor_quant_hip,
-        QuantType.per_Token.value: per_token_quant_hip,
-        QuantType.per_1x32.value: per_1x32_f4_quant_hip,
-        QuantType.per_1x128.value: functools.partial(
-            per_group_quant_hip, group_size=128
-        ),
+        QuantType.No: lambda *a, **k: (a[0], None),
+        QuantType.per_Tensor: per_tensor_quant_hip,
+        QuantType.per_Token: per_token_quant_hip,
+        QuantType.per_1x32: per_1x32_f4_quant_hip,
+        QuantType.per_1x128: functools.partial(per_group_quant_hip, group_size=128),
     }
 
     def raise_NotImplementedError(*a, **k):
         raise NotImplementedError(f"unsupported quant type {qType=}")
 
-    return tmp.get(qType.value, raise_NotImplementedError)
+    return tmp.get(qType, raise_NotImplementedError)
 
 
 @functools.lru_cache()
@@ -236,21 +234,10 @@ def per_token_quant_hip(
     else:
         raise ValueError("unsupported: static per token quant")
 
-    if 1:
-        y = torch.empty(shape, dtype=quant_dtype, device=device)
-        dynamic_per_token_scaled_quant(
-            y, x, scale, num_rows=num_rows, num_rows_factor=num_rows_factor
-        )
-    elif quant_dtype == dtypes.i8:
-        M, N = x.view(-1, shape[-1]).shape
-        y = torch.empty((M, N), dtype=dtypes.i8, device=device)
-        scale = torch.empty(M, dtype=dtypes.fp32, device=device)
-        smooth_scale = torch.ones(N, dtype=dtypes.fp32, device=device)
-        smoothquant_fwd(y, x, smooth_scale, scale)
-        y = y.view(shape)
-    else:
-        raise ValueError(f"unsupported: {quant_dtype=}")
-    # print("finished per token quant hip")
+    y = torch.empty(shape, dtype=quant_dtype, device=device)
+    dynamic_per_token_scaled_quant(
+        y, x, scale, num_rows=num_rows, num_rows_factor=num_rows_factor
+    )
     return y, scale
 
 
@@ -398,7 +385,11 @@ def get_torch_act(aType):
         ActivationType.Silu: F.silu,
         ActivationType.Gelu: F.gelu,
     }
-    return tmp.get(aType, NotImplementedError)
+
+    def raise_NotImplementedError(*a, **k):
+        raise NotImplementedError(f"unsupported activation type {aType=}")
+
+    return tmp.get(aType, raise_NotImplementedError)
 
 
 @compile_ops("module_quant")


### PR DESCRIPTION
Spotted a few issues while reading through `aiter/ops/quant.py` — all in the dispatch helpers and one function body. Single-file change, no new dependencies.

`get_torch_act` uses `dict.get(aType, NotImplementedError)` as its fallback, which returns the class object itself rather than raising. Callers in `fused_moe.py` and `fused_moe_dp_shared_expert.py` do `torch_act = get_torch_act(activation)` and then call `torch_act(x)` — for an unsupported activation type this ends up constructing `NotImplementedError(tensor)` and returning it as a value instead of blowing up. The sibling `get_*_quant` functions already handle this properly with a local closure that raises, so I matched that pattern.

`get_dtype_max` has a bare `except:` around the `torch.finfo` / `torch.iinfo` fallback. The only expected failure is `TypeError` (finfo on an integer dtype), but bare except also catches `KeyboardInterrupt`, `SystemExit`, etc. Narrowed it to `except TypeError:`.

`per_token_quant_hip` had an `if 1:` guarding the active code path with unreachable `elif`/`else` branches — the `elif` was an older smoothquant-based implementation that's been superseded by `dynamic_per_token_scaled_quant`. Removed the dead branches.

`get_hip_quant` keyed its dispatch dict on `QuantType.*.value` (raw ints) and looked up with `qType.value`, while `get_torch_quant` and `get_triton_quant` both key on enum members directly. Not a bug, but inconsistent for no reason — switched to enum members to match.

All changes are behavior-preserving on valid inputs. The only difference is on error paths: unsupported activation types now raise properly, and `get_dtype_max` won't swallow signals. Existing `op_tests/test_quant.py` covers the valid dispatch paths.