### PR TITLE
CI: Upload wheel to S3 in CI test workflow

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -132,7 +132,7 @@ jobs:
           echo "Successfully prepared image: rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}"
 
       - name: Extract wheel from image
-        if: ${{ github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           set -ex
           IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
@@ -145,21 +145,21 @@ jobs:
           ls -lh dist/*.whl
 
       - name: Upload wheel as artifact
-        if: ${{ github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v4
         with:
           name: aiter-whl-main-${{ github.run_id }}
           path: dist/*.whl
 
       - name: Configure AWS credentials
-        if: ${{ github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'ROCm' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::661452401056:role/framework-aiter-nightlies
 
       - name: Install AWS CLI
-        if: ${{ github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'ROCm' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           if ! command -v aws &> /dev/null; then
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -169,7 +169,7 @@ jobs:
           fi
 
       - name: Upload wheels to S3
-        if: ${{ github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'ROCm' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           for WHL in dist/*.whl; do
             WHL_NAME=$(basename ${WHL})


### PR DESCRIPTION
## Summary
- Build wheel from the pre-built Docker image and upload to S3 (`framework-whls-nightlies`) in the `build_aiter_image` job
- Also uploads wheel as GitHub artifact for traceability
- Uses OIDC-based AWS credential (same pattern as aiter-release.yaml)

> Note: `refs/heads/main` condition is temporarily removed to test the S3 upload flow in this PR. Will be re-added before merging.