### PR TITLE
CI: Pin triton to known-good commit to fix Shard 4/6 test failures

### DIFF
--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -22,8 +22,12 @@ if [[ "$BUILD_TRITON" == "1" ]]; then
     echo
     echo "==== Install triton ===="
     pip uninstall -y triton || true
-    git clone --depth=1 https://github.com/triton-lang/triton || true
+    # Pin triton to a known-good commit to avoid CI breakage from
+    # upstream changes (e.g. AMD codegen regressions in triton-lang/triton).
+    TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
+    git clone https://github.com/triton-lang/triton || true
     cd triton
+    git checkout "$TRITON_COMMIT"
     pip install -r python/requirements.txt
     pip install filecheck
     # NetworkX is a dependency of Triton test selection script


### PR DESCRIPTION
## Motivation

Triton Test CI Shard 4 and Shard 6 have been consistently failing since Mar 4 ([example run](https://github.com/ROCm/aiter/actions/runs/22673604744/job/65727885449)). The root cause is that `build_aiter_triton.sh` builds triton from `HEAD` of `triton-lang/triton` via `git clone --depth=1`, making CI vulnerable to any upstream regression.

Between the last green run (Mar 3) and the first red run (Mar 4), the triton compiler updated from `756afc06` to `9a39c7c6` — a diff of 10 commits that includes several AMD-specific codegen changes:

- `[AMD] Add fence to workaround MachineSink issue (#9624)`
- `[AMD] Fix BlockPingpong for non-MFMA dot (#9618)`
- `[AMD] Fix a crash in SWP (#9631)`
- `[Backend] Bump to llvm/llvm-project@27d654c4c4e6 (#9552)`

These changes caused:
- **Shard 4**: `test_moe_e2e[True-dtype0-False-False-False-16-14336-4096-2-8]` — persistent MoE kernel crash (exit code 1)
- **Shard 6**: `test_mha_backward[False-False-128-1-1-0.0-True-2-1-1]` — GPU hang

Both failures are deterministic and reproduced on different runner machines.

## Technical Details

Pin triton to the last known-good commit (`756afc06`) while still allowing override via the `TRITON_COMMIT` env var for testing newer versions. Removed `--depth=1` from `git clone` so that `git checkout` to a specific commit works.

## Test Plan

- CI Triton Test workflow should pass Shard 4 and Shard 6 with this change
- To test a newer triton version in CI, set `TRITON_COMMIT` env var

## Test Result

Pending CI run with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)