### PR TITLE
CI: add docker login before ATOM base image pull

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -89,6 +89,10 @@ jobs:
           repository: ${{ env.ATOM_REPOSITORY_URL }}
           branch: ${{ env.ATOM_BRANCH }}
 
+      - name: Docker login
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
+        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
+
       - name: Download the ATOM base image
         if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -90,7 +90,6 @@ jobs:
           branch: ${{ env.ATOM_BRANCH }}
 
       - name: Docker login
-        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
 
       - name: Download the ATOM base image


### PR DESCRIPTION
## Summary
- add a Docker registry login step before pulling the ATOM base image in `atom-test.yaml`
- make the ATOM test workflow more reliable on runners that require authentication before `docker pull`

## Test plan
- [ ] Trigger `Atom Test` on this PR
- [ ] Verify the `Download the ATOM base image` step succeeds on the affected runner
- [ ] Verify the remaining ATOM test steps still proceed normally