### PR TITLE
mxfp4 quantize kernel

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -808,7 +808,8 @@
     "module_quant": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/quant_pybind.cu'",
-            "f'{AITER_CSRC_DIR}/kernels/quant_kernels.cu'"
+            "f'{AITER_CSRC_DIR}/kernels/quant_kernels.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/quant_mxfp4.cu'"
         ],
         "flags_extra_cc": [],
         "flags_extra_hip": [

--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -694,8 +694,7 @@ def quant_mxfp4_even_round(
     a16w4_shuffle: bool = False,
     gate_up: bool = False,
     shuffle_weight: bool = False,
-) -> None:
-    ...
+) -> None: ...
 
 
 def quant_mxfp4_even_round_hip(
@@ -724,13 +723,19 @@ def quant_mxfp4_even_round_hip(
             rows_pad, scaleN_pad, dtype=torch.uint8, device=x.device
         ).view(fp8_e8m0)
     else:
-        out_scale = torch.empty(
-            rows, scaleN, dtype=torch.uint8, device=x.device
-        ).view(fp8_e8m0)
+        out_scale = torch.empty(rows, scaleN, dtype=torch.uint8, device=x.device).view(
+            fp8_e8m0
+        )
 
     quant_mxfp4_even_round(
-        x, out_packed, out_scale, group_size,
-        e8m0_shuffle, a16w4_shuffle, gate_up, shuffle_weight,
+        x,
+        out_packed,
+        out_scale,
+        group_size,
+        e8m0_shuffle,
+        a16w4_shuffle,
+        gate_up,
+        shuffle_weight,
     )
     return out_packed, out_scale
 

--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -685,11 +685,12 @@ def fused_dynamic_mxfp4_quant_moe_sort_hip(
 
 
 @compile_ops("module_quant", develop=True)
-def quant_mxfp4_even_round(
+def quant_mxfp4(
     inp: torch.Tensor,
     out_packed: torch.Tensor,
     out_scale: torch.Tensor,
     group_size: int = 32,
+    round_mode: int = 0,
     e8m0_shuffle: bool = False,
     a16w4_shuffle: bool = False,
     gate_up: bool = False,
@@ -697,9 +698,10 @@ def quant_mxfp4_even_round(
 ) -> None: ...
 
 
-def quant_mxfp4_even_round_hip(
+def quant_mxfp4_hip(
     x: torch.Tensor,
     group_size: int = 32,
+    round_mode: int = 0,
     e8m0_shuffle: bool = False,
     a16w4_shuffle: bool = False,
     gate_up: bool = False,
@@ -727,11 +729,12 @@ def quant_mxfp4_even_round_hip(
             fp8_e8m0
         )
 
-    quant_mxfp4_even_round(
+    quant_mxfp4(
         x,
         out_packed,
         out_scale,
         group_size,
+        round_mode,
         e8m0_shuffle,
         a16w4_shuffle,
         gate_up,

--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -684,6 +684,57 @@ def fused_dynamic_mxfp4_quant_moe_sort_hip(
     ...
 
 
+@compile_ops("module_quant", develop=True)
+def quant_mxfp4_even_round(
+    inp: torch.Tensor,
+    out_packed: torch.Tensor,
+    out_scale: torch.Tensor,
+    group_size: int = 32,
+    e8m0_shuffle: bool = False,
+    a16w4_shuffle: bool = False,
+    gate_up: bool = False,
+    shuffle_weight: bool = False,
+) -> None:
+    ...
+
+
+def quant_mxfp4_even_round_hip(
+    x: torch.Tensor,
+    group_size: int = 32,
+    e8m0_shuffle: bool = False,
+    a16w4_shuffle: bool = False,
+    gate_up: bool = False,
+    shuffle_weight: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert x.is_contiguous() and x.dim() == 2
+    assert x.dtype in (torch.float16, torch.bfloat16)
+    rows, cols = x.shape
+    assert cols % group_size == 0
+
+    fp4x2 = getattr(torch, "float4_e2m1fn_x2", torch.uint8)
+    fp8_e8m0 = getattr(torch, "float8_e8m0fnu", torch.uint8)
+
+    out_packed = torch.empty(rows, cols // 2, dtype=fp4x2, device=x.device)
+
+    scaleN = cols // group_size
+    if e8m0_shuffle:
+        scaleN_pad = ((scaleN + 7) // 8) * 8
+        rows_pad = ((rows + 255) // 256) * 256
+        out_scale = torch.empty(
+            rows_pad, scaleN_pad, dtype=torch.uint8, device=x.device
+        ).view(fp8_e8m0)
+    else:
+        out_scale = torch.empty(
+            rows, scaleN, dtype=torch.uint8, device=x.device
+        ).view(fp8_e8m0)
+
+    quant_mxfp4_even_round(
+        x, out_packed, out_scale, group_size,
+        e8m0_shuffle, a16w4_shuffle, gate_up, shuffle_weight,
+    )
+    return out_packed, out_scale
+
+
 def fused_dynamic_mxfp4_quant_moe_sort(
     input: torch.Tensor,
     sorted_ids: torch.Tensor,

--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -707,6 +707,13 @@ def quant_mxfp4_hip(
     gate_up: bool = False,
     shuffle_weight: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """MXFP4 quantization with optional weight/scale shuffle.
+
+    Args:
+        round_mode: 0 = Even — e8m0 scale via even-rounding group max
+            to nearest power-of-2. gfx950 uses HW builtin (exact RNE);
+            gfx942 uses SW fallback (round-half-away).
+    """
     assert x.is_contiguous() and x.dim() == 2
     assert x.dtype in (torch.float16, torch.bfloat16)
     rows, cols = x.shape

--- a/csrc/include/quant.h
+++ b/csrc/include/quant.h
@@ -83,4 +83,12 @@ void mxfp4_moe_sort_hip(aiter_tensor_t& out_scale,
                          const aiter_tensor_t& num_valid_ids,
                          int token_num,
                          int cols);
+void quant_mxfp4_even_round(const aiter_tensor_t& inp,
+                            aiter_tensor_t& out_packed,
+                            aiter_tensor_t& out_scale,
+                            int group_size          = 32,
+                            bool e8m0_shuffle       = false,
+                            bool a16w4_shuffle      = false,
+                            bool gate_up            = false,
+                            bool shuffle_weight     = false);
 } // namespace aiter

--- a/csrc/include/quant.h
+++ b/csrc/include/quant.h
@@ -83,12 +83,13 @@ void mxfp4_moe_sort_hip(aiter_tensor_t& out_scale,
                          const aiter_tensor_t& num_valid_ids,
                          int token_num,
                          int cols);
-void quant_mxfp4_even_round(const aiter_tensor_t& inp,
-                            aiter_tensor_t& out_packed,
-                            aiter_tensor_t& out_scale,
-                            int group_size          = 32,
-                            bool e8m0_shuffle       = false,
-                            bool a16w4_shuffle      = false,
-                            bool gate_up            = false,
-                            bool shuffle_weight     = false);
+void quant_mxfp4(const aiter_tensor_t& inp,
+                 aiter_tensor_t& out_packed,
+                 aiter_tensor_t& out_scale,
+                 int group_size          = 32,
+                 int round_mode          = 0,
+                 bool e8m0_shuffle       = false,
+                 bool a16w4_shuffle      = false,
+                 bool gate_up            = false,
+                 bool shuffle_weight     = false);
 } // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1364,7 +1364,17 @@ namespace py = pybind11;
           &aiter::partial_transpose,                                     \
           py::arg("out"),                                                \
           py::arg("input"),                                              \
-          py::arg("num_rows"));
+          py::arg("num_rows"));                                          \
+    m.def("quant_mxfp4_even_round",                                      \
+          &aiter::quant_mxfp4_even_round,                                \
+          py::arg("inp"),                                                \
+          py::arg("out_packed"),                                         \
+          py::arg("out_scale"),                                          \
+          py::arg("group_size")      = 32,                               \
+          py::arg("e8m0_shuffle")    = false,                            \
+          py::arg("a16w4_shuffle")   = false,                            \
+          py::arg("gate_up")         = false,                            \
+          py::arg("shuffle_weight")  = false);
 
 #define DSV4_ROTATE_QUANT_PYBIND                                         \
     m.def("rotate_activation_fp4quant_inplace",                          \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1365,12 +1365,13 @@ namespace py = pybind11;
           py::arg("out"),                                                \
           py::arg("input"),                                              \
           py::arg("num_rows"));                                          \
-    m.def("quant_mxfp4_even_round",                                      \
-          &aiter::quant_mxfp4_even_round,                                \
+    m.def("quant_mxfp4",                                                 \
+          &aiter::quant_mxfp4,                                           \
           py::arg("inp"),                                                \
           py::arg("out_packed"),                                         \
           py::arg("out_scale"),                                          \
           py::arg("group_size")      = 32,                               \
+          py::arg("round_mode")      = 0,                                \
           py::arg("e8m0_shuffle")    = false,                            \
           py::arg("a16w4_shuffle")   = false,                            \
           py::arg("gate_up")         = false,                            \

--- a/csrc/kernels/quant_mxfp4.cu
+++ b/csrc/kernels/quant_mxfp4.cu
@@ -77,7 +77,8 @@ __device__ __forceinline__ int a16w4_shuffle_scale_id(
 }
 
 template <typename float_type, bool e8m0_shuffle, bool a16w4_shuffle, bool shuffle_weight>
-__global__ void quant_mxfp4_even_round_kernel(
+__global__ __launch_bounds__(kBlockThreads)
+void quant_mxfp4_even_round_kernel(
     const float_type* __restrict__ inp,
     uint8_t* __restrict__ out_packed,
     float* __restrict__ out_scale,
@@ -115,11 +116,18 @@ __global__ void quant_mxfp4_even_round_kernel(
 
     uint32_t max_bits = __float_as_uint(group_max);
     max_bits          = (max_bits + EVEN_ROUND_VAL_TO_ADD) & EVEN_ROUND_FP32_SIGN_EXP_MASK;
-    float max_rounded = __uint_as_float(max_bits);
 
-    float scale_unbiased = floorf(log2f(max_rounded)) - EVEN_ROUND_FP4_EMAX;
-    scale_unbiased       = fminf(fmaxf(scale_unbiased, -127.0f), 127.0f);
-    float dequant_scale  = exp2f(scale_unbiased);
+    uint32_t raw_exp = max_bits >> 23;
+    float dequant_scale;
+    uint8_t biased_exp;
+    if (__builtin_expect(raw_exp >= 3, 1)) {
+        uint32_t exp_out = raw_exp - 2;
+        dequant_scale = __uint_as_float(exp_out << 23);
+        biased_exp = (uint8_t)exp_out;
+    } else {
+        dequant_scale = 0x1.0p-127f;
+        biased_exp = 0;
+    }
 
     u8x16_t packed;
 
@@ -172,7 +180,6 @@ __global__ void quant_mxfp4_even_round_kernel(
     }
     *reinterpret_cast<u8x16_t*>(out_packed + w_base) = packed;
 
-    uint8_t biased_exp = (__float_as_uint(dequant_scale) >> 23) & 0xFF;
     int scale_idx;
     if constexpr (e8m0_shuffle) {
         scale_idx = fp4_scale_shuffle_id(scaleN_pad, (int)x, y);
@@ -223,12 +230,12 @@ void quant_mxfp4_even_round(
     AITER_CHECK(!shuffle_weight || e8m0_shuffle || a16w4_shuffle,
                 __func__, " shuffle_weight requires e8m0_shuffle or a16w4_shuffle");
 
-    int64_t ori_rows = inp.size(0);
-    int32_t ori_cols = inp.size(1);
+    const int64_t ori_rows = inp.size(0);
+    const int32_t ori_cols = inp.size(1);
     AITER_CHECK(ori_cols % group_size == 0, __func__, " cols must be divisible by group_size");
 
-    int32_t scaleN     = ori_cols / group_size;
-    int32_t scaleN_pad = e8m0_shuffle ? ((scaleN + 7) / 8) * 8 : scaleN;
+    const int32_t scaleN     = ori_cols / group_size;
+    const int32_t scaleN_pad = e8m0_shuffle ? ((scaleN + 7) / 8) * 8 : scaleN;
 
     if (a16w4_shuffle) {
         AITER_CHECK(ori_rows % 32 == 0, __func__, " a16w4 scale shuffle requires rows % 32 == 0");
@@ -244,8 +251,8 @@ void quant_mxfp4_even_round(
         }
     }
 
-    int64_t total_groups = ori_rows * (int64_t)scaleN_pad;
-    int64_t grid_size    = (total_groups + kBlockThreads - 1) / kBlockThreads;
+    const int64_t total_groups = ori_rows * (int64_t)scaleN_pad;
+    const int64_t grid_size    = (total_groups + kBlockThreads - 1) / kBlockThreads;
     AITER_CHECK(grid_size <= 2147483647LL, __func__, " grid size exceeds maximum");
 
     HipDeviceGuard device_guard(inp.device_id);

--- a/csrc/kernels/quant_mxfp4.cu
+++ b/csrc/kernels/quant_mxfp4.cu
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "aiter_hip_common.h"
+#include "aiter_dispatch.h"
+#include "aiter_opus_plus.h"
+#include "aiter_stream.h"
+#include "quant.h"
+
+namespace aiter {
+
+#define EVEN_ROUND_FP32_SIGN_EXP_MASK 0x7F800000u
+#define EVEN_ROUND_VAL_TO_ADD         0x00200000u
+#define EVEN_ROUND_FP4_EMAX           2
+
+static constexpr int kGroupSize      = 32;
+static constexpr int kPackedPerGroup = kGroupSize / 2;
+static constexpr int kBlockThreads   = 256;
+
+using packed_u16x8_t = vector_t<uint16_t, 8>;
+
+#if defined(__gfx950__)
+template <typename ftype, int sel>
+__device__ __forceinline__ uint32_t cvt_fp4_pk(uint32_t src, uint32_t pair, float scale) {
+    if constexpr (std::is_same_v<ftype, hip_bfloat16>)
+        return __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(
+            src, __builtin_bit_cast(bf16x2_t, pair), scale, sel);
+    else
+        return __builtin_amdgcn_cvt_scalef32_pk_fp4_f16(
+            src, __builtin_bit_cast(fp16x2_t, pair), scale, sel);
+}
+#else
+__device__ __forceinline__ uint8_t even_round_e2m1(float val) {
+    float a = fabsf(val);
+    uint8_t mag;
+    if      (a >= 5.0f)  mag = 7;
+    else if (a >= 3.5f)  mag = 6;
+    else if (a >= 2.5f)  mag = 5;
+    else if (a >= 1.75f) mag = 4;
+    else if (a >= 1.25f) mag = 3;
+    else if (a >= 0.75f) mag = 2;
+    else if (a >= 0.25f) mag = 1;
+    else                 mag = 0;
+    uint8_t sign_bit = (val < 0.0f) ? 8u : 0u;
+    return sign_bit | mag;
+}
+#endif
+
+__device__ __forceinline__ int fp4_scale_shuffle_id(int scaleN_pad, int x, int y) {
+    return (x / 32 * scaleN_pad) * 32 +
+           (y / 8) * 256 + (y % 4) * 64 + (x % 16) * 4 +
+           (y % 8) / 4 * 2 + (x % 32) / 16;
+}
+
+__device__ __forceinline__ int a16w4_shuffle_scale_id(
+    int scaleN, int ori_rows, int x, int y, bool gate_up
+) {
+    int N1_idx, N_Pack_idx, N_Lane_idx;
+    if (gate_up) {
+        int half_rows = ori_rows / 2;
+        N_Pack_idx = x / half_rows;
+        int rem    = x % half_rows;
+        N1_idx     = rem / 16;
+        N_Lane_idx = rem % 16;
+    } else {
+        N1_idx     = x / 32;
+        N_Pack_idx = (x % 32) / 16;
+        N_Lane_idx = x % 16;
+    }
+    int K1_idx     = y / 8;
+    int K_Pack_idx = (y % 8) / 4;
+    int K_Lane_idx = y % 4;
+    int k1_size    = scaleN / 8;
+    return N1_idx * (k1_size * 256) +
+           K1_idx * 256 + K_Lane_idx * 64 + N_Lane_idx * 4 +
+           K_Pack_idx * 2 + N_Pack_idx;
+}
+
+template <typename float_type, bool e8m0_shuffle, bool a16w4_shuffle, bool shuffle_weight>
+__global__ void quant_mxfp4_even_round_kernel(
+    const float_type* __restrict__ inp,
+    uint8_t* __restrict__ out_packed,
+    float* __restrict__ out_scale,
+    int64_t ori_rows, int32_t ori_cols,
+    int32_t scaleN, int32_t scaleN_pad, bool gate_up
+) {
+    int64_t gid = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t x   = gid / scaleN_pad;
+    int32_t y   = gid % scaleN_pad;
+
+    if (x >= ori_rows || y >= scaleN) return;
+
+    const packed_u16x8_t* vp = reinterpret_cast<const packed_u16x8_t*>(
+        inp + x * ori_cols + y * kGroupSize
+    );
+    packed_u16x8_t chunks[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) chunks[i] = vp[i];
+
+    const float_type* elems = reinterpret_cast<const float_type*>(chunks);
+
+    float group_max = 0.f;
+#if defined(__gfx950__)
+    #pragma unroll
+    for (int i = 0; i < kGroupSize; ++i)
+        group_max = fmaxf(group_max, fabsf(static_cast<float>(elems[i])));
+#else
+    float vals[kGroupSize];
+    #pragma unroll
+    for (int i = 0; i < kGroupSize; ++i) {
+        vals[i]   = static_cast<float>(elems[i]);
+        group_max = fmaxf(group_max, fabsf(vals[i]));
+    }
+#endif
+
+    uint32_t max_bits = __float_as_uint(group_max);
+    max_bits          = (max_bits + EVEN_ROUND_VAL_TO_ADD) & EVEN_ROUND_FP32_SIGN_EXP_MASK;
+    float max_rounded = __uint_as_float(max_bits);
+
+    float scale_unbiased = floorf(log2f(max_rounded)) - EVEN_ROUND_FP4_EMAX;
+    scale_unbiased       = fminf(fmaxf(scale_unbiased, -127.0f), 127.0f);
+    float dequant_scale  = exp2f(scale_unbiased);
+
+    u8x16_t packed;
+
+#if defined(__gfx950__)
+    const uint32_t* pairs = reinterpret_cast<const uint32_t*>(chunks);
+    u32x4_t pw;
+    #pragma unroll
+    for (int j = 0; j < 4; ++j) {
+        const uint32_t* p = pairs + j * 4;
+        uint32_t w = 0;
+        w = cvt_fp4_pk<float_type, 0>(w, p[0], dequant_scale);
+        w = cvt_fp4_pk<float_type, 1>(w, p[1], dequant_scale);
+        w = cvt_fp4_pk<float_type, 2>(w, p[2], dequant_scale);
+        w = cvt_fp4_pk<float_type, 3>(w, p[3], dequant_scale);
+        pw[j] = w;
+    }
+    packed = __builtin_bit_cast(u8x16_t, pw);
+#else
+    float quant_scale = (dequant_scale == 0.0f) ? 0.0f : (1.0f / dequant_scale);
+    #pragma unroll
+    for (int i = 0; i < kPackedPerGroup; ++i) {
+        packed[i] = even_round_e2m1(vals[i * 2] * quant_scale)
+                  | (even_round_e2m1(vals[i * 2 + 1] * quant_scale) << 4);
+    }
+#endif
+
+    int64_t w_base;
+    if constexpr (shuffle_weight) {
+        int K_pk = ori_cols / 2;
+        if constexpr (e8m0_shuffle) {
+            w_base = (int64_t)(x >> 4) * 16 * K_pk + (x & 15) * 16
+                   + (y >> 1) * 512 + (y & 1) * 256;
+        } else if constexpr (a16w4_shuffle) {
+            int K0 = y >> 2, KLane = y & 3;
+            if (gate_up) {
+                int half_rows = (int)ori_rows >> 1;
+                int N_Pack    = (int)x / half_rows;
+                int rem       = (int)x % half_rows;
+                int K0_size   = K_pk >> 6;
+                w_base = (int64_t)(rem >> 4) * (2 * K0_size * 1024)
+                       + (int64_t)N_Pack * (K0_size * 1024)
+                       + K0 * 1024 + KLane * 256 + (rem & 15) * 16;
+            } else {
+                w_base = (int64_t)(x >> 4) * 16 * K_pk + (x & 15) * 16
+                       + K0 * 1024 + KLane * 256;
+            }
+        }
+    } else {
+        w_base = x * (ori_cols / 2) + y * kPackedPerGroup;
+    }
+    *reinterpret_cast<u8x16_t*>(out_packed + w_base) = packed;
+
+    uint8_t biased_exp = (__float_as_uint(dequant_scale) >> 23) & 0xFF;
+    int scale_idx;
+    if constexpr (e8m0_shuffle) {
+        scale_idx = fp4_scale_shuffle_id(scaleN_pad, (int)x, y);
+    } else if constexpr (a16w4_shuffle) {
+        scale_idx = a16w4_shuffle_scale_id(scaleN, (int)ori_rows, (int)x, y, gate_up);
+    } else {
+        scale_idx = (int)(x * scaleN + y);
+    }
+    reinterpret_cast<uint8_t*>(out_scale)[scale_idx] = biased_exp;
+}
+
+#define MXFP4_LAUNCH(ftype, ss, a16, sw)                                     \
+    quant_mxfp4_even_round_kernel<ftype, ss, a16, sw>                        \
+        <<<(int)grid_size, kBlockThreads, 0, stream>>>(                      \
+            reinterpret_cast<const ftype*>(inp.data_ptr()),                   \
+            reinterpret_cast<uint8_t*>(out_packed.data_ptr()),               \
+            reinterpret_cast<float*>(out_scale.data_ptr()),                  \
+            ori_rows, ori_cols, scaleN, scaleN_pad, gate_up)
+
+#define MXFP4_DISPATCH(ftype)                                                \
+    if (e8m0_shuffle) {                                                      \
+        if (shuffle_weight) { MXFP4_LAUNCH(ftype, true, false, true); }      \
+        else                { MXFP4_LAUNCH(ftype, true, false, false); }     \
+    } else if (a16w4_shuffle) {                                              \
+        if (shuffle_weight) { MXFP4_LAUNCH(ftype, false, true, true); }      \
+        else                { MXFP4_LAUNCH(ftype, false, true, false); }     \
+    } else {                                                                 \
+        MXFP4_LAUNCH(ftype, false, false, false);                            \
+    }
+
+void quant_mxfp4_even_round(
+    const aiter_tensor_t& inp,
+    aiter_tensor_t& out_packed,
+    aiter_tensor_t& out_scale,
+    int group_size,
+    bool e8m0_shuffle,
+    bool a16w4_shuffle,
+    bool gate_up,
+    bool shuffle_weight
+) {
+    AITER_CHECK(inp.is_contiguous(), __func__, " expected input to be contiguous");
+    AITER_CHECK(inp.dim() == 2, __func__, " expected 2D input");
+    AITER_CHECK(out_packed.is_contiguous(), __func__, " expected out_packed to be contiguous");
+    AITER_CHECK(out_scale.is_contiguous(), __func__, " expected out_scale to be contiguous");
+    AITER_CHECK(group_size == 32, __func__, " expected group_size=32");
+    AITER_CHECK(!(e8m0_shuffle && a16w4_shuffle),
+                __func__, " e8m0_shuffle and a16w4_shuffle are mutually exclusive");
+    AITER_CHECK(!shuffle_weight || e8m0_shuffle || a16w4_shuffle,
+                __func__, " shuffle_weight requires e8m0_shuffle or a16w4_shuffle");
+
+    int64_t ori_rows = inp.size(0);
+    int32_t ori_cols = inp.size(1);
+    AITER_CHECK(ori_cols % group_size == 0, __func__, " cols must be divisible by group_size");
+
+    int32_t scaleN     = ori_cols / group_size;
+    int32_t scaleN_pad = e8m0_shuffle ? ((scaleN + 7) / 8) * 8 : scaleN;
+
+    if (a16w4_shuffle) {
+        AITER_CHECK(ori_rows % 32 == 0, __func__, " a16w4 scale shuffle requires rows % 32 == 0");
+        AITER_CHECK(scaleN % 8 == 0, __func__, " a16w4 scale shuffle requires scaleN % 8 == 0");
+    }
+    if (shuffle_weight) {
+        AITER_CHECK(ori_rows % 16 == 0, __func__, " shuffle_weight requires rows % 16 == 0");
+        int K_pk = ori_cols / 2;
+        if (e8m0_shuffle) {
+            AITER_CHECK(K_pk % 32 == 0, __func__, " e8m0 weight shuffle requires K_pk % 32 == 0");
+        } else {
+            AITER_CHECK(K_pk % 64 == 0, __func__, " a16w4 weight shuffle requires K_pk % 64 == 0");
+        }
+    }
+
+    int64_t total_groups = ori_rows * (int64_t)scaleN_pad;
+    int64_t grid_size    = (total_groups + kBlockThreads - 1) / kBlockThreads;
+    AITER_CHECK(grid_size <= 2147483647LL, __func__, " grid size exceeds maximum");
+
+    HipDeviceGuard device_guard(inp.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+        inp.dtype(), "quant_mxfp4_even_round_kernel", [&] {
+            MXFP4_DISPATCH(scalar_t);
+        });
+}
+
+#undef MXFP4_LAUNCH
+#undef MXFP4_DISPATCH
+
+} // namespace aiter

--- a/csrc/kernels/quant_mxfp4.cu
+++ b/csrc/kernels/quant_mxfp4.cu
@@ -9,6 +9,8 @@
 
 namespace aiter {
 
+enum class MxFp4RoundMode : int { Even = 0 };
+
 #define EVEN_ROUND_FP32_SIGN_EXP_MASK 0x7F800000u
 #define EVEN_ROUND_VAL_TO_ADD         0x00200000u
 #define EVEN_ROUND_FP4_EMAX           2
@@ -76,9 +78,9 @@ __device__ __forceinline__ int a16w4_shuffle_scale_id(
            K_Pack_idx * 2 + N_Pack_idx;
 }
 
-template <typename float_type, bool e8m0_shuffle, bool a16w4_shuffle, bool shuffle_weight>
+template <typename float_type, MxFp4RoundMode rmode, bool e8m0_shuffle, bool a16w4_shuffle, bool shuffle_weight>
 __global__ __launch_bounds__(kBlockThreads)
-void quant_mxfp4_even_round_kernel(
+void quant_mxfp4_kernel(
     const float_type* __restrict__ inp,
     uint8_t* __restrict__ out_packed,
     float* __restrict__ out_scale,
@@ -115,18 +117,17 @@ void quant_mxfp4_even_round_kernel(
 #endif
 
     uint32_t max_bits = __float_as_uint(group_max);
-    max_bits          = (max_bits + EVEN_ROUND_VAL_TO_ADD) & EVEN_ROUND_FP32_SIGN_EXP_MASK;
-
-    uint32_t raw_exp = max_bits >> 23;
     float dequant_scale;
     uint8_t biased_exp;
-    if (__builtin_expect(raw_exp >= 3, 1)) {
-        uint32_t exp_out = raw_exp - 2;
-        dequant_scale = __uint_as_float(exp_out << 23);
-        biased_exp = (uint8_t)exp_out;
-    } else {
-        dequant_scale = 0x1.0p-127f;
-        biased_exp = 0;
+
+    if constexpr (rmode == MxFp4RoundMode::Even) {
+        max_bits          = (max_bits + EVEN_ROUND_VAL_TO_ADD) & EVEN_ROUND_FP32_SIGN_EXP_MASK;
+        float max_rounded = __uint_as_float(max_bits);
+
+        float scale_unbiased = floorf(log2f(max_rounded)) - EVEN_ROUND_FP4_EMAX;
+        scale_unbiased       = fminf(fmaxf(scale_unbiased, -127.0f), 127.0f);
+        dequant_scale        = exp2f(scale_unbiased);
+        biased_exp           = (__float_as_uint(dequant_scale) >> 23) & 0xFF;
     }
 
     u8x16_t packed;
@@ -191,30 +192,31 @@ void quant_mxfp4_even_round_kernel(
     reinterpret_cast<uint8_t*>(out_scale)[scale_idx] = biased_exp;
 }
 
-#define MXFP4_LAUNCH(ftype, ss, a16, sw)                                     \
-    quant_mxfp4_even_round_kernel<ftype, ss, a16, sw>                        \
+#define MXFP4_LAUNCH(ftype, rmode, ss, a16, sw)                              \
+    quant_mxfp4_kernel<ftype, rmode, ss, a16, sw>                            \
         <<<(int)grid_size, kBlockThreads, 0, stream>>>(                      \
             reinterpret_cast<const ftype*>(inp.data_ptr()),                   \
             reinterpret_cast<uint8_t*>(out_packed.data_ptr()),               \
             reinterpret_cast<float*>(out_scale.data_ptr()),                  \
             ori_rows, ori_cols, scaleN, scaleN_pad, gate_up)
 
-#define MXFP4_DISPATCH(ftype)                                                \
+#define MXFP4_DISPATCH(ftype, rmode)                                         \
     if (e8m0_shuffle) {                                                      \
-        if (shuffle_weight) { MXFP4_LAUNCH(ftype, true, false, true); }      \
-        else                { MXFP4_LAUNCH(ftype, true, false, false); }     \
+        if (shuffle_weight) { MXFP4_LAUNCH(ftype, rmode, true, false, true); }  \
+        else                { MXFP4_LAUNCH(ftype, rmode, true, false, false); } \
     } else if (a16w4_shuffle) {                                              \
-        if (shuffle_weight) { MXFP4_LAUNCH(ftype, false, true, true); }      \
-        else                { MXFP4_LAUNCH(ftype, false, true, false); }     \
+        if (shuffle_weight) { MXFP4_LAUNCH(ftype, rmode, false, true, true); }  \
+        else                { MXFP4_LAUNCH(ftype, rmode, false, true, false); } \
     } else {                                                                 \
-        MXFP4_LAUNCH(ftype, false, false, false);                            \
+        MXFP4_LAUNCH(ftype, rmode, false, false, false);                     \
     }
 
-void quant_mxfp4_even_round(
+void quant_mxfp4(
     const aiter_tensor_t& inp,
     aiter_tensor_t& out_packed,
     aiter_tensor_t& out_scale,
     int group_size,
+    int round_mode,
     bool e8m0_shuffle,
     bool a16w4_shuffle,
     bool gate_up,
@@ -225,6 +227,7 @@ void quant_mxfp4_even_round(
     AITER_CHECK(out_packed.is_contiguous(), __func__, " expected out_packed to be contiguous");
     AITER_CHECK(out_scale.is_contiguous(), __func__, " expected out_scale to be contiguous");
     AITER_CHECK(group_size == 32, __func__, " expected group_size=32");
+    AITER_CHECK(round_mode == 0, __func__, " only Even round mode (0) is supported");
     AITER_CHECK(!(e8m0_shuffle && a16w4_shuffle),
                 __func__, " e8m0_shuffle and a16w4_shuffle are mutually exclusive");
     AITER_CHECK(!shuffle_weight || e8m0_shuffle || a16w4_shuffle,
@@ -259,8 +262,8 @@ void quant_mxfp4_even_round(
     const hipStream_t stream = aiter::getCurrentHIPStream();
 
     AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
-        inp.dtype(), "quant_mxfp4_even_round_kernel", [&] {
-            MXFP4_DISPATCH(scalar_t);
+        inp.dtype(), "quant_mxfp4_kernel", [&] {
+            MXFP4_DISPATCH(scalar_t, MxFp4RoundMode::Even);
         });
 }
 

--- a/csrc/kernels/quant_mxfp4.cu
+++ b/csrc/kernels/quant_mxfp4.cu
@@ -9,6 +9,8 @@
 
 namespace aiter {
 
+// Even: e8m0 scale via even-rounding group max to nearest power-of-2.
+//   gfx950: HW builtin (exact RNE); gfx942: SW fallback (round-half-away).
 enum class MxFp4RoundMode : int { Even = 0 };
 
 #define EVEN_ROUND_FP32_SIGN_EXP_MASK 0x7F800000u

--- a/op_tests/test_quant_mxfp4.py
+++ b/op_tests/test_quant_mxfp4.py
@@ -4,7 +4,7 @@
 import pytest
 import torch
 
-from aiter.ops.quant import quant_mxfp4_even_round_hip
+from aiter.ops.quant import quant_mxfp4_hip
 from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight, shuffle_weight_a16w4
 
 
@@ -85,7 +85,7 @@ def test_no_shuffle(shape, float_dtype):
     torch.manual_seed(42)
     inp = torch.randn(shape, dtype=float_dtype, device="cuda")
 
-    packed_hip, scale_hip = quant_mxfp4_even_round_hip(inp, group_size=32)
+    packed_hip, scale_hip = quant_mxfp4_hip(inp, group_size=32)
 
     py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
 
@@ -127,10 +127,10 @@ def test_e8m0_shuffle(shape, float_dtype):
     torch.manual_seed(42)
     inp = torch.randn(shape, dtype=float_dtype, device="cuda")
 
-    packed_out, scale_out = quant_mxfp4_even_round_hip(
+    packed_out, scale_out = quant_mxfp4_hip(
         inp, group_size=32, e8m0_shuffle=True, shuffle_weight=True
     )
-    packed_ref, scale_ref = quant_mxfp4_even_round_hip(inp, group_size=32)
+    packed_ref, scale_ref = quant_mxfp4_hip(inp, group_size=32)
     expected_w = shuffle_weight(packed_ref)
 
     scaleN = cols // 32
@@ -188,10 +188,10 @@ def test_a16w4_shuffle(shape, float_dtype, gate_up):
     torch.manual_seed(42)
     inp = torch.randn(shape, dtype=float_dtype, device="cuda")
 
-    packed_out, scale_out = quant_mxfp4_even_round_hip(
+    packed_out, scale_out = quant_mxfp4_hip(
         inp, group_size=32, a16w4_shuffle=True, gate_up=gate_up, shuffle_weight=True
     )
-    packed_ref, scale_ref = quant_mxfp4_even_round_hip(inp, group_size=32)
+    packed_ref, scale_ref = quant_mxfp4_hip(inp, group_size=32)
     expected_w = shuffle_weight_a16w4(
         packed_ref.view(torch.uint8).unsqueeze(0), NLane=16, gate_up=gate_up
     ).squeeze(0)
@@ -221,25 +221,25 @@ def test_edge_values(float_dtype):
     rows, cols = 32, 64
 
     inp_zero = torch.zeros(rows, cols, dtype=float_dtype, device="cuda")
-    packed, scale = quant_mxfp4_even_round_hip(inp_zero, group_size=32)
+    packed, scale = quant_mxfp4_hip(inp_zero, group_size=32)
     assert packed.view(torch.uint8).sum() == 0
 
     inp_large = torch.full((rows, cols), 1e4, dtype=float_dtype, device="cuda")
-    packed, scale = quant_mxfp4_even_round_hip(inp_large, group_size=32)
+    packed, scale = quant_mxfp4_hip(inp_large, group_size=32)
     assert packed.view(torch.uint8).max() > 0
 
     inp_tiny = torch.full((rows, cols), 1e-10, dtype=float_dtype, device="cuda")
-    packed, scale = quant_mxfp4_even_round_hip(inp_tiny, group_size=32)
+    packed, scale = quant_mxfp4_hip(inp_tiny, group_size=32)
 
     inp_neg = torch.full((rows, cols), -3.0, dtype=float_dtype, device="cuda")
-    packed, scale = quant_mxfp4_even_round_hip(inp_neg, group_size=32)
+    packed, scale = quant_mxfp4_hip(inp_neg, group_size=32)
     py_packed, _ = ref_quant_mxfp4_even_round(inp_neg.cpu(), group_size=32)
     assert torch.equal(packed.view(torch.uint8).cpu(), py_packed)
 
 
 def test_single_group():
     inp = torch.randn(1, 32, dtype=torch.bfloat16, device="cuda")
-    packed, scale = quant_mxfp4_even_round_hip(inp, group_size=32)
+    packed, scale = quant_mxfp4_hip(inp, group_size=32)
     assert packed.view(torch.uint8).shape == (1, 16)
     assert scale.view(torch.uint8).shape == (1, 1)
     py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
@@ -283,7 +283,7 @@ def test_e2m1_boundary_values(float_dtype):
         -0.25,
     ]
     inp = torch.tensor([boundary_vals], dtype=float_dtype, device="cuda")
-    packed, scale = quant_mxfp4_even_round_hip(inp, group_size=32)
+    packed, scale = quant_mxfp4_hip(inp, group_size=32)
     py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
     assert torch.equal(scale.view(torch.uint8).cpu(), py_scale)
     packed_u8 = packed.view(torch.uint8).cpu()
@@ -295,10 +295,10 @@ def test_e2m1_boundary_values(float_dtype):
 def test_e8m0_shuffle_scale_only():
     torch.manual_seed(42)
     inp = torch.randn(4096, 256, dtype=torch.bfloat16, device="cuda")
-    packed_shuf, scale_shuf = quant_mxfp4_even_round_hip(
+    packed_shuf, scale_shuf = quant_mxfp4_hip(
         inp, group_size=32, e8m0_shuffle=True, shuffle_weight=False
     )
-    packed_ref, scale_ref = quant_mxfp4_even_round_hip(inp, group_size=32)
+    packed_ref, scale_ref = quant_mxfp4_hip(inp, group_size=32)
     packed_shuf_u8 = packed_shuf.view(torch.uint8).cpu()
     packed_ref_u8 = packed_ref.view(torch.uint8).cpu()
     assert torch.equal(packed_shuf_u8, packed_ref_u8)

--- a/op_tests/test_quant_mxfp4.py
+++ b/op_tests/test_quant_mxfp4.py
@@ -8,9 +8,10 @@ import pandas as pd
 import torch
 
 import aiter
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.quant import quant_mxfp4_hip
 from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight, shuffle_weight_a16w4
-from aiter.test_common import benchmark, checkAllclose
+from aiter.test_common import benchmark
 
 torch.set_default_device("cuda")
 
@@ -35,7 +36,36 @@ def even_round_scale(max_abs: torch.Tensor) -> torch.Tensor:
     return max_abs_f32
 
 
-def fp32_to_e2m1(val: torch.Tensor) -> torch.Tensor:
+def fp32_to_e2m1_rne(val: torch.Tensor) -> torch.Tensor:
+    """E2M1 quantization with RNE (matches gfx950 HW builtin)."""
+    qx = val.float().contiguous().view(torch.int32).to(torch.int64) & 0xFFFFFFFF
+    s = qx & 0x80000000
+    qx = qx ^ s
+
+    abs_f = qx.to(torch.int32).view(torch.float32)
+    sat = abs_f >= 6.0
+    denorm = (~sat) & (abs_f < 1.0)
+    normal = ~(sat | denorm)
+
+    DENORM_CONST = 149 << 23
+    d = abs_f + torch.tensor(DENORM_CONST, dtype=torch.int32, device=val.device).view(
+        torch.float32
+    )
+    d = (d.view(torch.int32).to(torch.int64) & 0xFFFFFFFF) - DENORM_CONST
+
+    mant_odd = (qx >> 22) & 1
+    VAL_TO_ADD = ((1 - 127) << 23) + (1 << 21) - 1
+    n = (qx + (VAL_TO_ADD & 0xFFFFFFFF) + mant_odd) >> 22
+
+    e2m1 = torch.full_like(qx, 7)
+    e2m1 = torch.where(normal, n, e2m1)
+    e2m1 = torch.where(denorm, d, e2m1)
+    e2m1 = e2m1 | (s >> 28)
+    return e2m1.to(torch.uint8)
+
+
+def fp32_to_e2m1_rha(val: torch.Tensor) -> torch.Tensor:
+    """E2M1 quantization with round-half-away (matches non-gfx950 SW fallback)."""
     a = val.abs()
     dev = val.device
     mag = torch.zeros_like(val, dtype=torch.uint8)
@@ -52,6 +82,9 @@ def fp32_to_e2m1(val: torch.Tensor) -> torch.Tensor:
         torch.tensor(0, dtype=torch.uint8, device=dev),
     )
     return sign | mag
+
+
+fp32_to_e2m1 = fp32_to_e2m1_rne if get_gfx() == "gfx950" else fp32_to_e2m1_rha
 
 
 def ref_quant_mxfp4_even_round(inp: torch.Tensor, group_size: int = 32):
@@ -95,25 +128,10 @@ def test_no_shuffle(m, n, float_dtype):
     py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
 
     scale_hip_u8 = scale_hip.view(torch.uint8).cpu()
-    checkAllclose(
-        scale_hip_u8.to(torch.float32),
-        py_scale.to(torch.float32),
-        rtol=0,
-        atol=0,
-        msg=f"scale ({m},{n})",
-    )
+    assert torch.equal(scale_hip_u8, py_scale), f"scale mismatch ({m},{n})"
 
     packed_hip_u8 = packed_hip.view(torch.uint8).cpu()
-    diff = (packed_hip_u8.to(torch.int16) - py_packed.to(torch.int16)).abs()
-    bad = (diff > 0) & (diff != 1) & (diff != 16) & (diff != 17)
-    checkAllclose(
-        packed_hip_u8.to(torch.float32),
-        py_packed.to(torch.float32),
-        rtol=0,
-        atol=17,
-        msg=f"packed ({m},{n})",
-    )
-    assert not bad.any(), f"Packed diff too large: max={diff.max().item()}"
+    assert torch.equal(packed_hip_u8, py_packed), f"packed mismatch ({m},{n})"
 
     return {"result": "PASS"}
 
@@ -141,13 +159,7 @@ def test_e8m0_shuffle(m, n, float_dtype):
 
     packed_out_u8 = packed_out.view(torch.uint8).cpu()
     expected_w_u8 = expected_w.view(torch.uint8).cpu()
-    checkAllclose(
-        packed_out_u8.to(torch.float32),
-        expected_w_u8.to(torch.float32),
-        rtol=0,
-        atol=0,
-        msg=f"e8m0 weight ({m},{n})",
-    )
+    assert torch.equal(packed_out_u8, expected_w_u8), f"e8m0 weight mismatch ({m},{n})"
 
     scale_ref_u8 = scale_ref.view(torch.uint8).flatten().cpu()
     scale_out_u8 = scale_out.view(torch.uint8).flatten().cpu()
@@ -190,23 +202,15 @@ def test_a16w4_shuffle(m, n, float_dtype, gate_up):
 
     packed_out_u8 = packed_out.view(torch.uint8).cpu()
     expected_w_u8 = expected_w.view(torch.uint8).cpu()
-    checkAllclose(
-        packed_out_u8.to(torch.float32),
-        expected_w_u8.to(torch.float32),
-        rtol=0,
-        atol=0,
-        msg=f"a16w4 weight (gate_up={gate_up})",
-    )
+    assert torch.equal(
+        packed_out_u8, expected_w_u8
+    ), f"a16w4 weight mismatch (gate_up={gate_up})"
 
     scale_out_u8 = scale_out.view(torch.uint8).cpu()
     expected_s_u8 = expected_s.view(torch.uint8).cpu()
-    checkAllclose(
-        scale_out_u8.to(torch.float32),
-        expected_s_u8.to(torch.float32),
-        rtol=0,
-        atol=0,
-        msg=f"a16w4 scale (gate_up={gate_up})",
-    )
+    assert torch.equal(
+        scale_out_u8, expected_s_u8
+    ), f"a16w4 scale mismatch (gate_up={gate_up})"
 
     return {"result": "PASS"}
 
@@ -294,6 +298,7 @@ if __name__ == "__main__":
     if args.edge or run_all:
         for dt in float_dtypes:
             test_edge_values(dt)
+        aiter.logger.info("test_edge_values: PASS")
 
     df = pd.DataFrame(df)
     if "gate_up" in df.columns:

--- a/op_tests/test_quant_mxfp4.py
+++ b/op_tests/test_quant_mxfp4.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-import pytest
+import argparse
+import itertools
+
+import pandas as pd
 import torch
 
+import aiter
 from aiter.ops.quant import quant_mxfp4_hip
 from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight, shuffle_weight_a16w4
+from aiter.test_common import benchmark, checkAllclose
+
+torch.set_default_device("cuda")
 
 
 def even_round_scale(max_abs: torch.Tensor) -> torch.Tensor:
@@ -68,64 +75,60 @@ def ref_quant_mxfp4_even_round(inp: torch.Tensor, group_size: int = 32):
     return packed, scale_e8m0
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (4096, 128),
-        (4096, 256),
-        (4096, 1024),
-        (1, 32),
-        (3, 128),
-        (125, 64),
-        (4097, 256),
-    ],
-)
-@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
-def test_no_shuffle(shape, float_dtype):
+def _fp4_scale_shuffle_id(scaleN_pad, x, y):
+    return (
+        (x // 32 * scaleN_pad) * 32
+        + (y // 8) * 256
+        + (y % 4) * 64
+        + (x % 16) * 4
+        + (y % 8) // 4 * 2
+        + (x % 32) // 16
+    )
+
+
+@benchmark()
+def test_no_shuffle(m, n, float_dtype):
     torch.manual_seed(42)
-    inp = torch.randn(shape, dtype=float_dtype, device="cuda")
+    inp = torch.randn((m, n), dtype=float_dtype, device="cuda")
 
     packed_hip, scale_hip = quant_mxfp4_hip(inp, group_size=32)
-
     py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
 
     scale_hip_u8 = scale_hip.view(torch.uint8).cpu()
-    assert torch.equal(
-        scale_hip_u8, py_scale
-    ), f"Scale mismatch: {(scale_hip_u8 != py_scale).sum()} elements differ"
+    checkAllclose(
+        scale_hip_u8.to(torch.float32),
+        py_scale.to(torch.float32),
+        rtol=0,
+        atol=0,
+        msg=f"scale ({m},{n})",
+    )
 
     packed_hip_u8 = packed_hip.view(torch.uint8).cpu()
     diff = (packed_hip_u8.to(torch.int16) - py_packed.to(torch.int16)).abs()
     bad = (diff > 0) & (diff != 1) & (diff != 16) & (diff != 17)
-    assert (
-        not bad.any()
-    ), f"Packed diff too large for shape {shape}: max={diff.max().item()}"
+    checkAllclose(
+        packed_hip_u8.to(torch.float32),
+        py_packed.to(torch.float32),
+        rtol=0,
+        atol=17,
+        msg=f"packed ({m},{n})",
+    )
+    assert not bad.any(), f"Packed diff too large: max={diff.max().item()}"
+
+    return {"result": "PASS"}
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (4096, 128),
-        (4096, 256),
-        (4096, 1024),
-        (16, 64),
-        (48, 64),
-        (32, 192),
-        (80, 320),
-        (256, 96),
-    ],
-)
-@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
-def test_e8m0_shuffle(shape, float_dtype):
-    rows, cols = shape
+@benchmark()
+def test_e8m0_shuffle(m, n, float_dtype):
+    rows, cols = m, n
     if rows % 16 != 0:
-        pytest.skip(f"e8m0 shuffle_weight requires rows%16==0 (got {rows})")
+        return {"result": "SKIP"}
     K_pk = cols // 2
     if K_pk % 32 != 0:
-        pytest.skip(f"e8m0 shuffle_weight requires K_pk%32==0 (got K_pk={K_pk})")
+        return {"result": "SKIP"}
 
     torch.manual_seed(42)
-    inp = torch.randn(shape, dtype=float_dtype, device="cuda")
+    inp = torch.randn((m, n), dtype=float_dtype, device="cuda")
 
     packed_out, scale_out = quant_mxfp4_hip(
         inp, group_size=32, e8m0_shuffle=True, shuffle_weight=True
@@ -138,23 +141,16 @@ def test_e8m0_shuffle(shape, float_dtype):
 
     packed_out_u8 = packed_out.view(torch.uint8).cpu()
     expected_w_u8 = expected_w.view(torch.uint8).cpu()
-    assert torch.equal(
-        packed_out_u8, expected_w_u8
-    ), f"E8M0 weight mismatch: {(packed_out_u8 != expected_w_u8).sum()} differ"
+    checkAllclose(
+        packed_out_u8.to(torch.float32),
+        expected_w_u8.to(torch.float32),
+        rtol=0,
+        atol=0,
+        msg=f"e8m0 weight ({m},{n})",
+    )
 
     scale_ref_u8 = scale_ref.view(torch.uint8).flatten().cpu()
     scale_out_u8 = scale_out.view(torch.uint8).flatten().cpu()
-
-    def _fp4_scale_shuffle_id(scaleN_pad, x, y):
-        return (
-            (x // 32 * scaleN_pad) * 32
-            + (y // 8) * 256
-            + (y % 4) * 64
-            + (x % 16) * 4
-            + (y % 8) // 4 * 2
-            + (x % 32) // 16
-        )
-
     for row in range(rows):
         for g in range(scaleN):
             si = _fp4_scale_shuffle_id(scaleN_pad, row, g)
@@ -163,30 +159,21 @@ def test_e8m0_shuffle(shape, float_dtype):
                 scale_out_u8[si].item() == scale_ref_u8[li].item()
             ), f"Scale shuffle mismatch at row={row}, group={g}"
 
+    return {"result": "PASS"}
 
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (4096, 256),
-        (4096, 1024),
-        (32, 256),
-        (64, 512),
-        (96, 256),
-    ],
-)
-@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("gate_up", [False, True])
-def test_a16w4_shuffle(shape, float_dtype, gate_up):
-    rows, cols = shape
+
+@benchmark()
+def test_a16w4_shuffle(m, n, float_dtype, gate_up):
+    rows, cols = m, n
     scaleN = cols // 32
     if rows % 32 != 0 or scaleN % 8 != 0:
-        pytest.skip(f"a16w4 requires rows%32==0 and scaleN%8==0 (got {rows}x{cols})")
+        return {"result": "SKIP"}
     K_pk = cols // 2
     if K_pk % 64 != 0:
-        pytest.skip(f"a16w4 shuffle_weight requires K_pk%64==0 (got K_pk={K_pk})")
+        return {"result": "SKIP"}
 
     torch.manual_seed(42)
-    inp = torch.randn(shape, dtype=float_dtype, device="cuda")
+    inp = torch.randn((m, n), dtype=float_dtype, device="cuda")
 
     packed_out, scale_out = quant_mxfp4_hip(
         inp, group_size=32, a16w4_shuffle=True, gate_up=gate_up, shuffle_weight=True
@@ -203,30 +190,38 @@ def test_a16w4_shuffle(shape, float_dtype, gate_up):
 
     packed_out_u8 = packed_out.view(torch.uint8).cpu()
     expected_w_u8 = expected_w.view(torch.uint8).cpu()
-    assert torch.equal(packed_out_u8, expected_w_u8), (
-        f"A16W4 weight shuffle mismatch (gate_up={gate_up}): "
-        f"{(packed_out_u8 != expected_w_u8).sum()} bytes differ"
+    checkAllclose(
+        packed_out_u8.to(torch.float32),
+        expected_w_u8.to(torch.float32),
+        rtol=0,
+        atol=0,
+        msg=f"a16w4 weight (gate_up={gate_up})",
     )
 
     scale_out_u8 = scale_out.view(torch.uint8).cpu()
     expected_s_u8 = expected_s.view(torch.uint8).cpu()
-    assert torch.equal(scale_out_u8, expected_s_u8), (
-        f"A16W4 scale shuffle mismatch (gate_up={gate_up}): "
-        f"{(scale_out_u8 != expected_s_u8).sum()} bytes differ"
+    checkAllclose(
+        scale_out_u8.to(torch.float32),
+        expected_s_u8.to(torch.float32),
+        rtol=0,
+        atol=0,
+        msg=f"a16w4 scale (gate_up={gate_up})",
     )
 
+    return {"result": "PASS"}
 
-@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
+
+@benchmark()
 def test_edge_values(float_dtype):
     rows, cols = 32, 64
 
     inp_zero = torch.zeros(rows, cols, dtype=float_dtype, device="cuda")
     packed, scale = quant_mxfp4_hip(inp_zero, group_size=32)
-    assert packed.view(torch.uint8).sum() == 0
+    assert packed.view(torch.uint8).sum() == 0, "zero input failed"
 
     inp_large = torch.full((rows, cols), 1e4, dtype=float_dtype, device="cuda")
     packed, scale = quant_mxfp4_hip(inp_large, group_size=32)
-    assert packed.view(torch.uint8).max() > 0
+    assert packed.view(torch.uint8).max() > 0, "large input failed"
 
     inp_tiny = torch.full((rows, cols), 1e-10, dtype=float_dtype, device="cuda")
     packed, scale = quant_mxfp4_hip(inp_tiny, group_size=32)
@@ -234,71 +229,73 @@ def test_edge_values(float_dtype):
     inp_neg = torch.full((rows, cols), -3.0, dtype=float_dtype, device="cuda")
     packed, scale = quant_mxfp4_hip(inp_neg, group_size=32)
     py_packed, _ = ref_quant_mxfp4_even_round(inp_neg.cpu(), group_size=32)
-    assert torch.equal(packed.view(torch.uint8).cpu(), py_packed)
+    assert torch.equal(packed.view(torch.uint8).cpu(), py_packed), "neg input failed"
+
+    return {"result": "PASS"}
 
 
-def test_single_group():
-    inp = torch.randn(1, 32, dtype=torch.bfloat16, device="cuda")
-    packed, scale = quant_mxfp4_hip(inp, group_size=32)
-    assert packed.view(torch.uint8).shape == (1, 16)
-    assert scale.view(torch.uint8).shape == (1, 1)
-    py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
-    assert torch.equal(scale.view(torch.uint8).cpu(), py_scale)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no_shuffle", action="store_true")
+    parser.add_argument("--e8m0_shuffle", action="store_true")
+    parser.add_argument("--a16w4_shuffle", action="store_true")
+    parser.add_argument("--edge", action="store_true")
+    parser.add_argument("--all", action="store_true", default=True)
+    args = parser.parse_args()
 
-
-@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
-def test_e2m1_boundary_values(float_dtype):
-    boundary_vals = [
-        0.0,
-        0.25,
-        0.5,
-        0.75,
-        1.0,
-        1.25,
-        1.5,
-        1.75,
-        2.0,
-        2.5,
-        3.0,
-        3.5,
-        4.0,
-        5.0,
-        6.0,
-        -6.0,
-        0.0,
-        0.24,
-        0.26,
-        0.74,
-        0.76,
-        1.24,
-        1.26,
-        1.74,
-        1.76,
-        2.49,
-        2.51,
-        3.49,
-        3.51,
-        4.99,
-        5.01,
-        -0.25,
-    ]
-    inp = torch.tensor([boundary_vals], dtype=float_dtype, device="cuda")
-    packed, scale = quant_mxfp4_hip(inp, group_size=32)
-    py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
-    assert torch.equal(scale.view(torch.uint8).cpu(), py_scale)
-    packed_u8 = packed.view(torch.uint8).cpu()
-    diff = (packed_u8.to(torch.int16) - py_packed.to(torch.int16)).abs()
-    bad = (diff > 0) & (diff != 1) & (diff != 16) & (diff != 17)
-    assert not bad.any(), f"max diff={diff.max().item()}"
-
-
-def test_e8m0_shuffle_scale_only():
-    torch.manual_seed(42)
-    inp = torch.randn(4096, 256, dtype=torch.bfloat16, device="cuda")
-    packed_shuf, scale_shuf = quant_mxfp4_hip(
-        inp, group_size=32, e8m0_shuffle=True, shuffle_weight=False
+    run_all = args.all and not any(
+        [args.no_shuffle, args.e8m0_shuffle, args.a16w4_shuffle, args.edge]
     )
-    packed_ref, scale_ref = quant_mxfp4_hip(inp, group_size=32)
-    packed_shuf_u8 = packed_shuf.view(torch.uint8).cpu()
-    packed_ref_u8 = packed_ref.view(torch.uint8).cpu()
-    assert torch.equal(packed_shuf_u8, packed_ref_u8)
+
+    no_shuffle_shapes = [
+        (4096, 128),
+        (4096, 256),
+        (4096, 1024),
+        (1, 32),
+        (3, 128),
+        (125, 64),
+        (4097, 256),
+    ]
+    e8m0_shapes = [
+        (4096, 128),
+        (4096, 256),
+        (4096, 1024),
+        (16, 64),
+        (48, 64),
+        (32, 192),
+        (80, 320),
+        (256, 96),
+    ]
+    a16w4_shapes = [
+        (4096, 256),
+        (4096, 1024),
+        (32, 256),
+        (64, 512),
+        (96, 256),
+    ]
+    float_dtypes = [torch.bfloat16, torch.float16]
+
+    df = []
+
+    if args.no_shuffle or run_all:
+        for (m, n), dt in itertools.product(no_shuffle_shapes, float_dtypes):
+            df.append(test_no_shuffle(m, n, dt))
+
+    if args.e8m0_shuffle or run_all:
+        for (m, n), dt in itertools.product(e8m0_shapes, float_dtypes):
+            df.append(test_e8m0_shuffle(m, n, dt))
+
+    if args.a16w4_shuffle or run_all:
+        for (m, n), dt, gu in itertools.product(
+            a16w4_shapes, float_dtypes, [False, True]
+        ):
+            df.append(test_a16w4_shuffle(m, n, dt, gu))
+
+    if args.edge or run_all:
+        for dt in float_dtypes:
+            test_edge_values(dt)
+
+    df = pd.DataFrame(df)
+    if "gate_up" in df.columns:
+        df["gate_up"] = df["gate_up"].fillna(0).astype(int)
+    aiter.logger.info("quant_mxfp4 summary:\n%s", df.to_markdown(index=False))

--- a/op_tests/test_quant_mxfp4_even_round.py
+++ b/op_tests/test_quant_mxfp4_even_round.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter.ops.quant import quant_mxfp4_even_round_hip
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight, shuffle_weight_a16w4
+
+
+def even_round_scale(max_abs: torch.Tensor) -> torch.Tensor:
+    max_abs_f32 = max_abs.to(torch.float32).clone()
+    zero_mask = max_abs_f32 == 0
+
+    as_int = max_abs_f32.view(torch.int32)
+    as_int.add_(0x200000)
+    as_int.bitwise_and_(0x7F800000)
+    max_abs_f32 = as_int.view(torch.float32)
+
+    f32_min_normal = 2.0 ** (-126)
+    max_abs_f32.masked_fill_(zero_mask, f32_min_normal)
+
+    max_abs_f32.log2_()
+    max_abs_f32.floor_()
+    max_abs_f32.sub_(2)
+    max_abs_f32.clamp_(min=-127, max=127)
+    max_abs_f32.exp2_()
+    return max_abs_f32
+
+
+def fp32_to_e2m1(val: torch.Tensor) -> torch.Tensor:
+    a = val.abs()
+    dev = val.device
+    mag = torch.zeros_like(val, dtype=torch.uint8)
+    mag = torch.where(a >= 0.25, torch.tensor(1, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 0.75, torch.tensor(2, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 1.25, torch.tensor(3, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 1.75, torch.tensor(4, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 2.5,  torch.tensor(5, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 3.5,  torch.tensor(6, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 5.0,  torch.tensor(7, dtype=torch.uint8, device=dev), mag)
+    sign = torch.where(val < 0, torch.tensor(8, dtype=torch.uint8, device=dev),
+                       torch.tensor(0, dtype=torch.uint8, device=dev))
+    return sign | mag
+
+
+def ref_quant_mxfp4_even_round(inp: torch.Tensor, group_size: int = 32):
+    inp_f32 = inp.float()
+    rows, cols = inp_f32.shape
+    n_groups = cols // group_size
+
+    inp_grouped = inp_f32.reshape(rows, n_groups, group_size)
+    group_max = inp_grouped.abs().amax(dim=-1)
+    dq_scale = even_round_scale(group_max)
+
+    q_scale = torch.where(dq_scale == 0, torch.zeros_like(dq_scale), 1.0 / dq_scale)
+    scaled = inp_grouped * q_scale.unsqueeze(-1)
+
+    nibbles = fp32_to_e2m1(scaled)
+    nibbles = nibbles.reshape(rows, cols)
+    packed = nibbles[:, 0::2] | (nibbles[:, 1::2] << 4)
+
+    scale_e8m0 = ((dq_scale.view(torch.int32) >> 23) & 0xFF).to(torch.uint8)
+
+    return packed, scale_e8m0
+
+
+@pytest.mark.parametrize("shape", [
+    (4096, 128), (4096, 256), (4096, 1024),
+    (1, 32), (3, 128), (125, 64), (4097, 256),
+])
+@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
+def test_no_shuffle(shape, float_dtype):
+    torch.manual_seed(42)
+    inp = torch.randn(shape, dtype=float_dtype, device="cuda")
+
+    packed_hip, scale_hip = quant_mxfp4_even_round_hip(inp, group_size=32)
+
+    py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
+
+    scale_hip_u8 = scale_hip.view(torch.uint8).cpu()
+    assert torch.equal(scale_hip_u8, py_scale), (
+        f"Scale mismatch: {(scale_hip_u8 != py_scale).sum()} elements differ"
+    )
+
+    packed_hip_u8 = packed_hip.view(torch.uint8).cpu()
+    diff = (packed_hip_u8.to(torch.int16) - py_packed.to(torch.int16)).abs()
+    bad = (diff > 0) & (diff != 1) & (diff != 16) & (diff != 17)
+    assert not bad.any(), (
+        f"Packed diff too large for shape {shape}: max={diff.max().item()}"
+    )
+
+
+@pytest.mark.parametrize("shape", [
+    (4096, 128), (4096, 256), (4096, 1024),
+    (16, 64), (48, 64),
+    (32, 192), (80, 320), (256, 96),
+])
+@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
+def test_e8m0_shuffle(shape, float_dtype):
+    rows, cols = shape
+    if rows % 16 != 0:
+        pytest.skip(f"e8m0 shuffle_weight requires rows%16==0 (got {rows})")
+    K_pk = cols // 2
+    if K_pk % 32 != 0:
+        pytest.skip(f"e8m0 shuffle_weight requires K_pk%32==0 (got K_pk={K_pk})")
+
+    torch.manual_seed(42)
+    inp = torch.randn(shape, dtype=float_dtype, device="cuda")
+
+    packed_out, scale_out = quant_mxfp4_even_round_hip(
+        inp, group_size=32, e8m0_shuffle=True, shuffle_weight=True
+    )
+    packed_ref, scale_ref = quant_mxfp4_even_round_hip(inp, group_size=32)
+    expected_w = shuffle_weight(packed_ref)
+
+    scaleN = cols // 32
+    scaleN_pad = ((scaleN + 7) // 8) * 8
+
+    packed_out_u8 = packed_out.view(torch.uint8).cpu()
+    expected_w_u8 = expected_w.view(torch.uint8).cpu()
+    assert torch.equal(packed_out_u8, expected_w_u8), (
+        f"E8M0 weight mismatch: {(packed_out_u8 != expected_w_u8).sum()} differ"
+    )
+
+    scale_ref_u8 = scale_ref.view(torch.uint8).flatten().cpu()
+    scale_out_u8 = scale_out.view(torch.uint8).flatten().cpu()
+
+    def _fp4_scale_shuffle_id(scaleN_pad, x, y):
+        return ((x // 32 * scaleN_pad) * 32 + (y // 8) * 256
+                + (y % 4) * 64 + (x % 16) * 4 + (y % 8) // 4 * 2 + (x % 32) // 16)
+
+    for row in range(rows):
+        for g in range(scaleN):
+            si = _fp4_scale_shuffle_id(scaleN_pad, row, g)
+            li = row * scaleN + g
+            assert scale_out_u8[si].item() == scale_ref_u8[li].item(), (
+                f"Scale shuffle mismatch at row={row}, group={g}"
+            )
+
+
+@pytest.mark.parametrize("shape", [
+    (4096, 256), (4096, 1024),
+    (32, 256), (64, 512), (96, 256),
+])
+@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("gate_up", [False, True])
+def test_a16w4_shuffle(shape, float_dtype, gate_up):
+    rows, cols = shape
+    scaleN = cols // 32
+    if rows % 32 != 0 or scaleN % 8 != 0:
+        pytest.skip(f"a16w4 requires rows%32==0 and scaleN%8==0 (got {rows}x{cols})")
+    K_pk = cols // 2
+    if K_pk % 64 != 0:
+        pytest.skip(f"a16w4 shuffle_weight requires K_pk%64==0 (got K_pk={K_pk})")
+
+    torch.manual_seed(42)
+    inp = torch.randn(shape, dtype=float_dtype, device="cuda")
+
+    packed_out, scale_out = quant_mxfp4_even_round_hip(
+        inp, group_size=32, a16w4_shuffle=True, gate_up=gate_up, shuffle_weight=True
+    )
+    packed_ref, scale_ref = quant_mxfp4_even_round_hip(inp, group_size=32)
+    expected_w = shuffle_weight_a16w4(
+        packed_ref.view(torch.uint8).unsqueeze(0), NLane=16, gate_up=gate_up
+    ).squeeze(0)
+    expected_s = shuffle_scale_a16w4(
+        scale_ref.view(torch.uint8).reshape(rows, scaleN),
+        experts_cnt=1, gate_up=gate_up,
+    )
+
+    packed_out_u8 = packed_out.view(torch.uint8).cpu()
+    expected_w_u8 = expected_w.view(torch.uint8).cpu()
+    assert torch.equal(packed_out_u8, expected_w_u8), (
+        f"A16W4 weight shuffle mismatch (gate_up={gate_up}): "
+        f"{(packed_out_u8 != expected_w_u8).sum()} bytes differ"
+    )
+
+    scale_out_u8 = scale_out.view(torch.uint8).cpu()
+    expected_s_u8 = expected_s.view(torch.uint8).cpu()
+    assert torch.equal(scale_out_u8, expected_s_u8), (
+        f"A16W4 scale shuffle mismatch (gate_up={gate_up}): "
+        f"{(scale_out_u8 != expected_s_u8).sum()} bytes differ"
+    )
+
+
+@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
+def test_edge_values(float_dtype):
+    rows, cols = 32, 64
+
+    inp_zero = torch.zeros(rows, cols, dtype=float_dtype, device="cuda")
+    packed, scale = quant_mxfp4_even_round_hip(inp_zero, group_size=32)
+    assert packed.view(torch.uint8).sum() == 0
+
+    inp_large = torch.full((rows, cols), 1e4, dtype=float_dtype, device="cuda")
+    packed, scale = quant_mxfp4_even_round_hip(inp_large, group_size=32)
+    assert packed.view(torch.uint8).max() > 0
+
+    inp_tiny = torch.full((rows, cols), 1e-10, dtype=float_dtype, device="cuda")
+    packed, scale = quant_mxfp4_even_round_hip(inp_tiny, group_size=32)
+
+    inp_neg = torch.full((rows, cols), -3.0, dtype=float_dtype, device="cuda")
+    packed, scale = quant_mxfp4_even_round_hip(inp_neg, group_size=32)
+    py_packed, _ = ref_quant_mxfp4_even_round(inp_neg.cpu(), group_size=32)
+    assert torch.equal(packed.view(torch.uint8).cpu(), py_packed)
+
+
+def test_single_group():
+    inp = torch.randn(1, 32, dtype=torch.bfloat16, device="cuda")
+    packed, scale = quant_mxfp4_even_round_hip(inp, group_size=32)
+    assert packed.view(torch.uint8).shape == (1, 16)
+    assert scale.view(torch.uint8).shape == (1, 1)
+    py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
+    assert torch.equal(scale.view(torch.uint8).cpu(), py_scale)
+
+
+@pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
+def test_e2m1_boundary_values(float_dtype):
+    boundary_vals = [
+        0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75,
+        2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, -6.0,
+        0.0, 0.24, 0.26, 0.74, 0.76, 1.24, 1.26, 1.74,
+        1.76, 2.49, 2.51, 3.49, 3.51, 4.99, 5.01, -0.25,
+    ]
+    inp = torch.tensor([boundary_vals], dtype=float_dtype, device="cuda")
+    packed, scale = quant_mxfp4_even_round_hip(inp, group_size=32)
+    py_packed, py_scale = ref_quant_mxfp4_even_round(
+        inp.cpu(), group_size=32
+    )
+    assert torch.equal(scale.view(torch.uint8).cpu(), py_scale)
+    packed_u8 = packed.view(torch.uint8).cpu()
+    diff = (packed_u8.to(torch.int16) - py_packed.to(torch.int16)).abs()
+    bad = (diff > 0) & (diff != 1) & (diff != 16) & (diff != 17)
+    assert not bad.any(), f"max diff={diff.max().item()}"
+
+
+def test_e8m0_shuffle_scale_only():
+    torch.manual_seed(42)
+    inp = torch.randn(4096, 256, dtype=torch.bfloat16, device="cuda")
+    packed_shuf, scale_shuf = quant_mxfp4_even_round_hip(
+        inp, group_size=32, e8m0_shuffle=True, shuffle_weight=False
+    )
+    packed_ref, scale_ref = quant_mxfp4_even_round_hip(inp, group_size=32)
+    packed_shuf_u8 = packed_shuf.view(torch.uint8).cpu()
+    packed_ref_u8 = packed_ref.view(torch.uint8).cpu()
+    assert torch.equal(packed_shuf_u8, packed_ref_u8)

--- a/op_tests/test_quant_mxfp4_even_round.py
+++ b/op_tests/test_quant_mxfp4_even_round.py
@@ -36,11 +36,14 @@ def fp32_to_e2m1(val: torch.Tensor) -> torch.Tensor:
     mag = torch.where(a >= 0.75, torch.tensor(2, dtype=torch.uint8, device=dev), mag)
     mag = torch.where(a >= 1.25, torch.tensor(3, dtype=torch.uint8, device=dev), mag)
     mag = torch.where(a >= 1.75, torch.tensor(4, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 2.5,  torch.tensor(5, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 3.5,  torch.tensor(6, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 5.0,  torch.tensor(7, dtype=torch.uint8, device=dev), mag)
-    sign = torch.where(val < 0, torch.tensor(8, dtype=torch.uint8, device=dev),
-                       torch.tensor(0, dtype=torch.uint8, device=dev))
+    mag = torch.where(a >= 2.5, torch.tensor(5, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 3.5, torch.tensor(6, dtype=torch.uint8, device=dev), mag)
+    mag = torch.where(a >= 5.0, torch.tensor(7, dtype=torch.uint8, device=dev), mag)
+    sign = torch.where(
+        val < 0,
+        torch.tensor(8, dtype=torch.uint8, device=dev),
+        torch.tensor(0, dtype=torch.uint8, device=dev),
+    )
     return sign | mag
 
 
@@ -65,10 +68,18 @@ def ref_quant_mxfp4_even_round(inp: torch.Tensor, group_size: int = 32):
     return packed, scale_e8m0
 
 
-@pytest.mark.parametrize("shape", [
-    (4096, 128), (4096, 256), (4096, 1024),
-    (1, 32), (3, 128), (125, 64), (4097, 256),
-])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4096, 128),
+        (4096, 256),
+        (4096, 1024),
+        (1, 32),
+        (3, 128),
+        (125, 64),
+        (4097, 256),
+    ],
+)
 @pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
 def test_no_shuffle(shape, float_dtype):
     torch.manual_seed(42)
@@ -79,23 +90,31 @@ def test_no_shuffle(shape, float_dtype):
     py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
 
     scale_hip_u8 = scale_hip.view(torch.uint8).cpu()
-    assert torch.equal(scale_hip_u8, py_scale), (
-        f"Scale mismatch: {(scale_hip_u8 != py_scale).sum()} elements differ"
-    )
+    assert torch.equal(
+        scale_hip_u8, py_scale
+    ), f"Scale mismatch: {(scale_hip_u8 != py_scale).sum()} elements differ"
 
     packed_hip_u8 = packed_hip.view(torch.uint8).cpu()
     diff = (packed_hip_u8.to(torch.int16) - py_packed.to(torch.int16)).abs()
     bad = (diff > 0) & (diff != 1) & (diff != 16) & (diff != 17)
-    assert not bad.any(), (
-        f"Packed diff too large for shape {shape}: max={diff.max().item()}"
-    )
+    assert (
+        not bad.any()
+    ), f"Packed diff too large for shape {shape}: max={diff.max().item()}"
 
 
-@pytest.mark.parametrize("shape", [
-    (4096, 128), (4096, 256), (4096, 1024),
-    (16, 64), (48, 64),
-    (32, 192), (80, 320), (256, 96),
-])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4096, 128),
+        (4096, 256),
+        (4096, 1024),
+        (16, 64),
+        (48, 64),
+        (32, 192),
+        (80, 320),
+        (256, 96),
+    ],
+)
 @pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
 def test_e8m0_shuffle(shape, float_dtype):
     rows, cols = shape
@@ -119,30 +138,42 @@ def test_e8m0_shuffle(shape, float_dtype):
 
     packed_out_u8 = packed_out.view(torch.uint8).cpu()
     expected_w_u8 = expected_w.view(torch.uint8).cpu()
-    assert torch.equal(packed_out_u8, expected_w_u8), (
-        f"E8M0 weight mismatch: {(packed_out_u8 != expected_w_u8).sum()} differ"
-    )
+    assert torch.equal(
+        packed_out_u8, expected_w_u8
+    ), f"E8M0 weight mismatch: {(packed_out_u8 != expected_w_u8).sum()} differ"
 
     scale_ref_u8 = scale_ref.view(torch.uint8).flatten().cpu()
     scale_out_u8 = scale_out.view(torch.uint8).flatten().cpu()
 
     def _fp4_scale_shuffle_id(scaleN_pad, x, y):
-        return ((x // 32 * scaleN_pad) * 32 + (y // 8) * 256
-                + (y % 4) * 64 + (x % 16) * 4 + (y % 8) // 4 * 2 + (x % 32) // 16)
+        return (
+            (x // 32 * scaleN_pad) * 32
+            + (y // 8) * 256
+            + (y % 4) * 64
+            + (x % 16) * 4
+            + (y % 8) // 4 * 2
+            + (x % 32) // 16
+        )
 
     for row in range(rows):
         for g in range(scaleN):
             si = _fp4_scale_shuffle_id(scaleN_pad, row, g)
             li = row * scaleN + g
-            assert scale_out_u8[si].item() == scale_ref_u8[li].item(), (
-                f"Scale shuffle mismatch at row={row}, group={g}"
-            )
+            assert (
+                scale_out_u8[si].item() == scale_ref_u8[li].item()
+            ), f"Scale shuffle mismatch at row={row}, group={g}"
 
 
-@pytest.mark.parametrize("shape", [
-    (4096, 256), (4096, 1024),
-    (32, 256), (64, 512), (96, 256),
-])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4096, 256),
+        (4096, 1024),
+        (32, 256),
+        (64, 512),
+        (96, 256),
+    ],
+)
 @pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("gate_up", [False, True])
 def test_a16w4_shuffle(shape, float_dtype, gate_up):
@@ -166,7 +197,8 @@ def test_a16w4_shuffle(shape, float_dtype, gate_up):
     ).squeeze(0)
     expected_s = shuffle_scale_a16w4(
         scale_ref.view(torch.uint8).reshape(rows, scaleN),
-        experts_cnt=1, gate_up=gate_up,
+        experts_cnt=1,
+        gate_up=gate_up,
     )
 
     packed_out_u8 = packed_out.view(torch.uint8).cpu()
@@ -217,16 +249,42 @@ def test_single_group():
 @pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
 def test_e2m1_boundary_values(float_dtype):
     boundary_vals = [
-        0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75,
-        2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, -6.0,
-        0.0, 0.24, 0.26, 0.74, 0.76, 1.24, 1.26, 1.74,
-        1.76, 2.49, 2.51, 3.49, 3.51, 4.99, 5.01, -0.25,
+        0.0,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        1.25,
+        1.5,
+        1.75,
+        2.0,
+        2.5,
+        3.0,
+        3.5,
+        4.0,
+        5.0,
+        6.0,
+        -6.0,
+        0.0,
+        0.24,
+        0.26,
+        0.74,
+        0.76,
+        1.24,
+        1.26,
+        1.74,
+        1.76,
+        2.49,
+        2.51,
+        3.49,
+        3.51,
+        4.99,
+        5.01,
+        -0.25,
     ]
     inp = torch.tensor([boundary_vals], dtype=float_dtype, device="cuda")
     packed, scale = quant_mxfp4_even_round_hip(inp, group_size=32)
-    py_packed, py_scale = ref_quant_mxfp4_even_round(
-        inp.cpu(), group_size=32
-    )
+    py_packed, py_scale = ref_quant_mxfp4_even_round(inp.cpu(), group_size=32)
     assert torch.equal(scale.view(torch.uint8).cpu(), py_scale)
     packed_u8 = packed.view(torch.uint8).cpu()
     diff = (packed_u8.to(torch.int16) - py_packed.to(torch.int16)).abs()


### PR DESCRIPTION
## Motivation

Add single-kernel MXFP4 quantization (`quant_mxfp4_even_round`) that fused quantize mxfp4+ weight/scale shuffle in one HIP kernel. Using even_round scale algorithm which is aligned with the existing Triton kernel _mxfp4_quant_op in aiter/ops/triton/_triton_kernels/quant/quant.py.

## Comparison of kernel performance
| Shape | Scenario | quant_mxfp4_even_round_hip(us) | dynamic_per_group_scaled_quant_fp4+torch shuffle (us) |
|---|---|---|---|
| 4096×2560 | E8M0 shuffle | 8.0 | 32.6 |
| 4096×2560 | A16W4 shuffle | 8.0 | 54.4 |
| 4096×1280 | E8M0 shuffle | 5.6 | 30.9 |
| 4096×1280 | A16W4 shuffle | 4.7 | 51.1 |
| 4096×256 | E8M0 shuffle | 3.2 | 27.6 |
| 4096×256 | A16W4 shuffle | 2.8 | 48.9 |
 
## Precision verified
Sglang gsm8k test with Qwen3.5-397B
quant_mxfp4_even_round_kernel:
<img width="1436" height="580" alt="image" src="https://github.com/user-attachments/assets/08bf4861-3e5e-40fe-835c-b2b8f0971418" />

Triton kernel _mxfp4_quant_op used in sglang:
<img width="1428" height="583" alt="image" src="https://github.com/user-attachments/assets/ed223aff-ccae-40a9-adf5-004d6936773f" />


## Testcase
- no_shuffle: 7 shapes × bf16/fp16, vs Python reference (even_round scale + e2m1 quant)
- E8M0 shuffle: 8 shapes × bf16/fp16, vs `fp4_scale_shuffle_id` index + `shuffle_weight(layout=(16,16))`
- A16W4 shuffle: 5 shapes × bf16/fp16 × gate_up, vs `shuffle_scale_a16w4` + `shuffle_weight_a16w4`
- Edge cases: all-zero, large/tiny values, E2M1 boundary midpoints