### PR TITLE
Discard check_LLVM_MAIN_REVISION object file

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -423,7 +423,7 @@ def check_LLVM_MAIN_REVISION():
     import subprocess
 
     cmd = """echo "#include <tuple>
-__host__ __device__ void func(){std::tuple<int, int> t = std::tuple(1, 1);}" | hipcc -x hip -P -c -Wno-unused-command-line-argument -"""
+__host__ __device__ void func(){std::tuple<int, int> t = std::tuple(1, 1);}" | hipcc -x hip -P -c -Wno-unused-command-line-argument -o /dev/null -"""
     try:
         subprocess.check_output(cmd, shell=True, text=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
## Motivation

When running diffusion workloads on MI300/MI355 an unknown object file `.-o` kept being created in the current working directory. It was traced back to a function `check_LLVM_MAIN_REVISION()` which was introduced in https://github.com/ROCm/aiter/pull/1703 and is hit during JIT compilation of aiter kernels.


This PR introduces a minimal fix to prevent this stray .-o object file from being created during aiter JIT compilation without affecting the LLVM revision check logic.

## Technical Details

The `check_LLVM_MAIN_REVISION()` function in `aiter/jit/core.py` compiles a small test snippet using hipcc via stdin.
```
echo '#include <tuple> 
__host__ __device__ void func(){std::tuple<int, int> t = std::tuple(1, 1);}' | hipcc -x hip -P -c -Wno-unused-command-line-argument -
```

When hipcc is invoked with -c (compile-only) it derives the output object filename from the input filename. Because the input here is stdin (denoted by the trailing -), the compiler treats the filename as - and writes -.o into the current directory. That file is a side-effect and never referenced/consumed; the function only cares about the exit code.

The fix is minimal (discarding the object file using `-o /dev/null` as is done in `hip_flag_checker` in the same file).

## Test Plan

1. Tested diffusion workloads with aiter compiled kernels with and without the fix.
2. Testing the function return code

## Test Result

1. Generated images kept the same quality and e2e performance speed before and after
2. Function returned the same code before and after 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
