### PR TITLE
[MOE] Drop a_scale_one for _fp8 stage1 + remove fp8 fuse_quant bypass

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1586,12 +1586,7 @@ def fused_moe_2stages(
         and w1.dtype == dtypes.fp4x2
     ):
         # a8w4 mxfp8 activations + mxfp4 weights.
-        if metadata.fuse_quant == "fp8":
-            # FlyDSL stage1 fuses the fp8 quant of a1 internally, but the
-            # kernel dispatch requires an fp8-typed tensor.
-            a1 = hidden_states.to(dtypes.fp8)
-            a1_scale = torch.empty(0, dtype=torch.uint8, device=a1.device)
-        elif _MOE_A8W4_BYPASS_QUANT:
+        if _MOE_A8W4_BYPASS_QUANT:
             # Debug bypass: skip real quant, feed unit scales.
             a1 = hidden_states.to(dtypes.fp8)
             M = sorted_ids.shape[0]

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -60,7 +60,6 @@ def get_flydsl_kernel_params(name: str) -> Optional[Dict]:
                 extra["out_dtype"] = "fp4"
             if m.group("fp8"):
                 extra["out_dtype"] = "fp8"
-                extra["a_scale_one"] = True
             if m.group("sbm") is not None:
                 extra["sort_block_m"] = int(m.group("sbm"))
             return {**params, **extra}


### PR DESCRIPTION
The _fp8 stage1 kernel registry was forcing a_scale_one=True, which made the kernel ignore a1_scale and use scale=1.0 — a silent accuracy loss when hidden_states exceed fp8e4m3 range. Remove the override so the kernel reads the real per-tile scale.

Also drop the fuse_quant=="fp8" host branch in fused_moe_2stages that did a naive bf16→fp8 cast with an empty a1_scale; fall through to the fused_dynamic_mxfp8_quant_moe_sort path which produces a proper mxfp8 scale tensor.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
