### PR TITLE
CI: add standalone OPUS test workflow

### DIFF
--- a/csrc/include/opus/README.md
+++ b/csrc/include/opus/README.md
@@ -263,3 +263,24 @@ Using `ctypes.CDLL` to call `extern "C"` functions — or `hipModuleLaunchKernel
 | `--genco` (device-only compile) | Device | Eliminates host pass entirely |
 | `__HIP_DEVICE_COMPILE__` guard | Host | Skips heavy headers during host pass |
 | ctypes / `hipModuleLaunchKernel` | Host | Eliminates C++ binding compilation |
+
+## Device Intrinsic Wrappers
+
+`opus.hpp` provides device intrinsic wrappers so kernels only need `#include <opus/opus.hpp>` — no `<hip/hip_runtime.h>` required for device code:
+
+| HIP runtime | opus:: wrapper |
+|---|---|
+| `threadIdx.x` | `opus::thread_id_x()` |
+| `blockIdx.x` | `opus::block_id_x()` |
+| `blockDim.x` | `opus::block_size_x()` |
+| `gridDim.x * blockDim.x` | `opus::grid_size_x()` |
+| `__syncthreads()` | `opus::sync_threads()` |
+| `__all(pred)` | `opus::warp_all(pred)` |
+
+For host-side code (kernel launch, memory management), use `#include <opus/hip_minimal.hpp>` which provides `dim3`, `hipMalloc`, `hipLaunchKernelGGL`, etc.
+
+## Compile-Time Best Practices
+
+For a comprehensive guide on reducing compile time — including the recommended host/device separation pattern, template instantiation reduction, LLVM builtins, and profiling with `-ftime-trace` — see the [OPUS Kernel Best Practice skill](../../../.claude/skills/opus-kernel-best-practice/SKILL.md).
+
+Invoke it in Claude Code with `/opus-kernel-best-practice`.

--- a/csrc/include/opus/hip_minimal.hpp
+++ b/csrc/include/opus/hip_minimal.hpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef HIP_MINIMAL_HPP
+#define HIP_MINIMAL_HPP
+
+/**
+ * @file opus/hip_minimal.hpp
+ * @brief Minimal HIP host-side declarations for kernel launch and device management.
+ *
+ * Replaces <hip/hip_runtime.h> (~100K+ preprocessed lines) for the HOST pass only.
+ * For device-side intrinsics, use opus::thread_id_x(), opus::block_id_x(), etc. from opus.hpp.
+ *
+ * Usage (recommended separate host/device pattern):
+ *   #ifdef __HIP_DEVICE_COMPILE__
+ *   #include <opus/opus.hpp>        // device: template library + device intrinsics
+ *   #else
+ *   #include <opus/hip_minimal.hpp> // host: dim3, hipMalloc, hipLaunchKernelGGL, etc.
+ *   #endif
+ *
+ * Compile: hipcc kernel.cu -I<aiter_root>/csrc/include -D__HIPCC_RTC__ ...
+ */
+
+// ========== Attribute keyword fallbacks (both passes) ==========
+#ifndef __launch_bounds__
+#define __launch_bounds_impl0__(requiredMaxThreadsPerBlock) \
+    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock)))
+#define __launch_bounds_impl1__(requiredMaxThreadsPerBlock, minBlocksPerMultiprocessor) \
+    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock), \
+                   amdgpu_waves_per_eu(minBlocksPerMultiprocessor)))
+#define __launch_bounds_select__(_1, _2, impl_, ...) impl_
+#define __launch_bounds__(...) \
+    __launch_bounds_select__(__VA_ARGS__, __launch_bounds_impl1__, __launch_bounds_impl0__, )(__VA_ARGS__)
+#endif
+#ifndef __shared__
+#define __shared__ __attribute__((shared))
+#endif
+#ifndef __device__
+#define __device__ __attribute__((device))
+#endif
+#ifndef __global__
+#define __global__ __attribute__((global))
+#endif
+#ifndef __host__
+#define __host__ __attribute__((host))
+#endif
+
+// ========== Host-side declarations (guarded to coexist with <hip/hip_runtime.h>) ==========
+#if !defined(HIP_INCLUDE_HIP_HIP_RUNTIME_API_H)
+
+#include <cstddef>   // size_t
+
+typedef int hipError_t;
+typedef void* hipStream_t;
+#define hipSuccess 0
+
+struct dim3 {
+    unsigned int x, y, z;
+    constexpr dim3(unsigned int _x = 1, unsigned int _y = 1, unsigned int _z = 1)
+        : x(_x), y(_y), z(_z) {}
+};
+
+// Error handling
+extern "C" hipError_t hipGetLastError();
+extern "C" hipError_t hipDeviceSynchronize();
+extern "C" const char* hipGetErrorString(hipError_t error);
+
+// Memory management
+extern "C" hipError_t hipMalloc(void** ptr, size_t size);
+extern "C" hipError_t hipFree(void* ptr);
+extern "C" hipError_t hipMemset(void* dst, int value, size_t sizeBytes);
+enum hipMemcpyKind { hipMemcpyHostToHost = 0, hipMemcpyHostToDevice = 1, hipMemcpyDeviceToHost = 2, hipMemcpyDeviceToDevice = 3, hipMemcpyDefault = 4 };
+extern "C" hipError_t hipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind);
+template <typename T> inline hipError_t hipMalloc(T** ptr, size_t size) { return hipMalloc(reinterpret_cast<void**>(ptr), size); }
+
+// Events (timing)
+typedef void* hipEvent_t;
+extern "C" hipError_t hipEventCreate(hipEvent_t* event);
+extern "C" hipError_t hipEventDestroy(hipEvent_t event);
+extern "C" hipError_t hipEventRecord(hipEvent_t event, hipStream_t stream = nullptr);
+extern "C" hipError_t hipEventSynchronize(hipEvent_t event);
+extern "C" hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop);
+
+// Kernel launch (<<<>>> syntax)
+extern "C" hipError_t __hipPushCallConfiguration(dim3 gridDim, dim3 blockDim, size_t sharedMem = 0, hipStream_t stream = nullptr);
+extern "C" hipError_t __hipPopCallConfiguration(dim3* gridDim, dim3* blockDim, size_t* sharedMem, hipStream_t* stream);
+extern "C" hipError_t hipLaunchKernel(const void* function_address, dim3 numBlocks, dim3 dimBlocks, void** args, size_t sharedMemBytes, hipStream_t stream);
+#ifndef hipLaunchKernelGGL
+#define hipLaunchKernelGGL(kernel, numBlocks, dimBlocks, sharedMemBytes, stream, ...) \
+    kernel<<<numBlocks, dimBlocks, sharedMemBytes, stream>>>(__VA_ARGS__)
+#endif
+
+#endif // !HIP_INCLUDE_HIP_HIP_RUNTIME_API_H
+
+#endif // HIP_MINIMAL_HPP

--- a/csrc/include/opus/opus.hpp
+++ b/csrc/include/opus/opus.hpp
@@ -23,13 +23,13 @@
 
 #ifdef __HIPCC__
 #define OPUS_H inline __host__
-#define OPUS_D inline __device__
+#define OPUS_D __device__
 #define OPUS_H_D inline __host__ __device__
 #define OPUS_D_EXTERN __device__
 #define OPUS_H_D_EXTERN __host__ __device__
 #else
 #define OPUS_H inline
-#define OPUS_D inline
+#define OPUS_D
 #define OPUS_H_D inline
 #define OPUS_D_EXTERN
 #define OPUS_H_D_EXTERN
@@ -181,12 +181,16 @@ template<typename F, typename... R, std::enable_if_t<(is_constant_v<R> && ...), 
 OPUS_H_D constexpr void static_for(F f, R...) { impl::static_for_impl<make_index_seq<R::value...>>{}(f); }
 
 namespace impl {
-template <typename Seq> struct static_ford_impl {
-    template <typename F, typename... Ids> OPUS_H_D constexpr void operator()(F f, Ids... ids) const {
-        static_for<get<0>(Seq{})>([=](auto I){ static_ford_impl<decltype(seq_pop_front(Seq{}))>{}(f, ids..., I); });
-    }
+// Flat static_ford: single-level static_for, non-recursive compile-time index decomposition via fold expressions
+template <index_t D, index_t... Is, index_t... Ns> constexpr index_t ford_stride(seq<Is...>, seq<Ns...>) { return ((Is > D ? Ns : index_t(1)) * ... * index_t(1)); }
+template <index_t D, index_t... Is, index_t... Ns> constexpr index_t ford_dim(seq<Is...>, seq<Ns...>) { return ((Is == D ? Ns : index_t(1)) * ...); }
+template <index_t I, index_t D, index_t... Ns> constexpr index_t ford_at() { return (I / ford_stride<D>(make_index_seq<sizeof...(Ns)>{}, seq<Ns...>{})) % ford_dim<D>(make_index_seq<sizeof...(Ns)>{}, seq<Ns...>{}); }
+template <typename Seq> struct static_ford_impl;
+template <index_t... Ns> struct static_ford_impl<seq<Ns...>> {
+    template <typename F, index_t I, index_t... Ds> OPUS_H_D static constexpr void call_one(F& f, number<I>, seq<Ds...>) { f(number<ford_at<I, Ds, Ns...>()>{}...); }
+    template <typename F> OPUS_H_D constexpr void operator()(F f) const { static_for<(Ns * ... * 1)>([&](auto I) { call_one(f, I, make_index_seq<sizeof...(Ns)>{}); }); }
 };
-template <> struct static_ford_impl<seq<>> { template <typename F, typename... Ids> OPUS_H_D constexpr void operator()(F f, Ids... ids) const { f(ids...); } };
+template <> struct static_ford_impl<seq<>> { template <typename F> OPUS_H_D constexpr void operator()(F f) const { f(); } };
 }
 
 template<index_t... N, typename F> OPUS_H_D constexpr void static_ford(F f) { impl::static_ford_impl<seq<N...>>{}(f); }
@@ -375,8 +379,12 @@ OPUS_H_D  constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2) 
 template <class T0, class T1, class T2, class T3>
 OPUS_H_D  constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3) {
                                             return impl::concat_tuple(t0, t1, t2, t3, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}, make_index_seq<T3::size()>{}); }
-template <class T0, class T1, class T2, class T3, class T4, class... Ts>
-OPUS_H_D  constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, Ts const&... ts) { return concat_tuple(concat_tuple(t0, t1, t2, t3), concat_tuple(t4, ts...)); }
+namespace impl { template <class T0, class T1, class T2, class T3, class T4, index_t... I0, index_t... I1, index_t... I2, index_t... I3, index_t... I4>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, seq<I0...>, seq<I1...>, seq<I2...>, seq<I3...>, seq<I4...>) { return opus::make_tuple(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)..., get<I3>(t3)..., get<I4>(t4)...); } }
+template <class T0, class T1, class T2, class T3, class T4>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4) { return impl::concat_tuple(t0, t1, t2, t3, t4, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}, make_index_seq<T3::size()>{}, make_index_seq<T4::size()>{}); }
+template <class T0, class T1, class T2, class T3, class T4, class T5, class... Ts>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, T5 const& t5, Ts const&... ts) { return concat_tuple(concat_tuple(t0, t1, t2, t3, t4), concat_tuple(t5, ts...)); }
 
 template <typename> struct is_tuple : false_type {};
 template <typename... T> struct is_tuple<opus::tuple<T...>> : true_type {};
@@ -395,8 +403,22 @@ template <typename T, index_t... Is> OPUS_H_D constexpr auto                    
 template <typename T, std::enable_if_t<is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto  explode_tuple(const T& t) { return explode_tuple(t, make_index_seq<size<T>()>{}); }
 template <typename T, index_t... Is> OPUS_H_D constexpr auto                                 explode_tuple(const T& t, seq<Is...>) { return concat_tuple(explode_tuple(get<Is>(t))...); }
 
