### PR TITLE
make a8w8 preshuffle gemm support zero bias input

### DIFF
--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -747,8 +747,8 @@ def gemm_a8w8_blockscale_bpreshuffle_fake(
     WQ: Tensor,
     x_scale: Tensor,
     w_scale: Tensor,
-    zero_bias_buf: Optional[Tensor] = None,
     dtype: torch.dtype = dtypes.bf16,
+    zero_bias_buf: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty(XQ.shape[0], WQ.shape[0], dtype=dtype, device=XQ.device)
 
@@ -759,10 +759,8 @@ def gemm_a8w8_blockscale_bpreshuffle(
     WQ: Tensor,
     x_scale: Tensor,
     w_scale: Tensor,
-    zero_bias_buf: Optional[
-        Tensor
-    ] = None,  # which is used to asm kernel(asm always need a bias tensor)
     dtype: torch.dtype = dtypes.bf16,
+    zero_bias_buf: Optional[Tensor] = None,
 ) -> Tensor:
     assert dtype in [
         dtypes.bf16,

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -312,6 +312,19 @@ def _gemm_a8w8_blockscale_bpreshuffle_asm(
 ) -> None: ...
 
 
+# Ref on https://github.com/ROCm/aiter/blob/1be4ee9f70a7a7de5e9f57de2c0ecb9d13ed5983/aiter/ops/gemm_op_a16w16.py#L37-L57
+@functools.lru_cache(maxsize=1024)
+def get_zero_bias_buf_keyed(
+    device: torch.device, stream_id: int, out_shape: int
+) -> Tensor:
+    return torch.zeros(1, out_shape, dtype=torch.float32, device=device)
+
+
+def get_zero_bias_buf(B: Tensor) -> Tensor:
+    stream = torch.cuda.current_stream(B.device)
+    return get_zero_bias_buf_keyed(B.device, stream.cuda_stream, B.shape[0])
+
+
 def gemm_a8w8_blockscale_bpreshuffle_asm(
     A: Tensor,
     B: Tensor,
@@ -325,7 +338,7 @@ def gemm_a8w8_blockscale_bpreshuffle_asm(
     zero_bias_buf: Optional[Tensor] = None,
 ) -> Tensor:
     if bias is None and zero_bias_buf is None:
-        zero_bias_buf = torch.zeros(1, B.shape[0], dtype=torch.float32, device=A.device)
+        zero_bias_buf = get_zero_bias_buf(B)
     _gemm_a8w8_blockscale_bpreshuffle_asm(
         A,
         B,
@@ -748,7 +761,6 @@ def gemm_a8w8_blockscale_bpreshuffle_fake(
     x_scale: Tensor,
     w_scale: Tensor,
     dtype: torch.dtype = dtypes.bf16,
-    zero_bias_buf: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty(XQ.shape[0], WQ.shape[0], dtype=dtype, device=XQ.device)
 
@@ -760,7 +772,6 @@ def gemm_a8w8_blockscale_bpreshuffle(
     x_scale: Tensor,
     w_scale: Tensor,
     dtype: torch.dtype = dtypes.bf16,
-    zero_bias_buf: Optional[Tensor] = None,
 ) -> Tensor:
     assert dtype in [
         dtypes.bf16,
@@ -787,14 +798,7 @@ def gemm_a8w8_blockscale_bpreshuffle(
         elif libtype == "asm":
             splitK = config["splitK"]
             return gemm_a8w8_blockscale_bpreshuffle_asm(
-                XQ,
-                WQ,
-                Y,
-                x_scale,
-                w_scale,
-                splitK=splitK,
-                kernelName=kernelName,
-                zero_bias_buf=zero_bias_buf,
+                XQ, WQ, Y, x_scale, w_scale, splitK=splitK, kernelName=kernelName
             )
     try:
         return gemm_a8w8_blockscale_bpreshuffle_ck(XQ, WQ, x_scale, w_scale, Y)

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -747,6 +747,7 @@ def gemm_a8w8_blockscale_bpreshuffle_fake(
     WQ: Tensor,
     x_scale: Tensor,
     w_scale: Tensor,
+    zero_bias_buf: Optional[Tensor] = None,
     dtype: torch.dtype = dtypes.bf16,
 ) -> Tensor:
     return torch.empty(XQ.shape[0], WQ.shape[0], dtype=dtype, device=XQ.device)
@@ -758,6 +759,9 @@ def gemm_a8w8_blockscale_bpreshuffle(
     WQ: Tensor,
     x_scale: Tensor,
     w_scale: Tensor,
+    zero_bias_buf: Optional[
+        Tensor
+    ] = None,  # which is used to asm kernel(asm always need a bias tensor)
     dtype: torch.dtype = dtypes.bf16,
 ) -> Tensor:
     assert dtype in [
@@ -785,7 +789,14 @@ def gemm_a8w8_blockscale_bpreshuffle(
         elif libtype == "asm":
             splitK = config["splitK"]
             return gemm_a8w8_blockscale_bpreshuffle_asm(
-                XQ, WQ, Y, x_scale, w_scale, splitK=splitK, kernelName=kernelName
+                XQ,
+                WQ,
+                Y,
+                x_scale,
+                w_scale,
+                splitK=splitK,
+                kernelName=kernelName,
+                zero_bias_buf=zero_bias_buf,
             )
     try:
         return gemm_a8w8_blockscale_bpreshuffle_ck(XQ, WQ, x_scale, w_scale, Y)


### PR DESCRIPTION
## Motivation

For a8w8 preshuffle asm gemm， there is always a dynamic allocation of a zero tensor when not given bias. We should avoid it for better performance by giving a persistent zero tensor in FW side.

<img width="1282" height="468" alt="image" src="https://github.com/user-attachments/assets/8aec3a2a-7034-463f-9c66-a83935595d20" />


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

After fix：
<img width="1417" height="181" alt="image" src="https://github.com/user-attachments/assets/ffa93e8b-5d46-46b7-86c9-4c36bbda2384" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
