### PR TITLE
GFX1250 Gluon MoE A4W4 Kernel

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_gluon_kernels/moe/moe_op_gemm_a4w4.py
@@ -1,0 +1,678 @@
+from triton.experimental import gluon
+import triton.experimental.gluon.language as gl
+
+
+@gluon.jit
+def pid_grid(pid: int, num_pid_m: int, num_pid_n: int, GROUP_SIZE_M: gl.constexpr = 1):
+    """
+    Maps 1D pid to 2D grid coords (pid_m, pid_n).
+
+    Args:
+        - pid: 1D pid
+        - num_pid_m: grid m size
+        - num_pid_n: grid n size
+        - GROUP_SIZE_M: default is 1
+    """
+    if GROUP_SIZE_M == 1:
+        pid_m = pid // num_pid_n
+        pid_n = pid % num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        gl.assume(group_size_m >= 0)
+        pid_m = first_pid_m + (pid % group_size_m)
+        pid_n = (pid % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@gluon.jit
+def xcd_swizzle(pid, domain_size, XCD_SWIZZLE: gl.constexpr):
+    """
+    Swizzle the program id based on integer XCD_SWIZZLE.
+    This is useful for reording how blocks are ordered. A scheduler may, for example,
+    assign sequential blocks 0, 1, 2, 3, ..., 8, 9, 10.. to its 8 hardware units 0, 1, 2, 3, ..., 0, 1, 2.
+    This pattern may not be ideal for memory access, and it may be better to swizzle so the assignment
+    becomes 0, 0, 0, 0, ..., 1, 1, 1, ... In the swizzled arrangement, sequential blocks are assigned to
+    the same hardware unit.
+    """
+    # Number of pids per group in the new arrangement
+    pids_per_group = domain_size // XCD_SWIZZLE
+    extra_pid_groups = domain_size % XCD_SWIZZLE
+
+    # Compute current current and local pid within the group
+    group = pid % XCD_SWIZZLE
+    local_pid = pid // XCD_SWIZZLE
+
+    # Calculate new pid based on the new grouping
+    new_pid = group * pids_per_group + min(group, extra_pid_groups) + local_pid
+    return new_pid
+
+
+@gluon.jit
+def clip(x, limit, clip_lower: gl.constexpr):
+    res = gl.minimum(x, limit)
+    if clip_lower:
+        res = gl.maximum(-limit, res)
+    return res
+
+
+@gluon.jit
+def _swiglu(input, alpha, limit):
+    gelu, linear = gl.split(gl.reshape(input, (input.shape[0], input.shape[1] // 2, 2)))
+    gelu = gelu.to(gl.float32)
+    if limit is not None:
+        gelu = clip(gelu, limit, clip_lower=False)
+    linear = linear.to(gl.float32)
+    if limit is not None:
+        linear = clip(linear, limit, clip_lower=True)
+    s = gelu / (1 + gl.exp2(-1.44269504089 * alpha * gelu))
+    return gl.fma(s, linear, s)  # (s * (linear + 1))
+
+
+@gluon.jit
+def _compute_static_fp8_quant(tensor, scale):
+    tensor = tensor.to(gl.float32)
+    tensor = tensor / scale
+    tensor = tensor.to(gl.float8e4nv)
+    return tensor
+
+
+@gluon.jit
+def _reduce_grouped_gfx1250(
+    X,
+    stride_xb: gl.uint64,
+    stride_xm: gl.uint64,
+    stride_xn,  #
+    Out,
+    stride_om: gl.uint64,
+    stride_on,  # output tensor
+    InIndx,
+    B,
+    N,  #
+    # fused activation function
+    APPLY_SWIGLU: gl.constexpr,
+    alpha,
+    limit,
+    ACTIVATION_REDUCTION_N: gl.constexpr,
+    K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    EVEN_N: gl.constexpr,
+    # layouts
+    BLOCKED_LAYOUT_N: gl.constexpr,
+    BLOCKED_LAYOUT_N_OUT: gl.constexpr,
+):
+    pid_t = gl.program_id(1)  # groups
+    pid_n = gl.program_id(0)  # blocks
+
+    BLOCK_N_OUT: gl.constexpr = BLOCK_N // ACTIVATION_REDUCTION_N
+    start = pid_t * K
+
+    # load indices into a tuple
+    if InIndx is None:
+        indxs = (pid_t,)
+    else:
+        indxs = ()
+        for i in gl.static_range(0, K):
+            indxs = indxs + (gl.load(InIndx + start + i),)
+    XPtrs = (
+        X
+        + (pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=BLOCKED_LAYOUT_N)) * stride_xn
+    )
+    OutPtrs = (
+        Out
+        + (pid_n * BLOCK_N_OUT + gl.arange(0, BLOCK_N_OUT, layout=BLOCKED_LAYOUT_N_OUT))
+        * stride_on
+    )
+
+    acc = gl.zeros([BLOCK_N_OUT], dtype=gl.float32)
+    x_n_mask = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=BLOCKED_LAYOUT_N) < N
+
+    # accumulate contributions for this tile
+    for i in gl.static_range(0, K):
+        curr = gl.zeros([BLOCK_N], dtype=gl.float32)
+        # iterate over split_k partial values
+        for b in gl.static_range(0, B):
+            x_row_ptr = XPtrs + indxs[i] * stride_xm + b * stride_xb
+            if EVEN_N:
+                vals = gl.load(x_row_ptr)
+            else:
+                vals = gl.load(x_row_ptr, mask=x_n_mask, other=0.0)
+            vals = vals.to(gl.float32)
+            curr += vals
+
+        # apply nonlinearity to split-k output
+        if APPLY_SWIGLU:
+            curr = _swiglu(curr[None, :], alpha, limit)
+        curr = gl.reshape(curr, [curr.shape[-1]])
+
+        # update final accumulator
+        acc += curr
+
+    # Compute per-32-col MXFP scales for this tile if requested
+    Nrem = N // ACTIVATION_REDUCTION_N
+
+    # write-back for this tile
+    out_ptr = OutPtrs + pid_t * stride_om
+    if EVEN_N:
+        gl.store(out_ptr, acc)
+    else:
+        out_n_mask = (
+            pid_n * BLOCK_N_OUT + gl.arange(0, BLOCK_N_OUT, layout=BLOCKED_LAYOUT_N_OUT)
+            < Nrem
+        )
+        gl.store(out_ptr, acc, mask=out_n_mask)
+
+
+@gluon.jit
+def _moe_gemm_a4w4_gfx1250(
+    Y,
+    stride_y_k,
+    stride_y_m,
+    stride_y_n,
+    X,
+    stride_x_m,
+    stride_x_k,
+    XMxScale,
+    stride_x_mx_m,
+    stride_x_mx_k,
+    W,
+    stride_w_e,
+    stride_w_k,
+    stride_w_n,
+    WMxScale,
+    stride_w_mx_e,
+    stride_w_mx_k,
+    stride_w_mx_n,
+    X_static_scale,  # NOTE: not supported
+    Quant_static_scale,
+    # bias
+    B,
+    stride_b_e,
+    Gammas,
+    # shapes
+    num_tokens,
+    N,
+    K,
+    # expt data
+    GatherIndx,
+    ExptHist,
+    ExptOffs,
+    ExptOffsSum,
+    ExptData,
+    # true grid size
+    grid_m,
+    grid_n,
+    # fused activation function
+    APPLY_SWIGLU: gl.constexpr,
+    alpha,
+    limit,
+    ACTIVATION_REDUCTION_N: gl.constexpr,
+    # MoE config
+    N_EXPTS_ACT: gl.constexpr,
+    # optimization config
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    GROUP_M: gl.constexpr,
+    XCD_SWIZZLE: gl.constexpr,
+    SWIZZLE_MX_SCALE: gl.constexpr,
+    EVEN_K: gl.constexpr,
+    MASK_K_LIMIT: gl.constexpr,
+    SPLIT_K: gl.constexpr,
+    W_CACHE_MODIFIER: gl.constexpr,
+    WMMA_LAYOUT: gl.constexpr,
+    WMMA_LAYOUT_PACKED: gl.constexpr,
+    IDX_LAYOUT: gl.constexpr,
+    UPCAST_INDICES: gl.constexpr = False,
+):
+    gl.assume(stride_y_k >= 0)
+    gl.assume(stride_y_m >= 0)
+    gl.assume(stride_y_n >= 0)
+    gl.assume(stride_x_m >= 0)
+    gl.assume(stride_x_k >= 0)
+    gl.assume(stride_w_e >= 0)
+    gl.assume(stride_w_k >= 0)
+    gl.assume(stride_w_n >= 0)
+    if stride_x_mx_m is not None:
+        gl.assume(stride_x_mx_m >= 0)
+    if stride_x_mx_k is not None:
+        gl.assume(stride_x_mx_k >= 0)
+    if stride_w_mx_e is not None:
+        gl.assume(stride_w_mx_e >= 0)
+    if stride_w_mx_k is not None:
+        gl.assume(stride_w_mx_k >= 0)
+    if stride_w_mx_n is not None:
+        gl.assume(stride_w_mx_n >= 0)
+    if B is not None:
+        gl.assume(stride_b_e >= 0)
+    gl.assume(grid_m >= 0)
+    gl.assume(grid_n >= 0)
+
+    NUM_BUFFERS: gl.constexpr = 2
+
+    MX_PACK_DIVISOR: gl.constexpr = 32
+    gl.static_assert(
+        BLOCK_K % MX_PACK_DIVISOR == 0, "BLOCK_K must be a multiple of MX_PACK_DIVISOR"
+    )
+
+    is_x_microscaled: gl.constexpr = XMxScale is not None
+    NUM_LOADS_IN_BATCH: gl.constexpr = 4 if is_x_microscaled else 3
+    w_type: gl.constexpr = W.dtype.element_ty
+    gl.static_assert(w_type == gl.uint8, "mx_weight_ptr must be uint8 or fp8")
+    gl.static_assert(
+        WMxScale.dtype.element_ty == gl.uint8, "mx_scale_ptr must be uint8"
+    )
+    x_type: gl.constexpr = X.dtype.element_ty
+    if is_x_microscaled:
+        gl.static_assert(x_type == gl.uint8, "mx_act_ptr must be uint8")
+        gl.static_assert(
+            XMxScale.dtype.element_ty == gl.uint8, "mx_scale_ptr must be uint8"
+        )
+
+    OUT_BLOCK_N: gl.constexpr = BLOCK_N // ACTIVATION_REDUCTION_N
+    yN = N // ACTIVATION_REDUCTION_N
+
+    # get program id
+    pid = gl.program_id(0)
+    if ExptOffsSum is not None and XCD_SWIZZLE > 1:
+        # Determine how much padding there is on the expert data. This allows us to
+        # know the true grid size and avoid processing padding tiles.
+        padding_m = grid_m - gl.load(ExptOffsSum)
+    else:
+        padding_m: gl.constexpr = 0
+
+    index_type: gl.constexpr = gl.int64 if UPCAST_INDICES else gl.int32
+
+    # get unpadded grid size
+    unpadded_m = grid_m - padding_m
+    gl.assume(unpadded_m >= 0)
+    total_actual_tiles = unpadded_m * grid_n * SPLIT_K
+    if padding_m > 0 and pid >= total_actual_tiles:
+        return
+
+    # swizzle program ids
+    pid_emnk = pid
+    if XCD_SWIZZLE != 1:
+        pid_emnk = xcd_swizzle(pid_emnk, total_actual_tiles, XCD_SWIZZLE)
+    # pid_e = pid_emnk // (unpadded_m * grid_n * SPLIT_K)
+    pid_mnk = pid_emnk % (unpadded_m * grid_n * SPLIT_K)
+    pid_k = pid_mnk % SPLIT_K
+    pid_mn = pid_mnk // SPLIT_K
+    pid_m, pid_n = pid_grid(pid_mn, unpadded_m, grid_n, GROUP_M)
+
+    # for split-k, advance to the output k slice
+    if SPLIT_K > 1:
+        Y += pid_k.to(index_type) * stride_y_k
+
+    # unpack expert data
+    expt_data = gl.load(ExptData + pid_m)
+    if expt_data == -1:
+        return
+    expt_id = expt_data & 0x0000FFFF
+    block_id = expt_data >> 16
+    M = gl.load(ExptHist + expt_id)
+    start_m = gl.load(ExptOffs + expt_id)
+    expt_id, block_id = expt_id.to(index_type), block_id.to(index_type)
+    start_m = start_m.to(index_type)
+    pid_n, pid_k = pid_n.to(index_type), pid_k.to(index_type)
+
+    # constants
+    X_M_DIVISOR: gl.constexpr = 1
+    X_K_DIVISOR: gl.constexpr = 2
+    W_K_DIVISOR: gl.constexpr = 2
+    W_N_DIVISOR: gl.constexpr = 1
+    PACKED_BLOCK_M_X: gl.constexpr = BLOCK_M // X_M_DIVISOR
+    PACKED_BLOCK_K_X: gl.constexpr = BLOCK_K // X_K_DIVISOR
+    PACKED_BLOCK_K_W: gl.constexpr = BLOCK_K // W_K_DIVISOR
+    PACKED_BLOCK_N_W: gl.constexpr = BLOCK_N // W_N_DIVISOR
+    MX_SCALE_BLOCK_K: gl.constexpr = BLOCK_K // MX_PACK_DIVISOR
+
+    # A pointers
+    offs_x_m = PACKED_BLOCK_M_X * block_id
+    if GatherIndx is None:
+        X += start_m * stride_x_m
+    else:
+        offs_x_m = PACKED_BLOCK_M_X * block_id + gl.arange(
+            0, PACKED_BLOCK_M_X, layout=IDX_LAYOUT
+        )
+        GatherIndx += start_m
+        offs_x_m = gl.load(GatherIndx + offs_x_m) // N_EXPTS_ACT
+
+    # B scale pointers
+    WMxScale += expt_id * stride_w_mx_e
+    if SWIZZLE_MX_SCALE == "GFX1250_SCALE":
+        gl.static_assert(stride_w_mx_k is not None)
+        gl.static_assert(stride_w_mx_n is not None)
+        SCALE_KWIDTH: gl.constexpr = 4 if MX_SCALE_BLOCK_K >= 4 else MX_SCALE_BLOCK_K
+        PRESHUFFLE_FACTOR: gl.constexpr = 128
+        PACKED_MX_BLOCK: gl.constexpr = MX_SCALE_BLOCK_K * PRESHUFFLE_FACTOR
+        SCALE_BLOCK_N: gl.constexpr = BLOCK_N // PRESHUFFLE_FACTOR
+    else:
+        PRESHUFFLE_FACTOR: gl.constexpr = 1
+        PACKED_MX_BLOCK: gl.constexpr = MX_SCALE_BLOCK_K
+        SCALE_BLOCK_N: gl.constexpr = BLOCK_N
+    offs_w_n_scale = pid_n * SCALE_BLOCK_N
+
+    # B pointers
+    offs_w_n = pid_n * PACKED_BLOCK_N_W
+    W += expt_id * stride_w_e
+
+    # A scale pointers
+    if is_x_microscaled and GatherIndx is None:
+        XMxScale += start_m * stride_x_mx_m
+
+    SHARED_LAYOUT_X: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[PACKED_BLOCK_K_X, 16]], [PACKED_BLOCK_M_X, PACKED_BLOCK_K_X], [1, 0]
+    )
+    SHARED_LAYOUT_W: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[PACKED_BLOCK_K_W, 16]], [PACKED_BLOCK_N_W, PACKED_BLOCK_K_W], [1, 0]
+    )
+    SHARED_LAYOUT_X_SCALES: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 16]], [PACKED_BLOCK_M_X, MX_SCALE_BLOCK_K], [1, 0]
+    )
+    SHARED_LAYOUT_W_SCALES: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 16]], [SCALE_BLOCK_N, PACKED_MX_BLOCK], [1, 0]
+    )
+
+    if GatherIndx is None:
+        x_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+            base=X,
+            shape=(M, K // X_K_DIVISOR),
+            strides=(stride_x_m, stride_x_k),
+            block_shape=(PACKED_BLOCK_M_X, PACKED_BLOCK_K_X),
+            layout=SHARED_LAYOUT_X,
+        )
+    else:
+        x_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+            base=X,
+            shape=(num_tokens, K // X_K_DIVISOR),
+            strides=(stride_x_m, stride_x_k),
+            block_shape=(PACKED_BLOCK_M_X, PACKED_BLOCK_K_X),
+            layout=SHARED_LAYOUT_X,
+        )
+    w_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+        base=W,
+        shape=(N, K // W_K_DIVISOR),
+        strides=(stride_w_n, stride_w_k),
+        block_shape=(PACKED_BLOCK_N_W, PACKED_BLOCK_K_W),
+        layout=SHARED_LAYOUT_W,
+    )
+    if is_x_microscaled:
+        if GatherIndx is None:
+            x_scales_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+                base=XMxScale,
+                shape=(M, gl.cdiv(K, MX_PACK_DIVISOR)),
+                strides=(stride_x_mx_m, stride_x_mx_k),
+                block_shape=(PACKED_BLOCK_M_X, MX_SCALE_BLOCK_K),
+                layout=SHARED_LAYOUT_X_SCALES,
+            )
+        else:
+            x_scales_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+                base=XMxScale,
+                shape=(num_tokens, gl.cdiv(K, MX_PACK_DIVISOR)),
+                strides=(stride_x_mx_m, stride_x_mx_k),
+                block_shape=(PACKED_BLOCK_M_X, MX_SCALE_BLOCK_K),
+                layout=SHARED_LAYOUT_X_SCALES,
+            )
+    w_scales_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+        base=WMxScale,
+        shape=(N // PRESHUFFLE_FACTOR, gl.cdiv(K, MX_PACK_DIVISOR) * PRESHUFFLE_FACTOR),
+        strides=(stride_w_mx_n, stride_w_mx_k),
+        block_shape=(SCALE_BLOCK_N, PACKED_MX_BLOCK),
+        layout=SHARED_LAYOUT_W_SCALES,
+    )
+
+    DOT_LAYOUT_X: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=WMMA_LAYOUT_PACKED, k_width=16
+    )
+    DOT_LAYOUT_W: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=WMMA_LAYOUT_PACKED, k_width=16
+    )
+    DOT_LAYOUT_X_SCALES: gl.constexpr = gl.amd.gfx1250.get_wmma_scale_layout(
+        DOT_LAYOUT_X, [PACKED_BLOCK_M_X, MX_SCALE_BLOCK_K]
+    )
+    DOT_LAYOUT_W_SCALES: gl.constexpr = gl.amd.gfx1250.get_wmma_scale_layout(
+        DOT_LAYOUT_W, [PACKED_BLOCK_N_W, MX_SCALE_BLOCK_K]
+    )
+
+    x_buffer = gl.allocate_shared_memory(
+        x_desc.dtype, shape=[NUM_BUFFERS] + x_desc.block_shape, layout=x_desc.layout
+    )
+    w_buffer = gl.allocate_shared_memory(
+        w_desc.dtype, shape=[NUM_BUFFERS] + w_desc.block_shape, layout=w_desc.layout
+    )
+    if is_x_microscaled:
+        x_scales_buffer = gl.allocate_shared_memory(
+            x_scales_desc.dtype,
+            shape=[NUM_BUFFERS] + x_scales_desc.block_shape,
+            layout=x_scales_desc.layout,
+        )
+    w_scales_buffer = gl.allocate_shared_memory(
+        w_scales_desc.dtype,
+        shape=[NUM_BUFFERS] + w_scales_desc.block_shape,
+        layout=w_scales_desc.layout,
+    )
+
+    load_idx = 0
+    wmma_idx = 0
+
+    # prologue
+    for _ in gl.static_range(NUM_BUFFERS - 1):
+        if GatherIndx is None:
+            gl.amd.gfx1250.tdm.async_load(
+                x_desc,
+                [offs_x_m, load_idx * PACKED_BLOCK_K_X],
+                x_buffer.index(load_idx % NUM_BUFFERS),
+            )
+        else:
+            gl.amd.gfx1250.tdm.async_gather(
+                x_desc,
+                offs_x_m,
+                load_idx * PACKED_BLOCK_K_X,
+                x_buffer.index(load_idx % NUM_BUFFERS),
+            )
+        gl.amd.gfx1250.tdm.async_load(
+            w_desc,
+            [offs_w_n, load_idx * PACKED_BLOCK_K_W],
+            w_buffer.index(load_idx % NUM_BUFFERS),
+        )
+        if is_x_microscaled:
+            if GatherIndx is None:
+                gl.amd.gfx1250.tdm.async_load(
+                    x_scales_desc,
+                    [offs_x_m, load_idx * MX_SCALE_BLOCK_K],
+                    x_scales_buffer.index(load_idx % NUM_BUFFERS),
+                )
+            else:
+                gl.amd.gfx1250.tdm.async_gather(
+                    x_scales_desc,
+                    offs_x_m,
+                    load_idx * MX_SCALE_BLOCK_K,
+                    x_scales_buffer.index(load_idx % NUM_BUFFERS),
+                )
+        gl.amd.gfx1250.tdm.async_load(
+            w_scales_desc,
+            [offs_w_n_scale, load_idx * PACKED_MX_BLOCK],
+            w_scales_buffer.index(load_idx % NUM_BUFFERS),
+        )
+        load_idx += 1
+
+    # compute output
+    num_k_iter = gl.cdiv(K, BLOCK_K)
+    acc = gl.zeros((BLOCK_M, BLOCK_N), dtype=gl.float32, layout=WMMA_LAYOUT)
+    for k in range(num_k_iter - (NUM_BUFFERS - 1)):
+        if GatherIndx is None:
+            gl.amd.gfx1250.tdm.async_load(
+                x_desc,
+                [offs_x_m, load_idx * PACKED_BLOCK_K_X],
+                x_buffer.index(load_idx % NUM_BUFFERS),
+            )
+        else:
+            gl.amd.gfx1250.tdm.async_gather(
+                x_desc,
+                offs_x_m,
+                load_idx * PACKED_BLOCK_K_X,
+                x_buffer.index(load_idx % NUM_BUFFERS),
+            )
+        gl.amd.gfx1250.tdm.async_load(
+            w_desc,
+            [offs_w_n, load_idx * PACKED_BLOCK_K_W],
+            w_buffer.index(load_idx % NUM_BUFFERS),
+        )
+        if is_x_microscaled:
+            if GatherIndx is None:
+                gl.amd.gfx1250.tdm.async_load(
+                    x_scales_desc,
+                    [offs_x_m, load_idx * MX_SCALE_BLOCK_K],
+                    x_scales_buffer.index(load_idx % NUM_BUFFERS),
+                )
+            else:
+                gl.amd.gfx1250.tdm.async_gather(
+                    x_scales_desc,
+                    offs_x_m,
+                    load_idx * MX_SCALE_BLOCK_K,
+                    x_scales_buffer.index(load_idx % NUM_BUFFERS),
+                )
+        gl.amd.gfx1250.tdm.async_load(
+            w_scales_desc,
+            [offs_w_n_scale, load_idx * PACKED_MX_BLOCK],
+            w_scales_buffer.index(load_idx % NUM_BUFFERS),
+        )
+        load_idx += 1
+
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * NUM_LOADS_IN_BATCH)
+
+        x = x_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=DOT_LAYOUT_X)
+        w = (
+            w_buffer.index(wmma_idx % NUM_BUFFERS)
+            .permute((1, 0))
+            .load(layout=DOT_LAYOUT_W)
+        )
+        if is_x_microscaled:
+            x_scales_buffer_slice = x_scales_buffer.index(wmma_idx % NUM_BUFFERS)
+        w_scales_buffer_slice = w_scales_buffer.index(wmma_idx % NUM_BUFFERS)
+        if SWIZZLE_MX_SCALE == "GFX1250_SCALE":
+            w_scales_buffer_slice = (
+                w_scales_buffer_slice.reshape(
+                    (
+                        SCALE_BLOCK_N,
+                        MX_SCALE_BLOCK_K // SCALE_KWIDTH,
+                        PRESHUFFLE_FACTOR // 4,
+                        4,
+                        SCALE_KWIDTH,
+                    )
+                )
+                .permute((0, 3, 2, 1, 4))
+                .reshape((BLOCK_N, MX_SCALE_BLOCK_K))
+            )
+        if is_x_microscaled:
+            x_scales = x_scales_buffer_slice.load(layout=DOT_LAYOUT_X_SCALES)
+        else:
+            x_scales = gl.full(
+                (PACKED_BLOCK_M_X, MX_SCALE_BLOCK_K), 127, dtype=gl.uint8
+            )
+        w_scales = w_scales_buffer_slice.load(layout=DOT_LAYOUT_W_SCALES)
+
+        acc = gl.amd.gfx1250.wmma_scaled(x, x_scales, "e2m1", w, w_scales, "e2m1", acc)
+        wmma_idx += 1
+
+    # epilogue
+    for k_ep in gl.static_range(NUM_BUFFERS - 1):
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2 - k_ep) * NUM_LOADS_IN_BATCH)
+
+        x = x_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=DOT_LAYOUT_X)
+        w = (
+            w_buffer.index(wmma_idx % NUM_BUFFERS)
+            .permute((1, 0))
+            .load(layout=DOT_LAYOUT_W)
+        )
+        if is_x_microscaled:
+            x_scales_buffer_slice = x_scales_buffer.index(wmma_idx % NUM_BUFFERS)
+        w_scales_buffer_slice = w_scales_buffer.index(wmma_idx % NUM_BUFFERS)
+        if SWIZZLE_MX_SCALE == "GFX1250_SCALE":
+            w_scales_buffer_slice = (
+                w_scales_buffer_slice.reshape(
+                    (
+                        SCALE_BLOCK_N,
+                        MX_SCALE_BLOCK_K // SCALE_KWIDTH,
+                        PRESHUFFLE_FACTOR // 4,
+                        4,
+                        SCALE_KWIDTH,
+                    )
+                )
+                .permute((0, 3, 2, 1, 4))
+                .reshape((BLOCK_N, MX_SCALE_BLOCK_K))
+            )
+        if is_x_microscaled:
+            x_scales = x_scales_buffer_slice.load(layout=DOT_LAYOUT_X_SCALES)
+        else:
+            x_scales = gl.full(
+                (PACKED_BLOCK_M_X, MX_SCALE_BLOCK_K), 127, dtype=gl.uint8
+            )
+        w_scales = w_scales_buffer_slice.load(layout=DOT_LAYOUT_W_SCALES)
+
+        acc = gl.amd.gfx1250.wmma_scaled(x, x_scales, "e2m1", w, w_scales, "e2m1", acc)
+
+    # scalar fp8 scale
+    if X_static_scale is not None:
+        # should not go in here since static scale fp4 is disabled
+        gl.static_assert(
+            X_static_scale is None,
+            f"Static scale is disabled for fp4 precision. got {X_static_scale}",
+        )
+
+    # bias
+    offs_m = BLOCK_M * block_id + gl.arange(
+        0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT)
+    )
+    offs_y_n = BLOCK_N * pid_n + gl.arange(
+        0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
+    )
+    mask_m = offs_m < M
+    mask_n = offs_y_n < N
+    if B is not None:
+        BPtrs = B + expt_id * stride_b_e
+        bias = gl.amd.gfx1250.buffer_load(BPtrs, offs_y_n, mask=mask_n)
+        acc = acc + bias[None, :]
+
+    # apply activation function
+    if APPLY_SWIGLU and SPLIT_K == 1:
+        out = _swiglu(acc, alpha, limit)
+        out = gl.convert_layout(out, WMMA_LAYOUT)
+        gl.static_assert(
+            out.shape[1] == OUT_BLOCK_N,
+            f"Activation fn out.shape[1] ({out.shape[1]}) doesn't match computed OUT_BLOCK_N ({OUT_BLOCK_N})",
+        )
+        offs_y_n = OUT_BLOCK_N * pid_n + gl.arange(
+            0, OUT_BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
+        )
+        mask_n = offs_y_n < yN
+    else:
+        gl.static_assert(
+            ACTIVATION_REDUCTION_N == 1,
+            "Activation reduction must be 1 if no activation fn is provided",
+        )
+        out = acc
+
+    # apply gammas
+    if Gammas is not None:
+        gammas = gl.load(Gammas + start_m + offs_m, mask=mask_m, other=0.0)
+        out *= gammas[:, None]
+
+    # quant
+    if Quant_static_scale is not None:
+        out = _compute_static_fp8_quant(out, gl.load(Quant_static_scale))
+
+    # write-back
+    Y += start_m * stride_y_m
+    offs_y_m = offs_m
+    offs_y = (
+        offs_y_m.to(index_type)[:, None] * stride_y_m
+        + offs_y_n.to(index_type)[None, :] * stride_y_n
+    )
+    mask = mask_m[:, None] & mask_n[None, :]
+    if Quant_static_scale is None:
+        out = out.to(gl.bfloat16)
+    gl.amd.gfx1250.buffer_store(out, Y, offs_y, mask=mask)

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -2,14 +2,30 @@
 # original code https://github.com/triton-lang/triton/blob/main/python/triton_kernels/triton_kernels/matmul_ogs.py
 
 import itertools
