### PR TITLE
[Bugfix] Handle expert groups > 32 in biased_grouped_topk

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -97,6 +97,18 @@ def biased_grouped_topk(
         )
     else:
         topk = topk_ids.shape[1]
+        experts_per_group = gating_output.shape[1] // num_expert_group
+        if experts_per_group > 32:
+            return biased_grouped_topk_hip(
+                gating_output,
+                correction_bias,
+                topk_weights,
+                topk_ids,
+                num_expert_group,
+                topk_group,
+                need_renorm,
+                routed_scaling_factor,
+            )
         assert need_renorm, "Renormalization is required for moe_fused_gate."
         return moe_fused_gate(
             gating_output,


### PR DESCRIPTION
## Summary

Fix a crash in `biased_grouped_topk()` when models have more than 32 experts per group. Falls back to `biased_grouped_topk_hip` (which has no expert limit) instead of `moe_fused_gate` (which is limited to 32 experts per group).

## Motivation

When running MoE models with large expert counts (e.g., GLM-5 with 256 routed experts in a single group), AITER crashes with:

```
RuntimeError: Per group experts: num_experts / num_expert_group = (256) exceeds the maximum supported (32)
```

This occurs when `token_num > cu_num * 212` (approximately 64,448 tokens on MI300X), which triggers the `moe_fused_gate` code path.

## Root Cause

`biased_grouped_topk()` has two internal paths:
1. `biased_grouped_topk_hip` — HIP assembly kernel, **no expert limit**, used when `token_num ≤ cu_num * 212`
2. `moe_fused_gate` — C++ kernel, **32-expert-per-group limit**, used for larger batches

For models like GLM-5 (`topk_group=1`, `n_routed_experts=256`), we get `experts_per_group = 256/1 = 256 > 32`. Long prefills exceeding 64K tokens trigger the `moe_fused_gate` path, which crashes.

## Changes

Added a guard in the `else` branch of `biased_grouped_topk()` that checks `experts_per_group > 32` and falls back to `biased_grouped_topk_hip` instead of `moe_fused_gate`:

```python
experts_per_group = gating_output.shape[1] // num_expert_group
if experts_per_group > 32:
    return biased_grouped_topk_hip(
        gating_output,
        correction_bias,
        topk_weights,
        topk_ids,
        num_expert_group,
        topk_group,
        need_renorm,
        routed_scaling_factor,
    )
```

The HIP kernel works for all batch sizes. Performance may be slightly lower for very large batches compared to `moe_fused_gate`, but it produces correct expert routing.

## Testing

- [x] Tested with GLM-5 (256 experts, 1 group) on MI300X
- [x] Verified no crash with long prefills (>64K tokens)
- [x] Verified output quality is preserved (no repetitive text)

## Performance

| Configuration | Before | After |
|---------------|--------|-------|
| GLM-5, BS=1024, prefill >64K tokens | Crash | Works correctly |

The HIP kernel fallback may have slightly lower throughput for very large batches compared to `moe_fused_gate`, but this is acceptable given it enables support for models that would otherwise crash.

## Dependencies

- [x] No new third-party dependencies added

## Breaking Changes

None. This fix only affects the code path for models with `experts_per_group > 32`, which previously crashed.