### PR TITLE
CI: revert pre-checks Ruff step to baseline behavior

### DIFF
--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
@@ -53,36 +51,16 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-          fi
-
-          mapfile -t CHANGED_PY_FILES < <(git diff --name-only "$BASE_SHA" "$GITHUB_SHA" -- '*.py')
-          if [ "${#CHANGED_PY_FILES[@]}" -eq 0 ]; then
-            echo "No changed Python files detected."
-            exit 0
-          fi
-
-          set +e
-          # Only lint changed Python files to avoid unrelated historical violations.
-          ruff check "${CHANGED_PY_FILES[@]}" \
+          ruff check . \
             --output-format=rdjson \
-            --no-fix > ruff.rdjson
-          ruff_exit=$?
-          set -e
-
-          reviewdog \
+            --exit-zero \
+            --no-fix \
+          | reviewdog \
             -f=rdjson \
             -name="ruff" \
-            -reporter=github-check \
-            -fail-level=none < ruff.rdjson || echo "reviewdog failed (non-blocking)"
-
-          if [ "$ruff_exit" -ne 0 ]; then
-            echo "Ruff reported style issues."
-            exit "$ruff_exit"
-          fi
+            -reporter=github-pr-review \
+            -filter-mode=diff_context \
+            -fail-on-error=true
 
   upload-success-artifact:
     name: Upload Success Signal


### PR DESCRIPTION
## Summary
- Revert `.github/workflows/pre-checks.yaml` to the baseline Ruff and reviewdog configuration used previously.
- Remove the changed-file scoping logic and related checkout depth adjustments introduced in this PR branch.
- Keep repository checks aligned with the earlier behavior to avoid unintended workflow side effects.

## Test plan
- [x] Restored `pre-checks.yaml` to baseline behavior.
- [x] Verified branch diff only touches `.github/workflows/pre-checks.yaml`.
- [x] Pushed rollback commit to this PR branch.