### PR TITLE
ci(nightly): fix wheel/image ABI mismatch + 0-test false-pass (run 25202894144)

### DIFF
--- a/.github/scripts/resolve_aiter_version.sh
+++ b/.github/scripts/resolve_aiter_version.sh
@@ -14,6 +14,10 @@ if [ -n "${AITER_INDEX_URL:-}" ]; then
   # Export so the heredoc Python script can read them via os.environ
   export AITER_INDEX_URL AITER_PYTHON_TAG
   export AITER_VERSION
+  # AITER_ROCM_TAG (e.g. rocm7.0 / rocm7.1 / rocm7.2) optionally narrows wheel
+  # selection so the picked wheel's c10/hip ABI matches the consumer container.
+  # Set by run_sglang.sh from SGL_IMAGE; safe to leave unset elsewhere.
+  export AITER_ROCM_TAG="${AITER_ROCM_TAG:-}"
 
   # Find the direct wheel URL from the index.
   # Some S3 buckets serve wheels under an /amd-aiter/ subdirectory (PEP 503 style),
@@ -24,6 +28,7 @@ import os, re, sys, urllib.parse, urllib.request
 index = os.environ.get("AITER_INDEX_URL", "").rstrip("/")
 version_filter = os.environ.get("AITER_VERSION", "")
 pytag = os.environ.get("AITER_PYTHON_TAG", "cp312")
+rocm_filter = os.environ.get("AITER_ROCM_TAG", "")  # e.g. "rocm7.0" / "rocm7.1" / "rocm7.2"
 
 def list_wheels(page_url):
     try:
@@ -66,6 +71,18 @@ if version_filter:
 
 if not filenames:
     sys.exit(0)
+
+# Narrow to the ROCm tag matching the consumer container (e.g. rocm7.0).
+# Without this filter, wheel sort below picks the highest +rocm<X.Y> tag
+# (e.g. +rocm7.2) and pip-installs it into the wrong-ABI container.
+if rocm_filter:
+    matched = [f for f in filenames if rocm_filter in f]
+    if matched:
+        filenames = matched
+    else:
+        print(f"WARNING: no wheel matches AITER_ROCM_TAG={rocm_filter}; "
+              f"falling back to all matching version (ABI mismatch risk).",
+              file=sys.stderr)
 
 best_name = sorted(filenames)[-1]
 best_encoded = best_name.replace("+", "%2B")

--- a/.github/scripts/run_sglang.sh
+++ b/.github/scripts/run_sglang.sh
@@ -25,6 +25,25 @@ AITER_INDEX_URL="${3:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # SGLang Docker images use Python 3.10
 export AITER_PYTHON_TAG=cp310
+
+# Derive AITER wheel ROCm tag from the SGLang image's ROCm tag so that the
+# wheel's c10/hip ABI matches the container's PyTorch ABI. Without this, e.g.
+# a +rocm7.2 wheel installed in a rocm700 container fails at JIT .so load with
+# `undefined symbol: c10::hip::c10_hip_check_implementation` (run 25202894144).
+derive_aiter_rocm_tag() {
+  case "$1" in
+    *rocm700*|*rocm702*) echo rocm7.0 ;;
+    *rocm710*|*rocm711*) echo rocm7.1 ;;
+    *rocm720*|*rocm721*|*rocm722*) echo rocm7.2 ;;
+    *) echo "" ;;
+  esac
+}
+if [ -n "${SGL_IMAGE_OVERRIDE:-}" ]; then
+  AITER_ROCM_TAG="$(derive_aiter_rocm_tag "${SGL_IMAGE_OVERRIDE}")"
+  [ -n "${AITER_ROCM_TAG}" ] && export AITER_ROCM_TAG \
+    && echo "Derived AITER_ROCM_TAG=${AITER_ROCM_TAG} from SGL_IMAGE_OVERRIDE"
+fi
+
 source "${SCRIPT_DIR}/resolve_aiter_version.sh"
 
 SGL_BRANCH="${SGL_BRANCH:-v0.5.10}"
@@ -143,8 +162,32 @@ if [ -n "${SGL_IMAGE_OVERRIDE:-}" ]; then
     install_aiter_from_source
   fi
 
