### PR TITLE
ci: enable prebuilt kernel wheels for fork PRs

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -83,6 +83,8 @@ jobs:
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash -lc '
+              git config --global --add safe.directory /workspace &&
+              git -C /workspace rev-parse HEAD >/dev/null &&
               shopt -s nullglob &&
               rm -rf dist build aiter_meta ./*.egg-info &&
               pip install -r requirements.txt &&

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -50,23 +50,15 @@ jobs:
       id-token: write
       contents: read
     steps:
+      # ---- Common steps (fork and non-fork) ----
       - name: Checkout code
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/checkout@v4
 
       - name: Docker login
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }}
 
-      # - name: Prepare docker config
-      #   run: |
-      #     export DOCKER_CONFIG="$HOME/.docker"
-      #     mkdir -p "$DOCKER_CONFIG" || true
-      #     cp /docker-config/config.json "$DOCKER_CONFIG/config.json"
-      #     echo "DOCKER_CONFIG=$DOCKER_CONFIG" >> "$GITHUB_ENV"
-      
       - name: Generate Dockerfile
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           cat <<EOF > Dockerfile.mod
           FROM ${{ env.DOCKER_IMAGE }}
@@ -106,17 +98,14 @@ jobs:
           EOF
 
       - name: Show Dockerfile
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: cat Dockerfile.mod
 
       - name: Build Docker image
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
           docker build --network=host --no-cache -t $IMAGE_TAG -f Dockerfile.mod .
 
       - name: Verify prebuilt kernels
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
           echo "=== Prebuilt kernel validation ==="
@@ -129,6 +118,7 @@ jobs:
             echo "Prebuild validation passed: $KERNEL_COUNT kernels compiled"
           fi
 
+      # ---- Non-fork only: push image to Docker Hub ----
       - name: Push Docker image
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
@@ -136,12 +126,12 @@ jobs:
           docker push $IMAGE_TAG
 
       - name: Success message
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           echo "Successfully prepared image: rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}"
 
+      # ---- Extract and upload wheel (fork PRs + main branch) ----
       - name: Extract wheel from image
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
+        if: ${{ github.event.pull_request.head.repo.fork || (github.ref == 'refs/heads/main' && github.event_name != 'schedule') }}
         run: |
           set -ex
           IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
@@ -152,6 +142,14 @@ jobs:
             bash -c "cp /aiter/dist/*.whl /dist/"
           echo "Extracted wheels:"
           ls -lh dist/*.whl
+
+      - name: Upload wheel artifact (fork)
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiter-whl-fork-${{ github.run_id }}
+          path: dist/*.whl
+          retention-days: 1
 
       - name: Upload wheel as artifact
         if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
@@ -232,7 +230,7 @@ jobs:
       (!github.event.pull_request || github.event.pull_request.draft == false) &&
       github.event.action != 'labeled'
     name: Standard Tests (1 GPU)
-    needs: [build_aiter_image, split_aiter_tests] 
+    needs: [build_aiter_image, split_aiter_tests]
     strategy:
       fail-fast: false
       matrix:
@@ -284,10 +282,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      
+
       - name: Docker login
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
-      
+
       - name: Download test shard lists
         uses: actions/download-artifact@v4
         with:
@@ -332,16 +331,27 @@ jobs:
           --name aiter_test \
           $IMAGE_TAG
 
-      - name: Setup Aiter for fork PR
+      - name: Download wheel artifact (fork)
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        uses: actions/download-artifact@v4
+        with:
+          name: aiter-whl-fork-${{ github.run_id }}
+          path: dist/
+
+      - name: Install prebuilt wheel (fork)
         if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           set -ex
+          echo "Installing prebuilt wheel for fork PR..."
+          # CK submodule source needed by some tests
           git submodule sync && git submodule update --init --recursive --depth 1 --jobs 4
-          echo "Setting up Aiter for fork PR..."
-          docker exec \
-          -w /workspace \
-          aiter_test \
-          bash -c "BUILD_TRITON=0 ./.github/scripts/build_aiter_triton.sh"
+          # Copy wheel into container and install
+          docker cp dist/ aiter_test:/tmp/wheel/
+          docker exec aiter_test bash -c "
+            pip uninstall -y aiter || true
+            pip install /tmp/wheel/*.whl
+            pip install -r /workspace/requirements.txt
+          "
 
       - name: Restore CK from prebuilt image
         if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -380,17 +390,10 @@ jobs:
         timeout-minutes: 90
         run: |
           set -ex
-          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
-            docker exec \
-            -w /workspace \
-            aiter_test \
-            bash -c "MAX_JOBS=64 SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh"
-          else
-            docker exec \
-            -w /workspace \
-            aiter_test \
-            bash -c "SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh"
-          fi
+          docker exec \
+          -w /workspace \
+          aiter_test \
+          bash -c "SHARD_TOTAL=${{ matrix.shard_total }} SHARD_IDX=${{ matrix.shard_idx }} ./.github/scripts/aiter_test.sh"
 
       - name: Collect test logs
         if: always()
@@ -425,7 +428,7 @@ jobs:
         with:
           pattern: standard-test-log-*-shard-*
           path: .
-      
+
       - name: List test logs
         run: |
           ls -l standard-test-log-*
@@ -499,7 +502,7 @@ jobs:
           -w /workspace \
           --name aiter_test \
           $IMAGE_TAG
-      
+
       - name: Setup Aiter for fork PR
         if: ${{ github.event.pull_request.head.repo.fork }}
         run: |

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
 
-  build_aiter_image:
+  build_aiter_wheels:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
     runs-on: build-only-aiter
     needs: check-signal
@@ -185,7 +185,7 @@ jobs:
   split_aiter_tests:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    needs: [check-signal, build_aiter_image]
+    needs: [check-signal, build_aiter_wheels]
     outputs:
       shard_count: 5
     steps:
@@ -207,7 +207,7 @@ jobs:
       (!github.event.pull_request || github.event.pull_request.draft == false) &&
       github.event.action != 'labeled'
     name: Standard Tests (1 GPU)
-    needs: [build_aiter_image, split_aiter_tests]
+    needs: [build_aiter_wheels, split_aiter_tests]
     strategy:
       fail-fast: false
       matrix:
@@ -429,7 +429,7 @@ jobs:
   multi-gpu:
     name: Multi-GPU Tests (8 GPU)
     if: github.ref == 'refs/heads/main'
-    needs: build_aiter_image
+    needs: build_aiter_wheels
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -24,9 +24,8 @@ concurrency:
 env:
   DOCKER_IMAGE: "rocm/pytorch:latest"
   GPU_ARCH_LIST: "gfx942;gfx950"
-  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
-  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   AITER_TEST: "op_tests"
+  AITER_WHEEL_ARTIFACT_NAME: aiter-whl-${{ github.run_id }}
 
 jobs:
   check-signal:
@@ -53,109 +52,83 @@ jobs:
       # ---- Common steps (fork and non-fork) ----
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Docker login
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Generate Dockerfile
-        run: |
-          cat <<EOF > Dockerfile.mod
-          FROM ${{ env.DOCKER_IMAGE }}
-
-          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
-          RUN pip uninstall -y aiter
-          RUN pip install --upgrade pandas zmq einops numpy==1.26.2
-          RUN pip install --upgrade "pybind11>=3.0.1"
-          RUN pip install --upgrade "ninja>=1.11.1"
-          RUN pip install --upgrade setuptools_scm
-          RUN pip install tabulate
-          RUN pip list
-
-          RUN rm -rf aiter \
-           && git clone ${{ env.GITHUB_REPO_URL }} aiter \
-           && cd aiter \
-           && git checkout ${{ env.GITHUB_COMMIT_SHA }} \
-           && if [ "${{ github.event_name }}" = "schedule" ]; then \
-                echo "It's nightly build, syncing latest CK..."; \
-                git submodule set-branch --branch develop 3rdparty/composable_kernel; \
-                git submodule sync && \
-                git submodule update --init --recursive --remote --jobs 4; \
-                echo "Nightly CK commit: $(git -C 3rdparty/composable_kernel rev-parse HEAD)"; \
-              else \
-                echo "Using pinned CK commit..."; \
-                git submodule sync && \
-                git submodule update --init --recursive --depth 1 --jobs 4; \
-                echo "Pinned CK commit: $(git -C 3rdparty/composable_kernel rev-parse HEAD)"; \
-              fi \
-           && pip install -r requirements.txt \
-           && echo "Prebuilding kernels with GPU_ARCHS: ${{ env.GPU_ARCH_LIST }}, PREBUILD_KERNELS: 1, and MAX_JOBS: 128" \
-           && PREBUILD_KERNELS=1 MAX_JOBS=128 GPU_ARCHS="${{ env.GPU_ARCH_LIST }}" python setup.py bdist_wheel \
-           && pip install dist/*.whl \
-           && echo "Prebuilding kernels completed"
-
-          RUN echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true
-          EOF
-
-      - name: Show Dockerfile
-        run: cat Dockerfile.mod
-
-      - name: Build Docker image
-        run: |
-          IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
-          docker build --network=host --no-cache -t $IMAGE_TAG -f Dockerfile.mod .
-
-      - name: Verify prebuilt kernels
-        run: |
-          IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
-          echo "=== Prebuilt kernel validation ==="
-          KERNEL_COUNT=$(docker run --rm $IMAGE_TAG find /aiter/aiter/jit -name "*.so" | wc -l)
-          echo "Prebuilt kernel .so files: $KERNEL_COUNT"
-          docker run --rm $IMAGE_TAG find /aiter/aiter/jit -name "*.so" | sort
-          if [ "$KERNEL_COUNT" -lt 10 ]; then
-            echo "::warning::Prebuild may have failed: expected at least 10 kernel .so files, found $KERNEL_COUNT. This can cause JIT compilation and OOM at runtime."
-          else
-            echo "Prebuild validation passed: $KERNEL_COUNT kernels compiled"
-          fi
-
-      # ---- Non-fork only: push image to Docker Hub ----
-      - name: Push Docker image
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
-          docker push $IMAGE_TAG
-
-      - name: Success message
-        run: |
-          echo "Successfully prepared image: rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}"
-
-      # ---- Extract and upload wheel (fork PRs + main branch) ----
-      - name: Extract wheel from image
-        if: ${{ github.event.pull_request.head.repo.fork || (github.ref == 'refs/heads/main' && github.event_name != 'schedule') }}
+      - name: Sync submodules for wheel build
         run: |
           set -ex
-          IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
-          mkdir -p dist
-          docker run --rm \
-            -v "${{ github.workspace }}/dist:/dist" \
-            $IMAGE_TAG \
-            bash -c "cp /aiter/dist/*.whl /dist/"
-          echo "Extracted wheels:"
-          ls -lh dist/*.whl
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Nightly build: syncing latest CK from develop branch..."
+            git submodule set-branch --branch develop 3rdparty/composable_kernel
+            git submodule sync
+            git submodule update --init --recursive --remote --jobs 4
+          else
+            echo "Using pinned CK commit..."
+            git submodule sync
+            git submodule update --init --recursive --depth 1 --jobs 4
+          fi
+          echo "CK commit: $(git -C 3rdparty/composable_kernel rev-parse HEAD)"
 
-      - name: Upload wheel artifact (fork)
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: aiter-whl-fork-${{ github.run_id }}
-          path: dist/*.whl
-          retention-days: 1
+      - name: Build Aiter wheel in base container
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --network=host \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            ${{ env.DOCKER_IMAGE }} \
+            bash -lc '
+              shopt -s nullglob &&
+              rm -rf dist build aiter_meta ./*.egg-info &&
+              pip install -r requirements.txt &&
+              pip install --upgrade pandas zmq einops numpy==1.26.2 &&
+              pip install --upgrade "pybind11>=3.0.1" &&
+              pip install --upgrade "ninja>=1.11.1" &&
+              pip install --upgrade setuptools_scm &&
+              pip install tabulate &&
+              echo "Prebuilding kernels with GPU_ARCHS: ${{ env.GPU_ARCH_LIST }}, PREBUILD_KERNELS: 1, and MAX_JOBS: 128" &&
+              PREBUILD_KERNELS=1 MAX_JOBS=128 GPU_ARCHS="${{ env.GPU_ARCH_LIST }}" python setup.py bdist_wheel &&
+              ls -lh dist/*.whl
+            '
+
+      - name: Verify prebuilt kernels in wheel
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import glob
+          import zipfile
+
+          wheels = glob.glob("dist/*.whl")
+          if len(wheels) != 1:
+              raise SystemExit(f"Expected exactly one wheel in dist/, found {len(wheels)}")
+
+          wheel = wheels[0]
+          with zipfile.ZipFile(wheel) as zf:
+              kernels = sorted(
+                  name for name in zf.namelist()
+                  if name.startswith("aiter/jit/") and name.endswith(".so")
+              )
+
+          print("=== Prebuilt kernel validation ===")
+          print(f"Wheel: {wheel}")
+          print(f"Prebuilt kernel .so files: {len(kernels)}")
+          for kernel in kernels:
+              print(kernel)
+
+          if len(kernels) < 10:
+              print(
+                  f"::warning::Prebuild may have failed: expected at least 10 kernel .so files, found {len(kernels)}. "
+                  "This can cause JIT compilation and OOM at runtime."
+              )
+          else:
+              print(f"Prebuild validation passed: {len(kernels)} kernels compiled")
+          PY
 
       - name: Upload wheel as artifact
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         uses: actions/upload-artifact@v4
         with:
-          name: aiter-whl-main-${{ github.run_id }}
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
           path: dist/*.whl
           retention-days: 14
 
@@ -283,10 +256,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Docker login
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
-
       - name: Download test shard lists
         uses: actions/download-artifact@v4
         with:
@@ -302,6 +271,12 @@ jobs:
           echo "AITER_TEST=$(cat aiter_shard_${{ matrix.shard_idx }}.list)" >> $GITHUB_ENV
           echo "$AITER_TEST"
 
+      - name: Download Aiter wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          path: aiter_wheels
+
       - name: Run the container
         run: |
           set -ex
@@ -313,11 +288,7 @@ jobs:
             DEVICE_FLAG="--device /dev/dri"
           fi
 
-          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
-            IMAGE_TAG=${{ env.DOCKER_IMAGE }}
-          else
-            IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
-          fi
+          IMAGE_TAG=${{ env.DOCKER_IMAGE }}
 
           docker run -dt \
           --device=/dev/kfd $DEVICE_FLAG \
@@ -331,52 +302,45 @@ jobs:
           --name aiter_test \
           $IMAGE_TAG
 
-      - name: Download wheel artifact (fork)
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        uses: actions/download-artifact@v4
-        with:
-          name: aiter-whl-fork-${{ github.run_id }}
-          path: dist/
-
-      - name: Install prebuilt wheel (fork)
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        run: |
-          set -ex
-          echo "Installing prebuilt wheel for fork PR..."
-          # CK submodule source needed by some tests
-          git submodule sync && git submodule update --init --recursive --depth 1 --jobs 4
-          # Copy wheel into container and install
-          docker cp dist/ aiter_test:/tmp/wheel/
-          docker exec aiter_test bash -c "
-            pip uninstall -y aiter || true
-            pip install /tmp/wheel/*.whl
-            pip install -r /workspace/requirements.txt
-          "
-
-      - name: Restore CK from prebuilt image
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+      - name: Sync CK submodule
         run: |
           set -ex
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "Nightly build: restoring CK that was synced from develop in the prebuild image..."
+            echo "Nightly build: syncing latest CK from develop branch..."
+            git submodule set-branch --branch develop 3rdparty/composable_kernel
+            git submodule sync
+            git submodule update --init --recursive --remote --jobs 4
           else
-            echo "Restoring the pinned CK checkout from the prebuild image..."
+            echo "Using pinned CK commit..."
+            git submodule sync
+            git submodule update --init --recursive --depth 1 --jobs 4
           fi
 
-          rm -rf "${{ github.workspace }}/3rdparty/composable_kernel"
-          rm -rf "${{ github.workspace }}/.git/modules/3rdparty/composable_kernel"
-          mkdir -p "${{ github.workspace }}/3rdparty"
-          mkdir -p "${{ github.workspace }}/.git/modules/3rdparty"
-          docker cp aiter_test:/aiter/.git/modules/3rdparty/composable_kernel \
-            "${{ github.workspace }}/.git/modules/3rdparty/composable_kernel"
-          docker cp aiter_test:/aiter/3rdparty/composable_kernel \
-            "${{ github.workspace }}/3rdparty/composable_kernel"
-
-          IMAGE_CK_COMMIT=$(docker exec aiter_test git -C /aiter/3rdparty/composable_kernel rev-parse HEAD)
-          WORKSPACE_CK_COMMIT=$(git -C "${{ github.workspace }}/3rdparty/composable_kernel" rev-parse HEAD)
-          echo "Image CK commit: ${IMAGE_CK_COMMIT}"
-          echo "Workspace CK commit: ${WORKSPACE_CK_COMMIT}"
-          test "${IMAGE_CK_COMMIT}" = "${WORKSPACE_CK_COMMIT}"
+      - name: Install Aiter wheel
+        run: |
+          set -euo pipefail
+          ls -lh aiter_wheels
+          shopt -s nullglob
+          wheels=(aiter_wheels/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one Aiter wheel artifact, found ${#wheels[@]}"
+            exit 1
+          fi
+          AITER_WHEEL_PATH="/workspace/${wheels[0]}"
+          echo "Installing Aiter wheel: ${AITER_WHEEL_PATH}"
+          docker exec \
+          -w /workspace \
+          aiter_test \
+          bash -lc "
+            pip uninstall -y amd-aiter aiter || true
+            pip install -r requirements.txt
+            pip install --upgrade pandas zmq einops numpy==1.26.2
+            pip install --upgrade 'pybind11>=3.0.1'
+            pip install --upgrade 'ninja>=1.11.1'
+            pip install tabulate
+            pip install '${AITER_WHEEL_PATH}'
+            pip show amd-aiter
+          "
 
       - name: Show Aiter version
         run: |
@@ -471,9 +435,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Docker login
-        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
+      - name: Download Aiter wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          path: aiter_wheels
 
       - name: Run the container
         run: |
@@ -486,11 +455,7 @@ jobs:
             DEVICE_FLAG="--device /dev/dri"
           fi
 
-          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
-            IMAGE_TAG=${{ env.DOCKER_IMAGE }}
-          else
-            IMAGE_TAG=rocm/aiter-ci:pre-build-${{ env.GITHUB_COMMIT_SHA }}
-          fi
+          IMAGE_TAG=${{ env.DOCKER_IMAGE }}
 
           docker run -dt \
           --device=/dev/kfd $DEVICE_FLAG \
@@ -503,15 +468,45 @@ jobs:
           --name aiter_test \
           $IMAGE_TAG
 
-      - name: Setup Aiter for fork PR
-        if: ${{ github.event.pull_request.head.repo.fork }}
+      - name: Sync CK submodule
         run: |
           set -ex
-          echo "Setting up Aiter for fork PR..."
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Nightly build: syncing latest CK from develop branch..."
+            git submodule set-branch --branch develop 3rdparty/composable_kernel
+            git submodule sync
+            git submodule update --init --recursive --remote --jobs 4
+          else
+            echo "Using pinned CK commit..."
+            git submodule sync
+            git submodule update --init --recursive --depth 1 --jobs 4
+          fi
+
+      - name: Install Aiter wheel
+        run: |
+          set -euo pipefail
+          ls -lh aiter_wheels
+          shopt -s nullglob
+          wheels=(aiter_wheels/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one Aiter wheel artifact, found ${#wheels[@]}"
+            exit 1
+          fi
+          AITER_WHEEL_PATH="/workspace/${wheels[0]}"
+          echo "Installing Aiter wheel: ${AITER_WHEEL_PATH}"
           docker exec \
           -w /workspace \
           aiter_test \
-          bash -c "BUILD_TRITON=0 ./.github/scripts/build_aiter_triton.sh"
+          bash -lc "
+            pip uninstall -y amd-aiter aiter || true
+            pip install -r requirements.txt
+            pip install --upgrade pandas zmq einops numpy==1.26.2
+            pip install --upgrade 'pybind11>=3.0.1'
+            pip install --upgrade 'ninja>=1.11.1'
+            pip install tabulate
+            pip install '${AITER_WHEEL_PATH}'
+            pip show amd-aiter
+          "
 
       - name: Show Aiter version
         run: |

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -70,6 +70,10 @@ jobs:
           fi
           echo "CK commit: $(git -C 3rdparty/composable_kernel rev-parse HEAD)"
 
+      - name: Docker login
+        if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
+        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build Aiter wheel in base container
         run: |
           set -euo pipefail
@@ -277,6 +281,10 @@ jobs:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
           path: aiter_wheels
 
+      - name: Docker login
+        if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
+        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Run the container
         run: |
           set -ex
@@ -443,6 +451,10 @@ jobs:
         with:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
           path: aiter_wheels
+
+      - name: Docker login
+        if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
+        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Run the container
         run: |


### PR DESCRIPTION
## Summary

Fork PRs currently skip the entire `build_aiter_image` job because all steps are gated on `!fork` to protect Docker Hub secrets. This forces fork PRs to compile kernels from source on the GPU runner via `build_aiter_triton.sh`, wasting GPU time on compilation.

Only `docker login` and `docker push` actually need secrets. The `docker build` itself uses the public `rocm/pytorch:latest` base image and the fork's public clone URL — no secrets required.

**Changes:**
- Remove the `!fork` gate from checkout, Dockerfile generation, `docker build`, and kernel verification so fork PRs build prebuilt wheels on the CPU build runner
- Extract the wheel and upload as a GHA artifact for fork PRs
- In the test job, fork PRs download the wheel artifact and `pip install` it instead of running `build_aiter_triton.sh` from source
- Remove the `MAX_JOBS=64` fork-specific test path since fork PRs now have prebuilt kernels
- Gate Docker login in the test job on `!fork` (was running and failing silently with `|| true`)

**Unchanged:**
- Docker Hub push (still `!fork` only)
- Non-fork PR flow
- Nightly builds and S3 uploads
- Multi-GPU jobs (main branch only)

## Test plan

- [ ] Verify non-fork PR CI passes with no behavior change (build → push → pull → test)
- [ ] Open a test PR from a fork to verify: build job completes, wheel artifact uploaded, test job installs wheel and runs tests with prebuilt kernels
- [ ] Confirm kernel `.so` count in fork PR build matches non-fork builds