### PR TITLE
CI: extend clang toolchain timeout in aiter tests

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 MULTIGPU=${MULTIGPU:-FALSE}
 SHARD_TOTAL=${SHARD_TOTAL:-5}
 SHARD_IDX=${SHARD_IDX:-0}
+export CLANG_TOOLCHAIN_PROGRAM_TIMEOUT="${CLANG_TOOLCHAIN_PROGRAM_TIMEOUT:-300}"
 
 files=()
 failedFiles=()
@@ -48,6 +49,7 @@ else
 fi
 
 echo "Running ${sharded_files[@]} in shard $SHARD_IDX of $SHARD_TOTAL."
+echo "Using CLANG_TOOLCHAIN_PROGRAM_TIMEOUT=${CLANG_TOOLCHAIN_PROGRAM_TIMEOUT}" | tee -a latest_test.log
 
 for file in "${sharded_files[@]}"; do
     # Print a clear separator and test file name for readability


### PR DESCRIPTION
## Summary
- increase the default `CLANG_TOOLCHAIN_PROGRAM_TIMEOUT` to 300 in `./.github/scripts/aiter_test.sh`
- log the effective timeout in `latest_test.log` so CI runs show which value was used
- keep the workaround scoped to the test script instead of changing workflow routing or test selection

## Test plan
- [x] `bash -n .github/scripts/aiter_test.sh`
- [ ] Run the `Aiter Test` workflow in GitHub Actions