### PR TITLE
Fused ar(use_new=false) + rmsnorm

### DIFF
--- a/aiter/dist/communication_op.py
+++ b/aiter/dist/communication_op.py
@@ -66,10 +66,11 @@ def tensor_model_parallel_fused_allreduce_rmsnorm(
     weight_: torch.Tensor,
     eps: float,
     prefill_support: bool = False,
+    use_new: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     _assert_no_custom_group("tensor_model_parallel_fused_allreduce_rmsnorm")
     return get_tp_group().fused_allreduce_rmsnorm(
-        input_, residual_inp_, weight_, eps, prefill_support
+        input_, residual_inp_, weight_, eps, prefill_support, use_new=use_new
     )
 
 

--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -199,6 +199,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         weight_,
         eps,
         prefill_support: bool = False,
+        use_new: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         n = input_.shape[-1]
         total_bytes = input_.numel() * input_.element_size()
@@ -218,7 +219,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 else (total_bytes <= 128 * 1024)
             )
             out, res_out = ca_comm.custom_fused_ar_rms(
-                input_, res_inp_, weight_, eps, use_1stage
+                input_, res_inp_, weight_, eps, use_1stage, use_new=use_new
             )
             assert out is not None
             assert res_out is not None

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -685,6 +685,7 @@ class CustomAllreduce:
         registered: bool = False,
         use_1stage: bool = False,
         post_per_token_quant: bool = False,
+        use_new: bool = True,
     ):
         if res_out is None:
             res_out = torch.empty_like(inp)
@@ -705,6 +706,7 @@ class CustomAllreduce:
                 reg,
                 reg_bytes,
                 use_1stage,
+                use_new,
             )
             return out, res_out
         else:
@@ -737,10 +739,16 @@ class CustomAllreduce:
         weight: torch.Tensor,
         eps: float,
         use_1stage: bool,
+        use_new: bool = True,
     ) -> Optional[torch.Tensor]:
         # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
             return None
+        if not use_new and input.shape[0] <= 80:
+            # The legacy-CA single-kernel path supports up to kMaxBlocks (80)
+            # tokens. Prefer it over the use-new byte threshold to keep graph
+            # capture on the single-kernel path for decode-sized batches.
+            use_1stage = True
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
                 return self.fused_ar_rms(
@@ -750,6 +758,7 @@ class CustomAllreduce:
                     eps=eps,
                     registered=True,
                     use_1stage=use_1stage,
+                    use_new=use_new,
                 )
             else:
                 return torch.zeros_like(input), torch.zeros_like(input)
@@ -761,6 +770,7 @@ class CustomAllreduce:
                 eps=eps,
                 registered=False,
                 use_1stage=use_1stage,
