### PR TITLE
CI: Fix welcome comment permission error

### DIFF
--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: pull-requests: write` to `pr-welcome-comment.yaml`
- Fixes 403 `Resource not accessible by integration` error when posting welcome comments on PRs

## Test plan

- [ ] Open a new PR → verify the welcome comment is posted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)