### PR TITLE
CI: Use pinned CK on main branch and add nightly schedule for latest CK

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -13,6 +13,8 @@ on:
       - '.gitignore'
 
   workflow_dispatch:
+  schedule:
+    - cron: '0 22 * * *'  # 6:00 AM Beijing Time (UTC+8)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +24,7 @@ env:
   DOCKER_IMAGE: "rocm/pytorch:latest"
   GPU_ARCH_LIST: "gfx942;gfx950"
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
-  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   AITER_TEST: "op_tests"
 
 jobs:
@@ -76,13 +78,13 @@ jobs:
            && git clone ${{ env.GITHUB_REPO_URL }} aiter \
            && cd aiter \
            && git checkout ${{ env.GITHUB_COMMIT_SHA }} \
-           && if [ "${GITHUB_REF:-}" = "refs/heads/main" ]; then \
-                echo "It's main branch, syncing latest CK..."; \
+           && if [ "${{ github.event_name }}" = "schedule" ]; then \
+                echo "It's nightly build, syncing latest CK..."; \
                 git submodule set-branch --branch develop 3rdparty/composable_kernel; \
                 git submodule sync && \
                 git submodule update --init --recursive --remote --jobs 4; \
               else \
-                echo "It's a PR branch, syncing specific CK..."; \
+                echo "Using pinned CK commit..."; \
                 git submodule sync && \
                 git submodule update --init --recursive --depth 1 --jobs 4; \
               fi \
@@ -132,7 +134,7 @@ jobs:
           echo "Successfully prepared image: rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}"
 
       - name: Extract wheel from image
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         run: |
           set -ex
           IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
@@ -145,21 +147,21 @@ jobs:
           ls -lh dist/*.whl
 
       - name: Upload wheel as artifact
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         uses: actions/upload-artifact@v4
         with:
           name: aiter-whl-main-${{ github.run_id }}
           path: dist/*.whl
 
       - name: Configure AWS credentials
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::661452401056:role/framework-aiter-nightlies
 
       - name: Install AWS CLI
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         run: |
           if ! command -v aws &> /dev/null; then
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -169,7 +171,7 @@ jobs:
           fi
 
       - name: Upload wheels to S3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         run: |
           for WHL in dist/*.whl; do
             WHL_NAME=$(basename ${WHL})


### PR DESCRIPTION
## Summary
- Main branch push now uses the pinned CK submodule commit instead of syncing latest CK develop HEAD, improving build reproducibility.
- Added a nightly schedule (daily at 6:00 AM Beijing Time / UTC 22:00) that syncs the latest CK develop branch to catch CK regressions early.
- S3 wheel upload is skipped for nightly runs (only triggered on main push).
- Added `github.sha` fallback for `GITHUB_COMMIT_SHA` to support schedule events.

## Behavior Matrix

| Trigger | CK Version | S3 Upload | Multi-GPU |
|---------|-----------|-----------|-----------|
| push to main | pinned commit | Yes | Yes |
| PR | pinned commit | No | No |
| nightly (schedule) | latest CK develop | No | Yes |

## Test plan
- [ ] Verify PR CI passes with pinned CK commit
- [ ] Manually trigger workflow_dispatch to confirm it uses pinned CK
- [ ] Wait for nightly schedule trigger to verify latest CK sync