### PR TITLE
[TRITON] Improve RDNA config selection for FA

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -80,7 +80,12 @@ def get_fwd_prefill_configs(autotune: bool):
             BLOCK_N = 64 if arch.name == "gfx1100" else 32
             return [
                 triton.Config(
-                    {"BLOCK_M": 128, "BLOCK_N": BLOCK_N, "PRE_LOAD_V": False, "waves_per_eu" : 6},
+                    {
+                        "BLOCK_M": 128,
+                        "BLOCK_N": BLOCK_N,
+                        "PRE_LOAD_V": False,
+                        "waves_per_eu": 6,
+                    },
                     num_stages=1,
                     num_warps=8,
                 ),


### PR DESCRIPTION
## Motivation

Improve config selection for Flash Attention Prefill for RDNA GPUs.

## Evaluation

Head Dim : 128

### gfx1151
| Batch size | Seq Len | FLOPS (current) | FLOPS (PR) |
| :--- | :--- | :--- | :--- |
| 32 | 512 | 1.29 | 1.79 |
| 16 | 1024 | 2.71 | 5.04 |
| 8 | 2048 | 4.53 | 11.58 |
| 4 | 4096 | 5.24 | 15.93 |
| 2 | 8192 | 5.61 | 16.97 |
| 1 | 16384 | 6.02 | 18.12 |
| 1 | 32768 | 5.02 | 18.00 |

### gfx1100
| Batch size | Seq Len | FLOPS (current) | FLOPS (PR) |
| :--- | :--- | :--- | :--- |
| 32 | 512 | 13.15 | 20.99 |
| 16 | 1024 | 16.97 | 35.77 |
| 8 | 2048 | 24.02 | 51.89 |
| 4 | 4096 | 26.50 | 59.24 |
| 2 | 8192 | 27.06 | 60.84 |
| 1 | 16384 | 27.37 | 59.68 |
| 1 | 32768 | 28.74 | 54.15 |

### gfx1201
| Batch size | Seq Len | FLOPS (current) | FLOPS (PR) |
| :--- | :--- | :--- | :--- |
| 32 | 512 | 18.81 | 30.00 |
| 16 | 1024 | 22.90 | 52.70 |
| 8 | 2048 | 26.72 | 69.31 |
| 4 | 4096 | 29.54 | 79.06 |
| 2 | 8192 | 31.22 | 82.98 |
| 1 | 16384 | 37.65 | 83.21 |
| 1 | 32768 | 27.24 | 79.71 |