### PR TITLE
ci: make Standard Tests resilient to PRs missing install_triton.sh

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -382,6 +382,18 @@ jobs:
 
       - name: Install amd-triton
         run: |
+          # Ensure install_triton.sh is available even when the PR branch
+          # was created before the script was added to main (#2959).
+          # The workflow file always comes from the base branch, so we
+          # materialize the script from the base ref when missing.
+          if [ ! -f .github/scripts/install_triton.sh ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
+            mkdir -p .github/scripts
+            curl -fsSL \
+              "https://raw.githubusercontent.com/${{ github.repository }}/${BASE_REF}/.github/scripts/install_triton.sh" \
+              -o .github/scripts/install_triton.sh
+            chmod +x .github/scripts/install_triton.sh
+          fi
           docker exec -w /workspace aiter_test \
             bash -c "./.github/scripts/install_triton.sh && pip show amd-triton"
 
@@ -571,6 +583,18 @@ jobs:
 
       - name: Install amd-triton
         run: |
+          # Ensure install_triton.sh is available even when the PR branch
+          # was created before the script was added to main (#2959).
+          # The workflow file always comes from the base branch, so we
+          # materialize the script from the base ref when missing.
+          if [ ! -f .github/scripts/install_triton.sh ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
+            mkdir -p .github/scripts
+            curl -fsSL \
+              "https://raw.githubusercontent.com/${{ github.repository }}/${BASE_REF}/.github/scripts/install_triton.sh" \
+              -o .github/scripts/install_triton.sh
+            chmod +x .github/scripts/install_triton.sh
+          fi
           docker exec -w /workspace aiter_test \
             bash -c "./.github/scripts/install_triton.sh && pip show amd-triton"
 


### PR DESCRIPTION
## Problem

PR #2959 (`Update AITER Triton wheel`) introduced `.github/scripts/install_triton.sh` and added an `Install amd-triton` step in `aiter-test.yaml` that calls the script inside the docker container:

```yaml
- name: Install amd-triton
  run: |
    docker exec -w /workspace aiter_test       bash -c "./.github/scripts/install_triton.sh && pip show amd-triton"
```

The container's working directory `/workspace` is bind-mounted from the runner's checkout, which uses `ref: ${{ github.event.pull_request.head.sha || github.sha }}`. Any PR opened or last synced before #2959 landed on main does not have the script in its tree, so the step crashes with:

```
bash: line 1: ./.github/scripts/install_triton.sh: No such file or directory
##[error]Process completed with exit code 127.
```

## Evidence

PR #2969 (`feat/flydsl-fmha-gfx1201`) is currently failing 9/10 Standard Tests shards on this exact error. Example failing job: https://github.com/ROCm/aiter/actions/runs/25182228636/job/73840529361

The wheel artifact `aiter-whl-25182228636` is downloaded successfully (the log shows `Total of 1 artifact(s) downloaded` and `pip install` of the wheel succeeds). The crash occurs in the next step, the new `Install amd-triton` step.

This affects every PR branched before commit `77bda8de` until those PRs rebase. Forcing every stuck author to rebase purely to pick up a CI script is friction we can avoid.

## Fix

In the `Install amd-triton` step (both Standard Tests and Multi-GPU Tests jobs), fall back to fetching the script from the base ref via `raw.githubusercontent.com` when it is missing in the runner workspace. Workflow files for PR events always come from the base branch, so the fetched script stays consistent with the rest of the CI flow and there is no security boundary being crossed.

Single-line guard, no logic changes when the script is already present on the PR.

## Scope

- Touches only `.github/workflows/aiter-test.yaml` (two locations, identical fallback).
- `atom-test.yaml` and `sglang_downstream.yaml` call the same script after a fresh `git clone` of the PR sha and have the same latent bug. Currently they only run when label-gated so are not blocking PR #2969. Suggested as a separate follow-up.
- YAML validated locally with `python3 -c "import yaml; yaml.safe_load(open(...))"`.

## Expected outcome

Stale PRs (#2969 and any others branched before #2959) start passing the `Install amd-triton` step on the next CI run without requiring a rebase. Up-to-date PRs are unchanged because the `if [ ! -f ... ]` guard skips the curl path.