### PR TITLE
[feat](norm_rope_cache): support q k v input for fused_qk_norm_rope_c…

### DIFF
--- a/aiter/ops/fused_qk_norm_rope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_rope_cache_quant.py
@@ -7,8 +7,11 @@ from ..jit.core import compile_ops
 from typing import Optional
 
 
-@compile_ops("module_fused_qk_norm_rope_cache_quant_shuffle")
-def fused_qk_norm_rope_cache_quant_shuffle(
+@compile_ops(
+    "module_fused_qk_norm_rope_cache_quant_shuffle",
+    fc_name="fused_qk_norm_rope_cache_quant_shuffle",
+)
+def _fused_qk_norm_rope_cache_quant_shuffle_hip(
     qkv: Tensor,
     num_heads_q: int,
     num_heads_k: int,
@@ -26,7 +29,95 @@ def fused_qk_norm_rope_cache_quant_shuffle(
     kv_cache_dtype: str,
     k_scale: Tensor,
     v_scale: Tensor,
+    q: Optional[Tensor] = None,
+    k: Optional[Tensor] = None,
+    v: Optional[Tensor] = None,
 ) -> None: ...
+
+
+def fused_qk_norm_rope_cache_quant_shuffle(
+    qkv: Optional[Tensor] = None,
+    *,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_dim: int,
+    eps: float,
+    qw: Tensor,
+    kw: Tensor,
+    cos_sin_cache: Tensor,
+    is_neox_style: bool,
+    pos_ids: Tensor,
+    k_cache: Tensor,
+    v_cache: Tensor,
+    slot_mapping: Tensor,
+    kv_cache_dtype: str,
+    k_scale: Tensor,
+    v_scale: Tensor,
+    q: Optional[Tensor] = None,
+    k: Optional[Tensor] = None,
+    v: Optional[Tensor] = None,
+) -> None:
+    if q is None:
+        if qkv is None or qkv.numel() == 0:
+            raise TypeError(
+                "fused_qk_norm_rope_cache_quant_shuffle: non-empty `qkv` is required when "
+                "`q`, `k`, `v` are not all passed."
+            )
+        _fused_qk_norm_rope_cache_quant_shuffle_hip(
+            qkv,
+            num_heads_q,
+            num_heads_k,
+            num_heads_v,
+            head_dim,
+            eps,
+            qw,
+            kw,
+            cos_sin_cache,
+            is_neox_style,
+            pos_ids,
+            k_cache,
+            v_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+            v_scale,
+            None,
+            None,
+            None,
+        )
+        return
+    if k is None or v is None:
+        raise TypeError(
+            "fused_qk_norm_rope_cache_quant_shuffle: q, k, v must be provided together."
+        )
+    qkv_hip: Tensor = (
+        qkv
+        if qkv is not None and qkv.numel() > 0
+        else torch.empty((0, 0), device=q.device, dtype=q.dtype)
+    )
+    _fused_qk_norm_rope_cache_quant_shuffle_hip(
+        qkv_hip,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        eps,
+        qw,
+        kw,
+        cos_sin_cache,
+        is_neox_style,
+        pos_ids,
+        k_cache,
+        v_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+        q,
+        k,
+        v,
+    )
 
 
 def gen_fused_qk_rmsnorm_fake_tensor(

--- a/csrc/include/fused_qk_norm_rope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_rope_cache_quant.h
@@ -7,8 +7,8 @@ using namespace at;
 namespace aiter {
 
 void fused_qk_norm_rope_cache_quant_shuffle(
-    at::Tensor& qkv,                   // Combined QKV tensor [num_tokens,
-                                       // (num_heads_q+num_heads_k+num_heads_v)*head_dim]
+    at::Tensor& qkv, // Deprecated concatenated QKV [num_tokens, total_heads*head_dim]. May be empty
+                     // when using opt_q/opt_k/opt_v only. If both are passed, q/k/v win; qkv is ignored.
     int64_t num_heads_q,               // Number of query heads
     int64_t num_heads_k,               // Number of key heads
     int64_t num_heads_v,               // Number of value heads
@@ -25,7 +25,10 @@ void fused_qk_norm_rope_cache_quant_shuffle(
     at::Tensor& slot_mapping,          // slot mapping
     const std::string& kv_cache_dtype, // kv cache data type
     std::optional<at::Tensor> k_scale, // k scale tensor for quantized k cache
-    std::optional<at::Tensor> v_scale  // v scale tensor for quantized v cache
+    std::optional<at::Tensor> v_scale,  // v scale tensor for quantized v cache
+    std::optional<at::Tensor> opt_q = c10::nullopt, // 2D [T, Hq*D] or 3D [T, Hq, D]; arbitrary strides (kernel uses scalar path if dim stride != 1)
+    std::optional<at::Tensor> opt_k = c10::nullopt, // 2D [T, Hk*D] or 3D [T, Hk, D]
+    std::optional<at::Tensor> opt_v = c10::nullopt  // 2D [T, Hv*D] or 3D [T, Hv, D]
 );
 
 void fused_qk_norm_rope_cache_pts_quant_shuffle(at::Tensor& qkv,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1497,9 +1497,29 @@ namespace py = pybind11;
           py::arg("x"),                                     \
           py::arg("rotary_dim") = 0);
 
-#define FUSED_QKNORM_ROPE_CACHE_QUANT_PYBIND                    \
-    m.def("fused_qk_norm_rope_cache_quant_shuffle",             \
-          &aiter::fused_qk_norm_rope_cache_quant_shuffle);      \
+#define FUSED_QKNORM_ROPE_CACHE_QUANT_PYBIND                                        \
+    m.def("fused_qk_norm_rope_cache_quant_shuffle",                                 \
+          &aiter::fused_qk_norm_rope_cache_quant_shuffle,                           \
+          py::arg("qkv"),                                                          \
+          py::arg("num_heads_q"),                                                  \
+          py::arg("num_heads_k"),                                                  \
+          py::arg("num_heads_v"),                                                  \
+          py::arg("head_dim"),                                                     \
+          py::arg("eps"),                                                          \
+          py::arg("qw"),                                                           \
+          py::arg("kw"),                                                           \
+          py::arg("cos_sin_cache"),                                                \
+          py::arg("is_neox_style"),                                                \
+          py::arg("pos_ids"),                                                      \
+          py::arg("k_cache"),                                                      \
+          py::arg("v_cache"),                                                      \
+          py::arg("slot_mapping"),                                                 \
+          py::arg("kv_cache_dtype"),                                               \
+          py::arg("k_scale"),                                                      \
+          py::arg("v_scale"),                                                      \
+          py::arg("q")        = py::none(),                                        \
+          py::arg("k")        = py::none(),                                        \
+          py::arg("v")        = py::none());                                       \
     m.def("fused_qk_rmsnorm",                                   \
           &aiter::fused_qk_rmsnorm,                             \
           py::arg("q"),                                         \

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -32,6 +32,36 @@
  #define CHECK_INPUT(x) \
      CHECK_TH_CUDA(x);  \
      CHECK_CONTIGUOUS(x)
+
+namespace aiter {
+/** Map q/k/v tensor strides to logical [token, head, dim] element strides (PyTorch strides are in elements). */
+struct ActivationStrides3D
+{
+    int64_t st;
+    int64_t sh;
+    int64_t sd;
+};
+
+inline ActivationStrides3D activation_strides_logical_3d(
+    at::Tensor const& t, int64_t num_heads, int64_t head_dim)
+{
+    if(t.dim() == 2)
+    {
+        TORCH_CHECK(
+            t.size(1) == num_heads * head_dim,
+            "activation dim 1 must be num_heads * head_dim (got ",
+            t.size(1),
+            " vs ",
+            num_heads * head_dim,
+            ")");
+        return {t.stride(0), num_heads * t.stride(1), t.stride(1)};
+    }
+    TORCH_CHECK(t.dim() == 3, "q/k/v must be 2D [T, H*D] or 3D [T, H, D], got dim ", t.dim());
+    TORCH_CHECK(t.size(1) == num_heads && t.size(2) == head_dim,
+                "q/k/v 3D shape must be [T, num_heads, head_dim]");
+    return {t.stride(0), t.stride(1), t.stride(2)};
+}
+} // namespace aiter
  
  namespace {
  using mrope_utils::vec_t;
@@ -84,7 +114,20 @@
            int num_kv_heads,
            vllm::Fp8KVCacheDataType kv_dt>
  __global__ void fusedQKNormRopeQuantCacheShuffleKernel(
-     scalar_t* qkv_void,            // Combined QKV tensor
+     scalar_t* qkv_void,            // Combined QKV tensor (unused if separate_qkv)
+     bool const separate_qkv,       // If true, use q_act/k_act/v_act with [token, heads, dim] layout
+     scalar_t* q_act,               // [num_tokens, num_heads_q * head_dim] or nullptr
+     scalar_t* k_act,               // [num_tokens, num_heads_k * head_dim] or nullptr
+     scalar_t* v_act,               // [num_tokens, num_heads_v * head_dim] or nullptr
+     int64_t const q_st,
+     int64_t const q_sh,
+     int64_t const q_sd,
+     int64_t const k_st,
+     int64_t const k_sh,
+     int64_t const k_sd,
+     int64_t const v_st,
+     int64_t const v_sh,
+     int64_t const v_sd,
      int const num_heads_q,         // Number of query heads
      int const num_heads_k,         // Number of key heads
      int const num_heads_v,         // Number of value heads
@@ -132,15 +175,45 @@
      const float inverted_kscale = k_scale == nullptr ? 1.0f : 1 / (*k_scale);
      const float inverted_vscale = v_scale == nullptr ? 1.0f : 1 / (*v_scale);
  
- #pragma unroll
+     int64_t const act_st = isQ ? q_st : (isK ? k_st : v_st);
+     int64_t const act_sh = isQ ? q_sh : (isK ? k_sh : v_sh);
+     int64_t const act_sd = isQ ? q_sd : (isK ? k_sd : v_sd);
+     scalar_t* const act_base = isQ ? q_act : (isK ? k_act : v_act);
+ 
      // Load data first, suppose have no tail since we check the head_dim is multiple of 32 before
      // kernel launch
-     for(int i = 0; i < load_loop_cnt; i += 1)
+     if(!separate_qkv)
      {
-         int64_t offsetWarp = (tokenIdx * num_heads * head_dim + localHeadIdx * head_dim +
-                               laneId * numElemsPerThread) /
-                              vec_size;
-         reinterpret_cast<ltype*>(elements)[i] = reinterpret_cast<ltype*>(qkv_void)[offsetWarp + i];
+ #pragma unroll
+         for(int i = 0; i < load_loop_cnt; i += 1)
+         {
+             int64_t offsetWarp = (tokenIdx * num_heads * head_dim + localHeadIdx * head_dim +
+                                   laneId * numElemsPerThread) /
+                                  vec_size;
+             reinterpret_cast<ltype*>(elements)[i] =
+                 reinterpret_cast<ltype*>(qkv_void)[offsetWarp + i];
+         }
+     }
+     else if(act_sd == 1)
+     {
+         int64_t const base_elems = (int64_t)tokenIdx * act_st + (int64_t)headIdx * act_sh +
+                                    (int64_t)(laneId * numElemsPerThread);
+ #pragma unroll
+         for(int i = 0; i < load_loop_cnt; i += 1)
+         {
+             reinterpret_cast<ltype*>(elements)[i] =
+                 *reinterpret_cast<ltype const*>(act_base + base_elems + i * vec_size);
+         }
+     }
+     else
+     {
+ #pragma unroll
+         for(int j = 0; j < numElemsPerThread; j++)
+         {
+             int64_t const off = (int64_t)tokenIdx * act_st + (int64_t)headIdx * act_sh +
+                                 (int64_t)(laneId * numElemsPerThread + j) * act_sd;
+             elements[j] = act_base[off];
+         }
      }
  
      // If qk, we adopt RMSNorm + RoPE, so we need to compute sum of squares.
@@ -226,14 +299,42 @@
              }
              __syncwarp();
          }
- #pragma unroll
-         for(int i = 0; i < load_loop_cnt; i += 1)
+         int64_t const qk_st = isQ ? q_st : k_st;
+         int64_t const qk_sh = isQ ? q_sh : k_sh;
+         int64_t const qk_sd = isQ ? q_sd : k_sd;
+         scalar_t* const qk_dst = isQ ? q_act : k_act;
+         if(!separate_qkv)
          {
-             int64_t offsetWarp = (tokenIdx * num_heads * head_dim + localHeadIdx * head_dim +
-                                   laneId * numElemsPerThread) /
-                                  vec_size;
-             reinterpret_cast<ltype*>(qkv_void)[offsetWarp + i] =
-                 reinterpret_cast<ltype*>(elements)[i];
+ #pragma unroll
+             for(int i = 0; i < load_loop_cnt; i += 1)
+             {
+                 int64_t offsetWarp = (tokenIdx * num_heads * head_dim + localHeadIdx * head_dim +
+                                       laneId * numElemsPerThread) /
+                                      vec_size;
+                 reinterpret_cast<ltype*>(qkv_void)[offsetWarp + i] =
+                     reinterpret_cast<ltype*>(elements)[i];
+             }
+         }
+         else if(qk_sd == 1)
+         {
+             int64_t const base_elems = (int64_t)tokenIdx * qk_st + (int64_t)headIdx * qk_sh +
+                                          (int64_t)(laneId * numElemsPerThread);
+ #pragma unroll
+             for(int i = 0; i < load_loop_cnt; i += 1)
+             {
+                 *reinterpret_cast<ltype*>(qk_dst + base_elems + i * vec_size) =
+                     reinterpret_cast<ltype*>(elements)[i];
+             }
+         }
+         else
+         {
+ #pragma unroll
+             for(int j = 0; j < numElemsPerThread; j++)
+             {
+                 int64_t const off = (int64_t)tokenIdx * qk_st + (int64_t)headIdx * qk_sh +
+                                     (int64_t)(laneId * numElemsPerThread + j) * qk_sd;
+                 qk_dst[off] = elements[j];
+             }
          }
      }
  
@@ -870,6 +971,19 @@
  
  template <typename scalar_t, typename kv_cache_scalar_t, vllm::Fp8KVCacheDataType kv_dt>
  void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
+                                             bool const separate_qkv,
+                                             scalar_t* q_act,
+                                             scalar_t* k_act,
+                                             scalar_t* v_act,
+                                             int64_t const q_st,
+                                             int64_t const q_sh,
+                                             int64_t const q_sd,
+                                             int64_t const k_st,
+                                             int64_t const k_sh,
+                                             int64_t const k_sd,
+                                             int64_t const v_st,
+                                             int64_t const v_sh,
+                                             int64_t const v_sd,
                                              int const num_tokens,
                                              int const num_heads_q,
                                              int const num_heads_k,
@@ -910,6 +1024,19 @@
                                                     NUM_KV_HEADS,
                                                     kv_dt>
                  <<<gridDim, blockDim, 0, stream>>>(qkv,
+                                                    separate_qkv,
+                                                    q_act,
+                                                    k_act,
+                                                    v_act,
+                                                    q_st,
+                                                    q_sh,
+                                                    q_sd,
+                                                    k_st,
+                                                    k_sh,
+                                                    k_sd,
+                                                    v_st,
+                                                    v_sh,
+                                                    v_sd,
                                                     num_heads_q,
                                                     num_heads_k,
                                                     num_heads_v,
@@ -937,6 +1064,19 @@
                                                     NUM_KV_HEADS,
                                                     kv_dt>
                  <<<gridDim, blockDim, 0, stream>>>(qkv,
+                                                    separate_qkv,
+                                                    q_act,
+                                                    k_act,
+                                                    v_act,
+                                                    q_st,
+                                                    q_sh,
+                                                    q_sd,
+                                                    k_st,
+                                                    k_sh,
+                                                    k_sd,
+                                                    v_st,
+                                                    v_sh,
+                                                    v_sd,
                                                     num_heads_q,
                                                     num_heads_k,
                                                     num_heads_v,
@@ -964,6 +1104,19 @@
                                                     NUM_KV_HEADS,
                                                     kv_dt>
                  <<<gridDim, blockDim, 0, stream>>>(qkv,
+                                                    separate_qkv,
+                                                    q_act,
+                                                    k_act,
+                                                    v_act,
+                                                    q_st,
+                                                    q_sh,
+                                                    q_sd,
+                                                    k_st,
+                                                    k_sh,
+                                                    k_sd,
+                                                    v_st,
+                                                    v_sh,
+                                                    v_sd,
                                                     num_heads_q,
                                                     num_heads_k,
                                                     num_heads_v,
@@ -1116,28 +1269,6 @@ void launchFusedQKNormRopeBlockQuantCacheShuffle(scalar_t* qkv,
     }
 }
  } // namespace
- #define CALL_QK_NORM_ROPE_CACHE_QUANT(SRC_T, CACHE_T, KV_DTYPE)       \
-     launchFusedQKNormRopeQuantCacheShuffle<SRC_T, CACHE_T, KV_DTYPE>( \
-         reinterpret_cast<SRC_T*>(qkv.data_ptr()),                     \
-         num_tokens,                                                   \
-         num_heads_q,                                                  \
-         num_heads_k,                                                  \
-         num_heads_v,                                                  \
-         head_dim,                                                     \
-         eps,                                                          \
-         reinterpret_cast<SRC_T*>(q_weight.data_ptr()),                \
-         reinterpret_cast<SRC_T*>(k_weight.data_ptr()),                \
-         reinterpret_cast<SRC_T*>(cos_sin_cache.data_ptr()),           \
-         !is_neox,                                                     \
-         position_ids.data_ptr<int64_t>(),                             \
-         reinterpret_cast<CACHE_T*>(k_cache.data_ptr()),               \
-         reinterpret_cast<CACHE_T*>(v_cache.data_ptr()),               \
-         slot_mapping.data_ptr<int64_t>(),                             \
-         k_scale.has_value() ? k_scale->data_ptr<float>() : nullptr,   \
-         v_scale.has_value() ? v_scale->data_ptr<float>() : nullptr,   \
-         page_size,                                                    \
-         x,                                                            \
-         stream);
  #define CALL_QK_NORM_ROPE_CACHE_BLOCK_QUANT(SRC_T, CACHE_T, KV_DTYPE)       \
          launchFusedQKNormRopeBlockQuantCacheShuffle<SRC_T, CACHE_T, KV_DTYPE>( \
              reinterpret_cast<SRC_T*>(qkv.data_ptr()),                     \
@@ -1164,27 +1295,40 @@ void launchFusedQKNormRopeBlockQuantCacheShuffle(scalar_t* qkv,
              max_tokens_per_batch,                                         \
              stream);
 
-#define CALL_QK_NORM_ROPE_CACHE_QUANT(SRC_T, CACHE_T, KV_DTYPE)       \
-    launchFusedQKNormRopeQuantCacheShuffle<SRC_T, CACHE_T, KV_DTYPE>( \
-        reinterpret_cast<SRC_T*>(qkv.data_ptr()),                     \
-        num_tokens,                                                   \
-        num_heads_q,                                                  \
-        num_heads_k,                                                  \
-        num_heads_v,                                                  \
-        head_dim,                                                     \
-        eps,                                                          \
-        reinterpret_cast<SRC_T*>(q_weight.data_ptr()),                \
-        reinterpret_cast<SRC_T*>(k_weight.data_ptr()),                \
-        reinterpret_cast<SRC_T*>(cos_sin_cache.data_ptr()),           \
-        !is_neox,                                                     \
-        position_ids.data_ptr<int64_t>(),                             \
-        reinterpret_cast<CACHE_T*>(k_cache.data_ptr()),               \
-        reinterpret_cast<CACHE_T*>(v_cache.data_ptr()),               \
-        slot_mapping.data_ptr<int64_t>(),                             \
-        k_scale.has_value() ? k_scale->data_ptr<float>() : nullptr,   \
-        v_scale.has_value() ? v_scale->data_ptr<float>() : nullptr,   \
-        page_size,                                                    \
-        x,                                                            \
+#define CALL_QK_NORM_ROPE_CACHE_QUANT(SRC_T, CACHE_T, KV_DTYPE)                                    \
+    launchFusedQKNormRopeQuantCacheShuffle<SRC_T, CACHE_T, KV_DTYPE>(                               \
+        use_separate ? nullptr : reinterpret_cast<SRC_T*>(qkv.data_ptr()),                      \
+        use_separate,                                                                             \
+        use_separate ? reinterpret_cast<SRC_T*>(opt_q.value().data_ptr()) : nullptr,             \
+        use_separate ? reinterpret_cast<SRC_T*>(opt_k.value().data_ptr()) : nullptr,             \
+        use_separate ? reinterpret_cast<SRC_T*>(opt_v.value().data_ptr()) : nullptr,             \
+        q_stride_token,                                                                           \
+        q_stride_head,                                                                            \
+        q_stride_dim,                                                                             \
+        k_stride_token,                                                                           \
+        k_stride_head,                                                                            \
+        k_stride_dim,                                                                             \
+        v_stride_token,                                                                           \
+        v_stride_head,                                                                            \
+        v_stride_dim,                                                                             \
+        num_tokens,                                                                               \
+        num_heads_q,                                                                              \
+        num_heads_k,                                                                              \
+        num_heads_v,                                                                              \
+        head_dim,                                                                                 \
+        eps,                                                                                      \
+        reinterpret_cast<SRC_T*>(q_weight.data_ptr()),                                            \
+        reinterpret_cast<SRC_T*>(k_weight.data_ptr()),                                            \
+        reinterpret_cast<SRC_T*>(cos_sin_cache.data_ptr()),                                       \
+        !is_neox,                                                                                 \
+        position_ids.data_ptr<int64_t>(),                                                         \
+        reinterpret_cast<CACHE_T*>(k_cache.data_ptr()),                                         \
+        reinterpret_cast<CACHE_T*>(v_cache.data_ptr()),                                         \
+        slot_mapping.data_ptr<int64_t>(),                                                         \
+        k_scale.has_value() ? k_scale->data_ptr<float>() : nullptr,                             \
+        v_scale.has_value() ? v_scale->data_ptr<float>() : nullptr,                             \
+        page_size,                                                                                \
+        x,                                                                                        \
         stream);
 
 template <typename T, int HEAD_SIZE, bool IS_NEOX>
@@ -1471,8 +1615,7 @@ void fused_rope_rms_2way(const T* q0,
 namespace aiter {
 
 void fused_qk_norm_rope_cache_quant_shuffle(
-    at::Tensor& qkv,                   // Combined QKV tensor [num_tokens,
-                                       // (num_heads_q+num_heads_k+num_heads_v)*head_dim]
+    at::Tensor& qkv, // Deprecated concat QKV; empty if only q/k/v. If both given, q/k/v used; qkv ignored.
     int64_t num_heads_q,               // Number of query heads
     int64_t num_heads_k,               // Number of key heads
     int64_t num_heads_v,               // Number of value heads
@@ -1489,11 +1632,22 @@ void fused_qk_norm_rope_cache_quant_shuffle(
     at::Tensor& slot_mapping,          // slot mapping
     const std::string& kv_cache_dtype, // kv cache data type
     std::optional<at::Tensor> k_scale, // k scale tensor for quantized k cache
-    std::optional<at::Tensor> v_scale  // v scale tensor for quantized v cache
+    std::optional<at::Tensor> v_scale,  // v scale tensor for quantized v cache
+    std::optional<at::Tensor> opt_q,    // [num_tokens, num_heads_q * head_dim] (preferred)
+    std::optional<at::Tensor> opt_k,    // [num_tokens, num_heads_k * head_dim]
+    std::optional<at::Tensor> opt_v     // [num_tokens, num_heads_v * head_dim]
 )
 {
-    // Input validation
-    CHECK_INPUT(qkv);
+    const bool have_q = opt_q.has_value();
+    const bool have_k = opt_k.has_value();
+    const bool have_v = opt_v.has_value();
+    const bool any_sep = have_q || have_k || have_v;
+    TORCH_CHECK(
+        !any_sep || (have_q && have_k && have_v),
+        "fused_qk_norm_rope_cache_quant_shuffle: pass all of q, k, v together, or omit all three.");
+    const bool use_separate = have_q && have_k && have_v;
+    const bool have_qkv   = qkv.numel() > 0;
+
     CHECK_INPUT(position_ids);
     CHECK_INPUT(q_weight);
     CHECK_INPUT(k_weight);
@@ -1504,9 +1658,6 @@ void fused_qk_norm_rope_cache_quant_shuffle(
     CHECK_TYPE(position_ids, torch::kInt64);
     CHECK_TYPE(slot_mapping, torch::kInt64);
 
-    TORCH_CHECK(qkv.dim() == 2,
-                "QKV tensor must be 2D: [num_tokens, "
-                "(num_heads_q+num_heads_k+num_heads_v)*head_dim]");
     TORCH_CHECK(position_ids.dim() == 1, "Position IDs must be 1D: [num_tokens]");
     TORCH_CHECK(q_weight.dim() == 1, "Query weights must be 1D: [head_dim]");
     TORCH_CHECK(k_weight.dim() == 1, "Key weights must be 1D: [head_dim]");
@@ -1514,18 +1665,119 @@ void fused_qk_norm_rope_cache_quant_shuffle(
     TORCH_CHECK(q_weight.size(0) == head_dim, "Query weights size must match head dimension");
     TORCH_CHECK(k_weight.size(0) == head_dim, "Key weights size must match head dimension");
     TORCH_CHECK(cos_sin_cache.size(1) == head_dim, "Cos/sin cache dimension must match head_dim");
-    TORCH_CHECK(qkv.scalar_type() == q_weight.scalar_type() &&
-                    qkv.scalar_type() == k_weight.scalar_type(),
-                "qkv, q_weight and k_weight must have the same dtype");
     TORCH_CHECK(head_dim % 32 == 0,
                 "Head dimension must be multiple of 32 for fused QK Norm RoPE kernel");
     TORCH_CHECK(
         num_heads_k <= 32,
         "Number of key heads must be less than or equal to 32 for fused QK Norm RoPE kernel");
 
-    int64_t num_tokens = qkv.size(0);
+    int64_t num_tokens = 0;
+    at::ScalarType act_dtype = at::ScalarType::Undefined;
+
+    int64_t q_stride_token = 0, q_stride_head = 0, q_stride_dim = 0;
+    int64_t k_stride_token = 0, k_stride_head = 0, k_stride_dim = 0;
+    int64_t v_stride_token = 0, v_stride_head = 0, v_stride_dim = 0;
+
+    if(use_separate)
+    {
+        at::Tensor const& q_t = opt_q.value();
+        at::Tensor const& k_t = opt_k.value();
+        at::Tensor const& v_t = opt_v.value();
+        CHECK_TH_CUDA(q_t);
+        CHECK_TH_CUDA(k_t);
+        CHECK_TH_CUDA(v_t);
+        TORCH_CHECK(
+            (q_t.dim() == 2 || q_t.dim() == 3) && (k_t.dim() == 2 || k_t.dim() == 3) &&
+                (v_t.dim() == 2 || v_t.dim() == 3),
+            "q, k, v must be 2D [num_tokens, num_heads * head_dim] or 3D [num_tokens, num_heads, head_dim]");
+        num_tokens = q_t.size(0);
+        TORCH_CHECK(k_t.size(0) == num_tokens && v_t.size(0) == num_tokens,
+                    "q, k, v must share the same num_tokens");
+        if(q_t.dim() == 2)
+        {
+            TORCH_CHECK(q_t.size(1) == num_heads_q * head_dim,
+                        "q dim 1 must be num_heads_q * head_dim");
+        }
+        else
+        {
+            TORCH_CHECK(q_t.size(1) == num_heads_q && q_t.size(2) == head_dim,
+                        "q 3D shape must be [num_tokens, num_heads_q, head_dim]");
+        }
+        if(k_t.dim() == 2)
+        {
+            TORCH_CHECK(k_t.size(1) == num_heads_k * head_dim,
+                        "k dim 1 must be num_heads_k * head_dim");
+        }
+        else
+        {
+            TORCH_CHECK(k_t.size(1) == num_heads_k && k_t.size(2) == head_dim,
+                        "k 3D shape must be [num_tokens, num_heads_k, head_dim]");
+        }
+        if(v_t.dim() == 2)
+        {
+            TORCH_CHECK(v_t.size(1) == num_heads_v * head_dim,
+                        "v dim 1 must be num_heads_v * head_dim");
+        }
+        else
+        {
+            TORCH_CHECK(v_t.size(1) == num_heads_v && v_t.size(2) == head_dim,
+                        "v 3D shape must be [num_tokens, num_heads_v, head_dim]");
+        }
+        TORCH_CHECK(q_t.scalar_type() == k_t.scalar_type() && q_t.scalar_type() == v_t.scalar_type(),
+                    "q, k, v must share the same dtype");
+        TORCH_CHECK(q_t.scalar_type() == q_weight.scalar_type() &&
+                        q_t.scalar_type() == k_weight.scalar_type(),
+                    "q/k/v must match q_weight/k_weight dtype");
+        act_dtype = q_t.scalar_type();
+        ActivationStrides3D const sq = activation_strides_logical_3d(q_t, num_heads_q, head_dim);
+        ActivationStrides3D const sk = activation_strides_logical_3d(k_t, num_heads_k, head_dim);
+        ActivationStrides3D const sv = activation_strides_logical_3d(v_t, num_heads_v, head_dim);
+        q_stride_token = sq.st;
+        q_stride_head    = sq.sh;
+        q_stride_dim     = sq.sd;
+        k_stride_token   = sk.st;
+        k_stride_head    = sk.sh;
+        k_stride_dim     = sk.sd;
+        v_stride_token   = sv.st;
+        v_stride_head    = sv.sh;
+        v_stride_dim     = sv.sd;
+        if(have_qkv)
+        {
+            TORCH_WARN_ONCE(
+                "fused_qk_norm_rope_cache_quant_shuffle: `qkv` is deprecated and will be removed. "
+                "Separate `q`, `k`, `v` were also passed; the kernel uses `q/k/v` in-place and ignores `qkv`.");
+            int64_t const total_heads = num_heads_q + num_heads_k + num_heads_v;
+            TORCH_CHECK(qkv.dim() == 2,
+                        "When passing both qkv and q/k/v, qkv must be 2D [num_tokens, total_heads*head_dim]");
+            TORCH_CHECK(qkv.size(0) == num_tokens && qkv.size(1) == total_heads * head_dim,
+                        "When passing both qkv and q/k/v, qkv shape must be [num_tokens, (nh_q+nh_k+nh_v)*head_dim] "
+                        "(qkv is unused but must be consistent).");
+            TORCH_CHECK(qkv.scalar_type() == q_t.scalar_type(),
+                        "When passing both qkv and q/k/v, qkv dtype must match q/k/v.");
+            CHECK_INPUT(qkv);
+        }
+    }
+    else
+    {
+        TORCH_CHECK(
+            have_qkv,
+            "fused_qk_norm_rope_cache_quant_shuffle: pass non-empty `qkv`, or pass all of `q`, `k`, `v`.");
+        TORCH_WARN_ONCE(
+            "fused_qk_norm_rope_cache_quant_shuffle: the concatenated `qkv` input alone is deprecated and "
+            "will be removed; prefer separate `q`, `k`, `v` tensors.");
+        CHECK_INPUT(qkv);
+        TORCH_CHECK(qkv.dim() == 2,
+                    "QKV tensor must be 2D: [num_tokens, "
+                    "(num_heads_q+num_heads_k+num_heads_v)*head_dim]");
+        TORCH_CHECK(qkv.scalar_type() == q_weight.scalar_type() &&
+                        qkv.scalar_type() == k_weight.scalar_type(),
+                    "qkv, q_weight and k_weight must have the same dtype");
+        num_tokens = qkv.size(0);
+        act_dtype  = qkv.scalar_type();
+    }
+
     TORCH_CHECK(position_ids.size(0) == num_tokens,
-                "Number of tokens in position_ids must match QKV");
+                "Number of tokens in position_ids must match activations");
 
     TORCH_CHECK(k_cache.dim() == 5,
                 "k_cache must be 5D [num_blocks, num_kv_heads, head_dim//x, page_size, x], got dim ",
@@ -1602,13 +1854,17 @@ void fused_qk_norm_rope_cache_quant_shuffle(
                     v_cache.dim());
     }
 
-    int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
-    TORCH_CHECK(qkv.size(1) == total_heads * head_dim,
-                "QKV tensor size must match total number of heads and head dimension");
+    if(!use_separate)
+    {
+        int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
+        TORCH_CHECK(qkv.size(1) == total_heads * head_dim,
+                    "QKV tensor size must match total number of heads and head dimension");
+    }
 
-    auto stream = at::hip::getCurrentHIPStream(qkv.get_device());
+    const int64_t stream_device = use_separate ? opt_q.value().get_device() : qkv.get_device();
+    auto stream                 = at::hip::getCurrentHIPStream(stream_device);
 
-    DISPATCH_BY_KV_CACHE_DTYPE(qkv.scalar_type(), kv_cache_dtype, CALL_QK_NORM_ROPE_CACHE_QUANT);
+    DISPATCH_BY_KV_CACHE_DTYPE(act_dtype, kv_cache_dtype, CALL_QK_NORM_ROPE_CACHE_QUANT);
 }
 
 template <typename T>

--- a/op_tests/test_fused_qk_norm_rope_cache_quant.py
+++ b/op_tests/test_fused_qk_norm_rope_cache_quant.py
@@ -164,22 +164,22 @@ def run_aiter_qk_norm_rope_cache_quant_shuffle(
 
     aiter.fused_qk_norm_rope_cache_quant_shuffle(
         qkv,
-        num_heads_q,
-        num_heads_k,
-        num_heads_v,
-        head_size,
-        eps,
-        qw,
-        kw,
-        cos_sin,
-        is_neox_style,
-        positions,
-        k_cache,
-        v_cache,
-        slot_mapping,
-        kv_cache_dtype,
-        k_scale,
-        v_scale,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        num_heads_v=num_heads_v,
+        head_dim=head_size,
+        eps=eps,
+        qw=qw,
+        kw=kw,
+        cos_sin_cache=cos_sin,
+        is_neox_style=is_neox_style,
+        pos_ids=positions,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        slot_mapping=slot_mapping,
+        kv_cache_dtype=kv_cache_dtype,
+        k_scale=k_scale,
+        v_scale=v_scale,
     )
 
     q_size = num_heads_q * head_size
@@ -189,6 +189,425 @@ def run_aiter_qk_norm_rope_cache_quant_shuffle(
     qkv = qkv.view(num_tokens, q_size + k_size + v_size)
     q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
     return q, k, v, k_cache, v_cache
+
+
+@perftest()
+def run_aiter_qk_norm_rope_cache_quant_shuffle_separate(
+    qkv: Tensor,
+    qw: Tensor,
+    kw: Tensor,
+    cos_sin: Tensor,
+    positions: Tensor,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_size: int,
+    is_neox_style: bool,
+    eps: float,
+    k_cache: Tensor,
+    v_cache: Tensor,
+    slot_mapping: Tensor,
+    kv_cache_dtype: str,
+    k_scale: Tensor,
+    v_scale: Tensor,
+):
+    """Same as run_aiter_qk_norm_rope_cache_quant_shuffle but exercises q/k/v inputs."""
+    q_size = num_heads_q * head_size
+    k_size = num_heads_k * head_size
+    v_size = num_heads_v * head_size
+    qkv_c = qkv.clone()
+    qkv_2d = qkv_c.view(num_tokens, q_size + k_size + v_size)
+    # 与 concat qkv 同一块存储上 split 出的视图（通常非 contiguous）
+    q = qkv_2d[:, :q_size]
+    k = qkv_2d[:, q_size : q_size + k_size]
+    v = qkv_2d[:, q_size + k_size :]
+    aiter.fused_qk_norm_rope_cache_quant_shuffle(
+        None,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        num_heads_v=num_heads_v,
+        head_dim=head_size,
+        eps=eps,
+        qw=qw,
+        kw=kw,
+        cos_sin_cache=cos_sin,
+        is_neox_style=is_neox_style,
+        pos_ids=positions,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        slot_mapping=slot_mapping,
+        kv_cache_dtype=kv_cache_dtype,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        q=q,
+        k=k,
+        v=v,
+    )
+    return q, k, v, k_cache, v_cache
+
+
+@benchmark()
+def test_shuffle_separate_inputs_match_concat_qkv():
+    """fused_qk_norm_rope_cache_quant_shuffle: q/k/v path matches legacy concatenated qkv."""
+    dtype = torch.bfloat16
+    num_tokens = 11
+    num_heads_q = num_heads_k = num_heads_v = 2
+    head_size = 128
+    is_neox_style = False
+    eps = 1e-6
+    kv_cache_dtype = "auto"
+    num_blocks = 4
+    page_size = 16
+    max_positions = 4096
+
+    k_cache = torch.randn(
+        [num_blocks, page_size, num_heads_k, head_size],
+        dtype=dtype,
+        device="cuda",
+    )
+    v_cache = torch.randn(
+        [num_blocks, page_size, num_heads_v, head_size],
+        dtype=dtype,
+        device="cuda",
+    )
+    x = 16 // k_cache.element_size()
+    k_cache = (
+        k_cache.view([num_blocks, page_size, num_heads_k, head_size // x, x])
+        .permute(0, 2, 3, 1, 4)
+        .contiguous()
+    )
+    v_cache = v_cache.permute(0, 2, 3, 1).contiguous()
+    slot_mapping = torch.randperm(num_tokens, dtype=torch.int64, device="cuda")
+    k_scale = torch.zeros(
+        [num_blocks, num_heads_k, page_size], dtype=torch.float32, device="cuda"
+    )
+    v_scale = torch.zeros(
+        [num_blocks, num_heads_v, page_size], dtype=torch.float32, device="cuda"
+    )
+    qkv = torch.randn(
+        (num_tokens, (num_heads_q + num_heads_k + num_heads_v) * head_size),
+        dtype=dtype,
+        device="cuda",
+    )
+    qw = torch.randn(head_size, dtype=dtype, device="cuda")
+    kw = torch.randn(head_size, dtype=dtype, device="cuda")
+    cos_sin = torch.randn((max_positions, head_size), dtype=dtype, device="cuda")
+    positions = torch.randint(
+        0, max_positions, (num_tokens,), dtype=torch.int64, device="cuda"
+    )
+
+    k_cache_c = k_cache.clone()
+    v_cache_c = v_cache.clone()
+    k_scale_c = k_scale.clone()
+    v_scale_c = v_scale.clone()
+    qkv_c = qkv.clone()
+
+    (q1, k1, v1, kc1, vc1), _ = run_aiter_qk_norm_rope_cache_quant_shuffle(
+        qkv,
+        qw,
+        kw,
+        cos_sin,
+        positions,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_size,
+        is_neox_style,
+        eps,
+        k_cache,
+        v_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )
+
+    (q2, k2, v2, kc2, vc2), _ = run_aiter_qk_norm_rope_cache_quant_shuffle_separate(
+        qkv_c,
+        qw,
+        kw,
+        cos_sin,
+        positions,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_size,
+        is_neox_style,
+        eps,
+        k_cache_c,
+        v_cache_c,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale_c,
+        v_scale_c,
+    )
+
+    checkAllclose(q1, q2, msg="q separate vs qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(k1, k2, msg="k separate vs qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(v1, v2, msg="v separate vs qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(kc1.float(), kc2.float(), msg="k_cache", rtol=1e-2, atol=0.05)
+    checkAllclose(vc1.float(), vc2.float(), msg="v_cache", rtol=1e-2, atol=0.05)
+    checkAllclose(k_scale, k_scale_c, msg="k_scale", rtol=1e-2, atol=0.05)
+    checkAllclose(v_scale, v_scale_c, msg="v_scale", rtol=1e-2, atol=0.05)
+
+
+@benchmark()
+def test_shuffle_noncontiguous_qkv_matches_contiguous():
+    """q/k/v 仅从拼接 qkv 的 view 上 slice 得到（同一行存储、stride0 为总宽，通常非 contiguous），与 concat qkv 路径一致。"""
+    dtype = torch.bfloat16
+    num_tokens = 11
+    num_heads_q = num_heads_k = num_heads_v = 2
+    head_size = 128
+    is_neox_style = False
+    eps = 1e-6
+    kv_cache_dtype = "auto"
+    num_blocks = 4
+    page_size = 16
+    max_positions = 4096
+
+    k_cache = torch.randn(
+        [num_blocks, page_size, num_heads_k, head_size],
+        dtype=dtype,
+        device="cuda",
+    )
+    v_cache = torch.randn(
+        [num_blocks, page_size, num_heads_v, head_size],
+        dtype=dtype,
+        device="cuda",
+    )
+    x = 16 // k_cache.element_size()
+    k_cache = (
+        k_cache.view([num_blocks, page_size, num_heads_k, head_size // x, x])
+        .permute(0, 2, 3, 1, 4)
+        .contiguous()
+    )
+    v_cache = v_cache.permute(0, 2, 3, 1).contiguous()
+    slot_mapping = torch.randperm(num_tokens, dtype=torch.int64, device="cuda")
+    k_scale = torch.zeros(
+        [num_blocks, num_heads_k, page_size], dtype=torch.float32, device="cuda"
+    )
+    v_scale = torch.zeros(
+        [num_blocks, num_heads_v, page_size], dtype=torch.float32, device="cuda"
+    )
+    qw = torch.randn(head_size, dtype=dtype, device="cuda")
+    kw = torch.randn(head_size, dtype=dtype, device="cuda")
+    cos_sin = torch.randn((max_positions, head_size), dtype=dtype, device="cuda")
+    positions = torch.randint(
+        0, max_positions, (num_tokens,), dtype=torch.int64, device="cuda"
+    )
+
+    qs = num_heads_q * head_size
+    ks = num_heads_k * head_size
+    vs = num_heads_v * head_size
+    total = qs + ks + vs
+    flat = torch.randn((num_tokens, total), dtype=dtype, device="cuda")
+
+    buf_ref = flat.clone()
+    k_cache_ref = k_cache.clone()
+    v_cache_ref = v_cache.clone()
+    k_scale_ref = k_scale.clone()
+    v_scale_ref = v_scale.clone()
+    (q_ref, k_ref, v_ref, kc_ref, vc_ref), _ = (
+        run_aiter_qk_norm_rope_cache_quant_shuffle(
+            buf_ref,
+            qw,
+            kw,
+            cos_sin,
+            positions,
+            num_tokens,
+            num_heads_q,
+            num_heads_k,
+            num_heads_v,
+            head_size,
+            is_neox_style,
+            eps,
+            k_cache_ref,
+            v_cache_ref,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale_ref,
+            v_scale_ref,
+        )
+    )
+
+    buf = flat.clone()
+    k_cache_a = k_cache.clone()
+    v_cache_a = v_cache.clone()
+    k_scale_a = k_scale.clone()
+    v_scale_a = v_scale.clone()
+    qkv_2d = buf.view(num_tokens, total)
+    q_nc = qkv_2d[:, :qs]
+    k_nc = qkv_2d[:, qs : qs + ks]
+    v_nc = qkv_2d[:, qs + ks :]
+    assert not q_nc.is_contiguous()
+    assert not k_nc.is_contiguous()
+    assert not v_nc.is_contiguous()
+
+    aiter.fused_qk_norm_rope_cache_quant_shuffle(
+        qkv=None,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        num_heads_v=num_heads_v,
+        head_dim=head_size,
+        eps=eps,
+        qw=qw,
+        kw=kw,
+        cos_sin_cache=cos_sin,
+        is_neox_style=is_neox_style,
+        pos_ids=positions,
+        k_cache=k_cache_a,
+        v_cache=v_cache_a,
+        slot_mapping=slot_mapping,
+        kv_cache_dtype=kv_cache_dtype,
+        k_scale=k_scale_a,
+        v_scale=v_scale_a,
+        q=q_nc,
+        k=k_nc,
+        v=v_nc,
+    )
+
+    checkAllclose(q_nc, q_ref, msg="q split-view vs concat qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(k_nc, k_ref, msg="k split-view vs concat qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(v_nc, v_ref, msg="v split-view vs concat qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(
+        k_cache_a.float(), kc_ref.float(), msg="k_cache", rtol=1e-2, atol=0.05
+    )
+    checkAllclose(
+        v_cache_a.float(), vc_ref.float(), msg="v_cache", rtol=1e-2, atol=0.05
+    )
+    checkAllclose(k_scale_a, k_scale_ref, msg="k_scale", rtol=1e-2, atol=0.05)
+    checkAllclose(v_scale_a, v_scale_ref, msg="v_scale", rtol=1e-2, atol=0.05)
+
+
+@benchmark()
+def test_shuffle_when_qkv_and_qkv_tensors_both_passed_uses_qk_v():
+    """同时传入拼接 qkv 与 q/k/v 时走 q/k/v；qkv 内容应被忽略。"""
+    dtype = torch.bfloat16
+    num_tokens = 9
+    num_heads_q = num_heads_k = num_heads_v = 2
+    head_size = 128
+    is_neox_style = False
+    eps = 1e-6
+    kv_cache_dtype = "auto"
+    num_blocks = 3
+    page_size = 16
+    max_positions = 2048
+
+    def make_kv_caches():
+        kc = torch.randn(
+            [num_blocks, page_size, num_heads_k, head_size],
+            dtype=dtype,
+            device="cuda",
+        )
+        vc = torch.randn(
+            [num_blocks, page_size, num_heads_v, head_size],
+            dtype=dtype,
+            device="cuda",
+        )
+        x_ = 16 // kc.element_size()
+        kc = (
+            kc.view([num_blocks, page_size, num_heads_k, head_size // x_, x_])
+            .permute(0, 2, 3, 1, 4)
+            .contiguous()
+        )
+        vc = vc.permute(0, 2, 3, 1).contiguous()
+        return kc, vc
+
+    slot_mapping = torch.randperm(num_tokens, dtype=torch.int64, device="cuda")
+    qkv_truth = torch.randn(
+        (num_tokens, (num_heads_q + num_heads_k + num_heads_v) * head_size),
+        dtype=dtype,
+        device="cuda",
+    )
+    qw = torch.randn(head_size, dtype=dtype, device="cuda")
+    kw = torch.randn(head_size, dtype=dtype, device="cuda")
+    cos_sin = torch.randn((max_positions, head_size), dtype=dtype, device="cuda")
+    positions = torch.randint(
+        0, max_positions, (num_tokens,), dtype=torch.int64, device="cuda"
+    )
+
+    qs = int(num_heads_q * head_size)
+    ks = int(num_heads_k * head_size)
+    vs = int(num_heads_v * head_size)
+    flat = qkv_truth.view(num_tokens, qs + ks + vs)
+    q_src = flat[:, :qs].contiguous()
+    k_src = flat[:, qs : qs + ks].contiguous()
+    v_src = flat[:, qs + ks :].contiguous()
+
+    k_cache_a, v_cache_a = make_kv_caches()
+    k_scale_a = torch.zeros(
+        [num_blocks, num_heads_k, page_size], dtype=torch.float32, device="cuda"
+    )
+    v_scale_a = torch.zeros(
+        [num_blocks, num_heads_v, page_size], dtype=torch.float32, device="cuda"
+    )
+    qkv_decoy = torch.randn_like(qkv_truth)
+
+    q_a, k_a, v_a = q_src.clone(), k_src.clone(), v_src.clone()
+    aiter.fused_qk_norm_rope_cache_quant_shuffle(
+        qkv_decoy,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        num_heads_v=num_heads_v,
+        head_dim=head_size,
+        eps=eps,
+        qw=qw,
+        kw=kw,
+        cos_sin_cache=cos_sin,
+        is_neox_style=is_neox_style,
+        pos_ids=positions,
+        k_cache=k_cache_a,
+        v_cache=v_cache_a,
+        slot_mapping=slot_mapping,
+        kv_cache_dtype=kv_cache_dtype,
+        k_scale=k_scale_a,
+        v_scale=v_scale_a,
+        q=q_a,
+        k=k_a,
+        v=v_a,
+    )
+
+    k_cache_b, v_cache_b = make_kv_caches()
+    k_scale_b = torch.zeros_like(k_scale_a)
+    v_scale_b = torch.zeros_like(v_scale_a)
+    q_b, k_b, v_b = q_src.clone(), k_src.clone(), v_src.clone()
+    aiter.fused_qk_norm_rope_cache_quant_shuffle(
+        qkv_truth.clone(),
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        num_heads_v=num_heads_v,
+        head_dim=head_size,
+        eps=eps,
+        qw=qw,
+        kw=kw,
+        cos_sin_cache=cos_sin,
+        is_neox_style=is_neox_style,
+        pos_ids=positions,
+        k_cache=k_cache_b,
+        v_cache=v_cache_b,
+        slot_mapping=slot_mapping,
+        kv_cache_dtype=kv_cache_dtype,
+        k_scale=k_scale_b,
+        v_scale=v_scale_b,
+        q=q_b,
+        k=k_b,
+        v=v_b,
+    )
+
+    checkAllclose(q_a, q_b, msg="q decoy vs truth qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(k_a, k_b, msg="k decoy vs truth qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(v_a, v_b, msg="v decoy vs truth qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(
+        k_cache_a.float(), k_cache_b.float(), msg="k_cache", rtol=1e-2, atol=0.05
+    )
+    checkAllclose(
+        v_cache_a.float(), v_cache_b.float(), msg="v_cache", rtol=1e-2, atol=0.05
+    )
+    checkAllclose(k_scale_a, k_scale_b, msg="k_scale", rtol=1e-2, atol=0.05)
+    checkAllclose(v_scale_a, v_scale_b, msg="v_scale", rtol=1e-2, atol=0.05)
 
 
 @perftest(num_iters=2)


### PR DESCRIPTION


## Motivation

This PR supports separated non-contiguous q,k,v for fused_qk_norm_rope_cache_quant_shuffle ops.  For the compatibility of frameworks, this op retains qkv inputs, and it will prioritize selecting q, k, v inputs.

## Test

Qwen-235
<img width="516" height="74" alt="image" src="https://github.com/user-attachments/assets/71d1ecd1-21c1-4440-a68a-bae7212bdd4f" />

