### PR TITLE
[Bugfix] Fix op schema for fmha_v3_fowd and gemm_a16w16

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -1395,7 +1395,7 @@ def compile_ops(
     gen_fake: Optional[Callable[..., Any]] = None,
     ffi_type: str = "pybind",
     develop: bool = False,
-    mutates_args: Union[bool, List[str]] = "unknown",
+    mutates_args: Union[str, List[str]] = "unknown",
 ):
     def decorator(func):
         loadName = fc_name if fc_name is not None else func.__name__

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -14,7 +14,7 @@ import time
 import traceback
 import types
 import typing
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional, Union
 
 from packaging.version import Version, parse
 
@@ -1395,6 +1395,7 @@ def compile_ops(
     gen_fake: Optional[Callable[..., Any]] = None,
     ffi_type: str = "pybind",
     develop: bool = False,
+    mutates_args: Union[bool, List[str]] = "unknown",
 ):
     def decorator(func):
         loadName = fc_name if fc_name is not None else func.__name__
@@ -1406,7 +1407,9 @@ def compile_ops(
             def ctypes_wrapper(*args, **kwargs):
                 return ctypes_caller(*args, **kwargs)
 
-            @torch_compile_guard(device="cuda", calling_func_=func)
+            @torch_compile_guard(
+                device="cuda", calling_func_=func, mutates_args=mutates_args
+            )
             def ctypes_custom_wrapper(*args, **kwargs):
                 return ctypes_wrapper(*args, **kwargs)
 
@@ -1656,7 +1659,12 @@ def compile_ops(
                     )
                 return op(*args, **kwargs)
 
-            @torch_compile_guard(device="cuda", gen_fake=gen_fake, calling_func_=func)
+            @torch_compile_guard(
+                device="cuda",
+                gen_fake=gen_fake,
+                calling_func_=func,
+                mutates_args=mutates_args,
+            )
             def custom_wrapper(*args, **kwargs):
                 return wrapper(*args, **kwargs)
 

--- a/aiter/jit/utils/torch_guard.py
+++ b/aiter/jit/utils/torch_guard.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
 from packaging import version
 from packaging.version import Version
 import importlib
@@ -75,7 +75,7 @@ NONE_WRAPPED_OP = [
     "qr_destroy",
     "qr_open_handles",
     "qr_get_handle",
-    # These take pybind aiter_tensor_t, not torch.Tensor — incompatible with torch.compile
+    # These take pybind aiter_tensor_t, not torch.Tensor -- incompatible with torch.compile
     "all_reduce",
     "reduce_scatter",
     "all_gather_reg",
@@ -224,7 +224,7 @@ def torch_compile_guard(
             aiter_lib = Library("aiter", "FRAGMENT") if aiter_lib is None else aiter_lib
             schema = ""
             if calling_func.__name__ in MANUAL_SCHEMA_OPS:
-                schema = generate_schema(calling_func)
+                schema = generate_schema(calling_func, mutates_args=mutates_args)
             else:
                 sig = inspect.signature(calling_func)
                 if hasattr(torch.library, "infer_schema"):

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -246,7 +246,10 @@ def gen_fmha_v3_fwd_fake_tensors(
 
 
 @compile_ops(
-    "module_fmha_v3_fwd", fc_name="fmha_v3_fwd", gen_fake=gen_fmha_v3_fwd_fake_tensors
+    "module_fmha_v3_fwd",
+    fc_name="fmha_v3_fwd",
+    gen_fake=gen_fmha_v3_fwd_fake_tensors,
+    mutates_args=[],
 )
 def fmha_v3_fwd(
     q: Tensor,

--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -247,7 +247,7 @@ def gen_gemm_a16w16_fake_tensor(
     )
 
 
-@torch_compile_guard(gen_fake=gen_gemm_a16w16_fake_tensor)
+@torch_compile_guard(mutates_args=[], gen_fake=gen_gemm_a16w16_fake_tensor)
 def gemm_a16w16(
     A: Tensor,
     B: Tensor,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
For Flux2 model inference with `torch.compile` enabled,  it may cause `assert_size_stride` failure and precision problem. Aligning the op schema with PyTorch native schema resolves both problems.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Reference:
1. https://github.com/pytorch/pytorch/blob/main/torch/_library/custom_ops.py#L78-L80
2. https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
