### PR TITLE
[TRITON] gfx1201: gemm_a8w8 tuning configs (Mistral-3 / Qwen3 shapes)

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=28672-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=28672-K=4096.json
@@ -1,0 +1,15 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=4096-K=14336.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=4096-K=14336.json
@@ -1,0 +1,15 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=4096-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=4096-K=4096.json
@@ -1,0 +1,15 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=6144-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8-N=6144-K=4096.json
@@ -1,0 +1,15 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8.json
@@ -1,0 +1,15 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}


### PR DESCRIPTION
## Summary

Two small additions that let aiter run on RDNA4 (gfx1201, RX 9070 XT family) without the calling project having to maintain its own kernel/config replicas.

1. **`aiter.ops.triton.activation.silu_and_mul`** — a triton implementation of the existing HIP `silu_and_mul`, with the same `(out, x)` signature so callers can dispatch by arch without changing call sites. The HIP kernel does not compile on RDNA4: its inner `activation_kernels.cu` uses `v_pk_mul_f32`, an instruction that exists only on CDNA (gfx9*) and gfx1250.

2. **5 `gfx1201-GEMM-A8W8*.json` tuning configs** for the per-tensor FP8 `gemm_a8w8` triton kernel. Without these, `gemm_config_utils` falls through to the cross-arch default (`GROUP_SIZE_M=4`), which leaves 75% of M-dim launch slots idle on RDNA4 at decode bs=1..32. Each config is hand-tuned on RX 9070 XT for one of the four projection shapes used by Mistral-3-8B / Qwen3-8B-FP8 (qkv, o, gate_up, down).

## Headline numbers (gfx1201, RX 9070 XT, ROCm 7.x)

`silu_and_mul` triton vs torch fallback (the only other option on gfx1201):

| Shape (M, 2H)        | Triton | Torch  | Δ      |
|---------------------:|-------:|-------:|-------:|
| (8,    28672)        |  9.1us | 10.0us | -9%    |
| (32,   28672)        |  9.2us | 13.2us | -30%   |
| (1024, 28672)        |  153us | 205us  | -25%   |

`gemm_a8w8` per-shape configs vs the cross-arch default at decode bs=1:

| Shape   | Default | Tuned   |
|---------|--------:|--------:|
| qkv     | 163us   | 33us    |
| o       |  45us   | 28us    |
| gate_up | 229us   | 211us   |
| down    | 107us   | 36us    |

## Test plan

- [x] silu_and_mul: bf16 + fp16, 2H non-power-of-2 included; relative err <1% vs F.silu(a)*b (triton accumulates in fp32, so it is in fact more accurate than the bf16 reference)
- [x] gemm_a8w8: `get_gemm_config(\"GEMM-A8W8\", M, N, K)` returns the new specialized blocks for all 4 (N, K); kernel output 0 abs-err vs BF16 reference (dequant FP8 then matmul) at bs in {1, 8, 32}
- [x] No regression risk for other archs — both additions are arch-specific files / new symbols; nothing existing is renamed or removed

## Context

Used by ROCm/ATOM in https://github.com/ROCm/ATOM/pull/749 (gfx1201 / Mistral-3-8B + Qwen3-8B-FP8 enablement). Once this PR lands and the aiter pin in ATOM is bumped, ATOM can delete its `_silu_mul_triton` and `_gfx1201_gemm_a8w8_config` replicas.
