### PR TITLE
[Bugfix] Suppress pandas FutureWarning and fix pybind11 type hint mismatch

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -216,7 +216,12 @@ class AITER_CONFIG(object):
                     df[c] = _FILL_DEFAULTS.get(c, 0)
             source_pairs[i] = (path, df[all_cols])
 
-        merge_df = pd.concat([df for _, df in source_pairs], ignore_index=True)
+        non_empty = [df for _, df in source_pairs if not df.empty]
+        merge_df = (
+            pd.concat(non_empty, ignore_index=True)
+            if non_empty
+            else source_pairs[0][1].iloc[0:0].copy()
+        )
         has_tag = "_tag" in merge_df.columns
         if has_tag:
             merge_df["_tag"] = merge_df["_tag"].fillna("")

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -494,8 +494,11 @@ namespace py = pybind11;
           "        int CuCount) -> ()");                                                        \
     m.def("wv_splitk_small_fp16_bf16",                                                          \
           &aiter::wv_splitk_small_fp16_bf16_wrapper,                                            \
-          "wv_splitk_small_fp16_bf16(Tensor in_a, Tensor in_b, Tensor! out_c, int N_in,"        \
-          "        int CuCount) -> ()");                                                        \
+          py::arg("in_a"),                                                                      \
+          py::arg("in_b"),                                                                      \
+          py::arg("out_c"),                                                                     \
+          py::arg("N_in"),                                                                      \
+          py::arg("CuCount"));                                                                  \
     m.def("LLMM1",                                                                              \
           &aiter::LLMM1,                                                                        \
           "LLMM1(Tensor in_a, Tensor in_b, Tensor! out_c, int rows_per_block) -> "              \
@@ -1464,8 +1467,17 @@ namespace py = pybind11;
 #define ROPE_1C_THD_BWD_PYBIND m.def("rope_thd_bwd_impl", &rope_thd_bwd_impl);
 #define ROPE_1C_2D_BWD_PYBIND m.def("rope_2d_bwd_impl", &rope_2d_bwd_impl);
 
-#define ROPE_1C_CACHED_POSITIONS_FWD_PYBIND \
-    m.def("rope_cached_positions_fwd_impl", &rope_cached_positions_fwd_impl)
+#define ROPE_1C_CACHED_POSITIONS_FWD_PYBIND        \
+    m.def("rope_cached_positions_fwd_impl",        \
+          &rope_cached_positions_fwd_impl,         \
+          py::arg("output"),                       \
+          py::arg("input"),                        \
+          py::arg("cos"),                          \
+          py::arg("sin"),                          \
+          py::arg("positions"),                    \
+          py::arg("rotate_style"),                 \
+          py::arg("reuse_freqs_front_part"),       \
+          py::arg("nope_first"))
 #define ROPE_2C_CACHED_POSITIONS_FWD_PYBIND    \
     m.def("rope_cached_positions_2c_fwd_impl", \
           &rope_cached_positions_2c_fwd_impl,  \
@@ -1479,10 +1491,32 @@ namespace py = pybind11;
           py::arg("rotate_style"),             \
           py::arg("reuse_freqs_front_part"),   \
           py::arg("nope_first"))
-#define ROPE_1C_CACHED_POSITIONS_OFFSETS_FWD_PYBIND \
-    m.def("rope_cached_positions_offsets_fwd_impl", &rope_cached_positions_offsets_fwd_impl)
-#define ROPE_2C_CACHED_POSITIONS_OFFSETS_FWD_PYBIND \
-    m.def("rope_cached_positions_offsets_2c_fwd_impl", &rope_cached_positions_offsets_2c_fwd_impl)
+#define ROPE_1C_CACHED_POSITIONS_OFFSETS_FWD_PYBIND        \
+    m.def("rope_cached_positions_offsets_fwd_impl",        \
+          &rope_cached_positions_offsets_fwd_impl,         \
+          py::arg("output"),                               \
+          py::arg("input"),                                \
+          py::arg("cos"),                                  \
+          py::arg("sin"),                                  \
+          py::arg("positions"),                            \
+          py::arg("offsets"),                              \
+          py::arg("rotate_style"),                         \
+          py::arg("reuse_freqs_front_part"),               \
+          py::arg("nope_first"))
+#define ROPE_2C_CACHED_POSITIONS_OFFSETS_FWD_PYBIND        \
+    m.def("rope_cached_positions_offsets_2c_fwd_impl",     \
+          &rope_cached_positions_offsets_2c_fwd_impl,      \
+          py::arg("output_x"),                             \
+          py::arg("output_y"),                             \
+          py::arg("input_x"),                              \
+          py::arg("input_y"),                              \
+          py::arg("cos"),                                  \
+          py::arg("sin"),                                  \
+          py::arg("positions"),                            \
+          py::arg("offsets"),                              \
+          py::arg("rotate_style"),                         \
+          py::arg("reuse_freqs_front_part"),               \
+          py::arg("nope_first"))
 
 #define FUSED_QKNORM_MROPE_CACHE_QUANT_PYBIND               \
     m.def("fused_qk_norm_mrope_3d_cache_pts_quant_shuffle", \


### PR DESCRIPTION
## Summary
- **aiter/jit/core.py**: filter out empty DataFrames before `pd.concat` to avoid `FutureWarning` about empty/all-NA dtype inference
- **csrc/include/rocm_ops.hpp**: add `py::arg(...)` to ROPE 1c/2c `cached_positions(_offsets)` fwd bindings and `wv_splitk_small_fp16_bf16` so pybind11 doc strings expose real parameter names instead of `arg0/arg1/...`, eliminating the spurious "type hints mismatch" warnings

## Test plan
- [ ] No more `FutureWarning` from pandas concat on tuned-config merge
- [ ] No more `type hints mismatch, override to --> rope_cached_positions_fwd_impl(arg0, ...)` warnings
- [ ] No more `type hints mismatch, override to --> wv_splitk_small_fp16_bf16(arg0, ...)` warnings