### PR TITLE
identify device name by chip id

### DIFF
--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -145,15 +145,33 @@ def get_cu_num():
     return cu_num
 
 
+def _get_pci_chip_id(device_id=0):
+    import ctypes
+
+    libhip = ctypes.CDLL("libamdhip64.so")
+    chip_id = ctypes.c_int(0)
+    hipDeviceAttributePciChipId = 10019
+    err = libhip.hipDeviceGetAttribute(
+        ctypes.byref(chip_id),
+        hipDeviceAttributePciChipId,
+        device_id,
+    )
+    if err != 0:
+        raise RuntimeError(f"hipDeviceGetAttribute(PciChipId) failed with error {err}")
+    return chip_id.value
+
+
+MI308_CHIP_IDS = {0x74A2, 0x74A8, 0x74B6, 0x74BC}
+
+
 def get_device_name():
     gfx = get_gfx()
 
     if gfx == "gfx942":
-        cu = get_cu_num()
-        if cu == 304:
-            return "MI300"
-        elif cu == 80 or cu == 64:
+        chip_id = _get_pci_chip_id()
+        if chip_id in MI308_CHIP_IDS:
             return "MI308"
+        return "MI300"
     elif gfx == "gfx950":
         return "MI350"
     else:

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -65,15 +65,14 @@ std::string get_kernel_co_name(const std::string& cfg_co_name, const std::string
     std::string co_name = cfg_co_name;
     if(arch_id == "gfx942")
     {
-        auto pos        = cfg_co_name.rfind('/');
-        uint32_t cu_num = get_num_cu_func();
-        if(cu_num == 304)
-        {
-            co_name = cfg_co_name.substr(0, pos + 1) + "MI300/" + cfg_co_name.substr(pos + 1);
-        }
-        else if(cu_num == 80 || cu_num == 64)
+        auto pos = cfg_co_name.rfind('/');
+        if(is_mi308_device())
         {
             co_name = cfg_co_name.substr(0, pos + 1) + "MI308/" + cfg_co_name.substr(pos + 1);
+        }
+        else
+        {
+            co_name = cfg_co_name.substr(0, pos + 1) + "MI300/" + cfg_co_name.substr(pos + 1);
         }
     }
     return co_name;

--- a/csrc/include/aiter_hip_common.h
+++ b/csrc/include/aiter_hip_common.h
@@ -216,3 +216,24 @@ static uint32_t get_num_cu_func()
     static const uint32_t num_cu = get_num_cu_local();
     return num_cu;
 }
+
+static int get_pci_chip_id()
+{
+    static const int chip_id = []() {
+        hipDevice_t dev;
+        int id = 0;
+        HIP_CALL(hipGetDevice(&dev));
+        HIP_CALL(hipDeviceGetAttribute(&id, hipDeviceAttributePciChipId, dev));
+        AITER_LOG_INFO("pciChipId: 0x" << std::hex << id << std::dec
+                       << ", CU count: " << get_num_cu_func());
+        return id;
+    }();
+    return chip_id;
+}
+
+static bool is_mi308_device()
+{
+    int chip_id = get_pci_chip_id();
+    return chip_id == 0x74a2 || chip_id == 0x74a8 ||
+           chip_id == 0x74b6 || chip_id == 0x74bc;
+}


### PR DESCRIPTION
## Motivation

In DPX (Dynamic Partition eXecution) mode, the visible CU count changes depending on the partition configuration. The previous device identification logic relied on hardcoded CU counts (multiProcessorCount == 304 for MI300, == 80 || == 64 for MI308) to select the correct pre-compiled kernel binary (.co file). When running in DPX mode, the CU count no longer matches these expected values, causing device identification to fail and the wrong kernel path to be selected -- resulting in "file not found" errors and kernel launch failures.

## Technical Details

Replace CU-count-based MI300/MI308 GPU identification with PCI Chip ID detection via hipDeviceAttributePciChipId. PCI Chip ID is a hardware constant burned into the silicon that never changes regardless of DPX partition mode, CU masking, or container environments.
MI308 device IDs (0x74A2, 0x74A8, 0x74B6, 0x74BC) are identified from the official AMD device ID registry; all other gfx942 devices default to MI300.

csrc/include/aiter_hip_common.h: Add get_pci_chip_id() helper using hipDeviceGetAttribute(hipDeviceAttributePciChipId) and is_mi308_device() that checks against known MI308 chip IDs.
csrc/cpp_itfs/mha_fwd.cu: Update get_kernel_co_name() to use is_mi308_device() instead of CU count comparison for selecting the correct .co kernel binary path (MI308/ vs MI300/).
aiter/jit/utils/chip_info.py: Add _get_pci_chip_id() using ctypes to call hipDeviceGetAttribute directly, and update get_device_name() to use chip ID instead of CU count.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
