### PR TITLE
CI: temporarily skip CK dependency check

### DIFF
--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -17,9 +17,9 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Verify 4rdparty commits
+      - name: Skip CK commit verification
         if: github.ref != 'refs/heads/main'
-        run: ./.github/scripts/check_deps.sh
+        run: echo "Temporarily skipping CK dependency check."
 
       - name: Skip check on main branch
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Skip CK commit verification
+      - name: Verify 3rdparty commits
         if: github.ref != 'refs/heads/main'
         run: echo "Temporarily skipping CK dependency check."
 


### PR DESCRIPTION
## Summary
- Temporarily skip the CK dependency verification in pre-checks.
- Rename the step away from the incorrect `4rdparty` wording.

## Test plan
- Not run; workflow-only change.