### PR TITLE
fix(flydsl): support AOT cache generation without GPUs

### DIFF
--- a/aiter/aot/flydsl/common.py
+++ b/aiter/aot/flydsl/common.py
@@ -51,3 +51,158 @@ def compile_only_env() -> Iterator[None]:
             os.environ.pop("COMPILE_ONLY", None)
         else:
             os.environ["COMPILE_ONLY"] = prev
+
+
+def aot_compile_device():
+    import torch
+
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def aot_compile_stream(device=None):
+    import torch
+    from flydsl.expr.typing import Stream
+
+    if torch.cuda.is_available():
+        return torch.cuda.current_stream(device=device)
+    return Stream(0)
+
+
+class CompileOnlyTensorArg:
+    """CPU tensor wrapper that preserves FlyDSL compile-only metadata paths.
+
+    FlyDSL's default TensorAdaptor always exports DLPack with ``stream=-1``,
+    which is correct for GPU tensors but invalid for CPU tensors.  This wrapper
+    switches CPU tensors to the CPU DLPack path so ``COMPILE_ONLY=1`` can build
+    launcher signatures without requiring a visible HIP device.
+    """
+
+    def __init__(
+        self,
+        tensor,
+        assumed_align: int | None = None,
+        use_32bit_stride: bool = False,
+    ):
+        import torch
+
+        float8_dtypes = tuple(
+            dt
+            for dt in (
+                getattr(torch, "float8_e4m3fn", None),
+                getattr(torch, "float8_e5m2", None),
+                getattr(torch, "float8_e4m3fnuz", None),
+                getattr(torch, "float8_e5m2fnuz", None),
+            )
+            if dt is not None
+        )
+
+        dlpack_tensor = tensor.detach() if tensor.requires_grad else tensor
+        if float8_dtypes and dlpack_tensor.dtype in float8_dtypes:
+            dlpack_tensor = dlpack_tensor.view(torch.uint8)
+
+        self._tensor = tensor
+        self._dlpack_tensor = dlpack_tensor
+        self._tensor_adaptor = None
+        self.assumed_align = assumed_align
+        self.use_32bit_stride = use_32bit_stride
+
+    def _ensure_tensor_adaptor(self):
+        if self._tensor_adaptor is not None:
+            return self._tensor_adaptor
+
+        from flydsl.compiler.jit_argument import DLTensorAdaptor
+
+        if self._dlpack_tensor.device.type == "cpu":
+            dlpack_capsule = self._dlpack_tensor.__dlpack__()
+        else:
+            dlpack_capsule = self._dlpack_tensor.__dlpack__(stream=-1)
+        self._tensor_adaptor = DLTensorAdaptor(
+            dlpack_capsule, self.assumed_align, self.use_32bit_stride
+        )
+        self._tensor_adaptor.build_memref_desc()
+        return self._tensor_adaptor
+
+    def __fly_types__(self):
+        return [self._ensure_tensor_adaptor().get_memref_type()]
+
+    def __fly_ptrs__(self):
+        return self._ensure_tensor_adaptor().get_c_pointers()
+
+    def __cache_signature__(self):
+        return (
+            self._tensor.dtype,
+            self.assumed_align,
+            self.use_32bit_stride,
+        )
+
+
+def _register_compile_only_tensor_arg() -> None:
+    from flydsl.compiler.jit_argument import JitArgumentRegistry
+    from flydsl.expr.typing import Tensor
+
+    try:
+        JitArgumentRegistry.register_jit_arg(CompileOnlyTensorArg, Tensor)
+    except ValueError:
+        pass
+
+
+_register_compile_only_tensor_arg()
+
+
+def prepare_compile_arg(arg):
+    import torch
+
+    if isinstance(arg, torch.Tensor) and arg.device.type == "cpu":
+        return CompileOnlyTensorArg(arg)
+    return arg
+
+
+def prepare_compile_args(args):
+    return tuple(prepare_compile_arg(arg) for arg in args)
+
+
+def _jit_cache_hit(exe, *args, **kwargs) -> bool:
+    ensure_sig = getattr(exe, "_ensure_sig", None)
+    ensure_cache_manager = getattr(exe, "_ensure_cache_manager", None)
+    make_cache_key = getattr(exe, "_make_cache_key", None)
+    cache_key_to_str = getattr(exe, "_cache_key_to_str", None)
+    sig = getattr(exe, "_sig", None)
+    mem_cache = getattr(exe, "_mem_cache", None)
+    cache_manager = getattr(exe, "cache_manager", None)
+
+    if (
+        ensure_sig is None
+        or ensure_cache_manager is None
+        or make_cache_key is None
+        or cache_key_to_str is None
+    ):
+        return False
+
+    ensure_sig()
+    ensure_cache_manager()
+    sig = getattr(exe, "_sig", sig)
+    cache_manager = getattr(exe, "cache_manager", cache_manager)
+    mem_cache = getattr(exe, "_mem_cache", mem_cache)
+    if sig is None:
+        return False
+
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+    cache_key = make_cache_key(bound.arguments)
+    if mem_cache is not None and cache_key in mem_cache:
+        return True
+
+    str_key = cache_key_to_str(cache_key)
+    return bool(cache_manager is not None and str_key in cache_manager)
+
+
+def compile_executable_to_cache(exe, *args, **kwargs):
+    prepared_args = prepare_compile_args(args)
+    prepared_kwargs = {k: prepare_compile_arg(v) for k, v in kwargs.items()}
+
+    if _jit_cache_hit(exe, *prepared_args, **prepared_kwargs):
+        print("[flydsl] COMPILE_ONLY=1, cache hit")
+        return None
+
+    with compile_only_env():
+        return exe(*prepared_args, **prepared_kwargs)

