### PR TITLE
perf(gemm_dispatch): POD lookup key + raw fn-ptr value, compile time …

### DIFF
--- a/csrc/ck_batched_gemm_a8w8/batched_gemm_a8w8.cu
+++ b/csrc/ck_batched_gemm_a8w8/batched_gemm_a8w8.cu
@@ -7,11 +7,13 @@
 #include "gemm_dispatch_utils.h"
 #include <cmath>
 
-using BatchedRowwiseKernel = std::function<
-    torch::Tensor(torch::Tensor &, torch::Tensor &,
-                  torch::Tensor &, torch::Tensor &, 
-                  torch::Tensor &, std::optional<torch::Tensor>,
-                  int)>;
+using BatchedRowwiseKernel = torch::Tensor (*)(torch::Tensor&,
+                                               torch::Tensor&,
+                                               torch::Tensor&,
+                                               torch::Tensor&,
+                                               torch::Tensor&,
+                                               std::optional<torch::Tensor>,
+                                               int);
 
 // For certain high priority shapes, we directly use the best kernel rather
 // than use heuristics.
@@ -99,8 +101,8 @@ BatchedRowwiseKernel batched_rowwise_dispatch(int B, int M, int N, int K)
     }
   }();
 
-  const int cu_num         = get_device_cu_num();
-  const std::string& gfx   = get_device_gfx();
+  const int cu_num           = get_device_cu_num();
+  const std::string_view gfx = get_device_gfx();
 
   // First check if this shape(B,M,N,K) is available in the direct lookup.
   auto it = lookup.find({gfx, cu_num, B, M, N, K});

--- a/csrc/ck_batched_gemm_bf16/batched_gemm_bf16.cu
+++ b/csrc/ck_batched_gemm_bf16/batched_gemm_bf16.cu
@@ -7,10 +7,8 @@
 #include "gemm_dispatch_utils.h"
 #include <cmath>
 
-using BatchedKernel = std::function<
-    torch::Tensor(torch::Tensor &, torch::Tensor &,
-                  torch::Tensor &, std::optional<torch::Tensor>,
-                  int)>;
+using BatchedKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, std::optional<torch::Tensor>, int);
 
 // For certain high priority shapes, we directly use the best kernel rather
 // than use heuristics.
@@ -90,8 +88,8 @@ BatchedKernel batched_dispatch(int B, int M, int N, int K)
       return BatchedKernelMap{GENERATE_LOOKUP_TABLE()};
   }();
 
-  const int cu_num         = get_device_cu_num();
-  const std::string& gfx   = get_device_gfx();
+  const int cu_num           = get_device_cu_num();
+  const std::string_view gfx = get_device_gfx();
 
   // First check if this shape(B,M,N,K) is available in the direct lookup.
   auto it = lookup.find({gfx, cu_num, B, M, N, K});

--- a/csrc/ck_deepgemm/deepgemm.cu
+++ b/csrc/ck_deepgemm/deepgemm.cu
@@ -8,10 +8,12 @@
 #include <cmath>
 #include "py_itfs_common.h"
 
-using RowwiseKernel = std::function<
-    torch::Tensor(torch::Tensor &, torch::Tensor &,
-                  torch::Tensor &, torch::Tensor &,
-                  std::optional<torch::Tensor>, std::optional<torch::Tensor>)>;
+using RowwiseKernel = torch::Tensor (*)(torch::Tensor&,
+                                        torch::Tensor&,
+                                        torch::Tensor&,
+                                        torch::Tensor&,
+                                        std::optional<torch::Tensor>,
+                                        std::optional<torch::Tensor>);
 
 // For certain high priority shapes, we directly use the best kernel rather
 // than use heuristics.

--- a/csrc/ck_gemm_a4w4_blockscale/gemm_a4w4_blockscale.cu
+++ b/csrc/ck_gemm_a4w4_blockscale/gemm_a4w4_blockscale.cu
@@ -8,10 +8,8 @@
 #include "gemm_dispatch_utils.h"
 #include <cmath>
 
