### PR TITLE
activation: silu_and_mul HIP → triton fallback for non-CDNA archs

### DIFF
--- a/aiter/ops/activation.py
+++ b/aiter/ops/activation.py
@@ -12,9 +12,7 @@ MD_NAME = "module_activation"
 # exception, so we must allowlist arches BEFORE calling the HIP path.
 # Same set as aiter.ops.gemm_op_a8w8._BLOCKSCALE_HIP_PREBUILT_ARCHES and
 # aiter.ops.cache._CACHE_HIP_PREBUILT_ARCHES.
-_ACTIVATION_HIP_PREBUILT_ARCHES = frozenset(
-    {"gfx940", "gfx941", "gfx942", "gfx950"}
-)
+_ACTIVATION_HIP_PREBUILT_ARCHES = frozenset({"gfx940", "gfx941", "gfx942", "gfx950"})
 
 
 def _hip_activation_supported() -> bool:
@@ -52,9 +50,9 @@ def silu_and_mul(out: Tensor, input: Tensor, limit: float = 0.0) -> None:
         "silu_and_mul triton fallback does not support the 'limit' clamp; "
         f"got limit={limit}"
     )
-    assert input.is_contiguous(), (
-        "silu_and_mul triton fallback requires a contiguous input tensor"
-    )
+    assert (
+        input.is_contiguous()
+    ), "silu_and_mul triton fallback requires a contiguous input tensor"
     assert input.size(-1) % 2 == 0, (
         f"silu_and_mul triton fallback requires an even last dim; "
         f"got {input.size(-1)}"

--- a/aiter/ops/activation.py
+++ b/aiter/ops/activation.py
@@ -6,9 +6,62 @@ from ..jit.core import compile_ops
 
 MD_NAME = "module_activation"
 
+# Arches where the prebuilt HIP CK module 'module_activation' ships matching
+# code objects. On any other arch (e.g. gfx1201 RDNA4 in
+# rocm/atom-dev:latest) the HIP kernel launch SIGSEGVs with no catchable
+# exception, so we must allowlist arches BEFORE calling the HIP path.
+# Same set as aiter.ops.gemm_op_a8w8._BLOCKSCALE_HIP_PREBUILT_ARCHES and
+# aiter.ops.cache._CACHE_HIP_PREBUILT_ARCHES.
+_ACTIVATION_HIP_PREBUILT_ARCHES = frozenset(
+    {"gfx940", "gfx941", "gfx942", "gfx950"}
+)
+
+
+def _hip_activation_supported() -> bool:
+    """True when the prebuilt 'module_activation' has a code object for the
+    running device. False -> fall back to the triton variant."""
+    try:
+        from ..jit.utils.chip_info import get_gfx_runtime
+
+        return get_gfx_runtime() in _ACTIVATION_HIP_PREBUILT_ARCHES
+    except Exception:
+        return False
+
 
 @compile_ops("module_activation", develop=True)
-def silu_and_mul(out: Tensor, input: Tensor, limit: float = 0.0) -> None: ...
+def _silu_and_mul_ck(out: Tensor, input: Tensor, limit: float = 0.0) -> None: ...
+
+
+def silu_and_mul(out: Tensor, input: Tensor, limit: float = 0.0) -> None:
+    """SwiGLU activation: ``out = silu(input[..., :d]) * input[..., d:]`` where
+    ``d = input.size(-1) // 2``.
+
+    On arches with a prebuilt HIP CK code object for module_activation
+    (gfx94x / gfx95x), dispatches to the CK kernel. On other arches
+    (e.g. gfx1201 RDNA4) falls back to
+    aiter.ops.triton.activation.fused_silu_mul, which JIT-compiles for
+    any arch.
+
+    Triton-fallback constraints:
+      - ``input`` must be contiguous with an even last dim
+      - ``limit`` must be 0.0 (the triton variant has no limit clamp)
+    """
+    if _hip_activation_supported():
+        return _silu_and_mul_ck(out, input, limit)
+    assert limit == 0.0, (
+        "silu_and_mul triton fallback does not support the 'limit' clamp; "
+        f"got limit={limit}"
+    )
+    assert input.is_contiguous(), (
+        "silu_and_mul triton fallback requires a contiguous input tensor"
+    )
+    assert input.size(-1) % 2 == 0, (
+        f"silu_and_mul triton fallback requires an even last dim; "
+        f"got {input.size(-1)}"
+    )
+    from .triton.activation import fused_silu_mul as _silu_and_mul_triton
+
+    _silu_and_mul_triton(input, out=out)
 
 
 @compile_ops("module_activation", develop=True)


### PR DESCRIPTION
## Summary

The HIP CK module `module_activation` (`aiter.ops.activation.silu_and_mul`) ships prebuilt code objects only for gfx94x/95x. On other arches (e.g. gfx1201 RDNA4 in `rocm/atom-dev:latest`) the HIP kernel launch SIGSEGVs at first forward — no catchable exception, so we must allowlist arches **before** calling the HIP path. Same pattern as:

- [#3343](https://github.com/ROCm/aiter/pull/3343) — `gemm_a8w8_blockscale[_bpreshuffle]` HIP → triton
- [#3351](https://github.com/ROCm/aiter/pull/3351) — `cache.reshape_and_cache` HIP → triton

## Implementation

Adds:
- `_ACTIVATION_HIP_PREBUILT_ARCHES = {gfx940, gfx941, gfx942, gfx950}` (same set as the two earlier fallback PRs)
- `_hip_activation_supported()` helper
- `_silu_and_mul_ck` — renamed direct HIP binding
- A new public Python wrapper `silu_and_mul(...)` that dispatches: HIP CK on allowlisted arches, triton on others.

The triton fallback routes to `aiter.ops.triton.activation.fused_silu_mul`. Same SwiGLU semantics — `out[..., :d] = silu(input[..., :d]) * input[..., d:]` where `d = input.size(-1) // 2`.

**Asserted fallback constraints** (raised, not silently dropped):
- `input` must be contiguous with an even last dim (always true for MLP gate-up packed activations)
- `limit` must be `0.0` — the triton variant has no limit clamp (no current caller uses it non-zero)

## Why

ATOM PR #811 today imports `aiter.ops.triton.activation.fused_silu_mul` directly in `atom/model_ops/activation.py` to bypass the broken HIP path on gfx1201. After this PR lands, ATOM can revert that file to zero-diff vs main and call stock `aiter.silu_and_mul` like any other arch.

## Test plan

- [x] Correctness on gfx1201: `aiter.silu_and_mul` over BF16 input `[4, 32]` (gate+up packed, d=16) vs `F.silu(gate) * up` reference. Max abs diff = 0.0065 (BF16 quant noise floor).
- [x] No behavior change on CDNA — `_hip_activation_supported()` returns True for gfx94x/95x and the HIP CK path runs unchanged.