### PR TITLE
Remove torch dependency from module_moe_asm

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -432,7 +432,6 @@
     },
     "module_moe_asm": {
         "srcs": [
-            "f'{AITER_CSRC_DIR}/pybind/moe_op_pybind.cu'",
             "f'{AITER_CSRC_DIR}/kernels/topk_softmax_kernels.cu'",
             "f'{AITER_CSRC_DIR}/kernels/topk_softmax_kernels_group.cu'",
             "f'{AITER_CSRC_DIR}/kernels/moe_fused_gate.cu'",
@@ -446,6 +445,7 @@
             "f'{AITER_CSRC_DIR}/include/ck_tile'"
         ],
         "verbose": "False",
+        "torch_exclude": "True",
         "blob_gen_cmd": [
             "f'{AITER_META_DIR}/hsa/codegen.py -m topksoftmax --output_dir {{}}'"
         ]

--- a/aiter/ops/moe_op.py
+++ b/aiter/ops/moe_op.py
@@ -12,7 +12,7 @@ import functools
 torch.int4 = getattr(torch, "int4", torch.uint32)
 
 
-@compile_ops("module_moe_asm")
+@compile_ops("module_moe_asm", ffi_type="ctypes")
 def topk_softmax(
     topk_weights: Tensor,
     topk_indices: Tensor,
@@ -40,11 +40,11 @@ def topk_sigmoid(
 ) -> None: ...
 
 
-@compile_ops("module_moe_asm")
+@compile_ops("module_moe_asm", ffi_type="ctypes")
 def moe_sum(input: Tensor, output: Tensor) -> None: ...
 
 
-@compile_ops("module_moe_asm")
+@compile_ops("module_moe_asm", ffi_type="ctypes")
 def moe_align_block_size(
     topk_ids: Tensor,
     num_experts: int,

--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -3,7 +3,7 @@
 
 # user interface
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -12,7 +12,7 @@ from ..jit.utils.chip_info import get_cu_num
 from ..utility import dtypes
 
 
-@compile_ops("module_moe_asm", fc_name="biased_grouped_topk")
+@compile_ops("module_moe_asm", fc_name="biased_grouped_topk", ffi_type="ctypes")
 def biased_grouped_topk_hip(
     gating_output: torch.Tensor,
     correction_bias: torch.Tensor,
@@ -25,7 +25,7 @@ def biased_grouped_topk_hip(
 ) -> None: ...
 
 
-@compile_ops("module_moe_asm")
+@compile_ops("module_moe_asm", ffi_type="ctypes")
 def grouped_topk(
     gating_output: torch.Tensor,
     topk_weights: torch.Tensor,
@@ -38,27 +38,7 @@ def grouped_topk(
 ) -> None: ...
 
 
-def gen_moe_fused_gate_fake_tensor(
-    input: torch.Tensor,
-    bias: torch.Tensor,
-    topk_weights: torch.Tensor,
-    topk_ids: torch.Tensor,
-    num_expert_group: int,
-    topk_group: int,
-    topk: int,
-    n_share_experts_fusion: int,
-    routed_scaling_factor: float = 1.0,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    output = torch.empty_like(
-        topk_weights, dtype=topk_weights.dtype, device=topk_weights.device
-    )
-
-    indices = torch.empty_like(topk_ids, dtype=topk_ids.dtype, device=topk_ids.device)
-
-    return [output, indices]
-
-
-@compile_ops("module_moe_asm", gen_fake=gen_moe_fused_gate_fake_tensor)
+@compile_ops("module_moe_asm", ffi_type="ctypes")
 def moe_fused_gate(
     input: torch.Tensor,
     bias: torch.Tensor,
@@ -69,7 +49,7 @@ def moe_fused_gate(
     topk: int,
     n_share_experts_fusion: int,
     routed_scaling_factor: float = 1.0,
-) -> Tuple[torch.Tensor, torch.Tensor]: ...
+) -> None: ...
 
 
 def biased_grouped_topk(

--- a/csrc/kernels/moe_align_block_size_kernels.cu
+++ b/csrc/kernels/moe_align_block_size_kernels.cu
@@ -122,8 +122,8 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids,
 
 AITER_C_ITFS
 void moe_align_block_size(aiter_tensor_t* topk_ids,
-                          int num_experts,
-                          int block_size,
+                          int64_t num_experts,
+                          int64_t block_size,
                           aiter_tensor_t* sorted_token_ids,
                           aiter_tensor_t* experts_ids,
                           aiter_tensor_t* token_nums,

--- a/csrc/kernels/moe_align_block_size_kernels.cu
+++ b/csrc/kernels/moe_align_block_size_kernels.cu
@@ -14,14 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
-#include <torch/all.h>
-
-#include <ATen/ATen.h>
-
 #include "aiter_hip_common.h"
-#include "dispatch_utils.h"
 #include "hip_compat.h"
 
 #define CEILDIV(x, y) (((x) + (y) - 1) / (y))
@@ -127,36 +120,52 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids,
 }
 } // namespace vllm
 
-namespace aiter {
-
-void moe_align_block_size(torch::Tensor topk_ids,
-                          int64_t num_experts,
-                          int64_t block_size,
-                          torch::Tensor sorted_token_ids,
-                          torch::Tensor experts_ids,
-                          torch::Tensor token_nums,
-                          torch::Tensor num_tokens_post_pad)
+AITER_C_ITFS
+void moe_align_block_size(aiter_tensor_t* topk_ids,
+                          int num_experts,
+                          int block_size,
+                          aiter_tensor_t* sorted_token_ids,
+                          aiter_tensor_t* experts_ids,
+                          aiter_tensor_t* token_nums,
+                          aiter_tensor_t* num_tokens_post_pad,
+                          hipStream_t stream)
 {
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(topk_ids));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
-    VLLM_DISPATCH_INTEGRAL_TYPES(topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
-        // Optimized shared memory: O(num_experts) instead of O(num_experts^2)
-        // expert_token_counts[num_experts] + cumsum[num_experts + 1] + write_positions[num_experts]
-        const int32_t shared_mem = (3 * num_experts + 1) * sizeof(int32_t);
+    const HipDeviceGuard device_guard(topk_ids->device_id);
+    // Optimized shared memory: O(num_experts) instead of O(num_experts^2)
+    // expert_token_counts[num_experts] + cumsum[num_experts + 1] + write_positions[num_experts]
+    const int32_t shared_mem = (3 * num_experts + 1) * sizeof(int32_t);
 
-        // set dynamic shared mem
-        auto kernel = vllm::moe_align_block_size_kernel<scalar_t>;
+    if(topk_ids->dtype() == AITER_DTYPE_i32)
+    {
+        auto kernel = vllm::moe_align_block_size_kernel<int32_t>;
         HIP_CALL(
             VLLM_DevFuncAttribute_SET_MaxDynamicSharedMemorySize((void*)kernel, shared_mem));
-        kernel<<<1, num_experts, shared_mem, stream>>>(topk_ids.data_ptr<scalar_t>(),
-                                                       sorted_token_ids.data_ptr<int32_t>(),
-                                                       experts_ids.data_ptr<int32_t>(),
-                                                       token_nums.data_ptr<int32_t>(),
-                                                       num_tokens_post_pad.data_ptr<int32_t>(),
+        kernel<<<1, num_experts, shared_mem, stream>>>(static_cast<int32_t*>(topk_ids->ptr),
+                                                       static_cast<int32_t*>(sorted_token_ids->ptr),
+                                                       static_cast<int32_t*>(experts_ids->ptr),
+                                                       static_cast<int32_t*>(token_nums->ptr),
+                                                       static_cast<int32_t*>(num_tokens_post_pad->ptr),
                                                        num_experts,
                                                        block_size,
-                                                       topk_ids.numel());
-    });
+                                                       topk_ids->numel());
+    }
+    else if(topk_ids->dtype() == AITER_DTYPE_i64)
+    {
+        auto kernel = vllm::moe_align_block_size_kernel<int64_t>;
+        HIP_CALL(
+            VLLM_DevFuncAttribute_SET_MaxDynamicSharedMemorySize((void*)kernel, shared_mem));
+        kernel<<<1, num_experts, shared_mem, stream>>>(static_cast<int64_t*>(topk_ids->ptr),
+                                                       static_cast<int32_t*>(sorted_token_ids->ptr),
+                                                       static_cast<int32_t*>(experts_ids->ptr),
+                                                       static_cast<int32_t*>(token_nums->ptr),
+                                                       static_cast<int32_t*>(num_tokens_post_pad->ptr),
+                                                       num_experts,
+                                                       block_size,
+                                                       topk_ids->numel());
+    }
+    else
+    {
+        AITER_CHECK(false, "moe_align_block_size: unsupported topk_ids dtype: ",
+                    AiterDtype_to_str(topk_ids->dtype()));
+    }
 }
-
-} // namespace aiter

--- a/csrc/kernels/moe_fused_gate.cu
+++ b/csrc/kernels/moe_fused_gate.cu
@@ -550,6 +550,12 @@ void moe_fused_gate(aiter_tensor_t* input,
     const int out_stride = topk_ids->stride(0);
     AITER_CHECK(topk_weights->stride(0) == out_stride,
                 "topk_weights and topk_ids must have the same stride in dim 0");
+    AITER_CHECK(topk_weights->dtype() == AITER_DTYPE_fp32,
+                "topk_weights.dtype() must be fp32");
+    AITER_CHECK(topk_ids->dtype() == AITER_DTYPE_i32,
+                "topk_ids.dtype() must be i32");
+    AITER_CHECK(input->dtype() == bias->dtype(),
+                "input.dtype() must match bias.dtype()");
 
     // Compute grid dimensions based on runtime value for num_expert_group.
     int64_t rows_per_warp = std::max<int64_t>(1, WARP_SIZE / num_expert_group);

--- a/csrc/kernels/moe_fused_gate.cu
+++ b/csrc/kernels/moe_fused_gate.cu
@@ -15,16 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "aiter_hip_common.h"
 #include "hip_compat.h"
 #include "hip_reduce.h"
 #include "vec_convert.h"
-#include <ATen/hip/HIPContext.h>
 #include <cfloat>
 #include <hip/hip_runtime.h>
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
 #include <stdio.h>
-#include <torch/all.h>
 #include <type_traits>
 
 /// Aligned array type
@@ -463,10 +462,10 @@ __global__ void moe_fused_gate_kernel(void* input,
                               ROWS_PER_WARP,                                                  \
                               ROWS_PER_CTA,                                                   \
                               WARPS_PER_CTA>                                                  \
-            <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),            \
-                                                                 bias.data_ptr(),             \
-                                                                 output.data_ptr<float>(),    \
-                                                                 indices.data_ptr<int32_t>(), \
+            <<<num_blocks, block_dim, shared_mem_size, stream>>>(input_ptr,                   \
+                                                                 bias_ptr,                    \
+                                                                 output_ptr,                  \
+                                                                 indices_ptr,                 \
                                                                  num_rows,                    \
                                                                  topk_group,                  \
                                                                  topk,                        \
@@ -529,23 +528,27 @@ __global__ void moe_fused_gate_kernel_dynamic(void* input,
 //------------------------------------------------------------------------------
 // Host Launcher Function
 //------------------------------------------------------------------------------
-std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
-                                       at::Tensor& bias,
-                                       at::Tensor& topk_weights,
-                                       at::Tensor& topk_ids,
-                                       int64_t num_expert_group,
-                                       int64_t topk_group,
-                                       int64_t topk,
-                                       int64_t num_fused_shared_experts,
-                                       double routed_scaling_factor)
+AITER_C_ITFS
+void moe_fused_gate(aiter_tensor_t* input,
+                    aiter_tensor_t* bias,
+                    aiter_tensor_t* topk_weights,
+                    aiter_tensor_t* topk_ids,
+                    int64_t num_expert_group,
+                    int64_t topk_group,
+                    int64_t topk,
+                    int64_t num_fused_shared_experts,
+                    double routed_scaling_factor,
+                    hipStream_t stream)
 {
-    int64_t num_rows     = input.size(0);
-    int32_t num_experts  = input.size(1);
-    auto options         = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
-    auto output          = topk_weights;
-    auto indices         = topk_ids;
-    const int out_stride = topk_ids.stride(0);
-    TORCH_CHECK(topk_weights.stride(0) == out_stride,
+    const HipDeviceGuard device_guard(input->device_id);
+    int64_t num_rows     = input->size(0);
+    int32_t num_experts  = input->size(1);
+    void* input_ptr      = input->ptr;
+    void* bias_ptr       = bias->ptr;
+    float* output_ptr    = static_cast<float*>(topk_weights->ptr);
+    int32_t* indices_ptr = static_cast<int32_t*>(topk_ids->ptr);
+    const int out_stride = topk_ids->stride(0);
+    AITER_CHECK(topk_weights->stride(0) == out_stride,
                 "topk_weights and topk_ids must have the same stride in dim 0");
 
     // Compute grid dimensions based on runtime value for num_expert_group.
@@ -555,17 +558,16 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
     int ROWS_PER_WARP     = std::max<int64_t>(1, WARP_SIZE / num_expert_group);
     size_t shared_mem_size =
         ((topk * sizeof(float) + topk * sizeof(int)) * ROWS_PER_WARP + 255) & ~255;
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
     dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
 
     // Check 1: Ensure that num_experts is a power of 2.
-    TORCH_CHECK((num_experts & (num_experts - 1)) == 0,
+    AITER_CHECK((num_experts & (num_experts - 1)) == 0,
                 "num_experts must be a power of 2, but got ",
                 num_experts);
 
     // Check 2: Ensure that num_experts is divisible by num_expert_group. (this also means
     // num_expert_group is power of 2)
-    TORCH_CHECK(num_experts % num_expert_group == 0,
+    AITER_CHECK(num_experts % num_expert_group == 0,
                 "num_experts must be divisible by num_expert_group, but got ",
                 num_experts,
                 " / ",
@@ -574,12 +576,14 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
     int computed_vpt = num_experts / num_expert_group;
     // Check 3: Ensure that num_experts/num_expert_group does not exceed MAX_VPT=32. Maximum VPT
     // indicate max value per threads we can process.
-    TORCH_CHECK(computed_vpt <= MAX_VPT,
+    AITER_CHECK(computed_vpt <= MAX_VPT,
                 "Per group experts: num_experts / num_expert_group = (",
                 computed_vpt,
                 ") exceeds the maximum supported (",
                 MAX_VPT,
                 ")");
+
+    int input_dtype = input->dtype();
 
     // Dispatch to templated kernel for known compile-time configurations.
     // We currently only support for:
@@ -594,15 +598,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         {
             // This is deepseek v3 case. Here VPT = 256/8 = 32, ROWS_PER_WARP = 32/8 = 4,
             // ROWS_PER_CTA = 6 * 4 = 24.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input_dtype == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 256, 8);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input_dtype == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 256, 8);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input_dtype == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 256, 8);
             }
@@ -610,15 +614,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         else if(num_expert_group == 16)
         {
             // Here VPT = 256/16 = 16, ROWS_PER_WARP = 32/16 = 2, ROWS_PER_CTA = 6 * 2 = 12.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input_dtype == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 256, 16);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input_dtype == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 256, 16);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input_dtype == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 256, 16);
             }
@@ -628,15 +632,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         if(num_expert_group == 4)
         {
             // VPT = 128/4 = 32, ROWS_PER_WARP = 32/16 = 2, ROWS_PER_CTA = 6 * 2 = 12.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input_dtype == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 128, 4);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input_dtype == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 128, 4);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input_dtype == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 128, 4);
             }
@@ -644,15 +648,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         else if(num_expert_group == 8)
         {
             // VPT = 128/8 = 16, ROWS_PER_WARP = 32/8 = 4, ROWS_PER_CTA = 6 * 4 = 24.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input_dtype == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 128, 8);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input_dtype == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 128, 8);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input_dtype == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 128, 8);
             }
@@ -664,13 +668,13 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
     {
         // Fallback to the dynamic kernel if none of the supported combinations match.
         // currently only support num_experts / num_expert_group <= 32 for dynamic kernels
-        if(input.scalar_type() == at::kBFloat16)
+        if(input_dtype == AITER_DTYPE_bf16)
         {
             moe_fused_gate_kernel_dynamic<bfloat16_t>
-                <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),
-                                                                     bias.data_ptr(),
-                                                                     output.data_ptr<float>(),
-                                                                     indices.data_ptr<int32_t>(),
+                <<<num_blocks, block_dim, shared_mem_size, stream>>>(input_ptr,
+                                                                     bias_ptr,
+                                                                     output_ptr,
+                                                                     indices_ptr,
                                                                      num_rows,
                                                                      num_experts,
                                                                      num_expert_group,
@@ -680,13 +684,13 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
                                                                      routed_scaling_factor,
                                                                      out_stride);
         }
-        else if(input.scalar_type() == at::kHalf)
+        else if(input_dtype == AITER_DTYPE_fp16)
         {
             moe_fused_gate_kernel_dynamic<float16_t>
-                <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),
-                                                                     bias.data_ptr(),
-                                                                     output.data_ptr<float>(),
-                                                                     indices.data_ptr<int32_t>(),
+                <<<num_blocks, block_dim, shared_mem_size, stream>>>(input_ptr,
+                                                                     bias_ptr,
+                                                                     output_ptr,
+                                                                     indices_ptr,
                                                                      num_rows,
                                                                      num_experts,
                                                                      num_expert_group,
@@ -696,13 +700,13 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
                                                                      routed_scaling_factor,
                                                                      out_stride);
         }
-        else if(input.scalar_type() == at::kFloat)
+        else if(input_dtype == AITER_DTYPE_fp32)
         {
             moe_fused_gate_kernel_dynamic<float32_t>
-                <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),
-                                                                     bias.data_ptr(),
-                                                                     output.data_ptr<float>(),
-                                                                     indices.data_ptr<int32_t>(),
+                <<<num_blocks, block_dim, shared_mem_size, stream>>>(input_ptr,
+                                                                     bias_ptr,
+                                                                     output_ptr,
+                                                                     indices_ptr,
                                                                      num_rows,
                                                                      num_experts,
                                                                      num_expert_group,
@@ -714,8 +718,7 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         }
         else
         {
-            TORCH_CHECK(false, "Unsupported data type for moe_fused_gate");
+            AITER_CHECK(false, "Unsupported data type for moe_fused_gate");
         }
     }
-    return {output, indices};
 }

--- a/csrc/kernels/moe_fused_gate.cu
+++ b/csrc/kernels/moe_fused_gate.cu
@@ -537,7 +537,7 @@ void moe_fused_gate(aiter_tensor_t* input,
                     int64_t topk_group,
                     int64_t topk,
                     int64_t num_fused_shared_experts,
-                    double routed_scaling_factor,
+                    float routed_scaling_factor,
                     hipStream_t stream)
 {
     const HipDeviceGuard device_guard(input->device_id);

--- a/csrc/kernels/topk_softmax_kernels.cu
+++ b/csrc/kernels/topk_softmax_kernels.cu
@@ -18,14 +18,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dispatch_utils.h"
+#include "aiter_hip_common.h"
 #include "hip_compat.h"
 #include "hip_reduce.h"
-#include "py_itfs_common.h"
 #include "vec_convert.h"
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
-#include <torch/all.h>
+#include <cfloat>
 
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
@@ -611,12 +608,12 @@ void topkGatingSoftmaxLauncherHelper(const DTYPE* input,
             case 8: LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, 8,               \
                                               SharedExpertScoringFunc::SIGMOID); break;     \
             default:                                                                        \
-                TORCH_CHECK(false, "Unsupported num_shared_experts: " +                    \
+                AITER_CHECK(false, "Unsupported num_shared_experts: " +                    \
                             std::to_string(num_shared_experts) +                            \
                             ". Supported values: 1, 2, 4, 8");                              \
             }                                                                               \
         } else {                                                                            \
-            TORCH_CHECK(false, "Unsupported scoring function");                             \
+            AITER_CHECK(false, "Unsupported scoring function");                             \
         }                                                                                   \
     } while(0)
 
@@ -674,7 +671,7 @@ void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
         }
         else
         {
-            TORCH_CHECK(false, "Unsupported shared expert scoring function: " + shared_experts_scoring_func);
+            AITER_CHECK(false, "Unsupported shared expert scoring function: " + shared_experts_scoring_func);
         }
     }
 
@@ -694,7 +691,7 @@ void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
     case 256: LAUNCH_SOFTMAX(256, WARPS_PER_TB); break;
     case 512: LAUNCH_SOFTMAX(512, 2); break;
     default: {
-        TORCH_CHECK(
+        AITER_CHECK(
             softmax_workspace != nullptr,
             "softmax_workspace must be provided for num_experts that are not a power of 2.");
         static constexpr int TPB = 256;
@@ -751,102 +748,178 @@ __global__ void moe_sum_kernel(scalar_t* __restrict__ out,         // [..., d]
 } // namespace moe
 } // namespace vllm
 
-namespace aiter {
-
-void topk_softmax(torch::Tensor& topk_weights,         // [num_tokens, topk + num_shared_experts]
-                  torch::Tensor& topk_indices,         // [num_tokens, topk]
-                  torch::Tensor& token_expert_indices, // [num_tokens, topk]
-                  torch::Tensor& gating_output,        // [num_tokens, num_experts + num_shared_experts]
-                  bool need_renorm,
-                  int num_shared_experts,
-                  const std::string& shared_expert_scoring_func)
+// Generic moe_sum kernel for arbitrary topk values (replaces at::sum_out fallback)
+template <typename scalar_t>
+__global__ void moe_sum_kernel_generic(scalar_t* __restrict__ out,         // [..., d]
+                                       const scalar_t* __restrict__ input, // [..., topk, d]
+                                       const int d,
+                                       const int topk)
 {
-    const int num_experts_total   = gating_output.size(-1);
-    const int num_tokens          = gating_output.numel() / num_experts_total;
-    const int topk                = topk_indices.size(-1);  // Use indices size for topk
-    const int topk_weights_stride = topk_weights.stride(0);
-    const int topk_id_stride      = topk_indices.stride(0);
-    const int gating_token_stride = gating_output.stride(0);
+    const int64_t token_idx = blockIdx.x;
+    for(int64_t idx = threadIdx.x; idx < d; idx += blockDim.x)
+    {
+        scalar_t x = 0.0;
+        for(int k = 0; k < topk; ++k)
+        {
+            x += VLLM_LDG(&input[token_idx * topk * d + k * d + idx]);
+        }
+        out[token_idx * d + idx] = x;
+    }
+}
 
-    // Determine number of routing experts (experts for topk selection)
+template <typename input_dtype>
+static void launch_topk_softmax(aiter_tensor_t* topk_weights,
+                                aiter_tensor_t* topk_indices,
+                                aiter_tensor_t* token_expert_indices,
+                                aiter_tensor_t* gating_output,
+                                int need_renorm,
+                                int num_shared_experts,
+                                const char* shared_expert_scoring_func,
+                                hipStream_t stream)
+{
+    const int num_experts_total   = gating_output->size(-1);
+    const int num_tokens          = gating_output->numel() / num_experts_total;
+    const int topk                = topk_indices->size(-1);
+    const int topk_weights_stride = topk_weights->stride(0);
+    const int topk_id_stride      = topk_indices->stride(0);
+    const int gating_token_stride = gating_output->stride(0);
+
     const int num_routing_experts = num_shared_experts > 0 ? num_experts_total - num_shared_experts : num_experts_total;
 
-    // Validate shared expert scoring function
-    if(num_shared_experts > 0 && !shared_expert_scoring_func.empty())
+    std::string scoring_func_str = shared_expert_scoring_func ? shared_expert_scoring_func : "";
+    if(num_shared_experts > 0 && !scoring_func_str.empty())
     {
-        TORCH_CHECK(shared_expert_scoring_func == "sigmoid",
-                   "Only 'sigmoid' scoring function is supported for shared experts, got: " +
-                   shared_expert_scoring_func);
+        AITER_CHECK(scoring_func_str == "sigmoid",
+                   "Only 'sigmoid' scoring function is supported for shared experts, got: ",
+                   scoring_func_str);
     }
 
     const bool is_pow_2          = (num_routing_experts != 0) && ((num_routing_experts & (num_routing_experts - 1)) == 0);
     const bool needs_workspace   = !is_pow_2 || num_routing_experts > 256;
     const int64_t workspace_size = needs_workspace ? num_tokens * num_routing_experts : 0;
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
-    torch::Tensor softmax_workspace =
-        torch::empty({workspace_size}, gating_output.options().dtype(torch::kFloat32));
+    float* softmax_workspace = nullptr;
+    if(workspace_size > 0)
+    {
+        HIP_CALL(hipMallocAsync(&softmax_workspace, workspace_size * sizeof(float), stream));
+    }
 
-    // Process routing experts with softmax + topk, and shared experts with sigmoid in one kernel
-    VLLM_DISPATCH_FLOATING_TYPES(gating_output.scalar_type(), "topk_softmax", [&] {
-        using input_dtype = typename t2ck<scalar_t>::type;
-        vllm::moe::topkGatingSoftmaxKernelLauncher(
-            reinterpret_cast<input_dtype*>(gating_output.data_ptr()),
-            topk_weights.data_ptr<float>(),
-            topk_indices.data_ptr<int>(),
-            token_expert_indices.data_ptr<int>(),
-            softmax_workspace.data_ptr<float>(),
-            num_tokens,
-            num_routing_experts,  // Only routing experts for softmax
-            num_shared_experts,   // Number of shared experts to process with sigmoid
-            shared_expert_scoring_func,
-            topk,
-            topk_weights_stride,
-            topk_id_stride,
-            gating_token_stride,
-            need_renorm,
-            stream);
-    });
+    vllm::moe::topkGatingSoftmaxKernelLauncher(
+        static_cast<input_dtype*>(gating_output->ptr),
+        static_cast<float*>(topk_weights->ptr),
+        static_cast<int*>(topk_indices->ptr),
+        static_cast<int*>(token_expert_indices->ptr),
+        softmax_workspace,
+        num_tokens,
+        num_routing_experts,
+        num_shared_experts,
+        scoring_func_str,
+        topk,
+        topk_weights_stride,
+        topk_id_stride,
+        gating_token_stride,
+        need_renorm != 0,
+        stream);
+
+    if(softmax_workspace)
+    {
+        HIP_CALL(hipFreeAsync(softmax_workspace, stream));
+    }
 }
 
-void moe_sum(torch::Tensor& input,  // [num_tokens, topk, hidden_size]
-             torch::Tensor& output) // [num_tokens, hidden_size]
+AITER_C_ITFS
+void topk_softmax(aiter_tensor_t* topk_weights,         // [num_tokens, topk + num_shared_experts]
+                  aiter_tensor_t* topk_indices,         // [num_tokens, topk]
+                  aiter_tensor_t* token_expert_indices, // [num_tokens, topk]
+                  aiter_tensor_t* gating_output,        // [num_tokens, num_experts + num_shared_experts]
+                  int need_renorm,
+                  int num_shared_experts,
+                  const char* shared_expert_scoring_func,
+                  hipStream_t stream)
 {
-    const int hidden_size = input.size(-1);
-    const int num_tokens  = output.numel() / hidden_size;
-    const int topk        = input.size(1);
+    const HipDeviceGuard device_guard(gating_output->device_id);
+
+    if(gating_output->dtype() == AITER_DTYPE_bf16)
+    {
+        launch_topk_softmax<ck_tile::bfloat16_t>(
+            topk_weights, topk_indices, token_expert_indices, gating_output,
+            need_renorm, num_shared_experts, shared_expert_scoring_func, stream);
+    }
+    else if(gating_output->dtype() == AITER_DTYPE_fp16)
+    {
+        launch_topk_softmax<ck_tile::half_t>(
+            topk_weights, topk_indices, token_expert_indices, gating_output,
+            need_renorm, num_shared_experts, shared_expert_scoring_func, stream);
+    }
+    else if(gating_output->dtype() == AITER_DTYPE_fp32)
+    {
+        launch_topk_softmax<float>(
+            topk_weights, topk_indices, token_expert_indices, gating_output,
+            need_renorm, num_shared_experts, shared_expert_scoring_func, stream);
+    }
+    else
+    {
+        AITER_CHECK(false, "topk_softmax: unsupported dtype: ",
+                    AiterDtype_to_str(gating_output->dtype()));
+    }
+}
+
+template <typename scalar_t>
+static void launch_moe_sum(aiter_tensor_t* input, aiter_tensor_t* output, hipStream_t stream)
+{
+    const int hidden_size = input->size(-1);
+    const int num_tokens  = output->numel() / hidden_size;
+    const int topk        = input->size(1);
 
     dim3 grid(num_tokens);
     dim3 block(std::min(hidden_size, 1024));
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    auto out_ptr = static_cast<scalar_t*>(output->ptr);
+    auto inp_ptr = static_cast<scalar_t*>(input->ptr);
 
     switch(topk)
     {
     case 2:
-        VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
-            vllm::moe::moe_sum_kernel<scalar_t, 2><<<grid, block, 0, stream>>>(
-                output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), hidden_size);
-        });
+        vllm::moe::moe_sum_kernel<scalar_t, 2><<<grid, block, 0, stream>>>(
+            out_ptr, inp_ptr, hidden_size);
         break;
-
     case 4:
-        VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
-            vllm::moe::moe_sum_kernel<scalar_t, 4><<<grid, block, 0, stream>>>(
-                output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), hidden_size);
-        });
+        vllm::moe::moe_sum_kernel<scalar_t, 4><<<grid, block, 0, stream>>>(
+            out_ptr, inp_ptr, hidden_size);
         break;
-
     case 5:
-        VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
-            vllm::moe::moe_sum_kernel<scalar_t, 5><<<grid, block, 0, stream>>>(
-                output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), hidden_size);
-        });
+        vllm::moe::moe_sum_kernel<scalar_t, 5><<<grid, block, 0, stream>>>(
+            out_ptr, inp_ptr, hidden_size);
         break;
-    default: at::sum_out(output, input, 1); break;
+    default:
+        moe_sum_kernel_generic<scalar_t><<<grid, block, 0, stream>>>(
+            out_ptr, inp_ptr, hidden_size, topk);
+        break;
     }
 }
 
