### PR TITLE
Gate opus fp8 code for gfx1100

### DIFF
--- a/csrc/include/aiter_opus_plus.h
+++ b/csrc/include/aiter_opus_plus.h
@@ -9,6 +9,15 @@
 #include <c10/util/Half.h>
 #include <hip/hip_bf16.h>
 
+#if defined(NDEBUG)
+#undef NDEBUG
+#include <assert.h>
+#define UNREACHABLE_CODE assert(false);
+#define NDEBUG
+#else
+#define UNREACHABLE_CODE assert(false);
+#endif
+
 namespace aiter {
 using namespace opus;
 #define RT 0
@@ -52,11 +61,15 @@ OPUS_D decltype(auto) fp32_to_fp8_scaled_x2(const S& s, float inverted_scale)
 #endif
     float a = tmp[0], b = tmp[1];
     int w;
+#if !defined (__GFX11__)
     asm volatile("v_med3_f32 %1, %1, %3, %4\n"
                  "v_med3_f32 %2, %2, %3, %4\n"
                  "v_cvt_pk_fp8_f32 %0, %1, %2"
                  : "=v"(w), "+v"(a), "+v"(b)
                  : "v"(lo), "v"(hi));
+#else
+    UNREACHABLE_CODE
+#endif
     return __builtin_bit_cast(fp8x2_t, static_cast<int16_t>(w));
 }
 
@@ -77,11 +90,15 @@ OPUS_D decltype(auto) fp32_to_bf8_scaled_x2(const S& s, float inverted_scale)
     constexpr float hi = 57344.0f, lo = -57344.0f;
     float a = tmp[0], b = tmp[1];
     int w;
+#if !defined (__GFX11__)
     asm volatile("v_med3_f32 %1, %1, %3, %4\n"
                  "v_med3_f32 %2, %2, %3, %4\n"
                  "v_cvt_pk_bf8_f32 %0, %1, %2"
                  : "=v"(w), "+v"(a), "+v"(b)
                  : "v"(lo), "v"(hi));
+#else
+    UNREACHABLE_CODE
+#endif
     return __builtin_bit_cast(bf8x2_t, static_cast<int16_t>(w));
 }
 

--- a/csrc/include/opus/opus.hpp
+++ b/csrc/include/opus/opus.hpp
@@ -1104,7 +1104,7 @@ OPUS_D constexpr unsigned short fp32_to_bf16_rtn_raw(float f)
     else if(bits & 0xffff) { bits |= 0x10000; /* Preserve signaling NaN */ }
     return static_cast<unsigned short>(bits >> 16);
 }
-#if (defined(__gfx950__) || defined(__gfx1250__) || defined(__gfx1201__) || defined(__gfx1200__)) && __clang_major__ >= 20
+#if (defined(__gfx950__) || defined(__gfx1250__) || defined(__gfx1201__) || defined(__gfx1200__) || defined (__GFX11__)) && __clang_major__ >= 20
 template<index_t rm = OPUS_FP32_to_BF16_DEFAULT> // gfx950/gfx1250/gfx12 has instruction conversion, leave 'rm' here for compatiblity
 OPUS_D constexpr auto fp32_to_bf16(const fp32_t& x, number<rm> = {}) { return static_cast<bf16_t>(x); }
 #else
