### PR TITLE
[TRITON] Reduce GMM tests

### DIFF
--- a/aiter/ops/triton/utils/gmm_common.py
+++ b/aiter/ops/triton/utils/gmm_common.py
@@ -343,7 +343,7 @@ def gen_gmm_tensors(
     rng_seed: int | None = RNG_SEED,
     unif_group_sizes: bool = False,
     use_bias: bool = False,
-) -> tuple[Tensor, Tensor, list[Tensor], Tensor]:
+) -> tuple[Tensor, Tensor, list[Tensor], Tensor, Tensor | None]:
     lhs, rhs, group_sizes_0 = gen_gmm_input(
         M,
         K,
@@ -563,7 +563,7 @@ def gen_tgmm_tensors(
     rng_seed: int | None = RNG_SEED,
     unif_group_sizes: bool = False,
     use_bias: bool = False,
-) -> tuple[Tensor, Tensor, list[Tensor], Tensor]:
+) -> tuple[Tensor, Tensor, list[Tensor], Tensor, Tensor | None]:
     lhs, rhs, group_sizes_0 = gen_tgmm_input(
         M,
         K,

--- a/op_tests/triton_tests/test_gmm.py
+++ b/op_tests/triton_tests/test_gmm.py
@@ -17,9 +17,7 @@ import pytest
 
 # AITER: GMM defaults and utility functions
 from aiter.ops.triton.utils.gmm_common import (
-    SUPPORTED_DTYPES_STR,
     DTYPE,
-    dtype_from_str,
     check_input_device_dtype,
     gen_gmm_tensors,
     get_gmm_shape,
@@ -49,7 +47,6 @@ TEST_ONLY_SHAPES: list[tuple[int, int, int, int]] = [
     #  M,    K,    N,   G
     ( 10,    2,    3,   4),
     ( 32,   16,    8,   4),
-    (512, 4096, 2048, 160),
 ]
 # fmt: on
 
@@ -59,7 +56,6 @@ REAL_SHAPES: list[tuple[int, int, int, int]] = [
     #      M,     K,     N,   G
     (  49152,  1408,  2048,  64),  # deepseekv2-16B
     (3145728,  2048,  1408,   8),  # deepseekv2-16B
-    ( 393216,  2048,  1408,  64),  # deepseekv2-16B
     (  32768,  6144, 16384,   8),  # Mixtral 8x22B
     (  32768, 16384,  6144,   8),  # Mixtral 8x22B
 ]
@@ -67,12 +63,6 @@ REAL_SHAPES: list[tuple[int, int, int, int]] = [
 
 # Test shapes are test only + real ones.
 TEST_SHAPES: list[tuple[int, int, int, int]] = TEST_ONLY_SHAPES + REAL_SHAPES
-
-
-# Input and output types.
-
-INPUT_DTYPES_STR: set[str] = {"i" + dtype_str for dtype_str in SUPPORTED_DTYPES_STR}
-OUTPUT_DTYPES_STR: set[str] = {"o" + dtype_str for dtype_str in SUPPORTED_DTYPES_STR}
 
 
 # Transpositions.
@@ -91,18 +81,10 @@ trans_rhs_from_str = partial(trans_from_str, tensor_str="rhs")
 
 
 # RNG seed.
-
-RNG_SEED_STR: set[str] = {f"rng{rng_seed}" for rng_seed in {77, 121}}
-
-
-def rng_seed_from_str(rng_seed_str: str) -> int:
-    rng_seed_int = int(rng_seed_str.replace("rng", ""))
-    assert rng_seed_int >= 0, f"RNG seed must be non-negative (it's {rng_seed_int})."
-    return rng_seed_int
-
+RNG_SEED: int = 77
 
 # Number of distinct group sizes for each test shape.
-NUM_GROUP_SIZES: int = 5
+NUM_GROUP_SIZES: int = 3
 
 
 # Tensor comparison.
@@ -177,26 +159,18 @@ def torch_gmm(
 
 
 @pytest.mark.parametrize("M, K, N, G", TEST_SHAPES)
-@pytest.mark.parametrize("in_dtype_str", INPUT_DTYPES_STR)
-@pytest.mark.parametrize("out_dtype_str", OUTPUT_DTYPES_STR)
 @pytest.mark.parametrize("trans_rhs_str", TRANS_RHS_STR)
-@pytest.mark.parametrize("rng_seed_str", RNG_SEED_STR)
 @pytest.mark.parametrize("use_bias", [False, True])
 def test_gmm(
     M: int,
     K: int,
     N: int,
     G: int,
-    in_dtype_str: str,
-    out_dtype_str: str,
     trans_rhs_str: str,
-    rng_seed_str: str,
     use_bias: bool,
 ):
-    in_dtype = dtype_from_str(in_dtype_str)
-    out_dtype = dtype_from_str(out_dtype_str)
+    in_dtype = out_dtype = DTYPE
     trans_rhs = trans_rhs_from_str(trans_rhs_str)
-    rng_seed = rng_seed_from_str(rng_seed_str)
 
     lhs, rhs, multiple_group_sizes, out_torch, bias = gen_gmm_tensors(
         M,
@@ -207,7 +181,7 @@ def test_gmm(
         input_type=in_dtype,
         output_type=out_dtype,
         trans_rhs=trans_rhs,
-        rng_seed=rng_seed,
+        rng_seed=RNG_SEED,
         unif_group_sizes=True,  # 1st group_sizes in test is evenly distributed
         use_bias=use_bias,
     )
@@ -320,10 +294,7 @@ def torch_tgmm(
 @pytest.mark.parametrize("persistent_str", {"p", "np"})
 @pytest.mark.parametrize("with_bias_grad", [False, True])
 @pytest.mark.parametrize("M, K, N, G", TEST_SHAPES)
-@pytest.mark.parametrize("in_dtype_str", INPUT_DTYPES_STR)
-@pytest.mark.parametrize("out_dtype_str", OUTPUT_DTYPES_STR)
 @pytest.mark.parametrize("trans_lhs_str", TRANS_LSH_STR)
-@pytest.mark.parametrize("rng_seed_str", RNG_SEED_STR)
 def test_tgmm(
     persistent_str: str,
     with_bias_grad: bool,
@@ -331,18 +302,13 @@ def test_tgmm(
     K: int,
     N: int,
     G: int,
-    in_dtype_str: str,
-    out_dtype_str: str,
     trans_lhs_str: str,
-    rng_seed_str: str,
 ):
     assert persistent_str in {"p", "np"}
     persistent: bool = persistent_str == "p"
 
-    in_dtype = dtype_from_str(in_dtype_str)
-    out_dtype = dtype_from_str(out_dtype_str)
+    in_dtype = out_dtype = DTYPE
     trans_lhs = trans_lhs_from_str(trans_lhs_str)
-    rng_seed = rng_seed_from_str(rng_seed_str)
 
     lhs, rhs, multiple_group_sizes, out_torch, bias_grad_torch = gen_tgmm_tensors(
         M,
@@ -353,7 +319,7 @@ def test_tgmm(
         input_type=in_dtype,
         output_type=out_dtype,
         trans_lhs=trans_lhs,
-        rng_seed=rng_seed,
+        rng_seed=RNG_SEED,
         unif_group_sizes=True,  # 1st group_sizes in test is evenly distributed
         use_bias=with_bias_grad,
     )
@@ -431,10 +397,7 @@ def test_tgmm_accumulate(persistent_str: str, with_bias_grad: bool):
     # Use the smallest TEST_ONLY_SHAPES entry to keep runtime low.
     M, K, N, G = TEST_ONLY_SHAPES[0]
 
-    in_dtype = DTYPE
-    out_dtype = DTYPE
-    trans_lhs = False
-    rng_seed = 77
+    in_dtype = out_dtype = DTYPE
 
     lhs, rhs, multiple_group_sizes, out_torch, bias_grad_torch = gen_tgmm_tensors(
         M,
@@ -444,8 +407,8 @@ def test_tgmm_accumulate(persistent_str: str, with_bias_grad: bool):
         NUM_GROUP_SIZES,
         input_type=in_dtype,
         output_type=out_dtype,
-        trans_lhs=trans_lhs,
-        rng_seed=rng_seed,
+        trans_lhs=False,
+        rng_seed=RNG_SEED,
         unif_group_sizes=True,
         use_bias=with_bias_grad,
     )


### PR DESCRIPTION
## Motivation

Speedup Triton tests in AITER CI by reducing the number of test cases. This PR proposes test case reduction for GMM (Group Matrix Multiplication) Triton kernels.

## Technical Details

Test case reduction was achieved by simplifying test parameter space:

| Test Parameter                 | Current | Proposed |
|--------------------------------|---------|----------|
| Number of toy shapes           |       3 |        2 |
| Number of real model shapes    |       4 |        3 |
| (Input, Output) data types     | (`bf16`, `bf16`), (`bf16`, `fp16`), (`fp16`, `bf16`), (`fp16`, `fp16`) | (`bf16`, `bf16`) - it's the only production case so far |
| Number of RNG seeds            |       2 |        1 |
| Number of distinct group sizes |       5 |        3 |

## Test Plan

Run GMM tests:

```bash
pytest --quiet op_tests/triton_tests/test_gmm.py
```

Expected result: all tests should pass and total execution time should decrease.

## Test Result

- `main` branch: 772 passed in 267.03s (0:04:27)
- Feature branch of this PR: 76 passed in 52.79s
- 80% reduction in test time

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.