### PR TITLE
Fix CPU/GPU device mismatch in _yarn_linear_ramp_mask

### DIFF
--- a/aiter/rotary_embedding.py
+++ b/aiter/rotary_embedding.py
@@ -595,12 +595,12 @@ def _yarn_find_correction_range(
 
 
 def _yarn_linear_ramp_mask(
-    low: float, high: float, dim: int, dtype: torch.dtype
+    low: float, high: float, dim: int, dtype: torch.dtype, device=None
 ) -> torch.Tensor:
     if low == high:
         high += 0.001  # Prevent singularity
 
-    linear_func = (torch.arange(dim, dtype=dtype) - low) / (high - low)
+    linear_func = (torch.arange(dim, dtype=dtype, device=device) - low) / (high - low)
     ramp_func = torch.clamp(linear_func, 0, 1)
     return ramp_func
 
@@ -660,7 +660,13 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         # Get n-d rotational scaling corrected for extrapolation
         inv_freq_mask = (
             1
-            - _yarn_linear_ramp_mask(low, high, self.rotary_dim // 2, dtype=dtypes.fp32)
+            - _yarn_linear_ramp_mask(
+                low,
+                high,
+                self.rotary_dim // 2,
+                dtype=dtypes.fp32,
+                device=pos_freqs.device,
+            )
         ) * self.extrapolation_factor
         inv_freq = (
             inv_freq_interpolation * (1 - inv_freq_mask)
@@ -876,7 +882,13 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
         # Get n-d rotational scaling corrected for extrapolation
         inv_freq_mask = (
             1
-            - _yarn_linear_ramp_mask(low, high, self.rotary_dim // 2, dtype=dtypes.fp32)
+            - _yarn_linear_ramp_mask(
+                low,
+                high,
+                self.rotary_dim // 2,
+                dtype=dtypes.fp32,
+                device=pos_freqs.device,
+            )
         ) * self.extrapolation_factor
         inv_freq = (
             inv_freq_interpolation * (1 - inv_freq_mask)

--- a/aiter/rotary_embedding.py
+++ b/aiter/rotary_embedding.py
@@ -596,12 +596,12 @@ def _yarn_find_correction_range(
 
 
 def _yarn_linear_ramp_mask(
-    low: float, high: float, dim: int, dtype: torch.dtype
+    low: float, high: float, dim: int, dtype: torch.dtype, device=None
 ) -> torch.Tensor:
     if low == high:
         high += 0.001  # Prevent singularity
 
-    linear_func = (torch.arange(dim, dtype=dtype) - low) / (high - low)
+    linear_func = (torch.arange(dim, dtype=dtype, device=device) - low) / (high - low)
     ramp_func = torch.clamp(linear_func, 0, 1)
     return ramp_func
 
@@ -661,7 +661,13 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
         # Get n-d rotational scaling corrected for extrapolation
         inv_freq_mask = (
             1
-            - _yarn_linear_ramp_mask(low, high, self.rotary_dim // 2, dtype=dtypes.fp32)
+            - _yarn_linear_ramp_mask(
+                low,
+                high,
+                self.rotary_dim // 2,
+                dtype=dtypes.fp32,
+                device=pos_freqs.device,
+            )
         ) * self.extrapolation_factor
         inv_freq = (
             inv_freq_interpolation * (1 - inv_freq_mask)
@@ -877,7 +883,13 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
         # Get n-d rotational scaling corrected for extrapolation
         inv_freq_mask = (
             1
-            - _yarn_linear_ramp_mask(low, high, self.rotary_dim // 2, dtype=dtypes.fp32)
+            - _yarn_linear_ramp_mask(
+                low,
+                high,
+                self.rotary_dim // 2,
+                dtype=dtypes.fp32,
+                device=pos_freqs.device,
+            )
         ) * self.extrapolation_factor
         inv_freq = (
             inv_freq_interpolation * (1 - inv_freq_mask)


### PR DESCRIPTION
`_yarn_linear_ramp_mask` creates `torch.arange` on CPU (default device) but callers in `YaRNScalingRotaryEmbedding._compute_inv_freq` and `DeepseekScalingRotaryEmbedding._compute_inv_freq` use the result with GPU tensors (`pos_freqs` created with `device="cuda"`), causing:

  RuntimeError: Expected all tensors to be on the same device,
  but found at least two devices, cuda:N and cpu!

This manifests during CUDA graph capture in SGLang when serving models with DeepseekScaling/YaRN rotary embeddings (e.g., Kimi-K2.5).

Fix: Add `device` parameter to `_yarn_linear_ramp_mask` (default "cuda") and pass `device="cuda"` from both call sites.

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
