### PR TITLE
Fix error checking in aiter_hip_common.h

### DIFF
--- a/csrc/include/aiter_hip_common.h
+++ b/csrc/include/aiter_hip_common.h
@@ -19,55 +19,37 @@
 #include AITER_EMBEDDED_HSA_HEADER
 #endif
 
-enum class GPUArch
-{
-    gfx942,
-    gfx950
-};
-
-#define CHECK_COND(x)                                                                             \
-    do                                                                                            \
-    {                                                                                             \
-        if(!(x))                                                                                  \
-        {                                                                                         \
-            std::cerr << "check failed, file=" << __FILE__ << ", line=" << __LINE__ << std::endl; \
-            std::terminate();                                                                     \
-        }                                                                                         \
-    } while(0)
-
-namespace aiter_detail {
+namespace detail {
 template <typename... Args>
-inline void check_print(std::ostream& os, Args&&... args)
+[[noreturn, noinline]] inline void aiter_check_fatal(const char* file, size_t line, Args&&... args)
 {
-    (os << ... << std::forward<Args>(args));
+    std::cerr << "[AITER] " << file << ":" << line << " ";
+    (std::cerr << ... << std::forward<Args>(args)) << std::endl;
+    std::abort();
 }
-} // namespace aiter_detail
+} // namespace detail
 
-#define AITER_CHECK(x, ...)                                                \
-    do                                                                     \
-    {                                                                      \
-        if(!(x))                                                           \
-        {                                                                  \
-            std::cerr << "[AITER] " << __FILE__ << ":" << __LINE__ << " "; \
-            aiter_detail::check_print(std::cerr, __VA_ARGS__);             \
-            std::cerr << std::endl;                                        \
-            std::terminate();                                              \
-        }                                                                  \
+#define AITER_CHECK(x, ...)                                             \
+    do                                                                  \
+    {                                                                   \
+        if(!(x)) [[unlikely]]                                           \
+        {                                                               \
+            detail::aiter_check_fatal(__FILE__, __LINE__, __VA_ARGS__); \
+        }                                                               \
     } while(0)
 
-#define HIP_CALL(call)                                                       \
-    do                                                                       \
-    {                                                                        \
-        hipError_t err = call;                                               \
-        if(err != hipSuccess)                                                \
-        {                                                                    \
-            printf("\n[AITER] %s:%d fail to call %s ---> [HIP error](%s)\n", \
-                   __FILE__,                                                 \
-                   __LINE__,                                                 \
-                   #call,                                                    \
-                   hipGetErrorString(err));                                  \
-            exit(0);                                                         \
-        }                                                                    \
+#define HIP_CALL(call)                                                            \
+    do                                                                            \
+    {                                                                             \
+        hipError_t err = call;                                                    \
+        if(err != hipSuccess) [[unlikely]]                                        \
+        {                                                                         \
+            detail::aiter_check_fatal(__FILE__,                                   \
+                                      __LINE__,                                   \
+                                      "fail to call " #call " ---> [HIP error](", \
+                                      hipGetErrorString(err),                     \
+                                      ')');                                       \
+        }                                                                         \
     } while(0)
 
 struct p3
@@ -119,8 +101,8 @@ inline void load_asm_kernel(const char* name,
 #if defined(AITER_EMBEDDED_HSA_HEADER) && defined(AITER_EMBEDDED_HSA_MAP)
         std::string fname = "hsa/" + arch_name + "/" + hsaco;
         auto hasco_obj    = AITER_EMBEDDED_HSA_MAP.find(fname);
-        CHECK_COND(hasco_obj != AITER_EMBEDDED_HSA_MAP.end());
-        CHECK_COND(hasco_obj->second.data() != nullptr);
+        AITER_CHECK(hasco_obj != AITER_EMBEDDED_HSA_MAP.end(), "hasco_obj not found");
+        AITER_CHECK(hasco_obj->second.data() != nullptr, "hasco_obj is nullptr");
         AITER_LOG_INFO("hipModuleLoad: " << fname << " GetFunction: " << name);
         HIP_CALL(hipModuleLoadData(&module, hasco_obj->second.data()));
 #endif


### PR DESCRIPTION
## Motivation

HIP_CALL is using exit(0) thus hiding issues in the CI

## Technical Details

Use std::abort

## Test Plan

Check CI

## Test Result

TBD

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
