### PR TITLE
Fix: use pull_request_target for PR welcome comment on forked PRs

### DIFF
--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -1,7 +1,7 @@
 name: PR Welcome Comment
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, reopened]
 


### PR DESCRIPTION
## Summary

- Change `pull_request` to `pull_request_target` in the PR welcome comment workflow
- `pull_request` events from forked repos only receive a read-only `GITHUB_TOKEN`, causing `createComment` to fail with permission errors (e.g. [#2441](https://github.com/ROCm/aiter/pull/2441))
- `pull_request_target` runs in the base repository context with write permissions

## Safety

This workflow only posts a comment via GitHub API and never checks out or executes any code from the PR, so using `pull_request_target` introduces no security risk.

## Test plan

- [x] This PR itself is submitted from a fork to verify the fix works