### PR TITLE
CI: trigger split-test PR checks with app token

### DIFF
--- a/.github/workflows/update-split-tests.yaml
+++ b/.github/workflows/update-split-tests.yaml
@@ -21,7 +21,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write
+  actions: read
 
 jobs:
   update:
@@ -69,32 +69,25 @@ jobs:
             echo "- [x] bash .github/scripts/split_tests.sh --shards 8 --test-type triton --dry-run"
           } > pr-body.md
 
+      - name: Generate PR GitHub App token
+        if: steps.update_times.outputs.changed == 'true'
+        id: pr_app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AITER_CI_APP_ID }}
+          private-key: ${{ secrets.AITER_CI_APP_PRIVATE_KEY }}
+          owner: ROCm
+          repositories: aiter
+
       - name: Create Pull Request
         if: steps.update_times.outputs.changed == 'true'
         id: create_pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.pr_app_token.outputs.token }}
           branch: ci/update-split-tests-file-times
           title: "CI: auto-update split test FILE_TIMES"
           assignees: gyohuangxin
           body-path: pr-body.md
           commit-message: "CI: auto-update split test FILE_TIMES"
           delete-branch: true
-
-      - name: Dispatch CI workflows
-        if: steps.update_times.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BRANCH: ${{ steps.create_pr.outputs['pull-request-branch'] || 'ci/update-split-tests-file-times' }}
-        run: |
-          set -euo pipefail
-
-          gh workflow run pre-checks.yaml --repo "${REPO}" --ref "${BRANCH}"
-
-          # Downstream workflows poll for the checks artifact, so a short
-          # delay reduces races between dispatch and artifact publication.
-          sleep 60
-
-          gh workflow run aiter-test.yaml --repo "${REPO}" --ref "${BRANCH}"
-          gh workflow run triton-test.yaml --repo "${REPO}" --ref "${BRANCH}"


### PR DESCRIPTION
## Summary
- Use a GitHub App installation token when the scheduled split-test updater creates or updates its PR, so the resulting branch updates can trigger PR-visible `pull_request` checks.
- Remove the manual `workflow_dispatch` CI fan-out now that PR checks are triggered by the PR event.
- Reduce workflow permissions from `actions: write` to `actions: read` for the artifact/history lookup path.

## Test plan
- [x] `python3` YAML parse for `.github/workflows/update-split-tests.yaml`
- [x] `git diff --check`