### PR TITLE
CI: Replace simple inference with accuracy tests in ATOM test workflow

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -183,7 +183,7 @@ jobs:
           set -euo pipefail
           echo ""
           echo "========== Launching ATOM server =========="
-          if [ -d "/run" ]; then
+          if [ -d "/run/${{ matrix.model_path }}" ]; then
             model_path="/run/${{ matrix.model_path }}"
           else
             model_path="${{ matrix.model_path }}"


### PR DESCRIPTION
## Summary

- Remove simple inference step that only tested basic model output
- Run accuracy tests (gsm8k benchmark via lm-eval) for all models including DeepSeek-R1-0528
- Add per-model accuracy test threshold checking (DeepSeek-R1-0528: 0.94, gpt-oss-120b: 0.38)
- Add test summary collection to GitHub Step Summary
- Add `atom_test.sh` script (from ATOM repo) for launching ATOM server and running accuracy tests
- Fix shell syntax errors in model path detection logic

## Test plan

- [ ] Verify ATOM accuracy test runs successfully for DeepSeek-R1-0528 on MI325
- [ ] Verify ATOM accuracy test runs successfully for gpt-oss-120b on MI355
- [ ] Verify accuracy threshold check passes for both models
- [ ] Verify test summary appears in GitHub Step Summary