### PR TITLE
[MOE] remove fill(0) in flydsl_moe_stage2

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -835,6 +835,9 @@ def _flydsl_stage2_wrapper(
         persist=parsed.get("persist", None),
         bias=bias2,
         xcd_swizzle=parsed.get("xcd_swizzle", 0),
+        out_already_filled_with_zeros=_kwargs.get(
+            "out_already_filled_with_zeros", "False"
+        ),
     )
 
 
@@ -1608,6 +1611,8 @@ def fused_moe_2stages(
             extra_stage2_args["bias2"] = _normalize_bias_for_kernel(bias2)
     if metadata.stage1.func is _flydsl_stage1_wrapper:
         extra_stage1_args["swiglu_limit"] = swiglu_limit
+    if metadata.stage2.func is _flydsl_stage2_wrapper:
+        extra_stage2_args["out_already_filled_with_zeros"] = True
     a2 = metadata.stage1(
         a1,
         w1,

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -835,9 +835,6 @@ def _flydsl_stage2_wrapper(
         persist=parsed.get("persist", None),
         bias=bias2,
         xcd_swizzle=parsed.get("xcd_swizzle", 0),
-        out_already_filled_with_zeros=_kwargs.get(
-            "out_already_filled_with_zeros", "False"
-        ),
     )
 
 
@@ -1611,8 +1608,6 @@ def fused_moe_2stages(
             extra_stage2_args["bias2"] = _normalize_bias_for_kernel(bias2)
     if metadata.stage1.func is _flydsl_stage1_wrapper:
         extra_stage1_args["swiglu_limit"] = swiglu_limit
-    if metadata.stage2.func is _flydsl_stage2_wrapper:
-        extra_stage2_args["out_already_filled_with_zeros"] = True
     a2 = metadata.stage1(
         a1,
         w1,

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1040,7 +1040,6 @@ def flydsl_moe_stage2(
     inter_dim_pad: int = 0,
     xcd_swizzle: int = 0,
     bias: Optional[torch.Tensor] = None,
-    out_already_filled_with_zeros: Optional[bool] = False,
 ) -> torch.Tensor:
     """Down-projection GEMM (MOE stage2). Supports atomic/reduce modes.
 
@@ -1071,8 +1070,6 @@ def flydsl_moe_stage2(
         out = alloc_fn(
             (token_num, model_dim), dtype=torch_out_dtype, device=inter_states.device
         )
-    elif accumulate and not out_already_filled_with_zeros:
-        out.fill_(0)
 
     dev = inter_states.device
     flat_a_scale = (

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1040,6 +1040,7 @@ def flydsl_moe_stage2(
     inter_dim_pad: int = 0,
     xcd_swizzle: int = 0,
     bias: Optional[torch.Tensor] = None,
+    out_already_filled_with_zeros: Optional[bool] = False,
 ) -> torch.Tensor:
     """Down-projection GEMM (MOE stage2). Supports atomic/reduce modes.
 
@@ -1070,7 +1071,7 @@ def flydsl_moe_stage2(
         out = alloc_fn(
             (token_num, model_dim), dtype=torch_out_dtype, device=inter_states.device
         )
-    elif accumulate:
+    elif accumulate and not out_already_filled_with_zeros:
         out.fill_(0)
 
     dev = inter_states.device


### PR DESCRIPTION
This PR removes the `.fill(0)` in flydsl_moe_stage2 helper function as the moe_sorting kernel already allocates the zero tensor, both are inside the universal `fused_moe` entry point so the zero tensor should always be allocated

on ATOM side:
```
local-completions ({'model': '/data/deepseek-ai/DeepSeek-V4-Pro', 'base_url': 'http://localhost:8000/v1/completions', 'num_concurrent': 65, 'max_retries': 2, 'tokenized_requests': False}), gen_kwargs: ({}), limit: 100.0, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  | 0.97|±  |0.0171|
|     |       |strict-match    |     3|exact_match|↑  | 0.97|±  |0.0171|
```

Baseline
<img width="911" height="121" alt="image" src="https://github.com/user-attachments/assets/b7d67682-b21c-40ef-87b9-33403f9aed8b" />

The fill kernel between the 2 stages of MOE is gone
<img width="939" height="146" alt="image" src="https://github.com/user-attachments/assets/1ae00f86-c181-4292-822a-4b52bfbdc786" />