--- a/aiter/aot/flydsl/gemm.py
+++ b/aiter/aot/flydsl/gemm.py
@@ -36,7 +36,13 @@ import sys
 import time
 from typing import Dict, Optional
 
-from aiter.aot.flydsl.common import collect_aot_jobs, compile_only_env, job_identity
+from aiter.aot.flydsl.common import (
+    aot_compile_device,
+    aot_compile_stream,
+    collect_aot_jobs,
+    compile_executable_to_cache,
+    job_identity,
+)
 from aiter.jit.core import AITER_CONFIGS
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.flydsl.gemm_kernels import get_flydsl_splitk_hgemm_kernel_params
@@ -178,14 +184,7 @@ def _torch_dtype_for_kernel(dtype_name: str):
 
 
 def _compile_executable_to_cache(exe, *args) -> None:
-    compile_fn = getattr(exe, "compile", None)
-    if compile_fn is None:
-        import flydsl.compiler as flyc
-
-        compile_fn = flyc.compile
-        args = (exe, *args)
-    with compile_only_env():
-        compile_fn(*args)
+    compile_executable_to_cache(exe, *args)
 
 
 def _compile_hgemm_to_cache(
@@ -218,7 +217,7 @@ def _compile_hgemm_to_cache(
 
     import torch
 
-    dev = torch.device("cuda")
+    dev = aot_compile_device()
     torch_dtype = _torch_dtype_for_kernel(dtype)
 
     current_gfx = get_gfx()
@@ -237,7 +236,7 @@ def _compile_hgemm_to_cache(
         device=dev,
         dtype=torch.int32,
     )
-    stream = torch.cuda.current_stream(device=dev)
+    stream = aot_compile_stream(dev)
 
     exe = compile_flydsl_hgemm_kernel(
         dtype,
@@ -285,7 +284,7 @@ def _compile_preshuffle_to_cache(
 
     import torch
 
-    dev = torch.device("cuda")
+    dev = aot_compile_device()
     out_torch_dtype = _torch_dtype_for_kernel(out_dtype)
 
     # FlyDSL preshuffle kernels consume raw quantized bytes for fp8/int8 paths.
@@ -294,7 +293,7 @@ def _compile_preshuffle_to_cache(
     out = torch.empty((m * n,), device=dev, dtype=out_torch_dtype)
     scale_a = torch.empty((max(m, 1),), device=dev, dtype=torch.float32)
     scale_b = torch.empty((max(n, 1),), device=dev, dtype=torch.float32)
-    stream = torch.cuda.current_stream(device=dev)
+    stream = aot_compile_stream(dev)
 
     exe = compile_preshuffle_gemm_a8(
         N=n,

--- a/aiter/aot/flydsl/moe.py
+++ b/aiter/aot/flydsl/moe.py
@@ -28,13 +28,19 @@ import os
 import sys
 import time
 
-from aiter.aot.flydsl.common import collect_aot_jobs, compile_only_env, job_identity
+from aiter.aot.flydsl.common import (
+    aot_compile_device,
+    aot_compile_stream,
+    collect_aot_jobs,
+    compile_executable_to_cache,
+    compile_only_env,
+    job_identity,
+)
 from aiter.jit.core import AITER_CONFIGS
 from aiter.ops.flydsl.moe_kernels import (
     compile_flydsl_moe_stage1,
     compile_flydsl_moe_stage2,
     get_flydsl_kernel_params,
-    _run_compiled,
     _s1_args_fp4,
     _s1_args_std,
     _s2_args_fp4,
@@ -113,11 +119,15 @@ def _precompile_to_cache(
     waves_per_eu: int = 3,
     k_batch: int = 1,
     b_nt: int = 2,
-    gate_only: bool = False,
-    fuse_fp4_quant: bool = False,
+    gate_mode: str = "separated",
     mode: str = "atomic",
     persist: bool = False,
     sort_block_m: int = 0,
+    model_dim_pad: int = 0,
+    inter_dim_pad: int = 0,
+    enable_bias: bool = False,
+    a_scale_one: bool = False,
+    xcd_swizzle: int = 0,
     **kwargs,
 ):
     """Trigger MLIR compilation with dummy tensors and COMPILE_ONLY=1.
@@ -129,7 +139,8 @@ def _precompile_to_cache(
     """
     import torch
 
-    dev = torch.device("cuda")
+    dev = aot_compile_device()
+    stream = aot_compile_stream(dev)
     is_fp4 = b_dtype == "fp4"
     tokens = tile_m
     E = experts
@@ -174,6 +185,7 @@ def _precompile_to_cache(
                     k_in,
                     _grid_y,
                     dev,
+                    stream=stream,
                 )
             else:
                 out = torch.zeros(
@@ -199,6 +211,7 @@ def _precompile_to_cache(
                     n_in,
                     k_in,
                     _grid_y,
+                    stream=stream,
                 )
 
             exe = compile_flydsl_moe_stage1(
@@ -216,11 +229,14 @@ def _precompile_to_cache(
                 waves_per_eu=waves_per_eu,
                 k_batch=k_batch,
                 b_nt=b_nt,
-                gate_only=gate_only,
-                fuse_fp4_quant=fuse_fp4_quant and not _is_splitk,
-                fuse_sort_scale=fuse_fp4_quant and not _is_splitk,
+                gate_mode=gate_mode,
+                model_dim_pad=model_dim_pad,
+                inter_dim_pad=inter_dim_pad,
+                enable_bias=enable_bias,
+                a_scale_one=a_scale_one,
+                xcd_swizzle=xcd_swizzle,
             )
-            _run_compiled(exe, args)
+            compile_executable_to_cache(exe, *args)
 
         elif stage == 2:
             accumulate = mode != "reduce"
@@ -253,6 +269,7 @@ def _precompile_to_cache(
                     k_in,
                     _grid_y,
                     dev,
+                    stream=stream,
                 )
             else:
                 out = torch.zeros(tokens * model_dim, device=dev, dtype=torch.bfloat16)
@@ -274,6 +291,7 @@ def _precompile_to_cache(
                     n_in,
                     k_in,
                     _grid_y,
+                    stream=stream,
                 )
 
             exe = compile_flydsl_moe_stage2(
@@ -291,8 +309,13 @@ def _precompile_to_cache(
                 accumulate=accumulate,
                 persist_m=_persist_m,
                 sort_block_m=sort_block_m,
+                b_nt=b_nt,
+                model_dim_pad=model_dim_pad,
+                inter_dim_pad=inter_dim_pad,
+                xcd_swizzle=xcd_swizzle,
+                enable_bias=enable_bias,
             )
-            _run_compiled(exe, args)
+            compile_executable_to_cache(exe, *args)
 
 
 def compile_one_config(

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -359,6 +359,7 @@ def _s1_args_fp4(
     size_expert_ids_in,
     dev,
     bias=None,
+    stream=None,
 ):
     empty_f32 = torch.empty(0, device=dev, dtype=torch.float32)
     _bias = bias if bias is not None else empty_f32
@@ -378,7 +379,7 @@ def _s1_args_fp4(
         n_in,
         k_in,
         size_expert_ids_in,
-        torch.cuda.current_stream(),
+        torch.cuda.current_stream() if stream is None else stream,
     )
 
 
@@ -396,6 +397,7 @@ def _s1_args_std(
     n_in,
     k_in,
     size_expert_ids_in,
+    stream=None,
 ):
     return (
         out,
@@ -411,7 +413,7 @@ def _s1_args_std(
         n_in,
         k_in,
         size_expert_ids_in,
-        torch.cuda.current_stream(),
+        torch.cuda.current_stream() if stream is None else stream,
     )
 
 
@@ -431,6 +433,7 @@ def _s2_args_fp4(
     blocks,
     dev,
     bias=None,
+    stream=None,
 ):
     _bias = (
         bias.view(-1)
@@ -452,7 +455,7 @@ def _s2_args_fp4(
         n_in,
         k_in,
         blocks,
-        torch.cuda.current_stream(),
+        torch.cuda.current_stream() if stream is None else stream,
     )
 
 
@@ -470,6 +473,7 @@ def _s2_args_std(
     n_in,
     k_in,
     blocks,
+    stream=None,
 ):
     return (
         target,
@@ -485,7 +489,7 @@ def _s2_args_std(
         n_in,
         k_in,
         blocks,
-        torch.cuda.current_stream(),
+        torch.cuda.current_stream() if stream is None else stream,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -378,6 +378,10 @@ if PREBUILD_KERNELS != 0:
                     )
                     fail = len(results) - ok
                     print(f"[aiter] {label}: compiled {ok} ok, {fail} failed")
+                    assert fail == 0, (
+                        f"{label} failed for {fail} kernel(s). "
+                        "See compile log above for the failing cases."
+                    )
 
             from aiter.aot.flydsl.moe import (
                 DEFAULT_CSVS as MOE_DEFAULT_CSVS,
@@ -408,7 +412,7 @@ if PREBUILD_KERNELS != 0:
             import traceback
 
             traceback.print_exc()
-            print(f"[aiter] FlyDSL AOT skipped: {e}")
+            raise AssertionError(f"[aiter] FlyDSL AOT failed: {e}") from e
 
 
 class NinjaBuildExtension(build_ext):


### PR DESCRIPTION
Use CPU placeholders and cache-hit short-circuiting so FlyDSL AOT can populate caches in environments without visible HIP devices. Fail setup.py early when any FlyDSL AOT kernel compilation errors out.


Made-with: Cursor

