### PR TITLE
disable v_fmac_f32 in add_rmsnorm_quant_kernel for sglang fp16 ci test()

### DIFF
--- a/csrc/kernels/rmsnorm_quant_kernels.cu
+++ b/csrc/kernels/rmsnorm_quant_kernels.cu
@@ -132,8 +132,8 @@ __global__ void add_rmsnorm_quant_kernel(
             float square_sum = 0.0f;
             for(int i = 0; i < thread_data_size; i++)
             {
-                asm volatile("v_fmac_f32_e32 %0, %1, %1" : "+v"(square_sum) : "v"(thread_data_float[i]));
-                // square_sum += (thread_data_float[i] * thread_data_float[i]);
+                // asm volatile("v_fmac_f32_e32 %0, %1, %1" : "+v"(square_sum) : "v"(thread_data_float[i]));
+                square_sum += (thread_data_float[i] * thread_data_float[i]);
             }
             
             auto sum_f = [](float a, float b) { return a + b; };


### PR DESCRIPTION
## Motivation
For this issue https://github.com/ROCm/aiter/issues/2236
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
