### PR TITLE
[DO NOT MERGE] CI: split Aiter wheel prebuild by architecture

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -23,9 +23,7 @@ concurrency:
 
 env:
   DOCKER_IMAGE: "rocm/pytorch:latest"
-  GPU_ARCH_LIST: "gfx942;gfx950"
   AITER_TEST: "op_tests"
-  AITER_WHEEL_ARTIFACT_NAME: aiter-whl-${{ github.run_id }}
   AITER_PREBUILD_MAX_JOBS: "96"
 
 jobs:
@@ -44,8 +42,17 @@ jobs:
 
   build_aiter_wheels:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
+    name: Build Aiter wheel (${{ matrix.label }})
     runs-on: build-only-aiter
     needs: check-signal
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: gfx942
+            label: MI300X
+          - arch: gfx950
+            label: MI35X
     permissions:
       id-token: write
       contents: read
@@ -111,10 +118,10 @@ jobs:
               pip install --upgrade "ninja>=1.11.1" &&
               pip install --upgrade setuptools_scm &&
               pip install tabulate &&
-              echo "Prebuilding kernels with GPU_ARCHS: ${{ env.GPU_ARCH_LIST }}, PREBUILD_KERNELS: 1, and MAX_JOBS: ${AITER_PREBUILD_MAX_JOBS}" &&
+              echo "Prebuilding kernels with GPU_ARCHS: ${{ matrix.arch }}, PREBUILD_KERNELS: 1, and MAX_JOBS: ${AITER_PREBUILD_MAX_JOBS}" &&
               export PREBUILD_KERNELS=1 &&
               export MAX_JOBS="${AITER_PREBUILD_MAX_JOBS}" &&
-              export GPU_ARCHS="${{ env.GPU_ARCH_LIST }}" &&
+              export GPU_ARCHS="${{ matrix.arch }}" &&
               prebuild_start=$(date +%s) &&
               set +e &&
               python setup.py bdist_wheel 2>&1 | tee .aiter-prebuild.log
@@ -142,7 +149,7 @@ jobs:
           fi
           . ./.aiter-prebuild.env
           AITER_RUNNER_NAME="${RUNNER_NAME:-unknown}" \
-          GPU_ARCHS="${{ env.GPU_ARCH_LIST }}" \
+          GPU_ARCHS="${{ matrix.arch }}" \
           PREBUILD_KERNELS=1 \
           MAX_JOBS="${{ env.AITER_PREBUILD_MAX_JOBS }}" \
           python3 .github/scripts/aiter_prebuild_summary.py \
