### PR TITLE
CI: reuse Triton wheel preparation workflow

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -260,32 +260,12 @@ jobs:
 
   prepare_triton_wheel:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
     needs: check-signal
-    env:
-      DOCKER_IMAGE: "rocm/pytorch:latest"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download Triton wheel
-        id: download_triton_wheel
-        continue-on-error: true
-        run: |
-          set -ex
-          docker run --rm \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            ${{ env.DOCKER_IMAGE }} \
-            bash ./.github/scripts/download_triton_wheel.sh triton_wheels
-
-      - name: Upload Triton wheel artifact
-        if: ${{ steps.download_triton_wheel.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
-          path: triton_wheels/
-          retention-days: 3
+    uses: ./.github/workflows/prepare-triton-wheel.yaml
+    with:
+      docker-image: rocm/pytorch:latest
+      artifact-name: triton_wheelhouse
+      retention-days: 3
 
   standard:
     if: >-

--- a/.github/workflows/prepare-triton-wheel.yaml
+++ b/.github/workflows/prepare-triton-wheel.yaml
@@ -1,0 +1,50 @@
+name: Prepare Triton Wheel
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        description: Docker image used to resolve and download the matching Triton wheel.
+        required: false
+        type: string
+        default: rocm/pytorch:latest
+      artifact-name:
+        description: Name of the Triton wheel artifact uploaded for the caller workflow run.
+        required: false
+        type: string
+        default: triton_wheelhouse
+      retention-days:
+        description: Number of days to keep the Triton wheel artifact.
+        required: false
+        type: number
+        default: 3
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Triton wheel
+        id: download_triton_wheel
+        continue-on-error: true
+        run: |
+          set -ex
+          bash .github/scripts/docker_pull_with_retry.sh "${{ inputs.docker-image }}"
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            "${{ inputs.docker-image }}" \
+            bash ./.github/scripts/download_triton_wheel.sh triton_wheels
+
+      - name: Upload Triton wheel artifact
+        if: ${{ steps.download_triton_wheel.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: triton_wheels/
+          retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -15,6 +15,7 @@ on:
       - ".github/scripts/build_aiter_triton.sh"
       - ".github/scripts/download_triton_wheel.sh"
       - ".github/scripts/install_triton.sh"
+      - ".github/workflows/prepare-triton-wheel.yaml"
       - ".github/scripts/select_triton_tests.py"
       - ".github/scripts/split_tests.sh"
       - ".github/scripts/verify_triton_pin.py"
@@ -62,32 +63,12 @@ jobs:
 
   prepare_triton_wheel:
     if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') }}
-    runs-on: ubuntu-latest
     needs: [check-signal]
-    env:
-      DOCKER_IMAGE: "rocm/pytorch:latest"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download Triton wheel
-        id: download_triton_wheel
-        continue-on-error: true
-        run: |
-          set -ex
-          docker run --rm \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            ${{ env.DOCKER_IMAGE }} \
-            bash ./.github/scripts/download_triton_wheel.sh triton_wheels
-
-      - name: Upload Triton wheel artifact
-        if: ${{ steps.download_triton_wheel.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: triton_wheelhouse
-          path: triton_wheels/
-          retention-days: 3
+    uses: ./.github/workflows/prepare-triton-wheel.yaml
+    with:
+      docker-image: rocm/pytorch:latest
+      artifact-name: triton_wheelhouse
+      retention-days: 3
 
   # Step 2: MI35X matrix jobs
   triton:

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -19,6 +19,7 @@ env:
   DOCKER_PULL_MAX_ATTEMPTS: "3"
   DOCKER_PULL_RETRY_DELAY_SECONDS: "10"
   AITER_WHEEL_ARTIFACT_NAME: aiter-vllm-whl-${{ github.run_id }}
+  TRITON_WHEEL_ARTIFACT_NAME: triton_wheelhouse
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -115,6 +116,19 @@ jobs:
           path: dist/*.whl
           retention-days: 14
 
+  prepare_triton_wheel:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      (contains(github.event.pull_request.labels.*.name, 'ci:vllm') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:all')))
+    needs: check-signal
+    uses: ./.github/workflows/prepare-triton-wheel.yaml
+    with:
+      docker-image: rocm/vllm-dev:nightly
+      artifact-name: triton_wheelhouse
+      retention-days: 3
+
   vllm_benchmark:
     name: vLLM Benchmark (8 GPU)
     timeout-minutes: 60
@@ -123,7 +137,7 @@ jobs:
       (github.event.pull_request.draft == false &&
       (contains(github.event.pull_request.labels.*.name, 'ci:vllm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:all')))
-    needs: build_aiter_wheel
+    needs: [build_aiter_wheel, prepare_triton_wheel]
     runs-on: aiter-8gpu-runner
     strategy:
       fail-fast: false
@@ -159,6 +173,13 @@ jobs:
         with:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
           path: aiter_wheels
+
+      - name: Download Triton wheel artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
+          path: triton_wheels
 
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
@@ -209,6 +230,7 @@ jobs:
               $MODEL_MOUNT \
               -v "${{ github.workspace }}:/workspace" -w /workspace \
               -e HF_TOKEN=${{ secrets.HF_TOKEN_TEST }} -e VLLM_ROCM_USE_AITER=1 \
+              -e TRITON_WHEEL_DIR=/workspace/triton_wheels \
               ${{ matrix.extra_env_args }} \
               ${{ env.BASE_IMAGE }} bash -lc "
                 set -euo pipefail
@@ -219,6 +241,8 @@ jobs:
                   exit 1
                 fi
                 ls -lh /workspace/aiter_wheels
+                bash ./.github/scripts/install_triton.sh
+                pip show triton
                 pip uninstall -y aiter amd-aiter || true
                 pip install --no-deps \"\${wheels[0]}\"
                 pip show amd-aiter || pip show aiter


### PR DESCRIPTION
## Summary
- Add a reusable workflow for preparing the Triton wheel artifact once per workflow run.
- Switch Triton tests and Aiter standard tests to call the reusable workflow instead of duplicating the prepare job.
- Add the same Triton wheel artifact setup to vLLM benchmark and install Triton from the artifact before running benchmarks, with public index fallback preserved by install_triton.sh.

## Test plan
- python3 -c "import yaml; [yaml.safe_load(open(p)) for p in ['.github/workflows/prepare-triton-wheel.yaml', '.github/workflows/triton-test.yaml', '.github/workflows/aiter-test.yaml', '.github/workflows/vllm_benchmark.yaml']]"
- git diff --check --cached -- .github/workflows/prepare-triton-wheel.yaml .github/workflows/triton-test.yaml .github/workflows/aiter-test.yaml .github/workflows/vllm_benchmark.yaml