### PR TITLE
feat(top_k_per_row): expose parametric k via runtime arg

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -207,6 +207,7 @@ def top_k_per_row_prefill(
     numRows: int,
     stride0: int,
     stride1: int,
+    k: int = 2048,
 ) -> None: ...
 
 
@@ -232,6 +233,7 @@ def top_k_per_row_decode(
     numRows: int,
     stride0: int,
     stride1: int,
+    k: int = 2048,
 ) -> None: ...
 
 

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1646,26 +1646,28 @@ namespace py = pybind11;
     m.def("rocb_mm", &RocSolIdxBlas, "mm");                                        \
     m.def("rocb_findallsols", &RocFindAllSolIdxBlas, "rocblas_find_all_sols");
 
-#define TOP_K_PER_ROW_PYBIND       \
-    m.def("top_k_per_row_prefill", \
-          &top_k_per_row_prefill,  \
-          py::arg("logits"),       \
-          py::arg("rowStarts"),    \
-          py::arg("rowEnds"),      \
-          py::arg("indices"),      \
-          py::arg("values"),       \
-          py::arg("numRows"),      \
-          py::arg("stride0"),      \
-          py::arg("stride1"));     \
-    m.def("top_k_per_row_decode",  \
-          &top_k_per_row_decode,   \
-          py::arg("logits"),       \
-          py::arg("next_n"),       \
-          py::arg("seqLens"),      \
-          py::arg("indices"),      \
-          py::arg("numRows"),      \
-          py::arg("stride0"),      \
-          py::arg("stride1"));
+#define TOP_K_PER_ROW_PYBIND          \
+    m.def("top_k_per_row_prefill",    \
+          &top_k_per_row_prefill,     \
+          py::arg("logits"),          \
+          py::arg("rowStarts"),       \
+          py::arg("rowEnds"),         \
+          py::arg("indices"),         \
+          py::arg("values"),          \
+          py::arg("numRows"),         \
+          py::arg("stride0"),         \
+          py::arg("stride1"),         \
+          py::arg("k") = 2048);       \
+    m.def("top_k_per_row_decode",     \
+          &top_k_per_row_decode,      \
+          py::arg("logits"),          \
+          py::arg("next_n"),          \
+          py::arg("seqLens"),         \
+          py::arg("indices"),         \
+          py::arg("numRows"),         \
+          py::arg("stride0"),         \
+          py::arg("stride1"),         \
+          py::arg("k") = 2048);
 
 #define MLA_METADATA_PYBIND                              \
     m.def("get_mla_metadata_v1",                         \

--- a/csrc/include/topk_per_row.h
+++ b/csrc/include/topk_per_row.h
@@ -9,7 +9,8 @@ void top_k_per_row_prefill(const torch::Tensor& logits,
                            std::optional<torch::Tensor> values,
                            int64_t numRows,
                            int64_t stride0,
-                           int64_t stride1);
+                           int64_t stride1,
+                           int64_t k = 2048);
 
 void top_k_per_row_decode(const torch::Tensor& logits,
                           int64_t next_n,
@@ -17,4 +18,5 @@ void top_k_per_row_decode(const torch::Tensor& logits,
                           torch::Tensor& indices,
                           int64_t numRows,
                           int64_t stride0,
-                          int64_t stride1);
+                          int64_t stride1,
+                          int64_t k = 2048);

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -2435,7 +2435,9 @@ static __global__ void topk_per_row_decode(
 } // namespace aiter
 
 template <typename T, aiter::Phase phase = aiter::Phase::Prefill>
-int64_t invokeComputeTopkLastDimWorkspaceSize(int32_t numRows, int32_t stride0)
+int64_t invokeComputeTopkLastDimWorkspaceSize(int32_t numRows,
+                                              int32_t stride0,
+                                              int k_param = 2048)
 {
     using IdxT = int32_t;
 
@@ -2449,7 +2451,7 @@ int64_t invokeComputeTopkLastDimWorkspaceSize(int32_t numRows, int32_t stride0)
     constexpr bool fused_last_filter = false;
     constexpr bool sorted            = true;
     constexpr bool is_largest        = true;
-    constexpr int k                  = 2048;
+    int k                            = k_param;
 
     int sm_cnt = get_num_cu_func();
     unsigned grid_dim =
@@ -2497,7 +2499,9 @@ int64_t invokeComputeTopkLastDimWorkspaceSize(int32_t numRows, int32_t stride0)
 }
 
 // Explicit template instantiation to ensure the symbol is available for linking
