### PR TITLE
CI: remove stale inplace parametrization from rope THD backward test

### DIFF
--- a/op_tests/triton_tests/rope/test_rope.py
+++ b/op_tests/triton_tests/rope/test_rope.py
@@ -454,7 +454,6 @@ def test_rope_thd_fwd(
 )
 @pytest.mark.parametrize("reuse_freqs_front_part", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("inplace", [True, False])
 def test_rope_thd_bwd(
     B: int,
     T: int,


### PR DESCRIPTION
## Summary
- remove the stale `inplace` parametrization from `test_rope_thd_bwd`
- fix the pytest collection error `function uses no argument 'inplace'` in the Triton rope shard
- let shard 1 reach test execution instead of exiting during collection

## Test plan
- [x] `python3 -m py_compile op_tests/triton_tests/rope/test_rope.py`
- [x] verify the parametrized argument names for `test_rope_thd_bwd` match its function signature
- [ ] full `pytest` run not executed locally