### PR TITLE
[bug] reproducer for pa_*.co block_id truncation at 65,536

### DIFF
--- a/PA_BLOCK_ID_TRUNCATION_BUG.md
+++ b/PA_BLOCK_ID_TRUNCATION_BUG.md
@@ -1,0 +1,112 @@
+# aiter ASM paged-attention `block_id` truncation at the 2 GB / 65,536-block boundary
+
+## Summary
+
+When the `block_id` value loaded from the `block_tables` tensor reaches **65,536**, aiter's precompiled ASM `pa_*.co` paged-attention kernels on `gfx950` read from the wrong physical KV slot. The wrong-slot index matches `block_id & 0xFFFF`, consistent with a 16-bit narrowing of `block_id` somewhere in the slot-address path before the multiply by per-block stride.
+
+Equivalently: the bug fires the moment `block_id × per_block_stride` reaches **2^31 bytes (2 GB)** — exactly the signed-i32 buffer-descriptor offset limit on AMD GPUs. For the production-relevant Eagle3 draft layout (`num_kv_heads=8, head_dim=128, block_size=16, bf16` → 32 KB per block), this happens at **block_id = 65,536**.
+
+The bug is silent: no error, no NaN. Output collapses to whatever value lives at `block_id & 0xFFFF` (often zero in test, garbage in production), which propagates through softmax as a wrong attention result.
+
+A self-contained microbench is included at `op_tests/test_pa_block_id_truncation.py`.
+
+## Affected binaries
+
+Reproduced on `gfx950` (AMD Instinct MI355X). Verified affected:
+
+```
+hsa/gfx950/pa/pa_bf16_noquant_gqa8_1tg_4w.co            (qlen=1, non-MTP)
+hsa/gfx950/pa/pa_bf16_noquant_gqa8_1tg_4w_mtp_msk1.co   (qlen=4, MTP)
+```
+
+Both fail with the identical wrap signature, suggesting the truncation lives in shared ASM code rather than per-kernel logic. Likely the entire same-build `pa_*_blkSz=16` family (including the bf16/fp8 variants used in production).
+
+C++ entry: `csrc/py_itfs_cu/asm_pa.cu:166 pa_fwd`.
+
+## Reproduction
+
+```bash
+cd /root/aiter
+HSA_NO_SCRATCH_RECLAIM=1 AITER_LOG_LEVEL=WARNING \
+    python op_tests/test_pa_block_id_truncation.py
+```
+
+Or with pytest:
+
+```bash
+HSA_NO_SCRATCH_RECLAIM=1 \
+    pytest op_tests/test_pa_block_id_truncation.py -v -s
+```
+
+The script allocates a 70,000-block KV pool (~4.6 GB total bf16 K+V), fingerprints four blocks with distinct constant values, then runs `pa_fwd_asm` once per block with a single-block sequence. Because each fingerprinted block is filled with a constant V, the attention output should equal that constant. If the kernel reads from a different block instead, the output collapses to whatever lives there (zero for unfilled blocks).
+
+## Observed output
+
+```
+[OK]  block_id=   1000  expected=0.5000  actual=0.5000  Δ=+0.0000  (below_65535)
+[OK]  block_id=  65535  expected=0.3000  actual=0.3008  Δ=+0.0008  (edge_65535_last_u16)
+[BUG] block_id=  65536  expected=0.4000  actual=0.0000  Δ=-0.4000  (edge_65536_first_overflow)
+  → if block_id is narrowed to 16 bits, reads block 0 instead (unfilled = 0).
+[BUG] block_id=  67000  expected=0.7500  actual=0.0000  Δ=-0.7500  (above_65535)
+  → if block_id is narrowed to 16 bits, reads block 1464 instead (unfilled = 0).
+```
+
+Both kernels (qlen=1 non-MTP and qlen=4 MTP) exhibit identical behavior.
+
+| `block_id` | `block_id & 0xFFFF` | reads block | expected fingerprint | actual output | verdict |
+|---:|---:|---:|---:|---:|---|
+| 1,000 | 1,000 | 1,000 (= itself) | 0.5000 | 0.5000 | OK |
+| 65,535 | 65,535 | 65,535 (= itself, no wrap) | 0.3000 | 0.3008 | OK |
+| **65,536** | **0** | **0** (unfilled) | 0.4000 | **0.0000** | **BUG** |
+| 67,000 | 1,464 | 1,464 (unfilled) | 0.7500 | 0.0000 | BUG |
+
+Last safe value: `block_id = 65,535`. First failing value: `block_id = 65,536`.
+
+## Root-cause hypothesis
+
+For the test's per-block stride (Eagle3 draft layout):
+
+```
+slot_byte_offset = block_id × (block_size × num_kv_heads × head_dim × elem_size)
+                 = block_id × (16 × 8 × 128 × 2)
+                 = block_id × 32,768
+```
+
+| `block_id` | `slot_byte_offset` | meaning |
+|---:|---:|---|
+| 65,535 | 2,147,450,880 | 2 GB − 32 KB |
+| **65,536** | **2,147,483,648** | **= 2^31 = 2 GB exactly = signed-i32 max + 1** |
+
+AMD GPU buffer-descriptor offsets are signed i32, so a single descriptor cannot address more than ~2 GB. The kernel author likely reasoned:
+
+> "Per-block stride is at most 32 KB, so `block_id` never exceeds 2 GB / 32 KB = 65,536. Store `block_id` as `u16` to save register space."
+
+This holds when the entire KV cache fits in 2 GB. It breaks the moment any layer's KV pool exceeds 2 GB and `block_id` actually crosses 65,535 — exactly what happens for few-layer drafts (e.g. Eagle3) where the entire KV budget concentrates on one layer (~4.4 GB at `--gpu-memory-utilization 0.8`).
+
+## Production impact
+
+This bug was discovered during ATOM Eagle3 spec-decoding investigation on Kimi-K2.5 + kimi-k2.5-eagle3 (8× MI355X, TP=8, bf16 KV). Symptoms:
+
+- Sharp, permanent acceptance-rate collapse from ~80% to ~10–25% the first time the draft KV pool's `block_id_amax` crosses 65,535.
+- 100% reproducible across 7+ independent runs at `--gpu-memory-utilization 0.8`.
+- `--gpu-memory-utilization 0.4` keeps `num_blocks < 30k` and the bug never fires (workaround).
+
+ATOM's current workaround is to route pure-MHA layers (Eagle3 draft) through the triton/gluon paged-attention path instead of the aiter ASM family.
+
+## Suggested fix
+
+Audit ASM source for the affected `pa_*.co` kernels. For every load from the `block_tables` tensor, ensure:
+
+1. `block_id` stays in i32 (or i64) all the way through the slot-address computation — never narrowed via `s_pack_*_b16` / `v_pack_*_b16` / `AND 0xFFFF` to a 16-bit register.
+2. The product `block_id × per_block_stride` and the final add of the within-block offset are both 64-bit.
+3. When the total KV cache exceeds 2 GB, span it across multiple buffer descriptors (chunked by `0x7FFF0000` byte windows) and switch descriptors as `block_id` crosses chunk boundaries — analogous to FlyDSL's `_chunk_buffer_resource_for_block`.
+
+A regression test reproducing the bug is at `op_tests/test_pa_block_id_truncation.py`. Once the ASM is fixed, that test should report `[OK]` for all four block IDs.
+
+## Environment
+
+- Hardware: 8× AMD Instinct MI355X (`gfx950`)
+- OS: Ubuntu 24.04.4 LTS, kernel 6.8.0-65-generic
+- ROCm: 7.2.2 (HIP runtime 7.2.53211.70202-86~24.04, GPU firmware version 14)
+- aiter: built locally from this branch
+- Python: 3.12, PyTorch with ROCm support