-  # Verify AITER works on this runner (may differ from preflight runner)
-  docker exec ci_sglang python3 -c "import aiter; print('AITER import OK')"
+  # Verify AITER works on this runner (may differ from preflight runner).
+  # Deep smoke: dlopen every aiter/jit/*.so via ctypes (no torch op registration,
+  # no GPU required). Catches c10/hip ABI symbol mismatches that bare
+  # `import aiter` misses, because aiter's top-level package does not load
+  # the JIT shared objects until a tensor op is dispatched into them.
+  # See run 25202894144 for the failure mode this guards against.
+  docker exec ci_sglang python3 - <<'AITER_DEEP_SMOKE'
+import ctypes, glob, os, sys
+import aiter
+jit_dir = os.path.join(os.path.dirname(aiter.__file__), "jit")
+sos = sorted(glob.glob(os.path.join(jit_dir, "*.so")))
+if not sos:
+    sys.exit(f"AITER deep smoke FAILED: no .so found in {jit_dir} (wheel install broken)")
+fails = []
+for so in sos:
+    try:
+        ctypes.CDLL(so)  # RTLD_LOCAL — verify symbols without polluting global namespace
+    except OSError as e:
+        fails.append(f"  {os.path.basename(so)}: {e}")
+if fails:
+    print("AITER deep smoke FAILED — ABI mismatch (likely wheel ROCm != image ROCm):", file=sys.stderr)
+    for f in fails:
+        print(f, file=sys.stderr)
+    sys.exit(1)
+print(f"AITER deep smoke OK: {len(sos)} JIT .so files dlopen cleanly")
+AITER_DEEP_SMOKE
 else
 # Resolve candidates by matching ROCm version from AITER_VERSION
 readarray -t SGL_IMAGES < <(python3 - "${GPU_TAG}" "${AITER_VERSION:-}" <<'PY'
@@ -222,9 +265,29 @@ for candidate in "${SGL_IMAGES[@]}"; do
     fi
   fi
 
-  # Smoke-test: verify AITER can be imported
-  if docker exec ci_sglang python3 -c "import aiter; print('AITER import OK')" 2>&1; then
-    echo "AITER wheel is compatible with ${candidate}"
+  # Smoke-test: deep dlopen of every JIT .so to catch c10/hip ABI mismatches
+  # that bare `import aiter` misses (see run_sglang.sh:147 for rationale).
+  if docker exec ci_sglang python3 - <<'AITER_DEEP_SMOKE_CANDIDATE' 2>&1; then
+import ctypes, glob, os, sys
+import aiter
+jit_dir = os.path.join(os.path.dirname(aiter.__file__), "jit")
+sos = sorted(glob.glob(os.path.join(jit_dir, "*.so")))
+if not sos:
+    sys.exit(f"AITER deep smoke FAILED: no .so in {jit_dir}")
+fails = []
+for so in sos:
+    try:
+        ctypes.CDLL(so)
+    except OSError as e:
+        fails.append(f"  {os.path.basename(so)}: {e}")
+if fails:
+    print("ABI mismatch:", file=sys.stderr)
+    for f in fails:
+        print(f, file=sys.stderr)
+    sys.exit(1)
+print(f"AITER deep smoke OK: {len(sos)} JIT .so OK")
+AITER_DEEP_SMOKE_CANDIDATE
+    echo "AITER wheel is ABI-compatible with ${candidate}"
     SGL_IMAGE="${candidate}"
     break
   else
@@ -249,7 +312,29 @@ fi
 # ── Run test ──
 echo ""
 echo "=== Running: ${TEST_CMD} ==="
-bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" bash -c "${TEST_CMD}"
+TEST_LOG="$(mktemp)"
+set +e
+bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" bash -c "${TEST_CMD}" 2>&1 | tee "${TEST_LOG}"
+TEST_RC=${PIPESTATUS[0]}
+set -e
+
+# Empty-suite guard: SGLang's incremental migration prints "No tests found ...
+# Skipping." and exits 0. Without this guard those zero-test runs were counted
+# as PASS (run 25202894144 nightly-8gpu-deepseek-v32). Treat as SKIPPED via
+# GitHub Actions neutral exit code (78) so dashboards distinguish from a real
+# pass without flipping the job to red.
+if grep -qE "No tests found .*Skipping\.?" "${TEST_LOG}"; then
+  echo ""
+  echo "::warning title=Empty Suite::No tests found for this suite — marking SKIPPED, not PASSED"
+  echo "=== Test SKIPPED (no tests in suite) ==="
+  exit 78
+fi
+
+if [ "${TEST_RC}" -ne 0 ]; then
+  echo ""
+  echo "=== Test FAILED (exit ${TEST_RC}) ==="
+  exit "${TEST_RC}"
+fi
 
 echo ""
 echo "=== Test PASSED ==="

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -178,9 +178,21 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN_TEST }}
           AITER_VERSION: ${{ github.event.inputs.aiter_version }}
         run: |