-} // namespace aiter
+AITER_C_ITFS
+void moe_sum(aiter_tensor_t* input,  // [num_tokens, topk, hidden_size]
+             aiter_tensor_t* output, // [num_tokens, hidden_size]
+             hipStream_t stream)
+{
+    const HipDeviceGuard device_guard(output->device_id);
+
+    if(input->dtype() == AITER_DTYPE_bf16)
+    {
+        launch_moe_sum<ck_tile::bfloat16_t>(input, output, stream);
+    }
+    else if(input->dtype() == AITER_DTYPE_fp16)
+    {
+        launch_moe_sum<ck_tile::half_t>(input, output, stream);
+    }
+    else if(input->dtype() == AITER_DTYPE_fp32)
+    {
+        launch_moe_sum<float>(input, output, stream);
+    }
+    else
+    {
+        AITER_CHECK(false, "moe_sum: unsupported dtype: ",
+                    AiterDtype_to_str(input->dtype()));
+    }
+}

--- a/csrc/kernels/topk_softmax_kernels.cu
+++ b/csrc/kernels/topk_softmax_kernels.cu
@@ -773,7 +773,7 @@ static void launch_topk_softmax(aiter_tensor_t* topk_weights,
                                 aiter_tensor_t* token_expert_indices,
                                 aiter_tensor_t* gating_output,
                                 int need_renorm,
-                                int num_shared_experts,
+                                int64_t num_shared_experts,
                                 const char* shared_expert_scoring_func,
                                 hipStream_t stream)
 {
@@ -796,7 +796,7 @@ static void launch_topk_softmax(aiter_tensor_t* topk_weights,
 
     const bool is_pow_2          = (num_routing_experts != 0) && ((num_routing_experts & (num_routing_experts - 1)) == 0);
     const bool needs_workspace   = !is_pow_2 || num_routing_experts > 256;
-    const int64_t workspace_size = needs_workspace ? num_tokens * num_routing_experts : 0;
+    const int64_t workspace_size = needs_workspace ? (int64_t)num_tokens * num_routing_experts : 0;
 
     float* softmax_workspace = nullptr;
     if(workspace_size > 0)
@@ -833,7 +833,7 @@ void topk_softmax(aiter_tensor_t* topk_weights,         // [num_tokens, topk + n
                   aiter_tensor_t* token_expert_indices, // [num_tokens, topk]
                   aiter_tensor_t* gating_output,        // [num_tokens, num_experts + num_shared_experts]
                   int need_renorm,
-                  int num_shared_experts,
+                  int64_t num_shared_experts,
                   const char* shared_expert_scoring_func,
                   hipStream_t stream)
 {

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -1246,8 +1246,8 @@ void biased_grouped_topk(aiter_tensor_t* gating_output,   // [num_tokens, num_ex
                          aiter_tensor_t* correction_bias, // [num_expert]
                          aiter_tensor_t* topk_weights,    // [num_tokens, topk]
                          aiter_tensor_t* topk_ids,        // [num_tokens, topk]
-                         int num_expert_group,
-                         int topk_grp,
+                         int64_t num_expert_group,
+                         int64_t topk_grp,
                          int need_renorm,
                          float routed_scaling_factor,
                          hipStream_t stream)
@@ -1261,6 +1261,10 @@ void biased_grouped_topk(aiter_tensor_t* gating_output,   // [num_tokens, num_ex
                 "topk_ids.stride(0) == topk_weights.stride(0)");
     AITER_CHECK(gating_output->dtype() == correction_bias->dtype(),
                 "gating_output.dtype() == correction_bias.dtype()");
+    AITER_CHECK(topk_weights->dtype() == AITER_DTYPE_fp32,
+                "topk_weights.dtype() must be fp32");
+    AITER_CHECK(topk_ids->dtype() == AITER_DTYPE_i32,
+                "topk_ids.dtype() must be i32");
 
     bool use_opt_sort = (topk == 8) && (num_expert_group == 8) && (num_experts == 256) &&
                         (topk_grp == 4);
@@ -1337,8 +1341,8 @@ AITER_C_ITFS
 void grouped_topk(aiter_tensor_t* gating_output, // [num_tokens, num_experts]
                   aiter_tensor_t* topk_weights,  // [num_tokens, topk]
                   aiter_tensor_t* topk_ids,      // [num_tokens, topk]
-                  int num_expert_group,
-                  int topk_grp,
+                  int64_t num_expert_group,
+                  int64_t topk_grp,
                   int need_renorm,
                   int is_softmax,
                   float routed_scaling_factor,
@@ -1351,6 +1355,10 @@ void grouped_topk(aiter_tensor_t* gating_output, // [num_tokens, num_experts]
     size_t stride_tk = topk_ids->stride(0);
     AITER_CHECK(stride_tk == (size_t)topk_weights->stride(0),
                 "topk_ids.stride(0) == topk_weights.stride(0)");
+    AITER_CHECK(topk_weights->dtype() == AITER_DTYPE_fp32,
+                "topk_weights.dtype() must be fp32");
+    AITER_CHECK(topk_ids->dtype() == AITER_DTYPE_i32,
+                "topk_ids.dtype() must be i32");
 
     if(gating_output->dtype() == AITER_DTYPE_bf16)
     {

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -10,16 +10,12 @@
  * @Description: This is description.
  */
 
-#include "dispatch_utils.h"
+#include "aiter_hip_common.h"
 #include "hip_reduce.h"
-#include "py_itfs_common.h"
 #include "warp_sort.h"
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <hip/hip_runtime.h>
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
-#include <torch/all.h>
 
 #ifndef AITER_TOPK_SOFTMAX_GROUP_PERMUTE_SCORE
 #define AITER_TOPK_SOFTMAX_GROUP_PERMUTE_SCORE 0
@@ -348,7 +344,7 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
     // float *topk_values_f = reinterpret_cast<float *>(ptr);
 
     f32vec* scores_vec            = reinterpret_cast<f32vec*>(scores);
-    using cktype_i                = typename t2ck<DTYPE_I>::type;
+    using cktype_i                = DTYPE_I;
     static constexpr int vec_size = ck_tile::vector_traits<f32vec>::vector_size;
     using vec_i                   = ck_tile::ext_vector_t<cktype_i, vec_size>;
     const int num_experts_vec     = num_experts / vec_size;
@@ -672,7 +668,7 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
     // float *topk_values_f = reinterpret_cast<float *>(ptr);
 
     f32vec* scores_vec            = reinterpret_cast<f32vec*>(scores);
-    using cktype_i                = typename t2ck<DTYPE_I>::type;
+    using cktype_i                = DTYPE_I;
     static constexpr int vec_size = ck_tile::vector_traits<f32vec>::vector_size;
     using vec_i                   = ck_tile::ext_vector_t<cktype_i, vec_size>;
     const int num_experts_vec     = num_experts / vec_size;
@@ -1117,7 +1113,7 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
     case 4: LAUNCHER3(VEC_F, 4) break;                                                      \
     case 2: LAUNCHER3(VEC_F, 2) break;                                                      \
     case 1: LAUNCHER3(VEC_F, 1) break;                                                      \
-    default: TORCH_CHECK(false, "Unsupported num_expert_group: ", num_expert_group); break; \
+    default: AITER_CHECK(false, "Unsupported num_expert_group: ", num_expert_group); break; \
     }
 #define LAUNCHER3(VEC_F, NUM_GRP)                     \
     switch(need_renorm)                               \
@@ -1151,97 +1147,84 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
     }
 
 #define LAUNCHER_biased_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)      \
-    VLLM_DISPATCH_FLOATING_TYPES(gating_output.scalar_type(), "biased_grouped_topk_kernel", [&] {  \
-        hipLaunchKernelGGL(                                                                        \
-            (aiter::                                                                               \
-                 grouped_topk_kernel<scalar_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>), \
-            dim3(grid),                                                                            \
-            dim3(block),                                                                           \
-            shared_mem_size,                                                                       \
-            stream,                                                                                \
-            gating_output.data_ptr<scalar_t>(),                                                    \
-            correction_bias.data_ptr<scalar_t>(),                                                  \
-            topk_weights.data_ptr<float>(),                                                        \
-            topk_ids.data_ptr<int>(),                                                              \
-            stride_tk,                                                                             \
-            num_experts,                                                                           \
-            topk,                                                                                  \
-            topk_grp,                                                                              \
-            num_tokens,                                                                            \
-            routed_scaling_factor);                                                                \
-    });
+    hipLaunchKernelGGL(                                                                            \
+        (aiter::                                                                                   \
+             grouped_topk_kernel<dtype_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>),      \
+        dim3(grid),                                                                                \
+        dim3(block),                                                                               \
+        shared_mem_size,                                                                           \
+        stream,                                                                                    \
+        gating_output_ptr,                                                                         \
+        correction_bias_ptr,                                                                       \
+        topk_weights_ptr,                                                                          \
+        topk_ids_ptr,                                                                              \
+        stride_tk,                                                                                 \
+        num_experts,                                                                               \
+        topk,                                                                                      \
+        topk_grp,                                                                                  \
+        num_tokens,                                                                                \
+        routed_scaling_factor);
 
 #define LAUNCHER_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)             \
-    VLLM_DISPATCH_FLOATING_TYPES(gating_output.scalar_type(), "grouped_topk_kernel", [&] {         \
-        hipLaunchKernelGGL(                                                                        \
-            (aiter::                                                                               \
-                 grouped_topk_kernel<scalar_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>), \
-            dim3(grid),                                                                            \
-            dim3(block),                                                                           \
-            shared_mem_size,                                                                       \
-            stream,                                                                                \
-            gating_output.data_ptr<scalar_t>(),                                                    \
-            nullptr,                                                                               \
-            topk_weights.data_ptr<float>(),                                                        \
-            topk_ids.data_ptr<int>(),                                                              \
-            stride_tk,                                                                             \
-            num_experts,                                                                           \
-            topk,                                                                                  \
-            topk_grp,                                                                              \
-            num_tokens,                                                                            \
-            routed_scaling_factor);                                                                \
-    });
+    hipLaunchKernelGGL(                                                                            \
+        (aiter::                                                                                   \
+             grouped_topk_kernel<dtype_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>),      \
+        dim3(grid),                                                                                \
+        dim3(block),                                                                               \
+        shared_mem_size,                                                                           \
+        stream,                                                                                    \
+        gating_output_ptr,                                                                         \
+        (dtype_t*)nullptr,                                                                         \
+        topk_weights_ptr,                                                                          \
+        topk_ids_ptr,                                                                              \
+        stride_tk,                                                                                 \
+        num_experts,                                                                               \
+        topk,                                                                                      \
+        topk_grp,                                                                                  \
+        num_tokens,                                                                                \
+        routed_scaling_factor);
 
-#define LAUNCHER_biased_grouped_topk_opt_sort_kernel(                             \
-    VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)                             \
-    VLLM_DISPATCH_FLOATING_TYPES(                                                 \
-        gating_output.scalar_type(), "biased_grouped_topk_opt_sort_kernel", [&] { \
-            hipLaunchKernelGGL((aiter::grouped_topk_opt_sort_kernel<scalar_t,     \
-                                                                    VEC_F,        \
-                                                                    NUM_GRP,      \
-                                                                    need_renorm,  \
-                                                                    isBiased,     \
-                                                                    isSoftmax>),  \
-                               dim3(grid),                                        \
-                               dim3(block),                                       \
-                               shared_mem_size,                                   \
-                               stream,                                            \
-                               gating_output.data_ptr<scalar_t>(),                \
-                               correction_bias.data_ptr<scalar_t>(),              \
-                               topk_weights.data_ptr<float>(),                    \
-                               topk_ids.data_ptr<int>(),                          \
-                               stride_tk,                                         \
-                               num_experts,                                       \
-                               topk,                                              \
-                               topk_grp,                                          \
-                               num_tokens,                                        \
-                               routed_scaling_factor);                            \
-        });
+#define LAUNCHER_biased_grouped_topk_opt_sort_kernel(                                              \
+    VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)                                              \
+    hipLaunchKernelGGL((aiter::grouped_topk_opt_sort_kernel<dtype_t,                               \
+                                                            VEC_F,                                 \
+                                                            NUM_GRP,                               \
+                                                            need_renorm,                           \
+                                                            isBiased,                              \
+                                                            isSoftmax>),                           \
+                       dim3(grid),                                                                 \
+                       dim3(block),                                                                \
+                       shared_mem_size,                                                            \
+                       stream,                                                                     \
+                       gating_output_ptr,                                                          \
+                       correction_bias_ptr,                                                        \
+                       topk_weights_ptr,                                                           \
+                       topk_ids_ptr,                                                               \
+                       stride_tk,                                                                  \
+                       num_experts,                                                                \
+                       topk,                                                                       \
+                       topk_grp,                                                                   \
+                       num_tokens,                                                                 \
+                       routed_scaling_factor);
 
-void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_experts]
-                         torch::Tensor& correction_bias, // [num_expert]
-                         torch::Tensor& topk_weights,    // [num_tokens, topk]
-                         torch::Tensor& topk_ids,        // [num_tokens, topk]
-                         int num_expert_group,
-                         int topk_grp,
-                         bool need_renorm,
-                         const float routed_scaling_factor = 1.)
+template <typename dtype_t>
+static void launch_biased_grouped_topk(dtype_t* gating_output_ptr,
+                                       dtype_t* correction_bias_ptr,
+                                       float* topk_weights_ptr,
+                                       int* topk_ids_ptr,
+                                       int num_tokens,
+                                       int num_experts,
+                                       int topk,
+                                       size_t stride_tk,
+                                       int num_expert_group,
+                                       int topk_grp,
+                                       bool need_renorm,
+                                       bool use_opt_sort,
+                                       float routed_scaling_factor,
+                                       hipStream_t stream)
 {
     const bool isBiased = true;
     bool isSoftmax      = false;
-    int num_tokens      = gating_output.size(0);
-    int num_experts     = gating_output.size(1);
-    int topk            = topk_ids.size(1);
-    size_t stride_tk    = topk_ids.stride(0);
-    TORCH_CHECK(stride_tk == topk_weights.stride(0),
-                "topk_ids.stride(0) == topk_weights.stride(0)");
-    TORCH_CHECK(gating_output.dtype() == correction_bias.dtype(),
-                "gating_output.dtype() == correction_bias.dtype()");
-
-    // TODO: expand usage in the future
-    // bool use_opt_sort = false;
-    bool use_opt_sort = (topk == 8) && (num_expert_group == 8) && (num_experts == 256) &&
-                        (topk_grp == 4) && (isBiased == true);
 
     dim3 grid(num_tokens);
     dim3 block(64);
@@ -1251,39 +1234,95 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
                            : (num_expert_group * sizeof(int) /*group_map_idx*/
                               + topk * sizeof(int)           /*idx+weight*/
                               + topk * sizeof(float)         /*idx+weight*/
-                              //   + num_experts * sizeof(float)                         /*bias*/
                               + (topk > topk_grp ? topk : topk_grp) * sizeof(int)   /* sort_k*/
                               + (topk > topk_grp ? topk : topk_grp) * sizeof(float) /* sort_v*/
-                              //    + 64 / num_expert_group * sizeof(float) /* for sorting */
                              );
-
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
 
     LAUNCH_KERNEL()
 }
 
