### PR TITLE
fix(setup.py): accept FlyDSL dev/rc builds when version matches pinned release

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -14,6 +14,16 @@ from .utils import is_flydsl_available
 
 _REQUIRED_FLYDSL_VERSION = "0.1.2"
 
+
+def _flydsl_matches_pinned(installed_ver: str, pinned_ver: str) -> bool:
+    """Same X.Y.Z as pin, allowing dev/rc/post/local segments (e.g. 0.1.2.dev462 == 0.1.2)."""
+    try:
+        from packaging.version import Version
+    except ImportError:
+        return installed_ver == pinned_ver
+    return Version(installed_ver).release == Version(pinned_ver).release
+
+
 __all__ = [
     "is_flydsl_available",
 ]
@@ -27,10 +37,10 @@ if is_flydsl_available():
             "so its version cannot be validated."
         ) from exc
 
-    if installed_flydsl_version != _REQUIRED_FLYDSL_VERSION:
+    if not _flydsl_matches_pinned(installed_flydsl_version, _REQUIRED_FLYDSL_VERSION):
         raise ImportError(
             "Unsupported `flydsl` version: "
-            f"expected `{_REQUIRED_FLYDSL_VERSION}`, "
+            f"expected `{_REQUIRED_FLYDSL_VERSION}` (same release, dev/rc/post allowed), "
             f"got `{installed_flydsl_version}`."
         )
 

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,21 @@ def is_develop_mode():
     return False
 
 
+def _flydsl_matches_pinned(installed_ver: str, pinned_ver: str) -> bool:
+    """Same X.Y.Z as pin, allowing dev/rc/post/local segments (e.g. 0.1.2.dev462 == 0.1.2)."""
+    try:
+        from packaging.version import Version
+    except ImportError:
+        return installed_ver == pinned_ver
+    return Version(installed_ver).release == Version(pinned_ver).release
+
+
 if not IS_WINDOWS and is_develop_mode():
+    _flydsl_pin = FLYDSL_VERSION.split("==")[1]
     try:
         from importlib.metadata import version as pkg_version
 
-        if pkg_version("flydsl") != FLYDSL_VERSION.split("==")[1]:
+        if not _flydsl_matches_pinned(pkg_version("flydsl"), _flydsl_pin):
             raise ImportError("version mismatch")
     except Exception:
         subprocess.check_call(


### PR DESCRIPTION
**Problem**
In develop mode, setup.py ensures FlyDSL matches the pinned version by:

Reading the installed version with importlib.metadata.version("flydsl").
Comparing it to the pinned string (0.1.2).
On any mismatch or import error, running pip install flydsl==0.1.2.
For an editable/local FlyDSL install, the reported version is often 0.1.2.dev462 (or similar), which is not equal to the string "0.1.2", so the script always took the “mismatch” path and invoked pip install. That is unnecessary and can break workflows where:

- FlyDSL is installed from a git checkout (dev/local version), or
- PyPI has no wheel for the current Python ABI (e.g. cp313 while wheels exist only for cp310/cp312).

**Solution**
Add _flydsl_matches_pinned(installed_ver, pinned_ver) that uses packaging.version.Version and compares the .release tuples (e.g. (0, 1, 2)), so 0.1.2, 0.1.2.dev462, and other suffixes on the same X.Y.Z are treated as matching the pin.
If packaging is not importable, fall back to the previous strict string comparison for safety.
