### PR TITLE
fix: fix out-of-bounds issue in rope under concurrent scenarios，fix interleaved fused_rope_rms_2way cos/sin out-of-bounds access

### DIFF
--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -1353,6 +1353,7 @@ __global__ void fused_rope_rms_2way_kernel(const T* q0_,
 {
     using mrope_utils::WARP_SIZE;
     constexpr int VEC_SIZE        = HEAD_SIZE / WARP_SIZE;
+    constexpr int PAIR_VEC_SIZE   = VEC_SIZE / 2;
     constexpr int HALF_HEAD_SIZE  = HEAD_SIZE / 2;
     const int warp_id             = threadIdx.x / WARP_SIZE;
     const int num_warps_per_block = blockDim.x / WARP_SIZE;
@@ -1388,7 +1389,8 @@ __global__ void fused_rope_rms_2way_kernel(const T* q0_,
     int head_id_in_token;
     int data_offset;
 
-    vec_t<T, VEC_SIZE> w_vec, x_vec, cos_sin_vec, cos_vec, sin_vec;
+    vec_t<T, VEC_SIZE> w_vec, x_vec, cos_sin_vec;
+    vec_t<T, PAIR_VEC_SIZE> cos_vec, sin_vec;
 
     if(is_q0)
     {
@@ -1494,7 +1496,7 @@ __global__ void fused_rope_rms_2way_kernel(const T* q0_,
     else
     {
 #pragma unroll
-        for(int i = 0; i < VEC_SIZE / 2; ++i)
+        for(int i = 0; i < PAIR_VEC_SIZE; ++i)
         {
             out_vec[2 * i + 0] = (float)x_vec[2 * i + 0] * (float)cos_vec[i] -
                                  (float)x_vec[2 * i + 1] * (float)sin_vec[i];


### PR DESCRIPTION
## Summary

This PR fixes an out-of-bounds access in the interleaved branch of
`fused_rope_rms_2way_kernel` in:

- `csrc/kernels/fused_qk_norm_rope_cache_quant.cu`

The fix introduces `PAIR_VEC_SIZE = VEC_SIZE / 2` and uses it for the
`cos_vec` / `sin_vec` load width and loop bound, preventing the kernel from
reading past the valid cosine/sine range for the last warp lane.

## Target Repo

- Target repo: `aiter`

## Validation Environment

This fix was validated in the following runtime environment:

- validation repo: `zejunchen-zejun/sglang`
- validation branch: `Qwen-Image-v0.5.8`
- docker:
  `ubuntu22.04_rocm7.2.0.43_cp310_torch2.9.1_7e1940d_sglang_a1b3c40_aiter_9cc375d_20260413`
- GPU: single card, `HIP_VISIBLE_DEVICES=7`

## Motivation

We received a customer report that `Qwen-Image-Edit-2511` can hit a GPU-side
crash / coredump when running the `benchmark_single` dataset on ROCm with
AITer enabled.

The failure path is tied to fused rope:

- `SGLANG_ENABLE_FUSED_ROPE_RMS_2WAY=1` can trigger the issue
- setting `SGLANG_ENABLE_FUSED_ROPE_RMS_2WAY=0` avoids the rope-fused path

This strongly points to `fused_rope_rms_2way_kernel` in
`fused_qk_norm_rope_cache_quant.cu`.

## Root Cause

The interleaved branch of `fused_rope_rms_2way_kernel` was loading
`cos_vec` / `sin_vec` with the wrong vector width.

For `head_size = 128`:

- `VEC_SIZE = HEAD_SIZE / WARP_SIZE = 128 / 32 = 4`
- `HALF_HEAD_SIZE = 64`

For the last warp lane:

- `access_id_in_head = 31 * 4 = 124`
- `access_id_in_head / 2 = 62`

In the old implementation, `cos_vec` / `sin_vec` were declared as
`vec_t<T, VEC_SIZE>`, so the last lane reads:

- `cos[62..65]`
- `sin[126..129]`

But the legal bounds are:

- `cos[0..63]`
- `sin[64..127]`

So the old code crosses the valid range:

- `unpatched_max_cos_idx = 65`
- `unpatched_max_sin_idx = 129`

This means:

- cosine loads cross the half-head boundary
- sine loads can read past the end of the token row / backing buffer

Host-side debug logging on the unpatched kernel confirmed this directly:

- `head_size=128`
- `vec_size=4`
- `half_head=64`
- `unpatched_max_cos_idx=65`
- `unpatched_max_sin_idx=129`
- `patched_max_cos_idx=63`
- `patched_max_sin_idx=127`
- `unpatched_cos_oob=1`
- `unpatched_sin_oob=1`

## Why the Old Access Pattern Is Wrong

In the old code, when `cos_vec` is `vec_t<T, 4>`, the last lane reads:

- `cos[62..65]`
- `sin[126..129]`

This is out of bounds.

After the fix, `cos_vec` / `sin_vec` become `vec_t<T, 2>`, so the last lane reads:

- `cos[62..63]`
- `sin[126..127]`

which is exactly within the valid range.

## Fix

The fix is:

1. Introduce:
   ```cpp
   constexpr int PAIR_VEC_SIZE = VEC_SIZE / 2;
   
   