### PR TITLE
Fix: correct mxfp4  for K not divisible by 256

### DIFF
--- a/aiter/utility/fp4_utils.py
+++ b/aiter/utility/fp4_utils.py
@@ -386,11 +386,11 @@ def _dynamic_mxfp4_quant_kernel_asm_layout(
             + bs_offs_2 * 2 * 2
             + bs_offs_5 * 2 * 2 * 16
             + bs_offs_3 * 2 * 2 * 16 * 4
-            + bs_offs_0 * 2 * 16 * scaleN
+            + bs_offs_0 * 2 * 16 * scaleN_pad
         )
         bs_mask1 = (bs_offs_m < M)[:, None] & (bs_offs_n < scaleN)[None, :]
         bs_mask2 = (bs_offs_m < scaleM_pad)[:, None] & (bs_offs_n < scaleN_pad)[None, :]
-        bs_e8m0 = tl.where(bs_mask1, bs_e8m0, 127)
+        bs_e8m0 = tl.where(bs_mask1, bs_e8m0, 0)
         tl.store(bs_ptr + bs_offs, bs_e8m0, mask=bs_mask2)
     else:
         bs_offs = bs_offs_m[:, None] * stride_bs_m + bs_offs_n[None, :] * stride_bs_n


### PR DESCRIPTION
###   Root cause                                                                                                                                       
   
  In _dynamic_mxfp4_quant_kernel_asm_layout (shuffle=True path), the scale buffer row-group stride was computed as bs_offs_0 * 2 * 16 * scaleN     
  where scaleN = scaleN_valid = ceil(K/32). However, the f4gemm kernel reads the scale buffer using the physical column width scaleN_pad = 
  ceil(scaleN_valid/8)*8.                                                                                                                          
                                                                      
  When K % 256 != 0, scaleN_valid is not a multiple of 8, so scaleN_valid != scaleN_pad. This mismatch causes the quant kernel to write valid      
  scales at offsets based on stride scaleN_valid, while the GEMM kernel reads them at offsets based on stride scaleN_pad. Every row group beyond
  the first 32 rows is misaligned, corrupting ~99% of output elements.                                                                             
                                                                      
  Additionally, out-of-bounds scale entries (for K_pad > K_actual) were filled with 127 (= 1.0 in e8m0), causing padding K tiles to contribute     
  garbage values to the GEMM output instead of zero.
                                                                                                                                                   
###   Fix                                                                                                                                              
   
  - Replace scaleN with scaleN_pad in the row-group stride term so the write layout matches what the GEMM kernel reads.                            
  - Fill out-of-bounds scale entries with 0 (= 2^-127 ≈ 0 in e8m0) so padding K tiles contribute negligibly to the output.
                                                                                                                                                   
###   Affected shapes                                                                                                                                  
                                                                                                                                                   
  Any shape where K % 256 != 0 and ceil(K/32) % 8 != 0, e.g. K=2880 (scaleN_valid=90, scaleN_pad=96). K=2816 and K=3072 are both divisible by 256  
  so were unaffected.  

###   Alternative fix
pad B's packed K dimension to a multiple of 128 (= 256 actual fp4 elements) with zeros before shuffling, so the GEMM never reads
   padding K tiles. This PR fixes it on the scale side instead.   

