### PR TITLE
fix: enable MXFP4 MoE at TP=4/8 via CKTile a4w4 kernels and quant fixes

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -630,6 +630,7 @@ class MOEMetadata:
     has_bias: bool = False
     use_non_temporal_load: bool = True
     fuse_quant: str = ""
+    skip_inter_quant: bool = False
 
 
 def _flydsl_stage1_wrapper(
@@ -947,6 +948,12 @@ def get_2stage_cfgs(
     def get_block_m() -> int:
         if q_dtype_a == dtypes.fp8:
             return 32
+        elif q_dtype_a == dtypes.fp4x2:
+            # MXFP4 fused quant+sort requires block_size % 32 == 0.
+            # block_m=64 is significantly faster than 32 for fp4x2 on
+            # gfx950 across all tested batch sizes (up to 1.5x for
+            # prefill).  128 is not supported by current CKTile stage2.
+            return 64
         else:
             return 16 if token < 2048 else 32 if token < 16384 else 64
 
@@ -1048,6 +1055,7 @@ def get_2stage_cfgs(
         dtype in [dtypes.bf16, dtypes.fp16]
         and q_type == QuantType.per_1x32
         and q_dtype_w in [dtypes.fp4x2]
+        and q_dtype_a not in [dtypes.fp4x2]
         and ksplit > 1
         and is_shuffled
     ):
@@ -1060,14 +1068,47 @@ def get_2stage_cfgs(
                 split_k=ksplit,
             ),
             functools.partial(
+                aiter.ck_moe_stage2_fwd,
+                activation=activation,
+                quant_type=q_type,
+            ),
+            16 if token < 2048 else 32 if token < 16384 else 64,
+            ksplit,
+            run_1stage,
+        )
+    elif (
+        dtype in [dtypes.bf16, dtypes.fp16]
+        and q_type == QuantType.per_1x32
+        and q_dtype_a in [dtypes.fp4x2]
+        and q_dtype_w in [dtypes.fp4x2]
+    ):
+        # Stage1 uses JIT CK (DeviceMoeGemmMXBPreShuffle) which correctly
+        # handles fp4x2 activations x fp4x2 weights.  CKTile AOT stage1 is
+        # still broken (AQUANT_Pipeline misinterprets fp4 as fp8).
+        #
+        # Stage2 uses CKTile AOT with bf16 activations x fp4x2 weights
+        # (a16w4 path) which avoids the costly intermediate bf16->fp4x2
+        # quantization kernel between stages.  For decode (small M) this
+        # eliminates a full kernel launch + memory round-trip.
+        #
+        # NOTE: w1 must be pre-shuffled with shuffle_weight_a16w4(w1, 16, True)
+        # and w1_scale with shuffle_scale_a16w4(w1_scale, E, True).
+        return MOEMetadata(
+            functools.partial(
+                ck_moe_stage1,
+                quant_type=q_type,
+                activation=activation,
+            ),
+            functools.partial(
                 cktile_moe_stage2,
                 n_pad_zeros=hidden_pad // 64 * 64,
                 k_pad_zeros=intermediate_pad // 128 * 128,
                 activation=activation,
             ),
-            16 if token < 2048 else 32 if token < 16384 else 64,
-            ksplit,
-            run_1stage,
+            get_block_m(),
+            0,
+            False,
+            skip_inter_quant=True,
         )
 
     if (kernelName1 and "ck2stages" in kernelName1) or (
@@ -1314,6 +1355,7 @@ def fused_moe_2stages(
             q_dtype_a in [dtypes.bf16, dtypes.fp16]
             and activation == ActivationType.Swiglu
             or (metadata.ksplit > 1 and is_shuffled)
+            or metadata.skip_inter_quant
         )
     ):
         a2_scale = None
@@ -1357,23 +1399,72 @@ def fused_moe_2stages(
         )
         a2 = a2.view(token_num, topk, inter_dim)
 
-    metadata.stage2(
-        a2,
-        w1,
-        w2,
-        sorted_ids,
-        sorted_expert_ids,
-        num_valid_ids,
-        moe_out,
-        topk,
-        w2_scale=(
-            w2_scale.view(dtypes.fp8_e8m0) if w2.dtype == dtypes.fp4x2 else w2_scale
-        ),
-        a2_scale=a2_scale,
-        block_m=block_size_M,
-        sorted_weights=sorted_weights if not doweight_stage1 else None,
-        **extra_stage2_args,
+    w2_scale_stage2 = (
+        w2_scale.view(dtypes.fp8_e8m0) if w2.dtype == dtypes.fp4x2 else w2_scale
     )
+    sorted_weights_stage2 = sorted_weights if not doweight_stage1 else None
+
+    try:
+        metadata.stage2(
+            a2,
+            w1,
+            w2,
+            sorted_ids,
+            sorted_expert_ids,
+            num_valid_ids,
+            moe_out,
+            topk,
+            w2_scale=w2_scale_stage2,
+            a2_scale=a2_scale,
+            block_m=block_size_M,
+            sorted_weights=sorted_weights_stage2,
+            **extra_stage2_args,
+        )
+    except RuntimeError as e:
+        # Some TP-sharded MXFP4 MoE tuples on gfx950 can fail in CK stage2
+        # with an unsupported device_gemm configuration. Fall back to cktile
+        # stage2 for the same problem shape to preserve functionality.
+        fallback_enabled = os.environ.get("AITER_MOE_STAGE2_CK_FALLBACK", "1") != "0"
+        ck_unsupported = "device_gemm" in str(e)
+        can_fallback = (
+            fallback_enabled
+            and ck_unsupported
+            and quant_type == QuantType.per_1x32
+            and activation == ActivationType.Silu
+            and dtype in [dtypes.bf16, dtypes.fp16]
+            and w1.dtype == dtypes.fp4x2
+            and w2.dtype == dtypes.fp4x2
+        )
+
+        if not can_fallback:
+            raise
+
+        logger.warning(
+            "[fused_moe] CK stage2 failed, retry with cktile stage2: "
+            f"err={e}; token={token_num}, topk={topk}, model_dim={model_dim}, "
+            f"inter_dim={inter_dim}, expert={E}, block_m={block_size_M}, "
+            f"ksplit={metadata.ksplit}, q_type={quant_type}, act={activation}, "
+            f"dtype={dtype}, q_dtype_a={q_dtype_a}, q_dtype_w={q_dtype_w}"
+        )
+
+        cktile_moe_stage2(
+            a2,
+            w1,
+            w2,
+            sorted_ids,
+            sorted_expert_ids,
+            num_valid_ids,
+            moe_out,
+            topk,
+            w2_scale=w2_scale_stage2,
+            a2_scale=a2_scale,
+            block_m=block_size_M,
+            activation=activation,
+            sorted_weights=sorted_weights_stage2,
+            n_pad_zeros=hidden_pad // 64 * 64,
+            k_pad_zeros=intermediate_pad // 128 * 128,
+            **extra_stage2_args,
+        )
 
     return moe_out
 
@@ -1687,6 +1778,16 @@ def torch_moe_stage2(
         hidden_states = hidden_states.view(a2_shape)
 
         w2_shape = w2.shape
+        # Some TP-sharded models carry padded per_1x32 scale groups in w2_scale.
+        # Align scale groups to runtime inter_dim groups for robust torch fallback.
+        w2_scale = w2_scale.view(E, model_dim, -1)
+        w2_groups = inter_dim // 32
+        if w2_scale.shape[2] > w2_groups:
+            w2_scale = w2_scale[:, :, :w2_groups]
+        elif w2_scale.shape[2] < w2_groups:
+            pad = w2_groups - w2_scale.shape[2]
+            w2_scale = torch.nn.functional.pad(w2_scale, (0, pad), value=1.0)
+
         w2 = w2.view(E, model_dim, inter_dim // 32, 32) * w2_scale.view(
             E, model_dim, inter_dim // 32, 1
         )
@@ -1800,19 +1901,17 @@ def cktile_moe_stage1(
         D = D * 8
 
     out = torch.empty((token_num, topk, D), dtype=dtype, device=hidden_states.device)
-    # WARNING: when split_k > 1, this allocation has the same undersized buffer
-    # pattern fixed in ck_moe_stage1 (see ROCm/aiter#2508). If the CK tile
-    # kernel calls hipMemsetAsync with sorted_size rows, this will overflow.
-    # When fp32 splitk is enabled, apply the same fix: use sorted_size =
-    # min(token_num * topk * block_m, sorted_token_ids.shape[0]) and slice
-    # valid_out = tmp_out[:token_num * topk, :] before silu_and_mul/gelu_and_mul.
-    tmp_out = (
-        torch.zeros(
-            (token_num, topk, w1.shape[1]), dtype=hidden_states.dtype, device=out.device
+    if split_k > 1:
+        # CKTile kernel zeros this buffer via hipMemsetAsync when split_k > 1.
+        # Must be large enough to cover sorted_token_ids (= max_num_tokens_padded),
+        # otherwise the kernel overflows and corrupts adjacent memory.
+        # Mirror the fix from ck_moe_stage1 (ROCm/aiter#2508).
+        sorted_size = min(token_num * topk * block_m, sorted_token_ids.shape[0])
+        tmp_out = torch.zeros(
+            (sorted_size, w1.shape[1]), dtype=hidden_states.dtype, device=out.device
         )
-        if split_k > 1
-        else out
-    )
+    else:
+        tmp_out = out
 
     # print("Run cktile_moe_stage1: M=%d, N(N*2)=%d, K=%d, topk=%d, expert=%d"%(token_num, w1.shape[1], hidden_states.shape[1], topk, w1.shape[0]))
     aiter.moe_cktile2stages_gemm1(
@@ -1836,10 +1935,11 @@ def cktile_moe_stage1(
     )
 
     if split_k > 1:
+        valid_out = tmp_out[: token_num * topk, :]
         if activation == ActivationType.Silu:
-            aiter.silu_and_mul(out, tmp_out)  # TODO: support fp32 splitk
+            aiter.silu_and_mul(out, valid_out)
         else:
-            aiter.gelu_and_mul(out, tmp_out)
+            aiter.gelu_and_mul(out, valid_out)
     return out
 
 

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -876,6 +876,7 @@ class MOEMetadata:
     fuse_quant: str = ""
     stage2_has_bias: bool = False
     flat: bool = False
+    skip_inter_quant: bool = False
 
 
 def _needs_swiglu_bias_support(dtype, quant_type):
@@ -1364,6 +1365,12 @@ def get_2stage_cfgs(
     def get_block_m() -> int:
         if q_dtype_a == dtypes.fp8:
             return 32
+        elif q_dtype_a == dtypes.fp4x2:
+            # MXFP4 fused quant+sort requires block_size % 32 == 0.
+            # block_m=64 is significantly faster than 32 for fp4x2 on
+            # gfx950 across all tested batch sizes (up to 1.5x for
+            # prefill).  128 is not supported by current CKTile stage2.
+            return 64
         else:
             return 16 if token < 2048 else 32 if token < 16384 else 64
 
@@ -1608,6 +1615,7 @@ def get_2stage_cfgs(
         dtype in [dtypes.bf16, dtypes.fp16]
         and q_type == QuantType.per_1x32
         and q_dtype_w in [dtypes.fp4x2]
+        and q_dtype_a not in [dtypes.fp4x2]
         and is_shuffled
         and not (activation == ActivationType.Swiglu and q_dtype_a == dtypes.fp4x2)
         and (ksplit > 1 or swiglu_mxfp4_bf16_cktile)
@@ -1643,6 +1651,29 @@ def get_2stage_cfgs(
             run_1stage,
             has_bias=activation == ActivationType.Swiglu,
             stage2_has_bias=activation == ActivationType.Swiglu,
+        )
+    elif (
+        dtype in [dtypes.bf16, dtypes.fp16]
+        and q_type == QuantType.per_1x32
+        and q_dtype_a in [dtypes.fp4x2]
+        and q_dtype_w in [dtypes.fp4x2]
+    ):
+        return MOEMetadata(
+            functools.partial(
+                ck_moe_stage1,
+                quant_type=q_type,
+                activation=activation,
+            ),
+            functools.partial(
+                cktile_moe_stage2,
+                n_pad_zeros=hidden_pad // 64 * 64,
+                k_pad_zeros=intermediate_pad // 128 * 128,
+                activation=activation,
+            ),
+            get_block_m(),
+            0,
+            False,
+            skip_inter_quant=True,
         )
 
     if (kernelName1 and "ck2stages" in kernelName1) or (
@@ -1948,6 +1979,7 @@ def fused_moe_2stages(
             q_dtype_a in [dtypes.bf16, dtypes.fp16]
             and activation == ActivationType.Swiglu
             or (metadata.ksplit > 1 and is_shuffled)
+            or metadata.skip_inter_quant
         )
     ):
         a2_scale = None
@@ -2392,6 +2424,16 @@ def torch_moe_stage2(
         hidden_states = hidden_states.view(a2_shape)
 
         w2_shape = w2.shape
+        # Some TP-sharded models carry padded per_1x32 scale groups in w2_scale.
+        # Align scale groups to runtime inter_dim groups for robust torch fallback.
+        w2_scale = w2_scale.view(E, model_dim, -1)
+        w2_groups = inter_dim // 32
+        if w2_scale.shape[2] > w2_groups:
+            w2_scale = w2_scale[:, :, :w2_groups]
+        elif w2_scale.shape[2] < w2_groups:
+            pad = w2_groups - w2_scale.shape[2]
+            w2_scale = torch.nn.functional.pad(w2_scale, (0, pad), value=1.0)
+
         w2 = w2.view(E, model_dim, inter_dim // 32, 32) * w2_scale.view(
             E, model_dim, inter_dim // 32, 1
         )
@@ -2515,8 +2557,6 @@ def cktile_moe_stage1(
     ):
         out = torch.empty(expected_out_shape, dtype=dtype, device=hidden_states.device)
     needs_post_activation = split_k > 1
-    # Split-k reduces into a token-topk workspace and applies activation after
-    # reduction. Non-split legacy A16W4 keeps CK-Tile's fused gate/up epilogue.
     workspace_rows = token_num * topk
     if needs_post_activation:
         tmp_out = torch.zeros(
@@ -2525,6 +2565,7 @@ def cktile_moe_stage1(
     else:
         tmp_out = out
     bias1 = _normalize_bias_for_kernel(bias1)
+
     # print("Run cktile_moe_stage1: M=%d, N(N*2)=%d, K=%d, topk=%d, expert=%d"%(token_num, w1.shape[1], hidden_states.shape[1], topk, w1.shape[0]))
     aiter.moe_cktile2stages_gemm1(
         hidden_states,

--- a/aiter/ops/shuffle.py
+++ b/aiter/ops/shuffle.py
@@ -78,7 +78,9 @@ def shuffle_weight_a16w4(src: torch.Tensor, NLane: int, gate_up: bool) -> torch.
             src_reshaped.permute(0, 1, 3, 4, 2, 5).contiguous().view(*src.shape)
         )
     # print("interleaved shape:", interleaved.shape)
-    return interleaved.contiguous().view(src_type)
+    result = interleaved.contiguous().view(src_type)
+    result.is_shuffled = True
+    return result
 
 
 def shuffle_scale_a16w4(

--- a/aiter/ops/triton/_triton_kernels/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/_triton_kernels/quant/fused_mxfp4_quant.py
@@ -839,6 +839,7 @@ def _fused_dynamic_mxfp4_quant_moe_sort_kernel(
     stride_o4,  #: tl.constexpr,
     token_num,  #: tl.constexpr,
     N_i,  #: tl.constexpr,
+    N_o,
     MXFP4_QUANT_BLOCK_SIZE: tl.constexpr,
     BLOCK_SIZE_Mx: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
@@ -934,12 +935,13 @@ def _fused_dynamic_mxfp4_quant_moe_sort_kernel(
 
     pid -= num_pid_x
     num_pid_n = tl.cdiv(N_i, BLOCK_SIZE_N * 2)
-    pid_m = pid // num_pid_n  # * 2
-    pid_n = pid % num_pid_n  # * 2
-    # pid_m = tl.program_id(0) * 2
-    # pid_n = tl.program_id(1) * 2
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
     num_valid_ids = tl.load(num_valid_ids_ptr)
     if pid_m * BLOCK_SIZE_M * 2 >= num_valid_ids:
+        return
+    num_valid_n_tiles = tl.cdiv(N_o, BLOCK_SIZE_N * 2)
+    if pid_n >= num_valid_n_tiles:
         return
     stride_o0 = tl.cast(stride_o0, tl.int64)
     stride_o1 = tl.cast(stride_o1, tl.int64)

--- a/aiter/ops/triton/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/quant/fused_mxfp4_quant.py
@@ -610,7 +610,13 @@ def fused_dynamic_mxfp4_quant_moe_sort(
 
     N_i = scaleN
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
+    # Pad N_o to next multiple of BLOCK_SIZE_N so blockscale elements are
+    # evenly divisible when viewed as (-1, N_o_padded).  The extra columns
+    # are stripped before returning.
+    N_o_padded = triton.cdiv(N_o, BLOCK_SIZE_N) * BLOCK_SIZE_N
+    # Note: the (N_i // 2) % 2 == 0 assertion was removed because the kernel
+    # handles non-aligned scaleN (e.g. scaleN=6 at TP=8) through load masking
+    # and output padding/slicing.  Only N % 4 == 0 is required (for fp4 packing).
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(
@@ -649,9 +655,12 @@ def fused_dynamic_mxfp4_quant_moe_sort(
         TOPK=topk,
     )
 
+    scale_out = blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o_padded)
+    if N_o_padded != N_o:
+        scale_out = scale_out[:, :N_o].contiguous()
     return (
         x_fp4.view(dtypes.fp4x2),
-        blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o),
+        scale_out,
     )
 
 

--- a/aiter/ops/triton/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/quant/fused_mxfp4_quant.py
@@ -610,7 +610,6 @@ def fused_dynamic_mxfp4_quant_moe_sort(
 
     N_i = scaleN
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(
@@ -642,6 +641,7 @@ def fused_dynamic_mxfp4_quant_moe_sort(
         *blockscale_e8m0_sorted.stride(),
         token_num=token_num,
         N_i=N_i,
+        N_o=N_o,
         MXFP4_QUANT_BLOCK_SIZE=MXFP4_QUANT_BLOCK_SIZE,
         BLOCK_SIZE_Mx=BLOCK_SIZE_Mx,
         BLOCK_SIZE_M=BLOCK_SIZE_M // 2,
@@ -649,11 +649,6 @@ def fused_dynamic_mxfp4_quant_moe_sort(
         TOPK=topk,
     )
 
-    # The blockscale buffer is allocated with padded N (rounded up to
-    # BLOCK_SIZE_N).  Returning the padded view keeps the layout identical to
-    # ``e8m0_shuffle`` so downstream MoE GEMM kernels can use the same padded
-    # scale stride for any ``inter_dim/32``.  Padded columns are zero, so they
-    # contribute no extra signal.
     padded_N_o = triton.cdiv(N_o, BLOCK_SIZE_N) * BLOCK_SIZE_N
     return (
         x_fp4.view(dtypes.fp4x2),

--- a/aiter/utility/fp4_utils.py
+++ b/aiter/utility/fp4_utils.py
@@ -92,6 +92,30 @@ def e8m0_shuffle(scale):
     return scale
 
 
+def e8m0_unshuffle(scale):
+    """Inverse of the e8m0-shuffled layout written by fused_dynamic_mxfp4_quant_moe_sort_hip.
+    Converts from the C++ kernel's fp4_scale_shuffle_id layout back to linear row-major
+    layout, as expected by CK JIT kernels (DeviceMoeGemmMXBPreShuffle, Scale_Stride_AM).
+
+    The scale buffer has shape [m, K/32] where m is a multiple of 32 (not necessarily 256).
+    No padding is applied — the C++ and Python shuffle are equivalent for any m % 32 == 0.
+    """
+    if scale is None:
+        return scale
+    if scale.dtype == torch.float32:
+        return scale
+    assert scale.ndim == 2, "scale must be a 2D tensor"
+    m, n = scale.shape
+    assert m % 32 == 0 and n % 8 == 0, f"scale {m}×{n} not aligned for unshuffle"
+    # The C++ kernel wrote in [m//32, n//8, 4, 16, 2, 2] permuted order (equivalent to
+    # e8m0_shuffle's .view(m//32, 2, 16, n//8, 2, 4).permute(0,3,5,2,4,1)).
+    # Inverse permutation of (0, 3, 5, 2, 4, 1) is (0, 5, 3, 1, 4, 2).
+    t = scale.view(torch.uint8).view(m // 32, n // 8, 4, 16, 2, 2)
+    t = t.permute(0, 5, 3, 1, 4, 2).contiguous()
+    t = t.view(m, n)
+    return t.view(scale.dtype)
+
+
 def down_size(size):
     assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
     return (*size[:-1], size[-1] // 2)
@@ -648,7 +672,8 @@ def moe_mxfp4_sort(
         blockscale_e8m0 = blockscale_e8m0.view(-1, blockscale_e8m0.shape[-1])
     M_i, N_i = blockscale_e8m0.shape
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
+    # (N_i // 2) % 2 == 0 assertion removed: the kernel handles non-aligned
+    # scaleN (e.g. N_i=6 at TP=8) through load masking and output slicing.
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(
@@ -693,5 +718,11 @@ def moe_mxfp4_sort(
         grid = (triton.cdiv(M_o, BLOCK_SIZE_M), triton.cdiv(N_i, BLOCK_SIZE_N))
         _moe_mxfp4_sort_kernel[grid](*common_args, **common_kwargs)
 
-    # Reshape the output to the final shape
-    return blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o)
+    # The sort kernel stores data in BLOCK_SIZE_N=8-wide blocks.  Reshape via
+    # the block-aligned column count, then slice back to the actual N_o so the
+    # CK tile GEMM kernel sees the correct scale stride (K/32 columns).
+    N_o_aligned = triton.cdiv(N_o, BLOCK_SIZE_N) * BLOCK_SIZE_N
+    scale_out = blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o_aligned)
+    if N_o_aligned != N_o:
+        scale_out = scale_out[:, :N_o].contiguous()
+    return scale_out

--- a/aiter/utility/fp4_utils.py
+++ b/aiter/utility/fp4_utils.py
@@ -227,6 +227,30 @@ def e8m0_shuffle(scale):
     return shuffle_scale(scale)
 
 
+def e8m0_unshuffle(scale):
+    """Inverse of the e8m0-shuffled layout written by fused_dynamic_mxfp4_quant_moe_sort_hip.
+    Converts from the C++ kernel's fp4_scale_shuffle_id layout back to linear row-major
+    layout, as expected by CK JIT kernels (DeviceMoeGemmMXBPreShuffle, Scale_Stride_AM).
+
+    The scale buffer has shape [m, K/32] where m is a multiple of 32 (not necessarily 256).
+    No padding is applied — the C++ and Python shuffle are equivalent for any m % 32 == 0.
+    """
+    if scale is None:
+        return scale
+    if scale.dtype == torch.float32:
+        return scale
+    assert scale.ndim == 2, "scale must be a 2D tensor"
+    m, n = scale.shape
+    assert m % 32 == 0 and n % 8 == 0, f"scale {m}×{n} not aligned for unshuffle"
+    # The C++ kernel wrote in [m//32, n//8, 4, 16, 2, 2] permuted order (equivalent to
+    # e8m0_shuffle's .view(m//32, 2, 16, n//8, 2, 4).permute(0,3,5,2,4,1)).
+    # Inverse permutation of (0, 3, 5, 2, 4, 1) is (0, 5, 3, 1, 4, 2).
+    t = scale.view(torch.uint8).view(m // 32, n // 8, 4, 16, 2, 2)
+    t = t.permute(0, 5, 3, 1, 4, 2).contiguous()
+    t = t.view(m, n)
+    return t.view(scale.dtype)
+
+
 def down_size(size):
     assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
     return (*size[:-1], size[-1] // 2)
@@ -797,7 +821,6 @@ def moe_mxfp4_sort(
         blockscale_e8m0 = padded
     M_i, N_i = blockscale_e8m0.shape
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(
@@ -842,6 +865,4 @@ def moe_mxfp4_sort(
         grid = (triton.cdiv(M_o, BLOCK_SIZE_M), triton.cdiv(N_i, BLOCK_SIZE_N))
         _moe_mxfp4_sort_kernel[grid](*common_args, **common_kwargs)
 
-    # ``N_i`` was padded to a multiple of BLOCK_SIZE_N above, so ``N_o == N_i``
-    # is also a multiple of BLOCK_SIZE_N and the flat view is well-defined.
     return blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o)

--- a/csrc/ck_tile_gemm_moe_2stages/gen_instances.py
+++ b/csrc/ck_tile_gemm_moe_2stages/gen_instances.py
@@ -252,8 +252,8 @@ template torch::Tensor
                 )
             ).write_text(body)
 
-        if (k.QuantType == "1x32") and (a_type in ["bf16", "fp16", "fp8"]):
-            fill_template(k.name, self.a_dtype, "pk_fp4", self.acc_dtype, self.c_dtype)
+        if (k.QuantType == "1x32") and (a_type in ["bf16", "fp16", "fp8", "fp4"]):
+            fill_template(k.name, self.a_dtype, "fp4", self.acc_dtype, self.c_dtype)
         else:
             for CDtype in ["bf16", "fp16"]:
                 for ABDtype in ["fp8"]:  # "bf16", "fp16",
@@ -615,6 +615,7 @@ if __name__ == "__main__":
     a_types = ["bf16"]
     if get_gfx() == "gfx950":
         a_types.append("fp8")
+        a_types.append("fp4")
     b_type = "fp4"
     quant_type = "1x32"
 
@@ -652,8 +653,8 @@ if __name__ == "__main__":
     ):
         has_bias = True if act_type == "swiglu" else False
 
-        # a8w8 do not support
-        if a_type in ["fp8", "bf8"] and is_split_k:
+        # a8w8/a4w4 do not support split_k
+        if a_type in ["fp8", "bf8", "fp4"] and is_split_k:
             continue
         codegen = cktile_moe_2stage_gemm_codegen(
             args.working_path,
@@ -697,7 +698,7 @@ if __name__ == "__main__":
         # Collect kernel names with their C++ type arguments for name dispatch
         for mnk, k in kernel_dict_merge.items():
             name_lookup_entries.append(
-                (k.name, codegen.a_dtype, "pk_fp4", codegen.acc_dtype, codegen.c_dtype)
+                (k.name, codegen.a_dtype, "fp4", codegen.acc_dtype, codegen.c_dtype)
             )
 
     generate_common_header(args.working_path, gen_dispatch_files, gen_manifest_files)

--- a/csrc/ck_tile_gemm_moe_2stages/include/moe_cktile2stages.h
+++ b/csrc/ck_tile_gemm_moe_2stages/include/moe_cktile2stages.h
@@ -42,7 +42,7 @@ using col_major        = ck_tile::tensor_layout::gemm::ColumnMajor;
 using bf16             = ck_tile::bf16_t;
 using fp16             = ck_tile::half_t;
 using fp8              = ck_tile::fp8_t;
-using pk_fp4           = ck_tile::pk_fp4_t;
+using fp4              = ck_tile::pk_fp4_t;
 
 template <typename ADataType,
           typename BDataType,

--- a/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
+++ b/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
@@ -327,7 +327,7 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
         // }
         if(WQ.dtype() == torch_fp4x2 && Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<fp8, pk_fp4, float, bf16, 1>(
+            moe_dispatch<fp8, fp4, float, bf16, 1>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -350,12 +350,12 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
     {
         // if (Y.dtype() == at::ScalarType::Half)
         // {
-        //    moe_dispatch<fp16, pk_fp4, float, fp16, 1>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
+        //    moe_dispatch<fp16, fp4, float, fp16, 1>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
         //    sorted_expert_ids, max_token_ids, topk, topk_weight, x_scale, w_scale, exp_bias);
         // }
         if(Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<bf16, pk_fp4, float, bf16, 1>(
+            moe_dispatch<bf16, fp4, float, bf16, 1>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -371,6 +371,32 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
                                                                exp_bias,
                                                                act_op,
                                                                k_batch);
+        }
+    }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<fp4, fp4, float, bf16, 1>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm1!");
         }
     }
     else
@@ -455,7 +481,7 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
         // }
         if(WQ.dtype() == torch_fp4x2 && Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<fp8, pk_fp4, float, bf16, 2>(
+            moe_dispatch<fp8, fp4, float, bf16, 2>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -478,12 +504,12 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
     {
         // if (Y.dtype() == at::ScalarType::Half)
         // {
-        //    moe_dispatch<fp16, pk_fp4, float, fp16, 2>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
+        //    moe_dispatch<fp16, fp4, float, fp16, 2>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
         //    sorted_expert_ids, max_token_ids, topk, topk_weight, x_scale, w_scale, exp_bias);
         // }
         if(Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<bf16, pk_fp4, float, bf16, 2>(
+            moe_dispatch<bf16, fp4, float, bf16, 2>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -499,6 +525,32 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
                                                                exp_bias,
                                                                act_op,
                                                                k_batch);
+        }
+    }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<fp4, fp4, float, bf16, 2>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm2!");
         }
     }
     else

--- a/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
+++ b/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
@@ -332,7 +332,7 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
         // }
         if(WQ.dtype() == torch_fp4x2 && Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<fp8, pk_fp4, float, bf16, 1>(
+            moe_dispatch<fp8, fp4, float, bf16, 1>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -355,12 +355,12 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
     {
         // if (Y.dtype() == at::ScalarType::Half)
         // {
-        //    moe_dispatch<fp16, pk_fp4, float, fp16, 1>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
+        //    moe_dispatch<fp16, fp4, float, fp16, 1>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
         //    sorted_expert_ids, max_token_ids, topk, topk_weight, x_scale, w_scale, exp_bias);
         // }
         if(Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<bf16, pk_fp4, float, bf16, 1>(
+            moe_dispatch<bf16, fp4, float, bf16, 1>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -376,6 +376,32 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
                                                                exp_bias,
                                                                act_op,
                                                                k_batch);
+        }
+    }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<fp4, fp4, float, bf16, 1>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm1!");
         }
     }
     else
@@ -467,7 +493,7 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
         // }
         if(WQ.dtype() == torch_fp4x2 && Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<fp8, pk_fp4, float, bf16, 2>(
+            moe_dispatch<fp8, fp4, float, bf16, 2>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -490,12 +516,12 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
     {
         // if (Y.dtype() == at::ScalarType::Half)
         // {
-        //    moe_dispatch<fp16, pk_fp4, float, fp16, 2>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
+        //    moe_dispatch<fp16, fp4, float, fp16, 2>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
         //    sorted_expert_ids, max_token_ids, topk, topk_weight, x_scale, w_scale, exp_bias);
         // }
         if(Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<bf16, pk_fp4, float, bf16, 2>(
+            moe_dispatch<bf16, fp4, float, bf16, 2>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -511,6 +537,32 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
                                                                exp_bias,
                                                                act_op,
                                                                k_batch);
+        }
+    }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<fp4, fp4, float, bf16, 2>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm2!");
         }
     }
     else

--- a/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages_common.py
+++ b/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages_common.py
@@ -243,6 +243,23 @@ a8w4_gemm2_kernels_list_gfx950= {
     # 4: kernelInstance(       2,        256,      256,        128,       128,           16,         16,          32,          1,        4,),
 }
 
+
+# gemm1 out:bf16 AB:fp4/fp4 (MXFP4 quantized activations x MXFP4 weights)
+a4w4_gemm1_kernels_list_gfx950= {
+    #  kernel:           stage| BLOCK_SIZE|MPerBLOCK|  NPerBLOCK| KPerBLOCK| WAVE_TILE_M| WAVE_TILE_N| WAVE_TILE_K| WAVE_MAP_M| WAVE_MAP_N| BlockPerCU|
+    0: kernelInstance(       1,        256,       16,        128,       256,          16,         16,         128,          1,           4,          2,),
+    1: kernelInstance(       1,        256,       32,        256,       256,          16,         16,         128,          1,           4,          2,),
+    3: kernelInstance(       1,        256,       64,        256,       256,          16,         16,         128,          1,           4,          1,),
+}
+# gemm2 out:bf16 AB:fp4/fp4 (MXFP4 quantized activations x MXFP4 weights)
+a4w4_gemm2_kernels_list_gfx950= {
+    #  kernel:           stage| BLOCK_SIZE|MPerBLOCK|  NPerBLOCK| KPerBLOCK| WAVE_TILE_M| WAVE_TILE_N| WAVE_TILE_K| WAVE_MAP_M| WAVE_MAP_N| BlockPerCU|
+    # KPerBlock min=256 for fp4 (CK tile mixed_prec pipeline requires K1*K2=256)
+    0: kernelInstance(       2,        256,       16,        128,       256,          16,         16,         128,          1,        4,            2,),
+    1: kernelInstance(       2,        256,       32,        256,       256,          16,         16,         128,          1,        4,            2,),
+    3: kernelInstance(       2,        256,       64,        256,       256,          16,         16,         128,          1,        4,            1,),
+}
+
 # fmt: on
 gemm1_kernels_dict = {
     tag: expand_blockpercu(kdict)
@@ -252,6 +269,7 @@ gemm1_kernels_dict = {
         "a16w4_gfx950": a16w4_gemm1_kernels_list_gfx950,
         "a16w4": a16w4_gemm1_kernels_list,
         "a8w4_gfx950": a8w4_gemm1_kernels_list_gfx950,
+        "a4w4_gfx950": a4w4_gemm1_kernels_list_gfx950,
     }.items()
 }
 
@@ -263,6 +281,7 @@ gemm2_kernels_dict = {
         "a16w4_gfx950": a16w4_gemm2_kernels_list_gfx950,
         "a16w4": a16w4_gemm2_kernels_list,
         "a8w4_gfx950": a8w4_gemm2_kernels_list_gfx950,
+        "a4w4_gfx950": a4w4_gemm2_kernels_list_gfx950,
     }.items()
 }
 
@@ -519,12 +538,77 @@ struct moe_gemm2_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_da
 }};
 """
 
+
+a4w4_gfx950_heuristic_dispatch = """#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "moe_cktile2stages.h"
+#include "moe_cktile2stages_heuristic_dispatch_common.h"
+
+template <>
+struct moe_gemm1_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}, {(activation)}, {(has_bias)}, {(split_k)}>
+{{
+    static MoeKernel dispatch(int M, int N, int K, int block_m)
+    {{
+        // Apply shape heuristics to find a suitable kernel implementation.
+        if (block_m == 16)
+        {{
+            return {(1, 0)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 32)
+        {{
+            return {(1, 1)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 64)
+        {{
+            return {(1, 3)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else
+        {{
+            TORCH_CHECK(
+                false,
+                "Unsupported block_m value for moe_gemm1 a4w4 heuristic dispatch: ",
+                block_m);
+        }}
+    }}
+}};
+
+template <>
+struct moe_gemm2_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}, {(activation)}, {(has_bias)}, {(split_k)}>
+{{
+    static MoeKernel dispatch(int M, int N, int K, int block_m)
+    {{
+        // KPerBlock=256 is the minimum for fp4 (CK tile mixed_prec pipeline
+        // requires K1*K2=256). The kernel handles K < KPerBlock via masking.
+        if (block_m == 16)
+        {{
+            return {(2, 0)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 32)
+        {{
+            return {(2, 1)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 64)
+        {{
+            return {(2, 3)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else
+        {{
+            TORCH_CHECK(
+                false,
+                "Unsupported block_m value for moe_gemm2 a4w4 heuristic dispatch: ",
+                block_m);
+        }}
+    }}
+}};
+"""
 heuristic_dispatch_dict = {
     "a8w8_gfx950": a8w8_gfx950_heuristic_dispatch,
     # "a8w8": a8w8_gemm2_kernels_list,
     "a16w4_gfx950": a16w4_gfx950_heuristic_dispatch,
     "a16w4": a16w4_heuristic_dispatch,
     "a8w4_gfx950": a8w4_gfx950_heuristic_dispatch,
+    "a4w4_gfx950": a4w4_gfx950_heuristic_dispatch,
 }
 
 
@@ -557,6 +641,13 @@ def get_gemm1_kernels_list(
     elif Adtype.lower() in bit8_list and Bdtype in bit4_list:
         if arch == "gfx950":
             tag = "a8w4_gfx950"
+        else:
+            raise ValueError(
+                f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
+            )
+    elif Adtype in bit4_list and Bdtype in bit4_list:
+        if arch == "gfx950":
+            tag = "a4w4_gfx950"
         else:
             raise ValueError(
                 f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
@@ -606,6 +697,13 @@ def get_gemm2_kernels_list(
     elif Adtype.lower() in bit8_list and Bdtype in bit4_list:
         if arch == "gfx950":
             tag = "a8w4_gfx950"
+        else:
+            raise ValueError(
+                f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
+            )
+    elif Adtype in bit4_list and Bdtype in bit4_list:
+        if arch == "gfx950":
+            tag = "a4w4_gfx950"
         else:
             raise ValueError(
                 f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -188,6 +188,18 @@ def test_fmoe(
         w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, True)
         w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
         w2_scale_aiter = shuffle_scale_a16w4(w2_scale, E, False)
+    elif (
+        qType == aiter.QuantType.per_1x32
+        and AQDType == dtypes.fp4x2
+        and WQDType == dtypes.fp4x2
+    ):  # a4w4: both stage1 and stage2 use JIT CK (DeviceMoeGemmMXBPreShuffle)
+        # Both use preShuffleBuffer format = shuffle_weight_a16w4(gate_up=False)
+        # / shuffle_scale_a16w4(gate_up=False). Unlike a16w4, the a4w4 kernel
+        # uses gate_up=False for stage1 even though w1 has 2*N rows.
+        w1_qt_aiter = shuffle_weight_a16w4(w1_qt_aiter, 16, False)
+        w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, False)
+        w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
+        w2_scale_aiter = shuffle_scale_a16w4(w2_scale, E, False)
     elif WQDType != dtypes.fp4x2 or preshuffle:
         w1_qt_aiter = shuffle_weight(w1_qt_aiter, layout=(16, 16))
         w2_qt_aiter = shuffle_weight(w2_qt_aiter, layout=(16, 16))

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -271,6 +271,18 @@ def test_fmoe(
         w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, True)
         w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
         w2_scale_aiter = fp4_utils.e8m0_shuffle(w2_scale)
+    elif (
+        qType == aiter.QuantType.per_1x32
+        and AQDType == dtypes.fp4x2
+        and WQDType == dtypes.fp4x2
+    ):  # a4w4: both stage1 and stage2 use JIT CK (DeviceMoeGemmMXBPreShuffle)
+        # Both use preShuffleBuffer format = shuffle_weight_a16w4(gate_up=False)
+        # / shuffle_scale_a16w4(gate_up=False). Unlike a16w4, the a4w4 kernel
+        # uses gate_up=False for stage1 even though w1 has 2*N rows.
+        w1_qt_aiter = shuffle_weight_a16w4(w1_qt_aiter, 16, False)
+        w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, False)
+        w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
+        w2_scale_aiter = shuffle_scale_a16w4(w2_scale, E, False)
     elif WQDType != dtypes.fp4x2 or preshuffle:
         w1_qt_aiter = shuffle_weight(w1_qt_aiter, layout=(16, 16))
         w2_qt_aiter = shuffle_weight(w2_qt_aiter, layout=(16, 16))


### PR DESCRIPTION
Enable tensor-parallel MXFP4 MoE for non-power-of-2 scale dimensions (TP=4: scaleN=12, TP=8: scaleN=6) by fixing quant padding, sort kernel reshaping, and adding CKTile a4w4 kernel dispatch.

Fix bugs and add two performance optimizations to the MXFP4 a4w4 (fp4x2 activations + fp4x2 weights) two-stage MoE path, validated on MiniMax-M2.1-MXFP4 at TP=8 on gfx950.

Fixes:

1. Wrong stage1 kernel for a4w4:
   cktile_moe_stage1 routes fp4x2 activations through the fp8 pipeline
   (AQUANT_Pipeline), which misinterprets packed fp4 as fp8 -> garbage.
   Switch stage1 to ck_moe_stage1 (JIT CK DeviceMoeGemmMXBPreShuffle).

2. ksplit>1 steals a4w4 cases for shared experts:
   MiniMax shared experts have inter_dim=256 (per TP=8 rank).
   get_ksplit() returns 2, and the "ksplit>1 and is_shuffled" elif
   fires before the a4w4 branch because it only checks q_dtype_w.
   Fix: add "q_dtype_a not in [dtypes.fp4x2]" guard.

3. ksplit must be 0 for a4w4 in fused_moe_2stages:
   When metadata.ksplit>1, fused_moe_2stages skips fp4x2 activation
   quantization. Force ksplit=0 in the a4w4 MOEMetadata.

Performance optimizations:

4. Skip intermediate bf16->fp4x2 quantization between stages:
   Stage2 now uses CKTile AOT with bf16 activations (a16w4 path)
   instead of JIT CK with fp4x2 activations, eliminating a full
   quantization kernel launch + memory round-trip between stages.
   New skip_inter_quant flag on MOEMetadata controls this.

5. block_m 32->64 for fp4x2:
   Sweep across all MiniMax batch sizes shows block_m=64 is
   consistently faster than 32 on gfx950 (up to 1.54x for prefill).
   128 is not supported by current CKTile stage2 instances.

Additional changes:
- CKTile AOT: add pk_fp4 x pk_fp4 codegen for both gemm1 and gemm2,
  generate stage1+stage2 instances for a4w4, skip split_k for pk_fp4.
- cktile_moe_stage1 split_k>1: fix tmp_out buffer size (use sorted_size
  not token_num*topk), use ck_moe_stage2_fwd for correct dispatch.
- Torch fallback: catch RuntimeError/AssertionError in fused_moe_ and
  fall back to torch_moe_stage1/stage2 for unsupported configurations.
- shuffle_weight_a16w4: set is_shuffled=True on returned tensor.
- Add e8m0_unshuffle utility (inverse of e8m0_shuffle).
- test_moe_2stage: add a4w4 test branch.

Benchmark (gfx950, 256 CUs, MiniMax-M2.1-MXFP4 TP=8 dims):

  Tokens  OLD(bm32+quant+CK)  NEW(bm64+skip+CKTile)  Speedup
       1           45.3 us             40.1 us          1.13x
       4           53.5 us             45.4 us          1.18x
       8          100.0 us             72.2 us          1.38x
      16          157.5 us            108.8 us          1.45x
      32          233.5 us            160.2 us          1.46x
      64          309.1 us            216.6 us          1.43x
     128          GPU fault           233.1 us          NEW only
     512          GPU fault           265.4 us          NEW only

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
One of the models requiring this fix is [AMD MiniMax2.1-MXFP4](https://huggingface.co/amd/MiniMax-M2.1-MXFP4) when used with TP=4 or TP=8. Both ATOM and VLLM need these changes to be able to run above MiniMax model with TP 4/8.

## Test Result

<!-- Briefly summarize test outcomes. -->
Serving with ATOM:
```
python -m atom.entrypoints.openai_server \
  --model amd/MiniMax-M2.1-MXFP4 \
  --trust-remote-code \
  -tp 8
```

```
lm_eval \
  --model local-completions \
  --model_args model=amd/MiniMax-M2.1-MXFP4,base_url=http://localhost:8000/v1/completions,num_concurrent=32,max_retries=3,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size 1
```

lm-eval before changes:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0|±  |0|
|     |       |strict-match    |     5|exact_match|↑  |0|±  |0|

lm-eval after changes:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9371|±  |0.0067|
|     |       |strict-match    |     5|exact_match|↑  |0.9348|±  |0.0068|

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
