### PR TITLE
cpp_extension: fix crash if compiler is not found

### DIFF
--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -282,7 +282,11 @@ def check_compiler_ok_for_platform(compiler: str) -> bool:
         True if the compiler is gcc/g++ on Linux or clang/clang++ on macOS,
         and always True for Windows.
     """
-    compiler_path = os.path.realpath(shutil.which(compiler))
+    found_compiler = shutil.which(compiler)
+    if not found_compiler:
+        return False
+
+    compiler_path = os.path.realpath(found_compiler)
     if not compiler_path:
         return False
 


### PR DESCRIPTION

If the compiler is not found, `shutil.which` will return `None` and `realpath` will error out:

```python
vllm (Worker_TP0 pid=332)     compiler_path = os.path.realpath(shutil.which(compiler))
qwen3-5-397b-vllm-66f4cf85cd-sr5mc vllm (Worker_TP0 pid=332) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qwen3-5-397b-vllm-66f4cf85cd-sr5mc vllm (Worker_TP0 pid=332) -->  File "<frozen posixpath>", line 426, in realpath
qwen3-5-397b-vllm-66f4cf85cd-sr5mc vllm (Worker_TP0 pid=332) -->Typeerror: expected str, bytes or os.PathLike object, not NoneType
vllm (Worker_TP0 pid=332)     compiler_path = os.path.realpath(shutil.which(compiler))
qwen3-5-397b-vllm-66f4cf85cd-sr5mc vllm (Worker_TP0 pid=332)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qwen3-5-397b-vllm-66f4cf85cd-sr5mc vllm (Worker_TP0 pid=332) -->  File "<frozen posixpath>", line 426, in realpath
qwen3-5-397b-vllm-66f4cf85cd-sr5mc vllm (Worker_TP0 pid=332) -->Typeerror: expected str, bytes or os.PathLike object, not NoneType
```
