### PR TITLE
Added HSA header flag passthrough to `compile.py`

### DIFF
--- a/op_tests/cpp/mha/compile.py
+++ b/op_tests/cpp/mha/compile.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import argparse
+from pathlib import Path
 
 # !!!!!!!!!!!!!!!! never import aiter
 # from aiter.jit import core
@@ -13,8 +14,26 @@ from jit.core import compile_ops, CK_DIR, AITER_CSRC_DIR, AITER_META_DIR  # noqa
 FWD_CODEGEN_CMD = [f"{AITER_META_DIR}/hsa/codegen.py -m fmha_v3_fwd --output_dir {{}}"]
 BWD_CODEGEN_CMD = [f"{AITER_META_DIR}/hsa/codegen.py -m fmha_v3_bwd --output_dir {{}}"]
 
+def get_embedded_hsa_build_args():
+    """Optional embedded-HSA config passed from the outer build via env vars."""
+    header_path_var = os.getenv("AITER_EMBEDDED_HSA_HEADER_PATH", "").strip()
+    flags_extra_cc = []
+
+    # If header is provided, then make sure that include_dir is also provided,
+    # otherwise the embedded HSA header won't be found during compilation.
+    if header_path_var:
+        header_path = Path(header_path_var)
+        # aiter_hip_common.h uses: #include AITER_EMBEDDED_HSA_HEADER
+        # so the macro value must be a quoted header token.
+        flags_extra_cc.append(f'-DAITER_EMBEDDED_HSA_HEADER=\\"{header_path.name}\\"')
+
+        # Keep optCompilerConfig's default include list intact by passing include dir
+        # as a compile flag instead of overriding `extra_include` in custom args.
+        flags_extra_cc.append(f"-I{header_path.parent}")
+    return flags_extra_cc
 
 def cmdGenFunc_mha_fwd(ck_exclude: bool):
+    flags_extra_cc = get_embedded_hsa_build_args()
     if ck_exclude:
         srcs = [f"{AITER_CSRC_DIR}/cpp_itfs/mha_fwd.cu"]
         blob_gen_cmd = []
@@ -35,7 +54,7 @@ def cmdGenFunc_mha_fwd(ck_exclude: bool):
         "srcs": srcs,
         "md_name": "libmha_fwd",
         "blob_gen_cmd": blob_gen_cmd,
-        "flags_extra_cc": [flag_use_v3],
+        "flags_extra_cc": [flag_use_v3] + flags_extra_cc,
     }
 
 
@@ -56,6 +75,7 @@ def cmdGenFunc_mha_bwd(ck_exclude: bool):
         ]
     blob_gen_cmd.extend(BWD_CODEGEN_CMD)
     flags_extra_cc = ["-DONLY_FAV3"] if ck_exclude else []
+    flags_extra_cc += get_embedded_hsa_build_args()
     return {
         "md_name": "libmha_bwd",
         "blob_gen_cmd": blob_gen_cmd,

--- a/op_tests/cpp/mha/compile.py
+++ b/op_tests/cpp/mha/compile.py
@@ -19,8 +19,8 @@ def get_embedded_hsa_build_args():
     header_path_var = os.getenv("AITER_EMBEDDED_HSA_HEADER_PATH", "").strip()
     flags_extra_cc = []
 
-    # If header is provided, then make sure that include_dir is also provided,
-    # otherwise the embedded HSA header won't be found during compilation.
+    # If a header path is provided, derive its directory and pass it via -I so
+    # the embedded HSA header can be found during compilation (no separate include_dir).
     if header_path_var:
         header_path = Path(header_path_var)
         # aiter_hip_common.h uses: #include AITER_EMBEDDED_HSA_HEADER

--- a/op_tests/cpp/mha/compile.py
+++ b/op_tests/cpp/mha/compile.py
@@ -29,7 +29,7 @@ def get_embedded_hsa_build_args():
 
         # Keep optCompilerConfig's default include list intact by passing include dir
         # as a compile flag instead of overriding `extra_include` in custom args.
-        flags_extra_cc.append(f"-I{header_path.parent}")
+        flags_extra_cc.append(f'-I"{header_path.parent}"')
     return flags_extra_cc
 
 def cmdGenFunc_mha_fwd(ck_exclude: bool):


### PR DESCRIPTION
## Motivation

TE relies on `aiter/op_tests/cpp/mha/compile.py` to generate `libmha_*wd.so`. These libraries are used in multi-threaded contexts, whereas their reliance on the `AITER_ASM_DIR` environment variable is thread-unsafe. To mitigate this, we would like to use the embedded HSA header option, but that requires some minor modifications to `compile.py`.

## Technical Details

- Adds the ability to parse an `AITER_EMBEDDED_HSA_HEADER_PATH` environment variable to generate necessary flags for utilizing AITER's HSA embedded header strategy.

## Test Plan

Test with TE build.

## Test Result

Unable to test on exact commit yet, since TE is still pending updates to newer compatible versions of AITER, however these changes work on older commits of AITER on TE branches.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
