### PR TITLE
[release/v0.1.12] Remove C10_HIP_KERNEL_LAUNCH_CHECK (Lingpeng's preferred fix)

### DIFF
--- a/csrc/kernels/gated_rmsnorm_quant_kernels.cu
+++ b/csrc/kernels/gated_rmsnorm_quant_kernels.cu
@@ -219,8 +219,6 @@ void gated_rmsnorm_fp8_group_quant_launcher_impl(
             num_heads,
             head_dim
         );
-
-    C10_HIP_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename DTYPE_I, typename DTYPE_O>


### PR DESCRIPTION
## Summary

Remove the `C10_HIP_KERNEL_LAUNCH_CHECK();` call from `csrc/kernels/gated_rmsnorm_quant_kernels.cu` (the only occurrence across all of `csrc/`). This is Lingpeng's preferred fix per Teams discussion 2026-04-21 and supersedes the include-based approach in #2842.

## Background

- Issue #2837: vLLM `ml-ci-internal` lane fails to build AITER because `C10_HIP_KERNEL_LAUNCH_CHECK` is undeclared.
- PR #2839 (and its release/v0.1.12 cherry-pick #2842) tried to fix this by adding `#include <c10/hip/HIPException.h>`.
- Greg confirmed today (2026-04-21) that even with #2839's include applied, his build still fails — his PyTorch version predates the macro's definition in `c10/hip/HIPException.h`. The include-based fix is brittle across PyTorch versions.

## Why removal is safe

`C10_HIP_KERNEL_LAUNCH_CHECK` is a thin error-reporting wrapper around `hipGetLastError()`. The kernel launches themselves (`<<<grid, block, 0, stream>>>`) are unaffected. Dropping the post-launch check removes the build-environment dependency on PyTorch's HIPException header and makes the file robust across PyTorch versions.

The macro is used in exactly one place across `csrc/` (verified). On `release/v0.1.12` HEAD (04d4009b1) the include from #2842 is not yet present, so no include needs to be removed.

## Relationship to other PRs / issues

- Supersedes #2842 (cherry-pick of #2839's include-based fix).
- Fixes #2837.

## CI

Adding labels for vLLM, ATOM, SGLang, and Triton MI355 lanes per release/v0.1.12 validation policy.