### PR TITLE
Moe gfx1250 optimizations

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
@@ -365,7 +365,7 @@ def _moe_gemm_a8w4(
 
     read_idx = 0
     write_idx = 0
-    for _ in gl.static_range(NUM_BUFFERS - 1):
+    for _ in gl.static_range(NUM_BUFFERS):
         if GatherIndx is None:
             gl.amd.gfx1250.tdm.async_load(
                 x_desc,
@@ -407,9 +407,9 @@ def _moe_gemm_a8w4(
 
     num_k_iter = tl.cdiv(K, BLOCK_K)
 
-    # After TDM prologue there are (NUM_BUFFERS-1)*3 ops in-flight; waiting for
-    # (NUM_BUFFERS-2)*3 lets exactly one tile (tile 0) complete.
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * NUM_TDM_OPS)
+    # After TDM prologue there are NUM_BUFFERS*3 ops in-flight; waiting for
+    # (NUM_BUFFERS-1)*3 lets exactly one tile (tile 0) complete.
+    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * NUM_TDM_OPS)
 
     # Register pre-load prologue: wait for tile 0 then read it into cur_x/cur_w/cur_w_scales.
     cur_x = x_buffer.index(read_idx % NUM_BUFFERS).load(layout=DOT_LAYOUT_X)
@@ -433,7 +433,7 @@ def _moe_gemm_a8w4(
     read_idx += 1
 
     acc = gl.zeros((BLOCK_M, BLOCK_N), dtype=gl.float32, layout=WMMA_LAYOUT)
-    for k in range(num_k_iter - (NUM_BUFFERS - 1)):
+    for k in range(num_k_iter - NUM_BUFFERS):
         if is_x_microscaled:
             acc = gl.amd.gfx1250.wmma_scaled(
                 cur_x, cur_x_scales, "e4m3", cur_w, cur_w_scales, "e2m1", acc
@@ -482,7 +482,7 @@ def _moe_gemm_a8w4(
                 )
         write_idx += 1
 
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * NUM_TDM_OPS)
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * NUM_TDM_OPS)
 
         next_x = x_buffer.index(read_idx % NUM_BUFFERS).load(layout=DOT_LAYOUT_X)
         next_w = (
@@ -513,9 +513,19 @@ def _moe_gemm_a8w4(
         read_idx += 1
 
     # Epilogue: drain remaining pipeline stages (no new TDM loads).
-    # The first NUM_BUFFERS-2 iterations still use the pre-load / WMMA pattern.
-    for k_ep in gl.static_range(NUM_BUFFERS - 2):
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 3 - k_ep) * NUM_TDM_OPS)
+    # The first NUM_BUFFERS-1 iterations still use the pre-load / WMMA pattern.
+
+    for k_ep in gl.static_range(NUM_BUFFERS - 1):
+        if is_x_microscaled:
+            acc = gl.amd.gfx1250.wmma_scaled(
+                cur_x, cur_x_scales, "e4m3", cur_w, cur_w_scales, "e2m1", acc
+            )
+        else:
+            acc = gl.amd.gfx1250.wmma_scaled(
+                cur_x, 0, "e4m3", cur_w, cur_w_scales, "e2m1", acc
+            )
+
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2 - k_ep) * NUM_TDM_OPS)
 
         next_x = x_buffer.index(read_idx % NUM_BUFFERS).load(layout=DOT_LAYOUT_X)
         next_w = (
@@ -538,14 +548,6 @@ def _moe_gemm_a8w4(
                 layout=DOT_LAYOUT_X_SCALES
             )
 
-        if is_x_microscaled:
-            acc = gl.amd.gfx1250.wmma_scaled(
-                cur_x, cur_x_scales, "e4m3", cur_w, cur_w_scales, "e2m1", acc
-            )
-        else:
-            acc = gl.amd.gfx1250.wmma_scaled(
-                cur_x, 0, "e4m3", cur_w, cur_w_scales, "e2m1", acc
-            )
         cur_x = next_x
         cur_w = next_w
         cur_w_scales = next_w_scales

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
@@ -26,8 +26,8 @@ def matmul_launch_metadata(grid, kernel, args):
     nbits = X.dtype.itemsize * 8
     ret["name"] = f"{kernel.name} [{repr('M', M)}, {repr('N', N)}, {repr('K', K)}]"
     gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     if gindx is not None:
+        gindx = gindx.to(torch.int32)
         ret["name"] += "_layer1"
     else:
         ret["name"] += "_layer2"
@@ -42,8 +42,6 @@ def matmul_launch_metadata(grid, kernel, args):
     fK = K if K is not None else n_tokens
     ret[f"flops{nbits}"] = 2.0 * fM * N * fK
 
-    gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     n_x_bytes = X.numel() * X.element_size()
     n_y_bytes = Y.numel() * Y.element_size()
     if hist is not None:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a16w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a16w4.py
@@ -28,6 +28,7 @@ def matmul_launch_metadata(grid, kernel, args):
     ret["name"] = f"{kernel.name} [{repr('M', M)}, {repr('N', N)}, {repr('K', K)}]"
     gindx = args.get("GatherIndx", None)
     if gindx is not None:
+        gindx = gindx.to(torch.int32)
         ret["name"] += "_layer1"
     else:
         ret["name"] += "_layer2"
@@ -40,7 +41,6 @@ def matmul_launch_metadata(grid, kernel, args):
     fK = K if K is not None else n_tokens
     ret[f"flops{nbits}"] = 2.0 * fM * N * fK
 
-    gindx = args.get("GatherIndx", None)
     n_x_bytes = X.numel() * X.element_size()
     n_y_bytes = Y.numel() * Y.element_size()
     if hist is not None:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
@@ -29,9 +29,9 @@ def matmul_launch_metadata(grid, kernel, args):
     nbits = X.dtype.itemsize * 8
     ret["name"] = f"{kernel.name} [{repr('M', M)}, {repr('N', N)}, {repr('K', K)}]"
     gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     if gindx is not None:
         ret["name"] += "_layer1"
+        gindx = gindx.to(torch.int32)
     else:
         ret["name"] += "_layer2"
     if args["B"] is not None:
@@ -45,8 +45,6 @@ def matmul_launch_metadata(grid, kernel, args):
     fK = K if K is not None else n_tokens
     ret[f"flops{nbits}"] = 2.0 * fM * N * fK
 
-    gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     n_x_bytes = X.numel() * X.element_size()
     n_y_bytes = Y.numel() * Y.element_size()
     if hist is not None:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
@@ -28,8 +28,8 @@ def matmul_launch_metadata(grid, kernel, args):
     nbits = X.dtype.itemsize * 8
     ret["name"] = f"{kernel.name} [{repr('M', M)}, {repr('N', N)}, {repr('K', K)}]"
     gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     if gindx is not None:
+        gindx = gindx.to(torch.int32)
         ret["name"] += "_layer1"
     else:
         ret["name"] += "_layer2"
@@ -44,8 +44,6 @@ def matmul_launch_metadata(grid, kernel, args):
     fK = K if K is not None else n_tokens
     ret[f"flops{nbits}"] = 2.0 * fM * N * fK
 
-    gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     n_x_bytes = X.numel() * X.element_size()
     n_y_bytes = Y.numel() * Y.element_size()
     if hist is not None:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w8.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w8.py
@@ -28,8 +28,8 @@ def matmul_launch_metadata(grid, kernel, args):
     nbits = X.dtype.itemsize * 8
     ret["name"] = f"{kernel.name} [{repr('M', M)}, {repr('N', N)}, {repr('K', K)}]"
     gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     if gindx is not None:
+        gindx = gindx.to(torch.int32)
         ret["name"] += "_layer1"
     else:
         ret["name"] += "_layer2"
@@ -44,8 +44,6 @@ def matmul_launch_metadata(grid, kernel, args):
     fK = K if K is not None else n_tokens
     ret[f"flops{nbits}"] = 2.0 * fM * N * fK
 
-    gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     n_x_bytes = X.numel() * X.element_size()
     n_y_bytes = Y.numel() * Y.element_size()
     if hist is not None:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w8_blockscale.py
@@ -28,8 +28,8 @@ def matmul_launch_metadata(grid, kernel, args):
     nbits = X.dtype.itemsize * 8
     ret["name"] = f"{kernel.name} [{repr('M', M)}, {repr('N', N)}, {repr('K', K)}]"
     gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     if gindx is not None:
+        gindx = gindx.to(torch.int32)
         ret["name"] += "_layer1"
     else:
         ret["name"] += "_layer2"
@@ -44,8 +44,6 @@ def matmul_launch_metadata(grid, kernel, args):
     fK = K if K is not None else n_tokens
     ret[f"flops{nbits}"] = 2.0 * fM * N * fK
 
-    gindx = args.get("GatherIndx", None)
-    # sindx = args.get("WriteBackIndx", None)
     n_x_bytes = X.numel() * X.element_size()
     n_y_bytes = Y.numel() * Y.element_size()
     if hist is not None:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_int8_smoothquant.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_int8_smoothquant.py
@@ -28,6 +28,7 @@ def matmul_launch_metadata(grid, kernel, args):
     ret["name"] = f"{kernel.name} [{repr('M', M)}, {repr('N', N)}, {repr('K', K)}]"
     gindx = args.get("GatherIndx", None)
     if gindx is not None:
+        gindx = gindx.to(torch.int32)
         ret["name"] += "_layer1"
     else:
         ret["name"] += "_layer2"

--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing/routing.py
@@ -55,7 +55,7 @@ def _routing_compute_indx(
             strides=(LOAD_SIZE, 1),
             block_shape=(1, LOAD_SIZE),
         )
-        expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
+        expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,))
         expert = tl.where(offs < n_gates, expert, -1).to(tl.uint32)
     elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expert = tl.load(ExptIndx + offs).to(tl.uint32)
