### PR TITLE
fix(dist): DP-attention CUDAGraph capture compatibility

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -125,7 +125,7 @@ try:
     from .ops.triton.comms import (
         IrisCommContext,  # noqa: F401
         calculate_heap_size,  # noqa: F401
-        reduce_scatter,  # noqa: F401
+        reduce_scatter as iris_reduce_scatter,  # noqa: F401  # avoid shadowing C++ reduce_scatter exported by custom_all_reduce.py
         all_gather,  # noqa: F401
         reduce_scatter_rmsnorm_quant_all_gather,  # noqa: F401
         IRIS_COMM_AVAILABLE,  # noqa: F401

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -660,17 +660,36 @@ class CustomAllreduce:
         )
         return out
 
+    # Int dtypes have no fp counterpart in the C++ dispatch enum, but the
+    # all-gather kernel is pure memcpy parametrized only by sizeof(T). View
+    # ints as same-size floats so callers gathering token-id tensors work
+    # (e.g. DeepSeek-V4-Pro hash-gate gathers int32 across DP ranks).
+    _INT_TO_FP_VIEW = {
+        torch.int64: torch.float64,
+        torch.int32: torch.float32,
+        torch.int16: torch.float16,
+    }
+
     def custom_all_gather(
         self, inp: torch.Tensor, dim: int = 0
     ) -> Optional[torch.Tensor]:
+        orig_dtype = inp.dtype
+        view_dtype = self._INT_TO_FP_VIEW.get(orig_dtype)
+        if view_dtype is not None:
+            inp = inp.view(view_dtype)
+
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                return self.all_gather_reg(inp, dim=dim)
+                out = self.all_gather_reg(inp, dim=dim)
             else:
                 print("allgather capture hipgraph error")
-                return torch.zeros_like(inp)
+                out = torch.zeros_like(inp)
         else:
-            return self.all_gather_unreg(inp, dim=dim)
+            out = self.all_gather_unreg(inp, dim=dim)
+
+        if view_dtype is not None and out is not None:
+            out = out.view(orig_dtype)
+        return out
 
     def fused_ar_rms(
         self,
@@ -856,7 +875,7 @@ class CustomAllreduce:
         if emit_bf16:
             return out, res_out, scale_out, bf16_out
         return out, res_out, scale_out
-    
+
     def fused_qknorm_ar(
         self,
         qkv_in: torch.Tensor,
@@ -889,7 +908,7 @@ class CustomAllreduce:
             reg_bytes,
         )
         return q_out, k_out, v_out
-    
+
     def custom_fused_qknorm_ar(
         self,
         qkv_in: torch.Tensor,
@@ -900,9 +919,17 @@ class CustomAllreduce:
         dtype = qkv_in.dtype
         if self.disabled:
             return (
-                torch.empty((qkv_in.shape[0], q_w.shape[-1]), dtype=dtype, device=qkv_in.device),
-                torch.empty((qkv_in.shape[0], k_w.shape[-1]), dtype=dtype, device=qkv_in.device),
-                torch.empty((qkv_in.shape[0], qkv_in.shape[1] - q_w.shape[-1] - k_w.shape[-1]), dtype=dtype, device=qkv_in.device)
+                torch.empty(
+                    (qkv_in.shape[0], q_w.shape[-1]), dtype=dtype, device=qkv_in.device
+                ),
+                torch.empty(
+                    (qkv_in.shape[0], k_w.shape[-1]), dtype=dtype, device=qkv_in.device
+                ),
+                torch.empty(
+                    (qkv_in.shape[0], qkv_in.shape[1] - q_w.shape[-1] - k_w.shape[-1]),
+                    dtype=dtype,
+                    device=qkv_in.device,
+                ),
             )
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
@@ -915,9 +942,24 @@ class CustomAllreduce:
                 )
             else:
                 return (
-                    torch.empty((qkv_in.shape[0], q_w.shape[-1]), dtype=dtype, device=qkv_in.device),
-                    torch.empty((qkv_in.shape[0], k_w.shape[-1]), dtype=dtype, device=qkv_in.device),
-                    torch.empty((qkv_in.shape[0], qkv_in.shape[1] - q_w.shape[-1] - k_w.shape[-1]), dtype=dtype, device=qkv_in.device)
+                    torch.empty(
+                        (qkv_in.shape[0], q_w.shape[-1]),
+                        dtype=dtype,
+                        device=qkv_in.device,
+                    ),
+                    torch.empty(
+                        (qkv_in.shape[0], k_w.shape[-1]),
+                        dtype=dtype,
+                        device=qkv_in.device,
+                    ),
+                    torch.empty(
+                        (
+                            qkv_in.shape[0],
+                            qkv_in.shape[1] - q_w.shape[-1] - k_w.shape[-1],
+                        ),
+                        dtype=dtype,
+                        device=qkv_in.device,
+                    ),
                 )
         else:
             return self.fused_qknorm_ar(


### PR DESCRIPTION
## Summary
Two related fixes that together make \`--enable-dp-attention\` work under hipgraph capture for DeepSeek-V4-Pro (and any model whose forward calls \`dp_group.reduce_scatter_tensor\` / \`dp_group.all_gather\` with non-fp inputs).

### 1. \`aiter/__init__.py\` — un-shadow C++ \`reduce_scatter\`
The Iris wrapper had the same name as the C++ \`reduce_scatter\` exported by \`custom_all_reduce.py\`, so Python import order silently shadowed the C++ binding. Callers using \`aiter.reduce_scatter\` (e.g. dp_group's custom-AR reduce_scatter path) resolved to the Iris function and crashed with:

\`\`\`
AttributeError: 'Tensor' object has no attribute 'is_initialized'
\`\`\`

Fix: rename the Iris symbol to \`iris_reduce_scatter\`.

### 2. \`custom_all_reduce.py\` — accept int dtypes in \`custom_all_gather\`
\`custom_all_gather\` previously rejected int dtypes because the C++ \`_all_gather\` dispatch enum only enumerates fp32/fp16/bf16. The underlying \`dispatchAllGather\` kernel is a pure memcpy templated only on \`sizeof(T)\` — type semantics don't matter for gather (no arithmetic).

Fix: zero-copy view int64/int32/int16 as same-size fp dtypes around the call, then view back on output. No kernel change; no perf cost (\`.view()\` is a bit-reinterpret).

Without it, callers gathering token-id tensors (DeepSeek-V4-Pro hash gate gathers int32 across DP ranks) hit:

\`\`\`
RuntimeError: custom allreduce only supports float32, float16 and bfloat16
\`\`\`

## Why both matter
Without either fix, \`dp_group.{all_gather,reduce_scatter_tensor}(..., use_custom=True)\` falls back to \`torch.distributed\` NCCL ops. WorkNCCL records an end-event on the capturing stream, the ProcessGroupNCCL watchdog later calls \`hipEventQuery\` on it, and HIP returns \`hipErrorCapturedEvent\` — server crashes mid decode-graph capture.

## Test plan
- [x] Reproduced original crash: V4-Pro tp=8 \`--enable-dp-attention\` capture at bs=128/256 → \`hipErrorCapturedEvent\` in watchdog
- [x] After fix: capture completes, server READY
- [x] 1k/1k c=128 benchmark: 5325 tok/s, TPOT 42ms (8-rank kineto trace captured cleanly)
- [x] GSM8K 3-shot: flexible-extract 0.9538, strict-match 0.9530 (within baseline noise)
- [ ] Iris path \`iris_reduce_scatter\` callers updated downstream