### PR TITLE
CI: separate Aiter Test concurrency for push and schedule

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -17,7 +17,8 @@ on:
     - cron: '0 22 * * *'  # 6:00 AM Beijing Time (UTC+8)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Keep scheduled main runs from blocking push-triggered validation.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:


### PR DESCRIPTION
## Summary
- split `Aiter Test` concurrency on `main` by event type
- prevent scheduled runs from blocking push-triggered validation when a queued nightly job keeps the workflow open
- preserve the existing cancel-in-progress behavior for non-main refs

## Test plan
- Not run locally; GitHub Actions workflow change only
- Confirm a scheduled `main` run and a push-triggered `main` run can queue independently after merge