### PR TITLE
[TRITON] Skip `test_metadata_redirect.py` on archs other than `gfx942`

### DIFF
--- a/op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py
+++ b/op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py
@@ -3,15 +3,24 @@ from pathlib import Path
 import torch
 import tempfile
 
+import pytest
+
 import triton
 import triton.language as tl
 from triton.backends.compiler import GPUTarget
 from triton.tools.compile import compile_kernel, CompileArgs
 
+from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.utility.triton.triton_metadata_redirect import (
     AOTMetadataContext,
     with_custom_metadata_path,
 )
+
+TARGET_ARCH: str = "gfx942"
+SKIP_TEST: bool = get_arch() != TARGET_ARCH
+SKIP_REASON: str = f"{os.path.basename(__file__)} only runs on {TARGET_ARCH}."
+
+pytestmark = pytest.mark.skipif(SKIP_TEST, reason=SKIP_REASON)
 
 triton_path = triton.__path__[0]
 kernel_path = os.path.join(Path(__file__).parent, "kernel.py")
@@ -5785,7 +5794,7 @@ def test_f32_kernel():
         compile_args = CompileArgs(
             path=kernel_path,
             kernel_name="empty_kernel",
-            signature=f"*fp32:16,1",
+            signature="*fp32:16,1",
             grid="1,1,1",
             num_warps=4,
             num_stages=2,
@@ -5867,6 +5876,9 @@ def test_separate_compile_and_run():
 
 
 if __name__ == "__main__":
-    test_f32_kernel()
-    test_jit()
-    test_separate_compile_and_run()
+    if SKIP_TEST:
+        print(SKIP_REASON)
+    else:
+        test_f32_kernel()
+        test_jit()
+        test_separate_compile_and_run()


### PR DESCRIPTION
## Motivation

`test_metadata_redirect.py` was designed to run only on `gfx942`. We want to run all Triton tests on `gfx950` as well - this is the reason behind the proposed changes.

## Technical Details

Conditionally skip all tests present on `test_metadata_redirect.py`, running them only on `gfx942` GPUs.

## Test Plan

Execute on `gfx942` and `gfx950`:

1. Run unit test: `pytest op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py`
2. Run main function: `python op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py`

Expected result: tests run on `gfx942`, tests are skipped on `gfx950`.

## Test Result

### `gfx942`

Running `pytest`:

```bash
pytest op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py
```
```text
============================================= test session starts ==============================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0
rootdir: /workspace/aiter
configfile: pyproject.toml
plugins: hypothesis-6.148.3
collected 3 items

op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py ...                             [100%]

============================================== 3 passed in 5.21s ===============================================
```

Running `test_metadata_redirect.py` main function:

```bash
python op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py
```
```text
[aiter] import [module_aiter_enum] under /workspace/aiter/aiter/jit/module_aiter_enum.so
temp_dir: /tmp/tmppnyt_roc
temp_dir: /tmp/tmpcmxuvu__
temp_dir: /tmp/tmphmrbnfp1
```

### `gfx950`

Running `pytest`:

```bash
pytest op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py
```
```text
============================================= test session starts ==============================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/aiter
configfile: pyproject.toml
plugins: hypothesis-6.151.9
collected 3 items

op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py sss                             [100%]

============================================== 3 skipped in 2.94s ==============================================
```

Running `test_metadata_redirect.py` main function:

```bash
python op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py
```
```text
[aiter] import [module_aiter_enum] under /workspace/aiter/aiter/jit/module_aiter_enum.so
test_metadata_redirect.py only runs on gfx942.
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
