### PR TITLE
[FIX] AITER_LOG_MORE=2

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -1641,6 +1641,10 @@ def compile_ops(
                             )
                     return True
 
+                if AITER_LOG_MORE == 2:
+                    from ..test_common import log_args
+
+                    log_args(func, *args, **kwargs)
                 # develop=True: torch.Tensor -> pybind aiter_tensor_t before C++ (activation, CAR, ...).
                 if develop:
                     import torch
@@ -1662,11 +1666,6 @@ def compile_ops(
 
                 if not func.arg_checked:
                     func.arg_checked = check_args()
-
-                if AITER_LOG_MORE == 2:
-                    from ..test_common import log_args
-
-                    log_args(func, *args, **kwargs)
 
                 if develop:
                     module._set_current_hip_stream(


### PR DESCRIPTION
## Motivation

Previously, we printed the log after converting torch.Tensor to aiter_tensor_t.
As a result, enabling AITER_LOG_MORE=2 only printed the address of the aiter_tensor_t object.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
