### PR TITLE
[feat] add no_combine flag in 2-stage MoE backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ scripts/results/*.csv
 # vim swaps
 *.swo
 *.swp
+
+# Agents
+.humanize/

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -171,6 +171,11 @@ def fused_moe(
     splitk=0,
     swiglu_limit=0.0,
     gate_mode: Optional[str] = GateMode.SEPARATED.value,
+    # When True, return per-route unweighted output of shape (M, topk, model_dim)
+    # instead of the combined (M, model_dim) output. Supported on the CK 2-stage
+    # path with QuantType.No and bf16 inputs/output; other configs raise
+    # NotImplementedError.
+    no_combine: bool = False,
 ):
     if not block_size_M:
         block_size_M = -1
@@ -198,6 +203,7 @@ def fused_moe(
         bias2=bias2,
         swiglu_limit=swiglu_limit,
         gate_mode=gate_mode,
+        no_combine=no_combine,
     )
 
 
@@ -227,12 +233,16 @@ def fused_moe_fake(
     bias2: Optional[torch.Tensor] = None,
     swiglu_limit: float = 0.0,
     gate_mode: str = GateMode.SEPARATED.value,
+    no_combine: bool = False,
 ) -> torch.Tensor:
     device = topk_ids.device
     M, topk = topk_ids.shape
     dtype = hidden_states.dtype if dtype is None else dtype
     model_dim = w2.shape[1]
-    moe_buf = torch.empty((M, model_dim), dtype=dtype, device=device)
+    if no_combine:
+        moe_buf = torch.empty((M, topk, model_dim), dtype=dtype, device=device)
+    else:
+        moe_buf = torch.empty((M, model_dim), dtype=dtype, device=device)
     return moe_buf
 
 
@@ -263,6 +273,7 @@ def fused_moe_(
     bias2: Optional[torch.Tensor] = None,
     swiglu_limit: float = 0.0,
     gate_mode: str = GateMode.SEPARATED.value,
+    no_combine: bool = False,
 ) -> torch.Tensor:
     # We do such convert since custom_op schema restriction on block_size_M, and Enum type
     activation = ActivationType(activation)
@@ -273,6 +284,38 @@ def fused_moe_(
     """user API"""
     M, topk = topk_ids.shape
     E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+
+    # no_combine guards: reject early before any kernel launch so the
+    # per-route output contract is only attempted on the supported path
+    # (CK 2-stage, QuantType.No, bf16, no stage1 weighting).
+    if no_combine:
+        if quant_type != QuantType.No:
+            raise NotImplementedError(
+                f"fused_moe(no_combine=True) only supports quant_type=QuantType.No; "
+                f"got quant_type={quant_type!r}"
+            )
+        if doweight_stage1:
+            raise NotImplementedError(
+                "fused_moe(no_combine=True) is incompatible with doweight_stage1=True "
+                "(stage1 weighting contradicts the unweighted per-route output contract)"
+            )
+        if hidden_states.dtype != dtypes.bf16:
+            raise NotImplementedError(
+                f"fused_moe(no_combine=True) only supports bf16 inputs; "
+                f"got hidden_states.dtype={hidden_states.dtype}"
+            )
+        for _wname, _w in (("w1", w1), ("w2", w2)):
+            if _w.dtype != dtypes.bf16:
+                raise NotImplementedError(
+                    f"fused_moe(no_combine=True) only supports bf16 weights; "
+                    f"got {_wname}.dtype={_w.dtype}"
+                )
+        _resolved_out_dtype = hidden_states.dtype if dtype is None else dtype
+        if _resolved_out_dtype != dtypes.bf16:
+            raise NotImplementedError(
+                f"fused_moe(no_combine=True) only supports bf16 output dtype; "
+                f"got dtype={_resolved_out_dtype}"
+            )
 
     assert w1.shape[1] in [
         inter_dim,
@@ -351,6 +394,11 @@ def fused_moe_(
     )
 
     if metadata.run_1stage:
+        if no_combine:
+            raise NotImplementedError(
+                "fused_moe(no_combine=True) only supports the CK 2-stage path; "
+                "the configured shape selected the 1-stage dispatch (metadata.run_1stage=True)"
+            )
         return metadata.stage1(
             hidden_states,
             w1,
@@ -409,6 +457,7 @@ def fused_moe_(
             # only for flydsl dsv4
             swiglu_limit=swiglu_limit,
             gate_mode=gate_mode,
+            no_combine=no_combine,
         )
 
 
@@ -1451,6 +1500,7 @@ def fused_moe_2stages(
     topk_weights=None,
     swiglu_limit=0.0,
     gate_mode=GateMode.SEPARATED.value,
+    no_combine: bool = False,
 ):
     quant_func = get_quant(quant_type)
     gate_mode = GateMode(gate_mode)
@@ -1477,6 +1527,21 @@ def fused_moe_2stages(
         is_shuffled,
         gate_mode,
     )
+
+    if no_combine:
+        _stage1_func = getattr(metadata.stage1, "func", metadata.stage1)
+        if _stage1_func in (_flydsl_stage1_wrapper, cktile_moe_stage1, asm_stage1):
+            raise NotImplementedError(
+                f"fused_moe(no_combine=True) requires CK 2-stage stage1; "
+                f"the configured shape selected {getattr(_stage1_func, '__name__', _stage1_func)!r}."
+            )
+        _stage2_func = getattr(metadata.stage2, "func", metadata.stage2)
+        if _stage2_func is not aiter.ck_moe_stage2_fwd:
+            raise NotImplementedError(
+                f"fused_moe(no_combine=True) requires CK 2-stage stage2; "
+                f"the configured shape selected {getattr(_stage2_func, '__name__', _stage2_func)!r}."
+            )
+
     if (
         quant_type == QuantType.per_1x32
         and dtype in [dtypes.bf16, dtypes.fp16]
@@ -1666,6 +1731,36 @@ def fused_moe_2stages(
             num_rows_factor=topk,
         )
         a2 = a2.view(token_num, topk, inter_dim)
+
+    if no_combine:
+        per_route_out = torch.zeros(
+            (token_num, topk, model_dim),
+            dtype=dtype,
+            device=device,
+        )
+        metadata.stage2(
+            a2,
+            w1,
+            w2,
+            sorted_ids,
+            sorted_expert_ids,
+            num_valid_ids,
+            per_route_out,
+            topk,
+            w2_scale=(
+                w2_scale.view(dtypes.fp8_e8m0) if w2.dtype == dtypes.fp4x2 else w2_scale
+            ),
+            a2_scale=a2_scale,
+            block_m=block_size_M,
+            sorted_weights=None,
+            no_combine=True,
+            **extra_stage2_args,
+        )
+        if num_local_tokens is not None:
+            k_local = int(num_local_tokens.item())
+            if 0 <= k_local < token_num:
+                per_route_out[k_local:, :, :].zero_()
+        return per_route_out
 
     metadata.stage2(
         a2,

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -818,6 +818,10 @@ def build_module(
         if not any("ENABLE_CK" in f for f in flags_extra_cc):
             flags_cc.append(f"-DENABLE_CK={enable_ck}")
 
+        if int(os.environ.get("AITER_CK_HAS_NO_COMBINE_TEMPLATE", "0")):
+            flags_hip.append("-DAITER_CK_HAS_NO_COMBINE_TEMPLATE")
+            flags_cc.append("-DAITER_CK_HAS_NO_COMBINE_TEMPLATE")
+
         enable_rope_positions_int32 = int(
             os.environ.get("ENABLE_ROPE_POSITIONS_INT32", "0")
         )

--- a/aiter/ops/moe_op.py
+++ b/aiter/ops/moe_op.py
@@ -275,6 +275,7 @@ def cmdGenFunc_ck_moe_stage2(
     use_non_temporal_load: bool = False,
     dst_type: Optional[str] = None,
     is_shuffled: bool = True,
+    no_combine: bool = False,
 ):
 
     mul_routed_weight_stage = 1 if sorted_weights is None else 2
@@ -286,6 +287,7 @@ def cmdGenFunc_ck_moe_stage2(
         quant_type,
         mul_routed_weight_stage,
         is_shuffled,
+        no_combine=no_combine,
     )
     return {
         "md_name": md_name,
@@ -338,6 +340,7 @@ def ck_moe_stage2(
     use_non_temporal_load: bool = False,
     dst_type: Optional[str] = None,
     is_shuffled: bool = True,
+    no_combine: bool = False,
 ) -> None: ...
 
 
@@ -491,6 +494,7 @@ def get_moe_stage_module(
     mul_routed_weight_stage,
     preshuffle_mode=False,
     is_splitk=False,
+    no_combine=False,
 ):
     if isinstance(activation, int):
         activation = ActivationType(activation)
@@ -506,6 +510,7 @@ def get_moe_stage_module(
         preshuffle_str = "--preshuffle"
 
     splitk_str = "--issplitk" if is_splitk else ""
+    no_combine_str = "--no_combine" if no_combine else ""
     quant_type = (
         QuantType.per_1x128 if quant_type == QuantType.per_128x128 else quant_type
     )
@@ -524,9 +529,11 @@ def get_moe_stage_module(
     ]
     if is_splitk:
         parts.append("splitk")
+    if no_combine:
+        parts.append("no_combine")
     md_name = "_".join(parts)
     blob_gen_cmd = [
-        f"{AITER_CSRC_DIR}/ck_gemm_moe_2stages_codegen/gen_instances.py -a {Adtype} -b {Bdtype} -c {Cdtype} -q {quant_type} -act {act} -m {mul_routed_weight_stage} {preshuffle_str} {splitk_str} -w {{}}"
+        f"{AITER_CSRC_DIR}/ck_gemm_moe_2stages_codegen/gen_instances.py -a {Adtype} -b {Bdtype} -c {Cdtype} -q {quant_type} -act {act} -m {mul_routed_weight_stage} {preshuffle_str} {splitk_str} {no_combine_str} -w {{}}"
     ]
 
     return md_name, blob_gen_cmd
@@ -593,6 +600,7 @@ def ck_moe_stage2_fwd(
     quant_type: QuantType = QuantType.No,
     activation: ActivationType = ActivationType.Silu,
     use_non_temporal_load: Optional[bool] = False,
+    no_combine: bool = False,
 ):
     ck_moe_stage2(
         inter_states,
@@ -612,5 +620,6 @@ def ck_moe_stage2_fwd(
         activation.value,
         use_non_temporal_load=use_non_temporal_load,
         is_shuffled=getattr(w2, "is_shuffled", False),
+        no_combine=no_combine,
     )
     return out

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu
@@ -16,12 +16,20 @@ using MoeKernelMap = std::unordered_map<std::string, MoeKernel>;
 // API for user aiter.ck_moe_stage1(...)
 
 template <int stage = 1>
-MoeKernel moe_dispatch(std::string &kernelName, int block_m, int inter_dim, at::ScalarType x_dtype, at::ScalarType w_dtype, at::ScalarType y_dtype, int act_op, int quant_type, bool mul_routed_weight, bool is_shuffled)
+MoeKernel moe_dispatch(std::string &kernelName, int block_m, int inter_dim, at::ScalarType x_dtype, at::ScalarType w_dtype, at::ScalarType y_dtype, int act_op, int quant_type, bool mul_routed_weight, bool is_shuffled, bool no_combine = false)
 {
     static const auto lookup = []
     {
         return MoeKernelMap{GENERATE_LOOKUP_TABLE()};
     }();
+
+    if constexpr (stage == 2)
+    {
+        if (no_combine)
+        {
+            kernelName = "";
+        }
+    }
 
     if (kernelName != "")
     {
@@ -39,7 +47,7 @@ MoeKernel moe_dispatch(std::string &kernelName, int block_m, int inter_dim, at::
     }
     else
     {
-        return moe_stage2_heuristic_dispatch(block_m, inter_dim, x_dtype, w_dtype, y_dtype, 0, quant_type, mul_routed_weight, is_shuffled);
+        return moe_stage2_heuristic_dispatch(block_m, inter_dim, x_dtype, w_dtype, y_dtype, 0, quant_type, mul_routed_weight, is_shuffled, no_combine);
     }
 }
 
@@ -135,7 +143,8 @@ void ck_moe_stage2(torch::Tensor &inter_states,      // [m, k], input token
                    std::optional<int> splitk = 1,
                    bool nt = false,
                    std::optional<std::string> dst_type = std::nullopt,
-                   bool is_shuffled = true)
+                   bool is_shuffled = true,
+                   bool no_combine = false)
 {
     // std::cerr << __FILE__ << ":" << __LINE__ << " ck_moe_stage2 called!" << nt << " " << block_m.value() << std::endl;
     TORCH_CHECK(out.dtype() == at::ScalarType::BFloat16 || out.dtype() == at::ScalarType::Half,
@@ -173,7 +182,7 @@ void ck_moe_stage2(torch::Tensor &inter_states,      // [m, k], input token
     }
 
     activation = !activation;
-    auto kernel = moe_dispatch<2>(kernelName, MPerBlock, K, inter_states.dtype().toScalarType(), w1.dtype().toScalarType(), out.dtype().toScalarType(), activation, quant_type, MulRoutedWeight, is_shuffled);
+    auto kernel = moe_dispatch<2>(kernelName, MPerBlock, K, inter_states.dtype().toScalarType(), w1.dtype().toScalarType(), out.dtype().toScalarType(), activation, quant_type, MulRoutedWeight, is_shuffled, no_combine);
 
     kernel(at::hip::getCurrentHIPStream(),
            tokens, sorted_size, N, K, topk,

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.h
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.h
@@ -456,7 +456,8 @@ template <typename A0DataType,
           bool Nswizzle,
           bool PerTensorQuant,
           bool MulRoutedWeight,
-          int ActOP>
+          int ActOP,
+          bool NoCombine = false>
 void ck_moe_stage2_gemm(
     const hipStream_t& stream,
     int tokens,

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.cuh
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.cuh
@@ -108,7 +108,11 @@ void ck_moe_stage1_gemm(const hipStream_t& stream,
                S<K0_A, K0_M_A, 1>, S<1, 0, 2>, S<1, 0, 2>, 2, AK1, AK1, 0,
                S<K0_B, K0_N_B, 1>, S<1, 0, 2>, S<1, 0, 2>, 2, BK1, BK1, 0,
                CShuffleMXDLPerWave,    CShuffleNXDLPerWave,   S<1, CShuffleMLane, 1, CShuffleNLane>, S<EVec, D0Vec, D1Vec>,
+#ifdef AITER_CK_HAS_NO_COMBINE_TEMPLATE
+               ck::BlockGemmPipelineScheduler::Intrawave, PipelineVer, ActOP, Nswizzle, true, MulRoutedWeight, !PerTensorQuant, false, ck::index_t, A0DataType>;
+#else
                ck::BlockGemmPipelineScheduler::Intrawave, PipelineVer, ActOP, Nswizzle, true, MulRoutedWeight, !PerTensorQuant, ck::index_t, A0DataType>;
+#endif
     // clang-format on
 
     auto a_element_op   = AElementOp{};
@@ -210,7 +214,8 @@ template <typename A0DataType,
           bool Nswizzle,
           bool PerTensorQuant,
           bool MulRoutedWeight,
-          int ActOP = 0>
+          int ActOP,
+          bool NoCombine>
 void ck_moe_stage2_gemm(const hipStream_t& stream,
                         int tokens,
                         int sorted_size,
@@ -295,7 +300,15 @@ void ck_moe_stage2_gemm(const hipStream_t& stream,
               S<K0_A, K0_M, 1>, S<1, 0, 2>, S<1, 0, 2>, 2, AK1, AK1, 0,
               S<K0_B, K0_N, 1>, S<1, 0, 2>, S<1, 0, 2>, 2, BK1, BK1, 0,
               CShuffleMXDLPerWave,    CShuffleNXDLPerWave,   S<1, CShuffleMLane, 1, CShuffleNLane>, S<EVec, D0Vec, D1Vec, D2Vec>,
+#ifdef AITER_CK_HAS_NO_COMBINE_TEMPLATE
+              ck::BlockGemmPipelineScheduler::Intrawave, PipelineVer, 0, Nswizzle, false, MulRoutedWeight, !PerTensorQuant, NoCombine, ck::index_t, A0DataType>;
+#else
               ck::BlockGemmPipelineScheduler::Intrawave, PipelineVer, 0, Nswizzle, false, MulRoutedWeight, !PerTensorQuant, ck::index_t, A0DataType>;
+    static_assert(!NoCombine,
+                  "ck_moe_stage2_gemm: NoCombine=true requires building with "
+                  "AITER_CK_HAS_NO_COMBINE_TEMPLATE defined and a CK DeviceMoeGemm "
+                  "that accepts the trailing NoCombine template parameter.");
+#endif
 
 
     auto a_element_op = AElementOp{};
@@ -346,7 +359,7 @@ void ck_moe_stage2_gemm(const hipStream_t& stream,
 }
 
 #define CK_MOE_STAGE2_GEMM_DEFINE(BLOCKSIZE, MPerfBlock, NPerfBlock, KPerBlock, MWaves, NWaves, PipelineVer)                                                                                    \
-    template void ck_moe_stage2_gemm<A0DataType, B0DataType, AccDataType, EDataType, CDEElementOp, PipelineVer, BLOCKSIZE, MPerfBlock, NPerfBlock, KPerBlock, MWaves, NWaves, Nswizzle, PerTensorQuant, MulRoutedWeight, ActOP>( \
+    template void ck_moe_stage2_gemm<A0DataType, B0DataType, AccDataType, EDataType, CDEElementOp, PipelineVer, BLOCKSIZE, MPerfBlock, NPerfBlock, KPerBlock, MWaves, NWaves, Nswizzle, PerTensorQuant, MulRoutedWeight, ActOP, NoCombine>( \
         const hipStream_t &stream,                                                                                                                                   \
         int tokens, int sorted_size, int N, int K,                                                                                                                   \
         int topk,                                                                                                                                                    \

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.py
@@ -78,6 +78,7 @@ class kernelInstanceGEMM2:
     GemmPipelineVersion: int
     Nswizzle: bool = False
     MulRoutedWeight: bool = True
+    NoCombine: bool = False
     CDEElementOp: str = "TypeCast"
     QuantType: int = 1
     stage: int = 2
@@ -104,6 +105,7 @@ class kernelInstanceGEMM2:
                 "Nswizzle" + str(int(self.Nswizzle)),
                 "Quant" + str(self.QuantType),
                 "MulRoutedWeight" + str(int(self.MulRoutedWeight)),
+                "NoCombine" + str(int(self.NoCombine)),
                 self.Adtype.upper(),
                 self.Bdtype.upper(),
                 self.Cdtype.upper(),
@@ -444,6 +446,7 @@ def get_gemm2_kernels_list(
     QuantType: str,
     MulRoutedWeight: bool,
     preshuffle: bool = False,
+    NoCombine: bool = False,
 ) -> list:
     arch = get_gfx()
 
@@ -480,6 +483,7 @@ def get_gemm2_kernels_list(
     kernels_list = {k: copy.deepcopy(v) for k, v in gemm2_kernels_dict[tag].items()}
     for id, kernel in kernels_list.items():
         kernel.MulRoutedWeight = MulRoutedWeight
+        kernel.NoCombine = NoCombine
         kernel.Nswizzle = Nswizzle
         kernel.QuantType = QuantType
         kernel.Adtype = Adtype

--- a/csrc/ck_gemm_moe_2stages_codegen/gen_instances.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gen_instances.py
@@ -18,6 +18,7 @@ const bool Nswizzle = {Nswizzle};
 const bool PerTensorQuant = {Quant} == static_cast<int>(QuantType::per_Tensor);
 const bool MulRoutedWeight = {MulRoutedWeight};
 const int ActOP = {ActOP};
+[[maybe_unused]] const bool NoCombine = {NoCombine};
 CK_MOE_STAGE{Stage}_GEMM_DEFINE({BlockSize}, {MPerBlock}, {NPerBlock}, {KPerBlock}, {MWaves}, {NWaves}, V{PipelineVer})
 """
 
@@ -32,7 +33,7 @@ LOOKUP_head = """#pragma once
 
 LOOKUP_template = """
        {{"{kernel_tag}",                                                                                                       \\
-        ck_moe_stage{Stage}_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V{PipelineVer}, {BlockSize}, {MPerBlock}, {NPerBlock}, {KPerBlock}, {MWaves}, {NWaves}, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>}},                       \\"""
+        ck_moe_stage{Stage}_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V{PipelineVer}, {BlockSize}, {MPerBlock}, {NPerBlock}, {KPerBlock}, {MWaves}, {NWaves}, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}{NoCombineSuffix}>}},                       \\"""
 
 LOOKUP_end = """
    }
@@ -54,7 +55,7 @@ gemm2_heuristic_dispatch_head = """#pragma once
 // Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 #include "gemm_moe_ck2stages.h"
 
-MoeKernel moe_stage2_heuristic_dispatch(int block_m, int inter_dim, at::ScalarType x_dtype, at::ScalarType w_dtype, at::ScalarType y_dtype, int act_op, int quant, bool mul_routed_weight_stage, bool is_shuffled)
+MoeKernel moe_stage2_heuristic_dispatch(int block_m, int inter_dim, at::ScalarType x_dtype, at::ScalarType w_dtype, at::ScalarType y_dtype, int act_op, int quant, bool mul_routed_weight_stage, bool is_shuffled, bool no_combine)
 {{
 """
 
@@ -366,50 +367,51 @@ A16W16_gemm2_gfx950_heuristic_dispatch = """
         && dtype_checker<{B0DataType}>{{}}(w_dtype)
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
-        && {Quant} == quant)
+        && {Quant} == quant
+        && {NoCombine} == no_combine)
     {{
         if (block_m == 32)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 64)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 128)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 256)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else
@@ -428,23 +430,24 @@ A8W8_gemm2_gfx950_heuristic_dispatch = """
         && dtype_checker<{B0DataType}>{{}}(w_dtype)
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
-        && {Quant} == quant)
+        && {Quant} == quant
+        && {NoCombine} == no_combine)
     {{
         if (block_m == 32)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 64)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 128)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 256)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else
         {{
@@ -461,50 +464,51 @@ A16W16_gemm2_heuristic_dispatch = """
         && dtype_checker<{B0DataType}>{{}}(w_dtype)
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
-        && {Quant} == quant)
+        && {Quant} == quant
+        && {NoCombine} == no_combine)
     {{
         if (block_m == 32)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 64)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 128)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 256)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else
@@ -522,54 +526,55 @@ A8W8_gemm2_heuristic_dispatch = """
         && dtype_checker<{B0DataType}>{{}}(w_dtype)
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
-        && {Quant} == quant)
+        && {Quant} == quant
+        && {NoCombine} == no_combine)
     {{
         if (block_m == 16)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 16, 64, 64, 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 16, 64, 64, 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 32)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 64)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 128)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else if (block_m == 256)
         {{
             if (inter_dim <= 192)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
         }}
         else
@@ -587,23 +592,24 @@ A8W4_gemm2_heuristic_dispatch = """
         && dtype_checker<{B0DataType}>{{}}(w_dtype)
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
-        && {Quant} == quant)
+        && {Quant} == quant
+        && {NoCombine} == no_combine)
     {{
         if (block_m == 32)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 64)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 128)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 256)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 256, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else
         {{
@@ -623,21 +629,22 @@ A4W4_gemm2_heuristic_dispatch = """
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
         && {Quant} == quant
-        && {Preshuffle} == is_shuffled)
+        && {Preshuffle} == is_shuffled
+        && {NoCombine} == no_combine)
     {{
         if (inter_dim <= 256)
         {{
             if (block_m == 32)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 32, 32, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 32, 32, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 64)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 64, 64, 128, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 64, 64, 128, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 128)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 64, 128, 128, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 64, 128, 128, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
@@ -651,15 +658,15 @@ A4W4_gemm2_heuristic_dispatch = """
         {{
             if (block_m == 32)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 64)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 128)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
@@ -680,21 +687,22 @@ A4W4_bns_gemm2_heuristic_dispatch = """
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
         && {Quant} == quant
-        && {Preshuffle} == is_shuffled)
+        && {Preshuffle} == is_shuffled
+        && {NoCombine} == no_combine)
     {{
         if (inter_dim <= 256)
         {{
             if (block_m == 32)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 32, 32, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 32, 32, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 64)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 64, 64, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 64, 64, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 128)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 128, 128, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 64, 128, 128, 128/sizeof({A0DataType}), 1, 1, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
@@ -708,15 +716,15 @@ A4W4_bns_gemm2_heuristic_dispatch = """
         {{
             if (block_m == 32)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 64)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 64, 128/sizeof({A0DataType}), 2, 2, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 64, 128/sizeof({A0DataType}), 2, 2, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else if (block_m == 128)
             {{
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 128/sizeof({A0DataType}), 2, 2, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 128/sizeof({A0DataType}), 2, 2, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             }}
             else
             {{
@@ -736,22 +744,23 @@ A8W8_blockscale_gemm2_heuristic_dispatch = """
         && dtype_checker<{B0DataType}>{{}}(w_dtype)
         && dtype_checker<{EDataType}>{{}}(y_dtype)
         && {MulRoutedWeight} == mul_routed_weight_stage
-        && {Quant} == quant)
+        && {Quant} == quant
+        && {NoCombine} == no_combine)
     {{
         if (block_m == 16)
         {{
             if (inter_dim % 256 == 0)
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 16, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 16, 128, 256/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
             else
-                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 128, 16, 128, 128/sizeof({A0DataType}), 1, 2, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+                return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 128, 16, 128, 128/sizeof({A0DataType}), 1, 2, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 32)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else if (block_m == 64)
         {{
-            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
+            return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 64, 128, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}, {NoCombine}>;
         }}
         else
         {{
@@ -854,6 +863,7 @@ class ck_moe_2stage_gemm_codegen:
         mul_routed_weight_stage,
         preshuffle,
         splitk,
+        no_combine: bool = False,
     ):
         self.working_path = working_path
         self.a_dtype = a_dtype.upper()
@@ -865,19 +875,23 @@ class ck_moe_2stage_gemm_codegen:
         self.nswizzle = False
         self.preshuffle = preshuffle
         self.splitk = splitk
+        self.no_combine = no_combine
 
     def generate_instance_and_lookUpTable(self):
-        _, gemm1_kernel_list = get_gemm1_kernels_list(
-            self.a_dtype,
-            self.b_dtype,
-            self.c_dtype,
-            self.nswizzle,
-            self.quant_type,
-            self.activation,
-            self.mul_routed_weight_stage == 1,
-            self.preshuffle,
-            self.splitk,
-        )
+        if not self.no_combine:
+            _, gemm1_kernel_list = get_gemm1_kernels_list(
+                self.a_dtype,
+                self.b_dtype,
+                self.c_dtype,
+                self.nswizzle,
+                self.quant_type,
+                self.activation,
+                self.mul_routed_weight_stage == 1,
+                self.preshuffle,
+                self.splitk,
+            )
+        else:
+            gemm1_kernel_list = {}
         tag, gemm2_kernel_list = get_gemm2_kernels_list(
             self.a_dtype,
             self.b_dtype,
@@ -886,6 +900,7 @@ class ck_moe_2stage_gemm_codegen:
             self.quant_type,
             self.mul_routed_weight_stage == 2,
             self.preshuffle,
+            self.no_combine,
         )
         kernel_list = list(gemm1_kernel_list.values()) + list(
             gemm2_kernel_list.values()
@@ -941,6 +956,9 @@ class ck_moe_2stage_gemm_codegen:
                             MulRoutedWeight=str(
                                 self.mul_routed_weight_stage == kernel.stage
                             ).lower(),
+                            NoCombine=str(
+                                self.no_combine and kernel.stage == 2
+                            ).lower(),
                         )
                         if "FP4" in self.b_dtype:
                             stage_instance = (
@@ -970,30 +988,36 @@ class ck_moe_2stage_gemm_codegen:
                     MulRoutedWeight=str(
                         self.mul_routed_weight_stage == kernel.stage
                     ).lower(),
+                    NoCombineSuffix=(
+                        f", {str(self.no_combine).lower()}"
+                        if kernel.stage == 2
+                        else ""
+                    ),
                 )
                 f_lookup.write(lookup_ele)
 
-        f_gemm1_heuristic_dispatch = os.path.join(
-            self.working_path, "ck2stages_moe_stage1_heuristic_dispatch.hpp"
-        )
         gemm1_heuristic_dispatch, gemm2_heuristic_dispatch = heuristic_dispatch_dict[
             tag
         ]
-        with open(f_gemm1_heuristic_dispatch, "a") as f_h:
-            gemm1_fp32 = self.splitk and (quanttype == "_blockscale")
-            gemm1_heuristic_dispatch_str = gemm1_heuristic_dispatch.format(
-                A0DataType=self.a_dtype,
-                B0DataType=self.b_dtype,
-                AccDataType="F32" if self.a_dtype != "I8" else "I32",
-                EDataType="F32" if gemm1_fp32 else self.c_dtype,
-                CDEElementOp=kernel_list[0].CDEElementOp,
-                Nswizzle=str(self.nswizzle).lower(),
-                Quant=self.quant_type,
-                ActOP=str(int(self.activation == "silu")),
-                MulRoutedWeight=str(self.mul_routed_weight_stage == 1).lower(),
-                Preshuffle=str(self.preshuffle).lower(),
+        if not self.no_combine:
+            f_gemm1_heuristic_dispatch = os.path.join(
+                self.working_path, "ck2stages_moe_stage1_heuristic_dispatch.hpp"
             )
-            f_h.write(gemm1_heuristic_dispatch_str)
+            with open(f_gemm1_heuristic_dispatch, "a") as f_h:
+                gemm1_fp32 = self.splitk and (quanttype == "_blockscale")
+                gemm1_heuristic_dispatch_str = gemm1_heuristic_dispatch.format(
+                    A0DataType=self.a_dtype,
+                    B0DataType=self.b_dtype,
+                    AccDataType="F32" if self.a_dtype != "I8" else "I32",
+                    EDataType="F32" if gemm1_fp32 else self.c_dtype,
+                    CDEElementOp=kernel_list[0].CDEElementOp,
+                    Nswizzle=str(self.nswizzle).lower(),
+                    Quant=self.quant_type,
+                    ActOP=str(int(self.activation == "silu")),
+                    MulRoutedWeight=str(self.mul_routed_weight_stage == 1).lower(),
+                    Preshuffle=str(self.preshuffle).lower(),
+                )
+                f_h.write(gemm1_heuristic_dispatch_str)
 
         f_gemm2_heuristic_dispatch = os.path.join(
             self.working_path, "ck2stages_moe_stage2_heuristic_dispatch.hpp"
@@ -1010,6 +1034,7 @@ class ck_moe_2stage_gemm_codegen:
                 ActOP=0,
                 MulRoutedWeight=str(self.mul_routed_weight_stage == 2).lower(),
                 Preshuffle=str(self.preshuffle).lower(),
+                NoCombine=str(self.no_combine).lower(),
             )
             f_h.write(gemm2_heuristic_dispatch_str)
 
@@ -1106,6 +1131,12 @@ if __name__ == "__main__":
         help="enable moe_stage1 splitk mode",
     )
 
+    parser.add_argument(
+        "--no_combine",
+        action="store_true",
+        help="emit a stage2 variant that writes per-route [M, topk, model_dim] without route reduction",
+    )
+
     args = parser.parse_args()
     args.quant_type = (
         "per_1x128" if args.quant_type == "per_128x128" else args.quant_type
@@ -1118,6 +1149,22 @@ if __name__ == "__main__":
         "per_1x32": 3,
         "per_1x128": 4,
     }
+
+    if args.no_combine:
+        if args.quant_type != "no":
+            parser.error(
+                f"--no_combine requires --quant_type=no; got {args.quant_type}"
+            )
+        if args.c_dtype != "b16":
+            parser.error(
+                f"--no_combine requires --c_dtype=b16; got {args.c_dtype}"
+            )
+        if args.b_dtype is not None:
+            non_b16 = [d for d in args.b_dtype if d != "b16"]
+            if non_b16:
+                parser.error(
+                    f"--no_combine requires --b_dtype to be only b16; got {non_b16}"
+                )
 
     generate_instance_and_lookUpTable_head(args.working_path)
     # build all
@@ -1203,6 +1250,21 @@ if __name__ == "__main__":
                 False,  # splitk
             )
             codegen.generate_instance_and_lookUpTable()
+            # NoCombine stage2 variant: QuantType.No x bf16 only
+            if b_dtype == "b16":
+                codegen_nc = ck_moe_2stage_gemm_codegen(
+                    args.working_path,
+                    a_dtype,
+                    b_dtype,
+                    c_dtype,
+                    quant_dict["no"],
+                    act,
+                    routed_weight,
+                    preshuffle_mode,
+                    False,  # splitk
+                    no_combine=True,
+                )
+                codegen_nc.generate_instance_and_lookUpTable()
     else:
         for b_dtype in args.b_dtype:
             a_dtype = b_dtype if b_dtype != "i4" else "f8"
@@ -1216,6 +1278,7 @@ if __name__ == "__main__":
                 args.mul_routed_weight_stage,
                 args.preshuffle,
                 args.issplitk,
+                no_combine=args.no_combine,
             )
             codegen.generate_instance_and_lookUpTable()
 

--- a/csrc/include/moe_ck.h
+++ b/csrc/include/moe_ck.h
@@ -42,4 +42,5 @@ void ck_moe_stage2(torch::Tensor& inter_states, // [m, k], input token
                    std::optional<int> splitk,
                    bool nt,
                    std::optional<std::string> dst_type,
-                   bool is_shuffled);
+                   bool is_shuffled,
+                   bool no_combine);

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1024,7 +1024,8 @@ namespace py = pybind11;
           py::arg("splitk")            = 1,            \
           py::arg("non_temporal_load") = false,        \
           py::arg("dst_type")          = std::nullopt, \
-          py::arg("is_shuffled")       = true);
+          py::arg("is_shuffled")       = true,         \
+          py::arg("no_combine")        = false);
 
 #define MOE_CKTILE_2STAGES_PYBIND                    \
     m.def("cktile_moe_gemm1",                        \

--- a/op_tests/test_moe_no_combine.py
+++ b/op_tests/test_moe_no_combine.py
@@ -1,0 +1,496 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for `fused_moe(..., no_combine=True)`.
+
+`no_combine=True` returns per-route unweighted output of shape
+`(M, topk, model_dim)` instead of the default combined `(M, model_dim)`.
+Downstream consumers (e.g. GPT-OSS-style pipelines) apply their own topk
+weighting and mixing after the kernel.
+
+Scope (MI350X / gfx950):
+- CK 2-stage backend only.
+- bf16 inputs / weights / output, QuantType.No only.
+- Other configurations raise NotImplementedError.
+
+Hardware-running tests require the patched CK header that adds the
+`bool NoCombine = false` template parameter to `DeviceMoeGemm` and gate
+the stage2 epilogue on `MulRoutedWeight && !NoCombine`. Build aiter with
+`AITER_CK_HAS_NO_COMBINE_TEMPLATE=1` to enable. Without the patch, the
+hardware tests skip via `_NEEDS_CK_NO_COMBINE`.
+"""
+
+import os
+
+import pytest
+import torch
+
+import aiter
+from aiter import ActivationType, QuantType
+from aiter.fused_moe import (
+    MOEMetadata,
+    asm_stage1,
+    cktile_moe_stage1,
+    cktile_moe_stage2,
+    fused_moe,
+    fused_moe_fake,
+    torch_moe_stage1,
+    _flydsl_stage1_wrapper,
+    _flydsl_stage2_wrapper,
+)
+from aiter.ops.shuffle import shuffle_weight
+
+torch.set_default_device("cuda")
+
+
+_NEEDS_CK_NO_COMBINE = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or os.environ.get("AITER_CK_HAS_NO_COMBINE_TEMPLATE") != "1",
+    reason=(
+        "CK NoCombine template not available. Build aiter with "
+        "AITER_CK_HAS_NO_COMBINE_TEMPLATE=1 against a CK that carries the "
+        "DeviceMoeGemm NoCombine patch."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Reference and fixtures
+# ---------------------------------------------------------------------------
+
+
+def _torch_reference_route_outputs(hidden, w1, w2, topk_ids, topk_w):
+    """Per-route unweighted reference matching `fused_moe(no_combine=True)`.
+
+    Pipeline: `torch_moe_stage1(doweight=False)` then an inline per-route
+    stage2 GEMM that keeps the topk axis intact. `torch_moe_stage2` collapses
+    the topk axis via `.sum(1)`, which is why we re-implement its inner GEMM
+    here. Returns dtype bf16 to match the kernel output.
+    """
+    stage1_out = torch_moe_stage1(
+        hidden, w1, w2, topk_w, topk_ids,
+        dtype=torch.bfloat16,
+        activation=ActivationType.Silu,
+        quant_type=QuantType.No,
+        doweight=False,
+    )
+    token_num, topk = topk_ids.shape
+    model_dim = w2.shape[1]
+    stage1_fp32 = stage1_out.to(torch.float32)
+    w2_fp32 = w2.to(torch.float32)
+    out = torch.zeros(
+        (token_num, topk, model_dim),
+        dtype=torch.float32,
+        device=stage1_out.device,
+    )
+    for e in range(w2.shape[0]):
+        mask = topk_ids == e
+        if not mask.any():
+            continue
+        sub = stage1_fp32[mask]
+        out[mask] = sub @ w2_fp32[e].transpose(0, 1)
+    return out.to(torch.bfloat16)
+
+
+def _make_bf16_case(
+    M, topk, model_dim, inter_dim, expert_num,
+    *, seed=0, topk_id_override=None,
+):
+    """Deterministic case builder.
+
+    `topk_ids` defaults to a per-token round-robin over experts so different
+    tokens land on different expert mixes without invoking the optional
+    fused_topk ASM kernel.
+    """
+    torch.manual_seed(seed)
+    dtype = torch.bfloat16
+    hidden_states = torch.randn((M, model_dim), dtype=dtype)
+    w1 = torch.randn((expert_num, inter_dim * 2, model_dim), dtype=dtype) * 0.02
+    w2 = torch.randn((expert_num, model_dim, inter_dim), dtype=dtype) * 0.02
+    if topk_id_override is not None:
+        topk_ids = topk_id_override.to(torch.int32)
+    else:
+        base = torch.arange(M, dtype=torch.int32).unsqueeze(1)
+        offset = torch.arange(topk, dtype=torch.int32).unsqueeze(0)
+        topk_ids = ((base + offset) % expert_num).contiguous()
+    topk_weights = torch.ones((M, topk), dtype=torch.float32) / topk
+    return hidden_states, w1, w2, topk_ids, topk_weights
+
+
+def _shuffled(*tensors):
+    """CK 2-stage expects pre-shuffled weights (layout=(16, 16)).
+
+    Mirrors the convention used by `op_tests/test_moe_2stage.py`.
+    """
+    return tuple(shuffle_weight(t, layout=(16, 16)) for t in tensors)
+
+
+# ---------------------------------------------------------------------------
+# Shape contract
+# ---------------------------------------------------------------------------
+
+
+def test_default_returns_combined_shape():
+    """Regression guard: default call (no no_combine kwarg) keeps (M, D)."""
+    M, topk, model_dim, inter_dim, expert_num = 64, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    out = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+    )
+    assert out.shape == (M, model_dim)
+    assert out.shape != (M, topk, model_dim)
+
+
+@_NEEDS_CK_NO_COMBINE
+@pytest.mark.parametrize(
+    "M,topk,model_dim,inter_dim",
+    [
+        (64, 2, 128, 256),
+        (64, 4, 512, 512),
+        (64, 8, 2048, 1024),
+    ],
+)
+def test_no_combine_returns_per_route_shape(M, topk, model_dim, inter_dim):
+    """no_combine=True returns contiguous (M, topk, model_dim)."""
+    expert_num = 16
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    w1, w2 = _shuffled(w1, w2)
+    out = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        no_combine=True,
+    )
+    assert out.shape == (M, topk, model_dim)
+    assert out.shape != (M, model_dim)
+    assert out.is_contiguous()
+    assert out.dtype == torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
+# Numerical correctness
+# ---------------------------------------------------------------------------
+
+
+@_NEEDS_CK_NO_COMBINE
+@pytest.mark.parametrize("topk", [2, 4, 8])
+@pytest.mark.parametrize("model_dim", [128, 512, 2048])
+def test_no_combine_matches_torch_reference(topk, model_dim):
+    """fused_moe(no_combine=True) matches the per-route torch reference."""
+    M, inter_dim, expert_num = 64, 1024, 16
+    hidden, w1_orig, w2_orig, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    w1, w2 = _shuffled(w1_orig, w2_orig)
+    out = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        no_combine=True,
+    )
+    ref = _torch_reference_route_outputs(hidden, w1_orig, w2_orig, topk_ids, topk_w)
+    torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
+
+
+@_NEEDS_CK_NO_COMBINE
+@pytest.mark.parametrize("topk", [2, 4, 8])
+@pytest.mark.parametrize("model_dim", [128, 512, 2048])
+def test_no_combine_sums_to_combined(topk, model_dim):
+    """Weighted sum of per-route output equals the combined kernel output."""
+    M, inter_dim, expert_num = 64, 1024, 16
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    w1, w2 = _shuffled(w1, w2)
+    out_nc = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        no_combine=True,
+    )
+    out_c = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        no_combine=False,
+    )
+    manual = (out_nc.float() * topk_w.unsqueeze(-1)).sum(dim=1).to(out_c.dtype)
+    is_close = torch.isclose(manual, out_c, rtol=1e-2, atol=5e-2)
+    # Up to 5% of elements may fall outside the band — Python re-cast to bf16
+    # introduces an extra rounding step relative to the in-kernel atomic_add.
+    assert (~is_close).float().mean().item() <= 0.05
+
+
+@_NEEDS_CK_NO_COMBINE
+def test_no_combine_high_numbered_experts():
+    """Exercises the full expert id range (experts {5, 7} of 8)."""
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    topk_ids = torch.tensor([[5, 7]] * M, dtype=torch.int32)
+    hidden, w1_orig, w2_orig, _, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num,
+        topk_id_override=topk_ids,
+    )
+    w1, w2 = _shuffled(w1_orig, w2_orig)
+    out = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        no_combine=True,
+    )
+    ref = _torch_reference_route_outputs(hidden, w1_orig, w2_orig, topk_ids, topk_w)
+    torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Rejection guards
+# ---------------------------------------------------------------------------
+
+
+def test_no_combine_rejects_non_bf16_output_dtype():
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    with pytest.raises(NotImplementedError, match=r"bf16 output dtype"):
+        fused_moe(
+            hidden_states=hidden, w1=w1, w2=w2,
+            topk_weight=topk_w, topk_ids=topk_ids,
+            activation=ActivationType.Silu, quant_type=QuantType.No,
+            dtype=torch.float16,
+            no_combine=True,
+        )
+
+
+def test_no_combine_rejects_doweight_stage1():
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    with pytest.raises(NotImplementedError, match=r"doweight_stage1"):
+        fused_moe(
+            hidden_states=hidden, w1=w1, w2=w2,
+            topk_weight=topk_w, topk_ids=topk_ids,
+            activation=ActivationType.Silu, quant_type=QuantType.No,
+            doweight_stage1=True, no_combine=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "qt",
+    [QuantType.per_Tensor, QuantType.per_Token, QuantType.per_1x128, QuantType.per_1x32],
+)
+def test_no_combine_rejects_non_no_quant(qt):
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    with pytest.raises(NotImplementedError, match=r"quant_type"):
+        fused_moe(
+            hidden_states=hidden, w1=w1, w2=w2,
+            topk_weight=topk_w, topk_ids=topk_ids,
+            activation=ActivationType.Silu, quant_type=qt, no_combine=True,
+        )
+
+
+def _identity_stage1(*args, **kwargs):
+    raise AssertionError("stage1 must not be called when guard fires")
+
+
+def _identity_stage2(*args, **kwargs):
+    raise AssertionError("stage2 must not be called when guard fires")
+
+
+def _patch_metadata(monkeypatch, stage1_func, stage2_func, *, run_1stage=False):
+    """Inject a fake MOEMetadata so the no_combine guards see the requested
+    stage1/stage2 funcs without triggering the real heuristic dispatch.
+    """
+    def fake(*args, **kwargs):
+        return MOEMetadata(
+            stage1=stage1_func, stage2=stage2_func,
+            block_m=32, ksplit=1, run_1stage=run_1stage,
+        )
+    import aiter.fused_moe as fm_mod
+    monkeypatch.setattr(fm_mod, "get_2stage_cfgs", fake)
+
+
+def test_no_combine_rejects_1stage_dispatch(monkeypatch):
+    _patch_metadata(monkeypatch, _identity_stage1, _identity_stage2, run_1stage=True)
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    with pytest.raises(NotImplementedError, match=r"1-stage dispatch"):
+        fused_moe(
+            hidden_states=hidden, w1=w1, w2=w2,
+            topk_weight=topk_w, topk_ids=topk_ids,
+            activation=ActivationType.Silu, quant_type=QuantType.No,
+            no_combine=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "stage1_func",
+    [_flydsl_stage1_wrapper, cktile_moe_stage1, asm_stage1],
+    ids=["flydsl", "cktile", "asm"],
+)
+def test_no_combine_rejects_non_ck_stage1(monkeypatch, stage1_func):
+    _patch_metadata(monkeypatch, stage1_func, aiter.ck_moe_stage2_fwd)
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    with pytest.raises(NotImplementedError, match=r"CK 2-stage stage1"):
+        fused_moe(
+            hidden_states=hidden, w1=w1, w2=w2,
+            topk_weight=topk_w, topk_ids=topk_ids,
+            activation=ActivationType.Silu, quant_type=QuantType.No,
+            no_combine=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "stage2_func",
+    [_flydsl_stage2_wrapper, cktile_moe_stage2],
+    ids=["flydsl", "cktile"],
+)
+def test_no_combine_rejects_non_ck_stage2(monkeypatch, stage2_func):
+    def ck_stage1_stub(*args, **kwargs):
+        raise AssertionError("stage1 must not run when stage2 guard fires")
+    _patch_metadata(monkeypatch, ck_stage1_stub, stage2_func)
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    with pytest.raises(NotImplementedError, match=r"CK 2-stage stage2"):
+        fused_moe(
+            hidden_states=hidden, w1=w1, w2=w2,
+            topk_weight=topk_w, topk_ids=topk_ids,
+            activation=ActivationType.Silu, quant_type=QuantType.No,
+            no_combine=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# EP semantics: pre-zero'd buffer guarantees deterministic zeros where the
+# kernel does not write.
+# ---------------------------------------------------------------------------
+
+
+@_NEEDS_CK_NO_COMBINE
+def test_no_combine_expert_mask_zero_fills_non_local_routes():
+    """Routes to non-local experts (expert_mask=0) stay exactly zero."""
+    M, topk, model_dim, inter_dim, expert_num = 32, 2, 128, 256, 8
+    topk_ids = torch.zeros((M, topk), dtype=torch.int32)
+    topk_ids[:, 0] = 0   # local
+    topk_ids[:, 1] = 7   # non-local
+    hidden, w1, w2, _, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num,
+        topk_id_override=topk_ids,
+    )
+    w1, w2 = _shuffled(w1, w2)
+    expert_mask = torch.tensor([1, 1, 1, 1, 1, 1, 1, 0], dtype=torch.int32)
+    out = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        expert_mask=expert_mask, no_combine=True,
+    )
+    assert torch.all(out[:, 1, :] == 0)
+    assert torch.any(out[:, 0, :] != 0)
+
+
+@_NEEDS_CK_NO_COMBINE
+def test_no_combine_num_local_tokens_zero_fills_tail():
+    """Tokens [k:M] are exactly zero when num_local_tokens=k.
+
+    Enforced in Python (after stage2) by aiter; the CK kernel itself may emit
+    block-padding leakage past the boundary.
+    """
+    M, topk, model_dim, inter_dim, expert_num = 32, 2, 128, 256, 8
+    k_local = 16
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    w1, w2 = _shuffled(w1, w2)
+    num_local_tokens = torch.tensor([k_local], dtype=torch.int32)
+    out = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        num_local_tokens=num_local_tokens, no_combine=True,
+    )
+    assert torch.all(out[k_local:, :, :] == 0)
+    assert torch.any(out[:k_local, :, :] != 0)
+
+
+@_NEEDS_CK_NO_COMBINE
+def test_no_combine_all_experts_masked_produces_zero_output():
+    """All-zero expert_mask produces an all-zero output, no NaNs."""
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    w1, w2 = _shuffled(w1, w2)
+    expert_mask = torch.zeros(expert_num, dtype=torch.int32)
+    out = fused_moe(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        expert_mask=expert_mask, no_combine=True,
+    )
+    assert torch.all(out == 0)
+    assert not torch.any(torch.isnan(out))
+
+
+# ---------------------------------------------------------------------------
+# torch.compile / fake-tensor path
+# ---------------------------------------------------------------------------
+
+
+def test_no_combine_fake_returns_per_route_shape():
+    """fused_moe_fake(..., no_combine=True) returns (M, topk, model_dim)."""
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden = torch.empty((M, model_dim), dtype=torch.bfloat16)
+    w1 = torch.empty((expert_num, inter_dim * 2, model_dim), dtype=torch.bfloat16)
+    w2 = torch.empty((expert_num, model_dim, inter_dim), dtype=torch.bfloat16)
+    topk_ids = torch.zeros((M, topk), dtype=torch.int32)
+    topk_w = torch.ones((M, topk), dtype=torch.float32) / topk
+    out = fused_moe_fake(
+        hidden_states=hidden, w1=w1, w2=w2,
+        topk_weight=topk_w, topk_ids=topk_ids,
+        activation=ActivationType.Silu, quant_type=QuantType.No,
+        no_combine=True,
+    )
+    assert out.shape == (M, topk, model_dim)
+    assert out.dtype == torch.bfloat16
+
+
+@_NEEDS_CK_NO_COMBINE
+def test_no_combine_torch_compile_traces_fused_moe():
+    """torch.compile(fused_moe)(..., no_combine=True) traces and runs."""
+    if not hasattr(torch, "compile"):
+        pytest.skip("torch.compile not available in this torch build")
+    M, topk, model_dim, inter_dim, expert_num = 16, 2, 128, 256, 8
+    hidden, w1, w2, topk_ids, topk_w = _make_bf16_case(
+        M, topk, model_dim, inter_dim, expert_num
+    )
+    w1, w2 = _shuffled(w1, w2)
+
+    def call(h, _w1, _w2, ids, w):
+        return fused_moe(
+            hidden_states=h, w1=_w1, w2=_w2,
+            topk_weight=w, topk_ids=ids,
+            activation=ActivationType.Silu, quant_type=QuantType.No,
+            no_combine=True,
+        )
+
+    compiled = torch.compile(call, fullgraph=False, dynamic=False)
+    out = compiled(hidden, w1, w2, topk_ids, topk_w)
+    assert out.shape == (M, topk, model_dim)
+    assert out.dtype == torch.bfloat16


### PR DESCRIPTION
## Motivation

Adds an opt-in NoCombine template flag that returns CK MoE's per-route [NumTokens, TopK, model_dim]
output (unweighted, no atomic combine) so callers can apply their own post-expert op.

## Technical Details

Adds `no_combine: bool = False` to `aiter.fused_moe`. When `no_combine=True`, the function returns the per-route, *unweighted* output of shape `(M, topk, model_dim)` instead of the default combined `(M, model_dim)`. Downstream callers (e.g. GPT-OSS-style pipelines) apply their own topk weighting / mixing.

### Scope

- Backend: CK 2-stage only (rejects FlyDSL, CK-Tile, ASM stage1; rejects `metadata.run_1stage`; rejects non-CK stage2).
- Quant:   `QuantType.No` only (rejects per_Tensor / per_Token / per_1x128 / per_1x32).
- Dtype:   bf16 inputs, bf16 weights, bf16 output (rejects `dtype=` override).
- Stage1 weighting: rejects `doweight_stage1=True`.

### CK template (submodule bump)

`3rdparty/composable_kernel` needs a separate upstream PR (https://github.com/ROCm/rocm-libraries/pull/7773)

### Aiter wrapper

`csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.cuh` forwards the new template parameter to `DeviceMoeGemm` only when `AITER_CK_HAS_NO_COMBINE_TEMPLATE` is defined; otherwise a `static_assert(!NoCombine, ...)` fails the build for any `NoCombine=true` instantiation. `aiter/jit/core.py` threads the env var of the same name into hipcc `-D` flags.

### Codegen

`csrc/ck_gemm_moe_2stages_codegen/gen_instances.py` adds a `NoCombine: bool = False` field to `kernelInstanceGEMM2`; the `.name` property carries `NoCombine0` / `NoCombine1` after the existing `MulRoutedWeight{0,1}` suffix. The 8 per-dtype `gemm2_heuristic_dispatch` templates branch on `{NoCombine} == no_combine`, and every stage2 `ck_moe_stage2_gemm<...>` template call now appends the `NoCombine` bool. A new `--no_combine` CLI flag emits the `(QuantType.No × b16)` stage2 instances and `parser.error()`s for any combination outside v1 scope.

### Python plumbing

`ck_moe_stage2` / `ck_moe_stage2_fwd` / `cmdGenFunc_ck_moe_stage2` / `get_moe_stage_module` (`aiter/ops/moe_op.py`), the C++ binding (`csrc/include/moe_ck.h`), the dispatcher
(`csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu`), and the pybind macro (`csrc/include/rocm_ops.hpp`) all expose `no_combine: bool = False` end-to-end. `get_moe_stage_module` appends `--no_combine` to the JIT `blob_gen_cmd` and tags the module name with `_no_combine`. The C++ dispatcher force-empties `kernelName2` when `no_combine=true` so the heuristic dispatch is used instead of the tuned table (which only has `NoCombine0` entries today).

`fused_moe_2stages`'s `no_combine` branch pre-zeros a `(token_num, topk, model_dim)` buffer, calls
`metadata.stage2(..., per_route_out, sorted_weights=None, no_combine=True)`, and zeros `per_route_out[k_local:]` when the caller passed `num_local_tokens`. The pre-zero is required by the EP zero-fill contract (non-local routes and `num_local_tokens` tails must be exactly zero in the per-route output).

## Test Plan

40passes in op_tests/test_moe_no_combine.py

## Test Result

Performance (MI350X, gfx950, `AITER_CK_HAS_NO_COMBINE_TEMPLATE=1`)

50-iter trim-10/10/10 mean:

| Shape                                | combined | no_combine | ratio |
|--------------------------------------|----------|------------|-------|
| M=256,  topk=2, D=4096, E=8          | 0.192 ms | 0.193 ms   | 1.006×|
| M=2048, topk=8, D=4096, E=8          | 1.906 ms | 2.073 ms   | 1.088×|

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
