### PR TITLE
[setup][flydsl] Add flydsl into aiter install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -328,7 +328,7 @@ setup(
         "einops",
         "psutil",
         "packaging",
-        "flydsl>=0.1.1",
+        "flydsl==0.1.1",
     ],
     extras_require={
         # Triton-based communication using Iris


### PR DESCRIPTION
flydsl was only declared in requirements.txt and pyproject.toml build-system requires, but missing from setup.py install_requires. This caused flydsl to be absent in Docker images because `pip install -e . --no-build-isolation` skips build deps and only installs install_requires