+from typing import Literal, Optional
 import torch
 import triton
+from triton.experimental import gluon
+import triton.experimental.gluon.language as gl
+from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.moe.moe_routing.routing import RoutingData
 from aiter.ops.triton._triton_kernels.moe.moe_op_gemm_a4w4 import (
     _mxfp4_quant_kernel,
     _moe_gemm_a4w4,
     _reduce_grouped,
 )
+from aiter.ops.triton._gluon_kernels.moe.moe_op_gemm_a4w4 import (
+    _moe_gemm_a4w4_gfx1250,
+    _reduce_grouped_gfx1250,
+)
+
+GLUON_SUPPORTED_ARCHS = set(["gfx1250"])
+
+
+def is_gluon_supported():
+    arch = get_arch()
+    return arch in GLUON_SUPPORTED_ARCHS
+
 
 # -----------------------------------------------------------------------------
 #                    Matrix Multiplication + Outer Gather/Scatter
@@ -122,6 +138,22 @@ def swizzle_scales(data):
     return data.transpose(-1, -2)
 
 
+def swizzle_scales_gfx1250(data):
+    NON_K_PRESHUFFLE_BLOCK_SIZE = 128
+    block_shape = data.shape
+    SCALE_K = block_shape[-2]
+    N = block_shape[-1]
+    num_chunk_m = N // NON_K_PRESHUFFLE_BLOCK_SIZE
+    SCALE_KWIDTH = 4 if SCALE_K >= 4 else SCALE_K
+    num_chunk_k = SCALE_K // SCALE_KWIDTH
+    data = data.transpose(-1, -2)
+    data = data.view(-1, num_chunk_m, 4, NON_K_PRESHUFFLE_BLOCK_SIZE // 4, num_chunk_k, SCALE_KWIDTH)
+    data = data.permute(0, 1, 4, 3, 2, 5).contiguous()
+    E = block_shape[0]
+    data = data.view(E, N // NON_K_PRESHUFFLE_BLOCK_SIZE, SCALE_K * NON_K_PRESHUFFLE_BLOCK_SIZE)
+    return data.transpose(-1, -2)
+
+
 def reduce_grouped(
     x: torch.Tensor,
     indx: torch.Tensor,
@@ -130,7 +162,8 @@ def reduce_grouped(
     alpha=1.0,
     limit=1.0,
     reduction_n=1,
-    out_dtype: bool = None,
+    backend: Optional[Literal["triton", "gluon"]] = None,
+    out_dtype: Optional[torch.dtype] = None,
 ):
     """
     In-place grouped row reduction.
@@ -172,28 +205,80 @@ def reduce_grouped(
     assert x.shape[-1] % reduction_n == 0
     BLOCK_N = 512
     num_blocks = triton.cdiv(x.shape[-1], BLOCK_N)
+    num_warps = 2
 
-    _reduce_grouped[(num_blocks, num_groups)](
-        x,
-        x.stride(0),
-        x.stride(1),
-        x.stride(2),  #
-        out,
-        out.stride(0),
-        out.stride(1),  #
-        indx,  #
-        x.shape[0],
-        x.shape[-1],  #
-        apply_swiglu,
-        alpha,
-        limit,
-        reduction_n,
-        BLOCK_N=BLOCK_N,
-        EVEN_N=(x.shape[-1] % BLOCK_N == 0),
-        K=K,  #
-        num_warps=2,  #
-    )
+    if backend == "gluon" and get_arch() == "gfx1250":
+        BLOCKED_LAYOUT_N: gl.constexpr = gl.BlockedLayout(
+            [BLOCK_N], [32], [num_warps], [0]
+        )
+        BLOCKED_LAYOUT_N_OUT: gl.constexpr = gl.BlockedLayout(
+            [BLOCK_N // reduction_n], [32], [num_warps], [0]
+        )
+        _reduce_grouped_gfx1250[(num_blocks, num_groups)](
+            x,
+            x.stride(0),
+            x.stride(1),
+            x.stride(2),  #
+            out,
+            out.stride(0),
+            out.stride(1),  #
+            indx,  #
+            x.shape[0],
+            x.shape[-1],  #
+            apply_swiglu,
+            alpha,
+            limit,
+            reduction_n,
+            BLOCK_N=BLOCK_N,
+            EVEN_N=(x.shape[-1] % BLOCK_N == 0),
+            K=K,  #
+            BLOCKED_LAYOUT_N=BLOCKED_LAYOUT_N,
+            BLOCKED_LAYOUT_N_OUT=BLOCKED_LAYOUT_N_OUT,
+            num_warps=num_warps,  #
+        )
+    else:
+        _reduce_grouped[(num_blocks, num_groups)](
+            x,
+            x.stride(0),
+            x.stride(1),
+            x.stride(2),  #
+            out,
+            out.stride(0),
+            out.stride(1),  #
+            indx,  #
+            x.shape[0],
+            x.shape[-1],  #
+            apply_swiglu,
+            alpha,
+            limit,
+            reduction_n,
+            BLOCK_N=BLOCK_N,
+            EVEN_N=(x.shape[-1] % BLOCK_N == 0),
+            K=K,  #
+            num_warps=num_warps,  #
+        )
     return out
+
+
+@gluon.constexpr_function
+def get_wmma_layout(num_warps, packed, scale_preshuffle):
+    assert num_warps in (4, 8)
+    if scale_preshuffle:
+        reg_bases = [[0, 1], [1, 0]]
+        tiles_per_warp = 2
+    else:
+        reg_bases = []
+        tiles_per_warp = 1
+
+    # [NUM_WARPS // 2, 2]
+    if num_warps == 4:
+        warp_bases = [[0, tiles_per_warp], [tiles_per_warp, 0]]
+    else:
+        warp_bases = [[0, tiles_per_warp], [0, tiles_per_warp * 2], [tiles_per_warp, 0]]
+
+    instr_shape = [16, 16, 64] if packed else [16, 16, 128]
+
+    return gl.amd.AMDWMMALayout(3, True, warp_bases, reg_bases, instr_shape)
 
 
 # -----------------------------------------------------------------------------
@@ -275,12 +360,23 @@ def moe_gemm_a4w4(
     limit=1.0,
     unpadded_N=None,
     unpadded_K=None,
+    backend: Optional[Literal["triton", "gluon"]] = None,
 ):
     """
     Y[:, :] = 0.
     for e in num_experts:
         Y[idxs_y_m(e), :] += matmul(X[idxs_x_m(e), :], W[e, :, :])
     """
+    backend = (
+        backend
+        if backend is not None
+        else ("gluon" if is_gluon_supported() else "triton")
+    )
+    assert backend in ["triton", "gluon"], f"Invalid backend: {backend}"
+    if backend == "gluon":
+        assert (
+            is_gluon_supported()
+        ), f"Gluon backend is not supported on this architecture: {get_arch()}"
     assert w.stride(-2) == 1, "`w` must be column-major when it has data-type mxfp"
     x_has_mx = x_scales is not None
     if x_has_mx:
@@ -292,6 +388,7 @@ def moe_gemm_a4w4(
         stride_x_mx_m = 0
         stride_x_mx_k = 0
     # determine shapes
+    num_tokens = x.shape[-2]
     M = x.shape[-2] if gather_indx is None else gather_indx.shape[0]
     K, N = x.shape[-1] * 2, w.shape[-1]
     block_m = routing_data.block_m
@@ -341,61 +438,132 @@ def moe_gemm_a4w4(
     grid_n = triton.cdiv(N, config["block_n"])
     grid = grid_m * grid_n * config["split_k"]
     # launch kernel
-    _moe_gemm_a4w4[(grid,)](
-        y,
-        y.stride(0),
-        y.stride(1),
-        y.stride(2),
-        x,
-        x.stride(0),
-        x.stride(1),
-        x_scales,
-        stride_x_mx_m,
-        stride_x_mx_k,
-        w,
-        w.stride(0),
-        w.stride(1),
-        w.stride(2),
-        w_scales,
-        w_scales.stride(0),
-        w_scales.stride(1),
-        w_scales.stride(2),
-        x_static_scale,
-        quant_static_scale,
-        bias,
-        stride_bias,
-        gammas,
-        N,
-        K,
-        gather_indx,
-        expt_hist,
-        expt_token_offs_raw,
-        expt_hist_sum,
-        expt_block_pid_map,
-        grid_m,
-        grid_n,
-        apply_swiglu_matmul,
-        alpha,
-        limit,
-        reduction_n_matmul,
-        routing_data.n_expts_act,
-        config["block_m"],
-        config["block_n"],
-        config["block_k"],
-        config["group_m"],
-        XCD_SWIZZLE=config["xcd_swizzle"],
-        SWIZZLE_MX_SCALE=swizzle_mx_scale,
-        SPLIT_K=config["split_k"],
-        EVEN_K=K % config["block_k"] == 0,
-        MASK_K_LIMIT=K % config["block_k"],
-        W_CACHE_MODIFIER=config["w_cache_modifier"],
-        num_warps=config["num_warps"],
-        num_stages=config["num_stages"],
-        UPCAST_INDICES=should_upcast_indices(x, w, y),
-        waves_per_eu=config["waves_per_eu"],
-        matrix_instr_nonkdim=config["matrix_instr_nonkdim"],
-        kpack=config["kpack"],
-    )
+    if backend == "gluon" and get_arch() == "gfx1250":
+        # layouts
+        WMMA_LAYOUT = get_wmma_layout(
+            config["num_warps"], False, swizzle_mx_scale == "GFX1250_SCALE"
+        )
+        WMMA_LAYOUT_PACKED = get_wmma_layout(
+            config["num_warps"], True, swizzle_mx_scale == "GFX1250_SCALE"
+        )
+        IDX_LAYOUT = gl.BlockedLayout(
+            [config["block_m"]], [32], [config["num_warps"]], [0]
+        )
+        _moe_gemm_a4w4_gfx1250[(grid,)](
+            y,
+            y.stride(0),
+            y.stride(1),
+            y.stride(2),
+            x,
+            x.stride(0),
+            x.stride(1),
+            x_scales,
+            stride_x_mx_m,
+            stride_x_mx_k,
+            w,
+            w.stride(0),
+            w.stride(1),
+            w.stride(2),
+            w_scales,
+            w_scales.stride(0),
+            w_scales.stride(1),
+            w_scales.stride(2),
+            x_static_scale,
+            quant_static_scale,
+            bias,
+            stride_bias,
+            gammas,
+            num_tokens,
+            N,
+            K,
+            gather_indx,
+            expt_hist,
+            expt_token_offs_raw,
+            expt_hist_sum,
+            expt_block_pid_map,
+            grid_m,
+            grid_n,
+            apply_swiglu_matmul,
+            alpha,
+            limit,
+            reduction_n_matmul,
+            routing_data.n_expts_act,
+            config["block_m"],
+            config["block_n"],
+            config["block_k"],
+            config["group_m"],
+            XCD_SWIZZLE=config["xcd_swizzle"],
+            SWIZZLE_MX_SCALE=swizzle_mx_scale,
+            SPLIT_K=config["split_k"],
+            EVEN_K=K % config["block_k"] == 0,
+            MASK_K_LIMIT=K % config["block_k"],
+            W_CACHE_MODIFIER=config["w_cache_modifier"],
+            WMMA_LAYOUT=WMMA_LAYOUT,
+            WMMA_LAYOUT_PACKED=WMMA_LAYOUT_PACKED,
+            IDX_LAYOUT=IDX_LAYOUT,
+            UPCAST_INDICES=should_upcast_indices(x, w, y),
+            num_warps=config["num_warps"],
+            num_stages=config["num_stages"],
+            waves_per_eu=config["waves_per_eu"],
+            matrix_instr_nonkdim=config["matrix_instr_nonkdim"],
+            kpack=config["kpack"],
+        )
+    else:
+        _moe_gemm_a4w4[(grid,)](
+            y,
+            y.stride(0),
+            y.stride(1),
+            y.stride(2),
+            x,
+            x.stride(0),
+            x.stride(1),
+            x_scales,
+            stride_x_mx_m,
+            stride_x_mx_k,
+            w,
+            w.stride(0),
+            w.stride(1),
+            w.stride(2),
+            w_scales,
+            w_scales.stride(0),
+            w_scales.stride(1),
+            w_scales.stride(2),
+            x_static_scale,
+            quant_static_scale,
+            bias,
+            stride_bias,
+            gammas,
+            N,
+            K,
+            gather_indx,
+            expt_hist,
+            expt_token_offs_raw,
+            expt_hist_sum,
+            expt_block_pid_map,
+            grid_m,
+            grid_n,
+            apply_swiglu_matmul,
+            alpha,
+            limit,
+            reduction_n_matmul,
+            routing_data.n_expts_act,
+            config["block_m"],
+            config["block_n"],
+            config["block_k"],
+            config["group_m"],
+            XCD_SWIZZLE=config["xcd_swizzle"],
+            SWIZZLE_MX_SCALE=swizzle_mx_scale,
+            SPLIT_K=config["split_k"],
+            EVEN_K=K % config["block_k"] == 0,
+            MASK_K_LIMIT=K % config["block_k"],
+            W_CACHE_MODIFIER=config["w_cache_modifier"],
+            num_warps=config["num_warps"],
+            num_stages=config["num_stages"],
+            UPCAST_INDICES=should_upcast_indices(x, w, y),
+            waves_per_eu=config["waves_per_eu"],
+            matrix_instr_nonkdim=config["matrix_instr_nonkdim"],
+            kpack=config["kpack"],
+        )
     # Build grouped reduction inputs in a uniform way
     group_indx = (
         None
@@ -410,6 +578,7 @@ def moe_gemm_a4w4(
         alpha,
         limit,
         reduction_n_reduction,
+        backend=backend,
         out_dtype=out_dtype,
     )
     return y_final

--- a/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
@@ -14,6 +14,7 @@ from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     moe_gemm_a4w4,
     moe_gemm_torch,
     swizzle_scales,
+    swizzle_scales_gfx1250,
 )
 
 # numerics utilities
@@ -68,7 +69,8 @@ def init_compute_data(
     has_y_gammas,
     device="cuda",
 ):
-    torch.manual_seed(0)
+    # TODO: Uncomment after pytorch adds support for manual_seed
+    # torch.manual_seed(0)
     in_m = m * (n_expts_act if gindx is None else 1)
     shape_x = (in_m, k)
     x = alloc_rand(shape_x, device=device, dtype=act_dtype)
@@ -213,6 +215,7 @@ class Case:
 @pytest.mark.parametrize("has_y_gammas", [False, True])
 @pytest.mark.parametrize("apply_swiglu", [False, True])
 @pytest.mark.parametrize("fused_quant", [False, True])
+@pytest.mark.parametrize("backend", ["triton", "gluon"])
 def test_op(
     m,
     n,
@@ -225,17 +228,17 @@ def test_op(
     n_expts_tot,
     n_expts_act,
     hbm_swizzling,
+    backend,
     device="cuda",
 ):
-    if get_arch() != "gfx950":
-        pytest.skip("FP4 kernels are not supported on MI300.")
     if hbm_swizzling:
         if n % 32 != 0 or k % (32 * 8) != 0:
             pytest.skip(
                 f"Shape {m}x{n}x{k} is not supported for scale swizzling on AMD GPU"
             )
 
-    torch.manual_seed(0)
+    # TODO: Uncomment after pytorch adds support for manual_seed
+    # torch.manual_seed(0)
 
     act_mxfp4 = "mxfloat4_e2m1"
     weight_mxfp4 = "mxfloat4_e2m1"
@@ -264,8 +267,14 @@ def test_op(
     w_tri, w_scale_tri = downcast_to_mxfp(w_tri, weight_dtype, axis=1)
     w_ref = upcast_from_mxfp(w_tri, w_scale_tri, torch.bfloat16, axis=1)
     if hbm_swizzling:
-        swizzle_mx_scale = "CDNA4_SCALE"
-        w_scale_tri = swizzle_scales(w_scale_tri)
+        if get_arch() == "gfx1250":
+            swizzle_mx_scale = "GFX1250_SCALE"
+            w_scale_tri = swizzle_scales_gfx1250(w_scale_tri)
+        elif get_arch() == "gfx950":
+            swizzle_mx_scale = "CDNA4_SCALE"
+            w_scale_tri = swizzle_scales(w_scale_tri)
+        else:
+            assert False, "Unsupported architecture"
     else:
         swizzle_mx_scale = None
 
@@ -283,6 +292,8 @@ def test_op(
         quant_static_scale = ref_y.abs().max().float() / 448.0
     else:
         quant_static_scale = None
+
+    # run kernel
     tri_y = moe_gemm_a4w4(
         x_tri,
         w_tri,
@@ -298,6 +309,7 @@ def test_op(
         swizzle_mx_scale,
         out_dtype,
         apply_swiglu,
+        backend=backend,
     )
     if not act_mxfp4 and fused_quant:
         tri_y = (tri_y.float() * quant_static_scale).to(ref_y.dtype)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Port MoE A4W4 kernel from Triton to Gluon for GFX1250.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Follows the same function signature as Triton version but using TDM features in Gluon.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Added `backend` parameter to the Triton unit tests to switch between Triton and Gluon.

```bash
pytest op_tests/triton_tests/moe/test_moe_gemm_a4w4.py # runs both triton and gluon tests
pytest op_tests/triton_tests/moe/test_moe_gemm_a4w4.py -k "gluon" # runs just gluon tests
pytest op_tests/triton_tests/moe/test_moe_gemm_a4w4.py -k "triton" # runs just triton tests
```

## Test Result

<!-- Briefly summarize test outcomes. -->

The following unit tests has passed:

- [x] Base (no HBM swizzling, no gather, no scatter, no gammas, no activations, no fused quant)
- [x] With HBM swizzling
- [x] With gather
- [x] With scatter
- [x] With gammas
- [x] With swiglu activation
- [x] With fused quant

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
