### PR TITLE
Fix CK MoE split-k dispatch for blockscale FP8

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1828,7 +1828,7 @@ def ck_moe_stage1(
     dtype=None,
 ):
     token_num = hidden_states.shape[0]
-    is_splitk = quant_type is aiter.QuantType.per_1x128 and splitk > 1
+    is_splitk = quant_type == QuantType.per_1x128 and splitk > 1
     if is_splitk:
         # CK kernel zeros this buffer via hipMemsetAsync when KBatch > 1
         sorted_size = min(token_num * topk * block_m, sorted_token_ids.shape[0])


### PR DESCRIPTION
## Motivation
In `ck_moe_stage1`, split-k kernels write to a separate, differently sized buffer from the module output. However, currently the blockscale quant type predicate for split-k is compared through object identity rather than values, and may always be evaluated to False as `QuantType` is not a strict python enum.
The downstream `cmdGenFunc_ck_moe_stage` also determines its own split-k conditions based on name matching from tuned configs. While this may be fine when tuned configs are not used as the non-splitk versions are always chosen, when the split-k kernels are selected from tuned configs through name matching, the split-k kernels would consume wrong-sized buffers, resulting in memory access faults.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
This PR replaces the `QuantType` comparison with value equality in the detection of CK MoE stage1's split-k so that the correct buffer can be allocated for the blockscale splitk paths.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
