### PR TITLE
Initial Windows ROCm build support for FlashAttention-2 ROCm/aiter Triton backend

### DIFF
--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -33,7 +33,14 @@ from unittest.mock import patch
 
 import torch
 import torch.distributed
-from torch.distributed import Backend, ProcessGroup
+try:
+    from torch.distributed import Backend, ProcessGroup
+except ImportError:
+    # torch.distributed is not available on all Windows ROCm builds.
+    # Set to None so the module can be imported; code paths that actually
+    # use these names are guarded by distributed-availability checks.
+    Backend = None      # type: ignore[assignment]
+    ProcessGroup = None  # type: ignore[assignment]
 
 import os
 from aiter import logger

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -368,6 +368,13 @@ if multiprocessing.current_process().name == "MainProcess":
 def validate_and_update_archs():
     archs = os.getenv("GPU_ARCHS", "native").split(";")
     archs = [arch.strip() for arch in archs]
+
+    if "native" in archs and sys.platform == "win32":
+        # hipcc on Windows does not support --offload-arch=native;
+        # resolve it to the actual gfx string detected from hipinfo/rocminfo.
+        resolved = get_gfx()
+        archs = [resolved if a == "native" else a for a in archs]
+
     # List of allowed architectures
     allowed_archs = [
         "native",
@@ -398,18 +405,56 @@ def validate_and_update_archs():
 @functools.lru_cache()
 def hip_flag_checker(flag_hip: str) -> bool:
     import subprocess
+    import tempfile
+    from cpp_extension import get_cxx_compiler, ROCM_HOME
 
-    cmd = (
-        ["hipcc"]
-        + flag_hip.split()
-        + ["-x", "hip", "-E", "-P", "/dev/null", "-o", "/dev/null"]
-    )
-    try:
-        subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
-    except subprocess.CalledProcessError:
-        logger.warning(f"Current hipcc not support: {flag_hip}, skip it.")
-        return False
-    return True
+    hipcc_bin = get_cxx_compiler()
+
+    # On Windows hipcc.exe uses the HIP_PATH environment variable to find
+    # HIP headers and device libs — not --rocm-path compiler flags.
+    # Inject it into the subprocess environment if not already set.
+    extra_env = {}
+    if sys.platform == "win32" and ROCM_HOME and "HIP_PATH" not in os.environ:
+        extra_env["HIP_PATH"] = ROCM_HOME
+
+    if sys.platform == "win32":
+        tmp_in = None
+        tmp_out = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".cu", delete=False, mode="w") as f:
+                f.write("// flag check\n")
+                tmp_in = f.name
+            tmp_out = tmp_in.replace(".cu", ".o")
+            env = {**os.environ, **extra_env}
+            cmd = (
+                [hipcc_bin]
+                + flag_hip.split()
+                + ["-x", "hip", "-c", tmp_in, "-o", tmp_out]
+            )
+            subprocess.check_output(cmd, stderr=subprocess.DEVNULL, env=env)
+            return True
+        except subprocess.CalledProcessError:
+            logger.warning(f"Current hipcc not support: {flag_hip}, skip it.")
+            return False
+        finally:
+            for f in filter(None, [tmp_in, tmp_out]):
+                try:
+                    os.unlink(f)
+                except OSError:
+                    pass
+    else:
+        null_dev = "/dev/null"
+        cmd = (
+            [hipcc_bin]
+            + flag_hip.split()
+            + ["-x", "hip", "-E", "-P", null_dev, "-o", null_dev]
+        )
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            logger.warning(f"Current hipcc not support: {flag_hip}, skip it.")
+            return False
+        return True
 
 
 @functools.lru_cache()
@@ -421,14 +466,53 @@ def check_LLVM_MAIN_REVISION():
     #else
     #define CK_TILE_HOST_DEVICE_EXTERN"""
     import subprocess
+    import tempfile
+    from cpp_extension import get_cxx_compiler
 
-    cmd = """echo "#include <tuple>
+    src = "#include <tuple>\n__host__ __device__ void func(){std::tuple<int, int> t = std::tuple(1, 1);}\n"
+    hipcc_bin = get_cxx_compiler()
+    if sys.platform == "win32":
+        # On Windows we can't use bash pipes; write to a temp file instead.
+        with tempfile.NamedTemporaryFile(suffix=".cu", delete=False, mode="w") as f:
+            f.write(src)
+            tmp = f.name
+        try:
+            subprocess.check_output(
+                [
+                    hipcc_bin,
+                    "-x",
+                    "hip",
+                    "-P",
+                    "-c",
+                    "-Wno-unused-command-line-argument",
+                    tmp,
+                ],
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            return 554785 - 1
+        except subprocess.CalledProcessError:
+            return 554785
+        finally:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            obj = tmp.replace(".cu", ".obj")
+            try:
+                os.unlink(obj)
+            except OSError:
+                pass
+    else:
+        cmd = """echo "#include <tuple>
 __host__ __device__ void func(){std::tuple<int, int> t = std::tuple(1, 1);}" | hipcc -x hip -P -c -Wno-unused-command-line-argument -o /dev/null -"""
