### PR TITLE
ew kernels support on gfx12.

### DIFF
--- a/aiter/jit/utils/mha_recipes.py
+++ b/aiter/jit/utils/mha_recipes.py
@@ -1,6 +1,25 @@
 from typing import List, Dict, Tuple
 
 
+def _ck_targets_flag() -> str:
+    """Return ``--targets <runtime arch>`` when the runtime GPU is not gfx9.
+
+    ck-tile's ``generate.py`` defaults to ``--targets gfx9,gfx950``, so any
+    non-gfx9 host (gfx10/11/12) ends up with an empty kernel set and ``mha_fwd``
+    fails at dispatch with "invalid argument for fmha_fwd". For gfx9 hosts we
+    keep the default (covers both gfx942 and gfx950 like before).
+    """
+    try:
+        from chip_info import get_gfx
+
+        gfx = get_gfx()
+    except Exception:
+        return ""
+    if gfx.startswith("gfx9"):
+        return ""
+    return f" --targets {gfx}"
+
+
 def compose_mha_fwd_variant_suffix_and_filter(
     dtype: str,
     logits_positive: bool,
@@ -104,8 +123,8 @@ def get_mha_varlen_prebuild_variants_by_names(
             has_qscale=has_qscale,
         )
         blob_gen_cmd = [
-            f"{ck_dir}/example/ck_tile/01_fmha/generate.py -d fwd --receipt {receipt} --filter {filter_pattern} --output_dir {{}}",
-            f'{ck_dir}/example/ck_tile/01_fmha/generate.py -d fwd_splitkv --receipt {receipt} --filter " @ " --output_dir {{}}',
+            f"{ck_dir}/example/ck_tile/01_fmha/generate.py -d fwd --receipt {receipt} --filter {filter_pattern} --output_dir {{}}{_ck_targets_flag()}",
+            f'{ck_dir}/example/ck_tile/01_fmha/generate.py -d fwd_splitkv --receipt {receipt} --filter " @ " --output_dir {{}}{_ck_targets_flag()}',
         ]
         variants.append(
             {"md_name": f"mha_varlen_fwd{suffix}", "blob_gen_cmd": blob_gen_cmd}

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -1310,7 +1310,9 @@ def _flash_attn_forward(
 
     def can_impl_fmha_v3_fwd():
         # basic
-        ret = alibi_slopes is None
+        # fmha v3 is hand-written gfx9 ASM; non-gfx9 must fall back to ck-tile.
+        ret = get_gfx() in ("gfx942", "gfx950")
+        ret = ret and (alibi_slopes is None)
         ret = ret and (bias is None)
         ret = ret and (dropout_p == 0.0)
         ret = ret and (hdim_v == 128)
@@ -2096,7 +2098,10 @@ def _flash_attn_varlen_forward(
 
     def can_impl_fmha_v3_fwd():
         # basic
-        ret = alibi_slopes is None
+        # fmha v3 varlen is hand-written gfx9 ASM; non-gfx9 must fall back to
+        # ck-tile (mha_varlen_fwd, the else branch below).
+        ret = get_gfx() in ("gfx942", "gfx950")
+        ret = ret and (alibi_slopes is None)
         ret = ret and (bias is None)
         ret = ret and (dropout_p == 0.0)
         ret = ret and (hdim_v == 128)

--- a/csrc/kernels/fused_qk_norm.cu
+++ b/csrc/kernels/fused_qk_norm.cu
@@ -109,9 +109,16 @@ __global__ void fused_qk_rmsnorm_kernel(
         vec2_f* thread_data_float2 = reinterpret_cast<vec2_f*>(&thread_data_float);
         for(int i = 0; i < thread_data_size / 2; i++)
         {
+#if defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) || \
+    defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || \
+    defined(__gfx950__)
             asm volatile("v_pk_mul_f32 %0, %1, %2"
                          : "=v"(thread_data_float2[i])
                          : "v"(thread_data_float2[i]), "v"(rcp));
+#else
+            thread_data_float2[i][0] *= rcp[0];
+            thread_data_float2[i][1] *= rcp[1];
+#endif
         }
 
         for(int i = 0; i < thread_data_size / 2; i++)
@@ -119,9 +126,16 @@ __global__ void fused_qk_rmsnorm_kernel(
             vec2_f& thread_data_weight_float2 = rcp;
             thread_data_weight_float2[0] = static_cast<float>(thread_data_weight[2 * i]);
             thread_data_weight_float2[1] = static_cast<float>(thread_data_weight[2 * i + 1]);
+#if defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) || \
+    defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || \
+    defined(__gfx950__)
             asm volatile("v_pk_mul_f32 %0, %1, %2"
                          : "=v"(thread_data_float2[i])
                          : "v"(thread_data_float2[i]), "v"(thread_data_weight_float2));
+#else
+            thread_data_float2[i][0] *= thread_data_weight_float2[0];
+            thread_data_float2[i][1] *= thread_data_weight_float2[1];
+#endif
         }
 
         DTYPE_I* out_ptr = out_base + cur_idx * static_cast<int64_t>(out_stride);

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -7497,6 +7497,10 @@ __device__ __forceinline__ uint32_t f32x2_to_bf16x2_rne(float a, float b)
     uint32_t a_bits               = __builtin_bit_cast(uint32_t, a);
     uint32_t b_bits               = __builtin_bit_cast(uint32_t, b);
     uint32_t result;
+#if defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) || \
+    defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || \
+    defined(__gfx950__)
+    // CDNA path: v_cmp_u_f32 with explicit SGPR dest + v_add3 + v_and_or_b32
     // tmp scratch is read+written; nan_mask is an SGPR pair output of v_cmp_u_f32.
     // We declare them as early-clobber outputs so the compiler doesn't alias them
     // with any input register.
@@ -7522,6 +7526,22 @@ __device__ __forceinline__ uint32_t f32x2_to_bf16x2_rne(float a, float b)
           [bias] "v"(ROUND_BIAS),
           [nan] "v"(FP32_NAN),
           [mmsk] "v"(MERGE_MASK));
+#else
+    // Portable path for RDNA and other archs that lack explicit-dest v_cmp
+    // and/or v_add3_u32. Implements the same RNE + NaN logic in C++.
+    auto rne_f32_to_bf16 = [](uint32_t bits) -> uint32_t {
+        // If NaN, return canonical BF16 NaN (0x7fff)
+        if (__builtin_expect((bits & 0x7f800000u) == 0x7f800000u && (bits & 0x007fffffu) != 0, 0))
+            return 0x7fffu;
+        // Round-to-nearest-even: add bias + lsb of target
+        uint32_t lsb = (bits >> 16) & 1u;
+        uint32_t rounded = bits + 0x7fffu + lsb;
+        return rounded >> 16;
+    };
+    uint32_t lo = rne_f32_to_bf16(a_bits);
+    uint32_t hi = rne_f32_to_bf16(b_bits);
+    result = lo | (hi << 16);
+#endif
     return result;
 }
 


### PR DESCRIPTION
## Motivation

Enable building and running [aiter] on RDNA4 (gfx1201, e.g. Radeon RX 9700) GPUs. Several kernels currently fail to compile or dispatch on gfx1201:

v_pk_mul_f32 in fused-qk-norm kernel — this packed FP32 SIMD instruction exists on CDNA (gfx9xx) but is not available on RDNA4, causing a backend assembler error when building for gfx1201.

v_cmp_u_f32 with explicit SGPR dest + v_add3_u32 in [rope_common.h]— the [f32x2_to_bf16x2_rne()] function uses CDNA-specific inline assembly (explicit SGPR destination for v_cmp, 3-operand integer add). RDNA4's v_cmp can only write to implicit VCC, and v_add3_u32 does not exist, causing "invalid operand for instruction" errors.

fmha_v3 ASM kernels — hand-written gfx9 assembly (gfx942/gfx950 only). On non-gfx9 hosts, can_impl_fmha_v3_fwd() unconditionally returned True, causing dispatch failures ("invalid argument for fmha_fwd") instead of falling back to the ck-tile path.

ck-tile MHA generate.py targets — defaults to --targets gfx9,gfx950, so non-gfx9 hosts get an empty kernel set and mha_fwd fails at dispatch.

As a result, downstream users (sglang on Radeon) cannot use aiter's fused-qk-norm-rope, fused-qk-norm-rope-cache-quant, or flash-attention paths at all on RDNA4.


## Technical Details

csrc/kernels/fused_qk_norm.cu: Added [#if defined(__gfx906__) || ... || defined(__gfx950__)]positive-enumeration guard at both v_pk_mul_f32 sites. CDNA archs keep the asm fast path; all other archs fall back to portable element-wise multiplies (v_mul_f32 x2).

csrc/kernels/rope/rope_common.h: Added arch guard around the [f32x2_to_bf16x2_rne()] inline asm block. The CDNA path uses v_cmp_u_f32 (explicit SGPR dest) + v_add3_u32 + v_and_or_b32 for high-throughput packed bf16 conversion. The #else path implements identical RNE + NaN logic in portable C++ (compiler emits standard RDNA scalar instructions).

aiter/ops/mha.py: can_impl_fmha_v3_fwd() now gates on get_gfx() in ("gfx942", "gfx950") before enabling the v3 ASM path. Non-gfx9 archs cleanly fall through to the ck-tile FmhaFwd implementation.

aiter/jit/utils/mha_recipes.py: Added _ck_targets_flag() helper that detects runtime GPU arch. For non-gfx9 hosts, it appends --targets <runtime arch> (e.g. --targets gfx1201) to ck-tile's generate.py invocations, ensuring the correct kernel variants are generated instead of defaulting to gfx9-only.


## Files changed:
<img width="1066" height="202" alt="aiter_pr1" src="https://github.com/user-attachments/assets/a0f0bd2c-9bc9-4d35-9bbc-c04bd7c64416" />


All changes are guarded by positive CDNA arch enumeration macros or runtime get_gfx() checks, so:
gfx1201 builds: take the scalar/portable path (compiles and runs); MHA dispatches via ck-tile.
gfx9 builds (gfx942/gfx950): bit-for-bit unchanged (same asm / same fmha_v3 as before).


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
