### PR TITLE
[Bugfix][gfx950] Force 1-stage MoE assembly kernels for FP8 blockscale

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -833,8 +833,14 @@ def get_2stage_cfgs(
             doweight_stage1,
         ) in fused_moe_1stage_dict[get_gfx()]:
             if q_type == QuantType.per_1x128:
-                # for fp8 blockscale, ck has better performance so disable assembly kernel
-                run_1stage = token > 32 and (inter_dim % 128 == 0)
+                if get_gfx() == "gfx950":
+                    # gfx950 has no pre-compiled 2-stage CK MoE kernels;
+                    # JIT-compiled ones crash with HIP runtime error.
+                    # Always use 1-stage assembly kernels on gfx950.
+                    run_1stage = inter_dim % 128 == 0
+                else:
+                    # for fp8 blockscale, ck has better performance so disable assembly kernel
+                    run_1stage = token > 32 and (inter_dim % 128 == 0)
             elif q_type == QuantType.per_Token and q_dtype_w == dtypes.i8:
                 run_1stage = token > 32
             elif q_type == QuantType.per_Token and q_dtype_w == dtypes.fp8:


### PR DESCRIPTION
## Summary

- gfx950 (MI355X) has no pre-compiled 2-stage CK MoE kernels in `hsa/gfx950/fmoe_2stages/`. When the existing heuristic in `get_2stage_cfgs()` falls through to the 2-stage path (token <= 32), JIT compilation produces incompatible kernels that crash at runtime with `HIP runtime error: invalid argument`.
- Fix: for `QuantType.per_1x128` on gfx950, always use the 1-stage assembly kernel path (`run_1stage = inter_dim % 128 == 0`), bypassing the problematic 2-stage CK path. The 1-stage assembly kernels in `hsa/gfx950/fmoe/` work correctly for all token counts.

## Reproduction

Run DeepSeek V3.2 (MoE with FP8 block-scale quantization) on MI355X with AITER enabled. The crash occurs during decode when token count is small (<= 32) and the 2-stage CK MoE kernel is selected.

## Test Plan

- [x] Verified fix on MI355X (gfx950) with DeepSeek V3.2 TP4
- [x] Full ITT benchmark sweep passes with ~220+ tok/s output throughput
- [ ] No change in behavior on gfx942 (MI300X) since the fix only applies to gfx950

Made with [Cursor](https://cursor.com)