### PR TITLE
fea: Refactor the allreduce framework

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -45,20 +45,35 @@ def is_weak_contiguous(inp: torch.Tensor):
     )
 
 
+class _GpuPtrBuffer:
+    """Wraps a raw GPU pointer as a buffer with __cuda_array_interface__
+    so that torch.as_tensor can create a tensor view without copying."""
+
+    def __init__(self, ptr: int, nbytes: int):
+        self.ptr = ptr
+        self.nbytes = nbytes
+        self.__cuda_array_interface__ = {
+            "data": (ptr, False),
+            "shape": (nbytes,),
+            "typestr": "<u1",
+            "strides": None,
+            "version": 3,
+        }
+
+
 class CustomAllreduce:
 
     _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
 
-    # max_size: max supported allreduce size
+    SHMEM_INPUT_BUFFER_SIZE = int(1.2 * 1024**3)  # 1.2 GB
+    SHMEM_OUTPUT_BUFFER_SIZE = int(1.2 * 1024**3)  # 1.2 GB
+    SHMEM_TMP_BUFFER_SIZE = int(2.4 * 1024**3)  # 2.4 GB
+    _IPC_FALLBACK_MAX_SIZE = 8192 * 1024 * 8 * 2  # ~128 MB, IPC fallback only
+
     def __init__(
         self,
         group: ProcessGroup,
         device: Union[int, str, torch.device],
-        max_size=8192
-        * 1024
-        * 8
-        * 2,  # In allreduce 2stage writemode, use 2x tmp buffer
-        enable_register_for_capturing: bool = True,
     ) -> None:
         """
         Args:
@@ -69,9 +84,22 @@ class CustomAllreduce:
         It is the caller's responsibility to make sure each communicator
         is bind to a unique device, and all communicators in this group
         are in the same node.
+
+        Buffer allocation is automatic:
+        - Primary path uses MoRI SHMEM symmetric memory (1.2 GB input/output,
+          2.4 GB tmp) with no IPC handles needed for static buffers.
+        - Falls back to IPC-based buffers if MoRI SHMEM is unavailable.
+        - Eager mode: input address varies each call, so a d2d copy to the
+          pre-registered static buffer is required before the allreduce kernel.
+        - Graph mode: the input address is captured once and replayed at a
+          fixed address, so the kernel operates directly on the captured input
+          with zero d2d copy.  Graph-captured addresses are registered via IPC
+          at the end of capture (they are not SHMEM allocations).
         """
         self._IS_CAPTURING = False
         self.disabled = True
+        self._use_shmem = False
+        self._shmem_ptrs = []
 
         if not custom_ar:
             # disable because of missing custom allreduce library
@@ -116,21 +144,6 @@ class CustomAllreduce:
         assert isinstance(device, torch.device)
         self.device = device
 
-        # device_ids = get_cuda_visible_devices()
-
-        # physical_device_id = device_ids[device.index]
-        # tensor = torch.tensor([physical_device_id], dtype=torch.int, device="cpu")
-        # gather_list = [
-        #     torch.tensor([0], dtype=torch.int, device="cpu") for _ in range(world_size)
-        # ]
-        # dist.all_gather(gather_list, tensor, group=self.group)
-        # physical_device_ids = [t.item() for t in gather_list]
-
-        # test nvlink first, this will filter out most of the cases
-        # where custom allreduce is not supported
-        # this checks hardware and driver support for NVLink
-        # assert current_platform.is_cuda() or current_platform.is_rocm()
-        # fully_connected = current_platform.is_full_nvlink(physical_device_ids)
         fully_connected = True
         if world_size > 2 and not fully_connected:
             logger.warning(
@@ -139,30 +152,133 @@ class CustomAllreduce:
                 "specify disable_custom_all_reduce=True explicitly."
             )
             return
-        # test P2P capability, this checks software/cudaruntime support
-        # this is expensive to compute at the first time
-        # then we cache the result
-        # On AMD GPU, p2p is always enabled between XGMI connected GPUs
-        # if not current_platform.is_rocm() and not _can_p2p(rank, world_size):
-        #     logger.warning(
-        #         "Custom allreduce is disabled because your platform lacks "
-        #         "GPU P2P capability or P2P test failed. To silence this "
-        #         "warning, specify disable_custom_all_reduce=True explicitly.")
-        #     return
 
         self.disabled = False
