### PR TITLE
CI: retry aiter editable install without build isolation

### DIFF
--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -2,6 +2,28 @@
 
 set -ex
 
+retry_cmd() {
+    local max_attempts="$1"
+    shift
+    local attempt=1
+    local rc=0
+
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        rc=$?
+        if [[ "$attempt" -ge "$max_attempts" ]]; then
+            echo "Command failed after ${attempt} attempts: $*"
+            return "$rc"
+        fi
+        local sleep_seconds=$((attempt * 20))
+        echo "Attempt ${attempt}/${max_attempts} failed; retrying in ${sleep_seconds}s..."
+        sleep "${sleep_seconds}"
+        attempt=$((attempt + 1))
+    done
+}
+
 echo
 echo "==== ROCm Packages Installed ===="
 dpkg -l | grep rocm || echo "No ROCm packages found."
@@ -19,10 +41,18 @@ pip install --upgrade pandas pyzmq einops numpy==1.26.2 || {
     pip install --upgrade "numpy==1.26.2"
 }
 pip uninstall -y aiter || true
-pip install --upgrade "pybind11>=3.0.1"
-pip install --upgrade "ninja>=1.11.1"
+retry_cmd 3 pip install --upgrade \
+    "pybind11>=3.0.1" \
+    "setuptools>=45" \
+    "setuptools_scm[toml]>=6.2" \
+    wheel \
+    packaging \
+    psutil \
+    "ninja>=1.11.1" \
+    pandas \
+    "flydsl==0.1.5"
 pip install tabulate
-pip install -e .
+retry_cmd 3 pip install --no-build-isolation -e .
 ./.github/scripts/install_triton.sh
 
 # Read BUILD_TRITON env var, default to 1. If 1, install Triton; if 0, skip installation.


### PR DESCRIPTION
## Summary
- preinstall the `aiter` pyproject build dependencies in `build_aiter_triton.sh`
- retry the editable install and switch it to `pip install --no-build-isolation -e .`
- reduce Triton CI flakes caused by transient package fetch failures during build isolation

## Test plan
- [x] `bash -n .github/scripts/build_aiter_triton.sh`
- [ ] rerun the affected Triton CI shards