@@ -187,7 +194,7 @@ jobs:
       - name: Upload wheel as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          name: aiter-whl-${{ github.run_id }}-${{ matrix.arch }}
           path: dist/*.whl
           retention-days: 14
 
@@ -214,7 +221,7 @@ jobs:
           for WHL in dist/*.whl; do
             WHL_NAME=$(basename ${WHL})
             echo "Uploading ${WHL_NAME} to S3..."
-            aws s3 cp ${WHL} s3://framework-whls-nightlies/whl-staging/gfx942-gfx950/${WHL_NAME}
+            aws s3 cp ${WHL} s3://framework-whls-nightlies/whl-staging/${{ matrix.arch }}/${WHL_NAME}
           done
           echo "Wheels uploaded to S3 staging"
 
@@ -225,14 +232,14 @@ jobs:
           fi
 
           MANIFEST_WHL_NAME=$(basename "$MANIFEST_WHL")
-          MANIFEST_WHL_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/${MANIFEST_WHL_NAME}"
+          MANIFEST_WHL_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/${{ matrix.arch }}/${MANIFEST_WHL_NAME}"
           MANIFEST_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           python3 -c "import json, pathlib, sys; pathlib.Path('latest-main-wheel.json').write_text(json.dumps({'branch': sys.argv[1], 'timestamp': sys.argv[2], 'commit': sys.argv[3], 'wheel_name': sys.argv[4], 'wheel_url': sys.argv[5]}, indent=2) + '\n', encoding='utf-8')" \
             "$GITHUB_REF_NAME" "$MANIFEST_TIMESTAMP" "$GITHUB_SHA" "$MANIFEST_WHL_NAME" "$MANIFEST_WHL_URL"
 
           aws s3 cp latest-main-wheel.json \
-            s3://framework-whls-nightlies/whl-staging/gfx942-gfx950/main/latest.json \
+            s3://framework-whls-nightlies/whl-staging/${{ matrix.arch }}/main/latest.json \
             --content-type application/json
 
           echo "Uploaded latest main wheel manifest for ${MANIFEST_WHL_NAME}"
@@ -269,42 +276,52 @@ jobs:
         include:
           - runner: linux-aiter-mi35x-1
             label: MI35X
+            arch: gfx950
             shard_total: 5
             shard_idx: 0
           - runner: linux-aiter-mi35x-1
             label: MI35X
+            arch: gfx950
             shard_total: 5
             shard_idx: 1
           - runner: linux-aiter-mi35x-1
             label: MI35X
+            arch: gfx950
             shard_total: 5
             shard_idx: 2
           - runner: linux-aiter-mi35x-1
             label: MI35X
+            arch: gfx950
             shard_total: 5
             shard_idx: 3
           - runner: linux-aiter-mi35x-1
             label: MI35X
+            arch: gfx950
             shard_total: 5
             shard_idx: 4
           - runner: linux-aiter-mi300x-1
             label: MI300X
+            arch: gfx942
             shard_total: 5
             shard_idx: 0
           - runner: linux-aiter-mi300x-1
             label: MI300X
+            arch: gfx942
             shard_total: 5
             shard_idx: 1
           - runner: linux-aiter-mi300x-1
             label: MI300X
+            arch: gfx942
             shard_total: 5
             shard_idx: 2
           - runner: linux-aiter-mi300x-1
             label: MI300X
+            arch: gfx942
             shard_total: 5
             shard_idx: 3
           - runner: linux-aiter-mi300x-1
             label: MI300X
+            arch: gfx942
             shard_total: 5
             shard_idx: 4
     runs-on: ${{ matrix.runner }}
@@ -333,7 +350,7 @@ jobs:
       - name: Download Aiter wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          name: aiter-whl-${{ github.run_id }}-${{ matrix.arch }}
           path: aiter_wheels
 
       - name: Docker login
@@ -551,8 +568,10 @@ jobs:
         include:
           - runner: linux-aiter-mi35x-8
             label: MI35X
+            arch: gfx950
           - runner: linux-aiter-mi300x-8
             label: MI300X
+            arch: gfx942
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -564,7 +583,7 @@ jobs:
       - name: Download Aiter wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          name: aiter-whl-${{ github.run_id }}-${{ matrix.arch }}
           path: aiter_wheels
 
       - name: Docker login

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -40,23 +40,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
 
-  build_aiter_wheels:
+  build_aiter_wheel_gfx942:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
-    name: Build Aiter wheel (${{ matrix.label }})
+    name: Build Aiter wheel (MI300X)
     runs-on: build-only-aiter
     needs: check-signal
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: gfx942
-            label: MI300X
-          - arch: gfx950
-            label: MI35X
+    env:
+      AITER_GPU_ARCH: gfx942
     permissions:
       id-token: write
       contents: read
-    steps:
+    steps: &build_aiter_wheel_steps
       # ---- Common steps (fork and non-fork) ----
       - name: Checkout code
         uses: actions/checkout@v4
@@ -102,6 +96,7 @@ jobs:
           docker run --rm \
             --network=host \
             -e AITER_PREBUILD_MAX_JOBS="${{ env.AITER_PREBUILD_MAX_JOBS }}" \
+            -e AITER_GPU_ARCH="${AITER_GPU_ARCH}" \
             -e AITER_RUNNER_NAME="${RUNNER_NAME:-unknown}" \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
@@ -118,10 +113,10 @@ jobs:
               pip install --upgrade "ninja>=1.11.1" &&
               pip install --upgrade setuptools_scm &&
               pip install tabulate &&
-              echo "Prebuilding kernels with GPU_ARCHS: ${{ matrix.arch }}, PREBUILD_KERNELS: 1, and MAX_JOBS: ${AITER_PREBUILD_MAX_JOBS}" &&
+              echo "Prebuilding kernels with GPU_ARCHS: ${AITER_GPU_ARCH}, PREBUILD_KERNELS: 1, and MAX_JOBS: ${AITER_PREBUILD_MAX_JOBS}" &&
               export PREBUILD_KERNELS=1 &&
               export MAX_JOBS="${AITER_PREBUILD_MAX_JOBS}" &&
-              export GPU_ARCHS="${{ matrix.arch }}" &&
+              export GPU_ARCHS="${AITER_GPU_ARCH}" &&
               prebuild_start=$(date +%s) &&
               set +e &&
               python setup.py bdist_wheel 2>&1 | tee .aiter-prebuild.log
@@ -149,7 +144,7 @@ jobs:
           fi
           . ./.aiter-prebuild.env
           AITER_RUNNER_NAME="${RUNNER_NAME:-unknown}" \
-          GPU_ARCHS="${{ matrix.arch }}" \
+          GPU_ARCHS="${AITER_GPU_ARCH}" \
           PREBUILD_KERNELS=1 \
           MAX_JOBS="${{ env.AITER_PREBUILD_MAX_JOBS }}" \
           python3 .github/scripts/aiter_prebuild_summary.py \
@@ -194,7 +189,7 @@ jobs:
       - name: Upload wheel as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: aiter-whl-${{ github.run_id }}-${{ matrix.arch }}
+          name: aiter-whl-${{ github.run_id }}-${{ env.AITER_GPU_ARCH }}
           path: dist/*.whl
           retention-days: 14
 
@@ -221,7 +216,7 @@ jobs:
           for WHL in dist/*.whl; do
             WHL_NAME=$(basename ${WHL})
             echo "Uploading ${WHL_NAME} to S3..."
-            aws s3 cp ${WHL} s3://framework-whls-nightlies/whl-staging/${{ matrix.arch }}/${WHL_NAME}
+            aws s3 cp ${WHL} s3://framework-whls-nightlies/whl-staging/${AITER_GPU_ARCH}/${WHL_NAME}
           done
           echo "Wheels uploaded to S3 staging"
 
@@ -232,22 +227,34 @@ jobs:
           fi
 
           MANIFEST_WHL_NAME=$(basename "$MANIFEST_WHL")
-          MANIFEST_WHL_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/${{ matrix.arch }}/${MANIFEST_WHL_NAME}"
+          MANIFEST_WHL_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/${AITER_GPU_ARCH}/${MANIFEST_WHL_NAME}"
           MANIFEST_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           python3 -c "import json, pathlib, sys; pathlib.Path('latest-main-wheel.json').write_text(json.dumps({'branch': sys.argv[1], 'timestamp': sys.argv[2], 'commit': sys.argv[3], 'wheel_name': sys.argv[4], 'wheel_url': sys.argv[5]}, indent=2) + '\n', encoding='utf-8')" \
             "$GITHUB_REF_NAME" "$MANIFEST_TIMESTAMP" "$GITHUB_SHA" "$MANIFEST_WHL_NAME" "$MANIFEST_WHL_URL"
 
           aws s3 cp latest-main-wheel.json \
-            s3://framework-whls-nightlies/whl-staging/${{ matrix.arch }}/main/latest.json \
+            s3://framework-whls-nightlies/whl-staging/${AITER_GPU_ARCH}/main/latest.json \
             --content-type application/json
 
           echo "Uploaded latest main wheel manifest for ${MANIFEST_WHL_NAME}"
 
+  build_aiter_wheel_gfx950:
+    if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
+    name: Build Aiter wheel (MI35X)
+    runs-on: build-only-aiter
+    needs: check-signal
+    env:
+      AITER_GPU_ARCH: gfx950
+    permissions:
+      id-token: write
+      contents: read
+    steps: *build_aiter_wheel_steps
+
   split_aiter_tests:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    needs: [check-signal, build_aiter_wheels]
+    needs: check-signal
     outputs:
       shard_count: 5
     steps:
@@ -264,41 +271,16 @@ jobs:
           path: aiter_shard_*.list
           retention-days: 7
 
-  standard:
+  standard-mi300x:
     if: >-
       (!github.event.pull_request || github.event.pull_request.draft == false) &&
       github.event.action != 'labeled'
-    name: Standard Tests (1 GPU)
-    needs: [build_aiter_wheels, split_aiter_tests]
+    name: Standard Tests (1 GPU, MI300X)
+    needs: [build_aiter_wheel_gfx942, split_aiter_tests]
     strategy:
       fail-fast: false
       matrix:
         include:
-          - runner: linux-aiter-mi35x-1
-            label: MI35X
-            arch: gfx950
-            shard_total: 5
-            shard_idx: 0
-          - runner: linux-aiter-mi35x-1
-            label: MI35X
-            arch: gfx950
-            shard_total: 5
-            shard_idx: 1
-          - runner: linux-aiter-mi35x-1
-            label: MI35X
-            arch: gfx950
-            shard_total: 5
-            shard_idx: 2
-          - runner: linux-aiter-mi35x-1
-            label: MI35X
-            arch: gfx950
-            shard_total: 5
-            shard_idx: 3
-          - runner: linux-aiter-mi35x-1
-            label: MI35X
-            arch: gfx950
-            shard_total: 5
-            shard_idx: 4
           - runner: linux-aiter-mi300x-1
             label: MI300X
             arch: gfx942
@@ -326,7 +308,7 @@ jobs:
             shard_idx: 4
     runs-on: ${{ matrix.runner }}
 
-    steps:
+    steps: &standard_test_steps
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -519,13 +501,52 @@ jobs:
         run: |
           docker rm -f aiter_test || true
 
+  standard-mi35x:
+    if: >-
+      (!github.event.pull_request || github.event.pull_request.draft == false) &&
+      github.event.action != 'labeled'
+    name: Standard Tests (1 GPU, MI35X)
+    needs: [build_aiter_wheel_gfx950, split_aiter_tests]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            arch: gfx950
+            shard_total: 5
+            shard_idx: 0
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            arch: gfx950
+            shard_total: 5
+            shard_idx: 1
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            arch: gfx950
+            shard_total: 5
+            shard_idx: 2
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            arch: gfx950
+            shard_total: 5
+            shard_idx: 3
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            arch: gfx950
+            shard_total: 5
+            shard_idx: 4
+    runs-on: ${{ matrix.runner }}
+
+    steps: *standard_test_steps
+
   standard-test-finish:
     if: >-
       !github.event.pull_request.draft &&
       github.event.action != 'labeled'
     name: Standard Test Results
     runs-on: ubuntu-latest
-    needs: [standard]
+    needs: [standard-mi300x, standard-mi35x]
     steps:
       - name: Download all test logs
         uses: actions/download-artifact@v4
@@ -558,23 +579,16 @@ jobs:
             exit 1
           fi
 
-  multi-gpu:
-    name: Multi-GPU Tests (8 GPU)
+  multi-gpu-mi300x:
+    name: Multi-GPU Tests (8 GPU, MI300X)
     if: github.ref == 'refs/heads/main'
-    needs: build_aiter_wheels
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: linux-aiter-mi35x-8
-            label: MI35X
-            arch: gfx950
-          - runner: linux-aiter-mi300x-8
-            label: MI300X
-            arch: gfx942
-    runs-on: ${{ matrix.runner }}
+    needs: build_aiter_wheel_gfx942
+    runs-on: linux-aiter-mi300x-8
+    env:
+      AITER_GPU_ARCH: gfx942
+      AITER_RUNNER_LABEL: linux-aiter-mi300x-8
 
-    steps:
+    steps: &multi_gpu_test_steps
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -583,7 +597,7 @@ jobs:
       - name: Download Aiter wheel artifact
         uses: actions/download-artifact@v4
         with:
-          name: aiter-whl-${{ github.run_id }}-${{ matrix.arch }}
+          name: aiter-whl-${{ github.run_id }}-${{ env.AITER_GPU_ARCH }}
           path: aiter_wheels
 
       - name: Docker login
@@ -736,7 +750,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: multigpu-test-${{ matrix.runner }}
+          name: multigpu-test-${{ env.AITER_RUNNER_LABEL }}
           path: latest_test.log
           retention-days: 7
 
@@ -749,3 +763,14 @@ jobs:
         if: always()
         run: |
           ./.github/scripts/clean_up_rocm.sh
+
+  multi-gpu-mi35x:
+    name: Multi-GPU Tests (8 GPU, MI35X)
+    if: github.ref == 'refs/heads/main'
+    needs: build_aiter_wheel_gfx950
+    runs-on: linux-aiter-mi35x-8
+    env:
+      AITER_GPU_ARCH: gfx950
+      AITER_RUNNER_LABEL: linux-aiter-mi35x-8
+
+    steps: *multi_gpu_test_steps


### PR DESCRIPTION
## Summary
- Split Aiter wheel prebuild into per-architecture matrix jobs for gfx942 and gfx950.
- Publish per-arch wheel artifacts and have MI300X/MI35X test jobs download the matching artifact.
- Upload main-branch wheel artifacts and manifests to per-arch S3 staging paths.

## Test plan
- Parsed `.github/workflows/aiter-test.yaml` with PyYAML.
- Ran `git diff --check` for workflow whitespace validation.
- This PR is intended to validate the updated workflow in CI.