### PR TITLE
[gluon gemm_afp4wfp4] Fix data access pattern to remove redundant data loads

### DIFF
--- a/aiter/ops/triton/gluon/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gluon/gemm_afp4wfp4.py
@@ -105,7 +105,7 @@ def _gemm_afp4wfp4_kernel(
 
     blocked_scales: gl.constexpr = gl.BlockedLayout(
         size_per_thread=[4, 1],
-        threads_per_warp=[8, 8],
+        threads_per_warp=[64, 1],
         warps_per_cta=[1, num_warps],
         order=[0, 1],
     )


### PR DESCRIPTION
## Motivation

The original Gluon `gemm_afp4wfp4` kernel suffered from an inferior performance compared to the brother Triton kernel and was around 14% slower (considering a problem size the kernel is tailored to: `M=N=K=8192, bf16, TN` on `gfx950`). This applies to both Triton 3.5.1 and 3.6. The current latest Triton 3.7 has a massive performance regression at least for that kernel - around 0.88ms vs <0.36ms in previous versions, so proper benchmarking is unavailable, but there's little reason to expect it be better even after the regression bugfixing.

The investigation led to a discovery that the lane split for `blocked_scales` used in the kernel was inefficient and produced a redundant data loads and an increased VGPR pressure. Fixing the lane split pattern led to the kernel speedup and made it from 14% slower for `M=N=K=8192, bf16, TN` problem to ~3-4% faster than the corresponding Triton kernel. In slightly differently sized problems (on Triton 3.6, in `JAX-Triton` launcher using exactly that kernel), I saw even better results: `M=N=K=32768` - ~6%, for `4096,16384,4096` ~8% faster. (in the latest Triton 3.7 timing also drops from ~`0.88ms` to ~`0.51ms`, but that isn't of much value until the main regression is fixed)

## Technical Details

The original `threads_per_warp=[8, 8]` splits the 64 lanes of a warp as 8×8 in (M, K_scale). For a `(256, 8)` scale tile this means:
- M-span per warp is only `8 × 4 = 32`, so each lane is forced to do **8 sequential `buffer_load_dword` ops along M** to cover the tile.
- K_scale-span per warp is `8 × 1 = 8`, but the tile only has 8 K_scale columns — so 56 of 64 lanes load redundant data on every K_scale step.

With `threads_per_warp=[64, 1]`, all 64 lanes of a warp step along M, each lane loads one DWORD, and 8 warps cover the tile in 8 perfectly coalesced transactions — exactly the layout Triton's auto-layout chooses for the equivalent `tl.load`.

### Static evidence (AMDGCN, gfx950)

| | Gluon (orig) | Triton | Gluon (fixed) |
|---|---:|---:|---:|
| `v_mfma_scale_f32_32x32x64` | 64 | 64 | 64 |
| `buffer_load_dwordx4` | 16 | 16 | 16 |
| `buffer_load_dword` (scales) | **32** | **4** | **4** |
| `ds_write_b32` (scales LDS) | **32** | **4** | **4** |
| `s_waitcnt` | **73** | 51 | **44** |
| VGPRs | **254** | 218 | **214** |

## Test Plan

Currently tests for the Gluon kernel are disabled with a comment `# TODO(brunomazzotti): Fix gluon instr shape then enable gluon tests conditionally on 950`. The correctness of the change was validated using older checkouts of the full kernel test suite working on Triton 3.6 and Triton 3.5.1.

## Test Result

All 3328 test cases for the Gluon kernel PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