-template int64_t invokeComputeTopkLastDimWorkspaceSize<float>(int32_t numRows, int32_t stride0);
+template int64_t invokeComputeTopkLastDimWorkspaceSize<float>(int32_t numRows,
+                                                              int32_t stride0,
+                                                              int k_param);
 
 void top_k_per_row_prefill(const torch::Tensor& logits,
                            const torch::Tensor& rowStarts,
@@ -2506,15 +2510,17 @@ void top_k_per_row_prefill(const torch::Tensor& logits,
                            std::optional<torch::Tensor> values,
                            int64_t numRows,
                            int64_t stride0,
-                           int64_t stride1)
+                           int64_t stride1,
+                           int64_t k)
 {
     size_t buf_size = 0; // will be overwritten by the kernel
 
-    static constexpr int kTopK       = 2048;
+    int kTopK                        = static_cast<int>(k);
     static constexpr bool is_largest = true;
 
     const hipStream_t stream = at::hip::getCurrentHIPStream();
-    int64_t workspace_size   = invokeComputeTopkLastDimWorkspaceSize<float>(numRows, stride0);
+    int64_t workspace_size =
+        invokeComputeTopkLastDimWorkspaceSize<float>(numRows, stride0, kTopK);
     // int64_t workspace_size   = int64_t(1024)*1024*1024*2;
     auto options            = torch::TensorOptions().dtype(torch::kUInt8).device(logits.device());
     torch::Tensor workspace = torch::empty({workspace_size}, options);
@@ -2630,16 +2636,17 @@ void top_k_per_row_decode(const torch::Tensor& logits,
                           torch::Tensor& indices,
                           int64_t numRows,
                           int64_t stride0,
-                          int64_t stride1)
+                          int64_t stride1,
+                          int64_t k)
 {
     size_t buf_size = 0; // will be overwritten by the kernel
 
-    static constexpr int kTopK       = 2048;
+    int kTopK                        = static_cast<int>(k);
     static constexpr bool is_largest = true;
 
     const hipStream_t stream = at::hip::getCurrentHIPStream();
-    int64_t workspace_size =
-        invokeComputeTopkLastDimWorkspaceSize<float, aiter::Phase::Decode>(numRows, stride0);
+    int64_t workspace_size = invokeComputeTopkLastDimWorkspaceSize<float, aiter::Phase::Decode>(
+        numRows, stride0, kTopK);
     auto options            = torch::TensorOptions().dtype(torch::kUInt8).device(logits.device());
     torch::Tensor workspace = torch::empty({workspace_size}, options);
 

--- a/csrc/kernels/topk_plain_kernels.cu
+++ b/csrc/kernels/topk_plain_kernels.cu
@@ -92,10 +92,13 @@ void standalone_stable_radix_11bits(void* buf,
 
 // Forward declaration of workspace size calculation function (at global scope)
 template <typename T, aiter::Phase phase = aiter::Phase::Prefill>
-int64_t invokeComputeTopkLastDimWorkspaceSize(int32_t numRows, int32_t stride0);
+int64_t invokeComputeTopkLastDimWorkspaceSize(int32_t numRows,
+                                              int32_t stride0,
+                                              int k_param = 2048);
 extern template int64_t
 invokeComputeTopkLastDimWorkspaceSize<float, aiter::Phase::Prefill>(int32_t numRows,
-                                                                    int32_t stride0);
+                                                                    int32_t stride0,
+                                                                    int k_param);
 
 // Forward declaration of helper function to call topk_per_row kernel
 template <typename IdxT>

--- a/op_tests/test_topk_per_row.py
+++ b/op_tests/test_topk_per_row.py
@@ -133,6 +133,7 @@ def run_top_k_per_row_prefill(
     num_rows: int,
     stride_row: int,
     stride_col: int,
+    k: int = 2048,
 ) -> None:
     """
     Run the top_k_per_row kernel.
@@ -146,6 +147,7 @@ def run_top_k_per_row_prefill(
         num_rows,
         stride_row,
         stride_col,
+        k=k,
     )
 
 
@@ -159,11 +161,17 @@ def run_top_k_per_row_decode(
     stride0: int,
     stride1: int,
     fast: bool,
+    k: int = 2048,
 ) -> None:
     """
     Run the top_k_per_row kernel.
+
+    Note: the `_fast` ASM-kernel variant has `kTopK=2048` baked into its
+    precompiled `.co`; it ignores any caller-supplied `k`. The dispatch
+    here only allows `_fast` when k == 2048.
     """
     if fast:
+        assert k == 2048, "top_k_per_row_decode_fast only supports k=2048"
         return aiter.top_k_per_row_decode_fast(
             logits,
             next_n,
@@ -182,6 +190,7 @@ def run_top_k_per_row_decode(
             numRows,
             stride0,
             stride1,
+            k=k,
         )
 
 
@@ -216,6 +225,7 @@ def test_top_k_per_row_prefill(
         num_rows,
         logits.stride(0),
         logits.stride(1),
+        k=top_k,
     )
 
     # Run reference implementation
@@ -277,6 +287,7 @@ def test_top_k_per_row_decode(
         logits.stride(0),
         logits.stride(1),
         fast,
+        k=top_k,
     )
 
     torch.cuda.synchronize()
@@ -319,10 +330,12 @@ parser.add_argument(
     "-k",
     "--top_k",
     type=int,
-    default=[2048],
+    default=[512, 1024, 2048],
     nargs="+",
-    help="""top-k elements per row.
-    e.g.: -k 2048""",
+    help="""top-k elements per row. The radix backend supports any positive
+    int; the `_fast` ASM-kernel path only supports 2048 and is skipped
+    for other values.
+    e.g.: -k 512 1024 2048""",
 )
 
 parser.add_argument(
@@ -391,7 +404,8 @@ for data_generation in args.data_generation:
                         m, ctx, k, n, data_generation, False
                     )
                     df.append(ret)
-                    if get_gfx() == "gfx942":
+                    # `_fast` ASM kernel hardcodes k=2048; skip otherwise.
+                    if get_gfx() == "gfx942" and k == 2048:
                         ret = test_top_k_per_row_decode(
                             m, ctx, k, n, data_generation, True
                         )


### PR DESCRIPTION
## Summary

The radix backend (`standalone_stable_radix_11bits`) supports arbitrary `k` at runtime, but the public C++/Python wrappers `top_k_per_row_prefill` and `top_k_per_row_decode` hardcoded `kTopK = 2048`. This PR plumbs `k` through end-to-end so callers (e.g. DeepSeek-V4 indexer with `k = index_topk = 1024`) can use the same kernel without forcing 2048.

Backward compatible: the default `k = 2048` matches previous behavior; existing callers do not need changes.

## Changes

### C++ surface (header / pybind / kernel)
- **`csrc/include/topk_per_row.h`** — both wrapper signatures get `int64_t k = 2048` default.
- **`csrc/include/rocm_ops.hpp`** — pybind exposes `py::arg(""k"") = 2048` for both ops.
- **`csrc/kernels/topk_per_row_kernels.cu`**
  - `invokeComputeTopkLastDimWorkspaceSize<T, Phase>(numRows, stride0)` gains `int k_param = 2048`; the internal `constexpr int k = 2048` becomes runtime `int k = k_param` and is threaded into the radix call.
  - Explicit `<float>` instantiation updated.
  - `top_k_per_row_prefill` / `top_k_per_row_decode` bodies replace `static constexpr int kTopK = 2048` with `static_cast<int>(k)` and pass it into both the workspace-size query and `standalone_stable_radix_11bits`.

### Python surface
- **`aiter/ops/topk.py`** — `top_k_per_row_prefill` and `top_k_per_row_decode` (the radix-backed variants) gain `k: int = 2048` so the `@compile_ops`-generated torch op schema accepts the new kwarg.
- The `_fast` ASM-kernel variants (`top_k_per_row_prefill_fast`, `top_k_per_row_decode_fast`) are intentionally **not** modified — their precompiled `.co` blobs hardcode k=2048 and cannot honor a runtime k.

### Tests
- **`op_tests/test_topk_per_row.py`**
  - Default `--top_k` widened from `[2048]` to `[512, 1024, 2048]`.
  - `run_top_k_per_row_{prefill,decode}` thread `k` through to the kernel call.
  - `_fast` decode is skipped when `k != 2048`; the dispatcher also asserts `k == 2048` for `_fast` to surface misuse loudly.

## Local validation

Ran `python op_tests/test_topk_per_row.py` on MI355X (gfx950) with the new defaults:

**Prefill** (9 cases, k ∈ {512, 1024, 2048} × ctx ∈ {1024, 4096, 16384}): all `all_close = True`.

**Decode** (18 cases, bs ∈ {4, 16} × ctx ∈ {1024, 4096, 16384} × k ∈ {512, 1024, 2048}, next_n=1): all `all_close = True`.

Sample decode results:

| batch_size | context_len | top_k | all_close |     us |
|-----------:|------------:|------:|:---------:|-------:|
|          4 |        1024 |   512 |    True   |   7.50 |
|          4 |        1024 |  1024 |    True   |   2.11 |
|          4 |        1024 |  2048 |    True   |   2.12 |
|         16 |        4096 |   512 |    True   |  11.38 |
|         16 |        4096 |  1024 |    True   |  10.44 |
|         16 |        4096 |  2048 |    True   |  10.26 |
|         16 |       16384 |   512 |    True   |  17.28 |
|         16 |       16384 |  1024 |    True   |  18.07 |
|         16 |       16384 |  2048 |    True   |  19.33 |

## Test plan

- [x] Unit test: `python op_tests/test_topk_per_row.py` parity vs `torch.topk` for k ∈ {512, 1024, 2048}.
- [x] Downstream consumer (DeepSeek-V4 indexer in ATOM): GSM8K-100 num_fewshot=3 = 0.97 / 0.97 with k=1024 prefill + decode paths.
- [ ] CI: confirm the matrix in `op_tests/test_topk_per_row.py` runs on the target gfx variants.