### PR TITLE
MI350 MLA PS mode fold nhead64,2 to nhead32,4 kernel

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -324,15 +324,11 @@ def mla_decode_fwd(
                 and kv_buffer.dtype == dtypes.fp8
                 and (
                     (max_seqlen_q * (ori_nhead // 16) == 4)
-                    or (
-                        (ori_nhead % 32 == 0)
-                        and (ori_nhead > 32)
-                        and (max_seqlen_q * (ori_nhead // 32) == 4)
-                    )
+                    or (ori_nhead == 64 and max_seqlen_q == 2)
                 )
             )
 
-            if use_qseqlen_fold and (max_seqlen_q * (ori_nhead // 32) == 4):
+            if use_qseqlen_fold and (ori_nhead == 64 and max_seqlen_q == 2):
                 fold_factor = ori_nhead // 32
                 nhead = 32
             else:

--- a/aiter/ops/attention.py
+++ b/aiter/ops/attention.py
@@ -928,11 +928,7 @@ def get_mla_metadata_info_v1(
         and num_head_qo > 16
         and (
             (max_seqlen_qo * (num_head_qo // 16) == 4)
-            or (
-                (num_head_qo % 32 == 0)
-                and (num_head_qo > 32)
-                and (max_seqlen_qo * (num_head_qo // 32) == 4)
-            )
+            or (num_head_qo == 64 and max_seqlen_qo == 2)
         )
     )
 

--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -465,10 +465,9 @@ void get_mla_metadata_v1_2_device(const torch::Tensor& seqlens_qo_indptr, // [ba
 
     const bool use_qseqlen_fold =
         !natively_supported && (arch_id == "gfx950") && q_is_fp8 && kv_is_fp8 && (num_heads > 16) &&
-        ((uni_seqlen_qo * (num_heads / 16) == 4) ||
-         ((num_heads % 32 == 0) && (num_heads > 32) && (uni_seqlen_qo * (num_heads / 32) == 4)));
+        ((uni_seqlen_qo * (num_heads / 16) == 4) || ((num_heads == 64) && (uni_seqlen_qo == 2)));
 
-    if(use_qseqlen_fold && (uni_seqlen_qo * (num_heads / 32) == 4))
+    if(use_qseqlen_fold && (num_heads == 64) && (uni_seqlen_qo == 2))
     {
         qk_seqlen_ratio = num_heads / 32;
         num_heads       = 32;

--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -411,15 +411,11 @@ def torch_mla_extend_split_kv(
             and is_fp8_kvc
             and (
                 (max_seqlen_q * (nheads // 16)) == 4
-                or (
-                    (nheads % 32 == 0)
-                    and (nheads > 32)
-                    and (max_seqlen_q * (nheads // 32) == 4)
-                )
+                or (nheads == 64 and max_seqlen_q == 2)
             )
         )
 
-        if use_qseqlen_fold and (max_seqlen_q * (nheads // 32) == 4):
+        if use_qseqlen_fold and nheads == 64 and max_seqlen_q == 2:
             fold_factor = nheads // 32
             nheads = 32
         else:


### PR DESCRIPTION
## Motivation
fold nhead64,2 to nhead32,4 kernel

## Technical Details
Extend qseqlen-fold detection/selection to optionally fold to nhead=32 (instead of always nhead=16) when it yields qlen=4.
Update device-side metadata generation (v1.2) to apply the new fold-to-32 behavior.
Update the persistent MLA test’s reference path to track use_qseqlen_fold and reshape outputs correctly.

## Test Plan
python3 op_tests/test_mla_persistent.py --nhead 64,2 -d fp8 -kvd fp8 -c 1024 8192 32768 -b 64
python3 op_tests/test_mla_persistent.py --nhead 16,4 32,2 64,1 32,4 128,1 64,2 -d fp8 -kvd fp8 -c 1024 8192 32768 -b 64

## Test Result
<img width="2301" height="497" alt="image" src="https://github.com/user-attachments/assets/67694048-6caa-4fa1-9836-5756285556bc" />
<img width="2124" height="931" alt="image" src="https://github.com/user-attachments/assets/d0d327ef-615f-44bb-bbfb-160141b67abf" />

perf对比：
<img width="1041" height="1638" alt="image" src="https://github.com/user-attachments/assets/b0208cfc-cfc6-464d-acff-6611e1311a95" />

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
