### PR TITLE
CI: Install setuptools_scm and vcs_versioning before aiter setup

### DIFF
--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -10,6 +10,7 @@ echo
 echo "==== Install dependencies and aiter ===="
 pip install --upgrade pandas zmq einops numpy==1.26.2
 pip uninstall -y aiter || true
+pip install --upgrade "setuptools_scm<9" vcs_versioning
 pip install --upgrade "pybind11>=3.0.1"
 pip install --upgrade "ninja>=1.11.1"
 pip install tabulate

--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -10,7 +10,7 @@ echo
 echo "==== Install dependencies and aiter ===="
 pip install --upgrade pandas zmq einops numpy==1.26.2
 pip uninstall -y aiter || true
-pip install --upgrade "setuptools_scm<9" vcs_versioning
+pip install --upgrade "setuptools_scm<9"
 pip install --upgrade "pybind11>=3.0.1"
 pip install --upgrade "ninja>=1.11.1"
 pip install tabulate

--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -8,6 +8,7 @@ dpkg -l | grep rocm || echo "No ROCm packages found."
 
 echo
 echo "==== Install dependencies and aiter ===="
+git config --global --add safe.directory /workspace
 pip install --upgrade pandas zmq einops numpy==1.26.2
 pip uninstall -y aiter || true
 pip install --upgrade "setuptools_scm<9"

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -69,6 +69,7 @@ jobs:
           RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
           RUN pip uninstall -y aiter
           RUN pip install --upgrade pandas zmq einops numpy==1.26.2
+          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip install --upgrade "ninja>=1.11.1"
           RUN pip install tabulate

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -69,7 +69,7 @@ jobs:
           RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
           RUN pip uninstall -y aiter
           RUN pip install --upgrade pandas zmq einops numpy==1.26.2
-          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
+          RUN pip install --upgrade "setuptools_scm<9"
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip install --upgrade "ninja>=1.11.1"
           RUN pip install tabulate

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -94,6 +94,7 @@ jobs:
 
           RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
           RUN pip uninstall -y amd-aiter
+          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip show pybind11
           RUN rm -rf /app/aiter-test

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -94,7 +94,7 @@ jobs:
 
           RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
           RUN pip uninstall -y amd-aiter
-          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
+          RUN pip install --upgrade "setuptools_scm<9"
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip show pybind11
           RUN rm -rf /app/aiter-test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
           # Install minimal dependencies for doc build
           # (ROCm not needed for documentation generation)
           pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install "setuptools_scm<9" vcs_versioning
           pip install -e . || true  # Continue even if full install fails
 
       - name: Build Sphinx documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
           # Install minimal dependencies for doc build
           # (ROCm not needed for documentation generation)
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install "setuptools_scm<9" vcs_versioning
+          pip install "setuptools_scm<9"
           pip install -e . || true  # Continue even if full install fails
 
       - name: Build Sphinx documentation

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -81,7 +81,7 @@ jobs:
 
           RUN echo "=== Aiter version BEFORE uninstall ===" && pip show aiter || true
           RUN pip uninstall -y aiter
-          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
+          RUN pip install --upgrade "setuptools_scm<9"
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip show pybind11
 

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -81,6 +81,7 @@ jobs:
 
           RUN echo "=== Aiter version BEFORE uninstall ===" && pip show aiter || true
           RUN pip uninstall -y aiter
+          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip show pybind11
 

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -74,6 +74,7 @@ jobs:
           RUN pip config set global.default-timeout 60 \
               && pip config set global.retries 10
           RUN pip config set global.index-url https://ausartifactory.amd.com/artifactory/api/pypi/hw-cpe-prod-remote/simple
+          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip show pybind11
 

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -74,7 +74,7 @@ jobs:
           RUN pip config set global.default-timeout 60 \
               && pip config set global.retries 10
           RUN pip config set global.index-url https://ausartifactory.amd.com/artifactory/api/pypi/hw-cpe-prod-remote/simple
-          RUN pip install --upgrade "setuptools_scm<9" vcs_versioning
+          RUN pip install --upgrade "setuptools_scm<9"
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip show pybind11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "pybind11>=3.0.1",
     "setuptools>=45",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools_scm[toml]<9",
     "wheel",
     "packaging",
     "psutil",


### PR DESCRIPTION
## Summary
- Install `setuptools_scm<9` and `vcs_versioning` before aiter setup/build steps in CI.
- Apply the same dependency pre-installation in both shared build script and workflow Dockerfile paths.
- Cover all known CI paths that run `setup.py develop` or editable installs for aiter.

## Why
Recent CI failures showed `ModuleNotFoundError: No module named 'vcs_versioning'` during aiter setup, especially in runner/network-unstable environments. Pre-installing these dependencies makes setup path deterministic and avoids transient build-time breakage.

## Scope
- `.github/scripts/build_aiter_triton.sh`
- `.github/workflows/aiter-test.yaml`
- `.github/workflows/atom-test.yaml`
- `.github/workflows/docs.yml`
- `.github/workflows/sglang_downstream.yaml`
- `.github/workflows/vllm_benchmark.yaml`

## Test plan
- [ ] Trigger `Aiter Test` and confirm no `vcs_versioning` import failure in setup stage.
- [ ] Trigger `Triton Test` and confirm `build_aiter_triton.sh` setup stage is stable.
- [ ] Trigger `ATOM Test` and `vLLM Benchmark` image build path to verify dependency step completes.