### PR TITLE
[CI] Flash Attention RDNA CI

### DIFF
--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -29,7 +29,6 @@ env:
   # TODO: Switch to Dao-AILab/flash-attention main
   FA_BRANCH: micmelesse/aiter_migration
   FA_REPOSITORY_URL: https://github.com/ROCm/flash-attention.git
-  GPU_ARCH: gfx950
   BASE_IMAGE: rocm/pytorch:latest@sha256:683765a52c61341e1674fe730ab3be861a444a45a36c0a8caae7653a08a0e208
   AITER_SUBMODULE_PATH: third_party/aiter
 
@@ -90,9 +89,17 @@ jobs:
   # =============================================================================
   flash_attention_triton:
     if: ${{ needs.prechecks.outputs.run_triton == 'true' }}
-    name: Flash Attention - Triton (1 GPU)
+    name: Flash Attention - Triton / ${{ matrix.label }} (1 GPU)
     needs: [check-signal, prechecks]
-    runs-on: linux-aiter-mi355-1
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: linux-aiter-mi355-1
+            label: MI355
+          - runner: aiter-gfx1100
+            label: RDNA3
 
     steps:
       - name: Checkout aiter repo
@@ -187,14 +194,14 @@ jobs:
             cd /flash-attention
             FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE \
             python benchmarks/benchmark_flash_attention.py
-          " |& tee benchmark_triton.log
+          " |& tee benchmark_triton_${{ matrix.label }}.log
 
       - name: Upload benchmark results
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: flash-attention-triton-benchmark
-          path: benchmark_triton.log
+          name: flash-attention-triton-benchmark-${{ matrix.label }}
+          path: benchmark_triton_${{ matrix.label }}.log
 
       - name: Clean Up
         if: always()


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The triton backend of flash attention is used on consumer cards (RDNA) in addition to datacenter cards (CDNA). This adds an RDNA CI runner (aiter-gfx1100) to the existing flash_attention_integration workflow via matrix strategy so both architectures are tested in parallel. This is a follow up to https://github.com/ROCm/aiter/pull/1974

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
