### PR TITLE
[Perf] Cache scale-transpose and quant-func-partial allocations in decode path

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -365,6 +365,30 @@ def fused_moe_(
         )
 
 
+_scale_t_cache: dict = {}
+
+
+def _get_scale_t_buf(scale: torch.Tensor) -> torch.Tensor:
+    rows, cols = scale.shape[-2], scale.shape[-1]
+    key = (scale.device.index, cols, rows, scale.dtype)
+    if key not in _scale_t_cache:
+        _scale_t_cache[key] = torch.empty(
+            (cols, rows), dtype=scale.dtype, device=scale.device
+        )
+    return _scale_t_cache[key]
+
+
+_quant_func_cache: dict = {}
+
+
+def _get_quant_func_transpose(quant_type):
+    if quant_type not in _quant_func_cache:
+        _quant_func_cache[quant_type] = functools.partial(
+            get_quant(quant_type), transpose_scale=True
+        )
+    return _quant_func_cache[quant_type]
+
+
 def fused_moe_1stage(
     hidden_states,
     w1,  # [expert(local_expert:EP), inter_dim*2, dim] N,K
@@ -440,7 +464,7 @@ def fused_moe_1stage(
             quant_func = get_quant(quant_type)
             if hidden_states.dtype != q_dtype_a:
                 if quant_type == QuantType.per_1x128:
-                    quant_func = functools.partial(quant_func, transpose_scale=True)
+                    quant_func = _get_quant_func_transpose(quant_type)
                 a1, a1_scale = quant_func(
                     hidden_states,
                     scale=a1_scale,
@@ -453,7 +477,7 @@ def fused_moe_1stage(
                 ), "a1_scale must be provided for quantized input for fused_moe"
                 a1 = hidden_states
                 if quant_type == QuantType.per_1x128:
-                    scale_t = torch.empty_like(a1_scale)
+                    scale_t = _get_scale_t_buf(a1_scale)
                     aiter.partial_transpose(
                         scale_t, a1_scale, num_rows=num_local_tokens
                     )


### PR DESCRIPTION
## Motivation

Eliminate per-step HIP malloc for the transposed-scale buffer and the repeated functools.partial() creation for quantisation functions by caching both at module level.

## Technical Details

Scale-transpose buffer reuse and quant-func-partial caching are independently correct micro-optimisations with no behavioural change. They can be reviewed without understanding the 1-stage dispatch logic.

Source: AMD-AGI/Agentic-InferenceX MiniMax-M2.5-marathon-optimized

## Test Plan

Run: `bash .github/scripts/aiter_test.sh`

## Test Result

Pending benchmark results on MI300X / MI355X.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

---
PR 4 builds on the fast-path structure introduced here.
