### PR TITLE
[DO NOT MERGE] CI: install Triton wheel before Aiter standard tests

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -230,6 +230,11 @@ jobs:
       github.event.action != 'labeled'
     name: Standard Tests (1 GPU)
     needs: [build_aiter_image, split_aiter_tests] 
+    env:
+      TRITON_COMMIT: "d1660454"
+      TRITON_VERSION: "3.7.0"
+      ROCM_VERSION: "rocm7.2.0"
+      PYTHON_VERSION: "cp312"
     strategy:
       fail-fast: false
       matrix:
@@ -284,6 +289,54 @@ jobs:
       
       - name: Docker login
         run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
+
+      - name: Try downloading pre-built Triton wheel
+        id: download_triton_wheel
+        run: |
+          set -ex
+          mkdir -p triton-wheels
+          WHEEL_NAME="triton-${{ env.TRITON_VERSION }}+${{ env.ROCM_VERSION }}.git${{ env.TRITON_COMMIT }}-${{ env.PYTHON_VERSION }}-${{ env.PYTHON_VERSION }}-linux_x86_64.whl"
+          WHEEL_URL_NAME="triton-${{ env.TRITON_VERSION }}%2B${{ env.ROCM_VERSION }}.git${{ env.TRITON_COMMIT }}-${{ env.PYTHON_VERSION }}-${{ env.PYTHON_VERSION }}-linux_x86_64.whl"
+          WHEEL_URL="https://rocm.frameworks-nightlies.amd.com/whl/gfx942-gfx950/${WHEEL_URL_NAME}"
+          echo "Attempting to download: ${WHEEL_URL}"
+          if curl -fSL --retry 3 --retry-delay 5 -o "triton-wheels/${WHEEL_NAME}" "${WHEEL_URL}"; then
+            echo "Successfully downloaded pre-built Triton wheel"
+            echo "wheel_found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pre-built Triton wheel not available, will build from source"
+            echo "wheel_found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Triton wheel from source
+        if: steps.download_triton_wheel.outputs.wheel_found != 'true'
+        run: |
+          set -ex
+          mkdir -p triton-wheels
+
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+
+          docker run --rm \
+            --device=/dev/kfd $DEVICE_FLAG \
+            --shm-size=16G \
+            --group-add $(getent group render | cut -d: -f3) \
+            --group-add $(getent group video | cut -d: -f3) \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            ${{ env.DOCKER_IMAGE }} \
+            bash -c '
+              set -ex
+              pip config set global.default-timeout 60
+              pip config set global.retries 10
+              git clone https://github.com/triton-lang/triton
+              cd triton
+              git checkout "${{ env.TRITON_COMMIT }}"
+              pip install -r python/requirements.txt
+              MAX_JOBS=64 pip wheel --no-deps -w /workspace/triton-wheels .
+            '
       
       - name: Download test shard lists
         uses: actions/download-artifact@v4
@@ -364,6 +417,21 @@ jobs:
           echo "Image CK commit: ${IMAGE_CK_COMMIT}"
           echo "Workspace CK commit: ${WORKSPACE_CK_COMMIT}"
           test "${IMAGE_CK_COMMIT}" = "${WORKSPACE_CK_COMMIT}"
+
+      - name: Install Triton wheel
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(triton-wheels/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one Triton wheel, found ${#wheels[@]}"
+            exit 1
+          fi
+          echo "Installing Triton wheel: ${wheels[0]}"
+          docker exec \
+          -w /workspace \
+          aiter_test \
+          bash -c "pip uninstall -y triton || true && pip install \"/workspace/${wheels[0]}\" && pip show triton"
 
       - name: Show Aiter version
         run: |


### PR DESCRIPTION
## Summary
- add a Triton wheel bootstrap flow to the Aiter standard test job
- try downloading the pre-built nightly wheel before falling back to a source build
- install the prepared wheel in the test container before running the standard shards

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/aiter-test.yaml'))"`
- [x] `git diff --check -- .github/workflows/aiter-test.yaml`
- [ ] GitHub Actions workflow run