### PR TITLE
Adds the ability to build static archives in addition to shared objects 

### DIFF
--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -1720,10 +1720,14 @@ def _write_ninja_file(
     else:
         devlink_rule, devlink = [], []
 
+    aiter_build_static = os.environ.get("AITER_BUILD_STATIC", "0")
     emit_static_archive = (
-        library_target is not None
-        and os.environ.get("AITER_BUILD_STATIC", "0") == "1"
-        and os.path.basename(library_target) in {"libmha_fwd.so", "libmha_bwd.so"}
+        library_target is not None and
+        aiter_build_static != "0" and
+        (
+            aiter_build_static in ("1", "all") or
+            os.path.splitext(library_target)[0] in aiter_build_static.split(",")
+        )
     )
 
     if library_target is not None:

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -1667,7 +1667,7 @@ def _write_ninja_file(
     # Version 1.3 is required for the `deps` directive.
     config = ["ninja_required_version = 1.3"]
     config.append(f"cxx = {compiler}")
-    config.append(f"ar = {os.environ.get('AR', 'ar')}")
+    config.append(f"ar = {os.environ.get('AITER_AR_BIN', 'ar')}")
     if with_cuda or cuda_dlink_post_cflags:
         nvcc = _join_rocm_home("bin", "hipcc")
         config.append(f"nvcc = {nvcc}")
@@ -1720,6 +1720,12 @@ def _write_ninja_file(
     else:
         devlink_rule, devlink = [], []
 
+    emit_static_archive = (
+        library_target is not None
+        and os.environ.get("AITER_BUILD_STATIC", "0") == "1"
+        and os.path.basename(library_target) in {"libmha_fwd.so", "libmha_bwd.so"}
+    )
+
     if library_target is not None:
         link_rule = ["rule link"]
 
@@ -1734,10 +1740,18 @@ def _write_ninja_file(
 
         link = [f'build {library_target}: link {" ".join(objects)}']
 
-        archive_target = os.path.splitext(library_target)[0] + ".a"
-        archive = [f'build {archive_target}: archive {" ".join(objects)}']
+        if emit_static_archive:
+            archive_rule = ["rule archive"]
+            archive_rule.append(
+                "  command = rm -f $out && $ar rcs $out @$out.rsp\n  rspfile = $out.rsp\n  rspfile_content = $in"
+            )
 
-        default = [f"default {library_target}"]
+            archive_target = os.path.splitext(library_target)[0] + ".a"
+            archive = [f'build {archive_target}: archive {" ".join(objects)}']
+            default = [f"default {library_target} {archive_target}"]
+        else:
+            archive_rule, archive = [], []
+            default = [f"default {library_target}"]
     else:
         link_rule, archive_rule, link, archive, default = [], [], [], [], []
 

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -1667,6 +1667,7 @@ def _write_ninja_file(
     # Version 1.3 is required for the `deps` directive.
     config = ["ninja_required_version = 1.3"]
     config.append(f"cxx = {compiler}")
+    config.append(f"ar = {os.environ.get('AR', 'ar')}")
     if with_cuda or cuda_dlink_post_cflags:
         nvcc = _join_rocm_home("bin", "hipcc")
         config.append(f"nvcc = {nvcc}")
@@ -1726,17 +1727,25 @@ def _write_ninja_file(
             "  command = $cxx @$out.rsp $ldflags -o $out\n  rspfile = $out.rsp\n  rspfile_content = $in"
         )
 
+        archive_rule = ["rule archive"]
+        archive_rule.append(
+            "  command = rm -f $out && $ar rcs $out @$out.rsp\n  rspfile = $out.rsp\n  rspfile_content = $in"
+        )
+
         link = [f'build {library_target}: link {" ".join(objects)}']
+
+        archive_target = os.path.splitext(library_target)[0] + ".a"
+        archive = [f'build {archive_target}: archive {" ".join(objects)}']
 
         default = [f"default {library_target}"]
     else:
-        link_rule, link, default = [], [], []
+        link_rule, archive_rule, link, archive, default = [], [], [], [], []
 
     # 'Blocks' should be separated by newlines, for visual benefit.
     blocks = [config, flags, compile_rule]
     if with_cuda:
         blocks.append(cuda_compile_rule)  # type: ignore[possibly-undefined]
-    blocks += [devlink_rule, link_rule, build, devlink, link, default]
+    blocks += [devlink_rule, link_rule, archive_rule, build, devlink, link, archive, default]
     content = "\n\n".join("\n".join(b) for b in blocks)
     # Ninja requires a new lines at the end of the .ninja file
     content += "\n"

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -1732,12 +1732,6 @@ def _write_ninja_file(
         link_rule.append(
             "  command = $cxx @$out.rsp $ldflags -o $out\n  rspfile = $out.rsp\n  rspfile_content = $in"
         )
-
-        archive_rule = ["rule archive"]
-        archive_rule.append(
-            "  command = rm -f $out && $ar rcs $out @$out.rsp\n  rspfile = $out.rsp\n  rspfile_content = $in"
-        )
-
         link = [f'build {library_target}: link {" ".join(objects)}']
 
         if emit_static_archive:
@@ -1767,7 +1761,7 @@ def _write_ninja_file(
         devlink,
         link,
         archive,
-        default
+        default,
     ]
     content = "\n\n".join("\n".join(b) for b in blocks)
     # Ninja requires a new lines at the end of the .ninja file

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -1759,7 +1759,16 @@ def _write_ninja_file(
     blocks = [config, flags, compile_rule]
     if with_cuda:
         blocks.append(cuda_compile_rule)  # type: ignore[possibly-undefined]
-    blocks += [devlink_rule, link_rule, archive_rule, build, devlink, link, archive, default]
+    blocks += [
+        devlink_rule,
+        link_rule,
+        archive_rule,
+        build,
+        devlink,
+        link,
+        archive,
+        default
+    ]
     content = "\n\n".join("\n".join(b) for b in blocks)
     # Ninja requires a new lines at the end of the .ninja file
     content += "\n"


### PR DESCRIPTION
## Motivation

TE currently relies on `libmha_{b, f}wd.so` to provide AITER symbols at runtime, however if other projects (e.g. pytorch) also build the AITER library, but of a different version, then loading the same symbols can create conflict. To avoid this, we at TE would like to be able to generate static archives as part of the build triggered through `aiter/op_tests/cpp/mha/compile.py`.

## Technical Details

Gated by a new environment variable `AITER_BUILD_STATIC`, there is now a new rule inserted which will build `libmha_*wd.a` using `AITER_AR_BIN` (set to `ar` by default). Backwards compatibility is ensured by `AITER_BUILD_STATIC` being defaulted to `0`.

## Test Plan

Run `aiter/op_tests/cpp/mha/compile.py` and validate that the expected artifacts are produced.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