-template <typename T, index_t... Is> OPUS_H_D constexpr auto flatten_tuple(const T& t, seq<Is...>) { return concat_tuple(explode_tuple(get<Is>(t))...); }
-template <typename T> OPUS_H_D constexpr auto                flatten_tuple(const T& t) { return flatten_tuple(t, make_index_seq<size<T>()>{}); }
+template <typename T, index_t... Is> OPUS_H_D constexpr auto flatten_tuple_general(const T& t, seq<Is...>) { return concat_tuple(explode_tuple(get<Is>(t))...); }
+template <typename T, std::enable_if_t<is_tuple_v<T> && !(is_tuple_v<tuple_element_t<0, remove_cvref_t<T>>>), bool> = true>
+OPUS_H_D constexpr auto flatten_tuple(const T& t) { return t; }  // already flat
+template <typename T, std::enable_if_t<!is_tuple_v<T>, bool> = true>
+OPUS_H_D constexpr auto flatten_tuple(const T& t) { return flatten_tuple_general(t, make_index_seq<size<T>()>{}); }  // non-tuple (e.g. seq)
+namespace impl { // direct flatten for 1-level nested tuples — bypasses concat_tuple + explode_tuple
+template<typename T, index_t... Gs> constexpr auto group_sizes(seq<Gs...>) { return seq<size<tuple_element_t<Gs, T>>()...>{}; }
+template<typename T, index_t... Gs> constexpr index_t group_total(seq<Gs...>) { return (size<tuple_element_t<Gs, T>>() + ...); }
+template<index_t J, index_t... Gs, index_t... Ns> constexpr index_t flat_group(seq<Gs...>, seq<Ns...>) { index_t acc = 0, r = 0; ((void)(acc += Ns, (acc <= J ? (void)(r = Gs + 1) : (void)0)), ...); return r; }
+template<typename T, index_t G, index_t... Gs> constexpr index_t group_offset(seq<Gs...>) { return ((Gs < G ? size<tuple_element_t<Gs, T>>() : 0) + ...); }
+template<typename T, index_t J, typename GS> OPUS_H_D constexpr auto flatten_at(const T& t) {
+    constexpr auto gs = make_index_seq<size<T>()>{}; constexpr index_t G = flat_group<J>(gs, GS{}); return get<J - group_offset<T, G>(gs)>(get<G>(t)); }
+template<typename T, typename GS, index_t... Js> OPUS_H_D constexpr auto flatten_tuple_impl(const T& t, seq<Js...>) { return opus::make_tuple(flatten_at<T, Js, GS>(t)...); }
+}
+template <typename T, std::enable_if_t<is_tuple_v<T> && (is_tuple_v<tuple_element_t<0, remove_cvref_t<T>>>), bool> = true>
+OPUS_H_D constexpr auto flatten_tuple(const T& t) { using U = remove_cvref_t<T>; constexpr auto gs = make_index_seq<size<U>()>{}; return impl::flatten_tuple_impl<U, decltype(impl::group_sizes<U>(gs))>(t, make_index_seq<impl::group_total<U>(gs)>{}); }
 
 namespace impl {
 template<typename Outer, typename Inner, index_t...Is>
@@ -436,6 +458,9 @@ template<typename R, typename T, std::enable_if_t<is_tuple_v<T>, bool> = true>
 OPUS_H_D constexpr auto reduce_tuple(const T & t) { return  impl::reduce_tuple_impl<R>(t, make_index_seq<size<T>()>{}); }
 template<typename T, std::enable_if_t<is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto reduce_tuple_sum(const T & t) { return reduce_tuple<opus::plus>(t); }
 template<typename T, std::enable_if_t<is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto reduce_tuple_mul(const T & t) { return reduce_tuple<opus::multiplies>(t); }
+// Fast path: fold expression for tuple of number<> types (avoids N-1 intermediate tuple types)
+template<typename... Ns, std::enable_if_t<sizeof...(Ns) != 0 && (is_constant_v<Ns> && ...), bool> = true>
+OPUS_H_D constexpr auto reduce_tuple_mul(const tuple<Ns...>&) { return opus::tuple<number<(Ns::value * ...)>>{}; }
 
 namespace impl {
 template<typename PT, index_t... Js>
@@ -647,17 +672,26 @@ OPUS_H_D constexpr auto layout_to_vectorized_issue_space() {
     return issue_space_vec;
 }
 
-// this function is usually not constexpr. pre-compute all the offset under current layout
-template<index_t vec, typename Layout>
-OPUS_H_D constexpr auto layout_to_offsets(const Layout& u) {
-    constexpr auto issue_space_vec = layout_to_vectorized_issue_space<vec, Layout>();
-    constexpr index_t num_issues = get<0>(reduce_tuple_mul(issue_space_vec)).value;
+// Cache issue-space computations for load/store (avoids redundant evaluation across methods)
+template<typename Layout, index_t vec = 1> struct layout_load_traits {
+    static constexpr auto issue_space = layout_to_issue_space<Layout>();
+    static constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{}); static constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+};
+template<typename Layout, index_t vec, bool use_imm> struct layout_imm_offsets {};  // cached offsets for tr_load immediate-offset path
+template<typename Layout, index_t vec> struct layout_imm_offsets<Layout, vec, true> { using L = remove_cvref_t<Layout>;
+    static constexpr auto u_linear = make_layout<-1>(layout_load_traits<Layout, vec>::issue_space_vec);
+    static constexpr auto offsets = layout_to_offsets<vec>(L(typename L::Shape{}, typename L::Stride{}, typename L::Coord{})); };
+// Runtime flat index → multi-index tuple (all index_t) — avoids per-iteration template instantiation
+template<index_t... Is, index_t... Ns> OPUS_H_D constexpr auto flat_to_coords(index_t flat, seq<Is...>, tuple<number<Ns>...>) {
+    constexpr index_t strides[] = {impl::ford_stride<Is>(make_index_seq<sizeof...(Ns)>{}, seq<Ns...>{})...}, dims[] = {Ns...};
+    return opus::make_tuple(static_cast<index_t>((flat / strides[Is]) % dims[Is])...); }
+// Pre-compute offsets via runtime loop — 1 coord_to_linear instantiation per layout instead of N
+template<index_t vec, typename Layout> OPUS_H_D constexpr auto layout_to_offsets(const Layout& u) {
+    using LT = layout_load_traits<Layout, vec>; constexpr auto issue_space_vec = LT::issue_space_vec;
+    constexpr index_t num_issues = LT::r_elem.value, ndim = size<remove_cvref_t<decltype(issue_space_vec)>>();
     array<index_t, num_issues> offsets;
-
-    constexpr auto u_linear = make_layout<-1>(issue_space_vec);
-    static_ford(issue_space_vec, [&](auto ... ids){ offsets[u_linear(ids...)] = u(ids...); });
-    return offsets;
-}
+    for (index_t i = 0; i < num_issues; i++) offsets[i] = u(flat_to_coords(i, make_index_seq<ndim>{}, issue_space_vec));
+    return offsets; }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 // vector, a wrapper for __attribute__((ext_vector_type(*)))
 template <typename V_, index_t N_> // V_ must be literal type, otherwise clang ext_vector_type will not recognize
@@ -708,7 +742,12 @@ template <index_t I, typename T, std::enable_if_t<is_vector_v<T>, bool> = true> 
 
 namespace impl {
 template <class T0, class T1, index_t... I0, index_t... I1>
-OPUS_H_D constexpr auto concat_vector(T0 const& t0, T1 const& t1, seq<I0...>, seq<I1...>) { return opus::make_vector(get<I0>(t0)..., get<I1>(t1)...); }
+OPUS_H_D constexpr auto concat_vector(T0 const& t0, T1 const& t1, seq<I0...>, seq<I1...>) {
+    if constexpr (std::is_same_v<remove_cvref_t<T0>, remove_cvref_t<T1>> && sizeof...(I0) > 1) {
+        using R = vector_t<typename vector_traits<remove_cvref_t<T0>>::dtype, sizeof...(I0) + sizeof...(I1)>;
+        return __builtin_bit_cast(R, __builtin_shufflevector(t0, t1, I0..., (sizeof...(I0) + I1)...));
+    } else { return opus::make_vector(get<I0>(t0)..., get<I1>(t1)...); }
+}
 template <class T0, class T1, class T2, index_t... I0, index_t... I1, index_t...I2>
 OPUS_H_D constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2, seq<I0...>, seq<I1...>, seq<I2...>) { return opus::make_vector(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)...); }
 template <class T0, class T1, class T2, class T3, index_t... I0, index_t... I1, index_t...I2, index_t...I3>
@@ -716,7 +755,7 @@ OPUS_H_D constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2, 
 }
 template <class T0> OPUS_H_D  constexpr auto concat_vector(T0 const& t0) { return t0; }
 template <class T0, class T1>
-OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1) { return impl::concat_vector(t0, t1, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}); }
+OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1) { return impl::concat_vector(t0, t1, make_index_seq<size<T0>()>{}, make_index_seq<size<T1>()>{}); }
 template <class T0, class T1, class T2>
 OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2) { return impl::concat_vector(t0, t1, t2, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}); }
 template <class T0, class T1, class T2, class T3>
@@ -725,8 +764,11 @@ OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2,
 template <class T0, class T1, class T2, class T3, class T4, class... Ts>
 OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, Ts const&... ts) { return concat_vector(concat_vector(t0, t1, t2, t3), concat_vector(t4, ts...)); }
 
-template <typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr void fill(T& a, typename vector_traits<T>::dtype const& value) { static_for<size<T>()>([&](auto i){ a[i.value] = value; }); }
-template <typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr void clear(T& a) { fill(a, static_cast<typename vector_traits<T>::dtype>(0)); }
+template <typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr void fill(T& a, typename vector_traits<T>::dtype const& value) {
+    if constexpr (size<T>() <= 4) { static_for<size<T>()>([&](auto i){ a[i.value] = value; }); }
+    else { for (index_t i = 0; i < size<T>(); ++i) a[i] = value; }  // runtime loop for large vectors
+}
+template <typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr void clear(T& a) { a = {}; }
 
 namespace impl {
 template<typename T, index_t... Is, std::enable_if_t<is_vector_v<T>, bool> = true>
@@ -754,7 +796,10 @@ OPUS_H_D constexpr auto to_vector(const T& t) { return impl::to_vector_impl(t, m
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 // slice
 namespace impl {
-template<typename C, index_t...Is, std::enable_if_t<is_vector_v<C>, bool> = true> OPUS_H_D constexpr auto slice_impl(C&& c, seq<Is...>) { return opus::make_vector(get<Is>(c)...); }
+template<typename C, index_t...Is, std::enable_if_t<is_vector_v<C>, bool> = true> OPUS_H_D constexpr auto slice_impl(C&& c, seq<Is...>) {
+    if constexpr (sizeof...(Is) == 1) return opus::make_vector(get<Is>(c)...);
+    else { using R = vector_t<typename vector_traits<remove_cvref_t<C>>::dtype, sizeof...(Is)>; return __builtin_bit_cast(R, __builtin_shufflevector(c, c, Is...)); }
+}
 template<typename C, index_t...Is, std::enable_if_t<is_array_v<C>, bool> = true>  OPUS_H_D constexpr auto slice_impl(C&& c, seq<Is...>) { return opus::make_array(get<Is>(c)...); }
 template<typename C, index_t...Is, std::enable_if_t<is_tuple_v<C>, bool> = true>  OPUS_H_D constexpr auto slice_impl(C&& c, seq<Is...>) { return opus::make_tuple(get<Is>(c)...); }
 
@@ -785,7 +830,10 @@ OPUS_H_D constexpr auto set_slice_impl(C&& dst_c, V&& src_c, seq<Ds...>, seq<Ss.
             dst_c = __builtin_bit_cast(dst_t, dst_i32); return;
         }
     }
-    ((dst_c[Ds] = src_c[Ss]), ...);
+    if constexpr (is_contiguous_seq(seq<Ds...>{}) && is_contiguous_seq(seq<Ss...>{}) && (is_vector_v<dst_t> || is_array_v<dst_t>) && len > 2) {
+        constexpr index_t d0 = seq<Ds...>::at(number<0>{}), s0 = seq<Ss...>::at(number<0>{});
+        for (index_t i = 0; i < len; ++i) dst_c[d0 + i] = src_c[s0 + i];  // runtime loop avoids N-element fold instantiation
+    } else { ((dst_c[Ds] = src_c[Ss]), ...); }
 }
 }
 
@@ -1348,7 +1396,7 @@ namespace impl {
 // rocm-7.1.1, when there are multiple invokes of this kernel (across different __global__ in same compile target ?) will fail to inline below function
 template<typename D, typename S, index_t... Is, typename... Aux, std::enable_if_t<is_vector_v<S>, bool> = true>
 OPUS_D constexpr decltype(auto) cast_impl(const S& s, seq<Is...>, Aux&&... aux) {
-    return impl::vector_return_type<void, decltype(cast<D>(get<Is>(s), std::forward<Aux>(aux)...))...>{cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...}; }
+    return impl::vector_return_type<D, decltype(cast<D>(get<Is>(s), std::forward<Aux>(aux)...))...>{cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...}; }
     //return opus::make_vector(cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...); }
 template<typename D, typename S, index_t... Is, typename... Aux, std::enable_if_t<is_tuple_v<S>, bool> = true>
 OPUS_D constexpr decltype(auto) cast_impl(const S& s, seq<Is...>, Aux&&... aux) {
@@ -1374,6 +1422,8 @@ OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) {
                     return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<4>{}), make_index_seq<size<S>() / 4>{}, std::forward<Aux>(aux)...)); }
     else if constexpr (std::is_same_v<get_value_t<S>, fp8_t>  && size<S>() % 2 == 0 && std::is_same_v<D, fp32_t>) { // fp8 -> fp32, x2N
                     return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<2>{}), make_index_seq<size<S>() / 2>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (is_vector_v<S> && size<S>() > 16 && sizeof...(Aux) == 0) {
+        return __builtin_convertvector(s, vector_t<D, size<S>()>); }
     else   return impl::cast_impl<D>(s, make_index_seq<size<S>()>{}, std::forward<Aux>(aux)...); }
 
 // entry point for vectorized cast(), for dpacks
