### PR TITLE
CI: reduce retention for workflow artifacts

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -163,6 +163,7 @@ jobs:
         with:
           name: aiter-whl-packages-py${{ matrix.python_version }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/*.whl
+          retention-days: 14
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -156,6 +156,7 @@ jobs:
         with:
           name: aiter-whl-main-${{ github.run_id }}
           path: dist/*.whl
+          retention-days: 14
 
       - name: Configure AWS credentials
         if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
@@ -221,6 +222,7 @@ jobs:
         with:
           name: aiter_shards
           path: aiter_shard_*.list
+          retention-days: 7
 
   standard:
     if: >-
@@ -400,6 +402,7 @@ jobs:
         with:
           name: standard-test-log-${{ matrix.runner }}-shard-${{ matrix.shard_idx }}
           path: latest_test.log
+          retention-days: 7
 
       - name: Cleanup container
         if: always()
@@ -528,6 +531,7 @@ jobs:
         with:
           name: multigpu-test-${{ matrix.runner }}
           path: latest_test.log
+          retention-days: 7
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/amd-ci-job-monitor.yml
+++ b/.github/workflows/amd-ci-job-monitor.yml
@@ -150,6 +150,7 @@ jobs:
         with:
           name: actions-job-snapshot
           path: actions-snapshot.json
+          retention-days: 7
 
   matrix-reports:
     name: ${{ matrix.workflow }} - ${{ matrix.job_name }}

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -263,6 +263,7 @@ jobs:
         with:
           name: ${{ matrix.model_name }}_${{ matrix.label }}_${{ matrix.runner }}_atom_accuracy_output.txt
           path: atom_accuracy_output.txt
+          retention-days: 7
 
       - name: Clean Up
         if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && always()

--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -229,6 +229,7 @@ jobs:
             benchmark_fa_triton_${{ matrix.label }}.log
             benchmark_mha_daoai_${{ matrix.label }}.log
             bench_dao_ai_${{ matrix.label }}/
+          retention-days: 7
 
       - name: Clean Up
         if: always()

--- a/.github/workflows/operators-tuning.yaml
+++ b/.github/workflows/operators-tuning.yaml
@@ -108,6 +108,7 @@ jobs:
         with:
           name: tuned-csvs
           path: aiter/configs/*.csv
+          retention-days: 7
       
       - name: Cleanup
         if: always()

--- a/.github/workflows/opus-test.yaml
+++ b/.github/workflows/opus-test.yaml
@@ -105,6 +105,7 @@ jobs:
           name: opus-test-log-${{ matrix.runner }}
           path: latest_test.log
           if-no-files-found: warn
+          retention-days: 7
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -78,6 +78,7 @@ jobs:
         with:
           name: checks-signal-${{ github.sha }}
           path: checks_signal.txt
+          retention-days: 1
 
   upload-failure-artifact:
     name: Upload Failure Signal
@@ -103,3 +104,4 @@ jobs:
         with:
           name: checks-signal-${{ github.sha }}
           path: checks_signal.txt
+          retention-days: 1

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           name: triton_shards
           path: triton_shard_*.list
+          retention-days: 7
 
   # Build Triton wheel once, shared by all shard jobs via artifact
   build-triton:
@@ -107,6 +108,7 @@ jobs:
         with:
           name: triton-wheel
           path: triton-wheels/*.whl
+          retention-days: 7
 
   # Step 2: MI325 matrix jobs (always runs)
   triton:
@@ -234,6 +236,7 @@ jobs:
         with:
           name: triton-test-shard-${{ matrix.shard }}
           path: test-reports/triton.xml
+          retention-days: 7
 
       - name: Cleanup container
         if: always()
@@ -344,6 +347,7 @@ jobs:
         with:
           name: triton-test-mi35x-shard-${{ matrix.shard }}
           path: test-reports/triton.xml
+          retention-days: 7
 
       - name: Cleanup container
         if: always()


### PR DESCRIPTION
Fix: https://github.com/ROCm/aiter/issues/2755
## Summary
- set `checks-signal-*` artifacts to 1 day retention
- set shard lists, routine test logs, job snapshots, and benchmark outputs to 7 day retention
- keep wheel artifacts available longer with 14 day retention

## Notes
- this PR only sets workflow-level `retention-days` values on uploaded artifacts
- the repository-level default Actions retention setting still needs to be updated separately in GitHub settings if we want a 14 day default for all new artifacts and logs

## Test plan
- [x] Verified every `actions/upload-artifact@v4` block defines `retention-days`
- [x] `git diff --check`
- [x] Checked the workflow diffs to confirm artifact classes map to the intended retention buckets