### PR TITLE
Fix Correction Issues in `batched_gemm_a8w8` for ASYNC_COPY Enabled

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-BATCHED_GEMM-A8W8.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-BATCHED_GEMM-A8W8.json
@@ -5,7 +5,7 @@
         "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 4,
         "num_warps": 8,
-        "num_stages": 2,
+        "num_stages": 1,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16
     },


### PR DESCRIPTION
## Motivation

This PR addresses a correctness failure in the `batched_gemm_a8w8` Triton kernel when running with `TRITON_HIP_USE_ASYNC_COPY` enabled (the default in the current Triton compiler, which has caused [breakage across kernels in UTs and potentially performance](https://github.com/ROCm/triton-internal/issues/1772)). The failures occur for two test cases:

- `test_batched_gemm_a8w8[bf16-16-9728-8192-65000-True]`
- `test_batched_gemm_a8w8[bf16-16-9728-8192-65000-False]`

Both test cases share the same shape `(M=9728, N=8192, K=65000)` with `B=16`. These were the only two failing cases out of 196 total, with ~98.7% of mismatched elements and absolute errors as large as `65024.0`, which are far greater than the `atol=0.01` tolerance.

## Technical Details

The issue stems from incorrect behavior in the `batched_gemm_a8w8` Triton kernel when `TRITON_HIP_USE_ASYNC_COPY ` is enabled. Under certain shapes, specifically `(M=9728, N=8192, K=65000)`, the kernel produces large numerical errors due to how pipelined stages interact with boundary conditions in the K dimension.

The kernel configuration for the `M_GEQ_4096` bucket uses:

- `BLOCK_SIZE_K = 64`
- `"num_stages": 2`

With `num_stages=2`, the Triton pipeline enables double-buffered prefetching into LDS. However, when K is not evenly divisible by `BLOCK_SIZE_K`, this can lead to out-of-bounds or invalid prefetch behaviour under async copy, resulting in numerical errors (mismatched elements).

Rather than modifying the input (e.g., padding K like in the previous change), this fix simplifies the test by reducing the number of pipeline stages. By setting `num_stages=1`, the kernel no longer performs multi-stage prefetching. This eliminates the possibility of mismatched elements and LDS exhaustion

## Test Plan

Ran the full pytest suite for test_batched_gemm_a8w8.py covering:

- `B = 16 # batch size`
- `(M, N, K)` from `get_x_vals()`: 8 cubic shapes `(1024v, 1024v, 1024v)` for `v ∈ {1, 2, ..., 8}`, practical shapes including the previously failing `(9728, 8192, 65000)`, and a sweep of `(M, 1280, 8192)` and `(M, 8192, 1024)` for `M ∈ {1, 32, 64, 128, 192, 256, 320, 512, 1024, 2048, 4096, 8192, 16384}`, plus the minimal case `(1, 1, 1)`
- `dtype ∈ {bfloat16}`
- `output ∈ {True, False}`
- Layout variants `∈ {TN (default), TT, NN, NT}` (via `test_batched_gemm_a8w8_layout`, run on the 20 smallest shapes)

Correctness verified against PyTorch reference (run_torch) using atol=0.01, rtol=1e-2.

## Test Result

All 196 test cases passed across all shapes tested and config combinations, even at large values of M and K dimension.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
