### PR TITLE
CI: run SGLang downstream tests on MI355

### DIFF
--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         include:
           - runner: linux-aiter-mi35x-1
-            label: MI355
+            label: MI35X
 
     env:
       SGL_BRANCH: v0.5.10

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -41,20 +41,20 @@ jobs:
       (github.event.pull_request.draft == false &&
       (contains(github.event.pull_request.labels.*.name, 'ci:sglang') ||
       contains(github.event.pull_request.labels.*.name, 'ci:all')))
-    name: Sglang Integration Test (1 GPU)
+    name: Sglang Integration Test (1 GPU, ${{ matrix.label }})
     needs: [check-signal]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - runner: aiter-1gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi355-1
+            label: MI355
 
     env:
       SGL_BRANCH: v0.5.10
-      GPU_ARCH: gfx942
-      SGLANG_CI_HOSTNAME_OVERRIDE: linux-mi325-gpu-1
+      GPU_ARCH: gfx950
+      SGLANG_CI_HOSTNAME_OVERRIDE: linux-mi35x-gpu-1
       GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
       GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
 
@@ -112,8 +112,8 @@ jobs:
           import urllib.request
 
           prefixes = [
-              "v0.5.10-rocm700-mi30x-",
-              "v0.5.10rc0-rocm700-mi30x-",
+              "v0.5.10-rocm700-mi35x-",
+              "v0.5.10rc0-rocm700-mi35x-",
           ]
           matches = {prefix: [] for prefix in prefixes}
           patterns = {
@@ -139,12 +139,12 @@ jobs:
                   break
 
           if not chosen_tag:
-              raise SystemExit("No public MI30X SGLang image found for v0.5.10.")
+              raise SystemExit("No public MI35X SGLang image found for v0.5.10.")
 
           image = f"rocm/sgl-dev:{chosen_tag}"
           print(f"Resolved SGLang base image: {image}")
           if chosen_tag.startswith("v0.5.10rc0-"):
-              print("Using v0.5.10rc0 image because no public v0.5.10 MI30X tag was found.")
+              print("Using v0.5.10rc0 image because no public v0.5.10 MI35X tag was found.")
 
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
               fh.write(f"SGL_IMAGE={image}\n")

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: linux-aiter-mi355-1
+          - runner: linux-aiter-mi35x-1
             label: MI355
 
     env:


### PR DESCRIPTION
Related to https://github.com/ROCm/aiter/issues/2751 

## Summary
- switch `sglang_downstream` from the MI325 runner to the dedicated MI355 runner
- update the downstream job to build aiter with `gfx950` and override the SGLang hostname to the expected `mi35x` pattern
- resolve public `mi35x` SGLang base images so the workflow uses the correct container family on MI355

## Test plan
- [x] `git diff --check -- .github/workflows/sglang_downstream.yaml`
- [x] Verified the workflow now targets `linux-aiter-mi355-1`, `gfx950`, and `linux-mi35x-gpu-1`
- [x] Confirmed public `rocm/sgl-dev:v0.5.10rc0-rocm700-mi35x-*` tags exist
- [ ] Run the `Sglang Downstream Test` workflow via `ci:sglang` on this PR