### PR TITLE
[TRITON] Update config of MHA PE forward kernel on `gfx950`

### DIFF
--- a/aiter/ops/triton/configs/gfx950-MHA-DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950-MHA-DEFAULT.json
@@ -19,11 +19,11 @@
       "num_stages": 1
     },
     "pe": {
-      "BLOCK_M": 256,
-      "BLOCK_N": 64,
+      "BLOCK_M": 128,
+      "BLOCK_N": 32,
       "PRELOAD_V": true,
       "waves_per_eu": 2,
-      "num_warps": 8,
+      "num_warps": 4,
       "num_ctas": 1,
       "num_stages": 3
     },


### PR DESCRIPTION
## Motivation

This PR updates MHA PE forward kernel config for `gfx950` architecture. This kernel is used in prefill workload of DeepSeek models. It's a suggestion from @scxiao, that retuned the kernel a couple of days ago. The new config improves performance.

## Technical Details

### Current Config vs. Proposed Config

| Parameter      | Current | Proposed |
|----------------|--------:|---------:|
| `BLOCK_M`      |     256 |      128 |
| `BLOCK_N`      |      64 |       32 |
| `PRELOAD_V`    |    true |     true |
| `waves_per_eu` |       2 |        2 |
| `num_warps`    |       8 |        4 |
| `num_ctas`     |       1 |        1 |
| `num_stages`   |       3 |        3 |

### Benchmarking Procedure

The attention bench script `op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_attn_models.py` was used to evaluate performance impact of the new config. The script was executed 10 times for each kernel config as follows:

```bash
for i in $(seq 0 9); do
    python op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_attn_models.py \
        --max-cache 100 \
        -k fwd -m 'DeepSeek-R1 \(Prefill\)' \
        -o "run_${i}.csv"
done
```

As called, the script measured the kernel performance (in milliseconds) for the following attention use cases:

* Forward kernel
* DeepSeek-R1 (Prefill) - MHA with PE: HQ = HKV = 128, DQK = 128 + 64 = 192, DV = 128
* Tensor Parallelism (TP): 1, 2, 4, 8 (split attention heads)
* Batch Size (B): from 1 to 8, by increments of 1
* Sequence Length (S): from 1K (1024) to 8K (8192) tokens, by increments of 1K tokens
* Layout: BSHD, THD
* Causal attention
* `bf16` data type

It's a total of 512 combinations.

### Speedup Computation

`current_ms` is defined as the average kernel execution time, in milliseconds, for the current kernel config. Since we have 10 time samples for each kernel, it's the average of these 10 samples. Analogously, `new_ms` is defined as the average kernel execution time, in milliseconds, for the proposed config. Speedup was computed as `speedup = current_ms / new_ms`, values greater than one mean the new config is faster, values less than one mean it is slower.

A speedup threshold `eps = 0.01` (1%) is used so small noise is not treated as a real change:

* Significant regression: speedup less than 1 − *eps* = 0.99 (new config meaningfully slower)
* Significant improvement: speedup greater than 1 + *eps* = 1.01 (new config meaningfully faster)

### Performance Improvement

The new config improved performance of all 512 attention use cases, as show by the violin plot:

<img width="390" height="396" alt="image" src="https://github.com/user-attachments/assets/50e43c3e-465b-4119-8ffa-51dc047166ac" />

* Speedup statistics min=1.176, q1=1.287, median=1.341, q3=1.401, max=1.983
* +34.108% median improvement

## Test Plan

MHA PE unit tests:

```bash
pytest op_tests/triton_tests/attention/test_mha.py -k with_pe
```

## Test Result

Tests pass on `gfx950` and `gfx942`. ✅

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
