### PR TITLE
CI: Document downstream model tests in PR guide

### DIFF
--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -33,7 +33,7 @@ jobs:
             | \`ci:triton-300x\` | Run an additional Triton test job on MI300X in PRs; main branch always runs both MI35X and MI300X |
             | \`ci:sglang\` | SGLang integration tests: DeepSeek-R1-MXFP4 accuracy, Qwen 3.5 accuracy |
             | \`ci:atom\` | ATOM benchmark (DeepSeek-R1 + GPT-OSS) |
-            | \`ci:vllm\` | vLLM benchmark: openai/gpt-oss-120b, deepseek-ai/DeepSeek-R1-0528, moonshotai/Kimi-K2.5 |
+            | \`ci:vllm\` | vLLM benchmark: GPT-OSS-120B, DeepSeek-R1-0528, Kimi-K2.5 |
             | \`ci:all\` | All of the above |
 
             > Add labels via the sidebar or \`gh pr edit ${context.issue.number} --add-label <label>\``

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -32,7 +32,7 @@ jobs:
             |-------|-------|
             | \`ci:triton-300x\` | Run an additional Triton test job on MI300X in PRs; main branch always runs both MI35X and MI300X |
             | \`ci:sglang\` | SGLang integration tests: DeepSeek-R1-MXFP4 accuracy, Qwen 3.5 accuracy |
-            | \`ci:atom\` | ATOM benchmark (DeepSeek-R1 + GPT-OSS) |
+            | \`ci:atom\` | ATOM benchmark: DeepSeek-R1-0528, GPT-OSS-120B |
             | \`ci:vllm\` | vLLM benchmark: GPT-OSS-120B, DeepSeek-R1-0528, Kimi-K2.5 |
             | \`ci:all\` | All of the above |
 

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -31,9 +31,9 @@ jobs:
             | Label | Tests |
             |-------|-------|
             | \`ci:triton-300x\` | Run an additional Triton test job on MI300X in PRs; main branch always runs both MI35X and MI300X |
-            | \`ci:sglang\` | SGLang integration tests |
+            | \`ci:sglang\` | SGLang integration tests: DeepSeek-R1-MXFP4 accuracy, Qwen 3.5 accuracy |
             | \`ci:atom\` | ATOM benchmark (DeepSeek-R1 + GPT-OSS) |
-            | \`ci:vllm\` | vLLM benchmark |
+            | \`ci:vllm\` | vLLM benchmark: openai/gpt-oss-120b, deepseek-ai/DeepSeek-R1-0528, moonshotai/Kimi-K2.5 |
             | \`ci:all\` | All of the above |
 
             > Add labels via the sidebar or \`gh pr edit ${context.issue.number} --add-label <label>\``


### PR DESCRIPTION
## Summary
- Document the current SGLang PR model tests in the PR welcome CI guide.
- Document the current vLLM benchmark model list in the same guide.

## Test plan
- Verified the updated welcome comment includes the expected SGLang and vLLM model strings with a local Python check.