### PR TITLE
CI: Raise atom-test accuracy step timeout to 90 minutes

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Run ATOM accuracy test
         if: matrix.run_on_pr == true || github.event_name != 'pull_request'
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           set -euo pipefail
           echo ""


### PR DESCRIPTION
## Summary
- Set `timeout-minutes` to 90 on the `Run ATOM accuracy test` step in `.github/workflows/atom-test.yaml`.
- ATOM startup wait in `ROCm/ATOM` `atom_test.sh` can now take up to 45 minutes; 60 minutes for the whole step was too tight once warmup and `lm_eval` are included.

## Related
- Depends on or should merge together with `ROCm/ATOM` PR extending the server `/health` wait to 45 minutes.