### PR TITLE
aiter/__init__: per-module try/except so the first broken op surfaces

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -66,52 +66,101 @@ if os.path.isdir(_flydsl_cache) and "FLYDSL_RUNTIME_CACHE_DIR" not in os.environ
 if sys.platform == "win32":
     logger.info("Windows: CK and HIP ops are not available. Triton ops only.")
 else:
+    _HIP_INIT_EXCEPTIONS = (ImportError, RuntimeError, OSError, KeyError)
+
+    _hip_runtime_ok = True
     try:
         from .jit import core as core  # noqa: E402
         from .utility import dtypes as dtypes  # noqa: E402
-        from .ops.enum import *  # noqa: F403,E402
-        from .ops.norm import *  # noqa: F403,E402
-        from .ops.quant import *  # noqa: F403,E402
-        from .ops.gemm_op_a8w8 import *  # noqa: F403,E402
-        from .ops.gemm_op_a16w16 import *  # noqa: F403,E402
-        from .ops.gemm_op_a4w4 import *  # noqa: F403,E402
-        from .ops.batched_gemm_op_a8w8 import *  # noqa: F403,E402
-        from .ops.batched_gemm_op_bf16 import *  # noqa: F403,E402
-        from .ops.deepgemm import *  # noqa: F403,E402
-        from .ops.aiter_operator import *  # noqa: F403,E402
-        from .ops.activation import *  # noqa: F403,E402
-        from .ops.attention import *  # noqa: F403,E402
-        from .ops.custom import *  # noqa: F403,E402
-        from .ops.custom_all_reduce import *  # noqa: F403,E402
-        from .ops.quick_all_reduce import *  # noqa: F403,E402
-        from .ops.moe_op import *  # noqa: F403,E402
-        from .ops.moe_sorting import *  # noqa: F403,E402
-        from .ops.moe_sorting_opus import *  # noqa: F403,E402
-        from .ops.pos_encoding import *  # noqa: F403,E402
-        from .ops.cache import *  # noqa: F403,E402
-        from .ops.rmsnorm import *  # noqa: F403,E402
-        from .ops.communication import *  # noqa: F403,E402
-        from .ops.rope import *  # noqa: F403,E402
-        from .ops.topk import *  # noqa: F403,E402
-        from .ops.topk_plain import topk_plain  # noqa: F403,F401,E402
-        from .ops.mha import *  # noqa: F403,E402
-        from .ops.gradlib import *  # noqa: F403,E402
-        from .ops.trans_ragged_layout import *  # noqa: F403,E402
-        from .ops.sample import *  # noqa: F403,E402
-        from .ops.fused_qk_norm_mrope_cache_quant import *  # noqa: F403,E402
-        from .ops.fused_qk_norm_rope_cache_quant import *  # noqa: F403,E402
-        from .ops.fused_qk_rmsnorm_group_quant import *  # noqa: F403,E402
-        from .ops.groupnorm import *  # noqa: F403,E402
-        from .ops.mhc import *  # noqa: F403,E402
-        from .ops.causal_conv1d import *  # noqa: F403,E402
-        from .ops.fused_split_gdr_update import *  # noqa: F403,E402
-        from . import mla  # noqa: F403,F401,E402
-    except (ImportError, RuntimeError, OSError, KeyError) as e:
+    except _HIP_INIT_EXCEPTIONS as _e:
+        _hip_runtime_ok = False
         logger.warning(
-            "ROCm/HIP JIT runtime not available: %s. "
+            "ROCm/HIP JIT core unavailable: %s. "
             "CK and HIP ops are disabled. Triton ops remain available.",
-            e,
+            _e,
+            exc_info=True,
         )
