### PR TITLE
CI: log in to Docker before building aiter image

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -54,6 +54,10 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/checkout@v4
 
+      - name: Docker login
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }}
+
       # - name: Prepare docker config
       #   run: |
       #     export DOCKER_CONFIG="$HOME/.docker"
@@ -129,7 +133,6 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
-          docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }}
           docker push $IMAGE_TAG
 
       - name: Success message


### PR DESCRIPTION
## Summary
- move Docker registry authentication to the start of `build_aiter_image`
- let `docker build` pull the base image with authenticated credentials to avoid rate limiting
- reuse the same login session for the later image push step

## Test plan
- Not run locally (GitHub Actions workflow change only)