### PR TITLE
Normalize CSV line endings for cleaner diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csv text eol=lf


### PR DESCRIPTION
Add a repository-level .gitattributes rule so CSV files are normalized to LF and reduce noisy whole-file CSV diffs caused by cross-platform line-ending differences.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
