### PR TITLE
fix(attention): restrict ASM paged attention to head_size=128

### DIFF
--- a/aiter/ops/attention.py
+++ b/aiter/ops/attention.py
@@ -128,9 +128,19 @@ def pa_fwd_asm(
 def _should_use_asm_kernel(
     num_seqs: int,
     num_heads: int,
+    head_size: int,
     kv_cache_tensor_dtype: torch.dtype,
+    high_precision: int,
 ) -> bool:
+    # ASM kernel only supports head_size == 128; all other head sizes use HIP.
+    if head_size != 128:
+        return False
 
+    # high_precision == 2 forces ASM for maximum precision (fp8 kvcache only)
+    if high_precision == 2:
+        return True
+
+    # int8 kv cache always uses ASM
     if kv_cache_tensor_dtype == torch.int8:
         return True
 
@@ -183,9 +193,8 @@ def paged_attention_common(
     )
     num_seqs, num_heads, head_size = Q.shape
 
-    use_asm_kernel = (
-        _should_use_asm_kernel(num_seqs, num_heads, kv_cache_tensor_dtype)
-        or high_precision == 2
+    use_asm_kernel = _should_use_asm_kernel(
+        num_seqs, num_heads, head_size, kv_cache_tensor_dtype, high_precision
     )
 
     if use_asm_kernel:

--- a/csrc/py_itfs_cu/asm_pa.cu
+++ b/csrc/py_itfs_cu/asm_pa.cu
@@ -177,6 +177,10 @@ torch::Tensor pa_fwd(torch::Tensor& Q, //   [num_seqs, num_heads, head_size]
     // int block_tables_stride0 = block_tables.size(1);
     int num_heads       = Q.size(1);
     int head_size       = Q.size(2);
+    TORCH_CHECK(head_size == 128,
+        __func__,
+        ": ASM PA only supports head_size=128, got ",
+        head_size);
     int num_kv_heads    = K.size(1);
     int block_size      = K.size(3);
     const int gqa_ratio = num_heads / num_kv_heads;


### PR DESCRIPTION
The ASM PA kernel only supports `head_size=128` (@JohnNikolay84 confirmed this by checking the asm code) but was previously called for other head sizes, leading to incorrect results. Move `head_size` and `high_precision` checks into `_should_use_asm_kernel` so non-128 head sizes fall back to the HIP kernel, and add a TORCH_CHECK in the CUDA entry point as a safety net.