### PR TITLE
[PERF] Tune moe_gemm_a8w4 Triton kernel for gfx950 (MI355X)

### DIFF
--- a/aiter/configs/moe_a8w4_configs/gfx950.json
+++ b/aiter/configs/moe_a8w4_configs/gfx950.json
@@ -1,0 +1,38 @@
+{
+    "1": {
+        "block_n": 128, "block_k": 256, "num_warps": 4,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    },
+    "2": {
+        "block_n": 128, "block_k": 256, "num_warps": 4,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    },
+    "4": {
+        "block_n": 128, "block_k": 256, "num_warps": 4,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    },
+    "8": {
+        "block_n": 128, "block_k": 256, "num_warps": 4,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    },
+    "16": {
+        "block_n": 128, "block_k": 256, "num_warps": 4,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    },
+    "32": {
+        "block_n": 256, "block_k": 256, "num_warps": 8,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 2
+    },
+    "64": {
+        "block_n": 256, "block_k": 256, "num_warps": 8,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    },
+    "128": {
+        "block_n": 256, "block_k": 256, "num_warps": 8,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    },
+    "256": {
+        "block_n": 256, "block_k": 256, "num_warps": 8,
+        "num_stages": 3, "group_m": 4, "waves_per_eu": 0
+    }
+}

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -63,89 +63,107 @@ def allocate_output(
     return matmul_output, final_output
 
 
-def _is_gfx950():
+_moe_a8w4_config_cache = {}
+
+
+def _load_moe_a8w4_config():
+    """Load per-device tuned configs from JSON files in aiter/configs/moe_a8w4_configs/."""
+    if _moe_a8w4_config_cache:
+        return _moe_a8w4_config_cache.get("data")
+
+    import json
+    import os
     try:
         from aiter.jit.utils.chip_info import get_gfx
-        return get_gfx() == "gfx950"
+        gfx = get_gfx()
     except Exception:
-        return False
+        gfx = None
+
+    if gfx is None:
+        _moe_a8w4_config_cache["data"] = None
+        return None
+
+    config_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))))),
+        "configs", "moe_a8w4_configs"
+    )
+    config_file = os.path.join(config_dir, f"{gfx}.json")
+
+    if not os.path.exists(config_file):
+        _moe_a8w4_config_cache["data"] = None
+        return None
+
+    with open(config_file) as f:
+        data = json.load(f)
+
+    _moe_a8w4_config_cache["data"] = data
+    return data
 
 
 def get_kernel_config(m, n, k, routing_data):
     block_m = routing_data.block_m
-    group_m = 4
     num_xcds = 8
     xcd_swizzle = num_xcds
     w_cache_modifier = ".cg" if block_m <= 32 else None
     split_k = 1
+
+    tuned = _load_moe_a8w4_config()
+    if tuned is not None:
+        best_key = None
+        for key in sorted(tuned.keys(), key=int):
+            if int(key) <= block_m:
+                best_key = key
+        if best_key is not None:
+            cfg = tuned[best_key]
+            return {
+                "block_m": block_m,
+                "block_n": cfg["block_n"],
+                "block_k": cfg.get("block_k", 256),
+                "num_warps": cfg["num_warps"],
+                "num_stages": cfg["num_stages"],
+                "group_m": cfg.get("group_m", 4),
+                "xcd_swizzle": xcd_swizzle,
+                "w_cache_modifier": w_cache_modifier,
+                "split_k": split_k,
+                "waves_per_eu": cfg.get("waves_per_eu", 0),
+                "matrix_instr_nonkdim": 16,
+                "kpack": 1,
+            }
+
+    # Default heuristics (no tuned config found)
+    group_m = 4
     block_k = 256
+    num_stages = 2
+    waves_per_eu = 0
 
-    if _is_gfx950():
-        num_stages = 3
-        waves_per_eu = 2 if block_m <= 32 else 0
+    if block_m == 16:
+        block_n = 128
+        num_warps = 4
 