-    try:
-        subprocess.check_output(cmd, shell=True, text=True, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError:
-        return 554785
-    return 554785 - 1
+        try:
+            subprocess.check_output(
+                cmd, shell=True, text=True, stderr=subprocess.STDOUT
+            )
+        except subprocess.CalledProcessError:
+            return 554785
+        return 554785 - 1
 
 
 def check_and_set_ninja_worker():
@@ -489,6 +573,8 @@ def rename_cpp_to_cu(els, dst, hipify, recursive=False):
 
 @torch_compile_guard()
 def check_numa_custom_op() -> None:
+    if sys.platform == "win32":
+        return  # /proc/sys/kernel/numa_balancing does not exist on Windows
     numa_balance_set = os.popen("cat /proc/sys/kernel/numa_balancing").read().strip()
     if numa_balance_set == "1":
         logger.warning(
@@ -654,11 +740,20 @@ def clone_3rdparty(third_party: str) -> None:
 
 
 def rm_module(md_name):
-    os.system(f"rm -rf {get_user_jit_dir()}/{md_name}.so")
+    import glob as _glob
+
+    _lib_ext = ".pyd" if sys.platform == "win32" else ".so"
+    for _f in _glob.glob(f"{get_user_jit_dir()}/{md_name}{_lib_ext}"):
+        try:
+            os.remove(_f)
+        except OSError:
+            pass
 
 
 def clear_build(md_name):
-    os.system(f"rm -rf {bd_dir}/{md_name}")
+    import shutil as _shutil
+
+    _shutil.rmtree(f"{bd_dir}/{md_name}", ignore_errors=True)
 
 
 def build_module(
@@ -679,7 +774,8 @@ def build_module(
     os.makedirs(bd_dir, exist_ok=True)
     lock_path = f"{bd_dir}/lock_{md_name}"
     startTS = time.perf_counter()
-    target_name = f"{md_name}.so" if not is_standalone else md_name
+    _lib_ext = ".pyd" if sys.platform == "win32" else ".so"
+    target_name = f"{md_name}{_lib_ext}" if not is_standalone else md_name
 
     for tp in third_party:
         clone_3rdparty(tp)
@@ -1255,6 +1351,7 @@ def compile_ops(
                 d_args = get_args_of_build(md_name)
                 d_args.update(custom_build_args)
 
+                # update module name if we have a custom build
                 md_name = custom_build_args.get("md_name", md_name)
 
                 srcs = d_args["srcs"]
@@ -1324,6 +1421,7 @@ def compile_ops(
                     doc_str = doc_str.replace("collections.abc.Sequence[", "List[")
                     doc_str = doc_str.replace("typing.SupportsInt", "int")
                     doc_str = doc_str.replace("typing.SupportsFloat", "float")
+                    # A|None  -->  Optional[A]
                     pattern = r"([\w\.]+(?:\[[^\]]+\])?)\s*\|\s*None"
                     doc_str = re.sub(pattern, r"Optional[\1]", doc_str)
                     for el in enum_types:
@@ -1353,6 +1451,7 @@ def compile_ops(
 
                         if origin is None:
                             if not isinstance(arg, expected_type) and not (
+                                # aiter_enum can be int
                                 any(el in str(expected_type) for el in enum_types)
                                 and isinstance(arg, int)
                             ):
@@ -1360,7 +1459,10 @@ def compile_ops(
                                     f"{loadName}: {el} needs to be {expected_type} but got {got_type}"
                                 )
                         elif origin is list:
-                            if not isinstance(arg, list):
+                            if (
+                                not isinstance(arg, list)
+                                # or not all(isinstance(i, sub_t) for i in arg)
+                            ):
                                 raise TypeError(
                                     f"{loadName}: {el} needs to be List[{sub_t}] but got {arg}"
                                 )

--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -3,8 +3,11 @@
 import functools
 import os
 import re
+import shutil
 import subprocess
+import sys
 
+from typing import Optional
 from cpp_extension import executable_path
 from torch_guard import torch_compile_guard
 
@@ -30,23 +33,82 @@ GFX_MAP = {
 }
 
 
-@functools.lru_cache(maxsize=1)
-def _detect_native() -> list[str]:
-    try:
-        rocminfo = executable_path("rocminfo")
+def _run_gpu_info_tool() -> str:
+    """
+    Run rocminfo (Linux) or hipinfo (Windows) and return stdout.
+    rocminfo is not shipped with the Windows ROCm SDK; hipinfo is the
+    equivalent tool available there.
+    """
+    # Try rocminfo first (Linux / full ROCm installs)
+    rocminfo_path = shutil.which("rocminfo")
+    if rocminfo_path is None and sys.platform != "win32":
+        # On Linux also try via executable_path which searches ROCM_HOME/bin
+        try:
+            rocminfo_path = executable_path("rocminfo")
+        except Exception:
+            pass
+
+    if rocminfo_path is not None:
         result = subprocess.run(
-            [rocminfo],
+            [rocminfo_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            check=True,
         )
-        for line in result.stdout.splitlines():
-            if "gfx" in line.lower():
-                return [line.split(":", 1)[-1].strip()]
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+
+    # Fall back to hipinfo (Windows ROCm SDK)
+    hipinfo_path = shutil.which("hipinfo")
+    if hipinfo_path is not None:
+        result = subprocess.run(
+            [hipinfo_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+
+    raise RuntimeError(
+        "Could not find rocminfo or hipinfo in PATH. "
+        "Please ensure the ROCm/HIP SDK bin directory is on your PATH "
+        "(e.g. C:\\Program Files\\AMD\\ROCm\\<ver>\\bin on Windows)."
+    )
+
+
+def _extract_gfx_from_output(output: str) -> Optional[str]:
+    """
+    Parse a gfx architecture string out of rocminfo or hipinfo output.
+    """
+    for line in output.splitlines():
+        match = re.search(r"\b(gfx\w+)\b", line, re.IGNORECASE)
+        if match:
+            return match.group(1).lower()
+    return None
+
+
+def _extract_cu_from_output(output: str) -> Optional[int]:
+    """
+    Parse the Compute Unit count out of rocminfo or hipinfo output.
+    """
+    for line in output.splitlines():
+        match = re.search(r"Compute Units?\s*:+\s*(\d+)", line, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def _detect_native() -> list[str]:
+    try:
+        output = _run_gpu_info_tool()
+        gfx = _extract_gfx_from_output(output)
+        if gfx is not None:
+            return [gfx]
     except Exception as e:
-        raise RuntimeError(f"Get GPU arch from rocminfo failed: {e}") from e
-    raise RuntimeError("No gfx arch found in rocminfo output.")
+        raise RuntimeError(f"Get GPU arch from rocminfo/hipinfo failed: {e}") from e
+    raise RuntimeError("No gfx arch found in rocminfo/hipinfo output.")
 
 
 @torch_compile_guard()
@@ -58,30 +120,25 @@ def get_gfx_custom_op() -> int:
 def get_gfx_custom_op_core() -> int:
     gfx = os.getenv("GPU_ARCHS", "native")
     gfx_mapping = {v: k for k, v in GFX_MAP.items()}
-    # gfx = os.getenv("GPU_ARCHS", "native")
+
     if gfx == "native":
         try:
-            rocminfo = executable_path("rocminfo")
-            result = subprocess.run(
-                [rocminfo], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            output = result.stdout
-            for line in output.split("\n"):
-                match = re.search(r"\b(gfx\w+)\b", line, re.IGNORECASE)
-                if match:
-                    gfx_arch = match.group(1).lower()
-                    try:
-                        return gfx_mapping[gfx_arch]
-                    except KeyError:
-                        raise KeyError(
-                            f"Unknown GPU architecture: {gfx_arch}. "
-                            f"Supported architectures: {list(gfx_mapping.keys())}"
-                        )
-
+            output = _run_gpu_info_tool()
+            gfx_arch = _extract_gfx_from_output(output)
+            if gfx_arch is None:
+                raise RuntimeError("No gfx arch found in rocminfo/hipinfo output.")
+            try:
+                return gfx_mapping[gfx_arch]
+            except KeyError:
+                raise KeyError(
+                    f"Unknown GPU architecture: {gfx_arch}. "
+                    f"Supported architectures: {list(gfx_mapping.keys())}"
+                )
         except Exception as e:
-            raise RuntimeError(f"Get GPU arch from rocminfo failed {str(e)}")
+            raise RuntimeError(f"Get GPU arch from rocminfo/hipinfo failed: {e}")
     elif ";" in gfx:
         gfx = gfx.split(";")[-1]
+
     try:
         return gfx_mapping[gfx]
     except KeyError:
@@ -99,7 +156,6 @@ def get_gfx():
 
 @functools.lru_cache(maxsize=1)
 def get_gfx_list() -> list[str]:
-
     gfx_env = os.getenv("GPU_ARCHS", "native")
     if gfx_env == "native":
         try:
@@ -109,7 +165,6 @@ def get_gfx_list() -> list[str]:
     else:
         gfxs = [g.strip() for g in gfx_env.split(";") if g.strip()]
     os.environ["AITER_GPU_ARCHS"] = ";".join(gfxs)
-
     return gfxs
 
 
@@ -118,23 +173,32 @@ def get_cu_num_custom_op() -> int:
     cu_num = int(os.getenv("CU_NUM", 0))
     if cu_num == 0:
         try:
-            rocminfo = executable_path("rocminfo")
-            result = subprocess.run(
-                [rocminfo], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            output = result.stdout
+            output = _run_gpu_info_tool()
+            # rocminfo groups by Agent; collect CU counts for GPU agents only
             devices = re.split(r"Agent\s*\d+", output)
             gpu_compute_units = []
             for device in devices:
-                for line in device.split("\n"):
-                    if "Device Type" in line and line.find("GPU") != -1:
-                        match = re.search(r"Compute Unit\s*:\s*(\d+)", device)
-                        if match:
-                            gpu_compute_units.append(int(match.group(1)))
-                        break
+                if "Device Type" in device and "GPU" in device:
+                    cu = _extract_cu_from_output(device)
+                    if cu is not None:
+                        gpu_compute_units.append(cu)
+            # hipinfo doesn't have the Agent split — fall back to global scan
+            if not gpu_compute_units:
+                cu = _extract_cu_from_output(output)
+                if cu is not None:
+                    gpu_compute_units.append(cu)
         except Exception as e:
-            raise RuntimeError(f"Get GPU Compute Unit from rocminfo failed {str(e)}")
-        assert len(set(gpu_compute_units)) == 1
+            raise RuntimeError(
+                f"Get GPU Compute Unit from rocminfo/hipinfo failed: {e}"
+            )
+
+        if not gpu_compute_units:
+            raise RuntimeError(
+                "Could not determine Compute Unit count from GPU info output."
+            )
+        assert (
+            len(set(gpu_compute_units)) == 1
+        ), f"Multiple different CU counts found: {gpu_compute_units}"
         cu_num = gpu_compute_units[0]
     return cu_num
 
@@ -168,10 +232,27 @@ def get_device_name():
     gfx = get_gfx()
 
     if gfx == "gfx942":
-        chip_id = _get_pci_chip_id()
-        if chip_id in MI308_CHIP_IDS:
-            return "MI308"
-        return "MI300"
+        if sys.platform == "win32":
+            # libamdhip64.so ctypes probe is Linux-only; identify the SKU by
+            # Compute Unit count instead.  Known gfx942 SKU map:
+            #   304 CU -> MI300X
+            #   228 CU -> MI300A
+            #    80 CU -> MI308X
+            #    64 CU -> MI308  (smaller variant)
+            cu = get_cu_num()
+            if cu == 304:
+                return "MI300X"
+            elif cu == 228:
+                return "MI300A"
+            elif cu in (80, 64):
+                return "MI308"
+            else:
+                return f"MI300-family (gfx942, {cu} CUs)"
+        else:
+            chip_id = _get_pci_chip_id()
+            if chip_id in MI308_CHIP_IDS:
+                return "MI308"
+            return "MI300"
     elif gfx == "gfx950":
         return "MI350"
     else:

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -26,13 +26,39 @@ from hipify.hipify_python import GeneratedFileCleaner
 from packaging.version import Version
 from setuptools.command.build_ext import build_ext
 
+
+def _quote(s: str) -> str:
+    """
+    Quote a string for inclusion in a ninja build file.
+
+    On Linux/macOS shlex.quote() wraps in single quotes which the shell strips.
+    On Windows hipcc.exe is called directly (no shell), so single-quoted paths
+    like 'C:\\foo\\bar' are passed literally with the quotes as part of the
+    string — breaking every include path.  On Windows we use double-quotes only
+    when the path contains spaces; otherwise return as-is.
+    """
+    if sys.platform == "win32":
+        if " " in s:
+            return '"' + s.replace('"', '\\"') + '"'
+        return s
+    return shlex.quote(s)
+
 IS_WINDOWS = sys.platform == "win32"
 IS_LINUX = sys.platform.startswith("linux")
-LIB_EXT = ".so"
-EXEC_EXT = ""
-CLIB_PREFIX = "lib"
-CLIB_EXT = ".so"
-SHARED_FLAG = "-shared"
+if IS_WINDOWS:
+    LIB_EXT = ".pyd"
+    EXEC_EXT = ".exe"
+    CLIB_PREFIX = ""
+    CLIB_EXT = ".dll"
+    SHARED_FLAG = (
+        ""  # MSVC/clang-cl uses /DLL via the linker; hipcc on Windows uses --shared
+    )
+else:
+    LIB_EXT = ".so"
+    EXEC_EXT = ""
+    CLIB_PREFIX = "lib"
+    CLIB_EXT = ".so"
+    SHARED_FLAG = "-shared"
 
 SUBPROCESS_DECODE_ARGS = ()
 MINIMUM_GCC_VERSION = (5, 0, 0)
@@ -74,6 +100,15 @@ def executable_path(executable: str) -> str:
     Returns:
         The path to the executable.
     """
+    # On Windows always prefer the executable from ROCM_HOME/bin.
+    if sys.platform == "win32":
+        home = _find_rocm_home()
+        if home:
+            for name in (executable, executable + ".exe"):
+                candidate = os.path.join(home, "bin", name)
+                if os.path.isfile(candidate):
+                    return os.path.realpath(candidate)
+
     path = shutil.which(executable)
     if not path:
         home = _find_rocm_home()
@@ -96,21 +131,92 @@ def get_hip_version():
 
 def _find_rocm_home() -> Optional[str]:
     """Find the ROCm install path."""
-    # Guess #1
+    # Guess #1 — explicit env var
     rocm_home = os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH")
+
+    if rocm_home is None and sys.platform == "win32":
+        # On Windows the ROCm SDK installer sets HIP_PATH
+        rocm_home = os.environ.get("HIP_PATH")
+
+    if rocm_home is None and sys.platform == "win32":
+        # PyTorch ROCm Windows wheels bundle the SDK inside the venv
+        # under site-packages/_rocm_sdk_devel (preferred) or _rocm_sdk_core.
+        # We use multiple methods to get site-packages because sysconfig.get_path()
+        # can return paths without a drive letter in some venv configurations.
+        site_candidates = []
+        try:
+            import site as _site
+
+            site_candidates += _site.getsitepackages() or []
+            user_site = _site.getusersitepackages()
+            if user_site:
+                site_candidates.append(user_site)
+        except Exception:
+            pass
+        try:
+            import sysconfig as _sc
+
+            p = _sc.get_path("purelib")
+            if p:
+                site_candidates.append(p)
+            p2 = _sc.get_path("platlib")
+            if p2:
+                site_candidates.append(p2)
+        except Exception:
+            pass
+        # Also try finding via an installed package we know exists
+        try:
+            import torch as _torch
+
+            torch_site = os.path.dirname(os.path.dirname(_torch.__file__))
+            site_candidates.append(torch_site)
+        except Exception:
+            pass
+
+        for site in site_candidates:
+            site = os.path.abspath(site)
+            for candidate_name in ("_rocm_sdk_devel", "_rocm_sdk_core"):
+                candidate = os.path.join(site, candidate_name)
+                if os.path.isfile(os.path.join(candidate, "bin", "hipcc.exe")):
+                    rocm_home = os.path.abspath(candidate)
+                    break
+            if rocm_home:
+                break
+
     if rocm_home is None:
-        # Guess #2
+        # Guess #2 — find hipcc on PATH
         hipcc_path = shutil.which("hipcc")
         if hipcc_path is not None:
-            rocm_home = os.path.dirname(os.path.dirname(os.path.realpath(hipcc_path)))
-            # can be either <ROCM_HOME>/hip/bin/hipcc or <ROCM_HOME>/bin/hipcc
-            if os.path.basename(rocm_home) == "hip":
-                rocm_home = os.path.dirname(rocm_home)
-        else:
-            # Guess #3
-            fallback_path = "/opt/rocm"
-            if os.path.exists(fallback_path):
-                rocm_home = fallback_path
+            real = os.path.realpath(hipcc_path)
+            candidate = os.path.dirname(os.path.dirname(real))
+            if os.path.basename(candidate) == "hip":
+                candidate = os.path.dirname(candidate)
+            if sys.platform == "win32":
+                if os.path.isfile(os.path.join(candidate, "bin", "hipcc.exe")):
+                    rocm_home = candidate
+                # else: leave rocm_home as None, fall through to next guess
+            else:
+                rocm_home = candidate
+
+    if rocm_home is None and sys.platform == "win32":
+        # Guess #3 — standard Windows SDK install locations
+        import glob as _glob
+
+        for pattern in [
+            r"C:\Program Files\AMD\ROCm\*",
+            r"C:\Program Files (x86)\AMD\ROCm\*",
+        ]:
+            matches = sorted(_glob.glob(pattern), reverse=True)
+            if matches:
+                rocm_home = matches[0]
+                break
+
+    if rocm_home is None and sys.platform != "win32":
+        # Linux standard install
+        fallback_path = "/opt/rocm"
+        if os.path.exists(fallback_path):
+            rocm_home = fallback_path
+
     if rocm_home is None:
         print(
             f"No ROCm runtime is found, using ROCM_HOME='{rocm_home}'", file=sys.stderr
@@ -130,10 +236,7 @@ def _join_rocm_home(*paths) -> str:
             "ROCM_HOME environment variable is not set. "
             "Please set it to your ROCm install root."
         )
-    elif IS_WINDOWS:
-        raise OSError(
-            "Building PyTorch extensions using " "ROCm and Windows is not supported."
-        )
+    # Windows ROCm is supported via triton-windows; do not raise here.
     return os.path.join(ROCM_HOME, *paths)
 
 
@@ -172,6 +275,25 @@ with compiling PyTorch from source.
 
 HIP_VERSION = get_hip_version()
 ROCM_HOME = _find_rocm_home()
+
+# Sanity check: on Windows, if ROCM_HOME is missing its drive letter (a known
+# sysconfig bug in some venvs), re-resolve it using torch.__file__ as an anchor,
+# which always carries a fully-qualified absolute path.
+if sys.platform == "win32" and ROCM_HOME and not os.path.splitdrive(ROCM_HOME)[0]:
+    try:
+        import torch as _torch_anchor
+
+        _sp = os.path.abspath(os.path.dirname(os.path.dirname(_torch_anchor.__file__)))
+        for _sdk in ("_rocm_sdk_devel", "_rocm_sdk_core"):
+            _cand = os.path.join(_sp, _sdk)
+            if os.path.isfile(os.path.join(_cand, "bin", "hipcc.exe")):
+                ROCM_HOME = os.path.abspath(_cand)
+                break
+    except Exception:
+        pass
+
+# On Windows, clang (invoked by hipcc) cannot auto-discover the bundled HIP
+# runtime. --rocm-path is appended to COMMON_HIP_FLAGS after it is defined below.
 HIP_HOME = _join_rocm_home("hip") if ROCM_HOME else None
 IS_HIP_EXTENSION = (
     True if ((ROCM_HOME is not None) and (HIP_VERSION is not None)) else False
@@ -216,24 +338,39 @@ COMMON_NVCC_FLAGS = [
 ]
 
 COMMON_HIP_FLAGS = [
-    "-fPIC",
     "-D__HIP_PLATFORM_AMD__=1",
     "-DUSE_ROCM=1",
     "-DHIPBLAS_V2",
 ]
+if sys.platform != "win32":
+    COMMON_HIP_FLAGS.insert(0, "-fPIC")  # meaningless on Windows
+# On Windows the HIP runtime is bundled inside the venv; clang cannot auto-discover
+# it, so we must pass --rocm-path explicitly. This is appended after ROCM_HOME is
+# resolved (see the deferred append below, after ROCM_HOME is set).
 
 COMMON_HIPCC_FLAGS = [
     "-DCUDA_HAS_FP16=1",
     "-D__HIP_NO_HALF_OPERATORS__=1",
     "-D__HIP_NO_HALF_CONVERSIONS__=1",
-    "-mcmodel=large",
-    "-fno-unique-section-names",
-    "-ffunction-sections",
-    "-fdata-sections",
 ]
+if sys.platform != "win32":
+    # These are ELF/Linux-only flags; hipcc on Windows (LLVM/lld) rejects them
+    COMMON_HIPCC_FLAGS += [
+        "-mcmodel=large",
+        "-fno-unique-section-names",
+        "-ffunction-sections",
+        "-fdata-sections",
+    ]
 
 if not int(os.environ.get("AITER_SYMBOL_VISIBLE", "0")):
     COMMON_HIPCC_FLAGS.extend(["-fvisibility=hidden", "-fvisibility-inlines-hidden"])
+
+# On Windows the HIP runtime is bundled inside the venv. hipcc.exe uses the
+# HIP_PATH environment variable (not --rocm-path compiler flags) to locate HIP
+# headers and device libs. We inject it here so all subprocess calls to hipcc
+# pick it up automatically.
+if sys.platform == "win32" and ROCM_HOME:
+    os.environ.setdefault("HIP_PATH", ROCM_HOME)
 
 JIT_EXTENSION_VERSIONER = ExtensionVersioner()
 
@@ -244,7 +381,27 @@ PLAT_TO_VCVARS = {
 
 
 def get_cxx_compiler():
-    return os.environ.get("CXX", "c++")
+    if "CXX" in os.environ:
+        return os.environ["CXX"]
+    if sys.platform == "win32":
+        # Try ROCM_HOME first (already resolved at module load time)
+        if ROCM_HOME:
+            hipcc = os.path.join(ROCM_HOME, "bin", "hipcc.exe")
+            if os.path.isfile(hipcc):
+                return hipcc
+        # Fallback: find hipcc relative to torch's site-packages location,
+        # since the ROCm SDK is bundled there on Windows PyTorch ROCm wheels.
+        try:
+            import torch as _torch
+
+            sp = os.path.dirname(os.path.dirname(_torch.__file__))
+            for sdk in ("_rocm_sdk_devel", "_rocm_sdk_core"):
+                candidate = os.path.join(sp, sdk, "bin", "hipcc.exe")
+                if os.path.isfile(candidate):
+                    return os.path.abspath(candidate)
+        except Exception:
+            pass
+    return "c++"
 
 
 def _is_binary_build() -> bool:
@@ -255,7 +412,7 @@ def _is_binary_build() -> bool:
 
 def _accepted_compilers_for_platform() -> List[str]:
     # gnu-c++ and gnu-cc are the conda gcc compilers
-    return ["g++", "gcc", "gnu-c++", "gnu-cc", "clang++", "clang"]
+    return ["g++", "gcc", "gnu-c++", "gnu-cc", "clang++", "clang", "hipcc"]
 
 
 def _maybe_write(filename, new_content):
@@ -329,6 +486,11 @@ def get_compiler_abi_compatibility_and_version(
         A tuple that contains a boolean that defines if the compiler is (likely) ABI-incompatible with PyTorch,
         followed by a `Version` string that contains the compiler version separated by dots.
     """
+    # On Windows we use hipcc (clang-based) which is always acceptable.
+    # The Linux gcc-version checks below don't apply and would crash.
+    if IS_WINDOWS:
+        return (True, Version("0.0.0"))
+
     if not torch_exclude:
         if not _is_binary_build():
             return (True, Version("0.0.0"))
@@ -363,6 +525,9 @@ def get_compiler_abi_compatibility_and_version(
                 versionstr.decode(*SUBPROCESS_DECODE_ARGS).strip(),
             )
             version = ["0", "0", "0"] if match is None else list(match.groups())
+        else:
+            # macOS or other non-Linux Unix — just report compatible
+            return (True, Version("0.0.0"))
     except Exception:
         _, error, _ = sys.exc_info()
         warnings.warn(f"Error checking compiler version for {compiler}: {error}")
@@ -601,14 +766,14 @@ class BuildExtension(build_ext):
                 )
 
                 append_std17_if_no_std_present(cuda_post_cflags)
-                cuda_cflags = [shlex.quote(f) for f in cuda_cflags]
-                cuda_post_cflags = [shlex.quote(f) for f in cuda_post_cflags]
+                cuda_cflags = [_quote(f) for f in cuda_cflags]
+                cuda_post_cflags = [_quote(f) for f in cuda_post_cflags]
 
             _write_ninja_file_and_compile_objects(
                 sources=sources,
                 objects=objects,
-                cflags=[shlex.quote(f) for f in extra_cc_cflags + common_cflags],
-                post_cflags=[shlex.quote(f) for f in post_cflags],
+                cflags=[_quote(f) for f in extra_cc_cflags + common_cflags],
+                post_cflags=[_quote(f) for f in post_cflags],
                 cuda_cflags=cuda_cflags,
                 cuda_post_cflags=cuda_post_cflags,
                 cuda_dlink_post_cflags=None,
@@ -1371,35 +1536,106 @@ def verify_ninja_availability():
 
 
 def _prepare_ldflags(extra_ldflags, with_cuda, verbose, is_standalone, torch_exclude):
-    extra_ldflags.append("-mcmodel=large")
-    extra_ldflags.append("-ffunction-sections")
-    extra_ldflags.append("-fdata-sections ")
-    extra_ldflags.append("-Wl,--gc-sections")
-    extra_ldflags.append("-Wl,--cref")
+    if sys.platform != "win32":
+        # These flags are GCC/clang-linux linker flags; not valid on Windows
+        extra_ldflags.append("-mcmodel=large")
+        extra_ldflags.append("-ffunction-sections")
+        extra_ldflags.append("-fdata-sections ")
+        extra_ldflags.append("-Wl,--gc-sections")
+        extra_ldflags.append("-Wl,--cref")
+
+    # On Windows, always add the Python import lib dir and python3xx.lib for
+    # .pyd modules — this is needed regardless of torch_exclude because
+    # PyInit_<module> symbols come from the Python runtime, not torch.
+    # Also tell lld-link we're building a DLL with the Windows subsystem.
+    if sys.platform == "win32" and not is_standalone:
+        py_lib_name = f"python{sys.version_info.major}{sys.version_info.minor}.lib"
+        py_lib_dir = None
+        py_lib_candidates = []
+        for prefix in (
+            getattr(sys, "base_prefix", None),
+            getattr(sys, "base_exec_prefix", None),
+        ):
+            if prefix:
+                py_lib_candidates += [prefix, os.path.join(prefix, "libs")]
+        try:
+            venv_root = os.path.dirname(os.path.dirname(sys.executable))
+            cfg = os.path.join(venv_root, "pyvenv.cfg")
+            if os.path.isfile(cfg):
+                with open(cfg) as _f:
+                    for line in _f:
+                        if line.lower().startswith("home"):
+                            base_home = line.split("=", 1)[1].strip()
+                            base_root = os.path.dirname(base_home)
+                            py_lib_candidates += [
+                                base_home,
+                                os.path.join(base_root, "libs"),
+                                base_root,
+                            ]
+                            break
+        except Exception:
+            pass
+        exe_dir = os.path.dirname(sys.executable)
+        py_lib_candidates += [
+            exe_dir,
+            os.path.join(exe_dir, "libs"),
+            os.path.dirname(exe_dir),
+            os.path.join(os.path.dirname(exe_dir), "libs"),
+        ]
+        for cand in py_lib_candidates:
+            if cand and os.path.isfile(os.path.join(cand, py_lib_name)):
+                py_lib_dir = cand
+                break
+        if py_lib_dir:
+            extra_ldflags.append(f"-L{_ninja_var_path(py_lib_dir)}")
+        # Use -l flag so clang translates it correctly for lld-link (/DEFAULTLIB:)
+        py_lib_stem = f"python{sys.version_info.major}{sys.version_info.minor}"
+        extra_ldflags.append(f"-l{py_lib_stem}")
+        # Tell lld-link this is a DLL with the Windows subsystem
+        extra_ldflags.append("-Wl,/SUBSYSTEM:WINDOWS")
+        extra_ldflags.append("-Wl,/DLL")
+
     if not torch_exclude:
         import torch
 
         _TORCH_PATH = os.path.join(os.path.dirname(torch.__file__))
         TORCH_LIB_PATH = os.path.join(_TORCH_PATH, "lib")
-        extra_ldflags.append(f"-L{TORCH_LIB_PATH}")
-        extra_ldflags.append("-lc10")
-        if with_cuda:
-            extra_ldflags.append("-lc10_hip" if IS_HIP_EXTENSION else "-lc10_cuda")
-        extra_ldflags.append("-ltorch_cpu")
-        if with_cuda:
-            extra_ldflags.append("-ltorch_hip" if IS_HIP_EXTENSION else "-ltorch_cuda")
-        extra_ldflags.append("-ltorch")
-        if not is_standalone:
-            extra_ldflags.append("-ltorch_python")
-
-        if is_standalone:
-            extra_ldflags.append(f"-Wl,-rpath,{TORCH_LIB_PATH}")
+        if sys.platform == "win32":
+            extra_ldflags.append(f"-L{_ninja_var_path(TORCH_LIB_PATH)}")
+            extra_ldflags.append("c10.lib")
+            if with_cuda:
+                extra_ldflags.append(
+                    "c10_hip.lib" if IS_HIP_EXTENSION else "c10_cuda.lib"
+                )
+            extra_ldflags.append("torch_cpu.lib")
+            if with_cuda:
+                extra_ldflags.append(
+                    "torch_hip.lib" if IS_HIP_EXTENSION else "torch_cuda.lib"
+                )
+            extra_ldflags.append("torch.lib")
+            if not is_standalone:
+                extra_ldflags.append("torch_python.lib")
+        else:
+            extra_ldflags.append(f"-L{TORCH_LIB_PATH}")
+            extra_ldflags.append("-lc10")
+            if with_cuda:
+                extra_ldflags.append("-lc10_hip" if IS_HIP_EXTENSION else "-lc10_cuda")
+            extra_ldflags.append("-ltorch_cpu")
+            if with_cuda:
+                extra_ldflags.append(
+                    "-ltorch_hip" if IS_HIP_EXTENSION else "-ltorch_cuda"
+                )
+            extra_ldflags.append("-ltorch")
+            if not is_standalone:
+                extra_ldflags.append("-ltorch_python")
+            if is_standalone:
+                extra_ldflags.append(f"-Wl,-rpath,{TORCH_LIB_PATH}")
 
     if with_cuda and IS_HIP_EXTENSION:
         if verbose:
             print("Detected CUDA files, patching ldflags", file=sys.stderr)
-
-        extra_ldflags.append(f'-L{_join_rocm_home("lib")}')
+        rocm_lib = _ninja_var_path(_join_rocm_home("lib"))
+        extra_ldflags.append(f"-L{rocm_lib}")
         extra_ldflags.append("-lamdhip64")
     return extra_ldflags
 
@@ -1424,6 +1660,20 @@ def _get_rocm_arch_flags(cflags: Optional[List[str]] = None) -> List[str]:
             archs = []
     else:
         archs = _archs.replace(" ", ";").split(";")
+
+    # On Windows, filter the arch list to only the GPU actually present.
+    # PyTorch ROCm wheels compile for many targets (e.g. gfx1200 + gfx1201)
+    # but hipcc on Windows is slower and we only need the one we have.
+    if sys.platform == "win32" and archs:
+        try:
+            from chip_info import get_gfx
+
+            detected = get_gfx()
+            if detected and detected != "unknown" and detected in archs:
+                archs = [detected]
+        except Exception:
+            pass
+
     flags = [f"--offload-arch={arch}" for arch in archs]
     flags += ["-fno-gpu-rdc"]
     return flags
@@ -1564,7 +1814,8 @@ def _write_ninja_file_to_build_library(
     # Explicitly specify 'posix_prefix' scheme on non-Windows platforms to workaround error on some MacOS
     # installations where default `get_path` points to non-existing `/Library/Python/M.m/include` folder
     if is_python_module:
-        python_include_path = sysconfig.get_path("include", scheme="posix_prefix")
+        _scheme = "nt" if sys.platform == "win32" else "posix_prefix"
+        python_include_path = sysconfig.get_path("include", scheme=_scheme)
         if python_include_path is not None:
             system_includes.append(python_include_path)
 
@@ -1579,10 +1830,12 @@ def _write_ninja_file_to_build_library(
         # common_cflags += [f"{x}" for x in _get_glibcxx_abi_build_flags()]
 
     # Windows does not understand `-isystem` and quotes flags later.
-    common_cflags += [f"-I{shlex.quote(include)}" for include in user_includes]
-    common_cflags += [f"-isystem {shlex.quote(include)}" for include in system_includes]
+    common_cflags += [f"-I{_quote(include)}" for include in user_includes]
+    common_cflags += [f"-isystem {_quote(include)}" for include in system_includes]
 
-    cflags = common_cflags + ["-fPIC", "-std=c++20"] + extra_cflags
+    cflags = common_cflags + ["-std=c++20"] + extra_cflags
+    if sys.platform != "win32":
+        cflags = ["-fPIC"] + cflags
 
     if with_cuda and IS_HIP_EXTENSION:
         cuda_flags = ["-DWITH_HIP"] + cflags + COMMON_HIP_FLAGS + COMMON_HIPCC_FLAGS
@@ -1601,7 +1854,11 @@ def _write_ninja_file_to_build_library(
         return target
 
     objects = [object_file_path(src) for src in sources]
-    ldflags = ([] if is_standalone else [SHARED_FLAG]) + extra_ldflags
+    ldflags = (
+        extra_ldflags
+        if is_standalone
+        else (([SHARED_FLAG] if SHARED_FLAG else []) + extra_ldflags)
+    )
 
     ext = EXEC_EXT if is_standalone else LIB_EXT
     library_target = f"{name}{ext}"
@@ -1619,6 +1876,37 @@ def _write_ninja_file_to_build_library(
         library_target=library_target,
         with_cuda=with_cuda,
     )
+
+
+def _ninja_path(path: str) -> str:
+    """
+    Convert a filesystem path for use inside ninja build/default lines.
+
+    Ninja uses ':' as a rule separator, so Windows drive-letter colons must be
+    escaped as '$:'.  Forward slashes are used throughout.
+
+    Use this for: source files, object files, library targets, devlink outputs.
+    Do NOT use this for variable assignments (nvcc =, cxx =) — use
+    _ninja_var_path() for those.
+    """
+    if sys.platform == "win32":
+        path = path.replace("\\", "/")
+        # Escape drive-letter colon: E:/foo  ->  E$:/foo
+        if len(path) >= 2 and path[1] == ":":
+            path = path[0] + "$:" + path[2:]
+    return path
+
+
+def _ninja_var_path(path: str) -> str:
+    """
+    Convert a filesystem path for use in ninja variable assignments (e.g. nvcc = ...).
+
+    Variable values are not parsed as build rules, so ':' does NOT need '$:'
+    escaping — only backslashes need converting to forward slashes.
+    """
+    if sys.platform == "win32":
+        path = path.replace("\\", "/")
+    return path
 
 
 def _write_ninja_file(
@@ -1672,7 +1960,7 @@ def _write_ninja_file(
     config = ["ninja_required_version = 1.3"]
     config.append(f"cxx = {compiler}")
     if with_cuda or cuda_dlink_post_cflags:
-        nvcc = _join_rocm_home("bin", "hipcc")
+        nvcc = _ninja_var_path(_join_rocm_home("bin", "hipcc"))
         config.append(f"nvcc = {nvcc}")
 
     if IS_HIP_EXTENSION:
@@ -1686,7 +1974,10 @@ def _write_ninja_file(
 
     # Turn into absolute paths so we can emit them into the ninja build
     # file wherever it is.
-    sources = [os.path.abspath(file) for file in sources]
+    sources = [_ninja_path(os.path.abspath(file)) for file in sources]
+    objects = [_ninja_path(obj) for obj in objects]
+    if library_target is not None:
+        library_target = _ninja_path(library_target)
 
     # See https://ninja-build.org/build.ninja.html for reference.
     compile_rule = ["rule compile"]
@@ -1708,14 +1999,14 @@ def _write_ninja_file(
     for source_file, object_file in zip(sources, objects):
         is_cuda_source = _is_cuda_file(source_file) and with_cuda
         rule = "cuda_compile" if is_cuda_source else "compile"
-
+        # Spaces still need escaping in ninja (paths already have $: for Windows drives)
         source_file = source_file.replace(" ", "$ ")
         object_file = object_file.replace(" ", "$ ")
         build.append(f"build {object_file}: {rule} {source_file}")
 
     flags.append(f'ldflags = {" ".join(ldflags)}')
     if cuda_dlink_post_cflags:
-        devlink_out = os.path.join(os.path.dirname(objects[0]), "dlink.o")
+        devlink_out = _ninja_path(os.path.join(os.path.dirname(objects[0]), "dlink.o"))
         devlink_rule = ["rule cuda_devlink"]
         devlink_rule.append("  command = $nvcc $in -o $out $cuda_dlink_post_cflags")
         devlink = [f'build {devlink_out}: cuda_devlink {" ".join(objects)}']

--- a/setup.py
+++ b/setup.py
@@ -63,217 +63,200 @@ def prepare_packaging():
         shutil.copytree("3rdparty", "aiter_meta/3rdparty")
     else:
         os.makedirs("aiter_meta/3rdparty", exist_ok=True)
-    shutil.copytree("hsa", "aiter_meta/hsa")
+    if sys.platform != "win32":
+        shutil.copytree("hsa", "aiter_meta/hsa")
+    else:
+        # hsa contains Linux-specific assembly blobs; skip on Windows
+        os.makedirs("aiter_meta/hsa", exist_ok=True)
     shutil.copytree("gradlib", "aiter_meta/gradlib")
     shutil.copytree("csrc", "aiter_meta/csrc")
     open("aiter_meta/__init__.py", "w").close()
     write_install_mode()
 
 
-if is_develop_mode():
-    packages = ["aiter"]
-    write_install_mode()
-else:
-    prepare_packaging()
-    packages = ["aiter_meta", "aiter"]
-
-
-def _is_metadata_only():
-    _skip = frozenset(
-        {
-            "egg_info",
-            "dist_info",
-            "clean",
-            "--version",
-            "--name",
-            "--fullname",
-            "--author",
-            "--author-email",
-            "--url",
-            "--license",
-            "--classifiers",
-        }
-    )
-    return len(sys.argv) < 2 or sys.argv[1] in _skip
-
-
-# Defer heavy imports until build time
-if not _is_metadata_only():
-    import json
-    from concurrent.futures import ThreadPoolExecutor
-
-    sys.path.insert(0, f"{this_dir}/aiter/")
-    from jit import core
-    from jit.utils.cpp_extension import IS_HIP_EXTENSION
-
-    # Determine build target
-    if BUILD_TARGET == "auto":
-        IS_ROCM = IS_HIP_EXTENSION
-    elif BUILD_TARGET == "rocm":
-        IS_ROCM = True
-    else:
-        IS_ROCM = False
-
-    if not IS_ROCM:
-        raise NotImplementedError("Only ROCM is supported")
-
-    ck_dir = os.environ.get("CK_DIR", f"{this_dir}/3rdparty/composable_kernel")
-    if ENABLE_CK:
-        assert os.path.exists(ck_dir), (
-            "CK is needed by aiter, please make sure clone by "
-            '"git clone --recursive https://github.com/ROCm/aiter.git" or '
-            '"git submodule sync ; git submodule update --init --recursive"'
-        )
-
-
-def _load_modules_from_config():
-    cfg_path = os.path.join(this_dir, "aiter", "jit", "optCompilerConfig.json")
-    try:
-        with open(cfg_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception:
-        return []
-    if isinstance(data, dict):
-        return list(data.keys())
-    return []
-
-
-def get_exclude_ops():
-    all_modules = _load_modules_from_config()
-    exclude_ops = []
-
-    # When CK is disabled, exclude all CK-dependent modules
-    if not ENABLE_CK:
-        exclude_ops.extend(sorted(core._get_ck_exclude_modules()))
-        return exclude_ops
-
-    for module in all_modules:
-        if PREBUILD_KERNELS == 1:
-            if "_tune" in module or module == "module_gemm_mi350_a8w8_blockscale_asm":
-                exclude_ops.append(module)
-            if "mha" in module and module not in [
-                "module_fmha_v3_fwd",
-                "module_fmha_v3_varlen_fwd",
-            ]:
-                exclude_ops.append(module)
-        elif PREBUILD_KERNELS == 2:
-            # Exclude _bwd, _tune, and specific module
-            if (
-                "_bwd" in module
-                or "_tune" in module
-                or module == "module_gemm_mi350_a8w8_blockscale_asm"
-            ):
-                exclude_ops.append(module)
-        elif PREBUILD_KERNELS == 3:
-            # Keep only module_fmha_v3* and module_aiter_enum
-            if not (
-                module.startswith("module_fmha_v3")
-                or module == "module_aiter_enum"
-                or module == "module_gemm_mi350_a8w8_blockscale_asm"
-            ):
-                exclude_ops.append(module)
-        else:
-            # Default behavior: exclude tunes and specific mi350 module
-            if "_tune" in module or module == "module_gemm_mi350_a8w8_blockscale_asm":
-                exclude_ops.append(module)
-
-    return exclude_ops
-
-
-if PREBUILD_KERNELS != 0:
-    has_torch = True
-    try:
-        import torch as _
-    except Exception:
-        has_torch = False
-
-    if not has_torch:
-        print(
-            "[aiter] PREBUILD_KERNELS set but torch not installed, "
-            "skip precompilation in this environment"
-        )
-    else:
-        from jit.utils.mha_recipes import (
-            get_mha_varlen_prebuild_variants_by_names,
-        )
-        import glob
-
-        exclude_ops = get_exclude_ops()
-        all_opts_args_build, _ = core.get_args_of_build("all", exclude=exclude_ops)
-
-        if PREBUILD_KERNELS == 1 and ENABLE_CK:
-            extra_args_build = []
-
-            req_md_names = [
-                "mha_varlen_fwd_bf16_nlogits_nbias_mask_nlse_ndropout_nskip_nqscale",
-                "mha_varlen_fwd_bf16_nlogits_nbias_nmask_lse_ndropout_nskip_nqscale",
-            ]
-            variants = get_mha_varlen_prebuild_variants_by_names(req_md_names, ck_dir)
-            base_args = core.get_args_of_build("module_mha_varlen_fwd")
-            for v in variants:
-                if not isinstance(base_args, dict) or not base_args.get("srcs"):
-                    continue
-                extra_args_build.append(
-                    {
-                        "md_name": v["md_name"],
-                        "srcs": base_args["srcs"],
-                        "flags_extra_cc": base_args["flags_extra_cc"],
-                        "flags_extra_hip": base_args["flags_extra_hip"],
-                        "extra_include": base_args["extra_include"],
-                        "blob_gen_cmd": v["blob_gen_cmd"],
-                        "third_party": base_args["third_party"],
-                    }
-                )
-            all_opts_args_build.extend(extra_args_build)
-
-        bd = f"{core.get_user_jit_dir()}/build"
-
-        shutil.rmtree(bd, ignore_errors=True)
-        for f in glob.glob(f"{core.get_user_jit_dir()}/*.so"):
-            try:
-                os.remove(f)
-            except Exception:
-                pass
-
-        def build_one_module(one_opt_args):
-            flags_cc = list(one_opt_args["flags_extra_cc"]) + [
-                f"-DPREBUILD_KERNELS={PREBUILD_KERNELS}"
-            ]
-            flags_hip = list(one_opt_args["flags_extra_hip"]) + [
-                f"-DPREBUILD_KERNELS={PREBUILD_KERNELS}"
-            ]
-
-            core.build_module(
-                md_name=one_opt_args["md_name"],
-                srcs=one_opt_args["srcs"],
-                flags_extra_cc=flags_cc,
-                flags_extra_hip=flags_hip,
-                blob_gen_cmd=one_opt_args["blob_gen_cmd"],
-                extra_include=one_opt_args["extra_include"],
-                extra_ldflags=None,
-                verbose=False,
-                is_python_module=True,
-                is_standalone=False,
-                torch_exclude=False,
-                third_party=one_opt_args["third_party"],
-            )
-
-        prebuid_thread_num = 5
-        max_jobs = os.environ.get("MAX_JOBS")
-        if max_jobs is not None and max_jobs.isdigit() and int(max_jobs) > 0:
-            prebuid_thread_num = min(prebuid_thread_num, int(max_jobs))
-        else:
-            prebuid_thread_num = min(prebuid_thread_num, getMaxJobs())
-        os.environ["PREBUILD_THREAD_NUM"] = str(prebuid_thread_num)
-
-        with ThreadPoolExecutor(max_workers=prebuid_thread_num) as executor:
-            list(executor.map(build_one_module, all_opts_args_build))
-
-
 class NinjaBuildExtension(build_ext):
     """Custom build_ext that defers expensive operations until run() is called."""
 
     def run(self):
+        import json
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Defer heavy imports until build time
+        sys.path.insert(0, f"{this_dir}/aiter/")
+        from jit import core
+        from jit.utils.cpp_extension import IS_HIP_EXTENSION
+
+        # Determine build target
+        if BUILD_TARGET == "auto":
+            IS_ROCM = IS_HIP_EXTENSION
+        elif BUILD_TARGET == "rocm":
+            IS_ROCM = True
+        else:
+            IS_ROCM = False
+
+        if not IS_ROCM:
+            raise NotImplementedError("Only ROCM is supported")
+
+        ck_dir = os.environ.get("CK_DIR", f"{this_dir}/3rdparty/composable_kernel")
+        if ENABLE_CK:
+            assert os.path.exists(ck_dir), (
+                "CK is needed by aiter, please make sure clone by "
+                '"git clone --recursive https://github.com/ROCm/aiter.git" or '
+                '"git submodule sync ; git submodule update --init --recursive"'
+            )
+
+        write_install_mode()
+
+        def _load_modules_from_config():
+            cfg_path = os.path.join(this_dir, "aiter", "jit", "optCompilerConfig.json")
+            try:
+                with open(cfg_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except Exception:
+                return []
+            if isinstance(data, dict):
+                return list(data.keys())
+            return []
+
+        def get_exclude_ops():
+            all_modules = _load_modules_from_config()
+            exclude_ops = []
+
+            # When CK is disabled, exclude all CK-dependent modules
+            if not ENABLE_CK:
+                exclude_ops.extend(sorted(core._get_ck_exclude_modules()))
+                return exclude_ops
+
+            for module in all_modules:
+                if PREBUILD_KERNELS == 1:
+                    if (
+                        "_tune" in module
+                        or module == "module_gemm_mi350_a8w8_blockscale_asm"
+                    ):
+                        exclude_ops.append(module)
+                    if "mha" in module and module not in [
+                        "module_fmha_v3_fwd",
+                        "module_fmha_v3_varlen_fwd",
+                    ]:
+                        exclude_ops.append(module)
+                elif PREBUILD_KERNELS == 2:
+                    # Exclude _bwd, _tune, and specific module
+                    if (
+                        "_bwd" in module
+                        or "_tune" in module
+                        or module == "module_gemm_mi350_a8w8_blockscale_asm"
+                    ):
+                        exclude_ops.append(module)
+                elif PREBUILD_KERNELS == 3:
+                    # Keep only module_fmha_v3* and module_aiter_enum
+                    if not (
+                        module.startswith("module_fmha_v3")
+                        or module == "module_aiter_enum"
+                        or module == "module_gemm_mi350_a8w8_blockscale_asm"
+                    ):
+                        exclude_ops.append(module)
+                else:
+                    # Default behavior: exclude tunes and specific mi350 module
+                    if (
+                        "_tune" in module
+                        or module == "module_gemm_mi350_a8w8_blockscale_asm"
+                    ):
+                        exclude_ops.append(module)
+
+            return exclude_ops
+
+        if PREBUILD_KERNELS != 0 and sys.platform != "win32":
+            has_torch = True
+            try:
+                import torch as _
+            except Exception:
+                has_torch = False
+
+            if not has_torch:
+                print(
+                    "[aiter] PREBUILD_KERNELS set but torch not installed, "
+                    "skip precompilation in this environment"
+                )
+            else:
+                from jit.utils.mha_recipes import (
+                    get_mha_varlen_prebuild_variants_by_names,
+                )
+                import glob
+
+                exclude_ops = get_exclude_ops()
+                all_opts_args_build, _ = core.get_args_of_build(
+                    "all", exclude=exclude_ops
+                )
+
+                if PREBUILD_KERNELS == 1 and ENABLE_CK:
+                    extra_args_build = []
+
+                    req_md_names = [
+                        "mha_varlen_fwd_bf16_nlogits_nbias_mask_nlse_ndropout_nskip_nqscale",
+                        "mha_varlen_fwd_bf16_nlogits_nbias_nmask_lse_ndropout_nskip_nqscale",
+                    ]
+                    variants = get_mha_varlen_prebuild_variants_by_names(
+                        req_md_names, ck_dir
+                    )
+                    base_args = core.get_args_of_build("module_mha_varlen_fwd")
+                    for v in variants:
+                        if not isinstance(base_args, dict) or not base_args.get("srcs"):
+                            continue
+                        extra_args_build.append(
+                            {
+                                "md_name": v["md_name"],
+                                "srcs": base_args["srcs"],
+                                "flags_extra_cc": base_args["flags_extra_cc"],
+                                "flags_extra_hip": base_args["flags_extra_hip"],
+                                "extra_include": base_args["extra_include"],
+                                "blob_gen_cmd": v["blob_gen_cmd"],
+                            }
+                        )
+                    all_opts_args_build.extend(extra_args_build)
+
+                bd = f"{core.get_user_jit_dir()}/build"
+
+                shutil.rmtree(bd, ignore_errors=True)
+                _lib_ext = "*.pyd" if sys.platform == "win32" else "*.so"
+                for f in glob.glob(f"{core.get_user_jit_dir()}/{_lib_ext}"):
+                    try:
+                        os.remove(f)
+                    except Exception:
+                        pass
+
+                def build_one_module(one_opt_args):
+                    flags_cc = list(one_opt_args["flags_extra_cc"]) + [
+                        f"-DPREBUILD_KERNELS={PREBUILD_KERNELS}"
+                    ]
+                    flags_hip = list(one_opt_args["flags_extra_hip"]) + [
+                        f"-DPREBUILD_KERNELS={PREBUILD_KERNELS}"
+                    ]
+
+                    core.build_module(
+                        md_name=one_opt_args["md_name"],
+                        srcs=one_opt_args["srcs"],
+                        flags_extra_cc=flags_cc,
+                        flags_extra_hip=flags_hip,
+                        blob_gen_cmd=one_opt_args["blob_gen_cmd"],
+                        extra_include=one_opt_args["extra_include"],
+                        extra_ldflags=None,
+                        verbose=False,
+                        is_python_module=True,
+                        is_standalone=False,
+                        torch_exclude=False,
+                    )
+
+                prebuid_thread_num = 5
+                max_jobs = os.environ.get("MAX_JOBS")
+                if max_jobs is not None and max_jobs.isdigit() and int(max_jobs) > 0:
+                    prebuid_thread_num = min(prebuid_thread_num, int(max_jobs))
+                else:
+                    prebuid_thread_num = min(prebuid_thread_num, getMaxJobs())
+                os.environ["PREBUILD_THREAD_NUM"] = str(prebuid_thread_num)
+
+                with ThreadPoolExecutor(max_workers=prebuid_thread_num) as executor:
+                    list(executor.map(build_one_module, all_opts_args_build))
+
         # Set MAX_JOBS for ninja
         max_jobs_env = os.environ.get("MAX_JOBS")
         if max_jobs_env is None:
@@ -306,6 +289,13 @@ class ForcePlatlibDistribution(Distribution):
         return True
 
 
+if is_develop_mode():
+    packages = ["aiter"]
+    write_install_mode()
+else:
+    prepare_packaging()
+    packages = ["aiter_meta", "aiter"]
+
 setup(
     name=PACKAGE_NAME,
     use_scm_version=True,
@@ -318,6 +308,7 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: Unix",
+        "Operating System :: Microsoft :: Windows",
     ],
     cmdclass={"build_ext": NinjaBuildExtension},
     python_requires=">=3.8",


### PR DESCRIPTION
## Motivation

Since AMD [migrated](https://github.com/Dao-AILab/flash-attention/pull/2230) FlashAttention-2's Triton backend to `ROCm/aiter`, Windows users with AMD GPUs have been unable to build FA-2 at all - the entire build pipeline assumes Linux. This PR adds the necessary platform support so FA-2 can be built and used on Windows via the ROCm/HIP SDK.

> [!NOTE]
> This PR depends on Windows build support being merged in `Dao-AILab/flash-attention` first (or applied locally). See the corresponding PR: Dao-AILab/flash-attention#2384

## Technical Details

**`cpp_extension.py`**
- Add Windows ROCm/HIP SDK discovery via `HIP_PATH`, bundled venv SDK packages (`_rocm_sdk_devel`, `_rocm_sdk_core`), and standard install paths (`C:\Program Files\AMD\ROCm\*`)
- Gate Linux-only compiler flags (`-fPIC`, `-mcmodel=large`, ELF linker flags) behind `sys.platform != "win32"` checks
- Fix ninja build file path escaping for Windows drive letters (`E:/foo` → `E$:/foo`)
- Use `.pyd`/`.dll` extensions and correct Windows linker flags (`/SUBSYSTEM:WINDOWS`, `/DLL`) for Python extension modules
- Add `_quote()` helper that uses double-quotes on Windows instead of `shlex.quote()` (single quotes break hipcc include paths)

**`chip_info.py`**
- Add `hipinfo` fallback alongside `rocminfo` for GPU/CU detection (`rocminfo` is not shipped with the Windows ROCm SDK)
- Refactor arch and CU count parsing into shared `_extract_gfx_from_output()` / `_extract_cu_from_output()` helpers
- Identify gfx942 SKUs by CU count on Windows instead of PCI chip ID (`libamdhip64` ctypes probe is Linux-only)

**`core.py`**
- Resolve `--offload-arch=native` on Windows (`hipcc.exe` does not support it; replace with detected gfx string)
- Use temp files instead of `/dev/null` and shell pipes in `hip_flag_checker()` and `check_LLVM_MAIN_REVISION()`
- Skip `/proc/sys/kernel/numa_balancing` check on Windows
- Replace `os.system("rm -rf ...")` with `shutil.rmtree` / `glob` + `os.remove`

**`parallel_state.py`**
- Guard `torch.distributed` import for Windows ROCm builds where it may be unavailable

**`setup.py`**
- Skip Linux-specific `hsa/` assembly blobs on Windows
- Move pre-build kernel compilation inside `NinjaBuildExtension.run()` to defer heavy imports until build time

## Test Plan
- Source build and install (using both PRs for now):
```
git clone -b fa2-aiter-triton-win-support https://github.com/0xDELUXA/flash-attention.git
cd flash-attention\third_party
git clone -b fa2-triton-win-support https://github.com/0xDELUXA/aiter.git
cd ..
$env:ENABLE_CK = "0"
$env:PREBUILD_KERNELS = "0"
$env:FLASH_ATTENTION_TRITON_AMD_ENABLE = "TRUE"
pip install --no-build-isolation -e .
```
- Run basic tests via `from flash_attn import flash_attn_func`.

## Test Result

- Successfully built FlashAttention-2 with aiter on Windows with an AMD GPU (`gfx1200`), ROCm `7.13.0a20260321`, PyTorch `2.12.0a0+rocm7.13.0a20260321`, Python `3.12`. 
- All tests passed.

###  **Discovery** 
`aiter.ops.triton.attention.mha.flash_attn_func` works directly on Windows when a tuned config JSON is placed at `aiter/ops/triton/configs/gfxNNNN-MHA-DEFAULT.json`. Benchmarking against `flash_attn.flash_attn_func` on `gfx1200` shows a 1.5x geomean speedup in favor of the aiter Triton kernel.

Used [this](https://gist.github.com/0xDELUXA/39b4b60afbd3e211bf418f6179c97023) benchmark script with [this](https://gist.github.com/0xDELUXA/266a88ce8a2c643acb6e1bff816e73d4) file placed in: `aiter/ops/triton/configs/` (otherwise it won’t find the config file and will error out). 

Results:

```
Importing aiter Triton backend... [aiter] import [module_aiter_enum] under C:\flash-attention\third_party\aiter\aiter\jit\module_aiter_enum.pyd
OK
Importing flash_attn... OK

PyTorch    : 2.12.0a0+rocm7.13.0a20260321
GPU        : AMD Radeon RX 9060 XT
aiter ver  : unknown  ->  aiter.ops.triton.attention.mha
flash_attn : 2.8.4  ->  flash_attn
dtype      : bf16  |  warmup=20  rep=100

[ 1/12] b1 hq32 hk32 sq1 sk4096 d128
         aiter  : 0.231 ms  0.07 TFLOPS
         fa     : 0.430 ms  0.04 TFLOPS
         winner : aiter  (1.863x)
[ 2/12] b1 hq32 hk32 sq512 sk4096 d128
         aiter  : 1.090 ms  7.88 TFLOPS
         fa     : 1.968 ms  4.37 TFLOPS
         winner : aiter  (1.806x)
[ 3/12] b1 hq32 hk32 sq2048 sk4096 d128
         aiter  : 3.895 ms  8.82 TFLOPS
         fa     : 6.978 ms  4.92 TFLOPS
         winner : aiter  (1.791x)
[ 4/12] b1 hq32 hk8 sq1 sk4096 d128
         aiter  : 0.202 ms  0.08 TFLOPS
         fa     : 0.196 ms  0.09 TFLOPS
         winner : flash_attn  (0.971x)
[ 5/12] b1 hq32 hk8 sq512 sk4096 d128
         aiter  : 0.988 ms  8.69 TFLOPS
         fa     : 1.432 ms  6.00 TFLOPS
         winner : aiter  (1.449x)
[ 6/12] b1 hq32 hk8 sq2048 sk4096 d128
         aiter  : 2.740 ms  12.54 TFLOPS
         fa     : 4.514 ms  7.61 TFLOPS
         winner : aiter  (1.647x)
[ 7/12] b4 hq32 hk32 sq1 sk4096 d128
         aiter  : 1.000 ms  0.07 TFLOPS
         fa     : 1.231 ms  0.06 TFLOPS
         winner : aiter  (1.231x)
[ 8/12] b4 hq32 hk32 sq512 sk4096 d128
         aiter  : 5.640 ms  6.09 TFLOPS
         fa     : 13.037 ms  2.64 TFLOPS
         winner : aiter  (2.312x)
[ 9/12] b4 hq32 hk32 sq2048 sk4096 d128
         aiter  : 15.426 ms  8.91 TFLOPS
         fa     : 41.548 ms  3.31 TFLOPS
         winner : aiter  (2.693x)
[10/12] b4 hq32 hk8 sq1 sk4096 d128
         aiter  : 0.590 ms  0.11 TFLOPS
         fa     : 0.459 ms  0.15 TFLOPS
         winner : flash_attn  (0.777x)
[11/12] b4 hq32 hk8 sq512 sk4096 d128
         aiter  : 3.506 ms  9.80 TFLOPS
         fa     : 5.835 ms  5.89 TFLOPS
         winner : aiter  (1.665x)
[12/12] b4 hq32 hk8 sq2048 sk4096 d128
         aiter  : 11.094 ms  12.39 TFLOPS
         fa     : 18.862 ms  7.29 TFLOPS
         winner : aiter  (1.700x)

===================================================================================================================
Config                                            aiter ms     fa ms     Δ ms   Speedup   aiter TFLOPS  fa TFLOPS
===================================================================================================================
b1 hq32 hk32 sq1 sk4096 d128                         0.231     0.430   -0.199    1.863x ✓           0.07       0.04
b1 hq32 hk32 sq512 sk4096 d128                       1.090     1.968   -0.878    1.806x ✓           7.88       4.37
b1 hq32 hk32 sq2048 sk4096 d128                      3.895     6.978   -3.083    1.791x ✓           8.82       4.92
b1 hq32 hk8 sq1 sk4096 d128                          0.202     0.196   +0.006    0.971x ✗           0.08       0.09
b1 hq32 hk8 sq512 sk4096 d128                        0.988     1.432   -0.444    1.449x ✓           8.69       6.00
b1 hq32 hk8 sq2048 sk4096 d128                       2.740     4.514   -1.774    1.647x ✓          12.54       7.61
b4 hq32 hk32 sq1 sk4096 d128                         1.000     1.231   -0.231    1.231x ✓           0.07       0.06
b4 hq32 hk32 sq512 sk4096 d128                       5.640    13.037   -7.397    2.312x ✓           6.09       2.64
b4 hq32 hk32 sq2048 sk4096 d128                     15.426    41.548  -26.122    2.693x ✓           8.91       3.31
b4 hq32 hk8 sq1 sk4096 d128                          0.590     0.459   +0.132    0.777x ✗           0.11       0.15
b4 hq32 hk8 sq512 sk4096 d128                        3.506     5.835   -2.330    1.665x ✓           9.80       5.89
b4 hq32 hk8 sq2048 sk4096 d128                      11.094    18.862   -7.768    1.700x ✓          12.39       7.29
-------------------------------------------------------------------------------------------------------------------
aiter wins / total                                      10 / 12
Geomean speedup (aiter / flash_attn)                 1.576x
===================================================================================================================
```