### PR TITLE
Gluon gfx12 a8w8blockscale v1 to main

### DIFF
--- a/op_tests/triton_tests/gemm/basic/test_gemm_a8w8_blockscale.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_a8w8_blockscale.py
@@ -191,7 +191,7 @@ def generate_gemm_a8w8_blockscale_inputs(
 @pytest.mark.parametrize(
     "impl",
     [
-        # "gluon",
+        "gluon",
         "triton",
         "triton_shuffle",
     ],
@@ -202,7 +202,7 @@ def test_gemm(dtype, M, N, K, layout, output, impl: str):
 
     block_shape_n, block_shape_k = block_shape
 
-    if impl == "gluon" and DEVICE_ARCH not in ("gfx950",):
+    if impl == "gluon" and DEVICE_ARCH not in ("gfx950", "gfx1250"):
         pytest.skip(
             "Gluon implementation is not supported on this device (requires CDNA4/gfx950)."
         )
@@ -245,7 +245,7 @@ def test_gemm(dtype, M, N, K, layout, output, impl: str):
 
     if impl == "gluon" and DEVICE_ARCH in ("gfx1250",):
         impl = gluon_gemm_a8w8_blockscale_gfx12
-    elif impl == "gluon":
+    elif impl == "gluon" and DEVICE_ARCH in ("gfx950",):
         impl = gluon_gemm_a8w8_blockscale
     elif impl == "triton":
         impl = triton_gemm_a8w8_blockscale


### PR DESCRIPTION
## Motivation

New gluon kernel for gfx12 a8w8 blockscale. 

## Technical Details

Like original blockscale kernel, but modified for gfx12. Will be optimized in future versions to include new optimization features.

## Test Plan

Pytest with modified unit tests from mi350 blockscale. FFM slow but all UT passing before terminal shuts down from inactivity.

## Test Result

All pass before terminal shuts down from inactivity.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
