### PR TITLE
[Bugfix][Triton] Honor `transpose_bm` in batched_gemm_a16wfp4_ fake tensor

### DIFF
--- a/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
+++ b/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
@@ -65,9 +65,7 @@ def batched_gemm_a16wfp4_fake_tensor(
 # memory. Do not remove this argument without re-auditing the kernel's
 # tl.store sites and re-checking the post-grad FX graph of any compiled
 # downstream consumer.
-@torch_compile_guard(
-    mutates_args=["y"], gen_fake=batched_gemm_a16wfp4_fake_tensor
-)
+@torch_compile_guard(mutates_args=["y"], gen_fake=batched_gemm_a16wfp4_fake_tensor)
 def batched_gemm_a16wfp4_(
     x: torch.Tensor,
     w: torch.Tensor,

--- a/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
+++ b/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
@@ -54,7 +54,20 @@ def batched_gemm_a16wfp4_fake_tensor(
     return y
 
 
-@torch_compile_guard(gen_fake=batched_gemm_a16wfp4_fake_tensor)
+# Explicit ``mutates_args=["y"]`` rather than the ``torch_compile_guard``
+# default ("unknown"). Without this, ``torch.library.infer_schema`` marks
+# every Tensor argument as in-place mutated (``Tensor(aN!)`` for
+# ``x`` / ``w`` / ``w_scales`` / ``y_scale``), which is wrong: the kernel
+# only writes to ``y``. The spurious markers cause downstream
+# ``torch.compile`` consumers to emit ``auto_functionalized()`` writeback
+# chains on the read-only inputs, which break FX pattern matchers (e.g.
+# vLLM's MLA decode q-prep fusion) and inflate cudagraph capture peak
+# memory. Do not remove this argument without re-auditing the kernel's
+# tl.store sites and re-checking the post-grad FX graph of any compiled
+# downstream consumer.
+@torch_compile_guard(
+    mutates_args=["y"], gen_fake=batched_gemm_a16wfp4_fake_tensor
+)
 def batched_gemm_a16wfp4_(
     x: torch.Tensor,
     w: torch.Tensor,

--- a/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
+++ b/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
@@ -42,6 +42,14 @@ def batched_gemm_a16wfp4_fake_tensor(
     if y is None:
         Bx, M, _ = x.shape
         _, N, _ = w.shape
+        # Match the real kernel's allocation (lines 100-103 of this file).
+        # Returning ``(Bx, M, N)`` regardless of ``transpose_bm`` causes
+        # ``torch.compile`` to specialize the leading SymInt of the BMM
+        # output to ``Bx`` whenever a downstream op constrains it (e.g. a
+        # ``torch.cat`` on ``dim=-1`` with a tensor of shape ``(M, Bx, K)``),
+        # silently baking the wrong static slice into the captured graph.
+        if transpose_bm:
+            return torch.empty((M, Bx, N), dtype=dtype, device=x.device)
         return torch.empty((Bx, M, N), dtype=dtype, device=x.device)
     return y
 

--- a/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
+++ b/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
@@ -191,80 +191,47 @@ def test_batched_gemm_a16wfp4(B: int, M: int, N: int, K: int, layout, dtype):
     torch.testing.assert_close(torch_out, out)
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("B, M, N, K", [(16, 16, 512, 128), (16, 512, 512, 128)])
-def test_batched_gemm_a16wfp4_transpose_bm_eager(B, M, N, K, dtype):
-    """Lock the eager-mode shape contract: ``transpose_bm=True`` returns ``(M, B, N)``.
+def test_batched_gemm_a16wfp4_fake_honors_transpose_bm():
+    """Regression: the fake must match the real kernel's allocation
+    branch on ``transpose_bm`` (lines 100-103 of batched_gemm_a16wfp4.py).
 
-    The real kernel has switched on ``transpose_bm`` since the op was added,
-    but the public shape contract was previously only enforced via the fake
-    tensor (which did not match). This test pins the kernel contract so a
-    future kernel refactor cannot silently regress it.
+    Pre-fix the fake returned ``(Bx, M, N)`` regardless of
+    ``transpose_bm``, so under ``torch.compile`` AOTAutograd specialized
+    the unbacked SymInt ``M`` of any downstream consumer to the static
+    ``Bx`` -- silently producing wrong output (or a GPU memory access
+    fault) on cudagraph replay at any other ``M``. Post-fix the fake
+    returns ``(M, Bx, N)`` when ``transpose_bm=True``, matching the real
+    kernel.
+
+    Pure meta-tensor test: no GPU, no FP4 hardware, no kernel launch,
+    no ``torch.compile`` trace -- testing the fake function in isolation
+    is the necessary and sufficient condition for the downstream graph
+    to be correct.
     """
-    if not arch_info.is_fp4_avail():
-        pytest.skip("MXFP4 not supported on this architecture")
-
-    torch.cuda.empty_cache()
-    x, w, _x_scales, w_scales, _ = generate_batched_gemm_a16wfp4_inputs(
-        B, M, N, K, dtype, layout="TN", output=False
+    from aiter.ops.triton.gemm.batched.batched_gemm_a16wfp4 import (
+        batched_gemm_a16wfp4_fake_tensor,
     )
 
-    out = batched_gemm_a16wfp4(
-        x, w, w_scales, dtype, None, transpose_bm=True, prequant=True
+    B, M, N, K = 16, 7, 512, 128
+
+    x = torch.empty((B, M, K), dtype=torch.bfloat16, device="meta")
+    w = torch.empty((B, N, K // 2), dtype=torch.uint8, device="meta")
+    w_scales = torch.empty((B, N, K // 32), dtype=torch.uint8, device="meta")
+
+    out_t = batched_gemm_a16wfp4_fake_tensor(
+        x, w, w_scales, dtype=torch.bfloat16, transpose_bm=True
     )
-    assert out.shape == (
+    assert out_t.shape == (
         M,
         B,
         N,
-    ), f"transpose_bm=True must return (M, B, N); got {tuple(out.shape)}"
+    ), f"transpose_bm=True must return (M, B, N); got {tuple(out_t.shape)}"
 
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-def test_batched_gemm_a16wfp4_transpose_bm_compile_dynamic_M(dtype):
-    """Regression: under ``torch.compile`` with a dynamic-``M`` BMM whose
-    output is ``cat``-ed on ``dim=-1`` with a tensor of shape ``(M, B, K)``,
-    the fake tensor MUST honor ``transpose_bm`` -- otherwise AOTAutograd
-    specializes the unbacked ``M`` to ``B`` and replay at any other ``M``
-    runs the wrong slice.
-
-    Pre-fix this test fails with either:
-      * ``RuntimeError: Sizes of tensors must match except in dimension 2``
-        from the ``torch.cat`` (when shape mismatch is caught at trace time),
-      * a ``_assert_scalar`` runtime failure on the second invocation
-        (when AOTAutograd specialized ``M = B = 16`` and we later call with
-        ``M = 512``), or
-      * a silent shape mismatch + downstream OOB.
-    """
-    if not arch_info.is_fp4_avail():
-        pytest.skip("MXFP4 not supported on this architecture")
-
-    B, K, N = 16, 128, 512
-    qk_rope = 64
-
-    def f(x, w, w_scales, q_pe):
-        # x: (B, M, K)   w: (B, N, K//2)   w_scales: (B, N, K//SCALE_GROUP_SIZE)
-        # q_pe: (M, B, qk_rope) -- mirrors vLLM's MLA decode q-prep cat input
-        ql_nope = batched_gemm_a16wfp4(
-            x, w, w_scales, dtype, None, transpose_bm=True, prequant=True
-        )
-        # Must be cat-able on dim=-1 -> requires non-cat dims to match.
-        return torch.cat((ql_nope, q_pe), dim=-1)
-
-    fc = torch.compile(f, fullgraph=True, dynamic=True)
-
-    for M in (16, 512):
-        x, w, _x_scales, w_scales, _ = generate_batched_gemm_a16wfp4_inputs(
-            B, M, N, K, dtype, layout="TN", output=False
-        )
-        q_pe = torch.randn((M, B, qk_rope), dtype=dtype, device="cuda")
-        # Mark the M dim of x dynamic so AOTAutograd traces an unbacked SymInt
-        # for the BMM's M -- the conditions under which the fake bug triggers.
-        torch._dynamo.mark_dynamic(x, 1)
-        torch._dynamo.mark_dynamic(q_pe, 0)
-
-        out = fc(x, w, w_scales, q_pe)
-        assert out.shape == (
-            M,
-            B,
-            N + qk_rope,
-        ), f"M={M}: got {tuple(out.shape)}, expected ({M}, {B}, {N + qk_rope})"
+    out_f = batched_gemm_a16wfp4_fake_tensor(
+        x, w, w_scales, dtype=torch.bfloat16, transpose_bm=False
+    )
+    assert out_f.shape == (
+        B,
+        M,
+        N,
+    ), f"transpose_bm=False must return (B, M, N); got {tuple(out_f.shape)}"

--- a/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
+++ b/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
@@ -189,3 +189,82 @@ def test_batched_gemm_a16wfp4(B: int, M: int, N: int, K: int, layout, dtype):
     batched_gemm_a16wfp4(x, w, w_scales, dtype, out, transpose_bm=False, prequant=True)
 
     torch.testing.assert_close(torch_out, out)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("B, M, N, K", [(16, 16, 512, 128), (16, 512, 512, 128)])
+def test_batched_gemm_a16wfp4_transpose_bm_eager(B, M, N, K, dtype):
+    """Lock the eager-mode shape contract: ``transpose_bm=True`` returns ``(M, B, N)``.
+
+    The real kernel has switched on ``transpose_bm`` since the op was added,
+    but the public shape contract was previously only enforced via the fake
+    tensor (which did not match). This test pins the kernel contract so a
+    future kernel refactor cannot silently regress it.
+    """
+    if not arch_info.is_fp4_avail():
+        pytest.skip("MXFP4 not supported on this architecture")
+
+    torch.cuda.empty_cache()
+    x, w, _x_scales, w_scales, _ = generate_batched_gemm_a16wfp4_inputs(
+        B, M, N, K, dtype, layout="TN", output=False
+    )
+
+    out = batched_gemm_a16wfp4(
+        x, w, w_scales, dtype, None, transpose_bm=True, prequant=True
+    )
+    assert out.shape == (
+        M,
+        B,
+        N,
+    ), f"transpose_bm=True must return (M, B, N); got {tuple(out.shape)}"
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_batched_gemm_a16wfp4_transpose_bm_compile_dynamic_M(dtype):
+    """Regression: under ``torch.compile`` with a dynamic-``M`` BMM whose
+    output is ``cat``-ed on ``dim=-1`` with a tensor of shape ``(M, B, K)``,
+    the fake tensor MUST honor ``transpose_bm`` -- otherwise AOTAutograd
+    specializes the unbacked ``M`` to ``B`` and replay at any other ``M``
+    runs the wrong slice.
+
+    Pre-fix this test fails with either:
+      * ``RuntimeError: Sizes of tensors must match except in dimension 2``
+        from the ``torch.cat`` (when shape mismatch is caught at trace time),
+      * a ``_assert_scalar`` runtime failure on the second invocation
+        (when AOTAutograd specialized ``M = B = 16`` and we later call with
+        ``M = 512``), or
+      * a silent shape mismatch + downstream OOB.
+    """
+    if not arch_info.is_fp4_avail():
+        pytest.skip("MXFP4 not supported on this architecture")
+
+    B, K, N = 16, 128, 512
+    qk_rope = 64
+
+    def f(x, w, w_scales, q_pe):
+        # x: (B, M, K)   w: (B, N, K//2)   w_scales: (B, N, K//SCALE_GROUP_SIZE)
+        # q_pe: (M, B, qk_rope) -- mirrors vLLM's MLA decode q-prep cat input
+        ql_nope = batched_gemm_a16wfp4(
+            x, w, w_scales, dtype, None, transpose_bm=True, prequant=True
+        )
+        # Must be cat-able on dim=-1 -> requires non-cat dims to match.
+        return torch.cat((ql_nope, q_pe), dim=-1)
+
+    fc = torch.compile(f, fullgraph=True, dynamic=True)
+
+    for M in (16, 512):
+        x, w, _x_scales, w_scales, _ = generate_batched_gemm_a16wfp4_inputs(
+            B, M, N, K, dtype, layout="TN", output=False
+        )
+        q_pe = torch.randn((M, B, qk_rope), dtype=dtype, device="cuda")
+        # Mark the M dim of x dynamic so AOTAutograd traces an unbacked SymInt
+        # for the BMM's M -- the conditions under which the fake bug triggers.
+        torch._dynamo.mark_dynamic(x, 1)
+        torch._dynamo.mark_dynamic(q_pe, 0)
+
+        out = fc(x, w, w_scales, q_pe)
+        assert out.shape == (
+            M,
+            B,
+            N + qk_rope,
+        ), f"M={M}: got {tuple(out.shape)}, expected ({M}, {B}, {N + qk_rope})"


### PR DESCRIPTION
## Summary

The fake tensor function registered for `aiter::batched_gemm_a16wfp4_` ignores
the `transpose_bm` argument and always returns `(Bx, M, N)`, while the real
kernel returns `(M, B, N)` when `transpose_bm=True`. Under `torch.compile`,
this fake/real mismatch silently produces wrong output (or a GPU memory access
fault) for any caller whose downstream consumer constrains the BMM output's
leading dimension.

Fixes the fake to match the real kernel by branching on `transpose_bm` and
adds a torch.compile regression test that catches the bug deterministically.

## Motivation

`aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py`:

* Real kernel allocation (lines 100-103, unchanged):

  ```python
  if y is None:
      if transpose_bm:
          y = torch.empty((M, B, N), dtype=dtype, device=x.device)
      else:
          y = torch.empty((B, M, N), dtype=dtype, device=x.device)
  ```

* Registered fake (lines 31-46, before this PR):

  ```python
  def batched_gemm_a16wfp4_fake_tensor(...):
      if y is None:
          Bx, M, _ = x.shape
          _, N, _ = w.shape
          return torch.empty((Bx, M, N), dtype=dtype, device=x.device)  # ignores transpose_bm
      return y
  ```

Under `torch.compile`, AOTAutograd traces against the fake, so it propagates
`(Bx, M, N)` even when `transpose_bm=True`. 

### Why the fake's dim *position* matters even when both `Bx` and `M` are real

Both `Bx` and `M` are real values pulled from `x.shape`, so the natural reaction
is "returning `(Bx, M, N)` vs `(M, Bx, N)` is just the same tensor with the
dims renamed". It isn't. Under `torch.compile`, the fake commits to the
**positional identity** of each output dim, not just to its value, and in this
op the two dims carry very different tracing semantics:

* `Bx = x.shape[0]` is typically a **static int** in the caller (e.g. a
  `num_heads` constant baked into the FX graph at module-init time).
* `M = x.shape[1]` is typically an **unbacked `SymInt`** (e.g. a per-step
  `num_decode_tokens` returned by an upstream metadata-reading custom op,
  resolved only at runtime).

The real kernel under `transpose_bm=True` puts the *SymInt* at
`output.shape[0]`. The buggy fake puts the *static int* at `output.shape[0]`.
Numerically equivalent only when they happen to coincide at one particular
trace; structurally inequivalent always — and it's the structural identity
that the rest of the compiled graph reads.

If the BMM output is then `cat`-ed on `dim=-1` with a tensor of shape
`(M, B, K)` — the typical pattern for an MLA decode q-prep where the per-head
BMM output is concatenated with a per-head RoPE tensor — AOTAutograd cannot
make the non-cat dims agree under the buggy fake without specializing
`Eq(M, Bx)`. The captured graph then bakes a literal-`Bx` slice
(`aten.slice(q, 0, 0, Bx)`) in place of the dynamic
`aten.slice(q, 0, 0, M_symbolic)`, and on cudagraph replay at any `M ≠ Bx` the
BMM processes the wrong rows — silently wrong output, or a GPU memory access
fault when the consumer indexes past the truncated buffer.

This was first reproduced from vLLM with `fuse_aiter_qk_rope_concat_and_cache_mla=True` 
on Kimi-K2.5 MXFP4: server compiles cleanly and starts, but `lm_eval` triggers
`Memory access fault by GPU node-N (Agent handle: ...) on address ...`
during the first decode batch with `num_decode_tokens != num_heads`. The
post-grad FX graph dump shows four `_assert_scalar(Eq(u0, 16))` runtime
asserts and a literal `aten.slice.Tensor(slice_scatter, 0, 0, 16)` where
the lift wrote `q.narrow(0, 0, num_decode)`.

## Changes

* `aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py`:
  one branch added to `batched_gemm_a16wfp4_fake_tensor` so it returns
  `(M, Bx, N)` when `transpose_bm=True`, matching the real kernel.
* `op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py`:
  two new tests:
  - `test_batched_gemm_a16wfp4_transpose_bm_eager` -- pins the eager-mode
    shape contract `(M, B, N)` for `transpose_bm=True` so a future kernel
    refactor cannot silently regress it.
  - `test_batched_gemm_a16wfp4_transpose_bm_compile_dynamic_M` -- compiles
    the BMM under `torch.compile(fullgraph=True, dynamic=True)` with
    `mark_dynamic` on the `M` dim, runs it twice with different `M` values,
    and asserts the cat-on-dim=-1 output shape. Pre-fix this fails (either
    at trace time with a `torch.cat` shape mismatch, or at runtime with an
    `Eq(u0, B)` `_assert_scalar` on the second call); post-fix it passes.

No public API change, no kernel change, no impact on `transpose_bm=False`
callers.

### Related code that is not changed by this PR

`aiter/ops/triton/gemm/batched/batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant.py`
also has a `transpose_bm` parameter and would be vulnerable to the same
fake/real mismatch -- but it is currently a plain Python wrapper (no
`torch_compile_guard`, no fake). It computes the output shape directly at
trace time, so the bug is dormant. Flagging here so a future PR that wraps
it as a custom op remembers to add the `transpose_bm` switch in its fake too.

## Performance

No performance impact. Fake tensor functions only run during
`torch.compile` tracing.

## Testing

* New regression tests in `op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py`:
  - `test_batched_gemm_a16wfp4_transpose_bm_eager` (eager)
  - `test_batched_gemm_a16wfp4_transpose_bm_compile_dynamic_M` (`torch.compile`)
* Existing `test_batched_gemm_a16wfp4` continues to pass unchanged
  (covers `transpose_bm=False`).
* Verified end-to-end on the original failure on vLLM with
  `fuse_aiter_qk_rope_concat_and_cache_mla=True` on Kimi-K2.5 MXFP4 (gfx950),
  4× tp, AITER FP4 BMM enabled. Pre-fix: GPU memory access fault during
  `lm_eval`. Post-fix: clean compile + clean codegen (no `Eq(u0, 16)`
  runtime asserts in the captured graph) + `lm_eval` accuracy unchanged
  versus the no-fusion baseline.


## Dependencies

- [x] No new third-party dependencies added

## Breaking Changes

None. The eager-mode shape contract is unchanged. Any caller relying on the
buggy fake shape would already have been broken at runtime, so there is no
working-but-now-broken caller.