### PR TITLE
Add mutates_args=[] to gemm_a4w4 torch_compile_guard to fix torch.compile crash (fix for #2780)

### DIFF
--- a/aiter/ops/gemm_op_a4w4.py
+++ b/aiter/ops/gemm_op_a4w4.py
@@ -94,7 +94,7 @@ def gemm_a4w4_fake(
     return out
 
 
-@torch_compile_guard(gen_fake=gemm_a4w4_fake)
+@torch_compile_guard(mutates_args=[], gen_fake=gemm_a4w4_fake)
 def gemm_a4w4(
     A: Tensor,  # A:[M, K/2] f4x2
     B: Tensor,  # B:[N, K/2] f4x2


### PR DESCRIPTION
## Motivation

`gemm_a4w4` under torch.compile crashes with `AssertionError: auto_functionalized_v2 was not removed.` This blocks any downstream user from compiling models that use the A4W4 GEMM path. (https://github.com/ROCm/aiter/issues/2780)

## Technical Details

`@torch_compile_guard` defaults `mutates_args="unknown"`, which causes `torch.library.infer_schema` to declare them mutated in-place. The inductor wraps such ops in `auto_functionalized_v2` to handle, then fails to decompose the wrapper node during post-grad passes. (`gemm_a4w4` does not mutate any of its inputs) 

The fix adds `mutates_args=[]` so no `auto_functionalized_v2` wrapper is generated.

## Test Plan

Minimal reproducer/fix-verification script provided in https://github.com/ROCm/aiter/issues/2780.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
