### PR TITLE
CI: scope check-signal artifact downloads to matching run

### DIFF
--- a/.github/scripts/check_signal.sh
+++ b/.github/scripts/check_signal.sh
@@ -1,34 +1,132 @@
 #!/bin/bash
 
-# This script attempts to download a pre-checks artifact from a GitHub workflow up to 5 times.
-# If the artifact is found and the signal indicates success, the workflow continues.
-# If the signal indicates failure, the workflow is skipped with details printed.
-# If the artifact cannot be downloaded after all retries, the workflow exits with an error.
+# This script downloads the pre-checks artifact produced by the Checks workflow.
+# It scopes artifact lookup to the matching workflow run for the current branch and
+# head SHA, which avoids repo-wide artifact pagination and GitHub API rate limits.
 
-set -e
+set -euo pipefail
 
-ARTIFACT_NAME="checks-signal-${GITHUB_SHA:-${1}}"
-MAX_RETRIES=5
+ARTIFACT_NAME="checks-signal-${GITHUB_SHA:-${1:-}}"
+CHECKS_WORKFLOW_NAME="${CHECKS_WORKFLOW_NAME:-Checks}"
+MAX_RETRIES="${MAX_RETRIES:-5}"
+RETRY_INTERVAL_SECONDS="${RETRY_INTERVAL_SECONDS:-30}"
+REPO="${GITHUB_REPOSITORY:-}"
 
-for i in $(seq 1 $MAX_RETRIES); do
-  echo "Attempt $i: Downloading artifact..."
-  if gh run download --name "$ARTIFACT_NAME"; then
-    if [ -f checks_signal.txt ]; then
-      echo "Artifact $ARTIFACT_NAME downloaded successfully."
-      SIGNAL=$(head -n 1 checks_signal.txt)
-      if [ "$SIGNAL" = "success" ]; then
-        echo "Pre-checks passed, continuing workflow."
-        exit 0
-      else
+if [ -z "${ARTIFACT_NAME#checks-signal-}" ]; then
+  echo "GITHUB_SHA or an explicit SHA argument is required."
+  exit 1
+fi
+
+get_target_branch() {
+  if [ -n "${GITHUB_HEAD_REF:-}" ]; then
+    printf '%s\n' "${GITHUB_HEAD_REF}"
+    return
+  fi
+
+  if [ -n "${GITHUB_REF_NAME:-}" ]; then
+    printf '%s\n' "${GITHUB_REF_NAME}"
+    return
+  fi
+
+  python3 - <<'PY'
+import json
+import os
+
+event_path = os.environ.get("GITHUB_EVENT_PATH")
+if event_path and os.path.exists(event_path):
+    with open(event_path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    print(data.get("pull_request", {}).get("head", {}).get("ref", ""))
+else:
+    print("")
+PY
+}
+
+get_target_head_sha() {
+  case "${GITHUB_EVENT_NAME:-}" in
+    pull_request|pull_request_target)
+      python3 - <<'PY'
+import json
+import os
+
+event_path = os.environ.get("GITHUB_EVENT_PATH")
+if event_path and os.path.exists(event_path):
+    with open(event_path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    print(data.get("pull_request", {}).get("head", {}).get("sha", ""))
+else:
+    print("")
+PY
+      ;;
+    *)
+      printf '%s\n' "${GITHUB_SHA:-}"
+      ;;
+  esac
+}
+
+find_checks_run_id() {
+  local target_branch target_head_sha
+  target_branch="$(get_target_branch)"
+  target_head_sha="$(get_target_head_sha)"
+
+  if [ -z "${REPO}" ]; then
+    echo "GITHUB_REPOSITORY is required to locate the Checks workflow run." >&2
+    return 1
+  fi
+
+  if [ -z "${target_head_sha}" ]; then
+    echo "Could not determine the target head SHA for the Checks workflow run." >&2
+    return 1
+  fi
+
+  local -a gh_args=(
+    run list
+    --repo "${REPO}"
+    --workflow "${CHECKS_WORKFLOW_NAME}"
+    --limit 20
+    --json databaseId,headSha,headBranch,event,createdAt,status
+  )
+
+  if [ -n "${target_branch}" ]; then
+    gh_args+=(--branch "${target_branch}")
+  fi
+
+  if [ -n "${GITHUB_EVENT_NAME:-}" ]; then
+    gh_args+=(--event "${GITHUB_EVENT_NAME}")
+  fi
+
+  gh "${gh_args[@]}" \
+    --jq "(map(select(.headSha == \"${target_head_sha}\")) | first | .databaseId) // empty"
+}
+
+for i in $(seq 1 "${MAX_RETRIES}"); do
+  echo "Attempt ${i}: Locating ${CHECKS_WORKFLOW_NAME} workflow run..."
+  rm -f checks_signal.txt
+
+  RUN_ID="$(find_checks_run_id || true)"
+  if [ -n "${RUN_ID}" ]; then
+    echo "Attempt ${i}: Downloading artifact '${ARTIFACT_NAME}' from run ${RUN_ID}..."
+    if gh run download "${RUN_ID}" --repo "${REPO}" --name "${ARTIFACT_NAME}"; then
+      if [ -f checks_signal.txt ]; then
+        echo "Artifact ${ARTIFACT_NAME} downloaded successfully."
+        SIGNAL="$(head -n 1 checks_signal.txt)"
+        if [ "${SIGNAL}" = "success" ]; then
+          echo "Pre-checks passed, continuing workflow."
+          exit 0
+        fi
+
         echo "Pre-checks failed, skipping workflow. Details:"
         tail -n +2 checks_signal.txt
         exit 78  # 78 = neutral/skip
       fi
     fi
+  else
+    echo "Attempt ${i}: Matching ${CHECKS_WORKFLOW_NAME} run not found yet."
   fi
-  echo "Artifact not found, retrying in 30s..."
-  sleep 30
+
+  echo "Artifact not ready yet, retrying in ${RETRY_INTERVAL_SECONDS}s..."
+  sleep "${RETRY_INTERVAL_SECONDS}"
 done
 
-echo "Failed to download pre-checks artifact after $MAX_RETRIES attempts. Exiting workflow."
+echo "Failed to download pre-checks artifact after ${MAX_RETRIES} attempts. Exiting workflow."
 exit 1


### PR DESCRIPTION
Closes #2755

## Summary
- scope `check_signal.sh` artifact downloads to the matching `Checks` workflow run instead of scanning artifacts repo-wide
- derive the PR head SHA from the event payload while keeping the merge SHA for the artifact name lookup
- keep the existing retry behavior, but avoid the GitHub Actions artifact API rate limit failure mode

## Test plan
- [x] `bash -n .github/scripts/check_signal.sh`
- [x] Replayed the failing PR context from run `24494735362` and verified the script downloads `checks-signal-d4fa6e2a98ee2336b19ed7d520e98242e65a6992` from `Checks` run `24494735372`
- [x] Replayed the `main` push context and verified the script downloads `checks-signal-8090820237161af1b14d53bf66e467af588357a8` from `Checks` run `24494517186`