@@ -1124,14 +1124,22 @@ OPUS_D constexpr auto fp32_to_bf16(const fp32_t& x, number<rm> = {}) {
 // constexpr functions containing GPU builtins (__builtin_amdgcn_cvt_*) that can never be compile-time evaluated.
 // Template constexpr (packed variants, OPUS_CAST_DEFINE) survives because the check is deferred to instantiation.
 // TODO: we may remove constexpr from cast in the future
+#if __has_builtin(__builtin_amdgcn_cvt_pk_fp8_f32)
 OPUS_D auto fp32_to_fp8(const fp32_t& x) {
     int w; w = __builtin_amdgcn_cvt_pk_fp8_f32(x, 0.0f, w, /*sel=lo*/0);
     return __builtin_bit_cast(fp8_t, static_cast<signed char>(w));
 }
+#else
+OPUS_D auto fp32_to_fp8(const fp32_t& /*x*/) { return fp8_t{}; }
+#endif
+#if __has_builtin(__builtin_amdgcn_cvt_f32_fp8)
 OPUS_D auto fp8_to_fp32(const fp8_t& x) {
     int w = static_cast<int>(__builtin_bit_cast(unsigned char, x));
     return __builtin_amdgcn_cvt_f32_fp8(w, /*byte=*/0);
 }
+#else
+OPUS_D auto fp8_to_fp32(const fp8_t& /*x*/) { return fp32_t{}; }
+#endif
 OPUS_D constexpr auto fp32_to_fp32(const fp32_t& x) { return x; }
 OPUS_D constexpr auto fp32_to_i8(const fp32_t& x) { return static_cast<i8_t>(x); }
 OPUS_D constexpr auto i8_to_fp32(const i8_t& x) { return static_cast<fp32_t>(x); }
@@ -1222,6 +1230,7 @@ template<> struct finfo<e8m0_t> {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wuninitialized"
 #pragma clang diagnostic ignored "-Wc++20-extensions"
+#if __has_builtin(__builtin_amdgcn_cvt_pk_fp8_f32)
 template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x2(const S& s, number<sel> = {}) {
     int w ; w = __builtin_amdgcn_cvt_pk_fp8_f32(s[0], s[1], w, sel);
@@ -1243,6 +1252,17 @@ OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x4(const S& s) {
     auto x = __builtin_amdgcn_cvt_pk_f32_fp8(bitwise, 0); auto y = __builtin_amdgcn_cvt_pk_f32_fp8(bitwise, 1);
     return fp32x4_t{x[0], x[1], y[0], y[1]};
 }
+#else
+// TODO implement emulated fp8 casts for gfx1100
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x2(const S& /*s*/, number<sel> = {}) { return fp8x2_t{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x4(const S& /*s*/) { return fp8x4_t{}; }
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp8x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x2(const S& /*s*/, number<sel> = {}) { return fp32x2_t{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, fp8x4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x4(const S& /*s*/) { return fp32x4_t{}; }
+#endif
 
 namespace impl {
 template<typename S, index_t... Xs>     OPUS_D constexpr decltype(auto) fold_as_tuple_of_vec(const S& s, seq<Xs...>) {
@@ -1627,8 +1647,7 @@ OPUS_D constexpr auto buffer_default_config() {
     return 0x00020000;
 #elif defined(__gfx103__)
     return 0x31014000;
-// gfx1200/gfx1201 (Navi 44/48) listed explicitly — __gfx11__/__gfx12__ are typos (clang predefines only uppercase __GFX11__/__GFX12__), so without this gfx1200/gfx1201 fall into the 0xffffffff sentinel and make_gmem<> stores silently drop.
-#elif defined(__gfx11__) || defined(__gfx12__) || defined(__gfx1250__) || defined(__gfx1201__) || defined(__gfx1200__)
+#elif defined(__GFX11__) || defined(__gfx1201__) || defined(__gfx1200__)
     return 0x31004000;
 #else
     return 0xffffffff;

--- a/op_tests/opus/device/setup.py
+++ b/op_tests/opus/device/setup.py
@@ -44,6 +44,7 @@ _CU_SOURCES = [
     "test_wmma_gfx1201.cu",
     "test_wmma_gfx1201_w64.cu",
     "test_wmma_gfx1201_tiled.cu",
+    "test_opus_gmem_gfx1100.cu",
 ]
 
 # Sources requiring -mwavefrontsize64 (wave64 builtins).

--- a/op_tests/opus/device/test_opus_device.py
+++ b/op_tests/opus/device/test_opus_device.py
@@ -183,6 +183,13 @@ class OpusDeviceLib:
         fn.argtypes = [_VP, _VP, _VP, _I]
         fn(self._ptr(A), self._ptr(B), self._ptr(Result), int(A.numel()))
 
+    # -- opus_gmem_gfx1100 (verifies opus.hpp parses + opus utils work on gfx1100) --
+    def run_opus_gmem_gfx1100(self, A, B, Result):
+        fn = self._lib.run_opus_gmem_gfx1100
+        fn.restype = None
+        fn.argtypes = [_VP, _VP, _VP, _I]
+        fn(self._ptr(A), self._ptr(B), self._ptr(Result), int(A.numel()))
+
     # -- wmma_gfx1201 (8 wave32 16x16x16 variants via __builtin_amdgcn_wmma_*_w32_gfx12) --
     def _run_wmma_gfx1201(self, suffix, A, B, C):
         fn = getattr(self._lib, f"run_wmma_gfx1201_{suffix}")
@@ -384,6 +391,7 @@ _MFMA_ARCHS_GFX942_GFX950 = {"gfx942", "gfx950"}  # 32x32x16, 16x16x32
 _MFMA_ALL = _MFMA_ARCHS_GFX942 | _MFMA_ARCHS_GFX942_GFX950  # all archs with MFMA
 _WMMA_ARCHS_GFX1250 = {"gfx1250"}  # WMMA 16x16x32 (wave32)
 _TR_LOAD_ARCHS_GFX950 = {"gfx950"}  # smem tr_load
+_SKIP_FP8_GFX11 = {"gfx1100"}
 
 
 # FP8/BF8 torch dtypes differ by architecture:
@@ -1271,6 +1279,7 @@ def test_vector_add(mod):
 # on other archs the launcher runs an empty kernel, so we skip the correctness
 # check to avoid a misleading failure.
 _OPUS_PARSE_GFX1201_ARCHS = {"gfx1201", "gfx1200"}
+_OPUS_PARSE_GFX1100_ARCHS = {"gfx1100"}
 
 
 def test_opus_gmem_gfx1201(mod):
@@ -1598,6 +1607,46 @@ def test_wmma_gfx1201_tiled_f32_bf16(mod):
         torch.float32,
     )
 
+
+# ---------------------------------------------------------------------------
+# gfx1100 (RDNA3, Navi 31) tests
+# ---------------------------------------------------------------------------
+
+
+def test_opus_gmem_gfx1100(mod):
+    """Verify opus.hpp parses + opus utilities (make_gmem / .load/.store /
+    cast) work on gfx1100. Mirrors the load → cast<float> → store pattern
+    in sample_kernels.cu. Skips on other archs (kernel body is gfx1100-only)."""
+    arch = _get_gpu_arch()
+    if arch not in _OPUS_PARSE_GFX1100_ARCHS:
+        print(f"  SKIP: opus_gmem_gfx1100 (arch={arch}, gfx1100-only test)")
+        return 0
+
+    n = 1310720
+    device = torch.device("cuda")
+    dtype = torch.float32
+
+    torch.manual_seed(42)
+    A = torch.randn(n, device=device, dtype=dtype)
+    B = torch.randn(n, device=device, dtype=dtype)
+    Result = torch.empty(n, device=device, dtype=dtype)
+
+    mod.run_opus_gmem_gfx1100(A, B, Result)
+
+    Ref = A + B
+
+    atol, rtol = 1e-5, 1e-5
+    ok = torch.allclose(Result, Ref, atol=atol, rtol=rtol)
+    max_diff = (Result - Ref).abs().max().item()
+    if not ok:
+        diff_count = (Result - Ref).abs().gt(atol + rtol * Ref.abs()).sum().item()
+        print(
+            f"  FAIL: opus_gmem_gfx1100 max_diff={max_diff:.6e}, "
+            f"{diff_count} elements outside tol"
+        )
+        return 1
+    print(f"  PASS: opus_gmem_gfx1100 (arch={arch}, n={n}), max_diff={max_diff:.6e}")
+    return 0
 
 def test_async_load(mod):
     """Test async_load: copy data through LDS and verify integrity."""
@@ -2394,6 +2443,9 @@ def test_numeric_limits(mod):
     ]
 
     for name, offset, size, is_float, dtype, has_inf in type_table:
+        if name in ("fp8", "bf8") and arch in _SKIP_FP8_GFX11:
+            print(f"  SKIP: numeric_limits<{name}> (fp8/bf8 not supported on {arch})")
+            continue
         if is_float:
             ref = ref_float(dtype, size, has_inf)
         else:
@@ -2454,6 +2506,7 @@ def test_finfo(mod):
             "tiny": fi.tiny,
         }
 
+    arch = _get_gpu_arch()
     fp8_dtype = _get_fp8_dtype()
     bf8_dtype = _get_bf8_dtype()
 
@@ -2479,6 +2532,9 @@ def test_finfo(mod):
     ]
 
     for name, offset, dtype, expected_bits, manual_ref in type_table:
+        if name in ("fp8", "bf8") and arch in _SKIP_FP8_GFX11:
+            print(f"  SKIP: finfo<{name}> (fp8/bf8 not supported on {arch})")
+            continue
         if dtype is not None:
             ref = ref_from_torch_finfo(dtype)
             ref["bits"] = expected_bits
@@ -2638,6 +2694,7 @@ def main():
     failures += test_wmma_gfx1201_w64_bf16_bf16(mod)
     failures += test_wmma_gfx1201_tiled_f32_f16(mod)
     failures += test_wmma_gfx1201_tiled_f32_bf16(mod)
+    failures += test_opus_gmem_gfx1100(mod)
     failures += test_async_load(mod)
     failures += test_tr_load_f16(mod)
     failures += test_dtype_convert_fp32_bf16(mod)

--- a/op_tests/opus/device/test_opus_gmem_gfx1100.cu
+++ b/op_tests/opus/device/test_opus_gmem_gfx1100.cu
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+/**
+ * @file test_opus_gmem_gfx1100.cu
+ * @brief Exercise opus::make_gmem<>.load<>/.store<> on gfx1100 (Navi 31 /
+ *        RDNA3).
+ *
+ * Two opus.hpp changes need to be in place for this test to pass:
+ *
+ *  1) Forward declarations of mfma_adaptor / wmma_adaptor in the opus
+ *     namespace, so the header parses for gfx1100 device code.
+ *     make_tiled_mma()'s default template argument names these types,
+ *     and without forward decls name lookup fails on archs where the
+ *     full definitions (gated by __GFX9__ / __gfx1250__) are inactive.
+ *
+ *  2) buffer_default_config() returning the correct RDNA buffer rsrc
+ *     config (0x31004000) for gfx1100 instead of the 0xffffffff
+ *     fallback. The existing __gfx11__ / __gfx12__ tokens are typos
+ *     (clang only predefines the uppercase __GFX11__ / __GFX12__), so
+ *     without an explicit __gfx1100__ branch the make_gmem<> resource
+ *     descriptor is invalid and all buffer_load_b32 lanes return 0 /
+ *     all buffer_store_b32 lanes drop on the floor.
+ *
+ * The kernel exercises the exact opus API that sample_kernels.cu /
+ * topk_softmax_kernels_group.cu / mhc_kernels.cu depend on:
+ *
+ *     auto g = opus::make_gmem(ptr);
+ *     auto v = g.load<VEC>(i);    // buffer_load via cached rsrc
+ *     ... opus::cast<float>(v[j]) ...
+ *     g.store<VEC>(vr, i);        // buffer_store via cached rsrc
+ *
+ * Kernel body is gated by __gfx1100__ so other archs see an empty no-op pass
+ * — gfx1250 / gfx1201 / gfx9x behavior is unchanged.
+ */
+
+#ifdef __HIP_DEVICE_COMPILE__
+// ── Device pass: opus.hpp + kernel body, no hip_runtime.h ──────────────────
+#include "opus/opus.hpp"
+
+#if defined(__gfx1100__)
+// Element-wise add via opus make_gmem load / store + per-lane opus::cast.
+// Mirrors the load → cast<float> → store pattern in sample_kernels.cu.
+template<int BLOCK_SIZE, int VECTOR_SIZE>
+__global__ void opus_gmem_gfx1100_kernel(
+    const float* __restrict__ a,
+    const float* __restrict__ b,
+    float*       __restrict__ result,
+    int n)
+{
+    auto g_a = opus::make_gmem(a);
+    auto g_b = opus::make_gmem(b);
+    auto g_r = opus::make_gmem(result);
+
+    int idx    = __builtin_amdgcn_workgroup_id_x() * BLOCK_SIZE + __builtin_amdgcn_workitem_id_x();
+    int stride = __builtin_amdgcn_grid_size_x();
+
+    for (int i = idx * VECTOR_SIZE; i < n; i += stride * VECTOR_SIZE) {
+        auto va = g_a.load<VECTOR_SIZE>(i);
+        auto vb = g_b.load<VECTOR_SIZE>(i);
+
+        decltype(va) vr;
+        for (int j = 0; j < VECTOR_SIZE; ++j) {
+            // opus::cast<float>(float) is a compile-time pass-through.
+            // Including it exercises the same template path sample_kernels.cu
+            // instantiates for its per-lane DTYPE_I → float conversion.
+            vr[j] = opus::cast<float>(va[j]) + opus::cast<float>(vb[j]);
+        }
+        g_r.store<VECTOR_SIZE>(vr, i);
+    }
+}
+
+template __global__ void opus_gmem_gfx1100_kernel<256, 4>(const float*, const float*, float*, int);
+#endif // __gfx1100__
+
+#else
+// ── Host pass: launcher + empty kernel stub ────────────────────────────────
+#include "opus/hip_minimal.hpp"
+#include <cstdio>
+
+#define HIP_CALL(call) do { \
+    hipError_t err = (call); \
+    if (err != hipSuccess) { \
+        fprintf(stderr, "HIP error %d at %s:%d\n", (int)err, __FILE__, __LINE__); \
+        return; \
+    } \
+} while(0)
+
+template<int BLOCK_SIZE, int VECTOR_SIZE>
+__global__ void opus_gmem_gfx1100_kernel(const float*, const float*, float*, int) {}
+
+extern "C" void run_opus_gmem_gfx1100(
+    const void* d_a,
+    const void* d_b,
+    void*       d_result,
+    int n)
+{
+    const auto* a = static_cast<const float*>(d_a);
+    const auto* b = static_cast<const float*>(d_b);
+    auto*       r = static_cast<float*>(d_result);
+
+    constexpr int BLOCK_SIZE  = 256;
+    constexpr int VECTOR_SIZE = 4;
+    int blocks = (n + (BLOCK_SIZE * VECTOR_SIZE) - 1) / (BLOCK_SIZE * VECTOR_SIZE);
+
+    hipLaunchKernelGGL(
+        (opus_gmem_gfx1100_kernel<BLOCK_SIZE, VECTOR_SIZE>),
+        dim3(blocks), dim3(BLOCK_SIZE), 0, 0,
+        a, b, r, n);
+    HIP_CALL(hipGetLastError());
+    HIP_CALL(hipDeviceSynchronize());
+}
+#endif


### PR DESCRIPTION
## Motivation

Any kernel which includes `opus.hpp` fails to compile on hardware without fp8, such as gfx1100.

I hope to contribute more RDNA3 enablement in the future.

## Technical Details

Some code is copied and/or heavily derived from https://github.com/ROCm/aiter/pull/3236

I followed the same pattern as is done for fp4 on unsupported arches; implement a stub function. Maybe it would be better to add emulated fp8 casts in the future.

## Test Plan

Copied the test file test_opus_gmem_gfx1100.cu from https://github.com/ROCm/aiter/pull/3236

The main purpose of this test is to ensure that the kernels can build for gfx1100 when `opus.hpp` is included.

Added arch checks in the test scaffold to skip fp8 tests

All other tests either run successfully, or are skipped.

## Test Result

The following tests pass:

```
  PASS: vector_add (n=1310720), max_diff=0.000000e+00
  PASS: opus_gmem_gfx1100 (arch=gfx1100, n=1310720), max_diff=0.000000e+00
  PASS: async_load (n=1048576), bit-exact copy
  PASS: dtype_convert fp32<->bf16 (n=1048576), bit-exact
  PASS: dtype_convert fp32<->fp16 (n=1048576), max_diff=0.000000e+00
  PASS: dtype_convert fp32<->bf16 vec4 (n=1048576), bit-exact
  PASS: dtype_convert fp32<->fp16 vec4 (n=1048576), max_diff=0.000000e+00
  PASS: predicated_copy (n=1001), bit-exact with boundary predicate
  PASS: predicated_copy_2d (6x1021), 2D multi-index predicate
  PASS: free_func_vector_add (n=1310720), max_diff=0.000000e+00
  PASS: predicated_async_load (n=1001), bit-exact with boundary predicate
  PASS: numeric_limits<fp32> (all 5 fields)
  PASS: numeric_limits<fp16> (all 5 fields)
  PASS: numeric_limits<bf16> (all 5 fields)
  PASS: numeric_limits<i32> (all 5 fields)
  PASS: numeric_limits<i16> (all 5 fields)
  PASS: numeric_limits<i8> (all 5 fields)
  PASS: numeric_limits<u8> (all 5 fields)
  PASS: numeric_limits all types correct
  PASS: finfo<fp32> (all 5 fields)
  PASS: finfo<fp16> (all 5 fields)
  PASS: finfo<bf16> (all 5 fields)
  PASS: finfo<fp4> (all 5 fields)
  PASS: finfo<e8m0> (all 5 fields)
  PASS: finfo all types correct
  PASS: mdiv divisor=1
  PASS: mdiv divisor=2
  PASS: mdiv divisor=3
  PASS: mdiv divisor=7
  PASS: mdiv divisor=13
  PASS: mdiv divisor=32
  PASS: mdiv divisor=64
  PASS: mdiv divisor=127
  PASS: mdiv divisor=255
  PASS: mdiv divisor=1024
  PASS: mdiv divisor=65537
  PASS: mdiv all 11 divisors correct
  PASS: wb_cumulative (n=128, accum=8256)
  PASS: wb_streamk_reduce n_chunks=1 (rel_err=0.00e+00)
  PASS: wb_streamk_reduce n_chunks=4 (rel_err=1.50e-07)
  PASS: wb_streamk_reduce n_chunks=16 (rel_err=7.25e-07)
  PASS: wb_streamk_reduce n_chunks=64 (rel_err=1.50e-07)
All device tests PASSED
```

All other tests are skipped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
