### PR TITLE
support partial rope with fused_qk_norm_rope_cache_quant_shuffle

### DIFF
--- a/aiter/ops/fused_qk_norm_rope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_rope_cache_quant.py
@@ -13,7 +13,9 @@ from typing import Optional
     develop=True,
 )
 def _fused_qk_norm_rope_cache_quant_shuffle_hip(
-    qkv: Tensor,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
     num_heads_q: int,
     num_heads_k: int,
     num_heads_v: int,
@@ -30,14 +32,13 @@ def _fused_qk_norm_rope_cache_quant_shuffle_hip(
     kv_cache_dtype: str,
     k_scale: Tensor,
     v_scale: Tensor,
-    q: Optional[Tensor] = None,
-    k: Optional[Tensor] = None,
-    v: Optional[Tensor] = None,
 ) -> None: ...
 
 
 def fused_qk_norm_rope_cache_quant_shuffle(
-    qkv: Optional[Tensor] = None,
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
     *,
     num_heads_q: int,
     num_heads_k: int,
@@ -55,50 +56,11 @@ def fused_qk_norm_rope_cache_quant_shuffle(
     kv_cache_dtype: str,
     k_scale: Tensor,
     v_scale: Tensor,
-    q: Optional[Tensor] = None,
-    k: Optional[Tensor] = None,
-    v: Optional[Tensor] = None,
 ) -> None:
-    if q is None:
-        if qkv is None or qkv.numel() == 0:
-            raise TypeError(
-                "fused_qk_norm_rope_cache_quant_shuffle: non-empty `qkv` is required when "
-                "`q`, `k`, `v` are not all passed."
-            )
-        _fused_qk_norm_rope_cache_quant_shuffle_hip(
-            qkv,
-            num_heads_q,
-            num_heads_k,
-            num_heads_v,
-            head_dim,
-            eps,
-            qw,
-            kw,
-            cos_sin_cache,
-            is_neox_style,
-            pos_ids,
-            k_cache,
-            v_cache,
-            slot_mapping,
-            kv_cache_dtype,
-            k_scale,
-            v_scale,
-            None,
-            None,
-            None,
-        )
-        return
-    if k is None or v is None:
-        raise TypeError(
-            "fused_qk_norm_rope_cache_quant_shuffle: q, k, v must be provided together."
-        )
-    qkv_hip: Tensor = (
-        qkv
-        if qkv is not None and qkv.numel() > 0
-        else torch.empty((0, 0), device=q.device, dtype=q.dtype)
-    )
     _fused_qk_norm_rope_cache_quant_shuffle_hip(
-        qkv_hip,
+        q,
+        k,
+        v,
         num_heads_q,
         num_heads_k,
         num_heads_v,
@@ -115,9 +77,6 @@ def fused_qk_norm_rope_cache_quant_shuffle(
         kv_cache_dtype,
         k_scale,
         v_scale,
-        q,
-        k,
-        v,
     )
 
 

--- a/csrc/include/fused_qk_norm_rope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_rope_cache_quant.h
@@ -10,7 +10,9 @@
 namespace aiter {
 
 void fused_qk_norm_rope_cache_quant_shuffle(
-    aiter_tensor_t& qkv,
+    aiter_tensor_t& q,
+    aiter_tensor_t& k,
+    aiter_tensor_t& v,
     int64_t num_heads_q,
     int64_t num_heads_k,
     int64_t num_heads_v,
@@ -26,10 +28,7 @@ void fused_qk_norm_rope_cache_quant_shuffle(
     aiter_tensor_t& slot_mapping,
     const std::string& kv_cache_dtype,
     std::optional<aiter_tensor_t> k_scale,
-    std::optional<aiter_tensor_t> v_scale,
-    std::optional<aiter_tensor_t> opt_q = std::nullopt,
-    std::optional<aiter_tensor_t> opt_k = std::nullopt,
-    std::optional<aiter_tensor_t> opt_v = std::nullopt);
+    std::optional<aiter_tensor_t> v_scale);
 
 void fused_qk_norm_rope_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                                                 aiter_tensor_t& qw,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1689,7 +1689,9 @@ namespace py = pybind11;
 #define FUSED_QKNORM_ROPE_CACHE_QUANT_PYBIND                    \
     m.def("fused_qk_norm_rope_cache_quant_shuffle",             \
           &aiter::fused_qk_norm_rope_cache_quant_shuffle,       \
-          py::arg("qkv"),                                       \
+          py::arg("q"),                                         \
+          py::arg("k"),                                         \
+          py::arg("v"),                                         \
           py::arg("num_heads_q"),                               \
           py::arg("num_heads_k"),                               \
           py::arg("num_heads_v"),                               \
@@ -1705,10 +1707,7 @@ namespace py = pybind11;
           py::arg("slot_mapping"),                              \
           py::arg("kv_cache_dtype"),                            \
           py::arg("k_scale"),                                   \
-          py::arg("v_scale"),                                   \
-          py::arg("q") = std::nullopt,                          \
-          py::arg("k") = std::nullopt,                          \
-          py::arg("v") = std::nullopt);                         \
+          py::arg("v_scale"));                                  \
     m.def("fused_qk_rmsnorm",                                   \
           &aiter::fused_qk_rmsnorm,                             \
           py::arg("q"),                                         \

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -60,7 +60,7 @@ activation_strides_logical_3d(const aiter_tensor_t& t, int64_t num_heads, int64_
                     " vs ",
                     num_heads * head_dim,
                     ")");
-        return {t.stride(0), num_heads * t.stride(1), t.stride(1)};
+        return {t.stride(0), head_dim * t.stride(1), t.stride(1)};
     }
     AITER_CHECK(t.dim() == 3, "q/k/v must be 2D [T, H*D] or 3D [T, H, D], got dim ", t.dim());
     AITER_CHECK(t.size(1) == num_heads && t.size(2) == head_dim,
@@ -120,11 +120,9 @@ template <typename scalar_t,
           int num_kv_heads,
           vllm::Fp8KVCacheDataType kv_dt>
 __global__ void fusedQKNormRopeQuantCacheShuffleKernel(
-    scalar_t* qkv_void,      // Combined QKV tensor (unused if separate_qkv)
-    bool const separate_qkv, // If true, use q_act/k_act/v_act with [token, heads, dim] layout
-    scalar_t* q_act,         // [num_tokens, num_heads_q * head_dim] or nullptr
-    scalar_t* k_act,         // [num_tokens, num_heads_k * head_dim] or nullptr
-    scalar_t* v_act,         // [num_tokens, num_heads_v * head_dim] or nullptr
+    scalar_t* q_act, // [num_tokens, num_heads_q * head_dim]
+    scalar_t* k_act, // [num_tokens, num_heads_k * head_dim]
+    scalar_t* v_act, // [num_tokens, num_heads_v * head_dim]
     int64_t const q_st,
     int64_t const q_sh,
     int64_t const q_sd,
@@ -151,7 +149,8 @@ __global__ void fusedQKNormRopeQuantCacheShuffleKernel(
     float* v_scale,        // Value scale for quantized value cache [num_blocks, block_size]
     int const num_tokens,  // Number of tokens
     int const page_size,   // Page size for kv cache
-    int x                  // kv cache tiling size
+    int x,                 // kv cache tiling size
+    int const rotary_dim   // Rotary dimension (concatenated cos+sin width); <= head_dim
 )
 {
 
@@ -188,19 +187,7 @@ __global__ void fusedQKNormRopeQuantCacheShuffleKernel(
 
     // Load data first, suppose have no tail since we check the head_dim is multiple of 32 before
     // kernel launch
-    if(!separate_qkv)
-    {
-#pragma unroll
-        for(int i = 0; i < load_loop_cnt; i += 1)
-        {
-            int64_t offsetWarp = (tokenIdx * num_heads * head_dim + localHeadIdx * head_dim +
-                                  laneId * numElemsPerThread) /
-                                 vec_size;
-            reinterpret_cast<ltype*>(elements)[i] =
-                reinterpret_cast<ltype*>(qkv_void)[offsetWarp + i];
-        }
-    }
-    else if(act_sd == 1)
+    if(act_sd == 1)
     {
         int64_t const base_elems = (int64_t)tokenIdx * act_st + (int64_t)headIdx * act_sh +
                                    (int64_t)(laneId * numElemsPerThread);
@@ -248,12 +235,9 @@ __global__ void fusedQKNormRopeQuantCacheShuffleKernel(
 
         // Apply RoPE to normalized elements
 
-        int64_t pos_id = position_ids[tokenIdx];
-
-        // Calculate cache pointer for this position - similar to
-        // pos_encoding_kernels.cu
-        scalar_t const* cache_ptr = cos_sin_cache + pos_id * head_dim;
-        int const embed_dim       = head_dim / 2;
+        int64_t pos_id            = position_ids[tokenIdx];
+        int const embed_dim       = rotary_dim / 2;
+        scalar_t const* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
         scalar_t const* cos_ptr   = cache_ptr;
         scalar_t const* sin_ptr   = cache_ptr + embed_dim;
 
@@ -265,43 +249,48 @@ __global__ void fusedQKNormRopeQuantCacheShuffleKernel(
             {
                 int const idx0 = 2 * i;
                 int const idx1 = 2 * i + 1;
+                int const dim0 = laneId * numElemsPerThread + idx0;
 
-                float const val0 = elements[idx0];
-                float const val1 = elements[idx1];
+                if(dim0 + 1 < rotary_dim)
+                {
+                    float const val0  = elements[idx0];
+                    float const val1  = elements[idx1];
+                    int const half_dim = dim0 / 2;
+                    float cos_val     = static_cast<float>(cos_ptr[half_dim]);
+                    float sin_val     = static_cast<float>(sin_ptr[half_dim]);
 
-                int const dim_idx  = laneId * numElemsPerThread + idx0;
-                int const half_dim = dim_idx / 2;
-                float cos_val      = static_cast<float>(cos_ptr[half_dim]);
-                float sin_val      = static_cast<float>(sin_ptr[half_dim]);
-
-                elements[idx0] = static_cast<scalar_t>(val0 * cos_val - val1 * sin_val);
-                elements[idx1] = static_cast<scalar_t>(val0 * sin_val + val1 * cos_val);
+                    elements[idx0] = static_cast<scalar_t>(val0 * cos_val - val1 * sin_val);
+                    elements[idx1] = static_cast<scalar_t>(val0 * sin_val + val1 * cos_val);
+                }
             }
         }
         else
         {
             scalar_t elements2[numElemsPerThread]; // Additional buffer required for RoPE.
-            // Before data exchange with in warp, we need to sync.
+            // Before data exchange within warp, we need to sync.
             __syncwarp();
-            // Get the data from the other half of the warp. Use pre-computed cos/sin
-            // values.
+            int const partner_lane_delta = embed_dim / numElemsPerThread;
+            // Get the data from the other half of the warp. Use pre-computed cos/sin values.
 #pragma unroll
             for(int i = 0; i < numElemsPerThread; i++)
             {
-                elements2[i] = static_cast<scalar_t>(__shfl_xor(float(elements[i]), 16, 32));
-                if(laneId < 16)
+                int const dim_idx = laneId * numElemsPerThread + i;
+                if(dim_idx < rotary_dim)
                 {
-                    elements2[i] = -elements2[i];
+                    elements2[i] = static_cast<scalar_t>(
+                        __shfl_xor(float(elements[i]), partner_lane_delta, 32));
+                    if(dim_idx < embed_dim)
+                    {
+                        elements2[i] = -elements2[i];
+                    }
+
+                    int const half_dim = dim_idx % embed_dim;
+                    float cos_val      = static_cast<float>(cos_ptr[half_dim]);
+                    float sin_val      = static_cast<float>(sin_ptr[half_dim]);
+
+                    elements[i] = static_cast<scalar_t>(
+                        elements[i] * cos_val + elements2[i] * sin_val);
                 }
-
-                int dim_idx  = laneId * numElemsPerThread + i;
-                dim_idx      = (dim_idx * 2) % head_dim;
-                int half_dim = dim_idx / 2;
-                // Use pre-computed cos/sin from cache
-                float cos_val = cos_ptr[half_dim];
-                float sin_val = sin_ptr[half_dim];
-
-                elements[i] = static_cast<scalar_t>(elements[i] * cos_val + elements2[i] * sin_val);
             }
             __syncwarp();
         }
@@ -309,19 +298,7 @@ __global__ void fusedQKNormRopeQuantCacheShuffleKernel(
         int64_t const qk_sh    = isQ ? q_sh : k_sh;
         int64_t const qk_sd    = isQ ? q_sd : k_sd;
         scalar_t* const qk_dst = isQ ? q_act : k_act;
-        if(!separate_qkv)
-        {
-#pragma unroll
-            for(int i = 0; i < load_loop_cnt; i += 1)
-            {
-                int64_t offsetWarp = (tokenIdx * num_heads * head_dim + localHeadIdx * head_dim +
-                                      laneId * numElemsPerThread) /
-                                     vec_size;
-                reinterpret_cast<ltype*>(qkv_void)[offsetWarp + i] =
-                    reinterpret_cast<ltype*>(elements)[i];
-            }
-        }
-        else if(qk_sd == 1)
+        if(qk_sd == 1)
         {
             int64_t const base_elems = (int64_t)tokenIdx * qk_st + (int64_t)headIdx * qk_sh +
                                        (int64_t)(laneId * numElemsPerThread);
@@ -1003,9 +980,7 @@ __global__ void fusedQKNormRopeBlockQuantCacheShuffleKernel(
     }
 
 template <typename scalar_t, typename kv_cache_scalar_t, vllm::Fp8KVCacheDataType kv_dt>
-void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
-                                            bool const separate_qkv,
-                                            scalar_t* q_act,
+void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* q_act,
                                             scalar_t* k_act,
                                             scalar_t* v_act,
                                             int64_t const q_st,
@@ -1035,6 +1010,7 @@ void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
                                             float* v_scale,
                                             int page_size,
                                             int x,
+                                            int const rotary_dim,
                                             hipStream_t stream)
 {
     // make sure no thread is wasted, adopt 64 here
@@ -1056,9 +1032,7 @@ void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
                                                    INTERLEAVE,
                                                    NUM_KV_HEADS,
                                                    kv_dt>
-                <<<gridDim, blockDim, 0, stream>>>(qkv,
-                                                   separate_qkv,
-                                                   q_act,
+                <<<gridDim, blockDim, 0, stream>>>(q_act,
                                                    k_act,
                                                    v_act,
                                                    q_st,
@@ -1085,7 +1059,8 @@ void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
                                                    v_scale,
                                                    num_tokens,
                                                    page_size,
-                                                   x);
+                                                   x,
+                                                   rotary_dim);
         });
         break;
     case 128:
@@ -1096,9 +1071,7 @@ void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
                                                    INTERLEAVE,
                                                    NUM_KV_HEADS,
                                                    kv_dt>
-                <<<gridDim, blockDim, 0, stream>>>(qkv,
-                                                   separate_qkv,
-                                                   q_act,
+                <<<gridDim, blockDim, 0, stream>>>(q_act,
                                                    k_act,
                                                    v_act,
                                                    q_st,
@@ -1125,7 +1098,8 @@ void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
                                                    v_scale,
                                                    num_tokens,
                                                    page_size,
-                                                   x);
+                                                   x,
+                                                   rotary_dim);
         });
         break;
     case 256:
@@ -1136,9 +1110,7 @@ void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
                                                    INTERLEAVE,
                                                    NUM_KV_HEADS,
                                                    kv_dt>
-                <<<gridDim, blockDim, 0, stream>>>(qkv,
-                                                   separate_qkv,
-                                                   q_act,
+                <<<gridDim, blockDim, 0, stream>>>(q_act,
                                                    k_act,
                                                    v_act,
                                                    q_st,
@@ -1165,7 +1137,8 @@ void launchFusedQKNormRopeQuantCacheShuffle(scalar_t* qkv,
                                                    v_scale,
                                                    num_tokens,
                                                    page_size,
-                                                   x);
+                                                   x,
+                                                   rotary_dim);
         });
         break;
     default: AITER_CHECK(false, "Unsupported head dimension for fusedQKNormRope: ", head_dim);
@@ -1353,11 +1326,9 @@ void launchFusedQKNormRopeBlockQuantCacheShuffle(scalar_t* qkv,
 
 #define CALL_QK_NORM_ROPE_CACHE_QUANT(SRC_T, CACHE_T, KV_DTYPE)                        \
     launchFusedQKNormRopeQuantCacheShuffle<SRC_T, CACHE_T, KV_DTYPE>(                  \
-        use_separate ? nullptr : reinterpret_cast<SRC_T*>(qkv.data_ptr()),             \
-        use_separate,                                                                  \
-        use_separate ? reinterpret_cast<SRC_T*>(opt_q.value().data_ptr()) : nullptr,   \
-        use_separate ? reinterpret_cast<SRC_T*>(opt_k.value().data_ptr()) : nullptr,   \
-        use_separate ? reinterpret_cast<SRC_T*>(opt_v.value().data_ptr()) : nullptr,   \
+        reinterpret_cast<SRC_T*>(q_t.data_ptr()),                                       \
+        reinterpret_cast<SRC_T*>(k_t.data_ptr()),                                       \
+        reinterpret_cast<SRC_T*>(v_t.data_ptr()),                                       \
         q_stride_token,                                                                \
         q_stride_head,                                                                 \
         q_stride_dim,                                                                  \
@@ -1385,6 +1356,7 @@ void launchFusedQKNormRopeBlockQuantCacheShuffle(scalar_t* qkv,
         v_scale.has_value() ? reinterpret_cast<float*>(v_scale->data_ptr()) : nullptr, \
         page_size,                                                                     \
         x,                                                                             \
+        rotary_dim_,                                                                   \
         stream);
 
 template <typename T, int HEAD_SIZE, bool IS_NEOX>
@@ -2420,40 +2392,28 @@ void fused_rope_rms_1way(const T* q,
 namespace aiter {
 
 void fused_qk_norm_rope_cache_quant_shuffle(
-    aiter_tensor_t&
-        qkv, // Deprecated concat QKV; empty if only q/k/v. If both given, q/k/v used; qkv ignored.
-    int64_t num_heads_q,           // Number of query heads
-    int64_t num_heads_k,           // Number of key heads
-    int64_t num_heads_v,           // Number of value heads
-    int64_t head_dim,              // Dimension per head
-    double eps,                    // Epsilon for RMS normalization
-    aiter_tensor_t& q_weight,      // RMSNorm weights for query [head_dim]
-    aiter_tensor_t& k_weight,      // RMSNorm weights for key [head_dim]
-    aiter_tensor_t& cos_sin_cache, // Cos/sin cache [max_position, head_dim]
-    bool is_neox,                  // Whether RoPE is applied in Neox style
-    aiter_tensor_t& position_ids,  // Position IDs for RoPE [num_tokens]
-    aiter_tensor_t& k_cache,       // [num_blocks, num_kv_heads, head_dim//x, page_size, x]
-    aiter_tensor_t& v_cache,      // 4D [num_blocks, num_heads_v, head_dim, page_size] or 5D shuffle
-                                  // [num_blocks, num_heads_v, page_size//x, head_dim, x]
-    aiter_tensor_t& slot_mapping, // slot mapping
-    const std::string& kv_cache_dtype,     // kv cache data type
+    aiter_tensor_t& q,
+    aiter_tensor_t& k,
+    aiter_tensor_t& v,
+    int64_t num_heads_q,               // Number of query heads
+    int64_t num_heads_k,               // Number of key heads
+    int64_t num_heads_v,               // Number of value heads
+    int64_t head_dim,                  // Dimension per head
+    double eps,                        // Epsilon for RMS normalization
+    aiter_tensor_t& q_weight,          // RMSNorm weights for query [head_dim]
+    aiter_tensor_t& k_weight,          // RMSNorm weights for key [head_dim]
+    aiter_tensor_t& cos_sin_cache,     // Cos/sin cache [max_position, rotary_dim]
+    bool is_neox,                      // Whether RoPE is applied in Neox style
+    aiter_tensor_t& position_ids,      // Position IDs for RoPE [num_tokens]
+    aiter_tensor_t& k_cache,           // [num_blocks, num_kv_heads, head_dim//x, page_size, x]
+    aiter_tensor_t& v_cache,           // 4D [num_blocks, num_heads_v, head_dim, page_size] or 5D shuffle
+                                       // [num_blocks, num_heads_v, page_size//x, head_dim, x]
+    aiter_tensor_t& slot_mapping,      // slot mapping
+    const std::string& kv_cache_dtype, // kv cache data type
     std::optional<aiter_tensor_t> k_scale, // k scale tensor for quantized k cache
-    std::optional<aiter_tensor_t> v_scale, // v scale tensor for quantized v cache
-    std::optional<aiter_tensor_t> opt_q,   // [num_tokens, num_heads_q * head_dim] (preferred)
-    std::optional<aiter_tensor_t> opt_k,   // [num_tokens, num_heads_k * head_dim]
-    std::optional<aiter_tensor_t> opt_v    // [num_tokens, num_heads_v * head_dim]
+    std::optional<aiter_tensor_t> v_scale  // v scale tensor for quantized v cache
 )
 {
-    const bool have_q  = opt_q.has_value();
-    const bool have_k  = opt_k.has_value();
-    const bool have_v  = opt_v.has_value();
-    const bool any_sep = have_q || have_k || have_v;
-    AITER_CHECK(
-        !any_sep || (have_q && have_k && have_v),
-        "fused_qk_norm_rope_cache_quant_shuffle: pass all of q, k, v together, or omit all three.");
-    const bool use_separate = have_q && have_k && have_v;
-    const bool have_qkv     = qkv.numel() > 0;
-
     CHECK_INPUT(position_ids);
     CHECK_INPUT(q_weight);
     CHECK_INPUT(k_weight);
@@ -2461,16 +2421,37 @@ void fused_qk_norm_rope_cache_quant_shuffle(
     CHECK_INPUT(k_cache);
     CHECK_INPUT(v_cache);
     CHECK_INPUT(slot_mapping);
+    CHECK_TH_CUDA(q);
+    CHECK_TH_CUDA(k);
+    CHECK_TH_CUDA(v);
     CHECK_TYPE(position_ids, AITER_DTYPE_i64);
     CHECK_TYPE(slot_mapping, AITER_DTYPE_i64);
 
     AITER_CHECK(position_ids.dim() == 1, "Position IDs must be 1D: [num_tokens]");
     AITER_CHECK(q_weight.dim() == 1, "Query weights must be 1D: [head_dim]");
     AITER_CHECK(k_weight.dim() == 1, "Key weights must be 1D: [head_dim]");
-    AITER_CHECK(cos_sin_cache.dim() == 2, "Cos/sin cache must be 2D: [max_position, head_dim]");
+    AITER_CHECK(cos_sin_cache.dim() == 2, "Cos/sin cache must be 2D: [max_position, rotary_dim]");
     AITER_CHECK(q_weight.size(0) == head_dim, "Query weights size must match head dimension");
     AITER_CHECK(k_weight.size(0) == head_dim, "Key weights size must match head dimension");
-    AITER_CHECK(cos_sin_cache.size(1) == head_dim, "Cos/sin cache dimension must match head_dim");
+    int64_t const rotary_dim_ = cos_sin_cache.size(1);
+    AITER_CHECK(rotary_dim_ > 0, "rotary_dim must be positive");
+    AITER_CHECK(rotary_dim_ <= head_dim,
+                "rotary_dim (",
+                rotary_dim_,
+                ") must be <= head_dim (",
+                head_dim,
+                ")");
+    AITER_CHECK(rotary_dim_ % 2 == 0, "rotary_dim must be even");
+    if(is_neox)
+    {
+        int64_t const num_elems_per_thread = head_dim / 32;
+        AITER_CHECK((rotary_dim_ / 2) % num_elems_per_thread == 0,
+                    "For NeoX-style partial rotary, rotary_dim/2 (",
+                    rotary_dim_ / 2,
+                    ") must be divisible by head_dim/32 (",
+                    num_elems_per_thread,
+                    ")");
+    }
     AITER_CHECK(head_dim % 32 == 0,
                 "Head dimension must be multiple of 32 for fused QK Norm RoPE kernel");
     AITER_CHECK(
@@ -2483,100 +2464,61 @@ void fused_qk_norm_rope_cache_quant_shuffle(
     int64_t q_stride_token = 0, q_stride_head = 0, q_stride_dim = 0;
     int64_t k_stride_token = 0, k_stride_head = 0, k_stride_dim = 0;
     int64_t v_stride_token = 0, v_stride_head = 0, v_stride_dim = 0;
+    aiter_tensor_t const& q_t = q;
+    aiter_tensor_t const& k_t = k;
+    aiter_tensor_t const& v_t = v;
 
-    if(use_separate)
+    AITER_CHECK((q_t.dim() == 2 || q_t.dim() == 3) && (k_t.dim() == 2 || k_t.dim() == 3) &&
+                    (v_t.dim() == 2 || v_t.dim() == 3),
+                "q, k, v must be 2D [num_tokens, num_heads * head_dim] or 3D [num_tokens, "
+                "num_heads, head_dim]");
+    num_tokens = q_t.size(0);
+    AITER_CHECK(k_t.size(0) == num_tokens && v_t.size(0) == num_tokens,
+                "q, k, v must share the same num_tokens");
+    if(q_t.dim() == 2)
     {
-        aiter_tensor_t const& q_t = opt_q.value();
-        aiter_tensor_t const& k_t = opt_k.value();
-        aiter_tensor_t const& v_t = opt_v.value();
-        CHECK_TH_CUDA(q_t);
-        CHECK_TH_CUDA(k_t);
-        CHECK_TH_CUDA(v_t);
-        AITER_CHECK((q_t.dim() == 2 || q_t.dim() == 3) && (k_t.dim() == 2 || k_t.dim() == 3) &&
-                        (v_t.dim() == 2 || v_t.dim() == 3),
-                    "q, k, v must be 2D [num_tokens, num_heads * head_dim] or 3D [num_tokens, "
-                    "num_heads, head_dim]");
-        num_tokens = q_t.size(0);
-        AITER_CHECK(k_t.size(0) == num_tokens && v_t.size(0) == num_tokens,
-                    "q, k, v must share the same num_tokens");
-        if(q_t.dim() == 2)
-        {
-            AITER_CHECK(q_t.size(1) == num_heads_q * head_dim,
-                        "q dim 1 must be num_heads_q * head_dim");
-        }
-        else
-        {
-            AITER_CHECK(q_t.size(1) == num_heads_q && q_t.size(2) == head_dim,
-                        "q 3D shape must be [num_tokens, num_heads_q, head_dim]");
-        }
-        if(k_t.dim() == 2)
-        {
-            AITER_CHECK(k_t.size(1) == num_heads_k * head_dim,
-                        "k dim 1 must be num_heads_k * head_dim");
-        }
-        else
-        {
-            AITER_CHECK(k_t.size(1) == num_heads_k && k_t.size(2) == head_dim,
-                        "k 3D shape must be [num_tokens, num_heads_k, head_dim]");
-        }
-        if(v_t.dim() == 2)
-        {
-            AITER_CHECK(v_t.size(1) == num_heads_v * head_dim,
-                        "v dim 1 must be num_heads_v * head_dim");
-        }
-        else
-        {
-            AITER_CHECK(v_t.size(1) == num_heads_v && v_t.size(2) == head_dim,
-                        "v 3D shape must be [num_tokens, num_heads_v, head_dim]");
-        }
-        AITER_CHECK(q_t.dtype() == k_t.dtype() && q_t.dtype() == v_t.dtype(),
-                    "q, k, v must share the same dtype");
-        AITER_CHECK(q_t.dtype() == q_weight.dtype() && q_t.dtype() == k_weight.dtype(),
-                    "q/k/v must match q_weight/k_weight dtype");
-        act_dtype                    = q_t.dtype();
-        ActivationStrides3D const sq = activation_strides_logical_3d(q_t, num_heads_q, head_dim);
-        ActivationStrides3D const sk = activation_strides_logical_3d(k_t, num_heads_k, head_dim);
-        ActivationStrides3D const sv = activation_strides_logical_3d(v_t, num_heads_v, head_dim);
-        q_stride_token               = sq.st;
-        q_stride_head                = sq.sh;
-        q_stride_dim                 = sq.sd;
-        k_stride_token               = sk.st;
-        k_stride_head                = sk.sh;
-        k_stride_dim                 = sk.sd;
-        v_stride_token               = sv.st;
-        v_stride_head                = sv.sh;
-        v_stride_dim                 = sv.sd;
-        if(have_qkv)
-        {
-            // qkv is deprecated; q/k/v used instead.
-            int64_t const total_heads = num_heads_q + num_heads_k + num_heads_v;
-            AITER_CHECK(qkv.dim() == 2,
-                        "When passing both qkv and q/k/v, qkv must be 2D [num_tokens, "
-                        "total_heads*head_dim]");
-            AITER_CHECK(qkv.size(0) == num_tokens && qkv.size(1) == total_heads * head_dim,
-                        "When passing both qkv and q/k/v, qkv shape must be [num_tokens, "
-                        "(nh_q+nh_k+nh_v)*head_dim] "
-                        "(qkv is unused but must be consistent).");
-            AITER_CHECK(qkv.dtype() == q_t.dtype(),
-                        "When passing both qkv and q/k/v, qkv dtype must match q/k/v.");
-            CHECK_INPUT(qkv);
-        }
+        AITER_CHECK(q_t.size(1) == num_heads_q * head_dim, "q dim 1 must be num_heads_q * head_dim");
     }
     else
     {
-        AITER_CHECK(have_qkv,
-                    "fused_qk_norm_rope_cache_quant_shuffle: pass non-empty `qkv`, or pass all of "
-                    "`q`, `k`, `v`.");
-        // qkv alone is deprecated; prefer separate q, k, v tensors.
-        CHECK_INPUT(qkv);
-        AITER_CHECK(qkv.dim() == 2,
-                    "QKV tensor must be 2D: [num_tokens, "
-                    "(num_heads_q+num_heads_k+num_heads_v)*head_dim]");
-        AITER_CHECK(qkv.dtype() == q_weight.dtype() && qkv.dtype() == k_weight.dtype(),
-                    "qkv, q_weight and k_weight must have the same dtype");
-        num_tokens = qkv.size(0);
-        act_dtype  = qkv.dtype();
+        AITER_CHECK(q_t.size(1) == num_heads_q && q_t.size(2) == head_dim,
+                    "q 3D shape must be [num_tokens, num_heads_q, head_dim]");
     }
+    if(k_t.dim() == 2)
+    {
+        AITER_CHECK(k_t.size(1) == num_heads_k * head_dim, "k dim 1 must be num_heads_k * head_dim");
+    }
+    else
+    {
+        AITER_CHECK(k_t.size(1) == num_heads_k && k_t.size(2) == head_dim,
+                    "k 3D shape must be [num_tokens, num_heads_k, head_dim]");
+    }
+    if(v_t.dim() == 2)
+    {
+        AITER_CHECK(v_t.size(1) == num_heads_v * head_dim, "v dim 1 must be num_heads_v * head_dim");
+    }
+    else
+    {
+        AITER_CHECK(v_t.size(1) == num_heads_v && v_t.size(2) == head_dim,
+                    "v 3D shape must be [num_tokens, num_heads_v, head_dim]");
+    }
+    AITER_CHECK(q_t.dtype() == k_t.dtype() && q_t.dtype() == v_t.dtype(),
+                "q, k, v must share the same dtype");
+    AITER_CHECK(q_t.dtype() == q_weight.dtype() && q_t.dtype() == k_weight.dtype(),
+                "q/k/v must match q_weight/k_weight dtype");
+    act_dtype                    = q_t.dtype();
+    ActivationStrides3D const sq = activation_strides_logical_3d(q_t, num_heads_q, head_dim);
+    ActivationStrides3D const sk = activation_strides_logical_3d(k_t, num_heads_k, head_dim);
+    ActivationStrides3D const sv = activation_strides_logical_3d(v_t, num_heads_v, head_dim);
+    q_stride_token               = sq.st;
+    q_stride_head                = sq.sh;
+    q_stride_dim                 = sq.sd;
+    k_stride_token               = sk.st;
+    k_stride_head                = sk.sh;
+    k_stride_dim                 = sk.sd;
+    v_stride_token               = sv.st;
+    v_stride_head                = sv.sh;
+    v_stride_dim                 = sv.sd;
 
     AITER_CHECK(position_ids.size(0) == num_tokens,
                 "Number of tokens in position_ids must match activations");
@@ -2658,14 +2600,7 @@ void fused_qk_norm_rope_cache_quant_shuffle(
             v_cache.dim());
     }
 
-    if(!use_separate)
-    {
-        int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
-        AITER_CHECK(qkv.size(1) == total_heads * head_dim,
-                    "QKV tensor size must match total number of heads and head dimension");
-    }
-
-    const int stream_device = use_separate ? opt_q.value().device_id : qkv.device_id;
+    const int stream_device = q_t.device_id;
     HipDeviceGuard device_guard(stream_device);
     const hipStream_t stream = aiter::getCurrentHIPStream();
 

--- a/op_tests/test_fused_qk_norm_rope_cache_quant.py
+++ b/op_tests/test_fused_qk_norm_rope_cache_quant.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+import copy
 import torch
 from torch import Tensor
 import aiter
@@ -95,17 +96,60 @@ def apply_rotary_emb_diffusers(
 
 
 def apply_rotary_emb_dispatch(
-    x: Tensor, cos: Tensor, sin: Tensor, is_neox_style: bool
+    x: Tensor,
+    cos: Tensor,
+    sin: Tensor,
+    is_neox_style: bool,
+    rotary_dim: int = 0,
 ) -> Tensor:
     """
     Args:
         x: [num_tokens, num_heads, head_size]
-        cos: [num_tokens, head_size // 2]
-        sin: [num_tokens, head_size // 2]
+        cos: [num_tokens, rotary_dim // 2]
+        sin: [num_tokens, rotary_dim // 2]
         is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
             positional embeddings.
+        rotary_dim: 0 means full rotary; otherwise only the first rotary_dim
+            channels are rotated.
     """
+    head_size = x.shape[-1]
+    rotary_dim_ = rotary_dim if rotary_dim > 0 else head_size
+    if rotary_dim_ < head_size:
+        x_rot = apply_rotary_emb_torch(x[..., :rotary_dim_], cos, sin, is_neox_style)
+        return torch.cat((x_rot, x[..., rotary_dim_:]), dim=-1)
     return apply_rotary_emb_torch(x, cos, sin, is_neox_style)
+
+
+def split_qkv(
+    qkv: Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_size: int,
+) -> tuple[Tensor, Tensor, Tensor]:
+    q_size = num_heads_q * head_size
+    k_size = num_heads_k * head_size
+    v_size = num_heads_v * head_size
+    qkv_2d = qkv.view(qkv.shape[0], q_size + k_size + v_size)
+    return (
+        qkv_2d[:, :q_size],
+        qkv_2d[:, q_size : q_size + k_size],
+        qkv_2d[:, q_size + k_size :],
+    )
+
+
+def clone_qkv_inputs(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_size: int,
+) -> tuple[Tensor, Tensor, Tensor]:
+    # deepcopy preserves the original split-view aliasing/strides, so perf/warmup
+    # iterations do not mutate the caller's tensors in-place.
+    return copy.deepcopy((q, k, v))
 
 
 @perftest()
@@ -113,7 +157,7 @@ def run_torch_qk_norm_rope_cache_quant_shuffle(
     qkv: Tensor,  # contiguous (num_tokens * (num_heads_q + num_heads_k + num_heads_v) * head_size)
     qw: Tensor,  #  contiguous (head_size)
     kw: Tensor,  #  contiguous (head_size)
-    cos_sin: Tensor,  # contiguous (max_positions * head_size)
+    cos_sin: Tensor,  # contiguous (max_positions * rotary_dim), rotary_dim <= head_size
     positions: Tensor,  # contiguous (3 * num_tokens) or (num_tokens)
     num_tokens: int,
     num_heads_q: int,
@@ -129,11 +173,7 @@ def run_torch_qk_norm_rope_cache_quant_shuffle(
     slot_mapping: Tensor,
     kv_cache_dtype: str,
 ):
-    q_size = num_heads_q * head_size
-    k_size = num_heads_k * head_size
-    v_size = num_heads_v * head_size
-    qkv = qkv.view(num_tokens, q_size + k_size + v_size)
-    q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
+    q, k, v = split_qkv(qkv, num_heads_q, num_heads_k, num_heads_v, head_size)
 
     q_by_head = q.view(num_tokens, num_heads_q, head_size)
     q_by_head = rms_norm_forward(q_by_head, qw, eps)
@@ -143,18 +183,19 @@ def run_torch_qk_norm_rope_cache_quant_shuffle(
     k_by_head = rms_norm_forward(k_by_head, kw, eps)
     k = k_by_head.view(k.shape)
 
-    cos_sin = cos_sin.view(cos_sin.shape[0], head_size)
+    rotary_dim = cos_sin.shape[-1]
+    cos_sin = cos_sin.view(cos_sin.shape[0], rotary_dim)
     cos_sin = cos_sin[positions]
     cos, sin = cos_sin.chunk(2, dim=-1)
 
     q_shape = q.shape
     q = q.view(num_tokens, -1, head_size)
-    q = apply_rotary_emb_dispatch(q, cos, sin, is_neox_style)
+    q = apply_rotary_emb_dispatch(q, cos, sin, is_neox_style, rotary_dim)
     q = q.reshape(q_shape)
 
     k_shape = k.shape
     k = k.view(num_tokens, -1, head_size)
-    k = apply_rotary_emb_dispatch(k, cos, sin, is_neox_style)
+    k = apply_rotary_emb_dispatch(k, cos, sin, is_neox_style, rotary_dim)
 
     v = v.view(num_tokens, -1, head_size)
 
@@ -184,12 +225,13 @@ def run_torch_qk_norm_rope_cache_quant_shuffle(
 
 @perftest()
 def run_aiter_qk_norm_rope_cache_quant_shuffle(
-    qkv: Tensor,  # contiguous (num_tokens * (num_heads_q + num_heads_k + num_heads_v) * head_size)
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
     qw: Tensor,  #  contiguous (head_size)
     kw: Tensor,  #  contiguous (head_size)
     cos_sin: Tensor,  # contiguous (max_positions * head_size)
     positions: Tensor,  # contiguous (3 * num_tokens)
-    num_tokens: int,
     num_heads_q: int,
     num_heads_k: int,
     num_heads_v: int,
@@ -203,70 +245,13 @@ def run_aiter_qk_norm_rope_cache_quant_shuffle(
     k_scale: Tensor,
     v_scale: Tensor,
 ):
-    qkv = qkv.clone()  # inplace op
-
-    aiter.fused_qk_norm_rope_cache_quant_shuffle(
-        qkv,
-        num_heads_q=num_heads_q,
-        num_heads_k=num_heads_k,
-        num_heads_v=num_heads_v,
-        head_dim=head_size,
-        eps=eps,
-        qw=qw,
-        kw=kw,
-        cos_sin_cache=cos_sin,
-        is_neox_style=is_neox_style,
-        pos_ids=positions,
-        k_cache=k_cache,
-        v_cache=v_cache,
-        slot_mapping=slot_mapping,
-        kv_cache_dtype=kv_cache_dtype,
-        k_scale=k_scale,
-        v_scale=v_scale,
+    q, k, v = clone_qkv_inputs(
+        q, k, v, num_heads_q, num_heads_k, num_heads_v, head_size
     )
-
-    q_size = num_heads_q * head_size
-    k_size = num_heads_k * head_size
-    v_size = num_heads_v * head_size
-
-    qkv = qkv.view(num_tokens, q_size + k_size + v_size)
-    q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
-    return q, k, v, k_cache, v_cache
-
-
-@perftest()
-def run_aiter_qk_norm_rope_cache_quant_shuffle_separate(
-    qkv: Tensor,
-    qw: Tensor,
-    kw: Tensor,
-    cos_sin: Tensor,
-    positions: Tensor,
-    num_tokens: int,
-    num_heads_q: int,
-    num_heads_k: int,
-    num_heads_v: int,
-    head_size: int,
-    is_neox_style: bool,
-    eps: float,
-    k_cache: Tensor,
-    v_cache: Tensor,
-    slot_mapping: Tensor,
-    kv_cache_dtype: str,
-    k_scale: Tensor,
-    v_scale: Tensor,
-):
-    """Same as run_aiter_qk_norm_rope_cache_quant_shuffle but exercises q/k/v inputs."""
-    q_size = num_heads_q * head_size
-    k_size = num_heads_k * head_size
-    v_size = num_heads_v * head_size
-    qkv_c = qkv.clone()
-    qkv_2d = qkv_c.view(num_tokens, q_size + k_size + v_size)
-    # 与 concat qkv 同一块存储上 split 出的视图（通常非 contiguous）
-    q = qkv_2d[:, :q_size]
-    k = qkv_2d[:, q_size : q_size + k_size]
-    v = qkv_2d[:, q_size + k_size :]
     aiter.fused_qk_norm_rope_cache_quant_shuffle(
-        None,
+        q,
+        k,
+        v,
         num_heads_q=num_heads_q,
         num_heads_k=num_heads_k,
         num_heads_v=num_heads_v,
@@ -283,16 +268,13 @@ def run_aiter_qk_norm_rope_cache_quant_shuffle_separate(
         kv_cache_dtype=kv_cache_dtype,
         k_scale=k_scale,
         v_scale=v_scale,
-        q=q,
-        k=k,
-        v=v,
     )
     return q, k, v, k_cache, v_cache
 
 
 @benchmark()
-def test_shuffle_separate_inputs_match_concat_qkv():
-    """fused_qk_norm_rope_cache_quant_shuffle: q/k/v path matches legacy concatenated qkv."""
+def test_shuffle_contiguous_inputs_match_split_views():
+    """Contiguous q/k/v inputs should match non-contiguous split views."""
     dtype = torch.bfloat16
     num_tokens = 11
     num_heads_q = num_heads_k = num_heads_v = 2
@@ -346,13 +328,27 @@ def test_shuffle_separate_inputs_match_concat_qkv():
     v_scale_c = v_scale.clone()
     qkv_c = qkv.clone()
 
+    q1_src, k1_src, v1_src = split_qkv(
+        qkv.clone(), num_heads_q, num_heads_k, num_heads_v, head_size
+    )
+    q1_src = q1_src.contiguous()
+    k1_src = k1_src.contiguous()
+    v1_src = v1_src.contiguous()
+    q2_src, k2_src, v2_src = split_qkv(
+        qkv_c, num_heads_q, num_heads_k, num_heads_v, head_size
+    )
+    assert not q2_src.is_contiguous()
+    assert not k2_src.is_contiguous()
+    assert not v2_src.is_contiguous()
+
     (q1, k1, v1, kc1, vc1), _ = run_aiter_qk_norm_rope_cache_quant_shuffle(
-        qkv,
+        q1_src,
+        k1_src,
+        v1_src,
         qw,
         kw,
         cos_sin,
         positions,
-        num_tokens,
         num_heads_q,
         num_heads_k,
         num_heads_v,
@@ -367,13 +363,14 @@ def test_shuffle_separate_inputs_match_concat_qkv():
         v_scale,
     )
 
-    (q2, k2, v2, kc2, vc2), _ = run_aiter_qk_norm_rope_cache_quant_shuffle_separate(
-        qkv_c,
+    (q2, k2, v2, kc2, vc2), _ = run_aiter_qk_norm_rope_cache_quant_shuffle(
+        q2_src,
+        k2_src,
+        v2_src,
         qw,
         kw,
         cos_sin,
         positions,
-        num_tokens,
         num_heads_q,
         num_heads_k,
         num_heads_v,
@@ -388,9 +385,9 @@ def test_shuffle_separate_inputs_match_concat_qkv():
         v_scale_c,
     )
 
-    checkAllclose(q1, q2, msg="q separate vs qkv", rtol=1e-2, atol=0.05)
-    checkAllclose(k1, k2, msg="k separate vs qkv", rtol=1e-2, atol=0.05)
-    checkAllclose(v1, v2, msg="v separate vs qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(q1, q2, msg="q contiguous vs split-view", rtol=1e-2, atol=0.05)
+    checkAllclose(k1, k2, msg="k contiguous vs split-view", rtol=1e-2, atol=0.05)
+    checkAllclose(v1, v2, msg="v contiguous vs split-view", rtol=1e-2, atol=0.05)
     checkAllclose(kc1.float(), kc2.float(), msg="k_cache", rtol=1e-2, atol=0.05)
     checkAllclose(vc1.float(), vc2.float(), msg="v_cache", rtol=1e-2, atol=0.05)
     checkAllclose(k_scale, k_scale_c, msg="k_scale", rtol=1e-2, atol=0.05)
@@ -398,8 +395,8 @@ def test_shuffle_separate_inputs_match_concat_qkv():
 
 
 @benchmark()
-def test_shuffle_noncontiguous_qkv_matches_contiguous():
-    """q/k/v 仅从拼接 qkv 的 view 上 slice 得到（同一行存储、stride0 为总宽，通常非 contiguous），与 concat qkv 路径一致。"""
+def test_shuffle_noncontiguous_split_views_match_contiguous_inputs():
+    """Non-contiguous q/k/v split views should match equivalent contiguous inputs."""
     dtype = torch.bfloat16
     num_tokens = 11
     num_heads_q = num_heads_k = num_heads_v = 2
@@ -453,14 +450,21 @@ def test_shuffle_noncontiguous_qkv_matches_contiguous():
     v_cache_ref = v_cache.clone()
     k_scale_ref = k_scale.clone()
     v_scale_ref = v_scale.clone()
+    q_ref_src, k_ref_src, v_ref_src = split_qkv(
+        buf_ref, num_heads_q, num_heads_k, num_heads_v, head_size
+    )
+    q_ref_src = q_ref_src.contiguous()
+    k_ref_src = k_ref_src.contiguous()
+    v_ref_src = v_ref_src.contiguous()
     (q_ref, k_ref, v_ref, kc_ref, vc_ref), _ = (
         run_aiter_qk_norm_rope_cache_quant_shuffle(
-            buf_ref,
+            q_ref_src,
+            k_ref_src,
+            v_ref_src,
             qw,
             kw,
             cos_sin,
             positions,
-            num_tokens,
             num_heads_q,
             num_heads_k,
             num_heads_v,
@@ -490,7 +494,9 @@ def test_shuffle_noncontiguous_qkv_matches_contiguous():
     assert not v_nc.is_contiguous()
 
     aiter.fused_qk_norm_rope_cache_quant_shuffle(
-        qkv=None,
+        q_nc,
+        k_nc,
+        v_nc,
         num_heads_q=num_heads_q,
         num_heads_k=num_heads_k,
         num_heads_v=num_heads_v,
@@ -507,14 +513,11 @@ def test_shuffle_noncontiguous_qkv_matches_contiguous():
         kv_cache_dtype=kv_cache_dtype,
         k_scale=k_scale_a,
         v_scale=v_scale_a,
-        q=q_nc,
-        k=k_nc,
-        v=v_nc,
     )
 
-    checkAllclose(q_nc, q_ref, msg="q split-view vs concat qkv", rtol=1e-2, atol=0.05)
-    checkAllclose(k_nc, k_ref, msg="k split-view vs concat qkv", rtol=1e-2, atol=0.05)
-    checkAllclose(v_nc, v_ref, msg="v split-view vs concat qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(q_nc, q_ref, msg="q split-view vs contiguous", rtol=1e-2, atol=0.05)
+    checkAllclose(k_nc, k_ref, msg="k split-view vs contiguous", rtol=1e-2, atol=0.05)
+    checkAllclose(v_nc, v_ref, msg="v split-view vs contiguous", rtol=1e-2, atol=0.05)
     checkAllclose(
         k_cache_a.float(), kc_ref.float(), msg="k_cache", rtol=1e-2, atol=0.05
     )
@@ -526,8 +529,8 @@ def test_shuffle_noncontiguous_qkv_matches_contiguous():
 
 
 @benchmark()
-def test_shuffle_when_qkv_and_qkv_tensors_both_passed_uses_qk_v():
-    """同时传入拼接 qkv 与 q/k/v 时走 q/k/v；qkv 内容应被忽略。"""
+def test_shuffle_3d_inputs_match_2d_inputs():
+    """The operator should produce the same result for equivalent 2D and 3D q/k/v inputs."""
     dtype = torch.bfloat16
     num_tokens = 9
     num_heads_q = num_heads_k = num_heads_v = 2
@@ -560,7 +563,7 @@ def test_shuffle_when_qkv_and_qkv_tensors_both_passed_uses_qk_v():
         return kc, vc
 
     slot_mapping = torch.randperm(num_tokens, dtype=torch.int64, device="cuda")
-    qkv_truth = torch.randn(
+    qkv = torch.randn(
         (num_tokens, (num_heads_q + num_heads_k + num_heads_v) * head_size),
         dtype=dtype,
         device="cuda",
@@ -575,23 +578,24 @@ def test_shuffle_when_qkv_and_qkv_tensors_both_passed_uses_qk_v():
     qs = int(num_heads_q * head_size)
     ks = int(num_heads_k * head_size)
     vs = int(num_heads_v * head_size)
-    flat = qkv_truth.view(num_tokens, qs + ks + vs)
+    flat = qkv.view(num_tokens, qs + ks + vs)
     q_src = flat[:, :qs].contiguous()
     k_src = flat[:, qs : qs + ks].contiguous()
     v_src = flat[:, qs + ks :].contiguous()
 
-    k_cache_a, v_cache_a = make_kv_caches()
+    k_cache_init, v_cache_init = make_kv_caches()
+    k_cache_a, v_cache_a = k_cache_init.clone(), v_cache_init.clone()
     k_scale_a = torch.zeros(
         [num_blocks, num_heads_k, page_size], dtype=torch.float32, device="cuda"
     )
     v_scale_a = torch.zeros(
         [num_blocks, num_heads_v, page_size], dtype=torch.float32, device="cuda"
     )
-    qkv_decoy = torch.randn_like(qkv_truth)
-
     q_a, k_a, v_a = q_src.clone(), k_src.clone(), v_src.clone()
     aiter.fused_qk_norm_rope_cache_quant_shuffle(
-        qkv_decoy,
+        q_a,
+        k_a,
+        v_a,
         num_heads_q=num_heads_q,
         num_heads_k=num_heads_k,
         num_heads_v=num_heads_v,
@@ -608,17 +612,18 @@ def test_shuffle_when_qkv_and_qkv_tensors_both_passed_uses_qk_v():
         kv_cache_dtype=kv_cache_dtype,
         k_scale=k_scale_a,
         v_scale=v_scale_a,
-        q=q_a,
-        k=k_a,
-        v=v_a,
     )
 
-    k_cache_b, v_cache_b = make_kv_caches()
+    k_cache_b, v_cache_b = k_cache_init.clone(), v_cache_init.clone()
     k_scale_b = torch.zeros_like(k_scale_a)
     v_scale_b = torch.zeros_like(v_scale_a)
-    q_b, k_b, v_b = q_src.clone(), k_src.clone(), v_src.clone()
+    q_b = q_src.clone().view(num_tokens, num_heads_q, head_size)
+    k_b = k_src.clone().view(num_tokens, num_heads_k, head_size)
+    v_b = v_src.clone().view(num_tokens, num_heads_v, head_size)
     aiter.fused_qk_norm_rope_cache_quant_shuffle(
-        qkv_truth.clone(),
+        q_b,
+        k_b,
+        v_b,
         num_heads_q=num_heads_q,
         num_heads_k=num_heads_k,
         num_heads_v=num_heads_v,
@@ -635,14 +640,11 @@ def test_shuffle_when_qkv_and_qkv_tensors_both_passed_uses_qk_v():
         kv_cache_dtype=kv_cache_dtype,
         k_scale=k_scale_b,
         v_scale=v_scale_b,
-        q=q_b,
-        k=k_b,
-        v=v_b,
     )
 
-    checkAllclose(q_a, q_b, msg="q decoy vs truth qkv", rtol=1e-2, atol=0.05)
-    checkAllclose(k_a, k_b, msg="k decoy vs truth qkv", rtol=1e-2, atol=0.05)
-    checkAllclose(v_a, v_b, msg="v decoy vs truth qkv", rtol=1e-2, atol=0.05)
+    checkAllclose(q_a, q_b.view_as(q_a), msg="q 2d vs 3d", rtol=1e-2, atol=0.05)
+    checkAllclose(k_a, k_b.view_as(k_a), msg="k 2d vs 3d", rtol=1e-2, atol=0.05)
+    checkAllclose(v_a, v_b.view_as(v_a), msg="v 2d vs 3d", rtol=1e-2, atol=0.05)
     checkAllclose(
         k_cache_a.float(), k_cache_b.float(), msg="k_cache", rtol=1e-2, atol=0.05
     )
@@ -889,12 +891,16 @@ def test_qk_norm_rope_cache_quant(
     num_blocks,
     page_size,
     max_positions: int = 10000,
+    rotary_dim: int = 0,
 ):
     # Construct tensors inside the function
     if kv_cache_dtype == "fp8_e4m3":
         cache_dtype = get_dtype_fp8()
     else:
         cache_dtype = dtype
+    rotary_dim_ = rotary_dim if rotary_dim > 0 else head_size
+    assert rotary_dim_ <= head_size
+    assert rotary_dim_ % 2 == 0
 
     k_cache = torch.randn(
         [num_blocks, page_size, num_heads_k, head_size],
@@ -929,7 +935,7 @@ def test_qk_norm_rope_cache_quant(
     )
     qw = torch.randn(head_size, dtype=dtype, device="cuda")
     kw = torch.randn(head_size, dtype=dtype, device="cuda")
-    cos_sin = torch.randn((max_positions, head_size), dtype=dtype, device="cuda")
+    cos_sin = torch.randn((max_positions, rotary_dim_), dtype=dtype, device="cuda")
     pos_shape = (num_tokens,)
     positions = torch.randint(
         0, max_positions, pos_shape, dtype=torch.int64, device="cuda"
@@ -959,13 +965,17 @@ def test_qk_norm_rope_cache_quant(
             kv_cache_dtype,
         )
     )
+    q_in, k_in, v_in = split_qkv(
+        qkv.clone(), num_heads_q, num_heads_k, num_heads_v, head_size
+    )
     (q, k, v, k_cache, v_cache), avg_cu = run_aiter_qk_norm_rope_cache_quant_shuffle(
-        qkv,
+        q_in,
+        k_in,
+        v_in,
         qw,
         kw,
         cos_sin,
         positions,
-        num_tokens,
         num_heads_q,
         num_heads_k,
         num_heads_v,
@@ -981,6 +991,8 @@ def test_qk_norm_rope_cache_quant(
     )
 
     info = f"dtype:{dtype}, num_tokens:{num_tokens}, num_heads_q:{num_heads_q}, num_heads_k:{num_heads_k}, num_heads_v:{num_heads_v}, head_size:{head_size}, is_neox_style:{is_neox_style}"
+    if rotary_dim > 0:
+        info += f", rotary_dim:{rotary_dim_}"
     msg = f"[perf] === {info} === torch avg: {avg_torch:<8.2f} us, cu avg: {avg_cu:<8.2f} us, uplift: {avg_torch / avg_cu - 1:<5.1%}"
     checkAllclose(q_ref, q, msg="q", rtol=1e-2, atol=0.05)
     checkAllclose(k_ref, k, msg="k", rtol=1e-2, atol=0.05)
@@ -996,6 +1008,7 @@ def test_qk_norm_rope_cache_quant(
     ret = {}
     ret["fused_qk_us"] = avg_cu
     ret["unfused_us"] = avg_torch
+    ret["rotary_dim"] = rotary_dim_
     ret["aiter_bw(TB/s)"] = (
         num_tokens
         * (num_heads_k + num_heads_v + num_heads_q)
@@ -1079,14 +1092,22 @@ def test_qk_norm_rope_cache_quant_v_shuffle_layout(
     k_scale_b = k_scale.clone()
     v_scale_b = v_scale.clone()
 
+    q_a_in, k_a_in, v_a_in = split_qkv(
+        qkv.clone(), num_heads_q, num_heads_k, num_heads_v, head_size
+    )
+    q_b_in, k_b_in, v_b_in = split_qkv(
+        qkv.clone(), num_heads_q, num_heads_k, num_heads_v, head_size
+    )
+
     (q_a, k_a, v_a, k_cache_a, v_cache_a), avg_a = (
         run_aiter_qk_norm_rope_cache_quant_shuffle(
-            qkv.clone(),
+            q_a_in,
+            k_a_in,
+            v_a_in,
             qw,
             kw,
             cos_sin,
             positions,
-            num_tokens,
             num_heads_q,
             num_heads_k,
             num_heads_v,
@@ -1104,12 +1125,13 @@ def test_qk_norm_rope_cache_quant_v_shuffle_layout(
 
     (q_b, k_b, v_b, k_cache_b, v_cache_b), avg_b = (
         run_aiter_qk_norm_rope_cache_quant_shuffle(
-            qkv.clone(),
+            q_b_in,
+            k_b_in,
+            v_b_in,
             qw,
             kw,
             cos_sin,
             positions,
-            num_tokens,
             num_heads_q,
             num_heads_k,
             num_heads_v,
@@ -2788,6 +2810,9 @@ if __name__ == "__main__":
     df = []
     # rope
     block_df = []
+    # partial rope: Qwen3.5-style has head_size=256 and rotary_dim=64
+    # GLM 4.7 has head_size=128 and rotary_dim=64
+    partial_rotary_configs = {256: 64, 128: 64, 64: 16}
 
     for is_neox_style in args.is_neox_styles:
         for num_token in args.token:
@@ -2833,6 +2858,27 @@ if __name__ == "__main__":
                                     max_positions=args.max_positions,
                                 )
                                 df.append(ret)
+                                partial_rotary_dim = partial_rotary_configs.get(
+                                    head_size
+                                )
+                                if partial_rotary_dim is not None:
+                                    assert partial_rotary_dim < head_size
+                                    ret = test_qk_norm_rope_cache_quant(
+                                        args.dtype,
+                                        num_token,
+                                        num_head,
+                                        num_kv_head,
+                                        num_kv_head,
+                                        head_size,
+                                        is_neox_style,
+                                        1e-6,
+                                        kv_cache_dtype,
+                                        args.num_blocks,
+                                        args.page_size,
+                                        max_positions=args.max_positions,
+                                        rotary_dim=partial_rotary_dim,
+                                    )
+                                    df.append(ret)
     df = pd.DataFrame(df)
     block_df = pd.DataFrame(block_df)
     if "per_head" in args.quant_type:


### PR DESCRIPTION
## Motivation
This PR added support of partial rope, i.e., rotary_dim < head_dim, with fused_qk_norm_rope_cache_quant_shuffle kernel.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
