### PR TITLE
CI: increase standard test timeout and MAX_JOBS for fork PR builds

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -322,14 +322,14 @@ jobs:
           bash -c "pip show amd-aiter || true"
       
       - name: Tests
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           set -ex
           if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
             docker exec \
             -w /workspace \
             aiter_test \
-            bash -c "MAX_JOBS=20 SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh"
+            bash -c "MAX_JOBS=64 SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh"
           else
             docker exec \
             -w /workspace \


### PR DESCRIPTION
## Summary

- Increase standard test step timeout from 60 to 90 minutes to prevent frequent CI timeouts caused by JIT kernel compilation
- Increase `MAX_JOBS` from 20 to 64 for fork PR builds to speed up JIT compilation