### PR TITLE
CI: retry Triton wheel build on transient failures

### DIFF
--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -22,24 +22,7 @@ BUILD_TRITON=${BUILD_TRITON:-1}
 if [[ "$BUILD_TRITON" == "1" ]]; then
     echo
     echo "==== Install triton ===="
-    pip uninstall -y triton || true
-
-    TRITON_WHEEL_DIR=${TRITON_WHEEL_DIR:-}
-    if [[ -n "$TRITON_WHEEL_DIR" ]] && ls "$TRITON_WHEEL_DIR"/*.whl 1>/dev/null 2>&1; then
-        echo "Installing triton from pre-built wheel in $TRITON_WHEEL_DIR"
-        pip install "$TRITON_WHEEL_DIR"/*.whl
-    else
-        echo "Building triton from source..."
-        # Pin triton to a known-good commit to avoid CI breakage from
-        # upstream changes (e.g. AMD codegen regressions in triton-lang/triton).
-        TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
-        git clone https://github.com/triton-lang/triton || true
-        cd triton
-        git checkout "$TRITON_COMMIT"
-        pip install -r python/requirements.txt
-        MAX_JOBS=64 pip --retries=10 --default-timeout=60 install .
-        cd ..
-    fi
+    bash ./.github/scripts/install_triton.sh
     pip install filecheck
     # NetworkX is a dependency of Triton test selection script
     # `.github/scripts/select_triton_tests.py`.

--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -ex
+
+TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
+TRITON_WHEEL_DIR=${TRITON_WHEEL_DIR:-}
+TRITON_BUILD_WHEEL_DIR=${TRITON_BUILD_WHEEL_DIR:-}
+TRITON_RETRY_ATTEMPTS=${TRITON_RETRY_ATTEMPTS:-3}
+TRITON_RETRY_SLEEP_SECONDS=${TRITON_RETRY_SLEEP_SECONDS:-30}
+PIP_DEFAULT_TIMEOUT=${PIP_DEFAULT_TIMEOUT:-120}
+PIP_RETRIES=${PIP_RETRIES:-20}
+
+retry_with_backoff() {
+    local max_attempts="$1"
+    local base_sleep="$2"
+    shift 2
+
+    local attempt=1
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+
+        if [[ "$attempt" -ge "$max_attempts" ]]; then
+            return 1
+        fi
+
+        echo "Triton setup failed on attempt ${attempt}"
+        sleep $((attempt * base_sleep))
+        attempt=$((attempt + 1))
+    done
+}
+
+install_triton_from_wheel() {
+    pip uninstall -y triton || true
+    pip install \
+        --default-timeout "$PIP_DEFAULT_TIMEOUT" \
+        --retries "$PIP_RETRIES" \
+        "$TRITON_WHEEL_DIR"/*.whl
+}
+
+build_triton_from_source() {
+    (
+        rm -rf triton
+        git clone https://github.com/triton-lang/triton
+        cd triton
+        git checkout "$TRITON_COMMIT"
+        pip install \
+            --default-timeout "$PIP_DEFAULT_TIMEOUT" \
+            --retries "$PIP_RETRIES" \
+            -r python/requirements.txt
+
+        if [[ -n "$TRITON_BUILD_WHEEL_DIR" ]]; then
+            mkdir -p "$TRITON_BUILD_WHEEL_DIR"
+            MAX_JOBS=64 pip wheel \
+                --default-timeout "$PIP_DEFAULT_TIMEOUT" \
+                --retries "$PIP_RETRIES" \
+                --no-deps \
+                -w "$TRITON_BUILD_WHEEL_DIR" \
+                .
+        else
+            pip uninstall -y triton || true
+            MAX_JOBS=64 pip install \
+                --default-timeout "$PIP_DEFAULT_TIMEOUT" \
+                --retries "$PIP_RETRIES" \
+                .
+        fi
+    )
+}
+
+if [[ -n "$TRITON_WHEEL_DIR" ]] && ls "$TRITON_WHEEL_DIR"/*.whl 1>/dev/null 2>&1; then
+    echo "Installing triton from pre-built wheel in $TRITON_WHEEL_DIR"
+    retry_with_backoff "$TRITON_RETRY_ATTEMPTS" "$TRITON_RETRY_SLEEP_SECONDS" install_triton_from_wheel
+else
+    echo "Building triton from source..."
+    retry_with_backoff "$TRITON_RETRY_ATTEMPTS" "$TRITON_RETRY_SLEEP_SECONDS" build_triton_from_source
+fi

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -84,38 +84,16 @@ jobs:
             DEVICE_FLAG="--device /dev/dri"
           fi
 
-          for attempt in 1 2 3; do
-            if docker run --rm \
-              --device=/dev/kfd $DEVICE_FLAG \
-              --shm-size=16G \
-              --group-add $(getent group render | cut -d: -f3) \
-              --group-add $(getent group video | cut -d: -f3) \
-              -v "${{ github.workspace }}:/workspace" \
-              -w /workspace \
-              ${{ env.DOCKER_IMAGE }} \
-              bash -c '
-                set -ex
-                pip config set global.default-timeout 120
-                pip config set global.retries 20
-                TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
-                git clone https://github.com/triton-lang/triton
-                cd triton
-                git checkout "$TRITON_COMMIT"
-                pip install -r python/requirements.txt
-                MAX_JOBS=64 pip wheel --no-deps -w /workspace/triton-wheels .
-              '; then
-              echo "Triton wheel build succeeded on attempt ${attempt}"
-              exit 0
-            fi
-
-            echo "Triton wheel build failed on attempt ${attempt}"
-            if [ "${attempt}" != 3 ]; then
-              sleep $((attempt * 30))
-            fi
-          done
-
-          echo "Triton wheel build failed after 3 attempts"
-          exit 1
+          docker run --rm \
+            --device=/dev/kfd $DEVICE_FLAG \
+            --shm-size=16G \
+            --group-add $(getent group render | cut -d: -f3) \
+            --group-add $(getent group video | cut -d: -f3) \
+            -e TRITON_BUILD_WHEEL_DIR=/workspace/triton-wheels \
+            -w /workspace \
+            -v "${{ github.workspace }}:/workspace" \
+            ${{ env.DOCKER_IMAGE }} \
+            bash ./.github/scripts/install_triton.sh
 
       - name: Upload Triton wheel
         uses: actions/upload-artifact@v4

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -84,25 +84,38 @@ jobs:
             DEVICE_FLAG="--device /dev/dri"
           fi
 
-          docker run --rm \
-            --device=/dev/kfd $DEVICE_FLAG \
-            --shm-size=16G \
-            --group-add $(getent group render | cut -d: -f3) \
-            --group-add $(getent group video | cut -d: -f3) \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            ${{ env.DOCKER_IMAGE }} \
-            bash -c '
-              set -ex
-              pip config set global.default-timeout 60
-              pip config set global.retries 10
-              TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
-              git clone https://github.com/triton-lang/triton
-              cd triton
-              git checkout "$TRITON_COMMIT"
-              pip install -r python/requirements.txt
-              MAX_JOBS=64 pip wheel --no-deps -w /workspace/triton-wheels .
-            '
+          for attempt in 1 2 3; do
+            if docker run --rm \
+              --device=/dev/kfd $DEVICE_FLAG \
+              --shm-size=16G \
+              --group-add $(getent group render | cut -d: -f3) \
+              --group-add $(getent group video | cut -d: -f3) \
+              -v "${{ github.workspace }}:/workspace" \
+              -w /workspace \
+              ${{ env.DOCKER_IMAGE }} \
+              bash -c '
+                set -ex
+                pip config set global.default-timeout 120
+                pip config set global.retries 20
+                TRITON_COMMIT=${TRITON_COMMIT:-756afc06}
+                git clone https://github.com/triton-lang/triton
+                cd triton
+                git checkout "$TRITON_COMMIT"
+                pip install -r python/requirements.txt
+                MAX_JOBS=64 pip wheel --no-deps -w /workspace/triton-wheels .
+              '; then
+              echo "Triton wheel build succeeded on attempt ${attempt}"
+              exit 0
+            fi
+
+            echo "Triton wheel build failed on attempt ${attempt}"
+            if [ "${attempt}" != 3 ]; then
+              sleep $((attempt * 30))
+            fi
+          done
+
+          echo "Triton wheel build failed after 3 attempts"
+          exit 1
 
       - name: Upload Triton wheel
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- retry the Triton wheel docker build step up to 3 times so transient network failures restart in a clean container
- increase pip timeout and retry settings inside the wheel build container to better tolerate flaky dependency downloads
- keep the rest of the Triton test workflow unchanged

## Test plan
- [x] Validate workflow YAML with `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/triton-test.yaml').read_text())"`
- [ ] Re-run `Triton Test` workflow in CI