### PR TITLE
Revert max_size from 1GB to 128MB to fix KV cache regression

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -256,7 +256,7 @@ class CustomAllreduce:
         self,
         group: ProcessGroup,
         device: Union[int, str, torch.device],
-        max_size=1024 * 1024 * 1024,  # 2GB bf16/half
+        max_size=8192 * 1024 * 8 * 2,  # 128MB - match old e47cc0ec behavior
         enable_register_for_capturing: bool = True,
     ) -> None:
         """


### PR DESCRIPTION
The max_size change in 8cfe5e28 (1024*1024*1024 = 1GB) causes:
1. Prefill allreduce dispatch change: QuickReduce INT8 -> custom_all_reduce
2. GPU memory increase: +3.6GB/GPU for allreduce buffers
3. KV cache reduction: -75K tokens (-1.68%), -2.47GB

This causes MTP accept rate regression at C>=2 (-8~10%) and throughput regression (-4~10%) while only C=1 improves slightly.

Reverting to 8192*1024*8*2 = 128MB restores the old dispatch behavior and recovers full KV cache capacity.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
