### PR TITLE
Fusion allreduce old add rmsnorm

### DIFF
--- a/aiter/dist/communication_op.py
+++ b/aiter/dist/communication_op.py
@@ -43,9 +43,11 @@ def tensor_model_parallel_fused_allreduce_rmsnorm(
     weight_: torch.Tensor,
     eps: float,
     prefill_support: bool = False,
+    use_old_ca: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return get_tp_group().fused_allreduce_rmsnorm(
-        input_, residual_inp_, weight_, eps, prefill_support
+        input_, residual_inp_, weight_, eps, prefill_support,
+        use_old_ca=use_old_ca,
     )
 
 
@@ -55,13 +57,37 @@ def tensor_model_parallel_fused_allreduce_rmsnorm_quant(
     weight_: torch.Tensor,
     eps: float,
     prefill_support: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    emit_bf16: bool = False,
+    use_old_ca: bool = False,
+):
     return get_tp_group().fused_allreduce_rmsnorm_quant(
         input_,
         residual_inp_,
         weight_,
         eps,
         prefill_support,
+        emit_bf16=emit_bf16,
+        use_old_ca=use_old_ca,
+    )
+
+
+def tensor_model_parallel_fused_allreduce_rmsnorm_quant_per_group(
+    input_: torch.Tensor,
+    residual_inp_: torch.Tensor,
+    weight_: torch.Tensor,
+    eps: float,
+    group_size: int = 128,
+    prefill_support: bool = False,
+    emit_bf16: bool = False,
+):
+    return get_tp_group().fused_allreduce_rmsnorm_quant_per_group(
+        input_,
+        residual_inp_,
+        weight_,
+        eps,
+        group_size,
+        prefill_support,
+        emit_bf16=emit_bf16,
     )
 
 

--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -211,6 +211,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         weight_,
         eps,
         prefill_support: bool = False,
+        use_old_ca: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         n = input_.shape[-1]
         total_bytes = input_.numel() * input_.element_size()
@@ -233,7 +234,8 @@ class CudaCommunicator(DeviceCommunicatorBase):
                     else (total_bytes <= 128 * 1024)
                 )
                 out, res_out = ca_comm.custom_fused_ar_rms(
-                    input_, res_inp_, weight_, eps, use_1stage
+                    input_, res_inp_, weight_, eps, use_1stage,
+                    use_old_ca=use_old_ca,
                 )
                 assert out is not None
                 assert res_out is not None
@@ -262,8 +264,28 @@ class CudaCommunicator(DeviceCommunicatorBase):
         weight_,
         eps,
         prefill_support: bool = False,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        emit_bf16: bool = False,
+        use_old_ca: bool = False,
+    ):
+        """Fused AR+RMSNorm+per-token FP8 quant, optionally also emitting the
+        pre-quantization bf16/fp16 normed output.
+
+        When ``emit_bf16=False`` returns ``(fp8, residual_out, scale)``.
+        When ``emit_bf16=True`` returns ``(fp8, residual_out, scale, bf16)`` —
+        used by Qwen3.5 sparse MoE so the gate / shared-expert can keep an
+        unquantized view of the same normed activation that the dense
+        gate_up_proj consumes in fp8.
+
+        When ``use_old_ca=True`` the all-reduce half of the fused kernel is
+        swapped for the legacy ("old") custom_all_reduce primitive (start_sync
+        + cross-rank load + end_sync), so the kernel can interleave safely
+        with other old-CA all_reduce calls when SGLang sets
+        SGLANG_USE_AITER_NEW_CA=false. The ``+ add + rmsnorm + quant``
+        epilogue (and the bf16 side-output) is unchanged in either case.
+        """
         total_bytes = input_.numel() * input_.element_size()
+        out = res_out = scale_out = bf16_out = None
+        fused_ok = False
         if (
             int(input_.shape[-1]) in [512, 1024, 2048, 4096]
             and total_bytes <= 4096 * 1024
@@ -274,18 +296,98 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 if self._ar_1stage_override is not None
                 else (total_bytes <= 128 * 1024)
             )
-            out, res_out, scale_out = self.ca_comm.custom_fused_ar_rms_quant(
-                input_, res_inp_, weight_, eps, use_1stage
+            result = self.ca_comm.custom_fused_ar_rms_quant(
+                input_,
+                res_inp_,
+                weight_,
+                eps,
+                use_1stage,
+                emit_bf16=emit_bf16,
+                use_old_ca=use_old_ca,
             )
-        else:
+            if result is not None:
+                if emit_bf16:
+                    out, res_out, scale_out, bf16_out = result
+                else:
+                    out, res_out, scale_out = result
+                fused_ok = True
+        if not fused_ok:
             out_, res_out = self.fused_allreduce_rmsnorm(
                 input_, res_inp_, weight_, eps, prefill_support
             )
             hip_quant = get_hip_quant(QuantType.per_Token)
             out, scale_out = hip_quant(out_, quant_dtype=fp8)
+            if emit_bf16:
+                bf16_out = out_
         assert out is not None
         assert res_out is not None
         assert scale_out is not None
+        if emit_bf16:
+            assert bf16_out is not None
+            return out, res_out, scale_out, bf16_out
+        return out, res_out, scale_out
+
+    def fused_allreduce_rmsnorm_quant_per_group(
+        self,
+        input_,
+        res_inp_,
+        weight_,
+        eps,
+        group_size: int = 128,
+        prefill_support: bool = False,
+        emit_bf16: bool = False,
+    ):
+        """Fused AR+RMSNorm+per-group FP8 quant, optionally also emitting the
+        pre-quantization bf16/fp16 normed output.
+
+        When ``emit_bf16=False`` returns ``(fp8, residual_out, scale)``.
+        When ``emit_bf16=True`` returns ``(fp8, residual_out, scale, bf16)`` —
+        used by GDN-style layers that have both an FP8 projection and a bf16
+        gating projection consuming the same normed activation, so they can
+        skip the separate per-group quant kernel entirely (see Qwen3.5).
+        """
+        total_bytes = input_.numel() * input_.element_size()
+        K = int(input_.shape[-1])
+        fused_ok = False
+        out = res_out = scale_out = bf16_out = None
+        if (
+            K % group_size == 0
+            and K <= 16384
+            and total_bytes < 8 * 1024 * 8192
+            and self.world_size != 6
+            and (prefill_support or total_bytes <= 64 * 1024 * 1024)
+        ):
+            use_1stage = (
+                self._ar_1stage_override
+                if self._ar_1stage_override is not None
+                else (total_bytes <= 128 * 1024)
+            )
+            try:
+                result = self.ca_comm.custom_fused_ar_rms_per_group_quant(
+                    input_, res_inp_, weight_, eps, group_size, use_1stage,
+                    emit_bf16=emit_bf16,
+                )
+                if emit_bf16:
+                    out, res_out, scale_out, bf16_out = result
+                else:
+                    out, res_out, scale_out = result
+                fused_ok = True
+            except Exception:
+                pass
+        if not fused_ok:
+            out_, res_out = self.fused_allreduce_rmsnorm(
+                input_, res_inp_, weight_, eps, prefill_support
+            )
+            hip_quant = get_hip_quant(QuantType.per_1x128)
+            out, scale_out = hip_quant(out_, quant_dtype=fp8)
+            if emit_bf16:
+                bf16_out = out_
+        assert out is not None
+        assert res_out is not None
+        assert scale_out is not None
+        if emit_bf16:
+            assert bf16_out is not None
+            return out, res_out, scale_out, bf16_out
         return out, res_out, scale_out
 
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -46,6 +46,73 @@ def is_weak_contiguous(inp: torch.Tensor):
     )
 
 
