### PR TITLE
[custom_all_reduce] qknorm_allreduce_fusion_kernel_2stage: grid-strided loop, drop 80-token cap

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -1843,14 +1843,11 @@ __global__ void __launch_bounds__(1024, 1)
     int hidden_dim          = hidden_dim_q + hidden_dim_k + hidden_dim_v;
     bool is_q               = (int)threadIdx.x * pack_size < hidden_dim_q;
     bool is_qk              = (int)threadIdx.x * pack_size < hidden_dim_qk;
-    bool is_k               = (!is_q) && (is_qk);
     bool is_q_t0            = threadIdx.x == 0;
     bool is_k_t0            = threadIdx.x == (hidden_dim_q / pack_size);
     using P                 = typename opus::vector_t<T, pack_size>;
     using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
-    int tidx                = blockIdx.x;
     int access_id_in_token  = threadIdx.x * pack_size;
-    int idx                 = tidx * hidden_dim + access_id_in_token;
     int wid                 = threadIdx.x / WARP_SIZE;
 
     const P* ptrs[ngpus];
@@ -1865,97 +1862,110 @@ __global__ void __launch_bounds__(1024, 1)
 
     __shared__ float smem[32];
 
-    A acc{};
-    P vec{};
-    P var_vec{};
-    P weight_p{};
-    float sum2 = 0.0f;
+    for(int tidx = blockIdx.x; tidx < token_num; tidx += gridDim.x)
+    {
+        int idx = tidx * hidden_dim + access_id_in_token;
+        P vec = ptrs[rank][idx / pack_size];
+        A acc;
 
-    vec = ptrs[rank][idx / pack_size];
-
-    if (is_qk) {
-
+        if (is_qk) {
+            float sum2 = 0.0f;
 #pragma unroll
-        for(int v = 0; v < pack_size; ++v)
-        {
-            acc[v] = upcast_s(vec[v]);
-            sum2 += acc[v] * acc[v];
+            for(int v = 0; v < pack_size; ++v)
+            {
+                acc[v] = upcast_s(vec[v]);
+                sum2 += acc[v] * acc[v];
+            }
+            sum2 = warpReduce<AddFunctor, float, WARP_SIZE>(sum2);
+            if (threadIdx.x % WARP_SIZE == 0)
+                smem[wid] = sum2;
         }
-        
-        sum2 = warpReduce<AddFunctor, float, WARP_SIZE>(sum2);
-
-        if (threadIdx.x % WARP_SIZE == 0)
-            smem[wid] = sum2;
         __syncthreads();
 
-        sum2 = 0.0f;
-
-        if (is_q_t0) {
-            for (int i = 0; i < hidden_dim_q / WARP_SIZE / pack_size; ++i) {
-                sum2 += smem[i];
+        if (is_qk) {
+            P var_vec{};
+            float sum2 = 0.0f;
+            if (is_q_t0) {
+                for (int i = 0; i < hidden_dim_q / WARP_SIZE / pack_size; ++i)
+                    sum2 += smem[i];
+                sum2 /= (float)hidden_dim_q;
+                *reinterpret_cast<float*>(&var_vec) = sum2;
+                tmps[rank][tidx * 2 + 0] = var_vec;
+            } else if (is_k_t0) {
+                for (int i = hidden_dim_q / WARP_SIZE / pack_size;
+                     i < hidden_dim_qk / WARP_SIZE / pack_size; ++i)
+                    sum2 += smem[i];
+                sum2 /= (float)hidden_dim_k;
+                *reinterpret_cast<float*>(&var_vec) = sum2;
+                tmps[rank][tidx * 2 + 1] = var_vec;
             }
-            sum2 /= (float)hidden_dim_q;
-            *reinterpret_cast<float*>(&var_vec) = sum2;
-            tmps[rank][tidx * 2 + 0] = var_vec;
-        } else if (is_k_t0) {
-            for (int i = hidden_dim_q / WARP_SIZE / pack_size; i < hidden_dim_qk / WARP_SIZE / pack_size; ++i) {
-                sum2 += smem[i];
-            }
-            sum2 /= (float)hidden_dim_k;
-            *reinterpret_cast<float*>(&var_vec) = sum2;
-            tmps[rank][tidx * 2 + 1] = var_vec;
+        } else {
+            *reinterpret_cast<P*>(&v_out[tidx * hidden_dim_v +
+                                        access_id_in_token - hidden_dim_qk]) = vec;
         }
+        __syncthreads();
+    }
 
-        end_sync<ngpus>(sg, self_sg, rank);
+    end_sync<ngpus>(sg, self_sg, rank);
 
-        if (is_q_t0) {
+    for(int tidx = blockIdx.x; tidx < token_num; tidx += gridDim.x)
+    {
+        int idx = tidx * hidden_dim + access_id_in_token;
+        P vec;
+        A acc;
+
+        if (is_qk) {
+            vec = ptrs[rank][idx / pack_size];
 #pragma unroll
-            for(int r = 1; r < ngpus; ++r)
-            {
-                int target = (rank + r) % ngpus;
-                auto peer_vec = tmps[target][tidx * 2 + 0];
-                sum2 += *reinterpret_cast<float*>(&peer_vec);
-            }
-            smem[0] = sum2;
-        } else if (is_k_t0) {
+            for(int v = 0; v < pack_size; ++v)
+                acc[v] = upcast_s(vec[v]);
+
+            float sum2 = 0.0f;
+            if (is_q_t0) {
+                sum2 = *reinterpret_cast<float*>(&tmps[rank][tidx * 2 + 0]);
 #pragma unroll
-            for(int r = 1; r < ngpus; ++r)
-            {
-                int target = (rank + r) % ngpus;
-                auto peer_vec = tmps[target][tidx * 2 + 1];
-                sum2 += *reinterpret_cast<float*>(&peer_vec);
+                for(int r = 1; r < ngpus; ++r)
+                {
+                    int target = (rank + r) % ngpus;
+                    auto peer_vec = tmps[target][tidx * 2 + 0];
+                    sum2 += *reinterpret_cast<float*>(&peer_vec);
+                }
+                smem[0] = sum2;
+            } else if (is_k_t0) {
+                sum2 = *reinterpret_cast<float*>(&tmps[rank][tidx * 2 + 1]);
+#pragma unroll
+                for(int r = 1; r < ngpus; ++r)
+                {
+                    int target = (rank + r) % ngpus;
+                    auto peer_vec = tmps[target][tidx * 2 + 1];
+                    sum2 += *reinterpret_cast<float*>(&peer_vec);
+                }
+                smem[1] = sum2;
             }
-            smem[1] = sum2;
         }
-
         __syncthreads();
 
         if (is_q) {
-            weight_p = *reinterpret_cast<P*>(&q_w[access_id_in_token]);
+            P weight_p = *reinterpret_cast<P*>(&q_w[access_id_in_token]);
             float denom = rsqrtf(smem[0] / ngpus + eps);
 #pragma unroll
             for(int v = 0; v < pack_size; ++v)
-            {
                 vec[v] = downcast_s<T>(acc[v] * denom * weight_p[v]);
-            }
             *reinterpret_cast<P*>(&q_out[tidx * hidden_dim_q + access_id_in_token]) = vec;
-        } else {
-            weight_p = *reinterpret_cast<P*>(&k_w[access_id_in_token - hidden_dim_q]);
+        } else if (is_qk) {
+            P weight_p = *reinterpret_cast<P*>(&k_w[access_id_in_token - hidden_dim_q]);
             float denom = rsqrtf(smem[1] / ngpus + eps);
 #pragma unroll
             for(int v = 0; v < pack_size; ++v)
-            {
                 vec[v] = downcast_s<T>(acc[v] * denom * weight_p[v]);
-            }
-            *reinterpret_cast<P*>(&k_out[tidx * hidden_dim_k + access_id_in_token - hidden_dim_q]) = vec;
+            *reinterpret_cast<P*>(&k_out[tidx * hidden_dim_k +
+                                         access_id_in_token - hidden_dim_q]) = vec;
         }
-    
-    } else {
-        *reinterpret_cast<P*>(&v_out[tidx * hidden_dim_v + access_id_in_token - hidden_dim_qk]) = vec;
+        __syncthreads();
     }
 }
 
-template <typename T , int NGPUS>
+template <typename T, int NGPUS>
 void qknorm_allreduce_fusion_kernel_2stage_launcher(RankData* _dp,
                                              RankSignals sg,
                                              Signal* self_sg,
@@ -1978,15 +1988,13 @@ void qknorm_allreduce_fusion_kernel_2stage_launcher(RankData* _dp,
     constexpr int WARP_WORK_SIZE = WARP_SIZE * PACK_SIZE;
     int hidden_dim               = hidden_dim_q + hidden_dim_k + hidden_dim_v;
     int BLOCK_SIZE               = hidden_dim / PACK_SIZE;
-    if(token_num > kMaxBlocks)
-        throw std::runtime_error(
-            "Token number is too large for qknorm_allreduce_fusion_kernel_2stage kernel");
     bool valid = (hidden_dim_q % WARP_WORK_SIZE == 0) && (hidden_dim_k % WARP_WORK_SIZE == 0) && (hidden_dim_v % WARP_WORK_SIZE == 0);
     if (!valid)
         throw std::runtime_error(
             "Invalid qk hidden dim layout for qknorm_allreduce_fusion_kernel_2stage kernel");
     dim3 threadsPerBlock(BLOCK_SIZE);
-    dim3 numBlocks(token_num);
+    int grid_blocks = std::min(token_num, kMaxBlocks);
+    dim3 numBlocks(grid_blocks);
     qknorm_allreduce_fusion_kernel_2stage<T, NGPUS, WARP_SIZE>
         <<<numBlocks, threadsPerBlock, 0, stream>>>(_dp,
                                                     sg,

--- a/op_tests/multigpu_tests/test_fused_qknorm_ar.py
+++ b/op_tests/multigpu_tests/test_fused_qknorm_ar.py
@@ -208,6 +208,15 @@ def test_qknorm_allreduce(
 l_dtype = ["fp16", "bf16"]
 l_shape = [(1, 3072, 512, 1024), (2, 3072, 512, 1024), (16, 3072, 512, 1024)]
 
+# MiniMax-M2 per-rank QKV geometry at TP in {2, 4, 8}, swept across
+# token_num to exercise the grid-strided outer loop above kMaxBlocks (=80).
+l_T_widen = [1, 16, 32, 64, 80, 128, 256, 512, 1024, 2048]
+SHAPE_BY_TP = {
+    2: [(T, 3072, 512, 512) for T in l_T_widen],
+    4: [(T, 1536, 256, 256) for T in l_T_widen],
+    8: [(T, 768, 128, 128) for T in l_T_widen],
+}
+
 
 parser = argparse.ArgumentParser(description="config input of test")
 parser.add_argument(
@@ -236,6 +245,46 @@ parser.add_argument(
     default=True,
     help="use CUDA graph (default: True). e.g. -g true or -g false",
 )
+parser.add_argument(
+    "--tp-sizes",
+    type=lambda s: [int(x) for x in s.split(",") if x.strip()],
+    default=[8],
+    help="comma-separated TP sizes from {2, 4, 8} (default 8). "
+    "Non-default switches to the multi-T SHAPE_BY_TP matrix.",
+)
+
+
+try:
+    import pytest
+
+    @pytest.mark.parametrize(
+        "tp,shape,dtype_str",
+        [
+            (tp, shape, d)
+            for tp in (2, 4, 8)
+            for shape in SHAPE_BY_TP[tp]
+            for d in ("bf16", "fp16")
+        ],
+    )
+    def test_widen_multi_t(tp, shape, dtype_str):
+        if torch.cuda.device_count() < tp:
+            pytest.skip(f"requires >= {tp} GPUs (have {torch.cuda.device_count()})")
+        ret = test_qknorm_allreduce(
+            tp,
+            1,
+            shape,
+            dtypes.d_dtypes[dtype_str],
+            withGraph=True,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(), get_open_port()
+            ),
+        )
+        assert (
+            ret["err"] < 1e-2
+        ), f"qknorm err={ret['err']} at tp={tp} shape={shape} dtype={dtype_str}"
+
+except ImportError:
+    pass
 
 
 if __name__ == "__main__":
@@ -245,22 +294,27 @@ if __name__ == "__main__":
         l_dtype = [dtypes.d_dtypes[key] for key in l_dtype]
     else:
         l_dtype = [dtypes.d_dtypes[args.dtype]]
-    if args.shape is not None:
-        l_shape = [args.shape]
     df = []
-    for dtype in l_dtype:
-        for shape in l_shape:
-            ret = test_qknorm_allreduce(
-                8,
-                1,
-                shape,
-                dtype,
-                withGraph=args.with_graph,
-                distributed_init_method=get_distributed_init_method(
-                    get_ip(), get_open_port()
-                ),
-            )
-            df.append(ret)
+    for tp in args.tp_sizes:
+        if args.shape is not None:
+            shapes = [args.shape]
+        elif args.tp_sizes == [8]:
+            shapes = l_shape
+        else:
+            shapes = SHAPE_BY_TP.get(tp, l_shape)
+        for dtype in l_dtype:
+            for shape in shapes:
+                ret = test_qknorm_allreduce(
+                    tp,
+                    1,
+                    shape,
+                    dtype,
+                    withGraph=args.with_graph,
+                    distributed_init_method=get_distributed_init_method(
+                        get_ip(), get_open_port()
+                    ),
+                )
+                df.append(ret)
     df = pd.DataFrame(df)
     show_cols = [
         "tp_size",


### PR DESCRIPTION
## Summary

`qknorm_allreduce_fusion_kernel_2stage` (added in #3163) launches `dim3 numBlocks(token_num)` — one block per token — and the launcher hard-throws on `token_num > kMaxBlocks` (= 80). Any caller above 80 tokens falls back to the unfused chain.

This PR converts the kernel to one block per group with a grid-strided outer loop, mirroring `allreduce_fusion_kernel_2stage` in the same file. Grid stays capped at `kMaxBlocks` (`Signal::start/end/_flag` are sized to it; `start_sync`/`end_sync` index by `blockIdx.x`), but each block now handles `ceil(token_num / gridDim.x)` tokens. The kernel accepts any token_num that fits in the CustomAllreduce scratch tail (max_size * 2; default 2 GiB on the vLLM path) The `RuntimeError` is gone.

## Changes

- **Kernel**: one `start_sync` + one `end_sync` bookend two strided outer loops; two unconditional `__syncthreads()` per iteration (mid + trailing), matching `allreduce_fusion_kernel_2stage`'s rhythm.
- **Launcher**: drop the `RuntimeError`; `int grid_blocks = std::min(token_num, kMaxBlocks); dim3 numBlocks(grid_blocks);`. A `grid_blocks` local (rather than overwriting `token_num`) preserves the kernel arg used in the strided-loop terminator.
- **Test**: new `--tp-sizes` argparse + `SHAPE_BY_TP` matrix at MiniMax-M2 per-rank geometry (TP ∈ {2, 4, 8}, T ∈ {1, 16, 32, 64, 80, 128, 256, 512, 1024, 2048}); pytest-discovered `test_widen_multi_t` cell. Existing `__main__ tp_size=8` behavior preserved.

## Tests

**Multi-T bit-exact correctness** at TP=2/bf16 (also TP=2/fp16 and TP=4/bf16, all `err = 0`):

```
| tp_size | shape                  | dtype          | min_us  | err |
|---------|------------------------|----------------|---------|-----|
|       2 | (80,   3072, 512, 512) | torch.bfloat16 |  6.08   |   0 |
|       2 | (128,  3072, 512, 512) | torch.bfloat16 |  8.04   |   0 |
|       2 | (512,  3072, 512, 512) | torch.bfloat16 | 17.94   |   0 |
|       2 | (1024, 3072, 512, 512) | torch.bfloat16 | 29.98   |   0 |
|       2 | (2048, 3072, 512, 512) | torch.bfloat16 | 56.11   |   0 |
```

**Fusion coverage on MiniMax-M2.5 / TP=2** (`VLLM_LOGGING_LEVEL=DEBUG`, verbatim from `serve.log`; same build, only the gate ceiling differs — the AITER kernel itself is the widened one in both arms):

```
Baseline — today's ROCm gate (MAX_TOKEN_NUM = 80, the 80-cap this PR removes):
  compile_ranges_endpoints: [80, 10922, 32768]
  MiniMaxQKNormPass replaced 1 patterns                          ← fires on (1, 80)
  Skipping MiniMaxQKNormPass with compile range (81, 10922)      ← prefill UNFUSED
  Skipping MiniMaxQKNormPass with compile range (10923, 32768)

This PR + lifted gate (MAX_TOKEN_NUM = 2048):
  compile_ranges_endpoints: [2048, 10922, 32768]
  MiniMaxQKNormPass replaced 1 patterns                          ← fires on (1, 2048)
  Skipping MiniMaxQKNormPass with compile range (2049, 10922)
  Skipping MiniMaxQKNormPass with compile range (10923, 32768)
```

The fusion-applicable compile range grows 25.6×; MiniMax-M2.5's 51 cudagraph-captured sizes go from **13/51 fused → 51/51 fused**, and mainstream prefill (input_len ~ 1000) now uses the fused path.

**End-to-end perf — MiniMax-M2.5 / MI355X / TP=2** (this PR vs `MAX_TOKEN_NUM = 80` baseline, fusion enabled in both arms):

| metric              | conc | Δ            |
|---------------------|-----:|-------------:|
| Median TPOT         |   16 | **−3.5 %**   |
| Output throughput   |   16 | **+3.5 %**   |
| Median TTFT         |  256 | **−4.67 %**  |

**Accuracy** — `lm_eval gsm8k --num_fewshot 5 --limit 256`: 0.9375 ± 0.0152 (flex) / 0.9336 ± 0.0156 (strict). Within 1 σ.

Big thanks to @xytpai for driving the original work!! Could you try patching your kernel with this one and testing uplifts on your end ?
