### PR TITLE
mha: make impl_ptr_map caceh in fmha_v3_bwd and fmha_fwd_v3 thread-safe.

### DIFF
--- a/csrc/cpp_itfs/mha_bwd.cu
+++ b/csrc/cpp_itfs/mha_bwd.cu
@@ -442,6 +442,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
             return -1;
         }
     }
+#undef LOCK_IMPL_PTR_MAP
 
     if(a.v3_api_check)
         return 1;

--- a/csrc/cpp_itfs/mha_bwd.cu
+++ b/csrc/cpp_itfs/mha_bwd.cu
@@ -3,6 +3,7 @@
 #include "asm_fmha_v3_bwd_configs.hpp"
 #include <memory>
 #include <string>
+#include <mutex>
 
 namespace aiter {
 std::tuple<int, int> get_padded_hdim(int hdim_q, int hdim_v, std::string arch_id)
@@ -369,7 +370,9 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
     AiterAsmKernel* impl_ptr_pre    = nullptr;
     AiterAsmKernel* impl_ptr_dqdkdv = nullptr;
     AiterAsmKernel* impl_ptr_post   = nullptr;
+    static std::mutex impl_ptr_mutex;
     static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
+#define LOCK_IMPL_PTR_MAP   std::lock_guard<std::mutex> lock(impl_ptr_mutex)
 
     auto it_pre = pre_cfgs->find(pre_kernel);
     if(it_pre != pre_cfgs->end())
@@ -379,6 +382,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         const char* co_name = cfg.co_name.c_str();
         ts_odo              = cfg.ts;
 
+        LOCK_IMPL_PTR_MAP;
         auto result = impl_ptr_map.emplace(name, nullptr);
         if(result.second)
         {
@@ -400,6 +404,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         const char* co_name = cfg.co_name.c_str();
         ts_kv               = cfg.ts;
 
+        LOCK_IMPL_PTR_MAP;
         auto result = impl_ptr_map.emplace(name, nullptr);
         if(result.second)
         {
@@ -423,6 +428,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
             const char* co_name = cfg.co_name.c_str();
             ts_dq               = cfg.ts;
 
+            LOCK_IMPL_PTR_MAP;
             auto result = impl_ptr_map.emplace(name, nullptr);
             if(result.second)
             {

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -5,7 +5,6 @@
 #endif
 #include <memory>
 #include <string>
-#include <mutex>
 
 namespace aiter {
 #if FAV3_ON
@@ -241,23 +240,19 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
     };
 
     AiterAsmKernel* impl_ptr = nullptr;
-    static std::mutex impl_ptr_mutex;
-    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
+    static thread_local std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
         impl_ptr_map;
 
     const auto& cfg     = it->second;
     const char* name    = cfg.knl_name.c_str();
     std::string co_name = get_kernel_co_name(cfg.co_name, arch_id);
 
+    auto result = impl_ptr_map.emplace(name, nullptr);
+    if(result.second)
     {
-      std::lock_guard<std::mutex> lock(impl_ptr_mutex);
-      auto result = impl_ptr_map.emplace(name, nullptr);
-      if(result.second)
-      {
         result.first->second = std::make_unique<AiterAsmKernel>(name, co_name.c_str());
-      }
-      impl_ptr = result.first->second.get();
     }
+    impl_ptr = result.first->second.get();
 
     fmha_fwd_v3_args args;
     size_t arg_size = sizeof(args);

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -5,6 +5,7 @@
 #endif
 #include <memory>
 #include <string>
+#include <mutex>
 
 namespace aiter {
 #if FAV3_ON
@@ -240,19 +241,24 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
     };
 
     AiterAsmKernel* impl_ptr = nullptr;
+    static std::mutex impl_ptr_mutex;
     static thread_local std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
         impl_ptr_map;
+#define LOCK_IMPL_PTR_MAP   std::lock_guard<std::mutex> lock(impl_ptr_mutex)
 
     const auto& cfg     = it->second;
     const char* name    = cfg.knl_name.c_str();
     std::string co_name = get_kernel_co_name(cfg.co_name, arch_id);
 
-    auto result = impl_ptr_map.emplace(name, nullptr);
-    if(result.second)
     {
+      LOCK_IMPL_PTR_MAP;
+      auto result = impl_ptr_map.emplace(name, nullptr);
+      if(result.second)
+      {
         result.first->second = std::make_unique<AiterAsmKernel>(name, co_name.c_str());
+      }
+      impl_ptr = result.first->second.get();
     }
-    impl_ptr = result.first->second.get();
 
     fmha_fwd_v3_args args;
     size_t arg_size = sizeof(args);

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -242,7 +242,7 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
 
     AiterAsmKernel* impl_ptr = nullptr;
     static std::mutex impl_ptr_mutex;
-    static thread_local std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
+    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
         impl_ptr_map;
 #define LOCK_IMPL_PTR_MAP   std::lock_guard<std::mutex> lock(impl_ptr_mutex)
 

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -259,6 +259,7 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
       }
       impl_ptr = result.first->second.get();
     }
+#undef LOCK_IMPL_PTR_MAP
 
     fmha_fwd_v3_args args;
     size_t arg_size = sizeof(args);

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -244,14 +244,13 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
     static std::mutex impl_ptr_mutex;
     static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
         impl_ptr_map;
-#define LOCK_IMPL_PTR_MAP   std::lock_guard<std::mutex> lock(impl_ptr_mutex)
 
     const auto& cfg     = it->second;
     const char* name    = cfg.knl_name.c_str();
     std::string co_name = get_kernel_co_name(cfg.co_name, arch_id);
 
     {
-      LOCK_IMPL_PTR_MAP;
+      std::lock_guard<std::mutex> lock(impl_ptr_mutex);
       auto result = impl_ptr_map.emplace(name, nullptr);
       if(result.second)
       {
@@ -259,7 +258,6 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
       }
       impl_ptr = result.first->second.get();
     }
-#undef LOCK_IMPL_PTR_MAP
 
     fmha_fwd_v3_args args;
     size_t arg_size = sizeof(args);


### PR DESCRIPTION
## Motivation

`fmha_v3_bwd` is not thread-safe due to missing locks in internal cache object.

## Technical Details

The cache object `impl_ptr_map` in `fmha_v3_bwd` and `fmha_fwd_v3` is updated without any locking.

`fmha_fwd_v3` uses `thread_local` to ensures its correctness but defeats the purpose of caching in multi-threading environment.

The PR makes both cache objects shared by all threads and protected by locks properly.

## Test Plan

There is no testing planned at the moment due to difficult to validate if a function is thread-safe with unit tests.

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