@@ -1446,6 +1496,29 @@ OPUS_H_D constexpr index_t get_smem_size()
     return 65536;   // 64KB
 #endif
 }
+
+// ---- Device intrinsic wrappers ----
+// Replace HIP runtime macros (threadIdx.x, __syncthreads, __all, etc.) so kernels compile
+// with just #include <opus/opus.hpp> — no <hip/hip_runtime.h> needed.
+OPUS_D index_t thread_id_x() { return __builtin_amdgcn_workitem_id_x(); }
+OPUS_D index_t thread_id_y() { return __builtin_amdgcn_workitem_id_y(); }
+OPUS_D index_t thread_id_z() { return __builtin_amdgcn_workitem_id_z(); }
+OPUS_D index_t block_id_x()  { return __builtin_amdgcn_workgroup_id_x(); }
+OPUS_D index_t block_id_y()  { return __builtin_amdgcn_workgroup_id_y(); }
+OPUS_D index_t block_id_z()  { return __builtin_amdgcn_workgroup_id_z(); }
+OPUS_D index_t block_size_x() { return __builtin_amdgcn_workgroup_size_x(); }
+OPUS_D index_t block_size_y() { return __builtin_amdgcn_workgroup_size_y(); }
+OPUS_D index_t block_size_z() { return __builtin_amdgcn_workgroup_size_z(); }
+OPUS_D index_t grid_size_x()  { return __builtin_amdgcn_grid_size_x(); }
+OPUS_D index_t grid_size_y()  { return __builtin_amdgcn_grid_size_y(); }
+OPUS_D index_t grid_size_z()  { return __builtin_amdgcn_grid_size_z(); }
+OPUS_D void    sync_threads() { __builtin_amdgcn_s_barrier(); }
+#if !defined(HIP_INCLUDE_HIP_AMD_DETAIL_DEVICE_LIBRARY_DECLS_H)
+extern "C" __device__ int __ockl_wfall_i32(int);
+#endif
+#if !defined(HIP_INCLUDE_HIP_AMD_DETAIL_WARP_FUNCTIONS_H)
+OPUS_D int     warp_all(int predicate) { return __ockl_wfall_i32(predicate); }
+#endif
 
 #if OPUS_ENABLE_RUNTIME_QUERY
 OPUS_H index_t query_warp_size() { int d; (void)hipGetDevice(&d); hipDeviceProp_t p; (void)hipGetDeviceProperties(&p, d); return static_cast<index_t>(p.warpSize); }
@@ -1630,23 +1703,20 @@ struct gmem {
     template<index_t vec = 1, typename Layout, index_t aux = 0, std::enable_if_t<is_layout_v<Layout>, bool> = true>
     OPUS_D auto load(const Layout& u, int s_os = 0/* do we really need this? */, number<aux> = {})
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-        constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
 
 #if OPUS_TILE_CONTAINER == 0
-        constexpr auto u_r = make_layout<-1>(issue_space);                      // we use this layout to describe the register layout
-        vector_t<scalar_type, vec * vector_size * r_elem.value> r;          // local scratch to host the loaded register, and return it
-        static_ford(issue_space_vec, [&](auto ... ids){
-            auto tmp = load<vec>(u(ids...), s_os, number<aux>{});
-            constexpr index_t u_rs = u_r(ids...);
-            set_slice(r, tmp, number<u_rs>{}, number<u_rs + vec>{});
-        });
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) {
+            auto tmp = load<vec>(offsets[i], s_os, number<aux>{});
+            for (index_t j = 0; j < vec * vector_size; j++) r[i * vec * vector_size + j] = tmp[j];
+        }
         return r;
 #elif OPUS_TILE_CONTAINER == 1
-        constexpr auto u_r = make_layout<-1>(issue_space_vec);                      // we use this layout to describe the register layout
-        array<vector_type<vec>, r_elem.value> r;                                      // local scratch to host the loaded register, and return it
-        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = load<vec>(u(ids...), s_os, number<aux>{}); }); // issue the loading instruction multiple times
+        array<vector_type<vec>, r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) r[i] = load<vec>(offsets[i], s_os, number<aux>{});
         return r;
 #endif
     }
@@ -1654,53 +1724,57 @@ struct gmem {
     template<index_t vec = 1, typename V, typename Layout, index_t aux = 0, std::enable_if_t<((is_array_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
     OPUS_D void store(const V& x, const Layout& u, int s_os = 0/* do we really need this? */, number<aux> = {})
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
 
-        constexpr auto u_r = make_layout<-1>(issue_space);                      // we use this layout to describe the register layout
 #if OPUS_TILE_CONTAINER == 0
         auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
-                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<get<0>(reduce_tuple_mul(issue_space)).value>{});
+                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<r_elem.value>{});
                          else if constexpr (is_vector_v<V>) return x; }();
 #elif OPUS_TILE_CONTAINER == 1
         auto a_ = to_array(x);
 #endif
-        static_ford(issue_space_vec, [&](auto ... ids){ // issue the loading instruction multiple times
-            auto v_ = slice(a_, number<u_r(ids...)>{}, number<u_r(ids...) + vec>{});
-            store<vec>(v_, u(ids...), s_os, number<aux>{});
-        });
+        for (index_t i = 0; i < r_elem.value; i++) {
+            vector_type<vec> v_;
+            for (index_t j = 0; j < vec * vector_size; j++) v_[j] = a_[i * vec * vector_size + j];
+            store<vec>(v_, offsets[i], s_os, number<aux>{});
+        }
     }
 
     template<index_t vec = 1, typename LayoutG, typename LayoutS, index_t aux = 0, std::enable_if_t<is_layout_v<LayoutG> && is_layout_v<LayoutS>, bool> = true>
     OPUS_D void async_load(void* smem_base, const LayoutG& u_gmem, const LayoutS& u_smem, int s_os = 0, number<aux> = {}) {
-        constexpr auto issue_space = layout_to_issue_space<LayoutG>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
+        using LT = layout_load_traits<LayoutG, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto gmem_offsets = layout_to_offsets<vec>(u_gmem);
+        auto smem_offsets = layout_to_offsets<vec>(u_smem);
         auto smem_ptr = reinterpret_cast<OPUS_LDS_ADDR scalar_type*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_base));
-        static_ford(issue_space_vec, [&](auto... ids) {
-            async_load<vec>(reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_ptr + u_smem(ids...))), u_gmem(ids...), s_os, number<aux>{});
-        });
+        for (index_t i = 0; i < r_elem.value; i++) {
+            async_load<vec>(reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_ptr + smem_offsets[i])), gmem_offsets[i], s_os, number<aux>{});
+        }
     }
 
     template<index_t vec = 1, typename Predicate, typename Layout, index_t aux = 0, std::enable_if_t<is_layout_v<Layout>, bool> = true>
     OPUS_D auto load_if(const Predicate& pred, const Layout& u, int s_os = 0, number<aux> = {})
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-        constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space = LT::issue_space;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
 
 #if OPUS_TILE_CONTAINER == 0
-        constexpr auto u_r = make_layout<-1>(issue_space);
         vector_t<scalar_type, vec * vector_size * r_elem.value> r;
         static_ford(issue_space_vec, [&](auto ... ids){
-            auto tmp = pred(ids...) ? load<vec>(u(ids...), s_os, number<aux>{}) : vector_type<vec>{0};
-            constexpr index_t u_rs = u_r(ids...);
-            set_slice(r, tmp, number<u_rs>{}, number<u_rs + vec>{});
+            constexpr index_t idx = u_r(ids...);
+            auto tmp = pred(ids...) ? load<vec>(offsets[idx], s_os, number<aux>{}) : vector_type<vec>{0};
+            set_slice(r, tmp, number<idx * vec>{}, number<(idx + 1) * vec>{});
         });
         return r;
 #elif OPUS_TILE_CONTAINER == 1
-        constexpr auto u_r = make_layout<-1>(issue_space_vec);
         array<vector_type<vec>, r_elem.value> r;
-        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? load<vec>(u(ids...), s_os, number<aux>{}) : vector_type<vec>{0}; }); // issue the loading instruction multiple times
+        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? load<vec>(offsets[u_r(ids...)], s_os, number<aux>{}) : vector_type<vec>{0}; });
         return r;
 #endif
     }
@@ -1708,10 +1782,12 @@ struct gmem {
     template<index_t vec = 1, typename Predicate, typename V, typename Layout, index_t aux = 0, std::enable_if_t<((is_array_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
     OPUS_D void store_if(const Predicate& pred, const V& x, const Layout& u, int s_os = 0, number<aux> = {})
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space = LT::issue_space;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        auto offsets = layout_to_offsets<vec>(u);
         constexpr auto u_r = make_layout<-1>(issue_space);
+
 #if OPUS_TILE_CONTAINER == 0
         auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
                          else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<get<0>(reduce_tuple_mul(issue_space)).value>{});
@@ -1721,25 +1797,30 @@ struct gmem {
 #endif
         static_ford(issue_space_vec, [&](auto ... ids){
             if (pred(ids...)) {
-                auto v_ = slice(a_, number<u_r(ids...)>{}, number<u_r(ids...) + vec>{});
-                store<vec>(v_, u(ids...), s_os, number<aux>{});
+                constexpr index_t idx = u_r(ids...);
+                auto v_ = slice(a_, number<idx>{}, number<idx + vec>{});
+                store<vec>(v_, offsets[make_layout<-1>(issue_space_vec)(ids...)], s_os, number<aux>{});
             }
         });
     }
 
     template<index_t vec = 1, typename Predicate, typename LayoutG, typename LayoutS, index_t aux = 0, std::enable_if_t<is_layout_v<LayoutG> && is_layout_v<LayoutS>, bool> = true>
     OPUS_D void async_load_if(const Predicate& pred, void* smem_base, const LayoutG& u_gmem, const LayoutS& u_smem, int s_os = 0, number<aux> = {}) {
-        constexpr auto issue_space = layout_to_issue_space<LayoutG>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
+        using LT = layout_load_traits<LayoutG, vec>;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        auto gmem_offsets = layout_to_offsets<vec>(u_gmem);
+        auto smem_offsets = layout_to_offsets<vec>(u_smem);
         auto smem_ptr = reinterpret_cast<OPUS_LDS_ADDR scalar_type*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_base));
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
 
         static_ford(issue_space_vec, [&](auto... ids) {
+            constexpr index_t idx = u_r(ids...);
             if (pred(ids...)) {
-                async_load<vec>(reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_ptr + u_smem(ids...))), u_gmem(ids...), s_os, number<aux>{});
+                async_load<vec>(reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_ptr + smem_offsets[idx])), gmem_offsets[idx], s_os, number<aux>{});
             } else {
                 using type = vector_type<vec>;
                 type z = {0};
-                *reinterpret_cast<OPUS_LDS_ADDR type*>(smem_ptr + u_smem(ids...)) = z;
+                *reinterpret_cast<OPUS_LDS_ADDR type*>(smem_ptr + smem_offsets[idx]) = z;
             }
         });
     }
