### PR TITLE
[TEST] Reduce prebuild thread num from 5 to 3 for faster CI builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,7 @@ class NinjaBuildExtension(build_ext):
                         torch_exclude=False,
                     )
 
-                prebuid_thread_num = 5
+                prebuid_thread_num = 3
                 max_jobs = os.environ.get("MAX_JOBS")
                 if max_jobs is not None and max_jobs.isdigit() and int(max_jobs) > 0:
                     prebuid_thread_num = min(prebuid_thread_num, int(max_jobs))


### PR DESCRIPTION
## ⚠️ This is a test PR — do not merge

This PR is an experiment to validate whether reducing `prebuid_thread_num` from 5 to 3 can speed up CI prebuild time.

## Motivation

Analysis of [prebuild job logs](https://github.com/ROCm/aiter/actions/runs/22692076494/job/65790030195) shows:

- Total CPU compile time across all 64 kernels: **180 min**
- Wall clock prebuild time: **41 min** (with max concurrency = 5)
- The critical path is dominated by a few very long kernel builds:
  - `module_moe_ck2stages`: **28.2 min**
  - `module_aiter_operator`: **21.2 min**
  - `module_gemm_a8w8`: **14.7 min**

The prebuild system divides total CPU budget (`max_jobs = 0.8 * cpu_count`) equally among concurrent kernel builds via `PREBUILD_THREAD_NUM`:

```python
# cpp_extension.py: _get_num_workers()
ninja_jobs_per_kernel = max_jobs / PREBUILD_THREAD_NUM
```

With `prebuid_thread_num = 5`, each kernel gets fewer ninja jobs, so the critical-path kernels compile slower. Reducing to 3 gives each kernel **~67% more ninja parallelism**, which should speed up the longest-running kernels and reduce overall wall clock time.

## Expected Impact

| Setting | Ninja jobs/kernel (48-core) | Critical path speed | Short kernel queuing |
|---------|----------------------------|--------------------|--------------------|
| `thread_num=5` (current) | ~7 | baseline | less queuing |
| `thread_num=3` (this PR) | ~12 | **~40% faster** | slightly more queuing |

The net effect should be positive since wall clock is bottlenecked by the longest kernel, not by short kernel throughput.

## Test Plan

Compare the prebuild wall clock time in CI with this change vs the current baseline (~41 min).