### PR TITLE
fix(build): add missing c10/hip/HIPException.h include in gated_rmsnorm_quant_kernels.cu

### DIFF
--- a/csrc/kernels/gated_rmsnorm_quant_kernels.cu
+++ b/csrc/kernels/gated_rmsnorm_quant_kernels.cu
@@ -6,6 +6,7 @@
 #include "aiter_opus_plus.h"
 #include "dispatch_utils.h"
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/hip/HIPException.h>
 
 namespace aiter {
 


### PR DESCRIPTION
﻿## Summary

Adds the missing `#include <c10/hip/HIPException.h>` to `csrc/kernels/gated_rmsnorm_quant_kernels.cu` so that wheel builds with `PREBUILD_KERNELS=1` succeed.

Fixes #2837.

## Root cause

`gated_rmsnorm_quant_kernels.cu` line 223 uses `C10_HIP_KERNEL_LAUNCH_CHECK()` but the file never includes the header that defines it. The macro lives in `c10/hip/HIPException.h` (analogue of `C10_CUDA_KERNEL_LAUNCH_CHECK` in `c10/cuda/CUDAException.h`).

- **JIT path**: the AITER hipify pipeline under `aiter/jit/utils/hipify/` injects these c10 headers implicitly, so the missing include was invisible in per-PR CI.
- **`PREBUILD_KERNELS=1` path**: compiles the `.cu` directly via `setup.py` extensions, without that injection, and fails with

```
csrc/kernels/gated_rmsnorm_quant_kernels.cu:223:5:
  error: use of undeclared identifier 'C10_HIP_KERNEL_LAUNCH_CHECK'
```

The regression was introduced in 875f6b7cd (#2499, "Fuse gated rmsnorm + group_quant for qwen3next and qwen3.5") and is present in v0.1.12.post1.

## Fix

One-line change: add `#include <c10/hip/HIPException.h>` to the file's include block.

## Test plan

- [ ] Local: `PREBUILD_KERNELS=1 pip install .` no longer errors on `gated_rmsnorm_quant_kernels.cu`.
- [ ] JIT path still builds the kernel unchanged (no behavioral change; only adds a header).
- [ ] No runtime semantics change - same macro, same call site.

## Follow-up suggestion

This class of bug (compiles via JIT, fails via `PREBUILD_KERNELS=1`) is only catchable by a wheel-build CI lane. Consider adding a per-PR job that runs `PREBUILD_KERNELS=1 pip wheel .` on at least one config; happy to send a separate proposal.