### PR TITLE
Select a bigger kernel if token per expert is large

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -843,9 +843,11 @@ def get_2stage_cfgs(
                 run_1stage = token < 256
 
         block_m = (
-            ( 
-                (64 if token*topk/expert > 32 else BLOCK_SIZE_M)
-                if q_type == QuantType.per_1x128 and use_g1u1 and q_dtype_w == torch.float8_e4m3fn
+            (
+                (64 if token * topk / expert > 32 else BLOCK_SIZE_M)
+                if q_type == QuantType.per_1x128
+                and use_g1u1
+                and q_dtype_w == torch.float8_e4m3fn
                 else BLOCK_SIZE_M
             )
             if run_1stage

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -843,7 +843,11 @@ def get_2stage_cfgs(
                 run_1stage = token < 256
 
         block_m = (
-            BLOCK_SIZE_M
+            ( 
+                (64 if token*topk/expert > 32 else BLOCK_SIZE_M)
+                if q_type == QuantType.per_1x128 and use_g1u1 and q_dtype_w == torch.float8_e4m3fn
+                else BLOCK_SIZE_M
+            )
             if run_1stage
             else (
                 (64 if token > 32 else 16)


### PR DESCRIPTION
## Motivation

Default asm kernel 32x256 blockscale kernel is not the best default choice if token count is very big. We want to fit as many tokens processing inside a single TG as possible.

## Technical Details

Chose m=64 for asm for  1x128 quant and fp8 q type.

## Test Plan
Manual moe tests and Aiter CI.

## Test Result

Observe 64x256 kernels being picked for the relevant blockscale tests and no failures  otherwise.
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
