### PR TITLE
Add option to skip kernel build in op_test build_mha.sh

### DIFF
--- a/op_tests/cpp/mha/build_mha.sh
+++ b/op_tests/cpp/mha/build_mha.sh
@@ -8,8 +8,14 @@ else
     FMA_API=""  # build all
 fi
 
-echo "######## building mha kernel $FMA_API"
-python3 compile.py --api=$FMA_API
+# Skip building the kernels if AITER_TEST_SKIP_BUILD is set to 1
+# and continue onto linking
+if [ x"$AITER_TEST_SKIP_BUILD" = x"1" ]; then
+    echo "######## skipping build of mha kernels $FMA_API"
+else
+    echo "######## building mha kernels $FMA_API"
+    python3 compile.py --api=$FMA_API
+fi
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 TOP_DIR=$(dirname "$SCRIPT_DIR")/../../


### PR DESCRIPTION
## Motivation

Often times we'll use the generated `{f, b}wd.exe` programs to isolate specific kernels and validate TE's AITER integration. In doing so, we usually prefer to use existing pre-built `libmha_{f, b}wd.so` libraries. This addition makes it so we can directly skip building the libraries while still easily building `{f, b}wd.exe`.

## Technical Details

Adds an option to skip running `compile.py` in `build_mha.sh` by setting `AITER_TEST_SKIP_BUILD=1`. It is not set by default, hence this change is backwards compatible.

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
