### PR TITLE
Add MiniMax M25 FMoE Instances support

### DIFF
--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.py
@@ -185,7 +185,9 @@ a8w8_gemm1_blockscale_kernels_list= {
      1: kernelInstanceGEMM1(       128,       16,        128,       128,     1,       2,        1,),
      2: kernelInstanceGEMM1(       256,       32,        128,       128,     1,       4,        1,),
      3: kernelInstanceGEMM1(       256,       64,        128,       128,     1,       4,        3,),
-     #2: kernelInstanceGEMM1(       256,      128,        128,       128,     1,       4,        3,),
+     4: kernelInstanceGEMM1(       256,      128,        128,       128,     1,       4,        3,),
+     5: kernelInstanceGEMM1(       256,       64,        128,       128,     1,       4,        1,),
+     6: kernelInstanceGEMM1(       256,      128,        128,       128,     1,       4,        1,),
 }
 
 # gemm1 out:bf16/fp16 A:fp8 B:win4
@@ -308,7 +310,9 @@ a8w8_gemm2_blockscale_kernels_list= {
      1: kernelInstanceGEMM2(       128,       16,        128,       128,     1,       2,        1,),
      2: kernelInstanceGEMM2(       256,       32,        128,       128,     1,       4,        1,),
      3: kernelInstanceGEMM2(       256,       64,        128,       128,     1,       4,        3,),
-     #2: kernelInstanceGEMM2(       256,      128,        128,       128,     2,       2,        3,),
+     4: kernelInstanceGEMM2(       256,      128,        128,       128,     2,       2,        3,),
+     5: kernelInstanceGEMM2(       256,       64,        128,       128,     1,       4,        1,),
+     6: kernelInstanceGEMM2(       256,      128,        128,       128,     1,       4,        1,),
 }
 
 # gemm2 out:bf16/fp16 A:fp8 B:in4


### PR DESCRIPTION
Adds the MiniMax M25 FMoE codegen change that was left out of PR #3004 but is referenced by some of the tuned FMoE config.csv