### PR TITLE
Rename amd-triton to triton

### DIFF
--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -3,12 +3,12 @@ set -e
 
 pip uninstall -y triton pytorch-triton pytorch-triton-rocm triton-rocm amd-triton || true
 
-TRITON_INDEX_URL="https://pypi.amd.com/triton/rocm-7.0.0/simple/"
+TRITON_INDEX_URL="https://pypi.amd.com/triton/release/rocm-7.0.0/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
 if [[ -n "$ROCM_VERSION" ]]; then
     ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | cut -d. -f1,2)
-    TRITON_INDEX_URL="https://pypi.amd.com/triton/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
+    TRITON_INDEX_URL="https://pypi.amd.com/triton/release/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
 fi
 
-echo "Installing amd-triton from $TRITON_INDEX_URL"
-pip install --extra-index-url "$TRITON_INDEX_URL" amd-triton
+echo "Installing triton from $TRITON_INDEX_URL"
+pip install --extra-index-url "$TRITON_INDEX_URL" triton

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -380,7 +380,7 @@ jobs:
             pip show amd-aiter
           "
 
-      - name: Install amd-triton
+      - name: Install triton
         run: |
           # Ensure install_triton.sh is available even when the PR branch
           # was created before the script was added to main (#2959).
@@ -395,7 +395,7 @@ jobs:
             chmod +x .github/scripts/install_triton.sh
           fi
           docker exec -w /workspace aiter_test \
-            bash -c "./.github/scripts/install_triton.sh && pip show amd-triton"
+            bash -c "./.github/scripts/install_triton.sh && pip show triton"
 
       - name: Show Aiter version
         run: |
@@ -581,7 +581,7 @@ jobs:
             pip show amd-aiter
           "
 
-      - name: Install amd-triton
+      - name: Install triton
         run: |
           # Ensure install_triton.sh is available even when the PR branch
           # was created before the script was added to main (#2959).
@@ -596,7 +596,7 @@ jobs:
             chmod +x .github/scripts/install_triton.sh
           fi
           docker exec -w /workspace aiter_test \
-            bash -c "./.github/scripts/install_triton.sh && pip show amd-triton"
+            bash -c "./.github/scripts/install_triton.sh && pip show triton"
 
       - name: Show Aiter version
         run: |

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -203,7 +203,7 @@ jobs:
               git submodule sync && git submodule update --init --recursive && \\
               MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 pip install -e . && \\
               ./.github/scripts/install_triton.sh
-          RUN echo "=== amd-triton version ===" && pip show amd-triton || true
+          RUN echo "=== triton version ===" && pip show triton || true
           RUN echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true
           EOF
 

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -144,7 +144,6 @@ jobs:
             git submodule update --init --recursive
             pip install -e .
             # ./.github/scripts/install_triton.sh
-            pip show amd-triton || true
             pip show triton || true
             pip show amd-aiter || pip show aiter
           "

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ pip install -r requirements.txt
 
 ### Triton
 
