### PR TITLE
CI: fix pre-check signal lookup for labeled PR runs

### DIFF
--- a/.github/scripts/check_signal.sh
+++ b/.github/scripts/check_signal.sh
@@ -6,16 +6,11 @@
 
 set -euo pipefail
 
-ARTIFACT_NAME="checks-signal-${GITHUB_SHA:-${1:-}}"
 CHECKS_WORKFLOW_NAME="${CHECKS_WORKFLOW_NAME:-Checks}"
+CHECKS_SIGNAL_ARTIFACT_PREFIX="${CHECKS_SIGNAL_ARTIFACT_PREFIX:-checks-signal}"
 MAX_RETRIES="${MAX_RETRIES:-5}"
 RETRY_INTERVAL_SECONDS="${RETRY_INTERVAL_SECONDS:-30}"
 REPO="${GITHUB_REPOSITORY:-}"
-
-if [ -z "${ARTIFACT_NAME#checks-signal-}" ]; then
-  echo "GITHUB_SHA or an explicit SHA argument is required."
-  exit 1
-fi
 
 get_target_branch() {
   if [ -n "${GITHUB_HEAD_REF:-}" ]; then
@@ -100,25 +95,57 @@ find_checks_run_id() {
     --jq "(map(select(.headSha == \"${target_head_sha}\")) | first | .databaseId) // empty"
 }
 
+find_signal_artifact_name() {
+  local run_id="$1"
+
+  gh api "repos/${REPO}/actions/runs/${run_id}/artifacts" | python3 -c '
+import json
+import sys
+
+prefix = sys.argv[1]
+data = json.load(sys.stdin)
+
+matching = sorted(
+    (
+        artifact
+        for artifact in data.get("artifacts", [])
+        if not artifact.get("expired")
+        and (
+            artifact.get("name") == prefix
+            or artifact.get("name", "").startswith(f"{prefix}-")
+        )
+    ),
+    key=lambda artifact: artifact.get("created_at", ""),
+)
+
+print(matching[-1]["name"] if matching else "")
+' "${CHECKS_SIGNAL_ARTIFACT_PREFIX}"
+}
+
 for i in $(seq 1 "${MAX_RETRIES}"); do
   echo "Attempt ${i}: Locating ${CHECKS_WORKFLOW_NAME} workflow run..."
   rm -f checks_signal.txt
 
   RUN_ID="$(find_checks_run_id || true)"
   if [ -n "${RUN_ID}" ]; then
-    echo "Attempt ${i}: Downloading artifact '${ARTIFACT_NAME}' from run ${RUN_ID}..."
-    if gh run download "${RUN_ID}" --repo "${REPO}" --name "${ARTIFACT_NAME}"; then
-      if [ -f checks_signal.txt ]; then
-        echo "Artifact ${ARTIFACT_NAME} downloaded successfully."
-        SIGNAL="$(head -n 1 checks_signal.txt)"
-        if [ "${SIGNAL}" = "success" ]; then
-          echo "Pre-checks passed, continuing workflow."
-          exit 0
-        fi
+    ARTIFACT_NAME="$(find_signal_artifact_name "${RUN_ID}" || true)"
+    if [ -z "${ARTIFACT_NAME}" ]; then
+      echo "Attempt ${i}: No ${CHECKS_SIGNAL_ARTIFACT_PREFIX} artifact found in run ${RUN_ID} yet."
+    else
+      echo "Attempt ${i}: Downloading artifact '${ARTIFACT_NAME}' from run ${RUN_ID}..."
+      if gh run download "${RUN_ID}" --repo "${REPO}" --name "${ARTIFACT_NAME}"; then
+        if [ -f checks_signal.txt ]; then
+          echo "Artifact ${ARTIFACT_NAME} downloaded successfully."
+          SIGNAL="$(head -n 1 checks_signal.txt)"
+          if [ "${SIGNAL}" = "success" ]; then
+            echo "Pre-checks passed, continuing workflow."
+            exit 0
+          fi
 
-        echo "Pre-checks failed, skipping workflow. Details:"
-        tail -n +2 checks_signal.txt
-        exit 78  # 78 = neutral/skip
+          echo "Pre-checks failed, skipping workflow. Details:"
+          tail -n +2 checks_signal.txt
+          exit 78  # 78 = neutral/skip
+        fi
       fi
     fi
   else


### PR DESCRIPTION
## Summary
- stop rebuilding the `checks-signal-*` artifact name from the current workflow SHA in `.github/scripts/check_signal.sh`
- resolve the matching `Checks` run by PR head SHA, then list that run's artifacts and download the latest `checks-signal` artifact from it
- keep pre-check gating stable when `pull_request` jobs are retriggered by labels or reruns and GitHub generates a new merge SHA

## Test plan
- [x] `bash -n .github/scripts/check_signal.sh`
- [x] Replayed the failing PR case locally with PR head SHA `fc4edb8adf64bcc93ec70cc6926a31b92536c29b`; the script resolved run `24705651419` and downloaded `checks-signal-7ad91842b5643937298b4f5a144e11bf99808aef`