### PR TITLE
Fix _gluon_deepgemm_fp8_paged_mqa_logits instr_shape compatibility

### DIFF
--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -127,12 +127,20 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
         order=[1, 0],
     )
 
-    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
-        version=CDNA_VERSION,
-        instr_shape=[16, 16],
-        transposed=False,
-        warps_per_cta=[1, NumWarps],
-    )
+    if _Use_2d_instr_shape_mfma_layout:
+        mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+            version=CDNA_VERSION,
+            instr_shape=[16, 16],
+            transposed=False,
+            warps_per_cta=[1, NumWarps],
+        )
+    else:
+        mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+            version=CDNA_VERSION,
+            instr_shape=[16, 16, 32],
+            transposed=False,
+            warps_per_cta=[1, NumWarps],
+        )
     mfma_layout_a: gl.constexpr = gl.DotOperandLayout(
         operand_index=0, parent=mfma_layout, k_width=16
     )


### PR DESCRIPTION
cc @Jacob0226 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

In triton [PR#8213](https://github.com/triton-lang/triton/pull/8213/changes#diff-81e131fae08ae21cfe2169595c733bb2b90c41321733daf966ea4372eebe4a35R82), gluon MFMA layout validation was updated to require a 3D instruction shape (M, N, K). As a result, on newer triton versions (e.g. triton 3.6.0 used in sglang), the `_gluon_deepgemm_fp8_paged_mqa_logits` kernel can fail during compilation when it still passes a 2D shape.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Following the existing compatibility pattern already used in aiter, this change adds an explicit 2D/3D layout split in `_gluon_deepgemm_fp8_paged_mqa_logits`:
- Use 2D `instr_shape=[16, 16]` on older triton behavior.
- Use 3D `instr_shape=[16, 16, 32]` on newer triton behavior.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
