### PR TITLE
bwd v3 remove ck dependency

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -992,7 +992,8 @@
             "f'{AITER_CSRC_DIR}/pybind/mha_bwd_asm_pybind.cu'"
         ],
         "flags_extra_cc": [
-            "'-DONLY_FAV3=1'"
+            "'-DONLY_FAV3=1'",
+            "'-DDISABLE_CK=1'"
         ],
         "flags_extra_hip": [],
         "extra_ldflags": "None",
@@ -1010,7 +1011,8 @@
             "f'{AITER_CSRC_DIR}/pybind/mha_varlen_bwd_asm_pybind.cu'"
         ],
         "flags_extra_cc": [
-            "'-DONLY_FAV3=1'"
+            "'-DONLY_FAV3=1'",
+            "'-DDISABLE_CK=1'"
         ],
         "flags_extra_hip": [],
         "extra_ldflags": "None",

--- a/csrc/cpp_itfs/mha_bwd.cu
+++ b/csrc/cpp_itfs/mha_bwd.cu
@@ -531,7 +531,7 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
 
     if(mt == 3)
     {
-#if ONLY_FAV3
+#if DISABLE_CK
         bool is_top_left = (a.mask_type == static_cast<int>(mask_enum::mask_top_left) ||
                             a.mask_type == static_cast<int>(mask_enum::window_generic));
         auto [mask_y, mask_x] = compute_mask_coordinates(

--- a/csrc/include/aiter_hip_common.h
+++ b/csrc/include/aiter_hip_common.h
@@ -2,7 +2,7 @@
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
 #include "aiter_logger.h"
-#if ONLY_FAV3
+#if DISABLE_CK
 #include "ck_tile_shim.h"
 #else
 #include "ck_tile/core.hpp"

--- a/csrc/include/ck_tile_shim.h
+++ b/csrc/include/ck_tile_shim.h
@@ -3,7 +3,7 @@
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Minimal shim providing ck_tile:: types and FMHA enums/structs when
-// compiling without the full Composable Kernel dependency (ONLY_FAV3==1).
+// compiling without the full Composable Kernel dependency (DISABLE_CK==1).
 
 #include <hip/hip_runtime.h>
 #include <cstdint>

--- a/csrc/include/mha_bwd.h
+++ b/csrc/include/mha_bwd.h
@@ -5,7 +5,7 @@
 // Include these 2 headers instead of torch/extension.h since we don't need all of the torch
 // headers.
 #include "aiter_hip_common.h"
-#if !ONLY_FAV3
+#if !DISABLE_CK
 #include "fmha_bwd.hpp"
 #endif
 #include <variant>

--- a/csrc/include/py_itfs_common.h
+++ b/csrc/include/py_itfs_common.h
@@ -44,7 +44,7 @@ const constexpr auto torch_fp4x2  = torch::kUInt8;
 #endif
 
 // clang-format off
-#if !ONLY_FAV3
+#if !DISABLE_CK
 template <typename T> struct t2ck;
 template <> struct t2ck<float> { using type = ck_tile::fp32_t; };
 template <> struct t2ck<c10::Half> { using type = ck_tile::fp16_t; };


### PR DESCRIPTION
## Motivation

Remove the Composable Kernel (CK) dependency from the FMHA backward pass library when building with ONLY_FAV3=1. The V3 ASM kernels are self-contained .co binaries that don't need CK at compile time, but the build previously required CK headers (fmha_bwd.hpp, ck_tile/core.hpp, mask.hpp, etc.) even when only the ASM path was used. This decouples the V3 backward build from CK, enabling faster builds and removing the hard dependency on the CK submodule for ASM-only configurations.

## Technical Details

New file: csrc/include/ck_tile_shim.h Minimal shim providing ck_tile:: types (stream_config, index_t, long_index_t, log2e_v, get_warp_size, launch_kernel) for compilation without CK. 

csrc/include/aiter_hip_common.h Conditional include: #if ONLY_FAV3 includes ck_tile_shim.h, otherwise includes ck_tile/core.hpp. Safe for all other modules since #if ONLY_FAV3 evaluates to 0 when the macro is undefined.

csrc/include/mha_bwd.h Guarded #include "fmha_bwd.hpp" with #if !ONLY_FAV3 to skip the heavy CK FMHA headers when building V3-only.

csrc/cpp_itfs/mha_bwd.cu

Defined local mask_enum and compute_mask_coordinates() under #if ONLY_FAV3 to replace CK's mask_enum (from mask.hpp) and ck_tile::make_generic_attention_mask_coordinates_from_lr_window().
The SWA mask coordinate computation block is dual-pathed: #if ONLY_FAV3 uses the local function, #else uses the original CK function.
The CK fallback path in mha_bwd() (fmha_bwd(traits, ck_args, s)) remains guarded by the existing #if ONLY_FAV3 / #else block -- no change needed there.
aiter/jit/optCompilerConfig.json For module_fmha_v3_bwd and module_fmha_v3_varlen_bwd:

Removed extra_include: [CK_DIR/example/ck_tile/01_fmha]
Removed flags_extra_hip: ['-DCK_TILE_FMHA_FWD_FAST_EXP2=1']
Kept flags_extra_cc: ['-DONLY_FAV3=1'] and blob_gen_cmd (ASM codegen, not CK-related).
op_tests/cpp/mha/build_mha.sh Updated bwd_v3 benchmark linking: the benchmark binary (bwd.exe) still uses CK include paths for its reference computation (CK is only removed from the library, not the test harness).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
