### PR TITLE
Update triton wheel

### DIFF
--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -2,13 +2,15 @@
 set -e
 
 pip uninstall -y triton pytorch-triton pytorch-triton-rocm triton-rocm amd-triton || true
+pip uninstall -y triton-kernels || true
 
-TRITON_INDEX_URL="https://pypi.amd.com/triton/release/rocm-7.0.0/simple/"
+TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
 if [[ -n "$ROCM_VERSION" ]]; then
     ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | cut -d. -f1,2)
-    TRITON_INDEX_URL="https://pypi.amd.com/triton/release/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
+    TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
 fi
 
 echo "Installing triton from $TRITON_INDEX_URL"
 pip install --extra-index-url "$TRITON_INDEX_URL" triton
+pip install --extra-index-url "$TRITON_INDEX_URL" triton-kernels

--- a/.github/scripts/split_tests.sh
+++ b/.github/scripts/split_tests.sh
@@ -223,6 +223,19 @@ elif [[ "$TEST_TYPE" == "triton" ]]; then
     FILE_TIMES[op_tests/triton_tests/moe/test_moe_align_block_size.py]=1
     FILE_TIMES[op_tests/triton_tests/torch_compile/test_compile_topk.py]=1
     FILE_TIMES[op_tests/triton_tests/triton_metadata_redirect/test_metadata_redirect.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_distributed.py]=507
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_matmul.py]=157
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_roofline.py]=4
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_reduce.py]=2
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_compaction.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_tensor.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_topk.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_mxfp.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_specialize.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_swiglu.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_matmul_details/test_opt_flags_split_k.py]=1
+    FILE_TIMES[op_tests/triton_tests/triton_kernels/test_tensor_details/test_layout_cdna4.py]=1
+    FILE_TIMES[op_tests/triton_tests/torch_compile/test_compile_constexpr_mutation.py]=2
 fi
 
 get_time() {

--- a/op_tests/triton_tests/torch_compile/test_compile_constexpr_mutation.py
+++ b/op_tests/triton_tests/torch_compile/test_compile_constexpr_mutation.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+from . import _get_compiled
+
+
+@triton.jit
+def _rmsnorm_constexpr_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    eps,
+    stride_x,
+    stride_out,
+    N: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_N)
+    mask = cols < N
+
+    x = tl.load(x_ptr + row * stride_x + cols, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(x * x, axis=0) / N
+    x_hat = x / tl.sqrt(variance + eps)
+
+    w = tl.load(weight_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr + row * stride_out + cols, (x_hat * w).to(tl.float16), mask=mask)
+
+
+def triton_rmsnorm(x, weight, eps, out):
+    M, N = x.shape
+    _rmsnorm_constexpr_kernel[(M,)](
+        x, weight, out, eps, x.stride(0), out.stride(0), N, triton.next_power_of_2(N)
+    )
+    return out
+
+
+def torch_rmsnorm(x, weight, eps):
+    x_f32 = x.to(torch.float32)
+    return (x_f32 * torch.rsqrt(x_f32.pow(2).mean(-1, keepdim=True) + eps) * weight).to(
+        x.dtype
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("M, N", [(32, 64), (64, 128), (128, 256)])
+def test_compile_constexpr_mutation(M, N, dtype):
+    """Triton kernel with tl.constexpr + shared-storage views under torch.compile."""
+    torch.manual_seed(42)
+    torch.cuda.empty_cache()
+    torch._dynamo.reset()
+
+    head_dim = N // 4
+    q_dim = 2 * head_dim
+    k_dim = head_dim
+    eps = 1e-6
+
+    qkv = torch.randn(M, N, device="cuda", dtype=dtype)
+    w_q = torch.ones(q_dim, device="cuda", dtype=dtype)
+    w_k = torch.ones(k_dim, device="cuda", dtype=dtype)
+
+    def fn(qkv, w_q, w_k):
+        q = qkv[:, :q_dim]
+        k = qkv[:, q_dim : q_dim + k_dim]
+        v = qkv[:, q_dim + k_dim :]
+        q_out = torch.empty_like(q)
+        k_out = torch.empty_like(k)
+        triton_rmsnorm(q, w_q, eps, q_out)
+        triton_rmsnorm(k, w_k, eps, k_out)
+        return q_out, k_out, v
+
+    q_ref = torch_rmsnorm(qkv[:, :q_dim], w_q, eps)
+    k_ref = torch_rmsnorm(qkv[:, q_dim : q_dim + k_dim], w_k, eps)
+    v_ref = qkv[:, q_dim + k_dim :].clone()
+
+    compiled_fn = _get_compiled(fn)
+    q_out, k_out, v_out = compiled_fn(qkv, w_q, w_k)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(q_out, q_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(k_out, k_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(v_out, v_ref, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/op_tests/triton_tests/triton_kernels/conftest.py
+++ b/op_tests/triton_tests/triton_kernels/conftest.py
@@ -1,0 +1,60 @@
+import pytest
+import tempfile
+import os
+
+
+def pytest_addoption(parser):
+    parser.addoption("--device", action="store", default="cuda")
+
+
+@pytest.fixture
+def device(request):
+    return request.config.getoption("--device")
+
+
+@pytest.fixture
+def fresh_knobs():
+    """
+    Default fresh knobs fixture that preserves library path
+    information from the environment as these are typically
+    needed to successfully compile kernels.
+    """
+    from triton._internal_testing import _fresh_knobs_impl
+    fresh_function, reset_function = _fresh_knobs_impl(skipped_attr={"build", "nvidia", "amd"})
+    try:
+        yield fresh_function()
+    finally:
+        reset_function()
+
+
+@pytest.fixture
+def fresh_knobs_including_libraries():
+    """
+    A variant of `fresh_knobs` that resets ALL knobs including
+    library paths. Use this only for tests that need complete
+    environment isolation.
+    """
+    from triton._internal_testing import _fresh_knobs_impl
+    fresh_function, reset_function = _fresh_knobs_impl()
+    try:
+        yield fresh_function()
+    finally:
+        reset_function()
+
+
+@pytest.fixture
+def fresh_triton_cache():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from triton import knobs
+
+        with knobs.cache.scope(), knobs.runtime.scope():
+            knobs.cache.dir = tmpdir
+            yield tmpdir
+
+
+def pytest_configure(config):
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id is not None and worker_id.startswith("gw"):
+        import torch
+        gpu_id = int(worker_id[2:])  # map gw0 → 0, gw1 → 1, ...
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id % torch.cuda.device_count())

--- a/op_tests/triton_tests/triton_kernels/conftest.py
+++ b/op_tests/triton_tests/triton_kernels/conftest.py
@@ -20,7 +20,10 @@ def fresh_knobs():
     needed to successfully compile kernels.
     """
     from triton._internal_testing import _fresh_knobs_impl
-    fresh_function, reset_function = _fresh_knobs_impl(skipped_attr={"build", "nvidia", "amd"})
+
+    fresh_function, reset_function = _fresh_knobs_impl(
+        skipped_attr={"build", "nvidia", "amd"}
+    )
     try:
         yield fresh_function()
     finally:
@@ -35,6 +38,7 @@ def fresh_knobs_including_libraries():
     environment isolation.
     """
     from triton._internal_testing import _fresh_knobs_impl
+
     fresh_function, reset_function = _fresh_knobs_impl()
     try:
         yield fresh_function()
@@ -56,5 +60,6 @@ def pytest_configure(config):
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     if worker_id is not None and worker_id.startswith("gw"):
         import torch
+
         gpu_id = int(worker_id[2:])  # map gw0 → 0, gw1 → 1, ...
         os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id % torch.cuda.device_count())

--- a/op_tests/triton_tests/triton_kernels/test_compaction.py
+++ b/op_tests/triton_tests/triton_kernels/test_compaction.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+from triton_kernels.compaction import compaction, compaction_torch
+
+
+@pytest.mark.parametrize("n_tokens, n_cols, k, p", [
+    (8192, 64, 4, 0.5),
+    (8192, 64, 4, 1.0),
+    (131, 128, 16, 0.6),
+    (496, 128, 16, 0.),
+])
+def test_compaction(n_tokens, n_cols, k, p, device):
+    yi = torch.rand((n_tokens, n_cols), device=device).argsort(dim=-1)
+    yi = yi[:, :k].to(torch.int32)
+    yv = torch.randn((n_tokens, k), dtype=torch.bfloat16, device=device)
+    # "drop" indices from yi with probability `p`
+    mask = torch.zeros((n_tokens, n_cols), dtype=torch.int32, device=device)
+    keep = (torch.rand(yi.shape, device=device) < p)
+    if keep.any():
+        rows = torch.arange(yi.size(0), device=device).unsqueeze(1).expand_as(yi)
+        mask[rows[keep], yi[keep]] = 1
+    chunks = mask.view(*mask.shape[:-1], -1, 32)
+    weights = (1 << torch.arange(32, dtype=torch.int32, device=device))
+    bitmask = (chunks.int() * weights).sum(dim=-1)
+    yv_ref, yi_ref = compaction_torch(yv, yi, bitmask)
+    yv_tri, yi_tri = compaction(yv, yi, bitmask)
+    assert torch.all(yi_ref == yi_tri)
+    assert torch.all(yv_ref == yv_tri)

--- a/op_tests/triton_tests/triton_kernels/test_compaction.py
+++ b/op_tests/triton_tests/triton_kernels/test_compaction.py
@@ -3,24 +3,27 @@ import torch
 from triton_kernels.compaction import compaction, compaction_torch
 
 
-@pytest.mark.parametrize("n_tokens, n_cols, k, p", [
-    (8192, 64, 4, 0.5),
-    (8192, 64, 4, 1.0),
-    (131, 128, 16, 0.6),
-    (496, 128, 16, 0.),
-])
+@pytest.mark.parametrize(
+    "n_tokens, n_cols, k, p",
+    [
+        (8192, 64, 4, 0.5),
+        (8192, 64, 4, 1.0),
+        (131, 128, 16, 0.6),
+        (496, 128, 16, 0.0),
+    ],
+)
 def test_compaction(n_tokens, n_cols, k, p, device):
     yi = torch.rand((n_tokens, n_cols), device=device).argsort(dim=-1)
     yi = yi[:, :k].to(torch.int32)
     yv = torch.randn((n_tokens, k), dtype=torch.bfloat16, device=device)
     # "drop" indices from yi with probability `p`
     mask = torch.zeros((n_tokens, n_cols), dtype=torch.int32, device=device)
-    keep = (torch.rand(yi.shape, device=device) < p)
+    keep = torch.rand(yi.shape, device=device) < p
     if keep.any():
         rows = torch.arange(yi.size(0), device=device).unsqueeze(1).expand_as(yi)
         mask[rows[keep], yi[keep]] = 1
     chunks = mask.view(*mask.shape[:-1], -1, 32)
-    weights = (1 << torch.arange(32, dtype=torch.int32, device=device))
+    weights = 1 << torch.arange(32, dtype=torch.int32, device=device)
     bitmask = (chunks.int() * weights).sum(dim=-1)
     yv_ref, yi_ref = compaction_torch(yv, yi, bitmask)
     yv_tri, yi_tri = compaction(yv, yi, bitmask)

--- a/op_tests/triton_tests/triton_kernels/test_distributed.py
+++ b/op_tests/triton_tests/triton_kernels/test_distributed.py
@@ -1,0 +1,260 @@
+import contextlib
+import os
+import socket
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import triton
+from triton_kernels.distributed import convert_dp_to_ep, convert_ep_to_dp, make_expt_dict_uniform, make_expt_dict_random, make_expt_assignment, SymmetricMemoryPool
+from triton_kernels.distributed_details.mesh import Mesh
+from triton_kernels.reduce import reduce
+from triton_kernels.topk import topk
+from triton_kernels.matmul import matmul
+from triton_kernels.tensor import make_ragged_tensor_metadata, remap_ragged_tensor_metadata
+import pytest
+
+
+def _make_expt_dict_for_mode(n_shards, n_expts_tot, affinity_mode):
+    factories = {
+        "uniform": make_expt_dict_uniform,
+        "random": make_expt_dict_random,
+    }
+    try:
+        return factories[affinity_mode](n_shards, n_expts_tot)
+    except KeyError as exc:
+        raise ValueError(f"Unknown affinity mode: {affinity_mode}") from exc
+
+
+def _make_y_indx_for_mode(n_tokens_global, n_expts_tot, n_expts_act, n_shards, affinity_mode, dev):
+    y_indx_global = None
+    if affinity_mode == "uniform":
+        if n_expts_tot % n_shards != 0:
+            raise ValueError("uniform affinity requires experts evenly divisible by shards")
+        expts_per_rank = n_expts_tot // n_shards
+        rounds = (n_expts_act + n_shards - 1) // n_shards
+        if rounds > expts_per_rank:
+            raise ValueError("round-robin selection exceeds experts available per shard")
+        order = torch.arange(n_expts_act, device=dev, dtype=torch.int32)
+        shard_order = order % n_shards
+        intra_shard = order // n_shards
+        round_robin_indx = (shard_order * expts_per_rank + intra_shard).to(torch.int16)
+        y_indx_global = round_robin_indx.unsqueeze(0).expand(n_tokens_global, -1).contiguous()
+    return y_indx_global
+
+
+# ------------------------------------------------------------
+# fixture
+# ------------------------------------------------------------
+
+
+def _get_free_tcp_port():
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _distributed_worker(rank, fn, world_size, kwargs):
+    dev = f"cuda:{rank}"
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size, device_id=torch.device(dev))
+    torch.cuda.set_device(dev)
+    try:
+        fn(rank=rank, world_size=world_size, **kwargs)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.fixture
+def distributed_launcher(request):
+    n_gpus = getattr(request, "param", None)
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for distributed GPU test")
+    if torch.cuda.device_count() < n_gpus:
+        pytest.skip(f"requires up to {n_gpus} CUDA devices, found {torch.cuda.device_count()}")
+
+    master_port = _get_free_tcp_port()
+
+    os.environ["WORLD_SIZE"] = str(n_gpus)
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", str(master_port))
+
+    def launch(fn, **kwargs):
+        mp.spawn(
+            _distributed_worker,
+            args=(fn, n_gpus, kwargs),
+            nprocs=n_gpus,
+            join=True,
+        )
+
+    launch.world_size = n_gpus
+    return launch
+
+
+# ------------------------------------------------------------
+# expt assignment
+# ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_expts_shard, n_expts_tot", [(8, 512), (16, 64)])
+@pytest.mark.parametrize("affinity_mode", ["uniform", "random"])
+def test_make_expt_assignment(n_expts_shard, n_expts_tot, affinity_mode):
+    device = "cuda"
+    expt_dict = _make_expt_dict_for_mode(n_expts_shard, n_expts_tot, affinity_mode)
+    expt_assignment = make_expt_assignment(n_expts_shard, n_expts_tot, expt_dict, device)
+    # mask correctness & uniqueness: each expert set exactly once, and on the right shard
+    for shard in range(n_expts_shard):
+        bitmask = expt_assignment.expt_bitmask[shard, :]
+        bitmask = (bitmask >> torch.arange(32, device=bitmask.device)[:, None]) & 1
+        experts = bitmask.T.flatten().nonzero()[:, 0].tolist()
+        assert sorted(expt_dict[shard]) == experts
+        expt_map = torch.full((n_expts_tot, ), -1, device=device)
+        expt_map[experts] = torch.arange(len(experts), device=expt_map.device)
+        assert torch.all(expt_map == expt_assignment.expt_map[shard, :])
+
+
+# ------------------------------------------------------------
+# expert sharding
+# ------------------------------------------------------------
+
+
+def routing(logits, n_expts_act, all_gather=False, y_indx=None):
+    sparse_logits = topk(logits, n_expts_act, all_gather=all_gather, y_indx=y_indx)
+    dispatch_indx = sparse_logits.mask_metadata.row_sorted_indx
+    combine_indx = sparse_logits.mask_metadata.col_sorted_indx
+    ragged_batch_metadata = make_ragged_tensor_metadata(sparse_logits.mask_metadata.col_sum, dispatch_indx.shape[0])
+    gather_idx = torch.div(combine_indx, n_expts_act, rounding_mode="trunc")
+    scatter_idx = combine_indx
+    return ragged_batch_metadata, gather_idx, scatter_idx, sparse_logits.indx
+
+
+def mixture_of_expt_nosharded(x_global, l_global, w_global, b_global, n_expts_act, y_indx=None):
+    rdata, combine_indx, dispatch_indx, _ = routing(l_global, n_expts_act, y_indx=y_indx)
+    y_global = matmul(x_global, w_global, b_global, rdata, gather_indx=combine_indx, scatter_indx=dispatch_indx)
+    y_mask = (dispatch_indx != -1).view(y_global.shape[-2] // n_expts_act, n_expts_act, 1)
+    y_global = y_global.view(y_global.shape[-2] // n_expts_act, n_expts_act, -1)
+    y_mask = y_mask.expand_as(y_global)
+    y_global, _ = reduce(y_global, dim=1, mask=y_mask)
+    return y_global
+
+
+def mixture_of_expt_epsharded(x_dp_local, l_dp_local, w_ep_local, b_ep_local, expt_assignment, n_expts_act,
+                              symm_mem_pool, y_indx=None):
+    rank = dist.get_rank()
+    expt_map = expt_assignment.expt_map[rank, :]
+    # active global logits (sparse)
+    l_global_active = topk(l_dp_local, n_expts_act, apply_softmax=True, all_gather=True, y_indx=y_indx,
+                           symm_mem_pool=symm_mem_pool)
+    # expert histogram, dispatch/combine indx
+    active_indx = l_global_active.indx
+    expt_sizes = l_global_active.mask_metadata.col_sum
+    dispatch_indx = l_global_active.mask_metadata.row_sorted_indx
+    combine_indx = l_global_active.mask_metadata.col_sorted_indx
+    # ragged tensor metadata
+    x_global_metadata = make_ragged_tensor_metadata(expt_sizes, dispatch_indx.shape[0])
+    # convert x from dp-local to expert-sorted, ep-local
+    y_ep_local = convert_dp_to_ep(x_dp_local, expt_assignment, active_indx, dispatch_indx, symm_mem_pool)
+    y_ep_local_metadata = remap_ragged_tensor_metadata(x_global_metadata, expt_map)
+    # matrix multiply
+    y_ep_local = matmul(y_ep_local, w_ep_local, b_ep_local, a_ragged_metadata=y_ep_local_metadata)
+    # convert x from expert-sorted, ep-local to token-sorted, dp-local
+    y_dp_local = convert_ep_to_dp(y_ep_local, expt_assignment, active_indx, combine_indx, symm_mem_pool)
+    # weighted average of the output token from experts
+    y_dp_local = y_dp_local.view(-1, n_expts_act, y_dp_local.shape[-1])
+    z_dp_local, _ = reduce(y_dp_local, dim=1)
+    return z_dp_local
+
+
+def _run_expert_sharding(rank, world_size, *, n_tokens, d_model, n_expts_tot, n_expts_act, affinity_mode):
+    torch.manual_seed(0)
+
+    dev = torch.cuda.current_device()
+    n_shards = world_size
+
+    expt_dict = _make_expt_dict_for_mode(n_shards, n_expts_tot, affinity_mode)
+    expt_assignment = make_expt_assignment(n_shards, n_expts_tot, expt_dict, device=dev)
+    # reference data
+    n_tokens_global = n_tokens
+    x_global = torch.randn(n_tokens_global, d_model, device=dev, dtype=torch.bfloat16)
+    l_global = torch.rand(n_tokens_global, n_expts_tot, device=dev, dtype=torch.float32)
+    w_global = torch.randn((n_expts_tot, d_model, d_model), device=dev, dtype=torch.bfloat16)
+    b_global = torch.randn((n_expts_tot, d_model), device=dev, dtype=torch.float32)
+    # initialize data shard
+    n_tokens_local = n_tokens_global // n_shards
+    first_token_indx, last_token_indx = rank * n_tokens_local, (rank + 1) * n_tokens_local
+    w_ep_local = w_global[expt_assignment.expt_boolmask[rank, :], :, :]
+    b_ep_local = b_global[expt_assignment.expt_boolmask[rank, :], :]
+    x_dp_local = x_global[first_token_indx:last_token_indx, :]
+    l_dp_local = l_global[first_token_indx:last_token_indx, :]
+    # routing
+    # test correctness
+    y_indx_global = _make_y_indx_for_mode(n_tokens_global, n_expts_tot, n_expts_act, n_shards, affinity_mode, dev)
+    y_global_ref = mixture_of_expt_nosharded(
+        x_global,
+        l_global,
+        w_global,
+        b_global,
+        n_expts_act,
+        y_indx=y_indx_global,
+    )
+
+    symm_mem_pool = SymmetricMemoryPool(Mesh(dist.group.WORLD))
+    symm_mem_pool.initialize_matmul(
+        n_tokens_global=n_tokens_global,
+        d_input=d_model,
+        d_model=d_model,
+        n_expts_act=n_expts_act,
+        n_expts_tot=n_expts_tot,
+        dtype=torch.bfloat16,
+        device=dev,
+    )
+
+    def run_moe():
+        return mixture_of_expt_epsharded(
+            x_dp_local,
+            l_dp_local,
+            w_ep_local,
+            b_ep_local,
+            expt_assignment,
+            n_expts_act,
+            y_indx=y_indx_global,
+            symm_mem_pool=symm_mem_pool,
+        )
+
+    y_dp_local_tri = run_moe()
+    y_global_tri = torch.empty_like(y_global_ref)
+
+    # Validate warmup run.
+    dist.all_gather_into_tensor(y_global_tri, y_dp_local_tri)
+    triton.testing.assert_close(y_global_ref, y_global_tri)
+
+    # Validate cuda graph capture + replay.
+    g = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        with torch.cuda.graph(g):
+            y_dp_local_tri_graph = run_moe()
+
+    g.replay()
+    dist.all_gather_into_tensor(y_global_tri, y_dp_local_tri_graph)
+    triton.testing.assert_close(y_global_ref, y_global_tri)
+
+
+@pytest.mark.parametrize("distributed_launcher", [2, 4], indirect=True)
+@pytest.mark.parametrize("n_tokens", [16, 128, 4096])
+@pytest.mark.parametrize("d_model, n_expts_tot, n_expts_act", [(16, 4, 4), (5760, 128, 4)])
+@pytest.mark.parametrize("affinity_mode", ["uniform", "random"])
+def test_expert_sharding(distributed_launcher, n_tokens, d_model, n_expts_tot, n_expts_act, affinity_mode):
+    if n_tokens < distributed_launcher.world_size:
+        raise ValueError("n_tokens must be >= number of gpus")
+    if n_tokens % distributed_launcher.world_size != 0:
+        raise ValueError("n_tokens must be divisible by number of gpus")
+
+    distributed_launcher(
+        _run_expert_sharding,
+        n_tokens=n_tokens,
+        d_model=d_model,
+        n_expts_tot=n_expts_tot,
+        n_expts_act=n_expts_act,
+        affinity_mode=affinity_mode,
+    )

--- a/op_tests/triton_tests/triton_kernels/test_distributed.py
+++ b/op_tests/triton_tests/triton_kernels/test_distributed.py
@@ -6,12 +6,22 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import triton
-from triton_kernels.distributed import convert_dp_to_ep, convert_ep_to_dp, make_expt_dict_uniform, make_expt_dict_random, make_expt_assignment, SymmetricMemoryPool
+from triton_kernels.distributed import (
+    convert_dp_to_ep,
+    convert_ep_to_dp,
+    make_expt_dict_uniform,
+    make_expt_dict_random,
+    make_expt_assignment,
+    SymmetricMemoryPool,
+)
 from triton_kernels.distributed_details.mesh import Mesh
 from triton_kernels.reduce import reduce
 from triton_kernels.topk import topk
 from triton_kernels.matmul import matmul
-from triton_kernels.tensor import make_ragged_tensor_metadata, remap_ragged_tensor_metadata
+from triton_kernels.tensor import (
+    make_ragged_tensor_metadata,
+    remap_ragged_tensor_metadata,
+)
 import pytest
 
 
@@ -26,20 +36,28 @@ def _make_expt_dict_for_mode(n_shards, n_expts_tot, affinity_mode):
         raise ValueError(f"Unknown affinity mode: {affinity_mode}") from exc
 
 
-def _make_y_indx_for_mode(n_tokens_global, n_expts_tot, n_expts_act, n_shards, affinity_mode, dev):
+def _make_y_indx_for_mode(
+    n_tokens_global, n_expts_tot, n_expts_act, n_shards, affinity_mode, dev
+):
     y_indx_global = None
     if affinity_mode == "uniform":
         if n_expts_tot % n_shards != 0:
-            raise ValueError("uniform affinity requires experts evenly divisible by shards")
+            raise ValueError(
+                "uniform affinity requires experts evenly divisible by shards"
+            )
         expts_per_rank = n_expts_tot // n_shards
         rounds = (n_expts_act + n_shards - 1) // n_shards
         if rounds > expts_per_rank:
-            raise ValueError("round-robin selection exceeds experts available per shard")
+            raise ValueError(
+                "round-robin selection exceeds experts available per shard"
+            )
         order = torch.arange(n_expts_act, device=dev, dtype=torch.int32)
         shard_order = order % n_shards
         intra_shard = order // n_shards
         round_robin_indx = (shard_order * expts_per_rank + intra_shard).to(torch.int16)
-        y_indx_global = round_robin_indx.unsqueeze(0).expand(n_tokens_global, -1).contiguous()
+        y_indx_global = (
+            round_robin_indx.unsqueeze(0).expand(n_tokens_global, -1).contiguous()
+        )
     return y_indx_global
 
 
@@ -56,7 +74,9 @@ def _get_free_tcp_port():
 
 def _distributed_worker(rank, fn, world_size, kwargs):
     dev = f"cuda:{rank}"
-    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size, device_id=torch.device(dev))
+    dist.init_process_group(
+        backend="nccl", rank=rank, world_size=world_size, device_id=torch.device(dev)
+    )
     torch.cuda.set_device(dev)
     try:
         fn(rank=rank, world_size=world_size, **kwargs)
@@ -71,7 +91,9 @@ def distributed_launcher(request):
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for distributed GPU test")
     if torch.cuda.device_count() < n_gpus:
-        pytest.skip(f"requires up to {n_gpus} CUDA devices, found {torch.cuda.device_count()}")
+        pytest.skip(
+            f"requires up to {n_gpus} CUDA devices, found {torch.cuda.device_count()}"
+        )
 
     master_port = _get_free_tcp_port()
 
@@ -101,14 +123,16 @@ def distributed_launcher(request):
 def test_make_expt_assignment(n_expts_shard, n_expts_tot, affinity_mode):
     device = "cuda"
     expt_dict = _make_expt_dict_for_mode(n_expts_shard, n_expts_tot, affinity_mode)
-    expt_assignment = make_expt_assignment(n_expts_shard, n_expts_tot, expt_dict, device)
+    expt_assignment = make_expt_assignment(
+        n_expts_shard, n_expts_tot, expt_dict, device
+    )
     # mask correctness & uniqueness: each expert set exactly once, and on the right shard
     for shard in range(n_expts_shard):
         bitmask = expt_assignment.expt_bitmask[shard, :]
         bitmask = (bitmask >> torch.arange(32, device=bitmask.device)[:, None]) & 1
         experts = bitmask.T.flatten().nonzero()[:, 0].tolist()
         assert sorted(expt_dict[shard]) == experts
-        expt_map = torch.full((n_expts_tot, ), -1, device=device)
+        expt_map = torch.full((n_expts_tot,), -1, device=device)
         expt_map[experts] = torch.arange(len(experts), device=expt_map.device)
         assert torch.all(expt_map == expt_assignment.expt_map[shard, :])
 
@@ -122,29 +146,58 @@ def routing(logits, n_expts_act, all_gather=False, y_indx=None):
     sparse_logits = topk(logits, n_expts_act, all_gather=all_gather, y_indx=y_indx)
     dispatch_indx = sparse_logits.mask_metadata.row_sorted_indx
     combine_indx = sparse_logits.mask_metadata.col_sorted_indx
-    ragged_batch_metadata = make_ragged_tensor_metadata(sparse_logits.mask_metadata.col_sum, dispatch_indx.shape[0])
+    ragged_batch_metadata = make_ragged_tensor_metadata(
+        sparse_logits.mask_metadata.col_sum, dispatch_indx.shape[0]
+    )
     gather_idx = torch.div(combine_indx, n_expts_act, rounding_mode="trunc")
     scatter_idx = combine_indx
     return ragged_batch_metadata, gather_idx, scatter_idx, sparse_logits.indx
 
 
-def mixture_of_expt_nosharded(x_global, l_global, w_global, b_global, n_expts_act, y_indx=None):
-    rdata, combine_indx, dispatch_indx, _ = routing(l_global, n_expts_act, y_indx=y_indx)
-    y_global = matmul(x_global, w_global, b_global, rdata, gather_indx=combine_indx, scatter_indx=dispatch_indx)
-    y_mask = (dispatch_indx != -1).view(y_global.shape[-2] // n_expts_act, n_expts_act, 1)
+def mixture_of_expt_nosharded(
+    x_global, l_global, w_global, b_global, n_expts_act, y_indx=None
+):
+    rdata, combine_indx, dispatch_indx, _ = routing(
+        l_global, n_expts_act, y_indx=y_indx
+    )
+    y_global = matmul(
+        x_global,
+        w_global,
+        b_global,
+        rdata,
+        gather_indx=combine_indx,
+        scatter_indx=dispatch_indx,
+    )
+    y_mask = (dispatch_indx != -1).view(
+        y_global.shape[-2] // n_expts_act, n_expts_act, 1
+    )
     y_global = y_global.view(y_global.shape[-2] // n_expts_act, n_expts_act, -1)
     y_mask = y_mask.expand_as(y_global)
     y_global, _ = reduce(y_global, dim=1, mask=y_mask)
     return y_global
 
 
-def mixture_of_expt_epsharded(x_dp_local, l_dp_local, w_ep_local, b_ep_local, expt_assignment, n_expts_act,
-                              symm_mem_pool, y_indx=None):
+def mixture_of_expt_epsharded(
+    x_dp_local,
+    l_dp_local,
+    w_ep_local,
+    b_ep_local,
+    expt_assignment,
+    n_expts_act,
+    symm_mem_pool,
+    y_indx=None,
+):
     rank = dist.get_rank()
     expt_map = expt_assignment.expt_map[rank, :]
     # active global logits (sparse)
-    l_global_active = topk(l_dp_local, n_expts_act, apply_softmax=True, all_gather=True, y_indx=y_indx,
-                           symm_mem_pool=symm_mem_pool)
+    l_global_active = topk(
+        l_dp_local,
+        n_expts_act,
+        apply_softmax=True,
+        all_gather=True,
+        y_indx=y_indx,
+        symm_mem_pool=symm_mem_pool,
+    )
     # expert histogram, dispatch/combine indx
     active_indx = l_global_active.indx
     expt_sizes = l_global_active.mask_metadata.col_sum
@@ -153,19 +206,27 @@ def mixture_of_expt_epsharded(x_dp_local, l_dp_local, w_ep_local, b_ep_local, ex
     # ragged tensor metadata
     x_global_metadata = make_ragged_tensor_metadata(expt_sizes, dispatch_indx.shape[0])
     # convert x from dp-local to expert-sorted, ep-local
-    y_ep_local = convert_dp_to_ep(x_dp_local, expt_assignment, active_indx, dispatch_indx, symm_mem_pool)
+    y_ep_local = convert_dp_to_ep(
+        x_dp_local, expt_assignment, active_indx, dispatch_indx, symm_mem_pool
+    )
     y_ep_local_metadata = remap_ragged_tensor_metadata(x_global_metadata, expt_map)
     # matrix multiply
-    y_ep_local = matmul(y_ep_local, w_ep_local, b_ep_local, a_ragged_metadata=y_ep_local_metadata)
+    y_ep_local = matmul(
+        y_ep_local, w_ep_local, b_ep_local, a_ragged_metadata=y_ep_local_metadata
+    )
     # convert x from expert-sorted, ep-local to token-sorted, dp-local
-    y_dp_local = convert_ep_to_dp(y_ep_local, expt_assignment, active_indx, combine_indx, symm_mem_pool)
+    y_dp_local = convert_ep_to_dp(
+        y_ep_local, expt_assignment, active_indx, combine_indx, symm_mem_pool
+    )
     # weighted average of the output token from experts
     y_dp_local = y_dp_local.view(-1, n_expts_act, y_dp_local.shape[-1])
     z_dp_local, _ = reduce(y_dp_local, dim=1)
     return z_dp_local
 
 
-def _run_expert_sharding(rank, world_size, *, n_tokens, d_model, n_expts_tot, n_expts_act, affinity_mode):
+def _run_expert_sharding(
+    rank, world_size, *, n_tokens, d_model, n_expts_tot, n_expts_act, affinity_mode
+):
     torch.manual_seed(0)
 
     dev = torch.cuda.current_device()
@@ -177,18 +238,25 @@ def _run_expert_sharding(rank, world_size, *, n_tokens, d_model, n_expts_tot, n_
     n_tokens_global = n_tokens
     x_global = torch.randn(n_tokens_global, d_model, device=dev, dtype=torch.bfloat16)
     l_global = torch.rand(n_tokens_global, n_expts_tot, device=dev, dtype=torch.float32)
-    w_global = torch.randn((n_expts_tot, d_model, d_model), device=dev, dtype=torch.bfloat16)
+    w_global = torch.randn(
+        (n_expts_tot, d_model, d_model), device=dev, dtype=torch.bfloat16
+    )
     b_global = torch.randn((n_expts_tot, d_model), device=dev, dtype=torch.float32)
     # initialize data shard
     n_tokens_local = n_tokens_global // n_shards
-    first_token_indx, last_token_indx = rank * n_tokens_local, (rank + 1) * n_tokens_local
+    first_token_indx, last_token_indx = (
+        rank * n_tokens_local,
+        (rank + 1) * n_tokens_local,
+    )
     w_ep_local = w_global[expt_assignment.expt_boolmask[rank, :], :, :]
     b_ep_local = b_global[expt_assignment.expt_boolmask[rank, :], :]
     x_dp_local = x_global[first_token_indx:last_token_indx, :]
     l_dp_local = l_global[first_token_indx:last_token_indx, :]
     # routing
     # test correctness
-    y_indx_global = _make_y_indx_for_mode(n_tokens_global, n_expts_tot, n_expts_act, n_shards, affinity_mode, dev)
+    y_indx_global = _make_y_indx_for_mode(
+        n_tokens_global, n_expts_tot, n_expts_act, n_shards, affinity_mode, dev
+    )
     y_global_ref = mixture_of_expt_nosharded(
         x_global,
         l_global,
@@ -242,9 +310,13 @@ def _run_expert_sharding(rank, world_size, *, n_tokens, d_model, n_expts_tot, n_
 
 @pytest.mark.parametrize("distributed_launcher", [2, 4], indirect=True)
 @pytest.mark.parametrize("n_tokens", [16, 128, 4096])
-@pytest.mark.parametrize("d_model, n_expts_tot, n_expts_act", [(16, 4, 4), (5760, 128, 4)])
+@pytest.mark.parametrize(
+    "d_model, n_expts_tot, n_expts_act", [(16, 4, 4), (5760, 128, 4)]
+)
 @pytest.mark.parametrize("affinity_mode", ["uniform", "random"])
-def test_expert_sharding(distributed_launcher, n_tokens, d_model, n_expts_tot, n_expts_act, affinity_mode):
+def test_expert_sharding(
+    distributed_launcher, n_tokens, d_model, n_expts_tot, n_expts_act, affinity_mode
+):
     if n_tokens < distributed_launcher.world_size:
         raise ValueError("n_tokens must be >= number of gpus")
     if n_tokens % distributed_launcher.world_size != 0:

--- a/op_tests/triton_tests/triton_kernels/test_matmul.py
+++ b/op_tests/triton_tests/triton_kernels/test_matmul.py
@@ -407,7 +407,8 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         c = c.mT.contiguous().mT
 
     # --- create precision config ---
-    wrap_list = lambda vals: torch.tensor(vals, dtype=torch.float32, device=device)
+    def wrap_list(vals):
+        return torch.tensor(vals, dtype=torch.float32, device=device)
     flex_a = InFlexData(c_dtype.torch_dtype, wrap_list([1.25])) if c_dtype.has_global_scale else InFlexData()
     flex_b = InFlexData(b_dtype.torch_dtype, wrap_list([1.25])) if b_dtype.has_global_scale else InFlexData()
     flex_c = OutFlexData(c_dtype.torch_dtype, wrap_list([4.00]), wrap_list([0]), None) if c_dtype.has_global_scale else OutFlexData()

--- a/op_tests/triton_tests/triton_kernels/test_matmul.py
+++ b/op_tests/triton_tests/triton_kernels/test_matmul.py
@@ -1,0 +1,488 @@
+# isort: off
+# fmt: off
+from dataclasses import dataclass, fields
+import itertools
+import pytest
+import torch
+from typing import Union
+import triton
+from triton._internal_testing import is_hopper
+# matmul utilities
+import triton_kernels.matmul_details.opt_flags as opt_flags
+from triton_kernels.matmul import FlexCtx, PrecisionConfig, FusedActivation, FnSpecs, FnName, Epilogue
+from triton_kernels.matmul import matmul_set_idle_sms, matmul, matmul_torch
+# numerics utilities
+from triton_kernels.numerics import InFlexData, OutFlexData
+from triton_kernels.numerics_details.mxfp import upcast_from_mxfp, quantize_mxfp8_fn, downcast_to_mxfp_torch, upcast_from_mxfp_torch, MXFP_BLOCK_SIZE, NVFP_BLOCK_SIZE
+# testing utilities
+from triton_kernels.testing import assert_close, make_random_tensor
+# target-specific utilities
+from triton_kernels.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_gfx1250
+from triton_kernels.swiglu import swiglu, swiglu_fn
+from triton_kernels.swiglu import PrecisionConfig as SwiGLUPrecisionConfig
+from triton_kernels.tensor_details import layout
+from triton_kernels.tensor_details.dtype import FP32
+
+# ---------------
+# numerics stuff
+# ---------------
+
+class DType:
+
+    def __init__(self, dtype_str):
+        self.has_global_scale = dtype_str.startswith("float8")
+        self.is_nvfp4 = dtype_str == "nvfp4_e2m1"
+        self.has_mx_scale = dtype_str.startswith("mx") or self.is_nvfp4
+        if dtype_str in {"float4_e2m1", "mxfloat4_e2m1", "nvfp4_e2m1"}:
+            self.torch_dtype = torch.uint8
+        else:
+            self.torch_dtype = getattr(torch, dtype_str.strip("mx"))
+        self.is_mxfloat4 = self.has_mx_scale and ("float4" in dtype_str or self.is_nvfp4)
+        self.scale_dtype = torch.float8_e4m3fn if self.is_nvfp4 else torch.uint8 if self.has_mx_scale else None
+        self.microblock_size = NVFP_BLOCK_SIZE.value if self.is_nvfp4 else MXFP_BLOCK_SIZE.value if self.has_mx_scale else None
+
+
+# Scope to ensure that the opt_flags_constraints are reset after the test
+@pytest.fixture
+def opt_flags_scope(request):
+    yield
+    opt_flags.reset_opt_flags_constraints()
+
+
+def make_constraints(block_m, split_k, is_persistent, epilogue_subtile, hbm_swizzling, weight_dtype_str, num_warps):
+    constraints = {
+        "block_m": block_m,
+        "split_k": split_k,
+        "is_persistent": is_persistent,
+        "epilogue_subtile": epilogue_subtile,
+        "num_warps": num_warps,
+    }
+    if is_hip() and hbm_swizzling and "float4" in weight_dtype_str:
+        # Minimum block size to satisfy scale preshuffling
+        if is_hip_gfx1250():
+            constraints.update({
+                "block_m": 128,
+                "block_n": 128,
+                "block_k": 128
+            })
+        else:
+            constraints.update({
+                "block_m": 32,
+                "block_n": 32,
+                "block_k": 256
+            })
+    return constraints
+
+# ---------------
+# unit tests
+# ---------------
+
+
+@dataclass
+class Case:
+    m: int
+    n: int
+    k: int
+    mode: str
+    act_dtype_str: str
+    weight_dtype_str: str
+    output_dtype_str: Union[str, None] = None
+    n_slices: int = None
+    split_k: int = 1
+    a_hbm_swizzling: bool = False
+    b_hbm_swizzling: bool = False
+    epilogue_subtile: Union[int, None] = None
+    a_transpose: bool = False
+    b_transpose: bool = False
+    c_transpose: bool = False
+    colmajor_mxfp_weight: bool = True
+    swiglu_opts: tuple[float, float] = None
+
+    def __post_init__(self):
+        if self.n_slices is None:
+            self.n_slices = 1 if self.mode == "plain" else 10
+
+def _build_test_op_cases():
+    test_cases = []
+    # zero-sized
+    test_cases.extend([
+        Case(m, n, k, mode, "float16", "float16")
+        for mode in ("ragged", "batched")
+        for (m, n, k) in ((0, 5, 7), (5, 0, 7), (5, 7, 0))
+    ])
+    odd_shape1 = (727, 577, 859)
+    odd_shape2 = (720, 576, 768)
+    even_shape = (768, 512, 1024)
+    # canonical float16
+    test_cases.extend([
+        Case(*shape, mode, "float16", "float16", split_k=split_k)
+      for shape in [odd_shape1, even_shape] for mode in ["ragged", "batched"] for split_k in [1, 5]
+    ])
+    # native float8
+    test_cases.extend([
+        Case(*shape, mode, "float8_e5m2", "float8_e5m2", split_k=split_k)
+     for shape in [odd_shape1, even_shape] for mode in ["ragged", "batched"] for split_k in [1, 5]
+    ])
+    test_cases.extend([
+        Case(*even_shape, "ragged", "float8_e5m2", "float8_e5m2", epilogue_subtile=val)
+        for val in (1, 2, 4)
+    ])
+    # fp32
+    test_cases.extend([
+        Case(1024, 1000, 2048, "ragged", "float32", "float32", b_transpose=True)
+    ])
+    # bfloat16 x mx
+    for shape in [odd_shape2, even_shape]:
+        test_cases.extend([
+            Case(*shape, "plain", "bfloat16", "mxfloat4_e2m1"),
+            Case(*shape, "plain", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True),
+            Case(*shape, "batched", "bfloat16", "mxfloat4_e2m1"),
+            Case(*shape, "batched", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True),
+            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1"),
+            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True),
+            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", split_k=9),
+            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", split_k=9, b_hbm_swizzling=True),
+            Case(*shape, "ragged", "bfloat16", "mxfloat8_e4m3fn"),
+            Case(*shape, "ragged", "bfloat16", "mxfloat8_e4m3fn", b_hbm_swizzling=True)
+        ])
+    # float8 x mxfloat
+    test_cases.extend([
+        Case(16, 256, 256, "ragged", "float8_e5m2", "mxfloat4_e2m1", b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "batched", "float8_e5m2", "mxfloat4_e2m1", b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "batched", "float8_e5m2", "mxfloat4_e2m1"),
+        Case(1024, 1024, 1024, "ragged", "float8_e5m2", "mxfloat4_e2m1", split_k=9),
+        Case(1024, 1024, 1024, "ragged", "float8_e5m2", "mxfloat4_e2m1", split_k=9, b_hbm_swizzling=True),
+        Case(300, 400, 416, "ragged", "float8_e5m2", "mxfloat8_e4m3fn"),
+        Case(300, 400, 832, "ragged", "float8_e5m2", "mxfloat4_e2m1"),
+        Case(300, 400, 416, "batched", "float8_e5m2", "mxfloat8_e4m3fn"),
+    ])
+    # mxfloat x mxfloat
+    test_cases.extend([
+        Case(16, 256, 256, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", split_k=9, b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", split_k=9, colmajor_mxfp_weight=False),
+        Case(1000, 704, 800, "batched", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(1000, 704, 800, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(300, 400, 416, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(256, 1024, 512, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(300, 400, 416, "ragged", "mxfloat8_e4m3fn", "mxfloat8_e4m3fn"),
+        Case(300, 400, 416, "ragged", "mxfloat8_e4m3fn", "mxfloat8_e4m3fn", b_hbm_swizzling=True),
+        Case(300, 400, 416, "batched", "mxfloat8_e4m3fn", "mxfloat8_e4m3fn"),
+        Case(1024, 1024, 1024, "batched", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True),
+        Case(256, 256, 256, "plain", "mxfloat4_e2m1", "mxfloat4_e2m1", "bfloat16"),
+        Case(256, 256, 256, "plain", "mxfloat4_e2m1", "mxfloat4_e2m1", "bfloat16", b_hbm_swizzling=True),
+        Case(16, 256, 256, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", split_k=9, b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", split_k=9, colmajor_mxfp_weight=False),
+        Case(1000, 704, 800, "batched", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(1000, 704, 800, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(300, 400, 416, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(256, 1024, 512, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "batched", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True),
+    ])
+    # amd-specific float8
+    test_cases.extend([
+        Case(300, 400, 400, "ragged", "float8_e4m3fnuz", "float8_e4m3fnuz"),
+        Case(1000, 400, 400, "ragged", "float8_e4m3fnuz", "float8_e4m3fnuz"),
+        Case(600, 400, 400, "ragged", "float8_e4m3fnuz", "float8_e4m3fnuz", split_k=2),
+        Case(300, 400, 400, "ragged", "float8_e4m3fn", "float8_e4m3fn"),
+    ])
+    # transposes / permutes
+    test_cases.extend([
+        Case(320, 400, 400, "batched", "float16", "float16",
+                a_transpose=a_tr, b_transpose=b_tr, c_transpose=c_tr)
+        for a_tr, b_tr, c_tr in itertools.product((False, True), repeat=3)
+    ])
+    test_cases.extend([
+        Case(320, 400, 400, "ragged", "float8_e5m2", "float8_e5m2",
+                a_transpose=False, b_transpose=True, c_transpose=False),
+        Case(320, 400, 400, "ragged", "float8_e5m2", "float8_e5m2",
+                a_transpose=True, b_transpose=True, c_transpose=True),
+    ])
+    # swiglu
+    test_cases.extend([
+        Case(*shape, mode, "bfloat16", "bfloat16", split_k=split_k, swiglu_opts=(1.1, 1.4))
+     for shape in [odd_shape2, even_shape] for mode in ["ragged", "batched"] for split_k in [1, 5]
+    ])
+    test_cases.extend([
+        Case(*even_shape, "ragged", "bfloat16", "bfloat16", epilogue_subtile=val, swiglu_opts=(1.1, 1.4))
+        for val in (1, 2, 4)
+    ])
+    # swiglu together with mxfp8 downcastepilogue
+    test_cases.extend([
+        Case(*shape, mode, "mxfloat8_e4m3fn", "mxfloat4_e2m1", a_hbm_swizzling=True, b_hbm_swizzling=True, split_k=split_k, swiglu_opts=(1.1, 7))
+     for shape in [odd_shape2, even_shape] for mode in ["ragged", "batched"] for split_k in [1, 5]
+    ])
+
+    return test_cases
+
+@pytest.mark.parametrize(
+    ", ".join(f.name for f in fields(Case)),
+    [
+        tuple(getattr(case, f.name) for f in fields(Case))
+        for case in _build_test_op_cases()
+    ],
+)
+@pytest.mark.parametrize("block_m", [16, 128])
+@pytest.mark.parametrize("do_gather, do_scatter, inner_expt_opt", [
+    (False, False, None),
+    (True, False, None),
+    (False, True, None),
+    (True, True, None),
+    (False, False, "pad_b"),
+    (False, False, "pad_a"),
+])
+@pytest.mark.parametrize("do_gamma", [False,True])
+@pytest.mark.parametrize("is_persistent", [False,True])
+@pytest.mark.parametrize("num_warps", [4, 8] if is_hopper() else [None])
+def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
+            mode, act_dtype_str, weight_dtype_str, output_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
+            a_transpose, b_transpose, c_transpose,
+            swiglu_opts, device, opt_flags_scope):
+    # We catch and re-invoke pytest.skip(), because otherwise pytest may hold a reference to
+    # the frame that called pytest.skip, including all the tensors, leading to OOM.
+    skip_message = None
+    try:
+        _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
+                 mode, act_dtype_str, weight_dtype_str, output_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
+                 a_transpose, b_transpose, c_transpose,
+                 swiglu_opts, device, opt_flags_scope)
+    except pytest.skip.Exception as e:
+        skip_message = str(e)
+
+    if skip_message is not None:
+        pytest.skip(skip_message)
+
+def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
+            mode, act_dtype_str, weight_dtype_str, output_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
+            a_transpose, b_transpose, c_transpose,
+            swiglu_opts, device, opt_flags_scope):
+    act_uses_mx = act_dtype_str.startswith("mx") or act_dtype_str == "nvfp4_e2m1"
+    weight_uses_mx = weight_dtype_str.startswith("mx") or weight_dtype_str == "nvfp4_e2m1"
+    # TODO: remove when Triton FP8 supports proper RTNE
+    if is_cuda():
+        if "float8" in weight_dtype_str and torch.cuda.get_device_capability()[0] < 9:
+            pytest.skip("Float8 not tested on A100")
+        if act_dtype_str == "float16" and weight_uses_mx and torch.cuda.get_device_capability()[0] >= 10:
+            pytest.skip("float16 x mx not supported with cuda capability >= 10")
+        if weight_uses_mx:
+            if "float8" in act_dtype_str and torch.cuda.get_device_capability()[0] < 10:
+                pytest.skip("float8 x mx not supported with cuda capability < 10")
+        if swiglu_opts is not None and do_gamma:
+            pytest.skip("NYI: swiglu and gamma not supported together")
+
+    elif is_hip():
+        if "float8" in act_dtype_str and weight_uses_mx and not (is_hip_cdna4() or is_hip_gfx1250()):
+            pytest.skip("float8 x mx only supported on CDNA4 and gfx1250")
+        if "float8" in act_dtype_str and "mxfloat8" in weight_dtype_str:
+            pytest.skip("NYI: float8 x mxfloat8 not tested on AMD GPU")
+        if act_uses_mx and weight_uses_mx:
+            pytest.skip("NYI: mx x mx not tested on AMD GPU")
+        if is_persistent:
+            pytest.skip("NYI: Persistent kernel not supported on AMD GPU")
+        # FIXME: this works on nvidia; looks like some sort of bug on AMD?
+        if do_gamma and swiglu_opts is not None:
+            pytest.skip("NYI: gamma and swiglu not supported together on AMD GPU")
+        if split_k is not None and split_k > 1:
+            pytest.skip("splitK hasn't been fully tested on AMD GPU.")
+        if "float32" in act_dtype_str:
+            pytest.skip("float32 not fully tested on AMD GPU")
+
+    if "float8_e4m3fnuz" in (weight_dtype_str, act_dtype_str) and not is_hip_cdna3():
+        pytest.skip("float8_e4m3fnuz only tested on AMD CDNA3 Platform")
+
+    if b_hbm_swizzling:
+        if is_hip():
+            if not (is_hip_cdna4() or is_hip_gfx1250()):
+                pytest.skip("Scale preshuffling on AMD GPU has not been emulated on archs other than CDNA4 and gfx1250 yet.")
+            if "mx" not in weight_dtype_str:
+                pytest.skip("Non-scale swizzling not supported on CDNA4 yet")
+        if torch.cuda.get_device_capability()[0] < 9:
+            pytest.skip("NYI. Ampere swizzling.")
+        if torch.cuda.get_device_capability()[0] < 10:
+            if "mxfloat4" not in weight_dtype_str:
+                pytest.skip("NYI. Hopper swizzling just implemented for mxfp4.")
+            if act_dtype_str in {"mxfloat4_e2m1", "mxfloat8_e4m3fn", "nvfp4_e2m1"}:
+                pytest.skip("Hopper mxfp4 swizzled weights do not support microscaled lhs.")
+
+    if a_hbm_swizzling:
+        # current x scale swizzling requires B200, batched input, microscaled act and persistent case
+        if is_hip():
+            pytest.skip("NYI. X swizzling not tested on AMD GPU yet.")
+        if torch.cuda.get_device_capability()[0] < 10:
+            pytest.skip("NYI. X swizzling only implemented for B200 for now.")
+        if not act_uses_mx:
+            pytest.skip(f"NYI. X swizzling only implemented for microscaled activations for now. Got {act_dtype_str}")
+        if not is_persistent:
+            pytest.skip("NYI. X swizzling only implemented for persistent case for now.")
+        if block_m < 128:
+            pytest.skip("X swizzling requires block_m >= 128")
+        if do_gather:
+            pytest.skip("X swizzling does not support gathered activations")
+
+    expt_is_inner = (inner_expt_opt is not None)
+    if expt_is_inner:
+        if mode != "ragged":
+            pytest.skip("inner_expt_opt only meaningful with ragged")
+        if act_uses_mx and inner_expt_opt != "pad_a":
+            pytest.skip("inner_expt_opt and act mx only supported with pad_a")
+        if weight_uses_mx:
+            if inner_expt_opt != "pad_b":
+                pytest.skip("inner_expt_opt and weight mx only supported with pad_b")
+            if is_persistent and not b_hbm_swizzling:
+                pytest.skip("FIXME: Fatal Python error: Aborted")
+            if is_hip():
+                if act_dtype_str == "bfloat16":
+                    pytest.skip("FIXME: failed to translate module to LLVM IR")
+                if b_hbm_swizzling:
+                    pytest.skip("NYI: nner_expt_opt and HBM swizzling")
+    if not colmajor_mxfp_weight:
+        if torch.cuda.get_device_capability()[0] < 10:
+            pytest.skip("transposed mxfp weight not supported with cuda capability < 10")
+        if block_m == 16:
+            pytest.skip("PassManager::run failed from Triton compiler")
+    # TODO: should construct the test case differently rather than overriding here
+    if "float8" in weight_dtype_str and torch.cuda.get_device_capability()[0] < 10:
+        b_transpose = True
+
+    torch.manual_seed(0)
+
+    # set opt flags constraints
+    constraints = make_constraints(block_m, split_k, is_persistent, epilogue_subtile, b_hbm_swizzling, weight_dtype_str, num_warps)
+    opt_flags.update_opt_flags_constraints(constraints)
+
+    a_dtype = DType(act_dtype_str)
+    b_dtype = DType(weight_dtype_str)
+    c_dtype = DType(output_dtype_str or act_dtype_str)
+
+    # --- create conditionals ---
+    do_bias = inner_expt_opt is None
+    do_gather = do_gather and mode != "batched"
+    do_scatter = do_scatter and mode != "batched"
+
+    # --- create inputs ---
+    a, a_scales, a_ragged_metadata = make_random_tensor(
+        shape=(m, k),
+        n_slices = n_slices,
+        dtype = a_dtype,
+        device = device,
+        ragged_dim = None if mode != "ragged" else 1 if expt_is_inner else 0,
+        mxfp_dim = -1 if a_dtype.has_mx_scale else None,
+        transpose = a_transpose,
+        ragged_padding = inner_expt_opt is not None and "pad_a" in inner_expt_opt,
+        squeeze_batch_dim = mode == "plain",
+        scale_hbm_swizzling = layout.make_default_matmul_mx_act_scale_layout if a_hbm_swizzling else None,
+    )
+    b, b_scale_tri, b_ragged_metadata = make_random_tensor(
+        shape=(k, n),
+        n_slices = n_slices,
+        dtype = b_dtype,
+        device = device,
+        ragged_dim = None if mode != "ragged" or inner_expt_opt is None else 0,
+        mxfp_dim = -2 if b_dtype.has_mx_scale else None,
+        transpose = b_transpose,
+        ragged_padding = inner_expt_opt is not None and "pad_b" in inner_expt_opt,
+        squeeze_batch_dim = mode == "plain",
+        is_mx_rowmajor = not colmajor_mxfp_weight,
+        value_hbm_swizzling = layout.make_default_matmul_mxfp4_w_layout(mx_axis=-2) if b_hbm_swizzling and colmajor_mxfp_weight and b_dtype.is_mxfloat4 else None,
+        scale_hbm_swizzling = layout.make_default_matmul_mxfp4_w_scale_layout(mx_axis=-2, num_warps=num_warps) if b_hbm_swizzling and colmajor_mxfp_weight and b_dtype.is_mxfloat4 else None,
+    )
+    gather_indx  = None if not do_gather  else torch.randint(0, max(m, 1), (m, ), dtype=torch.int32, device=device)
+    scatter_indx = None if not do_scatter else torch.randperm(m, dtype=torch.int32, device=device)
+    bias         = None if not do_bias    else torch.randn(b.shape[:-2] + b.shape[-1:], dtype=torch.float32, device=device)
+    gammas       = None if not do_gamma   else 2**torch.randint(-5, 0, (m, ), dtype=torch.float32, device=device)
+
+    # --- create fused activation ---
+    fused_activation = None
+    if swiglu_opts is not None:
+        fused_activation = FusedActivation(FnSpecs("swiglu", swiglu_fn, ("alpha", "limit"), reduction_n=2), swiglu_opts)
+
+    # --- initialize output ---
+    c_shape = (n_slices,) if mode == "batched" or inner_expt_opt is not None else tuple() # batch dim
+    c_shape += (scatter_indx.shape[0] if do_scatter else a.shape[-2],) # row dim
+    c_shape += (b.shape[-1] // (1 if fused_activation is None else fused_activation.specs.reduction_n) ,) # col dim
+    c_storage_shape = c_shape[:-1] + (c_shape[-1] // 2,) if c_dtype.has_mx_scale and c_dtype.is_mxfloat4 else c_shape
+    c = torch.empty(c_storage_shape, dtype=c_dtype.torch_dtype, device=device)
+    if c_transpose:
+        c = c.mT.contiguous().mT
+
+    # --- create precision config ---
+    wrap_list = lambda vals: torch.tensor(vals, dtype=torch.float32, device=device)
+    flex_a = InFlexData(c_dtype.torch_dtype, wrap_list([1.25])) if c_dtype.has_global_scale else InFlexData()
+    flex_b = InFlexData(b_dtype.torch_dtype, wrap_list([1.25])) if b_dtype.has_global_scale else InFlexData()
+    flex_c = OutFlexData(c_dtype.torch_dtype, wrap_list([4.00]), wrap_list([0]), None) if c_dtype.has_global_scale else OutFlexData()
+    precision_opt = PrecisionConfig(
+        flex_ctx=FlexCtx(flex_a, flex_b, flex_c),
+        acc_scale=2.0 if c_dtype.has_global_scale or b_dtype.has_global_scale else 1.0,
+        out_dtype=c_dtype.torch_dtype,
+        a_mx_scale=a_scales,
+        a_microblock_size=a_dtype.microblock_size,
+        b_mx_scale=b_scale_tri,
+        b_microblock_size=b_dtype.microblock_size,
+    )
+
+    # --- create epilogue ---
+    epilogue = None
+    if c_dtype.has_mx_scale:
+        c_scale_shape = c_shape[:-1] + (triton.cdiv(c_shape[-1], c_dtype.microblock_size),)
+        c_scale = torch.empty(c_scale_shape, dtype=c_dtype.scale_dtype, device=a.device)
+        precision_opt.c_mx_scale = c_scale
+        precision_opt.c_microblock_size = c_dtype.microblock_size
+        precision_opt.c_value_pack_factor = 2 if c_dtype.is_mxfloat4 else 1
+        epilogue_spec = FnSpecs(FnName.QUANTIZE_MXFP8.name, quantize_mxfp8_fn, (), ())
+        epilogue = Epilogue(epilogue_spec, tuple(), tuple(), effective_itemsize=6.0)
+
+
+    # --- triton implementation ---
+    try:
+        tri_y = matmul(a, b, bias,
+                           a_ragged_metadata, b_ragged_metadata,
+                           gather_indx, scatter_indx, precision_opt,
+                           gammas=gammas, epilogue=epilogue, c=c,
+                           fused_activation=fused_activation)
+        if c_dtype.has_global_scale:
+            tri_y_scale = precision_opt.flex_ctx.out_data.actual_scale.clone()
+    except (opt_flags.InapplicableConstraint, NotImplementedError) as e:
+        pytest.skip(f"inapplicable opt_flags constraint {e}")
+    # --- torch implementation ---
+    ref_y = matmul_torch(a, b, bias,  #
+                        a_ragged_metadata, b_ragged_metadata,
+                        gather_indx, scatter_indx, precision_opt,
+                        gammas=gammas)
+    if swiglu_opts is not None:
+        ref_y = swiglu(ref_y, alpha=swiglu_opts[0], precision_config=SwiGLUPrecisionConfig(swiglu_opts[1]))
+    if c_dtype.has_global_scale:
+        ref_y_scale = precision_opt.flex_ctx.out_data.actual_scale.clone()
+
+    # --- check results ---
+    if c_dtype.has_mx_scale:
+        tri_y = upcast_from_mxfp(tri_y, precision_opt.c_mx_scale, target_dtype=torch.bfloat16, axis=-1).to(ref_y.dtype)
+        ref_target_dtype = ref_y.dtype
+        ref_y, ref_scale = downcast_to_mxfp_torch(
+            ref_y,
+            c_dtype.torch_dtype,
+            axis=-1,
+            scale_dtype=c_dtype.scale_dtype,
+            microblock_size=c_dtype.microblock_size,
+        )
+        ref_y = upcast_from_mxfp_torch(ref_y, ref_scale, target_dtype=ref_target_dtype, axis=-1)
+    maxtol, rmstol = None, None
+    if c_dtype.has_mx_scale:
+        maxtol, rmstol = 4e-1, 4e-2
+    elif b_dtype.is_mxfloat4:
+        maxtol, rmstol = 3e-2, None
+    assert_close(ref_y, tri_y, maxtol=maxtol, rmstol=rmstol)
+    if c_dtype.has_global_scale:
+        assert torch.all((ref_y_scale - tri_y_scale).abs() < 1e-10), \
+               f"ref_y_scale: {ref_y_scale}, tri_y_scale: {tri_y_scale.item()}"
+
+
+def test_set_idle_sms():
+    if not is_cuda():
+        pytest.skip("Only supported on CUDA")
+    from triton_kernels.matmul_details.opt_flags import make_opt_flags
+    num_idle_sms = 24
+    matmul_set_idle_sms(num_idle_sms)
+    flags = make_opt_flags(FP32, FP32, FP32, PrecisionConfig(), \
+                           1, 1024, 1024, 1024, None, True, False, 1, False, False, None)
+    assert flags.idle_sms == num_idle_sms

--- a/op_tests/triton_tests/triton_kernels/test_matmul_details/test_opt_flags_split_k.py
+++ b/op_tests/triton_tests/triton_kernels/test_matmul_details/test_opt_flags_split_k.py
@@ -1,0 +1,206 @@
+# isort: off
+# fmt: off
+import pytest
+import types
+
+import torch
+
+import triton_kernels.matmul_details.opt_flags as opt_flags
+from triton_kernels.tensor_details.dtype import FP16
+
+class _DummyPrecisionConfig:
+    def __init__(self):
+        self.b_mx_scale = None
+        self.max_num_imprecise_acc = None
+        self.a_mx_scale = None
+        self.c_mx_scale = None
+        self.enforce_bitwise_invariance = False
+
+
+def _stub_cuda_props(*_args, **_kwargs):
+    return types.SimpleNamespace(multi_processor_count=16)
+
+
+def setup_amd(monkeypatch):
+    monkeypatch.setattr(opt_flags, "get_cdna_version", lambda: 3)
+    monkeypatch.setattr(opt_flags, "get_rdna_version", lambda: -1)
+    monkeypatch.setattr(opt_flags.torch.cuda, "get_device_properties", _stub_cuda_props)
+    monkeypatch.setattr(
+        opt_flags.opt_flags_amd,
+        "compute_block_nk",
+        lambda *args, **kwargs: (64, 32),
+    )
+
+    fake_target = types.SimpleNamespace(backend="hip", arch=0)
+    monkeypatch.setattr(
+        "triton.runtime.driver.active.get_current_target",
+        lambda: fake_target,
+    )
+
+
+def setup_nvidia(monkeypatch):
+    monkeypatch.setattr(opt_flags.torch.cuda, "get_device_properties", _stub_cuda_props)
+    monkeypatch.setattr(opt_flags.torch.cuda, "get_device_capability", lambda: (9, 0))
+    monkeypatch.setattr(
+        opt_flags.opt_flags_nvidia,
+        "compute_block_n",
+        lambda n, arch, precision_config: (64, 32),
+    )
+    monkeypatch.setattr(
+        opt_flags.opt_flags_nvidia,
+        "compute_grid_size",
+        lambda routing_data, batch_size, m, n, block_m, block_n: 4,
+    )
+    monkeypatch.setattr(
+        opt_flags.opt_flags_nvidia,
+        "compute_block_k",
+        lambda m, k, is_persistent, lhs_dtype, rhs_dtype, precision_config, has_y_acc_in: 32,
+    )
+    monkeypatch.setattr(
+        opt_flags.opt_flags_nvidia,
+        "compute_split_k",
+        lambda block_k, k, estimated_actual_grid_size: 1,
+    )
+    monkeypatch.setattr(
+        opt_flags.opt_flags_nvidia,
+        "compute_num_stages",
+        lambda *args, **kwargs: 2,
+    )
+    monkeypatch.setattr(
+        opt_flags.opt_flags_nvidia,
+        "compute_num_warps",
+        lambda block_m, block_n, is_persistent, precision_config, constraints: 4,
+    )
+
+    fake_target = types.SimpleNamespace(backend="cuda", arch=100)
+    monkeypatch.setattr(
+        "triton.runtime.driver.active.get_current_target",
+        lambda: fake_target,
+    )
+
+
+def test_make_default_opt_flags_amd_split_k_constraint(monkeypatch):
+    setup_amd(monkeypatch)
+
+    precision_config = _DummyPrecisionConfig()
+    flags = opt_flags.make_default_opt_flags_amd(
+        FP16,
+        FP16,
+        FP16,
+        precision_config,
+        2,
+        128,
+        64,
+        32,
+        None,
+        False,
+        False,
+        False,
+        0,
+        False,
+        False,
+        {"split_k": 5},
+    )
+
+    assert flags.split_k == 5
+
+
+def test_make_default_opt_flags_nvidia_split_k_constraint(monkeypatch):
+    setup_nvidia(monkeypatch)
+
+    precision_config = _DummyPrecisionConfig()
+    flags = opt_flags.make_default_opt_flags_nvidia(
+        torch.float16,
+        torch.float16,
+        torch.float16,
+        precision_config,
+        4,
+        256,
+        128,
+        64,
+        None,
+        False,
+        False,
+        False,
+        0,
+        False,
+        False,
+        {"split_k": 3},
+    )
+
+    assert flags.split_k == 3
+
+def test_max_allowable_mn_and_split_k_constraints(monkeypatch):
+    setup_nvidia(monkeypatch)
+
+    opt_flags.reset_opt_flags()
+    opt_flags.reset_opt_flags_constraints()
+    opt_flags.update_opt_flags_constraints(
+        {
+            "max_allowable_mn": 256,
+            # Without split_k, this should raise an error
+        }
+    )
+
+    with pytest.raises(opt_flags.InapplicableConstraint):
+        opt_flags.make_opt_flags(
+                    torch.float16,
+                    torch.float16,
+                    torch.float16,
+                    _DummyPrecisionConfig(),
+                    1,
+                    256,
+                    256,
+                    256,
+                    None,
+                    False,
+                    False,
+                    False,
+                    0,
+                    False,
+                    None,
+                )
+
+def test_max_allowable_mn(monkeypatch):
+    setup_nvidia(monkeypatch)
+
+    batch_size, m, n, k = 1, 256, 256, 256
+
+    def get_flags(split_k, max_mn):
+        opt_flags.reset_opt_flags()
+        opt_flags.reset_opt_flags_constraints()
+        opt_flags.update_opt_flags_constraints(
+            {
+                "split_k": split_k,
+                "max_allowable_mn": max_mn,
+            }
+        )
+        return opt_flags.make_opt_flags(
+            torch.float16,
+            torch.float16,
+            torch.float16,
+            _DummyPrecisionConfig(),
+            batch_size,
+            m,
+            n,
+            k,
+            None,
+            False,
+            True,
+            False,
+            0,
+            False,
+            None,
+        )
+
+    split_k = 6
+    # Allowable mn is less than actual mn, so split_k should be set to 1
+    max_mn = (m * n) // 2
+    flags = get_flags(split_k, max_mn)
+    assert flags.split_k == 1
+
+    split_k = 6
+    # Allowable mn is more than actual mn, so split_k should be unchanged
+    max_mn = (m * n) * 2
+    flags = get_flags(split_k, max_mn)
+    assert flags.split_k == split_k

--- a/op_tests/triton_tests/triton_kernels/test_mxfp.py
+++ b/op_tests/triton_tests/triton_kernels/test_mxfp.py
@@ -1,0 +1,282 @@
+import itertools
+from functools import partial
+
+import pytest
+import torch
+import triton
+from triton_kernels.numerics_details.mxfp import (
+    MXFP_BLOCK_SIZE,
+    NVFP_BLOCK_SIZE,
+    DequantScaleRoundingMode,
+    downcast_to_mxfp,
+    downcast_to_mxfp_torch,
+    get_max_quant_val,
+    upcast_from_mxfp,
+    upcast_from_mxfp_torch,
+)
+from triton_kernels.target_info import is_cuda
+from triton_kernels.testing import assert_close, assert_equal
+
+
+def dtype_str_to_torch(dtype_str: str) -> torch.dtype:
+    return torch.uint8 if dtype_str == "float4_e2m1" else getattr(torch, dtype_str)
+
+
+@pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16", "float32"])
+def test_mxfp4_rounding_cases(dst_dtype, device):
+    dst_dtype = dtype_str_to_torch(dst_dtype)
+    two_point_five_plus_ulp = {
+        torch.bfloat16: 0.251953125,
+        torch.float16: 0.250244140625,
+        torch.float32: 0.2500000298023223877,
+    }[dst_dtype]
+    pad_values = [0] * 22
+    # Construct an example where scale is 1 (when max value is 6.0, the maximum value of e2m1)
+    x = torch.tensor([6, 0, 0.24, 0.25, 0.75, 0.99, 1.2, 1.3, -1.25, two_point_five_plus_ulp] + pad_values,
+                     dtype=dst_dtype, device=device).view(1, -1, 1)
+    quant, scale = downcast_to_mxfp(x, torch.uint8, axis=1)
+    dequant = upcast_from_mxfp(quant, scale, dst_dtype, axis=1)
+    # Tie-breaking cases (RTNE):
+    # - 0.25 is exactly halfway between 0.0 and 0.5. RTNE selects the even quantized value 0.0
+    #   (binary LSB of target is 0). Rounding away from zero would pick 0.5; towards zero also picks 0.0.
+    # - 0.75 is halfway between 0.5 and 1.0. RTNE selects the even value 1.0 (LSB 0). Away-from-zero would pick 1.0;
+    #   towards-zero would pick 0.5.
+    # - -1.25 is halfway between -1.0 and -1.5. RTNE selects -1.0 (even). Away-from-zero would pick -1.5;
+    #   towards-zero would pick -1.0.
+    # - two_point_five_plus_ulp is slightly bigger than 0.25, so it rounds to 0.5.
+    assert dequant.flatten().tolist() == [6, 0, 0, 0.0, 1.0, 1.0, 1.0, 1.5, -1.0, 0.5] + pad_values, f"{dequant=}"
+
+    quant_torch, scale_torch = downcast_to_mxfp_torch(x, torch.uint8, axis=1)
+    assert_equal(quant_torch, quant)
+    assert_equal(scale_torch, scale)
+
+    dequant_torch = upcast_from_mxfp_torch(quant_torch, scale_torch, dst_dtype, axis=1)
+    assert_equal(dequant_torch, dequant)
+
+    # ROUND_DOWN should use the max power-of-two when computing scale.
+    # Choose a block whose max is 33 so the chosen scale is
+    # 2**floor(log2(33/(e2m1 max power of 2 = 4)) = 2**3 = 8 (exponent 127+3),
+    # and the other values are multiples of representable FP4 values times 8
+    # that allow exact reconstruction.
+    pad_values = [0] * 24
+    x = torch.tensor([33.0, 24.0, 16.0, 8.0, 4.0, 0.0, -32.0, 0.0] + pad_values,
+                     device=device).bfloat16().view(1, -1, 1)
+    quant, scale = downcast_to_mxfp(
+        x,
+        torch.uint8,
+        axis=1,
+        DEQUANT_SCALE_ROUNDING_MODE=DequantScaleRoundingMode.ROUND_DOWN,
+    )
+    dequant = upcast_from_mxfp(quant, scale, dst_dtype, axis=1)
+    assert_equal(dequant[0, 1:, :], x[0, 1:, :])
+
+    # Golden: scale exponent is 127 + 3 for 2**3 = 8
+    assert scale.item() == 127 + 3
+
+    # Torch reference path should match
+    quant_torch, scale_torch = downcast_to_mxfp_torch(
+        x,
+        torch.uint8,
+        axis=1,
+        DEQUANT_SCALE_ROUNDING_MODE=DequantScaleRoundingMode.ROUND_DOWN,
+    )
+    assert_equal(quant_torch, quant)
+    assert_equal(scale_torch, scale)
+
+
+@pytest.mark.parametrize("src_dtype", ["float4_e2m1", "float8_e5m2", "float8_e4m3fn"])
+@pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16", "float32"])
+def test_mxfp_extreme_values(src_dtype, dst_dtype, device):
+    if "float8" in src_dtype and (is_cuda() and torch.cuda.get_device_capability()[0] < 9):
+        pytest.skip("Float8 not tested on A100")
+    src_dtype = dtype_str_to_torch(src_dtype)
+    dst_dtype = dtype_str_to_torch(dst_dtype)
+    BIG_VALUE = 65470 if dst_dtype == torch.float16 else 3.3895e38
+    pad_values = [0] * 30
+    x = torch.tensor([BIG_VALUE, BIG_VALUE] + pad_values, dtype=dst_dtype, device=device)
+    xq_value, xq_scale = downcast_to_mxfp(x, src_dtype, axis=-1)
+    xdq = upcast_from_mxfp(xq_value, xq_scale, dst_dtype, axis=-1)
+    xdq_ref = upcast_from_mxfp_torch(xq_value, xq_scale, dst_dtype, axis=-1)
+    assert_equal(xdq_ref, xdq)
+    assert not xdq.isinf().any()
+
+
+@pytest.mark.parametrize("src_dtype", ["float4_e2m1", "float8_e5m2", "float8_e4m3fn"])
+@pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16", "float32"])
+def test_mxfp_quant_dequant(src_dtype, dst_dtype, device):
+    if "float8" in src_dtype and (is_cuda() and torch.cuda.get_device_capability()[0] < 9):
+        pytest.skip("Float8 not tested on A100")
+    limit_range = src_dtype == "float8_e5m2" and dst_dtype == "float16"
+
+    # This test checks that quantization and dequantization kernels produce the exact values for some inputs
+    # that can be represented exactly in the quantized format.
+    src_dtype = dtype_str_to_torch(src_dtype)
+    dst_dtype = dtype_str_to_torch(dst_dtype)
+    max_val = get_max_quant_val(src_dtype)
+    if limit_range:
+        # FP16 can't represent the full range of MXFP8, so we limit the max value here
+        max_val = 128
+
+    # These are all the valid mxfp4 positive values.
+    pos_vals = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, max_val], device=device, dtype=dst_dtype)
+    neg_vals = -pos_vals
+    k_dim = torch.cat([pos_vals, neg_vals])
+    k_dim = k_dim.reshape([k_dim.shape[0], 1])
+
+    # We pick power of 2 scales since both the scales and their inverse only require exponent bits to be exactly
+    # represented. This means we can store the scales exactly in the e8m0 format.
+    powers = torch.arange(-8, 8, device=device, dtype=dst_dtype)
+    scales = 2**powers
+    scales = scales.reshape([1, powers.shape[0]])
+    weight = k_dim * scales
+    weight = weight.repeat((9, 32))  # Repeat the dimensions to test multi block launches.
+    weight = weight.reshape([1, weight.shape[0], weight.shape[1]])
+    weight = weight.mT.contiguous().mT
+    weight = torch.nn.functional.pad(weight, (0, 0, 0, 16))
+    quant, scale = downcast_to_mxfp(weight, src_dtype, axis=1)
+    dequant = upcast_from_mxfp(quant, scale, dst_dtype, axis=1)
+    assert_equal(weight, dequant)
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "shape, axis, quant_dtype, rounding_mode, scale_dtype, microblock_size",
+    [
+        # Zero-sized arrays
+        ((0, 4096, 1024), 1, "float4_e2m1", DequantScaleRoundingMode.ROUND_UP, torch.uint8, MXFP_BLOCK_SIZE.value),
+        ((3, 4096, 0), 1, "float4_e2m1", DequantScaleRoundingMode.ROUND_DOWN, torch.uint8, MXFP_BLOCK_SIZE.value),
+        ((10, 0, 1024), 2, "float8_e5m2", DequantScaleRoundingMode.ROUND_UP, torch.uint8, MXFP_BLOCK_SIZE.value),
+        ((0, 0, 1024), 2, "float8_e4m3fn", DequantScaleRoundingMode.ROUND_DOWN, torch.uint8, MXFP_BLOCK_SIZE.value),
+
+        ((3, 4096, 1024), 1, "float4_e2m1", DequantScaleRoundingMode.ROUND_UP, torch.uint8, MXFP_BLOCK_SIZE.value),
+        ((32, 254, 60), 0, "float4_e2m1", DequantScaleRoundingMode.ROUND_DOWN, torch.uint8, MXFP_BLOCK_SIZE.value),
+        ((1, 320, 160), 2, "float8_e5m2", DequantScaleRoundingMode.ROUND_UP, torch.uint8, MXFP_BLOCK_SIZE.value),
+        ((2, 16, 512), -1, "float8_e4m3fn", DequantScaleRoundingMode.ROUND_DOWN, torch.uint8, MXFP_BLOCK_SIZE.value),
+        ((2, 64, 3), 1, "float4_e2m1", DequantScaleRoundingMode.ROUND_UP, torch.float8_e4m3fn, NVFP_BLOCK_SIZE.value),
+    ],
+)
+# fmt: on
+@pytest.mark.parametrize("dequant_dtype", ["float16", "bfloat16", "float32"])
+def test_mxfp_casting(
+    shape: tuple[int, ...],
+    axis: int,
+    quant_dtype: str,
+    dequant_dtype: str,
+    rounding_mode: DequantScaleRoundingMode,
+    scale_dtype: torch.dtype,
+    microblock_size: int,
+    device,
+):
+    if ("float8" in quant_dtype
+            or scale_dtype == torch.float8_e4m3fn) and (is_cuda() and torch.cuda.get_device_capability()[0] < 9):
+        pytest.skip("Float8 not tested on A100")
+    torch.manual_seed(0)
+    quant_torch_type = dtype_str_to_torch(quant_dtype)
+    dequant_torch_type = dtype_str_to_torch(dequant_dtype)
+    # Generate random input tensor that is contiguous once axis is the last dimension
+    x = torch.randn(shape, device=device, dtype=dequant_torch_type)
+
+    # Quantize and check equivalence
+    quant, scale = downcast_to_mxfp(
+        x,
+        quant_torch_type,
+        axis,
+        scale_dtype=scale_dtype,
+        microblock_size=microblock_size,
+        DEQUANT_SCALE_ROUNDING_MODE=rounding_mode,
+    )
+    quant_torch, scale_torch = downcast_to_mxfp_torch(
+        x,
+        quant_torch_type,
+        axis,
+        scale_dtype=scale_dtype,
+        microblock_size=microblock_size,
+        DEQUANT_SCALE_ROUNDING_MODE=rounding_mode,
+    )
+
+    assert_equal(quant_torch, quant)
+    assert_equal(scale_torch, scale)
+    assert_equal(1, quant.stride(axis))
+    assert_equal(1, quant_torch.stride(axis))
+
+    # Dequantize and check equivalence
+    dequant = upcast_from_mxfp(quant, scale, dequant_torch_type, axis)
+    dequant_torch = upcast_from_mxfp_torch(quant_torch, scale_torch, dequant_torch_type, axis)
+    assert_equal(dequant, dequant_torch)
+
+    # Dequantized result should be close to the original, though tolerance is large due to the precision loss.
+    assert_close(x, dequant, maxtol=0.5, rmstol=0.15)
+
+
+def _benchmark_mxfp_quantization(shape, src_dtype: torch.dtype, target_quant_dtype: torch.dtype, n_iters=1000):
+    x = torch.randn(*shape, dtype=src_dtype, device="cuda")
+    elapsed = (triton.testing.do_bench(
+        partial(downcast_to_mxfp, x, target_quant_dtype, axis=-1),
+        rep=n_iters,
+        return_mode="min",
+    ) / 1e3)
+
+    # Each call reads x (2 Bytes) and writes the output tensor (1B or 0.5B) once.
+    # -> 3B * numel
+    gbytes = ((3 if target_quant_dtype == torch.float8_e4m3fn else 2.5) * x.numel()) / 1e9
+
+    bw = gbytes / elapsed
+    return bw
+
+
+def _benchmark_mxfp_dequantization(shape, src_quant_dtype: torch.dtype, target_dtype: torch.dtype, n_iters=1000):
+    x = torch.randn(*shape, dtype=torch.bfloat16, device="cuda").to(src_quant_dtype)
+    scale_shape = shape[:-1] + (triton.cdiv(shape[-1], MXFP_BLOCK_SIZE), )
+    x_scale = torch.randint(0, 256, scale_shape, device="cuda", dtype=torch.uint8)
+    elapsed = (triton.testing.do_bench(
+        partial(upcast_from_mxfp, x, x_scale, target_dtype, axis=-1),
+        rep=n_iters,
+        return_mode="min",
+    ) / 1e3)
+
+    # Each call reads x (1B or 0.5B) and writes the output tensor (2 Bytes) once.
+    # -> 3B * numel
+    gbytes = ((3 if src_quant_dtype == torch.float8_e4m3fn else 2.5) * x.numel()) / 1e9
+
+    bw = gbytes / elapsed
+    return bw
+
+
+if __name__ == "__main__":
+    tests = [
+        ((1024, 8192), torch.float16),
+        ((4096, 8192), torch.float16),
+        ((1024, 8192), torch.bfloat16),
+        ((4096, 8192), torch.bfloat16),
+    ]
+
+    table = []
+    shapes = [(1024, 8192), (4096, 8192)]
+    source_dtypes = [torch.bfloat16, torch.float16]
+    for shape, quant_dtype in itertools.product(shapes, [torch.float8_e4m3fn, torch.uint8]):
+        results = [*shape, quant_dtype]
+        for src_dtype in source_dtypes:
+            results.append(_benchmark_mxfp_quantization(shape, src_dtype, quant_dtype))
+        for src_dtype in source_dtypes:
+            results.append(_benchmark_mxfp_dequantization(shape, quant_dtype, src_dtype))
+        table.append(results)
+
+    from tabulate import tabulate
+
+    headers = [
+        "M",
+        "N",
+        "quant_dtype",
+        "quant_bw_bfloat16",
+        "quant_bw_float16",
+        "dequant_bw_bfloat16",
+        "dequant_bw_float16",
+    ]
+    mxfp8_rows = [row for row in table if row[2] == torch.float8_e4m3fn]
+    mxfp4_rows = [row for row in table if row[2] == torch.uint8]
+
+    print("MXFP8 (e4m3fn):")
+    print(tabulate(mxfp8_rows, headers=headers))
+    print()
+    print("MXFP4 (e2m1):")
+    print(tabulate(mxfp4_rows, headers=headers))

--- a/op_tests/triton_tests/triton_kernels/test_mxfp.py
+++ b/op_tests/triton_tests/triton_kernels/test_mxfp.py
@@ -32,8 +32,12 @@ def test_mxfp4_rounding_cases(dst_dtype, device):
     }[dst_dtype]
     pad_values = [0] * 22
     # Construct an example where scale is 1 (when max value is 6.0, the maximum value of e2m1)
-    x = torch.tensor([6, 0, 0.24, 0.25, 0.75, 0.99, 1.2, 1.3, -1.25, two_point_five_plus_ulp] + pad_values,
-                     dtype=dst_dtype, device=device).view(1, -1, 1)
+    x = torch.tensor(
+        [6, 0, 0.24, 0.25, 0.75, 0.99, 1.2, 1.3, -1.25, two_point_five_plus_ulp]
+        + pad_values,
+        dtype=dst_dtype,
+        device=device,
+    ).view(1, -1, 1)
     quant, scale = downcast_to_mxfp(x, torch.uint8, axis=1)
     dequant = upcast_from_mxfp(quant, scale, dst_dtype, axis=1)
     # Tie-breaking cases (RTNE):
@@ -44,7 +48,10 @@ def test_mxfp4_rounding_cases(dst_dtype, device):
     # - -1.25 is halfway between -1.0 and -1.5. RTNE selects -1.0 (even). Away-from-zero would pick -1.5;
     #   towards-zero would pick -1.0.
     # - two_point_five_plus_ulp is slightly bigger than 0.25, so it rounds to 0.5.
-    assert dequant.flatten().tolist() == [6, 0, 0, 0.0, 1.0, 1.0, 1.0, 1.5, -1.0, 0.5] + pad_values, f"{dequant=}"
+    assert (
+        dequant.flatten().tolist()
+        == [6, 0, 0, 0.0, 1.0, 1.0, 1.0, 1.5, -1.0, 0.5] + pad_values
+    ), f"{dequant=}"
 
     quant_torch, scale_torch = downcast_to_mxfp_torch(x, torch.uint8, axis=1)
     assert_equal(quant_torch, quant)
@@ -59,8 +66,13 @@ def test_mxfp4_rounding_cases(dst_dtype, device):
     # and the other values are multiples of representable FP4 values times 8
     # that allow exact reconstruction.
     pad_values = [0] * 24
-    x = torch.tensor([33.0, 24.0, 16.0, 8.0, 4.0, 0.0, -32.0, 0.0] + pad_values,
-                     device=device).bfloat16().view(1, -1, 1)
+    x = (
+        torch.tensor(
+            [33.0, 24.0, 16.0, 8.0, 4.0, 0.0, -32.0, 0.0] + pad_values, device=device
+        )
+        .bfloat16()
+        .view(1, -1, 1)
+    )
     quant, scale = downcast_to_mxfp(
         x,
         torch.uint8,
@@ -87,13 +99,17 @@ def test_mxfp4_rounding_cases(dst_dtype, device):
 @pytest.mark.parametrize("src_dtype", ["float4_e2m1", "float8_e5m2", "float8_e4m3fn"])
 @pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16", "float32"])
 def test_mxfp_extreme_values(src_dtype, dst_dtype, device):
-    if "float8" in src_dtype and (is_cuda() and torch.cuda.get_device_capability()[0] < 9):
+    if "float8" in src_dtype and (
+        is_cuda() and torch.cuda.get_device_capability()[0] < 9
+    ):
         pytest.skip("Float8 not tested on A100")
     src_dtype = dtype_str_to_torch(src_dtype)
     dst_dtype = dtype_str_to_torch(dst_dtype)
     BIG_VALUE = 65470 if dst_dtype == torch.float16 else 3.3895e38
     pad_values = [0] * 30
-    x = torch.tensor([BIG_VALUE, BIG_VALUE] + pad_values, dtype=dst_dtype, device=device)
+    x = torch.tensor(
+        [BIG_VALUE, BIG_VALUE] + pad_values, dtype=dst_dtype, device=device
+    )
     xq_value, xq_scale = downcast_to_mxfp(x, src_dtype, axis=-1)
     xdq = upcast_from_mxfp(xq_value, xq_scale, dst_dtype, axis=-1)
     xdq_ref = upcast_from_mxfp_torch(xq_value, xq_scale, dst_dtype, axis=-1)
@@ -104,7 +120,9 @@ def test_mxfp_extreme_values(src_dtype, dst_dtype, device):
 @pytest.mark.parametrize("src_dtype", ["float4_e2m1", "float8_e5m2", "float8_e4m3fn"])
 @pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16", "float32"])
 def test_mxfp_quant_dequant(src_dtype, dst_dtype, device):
-    if "float8" in src_dtype and (is_cuda() and torch.cuda.get_device_capability()[0] < 9):
+    if "float8" in src_dtype and (
+        is_cuda() and torch.cuda.get_device_capability()[0] < 9
+    ):
         pytest.skip("Float8 not tested on A100")
     limit_range = src_dtype == "float8_e5m2" and dst_dtype == "float16"
 
@@ -118,7 +136,9 @@ def test_mxfp_quant_dequant(src_dtype, dst_dtype, device):
         max_val = 128
 
     # These are all the valid mxfp4 positive values.
-    pos_vals = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, max_val], device=device, dtype=dst_dtype)
+    pos_vals = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, max_val], device=device, dtype=dst_dtype
+    )
     neg_vals = -pos_vals
     k_dim = torch.cat([pos_vals, neg_vals])
     k_dim = k_dim.reshape([k_dim.shape[0], 1])
@@ -129,7 +149,9 @@ def test_mxfp_quant_dequant(src_dtype, dst_dtype, device):
     scales = 2**powers
     scales = scales.reshape([1, powers.shape[0]])
     weight = k_dim * scales
-    weight = weight.repeat((9, 32))  # Repeat the dimensions to test multi block launches.
+    weight = weight.repeat(
+        (9, 32)
+    )  # Repeat the dimensions to test multi block launches.
     weight = weight.reshape([1, weight.shape[0], weight.shape[1]])
     weight = weight.mT.contiguous().mT
     weight = torch.nn.functional.pad(weight, (0, 0, 0, 16))

--- a/op_tests/triton_tests/triton_kernels/test_reduce.py
+++ b/op_tests/triton_tests/triton_kernels/test_reduce.py
@@ -1,0 +1,140 @@
+import pytest
+import torch
+from triton.testing import do_bench
+from triton_kernels.reduce import reduce, reduce_torch, PostprocessFn, FnSpecs
+from triton_kernels.numerics_details.mxfp import upcast_from_mxfp_torch, downcast_to_mxfp_torch
+from triton_kernels.numerics import InFlexData, OutFlexData
+from triton_kernels.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4
+import triton
+import triton.language as tl
+
+
+def init_mask(mask_mode, B, M, N, device):
+    if mask_mode == "none":
+        return None
+    if mask_mode == "full":
+        mask = (torch.rand((B, M, N), device=device) > 0.3).to(torch.int8)
+    if mask_mode == "broadcast_b":
+        mask = (torch.rand((1, M, N), device=device) > 0.3).to(torch.int8)
+    if mask_mode == "broadcast_m":
+        mask = (torch.rand((B, 1, N), device=device) > 0.3).to(torch.int8)
+    if mask_mode == "broadcast_n":
+        mask = (torch.rand((B, M, 1), device=device) > 0.3).to(torch.int8)
+    return mask.expand(B, M, N)
+
+
+def dtype_str_to_torch(dtype_str: str) -> torch.dtype:
+    if dtype_str == "float4_e2m1":
+        return torch.uint8
+    if dtype_str == "float8":
+        return torch.float8_e4m3fn
+    return getattr(torch, dtype_str)
+
+
+@triton.jit
+def plus_a_reduce(x, a):
+    y = x + a
+    return tl.sum(y.reshape([x.shape[0], x.shape[1] // 2, 2]), axis=2)
+
+
+@pytest.mark.parametrize("B, M, N, postprocess_fn", [
+    (311, 384, 384, None),
+    (384, 311, 384, None),
+    (384, 384, 311, None),
+    (512, 512, 512, None),
+    (512, 512, 512, "plus_ten"),
+    (4, 4, 4, None),
+])
+@pytest.mark.parametrize("dtype_str", [
+    "float16",
+    "float32",
+    "mxfloat8",
+    "flexfloat8",
+])
+@pytest.mark.parametrize("mask_mode", [
+    "none",  # no mask
+    "full",  # full-sized mask [B,M,N]
+    "broadcast_b",  # broadcast over B: [1,M,N]
+    "broadcast_m",  # broadcast over M: [B,1,N]
+    "broadcast_n",  # broadcast over N: [B,M,1]
+])
+@pytest.mark.parametrize("dim", [0, 1, 2])
+def test_op(B, M, N, dtype_str, dim, mask_mode, postprocess_fn):
+    # Check float8 hardware support
+    if "float8" in dtype_str:
+        if is_cuda() and torch.cuda.get_device_capability() < (9, 0):
+            pytest.skip("float8 not supported on CUDA < 9.0")
+        if is_hip() and not (is_hip_cdna3() or is_hip_cdna4()):
+            pytest.skip("float8 not supported on AMD GPU < CDNA3")
+
+    torch.manual_seed(0)
+    device = "cuda"
+    x = torch.randn((B, M, N), device=device, dtype=torch.float32, requires_grad=True)
+    x_mscale, x_flex = None, None
+    y_flex_tri, y_flex_ref = None, None
+    if is_mx := dtype_str.startswith("mx"):
+        dtype = dtype_str_to_torch(dtype_str.removeprefix("mx"))
+        x, x_mscale = downcast_to_mxfp_torch(x.to(torch.float16), dtype, axis=-1)
+    if is_flex := dtype_str.startswith("flex"):
+        dtype = dtype_str_to_torch(dtype_str.removeprefix("flex"))
+        expected_scale = torch.tensor([4], device=device, dtype=torch.float32)
+        x_flex = InFlexData(scale=torch.tensor([2], device=device, dtype=torch.float32))
+        x = x / x_flex.scale
+        x = x.to(dtype)
+        y_flex_tri = OutFlexData(expected_scale=expected_scale, actual_scale=torch.empty_like(expected_scale))
+        y_flex_ref = OutFlexData(expected_scale=expected_scale, actual_scale=torch.empty_like(expected_scale))
+    mask = init_mask(mask_mode, B, M, N, device)
+    expected_exception = ValueError if dim == 2 and is_mx else None
+    if expected_exception is not None:
+        with pytest.raises(expected_exception):
+            reduce(x, dim=dim, mask=mask, x_mxscale=x_mscale)
+        return
+    if postprocess_fn == "plus_ten":
+        postprocess_fn_tri = PostprocessFn(specs=FnSpecs("plus_a", plus_a_reduce, ("a", ), reduction_n=2),
+                                           fn_args=(10, ))
+        postprocess_fn_ref = lambda x: (x + 10).reshape([x.shape[0], x.shape[1] // 2, 2]).sum(dim=2)
+    else:
+        postprocess_fn_tri = postprocess_fn_ref = None
+    # run forward pass
+    x_tri = x.clone().detach().requires_grad_(True)
+    x_ref = x.clone().detach().requires_grad_(True)
+    y_tri, y_tri_mxscale = reduce(x_tri, dim=dim, mask=mask, x_mxscale=x_mscale, x_flex=x_flex, y_flex=y_flex_tri,
+                                  postprocess_fn1=postprocess_fn_tri)
+    y_ref, y_ref_mxscale = reduce_torch(x_ref, dim=dim, mask=mask, x_mxscale=x_mscale, x_flex=x_flex, y_flex=y_flex_ref,
+                                        postprocess_fn1=postprocess_fn_ref)
+    if is_mx:
+        y_ref = upcast_from_mxfp_torch(y_ref, y_ref_mxscale, torch.float16, axis=-1)
+        y_tri = upcast_from_mxfp_torch(y_tri, y_tri_mxscale, torch.float16, axis=-1)
+    assert torch.allclose(y_tri.float(), y_ref.float(), atol=1e-3, rtol=1e-3)
+    if is_flex:
+        torch.allclose(y_flex_tri.actual_scale, y_flex_ref.actual_scale, atol=1e-3, rtol=1e-3)
+    run_bwd = postprocess_fn is None and "float8" not in dtype_str
+    if run_bwd:
+        dy = torch.randn_like(y_tri)
+        y_tri.backward(dy)
+        y_ref.backward(dy)
+        assert torch.allclose(x_tri.grad.float(), x_ref.grad.float(), atol=1e-3, rtol=1e-3)
+
+
+def bench_reduce(B: int = 4, M: int = 4096, N: int = 4096, *, dim: int = 0, dtype: torch.dtype = torch.float16,
+                 iters: int = 200, mask_mode: str = "none"):
+    torch.manual_seed(0)
+    device = "cuda"
+    x = torch.randn((B, M, N), device=device, dtype=torch.float32).to(dtype)
+    mask = init_mask(mask_mode, B, M, N, device)
+    ms = do_bench(lambda: reduce(x, dim=dim, mask=mask), rep=iters)
+    nnz = x.numel() if mask is None else (mask.expand(B, M, N) != 0).sum()
+    read_bytes = nnz * x.element_size()
+    out_elems = (M * N) if dim == 0 else ((B * N) if dim == 1 else (B * M))
+    write_bytes = out_elems * x.element_size()
+    mask_bytes = 0 if mask is None else (mask.numel() * mask.element_size())
+    bytes_total = read_bytes + write_bytes + mask_bytes
+    gbps = (bytes_total) / ms / 1e6
+    desc = f"reduce: B={B}, M={M}, N={N}, dim={dim}, dtype={str(dtype).split('.')[-1]}, mask={mask_mode}"
+    print(f"{desc} -> {gbps:.2f} GB/s")
+
+
+# bench_reduce(B=4, M=8192, N=8192, dim=0, dtype=torch.float16, mask_mode="none")
+# bench_reduce(B=8192, M=4, N=8192, dim=1, dtype=torch.float16, mask_mode="broadcast_n")
+# bench_reduce(B=8192, M=4, N=8192, dim=1, dtype=torch.float16, mask_mode="broadcast_m")
+# bench_reduce(B=8192, M=4, N=8192, dim=1, dtype=torch.float16, mask_mode="broadcast_b")

--- a/op_tests/triton_tests/triton_kernels/test_reduce.py
+++ b/op_tests/triton_tests/triton_kernels/test_reduce.py
@@ -2,7 +2,10 @@ import pytest
 import torch
 from triton.testing import do_bench
 from triton_kernels.reduce import reduce, reduce_torch, PostprocessFn, FnSpecs
-from triton_kernels.numerics_details.mxfp import upcast_from_mxfp_torch, downcast_to_mxfp_torch
+from triton_kernels.numerics_details.mxfp import (
+    upcast_from_mxfp_torch,
+    downcast_to_mxfp_torch,
+)
 from triton_kernels.numerics import InFlexData, OutFlexData
 from triton_kernels.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4
 import triton
@@ -37,27 +40,36 @@ def plus_a_reduce(x, a):
     return tl.sum(y.reshape([x.shape[0], x.shape[1] // 2, 2]), axis=2)
 
 
-@pytest.mark.parametrize("B, M, N, postprocess_fn", [
-    (311, 384, 384, None),
-    (384, 311, 384, None),
-    (384, 384, 311, None),
-    (512, 512, 512, None),
-    (512, 512, 512, "plus_ten"),
-    (4, 4, 4, None),
-])
-@pytest.mark.parametrize("dtype_str", [
-    "float16",
-    "float32",
-    "mxfloat8",
-    "flexfloat8",
-])
-@pytest.mark.parametrize("mask_mode", [
-    "none",  # no mask
-    "full",  # full-sized mask [B,M,N]
-    "broadcast_b",  # broadcast over B: [1,M,N]
-    "broadcast_m",  # broadcast over M: [B,1,N]
-    "broadcast_n",  # broadcast over N: [B,M,1]
-])
+@pytest.mark.parametrize(
+    "B, M, N, postprocess_fn",
+    [
+        (311, 384, 384, None),
+        (384, 311, 384, None),
+        (384, 384, 311, None),
+        (512, 512, 512, None),
+        (512, 512, 512, "plus_ten"),
+        (4, 4, 4, None),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype_str",
+    [
+        "float16",
+        "float32",
+        "mxfloat8",
+        "flexfloat8",
+    ],
+)
+@pytest.mark.parametrize(
+    "mask_mode",
+    [
+        "none",  # no mask
+        "full",  # full-sized mask [B,M,N]
+        "broadcast_b",  # broadcast over B: [1,M,N]
+        "broadcast_m",  # broadcast over M: [B,1,N]
+        "broadcast_n",  # broadcast over N: [B,M,1]
+    ],
+)
 @pytest.mark.parametrize("dim", [0, 1, 2])
 def test_op(B, M, N, dtype_str, dim, mask_mode, postprocess_fn):
     # Check float8 hardware support
@@ -81,8 +93,12 @@ def test_op(B, M, N, dtype_str, dim, mask_mode, postprocess_fn):
         x_flex = InFlexData(scale=torch.tensor([2], device=device, dtype=torch.float32))
         x = x / x_flex.scale
         x = x.to(dtype)
-        y_flex_tri = OutFlexData(expected_scale=expected_scale, actual_scale=torch.empty_like(expected_scale))
-        y_flex_ref = OutFlexData(expected_scale=expected_scale, actual_scale=torch.empty_like(expected_scale))
+        y_flex_tri = OutFlexData(
+            expected_scale=expected_scale, actual_scale=torch.empty_like(expected_scale)
+        )
+        y_flex_ref = OutFlexData(
+            expected_scale=expected_scale, actual_scale=torch.empty_like(expected_scale)
+        )
     mask = init_mask(mask_mode, B, M, N, device)
     expected_exception = ValueError if dim == 2 and is_mx else None
     if expected_exception is not None:
@@ -90,34 +106,64 @@ def test_op(B, M, N, dtype_str, dim, mask_mode, postprocess_fn):
             reduce(x, dim=dim, mask=mask, x_mxscale=x_mscale)
         return
     if postprocess_fn == "plus_ten":
-        postprocess_fn_tri = PostprocessFn(specs=FnSpecs("plus_a", plus_a_reduce, ("a", ), reduction_n=2),
-                                           fn_args=(10, ))
-        postprocess_fn_ref = lambda x: (x + 10).reshape([x.shape[0], x.shape[1] // 2, 2]).sum(dim=2)
+        postprocess_fn_tri = PostprocessFn(
+            specs=FnSpecs("plus_a", plus_a_reduce, ("a",), reduction_n=2), fn_args=(10,)
+        )
+
+        def postprocess_fn_ref(x):
+            return (x + 10).reshape([x.shape[0], x.shape[1] // 2, 2]).sum(dim=2)
+
     else:
         postprocess_fn_tri = postprocess_fn_ref = None
     # run forward pass
     x_tri = x.clone().detach().requires_grad_(True)
     x_ref = x.clone().detach().requires_grad_(True)
-    y_tri, y_tri_mxscale = reduce(x_tri, dim=dim, mask=mask, x_mxscale=x_mscale, x_flex=x_flex, y_flex=y_flex_tri,
-                                  postprocess_fn1=postprocess_fn_tri)
-    y_ref, y_ref_mxscale = reduce_torch(x_ref, dim=dim, mask=mask, x_mxscale=x_mscale, x_flex=x_flex, y_flex=y_flex_ref,
-                                        postprocess_fn1=postprocess_fn_ref)
+    y_tri, y_tri_mxscale = reduce(
+        x_tri,
+        dim=dim,
+        mask=mask,
+        x_mxscale=x_mscale,
+        x_flex=x_flex,
+        y_flex=y_flex_tri,
+        postprocess_fn1=postprocess_fn_tri,
+    )
+    y_ref, y_ref_mxscale = reduce_torch(
+        x_ref,
+        dim=dim,
+        mask=mask,
+        x_mxscale=x_mscale,
+        x_flex=x_flex,
+        y_flex=y_flex_ref,
+        postprocess_fn1=postprocess_fn_ref,
+    )
     if is_mx:
         y_ref = upcast_from_mxfp_torch(y_ref, y_ref_mxscale, torch.float16, axis=-1)
         y_tri = upcast_from_mxfp_torch(y_tri, y_tri_mxscale, torch.float16, axis=-1)
     assert torch.allclose(y_tri.float(), y_ref.float(), atol=1e-3, rtol=1e-3)
     if is_flex:
-        torch.allclose(y_flex_tri.actual_scale, y_flex_ref.actual_scale, atol=1e-3, rtol=1e-3)
+        torch.allclose(
+            y_flex_tri.actual_scale, y_flex_ref.actual_scale, atol=1e-3, rtol=1e-3
+        )
     run_bwd = postprocess_fn is None and "float8" not in dtype_str
     if run_bwd:
         dy = torch.randn_like(y_tri)
         y_tri.backward(dy)
         y_ref.backward(dy)
-        assert torch.allclose(x_tri.grad.float(), x_ref.grad.float(), atol=1e-3, rtol=1e-3)
+        assert torch.allclose(
+            x_tri.grad.float(), x_ref.grad.float(), atol=1e-3, rtol=1e-3
+        )
 
 
-def bench_reduce(B: int = 4, M: int = 4096, N: int = 4096, *, dim: int = 0, dtype: torch.dtype = torch.float16,
-                 iters: int = 200, mask_mode: str = "none"):
+def bench_reduce(
+    B: int = 4,
+    M: int = 4096,
+    N: int = 4096,
+    *,
+    dim: int = 0,
+    dtype: torch.dtype = torch.float16,
+    iters: int = 200,
+    mask_mode: str = "none",
+):
     torch.manual_seed(0)
     device = "cuda"
     x = torch.randn((B, M, N), device=device, dtype=torch.float32).to(dtype)

--- a/op_tests/triton_tests/triton_kernels/test_roofline.py
+++ b/op_tests/triton_tests/triton_kernels/test_roofline.py
@@ -1,0 +1,16 @@
+import pytest
+from triton_kernels.roofline import get_memset_tbps, get_blas_tflops
+from triton_kernels.target_info import cuda_capability_geq, is_cuda
+
+
+def test_get_memset_tbps():
+    tbps = get_memset_tbps()
+    assert tbps > 0
+
+
+@pytest.mark.parametrize("dtype", ["fp16", "bf16", "fp8"])
+def test_get_blas_tflops(dtype):
+    if dtype in ["fp8"] and is_cuda() and not cuda_capability_geq(9, 0):
+        pytest.skip("FP8 not supported on this GPU")
+    tflops = get_blas_tflops(dtype)
+    assert tflops > 0

--- a/op_tests/triton_tests/triton_kernels/test_specialize.py
+++ b/op_tests/triton_tests/triton_kernels/test_specialize.py
@@ -1,0 +1,103 @@
+import importlib
+
+import torch
+from triton_kernels.specialize import cacheable, specialize
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def identity(x):
+    return x
+
+
+@triton.jit
+def template_kernel(o, fn: tl.constexpr):
+    cst = 1.0
+    cst = fn(cst)
+    tl.store(o, cst)
+
+
+def retrieve_fn(module, name):
+    module = importlib.import_module(module)
+    fn = getattr(module, name)
+    return fn
+
+
+_specialized_kernel = None
+
+
+def get_specialized_kernel():
+    global _specialized_kernel
+    if _specialized_kernel is not None:
+        return _specialized_kernel
+    import types
+    spec_constants = {"fn": identity}
+    spec_tuples = {}
+    module = types.ModuleType("specialized_kernel")
+    module.specialized = specialize(template_kernel, module, spec_constants, spec_tuples)
+    _specialized_kernel = module.specialized
+    return _specialized_kernel
+
+
+@cacheable
+def cacheable_kernel():
+    return get_specialized_kernel()
+
+
+def test_cacheable(device, fresh_triton_cache, monkeypatch):
+    specialized_kernel = get_specialized_kernel()
+    monkeypatch.setenv("TRITON_DISABLE_LINE_INFO", "0")
+
+    specialization_data = None
+    fn_name = None
+    module_name = None
+
+    def cache_hook(*args, **kwargs):
+        nonlocal specialization_data
+        nonlocal fn_name
+        nonlocal module_name
+        specialization_data = kwargs["compile"]["specialization_data"]
+        fn_name = kwargs["fn"].name
+        module_name = kwargs["fn"].module
+
+    triton.knobs.runtime.jit_cache_hook = cache_hook
+    o = torch.empty((1, ), dtype=torch.float32, device=device)
+    k = specialized_kernel[(1, )](o, )
+    hash = k.hash
+    assert o.item() == 1.0
+    assert module_name.endswith("test_specialize")
+    assert fn_name == "cacheable_kernel"
+
+    # check line info in ttir
+    ttir = k.asm["ttir"]
+    loc = None
+    for line in ttir.split("\n"):
+        if loc and loc in line:
+            assert "test_specialize.py" in line
+            assert ":18:5" in line
+        if "store" in line:
+            loc = line.split("(", 1)[1].split(")", 1)[0]
+    assert loc is not None, f"Expected to find a store instruction with location info, got: {ttir}"
+
+    compile_count = 0
+
+    def count_hook(*args, **kwargs):
+        nonlocal compile_count
+        compile_count += 1
+
+    triton.knobs.runtime.jit_cache_hook = count_hook
+    # clear the cache
+    specialized_kernel.device_caches.clear()
+
+    # retrieve the kernel from name and preload it.
+    fn = retrieve_fn(module_name, fn_name)
+    assert fn == specialized_kernel
+    preload = fn.preload(specialization_data)
+    assert compile_count == 1
+    assert preload.hash == hash
+
+    # verify that we hit the cache.
+    compile_count = 0
+    specialized_kernel[(1, )](o, )
+    assert compile_count == 0

--- a/op_tests/triton_tests/triton_kernels/test_specialize.py
+++ b/op_tests/triton_tests/triton_kernels/test_specialize.py
@@ -32,10 +32,13 @@ def get_specialized_kernel():
     if _specialized_kernel is not None:
         return _specialized_kernel
     import types
+
     spec_constants = {"fn": identity}
     spec_tuples = {}
     module = types.ModuleType("specialized_kernel")
-    module.specialized = specialize(template_kernel, module, spec_constants, spec_tuples)
+    module.specialized = specialize(
+        template_kernel, module, spec_constants, spec_tuples
+    )
     _specialized_kernel = module.specialized
     return _specialized_kernel
 
@@ -62,8 +65,10 @@ def test_cacheable(device, fresh_triton_cache, monkeypatch):
         module_name = kwargs["fn"].module
 
     triton.knobs.runtime.jit_cache_hook = cache_hook
-    o = torch.empty((1, ), dtype=torch.float32, device=device)
-    k = specialized_kernel[(1, )](o, )
+    o = torch.empty((1,), dtype=torch.float32, device=device)
+    k = specialized_kernel[(1,)](
+        o,
+    )
     hash = k.hash
     assert o.item() == 1.0
     assert module_name.endswith("test_specialize")
@@ -78,7 +83,9 @@ def test_cacheable(device, fresh_triton_cache, monkeypatch):
             assert ":18:5" in line
         if "store" in line:
             loc = line.split("(", 1)[1].split(")", 1)[0]
-    assert loc is not None, f"Expected to find a store instruction with location info, got: {ttir}"
+    assert (
+        loc is not None
+    ), f"Expected to find a store instruction with location info, got: {ttir}"
 
     compile_count = 0
 
@@ -99,5 +106,7 @@ def test_cacheable(device, fresh_triton_cache, monkeypatch):
 
     # verify that we hit the cache.
     compile_count = 0
-    specialized_kernel[(1, )](o, )
+    specialized_kernel[(1,)](
+        o,
+    )
     assert compile_count == 0

--- a/op_tests/triton_tests/triton_kernels/test_swiglu.py
+++ b/op_tests/triton_tests/triton_kernels/test_swiglu.py
@@ -1,0 +1,32 @@
+from triton_kernels.swiglu import swiglu, swiglu_torch, PrecisionConfig
+from triton_kernels.testing import assert_close
+import torch
+import pytest
+
+# ---------------
+# initialize data
+# ---------------
+
+
+def alloc_rand(shape, device, dtype, requires_grad=True):
+    if dtype.itemsize == 1:
+        tmp = 2**-(torch.randint(4, 8, shape, device=device, dtype=torch.float16))
+        return tmp.to(dtype).requires_grad_(requires_grad)
+    return torch.randn(shape, device=device, dtype=dtype, requires_grad=requires_grad)
+
+
+# ---------------
+# unit tests
+# ---------------
+
+
+@pytest.mark.parametrize("M, N", [(1311, 4352)])
+@pytest.mark.parametrize("limit", [1e-2, 10])
+def test_op(M, N, limit, device, alpha=0.5):
+    torch.manual_seed(2)
+    # initialize data
+    x = alloc_rand([M, N], device=device, dtype=torch.bfloat16)
+    precision_config = PrecisionConfig(limit=limit)
+    tri_y = swiglu(x, alpha, precision_config)
+    ref_y = swiglu_torch(x, alpha, precision_config)
+    assert_close(tri_y, ref_y)

--- a/op_tests/triton_tests/triton_kernels/test_swiglu.py
+++ b/op_tests/triton_tests/triton_kernels/test_swiglu.py
@@ -10,7 +10,7 @@ import pytest
 
 def alloc_rand(shape, device, dtype, requires_grad=True):
     if dtype.itemsize == 1:
-        tmp = 2**-(torch.randint(4, 8, shape, device=device, dtype=torch.float16))
+        tmp = 2 ** -(torch.randint(4, 8, shape, device=device, dtype=torch.float16))
         return tmp.to(dtype).requires_grad_(requires_grad)
     return torch.randn(shape, device=device, dtype=dtype, requires_grad=requires_grad)
 

--- a/op_tests/triton_tests/triton_kernels/test_tensor.py
+++ b/op_tests/triton_tests/triton_kernels/test_tensor.py
@@ -1,0 +1,75 @@
+import pytest
+import torch
+from triton_kernels.tensor_details.dtype import BIT
+from triton_kernels.tensor import (
+    make_ragged_tensor_metadata,
+    make_ragged_tensor_metadata_torch,
+    remap_ragged_tensor_metadata,
+    remap_ragged_tensor_metadata_torch,
+    make_bitmatrix_metadata,
+    make_bitmatrix_metadata_torch,
+    wrap_torch_tensor,
+)
+from triton_kernels.testing import assert_equal
+
+
+@pytest.mark.parametrize("n_slices", [1, 7, 33, 911, 1025])
+def test_make_ragged_tensor_metadata(n_slices):
+    torch.manual_seed(0)
+    device = "cuda"
+    max_slice_size = 200
+    n_total_rows = max_slice_size * n_slices
+    slice_sizes = torch.randint(0, max_slice_size, (n_slices, ), dtype=torch.int32, device=device)
+    slice_sizes[torch.randint(0, n_slices, (1, ))] = 0
+    meta = make_ragged_tensor_metadata(slice_sizes, n_total_rows)
+    ref = make_ragged_tensor_metadata_torch(slice_sizes, n_total_rows)
+    assert_equal(meta.slice_sizes, ref.slice_sizes)
+    assert_equal(meta.slice_offs, ref.slice_offs)
+    assert_equal(meta.block_offs_data, ref.block_offs_data)
+    assert_equal(meta.block_schedule_data, ref.block_schedule_data)
+
+
+@pytest.mark.parametrize("n_slices", [9, 32, 911, 1025])
+def test_remap_ragged_tensor_metadata(n_slices):
+    device = "cuda"
+    max_slice_size = 200
+    n_total_rows = max_slice_size * n_slices
+    slice_sizes = torch.randint(0, max_slice_size, (n_slices, ), dtype=torch.int32, device=device)
+    slice_sizes[torch.randint(0, n_slices, (1, ))] = 0
+    # randomly permute slices
+    slice_map = torch.randperm(n_slices, device=device, dtype=torch.int32)
+    # discard random slices
+    slice_map[torch.randint(0, len(slice_map), (5, ))] = -1
+    tri_metadata = make_ragged_tensor_metadata(slice_sizes, n_total_rows)
+    ref_metadata = make_ragged_tensor_metadata_torch(slice_sizes, n_total_rows)
+    tri_metadata = remap_ragged_tensor_metadata(tri_metadata, slice_map)
+    ref_metadata = remap_ragged_tensor_metadata_torch(ref_metadata, slice_map)
+    assert_equal(tri_metadata.slice_sizes, ref_metadata.slice_sizes)
+    assert_equal(tri_metadata.slice_offs, ref_metadata.slice_offs)
+    assert_equal(tri_metadata.block_offs_data, ref_metadata.block_offs_data)
+    assert_equal(tri_metadata.block_schedule_data, ref_metadata.block_schedule_data)
+
+
+@pytest.mark.parametrize("n_rows", [7, 256, 17111])
+@pytest.mark.parametrize("n_cols", [13, 32, 128, 811])
+@pytest.mark.parametrize("k", [1, 4, 8])
+def test_make_bitmatrix_metadata(n_rows, n_cols, k):
+    if k > n_cols:
+        pytest.skip("k must be <= n_cols")
+    device = "cuda"
+    torch.manual_seed(0)
+    # random permutation of column indices
+    # NOTE: `indx` *must* be sorted
+    indx = torch.rand(n_rows, n_cols, device=device).argsort(dim=1).int()[:, :k]
+    indx = torch.sort(indx, dim=1)[0]
+    # create bitmask
+    rows = torch.arange(n_rows, device=device).unsqueeze(1).expand_as(indx)
+    bitmask_data = torch.zeros((n_rows, (n_cols + 31) // 32), dtype=torch.int32, device=device)
+    bitmask_data.index_put_((rows, indx // 32), 1 << (indx % 32), accumulate=True)
+    bitmask = wrap_torch_tensor(bitmask_data.view(torch.uint32), dtype=BIT, shape=(n_rows, n_cols))
+    # make metadata and compare
+    metadata_tri = make_bitmatrix_metadata(indx, bitmask)
+    metadata_ref = make_bitmatrix_metadata_torch(indx, bitmask)
+    assert_equal(metadata_tri.col_sum, metadata_ref.col_sum)
+    assert_equal(metadata_tri.row_sorted_indx, metadata_ref.row_sorted_indx)
+    assert_equal(metadata_tri.col_sorted_indx, metadata_ref.col_sorted_indx)

--- a/op_tests/triton_tests/triton_kernels/test_tensor.py
+++ b/op_tests/triton_tests/triton_kernels/test_tensor.py
@@ -19,8 +19,10 @@ def test_make_ragged_tensor_metadata(n_slices):
     device = "cuda"
     max_slice_size = 200
     n_total_rows = max_slice_size * n_slices
-    slice_sizes = torch.randint(0, max_slice_size, (n_slices, ), dtype=torch.int32, device=device)
-    slice_sizes[torch.randint(0, n_slices, (1, ))] = 0
+    slice_sizes = torch.randint(
+        0, max_slice_size, (n_slices,), dtype=torch.int32, device=device
+    )
+    slice_sizes[torch.randint(0, n_slices, (1,))] = 0
     meta = make_ragged_tensor_metadata(slice_sizes, n_total_rows)
     ref = make_ragged_tensor_metadata_torch(slice_sizes, n_total_rows)
     assert_equal(meta.slice_sizes, ref.slice_sizes)
@@ -34,12 +36,14 @@ def test_remap_ragged_tensor_metadata(n_slices):
     device = "cuda"
     max_slice_size = 200
     n_total_rows = max_slice_size * n_slices
-    slice_sizes = torch.randint(0, max_slice_size, (n_slices, ), dtype=torch.int32, device=device)
-    slice_sizes[torch.randint(0, n_slices, (1, ))] = 0
+    slice_sizes = torch.randint(
+        0, max_slice_size, (n_slices,), dtype=torch.int32, device=device
+    )
+    slice_sizes[torch.randint(0, n_slices, (1,))] = 0
     # randomly permute slices
     slice_map = torch.randperm(n_slices, device=device, dtype=torch.int32)
     # discard random slices
-    slice_map[torch.randint(0, len(slice_map), (5, ))] = -1
+    slice_map[torch.randint(0, len(slice_map), (5,))] = -1
     tri_metadata = make_ragged_tensor_metadata(slice_sizes, n_total_rows)
     ref_metadata = make_ragged_tensor_metadata_torch(slice_sizes, n_total_rows)
     tri_metadata = remap_ragged_tensor_metadata(tri_metadata, slice_map)
@@ -64,9 +68,13 @@ def test_make_bitmatrix_metadata(n_rows, n_cols, k):
     indx = torch.sort(indx, dim=1)[0]
     # create bitmask
     rows = torch.arange(n_rows, device=device).unsqueeze(1).expand_as(indx)
-    bitmask_data = torch.zeros((n_rows, (n_cols + 31) // 32), dtype=torch.int32, device=device)
+    bitmask_data = torch.zeros(
+        (n_rows, (n_cols + 31) // 32), dtype=torch.int32, device=device
+    )
     bitmask_data.index_put_((rows, indx // 32), 1 << (indx % 32), accumulate=True)
-    bitmask = wrap_torch_tensor(bitmask_data.view(torch.uint32), dtype=BIT, shape=(n_rows, n_cols))
+    bitmask = wrap_torch_tensor(
+        bitmask_data.view(torch.uint32), dtype=BIT, shape=(n_rows, n_cols)
+    )
     # make metadata and compare
     metadata_tri = make_bitmatrix_metadata(indx, bitmask)
     metadata_ref = make_bitmatrix_metadata_torch(indx, bitmask)

--- a/op_tests/triton_tests/triton_kernels/test_tensor_details/test_layout_cdna4.py
+++ b/op_tests/triton_tests/triton_kernels/test_tensor_details/test_layout_cdna4.py
@@ -1,0 +1,25 @@
+import pytest
+import torch
+from triton_kernels.tensor_details.layout import CDNA4MXScaleLayout
+
+# ------------------------------------------------------------
+# Torch tests
+# ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 4096, 1024),
+        (10, 254, 60),
+        (1, 320, 160),
+        (2, 16, 512),
+        (3, 2, 36),
+    ],
+)
+def test_mxfp4_scale_roundtrip(shape):
+    x = torch.randint(0, 256, shape, dtype=torch.uint8, device="cuda")
+    layout = CDNA4MXScaleLayout()
+    transformation = layout.make_transformation(x.shape, is_fp4=False)
+    res = transformation.unswizzle_data(transformation.swizzle_data(x))
+    assert (res == x).all()

--- a/op_tests/triton_tests/triton_kernels/test_topk.py
+++ b/op_tests/triton_tests/triton_kernels/test_topk.py
@@ -1,0 +1,63 @@
+import pytest
+import torch
+import triton.profiler as proton
+from triton_kernels.topk import topk, topk_torch
+from triton_kernels.testing import assert_equal, assert_close
+from triton_kernels.distributed import SymmetricMemoryPool
+import torch.distributed as dist
+
+
+@pytest.mark.parametrize("n_rows", [1, 7, 256, 300])
+@pytest.mark.parametrize("n_cols", [13, 32, 128, 200])
+@pytest.mark.parametrize("k", [8])
+@pytest.mark.parametrize("apply_softmax", [True, False])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32"])
+def test_topk(n_rows, n_cols, k, apply_softmax, dtype):
+    device = "cuda"
+
+    torch.manual_seed(0)
+    dtype = getattr(torch, dtype)
+    x = torch.randn((n_rows, n_cols), dtype=torch.float32, device=device)
+    sparse_x_tri = topk(x, k, apply_softmax=apply_softmax)
+    sparse_x_ref = topk_torch(x, k, apply_softmax=apply_softmax)
+    assert_close(sparse_x_tri.vals, sparse_x_ref.vals)
+    assert_equal(sparse_x_tri.indx, sparse_x_ref.indx)
+    assert_equal(sparse_x_tri.mask.storage.data, sparse_x_ref.mask.storage.data)
+    assert sparse_x_tri.mask.storage.data.stride() == sparse_x_ref.mask.storage.data.stride()
+    assert sparse_x_tri.mask.storage.data.shape == sparse_x_ref.mask.storage.data.shape
+
+
+def bench_topk(n_rows, n_cols, k, apply_softmax, all_gather=False):
+    # setup distributed environment
+    rank, world_size = 0, 1
+    if all_gather:
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(backend="nccl")
+        rank = torch.distributed.get_rank()
+        world_size = torch.distributed.get_world_size()
+    torch.cuda.set_device(rank)
+    # run benchmark
+    x = torch.randn((n_rows, n_cols), dtype=torch.float32, device=f"cuda:{rank}")
+    symm_mem_pool = SymmetricMemoryPool()
+    symm_mem_pool._reserve_region("topk", world_size * x.numel() * x.element_size(), 128, 0)
+    symm_mem_pool._initialize(world_size, group=torch.distributed.group.WORLD, device=x.device)
+    proton.start(f"profile_{rank}", hook="triton")
+    # warmup
+    proton.deactivate()
+    g = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        with torch.cuda.graph(g):
+            _ = topk(x, k, apply_softmax=apply_softmax, all_gather=all_gather, symm_mem_pool=symm_mem_pool)
+    torch.cuda.synchronize()
+    proton.activate()
+    for i in range(100):
+        g.replay()
+    dist.barrier()
+    torch.cuda.synchronize()
+    proton.finalize()
+    symm_mem_pool.release()
+
+
+if __name__ == "__main__":
+    bench_topk(1024, 1024, 8, False, all_gather=True)

--- a/op_tests/triton_tests/triton_kernels/test_topk.py
+++ b/op_tests/triton_tests/triton_kernels/test_topk.py
@@ -23,7 +23,10 @@ def test_topk(n_rows, n_cols, k, apply_softmax, dtype):
     assert_close(sparse_x_tri.vals, sparse_x_ref.vals)
     assert_equal(sparse_x_tri.indx, sparse_x_ref.indx)
     assert_equal(sparse_x_tri.mask.storage.data, sparse_x_ref.mask.storage.data)
-    assert sparse_x_tri.mask.storage.data.stride() == sparse_x_ref.mask.storage.data.stride()
+    assert (
+        sparse_x_tri.mask.storage.data.stride()
+        == sparse_x_ref.mask.storage.data.stride()
+    )
     assert sparse_x_tri.mask.storage.data.shape == sparse_x_ref.mask.storage.data.shape
 
 
@@ -39,8 +42,12 @@ def bench_topk(n_rows, n_cols, k, apply_softmax, all_gather=False):
     # run benchmark
     x = torch.randn((n_rows, n_cols), dtype=torch.float32, device=f"cuda:{rank}")
     symm_mem_pool = SymmetricMemoryPool()
-    symm_mem_pool._reserve_region("topk", world_size * x.numel() * x.element_size(), 128, 0)
-    symm_mem_pool._initialize(world_size, group=torch.distributed.group.WORLD, device=x.device)
+    symm_mem_pool._reserve_region(
+        "topk", world_size * x.numel() * x.element_size(), 128, 0
+    )
+    symm_mem_pool._initialize(
+        world_size, group=torch.distributed.group.WORLD, device=x.device
+    )
     proton.start(f"profile_{rank}", hook="triton")
     # warmup
     proton.deactivate()
@@ -48,7 +55,13 @@ def bench_topk(n_rows, n_cols, k, apply_softmax, all_gather=False):
     stream = torch.cuda.Stream()
     with torch.cuda.stream(stream):
         with torch.cuda.graph(g):
-            _ = topk(x, k, apply_softmax=apply_softmax, all_gather=all_gather, symm_mem_pool=symm_mem_pool)
+            _ = topk(
+                x,
+                k,
+                apply_softmax=apply_softmax,
+                all_gather=all_gather,
+                symm_mem_pool=symm_mem_pool,
+            )
     torch.cuda.synchronize()
     proton.activate()
     for i in range(100):

--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,26 @@ def _run_install_triton():
 
 AITER_USE_SYSTEM_TRITON = int(os.environ.get("AITER_USE_SYSTEM_TRITON", 0))
 
+
+def _torch_version_below(min_version):
+    try:
+        import torch
+        from packaging.version import Version
+
+        return Version(torch.__version__.split("+")[0].split("dev")[0]) < Version(
+            min_version
+        )
+    except Exception:
+        return False
+
+
 _triton_info = _is_triton_installed()
-if AITER_USE_SYSTEM_TRITON and _triton_info:
+if _torch_version_below("2.9.1"):
+    print(
+        f"[aiter] torch < 2.9.1 detected, skipping triton reinstall"
+        f"{f' (keeping {_triton_info[0]}=={_triton_info[1]})' if _triton_info else ''}"
+    )
+elif AITER_USE_SYSTEM_TRITON and _triton_info:
     print(
         f"[aiter] AITER_USE_SYSTEM_TRITON=1, keeping existing"
         f" {_triton_info[0]}=={_triton_info[1]}"


### PR DESCRIPTION

- Add triton_kernels test suite from upstream triton (removed NVIDIA-specific tests)
- Add torch.compile constexpr mutation regression test for Triton 3.7.0
- Update install_triton.sh: use release_ PyPI URL, add triton-kernels install
- Skip triton reinstall when torch < 2.9.1 in setup.py
- Add triton_kernels test timing to split_tests.sh

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