+
+    if _hip_runtime_ok:
+        # Ops loaded with `from .ops.X import *` semantics. Each is wrapped in its
+        # own try/except so a single broken op (e.g. a dlopen failure inside one
+        # .so) surfaces an actionable per-module traceback instead of silently
+        # stripping every HIP/CK symbol from the `aiter` namespace.
+        _OPS_IMPORT_STAR = (
+            "enum",
+            "norm",
+            "quant",
+            "gemm_op_a8w8",
+            "gemm_op_a16w16",
+            "gemm_op_a4w4",
+            "batched_gemm_op_a8w8",
+            "batched_gemm_op_bf16",
+            "deepgemm",
+            "aiter_operator",
+            "activation",
+            "attention",
+            "custom",
+            "custom_all_reduce",
+            "quick_all_reduce",
+            "moe_op",
+            "moe_sorting",
+            "moe_sorting_opus",
+            "pos_encoding",
+            "cache",
+            "rmsnorm",
+            "communication",
+            "rope",
+            "topk",
+            "mha",
+            "gradlib",
+            "trans_ragged_layout",
+            "sample",
+            "fused_qk_norm_mrope_cache_quant",
+            "fused_qk_norm_rope_cache_quant",
+            "fused_qk_rmsnorm_group_quant",
+            "groupnorm",
+            "mhc",
+            "causal_conv1d",
+            "fused_split_gdr_update",
+        )
+
+        import importlib as _importlib  # noqa: E402
+
+        for _ops_mod in _OPS_IMPORT_STAR:
+            try:
+                _m = _importlib.import_module(f".ops.{_ops_mod}", __name__)
+            except _HIP_INIT_EXCEPTIONS as _e:
+                logger.warning(
+                    "Failed to import aiter.ops.%s: %s. "
+                    "Symbols from this op will be unavailable.",
+                    _ops_mod,
+                    _e,
+                    exc_info=True,
+                )
+                continue
+            _all = getattr(_m, "__all__", None)
+            if _all is None:
+                _all = [n for n in dir(_m) if not n.startswith("_")]
+            for _name in _all:
+                globals()[_name] = getattr(_m, _name)
+
+        try:
+            from .ops.topk_plain import topk_plain  # noqa: F401,E402
+        except _HIP_INIT_EXCEPTIONS as _e:
+            logger.warning(
+                "Failed to import aiter.ops.topk_plain.topk_plain: %s",
+                _e,
+                exc_info=True,
+            )
+
+        try:
+            from . import mla  # noqa: F401,E402
+        except _HIP_INIT_EXCEPTIONS as _e:
+            logger.warning(
+                "Failed to import aiter.mla: %s",
+                _e,
+                exc_info=True,
+            )
 
 # Import Triton-based communication primitives from ops.triton.comms (optional, only if Iris is available)
 try:


### PR DESCRIPTION
## Summary

Replace the single `try/except` around all ~35 `from .ops.X import *` statements in `aiter/__init__.py` with a per-module `try/except` + `exc_info=True`. When any one op module fails to load, the init log now pinpoints the responsible op and prints the full underlying traceback, instead of silently dropping every HIP/CK symbol from the `aiter` namespace and re-raising as a generic "cannot import name" error on first downstream use.

## Motivation

A user hit `ImportError: cannot import name 'flash_attn_varlen_func' from 'aiter'` with a release wheel. The real root cause was a libstdc++ ABI mismatch:

```
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.31' not found
(required by .../aiter/jit/module_aiter_core.so)
```

`aiter.ops.enum` line 15 implicitly calls `_ActivationType(0)`, which triggers `get_module_custom_op -> importlib.import_module("aiter.jit.module_aiter_core")`. That dlopen failed on the ABI-mismatched host. The single outer `try/except` caught the `ImportError`, logged one `[aiter] ROCm/HIP JIT runtime not available: ...` line, and all subsequent `from .ops.X import *` lines were skipped. The user never saw which op failed first, never saw the Python traceback, and the symbol they actually wanted (`flash_attn_varlen_func`, defined in `aiter.ops.mha`) disappeared along with ~200 others.

With this change, the failure now surfaces as:

```
[aiter] Failed to import aiter.ops.enum: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by .../aiter/jit/module_aiter_core.so). Symbols from this op will be unavailable.
Traceback (most recent call last):
  File ".../aiter/__init__.py", line ..., in <module>
    _m = _importlib.import_module(f".ops.{_ops_mod}", __name__)
  ...
  File ".../aiter/ops/enum.py", line 15, in <module>
    ActivationType = type(_ActivationType(0))
  ...
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.31' not found ...
```

— which is directly actionable.

## What changed

* Core infra (`from .jit import core`, `from .utility import dtypes`) is still one gated block — if those fail, skipping ops is correct.
* Each `from .ops.X import *` is replaced by an `importlib.import_module(".ops.X", __name__)` call inside its own `try/except`, followed by copying `__all__` / public attributes into `globals()`. This matches the original `import *` semantics.
* `from .ops.topk_plain import topk_plain` and `from . import mla` keep their named-import form and each get their own `try/except`.
* All `except` handlers log with `exc_info=True` so the underlying traceback is always printed.
* Catch tuple is unchanged: `(ImportError, RuntimeError, OSError, KeyError)`.

## Test plan

- [ ] `import aiter` on a host where `module_aiter_core.so` loads cleanly — every op module should continue to populate its symbols in `aiter`'s namespace (no regression).
- [ ] `import aiter` on a host where the `.so` has an ABI mismatch — the log should name the first failing op and print its full traceback; ops that don't transitively depend on the failing `.so` should still load (graceful partial degradation instead of silent total loss).
- [ ] `aiter.flash_attn_varlen_func`, `aiter.flash_attn_func`, and a sampling of other symbols previously exposed via `from .ops.mha import *` still resolve.

## Related

- Referenced user report: `import aiter` against the `v0.1.12.post2` trial wheel inside `vllm/vllm-openai-rocm:v0.19.1` (see internal Teams thread).
- Complements (does not replace) a separate fix on the wheel-build side to target an older libstdc++/glibc baseline.
