### PR TITLE
Unify FlyDSL W4A4/G1U0 updates and tuning fixes

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -638,12 +638,18 @@ def _flydsl_stage1_wrapper(
     w1_scale=None,
     a1_scale=None,
     sorted_weights=None,
+    g1u0=False,
     **_kwargs,
 ):
     parsed = aiter.ops.flydsl.moe_kernels.get_flydsl_kernel_params(kernelName)
     if parsed is None:
         raise ValueError(f"Invalid FlyDSL kernel name: {kernelName}")
-    act = "swiglu" if activation == ActivationType.Swiglu else "silu"
+    if activation == ActivationType.Swiglu:
+        act = "swiglu"
+    elif activation == ActivationType.Gelu:
+        act = "gelu"
+    else:
+        act = "silu"
     return aiter.ops.flydsl.flydsl_moe_stage1(
         a=hidden_states,
         w1=w1,
@@ -662,6 +668,7 @@ def _flydsl_stage1_wrapper(
         w1_scale=w1_scale,
         a1_scale=a1_scale,
         sorted_weights=sorted_weights,
+        g1u0=g1u0,
     )
 
 
@@ -949,6 +956,7 @@ def get_2stage_cfgs(
                 _flydsl_stage1_wrapper,
                 kernelName=kernelName1,
                 activation=activation,
+                g1u0=(not use_g1u1),
             )
         else:
             stage1_func = functools.partial(

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
@@ -79,6 +79,7 @@ def compile_mixed_moe_gemm1(
     enable_bias: bool = False,
     model_dim_pad: int = 0,
     inter_dim_pad: int = 0,
+    g1u0: bool = False,
 ):
     """Compile stage1 kernel (`moe_gemm1`) and return the compiled executable.
 
@@ -219,8 +220,9 @@ def compile_mixed_moe_gemm1(
     use_cshuffle_epilog = bool(use_cshuffle_epilog)
 
     epilog_tag = "cshuffle" if use_cshuffle_epilog else "direct"
-    module_name = (
-        f"mfma_moe1_a{a_dtype}_w{b_dtype}_{epilog_tag}_abi35_ckstage1".replace("-", "_")
+    g1u_tag = "g1u0" if g1u0 else "g1u1"
+    module_name = f"mfma_moe1_{g1u_tag}_a{a_dtype}_w{b_dtype}_{epilog_tag}_abi35_ckstage1".replace(
+        "-", "_"
     )
     # -- LDS sizing (pure Python; no MLIR Context needed) ---------------------
     # Reuse the same LDS bytes for both:
@@ -302,6 +304,18 @@ def compile_mixed_moe_gemm1(
                 sig = llvm.call_intrinsic(f32, "llvm.amdgcn.rcp.f32", [den], [], [])
                 return x * sig
 
+            def gelu(x):
+                # e^(x*(c1*x*x+c2))
+                t = (
+                    (x * x * (-0.07135400176048279) - 1.595770001411438)
+                    * x
+                    * (1.4426950408889634)
+                )
+                emu = llvm.call_intrinsic(f32, "llvm.amdgcn.exp2.f32", [t], [], [])
+                den = 1.0 + emu
+                sig = llvm.call_intrinsic(f32, "llvm.amdgcn.rcp.f32", [den], [], [])
+                return x * sig
+
             _arith_min = getattr(arith, "minimum", None) or getattr(arith, "minimumf")
             _arith_max = getattr(arith, "maximum", None) or getattr(arith, "maximumf")
 
@@ -335,7 +349,10 @@ def compile_mixed_moe_gemm1(
             _layout_x = fx.make_layout((tokens_i32_v, k_i32_v), stride=(k_i32_v, 1))
 
             # B preshuffle layout: match GEMM test helper exactly.
-            c_n_total = arith.constant(experts * (2 * inter_dim), index=True)
+            # For g1u0, stage1 W1 rows are [experts * inter_dim].
+            # For g1u1, stage1 W1 rows are [experts * (2 * inter_dim)].
+            _w_rows_per_expert = inter_dim if g1u0 else (2 * inter_dim)
+            c_n_total = arith.constant(experts * _w_rows_per_expert, index=True)
             kpack_bytes = 8 if is_int4 else 16
             b_layout = make_preshuffle_b_layout(
                 arith,
@@ -434,7 +451,7 @@ def compile_mixed_moe_gemm1(
                 x_rsrc = buffer_ops.create_buffer_resource(
                     arg_x, max_size=False, num_records_bytes=x_nbytes
                 )
-                _w_n = arith.constant(experts * (2 * inter_dim), index=True)
+                _w_n = arith.constant(experts * _w_rows_per_expert, index=True)
                 _w_nbytes = (
                     _w_n
                     * (k_in / arith.constant(int(a_elem_vec_pack), index=True))
@@ -473,10 +490,10 @@ def compile_mixed_moe_gemm1(
                 if is_f16_b:
                     sw_rsrc = None
                 else:
-                    # W1 microscale: [experts * 2 * inter_dim, K/32] e8m0 bytes.
+                    # W1 microscale: [experts * rows_per_expert, K/32] e8m0 bytes.
                     _c32_w = arith.constant(32, index=True)
                     _kblk_w = k_in / _c32_w
-                    _mn_w = arith.constant(experts * (2 * inter_dim), index=True)
+                    _mn_w = arith.constant(experts * _w_rows_per_expert, index=True)
                     sw_nbytes = _mn_w * _kblk_w
                     sw_nbytes_i32 = arith.index_cast(T.i32, sw_nbytes)
                     sw_rsrc = buffer_ops.create_buffer_resource(
@@ -521,7 +538,7 @@ def compile_mixed_moe_gemm1(
                 _ifexpert_of = scf.IfOp(exp_valid)
                 with _if_then(_ifexpert_of):
                     expert_idx = arith.index_cast(ir.IndexType.get(), expert_i32)
-                    inter2_idx = arith.constant(2 * inter_dim, index=True)
+                    inter2_idx = arith.constant(_w_rows_per_expert, index=True)
                     expert_off_idx = expert_idx * inter2_idx  # index
 
                     bx_m = bx * arith.constant(tile_m, index=True)
@@ -673,7 +690,7 @@ def compile_mixed_moe_gemm1(
                     out_block_base = by_n
                     out_wave_base = n_tile_base
                     # layout for (row -> (blk,intra)) where intra is 0..15
-                    c_n0_static = experts * (2 * inter_dim) // 16
+                    c_n0_static = (experts * _w_rows_per_expert) // 16
                     layout_n_blk_intra = fx.make_layout(
                         (c_n0_static, 16), stride=(16, 1)
                     )
@@ -694,10 +711,11 @@ def compile_mixed_moe_gemm1(
                         gate_n_blk_list.append(layout_get(gate_coord_n, 0))
                         gate_n_intra_list.append(layout_get(gate_coord_n, 1))
 
-                        up_row_w = gate_row_w + inter_idx
-                        up_coord_n = idx2crd(up_row_w, layout_n_blk_intra)
-                        up_n_blk_list.append(layout_get(up_coord_n, 0))
-                        up_n_intra_list.append(layout_get(up_coord_n, 1))
+                        if not g1u0:
+                            up_row_w = gate_row_w + inter_idx
+                            up_coord_n = idx2crd(up_row_w, layout_n_blk_intra)
+                            up_n_blk_list.append(layout_get(up_coord_n, 0))
+                            up_n_intra_list.append(layout_get(up_coord_n, 1))
 
                     # --- B Load Logic (K64) - shared layout with preshuffle GEMM ---
                     def load_b_packs_k64(base_k, ku: int, n_blk, n_intra):
@@ -740,12 +758,12 @@ def compile_mixed_moe_gemm1(
 
                     def load_b_tile(base_k):
                         gate_b_tile = []
-                        up_b_tile = []
+                        up_b_tile = [] if not g1u0 else None
                         for ku in range_constexpr(k_unroll):
                             gate_packs0 = []
                             gate_packs1 = []
-                            up_packs0 = []
-                            up_packs1 = []
+                            up_packs0 = [] if not g1u0 else None
+                            up_packs1 = [] if not g1u0 else None
                             for ni in range_constexpr(num_acc_n):
                                 gate_b0, gate_b1 = load_b_packs_k64(
                                     base_k,
@@ -753,18 +771,20 @@ def compile_mixed_moe_gemm1(
                                     gate_n_blk_list[ni],
                                     gate_n_intra_list[ni],
                                 )
-                                up_b0, up_b1 = load_b_packs_k64(
-                                    base_k,
-                                    ku,
-                                    up_n_blk_list[ni],
-                                    up_n_intra_list[ni],
-                                )
                                 gate_packs0.append(gate_b0)
                                 gate_packs1.append(gate_b1)
-                                up_packs0.append(up_b0)
-                                up_packs1.append(up_b1)
+                                if not g1u0:
+                                    up_b0, up_b1 = load_b_packs_k64(
+                                        base_k,
+                                        ku,
+                                        up_n_blk_list[ni],
+                                        up_n_intra_list[ni],
+                                    )
+                                    up_packs0.append(up_b0)
+                                    up_packs1.append(up_b1)
                             gate_b_tile.append((gate_packs0, gate_packs1))
-                            up_b_tile.append((up_packs0, up_packs1))
+                            if not g1u0:
+                                up_b_tile.append((up_packs0, up_packs1))
                         return gate_b_tile, up_b_tile
 
                     def load_scale(arg_scale, rsrc, scale_info, ku, mni):
@@ -798,7 +818,7 @@ def compile_mixed_moe_gemm1(
 
                     def load_b_scale_tile(base_k):
                         gate_b_scale_tile = []
-                        up_b_scale_tile = []
+                        up_b_scale_tile = [] if not g1u0 else None
                         for ku in range_constexpr(k_unroll_packed):
                             for ni in range_constexpr(num_acc_n_packed):
                                 col_offset = ni * 16 * pack_N
@@ -812,9 +832,6 @@ def compile_mixed_moe_gemm1(
                                 gate_mni = (
                                     expert_off_idx + col_base
                                 ) // arith.constant(32, index=True)
-                                up_mni = (
-                                    expert_off_idx + inter_idx + col_base
-                                ) // arith.constant(32, index=True)
                                 gate_scale_i32 = load_scale_masked(
                                     arg_scale_w,
                                     sw_rsrc,
@@ -823,16 +840,20 @@ def compile_mixed_moe_gemm1(
                                     gate_mni,
                                     col_valid,
                                 )
-                                up_scale_i32 = load_scale_masked(
-                                    arg_scale_w,
-                                    sw_rsrc,
-                                    layout_b_scale,
-                                    ku + base_k,
-                                    up_mni,
-                                    col_valid,
-                                )
                                 gate_b_scale_tile.append(gate_scale_i32)
-                                up_b_scale_tile.append(up_scale_i32)
+                                if not g1u0:
+                                    up_mni = (
+                                        expert_off_idx + inter_idx + col_base
+                                    ) // arith.constant(32, index=True)
+                                    up_scale_i32 = load_scale_masked(
+                                        arg_scale_w,
+                                        sw_rsrc,
+                                        layout_b_scale,
+                                        ku + base_k,
+                                        up_mni,
+                                        col_valid,
+                                    )
+                                    up_b_scale_tile.append(up_scale_i32)
                         return gate_b_scale_tile, up_b_scale_tile
 
                     def load_a_scale_tile(base_k):
@@ -854,7 +875,7 @@ def compile_mixed_moe_gemm1(
                         return [load_a_scale_tile(base_k), gate_bs, up_bs]
 
                     acc_gate = [acc_init] * (num_acc_n * m_repeat)
-                    acc_up = [acc_init] * (num_acc_n * m_repeat)
+                    acc_up = None if g1u0 else ([acc_init] * (num_acc_n * m_repeat))
 
                     # ---- Pipeline helpers: store X tile to LDS with ping-pong base ----
                     def store_x_tile_to_lds(vec_x_in_parts, lds_base):
@@ -915,7 +936,7 @@ def compile_mixed_moe_gemm1(
                         prefetch_epilogue: bool = False,
                     ):
                         gate_list = list(acc_gate_in)
-                        up_list = list(acc_up_in)
+                        up_list = None if g1u0 else list(acc_up_in)
 
                         # Re-sync all threads before consuming the current LDS tile.
                         gpu.barrier()
@@ -926,22 +947,23 @@ def compile_mixed_moe_gemm1(
                             expert_off_idx + by_n + n_tile_base
 
                             gate_bias = []
-                            up_bias = []
+                            up_bias = [] if not g1u0 else None
                             for ni in range_constexpr(num_acc_n):
                                 global_n = by_n + n_tile_base + ni * 16 + lane_mod_16
                                 gate_offset = expert_off_idx + global_n
-                                up_offset = expert_off_idx + global_n + inter_dim
                                 gate_bias.append(
                                     buffer_ops.buffer_load(
                                         bias_rsrc, gate_offset, vec_width=1, dtype=f32
                                     )
                                 )
-                                up_bias.append(
-                                    buffer_ops.buffer_load(
-                                        bias_rsrc, up_offset, vec_width=1, dtype=f32
+                                if not g1u0:
+                                    up_offset = expert_off_idx + global_n + inter_dim
+                                    up_bias.append(
+                                        buffer_ops.buffer_load(
+                                            bias_rsrc, up_offset, vec_width=1, dtype=f32
+                                        )
                                     )
-                                )
-                            epilogue_pf = (gate_bias, up_bias)
+                            epilogue_pf = gate_bias if g1u0 else (gate_bias, up_bias)
 
                         if (int(tile_k) % 128) != 0:
                             raise ValueError(
@@ -975,18 +997,11 @@ def compile_mixed_moe_gemm1(
                                         static_position=[0],
                                         dynamic_position=[],
                                     )
-                                    up_bs_i32 = up_b_scale[
-                                        ku128 * num_acc_n_packed + ni
-                                    ]
-                                    up_bs_val = vector.extract(
-                                        up_bs_i32,
-                                        static_position=[0],
-                                        dynamic_position=[],
-                                    )
                                     for ikxdl in range_constexpr(pack_K):
                                         k_idx = ku128 * pack_K + ikxdl
                                         gate_bp0, gate_bp1 = gate_b_tile_in[k_idx]
-                                        up_bp0, up_bp1 = up_b_tile_in[k_idx]
+                                        if not g1u0:
+                                            up_bp0, up_bp1 = up_b_tile_in[k_idx]
                                         col_base = (
                                             col_offset_base
                                             + (k_idx * 128) // a_elem_vec_pack
@@ -1036,12 +1051,6 @@ def compile_mixed_moe_gemm1(
                                                     gb0, gb1, c0_i64, c0_i64
                                                 )
 
-                                                ub0 = up_bp0[ni_idx]
-                                                ub1 = up_bp1[ni_idx]
-                                                ub128 = pack_i64x4_to_i32x8(
-                                                    ub0, ub1, c0_i64, c0_i64
-                                                )
-
                                                 rocdl.sched_barrier(0)
                                                 gate_list[acc_idx] = (
                                                     rocdl.mfma_scale_f32_16x16x128_f8f6f4(
@@ -1059,23 +1068,37 @@ def compile_mixed_moe_gemm1(
                                                         ],
                                                     )
                                                 )
-                                                rocdl.sched_barrier(0)
-                                                up_list[acc_idx] = (
-                                                    rocdl.mfma_scale_f32_16x16x128_f8f6f4(
-                                                        mfma_res_ty,
-                                                        [
-                                                            a128,
-                                                            ub128,
-                                                            up_list[acc_idx],
-                                                            cbsz,
-                                                            blgp,
-                                                            ikxdl * pack_M + imxdl,
-                                                            a_scale_val,
-                                                            ikxdl * pack_N + inxdl,
-                                                            up_bs_val,
-                                                        ],
+                                                if not g1u0:
+                                                    ub0 = up_bp0[ni_idx]
+                                                    ub1 = up_bp1[ni_idx]
+                                                    ub128 = pack_i64x4_to_i32x8(
+                                                        ub0, ub1, c0_i64, c0_i64
                                                     )
-                                                )
+                                                    up_bs_i32 = up_b_scale[
+                                                        ku128 * num_acc_n_packed + ni
+                                                    ]
+                                                    up_bs_val = vector.extract(
+                                                        up_bs_i32,
+                                                        static_position=[0],
+                                                        dynamic_position=[],
+                                                    )
+                                                    rocdl.sched_barrier(0)
+                                                    up_list[acc_idx] = (
+                                                        rocdl.mfma_scale_f32_16x16x128_f8f6f4(
+                                                            mfma_res_ty,
+                                                            [
+                                                                a128,
+                                                                ub128,
+                                                                up_list[acc_idx],
+                                                                cbsz,
+                                                                blgp,
+                                                                ikxdl * pack_M + imxdl,
+                                                                a_scale_val,
+                                                                ikxdl * pack_N + inxdl,
+                                                                up_bs_val,
+                                                            ],
+                                                        )
+                                                    )
                         return gate_list, up_list, epilogue_pf
 
                     # ---------------- 2-stage pipeline (ping-pong LDS + B tile prefetch) ----------------
@@ -1087,7 +1110,7 @@ def compile_mixed_moe_gemm1(
                     rocdl.sched_barrier(0)
 
                     def hot_loop_scheduler():
-                        mfma_group = num_acc_n * 2
+                        mfma_group = num_acc_n if g1u0 else (num_acc_n * 2)
                         # K64 micro-step: 2x K32 MFMA per gemm.
                         mfma_total = (k_unroll * 2) * m_repeat * mfma_group
                         mfma_per_iter = 2 * mfma_group
@@ -1335,21 +1358,31 @@ def compile_mixed_moe_gemm1(
                                     static_position=[ii],
                                     dynamic_position=[],
                                 )
-                                vu = vector.extract(
-                                    acc_up[acc_idx],
-                                    static_position=[ii],
-                                    dynamic_position=[],
-                                )
-
-                                if enable_bias:
-                                    gate_bias_list, up_bias_list = epilogue_pf
-                                    vg = vg + gate_bias_list[ni]
-                                    vu = vu + up_bias_list[ni]
-
-                                if act == "swiglu":
-                                    y = swiglu(vg, vu)
+                                if g1u0:
+                                    if enable_bias:
+                                        gate_bias_list = epilogue_pf
+                                        vg = vg + gate_bias_list[ni]
+                                    if act == "gelu":
+                                        y = gelu(vg)
+                                    else:
+                                        y = silu(vg)
                                 else:
-                                    y = silu(vg) * vu
+                                    vu = vector.extract(
+                                        acc_up[acc_idx],
+                                        static_position=[ii],
+                                        dynamic_position=[],
+                                    )
+                                    if enable_bias:
+                                        gate_bias_list, up_bias_list = epilogue_pf
+                                        vg = vg + gate_bias_list[ni]
+                                        vu = vu + up_bias_list[ni]
+
+                                    if act == "swiglu":
+                                        y = swiglu(vg, vu)
+                                    elif act == "gelu":
+                                        y = gelu(vg) * vu
+                                    else:
+                                        y = silu(vg) * vu
 
                                 if doweight_stage1:
                                     y = y * tw
@@ -1496,20 +1529,31 @@ def compile_mixed_moe_gemm1(
                                     static_position=[ii],
                                     dynamic_position=[],
                                 )
-                                vu = vector.extract(
-                                    acc_up[acc_idx],
-                                    static_position=[ii],
-                                    dynamic_position=[],
-                                )
-                                if enable_bias:
-                                    gate_bias_list, up_bias_list = epilogue_pf
-                                    vg = vg + gate_bias_list[ni]
-                                    vu = vu + up_bias_list[ni]
-
-                                if act == "swiglu":
-                                    y = swiglu(vg, vu)
+                                if g1u0:
+                                    if enable_bias:
+                                        gate_bias_list = epilogue_pf
+                                        vg = vg + gate_bias_list[ni]
+                                    if act == "gelu":
+                                        y = gelu(vg)
+                                    else:
+                                        y = silu(vg)
                                 else:
-                                    y = silu(vg) * vu
+                                    vu = vector.extract(
+                                        acc_up[acc_idx],
+                                        static_position=[ii],
+                                        dynamic_position=[],
+                                    )
+                                    if enable_bias:
+                                        gate_bias_list, up_bias_list = epilogue_pf
+                                        vg = vg + gate_bias_list[ni]
+                                        vu = vu + up_bias_list[ni]
+
+                                    if act == "swiglu":
+                                        y = swiglu(vg, vu)
+                                    elif act == "gelu":
+                                        y = gelu(vg) * vu
+                                    else:
+                                        y = silu(vg) * vu
 
                                 if doweight_stage1:
                                     y = y * tw
@@ -1531,6 +1575,7 @@ def compile_mixed_moe_gemm1(
     # -- Host launcher (flyc.jit + .launch) --------------------------------
     _cache_tag = (
         module_name,
+        g1u_tag,
         a_dtype,
         b_dtype,
         out_dtype,

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -39,9 +39,9 @@ def get_flydsl_stage1_kernels(
     """Return {kernelName: params} for all supported stage1 configs."""
     kernels = {}
     is_fp4 = b_dtype == "fp4"
-    tile_ns = [256] if is_fp4 else [128]
-    tile_ks = [256] if is_fp4 else [128]
-    tile_ms = [16, 32, 64]
+    tile_ns = [256, 512] if is_fp4 else [128]
+    tile_ks = [256, 512] if is_fp4 else [128]
+    tile_ms = [16, 32, 64, 128, 256]
 
     for tm in tile_ms:
         for tn in tile_ns:
@@ -66,9 +66,9 @@ def get_flydsl_stage2_kernels(
     """Return {kernelName: params} for all supported stage2 configs."""
     kernels = {}
     is_fp4 = b_dtype == "fp4"
-    tile_ns = [128, 256] if is_fp4 else [128]
-    tile_ks = [256] if is_fp4 else [128]
-    tile_ms = [32, 64, 128]
+    tile_ns = [128, 256, 512] if is_fp4 else [128]
+    tile_ks = [256, 512] if is_fp4 else [128]
+    tile_ms = [32, 64, 128, 256]
     modes = ["atomic", "reduce"]
 
     for tm in tile_ms:
@@ -117,6 +117,7 @@ def compile_flydsl_moe_stage1(
     b_dtype: str,
     out_dtype: str,
     act: str = "silu",
+    g1u0: bool = False,
 ):
     """Compile stage1 kernel (cached via underlying lru_cache)."""
     if b_dtype == "fp4":
@@ -135,6 +136,7 @@ def compile_flydsl_moe_stage1(
             b_dtype=b_dtype,
             out_dtype=out_dtype,
             act=act,
+            g1u0=g1u0,
         )
     else:
         from .kernels.moe_gemm_2stage import compile_moe_gemm1
@@ -220,6 +222,7 @@ def _get_compiled_stage1(
     b_dtype: str,
     out_dtype: str,
     act: str,
+    g1u0: bool = False,
 ):
     """Compile and cache stage1 kernel, return a tensor_api closure."""
     exe = compile_flydsl_moe_stage1(
@@ -235,9 +238,17 @@ def _get_compiled_stage1(
         b_dtype=b_dtype,
         out_dtype=out_dtype,
         act=act,
+        g1u0=g1u0,
     )
     is_fp4 = b_dtype == "fp4"
-    _n_in = inter_dim * 2 if is_fp4 else inter_dim
+    # _n_in is used by kernel launch to compute gx.
+    # Keep historical behavior:
+    # - g1u0=False (gated): fp4 path uses 2*inter_dim, non-fp4 uses inter_dim
+    # - g1u0=True  (non-gated): always inter_dim
+    if g1u0:
+        _n_in = inter_dim
+    else:
+        _n_in = inter_dim * 2 if is_fp4 else inter_dim
     _k_in = model_dim
 
     def tensor_api(
@@ -475,17 +486,19 @@ def flydsl_moe_stage1(
     w1_scale: Optional[torch.Tensor] = None,
     a1_scale: Optional[torch.Tensor] = None,
     sorted_weights: Optional[torch.Tensor] = None,
+    g1u0: bool = False,
 ) -> torch.Tensor:
-    """Fused gate+up GEMM (MOE stage1).
+    """Fused gate+up/gate GEMM (MOE stage1).
 
-    a: (token_num, model_dim), w1: (E, 2*inter_dim, model_dim) pre-shuffled.
+    a: (token_num, model_dim),
+    w1: (E, 2*inter_dim, model_dim) pre-shuffled for G1U1, or (E, inter_dim, model_dim) for G1U0.
     For fp4 stage1, `w1`/`w1_scale` must use the same CK preshuffle layout as `shuffle_weight(..., (16, 16))`
     and `e8m0_shuffle(...)`.
     Returns (token_num, topk, inter_dim).
     """
     token_num = a.shape[0]
     E = w1.shape[0]
-    inter_dim = w1.shape[1] // 2
+    inter_dim = w1.shape[1] if g1u0 else (w1.shape[1] // 2)
     model_dim = a.shape[1]
 
     if a_dtype == "fp4":
@@ -524,6 +537,7 @@ def flydsl_moe_stage1(
         b_dtype=b_dtype,
         out_dtype=out_dtype,
         act=act,
+        g1u0=g1u0,
     )
     tensor_api(
         out.view(-1),

--- a/aiter/ops/flydsl/test_flydsl_moe_a4w4.py
+++ b/aiter/ops/flydsl/test_flydsl_moe_a4w4.py
@@ -13,6 +13,7 @@ Usage:
     python op_tests/test_flydsl_moe_a4w4.py --stage stage1          # stage1 only
     python op_tests/test_flydsl_moe_a4w4.py --stage stage2          # stage2 only
     python op_tests/test_flydsl_moe_a4w4.py --stage e2e             # end-to-end only
+    python op_tests/test_flydsl_moe_a4w4.py --g1u0 true             # run g1u0
     python op_tests/test_flydsl_moe_a4w4.py -t 16 -t 128            # specific token counts
     python op_tests/test_flydsl_moe_a4w4.py --block-m 16 32 64      # specific block sizes
 """
@@ -42,6 +43,18 @@ Q_DTYPE_A = dtypes.fp4x2
 Q_DTYPE_W = dtypes.fp4x2
 
 
+def _act_str_to_activation_type(act: str) -> ActivationType:
+    """Map kernel act string to ActivationType for torch reference."""
+    act_l = act.lower()
+    if act_l == "silu":
+        return ActivationType.Silu
+    if act_l == "gelu":
+        return ActivationType.Gelu
+    if act_l == "swiglu":
+        return ActivationType.Swiglu
+    raise ValueError(f"Unsupported act: {act}")
+
+
 # ---------------------------------------------------------------------------
 # Shared data generation
 # ---------------------------------------------------------------------------
@@ -56,15 +69,19 @@ def _generate_a4w4_data(
     block_m: int,
     dtype=torch.bfloat16,
     doweight_stage1: bool = False,
+    g1u0: bool = False,
+    act: str = "silu",
 ):
     """Generate quantised a4w4 data with torch reference outputs for stage1 and stage2."""
     torch_quant = aiter.get_torch_quant(Q_TYPE)
+    activation = _act_str_to_activation_type(act)
 
     torch.manual_seed(0)
     torch.cuda.manual_seed(0)
 
     inp = torch.randn((token, model_dim), dtype=dtype) / 10
-    w1 = torch.randn((E, inter_dim * 2, model_dim), dtype=dtype) / 10
+    w1_n = inter_dim if g1u0 else inter_dim * 2
+    w1 = torch.randn((E, w1_n, model_dim), dtype=dtype) / 10
     w2 = torch.randn((E, model_dim, inter_dim), dtype=dtype) / 10
     score = torch.randn((token, E), dtype=dtype)
     topk_weights, topk_ids = fused_topk(inp, score, topk, True)
@@ -86,7 +103,7 @@ def _generate_a4w4_data(
         topk_weights,
         topk_ids,
         dtype=dtype,
-        activation=ActivationType.Silu,
+        activation=activation,
         quant_type=Q_TYPE,
         a1_scale=a1_scale,
         w1_scale=w1_scale,
@@ -180,6 +197,7 @@ def _generate_a4w4_data(
         inter_dim=inter_dim,
         E=E,
         topk=topk,
+        g1u0=g1u0,
     )
 
 
@@ -213,6 +231,8 @@ def test_flydsl_stage1_a4w4(
     block_m: int = 32,
     atol: float = 1.0,
     rtol: float = 0.05,
+    g1u0: bool = False,
+    act: str = "silu",
 ):
     from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1
 
@@ -230,6 +250,8 @@ def test_flydsl_stage1_a4w4(
         E=E,
         topk=topk,
         block_m=block_m,
+        g1u0=g1u0,
+        act=act,
     )
 
     out_dtype_str = "bf16" if data["dtype"] == torch.bfloat16 else "f16"
@@ -247,9 +269,11 @@ def test_flydsl_stage1_a4w4(
         a_dtype="fp4",
         b_dtype="fp4",
         out_dtype=out_dtype_str,
+        act=act,
         w1_scale=data["w1_scale_shuf"],
         a1_scale=data["a1_scale_sort"],
         sorted_weights=data["sorted_weights_s1"],
+        g1u0=g1u0,
     )
     torch.cuda.synchronize()
 
@@ -272,6 +296,8 @@ def test_flydsl_stage2_a4w4(
     mode: str = "atomic",
     atol: float = 1.0,
     rtol: float = 0.05,
+    g1u0: bool = False,
+    act: str = "silu",
 ):
     from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage2
 
@@ -289,6 +315,8 @@ def test_flydsl_stage2_a4w4(
         E=E,
         topk=topk,
         block_m=block_m,
+        g1u0=g1u0,
+        act=act,
     )
 
     out_dtype_str = "bf16" if data["dtype"] == torch.bfloat16 else "f16"
@@ -332,6 +360,8 @@ def test_flydsl_e2e_a4w4(
     mode: str = "atomic",
     atol: float = 1.0,
     rtol: float = 0.05,
+    g1u0: bool = False,
+    act: str = "silu",
 ):
     """End-to-end test: FlyDSL stage1 output -> quantise -> FlyDSL stage2."""
     from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1, flydsl_moe_stage2
@@ -352,6 +382,8 @@ def test_flydsl_e2e_a4w4(
         E=E,
         topk=topk,
         block_m=block_m,
+        g1u0=g1u0,
+        act=act,
     )
 
     out_dtype_str = "bf16" if data["dtype"] == torch.bfloat16 else "f16"
@@ -370,9 +402,11 @@ def test_flydsl_e2e_a4w4(
         a_dtype="fp4",
         b_dtype="fp4",
         out_dtype=out_dtype_str,
+        act=act,
         w1_scale=data["w1_scale_shuf"],
         a1_scale=data["a1_scale_sort"],
         sorted_weights=data["sorted_weights_s1"],
+        g1u0=g1u0,
     )
     torch.cuda.synchronize()
 
@@ -450,6 +484,19 @@ def main():
         choices=["stage1", "stage2", "e2e"],
         help="Which tests to run (default: all)",
     )
+    parser.add_argument(
+        "--g1u0",
+        type=dtypes.str2bool,
+        default=False,
+        help="Whether to use g1u0 path (default: false).",
+    )
+    parser.add_argument(
+        "--act",
+        type=str,
+        default="silu",
+        choices=["silu", "gelu", "swiglu"],
+        help="Activation for stage1 (default: silu).",
+    )
     parser.add_argument("--atol", type=float, default=1.0)
     parser.add_argument("--rtol", type=float, default=0.05)
     args = parser.parse_args()
@@ -462,6 +509,9 @@ def main():
 
     results = []
 
+    g1u0 = args.g1u0
+    g1u0_str = "g1u0" if g1u0 else "g1u1"
+    act = args.act
     for token in args.tokens:
         for bm in args.block_m:
             # Stage1 tests
@@ -476,10 +526,12 @@ def main():
                         block_m=bm,
                         atol=args.atol,
                         rtol=args.rtol,
+                        g1u0=g1u0,
+                        act=act,
                     )
                     results.append(
                         (
-                            f"stage1_a4w4_t{token}_bm{bm}",
+                            f"stage1_a4w4_t{token}_bm{bm}_{g1u0_str}_{act}",
                             "PASS" if passed else "FAIL",
                             max_delta,
                             pct,
@@ -489,7 +541,9 @@ def main():
                     import traceback
 
                     traceback.print_exc()
-                    results.append((f"stage1_a4w4_t{token}_bm{bm}", "ERROR", 0, 0))
+                    results.append(
+                        (f"stage1_a4w4_t{token}_bm{bm}_{g1u0_str}_{act}", "ERROR", 0, 0)
+                    )
 
             # Stage2 tests
             if "stage2" in args.stage:
@@ -505,10 +559,12 @@ def main():
                             mode=mode,
                             atol=args.atol,
                             rtol=args.rtol,
+                            g1u0=g1u0,
+                            act=act,
                         )
                         results.append(
                             (
-                                f"stage2_a4w4_t{token}_bm{bm}_{mode}",
+                                f"stage2_a4w4_t{token}_bm{bm}_{mode}_{g1u0_str}_{act}",
                                 "PASS" if passed else "FAIL",
                                 max_delta,
                                 pct,
@@ -519,7 +575,12 @@ def main():
 
                         traceback.print_exc()
                         results.append(
-                            (f"stage2_a4w4_t{token}_bm{bm}_{mode}", "ERROR", 0, 0)
+                            (
+                                f"stage2_a4w4_t{token}_bm{bm}_{mode}_{g1u0_str}_{act}",
+                                "ERROR",
+                                0,
+                                0,
+                            )
                         )
 
             # End-to-end tests
@@ -536,10 +597,12 @@ def main():
                             mode=mode,
                             atol=args.atol,
                             rtol=args.rtol,
+                            g1u0=g1u0,
+                            act=act,
                         )
                         results.append(
                             (
-                                f"e2e_a4w4_t{token}_bm{bm}_{mode}",
+                                f"e2e_a4w4_t{token}_bm{bm}_{mode}_{g1u0_str}_{act}",
                                 "PASS" if passed else "FAIL",
                                 max_delta,
                                 pct,
@@ -550,7 +613,12 @@ def main():
 
                         traceback.print_exc()
                         results.append(
-                            (f"e2e_a4w4_t{token}_bm{bm}_{mode}", "ERROR", 0, 0)
+                            (
+                                f"e2e_a4w4_t{token}_bm{bm}_{mode}_{g1u0_str}_{act}",
+                                "ERROR",
+                                0,
+                                0,
+                            )
                         )
 
     # Summary

--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -410,7 +410,13 @@ class TunerCommon:
         logger.info("Failed shapes:")
         print(self.failed, flush=True)
 
-        tunedf_subset = tunedf[self.untunedf.columns].astype(self.untunedf.dtypes)
+        # tunedf_subset = tunedf[self.untunedf.columns].astype(self.untunedf.dtypes)
+        tunedf_subset = tunedf[self.untunedf.columns]
+        for col in tunedf_subset.columns:
+            try:
+                tunedf_subset[col] = tunedf_subset[col].astype(self.untunedf[col].dtype)
+            except (ValueError, TypeError):
+                pass
         mask = self.untunedf.apply(tuple, axis=1).isin(
             tunedf_subset.apply(tuple, axis=1)
         )

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -24,6 +24,8 @@ from aiter.fused_moe import (
 from aiter import ck_moe_stage1_fwd, ck_moe_stage2_fwd, dtype2str_dict
 from aiter.ops.shuffle import (
     shuffle_weight,
+    shuffle_weight_a16w4,
+    shuffle_scale_a16w4,
 )
 from aiter.utility.mp_tuner import mp_tuner
 from aiter.int4_utils import (
@@ -65,6 +67,17 @@ torch.int4 = getattr(torch, "int4", torch.uint32)
 
 
 FLYDSL_FALLBACK_TAG = "flydsl_fallback"
+
+
+def _activation_type_to_flydsl_act(act_type):
+    """Map ActivationType enum to FlyDSL stage1 `act` string."""
+    if act_type == ActivationType.Swiglu:
+        return "swiglu"
+    if act_type == ActivationType.Gelu:
+        return "gelu"
+    if act_type == ActivationType.Silu:
+        return "silu"
+    raise ValueError(f"Unsupported ActivationType for FlyDSL stage1: {act_type}")
 
 
 class FmoeTuner(TunerCommon):
@@ -350,8 +363,9 @@ class FmoeTuner(TunerCommon):
         blockM,
         q_type,
         act_type,
+        g1u0,
     ):
-        act = "swiglu" if act_type == ActivationType.Swiglu else "silu"
+        act = _activation_type_to_flydsl_act(act_type)
         return flydsl_moe_stage1(
             a=a1_qt,
             w1=w1_qt_shffle_ck,
@@ -369,6 +383,7 @@ class FmoeTuner(TunerCommon):
             w1_scale=w1_scale_aiter,
             a1_scale=a1_scale,
             sorted_weights=sorted_weights,
+            g1u0=g1u0,
         )
 
     @staticmethod
@@ -835,12 +850,12 @@ class FmoeTuner(TunerCommon):
             )
         elif q_dtype_w == dtypes.fp4x2:
             w1_qt_shffle_ck = shuffle_weight(w1_qt, (16, 16))
-            w2_qt_shffle_ck = shuffle_weight(w2_qt, (16, 16))
+            w2_qt_shffle_ck = shuffle_weight_a16w4(w2_qt, 16, False)
         else:
             w1_qt_shffle_ck = w1_qt_shffle
             w2_qt_shffle_ck = w2_qt_shffle
         w1_scale_aiter = fp4_utils.e8m0_shuffle(w1_scale)
-        w2_scale_aiter = fp4_utils.e8m0_shuffle(w2_scale)
+        w2_scale_aiter = shuffle_scale_a16w4(w2_scale, expert, False)
 
         w1_qt_shffle_flydsl = w1_qt_shffle_ck
         w2_qt_shffle_flydsl = w2_qt_shffle_ck
@@ -1965,7 +1980,7 @@ class FmoeTuner(TunerCommon):
         for blockM in blockMs:
             # per_1x32 fp4 sorting requires block size to be a multiple of 32, so
             # the tile_m=16 FlyDSL candidate is invalid for this tuning path.
-            if blockM not in [32, 64, 128] or not use_g1u1:
+            if blockM not in [32, 64, 128, 256]:  # or not use_g1u1:
                 continue
             for kname, kparams in flydsl_s1_kernels.items():
                 if kparams["tile_m"] != blockM:
@@ -1999,6 +2014,7 @@ class FmoeTuner(TunerCommon):
                             blockM,
                             q_type,
                             act_type,
+                            not use_g1u1,  # g1u0
                         ),
                         {},
                         FmoeTuner.run_torch_moe_stage1,
@@ -2268,9 +2284,9 @@ class FmoeTuner(TunerCommon):
             if get_gfx() not in ["gfx950"] and q_type == aiter.QuantType.per_1x32:
                 print(f"{q_type} is not supported on {get_gfx()}")
                 return []
-            if not use_g1u1:
-                print("no moe solution(g1u0) can tune for ", line)
-                continue
+            # if not use_g1u1:
+            #     print("no moe solution(g1u0) can tune for ", line)
+            #     continue
             act_type = eval(act_type)
             info = (
                 cu_num,


### PR DESCRIPTION
- add G1U0 support for stage1 GEMM path
- enable GELU path for W4A4 kernels
- fix stage1 selection and GELU behavior
- refresh tuned FP4 config and remove obsolete code

## Motivation
flydsl w4a4 moe support g1u0
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
