### PR TITLE
Fix batch_prefill dispatch mismatch for sliding window attention models

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -983,6 +983,10 @@ def cmdGenFunc_mha_batch_prefill(
     causal = is_causal
     if max_seqlen_q == 1 and alibi_slopes is None:
         causal = False
+        if window_size_left >= max_seqlen_k:
+            window_size_left = -1
+        if window_size_right >= max_seqlen_k:
+            window_size_right = -1
     md_name = "mha_batch_prefill"
     filter_fwd = "*"  # get_fwd_blobs()
     if q.dtype == torch.float16:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fixes `RuntimeError: invalid argument for batch_prefill` when running sliding window attention models (e.g. Gemma2) through `mha_batch_prefill_func`. https://github.com/sgl-project/sglang/actions/runs/22648816293/job/65643197288#step:5:1140

This PR adds the same window normalization to the Python module selection logic.

## Technical Details
The JIT module selection in `cmdGenFunc_mha_batch_prefill` determines whether to load the `_mask` or `_nmask` module based on `window_size_left/right`. The C++ kernel (`mha_batch_prefill_kernels.cu` L597-604) normalizes `window_size` to `-1` when `>= max_seqlen_k` before determining mask type, but the Python side does not. During early decode (`q_len=1`, `kv_len <= window_size`), this causes Python to load the `_mask` module while C++ computes `no_mask`, resulting in a dispatch failure.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
