### PR TITLE
[Bugfix] a16w16 splitk: per-stream semaphore workspace to avoid deadlock

### DIFF
--- a/aiter/ops/gemm_op_a16w16.py
+++ b/aiter/ops/gemm_op_a16w16.py
@@ -32,9 +32,29 @@ _SEMA_SHAPE = (16, 64)
 ASM_SPLITK_MAX_GRID = _SEMA_SHAPE[0] * _SEMA_SHAPE[1]
 
 
-@functools.lru_cache(maxsize=1)
-def get_semaphore_workspace(device: torch.device) -> Tensor:
+@functools.lru_cache(maxsize=64)
+def _get_semaphore_workspace_keyed(device: torch.device, stream_id: int) -> Tensor:
     return torch.zeros(_SEMA_SHAPE, dtype=torch.uint32, device=device)
+
+
+def get_semaphore_workspace(device: torch.device) -> Tensor:
+    """Return a per-(device, stream) zero-initialized semaphore workspace.
+
+    SplitK a16w16 ASM kernels use an atomic-counter protocol where the last
+    workgroup performs the reduction phase. Concurrent launches on different
+    streams must not share the same atomic counter, or the counts get mixed
+    and the reduction phase never fires (deadlock).
+
+    Reuse across launches on the same stream relies on the kernel resetting
+    the counter to zero after the reduction completes; do not call this from
+    callers that violate that invariant.
+
+    Workspace size is small (~4 KB) and stream count per process is typically
+    < 8, so the LRU cap of 64 leaves plenty of headroom before any in-flight
+    workspace risks being evicted.
+    """
+    stream = torch.cuda.current_stream(device)
+    return _get_semaphore_workspace_keyed(device, stream.cuda_stream)
 
 
 def gemm_a16w16_asm(


### PR DESCRIPTION
## Summary

The a16w16 ASM splitk kernels use an atomic-counter protocol where the **last** workgroup performs the reduction phase. With a single shared semaphore workspace, concurrent launches on different CUDA streams contend on the same counter:

1. Stream A launches splitk GEMM → workgroups atomicAdd on shared counter
2. Stream B launches splitk GEMM concurrently → its workgroups also atomicAdd on the **same** counter
3. The counter now reflects *both* kernels' workgroups
4. Neither stream's last-writer check (\`counter == this_kernel_expected_count\`) ever fires
5. Reduction phase never runs → host blocks waiting for output → **deadlock**

**Symptom:** multi-stream attention paths (e.g. \`default + alt_stream + compress_stream\` in DSv4 attention) hang inside \`*_splitk_clean\` kernel.

## Fix

Key the workspace cache by \`(device, stream_ptr)\` instead of just \`device\`, so each stream gets its own zero-initialized counter array.

- New private \`_get_semaphore_workspace_keyed(device, stream_id)\` with \`lru_cache(maxsize=64)\`. Workspace is ~4 KB and process stream count is typically < 8, so the cap leaves wide headroom and avoids evicting an in-flight workspace.
- Public \`get_semaphore_workspace(device)\` resolves the current stream via \`torch.cuda.current_stream(device).cuda_stream\` and delegates. **Public signature unchanged** — backward compatible.
- Docstring documents the atomic-counter invariant: the kernel must reset the counter to zero after reduction for reuse on the same stream to be safe.

## Test plan
- [x] \`py_compile\` clean
- [ ] Multi-stream splitk a16w16 launch no longer hangs (DSv4 attention path)
- [ ] Single-stream / single-launch performance unchanged (no extra work; same fast path)