### PR TITLE
Import get_fp8_dtypes from the correct place in bench_gemm_a8wfp4

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_gemm_a8wfp4.py
+++ b/op_tests/op_benchmarks/triton/bench_gemm_a8wfp4.py
@@ -20,10 +20,11 @@ from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_caller_name_no_ext,
 )
 import aiter.ops.triton.utils._triton.arch_info as arch_info
+from aiter.ops.triton.utils.types import get_fp8_dtypes
 
 
 def bench_gemm_fn(M: int, N: int, K: int, metric: str, layout: str):
-    e5m2_type, e4m3_type = arch_info.get_fp8_dtypes()
+    e5m2_type, e4m3_type = get_fp8_dtypes()
     a_dtype = e4m3_type
     out_dtype = torch.float16
     x, w, x_scales, w_scales, _, _, y = generate_gemm_a8wfp4_inputs(


### PR DESCRIPTION
## Motivation

When running bench_gemm_a8wfp4.py, the script fails immediately with:
```
AttributeError: module 'aiter.ops.triton.utils._triton.arch_info' has no attribute 'get_fp8_dtypes'
```
## Technical Details

`bench_gemm_a8wfp4.py` was calling `arch_info.get_fp8_dtypes()`, but `get_fp8_dtypes` is defined in `aiter.ops.triton.utils.types`, not in `arch_info`. Fixed by importing and calling it from the correct module, consistent with every other call
site in the codebase (e.g. `test_gemm_a8wfp4.py`, `test_gemm_a8w8.py`, etc.).

## Test Plan

Run `bench_gemm_a8wfp4.py --model all -M 4096 --model-configs ... --metric time --layout TT -o` and verify it no longer raises `AttributeError`.

## Test Result

Script launches successfully after the fix.