### PR TITLE
[ROCm] ops/quant: add static_per_tensor_quant_fp8_hip

### DIFF
--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -450,6 +450,16 @@ def per_tensor_quant_hip(
     return y, scale.view(1)
 
 
+def static_per_tensor_quant_fp8_hip(
+    x: Tensor,
+    scale: Tensor,
+) -> Tensor:
+    """Static FP8 per-tensor quant returning only the quantized tensor."""
+    y = torch.empty(x.shape, dtype=dtypes.fp8, device=x.device)
+    static_per_tensor_quant(y, x, scale)
+    return y
+
+
 def per_token_quant_triton(x, scale=None, quant_dtype=dtypes.i8):
     shape = x.shape
     device = x.device


### PR DESCRIPTION
Adds a thin wrapper around `static_per_tensor_quant` for the FP8 static-scale path that returns only the quantized tensor (no tuple). This is consumed by vLLM's `attn_quant_fusion` pass which needs a single-tensor return for FX graph pattern replacement.

- No changes to existing functions
- Verified with A/B perf runs on GPT-OSS-120B (TP=2, repeat=5):
  TPOT -5.4% at c128, -6.4% at c32 when used by vLLM's fusion rewrite (draft PR to wire the fusion on vLLM side -> https://github.com/vllm-project/vllm/pull/43147)