### PR TITLE
Fix fp8 sparse MLA folded batch mapping

### DIFF
--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -165,9 +165,12 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
 
                 auto fill_work_info = [&](const int32_t split_idx) {
                     const int32_t global_qo_tile_idx = tot_qo_tiles;
+                    const int32_t curr_batch_kv =
+                        Traits::kIsSparse ? (curr_batch / ori_seqlen_qo / params.qk_batch_ratio)
+                                          : (curr_batch / params.qk_batch_ratio);
 
                     MlaWorkInfo work_info{};
-                    work_info.batch_idx = curr_batch;
+                    work_info.batch_idx = curr_batch_kv;
                     work_info.qo_start =
                         qo_state.get_begin(curr_batch) + curr_qo_tile_idx * qo_tile_size;
                     work_info.qo_end =
@@ -212,7 +215,7 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
                             (curr_kv_end - work_info.kv_end == 0)
                                 ? 0
                                 : ((curr_kv_end - work_info.kv_end - 1) * page_size +
-                                   params.p_kv_last_page_lens[curr_batch]);
+                                   params.p_kv_last_page_lens[curr_batch_kv]);
                     }
                     // split related info
                     if(curr_n_split_idx > 0)
@@ -312,8 +315,12 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
                         remain_payload - params.fixed_over_head_num_blocks;
 
                     auto fill_work_info = [&]() {
+                        const int32_t curr_batch_kv =
+                            Traits::kIsSparse
+                                ? (curr_batch / ori_seqlen_qo / params.qk_batch_ratio)
+                                : (curr_batch / params.qk_batch_ratio);
                         MlaWorkInfo work_info{};
-                        work_info.batch_idx = curr_batch;
+                        work_info.batch_idx = curr_batch_kv;
                         work_info.qo_start =
                             qo_state.get_begin(curr_batch) + curr_qo_tile_idx * qo_tile_size;
                         work_info.qo_end = opus::min(work_info.qo_start + qo_tile_size,
@@ -359,7 +366,7 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
                                 (curr_kv_end - work_info.kv_end == 0)
                                     ? 0
                                     : ((curr_kv_end - work_info.kv_end - 1) * page_size +
-                                       params.p_kv_last_page_lens[curr_batch]);
+                                       params.p_kv_last_page_lens[curr_batch_kv]);
                         }
                         work_info.partial_qo_loc = partial_idx;
                         if(!cur_tail_done)

--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -167,7 +167,7 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
                     const int32_t global_qo_tile_idx = tot_qo_tiles;
                     const int32_t curr_batch_kv =
                         Traits::kIsSparse ? (curr_batch / ori_seqlen_qo / params.qk_batch_ratio)
-                                          : (curr_batch / params.qk_batch_ratio);
+                                          : curr_batch;
 
                     MlaWorkInfo work_info{};
                     work_info.batch_idx = curr_batch_kv;
@@ -318,7 +318,7 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
                         const int32_t curr_batch_kv =
                             Traits::kIsSparse
                                 ? (curr_batch / ori_seqlen_qo / params.qk_batch_ratio)
-                                : (curr_batch / params.qk_batch_ratio);
+                                : curr_batch;
                         MlaWorkInfo work_info{};
                         work_info.batch_idx = curr_batch_kv;
                         work_info.qo_start =


### PR DESCRIPTION
## Summary
- Fix persistent sparse MLA metadata for folded fp8 decode shapes by mapping virtual folded work items back to the original KV batch.
- Preserve the fast single-kernel decode path for TP4 DeepSeek V3.2 `fp8` KV cache instead of splitting into two 16-head kernel launches.
- Use the original KV batch when reading `kv_last_page_lens`, matching the corrected `work_info.batch_idx` mapping.

## Problem
DeepSeek V3.2 with TP4 and `--kv-cache-dtype fp8` has 32 local query heads. On gfx950, the fast persistent sparse MLA decode path does not natively handle `fp8/fp8, nhead=32, q_len=1` as a direct 32-head tile. To keep one efficient decode launch, AITER folds the shape from:

```text
[tokens, 32 heads, dim]
```

to:

```text
[tokens * 2, 16 heads, dim]
```

Those two virtual folded query entries are two head groups for the same original query token, so both must read the same sparse KV token range.

Before this fix, sparse metadata used the folded virtual batch index directly in some paths. For TP4 this effectively mapped:

```text
virtual entry 0 -> sparse KV token 0
virtual entry 1 -> sparse KV token 1  # wrong; should still be token 0
```

The second 16-head group could therefore read sparse KV pages from the next token. That produced a severe accuracy collapse with TP4 + fp8 KV cache.

## Why This Fix Is Correct
The mathematical attention computation is unchanged. This patch only fixes metadata bookkeeping for the folded representation.

For sparse folded metadata, the KV batch should be derived from the original token index, not from the folded virtual query entry. The corrected mapping divides by both the original q length and the q/head folding ratio:

```text
curr_batch_kv = curr_batch / ori_seqlen_qo / qk_batch_ratio
```

This makes all folded head groups for one original query token use the same sparse KV batch. It also uses `curr_batch_kv` when indexing `kv_last_page_lens`, keeping last-page handling consistent with `work_info.batch_idx`.

This preserves the intended high-performance single-call decode path. The earlier workaround of launching two 16-head calls was numerically correct but regressed performance by adding an extra kernel launch and duplicated decode setup.

## Accuracy Validation
GSM8K was run with DeepSeek V3.2, `--kv-cache-dtype fp8`, local completions, and 20-shot evaluation.

Before/after TP4 was measured by running the same TP4 + fp8 KV server and evaluation flow. For the before-fix run, ATOM/AITER were temporarily switched back to `main` and the AITER `module_mla_metadata` JIT artifact was deleted so the unfixed metadata kernel rebuilt from source.

| Config | Filter | Before fix exact_match | After fix exact_match |
| --- | --- | ---: | ---: |
| TP4 + fp8 KV | flexible-extract | 0.0076 +/- 0.0024 | 0.9507 +/- 0.0060 |
| TP4 + fp8 KV | strict-match | 0.0008 +/- 0.0008 | 0.9500 +/- 0.0060 |
| TP8 + fp8 KV | flexible-extract | not affected | 0.9530 +/- 0.0058 |
| TP8 + fp8 KV | strict-match | not affected | 0.9522 +/- 0.0059 |

TP8 is included as a guardrail. TP8 has 16 local heads, which is already a native fast-path shape, so it does not require the TP4 32-head folded mapping.

## Test Plan
- `git diff --check`
- Unit-level comparison between single folded decode call and two 16-head baseline calls: max absolute difference = 0
- DeepSeek V3.2 TP4 + `--kv-cache-dtype fp8`, GSM8K 20-shot accuracy before fix
- DeepSeek V3.2 TP4 + `--kv-cache-dtype fp8`, GSM8K 20-shot accuracy after fix
- DeepSeek V3.2 TP8 + `--kv-cache-dtype fp8`, GSM8K 20-shot accuracy after fix

## Companion PR
- ATOM plugin metadata dtype fix: https://github.com/ROCm/ATOM/pull/884