### PR TITLE
fix(gradlib): use string data keys in opus_gemm_all_sols

### DIFF
--- a/gradlib/gradlib/GemmTuner.py
+++ b/gradlib/gradlib/GemmTuner.py
@@ -138,7 +138,7 @@ def run_triton_gemm_bf16(input, weight, bias=None, otype=dtypes.bf16):
 # 32K x 2K x 7K), so running it on every iter of run_perftest's
 # num_iters=101 hot loop adds 100 * 8ms = 800ms of pure ref-compute
 # time to each candidate, AND inflates the reported per-iter latency
-# to (kernel + ref) ≈ kernel + ~8ms. That hides the true kernel
+# to (kernel + ref) ? kernel + ~8ms. That hides the true kernel
 # ranking (every candidate measures ~ref_time) and makes mp_tuner
 # pick a sub-optimal winner -- e.g. on 32K x 2K x 7K the tuner
 # reported kid=9 @ 108 TFLOPS while persistent kid=304 actually runs
@@ -743,17 +743,28 @@ class Gemm:
                             self.has_bias,
                         ),
                         run_opus_gemm_bf16,
-                        ([0, 1, 5, 3], kid, sk),
+                        (
+                            ["inp", "weights", "out_asm", "bias"],
+                            kid,
+                            sk,
+                        ),
                         {
                             "num_warmup": self.num_warmup,
                             "num_iters": 101,
                         },
                         get_gemm_ref,
-                        ([0, 1, 3, 4, 7], self.indtype, self.outdtype),
+                        (
+                            ["inp", "weights", "bias", "x_scale", "w_scale"],
+                            self.indtype,
+                            self.outdtype,
+                        ),
                         {},
                         None,
                         2e-2,
                         1.0,
+                        None,  # compare_fn
+                        None,  # max_abs_delta
+                        ("out_asm",),  # output_keys: NaN-init the out tensor
                     )
                 )
         logger.info(


### PR DESCRIPTION
The opus tuning path in GemmTuner.opus_gemm_all_sols passed integer positional indices ([0, 1, 5, 3] and [0, 1, 3, 4, 7]) as data-key lists for the kernel args / ref_args. After the mp_tuner refactor that made work_group look up data via `data[k]` against the dict returned by generate_data() (which has string keys "inp"/"weights"/"out_asm"/...), this raised KeyError(0) on every opus task.

The KeyError propagated out of work_group's pre-try section and was mis-reported by mp_tuner's outer handler as
  "[Mapping Error] Task 0 - Process PID not in GPU map: KeyError - 0"
which made the failure look like a GPU-PID mapping issue rather than a schema mismatch. All N opus candidates failed before a single kernel ran.

Fix: - replace the integer index lists with the matching string keys, in
    line with every other tuner (asm / flydsl / skinny / torch /
    triton)
  - append (None, None, ("out_asm",)) so the worker NaN-initializes the output tensor before warmup, matching the asm path's catastrophic write-detection safety

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
