### PR TITLE
[Hotfix] aiter/__init__: do not swallow import errors on Linux (fixes silent rms*/quant*/gemm* truncation)

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -66,52 +66,51 @@ if os.path.isdir(_flydsl_cache) and "FLYDSL_RUNTIME_CACHE_DIR" not in os.environ
 if sys.platform == "win32":
     logger.info("Windows: CK and HIP ops are not available. Triton ops only.")
 else:
-    try:
-        from .jit import core as core  # noqa: E402
-        from .utility import dtypes as dtypes  # noqa: E402
-        from .ops.enum import *  # noqa: F403,E402
-        from .ops.norm import *  # noqa: F403,E402
-        from .ops.quant import *  # noqa: F403,E402
-        from .ops.gemm_op_a8w8 import *  # noqa: F403,E402
-        from .ops.gemm_op_a16w16 import *  # noqa: F403,E402
-        from .ops.gemm_op_a4w4 import *  # noqa: F403,E402
-        from .ops.batched_gemm_op_a8w8 import *  # noqa: F403,E402
-        from .ops.batched_gemm_op_bf16 import *  # noqa: F403,E402
-        from .ops.deepgemm import *  # noqa: F403,E402
-        from .ops.aiter_operator import *  # noqa: F403,E402
-        from .ops.activation import *  # noqa: F403,E402
-        from .ops.attention import *  # noqa: F403,E402
-        from .ops.custom import *  # noqa: F403,E402
-        from .ops.custom_all_reduce import *  # noqa: F403,E402
-        from .ops.quick_all_reduce import *  # noqa: F403,E402
-        from .ops.moe_op import *  # noqa: F403,E402
-        from .ops.moe_sorting import *  # noqa: F403,E402
-        from .ops.moe_sorting_opus import *  # noqa: F403,E402
-        from .ops.pos_encoding import *  # noqa: F403,E402
-        from .ops.cache import *  # noqa: F403,E402
-        from .ops.rmsnorm import *  # noqa: F403,E402
-        from .ops.communication import *  # noqa: F403,E402
-        from .ops.rope import *  # noqa: F403,E402
-        from .ops.topk import *  # noqa: F403,E402
-        from .ops.topk_plain import topk_plain  # noqa: F403,F401,E402
-        from .ops.mha import *  # noqa: F403,E402
-        from .ops.gradlib import *  # noqa: F403,E402
-        from .ops.trans_ragged_layout import *  # noqa: F403,E402
-        from .ops.sample import *  # noqa: F403,E402
-        from .ops.fused_qk_norm_mrope_cache_quant import *  # noqa: F403,E402
-        from .ops.fused_qk_norm_rope_cache_quant import *  # noqa: F403,E402
-        from .ops.fused_qk_rmsnorm_group_quant import *  # noqa: F403,E402
-        from .ops.groupnorm import *  # noqa: F403,E402
-        from .ops.mhc import *  # noqa: F403,E402
-        from .ops.causal_conv1d import *  # noqa: F403,E402
-        from .ops.fused_split_gdr_update import *  # noqa: F403,E402
-        from . import mla  # noqa: F403,F401,E402
-    except (ImportError, RuntimeError, OSError, KeyError) as e:
-        logger.warning(
-            "ROCm/HIP JIT runtime not available: %s. "
-            "CK and HIP ops are disabled. Triton ops remain available.",
-            e,
-        )
+    # NOTE: do NOT wrap this block in try/except.
+    # Catching ImportError here silently truncates the top-level aiter
+    # namespace whenever any single import fails, which has caused
+    # downstream regressions (e.g. vLLM-ROCm losing rmsnorm2d_fwd_with_add).
+    # Any real import failure on Linux must surface as a loud ImportError
+    # on `import aiter` -- that is what 0.1.10.post3 and earlier did.
+    from .jit import core as core  # noqa: E402
+    from .utility import dtypes as dtypes  # noqa: E402
+    from .ops.enum import *  # noqa: F403,E402
+    from .ops.norm import *  # noqa: F403,E402
+    from .ops.quant import *  # noqa: F403,E402
+    from .ops.gemm_op_a8w8 import *  # noqa: F403,E402
+    from .ops.gemm_op_a16w16 import *  # noqa: F403,E402
+    from .ops.gemm_op_a4w4 import *  # noqa: F403,E402
+    from .ops.batched_gemm_op_a8w8 import *  # noqa: F403,E402
+    from .ops.batched_gemm_op_bf16 import *  # noqa: F403,E402
+    from .ops.deepgemm import *  # noqa: F403,E402
+    from .ops.aiter_operator import *  # noqa: F403,E402
+    from .ops.activation import *  # noqa: F403,E402
+    from .ops.attention import *  # noqa: F403,E402
+    from .ops.custom import *  # noqa: F403,E402
+    from .ops.custom_all_reduce import *  # noqa: F403,E402
+    from .ops.quick_all_reduce import *  # noqa: F403,E402
+    from .ops.moe_op import *  # noqa: F403,E402
+    from .ops.moe_sorting import *  # noqa: F403,E402
+    from .ops.moe_sorting_opus import *  # noqa: F403,E402
+    from .ops.pos_encoding import *  # noqa: F403,E402
+    from .ops.cache import *  # noqa: F403,E402
+    from .ops.rmsnorm import *  # noqa: F403,E402
+    from .ops.communication import *  # noqa: F403,E402
+    from .ops.rope import *  # noqa: F403,E402
+    from .ops.topk import *  # noqa: F403,E402
+    from .ops.topk_plain import topk_plain  # noqa: F403,F401,E402
+    from .ops.mha import *  # noqa: F403,E402
+    from .ops.gradlib import *  # noqa: F403,E402
+    from .ops.trans_ragged_layout import *  # noqa: F403,E402
+    from .ops.sample import *  # noqa: F403,E402
+    from .ops.fused_qk_norm_mrope_cache_quant import *  # noqa: F403,E402
+    from .ops.fused_qk_norm_rope_cache_quant import *  # noqa: F403,E402
+    from .ops.fused_qk_rmsnorm_group_quant import *  # noqa: F403,E402
+    from .ops.groupnorm import *  # noqa: F403,E402
+    from .ops.mhc import *  # noqa: F403,E402
+    from .ops.causal_conv1d import *  # noqa: F403,E402
+    from .ops.fused_split_gdr_update import *  # noqa: F403,E402
+    from . import mla  # noqa: F403,F401,E402
 
 # Import Triton-based communication primitives from ops.triton.comms (optional, only if Iris is available)
 try:


