### PR TITLE
CI: rename aiter MI300X runners

### DIFF
--- a/.github/runner-config.yml
+++ b/.github/runner-config.yml
@@ -2,12 +2,12 @@
 # Used by frameworks-devops-dashboard to display GPU architecture
 # Update this when runners are added/changed in CI workflows
 runners:
-  aiter-1gpu-runner:
-    gpu_arch: MI325
+  linux-aiter-mi300x-1:
+    gpu_arch: MI300X
     gpu_count: 1
 
-  aiter-8gpu-runner:
-    gpu_arch: MI325
+  linux-aiter-mi300x-8:
+    gpu_arch: MI300X
     gpu_count: 8
 
   linux-aiter-mi355-1:

--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -49,7 +49,7 @@ on:
           - build-only-aiter
           - linux-aiter-mi35x-1
           - linux-aiter-mi355-1
-          - aiter-1gpu-runner
+          - linux-aiter-mi300x-1
       release_type:
         description: 'Release type for S3 publishing (leave empty for artifacts only)'
         type: choice

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -257,24 +257,24 @@ jobs:
             label: MI35X
             shard_total: 5
             shard_idx: 4
-          - runner: aiter-1gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi300x-1
+            label: MI300X
             shard_total: 5
             shard_idx: 0
-          - runner: aiter-1gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi300x-1
+            label: MI300X
             shard_total: 5
             shard_idx: 1
-          - runner: aiter-1gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi300x-1
+            label: MI300X
             shard_total: 5
             shard_idx: 2
-          - runner: aiter-1gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi300x-1
+            label: MI300X
             shard_total: 5
             shard_idx: 3
-          - runner: aiter-1gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi300x-1
+            label: MI300X
             shard_total: 5
             shard_idx: 4
     runs-on: ${{ matrix.runner }}
@@ -436,7 +436,7 @@ jobs:
           echo "Checking Standard Test Results..."
           all_passed=true
           for shard in {0..4}; do
-            for runner in {linux-aiter-mi35x-1,aiter-1gpu-runner}; do
+            for runner in {linux-aiter-mi35x-1,linux-aiter-mi300x-1}; do
               if [ ! -f standard-test-log-${runner}-shard-${shard}/latest_test.log ]; then
                 echo "Test report for ${runner} shard ${shard} not found."
                 all_passed=false
@@ -461,8 +461,8 @@ jobs:
         include:
           - runner: linux-aiter-mi35x-8
             label: MI35X
-          - runner: aiter-8gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi300x-8
+            label: MI300X
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -56,12 +56,12 @@ jobs:
         include:
           # run_on_pr: true = run on all events; false = skip on PR (still runs on push/schedule/workflow_dispatch)
           - model_name: "DeepSeek-R1-0528"
-            label: MI325
+            label: MI300X
             model_path: "deepseek-ai/DeepSeek-R1-0528"
             extraArgs: "--kv_cache_dtype fp8 -tp 8"
             env_vars: ""
             accuracy_test_threshold: "0.94"
-            runner: aiter-8gpu-runner
+            runner: linux-aiter-mi300x-8
             run_on_pr: true
           - model_name: "DeepSeek-R1-0528"
             label: MI35X

--- a/.github/workflows/operators-tuning.yaml
+++ b/.github/workflows/operators-tuning.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [aiter-1gpu-runner] # TODO: add more runners
+        runner: [linux-aiter-mi300x-1] # TODO: add more runners
     name: Operators tuning
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/opus-test.yaml
+++ b/.github/workflows/opus-test.yaml
@@ -49,8 +49,8 @@ jobs:
         include:
           - runner: linux-aiter-mi35x-1
             label: MI35X
-          - runner: aiter-1gpu-runner
-            label: MI325
+          - runner: linux-aiter-mi300x-1
+            label: MI300X
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -30,7 +30,7 @@ jobs:
 
             | Label | Tests |
             |-------|-------|
-            | \`ci:triton-355\` | Run Triton tests on MI355 in addition to MI325 |
+            | \`ci:triton-355\` | Run Triton tests on MI355 in addition to MI300X |
             | \`ci:sglang\` | SGLang integration tests |
             | \`ci:atom\` | ATOM benchmark (DeepSeek-R1 + GPT-OSS) |
             | \`ci:vllm\` | vLLM benchmark |

--- a/.github/workflows/test-network.yaml
+++ b/.github/workflows/test-network.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: 'Runner to use for the test, e.g. linux-aiter-mi355-1, aiter-1gpu-runner, etc.'
+        description: 'Runner to use for the test, e.g. linux-aiter-mi355-1, linux-aiter-mi300x-1, etc.'
         required: true
         default: 'linux-aiter-mi355-1'
 

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         include:
           # Python 3.12 tests
-          - runner: aiter-1gpu-runner
-            label: MI300-py312
+          - runner: linux-aiter-mi300x-1
+            label: MI300X-py312
             python_version: "3.12"
             docker_image: rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1
           - runner: linux-aiter-mi355-1
@@ -28,8 +28,8 @@ jobs:
             python_version: "3.12"
             docker_image: rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.9.1
           # Python 3.10 tests
-          - runner: aiter-1gpu-runner
-            label: MI300-py310
+          - runner: linux-aiter-mi300x-1
+            label: MI300X-py310
             python_version: "3.10"
             docker_image: rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1
           - runner: linux-aiter-mi355-1

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -59,7 +59,7 @@ jobs:
   build-triton:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
     name: Build Triton Wheel
-    runs-on: aiter-1gpu-runner
+    runs-on: linux-aiter-mi300x-1
     needs: [check-signal]
     env:
       DOCKER_IMAGE: "rocm/pytorch:latest"
@@ -110,11 +110,11 @@ jobs:
           path: triton-wheels/*.whl
           retention-days: 7
 
-  # Step 2: MI325 matrix jobs (always runs)
+  # Step 2: MI300X matrix jobs (always runs)
   triton:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
-    name: Triton Tests (MI325) / Shard ${{ matrix.shard }}
-    runs-on: aiter-1gpu-runner
+    name: Triton Tests (MI300X) / Shard ${{ matrix.shard }}
+    runs-on: linux-aiter-mi300x-1
     needs: [split_triton_tests, build-triton, check-signal]
     strategy:
       fail-fast: false

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -114,7 +114,7 @@ jobs:
       (contains(github.event.pull_request.labels.*.name, 'ci:vllm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:all')))
     needs: build_vllm_image
-    runs-on: aiter-8gpu-runner
+    runs-on: linux-aiter-mi300x-8
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- replace every `aiter-1gpu-runner` and `aiter-8gpu-runner` reference in Aiter workflows with `linux-aiter-mi300x-1` and `linux-aiter-mi300x-8`
- update workflow labels, comments, and PR guidance that referenced the old MI325 runner names so the CI matrix stays consistent
- refresh `.github/runner-config.yml` so dashboard metadata maps the renamed runners to MI300X hardware

## Test plan
- [x] `rg 'aiter-1gpu-runner|aiter-8gpu-runner'` returns no matches in the repo
- [x] `git diff --check`
- [ ] Run the affected GitHub Actions workflows to confirm the new runner labels are available in CI