### PR TITLE
Fix CKTile blockscale GEMM to read strides from tensor metadata

### DIFF
--- a/csrc/ck_gemm_a8w8_blockscale/include/gemm_a8w8_blockscale_cktile_common.cuh
+++ b/csrc/ck_gemm_a8w8_blockscale/include/gemm_a8w8_blockscale_cktile_common.cuh
@@ -281,6 +281,16 @@ __forceinline__ torch::Tensor gemm_a8w8_blockscale_cktile_impl(torch::Tensor& XQ
     TORCH_CHECK(XQ.dtype() == WQ.dtype(), "Weights and activations should have the same dtype!");
     TORCH_CHECK(x_scale.dtype() == w_scale.dtype(), "Scales should have the same dtype!");
 
+    TORCH_CHECK(XQ.stride(-1) == 1,
+        "CKTile blockscale GEMM: XQ inner dim must be contiguous, "
+        "got strides=[", XQ.stride(0), ",", XQ.stride(1), "]");
+    TORCH_CHECK(WQ.stride(-1) == 1,
+        "CKTile blockscale GEMM: WQ inner dim must be contiguous, "
+        "got strides=[", WQ.stride(0), ",", WQ.stride(1), "]");
+    TORCH_CHECK(Y.stride(-1) == 1,
+        "CKTile blockscale GEMM: Y inner dim must be contiguous, "
+        "got strides=[", Y.stride(0), ",", Y.stride(1), "]");
+
     // M, N, K
     const int M = XQ.size(0);
     const int N = WQ.size(0);
@@ -329,13 +339,16 @@ __forceinline__ torch::Tensor gemm_a8w8_blockscale_cktile_impl(torch::Tensor& XQ
     const int BQK = ck_tile::integer_divide_ceil(K, BQuantGroupSize::kK);
     const int BQN = ck_tile::integer_divide_ceil(N, BQuantGroupSize::kN);
 
-    const int stride_A = K;
-    const int stride_B = K;
-    const int stride_C = N;
-    // const int stride_AQ = AQK;
-    const int stride_AQ = eight_waves ? M    // Col-Major
-                                      : AQK; // Row-Major
-    const int stride_BQ = BQK;
+    // Read leading-dimension strides from tensor metadata instead of
+    // assuming dense layout.  vLLM's _maybe_pad_fp8_weight can produce
+    // row-major tensors whose leading-dimension stride exceeds the
+    // logical column count (e.g. shape [N,K] with stride [K+pad, 1]).
+    const int stride_A = XQ.stride(0);
+    const int stride_B = WQ.stride(0);
+    const int stride_C = Y.stride(0);
+    const int stride_AQ = eight_waves ? M
+                                      : static_cast<int>(x_scale.stride(0));
+    const int stride_BQ = w_scale.stride(0);
 
     args.QK_A      = AQK;
     args.QK_B      = BQK;


### PR DESCRIPTION
## Summary

- **Root cause**: The CKTile blockscale GEMM host wrapper hardcoded leading-dimension strides (`stride_A = K`, `stride_B = K`, `stride_C = N`), assuming fully contiguous row-major layout. In vLLM on ROCm, `_maybe_pad_fp8_weight` pads FP8 weight tensors for alignment and creates a narrowed view, producing tensors with shape `[N, K]` but physical stride `[K+pad, 1]`. The hardcoded `stride_B = K` caused the kernel to read from wrong memory offsets, producing silently wrong output.
- **Fix**: Read leading-dimension strides from PyTorch tensor metadata (`XQ.stride(0)`, `WQ.stride(0)`, etc.) instead of assuming dense layout. Add `TORCH_CHECK` assertions verifying inner-dimension contiguity (`stride(-1) == 1`), which the CKTile kernel requires.
- The old CK backend (`gemm_a8w8_blockscale_common.cuh`) already reads strides from tensor metadata, which is why it was unaffected.

## Test plan

- [x] Verified fix produces correct output by running vLLM serve (Qwen3-Next-80B-A3B-Instruct-FP8, TP=1, eager mode) inside the `amdsiloai/vllm-private` Docker image on MI355X (gfx950)
- [x] Confirmed CKTile 8-warp kernels (kernel IDs 10, 11) are dispatched and produce correct results (20,500+ GEMM calls, all outputs coherent)
- [x] `TORCH_CHECK` assertions correctly catch non-contiguous inner dimensions at runtime
- [ ] Existing `op_tests/test_gemm_a8w8_blockscale.py` should continue to pass (contiguous inputs → strides match logical dimensions)