### PR TITLE
CI: add docker password secret selector for aiter release workflow

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -24,6 +24,14 @@ on:
         description: 'Docker image for Python 3.12 build'
         required: true
         default: 'rocm/vllm-dev:nightly'
+      docker_password_secret:
+        description: 'Docker password secret for docker login'
+        required: true
+        default: 'DOCKER_PASSWORD'
+        type: choice
+        options:
+          - DOCKER_PASSWORD
+          - DOCKER_PASSWORD_ROCM
       gpu_archs:
         description: 'GPU architectures (e.g. gfx942;gfx950)'
         required: false
@@ -88,6 +96,12 @@ jobs:
           set -ex
           git submodule sync
           git submodule update --init --recursive --depth 1 --jobs 4
+
+      - name: Docker login
+        if: ${{ matrix.build_enabled }}
+        run: |
+          set -ex
+          echo "${{ secrets[github.event.inputs.docker_password_secret] }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Run the container
         if: ${{ matrix.build_enabled }}


### PR DESCRIPTION
## Summary
- Add a `workflow_dispatch` choice input `docker_password_secret` for `Aiter Release Package` manual runs.
- Default the selector to `DOCKER_PASSWORD` and allow `DOCKER_PASSWORD_ROCM` as an alternative.
- Add a Docker login step that reads the selected secret dynamically before build steps.

## Test plan
- [ ] Open Actions -> Aiter Release Package -> Run workflow.
- [ ] Verify `docker_password_secret` shows both options and defaults to `DOCKER_PASSWORD`.
- [ ] Trigger one run with each option and verify Docker login succeeds.