### PR TITLE
Add explicit num_stages to blockscale triton kernel to pipeline non-d…

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w8_blockscale.py
@@ -155,7 +155,9 @@ def _gemm_a16w8_blockscale_kernel(
         acc_dtype = tl.float32 if c_ptr.type.element_ty != tl.int8 else tl.int32
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
-        for k in range(pid_k * num_k_iter, (pid_k + 1) * num_k_iter):
+        for k in tl.range(
+            pid_k * num_k_iter, (pid_k + 1) * num_k_iter, num_stages=num_stages
+        ):
             # Load the next block of A and B, generate a mask by checking the K dimension.
             # If it is out of bounds, set it to 0.
             if EVEN_K:

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
@@ -82,6 +82,7 @@ def _gemm_a8w8_blockscale_kernel(
     EVEN_K: tl.constexpr,
     GRID_MN: tl.constexpr,
     cache_modifier: tl.constexpr,
+    num_stages: tl.constexpr,
 ):
     """
     Note: this is Triton jited function and not meant to be called directly. Call gemm_a8w8_blockscale function
@@ -169,7 +170,9 @@ def _gemm_a8w8_blockscale_kernel(
         acc_dtype = tl.float32 if c_ptr.type.element_ty != tl.int8 else tl.int32
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
-        for k in range(pid_k * num_k_iter, (pid_k + 1) * num_k_iter):
+        for k in tl.range(
+            pid_k * num_k_iter, (pid_k + 1) * num_k_iter, num_stages=num_stages
+        ):
             # Load the next block of A and B, generate a mask by checking the K dimension.
             # If it is out of bounds, set it to 0.
             if EVEN_K:


### PR DESCRIPTION
…ot loads

before:
          M       N       K  TFLOPS (Throughput (TFLOPS))
0       1.0  1280.0  8192.0                      0.451829
1      32.0  1280.0  8192.0                     12.869310
2      64.0  1280.0  8192.0                     24.087076
3     128.0  1280.0  8192.0                     33.434979
4     192.0  1280.0  8192.0                     75.571433
5     256.0  1280.0  8192.0                     96.858712
6     320.0  1280.0  8192.0                    102.001978
7     512.0  1280.0  8192.0                    160.802553
8    1024.0  1280.0  8192.0                    119.088444
9    2048.0  1280.0  8192.0                    236.311577
10   4096.0  1280.0  8192.0                    448.330269
11   8192.0  1280.0  8192.0                    435.807035
12  16384.0  1280.0  8192.0                    559.566602
13   4096.0  4096.0  4096.0                    681.811497
14   4096.0  4096.0  4160.0                    819.575340

after:
          M       N       K  TFLOPS (Throughput (TFLOPS))
0       1.0  1280.0  8192.0                      0.450725
1      32.0  1280.0  8192.0                     13.143630
2      64.0  1280.0  8192.0                     24.290469
3     128.0  1280.0  8192.0                     51.187744
4     192.0  1280.0  8192.0                     85.569397
5     256.0  1280.0  8192.0                    109.648562
6     320.0  1280.0  8192.0                    138.371357
7     512.0  1280.0  8192.0                    219.318038
8    1024.0  1280.0  8192.0                    171.423113
9    2048.0  1280.0  8192.0                    340.814584
10   4096.0  1280.0  8192.0                    671.147979
11   8192.0  1280.0  8192.0                    679.417517
12  16384.0  1280.0  8192.0                    895.930605
13   4096.0  4096.0  4096.0                   1012.349721
14   4096.0  4096.0  4160.0                    870.790506

bench_gemm_a16w8_blockscale:

before:
          M       N       K  TFLOPS (Throughput (TFLOPS))
0       1.0  1280.0  8192.0                      0.612971
1      32.0  1280.0  8192.0                     18.243675
2      64.0  1280.0  8192.0                     38.630043
3     128.0  1280.0  8192.0                     77.751778
4     192.0  1280.0  8192.0                     77.094444
5     256.0  1280.0  8192.0                    100.257393
6     320.0  1280.0  8192.0                     60.658780
7     512.0  1280.0  8192.0                     96.005049
8    1024.0  1280.0  8192.0                    192.657636
9    2048.0  1280.0  8192.0                    372.239918
10   4096.0  1280.0  8192.0                    392.784294
11   8192.0  1280.0  8192.0                    529.004684
12  16384.0  1280.0  8192.0                    598.012579
13   4096.0  4096.0  4096.0                    626.637559
14   4096.0  4096.0  4160.0                    629.976291

after:
          M       N       K  TFLOPS (Throughput (TFLOPS))
0       1.0  1280.0  8192.0                      0.617337
1      32.0  1280.0  8192.0                     15.298067
2      64.0  1280.0  8192.0                     35.073917
3     128.0  1280.0  8192.0                     71.656473
4     192.0  1280.0  8192.0                     77.173068
5     256.0  1280.0  8192.0                    102.782553
6     320.0  1280.0  8192.0                     75.468107
7     512.0  1280.0  8192.0                    119.971498
8    1024.0  1280.0  8192.0                    235.817648
9    2048.0  1280.0  8192.0                    463.437067
10   4096.0  1280.0  8192.0                    486.038079
11   8192.0  1280.0  8192.0                    610.240488
12  16384.0  1280.0  8192.0                    661.144325
13   4096.0  4096.0  4096.0                    682.940834
14   4096.0  4096.0  4160.0                    656.672637

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
