### PR TITLE
Avoid an AttributeError in bench_moe_align_block_size.py

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_moe_align_block_size.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_align_block_size.py
@@ -145,15 +145,9 @@ arg_to_torch_dtype = {
 def main():
     args = parse_args()
     custom_config = False
-    # This benchmark only exposes -M and -block_size on the CLI today.
-    # Guard against missing attributes to avoid AttributeError.
-    if (
-        getattr(args, "M", 0)
-        and getattr(args, "K", 0)
-        and getattr(args, "N", 0)
-        and getattr(args, "E", 0)
-        and getattr(args, "top_k", 0)
-    ):
+    # For sizing/custom configs, this benchmark currently only uses -M and -block_size
+    # from the CLI today. Guard against missing attributes to avoid AttributeError.
+    if all(getattr(args, name, 0) for name in ("M", "K", "N", "E", "top_k")):
         custom_config = True
     if args.print_vgpr:
         print("Retrieving VGPR usage for Triton kernels...")


### PR DESCRIPTION
## Motivation

The benchmark script `op_tests/op_benchmarks/triton/bench_moe_align_block_size.py` accepts the following arguments (in the `parse_args` function):

* `-model_configs`
* `--model`
* `-M`
* `-block_size`
* `-print_vgpr`
* `-o`

However, it errors after parsing the inputs because the code does:

```
if args.M and args.K and args.N and args.E and args.top_k:
    custom_config = True
```

which raises an `AttributeError`. This change fixes the issue.

## Technical Details

Instead of accessing `args.X` directly, we use `getattr` to safely check whether each attribute exists. If they are all provided, we set `custom_config = True`.

## Test Plan

Test the script interactively by executing it.

## Test Result

After the fix, the script works as expected.