-using BlockwiseKernel = std::function<
-    torch::Tensor(torch::Tensor &, torch::Tensor &,
-                  torch::Tensor &, torch::Tensor &,
-                  torch::Tensor &, int)>;
+using BlockwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
 
 using BlockwiseKernelMap = GemmDispatchMap<BlockwiseKernel>;
 
@@ -32,8 +30,8 @@ BlockwiseKernel blockscale_dispatch(int M, int N, int K)
           static_assert(false, "blockscale_dispatch used with unsupported dtype!");
       } }();
 
-    const int cu_num         = get_device_cu_num();
-    const std::string& gfx   = get_device_gfx();
+    const int cu_num           = get_device_cu_num();
+    const std::string_view gfx = get_device_gfx();
 
     // First check if this shape(M,N,K) is available in the direct lookup.
     auto it = lookup.find({gfx, cu_num, M, N, K});

--- a/csrc/ck_gemm_a8w8/gemm_a8w8.cu
+++ b/csrc/ck_gemm_a8w8/gemm_a8w8.cu
@@ -8,11 +8,13 @@
 #include <cmath>
 #include "py_itfs_common.h"
 
-using RowwiseKernel = std::function<
-    torch::Tensor(torch::Tensor &, torch::Tensor &,
-                  torch::Tensor &, torch::Tensor &,
-                  torch::Tensor &, std::optional<torch::Tensor>,
-                  int)>;
+using RowwiseKernel = torch::Tensor (*)(torch::Tensor&,
+                                        torch::Tensor&,
+                                        torch::Tensor&,
+                                        torch::Tensor&,
+                                        torch::Tensor&,
+                                        std::optional<torch::Tensor>,
+                                        int);
 
 // For certain high priority shapes, we directly use the best kernel rather
 // than use heuristics.
@@ -98,8 +100,8 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
     return RowwiseKernelMap{GENERATE_LOOKUP_TABLE(ABDataType, DDataType, EDataType)};
   }();
 
-  const int cu_num         = get_device_cu_num();
-  const std::string& gfx   = get_device_gfx();
+  const int cu_num           = get_device_cu_num();
+  const std::string_view gfx = get_device_gfx();
 
   // First check if this shape(M,N,K) is available in the direct lookup.
   auto it = lookup.find({gfx, cu_num, M, N, K});

--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <functional>
-#include <unordered_map>
-
 #include <torch/extension.h>
 
 #include "gemm_common.h"
@@ -13,8 +10,8 @@
 #include "gemm_a8w8_blockscale_lookup.h"
 #include "gemm_a8w8_blockscale_manifest.h"
 
-using BlockwiseKernel = std::function<torch::Tensor(
-    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int)>;
+using BlockwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
 
 using BlockwiseKernelMap = GemmDispatchMap<BlockwiseKernel>;
 
@@ -40,8 +37,8 @@ static BlockwiseKernel blockscale_dispatch(int M, int N, int K)
         }
     }();
 
-    const int cu_num         = get_device_cu_num();
-    const std::string& gfx   = get_device_gfx();
+    const std::string_view gfx = get_device_gfx();
+    const int cu_num           = get_device_cu_num();
 
     // First check if this shape(M,N,K) is available in the direct lookup.
     auto it = lookup.find({gfx, cu_num, M, N, K});

--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_cktile.cu
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_cktile.cu
@@ -13,8 +13,8 @@
 #include "gemm_a8w8_blockscale_cktile_lookup.h"
 #include "gemm_a8w8_blockscale_cktile_manifest.h"
 
-using BlockwiseKernel = std::function<torch::Tensor(
-    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, bool, int)>;
+using BlockwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, bool, int);
 
 using BlockwiseKernelMap = GemmDispatchMap<BlockwiseKernel>;
 
@@ -40,8 +40,8 @@ static BlockwiseKernel blockscale_dispatch(int M, int N, int K)
         }
     }();
 