-        self.enable_register_for_capturing = enable_register_for_capturing
-        # buffers memory are owned by this Python class and passed to C++
-        # meta data composes of two parts: meta data for synchronization
-        # (256 bytes) and a temporary buffer for storing intermediate
-        # allreduce results.
-        # if current_platform.is_rocm():
+        self.rank = rank
+        self.world_size = world_size
+        self.fully_connected = fully_connected
+
+        try:
+            self._init_with_shmem(rank, world_size, fully_connected)
+        except Exception as e:
+            print(f"MoRI SHMEM unavailable ({e}), falling back to IPC path.")
+            self._init_with_ipc(rank, world_size, fully_connected)
+
+    def _init_with_shmem(self, rank, world_size, fully_connected):
+        """Initialize using MoRI SHMEM symmetric memory (no IPC handles)."""
+        import mori.shmem as shmem
+
+        self._use_shmem = True
+        self.enable_register_for_capturing = True
+
+        # Ensure the SHMEM static heap is large enough for our buffers.
+        # Total: meta(signal + tmp) + input + output ≈ 4.8 GB
+        import os
+
+        required = (
+            ops.meta_size()
+            + self.SHMEM_TMP_BUFFER_SIZE
+            + self.SHMEM_INPUT_BUFFER_SIZE
+            + self.SHMEM_OUTPUT_BUFFER_SIZE
+        )
+        # 10 % headroom for alignment
+        required = int(required * 1.1)
+        if "MORI_SHMEM_HEAP_SIZE" not in os.environ:
+            os.environ["MORI_SHMEM_HEAP_SIZE"] = str(required)
+
+        # Initialize MoRI SHMEM: bootstrap via UniqueId broadcast
+        if rank == 0:
+            uid_list = [shmem.shmem_get_unique_id()]
+        else:
+            uid_list = [None]
+        dist.broadcast_object_list(uid_list, src=0, group=self.group)
+        shmem.shmem_init_attr(
+            shmem.MORI_SHMEM_INIT_WITH_UNIQUEID,
+            rank,
+            world_size,
+            uid_list[0],
+        )
+
+        meta_signal_size = ops.meta_size()
+        meta_total = meta_signal_size + self.SHMEM_TMP_BUFFER_SIZE
+
+        # Allocate symmetric memory via MoRI SHMEM
+        meta_ptr = shmem.shmem_malloc(meta_total)
+        input_ptr = shmem.shmem_malloc(self.SHMEM_INPUT_BUFFER_SIZE)
+        output_ptr = shmem.shmem_malloc(self.SHMEM_OUTPUT_BUFFER_SIZE)
+        assert meta_ptr != 0, "shmem_malloc failed for meta buffer"
+        assert input_ptr != 0, "shmem_malloc failed for input buffer"
+        assert output_ptr != 0, "shmem_malloc failed for output buffer"
+        self._shmem_ptrs = [meta_ptr, input_ptr, output_ptr]
+
+        # Zero-initialize the Signal region (synchronization flags must start at 0)
+        meta_view = torch.as_tensor(_GpuPtrBuffer(meta_ptr, meta_total), device="cuda")
+        meta_view[:meta_signal_size].zero_()
+        torch.cuda.synchronize(self.device)
+
+        # Wrap SHMEM pointers as torch tensors for the existing C++ eager-mode
+        # copy path (hipMemcpyAsync to/from registered buffers)
+        self.meta = meta_view
+        self.input_buffer = torch.as_tensor(
+            _GpuPtrBuffer(input_ptr, self.SHMEM_INPUT_BUFFER_SIZE), device="cuda"
+        )
+        self.output_buffer = torch.as_tensor(
+            _GpuPtrBuffer(output_ptr, self.SHMEM_OUTPUT_BUFFER_SIZE), device="cuda"
+        )
+
+        # Rank-data: GPU buffer for per-rank pointer tuples used by kernels
+        self.rank_data = torch.empty(
+            8 * 1024 * 1024, dtype=torch.uint8, device=self.device
+        )
+
+        # Resolve P2P peer addresses for every buffer
+        my_pe = shmem.shmem_mype()
+        meta_peers = [
+            shmem.shmem_ptr_p2p(meta_ptr, my_pe, pe) for pe in range(world_size)
+        ]
+        input_peers = [
+            shmem.shmem_ptr_p2p(input_ptr, my_pe, pe) for pe in range(world_size)
+        ]
+        output_peers = [
+            shmem.shmem_ptr_p2p(output_ptr, my_pe, pe) for pe in range(world_size)
+        ]
+
+        # Initialize C++ CustomAllreduce with pre-resolved peer pointers
+        self._ptr = ops.init_custom_ar_with_peer_ptrs(
+            meta_ptr,
+            self.rank_data,
+            meta_peers,
+            rank,
+            world_size,
+            fully_connected,
+        )
+
+        # Register input/output buffers with pre-resolved peer pointers
+        ops.register_input_buffer_with_peer_ptrs(
+            self._ptr,
+            input_ptr,
+            input_peers,
+        )
+        ops.register_output_buffer_with_peer_ptrs(
+            self._ptr,
+            output_ptr,
+            output_peers,
+        )
+
+        logger.info(
+            "CustomAllreduce initialized with MoRI SHMEM: "
+            "input=%.1fGB, output=%.1fGB, tmp=%.1fGB",
+            self.SHMEM_INPUT_BUFFER_SIZE / 1024**3,
+            self.SHMEM_OUTPUT_BUFFER_SIZE / 1024**3,
+            self.SHMEM_TMP_BUFFER_SIZE / 1024**3,
+        )
+
+    def _init_with_ipc(self, rank, world_size, fully_connected):
+        """Fallback: initialize using the original IPC handle exchange path."""
+        self.enable_register_for_capturing = True
+        max_size = self._IPC_FALLBACK_MAX_SIZE
         self.meta = ops.allocate_meta_buffer(ops.meta_size() + max_size)
-        # This is a pre-registered IPC buffer. In eager mode, input tensors
-        # are first copied into this buffer before allreduce is performed
         self.input_buffer = torch.empty(max_size, dtype=torch.uint8, device=self.device)
-        # This is a pre-registered IPC buffer for output. In eager mode, kernel
-        # writes results to this buffer, then it's copied to the actual output
         self.output_buffer = torch.empty(
             max_size, dtype=torch.uint8, device=self.device
         )
@@ -174,9 +290,10 @@ class CustomAllreduce:
         self.rank_data = torch.empty(
             8 * 1024 * 1024, dtype=torch.uint8, device=self.device
         )
