### PR TITLE
[CK] Fix Submodule Pin after CK Re-Syncing with rocm-libraries

### DIFF
--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Verify 3rdparty commits
         if: github.ref != 'refs/heads/main'
-        run: echo "Temporarily skipping CK dependency check."
+        run: ./.github/scripts/check_deps.sh
 
       - name: Skip check on main branch
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Motivation

On 2026-05-27, the `develop` branch of `ROCm/composable_kernel` was force-pushed as part of a re-sync with the `rocm-libraries` monorepo mirror pipeline. The previously pinned commit `83566ed` is no longer reachable from the new `develop` history (it remains as an orphan on the pre-restore history, tagged `develop-pre-restore-2026-05-27`).

This breaks `git submodule update` for fresh clones. Re-pin to `af7118e34`, the new-history commit mirroring the same upstream content `83566ed` tracked (both correspond to upstream `ROCm/rocm-libraries#7331` / monorepo `5692db0`).

## Technical Details

Update CK submodule pin: `83566ed` → `af7118e34` (`ROCm/composable_kernel@af7118e34`). Also bumps the CK SHA referenced in `.github/workflows/pre-checks.yaml`.

## Test Plan

Relying on this PR's CI.

## Test Result

See CI status on this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
