### PR TITLE
CI: allow nightly check-signal to reuse Checks push runs

### DIFF
--- a/.github/scripts/check_signal.sh
+++ b/.github/scripts/check_signal.sh
@@ -91,7 +91,8 @@ find_checks_run_id() {
     gh_args+=(--branch "${target_branch}")
   fi
 
-  if [ -n "${GITHUB_EVENT_NAME:-}" ]; then
+  # Nightly workflows reuse the Checks result from the push run on the same SHA.
+  if [ -n "${GITHUB_EVENT_NAME:-}" ] && [ "${GITHUB_EVENT_NAME}" != "schedule" ]; then
     gh_args+=(--event "${GITHUB_EVENT_NAME}")
   fi
 


### PR DESCRIPTION
## Summary
- skip the `--event` filter when `check_signal.sh` runs under `schedule`
- let nightly workflows reuse the matching `Checks` push run for the same SHA instead of failing early in `check-signal`
- keep the existing event-scoped lookup for non-scheduled workflows

## Test plan
- [x] Run `bash -n .github/scripts/check_signal.sh`
- [x] Verify the latest failing nightly SHA (`cf12b1381dcdec4b5d90d136a5403e718c7541ec`) resolves to `Checks` run `24602103194` without the `schedule` event filter
- [ ] Wait for the next scheduled `Aiter Test` run to confirm `check-signal` no longer fails early