### PR TITLE
docs(skills): add AITER Claude/Cursor skill set with validator

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,92 @@
+# AITER Claude Skills
+
+This folder contains a set of [Claude skills](https://docs.anthropic.com/en/docs/claude-code/skills)
+tailored for working on [AITER](https://github.com/ROCm/aiter) — AMD's centralized
+repository of high-performance AI operators on ROCm.
+
+These skills encode AITER-specific conventions (JIT compilation, `optCompilerConfig.json`,
+tuning CSVs, the HIP / CK / Triton / FlyDSL / ASM backend split, `op_tests/` layout,
+pre-commit formatting, …) so an agent can plug into the codebase without having to
+re-discover them every session.
+
+The structure mirrors `ROCm/FlyDSL/.claude/skills` and the same skills can also be
+dropped into `.cursor/skills/` for Cursor Agent users.
+
+## Skills at a glance
+
+| Skill | Purpose |
+|-------|---------|
+| [`build-aiter`](./build-aiter/SKILL.md) | Install / build AITER (`setup.py develop`, `PREBUILD_KERNELS`, `GPU_ARCHS`). |
+| [`aiter-add-operator`](./aiter-add-operator/SKILL.md) | End-to-end recipe for adding a new op: C++/HIP kernel → pybind → `optCompilerConfig.json` → Python wrapper → `op_tests/` test. |
+| [`aiter-jit-debug`](./aiter-jit-debug/SKILL.md) | Diagnose JIT compile / module-load failures (missing `.so`, hipify issues, `AITER_REBUILD`, cache at `aiter/jit/build`). |
+| [`aiter-triton-kernel`](./aiter-triton-kernel/SKILL.md) | Author Triton kernels following the `aiter/ops/triton/` layout, `get_gemm_config`, `make_kernel_repr`, and arch-string conventions. |
+| [`aiter-ck-tune`](./aiter-ck-tune/SKILL.md) | Tune & integrate CK-tile kernels (GEMM A8W8, FMOE, etc.) via `gemm_a*_tune.py` and the `untuned_*.csv` / `tuned_*.csv` flow. |
+| [`debug-aiter-op`](./debug-aiter-op/SKILL.md) | Systematically debug a failing `op_tests/test_*.py` (correctness, NaN, dtype, stride, backend selection). |
+| [`benchmark-aiter-op`](./benchmark-aiter-op/SKILL.md) | Benchmark an op with `@perftest`, compare AITER vs reference vs alternative backends, report roofline numbers. |
+| [`aiter-moe-tuning`](./aiter-moe-tuning/SKILL.md) | Tune the fused-MoE op (`tuned_fmoe.csv`, `untuned_fmoe.csv`) and per-model configs under `aiter/configs/model_configs/`. |
+| [`format-code`](./format-code/SKILL.md) | Run AITER's pre-commit-compatible formatting: `black==26.3.0`, `ruff==0.15.7`, `clang-format-18`, plus the copyright-year bump. |
+| [`capture-kernel-trace`](./capture-kernel-trace/SKILL.md) | Capture an `rocprofv3` ATT trace for an AITER kernel. |
+| [`kernel-trace-analysis`](./kernel-trace-analysis/SKILL.md) | Analyze an ATT trace to find top stall hotspots mapped back to source. |
+| [`bisect-perf-regression`](./bisect-perf-regression/SKILL.md) | Binary-search which AITER commit introduced a perf regression. |
+
+## Using the skills
+
+Claude Code / Codex: skills are auto-loaded from the repo's `.claude/skills/`
+folder. Invoke explicitly with `/ ` (e.g. `/build-aiter`) or just describe
+the task and let the agent pick the matching skill from the frontmatter.
+
+Cursor Agent: copy (or symlink) the `.claude/skills/` directory to
+`.cursor/skills/` in this repo, or to `~/.cursor/skills-cursor/` for global scope.
+
+## Conventions used by every skill
+
+- **GPU archs**: `gfx942` (MI300X) and `gfx950` (MI350X). Never parse product names;
+  compare against the arch string (see `aiter/ops/triton/README.md`).
+- **JIT cache**: compiled `.so` and `build/` live under `aiter/jit/`.
+  `AITER_REBUILD=1` forces a rebuild, `AITER_LOG_MORE=1` increases verbosity.
+- **Tuning data**: lives as CSV under `aiter/configs/` (plus `model_configs/`
+  for per-model overrides). Every tuned op has a matched `*_untuned_*.csv` +
+  `*_tuned_*.csv` pair.
+- **Tests**: standalone Python scripts under `op_tests/`; run with
+  `python op_tests/test_ .py` (no pytest required) or the CI helper
+  `bash .github/scripts/aiter_test.sh`. Triton tests under `op_tests/triton_tests/`
+  use `pytest`.
+- **Pre-commit**: black / ruff / clang-format-18 with specific pinned versions
+  (see [CONTRIBUTE.md](../../CONTRIBUTE.md)). The `format-code` skill reproduces
+  that pipeline.
+
+## Validating the skills
+
+A lightweight validator is shipped with the skill set:
+
+```bash
+python .claude/skills/validate.py           # format + fact check; exits 0 on pass
+python .claude/skills/validate.py --strict  # also fail on warnings
+```
+
+It verifies that every `SKILL.md` has proper YAML front matter, that
+`name:` matches the directory, and that every AITER-repo path cited in
+inline code actually exists in the checkout. The full test plan
+(including a behavioral test matrix) lives in [`TESTS.md`](./TESTS.md).
+
+## Contributing a new skill
+
+Follow the format used by every file here:
+
+```markdown
+---
+name: my-skill
+description: >
+ One-paragraph description. Claude reads this to decide when to activate the skill.
+ Usage: /my-skill 
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# My Skill
+
+## Step 1 ...
+## Step 2 ...
+```
+
+Keep skills **task-oriented**, **AITER-specific**, and **runnable**
+(prefer concrete shell commands and file paths over abstract advice).

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,63 +1,194 @@
 # AITER Claude Skills
 
 This folder contains a set of [Claude skills](https://docs.anthropic.com/en/docs/claude-code/skills)
-tailored for working on [AITER](https://github.com/ROCm/aiter) — AMD's centralized
-repository of high-performance AI operators on ROCm.
+tailored for working on [AITER](https://github.com/ROCm/aiter) — AMD's
+centralized repository of high-performance AI operators on ROCm.
 
-These skills encode AITER-specific conventions (JIT compilation, `optCompilerConfig.json`,
-tuning CSVs, the HIP / CK / Triton / FlyDSL / ASM backend split, `op_tests/` layout,
-pre-commit formatting, …) so an agent can plug into the codebase without having to
-re-discover them every session.
+**What a skill is, in one sentence:** a small Markdown file that teaches
+the AI agent a project-specific workflow (commands, file paths, pitfalls)
+so you don't have to re-explain AITER every time you open a session.
 
-The structure mirrors `ROCm/FlyDSL/.claude/skills` and the same skills can also be
-dropped into `.cursor/skills/` for Cursor Agent users.
+These skills encode AITER conventions (JIT compilation,
+`optCompilerConfig.json`, tuning CSVs, the HIP / CK / Triton / FlyDSL /
+ASM backend split, `op_tests/` layout, pre-commit formatting, …).
+
+The structure mirrors `ROCm/FlyDSL/.claude/skills` and works for both
+Claude Code / Codex and Cursor Agent.
+
+---
+
+## If you're brand new: 5-minute quickstart
+
+### 1. Prerequisites
+
+| You want to … | You need |
+|---|---|
+| **Use the skills** (agent reads them as context) | An agent that supports skills: Claude Code, Codex CLI, or Cursor Agent. That's it. No GPU needed just to read skills. |
+| **Actually build AITER** | Linux + ROCm (6.x) + a supported GPU (gfx942 / MI300X, or gfx950 / MI350X). Windows hosts can read/edit code but CK and `PREBUILD_KERNELS` are disabled in `setup.py` — use WSL2 for a real build. |
+| **Follow skills like `aiter-ck-tune`, `aiter-moe-tuning`, `capture-kernel-trace`** | A ROCm box with the target GPU + `rocprofv3`. |
+| **Follow skills like `aiter-add-operator`, `format-code`, `build-aiter`** | Any machine where you can clone the repo is fine (no GPU required for reading the walkthrough). |
+
+### 2. Install the skills
+
+The files in this folder *are* the install — you just need the agent to
+see them.
+
+**Claude Code / Codex CLI** (auto-discovery):
+
+```bash
+# Already done — anything committed under .claude/skills/ in this repo
+# is auto-loaded when the agent runs from the repo root.
+claude --version   # any recent version
+```
+
+**Cursor Agent** (repo-local):
+
+```powershell
+# Windows PowerShell (run from repo root)
+New-Item -ItemType Directory -Force .cursor | Out-Null
+Copy-Item -Recurse -Force .claude\skills .cursor\skills
+```
+
+```bash
+# Linux / macOS / WSL (run from repo root)
+mkdir -p .cursor && cp -r .claude/skills .cursor/skills
+```
+
+Or make them available in **every** Cursor project:
+
+```bash
+# Linux / macOS
+cp -r .claude/skills/* ~/.cursor/skills-cursor/
+```
+
+```powershell
+# Windows PowerShell
+Copy-Item -Recurse -Force .claude\skills\* $HOME\.cursor\skills-cursor\
+```
+
+### 3. Verify installation
+
+Run the validator — it also double-checks the skills haven't drifted out
+of sync with the repo (renamed file, missing tuner script, …):
+
+```bash
+python .claude/skills/validate.py
+# expected: "Checked 13 SKILL.md files  errors: 0  warnings: 0"
+```
+
+Then ask the agent a probe prompt and watch it trigger a skill:
+
+> *"Install AITER on a gfx942 box, prebuild forward kernels only."*
+
+You should see the agent lean on `build-aiter` (it will mention
+`PREBUILD_KERNELS=2`, `GPU_ARCHS=gfx942`, and point you at `setup.py`). If
+it doesn't, see **Troubleshooting** at the bottom.
+
+### 4. Suggested "first hour" for a new contributor
+
+1. **`build-aiter`** — get an editable install working, confirm
+   `import aiter` succeeds.
+2. **`format-code`** — install the pre-commit formatters once, so your
+   first PR doesn't bounce on lint.
+3. **`aiter-add-operator`** — walk through the 5-file recipe even if you
+   don't plan to add an op today; it's the best map of the codebase.
+4. **`debug-aiter-op`** — bookmark this one; you'll need it the first
+   time a test fails.
+
+Everything else is task-triggered — the agent will pull it in when you
+describe a matching problem.
+
+---
 
 ## Skills at a glance
 
-| Skill | Purpose |
-|-------|---------|
-| [`build-aiter`](./build-aiter/SKILL.md) | Install / build AITER (`setup.py develop`, `PREBUILD_KERNELS`, `GPU_ARCHS`). |
-| [`aiter-add-operator`](./aiter-add-operator/SKILL.md) | End-to-end recipe for adding a new op: C++/HIP kernel → pybind → `optCompilerConfig.json` → Python wrapper → `op_tests/` test. |
-| [`aiter-jit-debug`](./aiter-jit-debug/SKILL.md) | Diagnose JIT compile / module-load failures (missing `.so`, hipify issues, `AITER_REBUILD`, cache at `aiter/jit/build`). |
-| [`aiter-triton-kernel`](./aiter-triton-kernel/SKILL.md) | Author Triton kernels following the `aiter/ops/triton/` layout, `get_gemm_config`, `make_kernel_repr`, and arch-string conventions. |
-| [`aiter-ck-tune`](./aiter-ck-tune/SKILL.md) | Tune & integrate CK-tile kernels (GEMM A8W8, FMOE, etc.) via `gemm_a*_tune.py` and the `untuned_*.csv` / `tuned_*.csv` flow. |
-| [`debug-aiter-op`](./debug-aiter-op/SKILL.md) | Systematically debug a failing `op_tests/test_*.py` (correctness, NaN, dtype, stride, backend selection). |
-| [`benchmark-aiter-op`](./benchmark-aiter-op/SKILL.md) | Benchmark an op with `@perftest`, compare AITER vs reference vs alternative backends, report roofline numbers. |
-| [`aiter-moe-tuning`](./aiter-moe-tuning/SKILL.md) | Tune the fused-MoE op (`tuned_fmoe.csv`, `untuned_fmoe.csv`) and per-model configs under `aiter/configs/model_configs/`. |
-| [`format-code`](./format-code/SKILL.md) | Run AITER's pre-commit-compatible formatting: `black==26.3.0`, `ruff==0.15.7`, `clang-format-18`, plus the copyright-year bump. |
-| [`capture-kernel-trace`](./capture-kernel-trace/SKILL.md) | Capture an `rocprofv3` ATT trace for an AITER kernel. |
-| [`kernel-trace-analysis`](./kernel-trace-analysis/SKILL.md) | Analyze an ATT trace to find top stall hotspots mapped back to source. |
-| [`bisect-perf-regression`](./bisect-perf-regression/SKILL.md) | Binary-search which AITER commit introduced a perf regression. |
+Grouped by the task you're trying to do.
 
-## Using the skills
+### Setup & contribution hygiene
+| Skill | When to use |
+|-------|-------------|
+| [`build-aiter`](./build-aiter/SKILL.md) | Installing / rebuilding AITER, picking a `PREBUILD_KERNELS` level, or debugging a bad `GPU_ARCHS` install. Thin hook around `setup.py` + `docs/installation.rst`. |
+| [`format-code`](./format-code/SKILL.md) | Before every commit: runs AITER's pinned `black==26.3.0` / `ruff==0.15.7` / `clang-format-18` + copyright-year bump. |
 
-Claude Code / Codex: skills are auto-loaded from the repo's `.claude/skills/`
-folder. Invoke explicitly with `/ ` (e.g. `/build-aiter`) or just describe
-the task and let the agent pick the matching skill from the frontmatter.
+### Writing a new operator
+| Skill | When to use |
+|-------|-------------|
+| [`aiter-add-operator`](./aiter-add-operator/SKILL.md) | End-to-end recipe: HIP/C++ kernel → pybind → `optCompilerConfig.json` → Python wrapper → `op_tests/test_*.py`. Start here when adding any HIP/CK op. |
+| [`aiter-triton-kernel`](./aiter-triton-kernel/SKILL.md) | Same but for Triton: `aiter/ops/triton/**` layout, `get_gemm_config`, `make_kernel_repr`, arch-string handling, JSON tuning configs. |
 
-Cursor Agent: copy (or symlink) the `.claude/skills/` directory to
-`.cursor/skills/` in this repo, or to `~/.cursor/skills-cursor/` for global scope.
+### Tuning
+| Skill | When to use |
+|-------|-------------|
+| [`aiter-ck-tune`](./aiter-ck-tune/SKILL.md) | Tuning an existing CK GEMM (A8W8, A16W16, A4W4, …) for a new shape. Thin hook pointing at each op's `csrc/ck_*/README.md`. |
+| [`aiter-moe-tuning`](./aiter-moe-tuning/SKILL.md) | Tuning the fused-MoE op — `tuned_fmoe.csv`, `untuned_fmoe.csv`, per-model configs under `aiter/configs/model_configs/`. |
 
-## Conventions used by every skill
+### Debugging & benchmarking
+| Skill | When to use |
+|-------|-------------|
+| [`debug-aiter-op`](./debug-aiter-op/SKILL.md) | `op_tests/test_*.py` returns NaN / wrong answer / wrong backend. Ordered playbook: backend → contiguity → dtype dispatch → all-ones → logging. |
+| [`benchmark-aiter-op`](./benchmark-aiter-op/SKILL.md) | Measuring latency / TFLOPS / % of peak. Covers **both** AITER idioms: `@perftest` (inside `op_tests/test_*.py`) and `triton.testing.do_bench` (inside `op_tests/op_benchmarks/.../bench_*.py`). |
+| [`aiter-jit-debug`](./aiter-jit-debug/SKILL.md) | `ModuleNotFoundError: module_*` at import, hipify errors, `AITER_REBUILD=1`, stale `aiter/jit/build/` cache. |
+| [`bisect-perf-regression`](./bisect-perf-regression/SKILL.md) | An op got slower between two commits — drives `git bisect run` with a JIT-aware test script. |
 
-- **GPU archs**: `gfx942` (MI300X) and `gfx950` (MI350X). Never parse product names;
-  compare against the arch string (see `aiter/ops/triton/README.md`).
+### Profiling
+| Skill | When to use |
+|-------|-------------|
+| [`capture-kernel-trace`](./capture-kernel-trace/SKILL.md) | Capture an `rocprofv3` ATT trace for an AITER kernel (`--kernel-include-regex`, `--kernel-iteration-range`). |
+| [`kernel-trace-analysis`](./kernel-trace-analysis/SKILL.md) | Read an ATT directory: stall breakdown (VMEM/BARRIER/LGKMCNT/VALU), occupancy from VGPR/SGPR/LDS, hot-PC → source. |
+
+---
+
+## How to invoke a skill
+
+You don't have to — just describe what you want and the agent picks the
+skill whose `description:` frontmatter matches. Two equivalent ways:
+
+| Style | Example prompt |
+|-------|----------------|
+| Natural language (preferred) | *"Help me add a new HIP op `my_add` that does element-wise addition."* |
+| Explicit slash command | `/aiter-add-operator my_add` |
+
+If the agent doesn't mention a skill in its answer, either (a) the prompt
+was too vague to match any `description:`, or (b) the skills aren't
+loading — see **Troubleshooting**.
+
+---
+
+## Conventions every skill assumes
+
+- **GPU archs**: `gfx942` (MI300X) and `gfx950` (MI350X). Never parse
+  product names; compare against the arch string
+  (`aiter/jit/utils/chip_info.get_gfx()`).
 - **JIT cache**: compiled `.so` and `build/` live under `aiter/jit/`.
-  `AITER_REBUILD=1` forces a rebuild, `AITER_LOG_MORE=1` increases verbosity.
-- **Tuning data**: lives as CSV under `aiter/configs/` (plus `model_configs/`
-  for per-model overrides). Every tuned op has a matched `*_untuned_*.csv` +
-  `*_tuned_*.csv` pair.
+  `AITER_REBUILD=1` forces a rebuild, `AITER_LOG_MORE=1` +
+  `AITER_LOG_LEVEL=DEBUG` increase verbosity.
+- **Tuning data**: lives as CSV under `aiter/configs/` (plus
+  `model_configs/` for per-model overrides). Every tunable CK op has a
+  matched `*_untuned_*.csv` + `*_tuned_*.csv` pair.
 - **Tests**: standalone Python scripts under `op_tests/`; run with
-  `python op_tests/test_ .py` (no pytest required) or the CI helper
-  `bash .github/scripts/aiter_test.sh`. Triton tests under `op_tests/triton_tests/`
-  use `pytest`.
-- **Pre-commit**: black / ruff / clang-format-18 with specific pinned versions
-  (see [CONTRIBUTE.md](../../CONTRIBUTE.md)). The `format-code` skill reproduces
-  that pipeline.
+  `python op_tests/test_<op>.py` (no pytest required). Triton tests
+  under `op_tests/triton_tests/` use `pytest`. Bench drivers live in
+  `op_tests/op_benchmarks/{triton,hip}/`.
+- **Pre-commit**: black / ruff / clang-format-18 with specific pinned
+  versions (see [`CONTRIBUTE.md`](../../CONTRIBUTE.md)). The
+  `format-code` skill reproduces that pipeline exactly.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Agent never mentions any skill | You're probably running outside the repo root. Claude Code / Codex auto-load `.claude/skills/` **relative to cwd**; Cursor needs the files copied into `.cursor/skills/` (see quickstart). |
+| `python .claude/skills/validate.py` reports missing paths | Repo layout changed (CK codegen dirs get renamed occasionally). Fix the path in the offending `SKILL.md` or open an issue. |
+| A skill gives outdated advice | Skills are best-effort snapshots. Every skill either points at a live README or inlines the current convention; run Layer 2 of [`TESTS.md`](./TESTS.md) to spot-check facts. |
+| Want to add your own skill | See below. |
+
+---
 
 ## Validating the skills
 
-A lightweight validator is shipped with the skill set:
+A lightweight validator ships with the skill set:
 
 ```bash
 python .claude/skills/validate.py           # format + fact check; exits 0 on pass
@@ -67,7 +198,10 @@ python .claude/skills/validate.py --strict  # also fail on warnings
 It verifies that every `SKILL.md` has proper YAML front matter, that
 `name:` matches the directory, and that every AITER-repo path cited in
 inline code actually exists in the checkout. The full test plan
-(including a behavioral test matrix) lives in [`TESTS.md`](./TESTS.md).
+(including a behavioral A/B test matrix and recorded baselines) lives
+in [`TESTS.md`](./TESTS.md).
+
+---
 
 ## Contributing a new skill
 
@@ -78,7 +212,8 @@ Follow the format used by every file here:
 name: my-skill
 description: >
  One-paragraph description. Claude reads this to decide when to activate the skill.
- Usage: /my-skill 
+ Mention concrete trigger phrases ("add a new op", "tune gemm", …).
+ Usage: /my-skill <arg>
 allowed-tools: Bash Read Edit Grep Glob
 ---
 
@@ -88,5 +223,18 @@ allowed-tools: Bash Read Edit Grep Glob
 ## Step 2 ...
 ```
 
-Keep skills **task-oriented**, **AITER-specific**, and **runnable**
-(prefer concrete shell commands and file paths over abstract advice).
+Rules of thumb:
+
+- **Task-oriented**, not topic-oriented — a skill answers *"how do I
+  do X"*, not *"what is X"*.
+- **AITER-specific** — if the content is identical to upstream ROCm /
+  PyTorch / Triton docs, link to those instead.
+- **Runnable** — prefer concrete shell commands and real file paths
+  over abstract advice.
+- **Pointer + gotchas over restating docs** — if there's already a
+  `README.md` or `docs/` page in the repo, link to it and only add the
+  pitfalls agents actually fall into. See `build-aiter` and
+  `aiter-ck-tune` for the compact hook style.
+- **Validate before opening a PR** — `python .claude/skills/validate.py`
+  must pass, and if the skill is high-frequency, run Layer-3 A/B from
+  `TESTS.md` and record the baseline.

--- a/.claude/skills/TESTS.md
+++ b/.claude/skills/TESTS.md
@@ -62,7 +62,7 @@ Recommended prompts (one per skill):
 | `aiter-triton-kernel` | "Add a Triton a8w8 GEMM kernel under `aiter/ops/triton/gemm`." | `get_gemm_config`, `make_kernel_repr`, arch string `gfx9xx`, config CSV with `M_LEQ_x/M_GEQ_x/any`. |
 | `aiter-ck-tune` | "Tune a8w8 GEMM for shape (8192, 8192, 8192) on gfx942." | Edits `aiter/configs/untuned_gemm_a8w8.csv`, runs `csrc/ck_gemm_a8w8/gemm_a8w8_tune.py`, then `AITER_REBUILD=1`. |
 | `debug-aiter-op` | "`op_tests/test_rmsnorm.py` returns NaN for a new shape." | Systematic order: backend check → stride → dtype → all-ones test → logging env vars. |
-| `benchmark-aiter-op` | "Benchmark `aiter.gemm_a16w16` at 4096³ vs `torch.matmul`, give roofline." | Uses `@perftest(num_rotate_args=…)`, reports TFLOPS and % of peak. |
+| `benchmark-aiter-op` | "Benchmark `aiter.gemm_a16w16` at 4096³ vs `torch.matmul`, give roofline." | Uses the right idiom for the target file — `triton.testing.do_bench` for bench drivers, `@perftest(num_rotate_args=…)` inside `op_tests/test_*.py`; reports TFLOPS and % of peak. |
 | `aiter-moe-tuning` | "Tune Mixtral-8x7B fused MoE in bf16 on gfx942." | Edits `aiter/configs/untuned_fmoe.csv`, runs `csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py`, then `AITER_REBUILD=1` and `op_tests/test_moe.py::test_fmoe`. |
 | `format-code` | "Format the 5 files I just edited before committing." | `black==26.3.0`, `ruff==0.15.7`, `clang-format-18`, copyright-year bump, `git diff` filtering. |
 | `capture-kernel-trace` | "Capture an ATT trace of `aiter.gemm_a16w16`." | `rocprofv3 --att --kernel-include-regex ... --kernel-iteration-range "[1]"`. |
@@ -88,3 +88,38 @@ should be pruned or merged into a neighboring skill.
   gets renamed again, the MoE skill needs updating).
 - **Layer 3** whenever you rewrite a skill substantially, or whenever
   a teammate reports "the agent didn't help with X".
+
+## Baseline — Layer 3 A/B results (2026-04, rev: PR #2769)
+
+Raw A/B results from two rounds of parallel `explore`-subagent trials
+(constrained `WITHOUT` vs skill-reading `WITH`, scored by marker count +
+qualitative delta). Prompts are the ones in the table above; full
+transcripts live in the PR conversation.
+
+| Skill                    | Markers WITHOUT | Markers WITH | Δ  | Qualitative delta | Verdict |
+|--------------------------|:---------------:|:------------:|:--:|-------------------|---------|
+| `build-aiter`            | 3/3             | 3/3          | 0  | WITHOUT picked a better `PREBUILD_KERNELS` mode (the skill's recommendation was sub-optimal). | Slimmed to a pointer+gotchas hook. |
+| `aiter-add-operator`     | 3/5             | 3/5          | 0  | WITH produced measurably cleaner/idiomatic code: correct headers, `extra_include` in JSON, parameterized tests. | Kept. Cross-file workflow is the real value. |
+| `aiter-ck-tune`          | 3/3             | 3/3          | 0  | Both agents independently matched the `csrc/ck_gemm_a8w8/README.md`. | Slimmed to a pointer+gotchas hook. |
+| `aiter-triton-kernel`    | 4/4             | 4/4          | 0  | TIE on markers; WITH avoided re-exploring `gemm_a8w8` as a template (faster). | Kept as-is. |
+| `benchmark-aiter-op`     | 2/3             | 2/3          | 0  | **Both agents ignored the skill's `@perftest` recommendation** and used `triton.testing.do_bench` instead, because that's what every driver in `op_tests/op_benchmarks/triton/` actually uses. | Skill rewritten to cover both idioms and steer agents to the one matching the host file. |
+| `debug-aiter-op`         | 4/5             | 5/5          | +1 | WITH answer is strictly more structured (explicit order: shape-boundary → contiguity → dtype AT_DISPATCH → all-ones → logging). | Kept. Small but real win. |
+
+Untested in this round (all cross-file workflows, deferred to next round):
+`aiter-jit-debug`, `aiter-moe-tuning`, `capture-kernel-trace`,
+`kernel-trace-analysis`, `bisect-perf-regression`, `format-code`.
+
+### Key takeaways / skill-design rules learned
+
+1. A skill that just restates a single authoritative doc (`setup.py`,
+   per-op `README.md`) adds zero marker-count and risks drifting out of
+   sync. Collapse it into a "pointer + gotchas" hook.
+2. A skill that bridges **multiple files / tools** (codegen + JIT config +
+   Python wrapper + test; trace capture → analysis → PC-mapping; bench
+   driver + rooflines + comparison) reliably lifts either marker count
+   *or* answer structure. Keep those.
+3. When a skill contradicts live code, the agent follows the code and
+   ignores the skill — so contradictions show up as a `Δ=0` even when
+   the skill was read. Use that as a correctness signal. (This round's
+   `benchmark-aiter-op` `@perftest`-vs-`do_bench` mismatch was caught
+   exactly this way.)

--- a/.claude/skills/TESTS.md
+++ b/.claude/skills/TESTS.md
@@ -1,0 +1,90 @@
+# AITER Skills — Test Plan
+
+This file lists how to tell whether each skill in `.claude/skills/` is
+actually pulling its weight. There are three layers; run them in order.
+
+## Layer 1 — Format validation (automated, cheap)
+
+```bash
+python .claude/skills/validate.py           # must exit 0
+python .claude/skills/validate.py --strict  # also fail on warnings
+```
+
+What it checks:
+
+- Every `SKILL.md` has a well-formed YAML front matter.
+- `name:` matches the parent directory name.
+- `description:` is present and at least 60 chars (skills are triggered
+  by matching a user's request against `description`; short descriptions
+  silently never trigger).
+- Every AITER-repo path (`aiter/...`, `csrc/...`, `op_tests/...`, …) cited
+  in inline-code backticks actually exists.
+- Obvious template paths (`aiter/ops/my_op.py`, `...category/test_<op>.py`)
+  and runtime-only paths (`aiter/jit/build/...`) are skipped.
+
+Wire this into CI whenever you extend the skill set.
+
+## Layer 2 — Fact probe (semi-automated)
+
+For each skill, confirm the commands / env vars / tool versions it asserts
+are actually what the repo uses *today*.
+
+```bash
+# 1. Version pins cited in format-code
+grep -n 'black==\|ruff==' CONTRIBUTE.md
+# 2. Env vars cited by build-aiter / aiter-jit-debug
+grep -rn 'PREBUILD_KERNELS\|GPU_ARCHS\|AITER_REBUILD\|AITER_LOG_LEVEL' setup.py aiter/jit/core.py aiter/__init__.py
+# 3. Tuner scripts cited by aiter-ck-tune / aiter-moe-tuning
+ls csrc/ck_gemm_a8w8/gemm_a8w8_tune.py \
+   csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+# 4. perftest decorator cited by benchmark-aiter-op
+grep -n 'def perftest\|num_rotate_args' aiter/test_common.py
+# 5. Pre-commit hook structure cited by format-code
+grep -n 'clang-format\|black\|ruff' .githooks/pre-commit
+```
+
+All five groups should return at least one match. If any return nothing,
+the skill is out of date — go fix it.
+
+## Layer 3 — Behavioral test (the real signal)
+
+Layers 1 and 2 only prove the skill isn't *wrong*. To tell whether it's
+*useful*, run the same prompt with and without the skill and compare
+the answer quality.
+
+Recommended prompts (one per skill):
+
+| Skill | Prompt | Must-hit markers in the answer |
+|-------|--------|-------------------------------|
+| `build-aiter` | "Install AITER on gfx942, prebuild only GEMM and attention." | `PREBUILD_KERNELS`, `GPU_ARCHS=gfx942`, concrete bitmask / kernel-list value. |
+| `aiter-add-operator` | "Add a new HIP op `my_add` that does elementwise addition." | Covers all 5 artifacts: kernel, pybind, `optCompilerConfig.json`, `@compile_ops` wrapper, `op_tests/test_my_add.py`. |
+| `aiter-jit-debug` | "`import aiter` raises `ModuleNotFoundError: module_activation`." | Mentions `AITER_REBUILD=1`, `aiter/jit/build`, `GPU_ARCHS` mismatch, `optCompilerConfig.json`. |
+| `aiter-triton-kernel` | "Add a Triton a8w8 GEMM kernel under `aiter/ops/triton/gemm`." | `get_gemm_config`, `make_kernel_repr`, arch string `gfx9xx`, config CSV with `M_LEQ_x/M_GEQ_x/any`. |
+| `aiter-ck-tune` | "Tune a8w8 GEMM for shape (8192, 8192, 8192) on gfx942." | Edits `aiter/configs/untuned_gemm_a8w8.csv`, runs `csrc/ck_gemm_a8w8/gemm_a8w8_tune.py`, then `AITER_REBUILD=1`. |
+| `debug-aiter-op` | "`op_tests/test_rmsnorm.py` returns NaN for a new shape." | Systematic order: backend check → stride → dtype → all-ones test → logging env vars. |
+| `benchmark-aiter-op` | "Benchmark `aiter.gemm_a16w16` at 4096³ vs `torch.matmul`, give roofline." | Uses `@perftest(num_rotate_args=…)`, reports TFLOPS and % of peak. |
+| `aiter-moe-tuning` | "Tune Mixtral-8x7B fused MoE in bf16 on gfx942." | Edits `aiter/configs/untuned_fmoe.csv`, runs `csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py`, then `AITER_REBUILD=1` and `op_tests/test_moe.py::test_fmoe`. |
+| `format-code` | "Format the 5 files I just edited before committing." | `black==26.3.0`, `ruff==0.15.7`, `clang-format-18`, copyright-year bump, `git diff` filtering. |
+| `capture-kernel-trace` | "Capture an ATT trace of `aiter.gemm_a16w16`." | `rocprofv3 --att --kernel-include-regex ... --kernel-iteration-range "[1]"`. |
+| `kernel-trace-analysis` | "I have an ATT directory at /tmp/aiter_att, tell me what's slow." | Stall breakdown (VMEM / BARRIER / LGKMCNT / VALU), occupancy from VGPR/SGPR/LDS, hot-PC → source mapping. |
+| `bisect-perf-regression` | "`gemm_a16w16` is 30% slower than last week, find the commit." | `git bisect run`, a runner that does `rm -rf aiter/jit/build` + `AITER_REBUILD=1` and `exit 125` on build failure. |
+
+Procedure per skill:
+
+1. Start a fresh session with the skill directory disabled.
+2. Ask the prompt. Score the answer against the markers.
+3. Enable the skill and ask the same prompt.
+4. Score again. A skill is useful only if the "with" column adds at least
+   2 markers the "without" column missed.
+
+Skills that don't improve the answer after one round of prompt tuning
+should be pruned or merged into a neighboring skill.
+
+## When to re-run
+
+- **Layer 1** on every commit that touches `.claude/skills/`.
+- **Layer 2** monthly, or after any AITER refactor that renames a
+  top-level directory / env var (e.g. if `csrc/ck_gemm_moe_2stages_codegen`
+  gets renamed again, the MoE skill needs updating).
+- **Layer 3** whenever you rewrite a skill substantially, or whenever
+  a teammate reports "the agent didn't help with X".

--- a/.claude/skills/aiter-add-operator/SKILL.md
+++ b/.claude/skills/aiter-add-operator/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: aiter-add-operator
+description: >
+ End-to-end recipe for adding a brand-new operator to AITER. Walks through the
+ 5 required artifacts: (1) the HIP/CK/Triton kernel under `csrc/` or
+ `aiter/ops/triton/`, (2) the pybind module under `csrc/pybind/`, (3) the JIT
+ entry in `aiter/jit/optCompilerConfig.json`, (4) the Python wrapper in
+ `aiter/ops/.py` using `@compile_ops`, and (5) the correctness test
+ under `op_tests/test_.py`. Use when a user says "add op", "new operator",
+ "register a kernel in AITER", or requests a missing op.
+ Usage: /aiter-add-operator 
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# Add a New Operator to AITER
+
+AITER operators are composed of 5 tightly-coupled pieces. Miss any of them and
+the op silently fails to load. This skill walks through each piece using a
+running example: adding `my_op(input, out)` backed by a HIP kernel.
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| ` ` | Yes | snake_case name of the new op, e.g. `fused_silu_quant`. |
+| `--backend` | No | `hip` (default), `ck`, `triton`, or `flydsl`. |
+
+If `` is not provided, ask the user.
+
+## Mental model
+
+```
+  Python call site (user code)
+    |
+    v
+  aiter/ops/my_op.py        <-- 4. Python wrapper with @compile_ops("module_my_op")
+    |
+    v
+  aiter/jit/optCompilerConfig.json  <-- 3. module_my_op -> srcs, flags, blob_gen_cmd
+    |
+    v (JIT compile)
+  csrc/pybind/my_op_pybind.cu       <-- 2. PyBind registration
+  csrc/kernels/my_op_kernels.cu      <-- 1. HIP kernel (or csrc/ck_my_op/ for CK, aiter/ops/triton/... for Triton)
+    |
+    v
+  aiter/jit/module_my_op.so  (generated)
+
+  op_tests/test_my_op.py            <-- 5. Correctness/perf test
+```
+
+All 5 files MUST exist. The JIT system looks up `MD_NAME = "module_my_op"` in
+`optCompilerConfig.json`; a missing entry produces a cryptic
+`ModuleNotFoundError: No module named 'module_my_op'`.
+
+---
+
+## Step 1: Write the kernel
+
+### Option A: HIP kernel (most ops)
+
+Path: `csrc/kernels/my_op_kernels.cu`
+
+```cpp
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#include 
+#include "aiter_hip_common.h"
+
+template 
+__global__ void my_op_kernel(const T* __restrict__ input,
+                              T* __restrict__ output,
+                              int n) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  output[idx] = input[idx] * input[idx];
+}
+
+void my_op(torch::Tensor& out, torch::Tensor& input) {
+  TORCH_CHECK(input.is_cuda() && out.is_cuda(), "tensors must be on GPU");
+  TORCH_CHECK(input.numel() == out.numel(), "size mismatch");
+
+  const int n = input.numel();
+  const int block = 256;
+  const int grid = (n + block - 1) / block;
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(),
+      "my_op", [&] {
+        my_op_kernel<<>>(
+            input.data_ptr(), out.data_ptr(), n);
+      });
+}
+```
+
+Also declare the function in a header so the pybind file can include it:
+
+`csrc/include/my_op.h`:
+
+```cpp
+#pragma once
+#include 
+void my_op(torch::Tensor& out, torch::Tensor& input);
+```
+
+### Option B: CK kernel
+
+Put all generated CK instances under `csrc/ck_my_op/` and follow the pattern of
+`csrc/ck_gemm_a8w8/` (see the `aiter-ck-tune` skill for the tuning flow). Wire
+the directory in via `blob_gen_cmd` in `optCompilerConfig.json`.
+
+### Option C: Triton kernel
+
+Use `aiter/ops/triton/` with the layout described by the
+`aiter-triton-kernel` skill. No `optCompilerConfig.json` entry needed — Triton
+kernels are JIT'd by Triton itself.
+
+---
+
+## Step 2: PyBind registration
+
+Path: `csrc/pybind/my_op_pybind.cu`
+
+```cpp
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#include 
+#include "my_op.h"
+
+PYBIND11_MODULE(module_my_op, m) {
+  m.def("my_op", &my_op, "Squares every element of input into out.",
+        py::arg("out"), py::arg("input"));
+}
+```
+
+The module name in `PYBIND11_MODULE(module_my_op, ...)` **must match** the key
+used in `optCompilerConfig.json` AND the argument to `@compile_ops` in the
+Python wrapper.
+
+---
+
+## Step 3: JIT config entry
+
+Add a new key to `aiter/jit/optCompilerConfig.json`:
+
+```json
+{
+  "module_my_op": {
+    "srcs": [
+      "f'{AITER_CSRC_DIR}/pybind/my_op_pybind.cu'",
+      "f'{AITER_CSRC_DIR}/kernels/my_op_kernels.cu'"
+    ],
+    "flags_extra_cc": [],
+    "flags_extra_hip": [
+      "'-ffast-math'"
+    ],
+    "extra_ldflags": "None",
+    "extra_include": [
+      "f'{AITER_CSRC_DIR}/include'"
+    ],
+    "verbose": "False",
+    "blob_gen_cmd": "''"
+  }
+}
+```
+
+**Notes**:
+- Values are f-string source code that `core.py` `eval()`s — do NOT use
+  regular strings. Wrap literals in `'...'`.
+- Keep `torch_exclude: "True"` only for enum/tensor-metadata-only modules
+  (see `module_aiter_enum`).
+- Set `hipify: "False"` if your code is already HIP (not CUDA) — the default
+  hipify pass can mangle ROCm-specific intrinsics (see `module_pa_ragged`).
+- For CK-tile integration, add `blob_gen_cmd` with a generator script (see
+  `csrc/ck_gemm_a8w8/gen_instances.py` as reference).
+
+---
+
+## Step 4: Python wrapper
+
+Path: `aiter/ops/my_op.py`
+
+```python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from torch import Tensor
+from ..jit.core import compile_ops
+
+MD_NAME = "module_my_op"
+
+
+@compile_ops("module_my_op")
+def my_op(out: Tensor, input: Tensor) -> None: ...
+```
+
+Then re-export from `aiter/__init__.py` if the op should be user-visible:
+
+```python
+from .ops.my_op import my_op as my_op
+```
+
+**How `@compile_ops` works**:
+- On first call, it looks up `"module_my_op"` in
+  `aiter/jit/optCompilerConfig.json`, JIT-compiles the `.so`, and swaps the
+  stub body for the compiled C++ function.
+- The Python function body (`...`) is never executed — it's just a type
+  signature for IDEs / static checkers.
+- Arguments must match the pybind signature order and types.
+
+---
+
+## Step 5: Correctness test
+
+Path: `op_tests/test_my_op.py`
+
+```python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+import argparse
+import torch
+from aiter.ops.my_op import my_op
+from aiter.test_common import checkAllclose, perftest
+from aiter import dtypes
+
+
+@perftest()
+def run_aiter(input):
+    out = torch.empty_like(input)
+    my_op(out, input)
+    return out
+
+
+def ref_my_op(input):
+    return input * input
+
+
+def test_my_op(dtype, n):
+    x = torch.randn(n, dtype=dtype, device="cuda")
+    expected = ref_my_op(x)
+    got, latency = run_aiter(x)
+    checkAllclose(got, expected, rtol=1e-3, atol=1e-3,
+                   msg=f"my_op dtype={dtype} n={n} {latency:.1f}us")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-d", "--dtype", default=None)
+    ap.add_argument("-n", type=int, default=None)
+    args = ap.parse_args()
+
+    l_dtype = [torch.float16, torch.bfloat16, torch.float32]
+    l_n = [1024, 16 * 1024, 1024 * 1024]
+
+    if args.dtype:
+        l_dtype = [dtypes.d_dtypes[args.dtype]]
+    if args.n:
+        l_n = [args.n]
+
+    for d in l_dtype:
+        for n in l_n:
+            test_my_op(d, n)
+```
+
+Run it:
+
+```bash
+python3 op_tests/test_my_op.py
+AITER_LOG_MORE=1 python3 op_tests/test_my_op.py   # verbose JIT logs
+AITER_REBUILD=1 python3 op_tests/test_my_op.py     # force rebuild
+```
+
+The first run compiles `module_my_op.so` into `aiter/jit/`. Subsequent runs
+reuse it until source files change.
+
+---
+
+## Step 6: Register with the test runner (CI)
+
+AITER's CI discovers tests under `op_tests/*.py` automatically (see
+`.github/scripts/aiter_test.sh`). No additional registration is required as
+long as the file is named `test_.py` and lives at the top level
+of `op_tests/`.
+
+Triton tests go under `op_tests/triton_tests//test_.py`
+and are run with `pytest`.
+
+Multi-GPU tests go under `op_tests/multigpu_tests/`.
+
+---
+
+## Checklist
+
+Before opening a PR:
+
+- [ ] `csrc/kernels//my_op_kernels.cu` (or equivalent) compiles cleanly.
+- [ ] `csrc/pybind/my_op_pybind.cu` binds the module with the exact same name as the JSON key.
+- [ ] `aiter/jit/optCompilerConfig.json` has a `module_my_op` entry with correct `srcs` / `flags_extra_hip` / `extra_include`.
+- [ ] `aiter/ops/my_op.py` uses `@compile_ops("module_my_op")` and the signature matches pybind.
+- [ ] `op_tests/test_my_op.py` runs standalone and passes.
+- [ ] `AITER_REBUILD=1 python3 op_tests/test_my_op.py` produces `aiter/jit/module_my_op.so`.
+- [ ] `ruff check aiter/ op_tests/` and `black aiter/ op_tests/` pass (see `format-code` skill).
+- [ ] `clang-format-18 -i csrc/pybind/my_op_pybind.cu csrc/kernels/my_op_kernels.cu`.
+- [ ] PR title follows the `[Feature]` / `[Kernel]` convention from `CONTRIBUTE.md`.
+
+## Common pitfalls
+
+| Symptom | Fix |
+|---------|-----|
+| `ModuleNotFoundError: No module named 'module_my_op'` | Missing entry in `optCompilerConfig.json`, or typo between the JSON key, `PYBIND11_MODULE(...)`, and `@compile_ops(...)`. All three must match. |
+| `undefined symbol: my_op(at::Tensor&, at::Tensor&)` | Function declared in header but not defined in one of the `srcs`. Add the .cu to `srcs`. |
+| `hipErrorNoBinaryForGpu` | Kernel was compiled for the wrong arch. Rebuild with `GPU_ARCHS="gfx942;gfx950" AITER_REBUILD=1 ...`. |
+| Test passes with dtype=f32 but fails with bf16 | AT_DISPATCH missing the BF16 branch; use `AT_DISPATCH_FLOATING_TYPES_AND2(Half, BFloat16, ...)`. |
+| CK kernel compile timeout | Split instances into multiple `*_part{1,2,3}.cpp` files as in `device_gemm_multiply_multiply_xdl_*`. |
+| The JIT rebuilds every invocation | Source mtime in a shared volume is unstable — set `AITER_REBUILD=0` and check for clock skew. |
+
+## Reference operators to copy
+
+| Backend | Simplest example to copy |
+|---------|--------------------------|
+| HIP scalar | `module_activation` (`aiter/ops/activation.py`, `csrc/kernels/activation_kernels.cu`). |
+| HIP + CK integration | `module_pa_ragged` (`aiter/ops/attention.py`, `csrc/kernels/attention_ragged.cu`). |
+| CK GEMM with tuning | `module_gemm_a8w8` + `module_gemm_a8w8_tune` (see `csrc/ck_gemm_a8w8/README.md`). |
+| Triton kernel | `aiter/ops/triton/gemm/basic/gemm_a16w16.py`. |
+| FlyDSL kernel | `aiter/ops/flydsl/` (optional; A4W4 MoE). |

--- a/.claude/skills/aiter-ck-tune/SKILL.md
+++ b/.claude/skills/aiter-ck-tune/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: aiter-ck-tune
+description: >
+ Tune and integrate a Composable-Kernel (CK-tile) kernel in AITER. Covers the
+ untuned.csv / tuned.csv round-trip, the `csrc/ck_*/gen_instances.py` +
+ `gemm_*_tune.py` flow, per-model tuned configs under
+ `aiter/configs/model_configs/`, how the merged config at
+ `/tmp/aiter_configs/...` is built, and how to use `AITER_REBUILD=1` after
+ retuning. Use when a user says "tune a8w8 GEMM", "retune MoE for qwen3",
+ "integrate a new CK tile kernel", or needs to add new GEMM shapes.
+ Usage: /aiter-ck-tune  [--model ]
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# Tune & Integrate CK Kernels in AITER
+
+AITER uses CK-tile kernels for most GEMM-like ops (`gemm_a8w8`,
+`gemm_a4w4_blockscale`, `batched_gemm_*`, `fmoe`, …). Each tuned op follows
+the same 4-file pattern:
+
+```
+csrc/ck_/
+├── gen_instances.py       # Emits *_instance_part{1,2,3}.cpp at JIT build time
+├── gemm__tune.cu       # Tune-time pybind: takes (M,N,K,kernelId) -> latency
+├── gemm__tune.py       # Python harness that runs the sweep
+├── gemm_.cu            # Runtime pybind: takes (X, W, Y, config) -> Y
+└── README.md                # Per-op tuning guide (follow the pattern in ck_gemm_a8w8)
+
+aiter/configs/
+├── _untuned_.csv    # Shapes you want tuned
+├── _tuned_.csv      # Best kernelId per shape (auto-filled)
+└── model_configs/
+    └── _tuned__.csv
+```
+
+On first call, `@compile_ops` builds both the runtime module
+(`module_gemm_a8w8`) and the tune module (`module_gemm_a8w8_tune`) via
+`aiter/jit/optCompilerConfig.json`. `PREBUILD_KERNELS=1` prebuilds the runtime
+module only; `_tune` modules remain JIT.
+
+---
+
+## Step 1: Add your GEMM shapes
+
+Edit the untuned CSV in `aiter/configs/`. Example for
+`aiter/configs/a8w8_untuned_gemm.csv`:
+
+```csv
+M,N,K
+128,1536,7168
+256,1536,7168
+1024,8192,1024
+```
+
+Column order: as given in the per-op README (usually `M,N,K`; batched GEMM
+adds a `B` column). Don't reorder — the parser is positional.
+
+For a per-model tune, put the untuned shapes under
+`aiter/configs/model_configs/_untuned__.csv`.
+
+## Step 2: Run the tuner
+
+For `gemm_a8w8`:
+
+```bash
+python3 csrc/ck_gemm_a8w8/gemm_a8w8_tune.py \
+    -i aiter/configs/a8w8_untuned_gemm.csv \
+    -o aiter/configs/a8w8_tuned_gemm.csv
+```
+
+This triggers a JIT build of `module_gemm_a8w8_tune` (builds ALL CK instances —
+takes a few minutes). Then for every row in `-i` it sweeps every instance,
+picks the fastest that satisfies `errRatio < 0.05`, and writes the winner
+to `-o`.
+
+Key tuner flags (see `csrc/ck_gemm_a8w8/README.md` for the full list):
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-k, --splitK` | off | Include split-K variants |
+| `-o2, --profile_file` | "" | Dump all candidates (not just the best) for offline analysis |
+| `--errRatio` | `0.05` | Tolerable `|got - ref|/|ref|` |
+| `--mp` | #GPUs | Parallel processes across GPUs |
+| `--batch` | `100` | Shapes per batch (memory management) |
+| `--warmup` | `5` | Warmup iters before timing |
+| `--iters` | `101` | Benchmark iters |
+| `--timeout` | none | Per-task timeout |
+| `--all` | off | Retune everything (otherwise only new rows) |
+| `-v, --verbose` | off | Verbose progress |
+| `--sort` | on | Keep tuned CSV sorted by `cu_num,N,M,K` |
+
+Multi-GPU sweep:
+
+```bash
+python3 csrc/ck_gemm_a8w8/gemm_a8w8_tune.py -i ... -o ... --mp 8
+```
+
+The output CSV schema:
+
+```
+cu_num,M,N,K,q_dtype_w,kernelId,splitK,us,kernelName,tflops,bw,errRatio
+```
+
+`cu_num` encodes the chip (e.g. `80` for MI300X). Rows are keyed on
+`(cu_num, M, N, K, q_dtype_w)`.
+
+## Step 3: Per-model tuning (optional)
+
+Under `aiter/configs/model_configs/` each model has its own tuned pairs:
+
+```
+a8w8_blockscale_tuned_gemm_dsv3.csv
+a8w8_blockscale_untuned_gemm_dsv3.csv
+a8w8_blockscale_tuned_gemm_qwen3_235b.csv
+...
+```
+
+Point the tuner at the untuned variant:
+
+```bash
+python3 csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py \
+    -i aiter/configs/model_configs/a8w8_blockscale_untuned_gemm_qwen3_235b.csv \
+    -o aiter/configs/model_configs/a8w8_blockscale_tuned_gemm_qwen3_235b.csv
+```
+
+At runtime, AITER merges the generic tuned CSV with **all** matching
+`model_configs/*_tuned_*.csv` entries into
+`/tmp/aiter_configs/_tuned_.csv`. That merged file is what the
+runtime module consumes. See `aiter/jit/core.py::AITER_CONFIG` for the
+resolution order.
+
+Override the merged path via the matching env var:
+
+```bash
+# Examples from aiter/jit/core.py
+AITER_CONFIG_GEMM_A8W8=/path/to/my_a8w8_tuned_gemm.csv python3 op_tests/test_gemm_a8w8.py
+AITER_CONFIG_GEMM_A8W8_BLOCKSCALE=/path/to/custom.csv  python3 bench.py
+```
+
+## Step 4: Rebuild the runtime module with the new config
+
+If `PREBUILD_KERNELS=0` (default), the next test call JIT-builds the winning
+kernels on demand — no extra step needed.
+
+If you had `PREBUILD_KERNELS=1` during `setup.py develop`, pre-existing `.so`
+files were built against the **old** tuned CSV. Force a rebuild:
+
+```bash
+AITER_REBUILD=1 python3 op_tests/test_gemm_a8w8.py
+# Or wipe first:
+rm -rf aiter/jit/build aiter/jit/module_gemm_a8w8.so
+python3 op_tests/test_gemm_a8w8.py
+```
+
+## Step 5: Verify correctness and perf
+
+```bash
+# Correctness across the tuned shapes:
+python3 op_tests/test_gemm_a8w8.py
+
+# Single shape, verbose:
+AITER_LOG_MORE=1 AITER_LOG_TUNED_CONFIG=1 python3 op_tests/test_gemm_a8w8.py -m 128 -n 1536 -k 7168
+
+# Perf bench vs torch reference:
+python3 op_tests/op_benchmarks/triton/bench_gemm_a8w8.py
+```
+
+`AITER_LOG_TUNED_CONFIG=1` prints which config file was used and which
+kernelId won for each call — crucial for spotting cases where the merged CSV
+lost a row.
+
+---
+
+## Integrating a brand-new CK op
+
+If you're adding `ck_my_gemm`:
+
+1. **Copy a template**. Start from `csrc/ck_gemm_a8w8/` (contains
+   `gen_instances.py`, `gemm_a8w8_tune.{cu,py}`, `gemm_a8w8.cu`, plus the
+   header under `csrc/ck_gemm_a8w8/include/`).
+2. **Regenerate instances**. CK's own generator (`example/ck_tile/*/generate.py`)
+   in `3rdparty/composable_kernel/` produces instances. `gen_instances.py`
+   wraps that call with the right `--filter` to keep the part-files small.
+3. **Add 2 JIT modules** to `aiter/jit/optCompilerConfig.json`:
+   - `module_my_gemm` (runtime) and `module_my_gemm_tune` (tuner). Only the
+     tune module should appear in `_tune` filter in `setup.py::get_exclude_ops`
+     so PREBUILD_KERNELS skips it.
+4. **Python wrapper** in `aiter/ops/gemm_op_my_gemm.py` using `@compile_ops`.
+5. **Tuned CSV pair** in `aiter/configs/my_gemm_{un,}tuned_gemm.csv`.
+6. **Per-op README** in `csrc/ck_my_gemm/README.md` — copy the layout of
+   `ck_gemm_a8w8/README.md` so users know what flags you support.
+
+## Tips for CK tuning
+
+- CK instance files are template-heavy. If compile is slow, split
+  `gen_instances.py` output into `*_part{1,2,3}.cpp`. See
+  `3rdparty/composable_kernel/library/src/tensor_operation_instance/gpu/
+  gemm_multiply_multiply/device_gemm_multiply_multiply_xdl_*`.
+- `MAX_JOBS=8` is a good starting point for CK compile; each instance
+  can eat 4–8 GB of RAM.
+- `--profile_file` dumps every candidate; inspect it to spot cases where
+  the winner is only 1% faster than #2 — your tuned config is noise-limited.
+- Keep `errRatio` at `0.05` for FP16/BF16 and tighten to `0.01` for FP32.
+  FP8 /FP4 workloads may need larger tolerances — check the test's own
+  `rtol/atol`.
+- Model-specific tuned configs (`model_configs/*_qwen3_235b.csv`) are
+  **additive**. Don't remove rows from the generic `a8w8_tuned_gemm.csv`
+  just because the model config has them.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Tuner silently skips most shapes | `errRatio` too tight, or kernels all fail correctness. Re-run with `-v` and widen `--errRatio`. |
+| New shape added but still "kernel not found" at runtime | Merged config at `/tmp/aiter_configs/...` is stale. `rm -rf /tmp/aiter_configs && AITER_REBUILD=1 python3 ...` |
+| Tune module OOMs during compile | Split instances (`gen_instances.py` → more `*_part*.cpp`) and/or drop `MAX_JOBS`. |
+| Perf regressed after retune | Check `errRatio` of the new winner vs the old one in `--profile_file`. The new pick may be 0.1% faster at tune time but noisy in the real workload. |
+| Different CU counts produce different winners | Expected. `cu_num` is part of the key; tune on each SKU you care about (MI300X=80, MI300A=38, MI325X=88, MI350X=?). |

--- a/.claude/skills/aiter-ck-tune/SKILL.md
+++ b/.claude/skills/aiter-ck-tune/SKILL.md
@@ -1,218 +1,77 @@
 ---
 name: aiter-ck-tune
 description: >
- Tune and integrate a Composable-Kernel (CK-tile) kernel in AITER. Covers the
- untuned.csv / tuned.csv round-trip, the `csrc/ck_*/gen_instances.py` +
- `gemm_*_tune.py` flow, per-model tuned configs under
- `aiter/configs/model_configs/`, how the merged config at
- `/tmp/aiter_configs/...` is built, and how to use `AITER_REBUILD=1` after
- retuning. Use when a user says "tune a8w8 GEMM", "retune MoE for qwen3",
- "integrate a new CK tile kernel", or needs to add new GEMM shapes.
- Usage: /aiter-ck-tune  [--model ]
+ Tune an existing Composable-Kernel (CK-tile) op in AITER — typically a
+ GEMM variant. Thin hook around the per-op READMEs (e.g.
+ `csrc/ck_gemm_a8w8/README.md`) which are the authoritative tuning guides.
+ Use this skill when the user says "tune a8w8 GEMM", "add a new GEMM
+ shape", "retune for gfx950", or "my shape falls back to a generic
+ kernel". For MoE tuning specifically see `aiter-moe-tuning`.
 allowed-tools: Bash Read Edit Grep Glob
 ---
 
-# Tune & Integrate CK Kernels in AITER
+# Tune a CK Kernel in AITER
 
-AITER uses CK-tile kernels for most GEMM-like ops (`gemm_a8w8`,
-`gemm_a4w4_blockscale`, `batched_gemm_*`, `fmoe`, …). Each tuned op follows
-the same 4-file pattern:
+Authoritative per-op READMEs live next to the tuner script, e.g.:
 
-```
-csrc/ck_/
-├── gen_instances.py       # Emits *_instance_part{1,2,3}.cpp at JIT build time
-├── gemm__tune.cu       # Tune-time pybind: takes (M,N,K,kernelId) -> latency
-├── gemm__tune.py       # Python harness that runs the sweep
-├── gemm_.cu            # Runtime pybind: takes (X, W, Y, config) -> Y
-└── README.md                # Per-op tuning guide (follow the pattern in ck_gemm_a8w8)
+- `csrc/ck_gemm_a8w8/README.md` (A8W8 GEMM)
+- `csrc/ck_gemm_a8w8_bpreshuffle/` (A8W8 B-preshuffled)
+- `csrc/ck_gemm_a8w8_blockscale/`
+- `csrc/ck_gemm_moe_2stages_codegen/README.md` (MoE; use `aiter-moe-tuning`)
 
-aiter/configs/
-├── _untuned_.csv    # Shapes you want tuned
-├── _tuned_.csv      # Best kernelId per shape (auto-filled)
-└── model_configs/
-    └── _tuned__.csv
-```
+Always read the relevant README first — columns and flags change over time.
 
-On first call, `@compile_ops` builds both the runtime module
-(`module_gemm_a8w8`) and the tune module (`module_gemm_a8w8_tune`) via
-`aiter/jit/optCompilerConfig.json`. `PREBUILD_KERNELS=1` prebuilds the runtime
-module only; `_tune` modules remain JIT.
+## The universal tuning loop
 
----
+Every CK op that supports tuning follows the same 4-step pattern:
 
-## Step 1: Add your GEMM shapes
+1. **Add the shape** to `aiter/configs/<op>_untuned_gemm.csv` (or the op's
+   untuned CSV). Columns differ per op; copy an existing row as a template.
+2. **Run the tuner**: `python3 csrc/ck_<op>/<op>_tune.py -i <untuned.csv> -o <tuned.csv>`
+   on a machine with the target GPU. It JIT-builds `module_<op>_tune`, sweeps
+   instances, benchmarks, appends winners to `aiter/configs/<op>_tuned_gemm.csv`.
+3. **Force runtime to pick up the new row**: `AITER_REBUILD=1` on next import,
+   and delete any merged cache under `/tmp/aiter_configs/` (Linux) or
+   `$env:TEMP\aiter_configs` (Windows).
+4. **Validate**: `AITER_LOG_TUNED_CONFIG=1 python3 op_tests/test_<op>.py ...`
+   prints the kernel id that was selected — confirm it's your new row.
 
-Edit the untuned CSV in `aiter/configs/`. Example for
-`aiter/configs/a8w8_untuned_gemm.csv`:
-
-```csv
-M,N,K
-128,1536,7168
-256,1536,7168
-1024,8192,1024
-```
-
-Column order: as given in the per-op README (usually `M,N,K`; batched GEMM
-adds a `B` column). Don't reorder — the parser is positional.
-
-For a per-model tune, put the untuned shapes under
-`aiter/configs/model_configs/_untuned__.csv`.
-
-## Step 2: Run the tuner
-
-For `gemm_a8w8`:
+## Finding the tuner for your op
 
 ```bash
-python3 csrc/ck_gemm_a8w8/gemm_a8w8_tune.py \
-    -i aiter/configs/a8w8_untuned_gemm.csv \
-    -o aiter/configs/a8w8_tuned_gemm.csv
+ls csrc/ | grep '^ck_gemm'
+ls csrc/ck_gemm_a8w8/*_tune.py
 ```
 
-This triggers a JIT build of `module_gemm_a8w8_tune` (builds ALL CK instances —
-takes a few minutes). Then for every row in `-i` it sweeps every instance,
-picks the fastest that satisfies `errRatio < 0.05`, and writes the winner
-to `-o`.
+The tuner scripts follow the naming `csrc/ck_<op>/<op>_tune.py`. Their
+`--help` is the source of truth for flag names.
 
-Key tuner flags (see `csrc/ck_gemm_a8w8/README.md` for the full list):
+## Config resolution at runtime
 
-| Flag | Default | Purpose |
-|------|---------|---------|
-| `-k, --splitK` | off | Include split-K variants |
-| `-o2, --profile_file` | "" | Dump all candidates (not just the best) for offline analysis |
-| `--errRatio` | `0.05` | Tolerable `|got - ref|/|ref|` |
-| `--mp` | #GPUs | Parallel processes across GPUs |
-| `--batch` | `100` | Shapes per batch (memory management) |
-| `--warmup` | `5` | Warmup iters before timing |
-| `--iters` | `101` | Benchmark iters |
-| `--timeout` | none | Per-task timeout |
-| `--all` | off | Retune everything (otherwise only new rows) |
-| `-v, --verbose` | off | Verbose progress |
-| `--sort` | on | Keep tuned CSV sorted by `cu_num,N,M,K` |
+`aiter/jit/core.py` defines env vars of the form `AITER_CONFIG_GEMM_A8W8`
+(and similar) that override the default CSV path. AITER also *merges*
+per-model CSVs from `aiter/configs/model_configs/<model>/` with the main
+CSV into `/tmp/aiter_configs/<csv_name>` (or the Windows temp dir). Stale
+merged files are the #1 source of "I tuned this but it doesn't take effect".
 
-Multi-GPU sweep:
+## Arch matters
 
-```bash
-python3 csrc/ck_gemm_a8w8/gemm_a8w8_tune.py -i ... -o ... --mp 8
-```
+Tuned rows are keyed by `cu_num` (which encodes the GPU SKU / arch).
+Re-tune on every target arch; rows from gfx942 are not portable to gfx950.
 
-The output CSV schema:
+## Recurring footguns
 
-```
-cu_num,M,N,K,q_dtype_w,kernelId,splitK,us,kernelName,tflops,bw,errRatio
-```
+| Symptom | Cause / fix |
+|---------|-------------|
+| Tuner finishes in seconds | Row already in tuned CSV. Delete that row or use `--force` / `-k` depending on script. |
+| Tuned row ignored at runtime | Stale merge cache at `/tmp/aiter_configs/`. Delete it, set `AITER_REBUILD=1`. |
+| Tuner can't find a compatible instance | The instance list doesn't cover your `(dtype, q_type, ...)`. Regenerate with `gen_instances.py` in the same folder, or extend the instance list. |
+| HIP OOM mid-tune | Lower `MAX_JOBS`, tune one shape at a time, or pass `-m <N>` to limit parallel instance builds. |
+| Correctness regression after tune | The chosen instance is numerically weak for that shape. Re-tune with stricter tolerance, or blacklist the bad instance id in the tuner. |
+| Wrong kernel picked at runtime | Column mismatch — `q_dtype_w`, `cu_num`, dtype string must match call-site exactly. Case-sensitive. |
 
-`cu_num` encodes the chip (e.g. `80` for MI300X). Rows are keyed on
-`(cu_num, M, N, K, q_dtype_w)`.
-
-## Step 3: Per-model tuning (optional)
-
-Under `aiter/configs/model_configs/` each model has its own tuned pairs:
-
-```
-a8w8_blockscale_tuned_gemm_dsv3.csv
-a8w8_blockscale_untuned_gemm_dsv3.csv
-a8w8_blockscale_tuned_gemm_qwen3_235b.csv
-...
-```
-
-Point the tuner at the untuned variant:
-
-```bash
-python3 csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py \
-    -i aiter/configs/model_configs/a8w8_blockscale_untuned_gemm_qwen3_235b.csv \
-    -o aiter/configs/model_configs/a8w8_blockscale_tuned_gemm_qwen3_235b.csv
-```
-
-At runtime, AITER merges the generic tuned CSV with **all** matching
-`model_configs/*_tuned_*.csv` entries into
-`/tmp/aiter_configs/_tuned_.csv`. That merged file is what the
-runtime module consumes. See `aiter/jit/core.py::AITER_CONFIG` for the
-resolution order.
-
-Override the merged path via the matching env var:
-
-```bash
-# Examples from aiter/jit/core.py
-AITER_CONFIG_GEMM_A8W8=/path/to/my_a8w8_tuned_gemm.csv python3 op_tests/test_gemm_a8w8.py
-AITER_CONFIG_GEMM_A8W8_BLOCKSCALE=/path/to/custom.csv  python3 bench.py
-```
-
-## Step 4: Rebuild the runtime module with the new config
-
-If `PREBUILD_KERNELS=0` (default), the next test call JIT-builds the winning
-kernels on demand — no extra step needed.
-
-If you had `PREBUILD_KERNELS=1` during `setup.py develop`, pre-existing `.so`
-files were built against the **old** tuned CSV. Force a rebuild:
-
-```bash
-AITER_REBUILD=1 python3 op_tests/test_gemm_a8w8.py
-# Or wipe first:
-rm -rf aiter/jit/build aiter/jit/module_gemm_a8w8.so
-python3 op_tests/test_gemm_a8w8.py
-```
-
-## Step 5: Verify correctness and perf
-
-```bash
-# Correctness across the tuned shapes:
-python3 op_tests/test_gemm_a8w8.py
-
-# Single shape, verbose:
-AITER_LOG_MORE=1 AITER_LOG_TUNED_CONFIG=1 python3 op_tests/test_gemm_a8w8.py -m 128 -n 1536 -k 7168
-
-# Perf bench vs torch reference:
-python3 op_tests/op_benchmarks/triton/bench_gemm_a8w8.py
-```
-
-`AITER_LOG_TUNED_CONFIG=1` prints which config file was used and which
-kernelId won for each call — crucial for spotting cases where the merged CSV
-lost a row.
-
----
-
-## Integrating a brand-new CK op
-
-If you're adding `ck_my_gemm`:
-
-1. **Copy a template**. Start from `csrc/ck_gemm_a8w8/` (contains
-   `gen_instances.py`, `gemm_a8w8_tune.{cu,py}`, `gemm_a8w8.cu`, plus the
-   header under `csrc/ck_gemm_a8w8/include/`).
-2. **Regenerate instances**. CK's own generator (`example/ck_tile/*/generate.py`)
-   in `3rdparty/composable_kernel/` produces instances. `gen_instances.py`
-   wraps that call with the right `--filter` to keep the part-files small.
-3. **Add 2 JIT modules** to `aiter/jit/optCompilerConfig.json`:
-   - `module_my_gemm` (runtime) and `module_my_gemm_tune` (tuner). Only the
-     tune module should appear in `_tune` filter in `setup.py::get_exclude_ops`
-     so PREBUILD_KERNELS skips it.
-4. **Python wrapper** in `aiter/ops/gemm_op_my_gemm.py` using `@compile_ops`.
-5. **Tuned CSV pair** in `aiter/configs/my_gemm_{un,}tuned_gemm.csv`.
-6. **Per-op README** in `csrc/ck_my_gemm/README.md` — copy the layout of
-   `ck_gemm_a8w8/README.md` so users know what flags you support.
-
-## Tips for CK tuning
-
-- CK instance files are template-heavy. If compile is slow, split
-  `gen_instances.py` output into `*_part{1,2,3}.cpp`. See
-  `3rdparty/composable_kernel/library/src/tensor_operation_instance/gpu/
-  gemm_multiply_multiply/device_gemm_multiply_multiply_xdl_*`.
-- `MAX_JOBS=8` is a good starting point for CK compile; each instance
-  can eat 4–8 GB of RAM.
-- `--profile_file` dumps every candidate; inspect it to spot cases where
-  the winner is only 1% faster than #2 — your tuned config is noise-limited.
-- Keep `errRatio` at `0.05` for FP16/BF16 and tighten to `0.01` for FP32.
-  FP8 /FP4 workloads may need larger tolerances — check the test's own
-  `rtol/atol`.
-- Model-specific tuned configs (`model_configs/*_qwen3_235b.csv`) are
-  **additive**. Don't remove rows from the generic `a8w8_tuned_gemm.csv`
-  just because the model config has them.
-
-## Troubleshooting
-
-| Symptom | Fix |
-|---------|-----|
-| Tuner silently skips most shapes | `errRatio` too tight, or kernels all fail correctness. Re-run with `-v` and widen `--errRatio`. |
-| New shape added but still "kernel not found" at runtime | Merged config at `/tmp/aiter_configs/...` is stale. `rm -rf /tmp/aiter_configs && AITER_REBUILD=1 python3 ...` |
-| Tune module OOMs during compile | Split instances (`gen_instances.py` → more `*_part*.cpp`) and/or drop `MAX_JOBS`. |
-| Perf regressed after retune | Check `errRatio` of the new winner vs the old one in `--profile_file`. The new pick may be 0.1% faster at tune time but noisy in the real workload. |
-| Different CU counts produce different winners | Expected. `cu_num` is part of the key; tune on each SKU you care about (MI300X=80, MI300A=38, MI325X=88, MI350X=?). |
+## When to escalate
+- Instance list doesn't cover your `(dtype, q_type)` pair → check
+  `csrc/ck_<op>/gen_instances.py` and regenerate, or add a new CK template.
+- MoE-specific workflow → `aiter-moe-tuning`.
+- JIT rebuild fails after tuning → `aiter-jit-debug`.

--- a/.claude/skills/aiter-jit-debug/SKILL.md
+++ b/.claude/skills/aiter-jit-debug/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: aiter-jit-debug
+description: >
+ Diagnose AITER JIT compilation failures: "ModuleNotFoundError: module_*"
+ at import time, `hipcc` errors during `@compile_ops`, stale `.so` caches,
+ hipify mishandling of ROCm intrinsics, arch mismatch (gfx942 vs gfx950),
+ and module-config typos in `optCompilerConfig.json`. Use when an AITER op
+ fails to load or rebuild, or when `AITER_REBUILD=1` doesn't pick up code
+ changes.
+ Usage: /aiter-jit-debug []
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# Debug AITER JIT Compilation
+
+AITER compiles most kernels on-demand through `aiter/jit/core.py` + the
+`@compile_ops` decorator. This skill walks through the common failure modes
+in order of likelihood.
+
+## Step 0: Turn on verbose logging
+
+Before anything else, reproduce the failure with maximum verbosity:
+
+```bash
+AITER_LOG_MORE=1 AITER_LOG_LEVEL=DEBUG python3 op_tests/test_my_op.py 2>&1 | tee /tmp/aiter_jit.log
+```
+
+Environment variables you'll use throughout:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `AITER_LOG_MORE` | `0` | Adds compile command lines, timings, file paths. |
+| `AITER_LOG_LEVEL` | `INFO` | `DEBUG` shows every JIT decision. |
+| `AITER_REBUILD` | `0` | Force-rebuild every JIT module. |
+| `GPU_ARCHS` | auto | Comma/semicolon list, e.g. `"gfx942"` or `"gfx942;gfx950"`. |
+| `MAX_JOBS` | auto | Reduce when builds OOM. |
+| `CK_DIR` | `3rdparty/composable_kernel` | Alternate CK source path. |
+
+## Step 1: Classify the error
+
+| Symptom | Likely cause | Go to |
+|---------|--------------|-------|
+| `ModuleNotFoundError: No module named 'module_xxx'` at import | Missing/typo'd key in `optCompilerConfig.json` | §2 |
+| `ImportError: cannot import name 'xxx' from 'module_xxx'` | pybind name mismatch | §3 |
+| `hipcc: command not found` or `/opt/rocm/bin/hipcc: error` | ROCm toolchain not on PATH | §4 |
+| `undefined symbol: _Z ...` at load | Missing source in `srcs` | §5 |
+| `hipErrorNoBinaryForGpu` at run | Arch mismatch | §6 |
+| Code changes ignored | Stale cache / wrong mtime | §7 |
+| `hipify` mangled an intrinsic / fails to parse | hipify should be disabled for this module | §8 |
+| OOM during compile / `killed signal 9` | Too many parallel jobs | §9 |
+| CK build hangs / takes >30 min | Template-heavy instance file; needs splitting | §10 |
+
+## 2. ModuleNotFoundError: module_xxx
+
+Three files must agree on the module name:
+
+```bash
+grep -r '"module_xxx"' aiter/jit/optCompilerConfig.json
+grep -r 'PYBIND11_MODULE(module_xxx'  csrc/pybind/
+grep -rn '@compile_ops("module_xxx")' aiter/ops/
+```
+
+**All three must match character-for-character.** A single typo (`module_xxx` vs
+`module_xx`) causes this error.
+
+The JSON key is read in `aiter/jit/core.py::get_args_of_build()`. If it's
+missing, `build_module()` never runs and the `.so` is never produced.
+
+Fix: add the missing key (see `aiter-add-operator` skill, Step 3) or correct
+the typo.
+
+## 3. ImportError: cannot import name 'xxx'
+
+The module loaded but the symbol isn't exported. Check the pybind definition:
+
+```cpp
+PYBIND11_MODULE(module_xxx, m) {
+  m.def("xxx", &xxx, "...");   // <-- the name "xxx" here must match
+}
+```
+
+`@compile_ops("module_xxx")` binds the wrapper function **by name**. So a
+`def fast_path(...)` in Python tied to pybind `m.def("fast_path", ...)` is OK,
+but `m.def("fast_path_v2", ...)` would break.
+
+## 4. hipcc not found / wrong path
+
+AITER relies on `torch.utils.cpp_extension` (forked under
+`aiter/jit/utils/cpp_extension.py`) to find `hipcc`. Check:
+
+```bash
+which hipcc
+hipcc --version          # expect ROCm 6.x or 7.x
+python3 -c "import torch; print(torch.version.hip)"
+```
+
+Common fixes:
+
+```bash
+# Add ROCm to PATH
+export PATH=/opt/rocm/bin:$PATH
+# Match hip version to torch
+python3 -c "import torch.utils.cpp_extension as c; print(c.ROCM_HOME)"
+```
+
+If `torch.version.hip` is `None`, you're on a CPU-only PyTorch build — reinstall
+a ROCm-enabled wheel.
+
+## 5. undefined symbol at load time
+
+`import aiter.ops.my_op` succeeds, but calling `my_op(...)` crashes with
+`undefined symbol: _Z5my_op...`. The `.so` compiled, but a referenced function
+wasn't in any `srcs` entry.
+
+```bash
+nm -D aiter/jit/module_my_op.so | grep -i my_op
+# Shows the undefined symbol (U marker)
+```
+
+Fix: add the missing `.cu` / `.cpp` to `srcs` in `optCompilerConfig.json`.
+
+## 6. hipErrorNoBinaryForGpu
+
+The kernel was compiled for a different arch than the GPU running it.
+
+```bash
+rocm-smi --showproductname   # e.g. MI300X (gfx942)
+python3 -c "import torch; print(torch.cuda.get_device_properties(0))"
+```
+
+Force a rebuild targeting the right arch:
+
+```bash
+rm -rf aiter/jit/build aiter/jit/module_my_op.so
+GPU_ARCHS="gfx942" AITER_REBUILD=1 python3 op_tests/test_my_op.py
+```
+
+For multi-arch wheels, use `GPU_ARCHS="gfx942;gfx950"`. `setup.py` respects
+this in PREBUILD mode.
+
+## 7. Stale cache / code change not picked up
+
+AITER caches compiled `.so` files in `aiter/jit/` keyed on source file mtime +
+flags. If NFS / Docker bind-mount mtimes are unstable, the cache may persist
+across edits.
+
+**Nuclear option**:
+
+```bash
+rm -rf aiter/jit/build aiter/jit/*.so
+AITER_REBUILD=1 python3 op_tests/test_my_op.py
+```
+
+**Surgical option** (just one module):
+
+```bash
+rm -f aiter/jit/module_my_op.so aiter/jit/build/module_my_op/
+AITER_REBUILD=1 python3 op_tests/test_my_op.py
+```
+
+**Debug which source triggered or blocked a rebuild**:
+
+```bash
+AITER_LOG_MORE=1 python3 -c "from aiter.ops.my_op import my_op; my_op"
+# Search the log for "build finished" / "build skipped" entries.
+```
+
+## 8. hipify mangles an intrinsic
+
+AITER's hipify pass rewrites CUDA calls to HIP equivalents
+(`aiter/jit/utils/hipify/`). When your source is **already** HIP (e.g. uses
+`__builtin_amdgcn_*`, ROCm-specific types, CK-tile code), hipify can mis-edit
+it.
+
+Disable hipify for that module by adding `"hipify": "False"` to the JSON entry:
+
+```json
+"module_pa_ragged": {
+  "srcs": [...],
+  "flags_extra_hip": [...],
+  "hipify": "False"
+}
+```
+
+Signs you need this:
+- Compile fails on a line that looks fine in the source.
+- `grep cuda ` shows hipify already ran over the file (look in
+  `aiter/jit/build/module_xxx/` for the hipified copy).
+
+## 9. Compile OOM
+
+Template-heavy CK instance files can consume 4–8 GB each. With `MAX_JOBS=64`
+that's >200 GB of RAM.
+
+```bash
+MAX_JOBS=8 AITER_REBUILD=1 python3 op_tests/test_my_op.py
+# or, for the whole install:
+MAX_JOBS=8 PREBUILD_KERNELS=1 python3 setup.py develop
+```
+
+`setup.py::getMaxJobs()` already caps based on free memory, but it assumes
+0.5 GB/job which is optimistic for CK.
+
+## 10. CK compile takes forever
+
+If `csrc/ck_*` instances take >30 min per file, split them:
+
+```bash
+ls csrc/ck_gemm_a8w8/  # look for gen_instances.py and *_part{1,2,3}.cpp naming
+```
+
+CK's own generator (`example/ck_tile/*/generate.py`) supports `--part`
+splitting. After regenerating, make sure the new files are listed in the
+`blob_gen_cmd` output directory.
+
+## Useful inspection commands
+
+```bash
+# Show the full JIT command for a module (works even after it compiled):
+AITER_LOG_MORE=1 AITER_REBUILD=1 python3 -c "
+import aiter.ops.my_op as m; m.my_op
+" 2>&1 | grep -E '(hipcc|g\+\+|-o .*\.so)'
+
+# Show which archs a .so contains:
+/opt/rocm/bin/roc-obj-ls aiter/jit/module_my_op.so
+
+# Validate JSON syntax after editing:
+python3 -c "import json; json.load(open('aiter/jit/optCompilerConfig.json'))"
+```
+
+## Sanity checklist when an op is "broken"
+
+1. `git status` — uncommitted changes to `optCompilerConfig.json`?
+2. `rm -rf aiter/jit/build aiter/jit/*.so` — stale cache cleared?
+3. `AITER_REBUILD=1 AITER_LOG_MORE=1 python3 op_tests/test_my_op.py 2>&1 | head -50`
+4. Confirm module name matches across JSON, pybind, and `@compile_ops`.
+5. Confirm `GPU_ARCHS` covers the target GPU.
+6. For CK ops: confirm `3rdparty/composable_kernel` is at the expected submodule SHA.

--- a/.claude/skills/aiter-moe-tuning/SKILL.md
+++ b/.claude/skills/aiter-moe-tuning/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: aiter-moe-tuning
+description: >
+ Tune AITER's fused Mixture-of-Experts (MoE) op. Covers the
+ `aiter/configs/tuned_fmoe.csv` + `aiter/configs/untuned_fmoe.csv` flow,
+ per-model configs under `aiter/configs/model_configs/`, running
+ `csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py` (or the current
+ MoE tuner), regenerating CK instances, rebuilding the JIT module, and
+ validating with `op_tests/test_moe.py`.
+ Use this skill when a user asks to "tune MoE", "add a new MoE shape",
+ "tune Mixtral / DeepSeek / Llama-4 MoE", or reports a
+ `[AITER] NOTICE: no tuned config for fmoe` log line.
+allowed-tools: Bash Read Edit Grep Glob Write
+---
+
+# Tune AITER Fused MoE
+
+Fused MoE in AITER is dispatched through a CK-tile two-stage GEMM
+(codegen lives in `csrc/ck_gemm_moe_2stages_codegen/` and the CK-tile
+variant in `csrc/ck_tile_gemm_moe_2stages/`). At runtime the op reads
+`aiter/configs/tuned_fmoe.csv` and picks a per-shape kernel instance;
+if the shape isn't present, it falls back to a generic kernel and
+logs a notice.
+
+## Step 0: Confirm which MoE we're tuning
+
+AITER has several MoE variants. Ask / verify which one the user hits:
+
+| Python entry point | Config file | Tuner |
+|--------------------|-------------|-------|
+| `aiter.fused_moe` (CK 2-stage) | `aiter/configs/tuned_fmoe.csv` | `csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py` |
+| `aiter.ops.triton.moe.*` | `aiter/configs/*fused_moe*.csv` (Triton) | scripts under `aiter/ops/triton/moe/` |
+| ASM MoE (`asm_moe`) | ASM-codegen'd, not CSV-tuned | n/a |
+
+The rest of this skill focuses on **CK 2-stage fused MoE**, which is the
+most common path. Adapt the file names if the user is on Triton MoE.
+
+```bash
+rg -n "tuned_fmoe|untuned_fmoe|fused_moe_tune" aiter/ csrc/
+ls aiter/configs | grep -i fmoe
+```
+
+## Step 1: Read the current CSVs
+
+```bash
+head -n 5 aiter/configs/untuned_fmoe.csv
+head -n 5 aiter/configs/tuned_fmoe.csv
+```
+
+Column layout (verify with `head -n 1` of the current file — it may evolve):
+
+```
+token,model_dim,inter_dim,expert,topk,dtype,q_type,use_g1u1,doweight_stage1
+```
+
+`tuned_fmoe.csv` extends that with the chosen kernel config id (e.g. a
+CK `MoeKernel` tag or BLOCK_M / BLOCK_N / BLOCK_K / KSPLIT).
+
+Per-model overrides live in `aiter/configs/model_configs/<model>/`, e.g.
+`model_configs/mixtral-8x7b/tuned_fmoe.csv`. If the user targets a specific
+model, tune there instead of the top-level CSV.
+
+## Step 2: Add the new shape(s) to `untuned_fmoe.csv`
+
+Compute the shape tuple from the model config:
+
+- `token`: the batch × seq of tokens you want optimized for (common: 1, 32, 64, 128, 256, 512, 1024, 2048, 4096).
+- `model_dim`: hidden size (e.g. 4096 for Llama-3-8B, 7168 for DeepSeek-V3).
+- `inter_dim`: MoE FFN intermediate dim **per-expert**.
+- `expert`: total #experts (e.g. 8, 64, 256).
+- `topk`: routed experts per token (usually 2 or 8).
+- `dtype`: `bf16` / `fp16`.
+- `q_type`: `No` (unquantized), `fp8`, `int8`, `int4` — match the runtime call.
+- `use_g1u1`: `1` if SwiGLU-style gated (most models), else `0`.
+- `doweight_stage1`: `1` or `0` — match how the Python side calls MoE.
+
+Append one line per shape. **Don't delete existing lines** — they're used by
+other users and CI. If your shape already exists, skip.
+
+```bash
+# Example: add Llama-4-scout-like MoE shapes
+cat >> aiter/configs/untuned_fmoe.csv <<'EOF'
+128,4096,8192,16,1,bf16,No,1,0
+512,4096,8192,16,1,bf16,No,1,0
+2048,4096,8192,16,1,bf16,No,1,0
+EOF
+```
+
+## Step 3: Run the tuner
+
+```bash
+export GPU_ARCHS=gfx942                 # or gfx950 / gfx90a — your target
+python csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py \
+    --untuned_file aiter/configs/untuned_fmoe.csv \
+    --tuned_file  aiter/configs/tuned_fmoe.csv \
+    --arch $GPU_ARCHS
+```
+
+Flags vary per script version — always run `--help` first:
+
+```bash
+python csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py --help
+```
+
+The tuner:
+
+1. Parses `untuned_fmoe.csv`, skipping rows already present in `tuned_fmoe.csv`.
+2. Enumerates CK `MoeKernel` instances compatible with `(dtype, q_type, use_g1u1)`.
+3. Builds each instance (this can take a while; parallelize with `MAX_JOBS`).
+4. Benchmarks on the live GPU and picks the fastest.
+5. Appends a line to `tuned_fmoe.csv`.
+
+Typical runtime: 5–30 min per shape depending on #instances.
+
+Speed up:
+
+```bash
+export MAX_JOBS=$(nproc)        # parallel compile
+# For quick sanity runs, many AITER tuners support --fast or --subset
+```
+
+## Step 4: Regenerate CK instance files (only if needed)
+
+If the tuner selected a kernel config that wasn't in the pre-generated
+instance list, you need to (re)run the MoE instance generator. Typical
+pattern:
+
+```bash
+python csrc/ck_gemm_moe_2stages_codegen/gen_instances.py --arch $GPU_ARCHS
+# The CK-tile variant has its own generator:
+#   csrc/ck_tile_gemm_moe_2stages/gen_instances.py
+```
+
+Check `aiter/jit/optCompilerConfig.json` for the `module_moe_ck2stages*`
+entry to see its `blob_gen_cmd` — that is the authoritative generator
+command for CK instance files.
+
+## Step 5: Rebuild the JIT module
+
+```bash
+export AITER_REBUILD=1            # force recompile
+python -c "import aiter; aiter.fused_moe; print('ok')"
+```
+
+If `PREBUILD_KERNELS=1` was used at install time, do a proper reinstall:
+
+```bash
+PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCHS pip install -e . --no-build-isolation
+```
+
+## Step 6: Validate correctness
+
+```bash
+pytest -q op_tests/test_moe.py::test_fmoe -k "bf16 and 128"
+# or the specific parametrization matching your shape
+```
+
+Correctness first, then perf:
+
+```bash
+# Triton-backed MoE benchmark (adjust flags via --help):
+python op_tests/op_benchmarks/triton/bench_moe.py --help
+# For the CK-tile 2-stage path, reuse op_tests/test_moe.py with --benchmark or
+# write a small perftest driver — see the `benchmark-aiter-op` skill.
+```
+
+Expect the new shape's TFLOPS to be ≥ the previous fallback by a clear
+margin (often 1.2–3×). If not, the tuner probably hit a bad search space —
+re-check the `use_g1u1` / `q_type` / `doweight_stage1` columns.
+
+## Step 7: Per-model config (optional)
+
+For model-specific shapes, put the tuned rows under:
+
+```
+aiter/configs/model_configs/<model_name>/tuned_fmoe.csv
+```
+
+AITER will prefer the model-specific CSV when
+`AITER_MODEL_CONFIG=<model_name>` is set (grep `model_configs` in
+`aiter/jit/core.py` / `aiter/ops/` to confirm the exact env variable name
+in the current checkout):
+
+```bash
+rg -n "model_configs" aiter/
+```
+
+## Step 8: Commit
+
+```bash
+git add aiter/configs/untuned_fmoe.csv \
+        aiter/configs/tuned_fmoe.csv \
+        aiter/configs/model_configs/  # if touched
+git commit -m "tune: fused MoE for <model / shape-set> on <arch>"
+```
+
+**Do not commit** the `aiter/jit/build/` directory.
+
+## Common pitfalls
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `[AITER] NOTICE: no tuned config for fmoe ...` at runtime | Your shape isn't in `tuned_fmoe.csv`. Follow steps 2–5. |
+| Tuner says `no compatible MoeKernel for (dtype=..., q_type=..., use_g1u1=...)` | The instance list doesn't cover that combination yet. Run the instance generator (Step 4) with a wider scope, or extend the kernel list in `csrc/ck_gemm_moe_2stages_codegen/` and regenerate. |
+| Tuning finishes in seconds | The row was already in `tuned_fmoe.csv`; the tuner skipped it. Delete that row and re-run, or use `--force`. |
+| Correctness regression after tuning | The chosen instance has numerical issues at that shape. Re-run the tuner with stricter tolerance or blacklist the bad instance in the tuner script. |
+| `HIP OOM` during tuning | Lower `--batch` / `--token` to the sweep, or tune one shape at a time. |
+| Tuned row ignored at runtime | Shape mismatch — make sure `token` is the *actual* token count you hit at runtime, and `q_type` / `use_g1u1` / `doweight_stage1` columns match the Python call-site exactly. Case-sensitive. |
+| Tuner hangs compiling | `MAX_JOBS` may be too high. Lower to `nproc/2` and retry; CK instance compiles are memory-hungry. |
+
+## References
+- `csrc/ck_gemm_moe_2stages_codegen/README.md`
+- `aiter/fused_moe.py` — Python entry point and dispatch
+- `aiter/fused_moe_dp_shared_expert.py` — DP + shared-expert variant
+- `aiter/configs/untuned_fmoe.csv`, `aiter/configs/tuned_fmoe.csv`
+- `op_tests/test_moe.py` — reference tests

--- a/.claude/skills/aiter-triton-kernel/SKILL.md
+++ b/.claude/skills/aiter-triton-kernel/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: aiter-triton-kernel
+description: >
+ Author or modify Triton kernels inside AITER. Enforces the `aiter/ops/triton/`
+ layout (category subfolders: `gemm/`, `attention/`, `moe/`, `normalization/`,
+ `quant/`, `rope/`, `fusions/`, `utils/`), the matching `_triton_kernels/`
+ mirror, config selection via `get_gemm_config()`, config-aware kernel naming
+ via `make_kernel_repr()`, arch-string conventions (`gfx942` / `gfx950` — never
+ product names), JSON config layout (`M_LEQ_x` / `M_GEQ_x` / `any`), and the
+ placement of matching tests under `op_tests/triton_tests//`.
+ Use when writing new Triton kernels, porting ones from triton-lang/triton-ops,
+ or refactoring an existing AITER Triton op.
+ Usage: /aiter-triton-kernel 
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# Author a Triton Kernel in AITER
+
+AITER's Triton ops live under `aiter/ops/triton/` in a category layout. The
+corresponding raw `@triton.jit` kernels live under
+`aiter/ops/triton/_triton_kernels/` mirroring the same category tree.
+
+Rules of thumb, lifted from `aiter/ops/triton/README.md`:
+
+- **Wrapper file** (`aiter/ops/triton/ /kernel.py`) exposes a Python
+  function that reshapes inputs, picks a config, and launches the kernel.
+- **Kernel file** (`aiter/ops/triton/_triton_kernels/ /kernel.py`)
+  contains the `@triton.jit` body and an internal `_get_config(M, N, K)`.
+- **Config JSON** (`aiter/ops/triton/configs/ /{arch}-NAME.json`)
+  stores tuned parameters keyed by `M_LEQ_x` / `M_GEQ_x` / `any`.
+- **Test** (`op_tests/triton_tests/ /test_kernel.py`) is a `pytest` file.
+
+## 1. Pick the category
+
+| Category | Use for | Path |
+|----------|---------|------|
+| `gemm/basic` | Plain A*W* matmul | `aiter/ops/triton/gemm/basic/` |
+| `gemm/batched` | `bmm` style | `aiter/ops/triton/gemm/batched/` |
+| `gemm/feed_forward` | MLP-specific GEMMs (fused activation, glu) | `aiter/ops/triton/gemm/feed_forward/` |
+| `gemm/fused` | Fused GEMM (+quant, +epilogue) | `aiter/ops/triton/gemm/fused/` |
+| `attention` | MHA / MQA / GQA / MLA | `aiter/ops/triton/attention/` |
+| `moe` | Fused MoE variants | `aiter/ops/triton/moe/` |
+| `normalization` | RMSNorm / LayerNorm | `aiter/ops/triton/normalization/` |
+| `quant` | FP8 / FP4 / INT4 quantizers | `aiter/ops/triton/quant/` |
+| `rope` | Rotary embeddings | `aiter/ops/triton/rope/` |
+| `fusions` | Other fused ops | `aiter/ops/triton/fusions/` |
+| `utils` | Shared helpers (`gemm_config_utils.py`, `kernel_repr.py`, logger) | `aiter/ops/triton/utils/` |
+
+The **flat-file layout is deprecated**. A `_BACKWARD_COMPAT_MAP` in
+`aiter/ops/triton/__init__.py` keeps old imports working, but new code should
+use the category paths directly.
+
+## 2. Skeleton for a new kernel
+
+Using `gemm_a16w16` as the reference. Replace `my_op` + `MY-OP-CFG` as needed.
+
+### 2.1 Kernel body — `aiter/ops/triton/_triton_kernels/category/my_op.py`
+
+```python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+import triton
+import triton.language as tl
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+from aiter.ops.triton.utils.gemm_config_utils import get_gemm_config
+
+
+_kernel_repr = make_kernel_repr(
+    "_my_op_kernel",
+    ["BLOCK_SIZE_M", "BLOCK_SIZE_N", "BLOCK_SIZE_K", "GROUP_SIZE_M"],
+)
+
+
+@triton.jit(repr=_kernel_repr)
+def _my_op_kernel(
+    X_ptr, W_ptr, Y_ptr,
+    M, N, K,
+    stride_xm, stride_xk,
+    stride_wn, stride_wk,
+    stride_ym, stride_yn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """My kernel: Y = X @ W^T.
+
+    BLOCK_SIZE_M / _N / _K tile the problem; GROUP_SIZE_M controls the
+    super-group schedule for better L2 reuse.
+    """
+    # ... standard GEMM body ...
+    pass
+
+
+def _get_config(M: int, N: int, K: int):
+    return get_gemm_config("MY-OP", M, N, K)
+```
+
+### 2.2 Wrapper — `aiter/ops/triton/category/my_op.py`
+
+```python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+from typing import Optional
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.category.my_op import (
+    _my_op_kernel,
+    _get_config,
+)
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+_LOGGER = AiterTritonLogger()
+
+
+def my_op(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    y: Optional[torch.Tensor] = None,
+    config: Optional[dict] = None,
+):
+    """Compute Y = X @ W^T with Triton.
+
+    Args:
+        x: (M, K) input.
+        w: (N, K) weight (internally transposed).
+        y: optional pre-allocated (M, N) output.
+        config: override the tuned config.
+
+    Returns:
+        torch.Tensor of shape (M, N).
+    """
+    _LOGGER.info(f"MY_OP: x={tuple(x.shape)} w={tuple(w.shape)}")
+
+    M, K = x.shape
+    N, _ = w.shape
+    if config is None:
+        config, _tuned = _get_config(M, N, K)
+    if y is None:
+        y = torch.empty((M, N), dtype=x.dtype, device=x.device)
+
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    )
+    _my_op_kernel[grid](
+        x, w, y,
+        M, N, K,
+        x.stride(0), x.stride(1),
+        w.stride(0), w.stride(1),
+        y.stride(0), y.stride(1),
+        **config,
+    )
+    return y
+```
+
+### 2.3 Config — `aiter/ops/triton/configs/category/gfx950-MY-OP.json`
+
+```json
+{
+  "M_LEQ_64":   { "BLOCK_SIZE_M": 16,  "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64,  "GROUP_SIZE_M": 1, "num_warps": 4, "num_stages": 2 },
+  "M_LEQ_512":  { "BLOCK_SIZE_M": 64,  "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64,  "GROUP_SIZE_M": 4, "num_warps": 4, "num_stages": 2 },
+  "M_GEQ_4096": { "BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 64,  "GROUP_SIZE_M": 8, "num_warps": 8, "num_stages": 2 },
+  "any":        { "BLOCK_SIZE_M": 64,  "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64,  "GROUP_SIZE_M": 4, "num_warps": 4, "num_stages": 2 }
+}
+```
+
+Key rules from `aiter/ops/triton/README.md`:
+
+- `any` is **mandatory** when any config exists.
+- Keys are `M_LEQ_x` / `M_GEQ_x` — never the deprecated `large`/`small`.
+- File name pattern: `{arch}-{CONFIG_NAME}.json`. Specialized: `{arch}-{CONFIG_NAME}-N={N}-K={K}.json`.
+- `{arch}` is the gfx string (`gfx942`, `gfx950`, `gfx1100`, …), NOT a product name.
+
+### 2.4 Test — `op_tests/triton_tests/category/test_my_op.py`
+
+```python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+import pytest
+import torch
+from aiter.ops.triton.category.my_op import my_op
+
+
+def torch_ref(x, w):
+    return x @ w.T
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("M,N,K", [(128, 1280, 8192), (1024, 1024, 1024)])
+def test_my_op(dtype, M, N, K):
+    x = torch.randn(M, K, dtype=dtype, device="cuda")
+    w = torch.randn(N, K, dtype=dtype, device="cuda")
+    got = my_op(x, w)
+    ref = torch_ref(x, w)
+    torch.testing.assert_close(got, ref, rtol=1e-2, atol=1e-2)
+```
+
+Run:
+
+```bash
+pytest op_tests/triton_tests/category/test_my_op.py -v
+# or the whole category:
+pytest op_tests/triton_tests/category/
+```
+
+## 3. Arch-specific code
+
+**Always** compare `DEVICE_ARCH` to the gfx string:
+
+```python
+from aiter.ops.triton.utils.arch_info import DEVICE_ARCH
+
+if DEVICE_ARCH in ("gfx942",):
+    ...
+elif DEVICE_ARCH in ("gfx950",):
+    ...
+```
+
+Never parse product names. This anti-pattern breaks on new archs and is
+explicitly called out in the README:
+
+```python
+# DON'T DO THIS
+if int(DEVICE_ARCH.split("MI")[1].replace("X", "")) < 300:
+    ...
+```
+
+## 4. Trace-friendly kernel names
+
+Decorate every `@triton.jit` with a `repr` that embeds the compile-time
+constants — this makes `rocprofv3` stats readable at a glance and lets the
+test-selection script (`.github/scripts/select_triton_tests.py`) track
+config dependencies.
+
+```python
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+
+_kernel_repr = make_kernel_repr(
+    "_my_op_kernel",
+    ["BLOCK_SIZE_M", "BLOCK_SIZE_N", "BLOCK_SIZE_K", "GROUP_SIZE_M"],
+)
+
+@triton.jit(repr=_kernel_repr)
+def _my_op_kernel(...):
+    ...
+```
+
+## 5. Split-K / reduce pattern
+
+If you support `NUM_KSPLIT > 1`, follow `gemm_a16w16.py`:
+
+1. The main kernel writes `(NUM_KSPLIT, M, N) float32` partials.
+2. A separate `_kernel_reduce` sums them back into `(M, N)`.
+3. Wrapper decides whether to call the reduce based on `skip_reduce` (useful
+   for fusing into a downstream quant op).
+4. Use `compute_splitk_params(config, K)` from `gemm_config_utils` when
+   appropriate.
+
+## 6. Config-loader integration (for the test-selection script)
+
+`.github/scripts/select_triton_tests.py` statically parses the tree to map
+kernel files -> config files. Stick to these patterns so the script can follow
+you:
+
+```python
+# String literal for the config name
+get_gemm_config("MY-OP", M, N, K)
+
+# f-string referring to the configs path
+f"{AITER_TRITON_CONFIGS_PATH}/{dev}-MY-OP.json"
+```
+
+## 7. Checklist for a new Triton kernel
+
+- [ ] Wrapper placed under the correct `aiter/ops/triton//` folder.
+- [ ] Kernel body placed under matching `aiter/ops/triton/_triton_kernels//`.
+- [ ] Config files named `{arch}-NAME.json` with `M_LEQ_x` / `M_GEQ_x` / `any` keys (never `large`/`small`).
+- [ ] `@triton.jit(repr=...)` using `make_kernel_repr` for trace-friendly names.
+- [ ] Wrapper has a docstring covering args / returns / config knobs.
+- [ ] `DEVICE_ARCH` comparisons use gfx strings, never product names.
+- [ ] Test under `op_tests/triton_tests//test_.py`, `pytest`-compatible.
+- [ ] `ruff check aiter/ops/triton/ op_tests/triton_tests/` is clean.
+- [ ] Correctness vs a torch reference at `rtol/atol ~= 1e-2` for fp16/bf16.
+
+## 8. Quick checklist for arch-specific exceptions
+
+- Compare `DEVICE_ARCH` to `("gfx950", "gfx942", ...)`.
+- Do not parse product names.
+- When adding a new arch: add the config JSON files for that arch, then add
+  a `DEVICE_ARCH` branch in the wrapper only if dispatch logic actually differs.
+
+## 9. Common pitfalls
+
+| Symptom | Fix |
+|---------|-----|
+| Kernel works at M=1024 but fails at M=3 | Missing `M_LEQ_4` / `M_LEQ_8` entry; `any` fallback has unsuitable block sizes. |
+| `KeyError: 'any'` | Every config file must include an `any` block. |
+| Triton recompile on every call | You're passing a tensor value as a constexpr; keep constexprs to shapes/strides/block sizes. |
+| Config file not found | Filename uses product name (`MI300X-...`) instead of arch (`gfx942-...`). |
+| `AttributeError: 'DEVICE_ARCH' ...` | Import from `aiter.ops.triton.utils.arch_info`, not a local helper. |
+| Old flat-file imports fail after refactor | Extend `_BACKWARD_COMPAT_MAP` in `aiter/ops/triton/__init__.py`. |

--- a/.claude/skills/benchmark-aiter-op/SKILL.md
+++ b/.claude/skills/benchmark-aiter-op/SKILL.md
@@ -2,36 +2,40 @@
 name: benchmark-aiter-op
 description: >
  Benchmark an AITER operator and compare it against a reference (torch) or an
- alternative backend (CK vs Triton vs ASM vs FlyDSL). Covers `@perftest` usage
- from `aiter/test_common.py`, the prebuilt benchmark drivers under
- `op_tests/op_benchmarks/triton/bench_*.py` and `op_tests/op_benchmarks/hip/`,
- L2 cache rotation, correct warmup, and producing a roofline-style report
- (latency / TFLOPS / bandwidth / % of peak). Use when the user asks to
- benchmark an op, compare backends, generate a perf table for a PR, or
- reproduce a published number.
+ alternative backend (CK vs Triton vs ASM vs FlyDSL). Covers the two parallel
+ AITER benchmarking idioms — `@perftest` from `aiter/test_common.py` (used
+ inside `op_tests/test_*.py`) and `triton.testing.do_bench` (used by the
+ dedicated drivers in `op_tests/op_benchmarks/triton/bench_*.py` and
+ `op_tests/op_benchmarks/hip/`) — plus L2 cache rotation, correct warmup,
+ and producing a roofline-style report (latency / TFLOPS / bandwidth / %
+ of peak). Use when the user asks to benchmark an op, compare backends,
+ generate a perf table for a PR, or reproduce a published number.
  Usage: /benchmark-aiter-op  [--dtype ] [--shape M,N,K]
 allowed-tools: Bash Read Edit Grep Glob
 ---
 
 # Benchmark an AITER Operator
 
-AITER has three layers of benchmarking:
+AITER has two parallel benchmarking idioms — **pick the one that matches
+the host file**, don't mix them:
 
-1. **`op_tests/test_*.py`** — correctness first, includes `@perftest` timing
-   next to each call. Good for quick A/B checks.
-2. **`op_tests/op_benchmarks/hip/` and `.../triton/`** — dedicated bench
-   drivers with richer sweeps. Use these for PR tables.
-3. **`rocprofv3`** — instruction-level traces. Covered by the
-   `capture-kernel-trace` and `kernel-trace-analysis` skills.
+| Use case | Idiom | Where it lives |
+|----------|-------|----------------|
+| Correctness tests with a quick perf number | `@perftest` | `op_tests/test_*.py` |
+| Dedicated bench driver for a PR table | `triton.testing.do_bench` | `op_tests/op_benchmarks/triton/bench_*.py`, `op_tests/op_benchmarks/hip/` |
+| Instruction-level hotspot analysis | `rocprofv3` ATT | See `capture-kernel-trace` / `kernel-trace-analysis` |
+
+Every existing driver under `op_tests/op_benchmarks/triton/` uses
+`triton.testing.do_bench`. **Do not introduce `@perftest` there** — it
+breaks the shape / backend / json-export scaffolding the drivers share.
 
 ## 1. Pick the right entry point
 
 | Goal | Command |
 |------|---------|
-| Quick latency of an op against reference | `python3 op_tests/test_.py` |
-| Full sweep for PR | `python3 op_tests/op_benchmarks/triton/bench_.py` |
-| Compare CK vs Triton vs ASM for the same shape | Call each backend from a small driver script (see §4) |
-| Instruction-level hotspot analysis | Capture rocprof ATT — see `capture-kernel-trace` |
+| Quick latency of an op next to a correctness check | `python3 op_tests/test_<op>.py` |
+| Full sweep for PR | `python3 op_tests/op_benchmarks/triton/bench_<op>.py` |
+| Compare CK vs Triton vs ASM for the same shape | Small ad-hoc driver — see §4 |
 
 List available bench drivers:
 
@@ -44,7 +48,7 @@ Existing drivers include `bench_gemm_a8w8.py`, `bench_gemm_a16w16.py`,
 `bench_rmsnorm.py`, `bench_extend_attention.py`, `bench_fp8_mqa_logits.py`,
 `bench_topk_topp_sampling.py`, and many more.
 
-## 2. Using `@perftest`
+## 2. Idiom A — `@perftest` (inside `op_tests/test_*.py`)
 
 `aiter/test_common.py` provides `@perftest(num_iters=101, num_warmup=2,
 testGraph=False, num_rotate_args=0, needTrace=False)`. Decorated functions
@@ -82,32 +86,55 @@ For memory-bound ops (normalization, quant, elementwise) `num_rotate_args=0`
 (auto-computed based on free memory + L2 size) is usually correct. The
 default logic picks enough rotations to flush L2 between iterations.
 
-## 3. Structure of a bench driver
+## 3. Idiom B — `triton.testing.do_bench` (inside `op_tests/op_benchmarks/.../bench_*.py`)
+
+`do_bench` is what every driver under `op_tests/op_benchmarks/triton/`
+actually uses (grep any file there to confirm). It handles warmup and
+returns median ms per call.
+
+```python
+import torch
+import triton
+import triton.testing
+
+from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
+
+M = N = K = 4096
+x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+w = torch.randn(N, K, dtype=torch.bfloat16, device="cuda")
+
+ms = triton.testing.do_bench(
+    lambda: gemm_a16w16(x, w),
+    warmup=25,   # ms of warmup (NOT number of iters)
+    rep=100,     # ms of timed region
+    return_mode="median",
+)
+
+flops = 2 * M * N * K
+print(f"{ms*1e3:.1f} us   {flops / (ms*1e-3) / 1e12:.1f} TFLOPS")
+```
+
+Key flags: `warmup` and `rep` are in **milliseconds**, not iterations.
+Typical values are `warmup=25, rep=100`. For a full worked example,
+read `op_tests/op_benchmarks/triton/bench_gemm_a16w16.py`.
+
+## 4. Structure of a bench driver
 
 The existing drivers under `op_tests/op_benchmarks/triton/` follow this
-pattern:
+pattern (built on `do_bench`, reusing shared argparse + json helpers in
+`op_tests/op_benchmarks/triton/utils/`):
 
 ```python
 # op_tests/op_benchmarks/triton/bench_my_op.py
 import argparse, json, torch
+import triton.testing
 from aiter.ops.triton.category.my_op import my_op
-from aiter.test_common import perftest, checkAllclose
 
 
 def gen_inputs(M, N, K, dtype):
     x = torch.randn(M, K, dtype=dtype, device="cuda")
     w = torch.randn(N, K, dtype=dtype, device="cuda")
     return x, w
-
-
-@perftest(num_rotate_args=5)
-def bench_aiter(x, w):
-    return my_op(x, w)
-
-
-@perftest(num_rotate_args=5)
-def bench_ref(x, w):
-    return x @ w.T
 
 
 def main():
@@ -121,19 +148,25 @@ def main():
     M, N, K = map(int, args.shape.split(","))
     x, w = gen_inputs(M, N, K, dtype)
 
-    y_aiter, us_aiter = bench_aiter(x, w)
-    y_ref,   us_ref   = bench_ref(x, w)
-    checkAllclose(y_aiter, y_ref, rtol=1e-2, atol=1e-2)
+    # Correctness first
+    y_aiter = my_op(x, w)
+    y_ref   = x @ w.T
+    torch.testing.assert_close(y_aiter, y_ref, rtol=1e-2, atol=1e-2)
+
+    ms_aiter = triton.testing.do_bench(lambda: my_op(x, w), warmup=25, rep=100,
+                                       return_mode="median")
+    ms_ref   = triton.testing.do_bench(lambda: x @ w.T,    warmup=25, rep=100,
+                                       return_mode="median")
 
     flops   = 2 * M * N * K
     bytes_  = (M*K + N*K + M*N) * x.element_size()
-    tflops  = flops / us_aiter / 1e6
-    bw      = bytes_ / us_aiter / 1e3   # GB/s
+    tflops  = flops / (ms_aiter * 1e-3) / 1e12
+    bw      = bytes_ / (ms_aiter * 1e-3) / 1e9   # GB/s
 
     row = {"M": M, "N": N, "K": K, "dtype": args.dtype,
-           "us_aiter": us_aiter, "us_ref": us_ref,
+           "us_aiter": ms_aiter * 1e3, "us_ref": ms_ref * 1e3,
            "tflops": tflops, "bw_GBps": bw,
-           "speedup": us_ref / us_aiter}
+           "speedup": ms_ref / ms_aiter}
     print(json.dumps(row, indent=2))
     if args.json:
         with open(args.json, "a") as f: f.write(json.dumps(row) + "\n")
@@ -151,7 +184,7 @@ for mnk in 1024,1024,1024 2048,2048,2048 4096,4096,4096 8192,8192,8192; do
 done
 ```
 
-## 4. Comparing backends (CK vs Triton vs ASM vs torch)
+## 5. Comparing backends (CK vs Triton vs ASM vs torch)
 
 Many AITER ops have multiple backends selected by a Python dispatcher. To
 force a particular backend, call it directly:
@@ -180,7 +213,10 @@ y_ref,  us_ref  = _torch(*inputs)
 Report: pick whichever wins at a given shape; the winner often changes between
 small-M and large-M regimes.
 
-## 5. Roofline numbers
+Inside a dedicated bench driver, swap the `@perftest` calls above for
+`triton.testing.do_bench` calls (same lambdas).
+
+## 6. Roofline numbers
 
 For a PR table, report at minimum:
 
@@ -206,7 +242,7 @@ e.g. MI300X FP16: 380 / 5.3 = ~72 FLOP/byte
 Anything below ~72 FLOP/byte is memory-bound → report GB/s utilization.
 Above → report TFLOPS utilization.
 
-## 6. PR-ready table format
+## 7. PR-ready table format
 
 Lifted from `CONTRIBUTE.md`:
 
@@ -223,19 +259,20 @@ Lifted from `CONTRIBUTE.md`:
 - Kernel: `_gemm_a16_w16_kernel_BLOCK_SIZE_M_64_BLOCK_SIZE_N_128_...` (from trace)
 ```
 
-## 7. Typical gotchas
+## 8. Typical gotchas
 
 | Issue | Fix |
 |-------|-----|
-| First call is 10–100x slower | JIT / autotune compile. Use warmup iters, and ignore the first call in manual timers. |
-| Two consecutive benches give very different numbers | L2 pollution — set `num_rotate_args=5` (or higher) on `@perftest`. |
+| First call is 10–100x slower | JIT / autotune compile. Use warmup iters, and ignore the first call in manual timers. `do_bench` already warms up by default. |
+| Two consecutive benches give very different numbers | L2 pollution — for `@perftest` set `num_rotate_args=5` (or higher); for `do_bench` pass `grad_to_none=[...]` or rotate inputs manually. |
+| Mixed `@perftest` + `do_bench` in one file | Don't. Dedicated bench drivers use `do_bench`; unit-test files use `@perftest`. Timing semantics differ (`warmup`/`rep` are iters vs ms). |
 | Torch ref is faster than AITER at small M | Expected; AITER kernels are tuned for throughput, torch calls cuBLAS which has a highly tuned small-M path. |
 | Numbers vary ±5% between runs | Normal GPU jitter. Run 3 times and report the median. |
 | `torch.profiler` prints are empty | Need `needTrace=True` on `@perftest`, OR wrap manually in `torch.profiler.profile(...)`. |
 | Bench driver crashes on first iter | Correctness bug; run the `test_.py` first to confirm. |
 | Suspicious 2–3x speedup | Check that both paths produce matching output with `checkAllclose`. |
 
-## 8. When to escalate to rocprofv3
+## 9. When to escalate to rocprofv3
 
 If AITER is slower than expected **and** `checkAllclose` passes, collect an
 ATT trace and hand off to `kernel-trace-analysis`:

--- a/.claude/skills/benchmark-aiter-op/SKILL.md
+++ b/.claude/skills/benchmark-aiter-op/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: benchmark-aiter-op
+description: >
+ Benchmark an AITER operator and compare it against a reference (torch) or an
+ alternative backend (CK vs Triton vs ASM vs FlyDSL). Covers `@perftest` usage
+ from `aiter/test_common.py`, the prebuilt benchmark drivers under
+ `op_tests/op_benchmarks/triton/bench_*.py` and `op_tests/op_benchmarks/hip/`,
+ L2 cache rotation, correct warmup, and producing a roofline-style report
+ (latency / TFLOPS / bandwidth / % of peak). Use when the user asks to
+ benchmark an op, compare backends, generate a perf table for a PR, or
+ reproduce a published number.
+ Usage: /benchmark-aiter-op  [--dtype ] [--shape M,N,K]
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# Benchmark an AITER Operator
+
+AITER has three layers of benchmarking:
+
+1. **`op_tests/test_*.py`** — correctness first, includes `@perftest` timing
+   next to each call. Good for quick A/B checks.
+2. **`op_tests/op_benchmarks/hip/` and `.../triton/`** — dedicated bench
+   drivers with richer sweeps. Use these for PR tables.
+3. **`rocprofv3`** — instruction-level traces. Covered by the
+   `capture-kernel-trace` and `kernel-trace-analysis` skills.
+
+## 1. Pick the right entry point
+
+| Goal | Command |
+|------|---------|
+| Quick latency of an op against reference | `python3 op_tests/test_.py` |
+| Full sweep for PR | `python3 op_tests/op_benchmarks/triton/bench_.py` |
+| Compare CK vs Triton vs ASM for the same shape | Call each backend from a small driver script (see §4) |
+| Instruction-level hotspot analysis | Capture rocprof ATT — see `capture-kernel-trace` |
+
+List available bench drivers:
+
+```bash
+ls op_tests/op_benchmarks/triton/ | Select-String '^bench_'
+ls op_tests/op_benchmarks/hip/
+```
+
+Existing drivers include `bench_gemm_a8w8.py`, `bench_gemm_a16w16.py`,
+`bench_rmsnorm.py`, `bench_extend_attention.py`, `bench_fp8_mqa_logits.py`,
+`bench_topk_topp_sampling.py`, and many more.
+
+## 2. Using `@perftest`
+
+`aiter/test_common.py` provides `@perftest(num_iters=101, num_warmup=2,
+testGraph=False, num_rotate_args=0, needTrace=False)`. Decorated functions
+return `(output, latency_us)` instead of just `output`.
+
+```python
+from aiter.test_common import perftest, checkAllclose
+
+@perftest()
+def run_aiter(x, w):
+    return gemm_a8w8(x, w)
+
+@perftest()
+def run_torch(x, w):
+    return torch.mm(x.to(torch.bfloat16), w.to(torch.bfloat16).T)
+
+y_aiter, us_aiter = run_aiter(x, w)
+y_ref, us_ref = run_torch(x, w)
+
+checkAllclose(y_aiter, y_ref, rtol=1e-2, atol=1e-2)
+print(f"aiter={us_aiter:7.1f} us   torch={us_ref:7.1f} us   speedup={us_ref/us_aiter:.2f}x")
+```
+
+Key `@perftest` options:
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `num_iters` | `101` | Total timed iterations |
+| `num_warmup` | `2` | Warmup passes (not timed) |
+| `testGraph` | `False` | Wrap in `torch.cuda.CUDAGraph` to remove host overhead |
+| `num_rotate_args` | `0` | Rotate through N deep-copies of inputs each iter to defeat L2 cache. Use `>=3` for memory-bound ops. |
+| `needTrace` | `False` | Attach `torch.profiler` context |
+
+For memory-bound ops (normalization, quant, elementwise) `num_rotate_args=0`
+(auto-computed based on free memory + L2 size) is usually correct. The
+default logic picks enough rotations to flush L2 between iterations.
+
+## 3. Structure of a bench driver
+
+The existing drivers under `op_tests/op_benchmarks/triton/` follow this
+pattern:
+
+```python
+# op_tests/op_benchmarks/triton/bench_my_op.py
+import argparse, json, torch
+from aiter.ops.triton.category.my_op import my_op
+from aiter.test_common import perftest, checkAllclose
+
+
+def gen_inputs(M, N, K, dtype):
+    x = torch.randn(M, K, dtype=dtype, device="cuda")
+    w = torch.randn(N, K, dtype=dtype, device="cuda")
+    return x, w
+
+
+@perftest(num_rotate_args=5)
+def bench_aiter(x, w):
+    return my_op(x, w)
+
+
+@perftest(num_rotate_args=5)
+def bench_ref(x, w):
+    return x @ w.T
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dtype", default="bf16")
+    ap.add_argument("--shape", default="1024,1024,1024")
+    ap.add_argument("--json", default=None)
+    args = ap.parse_args()
+
+    dtype = {"fp16": torch.float16, "bf16": torch.bfloat16}[args.dtype]
+    M, N, K = map(int, args.shape.split(","))
+    x, w = gen_inputs(M, N, K, dtype)
+
+    y_aiter, us_aiter = bench_aiter(x, w)
+    y_ref,   us_ref   = bench_ref(x, w)
+    checkAllclose(y_aiter, y_ref, rtol=1e-2, atol=1e-2)
+
+    flops   = 2 * M * N * K
+    bytes_  = (M*K + N*K + M*N) * x.element_size()
+    tflops  = flops / us_aiter / 1e6
+    bw      = bytes_ / us_aiter / 1e3   # GB/s
+
+    row = {"M": M, "N": N, "K": K, "dtype": args.dtype,
+           "us_aiter": us_aiter, "us_ref": us_ref,
+           "tflops": tflops, "bw_GBps": bw,
+           "speedup": us_ref / us_aiter}
+    print(json.dumps(row, indent=2))
+    if args.json:
+        with open(args.json, "a") as f: f.write(json.dumps(row) + "\n")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Run across a shape sweep:
+
+```bash
+for mnk in 1024,1024,1024 2048,2048,2048 4096,4096,4096 8192,8192,8192; do
+  python3 op_tests/op_benchmarks/triton/bench_my_op.py --shape $mnk --json /tmp/results.jsonl
+done
+```
+
+## 4. Comparing backends (CK vs Triton vs ASM vs torch)
+
+Many AITER ops have multiple backends selected by a Python dispatcher. To
+force a particular backend, call it directly:
+
+```python
+# CK:
+from aiter.ops.gemm_op_a8w8 import gemm_a8w8 as gemm_a8w8_ck
+# Triton:
+from aiter.ops.triton.gemm.basic.gemm_a8w8 import gemm_a8w8 as gemm_a8w8_triton
+# Torch reference:
+def gemm_a8w8_ref(xq, wq, x_scale, w_scale, dtype):
+    return (xq.to(torch.float32) * x_scale) @ (wq.to(torch.float32).T * w_scale).T.to(dtype)
+
+@perftest(num_rotate_args=5)
+def _ck(*a):    return gemm_a8w8_ck(*a)
+@perftest(num_rotate_args=5)
+def _tri(*a):   return gemm_a8w8_triton(*a)
+@perftest(num_rotate_args=5)
+def _torch(*a): return gemm_a8w8_ref(*a)
+
+y_ck,   us_ck   = _ck(*inputs)
+y_tri,  us_tri  = _tri(*inputs)
+y_ref,  us_ref  = _torch(*inputs)
+```
+
+Report: pick whichever wins at a given shape; the winner often changes between
+small-M and large-M regimes.
+
+## 5. Roofline numbers
+
+For a PR table, report at minimum:
+
+- **Latency** (us)
+- **Throughput** — TFLOPS (compute-bound ops) or GB/s (memory-bound ops)
+- **% of peak** — against the known hardware peak (see below)
+- **Speedup** vs baseline
+
+Hardware peak reference (per `CONTRIBUTE.md`):
+
+| GPU | Arch | FP16 TFLOPS | BF16 TFLOPS | FP8 TFLOPS | HBM BW |
+|-----|------|-------------|-------------|------------|--------|
+| MI300X | gfx942 | ~380 | ~380 | ~770 | 5.3 TB/s (some SKUs 3.2 TB/s) |
+| MI350X | gfx950 | ~1000 | ~1000 | ~2000 | 8.0 TB/s |
+
+Arithmetic intensity threshold to decide compute- vs memory-bound:
+
+```
+AI_threshold = peak_TFLOPS / peak_BW
+e.g. MI300X FP16: 380 / 5.3 = ~72 FLOP/byte
+```
+
+Anything below ~72 FLOP/byte is memory-bound → report GB/s utilization.
+Above → report TFLOPS utilization.
+
+## 6. PR-ready table format
+
+Lifted from `CONTRIBUTE.md`:
+
+```markdown
+## Performance Results (MI300X, gfx942)
+
+| Config                   | Baseline | Optimized | Speedup |
+|--------------------------|----------|-----------|---------|
+| BF16, M=1024 N=4096 K=7168 | 180 μs  | 150 μs    | 1.20x   |
+| BF16, M=2048 N=8192 K=7168 | 720 μs  | 600 μs    | 1.20x   |
+
+- Bandwidth utilization (Optimized): 78% of peak
+- Arithmetic intensity: 0.83 FLOP/byte (memory-bound)
+- Kernel: `_gemm_a16_w16_kernel_BLOCK_SIZE_M_64_BLOCK_SIZE_N_128_...` (from trace)
+```
+
+## 7. Typical gotchas
+
+| Issue | Fix |
+|-------|-----|
+| First call is 10–100x slower | JIT / autotune compile. Use warmup iters, and ignore the first call in manual timers. |
+| Two consecutive benches give very different numbers | L2 pollution — set `num_rotate_args=5` (or higher) on `@perftest`. |
+| Torch ref is faster than AITER at small M | Expected; AITER kernels are tuned for throughput, torch calls cuBLAS which has a highly tuned small-M path. |
+| Numbers vary ±5% between runs | Normal GPU jitter. Run 3 times and report the median. |
+| `torch.profiler` prints are empty | Need `needTrace=True` on `@perftest`, OR wrap manually in `torch.profiler.profile(...)`. |
+| Bench driver crashes on first iter | Correctness bug; run the `test_.py` first to confirm. |
+| Suspicious 2–3x speedup | Check that both paths produce matching output with `checkAllclose`. |
+
+## 8. When to escalate to rocprofv3
+
+If AITER is slower than expected **and** `checkAllclose` passes, collect an
+ATT trace and hand off to `kernel-trace-analysis`:
+
+```bash
+# see capture-kernel-trace skill
+rocprofv3 --stats --kernel-trace -f csv -- python3 op_tests/test_my_op.py -m 1024 -n 4096 -k 7168
+```
+
+Look at `*_kernel_stats.csv` to confirm the expected kernel actually ran
+(and only once per iteration). A wrapper that falls back to a slow path is
+easy to miss without this check.

--- a/.claude/skills/bisect-perf-regression/SKILL.md
+++ b/.claude/skills/bisect-perf-regression/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: bisect-perf-regression
+description: >
+ Binary-search the AITER commit that introduced a performance regression
+ using `git bisect run`. Covers building a deterministic benchmark
+ driver (isolated shape, warmed, L2-flushed via `num_rotate_args`),
+ wrapping it in a pass/fail script with a user-supplied threshold,
+ rebuilding AITER correctly between commits (JIT cache invalidation,
+ `AITER_REBUILD=1`), skipping broken commits, and reporting the first
+ bad commit with its diff.
+ Use this skill when the user says "bisect perf", "find the regression
+ commit", "git bisect for AITER", or reports "kernel X got slower after
+ pulling main".
+allowed-tools: Bash Read Grep Glob Write
+---
+
+# Bisect an AITER Performance Regression
+
+Goal: find the exact AITER commit that caused a named op to get slower on
+a specific shape / backend. Deliverable: a commit SHA + one-line diff
+summary + a reproducer.
+
+## Step 1: Lock down a reproducer
+
+Before bisecting, confirm:
+
+- **Which op** (`aiter.gemm_a8w8`, `aiter.fused_moe`, `aiter.flash_attn_*`, …).
+- **Which backend** — HIP, CK, Triton, ASM. Force it if the op has an
+  env-var selector (grep the op's wrapper to see).
+- **Exact shape / dtype / q_type**.
+- **Known-good commit** (baseline) and **known-bad commit** (usually `HEAD`).
+  If the user only has "main", use the commit before the last known good
+  release as `--good`.
+
+Write a standalone benchmark driver. Keep it < 40 lines and deterministic:
+
+```python
+# /tmp/aiter_bench_repro.py
+import os, sys, time, torch, aiter
+from aiter.test_common import perftest
+
+torch.manual_seed(0)
+
+M, N, K = 4096, 4096, 4096
+dtype = torch.bfloat16
+
+@perftest(num_iters=50, num_warmup=20, num_rotate_args=4)
+def run(a, b):
+    return aiter.gemm_a16w16(a, b)
+
+a = torch.randn(M, K, device="cuda", dtype=dtype)
+b = torch.randn(N, K, device="cuda", dtype=dtype).t().contiguous()
+
+_, t_us = run(a, b)
+tflops = 2 * M * N * K / (t_us * 1e-6) / 1e12
+print(f"TFLOPS={tflops:.2f} time_us={t_us:.2f}")
+sys.exit(0)
+```
+
+Tips:
+
+- `num_rotate_args=4` flushes L2 between iterations — critical for stable
+  numbers.
+- Warmup ≥ 10 iterations; the first launch includes JIT overhead.
+- Pin the GPU clock if possible (`rocm-smi --setperflevel high`).
+- Set `HIP_VISIBLE_DEVICES=0` so runs are on one GPU.
+
+Run on `HEAD` and `HEAD~N` (a known-good) manually once to confirm the
+regression is real and reproducible:
+
+```bash
+git checkout <known-bad>
+AITER_REBUILD=1 python /tmp/aiter_bench_repro.py
+git checkout <known-good>
+AITER_REBUILD=1 python /tmp/aiter_bench_repro.py
+```
+
+Target a **20%+ delta**. Anything smaller is probably noise; tighten the
+benchmark first.
+
+## Step 2: Decide a pass/fail threshold
+
+Pick a TFLOPS number clearly between good and bad:
+
+```
+good:  210 TFLOPS
+bad:   145 TFLOPS
+threshold: 185 TFLOPS  (anywhere in the gap; err toward good)
+```
+
+## Step 3: Write the bisect runner
+
+`git bisect run` expects a script that exits `0` for good, `1` for bad,
+`125` for "skip this commit" (broken / uncompilable).
+
+```bash
+cat > /tmp/aiter_bisect.sh <<'EOF'
+#!/usr/bin/env bash
+set -u
+cd "$(git rev-parse --show-toplevel)"
+
+# --- update submodules that AITER depends on (CK, etc.) ---
+git submodule update --init --recursive 2>/dev/null || true
+
+# --- clean JIT cache; AITER caches compiled .so per (arch, commit) ---
+rm -rf aiter/jit/build 2>/dev/null || true
+
+# --- rebuild ---
+export AITER_REBUILD=1
+export GPU_ARCHS=${GPU_ARCHS:-gfx942}
+export MAX_JOBS=${MAX_JOBS:-$(nproc)}
+
+# If the user installed with PREBUILD_KERNELS=1, reinstall in-place.
+# Otherwise JIT-compile on first import.
+if ! pip install -e . --no-build-isolation --quiet 2>/tmp/build.log; then
+  echo "build failed on $(git rev-parse --short HEAD), skipping"
+  cat /tmp/build.log | tail -20
+  exit 125
+fi
+
+# --- run benchmark ---
+out=$(python /tmp/aiter_bench_repro.py 2>&1) || {
+  echo "benchmark crashed on $(git rev-parse --short HEAD), skipping"
+  echo "$out" | tail -20
+  exit 125
+}
+
+tflops=$(echo "$out" | sed -n 's/.*TFLOPS=\([0-9.]*\).*/\1/p')
+echo "commit=$(git rev-parse --short HEAD) tflops=$tflops"
+
+THRESHOLD=185   # <-- adjust per Step 2
+awk -v t="$tflops" -v th="$THRESHOLD" 'BEGIN{ exit !(t>=th) }'
+EOF
+chmod +x /tmp/aiter_bisect.sh
+```
+
+Notes:
+
+- Exit `125` (not `1`) for build / crash, so `git bisect` skips those
+  commits instead of blaming them.
+- The `THRESHOLD` is the only number that needs tuning between
+  investigations.
+- `rm -rf aiter/jit/build` is the single most important step — without
+  it, `git bisect` keeps loading a stale `.so` and "finds" a regression
+  at a random commit.
+
+## Step 4: Run the bisect
+
+```bash
+git bisect start
+git bisect good <known-good-sha>
+git bisect bad  <known-bad-sha>    # usually HEAD
+git bisect run /tmp/aiter_bisect.sh | tee /tmp/bisect.log
+```
+
+After it finishes, `git` will print the first bad commit. To inspect:
+
+```bash
+FIRST_BAD=$(git rev-parse BISECT_HEAD)
+git show --stat $FIRST_BAD
+git bisect reset
+```
+
+Save the log:
+
+```bash
+cp /tmp/bisect.log ./bisect_<op>_<arch>.log
+```
+
+## Step 5: Confirm & produce the report
+
+Re-run the benchmark on the first-bad commit and its parent, to rule out
+noise:
+
+```bash
+git checkout $FIRST_BAD^ && AITER_REBUILD=1 python /tmp/aiter_bench_repro.py
+git checkout $FIRST_BAD  && AITER_REBUILD=1 python /tmp/aiter_bench_repro.py
+```
+
+If the delta holds, write the report:
+
+```
+### Perf regression: aiter.<op> on (M,N,K,dtype)=(...)
+
+- Arch: gfx942
+- Backend: CK   (forced via <env var> = <value>)
+- Good: <SHA>  <TFLOPS_good> TFLOPS
+- Bad:  <SHA>  <TFLOPS_bad>  TFLOPS   (-XX%)
+- First bad commit: <SHA>   "<commit subject>"
+
+#### Diff summary
+<files changed, lines +/->
+
+#### Reproducer
+/tmp/aiter_bench_repro.py  (attached below)
+
+#### Suggested follow-up
+- Review `<files touched by first-bad commit>`.
+- If CK tile: check whether `aiter/configs/tuned_gemm_*.csv` lost a row.
+- If Triton: compare `get_gemm_config()` output for this shape on both commits.
+- If JIT config: diff `aiter/jit/optCompilerConfig.json`.
+```
+
+## Common pitfalls
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `git bisect` blames a commit that "can't" regress the kernel (e.g. a README change) | Stale JIT cache. Ensure `rm -rf aiter/jit/build` runs every iteration, and use `AITER_REBUILD=1`. |
+| Many commits in the middle fail to build | Good — mark them `exit 125`. If > 50% fail, widen `good`/`bad` range to skip the broken era. |
+| TFLOPS is noisy between runs on the same commit | Raise `num_iters` / `num_warmup`, pin clocks (`rocm-smi --setperflevel high`), reserve the GPU with `HIP_VISIBLE_DEVICES`. |
+| Submodule commits don't match AITER commit | Add `git submodule update --init --recursive` at the top of the runner (already in the template). |
+| First-bad commit is a tuning CSV change | Not a real regression, just missing a tuned shape. Fix by re-running the tuner for that shape; see `aiter-ck-tune` / `aiter-moe-tuning`. |
+| First-bad commit is a `optCompilerConfig.json` edit | JIT module definition changed; diff the module entry and rebuild locally to confirm. |
+| Kernel name changed across the range | `--kernel-include-regex` / env-var backend selector differs. Make the repro explicit: force the backend via env var, don't rely on defaults. |
+| `PREBUILD_KERNELS=1` previously | Reinstall step can take 10+ min/commit. Switch to pure JIT for the bisect (`unset PREBUILD_KERNELS`; `pip install -e . --no-build-isolation` without prebuilds). |
+
+## References
+- `benchmark-aiter-op` skill — how to write the perftest driver.
+- `aiter-jit-debug` skill — if the build fails on many commits.
+- `aiter-ck-tune` / `aiter-moe-tuning` — if the regression turns out to be a missing tuned row.
+- `git help bisect`, esp. `git bisect run` semantics.

--- a/.claude/skills/build-aiter/SKILL.md
+++ b/.claude/skills/build-aiter/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: build-aiter
+description: >
+ Install and build AITER from source on a ROCm host or inside a Docker container.
+ Covers recursive submodule checkout (Composable Kernel), `python setup.py develop`
+ vs `pip install -e .`, `PREBUILD_KERNELS` levels (0/1/2/3), `GPU_ARCHS`
+ selection (gfx942/gfx950), optional FlyDSL and Iris/Triton-comms deps, and how
+ to verify the install. Use when the user wants to set up AITER, rebuild after a
+ ROCm/torch upgrade, or switch between develop and install modes.
+ Usage: /build-aiter [container@host]
+allowed-tools: Bash Read
+---
+
+# Build and Install AITER
+
+Build AITER from source. AITER is normally installed in **editable (develop) mode**
+because most kernels are JIT-compiled on first use.
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[container@host]` | No | Target in the form `container@hostname`. If omitted, build locally. |
+
+## Prerequisites
+
+- **ROCm**: 6.x or 7.x, with `hipcc` on PATH and a working GPU (`rocm-smi`).
+- **PyTorch**: ROCm-enabled build, matching the installed ROCm (e.g. `rocm/vllm-dev:nightly`).
+- **Python**: 3.9 – 3.12.
+- **C++ toolchain**: `ninja`, a C++17 compiler, `cmake >= 3.20`.
+- **Disk space**: ~10 GB for build artifacts under `aiter/jit/`.
+- **Submodules**: The repo embeds `3rdparty/composable_kernel`. A non-recursive
+  clone will fail the build.
+
+## Step 1: Clone with submodules
+
+```bash
+git clone --recursive https://github.com/ROCm/aiter.git
+cd aiter
+```
+
+If you forgot `--recursive`:
+
+```bash
+cd aiter
+git submodule sync && git submodule update --init --recursive
+```
+
+## Step 2: Pick an install mode
+
+AITER supports three install flavors:
+
+| Mode | Command | When to use |
+|------|---------|-------------|
+| **JIT (default)** | `python3 setup.py develop` | Fastest setup; kernels are compiled lazily on first use. |
+| **Prebuild tuned kernels** | `PREBUILD_KERNELS=1 GPU_ARCHS="gfx942;gfx950" python3 setup.py develop` | Build all tuned kernels up-front; slow install (~30–60 min) but zero first-call latency. |
+| **Pip editable** | `pip install -e .` | Same as `setup.py develop` but uses PEP 517. Preferred for CI. |
+
+`PREBUILD_KERNELS` levels (see `setup.py`):
+
+| Value | Effect |
+|-------|--------|
+| `0` (default) | Skip all `_tune` modules; JIT everything on demand. |
+| `1` | Prebuild tuned kernels; skip most `_tune` modules and most `mha` variants. |
+| `2` | Prebuild everything except `_bwd` and `_tune`. |
+| `3` | Prebuild only `module_fmha_v3*`. |
+
+Common env vars:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GPU_ARCHS` | auto | Semicolon-separated arch list, e.g. `"gfx942;gfx950"`. |
+| `ENABLE_CK` | `1` | Set `0` to build without Composable Kernel (no `mha`/CK-GEMM ops). |
+| `AITER_REBUILD` | `0` | Force re-compile of every JIT module. |
+| `AITER_LOG_MORE` | `0` | Verbose JIT logs (command lines, compile times). |
+| `MAX_JOBS` | auto (CPU\*0.8) | Parallel compile jobs. |
+
+## Step 3: Optional extras
+
+```bash
+# FlyDSL (required for A4W4 FusedMoE kernels; optional otherwise)
+pip install --pre flydsl
+
+# OR: install all optional deps listed in requirements.txt
+pip install -r requirements.txt
+
+# Iris / Triton-based GPU communication
+pip install -r requirements-triton-comms.txt
+```
+
+## Step 4: Verify the install
+
+```bash
+python3 -c "import aiter; print('aiter OK')"
+python3 -c "from aiter.ops.activation import silu_and_mul; print('activation OK')"
+
+# Smoke test that JIT works (will compile module_activation on first call)
+python3 op_tests/test_activation.py --help
+```
+
+For a full smoke run:
+
+```bash
+python3 op_tests/test_layernorm2d.py
+python3 op_tests/test_gemm_a8w8.py -m 128 -n 1536 -k 7168
+```
+
+## Step 5: Remote / Docker build
+
+When building inside a container on a remote host, wrap every command in
+`ssh ... 'docker exec ... bash -c "..."'`:
+
+```bash
+HOST=hjbog-srdc-39.amd.com
+CONTAINER=my_aiter_dev
+
+# Checkout + build
+ssh -o LogLevel=ERROR $HOST "docker exec $CONTAINER bash -c '
+    cd / && git clone --recursive https://github.com/ROCm/aiter.git &&
+    cd aiter && python3 setup.py develop
+'"
+
+# Rebuild after code change
+ssh -o LogLevel=ERROR $HOST "docker exec $CONTAINER bash -c '
+    cd /aiter && AITER_REBUILD=1 python3 -c \"import aiter; from aiter.ops.activation import silu_and_mul\"
+'"
+```
+
+## Rebuild after code changes
+
+```bash
+# Python-only edits: no rebuild needed (editable install).
+
+# C++ / HIP kernel edits: force-rebuild the affected JIT module(s).
+AITER_REBUILD=1 python3 op_tests/test_activation.py
+
+# Wipe all JIT artifacts and start fresh:
+rm -rf aiter/jit/build aiter/jit/*.so
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `ModuleNotFoundError: No module named 'aiter'` | Re-run `python3 setup.py develop`; confirm the venv is activated. |
+| `fatal error: composable_kernel/...` | Submodules not initialized — run `git submodule update --init --recursive`. |
+| `hipcc: not found` | ROCm not on PATH; `source /opt/rocm/bin/rocm_env.sh` or reinstall ROCm. |
+| Build OOM / `killed (signal 9)` | Lower `MAX_JOBS` (e.g. `MAX_JOBS=4`). See `getMaxJobs()` in `setup.py`. |
+| `gfx ` not compiled | Re-run with explicit `GPU_ARCHS="gfxXXX"` and `AITER_REBUILD=1`. |
+| `import flydsl` fails | FlyDSL is optional; `pip install --pre flydsl` or ignore if you don't need A4W4 MoE. |
+| Wheel build produces `amd-aiter` but import needs `aiter` | The package name in `setup.py` is `amd-aiter`; the import name is `aiter`. Both are expected. |
+| Windows build fails | Windows sets `ENABLE_CK = False` and `PREBUILD_KERNELS = False`. Only a small Python subset builds. Use WSL or a Linux container for full builds. |
+
+## Reference env for reproducibility
+
+| Component | Version |
+|-----------|---------|
+| Base image | `rocm/vllm-dev:nightly` (ROCm 7.0, PyTorch 2.9, rocprofv3). |
+| AITER branch | `main` (use a SHA in CI). |
+| CK submodule | Tracked at the SHA committed in `.gitmodules`. |
+| FlyDSL | `flydsl==0.1.1.dev409` (pinned in `pyproject.toml`). |
+| Formatter pins | `black==26.3.0`, `ruff==0.15.7`, `clang-format-18`. |

--- a/.claude/skills/build-aiter/SKILL.md
+++ b/.claude/skills/build-aiter/SKILL.md
@@ -1,162 +1,84 @@
 ---
 name: build-aiter
 description: >
- Install and build AITER from source on a ROCm host or inside a Docker container.
- Covers recursive submodule checkout (Composable Kernel), `python setup.py develop`
- vs `pip install -e .`, `PREBUILD_KERNELS` levels (0/1/2/3), `GPU_ARCHS`
- selection (gfx942/gfx950), optional FlyDSL and Iris/Triton-comms deps, and how
- to verify the install. Use when the user wants to set up AITER, rebuild after a
- ROCm/torch upgrade, or switch between develop and install modes.
- Usage: /build-aiter [container@host]
+ Install and build AITER from source on a ROCm host (Linux; Windows disables
+ CK and prebuild). This skill is a thin hook: `setup.py` and
+ `docs/installation.rst` are the authoritative sources. Use this skill to get
+ the right env-var cheatsheet, pick the correct `PREBUILD_KERNELS` mode, and
+ avoid the handful of recurring footguns. Triggers: "install aiter",
+ "prebuild kernels", "setup.py develop", "GPU_ARCHS", "pip install -e aiter".
 allowed-tools: Bash Read
 ---
 
 # Build and Install AITER
 
-Build AITER from source. AITER is normally installed in **editable (develop) mode**
-because most kernels are JIT-compiled on first use.
+Authoritative references (read these first if the user wants depth):
+- `setup.py` — source of truth for all build behavior.
+- `docs/installation.rst` — prose walkthrough.
+- `CONTRIBUTE.md` — CK submodule / optional deps.
 
-## Arguments
+This skill encodes only the parts agents keep getting wrong.
 
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `[container@host]` | No | Target in the form `container@hostname`. If omitted, build locally. |
+## Platform
+- Linux + ROCm only for a full build. On Windows `setup.py` sets
+  `ENABLE_CK = False` and `PREBUILD_KERNELS = False` (search `IS_WINDOWS` in
+  `setup.py`). Use WSL2 / Linux / container for real builds.
 
-## Prerequisites
+## Install modes
 
-- **ROCm**: 6.x or 7.x, with `hipcc` on PATH and a working GPU (`rocm-smi`).
-- **PyTorch**: ROCm-enabled build, matching the installed ROCm (e.g. `rocm/vllm-dev:nightly`).
-- **Python**: 3.9 – 3.12.
-- **C++ toolchain**: `ninja`, a C++17 compiler, `cmake >= 3.20`.
-- **Disk space**: ~10 GB for build artifacts under `aiter/jit/`.
-- **Submodules**: The repo embeds `3rdparty/composable_kernel`. A non-recursive
-  clone will fail the build.
+| Mode | Command | When |
+|------|---------|------|
+| JIT (default, fastest install) | `python3 setup.py develop` | Dev iteration. Kernels built lazily on first use. |
+| Prebuild + editable | `PREBUILD_KERNELS=<N> GPU_ARCHS="gfx942;gfx950" pip install -e . --no-build-isolation` | CI / reproducible perf runs. |
 
-## Step 1: Clone with submodules
+Editable is preferred; `setup.py develop` is equivalent and works too.
 
-```bash
-git clone --recursive https://github.com/ROCm/aiter.git
-cd aiter
-```
+## `PREBUILD_KERNELS` modes (read straight from `setup.py::get_exclude_ops`)
 
-If you forgot `--recursive`:
+| Value | What is excluded from prebuild |
+|-------|--------------------------------|
+| `0` (default) | only `*_tune`; everything else is JIT on first use. |
+| `1` | `*_tune`, plus every `mha*` except `module_fmha_v3_fwd` and `module_fmha_v3_varlen_fwd`. |
+| `2` | `*_tune` and `*_bwd`. Forward-only inference build (common). |
+| `3` | Everything except `module_fmha_v3*`. Attention-only. |
 
-```bash
-cd aiter
-git submodule sync && git submodule update --init --recursive
-```
+**There is no mode that strictly prebuilds "GEMM + attention only".** The
+closest is `=2` (forward everything) or a custom edit to `get_exclude_ops()`.
 
-## Step 2: Pick an install mode
+## Key env vars
 
-AITER supports three install flavors:
+| Var | Default | Effect |
+|-----|---------|--------|
+| `GPU_ARCHS` | auto-detect | Semicolon-separated arch list, e.g. `"gfx942;gfx950"`. Set explicitly in CI. |
+| `PREBUILD_KERNELS` | `0` | See table above. |
+| `ENABLE_CK` | `1` | Set `0` to build without Composable Kernel (drops CK GEMM / MHA). |
+| `MAX_JOBS` | # cores | Parallel compile jobs. Lower if RAM-constrained (CK instances are heavy). |
+| `AITER_REBUILD` | `0` | Runtime: force a JIT rebuild of a module on next import. |
 
-| Mode | Command | When to use |
-|------|---------|-------------|
-| **JIT (default)** | `python3 setup.py develop` | Fastest setup; kernels are compiled lazily on first use. |
-| **Prebuild tuned kernels** | `PREBUILD_KERNELS=1 GPU_ARCHS="gfx942;gfx950" python3 setup.py develop` | Build all tuned kernels up-front; slow install (~30–60 min) but zero first-call latency. |
-| **Pip editable** | `pip install -e .` | Same as `setup.py develop` but uses PEP 517. Preferred for CI. |
-
-`PREBUILD_KERNELS` levels (see `setup.py`):
-
-| Value | Effect |
-|-------|--------|
-| `0` (default) | Skip all `_tune` modules; JIT everything on demand. |
-| `1` | Prebuild tuned kernels; skip most `_tune` modules and most `mha` variants. |
-| `2` | Prebuild everything except `_bwd` and `_tune`. |
-| `3` | Prebuild only `module_fmha_v3*`. |
-
-Common env vars:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GPU_ARCHS` | auto | Semicolon-separated arch list, e.g. `"gfx942;gfx950"`. |
-| `ENABLE_CK` | `1` | Set `0` to build without Composable Kernel (no `mha`/CK-GEMM ops). |
-| `AITER_REBUILD` | `0` | Force re-compile of every JIT module. |
-| `AITER_LOG_MORE` | `0` | Verbose JIT logs (command lines, compile times). |
-| `MAX_JOBS` | auto (CPU\*0.8) | Parallel compile jobs. |
-
-## Step 3: Optional extras
+## Sanity-check after install
 
 ```bash
-# FlyDSL (required for A4W4 FusedMoE kernels; optional otherwise)
-pip install --pre flydsl
-
-# OR: install all optional deps listed in requirements.txt
-pip install -r requirements.txt
-
-# Iris / Triton-based GPU communication
-pip install -r requirements-triton-comms.txt
+python3 -c "import aiter; print(aiter.__version__)"
+python3 -c "from aiter.jit.utils.chip_info import get_gfx; print(get_gfx())"
 ```
 
-## Step 4: Verify the install
+If arch detection disagrees with the `GPU_ARCHS` used at install time,
+expect `hipErrorNoBinaryForGpu` at first kernel call.
 
-```bash
-python3 -c "import aiter; print('aiter OK')"
-python3 -c "from aiter.ops.activation import silu_and_mul; print('activation OK')"
+## Recurring footguns
 
-# Smoke test that JIT works (will compile module_activation on first call)
-python3 op_tests/test_activation.py --help
-```
+| Symptom | Cause / fix |
+|---------|-------------|
+| Package named `amd-aiter`, import is `aiter` | Expected; both names are correct. |
+| Windows build succeeds but no kernels available | `ENABLE_CK/PREBUILD_KERNELS` forced to False. Use WSL/Linux. |
+| `error: Microsoft Visual C++ 14.0 required` | Wrong platform; AITER needs hipcc not MSVC. |
+| CK submodule missing | Run `git submodule update --init --recursive`. |
+| Prebuild skipped with "torch not installed" | Install a ROCm PyTorch wheel first, then rerun install. |
+| First import triggers long compile | JIT mode behaving normally; set `PREBUILD_KERNELS=1` (or 2) for up-front cost. |
+| Stale `.so` after arch change | `export AITER_REBUILD=1`, re-import. |
 
-For a full smoke run:
-
-```bash
-python3 op_tests/test_layernorm2d.py
-python3 op_tests/test_gemm_a8w8.py -m 128 -n 1536 -k 7168
-```
-
-## Step 5: Remote / Docker build
-
-When building inside a container on a remote host, wrap every command in
-`ssh ... 'docker exec ... bash -c "..."'`:
-
-```bash
-HOST=hjbog-srdc-39.amd.com
-CONTAINER=my_aiter_dev
-
-# Checkout + build
-ssh -o LogLevel=ERROR $HOST "docker exec $CONTAINER bash -c '
-    cd / && git clone --recursive https://github.com/ROCm/aiter.git &&
-    cd aiter && python3 setup.py develop
-'"
-
-# Rebuild after code change
-ssh -o LogLevel=ERROR $HOST "docker exec $CONTAINER bash -c '
-    cd /aiter && AITER_REBUILD=1 python3 -c \"import aiter; from aiter.ops.activation import silu_and_mul\"
-'"
-```
-
-## Rebuild after code changes
-
-```bash
-# Python-only edits: no rebuild needed (editable install).
-
-# C++ / HIP kernel edits: force-rebuild the affected JIT module(s).
-AITER_REBUILD=1 python3 op_tests/test_activation.py
-
-# Wipe all JIT artifacts and start fresh:
-rm -rf aiter/jit/build aiter/jit/*.so
-```
-
-## Troubleshooting
-
-| Symptom | Fix |
-|---------|-----|
-| `ModuleNotFoundError: No module named 'aiter'` | Re-run `python3 setup.py develop`; confirm the venv is activated. |
-| `fatal error: composable_kernel/...` | Submodules not initialized — run `git submodule update --init --recursive`. |
-| `hipcc: not found` | ROCm not on PATH; `source /opt/rocm/bin/rocm_env.sh` or reinstall ROCm. |
-| Build OOM / `killed (signal 9)` | Lower `MAX_JOBS` (e.g. `MAX_JOBS=4`). See `getMaxJobs()` in `setup.py`. |
-| `gfx ` not compiled | Re-run with explicit `GPU_ARCHS="gfxXXX"` and `AITER_REBUILD=1`. |
-| `import flydsl` fails | FlyDSL is optional; `pip install --pre flydsl` or ignore if you don't need A4W4 MoE. |
-| Wheel build produces `amd-aiter` but import needs `aiter` | The package name in `setup.py` is `amd-aiter`; the import name is `aiter`. Both are expected. |
-| Windows build fails | Windows sets `ENABLE_CK = False` and `PREBUILD_KERNELS = False`. Only a small Python subset builds. Use WSL or a Linux container for full builds. |
-
-## Reference env for reproducibility
-
-| Component | Version |
-|-----------|---------|
-| Base image | `rocm/vllm-dev:nightly` (ROCm 7.0, PyTorch 2.9, rocprofv3). |
-| AITER branch | `main` (use a SHA in CI). |
-| CK submodule | Tracked at the SHA committed in `.gitmodules`. |
-| FlyDSL | `flydsl==0.1.1.dev409` (pinned in `pyproject.toml`). |
-| Formatter pins | `black==26.3.0`, `ruff==0.15.7`, `clang-format-18`. |
+## When to escalate
+- Build errors during CK instance compilation → `aiter-jit-debug` skill.
+- Runtime `hipErrorNoBinaryForGpu` → `aiter-jit-debug`.
+- Tuning data for a specific op after a fresh install → `aiter-ck-tune` /
+  `aiter-moe-tuning`.

--- a/.claude/skills/capture-kernel-trace/SKILL.md
+++ b/.claude/skills/capture-kernel-trace/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: capture-kernel-trace
+description: >
+ Capture a `rocprofv3` ATT (Advanced Thread Trace) of an AITER kernel —
+ HIP, CK, Triton, or FlyDSL — so it can be loaded in the Radeon GPU
+ Profiler (RGP) or post-processed offline. Covers the kernel-name filter
+ (`--att-kernel` / `--kernel-iteration-range`), environment setup for ROCm
+ 7.x ATT, how to name the kernel from an AITER op (`make_kernel_repr`,
+ `@compile_ops` mangling), and how to shrink the trace to a single
+ dispatch.
+ Use this skill when the user asks to "capture an ATT trace", "profile
+ kernel with rocprofv3", "record an RGP capture", or "grab a trace of the
+ GEMM / attention / MoE kernel".
+allowed-tools: Bash Read Grep Glob
+---
+
+# Capture an ATT Kernel Trace of an AITER Op
+
+Goal: produce a single, minimal `rocprofv3` ATT capture that focuses on
+exactly the dispatch(es) the user cares about, then hand the resulting
+`.rgp` / `.att` files to the `kernel-trace-analysis` skill.
+
+## Step 1: Verify the environment
+
+```bash
+rocprofv3 --version            # need ROCm >= 6.2 for ATT; 7.x preferred
+rocminfo | grep -E "Name:.*gfx"     # confirm the target arch
+```
+
+Targeting a specific GPU on a multi-GPU box:
+
+```bash
+export HIP_VISIBLE_DEVICES=0
+```
+
+ATT data is *large* (hundreds of MB per capture). Make sure the output
+directory has >= 5 GB free.
+
+## Step 2: Identify the kernel name
+
+AITER kernels show up under different names depending on backend:
+
+| Backend | Name pattern | Where to find it |
+|---------|--------------|------------------|
+| HIP C++ | C++-mangled, e.g. `_Z18rmsnorm_kernel_...` | `csrc/.../*.cu` function name |
+| CK-tile | Long templated: `ck_tile::kernel<...>` | generated instance file in `build/` |
+| Triton | `make_kernel_repr(...)` string or JIT-hashed | `aiter/ops/triton/.../*.py` |
+| ASM | Symbol from `.s` file | `hsaco/` binaries |
+
+Fastest way to get the exact name: run the op once under a plain
+`rocprofv3` kernel-stats capture first, then grep for a distinctive
+substring.
+
+```bash
+rocprofv3 --stats --kernel-trace -d /tmp/aiter_stats -- \
+    python -c "import torch, aiter; \
+               a = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16); \
+               b = torch.randn(4096, 4096, device='cuda', dtype=torch.bfloat16); \
+               aiter.gemm_a16w16(a, b)"
+ls /tmp/aiter_stats
+cat /tmp/aiter_stats/*.kernel_stats.csv | head
+```
+
+Pick the substring that uniquely matches your kernel (e.g. `gemm_a16w16`,
+`rmsnorm`, `fused_moe_2stages`, `flashatt_fwd`). For Triton, the
+repr string from `make_kernel_repr` (defined in
+`aiter/ops/triton/utils/*`) is what you'll see.
+
+## Step 3: Minimize the Python driver
+
+Keep the capture to a **single kernel launch** if possible. Warm-up
+shows up in the trace and inflates it. A minimal driver:
+
+```python
+# /tmp/aiter_trace_driver.py
+import os, torch, aiter
+torch.manual_seed(0)
+
+# warm-up OUTSIDE the recorded range — see Step 4's --kernel-iteration-range
+a = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+b = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+for _ in range(3):
+    aiter.gemm_a16w16(a, b)
+
+torch.cuda.synchronize()
+# This is the dispatch we want traced:
+out = aiter.gemm_a16w16(a, b)
+torch.cuda.synchronize()
+```
+
+For ops that live inside a larger graph, isolate with:
+
+```python
+with torch.profiler.record_function("aiter_target"):
+    out = aiter.target_op(...)
+```
+
+`rocprofv3 --hip-activity` can filter by that marker.
+
+## Step 4: Run the ATT capture
+
+```bash
+mkdir -p /tmp/aiter_att
+rocprofv3 \
+    --att \
+    --att-activity \
+    --att-perfcounter-ctrl 0x3 \
+    --att-target-cu 0 \
+    --kernel-include-regex "gemm_a16w16" \
+    --kernel-iteration-range "[1]" \
+    -d /tmp/aiter_att \
+    -- python /tmp/aiter_trace_driver.py
+```
+
+Flag cheat-sheet (verify with `rocprofv3 --help` on your ROCm version —
+the flag names changed between ROCm 6.2 / 6.3 / 7.0):
+
+| Flag | Purpose |
+|------|---------|
+| `--att` | Enable ATT. |
+| `--kernel-include-regex "<substr>"` | Only trace kernels whose name matches. |
+| `--kernel-iteration-range "[N]"` / `"[N:M]"` | Only dispatch N (or N..M) of matched kernels. Use `[1]` to skip warm-up. |
+| `--att-target-cu 0` | Which compute unit to record (ATT is per-CU). `0` is fine for most kernels. |
+| `--att-se-mask 0x1` | Shader engine bitmask (default covers all). |
+| `-d <dir>` | Output directory. |
+| `--output-format rgp` | Emit RGP-loadable `.rgp` in addition to raw `.att`. |
+
+Minimum useful capture for a single kernel (ROCm 7.x style):
+
+```bash
+rocprofv3 --att \
+    --kernel-include-regex "<substr>" \
+    --kernel-iteration-range "[1]" \
+    --output-format rgp \
+    -d /tmp/aiter_att \
+    -- python /tmp/aiter_trace_driver.py
+```
+
+If the regex matches nothing, the run will complete normally but the
+output directory will have no `.att` / `.rgp`. Fix the regex (use the
+kernel-stats CSV from Step 2 to copy an exact substring).
+
+## Step 5: Verify the capture
+
+```bash
+ls -lh /tmp/aiter_att
+# expect: *.att (raw), *.rgp (RGP capture), and a codeobj-tracing folder
+```
+
+Good signs:
+
+- `.rgp` file of a few tens of MB — that's a healthy single-kernel capture.
+- `att/<dispatch_id>/` directories with `.out` files per CU.
+- `codeobj/` with the HSACO and ISA dump.
+
+Bad signs:
+
+- Directory is empty → regex didn't match. Re-check kernel name.
+- `.rgp` is multiple GB → too many dispatches captured. Narrow
+  `--kernel-iteration-range` to a single index.
+- Missing `codeobj/` → ATT can't map ISA back to source. Make sure the
+  driver uses a debug or line-mapped build: set
+  `HIPCC_VERBOSE=1` and include `-g` via `AITER_EXTRA_HIP_FLAGS="-g"`
+  when rebuilding (for HIP/CK kernels); Triton emits line info by default.
+
+## Step 6: Hand off
+
+Report back to the user:
+
+- Kernel name captured (exact string)
+- Path to the `.rgp` and output directory
+- Number of dispatches captured (`ls /tmp/aiter_att/att/ | wc -l`)
+- GPU arch (`gfx942`, `gfx950`, …)
+
+Then either open the `.rgp` in RGP, or run the
+`kernel-trace-analysis` skill on `/tmp/aiter_att/` for stall / ISA-level
+analysis.
+
+## Common pitfalls
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Empty output dir | `--kernel-include-regex` didn't match. Grab the exact name from the kernel-stats CSV first. |
+| Capture is several GB | Too many iterations. Add `--kernel-iteration-range "[1]"` and reduce warm-up loops. |
+| `rocprofv3: unrecognized option '--att'` | ROCm too old. Upgrade to ≥ 6.2; ATT was experimental before. |
+| RGP shows no ISA mapping | Code object wasn't emitted with line info. Rebuild with `-g` (HIP/CK) or `TRITON_DEBUG=1` (Triton). |
+| `HSA_STATUS_ERROR_OUT_OF_RESOURCES` | Too many counters requested. Drop `--att-perfcounter-ctrl` or pick a smaller mask. |
+| Triton kernel not filterable by name | Use `TRITON_KERNEL_DUMP=1` to find the auto-generated repr, or wrap the call in `torch.profiler.record_function(...)` and filter on that marker. |
+| Captured wrong dispatch (a warm-up) | Use `--kernel-iteration-range "[<idx>]"` with `<idx>` > warm-up count; or remove warm-up from the driver. |
+
+## References
+- `rocprofv3 --help` (authoritative for your installed ROCm)
+- AMD ATT user guide: `https://rocm.docs.amd.com/projects/rocprofiler-sdk/`
+- `aiter/ops/triton/utils/_triton/kernel_repr.py` for Triton `make_kernel_repr`
+- Use the `kernel-trace-analysis` skill next to read the capture.

--- a/.claude/skills/debug-aiter-op/SKILL.md
+++ b/.claude/skills/debug-aiter-op/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: debug-aiter-op
+description: >
+ Systematically debug a failing `op_tests/test_*.py`. Covers
+ tolerance-vs-precision mismatches, NaN/Inf propagation in FP8/FP4 paths,
+ stride / layout bugs, dtype-dispatch holes, wrong backend selection (CK vs
+ Triton vs ASM), JIT/rebuild issues, and the AITER-specific debug toggles
+ (`AITER_LOG_MORE`, `AITER_LOG_TUNED_CONFIG`, `AITER_LOG_LEVEL=DEBUG`,
+ `AITER_REBUILD`). Use when an op_test crashes, produces wrong output, or
+ passes on one dtype/shape but fails on another.
+ Usage: /debug-aiter-op 
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# Debug a Failing AITER Op Test
+
+Before anything else:
+
+```bash
+rm -rf aiter/jit/build aiter/jit/module_.so /tmp/aiter_configs
+AITER_REBUILD=1 AITER_LOG_MORE=1 AITER_LOG_LEVEL=DEBUG \
+    python3 op_tests/test_.py 2>&1 | tee /tmp/aiter_debug.log
+```
+
+A stale JIT cache or stale merged tuning CSV is the #1 source of "my fix didn't
+apply".
+
+## 1. Classify the failure
+
+| Symptom | Likely cause | Go to |
+|---------|--------------|-------|
+| Crashes before any output | JIT / import failure | §2 |
+| `checkAllclose` mismatch at every element | Wrong backend wired up, transpose bug | §3 |
+| Small relative error (<5%) in FP8/FP4 | Expected quantization noise, or wrong scale | §4 |
+| NaN/Inf in output | Softmax / normalization issue, overflow | §5 |
+| Passes at M=1024, fails at M=3 | Missing tiny-M config, edge-case masking | §6 |
+| Passes on bf16, fails on fp16 | Dtype-dispatch table missing a branch | §7 |
+| Passes once, fails on second call | Stateful buffer not zeroed, cache poisoning | §8 |
+| Perf much worse than expected | Wrong tuned config selected | §9 |
+| GPU hang / timeout | Infinite loop, bad sync, OOB memory | §10 |
+
+## 2. Import / JIT failure
+
+Run with the debug env and look for the first error:
+
+```bash
+AITER_REBUILD=1 AITER_LOG_MORE=1 python3 -c "import aiter; from aiter.ops. import *"
+```
+
+Jump to the `aiter-jit-debug` skill if you see:
+- `ModuleNotFoundError: No module named 'module_xxx'`
+- `undefined symbol: ...`
+- `hipErrorNoBinaryForGpu`
+- `fatal error: /path/to/header not found`
+
+## 3. All-elements-wrong correctness failure
+
+Checklist:
+
+1. **Transpose**: many AITER GEMMs expect `w: (N, K)` internally transposed.
+   Mixing up `(N, K)` vs `(K, N)` produces a permutation of the correct result.
+   Read the wrapper's docstring; print `x.shape`, `w.shape`, and compare with
+   the reference's expectation.
+
+2. **Backend selection**: some ops have multiple backends picked by a dispatch
+   function. For example, `aiter.ops.attention` can route to CK tile, ASM, or
+   a fallback depending on `dtype`, `head_dim`, or `causal`. Print which path
+   is taken:
+
+   ```python
+   import os; os.environ["AITER_LOG_LEVEL"] = "DEBUG"
+   from aiter.ops.attention import ...   # triggers DEBUG logs
+   ```
+
+3. **Strides / contiguity**: AITER kernels usually require contiguous inputs.
+   Check `x.is_contiguous()`; `.contiguous()` if necessary before calling.
+
+4. **Data types**: the test's reference may run in FP32 while the kernel runs
+   in BF16; widen the tolerance (`rtol=1e-2, atol=1e-2`) or cast the reference
+   to the same dtype before comparing.
+
+5. **All-ones isolation test**: fill every input with `1.0` and run both sides.
+   If reference and kernel both produce the same constant but different from
+   expected, your reference has a bug; if only the kernel is off, it's an
+   addressing / layout bug:
+
+   ```python
+   x.fill_(1.0); w.fill_(1.0)
+   ```
+
+## 4. Small relative error (1–5 %) in FP8 / FP4
+
+Common and usually expected:
+
+- **FP8 PV in attention**: ~0.03 max error vs BF16 is inherent to the FP8 data
+  path. Widen `atol=5e-3`.
+- **Per-tensor vs per-row quant**: if the reference uses per-row quant and the
+  kernel uses per-tensor (or vice versa), expect 1–3% mismatch. Verify the
+  quant mode matches.
+- **Scale factor mismatch**: common bug — applying `v_scale` twice (once in
+  prob scaling, once in PV output). Print `scale_q`, `scale_k`, `scale_v`
+  before the call and compare.
+- **FP4 `mxfp4`**: group-size mismatches between reference and kernel cause
+  block-local differences. `group_size=32` is the common default; verify.
+
+## 5. NaN / Inf
+
+### Softmax `-inf - (-inf) = NaN`
+
+If **all** attention keys are masked (out of context), `qk_max = -inf` and
+`exp(s - qk_max) = exp(-inf - (-inf)) = exp(NaN) = NaN`. Check the ref side
+has the same guard.
+
+### Division by zero in normalization
+
+`rms_norm` divides by `sqrt(mean + eps)`. If `eps=0` or the input is all zeros
+the output is NaN. Default eps in AITER is `1e-6` — if you're calling with `0`
+you'll hit this.
+
+### Host-side sanity check before the assert
+
+```python
+torch.cuda.synchronize()
+print("nan%:", float(got.isnan().float().mean()))
+print("inf%:", float(got.isinf().float().mean()))
+print("range:", float(got.min()), float(got.max()))
+```
+
+## 6. Edge cases (tiny or non-power-of-2 shapes)
+
+Triton kernels: check the config JSON has an `M_LEQ_4` or `M_LEQ_8` entry,
+otherwise the `any` fallback is used with block sizes that may be wrong for
+tiny shapes. See `aiter-triton-kernel` skill §2.3.
+
+CK kernels: `errRatio` tolerance in the tuner may have excluded some instances
+that worked for your small shape. Rerun the tuner with `--errRatio 0.1` just
+for that shape and inspect the winner.
+
+Also check for:
+- **Implicit padding**: some kernels pad M/N/K to a multiple of the block size
+  and trust that your output tensor is big enough. If `out.shape` isn't
+  padded you'll get OOB stores.
+- **Head-dim alignment**: attention kernels often require `head_dim %
+  {64,128} == 0`. Fall back to Triton / torch for the remainder.
+
+## 7. Dtype dispatch holes
+
+```cpp
+AT_DISPATCH_FLOATING_TYPES_AND2(
+    at::ScalarType::Half, at::ScalarType::BFloat16,
+    input.scalar_type(), "my_op", [&] { ... });
+```
+
+Missing a branch (e.g. omitting BF16 in an `AT_DISPATCH_FLOATING_TYPES`)
+manifests as `RuntimeError: "my_op" not implemented for 'BFloat16'`.
+Fix: use `AT_DISPATCH_FLOATING_TYPES_AND2` (or `AND3` including FP8).
+
+For FP8: `at::ScalarType::Float8_e4m3fnuz` on ROCm ≤7.0, `Float8_e4m3fn` on
+ROCm 7.x. Check `torch.version.hip` and match.
+
+## 8. Stateful buffers, cache poisoning
+
+- **AITER tuning CSV**: if `AITER_CONFIG_GEMM_A8W8` points to a hand-edited
+  CSV with a bad row, every subsequent call picks the bad kernel. Restore the
+  default: `unset AITER_CONFIG_GEMM_A8W8` and `rm -rf /tmp/aiter_configs`.
+- **Ragged / Paged attention**: KV-cache tensors must be zeroed before reuse
+  across test cases.
+- **Triton autotune cache**: `~/.triton/cache/`. Wipe it when you change the
+  kernel body or Triton version.
+- **FlyDSL cache**: `~/.flydsl/cache/`.
+
+## 9. Perf much worse than expected
+
+```bash
+AITER_LOG_TUNED_CONFIG=1 AITER_LOG_MORE=1 python3 op_tests/test_my_op.py
+```
+
+Look for `config file not found` / `using default config` / `kernelId=-1`
+messages. Then:
+
+1. Check `/tmp/aiter_configs/*_tuned_.csv` — is your shape there?
+2. Rebuild: `AITER_REBUILD=1 rm aiter/jit/module_*.so && python3 ...`
+3. If the shape is missing, add it to the untuned CSV and re-run the tuner
+   (`aiter-ck-tune` skill).
+4. For Triton ops: verify the right `{arch}-NAME.json` was loaded — hard-code
+   a `config={...}` dict to bisect.
+
+## 10. GPU hang
+
+Signs: test hangs with no CPU activity; `rocm-smi` shows one CU at 100%.
+
+Causes and fixes:
+
+- **`scf.for` with `stop < start`**: unsigned comparisons on 32-bit indices
+  overflow. Print the bounds before the launch.
+- **Divergent barrier**: `gpu.barrier()` / `__syncthreads()` with a divergent
+  predicate deadlocks. Make sure ALL threads in the workgroup reach the
+  barrier.
+- **OOB memory access on buffer_load/store**: the kernel may silently write
+  to random memory until it hits a page fault; can look like a hang.
+  Re-run with `HIP_DEVICE_LIB_PATH=... HSA_NO_SCRATCH_RECLAIM=1` (as
+  documented in ROCm debug docs) to enable pagefault detection.
+- **Recovery**: `sudo rocm-smi --gpureset -d 0` or reboot. In Docker,
+  `docker restart ` is usually enough.
+
+## Diagnostic workflow summary
+
+```
+1. rm -rf aiter/jit/build aiter/jit/*.so /tmp/aiter_configs
+2. AITER_LOG_MORE=1 AITER_LOG_LEVEL=DEBUG AITER_REBUILD=1 AITER_LOG_TUNED_CONFIG=1 \
+       python3 op_tests/test_.py 2>&1 | tee /tmp/dbg.log
+3. Classify with §1 and jump to the matching section.
+4. All-ones isolation test → layout bugs.
+5. NaN / Inf count on the output → softmax / normalization bugs.
+6. Narrow to a single (dtype, M, N, K) tuple that reproduces.
+7. Bisect backend by forcing a fallback (e.g. call the torch reference
+   directly from the wrapper to confirm the test driver itself is fine).
+```
+
+## Useful env toggles
+
+| Env var | Effect |
+|---------|--------|
+| `AITER_LOG_MORE=1` | Verbose JIT + wrapper logging. |
+| `AITER_LOG_LEVEL=DEBUG` | Everything. `WARNING`/`ERROR` also valid. |
+| `AITER_LOG_TUNED_CONFIG=1` | Print which tuned config & kernelId was used. |
+| `AITER_REBUILD=1` | Re-JIT every `module_*` on next touch. |
+| `AITER_CONFIG_GEMM_A8W8=/path/custom.csv` | Override merged tuned CSV (see `aiter/jit/core.py`). |
+| `GPU_ARCHS=gfx942;gfx950` | Limit archs compiled. |
+| `TORCH_SHOW_CPP_STACKTRACES=1` | C++ backtraces for CHECK failures. |
+
+## Common pitfalls checklist
+
+- [ ] Cache cleared (`rm -rf aiter/jit/build aiter/jit/*.so /tmp/aiter_configs`).
+- [ ] Input is contiguous (`x.is_contiguous()`).
+- [ ] Input dtype is supported (check the AT_DISPATCH list).
+- [ ] Input shape aligned to the kernel's block / head-dim requirements.
+- [ ] For Triton: config JSON has `M_LEQ_*` entries covering small shapes.
+- [ ] For CK: tuned CSV covers this `(cu_num, M, N, K)`.
+- [ ] Softmax guards against `-inf - (-inf)` and division-by-zero.
+- [ ] All-ones isolation test passes (rules out layout bugs).
+- [ ] Reference implementation uses the same quantization mode / scales.
+- [ ] Tolerance is realistic for the dtype (BF16: 1e-2, FP8: 5e-3).

--- a/.claude/skills/format-code/SKILL.md
+++ b/.claude/skills/format-code/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: format-code
+description: >
+ Format and lint AITER code before committing. Matches the pre-commit pipeline
+ in `.githooks/pre-commit` and `CONTRIBUTE.md`: runs autoflake / black 26.3.0 /
+ ruff 0.15.7 on Python, clang-format-18 (Google style via `.clang-format`) on
+ C/C++/HIP, strips trailing whitespace, converts UTF-8 to ASCII//TRANSLIT,
+ ensures trailing newlines, and bumps the copyright year at the top of modified
+ files. Operates only on files changed in `git diff` / `git diff --cached`.
+ Use this skill before any AITER commit or when the user says "format",
+ "lint", "clean up code", or "pre-commit".
+allowed-tools: Bash Read Edit Grep Glob
+---
+
+# Format AITER Code Before Committing
+
+AITER uses a specific combination of formatters pinned in `CONTRIBUTE.md`:
+
+| Tool | Version | Applies to |
+|------|---------|------------|
+| `black` | 26.3.0 | `.py` |
+| `ruff` | 0.15.7 | `.py` lint |
+| `autoflake` | any | `.py` unused imports / vars |
+| `clang-format-18` | 18 | `.c .cc .cpp .cxx .cu .cuh .h .hpp .hxx` |
+
+The shipping pre-commit hook (`.githooks/pre-commit`) also:
+- Bumps the copyright year in the top 10 lines of every modified source file.
+- Strips trailing whitespace.
+- Ensures every file ends in a newline.
+- Converts UTF-8 non-ASCII characters to ASCII via `iconv -t ascii//TRANSLIT`.
+
+## Step 1: Install tools (once per environment)
+
+```bash
+pip install "black==26.3.0" "ruff==0.15.7" autoflake
+# clang-format-18 (Ubuntu/Debian):
+sudo apt-get install -y clang-format-18
+# Then install the repo's git hook:
+bash ./.githooks/install
+```
+
+Verify:
+
+```bash
+black --version       # should print 26.3.0
+ruff --version        # should print 0.15.7
+clang-format-18 --version
+```
+
+## Step 2: Collect changed files
+
+Only touch files the user actually changed (staged OR unstaged):
+
+```bash
+changed=$( (git diff --name-only --cached; git diff --name-only) | sort -u )
+echo "$changed"
+```
+
+If empty, tell the user there's nothing to format and stop.
+
+## Step 3: Run the pipeline per file
+
+### 3.1 Python files (`.py`)
+
+```bash
+for f in $(echo "$changed" | grep -E '\.py$' || true); do
+  [ -f "$f" ] || continue
+  autoflake --in-place --remove-all-unused-imports --remove-unused-variables "$f"
+  black "$f"
+  ruff check --fix "$f" || true   # auto-fixes what it can; manual review for the rest
+done
+```
+
+AITER's `CONTRIBUTE.md` says PEP 8 + 88-char line width (`black` default) +
+type hints on function signatures. `ruff` config (if present in
+`pyproject.toml`) is respected automatically.
+
+### 3.2 C/C++/HIP files
+
+The repo root carries a `.clang-format` (Google style with AITER tweaks).
+`clang-format-18` honors it by default — **don't pass `--style=Google`**,
+that would override the local file.
+
+```bash
+for f in $(echo "$changed" | grep -E '\.(c|cc|cpp|cxx|cu|cuh|h|hpp|hxx|cl|h\.in|hpp\.in|cpp\.in)$' || true); do
+  [ -f "$f" ] || continue
+  clang-format-18 -i "$f"
+done
+```
+
+### 3.3 Whitespace / encoding / newline (matches `.githooks/pre-commit`)
+
+```bash
+for f in $changed; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    *.py|*.c|*.cc|*.cpp|*.cxx|*.cu|*.cuh|*.h|*.hpp|*.hxx|*.cl)
+      sed -i -e 's/[[:space:]]*$//' "$f"
+      sed -i -e '$a\' "$f"
+      tmp=$(mktemp) && iconv -s -f utf-8 -t ascii//TRANSLIT "$f" > "$tmp" && \
+        chmod --reference="$f" "$tmp" && mv -f "$tmp" "$f"
+      ;;
+  esac
+done
+```
+
+On Windows / PowerShell without `sed`/`iconv`, let `black` / `clang-format`
+handle whitespace and skip the `iconv` step (it's for CJK → ASCII cleanup).
+
+### 3.4 Copyright year bump
+
+```bash
+year=$(date +%Y)
+for f in $changed; do
+  [ -f "$f" ] || continue
+  /usr/bin/perl -pi -e 'INIT { $year = "'"$year"'" }
+      s/^([*\/#[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?/qq($1Copyright (C) $2@{[$year != $2 ? "-$year" : ""]})/ie
+      if $. < 10' "$f"
+done
+```
+
+(This is a direct port of the perl snippet in `.githooks/pre-commit`.)
+
+## Step 4: Re-stage files
+
+`black`, `clang-format`, and the in-place edits above leave the files as
+"modified" again even if they were already staged. Re-add:
+
+```bash
+git add -u
+```
+
+Don't `git add .` blindly — it would pull in unrelated new files.
+
+## Step 5: Summary
+
+Report to the user:
+
+- # Python files formatted
+- # C/C++/HIP files formatted
+- Any `ruff` warnings that couldn't be auto-fixed (these need manual review)
+- Any `clang-format` diffs that look semantically suspicious (usually none)
+
+If the user ran `git commit` and the hook modified files, remind them to
+re-stage and amend:
+
+```bash
+git add -u
+git commit --amend --no-edit      # only if the original commit was the last one
+```
+
+## Full pipeline script (for copy-paste)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+changed=$( (git diff --name-only --cached; git diff --name-only) | sort -u )
+[ -z "$changed" ] && { echo "Nothing to format."; exit 0; }
+
+py=$(echo "$changed" | grep -E '\.py$' || true)
+cc=$(echo "$changed" | grep -E '\.(c|cc|cpp|cxx|cu|cuh|h|hpp|hxx|cl)$' || true)
+
+for f in $py; do
+  [ -f "$f" ] || continue
+  autoflake --in-place --remove-all-unused-imports --remove-unused-variables "$f"
+  black "$f"
+  ruff check --fix "$f" || true
+done
+
+for f in $cc; do
+  [ -f "$f" ] || continue
+  clang-format-18 -i "$f"
+done
+
+# Whitespace + newline + copyright
+year=$(date +%Y)
+for f in $changed; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    *.py|*.c|*.cc|*.cpp|*.cxx|*.cu|*.cuh|*.h|*.hpp|*.hxx|*.cl)
+      sed -i -e 's/[[:space:]]*$//' "$f"
+      sed -i -e '$a\' "$f"
+      /usr/bin/perl -pi -e 'INIT { $year = "'"$year"'" }
+        s/^([*\/#[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?/qq($1Copyright (C) $2@{[$year != $2 ? "-$year" : ""]})/ie
+        if $. < 10' "$f"
+      ;;
+  esac
+done
+
+echo "Python:  $(echo "$py" | grep -c '^' || true) files"
+echo "C/C++:   $(echo "$cc" | grep -c '^' || true) files"
+echo ""
+echo "Remember to re-stage formatted files: git add -u"
+```
+
+## Common pitfalls
+
+| Symptom | Fix |
+|---------|-----|
+| `black` says version mismatch in CI | Pin locally: `pip install "black==26.3.0"`. |
+| `clang-format` changes look wrong | You're using `clang-format` v14/v17 — install v18 (`apt-get install clang-format-18`). |
+| `ruff` removes an import you actually use | Add `# noqa: F401` to that line or add the symbol to `__all__`. |
+| Pre-commit hook blocks the commit | Run this skill first, then `git add -u && git commit`. |
+| Copyright year stays at old value | The perl regex only runs in the first 10 lines of the file. Make sure the `Copyright (C)` header is near the top. |
+| `iconv: TRANSLIT not supported` | Rare; on Alpine, install `glibc-compat`. Otherwise skip the `iconv` step. |

--- a/.claude/skills/kernel-trace-analysis/SKILL.md
+++ b/.claude/skills/kernel-trace-analysis/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: kernel-trace-analysis
+description: >
+ Analyze an ATT trace captured from an AITER kernel and turn it into an
+ actionable perf report: top stall reasons (VMEM, LDS, SALU, VALU,
+ barrier, EXP), occupancy, VGPR/SGPR usage, LDS usage, latency hiding
+ quality, and — when ISA-to-source mapping is available — the hot source
+ lines. Output is formatted for a PR comment / perf report and ends with
+ a short list of concrete optimization suggestions that map to the other
+ AITER skills (`aiter-triton-kernel`, `aiter-ck-tune`, LDS prefetch, etc.).
+ Use this skill after `capture-kernel-trace`, or when a user provides an
+ `.att` / `.rgp` file and asks "what's slow", "why is this kernel
+ stalling", "analyze the trace", or "find the bottleneck".
+allowed-tools: Bash Read Grep Glob
+---
+
+# Analyze an AITER Kernel ATT Trace
+
+Input: a `rocprofv3` ATT output directory (typically from the
+`capture-kernel-trace` skill) containing `.att` files, a `.rgp`, and a
+`codeobj/` folder.
+
+Output: a structured report with:
+
+1. Header (kernel name, arch, grid, block, dispatches analyzed).
+2. Occupancy + resource usage (VGPR, SGPR, LDS, waves/CU).
+3. Stall breakdown by reason, sorted.
+4. Top hot ISA lines mapped back to source.
+5. Concrete next actions.
+
+## Step 1: Inventory the trace
+
+```bash
+ATT_DIR=/tmp/aiter_att           # adjust
+ls "$ATT_DIR"
+ls "$ATT_DIR"/att 2>/dev/null | head
+ls "$ATT_DIR"/codeobj 2>/dev/null | head
+```
+
+Sanity checks:
+
+- There must be a `codeobj/` with HSACO + disassembly, otherwise ISA
+  can't be mapped to source and you'll only get coarse stats.
+- `att/<dispatch_id>/` should contain per-CU `.out` files.
+- `*.rgp` should be present for RGP-based inspection.
+
+If any is missing, go back to the `capture-kernel-trace` skill and
+re-capture — don't try to guess around incomplete data.
+
+## Step 2: Pull kernel metadata
+
+From the dispatched kernel's HSACO metadata:
+
+```bash
+# Find the HSACO and dump metadata
+HSACO=$(find "$ATT_DIR/codeobj" -name "*.hsaco" | head -1)
+llvm-readelf -n "$HSACO" | head -80
+# Look for:
+#   .amdgpu_metadata: .kernarg_segment_size, .vgpr_count, .sgpr_count,
+#                     .group_segment_fixed_size (LDS), .wavefront_size
+```
+
+Fill in:
+
+| Metric | Source | Typical healthy range |
+|--------|--------|-----------------------|
+| VGPR count | `.vgpr_count` | ≤ 128 for 8 waves/SIMD on gfx942 |
+| SGPR count | `.sgpr_count` | ≤ 102 |
+| LDS (bytes) | `.group_segment_fixed_size` | ≤ 65 536 (64 KB); ≤ 163 840 (160 KB) on gfx950 |
+| Wave size | `.wavefront_size` | 64 (standard) or 32 (if `--wavefrontsize32`) |
+| Grid / block | from the ATT dispatch record | problem-specific |
+
+Occupancy estimate (gfx942, wave64):
+```
+waves_per_simd = min( 8,
+                      floor(256 / ceil(vgpr/4) ),      # VGPR: 256 regs per SIMD / lane-blocks
+                      floor(800 / sgpr),               # SGPR: 800 per SIMD
+                      floor(LDS_per_CU / lds_per_wg) * wg_per_cu_from_blocksize )
+```
+
+If waves/SIMD < 4, flag "low occupancy → latency hiding starved".
+
+## Step 3: Summarize stall reasons
+
+`rocprofv3` emits per-instruction stall tags. Roll them up to a
+kernel-level breakdown. Run the bundled aggregator if available in the
+user's ROCm install:
+
+```bash
+rocprof-sdk-att-summary "$ATT_DIR"/att/*/   # name varies between ROCm versions
+```
+
+If no aggregator is installed, parse manually:
+
+```bash
+# quick-and-dirty: count stall tags
+cat "$ATT_DIR"/att/*/*.out | grep -oE "stall_(vmem|lds|salu|valu|barrier|exp|branch|export|lgkmcnt|vmcnt)" \
+  | sort | uniq -c | sort -rn
+```
+
+Map raw tags to human categories:
+
+| Tag(s) | Category | What it usually means |
+|--------|----------|-----------------------|
+| `stall_vmem`, `vmcnt` | Global memory latency | Loads/stores from HBM aren't overlapped with compute. |
+| `stall_lgkmcnt` | LDS / scalar mem | Waiting on LDS loads/stores or constant memory. |
+| `stall_lds` | LDS bank conflicts | Bank conflicts or serialized LDS reads. |
+| `stall_barrier` | `s_barrier` | Block-level barrier — often too-fine-grained sync or wave imbalance. |
+| `stall_valu` | VALU busy | Compute-bound (this is often what you want). |
+| `stall_salu` | SALU busy | Scalar path bottleneck (address calc, branch decisions). |
+| `stall_exp` / `stall_export` | Output / export | Writing results back; rare in pure compute kernels. |
+| `stall_branch` | Divergence | Branchy code path — consider predication. |
+
+Produce a bar-chart-in-text:
+
+```
+VMEM (HBM latency)     ████████████████████  52.3%
+BARRIER                ██████                15.1%
+LGKMCNT (LDS)          █████                 12.8%
+VALU (actual compute)  ███                    9.4%
+SALU                   ██                     5.1%
+other                  ██                     5.3%
+```
+
+## Step 4: Locate hot ISA lines and map to source
+
+```bash
+# disassemble and annotate with hit-counts
+llvm-objdump -d --mcpu=$ARCH "$HSACO" > /tmp/kernel.isa
+```
+
+RGP / the `rocprofiler-sdk-att-parser` will emit per-PC counts.
+Intersect:
+
+```bash
+# pseudo — adapt to whatever tool your ROCm gives you
+rocprof-sdk-att-parser --annotate "$ATT_DIR" --output /tmp/hot.csv
+sort -t, -k2 -nr /tmp/hot.csv | head -20
+```
+
+For each top-10 PC, resolve to source with `llvm-dwarfdump` on the
+HSACO (requires the kernel built with `-g`):
+
+```bash
+for pc in $(sort -t, -k2 -nr /tmp/hot.csv | head -10 | cut -d, -f1); do
+  echo "== PC $pc =="
+  llvm-dwarfdump --lookup=$pc "$HSACO" | head -5
+done
+```
+
+If `-g` wasn't set, you'll only get the ISA opcode and no file:line.
+Tell the user to rebuild the relevant module with debug info:
+
+- HIP/CK: add `-g` to `flags_extra_hip` of the module in
+  `aiter/jit/optCompilerConfig.json`, set `AITER_REBUILD=1`, rerun.
+- Triton: set `TRITON_DEBUG=1` and re-run; Triton emits source line info
+  by default.
+
+## Step 5: Write the report
+
+Template (copy, fill in):
+
+```
+### Kernel: <mangled or make_kernel_repr string>
+- Arch: gfx942
+- Grid: (X, Y, Z)   Block: (bx, by, bz)   Wavefront: 64
+- Resources: VGPR=128  SGPR=98  LDS=49152 B
+- Estimated occupancy: 4 waves/SIMD (8 max)
+
+### Stall breakdown (cycle-weighted)
+| Category | Share |
+|----------|-------|
+| VMEM (HBM)  | 52.3% |
+| BARRIER     | 15.1% |
+| LGKMCNT     | 12.8% |
+| VALU        |  9.4% |
+| SALU        |  5.1% |
+| other       |  5.3% |
+
+### Top hot lines
+| PC  | ISA                   | Source (file:line) | Hits |
+|-----|-----------------------|--------------------|------|
+| 0x540 | `global_load_dwordx4` | gemm_a16w16.py:132 | 18.1% |
+| 0x620 | `ds_read_b128`        | gemm_a16w16.py:156 |  9.7% |
+| ...
+
+### Interpretation
+- Kernel is memory-latency bound: VMEM + LGKMCNT ≈ 65%.
+- Occupancy (4 waves/SIMD) is the main reason latency isn't hidden.
+- BARRIER share of 15% suggests producer/consumer imbalance between
+  the load and compute stages.
+
+### Recommended next actions
+1. Reduce VGPR pressure to 96 → 6 waves/SIMD. Candidates:
+   - Split accumulator into two passes.
+   - Drop the unused `idx_hi` cache.
+2. Add LDS double-buffering (see `prefetch-data-load` skill, if present)
+   so `ds_read` and `global_load` pipeline overlap.
+3. Replace the per-iteration `s_barrier` with a warp-level barrier.
+4. Consider raising `BLOCK_K` from 32 to 64 (tune via `aiter-ck-tune`
+   / `aiter-triton-kernel` configs and re-measure).
+```
+
+## Step 6: Tie back to other skills
+
+Match each recommendation to the right AITER skill:
+
+| Finding | Next skill |
+|---------|-----------|
+| VMEM-bound, low occupancy | Reduce VGPR; if Triton, re-tune configs via `aiter-triton-kernel`. |
+| BARRIER-heavy | `aiter-triton-kernel` or `aiter-ck-tune` — revisit pipeline stages. |
+| LDS bank conflicts | Look for `ds_read_b*`/`ds_write_b*` patterns; pad LDS arrays (swizzle). |
+| Compute-bound but low TFLOPS | MFMA instruction mix is wrong; compare vs `rocblas`. |
+| Wrong kernel picked | `aiter-ck-tune` / `aiter-moe-tuning`: re-run the tuner. |
+| Unexpectedly slow on new shape | `bisect-perf-regression`. |
+
+## Common pitfalls
+
+| Symptom | Fix |
+|---------|-----|
+| "No stall data" | Kernel ran too briefly (< 1 wave-cycle). Increase tensor size or run more iterations and widen `--kernel-iteration-range`. |
+| Percentages don't add to 100 | ATT samples are stochastic; a 2–3% gap is fine. A larger gap → re-capture with longer runtime. |
+| Source lines point to headers / std libs | Inlining hid the real source. Rebuild with `-O2 -g -fno-inline-functions` for HIP/CK (performance will drop, but you'll get true lines). Only for debugging. |
+| "VALU 90%" but TFLOPS low | You're likely emitting scalar/packed ops instead of MFMA. Check the ISA for `v_mfma_*` instructions; if absent, fix kernel/tile types to enable MFMA. |
+| Same hot line dominates across arches | That's a real bottleneck — prioritize it. |
+| Barrier % > 20% | Almost always a pipeline-stage imbalance. Re-examine the producer/consumer split. |
+
+## References
+- `capture-kernel-trace` skill (upstream step)
+- `bisect-perf-regression` skill (if the regression is commit-related)
+- AMD RGP documentation (`.rgp` viewer)
+- `llvm-objdump`, `llvm-dwarfdump`, `rocprof-sdk-att-parser`

--- a/.claude/skills/validate.py
+++ b/.claude/skills/validate.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Validate .claude/skills/*/SKILL.md files.
+
+Layer 1 (format): every SKILL.md has a well-formed YAML front matter with at
+                  least `name` and `description`, and `name` matches its
+                  directory.
+
+Layer 2 (facts):  every AITER-repo path referenced in backticks (inline code)
+                  actually exists in the checkout.
+
+Usage:
+    python .claude/skills/validate.py            # run all checks
+    python .claude/skills/validate.py --strict   # also treat warnings as errors
+
+Exit code 0 on success, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from typing import Iterable
+
+try:
+    import yaml  # type: ignore
+except ImportError:
+    print(
+        "ERROR: PyYAML is required. Install with: pip install pyyaml",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+
+REQUIRED_META_KEYS = ("name", "description")
+MIN_DESCRIPTION_LEN = 60
+
+# Paths worth fact-checking live under these top-level AITER directories.
+# Extend as the repo grows.
+TRACKED_PREFIXES = (
+    "aiter/",
+    "csrc/",
+    "op_tests/",
+    "scripts/",
+    ".github/",
+    ".githooks/",
+    "hsa_runtime/",
+    "3rdparty/",
+)
+
+# Inline-code paths we want to verify. Matches `foo/bar.py`, `csrc/.../x.cpp`,
+# etc. Stops at whitespace / backtick / closing punctuation.
+PATH_RE = re.compile(r"`([A-Za-z0-9_./-]+)`")
+
+# Characters that usually mean "placeholder, not a real path".
+PLACEHOLDER_MARKERS = ("<", ">", "*", "?", "$", "{")
+
+# Template tokens that appear in example paths in skills (e.g. `aiter/ops/my_op.py`).
+# Any backtick path containing one of these is treated as illustrative and skipped.
+TEMPLATE_TOKENS = (
+    "my_op",
+    "my_gemm",
+    "my_add",
+    "MY-OP",
+    "module_xxx",
+    "/category/",
+    "_untuned_",
+    "gemm_op_my_",
+    "_triton_kernels/category",
+    "triton_tests/category",
+    "triton_tests//",
+    "kernels//",
+    "ops/.py",
+    "test_.py",
+)
+
+# Runtime-only paths that don't exist until the user builds / runs something.
+# We skip these rather than fail the check.
+RUNTIME_PATHS = ("aiter/jit/build",)
+
+
+def iter_skill_files() -> Iterable[pathlib.Path]:
+    yield from sorted(SKILLS_DIR.rglob("SKILL.md"))
+
+
+def check_front_matter(path: pathlib.Path) -> list[str]:
+    errs: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not m:
+        errs.append("missing YAML front matter (--- ... ---)")
+        return errs
+    try:
+        meta = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError as exc:
+        errs.append(f"YAML parse error: {exc}")
+        return errs
+    if not isinstance(meta, dict):
+        errs.append("front matter is not a mapping")
+        return errs
+    for key in REQUIRED_META_KEYS:
+        if not meta.get(key):
+            errs.append(f"missing required key `{key}`")
+    name = meta.get("name")
+    if name and name != path.parent.name:
+        errs.append(f"`name: {name}` != directory `{path.parent.name}`")
+    desc = meta.get("description") or ""
+    if len(desc.strip()) < MIN_DESCRIPTION_LEN:
+        errs.append(
+            f"`description` too short ({len(desc.strip())} < {MIN_DESCRIPTION_LEN}); "
+            "it is what triggers the skill, keep it detailed"
+        )
+    return errs
+
+
+def is_placeholder(p: str) -> bool:
+    if any(mark in p for mark in PLACEHOLDER_MARKERS):
+        return True
+    if any(tok in p for tok in TEMPLATE_TOKENS):
+        return True
+    return False
+
+
+def is_runtime_path(p: str) -> bool:
+    return any(p.startswith(r) for r in RUNTIME_PATHS)
+
+
+def check_paths(path: pathlib.Path) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings). Errors = nonexistent paths. Warnings = suspicious."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    # Only verify paths inside fenced inline-code; ignore code blocks (```) to
+    # avoid false positives on sample shell commands.
+    text_wo_blocks = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    for m in PATH_RE.finditer(text_wo_blocks):
+        raw = m.group(1).rstrip(".,):;")
+        if is_placeholder(raw):
+            continue
+        if not raw.startswith(TRACKED_PREFIXES):
+            continue
+        if is_runtime_path(raw):
+            continue
+        # Strip any line-range suffixes like aiter/foo.py:12
+        raw = raw.split(":", 1)[0]
+        target = REPO_ROOT / raw
+        if not target.exists():
+            errors.append(f"missing path: `{raw}`")
+    return errors, warnings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--strict", action="store_true", help="treat warnings as errors")
+    args = ap.parse_args()
+
+    skill_files = list(iter_skill_files())
+    if not skill_files:
+        print(f"No SKILL.md files under {SKILLS_DIR}", file=sys.stderr)
+        return 1
+
+    total_errors = 0
+    total_warnings = 0
+
+    for f in skill_files:
+        rel = f.relative_to(REPO_ROOT)
+        errs = check_front_matter(f)
+        path_errs, path_warns = check_paths(f)
+        errs.extend(path_errs)
+
+        if errs or path_warns:
+            print(f"\n=== {rel}")
+        for e in errs:
+            print(f"  [ERROR]   {e}")
+            total_errors += 1
+        for w in path_warns:
+            print(f"  [WARNING] {w}")
+            total_warnings += 1
+
+    print()
+    print(f"Checked {len(skill_files)} SKILL.md files")
+    print(f"  errors   : {total_errors}")
+    print(f"  warnings : {total_warnings}")
+
+    if total_errors > 0:
+        return 1
+    if args.strict and total_warnings > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a task-oriented Claude / Cursor skill set under `.claude/skills/`
tailored for AITER development — modeled after the skill layout in
[`ROCm/FlyDSL/.claude/skills`](https://github.com/ROCm/FlyDSL/tree/main/.claude/skills),
but rewritten end-to-end for AITER's conventions.

12 skills, each a single `SKILL.md` with YAML front matter + a runnable,
step-by-step body:

| Skill | Purpose |
|-------|---------|
| `build-aiter` | Install / build AITER (`PREBUILD_KERNELS`, `GPU_ARCHS`). |
| `aiter-add-operator` | End-to-end recipe for adding a new op (kernel → pybind → `optCompilerConfig.json` → `@compile_ops` wrapper → `op_tests/`). |
| `aiter-jit-debug` | Diagnose JIT compile / module-load failures (`AITER_REBUILD`, `aiter/jit/build`). |
| `aiter-triton-kernel` | Author Triton kernels following `aiter/ops/triton/` conventions (`get_gemm_config`, `make_kernel_repr`, `gfx9xx` arch strings). |
| `aiter-ck-tune` | Tune CK-tile GEMM kernels (`gemm_a*_tune.py`, untuned → tuned CSV flow). |
| `aiter-moe-tuning` | Tune fused MoE (`tuned_fmoe.csv`, `untuned_fmoe.csv`, `csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py`). |
| `debug-aiter-op` | Debug a failing `op_tests/test_*.py` (backend selection, stride/dtype mismatches, NaN/Inf). |
| `benchmark-aiter-op` | Benchmark an op with `@perftest`, report roofline numbers. |
| `format-code` | Reproduce the `.githooks/pre-commit` pipeline (`black==26.3.0`, `ruff==0.15.7`, `clang-format-18`, copyright-year bump). |
| `capture-kernel-trace` | Capture a `rocprofv3` ATT trace of a specific AITER dispatch. |
| `kernel-trace-analysis` | Analyze an ATT trace → stall breakdown, occupancy, hot-PC → source. |
| `bisect-perf-regression` | `git bisect run` with proper JIT-cache hygiene + threshold-based runner. |

## Validation

A lightweight validator ships with the skills:

```bash
python .claude/skills/validate.py
# Checked 13 SKILL.md files
#   errors   : 0
#   warnings : 0
```

It enforces two layers:

1. **Format**: every `SKILL.md` has valid YAML front matter, `name:`
   matches the directory, `description:` is non-trivially long (Claude
   uses it to decide when to trigger the skill).
2. **Facts**: every AITER-repo path cited in inline-code backticks
   (`aiter/...`, `csrc/...`, `op_tests/...`, `.githooks/...`) actually
   exists in the checkout. Template paths (`aiter/ops/my_op.py`) and
   runtime-only paths (`aiter/jit/build/...`) are skipped.

The full three-layer test plan (format / fact-probe / behavioral A/B)
is documented in [`.claude/skills/TESTS.md`](./.claude/skills/TESTS.md).

## Test plan

- [x] `python .claude/skills/validate.py` exits 0 with zero errors across
      all 13 `SKILL.md` files.
- [x] All paths referenced in the skills have been verified against the
      current repo layout (e.g. `csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py`,
      `aiter/ops/triton/utils/_triton/kernel_repr.py`, `aiter/fused_moe.py`,
      `aiter/test_common.py::perftest`, `op_tests/test_moe.py::test_fmoe`).
- [x] Version pins (`black==26.3.0`, `ruff==0.15.7`, `clang-format-18`)
      cross-checked against `CONTRIBUTE.md` and `.githooks/pre-commit`.
- [x] `validate.py` itself formatted with `black` and passes `ruff check`.

## Notes

- Skills are under `.claude/skills/`; they also work as Cursor Agent
  skills if symlinked / copied to `.cursor/skills/` or
  `~/.cursor/skills-cursor/`. A note to that effect is in the skills
  README.
- No AITER source / build code is touched by this PR — it is
  documentation + one small Python validator.
- The pre-existing `opus-kernel-best-practice` skill is untouched; the
  validator confirms it continues to pass format/fact checks.
