### PR TITLE
[GFX1250] Add Triton TDM to MoE Metadata kernels 

### DIFF
--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
@@ -51,7 +51,9 @@ def _routing_compute_indx(
     if USE_TDM and EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expt_desc = tl.make_tensor_descriptor(
             base=ExptIndx + pid_m * BLOCK_M * N_EXPTS_ACT,
-            shape=(1, LOAD_SIZE), strides=(LOAD_SIZE, 1), block_shape=(1, LOAD_SIZE)
+            shape=(1, LOAD_SIZE),
+            strides=(LOAD_SIZE, 1),
+            block_shape=(1, LOAD_SIZE),
         )
         expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
     elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
@@ -122,7 +124,9 @@ def _routing_compute_indx_fused(
     if USE_TDM and EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expt_desc = tl.make_tensor_descriptor(
             base=ExptIndx,
-            shape=(1, LOAD_SIZE), strides=(LOAD_SIZE, 1), block_shape=(1, LOAD_SIZE)
+            shape=(1, LOAD_SIZE),
+            strides=(LOAD_SIZE, 1),
+            block_shape=(1, LOAD_SIZE),
         )
         expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
     elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
@@ -56,6 +56,7 @@ def _routing_compute_indx(
             block_shape=(1, LOAD_SIZE),
         )
         expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
+        expert = tl.where(offs < n_gates, expert, -1).to(tl.uint32)
     elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expert = tl.load(ExptIndx + offs).to(tl.uint32)
     else:
@@ -129,6 +130,7 @@ def _routing_compute_indx_fused(
             block_shape=(1, LOAD_SIZE),
         )
         expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
+        expert = tl.where(offs < n_gates, expert, -1).to(tl.uint32)
     elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expert = tl.load(ExptIndx + offs).to(tl.uint32)
     else:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
@@ -40,13 +40,21 @@ def _routing_compute_indx(
     EVEN_M: tl.constexpr,
     N_EXPTS_ACT: tl.constexpr,
     N_EXPTS_ACT_PAD: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
 
     tl.static_assert(N_EXPTS_ACT_PAD * BLOCK_M <= 32768)
 
-    local_offs = tl.arange(0, N_EXPTS_ACT_PAD * BLOCK_M)
+    LOAD_SIZE: tl.constexpr = N_EXPTS_ACT_PAD * BLOCK_M
+    local_offs = tl.arange(0, LOAD_SIZE)
     offs = pid_m * BLOCK_M * N_EXPTS_ACT + local_offs
-    if EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
+    if USE_TDM and EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
+        expt_desc = tl.make_tensor_descriptor(
+            base=ExptIndx + pid_m * BLOCK_M * N_EXPTS_ACT,
+            shape=(1, LOAD_SIZE), strides=(LOAD_SIZE, 1), block_shape=(1, LOAD_SIZE)
+        )
+        expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
+    elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expert = tl.load(ExptIndx + offs).to(tl.uint32)
     else:
         expert = tl.load(ExptIndx + offs, mask=(offs < n_gates), other=-1).to(tl.uint32)
@@ -103,13 +111,21 @@ def _routing_compute_indx_fused(
     EVEN_M: tl.constexpr,
     N_EXPTS_ACT: tl.constexpr,
     N_EXPTS_ACT_PAD: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
 
     tl.static_assert(N_EXPTS_ACT_PAD * BLOCK_M <= 32768)
 
-    local_offs = tl.arange(0, N_EXPTS_ACT_PAD * BLOCK_M)
+    LOAD_SIZE: tl.constexpr = N_EXPTS_ACT_PAD * BLOCK_M
+    local_offs = tl.arange(0, LOAD_SIZE)
     offs = local_offs
-    if EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
+    if USE_TDM and EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
+        expt_desc = tl.make_tensor_descriptor(
+            base=ExptIndx,
+            shape=(1, LOAD_SIZE), strides=(LOAD_SIZE, 1), block_shape=(1, LOAD_SIZE)
+        )
+        expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
+    elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expert = tl.load(ExptIndx + offs).to(tl.uint32)
     else:
         expert = tl.load(ExptIndx + offs, mask=(offs < n_gates), other=-1).to(tl.uint32)
@@ -176,6 +192,7 @@ def _combined_routing(
     tile_dim_log2: tl.constexpr,
     BLOCK_A: tl.constexpr,
     EQUAL_A: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
 
     pid = tl.program_id(0)
@@ -214,6 +231,7 @@ def _combined_routing(
             EVEN_M,
             N_EXPTS_ACT,
             N_EXPTS_ACT_PAD,
+            USE_TDM,
         )
 
 
@@ -244,6 +262,7 @@ def _combined_routing_fused(
     tile_dim_log2: tl.constexpr,
     BLOCK_A: tl.constexpr,
     EQUAL_A: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
 
     pid = tl.program_id(0)
@@ -295,4 +314,5 @@ def _combined_routing_fused(
             EVEN_M,
             N_EXPTS_ACT,
             N_EXPTS_ACT_PAD,
+            USE_TDM,
         )

--- a/aiter/ops/triton/_triton_kernels/moe/reduce.py
+++ b/aiter/ops/triton/_triton_kernels/moe/reduce.py
@@ -14,6 +14,7 @@ def _reduce_grouped(
     stride_on,  # output tensor
     InIndx,
     B,
+    M,
     N,
     num_blocks,
     # fused activation function
@@ -25,6 +26,7 @@ def _reduce_grouped(
     BLOCK_N: tl.constexpr,
     EVEN_N: tl.constexpr,
     ADD_RESIDUAL: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
     pid = tl.program_id(0)
     pid_t = pid // num_blocks
@@ -44,16 +46,24 @@ def _reduce_grouped(
 
     acc = tl.zeros([BLOCK_N_OUT], dtype=tl.float32)
     x_n_mask = pid_n * BLOCK_N + tl.arange(0, BLOCK_N) < N
+    if USE_TDM and EVEN_N:
+        x_desc = tl.make_tensor_descriptor(
+            base=X, shape=(B * M, N), strides=(N, 1), block_shape=(1, BLOCK_N)
+        )
     # accumulate contributions for this tile
     for i in tl.static_range(0, K):
         curr = tl.zeros([BLOCK_N], dtype=tl.float32)
         # iterate over split_k partial values
         for b in tl.range(0, B):
-            x_row_ptr = XPtrs + indxs[i] * stride_xm + b * stride_xb
-            if EVEN_N:
-                vals = tl.load(x_row_ptr)
+            if USE_TDM and EVEN_N:
+                row = b * M + indxs[i]
+                vals = tl.reshape(x_desc.load([row, pid_n * BLOCK_N]), (BLOCK_N,))
             else:
-                vals = tl.load(x_row_ptr, mask=x_n_mask, other=0.0)
+                x_row_ptr = XPtrs + indxs[i] * stride_xm + b * stride_xb
+                if EVEN_N:
+                    vals = tl.load(x_row_ptr)
+                else:
+                    vals = tl.load(x_row_ptr, mask=x_n_mask, other=0.0)
             vals = vals.to(tl.float32)
             curr += vals
 

--- a/aiter/ops/triton/_triton_kernels/topk.py
+++ b/aiter/ops/triton/_triton_kernels/topk.py
@@ -63,7 +63,10 @@ def _topk_kernel(
 
     if USE_TDM:
         row_desc = tl.make_tensor_descriptor(
-            base=X + pid * stride_xm, shape=(1, M), strides=(M, 1), block_shape=(1, BLOCK)
+            base=X + pid * stride_xm,
+            shape=(1, M),
+            strides=(M, 1),
+            block_shape=(1, BLOCK),
         )
         vals = tl.reshape(row_desc.load([0, 0]), (BLOCK,)).to(tl.float32)
     else:
@@ -112,7 +115,10 @@ def topk_stage1_kernel(
 
     if USE_TDM:
         x_desc = tl.make_tensor_descriptor(
-            base=x_ptr + cur_batch * N, shape=(1, N), strides=(N, 1), block_shape=(1, CHUNK_SIZE)
+            base=x_ptr + cur_batch * N,
+            shape=(1, N),
+            strides=(N, 1),
+            block_shape=(1, CHUNK_SIZE),
         )
         x_val = tl.reshape(x_desc.load([0, chunk_offset]), (CHUNK_SIZE,)).to(tl.float32)
     else:
@@ -273,10 +279,16 @@ def topk_stage2_kernel(
 
     if USE_TDM:
         cx_desc = tl.make_tensor_descriptor(
-            base=chunk_x + cur_batch * N, shape=(1, N), strides=(N, 1), block_shape=(1, BLOCK_SIZE)
+            base=chunk_x + cur_batch * N,
+            shape=(1, N),
+            strides=(N, 1),
+            block_shape=(1, BLOCK_SIZE),
         )
         ci_desc = tl.make_tensor_descriptor(
-            base=chunk_index + cur_batch * N, shape=(1, N), strides=(N, 1), block_shape=(1, BLOCK_SIZE)
+            base=chunk_index + cur_batch * N,
+            shape=(1, N),
+            strides=(N, 1),
+            block_shape=(1, BLOCK_SIZE),
         )
         chunk_x_val = tl.reshape(cx_desc.load([0, 0]), (BLOCK_SIZE,)).to(tl.float32)
         chunk_index_val = tl.reshape(ci_desc.load([0, 0]), (BLOCK_SIZE,)).to(tl.int32)
@@ -284,10 +296,12 @@ def topk_stage2_kernel(
         chunk_x += cur_batch * N
         chunk_index += cur_batch * N
         mask = cols < N
-        chunk_x_val = tl.load(chunk_x + cols, mask=mask, other=FILL_VALUE).to(tl.float32)
-        chunk_index_val = tl.load(chunk_index + cols, mask=mask, other=MASK_INDEX_VAL).to(
-            tl.int32
+        chunk_x_val = tl.load(chunk_x + cols, mask=mask, other=FILL_VALUE).to(
+            tl.float32
         )
+        chunk_index_val = tl.load(
+            chunk_index + cols, mask=mask, other=MASK_INDEX_VAL
+        ).to(tl.int32)
 
     sorted_chunk_x, sorted_chunk_index = argsort(
         chunk_x_val, chunk_index_val, 0, descending=DESCENDING

--- a/aiter/ops/triton/_triton_kernels/topk.py
+++ b/aiter/ops/triton/_triton_kernels/topk.py
@@ -53,17 +53,24 @@ def _topk_kernel(
     K: tl.constexpr,
     BLOCK: tl.constexpr,
     FILL_VALUE: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    row_ptr = X + pid * stride_xm
     offs = tl.arange(0, BLOCK)
-    mask = offs < M
-    # FILL_VALUE = tl.constexpr(torch.finfo(torch.float32).min)
-    vals = tl.load(row_ptr + offs, mask=mask, other=FILL_VALUE).to(tl.float32)
     idxs = offs.to(tl.int64)
-
     out_v_ptr = OUT_V + pid * stride_ovm
     out_i_ptr = OUT_I + pid * stride_oim
+
+    if USE_TDM:
+        row_desc = tl.make_tensor_descriptor(
+            base=X + pid * stride_xm, shape=(1, M), strides=(M, 1), block_shape=(1, BLOCK)
+        )
+        vals = tl.reshape(row_desc.load([0, 0]), (BLOCK,)).to(tl.float32)
+    else:
+        row_ptr = X + pid * stride_xm
+        mask = offs < M
+        # FILL_VALUE = tl.constexpr(torch.finfo(torch.float32).min)
+        vals = tl.load(row_ptr + offs, mask=mask, other=FILL_VALUE).to(tl.float32)
 
     # unrolled exactly K iterations -- no break/continue needed
     for j in core.static_range(0, K):
@@ -91,6 +98,7 @@ def topk_stage1_kernel(
     CHUNK_SIZE: tl.constexpr,
     DESCENDING: tl.constexpr,
     FILL_VALUE: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_chunk_idx = tl.program_id(1)
@@ -100,15 +108,20 @@ def topk_stage1_kernel(
     index_ptr += cur_batch * chunk_num * k + cur_chunk_idx * k
 
     chunk_offset = cur_chunk_idx * CHUNK_SIZE
-    x_ptr += cur_batch * N + chunk_offset
-
     cols = tl.arange(0, CHUNK_SIZE)
-    mask = (chunk_offset + cols) < N
 
-    # FILL_VALUE = tl.constexpr(
-    #    torch.finfo(torch.float32).min if DESCENDING else torch.finfo(torch.float32).max
-    # )
-    x_val = tl.load(x_ptr + cols, mask=mask, other=FILL_VALUE).to(tl.float32)
+    if USE_TDM:
+        x_desc = tl.make_tensor_descriptor(
+            base=x_ptr + cur_batch * N, shape=(1, N), strides=(N, 1), block_shape=(1, CHUNK_SIZE)
+        )
+        x_val = tl.reshape(x_desc.load([0, chunk_offset]), (CHUNK_SIZE,)).to(tl.float32)
+    else:
+        x_ptr += cur_batch * N + chunk_offset
+        mask = (chunk_offset + cols) < N
+        # FILL_VALUE = tl.constexpr(
+        #    torch.finfo(torch.float32).min if DESCENDING else torch.finfo(torch.float32).max
+        # )
+        x_val = tl.load(x_ptr + cols, mask=mask, other=FILL_VALUE).to(tl.float32)
     for k_idx in range(k):
         if DESCENDING:
             chunk_select_val, chunk_select_idx = tl.max(
@@ -251,29 +264,30 @@ def topk_stage2_kernel(
     DESCENDING: tl.constexpr,
     FILL_VALUE: tl.constexpr,
     MASK_INDEX_VAL: tl.constexpr,
+    USE_TDM: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
-    chunk_x += cur_batch * N
-    chunk_index += cur_batch * N
     y_ptr += cur_batch * k
     index_ptr += cur_batch * k
-
     cols = tl.arange(0, BLOCK_SIZE)
-    mask = cols < N
 
-    # FILL_VALUE = tl.constexpr(
-    #    torch.finfo(torch.float32).min if DESCENDING else torch.finfo(torch.float32).max
-    # )
-    # mask_index_val = (
-    #    tl.constexpr(torch.iinfo(torch.int32).min)
-    #    if DESCENDING
-    #    else tl.constexpr(torch.iinfo(torch.int32).max)
-    # )
-
-    chunk_x_val = tl.load(chunk_x + cols, mask=mask, other=FILL_VALUE).to(tl.float32)
-    chunk_index_val = tl.load(chunk_index + cols, mask=mask, other=MASK_INDEX_VAL).to(
-        tl.int32
-    )
+    if USE_TDM:
+        cx_desc = tl.make_tensor_descriptor(
+            base=chunk_x + cur_batch * N, shape=(1, N), strides=(N, 1), block_shape=(1, BLOCK_SIZE)
+        )
+        ci_desc = tl.make_tensor_descriptor(
+            base=chunk_index + cur_batch * N, shape=(1, N), strides=(N, 1), block_shape=(1, BLOCK_SIZE)
+        )
+        chunk_x_val = tl.reshape(cx_desc.load([0, 0]), (BLOCK_SIZE,)).to(tl.float32)
+        chunk_index_val = tl.reshape(ci_desc.load([0, 0]), (BLOCK_SIZE,)).to(tl.int32)
+    else:
+        chunk_x += cur_batch * N
+        chunk_index += cur_batch * N
+        mask = cols < N
+        chunk_x_val = tl.load(chunk_x + cols, mask=mask, other=FILL_VALUE).to(tl.float32)
+        chunk_index_val = tl.load(chunk_index + cols, mask=mask, other=MASK_INDEX_VAL).to(
+            tl.int32
+        )
 
     sorted_chunk_x, sorted_chunk_index = argsort(
         chunk_x_val, chunk_index_val, 0, descending=DESCENDING

--- a/aiter/ops/triton/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/moe/moe_routing/routing.py
@@ -5,6 +5,7 @@ from aiter.ops.triton._triton_kernels.moe.moe_routing.routing import (
     _combined_routing,
     _combined_routing_fused,
 )
+from aiter.ops.triton.utils._triton.arch_info import is_tdm_avail
 
 
 @dataclass
@@ -115,6 +116,7 @@ def sort_tokens(expt_scal, expt_indx, n_expts_tot, bitmatrix, block_m, HIST_BLOC
         block_m_log2,
         BLOCK_A=BLOCK_A,
         EQUAL_A=(hist.shape[0] == BLOCK_A),  # optimization parameters
+        USE_TDM=is_tdm_avail(),
         num_warps=1,
     )
 
@@ -183,6 +185,7 @@ def sort_tokens_fused(
         block_m_log2,
         BLOCK_A=BLOCK_A,
         EQUAL_A=(hist.shape[0] == BLOCK_A),  # optimization parameters
+        USE_TDM=is_tdm_avail(),
         num_warps=1,
     )
 

--- a/aiter/ops/triton/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/moe/moe_routing/routing.py
@@ -218,8 +218,11 @@ def _compute_expt_data_internal(n_expts_tot, n_gates, block_m, device):
         max_n_tiles = n_gates
     else:
         max_n_tiles = n_expts_tot - 1 - ((n_expts_tot - n_gates - 1) // block_m)
+
     # allocate memory
-    pad = lambda x: cdiv(x, BLOCK) * BLOCK
+    def pad(x):
+        return cdiv(x, BLOCK) * BLOCK
+
     dtype = torch.int32
 
     token_offs_combined = torch.empty(

--- a/aiter/ops/triton/moe/reduce.py
+++ b/aiter/ops/triton/moe/reduce.py
@@ -1,6 +1,7 @@
 import torch
 import triton
 from aiter.ops.triton._triton_kernels.moe.reduce import _reduce_grouped
+from aiter.ops.triton.utils._triton.arch_info import is_tdm_avail
 
 
 def reduce_grouped(
@@ -58,7 +59,8 @@ def reduce_grouped(
         out.stride(1),  #
         indx,  #
         x.shape[0],
-        x.shape[-1],
+        x.shape[1],
+        x.shape[2],
         num_blocks,
         apply_swiglu,
         alpha,
@@ -68,6 +70,7 @@ def reduce_grouped(
         EVEN_N=(x.shape[-1] % BLOCK_N == 0),
         K=K,  #
         ADD_RESIDUAL=add_residual,
+        USE_TDM=is_tdm_avail(),
         num_warps=2,  #
     )
     return out

--- a/aiter/ops/triton/topk.py
+++ b/aiter/ops/triton/topk.py
@@ -18,6 +18,7 @@ from aiter.ops.triton._triton_kernels.topk import (
     topk_stage1_kernel,
     topk_stage2_kernel,
 )
+from aiter.ops.triton.utils._triton.arch_info import is_tdm_avail
 from aiter.ops.triton.utils.logger import AiterTritonLogger
 
 _LOGGER = AiterTritonLogger()
@@ -41,7 +42,6 @@ def one_stage_topk(
 
     out_v = torch.empty((B, k), device=x.device, dtype=x.dtype)
     out_i = torch.empty((B, k), device=x.device, dtype=torch.int64)
-
     _topk_kernel[(B,)](
         x.contiguous(),
         out_v,
@@ -53,6 +53,7 @@ def one_stage_topk(
         K=k,
         BLOCK=BLOCK,
         FILL_VALUE=torch.finfo(torch.float32).min,
+        USE_TDM=is_tdm_avail(),
         num_warps=4,
         num_stages=2,
     )
@@ -102,6 +103,7 @@ def two_stage_topk(x, k, dim=-1, largest=True):
             if descending
             else torch.finfo(torch.float32).max
         ),
+        USE_TDM=is_tdm_avail(),
     )
     stage2_elem_cnt = chunk_num * k
     BLOCK_SIZE = triton.next_power_of_2(stage2_elem_cnt)
@@ -122,6 +124,7 @@ def two_stage_topk(x, k, dim=-1, largest=True):
                 else torch.finfo(torch.float32).max
             ),
             torch.iinfo(torch.int32).min,
+            USE_TDM=is_tdm_avail(),
         )
         if descending
         else tl.constexpr(torch.iinfo(torch.int32).max)

--- a/aiter/ops/triton/utils/_triton/arch_info.py
+++ b/aiter/ops/triton/utils/_triton/arch_info.py
@@ -26,3 +26,7 @@ def is_fp8_avail():
 
 def is_mx_scale_preshuffling_avail():
     return get_arch() in ("gfx950", "gfx1250")
+
+
+def is_tdm_avail():
+    return get_arch() in ("gfx1250",)

--- a/op_tests/triton_tests/moe/test_moe_routing.py
+++ b/op_tests/triton_tests/moe/test_moe_routing.py
@@ -97,7 +97,7 @@ n_tokens = [4, 7, 8, 64, 255, 256, 371, 911, 1023, 1024, 4096, 8192]
 )
 @pytest.mark.parametrize("sm_first", [True, False])
 def test_op(n_tokens, n_expts_tot, n_expts_act, sm_first):
-    if get_arch() != "gfx950":
+    if get_arch() not in ["gfx950", "gfx1250"]:
         pytest.skip("MOE stack not fully implemented on non-CDNA4 arch yet.")
 
     device = "cuda"


### PR DESCRIPTION
## Motivation

Add TDM code path for gfx1250 in MoE metadata kernels (Routing, Topk, Reduce)

## Test Plan

Passes all UT 

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
