### PR TITLE
ck_gemm_a8w8_blockscale: deduplicate manifest declarations and split lookup TUs

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -234,7 +234,9 @@
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/gemm_a8w8_blockscale_pybind.cu'",
             "f'{AITER_CSRC_DIR}/py_itfs_cu/gemm_common.cu'",
-            "f'{AITER_CSRC_DIR}/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu'"
+            "f'{AITER_CSRC_DIR}/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu'",
+            "f'{AITER_CSRC_DIR}/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_lookup_fp16.cu'",
+            "f'{AITER_CSRC_DIR}/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_lookup_bf16.cu'"
         ],
         "extra_include": [
             "f'{AITER_CSRC_DIR}/ck_gemm_a8w8_blockscale/include'"

--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu
@@ -8,7 +8,8 @@
 #include <torch/extension.h>
 
 #include "gemm_a8w8_blockscale_common.cuh"
-#include "gemm_a8w8_blockscale_lookup.h"
+// lookup.h is included by the two dtype-specific TUs below, not here,
+// so ninja can expand GENERATE_LOOKUP_TABLE for FP16 and BF16 in parallel.
 #include "gemm_a8w8_blockscale_manifest.h"
 
 using BlockwiseKernel = torch::Tensor (*)(
@@ -21,6 +22,10 @@ using BlockwiseKernel = torch::Tensor (*)(
 // matching the style of GemmDispatchMap introduced for the tuple-keyed
 // modules in PR #3255 (no per-pair std::function ctor / landing pad cost).
 using BlockwiseKernelMap = std::unordered_map<std::string_view, BlockwiseKernel>;
+
+// Defined in gemm_a8w8_blockscale_lookup_{fp16,bf16}.cu.
+extern const BlockwiseKernelMap& get_blockscale_lookup_fp16();
+extern const BlockwiseKernelMap& get_blockscale_lookup_bf16();
 
 // Python-driven name-keyed dispatch.  The Python frontend
 // (aiter/ops/gemm_op_a8w8.py) reads aiter/configs/a8w8_blockscale_tuned_gemm.csv
@@ -37,14 +42,14 @@ using BlockwiseKernelMap = std::unordered_map<std::string_view, BlockwiseKernel>
 template <typename DDataType, typename EDataType = DDataType>
 static BlockwiseKernel blockscale_dispatch(const std::string& kernelName)
 {
-    static const auto lookup = [] {
+    static const BlockwiseKernelMap& lookup = [] -> const BlockwiseKernelMap& {
         if constexpr(std::is_same_v<EDataType, FP16>)
         {
-            return BlockwiseKernelMap{GENERATE_LOOKUP_TABLE(DDataType, FP16)};
+            return get_blockscale_lookup_fp16();
         }
         else if constexpr(std::is_same_v<EDataType, BF16>)
         {
-            return BlockwiseKernelMap{GENERATE_LOOKUP_TABLE(DDataType, BF16)};
+            return get_blockscale_lookup_bf16();
         }
         else
         {

--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale.cu
@@ -8,8 +8,9 @@
 #include <torch/extension.h>
 
 #include "gemm_a8w8_blockscale_common.cuh"
-// lookup.h is included by the two dtype-specific TUs below, not here,
-// so ninja can expand GENERATE_LOOKUP_TABLE for FP16 and BF16 in parallel.
+// lookup.h is included by gemm_a8w8_blockscale_lookup_fp16.cu and
+// gemm_a8w8_blockscale_lookup_bf16.cu, not here, so ninja can expand
+// GENERATE_LOOKUP_TABLE for FP16 and BF16 in parallel.
 #include "gemm_a8w8_blockscale_manifest.h"
 
 using BlockwiseKernel = torch::Tensor (*)(

--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_lookup_bf16.cu
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_lookup_bf16.cu
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// BF16 output dtype lookup table — separate TU so ninja compiles this and
+// gemm_a8w8_blockscale_lookup_fp16.cu in parallel.
+
+#include <string_view>
+#include <unordered_map>
+
+#include <torch/extension.h>
+
+#include "gemm_a8w8_blockscale_common.cuh"
+#include "gemm_a8w8_blockscale_lookup.h"
+#include "gemm_a8w8_blockscale_manifest.h"
+
+using BlockwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
+
+using BlockwiseKernelMap = std::unordered_map<std::string_view, BlockwiseKernel>;
+
+const BlockwiseKernelMap& get_blockscale_lookup_bf16()
+{
+    static const BlockwiseKernelMap map{GENERATE_LOOKUP_TABLE(FP32, BF16)};
+    return map;
+}

--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_lookup_fp16.cu
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_lookup_fp16.cu
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// FP16 output dtype lookup table — separate TU so ninja compiles this and
+// gemm_a8w8_blockscale_lookup_bf16.cu in parallel.
+
+#include <string_view>
+#include <unordered_map>
+
+#include <torch/extension.h>
+
+#include "gemm_a8w8_blockscale_common.cuh"
+#include "gemm_a8w8_blockscale_lookup.h"
+#include "gemm_a8w8_blockscale_manifest.h"
+
+using BlockwiseKernel = torch::Tensor (*)(
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
+
+using BlockwiseKernelMap = std::unordered_map<std::string_view, BlockwiseKernel>;
+
+const BlockwiseKernelMap& get_blockscale_lookup_fp16()
+{
+    static const BlockwiseKernelMap map{GENERATE_LOOKUP_TABLE(FP32, FP16)};
+    return map;
+}

--- a/csrc/ck_gemm_a8w8_blockscale/gen_instances.py
+++ b/csrc/ck_gemm_a8w8_blockscale/gen_instances.py
@@ -369,8 +369,11 @@ torch::Tensor
             "w",
         ) as f:
             f.write(MAINFEST_head)
+            seen_kernel_names = set()
             for _, k in kernels_dict.items():
-                f.write(MAINFEST_template.format(kernel_name=k.name))
+                if k.name not in seen_kernel_names:
+                    seen_kernel_names.add(k.name)
+                    f.write(MAINFEST_template.format(kernel_name=k.name))
             f.write(MAINFEST_end)
 
     def gen_code(self, kernels_dict: dict):


### PR DESCRIPTION
## Problem

`gen_manifest_head()` emits one `DECLARE_INSTANCE` per CSV row without deduplication. With multiple model/TP CSVs loaded, overlapping shapes cause duplicate declarations to accumulate unboundedly.

Measured with Qwen3-VL-235B, Qwen3-VL-32B, and Qwen3.6-27B across TP=2/4/8 (37,404 shapes): manifest grew to **218,932 lines (6.4 MB)** → fixed to **162 lines (4.7 KB)**, a ~1,350× reduction. A manifest of this size places significant memory pressure on the LLVM backend (MachineLICM pass) during compilation and can cause OOM failures on machines with limited memory or when further model CSVs are added.

## Changes

- **`gen_instances.py`**: skip duplicate kernel names when writing `gemm_a8w8_blockscale_manifest.h`
- **`gemm_a8w8_blockscale_lookup_{fp16,bf16}.cu`**: move `GENERATE_LOOKUP_TABLE` expansion into two separate TUs (one per output dtype) so ninja can compile them in parallel; main CU references them via `extern` declarations
- **`optCompilerConfig.json`**: add both new CUs to `module_gemm_a8w8_blockscale` srcs

## Testing

`op_tests/test_gemm_a8w8_blockscale.py` on MI300X (gfx942) with 37,404 merged shapes. Build succeeds; manifest size confirmed reduced.
