### PR TITLE
CI: show ATOM default model names

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -82,7 +82,7 @@ jobs:
                   "accuracy_test_threshold": "0.94",
                   "runner": "linux-aiter-mi300x-8",
                   "run_on_pr": True,
-                  "job_name": "ATOM Benchmark",
+                  "job_name": "ATOM Benchmark (DeepSeek-R1-0528, MI300X)",
               },
               {
                   "model_name": "DeepSeek-R1-0528",
@@ -93,7 +93,7 @@ jobs:
                   "accuracy_test_threshold": "0.94",
                   "runner": "linux-aiter-mi35x-8",
                   "run_on_pr": True,
-                  "job_name": "ATOM Benchmark",
+                  "job_name": "ATOM Benchmark (DeepSeek-R1-0528, MI35X)",
               },
               {
                   "model_name": "gpt-oss-120b",
@@ -104,7 +104,7 @@ jobs:
                   "accuracy_test_threshold": "0.38",
                   "runner": "linux-aiter-mi35x-1",
                   "run_on_pr": True,
-                  "job_name": "ATOM Benchmark",
+                  "job_name": "ATOM Benchmark (gpt-oss-120b, MI35X)",
               },
           ]
 


### PR DESCRIPTION
## Summary
- Give the default ATOM benchmark matrix entries unique job names with model and runner labels.
- Restore model visibility for main-branch ATOM workflow runs, where the workflow uses the default model matrix instead of the `ci:atom_full` path.

## Test plan
- Verified the workflow diff is limited to `.github/workflows/atom-test.yaml`.
- Checked the three default `job_name` values are unique.