### PR TITLE
optimize the fa fwd and bwd kernels

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -8,6 +8,7 @@ from .utils import (
     AUTOTUNE,
     is_fp8,
     get_arch,
+    remap_xcd,
 )
 
 PREPROCESS_AUTOTUNE_KEYS = [
@@ -291,6 +292,30 @@ def get_bwd_configs(autotune: bool):
                     num_stages=1,
                     num_warps=4,
                 ),
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 256,
+                        "BLOCK_M2": 256,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 1,
+                    },
+                    num_stages=2,
+                    num_warps=8,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 256,
+                        "BLOCK_M2": 256,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=2,
+                    num_warps=8,
+                ),
             ]
             causal_configs = [
                 triton.Config(
@@ -315,6 +340,30 @@ def get_bwd_configs(autotune: bool):
                         "waves_per_eu": 1,
                     },
                     num_stages=1,
+                    num_warps=4,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 128,
+                        "BLOCK_M2": 128,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 1,
+                    },
+                    num_stages=2,
+                    num_warps=4,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 128,
+                        "BLOCK_M2": 128,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=2,
                     num_warps=4,
                 ),
             ]
@@ -2974,8 +3023,8 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
     stride_descale_v_z,
     stride_az,
     stride_ah,
-    HQ,
-    HK,
+    HQ: tl.constexpr,
+    HK: tl.constexpr,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -3008,11 +3057,16 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
     USE_SEQUSED: tl.constexpr,  # Add flag for seqused
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
+    NUM_XCD: tl.constexpr = 1,
 ):
     # program ids
     hkid = tl.program_id(0)
     pid = tl.program_id(1)
     bid = tl.program_id(2)
+
+    # apply the xcd remapping for the hq dim
+    hkid = remap_xcd(hkid, HK, NUM_XCD)
+
     if DEBUG_TRITON:
         print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")  # noqa: E701
     # figure out varlen start and end
@@ -3049,7 +3103,6 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
     offs_d_qk = tl.arange(0, HEAD_DIM_QK)
     offs_d_v = tl.arange(0, HEAD_DIM_V)
     GROUP_SIZE: tl.constexpr = HQ // HK
-
     # align the delta_qk
     start_n = pid * BLOCK_N1
     if start_n < seqlen_k:
@@ -3553,8 +3606,8 @@ def bwd_kernel_fused_noncausal(
     stride_descale_v_z,
     stride_az,
     stride_ah,
-    HQ,
-    HK,
+    HQ: tl.constexpr,
+    HK: tl.constexpr,
     cu_seqlens_q,
     cu_seqlens_k,
     seqused_q,
@@ -3587,11 +3640,16 @@ def bwd_kernel_fused_noncausal(
     USE_SEQUSED: tl.constexpr,  # Add flag for seqused
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
+    NUM_XCD: tl.constexpr = 1,
 ):
     # program ids
     hkid = tl.program_id(0)
     pid = tl.program_id(1)
     bid = tl.program_id(2)
+
+    # apply the xcd remapping for the hq dim
+    hkid = remap_xcd(hkid, HK, NUM_XCD)
+
     if DEBUG_TRITON:
         print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")  # noqa: E701
     # figure out varlen start and end
@@ -4280,14 +4338,18 @@ def attention_backward_triton_impl(
     if mode == "fused":
         seqlen = max(max_seqlen_q, max_seqlen_k)
 
+        arch = get_arch()
+        num_xcd = 1 if arch.is_rdna else 8
+
         def grid(META):
             return (
                 nheads_k,
-                (seqlen + META["BLOCK_N1"] - 1) // META["BLOCK_N1"],
+                ((seqlen + META["BLOCK_N1"] - 1) // META["BLOCK_N1"]),
                 batch,
             )
 
         if causal:
+
             if DEBUG_TRITON:
                 print(f"bwd_kernel: grid = {grid}")  # noqa: E701
             bwd_kernel_fused_causal[grid](
@@ -4375,6 +4437,7 @@ def attention_backward_triton_impl(
                 ),  # Add flag for seqused
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
+                NUM_XCD=num_xcd,
             )
         else:
             bwd_kernel_fused_noncausal[grid](
@@ -4462,6 +4525,7 @@ def attention_backward_triton_impl(
                 ),  # Add flag for seqused
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
+                NUM_XCD=num_xcd,
             )
     elif mode == "fused_atomic":
         NUM_WARPS, NUM_STAGES = 4, 1

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -10,6 +10,7 @@ from .utils import (
     FWD_CONF_OVERRIDE,
     get_arch,
     is_fp8,
+    remap_xcd,
 )
 
 FWD_PREFILL_AUTOTUNE_KEYS = [
@@ -47,7 +48,37 @@ def get_fwd_prefill_configs(autotune: bool):
                     },
                     num_stages=1,
                     num_warps=4,
-                )
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M": 128,
+                        "BLOCK_N": 64,
+                        "waves_per_eu": 2,
+                        "PRE_LOAD_V": False,
+                    },
+                    num_stages=1,
+                    num_warps=2,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M": 128,
+                        "BLOCK_N": 64,
+                        "waves_per_eu": 2,
+                        "PRE_LOAD_V": False,
+                    },
+                    num_stages=2,
+                    num_warps=4,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M": 128,
+                        "BLOCK_N": 128,
+                        "waves_per_eu": 2,
+                        "PRE_LOAD_V": False,
+                    },
+                    num_stages=2,
+                    num_warps=4,
+                ),
             ]
         elif arch.name == "gfx942":
             if arch.cu_count < 304:
