### PR TITLE
ci(release): add torch_pin + torch_index_url inputs for ABI-targeted release builds

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -67,6 +67,16 @@ on:
         description: 'Use pytorch/manylinux2_28-builder ROCm image (AlmaLinux 8 + devtoolset, glibc 2.28). Produces wheels ABI-compatible with vLLM/Ubuntu 22 containers.'
         type: boolean
         default: false
+      torch_pin:
+        description: 'Optional torch version pin for the manylinux build (e.g. 2.10.0+rocm7.1). Empty = latest available for the detected ROCm flavor.'
+        type: string
+        required: false
+        default: ''
+      torch_index_url:
+        description: 'Optional override for the torch wheel index URL. Empty = auto-derive from the manylinux builder image tag (https://download.pytorch.org/whl/rocmX.Y).'
+        type: string
+        required: false
+        default: ''
   workflow_call:
     inputs:
       release_type:
@@ -111,6 +121,16 @@ on:
         type: boolean
         required: false
         default: false
+      torch_pin:
+        description: 'Optional torch version pin for the manylinux build (e.g. 2.10.0+rocm7.1). Empty = latest.'
+        type: string
+        required: false
+        default: ''
+      torch_index_url:
+        description: 'Optional torch index URL override. Empty = auto-derive from builder image tag.'
+        type: string
+        required: false
+        default: ''
     outputs:
       wheel_names:
         description: 'Space-separated list of built wheel filenames'
@@ -145,6 +165,8 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type || github.event.inputs.release_type }}
       ADD_DATE_STAMP: ${{ inputs.add_date_stamp || github.event.inputs.add_date_stamp }}
       USE_MANYLINUX: ${{ inputs.use_manylinux || github.event.inputs.use_manylinux || (startsWith(matrix.docker_image, 'pytorch/manylinux') && 'true') || 'false' }}
+      TORCH_PIN: ${{ inputs.torch_pin || github.event.inputs.torch_pin }}
+      TORCH_INDEX_URL: ${{ inputs.torch_index_url || github.event.inputs.torch_index_url }}
 
     steps:
       - name: Checkout aiter repo
@@ -301,17 +323,32 @@ jobs:
           IMG="${BUILD_DOCKER_IMAGE}"
           ROCM_TAG="${IMG##*:}"           # rocm7.2 / rocm7.1 / rocm7.0
           ROCM_NUM="${ROCM_TAG#rocm}"      # 7.2
-          TORCH_INDEX="https://download.pytorch.org/whl/rocm${ROCM_NUM}"
+          # Allow caller to override the torch wheel index (e.g. pin a release
+          # to a specific ROCm flavor's PyTorch ABI). Defaults preserve the
+          # legacy auto-derived behavior.
+          if [ -n "${TORCH_INDEX_URL}" ]; then
+            TORCH_INDEX="${TORCH_INDEX_URL}"
+          else
+            TORCH_INDEX="https://download.pytorch.org/whl/rocm${ROCM_NUM}"
+          fi
+          # Optional torch version pin (e.g. 2.10.0+rocm7.1). Empty = latest.
+          if [ -n "${TORCH_PIN}" ]; then
+            TORCH_SPEC="torch==${TORCH_PIN}"
+          else
+            TORCH_SPEC="torch"
+          fi
           echo "Torch index: ${TORCH_INDEX}"
+          echo "Torch spec:  ${TORCH_SPEC}"
           docker exec \
             -w /workspace \
             -e PYBIN="${PYBIN}" \
             -e TORCH_INDEX="${TORCH_INDEX}" \
+            -e TORCH_SPEC="${TORCH_SPEC}" \
             aiter_build_${{ matrix.python_version }} \
             bash -c '
               set -e
               ${PYBIN}/pip install --upgrade --timeout=60 --retries=10 pip
-              ${PYBIN}/pip install --timeout=60 --retries=10 --index-url "${TORCH_INDEX}" torch
+              ${PYBIN}/pip install --timeout=60 --retries=10 --index-url "${TORCH_INDEX}" "${TORCH_SPEC}"
               # flydsl publishes only manylinux_2_35 wheels which cannot install
               # on AlmaLinux 8 (glibc 2.28). FlyDSL AOT pre-compilation in
               # setup.py is wrapped in try/except and is skipped gracefully when


