### PR TITLE
[Opt] Fused car+rms for gpt-oss and ensure to use 1-stage kernel

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -2506,7 +2506,7 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
     hipGetDeviceProperties(&dev_prop, dev);
     uint32_t num_cu = dev_prop.multiProcessorCount;
 
-    use_1stage = (use_1stage && (n == 4096 || n == 2048 || n == 1024 || n == 512));
+    use_1stage = (use_1stage && (n == 4096 || n == 2880 || n == 2048 || n == 1024 || n == 512));
 #define DISPATCH_1S_KERNEL(NGPUS, N)                                          \
     case N: {                                                                 \
         allreduce_fusion_kernel_1stage_launcher<T, T, NGPUS, N>(ptrs,         \
@@ -2529,6 +2529,7 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
         switch(n)                                                        \
         {                                                                \
             DISPATCH_1S_KERNEL(NGPUS, 4096)                              \
+            DISPATCH_1S_KERNEL(NGPUS, 2880)                              \
             DISPATCH_1S_KERNEL(NGPUS, 2048)                              \
             DISPATCH_1S_KERNEL(NGPUS, 1024)                              \
             DISPATCH_1S_KERNEL(NGPUS, 512)                               \
@@ -2579,7 +2580,7 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
             sg_, residual_inp, residual_out, output, weight, eps, rank_, m, n); \
     } while(0)
 
-    if(n_bytes % 1024 == 0)
+    if(n_bytes % 16 == 0)
     {
         if(8192 <= n_bytes && n_bytes <= 32768)
         {
@@ -2727,6 +2728,7 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
         switch(n)                                                                            \
         {                                                                                    \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 4096, allreduce_fusion_kernel_split_launcher)  \
+            DISPATCH_AR_FUSION_KERNEL_(NGPUS, 2880, allreduce_fusion_kernel_split_launcher)  \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 2048, allreduce_fusion_kernel_split_launcher)  \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 1024, allreduce_fusion_kernel_split_launcher)  \
             DISPATCH_AR_FUSION_KERNEL_(NGPUS, 512, allreduce_fusion_kernel_split_launcher)   \


### PR DESCRIPTION
…ptized performance

## Motivation

This PR will fix two issues

1. Functionality is not work
PR #2329 to fix the issue "fused allreduce rmsnorm shape error" when enable "car+rmsnorm fusion" in gpt-oss model.
But the later PR #2346 remove this change and cause the run-time error in gpt-oss run.

2. Performance is worse than no-fusion version
Current code logic, the fusion kernel for last_dim 2880 will not use 1-stage kernel, it will introduce two kernels `reduce_scatter_cross_device_store` + `local_device_load_rmsnorm` that does not get the fusion benefits than un-fusion version.


## Technical Details

Add last_dim 2880 support for gpt-oss model

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
