### PR TITLE
CI: replace MI355 runner labels with MI35X

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -211,23 +211,23 @@ jobs:
       matrix:
         include:
           - runner: linux-aiter-mi35x-1
-            label: MI355
+            label: MI35X
             shard_total: 5
             shard_idx: 0
           - runner: linux-aiter-mi35x-1
-            label: MI355
+            label: MI35X
             shard_total: 5
             shard_idx: 1
           - runner: linux-aiter-mi35x-1
-            label: MI355
+            label: MI35X
             shard_total: 5
             shard_idx: 2
           - runner: linux-aiter-mi35x-1
-            label: MI355
+            label: MI35X
             shard_total: 5
             shard_idx: 3
           - runner: linux-aiter-mi35x-1
-            label: MI355
+            label: MI35X
             shard_total: 5
             shard_idx: 4
           - runner: aiter-1gpu-runner
@@ -422,7 +422,7 @@ jobs:
       matrix:
         include:
           - runner: linux-aiter-mi35x-8
-            label: MI355
+            label: MI35X
           - runner: aiter-8gpu-runner
             label: MI325
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -64,7 +64,7 @@ jobs:
             runner: aiter-8gpu-runner
             run_on_pr: true
           - model_name: "gpt-oss-120b"
-            label: MI355
+            label: MI35X
             model_path: "openai/gpt-oss-120b"
             extraArgs: "--kv_cache_dtype fp8 --gpu-memory-utilization 0.3"
             env_vars: |

--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         include:
           - runner: linux-aiter-mi35x-1
-            label: MI355
+            label: MI35X
           - runner: aiter-gfx1100
             label: RDNA3
             optional: true

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -240,10 +240,10 @@ jobs:
         run: |
           docker rm -f triton_test || true
 
-  # Step 2b: MI355 matrix jobs (opt-in via ci:triton-355 label)
+  # Step 2b: MI35X matrix jobs (opt-in via ci:triton-355 label)
   triton-mi355:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:triton-355') }}
-    name: Triton Tests (MI355) / Shard ${{ matrix.shard }}
+    name: Triton Tests (MI35X) / Shard ${{ matrix.shard }}
     runs-on: linux-aiter-mi35x-1
     needs: [split_triton_tests, build-triton, check-signal]
     strategy:
@@ -342,7 +342,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: triton-test-mi355-shard-${{ matrix.shard }}
+          name: triton-test-mi35x-shard-${{ matrix.shard }}
           path: test-reports/triton.xml
 
       - name: Cleanup container
@@ -352,32 +352,32 @@ jobs:
 
   triton-mi355-test-finish:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:triton-355') }}
-    name: Triton MI355 Test Results
+    name: Triton MI35X Test Results
     runs-on: ubuntu-latest
     needs: [triton-mi355]
     steps:
-      - name: Download all MI355 test reports
+      - name: Download all MI35X test reports
         uses: actions/download-artifact@v4
         with:
-          pattern: triton-test-mi355-shard-*
+          pattern: triton-test-mi35x-shard-*
           path: .
 
-      - name: Check Triton MI355 Test Results
+      - name: Check Triton MI35X Test Results
         run: |
           set -ex
-          echo "Checking Triton MI355 Test Results..."
+          echo "Checking Triton MI35X Test Results..."
           all_passed=true
           for shard in {0..7}; do
-            if [ ! -f triton-test-mi355-shard-${shard}/triton.xml ]; then
-              echo "MI355 test report for shard ${shard} not found."
+            if [ ! -f triton-test-mi35x-shard-${shard}/triton.xml ]; then
+              echo "MI35X test report for shard ${shard} not found."
               all_passed=false
               break
             fi
           done
           if [ "$all_passed" = true ]; then
-            echo "All MI355 tests passed."
+            echo "All MI35X tests passed."
           else
-            echo "MI355 test failures or errors detected."
+            echo "MI35X test failures or errors detected."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Test-only change to swap selected workflow runner labels from `linux-aiter-mi355-1/8` to `linux-aiter-mi350-1/8`.
- Scope intentionally limited to:
  - `.github/workflows/aiter-test.yaml`
  - `.github/workflows/atom-test.yaml`
  - `.github/workflows/flash_attention_integration.yaml`
  - `.github/workflows/triton-test.yaml`
- Explicitly excluded from this PR:
  - `.github/runner-config.yml`
  - `.github/workflows/aiter-release.yaml`
  - `.github/workflows/test-network.yaml`

## Test plan
- [ ] Trigger `aiter-test` and verify jobs schedule on `linux-aiter-mi350-1` and `linux-aiter-mi350-8`.
- [ ] Trigger `flash_attention_integration` and verify MI355 lane uses `linux-aiter-mi350-1`.
- [ ] Trigger `atom-test` and `triton-test` labels and verify runner scheduling is correct.
- [ ] Confirm no unintended workflow behavior changes beyond runner label swaps.