### PR TITLE
[fix] fix compare error

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -305,8 +305,8 @@ class AITER_CONFIG(object):
             model_config_dir = Path(f"{AITER_ROOT_DIR}/aiter/configs/model_configs/")
             op_tuned_file_list = [
                 p
-                for p in model_config_dir.glob(f"*{tuned_file_name}*")
-                if (p.is_file() and "untuned" not in str(p))
+                for p in model_config_dir.glob(f"*{tuned_file_name}*.csv")
+                if (p.is_file() and "untuned" not in p.name)
             ]
 
             if not op_tuned_file_list:

--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -969,11 +969,14 @@ class TunerCommon:
         compare_dir = os.path.join(tempfile.gettempdir(), "aiter_compare")
         os.makedirs(compare_dir, exist_ok=True)
         base_name = os.path.splitext(os.path.basename(output_file))[0]
-        pid = os.getpid()
-        compare_report_file = os.path.join(
-            compare_dir, f"{base_name}.{pid}.compare.txt"
+        fd, compare_report_file = tempfile.mkstemp(
+            prefix=f"{base_name}.",
+            suffix=".compare.txt",
+            dir=compare_dir,
+            text=True,
         )
-        with open(compare_report_file, "w") as f:
+        os.chmod(compare_report_file, 0o600)
+        with os.fdopen(fd, "w") as f:
             f.write(
                 f"Compare report for {self.name}\n"
                 f"Shapes: {len(self.untunedf)}\n"

--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -966,8 +966,13 @@ class TunerCommon:
         if not args.compare or (total_batches <= 1 and len(self.untunedf) <= 30):
             return None
 
-        report_root, _ = os.path.splitext(output_file)
-        compare_report_file = f"{report_root}.compare.txt"
+        compare_dir = os.path.join(tempfile.gettempdir(), "aiter_compare")
+        os.makedirs(compare_dir, exist_ok=True)
+        base_name = os.path.splitext(os.path.basename(output_file))[0]
+        pid = os.getpid()
+        compare_report_file = os.path.join(
+            compare_dir, f"{base_name}.{pid}.compare.txt"
+        )
         with open(compare_report_file, "w") as f:
             f.write(
                 f"Compare report for {self.name}\n"
@@ -982,8 +987,13 @@ class TunerCommon:
         if not args.compare:
             return None
 
-        candidate_root, candidate_ext = os.path.splitext(output_file)
-        compare_candidate_file = f"{candidate_root}.candidate{candidate_ext or '.csv'}"
+        compare_dir = os.path.join(tempfile.gettempdir(), "aiter_compare")
+        os.makedirs(compare_dir, exist_ok=True)
+        base_name, candidate_ext = os.path.splitext(os.path.basename(output_file))
+        pid = os.getpid()
+        compare_candidate_file = os.path.join(
+            compare_dir, f"{base_name}.{pid}.candidate{candidate_ext or '.csv'}"
+        )
         if os.path.exists(output_file):
             shutil.copyfile(output_file, compare_candidate_file)
         elif os.path.exists(compare_candidate_file):


### PR DESCRIPTION
## Motivation

not write candidate and compare file in csv dir

## Technical Details

- Config discovery fix (core.py): Changed get_config_file glob from *{name}* to *{name}*.csv and filter by p.name instead of str(p), preventing .compare.txt and other non-CSV files from being merged as config

- Compare output isolation (base_tuner.py): Moved .compare.txt and .candidate.csv output from tuned CSV directory to /tmp/aiter_compare/ with PID-based naming, preventing config directory pollution and concurrent run conflicts

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
