### PR TITLE
[gluon][pa_mqa_logits] memory-safety: mask all OutLogits buffer_store lanes (does NOT fix long-context accuracy)

### DIFF
--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -673,13 +673,17 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 mask=(
                     context_idx
                     + ChunkKPerStage
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     >= split_context_start
                 )
                 & (
                     context_idx
                     + ChunkKPerStage
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )
@@ -753,7 +757,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 mask=(
                     context_idx
                     + ChunkK
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )
@@ -1037,7 +1043,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 mask=(
                     context_idx_
                     + ChunkKPerStage
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )
@@ -1117,7 +1125,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 mask=(
                     context_idx_
                     + ChunkK
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )
@@ -1537,13 +1547,17 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 mask=(
                     context_idx
                     + ChunkKPerStage
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     >= split_context_start
                 )
                 & (
                     context_idx
                     + ChunkKPerStage
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )
@@ -1617,7 +1631,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 mask=(
                     context_idx
                     + ChunkK
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )
@@ -1901,7 +1917,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 mask=(
                     context_idx_
                     + ChunkKPerStage
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )
@@ -1981,7 +1999,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 mask=(
                     context_idx_
                     + ChunkK
-                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     < max_model_len
                 ),
             )

--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -282,9 +282,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
                 context_idx
                 + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
-            >= 0,
+            mask=(
+                (
+                    context_idx
+                    + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+                    >= 0
+                )
+                & (
+                    context_idx
+                    + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                )
+            ),
         )
 
     context_idx = split_context_start + split_context_length - ChunkK
@@ -310,8 +319,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
         ptr=OutLogits_buffer,
         offsets=(pid_batch * next_n + pid_next_n) * stride_out_batch
         + (context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))),
-        mask=context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
-        >= 0,
+        mask=(
+            (
+                context_idx
+                + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+                >= 0
+            )
+            & (
+                context_idx
+                + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            )
+        ),
     )
 
 

