### PR TITLE
[Triton] Add s_barrier to sync waves after writing expert hist

### DIFF
--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
@@ -259,6 +259,8 @@ def _combined_routing_fused(
         EVEN_M,
     )
 
+    tl.debug_barrier()
+    
     if pid != 0 and pid < blocks1a:
         n_tokens = tl.load(ExpertHist + pid)
         if n_tokens == 0:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
@@ -260,7 +260,7 @@ def _combined_routing_fused(
     )
 
     tl.debug_barrier()
-    
+
     if pid != 0 and pid < blocks1a:
         n_tokens = tl.load(ExpertHist + pid)
         if n_tokens == 0:

--- a/aiter/ops/triton/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/moe/moe_routing/routing.py
@@ -216,7 +216,8 @@ def _compute_expt_data_internal(n_expts_tot, n_gates, block_m, device):
     else:
         max_n_tiles = n_expts_tot - 1 - ((n_expts_tot - n_gates - 1) // block_m)
     # allocate memory
-    pad = lambda x: cdiv(x, BLOCK) * BLOCK
+    def pad(x):
+        return cdiv(x, BLOCK) * BLOCK
     dtype = torch.int32
 
     token_offs_combined = torch.empty(

--- a/aiter/ops/triton/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/moe/moe_routing/routing.py
@@ -216,8 +216,7 @@ def _compute_expt_data_internal(n_expts_tot, n_gates, block_m, device):
     else:
         max_n_tiles = n_expts_tot - 1 - ((n_expts_tot - n_gates - 1) // block_m)
     # allocate memory
-    def pad(x):
-        return cdiv(x, BLOCK) * BLOCK
+    pad = lambda x: cdiv(x, BLOCK) * BLOCK
     dtype = torch.int32
 
     token_offs_combined = torch.empty(


### PR DESCRIPTION
Without this it is possible that wave 0 in a WG is reading addr X, wave 1 in the same WG is responsible for writing addr X, but hasn't yet arrived at its tl.store(X) while wave 0 is at its tl.load(X)