### PR TITLE
mla/gather_kv_b_proj: handle unquantized kv_b_proj weight (kv_proj_scale=None)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
+++ b/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
@@ -81,6 +81,7 @@ def _triton_gather_kv_b_proj(
     PaddedV: tl.constexpr,
     WEIGHT_PRESHUFFLE: tl.constexpr = False,
     PER_ROW_SCALE: tl.constexpr = False,
+    NO_SCALE: tl.constexpr = False,
 ):
     stride_k_buffer: tl.constexpr = KBlockSize * (KV_CDim + KV_PeDim)
     stride_k_prefix: tl.constexpr = TpNumHeads * (QkNopeHeadDim + KV_PeDim)
@@ -124,7 +125,10 @@ def _triton_gather_kv_b_proj(
     k_head_base = kv_proj_weight + pid_head * (QkNopeHeadDim + VHeadDim) * KV_CDim
     v_head_base = k_head_base + QkNopeHeadDim * KV_CDim
 
-    if PER_ROW_SCALE:
+    if NO_SCALE:
+        # weight is not quantized; skip scale loading entirely
+        pass
+    elif PER_ROW_SCALE:
         k_row0 = pid_head * (QkNopeHeadDim + VHeadDim)
         k_nope_scale_vec = tl.load(
             kv_proj_scale + k_row0 + offs_n_k, mask=mask_k, other=1.0
@@ -218,7 +222,7 @@ def _triton_gather_kv_b_proj(
             other=0.0,
         ).to(k_type)
 
-    if not PER_ROW_SCALE:
+    if (not NO_SCALE) and (not PER_ROW_SCALE):
         k_nope_scale_0 = tl.load(
             kv_proj_scale + k_scale_n_idx * num_scale_cols + 0,
             mask=mask_k,
@@ -291,7 +295,16 @@ def _triton_gather_kv_b_proj(
             + tl.arange(0, KV_PeDim)[None, :],
         )
 
-        if PER_ROW_SCALE:
+        if NO_SCALE:
+            accum_k += tl.dot(kv_c_data_0, k_nope_weight_0.T)
+            accum_v += tl.dot(kv_c_data_0, v_nope_weight_0.T)
+            accum_k += tl.dot(kv_c_data_1, k_nope_weight_1.T)
+            accum_v += tl.dot(kv_c_data_1, v_nope_weight_1.T)
+            accum_k += tl.dot(kv_c_data_2, k_nope_weight_2.T)
+            accum_v += tl.dot(kv_c_data_2, v_nope_weight_2.T)
+            accum_k += tl.dot(kv_c_data_3, k_nope_weight_3.T)
+            accum_v += tl.dot(kv_c_data_3, v_nope_weight_3.T)
+        elif PER_ROW_SCALE:
             accum_k += (
                 tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_vec[None, :]
             )

--- a/aiter/ops/triton/gather_kv_b_proj.py
+++ b/aiter/ops/triton/gather_kv_b_proj.py
@@ -29,20 +29,34 @@ def gather_kv_b_proj(
 
     qk_nope_head_dim = weight_n // tp_k_head_num_k - v_head_dim
 
-    per_row_scale = kv_proj_scale.dim() == 1 or (
-        kv_proj_scale.dim() == 2 and kv_proj_scale.shape[1] == 1
-    )
-    if per_row_scale:
-        assert kv_proj_scale.numel() == weight_n, (
-            f"per-row kv_proj_scale must have shape ({weight_n},) or ({weight_n}, 1), "
-            f"got {tuple(kv_proj_scale.shape)}"
-        )
+    # Three scale modes:
+    #   - kv_proj_scale is None   : weight is unquantized (e.g. bf16
+    #     kv_b_proj on Kimi-K2.5-MXFP4). Kernel skips scale-load and
+    #     scale-multiply entirely (NO_SCALE branch).
+    #   - kv_proj_scale.dim() == 1 (or [N, 1]) : per-row scale.
+    #   - else                     : per-block scale ([N//128, K//128]).
+    no_scale = kv_proj_scale is None
+    if no_scale:
+        # Triton requires a non-None tensor pointer for every kernel argument
+        # even if NO_SCALE=True makes it unread. Pass the weight tensor as a
+        # placeholder; the kernel does not load from it in this branch.
+        kv_proj_scale = kv_proj_weight
+        per_row_scale = False  # ignored when NO_SCALE=True
     else:
-        scale_n, scale_k = kv_proj_scale.shape
-        scale_k_granularity = weight_k // scale_k
-        scale_n_granularity = weight_n // scale_n
-        assert scale_k_granularity == 128
-        assert scale_n_granularity == 128
+        per_row_scale = kv_proj_scale.dim() == 1 or (
+            kv_proj_scale.dim() == 2 and kv_proj_scale.shape[1] == 1
+        )
+        if per_row_scale:
+            assert kv_proj_scale.numel() == weight_n, (
+                f"per-row kv_proj_scale must have shape ({weight_n},) or ({weight_n}, 1), "
+                f"got {tuple(kv_proj_scale.shape)}"
+            )
+        else:
+            scale_n, scale_k = kv_proj_scale.shape
+            scale_k_granularity = weight_k // scale_k
+            scale_n_granularity = weight_n // scale_n
+            assert scale_k_granularity == 128
+            assert scale_n_granularity == 128
 
     ChunkK = 16 if k_buffer.dtype in [torch.float16, torch.bfloat16] else 32
 
@@ -76,5 +90,6 @@ def gather_kv_b_proj(
         PaddedV=padded_v,
         WEIGHT_PRESHUFFLE=weight_preshuffle,
         PER_ROW_SCALE=per_row_scale,
+        NO_SCALE=no_scale,
         num_stages=3,
     )


### PR DESCRIPTION
Refs ROCm/ATOM#680

## What

`aiter.ops.triton.gather_kv_b_proj` currently dies with

```
File ".../aiter/ops/triton/gather_kv_b_proj.py", line 32
    per_row_scale = kv_proj_scale.dim() == 1 or (
                    ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'dim'
```

whenever the caller passes \`kv_proj_scale=None\` — which is the case for any
model whose \`kv_b_proj.weight\` is unquantized (e.g. bf16 \`kv_b_proj\` on
\`amd/Kimi-K2.5-MXFP4\`).

This PR adds a third constexpr branch alongside the existing PER_ROW_SCALE
and per-block paths so the kernel can run unscaled when no scale is
provided.

## Why

ATOM 0.1.2.post hits this on the **prefix-cache hit path during prefill**
and crashes all four model-runner ranks on the first cache hit. Downstream
symptom is that the API server stays up while the engine is dead, so every
subsequent request stalls until the client watchdog. Filed as
ROCm/ATOM#680.

## Change summary

\`aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py\`

- Add \`NO_SCALE: tl.constexpr = False\` to \`_triton_gather_kv_b_proj\`.
- Wrap the scale-load section so when \`NO_SCALE\` is set the kernel does
  not load from \`kv_proj_scale\` at all.
- Wrap the dot-product accumulation with a third branch that emits the
  scale-free form, e.g. \`accum_k += tl.dot(kv_c_data_0, k_nope_weight_0.T)\`
  instead of \`... * row_scale[None, :]\`.

\`aiter/ops/triton/gather_kv_b_proj.py\`

- Detect \`kv_proj_scale is None\` and set \`no_scale = True\`.
- Pass \`kv_proj_weight\` itself as the \`kv_proj_scale\` argument when
  \`no_scale\` is true (Triton requires a valid tensor pointer for every
  kernel argument even when the kernel does not load from it; the kernel
  guards every load with \`if not NO_SCALE:\`).
- Forward \`NO_SCALE=no_scale\` to the kernel.

## What this is *not*

Not a tune change — this kernel has no \`@triton.autotune\` decorator and no
tune-config CSV, only the hardcoded \`num_stages=3\` and the default
\`num_warps=4\`. Adding a constexpr branch just JITs one extra binary on
first hit, no re-tuning required.

## Verification

End-to-end on Kimi-K2.5-MXFP4, 4 × MI355X, TP=4, fp8 KV cache, agent-style
traffic with prefix sharing (sglang's \`lightrace-benchmark\` agent runner,
~64K mean prompt, ~93 % cache target). The patched build passes the full
K=2..24 sweep with \`--enable_prefix_caching\` on. Compared to the
no-cache workaround (the only way the un-patched build can run on this
workload at all):

| K  | no-cache TPS/user | no-cache TPM/GPU | patched TPS/user | patched TPM/GPU |
|---:|---:|---:|---:|---:|
|  2 | 60.8 |   150 k | 66.6 |   218 k |
|  4 | 34.1 |   191 k | 53.0 |   396 k |
|  **8** | **20.4** |   **227 k** | **46.3** |   **501 k** |
| 10 | 17.3 |   231 k | 35.0 |   845 k |
| 12 | 15.5 |   222 k | 34.5 |   765 k |
| 16 | 10.5 |   241 k | 27.7 |   943 k |
| 24 |  9.0 |   216 k | 24.9 | 1 131 k |

I.e. at K=8 (the SLO knee on this workload) the patch lifts user-perceived
generation rate by 2.3× and per-GPU input TPM by 2.2×; at K=24 it's a
2.8× lift on TPS/user and 5.2× on TPM/GPU. Output of small smoke tests
("Capital of France?", math) is coherent with prefix-cache hits enabled.

## Tests

I have not added a unit test in this PR because the existing kernel does
not appear to have an \`op_tests/\` entry for \`gather_kv_b_proj\`. Happy to
add one if pointed at the right harness.

## Compatibility

- Default \`NO_SCALE=False\` preserves all existing call sites byte-for-byte
  (they continue to take the PER_ROW_SCALE or per-block path as before).
- The wrapper changes are additive — only a new branch when
  \`kv_proj_scale is None\`; existing callers passing a tensor are unchanged.