### PR TITLE
Make FlyDSL LDS checks architecture-aware and reduce tuner failure noise

### DIFF
--- a/aiter/ops/flydsl/gemm_kernels.py
+++ b/aiter/ops/flydsl/gemm_kernels.py
@@ -19,7 +19,7 @@ from aiter.jit.utils.chip_info import get_gfx
 
 from ..shuffle import shuffle_weight
 from .kernels.splitk_hgemm import compile_hgemm_kernel
-from .utils import is_flydsl_available
+from .utils import get_shared_memory_per_block, is_flydsl_available
 
 __all__ = [
     "flydsl_hgemm",
@@ -27,7 +27,6 @@ __all__ = [
 
 SPLIT_K_COUNTER_MAX_LEN = 128
 SPLIT_K_SIGNAL_STATE_COUNT = 3
-MAX_LDS_BYTES = 163840
 FIXED_STAGE = 2
 FIXED_C_TO_LDS = False
 KERNEL_ASYNC_COPY = get_rocm_arch() != "gfx942"
@@ -333,10 +332,11 @@ def _validate_hgemm_tiling(
         stages=stages,
         b_to_lds=b_to_lds,
     )
-    if lds_bytes > MAX_LDS_BYTES:
+    lds_limit = get_shared_memory_per_block(fallback_gfx=get_gfx())
+    if lds_bytes > lds_limit:
         raise ValueError(
             "Invalid tile combination: estimated LDS usage "
-            f"{lds_bytes} exceeds the hardware limit {MAX_LDS_BYTES}"
+            f"{lds_bytes} exceeds the hardware limit {lds_limit}"
         )
 
 

--- a/aiter/ops/flydsl/gemm_tune/flydsl_gemm_a8w8_bpreshuffle_common.py
+++ b/aiter/ops/flydsl/gemm_tune/flydsl_gemm_a8w8_bpreshuffle_common.py
@@ -269,7 +269,7 @@ def _estimate_max_wpe(tile_m: int, tile_n: int, total_vgpr: int = 512) -> int:
 
     Preshuffle GEMM always uses 16x16 MFMA (4 VGPRs per thread per block).
     Per-thread accum VGPRs = round_up(tile_m, 16) * round_up(tile_n, 16) / 256.
-    Estimated total ? accum * 1.5 (pipeline overhead for A/B buffers).
+    Estimated total ~= accum * 1.5 (pipeline overhead for A/B buffers).
     Returns the max waves_per_eu that the register file can support.
     """
     padded_m = math.ceil(tile_m / _MFMA_M) * _MFMA_M

--- a/aiter/ops/flydsl/gemm_tune/flydsl_gemm_a8w8_bpreshuffle_common.py
+++ b/aiter/ops/flydsl/gemm_tune/flydsl_gemm_a8w8_bpreshuffle_common.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass
 import math
 import os
 
+from aiter.ops.flydsl.utils import (
+    addressable_lds_bytes_for_gfx as _addressable_lds_bytes_for_gfx,
+    get_shared_memory_per_block,
+)
+
 
 def get_gfx():
     """Detect GPU arch: honour GPU_ARCHS env, fall back to chip_info, default gfx942."""
@@ -165,26 +170,13 @@ def kernel_instance_estimated_lds_bytes(ki: kernelInstance) -> int:
     )
 
 
-# Per-kernel LDS cap for tune filtering (must match LLVM AMDGPU
-# getAddressableLocalMemorySize for the compile target).
-# When arch cannot be parsed (no GPU, bad string), stay conservative for CDNA.
-_FALLBACK_MAX_LDS_BYTES = 65536
-
-
 def addressable_lds_bytes_for_gfx(gfx: str) -> int:
-    g = (gfx or "").strip().lower().split(":")[0]
-    if not g.startswith("gfx"):
-        return _FALLBACK_MAX_LDS_BYTES
-    if g.startswith("gfx950"):
-        return 163840
-    if g.startswith("gfx7") or g.startswith("gfx8"):
-        return 32768
-    return 65536
+    return _addressable_lds_bytes_for_gfx(gfx)
 
 
 def max_lds_bytes_for_tune() -> int:
-    """Addressable LDS limit for current target (from ``get_gfx()``)."""
-    return addressable_lds_bytes_for_gfx(get_gfx())
+    """Addressable LDS limit for current target."""
+    return get_shared_memory_per_block(fallback_gfx=get_gfx())
 
 
 # fmt: off
@@ -277,7 +269,7 @@ def _estimate_max_wpe(tile_m: int, tile_n: int, total_vgpr: int = 512) -> int:
 
     Preshuffle GEMM always uses 16x16 MFMA (4 VGPRs per thread per block).
     Per-thread accum VGPRs = round_up(tile_m, 16) * round_up(tile_n, 16) / 256.
-    Estimated total ≈ accum * 1.5 (pipeline overhead for A/B buffers).
+    Estimated total ? accum * 1.5 (pipeline overhead for A/B buffers).
     Returns the max waves_per_eu that the register file can support.
     """
     padded_m = math.ceil(tile_m / _MFMA_M) * _MFMA_M

--- a/aiter/ops/flydsl/kernels/splitk_hgemm.py
+++ b/aiter/ops/flydsl/kernels/splitk_hgemm.py
@@ -18,6 +18,7 @@ from flydsl.runtime.device import get_rocm_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 
 from .tensor_shim import GTensor, STensor, _to_raw, get_dtype_in_kernel
+from ..utils import get_shared_memory_per_block
 
 SPLIT_K_COUNTER_MAX_LEN = 128
 SPLIT_K_SIGNAL_STATE_COUNT = 3
@@ -178,6 +179,15 @@ def compile_hgemm_kernel(
     assert BLOCK_MN_SIZE % BLOCK_VECS == 0
     BLOCK_K_BYTES = BLOCK_K * DTYPE_BYTES
 
+    KERNEL_NAME = f"hgemm_{dtype}_{BLOCK_M}x{BLOCK_N}x{BLOCK_K}_S{STAGES}TN"
+    KERNEL_NAME += "_NA" if not ASYNC_COPY else "_AS"
+    if B_PRE_SHUFFLE:
+        KERNEL_NAME += "_BP"
+    if IS_SPLIT_K:
+        KERNEL_NAME += f"_SPK{SPLIT_K}"
+    if B_TO_LDS:
+        KERNEL_NAME += "_BS"
+
     allocator = SmemAllocator(None, arch=GPU_ARCH, global_sym_name="smem")
     smem_a_offset = allocator._align(allocator.ptr, 16)
     AS_BYTES = STAGES * BLOCK_M * BLOCK_K * DTYPE_BYTES
@@ -188,21 +198,19 @@ def compile_hgemm_kernel(
         smem_b_offset = allocator._align(allocator.ptr, 16)
         allocator.ptr = smem_b_offset + STAGES * BLOCK_N * BLOCK_K * DTYPE_BYTES
         SMEM_USE += STAGES * BLOCK_N * BLOCK_K * DTYPE_BYTES
-    assert SMEM_USE <= 163840
+    smem_limit = get_shared_memory_per_block(fallback_gfx=GPU_ARCH)
+    if SMEM_USE > smem_limit:
+        raise RuntimeError(
+            f"{KERNEL_NAME} requires {SMEM_USE} bytes LDS, "
+            f"but device limit is {smem_limit} bytes "
+            f"(arch={GPU_ARCH}, TILE_M={TILE_M}, TILE_N={TILE_N}, TILE_K={TILE_K}, "
+            f"SPLIT_K={SPLIT_K}, B_TO_LDS={B_TO_LDS})",
+        )
     LDG_ASYNC_VEC_SIZE = DMA_BYTES // DTYPE_BYTES
     LDG_A_X_THREADS_AS = BLOCK_K // LDG_ASYNC_VEC_SIZE
     LDG_REG_A_COUNT_AS = BLOCK_MK_SIZE // LDG_ASYNC_VEC_SIZE // BLOCK_THREADS
     LDG_B_X_THREADS_AS = BLOCK_K // LDG_ASYNC_VEC_SIZE
     LDG_REG_B_COUNT_AS = BLOCK_NK_SIZE // LDG_ASYNC_VEC_SIZE // BLOCK_THREADS
-
-    KERNEL_NAME = f"hgemm_{dtype}_{BLOCK_M}x{BLOCK_N}x{BLOCK_K}_S{STAGES}TN"
-    KERNEL_NAME += "_NA" if not ASYNC_COPY else "_AS"
-    if B_PRE_SHUFFLE:
-        KERNEL_NAME += "_BP"
-    if IS_SPLIT_K:
-        KERNEL_NAME += f"_SPK{SPLIT_K}"
-    if B_TO_LDS:
-        KERNEL_NAME += "_BS"
 
     @flyc.kernel
     def hgemm_kernel(
@@ -925,9 +933,17 @@ def compile_hgemm_kernel(
     def _compile(C, A, B, m, COUNTER, signal_state, stream):
         with CompilationContext.compile_hints(_compile_hints):
             if _compile_cache.get(m, None) is None:
-                _compile_cache[m] = flyc.compile(
-                    launch_hgemm_kernel, C, A, B, m, COUNTER, signal_state, stream
-                )
+                try:
+                    _compile_cache[m] = flyc.compile(
+                        launch_hgemm_kernel, C, A, B, m, COUNTER, signal_state, stream
+                    )
+                except Exception as e:
+                    raise RuntimeError(
+                        f"{KERNEL_NAME} failed "
+                        f"(arch={GPU_ARCH}, n={n}, k={k}, TILE_M={TILE_M}, TILE_N={TILE_N}, "
+                        f"TILE_K={TILE_K}, SPLIT_K={SPLIT_K}, B_TO_LDS={B_TO_LDS}, "
+                        f"SMEM_USE={SMEM_USE}, SMEM_LIMIT={smem_limit}): {e}",
+                    ) from e
             return _compile_cache[m]
 
     _launch.compile = _compile

--- a/aiter/ops/flydsl/utils.py
+++ b/aiter/ops/flydsl/utils.py
@@ -4,6 +4,7 @@
 """General utilities shared across all FlyDSL kernel families."""
 
 import importlib.util
+from functools import lru_cache
 
 import torch
 
@@ -21,13 +22,21 @@ def addressable_lds_bytes_for_gfx(gfx: str) -> int:
     return 65536
 
 
-def get_shared_memory_per_block(device=None, fallback_gfx: str = "") -> int:
-    """Return per-block shared memory/LDS limit for the active device."""
+@lru_cache(maxsize=1)
+def _default_cuda_device_index():
     try:
-        if device is None:
-            device = torch.cuda.current_device()
-        props = torch.cuda.get_device_properties(device)
-        shared_memory_per_block = int(getattr(props, "shared_memory_per_block", 0) or 0)
+        return int(torch.cuda.current_device())
+    except Exception:
+        return None
+
+
+@lru_cache(maxsize=None)
+def _get_shared_memory_per_block_cached(device_index: int, fallback_gfx: str) -> int:
+    try:
+        props = torch.cuda.get_device_properties(device_index)
+        shared_memory_per_block = int(
+            getattr(props, "shared_memory_per_block", 0) or 0
+        )
         if shared_memory_per_block > 0:
             return shared_memory_per_block
         return addressable_lds_bytes_for_gfx(
@@ -35,6 +44,28 @@ def get_shared_memory_per_block(device=None, fallback_gfx: str = "") -> int:
         )
     except Exception:
         return addressable_lds_bytes_for_gfx(fallback_gfx)
+
+
+def get_shared_memory_per_block(device=None, fallback_gfx: str = "") -> int:
+    """Return per-block shared memory/LDS limit for the active device."""
+    if device is None:
+        device = _default_cuda_device_index()
+    elif isinstance(device, torch.device):
+        if device.type != "cuda":
+            device = None
+        elif device.index is None:
+            device = _default_cuda_device_index()
+        else:
+            device = int(device.index)
+    else:
+        try:
+            device = int(device)
+        except Exception:
+            device = None
+
+    if device is None:
+        return addressable_lds_bytes_for_gfx(fallback_gfx)
+    return _get_shared_memory_per_block_cached(device, fallback_gfx)
 
 
 def is_flydsl_available() -> bool:

--- a/aiter/ops/flydsl/utils.py
+++ b/aiter/ops/flydsl/utils.py
@@ -34,9 +34,7 @@ def _default_cuda_device_index():
 def _get_shared_memory_per_block_cached(device_index: int, fallback_gfx: str) -> int:
     try:
         props = torch.cuda.get_device_properties(device_index)
-        shared_memory_per_block = int(
-            getattr(props, "shared_memory_per_block", 0) or 0
-        )
+        shared_memory_per_block = int(getattr(props, "shared_memory_per_block", 0) or 0)
         if shared_memory_per_block > 0:
             return shared_memory_per_block
         return addressable_lds_bytes_for_gfx(

--- a/aiter/ops/flydsl/utils.py
+++ b/aiter/ops/flydsl/utils.py
@@ -5,6 +5,37 @@
 
 import importlib.util
 
+import torch
+
+_FALLBACK_MAX_LDS_BYTES = 65536
+
+
+def addressable_lds_bytes_for_gfx(gfx: str) -> int:
+    g = (gfx or "").strip().lower().split(":")[0]
+    if not g.startswith("gfx"):
+        return _FALLBACK_MAX_LDS_BYTES
+    if g.startswith("gfx950"):
+        return 163840
+    if g.startswith("gfx7") or g.startswith("gfx8"):
+        return 32768
+    return 65536
+
+
+def get_shared_memory_per_block(device=None, fallback_gfx: str = "") -> int:
+    """Return per-block shared memory/LDS limit for the active device."""
+    try:
+        if device is None:
+            device = torch.cuda.current_device()
+        props = torch.cuda.get_device_properties(device)
+        shared_memory_per_block = int(
+            getattr(props, "shared_memory_per_block", 0) or 0
+        )
+        if shared_memory_per_block > 0:
+            return shared_memory_per_block
+        return addressable_lds_bytes_for_gfx(getattr(props, "gcnArchName", fallback_gfx))
+    except Exception:
+        return addressable_lds_bytes_for_gfx(fallback_gfx)
+
 
 def is_flydsl_available() -> bool:
     return importlib.util.find_spec("flydsl") is not None

--- a/aiter/ops/flydsl/utils.py
+++ b/aiter/ops/flydsl/utils.py
@@ -27,12 +27,12 @@ def get_shared_memory_per_block(device=None, fallback_gfx: str = "") -> int:
         if device is None:
             device = torch.cuda.current_device()
         props = torch.cuda.get_device_properties(device)
-        shared_memory_per_block = int(
-            getattr(props, "shared_memory_per_block", 0) or 0
-        )
+        shared_memory_per_block = int(getattr(props, "shared_memory_per_block", 0) or 0)
         if shared_memory_per_block > 0:
             return shared_memory_per_block
-        return addressable_lds_bytes_for_gfx(getattr(props, "gcnArchName", fallback_gfx))
+        return addressable_lds_bytes_for_gfx(
+            getattr(props, "gcnArchName", fallback_gfx)
+        )
     except Exception:
         return addressable_lds_bytes_for_gfx(fallback_gfx)
 

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -37,7 +37,9 @@ def gen_gemm_a8w8_ck_fake_tensors(
     return Out
 
 
-@compile_ops("module_gemm_a8w8", fc_name="gemm_a8w8", gen_fake=gen_gemm_a8w8_ck_fake_tensors)
+@compile_ops(
+    "module_gemm_a8w8", fc_name="gemm_a8w8", gen_fake=gen_gemm_a8w8_ck_fake_tensors
+)
 def gemm_a8w8_ck(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
@@ -357,7 +359,9 @@ def get_CKGEMM_config(M: int, N: int, K: int, tuned_file="a8w8_tuned_gemm.csv"):
         _CKGEMM_CONFIG_CACHE = {}
     if tuned_file not in _CKGEMM_CONFIG_CACHE:
         ckgemm_dict = pd.read_csv(f"{tuned_file}").drop_duplicates()
-        _CKGEMM_CONFIG_CACHE[tuned_file] = ckgemm_dict.set_index(["cu_num", "M", "N", "K"]).to_dict("index")
+        _CKGEMM_CONFIG_CACHE[tuned_file] = ckgemm_dict.set_index(
+            ["cu_num", "M", "N", "K"]
+        ).to_dict("index")
 
     cu_num = get_cu_num()
     padded_M = M
@@ -372,7 +376,9 @@ def get_CKGEMM_config(M: int, N: int, K: int, tuned_file="a8w8_tuned_gemm.csv"):
                 )
             break
     if config is None:
-        logger.info(f"shape is M:{M}, N:{N}, K:{K}, not found tuned config in {tuned_file}, will use default config!")
+        logger.info(
+            f"shape is M:{M}, N:{N}, K:{K}, not found tuned config in {tuned_file}, will use default config!"
+        )
     return config
 
 
@@ -391,9 +397,11 @@ def get_GEMM_config_with_quant_type(
     # Load file if not cached
     if tuned_file not in get_GEMM_config_with_quant_type.file_cache:
         asmGemmDictDf = pd.read_csv(tuned_file).drop_duplicates()
-        get_GEMM_config_with_quant_type.file_cache[tuned_file] = asmGemmDictDf.set_index(
-            ["cu_num", "M", "N", "K", "q_dtype_w"]
-        ).to_dict("index")
+        get_GEMM_config_with_quant_type.file_cache[tuned_file] = (
+            asmGemmDictDf.set_index(["cu_num", "M", "N", "K", "q_dtype_w"]).to_dict(
+                "index"
+            )
+        )
 
     cu_num = get_cu_num()
     padded_M = M
@@ -487,12 +495,16 @@ def gemm_a8w8_ASM(
         )
         is not None
     ):
-        assert bias is not None, "Use asm gemm must give bias, please give a \
+        assert (
+            bias is not None
+        ), "Use asm gemm must give bias, please give a \
             bias=torch.zeros(n,dtype=dtypes.fp32,device='cuda')"
         splitK = asm_config["splitK"]
         kernelName = asm_config["kernelName"]
         Y = torch.empty(m, n, dtype=dtype, device=XQ.device)
-        return gemm_a8w8_asm(XQ, WQ, x_scale, w_scale, Y, kernelName, bias, splitK=splitK)
+        return gemm_a8w8_asm(
+            XQ, WQ, x_scale, w_scale, Y, kernelName, bias, splitK=splitK
+        )
     Y = torch.empty(m, n, dtype=dtype, device=XQ.device)
     return gemm_a8w8_asm(XQ, WQ, x_scale, w_scale, Y, kernelName, bias, splitK=1)
 
@@ -515,7 +527,9 @@ def gemm_a8w8_CK(
     k = XQ.shape[-1]
 
     q_dtype_w = WQ.dtype if WQ.dtype in [dtypes.fp8, dtypes.i8] else dtypes.i8
-    ck_config = get_GEMM_config_with_quant_type(m, n, k, q_dtype_w, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_FILE)
+    ck_config = get_GEMM_config_with_quant_type(
+        m, n, k, q_dtype_w, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_FILE
+    )
     if splitK is None:
         if ck_config is not None:
             splitK = ck_config["splitK"]
@@ -628,7 +642,9 @@ def gemm_a8w8_blockscale(
         else:
             assert 0, "asm kernel only support B preshuffle and m >= 16"
     else:
-        config = get_CKGEMM_config(m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_FILE)
+        config = get_CKGEMM_config(
+            m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_FILE
+        )
         if config is not None:
             libtype = config["libtype"]
             if libtype == "ck":
@@ -682,7 +698,9 @@ def gemm_a8w8_blockscale_bpreshuffle(
     m = XQ.shape[0]
     n = WQ.shape[0]
     k = XQ.shape[1]
-    config = get_CKGEMM_config(m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE)
+    config = get_CKGEMM_config(
+        m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE
+    )
     Y = torch.empty(m, n, dtype=dtype, device=XQ.device)
     if config is not None:
         libtype = config["libtype"]

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -37,9 +37,7 @@ def gen_gemm_a8w8_ck_fake_tensors(
     return Out
 
 
-@compile_ops(
-    "module_gemm_a8w8", fc_name="gemm_a8w8", gen_fake=gen_gemm_a8w8_ck_fake_tensors
-)
+@compile_ops("module_gemm_a8w8", fc_name="gemm_a8w8", gen_fake=gen_gemm_a8w8_ck_fake_tensors)
 def gemm_a8w8_ck(
     XQ: torch.Tensor,
     WQ: torch.Tensor,
@@ -103,6 +101,23 @@ def gemm_a8w8_bpreshuffle_cktile(
 ) -> Tensor: ...
 
 
+def _parse_flydsl_kernel_name(kernel_name: str):
+    """Parse tile config from flydsl kernelName, e.g.
+    'flydsl_bpreshuflle_128x64x256_F8_F8_B16_2x0x1x1_default'
+    -> (tile_m=128, tile_n=64, tile_k=256, lds_stage=2, cshuffle=0, async_copy=1, wpe=1)
+    Returns None on parse failure.
+    """
+    import re
+
+    m = re.match(
+        r"flydsl_bpreshuflle_(\d+)x(\d+)x(\d+)_\w+_\w+_\w+_(\d+)x(\d+)x(\d+)x(\d+)",
+        kernel_name,
+    )
+    if m is None:
+        return None
+    return tuple(int(m.group(i)) for i in range(1, 8))
+
+
 def gemm_a8w8_bpreshuffle_flydsl(
     XQ: Tensor,
     WQ: Tensor,
@@ -112,22 +127,12 @@ def gemm_a8w8_bpreshuffle_flydsl(
     config: dict,
 ) -> Tensor:
     from .flydsl.gemm_kernels import flydsl_preshuffle_gemm_a8
-    from .flydsl.gemm_tune.flydsl_gemm_a8w8_bpreshuffle_common import (
-        kernels_list as kernels_list_flydsl,
-    )
 
-    kernel_id = config.get("kernelId")
-    if kernel_id is not None and kernel_id in kernels_list_flydsl:
-        ki = kernels_list_flydsl[kernel_id]
-        tm, tn, tk = ki.tile_m, ki.tile_n, ki.tile_k
-        lds, csh, acp, wpe = (
-            ki.lds_stage,
-            ki.use_cshuffle_epilog,
-            ki.use_async_copy,
-            ki.waves_per_eu,
-        )
-    else:
+    kernel_name = config.get("kernelName", "")
+    parsed = _parse_flydsl_kernel_name(str(kernel_name))
+    if parsed is None:
         return gemm_a8w8_bpreshuffle_ck(XQ, WQ, x_scale, w_scale, Out)
+    tm, tn, tk, lds, csh, acp, wpe = parsed
 
     flydsl_preshuffle_gemm_a8(
         XQ.contiguous(),
@@ -352,9 +357,7 @@ def get_CKGEMM_config(M: int, N: int, K: int, tuned_file="a8w8_tuned_gemm.csv"):
         _CKGEMM_CONFIG_CACHE = {}
     if tuned_file not in _CKGEMM_CONFIG_CACHE:
         ckgemm_dict = pd.read_csv(f"{tuned_file}").drop_duplicates()
-        _CKGEMM_CONFIG_CACHE[tuned_file] = ckgemm_dict.set_index(
-            ["cu_num", "M", "N", "K"]
-        ).to_dict("index")
+        _CKGEMM_CONFIG_CACHE[tuned_file] = ckgemm_dict.set_index(["cu_num", "M", "N", "K"]).to_dict("index")
 
     cu_num = get_cu_num()
     padded_M = M
@@ -369,9 +372,7 @@ def get_CKGEMM_config(M: int, N: int, K: int, tuned_file="a8w8_tuned_gemm.csv"):
                 )
             break
     if config is None:
-        logger.info(
-            f"shape is M:{M}, N:{N}, K:{K}, not found tuned config in {tuned_file}, will use default config!"
-        )
+        logger.info(f"shape is M:{M}, N:{N}, K:{K}, not found tuned config in {tuned_file}, will use default config!")
     return config
 
 
@@ -390,11 +391,9 @@ def get_GEMM_config_with_quant_type(
     # Load file if not cached
     if tuned_file not in get_GEMM_config_with_quant_type.file_cache:
         asmGemmDictDf = pd.read_csv(tuned_file).drop_duplicates()
-        get_GEMM_config_with_quant_type.file_cache[tuned_file] = (
-            asmGemmDictDf.set_index(["cu_num", "M", "N", "K", "q_dtype_w"]).to_dict(
-                "index"
-            )
-        )
+        get_GEMM_config_with_quant_type.file_cache[tuned_file] = asmGemmDictDf.set_index(
+            ["cu_num", "M", "N", "K", "q_dtype_w"]
+        ).to_dict("index")
 
     cu_num = get_cu_num()
     padded_M = M
@@ -493,9 +492,7 @@ def gemm_a8w8_ASM(
         splitK = asm_config["splitK"]
         kernelName = asm_config["kernelName"]
         Y = torch.empty(m, n, dtype=dtype, device=XQ.device)
-        return gemm_a8w8_asm(
-            XQ, WQ, x_scale, w_scale, Y, kernelName, bias, splitK=splitK
-        )
+        return gemm_a8w8_asm(XQ, WQ, x_scale, w_scale, Y, kernelName, bias, splitK=splitK)
     Y = torch.empty(m, n, dtype=dtype, device=XQ.device)
     return gemm_a8w8_asm(XQ, WQ, x_scale, w_scale, Y, kernelName, bias, splitK=1)
 
@@ -518,9 +515,7 @@ def gemm_a8w8_CK(
     k = XQ.shape[-1]
 
     q_dtype_w = WQ.dtype if WQ.dtype in [dtypes.fp8, dtypes.i8] else dtypes.i8
-    ck_config = get_GEMM_config_with_quant_type(
-        m, n, k, q_dtype_w, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_FILE
-    )
+    ck_config = get_GEMM_config_with_quant_type(m, n, k, q_dtype_w, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_FILE)
     if splitK is None:
         if ck_config is not None:
             splitK = ck_config["splitK"]
@@ -633,9 +628,7 @@ def gemm_a8w8_blockscale(
         else:
             assert 0, "asm kernel only support B preshuffle and m >= 16"
     else:
-        config = get_CKGEMM_config(
-            m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_FILE
-        )
+        config = get_CKGEMM_config(m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_FILE)
         if config is not None:
             libtype = config["libtype"]
             if libtype == "ck":
@@ -689,9 +682,7 @@ def gemm_a8w8_blockscale_bpreshuffle(
     m = XQ.shape[0]
     n = WQ.shape[0]
     k = XQ.shape[1]
-    config = get_CKGEMM_config(
-        m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE
-    )
+    config = get_CKGEMM_config(m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE)
     Y = torch.empty(m, n, dtype=dtype, device=XQ.device)
     if config is not None:
         libtype = config["libtype"]

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -497,8 +497,7 @@ def gemm_a8w8_ASM(
     ):
         assert (
             bias is not None
-        ), "Use asm gemm must give bias, please give a \
-            bias=torch.zeros(n,dtype=dtypes.fp32,device='cuda')"
+        ), "Use asm gemm must give bias, please give a bias=torch.zeros(n,dtype=dtypes.fp32,device='cuda')"
         splitK = asm_config["splitK"]
         kernelName = asm_config["kernelName"]
         Y = torch.empty(m, n, dtype=dtype, device=XQ.device)

--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -443,13 +443,13 @@ class TunerCommon:
                     f"error: no valid candidate found for {info_key}, please check the result or errRatio in all result file running with --profile_file"
                 )
 
-            if len(filtered_time) < topk:
-                topk = len(filtered_time)
-                print(f"choose {topk} kernels")
-            self.topk = topk
+            effective_topk = min(topk, len(filtered_time))
+            if effective_topk < topk:
+                print(f"choose {effective_topk} kernels")
+            self.topk = effective_topk
             best_config = [
                 ((info_key, *info_ex), us, max_err_ratio)
-                for info_ex, us, max_err_ratio in filtered_time[0:topk]
+                for info_ex, us, max_err_ratio in filtered_time[0:effective_topk]
             ]
             if not best_config:
                 logger.info(f"No kernel can be used for {info_key}")

--- a/aiter/utility/mp_tuner.py
+++ b/aiter/utility/mp_tuner.py
@@ -9,6 +9,14 @@ from aiter import dtypes
 from aiter import logger
 
 
+def _is_mapping_error(exc: BaseException) -> bool:
+    return isinstance(exc, KeyError)
+
+
+def _is_accelerator_error(exc: BaseException) -> bool:
+    return type(exc).__name__ == "AcceleratorError"
+
+
 def worker(
     gpu_id,
     info,
@@ -36,7 +44,7 @@ def worker(
             res, us = run_perftest(func, *args, **kwargs)
             us = round(us, 4)
 
-        except RuntimeError as e:
+        except (RuntimeError, ValueError) as e:
             print(f"run gpu func warning: info:{info}\t {e}", flush=True)
             us = -1  # not support or error
             max_err_ratio = 1.0
@@ -50,6 +58,8 @@ def worker(
         if us == 0:
             print(f"Warning: try run {max_retries} times, but still get 0!")
         torch.cuda.synchronize()
+        if us == -1 or res is None:
+            return info, us, round(max_err_ratio, 4)
         if ref is not None:
             if isinstance(ref, torch.Tensor):
                 ref = [ref]
@@ -448,14 +458,13 @@ def mp_tuner(
             except Exception as e:
                 # Check if it's a process crash (segfault, memory fault, etc.)
                 error_type = type(e).__name__
-
-                # Special handling for KeyError (PID mapping issue)
-                is_mapping_error = error_type == "KeyError"
+                is_mapping_error = _is_mapping_error(e)
+                is_accelerator_error = _is_accelerator_error(e)
                 # not restart as this is not root use
                 if is_mapping_error:
                     error_msg = f"[Mapping Error] Task {k} - Process PID not in GPU map: {error_type} - {e}"
                     dummy_failed_tasks.append((k, "mapping error"))
-                elif error_type == "AcceleratorError":
+                elif is_accelerator_error:
                     # GPU fault (e.g. illegal memory access): worker returns exception instead of
                     # hanging. Unlike hang->timeout, the faulting worker may stay alive and accept
                     # more tasks on the same bad GPU. Break immediately to trigger restart and


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- Use device shared-memory/LDS limits for FlyDSL GEMM filtering and split-k kernel validation instead of relying on a fixed LDS cap.
- Surface FlyDSL candidate compile/LDS failures as concise runtime warnings so tuning can continue without noisy tracebacks.
- Keep tuner `topk` selection local to each shape to avoid leaking a reduced candidate limit into later shape groups.

## Test Plan

- Verified failing candidates now log a single concise warning with kernel/context information and no extra traceback noise.
- Verified tuning still completes and produces a valid best kernel result.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