@@ -1810,23 +1891,20 @@ struct smem {
     template<index_t vec = 1, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
     OPUS_D auto load(const Layout& u)
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-        constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
 
 #if OPUS_TILE_CONTAINER == 0
-        constexpr auto u_r = make_layout<-1>(issue_space);                      // we use this layout to describe the register layout
-        vector_t<scalar_type, vec * vector_size * r_elem.value> r;          // local scratch to host the loaded register, and return it
-        static_ford(issue_space_vec, [&](auto ... ids){
-            auto tmp = load<vec>(u(ids...));
-            constexpr index_t u_rs = u_r(ids...);
-            set_slice(r, tmp, number<u_rs>{}, number<u_rs + vec>{});
-        });
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) {
+            auto tmp = load<vec>(offsets[i]);
+            for (index_t j = 0; j < vec * vector_size; j++) r[i * vec * vector_size + j] = tmp[j];
+        }
         return r;
 #elif OPUS_TILE_CONTAINER == 1
-        constexpr auto u_r = make_layout<-1>(issue_space_vec);                      // we use this layout to describe the register layout
-        array<vector_type<vec>, r_elem.value> r;                                      // local scratch to host the loaded register, and return it
-        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = load<vec>(u(ids...)); }); // issue the loading instruction multiple times
+        array<vector_type<vec>, r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) r[i] = load<vec>(offsets[i]);
         return r;
 #endif
     }
@@ -1834,35 +1912,31 @@ struct smem {
     template<index_t vec = 1, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
     OPUS_D auto tr_load(const Layout& u)
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-        constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
         using L = remove_cvref_t<Layout>;
         constexpr bool use_imm = is_static_tuple_v<typename L::Shape> && is_static_tuple_v<typename L::Stride>;
-        [[maybe_unused]] const int base = u(transform_tuple([](auto) { return number<0>{}; }, issue_space_vec)) * sizeof(T);
+        [[maybe_unused]] const int base = u(transform_tuple([](auto) { return number<0>{}; }, LT::issue_space_vec)) * sizeof(T);
+        [[maybe_unused]] auto offsets = layout_to_offsets<vec>(u);
 
-        auto fn = [&](auto ... ids) {
+        auto do_load = [&](auto i) {
             if constexpr (use_imm) {
-                constexpr auto u_linear = make_layout<-1>(issue_space_vec);
-                constexpr auto offsets = layout_to_offsets<vec>(L(typename L::Shape{}, typename L::Stride{}, typename L::Coord{}));
-                constexpr int off = offsets[u_linear(ids...)] * sizeof(T);
+                using IMM = layout_imm_offsets<Layout, vec, true>;
+                constexpr int off = IMM::offsets[i.value] * sizeof(T);
                 if constexpr (off >= 0 && off <= 0xffff) { return _tr_load<vec, off>(base); }
             }
-            return tr_load<vec>(u(ids...));
+            return tr_load<vec>(offsets[i.value]);
         };
 
 #if OPUS_TILE_CONTAINER == 0
-        constexpr auto u_r = make_layout<-1>(issue_space);
         vector_t<scalar_type, vec * vector_size * r_elem.value> r;
-        static_ford(issue_space_vec, [&](auto ... ids){
-            constexpr index_t u_rs = u_r(ids...);
-            set_slice(r, fn(ids...), number<u_rs>{}, number<u_rs + vec>{});
+        static_for<r_elem.value>([&](auto i){
+            set_slice(r, do_load(i), number<i.value * vec>{}, number<(i.value + 1) * vec>{});
         });
         return r;
 #elif OPUS_TILE_CONTAINER == 1
-        constexpr auto u_r = make_layout<-1>(issue_space_vec);
         array<vector_type<vec>, r_elem.value> r;
-        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = fn(ids...); });
+        static_for<r_elem.value>([&](auto i){ r[i.value] = do_load(i); });
         return r;
 #endif
     }
@@ -1870,43 +1944,44 @@ struct smem {
     template<index_t vec = 1, typename V, typename Layout, std::enable_if_t<((is_array_v<V> || is_dtype_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
     OPUS_D void store(const V& x, const Layout& u)
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
 
-        constexpr auto u_r = make_layout<-1>(issue_space);                      // we use this layout to describe the register layout
 #if OPUS_TILE_CONTAINER == 0
         auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
-                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<get<0>(reduce_tuple_mul(issue_space)).value>{});
+                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<r_elem.value>{});
                          else if constexpr (is_vector_v<V>) return x; }();
 #elif OPUS_TILE_CONTAINER == 1
         auto a_ = to_array(x);
 #endif
-        static_ford(issue_space_vec, [&](auto ... ids){ // issue the loading instruction multiple times
-            auto v_ = slice(a_, number<u_r(ids...)>{}, number<u_r(ids...) + vec>{});
-            store<vec>(v_, u(ids...));
-        });
+        for (index_t i = 0; i < r_elem.value; i++) {
+            vector_type<vec> v_;
+            for (index_t j = 0; j < vec * vector_size; j++) v_[j] = a_[i * vec * vector_size + j];
+            store<vec>(v_, offsets[i]);
+        }
     }
 
     template<index_t vec = 1, typename Predicate, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
     OPUS_D auto load_if(const Predicate& pred, const Layout& u)
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-        constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
 
 #if OPUS_TILE_CONTAINER == 0
-        constexpr auto u_r = make_layout<-1>(issue_space);
         vector_t<scalar_type, vec * vector_size * r_elem.value> r;
         static_ford(issue_space_vec, [&](auto ... ids){
-            auto tmp = pred(ids...) ? load<vec>(u(ids...)) : vector_type<vec>{0};
-            constexpr index_t u_rs = u_r(ids...);
-            set_slice(r, tmp, number<u_rs>{}, number<u_rs + vec>{});
+            constexpr index_t idx = u_r(ids...);
+            auto tmp = pred(ids...) ? load<vec>(offsets[idx]) : vector_type<vec>{0};
+            set_slice(r, tmp, number<idx * vec>{}, number<(idx + 1) * vec>{});
         });
         return r;
 #elif OPUS_TILE_CONTAINER == 1
-        constexpr auto u_r = make_layout<-1>(issue_space_vec);
         array<vector_type<vec>, r_elem.value> r;
-        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? load<vec>(u(ids...)) : vector_type<vec>{0}; });
+        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? load<vec>(offsets[u_r(ids...)]) : vector_type<vec>{0}; });
         return r;
 #endif
     }
@@ -1914,23 +1989,23 @@ struct smem {
     template<index_t vec = 1, typename Predicate, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
     OPUS_D auto tr_load_if(const Predicate& pred, const Layout& u)
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-        constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
 
 #if OPUS_TILE_CONTAINER == 0
-        constexpr auto u_r = make_layout<-1>(issue_space);
         vector_t<scalar_type, vec * vector_size * r_elem.value> r;
         static_ford(issue_space_vec, [&](auto ... ids){
-            auto tmp = pred(ids...) ? tr_load<vec>(u(ids...)) : vector_type<vec>{0};
-            constexpr index_t u_rs = u_r(ids...);
-            set_slice(r, tmp, number<u_rs>{}, number<u_rs + vec>{});
+            constexpr index_t idx = u_r(ids...);
+            auto tmp = pred(ids...) ? tr_load<vec>(offsets[idx]) : vector_type<vec>{0};
+            set_slice(r, tmp, number<idx * vec>{}, number<(idx + 1) * vec>{});
         });
         return r;
 #elif OPUS_TILE_CONTAINER == 1
-        constexpr auto u_r = make_layout<-1>(issue_space_vec);
         array<vector_type<vec>, r_elem.value> r;
-        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? tr_load<vec>(u(ids...)) : vector_type<vec>{0}; });
+        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? tr_load<vec>(offsets[u_r(ids...)]) : vector_type<vec>{0}; });
         return r;
 #endif
     }
