### PR TITLE
[TRITON] Use tl.dot(..., acc=...) accumulator form

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/extend_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/extend_attention.py
@@ -179,7 +179,7 @@ def _fwd_kernel(
                 mask=mask_n[None, :],
                 other=0.0,
             )
-            qk += tl.dot(qpe.to(kpe.dtype), kpe)
+            qk = tl.dot(qpe.to(kpe.dtype), kpe, acc=qk)
         qk *= sm_scale
 
         if logit_cap > 0:
@@ -251,7 +251,7 @@ def _fwd_kernel(
                 mask=mask_n[None, :],
                 other=0.0,
             )
-            qk += tl.dot(qpe, kpe)
+            qk = tl.dot(qpe, kpe, acc=qk)
 
         qk *= sm_scale
 

--- a/aiter/ops/triton/_triton_kernels/attention/fav3_sage_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/fav3_sage_attention.py
@@ -199,7 +199,7 @@ def _sage_fwd_no_mask(
         l_i = l_i * alpha + l_ij
         m_i = m_ij
 
-        acc += tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
 
     return acc, l_i, m_i
 
@@ -352,7 +352,7 @@ def _sage_fwd_blocksparse_nomask(
                 v = tl.load(v_ptrs)
         l_i = l_i * alpha + l_ij
         m_i = m_ij
-        acc += tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
     return acc, l_i, m_i
 
 
@@ -500,7 +500,7 @@ def _sage_fwd_blocksparse_mask(
             v = tl.load(v_ptrs, mask=v_mask, other=0.0)
         l_i = l_i * alpha + l_ij
         m_i = m_ij
-        acc += tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
     return acc, l_i, m_i
 
 
@@ -858,7 +858,7 @@ def _sage_fwd_mask(
         # -- update m_i and l_i
         l_i = l_i * alpha + l_ij
         m_i = m_ij
-        acc += tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot((p).to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
 
     return acc, l_i, m_i
 

--- a/aiter/ops/triton/_triton_kernels/attention/fav3_sage_attention_mxfp4.py
+++ b/aiter/ops/triton/_triton_kernels/attention/fav3_sage_attention_mxfp4.py
@@ -243,7 +243,7 @@ def _sage_fwd_no_mask_mxfp4(
 
         l_i = l_i * alpha + l_ij
         m_i = m_ij
-        acc += tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
 
     return acc, l_i, m_i
 
@@ -354,7 +354,7 @@ def _sage_fwd_mask_mxfp4(
 
         l_i = l_i * alpha + l_ij
         m_i = m_ij
-        acc += tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
 
     return acc, l_i, m_i
 
@@ -458,7 +458,7 @@ def _sage_fwd_blocksparse_nomask_mxfp4(
 
         l_i = l_i * alpha + l_ij
         m_i = m_ij
-        acc += tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
 
     return acc, l_i, m_i
 
@@ -569,7 +569,7 @@ def _sage_fwd_blocksparse_mask_mxfp4(
 
         l_i = l_i * alpha + l_ij
         m_i = m_ij
-        acc += tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32)
+        acc = tl.dot(p.to(v.type.element_ty), v, out_dtype=tl.float32, acc=acc)
 
     return acc, l_i, m_i
 

--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -489,7 +489,7 @@ def _hstu_attn_bwd_one_block(  # noqa C901
         mask=mask_m[:, None],
         other=0.0,
     )
-    dv += tl.dot(silu_trans, do, allow_tf32=ALLOW_TF32)
+    dv = tl.dot(silu_trans, do, allow_tf32=ALLOW_TF32, acc=dv)
 
     # compute dk and dq
     dqk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
@@ -500,7 +500,7 @@ def _hstu_attn_bwd_one_block(  # noqa C901
     dqk_trans = dqk_trans.to(k.dtype)
 
     # Note: the factor `alpha` is delayed until the end of the function to reduce the cost
-    dk += tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32)
+    dk = tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32, acc=dk)
     if ATOMIC_ADD:
         lock_id = start_m // BLOCK_M
         stride_lock = tl.cdiv(MAX_SEQ_LEN, BLOCK_M)

--- a/aiter/ops/triton/_triton_kernels/attention/lean_atten.py
+++ b/aiter/ops/triton/_triton_kernels/attention/lean_atten.py
@@ -126,7 +126,7 @@ def _attention_inner(
         k = tl.load(k_ptrs, mask=mask_k_cols_local[:, None], other=0.0)
         qk_scale = SM_SCALE * RCP_LN2
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
-        qk += tl.dot(q, k)
+        qk = tl.dot(q, k, acc=qk)
         qk = qk * qk_scale
 
         if causal:
@@ -157,7 +157,7 @@ def _attention_inner(
         # Update accumulator
         acc = acc * alpha[:, None]
         v = tl.load(v_ptrs, mask=mask_k_cols_local[None, :], other=0.0)
-        acc += tl.dot(p.to(v.dtype), v)
+        acc = tl.dot(p.to(v.dtype), v, acc=acc)
 
         # Update stats
         l_ij = tl.sum(p, 1)

--- a/aiter/ops/triton/_triton_kernels/attention/lean_atten_paged.py
+++ b/aiter/ops/triton/_triton_kernels/attention/lean_atten_paged.py
@@ -323,7 +323,7 @@ def _attn_lean_tile(
             acc * alpha[:, None]
         )  # Scale each row of acc by the corresponding elements in alpha
         v = tl.load(V_bptr, cache_modifier=".cg")  # v.shape = [BLOCK_N, HEAD_DIM]
-        acc += tl.dot(p.to(v.dtype), v)  # acc.shape = [BLOCK_M, HEAD_DIM]
+        acc = tl.dot(p.to(v.dtype), v, acc=acc)  # acc.shape = [BLOCK_M, HEAD_DIM]
         # -- update l_i
         l_ij = tl.sum(p, 1)  # rowsum(p)
         l_i = l_i * alpha + l_ij

--- a/aiter/ops/triton/_triton_kernels/attention/mha.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha.py
@@ -178,8 +178,8 @@ def _attn_fwd_inner(
         # -- compute qk ----
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
         if HAS_PE:
-            qk += tl.dot(q_pe, k_pe)
-        qk += tl.dot(q, k)
+            qk = tl.dot(q_pe, k_pe, acc=qk)
+        qk = tl.dot(q, k, acc=qk)
         if IS_FP8:
             qk = qk * (qk_scale * descale_q * descale_k)
         else:
@@ -256,7 +256,7 @@ def _attn_fwd_inner(
                 tl.dot((p * scale_p).to(v.type.element_ty), v) * descale_p * descale_v
             )
         else:
-            acc += tl.dot(p.to(v.type.element_ty), v)
+            acc = tl.dot(p.to(v.type.element_ty), v, acc=acc)
 
         k_ptrs += BLOCK_N * stride_kn
         if HAS_PE:

--- a/aiter/ops/triton/_triton_kernels/attention/mha_fused_bwd.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha_fused_bwd.py
@@ -276,7 +276,7 @@ def _bwd_dkdvdq_inner(
                     * descale_do
                 )
             else:
-                dv += tl.dot(pT_dropout.to(do.type.element_ty), do)
+                dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
             if IS_FP8:
                 scale_pT, descale_pT = _compute_fp8_scaling_factors(pT, FP8_MAX)
@@ -286,7 +286,7 @@ def _bwd_dkdvdq_inner(
                     * descale_do
                 )
             else:
-                dv += tl.dot(pT.to(do.type.element_ty), do)
+                dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
 
         # Load delta
         Di = tl.load(D + offs_m * stride_deltam, mask=mask_m)
@@ -312,7 +312,7 @@ def _bwd_dkdvdq_inner(
                 * descale_q
             )
         else:
-            dk += tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT))
+            dk = tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT), acc=dk)
 
         # We can compute the dq_partial here and do a atomic add to the correct memory location
         # NOTE: Possible problems with the atomic add: contention, is inside a loop which has achieved bad perf before

--- a/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
@@ -242,7 +242,7 @@ def _bwd_dkdv_inner(
         else:
             qkT = tl.dot(k, qT)
             if HAS_PE:
-                qkT += tl.dot(k_pe, qT_pe)
+                qkT = tl.dot(k_pe, qT_pe, acc=qkT)
         qkT_scaled = qkT * sm_scale
 
         if USE_ALIBI:
@@ -294,7 +294,7 @@ def _bwd_dkdv_inner(
                     * descale_do
                 )
             else:
-                dv += tl.dot(pT_dropout.to(do.type.element_ty), do)
+                dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
             if IS_FP8:
                 scale_pT, descale_pT = _compute_fp8_scaling_factors(pT, FP8_MAX)
@@ -304,7 +304,7 @@ def _bwd_dkdv_inner(
                     * descale_do
                 )
             else:
-                dv += tl.dot(pT.to(do.type.element_ty), do)
+                dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
 
         if DEBUG_TRITON_DETAIL:
             if start_n == 256:
@@ -328,9 +328,11 @@ def _bwd_dkdv_inner(
                 * descale_q
             )
         else:
-            dk += tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT))
+            dk = tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT), acc=dk)
             if HAS_PE:
-                dk_pe += tl.dot(dsT.to(qT_pe.type.element_ty), tl.trans(qT_pe))
+                dk_pe = tl.dot(
+                    dsT.to(qT_pe.type.element_ty), tl.trans(qT_pe), acc=dk_pe
+                )
         # Increment pointers.
         curr_m += step_m
         qT_ptrs += step_m * stride_qm
@@ -465,7 +467,7 @@ def _bwd_dq_inner(
         else:
             qk = tl.dot(q, kT)
             if HAS_PE:
-                qk += tl.dot(q_pe, kT_pe)
+                qk = tl.dot(q_pe, kT_pe, acc=qk)
         qk_scaled = qk * sm_scale
 
         if USE_ALIBI:
@@ -512,9 +514,9 @@ def _bwd_dq_inner(
                 * descale_k
             )
         else:
-            dq += tl.dot(ds.to(kT.type.element_ty), tl.trans(kT))
+            dq = tl.dot(ds.to(kT.type.element_ty), tl.trans(kT), acc=dq)
             if HAS_PE:
-                dq_pe += tl.dot(ds.to(kT_pe.type.element_ty), tl.trans(kT_pe))
+                dq_pe = tl.dot(ds.to(kT_pe.type.element_ty), tl.trans(kT_pe), acc=dq_pe)
         # Increment pointers.
         curr_n += step_n
         kT_ptrs += step_n * stride_kn

--- a/aiter/ops/triton/_triton_kernels/attention/mla_decode_rope.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mla_decode_rope.py
@@ -264,7 +264,7 @@ def _fwd_grouped_kernel_stage1_rope(
 
             # (16, 512) x (512, 32)
             # dot product of nope parts
-            qk += tl.dot(q, kv)
+            qk = tl.dot(q, kv, acc=qk)
 
             qk *= sm_scale
 
@@ -287,7 +287,7 @@ def _fwd_grouped_kernel_stage1_rope(
             p = tl.exp(qk - n_e_max[:, None])
             acc *= re_scale[:, None]
             # (16, 32) x (32, 512)
-            acc += tl.dot(p.to(v.dtype), v)
+            acc = tl.dot(p.to(v.dtype), v, acc=acc)
 
             e_sum = e_sum * re_scale + tl.sum(p, 1)
             e_max = n_e_max

--- a/aiter/ops/triton/_triton_kernels/attention/pa_decode.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_decode.py
@@ -280,7 +280,7 @@ def _paged_attn_decode_v1_w_dot_kernel(
         v = v.to(compute_type)
 
         p = p.to(v.dtype)
-        acc += tl.dot(p, v, out_dtype=tl.float32)
+        acc = tl.dot(p, v, out_dtype=tl.float32, acc=acc)
 
         exp_sum = exp_sum * alpha + tl.sum(p, axis=1)
         max_logit = max_logit_new
@@ -705,7 +705,7 @@ def _paged_attn_decode_v2_w_dot_kernel(
         v = v.to(compute_type)
 
         p = p.to(v.dtype)
-        acc += tl.dot(p, v, out_dtype=tl.float32)
+        acc = tl.dot(p, v, out_dtype=tl.float32, acc=acc)
 
         exp_sum = exp_sum * alpha + tl.sum(p, axis=1)
         max_logit = max_logit_new
@@ -1132,7 +1132,7 @@ def _paged_attn_decode_v1_w_dot_kernel_per_token_quant(
         v = v.to(compute_type)
 
         p = p.to(v.dtype)
-        acc += tl.dot(p, v, out_dtype=tl.float32)
+        acc = tl.dot(p, v, out_dtype=tl.float32, acc=acc)
 
         exp_sum = exp_sum * alpha + tl.sum(p, axis=1)
         max_logit = max_logit_new
@@ -1580,7 +1580,7 @@ def _paged_attn_decode_v2_w_dot_kernel_per_token_quant(
         v = v.to(compute_type)
 
         p = p.to(v.dtype)
-        acc += tl.dot(p, v, out_dtype=tl.float32)
+        acc = tl.dot(p, v, out_dtype=tl.float32, acc=acc)
 
         exp_sum = exp_sum * alpha + tl.sum(p, axis=1)
         max_logit = max_logit_new

--- a/aiter/ops/triton/_triton_kernels/attention/prefill_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/prefill_attention.py
@@ -120,7 +120,7 @@ def _fwd_kernel(
         # mask = tl.load(mask_ptrs + start_n, mask=start_n + offs_n < cur_batch_end_loc, other=0.0)
 
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
-        qk += tl.dot(q, k)
+        qk = tl.dot(q, k, acc=qk)
         qk *= sm_scale
 
         if IS_CAUSAL:
@@ -159,7 +159,7 @@ def _fwd_kernel(
         )
 
         p = p.to(v.dtype)
-        acc += tl.dot(p, v)
+        acc = tl.dot(p, v, acc=acc)
         # update m_i and l_i
         l_i = l_i_new
         m_i = m_i_new

--- a/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
@@ -353,7 +353,7 @@ def kernel_unified_attention_2d(
         M = m_j
 
         # acc : (BLOCK_M, HEAD_SIZE_PADDED)
-        acc += tl.dot(P.to(V.dtype), V)
+        acc = tl.dot(P.to(V.dtype), V, acc=acc)
 
     # epilogue
     # This helps the compiler do Newton Raphson on l_i vs on acc which is much larger.
@@ -672,7 +672,7 @@ def kernel_unified_attention_3d(
         M = m_j
 
         # acc : (BLOCK_M, HEAD_SIZE_PADDED)
-        acc += tl.dot(P.to(V.dtype), V)
+        acc = tl.dot(P.to(V.dtype), V, acc=acc)
 
     if v_descale is not None:
         acc = acc * v_descale

--- a/aiter/ops/triton/_triton_kernels/attention/unified_attention_sparse_mla.py
+++ b/aiter/ops/triton/_triton_kernels/attention/unified_attention_sparse_mla.py
@@ -234,7 +234,7 @@ def _kernel_unified_attention_sparse_mla_2d(
             cache_modifier=KV_cache_modifier,
         )
 
-        acc += tl.dot(P.to(V_lora.dtype), V_lora)
+        acc = tl.dot(P.to(V_lora.dtype), V_lora, acc=acc)
 
     # epilogue
     one_over_L = 1.0 / L[:, None]

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -842,7 +842,7 @@ def _bwd_dq_inner_split(
             ds_transposed = tl.trans(ds).to(kT.type.element_ty)
             dq += tl.trans(tl.dot(kT, ds_transposed)) * descale_k
         else:
-            dq += tl.dot(ds.to(kT.type.element_ty), tl.trans(kT))
+            dq = tl.dot(ds.to(kT.type.element_ty), tl.trans(kT), acc=dq)
 
         curr_n += step_n
         kT_ptrs += step_n * stride_kn
@@ -968,9 +968,9 @@ def _bwd_dkdv_inner_split(
         # dV
         if ENABLE_DROPOUT:
             pT_dropout = tl.where(dropout_mask, pT, 0.0) * dropout_scale
-            dv += tl.dot(pT_dropout.to(do.type.element_ty), do)
+            dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
-            dv += tl.dot(pT.to(do.type.element_ty), do)
+            dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
 
         # Load delta
         Di = tl.load(D + offs_m * stride_deltam, mask=mask_m)
@@ -995,7 +995,7 @@ def _bwd_dkdv_inner_split(
             dsT_transposed = tl.trans(dsT).to(qT.type.element_ty)
             dk += tl.trans(tl.dot(qT, dsT_transposed)) * descale_q
         else:
-            dk += tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT))
+            dk = tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT), acc=dk)
 
         # increment pointers
         curr_m += step_m
@@ -1150,9 +1150,9 @@ def _bwd_dkdvdq_inner_atomic(
         # dV
         if ENABLE_DROPOUT:
             pT_dropout = tl.where(dropout_mask, pT, 0.0) * dropout_scale
-            dv += tl.dot(pT_dropout.to(do.type.element_ty), do)
+            dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
-            dv += tl.dot(pT.to(do.type.element_ty), do)
+            dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
 
         # Load delta
         Di = tl.load(D + offs_m * stride_deltam, mask=mask_m)
@@ -1177,7 +1177,7 @@ def _bwd_dkdvdq_inner_atomic(
             dsT_transposed = tl.trans(dsT).to(qT.type.element_ty)
             dk += tl.trans(tl.dot(qT, dsT_transposed)) * descale_q
         else:
-            dk += tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT))
+            dk = tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT), acc=dk)
 
         # We can compute the dq_partial here and do a atomic add to the correct memory location
         # NOTE: Possible problems with the atomic add: contention, is inside a loop which has achieved bad perf before
@@ -2921,9 +2921,9 @@ def _bwd_dkdv_inner(
         # Compute dV.
         if ENABLE_DROPOUT:
             pT_dropout = pT * dropout_mask.to(pT.dtype) * dropout_scale
-            dv += tl.dot(pT_dropout.to(do.type.element_ty), do)
+            dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
-            dv += tl.dot(pT.to(do.type.element_ty), do)
+            dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
 
         if DEBUG_TRITON_DETAIL:
             if start_n == 256:
@@ -2946,7 +2946,7 @@ def _bwd_dkdv_inner(
             dsT_transposed = tl.trans(dsT).to(qT.type.element_ty)
             dk += tl.trans(tl.dot(qT, dsT_transposed)) * descale_q
         else:
-            dk += tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT))
+            dk = tl.dot(dsT.to(qT.type.element_ty), tl.trans(qT), acc=dk)
         # Increment pointers.
         curr_m += step_m
         qT_ptrs += step_m * stride_qm
@@ -3110,7 +3110,7 @@ def _bwd_dq_inner(
             ds_transposed = tl.trans(ds).to(kT.type.element_ty)
             dq += tl.trans(tl.dot(kT, ds_transposed)) * descale_k
         else:
-            dq += tl.dot(ds.to(kT.type.element_ty), tl.trans(kT))
+            dq = tl.dot(ds.to(kT.type.element_ty), tl.trans(kT), acc=dq)
         # Increment pointers.
         curr_n += step_n
         kT_ptrs += step_n * stride_kn

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
@@ -186,7 +186,7 @@ def _attn_fwd_inner(
     if IS_FP8:
         qk += tl.dot(q, kT) * q_descale * k_descale  # Apply FP8 scaling
     else:
-        qk += tl.dot(q, kT)  # noqa: F821
+        qk = tl.dot(q, kT, acc=qk)  # noqa: F821
 
     if USE_ALIBI:
         row_idx = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -270,7 +270,7 @@ def _attn_fwd_inner(
     if IS_FP8:
         acc += tl.dot(p.to(v.dtype), v) * v_descale  # Apply FP8 scaling for V
     else:
-        acc += tl.dot(p.to(v.dtype), v)
+        acc = tl.dot(p.to(v.dtype), v, acc=acc)
 
     return m_i, l_i, acc
 

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -347,7 +347,7 @@ def _attn_fwd_inner(
         if IS_FP8:
             qk += tl.dot(q, k) * q_descale * k_descale
         else:
-            qk += tl.dot(q, k)
+            qk = tl.dot(q, k, acc=qk)
         qk_scaled = qk * SM_SCALE
 
         if USE_ALIBI:
@@ -565,7 +565,7 @@ def _attn_fwd_inner(
             else:
                 acc += tl.dot(p.to(v.type.element_ty), v) * v_descale
         else:
-            acc += tl.dot(p.to(v.type.element_ty), v)
+            acc = tl.dot(p.to(v.type.element_ty), v, acc=acc)
 
     return acc, l_i, m_i
 

--- a/aiter/ops/triton/_triton_kernels/fusions/fused_bmm_rope_kv_cache.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_bmm_rope_kv_cache.py
@@ -320,7 +320,9 @@ def _fused_fp4_bmm_rope_cat_and_cache_mla_kernel(
                         a_bf16, BLOCK_SIZE_K, BLOCK_SIZE_M, SCALE_GROUP_SIZE
                     )
 
-                accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+                accumulator = tl.dot_scaled(
+                    a, a_scales, "e2m1", b, b_scales, "e2m1", acc=accumulator
+                )
 
                 a_ptrs += BLOCK_SIZE_K * stride_ak
                 b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk

--- a/aiter/ops/triton/_triton_kernels/fusions/mhc.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/mhc.py
@@ -154,7 +154,7 @@ def _mhc_fused_kernel(
             other=0.0,
         )
 
-        acc += tl.dot(x_tile, phi_tile)
+        acc = tl.dot(x_tile, phi_tile, acc=acc)
         x_tile_f32 = x_tile.to(tl.float32)
         acc_sq += tl.sum(x_tile_f32 * x_tile_f32, axis=1)
 
@@ -317,7 +317,7 @@ def _mhc_fused_split_kernel(
             other=0.0,
         )
 
-        acc += tl.dot(x_tile, phi_tile)
+        acc = tl.dot(x_tile, phi_tile, acc=acc)
         x_tile_f32 = x_tile.to(tl.float32)
         acc_sq += tl.sum(x_tile_f32 * x_tile_f32, axis=1)
 

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
@@ -167,19 +167,19 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 w, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
+            b_v = tl.dot(b_w, b_h2.to(b_w.dtype), acc=b_v)
         if K > 128:
             p_w = tl.make_block_ptr(
                 w, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
+            b_v = tl.dot(b_w, b_h3.to(b_w.dtype), acc=b_v)
         if K > 192:
             p_w = tl.make_block_ptr(
                 w, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
+            b_v = tl.dot(b_w, b_h4.to(b_w.dtype), acc=b_v)
         p_v = tl.make_block_ptr(
             v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
         )
@@ -247,25 +247,25 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
         )
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_h1 += tl.dot(b_k, b_v)
+        b_h1 = tl.dot(b_k, b_v, acc=b_h1)
         if K > 64:
             p_k = tl.make_block_ptr(
                 k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
             )
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h2 += tl.dot(b_k, b_v)
+            b_h2 = tl.dot(b_k, b_v, acc=b_h2)
         if K > 128:
             p_k = tl.make_block_ptr(
                 k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
             )
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h3 += tl.dot(b_k, b_v)
+            b_h3 = tl.dot(b_k, b_v, acc=b_h3)
         if K > 192:
             p_k = tl.make_block_ptr(
                 k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
             )
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h4 += tl.dot(b_k, b_v)
+            b_h4 = tl.dot(b_k, b_v, acc=b_h4)
     # epilogue
     if STORE_FINAL_STATE:
         p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
@@ -463,7 +463,7 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_gk_last2 = tl.load(
                     gk + last_idx * H * K + o_k2, mask=(o_k2 < K), other=0.0
                 )
-            b_dv += tl.dot(b_k, b_dh2.to(b_k.dtype))
+            b_dv = tl.dot(b_k, b_dh2.to(b_k.dtype), acc=b_dv)
 
         if K > 128:
             p_k = tl.make_block_ptr(
@@ -475,7 +475,7 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_gk_last3 = tl.load(
                     gk + last_idx * H * K + o_k3, mask=(o_k3 < K), other=0.0
                 )
-            b_dv += tl.dot(b_k, b_dh3.to(b_k.dtype))
+            b_dv = tl.dot(b_k, b_dh3.to(b_k.dtype), acc=b_dv)
 
         if K > 192:
             p_k = tl.make_block_ptr(
@@ -487,7 +487,7 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_gk_last4 = tl.load(
                     gk + last_idx * H * K + o_k4, mask=(o_k4 < K), other=0.0
                 )
-            b_dv += tl.dot(b_k, b_dh4.to(b_k.dtype))
+            b_dv = tl.dot(b_k, b_dh4.to(b_k.dtype), acc=b_dv)
 
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
@@ -788,19 +788,19 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt(
                 w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
+            b_v = tl.dot(b_w, b_h2.to(b_w.dtype), acc=b_v)
         if K > 128:
             p_w = tl.make_block_ptr(
                 w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
+            b_v = tl.dot(b_w, b_h3.to(b_w.dtype), acc=b_v)
         if K > 192:
             p_w = tl.make_block_ptr(
                 w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
+            b_v = tl.dot(b_w, b_h4.to(b_w.dtype), acc=b_v)
         p_v = tl.make_block_ptr(
             v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
         )
@@ -868,25 +868,25 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt(
             k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
         )
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_h1 += tl.dot(b_k, b_v)
+        b_h1 = tl.dot(b_k, b_v, acc=b_h1)
         if K > 64:
             p_k = tl.make_block_ptr(
                 k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
             )
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h2 += tl.dot(b_k, b_v)
+            b_h2 = tl.dot(b_k, b_v, acc=b_h2)
         if K > 128:
             p_k = tl.make_block_ptr(
                 k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
             )
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h3 += tl.dot(b_k, b_v)
+            b_h3 = tl.dot(b_k, b_v, acc=b_h3)
         if K > 192:
             p_k = tl.make_block_ptr(
                 k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
             )
             b_k = tl.load(p_k, boundary_check=(0, 1))
-            b_h4 += tl.dot(b_k, b_v)
+            b_h4 = tl.dot(b_k, b_v, acc=b_h4)
 
     if STORE_FINAL_STATE:
         p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
@@ -1128,19 +1128,19 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
                 w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
+            b_v = tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype), acc=b_v)
         if K > 128:
             p_w = tl.make_block_ptr(
                 w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
+            b_v = tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype), acc=b_v)
         if K > 192:
             p_w = tl.make_block_ptr(
                 w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
             )
             b_w = tl.load(p_w, boundary_check=(0, 1))
-            b_v += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
+            b_v = tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype), acc=b_v)
         p_v = tl.make_block_ptr(
             v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
         )

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_o.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_o.py
@@ -110,9 +110,9 @@ def chunk_fwd_kernel_o(
         b_h = tl.load(p_h, boundary_check=(0, 1))
 
         # [BT, BK] @ [BK, BV] -> [BT, BV]
-        b_o += tl.dot(b_q, b_h)
+        b_o = tl.dot(b_q, b_h, acc=b_o)
         # [BT, BK] @ [BK, BT] -> [BT, BT]
-        b_A += tl.dot(b_q, b_k)
+        b_A = tl.dot(b_q, b_k, acc=b_A)
 
     if USE_G:
         g += bos * H + i_h
@@ -262,17 +262,17 @@ def chunk_bwd_kernel_dqkwg(
         if USE_G:
             b_dg_last += tl.sum(b_h * b_dh)
         # [BT, BV] @ [BV, BT] -> [BT, BT]
-        b_ds += tl.dot(b_do, tl.trans(b_v))
+        b_ds = tl.dot(b_do, tl.trans(b_v), acc=b_ds)
         # [BT, BV] @ [BV, BK] -> [BT, BK]
-        b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
+        b_dq = tl.dot(b_do, b_h.to(b_do.dtype), acc=b_dq)
         # [BT, BV] @ [BV, BK] -> [BT, BK]
-        b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
+        b_dk = tl.dot(b_v, b_dh.to(b_v.dtype), acc=b_dk)
         if USE_DW:
             p_dv = tl.make_block_ptr(
                 dv, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
             )
             b_dv = tl.load(p_dv, boundary_check=(0, 1))
-            b_dw += tl.dot(b_dv.to(b_v.dtype), b_h.to(b_v.dtype))
+            b_dw = tl.dot(b_dv.to(b_v.dtype), b_h.to(b_v.dtype), acc=b_dw)
 
     if USE_DW:
         p_dw = tl.make_block_ptr(
@@ -323,8 +323,8 @@ def chunk_bwd_kernel_dqkwg(
 
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
-        b_dq += tl.dot(b_ds, b_k)
-        b_dk += tl.dot(tl.trans(b_ds), b_q)
+        b_dq = tl.dot(b_ds, b_k, acc=b_dq)
+        b_dk = tl.dot(tl.trans(b_ds), b_q, acc=b_dk)
         p_dg = tl.make_block_ptr(dg, (T,), (H,), (i_t * BT,), (BT,), (0,))
         # (SY 09/21) revcumsum in a separate kernel due to strange triton compiler issue
         # b_dg = tl.dot(tl.where(o_t[:, None] <= o_t[None, :], 1., 0.), b_dg, allow_tf32=False) + b_dg_last)
@@ -339,15 +339,15 @@ def chunk_bwd_kernel_dqkwg(
         b_ds = tl.where(m_A, b_ds * exp(b_g[:, None] - b_g[None, :]), 0) * scale
         b_ds = b_ds.to(b_k.dtype)
         # [BT, BK]
-        b_dq += tl.dot(b_ds, b_k)
-        b_dk += tl.dot(tl.trans(b_ds), b_q)
+        b_dq = tl.dot(b_ds, b_k, acc=b_dq)
+        b_dk = tl.dot(tl.trans(b_ds), b_q, acc=b_dk)
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
 
     else:
         b_ds = tl.where(m_A, b_ds, 0)
         b_ds = b_ds.to(b_k.dtype)
-        b_dq += tl.dot(b_ds, b_k)
+        b_dq = tl.dot(b_ds, b_k, acc=b_dq)
         b_dk += tl.dot(tl.trans(b_ds), b_q) * scale
         b_dq *= scale
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
@@ -429,12 +429,12 @@ def chunk_bwd_kernel_dv(
         )
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_A += tl.dot(b_k, b_q)
+        b_A = tl.dot(b_k, b_q, acc=b_A)
         p_dh = tl.make_block_ptr(
             dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
         )
         b_dh = tl.load(p_dh, boundary_check=(0, 1))
-        b_dv += tl.dot(b_k, b_dh.to(b_k.dtype))
+        b_dv = tl.dot(b_k, b_dh.to(b_k.dtype), acc=b_dv)
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
@@ -463,7 +463,7 @@ def chunk_bwd_kernel_dv(
         dv, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
     )
     b_do = tl.load(p_do, boundary_check=(0, 1))
-    b_dv += tl.dot(b_A.to(b_do.dtype), b_do)
+    b_dv = tl.dot(b_A.to(b_do.dtype), b_do, acc=b_dv)
     tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
 
@@ -710,8 +710,8 @@ def chunk_fwd_kernel_o_opt(
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_h = tl.load(p_h, boundary_check=(0, 1))
 
-        b_o += tl.dot(b_q, b_h)
-        b_A += tl.dot(b_q, b_k)
+        b_o = tl.dot(b_q, b_h, acc=b_o)
+        b_A = tl.dot(b_q, b_k, acc=b_A)
 
     if USE_G:
         g += bos * H + i_h
@@ -892,8 +892,8 @@ def chunk_fwd_kernel_o_opt_vk(
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_h = tl.load(p_h, boundary_check=(0, 1))
 
-        b_o += tl.dot(b_q, tl.trans(b_h))
-        b_A += tl.dot(b_q, b_k)
+        b_o = tl.dot(b_q, tl.trans(b_h), acc=b_o)
+        b_A = tl.dot(b_q, b_k, acc=b_A)
 
     if USE_G:
         g += bos * H + i_h

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_cumsum_kkt.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_cumsum_kkt.py
@@ -209,7 +209,7 @@ def fused_chunk_local_cumsum_scaled_dot_kkt_fwd_kernel(
         )
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_kb = b_k * b_beta[:, None]
-        b_A += tl.dot(b_kb.to(b_k.dtype), tl.trans(b_k))
+        b_A = tl.dot(b_kb.to(b_k.dtype), tl.trans(b_k), acc=b_A)
 
     b_g_diff = b_g_cumsum[:, None] - b_g_cumsum[None, :]
     m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/wy_representation.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/wy_representation.py
@@ -79,7 +79,7 @@ def chunk_scaled_dot_kkt_fwd_kernel(
             (1, 0),
         )
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        b_A += tl.dot(b_k, tl.trans(b_k))
+        b_A = tl.dot(b_k, tl.trans(b_k), acc=b_A)
 
     if USE_G:
         p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))

--- a/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
+++ b/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
@@ -324,14 +324,14 @@ def _triton_gather_kv_b_proj(
         )
 
         if NO_SCALE:
-            accum_k += tl.dot(kv_c_data_0, k_nope_weight_0.T)
-            accum_v += tl.dot(kv_c_data_0, v_nope_weight_0.T)
-            accum_k += tl.dot(kv_c_data_1, k_nope_weight_1.T)
-            accum_v += tl.dot(kv_c_data_1, v_nope_weight_1.T)
-            accum_k += tl.dot(kv_c_data_2, k_nope_weight_2.T)
-            accum_v += tl.dot(kv_c_data_2, v_nope_weight_2.T)
-            accum_k += tl.dot(kv_c_data_3, k_nope_weight_3.T)
-            accum_v += tl.dot(kv_c_data_3, v_nope_weight_3.T)
+            accum_k = tl.dot(kv_c_data_0, k_nope_weight_0.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_0, v_nope_weight_0.T, acc=accum_v)
+            accum_k = tl.dot(kv_c_data_1, k_nope_weight_1.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_1, v_nope_weight_1.T, acc=accum_v)
+            accum_k = tl.dot(kv_c_data_2, k_nope_weight_2.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_2, v_nope_weight_2.T, acc=accum_v)
+            accum_k = tl.dot(kv_c_data_3, k_nope_weight_3.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_3, v_nope_weight_3.T, acc=accum_v)
         elif PER_ROW_SCALE:
             accum_k += (
                 tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_vec[None, :]

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16.py
@@ -167,7 +167,7 @@ def _gemm_a16_w16_kernel(
                     other=0.0,
                     cache_modifier=cache_modifier,
                 )
-            accumulator += tl.dot(a, b)
+            accumulator = tl.dot(a, b, acc=accumulator)
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak
             b_ptrs += BLOCK_SIZE_K * stride_bk

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_atomic.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_atomic.py
@@ -120,7 +120,7 @@ def _gemm_a16_w16_atomic_kernel(
                     b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
                 )
 
-            accumulator += tl.dot(a, b)
+            accumulator = tl.dot(a, b, acc=accumulator)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_gated.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_gated.py
@@ -127,8 +127,8 @@ def _gemm_a16_w16_gated_kernel(
                 cache_modifier=cache_modifier,
             )
 
-        acc0 += tl.dot(a, b0)
-        acc1 += tl.dot(a, b1)
+        acc0 = tl.dot(a, b0, acc=acc0)
+        acc1 = tl.dot(a, b1, acc=acc1)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16wfp4.py
@@ -158,7 +158,9 @@ def _gemm_a16wfp4_kernel(
 
             a, a_scales = _mxfp4_quant_op(a_bf16, BLOCK_SIZE_K, BLOCK_SIZE_M, 32)
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(
+                a, a_scales, "e2m1", b, b_scales, "e2m1", acc=accumulator
+            )
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak
@@ -354,7 +356,9 @@ def _gemm_a16wfp4_preshuffle_kernel(
             if PREQUANT:
                 a, a_scales = _mxfp4_quant_op(a_bf16, BLOCK_SIZE_K, BLOCK_SIZE_M, 32)
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(
+                a, a_scales, "e2m1", b, b_scales, "e2m1", acc=accumulator
+            )
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8.py
@@ -161,7 +161,7 @@ def _gemm_a8w8_kernel(
                     cache_modifier=cache_modifier,
                 )
 
-            accumulator += tl.dot(a, b)
+            accumulator = tl.dot(a, b, acc=accumulator)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8.py
@@ -161,7 +161,7 @@ def _gemm_a8w8_kernel(
                     cache_modifier=cache_modifier,
                 )
 
-            accumulator = tl.dot(a, b, acc=accumulator)
+            accumulator += tl.dot(a, b)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_per_token_scale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_per_token_scale.py
@@ -168,7 +168,7 @@ def _gemm_a8w8_per_token_scale_kernel(
                 )
 
             # Perform dot operation and apply scale
-            accumulator += tl.dot(a, b)
+            accumulator = tl.dot(a, b, acc=accumulator)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_per_token_scale.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_per_token_scale.py
@@ -168,7 +168,7 @@ def _gemm_a8w8_per_token_scale_kernel(
                 )
 
             # Perform dot operation and apply scale
-            accumulator = tl.dot(a, b, acc=accumulator)
+            accumulator += tl.dot(a, b)
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8wfp4.py
@@ -197,7 +197,9 @@ def _gemm_a8wfp4_kernel(
                     b_mask = offs_bk[:, None] < K - k * (BLOCK_SIZE_K // 2)
                     b = tl.load(b_ptrs, mask=b_mask, other=0)
                 b_scales = tl.load(b_scale_ptrs)
-            accumulator += tl.dot_scaled(a, a_ones_scale, "e4m3", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(
+                a, a_ones_scale, "e4m3", b, b_scales, "e2m1", acc=accumulator
+            )
 
         # Scale by a_scales at the end
         c = (accumulator * a_scales[:, None]).to(c_ptr.type.element_ty)

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a16wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a16wfp4.py
@@ -200,7 +200,9 @@ def _batched_gemm_a16wfp4_kernel(
                     a_bf16, BLOCK_SIZE_K, BLOCK_SIZE_M, SCALE_GROUP_SIZE
                 )
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(
+                a, a_scales, "e2m1", b, b_scales, "e2m1", acc=accumulator
+            )
 
             # Advance the ptrs to the next K block.
             a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8.py
@@ -163,7 +163,7 @@ def _batched_gemm_a8w8_kernel(
             a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
             b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
-        accumulator = tl.dot(a, b, acc=accumulator)
+        accumulator += tl.dot(a, b)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a8w8.py
@@ -163,7 +163,7 @@ def _batched_gemm_a8w8_kernel(
             a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
             b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, acc=accumulator)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_afp4wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_afp4wfp4.py
@@ -209,7 +209,9 @@ def _batched_gemm_afp4_wfp4_kernel(
                     b_ptrs, mask=offs_k[:, None] < K - k * (BLOCK_SIZE_K // 2), other=0
                 )
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(
+                a, a_scales, "e2m1", b, b_scales, "e2m1", acc=accumulator
+            )
 
             # Advance the ptrs to the next K block.
             a_ptrs += (BLOCK_SIZE_K // 2) * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_bf16.py
@@ -145,7 +145,7 @@ def _batched_gemm_bf16_kernel(
             a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
             b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
-        accumulator += tl.dot(a, b)
+        accumulator = tl.dot(a, b, acc=accumulator)
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_gated.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_gated.py
@@ -133,8 +133,8 @@ def _ff_a16w16_fused_gated(
                 cache_modifier=cache_modifier,
             )
 
-        acc0 += tl.dot(x, w1n0)
-        acc1 += tl.dot(x, w1n1)
+        acc0 = tl.dot(x, w1n0, acc=acc0)
+        acc1 = tl.dot(x, w1n1, acc=acc1)
 
         # Advance the ptrs to the next K block.
         x_ptrs += BLOCK_SIZE_K * stride_xk

--- a/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_ungated.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/feed_forward/ff_a16w16_fused_ungated.py
@@ -104,7 +104,7 @@ def _ff_a16w16_fused_ungated(
                 cache_modifier=cache_modifier,
             )
 
-        acc += tl.dot(x, w1)
+        acc = tl.dot(x, w1, acc=acc)
 
         # Advance the ptrs to the next K block.
         x_ptrs += BLOCK_SIZE_K * stride_xk

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_a16w16.py
@@ -232,7 +232,7 @@ def _fused_gemm_a8w8_blockscale_a16w16_kernel(
                         cache_modifier=cache_modifier,
                     )
 
-                accumulator_bf16 += tl.dot(a, b)
+                accumulator_bf16 = tl.dot(a, b, acc=accumulator_bf16)
 
                 a_ptrs += BLOCK_SIZE_K * stride_a_bf16_k
                 b_ptrs += BLOCK_SIZE_K * stride_b_bf16_k

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_a16w16.py
@@ -205,7 +205,9 @@ def _fused_gemm_afp4wfp4_a16w16_kernel(
                         cache_modifier=cache_modifier,
                     )
 
-                accumulator_fp4 += tl.dot_scaled(a, a_scale, "e2m1", b, b_scale, "e2m1")
+                accumulator_fp4 = tl.dot_scaled(
+                    a, a_scale, "e2m1", b, b_scale, "e2m1", acc=accumulator_fp4
+                )
 
                 a_fp4_ptrs += (BLOCK_SIZE_K // 2) * stride_a_fp4_k
                 b_fp4_ptrs += (BLOCK_SIZE_K // 2) * stride_b_fp4_k
@@ -282,7 +284,7 @@ def _fused_gemm_afp4wfp4_a16w16_kernel(
                         cache_modifier=cache_modifier,
                     )
 
-                accumulator_bf16 += tl.dot(a, b)
+                accumulator_bf16 = tl.dot(a, b, acc=accumulator_bf16)
 
                 a_ptrs += BLOCK_SIZE_K * stride_a_bf16_k
                 b_ptrs += BLOCK_SIZE_K * stride_b_bf16_k
@@ -572,7 +574,9 @@ def _fused_gemm_afp4wfp4_preshuffle_a16w16_kernel(
                     .trans(1, 0)
                 )
 
-                accumulator_fp4 += tl.dot_scaled(a, a_scale, "e2m1", b, b_scale, "e2m1")
+                accumulator_fp4 = tl.dot_scaled(
+                    a, a_scale, "e2m1", b, b_scale, "e2m1", acc=accumulator_fp4
+                )
 
                 a_fp4_ptrs += (BLOCK_SIZE_K // 2) * stride_a_fp4_k
                 b_fp4_ptrs += (BLOCK_SIZE_K // 2) * 16 * stride_b_fp4_k
@@ -652,7 +656,7 @@ def _fused_gemm_afp4wfp4_preshuffle_a16w16_kernel(
                         cache_modifier=cache_modifier,
                     )
 
-                accumulator_bf16 += tl.dot(a, b)
+                accumulator_bf16 = tl.dot(a, b, acc=accumulator_bf16)
 
                 a_ptrs += BLOCK_SIZE_K * stride_a_bf16_k
                 b_ptrs += BLOCK_SIZE_K * stride_b_bf16_k

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
@@ -449,7 +449,9 @@ def _fused_gemm_afp4wfp4_preshuffle_mul_add_kernel(
                 .trans(1, 0)
             )
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(
+                a, a_scales, "e2m1", b, b_scales, "e2m1", acc=accumulator
+            )
 
             # Advance the ptrs to the next K block.
             a_ptrs += (BLOCK_SIZE_K // 2) * stride_ak

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_split_cat.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_split_cat.py
@@ -489,7 +489,9 @@ def _fused_gemm_afp4wfp4_preshuffle_split_cat(
                 .trans(1, 0)
             )
 
-            accumulator += tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1")
+            accumulator = tl.dot_scaled(
+                a, a_scales, "e2m1", b, b_scales, "e2m1", acc=accumulator
+            )
 
             # Advance the ptrs to the next K block.
             a_ptrs += (BLOCK_SIZE_K // 2) * stride_a_k

--- a/aiter/ops/triton/_triton_kernels/gmm.py
+++ b/aiter/ops/triton/_triton_kernels/gmm.py
@@ -198,7 +198,7 @@ def gmm_kernel(
                         rhs_ptrs, mask=offs_k[:, None] < k_mask_limit, other=0
                     )
 
-                acc += tl.dot(lhs, rhs)
+                acc = tl.dot(lhs, rhs, acc=acc)
 
                 lhs_ptrs += BLOCK_SIZE_K
 
@@ -360,7 +360,7 @@ def tgmm_persistent_kernel(
                 lhs = tl.load(lhs_ptrs)
                 rhs = tl.load(rhs_ptrs)
 
-                acc += tl.dot(lhs, rhs)
+                acc = tl.dot(lhs, rhs, acc=acc)
 
                 # Accumulate for bias gradient: sum lhs across M dimension
                 if COMPUTE_BIAS_GRAD and tile_n == 0:
@@ -385,7 +385,7 @@ def tgmm_persistent_kernel(
                 offs_m = loop_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
                 lhs = tl.load(lhs_ptrs, mask=offs_m[None, :] < m, other=0)
                 rhs = tl.load(rhs_ptrs, mask=offs_m[:, None] < m, other=0)
-                acc += tl.dot(lhs, rhs)
+                acc = tl.dot(lhs, rhs, acc=acc)
 
                 # Accumulate last chunk for bias gradient
                 if COMPUTE_BIAS_GRAD and tile_n == 0:
@@ -531,7 +531,7 @@ def tgmm_non_persistent_kernel(
         lhs = tl.load(lhs_ptrs)
         rhs = tl.load(rhs_ptrs)
 
-        acc += tl.dot(lhs, rhs)
+        acc = tl.dot(lhs, rhs, acc=acc)
 
         # Accumulate for bias gradient: sum lhs across M dimension
         if COMPUTE_BIAS_GRAD and tile_n == 0:
@@ -554,7 +554,7 @@ def tgmm_non_persistent_kernel(
         offs_m = loop_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         lhs = tl.load(lhs_ptrs, mask=offs_m[None, :] < m, other=0)
         rhs = tl.load(rhs_ptrs, mask=offs_m[:, None] < m, other=0)
-        acc += tl.dot(lhs, rhs)
+        acc = tl.dot(lhs, rhs, acc=acc)
         # Accumulate last chunk for bias gradient
         if COMPUTE_BIAS_GRAD and tile_n == 0:
             bias_acc += tl.sum(lhs, axis=1)


### PR DESCRIPTION
Convert `acc += tl.dot(...)` and `acc += tl.dot_scaled(...)` to `acc = tl.dot(..., acc=acc)` / `acc = tl.dot_scaled(..., acc=acc)` so the matrix multiply accumulates directly into acc without a separate add.