### PR TITLE
Capture git errors in case git doesn't exist

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -29,7 +29,7 @@ def get_git_commit_id_short():
             .strip()
         )
         return commit_id
-    except subprocess.CalledProcessError:
+    except:
         return None
 
 


### PR DESCRIPTION
When git doesn't exist (e.g. in some bare-minimum containers), subprocess throws a different error not captured by `subprocess.CalledProcessError`. Change to `except:` to catch all.