@@ -1938,10 +2013,12 @@ struct smem {
     template<index_t vec = 1, typename Predicate, typename V, typename Layout, std::enable_if_t<((is_array_v<V> || is_dtype_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
     OPUS_D void store_if(const Predicate& pred, const V& x, const Layout& u)
     {
-        constexpr auto issue_space = layout_to_issue_space<Layout>();
-        constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
-
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space = LT::issue_space;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        auto offsets = layout_to_offsets<vec>(u);
         constexpr auto u_r = make_layout<-1>(issue_space);
+
 #if OPUS_TILE_CONTAINER == 0
         auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
                          else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<get<0>(reduce_tuple_mul(issue_space)).value>{});
@@ -1951,8 +2028,9 @@ struct smem {
 #endif
         static_ford(issue_space_vec, [&](auto ... ids){
             if (pred(ids...)) {
-                auto v_ = slice(a_, number<u_r(ids...)>{}, number<u_r(ids...) + vec>{});
-                store<vec>(v_, u(ids...));
+                constexpr index_t idx = u_r(ids...);
+                auto v_ = slice(a_, number<idx>{}, number<idx + vec>{});
+                store<vec>(v_, offsets[make_layout<-1>(issue_space_vec)(ids...)]);
             }
         });
     }
@@ -2409,11 +2487,13 @@ struct p_dim {};
 struct y_dim {};
 
 namespace impl{ // utlity function to play with shape
+template<typename FDim, typename Target> static constexpr auto pickup_filter(seq<>) { return seq<>{}; }
+template<typename FDim, typename Target, index_t I0, index_t... Rest> static constexpr auto pickup_filter(seq<I0, Rest...>) {
+    if constexpr (std::is_same_v<remove_cvref_t<decltype(get<I0>(FDim{}))>, remove_cvref_t<Target>>) return concat_seq(seq<I0>{}, pickup_filter<FDim, Target>(seq<Rest...>{}));
+    else return pickup_filter<FDim, Target>(seq<Rest...>{}); }
+template<typename Shape, index_t... Fs> OPUS_D static constexpr auto pickup_shape_apply(seq<Fs...>) { return opus::make_tuple(get<Fs>(Shape{})...); }
 template<typename Shape, typename FDim, typename Target, index_t... Is>
-OPUS_D static constexpr auto pickup_shape_impl(const Shape&, const FDim&, Target, seq<Is...>) {
-    static_assert(size<Shape>() == size<FDim>());
-    return concat_tuple(std::conditional_t< std::is_same_v<decltype(get<Is>(FDim{})), remove_cvref_t<Target>>,  tuple<decltype(get<Is>(Shape{}))>,  tuple<> >{}...);
-}
+OPUS_D static constexpr auto pickup_shape_impl(const Shape&, const FDim&, Target, seq<Is...>) { static_assert(size<Shape>() == size<FDim>()); return pickup_shape_apply<Shape>(pickup_filter<FDim, Target>(seq<Is...>{})); }
 
 template<typename Dim, index_t... Js>
 OPUS_D constexpr index_t dim_group_size_sum(seq<Js...>) { return (static_cast<index_t>(get<Js>(Dim{}).size()) + ... + 0); }
@@ -2451,8 +2531,13 @@ OPUS_D constexpr auto unfold_x_stride_each(const Stride& stride) {
     return transform_tuple([&](auto i_elem){ return i_elem * get<I>(stride); }, current_stride);
 }
 
-template<typename Dim, typename Shape, typename Stride, index_t... Is>
-OPUS_D constexpr auto unfold_x_stride_impl(const Stride& stride, seq<Is...>) { return concat_tuple(unfold_x_stride_each<Dim, Shape, Stride, Is>(stride)...); }
+template<typename Dim, index_t J, index_t... Gs> constexpr index_t unfold_find_group(seq<Gs...>) {
+    index_t acc = 0, r = 0; ((void)(acc += size<decltype(get<Gs>(Dim{}))>(), (acc <= J ? (void)(r = Gs + 1) : (void)0)), ...); return r; }
+template<typename Dim, typename Shape, typename Stride, index_t J> OPUS_D constexpr auto unfold_x_stride_at(const Stride& stride) {
+    constexpr index_t G = unfold_find_group<Dim, J>(make_index_seq<size<Dim>()>{}); constexpr index_t group_end = dim_offset_sum<Dim>(make_index_seq<G + 1>{});
+    return packed_stride_at<Shape, J>(make_index_seq<group_end - J - 1>{}) * get<G>(stride); }
+template<typename Dim, typename Shape, typename Stride, index_t... Js> OPUS_D constexpr auto unfold_x_stride_flat(const Stride& stride, seq<Js...>) { return opus::make_tuple(unfold_x_stride_at<Dim, Shape, Stride, Js>(stride)...); }
+template<typename Dim, typename Shape, typename Stride, index_t... Is> OPUS_D constexpr auto unfold_x_stride_impl(const Stride& stride, seq<Is...>) { return unfold_x_stride_flat<Dim, Shape, Stride>(stride, make_index_seq<size<Shape>()>{}); }
 }
 
 template<typename Shape, typename Dim, typename Target>
@@ -2484,42 +2569,24 @@ OPUS_D constexpr auto unfold_x_stride(const Dim&, const Shape&, const Stride& st
 }
 
 #define OPUS_KP_(x_) static_assert(opus::tuple_count<opus::p_dim>(opus::flatten_tuple(x_ ())) == size<C>())
+// Per-axis layout API: generates y_shape_X, p_shape_X, layout_X (3 overloads), layout_X_packed, y_layout_X
+#define OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(X)                                                                                                                       \
+    OPUS_D static constexpr auto y_shape_##X() { return y_shape(shape_##X(), dim_##X()); }                                                                          \
+    OPUS_D static constexpr auto p_shape_##X() { return p_shape(shape_##X(), dim_##X()); }                                                                          \
+    template<index_t cached_vec = 0> OPUS_D constexpr auto layout_##X() { return make_layout<cached_vec>(shape_##X());}                                             \
+    template<index_t cached_vec = 0, typename S> OPUS_D constexpr auto layout_##X(S&& stride) { return make_layout<cached_vec>(shape_##X(), unfold_x_stride(dim_##X(), shape_##X(), stride));} \
+    template<index_t cached_vec = 0, typename S, typename C> OPUS_D constexpr auto layout_##X(S&& stride, C&& z) { OPUS_KP_(dim_##X); return make_layout<cached_vec>(shape_##X(), unfold_x_stride(dim_##X(), shape_##X(), stride), opus::unfold_p_coord(dim_##X(), z));}  \
+    template<index_t cached_vec = 0, typename C> OPUS_D constexpr auto layout_##X##_packed(C&& z) { OPUS_KP_(dim_##X); return make_layout_packed<cached_vec>(shape_##X(), opus::unfold_p_coord(dim_##X(), z));}   \
+    template<index_t cached_vec = 0, typename... Ts, std::enable_if_t<(!is_tuple_v<Ts> && ...), bool> = true> OPUS_D constexpr auto layout_##X(Ts&&... strides) {return layout_##X<cached_vec>(opus::make_tuple(strides...)); }  \
+    template<index_t cached_vec = 0> OPUS_D constexpr auto y_layout_##X() { return make_layout<cached_vec>(y_shape_##X());}
+
 // any struct implement adaptor like feature must implement(or using from base) shape_a/b/c, dim_a/b/c
 #define OPUS_ADAPTOR_LAYOUT_API_DEFINE                                                                                                                              \
     template<typename S, typename D> OPUS_D static constexpr auto y_shape(const S& /*shape*/, const D& /*dim*/) { return opus::pickup_shape(S{}, D{}, y_dim{}); }   \
     template<typename S, typename D> OPUS_D static constexpr auto p_shape(const S& /*shape*/, const D& /*dim*/) { return opus::pickup_shape(S{}, D{}, p_dim{}); }   \
-                                                                                               \
-    OPUS_D static constexpr auto y_shape_a() { return y_shape(shape_a(), dim_a()); }           \
-    OPUS_D static constexpr auto y_shape_b() { return y_shape(shape_b(), dim_b()); }           \
-    OPUS_D static constexpr auto y_shape_c() { return y_shape(shape_c(), dim_c()); }           \
-                                                                                               \
-    OPUS_D static constexpr auto p_shape_a() { return p_shape(shape_a(), dim_a()); }           \
-    OPUS_D static constexpr auto p_shape_b() { return p_shape(shape_b(), dim_b()); }           \
-    OPUS_D static constexpr auto p_shape_c() { return p_shape(shape_c(), dim_c()); }           \
-                                                                                               \
-    template<index_t cached_vec = 0> OPUS_D constexpr auto layout_a() { return make_layout<cached_vec>(shape_a());}                         \
-    template<index_t cached_vec = 0> OPUS_D constexpr auto layout_b() { return make_layout<cached_vec>(shape_b());}                         \
-    template<index_t cached_vec = 0> OPUS_D constexpr auto layout_c() { return make_layout<cached_vec>(shape_c());}                         \
-                                                                                                                                            \
-    template<index_t cached_vec = 0, typename S> OPUS_D constexpr auto layout_a(S&& stride) { return make_layout<cached_vec>(shape_a(), unfold_x_stride(dim_a(), shape_a(), stride));} \
-    template<index_t cached_vec = 0, typename S> OPUS_D constexpr auto layout_b(S&& stride) { return make_layout<cached_vec>(shape_b(), unfold_x_stride(dim_b(), shape_b(), stride));} \
-    template<index_t cached_vec = 0, typename S> OPUS_D constexpr auto layout_c(S&& stride) { return make_layout<cached_vec>(shape_c(), unfold_x_stride(dim_c(), shape_c(), stride));} \
-    /* Note, all the coord passed in must be p_coord*/                                                                                      \
-    template<index_t cached_vec = 0, typename S, typename C> OPUS_D constexpr auto layout_a(S&& stride, C&& z) { OPUS_KP_(dim_a); return make_layout<cached_vec>(shape_a(), unfold_x_stride(dim_a(), shape_a(), stride), opus::unfold_p_coord(dim_a(), z));}  \
-    template<index_t cached_vec = 0, typename S, typename C> OPUS_D constexpr auto layout_b(S&& stride, C&& z) { OPUS_KP_(dim_b); return make_layout<cached_vec>(shape_b(), unfold_x_stride(dim_b(), shape_b(), stride), opus::unfold_p_coord(dim_b(), z));}  \
-    template<index_t cached_vec = 0, typename S, typename C> OPUS_D constexpr auto layout_c(S&& stride, C&& z) { OPUS_KP_(dim_c); return make_layout<cached_vec>(shape_c(), unfold_x_stride(dim_c(), shape_c(), stride), opus::unfold_p_coord(dim_c(), z));}  \
-                                                                                                                                                                                                        \
-    template<index_t cached_vec = 0, typename C> OPUS_D constexpr auto layout_a_packed(C&& z) { OPUS_KP_(dim_a); return make_layout_packed<cached_vec>(shape_a(), opus::unfold_p_coord(dim_a(), z));}   \
-    template<index_t cached_vec = 0, typename C> OPUS_D constexpr auto layout_b_packed(C&& z) { OPUS_KP_(dim_b); return make_layout_packed<cached_vec>(shape_b(), opus::unfold_p_coord(dim_b(), z));}   \
-    template<index_t cached_vec = 0, typename C> OPUS_D constexpr auto layout_c_packed(C&& z) { OPUS_KP_(dim_c); return make_layout_packed<cached_vec>(shape_c(), opus::unfold_p_coord(dim_c(), z));}   \
-                                                                                                                                                                                                        \
-    template<index_t cached_vec = 0, typename... Ts, std::enable_if_t<(!is_tuple_v<Ts> && ...), bool> = true> OPUS_D constexpr auto layout_a(Ts&&... strides) {return layout_a<cached_vec>(opus::make_tuple(strides...)); }  \
-    template<index_t cached_vec = 0, typename... Ts, std::enable_if_t<(!is_tuple_v<Ts> && ...), bool> = true> OPUS_D constexpr auto layout_b(Ts&&... strides) {return layout_b<cached_vec>(opus::make_tuple(strides...)); }  \
-    template<index_t cached_vec = 0, typename... Ts, std::enable_if_t<(!is_tuple_v<Ts> && ...), bool> = true> OPUS_D constexpr auto layout_c(Ts&&... strides) {return layout_c<cached_vec>(opus::make_tuple(strides...)); }  \
-                                                                                                                                    \
-    template<index_t cached_vec = 0> OPUS_D constexpr auto y_layout_a() { return make_layout<cached_vec>(y_shape_a());}             \
-    template<index_t cached_vec = 0> OPUS_D constexpr auto y_layout_b() { return make_layout<cached_vec>(y_shape_b());}             \
-    template<index_t cached_vec = 0> OPUS_D constexpr auto y_layout_c() { return make_layout<cached_vec>(y_shape_c());}
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(a)                                                                                                                           \
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(b)                                                                                                                           \
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(c)
 
 // Note: any class to support adaptor need include OPUS_ADAPTOR_LAYOUT_API_DEFINE and implement shape_a()/shape_b()/shape_c()
 // P indicates dim cross thread, Y indicates dim within thread, this is X layout (X=P+Y) view the tensor as a whole
@@ -2572,9 +2639,13 @@ struct mfma_adaptor : public remove_cvref_t<MFMA> {
 template<typename MFMA>
 struct mfma_adaptor_swap_ab : mfma_adaptor<MFMA> {
     using base = mfma_adaptor<MFMA>;
-    using base::shape_a; using base::shape_b; using base::dim_a; using base::dim_b;
+    using base::shape_a; using base::shape_b; using base::dim_a; using base::dim_b; using base::y_shape; using base::p_shape;
+    using base::y_shape_a; using base::y_shape_b; using base::p_shape_a; using base::p_shape_b;
+    using base::layout_a; using base::layout_b; using base::layout_a_packed; using base::layout_b_packed; using base::y_layout_a; using base::y_layout_b;
     OPUS_D static constexpr auto shape_c() { return tuple<number<base::grpn_c>, number<base::rept_c>, number<base::grpm_c>, number<base::pack_c>>{}; }
     OPUS_D static constexpr auto dim_c()   { return tuple<tuple<p_dim>,  tuple<y_dim, p_dim, y_dim> >{}; }    // dim encoding for C, MxN
+    // Only generate _c layout methods (shape_c/dim_c changed)
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(c)
 
     template<typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0>
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
@@ -2595,8 +2666,6 @@ struct mfma_adaptor_swap_ab : mfma_adaptor<MFMA> {
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, int scale_a, int scale_b) {
         typename MFMA::vtype_c c{0}; return operator()(a, b, c, scale_a, scale_b);
     }
-
-    OPUS_ADAPTOR_LAYOUT_API_DEFINE
 };
 }
 // helper class to create adaptor instance for mfma, need be paired with make_mfma(). don't directly use it
@@ -2654,9 +2723,13 @@ struct wmma_adaptor : public remove_cvref_t<WMMA> {
 template<typename WMMA>
 struct wmma_adaptor_swap_ab : wmma_adaptor<WMMA> {
     using base = wmma_adaptor<WMMA>;
-    using base::shape_a; using base::shape_b; using base::dim_a; using base::dim_b;
+    using base::shape_a; using base::shape_b; using base::dim_a; using base::dim_b; using base::y_shape; using base::p_shape;
+    using base::y_shape_a; using base::y_shape_b; using base::p_shape_a; using base::p_shape_b;
+    using base::layout_a; using base::layout_b; using base::layout_a_packed; using base::layout_b_packed; using base::y_layout_a; using base::y_layout_b;
     OPUS_D static constexpr auto shape_c() { return tuple<number<base::grpn_c>, number<base::grpm_c>, number<base::rept_c>, number<base::pack_c>>{}; }
     OPUS_D static constexpr auto dim_c()   { return tuple<tuple<p_dim>,  tuple<p_dim, y_dim, y_dim> >{}; }
+    // Only generate _c layout methods (shape_c/dim_c changed)
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(c)
 
     template<typename VA, typename VB, typename VC>
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c) {
@@ -2678,8 +2751,6 @@ struct wmma_adaptor_swap_ab : wmma_adaptor<WMMA> {
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, long scale_a, long scale_b) {
         return base::operator()(b, a, c, scale_a, scale_b);
     }
-
-    OPUS_ADAPTOR_LAYOUT_API_DEFINE
 };
 } // namespace impl (wmma_adaptor)
 
@@ -2733,42 +2804,45 @@ struct tiled_mma_adaptor : public MMA_ {
     OPUS_D static constexpr auto dim_b()   { return embed_nested_tuple(tile_dim_b(), MMA::dim_b()); }    // dim encoding for A, MxK
     OPUS_D static constexpr auto dim_c()   { return embed_nested_tuple(tile_dim_c(), MMA::dim_c()); }    // dim encoding for A, MxK
 
+    // Cached tile sizes (avoids re-evaluating y_shape + reduce_tuple_mul in every operator/step_k)
+    static constexpr index_t mma_a_len = get<0>(reduce_tuple_mul(MMA::y_shape_a())).value;
+    static constexpr index_t mma_b_len = get<0>(reduce_tuple_mul(MMA::y_shape_b())).value;
+    static constexpr index_t mma_c_len = get<0>(reduce_tuple_mul(MMA::y_shape_c())).value;
+    static constexpr index_t tile_a_len = EXPAND_M * EXPAND_K * mma_a_len;
+    static constexpr index_t tile_b_len = EXPAND_N * EXPAND_K * mma_b_len;
+    static constexpr index_t tile_c_len = EXPAND_M * EXPAND_N * mma_c_len;
+
     // input a/b/c is array of ext type e.g. "fp16x2_t a[2];", pass "a" to this function
     template<typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0,
                     std::enable_if_t< (is_array_v< remove_cvref_t<VA> > && is_array_v< remove_cvref_t<VB> > && is_array_v< remove_cvref_t<VC> >), bool > = true>
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
         VC c_ {c};
-        static_ford<EXPAND_K, EXPAND_M, EXPAND_N>([&](auto i_k, auto i_m, auto i_n){
-            auto s_a = a[i_m * EXPAND_K + i_k];
-            auto s_b = b[i_n * EXPAND_K + i_k];
-            auto s_c = c_[i_m * EXPAND_N + i_n];
-            s_c = MMA{}(s_a, s_b, s_c);
-            c_[i_m * EXPAND_N + i_n] = s_c;
-        });
+        for (index_t I = 0; I < EXPAND_K * EXPAND_M * EXPAND_N; I++) {
+            index_t i_k = I / (EXPAND_M * EXPAND_N), i_m = (I / EXPAND_N) % EXPAND_M, i_n = I % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + i_k]; auto s_b = b[i_n * EXPAND_K + i_k]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c); c_[i_m * EXPAND_N + i_n] = s_c;
+        }
         return c_;
     }
     template<typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0,
                     std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
-        static_assert(size<VA>() == get<0>(reduce_tuple_mul(y_shape_a())));
-        static_assert(size<VB>() == get<0>(reduce_tuple_mul(y_shape_b())));
-        static_assert(size<VC>() == get<0>(reduce_tuple_mul(y_shape_c())));
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
 
-        constexpr auto a_len = get<0>(reduce_tuple_mul(MMA::y_shape_a()));
-        constexpr auto b_len = get<0>(reduce_tuple_mul(MMA::y_shape_b()));
-        constexpr auto c_len = get<0>(reduce_tuple_mul(MMA::y_shape_c()));
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
 
         VC c_ {c};
-        static_ford<EXPAND_K, EXPAND_M, EXPAND_N>([&](auto i_k, auto i_m, auto i_n){
-            constexpr index_t i_tile_a = i_m * EXPAND_K + i_k;
-            constexpr index_t i_tile_b = i_n * EXPAND_K + i_k;
-            constexpr index_t i_tile_c = i_m * EXPAND_N + i_n;
-            auto s_a = slice(a, number<i_tile_a * a_len>{}, number<i_tile_a * a_len + a_len>{});
-            auto s_b = slice(b, number<i_tile_b * b_len>{}, number<i_tile_b * b_len + b_len>{});
-            auto s_c = slice(c_, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
+        for (index_t I = 0; I < EXPAND_K * EXPAND_M * EXPAND_N; I++) {
+            index_t i_k = I / (EXPAND_M * EXPAND_N), i_m = (I / EXPAND_N) % EXPAND_M, i_n = I % EXPAND_N;
+            index_t i_a = (i_m * EXPAND_K + i_k) * a_len, i_b = (i_n * EXPAND_K + i_k) * b_len, i_c = (i_m * EXPAND_N + i_n) * c_len;
+            typename MMA::vtype_a s_a; for (index_t j = 0; j < a_len; j++) s_a[j] = a[i_a + j];
+            typename MMA::vtype_b s_b; for (index_t j = 0; j < b_len; j++) s_b[j] = b[i_b + j];
+            typename MMA::vtype_c s_c; for (index_t j = 0; j < c_len; j++) s_c[j] = c_[i_c + j];
             s_c = MMA{}(s_a, s_b, s_c);
-            set_slice(c_, s_c, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
-        });
+            for (index_t j = 0; j < c_len; j++) c_[i_c + j] = s_c[j];
+        }
         return c_;
     }
 
@@ -2783,26 +2857,22 @@ struct tiled_mma_adaptor : public MMA_ {
              std::enable_if_t< (is_array_v< remove_cvref_t<VA> > && is_array_v< remove_cvref_t<VB> > && is_array_v< remove_cvref_t<VC> >), bool > = true>
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, int scale_a, int scale_b) {
         VC c_ {c};
-        static_ford<EXPAND_K, EXPAND_M, EXPAND_N>([&](auto i_k, auto i_m, auto i_n){
-            auto s_a = a[i_m * EXPAND_K + i_k];
-            auto s_b = b[i_n * EXPAND_K + i_k];
-            auto s_c = c_[i_m * EXPAND_N + i_n];
-            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b);
-            c_[i_m * EXPAND_N + i_n] = s_c;
-        });
+        for (index_t I = 0; I < EXPAND_K * EXPAND_M * EXPAND_N; I++) {
+            index_t i_k = I / (EXPAND_M * EXPAND_N), i_m = (I / EXPAND_N) % EXPAND_M, i_n = I % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + i_k]; auto s_b = b[i_n * EXPAND_K + i_k]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b); c_[i_m * EXPAND_N + i_n] = s_c;
+        }
         return c_;
     }
 
     template<typename VA, typename VB, typename VC,
              std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
     OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, int scale_a, int scale_b) {
-        static_assert(size<VA>() == get<0>(reduce_tuple_mul(y_shape_a())));
-        static_assert(size<VB>() == get<0>(reduce_tuple_mul(y_shape_b())));
-        static_assert(size<VC>() == get<0>(reduce_tuple_mul(y_shape_c())));
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
 
-        constexpr auto a_len = get<0>(reduce_tuple_mul(MMA::y_shape_a()));
-        constexpr auto b_len = get<0>(reduce_tuple_mul(MMA::y_shape_b()));
-        constexpr auto c_len = get<0>(reduce_tuple_mul(MMA::y_shape_c()));
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
 
         VC c_ {c};
         static_ford<EXPAND_K, EXPAND_M, EXPAND_N>([&](auto i_k, auto i_m, auto i_n){
@@ -2828,12 +2898,10 @@ struct tiled_mma_adaptor : public MMA_ {
     OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
         static_assert(STEP_K < EXPAND_K);
         VC c_ {c};
-        static_ford<EXPAND_M, EXPAND_N>([&](auto i_m, auto i_n){
-            auto s_a = a[i_m * EXPAND_K + STEP_K];
-            auto s_b = b[i_n * EXPAND_K + STEP_K];
-            auto s_c = c_[i_m * EXPAND_N + i_n];
-            s_c = MMA{}(s_a, s_b, s_c);
-            c_[i_m * EXPAND_N + i_n] = s_c;
+        static_for<EXPAND_M * EXPAND_N>([&](auto I){
+            constexpr index_t i_m = I.value / EXPAND_N, i_n = I.value % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + STEP_K]; auto s_b = b[i_n * EXPAND_K + STEP_K]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c); c_[i_m * EXPAND_N + i_n] = s_c;
         });
         return c_;
     }
@@ -2842,25 +2910,22 @@ struct tiled_mma_adaptor : public MMA_ {
                     std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
     OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
         static_assert(STEP_K < EXPAND_K);
-        static_assert(size<VA>() == get<0>(reduce_tuple_mul(y_shape_a())));
-        static_assert(size<VB>() == get<0>(reduce_tuple_mul(y_shape_b())));
-        static_assert(size<VC>() == get<0>(reduce_tuple_mul(y_shape_c())));
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
 
-        constexpr auto a_len = get<0>(reduce_tuple_mul(MMA::y_shape_a()));
-        constexpr auto b_len = get<0>(reduce_tuple_mul(MMA::y_shape_b()));
-        constexpr auto c_len = get<0>(reduce_tuple_mul(MMA::y_shape_c()));
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
 
         VC c_ {c};
-        static_ford<EXPAND_M, EXPAND_N>([&](auto i_m, auto i_n){
-            constexpr index_t i_tile_a = i_m * EXPAND_K + STEP_K;
-            constexpr index_t i_tile_b = i_n * EXPAND_K + STEP_K;
-            constexpr index_t i_tile_c = i_m * EXPAND_N + i_n;
-            auto s_a = slice(a, number<i_tile_a * a_len>{}, number<i_tile_a * a_len + a_len>{});
-            auto s_b = slice(b, number<i_tile_b * b_len>{}, number<i_tile_b * b_len + b_len>{});
-            auto s_c = slice(c_, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
+        for (index_t I = 0; I < EXPAND_M * EXPAND_N; I++) {
+            index_t i_m = I / EXPAND_N, i_n = I % EXPAND_N;
+            index_t i_a = (i_m * EXPAND_K + STEP_K) * a_len, i_b = (i_n * EXPAND_K + STEP_K) * b_len, i_c = (i_m * EXPAND_N + i_n) * c_len;
+            typename MMA::vtype_a s_a; for (index_t j = 0; j < a_len; j++) s_a[j] = a[i_a + j];
+            typename MMA::vtype_b s_b; for (index_t j = 0; j < b_len; j++) s_b[j] = b[i_b + j];
+            typename MMA::vtype_c s_c; for (index_t j = 0; j < c_len; j++) s_c[j] = c_[i_c + j];
             s_c = MMA{}(s_a, s_b, s_c);
-            set_slice(c_, s_c, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
-        });
+            for (index_t j = 0; j < c_len; j++) c_[i_c + j] = s_c[j];
+        }
         return c_;
     }
 
@@ -2875,13 +2940,11 @@ struct tiled_mma_adaptor : public MMA_ {
     OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, int scale_a, int scale_b) {
         static_assert(STEP_K < EXPAND_K);
         VC c_ {c};
-        static_ford<EXPAND_M, EXPAND_N>([&](auto i_m, auto i_n){
-            auto s_a = a[i_m * EXPAND_K + STEP_K];
-            auto s_b = b[i_n * EXPAND_K + STEP_K];
-            auto s_c = c_[i_m * EXPAND_N + i_n];
-            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b);
-            c_[i_m * EXPAND_N + i_n] = s_c;
-        });
+        for (index_t I = 0; I < EXPAND_M * EXPAND_N; I++) {
+            index_t i_m = I / EXPAND_N, i_n = I % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + STEP_K]; auto s_b = b[i_n * EXPAND_K + STEP_K]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b); c_[i_m * EXPAND_N + i_n] = s_c;
+        }
         return c_;
     }
 
@@ -2889,25 +2952,22 @@ struct tiled_mma_adaptor : public MMA_ {
              std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
     OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, int scale_a, int scale_b) {
         static_assert(STEP_K < EXPAND_K);
-        static_assert(size<VA>() == get<0>(reduce_tuple_mul(y_shape_a())));
-        static_assert(size<VB>() == get<0>(reduce_tuple_mul(y_shape_b())));
-        static_assert(size<VC>() == get<0>(reduce_tuple_mul(y_shape_c())));
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
 
-        constexpr auto a_len = get<0>(reduce_tuple_mul(MMA::y_shape_a()));
-        constexpr auto b_len = get<0>(reduce_tuple_mul(MMA::y_shape_b()));
-        constexpr auto c_len = get<0>(reduce_tuple_mul(MMA::y_shape_c()));
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
 
         VC c_ {c};
-        static_ford<EXPAND_M, EXPAND_N>([&](auto i_m, auto i_n){
-            constexpr index_t i_tile_a = i_m * EXPAND_K + STEP_K;
-            constexpr index_t i_tile_b = i_n * EXPAND_K + STEP_K;
-            constexpr index_t i_tile_c = i_m * EXPAND_N + i_n;
-            auto s_a = slice(a, number<i_tile_a * a_len>{}, number<i_tile_a * a_len + a_len>{});
-            auto s_b = slice(b, number<i_tile_b * b_len>{}, number<i_tile_b * b_len + b_len>{});
-            auto s_c = slice(c_, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
+        for (index_t I = 0; I < EXPAND_M * EXPAND_N; I++) {
+            index_t i_m = I / EXPAND_N, i_n = I % EXPAND_N;
+            index_t i_a = (i_m * EXPAND_K + STEP_K) * a_len, i_b = (i_n * EXPAND_K + STEP_K) * b_len, i_c = (i_m * EXPAND_N + i_n) * c_len;
+            typename MMA::vtype_a s_a; for (index_t j = 0; j < a_len; j++) s_a[j] = a[i_a + j];
+            typename MMA::vtype_b s_b; for (index_t j = 0; j < b_len; j++) s_b[j] = b[i_b + j];
+            typename MMA::vtype_c s_c; for (index_t j = 0; j < c_len; j++) s_c[j] = c_[i_c + j];
             s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b);
-            set_slice(c_, s_c, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
-        });
+            for (index_t j = 0; j < c_len; j++) c_[i_c + j] = s_c[j];
+        }
         return c_;
     }
 

--- a/op_tests/opus/README.md
+++ b/op_tests/opus/README.md
@@ -15,6 +15,9 @@ op_tests/opus/
 │   ├── test_mfma_f32.cu         # MFMA fp32 kernels
 │   ├── test_mfma_f8.cu          # MFMA fp8/bf8 kernels
 │   ├── test_mxfp.cu             # MXFP8/MXFP4 kernels (gfx950 only)
+│   ├── test_wmma_f16.cu         # WMMA fp16/bf16 kernels (gfx1250 only)
+│   ├── test_wmma_f32.cu         # WMMA fp32 kernels (gfx1250 only)
+│   ├── test_wmma_f8.cu          # WMMA fp8/bf8 kernels (gfx1250 only)
 │   ├── test_wmma_scale.cu       # WMMA scaled f8f6f4/f4 kernels (gfx1250 only)
 │   ├── test_mma_step_k.cu       # tiled_mma_adaptor::step_k bf16 kernel
 │   ├── test_vector_add.cu       # Vector addition kernel
@@ -26,7 +29,7 @@ op_tests/opus/
 │   ├── test_finfo.cu            # opus::finfo kernel
 │   ├── test_mdiv.cu             # opus::magic_div kernel
 │   ├── test_workgroup_barrier.cu# Workgroup barrier kernel
-│   ├── setup.py                 # Parallel hipcc build: 17 .cu -> .o -> .so
+│   ├── setup.py                 # Parallel hipcc build: 18 .cu -> .o -> .so
 │   └── test_opus_device.py      # Python test runner (builds .so, runs all tests)
 ├── run_tests.sh                 # Runs host test + device tests
 └── README.md
@@ -61,7 +64,7 @@ The device test build applies several techniques from the OPUS best-practices gu
 | 2 | Parallel compilation (each .cu -> .o, then link) | 3,950 ms | ~9 s | 4.7x |
 | 3 | Split `test_mfma.cu` into 3 files (f16/f32/f8) | 2,670 ms | ~8 s | 6.9x |
 | 4 | Add `-D__HIPCC_RTC__` to reduce device-pass header parsing | 2,070 ms | ~7.5 s | 8.9x |
-| 5 | Replace `<hip/hip_runtime.h>` with `hip_host_minimal.h` | **1,740 ms** | **~6.9 s** | **10.5x** |
+| 5 | Replace `<hip/hip_runtime.h>` with `opus/hip_minimal.hpp` | **1,740 ms** | **~6.9 s** | **10.5x** |
 
 ### What each optimization does
 
@@ -83,7 +86,7 @@ The device test build applies several techniques from the OPUS best-practices gu
    needed for runtime compilation, reducing preprocessing load on both host and device
    passes. Saves ~500ms per file on header parsing.
 
-5. **`hip_host_minimal.h`** — A ~70-line header (`csrc/include/hip_host_minimal.h`) that
+5. **`opus/hip_minimal.hpp`** — A ~70-line header (`csrc/include/opus/hip_minimal.hpp`) that
    declares only the dozen HIP APIs the host launcher code actually uses (`dim3`,
    `hipLaunchKernelGGL`, `hipMalloc`, `hipDeviceSynchronize`, etc.), replacing
    `<hip/hip_runtime.h>` (~100K preprocessed lines) on the host pass. Combined with
@@ -95,47 +98,47 @@ The device test build applies several techniques from the OPUS best-practices gu
 Measured on MI355 (gfx950) with ROCm 7.1.1:
 
 ```
-real    0m4.1s      (wall clock)
-user    0m12.9s     (CPU time, summed across parallel hipcc jobs)
-sys     0m2.3s
-
 Phase                              Time
 ────────────────────────────────  ──────
-Host build (hipcc test_opus_basic)  1,400 ms
+Host build (hipcc test_opus_basic)    738 ms
 Host run (13 unit tests)               12 ms
-Device .so build (16 .cu, parallel)   921 ms
-  compile (16 parallel jobs)           887 ms
-  link (.o -> .so)                      34 ms
+Device .so build (18 .cu, parallel)   625 ms
+  compile (18 parallel jobs)           599 ms
+  link (.o -> .so)                      25 ms
 Device tests (torch import + GPU)   1,800 ms
   torch import + .so build              ~800 ms
   kernel execution (60+ tests)        ~1,000 ms
 ────────────────────────────────  ──────
-Total wall clock                    ~4.1 s
+Total wall clock                    ~3.2 s
 ```
 
-On MI308 (gfx942) with ROCm 6.3: compile 1,694ms, total ~6.6s.
-
-### Per-file device compile times (MI355 / gfx950, 16 parallel jobs)
+### Per-file device compile times (MI355 / gfx950, 18 parallel jobs)
 
 ```
-test_finfo.cu              128 ms
-test_async_load.cu         128 ms
-test_vector_add.cu         131 ms
-test_numeric_limits.cu     139 ms
-test_workgroup_barrier.cu  149 ms
-test_wmma_f16.cu           162 ms
-test_wmma_f32.cu           163 ms
-test_mdiv.cu               165 ms
+test_async_load.cu         119 ms
+test_finfo.cu              124 ms
+test_vector_add.cu         125 ms
+test_numeric_limits.cu     128 ms
+test_workgroup_barrier.cu  139 ms
+test_wmma_f16.cu           152 ms
+test_wmma_f32.cu           156 ms
+test_mdiv.cu               161 ms
+test_wmma_f8.cu            165 ms
 test_wmma_scale.cu         172 ms
-test_wmma_f8.cu            173 ms
-test_load_store_if.cu      224 ms
-test_mxfp.cu               226 ms
-test_dtype_convert.cu      287 ms
-test_mfma_f32.cu           763 ms
-test_mfma_f8.cu            852 ms
-test_mfma_f16.cu           875 ms  <-- critical path
-link                        34 ms
+test_load_store_if.cu      187 ms
+test_mxfp.cu               214 ms
+test_dtype_convert.cu      282 ms
+test_mma_step_k.cu         421 ms
+test_tr_load_f16.cu        434 ms
+test_mfma_f32.cu           522 ms
+test_mfma_f8.cu            572 ms
+test_mfma_f16.cu           587 ms  <-- critical path
+link                        25 ms
 ```
+
+Before opus.hpp compile-time optimizations, the MFMA-heavy files took 750-890ms each
+(930ms total parallel build). The optimizations reduced these by 1.3-2.1x, bringing
+the parallel build from 930ms to 625ms (33% faster).
 
 ## How to add a new device test
 
@@ -161,8 +164,8 @@ __global__ void my_kernel(const float* in, float* out, int n) {
 
 #else
 // ── Host pass: minimal HIP header for kernel launch API ──
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by opus/hip_minimal.hpp for faster builds
+#include "opus/hip_minimal.hpp"
 
 __global__ void my_kernel(const float* in, float* out, int n);
 
@@ -243,6 +246,7 @@ In `device/test_opus_device.py`:
 | `test_dtype_convert` | fp32<->fp4 x4 pk | `cast<fp4_t>(fp32x4_t)` packed x4, e2m1 | gfx950 |
 | `test_dtype_convert` | fp32<->fp4 x8 pk | `cast<fp4_t>(fp32x8_t)` packed x8, e2m1 | gfx950 |
 | `test_load_store_if` | predicated_copy | `gmem::load_if`, `gmem::store_if`, free functions `opus::load_if`/`opus::store_if`, `layout_linear::operator+` | all |
+| `test_load_store_if` | predicated_copy_2d | 2D layout `load_if`/`store_if` with multi-index `(i_row, i_col)` predicate, `unfold_x_stride`, `unfold_p_coord` | all |
 | `test_load_store_if` | free_func_vector_add | Free functions `opus::load`/`opus::store`, `is_gmem_v`/`is_mem_v` type traits | all |
 | `test_load_store_if` | predicated_async_load | `gmem::async_load_if`, free function `opus::async_load_if`, `layout_linear::operator+` | all |
 | `test_numeric_limits` | all types | `opus::numeric_limits<T>` for fp32/fp16/bf16/fp8/bf8/i32/i16/i8/u8 | all |
@@ -258,7 +262,7 @@ In `device/test_opus_device.py`:
 | `test_mma_step_k` | 32x32x128 bf16 step_k | `make_tiled_mma`, `step_k` | gfx942 + gfx950 |
 | `test_workgroup_barrier` | cumulative + streamk | `opus::workgroup_barrier` cross-workgroup synchronization | all |
 
-Total: **60+ test calls** (14 MFMA + 4 MXFP + 11 WMMA + 10 WMMA-scale + 1 mma_step_k + 1 vector_add + 1 async_load + 1 tr_load + 11 dtype_convert + 3 load_store_if + 9 numeric_limits + 7 finfo + 11 mdiv + 4 workgroup_barrier).
+Total: **60+ test calls** (14 MFMA + 4 MXFP + 11 WMMA + 10 WMMA-scale + 1 mma_step_k + 1 vector_add + 1 async_load + 1 tr_load + 11 dtype_convert + 4 load_store_if + 9 numeric_limits + 7 finfo + 11 mdiv + 4 workgroup_barrier).
 
 ## Notes
 

--- a/op_tests/opus/device/test_async_load.cu
+++ b/op_tests/opus/device/test_async_load.cu
@@ -46,8 +46,8 @@ template __global__ void async_load_kernel<256>(const float*, float*, int);
 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_dtype_convert.cu
+++ b/op_tests/opus/device/test_dtype_convert.cu
@@ -28,8 +28,8 @@
 
 #include "opus/opus.hpp"
 #ifndef __HIP_DEVICE_COMPILE__
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #endif
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/op_tests/opus/device/test_finfo.cu
+++ b/op_tests/opus/device/test_finfo.cu
@@ -33,7 +33,7 @@ __global__ void finfo_kernel(float* out) {
 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
-#include "hip_host_minimal.h"
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 namespace {

--- a/op_tests/opus/device/test_load_store_if.cu
+++ b/op_tests/opus/device/test_load_store_if.cu
@@ -97,14 +97,46 @@ __global__ void predicated_async_load_kernel(const float* __restrict__ src,
     dst[gid] = smem_buf[tid];
 }
 
+// 2D predicated copy: layout shape = (ROWS, COLS), predicate receives multi-index (i_row, i_col)
+// Tests that _if methods pass multi-index to predicates, not flat index
+template<int BLOCK_SIZE, int ROWS, int COLS>
+__global__ void predicated_copy_2d_kernel(const float* __restrict__ src,
+                                           float* __restrict__ dst,
+                                           int actual_rows, int actual_cols, int stride)
+{
+    using namespace opus;
+    int tid = __builtin_amdgcn_workitem_id_x();
+    int wg  = __builtin_amdgcn_workgroup_id_x();
+    int base_row = wg * ROWS;
+
+    auto g_src = make_gmem(src);
+    auto g_dst = make_gmem(dst);
+
+    // 2D shape: (ROWS, COLS) with y_dim for both — issue space will be (ROWS, COLS)
+    constexpr auto shape = opus::make_tuple(number<ROWS>{}, number<COLS>{});
+    constexpr auto dim   = opus::make_tuple(opus::make_tuple(y_dim{}), opus::make_tuple(y_dim{}));
+    auto u = make_layout(shape,
+        unfold_x_stride(dim, shape, opus::tuple{stride, 1_I}),
+        unfold_p_coord(dim, opus::tuple{})) + (base_row * stride + tid * COLS);
+
+    // 2D predicate: receives (i_row, i_col) multi-index, checks row/col bounds
+    auto pred = [&](auto i_row, auto i_col) -> bool {
+        return (base_row + i_row.value) < actual_rows && (tid * COLS + i_col.value) < actual_cols;
+    };
+
+    auto data = load_if(g_src, pred, u);
+    store_if(g_dst, pred, data, u);
+}
+
 template __global__ void predicated_copy_kernel<256, 4>(const float*, float*, int);
 template __global__ void free_func_add_kernel<256, 4>(const float*, const float*, float*, int);
 template __global__ void predicated_async_load_kernel<256>(const float*, float*, int, int);
+template __global__ void predicated_copy_2d_kernel<256, 4, 4>(const float*, float*, int, int, int);
 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \
@@ -128,6 +160,30 @@ template<int BLOCK_SIZE>
 __global__ void predicated_async_load_kernel(const float* __restrict__ src,
                                               float* __restrict__ dst,
                                               int n, int n_padded) {}
+
+template<int BLOCK_SIZE, int ROWS, int COLS>
+__global__ void predicated_copy_2d_kernel(const float* __restrict__ src,
+                                           float* __restrict__ dst,
+                                           int actual_rows, int actual_cols, int stride) {}
+
+extern "C" void run_predicated_copy_2d(const void* d_src, void* d_dst,
+                                        int actual_rows, int actual_cols,
+                                        int total_rows, int stride)
+{
+    constexpr int BLOCK_SIZE = 256;
+    constexpr int ROWS = 4;
+    constexpr int COLS = 4;
+    int blocks = (total_rows + ROWS - 1) / ROWS;
+
+    hipLaunchKernelGGL(
+        (predicated_copy_2d_kernel<BLOCK_SIZE, ROWS, COLS>),
+        dim3(blocks), dim3(BLOCK_SIZE), 0, 0,
+        static_cast<const float*>(d_src),
+        static_cast<float*>(d_dst),
+        actual_rows, actual_cols, stride);
+    HIP_CALL(hipGetLastError());
+    HIP_CALL(hipDeviceSynchronize());
+}
 
 extern "C" void run_predicated_copy(const void* d_src, void* d_dst, int n)
 {

--- a/op_tests/opus/device/test_mdiv.cu
+++ b/op_tests/opus/device/test_mdiv.cu
@@ -26,8 +26,8 @@ __global__ void mdiv_kernel(const unsigned int* __restrict__ dividends,
 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 #include "opus/opus.hpp"
 using namespace opus;

--- a/op_tests/opus/device/test_mfma_f16.cu
+++ b/op_tests/opus/device/test_mfma_f16.cu
@@ -102,8 +102,8 @@ template __global__ void mfma_kernel_generic<opus::bf16_t, opus::bf16_t, 16, 16,
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_mfma_f32.cu
+++ b/op_tests/opus/device/test_mfma_f32.cu
@@ -82,8 +82,8 @@ template __global__ void mfma_kernel_generic<opus::fp32_t, opus::fp32_t, 16, 16,
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_mfma_f8.cu
+++ b/op_tests/opus/device/test_mfma_f8.cu
@@ -87,8 +87,8 @@ template __global__ void mfma_kernel_generic<opus::bf8_t, opus::fp32_t, 16, 16, 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_mma_step_k.cu
+++ b/op_tests/opus/device/test_mma_step_k.cu
@@ -89,7 +89,7 @@ __global__ void mma_step_k_bf16_kernel(
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-#include "hip_host_minimal.h"
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_mxfp.cu
+++ b/op_tests/opus/device/test_mxfp.cu
@@ -21,8 +21,8 @@
 
 #include "opus/opus.hpp"
 #ifndef __HIP_DEVICE_COMPILE__
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 #define HIP_CALL(call) do { \
     hipError_t err = (call); \

--- a/op_tests/opus/device/test_numeric_limits.cu
+++ b/op_tests/opus/device/test_numeric_limits.cu
@@ -46,8 +46,8 @@ __global__ void numeric_limits_kernel(unsigned int* out) {
 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 namespace {

--- a/op_tests/opus/device/test_opus_device.py
+++ b/op_tests/opus/device/test_opus_device.py
@@ -204,6 +204,15 @@ class OpusDeviceLib:
         fn.argtypes = [_VP, _VP, _I]
         fn(self._ptr(Src), self._ptr(Dst), int(Src.numel()))
 
+    # -- predicated_copy_2d --
+    def run_predicated_copy_2d(
+        self, Src, Dst, actual_rows, actual_cols, total_rows, stride
+    ):
+        fn = self._lib.run_predicated_copy_2d
+        fn.restype = None
+        fn.argtypes = [_VP, _VP, _I, _I, _I, _I]
+        fn(self._ptr(Src), self._ptr(Dst), actual_rows, actual_cols, total_rows, stride)
+
     # -- free_func_add --
     def run_free_func_add(self, A, B, Result):
         fn = self._lib.run_free_func_add
@@ -1700,6 +1709,51 @@ def test_predicated_copy(mod):
     return 0
 
 
+def test_predicated_copy_2d(mod):
+    """Test 2D predicated load_if/store_if with multi-index predicate (i_row, i_col).
+
+    Catches bugs where _if methods pass flat index instead of multi-index to predicates.
+    Uses a 2D layout with row/col boundary checking — the predicate receives (i_row, i_col)
+    and uses them to check bounds, which would fail if given a single flat index.
+    """
+    ROWS = 4  # issue space rows per workgroup
+    COLS = 4  # issue space cols per thread
+    BLOCK_SIZE = 256  # threads per block
+    stride = BLOCK_SIZE * COLS  # row stride in elements
+
+    # Actual data: slightly smaller than full tile to trigger boundary predicate
+    actual_rows = 6  # < ROWS * num_blocks for last block
+    actual_cols = BLOCK_SIZE * COLS - 3  # not aligned, last few cols should be masked
+    total_rows = ((actual_rows + ROWS - 1) // ROWS) * ROWS  # padded to full tiles
+    total_elems = total_rows * stride
+
+    device = torch.device("cuda")
+    torch.manual_seed(123)
+    Src = torch.randn(total_elems, device=device, dtype=torch.float32)
+    Dst = torch.full((total_elems,), -1.0, device=device, dtype=torch.float32)
+
+    mod.run_predicated_copy_2d(Src, Dst, actual_rows, actual_cols, total_rows, stride)
+
+    # Build expected: copy only elements where row < actual_rows AND col < actual_cols
+    Expected = torch.full((total_elems,), -1.0, device=device, dtype=torch.float32)
+    for r in range(actual_rows):
+        for c in range(actual_cols):
+            Expected[r * stride + c] = Src[r * stride + c]
+
+    ok = torch.equal(Dst, Expected)
+    if not ok:
+        diff = (Dst - Expected).abs()
+        n_diff = diff.gt(0).sum().item()
+        print(
+            f"  FAIL: predicated_copy_2d mismatch, {n_diff}/{total_elems} elements differ, max_diff={diff.max().item():.6e}"
+        )
+        return 1
+    print(
+        f"  PASS: predicated_copy_2d ({actual_rows}x{actual_cols}), 2D multi-index predicate"
+    )
+    return 0
+
+
 def test_free_func_vector_add(mod):
     """Test opus::load / opus::store free function wrappers (vector add)."""
     n = 1310720  # same as regular vector_add test
@@ -2131,6 +2185,7 @@ def main():
     failures += test_dtype_convert_fp32_fp4_x2(mod)
     failures += test_dtype_convert_fp32_fp4_x4(mod)
     failures += test_predicated_copy(mod)
+    failures += test_predicated_copy_2d(mod)
     failures += test_free_func_vector_add(mod)
     failures += test_predicated_async_load(mod)
     failures += test_numeric_limits(mod)

--- a/op_tests/opus/device/test_tr_load_f16.cu
+++ b/op_tests/opus/device/test_tr_load_f16.cu
@@ -80,7 +80,7 @@ __global__ void tr_load_f16_kernel(const opus::fp16_t* __restrict__ in_row_major
     using namespace opus;
     static_assert(get_warp_size() == 64, "layout assumes wave64");
 
-    __shared__ alignas(16) fp16_t smem_tile[ROWS * COLS];
+    __shared__ fp16_t smem_tile[ROWS * COLS];
 
     const int lane_id = static_cast<int>(__builtin_amdgcn_workitem_id_x());
     constexpr int stride = COLS;
@@ -123,8 +123,8 @@ template __global__ void tr_load_f16_kernel<16, 32>(const opus::fp16_t*, opus::f
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_vector_add.cu
+++ b/op_tests/opus/device/test_vector_add.cu
@@ -40,8 +40,8 @@ template __global__ void vector_add_kernel<256, 4>(const float*, const float*, f
 
 #else
 // ── Host pass: hip_runtime.h for launch API, empty kernel stubs ─────────────
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_wmma_f16.cu
+++ b/op_tests/opus/device/test_wmma_f16.cu
@@ -91,7 +91,7 @@ template __global__ void wmma_kernel_generic<opus::bf16_t, opus::fp32_t, 16, 16,
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-#include "hip_host_minimal.h"
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_wmma_f32.cu
+++ b/op_tests/opus/device/test_wmma_f32.cu
@@ -94,7 +94,7 @@ template __global__ void wmma_kernel_v2<opus::fp32_t, opus::fp32_t, 16, 16, 4>(
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-#include "hip_host_minimal.h"
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_wmma_f8.cu
+++ b/op_tests/opus/device/test_wmma_f8.cu
@@ -105,7 +105,7 @@ template __global__ void wmma_kernel_f8<opus::fp8_t, opus::fp8_t, opus::fp16_t, 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-#include "hip_host_minimal.h"
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_wmma_scale.cu
+++ b/op_tests/opus/device/test_wmma_scale.cu
@@ -279,7 +279,7 @@ template __global__ void tiled_wmma_scale_kernel<opus::fp8_t, 16, 16, 128, 4, 1>
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
 #include "opus/opus.hpp"
-#include "hip_host_minimal.h"
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \

--- a/op_tests/opus/device/test_workgroup_barrier.cu
+++ b/op_tests/opus/device/test_workgroup_barrier.cu
@@ -84,8 +84,8 @@ __global__ void streamk_reduce_kernel(
 
 #else
 // ── Host pass ───────────────────────────────────────────────────────────────
-// #include <hip/hip_runtime.h>   // replaced by hip_host_minimal.h for faster builds
-#include "hip_host_minimal.h"
+// #include <hip/hip_runtime.h>   // replaced by hip_minimal.h for faster builds
+#include "opus/hip_minimal.hpp"
 #include <cstdio>
 
 #define HIP_CALL(call) do { \


### PR DESCRIPTION
## Summary
- add a standalone `OPUS Test` workflow instead of folding OPUS into the main `Aiter Test` pipeline
- run `./op_tests/opus/run_tests.sh` on both MI35X and MI325 1-GPU runners to cover gfx950 and gfx942 paths
- upload `latest_test.log` from each runner so OPUS failures can be debugged independently from the main test shards

## Test plan
- [x] Validate `.github/workflows/opus-test.yaml` with `yaml.safe_load(...)`
- [ ] Run the new GitHub Actions workflow on CI