### PR TITLE
ci: replace deprecated zmq with pyzmq in CI scripts

### DIFF
--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -9,6 +9,8 @@ dpkg -l | grep rocm || echo "No ROCm packages found."
 echo
 echo "==== Install dependencies and aiter ===="
 git config --global --add safe.directory /workspace
+pip config set global.retries 15
+pip config set global.timeout 120
 pip install --upgrade pandas pyzmq einops numpy==1.26.2
 pip uninstall -y aiter || true
 pip install --upgrade "pybind11>=3.0.1"

--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -11,8 +11,13 @@ echo "==== Install dependencies and aiter ===="
 git config --global --add safe.directory /workspace
 pip config set global.retries 15
 pip config set global.timeout 120
-pip install --upgrade pandas einops numpy==1.26.2
-pip install --upgrade pyzmq || echo "WARNING: pyzmq install failed (non-critical, only needed by aiter.dist.shm_broadcast)"
+pip install --upgrade pandas pyzmq einops numpy==1.26.2 || {
+    echo "WARNING: batch pip install failed, retrying packages individually..."
+    pip install --upgrade pandas || true
+    pip install --upgrade pyzmq || echo "WARNING: pyzmq unavailable (only needed by aiter.dist.shm_broadcast)"
+    pip install --upgrade einops
+    pip install --upgrade "numpy==1.26.2"
+}
 pip uninstall -y aiter || true
 pip install --upgrade "pybind11>=3.0.1"
 pip install --upgrade "ninja>=1.11.1"

--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -9,7 +9,7 @@ dpkg -l | grep rocm || echo "No ROCm packages found."
 echo
 echo "==== Install dependencies and aiter ===="
 git config --global --add safe.directory /workspace
-pip install --upgrade pandas zmq einops numpy==1.26.2
+pip install --upgrade pandas pyzmq einops numpy==1.26.2
 pip uninstall -y aiter || true
 pip install --upgrade "pybind11>=3.0.1"
 pip install --upgrade "ninja>=1.11.1"

--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -11,7 +11,8 @@ echo "==== Install dependencies and aiter ===="
 git config --global --add safe.directory /workspace
 pip config set global.retries 15
 pip config set global.timeout 120
-pip install --upgrade pandas pyzmq einops numpy==1.26.2
+pip install --upgrade pandas einops numpy==1.26.2
+pip install --upgrade pyzmq || echo "WARNING: pyzmq install failed (non-critical, only needed by aiter.dist.shm_broadcast)"
 pip uninstall -y aiter || true
 pip install --upgrade "pybind11>=3.0.1"
 pip install --upgrade "ninja>=1.11.1"

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -102,7 +102,7 @@ jobs:
               shopt -s nullglob &&
               rm -rf dist build aiter_meta ./*.egg-info &&
               pip install -r requirements.txt &&
-              pip install --upgrade pandas zmq einops numpy==1.26.2 &&
+              pip install --upgrade pandas pyzmq einops numpy==1.26.2 &&
               pip install --upgrade "pybind11>=3.0.1" &&
               pip install --upgrade "ninja>=1.11.1" &&
               pip install --upgrade setuptools_scm &&
@@ -372,7 +372,7 @@ jobs:
           bash -lc "
             pip uninstall -y amd-aiter aiter || true
             pip install -r requirements.txt
-            pip install --upgrade pandas zmq einops numpy==1.26.2
+            pip install --upgrade pandas pyzmq einops numpy==1.26.2
             pip install --upgrade 'pybind11>=3.0.1'
             pip install --upgrade 'ninja>=1.11.1'
             pip install tabulate
@@ -573,7 +573,7 @@ jobs:
           bash -lc "
             pip uninstall -y amd-aiter aiter || true
             pip install -r requirements.txt
-            pip install --upgrade pandas zmq einops numpy==1.26.2
+            pip install --upgrade pandas pyzmq einops numpy==1.26.2
             pip install --upgrade 'pybind11>=3.0.1'
             pip install --upgrade 'ninja>=1.11.1'
             pip install tabulate

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -97,7 +97,7 @@ jobs:
               pip config set global.retries 10
               pip config set global.index-url https://ausartifactory.amd.com/artifactory/api/pypi/hw-cpe-prod-remote/simple
               pip install -r requirements.txt
-              pip install --upgrade pandas zmq einops numpy==1.26.2
+              pip install --upgrade pandas pyzmq einops numpy==1.26.2
               pip install --upgrade "pybind11>=3.0.1"
               pip install --upgrade "ninja>=1.11.1"
               pip install --upgrade "setuptools_scm[toml]>=6.2" wheel packaging psutil


### PR DESCRIPTION
## Summary
- Replace `zmq` (deprecated meta-package) with `pyzmq` (actual ZeroMQ Python bindings) across all CI workflow files and build scripts
- The `zmq` package intermittently fails to resolve `pyzmq` dependency on CI runners, causing Triton Test Shard setup failures (e.g., PR #3005 Shard 7)

## Files changed
- `.github/scripts/build_aiter_triton.sh` — triton test setup
- `.github/workflows/aiter-test.yaml` — standard + MI300X tests (3 occurrences)
- `.github/workflows/vllm_benchmark.yaml` — vLLM benchmark

## Test plan
- CI pre-checks should pass (no code changes)
- Triton test shards should no longer fail at setup with `pyzmq` resolution errors