### PR TITLE
[Triton] Flash Attention Nightly Build Issues

### DIFF
--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -312,6 +312,42 @@ jobs:
             python -c "from flash_attn.flash_attn_interface import flash_attn_func; print('flash_attn_func loaded (fake ROCm):', flash_attn_func)"
         shell: bash
 
+  # Triton-backend users install aiter on a pip ROCm distribution that has no
+  # C++ build toolchain or CK. With AITER_TRITON_ONLY, `import aiter` must expose
+  # the Triton ops without triggering the C++ JIT build (see FA #2580). No GPU.
+  nightly_smoke:
+    if: ${{ needs.prechecks.outputs.run_triton == 'true' }}
+    name: Nightly Smoke Test
+    needs: [prechecks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout aiter repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install torch (pip ROCm nightly)
+        run: |
+          python -m pip install --upgrade pip
+          pip install --pre torch torchvision torchaudio \
+            --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/
+        shell: bash
+
+      - name: Install aiter
+        run: pip install -e . --no-build-isolation
+        shell: bash
+
+      - name: Import aiter (Triton ops only, no JIT)
+        env:
+          AITER_TRITON_ONLY: 1
+        run: python -c "import aiter; import aiter.ops.triton; print('triton-only import OK')"
+        shell: bash
+
   # =============================================================================
   # CK Backend
   # =============================================================================

--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -58,14 +58,20 @@ def getLogger():
 
 logger = getLogger()
 AITER_AOT_IMPORT = os.getenv("AITER_AOT_IMPORT", "0") == "1"
+# Triton-only: expose only the Triton ops, skipping the C++/CK/HIP ops and their
+# JIT build. Always on for Windows (no CK/HIP there); elsewhere opt in via the
+# env var, e.g. Triton-backend users with no C++ toolchain or CK.
+AITER_TRITON_ONLY = (
+    os.getenv("AITER_TRITON_ONLY", "0") == "1" or sys.platform == "win32"
+)
 
 # Use bundled pre-compiled FlyDSL cache unless the user overrides via env var.
 _flydsl_cache = os.path.join(os.path.dirname(__file__), "jit", "flydsl_cache")
 if os.path.isdir(_flydsl_cache) and "FLYDSL_RUNTIME_CACHE_DIR" not in os.environ:
     os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = _flydsl_cache
 
-if sys.platform == "win32":
-    logger.info("Windows: CK and HIP ops are not available. Triton ops only.")
+if AITER_TRITON_ONLY:
+    logger.info("Triton ops only: CK and HIP ops (and their JIT build) are skipped.")
 elif AITER_AOT_IMPORT:
     from .jit import core as core  # noqa: E402
 else:


### PR DESCRIPTION
## Motivation

Upstream users are experiencing issues building flash attention on nightly whls. See https://github.com/Dao-AILab/flash-attention/issues/2580. We add a `AITER_TRITON_ONLY ` env variable so that only the triton ops are available. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
