### PR TITLE
Annotate moe_sorting_dispatch_policy as int for fused_moe

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -187,7 +187,7 @@ def fused_moe_fake(
     # following for tuning
     block_size_M: int = -1,
     num_local_tokens: Optional[torch.Tensor] = None,
-    moe_sorting_dispatch_policy: bool = 0,
+    moe_sorting_dispatch_policy: int = 0,
     dtype: Optional[torch.dtype] = None,
     hidden_pad: int = 0,
     intermediate_pad: int = 0,
@@ -221,7 +221,7 @@ def fused_moe_(
     # following for tuning
     block_size_M: int = -1,
     num_local_tokens: Optional[torch.Tensor] = None,
-    moe_sorting_dispatch_policy: bool = 0,
+    moe_sorting_dispatch_policy: int = 0,
     dtype: Optional[torch.dtype] = None,
     hidden_pad: int = 0,
     intermediate_pad: int = 0,


### PR DESCRIPTION
## Motivation

The type annotation bool was incorrect for moe_sorting_dispatch_policy, which accepts int values. The @torch_compile_guard decorator uses these annotations to generate PyTorch custom op schemas; with bool, PyTorch schema enforcement casts any value to bool, so dispatch_policy=2 becomes bool(2)=True (1), silently losing the intended policy. Using int allows callers to set dispatch_policy=2 correctly.

Fixes: #2576


## Technical Details

2-line change in aiter/fused_moe.py:

Line 191: moe_sorting_dispatch_policy: bool = 0 → int = 0 (in fused_moe_fake)
Line 225: moe_sorting_dispatch_policy: bool = 0 → int = 0 (in fused_moe_)

Will be followed up by vLLM change to enable user to set the policy.

## Test Plan

- Verified dispatch_policy=2 is passed through correctly to the kernel (previously silently truncated to 1)
- lm_eval gsm8k accuracy on Qwen3-Next-80B-A3B-Instruct-FP8 (MI355X, TP1)
- E2E throughput benchmark (vllm bench serve, 1k/1k, concurrency 16)

## Test Result

| Metric | dp=0 (baseline) | dp=2 (with fix) |
|--------|-----------------|-----------------|
| gsm8k flex_extract | 0.8560 | 0.8628 |
| gsm8k strict_match | 0.8143 | 0.8196 |
| Output throughput (tok/s) | 1527.83 | 1551.84 (+1.6%) |

No accuracy regression. Modest throughput improvement from correct dispatch policy.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
