### PR TITLE
(alternative to #2508) Fix/splitk tmp_out undersized buffer avoid double-zeroing

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1738,9 +1738,9 @@ def ck_moe_stage1(
     if is_splitk:
         valid_out = tmp_out[: token_num * topk, :]
         if activation == ActivationType.Silu:
-            aiter.silu_and_mul(out, valid_out)
+            aiter.silu_and_mul(out, valid_out.view(dtypes.fp32))
         else:
-            aiter.gelu_and_mul(out, valid_out)
+            aiter.gelu_and_mul(out, valid_out.view(dtypes.fp32))
     return out
 
 


### PR DESCRIPTION

The C++ side of this crash was fixed in [ROCm/rocm-libraries#5225](https://github.com/ROCm/rocm-libraries/pull/5225), which corrected the `hipMemsetAsync` size from `arg.M * arg.N` to `arg.NumTokens * arg.TopK * arg.N`. This PR fixes the **Python side** to match.

## Technical Details

### Root Cause

In `ck_moe_stage1()`, the `tmp_out` buffer was allocated as `(token_num, topk, w1.shape[1])` which is undersized when `splitK > 1`. The CK kernel operates on `sorted_size = min(token_num * topk * block_m, sorted_token_ids.shape[0])` rows, so the buffer must be `(sorted_size, w1.shape[1])`.

For DeepSeek V3 decode (`token_num=1, topk=8, block_m=16`):
- **Old Python buffer:** `1 * 8 * 4096 * 4 = 128 KB`
- **CK kernel expects:** `128 * 2048 * 4 * 2 = 2 MB`

### Fix

1. **`ck_moe_stage1`**: Allocate `tmp_out` with `sorted_size` rows using `torch.empty` (CK kernel zeros the buffer via `hipMemsetAsync`, avoiding redundant double-zeroing). After the kernel, slice `valid_out = tmp_out[:token_num * topk, :]` before `silu_and_mul`/`gelu_and_mul`.

2. **`cktile_moe_stage1`**: Added warning comment flagging the same undersized buffer pattern. The code is left unchanged since fp32 splitk is not yet active (see existing `TODO: support fp32 splitk`), but the comment documents the fix to apply when that path is enabled.

### Why `torch.empty` instead of `torch.zeros`

With [ROCm/rocm-libraries#5225](https://github.com/ROCm/rocm-libraries/pull/5225) merged, the CK kernel correctly zeros the buffer via `hipMemsetAsync` when `KBatch > 1`. Using `torch.empty` avoids double-zeroing (once by Python, once by CK), eliminating a redundant GPU kernel launch.

## Test Result

DeepSeek-R1-0528 (FP8, 8xMI355X): runtime error resolved, splitK active with correct results.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.