### PR TITLE
Fix dsink bf16 noise in Triton MHA one-kernel backward

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
@@ -345,7 +345,6 @@ def _bwd_dkdv_inner(
 def _bwd_dq_inner(
     dq,  # output
     dq_pe,  # optional output, pass None for non-PE case
-    delta_recomp,
     q,
     q_pe,
     K,
@@ -393,7 +392,7 @@ def _bwd_dq_inner(
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
-    RECOMPUTE_DELTA: tl.constexpr,
+    ENABLE_SINK: tl.constexpr,
 ):
     # if HEAD_DIM is padded
     PADDED_HEAD: tl.constexpr = ACTUAL_HEAD_DIM != HEAD_DIM
@@ -419,6 +418,7 @@ def _bwd_dq_inner(
     curr_philox_offset = batch_philox_offset
     curr_dropout_offset = dropout_offset
     RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
+    delta_recomp = tl.zeros([BLOCK_M2], dtype=tl.float32)
     for blk_idx in range(num_steps):
         if DEBUG_TRITON:
             print(f"iter {blk_idx}: curr_n = {curr_n}")  # noqa: E701
@@ -497,7 +497,7 @@ def _bwd_dq_inner(
             dp = tl.dot(do, vT)
         if ENABLE_DROPOUT:
             dp = tl.where(dropout_mask, dp, 0.0) * dropout_scale
-        if RECOMPUTE_DELTA:
+        if ENABLE_SINK:
             # Equal to do_i . o_i but skips the bf16 round-trip through forward `o`.
             delta_recomp += tl.sum(p * dp, axis=1)
         delta_i = Di[:, None]
@@ -1112,11 +1112,9 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 dq_pe = tl.zeros([BLOCK_M2, PE_HEAD_DIM], dtype=tl.float32)
             else:
                 dq_pe = dq  # Couldn't assign None to dq_pe because _bwd_dq_inner can't return None.
-            delta_recomp = tl.zeros([BLOCK_M2], dtype=tl.float32)
-            dq, dq_pe, delta_recomp = _bwd_dq_inner(
+            dq, dq_pe, delta_recomp_masked = _bwd_dq_inner(
                 dq,  # output tensor
                 dq_pe,  # optional output tensor
-                delta_recomp,
                 q,
                 q_pe,
                 K,
@@ -1162,7 +1160,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 SLIDING_WINDOW=SLIDING_WINDOW,
-                RECOMPUTE_DELTA=ENABLE_SINK,
+                ENABLE_SINK=ENABLE_SINK,
             )
             end_n -= num_steps * MASK_BLOCK_N2
             window_start_n = 0
@@ -1174,10 +1172,9 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 print(
                     f"unMasked: start_m: {start_m}, start_n: {start_n}, end_n: {end_n}, num_steps: {num_steps}"
                 )  # noqa: E701
-            dq, dq_pe, delta_recomp = _bwd_dq_inner(
+            dq, dq_pe, delta_recomp_unmasked = _bwd_dq_inner(
                 dq,  # output tensor
                 dq_pe,  # optional output tensor
-                delta_recomp,
                 q,
                 q_pe,
                 K,
@@ -1223,7 +1220,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 SLIDING_WINDOW=SLIDING_WINDOW,
-                RECOMPUTE_DELTA=ENABLE_SINK,
+                ENABLE_SINK=ENABLE_SINK,
             )
             if ENABLE_SINK:
                 sink = tl.load(Sink + hqid).to(tl.float32)
@@ -1232,6 +1229,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                     psink = tl.math.exp2(sink * RCP_LN2 - m * RCP_LN2)
                 else:
                     psink = tl.math.exp(sink - m)
+                delta_recomp = delta_recomp_masked + delta_recomp_unmasked
                 dsink = tl.sum(-psink * delta_recomp[:, None])
                 tl.atomic_add(DSink + hqid, dsink, sem="relaxed")
             # Write back dQ.
@@ -1698,11 +1696,9 @@ def bwd_kernel_noncausal(
                 dq_pe = tl.zeros([BLOCK_M2, PE_HEAD_DIM], dtype=tl.float32)
             else:
                 dq_pe = dq  # Couldn't assign None to dq_pe because _bwd_dq_inner can't return None.
-            delta_recomp = tl.zeros([BLOCK_M2], dtype=tl.float32)
             dq, dq_pe, delta_recomp = _bwd_dq_inner(
                 dq,  # output tensor
                 dq_pe,  # optional output tensor
-                delta_recomp,
                 q,
                 q_pe,
                 K,
@@ -1748,7 +1744,7 @@ def bwd_kernel_noncausal(
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 SLIDING_WINDOW=SLIDING_WINDOW,
-                RECOMPUTE_DELTA=ENABLE_SINK,
+                ENABLE_SINK=ENABLE_SINK,
             )
             if ENABLE_SINK:
                 sink = tl.load(Sink + hqid).to(tl.float32)

--- a/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
@@ -345,6 +345,7 @@ def _bwd_dkdv_inner(
 def _bwd_dq_inner(
     dq,  # output
     dq_pe,  # optional output, pass None for non-PE case
+    delta_recomp,
     q,
     q_pe,
     K,
@@ -392,6 +393,7 @@ def _bwd_dq_inner(
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
+    RECOMPUTE_DELTA: tl.constexpr,
 ):
     # if HEAD_DIM is padded
     PADDED_HEAD: tl.constexpr = ACTUAL_HEAD_DIM != HEAD_DIM
@@ -495,6 +497,9 @@ def _bwd_dq_inner(
             dp = tl.dot(do, vT)
         if ENABLE_DROPOUT:
             dp = tl.where(dropout_mask, dp, 0.0) * dropout_scale
+        if RECOMPUTE_DELTA:
+            # Equal to do_i . o_i but skips the bf16 round-trip through forward `o`.
+            delta_recomp += tl.sum(p * dp, axis=1)
         delta_i = Di[:, None]
         ds = p * (dp - delta_i)
         # Compute dQ.
@@ -516,7 +521,7 @@ def _bwd_dq_inner(
         if HAS_PE:
             kT_pe_ptrs += step_n * stride_kn
         vT_ptrs += step_n * stride_vn
-    return dq, dq_pe
+    return dq, dq_pe, delta_recomp
 
 
 _bwd_kernel_causal_repr = make_kernel_repr(
@@ -1089,16 +1094,6 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
             m = m[:, None]
             delta = tl.load(Delta_ptr + offs_m * stride_deltam, mask=mask_m, other=0.0)
 
-            if ENABLE_SINK:
-                sink = tl.load(Sink + hqid).to(tl.float32)
-                if USE_EXP2:
-                    RCP_LN2: tl.constexpr = 1.4426950408889634
-                    psink = tl.math.exp2(sink * RCP_LN2 - m * RCP_LN2)
-                else:
-                    psink = tl.math.exp(sink - m)
-                dsink = tl.sum(-psink * delta[:, None])
-                tl.atomic_add(DSink + hqid, dsink, sem="relaxed")
-
             MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
             # start can only be 0 at minimum
             start_n = max(end_n - BLOCK_M2, 0)
@@ -1117,9 +1112,11 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 dq_pe = tl.zeros([BLOCK_M2, PE_HEAD_DIM], dtype=tl.float32)
             else:
                 dq_pe = dq  # Couldn't assign None to dq_pe because _bwd_dq_inner can't return None.
-            dq, dq_pe = _bwd_dq_inner(
+            delta_recomp = tl.zeros([BLOCK_M2], dtype=tl.float32)
+            dq, dq_pe, delta_recomp = _bwd_dq_inner(
                 dq,  # output tensor
                 dq_pe,  # optional output tensor
+                delta_recomp,
                 q,
                 q_pe,
                 K,
@@ -1165,6 +1162,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 SLIDING_WINDOW=SLIDING_WINDOW,
+                RECOMPUTE_DELTA=ENABLE_SINK,
             )
             end_n -= num_steps * MASK_BLOCK_N2
             window_start_n = 0
@@ -1176,9 +1174,10 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 print(
                     f"unMasked: start_m: {start_m}, start_n: {start_n}, end_n: {end_n}, num_steps: {num_steps}"
                 )  # noqa: E701
-            dq, dq_pe = _bwd_dq_inner(
+            dq, dq_pe, delta_recomp = _bwd_dq_inner(
                 dq,  # output tensor
                 dq_pe,  # optional output tensor
+                delta_recomp,
                 q,
                 q_pe,
                 K,
@@ -1224,7 +1223,17 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 SLIDING_WINDOW=SLIDING_WINDOW,
+                RECOMPUTE_DELTA=ENABLE_SINK,
             )
+            if ENABLE_SINK:
+                sink = tl.load(Sink + hqid).to(tl.float32)
+                if USE_EXP2:
+                    RCP_LN2: tl.constexpr = 1.4426950408889634
+                    psink = tl.math.exp2(sink * RCP_LN2 - m * RCP_LN2)
+                else:
+                    psink = tl.math.exp(sink - m)
+                dsink = tl.sum(-psink * delta_recomp[:, None])
+                tl.atomic_add(DSink + hqid, dsink, sem="relaxed")
             # Write back dQ.
             adj_dq = bid * stride_dqb + hqid * stride_dqh + q_start * stride_dqm
             offs_dq = offs_m[:, None] * stride_dqm + offs_d[None, :] * stride_dqd
@@ -1671,16 +1680,6 @@ def bwd_kernel_noncausal(
             m = m[:, None]
             delta = tl.load(Delta_ptr + offs_m * stride_deltam, mask=mask_m, other=0.0)
 
-            if ENABLE_SINK:
-                sink = tl.load(Sink + hqid).to(tl.float32)
-                if USE_EXP2:
-                    RCP_LN2: tl.constexpr = 1.4426950408889634
-                    psink = tl.math.exp2(sink * RCP_LN2 - m * RCP_LN2)
-                else:
-                    psink = tl.math.exp(sink - m)
-                dsink = tl.sum(-psink * delta[:, None])
-                tl.atomic_add(DSink + hqid, dsink, sem="relaxed")
-
             if IS_FP8:
                 descale_q = tl.load(Descale_q + bid * stride_descale_q_z + hqid)
                 descale_k = tl.load(Descale_k + bid * stride_descale_k_z + hkid)
@@ -1699,9 +1698,11 @@ def bwd_kernel_noncausal(
                 dq_pe = tl.zeros([BLOCK_M2, PE_HEAD_DIM], dtype=tl.float32)
             else:
                 dq_pe = dq  # Couldn't assign None to dq_pe because _bwd_dq_inner can't return None.
-            dq, dq_pe = _bwd_dq_inner(
+            delta_recomp = tl.zeros([BLOCK_M2], dtype=tl.float32)
+            dq, dq_pe, delta_recomp = _bwd_dq_inner(
                 dq,  # output tensor
                 dq_pe,  # optional output tensor
+                delta_recomp,
                 q,
                 q_pe,
                 K,
@@ -1747,7 +1748,17 @@ def bwd_kernel_noncausal(
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 SLIDING_WINDOW=SLIDING_WINDOW,
+                RECOMPUTE_DELTA=ENABLE_SINK,
             )
+            if ENABLE_SINK:
+                sink = tl.load(Sink + hqid).to(tl.float32)
+                if USE_EXP2:
+                    RCP_LN2: tl.constexpr = 1.4426950408889634
+                    psink = tl.math.exp2(sink * RCP_LN2 - m * RCP_LN2)
+                else:
+                    psink = tl.math.exp(sink - m)
+                dsink = tl.sum(-psink * delta_recomp[:, None])
+                tl.atomic_add(DSink + hqid, dsink, sem="relaxed")
             # Write back dQ.
             adj_dq = bid * stride_dqb + hqid * stride_dqh + q_start * stride_dqm
             offs_dq = offs_m[:, None] * stride_dqm + offs_d[None, :] * stride_dqd

--- a/op_tests/triton_tests/attention/test_mha_with_sink.py
+++ b/op_tests/triton_tests/attention/test_mha_with_sink.py
@@ -332,12 +332,12 @@ def test_mha_varlen_with_sink(
 
 @pytest.mark.parametrize("BATCH", [1, 2])
 @pytest.mark.parametrize(
-    "SEQLEN_Q, SEQLEN_K", [(64, 64), (256, 256), (128, 64), (32, 128)]
+    "SEQLEN_Q, SEQLEN_K", [(64, 64), (256, 256), (128, 64), (32, 128), (1024, 1024)]
 )
-@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(8, 1), (16, 4)])
+@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(8, 1), (16, 4), (28, 4)])
 @pytest.mark.parametrize("HEAD_SZ", [64, 128])
 @pytest.mark.parametrize("CAUSAL", [True])
-@pytest.mark.parametrize("WINDOW_SIZE_LEFT", [4, 64])
+@pytest.mark.parametrize("WINDOW_SIZE_LEFT", [4, 32, 64])
 def test_mha_with_sink_sliding_window(
     BATCH: int,
     SEQLEN_Q: int,


### PR DESCRIPTION
## Motivation

[ROCM-23870](https://amd-hub.atlassian.net/browse/ROCM-23870): `flash_attn_onekernel_backward` returns wrong `dsink` for sink + sliding-window with large enough Q. `out`/`dq`/`dk`/`dv` are fine — only `dsink` fails the test tolerance.

Failing shapes (bf16, causal, GQA 28/4, head_dim=128, S=1024):
```
B=4, window_left=32 → dsink atol=5e-2 fails
B=2, window_left=64 → dsink atol=5e-2 fails
```

## Technical Details

`dsink_partial = sum_t (-p_sink(t) * delta(t))` where `delta = sum_d do_d * o_d`.

Old path loaded `delta` from `_bwd_preprocess`, which reads bf16 `o`. The per-token bf16 round-trip is harmless for `dq/dk/dv` (each `delta(t)` is multiplied by `p` and contributes per-(q,k); bias cancels), but `dsink` sums `delta(t)` directly across `batch * seqlen_q` per head — bias accumulates linearly past tolerance.

Fix: recompute `delta = sum_j(p_ij * dp_ij)` inside `_bwd_dq_inner` from the fp32 `p`/`dp` already materialized for `dq`, gated on a new `RECOMPUTE_DELTA` constexpr (= `ENABLE_SINK`). Move the `dsink` atomic_add to after the masked + unmasked dq inner loops so it sees the fully-accumulated value. Same change in `bwd_kernel_causal` and `bwd_kernel_noncausal`.

Non-sink path is unchanged (constexpr-gated, same code at compile time).

## Test Plan

Standalone reproducer from the ticket on MI300X / gfx942 / bf16.

## Test Result

Before:
```
window32_batch4 dsink allclose(5e-2, 5e-2) = False
window64_batch2 dsink allclose(5e-2, 5e-2) = False
```

After:
```
window32_batch4 dsink allclose(5e-2, 5e-2) = True
window64_batch2 dsink allclose(5e-2, 5e-2) = True
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

[ROCM-23870]: https://amd-hub.atlassian.net/browse/ROCM-23870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