### PR TITLE
[Misc] logging: skip aiter handler when root logger already has handlers

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -40,6 +40,8 @@ def getLogger():
         console_handler.setLevel(log_level)
 
         logger.addHandler(console_handler)
+        logger.propagate = False
+
         if hasattr(torch._dynamo.config, "ignore_logger_methods"):
             torch._dynamo.config.ignore_logger_methods = (
                 logging.Logger.info,


### PR DESCRIPTION
## Summary

Prevent duplicate aiter log output when used inside frameworks that configure the root logger (e.g. sglang, which imports xgrammar at startup).

## Motivation

When aiter is used inside sglang, xgrammar calls logging.basicConfig() at import time, adding a handler to the root logger. Because aiter's logger has propagate=True by default, every aiter log record is emitted twice:
```
[aiter] merge tuned file under model_configs/ and configs/ ...        # aiter's own handler
[2026-03-24 02:17:07] INFO core.py:276: merge tuned file under ...   # root logger's handler
```
after this change
```
[aiter] merge tuned file under model_configs/ and configs/ ...        # aiter's own handler
```

## Changes

- aiter/__init__.py getLogger(): add logger.propagate = False after logger.addHandler(console_handler)

aiter already attaches its own StreamHandler with the [aiter] formatter, so propagation to the root logger is redundant and causes duplicates. Disabling propagation ensures each record is handled exactly once, regardless of whether the calling framework has configured the root logger.


## Test Plan

Manually verified with sglang Engine — duplicate lines no longer appear

## Test Result

Manually verified with sglang Engine — duplicate lines no longer appear

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
