### PR TITLE
fix num_stages in `test_ff_a16w16_fused.py` to account for irregular shapes

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused.json
@@ -5,7 +5,7 @@
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 2,
+        "num_stages": 1,
         "waves_per_eu": 3,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg",


### PR DESCRIPTION
## Motivation

Fix `test_ff_a16w16_fused.py` failures on gfx950 when `TRITON_HIP_USE_ASYNC_COPY=1` is enabled. The failures were isolated to irregular correctness-test shapes such as `(3, 5, 2)`, which were exhausting LDS due to the selected fused FF config using too much staging for async copy.

## Technical Details

Updated the `gfx950-FF-A16W16-fused.json` config by changing `num_stages` from `2` to `1` for the affected small-M bucket. 
With async copy enabled, reducing the pipeline stages lowers the LDS requirement for these tiny irregular shapes while preserving the existing config structure and avoiding wrapper/kernel logic changes.

It's important to note that this change only applies to the small-M bucket on gfx950 and does not affect larger shapes or other architectures. Larger shapes retain pipelining `num_stages=2`.

## Test Plan

Ran the full pytest suite for test_ff_a16w16_fused.py covering:

```
(batch, hidden_dim, intermediate_dim) from get_x_vals():
  - minimal case: (1, 1, 1)
  - irregular correctness case: (3, 5, 2)
  - cubic shapes: (1024v, 1024v, 1024v) for v ∈ {1, 2, 4, 5, 8}
  - DSR1 router GEMM shapes: (2^i, 256, 7168) for i ∈ {5, 6, 7, 8}
  - GPT-OSS-120B attention projection shapes:
      - (2^i, 5120, 2880) for i ∈ {5, 6, 7, 8}
      - (2^i, 2880, 4096) for i ∈ {5, 6, 7, 8}
      - (2^i, 128, 2880) for i ∈ {5, 6, 7, 8}
  - large FC1 shapes: (256, 106496, 16384), (4096, 106496, 16384)

dtype ∈ {float16, bfloat16}
output ∈ {True, False}
activation ∈ {silu_exp2, gelu_tanh, relu, None}
kernel variants ∈ {ff_a16w16_fused_ungated, ff_a16w16_fused_gated}
```

## Test Result

We are seeing all tests previously failing, now passing with `672 passed, 128 skipped, and 352 warnings`
Note: the skip and warning number was the same prior to the change addressed in this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
