### PR TITLE
feat(custom_all_reduce): support GPT-OSS-120B hidden_size=2880 in fus…

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -2554,7 +2554,9 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
             sg_, residual_inp, residual_out, output, weight, eps, rank_, m, n); \
     } while(0)
 
-    if(n_bytes % 1024 == 0)
+    // Support GPT-OSS (e.g. 120B) hidden_size=2880: n_bytes=5760 not multiple of 1024.
+    // Require 16-byte alignment (pack_size alignment for vectorized load).
+    if(n_bytes % 16 == 0)
     {
         if(8192 <= n_bytes && n_bytes <= 32768)
         {
@@ -2606,7 +2608,9 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
             }
             else
             {
-                // n_loop = 2
+                // n_loop = 2: covers 4096 < n_bytes < 8192, e.g. GPT-OSS hidden_size=2880
+                // (n_bytes=5760). Kernel uses bound (n_iter*tnum+threadIdx.x) < (n/pack_size)
+                // so partial second iteration is correct; no precision change.
                 launch_fused_allreduce_rmsnorm((local_device_load_rmsnorm<T, 256, 2>));
             }
         }
@@ -2703,6 +2707,7 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
         {                                                                                    \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 4096, allreduce_fusion_kernel_split_launcher)  \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 2048, allreduce_fusion_kernel_split_launcher)  \
+            DISPATCH_AR_FUSION_KERNEL_(NGPUS, 2880, allreduce_fusion_kernel_split_launcher)  \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 1024, allreduce_fusion_kernel_split_launcher)  \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 512, allreduce_fusion_kernel_split_launcher)   \
         default: printf("fused allreduce rmsnorm quant N-dim error\n");                      \

--- a/op_tests/multigpu_tests/test_fused_ar_rms.py
+++ b/op_tests/multigpu_tests/test_fused_ar_rms.py
@@ -562,7 +562,16 @@ def acc_test_cudagraph_on(
 #         checkAllclose(cpu_rslt[i], ar_rslt[i].to(ref))
 
 l_dtype = ["fp16", "bf16"]
-l_shape = [(13, 512), (13, 1024), (13, 2048), (17, 4096), (17, 7168), (19, 8192)]
+# (13, 2880): GPT-OSS-120B / GPT-OSS-20B hidden_size (n_bytes=5760, 4096 < 5760 < 8192)
+l_shape = [
+    (13, 512),
+    (13, 1024),
+    (13, 2048),
+    (13, 2880),
+    (17, 4096),
+    (17, 7168),
+    (19, 8192),
+]
 l_tp = [8]
 l_pp = [1]
 l_graph = [False, True]


### PR DESCRIPTION
# Support GPT-OSS-120B hidden_size=2880 in fused allreduce rmsnorm

## Motivation

GPT-OSS-120B and GPT-OSS-20B use `hidden_size=2880`. The fused allreduce rmsnorm path previously only supported `n` where `n_bytes % 1024 == 0` (e.g. 512, 1024, 2048, 4096, 8192). For `n=2880`, `n_bytes=5760`, which failed that check and triggered "fused allreduce rmsnorm shape error". This MR adds support for `n=2880` so GPT-OSS models can use the fused allreduce rmsnorm kernel.

## Technical Details

- **Non-quant dispatch**: Relax step2 condition from `n_bytes % 1024 == 0` to `n_bytes % 16 == 0`; for `4096 <= n_bytes < 8192` use existing `local_device_load_rmsnorm<T, 256, 2>` with bounds so 2880 is correct.
- **Quant dispatch**: Add `n=2880` to the quant split-launcher `switch(n)` so 2880 uses `allreduce_fusion_kernel_split_launcher` instead of the default error path.
- **Quant kernel**: For `HIDDEN_DIM=2880`, round BLOCK_SIZE up to a multiple of 32 (384); let threads with `threadIdx.x >= hidden_dim/pack_size` only join the block reduce with identity and skip writing output (`idx >= 0` check in epilogue).
- **Block reduce**: When `N_WARPS < 32`, avoid OOB and use an identity for extra lanes; for `N_WARPS < 32` use a sequential reduce in thread 0 instead of a 12-way warp reduce.
- **Tests**: Add shape `(13, 2880)` to `test_fused_ar_rms.py` and add `README_fused_ar_rms_2880.md` for manual testing.

## Test Plan

Run fused allreduce rmsnorm tests for shape (13, 2880) with bf16/fp16, non-quant and quant:

python3 op_tests/multigpu_tests/test_fused_ar_rms.py -s 13,2880 -t 2 -d bf16 -g 0


## Test Result

<img width="949" height="64" alt="image" src="https://github.com/user-attachments/assets/e43efc5b-7878-4aa7-908f-bbacb6b62d7c" />
<img width="963" height="87" alt="image" src="https://github.com/user-attachments/assets/28cfa422-168b-4316-9786-ab836a479123" />
<img width="1077" height="92" alt="image" src="https://github.com/user-attachments/assets/abdce89b-47f8-4408-8e8f-c97e7b14e1f1" />
