### PR TITLE
Ensure GemmTuner doesn't generate invalid input combinations for SplitK kernels

### DIFF
--- a/aiter/ops/gemm_op_a16w16.py
+++ b/aiter/ops/gemm_op_a16w16.py
@@ -25,9 +25,16 @@ def _gemm_a16w16_asm(
 ) -> None: ...
 
 
+# Semaphore workspace shape for ASM SplitK kernels.
+# The kernel indexes into a flat array of size rows*cols; candidates whose
+# grid (gdx*gdy) exceeds this limit must be skipped to avoid out-of-bounds writes.
+_SEMA_SHAPE = (16, 64)
+ASM_SPLITK_MAX_GRID = _SEMA_SHAPE[0] * _SEMA_SHAPE[1]
+
+
 @functools.lru_cache(maxsize=1)
 def get_semaphore_workspace(device: torch.device) -> Tensor:
-    return torch.zeros((16, 64), dtype=torch.uint32, device=device)
+    return torch.zeros(_SEMA_SHAPE, dtype=torch.uint32, device=device)
 
 
 def gemm_a16w16_asm(

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -29,6 +29,7 @@ from aiter import dtypes, logger
 from aiter.jit.core import AITER_CONFIG_GEMM_BF16, get_asm_dir
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx
 from aiter.ops.flydsl.utils import is_flydsl_available
+from aiter.ops.gemm_op_a16w16 import ASM_SPLITK_MAX_GRID
 from aiter.ops.shuffle import shuffle_weight
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16 as triton_gemm_a16w16
 from aiter.utility.base_tuner import GemmCommonTuner
@@ -507,11 +508,11 @@ class Gemm:
                 if self.k / splitK < subK:
                     break
                 # splitK kernels use a semaphore array of size gdx*gdy; skip
-                # candidates where the grid exceeds the 1024-entry limit.
+                # candidates where the grid exceeds the semaphore workspace limit.
                 if splitK > 1:
                     gdx = (self.n + tile_n - 1) // tile_n
                     gdy = (self.m + tile_m - 1) // tile_m
-                    if gdx * gdy > 1024:
+                    if gdx * gdy > ASM_SPLITK_MAX_GRID:
                         continue
                 task_asm.append(
                     (

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -506,6 +506,13 @@ class Gemm:
                 )
                 if self.k / splitK < subK:
                     break
+                # splitK kernels use a semaphore array of size gdx*gdy; skip
+                # candidates where the grid exceeds the 1024-entry limit.
+                if splitK > 1:
+                    gdx = (self.n + tile_n - 1) // tile_n
+                    gdy = (self.m + tile_m - 1) // tile_m
+                    if gdx * gdy > 1024:
+                        continue
                 task_asm.append(
                     (
                         info,

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -453,6 +453,13 @@ class Gemm:
                 )
                 if self.k / splitK < subK:
                     break
+                # splitK kernels use a semaphore array of size gdx*gdy; skip
+                # candidates where the grid exceeds the 1024-entry limit.
+                if splitK > 1:
+                    gdx = (self.n + tile_n - 1) // tile_n
+                    gdy = (self.m + tile_m - 1) // tile_m
+                    if gdx * gdy > 1024:
+                        continue
                 task_asm.append(
                     (
                         info,

--- a/gradlib/test_gemm_tuner_splitk.py
+++ b/gradlib/test_gemm_tuner_splitk.py
@@ -7,6 +7,8 @@ where gdx*gdy > 1024 must be filtered out to avoid out-of-bounds writes.
 import sys
 import types
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +99,7 @@ def _install_stubs():
 _install_stubs()
 
 # Now import the module under test from the local gradlib tree
-sys.path.insert(0, "gradlib")
+sys.path.insert(0, str(Path(__file__).resolve().parent / "gradlib"))
 from gradlib.GemmTuner import Gemm  # noqa: E402
 
 

--- a/gradlib/test_gemm_tuner_splitk.py
+++ b/gradlib/test_gemm_tuner_splitk.py
@@ -99,7 +99,7 @@ def _install_stubs():
 _install_stubs()
 
 # Now import the module under test from the local gradlib tree
-sys.path.insert(0, str(Path(__file__).resolve().parent / "gradlib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 from gradlib.GemmTuner import Gemm  # noqa: E402
 
 

--- a/gradlib/test_gemm_tuner_splitk.py
+++ b/gradlib/test_gemm_tuner_splitk.py
@@ -7,7 +7,7 @@ where gdx*gdy > 1024 must be filtered out to avoid out-of-bounds writes.
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 # ---------------------------------------------------------------------------

--- a/gradlib/test_gemm_tuner_splitk.py
+++ b/gradlib/test_gemm_tuner_splitk.py
@@ -7,7 +7,6 @@ where gdx*gdy > 1024 must be filtered out to avoid out-of-bounds writes.
 import sys
 import types
 import unittest
-from unittest.mock import patch
 
 
 # ---------------------------------------------------------------------------

--- a/gradlib/test_gemm_tuner_splitk.py
+++ b/gradlib/test_gemm_tuner_splitk.py
@@ -1,0 +1,196 @@
+"""
+Tests for GemmTuner.asm_gemm_all_solutions SplitK semaphore guard.
+
+The ASM SplitK kernels use a semaphore array of size gdx*gdy.  Candidates
+where gdx*gdy > 1024 must be filtered out to avoid out-of-bounds writes.
+"""
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so GemmTuner can be imported without a real ROCm stack
+# ---------------------------------------------------------------------------
+
+def _make_stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+def _install_stubs():
+    import logging
+
+    class _DType:
+        def __init__(self, name):
+            self._name = name
+        def __str__(self):
+            return self._name
+        def __repr__(self):
+            return self._name
+        def __eq__(self, other):
+            return isinstance(other, _DType) and self._name == other._name
+        def __hash__(self):
+            return hash(self._name)
+
+    dtypes_mod = _make_stub("aiter.dtypes", bf16=_DType("bf16"), fp32=_DType("fp32"))
+
+    aiter_mod = _make_stub("aiter", dtypes=dtypes_mod, logger=logging.getLogger("aiter"))
+
+    stubs = {
+        "aiter":                            aiter_mod,
+        "aiter.dtypes":                     dtypes_mod,
+        "aiter.jit":                        _make_stub("aiter.jit"),
+        "aiter.jit.core":                   _make_stub(
+            "aiter.jit.core",
+            AITER_CONFIG_GEMM_BF16="",
+            get_asm_dir=lambda: "/nonexistent",
+        ),
+        "aiter.jit.utils":                  _make_stub("aiter.jit.utils"),
+        "aiter.jit.utils.chip_info":        _make_stub(
+            "aiter.jit.utils.chip_info",
+            get_cu_num=lambda: 128,
+            get_gfx=lambda: "gfx942",
+        ),
+        "aiter.ops":                        _make_stub("aiter.ops"),
+        "aiter.ops.flydsl":                 _make_stub("aiter.ops.flydsl"),
+        "aiter.ops.flydsl.utils":           _make_stub(
+            "aiter.ops.flydsl.utils",
+            is_flydsl_available=lambda: False,
+        ),
+        "aiter.ops.shuffle":                _make_stub(
+            "aiter.ops.shuffle",
+            shuffle_weight=lambda *a, **kw: None,
+        ),
+        "aiter.ops.triton":                 _make_stub("aiter.ops.triton"),
+        "aiter.ops.triton.gemm":            _make_stub("aiter.ops.triton.gemm"),
+        "aiter.ops.triton.gemm.basic":      _make_stub("aiter.ops.triton.gemm.basic"),
+        "aiter.ops.triton.gemm.basic.gemm_a16w16": _make_stub(
+            "aiter.ops.triton.gemm.basic.gemm_a16w16",
+            gemm_a16w16=lambda *a, **kw: None,
+        ),
+        "aiter.utility":                    _make_stub("aiter.utility"),
+        "aiter.utility.base_tuner":         _make_stub(
+            "aiter.utility.base_tuner",
+            GemmCommonTuner=type(
+                "GemmCommonTuner",
+                (),
+                {"ARG_DEFAULTS": {
+                    "verbose": False, "tune_file": "", "untune_file": "",
+                    "errRatio": 0.05, "batch": 100, "profile_file": "",
+                    "timeout": None, "warmup": 5, "iters": 101,
+                    "min_improvement_pct": 3.0,
+                }},
+            ),
+        ),
+        "aiter.utility.mp_tuner":           _make_stub(
+            "aiter.utility.mp_tuner",
+            mp_tuner=lambda *a, **kw: [],
+        ),
+    }
+    for name, mod in stubs.items():
+        sys.modules.setdefault(name, mod)
+
+
+_install_stubs()
+
+# Now import the module under test from the local gradlib tree
+sys.path.insert(0, "gradlib")
+from gradlib.GemmTuner import Gemm  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_gemm(m, n, k):
+    """Return a Gemm instance configured for the given shape, bypassing GPU calls."""
+    import aiter.dtypes as dtypes
+    gemm = Gemm.__new__(Gemm)
+    gemm.m = m
+    gemm.n = n
+    gemm.k = k
+    gemm.indtype = dtypes.bf16
+    gemm.outdtype = dtypes.fp32
+    gemm.scaleAB = False
+    gemm.has_bias = False
+    gemm.bias = None
+    gemm.is_shuffle = False
+    gemm.asm_map = {}
+    gemm.num_warmup = 0
+    gemm.rtol = 1e-2
+    gemm.atol = 1e-2
+    return gemm
+
+
+def _fake_kernels(tile_m, tile_n, splitK_flag, subK):
+    """Return a minimal kernel dict as returned by get_asm_kernels."""
+    key = (tile_m, tile_n, 1, splitK_flag, subK, 0, 0)
+    return {key: ["fake_kernel"]}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSplitKSemaphoreGuard(unittest.TestCase):
+
+    @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
+    @patch("gradlib.GemmTuner.generate_data", return_value=None)
+    def test_large_grid_candidates_are_skipped(self, _gen, _gfx):
+        """Candidates where gdx*gdy > 1024 must not appear in the task list."""
+        # tile 64x64 on a 4096x4096 grid => gdx=64, gdy=64 => 4096 > 1024
+        gemm = _make_gemm(m=4096, n=4096, k=256)
+
+        with patch.object(Gemm, "get_asm_kernels",
+                          return_value=_fake_kernels(64, 64, 1, 64)):
+            tasks = gemm.asm_gemm_all_solutions()
+
+        for task in tasks:
+            # info structure: ((m,n,k,...), solidx, splitK, libtype, kname)
+            info = task[0]
+            shape, splitK = info[0], info[2]
+            m, n = shape[0], shape[1]
+            gdx = (n + 64 - 1) // 64
+            gdy = (m + 64 - 1) // 64
+            self.assertLessEqual(
+                gdx * gdy, 1024,
+                f"Task with splitK={splitK} has grid {gdx}x{gdy}={gdx*gdy} > 1024",
+            )
+
+    @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
+    @patch("gradlib.GemmTuner.generate_data", return_value=None)
+    def test_small_grid_candidates_are_kept(self, _gen, _gfx):
+        """Candidates where gdx*gdy <= 1024 must still be generated."""
+        # tile 128x128 on 128x128 => gdx=1, gdy=1 => 1 <= 1024
+        gemm = _make_gemm(m=128, n=128, k=256)
+
+        with patch.object(Gemm, "get_asm_kernels",
+                          return_value=_fake_kernels(128, 128, 1, 64)):
+            tasks = gemm.asm_gemm_all_solutions()
+
+        splitk_tasks = [t for t in tasks if t[0][2] > 1]
+        self.assertGreater(len(splitk_tasks), 0,
+                           "Expected SplitK tasks for a small grid, got none")
+
+    @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
+    @patch("gradlib.GemmTuner.generate_data", return_value=None)
+    def test_boundary_grid_exactly_1024_is_kept(self, _gen, _gfx):
+        """A grid of exactly gdx*gdy == 1024 should not be filtered."""
+        # tile=64, m=64*32=2048, n=64*32=2048 => gdx=32, gdy=32 => exactly 1024
+        gemm = _make_gemm(m=2048, n=2048, k=256)
+
+        with patch.object(Gemm, "get_asm_kernels",
+                          return_value=_fake_kernels(64, 64, 1, 64)):
+            tasks = gemm.asm_gemm_all_solutions()
+
+        splitk_tasks = [t for t in tasks if t[0][2] > 1]
+        self.assertGreater(len(splitk_tasks), 0,
+                           "Grid of exactly 1024 should not be filtered")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/op_tests/tuning_tests/README.md
+++ b/op_tests/tuning_tests/README.md
@@ -9,6 +9,7 @@ Minimal test suite for validating the aiter tuning infrastructure.
 | `test_csv_validation.py` | 0 | No | Tuned CSV integrity: duplicates, invalid times, errRatio, git conflicts |
 | `test_tuner_infra.py` | 1 | No | `base_tuner` utilities: CSV I/O, merge, dedup, calculate, post_process topk |
 | `test_mp_tuner_logic.py` | 1 | No | `mp_tuner` polling: timeout, AcceleratorError, KeyError, pool restart |
+| `test_asm_splitk_guard.py` | 1 | No | `GemmTuner.asm_gemm_all_solutions` SplitK semaphore grid guard |
 | `test_tune_pipeline.py` | 2 | Yes | End-to-end: run each tuner on small shapes, verify output CSV |
 | `test_run_config.py` | 2 | Yes | Run --run_config on ALL existing tuned CSVs (configs + model_configs) |
 

--- a/op_tests/tuning_tests/test_asm_splitk_guard.py
+++ b/op_tests/tuning_tests/test_asm_splitk_guard.py
@@ -1,19 +1,30 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 """
-Tests for GemmTuner.asm_gemm_all_solutions SplitK semaphore guard.
+Level 1: Unit tests for the ASM SplitK semaphore grid guard in GemmTuner.
 
-The ASM SplitK kernels use a semaphore array of size gdx*gdy.  Candidates
-where gdx*gdy > 1024 must be filtered out to avoid out-of-bounds writes.
+The ASM SplitK kernels index into a semaphore workspace of size ASM_SPLITK_MAX_GRID
+(defined in aiter.ops.gemm_op_a16w16).  Candidates where gdx*gdy exceeds that limit
+must be filtered out by asm_gemm_all_solutions() to avoid out-of-bounds writes.
+
+No GPU required.  Run:
+    python3 -m unittest op_tests.tuning_tests.test_asm_splitk_guard -v
 """
+import importlib
 import sys
 import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+# ---------------------------------------------------------------------------
+# Minimal stubs so GemmTuner can be imported without a real ROCm stack.
+# Uses setdefault so installed packages, if present, take precedence.
+# ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# Minimal stubs so GemmTuner can be imported without a real ROCm stack
-# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ASM_SPLITK_MAX_GRID = 16 * 64  # mirrors aiter.ops.gemm_op_a16w16.ASM_SPLITK_MAX_GRID
+
 
 def _make_stub(name, **attrs):
     mod = types.ModuleType(name)
@@ -28,17 +39,20 @@ def _install_stubs():
     class _DType:
         def __init__(self, name):
             self._name = name
+
         def __str__(self):
             return self._name
+
         def __repr__(self):
             return self._name
+
         def __eq__(self, other):
             return isinstance(other, _DType) and self._name == other._name
+
         def __hash__(self):
             return hash(self._name)
 
     dtypes_mod = _make_stub("aiter.dtypes", bf16=_DType("bf16"), fp32=_DType("fp32"))
-
     aiter_mod = _make_stub("aiter", dtypes=dtypes_mod, logger=logging.getLogger("aiter"))
 
     stubs = {
@@ -61,6 +75,10 @@ def _install_stubs():
         "aiter.ops.flydsl.utils":           _make_stub(
             "aiter.ops.flydsl.utils",
             is_flydsl_available=lambda: False,
+        ),
+        "aiter.ops.gemm_op_a16w16":         _make_stub(
+            "aiter.ops.gemm_op_a16w16",
+            ASM_SPLITK_MAX_GRID=_ASM_SPLITK_MAX_GRID,
         ),
         "aiter.ops.shuffle":                _make_stub(
             "aiter.ops.shuffle",
@@ -93,13 +111,17 @@ def _install_stubs():
         ),
     }
     for name, mod in stubs.items():
-        sys.modules.setdefault(name, mod)
+        if name in sys.modules:
+            continue
+        try:
+            importlib.import_module(name)
+        except Exception:
+            sys.modules[name] = mod
 
 
 _install_stubs()
 
-# Now import the module under test from the local gradlib tree
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(_REPO_ROOT / "gradlib"))
 from gradlib.GemmTuner import Gemm  # noqa: E402
 
 
@@ -108,7 +130,6 @@ from gradlib.GemmTuner import Gemm  # noqa: E402
 # ---------------------------------------------------------------------------
 
 def _make_gemm(m, n, k):
-    """Return a Gemm instance configured for the given shape, bypassing GPU calls."""
     import aiter.dtypes as dtypes
     gemm = Gemm.__new__(Gemm)
     gemm.m = m
@@ -142,7 +163,7 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
     @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
     @patch("gradlib.GemmTuner.generate_data", return_value=None)
     def test_large_grid_candidates_are_skipped(self, _gen, _gfx):
-        """Candidates where gdx*gdy > 1024 must not appear in the task list."""
+        """Candidates where gdx*gdy > ASM_SPLITK_MAX_GRID must not appear in the task list."""
         # tile 64x64 on a 4096x4096 grid => gdx=64, gdy=64 => 4096 > 1024
         gemm = _make_gemm(m=4096, n=4096, k=256)
 
@@ -151,21 +172,20 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
             tasks = gemm.asm_gemm_all_solutions()
 
         for task in tasks:
-            # info structure: ((m,n,k,...), solidx, splitK, libtype, kname)
             info = task[0]
             shape, splitK = info[0], info[2]
             m, n = shape[0], shape[1]
             gdx = (n + 64 - 1) // 64
             gdy = (m + 64 - 1) // 64
             self.assertLessEqual(
-                gdx * gdy, 1024,
-                f"Task with splitK={splitK} has grid {gdx}x{gdy}={gdx*gdy} > 1024",
+                gdx * gdy, _ASM_SPLITK_MAX_GRID,
+                f"Task with splitK={splitK} has grid {gdx}x{gdy}={gdx*gdy} > {_ASM_SPLITK_MAX_GRID}",
             )
 
     @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
     @patch("gradlib.GemmTuner.generate_data", return_value=None)
     def test_small_grid_candidates_are_kept(self, _gen, _gfx):
-        """Candidates where gdx*gdy <= 1024 must still be generated."""
+        """Candidates where gdx*gdy <= ASM_SPLITK_MAX_GRID must still be generated."""
         # tile 128x128 on 128x128 => gdx=1, gdy=1 => 1 <= 1024
         gemm = _make_gemm(m=128, n=128, k=256)
 
@@ -179,9 +199,9 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
 
     @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
     @patch("gradlib.GemmTuner.generate_data", return_value=None)
-    def test_boundary_grid_exactly_1024_is_kept(self, _gen, _gfx):
-        """A grid of exactly gdx*gdy == 1024 should not be filtered."""
-        # tile=64, m=64*32=2048, n=64*32=2048 => gdx=32, gdy=32 => exactly 1024
+    def test_boundary_grid_exactly_max_is_kept(self, _gen, _gfx):
+        """A grid of exactly gdx*gdy == ASM_SPLITK_MAX_GRID must not be filtered."""
+        # tile=64, m=2048, n=2048 => gdx=32, gdy=32 => exactly 1024
         gemm = _make_gemm(m=2048, n=2048, k=256)
 
         with patch.object(Gemm, "get_asm_kernels",
@@ -190,7 +210,7 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
 
         splitk_tasks = [t for t in tasks if t[0][2] > 1]
         self.assertGreater(len(splitk_tasks), 0,
-                           "Grid of exactly 1024 should not be filtered")
+                           f"Grid of exactly {_ASM_SPLITK_MAX_GRID} should not be filtered")
 
 
 if __name__ == "__main__":

--- a/op_tests/tuning_tests/test_asm_splitk_guard.py
+++ b/op_tests/tuning_tests/test_asm_splitk_guard.py
@@ -28,7 +28,13 @@ from unittest.mock import patch
 # ---------------------------------------------------------------------------
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_ASM_SPLITK_MAX_GRID = 16 * 64  # mirrors aiter.ops.gemm_op_a16w16.ASM_SPLITK_MAX_GRID
+# Mirrors aiter.ops.gemm_op_a16w16.ASM_SPLITK_MAX_GRID (_SEMA_SHAPE[0] * _SEMA_SHAPE[1]).
+# We cannot import it directly: gemm_op_a16w16.py imports torch at module level,
+# which fails on machines without a GPU before any stub can intercept it.
+# If _SEMA_SHAPE changes in production, this constant and the boundary-test
+# shapes below (m=2048, n=2048 => gdx*gdy == 1024) must be updated together —
+# a mismatch causes a silent false pass, not a visible test failure.
+_ASM_SPLITK_MAX_GRID = 16 * 64
 
 
 def _make_stub(name, **attrs):

--- a/op_tests/tuning_tests/test_asm_splitk_guard.py
+++ b/op_tests/tuning_tests/test_asm_splitk_guard.py
@@ -10,6 +10,7 @@ must be filtered out by asm_gemm_all_solutions() to avoid out-of-bounds writes.
 No GPU required.  Run:
     python3 -m unittest op_tests.tuning_tests.test_asm_splitk_guard -v
 """
+
 import importlib
 import sys
 import types
@@ -66,59 +67,69 @@ def _install_stubs():
             return hash(self._name)
 
     dtypes_mod = _make_stub("aiter.dtypes", bf16=_DType("bf16"), fp32=_DType("fp32"))
-    aiter_mod = _make_stub("aiter", dtypes=dtypes_mod, logger=logging.getLogger("aiter"))
+    aiter_mod = _make_stub(
+        "aiter", dtypes=dtypes_mod, logger=logging.getLogger("aiter")
+    )
 
     stubs = {
-        "aiter":                            aiter_mod,
-        "aiter.dtypes":                     dtypes_mod,
-        "aiter.jit":                        _make_stub("aiter.jit"),
-        "aiter.jit.core":                   _make_stub(
+        "aiter": aiter_mod,
+        "aiter.dtypes": dtypes_mod,
+        "aiter.jit": _make_stub("aiter.jit"),
+        "aiter.jit.core": _make_stub(
             "aiter.jit.core",
             AITER_CONFIG_GEMM_BF16="",
             get_asm_dir=lambda: "/nonexistent",
         ),
-        "aiter.jit.utils":                  _make_stub("aiter.jit.utils"),
-        "aiter.jit.utils.chip_info":        _make_stub(
+        "aiter.jit.utils": _make_stub("aiter.jit.utils"),
+        "aiter.jit.utils.chip_info": _make_stub(
             "aiter.jit.utils.chip_info",
             get_cu_num=lambda: 128,
             get_gfx=lambda: "gfx942",
         ),
-        "aiter.ops":                        _make_stub("aiter.ops"),
-        "aiter.ops.flydsl":                 _make_stub("aiter.ops.flydsl"),
-        "aiter.ops.flydsl.utils":           _make_stub(
+        "aiter.ops": _make_stub("aiter.ops"),
+        "aiter.ops.flydsl": _make_stub("aiter.ops.flydsl"),
+        "aiter.ops.flydsl.utils": _make_stub(
             "aiter.ops.flydsl.utils",
             is_flydsl_available=lambda: False,
         ),
-        "aiter.ops.gemm_op_a16w16":         _make_stub(
+        "aiter.ops.gemm_op_a16w16": _make_stub(
             "aiter.ops.gemm_op_a16w16",
             ASM_SPLITK_MAX_GRID=_ASM_SPLITK_MAX_GRID,
         ),
-        "aiter.ops.shuffle":                _make_stub(
+        "aiter.ops.shuffle": _make_stub(
             "aiter.ops.shuffle",
             shuffle_weight=lambda *a, **kw: None,
         ),
-        "aiter.ops.triton":                 _make_stub("aiter.ops.triton"),
-        "aiter.ops.triton.gemm":            _make_stub("aiter.ops.triton.gemm"),
-        "aiter.ops.triton.gemm.basic":      _make_stub("aiter.ops.triton.gemm.basic"),
+        "aiter.ops.triton": _make_stub("aiter.ops.triton"),
+        "aiter.ops.triton.gemm": _make_stub("aiter.ops.triton.gemm"),
+        "aiter.ops.triton.gemm.basic": _make_stub("aiter.ops.triton.gemm.basic"),
         "aiter.ops.triton.gemm.basic.gemm_a16w16": _make_stub(
             "aiter.ops.triton.gemm.basic.gemm_a16w16",
             gemm_a16w16=lambda *a, **kw: None,
         ),
-        "aiter.utility":                    _make_stub("aiter.utility"),
-        "aiter.utility.base_tuner":         _make_stub(
+        "aiter.utility": _make_stub("aiter.utility"),
+        "aiter.utility.base_tuner": _make_stub(
             "aiter.utility.base_tuner",
             GemmCommonTuner=type(
                 "GemmCommonTuner",
                 (),
-                {"ARG_DEFAULTS": {
-                    "verbose": False, "tune_file": "", "untune_file": "",
-                    "errRatio": 0.05, "batch": 100, "profile_file": "",
-                    "timeout": None, "warmup": 5, "iters": 101,
-                    "min_improvement_pct": 3.0,
-                }},
+                {
+                    "ARG_DEFAULTS": {
+                        "verbose": False,
+                        "tune_file": "",
+                        "untune_file": "",
+                        "errRatio": 0.05,
+                        "batch": 100,
+                        "profile_file": "",
+                        "timeout": None,
+                        "warmup": 5,
+                        "iters": 101,
+                        "min_improvement_pct": 3.0,
+                    }
+                },
             ),
         ),
-        "aiter.utility.mp_tuner":           _make_stub(
+        "aiter.utility.mp_tuner": _make_stub(
             "aiter.utility.mp_tuner",
             mp_tuner=lambda *a, **kw: [],
         ),
@@ -141,13 +152,14 @@ _install_stubs()
 sys.path.insert(0, str(_REPO_ROOT / "gradlib"))
 from gradlib.GemmTuner import Gemm  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_gemm(m, n, k):
     import aiter.dtypes as dtypes
+
     # __new__ allocates the instance without calling __init__, which would
     # trigger GPU data generation.  We set the attributes that
     # asm_gemm_all_solutions() actually reads, and nothing more.
@@ -178,6 +190,7 @@ def _fake_kernels(tile_m, tile_n, splitK_flag, subK):
 # Tests
 # ---------------------------------------------------------------------------
 
+
 class TestSplitKSemaphoreGuard(unittest.TestCase):
 
     # @patch target must name the lookup site, not the definition site.
@@ -191,8 +204,9 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
         # tile 64x64 on a 4096x4096 grid => gdx=64, gdy=64 => 4096 > 1024
         gemm = _make_gemm(m=4096, n=4096, k=256)
 
-        with patch.object(Gemm, "get_asm_kernels",
-                          return_value=_fake_kernels(64, 64, 1, 64)):
+        with patch.object(
+            Gemm, "get_asm_kernels", return_value=_fake_kernels(64, 64, 1, 64)
+        ):
             tasks = gemm.asm_gemm_all_solutions()
 
         for task in tasks:
@@ -202,7 +216,8 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
             gdx = (n + 64 - 1) // 64
             gdy = (m + 64 - 1) // 64
             self.assertLessEqual(
-                gdx * gdy, _ASM_SPLITK_MAX_GRID,
+                gdx * gdy,
+                _ASM_SPLITK_MAX_GRID,
                 f"Task with splitK={splitK} has grid {gdx}x{gdy}={gdx*gdy} > {_ASM_SPLITK_MAX_GRID}",
             )
 
@@ -213,13 +228,15 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
         # tile 128x128 on 128x128 => gdx=1, gdy=1 => 1 <= 1024
         gemm = _make_gemm(m=128, n=128, k=256)
 
-        with patch.object(Gemm, "get_asm_kernels",
-                          return_value=_fake_kernels(128, 128, 1, 64)):
+        with patch.object(
+            Gemm, "get_asm_kernels", return_value=_fake_kernels(128, 128, 1, 64)
+        ):
             tasks = gemm.asm_gemm_all_solutions()
 
         splitk_tasks = [t for t in tasks if t[0][2] > 1]
-        self.assertGreater(len(splitk_tasks), 0,
-                           "Expected SplitK tasks for a small grid, got none")
+        self.assertGreater(
+            len(splitk_tasks), 0, "Expected SplitK tasks for a small grid, got none"
+        )
 
     @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
     @patch("gradlib.GemmTuner.generate_data", return_value=None)
@@ -228,13 +245,17 @@ class TestSplitKSemaphoreGuard(unittest.TestCase):
         # tile=64, m=2048, n=2048 => gdx=32, gdy=32 => exactly 1024
         gemm = _make_gemm(m=2048, n=2048, k=256)
 
-        with patch.object(Gemm, "get_asm_kernels",
-                          return_value=_fake_kernels(64, 64, 1, 64)):
+        with patch.object(
+            Gemm, "get_asm_kernels", return_value=_fake_kernels(64, 64, 1, 64)
+        ):
             tasks = gemm.asm_gemm_all_solutions()
 
         splitk_tasks = [t for t in tasks if t[0][2] > 1]
-        self.assertGreater(len(splitk_tasks), 0,
-                           f"Grid of exactly {_ASM_SPLITK_MAX_GRID} should not be filtered")
+        self.assertGreater(
+            len(splitk_tasks),
+            0,
+            f"Grid of exactly {_ASM_SPLITK_MAX_GRID} should not be filtered",
+        )
 
 
 if __name__ == "__main__":

--- a/op_tests/tuning_tests/test_asm_splitk_guard.py
+++ b/op_tests/tuning_tests/test_asm_splitk_guard.py
@@ -19,7 +19,12 @@ from unittest.mock import patch
 
 # ---------------------------------------------------------------------------
 # Minimal stubs so GemmTuner can be imported without a real ROCm stack.
-# Uses setdefault so installed packages, if present, take precedence.
+#
+# GemmTuner.py executes nine "from aiter..." imports at module level, before
+# any test code runs.  On a machine without ROCm every one fails, so we must
+# pre-populate sys.modules with objects that satisfy those imports before the
+# "from gradlib.GemmTuner import Gemm" line below.  That is why _install_stubs()
+# is called unconditionally at module level rather than inside setUp().
 # ---------------------------------------------------------------------------
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -27,6 +32,8 @@ _ASM_SPLITK_MAX_GRID = 16 * 64  # mirrors aiter.ops.gemm_op_a16w16.ASM_SPLITK_MA
 
 
 def _make_stub(name, **attrs):
+    # types.ModuleType produces a bare module object — the same class "import"
+    # normally creates — so "from stub_name import attr" works without real code.
     mod = types.ModuleType(name)
     for k, v in attrs.items():
         setattr(mod, k, v)
@@ -114,6 +121,10 @@ def _install_stubs():
         if name in sys.modules:
             continue
         try:
+            # Prefer the real module when it is importable (e.g. on a GPU CI
+            # machine where aiter is installed).  Only fall back to the stub on
+            # ImportError, so we don't corrupt other tests in the same session
+            # that depend on the real implementation.
             importlib.import_module(name)
         except Exception:
             sys.modules[name] = mod
@@ -131,6 +142,9 @@ from gradlib.GemmTuner import Gemm  # noqa: E402
 
 def _make_gemm(m, n, k):
     import aiter.dtypes as dtypes
+    # __new__ allocates the instance without calling __init__, which would
+    # trigger GPU data generation.  We set the attributes that
+    # asm_gemm_all_solutions() actually reads, and nothing more.
     gemm = Gemm.__new__(Gemm)
     gemm.m = m
     gemm.n = n
@@ -160,6 +174,10 @@ def _fake_kernels(tile_m, tile_n, splitK_flag, subK):
 
 class TestSplitKSemaphoreGuard(unittest.TestCase):
 
+    # @patch target must name the lookup site, not the definition site.
+    # GemmTuner does "from aiter.jit.utils.chip_info import get_gfx", so get_gfx
+    # lives in the gradlib.GemmTuner namespace — patching the original module
+    # would have no effect on the already-bound local reference.
     @patch("gradlib.GemmTuner.get_gfx", return_value="gfx942")
     @patch("gradlib.GemmTuner.generate_data", return_value=None)
     def test_large_grid_candidates_are_skipped(self, _gen, _gfx):


### PR DESCRIPTION
## Motivation

  ASM SplitK kernels use a fixed semaphore workspace of `ASM_SPLITK_MAX_GRID` (1024) entries, indexed by grid position `gdx * gdy`. When the grid exceeds that limit, the kernel writes out of bounds, causing silent corruption or crashes
  during tuning.

  Large matrix shapes (e.g. M=4096, N=4096 with a 64×64 tile) produce `gdx * gdy = 4096`, well above the limit.

  ## Technical Details

  Extracts `_SEMA_SHAPE` and `ASM_SPLITK_MAX_GRID` from `aiter/ops/gemm_op_a16w16.py` so the semaphore allocation and the candidate filter share a single source of truth — previously the allocation shape `(16, 64)` and the guard literal
   `1024` were independent and could silently drift.

  Adds a guard in `Gemm.asm_gemm_all_solutions()` (`gradlib/gradlib/GemmTuner.py`) that imports `ASM_SPLITK_MAX_GRID` and skips any SplitK candidate where `gdx * gdy > ASM_SPLITK_MAX_GRID` before appending to the task list. The check
  only applies when `splitK > 1` (non-SplitK candidates are unaffected).

  ## Test Plan

  Added offline unit tests in `op_tests/tuning_tests/test_asm_splitk_guard.py` (Level 1 — no GPU required) covering three cases:
  - Large grid (`gdx*gdy > ASM_SPLITK_MAX_GRID`): all generated tasks must satisfy the constraint
  - Small grid (`gdx*gdy = 1`): SplitK tasks must still be generated (no false filtering)
  - Boundary (`gdx*gdy == ASM_SPLITK_MAX_GRID`): tasks at the exact limit must be kept

  Tests stub the full aiter/ROCm stack and run without a GPU:
  python3 -m unittest op_tests.tuning_tests.test_asm_splitk_guard -v

  ## Test Result

  3 passed in 0.19s

  ## Submission Checklist

  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.