+                use_new=use_new,
             )
 
     def custom_fused_ar_rms_quant(

--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -456,7 +456,20 @@ class GroupCoordinator:
         weight_: torch.Tensor,
         eps: float,
         prefill_support: bool = False,
+        use_new: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        # The torch_compile_guard-wrapped dispatcher does not expose the
+        # custom-AR version selector, so call the out-place path directly
+        # when the caller requests the legacy path.
+        if not use_new:
+            return self._fused_allreduce_rmsnorm_out_place(
+                input_,
+                residual_inp_,
+                weight_,
+                eps,
+                prefill_support,
+                use_new=False,
+            )
         return fused_allreduce_rmsnorm_(
             input_,
             residual_inp_,
@@ -520,6 +533,7 @@ class GroupCoordinator:
         weight_: torch.Tensor,
         eps: float,
         prefill_support: bool = False,
+        use_new: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.device_communicator is None:
             raise ValueError("No device communicator found")
@@ -529,6 +543,7 @@ class GroupCoordinator:
             weight_,
             eps,
             prefill_support,
+            use_new=use_new,
         )
 
     def _fused_allreduce_rmsnorm_quant_out_place(

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -76,6 +76,7 @@ def fused_allreduce_rmsnorm(
     reg_ptr: int,
     reg_bytes: int,
     use_1stage: bool,
+    use_new: bool = True,
 ) -> None: ...
 
 

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -1820,6 +1820,198 @@ void allreduce_fusion_kernel_1stage_launcher(RankData* _dp,
                                                     eps);
 }
 
+template <typename T, typename OutT, int ngpus>
+__global__ void __launch_bounds__(1024, 1)
+    allreduce_fusion_kernel_1stage_old_ca(RankData* _dp,
+                                          RankSignals sg,
+                                          Signal* self_sg,
+                                          int rank,
+                                          T* __restrict__ residual_inp,
+                                          T* __restrict__ residual_out,
+                                          OutT* __restrict__ output,
+                                          T* __restrict__ weight,
+                                          float* __restrict__ scale_out,
+                                          int size,
+                                          int hidden_dim,
+                                          float eps)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    int block_size          = hidden_dim / pack_size;
+    bool active             = (int)threadIdx.x < block_size;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int tidx                = blockIdx.x;
+    int access_id_in_token  = threadIdx.x * pack_size;
+    int idx                 = tidx * hidden_dim + access_id_in_token;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        ptrs[i] = (const P*)_dp->ptrs[i];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    A acc{};
+    P vec{};
+    P weight_p{};
+    if(active)
+    {
+        vec = ptrs[0][idx / pack_size];
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            acc[v] = upcast_s(vec[v]);
+        }
+
+#pragma unroll
+        for(int r = 1; r < ngpus; ++r)
+        {
+            vec = ptrs[r][idx / pack_size];
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+            {
+                acc[v] += upcast_s(vec[v]);
+            }
+        }
+
+        // Match unfused allreduce -> bf16/fp16 -> residual-add numerics.
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            acc[v] = upcast_s(downcast_s<T>(acc[v]));
+        }
+
+        P res = *reinterpret_cast<P*>(residual_inp + idx);
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            acc[v] += upcast_s(res[v]);
+        }
+
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+        {
+            vec[v] = downcast_s<T>(acc[v]);
+        }
+        *reinterpret_cast<P*>(residual_out + idx) = vec;
+        weight_p = *reinterpret_cast<P*>(weight + access_id_in_token);
+    }
+
+    int padded_block_size = (int)blockDim.x;
+    ar_fusion_epilogue<P, A, T, OutT, pack_size>(
+        acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size, output, scale_out, active);
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+template <typename T, typename OutT, int NGPUS>
+void allreduce_fusion_kernel_1stage_old_ca_launcher(RankData* _dp,
+                                                    RankSignals sg,
+                                                    Signal* self_sg,
+                                                    int rank,
+                                                    T* residual_inp,
+                                                    T* residual_out,
+                                                    OutT* output,
+                                                    T* weight,
+                                                    float* scale_out,
+                                                    int size,
+                                                    int hidden_dim,
+                                                    float eps,
+                                                    hipStream_t stream)
+{
+    constexpr int PACK_SIZE  = 16 / sizeof(T);
+    constexpr int WARP_SIZE  = 32;
+    int BLOCK_SIZE           = hidden_dim / PACK_SIZE;
+    int LAUNCH_THREADS       = ((BLOCK_SIZE + WARP_SIZE - 1) / WARP_SIZE) * WARP_SIZE;
+    int token_num            = size / hidden_dim;
+    if(token_num > kMaxBlocks)
+        throw std::runtime_error(
+            "Token number is too large for allreduce_fusion_kernel_1stage_old_ca kernel");
+    dim3 threadsPerBlock(LAUNCH_THREADS);
+    dim3 numBlocks(token_num);
+    allreduce_fusion_kernel_1stage_old_ca<T, OutT, NGPUS>
+        <<<numBlocks, threadsPerBlock, 0, stream>>>(_dp,
+                                                    sg,
+                                                    self_sg,
+                                                    rank,
+                                                    residual_inp,
+                                                    residual_out,
+                                                    output,
+                                                    weight,
+                                                    scale_out,
+                                                    size,
+                                                    hidden_dim,
+                                                    eps);
+}
+
+template <typename T, int tnum, int n_loop>
+__global__ void __launch_bounds__(tnum, 1) local_tensor_load_rmsnorm_old_ca(
+    T* __restrict__ reduce_out,
+    T* __restrict__ residual_inp,
+    T* __restrict__ residual_out,
+    T* __restrict__ output,
+    T* __restrict__ weight,
+    float eps,
+    int m,
+    int n)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    __shared__ float smem[tnum];
+
+    for(int bid = blockIdx.x; bid < m; bid += gridDim.x)
+    {
+        float square_sum = 0.0f;
+        A rms_inp_f32[n_loop];
+        P w_arr[n_loop];
+#pragma unroll
+        for(int n_iter = 0; n_iter < n_loop; ++n_iter)
+        {
+            if(n_iter * tnum + threadIdx.x < (n / pack_size))
+            {
+                int read_idx        = bid * (n / pack_size) + n_iter * tnum + threadIdx.x;
+                P reduce_out_pack   = *(reinterpret_cast<P*>(reduce_out) + read_idx);
+                P residual_inp_pack = *(reinterpret_cast<P*>(residual_inp) + read_idx);
+                w_arr[n_iter]       = *(reinterpret_cast<P*>(weight) + n_iter * tnum + threadIdx.x);
+                A reduce_pack;
+#pragma unroll
+                for(int i = 0; i < pack_size; ++i)
+                {
+                    float rms_inp = upcast_s(reduce_out_pack[i]) + upcast_s(residual_inp_pack[i]);
+                    rms_inp_f32[n_iter][i] = rms_inp;
+                    reduce_pack[i] = rms_inp * rms_inp;
+                }
+                square_sum += packReduce<AddFunctor, float, pack_size>(reduce_pack);
+            }
+        }
+        smem[threadIdx.x] = square_sum;
+        __syncthreads();
+        smemReduceSum<tnum>(&smem[0]);
+        float denom = rsqrtf(smem[0] / n + eps);
+
+#pragma unroll
+        for(int n_iter = 0; n_iter < n_loop; ++n_iter)
+        {
+            if(n_iter * tnum + threadIdx.x < (n / pack_size))
+            {
+                P rmsnorm_rslt;
+                P rmsnorm_inp;
+#pragma unroll
+                for(int i = 0; i < pack_size; ++i)
+                {
+                    float x_f32     = rms_inp_f32[n_iter][i];
+                    float w_f32     = upcast_s(w_arr[n_iter][i]);
+                    rmsnorm_inp[i]  = downcast_s<T>(x_f32);
+                    rmsnorm_rslt[i] = downcast_s<T>(x_f32 * w_f32 * denom);
+                }
+                int write_idx = bid * (n / pack_size) + n_iter * tnum + threadIdx.x;
+                *(reinterpret_cast<P*>(output) + write_idx)       = rmsnorm_rslt;
+                *(reinterpret_cast<P*>(residual_out) + write_idx) = rmsnorm_inp;
+            }
+        }
+    }
+}
+
 template <typename T, int ngpus, int WARP_SIZE>
 __global__ void __launch_bounds__(1024, 1)
     qknorm_allreduce_fusion_kernel_2stage(RankData* _dp,
@@ -3111,7 +3303,8 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
                                    float eps,
                                    int m,
                                    int n,
-                                   bool use_1stage)
+                                   bool use_1stage,
+                                   bool use_new = true)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -3130,6 +3323,99 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
 
     auto pack_size = 16 / sizeof(T);
     use_1stage     = use_1stage && (n % pack_size == 0) && (n / pack_size <= 1024);
