### PR TITLE
Add GEMM-A16W16-ATOMIC-N=256-K=6144 triton gemm tune config

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-ATOMIC-N=256-K=6144.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-ATOMIC-N=256-K=6144.json
@@ -1,0 +1,98 @@
+{
+  "M_LEQ_1": {
+    "BLOCK_SIZE_M": 4,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_4": {
+    "BLOCK_SIZE_M": 4,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 1,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 6,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 16
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 16
+  },
+  "any": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 8
+  }
+}

--- a/aiter/ops/triton/utils/_triton/tunning/ut_a16w16_gemm_atomic.py
+++ b/aiter/ops/triton/utils/_triton/tunning/ut_a16w16_gemm_atomic.py
@@ -1,0 +1,42 @@
+import sys
+from _utils import (
+    run_profile,
+    get_input_shape_and_config_list,
+)
+
+############################################################
+# <import>
+import torch
+import triton
+from aiter.ops.triton.gemm.basic.gemm_a16w16_atomic import gemm_a16w16_atomic
+from op_tests.triton_tests.gemm.basic.test_gemm_a16w16 import (
+    generate_gemm_a16w16_inputs,
+)
+
+############################################################
+
+input_shape, config_list = get_input_shape_and_config_list(sys.argv, shape_size=3)
+
+############################################################
+# <generate input>
+dtype = torch.bfloat16
+x, w, _, _, y = generate_gemm_a16w16_inputs(
+    *input_shape,
+    dtype,
+    output=True,
+)
+############################################################
+
+for config in config_list:
+    if config is not None:
+        config = config.copy()
+        config["SPLITK_BLOCK_SIZE"] = triton.cdiv(input_shape[2], config["NUM_KSPLIT"])
+
+    def fn():
+        ############################################################
+        # <run API>
+        y.zero_()
+        gemm_a16w16_atomic(x, w, dtype, y, config=config)
+        ############################################################
+
+    run_profile(fn)


### PR DESCRIPTION
## Motivation
Optimize GLM-5/GLM-5-FP8 model performance in SGLang.
GLM-5-FP8 Moe gate/router gemm shape is N=256 K=6144 https://huggingface.co/zai-org/GLM-5-FP8/blob/main/config.json#L17
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
1. Add tuning script ut_a16w16_gemm_atomic.py
2. Add tuning config gfx950-GEMM-A16W16-ATOMIC-N=256-K=6144.json
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
# Benchmark with verify-perf.py 
python verify-perf.py 32 256 6144 ut_a16w16_gemm_atomic.py
before:
_gemm_a16_w16_atomic_kernel_BLOCK_SIZE_M_256_BLOCK_SIZE_N_256_BLOCK_SIZE_K_64_GROUP_SIZE_M_4_NUM_KSPLIT_1_SPLITK_BLOCK_SIZE_6144_cache_modifier_NONE_EVEN_K_1_GRID_MN_1
 162.082 (us)

after:
_gemm_a16_w16_atomic_kernel_BLOCK_SIZE_M_16_BLOCK_SIZE_N_16_BLOCK_SIZE_K_256_GROUP_SIZE_M_1_NUM_KSPLIT_16_SPLITK_BLOCK_SIZE_384_cache_modifier_NONE_EVEN_K_0_GRID_MN_32
 4.640 (us)

# SGLang profiling
before:
<img width="691" height="278" alt="Pasted image 20260309104241" src="https://github.com/user-attachments/assets/1dee5b27-1ed5-458b-8507-c008ff86a679" />

after:
<img width="602" height="281" alt="Pasted image 20260309103135" src="https://github.com/user-attachments/assets/3e3a6824-bf8b-4436-955d-3a8a372ef9b0" />

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
