### PR TITLE
Add support for gfx1103 GPU architecture

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
@@ -60,6 +60,7 @@ RDNA_ARCHS = frozenset(
         "gfx1100",
         "gfx1101",
         "gfx1102",
+        "gfx1103",
         "gfx1150",
         "gfx1151",
         "gfx1200",


### PR DESCRIPTION
## Motivation

Add support for gfx1103 GPU architecture

## Test Plan

Install [0xDELUXA](https://github.com/0xDELUXA)'s whl ([amd_aiter-0.0.0-py3-none-win_amd64.whl](https://github.com/0xDELUXA/flash-attention/releases/download/v2.8.4_win-rocm/amd_aiter-0.0.0-py3-none-win_amd64.whl)), manully add gfx1103 and run comfyui.

## Test Result

No error. Run as fast as sageattention(1.0.6) on sdxl, <10% slower on z-image

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
