### PR TITLE
[Gluon] Fix MFMA instr_shape for Triton version compatibility

### DIFF
--- a/aiter/ops/triton/gluon/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/gluon/gemm_a8w8_blockscale.py
@@ -16,6 +16,10 @@ from triton import language as tl
 _LOGGER = AiterTritonLogger()
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
+import aiter.ops.triton.gluon.triton_version as tv
+
+# Pre-compute version check as constexpr for use in JIT kernels
+TRITON_VERSION_GE_3_6_0 = tl.constexpr(tv.TRITON_VERSION_GE_3_6_0)
 
 
 @triton.heuristics(
@@ -118,9 +122,14 @@ def _gemm_a8w8_blockscale_kernel(
         warps_per_cta=[1, NUM_WARPS],
         order=[0, 1],
     )
+    # V_MFMA_F32_16X16X32_FP8_FP8 instruction
+    # Triton >= 3.6.0 requires 3D instr_shape (M, N, K); older versions use 2D (M, N).
+    MFMA_INSTR_SHAPE: gl.constexpr = (
+        [16, 16, 32] if TRITON_VERSION_GE_3_6_0 else [16, 16]
+    )
     mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
         version=4,
-        instr_shape=[16, 16, 32],  # V_MFMA_F32_16X16X32_FP8_FP8 instruction
+        instr_shape=MFMA_INSTR_SHAPE,
         transposed=True,
         warps_per_cta=[NUM_WARPS // 2, 2],
     )

--- a/aiter/ops/triton/gluon/mla_decode_gluon.py
+++ b/aiter/ops/triton/gluon/mla_decode_gluon.py
@@ -36,6 +36,10 @@ from triton.experimental.gluon import language as gl
 
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils.device_info import get_num_xcds
+import aiter.ops.triton.gluon.triton_version as tv
+
+# Pre-compute version check as constexpr for use in JIT kernels
+TRITON_VERSION_GE_3_6_0 = tl.constexpr(tv.TRITON_VERSION_GE_3_6_0)
 
 # fmt: off
 @gluon.jit
@@ -155,9 +159,13 @@ def _mla_decode_gluon(
     )
 
     # layout for mfma
+    # Triton >= 3.6.0 requires 3D instr_shape (M, N, K); older versions use 2D (M, N).
+    MFMA_INSTR_SHAPE: gl.constexpr = (
+        [16, 16, 32] if TRITON_VERSION_GE_3_6_0 else [16, 16]
+    )
     mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
         version=4,
-        instr_shape=[16, 16, 32],
+        instr_shape=MFMA_INSTR_SHAPE,
         transposed=True,
         warps_per_cta=[4, 1],
     )


### PR DESCRIPTION
Triton >= 3.6.0 requires 3D instr_shape (M, N, K) for AMDMFMALayout, while older versions use 2D (M, N). Select the shape at compile time via a constexpr derived from triton_version so the gluon GEMM and MLA decode kernels build on both.

Fixes ROCm/triton-internal#1670

## Motivation

Similar to the fix in PR2491, this addresses the remaining compatibility issues for legacy Gluon kernels.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