### PR DESCRIPTION
Commit b4b75165 (#2433, Triton FA Windows build support) wrapped the top-level Linux import block in
    try:
        from .jit import core ...
        from .ops.* import *
        ...
    except (ImportError, RuntimeError, OSError, KeyError) as e:
        logger.warning("ROCm/HIP JIT runtime not available: ...", e)
to enable Windows / Triton-only builds.

Side effect on Linux: when any single import in the block fails, the whole try block aborts at that line, the except prints one warning, and every symbol declared after the failing line silently disappears from the top-level aiter namespace. import aiter still succeeds, so downstream code only discovers the missing symbol on first use.

Two visible regressions:

  1. vLLM-ROCm: ImportError: cannot import name rmsnorm2d_fwd_with_add from aiter against aiter main on rocm/vllm-dev:nightly. Failure depends on which import below line 22 (.ops.rmsnorm) the host trips on; layernorm2d_* stays available because .ops.norm is line 4.

  2. Pre-built downstream Docker images that were ABI-smoked on a non-GPU host (rocminfo unavailable) silently shipped with an empty rms*/quant*/gemm* surface, because .jit core import is the very first line in the try.

Fix: drop the try/except on Linux. Keep the Windows opt-out so #2433 Windows behaviour is preserved. Real import failures on Linux now surface immediately as ImportError on import aiter, which is what 0.1.10.post3 and earlier did.

Cc: @MichaelMelesse @gshtras

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
