### PR TITLE
[FLYDSL] pin dependency to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "psutil",
     "ninja",
     "pandas",
-    "flydsl==0.1.5.dev515"
+    "flydsl==0.1.5"
 ]
 
 [tool.setuptools_scm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyyaml
 einops
 pybind11>=3.0.1
 ninja
-flydsl==0.1.5.dev504
+flydsl==0.1.5

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 OPT_COMPILER_CONFIG = os.path.join(this_dir, "aiter", "jit", "optCompilerConfig.json")
 PACKAGE_NAME = "amd-aiter"
 
-FLYDSL_VERSION = "flydsl==0.1.5.dev515"
+FLYDSL_VERSION = "flydsl==0.1.5"
 
 BUILD_TARGET = os.environ.get("BUILD_TARGET", "auto")
 PREBUILD_KERNELS = int(os.environ.get("PREBUILD_KERNELS", 0))


### PR DESCRIPTION
## Summary
- Pin FlyDSL dependency to the `0.1.5` release in setup/build metadata and requirements.
- Align `setup.py`, `pyproject.toml`, and `requirements.txt` on the same FlyDSL version.

## Test plan
- `python -m py_compile setup.py`


Made with [Cursor](https://cursor.com)