-        self.max_size = max_size
-        self.rank = rank
-        self.world_size = world_size
+        # max_size = max input bytes the allreduce can handle.
+        # In 2-stage write mode, tmp needs 2x, and input/tmp share the same
+        # raw size in the IPC path, so effective max is raw_size // 2.
+        self.max_size = max_size // 2
         handle = ops.get_meta_buffer_ipc_handle(self.meta)
         shard_data = (
             handle,  # ipc handle to base ptr
@@ -188,16 +305,17 @@ class CustomAllreduce:
         self._ptr = ops.init_custom_ar(
             self.meta, self.rank_data, handles, offsets, rank, self.fully_connected
         )
-        # Register both input and output buffers
-        self.register_input_buffer(self.input_buffer)
-        self.register_output_buffer(self.output_buffer)
+        self._register_input_buffer_ipc(self.input_buffer)
+        self._register_output_buffer_ipc(self.output_buffer)
 
     @contextmanager
     def capture(self):
-        """
-        The main responsibility of this context manager is the
-        `register_graph_buffers` call at the end of the context.
-        It records all the buffer addresses used in the CUDA graph.
+        """Context manager for CUDA graph capture.
+
+        During capture the kernel operates directly on the captured input
+        address (no d2d copy).  After capture completes, all captured
+        addresses are registered via IPC so that peer GPUs can access them
+        during graph replay.
         """
         try:
             self._IS_CAPTURING = True
@@ -205,29 +323,19 @@ class CustomAllreduce:
         finally:
             self._IS_CAPTURING = False
             if not self.disabled:
-                self.register_graph_buffers()
+                self._register_graph_buffers()
+
+    # ---- IPC helpers ----
+    # Used by _init_with_ipc for static buffers AND by _register_graph_buffers
+    # for graph-captured addresses (which are regular PyTorch allocations, not
+    # SHMEM, so IPC is still needed for P2P address resolution).
 
     def _get_ipc_meta(self, inp: torch.Tensor):
-        # if current_platform.is_rocm():
-        if 1:
-            # _share_cuda_() doesn't accept meta buffer not allocated from
-            # PyTorch cache allocator, use direct HIP call to get IPC handle
-            handle = ops.get_meta_buffer_ipc_handle(inp)
-            shard_data = (
-                handle,  # ipc handle to base ptr
-                0,  # offset of base ptr
-            )
-        else:
-            data = inp.untyped_storage()._share_cuda_()
-            shard_data = (
-                data[1],  # ipc handle to base ptr
-                data[3],  # offset of base ptr
-            )
+        handle = ops.get_meta_buffer_ipc_handle(inp)
+        shard_data = (handle, 0)
         return self._gather_ipc_meta(shard_data)
 
     def _gather_ipc_meta(self, shard_data):
-        # Note: don't use `[[None]] * self.world_size` here
-        # because it will create a list of the same reference
         all_data: List[Optional[Any]] = [[None] for i in range(self.world_size)]
         all_data[self.rank][0] = shard_data
 
@@ -238,10 +346,6 @@ class CustomAllreduce:
                 all_data[i], src=rank, group=self.group, device="cpu"
             )
 
-        # we cannot directly use `dist.all_gather_object` here
-        # because it is incompatible with `gloo` backend under inference mode.
-        # see https://github.com/pytorch/pytorch/issues/126032 for details.
-
         handles = []
         offsets = []
         for i in range(len(all_data)):
@@ -249,34 +353,41 @@ class CustomAllreduce:
             offsets.append(all_data[i][0][1])  # type: ignore
         return handles, offsets
 
-    def register_input_buffer(self, inp: torch.Tensor):
+    def _register_input_buffer_ipc(self, inp: torch.Tensor):
         handles, offsets = self._get_ipc_meta(inp)
         ops.register_input_buffer(self._ptr, inp, handles, offsets)
 
-    def register_output_buffer(self, out: torch.Tensor):
+    def _register_output_buffer_ipc(self, out: torch.Tensor):
         handles, offsets = self._get_ipc_meta(out)
         ops.register_output_buffer(self._ptr, out, handles, offsets)
 
-    def register_graph_buffers(self):
+    def _register_graph_buffers(self):
+        """Register graph-captured addresses via IPC after capture ends.
+
+        Graph-captured tensor addresses come from PyTorch's caching allocator
+        (not SHMEM), so IPC handles are still needed for cross-GPU access.
+        """
         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
         handles, offsets = self._gather_ipc_meta((handle, offset))
         logger.info("Registering %d cuda graph addresses", len(offset))
         ops.register_graph_buffers(self._ptr, handles, offsets)
 
+    def _max_input_bytes(self) -> int:
+        """Max input bytes the custom allreduce can handle."""
+        if self._use_shmem:
+            return self.SHMEM_INPUT_BUFFER_SIZE
+        return self.max_size
+
     def should_custom_ar(self, inp: torch.Tensor):
         if self.disabled:
             return False
         inp_size = inp.numel() * inp.element_size()
-        # custom allreduce requires input byte size to be multiples of 16
         if inp_size % 16 != 0:
             return False
         if not is_weak_contiguous(inp):
             return False
-        # for 4 or more non NVLink-capable GPUs, custom allreduce provides
-        # little performance improvement over NCCL.
-        # In allreduce 2stage writemode, use 2x tmp buffer
         if self.world_size == 2 or self.fully_connected:
-            return inp_size <= (self.max_size / 2)
+            return inp_size <= self._max_input_bytes()
         return False
 
     def should_custom_ag(self, inp: torch.Tensor):
@@ -287,10 +398,9 @@ class CustomAllreduce:
             return False
         if not is_weak_contiguous(inp):
             return False
-        # all_gather output = input * world_size, so the per-rank input
-        # must fit within max_size / world_size
+        # all_gather output = input * world_size
         if self.world_size == 2 or self.fully_connected:
-            return inp_size <= (self.max_size / (self.world_size * 2))
+            return inp_size <= (self._max_input_bytes() / self.world_size)
         return False
 
     def all_reduce(
@@ -300,14 +410,16 @@ class CustomAllreduce:
         out: Optional[torch.Tensor] = None,
         use_new: bool = True,
         open_fp8_quant: bool = False,
-        registered_input: bool = False,
-        registered_output: bool = False,
+        registered: bool = False,
     ):
         """Performs an out-of-place all reduce.
 
-        If registered is True, this assumes inp's pointer is already
-        IPC-registered. Otherwise, inp is first copied into a pre-registered
-        buffer.
+        If registered is False (eager mode), inp is first d2d-copied into the
+        pre-registered static buffer before allreduce, and the result is copied
+        back to *out*.
+        If registered is True (graph mode), the kernel operates directly on
+        *inp* whose address was captured and later IPC-registered, so no d2d
+        copy takes place.
         """
         if out is None:
             out = torch.empty_like(inp)
@@ -317,42 +429,30 @@ class CustomAllreduce:
             out,
             use_new,
             open_fp8_quant,
-            None if registered_input else self.input_buffer,
-            None if registered_output else self.output_buffer,
+            None if registered else self.input_buffer,
+            None if registered else self.output_buffer,
         )
         return out
 
     def custom_all_reduce(
         self, input: torch.Tensor, use_new: bool = True, open_fp8_quant: bool = False
     ) -> Optional[torch.Tensor]:
-        # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
             return None
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
+                # Graph capture: kernel uses the captured input address directly
                 return self.all_reduce(
                     input,
                     use_new=use_new,
                     open_fp8_quant=open_fp8_quant,
-                    registered_input=self.enable_register_for_capturing,
-                    registered_output=self.enable_register_for_capturing,
+                    registered=True,
                 )
             else:
-                # if warm up, mimic the allocation pattern
-                # since custom allreduce is out-of-place
+                # Warmup: mimic the allocation pattern (out-of-place)
                 return torch.zeros_like(input)
-        else:
-            # note: outside of cuda graph context,
-            # custom allreduce incurs a cost of cudaMemcpy, which should
-            # be small(<=1% of overall latency) compared to the performance
-            # gains of using custom kernels
-            return self.all_reduce(
-                input,
-                use_new=use_new,
-                open_fp8_quant=open_fp8_quant,
-                registered_input=False,
-                registered_output=False,
-            )
+        # Eager: d2d copy to static buffer → allreduce → copy back
+        return self.all_reduce(input, use_new=use_new, open_fp8_quant=open_fp8_quant)
 
     def reduce_scatter(
         self,
@@ -371,14 +471,13 @@ class CustomAllreduce:
     def custom_reduce_scatter(
         self, input: torch.Tensor, output: torch.Tensor
     ) -> Optional[torch.Tensor]:
-        # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
             return None
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
                 return self.reduce_scatter(input, output, registered=True)
-        else:
-            return self.reduce_scatter(input, output, registered=False)
+            return None
+        return self.reduce_scatter(input, output)
 
     def _allgather_out_shape(self, inp: torch.Tensor, dim: int):
         ndim = inp.dim()
@@ -419,11 +518,8 @@ class CustomAllreduce:
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
                 return self.all_gather_reg(inp, dim=dim)
-            else:
-                print("allgather capture hipgraph error")
-                return torch.zeros_like(inp)
-        else:
-            return self.all_gather_unreg(inp, dim=dim)
+            return torch.zeros_like(inp)
+        return self.all_gather_unreg(inp, dim=dim)
 
     def fused_ar_rms(
         self,
@@ -485,7 +581,6 @@ class CustomAllreduce:
         eps: float,
         use_1stage: bool,
     ) -> Optional[torch.Tensor]:
-        # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
             return None
         if self._IS_CAPTURING:
@@ -498,17 +593,14 @@ class CustomAllreduce:
                     registered=True,
                     use_1stage=use_1stage,
                 )
-            else:
-                return torch.zeros_like(input), torch.zeros_like(input)
-        else:
-            return self.fused_ar_rms(
-                input,
-                residual_inp,
-                w=weight,
-                eps=eps,
-                registered=False,
-                use_1stage=use_1stage,
-            )
+            return torch.zeros_like(input), torch.zeros_like(input)
+        return self.fused_ar_rms(
+            input,
+            residual_inp,
+            w=weight,
+            eps=eps,
+            use_1stage=use_1stage,
+        )
 
     def custom_fused_ar_rms_quant(
         self,
@@ -518,7 +610,6 @@ class CustomAllreduce:
         eps: float,
         use_1stage: bool,
     ):
-        # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
             return None
         if self._IS_CAPTURING:
@@ -532,27 +623,35 @@ class CustomAllreduce:
                     use_1stage=use_1stage,
                     post_per_token_quant=True,
                 )
-            else:
-                dummy_out = torch.zeros(input.shape, dtype=fp8, device=input.device)
-                dummy_scale_out = torch.zeros(
-                    input.shape[:-1] + (1,), dtype=torch.float32, device=input.device
-                )
-                return dummy_out, torch.zeros_like(input), dummy_scale_out
-        else:
-            return self.fused_ar_rms(
-                input,
-                residual_inp,
-                w=weight,
-                eps=eps,
-                registered=False,
-                use_1stage=use_1stage,
-                post_per_token_quant=True,
+            dummy_out = torch.zeros(input.shape, dtype=fp8, device=input.device)
+            dummy_scale_out = torch.zeros(
+                input.shape[:-1] + (1,), dtype=torch.float32, device=input.device
             )
+            return dummy_out, torch.zeros_like(input), dummy_scale_out
+        return self.fused_ar_rms(
+            input,
+            residual_inp,
+            w=weight,
+            eps=eps,
+            use_1stage=use_1stage,
+            post_per_token_quant=True,
+        )
 
     def close(self):
         if not self.disabled and self._ptr:
             ops.dispose(self._ptr)
             self._ptr = 0
+        if self._shmem_ptrs:
+            try:
+                import mori.shmem as shmem
+
+                for ptr in self._shmem_ptrs:
+                    if ptr:
+                        shmem.shmem_free(ptr)
+                shmem.shmem_finalize()
+            except Exception:
+                pass
+            self._shmem_ptrs.clear()
 
     def __del__(self):
         self.close()

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -198,6 +198,36 @@ def all_reduce_rmsnorm_quant_(
 def dispose(_fa: int) -> None: ...
 
 
+# Peer-pointer based APIs (transport-agnostic, no IPC handles)
+
+
+@compile_ops("module_custom_all_reduce")
+def init_custom_ar_with_peer_ptrs(
+    meta_ptr: int,
+    rank_data: torch.Tensor,
+    meta_peer_ptrs: List[int],
+    rank: int,
+    world_size: int,
+    fully_connected: bool,
+) -> int: ...
+
+
+@compile_ops("module_custom_all_reduce")
+def register_input_buffer_with_peer_ptrs(
+    _fa: int,
+    self_ptr: int,
+    peer_ptrs: List[int],
+) -> None: ...
+
+
+@compile_ops("module_custom_all_reduce")
+def register_output_buffer_with_peer_ptrs(
+    _fa: int,
+    self_ptr: int,
+    peer_ptrs: List[int],
+) -> None: ...
+
+
 @compile_ops("module_custom_all_reduce")
 def meta_size() -> int: ...
 

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -1876,6 +1876,29 @@ class CustomAllreduce
         }
     }
 
+    // Peer-pointer based constructor: accepts pre-resolved peer pointers directly,
+    // without any IPC handle exchange. The caller (e.g. MoRI SHMEM) is responsible
+    // for obtaining peer-accessible addresses.
+    CustomAllreduce(Signal* meta,
+                    void* rank_data,
+                    size_t rank_data_sz,
+                    const std::vector<int64_t>& meta_peer_ptrs,
+                    int rank,
+                    int world_size,
+                    bool fully_connected = true)
+        : rank_(rank),
+          world_size_(world_size),
+          full_nvlink_(fully_connected),
+          self_sg_(meta),
+          d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+          d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData))
+    {
+        for(int i = 0; i < world_size_; i++)
+        {
+            sg_.signals[i] = reinterpret_cast<Signal*>(meta_peer_ptrs[i]);
+        }
+    }
+
     char* open_ipc_handle(const void* ipc_handle)
     {
         auto [it, new_handle] = ipc_handles_.insert({*((IPC_KEY*)ipc_handle), nullptr});
@@ -1989,6 +2012,36 @@ class CustomAllreduce
             {
                 data.ptrs[i] = self;
             }
+        }
+        auto d_data = d_rank_data_base_++;
+        HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
+        output_buffers_[self] = d_data;
+    }
+
+    // Register input buffer with pre-resolved peer pointers (no IPC handles).
+    void register_input_buffer_with_peer_ptrs(const std::vector<int64_t>& peer_ptrs,
+                                              void* self)
+    {
+        check_rank_data_capacity();
+        RankData data;
+        for(int i = 0; i < world_size_; i++)
+        {
+            data.ptrs[i] = reinterpret_cast<const void*>(peer_ptrs[i]);
+        }
+        auto d_data = d_rank_data_base_++;
+        HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
+        input_buffer[self] = d_data;
+    }
+
+    // Register output buffer with pre-resolved peer pointers (no IPC handles).
+    void register_output_buffer_with_peer_ptrs(const std::vector<int64_t>& peer_ptrs,
+                                               void* self)
+    {
+        check_rank_data_capacity();
+        RankData data;
+        for(int i = 0; i < world_size_; i++)
+        {
+            data.ptrs[i] = reinterpret_cast<const void*>(peer_ptrs[i]);
         }
         auto d_data = d_rank_data_base_++;
         HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -68,6 +68,20 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
 
 void dispose(fptr_t _fa);
 int64_t meta_size();
+
+// Peer-pointer based APIs (transport-agnostic, no IPC handles)
+fptr_t init_custom_ar_with_peer_ptrs(int64_t meta_ptr,
+                                     torch::Tensor& rank_data,
+                                     const std::vector<int64_t>& meta_peer_ptrs,
+                                     int64_t rank,
+                                     int64_t world_size,
+                                     bool fully_connected);
+void register_input_buffer_with_peer_ptrs(fptr_t _fa,
+                                          int64_t self_ptr,
+                                          const std::vector<int64_t>& peer_ptrs);
+void register_output_buffer_with_peer_ptrs(fptr_t _fa,
+                                           int64_t self_ptr,
+                                           const std::vector<int64_t>& peer_ptrs);
 void register_input_buffer(fptr_t _fa,
                            torch::Tensor& t,
                            const std::vector<torch::Tensor>& handles,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -470,7 +470,25 @@ namespace py = pybind11;
           py::arg("handles"),                                                                  \
           py::arg("offsets"));                                                                 \
     m.def("allocate_meta_buffer", &aiter::allocate_meta_buffer, py::arg("size"));              \
-    m.def("get_meta_buffer_ipc_handle", &aiter::get_meta_buffer_ipc_handle, py::arg("inp"));
+    m.def("get_meta_buffer_ipc_handle", &aiter::get_meta_buffer_ipc_handle, py::arg("inp")); \
+    m.def("init_custom_ar_with_peer_ptrs",                                                    \
+          &aiter::init_custom_ar_with_peer_ptrs,                                              \
+          py::arg("meta_ptr"),                                                                \
+          py::arg("rank_data"),                                                               \
+          py::arg("meta_peer_ptrs"),                                                          \
+          py::arg("rank"),                                                                    \
+          py::arg("world_size"),                                                              \
+          py::arg("fully_connected"));                                                        \
+    m.def("register_input_buffer_with_peer_ptrs",                                             \
+          &aiter::register_input_buffer_with_peer_ptrs,                                       \
+          py::arg("_fa"),                                                                     \
+          py::arg("self_ptr"),                                                                \
+          py::arg("peer_ptrs"));                                                              \
+    m.def("register_output_buffer_with_peer_ptrs",                                            \
+          &aiter::register_output_buffer_with_peer_ptrs,                                      \
+          py::arg("_fa"),                                                                     \
+          py::arg("self_ptr"),                                                                \
+          py::arg("peer_ptrs"));
 
 #define CUSTOM_PYBIND                                                                           \
     m.def("wvSpltK",                                                                            \

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -622,6 +622,51 @@ void register_graph_buffers(fptr_t _fa,
     fa->register_graph_buffers(handles, offsets);
 }
 
+// Peer-pointer based APIs: accept pre-resolved peer pointers directly,
+// agnostic to how the pointers were obtained (IPC, MoRI SHMEM, etc.).
+
+fptr_t init_custom_ar_with_peer_ptrs(int64_t meta_ptr,
+                                     torch::Tensor& rank_data,
+                                     const std::vector<int64_t>& meta_peer_ptrs,
+                                     int64_t rank,
+                                     int64_t world_size,
+                                     bool fully_connected)
+{
+    if(world_size > 8)
+        throw std::invalid_argument("world size > 8 is not supported");
+    if(world_size % 2 != 0)
+        throw std::invalid_argument("Odd num gpus is not supported for now");
+    if(rank < 0 || rank >= world_size)
+        throw std::invalid_argument("invalid rank passed in");
+    if(static_cast<int>(meta_peer_ptrs.size()) != world_size)
+        throw std::invalid_argument("meta_peer_ptrs size must equal world_size");
+
+    return (fptr_t) new aiter::CustomAllreduce(
+        reinterpret_cast<aiter::Signal*>(meta_ptr),
+        rank_data.data_ptr(),
+        rank_data.numel(),
+        meta_peer_ptrs,
+        rank,
+        world_size,
+        fully_connected);
+}
+
+void register_input_buffer_with_peer_ptrs(fptr_t _fa,
+                                          int64_t self_ptr,
+                                          const std::vector<int64_t>& peer_ptrs)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    fa->register_input_buffer_with_peer_ptrs(peer_ptrs, reinterpret_cast<void*>(self_ptr));
+}
+
+void register_output_buffer_with_peer_ptrs(fptr_t _fa,
+                                           int64_t self_ptr,
+                                           const std::vector<int64_t>& peer_ptrs)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    fa->register_output_buffer_with_peer_ptrs(peer_ptrs, reinterpret_cast<void*>(self_ptr));
+}
+
 #ifdef USE_ROCM
 
 void free_meta_buffer(void* buffer) { HIP_CALL(hipFree(buffer)); }

--- a/op_tests/multigpu_tests/test_allgather.py
+++ b/op_tests/multigpu_tests/test_allgather.py
@@ -230,16 +230,14 @@ def allgather_perftest(
 
 l_dtype = ["bf16"]
 l_shape = [
-    # (4096, 2048)
     (1345,),
-    # # (16, 512),
     (128, 7168),
-    # (32, 7168),
     # exceeds max_size/world_size but satisfies all other custom ag
     # conditions (contiguous, 16-byte aligned) — should fallback to RCCL
     # threshold: 64 MB (2 GPU) / 32 MB (4 GPU) / 16 MB (8 GPU)
     # this shape = 4097*8192*2 bytes ≈ 64.015 MB, exceeds even the 2-GPU threshold
     (4097, 8192),
+    (16384, 7168),
 ]
 
 parser = argparse.ArgumentParser(description="config input of test")

--- a/op_tests/multigpu_tests/test_allreduce_latency.py
+++ b/op_tests/multigpu_tests/test_allreduce_latency.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+import os
+import torch
+import torch.distributed as dist
+from multiprocessing import Pool, freeze_support, set_start_method
+
+from aiter.dist.communication_op import tensor_model_parallel_all_reduce
+from aiter.dist.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    ensure_model_parallel_initialized,
+    get_tp_group,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+
+set_start_method("spawn", force=True)
+
+NUM_WARMUP = 5
+NUM_ITERS = 20
+TP_SIZE = 8
+HIDDEN = 8192
+DTYPE = torch.bfloat16
+ELEM_BYTES = 2  # bf16
+
+SIZES_MB = [128, 256, 512, 1024]
+
+
+def _measure_per_iter_us(fn, num_warmup=NUM_WARMUP, num_iters=NUM_ITERS):
+    """Return a list of per-iteration latencies (us) after warmup."""
+    for _ in range(num_warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    latencies = []
+    for _ in range(num_iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        latencies.append(start.elapsed_time(end) * 1000.0)  # ms -> us
+    return latencies
+
+
+def bench_worker(rank_id, tp_size, distributed_init_method):
+    device = torch.device(f"cuda:{rank_id}")
+    torch.cuda.set_device(device)
+
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=tp_size,
+        rank=rank_id,
+        distributed_init_method=distributed_init_method,
+    )
+    ensure_model_parallel_initialized(tp_size, 1)
+
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, device=device), group=group)
+    torch.cuda.synchronize()
+
+    results = {}
+    for size_mb in SIZES_MB:
+        num_elems = size_mb * 1024 * 1024 // ELEM_BYTES
+        rows = num_elems // HIDDEN
+        shape = (rows, HIDDEN)
+
+        x_aiter = torch.randn(shape, dtype=DTYPE, device=device)
+        aiter_lats = _measure_per_iter_us(
+            lambda: tensor_model_parallel_all_reduce(x_aiter)
+        )
+
+        dist.barrier(group=group)
+
+        x_rccl = torch.randn(shape, dtype=DTYPE, device=device)
+        rccl_lats = _measure_per_iter_us(lambda: dist.all_reduce(x_rccl, group=group))
+
+        dist.barrier(group=group)
+
+        del x_aiter, x_rccl
+        torch.cuda.empty_cache()
+
+        results[size_mb] = (aiter_lats, rccl_lats)
+
+    if dist.is_initialized():
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        torch.cuda.empty_cache()
+
+    return rank_id, results
+
+
+if __name__ == "__main__":
+    freeze_support()
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "49373"
+
+    init_method = get_distributed_init_method(get_ip(), get_open_port())
+    pool = Pool(processes=TP_SIZE)
+
+    futures = []
+    for i in range(TP_SIZE):
+        futures.append(pool.apply_async(bench_worker, args=(i, TP_SIZE, init_method)))
+    pool.close()
+    pool.join()
+
+    all_results = [f.get() for f in futures]
+
+    hdr = f"{'Size':>8} | {'Shape':>16} | {'AITER (us)':>12} | {'RCCL (us)':>12}"
+    sep = "-" * len(hdr)
+
+    print()
+    print(sep)
+    print(hdr)
+    print(sep)
+
+    for size_mb in SIZES_MB:
+        rows = size_mb * 1024 * 1024 // ELEM_BYTES // HIDDEN
+        shape_str = f"({rows}, {HIDDEN})"
+
+        aiter_per_iter = [
+            max(r[1][size_mb][0][i] for r in all_results) for i in range(NUM_ITERS)
+        ]
+        rccl_per_iter = [
+            max(r[1][size_mb][1][i] for r in all_results) for i in range(NUM_ITERS)
+        ]
+        avg_aiter = sum(aiter_per_iter) / NUM_ITERS
+        avg_rccl = sum(rccl_per_iter) / NUM_ITERS
+
+        label = f"{size_mb} MB" if size_mb < 1024 else f"{size_mb // 1024} GB"
+        print(
+            f"{label:>8} | {shape_str:>16} | " f"{avg_aiter:>12.1f} | {avg_rccl:>12.1f}"
+        )
+
+    print(sep)
+    print(f"  dtype=bf16  hidden={HIDDEN}  tp={TP_SIZE}  mode=eager")
+    print(
+        f"  warmup={NUM_WARMUP}  iters={NUM_ITERS}  "
+        f"metric=avg of per-iter max latency across {TP_SIZE} GPUs"
+    )
+    print()

--- a/op_tests/multigpu_tests/test_custom_allreduce.py
+++ b/op_tests/multigpu_tests/test_custom_allreduce.py
@@ -117,7 +117,7 @@ def test_allreduce_custom(
 
 
 l_dtype = ["fp16", "bf16"]
-l_shape = [(128, 8192)]
+l_shape = [(128, 8192), (8192, 8192), (16384, 7168)]
 
 parser = argparse.ArgumentParser(description="config input of test")
 parser.add_argument(

--- a/op_tests/multigpu_tests/test_custom_allreduce_fp8.py
+++ b/op_tests/multigpu_tests/test_custom_allreduce_fp8.py
@@ -125,19 +125,19 @@ def test_allreduce_custom(
     rets = [el.get() for el in rets]
 
     a = ref.clone().cuda()
-    a.to(float)
     qtype = QuantType.per_1x128
     quant_function = get_hip_quant(qtype)
-    a = a.reshape(8192, 128)
-    fp8_output, scale = quant_function(a, quant_dtype=dtypes.fp8)
+    fp8_output, scale = quant_function(a.reshape(-1, 128), quant_dtype=dtypes.fp8)
     fp32_output = fp8_output.to(torch.float) * scale
-    fp16_quanted_ref = fp32_output.to(torch.float16).reshape(128, 8192)
+    fp16_quanted_ref = fp32_output.to(torch.float16).reshape(shape)
+    rows_per_gpu = shape[0] // tp_size
     for out, us in rets:
         gpu_id = out.device.index
         ori_ref = ref.clone()
-        ori_tensor = ori_ref[gpu_id * 16 : (gpu_id + 1) * 16][:]
+        s = gpu_id * rows_per_gpu
+        e = s + rows_per_gpu
         c = fp16_quanted_ref.clone()
-        c[gpu_id * 16 : (gpu_id + 1) * 16][:] = ori_tensor
+        c[s:e] = ori_ref[s:e]
         msg = f"test_allreduce_custom: {shape=} {dtype=} {withGraph=} {us:>8.2f}"
         checkAllclose(c.cpu(), out.cpu(), msg=msg)
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The current AITER custom allreduce relies on HIP IPC handles for cross-GPU buffer sharing, which requires hardcoded `max_size` for buffer allocation. This limits the maximum input size to ~128 MB and forces a fallback to RCCL for larger tensors, making custom allreduce unusable during prefill where tensor sizes can reach hundreds of MBs to GBs.

This PR replaces the IPC handle mechanism with MoRI SHMEM (symmetric shared memory) to:
- **Enable larger input sizes**: SHMEM static heap allows input/output buffers up to 1.2 GB and temporary buffers up to 2.4 GB, removing the previous ~128 MB ceiling.
- **More robust memory management**: Eliminate hardcoded `max_size` by leveraging SHMEM's dynamic allocation, making buffer sizing automatic and transparent.
- **Replace RCCL in prefill**: With large tensor support, custom allreduce and allgather can now serve as drop-in replacements for RCCL in the prefill phase.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

### C++ Layer (AITER and MoRI fully decoupled)

C++ functions accept raw pointers directly, with no awareness of MoRI SHMEM. This ensures AITER remains completely decoupled from MoRI at the C++ level.

- **`custom_all_reduce.cuh`**: Added a new `CustomAllreduce` constructor accepting peer pointer arrays (`std::vector<int64_t>`) instead of `hipIpcMemHandle_t`, and new `register_input_buffer_with_peer_ptrs` / `register_output_buffer_with_peer_ptrs` methods.
- **`custom_all_reduce.cu`**: Implemented corresponding C++ wrapper functions (`init_custom_ar_with_peer_ptrs`, `register_input_buffer_with_peer_ptrs`, `register_output_buffer_with_peer_ptrs`).
- **`custom_all_reduce.h`**: Added declarations for the new functions.
- **`rocm_ops.hpp`**: Added pybind11 bindings to expose the new functions to Python.

### Python Layer

- **`ops/custom_all_reduce.py`**: Added Python op stubs for the new peer-pointer-based C++ functions.
- **`dist/device_communicators/custom_all_reduce.py`**: Major refactoring:
  - Removed `max_size`, `enable_register_for_capturing`, and `use_shmem` from the constructor. The new constructor signature is simply `__init__(self, group, device)`.
  - Added `_init_with_shmem()`: allocates SHMEM buffers, resolves P2P peer addresses via `shmem.shmem_ptr_p2p`, and initializes the C++ backend with peer pointers.
  - Added `_init_with_ipc()` as automatic fallback when SHMEM is unavailable.
  - Dynamically sets `MORI_SHMEM_HEAP_SIZE` env var based on calculated buffer requirements.
  - Correctly handles eager mode (D2D copy to SHMEM buffer) vs CUDA graph mode (direct operation on captured input address with IPC registration).

### Supported operations

- **Allreduce**: Fully supports large input sizes for prefill.
- **Allgather**: Fully supports large input sizes for prefill.
- **Reduce-scatter**: Supports large input sizes but **not recommended for production use** — no performance optimization has been done yet. The primary motivation for supporting it is to enable CUDA graph capture, since RCCL's reduce_scatter does not support CUDA graph. Performance is currently worse than RCCL for both small and large sizes.
- **Fused allreduce + RMSNorm**: No changes to the dispatch logic. The fused kernel has strict shape constraints (`n <= 16384`, `total_bytes < 64 MB`) that limit it to decode-phase sizes, so it is not affected by this PR.

### Tests

- **`test_allreduce_latency.py`** (new): Benchmark script comparing AITER custom allreduce vs RCCL allreduce latency across multiple tensor sizes in eager mode.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- [x] Run `test_custom_allreduce.py` to verify correctness of custom allreduce with SHMEM path.
- [x] Run `test_allreduce_latency.py` to benchmark AITER vs RCCL latency at 128 MB, 256 MB, 512 MB, and 1 GB (bf16, 8 GPUs, eager mode).

## Test Result

<!-- Briefly summarize test outcomes. -->

Allreduce latency benchmark on 8 GPUs, bf16, eager mode (per-iter max latency across 8 GPUs, averaged over 20 iterations):

| Size | Shape | AITER (us) | RCCL (us) |
|------|-------|------------|-----------|
| 128 MB | (8192, 8192) | 788.7 | 867.3 |
| 256 MB | (16384, 8192) | 1472.8 | 1535.0 |
| 512 MB | (32768, 8192) | 2841.8 | 2872.5 |
| 1 GB | (65536, 8192) | 5547.2 | 5545.2 |

AITER custom allreduce now successfully handles tensor sizes up to 1 GB, achieving comparable latency to RCCL. At smaller sizes (128 MB, 256 MB), AITER shows a slight advantage. At 1 GB the two are on par. Further performance optimizations are planned as follow-up work.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.