### PR TITLE
Fix use-after-free in cktile blockscale GEMM x_scale handling

### DIFF
--- a/csrc/ck_gemm_a8w8_blockscale/include/gemm_a8w8_blockscale_cktile_common.cuh
+++ b/csrc/ck_gemm_a8w8_blockscale/include/gemm_a8w8_blockscale_cktile_common.cuh
@@ -295,14 +295,18 @@ __forceinline__ torch::Tensor gemm_a8w8_blockscale_cktile_impl(torch::Tensor& XQ
     ck_tile::QuantGemmHostArgs args;
     args.a_ptr = XQ.data_ptr();
 
+    // Declared at function scope so the transposed tensor stays alive
+    // through the async kernel launch.
+    torch::Tensor x_scale_t;
+
     if(eight_warps && !PreshuffleB)
     {
-        torch::Tensor x_scale_t = x_scale.transpose(0, 1).contiguous().view(x_scale.sizes());
-        args.aq_ptr             = x_scale_t.data_ptr();
+        x_scale_t   = x_scale.transpose(0, 1).contiguous().view(x_scale.sizes());
+        args.aq_ptr = x_scale_t.data_ptr();
     }
     else if(!eight_warps && PreshuffleB)
     {
-        torch::Tensor x_scale_t =
+        x_scale_t =
             x_scale.view({x_scale.size(1), x_scale.size(0)}).transpose(0, 1).contiguous();
         args.aq_ptr = x_scale_t.data_ptr();
     }


### PR DESCRIPTION
The 8-warp and PreshuffleB code paths in gemm_a8w8_blockscale_cktile_impl created a temporary torch::Tensor x_scale_t inside a local scope to hold the transposed x_scale data. When the scope ended, x_scale_t was destroyed and its GPU memory was freed back to the CUDA caching allocator, but args.aq_ptr still pointed to the now-freed memory. The subsequent async GEMM kernel launch then read from a dangling pointer.

In isolated tests the allocator typically did not reuse the block, so the kernel read stale-but-correct data. Under memory pressure (e.g. vLLM inference), the allocator recycled the block immediately, causing the kernel to read garbage and produce wrong output. The bug was confirmed by injecting memory poisoning: the allocator returned the exact same block, and the kernel produced max_abs_err ~21000 vs ~0.000008 in the baseline.

Fix: move x_scale_t to function scope so it stays alive through the kernel launch.

A longer-term alternative may be to switch AQLayout_8Warps from ColumnMajor to RowMajor and remove the transpose entirely. Initial analysis suggests the CK pipeline and block GEMM may support RowMajor AQ for 8-warp kernels, but this has not been fully validated and would need thorough testing.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
