### PR TITLE
fix(car): craph capture err

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -2039,19 +2039,22 @@ class CustomAllreduce
     RankData* get_buffer_RD(hipStream_t stream, void* input)
     {
         RankData* ptrs;
-        auto it = input_buffer.find(input);
-        if(it != input_buffer.end())
+        // During graph capture, always record the buffer unconditionally.
+        // Skip the input_buffer cache to ensure all ranks record the same
+        // number of buffers, even if their allocators reuse different addresses.
+        hipStreamCaptureStatus status;
+        HIP_CALL(hipStreamIsCapturing(stream, &status));
+        if(status == hipStreamCaptureStatusActive)
         {
-            ptrs = it->second;
+            ptrs = d_rank_data_base_ + graph_unreg_input_buffers_.size();
+            graph_unreg_input_buffers_.push_back(input);
         }
         else
         {
-            hipStreamCaptureStatus status;
-            HIP_CALL(hipStreamIsCapturing(stream, &status));
-            if(status == hipStreamCaptureStatusActive)
+            auto it = input_buffer.find(input);
+            if(it != input_buffer.end())
             {
-                ptrs = d_rank_data_base_ + graph_unreg_input_buffers_.size();
-                graph_unreg_input_buffers_.push_back(input);
+                ptrs = it->second;
             }
             else
             {
@@ -2067,21 +2070,23 @@ class CustomAllreduce
     RankData* get_output_buffer_RD(hipStream_t stream, void* output)
     {
         RankData* ptrs;
-        auto it = output_buffers_.find(output);
-        if(it != output_buffers_.end())
+        // During graph capture, always record the buffer unconditionally.
+        // Skip the output_buffers_ cache to ensure all ranks record the same
+        // number of buffers, even if their allocators reuse different addresses.
+        hipStreamCaptureStatus status;
+        HIP_CALL(hipStreamIsCapturing(stream, &status));
+        if(status == hipStreamCaptureStatusActive)
         {
-            ptrs = it->second;
+            ptrs = d_rank_data_base_ + graph_unreg_input_buffers_.size() +
+                   graph_unreg_output_buffers_.size();
+            graph_unreg_output_buffers_.push_back(output);
         }
         else
         {
-            hipStreamCaptureStatus status;
-            HIP_CALL(hipStreamIsCapturing(stream, &status));
-            if(status == hipStreamCaptureStatusActive)
+            auto it = output_buffers_.find(output);
+            if(it != output_buffers_.end())
             {
-                // For graph mode, collect output addresses
-                ptrs = d_rank_data_base_ + graph_unreg_input_buffers_.size() +
-                       graph_unreg_output_buffers_.size();
-                graph_unreg_output_buffers_.push_back(output);
+                ptrs = it->second;
             }
             else
             {


### PR DESCRIPTION
## Motivation

Fix custom_all_reduce graph buffer count mismatch across ranks during CUDA graph capture, which can cause out-of-bounds IPC handle access and silent data corruption.

## Technical Details

During graph capture, `get_buffer_RD` and `get_output_buffer_RD` check a local cache (`input_buffer` / `output_buffers_`) before recording buffers into `graph_unreg_input_buffers_`. Different ranks may have different GPU memory allocator behavior, causing some ranks to hit the cache (address reused from a prior `register_input_buffer`) while others miss. This results in different `graph_unreg_input_buffers_.size()` across ranks.

In `register_graph_buffers`, each rank uses its **local** count to index into **peer** handle/offset arrays, leading to out-of-bounds reads when counts differ.

Fix: move the `hipStreamIsCapturing` check **before** the cache lookup so that during graph capture, buffers are always recorded unconditionally, ensuring consistent counts across all ranks.

## Test Plan

- Multi-GPU (8xGPU) graph capture with custom_all_reduce enabled
- Verify all ranks log the same "Registering N cuda graph addresses" count
- Validate allreduce correctness after graph replay
- still need more test in framework

## Test Result

none

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.