### PR TITLE
enable topk_softmax with share expert scoring function

### DIFF
--- a/aiter/ops/moe_op.py
+++ b/aiter/ops/moe_op.py
@@ -19,6 +19,8 @@ def topk_softmax(
     token_expert_indices: Tensor,
     gating_output: Tensor,
     need_renorm: bool,
+    num_shared_experts: int = 0,
+    shared_expert_scoring_func: str = "",
 ) -> None: ...
 
 

--- a/csrc/include/moe_op.h
+++ b/csrc/include/moe_op.h
@@ -179,7 +179,9 @@ void topk_softmax(torch::Tensor& topk_weights,
                   torch::Tensor& topk_indices,
                   torch::Tensor& token_expert_indices,
                   torch::Tensor& gating_output,
-                  bool need_renorm);
+                  bool need_renorm,
+                  int num_shared_experts                        = 0,
+                  const std::string& shared_expert_scoring_func = "");
 
 void moe_align_block_size(torch::Tensor topk_ids,
                           int64_t num_experts,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1168,6 +1168,8 @@ namespace py = pybind11;
           py::arg("token_expert_indices"),                                     \
           py::arg("gating_output"),                                            \
           py::arg("need_renorm"),                                              \
+          py::arg("num_shared_experts")         = 0,                           \
+          py::arg("shared_expert_scoring_func") = "",                          \
           "Apply topk softmax to the gating outputs.");                        \
     m.def("topk_softmax_asm",                                                  \
           &topk_softmax_asm,                                                   \
@@ -1267,7 +1269,7 @@ namespace py = pybind11;
           py::arg("fc2_smooth_scale") = std::nullopt,                          \
           py::arg("activation")       = ActivationType::Silu);                       \
     m.def("fmoe_int8_g1u0_a16",                                                \
-          &fmoe_int8_g1u0_a16,                                                \
+          &fmoe_int8_g1u0_a16,                                                 \
           py::arg("out"),                                                      \
           py::arg("input"),                                                    \
           py::arg("gate"),                                                     \
@@ -1281,7 +1283,7 @@ namespace py = pybind11;
           py::arg("fc2_scale"),                                                \
           py::arg("fc1_smooth_scale"),                                         \
           py::arg("fc2_smooth_scale"),                                         \
-          py::arg("activation") = ActivationType::Silu);                      \
+          py::arg("activation") = ActivationType::Silu);                       \
     m.def("fmoe_g1u1_a16",                                                     \
           &fmoe_g1u1_a16,                                                      \
           py::arg("out"),                                                      \

--- a/csrc/kernels/topk_softmax_kernels.cu
+++ b/csrc/kernels/topk_softmax_kernels.cu
@@ -36,6 +36,14 @@
 namespace vllm {
 namespace moe {
 
+// Enum for shared expert scoring functions
+enum class SharedExpertScoringFunc
+{
+    NONE = 0,
+    SIGMOID = 1,
+    // Future: SOFTMAX = 2, LINEAR = 3, etc.
+};
+
 /// Aligned array type
 template <typename T,
           /// Number of elements in the array
@@ -211,7 +219,9 @@ template <typename DTYPE,
           int NUM_EXPERTS,
           int WARPS_PER_CTA,
           int BYTES_PER_LDG,
-          bool need_renorm>
+          bool need_renorm,
+          int NUM_SHARED_EXPERTS = 0,
+          SharedExpertScoringFunc SCORING_FUNC = SharedExpertScoringFunc::NONE>
 __launch_bounds__(WARPS_PER_CTA* WARP_SIZE) __global__
     void topkGatingSoftmax(const DTYPE* input,
                            const bool* finished,
@@ -309,6 +319,35 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE) __global__
     {
         row_chunk_vec_ptr[ii] = ck_tile::vec_convert<float, DTYPE, ELTS_PER_LDG>(
             vec_thread_read_ptr[ii * THREADS_PER_ROW]);
+    }
+
+    // Process shared experts: use the thread subgroup working on this row
+    // to load shared experts at the row's end, compute sigmoid, and write to output
+    // All threads in THREADS_PER_ROW collaborate for maximum coalescing
+    if constexpr(NUM_SHARED_EXPERTS > 0 && SCORING_FUNC != SharedExpertScoringFunc::NONE)
+    {
+        // Each thread in the row subgroup processes one or more shared experts
+        // thread_group_idx ranges from 0 to THREADS_PER_ROW-1
+        // Shared experts are at thread_row_ptr[NUM_EXPERTS + shared_idx]
+
+#pragma unroll
+        for(int shared_idx = thread_group_idx; shared_idx < NUM_SHARED_EXPERTS; shared_idx += THREADS_PER_ROW)
+        {
+            // Load shared expert logit at row's end (perfectly coalesced across threads)
+            const float logit = static_cast<float>(thread_row_ptr[NUM_EXPERTS + shared_idx]);
+
+            // Apply scoring function using constexpr dispatch
+            float score;
+            if constexpr(SCORING_FUNC == SharedExpertScoringFunc::SIGMOID)
+            {
+                score = 1.0f / (1.0f + expf(-logit));
+            }
+            // Future scoring functions: else if constexpr(SCORING_FUNC == ...) { ... }
+
+            // Write directly to output buffer
+            const int out_idx = output_stride * thread_row + k + shared_idx;
+            output[out_idx] = score;
+        }
     }
 
     // First, do an in-thread max reduction to get the max value and its index.
@@ -474,7 +513,11 @@ struct TopkConstants
 };
 } // namespace detail
 
-template <typename DTYPE, int EXPERTS, int WARPS_PER_TB>
+template <typename DTYPE,
+          int EXPERTS,
+          int WARPS_PER_TB,
+          int NUM_SHARED_EXPERTS = 0,
+          SharedExpertScoringFunc SCORING_FUNC = SharedExpertScoringFunc::NONE>
 void topkGatingSoftmaxLauncherHelper(const DTYPE* input,
                                      const bool* finished,
                                      float* output,
@@ -502,7 +545,7 @@ void topkGatingSoftmaxLauncherHelper(const DTYPE* input,
     dim3 block_dim(WARP_SIZE, WARPS_PER_TB);
     if(need_renorm)
     {
-        topkGatingSoftmax<DTYPE, VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, true>
+        topkGatingSoftmax<DTYPE, VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, true, NUM_SHARED_EXPERTS, SCORING_FUNC>
             <<<num_blocks, block_dim, 0, stream>>>(input,
                                                    finished,
                                                    output,
@@ -518,7 +561,7 @@ void topkGatingSoftmaxLauncherHelper(const DTYPE* input,
     }
     else
     {
-        topkGatingSoftmax<DTYPE, VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, false>
+        topkGatingSoftmax<DTYPE, VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG, false, NUM_SHARED_EXPERTS, SCORING_FUNC>
             <<<num_blocks, block_dim, 0, stream>>>(input,
                                                    finished,
                                                    output,
@@ -534,8 +577,9 @@ void topkGatingSoftmaxLauncherHelper(const DTYPE* input,
     }
 }
 
-#define LAUNCH_SOFTMAX(NUM_EXPERTS, WARPS_PER_TB)                                           \
-    topkGatingSoftmaxLauncherHelper<DTYPE, NUM_EXPERTS, WARPS_PER_TB>(gating_output,        \
+#define LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, NUM_SHARED, SCORING)          \
+    topkGatingSoftmaxLauncherHelper<DTYPE, NUM_EXPERTS, WARPS_PER_TB, NUM_SHARED, SCORING>(\
+                                                                      gating_output,        \
                                                                       nullptr,              \
                                                                       topk_weights,         \
                                                                       topk_indicies,        \
@@ -550,6 +594,59 @@ void topkGatingSoftmaxLauncherHelper(const DTYPE* input,
                                                                       need_renorm,          \
                                                                       stream);
 
+// Helper macro that dispatches based on num_shared_experts and scoring function
+#define LAUNCH_SOFTMAX(NUM_EXPERTS, WARPS_PER_TB)                                           \
+    do {                                                                                    \
+        if(num_shared_experts == 0) {                                                       \
+            LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, 0,                       \
+                                      SharedExpertScoringFunc::NONE);                       \
+        } else if(scoring_func_enum == SharedExpertScoringFunc::SIGMOID) {                  \
+            switch(num_shared_experts) {                                                    \
+            case 1: LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, 1,               \
+                                              SharedExpertScoringFunc::SIGMOID); break;     \
+            case 2: LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, 2,               \
+                                              SharedExpertScoringFunc::SIGMOID); break;     \
+            case 4: LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, 4,               \
+                                              SharedExpertScoringFunc::SIGMOID); break;     \
+            case 8: LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, 8,               \
+                                              SharedExpertScoringFunc::SIGMOID); break;     \
+            default:                                                                        \
+                TORCH_CHECK(false, "Unsupported num_shared_experts: " +                    \
+                            std::to_string(num_shared_experts) +                            \
+                            ". Supported values: 1, 2, 4, 8");                              \
+            }                                                                               \
+        } else {                                                                            \
+            TORCH_CHECK(false, "Unsupported scoring function");                             \
+        }                                                                                   \
+    } while(0)
+
+// Kernel to apply sigmoid scoring to shared experts
+template <typename DTYPE, int TPB>
+__launch_bounds__(TPB) __global__
+    void applySharedExpertSigmoid(const DTYPE* shared_gating_input,
+                                  float* shared_weights,
+                                  const int num_tokens,
+                                  const int num_shared_experts,
+                                  const int input_stride,
+                                  const int output_stride,
+                                  const int shared_expert_start_idx)
+{
+    const int token_idx = blockIdx.x;
+    if(token_idx >= num_tokens)
+        return;
+
+    for(int expert_idx = threadIdx.x; expert_idx < num_shared_experts; expert_idx += TPB)
+    {
+        const int input_idx  = token_idx * input_stride + shared_expert_start_idx + expert_idx;
+        const int output_idx = token_idx * output_stride + expert_idx;
+
+        // Apply sigmoid: 1 / (1 + exp(-x))
+        const float x = static_cast<float>(shared_gating_input[input_idx]);
+        const float sigmoid_val = 1.0f / (1.0f + expf(-x));
+        shared_weights[output_idx] = sigmoid_val;
+    }
+}
+
 template <typename DTYPE>
 void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
                                      float* topk_weights,
@@ -558,6 +655,8 @@ void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
                                      float* softmax_workspace,
                                      const int num_tokens,
                                      const int num_experts,
+                                     const int num_shared_experts,
+                                     const std::string& shared_experts_scoring_func,
                                      const int topk,
                                      const int topk_weights_stride,
                                      const int topk_id_stride,
@@ -565,6 +664,22 @@ void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
                                      const bool need_renorm,
                                      hipStream_t stream)
 {
+    // Convert string to enum for template dispatch
+    SharedExpertScoringFunc scoring_func_enum = SharedExpertScoringFunc::NONE;
+    if(num_shared_experts > 0 && !shared_experts_scoring_func.empty())
+    {
+        if(shared_experts_scoring_func == "sigmoid")
+        {
+            scoring_func_enum = SharedExpertScoringFunc::SIGMOID;
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported shared expert scoring function: " + shared_experts_scoring_func);
+        }
+    }
+
+    // Note: num_experts here is the routing experts count (passed from wrapper)
+    // Shared experts are processed within the same kernel using template params
     static constexpr int WARPS_PER_TB = 8;
     switch(num_experts)
     {
@@ -595,6 +710,22 @@ void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
                                                      0,
                                                      num_experts,
                                                      need_renorm);
+
+        // Handle shared experts for non-power-of-2 case
+        if(num_shared_experts > 0 && !shared_experts_scoring_func.empty())
+        {
+            if(shared_experts_scoring_func == "sigmoid")
+            {
+                applySharedExpertSigmoid<DTYPE, TPB><<<num_tokens, TPB, 0, stream>>>(
+                    gating_output,
+                    topk_weights + topk,
+                    num_tokens,
+                    num_shared_experts,
+                    gating_token_stride,
+                    topk_weights_stride,
+                    num_experts);
+            }
+        }
     }
     }
 }
