### PR TITLE
Fix release workflow: runner labels, Docker username, setuptools_scm

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -35,7 +35,7 @@ on:
       docker_username:
         description: 'Docker username for docker login'
         required: true
-        default: 'rocmshard'
+        default: 'rocmshared'
       gpu_archs:
         description: 'GPU architectures (e.g. gfx942;gfx950)'
         required: false
@@ -43,18 +43,16 @@ on:
       runner:
         description: 'Select build host'
         required: true
-        default: 'aiter-k8s-build'
+        default: 'aiter-1gpu-runner'
         type: choice
         options:
-          - build-only-aiter
-          - aiter-mi300-1gpu
-          - aiter-mi325-1gpu
-          - linux-aiter-mi355-1
           - aiter-1gpu-runner
+          - build-only-aiter
+          - linux-aiter-mi35x-1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') }}
 
 jobs:
   build_whl_package:
@@ -129,7 +127,16 @@ jobs:
           -w /workspace \
           aiter_build_${{ matrix.python_version }} \
           pip install --timeout=60 --retries=10 -r requirements.txt
-      
+
+      - name: Pin setuptools_scm
+        if: ${{ matrix.build_enabled }}
+        run: |
+          set -e
+          docker exec \
+          -w /workspace \
+          aiter_build_${{ matrix.python_version }} \
+          pip install --timeout=60 --retries=10 "setuptools_scm<10"
+
       - name: Install ninja
         if: ${{ matrix.build_enabled }}
         run: |


### PR DESCRIPTION
## Summary

Three independent bugs preventing release builds from completing:

- **Runner labels don't exist**: `aiter-mi300-1gpu` and `aiter-mi325-1gpu` were never registered as GitHub Actions runners. Builds queued indefinitely (7+ hours). Changed default to `aiter-1gpu-runner` (confirmed working in `aiter-test.yaml`). Fixed `linux-aiter-mi355-1` typo to `linux-aiter-mi35x-1`.
- **Docker username typo**: `rocmshard` -> `rocmshared` (missing 'e'), causing Docker login failure on `build-only-aiter` runner.
- **setuptools_scm 10.x breaks build**: `setuptools_scm` 10.0.5 moved core to `vcs_versioning` package, causing `ModuleNotFoundError: No module named 'vcs_versioning'`. Pin to `<10` until `pyproject.toml` is updated.

Also protects tag-based builds from `cancel-in-progress`.

## Test plan

- [x] Confirmed `aiter-1gpu-runner` label exists and picks up jobs (run 24287110305 was picked up immediately)
- [x] Confirmed `rocmshared` is the correct Docker username (used in aiter-test.yaml, triton-test.yaml)
- [x] Confirmed `setuptools_scm<10` (9.2.2) fixes the build (tested in 6 local containers)
- [ ] Trigger release build after merge to verify end-to-end