### PR TITLE
docs: add AITER May 2026 newsletter

### DIFF
--- a/docs/newsletter/2026-05.md
+++ b/docs/newsletter/2026-05.md
@@ -1,0 +1,170 @@
+# AITER Newsletter — May 2026
+
+**Period covered:** April 14 – May 13, 2026
+
+[AITER](https://github.com/ROCm/aiter) is AMD's open-source AI Tensor Engine for ROCm: a kernel and primitive library for inference and training acceleration on Instinct GPUs (MI300X, MI308, MI325X, MI355X) and Radeon RDNA4/RDNA5. AITER is consumed downstream by vLLM, SGLang, ATOM, and PyTorch ROCm.
+
+This is the first issue of a monthly newsletter. Goal: keep our partners current on what's landed in `main`, what's been released, and what's coming. Feedback welcome via [GitHub Issues](https://github.com/ROCm/aiter/issues).
+
+## TL;DR
+
+- **221 commits** to `main`, **37 contributors**, ~50 commits/week steady-state.
+- **2 official releases shipped:** v0.1.12.post2 (Apr 23) and v0.1.13 (May 9). v0.1.14 in RC.
+- **DeepSeek-V4 enablement** is the dominant cross-cutting theme: fused kernels, tuned configs, A8W4 MoE, MLA improvements landing in waves.
+- **MoE kernel family expanded:** new int4 path for Kimi-K2.5, A8W4 for DSv4, MXFP4 alignment, swiglu A4W4 for GPT-OSS, ASM fmoe for gfx950.
+- **Architecture footprint widened:** gfx950 (MI355X) maturing in production, gfx1201 (RDNA4) FlashAttention backend landed, gfx1250 (MI450) early enablement via FlyDSL 0.1.7.
+- **Release engineering tightened:** 6-wheel manylinux_2_28 matrix per release with strict torch ABI pinning.
+
+## How to Use AITER
+
+Public manylinux wheels are published with each release for ROCm 7.0 / 7.1 / 7.2 × Python 3.10 / 3.12, fat-binary across `gfx942` (MI300/MI308/MI325X) and `gfx950` (MI355X):
+
+```bash
+pip install aiter --extra-index-url https://download.pytorch.org/whl/rocm7.2
+```
+
+Or download release artifacts directly: [github.com/ROCm/aiter/releases](https://github.com/ROCm/aiter/releases).
+
+Build from source: see [BUILD.md](https://github.com/ROCm/aiter/blob/main/BUILD.md). Submodule init is required (`git submodule update --init --recursive`).
+
+## Releases Shipped This Period
+
+| Version | Date | Highlights |
+|---|---|---|
+| v0.1.12.post2 | 2026-04-23 | Critical CK MoE multi-arch dispatch fix (#2645), workflow `torch_pin` support (#2875) |
+| v0.1.13-rc1 → rc5 | 2026-04-25 → 2026-05-08 | Five RC iterations covering preshuffle layouts, MLA fixes, ASM fmoe kernels |
+| v0.1.13 | 2026-05-09 | Production release. New ASM fmoe kernels for gfx950 (off by default, opt-in via `AITER_XBFLOAT16=1`) |
+
+## Highlights by Area
+
+### DeepSeek-V4 Enablement
+
+DSv4 is now the largest cross-cutting workstream in AITER. Coverage spans Triton, ATOM integration, FlyDSL kernels, and tuned GEMM/FMoE configs.
+
+- **DSV4 fusions phase 1** ([#3057](https://github.com/ROCm/aiter/pull/3057)): `fused_reduce_q_norm_qk_rope_swa_write` and `fused_clamp_act_mul_quant`, integrated end-to-end in ATOM.
+- **DSv4-Pro BF16 tuned GEMM** ([#3113](https://github.com/ROCm/aiter/pull/3113)): no-hipblaslt path.
+- **DSv4-Pro A8W8 blockscale tuned configs** ([#3108](https://github.com/ROCm/aiter/pull/3108)).
+- **A8W4 MoE FlyDSL path for DSv4** ([#2951](https://github.com/ROCm/aiter/pull/2951)).
+- **Fused rope + rotate_activation + fp4_quant_inplace** ([#3035](https://github.com/ROCm/aiter/pull/3035)): single-pass DSv4 prologue.
+- **Bulk merge of tuned configs** ([#3004](https://github.com/ROCm/aiter/pull/3004) + [#3024](https://github.com/ROCm/aiter/pull/3024)): GLM-4.7, Kimi-K2.5, MiniMax-M2.5, DeepSeek-V3.2 GEMM and FMoE.
+
+### MoE Kernel Family
+
+Significant diversification of MoE precision and quantization paths.
+
+- **Kimi-K2.5 a16wi4 MoE** ([#2863](https://github.com/ROCm/aiter/pull/2863)): bf16 activations × packed int4 weights with per-1×32 bf16 groupwise scale. New FlyDSL `int4_bf16` stage1/stage2 kernels and fused `swiglu_and_mul`.
+- **MXFP4 fused quant path alignment** ([#3123](https://github.com/ROCm/aiter/pull/3123)): consistent semantics across A4W4 paths.
+- **MXFP4 quantize kernel** ([#2976](https://github.com/ROCm/aiter/pull/2976)): standalone primitive for upstream quantization pipelines.
+- **GPT-OSS swiglu A4W4 path** ([#2972](https://github.com/ROCm/aiter/pull/2972)): enables GPT-OSS on A4W4 hardware.
+- **ASM fmoe kernels for gfx950** ([#2262](https://github.com/ROCm/aiter/pull/2262)): bypass bf16→fp8 quantization. Triple-gated behind `AITER_XBFLOAT16=1` env var, gfx950 only, `per_1×128` quant only. Opt-in for safety in this release line.
+- **Top-k optimizations**: radix top-k for MI308/MI355X ([#3087](https://github.com/ROCm/aiter/pull/3087)), sigmoid/softmax `topk_gating` ([#3100](https://github.com/ROCm/aiter/pull/3100)), Triton fused topk ([#3096](https://github.com/ROCm/aiter/pull/3096)).
+- **GPT-OSS MoE TP2/TP8 tuned configs** ([#3140](https://github.com/ROCm/aiter/pull/3140)).
+
+### MLA / Multi-head Latent Attention
+
+- **HK MLA: MI35X m16x8 retune + new m16x4 kernel + page_size + mask support** ([#3072](https://github.com/ROCm/aiter/pull/3072)).
+- **MI350 MLA ps mode bf16**: `nhead64,1` routed to `m16x4`, no folding ([#3063](https://github.com/ROCm/aiter/pull/3063)).
+- **gfx950 ASM PA non-persistent decode crash on `nhead=32` fixed** ([#2983](https://github.com/ROCm/aiter/pull/2983)).
+- **FP8 MLA decode kernel for `sub_kv=64, sub_qh=8`** ([#3014](https://github.com/ROCm/aiter/pull/3014)): for `gqa_ratio=8, qseqlen=1` workloads.
+
+### FMHA / Attention
+
+- **F8 FMHA ASM gfx950** ([#2911](https://github.com/ROCm/aiter/pull/2911)): production-grade FMHA on MI355X.
+- **`batch_prefill` OOB page table read fix with regression tests** ([#3032](https://github.com/ROCm/aiter/pull/3032)).
+- **rope OOB under concurrent scenarios** ([#3078](https://github.com/ROCm/aiter/pull/3078)).
+- **dsink bf16 noise in Triton MHA backward** ([#3070](https://github.com/ROCm/aiter/pull/3070)).
+- **`fused_qk_rmsnorm_per_token_quant` kernel** ([#2958](https://github.com/ROCm/aiter/pull/2958)): new fused primitive.
+- **Manifold-constrained Hyper Connection (mHC-pre)** ([#2646](https://github.com/ROCm/aiter/pull/2646)): research path enabled in Triton.
+
+### Architecture Expansion
+
+- **gfx950 (MI355X)** — maturing across MoE, MLA, and FMHA. Now the primary production target alongside gfx942.
+- **gfx1201 (RDNA4)** — FlyDSL `flash_attn_func` backend landed in v0.1.13. First RDNA4-class attention backend in AITER.
+- **gfx1250 (MI450)** — FlyDSL 0.1.7 adds early gfx1250 support ([#3121](https://github.com/ROCm/aiter/pull/3121)). Pre-silicon enablement track.
+- **gfx942 (MI300/MI308/MI325X)** — continued tuning, e.g. dsv3 blockscale GEMM config in MI300 ([#2881](https://github.com/ROCm/aiter/pull/2881)).
+
+### FlyDSL
+
+FlyDSL is AITER's emerging in-house DSL for high-performance kernels, providing a path that complements Composable Kernel (CK).
+
+- Version progression: 0.1.4 → 0.1.5 → 0.1.6 → 0.1.7 over the period.
+- **gfx1250 support** ([#3121](https://github.com/ROCm/aiter/pull/3121)).
+- **GDR decode indexing fix** ([#3125](https://github.com/ROCm/aiter/pull/3125)).
+- **`fly_values` import compatibility fix** ([#3141](https://github.com/ROCm/aiter/pull/3141)).
+- New kernel families: int4 MoE, A8W4 MoE, `swiglu_and_mul`, MXScale FP8/A8W4 GEMM.
+
+### Notable Bug Fixes
+
+- **CK MoE multi-arch dispatch silent wrong-kernel** ([#2645](https://github.com/ROCm/aiter/pull/2645)) — shipped in v0.1.12.post2. Affected anyone with a multi-arch fat binary.
+- **CK MoE split-k buffer dispatch** ([#3050](https://github.com/ROCm/aiter/pull/3050)) — wrong buffer size on identity vs equality compare.
+- **Address overflow in tile dispatch** ([#3124](https://github.com/ROCm/aiter/pull/3124)).
+- **`cp_gather_indexer_k_cache` indexing** ([#2954](https://github.com/ROCm/aiter/pull/2954)).
+- **GLM-5 GEMM bf16 8192×2048 retune** ([#3101](https://github.com/ROCm/aiter/pull/3101)) — accuracy regression resolution.
+
+### Downstream Integrations
+
+- **vLLM v0.19.1**: torch ABI pinning matrix per ROCm version (7.0 → torch 2.10, 7.1 → torch 2.10, 7.2 → torch 2.11). Verified against MI355X.
+- **SGLang AMD aiter CI branch** ([#3120](https://github.com/ROCm/aiter/pull/3120)): downstream SGLang now runs on a dedicated AMD aiter branch in CI for predictable integration.
+- **ATOM 0.1.2.post**: tracks AITER releases. v0.1.13 validated against ATOM serving via lm-eval gsm8k 3-shot.
+- **PyTorch wheels**: AITER wheels available on `download.pytorch.org/whl/rocm{7.0,7.1,7.2}` via PyTorch's manylinux2_28 builder images.
+
+### Release Engineering
+
+- **6-wheel matrix per release**: ROCm 7.0 / 7.1 / 7.2 × Python 3.10 / 3.12, manylinux_2_28 ABI, fat binary `gfx942;gfx950`.
+- **Strict torch ABI pinning** via the `torch_pin` workflow input. Avoids the recurring `c10::cuda` undefined-symbol class of failures when wheels are mixed with mismatched torch builds.
+- **CI prebuilt kernel reuse** ([#3143](https://github.com/ROCm/aiter/pull/3143)): cuts test wall time.
+- **Auto-update split-test FILE_TIMES** ([#2918](https://github.com/ROCm/aiter/pull/2918)): keeps shard balance current.
+- **Known issues now tracked in release notes** when material to consumers (e.g. [#3076](https://github.com/ROCm/aiter/issues/3076), [#3062](https://github.com/ROCm/aiter/issues/3062)).
+
+## Validation Reference
+
+GSM8K 3-shot, flexible-extract, MI355X, on ATOM serving:
+
+| Model | v0.1.13 Score | Threshold |
+|---|---|---|
+| DeepSeek-R1-0528 | 0.9454 | 0.94 |
+| MiniMax-M2.5 | 0.9295 | 0.92 |
+| Qwen3-235B-FP8 | 0.8802 | 0.87 |
+
+## What's Coming
+
+### v0.1.14 (target this week)
+
+- Cumulative changes since v0.1.13 (141 commits).
+- DSv4 fusions phase 1 in baseline, plus DSv4-Pro tuned GEMM.
+- HK MLA retune for MI35X.
+- `batch_prefill` OOB fix.
+- 6-wheel matrix shipped, accuracy validation gating.
+
+### v0.1.13.post1 (in next 1–2 days)
+
+- Adds Kimi-K2.5 a16wi4 MoE ([#2863](https://github.com/ROCm/aiter/pull/2863)) + splitk fix ([#3050](https://github.com/ROCm/aiter/pull/3050)) on top of v0.1.13, for partners needing the int4 MoE path on the v0.1.13 line.
+
+### Beyond v0.1.14
+
+- DSv4 fusions phase 2.
+- MORI v1.2.0 first release.
+- Continued gfx1250 enablement as silicon matures.
+- Continued FlyDSL kernel coverage expansion.
+
+## Known Issues Carrying
+
+- **[#3076](https://github.com/ROCm/aiter/issues/3076)** — `aiter/dist/shm_broadcast.py` uses `pickle.loads` on a TCP-bound ZMQ XPUB. Pre-existing since v0.1.12. Mitigation: bind to loopback only or front the broadcast socket with a firewall.
+- **[#3062](https://github.com/ROCm/aiter/issues/3062)** — gfx950 ASM paged-attention `block_id` truncates at the 16-bit / 65,536-block (~2 GB) boundary. Pre-existing. Mitigation: route pure-MHA layers to the Triton/Gluon paged-attention path.
+
+Both will be addressed in v0.1.14 or a follow-up post-release.
+
+## Get Involved
+
+- **Repo:** [github.com/ROCm/aiter](https://github.com/ROCm/aiter)
+- **Releases & wheels:** [github.com/ROCm/aiter/releases](https://github.com/ROCm/aiter/releases)
+- **File issues / requests:** [GitHub Issues](https://github.com/ROCm/aiter/issues). Tag with `[request]` prefix for kernel/config tune requests.
+- **Pull requests welcome.** See [CONTRIBUTING.md](https://github.com/ROCm/aiter/blob/main/CONTRIBUTE.md) for how to land changes.
+
+## Contributor Acknowledgments
+
+37 unique contributors landed code in `main` over the past month. Top contributors by commit count: Xin Huang, yzhou103, Peng Sun, la, XiaobingZhang, Lingpeng Jin, Nidal Danial, amd-ruitang3, Sergey Solovyev, lalala-sh, Elton, Yutao Xu, Pleaplusone, JaxChen29, Felix Li, and many more. Thanks to everyone shipping kernels, fixes, and tuned configs.
+
+---
+
+*Newsletter compiled by the AMD AI Software Engineering team. Next issue: mid-June 2026.*


### PR DESCRIPTION
## Summary

First issue of an AITER monthly newsletter, covering activity from **April 14 – May 13, 2026**.

Saved to `docs/newsletter/2026-05.md` so future issues can follow the same convention.

## Audience and scope

- **AMD internal teams** (ATOM, ROCm framework, kernel devs, foundation)
- **Community partners** (vLLM, SGLang, ATOM, PyTorch ROCm consumers)

The tone is informational, factual, and includes pointers to public PRs and releases. Internal-only references (Slack channels, internal customer codenames, ticket numbers) are deliberately omitted.

## Content structure

- TL;DR — 5 bullets with the big picture
- How to use AITER — pip install + release link
- Releases shipped this period — v0.1.12.post2 + v0.1.13 + v0.1.13 RC iterations
- Highlights by area: DSv4, MoE, MLA, FMHA, architecture expansion, FlyDSL, bug fixes, downstream integrations, release engineering
- Validation reference — GSM8K 3-shot table for v0.1.13
- What's coming — v0.1.14, v0.1.13.post1, beyond
- Known issues carrying — #3076 + #3062
- Get involved — repo / releases / issues / contributing
- Contributor acknowledgments — 37 contributors over the period

## Cadence

Target monthly. Next issue mid-June 2026.

## Test plan

- [ ] Visual review of rendered markdown in PR preview
- [ ] Confirm all PR/issue links resolve
- [ ] Confirm no internal-only references leaked
- [ ] Confirm tone reads as community-friendly (not internal status update)

🤖 Drafted with assistance from Claude Code