-void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
-                  torch::Tensor& topk_weights,  // [num_tokens, topk]
-                  torch::Tensor& topk_ids,      // [num_tokens, topk]
-                  int num_expert_group,
-                  int topk_grp,
-                  bool need_renorm,
-                  bool is_softmax                   = true,
-                  const float routed_scaling_factor = 1.)
+AITER_C_ITFS
+void biased_grouped_topk(aiter_tensor_t* gating_output,   // [num_tokens, num_experts]
+                         aiter_tensor_t* correction_bias, // [num_expert]
+                         aiter_tensor_t* topk_weights,    // [num_tokens, topk]
+                         aiter_tensor_t* topk_ids,        // [num_tokens, topk]
+                         int num_expert_group,
+                         int topk_grp,
+                         int need_renorm,
+                         float routed_scaling_factor,
+                         hipStream_t stream)
 {
-    const bool isBiased  = false;
-    bool isSoftmax       = is_softmax;
-    int num_tokens       = gating_output.size(0);
-    int num_experts      = gating_output.size(1);
-    int topk             = topk_ids.size(1);
-    size_t stride_tk     = topk_ids.stride(0);
-    auto correction_bias = topk_ids;
-    TORCH_CHECK(stride_tk == topk_weights.stride(0),
+    const HipDeviceGuard device_guard(gating_output->device_id);
+    int num_tokens   = gating_output->size(0);
+    int num_experts  = gating_output->size(1);
+    int topk         = topk_ids->size(1);
+    size_t stride_tk = topk_ids->stride(0);
+    AITER_CHECK(stride_tk == (size_t)topk_weights->stride(0),
                 "topk_ids.stride(0) == topk_weights.stride(0)");
+    AITER_CHECK(gating_output->dtype() == correction_bias->dtype(),
+                "gating_output.dtype() == correction_bias.dtype()");
 
-    // TODO: expand usage in the future
-    bool use_opt_sort = false;
+    bool use_opt_sort = (topk == 8) && (num_expert_group == 8) && (num_experts == 256) &&
+                        (topk_grp == 4);
+
+    if(gating_output->dtype() == AITER_DTYPE_bf16)
+    {
+        launch_biased_grouped_topk<ck_tile::bf16_t>(
+            static_cast<ck_tile::bf16_t*>(gating_output->ptr),
+            static_cast<ck_tile::bf16_t*>(correction_bias->ptr),
+            static_cast<float*>(topk_weights->ptr),
+            static_cast<int*>(topk_ids->ptr),
+            num_tokens, num_experts, topk, stride_tk,
+            num_expert_group, topk_grp, need_renorm, use_opt_sort,
+            routed_scaling_factor, stream);
+    }
+    else if(gating_output->dtype() == AITER_DTYPE_fp16)
+    {
+        launch_biased_grouped_topk<ck_tile::half_t>(
+            static_cast<ck_tile::half_t*>(gating_output->ptr),
+            static_cast<ck_tile::half_t*>(correction_bias->ptr),
+            static_cast<float*>(topk_weights->ptr),
+            static_cast<int*>(topk_ids->ptr),
+            num_tokens, num_experts, topk, stride_tk,
+            num_expert_group, topk_grp, need_renorm, use_opt_sort,
+            routed_scaling_factor, stream);
+    }
+    else if(gating_output->dtype() == AITER_DTYPE_fp32)
+    {
+        launch_biased_grouped_topk<float>(
+            static_cast<float*>(gating_output->ptr),
+            static_cast<float*>(correction_bias->ptr),
+            static_cast<float*>(topk_weights->ptr),
+            static_cast<int*>(topk_ids->ptr),
+            num_tokens, num_experts, topk, stride_tk,
+            num_expert_group, topk_grp, need_renorm, use_opt_sort,
+            routed_scaling_factor, stream);
+    }
+    else
+    {
+        AITER_CHECK(false, "biased_grouped_topk: unsupported dtype: ",
+                    AiterDtype_to_str(gating_output->dtype()));
+    }
+}
+
+template <typename dtype_t>
+static void launch_grouped_topk(dtype_t* gating_output_ptr,
+                                float* topk_weights_ptr,
+                                int* topk_ids_ptr,
+                                int num_tokens,
+                                int num_experts,
+                                int topk,
+                                size_t stride_tk,
+                                int num_expert_group,
+                                int topk_grp,
+                                bool need_renorm,
+                                bool isSoftmax,
+                                float routed_scaling_factor,
+                                hipStream_t stream)
+{
+    const bool isBiased = false;
+    bool use_opt_sort   = false;
+    dtype_t* correction_bias_ptr = nullptr;
 
     dim3 grid(num_tokens);
     dim3 block(64);
@@ -1291,12 +1330,68 @@ void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
                               topk * sizeof(int) + topk * sizeof(float) + 255) &
                              ~255;
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
-
     LAUNCH_KERNEL()
 }
 
