### PR TITLE
CI: Fix multi-gpu tests running only one shard instead of all tests

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -33,8 +33,9 @@ skip_tests=(
 )
 
 # When AITER_TEST is set, files are already the exact list for this shard (from artifact).
+# Multi-GPU tests should always run all files without sharding.
 # Otherwise, apply modulo to split "all files" into shards by index.
-if [[ -n "${AITER_TEST:-}" ]]; then
+if [[ -n "${AITER_TEST:-}" ]] || [[ "$MULTIGPU" == "TRUE" ]]; then
     sharded_files=("${files[@]}")
 else
     sharded_files=()


### PR DESCRIPTION
## Summary

- Multi-GPU tests were unintentionally sharded (defaulting to shard 0 of 5), causing only a subset of tests to run
- Root cause: `aiter_test.sh` defaults `SHARD_TOTAL=5` and `SHARD_IDX=0`, and the multi-GPU workflow does not set these variables or `AITER_TEST`, so the modulo-based sharding logic was applied to multi-GPU tests
- Fix: skip sharding when `MULTIGPU=TRUE`, ensuring all multi-GPU test files are always executed

## Test plan

- [ ] Verify multi-GPU CI jobs run all test files under `op_tests/multigpu_tests/` without sharding
- [ ] Verify standard (1-GPU) sharded tests are unaffected