### PR TITLE
Add ROCm-versioned wheel naming to release workflow

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -40,6 +40,10 @@ on:
         description: 'GPU architectures (e.g. gfx942;gfx950)'
         required: false
         default: 'gfx942;gfx950'
+      rocm_version:
+        description: 'ROCm version label for wheel (e.g. 7.2.1). Auto-detected from container if empty.'
+        required: false
+        default: ''
       runner:
         description: 'Select build host'
         required: true
@@ -53,8 +57,8 @@ on:
           - aiter-1gpu-runner
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.rocm_version || 'default' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') }}
 
 jobs:
   build_whl_package:
@@ -120,6 +124,48 @@ jobs:
           --name aiter_build_${{ matrix.python_version }} \
           ${{ env.BUILD_DOCKER_IMAGE }}
 
+      - name: Detect ROCm version
+        if: ${{ matrix.build_enabled }}
+        id: rocm_ver
+        run: |
+          set -e
+          INPUT_VER="${{ github.event.inputs.rocm_version }}"
+          if [ -n "$INPUT_VER" ]; then
+            echo "Using user-provided ROCm version: $INPUT_VER"
+            echo "rocm_version=$INPUT_VER" >> "$GITHUB_OUTPUT"
+          else
+            DETECTED=$(docker exec aiter_build_${{ matrix.python_version }} \
+              bash -c 'cat /opt/rocm/.info/version 2>/dev/null || echo ""' | tr -d '[:space:]')
+            if [ -n "$DETECTED" ]; then
+              DETECTED=$(echo "$DETECTED" | cut -d'-' -f1)
+              echo "Auto-detected ROCm version: $DETECTED"
+              echo "rocm_version=$DETECTED" >> "$GITHUB_OUTPUT"
+            else
+              echo "WARNING: Could not detect ROCm version, wheel will have no ROCm suffix"
+              echo "rocm_version=" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Determine wheel version
+        if: ${{ matrix.build_enabled }}
+        id: whl_ver
+        run: |
+          set -e
+          ROCM_VER="${{ steps.rocm_ver.outputs.rocm_version }}"
+          BASE_VER=$(docker exec -w /workspace aiter_build_${{ matrix.python_version }} \
+            python3 -c "from setuptools_scm import get_version; print(get_version())" 2>/dev/null || true)
+          if [ -z "$BASE_VER" ]; then
+            BASE_VER=$(git describe --tags --match 'v*' 2>/dev/null | sed 's/^v//' || echo "0.1.0")
+          fi
+          if [ -n "$ROCM_VER" ]; then
+            FULL_VER="${BASE_VER}+rocm${ROCM_VER}"
+          else
+            FULL_VER="${BASE_VER}"
+          fi
+          echo "Wheel version: $FULL_VER (base=$BASE_VER, rocm=$ROCM_VER)"
+          echo "full_version=$FULL_VER" >> "$GITHUB_OUTPUT"
+          echo "rocm_suffix=rocm${ROCM_VER}" >> "$GITHUB_OUTPUT"
+
       - name: Install Dependencies
         if: ${{ matrix.build_enabled }}
         run: |
@@ -140,21 +186,22 @@ jobs:
           aiter_build_${{ matrix.python_version }} \
           pip install --timeout=60 --retries=10 ninja
 
-      - name: Build Aiter
+      - name: Build Aiter with precompiled kernels
         if: ${{ matrix.build_enabled }}
         run: |
           set -e
-          echo "Building aiter whl packages for Python ${{ matrix.python_version }}..."
+          FULL_VER="${{ steps.whl_ver.outputs.full_version }}"
+          echo "Building aiter whl version=${FULL_VER} with PREBUILD_KERNELS=1 for Python ${{ matrix.python_version }}..."
           docker exec \
           -w /workspace \
           aiter_build_${{ matrix.python_version }} \
-          bash -c 'PREBUILD_KERNELS=1 GPU_ARCHS="${{ env.GPU_ARCHS }}" python3 setup.py bdist_wheel && ls dist/*.whl'
+          bash -c "SETUPTOOLS_SCM_PRETEND_VERSION='${FULL_VER}' PREBUILD_KERNELS=1 GPU_ARCHS='${{ env.GPU_ARCHS }}' python3 setup.py bdist_wheel && ls -lh dist/*.whl"
 
       - name: Upload whl file as artifact
         if: ${{ matrix.build_enabled }}
         uses: actions/upload-artifact@v4
         with:
-          name: aiter-whl-packages-py${{ matrix.python_version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: aiter-whl-py${{ matrix.python_version }}-${{ steps.whl_ver.outputs.rocm_suffix }}-${{ github.run_id }}
           path: dist/*.whl
 
       - name: Cleanup container

--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -35,7 +35,7 @@ on:
       docker_username:
         description: 'Docker username for docker login'
         required: true
-        default: 'rocmshard'
+        default: 'rocmshared'
       gpu_archs:
         description: 'GPU architectures (e.g. gfx942;gfx950)'
         required: false
@@ -47,14 +47,12 @@ on:
       runner:
         description: 'Select build host'
         required: true
-        default: 'aiter-k8s-build'
+        default: 'aiter-1gpu-runner'
         type: choice
         options:
-          - build-only-aiter
-          - aiter-mi300-1gpu
-          - aiter-mi325-1gpu
-          - linux-aiter-mi355-1
           - aiter-1gpu-runner
+          - build-only-aiter
+          - linux-aiter-mi35x-1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.rocm_version || 'default' }}

--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -173,7 +173,16 @@ jobs:
           -w /workspace \
           aiter_build_${{ matrix.python_version }} \
           pip install --timeout=60 --retries=10 -r requirements.txt
-      
+
+      - name: Pin setuptools_scm
+        if: ${{ matrix.build_enabled }}
+        run: |
+          set -e
+          docker exec \
+          -w /workspace \
+          aiter_build_${{ matrix.python_version }} \
+          pip install --timeout=60 --retries=10 "setuptools_scm<10"
+
       - name: Install ninja
         if: ${{ matrix.build_enabled }}
         run: |


### PR DESCRIPTION
## Summary

Follow PyTorch's wheel naming convention (`+rocmX.Y.Z`) for AITER release wheels, enabling distinct wheels for different ROCm versions from a single workflow.

- Add `rocm_version` workflow input (auto-detects from container's `/opt/rocm/.info/version` if left empty)
- Use `SETUPTOOLS_SCM_PRETEND_VERSION` to embed version+rocm suffix in wheel filename
- Include ROCm version in concurrency group key to prevent cross-version build cancellation
- Protect tag-based builds from cancel-in-progress
- Update artifact naming to include ROCm suffix (e.g. `aiter-whl-py3.12-rocm7.2.1-<run_id>`)

Example output wheel: `amd_aiter-0.1.12.post1+rocm7.2.1-cp312-cp312-linux_x86_64.whl`

## Test plan

- [ ] Trigger workflow with explicit `rocm_version=7.2.1` — verify wheel filename contains `+rocm7.2.1`
- [ ] Trigger workflow with empty `rocm_version` — verify auto-detection from container
- [ ] Trigger two concurrent builds with different `rocm_version` values — verify they don't cancel each other