### PR TITLE
[Triton] [ATOM] remove near-MOE torch kernels

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -798,6 +798,9 @@ def _flydsl_stage2_wrapper(
         persist=parsed.get("persist", None),
         bias=bias2,
         xcd_swizzle=parsed.get("xcd_swizzle", 0),
+        out_already_filled_with_zeros=_kwargs.get(
+            "out_already_filled_with_zeros", "False"
+        ),
     )
 
 
@@ -1571,6 +1574,8 @@ def fused_moe_2stages(
             extra_stage2_args["bias2"] = _normalize_bias_for_kernel(bias2)
     if metadata.stage1.func is _flydsl_stage1_wrapper:
         extra_stage1_args["swiglu_limit"] = swiglu_limit
+    if metadata.stage2.func is _flydsl_stage2_wrapper:
+        extra_stage2_args["out_already_filled_with_zeros"] = True
     a2 = metadata.stage1(
         a1,
         w1,

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1040,6 +1040,7 @@ def flydsl_moe_stage2(
     inter_dim_pad: int = 0,
     xcd_swizzle: int = 0,
     bias: Optional[torch.Tensor] = None,
+    out_already_filled_with_zeros: Optional[bool] = False,
 ) -> torch.Tensor:
     """Down-projection GEMM (MOE stage2). Supports atomic/reduce modes.
 
@@ -1070,7 +1071,7 @@ def flydsl_moe_stage2(
         out = alloc_fn(
             (token_num, model_dim), dtype=torch_out_dtype, device=inter_states.device
         )
-    elif accumulate:
+    elif accumulate and not out_already_filled_with_zeros:
         out.fill_(0)
 
     dev = inter_states.device

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a16w16_copy_x.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a16w16_copy_x.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import triton.language as tl
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
+from aiter.ops.triton.utils.gemm_config_utils import (
+    compute_splitk_params,
+    get_gemm_config,
+)
+
+import triton
+
+_fused_gemm_a16w16_copy_x_repr = make_kernel_repr(
+    "_fused_gemm_a16w16_copy_x_kernel",
+    [
+        "BLOCK_SIZE_M",
+        "BLOCK_SIZE_N",
+        "BLOCK_SIZE_K",
+        "GROUP_SIZE_M",
+        "NUM_KSPLIT",
+        "SPLITK_BLOCK_SIZE",
+        "EVEN_K",
+        "EVEN_MN",
+        "cache_modifier",
+        "activation",
+        "use_activation",
+        "ADD_BIAS",
+        "SKIP_REDUCE",
+    ],
+)
+
+
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: (args["K"] % (args["SPLITK_BLOCK_SIZE"]) == 0)
+        and (args["SPLITK_BLOCK_SIZE"] % args["BLOCK_SIZE_K"] == 0),
+        "EVEN_MN": lambda args: (args["M"] % args["BLOCK_SIZE_M"] == 0)
+        and (args["N"] % args["BLOCK_SIZE_N"] == 0),
+    }
+)
+@triton.jit(
+    repr=_fused_gemm_a16w16_copy_x_repr,
+    do_not_specialize=["M", "N"],
+)
+def _fused_gemm_a16w16_copy_x_kernel(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    c_ptr,
+    a_copy_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_ck,
+    stride_cm,
+    stride_cn,
+    stride_a_copy_m,
+    stride_a_copy_k,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_KSPLIT: tl.constexpr,
+    SPLITK_BLOCK_SIZE: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    EVEN_MN: tl.constexpr,
+    cache_modifier: tl.constexpr,
+    activation: tl.constexpr,
+    use_activation: tl.constexpr,
+    ADD_BIAS: tl.constexpr,
+    SKIP_REDUCE: tl.constexpr,
+):
+    """Kernel that computes C = A x B and also emits a downcasted copy of A.
+
+    The grid is laid out as a single 1D program-id space split into two
+    contiguous regions:
+
+      * `[0, NUM_KSPLIT * num_pid_m * num_pid_n)` runs the GEMM (identical to
+        the unfused a16w16 kernel).
+      * `[NUM_KSPLIT * num_pid_m * num_pid_n, GEMM_GRID + num_pid_m * num_pid_k_copy)`
+        runs the pure downcast-copy of A: each program handles one
+        `BLOCK_SIZE_M x BLOCK_SIZE_K` tile of A and writes it to `a_copy_ptr`.
+
+    Decoupling the copy from the GEMM body keeps the GEMM hot loop unchanged
+    and lets the copy programs schedule independently.
+    """
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_ck > 0)
+    tl.assume(stride_cm > 0)
+    tl.assume(stride_cn > 0)
+    tl.assume(stride_a_copy_m > 0)
+    tl.assume(stride_a_copy_k > 0)
+
+    pid_unified = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_k_copy = tl.cdiv(K, BLOCK_SIZE_K)
+    GEMM_GRID = num_pid_m * num_pid_n * NUM_KSPLIT
+
+    if pid_unified < GEMM_GRID:
+        # ---- GEMM branch ----------------------------------------------------
+        pid_unified = remap_xcd(pid_unified, GEMM_GRID, NUM_XCDS=8)
+        pid_k = pid_unified % NUM_KSPLIT
+        pid = pid_unified // NUM_KSPLIT
+
+        if NUM_KSPLIT == 1:
+            pid_m, pid_n = pid_grid(
+                pid, num_pid_m, num_pid_n, GROUP_SIZE_M=GROUP_SIZE_M
+            )
+        else:
+            pid_m = pid // num_pid_n
+            pid_n = pid % num_pid_n
+
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_n >= 0)
+        tl.assume(pid_k >= 0)
+
+        split_k_start = pid_k * SPLITK_BLOCK_SIZE
+        if split_k_start < K:
+            offs_k = tl.arange(0, BLOCK_SIZE_K)
+            offs_k_split = split_k_start + offs_k
+            if EVEN_MN:
+                offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+                offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            else:
+                offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+                offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+            a_ptrs = a_ptr + (
+                offs_am[:, None] * stride_am + offs_k_split[None, :] * stride_ak
+            )
+            b_ptrs = b_ptr + (
+                offs_k_split[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+            )
+
+            acc_dtype = tl.float32 if c_ptr.type.element_ty != tl.int8 else tl.int32
+            if ADD_BIAS:
+                if NUM_KSPLIT == 1 or (SKIP_REDUCE and pid_k == 0):
+                    accumulator = tl.load(bias_ptr + offs_bn).to(dtype=acc_dtype)
+                    accumulator = tl.broadcast_to(
+                        accumulator[None, :], (BLOCK_SIZE_M, BLOCK_SIZE_N)
+                    )
+                else:
+                    accumulator = tl.zeros(
+                        (BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype
+                    )
+            else:
+                accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+            split_k_end = tl.minimum(split_k_start + SPLITK_BLOCK_SIZE, K)
+            k_span = split_k_end - split_k_start
+            num_k_iter = tl.cdiv(k_span, BLOCK_SIZE_K)
+
+            for k in range(num_k_iter):
+                if EVEN_K:
+                    a = tl.load(a_ptrs)
+                    b = tl.load(b_ptrs, cache_modifier=cache_modifier)
+                else:
+                    a = tl.load(
+                        a_ptrs,
+                        mask=offs_k[None, :] < k_span - k * BLOCK_SIZE_K,
+                        other=0.0,
+                    )
+                    b = tl.load(
+                        b_ptrs,
+                        mask=offs_k[:, None] < k_span - k * BLOCK_SIZE_K,
+                        other=0.0,
+                        cache_modifier=cache_modifier,
+                    )
+                accumulator += tl.dot(a, b)
+                a_ptrs += BLOCK_SIZE_K * stride_ak
+                b_ptrs += BLOCK_SIZE_K * stride_bk
+
+            if use_activation and NUM_KSPLIT == 1:
+                accumulator = activation(accumulator)
+
+            c = accumulator.to(c_ptr.type.element_ty)
+            offs_cm = pid_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            offs_cn = pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            c_ptrs = (
+                c_ptr
+                + stride_cm * offs_cm[:, None]
+                + stride_cn * offs_cn[None, :]
+                + pid_k * stride_ck
+            )
+            if EVEN_MN:
+                tl.store(c_ptrs, c)
+            else:
+                c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+                tl.store(c_ptrs, c, mask=c_mask)
+    else:
+        # ---- Downcast-copy branch ------------------------------------------
+        pid_copy = pid_unified - GEMM_GRID
+        pid_m = pid_copy // num_pid_k_copy
+        pid_k = pid_copy % num_pid_k_copy
+
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_k >= 0)
+
+        offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_k = pid_k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+
+        a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
+        a_copy_ptrs = a_copy_ptr + (
+            offs_m[:, None] * stride_a_copy_m + offs_k[None, :] * stride_a_copy_k
+        )
+
+        mask = (offs_m[:, None] < M) & (offs_k[None, :] < K)
+        a = tl.load(a_ptrs, mask=mask, other=0.0)
+        tl.store(a_copy_ptrs, a.to(a_copy_ptr.type.element_ty), mask=mask)
+
+
+def _get_config(
+    M: int,
+    N: int,
+    K: int,
+):
+    # Use the same tuning portal as the unfused gemm_a16w16 — the extra
+    # downcast copy is assumed not to shift the optimal config.
+    config, is_tunned = get_gemm_config("GEMM-A16W16", M, N, K)
+    return compute_splitk_params(config, K), is_tunned

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=384-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=384-K=7168.json
@@ -1,0 +1,98 @@
+{
+  "M_LEQ_4": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 6,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 8,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 1024,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 6,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 7
+  },
+  "any": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/gemm/fused/fused_gemm_a16w16_copy_x.py
+++ b/aiter/ops/triton/gemm/fused/fused_gemm_a16w16_copy_x.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from typing import Optional, Tuple
+import torch
+import triton
+from aiter.ops.triton._triton_kernels.gemm.fused.fused_gemm_a16w16_copy_x import (
+    _fused_gemm_a16w16_copy_x_kernel,
+    _get_config,
+)
+from aiter.ops.triton._triton_kernels.gemm.basic.gemm_a16w16 import (
+    _gemm_a16w16_reduce_kernel,
+)
+from aiter.ops.triton._triton_kernels.activation import _get_activation_from_str
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+from aiter import dtypes
+
+_LOGGER = AiterTritonLogger()
+
+
+def fused_gemm_a16w16_copy_x(
+    x,
+    w,
+    bias: Optional[torch.Tensor] = None,
+    dtype: Optional[torch.dtype] = torch.bfloat16,
+    copy_dtype: Optional[torch.dtype] = None,
+    y: Optional[torch.Tensor] = None,
+    x_copy: Optional[torch.Tensor] = None,
+    config: Optional[dict] = None,
+    activation: Optional[str] = None,
+    skip_reduce: Optional[bool] = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Computes 16-bit matmul Y = X @ W^T and also emits a downcasted copy of X.
+
+    This fuses the GEMM with the activation-quantization downcast that
+    immediately follows the router-gate GEMM in MoE flows (e.g. DSv4),
+    avoiding a separate kernel/DRAM pass to cast X from BF16 to FP8.
+
+    The fused kernel uses a single 1D grid split into two regions: GEMM tiles
+    occupy `NUM_KSPLIT * cdiv(M, BLOCK_M) * cdiv(N, BLOCK_N)` programs and an
+    additional `cdiv(M, BLOCK_M) * cdiv(K, BLOCK_K)` programs handle the
+    downcast copy.
+
+    Args:
+        x (torch.Tensor): Input matrix with shape (M, K).
+        w (torch.Tensor): Weight matrix with shape (N, K), internally transposed.
+        bias (Optional[torch.Tensor]): Bias vector with shape (N,).
+        dtype (Optional[torch.dtype]): Output Y datatype (BF16 or FP16).
+        copy_dtype (Optional[torch.dtype]): Output X-copy datatype
+            (defaults to aiter.dtypes.fp8).
+        y (Optional[torch.Tensor]): Pre-allocated output with shape (M, N).
+        x_copy (Optional[torch.Tensor]): Pre-allocated downcasted X copy with
+            shape (M, K).
+        config (Optional[dict]): Kernel tuning parameters.
+        activation (Optional[str]): Activation fused into Y.
+        skip_reduce (Optional[bool]): Skip split-K reduction for Y.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: (Y, x_copy). When skip_reduce=True
+        and NUM_KSPLIT > 1, Y has shape (NUM_KSPLIT, M, N).
+    """
+
+    _LOGGER.info(f"FUSED_GEMM_A16W16_COPY_X: x={tuple(x.shape)} w={tuple(w.shape)}")
+    # Shape checks
+    assert x.shape[1] == w.shape[1], "Incompatible matrix shapes."
+
+    if copy_dtype is None:
+        copy_dtype = dtypes.fp8
+
+    M, K = x.shape
+    N, K = w.shape
+    w = w.T
+
+    if config is None:
+        config, _ = _get_config(M, N, K)
+
+    if y is None and (config["NUM_KSPLIT"] == 1 or not skip_reduce):
+        y = torch.empty((M, N), dtype=dtype, device=x.device)
+
+    if x_copy is None:
+        x_copy = torch.empty((M, K), dtype=copy_dtype, device=x.device)
+
+    if config["NUM_KSPLIT"] > 1:
+        y_pp = torch.empty(
+            (config["NUM_KSPLIT"], M, N),
+            dtype=torch.float32,
+            device=y.device if y is not None else x.device,
+        )
+    else:
+        y_pp = None
+
+    grid = lambda META: (  # noqa: E731
+        META["NUM_KSPLIT"]
+        * triton.cdiv(M, META["BLOCK_SIZE_M"])
+        * triton.cdiv(N, META["BLOCK_SIZE_N"])
+        + triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(K, META["BLOCK_SIZE_K"]),
+    )
+    _fused_gemm_a16w16_copy_x_kernel[grid](
+        x,
+        w,
+        bias,
+        y if config["NUM_KSPLIT"] == 1 else y_pp,
+        x_copy,
+        M,
+        N,
+        K,
+        x.stride(0),
+        x.stride(1),
+        w.stride(0),
+        w.stride(1),
+        0 if config["NUM_KSPLIT"] == 1 else y_pp.stride(0),
+        y.stride(0) if config["NUM_KSPLIT"] == 1 else y_pp.stride(1),
+        y.stride(1) if config["NUM_KSPLIT"] == 1 else y_pp.stride(2),
+        x_copy.stride(0),
+        x_copy.stride(1),
+        activation=_get_activation_from_str(activation) if activation else "",
+        use_activation=activation is not None,
+        ADD_BIAS=(bias is not None),
+        SKIP_REDUCE=skip_reduce,
+        **config,
+    )
+
+    if config["NUM_KSPLIT"] > 1:
+        if skip_reduce:
+            return y_pp, x_copy
+
+        REDUCE_BLOCK_SIZE_M = 32
+        REDUCE_BLOCK_SIZE_N = 32
+        ACTUAL_KSPLIT = triton.cdiv(K, config["SPLITK_BLOCK_SIZE"])
+
+        grid_reduce = (
+            triton.cdiv(M, REDUCE_BLOCK_SIZE_M),
+            triton.cdiv(N, REDUCE_BLOCK_SIZE_N),
+        )
+        _gemm_a16w16_reduce_kernel[grid_reduce](
+            bias,
+            y_pp,
+            y,
+            M,
+            N,
+            y_pp.stride(0),
+            y_pp.stride(1),
+            y_pp.stride(2),
+            y.stride(0),
+            y.stride(1),
+            REDUCE_BLOCK_SIZE_M,
+            REDUCE_BLOCK_SIZE_N,
+            ACTUAL_KSPLIT,
+            triton.next_power_of_2(config["NUM_KSPLIT"]),
+            activation=_get_activation_from_str(activation) if activation else "",
+            use_activation=activation is not None,
+            ADD_BIAS=(bias is not None),
+        )
+
+    return y, x_copy

--- a/op_tests/triton_tests/gemm/fused/test_fused_gemm_a16w16_copy_x.py
+++ b/op_tests/triton_tests/gemm/fused/test_fused_gemm_a16w16_copy_x.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import torch
+import torch.nn.functional as F
+import pytest
+
+from aiter import dtypes
+from aiter.ops.triton.gemm.fused.fused_gemm_a16w16_copy_x import (
+    fused_gemm_a16w16_copy_x,
+)
+from op_tests.triton_tests.gemm.basic.test_gemm_a16w16 import (
+    generate_gemm_a16w16_inputs,
+)
+
+
+def get_x_vals():
+    x_vals = [(1, 1, 1)]
+    x_vals += [(3, 5, 2)]
+    x_vals += [(1024, 1024, 1024)]
+    x_vals += [(2048, 2048, 2048)]
+    # DSv4 router gate: num_tokens x 384 x 7168
+    x_vals += [(2**i, 384, 7168) for i in range(5, 9)]
+    # DSR1 router GEMM
+    x_vals += [(2**i, 256, 7168) for i in range(5, 9)]
+    return x_vals
+
+
+@pytest.mark.parametrize("M, N, K", get_x_vals())
+def test_fused_gemm_a16w16_copy_x(M: int, N: int, K: int):
+    torch.cuda.empty_cache()
+    x, w, _, _, _ = generate_gemm_a16w16_inputs(
+        M, N, K, dtype=torch.bfloat16, output=False
+    )
+
+    torch_y = F.linear(x, w, bias=None)
+    torch_x_copy = x.to(dtypes.fp8)
+
+    triton_y, triton_x_copy = fused_gemm_a16w16_copy_x(x, w)
+
+    torch.testing.assert_close(triton_y, torch_y, atol=1e-1, rtol=1e-2)
+    # x_copy comparison: both are produced by an identical BF16 -> FP8 cast,
+    # so we expect bitwise equality. Compare via BF16 to avoid FP8 dtype
+    # ambiguities across gfx targets.
+    torch.testing.assert_close(
+        triton_x_copy.to(torch.bfloat16),
+        torch_x_copy.to(torch.bfloat16),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+def get_fewer_x_vals():
+    x_vals = [(16, 1024, 1024)]
+    x_vals += [(128, 8192, 512)]
+    x_vals += [(256, 512, 8192)]
+    x_vals += [(1024, 1024, 1024)]
+    return x_vals
+
+
+@pytest.mark.parametrize("activation", ["gelu", "gelu_tanh", "silu"])
+@pytest.mark.parametrize("M, N, K", get_fewer_x_vals())
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("output", [True, False])
+def test_fused_gemm_a16w16_copy_x_activation(
+    M: int, N: int, K: int, dtype, output, activation
+):
+    x, w, _, _, y = generate_gemm_a16w16_inputs(M, N, K, dtype, output=output)
+
+    torch_y = F.linear(x, w, bias=None)
+    if activation == "gelu":
+        torch_y = F.gelu(torch_y)
+    elif activation == "gelu_tanh":
+        torch_y = F.gelu(torch_y, approximate="tanh")
+    elif activation == "silu":
+        torch_y = F.silu(torch_y)
+    torch_x_copy = x.to(dtypes.fp8)
+
+    triton_y, triton_x_copy = fused_gemm_a16w16_copy_x(
+        x,
+        w,
+        bias=None,
+        dtype=dtype,
+        y=y,
+        activation=activation,
+    )
+
+    torch.testing.assert_close(triton_y, torch_y, atol=1e-1, rtol=1e-2)
+    torch.testing.assert_close(
+        triton_x_copy.to(torch.bfloat16),
+        torch_x_copy.to(torch.bfloat16),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+@pytest.mark.parametrize("M, N, K", get_fewer_x_vals())
+@pytest.mark.parametrize("skip_reduce", [True, False])
+def test_fused_gemm_a16w16_copy_x_skip_reduce(M: int, N: int, K: int, skip_reduce):
+    torch.cuda.empty_cache()
+    x, w, _, _, _ = generate_gemm_a16w16_inputs(
+        M, N, K, dtype=torch.bfloat16, output=False
+    )
+
+    torch_y = F.linear(x, w, bias=None)
+    torch_x_copy = x.to(dtypes.fp8)
+
+    triton_y, triton_x_copy = fused_gemm_a16w16_copy_x(x, w, skip_reduce=skip_reduce)
+
+    if triton_y.dim() == 3:
+        triton_y = triton_y.sum(axis=0).to(torch.bfloat16)
+
+    torch.testing.assert_close(triton_y, torch_y, atol=1e-1, rtol=1e-2)
+    torch.testing.assert_close(
+        triton_x_copy.to(torch.bfloat16),
+        torch_x_copy.to(torch.bfloat16),
+        atol=0.0,
+        rtol=0.0,
+    )


### PR DESCRIPTION
This PR removes 

1. The BF16->FP8 downcast kernel by adding a fused A16W16 GEMM with a downcast copy kernel of the gating operation (the integration will be on the ATOM side, the `hidden_states` that is sent into `fused_moe` is fp8 but the `dtype` argument will have to be explicitly set to BF16 to make sure the MOE config can be correctly selected
2. The `torch.fill_` kernel in the `flydsl_moe_stage2` helper function if the moe output tensor is already a zero tensor