### PR TITLE
CI: set HSA_NO_SCRATCH_RECLAIM for gpt-oss atom test

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -79,6 +79,7 @@ jobs:
             extraArgs: "--kv_cache_dtype fp8 --gpu-memory-utilization 0.3"
             env_vars: |
               ATOM_GPT_OSS_MODEL=1
+              HSA_NO_SCRATCH_RECLAIM=1
             accuracy_test_threshold: "0.38"
             runner: linux-aiter-mi35x-1
             run_on_pr: true


### PR DESCRIPTION
## Summary
- add `HSA_NO_SCRATCH_RECLAIM=1` to the single GPU `gpt-oss-120b` ATOM test env vars
- keep the change scoped to the affected gpt-oss test on `linux-aiter-mi35x-1`
- validate whether the missing HSA setting is causing the gpt-oss initialization failure

## Test plan
- [x] Validate `.github/workflows/atom-test.yaml` with `yaml.safe_load`
- [x] Check workflow lints locally
- [ ] Run the updated ATOM test workflow on the PR