### PR TITLE
Make `rmsnorm2d_fwd` Handle Strided Higher-Rank Inputs Safely

### DIFF
--- a/aiter/ops/rmsnorm.py
+++ b/aiter/ops/rmsnorm.py
@@ -9,6 +9,28 @@ from typing import Optional
 MD_NAME = "module_rmsnorm"
 
 
+def _prepare_rmsnorm2d_input(
+    input: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Size | None]:
+    """Return a safe 2D contiguous tensor for RMSNorm kernels.
+
+    The low-level RMSNorm kernels operate on 2D contiguous inputs. Keep the
+    common already-safe layout as a zero-copy fast path, and only normalize
+    higher-rank or strided views.
+    """
+    if input.dim() == 2 and input.is_contiguous():
+        return input, None
+
+    original_shape = input.shape
+    return input.contiguous().reshape(-1, original_shape[-1]), original_shape
+
+
+def _restore_shape(output: torch.Tensor, original_shape: torch.Size | None) -> torch.Tensor:
+    if original_shape is None:
+        return output
+    return output.reshape(original_shape)
+
+
 @compile_ops("module_rmsnorm")
 def rms_norm_cu(
     out: Tensor,
@@ -65,12 +87,13 @@ def rmsnorm2d_fwd(
     epsilon: float,
     use_model_sensitive_rmsnorm: int = 0,
 ) -> Tensor:
-    if use_model_sensitive_rmsnorm > 0 or input.shape[-1] > 8192:
-        out = rmsnorm2d_fwd_ck(input, weight, epsilon, use_model_sensitive_rmsnorm)
+    input_2d, original_shape = _prepare_rmsnorm2d_input(input)
+    if use_model_sensitive_rmsnorm > 0 or input_2d.shape[-1] > 8192:
+        out = rmsnorm2d_fwd_ck(input_2d, weight, epsilon, use_model_sensitive_rmsnorm)
     else:
-        out = torch.empty_like(input, dtype=input.dtype, device=input.device)
-        rmsnorm(out, input, weight, epsilon)
-    return out
+        out = torch.empty_like(input_2d, dtype=input_2d.dtype, device=input_2d.device)
+        rmsnorm(out, input_2d, weight, epsilon)
+    return _restore_shape(out, original_shape)
 
 
 def rmsnorm2d_fwd_with_add(

--- a/op_tests/repro_rmsnorm2d_strided_layout.py
+++ b/op_tests/repro_rmsnorm2d_strided_layout.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Reproducer for Aiter rmsnorm2d_fwd layout handling on gfx942.
+
+The public rmsnorm2d_fwd API should accept higher-rank strided views such as
+Q/K tensors sliced from a packed QKV projection. Older behavior passed those
+views directly to the low-level 2D HIP kernel and could memory-fault on MI325
+(gfx942).
+
+Safe fixed path:
+    python op_tests/repro_rmsnorm2d_strided_layout.py --mode fixed
+
+Compare fixed public API against the old low-level path in an isolated child:
+    python op_tests/repro_rmsnorm2d_strided_layout.py --mode both
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+
+
+GPUCORE_GLOBS = (
+    "/sgl-workspace/sglang/gpucore.*",
+    "/sgl-workspace/gpucore.*",
+    "/tmp/gpucore.*",
+    "/root/gpucore.*",
+)
+
+
+def cleanup_gpucore() -> None:
+    for pattern in GPUCORE_GLOBS:
+        for path in glob.glob(pattern):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+
+def make_strided_qk():
+    import torch
+
+    tokens = 2048
+    q_dim = 4096
+    kv_dim = 1024
+    head_dim = 128
+    packed_dim = q_dim + 2 * kv_dim
+
+    qkv = torch.randn((tokens, packed_dim), device="cuda", dtype=torch.bfloat16)
+    q = qkv[:, :q_dim].view(tokens, q_dim // head_dim, head_dim)
+    k = qkv[:, q_dim : q_dim + kv_dim].view(tokens, kv_dim // head_dim, head_dim)
+    return q, k
+
+
+def describe(name, tensor) -> None:
+    print(
+        f"{name}: shape={tuple(tensor.shape)} stride={tuple(tensor.stride())} "
+        f"contiguous={tensor.is_contiguous()} dtype={tensor.dtype}",
+        flush=True,
+    )
+
+
+def run_fixed() -> None:
+    import torch
+    from aiter.ops.rmsnorm import rmsnorm2d_fwd
+
+    q, k = make_strided_qk()
+    describe("q_input", q)
+    describe("k_input", k)
+
+    q_weight = torch.ones((q.shape[-1],), device="cuda", dtype=torch.bfloat16)
+    k_weight = torch.ones((k.shape[-1],), device="cuda", dtype=torch.bfloat16)
+
+    q_out = rmsnorm2d_fwd(q, q_weight, 1e-6)
+    k_out = rmsnorm2d_fwd(k, k_weight, 1e-6)
+    torch.cuda.synchronize()
+
+    describe("q_output", q_out)
+    describe("k_output", k_out)
+    assert q_out.shape == q.shape
+    assert k_out.shape == k.shape
+    print("FIXED_PUBLIC_API_OK", flush=True)
+
+
+def run_old_low_level_path() -> None:
+    import torch
+    from aiter.ops.rmsnorm import rmsnorm
+
+    q, k = make_strided_qk()
+    describe("q_input", q)
+    describe("k_input", k)
+
+    q_weight = torch.ones((q.shape[-1],), device="cuda", dtype=torch.bfloat16)
+    k_weight = torch.ones((k.shape[-1],), device="cuda", dtype=torch.bfloat16)
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+
+    print(
+        "Calling low-level rmsnorm(out, input, weight, eps) directly on strided "
+        "3D views. This represents the pre-fix public-wrapper behavior and may "
+        "abort on gfx942.",
+        flush=True,
+    )
+    rmsnorm(q_out, q, q_weight, 1e-6)
+    rmsnorm(k_out, k, k_weight, 1e-6)
+    torch.cuda.synchronize()
+    print("OLD_LOW_LEVEL_PATH_DID_NOT_CRASH", flush=True)
+
+
+def run_both() -> int:
+    print("=== Fixed public API path ===", flush=True)
+    run_fixed()
+
+    print("\n=== Old low-level path in subprocess ===", flush=True)
+    proc = subprocess.run([sys.executable, __file__, "--mode", "old-low-level"])
+    cleanup_gpucore()
+    print(f"OLD_LOW_LEVEL_SUBPROCESS_EXIT_CODE={proc.returncode}", flush=True)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("fixed", "old-low-level", "both"),
+        default="fixed",
+        help="'old-low-level' may crash on gfx942; 'both' isolates it in a child process.",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "fixed":
+        run_fixed()
+    elif args.mode == "old-low-level":
+        run_old_low_level_path()
+    else:
+        run_both()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR fixes a gfx942 memory fault in Aiter's public `rmsnorm2d_fwd` wrapper when callers pass higher-rank strided tensors, such as Q/K views sliced from a packed QKV projection.

The wrapper now normalizes inputs to a contiguous 2D view before dispatching to the existing 2D RMSNorm kernels, then reshapes the output back to the caller's original shape.

## Motivation

SGLang's Qwen3 Q/K normalization path can pass tensors shaped like:

```text
q: shape=(2048, 32, 128), stride=(6144, 128, 1)
k: shape=(2048,  8, 128), stride=(6144, 128, 1)
```

These tensors are strided 3D views sliced from a packed QKV projection. Calling Aiter's low-level `rmsnorm` kernel directly on those views memory-faults on MI325/gfx942:

```text
Memory access fault by GPU node-2 ... Reason: Unknown.
Fatal Python error: Aborted
```

The same workload does not reproduce on MI355/gfx950, which suggests a gfx942-sensitive kernel/layout issue.

## Root Cause

`rmsnorm2d_fwd` is a public API, but its fast path passed `input` directly into a low-level kernel that expects a contiguous 2D tensor:

```python
out = torch.empty_like(input, dtype=input.dtype, device=input.device)
rmsnorm(out, input, weight, epsilon)
```

For higher-rank strided inputs, `torch.empty_like(input)` preserves the higher-rank shape, and the low-level 2D kernel receives a layout it does not safely support.

## Fix

Add layout normalization in `aiter/ops/rmsnorm.py`:

```python
input_2d, original_shape = _as_2d_contiguous(input)
...
out = rmsnorm2d_kernel(input_2d, ...)
return _restore_shape(out, original_shape)
```

The public API keeps the same output shape as before, but the low-level 2D kernel only sees a safe contiguous 2D tensor.

## Files Changed

```text
aiter/ops/rmsnorm.py
op_tests/repro_rmsnorm2d_strided_layout.py
```

## Reproducer

Safe fixed path:

```bash
cd /sgl-workspace/aiter
python op_tests/repro_rmsnorm2d_strided_layout.py --mode fixed
```

Expected:

```text
q_input: shape=(2048, 32, 128) stride=(6144, 128, 1) contiguous=False ...
k_input: shape=(2048, 8, 128) stride=(6144, 128, 1) contiguous=False ...
q_output: shape=(2048, 32, 128) ...
k_output: shape=(2048, 8, 128) ...
FIXED_PUBLIC_API_OK
```

Compare fixed public API against the old unsafe low-level path:

```bash
cd /sgl-workspace/aiter
python op_tests/repro_rmsnorm2d_strided_layout.py --mode both
```

On gfx942, expected behavior:

```text
=== Fixed public API path ===
FIXED_PUBLIC_API_OK

=== Old low-level path in subprocess ===
Calling low-level rmsnorm(...) directly on strided 3D views...
Memory access fault by GPU node-2 ...
OLD_LOW_LEVEL_SUBPROCESS_EXIT_CODE=-6
```

The unsafe path runs in a subprocess so the parent process can report the failure and clean `gpucore.*` files.

## Validation

Validated on MI325/gfx942:

```bash
python op_tests/repro_rmsnorm2d_strided_layout.py --mode fixed
```

Result:

```text
FIXED_PUBLIC_API_OK
```

Validated that the old low-level path still reproduces the gfx942 fault:

```bash
python op_tests/repro_rmsnorm2d_strided_layout.py --mode both
```

Result:

```text
OLD_LOW_LEVEL_SUBPROCESS_EXIT_CODE=-6
```

## Notes

- This is not a backend fallback.
- This preserves Aiter RMSNorm use.
- This is a public wrapper layout fix: callers can pass higher-rank tensors and receive the same higher-rank output shape, while the kernel receives the 2D contiguous layout it expects.
- SGLang also needs to keep its LFM/Qwen call sites correct, but this Aiter-side change makes the public API robust and prevents GPU faults from unsafe layouts.
