### PR TITLE
Revert gemm blockscale kernel config changes causing dpsk-r1 prefill regression

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE-N=2112-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE-N=2112-K=7168.json
@@ -72,15 +72,15 @@
     "NUM_KSPLIT": 4
   },
   "any": {
-    "BLOCK_SIZE_M": 64,
-    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
     "BLOCK_SIZE_K": 128,
     "GROUP_SIZE_M": 1,
-    "num_warps": 1,
+    "num_warps": 2,
     "num_stages": 2,
-    "waves_per_eu": 2,
+    "waves_per_eu": 1,
     "matrix_instr_nonkdim": 16,
     "cache_modifier": null,
-    "NUM_KSPLIT": 4
+    "NUM_KSPLIT": 1
   }
 }

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE-N=7168-K=2048.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE-N=7168-K=2048.json
@@ -48,26 +48,26 @@
     "NUM_KSPLIT": 1
   },
   "M_LEQ_128": {
-      "BLOCK_SIZE_M": 64,
-      "BLOCK_SIZE_N": 32,
-      "BLOCK_SIZE_K": 128,
-      "GROUP_SIZE_M": 4,
-      "num_warps": 2,
-      "num_stages": 2,
-      "waves_per_eu": 1,
-      "matrix_instr_nonkdim": 32,
-      "cache_modifier": null,
-      "NUM_KSPLIT": 1
-  },
-  "any": {
     "BLOCK_SIZE_M": 64,
-    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_N": 32,
     "BLOCK_SIZE_K": 128,
-    "GROUP_SIZE_M": 8,
-    "num_warps": 4,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 2,
     "num_stages": 2,
     "waves_per_eu": 1,
-    "matrix_instr_nonkdim": 16,
+    "matrix_instr_nonkdim": 32,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 32,
     "cache_modifier": null,
     "NUM_KSPLIT": 1
   }


### PR DESCRIPTION
cc @HaiShaw, @inkcherry 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

In [PR#2016](https://github.com/ROCm/aiter/pull/2016), the "any" config section of the following files was modified:
- gfx950-GEMM-A8W8_BLOCKSCALE-N=2112-K=7168.json
- gfx950-GEMM-A8W8_BLOCKSCALE-N=7168-K=2048.json

The change negatively impacts the performance of the dpsk-r1 prefill kernel at longer input lengths (`m`).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Revert the "any" part config changes.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

dpsk-r1-0528 ttft
| Version | 1k | 8k | 70k |
|---|---|---|---|
| v0.1.10.post3 | 65.74 | 264.58 | 2609.32 |
| d4f5e52 | 65.91 | 292.15 | 2919.00 |
| d4f5e52 + PR | 64.74 | 263.49 | 2605.39 |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
