### PR TITLE
Fix batched_model_benchmark_shapes returning hidden/intermediate sizes swapped

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_batched_gemm_afp4wfp4.py
+++ b/op_tests/op_benchmarks/triton/bench_batched_gemm_afp4wfp4.py
@@ -71,7 +71,7 @@ def run_model_benchmark(args):
     benchmark = get_model_benchmark_object(
         plot_name=get_caller_name_no_ext(),
         args=args,
-        x_names=["model_name", "M", "hidden_dim", "intermediate_dim", "batch"],
+        x_names=["M", "hidden_dim", "intermediate_dim", "batch", "model_name"],
         model_benchmark_shapes_fn=batched_model_benchmark_shapes,
     )
 

--- a/op_tests/op_benchmarks/triton/utils/benchmark_utils.py
+++ b/op_tests/op_benchmarks/triton/utils/benchmark_utils.py
@@ -163,11 +163,11 @@ def batched_model_benchmark_shapes(args):
     shapes = []
     for M in M_list:
         for model_name, config in configs.items():
-            N = config["intermediate_size"]
-            K = config["hidden_size"]
+            hidden_size = config["hidden_size"]
+            intermediate_size = config["intermediate_size"]
 
             shapes.append(
-                (M, N, K, batch_size, model_name)
+                (M, hidden_size, intermediate_size, batch_size, model_name)
             )  # rearrange batch to last dim so M is graph x-axis
 
     return shapes


### PR DESCRIPTION
## Motivation

Two bugs in the batched GEMM benchmark infrastructure caused model-mode benchmarks to either crash or silently measure the wrong GEMM shapes.

**Bug 1 — TypeError crash (bench_batched_gemm_afp4wfp4 only):** `x_names` in `run_model_benchmark()` was ordered as `["model_name", "M", "hidden_dim", "intermediate_dim", "batch"]`, but `batched_model_benchmark_shapes()` returns tuples positionally. Triton's `perf_report` zips `x_names` with each tuple in order, so `model_name` received an integer and `batch` received a model name string. Passing a string to `torch.randint` raised a `TypeError` immediately.

**Bug 2 — Wrong GEMM shapes (all three benchmarks):** `batched_model_benchmark_shapes()` returned tuples as `(M, intermediate_size, hidden_size, batch, model_name)`, but all three callers map the second position to `hidden_dim` and the third to `intermediate_dim`. As a result, fc1 was benchmarked as `N=hidden_size, K=intermediate_size` instead of `N=intermediate_size, K=hidden_size` — completely transposing the two largest dimensions for every model-mode run. This affected `bench_batched_gemm_a16w16`, `bench_batched_gemm_a8w8`, and `bench_batched_gemm_afp4wfp4`.

## Technical Details

**[`op_tests/op_benchmarks/triton/utils/benchmark_utils.py`](https://github.com/ROCm/aiter/blob/apicciau/fix_bench_batched_gemm_afp4wfp4_xnames/op_tests/op_benchmarks/triton/utils/benchmark_utils.py)**

Changed the tuple order in `batched_model_benchmark_shapes()` from:
```python
(M, N, K, batch_size, model_name)  # N=intermediate_size, K=hidden_size
```
to:
```python
(M, hidden_size, intermediate_size, batch_size, model_name)
```
This matches what all three callers expect: `hidden_dim` receives `hidden_size` and `intermediate_dim` receives `intermediate_size`, so fc1 correctly derives `N=intermediate_size, K=hidden_size` and fc2 derives `N=hidden_size, K=intermediate_size`.

**[`op_tests/op_benchmarks/triton/bench_batched_gemm_afp4wfp4.py`](https://github.com/ROCm/aiter/blob/apicciau/fix_bench_batched_gemm_afp4wfp4_xnames/op_tests/op_benchmarks/triton/bench_batched_gemm_afp4wfp4.py)**

Corrected `x_names` in `run_model_benchmark()` from:
```python
x_names=["model_name", "M", "hidden_dim", "intermediate_dim", "batch"]
```
to:
```python
x_names=["M", "hidden_dim", "intermediate_dim", "batch", "model_name"]
```
This is now consistent with `bench_batched_gemm_a16w16.py` and `bench_batched_gemm_a8w8.py`, which were already correct.

## Test Plan

Run each benchmark in model mode:

```bash
python3 op_tests/op_benchmarks/triton/bench_batched_gemm_a16w16.py \
  --model all -M 128 -B 1 --metric throughput --layout TN -o

python3 op_tests/op_benchmarks/triton/bench_batched_gemm_a8w8.py \
  --model all -M 128 -B 1 --metric throughput --layout TN -o

python3 op_tests/op_benchmarks/triton/bench_batched_gemm_afp4wfp4.py \
  --model all -M 128 -B 1 --metric throughput --layout TN -o
```

Verify that for a model with `hidden_size=4096, intermediate_size=14336`:
- fc1 benchmarks `N=14336, K=4096` (not `N=4096, K=14336`)
- fc2 benchmarks `N=4096, K=14336`

## Test Result

All three benchmarks run to completion and generate output CSVs. Shape labels in the output match the model configs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/aiter/blob/main/CONTRIBUTING.md