### PR TITLE
CI: Add CK submodule sync step for non-fork PRs in standard tests

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -315,6 +315,21 @@ jobs:
           aiter_test \
           bash -c "BUILD_TRITON=0 ./.github/scripts/build_aiter_triton.sh"
 
+      - name: Sync CK submodule
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          set -ex
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Nightly build: syncing latest CK from develop branch..."
+            git submodule set-branch --branch develop 3rdparty/composable_kernel
+            git submodule sync
+            git submodule update --init --recursive --remote --jobs 4
+          else
+            echo "Using pinned CK commit..."
+            git submodule sync
+            git submodule update --init --recursive --depth 1 --jobs 4
+          fi
+
       - name: Show Aiter version
         run: |
           set -ex
@@ -322,7 +337,7 @@ jobs:
           -w /workspace \
           aiter_test \
           bash -c "pip show amd-aiter || true"
-      
+
       - name: Tests
         timeout-minutes: 90
         run: |


### PR DESCRIPTION
## Summary
- Add a **Sync CK submodule** step to the `standard` test job for non-fork PRs
- For **nightly (schedule)** builds: sync the latest CK from `develop` branch
- For **all other triggers**: use the pinned CK commit

## Test plan
- [ ] Verify nightly schedule run syncs CK from develop branch
- [ ] Verify PR-triggered run uses pinned CK commit
- [ ] Verify fork PRs skip this step