### PR TITLE
[WIP] Enable fp8 attention for triton unified attention

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
@@ -154,6 +154,7 @@ def kernel_unified_attention_2d(
         other=0.0,
         cache_modifier=Q_cache_modifier,
     )
+    Q = Q.to(tl.float8e4nv)
 
     block_table_offset = seq_idx * block_table_stride
 
@@ -485,6 +486,7 @@ def kernel_unified_attention_3d(
         mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
         other=0.0,
     )
+    Q = Q.to(tl.float8e4nv)
 
     block_table_offset = seq_idx * block_table_stride
 


### PR DESCRIPTION
## Motivation
Triton unified attention already has the capability for doing fp8 compute, especially when using fp8 KV-cache. 
However, due to the limitation of Q's precision, the attention is often computed in fp16 even when kv-cache is in fp8. The fp16 route is computational inefficient as it involves two upcasting steps for K and V and computing attention in fp16, instead of fp8. 

## Technical Details
In this PR, we plan to enable fp8 unified attention when all of the below are checked
1. KV-cache is in fp8
2. ENABLE_FP8_UNIFIED_ATTENTION is true (env variable)

When both conditions are met, we down cast Q during the load step, which gives the best perf.  


## Test Plan
- [ ] Performance benchmarks run
- [ ] Accuracy run
- [ ] Tested on MI350X

## Test Result


## Submission Checklist