### PR TITLE
[Optest] Fix test_moe.py activation cli arg parse

### DIFF
--- a/op_tests/test_moe.py
+++ b/op_tests/test_moe.py
@@ -414,7 +414,7 @@ parser.add_argument(
 parser.add_argument(
     "-a",
     "--activation",
-    type=dtypes.str2ActivationType,
+    type=str,
     choices=[
         "silu",
         "gelu",
@@ -427,6 +427,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
+args.activation = dtypes.str2ActivationType(args.activation)
 
 
 for test in args.test:


### PR DESCRIPTION
## Motivation
Fix test_moe.py --activation argparse error: 
`python3 op_tests/test_moe.py -t g1u1_fp8quant -d bf16 -m 8192 -hd 4096 -id 128 -e 512 -k 10 -a silu`

```bash
[aiter] import [module_aiter_core] under /root/workspace/aiter/aiter/jit/module_aiter_core.so
usage: test_moe.py [-h]
                   [-t [{test_fmoe_16_bit,g1u1_no_quant,g1u1_int8quant,g1u1_fp8quant,g1u0_int8smoothquant,g1u1_int8smoothquant,g1u1_fp8smoothquant,g1u1_int4} ...]]
                   [-d [DTYPE ...]] [-m [TOKEN ...]] [-hd [HIDDEN_DIM ...]] [-id [INTER_DIM ...]] [-e [EXPERT]] [-k [TOPK]] [-a {silu,gelu}]

test_moe.py: error: argument -a/--activation: invalid choice: <ActivationType.Silu: 0> (choose from 'silu', 'gelu')
```
- argparse validates choices against the converted value, not the raw string. With `type=dtypes.str2ActivationType`, inputs were converted to `ActivationType.Silu / ActivationType.Gelu` before choice validation, so they never matched ["silu", "gelu"] and the flag failed even for valid inputs.

## Technical Details
- Fix --activation / -a CLI parsing in op_tests/test_moe.py so valid choices like silu and gelu are accepted.
- Use `type=str` with string choices during argparse validation, then convert the parsed value to `ActivationType` via `dtypes.str2ActivationType()` after parse_args().



## Test Plan
```bash
python3 op_tests/test_moe.py -t g1u1_fp8quant -d bf16 -m 8192 -hd 4096 -id 128 -e 512 -k 10 -a silu
python3 op_tests/test_moe.py -t g1u1_fp8quant -d bf16 -m 8192 -hd 4096 -id 128 -e 512 -k 10 -a gelu
```
## Test Result

```bash
[aiter] import [module_aiter_core] under /root/workspace/aiter/aiter/jit/module_aiter_core.so

Running test: g1u1_fp8quant
[aiter] import [module_moe_asm] under /root/workspace/aiter/aiter/jit/module_moe_asm.so
[W525 10:13:57.299198771 collection.cpp:1133] Warning: ROCTracer produced duplicate flow start: 1 (function operator())
[aiter] import [module_moe_sorting] under /root/workspace/aiter/aiter/jit/module_moe_sorting.so
[aiter] import [module_quant] under /root/workspace/aiter/aiter/jit/module_quant.so
[aiter] LoadKernel: _ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E hsaco: /root/workspace/aiter/hsa//gfx942/fmoe/silu/fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128.co
[BW  ] token=8192, quant=fp8quant, model_dim=4096, inter_dim=128, E=512, shared_E=0, topk=10, dtype: torch.bfloat16, asm_bandwidth:     0.44TB/s
[aiter] [perf] use_g1u1=True token=8192, quant=fp8quant, model_dim=4096, inter_dim=128, E=512, shared_E=0, topk=10, dtype: torch.bfloat16, torch_avg: 104645.55us, asm_avg:  1975.92 us ...... uplift: 5196.0%[checkAllclose atol=100 rtol=0.01 passed~]
```

```bash
[aiter] import [module_aiter_core] under /root/workspace/aiter/aiter/jit/module_aiter_core.so

Running test: g1u1_fp8quant
[aiter] import [module_moe_asm] under /root/workspace/aiter/aiter/jit/module_moe_asm.so
[W525 10:14:16.296184260 collection.cpp:1133] Warning: ROCTracer produced duplicate flow start: 1 (function operator())
[aiter] import [module_moe_sorting] under /root/workspace/aiter/aiter/jit/module_moe_sorting.so
[aiter] import [module_quant] under /root/workspace/aiter/aiter/jit/module_quant.so
[aiter] LoadKernel: _ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_gelu_1tg_ps_32x128E hsaco: /root/workspace/aiter/hsa//gfx942/fmoe/gelu/fmoe_bf16_pertokenFp8_g1u1_vs_gelu_1tg_ps_32x128.co
[BW  ] token=8192, quant=fp8quant, model_dim=4096, inter_dim=128, E=512, shared_E=0, topk=10, dtype: torch.bfloat16, asm_bandwidth:     0.44TB/s
[aiter] [perf] use_g1u1=True token=8192, quant=fp8quant, model_dim=4096, inter_dim=128, E=512, shared_E=0, topk=10, dtype: torch.bfloat16, torch_avg: 104238.34us, asm_avg:  1958.31 us ...... uplift: 5222.9%[checkAllclose atol=100 rtol=0.01 passed~]
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
