### PR TITLE
Update topk.py to support non-power-of-2 experts (Kimi-K2) for long contexts 

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -88,7 +88,9 @@ def biased_grouped_topk(
     # moe_fused_gate requires num_experts to be a power of 2.
     # For models with non-power-of-2 expert counts (e.g. Kimi-K2.5 with 384
     # experts), always use biased_grouped_topk_hip which has no such constraint.
-    num_experts_is_power_of_2 = num_experts > 0 and (num_experts & (num_experts - 1)) == 0
+    num_experts_is_power_of_2 = (
+        num_experts > 0 and (num_experts & (num_experts - 1)) == 0
+    )
     if token_num <= cu_num * 212 or not num_experts_is_power_of_2:
         return biased_grouped_topk_hip(
             gating_output,


### PR DESCRIPTION
## Problem

SGLang crashes when serving **Kimi-K2.5-MXFP4** (384 experts) for long sequence lengths > 54272 (212*256)

```
RuntimeError: num_experts must be a power of 2, but got 384
```

The crash only occurs at long inputs (e.g. `--random-input 70000`) and not at shorter ones (e.g. `--random-input 32768`), making it a subtle sequence-length-dependent failure.

**Call chain:**
```
biased_grouped_topk()  [aiter/ops/topk.py]
  → moe_fused_gate()   ← crashes: requires num_experts to be a power of 2
```

## Root Cause

`aiter/ops/topk.py::biased_grouped_topk()` dispatches to one of two kernels based on token count:

```python
if token_num <= cu_num * 212:
    return biased_grouped_topk_hip(...)   # no power-of-2 constraint
else:
    return moe_fused_gate(...)            # requires power-of-2 num_experts ← CRASH
```

Kimi-K2.5 has [**384 experts**](https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/config.json#L72) (384 = 3 × 128, not a power of 2). Short sequences stay under the `cu_num * 212`  threshold and use `biased_grouped_topk_hip` without issue. Long sequences that exceed the threshold (*54272*) are routed to `moe_fused_gate`, which enforces the power-of-2 constraint and raises a `RuntimeError`.

## Fix

Add a power-of-2 guard before the dispatch. When `num_experts` is not a power of 2, always use `biased_grouped_topk_hip` regardless of token count so it handles arbitrary expert counts correctly.

```python
num_experts = gating_output.shape[1]
num_experts_is_power_of_2 = num_experts > 0 and (num_experts & (num_experts - 1)) == 0

if token_num <= cu_num * 212 or not num_experts_is_power_of_2:
    return biased_grouped_topk_hip(...)
else:
    return moe_fused_gate(...)
```

The fix is minimal and surgical. It does not disable aiter, does not touch sglang, and has no impact on models whose expert count is already a power of 2 (DeepSeek V3/R1, etc.). It enables long context for MoE models that contain non power of 2 number of experts like Kimi-K2 to run on the MI355X.

## File Changed

- `aiter/aiter/ops/topk.py` — `biased_grouped_topk()`, 3-line change

## Verification

Benchmark run with `--random-input 70000` (above the threshold that previously triggered the crash):

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 4
Successful requests:                     32
Benchmark duration (s):                  137.66
Total input tokens:                      2240000
Total input text tokens:                 2240000
Total generated tokens:                  6400
Total generated tokens (retokenized):    6401
Request throughput (req/s):              0.23
Input token throughput (tok/s):          16272.54
Output token throughput (tok/s):         46.49
Peak output token throughput (tok/s):    160.00
Peak concurrent requests:                8
Total token throughput (tok/s):          16319.03
Concurrency:                             4.00
==================================================
```

No crash. Correct output tokens returned.

## Testing Commands
Server launch:
```bash
SGLANG_AITER_FP8_PREFILL_ATTN=1 SGLANG_AITER_MLA_PERSIST=1 AITER_MXFP4_MOE_SF=1 SGLANG_USE_AITER=1 SGLANG_INT4_WEIGHT=0 SGLANG_MOE_PADDING=1 SGLANG_SET_CPU_AFFINITY=1 SGLANG_ROCM_FUSED_DECODE_MLA=1 SGLANG_USE_ROCM700A=1 nohup python3 -m sglang.launch_server --model-path /models/Kimi-K2.5-MXFP4/ --tensor-parallel-size 4 --trust-remote-code --host 0.0.0.0 --port 8000 --log-requests --mem-fraction-static 0.95 --chunked-prefill-size 131072 --attention-backend aiter --disable-radix-cache --kv-cache-dtype fp8_e4m3 &
```

Benchmarking:
```bash
input_tokens=70000
output_tokens=200
max_concurrency=4
num_prompts=$((max_concurrency*8))
python3 -m sglang.bench_serving     --host localhost     --port 8000     --model /models/Kimi-K2.5-MXFP4/     --dataset-name random     --random-input ${input_tokens}     --random-output ${output_tokens}     --random-range-ratio 1.0     --max-concurrency ${max_concurrency}     --num-prompt ${num_prompts}
```