### PR TITLE
fix: MoE dispatch for Quark W4A6 models (MXFP4 weights with QuantType.No)

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -254,6 +254,10 @@ def fused_moe_(
         dtypes.bf16,
     ], f"Fused_moe unsupported out dtype: {dtype}"
     quant_type = quant_remap.get(quant_type, quant_type)
+    # W4A6: remap QuantType.No -> per_1x32 for fp4x2 weights so activations
+    # get quantized to fp4x2 at runtime (CK MoE only supports A4W4).
+    if quant_type == QuantType.No and w1.dtype == dtypes.fp4x2:
+        quant_type = QuantType.per_1x32
     q_dtype_w = w1.dtype
     q_dtype_a = w1.dtype if w1.dtype != torch.uint32 else dtypes.fp8
     # If input is already FP8-quantized (e.g. from FP8 dispatch) with block scale,

--- a/aiter/fused_moe_dp_shared_expert.py
+++ b/aiter/fused_moe_dp_shared_expert.py
@@ -160,6 +160,9 @@ def fused_moe_dp_share_expert(
         dtypes.bf16,
     ], f"Fused_moe unsupported out dtype: {dtype}"
     quant_type = quant_remap.get(quant_type, quant_type)
+    # W4A6: remap QuantType.No -> per_1x32 for fp4x2 weights.
+    if quant_type == QuantType.No and w1.dtype == dtypes.fp4x2:
+        quant_type = QuantType.per_1x32
     q_dtype_w = w1.dtype
     q_dtype_a = w1.dtype if w1.dtype != torch.uint32 else dtypes.fp8
     q_dtype_a = dtypes.fp4x2 if quant_type == QuantType.per_1x32 else q_dtype_a


### PR DESCRIPTION
## Motivation
W4A6 models store MoE weights in MXFP4 (`fp4x2 dtype`), but use MXFP6 for activation quantization. Because the Quark quantization scheme handles activation quantization separately, it passes `QuantType.No` to the AITER CK-based fused MoE kernel. However, the CK kernel only supports A4W4 (both activations and weights in fp4) and there is no codepath for bf16 activations with fp4x2 weights.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
After the existing `quant_remap `lookup in `ck_moe_2stages `(and the equivalent in `ck_moe_2stages_dp`), detect the unsupported combination of `QuantType.No` with `fp4x2` weights and remap to `QuantType.per_1x32`. This ensures activations are dynamically quantized to fp4x2 at runtime, matching what the CK kernel expects.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Verified with `ziliangpeng/DeepSeek-V3-Quark-MXFP4-v4-w4a6` on MI355X (gfx950) / ROCm 7.2 / vLLM 0.17.1. MoE layers execute successfully in both eager and compile modes. Results of the experiment can be found here: https://github.com/AMD-AGI/di-recipes/blob/main/tools/prompt_replay/baselines/DeepSeek-V3-0324/MI355/serve_dsr1_0528_mxfp4-v4-w4a6_20260316_smci355-ccs-aus-m15-13.cs-aus.dcgpu.log
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
