### PR TITLE
[Bugfix] fix use after free issue in moe_sorting_fwd

### DIFF
--- a/csrc/py_itfs_ck/moe_sorting_kernels.cu
+++ b/csrc/py_itfs_ck/moe_sorting_kernels.cu
@@ -33,12 +33,13 @@ void moe_sorting_fwd(torch::Tensor& topk_ids,          // [m, topk]
     const hipStream_t stream = at::hip::getCurrentHIPStream();
 
     int workspace_size = moe_sorting_get_workspace_size(num_tokens, num_experts, topk, dispatch_policy);
-    void* ws_ptr       = nullptr;
+    torch::Tensor ws;
+    void* ws_ptr = nullptr;
     if(workspace_size > 0)
     {
-        auto ws = torch::empty({workspace_size},
+        ws     = torch::empty({workspace_size},
                                torch::TensorOptions().dtype(dtype).device(device_of(topk_ids)));
-        ws_ptr  = ws.data_ptr();
+        ws_ptr = ws.data_ptr();
     }
 
     moe_sorting(


### PR DESCRIPTION
## Motivation

This PR fixed the use after free issue with torch::Tensor ws. 

## Technical Details

Declare torch::Tensor ws outside of curly braces {} to make the lifecycle of the buffer pointed to by ws_ptr valid.

## Test Plan
1) Run op_tests/test_moe_sorting.py tests.
2) Run Qwen3.5 inference to trigger this code snippet without any memory issue such as crash.

## Test Result
1) op_tests/test_moe_sorting.py passed.
2) Qwen3.5 inference with sglang, no memory issue such as crash, gsm8k accuracy passed.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
