### PR TITLE
mla ps fp8 mode get_meta_param avoid  kv_tail_len < max_seqlen_q and reduce mgc

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -137,9 +137,6 @@ def get_meta_param(num_kv_splits, bs, total_kv, nhead, max_seqlen_q, dtype):
             num_kv_splits = min(
                 num_kv_splits, int(total_kv / bs - max_seqlen_q) // min_block_n + 1
             )
-        # avg_tail_kv = (total_kv // bs) - min_block_n * (num_kv_splits - 1)
-        # if num_kv_splits > 1 and avg_tail_kv > 0 and avg_tail_kv < max_seqlen_q:
-        #     num_kv_splits = num_kv_splits - 1
 
     num_kv_splits_indptr = torch.arange(
         0, (bs + 1) * num_kv_splits, num_kv_splits, dtype=torch.int, device="cuda"


### PR DESCRIPTION
## Motivation
mla ps fp8 mode get_meta_param avoid kv_tail_len < max_seqlen_q

## Technical Details

## Test Plan
python3 op_tests/test_mla.py -b 1 --nhead 128,4 -d fp8 -kvd fp8 -splits 16 -c $(seq 4 200 | tr '\n' ' ')
rocm/atom:nightly_202601190317
用这个docker搭之后, cd /app  ,里面就有aiter和atom代码
cd ATOM
fetch最新之后
git checkout zlr/mtp_dp
 
pip install .
MORI_SHMEM_MODE=ISOLATION python3 -m atom.examples.simple_inference --model /data/DeepSeek-R1-0528/ -tp 8 --port 5678   --kv_cache_dtype fp8 --torch-profiler-dir ./log --method mtp --num-speculative-tokens 3 --block-size 10000 --gpu-memory-utilization 0.41 --enable-dp-attention --enable-expert-parallel
 
## Test Result
<img width="2526" height="1208" alt="image" src="https://github.com/user-attachments/assets/062600e8-6348-480c-b0d5-4f6fae46378c" />
<img width="2419" height="854" alt="image" src="https://github.com/user-attachments/assets/e69cbae9-d949-4725-8580-c2d5af78714f" />
<img width="2362" height="548" alt="image" src="https://github.com/user-attachments/assets/d9fd526a-312d-4042-8ffe-98b7588477c1" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
