### PR TITLE
[Bugfix][Triton] Declare explicit `mutates_args=["y"]` for batched_gemm_a16wfp4_

### DIFF
--- a/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
+++ b/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py
@@ -46,7 +46,7 @@ def batched_gemm_a16wfp4_fake_tensor(
     return y
 
 
-@torch_compile_guard(gen_fake=batched_gemm_a16wfp4_fake_tensor)
+@torch_compile_guard(mutates_args=["y"], gen_fake=batched_gemm_a16wfp4_fake_tensor)
 def batched_gemm_a16wfp4_(
     x: torch.Tensor,
     w: torch.Tensor,

--- a/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
+++ b/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
@@ -189,3 +189,43 @@ def test_batched_gemm_a16wfp4(B: int, M: int, N: int, K: int, layout, dtype):
     batched_gemm_a16wfp4(x, w, w_scales, dtype, out, transpose_bm=False, prequant=True)
 
     torch.testing.assert_close(torch_out, out)
+
+
+def test_batched_gemm_a16wfp4_schema_mutates_only_y():
+    """Lock the mutation contract: only ``y`` is mutated by the kernel.
+
+    AITER's ``torch_compile_guard`` decorator defaults ``mutates_args`` to
+    ``"unknown"``, which marks every Tensor argument of the wrapped op as
+    in-place mutated (``Tensor(aN!)`` in the schema). For
+    ``batched_gemm_a16wfp4_`` the kernel only writes to ``y``, so the op
+    must declare ``mutates_args=["y"]`` explicitly. Otherwise AOTAutograd
+    inserts spurious ``auto_functionalized()`` writeback chains on the
+    read-only inputs, which break downstream FX pattern matchers and inflate
+    cudagraph capture peak memory.
+    """
+    if not arch_info.is_fp4_avail():
+        pytest.skip("MXFP4 not supported on this architecture")
+
+    op = torch.ops.aiter.batched_gemm_a16wfp4_
+    schemas = list(op._schemas.values())
+    assert len(schemas) == 1, f"unexpected overload set: {schemas}"
+    schema_str = str(schemas[0])
+
+    # The post-fix schema must NOT have alias annotations on x / w / w_scales /
+    # y_scale -- those are read-only inputs.
+    for read_only_arg in ("Tensor x", "Tensor w", "Tensor w_scales"):
+        assert (
+            read_only_arg in schema_str
+        ), f"expected unannotated `{read_only_arg}` in schema, got: {schema_str}"
+        bad = read_only_arg.replace("Tensor", "Tensor(a")
+        assert (
+            bad not in schema_str
+        ), f"read-only arg appears as mutating in schema: {schema_str}"
+    assert (
+        "Tensor? y_scale" in schema_str
+    ), f"expected unannotated `Tensor? y_scale` in schema, got: {schema_str}"
+
+    # The post-fix schema MUST still mark `y` as mutating (`Tensor(aN!)?`).
+    assert (
+        "Tensor(a" in schema_str and "!)? y=None" in schema_str
+    ), f"expected `y` to remain a mutating optional tensor, got: {schema_str}"


### PR DESCRIPTION
## Summary

`aiter::batched_gemm_a16wfp4_` is wrapped with the default
`@torch_compile_guard(gen_fake=...)` decorator, which leaves
`mutates_args` at its default of `"unknown"`. Per
`torch.library.infer_schema`, `"unknown"` means "the caller has not
declared which args are mutated, so mark every Tensor argument as
in-place mutated for safety". For this op, only `y` is actually mutated;
declaring `x`, `w`, `w_scales`, and `y_scale` as mutating is incorrect
and breaks downstream `torch.compile` consumers.

This PR sets `mutates_args=["y"]` on the decorator. No kernel change.

## Motivation

The kernel `_batched_gemm_a16wfp4_kernel[grid](x, w, y, w_scales, y_scale, ...)`
in `aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py` writes to `y`
(or to a temporary `y_pp` if `NUM_KSPLIT > 1`, which is then reduced into
`y` by `_batched_gemm_a16wfp4_reduce_kernel`). It does **not** write to
`x`, `w`, `w_scales`, or `y_scale` -- those are loaded via `tl.load(...)`
inside the kernel and never stored back to. `y_scale` is read inside the
`HAVE_Y_SCALE` branch (line 185) as the per-tensor input quant scale.

Today the op declares (effectively) `mutates_args="unknown"`, so its
generated schema is:

    aiter::batched_gemm_a16wfp4_(
        Tensor(a0!) x, Tensor(a1!) w, Tensor(a2!) w_scales,
        ScalarType? dtype=15, Tensor(a4!)? y=None,
        str? config=None, bool? transpose_bm=False, bool? prequant=True,
        Tensor(a8!)? y_scale=None,
    ) -> Tensor

The `Tensor(aN!)` markers on `x`, `w`, `w_scales`, and `y_scale` are
unnecessary. Under `torch.compile`, AOTAutograd reacts to them by:

* Wrapping the call in `auto_functionalized(batched_gemm_a16wfp4_, ...)`
  with one entry in the output tuple **per Tensor argument** rather than
  just for the actually-mutated arguments.
* Synthesizing `aten.copy_(arg_view, at[N])` writeback chains for every
  Tensor input that came from a slice / select / view upstream.
* Inserting `slice_scatter` chains around every such input so the
  writeback can be functionalized.

These extra nodes:

1. **Break FX pattern matchers** that try to fuse around the BMM. The
   matcher expects a clean call to `auto_functionalized(BMM, ...)` whose
   output indices map to the actually-mutated args; with the unnecessary
   markers, the matcher has to navigate writeback chains on read-only
   inputs to find the BMM node, which is fragile and pattern-version-
   specific. In addition, vLLM's MLA decode q-prep fusion pass then has to
   manually erase these writeback chains in a post-fusion cleanup
   pass to keep the matcher viable -- a workaround that this PR removes
   the need for.
2. **Inflate cudagraph capture peak memory**, because read-only inputs
   are kept alive through the writeback chain past the point they would
   otherwise have died.
3. **Disable common subexpression elimination** on the read-only inputs,
   because each one ends up wrapped in a copy/slice_scatter cluster.

Setting `mutates_args=["y"]` declares the actual contract and the schema
becomes:

    aiter::batched_gemm_a16wfp4_(
        Tensor x, Tensor w, Tensor w_scales,
        ScalarType? dtype=15, Tensor(a4!)? y=None,
        str? config=None, bool? transpose_bm=False, bool? prequant=True,
        Tensor? y_scale=None,
    ) -> Tensor

AOTAutograd then only inserts a writeback for `y` (and only when `y is
not None`), the read-only inputs are left untouched, and downstream pattern matchers can bind on the BMM directly.

## Changes

* `aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py`:
  the decorator on `batched_gemm_a16wfp4_` (line 49) gains an explicit
  `mutates_args=["y"]`.
* `op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py`:
  new test `test_batched_gemm_a16wfp4_schema_mutates_only_y` pins the
  post-fix schema so a future revert cannot silently re-introduce the
  spurious mutation markers.

No kernel change, no Python API change, no impact on eager-mode callers.

## Performance

No measurable performance change in eager mode (the schema is
metadata-only). Under `torch.compile`, removing the spurious writeback
chains reduces graph size and cudagraph capture peak memory; vLLM
observed roughly a 5-10% reduction in captured graph node count for
the layer that uses this op (one BMM per attention layer, 61 layers in
the model under test).

## Testing

* New regression test:
  `op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py::test_batched_gemm_a16wfp4_schema_mutates_only_y`
  -- pins the post-fix schema.
* Existing `test_batched_gemm_a16wfp4` continues to pass unchanged
  (eager-mode correctness coverage; the schema change is invisible there).
* Validated end-to-end on vLLM's MLA decode q-prep fusion.

## Dependencies

- [x] No new third-party dependencies added

## Breaking Changes

None. The schema becomes strictly more permissive (fewer mutation
markers), which is backwards-compatible. Any caller that was relying on
AOTAutograd inserting writeback chains for `x` / `w` / `w_scales` /
`y_scale` would have been relying on accidental behavior -- the kernel
itself does not modify those inputs.

## Out of scope (explicit non-goals for this PR)

* Does not change the default value of `mutates_args` in
  `aiter/jit/utils/torch_guard.py::torch_compile_guard`. The conservative
  `"unknown"` default is correct as a "I have not audited this op" safety
  net; flipping it to `[]` (no mutation) would silently break any op that
  actually does mutate but never declared so. A follow-up PR could
  audit the ~20 other AITER ops that currently rely on the implicit
  default and either:
  - declare `mutates_args=[...]` explicitly per-op, or
  - leave them at `"unknown"` until their kernel side-effects are
    audited.

  The full inventory (from `git grep '@torch_compile_guard'`) of ops
  that today rely on the implicit default and may benefit from the same
  treatment as this PR:

  ```
  aiter/dist/parallel_state.py:                 all_reduce_, fused_allreduce_rmsnorm_, fused_allreduce_rmsnorm_quant_
  aiter/fused_moe.py:                           fused_moe_
  aiter/jit/chip_info.py:                       get_gfx_custom_op, get_cu_num_custom_op
  aiter/jit/core.py:                            check_numa_custom_op, get_module_custom_op
  aiter/ops/gemm_op_a4w4.py:                    gemm_a4w4
  aiter/ops/gemm_op_a8w8.py:                    gemm_a8w8, gemm_a8w8_bpreshuffle, gemm_a8w8_blockscale,
                                                gemm_a8w8_blockscale_bpreshuffle
  aiter/ops/quant.py:                           per_token_quant_hip, per_group_quant_hip
  aiter/ops/triton/attention/mha_v3.py:         _flash_attn_with_kvcache
  aiter/ops/triton/fusions/fused_kv_cache.py:   fused_qk_rope_cat_and_cache_mla
  aiter/ops/triton/gemm/basic/gemm_a16w16_atomic.py: gemm_a16w16_atomic_
  aiter/ops/triton/gemm/basic/gemm_a16wfp4.py:  gemm_a16wfp4_, gemm_a16wfp4_preshuffle_
  aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py: gemm_afp4wfp4_
  aiter/tuned_gemm.py:                          gemm_a16w16
  ```

  Each one needs a small per-op audit (look at the kernel launch and check
  which Tensor args appear on the LHS of an assignment). The pattern from
  this PR applies directly: most of these have an optional pre-allocated
  output `y` / `out` and read-only inputs `x` / `w` / `scales`, so the
  declaration is `mutates_args=["y"]` (or `["out"]`).

* Does not touch `_flash_attn_backward` (which already correctly declares
  `mutates_args=["dq", "dk", "dv"]`).