### PR TITLE
[TRITON] Add kernel filter to the bench_models.py script

### DIFF
--- a/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_models.py
+++ b/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_models.py
@@ -605,10 +605,12 @@ def run_benchmarks(
                 )
                 continue
 
+            # MLA only reports time (ms)
+            run_metric = "time" if kernel == "mla" else metric
+
             bench_fn = KERNEL_DICT[kernel]
             handler = _get_handler(kernel)
-            # MLA only reports time (ms); use "time" metric for it
-            run_metric = "time" if kernel == "mla" else metric
+
             handler.set_run(model, kernel, run_metric, gemm_layout, mha_layout, TP)
             tp_shapes = handler.get_tp_shapes(shapes)
             for shape in tp_shapes:
@@ -662,7 +664,9 @@ def parse_arg_list(
     return sorted(set(result))  # Remove duplicates and sort
 
 
-def parse_args(available_models: list[str]) -> argparse.Namespace:
+def parse_args(
+    available_models: list[str], available_kernels: list[str]
+) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Model benchmarking tool",
         allow_abbrev=False,
@@ -719,11 +723,23 @@ def parse_args(available_models: list[str]) -> argparse.Namespace:
         "--model",
         default=None,
         help=(
-            "model name filter: case-insensitive regex matched against model name (default: all models). "
+            "Model name filter: case-insensitive regex matched against model names "
+            "(default: all models). "
             "e.g. 'llama3' to include only Llama3 family, "
             "'llama|qwen' to include both Llama and Qwen families, "
             "'^(?!.*deepseek)' to exclude DeepSeek family."
             f"\nAvailable models: {', '.join(available_models)}."
+        ),
+    )
+    parser.add_argument(
+        "--kernel",
+        default=None,
+        help=(
+            "Kernel name filter: case-insensitive regex matched against kernel names "
+            "(default: all kernels). "
+            "e.g. 'gemm' to include any kernel name containing gemm, "
+            "'moe|rmsnorm' for MoE and RMSNorm."
+            f"\nAvailable kernels: {', '.join(available_kernels)}."
         ),
     )
     parser.add_argument(
@@ -754,12 +770,57 @@ def parse_args(available_models: list[str]) -> argparse.Namespace:
     return args
 
 
+def filter_models_and_kernels(
+    data: ModelShapesData,
+    available_models: list[str],
+    model_pattern: str | None,
+    kernel_pattern: str | None,
+) -> ModelShapesData | None:
+
+    def _filter_by_regex(
+        pattern: str, pattern_name: str, candidates: list[str]
+    ) -> list[str]:
+        try:
+            pat = re.compile(pattern, re.IGNORECASE)
+        except re.error:
+            print(
+                f"Invalid {pattern_name} regex: {pattern!r} - running all {pattern_name}s."
+            )
+            return candidates
+        return [n for n in candidates if pat.search(n) is not None]
+
+    if model_pattern is not None:
+        matched_models = _filter_by_regex(model_pattern, "model", available_models)
+        data = {m: data[m] for m in matched_models}
+        if not data:
+            print("There are no models after filtering by model name.")
+            return None
+
+    if kernel_pattern is not None:
+        filtered: ModelShapesData = {}
+        for m, kernels in data.items():
+            matched_kernels = _filter_by_regex(
+                kernel_pattern, "kernel", sorted(list(kernels.keys()))
+            )
+            kept = {k: kernels[k] for k in matched_kernels}
+            if kept:
+                filtered[m] = kept
+        data = filtered
+        if not data:
+            print("There are no models/kernels after filtering by kernel name.")
+            return None
+
+    return data
+
+
 def main() -> None:
     data = read_json("model_shapes.json")
-    available_models = list(data.keys())
-    args = parse_args(available_models)
+    available_models = sorted(list(data.keys()))
+    available_kernels = sorted(list(KERNEL_DICT.keys()))
+    args = parse_args(available_models, available_kernels)
 
     models = args.model
+    kernels = args.kernel
     batch_sizes = args.batch_size
     seq_lens = args.seq_len
     TP = args.TP
@@ -768,15 +829,10 @@ def main() -> None:
     mha_layout = args.mha_layout
     output_file = args.output_file
 
-    if models is not None:
-        try:
-            pattern: re.Pattern[str] = re.compile(models, re.IGNORECASE)
-            data = {m: data[m] for m in available_models if pattern.search(m)}
-            if not data:
-                print("There are no models after filtering by model name.")
-                return
-        except re.error:
-            print(f"Invalid model filter regex: {models!r} - running all models.")
+    filtered_data = filter_models_and_kernels(data, available_models, models, kernels)
+    if filtered_data is None:
+        return
+    data = filtered_data
 
     results = run_benchmarks(
         data, batch_sizes, seq_lens, TP, gemm_layout, mha_layout, metric


### PR DESCRIPTION
## Motivation

Add a regex kernel filtering functionality to the bench_models.py script.

## Technical Details

The new `--kernel` arg expects a case-insensitive regex to be matched against all the available kernel names.
E.g. `'gemm'` to include any kernel name containing gemm, `'moe|rmsnorm'` for MoE and RMSNorm kernels, `'^(?=.*gemm)(?!.*batched)'` to include GEMM and exclude batched GEMM kernels.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