@@ -129,7 +129,7 @@ def _routing_compute_indx_fused(
             strides=(LOAD_SIZE, 1),
             block_shape=(1, LOAD_SIZE),
         )
-        expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,)).to(tl.uint32)
+        expert = tl.reshape(expt_desc.load([0, 0]), (LOAD_SIZE,))
         expert = tl.where(offs < n_gates, expert, -1).to(tl.uint32)
     elif EVEN_M and N_EXPTS_ACT == N_EXPTS_ACT_PAD:
         expert = tl.load(ExptIndx + offs).to(tl.uint32)

--- a/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
@@ -355,6 +355,7 @@ def moe_gemm_torch(
         if gather_indx is None:
             idx = torch.arange(lo, hi, device=x.device)
         else:
+            gather_indx = gather_indx.to(torch.int32)
             idx = gather_indx[lo:hi] // n_expts_act
         out = torch.matmul(x[idx, :].float(), w[i].float())
         if bias is not None:
@@ -368,6 +369,7 @@ def moe_gemm_torch(
         return y
 
     # accumulate output from all experts
+    scatter_indx = scatter_indx.to(torch.int32)
     n_rows = y.shape[0] // n_expts_act
     out = torch.zeros((n_rows, y.shape[-1]), dtype=torch.float32, device=x.device)
     src_idx = scatter_indx.view(-1, n_expts_act)

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -403,6 +403,7 @@ def moe_gemm_torch(
         if gather_indx is None:
             idx = torch.arange(lo, hi, device=x.device)
         else:
+            gather_indx = gather_indx.to(torch.int32)
             idx = gather_indx[lo:hi] // n_expts_act
         out = torch.matmul(x[idx, :].float(), w[i].float())
         if bias is not None:
@@ -415,6 +416,7 @@ def moe_gemm_torch(
     if scatter_indx is None:
         return y
     # accumulate output from all experts
+    scatter_indx = scatter_indx.to(torch.int32)
     n_rows = y.shape[0] // n_expts_act
     out = torch.zeros((n_rows, y.shape[-1]), dtype=torch.float32, device=x.device)
     src_idx = scatter_indx.view(-1, n_expts_act)

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -477,6 +477,7 @@ def moe_gemm_torch(
         if gather_indx is None:
             idx = torch.arange(lo, hi, device=x.device)
         else:
+            gather_indx = gather_indx.to(torch.int32)
             idx = gather_indx[lo:hi] // n_expts_act
         out = torch.matmul(x[idx, :].float(), w[i].float())
         if bias is not None:
@@ -489,6 +490,7 @@ def moe_gemm_torch(
     if scatter_indx is None:
         return y
     # accumulate output from all experts
+    scatter_indx = scatter_indx.to(torch.int32)
     n_rows = y.shape[0] // n_expts_act
     out = torch.zeros((n_rows, y.shape[-1]), dtype=torch.float32, device=x.device)
     src_idx = scatter_indx.view(-1, n_expts_act)

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w8.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w8.py
@@ -360,6 +360,7 @@ def moe_gemm_torch(
         if gather_indx is None:
             idx = torch.arange(lo, hi, device=x.device)
         else:
+            gather_indx = gather_indx.to(torch.int32)
             idx = gather_indx[lo:hi] // n_expts_act
         out = torch.matmul(x[idx, :].float(), w[i].float())
         if bias is not None:
@@ -372,6 +373,7 @@ def moe_gemm_torch(
     if scatter_indx is None:
         return y
     # accumulate output from all experts
+    scatter_indx = scatter_indx.to(torch.int32)
     n_rows = y.shape[0] // n_expts_act
     out = torch.zeros((n_rows, y.shape[-1]), dtype=torch.float32, device=x.device)
     src_idx = scatter_indx.view(-1, n_expts_act)

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w8_blockscale.py
@@ -352,6 +352,7 @@ def moe_gemm_torch(
         if gather_indx is None:
             idx = torch.arange(lo, hi, device=x.device)
         else:
+            gather_indx = gather_indx.to(torch.int32)
             idx = gather_indx[lo:hi] // n_expts_act
         out = torch.matmul(x[idx, :].float(), w[i].float())
         if bias is not None:
@@ -364,6 +365,7 @@ def moe_gemm_torch(
     if scatter_indx is None:
         return y
     # accumulate output from all experts
+    scatter_indx = scatter_indx.to(torch.int32)
     n_rows = y.shape[0] // n_expts_act
     out = torch.zeros((n_rows, y.shape[-1]), dtype=torch.float32, device=x.device)
     src_idx = scatter_indx.view(-1, n_expts_act)

--- a/aiter/ops/triton/moe/moe_op_gemm_int8_smoothquant.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_int8_smoothquant.py
@@ -448,6 +448,7 @@ def moe_gemm_smoothquant_torch(
         if gather_indx is None:
             idx = torch.arange(lo, hi, device=x.device)
         else:
+            gather_indx = gather_indx.to(torch.int32)
             idx = gather_indx[lo:hi] // n_expts_act
         out = (
             torch.matmul(x[idx, :].float(), w[i].float())
@@ -464,6 +465,7 @@ def moe_gemm_smoothquant_torch(
     if scatter_indx is None:
         return y
     # accumulate output from all experts
+    scatter_indx = scatter_indx.to(torch.int32)
     n_rows_out = y.shape[0] // n_expts_act
     out = torch.zeros((n_rows_out, y.shape[-1]), dtype=torch.float32, device=x.device)
     src_idx = scatter_indx.view(-1, n_expts_act)

--- a/aiter/ops/triton/moe/moe_routing/routing.py
+++ b/aiter/ops/triton/moe/moe_routing/routing.py
@@ -78,7 +78,10 @@ def sort_tokens(expt_scal, expt_indx, n_expts_tot, bitmatrix, block_m, HIST_BLOC
     hist = hist[:n_expts_tot]
     assert hist.dtype == torch.int32
     # scratchpad
-    combined_indx = torch.empty(n_gates * 2, dtype=torch.int32, device=device)
+    if n_gates <= 65536:
+        combined_indx = torch.empty(n_gates * 2, dtype=torch.uint16, device=device)
+    else:
+        combined_indx = torch.empty(n_gates * 2, dtype=torch.int32, device=device)
     # output
     topk_indx = combined_indx[:n_gates]
     gate_indx = combined_indx[n_gates:]
@@ -147,7 +150,10 @@ def sort_tokens_fused(
     assert hist.dtype == torch.int32
     num_blocks_bitmatrix = cdiv(bitmatrix.shape[1], 32)
     # scratchpad
-    combined_indx = torch.empty(n_gates * 2, dtype=torch.int32, device=device)
+    if n_gates <= 65536:
+        combined_indx = torch.empty(n_gates * 2, dtype=torch.uint16, device=device)
+    else:
+        combined_indx = torch.empty(n_gates * 2, dtype=torch.int32, device=device)
     # output
     topk_indx = combined_indx[:n_gates]
     gate_indx = combined_indx[n_gates:]

--- a/op_tests/triton_tests/moe/test_moe_routing.py
+++ b/op_tests/triton_tests/moe/test_moe_routing.py
@@ -117,6 +117,7 @@ def test_op(n_tokens, n_expts_tot, n_expts_act, sm_first):
     )
 
     def _assert_indx_equal(ref, tri):
+        tri = tri.to(torch.int32)
         assert_equal(ref, tri[: len(ref)])
         assert torch.all(tri[len(ref) :] == -1)
 


### PR DESCRIPTION
## Motivation

Optimizations and bug fixes for MOE kernels on gfx1250.

## Technical Details

- Optimize prefetch pipeline on a8w4
- Enable int16 gather indices to reduce number of TDM gather instructions
- Fix compilation bug in routing

## Test Plan

Correctness tests on FFM and performance tests on AM.

## Test Result

UTs pass. AM shows improved performance on both decode and prefill.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