+# Wavefront width on AMD CDNA / gfx94x / gfx950. ``__shfl_xor`` in the
+# fused per-group FP8 quant epilogue is scoped to a single wavefront, so
+# ``threads_per_group = group_size / PACK_SIZE`` must fit inside it.
+_AITER_AR_WAVEFRONT_SIZE = 64
+
+
+def _validate_per_group_size(group_size: int, element_size: int, n: int) -> None:
+    """Validate ``group_size`` for the fused AR + RMSNorm + per-group FP8
+    quant kernel. Mirrors the C++ host dispatcher checks in
+    ``dispatchFusedAllReduceRMSNormQuantPerGroup`` so callers fail fast
+    with a clear Python-level ``ValueError`` (rather than a generic
+    ``RuntimeError`` from the extension, which aborts CUDA-graph capture
+    asynchronously).
+
+    The fused epilogue imposes five constraints on ``group_size``:
+
+    (a) ``group_size > 0``
+    (b) ``group_size % PACK_SIZE == 0`` with ``PACK_SIZE = 16 // element_size``
+        (each thread owns a full 16-byte pack, so a group must be made of
+        whole packs).
+    (c) ``threads_per_group = group_size / PACK_SIZE`` must be a power of two
+        (butterfly ``__shfl_xor`` reduction strides ``{tpg/2, tpg/4, ..., 1}``).
+    (d) ``threads_per_group`` must fit inside a wavefront
+        (``<= 64`` on AMD CDNA); cross-warp shuffles do not exist on HIP.
+    (e) ``n % group_size == 0`` so ``num_groups = n / group_size`` is an
+        integer.
+    """
+    if not isinstance(group_size, int):
+        raise TypeError(
+            f"per-group quant group_size must be int, got {type(group_size).__name__}"
+        )
+    if group_size <= 0:
+        raise ValueError(
+            f"per-group quant requires group_size > 0, got group_size={group_size}"
+        )
+    if element_size <= 0 or 16 % element_size != 0:
+        raise ValueError(
+            "per-group quant requires an element_size that divides 16 "
+            f"(bf16/fp16: 2), got element_size={element_size}"
+        )
+    pack_size = 16 // element_size
+    if group_size % pack_size != 0:
+        raise ValueError(
+            f"per-group quant requires group_size divisible by PACK_SIZE="
+            f"{pack_size} (16 // element_size), got group_size={group_size}"
+        )
+    threads_per_group = group_size // pack_size
+    if threads_per_group & (threads_per_group - 1) != 0:
+        raise ValueError(
+            "per-group quant requires group_size/PACK_SIZE to be a power of "
+            "two (butterfly __shfl_xor reduction), got "
+            f"group_size={group_size} PACK_SIZE={pack_size} "
+            f"threads_per_group={threads_per_group}"
+        )
+    if threads_per_group > _AITER_AR_WAVEFRONT_SIZE:
+        raise ValueError(
+            "per-group quant requires group_size/PACK_SIZE <= wavefront size "
+            f"({_AITER_AR_WAVEFRONT_SIZE}), got group_size={group_size} "
+            f"PACK_SIZE={pack_size} threads_per_group={threads_per_group}"
+        )
+    if n % group_size != 0:
+        raise ValueError(
+            f"per-group quant requires n divisible by group_size, "
+            f"got n={n} group_size={group_size}"
+        )
+
+
 class IPCBuffer:
     """A single IPC-accessible device buffer.
 
@@ -613,6 +680,8 @@ class CustomAllreduce:
         registered: bool = False,
         use_1stage: bool = False,
         post_per_token_quant: bool = False,
+        bf16_out: Optional[torch.Tensor] = None,
+        use_old_ca: bool = False,
     ):
         if res_out is None:
             res_out = torch.empty_like(inp)
@@ -633,6 +702,7 @@ class CustomAllreduce:
                 reg,
                 reg_bytes,
                 use_1stage,
+                use_old_ca,
             )
             return out, res_out
         else:
@@ -643,6 +713,21 @@ class CustomAllreduce:
                 scale_out = torch.empty(
                     inp.shape[:-1] + (1,), dtype=torch.float32, device=inp.device
                 )
+            # Optional bf16/fp16 mirror of the pre-quantization normed output.
+            # SGLang Qwen3.5 sparse MoE wants this so the gate / router experts
+            # can keep an unquantized view without paying for fp8 -> bf16
+            # dequant later in the layer. Zero-overhead when not requested
+            # because the kernel branches on bf16_out_ptr being non-null.
+            bf16_out_ptr = 0
+            if bf16_out is not None:
+                assert bf16_out.dtype == inp.dtype, (
+                    f"bf16_out dtype {bf16_out.dtype} must match inp dtype {inp.dtype}"
+                )
+                assert bf16_out.shape == inp.shape, (
+                    f"bf16_out shape {bf16_out.shape} must match inp shape {inp.shape}"
+                )
+                assert is_weak_contiguous(bf16_out), "bf16_out tensor is not weak-contiguous"
+                bf16_out_ptr = int(bf16_out.data_ptr())
             ops.fused_allreduce_rmsnorm_quant(
                 self._ptr,
                 inp,
@@ -655,7 +740,11 @@ class CustomAllreduce:
                 reg,
                 reg_bytes,
                 use_1stage,
+                bf16_out_ptr,
+                use_old_ca,
             )
+            if bf16_out is not None:
+                return out, res_out, scale_out, bf16_out
             return out, res_out, scale_out
 
     def custom_fused_ar_rms(
@@ -665,6 +754,7 @@ class CustomAllreduce:
         weight: torch.Tensor,
         eps: float,
         use_1stage: bool,
+        use_old_ca: bool = False,
     ) -> Optional[torch.Tensor]:
         # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
@@ -678,6 +768,7 @@ class CustomAllreduce:
                     eps=eps,
                     registered=True,
                     use_1stage=use_1stage,
+                    use_old_ca=use_old_ca,
                 )
             else:
                 return torch.zeros_like(input), torch.zeros_like(input)
@@ -689,6 +780,7 @@ class CustomAllreduce:
                 eps=eps,
                 registered=False,
                 use_1stage=use_1stage,
+                use_old_ca=use_old_ca,
             )
 
     def custom_fused_ar_rms_quant(
@@ -698,10 +790,19 @@ class CustomAllreduce:
         weight: torch.Tensor,
         eps: float,
         use_1stage: bool,
+        emit_bf16: bool = False,
+        use_old_ca: bool = False,
     ):
         # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
             return None
+        bf16_out = None
+        if emit_bf16:
+            # Allocate the side-output once at the Python boundary so the
+            # underlying fused kernel can write into it directly. This keeps
+            # the dummy-stream / hipgraph-replay code paths consistent: every
+            # branch returns a 4-tuple when emit_bf16=True.
+            bf16_out = torch.empty_like(input)
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
                 return self.fused_ar_rms(
@@ -712,12 +813,21 @@ class CustomAllreduce:
                     registered=True,
                     use_1stage=use_1stage,
                     post_per_token_quant=True,
+                    bf16_out=bf16_out,
+                    use_old_ca=use_old_ca,
                 )
             else:
                 dummy_out = torch.zeros(input.shape, dtype=fp8, device=input.device)
                 dummy_scale_out = torch.zeros(
                     input.shape[:-1] + (1,), dtype=torch.float32, device=input.device
                 )
+                if emit_bf16:
+                    return (
+                        dummy_out,
+                        torch.zeros_like(input),
+                        dummy_scale_out,
+                        torch.zeros_like(input),
+                    )
                 return dummy_out, torch.zeros_like(input), dummy_scale_out
         else:
             return self.fused_ar_rms(
@@ -728,10 +838,120 @@ class CustomAllreduce:
                 registered=False,
                 use_1stage=use_1stage,
                 post_per_token_quant=True,
+                bf16_out=bf16_out,
+                use_old_ca=use_old_ca,
+            )
+
+    def fused_ar_rms_per_group_quant(
+        self,
+        inp: torch.Tensor,
+        res_inp: torch.Tensor,
+        *,
+        w: torch.Tensor,
+        eps: float,
+        group_size: int = 128,
+        registered: bool = False,
+        use_1stage: bool = False,
+        emit_bf16: bool = False,
+    ):
+        K = inp.shape[-1]
+        # Fail fast on bad ``group_size`` at the Python boundary. Mirrors
+        # the C++ host dispatcher checks; catching it here surfaces a
+        # synchronous ``ValueError`` instead of a post-launch
+        # ``RuntimeError`` that would only fire at CUDA-graph replay and
+        # would be much harder to attribute to the offending call site.
+        _validate_per_group_size(group_size, inp.element_size(), K)
+        res_out = torch.empty_like(inp)
+        num_groups = K // group_size
+        out = torch.empty(inp.shape, dtype=fp8, device=inp.device)
+        scale_out = torch.empty(
+            inp.shape[:-1] + (num_groups,), dtype=torch.float32, device=inp.device
+        )
+        # Optional bf16/fp16 mirror of the pre-quantization normed output.
+        # Requested by GDN-style layers that also need an unquantized view
+        # (e.g. Qwen3.5 in_proj_ba). Zero-overhead when not requested
+        # because the kernel branches on the pointer being non-null.
+        bf16_out = None
+        bf16_ptr = 0
+        if emit_bf16:
+            bf16_out = torch.empty_like(inp)
+            bf16_ptr = int(bf16_out.data_ptr())
+        reg = 0 if registered else self._pool["input"].data_ptr
+        reg_bytes = 0 if registered else self._pool["input"].max_size
+        ops.fused_allreduce_rmsnorm_quant_per_group(
+            self._ptr,
+            inp,
+            res_inp,
+            res_out,
+            out,
+            scale_out,
+            w,
+            eps,
+            group_size,
+            reg,
+            reg_bytes,
+            use_1stage,
+            bf16_ptr,
+        )
+        if emit_bf16:
+            return out, res_out, scale_out, bf16_out
+        return out, res_out, scale_out
+
+    def custom_fused_ar_rms_per_group_quant(
+        self,
+        input: torch.Tensor,
+        residual_inp: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float,
+        group_size: int = 128,
+        use_1stage: bool = False,
+        emit_bf16: bool = False,
+    ):
+        if self.disabled or not self.should_custom_ar(input):
+            return None
+        if self._IS_CAPTURING:
+            if torch.cuda.is_current_stream_capturing():
+                return self.fused_ar_rms_per_group_quant(
+                    input,
+                    residual_inp,
+                    w=weight,
+                    eps=eps,
+                    group_size=group_size,
+                    registered=True,
+                    use_1stage=use_1stage,
+                    emit_bf16=emit_bf16,
+                )
+            else:
+                K = input.shape[-1]
+                num_groups = K // group_size
+                dummy_out = torch.zeros(input.shape, dtype=fp8, device=input.device)
+                dummy_scale = torch.zeros(
+                    input.shape[:-1] + (num_groups,),
+                    dtype=torch.float32,
+                    device=input.device,
+                )
+                if emit_bf16:
+                    return (
+                        dummy_out,
+                        torch.zeros_like(input),
+                        dummy_scale,
+                        torch.zeros_like(input),
+                    )
+                return dummy_out, torch.zeros_like(input), dummy_scale
+        else:
+            return self.fused_ar_rms_per_group_quant(
+                input,
+                residual_inp,
+                w=weight,
+                eps=eps,
+                group_size=group_size,
+                registered=False,
+                use_1stage=use_1stage,
+                emit_bf16=emit_bf16,
             )
 
     def close(self):
-        if not self.disabled and self._ptr:
+        if not self.disabled and getattr(self, "_ptr", 0):
             ops.dispose(self._ptr)
             self._ptr = 0
 

--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -174,13 +174,14 @@ def fused_allreduce_rmsnorm_quant_(
     eps: float,
     group_name: str,
     prefill_support: bool = False,
+    use_old_ca: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert group_name in _groups, f"Group {group_name} is not found."
     group = _groups[group_name]()
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
     return group._fused_allreduce_rmsnorm_quant_out_place(
-        inp, res_inp, w, eps, prefill_support
+        inp, res_inp, w, eps, prefill_support, use_old_ca=use_old_ca
     )
 
 
@@ -426,7 +427,23 @@ class GroupCoordinator:
         weight_: torch.Tensor,
         eps: float,
         prefill_support: bool = False,
+        use_old_ca: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        # When ``use_old_ca=True`` the fused kernel uses the legacy
+        # custom_all_reduce primitive for its AR half so it can interleave
+        # safely with other old-CA all_reduce calls when SGLang sets
+        # SGLANG_USE_AITER_NEW_CA=false. The AR-only path bypasses the
+        # ``torch_compile_guard``-wrapped dispatcher because that guard's
+        # torch.library schema does not include the new keyword arg.
+        if use_old_ca:
+            return self._fused_allreduce_rmsnorm_out_place(
+                input_,
+                residual_inp_,
+                weight_,
+                eps,
+                prefill_support,
+                use_old_ca=True,
+            )
         return fused_allreduce_rmsnorm_(
             input_,
             residual_inp_,
@@ -443,7 +460,26 @@ class GroupCoordinator:
         weight_: torch.Tensor,
         eps: float,
         prefill_support: bool = False,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        emit_bf16: bool = False,
+        use_old_ca: bool = False,
+    ):
+        # When the caller wants the bf16 mirror, bypass the
+        # ``torch_compile_guard``-wrapped dispatcher (its torch.library schema
+        # only describes the legacy 3-tuple return) and call directly into the
+        # device communicator, mirroring the per-group path. The ``use_old_ca``
+        # flag is threaded down so SGLANG_USE_AITER_NEW_CA=false swaps the
+        # internal AR half of the fused kernel for the legacy custom_all_reduce
+        # primitive without disturbing the add+rmsnorm+quant epilogue.
+        if emit_bf16:
+            return self._fused_allreduce_rmsnorm_quant_out_place(
+                input_,
+                residual_inp_,
+                weight_,
+                eps,
+                prefill_support,
+                emit_bf16=True,
+                use_old_ca=use_old_ca,
+            )
         return fused_allreduce_rmsnorm_quant_(
             input_,
             residual_inp_,
@@ -451,6 +487,24 @@ class GroupCoordinator:
             eps,
             group_name=self.unique_name,
             prefill_support=prefill_support,
+            use_old_ca=use_old_ca,
+        )
+
+    def fused_allreduce_rmsnorm_quant_per_group(
+        self,
+        input_: torch.Tensor,
+        residual_inp_: torch.Tensor,
+        weight_: torch.Tensor,
+        eps: float,
+        group_size: int = 128,
+        prefill_support: bool = False,
+        emit_bf16: bool = False,
+    ):
+        if self.device_communicator is None:
+            raise ValueError("No device communicator found")
+        return self.device_communicator.fused_allreduce_rmsnorm_quant_per_group(
+            input_, residual_inp_, weight_, eps, group_size, prefill_support,
+            emit_bf16=emit_bf16,
         )
 
     def _fused_allreduce_rmsnorm_out_place(
@@ -460,6 +514,7 @@ class GroupCoordinator:
         weight_: torch.Tensor,
         eps: float,
         prefill_support: bool = False,
+        use_old_ca: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.device_communicator is None:
             raise ValueError("No device communicator found")
@@ -469,6 +524,7 @@ class GroupCoordinator:
             weight_,
             eps,
             prefill_support,
+            use_old_ca=use_old_ca,
         )
 
     def _fused_allreduce_rmsnorm_quant_out_place(
@@ -478,7 +534,9 @@ class GroupCoordinator:
         weight_: torch.Tensor,
         eps: float,
         prefill_support: bool = False,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        emit_bf16: bool = False,
+        use_old_ca: bool = False,
+    ):
         if self.device_communicator is None:
             raise ValueError("No device communicator found")
         return self.device_communicator.fused_allreduce_rmsnorm_quant(
@@ -487,6 +545,8 @@ class GroupCoordinator:
             weight_,
             eps,
             prefill_support,
+            emit_bf16=emit_bf16,
+            use_old_ca=use_old_ca,
         )
 
     def _all_gather_out_place(self, input_: torch.Tensor, dim: int = 0) -> torch.Tensor:

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -3,6 +3,8 @@
 
 from typing import List
 
+import torch
+
 from ..jit.core import compile_ops
 
 MD_NAME = "module_custom_all_reduce"
@@ -65,31 +67,52 @@ def all_gather_unreg(
 @compile_ops("module_custom_all_reduce", develop=True)
 def fused_allreduce_rmsnorm(
     _fa: int,
-    inp,
-    res_inp,
-    res_out,
-    out,
-    w,
+    inp: torch.Tensor,
+    res_inp: torch.Tensor,
+    res_out: torch.Tensor,
+    out: torch.Tensor,
+    w: torch.Tensor,
     eps: float,
     reg_ptr: int,
     reg_bytes: int,
     use_1stage: bool,
+    use_old_ca: bool = False,
 ) -> None: ...
 
 
 @compile_ops("module_custom_all_reduce", develop=True)
 def fused_allreduce_rmsnorm_quant(
     _fa: int,
-    inp,
-    res_inp,
-    res_out,
-    out,
-    scale_out,
-    w,
+    inp: torch.Tensor,
+    res_inp: torch.Tensor,
+    res_out: torch.Tensor,
+    out: torch.Tensor,
+    scale_out: torch.Tensor,
+    w: torch.Tensor,
     eps: float,
     reg_ptr: int,
     reg_bytes: int,
     use_1stage: bool,
+    bf16_out_ptr: int = 0,
+    use_old_ca: bool = False,
+) -> None: ...
+
+
+@compile_ops("module_custom_all_reduce", develop=True)
+def fused_allreduce_rmsnorm_quant_per_group(
+    _fa: int,
+    inp: torch.Tensor,
+    res_inp: torch.Tensor,
+    res_out: torch.Tensor,
+    out: torch.Tensor,
+    scale_out: torch.Tensor,
+    w: torch.Tensor,
+    eps: float,
+    group_size: int,
+    reg_ptr: int,
+    reg_bytes: int,
+    use_1stage: bool,
+    bf16_out_ptr: int = 0,
 ) -> None: ...
 
 

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -1149,7 +1149,15 @@ __global__ void __launch_bounds__(512, 1) reduce_scatter_cross_device_store(
         P rslt                           = *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id);
         tmps[warp_id][rank * part + idx] = rslt;
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    // NOTE: must use final_sync=false (RELEASE/ACQUIRE) here. Stage 2
+    // (local_device_load_rmsnorm*) on each rank reads `tmps` on the
+    // rank's own memory which contains IPC writes from peer ranks'
+    // stage 1 kernels. With final_sync=true (RELAXED) those cross-device
+    // writes are not guaranteed to be visible even after we observe the
+    // peers' end flags, and the kernel produces progressively corrupted
+    // output at per-rank volumes above ~1.2 MB (verified via
+    // sglang/benchmark/kernels/all_reduce/repro_ar_rmsnorm_corruption.py).
+    end_sync<ngpus, false>(sg, self_sg, rank);
 }
 
 template <int reduce_range>
@@ -1479,7 +1487,8 @@ __device__ __forceinline__ void ar_fusion_epilogue(A& in,
                                                    int block_size,
                                                    OutT* __restrict__ output,
                                                    float* __restrict__ scale_out,
-                                                   bool active = true)
+                                                   bool active        = true,
+                                                   T* __restrict__ bf16_output = nullptr)
 {
     if constexpr(std::is_same_v<T, OutT>)
     {
@@ -1497,6 +1506,18 @@ __device__ __forceinline__ void ar_fusion_epilogue(A& in,
         A out;
         ar_fusion_epilogue_rms_norm<P, A, A, float, PACK_SIZE>(
             out, in, weight, eps, hidden_dim, block_size);
+        // Optionally write the pre-quantization bf16 normed output so callers
+        // (e.g. SGLang Qwen3.5 sparse MoE gate / router experts) that also
+        // need an unquantized view can avoid running a second separate
+        // RMSNorm or paying for fp8 -> bf16 dequant later in the layer.
+        if(bf16_output != nullptr && active)
+        {
+            P bf16_pack;
+#pragma unroll
+            for(int i = 0; i < PACK_SIZE; ++i)
+                bf16_pack[i] = downcast_s<T>(out[i]);
+            *reinterpret_cast<P*>(bf16_output + idx) = bf16_pack;
+        }
         float amax  = ar_fusion_epilogue_reduce_abs_max<A, PACK_SIZE>(out, block_size);
         float scale = amax == 0.f ? 1.f : amax / FP8_UPBOUND;
         out_quant   = packQuant<opus::fp32_t, PACK_SIZE>(out, scale);
@@ -1505,6 +1526,182 @@ __device__ __forceinline__ void ar_fusion_epilogue(A& in,
         if(threadIdx.x == 0)
             scale_out[tidx] = scale;
     }
+}
+
+// Per-group FP8 quantization epilogue.
+// group_size is in elements (e.g. 128). Each group of group_size/PACK_SIZE
+// consecutive threads computes its own abs-max and scale independently.
+// scale_out layout: (M, hidden_dim / group_size), row-major.
+template <typename P, typename A, typename T, typename OutT, int PACK_SIZE>
+__device__ __forceinline__ void ar_fusion_epilogue_per_group(
+    A& in,
+    P& weight,
+    int hidden_dim,
+    float eps,
+    int idx,
+    int tidx,
+    int block_size,
+    int group_size,
+    OutT* __restrict__ output,
+    float* __restrict__ scale_out,
+    bool active = true,
+    T* __restrict__ bf16_output = nullptr)
+{
+    static_assert(!std::is_same_v<T, OutT>, "per-group quant requires FP8 output");
+    float FP8_UPBOUND = opus::cast<opus::fp32_t>(opus::numeric_limits<opus::fp8_t>::max());
+    using OP          = opus::vector_t<OutT, PACK_SIZE>;
+    A out;
+
+    // Phase 1: RMSNorm (full block reduction, same as per-token)
+    ar_fusion_epilogue_rms_norm<P, A, A, float, PACK_SIZE>(
+        out, in, weight, eps, hidden_dim, block_size);
+
+    // Optionally write the pre-quantization bf16 normed output so GDN-style
+    // layers that also need an unquantized view (e.g. Qwen3.5 in_proj_ba)
+    // can skip the extra separate per-group quant kernel entirely.
+    if(bf16_output != nullptr && active)
+    {
+        P bf16_pack;
+#pragma unroll
+        for(int i = 0; i < PACK_SIZE; ++i)
+            bf16_pack[i] = downcast_s<T>(out[i]);
+        *reinterpret_cast<P*>(bf16_output + idx) = bf16_pack;
+    }
+
+    // Phase 2: Per-group abs-max reduction and quantization
+    int threads_per_group = group_size / PACK_SIZE;
+    int group_id          = threadIdx.x / threads_per_group;
+    int lane_in_group     = threadIdx.x % threads_per_group;
+    int num_groups        = hidden_dim / group_size;
+
+    // Local abs-max across this thread's pack
+    auto fn   = [](float a, float b) { return a > b ? a : b; };
+    float local_max = -1.f;
+#pragma unroll
+    for(int i = 0; i < PACK_SIZE; ++i)
+    {
+        float v   = upcast_s(out[i]);
+        local_max = fn(local_max, std::abs(v));
+    }
+
+    // Sub-group reduction: reduce across threads_per_group threads
+    // Using shfl_xor with progressively smaller strides
+    for(int stride = threads_per_group / 2; stride > 0; stride >>= 1)
+    {
+        float other = __shfl_xor(local_max, stride, threads_per_group);
+        local_max   = fn(local_max, other);
+    }
+
+    // Now local_max holds the group-wide abs-max for all threads in this group
+    float scale = local_max == 0.f ? 1.f : local_max / FP8_UPBOUND;
+
+    // Quantize with per-group scale
+    OP out_quant = packQuant<opus::fp32_t, PACK_SIZE>(out, scale);
+    if(active)
+        *reinterpret_cast<OP*>(output + idx) = out_quant;
+
+    // Write per-group scale: one float per group per token
+    if(lane_in_group == 0 && active)
+        scale_out[tidx * num_groups + group_id] = scale;
+}
+
+// Per-group quant variant of the 1-stage fused allreduce+rmsnorm kernel.
+// scale_out shape: (m, hidden_dim / group_size) instead of (m, 1).
+template <typename T, typename OutT, int ngpus>
+__global__ void __launch_bounds__(1024, 1)
+    allreduce_fusion_kernel_1stage_per_group(RankData* _dp,
+                                             RankSignals sg,
+                                             Signal* self_sg,
+                                             int rank,
+                                             T* __restrict__ residual_inp,
+                                             T* __restrict__ residual_out,
+                                             OutT* __restrict__ output,
+                                             T* __restrict__ weight,
+                                             float* __restrict__ scale_out,
+                                             int size,
+                                             int hidden_dim,
+                                             int group_size,
+                                             float eps,
+                                             T* __restrict__ bf16_output = nullptr)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    int block_size          = hidden_dim / pack_size;
+    bool active             = (int)threadIdx.x < block_size;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int tidx                = blockIdx.x;
+    int access_id_in_token  = threadIdx.x * pack_size;
+    int idx                 = tidx * hidden_dim + access_id_in_token;
+    const P* ptrs[ngpus];
+    P* tmps[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        ptrs[i] = (const P*)_dp->ptrs[i];
+        tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    A acc{};
+    P vec{};
+    P weight_p{};
+    if(active)
+    {
+        vec = ptrs[0][idx / pack_size];
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            acc[v] = upcast_s(vec[v]);
+
+#pragma unroll
+        for(int r = 1; r < ngpus; ++r)
+        {
+            vec = ptrs[r][idx / pack_size];
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+                acc[v] += upcast_s(vec[v]);
+        }
+
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            acc[v] = upcast_s(downcast_s<T>(acc[v]));
+
+        P res = *reinterpret_cast<P*>(residual_inp + idx);
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            acc[v] += upcast_s(res[v]);
+
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            vec[v] = downcast_s<T>(acc[v]);
+
+        *reinterpret_cast<P*>(residual_out + idx) = vec;
+        weight_p = *reinterpret_cast<P*>(weight + access_id_in_token);
+    }
+    int padded_block_size = (int)blockDim.x;
+    ar_fusion_epilogue_per_group<P, A, T, OutT, pack_size>(
+        acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size,
+        group_size, output, scale_out, active, bf16_output);
+}
+
+template <typename T, typename OutT, int NGPUS>
+void allreduce_fusion_kernel_1stage_per_group_launcher(
+    RankData* _dp, RankSignals sg, Signal* self_sg, int rank,
+    T* residual_inp, T* residual_out, OutT* output, T* weight,
+    float* scale_out, int size, int hidden_dim, int group_size,
+    float eps, hipStream_t stream, T* bf16_output = nullptr)
+{
+    auto pack_size  = 16 / sizeof(T);
+    int block_size  = hidden_dim / pack_size;
+    int padded_size = (block_size + 31) / 32 * 32;
+    int m           = size / hidden_dim;
+    dim3 grid(m);
+    dim3 block(padded_size);
+    allreduce_fusion_kernel_1stage_per_group<T, OutT, NGPUS>
+        <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank,
+                                     residual_inp, residual_out,
+                                     output, weight, scale_out,
+                                     size, hidden_dim, group_size, eps,
+                                     bf16_output);
 }
 
 template <typename T, typename OutT, int ngpus>
@@ -1520,7 +1717,8 @@ __global__ void __launch_bounds__(1024, 1)
                                    float* __restrict__ scale_out,
                                    int size,
                                    int hidden_dim,
-                                   float eps)
+                                   float eps,
+                                   T* __restrict__ bf16_output = nullptr)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -1592,7 +1790,7 @@ __global__ void __launch_bounds__(1024, 1)
     // padded threads participate in reduction with zero acc but skip output writes
     int padded_block_size = (int)blockDim.x;
     ar_fusion_epilogue<P, A, T, OutT, pack_size>(
-        acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size, output, scale_out, active);
+        acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size, output, scale_out, active, bf16_output);
 }
 
 template <typename T, typename OutT, int NGPUS>
@@ -1608,7 +1806,8 @@ void allreduce_fusion_kernel_1stage_launcher(RankData* _dp,
                                              int size,
                                              int hidden_dim,
                                              float eps,
-                                             hipStream_t stream)
+                                             hipStream_t stream,
+                                             T* bf16_output = nullptr)
 {
     constexpr int PACK_SIZE  = 16 / sizeof(T);
     constexpr int WARP_SIZE  = 32;
@@ -1633,7 +1832,321 @@ void allreduce_fusion_kernel_1stage_launcher(RankData* _dp,
                                                     scale_out,
                                                     size,
                                                     hidden_dim,
-                                                    eps);
+                                                    eps,
+                                                    bf16_output);
+}
+
+// ---------------------------------------------------------------------------
+// old-CA fused single-kernel path
+//
+// Identical to allreduce_fusion_kernel_1stage (peer-pointer cross-rank load +
+// residual add + RMSNorm + optional per-token FP8 quant via ar_fusion_epilogue
+// + optional bf16 mirror), but emits an explicit end_sync<ngpus, true> at the
+// end so the collective slot is released following the same start/end-sync
+// discipline as the legacy ("old") custom_all_reduce primitive. This lets the
+// fused kernel be safely interleaved with other old-CA all_reduce calls when
+// SGLANG_USE_AITER_NEW_CA=false on the SGLang side, while keeping the entire
+// add+rmsnorm+quant epilogue (including the bf16 side-output added for
+// per-token quant) byte-identical to the new-CA fused kernel.
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// old-CA fused split path (for token_num > kMaxBlocks)
+//
+// Reads the already-allreduced tensor `reduce_out` (produced by an old-CA
+// CustomAllreduce::allreduce<T>(...) call) plus the BF16 residual_inp, runs
+// residual add + RMSNorm + per-token FP8 quant, and writes the FP8 output,
+// per-token scale, residual_out, and (optionally) the pre-quantization BF16
+// normed view used by the SGLang Qwen3.5 sparse-MoE gate / shared-expert
+// fanout. Numerics mirror allreduce_fusion_kernel_1stage_old_ca exactly:
+// upcast(downcast(ar)) before adding residual, write residual_out as the
+// post-add BF16 sum, then RMSNorm + per-token quant on the f32 result.
+// Layout matches the reverted-commit local_tensor_load_rmsnorm template
+// (tnum threads, n_loop packs per thread along the hidden dim).
+// ---------------------------------------------------------------------------
+template <typename T, typename OutT, int tnum, int n_loop>
+__global__ void __launch_bounds__(tnum, 1) local_tensor_load_rmsnorm_quant(
+    T* __restrict__ reduce_out,
+    T* __restrict__ residual_inp,
+    T* __restrict__ residual_out,
+    OutT* __restrict__ output,
+    T* __restrict__ weight,
+    float* __restrict__ scale_out,
+    float eps,
+    int m,
+    int n,
+    T* __restrict__ bf16_output)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using OP                = typename opus::vector_t<OutT, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    __shared__ float smem[tnum];
+
+    for(int bid = blockIdx.x; bid < m; bid += gridDim.x)
+    {
+        float square_sum = 0.0f;
+        A rms_inp_f32[n_loop];
+        P w_arr[n_loop];
+#pragma unroll
+        for(int n_iter = 0; n_iter < n_loop; ++n_iter)
+        {
+            if(n_iter * tnum + threadIdx.x < (n / pack_size))
+            {
+                int read_idx        = bid * (n / pack_size) + n_iter * tnum + threadIdx.x;
+                P reduce_out_pack   = *(reinterpret_cast<P*>(reduce_out) + read_idx);
+                P residual_inp_pack = *(reinterpret_cast<P*>(residual_inp) + read_idx);
+                w_arr[n_iter]       = *(reinterpret_cast<P*>(weight) + n_iter * tnum + threadIdx.x);
+                A reduce_pack;
+#pragma unroll
+                for(int i = 0; i < pack_size; ++i)
+                {
+                    // reduce_out is already BF16/FP16 (written by the prior
+                    // old-CA allreduce<T> call), so the bf16 round-trip done
+                    // inside the 1stage_old_ca kernel (which still has the
+                    // f32 cross-rank accumulator) is unnecessary here.
+                    float ar_out  = upcast_s(reduce_out_pack[i]);
+                    float res_inp = upcast_s(residual_inp_pack[i]);
+                    float rms_inp = ar_out + res_inp;
+                    rms_inp_f32[n_iter][i] = rms_inp;
+                    reduce_pack[i] = rms_inp * rms_inp;
+                }
+                square_sum += packReduce<AddFunctor, float, pack_size>(reduce_pack);
+            }
+        }
+        smem[threadIdx.x] = square_sum;
+        __syncthreads();
+        smemReduceSum<tnum>(&smem[0]);
+        square_sum  = smem[0];
+        float denom = rsqrtf(square_sum / n + eps);
+
+        if constexpr(std::is_same_v<T, OutT>)
+        {
+            // BF16/FP16 output path (no quant): compute and write rmsnorm
+            // result + residual_out, identical layout to the reverted-commit
+            // local_tensor_load_rmsnorm.
+#pragma unroll
+            for(int n_iter = 0; n_iter < n_loop; ++n_iter)
+            {
+                if(n_iter * tnum + threadIdx.x < (n / pack_size))
+                {
+                    P rmsnorm_rslt;
+                    P rmsnorm_inp;
+#pragma unroll
+                    for(int i = 0; i < pack_size; ++i)
+                    {
+                        float x_f32     = rms_inp_f32[n_iter][i];
+                        float w_f32     = upcast_s(w_arr[n_iter][i]);
+                        rmsnorm_inp[i]  = downcast_s<T>(x_f32);
+                        rmsnorm_rslt[i] = downcast_s<T>(x_f32 * w_f32 * denom);
+                    }
+                    int write_idx = bid * (n / pack_size) + n_iter * tnum + threadIdx.x;
+                    *(reinterpret_cast<P*>(output) + write_idx)       = rmsnorm_rslt;
+                    *(reinterpret_cast<P*>(residual_out) + write_idx) = rmsnorm_inp;
+                }
+            }
+        }
+        else
+        {
+            // Per-token FP8 quant path: first compute the f32 normed values
+            // (and write residual_out + optional bf16 mirror), then reduce
+            // abs-max across threads to build a per-token scale, then quant
+            // and write the FP8 packs.
+            float FP8_UPBOUND = opus::cast<opus::fp32_t>(opus::numeric_limits<opus::fp8_t>::max());
+            A normed[n_loop];
+            float local_amax = 0.0f;
+#pragma unroll
+            for(int n_iter = 0; n_iter < n_loop; ++n_iter)
+            {
+                if(n_iter * tnum + threadIdx.x < (n / pack_size))
+                {
+                    P rmsnorm_inp;
+#pragma unroll
+                    for(int i = 0; i < pack_size; ++i)
+                    {
+                        float x_f32       = rms_inp_f32[n_iter][i];
+                        float w_f32       = upcast_s(w_arr[n_iter][i]);
+                        float normed_val  = x_f32 * w_f32 * denom;
+                        normed[n_iter][i] = normed_val;
+                        rmsnorm_inp[i]    = downcast_s<T>(x_f32);
+                        float abs_val     = fabsf(normed_val);
+                        local_amax        = local_amax > abs_val ? local_amax : abs_val;
+                    }
+                    int write_idx = bid * (n / pack_size) + n_iter * tnum + threadIdx.x;
+                    *(reinterpret_cast<P*>(residual_out) + write_idx) = rmsnorm_inp;
+                    if(bf16_output != nullptr)
+                    {
+                        P bf16_pack;
+#pragma unroll
+                        for(int i = 0; i < pack_size; ++i)
+                            bf16_pack[i] = downcast_s<T>(normed[n_iter][i]);
+                        *(reinterpret_cast<P*>(bf16_output) + write_idx) = bf16_pack;
+                    }
+                }
+            }
+
+            // amax reduction across the whole token (tnum threads).
+            __syncthreads();
+            smem[threadIdx.x] = local_amax;
+            __syncthreads();
+            for(int s = tnum / 2; s > 0; s >>= 1)
+            {
+                if((int)threadIdx.x < s)
+                {
+                    float a = smem[threadIdx.x];
+                    float b = smem[threadIdx.x + s];
+                    smem[threadIdx.x] = a > b ? a : b;
+                }
+                __syncthreads();
+            }
+            float amax  = smem[0];
+            float scale = amax == 0.f ? 1.f : amax / FP8_UPBOUND;
+
+            // Quant + write FP8 packs (uses the same packQuant helper as the
+            // per-pack ar_fusion_epilogue path so per-token outputs are
+            // byte-identical regardless of which old-CA path runs).
+#pragma unroll
+            for(int n_iter = 0; n_iter < n_loop; ++n_iter)
+            {
+                if(n_iter * tnum + threadIdx.x < (n / pack_size))
+                {
+                    OP fp8_pack = packQuant<opus::fp32_t, pack_size>(normed[n_iter], scale);
+                    int write_idx = bid * (n / pack_size) + n_iter * tnum + threadIdx.x;
+                    *(reinterpret_cast<OP*>(output) + write_idx) = fp8_pack;
+                }
+            }
+            if(threadIdx.x == 0)
+                scale_out[bid] = scale;
+        }
+    }
+}
+
+template <typename T, typename OutT, int ngpus>
+__global__ void __launch_bounds__(1024, 1)
+    allreduce_fusion_kernel_1stage_old_ca(RankData* _dp,
+                                          RankSignals sg,
+                                          Signal* self_sg,
+                                          int rank,
+                                          T* __restrict__ residual_inp,
+                                          T* __restrict__ residual_out,
+                                          OutT* __restrict__ output,
+                                          T* __restrict__ weight,
+                                          float* __restrict__ scale_out,
+                                          int size,
+                                          int hidden_dim,
+                                          float eps,
+                                          T* __restrict__ bf16_output = nullptr)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    int block_size          = hidden_dim / pack_size;
+    bool active             = (int)threadIdx.x < block_size;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int tidx                = blockIdx.x;
+    int access_id_in_token  = threadIdx.x * pack_size;
+    int idx                 = tidx * hidden_dim + access_id_in_token;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        ptrs[i] = (const P*)_dp->ptrs[i];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    A acc{};
+    P vec{};
+    P weight_p{};
+    if(active)
+    {
+        vec = ptrs[0][idx / pack_size];
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            acc[v] = upcast_s(vec[v]);
+        }
+
+#pragma unroll
+        for(int r = 1; r < ngpus; ++r)
+        {
+            vec = ptrs[r][idx / pack_size];
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+            {
+                acc[v] += upcast_s(vec[v]);
+            }
+        }
+
+        // Match unfused allreduce -> bf16 -> add residual numerics; without this
+        // round trip, extra f32 mantissa bits cause 1-ULP divergence that
+        // compounds across layers.
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            acc[v] = upcast_s(downcast_s<T>(acc[v]));
+        }
+
+        P res = *reinterpret_cast<P*>(residual_inp + idx);
+
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            acc[v] += upcast_s(res[v]);
+        }
+
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            vec[v] = downcast_s<T>(acc[v]);
+        }
+
+        *reinterpret_cast<P*>(residual_out + idx) = vec;
+        weight_p = *reinterpret_cast<P*>(weight + access_id_in_token);
+    }
+    int padded_block_size = (int)blockDim.x;
+    ar_fusion_epilogue<P, A, T, OutT, pack_size>(
+        acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size, output, scale_out, active, bf16_output);
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+template <typename T, typename OutT, int NGPUS>
+void allreduce_fusion_kernel_1stage_old_ca_launcher(RankData* _dp,
+                                                    RankSignals sg,
+                                                    Signal* self_sg,
+                                                    int rank,
+                                                    T* residual_inp,
+                                                    T* residual_out,
+                                                    OutT* output,
+                                                    T* weight,
+                                                    float* scale_out,
+                                                    int size,
+                                                    int hidden_dim,
+                                                    float eps,
+                                                    hipStream_t stream,
+                                                    T* bf16_output = nullptr)
+{
+    constexpr int PACK_SIZE  = 16 / sizeof(T);
+    constexpr int WARP_SIZE  = 32;
+    int BLOCK_SIZE           = hidden_dim / PACK_SIZE;
+    int LAUNCH_THREADS       = ((BLOCK_SIZE + WARP_SIZE - 1) / WARP_SIZE) * WARP_SIZE;
+    int token_num            = size / hidden_dim;
+    if(token_num > kMaxBlocks)
+        throw std::runtime_error(
+            "Token number is too large for allreduce_fusion_kernel_1stage_old_ca kernel");
+    dim3 threadsPerBlock(LAUNCH_THREADS);
+    dim3 numBlocks(token_num);
+    allreduce_fusion_kernel_1stage_old_ca<T, OutT, NGPUS>
+        <<<numBlocks, threadsPerBlock, 0, stream>>>(_dp,
+                                                    sg,
+                                                    self_sg,
+                                                    rank,
+                                                    residual_inp,
+                                                    residual_out,
+                                                    output,
+                                                    weight,
+                                                    scale_out,
+                                                    size,
+                                                    hidden_dim,
+                                                    eps,
+                                                    bf16_output);
 }
 
 template <typename T, typename OutT, int ngpus>
@@ -1649,7 +2162,8 @@ __global__ void __launch_bounds__(1024, 1)
                                    float* __restrict__ scale_out,
                                    int size,
                                    int hidden_dim,
-                                   float eps)
+                                   float eps,
+                                   T* __restrict__ bf16_output = nullptr)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -1727,7 +2241,7 @@ __global__ void __launch_bounds__(1024, 1)
             acc[v] = upcast_s(vec[v]);
         }
         ar_fusion_epilogue<P, A, T, OutT, pack_size>(
-            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out);
+            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out, /*active=*/true, bf16_output);
     }
 }
 
@@ -1744,7 +2258,8 @@ void allreduce_fusion_kernel_2stage_launcher(RankData* _dp,
                                              int size,
                                              int hidden_dim,
                                              float eps,
-                                             hipStream_t stream)
+                                             hipStream_t stream,
+                                             T* bf16_output = nullptr)
 {
     constexpr int PACK_SIZE = 16 / sizeof(T);
     int BLOCK_SIZE          = hidden_dim / PACK_SIZE;
@@ -1765,7 +2280,117 @@ void allreduce_fusion_kernel_2stage_launcher(RankData* _dp,
                                                             scale_out,
                                                             size,
                                                             hidden_dim,
-                                                            eps);
+                                                            eps,
+                                                            bf16_output);
+}
+
+// Per-group quant variant of the 2-stage kernel.
+template <typename T, typename OutT, int ngpus>
+__global__ void __launch_bounds__(1024, 1)
+    allreduce_fusion_kernel_2stage_per_group(RankData* _dp,
+                                             RankSignals sg,
+                                             Signal* self_sg,
+                                             int rank,
+                                             T* __restrict__ residual_inp,
+                                             T* __restrict__ residual_out,
+                                             OutT* __restrict__ output,
+                                             T* __restrict__ weight,
+                                             float* __restrict__ scale_out,
+                                             int size,
+                                             int hidden_dim,
+                                             int group_size,
+                                             float eps,
+                                             T* __restrict__ bf16_output = nullptr)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    int block_size          = hidden_dim / pack_size;
+    int tnum_gpu            = block_size / ngpus;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    extern __shared__ char smem_buf[];
+    P* tmp_smem = reinterpret_cast<P*>(smem_buf);
+    int warp_id = threadIdx.x / tnum_gpu;
+    int lane_id = threadIdx.x % tnum_gpu;
+    const P* ptrs[ngpus];
+    P* tmps[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        ptrs[i] = (const P*)_dp->ptrs[i];
+        tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+    }
+    A acc;
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    for(int idx = ((blockIdx.x * ngpus + rank) * tnum_gpu + lane_id) * pack_size; idx < size;
+        idx += gridDim.x * ngpus * tnum_gpu * pack_size)
+    {
+        P vec                 = ptrs[warp_id][idx / pack_size];
+        tmp_smem[threadIdx.x] = vec;
+        __syncthreads();
+        if(warp_id == 0)
+        {
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+                acc[v] = upcast_s(vec[v]);
+#pragma unroll
+            for(int r = 1; r < ngpus; ++r)
+            {
+                vec = tmp_smem[r * tnum_gpu + lane_id];
+#pragma unroll
+                for(int v = 0; v < pack_size; ++v)
+                    acc[v] += upcast_s(vec[v]);
+            }
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+                vec[v] = downcast_s<T>(acc[v]);
+            tmp_smem[lane_id] = vec;
+        }
+        __syncthreads();
+        vec                            = tmp_smem[lane_id];
+        tmps[warp_id][idx / pack_size] = vec;
+    }
+
+    int access_id_in_token = threadIdx.x * pack_size;
+    P weight_p             = *reinterpret_cast<P*>(weight + access_id_in_token);
+    end_sync<ngpus>(sg, self_sg, rank);
+    for(int idx = blockIdx.x * hidden_dim + access_id_in_token, tidx = blockIdx.x; idx < size;
+        idx += gridDim.x * hidden_dim, tidx += gridDim.x)
+    {
+        P vec = tmps[rank][idx / pack_size];
+        P res = *reinterpret_cast<P*>(residual_inp + idx);
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            vec[v] += res[v];
+        *reinterpret_cast<P*>(residual_out + idx) = vec;
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            acc[v] = upcast_s(vec[v]);
+        ar_fusion_epilogue_per_group<P, A, T, OutT, pack_size>(
+            acc, weight_p, hidden_dim, eps, idx, tidx, block_size,
+            group_size, output, scale_out, /*active=*/true, bf16_output);
+    }
+}
+
+template <typename T, typename OutT, int NGPUS>
+void allreduce_fusion_kernel_2stage_per_group_launcher(
+    RankData* _dp, RankSignals sg, Signal* self_sg, int rank,
+    T* residual_inp, T* residual_out, OutT* output, T* weight,
+    float* scale_out, int size, int hidden_dim, int group_size,
+    float eps, hipStream_t stream, T* bf16_output = nullptr)
+{
+    constexpr int PACK_SIZE = 16 / sizeof(T);
+    int BLOCK_SIZE          = hidden_dim / PACK_SIZE;
+    int token_num           = size / hidden_dim;
+    dim3 threadsPerBlock(BLOCK_SIZE);
+    token_num = std::min(token_num, kMaxBlocks);
+    dim3 numBlocks(token_num);
+    size_t smem_size = BLOCK_SIZE * sizeof(typename opus::vector_t<T, PACK_SIZE>);
+    allreduce_fusion_kernel_2stage_per_group<T, OutT, NGPUS>
+        <<<numBlocks, threadsPerBlock, smem_size, stream>>>(
+            _dp, sg, self_sg, rank,
+            residual_inp, residual_out, output, weight, scale_out,
+            size, hidden_dim, group_size, eps, bf16_output);
 }
 
 template <typename T, typename OutT>
@@ -1779,7 +2404,8 @@ __global__ void __launch_bounds__(1024, 1)
                                           float* __restrict__ scale_out,
                                           int size,
                                           int hidden_dim,
-                                          float eps)
+                                          float eps,
+                                          T* __restrict__ bf16_output = nullptr)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -1806,8 +2432,100 @@ __global__ void __launch_bounds__(1024, 1)
             acc[v] = upcast_s(vec[v]);
         }
         ar_fusion_epilogue<P, A, T, OutT, pack_size>(
-            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out);
+            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out, /*active=*/true, bf16_output);
     }
+}
+
+// Per-group quant variant of the naive local device load kernel.
+template <typename T, typename OutT>
+__global__ void __launch_bounds__(1024, 1)
+    local_device_load_rmsnorm_quant_per_group_naive(RankSignals sg,
+                                                    int rank,
+                                                    T* __restrict__ residual_inp,
+                                                    T* __restrict__ residual_out,
+                                                    OutT* __restrict__ output,
+                                                    T* __restrict__ weight,
+                                                    float* __restrict__ scale_out,
+                                                    int size,
+                                                    int hidden_dim,
+                                                    int group_size,
+                                                    float eps,
+                                                    T* __restrict__ bf16_output = nullptr)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    int block_size          = hidden_dim / pack_size;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    P* tmps                 = get_tmp_buf<P>(sg.signals[rank]);
+    int access_id_in_token  = threadIdx.x * pack_size;
+    P weight_p              = *reinterpret_cast<P*>(weight + access_id_in_token);
+    int idx                 = blockIdx.x * hidden_dim + access_id_in_token;
+    int tidx                = blockIdx.x;
+    {
+        A acc;
+        P vec = tmps[idx / pack_size];
+        P res = *reinterpret_cast<P*>(residual_inp + idx);
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            vec[v] += res[v];
+        *reinterpret_cast<P*>(residual_out + idx) = vec;
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            acc[v] = upcast_s(vec[v]);
+        ar_fusion_epilogue_per_group<P, A, T, OutT, pack_size>(
+            acc, weight_p, hidden_dim, eps, idx, tidx, block_size,
+            group_size, output, scale_out, /*active=*/true, bf16_output);
+    }
+}
+
+template <typename T, typename OutT, int NGPUS>
+void allreduce_fusion_kernel_split_per_group_launcher(RankData* _dp,
+                                                      RankSignals sg,
+                                                      Signal* self_sg,
+                                                      int rank,
+                                                      T* residual_inp,
+                                                      T* residual_out,
+                                                      OutT* output,
+                                                      T* weight,
+                                                      float* scale_out,
+                                                      int size,
+                                                      int hidden_dim,
+                                                      int group_size,
+                                                      float eps,
+                                                      hipStream_t stream,
+                                                      T* bf16_output = nullptr)
+{
+    // step 1: reduce-scatter + allgather cross device store (same as per-token)
+    dim3 block(512);
+    int block_num = ((size / NGPUS) + 512 - 1) / 512;
+    dim3 grid(std::min(block_num, 80));
+    switch(NGPUS)
+    {
+    case 8:
+        reduce_scatter_cross_device_store<T, 8>
+            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, size);
+        break;
+    case 4:
+        reduce_scatter_cross_device_store<T, 4>
+            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, size);
+        break;
+    case 2:
+        reduce_scatter_cross_device_store<T, 2>
+            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, size);
+        break;
+    default:
+        throw std::runtime_error("unsupported NGPUS=" + std::to_string(NGPUS));
+    }
+    // step 2: local device load + rmsnorm + per-group quant (+ optional bf16 mirror)
+    constexpr int PACK_SIZE = 16 / sizeof(T);
+    int BLOCK_SIZE          = hidden_dim / PACK_SIZE;
+    int nblocks             = size / hidden_dim;
+    dim3 threadsPerBlock(BLOCK_SIZE);
+    dim3 numBlocks(nblocks);
+    local_device_load_rmsnorm_quant_per_group_naive<T, OutT>
+        <<<numBlocks, threadsPerBlock, 0, stream>>>(
+            sg, rank, residual_inp, residual_out, output, weight, scale_out,
+            size, hidden_dim, group_size, eps, bf16_output);
 }
 
 template <typename T, typename OutT, int NGPUS>
@@ -1823,7 +2541,8 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
                                             int size,
                                             int hidden_dim,
                                             float eps,
-                                            hipStream_t stream)
+                                            hipStream_t stream,
+                                            T* bf16_output = nullptr)
 {
     // step 1, run reduce-scatter + allgather cross device save
     dim3 block(512);
@@ -1845,7 +2564,7 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
         break;
     default: throw std::runtime_error("fused allreduce rmsnorm: unsupported NGPUS=" + std::to_string(NGPUS));
     }
-    // step 2, run allgather local device load + rmsnorm + quant
+    // step 2, run allgather local device load + rmsnorm + quant (+ optional bf16 mirror)
     constexpr int PACK_SIZE = 16 / sizeof(T);
     int BLOCK_SIZE          = hidden_dim / PACK_SIZE;
     int nblocks             = size / hidden_dim;
@@ -1853,7 +2572,7 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
     dim3 numBlocks(nblocks);
     local_device_load_rmsnorm_quant_naive<T, OutT>
         <<<numBlocks, threadsPerBlock, 0, stream>>>(
-            sg, rank, residual_inp, residual_out, output, weight, scale_out, size, hidden_dim, eps);
+            sg, rank, residual_inp, residual_out, output, weight, scale_out, size, hidden_dim, eps, bf16_output);
 }
 
 using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
@@ -2538,7 +3257,8 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
                                    float eps,
                                    int m,
                                    int n,
-                                   bool use_1stage)
+                                   bool use_1stage,
+                                   bool use_old_ca = false)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -2555,8 +3275,131 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
     hipGetDeviceProperties(&dev_prop, dev);
     uint32_t num_cu = dev_prop.multiProcessorCount;
 
-    auto pack_size = 16 / sizeof(T);
-    use_1stage     = use_1stage && (n % pack_size == 0) && (n / pack_size <= 1024);
+    auto pack_size   = 16 / sizeof(T);
+    bool n_constrain = (n % pack_size == 0) && (n / pack_size <= 1024);
+    use_1stage       = use_1stage && n_constrain;
+
+    // ----- old-CA fused (norm-only) dispatch ----------------------------
+    // SGLANG_USE_AITER_NEW_CA=false routes the standalone all-reduce calls
+    // through the legacy custom_all_reduce. The fused AR + add + RMSNorm
+    // kernel must follow the same start/end-sync discipline so it can
+    // interleave with those calls without racing on the ring-buffer slot.
+    // Reuses allreduce_fusion_kernel_1stage_old_ca and
+    // local_tensor_load_rmsnorm_quant in their OutT == T specializations,
+    // which natively skip per-token quant and bf16 side-output writes
+    // (scale_out / bf16_output are unused in that path and passed nullptr).
+    if(use_old_ca)
+    {
+        if(use_1stage && (m <= kMaxBlocks))
+        {
+#define DISPATCH_OLD_CA_1S_NORM_ONLY_KERNEL(NGPUS)                                  \
+    allreduce_fusion_kernel_1stage_old_ca_launcher<T, T, NGPUS>(ptrs,               \
+                                                                sg_,                \
+                                                                self_sg_,           \
+                                                                rank_,              \
+                                                                residual_inp,       \
+                                                                residual_out,       \
+                                                                output,             \
+                                                                weight,             \
+                                                                /*scale_out=*/nullptr, \
+                                                                size,               \
+                                                                n,                  \
+                                                                eps,                \
+                                                                stream,             \
+                                                                /*bf16_output=*/nullptr); \
+    return;
+            switch(world_size_)
+            {
+            case 8: DISPATCH_OLD_CA_1S_NORM_ONLY_KERNEL(8); break;
+            case 4: DISPATCH_OLD_CA_1S_NORM_ONLY_KERNEL(4); break;
+            case 2: DISPATCH_OLD_CA_1S_NORM_ONLY_KERNEL(2); break;
+            default:
+                throw std::runtime_error(
+                    "old-CA fused allreduce rmsnorm: unsupported world_size=" +
+                    std::to_string(world_size_));
+            }
+#undef DISPATCH_OLD_CA_1S_NORM_ONLY_KERNEL
+        }
+
+        // Split path (large batch / m > kMaxBlocks): standalone old-CA
+        // all-reduce (use_new=false) into residual_out, then
+        // local_tensor_load_rmsnorm_quant<T, T, ...> which in the OutT == T
+        // specialization runs add + RMSNorm and writes BF16 output +
+        // residual_out (scale_out / bf16_output are nullptr in this norm-only
+        // path).
+        if(n_constrain)
+        {
+            allreduce<T>(stream, input, residual_out, size, /*use_new=*/false);
+
+            dim3 block(512);
+            dim3 grid;
+            auto setGrid = [&](int naive_grid_size, const void* kernel_ptr) {
+                int occupancy;
+                hipOccupancyMaxActiveBlocksPerMultiprocessor(&occupancy, kernel_ptr, block.x, 0);
+                grid.x =
+                    naive_grid_size < num_cu * occupancy ? naive_grid_size : num_cu * occupancy;
+            };
+
+#define LAUNCH_OLD_CA_NORM_ONLY_SPLIT(template_kernel)                                          \
+    do                                                                                          \
+    {                                                                                           \
+        auto kernel_ptr = reinterpret_cast<const void*>(template_kernel);                       \
+        setGrid(naive_grid_size, kernel_ptr);                                                   \
+        template_kernel<<<grid, block, 0, stream>>>(                                            \
+            residual_out, residual_inp, residual_out, output, weight, /*scale_out=*/nullptr,    \
+            eps, m, n, /*bf16_output=*/nullptr);                                                \
+    } while(0)
+
+            constexpr int ar_pack_size = 16 / sizeof(T);
+            int n_packs                = n / ar_pack_size;
+            int naive_grid_size        = m;
+            if(n_packs >= 256)
+            {
+                int n_loop = (n_packs + 511) / 512;
+                switch(n_loop)
+                {
+                case 1: LAUNCH_OLD_CA_NORM_ONLY_SPLIT((local_tensor_load_rmsnorm_quant<T, T, 512, 1>)); break;
+                case 2: LAUNCH_OLD_CA_NORM_ONLY_SPLIT((local_tensor_load_rmsnorm_quant<T, T, 512, 2>)); break;
+                case 3: LAUNCH_OLD_CA_NORM_ONLY_SPLIT((local_tensor_load_rmsnorm_quant<T, T, 512, 3>)); break;
+                case 4: LAUNCH_OLD_CA_NORM_ONLY_SPLIT((local_tensor_load_rmsnorm_quant<T, T, 512, 4>)); break;
+                default:
+                    throw std::runtime_error(
+                        "old-CA fused allreduce rmsnorm: n too large, m=" +
+                        std::to_string(m) + " n=" + std::to_string(n));
+                }
+            }
+            else if(n_packs >= 64)
+            {
+                block.x    = 256;
+                int n_loop = (n_packs + 255) / 256;
+                switch(n_loop)
+                {
+                case 1: LAUNCH_OLD_CA_NORM_ONLY_SPLIT((local_tensor_load_rmsnorm_quant<T, T, 256, 1>)); break;
+                case 2: LAUNCH_OLD_CA_NORM_ONLY_SPLIT((local_tensor_load_rmsnorm_quant<T, T, 256, 2>)); break;
+                default:
+                    throw std::runtime_error(
+                        "old-CA fused allreduce rmsnorm: n too large for tnum=256, m=" +
+                        std::to_string(m) + " n=" + std::to_string(n));
+                }
+            }
+            else
+            {
+                throw std::runtime_error(
+                    "old-CA fused allreduce rmsnorm: n too small, m=" + std::to_string(m) +
+                    " n=" + std::to_string(n) + " n_packs=" + std::to_string(n_packs) +
+                    " (need n_packs >= 64, i.e. n >= " + std::to_string(64 * ar_pack_size) +
+                    ")");
+            }
+#undef LAUNCH_OLD_CA_NORM_ONLY_SPLIT
+            return;
+        }
+
+        throw std::runtime_error(
+            "old-CA fused allreduce rmsnorm: hidden_dim out of range (n=" +
+            std::to_string(n) + ")");
+    }
+    // ----- end old-CA fused (norm-only) dispatch ------------------------
+
 #define MAYBE_DISPATCH_1S_KERNEL(NGPUS)                                            \
     if(use_1stage)                                                                 \
     {                                                                              \
@@ -2734,7 +3577,9 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
                                         float eps,
                                         int m,
                                         int n,
-                                        bool use_1stage)
+                                        bool use_1stage,
+                                        T* bf16_output = nullptr,
+                                        bool use_old_ca = false)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -2748,6 +3593,134 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
 
     auto pack_size   = 16 / sizeof(T);
     bool n_constrain = (n % pack_size == 0) && (n / pack_size <= 1024);
+
+    // ----- old-CA fused dispatch ----------------------------------------
+    // When SGLang sets SGLANG_USE_AITER_NEW_CA=false, the all-reduce primitive
+    // used elsewhere in the model is the legacy ("old") custom_all_reduce. The
+    // fused AR + add + RMSNorm + per-token quant kernel has to follow the same
+    // start/end-sync discipline so it can interleave with those calls without
+    // racing on the ring-buffer slot. The `+ add + rmsnorm + quant` epilogue
+    // (ar_fusion_epilogue, including the bf16 side-output) is reused as-is —
+    // only the AR half is swapped to old-CA.
+    if(use_old_ca)
+    {
+        if(use_1stage && n_constrain && (m <= kMaxBlocks))
+        {
+#define DISPATCH_OLD_CA_1S_FUSED_KERNEL(NGPUS)                                            \
+    allreduce_fusion_kernel_1stage_old_ca_launcher<T, QT, NGPUS>(ptrs,                    \
+                                                                 sg_,                     \
+                                                                 self_sg_,                \
+                                                                 rank_,                   \
+                                                                 residual_inp,            \
+                                                                 residual_out,            \
+                                                                 output,                  \
+                                                                 weight,                  \
+                                                                 scale_out,               \
+                                                                 size,                    \
+                                                                 n,                       \
+                                                                 eps,                     \
+                                                                 stream,                  \
+                                                                 bf16_output);            \
+    return;
+            switch(world_size_)
+            {
+            case 8: DISPATCH_OLD_CA_1S_FUSED_KERNEL(8); break;
+            case 4: DISPATCH_OLD_CA_1S_FUSED_KERNEL(4); break;
+            case 2: DISPATCH_OLD_CA_1S_FUSED_KERNEL(2); break;
+            default:
+                throw std::runtime_error(
+                    "old-CA fused allreduce rmsnorm quant: unsupported world_size=" +
+                    std::to_string(world_size_));
+            }
+#undef DISPATCH_OLD_CA_1S_FUSED_KERNEL
+        }
+
+        // Split path: run a standalone old-CA all-reduce (use_new=false) into
+        // residual_out (which is otherwise overwritten by the epilogue), then
+        // launch local_tensor_load_rmsnorm_quant which reads
+        // (reduce_out=residual_out, residual_inp), writes residual_out,
+        // optional bf16_output, output (FP8) and per-token scale_out. Layout
+        // mirrors the reverted-commit non-quant local_tensor_load_rmsnorm
+        // launcher exactly — only the epilogue is per-token quant.
+        if(n_constrain)
+        {
+            allreduce<T>(stream, input, residual_out, size, /*use_new=*/false);
+
+            hipDevice_t dev;
+            hipDeviceProp_t dev_prop;
+            hipGetDevice(&dev);
+            hipGetDeviceProperties(&dev_prop, dev);
+            uint32_t num_cu = dev_prop.multiProcessorCount;
+
+            dim3 block(512);
+            dim3 grid;
+            auto setGrid = [&](int naive_grid_size, const void* kernel_ptr) {
+                int occupancy;
+                hipOccupancyMaxActiveBlocksPerMultiprocessor(&occupancy, kernel_ptr, block.x, 0);
+                grid.x =
+                    naive_grid_size < num_cu * occupancy ? naive_grid_size : num_cu * occupancy;
+            };
+
+#define LAUNCH_OLD_CA_QUANT_SPLIT(template_kernel)                                              \
+    do                                                                                          \
+    {                                                                                           \
+        auto kernel_ptr = reinterpret_cast<const void*>(template_kernel);                       \
+        setGrid(naive_grid_size, kernel_ptr);                                                   \
+        template_kernel<<<grid, block, 0, stream>>>(                                            \
+            residual_out, residual_inp, residual_out, output, weight, scale_out, eps, m, n,     \
+            bf16_output);                                                                       \
+    } while(0)
+
+            constexpr int ar_pack_size = 16 / sizeof(T);
+            int n_packs                = n / ar_pack_size;
+            int naive_grid_size        = m;
+            if(n_packs >= 256)
+            {
+                int n_loop = (n_packs + 511) / 512;
+                switch(n_loop)
+                {
+                case 1: LAUNCH_OLD_CA_QUANT_SPLIT((local_tensor_load_rmsnorm_quant<T, QT, 512, 1>)); break;
+                case 2: LAUNCH_OLD_CA_QUANT_SPLIT((local_tensor_load_rmsnorm_quant<T, QT, 512, 2>)); break;
+                case 3: LAUNCH_OLD_CA_QUANT_SPLIT((local_tensor_load_rmsnorm_quant<T, QT, 512, 3>)); break;
+                case 4: LAUNCH_OLD_CA_QUANT_SPLIT((local_tensor_load_rmsnorm_quant<T, QT, 512, 4>)); break;
+                default:
+                    throw std::runtime_error(
+                        "old-CA fused allreduce rmsnorm quant: n too large, m=" +
+                        std::to_string(m) + " n=" + std::to_string(n));
+                }
+            }
+            else if(n_packs >= 64)
+            {
+                block.x    = 256;
+                int n_loop = (n_packs + 255) / 256;
+                switch(n_loop)
+                {
+                case 1: LAUNCH_OLD_CA_QUANT_SPLIT((local_tensor_load_rmsnorm_quant<T, QT, 256, 1>)); break;
+                case 2: LAUNCH_OLD_CA_QUANT_SPLIT((local_tensor_load_rmsnorm_quant<T, QT, 256, 2>)); break;
+                default:
+                    throw std::runtime_error(
+                        "old-CA fused allreduce rmsnorm quant: n too large for tnum=256, m=" +
+                        std::to_string(m) + " n=" + std::to_string(n));
+                }
+            }
+            else
+            {
+                throw std::runtime_error(
+                    "old-CA fused allreduce rmsnorm quant: n too small, m=" + std::to_string(m) +
+                    " n=" + std::to_string(n) + " n_packs=" + std::to_string(n_packs) +
+                    " (need n_packs >= 64)");
+            }
+
+#undef LAUNCH_OLD_CA_QUANT_SPLIT
+            return;
+        }
+
+        throw std::runtime_error(
+            "old-CA fused allreduce rmsnorm quant: n=" + std::to_string(n) +
+            " not supported (n must be multiple of pack_size and n/pack_size <= 1024)");
+    }
+    // ----- end old-CA fused dispatch ------------------------------------
+
     use_1stage       = use_1stage && n_constrain;
 #define DISPATCH_AR_FUSION_KERNEL(NGPUS)                                                       \
     if(use_1stage)                                                                             \
@@ -2764,7 +3737,8 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
                                                               size,                            \
                                                               n,                               \
                                                               eps,                             \
-                                                              stream);                         \
+                                                              stream,                          \
+                                                              bf16_output);                    \
         return;                                                                                \
     }                                                                                          \
     else if(n_constrain && (size * sizeof(T) <= 512 * 1024))                                   \
@@ -2781,7 +3755,8 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
                                                               size,                            \
                                                               n,                               \
                                                               eps,                             \
-                                                              stream);                         \
+                                                              stream,                          \
+                                                              bf16_output);                    \
         return;                                                                                \
     }                                                                                          \
     else if(n_constrain)                                                                       \
@@ -2798,7 +3773,8 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
                                                              size,                             \
                                                              n,                                \
                                                              eps,                              \
-                                                             stream);                          \
+                                                             stream,                           \
+                                                             bf16_output);                     \
         return;                                                                                \
     }                                                                                          \
     else                                                                                       \
@@ -2814,6 +3790,134 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
     case 2: DISPATCH_AR_FUSION_KERNEL(2); break;
     default: throw std::runtime_error("fused allreduce rmsnorm: unsupported world_size=" + std::to_string(world_size_));
     }
+}
+
+template <typename T, typename QT>
+void dispatchFusedAllReduceRMSNormQuantPerGroup(hipStream_t stream,
+                                                T* input,
+                                                T* residual_inp,
+                                                T* residual_out,
+                                                QT* output,
+                                                float* scale_out,
+                                                T* weight,
+                                                float eps,
+                                                int m,
+                                                int n,
+                                                int group_size,
+                                                bool use_1stage,
+                                                T* bf16_output = nullptr)
+{
+    auto d   = 16 / sizeof(T);
+    int size = m * n;
+    if(size % d != 0)
+    {
+        throw std::runtime_error("custom allreduce currently requires input length to be multiple "
+                                 "of " +
+                                 std::to_string(d));
+    }
+    // Per-group FP8 quant kernel constraints. The fused epilogue
+    // ``ar_fusion_epilogue_per_group`` uses a butterfly ``__shfl_xor``
+    // intra-group abs-max reduction with packed 16B loads, which imposes
+    // the following requirements on ``group_size``:
+    //
+    //   (a) group_size > 0
+    //   (b) group_size % PACK_SIZE == 0            (PACK_SIZE = 16/sizeof(T))
+    //   (c) (group_size / PACK_SIZE) is a power of two
+    //   (d) (group_size / PACK_SIZE) <= wavefront size (64 on CDNA)
+    //   (e) n % group_size == 0
+    //
+    // Without (a)-(d) the kernel would silently produce wrong scales
+    // (ill-formed butterfly stride, cross-warp shuffles, or a fractional
+    // pack per group); without (e) ``num_groups = n / group_size`` would
+    // not be an integer. Reject up front with an actionable message.
+    constexpr int kPackSize      = 16 / sizeof(T);
+    constexpr int kWavefrontSize = 64; // AMD CDNA wavefront width (gfx94x / gfx950)
+    if(group_size <= 0)
+    {
+        throw std::runtime_error(
+            "per-group quant requires group_size > 0, got group_size=" +
+            std::to_string(group_size));
+    }
+    if(group_size % kPackSize != 0)
+    {
+        throw std::runtime_error(
+            "per-group quant requires group_size divisible by PACK_SIZE=" +
+            std::to_string(kPackSize) + " (16/sizeof(T)), got group_size=" +
+            std::to_string(group_size));
+    }
+    int const threads_per_group_check = group_size / kPackSize;
+    if((threads_per_group_check & (threads_per_group_check - 1)) != 0)
+    {
+        throw std::runtime_error(
+            "per-group quant requires group_size/PACK_SIZE to be a power of two "
+            "(butterfly __shfl_xor reduction), got group_size=" +
+            std::to_string(group_size) +
+            " PACK_SIZE=" + std::to_string(kPackSize) +
+            " threads_per_group=" + std::to_string(threads_per_group_check));
+    }
+    if(threads_per_group_check > kWavefrontSize)
+    {
+        throw std::runtime_error(
+            "per-group quant requires group_size/PACK_SIZE <= wavefront size (" +
+            std::to_string(kWavefrontSize) +
+            "), got group_size=" + std::to_string(group_size) +
+            " PACK_SIZE=" + std::to_string(kPackSize) +
+            " threads_per_group=" + std::to_string(threads_per_group_check));
+    }
+    if(n % group_size != 0)
+    {
+        throw std::runtime_error(
+            "per-group quant requires n divisible by group_size, n=" +
+            std::to_string(n) + " group_size=" + std::to_string(group_size));
+    }
+    RankData* ptrs   = get_buffer_RD(stream, input);
+    auto pack_size   = 16 / sizeof(T);
+    bool n_constrain = (n % pack_size == 0) && (n / pack_size <= 1024);
+
+    use_1stage = use_1stage && n_constrain;
+
+#define DISPATCH_AR_FUSION_PG_KERNEL(NGPUS)                                               \
+    if(use_1stage)                                                                         \
+    {                                                                                      \
+        allreduce_fusion_kernel_1stage_per_group_launcher<T, QT, NGPUS>(                   \
+            ptrs, sg_, self_sg_, rank_,                                                     \
+            residual_inp, residual_out, output, weight, scale_out,                          \
+            size, n, group_size, eps, stream, bf16_output);                                 \
+        return;                                                                             \
+    }                                                                                      \
+    else if(n_constrain && (size * sizeof(T) <= 512 * 1024))                               \
+    {                                                                                      \
+        allreduce_fusion_kernel_2stage_per_group_launcher<T, QT, NGPUS>(                   \
+            ptrs, sg_, self_sg_, rank_,                                                     \
+            residual_inp, residual_out, output, weight, scale_out,                          \
+            size, n, group_size, eps, stream, bf16_output);                                 \
+        return;                                                                             \
+    }                                                                                      \
+    else if(n_constrain)                                                                   \
+    {                                                                                      \
+        allreduce_fusion_kernel_split_per_group_launcher<T, QT, NGPUS>(                    \
+            ptrs, sg_, self_sg_, rank_,                                                     \
+            residual_inp, residual_out, output, weight, scale_out,                          \
+            size, n, group_size, eps, stream, bf16_output);                                 \
+        return;                                                                             \
+    }                                                                                      \
+    else                                                                                   \
+    {                                                                                      \
+        throw std::runtime_error(                                                           \
+            "per-group quant fused kernel: unsupported n");                                  \
+    }
+
+    switch(world_size_)
+    {
+    case 8: DISPATCH_AR_FUSION_PG_KERNEL(8); break;
+    case 4: DISPATCH_AR_FUSION_PG_KERNEL(4); break;
+    case 2: DISPATCH_AR_FUSION_PG_KERNEL(2); break;
+    default:
+        throw std::runtime_error(
+            "fused allreduce rmsnorm per-group quant: unsupported world_size=" +
+            std::to_string(world_size_));
+    }
+#undef DISPATCH_AR_FUSION_PG_KERNEL
 }
 
 ~CustomAllreduce()

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -62,7 +62,8 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
                              double eps,
                              int64_t reg_ptr,
                              int64_t reg_bytes,
-                             bool use_1stage);
+                             bool use_1stage,
+                             bool use_old_ca = false);
 void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    const aiter_tensor_t& inp,
                                    const aiter_tensor_t& res_inp,
@@ -73,7 +74,22 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    double eps,
                                    int64_t reg_ptr,
                                    int64_t reg_bytes,
-                                   bool use_1stage);
+                                   bool use_1stage,
+                                   int64_t bf16_out_ptr = 0,
+                                   bool use_old_ca      = false);
+void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
+                                             const aiter_tensor_t& inp,
+                                             const aiter_tensor_t& res_inp,
+                                             const aiter_tensor_t& res_out,
+                                             const aiter_tensor_t& out,
+                                             const aiter_tensor_t& scale_out,
+                                             const aiter_tensor_t& w,
+                                             double eps,
+                                             int64_t group_size,
+                                             int64_t reg_ptr,
+                                             int64_t reg_bytes,
+                                             bool use_1stage,
+                                             int64_t bf16_out_ptr = 0);
 void dispose(fptr_t _fa);
 int64_t meta_size();
 void register_input_buffer(fptr_t _fa,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -424,7 +424,8 @@ namespace py = pybind11;
           py::arg("eps"),                                                                      \
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"),                                                                \
-          py::arg("use_1stage"));                                                              \
+          py::arg("use_1stage"),                                                               \
+          py::arg("use_old_ca") = false);                                                      \
     m.def("fused_allreduce_rmsnorm_quant",                                                     \
           &aiter::fused_allreduce_rmsnorm_quant,                                               \
           py::arg("_fa"),                                                                      \
@@ -437,7 +438,24 @@ namespace py = pybind11;
           py::arg("eps"),                                                                      \
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"),                                                                \
-          py::arg("use_1stage"));                                                              \
+          py::arg("use_1stage"),                                                               \
+          py::arg("bf16_out_ptr") = static_cast<int64_t>(0),                                   \
+          py::arg("use_old_ca")   = false);                                                    \
+    m.def("fused_allreduce_rmsnorm_quant_per_group",                                            \
+          &aiter::fused_allreduce_rmsnorm_quant_per_group,                                      \
+          py::arg("_fa"),                                                                       \
+          py::arg("inp"),                                                                       \
+          py::arg("res_inp"),                                                                   \
+          py::arg("res_out"),                                                                   \
+          py::arg("out"),                                                                       \
+          py::arg("scale_out"),                                                                 \
+          py::arg("w"),                                                                         \
+          py::arg("eps"),                                                                       \
+          py::arg("group_size"),                                                                \
+          py::arg("reg_ptr"),                                                                   \
+          py::arg("reg_bytes"),                                                                 \
+          py::arg("use_1stage"),                                                                \
+          py::arg("bf16_out_ptr") = static_cast<int64_t>(0));                                   \
     m.def("dispose", &aiter::dispose, py::arg("_fa"));                                         \
     m.def("meta_size", &aiter::meta_size);                                                     \
     m.def("register_input_buffer",                                                             \

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -194,7 +194,9 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
                                      void* scale_out, void* w,
                                      AiterDtype dtype, float eps,
                                      int m, int n,
-                                     bool use_1stage)
+                                     bool use_1stage,
+                                     void* bf16_out = nullptr,
+                                     bool use_old_ca = false)
 {
     hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
@@ -213,7 +215,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
             eps,                                                 \
             m,                                                   \
             n,                                                   \
-            use_1stage);                                         \
+            use_1stage,                                          \
+            use_old_ca);                                         \
     }                                                            \
     else                                                         \
     {                                                            \
@@ -228,7 +231,9 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
             eps,                                                 \
             m,                                                   \
             n,                                                   \
-            use_1stage);                                         \
+            use_1stage,                                          \
+            reinterpret_cast<DTYPE*>(bf16_out),                  \
+            use_old_ca);                                         \
     }
 
     switch(dtype)
@@ -451,7 +456,8 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
                              const aiter_tensor_t& w,
                              double eps,
                              int64_t reg_ptr, int64_t reg_bytes,
-                             bool use_1stage)
+                             bool use_1stage,
+                             bool use_old_ca)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -470,14 +476,16 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
         _fused_allreduce_rmsnorm(_fa,
                                  (void*)reg_ptr, res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, n, use_1stage);
+                                 dtype, (float)eps, m, n, use_1stage,
+                                 /*bf16_out=*/nullptr, use_old_ca);
     }
     else
     {
         _fused_allreduce_rmsnorm(_fa,
                                  inp.data_ptr(), res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, n, use_1stage);
+                                 dtype, (float)eps, m, n, use_1stage,
+                                 /*bf16_out=*/nullptr, use_old_ca);
     }
 }
 
@@ -490,7 +498,9 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    const aiter_tensor_t& w,
                                    double eps,
                                    int64_t reg_ptr, int64_t reg_bytes,
-                                   bool use_1stage)
+                                   bool use_1stage,
+                                   int64_t bf16_out_ptr,
+                                   bool use_old_ca)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -499,6 +509,9 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
     int64_t data_bytes = numel * inp.element_size();
     int n = (int)w.numel();
     int m = (int)(numel / w.numel());
+
+    // Optional pre-quantization bf16/fp16 normed output. 0 = not requested.
+    void* bf16_out = reinterpret_cast<void*>(bf16_out_ptr);
 
     if(reg_ptr != 0)
     {
@@ -509,14 +522,89 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
         _fused_allreduce_rmsnorm(_fa,
                                  (void*)reg_ptr, res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), scale_out.data_ptr(), w.data_ptr(),
-                                 dtype, (float)eps, m, n, use_1stage);
+                                 dtype, (float)eps, m, n, use_1stage, bf16_out, use_old_ca);
     }
     else
     {
         _fused_allreduce_rmsnorm(_fa,
                                  inp.data_ptr(), res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), scale_out.data_ptr(), w.data_ptr(),
-                                 dtype, (float)eps, m, n, use_1stage);
+                                 dtype, (float)eps, m, n, use_1stage, bf16_out, use_old_ca);
+    }
+}
+
+void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
+                                             const aiter_tensor_t& inp,
+                                             const aiter_tensor_t& res_inp,
+                                             const aiter_tensor_t& res_out,
+                                             const aiter_tensor_t& out,
+                                             const aiter_tensor_t& scale_out,
+                                             const aiter_tensor_t& w,
+                                             double eps,
+                                             int64_t group_size,
+                                             int64_t reg_ptr, int64_t reg_bytes,
+                                             bool use_1stage,
+                                             int64_t bf16_out_ptr)
+{
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto dtype     = inp.dtype();
+    int64_t numel  = inp.numel();
+    int64_t data_bytes = numel * inp.element_size();
+    int n = (int)w.numel();
+    int m = (int)(numel / w.numel());
+
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+
+    void* inp_ptr = inp.data_ptr();
+    if(reg_ptr != 0)
+    {
+        if(data_bytes > reg_bytes)
+            throw std::runtime_error("registered buffer is too small to contain the input");
+        HIP_CALL(hipMemcpyAsync((void*)reg_ptr, inp.data_ptr(), data_bytes,
+                                hipMemcpyDeviceToDevice, stream));
+        inp_ptr = (void*)reg_ptr;
+    }
+
+    // bf16_out_ptr is an opaque data pointer (0 = not requested). When non-zero
+    // the fused kernel writes the pre-quantization bf16/fp16 normed output so
+    // GDN-style callers can keep an unquantized view without launching a
+    // separate per-group quant kernel.
+    void* bf16_out = reinterpret_cast<void*>(bf16_out_ptr);
+
+    switch(dtype)
+    {
+#if(__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
+    case AITER_DTYPE_bf16: {
+        fa->dispatchFusedAllReduceRMSNormQuantPerGroup<opus::bf16_t, fp8_type>(
+            stream,
+            reinterpret_cast<opus::bf16_t*>(inp_ptr),
+            reinterpret_cast<opus::bf16_t*>(res_inp.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(res_out.data_ptr()),
+            reinterpret_cast<fp8_type*>(out.data_ptr()),
+            reinterpret_cast<float*>(scale_out.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(w.data_ptr()),
+            (float)eps, m, n, (int)group_size, use_1stage,
+            reinterpret_cast<opus::bf16_t*>(bf16_out));
+        break;
+    }
+#endif
+    case AITER_DTYPE_fp16: {
+        fa->dispatchFusedAllReduceRMSNormQuantPerGroup<opus::fp16_t, fp8_type>(
+            stream,
+            reinterpret_cast<opus::fp16_t*>(inp_ptr),
+            reinterpret_cast<opus::fp16_t*>(res_inp.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(res_out.data_ptr()),
+            reinterpret_cast<fp8_type*>(out.data_ptr()),
+            reinterpret_cast<float*>(scale_out.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(w.data_ptr()),
+            (float)eps, m, n, (int)group_size, use_1stage,
+            reinterpret_cast<opus::fp16_t*>(bf16_out));
+        break;
+    }
+    default:
+        throw std::runtime_error(
+            "fused_allreduce_rmsnorm_quant_per_group only supports float16 and bfloat16");
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
This PR tightens control over two HIP-specific paths that were introduced on the Qwen3.5 branch.
The fused `allreduce + next-layer residual add + RMSNorm` path should not run on new CA. When `SGLANG_USE_AITER_NEW_CA=true`, the server should use the normal new-CA allreduce path instead of any fused path. #266
corresponding pr https://github.com/zejunchen-zejun/sglang/pull/277
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Add explicit control for the fused `allreduce + residual add + RMSNorm` path.
  - With AITER legacy CA (`SGLANG_USE_AITER_NEW_CA=0`), the fusion is enabled by default and runs decode-only by default.
  - Set `SGLANG_DISABLE_AITER_FUSED_AR_RMSNORM=1` to disable it.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
397B PTPC stress testing:
<img width="490" height="613" alt="image" src="https://github.com/user-attachments/assets/efb5189a-ddc8-46f1-85d7-a37bfabfe8cf" />
397B PTPC TP8 acc:
<img width="995" height="91" alt="image" src="https://github.com/user-attachments/assets/71c64d66-5010-4e31-ba27-ed4ecad64652" />
<img width="1013" height="91" alt="image" src="https://github.com/user-attachments/assets/4853136a-f8e7-4056-a940-86134d3fd1b0" />
27B PTPC TP2 acc:
<img width="790" height="99" alt="image" src="https://github.com/user-attachments/assets/d3a30ad1-f217-4caf-bee3-d4e09e0f04fd" />
<img width="792" height="106" alt="image" src="https://github.com/user-attachments/assets/7c8d57cb-0fb9-4d0a-b2a5-4eb8257ad7ae" />
27B PTPC TP1 acc:
<img width="777" height="146" alt="image" src="https://github.com/user-attachments/assets/cc712efc-5b6b-4451-a06d-df1227a63d09" />
<img width="791" height="108" alt="image" src="https://github.com/user-attachments/assets/d8401343-27c8-4eed-872b-82c97cb0180b" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
The observed TPOT trend was approximately:
- base: ~9.83 ms
- with fused allreduce path: ~9.61 ms
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