+AITER_C_ITFS
+void grouped_topk(aiter_tensor_t* gating_output, // [num_tokens, num_experts]
+                  aiter_tensor_t* topk_weights,  // [num_tokens, topk]
+                  aiter_tensor_t* topk_ids,      // [num_tokens, topk]
+                  int num_expert_group,
+                  int topk_grp,
+                  int need_renorm,
+                  int is_softmax,
+                  float routed_scaling_factor,
+                  hipStream_t stream)
+{
+    const HipDeviceGuard device_guard(gating_output->device_id);
+    int num_tokens   = gating_output->size(0);
+    int num_experts  = gating_output->size(1);
+    int topk         = topk_ids->size(1);
+    size_t stride_tk = topk_ids->stride(0);
+    AITER_CHECK(stride_tk == (size_t)topk_weights->stride(0),
+                "topk_ids.stride(0) == topk_weights.stride(0)");
+
+    if(gating_output->dtype() == AITER_DTYPE_bf16)
+    {
+        launch_grouped_topk<ck_tile::bf16_t>(
+            static_cast<ck_tile::bf16_t*>(gating_output->ptr),
+            static_cast<float*>(topk_weights->ptr),
+            static_cast<int*>(topk_ids->ptr),
+            num_tokens, num_experts, topk, stride_tk,
+            num_expert_group, topk_grp, need_renorm, is_softmax,
+            routed_scaling_factor, stream);
+    }
+    else if(gating_output->dtype() == AITER_DTYPE_fp16)
+    {
+        launch_grouped_topk<ck_tile::half_t>(
+            static_cast<ck_tile::half_t*>(gating_output->ptr),
+            static_cast<float*>(topk_weights->ptr),
+            static_cast<int*>(topk_ids->ptr),
+            num_tokens, num_experts, topk, stride_tk,
+            num_expert_group, topk_grp, need_renorm, is_softmax,
+            routed_scaling_factor, stream);
+    }
+    else if(gating_output->dtype() == AITER_DTYPE_fp32)
+    {
+        launch_grouped_topk<float>(
+            static_cast<float*>(gating_output->ptr),
+            static_cast<float*>(topk_weights->ptr),
+            static_cast<int*>(topk_ids->ptr),
+            num_tokens, num_experts, topk, stride_tk,
+            num_expert_group, topk_grp, need_renorm, is_softmax,
+            routed_scaling_factor, stream);
+    }
+    else
+    {
+        AITER_CHECK(false, "grouped_topk: unsupported dtype: ",
+                    AiterDtype_to_str(gating_output->dtype()));
+    }
+}
+
+#undef LAUNCHER_biased_grouped_topk_opt_sort_kernel
+#undef LAUNCHER_grouped_topk_kernel
+#undef LAUNCHER_biased_grouped_topk_kernel
 #undef LAUNCHER4
 #undef LAUNCHER3
 #undef LAUNCHER2