-    const int cu_num         = get_device_cu_num();
-    const std::string& gfx   = get_device_gfx();
+    const int cu_num           = get_device_cu_num();
+    const std::string_view gfx = get_device_gfx();
 
     // First check if this shape(M,N,K) is available in the direct lookup.
     auto it = lookup.find({gfx, cu_num, M, N, K});

--- a/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gemm_a8w8_blockscale_bpreshuffle.cu
+++ b/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gemm_a8w8_blockscale_bpreshuffle.cu
@@ -9,8 +9,8 @@
 
 #include <cmath>
 
-using BlockwiseKernel = std::function<torch::Tensor(
-    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&)>;
+using BlockwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&);
 
 using BlockwiseKernelMap = GemmDispatchMap<BlockwiseKernel>;
 
@@ -44,8 +44,8 @@ BlockwiseKernel blockscale_bpreshuffle_dispatch(int M, int N, int K)
         }
     }();
 
-    const int cu_num         = get_device_cu_num();
-    const std::string& gfx   = get_device_gfx();
+    const int cu_num           = get_device_cu_num();
+    const std::string_view gfx = get_device_gfx();
 
     // First check if this shape(M,N,K) is available in the direct lookup.
     auto it = lookup.find({gfx, cu_num, M, N, K});

--- a/csrc/ck_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle.cu
+++ b/csrc/ck_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle.cu
@@ -8,8 +8,8 @@
 #include "gemm_dispatch_utils.h"
 #include <cmath>
 
-using RowwiseKernel = std::function<torch::Tensor(
-    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int)>;
+using RowwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
 
 using RowwiseKernelMap = GemmDispatchMap<RowwiseKernel>;
 
@@ -130,8 +130,8 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
         }
     }();
 
-    const int cu_num         = get_device_cu_num();
-    const std::string& gfx   = get_device_gfx();
+    const int cu_num           = get_device_cu_num();
+    const std::string_view gfx = get_device_gfx();
 
     // First check if this shape(M,N,K) is available in the direct lookup.
     auto it = lookup.find({gfx, cu_num, M, N, K});

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
@@ -8,8 +8,8 @@
 #include "gemm_dispatch_utils.h"
 #include <cmath>
 
-using RowwiseKernel = std::function<torch::Tensor(
-    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int)>;
+using RowwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
 
 using RowwiseKernelMap = GemmDispatchMap<RowwiseKernel>;
 
@@ -51,8 +51,8 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
         }
     }();
 
-    const int cu_num         = get_device_cu_num();
-    const std::string& gfx   = get_device_gfx();
+    const int cu_num           = get_device_cu_num();
+    const std::string_view gfx = get_device_gfx();
 
     // First check if this shape(M,N,K) is available in the direct lookup.
     auto it = lookup.find({gfx, cu_num, M, N, K});

--- a/csrc/include/gemm_dispatch_utils.h
+++ b/csrc/include/gemm_dispatch_utils.h
@@ -5,33 +5,55 @@
 #ifdef USE_ROCM
 
 #include "aiter_hip_common.h"
+#include <cstddef>
 #include <functional>
 #include <stdexcept>
 #include <string>
-#include <tuple>
+#include <string_view>
+#include <type_traits>
 #include <unordered_map>
 
 // ---------------------------------------------------------------------------
-// GemmDispatchHash
+// GemmLookupKey
 //
-// Hash for the (gfx, cu_num, M, N, K) 5-tuple used as the C++ runtime
-// dispatch key in all CK GEMM modules.  The gfx arch string (e.g. "gfx942")
-// is included so that multi-arch .so files containing kernels for two
-// architectures that share the same cu_num do not collide.  Uses boost-style
-// mixing with the golden-ratio constant (0x9e3779b9) for a non-commutative,
-// low-collision hash.
+// POD dispatch key keyed on (gfx, cu_num, M, N, K).  Keeping it trivially
+// destructible and standard-layout lets the generated lookup tables be
+// constant-initialized into .data.rel.ro — no per-entry constructor code,
+// no exception-cleanup chain in the dispatch lambda.
+//
+// gfx views must point into storage that outlives the table.  In practice
+// table entries point to string literals ("gfx950"); runtime keys point
+// into get_device_gfx()'s permanently-cached std::string.
 // ---------------------------------------------------------------------------