--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -595,9 +595,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 context_idx
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
 
         for context_idx in range(
@@ -663,10 +670,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
-                mask=context_idx
-                + ChunkKPerStage
-                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-                >= split_context_start,
+                mask=(
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    >= split_context_start
+                )
+                & (
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
 
             # =======================================================================================
@@ -735,6 +750,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
+                mask=(
+                    context_idx
+                    + ChunkK
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
 
         context_idx = split_context_start + split_context_length - ChunkK
@@ -769,10 +790,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 + ChunkKPerStage
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + ChunkKPerStage
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
     else:
         context_idx = split_context_start
@@ -925,6 +954,11 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 context_idx
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
+            mask=(
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
 
         for context_idx_ in range(
@@ -1000,6 +1034,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
+                mask=(
+                    context_idx_
+                    + ChunkKPerStage
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
 
             # =======================================================================================
@@ -1074,6 +1114,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
+                mask=(
+                    context_idx_
+                    + ChunkK
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
             context_idx = context_idx_ + ChunkK
 
@@ -1106,6 +1152,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 context_idx
                 + ChunkKPerStage
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+            ),
+            mask=(
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
             ),
         )
 
@@ -1407,9 +1459,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 context_idx
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
 
         for context_idx in range(
@@ -1475,10 +1534,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
-                mask=context_idx
-                + ChunkKPerStage
-                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-                >= split_context_start,
+                mask=(
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    >= split_context_start
+                )
+                & (
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
 
             # =======================================================================================
@@ -1547,6 +1614,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
+                mask=(
+                    context_idx
+                    + ChunkK
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
 
         context_idx = split_context_start + split_context_length - ChunkK
@@ -1581,10 +1654,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 + ChunkKPerStage
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + ChunkKPerStage
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
     else:
         context_idx = split_context_start
@@ -1737,6 +1818,11 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 context_idx
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
+            mask=(
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
 
         for context_idx_ in range(
@@ -1812,6 +1898,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
+                mask=(
+                    context_idx_
+                    + ChunkKPerStage
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
 
             # =======================================================================================
@@ -1886,6 +1978,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
+                mask=(
+                    context_idx_
+                    + ChunkK
+                    + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                    < max_model_len
+                ),
             )
             context_idx = context_idx_ + ChunkK
 
@@ -1918,5 +2016,11 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 context_idx
                 + ChunkKPerStage
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+            ),
+            mask=(
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
             ),
         )


### PR DESCRIPTION
## Summary (memory safety only — see "Scope" below)

Several `gl.amd.cdna3.buffer_store(ptr=OutLogits_buffer, …)` sites in the Gluon
`pa_mqa_logits` kernels write `float32` logits at logical column indices `col`
without an upper bound on `col < max_model_len`. Existing predicates only cover
the lower bound (e.g. `col >= 0` or `col >= split_context_start`). When
`context_length == max_model_len` and `split_context_length` is rounded up to
the next `KVBlockSize`, the inner-loop tail can issue stores up to
`(KVBlockSize − 1) + (ChunkKPerStage − 1)` columns past the end of the
`OutLogits_buffer` allocation. That is the textbook unmasked-`buffer_store`
overshoot pattern.

This patch combines `(col < max_model_len)` with the existing predicate via
`&` at every `OutLogits_buffer` store site in:

- `_gluon_deepgemm_fp8_paged_mqa_logits`
- `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle`
- `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx`

So lanes with `col >= max_model_len` are predicated off and no longer issue a
`buffer_store`. Nothing else in the kernel body (KV/scale loads, MFMA,
`gl.reduce`, the `tl.where` that fills `o`) is touched, so for any **in-bounds**
column the value of `OutLogits_buffer[batch, col]` is bit-identical before and
after this PR.

## Scope (read this first)

- This PR is a **memory-safety / OOB-write fix only.** It removes
  undefined-behaviour writes that can produce HIP "Memory access fault by GPU"
  (MAF) failures or silently corrupt neighbouring memory.
- This PR does **not** claim to change numerical answers for in-bounds
  columns. By construction it cannot — the upstream computation path is
  untouched.
- Therefore, this PR also does **not** address the documented long-context
  numerical regression in `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle`
  on `gfx950` (top-k mismatch vs. `deepgemm_fp8_paged_mqa_logits_stage1` once
  `context_len` exceeds ~2048; see vLLM
  [#39303](https://github.com/vllm-project/vllm/issues/39303)). That accuracy
  bug is a **separate** kernel-integration issue (SplitKV tiling, KV-block
  addressing in the `LoadBlockIndiceForEachStage` branch, MFMA operand
  orientation) and will be addressed in a follow-up.

## Worked bounds example

With `max_model_len = 100`, `ChunkKPerStage = 32`, `context_idx = 75`: lane
columns `75 … 106` were emitted. Only `75 … 99` are valid;
the **last 7 lanes** were performing OOB stores. With this PR they are
predicated off.

With `ChunkK = 256`, `ChunkKPerStage = 128`, `max_model_len = 5120`,
`context_idx = 5040`: indices up to `5167` are emitted; **48 tail lanes**
past `5119` were performing OOB stores and are now predicated off.

## Validation

| Gate | Status / Role |
|------|----------------|
| Ruff / Black on `pa_mqa_logits.py` | ✅ green |
| Repository style/dependency checks | ✅ green |
| Triton MI35X test shards (1 / 2 / 3 / 4 / 5 / 6 / 7) | ✅ green |
| OPUS Tests (MI35X) | ✅ green |
| Standard 1-GPU MI35X shards (0 / 1 / 4) | ✅ green |
| Standard 1-GPU MI35X shard 2 | ⚠ failure (under triage; pre-existing on main per author's bisect) |
| Standard 1-GPU MI300X shards | ⚠ failures (pre-existing on `main`, not caused by this PR; see CI artifacts) |
| Independent vLLM-side parallel of this fix (over-allocate `_cached_paged_logits` by +256 cols) | ✅ closed an MAF-class crash that previously reproduced reliably on long-context MTP, **20 / 20 trials** clean back-to-back at `n_spec=1, c=4` on MI355X |

The vLLM-side variant is the operational equivalent of this PR (it lets the
kernel's overshoot land in safe row padding instead of relying on the kernel
to predicate). Both are valid mitigations for the same memory-safety bug; the
kernel-side fix in this PR removes the dependency on caller-side padding and
is the right layer for the fix.

## Patch reproducibility

Regenerate via the supplied diff or cherry-pick from the branch tip; only
`buffer_store` predicates change.

## Checklist

- [x] Ruff / Black clean on touched file
- [x] All listed kernels: `(col < max_model_len)` `&`-combined with prior
      predicate on every `OutLogits_buffer` store
- [x] Confirmed by external (vLLM-side) operational equivalent that the
      OOB write is the cause of the MAF-class crash
- [ ] Upstream ROCm CI fully green on the latest commit before promoting
      from draft to ready-for-review
