### PR TITLE
CI: add docker username input to aiter release workflow

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -32,6 +32,10 @@ on:
         options:
           - DOCKER_PASSWORD
           - DOCKER_PASSWORD_ROCM
+      docker_username:
+        description: 'Docker username for docker login'
+        required: true
+        default: 'rocmshard'
       gpu_archs:
         description: 'GPU architectures (e.g. gfx942;gfx950)'
         required: false
@@ -101,7 +105,7 @@ jobs:
         if: ${{ matrix.build_enabled }}
         run: |
           set -ex
-          echo "${{ secrets[github.event.inputs.docker_password_secret] }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          echo "${{ secrets[github.event.inputs.docker_password_secret] }}" | docker login -u "${{ github.event.inputs.docker_username }}" --password-stdin
 
       - name: Run the container
         if: ${{ matrix.build_enabled }}


### PR DESCRIPTION
## Summary
- Add `docker_username` as a `workflow_dispatch` input in `aiter-release.yaml`, defaulting to `rocmshard`.
- Update Docker login to use `${{ github.event.inputs.docker_username }}` so release runs can select a username at dispatch time.
- Keep existing docker password secret selection flow unchanged.

## Test plan
- [x] Verified workflow YAML is valid after update.
- [x] Confirmed only `.github/workflows/aiter-release.yaml` is changed in this PR.
- [ ] Trigger `Aiter Release Package` manually with default `docker_username`.
- [ ] Trigger `Aiter Release Package` manually with a custom `docker_username`.