### PR TITLE
[TRITON] Fix bug in `bench_gmm.py`

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_gmm.py
+++ b/op_tests/op_benchmarks/triton/bench_gmm.py
@@ -220,9 +220,9 @@ def benchmark_gmm(
             gb_sum += 1e-9 * (read_bytes + write_bytes)
 
         # Compute milliseconds: milliseconds of all group sizes / number of group sizes.
-        p50_ms = round(p50_ms_sum / G, 4)
-        p20_ms = round(p20_ms_sum / G, 4)
-        p80_ms = round(p80_ms_sum / G, 4)
+        p50_ms = round(p50_ms_sum / num_group_sizes, 4)
+        p20_ms = round(p20_ms_sum / num_group_sizes, 4)
+        p80_ms = round(p80_ms_sum / num_group_sizes, 4)
 
         # Compute total seconds.
         p50_s_sum = 1e-3 * p50_ms_sum


### PR DESCRIPTION
## Motivation and Technical Details

In `op_tests/op_benchmarks/triton/bench_gmm.py` benchmark script, p50/p20/p80 times were divided by `G` (number of groups) instead of `num_group_sizes` (number of group-size configs iterated). This produced incorrect average time metric in the benchmark results.

It's important to notice that throughput in TFLOPS and bandwidth in GB/s metrics are working correctly. The bug only affects time metric in milliseconds.

## Test Plan

Run `op_tests/op_benchmarks/triton/bench_gmm.py`, requesting time as performance metric:

```bash
python op_tests/op_benchmarks/triton/bench_gmm.py \
    267424 1280 2560 32 --unif-group-sizes --metric time
```

## Test Result

Before the fix - wrong time metric, performance is greatly overestimated because kernel execution time is divided by `G = 32`:

```text
triton_gmm_ibf16_obf16_nnn_ms:
          M       K       N     G  triton_gmm_ibf16_obf16_nnn_ms (ms)
0  267424.0  1280.0  2560.0  32.0                              0.0719
```

After the fix - correct time metric:

```text
 triton_gmm_ibf16_obf16_nnn_ms:
          M       K       N     G  triton_gmm_ibf16_obf16_nnn_ms (ms)
0  267424.0  1280.0  2560.0  32.0                               2.294
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.