@@ -622,27 +753,42 @@ __global__ void moe_sum_kernel(scalar_t* __restrict__ out,         // [..., d]
 
 namespace aiter {
 
-void topk_softmax(torch::Tensor& topk_weights,         // [num_tokens, topk]
+void topk_softmax(torch::Tensor& topk_weights,         // [num_tokens, topk + num_shared_experts]
                   torch::Tensor& topk_indices,         // [num_tokens, topk]
                   torch::Tensor& token_expert_indices, // [num_tokens, topk]
-                  torch::Tensor& gating_output,        // [num_tokens, num_experts]
-                  bool need_renorm)
+                  torch::Tensor& gating_output,        // [num_tokens, num_experts + num_shared_experts]
+                  bool need_renorm,
+                  int num_shared_experts,
+                  const std::string& shared_expert_scoring_func)
 {
-    const int num_experts         = gating_output.size(-1);
-    const int num_tokens          = gating_output.numel() / num_experts;
-    const int topk                = topk_weights.size(-1);
+    const int num_experts_total   = gating_output.size(-1);
+    const int num_tokens          = gating_output.numel() / num_experts_total;
+    const int topk                = topk_indices.size(-1);  // Use indices size for topk
     const int topk_weights_stride = topk_weights.stride(0);
     const int topk_id_stride      = topk_indices.stride(0);
     const int gating_token_stride = gating_output.stride(0);
 
-    const bool is_pow_2          = (num_experts != 0) && ((num_experts & (num_experts - 1)) == 0);
-    const bool needs_workspace   = !is_pow_2 || num_experts > 256;
-    const int64_t workspace_size = needs_workspace ? num_tokens * num_experts : 0;
+    // Determine number of routing experts (experts for topk selection)
+    const int num_routing_experts = num_shared_experts > 0 ? num_experts_total - num_shared_experts : num_experts_total;
+
+    // Validate shared expert scoring function
+    if(num_shared_experts > 0 && !shared_expert_scoring_func.empty())
+    {
+        TORCH_CHECK(shared_expert_scoring_func == "sigmoid",
+                   "Only 'sigmoid' scoring function is supported for shared experts, got: " +
+                   shared_expert_scoring_func);
+    }
+
+    const bool is_pow_2          = (num_routing_experts != 0) && ((num_routing_experts & (num_routing_experts - 1)) == 0);
+    const bool needs_workspace   = !is_pow_2 || num_routing_experts > 256;
+    const int64_t workspace_size = needs_workspace ? num_tokens * num_routing_experts : 0;
 
     const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
     const hipStream_t stream = at::hip::getCurrentHIPStream();
     torch::Tensor softmax_workspace =
         torch::empty({workspace_size}, gating_output.options().dtype(torch::kFloat32));
+
+    // Process routing experts with softmax + topk, and shared experts with sigmoid in one kernel
     VLLM_DISPATCH_FLOATING_TYPES(gating_output.scalar_type(), "topk_softmax", [&] {
         using input_dtype = typename t2ck<scalar_t>::type;
         vllm::moe::topkGatingSoftmaxKernelLauncher(
@@ -652,7 +798,9 @@ void topk_softmax(torch::Tensor& topk_weights,         // [num_tokens, topk]
             token_expert_indices.data_ptr<int>(),
             softmax_workspace.data_ptr<float>(),
             num_tokens,
-            num_experts,
+            num_routing_experts,  // Only routing experts for softmax
+            num_shared_experts,   // Number of shared experts to process with sigmoid
+            shared_expert_scoring_func,
             topk,
             topk_weights_stride,
             topk_id_stride,

--- a/op_tests/test_moeTopkSoftmax.py
+++ b/op_tests/test_moeTopkSoftmax.py
@@ -409,6 +409,130 @@ def test_grouped_topk(
     return {"err": err, "us": us_aiter}
 
 
+@perftest(num_iters=2, num_warmup=1)
+def test_nofuse_shared(
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_shared_experts: int,
+):
+    """Reference implementation with shared experts using PyTorch."""
+    num_routing_experts = gating_output.size(-1) - num_shared_experts
+
+    # Split routing and shared expert logits
+    routing_logits = gating_output[:, :num_routing_experts]
+    shared_logits = gating_output[:, num_routing_experts:]
+
+    # Process routing experts with softmax + topk
+    routing_probs = torch.nn.functional.softmax(routing_logits.float(), dim=-1)
+    topk_weights_routing, topk_indices = routing_probs.topk(
+        k=topk, dim=-1, largest=True, sorted=True
+    )
+
+    if renormalize:
+        topk_weights_routing = topk_weights_routing / topk_weights_routing.sum(
+            dim=-1, keepdim=True
+        )
+
+    # Process shared experts with sigmoid
+    shared_weights = torch.sigmoid(shared_logits.float())
+
+    # Concatenate routing and shared weights
+    topk_weights = torch.cat([topk_weights_routing, shared_weights], dim=-1)
+
+    return topk_weights, topk_indices.to(dtypes.i32)
+
+
+@perftest()
+def test_fuse_shared(
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_shared_experts: int,
+):
+    """AITER kernel with shared experts."""
+    M = gating_output.shape[0]
+    total_output_size = topk + num_shared_experts
+
+    topk_weights = torch.empty_strided(
+        (M, total_output_size),
+        (total_output_size + 10, 1),
+        dtype=dtypes.fp32,
+        device=gating_output.device,
+    )
+    topk_ids = torch.empty_strided(
+        (M, topk), (topk + 10, 1), dtype=dtypes.i32, device=gating_output.device
+    )
+    token_expert_indicies = torch.empty_strided(
+        (M, topk), (topk + 10, 1), dtype=dtypes.i32, device=gating_output.device
+    )
+
+    aiter.topk_softmax(
+        topk_weights,
+        topk_ids,
+        token_expert_indicies,
+        gating_output,
+        renormalize,
+        num_shared_experts,
+        "sigmoid",
+    )
+
+    return topk_weights, topk_ids
+
+
+@benchmark()
+def test_topk_softmax_shared_experts(
+    dtype, token, num_routing_experts, num_shared_experts, topk, renormalize=True
+):
+    """Test topk_softmax with shared expert sigmoid scoring."""
+    num_experts = num_routing_experts + num_shared_experts
+    gating_output = torch.randn((token, num_experts + 10), dtype=dtype, device="cuda")
+    gating_output = gating_output[:, :num_experts]
+
+    # Reference (PyTorch)
+    (topk_weights_ref, topk_ids_ref), us_ref = test_nofuse_shared(
+        gating_output, topk, renormalize, num_shared_experts
+    )
+
+    # AITER kernel
+    (topk_weights_aiter, topk_ids_aiter), us_aiter = test_fuse_shared(
+        gating_output, topk, renormalize, num_shared_experts
+    )
+
+    ret = {}
+
+    # Split routing and shared weights for comparison
+    routing_weights_ref = topk_weights_ref[:, :topk]
+    routing_weights_aiter = topk_weights_aiter[:, :topk]
+
+    # Check routing weights (sort by indices first for fair comparison)
+    id_ref_sorted, _ref = torch.sort(topk_ids_ref)
+    id_aiter_sorted, _aiter = torch.sort(topk_ids_aiter)
+    w_ref_sorted = routing_weights_ref.gather(1, _ref)
+    w_aiter_sorted = routing_weights_aiter.gather(1, _aiter)
+
+    ret["routing_err"] = checkAllclose(
+        w_ref_sorted, w_aiter_sorted, msg="routing_weights [ref vs aiter]"
+    )
+    checkAllclose(id_ref_sorted, id_aiter_sorted, msg="routing_ids [ref vs aiter]")
+
+    # Check shared weights
+    if num_shared_experts > 0:
+        shared_weights_ref = topk_weights_ref[:, topk:]
+        shared_weights_aiter = topk_weights_aiter[:, topk:]
+        ret["shared_err"] = checkAllclose(
+            shared_weights_ref,
+            shared_weights_aiter,
+            msg=f"shared_weights [ref vs aiter]: {us_ref:>8.2f} us vs {us_aiter:>8.2f} us",
+        )
+
+    ret["us_ref"] = us_ref
+    ret["us_aiter"] = us_aiter
+    ret["speedup"] = us_ref / us_aiter if us_aiter > 0 else 0
+
+    return ret
+
+
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description="config input of test",
@@ -523,3 +647,36 @@ for token in args.token:
 df = pd.DataFrame(df)
 df_md = df.to_markdown(index=False)
 aiter.logger.info("moeTopkSoftmax_grouped_topk summary (markdown):\n%s", df_md)
+
+# Test shared expert sigmoid scoring
+aiter.logger.info("\n" + "=" * 70)
+aiter.logger.info("Testing topk_softmax with shared expert sigmoid scoring")
+aiter.logger.info("=" * 70)
+
+df = []
+# Test configurations: (num_routing_experts, num_shared_experts, topk, dtype, renormalize)
+shared_expert_configs = [
+    (8, 2, 2, dtypes.bf16, False),
+    (16, 2, 4, dtypes.bf16, True),
+    (32, 4, 8, dtypes.fp32, False),
+    (64, 4, 16, dtypes.fp32, True),
+    (8, 0, 2, dtypes.bf16, False),  # No shared experts (backward compatibility)
+    (16, 0, 4, dtypes.bf16, True),  # No shared experts (backward compatibility)
+]
+
+for token in [128, 256, 512, 1024]:
+    for num_routing, num_shared, topk, dtype, renorm in shared_expert_configs:
+        ret = test_topk_softmax_shared_experts(
+            dtype, token, num_routing, num_shared, topk, renorm
+        )
+        ret["token"] = token
+        ret["routing_experts"] = num_routing
+        ret["shared_experts"] = num_shared
+        ret["topk"] = topk
+        ret["dtype"] = str(dtype)
+        ret["renorm"] = renorm
+        df.append(ret)
+
+df = pd.DataFrame(df)
+df_md = df.to_markdown(index=False)
+aiter.logger.info("moeTopkSoftmax_shared_experts summary (markdown):\n%s", df_md)


### PR DESCRIPTION
## Motivation
Used in qwen3.5 for topk_softmax on routing expert, and sigmoid for shared expert in fused shared expert case
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
