### PR TITLE
CI: Build Triton wheel once and share across test shards

### DIFF
--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -22,19 +22,27 @@ if [[ "$BUILD_TRITON" == "1" ]]; then
     echo
     echo "==== Install triton ===="
     pip uninstall -y triton || true
-    # Pin triton to a known-good commit to avoid CI breakage from
-    # upstream changes (e.g. AMD codegen regressions in triton-lang/triton).
-    TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
-    git clone https://github.com/triton-lang/triton || true
-    cd triton
-    git checkout "$TRITON_COMMIT"
-    pip install -r python/requirements.txt
+
+    TRITON_WHEEL_DIR=${TRITON_WHEEL_DIR:-}
+    if [[ -n "$TRITON_WHEEL_DIR" ]] && ls "$TRITON_WHEEL_DIR"/*.whl 1>/dev/null 2>&1; then
+        echo "Installing triton from pre-built wheel in $TRITON_WHEEL_DIR"
+        pip install "$TRITON_WHEEL_DIR"/*.whl
+    else
+        echo "Building triton from source..."
+        # Pin triton to a known-good commit to avoid CI breakage from
+        # upstream changes (e.g. AMD codegen regressions in triton-lang/triton).
+        TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
+        git clone https://github.com/triton-lang/triton || true
+        cd triton
+        git checkout "$TRITON_COMMIT"
+        pip install -r python/requirements.txt
+        MAX_JOBS=64 pip --retries=10 --default-timeout=60 install .
+        cd ..
+    fi
     pip install filecheck
     # NetworkX is a dependency of Triton test selection script
     # `.github/scripts/select_triton_tests.py`.
     pip install networkx
-    MAX_JOBS=64 pip --retries=10 --default-timeout=60 install .
-    cd ..
 else
     echo
     echo "[SKIP] Triton installation skipped because BUILD_TRITON=$BUILD_TRITON"

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -54,12 +54,66 @@ jobs:
           name: triton_shards
           path: triton_shard_*.list
 
+  # Build Triton wheel once, shared by all shard jobs via artifact
+  build-triton:
+    if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
+    name: Build Triton Wheel
+    runs-on: aiter-1gpu-runner
+    needs: [check-signal]
+    env:
+      DOCKER_IMAGE: "rocm/pytorch:latest"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Docker login
+        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
+
+      - name: Build Triton wheel in Docker
+        run: |
+          set -ex
+          mkdir -p triton-wheels
+
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+
+          docker run --rm \
+            --device=/dev/kfd $DEVICE_FLAG \
+            --shm-size=16G \
+            --group-add $(getent group render | cut -d: -f3) \
+            --group-add $(getent group video | cut -d: -f3) \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            ${{ env.DOCKER_IMAGE }} \
+            bash -c '
+              set -ex
+              pip config set global.default-timeout 60
+              pip config set global.retries 10
+              TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
+              git clone https://github.com/triton-lang/triton
+              cd triton
+              git checkout "$TRITON_COMMIT"
+              pip install -r python/requirements.txt
+              MAX_JOBS=64 pip wheel --no-deps -w /workspace/triton-wheels .
+            '
+
+      - name: Upload Triton wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: triton-wheel
+          path: triton-wheels/*.whl
+
   # Step 2: matrix jobs consume shard file lists
   triton:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
     name: Triton Tests (1 GPU) / Shard ${{ matrix.shard }}
     runs-on: ${{ matrix.runner }}
-    needs: [split_triton_tests, check-signal]
+    needs: [split_triton_tests, build-triton, check-signal]
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +157,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: triton_shards
+
+      - name: Download Triton wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: triton-wheel
+          path: triton-wheels
 
       - name: List test shard files
         run: |
@@ -149,6 +209,7 @@ jobs:
           set -ex
           echo "Setting up Aiter and Triton..."
           docker exec \
+          -e TRITON_WHEEL_DIR=/workspace/triton-wheels \
           -w /workspace \
           triton_test \
           ./.github/scripts/build_aiter_triton.sh


### PR DESCRIPTION
Related to #2347 https://github.com/ROCm/frameworks-internal/issues/15752

### Problem
Each of the 8 Triton test shards independently compiles Triton from source (~15 min each), wasting 7× GPU runner minutes on redundant builds.

### Solution
Add a dedicated `build-triton` job that:
1. Compiles Triton once into a wheel inside the Docker container
2. Uploads the wheel as a GitHub Actions artifact
3. All shard jobs download and `pip install` the pre-built wheel instead of building from source

### Workflow flow (before → after)
```
Before: check-signal → split_tests → 8× shards (each builds Triton ~15 min + runs tests)
After:  check-signal → split_tests ─┐
                     → build-triton ─┴→ 8× shards (pip install wheel ~30s + runs tests)
```

### Backward compatibility
`build_aiter_triton.sh` checks for `TRITON_WHEEL_DIR` env var. If a pre-built wheel is found, it installs from wheel; otherwise falls back to building from source. Existing callers are unaffected.