### PR TITLE
[TRITON] Adapt Model Benchmarking Scripts to the New `bench_mha.py` CLI

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_mha.py
+++ b/op_tests/op_benchmarks/triton/bench_mha.py
@@ -598,7 +598,9 @@ def run_benchmark(run: BenchRun):
             requires_grad=requires_grad,
         )
         sink = (
-            torch.randn((HQ,), device=device, dtype=dtype, requires_grad=requires_grad)
+            torch.randn(
+                (HQ,), device=device, dtype=torch_dtype, requires_grad=requires_grad
+            )
             if run.sink
             else None
         )

--- a/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_attn_models.py
+++ b/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_attn_models.py
@@ -350,10 +350,23 @@ class BenchArgs:
         effective_dv: int
         effective_dqk, effective_dv = m.effective_d_qk_v(self.kernel)
 
+        # Map (kernel, layout) to bench_mha.py's -fn argument:
+        # bshd (batch-seq-head-dim): non-varlen functions
+        # thd  (token-head-dim): varlen functions with equal sequence lengths
+        is_varlen: bool = self.layout == "thd"
+        fn_map: dict[tuple[str, bool], str] = {
+            ("fwd", False): "fwd",
+            ("fwd", True): "fwd_varlen",
+            ("bwdo", False): "bwd",
+            ("bwdo", True): "bwd_varlen",
+            ("bwdf", False): "bwd",
+            ("bwdf", True): "bwd_varlen",
+        }
+        fn: str = fn_map[(self.kernel, is_varlen)]
+
         args_dict: dict[str, str] = {
-            "-mode": self.kernel[:3],
+            "-fn": fn,
             "-causal": "true",
-            "--layout": self.layout,
             "--dtype": "bf16",
             "-b": str(self.b),
             "-hq": str(m.hq),
@@ -366,6 +379,8 @@ class BenchArgs:
         }
 
         args_list: list[str] = [kv for k, v in args_dict.items() for kv in (k, v)]
+        if is_varlen:
+            args_list.append("-equal_seqlens")
         if m.use_sink:
             args_list.append("-sink")
         if m.sliding_window_left > 0:
