### PR TITLE
Fix kernel map collision on MGPU context

### DIFF
--- a/csrc/cpp_itfs/mha_bwd.cu
+++ b/csrc/cpp_itfs/mha_bwd.cu
@@ -371,6 +371,11 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
     AiterAsmKernel* impl_ptr_post   = nullptr;
     static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
 
+    // Include device ID in cache key so each GPU gets its own loaded module
+    int current_device;
+    HIP_CALL(hipGetDevice(&current_device));
+    std::string dev_prefix = std::to_string(current_device) + ":";
+
     auto it_pre = pre_cfgs->find(pre_kernel);
     if(it_pre != pre_cfgs->end())
     {
@@ -378,8 +383,9 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         const char* name    = cfg.knl_name.c_str();
         const char* co_name = cfg.co_name.c_str();
         ts_odo              = cfg.ts;
+        std::string key     = dev_prefix + name;
 
-        auto result = impl_ptr_map.emplace(name, nullptr);
+        auto result = impl_ptr_map.emplace(key, nullptr);
         if(result.second)
         {
             result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
@@ -399,8 +405,9 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
         const char* name    = cfg.knl_name.c_str();
         const char* co_name = cfg.co_name.c_str();
         ts_kv               = cfg.ts;
+        std::string key     = dev_prefix + name;
 
-        auto result = impl_ptr_map.emplace(name, nullptr);
+        auto result = impl_ptr_map.emplace(key, nullptr);
         if(result.second)
         {
             result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);
@@ -422,8 +429,9 @@ float fmha_v3_bwd(mha_bwd_args a, const ck_tile::stream_config& s)
             const char* name    = cfg.knl_name.c_str();
             const char* co_name = cfg.co_name.c_str();
             ts_dq               = cfg.ts;
+            std::string key     = dev_prefix + name;
 
-            auto result = impl_ptr_map.emplace(name, nullptr);
+            auto result = impl_ptr_map.emplace(key, nullptr);
             if(result.second)
             {
                 result.first->second = std::make_unique<AiterAsmKernel>(name, co_name);

--- a/csrc/cpp_itfs/mha_fwd.cu
+++ b/csrc/cpp_itfs/mha_fwd.cu
@@ -242,11 +242,17 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
     static thread_local std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
         impl_ptr_map;
 
+    // Include device ID in cache key so each GPU gets its own loaded module
+    int current_device;
+    HIP_CALL(hipGetDevice(&current_device));
+    std::string dev_prefix = std::to_string(current_device) + ":";
+
     const auto& cfg     = it->second;
     const char* name    = cfg.knl_name.c_str();
     std::string co_name = get_kernel_co_name(cfg.co_name, arch_id);
+    std::string key     = dev_prefix + name;
 
-    auto result = impl_ptr_map.emplace(name, nullptr);
+    auto result = impl_ptr_map.emplace(key, nullptr);
     if(result.second)
     {
         result.first->second = std::make_unique<AiterAsmKernel>(name, co_name.c_str());


### PR DESCRIPTION
## Motivation

Note: This is **not necessary** with https://github.com/ROCm/aiter/pull/2221 so I do think ideally that gets merged instead. This is just required as long as we use the standard hip module load.

In TE's JAX integration, the MGPU tests fail due to multiple devices registering separate kernels in the `impl_ptr_map`, leading to devices attempting to launch kernels that may have come from other devices resulting in a mismatched device ordinal launch error.

## Technical Details

Adds device ID to map key

## Test Plan

Verify TE JAX integration tests pass

## Test Result

TE JAX integration tests do indeed pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
