### PR TITLE
Add timeout to test steps in CI

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -272,18 +272,19 @@ jobs:
           bash -c "pip show amd-aiter || true"
       
       - name: Tests
+        timeout-minutes: 60
         run: |
           set -ex
           if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
             docker exec \
             -w /workspace \
             aiter_test \
-            bash -c "MAX_JOBS=20 SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh" 
+            bash -c "MAX_JOBS=20 SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh"
           else
             docker exec \
             -w /workspace \
             aiter_test \
-            bash -c "SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh" 
+            bash -c "SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh"
           fi
 
       - name: Collect test logs
@@ -416,6 +417,7 @@ jobs:
           bash -c "pip show amd-aiter || true"
 
       - name: Tests
+        timeout-minutes: 60
         run: |
           set -ex
           docker exec \


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 60` to Standard Tests (1 GPU) test step
- Add `timeout-minutes: 60` to Multi-GPU Tests (8 GPU) test step
- Prevents jobs from hanging indefinitely when tests get stuck

## Test plan
- [ ] Verify CI jobs respect the 60-minute timeout
- [ ] Verify normal test runs complete within the timeout