### PR TITLE
fix crash on import if git is missing

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -29,7 +29,7 @@ def get_git_commit_id_short():
             .strip()
         )
         return commit_id
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return None
 
 


### PR DESCRIPTION
If the `git` binary is missing, `FileNotFoundError` is raised in place of `subprocess.CalledProcessError`, causing a crash on import.