+
+    if(!use_new)
+    {
+        if(use_1stage)
+        {
+#define DISPATCH_OLD_CA_1S_KERNEL(NGPUS)                                      \
+    allreduce_fusion_kernel_1stage_old_ca_launcher<T, T, NGPUS>(ptrs,          \
+                                                               sg_,            \
+                                                               self_sg_,       \
+                                                               rank_,          \
+                                                               residual_inp,   \
+                                                               residual_out,   \
+                                                               output,         \
+                                                               weight,         \
+                                                               nullptr,        \
+                                                               size,           \
+                                                               n,              \
+                                                               eps,            \
+                                                               stream);        \
+    return;
+            switch(world_size_)
+            {
+            case 8: DISPATCH_OLD_CA_1S_KERNEL(8); break;
+            case 4: DISPATCH_OLD_CA_1S_KERNEL(4); break;
+            case 2: DISPATCH_OLD_CA_1S_KERNEL(2); break;
+            default:
+                throw std::runtime_error(
+                    "old-CA fused allreduce rmsnorm: unsupported world_size=" +
+                    std::to_string(world_size_));
+            }
+#undef DISPATCH_OLD_CA_1S_KERNEL
+        }
+
+        allreduce<T>(stream, input, residual_out, size, /*use_new=*/false);
+
+        dim3 block(512);
+        dim3 grid;
+        auto setGrid = [&](int naive_grid_size, const void* kernel_ptr) {
+            int occupancy;
+            hipOccupancyMaxActiveBlocksPerMultiprocessor(&occupancy, kernel_ptr, block.x, 0);
+            grid.x = naive_grid_size < num_cu * occupancy ? naive_grid_size : num_cu * occupancy;
+        };
+
+#define LAUNCH_OLD_CA_RMS_SPLIT(template_kernel)                               \
+    do                                                                         \
+    {                                                                          \
+        auto kernel_ptr = reinterpret_cast<const void*>(template_kernel);      \
+        setGrid(naive_grid_size, kernel_ptr);                                  \
+        template_kernel<<<grid, block, 0, stream>>>(                           \
+            residual_out, residual_inp, residual_out, output, weight, eps, m, n); \
+    } while(0)
+
+        constexpr int ar_pack_size = 16 / sizeof(T);
+        int n_packs                = n / ar_pack_size;
+        int naive_grid_size        = m;
+        if(n_packs >= 256)
+        {
+            int n_loop = (n_packs + 511) / 512;
+            switch(n_loop)
+            {
+            case 1: LAUNCH_OLD_CA_RMS_SPLIT((local_tensor_load_rmsnorm_old_ca<T, 512, 1>)); break;
+            case 2: LAUNCH_OLD_CA_RMS_SPLIT((local_tensor_load_rmsnorm_old_ca<T, 512, 2>)); break;
+            case 3: LAUNCH_OLD_CA_RMS_SPLIT((local_tensor_load_rmsnorm_old_ca<T, 512, 3>)); break;
+            case 4: LAUNCH_OLD_CA_RMS_SPLIT((local_tensor_load_rmsnorm_old_ca<T, 512, 4>)); break;
+            default:
+                throw std::runtime_error(
+                    "old-CA fused allreduce rmsnorm: n too large, m=" +
+                    std::to_string(m) + " n=" + std::to_string(n));
+            }
+        }
+        else if(n_packs >= 64)
+        {
+            block.x    = 256;
+            int n_loop = (n_packs + 255) / 256;
+            switch(n_loop)
+            {
+            case 1: LAUNCH_OLD_CA_RMS_SPLIT((local_tensor_load_rmsnorm_old_ca<T, 256, 1>)); break;
+            case 2: LAUNCH_OLD_CA_RMS_SPLIT((local_tensor_load_rmsnorm_old_ca<T, 256, 2>)); break;
+            default:
+                throw std::runtime_error(
+                    "old-CA fused allreduce rmsnorm: n too large for tnum=256, m=" +
+                    std::to_string(m) + " n=" + std::to_string(n));
+            }
+        }
+        else
+        {
+            throw std::runtime_error(
+                "old-CA fused allreduce rmsnorm: n too small, m=" + std::to_string(m) +
+                " n=" + std::to_string(n) + " n_packs=" + std::to_string(n_packs));
+        }
+#undef LAUNCH_OLD_CA_RMS_SPLIT
+        return;
+    }
 #define MAYBE_DISPATCH_1S_KERNEL(NGPUS)                                            \
     if(use_1stage)                                                                 \
     {                                                                              \

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -62,7 +62,8 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
                              double eps,
                              int64_t reg_ptr,
                              int64_t reg_bytes,
-                             bool use_1stage);
+                             bool use_1stage,
+                             bool use_new = true);
 void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    const aiter_tensor_t& inp,
                                    const aiter_tensor_t& res_inp,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -442,7 +442,8 @@ namespace py = pybind11;
           py::arg("eps"),                                                                      \
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"),                                                                \
-          py::arg("use_1stage"));                                                              \
+          py::arg("use_1stage"),                                                               \
+          py::arg("use_new") = true);                                                          \
     m.def("fused_allreduce_rmsnorm_quant",                                                     \
           &aiter::fused_allreduce_rmsnorm_quant,                                               \
           py::arg("_fa"),                                                                      \

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -194,7 +194,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
                                      void* scale_out, void* w,
                                      AiterDtype dtype, float eps,
                                      int m, int n,
