### PR TITLE
CI: improve AMD CI monitor runner fleet summary

### DIFF
--- a/.github/scripts/query_job_status.py
+++ b/.github/scripts/query_job_status.py
@@ -706,7 +706,8 @@ def main():
                             format_duration_seconds(values["avg_duration_seconds"]),
                         ]
                         for label, values in sorted(
-                            concurrency.items(), key=lambda item: runner_label_sort_key(item[0])
+                            concurrency.items(),
+                            key=lambda item: runner_label_sort_key(item[0]),
                         )
                     ],
                     headers=[
@@ -723,7 +724,9 @@ def main():
                 )
             )
         else:
-            print("No matching self-hosted runner labels found in the selected time window.")
+            print(
+                "No matching self-hosted runner labels found in the selected time window."
+            )
     else:
         print("### Job Status Report")
         print(


### PR DESCRIPTION
## Summary
- move the AMD CI monitor helper scripts under `.github/scripts` and update the workflow to use the new paths
- fetch the Actions job snapshot once per run and reuse it across the matrix reports to avoid repeated API queries
- add runner-label fleet metrics to the summary so aiter shows peak/average concurrency, queue latency percentiles, and average duration

## Test plan
- [x] `python3 -m py_compile .github/scripts/query_job_status.py`
- [x] smoke test the runner fleet summary rendering with representative snapshot records
- [ ] run the `AMD CI Job Monitor` workflow end to end on GitHub