-        if block_m == 16:
-            block_n = 128
-            num_warps = 4
-
+        grid_m = routing_data.n_blocks(m, block_m)
+        grid_n = triton.cdiv(n, block_n)
+        grid = grid_m * grid_n * split_k
+        while block_n >= 64 and grid < 256:
+            block_n = block_n // 2
             grid_m = routing_data.n_blocks(m, block_m)
             grid_n = triton.cdiv(n, block_n)
             grid = grid_m * grid_n * split_k
-            while block_n >= 64 and grid < 256:
-                block_n = block_n // 2
-                grid_m = routing_data.n_blocks(m, block_m)
-                grid_n = triton.cdiv(n, block_n)
-                grid = grid_m * grid_n * split_k
 
-        elif block_m == 32:
-            if n <= 1024:
-                block_n = 128
-                num_warps = 4
-            elif n <= 4096:
-                block_n = 256
-                num_warps = 8
-            else:
-                block_n = 256
-                num_warps = 8
-
-        elif block_m == 64:
-            block_n = 256
-            num_warps = 8
-
-        else:
-            block_n = 256
-            num_warps = 8
-    else:
-        num_stages = 2
-        waves_per_eu = 0
-
-        if block_m == 16:
+    elif block_m == 32:
+        if n <= 1024:
             block_n = 128
             num_warps = 4
-
-            grid_m = routing_data.n_blocks(m, block_m)
-            grid_n = triton.cdiv(n, block_n)
-            grid = grid_m * grid_n * split_k
-            while block_n >= 64 and grid < 256:
-                block_n = block_n // 2
-                grid_m = routing_data.n_blocks(m, block_m)
-                grid_n = triton.cdiv(n, block_n)
-                grid = grid_m * grid_n * split_k
-
-        elif block_m == 32:
-            if n <= 1024:
-                block_n = 128
-                num_warps = 4
-            elif n <= 4096:
-                block_n = 256
-                num_warps = 8
-            else:
-                block_n = 512
-                num_warps = 8
-
+        elif n <= 4096:
+            block_n = 256
+            num_warps = 8
         else:
             block_n = 512
             num_warps = 8
+
+    else:
+        block_n = 512
+        num_warps = 8
 
     ret = {
         "block_m": block_m,


### PR DESCRIPTION
## Summary

- Adds config-file-based tuning for the `moe_gemm_a8w4` Triton kernel (MXFP4 weights + FP8 activations MoE)
- Includes tuned config for gfx950 (MI355X)
- Non-gfx950 paths fall back to original heuristics unchanged

## Design

Kernel tile configurations are loaded from JSON files in `aiter/configs/moe_a8w4_configs/{gfx}.json`, keyed by `block_m` (token tile size set by the routing layer). This follows the same pattern as vLLM's fused MoE config files.

When no config file exists for the current device, the original hardcoded heuristics are used as fallback.

## gfx950 Config

Key tuning values vs defaults:

| Parameter | Default | gfx950 (decode, block_m<=16) | gfx950 (prefill, block_m=32) | gfx950 (prefill, block_m>=64) |
|-----------|---------|-----|-----|-----|
| `num_stages` | 2 | 3 | 3 | 3 |
| `waves_per_eu` | 0 | 0 | 2 | 0 |
| `block_n` | 512 (N>4096) | 128 | 256 | 256 |

## Benchmark Results

Model: `amd/gpt-oss-120b-w-mxfp4-a-fp8` on MI355X, TP1, vLLM nightly (v0.16.1rc1.dev153)

### ISL=1000, OSL=100

| MC | Before (tok/s) | After (tok/s) | Improvement |
|----|-------|-------|-------------|
| 4 | 479 | 621 | **+30%** |
| 8 | 905 | 931 | **+3%** |
| 16 | 1460 | 1528 | **+5%** |

More benchmark results at higher concurrency levels are being collected.

## Test Plan

- Benchmarked on MI355X instance with `vllm bench serve`
- Full sweep (ISL=1000/10000, OSL=100/1000, MC=4-128) in progress
- Non-gfx950 paths untouched, no regression expected
