### PR TITLE
FlyDSL tuning improvements: prune M-incompatible tile candidates and warn on stale kernel names

### DIFF
--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -138,7 +138,7 @@ def get_GEMM_A16W16_config(
                     if flydsl_config is None:
                         logger.warning(
                             f"FlyDSL kernel '{config['kernelName']}' from tuned config is not "
-                            "recognised by the current catalog; falling back to next candidate."
+                            "recognized by the current catalog; falling back to next candidate."
                         )
                         config = None
                 else:

--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -136,6 +136,10 @@ def get_GEMM_A16W16_config(
                         config["kernelName"]
                     )
                     if flydsl_config is None:
+                        logger.warning(
+                            f"FlyDSL kernel '{config['kernelName']}' from tuned config is not "
+                            "recognised by the current catalog; falling back to next candidate."
+                        )
                         config = None
                 else:
                     config = None

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -587,10 +587,11 @@ class Gemm:
         task = []
         flydsl_catalog = get_flydsl_bf16_catalog(self.m, self.n, self.k)
         weight_idx = 6 if self.is_shuffle else 1
+        min_tile_m = min((c["tile_m"] for _, _, c in flydsl_catalog), default=16)
         for solidx, kernel_name, config in flydsl_catalog:
             if config["b_preshuffle"] != self.is_shuffle:
                 continue
-            if config["tile_m"] > max(self.m, 16):
+            if config["tile_m"] > max(self.m, min_tile_m):
                 continue
             if self.n < config["tile_n"] or self.n % config["tile_n"] != 0:
                 continue

--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -590,6 +590,8 @@ class Gemm:
         for solidx, kernel_name, config in flydsl_catalog:
             if config["b_preshuffle"] != self.is_shuffle:
                 continue
+            if config["tile_m"] > max(self.m, 16):
+                continue
             if self.n < config["tile_n"] or self.n % config["tile_n"] != 0:
                 continue
             if self.k % config["split_k"] != 0:


### PR DESCRIPTION
## Motivation

Two small gaps in the FlyDSL tuning integration that affect tuning efficiency and observability:

1. `flydsl_gemm_all_sols()` in GemmTuner had no M-dimension filter, so for small-M shapes (e.g. M=4) all six `tile_m` variants (16→128) were benchmarked even though larger tiles pad most of their M dimension and will never win.
2. When a FlyDSL kernel name stored in the tuned CSV cannot be resolved against the current catalog (e.g. after a FlyDSL version bump that renamed kernels), the fallback to `torch` was completely silent — no indication in logs that a FlyDSL config was expected.

## Technical Details

**[`gradlib/gradlib/GemmTuner.py`](https://github.com/ROCm/aiter/blob/apicciau/flydsl_tuning_improvements/gradlib/gradlib/GemmTuner.py)**

Added one guard at the top of the candidate loop in `flydsl_gemm_all_sols()`:
```python
if config["tile_m"] > max(self.m, 16):
    continue
```
For M=4 this reduces FlyDSL candidates from all tile_m values to just tile_m=16. The `max(..., 16)` floor ensures shapes smaller than the minimum tile still get at least one candidate.

**[`aiter/tuned_gemm.py`](https://github.com/ROCm/aiter/blob/apicciau/flydsl_tuning_improvements/aiter/tuned_gemm.py)**

Added a `logger.warning` in `get_GEMM_A16W16_config()` when a stored FlyDSL kernel name resolves to `None`, naming the unrecognised kernel so operators know which shapes need re-tuning.

## Test Plan

```
python -m pytest gradlib/.geak_discovery_output/test_GemmTuner_focused.py -q
```

## Test Result

```
1 passed in 2.39s
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/aiter/blob/main/CONTRIBUTING.md
