### PR TITLE
fix(flydsl): add tile_m=16 support to FlyDSL stage1 kernel registry for fp4

### DIFF
--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -68,7 +68,7 @@ def get_flydsl_stage1_kernels(
 
     tile_ns = [32, 64, 128] if is_fp4_b else [128]
     tile_ks = [256]
-    tile_ms = [32, 64, 128]
+    tile_ms = [16, 32, 64, 128] if is_fp4_a else [32, 64, 128]
 
     waves_per_eus = [1, 2, 3, 4]
     k_batches = [1, 2, 4, 7, 14]
@@ -76,14 +76,14 @@ def get_flydsl_stage1_kernels(
     xcd_swizzles = [0, 4]
 
     for tm in tile_ms:
-        if tm == 32:
+        if tm <= 32:
             tile_ns = [32, 64, 128]
         else:
             tile_ns = [64, 128] if is_fp4_a else [128, 256]
         for tn in tile_ns:
             for tk in tile_ks:
                 for wpe in waves_per_eus:
-                    for kb in k_batches if wpe == 3 and tm == 32 and is_fp4_a else [1]:
+                    for kb in k_batches if wpe == 3 and tm in (16, 32) and is_fp4_a else [1]:
                         for bnt in b_nts:
                             gate_onlys = (
                                 [False, True] if kb > 1 and is_fp4_a else [False]

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -83,7 +83,9 @@ def get_flydsl_stage1_kernels(
         for tn in tile_ns:
             for tk in tile_ks:
                 for wpe in waves_per_eus:
-                    for kb in k_batches if wpe == 3 and tm in (16, 32) and is_fp4_a else [1]:
+                    for kb in (
+                        k_batches if wpe == 3 and tm in (16, 32) and is_fp4_a else [1]
+                    ):
                         for bnt in b_nts:
                             gate_onlys = (
                                 [False, True] if kb > 1 and is_fp4_a else [False]


### PR DESCRIPTION
## Motivation
fix ValueError: Invalid FlyDSL kernel name: flydsl_moe1_afp4_wfp4_bf16_t16x128x256_w3_kb7_bnt0_go_fp4 

  The tuned config file `dsv3_fp4_tuned_fmoe.csv` (auto-merged at runtime from `aiter/configs/model_configs/`) contains an entry that selects a stage1 kernel with `tile_m=16` for certain token counts. However, `get_flydsl_stage1_kernels()` only registered `tile_ms = [32, 64, 128]` for stage1, so the lookup in `_KERNEL_PARAMS` returned `None` and raised the error.                                                                                                                                             

## Technical Details
  1. **Extend `tile_ms`**: include `tile_m=16` when `a_dtype=fp4`.                                                                                                                                                                      
  2. **Fix `tile_ns` branch**: change `tm == 32` to `tm <= 32` so that `tile_m=16` also uses the `[32, 64, 128]` tile-N set (same as `tile_m=32`).                                                                                                                                                                    
  3. **Extend split-K condition**: change `tm == 32` to `tm in (16, 32)` so that `tile_m=16` kernels with `wpe=3` also enumerate multi-`k_batch` variants (required to register the `_kb7` variant seen in the tuned config). 

## Test Plan
sglang-atom ds fp4 tp8 acc&performance test

## Test Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.8628|±  |0.0095|
|     |       |strict-match    |     3|exact_match|↑  |0.8582|±  |0.0096|

```
============ Serving Benchmark Result ============
Successful requests:                     3         
Benchmark duration (s):                  22.88     
Total input tokens:                      3         
Total generated tokens:                  3072      
Request throughput (req/s):              0.13      
Output token throughput (tok/s):         134.29    
Total Token throughput (tok/s):          134.42    
---------------Time to First Token----------------
Mean TTFT (ms):                          63.72     
Median TTFT (ms):                        64.04     
P99 TTFT (ms):                           64.19     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.39      
Median TPOT (ms):                        7.39      
P99 TPOT (ms):                           7.39      
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.39      
Median ITL (ms):                         7.41      
P99 ITL (ms):                            7.68      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          7624.27   
Median E2EL (ms):                        7623.23   
P99 E2EL (ms):                           7627.64   
==================================================
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
