### PR TITLE
Add vcs_versioning as transitive dependency of setuptools_scm>=10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -437,6 +437,7 @@ setup_requires = [
     "psutil",
     "ninja",
     "setuptools_scm",
+    "vcs_versioning",  # transitive dep of setuptools_scm>=10
 ]
 if PREBUILD_KERNELS != 0:
     setup_requires.append("pandas")


### PR DESCRIPTION
## Motivation

`python3 setup.py develop` now breaks with the missing dependency. This is because setuptools 10 moved vcs_versioning into a separate package. Adding it.