@@ -478,49 +493,61 @@ def get_stdout(out: str, err: str, num_out_lines: int) -> Optional[list[list[str
 def get_mha_bench_result(
     args: BenchArgs, metric: Metric, out: str, err: str
 ) -> Optional[float]:
-    """Get result from `bench_mha.py`."""
-    # Get preprocessed stdout:
-    out_lines: Optional[list[list[str]]] = get_stdout(out, err, num_out_lines=3)
+    """Get result from `bench_mha.py`.
+
+    Expected stdout (4 lines):
+    Line 1 - progress: "[1/1] <model> B=... HQ=... ..."
+    Line 2 - plot name: "bench_mha:"
+    Line 3 - header: "model  BATCH  HQ  HK  N_CTX_Q  N_CTX_K  D_HEAD  D_HEAD_V  causal  function  dtype  impl  fused  <unit>"
+    Line 4 - data: "0  <model>  <b>  <hq>  <hk>  <sq>  <sk>  <d>  <dv>  <causal>  <fn>  <dtype>  <impl>  <fused>  <value>"
+    """
+    # Get preprocessed stdout (4 lines: progress + plot name + header + data):
+    out_lines: Optional[list[list[str]]] = get_stdout(out, err, num_out_lines=4)
     if out_lines is None:
         return None
     l0: list[str]
     l1: list[str]
     l2: list[str]
-    l0, l1, l2 = out_lines
-    # Check stdout line #1 (benchmark name):
-    if not (len(l0) == 1 and l0[0].startswith("bench_mha") and l0[0].endswith(":")):
-        logging.error("Benchmark name doesn't match: %s", l0)
+    l3: list[str]
+    l0, l1, l2, l3 = out_lines
+    # Check stdout line #1 (progress line "[counter/total] <model> B=... ..."):
+    if not (len(l0) >= 2 and l0[0].startswith("[") and l0[0].endswith("]")):
+        logging.error("Progress line doesn't match: %s", l0)
         return None
-    # Check stdout line #2 (table header):
-    kernel_header: str = {"fwd": "fwd", "bwdo": "bwd", "bwdf": "fused-bwd"}[args.kernel]
-    expected_metric_header = f"BF16-{kernel_header}({metric.user_unit})"
+    # Check stdout line #2 (benchmark name):
+    if not (len(l1) == 1 and l1[0].startswith("bench_mha") and l1[0].endswith(":")):
+        logging.error("Benchmark name doesn't match: %s", l1)
+        return None
+    # Check stdout line #3 (table header):
+    # x_names: model, BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, D_HEAD_V, causal, function, dtype, impl, fused
+    # Metric column is at index 13; triton sometimes appends an extra "(unit)" annotation at index 14.
     if not (
-        l1[:5] == ["BATCH", "HQ", "HK", "N_CTX_Q", "N_CTX_K"]
-        and l1[5:]
-        in (
-            [expected_metric_header],
-            [expected_metric_header, f"({metric.user_unit})"],
-        )
+        l2[:6] == ["model", "BATCH", "HQ", "HK", "N_CTX_Q", "N_CTX_K"]
+        and len(l2) in (14, 15)
+        and l2[13] == metric.user_unit
+        and (len(l2) == 14 or l2[14] == f"({metric.user_unit})")
     ):
-        logging.error("Table header doesn't match: %s", l1)
+        logging.error("Table header doesn't match: %s", l2)
         return None
-    # Check stdout line #3 (table data):
+    # Check stdout line #4 (table data):
+    # Columns: row_idx, model, BATCH, HQ, HK, N_CTX_Q, N_CTX_K, D_HEAD, D_HEAD_V,
+    #          causal, function, dtype, impl, fused, <metric> (15 tokens total).
     m: Model = args.tp_model.model
     try:
         if not all(
             [
-                len(l2) == 7,
-                l2[0] == "0",
-                int(float(l2[1])) == args.b,
-                int(float(l2[2])) == m.hq,
-                int(float(l2[3])) == m.hkv,
-                int(float(l2[4])) == args.s,
-                int(float(l2[5])) == args.s,
+                len(l3) == 15,
+                l3[0] == "0",
+                int(float(l3[2])) == args.b,
+                int(float(l3[3])) == m.hq,
+                int(float(l3[4])) == m.hkv,
+                int(float(l3[5])) == args.s,
+                int(float(l3[6])) == args.s,
             ]
         ):
-            logging.error("Table data doesn't match: %s", l2)
+            logging.error("Table data doesn't match: %s", l3)
             return None
-        return float(l2[6])
+        return float(l3[-1])
     except ValueError as e:
         logging.error(
             "Unexpected numeric conversion error. %s: %s", type(e).__name__, e
@@ -622,7 +649,7 @@ def run_bench(args: BenchArgs, metric: Metric) -> Optional[float]:
                 "Out of resources while benchmarking %s. %s", args.to_log_str(), e
             )
 
-    except Exception as e:
+    except (Exception, SystemExit) as e:
         logging.error(
             "Unexpected error while benchmarking %s. %s: %s",
             args.to_log_str(),

--- a/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_attn_models.py
+++ b/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_attn_models.py
@@ -570,17 +570,23 @@ def get_mla_bench_result(args: BenchArgs, out: str, err: str) -> Optional[float]
         logging.error("Benchmark name doesn't match: %s", l0)
         return None
     # Check stdout line #2 (table header):
-    if l1 != [
-        "model",
-        "B",
-        "H",
-        "S",
-        "kv_lora_rank",
-        "qk_rope_head_dim",
-        "rotary_dim",
-        "num_kv_splits",
-        "mla_decode_fwd",
-    ]:
+    # Triton sometimes appends a "(ms)" annotation token after the last column name.
+    if not (
+        l1[:9]
+        == [
+            "model",
+            "B",
+            "H",
+            "S",
+            "kv_lora_rank",
+            "qk_rope_head_dim",
+            "rotary_dim",
+            "num_kv_splits",
+            "mla_decode_fwd",
+        ]
+        and len(l1) in (9, 10)
+        and (len(l1) == 9 or l1[9] == "(ms)")
+    ):
         logging.error("Table header doesn't match: %s", l1)
         return None
     # Check stdout line #3 (table data):

--- a/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_models.py
+++ b/op_tests/op_benchmarks/triton/model_benchmarking_tool/bench_models.py
@@ -374,24 +374,35 @@ class MhaKernelHandler(KernelHandler):
 
     def build_args(self) -> str:
         shape = self._shape
-        return (
-            f"-mode fwd -causal true --layout {self._mha_layout} --dtype bf16 -b {self._batch_size} "
+        # bshd (batch-seq-head-dim) - fwd
+        # thd (token-head-dim) - fwd_varlen with equal seq lens
+        fn = "fwd_varlen" if self._mha_layout == "thd" else "fwd"
+        args = (
+            f"-fn {fn} -causal true --dtype bf16 -b {self._batch_size} "
             f"-hq {shape['hq']} -hk {shape['hkv']} -sq {self._seq_len} -sk {self._seq_len} "
             f"-d {shape['dqk']} -dv {shape['dv']} -metric {self._metric}"
         )
+        if fn == "fwd_varlen":
+            args += " -equal_seqlens"
+        return args
 
     def parse_stdout(self, stdout: str) -> float:
+        # Expected output (4 lines):
+        #   [0] "[1/1] <model> B=... HQ=... ..."   (progress)
+        #   [1] "bench_mha:"
+        #   [2] "model  BATCH  HQ  HK  N_CTX_Q  N_CTX_K  D_HEAD  D_HEAD_V  ..."   (header)
+        #   [3] "0  <model>  <b>  <hq>  <hk>  <sq>  <sk>  ...  <value>"   (data)
         lines = [line.split() for line in stdout.strip().splitlines() if line.strip()]
-        if len(lines) < 3:
+        if len(lines) < 4:
             raise ValueError(
-                f"Unexpected MHA bench output: expected at least 3 lines, got {len(lines)}"
+                f"Unexpected MHA bench output: expected at least 4 lines, got {len(lines)}"
             )
-        if lines[0] != ["bench_mha:"]:
-            raise ValueError(f"Unexpected MHA bench output: first line {lines[0]!r}")
-        data = lines[2]
-        if len(data) < 7:
+        if lines[1] != ["bench_mha:"]:
+            raise ValueError(f"Unexpected MHA bench output: second line {lines[1]!r}")
+        data = lines[3]
+        if len(data) < 15:
             raise ValueError(f"Unexpected MHA bench data line: {data!r}")
-        return float(data[6])
+        return float(data[-1])
 
     def build_result_row(self, bench_result: float | str) -> ResultRow:
         shape = self._shape
@@ -519,7 +530,7 @@ def call_function(
         else:
             print("Out of resources while benchmarking %s. %s" % (handler.to_str(), e))
 
-    except Exception as e:
+    except (Exception, SystemExit) as e:
         print(
             "Unexpected error while benchmarking %s. %s: %s"
             % (


### PR DESCRIPTION
## Motivation

Recently, `bench_mha.py` CLI (Command Line Interface) has changed. This ended up breaking `bench_attn_models.py` and `bench_models.py`. This PR fixes both model benchmarking scripts.

## Technical Details

This PR proposes AI-assisted fixes to:

* Fix wrong data type argument in `bench_mha.py` sink generation.
* Adapt `bench_attn_models.py` to new `bench_mha.py` CLI.
* Adapt `bench_models.py` to new `bench_mha.py` CLI.
* Adapt `bench_attn_models.py` to new `bench_mla_decode.py` CLI

## Test Plan

Execute `bench_attn_models.py` and `bench_models.py` with default arguments. Both scripts should run as expected, producing their respective output files.

## Test Result

Both scripts are working fine. ✅

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
