### PR TITLE
Add -o flag to bench_gmm.py for CSV output

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_gmm.py
+++ b/op_tests/op_benchmarks/triton/bench_gmm.py
@@ -121,6 +121,7 @@ def benchmark_gmm(
     metric: str = DEFAULT_METRIC,
     use_bias: bool = False,
     accumulate: bool = False,
+    output: bool = False,
 ) -> None:
     assert gmm_type in GMM_TYPES, "Invalid GMM type."
     assert metric in METRICS, "Invalid benchmark metric."
@@ -288,7 +289,7 @@ def benchmark_gmm(
         metric,
         unit,
     )
-    benchmark.run(show_plots=False, print_data=True)
+    benchmark.run(show_plots=False, print_data=True, save_path="." if output else "")
 
 
 # Command line interface parsing.
@@ -428,6 +429,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="accumulate bias gradient",
     )
+    parser.add_argument(
+        "-o",
+        action="store_true",
+        help="write performance results to CSV file in the current directory",
+    )
     try:
         return validate_args(parser.parse_args())
     except argparse.ArgumentError as arg_error:
@@ -468,6 +474,7 @@ def main() -> None:
         metric=args.metric,
         use_bias=args.use_bias,
         accumulate=args.accumulate,
+        output=args.o,
     )
 
 


### PR DESCRIPTION
## Motivation

`bench_gmm.py` is the only benchmark script under `op_tests/op_benchmarks/triton/` that cannot write its results to a CSV file. All other benchmark scripts expose a `-o` flag that passes `save_path="."` to Triton's `perf_report`, causing results to be written as a CSV in the current directory. Without this, `bench_gmm.py` outputs only to stdout, making it impossible to use with automated sweep scripts that rely on collecting and merging per-run CSVs.

## Technical Details

**[`op_tests/op_benchmarks/triton/bench_gmm.py`](https://github.com/ROCm/aiter/blob/apicciau/bench_gmm_add_csv_output/op_tests/op_benchmarks/triton/bench_gmm.py)**

Three changes, all following the pattern already used in `bench_batched_gemm_*.py` and other benchmark scripts:

1. Added `-o` flag to `parse_args()`:
```python
parser.add_argument(
    "-o",
    action="store_true",
    help="write performance results to CSV file in the current directory",
)
```

2. Added `output: bool = False` parameter to `benchmark_gmm()`.

3. Changed the `benchmark.run()` call to pass `save_path` when `-o` is set:
```python
benchmark.run(show_plots=False, print_data=True, save_path="." if output else "")
```

## Test Plan

```bash
# Run with -o and verify a CSV is written to the current directory
cd /tmp && python3 op_tests/op_benchmarks/triton/bench_gmm.py \
  --gmm-type gmm --metric throughput -o
ls *.csv
```

Verify that a `triton_gmm_*.csv` file is created in the current directory.

```bash
# Without -o, verify no CSV is written (existing behaviour preserved)
cd /tmp && python3 op_tests/op_benchmarks/triton/bench_gmm.py \
  --gmm-type gmm --metric throughput
ls *.csv 2>/dev/null || echo "No CSV written (expected)"
```

## Test Result

With `-o`: a `triton_gmm_ibf16_obf16_nnn_tflops.csv` file is written to the working directory containing the benchmark results for all REAL_SHAPES.

Without `-o`: no CSV file is created; output goes to stdout only, as before.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/aiter/blob/main/CONTRIBUTING.md