### PR TITLE
[COMMS] Fused allreduce, residual add, rms, quant, gemm

### DIFF
--- a/aiter/ops/triton/comms/fused_allreduce_add_rms_quant_gemm.py
+++ b/aiter/ops/triton/comms/fused_allreduce_add_rms_quant_gemm.py
@@ -1,0 +1,694 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+"""
+Fused AllReduce + RMSNorm + FP8 Quant + Scaled GEMM for ROCm.
+
+Combines allreduce + residual add + rmsnorm + FP8 per-row quant into a single
+Triton kernel launch using iris symmetric heap, followed by hipBLASLt GEMM
+via torch._scaled_mm.
+
+2D-tiled variant: processes BLOCK_SIZE_M rows at a time (default 1).
+RMSNorm requires a full-row reduction. Since BLOCK_SIZE_N covers the
+entire row, tl.sum(..., axis=1) gives the correct per-row variance.
+
+After the Triton kernel completes:
+  - quant_heap: (M, N) FP8 matrix on symmetric heap (all rows, all ranks)
+  - scale_heap: (M,) per-row float32 scales on symmetric heap
+  - result_out: (M, N) BF16 allreduced values (only owned rows)
+
+Then torch._scaled_mm is called for the GEMM via hipBLASLt.
+
+CUDA graph compatibility:
+- Buffer pre-allocation with view pattern
+- device_barrier() before and after kernel
+- Caller must capture on a dedicated stream (not the default stream)
+
+Also provides a reference (NCCL) implementation for correctness testing.
+"""
+
+import logging
+from typing import Any, Literal, Optional, Tuple
+
+import iris
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+from torch.distributed import ProcessGroup
+
+__all__ = ["fused_allreduce_add_rms_quant_gemm"]
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Utilities
+# ============================================================================
+
+
+def _compute_chunk_size(comm_sms: int, num_xcds: int, swizzle_size: int = 4) -> int:
+    chunk = swizzle_size * swizzle_size
+    return min(chunk, comm_sms // num_xcds)
+
+
+# ============================================================================
+# Fused two-shot AllReduce + RMSNorm + per-row FP8 Quant kernel (2D tiling)
+# ============================================================================
+
+
+@triton.jit
+def persistent_fused_allreduce_rmsnorm_2d_quant_two_shot(
+    # Symmetric heap buffers
+    input_ptr,
+    quant_heap_ptr,
+    scale_heap_ptr,
+    # Regular GPU memory
+    result_out_ptr,
+    # Residual (regular GPU memory; dummy ptr when HAS_RESIDUAL=False)
+    residual_in_ptr,
+    # RMSNorm weight
+    rms_weight_ptr,
+    # Scalar params
+    rms_eps,
+    fp8_max,
+    # Dimensions
+    M,
+    N,
+    # Input strides
+    stride_in_m,
+    stride_in_n,
+    # Quant heap strides
+    stride_qh_m,
+    stride_qh_n,
+    # Result out strides
+    stride_out_m,
+    stride_out_n,
+    # Residual strides
+    stride_res_m,
+    stride_res_n,
+    # Scale heap stride
+    stride_sh,
+    # Iris params
+    heap_bases: tl.tensor,
+    group_rank: tl.constexpr,
+    iris_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    rank_start: tl.constexpr,
+    rank_stride: tl.constexpr,
+    # Tile params
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    ACTUAL_N: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    PADDED_N: tl.constexpr,
+    COMM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    DISTRIBUTION: tl.constexpr,
+):
+    """Two-shot fused AllReduce + RMSNorm + per-row FP8 quant (2D).
+
+    Each rank reduces its assigned tiles, applies RMSNorm + per-row FP8
+    quant, then broadcasts the FP8 result and scales to all peers.
+    Barriers are external (called by the manager before/after kernel).
+    """
+    pid = tl.program_id(0)
+
+    # Row distribution across ranks
+    rows_per_rank = tl.cdiv(M, world_size)
+    if DISTRIBUTION == 0:
+        my_start = group_rank
+        stride = world_size
+        remaining = M - my_start
+        remaining = tl.maximum(remaining, 0)
+        max_row_offset = tl.cdiv(remaining, stride)
+    else:
+        my_start = group_rank * rows_per_rank
+        stride = 1
+        remaining = M - my_start
+        remaining = tl.maximum(remaining, 0)
+        max_row_offset = tl.minimum(rows_per_rank, remaining)
+
+    # Number of tile iterations (each tile covers BLOCK_SIZE_M rows)
+    num_tiles = tl.cdiv(max_row_offset, BLOCK_SIZE_M)
+
+    # Load RMSNorm weights
+    rn = tl.arange(0, BLOCK_SIZE_N)
+    if PADDED_N:
+        rms_w = tl.load(rms_weight_ptr + rn, mask=rn < ACTUAL_N, other=0.0).to(
+            tl.float32
+        )
+    else:
+        rms_w = tl.load(rms_weight_ptr + rn).to(tl.float32)
+
+    # Persistent traversal over this rank's assigned tiles
+    for tile_offset in range(pid, num_tiles, COMM_SMS):
+        row_base = my_start + tile_offset * BLOCK_SIZE_M * stride
+
+        # Build 2D indices
+        rm = row_base + tl.arange(0, BLOCK_SIZE_M) * stride
+        row_mask = rm < M
+
+        input_offset = rm[:, None] * stride_in_m + rn[None, :] * stride_in_n
+        qh_offset = rm[:, None] * stride_qh_m + rn[None, :] * stride_qh_n
+        out_offset = rm[:, None] * stride_out_m + rn[None, :] * stride_out_n
+        res_offset = rm[:, None] * stride_res_m + rn[None, :] * stride_res_n
+        scale_offset = rm * stride_sh
+
+        is_full = row_base + BLOCK_SIZE_M * stride <= M
+
+        if PADDED_N:
+            col_mask = rn < ACTUAL_N
+            mask = row_mask[:, None] & col_mask[None, :]
+        else:
+            mask = row_mask[:, None]
+
+        if is_full and not PADDED_N:
+            # ---- Fast path: no masks ----
+            acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for i in tl.static_range(0, world_size):
+                remote_rank = rank_start + i * rank_stride
+                partial = iris.load(
+                    input_ptr + input_offset,
+                    iris_rank,
+                    remote_rank,
+                    heap_bases,
+                )
+                acc += partial.to(tl.float32)
+                if HAS_RESIDUAL and remote_rank == iris_rank:
+                    res_in = tl.load(residual_in_ptr + res_offset).to(tl.float32)
+                    acc += res_in
+
+            if HAS_RESIDUAL:
+                tl.store(
+                    result_out_ptr + out_offset,
+                    acc.to(result_out_ptr.type.element_ty),
+                )
+
+            sq_sum = tl.sum(acc * acc, axis=1)
+            rrms = tl.rsqrt(sq_sum / N + rms_eps)
+            normed = acc * rrms[:, None] * rms_w[None, :]
+
+            row_amax = tl.max(tl.abs(normed), axis=1)
+            row_amax = tl.maximum(row_amax, 1e-12)
+            scale = row_amax / fp8_max
+
+            quantized = normed / scale[:, None]
+            quantized = tl.maximum(tl.minimum(quantized, fp8_max), -fp8_max)
+            quantized = quantized.to(quant_heap_ptr.type.element_ty)
+
+            tl.store(quant_heap_ptr + qh_offset, quantized)
+            tl.store(scale_heap_ptr + scale_offset, scale)
+
+            for i in tl.static_range(0, world_size):
+                remote_rank = rank_start + i * rank_stride
+                if remote_rank != iris_rank:
+                    iris.store(
+                        quant_heap_ptr + qh_offset,
+                        quantized,
+                        iris_rank,
+                        remote_rank,
+                        heap_bases,
+                    )
+                    iris.store(
+                        scale_heap_ptr + scale_offset,
+                        scale,
+                        iris_rank,
+                        remote_rank,
+                        heap_bases,
+                    )
+                    if HAS_RESIDUAL:
+                        iris.store(
+                            result_out_ptr + out_offset,
+                            acc.to(result_out_ptr.type.element_ty),
+                            iris_rank,
+                            remote_rank,
+                            heap_bases,
+                        )
+        else:
+            # ---- Slow path: masked (boundary tiles or padded N) ----
+            acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for i in tl.static_range(0, world_size):
+                remote_rank = rank_start + i * rank_stride
+                partial = iris.load(
+                    input_ptr + input_offset,
+                    iris_rank,
+                    remote_rank,
+                    heap_bases,
+                    mask=mask,
+                )
+                acc += partial.to(tl.float32)
+                if HAS_RESIDUAL and remote_rank == iris_rank:
+                    res_in = tl.load(
+                        residual_in_ptr + res_offset, mask=mask, other=0.0
+                    ).to(tl.float32)
+                    acc += res_in
+
+            if HAS_RESIDUAL:
+                tl.store(
+                    result_out_ptr + out_offset,
+                    acc.to(result_out_ptr.type.element_ty),
+                    mask=mask,
+                )
+
+            sq_sum = tl.sum(acc * acc, axis=1)
+            rrms = tl.rsqrt(sq_sum / N + rms_eps)
+            normed = acc * rrms[:, None] * rms_w[None, :]
+
+            row_amax = tl.max(tl.abs(normed), axis=1)
+            row_amax = tl.maximum(row_amax, 1e-12)
+            scale = row_amax / fp8_max
+
+            quantized = normed / scale[:, None]
+            quantized = tl.maximum(tl.minimum(quantized, fp8_max), -fp8_max)
+            quantized = quantized.to(quant_heap_ptr.type.element_ty)
+
+            tl.store(quant_heap_ptr + qh_offset, quantized, mask=mask)
+            tl.store(scale_heap_ptr + scale_offset, scale, mask=row_mask)
+
+            for i in tl.static_range(0, world_size):
+                remote_rank = rank_start + i * rank_stride
+                if remote_rank != iris_rank:
+                    iris.store(
+                        quant_heap_ptr + qh_offset,
+                        quantized,
+                        iris_rank,
+                        remote_rank,
+                        heap_bases,
+                        mask=mask,
+                    )
+                    iris.store(
+                        scale_heap_ptr + scale_offset,
+                        scale,
+                        iris_rank,
+                        remote_rank,
+                        heap_bases,
+                        mask=row_mask,
+                    )
+                    if HAS_RESIDUAL:
+                        iris.store(
+                            result_out_ptr + out_offset,
+                            acc.to(result_out_ptr.type.element_ty),
+                            iris_rank,
+                            remote_rank,
+                            heap_bases,
+                            mask=mask,
+                        )
+
+    # Post-kernel barrier is external (called by the manager).
+
+
+# ============================================================================
+# Manager and public API
+# ============================================================================
+
+
+class _AllReduceManager:
+    """Singleton manager for fused AllReduce+RMSNorm+per-row Quant + hipBLASLt GEMM.
+
+    Manages symmetric heap buffers (input, quant, scale, result_out).
+    GEMM is delegated to torch._scaled_mm.
+    """
+
+    _instance: Optional["_AllReduceManager"] = None
+    _initialized: bool = False
+
+    def __new__(cls) -> "_AllReduceManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self) -> None:
+        if _AllReduceManager._initialized:
+            return
+        _AllReduceManager._initialized = True
+
+        self._shmem: Any = None
+        self._heap_size: int = 2**33  # 8GB default
+
+        # Symmetric heap buffers
+        self._input_buf: Any = None
+        self._input_M: int = 0
+        self._input_N: int = 0
+        self._input_dtype: Optional[torch.dtype] = None
+
+        self._quant_heap_buf: Any = None
+        self._quant_heap_M: int = 0
+        self._quant_heap_N: int = 0
+        self._quant_heap_dtype: Optional[torch.dtype] = None
+
+        self._scale_heap_buf: Any = None
+        self._scale_heap_M: int = 0
+
+        # Result heap buffer (residual output, on heap for broadcast)
+        self._out_result: Optional[torch.Tensor] = None
+        self._out_result_M: int = 0
+        self._out_result_N: int = 0
+        self._out_result_dtype: Optional[torch.dtype] = None
+
+    def initialize(self, heap_size: Optional[int] = None) -> None:
+        """Initialize Iris symmetric heap (call once at startup)."""
+        if self._shmem is not None:
+            logger.debug("Iris (fused allreduce) already initialized, skipping")
+            return
+
+        if heap_size is not None:
+            self._heap_size = heap_size
+
+        cur_rank = (
+            torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        )
+        self._shmem = iris.iris(self._heap_size)
+
+        logger.info(
+            f"Iris (fused allreduce) initialized: "
+            f"rank={cur_rank}, heap_size={self._heap_size / 2**30:.1f}GB"
+        )
+
+    @property
+    def shmem(self) -> Any:
+        if self._shmem is None:
+            self.initialize()
+        return self._shmem
+
+    def _ensure_heap_buffers(
+        self,
+        M: int,
+        N: int,
+        input_dtype: torch.dtype,
+        quant_dtype: torch.dtype,
+    ) -> Tuple[Any, Any, Any, Any]:
+        """Allocate or reuse symmetric heap buffers.
+
+        All buffers live on the iris symmetric heap so the kernel can
+        broadcast them to all peers via iris.store.
+
+        Returns (input_buf, quant_heap, scale_heap, result_out).
+        """
+        need_input = (
+            self._input_buf is None
+            or M > self._input_M
+            or N != self._input_N
+            or input_dtype != self._input_dtype
+        )
+        need_quant = (
+            self._quant_heap_buf is None
+            or M > self._quant_heap_M
+            or N != self._quant_heap_N
+            or quant_dtype != self._quant_heap_dtype
+        )
+        need_scale = self._scale_heap_buf is None or M > self._scale_heap_M
+        need_result = (
+            self._out_result is None
+            or M > self._out_result_M
+            or N != self._out_result_N
+            or input_dtype != self._out_result_dtype
+        )
+
+        if not (need_input or need_quant or need_scale or need_result):
+            return (
+                self._input_buf[:M],
+                self._quant_heap_buf[:M],
+                self._scale_heap_buf[:M],
+                self._out_result[:M],
+            )
+
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"Iris (fused allreduce): heap buffers too small for "
+                f"M={M}. Cannot allocate during CUDA graph capture."
+            )
+
+        shmem = self.shmem
+
+        if need_input:
+            self._input_buf = shmem.zeros((M, N), dtype=input_dtype)
+            self._input_M = M
+            self._input_N = N
+            self._input_dtype = input_dtype
+
+        if need_quant:
+            self._quant_heap_buf = shmem.zeros((M, N), dtype=quant_dtype)
+            self._quant_heap_M = M
+            self._quant_heap_N = N
+            self._quant_heap_dtype = quant_dtype
+
+        if need_scale:
+            self._scale_heap_buf = shmem.zeros((M,), dtype=torch.float32)
+            self._scale_heap_M = M
+
+        if need_result:
+            self._out_result = shmem.zeros((M, N), dtype=input_dtype)
+            self._out_result_M = M
+            self._out_result_N = N
+            self._out_result_dtype = input_dtype
+
+        return (
+            self._input_buf[:M],
+            self._quant_heap_buf[:M],
+            self._scale_heap_buf[:M],
+            self._out_result[:M],
+        )
+
+    def run(
+        self,
+        input_tensor: torch.Tensor,
+        rms_weight: torch.Tensor,
+        rms_eps: float,
+        quant_dtype: torch.dtype,
+        gemm_weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        out_dtype: torch.dtype,
+        residual: Optional[torch.Tensor] = None,
+        bias: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Two-shot AllReduce + RMSNorm + per-row FP8 quant + hipBLASLt GEMM.
+
+        Returns (gemm_out, residual_out). residual_out is None when
+        residual is None.
+        """
+        shmem = self.shmem
+        M, N = input_tensor.shape
+
+        # Allocate heap buffers
+        iris_input, quant_heap, scale_heap, result_out = self._ensure_heap_buffers(
+            M, N, input_tensor.dtype, quant_dtype
+        )
+
+        # Copy input to symmetric heap (captured in graph)
+        iris_input.copy_(input_tensor)
+
+        # Pre-kernel barrier
+        shmem.device_barrier()
+
+        # FP8 max value
+        fp8_max = torch.finfo(quant_dtype).max
+
+        # Iris group info
+        rank_global = shmem.get_rank()
+        rank_in_group = rank_global
+        world_size = shmem.get_num_ranks()
+        rank_start = 0
+        rank_stride = 1
+        heap_bases = shmem.get_heap_bases()
+
+        # ---- Tunable parameters ----
+        num_xcds = iris.hip.get_num_xcc()
+        BLOCK_SIZE_M = 1
+        BLOCK_SIZE_N = triton.next_power_of_2(N)
+        ACTUAL_N = N
+        PADDED_N = BLOCK_SIZE_N != N
+        DISTRIBUTION = 1  # 0=striding, 1=block
+        COMM_SMS = 128
+        CHUNK_SIZE = _compute_chunk_size(COMM_SMS, num_xcds)
+        NUM_WARPS = 16
+        NUM_STAGES = 2
+        WAVES_PER_EU = 1
+        # ---- End tunable parameters ----
+
+        # Launch kernel
+        persistent_fused_allreduce_rmsnorm_2d_quant_two_shot[(COMM_SMS,)](
+            iris_input,
+            quant_heap,
+            scale_heap,
+            result_out,
+            # Residual
+            residual if residual is not None else input_tensor,
+            # RMSNorm
+            rms_weight,
+            rms_eps,
+            fp8_max,
+            # Dimensions
+            M,
+            N,
+            # Strides
+            iris_input.stride(0),
+            iris_input.stride(1),
+            quant_heap.stride(0),
+            quant_heap.stride(1),
+            result_out.stride(0),
+            result_out.stride(1),
+            residual.stride(0) if residual is not None else input_tensor.stride(0),
+            residual.stride(1) if residual is not None else input_tensor.stride(1),
+            scale_heap.stride(0),
+            # Iris
+            heap_bases,
+            rank_in_group,
+            rank_global,
+            world_size,
+            rank_start,
+            rank_stride,
+            # Tile params
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            ACTUAL_N,
+            residual is not None,  # HAS_RESIDUAL
+            PADDED_N,
+            COMM_SMS,
+            num_xcds,
+            CHUNK_SIZE,
+            DISTRIBUTION,
+            num_warps=NUM_WARPS,
+            num_stages=NUM_STAGES,
+            waves_per_eu=WAVES_PER_EU,
+        )
+
+        # Post-kernel barrier
+        shmem.device_barrier()
+
+        # hipBLASLt GEMM
+        K_GEMM = gemm_weight.shape[1]
+        scale_b = weight_scale.reshape(1, 1).expand(1, K_GEMM).contiguous()
+        gemm_out = torch._scaled_mm(
+            quant_heap,
+            gemm_weight,
+            out_dtype=out_dtype,
+            scale_a=scale_heap.unsqueeze(1),
+            scale_b=scale_b,
+            bias=bias,
+        )
+
+        residual_out = result_out if residual is not None else None
+
+        return gemm_out, residual_out
+
+
+_manager: Optional[_AllReduceManager] = None
+
+
+def _get_manager() -> _AllReduceManager:
+    global _manager
+    if _manager is None:
+        _manager = _AllReduceManager()
+    return _manager
+
+
+def fused_allreduce_add_rms_quant_gemm(
+    input: torch.Tensor,
+    rms_weight: torch.Tensor,
+    rms_eps: float,
+    quant_dtype: torch.dtype,
+    group_name: str,
+    gemm_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out_dtype: torch.dtype,
+    residual: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    impl: Literal["iris", "ref"] = "iris",
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """AllReduce + RMSNorm + per-row FP8 Quant + hipBLASLt GEMM.
+
+    Args:
+        impl: "iris" (default) uses iris symmetric heap for GPU-initiated
+            allreduce. "ref" uses NCCL allreduce + standard PyTorch ops.
+
+    Returns (gemm_out, residual_out). residual_out is None when residual
+    is None.
+    """
+    if impl == "iris":
+        return _get_manager().run(
+            input,
+            rms_weight,
+            rms_eps,
+            quant_dtype,
+            gemm_weight,
+            weight_scale,
+            out_dtype,
+            residual,
+            bias,
+        )
+    else:
+        return _run_ref(
+            input,
+            rms_weight,
+            rms_eps,
+            quant_dtype,
+            group_name,
+            gemm_weight,
+            weight_scale,
+            out_dtype,
+            residual=residual,
+            bias=bias,
+        )
+
+
+# ============================================================================
+# Reference implementation (NCCL baseline for correctness testing)
+# ============================================================================
+
+
+def _run_ref(
+    input: torch.Tensor,
+    rms_weight: torch.Tensor,
+    rms_eps: float,
+    quant_dtype: torch.dtype,
+    group_name: str,
+    gemm_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out_dtype: torch.dtype,
+    group: Optional[ProcessGroup] = None,
+    residual: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """NCCL AllReduce + Add + RMSNorm + FP8 Quant + hipBLASLt GEMM.
+
+    Reference implementation using standard PyTorch ops. No iris or custom
+    kernels. Useful for correctness testing against the fused variant.
+
+    Returns (gemm_out, residual_out). residual_out is None when residual
+    is None.
+    """
+    # Step 1: All-reduce in fp32 (matches fused kernel which accumulates in fp32)
+    allreduce_out = input.to(torch.float32)
+    dist.all_reduce(allreduce_out, group=group)
+
+    # Step 2: Optional residual add + RMSNorm (all in fp32)
+    if residual is not None:
+        residual_out = (allreduce_out + residual.to(torch.float32)).to(input.dtype)
+        rms_input_f32 = residual_out.to(torch.float32)
+    else:
+        residual_out = None
+        rms_input_f32 = allreduce_out
+    variance = rms_input_f32.pow(2).mean(dim=-1, keepdim=True)
+    rms_input_normed = rms_input_f32 * torch.rsqrt(variance + rms_eps)
+    rms_out_f32 = rms_input_normed * rms_weight.to(torch.float32)
+
+    # Step 3: Per-row FP8 quantization (matches fused kernel: fp32 → FP8)
+    fp8_max = torch.finfo(quant_dtype).max
+    row_amax = rms_out_f32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)
+    quant_scale_out = (row_amax / fp8_max).to(torch.float32)
+    quant_out = (rms_out_f32 / quant_scale_out).clamp(-fp8_max, fp8_max).to(quant_dtype)
+
+    # Step 4: hipBLASLt GEMM via torch._scaled_mm
+    K_GEMM = gemm_weight.shape[1]
+    scale_b = weight_scale.reshape(1, 1).expand(1, K_GEMM).contiguous()
+    gemm_out = torch._scaled_mm(
+        quant_out,
+        gemm_weight,
+        out_dtype=out_dtype,
+        scale_a=quant_scale_out,
+        scale_b=scale_b,
+        bias=bias,
+    )
+
+    return gemm_out, residual_out

--- a/op_tests/multigpu_tests/triton_test/bench_fused_allreduce_add_rms_quant_gemm.py
+++ b/op_tests/multigpu_tests/triton_test/bench_fused_allreduce_add_rms_quant_gemm.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Benchmark: fused allreduce+rmsnorm+quant+gemm vs unfused (NCCL) baseline.
+
+Both variants run in the same mode (eager or graph) for fair comparison.
+
+Usage:
+    torchrun --nproc_per_node=8 bench_fused_allreduce_add_rms_quant_gemm.py
+    torchrun --nproc_per_node=8 bench_fused_allreduce_add_rms_quant_gemm.py \
+        --mode graph --num-tokens 4 512 1024
+"""
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Callable, Literal, Optional
+
+import torch
+import torch.distributed as dist
+
+from aiter.dist.parallel_state import (
+    graph_capture as aiter_graph_capture,
+    init_distributed_environment,
+    ensure_model_parallel_initialized,
+    set_custom_all_reduce,
+)
+from aiter.ops.triton.comms.fused_allreduce_add_rms_quant_gemm import (
+    fused_allreduce_add_rms_quant_gemm,
+)
+from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
+
+FP8_DTYPE = get_fp8_e4m3_dtype()
+
+
+@dataclass
+class Variant:
+    name: str
+    impl: Literal["iris", "ref"]
+    is_baseline: bool = False
+
+    def make_fn(
+        self,
+        num_tokens: int,
+        hidden_dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> Callable[[], None]:
+        input_tensor = torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device)
+        residual = torch.randn_like(input_tensor)
+        rms_weight = torch.ones(hidden_dim, dtype=dtype, device=device)
+        gemm_weight = (
+            torch.rand(
+                hidden_dim,
+                hidden_dim,
+                dtype=torch.float32,
+                device=device,
+            )
+            .to(FP8_DTYPE)
+            .contiguous()
+            .t()
+        )
+        weight_scale = torch.tensor(
+            1.0,
+            dtype=torch.float32,
+            device=device,
+        ).unsqueeze(0)
+        impl = self.impl
+
+        def run():
+            fused_allreduce_add_rms_quant_gemm(
+                input_tensor,
+                rms_weight,
+                1e-6,
+                FP8_DTYPE,
+                "",
+                gemm_weight,
+                weight_scale,
+                dtype,
+                residual=residual,
+                impl=impl,
+            )
+
+        return run
+
+
+VARIANTS: dict[str, Variant] = {
+    "unfused": Variant(name="unfused", impl="ref", is_baseline=True),
+    "fused": Variant(name="fused", impl="iris"),
+}
+
+
+def warmup(fn: Callable[[], None], iterations: int) -> None:
+    for _ in range(iterations):
+        fn()
+        torch.cuda.synchronize()
+
+
+def benchmark_eager(fn: Callable[[], None], trials: int) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    times: list[float] = []
+
+    for _ in range(trials):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times.sort()
+    mid = len(times) // 2
+    return times[mid] if len(times) % 2 else (times[mid - 1] + times[mid]) / 2
+
+
+def benchmark_graph(
+    graph: torch.cuda.CUDAGraph, trials: int, stream: torch.cuda.Stream
+) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    times: list[float] = []
+
+    for _ in range(trials):
+        with torch.cuda.stream(stream):
+            start.record()
+            graph.replay()
+            end.record()
+        stream.synchronize()
+        times.append(start.elapsed_time(end))
+
+    times.sort()
+    mid = len(times) // 2
+    return times[mid] if len(times) % 2 else (times[mid - 1] + times[mid]) / 2
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark fused allreduce+rmsnorm+quant+gemm vs unfused"
+    )
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        nargs="+",
+        default=[4, 1024],
+    )
+    parser.add_argument("--hidden-dim", type=int, default=8192)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--trials", type=int, default=10)
+    parser.add_argument(
+        "--mode",
+        choices=["eager", "graph"],
+        default="graph",
+    )
+    parser.add_argument(
+        "--variant",
+        choices=["all", "unfused", "fused"],
+        default="all",
+    )
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default=None,
+        metavar="DIR",
+        help="Enable torch.profiler and write chrome traces to DIR.",
+    )
+    args = parser.parse_args()
+
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        raise RuntimeError(
+            "Must run with torchrun. Example: "
+            "torchrun --nproc_per_node=8 bench_fused_allreduce_add_rms_quant_gemm.py"
+        )
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    torch.set_default_device(device)
+
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        distributed_init_method="env://",
+    )
+    ensure_model_parallel_initialized(world_size, 1)
+
+    if world_size <= 1:
+        raise ValueError(f"World size must be > 1. Got world_size={world_size}.")
+
+    # Select variants
+    variants: list[Variant] = (
+        list(VARIANTS.values()) if args.variant == "all" else [VARIANTS[args.variant]]
+    )
+
+    # Build run functions and warmup
+    run_fns: dict[int, dict[str, Callable]] = {}
+    for num_tokens in args.num_tokens:
+        run_fns[num_tokens] = {}
+        for v in variants:
+            fn = v.make_fn(num_tokens, args.hidden_dim, torch.bfloat16, device)
+            run_fns[num_tokens][v.name] = fn
+            warmup(fn, args.warmup)
+            if rank == 0:
+                print(f"Warmup complete: {v.name}, tokens={num_tokens}")
+
+    # Capture graphs if graph mode
+    graphs: dict[int, dict[str, torch.cuda.CUDAGraph]] = {}
+    capture_stream: Optional[torch.cuda.Stream] = None
+    if args.mode == "graph":
+        with aiter_graph_capture() as gc:
+            capture_stream = gc.stream
+            for num_tokens in args.num_tokens:
+                graphs[num_tokens] = {}
+                for v in variants:
+                    graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(graph, stream=capture_stream):
+                        run_fns[num_tokens][v.name]()
+                    capture_stream.synchronize()
+                    graphs[num_tokens][v.name] = graph
+                    if rank == 0:
+                        print(f"Captured graph: {v.name}, tokens={num_tokens}")
+
+    # Timed runs
+    all_timings: dict[int, dict[str, float]] = {}
+    for num_tokens in args.num_tokens:
+        timings: dict[str, float] = {}
+        for v in variants:
+            if args.profile is not None:
+                prof = torch.profiler.profile(
+                    activities=[
+                        torch.profiler.ProfilerActivity.CPU,
+                        torch.profiler.ProfilerActivity.CUDA,
+                    ],
+                    record_shapes=True,
+                    with_stack=True,
+                )
+                prof.start()
+
+            if args.mode == "graph":
+                assert capture_stream is not None
+                timings[v.name] = benchmark_graph(
+                    graphs[num_tokens][v.name], args.trials, capture_stream
+                )
+            else:
+                timings[v.name] = benchmark_eager(
+                    run_fns[num_tokens][v.name], args.trials
+                )
+
+            if args.profile is not None:
+                prof.stop()
+                if rank == 0:
+                    print(f"\n--- Profile: {v.name}, tokens={num_tokens} ---")
+                    print(
+                        prof.key_averages().table(
+                            sort_by="self_cuda_time_total",
+                            row_limit=30,
+                        )
+                    )
+                trace_dir = os.path.join(args.profile, f"{v.name}_M{num_tokens}")
+                os.makedirs(trace_dir, exist_ok=True)
+                prof.export_chrome_trace(
+                    os.path.join(trace_dir, f"trace_rank{rank}.json")
+                )
+
+        all_timings[num_tokens] = timings
+
+    # Print results (rank 0 only)
+    if rank == 0:
+        baseline_variants = [v for v in variants if v.is_baseline]
+        baseline = baseline_variants[0].name if baseline_variants else None
+
+        print(f"\n{'=' * 70}")
+        print(f"Benchmark: {' vs '.join(v.name for v in variants)}  mode={args.mode}")
+        print(
+            f"world_size={world_size}  hidden_dim={args.hidden_dim}  "
+            f"dtype=bf16  warmup={args.warmup}  trials={args.trials}"
+        )
+        print(f"{'=' * 70}")
+
+        col_headers = ["Tokens"]
+        for v in variants:
+            col_headers.append(f"{v.name} (ms)")
+            if baseline and v.name != baseline:
+                col_headers.append("Speedup")
+        print("  ".join(f"{h:>15s}" for h in col_headers))
+        print("-" * (17 * len(col_headers)))
+
+        for num_tokens in args.num_tokens:
+            timings = all_timings[num_tokens]
+            cols = [f"{num_tokens:>15d}"]
+            baseline_ms = timings.get(baseline) if baseline else None
+            for v in variants:
+                t = timings[v.name]
+                cols.append(f"{t:>15.3f}")
+                if baseline and v.name != baseline:
+                    if baseline_ms and t > 0:
+                        cols.append(f"{baseline_ms / t:>14.2f}x")
+                    else:
+                        cols.append(f"{'N/A':>15s}")
+            print("".join(cols))
+        print()
+
+    dist.barrier()
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/multigpu_tests/triton_test/test_fused_allreduce_add_rms_quant_gemm.py
+++ b/op_tests/multigpu_tests/triton_test/test_fused_allreduce_add_rms_quant_gemm.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Test fused allreduce + rmsnorm + FP8 quant + scaled GEMM.
+
+Compares the fused (iris) implementation against the reference (NCCL)
+implementation for correctness in both eager and CUDA graph modes.
+
+Usage:
+    pytest test_fused_allreduce_add_rms_quant_gemm.py -v -s
+    pytest test_fused_allreduce_add_rms_quant_gemm.py -k "graph and M4"
+"""
+
+import logging
+import multiprocessing as mp
+import os
+import socket
+import sys
+import traceback
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from aiter.test_common import checkAllclose, ensure_spawn_method
+from aiter.ops.triton.comms.fused_allreduce_add_rms_quant_gemm import (
+    fused_allreduce_add_rms_quant_gemm,
+)
+from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
+
+logger = logging.getLogger("aiter")
+
+FP8_DTYPE = get_fp8_e4m3_dtype()
+
+
+def _find_free_port():
+    """Find a free TCP port by binding to port 0."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _run_on_gpu(
+    tp_size, gpu_id, M, N, dtype, use_residual, impl, graph, num_runs, input_type
+):
+    """Run one variant on one GPU.
+
+    The worker is impl-agnostic: `impl` is passed straight through to
+    `fused_allreduce_add_rms_quant_gemm`.
+
+    Returns list of (gemm_cpu, res_cpu) tuples of length `num_runs`.
+    """
+    try:
+        device = torch.device(f"cuda:{gpu_id}")
+        torch.cuda.set_device(device)
+        torch.set_default_device(device)
+
+        from aiter.dist.parallel_state import (
+            init_distributed_environment,
+            ensure_model_parallel_initialized,
+            set_custom_all_reduce,
+        )
+
+        set_custom_all_reduce(True)
+        init_distributed_environment(
+            world_size=tp_size,
+            rank=gpu_id,
+            distributed_init_method="env://",
+        )
+        ensure_model_parallel_initialized(tp_size, 1)
+
+        # Weights (same seed on all GPUs)
+        torch.manual_seed(42)
+        rms_weight = torch.ones(N, dtype=dtype, device=device)
+        gemm_weight = (
+            torch.rand(
+                N,
+                N,
+                dtype=torch.float32,
+                device=device,
+            )
+            .to(FP8_DTYPE)
+            .contiguous()
+            .t()
+        )
+        weight_scale = torch.tensor(
+            1.0,
+            dtype=torch.float32,
+            device=device,
+        ).unsqueeze(0)
+
+        def make_input(input_seed, residual_seed):
+            if input_type == "ones":
+                inp = torch.ones(M, N, dtype=dtype, device=device)
+                res = (
+                    torch.ones(M, N, dtype=dtype, device=device)
+                    if use_residual
+                    else None
+                )
+            else:
+                torch.manual_seed(input_seed)
+                inp = torch.randn(M, N, dtype=dtype, device=device)
+                res = None
+                if use_residual:
+                    # Residual must be the same on all ranks (matches
+                    # vLLM contract: residual = hidden_states from
+                    # before the TP layer, identical post-allreduce).
+                    torch.manual_seed(residual_seed)
+                    res = torch.randn(M, N, dtype=dtype, device=device)
+            return inp, res
+
+        def run(inp, res):
+            g, r = fused_allreduce_add_rms_quant_gemm(
+                inp,
+                rms_weight,
+                1e-6,
+                FP8_DTYPE,
+                "",
+                gemm_weight,
+                weight_scale,
+                dtype,
+                residual=res,
+                impl=impl,
+            )
+            torch.cuda.synchronize()
+            return g.cpu(), r.cpu() if r is not None else None
+
+        def input_seed_i(i):
+            return 1000 + gpu_id * num_runs + i
+
+        def residual_seed_i(i):
+            return 5000 + i  # same on all GPUs
+
+        if not graph:
+            results = []
+            for i in range(num_runs):
+                inp, res = make_input(input_seed_i(i), residual_seed_i(i))
+                gemm, res_out = run(inp, res)
+                results.append((gemm, res_out))
+            return results
+
+        # Graph mode: warmup + capture on a dedicated stream
+        capture_stream = torch.cuda.Stream()
+
+        with torch.cuda.stream(capture_stream):
+            for wi in range(3):
+                inp, res = make_input(200 + gpu_id, 5200)
+                run(inp, res)
+        capture_stream.synchronize()
+
+        # Capture
+        input_cap, res_cap = make_input(300 + gpu_id, 5300)
+        cuda_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(cuda_graph, stream=capture_stream):
+            cap_gemm, cap_res = fused_allreduce_add_rms_quant_gemm(
+                input_cap,
+                rms_weight,
+                1e-6,
+                FP8_DTYPE,
+                "",
+                gemm_weight,
+                weight_scale,
+                dtype,
+                residual=res_cap,
+            )
+
+        # Replay
+        results = []
+        for i in range(num_runs):
+            inp, res = make_input(input_seed_i(i), residual_seed_i(i))
+
+            with torch.cuda.stream(capture_stream):
+                input_cap.copy_(inp)
+                if res_cap is not None and res is not None:
+                    res_cap.copy_(res)
+                cuda_graph.replay()
+            capture_stream.synchronize()
+
+            gemm = cap_gemm.clone().cpu()
+            res_out = cap_res.clone().cpu() if cap_res is not None else None
+            results.append((gemm, res_out))
+
+        return results
+
+    except Exception as e:
+        logger.error(
+            f"\n-->[Error on GPU {gpu_id}]: {str(e)}\n"
+            f"-->[Traceback]: {''.join(traceback.format_exception(*sys.exc_info()))}"
+        )
+        raise
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _run_pool(
+    tp_size, impl, M, N, dtype, use_residual, graph, num_runs, input_type, port
+):
+    """Launch one variant across all GPUs via mp.Pool."""
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    ensure_spawn_method()
+
+    pool = mp.Pool(processes=tp_size)
+    async_results = []
+    for i in range(tp_size):
+        async_results.append(
+            pool.apply_async(
+                _run_on_gpu,
+                args=(
+                    tp_size,
+                    i,
+                    M,
+                    N,
+                    dtype,
+                    use_residual,
+                    impl,
+                    graph,
+                    num_runs,
+                    input_type,
+                ),
+            )
+        )
+    pool.close()
+    pool.join()
+    return [r.get() for r in async_results]
+
+
+@pytest.mark.parametrize("use_residual", [False, True])
+@pytest.mark.parametrize("N", [8192])
+@pytest.mark.parametrize("M", [1, 4, 32, 128, 512, 576, 1024])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("mode", ["eager", "graph"])
+@pytest.mark.parametrize("tp_size", [8])
+@pytest.mark.parametrize("graph_replays", [5])
+@pytest.mark.parametrize("input_type", ["rand"])
+def test_correctness(
+    M, N, dtype, use_residual, mode, tp_size, graph_replays, input_type
+):
+    """Compare fused (iris) vs ref (NCCL) for correctness.
+
+    Each variant runs in its own process pool to avoid contamination.
+
+    In eager mode, runs both variants once with the same input.
+    In graph mode, iris captures a CUDA graph and replays multiple times.
+    Ref always runs eagerly. Both use deterministic inputs so results
+    match. Graph mode verifies barrier epochs advance correctly across
+    repeated replays.
+    """
+    if torch.cuda.device_count() < tp_size:
+        pytest.skip(f"Need {tp_size} GPUs, only {torch.cuda.device_count()} available")
+    graph = mode == "graph"
+    num_runs = graph_replays if graph else 1
+
+    # Ref always runs eager (NCCL can't be graph-captured)
+    ref_results = _run_pool(
+        tp_size,
+        "ref",
+        M,
+        N,
+        dtype,
+        use_residual,
+        graph=False,
+        num_runs=num_runs,
+        input_type=input_type,
+        port=_find_free_port(),
+    )
+    iris_results = _run_pool(
+        tp_size,
+        "iris",
+        M,
+        N,
+        dtype,
+        use_residual,
+        graph=graph,
+        num_runs=num_runs,
+        input_type=input_type,
+        port=_find_free_port(),
+    )
+    failures = []
+    for gpu_id in range(tp_size):
+        ref_gpu = ref_results[gpu_id]
+        iris_gpu = iris_results[gpu_id]
+        assert len(ref_gpu) == len(iris_gpu)
+
+        for check_i, ((ref_gemm, ref_res), (fused_gemm, fused_res)) in enumerate(
+            zip(ref_gpu, iris_gpu)
+        ):
+            tag = f"replay {check_i}" if graph else "eager"
+
+            # Check residual first (isolates allreduce correctness)
+            if use_residual:
+                msg = f"GPU {gpu_id}, {tag}: Residual, M={M}, N={N}"
+                err = checkAllclose(
+                    ref_res,
+                    fused_res,
+                    msg=msg,
+                    atol=1e-3,
+                    rtol=1e-3,
+                )
+                if err != 0:
+                    failures.append(msg)
+
+            msg = (
+                f"GPU {gpu_id}, {tag}: GEMM, " f"M={M}, N={N}, residual={use_residual}"
+            )
+            err = checkAllclose(
+                ref_gemm,
+                fused_gemm,
+                msg=msg,
+                atol=6,
+                rtol=1e-1,
+            )
+            if err != 0:
+                failures.append(msg)
+
+    assert not failures, f"{len(failures)} checks failed:\n" + "\n".join(failures)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/requirements-triton-comms.txt
+++ b/requirements-triton-comms.txt
@@ -1,5 +1,4 @@
 # Optional dependencies for Triton-based GPU communication
 # Iris library for GPU-initiated communication primitives
-# Pinned to commit 905ec1c (Nov 18, 2024) for reproducibility and API stability
-iris @ git+https://github.com/ROCm/iris.git@905ec1cea8f350211a70c7d0b2bc11a09a6f6429
+iris @ git+https://github.com/ROCm/iris.git@eaacbab5f6aa405ab7944fd0b15152dfb8efc1fe
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This pr adds a fused Triton kernel that combines allreduce + residual add + rmsnorm + FP8 per-row quant into a single kernel launch, followed by a `torch._scaled_mm` call. Uses iris symmetric heap for GPU-initiated communication. Includes standalone correctness test and benchmark script. This pr requires the `device_barrier` pr in iris. Future work will look at fusing the gemm into the kernel.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
