### PR TITLE
[draft] Fix MLA decode: zero-init splitK accumulators to avoid uninit reads

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -242,18 +242,18 @@ def mla_decode_fwd(
                     )
                 )
             )
-            else torch.empty(
+            else torch.zeros(
                 (total_s, num_kv_splits, nhead, v_head_dim),
                 dtype=dtypes.fp32,
                 device=device,
             )
         )
 
-        attn_lse = torch.empty(
+        attn_lse = torch.zeros(
             (total_s, num_kv_splits, nhead, 1), dtype=dtypes.fp32, device=device
         )
         final_lse = (
-            torch.empty((total_s, nhead), dtype=dtypes.fp32, device=device)
+            torch.zeros((total_s, nhead), dtype=dtypes.fp32, device=device)
             if return_lse
             else None
         )
@@ -431,18 +431,18 @@ def mla_decode_fwd(
         else:
             assert False, f"{nhead=} and {max_seqlen_q=} not supported"
 
-        logits = torch.empty(
+        logits = torch.zeros(
             (reduce_partial_map.size(0) * max_seqlen_q, 1, nhead, v_head_dim),
             dtype=dtypes.fp32,
             device=device,
         )
-        attn_lse = torch.empty(
+        attn_lse = torch.zeros(
             (reduce_partial_map.size(0) * max_seqlen_q, 1, nhead, 1),
             dtype=dtypes.fp32,
             device=device,
         )
         final_lse = (
-            torch.empty((total_s, nhead), dtype=dtypes.fp32, device=device)
+            torch.zeros((total_s, nhead), dtype=dtypes.fp32, device=device)
             if return_lse
             else None
         )


### PR DESCRIPTION
## Summary
Replace `torch.empty` with `torch.zeros` for the three split-K accumulators (`logits`, `attn_lse`, `final_lse`) allocated in `mla_decode_fwd` (`aiter/mla.py`, both the non-persistent and persistent paths).

## Bug
On the non-persistent path (taken whenever `max_seqlen_q > 1`, since `get_mla_metadata_v1` is qseqlen=1 only), `mla_decode_stage1_asm_fwd` does not always populate every `(qrow, kv_split, head)` cell that `_fwd_kernel_stage2_asm` later reduces over. The stage-2 Python clamp `num_valid_kv_splits = min(splits, ceil(kv_seq_len/mgc))` bounds the *number* of splits read, but does not guarantee every `(qrow, head)` within a valid split was written by stage 1 — that depends on the ASM binding's tile/work distribution.

When the per-split KV count is small, stage 2 reads the unwritten cells. With a cold caching allocator the leftovers are zero (silent); with a warm pool (long-running vLLM worker) the leftovers are arbitrary fp32 values that propagate into the output.

Hit by vLLM `AiterMLAImpl` (rocm_aiter_mla) for spec-decode verify (dflash `num_speculative_tokens=15` → qseqlen=16; Eagle3 spec=7 → qseqlen=8) on the eager / PIECEWISE-cudagraph path, gfx950.

## Repro
- `/home/hangy/dflash_debug/aiter_bug_repro/clean_repro_test_mla.py` monkey-patches `aiter.mla.torch.empty` to fill fp32 allocations with sentinel `1e30`.
- With `ctx_lens=65, decode_qlen=16, nhead=16`, stage 2 reads the sentinel and the output's first 8 of 16 query rows become `1e30` (50.0% of elements; `8 × 16 × 512 = 65,536`).
- Confirmed on `/home/hangy/aiter/aiter/jit/module_mla_asm.so` (May-2 build); the older Apr-28 prebuilt binding tile-distributes differently and does not surface the bug.

## Fix
Zero-init the three accumulators. Stage 2's reduction on a zero `attn_lse` cell yields `exp(0 − e_max) · 0 = 0` weight contribution, so unwritten cells become inert.

This is a defensive fix in Python; the proper long-term fix belongs in `mla_decode_stage1_asm_fwd` itself — it should write every `(token, split, head)` position that stage 2 will read.

## Test plan
- [ ] `op_tests/test_mla.py` — `decode_qlen ∈ {8, 16}, ctx_lens ∈ {65, 128, 256}`, bf16 + fp8
- [ ] `clean_repro_test_mla.py` with `force_dirty_empty(1e30)` — `decode:err == 0` for all shapes
- [ ] vLLM dflash spec-decode verify path (qseqlen=16) end-to-end
- [ ] Persistent path: confirm `mla_reduce_v1` is also safe under zero-init accumulators
