### PR TITLE
CI: cache Triton wheel for test jobs

### DIFF
--- a/.github/scripts/download_triton_wheel.sh
+++ b/.github/scripts/download_triton_wheel.sh
@@ -19,7 +19,8 @@ echo "Downloading triton wheel from ${TRITON_INDEX_URL} into ${TRITON_WHEEL_DIR}
 python3 -m pip download \
     --only-binary=:all: \
     --dest "${TRITON_WHEEL_DIR}" \
-    --extra-index-url "${TRITON_INDEX_URL}" \
+    --index-url "${TRITON_INDEX_URL}" \
+    --extra-index-url https://pypi.org/simple \
     triton
 
 ls -lh "${TRITON_WHEEL_DIR}"

--- a/.github/scripts/download_triton_wheel.sh
+++ b/.github/scripts/download_triton_wheel.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TRITON_WHEEL_DIR="${1:-triton_wheels}"
+mkdir -p "${TRITON_WHEEL_DIR}"
+
+python3 -m pip config set global.retries 15
+python3 -m pip config set global.timeout 120
+
+TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/"
+ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
+if [[ -n "${ROCM_VERSION}" ]]; then
+    ROCM_MAJOR_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f1,2)
+    TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
+fi
+
+echo "Downloading triton wheel from ${TRITON_INDEX_URL} into ${TRITON_WHEEL_DIR}"
+python3 -m pip download \
+    --only-binary=:all: \
+    --dest "${TRITON_WHEEL_DIR}" \
+    --extra-index-url "${TRITON_INDEX_URL}" \
+    triton
+
+ls -lh "${TRITON_WHEEL_DIR}"

--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -3,6 +3,32 @@ set -euo pipefail
 
 python3 -m pip uninstall -y triton pytorch-triton pytorch-triton-rocm triton-rocm amd-triton || true
 
+install_triton_from_wheelhouse() {
+    local wheel_dir="$1"
+
+    if [[ -z "${wheel_dir}" || ! -d "${wheel_dir}" ]]; then
+        return 1
+    fi
+
+    local wheels=()
+    shopt -s nullglob
+    wheels=("${wheel_dir}"/triton*.whl)
+    shopt -u nullglob
+
+    if [[ "${#wheels[@]}" -eq 0 ]]; then
+        echo "No triton wheels found in ${wheel_dir}"
+        return 1
+    fi
+
+    echo "Installing triton from local wheelhouse: ${wheel_dir}"
+    if python3 -m pip install --no-index --find-links "${wheel_dir}" triton; then
+        return 0
+    fi
+
+    echo "Local triton wheel install failed; falling back to public index."
+    return 1
+}
+
 TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
 if [[ -n "$ROCM_VERSION" ]]; then
@@ -10,8 +36,11 @@ if [[ -n "$ROCM_VERSION" ]]; then
     TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
 fi
 
-echo "Installing triton from $TRITON_INDEX_URL"
-pip install --extra-index-url "$TRITON_INDEX_URL" triton
+TRITON_WHEEL_DIR=${TRITON_WHEEL_DIR:-}
+if ! install_triton_from_wheelhouse "${TRITON_WHEEL_DIR}"; then
+    echo "Installing triton from $TRITON_INDEX_URL"
+    python3 -m pip install --extra-index-url "$TRITON_INDEX_URL" triton
+fi
 
 python3 - <<'PY'
 import triton

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -13,6 +13,8 @@ on:
       - "op_tests/op_benchmarks/triton/**"
       - ".github/workflows/triton-test.yaml"
       - ".github/scripts/build_aiter_triton.sh"
+      - ".github/scripts/download_triton_wheel.sh"
+      - ".github/scripts/install_triton.sh"
       - ".github/scripts/select_triton_tests.py"
       - ".github/scripts/split_tests.sh"
       - ".github/scripts/verify_triton_pin.py"
@@ -58,12 +60,41 @@ jobs:
           path: triton_shard_*.list
           retention-days: 7
 
+  prepare_triton_wheel:
+    if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') }}
+    runs-on: ubuntu-latest
+    needs: [check-signal]
+    env:
+      DOCKER_IMAGE: "rocm/pytorch:latest"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Triton wheel
+        id: download_triton_wheel
+        continue-on-error: true
+        run: |
+          set -ex
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            ${{ env.DOCKER_IMAGE }} \
+            bash ./.github/scripts/download_triton_wheel.sh triton_wheels
+
+      - name: Upload Triton wheel artifact
+        if: ${{ steps.download_triton_wheel.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: triton_wheelhouse
+          path: triton_wheels/
+          retention-days: 7
+
   # Step 2: MI35X matrix jobs
   triton:
     if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') }}
     name: Triton Tests (MI35X) / Shard ${{ matrix.shard }}
     runs-on: linux-aiter-mi35x-1
-    needs: [split_triton_tests, check-signal]
+    needs: [split_triton_tests, prepare_triton_wheel, check-signal]
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +114,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: triton_shards
+
+      - name: Download Triton wheel artifact
+        id: download_triton_wheel
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: triton_wheelhouse
+          path: triton_wheels
 
       - name: List test shard files
         run: |
@@ -127,6 +166,7 @@ jobs:
           docker run -dt \
           --device=/dev/kfd $DEVICE_FLAG \
           --shm-size=16G \
+          -e TRITON_WHEEL_DIR=/workspace/triton_wheels \
           --group-add $(getent group render | cut -d: -f3) \
           --group-add $(getent group video | cut -d: -f3) \
           -v "${{ github.workspace }}:/workspace" \
@@ -187,7 +227,7 @@ jobs:
     if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:triton-300x'))) }}
     name: Triton Tests (MI300X) / Shard ${{ matrix.shard }}
     runs-on: aiter-1gpu-runner
-    needs: [split_triton_tests, check-signal]
+    needs: [split_triton_tests, prepare_triton_wheel, check-signal]
     strategy:
       fail-fast: false
       matrix:
@@ -207,6 +247,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: triton_shards
+
+      - name: Download Triton wheel artifact
+        id: download_triton_wheel
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: triton_wheelhouse
+          path: triton_wheels
 
       - name: List test shard files
         run: |
@@ -251,6 +299,7 @@ jobs:
           docker run -dt \
           --device=/dev/kfd $DEVICE_FLAG \
           --shm-size=16G \
+          -e TRITON_WHEEL_DIR=/workspace/triton_wheels \
           --group-add $(getent group render | cut -d: -f3) \
           --group-add $(getent group video | cut -d: -f3) \
           -v "${{ github.workspace }}:/workspace" \


### PR DESCRIPTION
## Summary
- Download the Triton wheel once per Triton test workflow run and upload it as a 7-day artifact.
- Make MI35X and MI300X Triton shards prefer the wheel artifact while falling back to the public Triton index when the artifact is missing or unusable.
- Keep the Triton index selection aligned with the ROCm version detected in the test container.

## Test plan
- bash -n .github/scripts/install_triton.sh
- bash -n .github/scripts/download_triton_wheel.sh
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/triton-test.yaml'))"
- git diff --check -- .github/workflows/triton-test.yaml .github/scripts/install_triton.sh .github/scripts/download_triton_wheel.sh