### PR TITLE
[TRITON] Fix `test_moe_routing_sigmoid_top1_fused` reference implementation tie-breaking

### DIFF
--- a/op_tests/triton_tests/moe/test_moe_routing_sigmoid_top1_fused.py
+++ b/op_tests/triton_tests/moe/test_moe_routing_sigmoid_top1_fused.py
@@ -17,7 +17,8 @@ def torch_routing_sigmoid_top1(
 
     assert topk == 1
 
-    topk_weights, topk_ids = torch.topk(scores, topk, dim=1)  # [M, topk]
+    topk_ids = torch.argmax(scores, dim=1, keepdim=True)  # [M, topk]
+    topk_weights = torch.gather(scores, dim=1, index=topk_ids)  # [M, topk]
 
     topk_ids = topk_ids.to(torch.int32)
     topk_weights = topk_weights.to(torch.float32)


### PR DESCRIPTION
## Motivation

Update of `rocm/pytorch:latest` Docker image from `2.10.0+rocm7.2.0.gitb6ee5fde` to `2.10.0+rocm7.2.2.git40d237bf` caused 10 unexpected failures in `op_tests/triton_tests/moe/test_moe_routing_sigmoid_top1_fused.py`. This PR fixes the issue.

## Technical Details

Replace `torch.topk` with `torch.argmax` + `torch.gather` in the reference implementation. `torch.topk` doesn't guarantee stable indices for tied elements, and its tie-breaking behavior changed between ROCm 7.2.0 and 7.2.2, causing 10 tests to fail for `N=128`, where integer inputs produce many tied sigmoid scores. `torch.argmax` always returns the first (leftmost) maximum, matching `tl.argmax(..., tie_break_left=True)` in the Triton kernel.

## Test Plan

Run `test_moe_routing_sigmoid_top1_fused.py` test:

```bash
pytest op_tests/triton_tests/moe/test_moe_routing_sigmoid_top1_fused.py
```

The expected result is no failures at all, no matter `rocm/pytorch` Docker container version.

## Test Result

* PyTorch version `2.10.0+rocm7.2.0.gitb6ee5fde`: 20 passed ✅
* PyTorch version `2.10.0+rocm7.2.2.git40d237bf`: 20 passed ✅

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