-                                     bool use_1stage)
+                                     bool use_1stage,
+                                     bool use_new = true)
 {
     hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
@@ -213,7 +214,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
             eps,                                                 \
             m,                                                   \
             n,                                                   \
-            use_1stage);                                         \
+            use_1stage,                                          \
+            use_new);                                            \
     }                                                            \
     else                                                         \
     {                                                            \
@@ -451,7 +453,8 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
                              const aiter_tensor_t& w,
                              double eps,
                              int64_t reg_ptr, int64_t reg_bytes,
-                             bool use_1stage)
+                             bool use_1stage,
+                             bool use_new)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -470,14 +473,14 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
         _fused_allreduce_rmsnorm(_fa,
                                  (void*)reg_ptr, res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, n, use_1stage);
+                                 dtype, (float)eps, m, n, use_1stage, use_new);
     }
     else
     {
         _fused_allreduce_rmsnorm(_fa,
                                  inp.data_ptr(), res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, n, use_1stage);
+                                 dtype, (float)eps, m, n, use_1stage, use_new);
     }
 }
 

--- a/op_tests/multigpu_tests/test_fused_ar_rms.py
+++ b/op_tests/multigpu_tests/test_fused_ar_rms.py
@@ -50,6 +50,7 @@ def fused_ar_rmsnorm(
     withGraph=False,
     distributed_init_method: Optional[str] = None,
     post_per_token_quant: bool = False,
+    use_new: bool = True,
 ):
     device = torch.device(f"cuda:{rankID}")
     torch.cuda.set_device(device)
