### PR TITLE
mla: refuse page_size > 1 on bf16 decode-stage1 kernel (no _ps variant shipped)

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -190,6 +190,23 @@ def mla_decode_fwd(
     if sm_scale is None:
         sm_scale = 1.0 / (qk_head_dim**0.5)
 
+    # AITER ships ps=0 (page-1-only) decode-stage1 kernels for the bf16
+    # absorbed MLA path used by DeepSeek-V3 / Kimi-K2 / Kimi-K2.5. The launcher
+    # template still passes s_log2_plen=log2(page_size), but the underlying
+    # kernel binary ignores it, silently producing wrong outputs. Refuse loudly
+    # rather than corrupting generation. See hsa/gfx950/mla/mla_asm.csv column
+    # "ps" (0/1) — bf16 a16w16 dec_stage1 has no _ps variant shipped.
+    _bf16_path = (kv_buffer.dtype == torch.bfloat16
+                  or (kv_buffer.dtype == torch.uint8 and q.dtype == torch.bfloat16))
+    if page_size != 1 and _bf16_path:
+        raise NotImplementedError(
+            f"aiter.mla.mla_decode_fwd: page_size={page_size} is not safe with "
+            "the bf16 decode-stage1 kernel. Only page_size=1 is correct in "
+            "this AITER build (kernel asm has no paged variant). "
+            "Pass page_size=1 or wait for an AITER release shipping "
+            "mla_dec_stage1_bf16_a16w16_*_ps.co."
+        )
+
     ori_total_s, ori_nhead, ori_v_head_dim = o.shape
     total_s, nhead, v_head_dim = o.shape
     bs = qo_indptr.shape[0] - 1

--- a/csrc/cpp_itfs/mla/asm_mla_decode_fwd.py
+++ b/csrc/cpp_itfs/mla/asm_mla_decode_fwd.py
@@ -47,6 +47,20 @@ def compile(
             (gqa_ratio, page_size, q_dtype, kv_dtype, num_kv_splits, v_head_dim),
         )
 
+    # Both .co kernels selected below are ps=0 (page_size=1 only) — see
+    # /sgl-workspace/aiter/hsa/gfx950/mla/mla_asm.csv. The launcher template
+    # passes s_log2_plen=log2(page_size), but these assembly blobs ignore it,
+    # silently corrupting outputs at page_size>1. Refuse instead of corrupting.
+    if page_size != 1:
+        raise NotImplementedError(
+            'asm_mla_decode_fwd (bf16 decode-stage1 kernel) only supports '
+            'page_size=1 in this AITER build; got page_size={}. The bf16 '
+            'a16w16_dec_stage1 kernels do not have a paged (_ps) variant '
+            'shipped in hsa/gfx950/mla/. Use page_size=1 or wait for an AITER '
+            'release that ships mla_dec_stage1_bf16_a16w16_*_ps.co.'
+            .format(page_size)
+        )
+
     if not_built(func_name):
         if gqa_ratio == 128:
             hsaco_path = f"{AITER_CORE_DIR}/hsa/{GPU_ARCH}/mla/mla_dec_stage1_bf16_a16w16_subQ128_mqa128.co"

--- a/op_tests/test_mla_page_guard.py
+++ b/op_tests/test_mla_page_guard.py
@@ -1,0 +1,114 @@
+"""Unit test for the AITER page-size guard patch.
+
+We test the Python `compile()` entry in
+`csrc/cpp_itfs/mla/asm_mla_decode_fwd.py` directly, which is the lowest layer
+where the kernel path becomes a fixed `.co` file.  At this layer:
+
+  * `compile(page_size=1, ...)` should still load the (correct) ps=0 kernel.
+  * `compile(page_size=32, ...)` should raise `NotImplementedError` with a
+    clear message that the bf16 decode-stage1 kernel has no paged variant.
+
+We also do a smoke check on the failing block_sizes that AITER's own
+`op_tests/test_mla.py` exposes (16/32/64/128) to confirm they all hit the
+guard.
+"""
+import os
+import sys
+import traceback
+
+# sys.path is set by the AITER test harness or by running from repo root
+
+
+def run():
+    from csrc.cpp_itfs.mla.asm_mla_decode_fwd import compile as compile_decode
+
+    print("=" * 72)
+    print("Test 1: page_size=1 (the documented good path)")
+    print("-" * 72)
+    try:
+        compile_decode(
+            gqa_ratio=128,
+            page_size=1,
+            q_dtype="bf16",
+            kv_dtype="bf16",
+            num_kv_splits=1,
+            v_head_dim=128,
+        )
+        print("PASS: compile() returned without NotImplementedError\n")
+        ok_one = True
+    except NotImplementedError as e:
+        print("FAIL: page_size=1 should NOT raise NotImplementedError")
+        print(f"      got: {e}\n")
+        ok_one = False
+    except Exception as e:
+        # Anything else (e.g. JIT errors) is unrelated to the guard test.
+        print(f"PASS-ish: page_size=1 did not hit guard ({type(e).__name__}: {e})")
+        ok_one = True
+
+    print("=" * 72)
+    print("Test 2: page_size > 1 should raise NotImplementedError")
+    print("        (these are the values AITER's own test_mla.py shows broken)")
+    print("-" * 72)
+    bad_sizes = [16, 32, 64, 128]
+    ok_two = True
+    for ps in bad_sizes:
+        try:
+            compile_decode(
+                gqa_ratio=128,
+                page_size=ps,
+                q_dtype="bf16",
+                kv_dtype="bf16",
+                num_kv_splits=1,
+                v_head_dim=128,
+            )
+            print(f"FAIL: page_size={ps} should raise NotImplementedError")
+            ok_two = False
+        except NotImplementedError as e:
+            msg = str(e).splitlines()[0]
+            print(f"PASS: page_size={ps:>3} → {msg}")
+        except Exception as e:
+            print(
+                f"FAIL: page_size={ps} raised wrong exception type: "
+                f"{type(e).__name__}: {e}"
+            )
+            ok_two = False
+
+    print("=" * 72)
+    print("Test 3: gqa_ratio=16 (the smaller decode-stage1 kernel) too")
+    print("-" * 72)
+    try:
+        compile_decode(
+            gqa_ratio=16,
+            page_size=32,
+            q_dtype="bf16",
+            kv_dtype="bf16",
+            num_kv_splits=1,
+            v_head_dim=128,
+        )
+        print("FAIL: gqa_ratio=16 / page_size=32 should also be guarded")
+        ok_three = False
+    except NotImplementedError as e:
+        msg = str(e).splitlines()[0]
+        print(f"PASS: gqa_ratio=16 / page_size=32 → {msg}")
+        ok_three = True
+
+    print()
+    summary = [
+        ("page_size=1 path", ok_one),
+        ("page_size>1 raises", ok_two),
+        ("gqa_ratio=16 also guarded", ok_three),
+    ]
+    print("=" * 72)
+    for name, ok in summary:
+        print(f"  {('PASS' if ok else 'FAIL'):>4}: {name}")
+    print("=" * 72)
+    return 0 if all(ok for _, ok in summary) else 1
+
+
+if __name__ == "__main__":
+    try:
+        rc = run()
+    except Exception:
+        traceback.print_exc()
+        rc = 2
+    sys.exit(rc)


### PR DESCRIPTION
Refs #2996

## What

Refuse `page_size != 1` for the bf16 decode-stage1 MLA path used by
DeepSeek-V3 / Kimi-K2 / Kimi-K2.5, raising `NotImplementedError` instead of
silently producing wrong outputs. Adds an `op_tests/test_mla_page_guard.py`
covering the new behavior.

## Why

The kernel selector in `csrc/cpp_itfs/mla/asm_mla_decode_fwd.py:46` always
loads the `ps=0` blob (`mla_dec_stage1_bf16_a16w16_subQ{16,128}_mqa{16,128}.co`).
The launcher template still packs `s_log2_plen=log2(page_size)`, but the
assembly ignores the scalar and reads the cache with `page_size=1` addressing
even when `page_size>1` is requested.

End-to-end on sglang + Kimi-K2.5-MXFP4 at TP=4: `--page-size 32` makes the
model emit word-salad while reporting +65 % decode throughput (per-call
latency of `kn_mla_reduce_v1<128,16,4>` drops from ~4 ms to ~23 µs). AITER's
own `op_tests/test_mla.py` shows the same regression at `-blk {16,32,64,128}`
on the prefill-absorb / decode-absorb checks:

```
$ python3 op_tests/test_mla.py -blk 1   -c 256 -b 4 -n 16,1
mla_prefill-absorb [torch vs aiter_asm]: ... PASSED
mla_decode-absorb  [golden vs aiter_asm]: ... PASSED

$ python3 op_tests/test_mla.py -blk 32  -c 256 -b 4 -n 16,1
mla_prefill-absorb [torch vs aiter_asm]: ... FAILED
mla_decode-absorb  [golden vs aiter_asm]: ... FAILED
```

CI only invokes `python3 op_tests/test_mla.py` with no flags, so the default
`--block_size 1` is the only configuration validated.

## What this PR does NOT do

Does **not** enable multi-token paging on the bf16 path. The real fix is to
ship `mla_dec_stage1_bf16_a16w16_*_ps.co` kernels and update the selector +
`hsa/gfx950/mla/mla_asm.csv`. That work is tracked as TODOs in #2996. This
PR is a fail-loud guard so users stop being silently miscomputed at while
that lands.

## Files

- `aiter/mla.py:mla_decode_fwd` — guard at the user-facing entry. Fires on
  every call, no JIT-cache race.
- `csrc/cpp_itfs/mla/asm_mla_decode_fwd.py:compile()` — guard at the JIT
  compile entry, which is what the C++ wrapper invokes via subprocess for
  not-yet-built `(gqa_ratio, page_size, ...)` cache keys.
- `op_tests/test_mla_page_guard.py` — new unit test:
  - `page_size=1` does **not** raise (the documented good path)
  - `page_size ∈ {16, 32, 64, 128}` all raise `NotImplementedError`
  - both `gqa_ratio=128` (Kimi/DSV3) and `gqa_ratio=16` are guarded

## Test plan

- [x] `python3 op_tests/test_mla.py -blk 1` still passes (decode/prefill absorb)
- [x] `python3 op_tests/test_mla.py -blk 32` raises `NotImplementedError` from
      `aiter.mla.mla_decode_fwd` instead of producing wrong outputs
- [x] `python3 op_tests/test_mla_page_guard.py` returns 0 (all 3 sub-tests pass)
- [x] Verified end-to-end: sglang serving Kimi-K2.5-MXFP4 at `--page-size 1`
      produces coherent output (math/code/factual prompts all sensible);
      `--page-size 32` now errors at startup instead of silently corrupting

## Suggested follow-ups (out of scope for this PR)

See the TODO list in #2996. In short: implement `_ps` variants of the bf16
decode-stage1 kernels, update the selector to pick them when `page_size>1`,
extend `mla_asm.csv`, and add a `-blk` matrix to `aiter_test.sh`'s CI
invocation so multi-page regressions surface in CI rather than user
deployments.

