### PR TITLE
[release/v0.1.12] Cherry-pick #2839: add missing c10/hip/HIPException.h include

### DIFF
--- a/csrc/kernels/gated_rmsnorm_quant_kernels.cu
+++ b/csrc/kernels/gated_rmsnorm_quant_kernels.cu
@@ -6,6 +6,7 @@
 #include "aiter_opus_plus.h"
 #include "dispatch_utils.h"
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/hip/HIPException.h>
 
 namespace aiter {
 


### PR DESCRIPTION
Cherry-picks #2839 (by @ChuanLi1101) onto `release/v0.1.12` to prepare `v0.1.12.post2`.

## Why

Building v0.1.12.post1 from source with `PREBUILD_KERNELS=1` fails in vLLM's `ml-ci-internal` base image:

```
csrc/kernels/gated_rmsnorm_quant_kernels.cu:223:5: error: use of undeclared identifier 'C10_HIP_KERNEL_LAUNCH_CHECK'
```

AITER CI doesn't catch this because `rocm/pytorch:latest` happens to pull `<c10/hip/HIPException.h>` transitively through other includes in this file. vLLM ml-ci-internal's base image doesn't, so the build fails. Per Richard's audit, this macro is referenced in exactly one `.cu` file across all of `csrc/`, so a single explicit include fully resolves it.

Fixes #2837. See #2839 for the full root-cause analysis from @ChuanLi1101.

## Diff

One line added after the existing `#include <ATen/...>` block:

```diff
 #include "dispatch_utils.h"
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/hip/HIPException.h>

 namespace aiter {
```

## CI

Adding `ci:vllm`, `ci:atom`, `ci:sglang`, `ci:triton-355` to validate downstream impact before merge — this is the `v0.1.12.post2` candidate so we want full coverage.

## Follow-up

Lingpeng raised the option of removing `C10_HIP_KERNEL_LAUNCH_CHECK` entirely instead of adding the header. We're going with the explicit include here to unblock @gshtras / vLLM 0.20 train today; macro removal will be tracked as a separate audit (no other `csrc/` files use it).