--- a/op_tests/test_pa_block_id_truncation.py
+++ b/op_tests/test_pa_block_id_truncation.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Reproduce the aiter ASM paged-attention block_id truncation issue.
+
+When the block_id loaded from the block_tables tensor crosses 65,535
+(= 2^16), the aiter precompiled ASM `pa_*.co` family on gfx950/gfx942
+reads from the wrong physical KV slot — consistent with a 16-bit
+narrowing (`block_id & 0xFFFF`) of the loaded value before it is used
+in slot-address arithmetic.
+
+Strategy:
+  * Allocate a KV pool with > 65,535 physical blocks (NUM_BLOCKS = 70,000).
+  * Fill two specific blocks (one below 65,535, one above) with a
+    distinctive constant, leave everything else at zero.
+  * Run pa_fwd_asm on a single sequence whose block_tables points at
+    each chosen block in turn, with context_lens = block_size.
+  * Because the chosen block is filled with a constant V, the attention
+    output equals that constant (softmax over a single block's slots
+    sums to 1, weighted with constant V).
+
+If the kernel narrows block_id to 16 bits, the high block_id (= 67,000)
+wraps to 67,000 - 65,536 = 1,464, an unfilled block that contains zeros,
+so the output collapses to ~0 instead of the expected fingerprint.
+
+Empirical result on gfx950 (MI355X), aiter built 2026-04-20+:
+  Both the qlen=1 kernel (`pa_bf16_noquant_gqa8_1tg_4w.co`) and the
+  qlen=4 MTP kernel (`pa_bf16_noquant_gqa8_1tg_4w_mtp_msk1.co`) return
+  0.0000 for block_id = 67,000 instead of the expected 0.7500. The wrap
+  target (1,464) matches `block_id & 0xFFFF`.
+
+  The reproduction requires NUM_KV_HEADS = 8 to match production
+  per-block stride (32 KB). With NUM_KV_HEADS = 1 (4 KB stride) the bug
+  does not surface — likely because some tile-level address calculation
+  in the kernel only narrows block_id when iterating over enough KV
+  heads. Either way, this file reproduces the production-relevant
+  configuration.
+
+Run:
+    pytest /root/aiter/op_tests/test_pa_block_id_truncation.py -v -s
+
+Or as a script:
+    python /root/aiter/op_tests/test_pa_block_id_truncation.py
+"""
+
+import pytest
+import torch
+
+import aiter
+from aiter import dtypes
+
+
+# ---------- configuration matching the ATOM Eagle3 draft signature ----------
+# Production layout per TP=8 rank: num_q_heads = num_kv_heads = 8 (full MHA).
+# aiter's gqa-rounding selects the gqa8 kernel either way.
+#
+# Critical: per-block stride must match production for the i32-overflow
+# hypothesis to be testable. With NUM_KV_HEADS=8, HEAD_DIM=128, BLOCK_SIZE=16,
+# bf16 elem_size=2:
+#     per_block_stride = 16 × 8 × 128 × 2 = 32,768 bytes
+#     i32 overflow boundary = 2^31 / 32768 = 65,536
+# Lowering NUM_KV_HEADS would shrink the stride and push the overflow
+# boundary far above any practical block_id, masking the bug.
+NUM_Q_HEADS = 8
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+BLOCK_SIZE = 16
+
+# Need num_blocks > 65535 to trigger the crossing.
+NUM_BLOCKS = 70_000
+
+# Block IDs to fingerprint and probe. Layout:
+#   1,000   — safely below the boundary (sanity baseline)
+#   65,535  — last value that fits in u16 (= 0xFFFF). Should still read
+#             correctly even if the kernel does `block_id & 0xFFFF`,
+#             because that operation is a no-op here.
+#   65,536  — first value that overflows u16 (= 0x10000). If the kernel
+#             narrows to 16 bits, this wraps to 0 and reads block 0.
+#   67,000  — well above the boundary; wraps to 67000 - 65536 = 1,464.
+SAFE_BLOCK_ID = 1_000
+EDGE_LAST_SAFE = 65_535
+EDGE_FIRST_BUGGY = 65_536
+BUGGY_BLOCK_ID = 67_000
+
+# Distinct fingerprint per block — kept small (< 1.0) to stay well within
+# bf16 precision after softmax normalization.
+SIG_SAFE = 0.50
+SIG_EDGE_LAST = 0.30
+SIG_EDGE_FIRST = 0.40
+SIG_BUGGY = 0.75
+
+_FINGERPRINTS = [
+    (SAFE_BLOCK_ID, SIG_SAFE, "below_65535"),
+    (EDGE_LAST_SAFE, SIG_EDGE_LAST, "edge_65535_last_u16"),
+    (EDGE_FIRST_BUGGY, SIG_EDGE_FIRST, "edge_65536_first_overflow"),
+    (BUGGY_BLOCK_ID, SIG_BUGGY, "above_65535"),
+]
+
+
+def _build_kv_cache():
+    """Allocate a sparse bf16 KV pool with two fingerprinted blocks."""
+    dtype = torch.bfloat16
+    x = 16 // dtype.itemsize  # = 8 for bf16
+    assert HEAD_DIM % x == 0
+
+    # K layout: [num_blocks, num_kv_heads, head_dim/x, block_size, x]
+    k_cache = torch.zeros(
+        NUM_BLOCKS, NUM_KV_HEADS, HEAD_DIM // x, BLOCK_SIZE, x,
+        dtype=dtype, device="cuda",
+    )
+    # V layout: [num_blocks, num_kv_heads, head_dim, block_size]
+    v_cache = torch.zeros(
+        NUM_BLOCKS, NUM_KV_HEADS, HEAD_DIM, BLOCK_SIZE,
+        dtype=dtype, device="cuda",
+    )
+
+    for block_id, sig, _label in _FINGERPRINTS:
+        k_cache[block_id].fill_(sig)
+        v_cache[block_id].fill_(sig)
+
+    return k_cache, v_cache
+
+
+def _run_pa_fwd_asm(k_cache, v_cache, target_block_id, max_qlen=1):
+    """Run pa_fwd_asm with a single sequence that contains exactly one block,
+    that block being `target_block_id`. Returns the attention output value.
+
+    `max_qlen` selects the kernel family:
+      max_qlen=1 → mtp=0 → pa_bf16_noquant_gqa8_1tg_4w.co (non-MTP decode)
+      max_qlen=4 → mtp=14→1 → pa_bf16_noquant_gqa8_1tg_4w_mtp_msk1.co (MTP)
+    """
+    block_tables = torch.zeros(1, 1, dtype=torch.int32, device="cuda")
+    block_tables[0, 0] = target_block_id
+    context_lens = torch.full(
+        (1,), BLOCK_SIZE, dtype=torch.int32, device="cuda"
+    )
+    cu_seqlens_q = torch.tensor([0, max_qlen], dtype=torch.int32, device="cuda")
+
+    # Query: arbitrary nonzero values — softmax will normalize, V is constant.
+    query = torch.ones(
+        max_qlen, NUM_Q_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    )
+
+    out = aiter.pa_fwd_asm(
+        query,
+        k_cache,
+        v_cache,
+        block_tables,
+        context_lens,
+        block_tables.stride(0),
+        max_qlen=max_qlen,
+        K_QScale=None,
+        V_QScale=None,
+        out_=None,
+        qo_indptr=cu_seqlens_q,
+        high_precision=0,
+    )
+    # Output shape: [max_qlen, num_q_heads, head_dim] — all elements should
+    # equal the fingerprint of target_block_id (because V is constant in
+    # that block and softmax weights sum to 1).
+    return out.float().mean().item()
+
+
+@pytest.mark.parametrize(
+    "block_id,expected_sig,label",
+    _FINGERPRINTS,
+)
+@pytest.mark.parametrize(
+    "max_qlen,kernel_label",
+    [
+        (1, "qlen1_non_MTP_kernel"),
+        (4, "qlen4_MTP_kernel"),
+    ],
+)
+def test_pa_fwd_asm_block_id_no_truncation(
+    block_id, expected_sig, label, max_qlen, kernel_label
+):
+    """Output for a single-block sequence must match that block's fingerprint
+    regardless of whether block_id is below or above 65,535. Run for both
+    qlen=1 (non-MTP decode kernel) and qlen=4 (MTP kernel)."""
+    k_cache, v_cache = _build_kv_cache()
+    actual = _run_pa_fwd_asm(k_cache, v_cache, block_id, max_qlen=max_qlen)
+
+    msg = (
+        f"[{kernel_label}/{label}] block_id={block_id} max_qlen={max_qlen}: "
+        f"expected output ≈ {expected_sig}, got {actual:.6f}. "
+    )
+    if block_id >= 65_536:
+        wrap = block_id - 65_536
+        msg += (
+            f"If the kernel narrows block_id to 16 bits, the high block_id "
+            f"would wrap to block {wrap} (unfilled, = 0), so output collapses "
+            f"toward ~0. Observed value of ~0 here is the bug signature."
+        )
+    assert actual == pytest.approx(expected_sig, abs=1e-2), msg
+
+
+if __name__ == "__main__":
+    # Standalone runner for quick repro without pytest infrastructure.
+    print(
+        f"Allocating KV pool: {NUM_BLOCKS} blocks × bf16 "
+        f"× {NUM_KV_HEADS} kv_head × {HEAD_DIM} head_dim × {BLOCK_SIZE} block_size"
+    )
+    k_cache, v_cache = _build_kv_cache()
+    print(f"  K cache {tuple(k_cache.shape)} = {k_cache.numel() * 2 / 1e9:.2f} GB")
+    print(f"  V cache {tuple(v_cache.shape)} = {v_cache.numel() * 2 / 1e9:.2f} GB")
+    print()
+
+    for max_qlen, kernel_label in [(1, "qlen1_non_MTP"), (4, "qlen4_MTP")]:
+        print(f"=== {kernel_label} (max_qlen={max_qlen}) ===")
+        for block_id, expected, label in _FINGERPRINTS:
+            actual = _run_pa_fwd_asm(k_cache, v_cache, block_id, max_qlen=max_qlen)
+            status = "OK" if abs(actual - expected) < 1e-2 else "BUG"
+            print(
+                f"[{status}] block_id={block_id:>7d}  expected={expected:.4f}  "
+                f"actual={actual:.4f}  Δ={actual - expected:+.4f}  ({label})"
+            )
+            if status == "BUG" and block_id >= 65_536:
+                wrap = block_id & 0xFFFF
+                print(
+                    f"  → if block_id is narrowed to 16 bits, "
+                    f"reads block {wrap} instead (unfilled = 0)."
+                )
+        print()


### PR DESCRIPTION
Adds:
  - op_tests/test_pa_block_id_truncation.py: self-contained microbench that fingerprints four blocks (1000, 65535, 65536, 67000) with distinct constants and verifies pa_fwd_asm reads each one back. Both qlen=1 (non-MTP) and qlen=4 (MTP) kernels return 0 for any block_id >= 65,536, matching block_id & 0xFFFF.
  - PA_BLOCK_ID_TRUNCATION_BUG.md: full writeup with affected binaries, root-cause hypothesis (2 GB / signed-i32 buffer-descriptor limit), production impact (ATOM Eagle3 spec-decode acceptance collapse), and suggested fix.

Run:
  HSA_NO_SCRATCH_RECLAIM=1 python op_tests/test_pa_block_id_truncation.py

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