-AITER includes Triton-based operators that require amd-triton ([ROCm 7.0](https://pypi.amd.com/triton/rocm-7.0.0/simple/), [ROCm 7.1](https://pypi.amd.com/triton/rocm-7.1.0/simple/), [ROCm 7.2](https://pypi.amd.com/triton/rocm-7.2.0/simple/)), with the correct version selected based on your ROCm installation.
+AITER includes Triton-based operators that require triton ([ROCm 7.0](https://pypi.amd.com/triton/release/rocm-7.0.0/simple/), [ROCm 7.1](https://pypi.amd.com/triton/release/rocm-7.1.0/simple/), [ROCm 7.2](https://pypi.amd.com/triton/release/rocm-7.2.0/simple/)), with the correct version selected based on your ROCm installation.
 
-If you install with `python3 setup.py develop`, amd-triton is installed automatically. If you use `pip install -e .`, run the install script manually:
+If you install with `python3 setup.py develop`, triton is installed automatically. If you use `pip install -e .`, run the install script manually:
 
 ```bash
 ./.github/scripts/install_triton.sh

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pip install -r requirements.txt
 
 ### Triton
 
-AITER includes Triton-based operators that require triton ([ROCm 7.0](https://pypi.amd.com/triton/release/rocm-7.0.0/simple/), [ROCm 7.1](https://pypi.amd.com/triton/release/rocm-7.1.0/simple/), [ROCm 7.2](https://pypi.amd.com/triton/release/rocm-7.2.0/simple/)), with the correct version selected based on your ROCm installation.
+AITER includes Triton-based operators that require triton from AMD PyPI ([ROCm 7.0](https://pypi.amd.com/triton/release/rocm-7.0.0/simple/), [ROCm 7.1](https://pypi.amd.com/triton/release/rocm-7.1.0/simple/), [ROCm 7.2](https://pypi.amd.com/triton/release/rocm-7.2.0/simple/)), with the correct version selected based on your ROCm installation.
 
 If you install with `python3 setup.py develop`, triton is installed automatically. If you use `pip install -e .`, run the install script manually:
 

--- a/setup.py
+++ b/setup.py
@@ -95,13 +95,21 @@ def _run_install_triton():
     subprocess.check_call(["bash", install_triton])
 
 
-_triton_info = _is_triton_installed() if is_develop_mode() else None
-if _triton_info:
+AITER_USE_SYSTEM_TRITON = int(os.environ.get("AITER_USE_SYSTEM_TRITON", 0))
+
+_triton_info = _is_triton_installed()
+if AITER_USE_SYSTEM_TRITON and _triton_info:
     print(
-        f"[aiter] {_triton_info[0]}=={_triton_info[1]} is already installed,"
-        " recommend using .github/scripts/install_triton.sh to install triton"
+        f"[aiter] AITER_USE_SYSTEM_TRITON=1, keeping existing"
+        f" {_triton_info[0]}=={_triton_info[1]}"
     )
 else:
+    if _triton_info:
+        print(
+            f"[aiter] Replacing existing {_triton_info[0]}=={_triton_info[1]}"
+            " with aiter-compatible triton"
+            " (if needed, set AITER_USE_SYSTEM_TRITON=1 to keep your triton)"
+        )
     try:
         _run_install_triton()
     except Exception:

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ def _is_triton_installed():
 
     for pkg in [
         "triton",
+        "amd-triton",
         "pytorch-triton",
         "pytorch-triton-rocm",
         "triton-rocm",
@@ -89,7 +90,7 @@ def _is_triton_installed():
 
 
 def _run_install_triton():
-    print("[aiter] Installing amd-triton via .github/scripts/install_triton.sh")
+    print("[aiter] Installing triton via .github/scripts/install_triton.sh")
     install_triton = os.path.join(this_dir, ".github", "scripts", "install_triton.sh")
     subprocess.check_call(["bash", install_triton])
 


### PR DESCRIPTION
Update package name from amd-triton to triton across install scripts, CI workflows, and documentation. Update PyPI index URLs to use the new /release/ path (e.g. https://pypi.amd.com/triton/release/rocm-7.0.0/simple/).

## Motivation

1. Replace amd-triton with triton to resolve the clobbering issue.
2. Previously, develop mode skipped triton installation if any triton variant (triton, pytorch-triton, etc.) was already present, only printing a recommendation. This could leave users with an incompatible triton version. Now aiter always installs its compatible triton by default, with a notice when replacing an existing version. Users who need to keep their own triton (e.g., source-built in Docker images) can opt out by setting AITER_USE_SYSTEM_TRITON=1.

## Technical Details

- setup.py: Added amd-triton to _is_triton_installed() detection list for backward compatibility; updated log messages.
-  CI workflows (aiter-test.yaml, atom-test.yaml, sglang_downstream.yaml): Updated step names and pip show commands from amd-triton to triton.
- AITER_USE_SYSTEM_TRITON=1: Skips installation only when an existing triton is detected. If no triton is present, installation proceeds regardless of this flag.
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
