### PR TITLE
[TRITON] Remove precision ieee from non-F32 tl.dots

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/fp8_mqa_logits.py
+++ b/aiter/ops/triton/_triton_kernels/attention/fp8_mqa_logits.py
@@ -79,7 +79,7 @@ def _fp8_mqa_logits_kernel(
         kv_scales = tl.load(kv_scales_ptrs)
 
         # [NUM_HEADS, BLOCK_KV] = [NUM_HEADS, HEAD_SIZE] x [HEAD_SIZE, BLOCK_KV]
-        scores = tl.dot(q_block, kv_block, input_precision="ieee")
+        scores = tl.dot(q_block, kv_block)
         # Multiply by kv_scales (broadcast along rows)
         scores = scores * kv_scales[None, :]
         # ReLU
@@ -100,7 +100,7 @@ def _fp8_mqa_logits_kernel(
     kv_scales = tl.load(kv_scales_ptrs, mask=kv_col_mask, other=0.0)
 
     # [NUM_HEADS, BLOCK_KV] = [NUM_HEADS, HEAD_SIZE] x [HEAD_SIZE, BLOCK_KV]
-    scores = tl.dot(q_block, kv_block, input_precision="ieee")
+    scores = tl.dot(q_block, kv_block)
     # Multiply by kv_scales (broadcast along rows)
     scores = scores * kv_scales[None, :]
     # ReLU

--- a/aiter/ops/triton/_triton_kernels/fusions/fused_bmm_rope_kv_cache.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_bmm_rope_kv_cache.py
@@ -816,7 +816,7 @@ def _fused_fp8_bmm_rope_cat_and_cache_mla_kernel(
                 b_ptr.dtype.element_ty
             )
 
-            accumulator += tl.dot(a, b, input_precision="ieee") * a_scale
+            accumulator += tl.dot(a, b) * a_scale
 
             a_ptrs += BLOCK_SIZE_K * stride_ak_i64
             b_ptrs += BLOCK_SIZE_K * stride_bk_i64

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16.py
@@ -167,7 +167,7 @@ def _gemm_a16_w16_kernel(
                     other=0.0,
                     cache_modifier=cache_modifier,
                 )
-            accumulator += tl.dot(a, b, input_precision="ieee")
+            accumulator += tl.dot(a, b)
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak
             b_ptrs += BLOCK_SIZE_K * stride_bk

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_atomic.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_atomic.py
@@ -120,7 +120,7 @@ def _gemm_a16_w16_atomic_kernel(
                     b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
                 )
 
-            accumulator += tl.dot(a, b, input_precision="ieee")
+            accumulator += tl.dot(a, b)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_gated.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_gated.py
@@ -127,8 +127,8 @@ def _gemm_a16_w16_gated_kernel(
                 cache_modifier=cache_modifier,
             )
 
-        acc0 += tl.dot(a, b0, input_precision="ieee")
-        acc1 += tl.dot(a, b1, input_precision="ieee")
+        acc0 += tl.dot(a, b0)
+        acc1 += tl.dot(a, b1)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w8_blockscale.py
@@ -180,13 +180,13 @@ def _gemm_a16w8_blockscale_kernel(
                 a = a.to(b_ptr.type.element_ty).reshape(BLOCK_SIZE_M, BLOCK_SIZE_K)
                 a_scale = a_scale.reshape(BLOCK_SIZE_M)
                 accumulator += (
-                    tl.dot(a, b, input_precision="ieee")
+                    tl.dot(a, b)
                     * a_scale[:, None]
                     * b_scale[None, :]
                 )
             else:
                 b = b.to(a_ptr.type.element_ty)
-                accumulator += tl.dot(a, b, input_precision="ieee") * b_scale[None, :]
+                accumulator += tl.dot(a, b) * b_scale[None, :]
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak
@@ -396,13 +396,13 @@ def _gemm_a16w8_blockscale_preshuffle_kernel(
                 a = a.to(b_ptr.type.element_ty).reshape(BLOCK_SIZE_M, BLOCK_SIZE_K)
                 a_scale = a_scale.reshape(BLOCK_SIZE_M)
                 accumulator += (
-                    tl.dot(a, b, input_precision="ieee")
+                    tl.dot(a, b)
                     * a_scale[:, None]
                     * b_scale[None, :]
                 )
             else:
                 b = b.to(a_ptr.type.element_ty)
-                accumulator += tl.dot(a, b, input_precision="ieee") * b_scale[None, :]
+                accumulator += tl.dot(a, b) * b_scale[None, :]
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w8_blockscale.py
@@ -179,11 +179,7 @@ def _gemm_a16w8_blockscale_kernel(
                 )
                 a = a.to(b_ptr.type.element_ty).reshape(BLOCK_SIZE_M, BLOCK_SIZE_K)
                 a_scale = a_scale.reshape(BLOCK_SIZE_M)
-                accumulator += (
-                    tl.dot(a, b)
-                    * a_scale[:, None]
-                    * b_scale[None, :]
-                )
+                accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
             else:
                 b = b.to(a_ptr.type.element_ty)
                 accumulator += tl.dot(a, b) * b_scale[None, :]
@@ -395,11 +391,7 @@ def _gemm_a16w8_blockscale_preshuffle_kernel(
                 )
                 a = a.to(b_ptr.type.element_ty).reshape(BLOCK_SIZE_M, BLOCK_SIZE_K)
                 a_scale = a_scale.reshape(BLOCK_SIZE_M)
-                accumulator += (
-                    tl.dot(a, b)
-                    * a_scale[:, None]
-                    * b_scale[None, :]
-                )
+                accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
             else:
                 b = b.to(a_ptr.type.element_ty)
                 accumulator += tl.dot(a, b) * b_scale[None, :]

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8.py
@@ -161,7 +161,7 @@ def _gemm_a8w8_kernel(
                     cache_modifier=cache_modifier,
                 )
 
-            accumulator += tl.dot(a, b, input_precision="ieee")
+            accumulator += tl.dot(a, b)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
@@ -190,11 +190,7 @@ def _gemm_a8w8_blockscale_kernel(
             b_scale = tl.load(b_scale_ptrs)
 
             # Perform dot operation and apply scale
-            accumulator += (
-                tl.dot(a, b)
-                * a_scale[:, None]
-                * b_scale[None, :]
-            )
+            accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak
@@ -407,11 +403,7 @@ def _gemm_a8w8_blockscale_preshuffle_kernel(
             b_scale = tl.load(b_scale_ptrs)
 
             # Perform dot operation and apply scale
-            accumulator += (
-                tl.dot(a, b)
-                * a_scale[:, None]
-                * b_scale[None, :]
-            )
+            accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py
@@ -191,7 +191,7 @@ def _gemm_a8w8_blockscale_kernel(
 
             # Perform dot operation and apply scale
             accumulator += (
-                tl.dot(a, b, input_precision="ieee")
+                tl.dot(a, b)
                 * a_scale[:, None]
                 * b_scale[None, :]
             )
@@ -408,7 +408,7 @@ def _gemm_a8w8_blockscale_preshuffle_kernel(
 
             # Perform dot operation and apply scale
             accumulator += (
-                tl.dot(a, b, input_precision="ieee")
+                tl.dot(a, b)
                 * a_scale[:, None]
                 * b_scale[None, :]
             )

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_per_token_scale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_per_token_scale.py
@@ -168,7 +168,7 @@ def _gemm_a8w8_per_token_scale_kernel(
                 )
 
             # Perform dot operation and apply scale
-            accumulator += tl.dot(a, b, input_precision="ieee")
+            accumulator += tl.dot(a, b)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8.py
@@ -163,7 +163,7 @@ def _batched_gemm_a8w8_kernel(
             a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
             b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
-        accumulator += tl.dot(a, b, input_precision="ieee")
+        accumulator += tl.dot(a, b)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant.py
@@ -175,7 +175,7 @@ def _batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant_ker
         a_scale_recip = 1.0 / a_scale
         a = tl.clamp(a * a_scale_recip, DTYPE_MIN, DTYPE_MAX).to(b_ptr.dtype.element_ty)
 
-        accumulator += tl.dot(a, b, input_precision="ieee") * a_scale
+        accumulator += tl.dot(a, b) * a_scale
 
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_bf16.py
@@ -145,7 +145,7 @@ def _batched_gemm_bf16_kernel(
             a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
             b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
-        accumulator += tl.dot(a, b, input_precision="ieee")
+        accumulator += tl.dot(a, b)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_gated.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_gated.py
@@ -133,8 +133,8 @@ def _ff_a16w16_fused_gated(
                 cache_modifier=cache_modifier,
             )
 
-        acc0 += tl.dot(x, w1n0, input_precision="ieee")
-        acc1 += tl.dot(x, w1n1, input_precision="ieee")
+        acc0 += tl.dot(x, w1n0)
+        acc1 += tl.dot(x, w1n1)
 
         # Advance the ptrs to the next K block.
         x_ptrs += BLOCK_SIZE_K * stride_xk

--- a/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_ungated.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_ungated.py
@@ -104,7 +104,7 @@ def _ff_a16w16_fused_ungated(
                 cache_modifier=cache_modifier,
             )
 
-        acc += tl.dot(x, w1, input_precision="ieee")
+        acc += tl.dot(x, w1)
 
         # Advance the ptrs to the next K block.
         x_ptrs += BLOCK_SIZE_K * stride_xk

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_a16w16.py
@@ -173,11 +173,7 @@ def _fused_gemm_a8w8_blockscale_a16w16_kernel(
                 a_scale = tl.load(a_scale_ptrs)
                 b_scale = tl.load(b_scale_ptrs)
 
-                accumulator_fp8 += (
-                    tl.dot(a, b)
-                    * a_scale[:, None]
-                    * b_scale[None, :]
-                )
+                accumulator_fp8 += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
 
                 a_fp8_ptrs += BLOCK_SIZE_K * stride_a_fp8_k
                 b_fp8_ptrs += BLOCK_SIZE_K * stride_b_fp8_k

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_a16w16.py
@@ -174,7 +174,7 @@ def _fused_gemm_a8w8_blockscale_a16w16_kernel(
                 b_scale = tl.load(b_scale_ptrs)
 
                 accumulator_fp8 += (
-                    tl.dot(a, b, input_precision="ieee")
+                    tl.dot(a, b)
                     * a_scale[:, None]
                     * b_scale[None, :]
                 )
@@ -236,7 +236,7 @@ def _fused_gemm_a8w8_blockscale_a16w16_kernel(
                         cache_modifier=cache_modifier,
                     )
 
-                accumulator_bf16 += tl.dot(a, b, input_precision="ieee")
+                accumulator_bf16 += tl.dot(a, b)
 
                 a_ptrs += BLOCK_SIZE_K * stride_a_bf16_k
                 b_ptrs += BLOCK_SIZE_K * stride_b_bf16_k

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
@@ -180,7 +180,7 @@ def _fused_gemm_a8w8_blockscale_mul_add_kernel(
 
             # Perform dot operation and apply scale
             accumulator += (
-                tl.dot(a, b, input_precision="ieee")
+                tl.dot(a, b)
                 * a_scale[:, None]
                 * b_scale[None, :]
             )

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
@@ -179,11 +179,7 @@ def _fused_gemm_a8w8_blockscale_mul_add_kernel(
             b_scale = tl.load(b_scale_ptrs)
 
             # Perform dot operation and apply scale
-            accumulator += (
-                tl.dot(a, b)
-                * a_scale[:, None]
-                * b_scale[None, :]
-            )
+            accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
@@ -157,7 +157,7 @@ def _fused_gemm_a8w8_blockscale_split_cat(
 
             # Perform dot operation and apply scale
             accumulator += (
-                tl.dot(a, b, input_precision="ieee")
+                tl.dot(a, b)
                 * a_scale[:, None]
                 * b_scale[None, :]
             )
@@ -414,7 +414,7 @@ def _fused_gemm_a8w8_blockscale_preshuffle_split_cat(
 
             # Perform dot operation and apply scale
             accumulator += (
-                tl.dot(a, b, input_precision="ieee")
+                tl.dot(a, b)
                 * a_scale[:, None]
                 * b_scale[None, :]
             )

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_split_cat.py
@@ -156,11 +156,7 @@ def _fused_gemm_a8w8_blockscale_split_cat(
             b_scale = tl.load(b_scale_ptrs)
 
             # Perform dot operation and apply scale
-            accumulator += (
-                tl.dot(a, b)
-                * a_scale[:, None]
-                * b_scale[None, :]
-            )
+            accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_a_k
@@ -413,11 +409,7 @@ def _fused_gemm_a8w8_blockscale_preshuffle_split_cat(
             b_scale = tl.load(b_scale_ptrs)
 
             # Perform dot operation and apply scale
-            accumulator += (
-                tl.dot(a, b)
-                * a_scale[:, None]
-                * b_scale[None, :]
-            )
+            accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_a_k

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_a16w16.py
@@ -282,7 +282,7 @@ def _fused_gemm_afp4wfp4_a16w16_kernel(
                         cache_modifier=cache_modifier,
                     )
 
-                accumulator_bf16 += tl.dot(a, b, input_precision="ieee")
+                accumulator_bf16 += tl.dot(a, b)
 
                 a_ptrs += BLOCK_SIZE_K * stride_a_bf16_k
                 b_ptrs += BLOCK_SIZE_K * stride_b_bf16_k
@@ -652,7 +652,7 @@ def _fused_gemm_afp4wfp4_preshuffle_a16w16_kernel(
                         cache_modifier=cache_modifier,
                     )
 
-                accumulator_bf16 += tl.dot(a, b, input_precision="ieee")
+                accumulator_bf16 += tl.dot(a, b)
 
                 a_ptrs += BLOCK_SIZE_K * stride_a_bf16_k
                 b_ptrs += BLOCK_SIZE_K * stride_b_bf16_k

--- a/aiter/ops/triton/_triton_kernels/gmm.py
+++ b/aiter/ops/triton/_triton_kernels/gmm.py
@@ -198,7 +198,7 @@ def gmm_kernel(
                         rhs_ptrs, mask=offs_k[:, None] < k_mask_limit, other=0
                     )
 
-                acc += tl.dot(lhs, rhs, input_precision="ieee")
+                acc += tl.dot(lhs, rhs)
 
                 lhs_ptrs += BLOCK_SIZE_K
 
@@ -360,7 +360,7 @@ def tgmm_persistent_kernel(
                 lhs = tl.load(lhs_ptrs)
                 rhs = tl.load(rhs_ptrs)
 
-                acc += tl.dot(lhs, rhs, input_precision="ieee")
+                acc += tl.dot(lhs, rhs)
 
                 # Accumulate for bias gradient: sum lhs across M dimension
                 if COMPUTE_BIAS_GRAD and tile_n == 0:
@@ -385,7 +385,7 @@ def tgmm_persistent_kernel(
                 offs_m = loop_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
                 lhs = tl.load(lhs_ptrs, mask=offs_m[None, :] < m, other=0)
                 rhs = tl.load(rhs_ptrs, mask=offs_m[:, None] < m, other=0)
-                acc += tl.dot(lhs, rhs, input_precision="ieee")
+                acc += tl.dot(lhs, rhs)
 
                 # Accumulate last chunk for bias gradient
                 if COMPUTE_BIAS_GRAD and tile_n == 0:
@@ -531,7 +531,7 @@ def tgmm_non_persistent_kernel(
         lhs = tl.load(lhs_ptrs)
         rhs = tl.load(rhs_ptrs)
 
-        acc += tl.dot(lhs, rhs, input_precision="ieee")
+        acc += tl.dot(lhs, rhs)
 
         # Accumulate for bias gradient: sum lhs across M dimension
         if COMPUTE_BIAS_GRAD and tile_n == 0:
@@ -554,7 +554,7 @@ def tgmm_non_persistent_kernel(
         offs_m = loop_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         lhs = tl.load(lhs_ptrs, mask=offs_m[None, :] < m, other=0)
         rhs = tl.load(rhs_ptrs, mask=offs_m[:, None] < m, other=0)
-        acc += tl.dot(lhs, rhs, input_precision="ieee")
+        acc += tl.dot(lhs, rhs)
         # Accumulate last chunk for bias gradient
         if COMPUTE_BIAS_GRAD and tile_n == 0:
             bias_acc += tl.sum(lhs, axis=1)

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w8_blockscale.py
@@ -324,7 +324,7 @@ def _moe_gemm_a8w8_blockscale(
             WScalePtrs += offs_ks_step * stride_w_bs_k
 
         scale_matrix = x_scale[:, None] * w_scale[None, :]
-        acc += tl.dot(x, w, input_precision="ieee") * scale_matrix
+        acc += tl.dot(x, w) * scale_matrix
         XPtrs += BLOCK_K * stride_x_k
         WPtrs += BLOCK_K * stride_w_k
 

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_int8_smoothquant.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_int8_smoothquant.py
@@ -248,7 +248,7 @@ def _moe_gemm_int8_smoothquant(
         if PRESHUFFLED:
             w = unshuffle_weights(w, BLOCK_N, BLOCK_K)
 
-        acc += tl.dot(x, w, input_precision="ieee")
+        acc += tl.dot(x, w)
 
         XPtrs += (BLOCK_K * SPLIT_K) * stride_x_k
         WPtrs += (PACKED_BLOCK_K * SPLIT_K) * stride_w_k
@@ -267,7 +267,7 @@ def _moe_gemm_int8_smoothquant(
         if PRESHUFFLED:
             w = unshuffle_weights(w, BLOCK_N, BLOCK_K)
 
-        acc += tl.dot(x, w, input_precision="ieee")
+        acc += tl.dot(x, w)
 
     # per-token activation scale
     offs_m = BLOCK_M * block_id + tl.arange(0, BLOCK_M)


### PR DESCRIPTION
This is needed only for f32 tl.dots because the AMD backend default is TF32 (and AFAICT only for gfx942).