--- a/csrc/pybind/moe_op_pybind.cu
+++ b/csrc/pybind/moe_op_pybind.cu
@@ -1,7 +1,0 @@
-/* SPDX-License-Identifier: MIT
-   Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
-*/
-#include "moe_op.h"
-#include "rocm_ops.hpp"
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { MOE_OP_PYBIND; }

--- a/op_tests/test_moeTopkSoftmax.py
+++ b/op_tests/test_moeTopkSoftmax.py
@@ -331,9 +331,6 @@ def test_biased_grouped_topk(
         scale_factor,
     )
 
-    w_sglang = _[0]
-    id_sglang = _[1]
-
     id_sglang, _sglang = torch.sort(id_sglang)
     w_sglang = w_sglang.gather(1, _sglang)
     ret["us_sglang"] = us_sglang


### PR DESCRIPTION
## Summary
- Migrate all 6 pybind entry functions in `module_moe_asm` to C ABI using `aiter_tensor_t*` and `AITER_C_ITFS`, eliminating torch/pybind11 dependency
- Fixes undefined symbol crash when ctypes cold JIT path sets `torch_exclude=True` (issue #2548)
- `ldd module_moe_asm.so | grep torch` returns empty — fully torch-free

## Changes
- **4 kernel files**: Rewrite `topk_softmax`, `moe_sum`, `moe_align_block_size`, `biased_grouped_topk`, `grouped_topk`, `moe_fused_gate` as `extern "C"` functions with `aiter_tensor_t*`
- Replace `VLLM_DISPATCH_*` macros with manual dtype dispatch (bf16/fp16/fp32)
- Replace `torch::empty` workspace with `hipMallocAsync`/`hipFreeAsync`
- `moe_fused_gate`: return type changed from `std::vector<at::Tensor>` to `void` (in-place)
- **Python bindings**: Add `ffi_type="ctypes"` to all 7 `@compile_ops` decorators
- **Config**: Remove `moe_op_pybind.cu` from srcs, add `torch_exclude: True`
- **Delete**: `csrc/pybind/moe_op_pybind.cu`

## Test plan
- [x] `test_moeTopkSoftmax` — passed
- [x] `test_moe` — passed
- [x] `test_moe_sorting` — passed
- [x] `test_moe_topk_sigmoid` — passed
- [x] `test_moe_blockscale` — passed
- [x] `test_moe_tkw1` — passed
- [x] `test_moe_dp_share_expert` — passed
- [x] `test_moe_2stage` — passed
- [x] All 59 op tests (single GPU) — passed
- [ ] CI Atom Test