### PR TITLE
[FLYDSL] Rebase GDR decode kernel for `flydsl-0.1.3.1`

### DIFF
--- a/aiter/ops/flydsl/kernels/gdr_decode.py
+++ b/aiter/ops/flydsl/kernels/gdr_decode.py
@@ -10,6 +10,7 @@ from flydsl.expr.typing import T
 from flydsl._mlir.dialects import (
     gpu as mlir_gpu,
     math as mlir_math,
+    vector as mlir_vector,
 )
 from flydsl.expr import range_constexpr, arith, vector, rocdl
 from flydsl._mlir import ir
@@ -30,11 +31,13 @@ fm_fast = arith.FastMathFlags.fast
 @functools.lru_cache(maxsize=1024)
 def create_shuffle_gdr_decode_kernel(
     dtype: str,
+    A_log_dtype: str,
     seq_length: int,
     num_k_heads: int,
     num_v_heads: int,
     head_k_dim: int,
     head_v_dim: int,
+    state_strides: tuple,
     use_qk_l2norm: bool,
     softplus_beta: float = 1.0,
     softplus_threshold: float = 20.0,
@@ -106,6 +109,7 @@ def create_shuffle_gdr_decode_kernel(
         softplus_threshold_ = arith.constant(softplus_threshold, type=T.f32)
 
         dtype_ = get_dtype_in_kernel(dtype)
+        A_log_dtype_ = get_dtype_in_kernel(A_log_dtype)
         # i32_0 = arith.constant(0, type=T.i32)
         f32_0 = arith.constant(0.0, type=T.f32)
         f32_1 = arith.constant(1.0, type=T.f32)
@@ -142,9 +146,17 @@ def create_shuffle_gdr_decode_kernel(
         a_tensor = GTensor(a, dtype=dtype_, shape=(-1, seq_length, num_v_heads))
         b_tensor = GTensor(b, dtype=dtype_, shape=(-1, seq_length, num_v_heads))
         dt_bias_tensor = GTensor(dt_bias, dtype=dtype_, shape=(num_v_heads,))
-        A_log_tensor = GTensor(A_log, dtype=T.f32, shape=(num_v_heads,))
+        A_log_tensor = GTensor(A_log, dtype=A_log_dtype_, shape=(num_v_heads,))
         state_tensor = GTensor(
-            state, dtype=T.f32, shape=(-1, num_v_heads, head_v_dim, head_k_dim)
+            state,
+            dtype=T.f32,
+            shape=(-1, num_v_heads, head_v_dim, head_k_dim),
+            stride=(
+                state_strides[0],
+                state_strides[1],
+                state_strides[2],
+                state_strides[3],
+            ),
         )
         out_tensor = GTensor(
             out, dtype=dtype_, shape=(-1, seq_length, num_v_heads, head_v_dim)
@@ -168,7 +180,10 @@ def create_shuffle_gdr_decode_kernel(
         cond_valid_if = scf.IfOp(cond_valid, results_=[], has_else=False)
         with ir.InsertionPoint(cond_valid_if.then_block):
 
-            r_A_log = A_log_tensor[hv_i]
+            if "f32" in A_log_dtype:
+                r_A_log = A_log_tensor[hv_i]
+            else:
+                r_A_log = A_log_tensor[hv_i].extf(T.f32)
             r_dt_bias = dt_bias_tensor[hv_i].extf(T.f32)
 
             state_vecs = [0] * (WARP_TILE_V_ITERS * WARP_TILE_K_ITERS)
@@ -237,10 +252,10 @@ def create_shuffle_gdr_decode_kernel(
                         sum_k_partial_vec = (
                             sum_k_partial_vec + sk_vecs[ki] * sk_vecs[ki]
                         )
-                        sum_q_partial = vector.ReductionOp(
+                        sum_q_partial = mlir_vector.ReductionOp(
                             T.f32, vector.CombiningKind.ADD, sum_q_partial_vec
                         ).dest
-                        sum_k_partial = vector.ReductionOp(
+                        sum_k_partial = mlir_vector.ReductionOp(
                             T.f32, vector.CombiningKind.ADD, sum_k_partial_vec
                         ).dest
                     for offset in WARP_THREADS_K_SHFL_OFFSETS:
@@ -300,7 +315,7 @@ def create_shuffle_gdr_decode_kernel(
                             state_vecs[vi * WARP_TILE_K_ITERS + ki], sk_vecs[ki], sum_hk
                         ).result
 
-                    sum_hk = vector.ReductionOp(
+                    sum_hk = mlir_vector.ReductionOp(
                         T.f32, vector.CombiningKind.ADD, sum_hk
                     ).dest
 
@@ -333,7 +348,7 @@ def create_shuffle_gdr_decode_kernel(
                         state_vecs[vi * WARP_TILE_K_ITERS + ki] = h_new
                         sum_hq = vector.FMAOp(h_new, r_q_val, sum_hq).result
 
-                    sum_hq = vector.ReductionOp(
+                    sum_hq = mlir_vector.ReductionOp(
                         T.f32, vector.CombiningKind.ADD, sum_hq
                     ).dest
 

--- a/aiter/ops/flydsl/linear_attention_kernels.py
+++ b/aiter/ops/flydsl/linear_attention_kernels.py
@@ -62,11 +62,13 @@ def flydsl_gdr_decode(
     kwargs = get_default_kwargs(batch_size, seq_length)
     exe = create_shuffle_gdr_decode_kernel(
         get_dtype_str(query.dtype),
+        get_dtype_str(A_log.dtype),
         seq_length,
         num_k_heads,
         num_v_heads,
         head_k_dim,
         head_v_dim,
+        state.stride(),
         use_qk_l2norm,
         **kwargs,
     )


### PR DESCRIPTION
## Motivation

1. Rebase FlyDSL GDR decode kernel to fit new flydsl version
2. Add linear attention state tensor stride support.
