### PR TITLE
[FlyDSL MOE] fix _fq suffix compatibility in kernel name parsing

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -955,7 +955,8 @@ def get_2stage_cfgs(
     is_flydsl1 = bool(kernelName1) and kernelName1.startswith("flydsl_")
     is_flydsl2 = bool(kernelName2) and kernelName2.startswith("flydsl_")
     if (is_flydsl1 or is_flydsl2) and is_flydsl_available():
-        _s1_fq = is_flydsl1 and "_fp4" in kernelName1.split("_t")[-1]
+        _s1_suffix = kernelName1.split("_t")[-1] if is_flydsl1 else ""
+        _s1_fq = is_flydsl1 and ("_fp4" in _s1_suffix or "_fq" in _s1_suffix)
         if is_flydsl1:
             stage1_func = functools.partial(
                 _flydsl_stage1_wrapper,

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -13,7 +13,7 @@ import torch
 
 _KERNEL_PARAMS: Dict[str, Dict] = {}
 
-_SUFFIX_RE = re.compile(r"(?P<fp4>_fp4)?(?P<fp8>_fp8)?(?:_sbm(?P<sbm>\d+))?$")
+_SUFFIX_RE = re.compile(r"(?P<fp4>_fp4|_fq)?(?P<fp8>_fp8)?(?:_sbm(?P<sbm>\d+))?$")
 
 
 def flydsl_kernel_name(

--- a/op_tests/test_flydsl_moe_naming.py
+++ b/op_tests/test_flydsl_moe_naming.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for FlyDSL MOE kernel naming and suffix parsing.
+
+These are pure-Python tests (no GPU / torch required) that verify the kernel
+name construction, suffix regex, and the FQ-detection logic used in
+get_2stage_cfgs.
+
+The regex and helpers are copied here to avoid importing aiter (which
+transitively requires torch).  If the source definitions change, these
+tests should be updated to match.
+"""
+
+import re
+import pytest
+
+# ── Mirror of _SUFFIX_RE from aiter/ops/flydsl/moe_kernels.py ──
+_SUFFIX_RE = re.compile(r"(?P<fp4>_fp4|_fq)?(?P<fp8>_fp8)?(?:_sbm(?P<sbm>\d+))?$")
+
+
+def flydsl_kernel_name(
+    stage: int,
+    a_dtype: str,
+    b_dtype: str,
+    out_dtype: str,
+    tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    mode: str = "",
+    sort_block_m: int = 0,
+) -> str:
+    """Mirror of aiter.ops.flydsl.moe_kernels.flydsl_kernel_name."""
+    name = f"flydsl_moe{stage}_a{a_dtype}_w{b_dtype}_{out_dtype}_t{tile_m}x{tile_n}x{tile_k}"
+    if mode:
+        name += f"_{mode}"
+    if sort_block_m > 0 and sort_block_m != tile_m:
+        name += f"_sbm{sort_block_m}"
+    return name
+
+
+def _detect_fq(kernel_name: str) -> bool:
+    """Mirror of the _s1_fq logic in aiter.fused_moe.get_2stage_cfgs."""
+    is_flydsl = bool(kernel_name) and kernel_name.startswith("flydsl_")
+    suffix = kernel_name.split("_t")[-1] if is_flydsl else ""
+    return is_flydsl and ("_fp4" in suffix or "_fq" in suffix)
+
+
+# ── Tests ────────────────────────────────────────────────────────
+
+
+class TestSuffixRegex:
+    """Verify _SUFFIX_RE recognises _fp4, _fq, _fp8, and _sbm suffixes."""
+
+    @pytest.mark.parametrize(
+        "suffix, expected_fp4",
+        [
+            ("_fp4", "_fp4"),
+            ("_fq", "_fq"),
+        ],
+    )
+    def test_fp4_group_variants(self, suffix, expected_fp4):
+        name = f"flydsl_moe1_abf16_wbf16_bf16_t64x128x64{suffix}"
+        m = _SUFFIX_RE.search(name)
+        assert m is not None
+        assert m.group("fp4") == expected_fp4
+
+    def test_fp8_suffix(self):
+        m = _SUFFIX_RE.search("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp8")
+        assert m is not None
+        assert m.group("fp8") == "_fp8"
+        assert m.group("fp4") is None
+
+    def test_fq_fp8_combined(self):
+        m = _SUFFIX_RE.search("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fq_fp8")
+        assert m is not None
+        assert m.group("fp4") == "_fq"
+        assert m.group("fp8") == "_fp8"
+
+    def test_fp4_with_sbm(self):
+        m = _SUFFIX_RE.search("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp4_sbm64")
+        assert m is not None
+        assert m.group("fp4") == "_fp4"
+        assert m.group("sbm") == "64"
+
+    def test_fq_with_sbm(self):
+        m = _SUFFIX_RE.search("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fq_sbm128")
+        assert m is not None
+        assert m.group("fp4") == "_fq"
+        assert m.group("sbm") == "128"
+
+    def test_no_suffix(self):
+        m = _SUFFIX_RE.search("flydsl_moe1_abf16_wbf16_bf16_t64x128x64")
+        assert m is not None
+        assert m.group("fp4") is None
+        assert m.group("fp8") is None
+        assert m.group("sbm") is None
+
+
+class TestKernelNameConstruction:
+    """Verify flydsl_kernel_name builds names correctly."""
+
+    def test_basic_name(self):
+        name = flydsl_kernel_name(1, "bf16", "bf16", "bf16", 64, 128, 64)
+        assert name == "flydsl_moe1_abf16_wbf16_bf16_t64x128x64"
+
+    def test_name_with_fp4_mode(self):
+        name = flydsl_kernel_name(1, "bf16", "bf16", "bf16", 64, 128, 64, mode="fp4")
+        assert name == "flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp4"
+
+    def test_name_with_fq_mode(self):
+        name = flydsl_kernel_name(1, "bf16", "bf16", "bf16", 64, 128, 64, mode="fq")
+        assert name == "flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fq"
+
+    def test_name_with_sbm(self):
+        name = flydsl_kernel_name(
+            1, "bf16", "bf16", "bf16", 64, 128, 64, sort_block_m=128
+        )
+        assert name == "flydsl_moe1_abf16_wbf16_bf16_t64x128x64_sbm128"
+
+    def test_sbm_equal_to_tile_m_is_omitted(self):
+        name = flydsl_kernel_name(
+            1, "bf16", "bf16", "bf16", 64, 128, 64, sort_block_m=64
+        )
+        assert name == "flydsl_moe1_abf16_wbf16_bf16_t64x128x64"
+
+
+class TestStage1FqDetection:
+    """Verify the _s1_fq detection logic from get_2stage_cfgs."""
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp4", True),
+            ("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fq", True),
+            ("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fq_sbm64", True),
+            ("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp4_fp8", True),
+            ("flydsl_moe1_abf16_wbf16_bf16_t64x128x64", False),
+            ("flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp8", False),
+            ("ck_moe_stage1_kernel", False),
+            ("", False),
+        ],
+    )
+    def test_fq_detection(self, name, expected):
+        assert _detect_fq(name) == expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add _fq as an alternative to _fp4 in the suffix regex and stage1 FQ detection logic so that tuning configs using the _fq naming convention are correctly recognized kernels.

## Motivation

with removed .csv file MOE kernel tuning failed with the following errors:
```
ERROR 04-17 16:06:05 [core.py:1108] RuntimeError: Worker failed with error 'Invalid FlyDSL kernel name: flydsl_moe1_afp4_wfp4_bf16_t32x64x256_w4_fq',  
```
after only suffix fix:
```
RuntimeError: Worker failed with error ''tuple' object has no attribute 'view'',
```

## Technical Details

Two files changed to recognize _fq as an alternative suffix to _fp4 for FlyDSL MOE kernels:

aiter/ops/flydsl/moe_kernels.py: Updated _SUFFIX_RE regex to accept _fq as an alternative to _fp4 in the named group ((?P<fp4>_fp4|_fq)), so kernel names like flydsl_..._fq_sbm64 are parsed correctly.

aiter/fused_moe.py: In get_2stage_cfgs(), the stage-1 FQ detection now checks for both _fp4 and _fq in the kernel name suffix, and safely handles the case where kernelName1 is not a FlyDSL kernel.


## Test Plan

* Unit tests (no GPU required): python3 -m pytest op_tests/test_flydsl_moe_naming.py -v
* Backward compatibility: Existing _fp4 suffix configs are unaffected — regex and detection logic accept both _fp4 and _fq.
* Integration (requires GPU): Run 2-stage MOE with a tuning config that uses _fq suffixed kernel names (e.g., kimik2fp4_tuned_fmoe.csv) and verify stage-1 is correctly dispatched as fake-quantized.

## Test Result

```
 python3 -m pytest op_tests/test_flydsl_moe_naming.py -v
/usr/lib/python3/dist-packages/xonsh/pytest_plugin.py:42: PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (file_path: pathlib.Path)
see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
  def pytest_collect_file(parent, path):
=========================================== test session starts ============================================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/okorzh/aiter-public/aiter
configfile: pyproject.toml
plugins: anyio-4.12.0, xonsh-0.11.0
collected 20 items                                                                                         

op_tests/test_flydsl_moe_naming.py::TestSuffixRegex::test_fp4_group_variants[_fp4-_fp4] PASSED       [  5%]
op_tests/test_flydsl_moe_naming.py::TestSuffixRegex::test_fp4_group_variants[_fq-_fq] PASSED         [ 10%]
op_tests/test_flydsl_moe_naming.py::TestSuffixRegex::test_fp8_suffix PASSED                          [ 15%]
op_tests/test_flydsl_moe_naming.py::TestSuffixRegex::test_fq_fp8_combined PASSED                     [ 20%]
op_tests/test_flydsl_moe_naming.py::TestSuffixRegex::test_fp4_with_sbm PASSED                        [ 25%]
op_tests/test_flydsl_moe_naming.py::TestSuffixRegex::test_fq_with_sbm PASSED                         [ 30%]
op_tests/test_flydsl_moe_naming.py::TestSuffixRegex::test_no_suffix PASSED                           [ 35%]
op_tests/test_flydsl_moe_naming.py::TestKernelNameConstruction::test_basic_name PASSED               [ 40%]
op_tests/test_flydsl_moe_naming.py::TestKernelNameConstruction::test_name_with_fp4_mode PASSED       [ 45%]
op_tests/test_flydsl_moe_naming.py::TestKernelNameConstruction::test_name_with_fq_mode PASSED        [ 50%]
op_tests/test_flydsl_moe_naming.py::TestKernelNameConstruction::test_name_with_sbm PASSED            [ 55%]
op_tests/test_flydsl_moe_naming.py::TestKernelNameConstruction::test_sbm_equal_to_tile_m_is_omitted PASSED [ 60%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp4-True] PASSED [ 65%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fq-True] PASSED [ 70%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fq_sbm64-True] PASSED [ 75%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp4_fp8-True] PASSED [ 80%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[flydsl_moe1_abf16_wbf16_bf16_t64x128x64-False] PASSED [ 85%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[flydsl_moe1_abf16_wbf16_bf16_t64x128x64_fp8-False] PASSED [ 90%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[ck_moe_stage1_kernel-False] PASSED [ 95%]
op_tests/test_flydsl_moe_naming.py::TestStage1FqDetection::test_fq_detection[-False] PASSED          [100%]

============================================ 20 passed in 0.02s ============================================
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