### PR DESCRIPTION
## Summary

Add two optional, additive workflow inputs to `aiter-release.yaml` so that release dispatches can pin the torch wheel used by the manylinux build path. Default behavior is unchanged.

- `torch_pin` (string, default `""`): when non-empty, becomes `torch==<value>` in the manylinux pip install (e.g. `2.10.0+rocm7.1`).
- `torch_index_url` (string, default `""`): when non-empty, overrides the auto-derived `https://download.pytorch.org/whl/rocm${ROCM_NUM}` index URL.

Both inputs are wired into both `workflow_dispatch` and `workflow_call`, exposed via the job `env:` block, and consumed by the existing `Install Dependencies (manylinux)` step.

## Root cause this enables us to fix

The current manylinux release path runs `pip install torch` with no version pin, picking up whatever wheel happens to be latest on the auto-derived `download.pytorch.org/whl/rocmX.Y` index at build time. That works for nightlies but is fragile for tagged releases that need to be ABI-compatible with a specific downstream container.

Concrete failure mode observed during `v0.1.12.post2` cut:

- Builder pulled `torch==2.11.0+rocm7.2` (the current latest on the rocm7.2 index).
- AITER `.so` files compiled against that ABI failed to dlopen inside `vllm/vllm-openai-rocm:v0.19.1`, which ships a custom `torch 2.10` build.
- Specific symbol: `c10::cuda::getCurrentCUDAStream` masquerade alias was dropped/changed across the 2.10 -> 2.11 transition.
- `module_gemm_a8w8_blockscale.so` (and several other AITER kernels) ImportError at runtime.

With this change the release pipeline can target a specific PyTorch ABI per release, instead of drifting with whatever the manylinux builder index happens to ship.

## Validation evidence

A side branch (`pensun/post2-final-rocm7.2`) hardcoded the same pin in the same step and produced wheels that:

- Built green in the AITER release CI.
- Loaded cleanly inside `vllm/vllm-openai-rocm:v0.19.1` (no `c10::cuda::getCurrentCUDAStream` ImportError).
- Ran DSR1 serving end-to-end on **MI300X** and **MI355X** with PASS results.

This PR productionizes that workaround as proper workflow inputs so future post-releases do not need a side-branch hack.

## Default behavior

Both new inputs default to `""`. When both are empty the install step is identical to today:

```bash
TORCH_INDEX="https://download.pytorch.org/whl/rocm${ROCM_NUM}"
${PYBIN}/pip install --index-url "${TORCH_INDEX}" torch
```

When either is set, the step uses it:

```bash
TORCH_INDEX="${TORCH_INDEX_URL:-https://download.pytorch.org/whl/rocm${ROCM_NUM}}"
TORCH_SPEC="torch${TORCH_PIN:+==${TORCH_PIN}}"
${PYBIN}/pip install --index-url "${TORCH_INDEX}" "${TORCH_SPEC}"
```

## Planned dispatch for v0.1.12.post2

```
torch_pin=2.10.0+rocm7.1
torch_index_url=https://download.pytorch.org/whl/rocm7.1
```

## Scope

- YAML only, single file: `.github/workflows/aiter-release.yaml`.
- ~+39 / -2 lines.
- No change to legacy (non-manylinux) build path.
- No change to version-stamp logic. The `BASE_VER` / `git describe` flow on `main` is correct for nightlies and is intentionally left alone (the side branch's `BASE_VER=0.1.12.post2` hardcode is a one-off for the dispatch-without-tag case and is not brought upstream).

## Test plan

- [ ] Dispatch the workflow with no new inputs -> confirm install log shows the existing `Torch index: https://download.pytorch.org/whl/rocm7.2` and `pip install ... torch` (no `==` pin), wheels match current main.
- [ ] Dispatch with `torch_pin=2.10.0+rocm7.1`, `torch_index_url=https://download.pytorch.org/whl/rocm7.1`, `use_manylinux=true` -> confirm install log shows the override and `pip install ... torch==2.10.0+rocm7.1`, wheels load inside vllm v0.19.1.
- [ ] Re-run downstream CI: `ci:vllm`, `ci:atom`, `ci:sglang`, `ci:triton-355`.

Refs: #2843