### PR TITLE
Fix "BLOCK_SIZE_S3 unrecognized" error caused by config reuse

### DIFF
--- a/aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_split_cat.py
+++ b/aiter/ops/triton/gemm/fused/fused_gemm_afp4wfp4_split_cat.py
@@ -73,6 +73,7 @@ def fused_gemm_afp4wfp4_split_cat(
 
     if config is None:
         config, _ = _get_config(M, N, K)
+    config = dict(config)
 
     c1 = torch.empty((M, D, S1 + S3), dtype=dtype, device=x.device)
     c2 = torch.empty((M, D, S2), dtype=dtype, device=x.device)
@@ -251,6 +252,7 @@ def fused_gemm_afp4wfp4_preshuffle_split_cat(
 
     if config is None:
         config, _ = _get_config(M, N, K, True)
+    config = dict(config)
 
     c1 = torch.empty((M, D, S1 + S3), dtype=dtype, device=x.device)
     c2 = torch.empty((M, D, S2), dtype=dtype, device=x.device)


### PR DESCRIPTION
cc @sogalin 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Both `fused_gemm_afp4wfp4` and the regular `gemm_afp4wfp4` kernel call `get_gemm_config()` using the same config name. Since `get_gemm_config()` is lru_cache-ed, the returned config object is effectively reused and remains fixed across calls.

After calling `fused_gemm_afp4wfp4`, the code adds a "BLOCK_SIZE_S3" attribute into the config by mutating the shared object in place. As a result, the next time `gemm_afp4wfp4` is invoked with the same shape, the cached config now contains this extra field, which causes error.
`Keyword argument BLOCK_SIZE_S3 was specified but unrecognized.`

## Technical Details

When the fused kernel receives the config, it now makes a copy before applying any modifications.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