@@ -852,14 +883,18 @@ def attn_fwd(
     FP8_P_DESCALE: tl.constexpr,
     USE_SEQUSED: tl.constexpr,
     FORCE_MASKING: tl.constexpr,
+    NUM_XCD: tl.constexpr = 1,
 ):
     # set params
     ACCUMULATOR_TYPE = tl.float32
 
     # compute offsets
-    off_z = tl.program_id(0)
-    off_h_q = tl.program_id(1)
-    start_m = tl.program_id(2)
+    off_h_q = tl.program_id(0)
+    # apply the xcd remapping for the hq dim
+    off_h_q = remap_xcd(off_h_q, HQ, NUM_XCD)
+
+    start_m = tl.program_id(1)
+    off_z = tl.program_id(2)
     # If MQA / GQA, set the K and V head offsets appropriately.
     GROUP_SIZE: tl.constexpr = HQ // HK
     if GROUP_SIZE != 1:
@@ -1698,9 +1733,11 @@ def attention_forward_prefill_triton_impl(
     arch = get_arch()
     force_masking = arch.is_rdna
 
+    num_xcd = 1 if arch.is_rdna else 8
+
     # launch kernel
     def grid(META):
-        return (batch, nheads_q, triton.cdiv(max_seqlens_q, META["BLOCK_M"]))
+        return (nheads_q, triton.cdiv(max_seqlens_q, META["BLOCK_M"]), batch)
 
     attn_fwd[grid](
         q,
@@ -1777,4 +1814,5 @@ def attention_forward_prefill_triton_impl(
         FP8_P_DESCALE=False,
         USE_SEQUSED=(seqused_q is not None or seqused_k is not None),
         FORCE_MASKING=force_masking,
+        NUM_XCD=num_xcd,
     )

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
@@ -14,6 +14,7 @@ import json
 import logging
 from dataclasses import dataclass
 from typing import Literal, Optional, Union
+import triton.language as tl
 
 import torch
 import triton
@@ -297,3 +298,33 @@ def get_arch() -> GpuArch:
         return GpuArch(name=name, family="rdna")
     else:
         return GpuArch(name=name)
+
+
+@triton.jit
+def remap_xcd(pid, GRID_MN, NUM_XCDS: tl.constexpr = 8):
+    ## pid remapping on xcds
+    # Number of pids per XCD in the new arrangement
+    pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+    # When GRID_MN cannot divide NUM_XCDS, some xcds will have
+    # pids_per_xcd pids, the other will have pids_per_xcd - 1 pids.
+    # We calculate the number of xcds that have pids_per_xcd pids as
+    # tall_xcds
+    tall_xcds = GRID_MN % NUM_XCDS
+    tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+    # Compute current XCD and local pid within the XCD
+    xcd = pid % NUM_XCDS
+    local_pid = pid // NUM_XCDS
+    # Calculate new pid based on the new grouping
+    # Note that we need to consider the following two cases:
+    # 1. the current pid is on a tall xcd
+    # 2. the current pid is on a short xcd
+    if xcd < tall_xcds:
+        pid = xcd * pids_per_xcd + local_pid
+    else:
+        pid = (
+            tall_xcds * pids_per_xcd
+            + (xcd - tall_xcds) * (pids_per_xcd - 1)
+            + local_pid
+        )
+
+    return pid


### PR DESCRIPTION
## Motivation

This PR is to optimize the Triton flash attention kernel used by public flash attn repo. The following changes are made:
- Add one or two tuning configs for the fwd and bwd kernel to boost the performance by 2x of some input shapes
- Change two kernel argument to `tl.constexpr` for the bwd kernel, which further improve the perf by 15%.
- Apply the xcd remapping to the `num_heads` dimension for better L2 cache hit.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

There are existing tests for these kernels

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
