### PR TITLE
Retry Triton requirements install

### DIFF
--- a/.github/scripts/build_aiter_triton.sh
+++ b/.github/scripts/build_aiter_triton.sh
@@ -33,7 +33,7 @@ echo "==== Install dependencies and aiter ===="
 git config --global --add safe.directory /workspace
 pip config set global.retries 15
 pip config set global.timeout 120
-pip install -r .github/requirements/triton-test.txt
+retry_cmd 3 pip install -r .github/requirements/triton-test.txt
 .github/scripts/install_triton.sh
 pip uninstall -y aiter || true
 retry_cmd 3 pip install --no-build-isolation -e .


### PR DESCRIPTION
## Summary
- Wrap the Triton test requirements install in the existing retry helper.
- Reduce failures from transient package index/network issues during `Setup Aiter and Triton`.

## Test plan
- `bash -n .github/scripts/build_aiter_triton.sh`