### PR TITLE
[TRITON] Fix: Prevent null pointer dereference with empty descale tensors

### DIFF
--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -139,6 +139,21 @@ def unified_attention(
     if sinks is not None:
         assert sinks.shape[0] == q.shape[1], "Sinks must be num_query_heads size"
 
+    # FIX: Normalize empty tensors to None to prevent null pointer dereference
+    # Empty tensors have data_ptr()=0 which causes memory access faults in the kernel.
+    # This happens when vLLM passes empty tensors instead of None for unused descale factors.
+    # See: https://github.com/vllm-project/vllm/issues/...
+    def _normalize_empty_tensor(tensor):
+        """Convert empty tensors to None to prevent null pointer dereference in kernel."""
+        if tensor is not None and tensor.numel() == 0:
+            return None
+        return tensor
+
+    q_descale = _normalize_empty_tensor(q_descale)
+    k_descale = _normalize_empty_tensor(k_descale)
+    v_descale = _normalize_empty_tensor(v_descale)
+    output_scale = _normalize_empty_tensor(output_scale)
+
     use_alibi_slopes = alibi_slopes is not None
     use_qq_bias = qq_bias is not None
     SLIDING_WINDOW = 1 + window_size[0]


### PR DESCRIPTION
Fixes a memory access fault in unified_attention kernel when used with empty descale tensors.

Root cause:
- The kernel checks `if q_descale_ptr is not None` but doesn't validate that the tensor is non-empty before calling `tl.load(q_descale_ptr)`
- When vLLM passes empty tensors (torch.empty(0)), the data_ptr() is 0x0
- This causes a null pointer dereference during CUDA graph capture

Symptoms:
- Memory access fault by GPU on address (nil)
- Crash at ~98% during "Capturing CUDA graphs (decode, FULL)"
- vLLM server fails to start with FP8 models

Fix:
- Added _normalize_empty_tensor() helper that converts empty tensors to None
- Applied to q_descale, k_descale, v_descale, and output_scale
- Works for both 2D and 3D kernel paths
- Zero performance impact (one-time check before kernel launch)

Tested with:
- Unit tests covering None, valid, and empty tensor cases
- CUDA graph capture and replay
- vLLM server with Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 model
- All tests pass, server starts successfully

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
