### PR TITLE
[MLA] Fix qh128 ASM nullptr write; enable native qh128 fp8 on gfx950	

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -248,9 +248,7 @@ def mla_decode_fwd(
         # Plan A safety: always allocate final_lse buffer.
         # qh128 ASM kernel (mla_a8w8_qh128_m32x4_n16x2_msk0_ps) writes ptr_LSEP
         # unconditionally; passing nullptr crashes on gfx950 at large batch.
-        final_lse_buf = torch.empty(
-            (total_s, nhead), dtype=dtypes.fp32, device=device
-        )
+        final_lse_buf = torch.empty((total_s, nhead), dtype=dtypes.fp32, device=device)
         final_lse = final_lse_buf if return_lse else None
 
         aiter.mla_decode_stage1_asm_fwd(
@@ -425,9 +423,7 @@ def mla_decode_fwd(
         # Plan A safety: always allocate final_lse buffer.
         # qh128 ASM kernel (mla_a8w8_qh128_m32x4_n16x2_msk0_ps) writes ptr_LSEP
         # unconditionally; passing nullptr crashes on gfx950 at large batch.
-        final_lse_buf = torch.empty(
-            (total_s, nhead), dtype=dtypes.fp32, device=device
-        )
+        final_lse_buf = torch.empty((total_s, nhead), dtype=dtypes.fp32, device=device)
         final_lse = final_lse_buf if return_lse else None
 
         use_hk = (

--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -324,7 +324,7 @@ def mla_decode_fwd(
         if (
             nhead == 16
             or (
-                get_gfx() == "gfx942"
+                get_gfx() in ("gfx942", "gfx950")
                 and nhead == 128
                 and q.dtype == dtypes.fp8
                 and kv_buffer.dtype == dtypes.fp8

--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -245,11 +245,13 @@ def mla_decode_fwd(
         attn_lse = torch.empty(
             (total_s, num_kv_splits, nhead, 1), dtype=dtypes.fp32, device=device
         )
-        final_lse = (
-            torch.empty((total_s, nhead), dtype=dtypes.fp32, device=device)
-            if return_lse
-            else None
+        # Plan A safety: always allocate final_lse buffer.
+        # qh128 ASM kernel (mla_a8w8_qh128_m32x4_n16x2_msk0_ps) writes ptr_LSEP
+        # unconditionally; passing nullptr crashes on gfx950 at large batch.
+        final_lse_buf = torch.empty(
+            (total_s, nhead), dtype=dtypes.fp32, device=device
         )
+        final_lse = final_lse_buf if return_lse else None
 
         aiter.mla_decode_stage1_asm_fwd(
             q,
@@ -269,7 +271,7 @@ def mla_decode_fwd(
             logits,
             attn_lse,
             o,
-            final_lse,
+            final_lse_buf,
             q_scale,
             kv_scale,
         )
@@ -420,11 +422,13 @@ def mla_decode_fwd(
             dtype=dtypes.fp32,
             device=device,
         )
-        final_lse = (
-            torch.empty((total_s, nhead), dtype=dtypes.fp32, device=device)
-            if return_lse
-            else None
+        # Plan A safety: always allocate final_lse buffer.
+        # qh128 ASM kernel (mla_a8w8_qh128_m32x4_n16x2_msk0_ps) writes ptr_LSEP
+        # unconditionally; passing nullptr crashes on gfx950 at large batch.
+        final_lse_buf = torch.empty(
+            (total_s, nhead), dtype=dtypes.fp32, device=device
         )
+        final_lse = final_lse_buf if return_lse else None
 
         use_hk = (
             nhead == 128
@@ -469,7 +473,7 @@ def mla_decode_fwd(
                 logits,
                 attn_lse,
                 o,
-                final_lse,
+                final_lse_buf,
                 q_scale,
                 kv_scale,
             )

--- a/aiter/ops/attention.py
+++ b/aiter/ops/attention.py
@@ -939,7 +939,7 @@ def get_mla_metadata_info_v1(
         int(math.ceil(effective_seqlen_qo * num_head_qo / 128))
         if num_head_qo == 16
         or (
-            get_gfx() == "gfx942"
+            get_gfx() in ("gfx942", "gfx950")
             and num_head_qo == 128
             and kv_dtype == dtypes.fp8
             and q_dtype == dtypes.fp8
@@ -1252,7 +1252,7 @@ def decode_update_mla_metadata_v1(
             and max_seqlen_qo == 4
         )
         or (
-            arch_id == "gfx942"
+            arch_id in ("gfx942", "gfx950")
             and num_heads_per_head_k == 128
             and q_is_fp8
             and kv_is_fp8

--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -478,7 +478,8 @@ void get_mla_metadata_v1_2_device(const torch::Tensor& seqlens_qo_indptr, // [ba
          (max_seqlen_qo == 1)) ||
         ((arch_id == "gfx950") && ((num_heads * max_seqlen_qo) % 128 == 0) && !q_is_fp8 &&
          !kv_is_fp8) ||
-        ((arch_id == "gfx942") && (num_heads == 128) && q_is_fp8 && kv_is_fp8);
+        (((arch_id == "gfx942") || (arch_id == "gfx950")) && (num_heads == 128) && q_is_fp8 &&
+         kv_is_fp8);
 
     const bool use_qseqlen_fold =
         !natively_supported && (arch_id == "gfx950") && q_is_fp8 && kv_is_fp8 && (num_heads > 16) &&

--- a/csrc/py_itfs_cu/asm_mla.cu
+++ b/csrc/py_itfs_cu/asm_mla.cu
@@ -62,23 +62,30 @@ std::string get_heuristic_kernel_mla(std::string q_type,
                                      CFG* cfgs,
                                      int lse = 0)
 {
-    for(const auto& el : *cfgs)
-    {
-        if (el.first.find(arch_id) != 0)
-            continue;
-        const auto& cfg = el.second;
-        
-        if (cfg.qType != q_type || cfg.kvType != kv_type)
-            continue;
-        if (cfg.Gqa != gqa || cfg.ps != ps || cfg.prefill != prefill)
-            continue;
-        if (cfg.causal != causal || cfg.qSeqLen != qseqlen)
-            continue;
-        if (cfg.lse != lse)
-            continue;
-        return el.first;
+    // Plan A: 2-pass lookup. First require exact lse match; if not found and
+    // lse was requested, fall back to lse=0 entries. The qh128 binary writes
+    // ptr_LSEP unconditionally, so passing a non-null buffer is safe even
+    // when CSV row is marked lse=0.
+    for (int pass = 0; pass < 2; ++pass) {
+        int eff_lse = (pass == 0) ? lse : 0;
+        if (pass == 1 && lse == 0) break;  // no fallback needed
+        for (const auto& el : *cfgs)
+        {
+            if (el.first.find(arch_id) != 0)
+                continue;
+            const auto& cfg = el.second;
+            if (cfg.qType != q_type || cfg.kvType != kv_type)
+                continue;
+            if (cfg.Gqa != gqa || cfg.ps != ps || cfg.prefill != prefill)
+                continue;
+            if (cfg.causal != causal || cfg.qSeqLen != qseqlen)
+                continue;
+            if (cfg.lse != eff_lse)
+                continue;
+            return el.first;
+        }
     }
-    
+
     AITER_CHECK(false,
                 __func__,
                 ": cannot get heuristic kernel!"

--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -452,7 +452,12 @@ def torch_mla_extend_split_kv(
     q_ratio = 1
     if (
         nheads == 16
-        or (get_gfx() == "gfx942" and nheads == 128 and is_fp8_q and is_fp8_kvc)
+        or (
+            get_gfx() in ("gfx942", "gfx950")
+            and nheads == 128
+            and is_fp8_q
+            and is_fp8_kvc
+        )
         or (
             get_gfx() == "gfx950"
             and nheads == 32


### PR DESCRIPTION
for OSL/ISL=8k/1k  con=256 InferenceMax DSV3 decode case cc @Duyi-Wang  @slippedJim 
Restore the native `qh128` fp8 decode path on gfx950 that PR #2204 had to
disable for this case, by fixing the underlying nullptr-write bug in the qh128 ASM kernel
call site rather than working around it. This recovers MLA decode performance
on gfx950 for `nhead=128, fp8/fp8` while keeping gfx942 unchanged.

```bash
python3 op_tests/test_mla_persistent.py \
    -n 128,1 -d fp8 -kvd fp8 \
    -b  32 64 128 256 -c 8192
```
| bs  | without this PR     | with this PR        | speedup |
| --: | :------------------ | :------------------ | :-----: |
|  32 | 210 µs / 0.75 TB/s  | 105 µs / 1.50 TB/s  |  2.0×   |
|  64 | 413 µs / 0.76 TB/s  | 174 µs / 1.82 TB/s  |  2.4×   |
| 128 | 800 µs / 0.79 TB/s  | 300 µs / 2.10 TB/s  |  2.7×   |
| 256 | 1812 µs / 0.70 TB/s | 526 µs / 2.40 TB/s  |  3.4×   |
