### PR TITLE
Skip triton install in develop mode when already installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ def _is_triton_installed():
     from importlib.metadata import version as pkg_version
 
     for pkg in [
-        "amd-triton",
         "triton",
         "pytorch-triton",
         "pytorch-triton-rocm",

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,10 @@ def _is_triton_installed():
         "triton-rocm",
     ]:
         try:
-            pkg_version(pkg)
-            return True
+            return pkg, pkg_version(pkg)
         except Exception:
             pass
-    return False
+    return None
 
 
 def _run_install_triton():
@@ -96,15 +95,17 @@ def _run_install_triton():
     subprocess.check_call(["bash", install_triton])
 
 
-if is_develop_mode() and _is_triton_installed():
+_triton_info = _is_triton_installed() if is_develop_mode() else None
+if _triton_info:
     print(
-        "[aiter] triton is already installed, skipping .github/scripts/install_triton.sh"
+        f"[aiter] {_triton_info[0]}=={_triton_info[1]} is already installed,"
+        " recommend using .github/scripts/install_triton.sh to install triton"
     )
 else:
     try:
         _run_install_triton()
     except Exception:
-        print("[aiter] Skipping .github/scripts/install_triton.sh")
+        print("[aiter] Skipping triton install via .github/scripts/install_triton.sh")
 
 
 def write_install_mode():

--- a/setup.py
+++ b/setup.py
@@ -71,13 +71,41 @@ if not IS_WINDOWS and is_develop_mode():
             ]
         )
 
+
+def _is_triton_installed():
+    from importlib.metadata import version as pkg_version
+
+    for pkg in [
+        "amd-triton",
+        "triton",
+        "pytorch-triton",
+        "pytorch-triton-rocm",
+        "triton-rocm",
+    ]:
+        try:
+            pkg_version(pkg)
+            return True
+        except Exception:
+            pass
+    return False
+
+
+def _run_install_triton():
+    print("[aiter] Installing amd-triton via .github/scripts/install_triton.sh")
+    install_triton = os.path.join(this_dir, ".github", "scripts", "install_triton.sh")
+    subprocess.check_call(["bash", install_triton])
+
+
+if is_develop_mode() and _is_triton_installed():
+    print(
+        "[aiter] triton is already installed, skipping .github/scripts/install_triton.sh"
+    )
+else:
     try:
-        install_triton = os.path.join(
-            this_dir, ".github", "scripts", "install_triton.sh"
-        )
-        subprocess.check_call(["bash", install_triton])
+        _run_install_triton()
     except Exception:
-        pass
+        print("[aiter] Skipping .github/scripts/install_triton.sh")
+
 
 
 def write_install_mode():

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ else:
         print("[aiter] Skipping .github/scripts/install_triton.sh")
 
 
-
 def write_install_mode():
     """Write install_mode so core.py uses aiter_meta/ (install) vs repo root (develop).
 


### PR DESCRIPTION
In develop mode, check if triton is already installed before running install_triton.sh to avoid pip conflicts. Non-develop mode still forces reinstall.

## Motivation

In develop mode, skip triton installation if already present and print the installed version. In non-develop mode, always run the install script. Provide a message when install is skipped.

## Technical Details

  - Add _is_triton_installed() to detect installed triton package and return its name and version.                                                                                                                                                                                                             
  - Add _run_install_triton() to wrap the install script call.
  - In develop mode, check triton presence before running install_triton.sh; print version and recommend the install script if already installed.                                                                                                                                                              
  - Remove amd-triton from the detection list since the install script itself installs it.  
## Test Plan

  - Run python setup.py develop with triton already installed — verify it skips install and prints the version info.
  - Run python setup.py develop without triton installed — verify it runs install_triton.sh.

## Test Result

Test results match expectations.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