@@ -77,7 +78,7 @@ def fused_ar_rmsnorm(
             with torch.cuda.graph(graph, stream=gc.stream):
                 if not post_per_token_quant:
                     out, res_out = tensor_model_parallel_fused_allreduce_rmsnorm(
-                        x, x, weight, eps
+                        x, x, weight, eps, use_new=use_new
                     )
                 else:
                     out, res_out, scale_out = (
@@ -94,16 +95,16 @@ def fused_ar_rmsnorm(
 
         _, us = run_ca()
         if not post_per_token_quant:
-            out = (out, us)
+            out = (rankID, out.cpu(), us)
         else:
-            out = (out.float() * scale_out, us)
+            out = (rankID, (out.float() * scale_out).cpu(), us)
     else:
 
         @perftest()
         def run_ca(x):
             if not post_per_token_quant:
                 out, res_out = tensor_model_parallel_fused_allreduce_rmsnorm(
-                    x, x, weight, eps
+                    x, x, weight, eps, use_new=use_new
                 )
                 return out
             else:
@@ -114,11 +115,11 @@ def fused_ar_rmsnorm(
                 )
                 return out, scale_out
 
+        result, us = run_ca(x)
         if not post_per_token_quant:
-            out = run_ca(x)
+            out = (rankID, result.cpu(), us)
         else:
-            out = run_ca(x)
-            out = (out[0][0].float() * out[0][1], out[1])
+            out = (rankID, (result[0].float() * result[1]).cpu(), us)
 
     # destroy
     if dist.is_initialized():
@@ -317,6 +318,7 @@ def test_fused_ar_rmsnorm(
     withGraph=False,
     distributed_init_method: Optional[str] = None,
     post_per_token_quant: bool = False,
+    use_new: bool = True,
 ):
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = "49373"
@@ -348,6 +350,7 @@ def test_fused_ar_rmsnorm(
                     withGraph,
                     distributed_init_method,
                     post_per_token_quant,
+                    use_new,
                 ),
             )
         )
@@ -366,20 +369,23 @@ def test_fused_ar_rmsnorm(
         cpu_rslt.append(host_rslt)
 
     rets = [el.get() for el in rets]
-    all_us = [us for _, us in rets]
+    all_us = [us for _, _, us in rets]
     atol = 5e-2 if post_per_token_quant else 1e-2
     rtol = atol
     max_err = 0.0
-    for out, us in rets:
-        msg = f"test_fused_ar_rmsnorm: {shape=} {dtype=} {withGraph=} {us:>8.2f}"
-        # print(cpu_rslt[out.device.index])
+    for rank_idx, out, us in rets:
+        msg = (
+            f"test_fused_ar_rmsnorm: {shape=} {dtype=} {withGraph=} "
+            f"{use_new=} {us:>8.2f}"
+        )
         err = checkAllclose(
-            cpu_rslt[out.device.index], out.to(ref), msg=msg, atol=atol, rtol=rtol
+            cpu_rslt[rank_idx], out.to(ref), msg=msg, atol=atol, rtol=rtol
         )
         max_err = max(max_err, err)
         # checkAllclose(ref, out.to(ref), msg=msg)
     suffix = "quant" if post_per_token_quant else "fused"
     return {
+        "use_new": use_new,
         f"{suffix}_min_us": min(all_us),
         f"{suffix}_max_us": max(all_us),
         f"{suffix}_err": max_err,
@@ -400,6 +406,7 @@ l_shape = [
 l_tp = [8]
 l_pp = [1]
 l_graph = [False, True]
+l_use_new = [True]
 
 parser = argparse.ArgumentParser(description="config input of test")
 parser.add_argument(
@@ -460,6 +467,13 @@ parser.add_argument(
     default=None,
     help="test type(s) to run. e.g. --test fused quant",
 )
+parser.add_argument(
+    "--use-new",
+    type=int,
+    choices=[0, 1],
+    default=1,
+    help="select custom all-reduce version for fused AR+RMSNorm; 0 uses legacy CA",
+)
 
 
 if __name__ == "__main__":
@@ -478,10 +492,11 @@ if __name__ == "__main__":
     if args.graphon is not None:
         print(args.graphon)
         l_graph = [args.graphon]
+    l_use_new = [bool(args.use_new)]
     run_tests = args.test if args.test else l_test_types
     df = []
-    for dtype, shape, tp, pp, graph_on in itertools.product(
-        l_dtype, l_shape, l_tp, l_pp, l_graph
+    for dtype, shape, tp, pp, graph_on, use_new in itertools.product(
+        l_dtype, l_shape, l_tp, l_pp, l_graph, l_use_new
     ):
         row = {}
         if "fused" in run_tests:
@@ -495,6 +510,7 @@ if __name__ == "__main__":
                     get_ip(), get_open_port()
                 ),
                 post_per_token_quant=False,
+                use_new=use_new,
             )
             row.update(ret)
         if "quant" in run_tests:
@@ -508,6 +524,7 @@ if __name__ == "__main__":
                     get_ip(), get_open_port()
                 ),
                 post_per_token_quant=True,
+                use_new=use_new,
             )
             row.update(ret)
         df.append(row)
@@ -517,6 +534,7 @@ if __name__ == "__main__":
         "shape",
         "dtype",
         "withGraph",
+        "use_new",
         "fused_min_us",
         "fused_max_us",
         "fused_err",


### PR DESCRIPTION
Fix the pre-existing allreduce kernel core dump in MoE and Dense model stress tests by enabling the fused `custom allreduce (use_new=false) + residual add + RMSNorm` path, which is not yet available on AITER main.

## Motivation
AITER main already has a fused `allreduce + residual add + RMSNorm` path for the newer custom allreduce implementation (`use_new=true`). However, stress tests for MoE and Dense models can hit a pre-existing allreduce kernel core dump with `use_new=true`.
This PR extends the existing fused AR+RMSNorm entry to also support the legacy custom allreduce path (`use_new=false`). This keeps the public control aligned with the existing AITER `use_new` convention while allowing users to avoid the problematic `use_new=true` allreduce path and still keep AR+RMSNorm fused.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- Extend the existing fused `allreduce + residual add + RMSNorm` API to accept `use_new`.
  - `use_new=true` remains the default and keeps the current main-branch behavior.
  - `use_new=false` selects the legacy custom allreduce synchronization path.
- Add an old-CA fused 1-stage kernel path for `use_new=false`.
  - Uses legacy CA start/end synchronization.
  - Preserves the same fused semantics: `allreduce(input) + residual -> RMSNorm`.
- Keep graph decode-sized batches on the 1-stage path for legacy CA.
  - For `use_new=false` and `m <= 80`, force the 1-stage path to avoid graph capture falling into the split path.
- Add a legacy CA split fallback for larger eager cases.
  - Runs legacy custom allreduce first, then local residual add + RMSNorm.
- Update Python wrappers and bindings consistently:
  - `communication_op.py`
  - `parallel_state.py`
  - `communicator_cuda.py`
  - `custom_all_reduce.py`
  - pybind / C++ headers
- Extend `op_tests/multigpu_tests/test_fused_ar_rms.py`.
  - Add `--use-new 0/1`.
  - Return CPU tensors from worker processes to avoid CUDA IPC issues during graph tests.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
```
PYTHONPATH=/opt/upstream_for_fusion_allreduce_old/aiter \
HSA_NO_SCRATCH_RECLAIM=1 \
python3 op_tests/multigpu_tests/test_fused_ar_rms.py \
  --test fused --use-new 0 -d bf16 -s 24,4096 -t 8 -p 1 -g 1
```
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
```
use_new=false, m=24, cuda graph: passed, fused_err=0.
use_new=false, m=1, cuda graph: passed, fused_err=0.
use_new=true, m=1, cuda graph: passed, fused_err=0.
Python compile checks passed.
No linter errors were reported for edited Python files.
```
Performance sanity check showed no meaningful regression:
```
use_new=false, m=24, graph: around 15-16 us.
use_new=false, m=1, graph: around 8-9 us.
use_new=true, m=1, graph: around 6.7-7.7 us.
```
<!-- Briefly summarize test outcomes. -->
Qwen3.5-397B-A17B TP8 CC16 apply in decode phase:
- before
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     16        
Benchmark duration (s):                  21.07     
Total input tokens:                      71656     
Total input text tokens:                 71656     
Total generated tokens:                  7916      
Total generated tokens (retokenized):    7891      
Request throughput (req/s):              0.76      
Input token throughput (tok/s):          3400.58   
Output token throughput (tok/s):         375.67    
Peak output token throughput (tok/s):    736.00    
Peak concurrent requests:                16        
Total token throughput (tok/s):          3776.25   
Concurrency:                             10.98     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   14455.75  
Median E2E Latency (ms):                 13762.36  
P90 E2E Latency (ms):                    20876.69  
P99 E2E Latency (ms):                    21032.41  
---------------Time to First Token----------------
Mean TTFT (ms):                          4393.34   
Median TTFT (ms):                        4643.51   
P99 TTFT (ms):                           4733.77   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.35     
Median TPOT (ms):                        21.09     
P99 TPOT (ms):                           30.59     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           20.38     
Median ITL (ms):                         21.57     
P95 ITL (ms):                            22.60     
P99 ITL (ms):                            22.77     
Max ITL (ms):                            4219.24   
==================================================
```
- after
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     16        
Benchmark duration (s):                  20.88     
Total input tokens:                      71656     
Total input text tokens:                 71656     
Total generated tokens:                  7916      
Total generated tokens (retokenized):    7903      
Request throughput (req/s):              0.77      
Input token throughput (tok/s):          3431.08   
Output token throughput (tok/s):         379.04    
Peak output token throughput (tok/s):    752.00    
Peak concurrent requests:                16        
Total token throughput (tok/s):          3810.12   
Concurrency:                             10.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   14351.47  
Median E2E Latency (ms):                 13669.63  
P90 E2E Latency (ms):                    20692.43  
P99 E2E Latency (ms):                    20845.45  
---------------Time to First Token----------------
Mean TTFT (ms):                          4413.86   
Median TTFT (ms):                        4666.61   
P99 TTFT (ms):                           4731.50   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.08     
Median TPOT (ms):                        20.82     
P99 TPOT (ms):                           30.34     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           20.13     
Median ITL (ms):                         21.34     
P95 ITL (ms):                            22.33     
P99 ITL (ms):                            22.48     
Max ITL (ms):                            4201.16   
==================================================
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