+          # Preflight test command: exercise the SGLang AITER hot path
+          # (rmsnorm forward) so that a wheel/image ABI mismatch surfaces here
+          # rather than later in 30+ shard jobs. `import aiter` alone cannot
+          # detect c10/hip undefined symbols because JIT .so files are loaded
+          # lazily on first dispatch.
+          PREFLIGHT_CMD='python3 -c "
+          import torch
+          from sglang.srt.layers.layernorm import RMSNorm
+          x = torch.randn(2, 1024, dtype=torch.bfloat16, device=\"cuda\")
+          RMSNorm(1024).cuda().to(torch.bfloat16)(x)
+          print(\"SGLang+AITER rmsnorm preflight OK\")
+          "'
           bash .github/scripts/run_sglang.sh \
             "${{ github.sha }}" \
-            "echo preflight-smoke-test-only" \
+            "${PREFLIGHT_CMD}" \
             "${{ github.event.inputs.aiter_index_url }}"
 
   # ── SGLang Integration ───────────────────────────────────────────────


### PR DESCRIPTION
## Why

Run [25202894144](https://github.com/ROCm/aiter/actions/runs/25202894144) on this branch reported **41/48 SGLang job failures**. Investigating with @SatyaRamji and @xiao-hai surfaced two distinct workflow-side bugs — the AITER source code in v0.1.13-rc1 is fine.

### Bug 1 (real, 41 jobs same root cause)

```
ImportError: aiter/jit/module_rmsnorm_quant.so: undefined symbol:
_ZN3c103hip28c10_hip_check_implementationEiPKcS2_jb
```

The mangled symbol is `c10::hip::c10_hip_check_implementation` — a c10/hip ABI symbol that is present in PyTorch ROCm 7.2 but **not** ROCm 7.0. This branch's workflow installed the **+rocm7.2** AITER wheel into a **rocm700** SGLang container (`rocm/sgl-dev:v0.5.10.post1-rocm700-mi30x-20260430`).

Why preflight didn't catch it: `import aiter` only loads the top-level Python package; `aiter/jit/*.so` files are loaded **lazily** on first dispatch. The bug surfaces 5+ minutes into the actual test, multiplied across every shard.

A previous attempt to deep-load via `importlib.import_module` (commit 4b0ada6) was reverted in 65ff2dd because it over-rejected working containers — it triggered torch op registration which can collide.

### Bug 2 (silent masking, ≥1 job false PASS)

```
No tests found for hw=AMD, suite=nightly-amd-accuracy-8-gpu-deepseek-v32, nightly=False
This is expected during incremental migration. Skipping.
=== Test PASSED ===
```

`run_sglang.sh` unconditionally echoes `=== Test PASSED ===` after `amd_ci_exec.sh` exit 0. Skipped suites count as PASS, so coverage gaps during the SGLang nightly migration are invisible.

## What

Five surgical fixes, workflow-only (no AITER source changes):

| # | File | Change |
|---|------|--------|
| 1 | `run_sglang.sh:147` | Replace `import aiter` smoke (override branch) with deep `ctypes.CDLL` dlopen of every `aiter/jit/*.so` |
| 2 | `run_sglang.sh:253` | Same deep smoke for the candidate-iteration branch |
| 3 | `run_sglang.sh:25-43` | New `derive_aiter_rocm_tag` + `AITER_ROCM_TAG` export from `SGL_IMAGE_OVERRIDE` |
| 4 | `resolve_aiter_version.sh:65-73` | Honor `AITER_ROCM_TAG` to filter wheel candidates before lex-sort |
| 5 | `nightly.yaml:181-191` | Replace preflight `echo` with real `RMSNorm.forward` exercising AITER hot path |
| 6 | `run_sglang.sh:312-340` | Detect `No tests found ... Skipping.` → exit 78 (GitHub neutral) instead of unconditional PASS |

### Why `ctypes.CDLL` instead of `importlib.import_module`

The reverted 4b0ada6 attempt used `importlib.import_module(f'aiter.jit.{so.stem}')` which goes through Python's torch op registration machinery — that can fail for reasons unrelated to ABI. `ctypes.CDLL(so)` just dlopens with `RTLD_LOCAL`, surfacing **only** undefined-symbol errors (the failure class we care about) without polluting global namespace or triggering torch op side effects.

## Verification

Local checks done:
- `bash -n` clean on both modified shell scripts
- `yaml.safe_load` clean on `nightly.yaml`

Recommended verification once merged into this branch:
- Manual `workflow_dispatch` of `nightly.yaml` with:
  - `aiter_version=0.1.13rc1`
  - `aiter_index_url=https://rocm.frameworks-prereleases.amd.com/whl/gfx942-gfx950/`
- Expected: SGLang failure count drops from 41 → ≤ 5. Any remaining red must show **real SGLang test stack errors**, not undefined-symbol.
- Expected: `nightly-8gpu-deepseek-v32` shows as **SKIPPED** (yellow) instead of PASS, until SGLang's incremental migration covers that suite.

## Scope

- **No** AITER source code changes
- **No** impact on `release/v0.1.13` or `v0.1.13-rc1` wheel ABI (those wheels are correct; this PR fixes the workflow that consumed the wrong one)
- **No** impact on `aiter-test`, `vllm`, `atom`, `triton-test` workflows
- All changes are scoped to `.github/scripts/{run_sglang,resolve_aiter_version}.sh` and `.github/workflows/nightly.yaml`

cc @kithumma (owner of base branch) — please review and merge into your branch when convenient.
cc @SatyaRamji @xiao-hai — context.