-struct GemmDispatchHash
+struct GemmLookupKey
 {
-    size_t operator()(const std::tuple<std::string, int, int, int, int>& t) const
+    std::string_view gfx;
+    int cu_num;
+    int M;
+    int N;
+    int K;
+};
+
+static_assert(std::is_trivially_destructible_v<GemmLookupKey>);
+static_assert(std::is_standard_layout_v<GemmLookupKey>);
+
+struct GemmLookupKeyHash
+{
+    size_t operator()(const GemmLookupKey& k) const noexcept
     {
-        size_t h = std::hash<std::string>{}(std::get<0>(t));
-        h ^= std::hash<int>{}(std::get<1>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(std::get<2>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(std::get<3>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(std::get<4>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        size_t h = std::hash<std::string_view>{}(k.gfx);
+        h ^= std::hash<int>{}(k.cu_num) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.M) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.N) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.K) + 0x9e3779b9 + (h << 6) + (h >> 2);
         return h;
     }
+};
+
+struct GemmLookupKeyEq
+{
+    bool operator()(const GemmLookupKey& a, const GemmLookupKey& b) const noexcept
+    { return a.cu_num == b.cu_num && a.M == b.M && a.N == b.N && a.K == b.K && a.gfx == b.gfx; }
 };
 
 // ---------------------------------------------------------------------------
@@ -60,8 +82,12 @@ inline int get_device_cu_num()
 // Cached per device ID via SynchronizedCache so that processes calling
 // hipSetDevice() across GPUs of different architectures always get the
 // correct arch string.  Strips any :sramecc+:xnack- suffix from gcnArchName.
+//
+// Returned by std::string_view because the cached std::string lives for the
+// program's lifetime (the cache is a function-local static unordered_map
+// that is never erased), so the view is permanently valid.
 // ---------------------------------------------------------------------------
-inline const std::string& get_device_gfx()
+inline std::string_view get_device_gfx()
 {
     static SynchronizedCache<int, std::string> cache;
     int device = -1;
@@ -79,48 +105,72 @@ inline const std::string& get_device_gfx()
 // GemmDispatchMap
 //
 // Convenience alias for the (gfx, cu_num, M, N, K)-keyed dispatch map type.
-// Each module instantiates this with its own RowwiseKernel / BlockwiseKernel
-// function type:
+// Each module instantiates this with its own raw-function-pointer kernel
+// type:
 //
+//   using RowwiseKernel    = torch::Tensor (*)(torch::Tensor&, ...);
 //   using RowwiseKernelMap = GemmDispatchMap<RowwiseKernel>;
+//
+// KernelFn must be trivially destructible (use a function pointer, not
+// std::function) for the constant-init / .rodata optimization to apply.
 // ---------------------------------------------------------------------------
 template <typename KernelFn>
 using GemmDispatchMap =
-    std::unordered_map<std::tuple<std::string, int, int, int, int>, KernelFn, GemmDispatchHash>;
+    std::unordered_map<GemmLookupKey, KernelFn, GemmLookupKeyHash, GemmLookupKeyEq>;
 
 // ---------------------------------------------------------------------------
-// BatchedGemmDispatchHash
+// BatchedGemmLookupKey
 //
-// Hash for the (gfx, cu_num, B, M, N, K) 6-tuple used as the C++ runtime
-// dispatch key in batched CK GEMM modules.  Same boost-style mixing as
-// GemmDispatchHash.
+// POD dispatch key keyed on (gfx, cu_num, B, M, N, K) — used by batched
+// GEMM modules.  Same trivial-destructibility / standard-layout properties
+// as GemmLookupKey.
 // ---------------------------------------------------------------------------
-struct BatchedGemmDispatchHash
+struct BatchedGemmLookupKey
 {
-    size_t operator()(const std::tuple<std::string, int, int, int, int, int>& t) const
+    std::string_view gfx;
+    int cu_num;
+    int B;
+    int M;
+    int N;
+    int K;
+};
+
+static_assert(std::is_trivially_destructible_v<BatchedGemmLookupKey>);
+static_assert(std::is_standard_layout_v<BatchedGemmLookupKey>);
+
+struct BatchedGemmLookupKeyHash
+{
+    size_t operator()(const BatchedGemmLookupKey& k) const noexcept
     {
-        size_t h = std::hash<std::string>{}(std::get<0>(t));
-        h ^= std::hash<int>{}(std::get<1>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(std::get<2>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(std::get<3>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(std::get<4>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-        h ^= std::hash<int>{}(std::get<5>(t)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        size_t h = std::hash<std::string_view>{}(k.gfx);
+        h ^= std::hash<int>{}(k.cu_num) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.B) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.M) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.N) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(k.K) + 0x9e3779b9 + (h << 6) + (h >> 2);
         return h;
+    }
+};
+
+struct BatchedGemmLookupKeyEq
+{
+    bool operator()(const BatchedGemmLookupKey& a, const BatchedGemmLookupKey& b) const noexcept
+    {
+        return a.cu_num == b.cu_num && a.B == b.B && a.M == b.M && a.N == b.N && a.K == b.K &&
+               a.gfx == b.gfx;
     }
 };
 
 // ---------------------------------------------------------------------------
 // BatchedGemmDispatchMap
 //
-// Convenience alias for the (gfx, cu_num, B, M, N, K)-keyed dispatch map type.
-// Used by batched GEMM modules:
+// Convenience alias for the (gfx, cu_num, B, M, N, K)-keyed dispatch map
+// used by batched GEMM modules:
 //
 //   using BatchedRowwiseKernelMap = BatchedGemmDispatchMap<BatchedRowwiseKernel>;
 // ---------------------------------------------------------------------------
 template <typename KernelFn>
-using BatchedGemmDispatchMap =
-    std::unordered_map<std::tuple<std::string, int, int, int, int, int>,
-                       KernelFn,
-                       BatchedGemmDispatchHash>;
+using BatchedGemmDispatchMap = std::
+    unordered_map<BatchedGemmLookupKey, KernelFn, BatchedGemmLookupKeyHash, BatchedGemmLookupKeyEq>;
 
 #endif // USE_ROCM


### PR DESCRIPTION
…speedup

Refactor the shared GemmDispatchMap / BatchedGemmDispatchMap dispatch tables and all 10 consumer .cu files from

    std::unordered_map<std::tuple<std::string,int,int,int,int>, std::function<...>>

to

    std::unordered_map<GemmLookupKey, KernelFnPtr, GemmLookupKeyHash, GemmLookupKeyEq>

where GemmLookupKey is a POD `{std::string_view gfx; int cu_num,M,N,K;}` and KernelFnPtr is a raw function pointer.

-ftime-report attributed the baseline cost to greedy regalloc and machine code generation on one huge lambda where each of the 14869 non-trivial pair constructors had its own exception-cleanup landing pad.

With POD key + raw fn ptr the 14869-entry table is constant-initialized into .data.rel.ro instead of being constructed inline as ~13k pair ctors with exception-cleanup landing pads, and each dispatch lambda collapses to memcpy + one hashtable range-insert call.

Also: `get_device_gfx()` returns `std::string_view` directly (cached std::string lives forever in a function-local static unordered_map).

Measurements on the gemm_a8w8_blockscale dispatch TU (14869 entries):

    wall      2505 s -> 43 s     (~58x)
    .o size   12.8 MB -> 2.7 MB  (~5x)
    peak RSS  ~14 GB -> ~150 MB  (~90x)

The other 9 modules share the same shared-header types and scale the same.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
