### PR TITLE
Opt prefill mxfp8 quant moe sort

### DIFF
--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -279,11 +279,16 @@ def get_torch_quant(qType):
 
 @functools.lru_cache()
 def get_hip_quant(qType):
+    # `per_1x32` points to the dtype-aware MX entry so callers can do
+    # `get_hip_quant(QuantType.per_1x32)(x, quant_dtype=dtypes.fp4x2)` for
+    # MXFP4 or `quant_dtype=dtypes.fp8` for MXFP8. The legacy
+    # `per_1x32_f4_quant_hip` thin wrapper is preserved separately for
+    # external callers that imported it by name.
     tmp = {
         QuantType.No.value: lambda *a, **k: (a[0], None),
         QuantType.per_Tensor.value: per_tensor_quant_hip,
         QuantType.per_Token.value: per_token_quant_hip,
-        QuantType.per_1x32.value: per_1x32_f4_quant_hip,
+        QuantType.per_1x32.value: per_1x32_mx_quant_hip,
         QuantType.per_1x128.value: functools.partial(
             per_group_quant_hip, group_size=128
         ),
@@ -379,46 +384,109 @@ def per_group_quant_hip(
     return y, scale
 
 
-def per_1x32_f4_quant_hip(
+def per_1x32_mx_quant_hip(
     x,
     scale=None,
     quant_dtype=dtypes.fp4x2,
     shuffle=False,
     num_rows: Optional[torch.Tensor] = None,
     num_rows_factor=1,
+    scale_type=None,
 ):
+    """1x32 per-group MX dynamic quant (HIP).
+
+    Dispatches by ``quant_dtype``:
+      * ``dtypes.fp4x2``: MXFP4, packed fp4x2 output ``(m, n // 2)``,
+        e8m0-byte scale ``(m, ceil(n/32))`` (or padded to
+        ``(pad256(m), pad8(ceil(n/32)))`` when ``shuffle=True``).
+        ``scale_type`` is ignored -- fp4 always produces an e8m0 byte scale.
+      * ``dtypes.fp8``: MXFP8, fp8 output ``(m, n)``. The scale layout is
+        chosen by ``scale_type``:
+            - ``dtypes.fp32`` (default for backward compat): continuous
+              fp32 per-group scale ``(m, ceil(n/32))``.
+            - ``dtypes.fp8_e8m0``: e8m0 byte scale ``(m, ceil(n/32))``
+              (or padded ``(pad256(m), pad8(ceil(n/32)))`` when
+              ``shuffle=True``). This is the byte layout consumed by
+              ``mxfp4_moe_sort_hip`` and MXFP8 GEMM kernels, enabling the
+              MXFP8 "split" path  (per_1x32 quant -> sorted-scale shuffle)
+              that mirrors the existing MXFP4 split path.
+
+    The legacy ``per_1x32_f4_quant_hip`` is kept as a thin wrapper for
+    backward compatibility.
+    """
     m, n = x.shape
-    assert quant_dtype == dtypes.fp4x2
-    assert n % 2 == 0
+    assert n % 32 == 0, f"n={n} must be divisible by 32"
     device = x.device
+
+    # Per-dtype defaults / validation.
+    if quant_dtype == dtypes.fp4x2:
+        assert n % 2 == 0
+        out_cols = n // 2
+        # fp4 is always e8m0; ignore caller-supplied scale_type (or assert
+        # it agrees) so the public surface stays simple.
+        effective_scale_type = dtypes.fp8_e8m0
+        if scale_type is not None and scale_type not in (dtypes.fp8_e8m0,):
+            raise ValueError(
+                f"per_1x32_mx_quant_hip: fp4x2 output requires e8m0 scale; "
+                f"got scale_type={scale_type}"
+            )
+    elif quant_dtype == dtypes.fp8:
+        out_cols = n
+        effective_scale_type = scale_type if scale_type is not None else dtypes.fp32
+        if effective_scale_type not in (dtypes.fp32, dtypes.fp8_e8m0):
+            raise ValueError(
+                f"per_1x32_mx_quant_hip: fp8 output expects scale_type in "
+                f"{{fp32, fp8_e8m0}}, got {effective_scale_type}"
+            )
+        if shuffle and effective_scale_type == dtypes.fp32:
+            raise NotImplementedError(
+                "per_1x32_mx_quant_hip(quant_dtype=fp8, scale_type=fp32, "
+                "shuffle=True): the fp32-scale path uses a transposed "
+                "(scaleN, M) layout and is not supported through this "
+                "wrapper. Pass scale_type=dtypes.fp8_e8m0 for the swizzled "
+                "byte-scale layout, or use fused_dynamic_mxfp8_quant_moe_sort "
+                "for the MoE-sort fused path."
+            )
+    else:
+        raise ValueError(
+            f"per_1x32_mx_quant_hip: unsupported quant_dtype {quant_dtype}, "
+            f"expected one of (dtypes.fp4x2, dtypes.fp8)"
+        )
+
+    # Allocate scale buffer matching the requested layout.
+    is_e8m0 = effective_scale_type == dtypes.fp8_e8m0
     if scale is None:
-        if shuffle:
-            scale = (
-                torch.empty(
+        if is_e8m0:
+            if shuffle:
+                scale = torch.empty(
                     (
                         (m + 255) // 256 * 256,
                         ((n + 31) // 32 + 7) // 8 * 8,
                     ),
                     dtype=torch.uint8,
                     device=device,
-                )
-                # .fill_(0x7F)
-                .view(dtypes.fp8_e8m0)
-            )
-        else:
-            scale = (
-                torch.empty(
+                ).view(dtypes.fp8_e8m0)
+            else:
+                scale = torch.empty(
                     (m, (n + 31) // 32),
                     dtype=torch.uint8,
                     device=device,
-                )
-                # .fill_(0x7F)
-                .view(dtypes.fp8_e8m0)
+                ).view(dtypes.fp8_e8m0)
+        else:
+            scale = torch.empty(
+                (m, (n + 31) // 32),
+                dtype=dtypes.fp32,
+                device=device,
             )
     else:
         raise ValueError("unsupported: static per token quant")
-    y = torch.empty(m, n // 2, dtype=quant_dtype, device=device)
-    dynamic_per_group_scaled_quant_fp4(
+    y = torch.empty(m, out_cols, dtype=quant_dtype, device=device)
+    # `dynamic_per_group_scaled_quant` is the canonical dtype-aware C entry;
+    # the C++ host dispatches by `out.dtype()` (fp4/fp8/i8) and by
+    # `scales.dtype()` (e8m0 vs fp32). The legacy
+    # `dynamic_per_group_scaled_quant_fp4` symbol is retained as a
+    # backward-compat forwarder for callers that import it directly.
+    dynamic_per_group_scaled_quant(
         y,
         x,
         scale,
@@ -428,6 +496,34 @@ def per_1x32_f4_quant_hip(
         num_rows_factor=num_rows_factor,
     )
     return y, scale
+
+
+def per_1x32_f4_quant_hip(
+    x,
+    scale=None,
+    quant_dtype=dtypes.fp4x2,
+    shuffle=False,
+    num_rows: Optional[torch.Tensor] = None,
+    num_rows_factor=1,
+):
+    """Backward-compat fp4-only wrapper around :func:`per_1x32_mx_quant_hip`.
+
+    New code should call ``per_1x32_mx_quant_hip`` directly with the
+    desired ``quant_dtype``; this wrapper exists so existing callers (and
+    the ``get_hip_quant(QuantType.per_1x32)`` lookup before MXFP8 support
+    was added) keep working unchanged.
+    """
+    assert (
+        quant_dtype == dtypes.fp4x2
+    ), "per_1x32_f4_quant_hip is fp4-only; use per_1x32_mx_quant_hip for fp8"
+    return per_1x32_mx_quant_hip(
+        x,
+        scale=scale,
+        quant_dtype=quant_dtype,
+        shuffle=shuffle,
+        num_rows=num_rows,
+        num_rows_factor=num_rows_factor,
+    )
 
 
 def per_tensor_quant_hip(
@@ -569,6 +665,28 @@ def dynamic_per_token_scaled_quant(
 
 
 @compile_ops("module_quant", develop=True)
+def dynamic_per_group_scaled_quant(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    group_size: int = 32,
+    shuffle_scale: bool = True,
+    num_rows: Optional[torch.Tensor] = None,
+    num_rows_factor: int = 1,
+) -> None:
+    """Dtype-aware per-group dynamic quant.
+
+    ``out.dtype`` selects the element format:
+      * ``dtypes.fp4x2`` / ``torch.uint8`` -> MXFP4 (e8m0 byte scale)
+      * ``dtypes.fp8``                      -> MXFP8 (fp32 per-group scale today)
+      * ``dtypes.i8``                       -> int8 per-group (fp32 scale)
+
+    Only ``group_size`` in {32, 64, 128} is supported.
+    """
+    ...
+
+
+@compile_ops("module_quant", develop=True)
 def dynamic_per_group_scaled_quant_fp4(
     out: torch.Tensor,
     input: torch.Tensor,
@@ -578,8 +696,10 @@ def dynamic_per_group_scaled_quant_fp4(
     num_rows: Optional[torch.Tensor] = None,
     num_rows_factor: int = 1,
 ) -> None:
-    """
-    Only support group_size in [32, 64, 128]
+    """Backward-compat fp4x2-only forwarder; delegates to
+    ``dynamic_per_group_scaled_quant``.
+
+    Only support group_size in [32, 64, 128].
     """
     ...
 
@@ -657,9 +777,12 @@ def mxfp4_moe_sort_fwd(
     token_num: int,
     cols: int,
 ):
+    # Pad cols to multiple of 8 to match `mx_scale_shuffle_idx`'s
+    # `scaleN_pad = pad8(scaleN)`. See note in `fused_dynamic_mx_quant_moe_sort`.
+    scaleN_pad = ((cols + 31) // 32 + 7) // 8 * 8
     out_scale = torch.empty(
         (sorted_ids.shape[0] + 31) // 32 * 32,
-        (cols + 31) // 32,
+        scaleN_pad,
         dtype=dtypes.fp8_e8m0,
         device=scale.device,
     )
@@ -712,7 +835,7 @@ def quant_mxfp4_hip(
     """MXFP4 quantization with optional weight/scale shuffle.
 
     Args:
-        round_mode: 0 = Even — e8m0 scale via even-rounding group max
+        round_mode: 0 = Even -- e8m0 scale via even-rounding group max
             to nearest power-of-2. gfx950 uses HW builtin (exact RNE);
             gfx942 uses SW fallback (round-half-away).
     """
@@ -752,35 +875,88 @@ def quant_mxfp4_hip(
     return out_packed, out_scale
 
 
-def fused_dynamic_mxfp4_quant_moe_sort(
+def fused_dynamic_mx_quant_moe_sort(
     input: torch.Tensor,
     sorted_ids: torch.Tensor,
     num_valid_ids: torch.Tensor,
     token_num: int,
     topk: int,  # stage1 and stage2: same topk value
     block_size: int,
+    quant_dtype: torch.dtype = dtypes.fp4x2,
     num_rows: Optional[torch.Tensor] = None,
     group_size: int = 32,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Unified fused dynamic MX quant + MoE-sort entry (MXFP4 / MXFP8).
+
+    Returns ``(out, scale)`` where:
+      * ``out``:
+          - ``dtypes.fp4x2`` -> ``(M, N // 2)`` packed fp4 (MXFP4)
+          - ``dtypes.fp8``   -> ``(M, N)`` fp8 e4m3 (MXFP8)
+      * ``scale``: ``(pad32(sorted_ids.shape[0]), N // group_size)`` e8m0
+                   byte, swizzled to the GEMM tile layout consumed by MXFP4
+                   / MXFP8 MoE GEMM kernels. The byte memory layout is
+                   identical between MXFP4 and MXFP8 (see
+                   ``mx_scale_shuffle_idx`` -- the swizzle formula is
+                   dtype-agnostic), only the per-byte exponent value
+                   differs based on the dtype's ``max_pow2`` constant.
+
+    Dispatch:
+      * Small ``M`` (or non-default ``group_size``): single fused HIP kernel
+        ``fused_dynamic_mx_quant_moe_sort_hip`` which does quant + sort +
+        swizzle in one pass. Saves a kernel launch but re-quantises each
+        input row up to ``topk`` times.
+      * Large ``M``: split path - one pass of ``per_1x32_mx_quant_hip`` to
+        produce per-token unswizzled fp8_e8m0 scale, then ``mxfp4_moe_sort_hip``
+        to sort + swizzle the byte tensor. The split kernel itself is dtype-
+        agnostic for the byte shuffle step (same kernel handles both MXFP4
+        and MXFP8 scale bytes). Wins at large ``M`` because the quant pass
+        reads each input row exactly once instead of ``topk`` times.
+
+    Threshold: stage1 cuts over at ``M = 8*256/topk``; stage2 cuts over at
+    ``M = 8*1024/topk * topk = 8*1024``. The previous ``fused_dynamic_mxfp4_*``
+    /``fused_dynamic_mxfp8_*`` entries are retained as thin wrappers for
+    backward compatibility.
+    """
+    if quant_dtype not in (dtypes.fp4x2, dtypes.fp8):
+        raise ValueError(
+            f"fused_dynamic_mx_quant_moe_sort: unsupported quant_dtype "
+            f"{quant_dtype}, expected one of (dtypes.fp4x2, dtypes.fp8)"
+        )
+
     token_num_quant_moe_sort_switch = [
         8 * 256 / topk,  # stage1
         8 * 1024 / topk,  # stage2
     ]
     M, N = input.view(-1, input.shape[-1]).shape
+    # Packed fp4x2 stores 2 elements per byte; fp8 is 1 elem per byte.
+    out_cols = N // 2 if quant_dtype == dtypes.fp4x2 else N
     is_stage1 = M == token_num
-    topk = 1 if is_stage1 else topk
+    # `eff_topk` mirrors what the HIP launcher would infer from
+    # `input.numel() / (cols * token_num)` (= 1 for stage1, original topk
+    # for stage2). Used as `num_rows_factor` in the split path.
+    eff_topk = 1 if is_stage1 else topk
+    # Scale cols pad to multiple of 8 to match `mx_scale_shuffle_idx`'s
+    # `scaleN_pad = pad8(scaleN)`. Without this, MX shapes with
+    # `N/group_size` not divisible by 8 (e.g. inter_dim=384 -> scaleN=12)
+    # trigger OOB writes in the kernel that uses the padded stride.
+    # Padding columns `[scaleN_valid, scaleN_pad)` are NOT written by the
+    # kernel (guarded by `scale_k < scaleN_valid`) and contain allocator
+    # garbage; production GEMM consumers don't read them so this is safe.
+    # Tests comparing byte-level equality must mask out those positions.
+    scaleN_pad = ((N + group_size - 1) // group_size + 7) // 8 * 8
     scale = torch.empty(
         (sorted_ids.shape[0] + 31) // 32 * 32,
-        (N + 31) // 32,
+        scaleN_pad,
         dtype=dtypes.fp8_e8m0,
         device=input.device,
     )
-    if (
+    use_fused = (
         (is_stage1 and M <= token_num_quant_moe_sort_switch[0])
-        or (not is_stage1 and M <= token_num_quant_moe_sort_switch[1] * topk)
+        or (not is_stage1 and M <= token_num_quant_moe_sort_switch[1] * eff_topk)
         or group_size != 32
-    ):
-        out = torch.empty(M, N // 2, dtype=dtypes.fp4x2, device=input.device)
+    )
+    if use_fused:
+        out = torch.empty(M, out_cols, dtype=quant_dtype, device=input.device)
         fused_dynamic_mx_quant_moe_sort_hip(
             out,
             scale,
@@ -792,11 +968,54 @@ def fused_dynamic_mxfp4_quant_moe_sort(
             group_size,
         )
     else:
-        out, scale_ = per_1x32_f4_quant_hip(
-            input, None, dtypes.fp4x2, num_rows=num_rows, num_rows_factor=topk
+        # Split path: per-token quant produces unswizzled e8m0 byte scale,
+        # then `mxfp4_moe_sort_hip` (dtype-agnostic byte shuffle) sorts +
+        # swizzles it into the GEMM-consumed tile layout.
+        # `per_1x32_mx_quant_hip` handles both fp4 (always e8m0 scale) and
+        # fp8 (with `scale_type=fp8_e8m0` for the byte-scale split path).
+        scale_type = dtypes.fp8_e8m0 if quant_dtype == dtypes.fp8 else None
+        out, scale_per_token = per_1x32_mx_quant_hip(
+            input,
+            scale=None,
+            quant_dtype=quant_dtype,
+            scale_type=scale_type,
+            shuffle=False,
+            num_rows=num_rows,
+            num_rows_factor=eff_topk,
         )
-        mxfp4_moe_sort_hip(scale, scale_, sorted_ids, num_valid_ids, token_num, N)
+        mxfp4_moe_sort_hip(
+            scale, scale_per_token, sorted_ids, num_valid_ids, token_num, N
+        )
     return out, scale
+
+
+def fused_dynamic_mxfp4_quant_moe_sort(
+    input: torch.Tensor,
+    sorted_ids: torch.Tensor,
+    num_valid_ids: torch.Tensor,
+    token_num: int,
+    topk: int,  # stage1 and stage2: same topk value
+    block_size: int,
+    num_rows: Optional[torch.Tensor] = None,
+    group_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Backward-compat wrapper around :func:`fused_dynamic_mx_quant_moe_sort`.
+
+    Forces ``quant_dtype=dtypes.fp4x2``; same dispatch + behaviour as the
+    unified entry. New code should call ``fused_dynamic_mx_quant_moe_sort``
+    directly with the desired ``quant_dtype``.
+    """
+    return fused_dynamic_mx_quant_moe_sort(
+        input=input,
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=token_num,
+        topk=topk,
+        block_size=block_size,
+        quant_dtype=dtypes.fp4x2,
+        num_rows=num_rows,
+        group_size=group_size,
+    )
 
 
 def fused_dynamic_mxfp8_quant_moe_sort(
@@ -806,35 +1025,31 @@ def fused_dynamic_mxfp8_quant_moe_sort(
     token_num: int,
     topk: int,
     block_size: int,
+    num_rows: Optional[torch.Tensor] = None,
     group_size: int = 32,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """HIP replacement for Triton fused_quant_fp8_sort.
+    """Backward-compat wrapper around :func:`fused_dynamic_mx_quant_moe_sort`.
 
-    Returns (fp8_out, e8m0_scale) with the scale tensor laid out as
-    (pad32(M_o), N_o) fp8_e8m0 — the same byte layout the FlyDSL stage1/stage2
-    GEMM consumes. ``topk`` is accepted for parity with the fp4 wrapper but
-    is inferred inside the HIP launcher from ``input.numel() / (cols * token_num)``.
+    Forces ``quant_dtype=dtypes.fp8``; same dispatch + behaviour as the
+    unified entry. New code should call ``fused_dynamic_mx_quant_moe_sort``
+    directly with ``quant_dtype=dtypes.fp8``.
+
+    Note: ``num_rows`` was not part of the original signature but is exposed
+    here so callers benefit from the new split-path dispatch on large ``M``
+    without a separate update. Set to ``None`` to match the previous
+    behaviour exactly.
     """
-    M, N = input.view(-1, input.shape[-1]).shape
-    N_o = (N + 31) // 32
-    out = torch.empty(M, N, dtype=dtypes.fp8, device=input.device)
-    scale = torch.empty(
-        (sorted_ids.shape[0] + 31) // 32 * 32,
-        N_o,
-        dtype=dtypes.fp8_e8m0,
-        device=input.device,
+    return fused_dynamic_mx_quant_moe_sort(
+        input=input,
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=token_num,
+        topk=topk,
+        block_size=block_size,
+        quant_dtype=dtypes.fp8,
+        num_rows=num_rows,
+        group_size=group_size,
     )
-    fused_dynamic_mx_quant_moe_sort_hip(
-        out,
-        scale,
-        input,
-        sorted_ids,
-        num_valid_ids,
-        token_num,
-        block_size,
-        group_size,
-    )
-    return out, scale
 
 
 @compile_ops("module_quant", develop=True)

--- a/csrc/include/fp4_quant_utils.h
+++ b/csrc/include/fp4_quant_utils.h
@@ -9,13 +9,19 @@ namespace aiter {
 // Round-to-power-of-2 with 1.5x threshold for E8M0 scale derivation.
 // Matches fp4_utils.f32_to_e8m0 in Python.
 //
+// Note: name is dtype-neutral on purpose. The same primitive is used for
+// both MXFP4 (max_pos = 6) and MXFP8 (max_pos = 448) callers -- only the
+// `inverted_DTYPE_MAX` they multiply by differs. The legacy
+// `fp4_f32_to_e8m0_scale` symbol is retained below as an alias for
+// backward compatibility.
+//
 // If the float mantissa >= 0.5 (i.e. value >= 1.5 x 2^k for some k),
 // the exponent is bumped by 1, rounding up to the next power of 2.
 // Otherwise, the value is truncated down (floor) to a power of 2.
 //
 // Special: Inf/NaN (exponent == 0xFF) passes through unchanged.
 //          Denormal with mantissa == exactly 0.5 is not bumped (guarded by exponent > 0).
-__device__ __forceinline__ float fp4_f32_to_e8m0_scale(float x)
+__device__ __forceinline__ float f32_to_e8m0_scale(float x)
 {
     uint32_t u32      = __builtin_bit_cast(uint32_t, x);
     uint32_t exponent = (u32 >> 23) & 0xFFu;
@@ -26,12 +32,26 @@ __device__ __forceinline__ float fp4_f32_to_e8m0_scale(float x)
     return __builtin_bit_cast(float, exponent << 23);
 }
 
-// Compute the swizzled E8M0 scale index for tiled FP4 layout.
-// Used when shuffle_scale is enabled for MXFP4 quantization.
-__device__ __forceinline__ int fp4_scale_shuffle_idx(int scaleN_pad, int x, int y)
+// Backward-compat alias. New code should call `f32_to_e8m0_scale` directly.
+__device__ __forceinline__ float fp4_f32_to_e8m0_scale(float x)
+{
+    return f32_to_e8m0_scale(x);
+}
+
+// Compute the swizzled E8M0 scale index for the tiled MX layout.
+// Used by both MXFP4 and MXFP8 paths (the e8m0 byte layout is identical
+// regardless of the element dtype). The legacy `fp4_scale_shuffle_idx`
+// symbol is kept as an alias below.
+__device__ __forceinline__ int mx_scale_shuffle_idx(int scaleN_pad, int x, int y)
 {
     return (x / 32 * scaleN_pad) * 32 + (y / 8) * 256 + (y % 4) * 64 + (x % 16) * 4 +
            (y % 8) / 4 * 2 + (x % 32) / 16;
+}
+
+// Backward-compat alias. New code should call `mx_scale_shuffle_idx` directly.
+__device__ __forceinline__ int fp4_scale_shuffle_idx(int scaleN_pad, int x, int y)
+{
+    return mx_scale_shuffle_idx(scaleN_pad, x, y);
 }
 
 } // namespace aiter

--- a/csrc/include/quant.h
+++ b/csrc/include/quant.h
@@ -23,6 +23,18 @@ void dynamic_per_token_scaled_quant(aiter_tensor_t& out,         // [..., d]
                                     std::optional<aiter_tensor_t> num_rows  = std::nullopt,
                                     int num_rows_factor                     = 1);
 
+// Canonical dtype-aware per-group dynamic quant. Accepts fp8 / i8 / fp4x2.
+// For fp4x2 it writes an e8m0 byte per group; for fp8/i8 it writes an
+// fp32 per-group scale.
+void dynamic_per_group_scaled_quant(aiter_tensor_t& out,         // [..., d]
+                                    const aiter_tensor_t& input, // [..., d]
+                                    aiter_tensor_t& scales,
+                                    int group_size                             = 32,
+                                    bool shuffle_scale                         = true,
+                                    std::optional<aiter_tensor_t> num_rows     = std::nullopt,
+                                    int num_rows_factor                        = 1);
+
+// Backward-compat fp4-only entry; delegates to dynamic_per_group_scaled_quant.
 void dynamic_per_group_scaled_quant_fp4(aiter_tensor_t& out,         // [..., d]
                                         const aiter_tensor_t& input, // [..., d]
                                         aiter_tensor_t& scales,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1391,6 +1391,15 @@ namespace py = pybind11;
           py::arg("shuffle_scale")   = false,                            \
           py::arg("num_rows")        = std::nullopt,                     \
           py::arg("num_rows_factor") = 1);                               \
+    m.def("dynamic_per_group_scaled_quant",                              \
+          &aiter::dynamic_per_group_scaled_quant,                        \
+          py::arg("out"),                                                \
+          py::arg("input"),                                              \
+          py::arg("scales"),                                             \
+          py::arg("group_size")     = 32,                                \
+          py::arg("shuffle_scale")  = true,                              \
+          py::arg("num_rows")       = std::nullopt,                      \
+          py::arg("num_rows_factor") = 1);                               \
     m.def("dynamic_per_group_scaled_quant_fp4",                          \
           &aiter::dynamic_per_group_scaled_quant_fp4,                    \
           py::arg("out"),                                                \

--- a/csrc/kernels/quant_kernels.cu
+++ b/csrc/kernels/quant_kernels.cu
@@ -16,7 +16,16 @@ const int32_t BlockSize           = 256;
 const int32_t groupQuantBlockSize = 64;
 
 namespace aiter {
-template <typename DTYPE_I, typename DTYPE_O, int thread_data_size = 32, int32_t group_size = 128, bool shuffle_scale = true, int32_t block_size = 64>
+// emit_e8m0_scale = false (default): legacy behaviour — fp4 outputs an e8m0
+// byte scale, fp8 / i8 output a continuous fp32 per-group scale.
+//
+// emit_e8m0_scale = true (opt-in for fp8): compute a power-of-2 per-group
+// scale via f32_to_e8m0_scale and write a single E8M0 byte per group,
+// matching the fp4 byte layout. Used by the MXFP8 "split" path
+// `per_1x32_mx_quant_hip(quant_dtype=fp8, scale_type=fp8_e8m0)` so the
+// produced byte scale is directly consumable by `mxfp4_moe_sort_hip` /
+// MXFP8 GEMM kernels without a post-hoc fp32 -> e8m0 conversion.
+template <typename DTYPE_I, typename DTYPE_O, int thread_data_size = 32, int32_t group_size = 128, bool shuffle_scale = true, int32_t block_size = 64, bool emit_e8m0_scale = false>
 __global__ void __launch_bounds__(block_size)
 dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
                                       float* __restrict__ scale,
@@ -29,6 +38,16 @@ dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
                                       int32_t const* __restrict__ num_rows = nullptr,
                                       const int32_t num_cols_factor        = 1)
 {
+    static_assert(!emit_e8m0_scale
+                      || std::is_same_v<DTYPE_O, opus::fp4_t>
+                      || std::is_same_v<DTYPE_O, opus::fp8_t>,
+                  "emit_e8m0_scale is only valid for fp4 / fp8 outputs");
+
+    // fp4 always emits e8m0 byte scale (no fp32-scale variant exists today);
+    // fp8 emits e8m0 byte scale iff caller opted in via emit_e8m0_scale.
+    static constexpr bool use_e8m0_scale =
+        std::is_same_v<DTYPE_O, opus::fp4_t> || emit_e8m0_scale;
+
     if(num_rows != nullptr)
     {
         ori_rows = static_cast<int64_t>(*num_rows) * num_cols_factor;
@@ -37,21 +56,18 @@ dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
     int64_t row_offset       = static_cast<int64_t>(blockIdx.x) * block_size;
     int64_t groupId          = (row_offset + threadIdx.x) / num_thread_per_group;
     int32_t scaleN           = ori_cols / group_size;
-    int32_t scaleN_pad       = (std::is_same_v<DTYPE_O, opus::fp4_t> && shuffle_scale)
+    // Shuffle tiles e8m0 bytes 8-wide along scaleN regardless of element
+    // dtype, so the padding applies to any e8m0-scale path (fp4 always,
+    // fp8 only when emit_e8m0_scale).
+    int32_t scaleN_pad       = (use_e8m0_scale && shuffle_scale)
                                    ? (((scaleN + 7) / 8) * 8)
                                    : scaleN;
     int64_t x                = groupId / scaleN_pad;
     int32_t y                = static_cast<int32_t>(groupId % scaleN_pad);
-    if constexpr(std::is_same_v<DTYPE_O, opus::fp4_t>)
+    if constexpr(use_e8m0_scale)
     {
         if(x >= ori_rows || y >= scaleN)
         {
-            // if (shuffle_scale && threadIdx.x % num_thread_per_group == 0)
-            // {
-            //   auto *tmp = reinterpret_cast<uint8_t *>(scale);
-            //   groupId = aiter::fp4_scale_shuffle_idx(scaleN_pad, x, y);
-            //   tmp[groupId] = 0x7f;
-            // }
             return;
         }
     }
@@ -65,10 +81,23 @@ dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
     using vec_i = opus::vector_t<DTYPE_I, thread_data_size>;
     static constexpr int32_t vec_size_o =
         std::is_same_v<DTYPE_O, opus::fp4_t> ? thread_data_size / 2 : thread_data_size;
+    // For e8m0 scale the row_scale is constrained to a power of 2, so the
+    // divisor (1 / DTYPE_MAX) must also be the inverse of a power of 2 —
+    // namely 1 / floor_pow2(DTYPE_MAX). fp4 uses 0.25 (= 1/4 = 1/floor_pow2(6)).
+    // fp8 uses gfx-specific constants (gfx950 fp8 max=448 -> 1/256;
+    // gfx942 fp8 e4m3 fnuz max=240 -> 1/128). For the legacy fp32-scale
+    // path we keep the exact 1/DTYPE_MAX divisor.
+#if defined(__gfx942__)
+    constexpr float fp8_e8m0_inv_max = 1.0f / 128.0f;
+#else
+    constexpr float fp8_e8m0_inv_max = 1.0f / 256.0f;
+#endif
     const float inverted_DTYPE_MAX =
         std::is_same_v<DTYPE_O, opus::fp4_t>
-            ? 0.25
-            : (1. / static_cast<float>(opus::finfo<DTYPE_O>::max()));
+            ? 0.25f
+            : (use_e8m0_scale && std::is_same_v<DTYPE_O, opus::fp8_t>
+                   ? fp8_e8m0_inv_max
+                   : 1.0f / static_cast<float>(opus::finfo<DTYPE_O>::max()));
 
     auto const* input_vecs = reinterpret_cast<vec_i const*>(input + row_offset);
     vec_i thread_data = input_vecs[threadIdx.x % num_thread_per_group];
@@ -79,21 +108,21 @@ dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
     }
     absMax = multithread_reduce(absMax, hipcub::Max(), num_thread_per_group);
 
-    float inverted_scale = std::is_same_v<DTYPE_O, opus::fp4_t>
-                               ? aiter::fp4_f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
+    float inverted_scale = use_e8m0_scale
+                               ? aiter::f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
                                : absMax * inverted_DTYPE_MAX;
     row_offset           = std::is_same_v<DTYPE_O, opus::fp4_t>
                                ? groupId * group_size / 2 + (threadIdx.x % num_thread_per_group) * vec_size_o
                                : groupId * group_size + (threadIdx.x % num_thread_per_group) * vec_size_o;
     if(threadIdx.x % num_thread_per_group == 0)
     {
-        if constexpr(std::is_same_v<DTYPE_O, opus::fp4_t>)
+        if constexpr(use_e8m0_scale)
         {
             auto* tmp        = reinterpret_cast<uint8_t*>(scale);
             uint8_t exponent = (__builtin_bit_cast(uint32_t, inverted_scale) >> 23) & 0b11111111;
             if constexpr(shuffle_scale)
             {
-                groupId = aiter::fp4_scale_shuffle_idx(scaleN_pad, static_cast<int>(x), y);
+                groupId = aiter::mx_scale_shuffle_idx(scaleN_pad, static_cast<int>(x), y);
             }
             tmp[groupId] = exponent;
         }
@@ -106,6 +135,15 @@ dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
             scale[groupId] = inverted_scale;
         }
     }
+    // The reciprocal is required by the store path, not by the scale-derivation
+    // mode: fp4 store uses the hardware `cvt_scalef32_pk_fp4_f32` intrinsic
+    // which consumes the e8m0 byte directly (so `inverted_scale` stays as the
+    // scale factor `pow2_amax / max_pow2`); fp8/i8 store does software
+    // `input * inv_scale` and therefore needs `inv_scale = 1 / row_scale`
+    // regardless of whether `row_scale` was derived via e8m0 (power-of-2)
+    // or the continuous `absMax * inv_DTYPE_MAX` formula. Earlier this gate
+    // was on `use_e8m0_scale` which silently skipped the reciprocal for the
+    // fp8 + e8m0 path and produced fp8 bytes ~2x off (`split_elem_err ≈ 100%`).
     inverted_scale =
         std::is_same_v<DTYPE_O, opus::fp4_t> ? inverted_scale : 1.0f / inverted_scale;
 
@@ -190,7 +228,7 @@ __device__ std::tuple<float, DTYPE_I*> data_to_per_row_scale(const DTYPE_I* __re
     absMax = block_reduce<float, hipcub::Max, BlockSize, true>(absMax, hipcub::Max());
 
     float row_scale = std::is_same_v<DTYPE_O, opus::fp4_t>
-                          ? aiter::fp4_f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
+                          ? aiter::f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
                           : absMax * inverted_DTYPE_MAX;
     return std::make_tuple(row_scale, reinterpret_cast<DTYPE_I*>(&vec_cur));
 }
@@ -404,7 +442,7 @@ smooth_data_to_per_row_scale(const DTYPE_I* __restrict__ input,
     absMax = block_reduce<float, hipcub::Max, block_size, true>(absMax, hipcub::Max());
 
     float row_scale = std::is_same_v<DTYPE_O, opus::fp4_t>
-                          ? aiter::fp4_f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
+                          ? aiter::f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
                           : absMax * inverted_DTYPE_MAX;
     return std::make_tuple(row_scale, reinterpret_cast<float*>(&smscale_cur));
 }
@@ -787,13 +825,22 @@ void dynamic_per_token_scaled_quant(aiter_tensor_t& out,         // [..., d]
     }
 }
 
-void dynamic_per_group_scaled_quant_fp4(aiter_tensor_t& out,         // [..., d]
-                                        const aiter_tensor_t& input, // [..., d]
-                                        aiter_tensor_t& scales,
-                                        int group_size,
-                                        bool shuffle_scale,
-                                        std::optional<aiter_tensor_t> num_rows,
-                                        int num_rows_factor)
+// Canonical dynamic per-group scaled quant. Accepts fp8 / i8 / fp4x2 output;
+// the per-group scale layout is selected by ``scales.dtype()``:
+//   * AITER_DTYPE_fp8_e8m0 / u8 -> e8m0 byte scale (one byte per group of
+//     ``group_size`` elements). Required for MXFP4/MXFP8 GEMM consumers.
+//   * AITER_DTYPE_fp32          -> continuous fp32 per-group scale.
+// fp4 outputs always emit e8m0 (there is no fp32-scale fp4 path); fp8 picks
+// the path by scale dtype; i8 only supports fp32. The legacy entry point
+// `dynamic_per_group_scaled_quant_fp4` (kept as a forwarder below) hard-coded
+// fp4 only, which made the MXFP8 1xG byte-scale path unreachable here.
+void dynamic_per_group_scaled_quant(aiter_tensor_t& out,         // [..., d]
+                                    const aiter_tensor_t& input, // [..., d]
+                                    aiter_tensor_t& scales,
+                                    int group_size,
+                                    bool shuffle_scale,
+                                    std::optional<aiter_tensor_t> num_rows,
+                                    int num_rows_factor)
 {
     AITER_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
                 __func__,
@@ -807,6 +854,15 @@ void dynamic_per_group_scaled_quant_fp4(aiter_tensor_t& out,         // [..., d]
 
     AITER_CHECK(cols % group_size == 0, __func__, " cols is not divisible by group_size");
 
+    // Decide e8m0 vs fp32 scale path from scales.dtype(). Note u8 alias is
+    // accepted for callers that build the scale tensor as raw uint8.
+    const bool use_e8m0_scale =
+        scales.dtype() == AITER_DTYPE_fp8_e8m0 || scales.dtype() == AITER_DTYPE_u8;
+    AITER_CHECK(use_e8m0_scale || scales.dtype() == AITER_DTYPE_fp32,
+                __func__,
+                " expects scales.dtype in {fp8_e8m0, u8, fp32}, got ",
+                AiterDtype_to_str(scales.dtype()));
+
     HipDeviceGuard device_guard(input.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
 
@@ -817,54 +873,102 @@ void dynamic_per_group_scaled_quant_fp4(aiter_tensor_t& out,         // [..., d]
         const int num_group_per_tg = dynGroupQuantBlockSize / num_thread_per_group;
 
         int scaleN    = cols / _GS;
-        int num_group = shuffle_scale ? rows * ((scaleN + 7) / 8 * 8) : rows * scaleN;
-        static constexpr int32_t ooba = 4 / sizeof(opus::fp4_t);
-        const int64_t oob_elems =
-            (static_cast<int64_t>(rows) * cols + ooba - 1) / ooba * ooba;
-        const int64_t oob_size = oob_elems * static_cast<int64_t>(sizeof(opus::fp4_t));
-        dim3 const grid((num_group + num_group_per_tg - 1) / num_group_per_tg);
         dim3 const block(dynGroupQuantBlockSize);
 
+        auto launch = [&](auto out_type_tag, auto shuffle_tag, auto e8m0_tag) {
+            using out_t = decltype(out_type_tag);
+            constexpr bool ss = decltype(shuffle_tag)::value;
+            constexpr bool ee = decltype(e8m0_tag)::value;
+            // e8m0 + shuffle pads scaleN up to a multiple of 8 (tile width)
+            // regardless of element dtype; non-shuffle / fp32-scale paths
+            // use exactly `rows * scaleN` slots.
+            int num_group;
+            if constexpr(ee)
+            {
+                num_group = ss ? rows * ((scaleN + 7) / 8 * 8) : rows * scaleN;
+            }
+            else
+            {
+                num_group = rows * scaleN;
+            }
+            static constexpr int32_t ooba = 4 / sizeof(out_t);
+            const int64_t oob_elems =
+                (static_cast<int64_t>(rows) * cols + ooba - 1) / ooba * ooba;
+            const int64_t oob_size = oob_elems * static_cast<int64_t>(sizeof(out_t));
+            dim3 const grid((num_group + num_group_per_tg - 1) / num_group_per_tg);
+            AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+                input.dtype(), "dynamic_per_group_scaled_quant_kernel", [&] {
+                    using input_dtype = typename aiter::hip2opus<scalar_t>::type;
+                    aiter::dynamic_per_group_scaled_quant_kernel<input_dtype, out_t, thread_data_size, _GS, ss, dynGroupQuantBlockSize, ee>
+                        <<<grid, block, 0, stream>>>(
+                        reinterpret_cast<out_t*>(out.data_ptr()),
+                        reinterpret_cast<float*>(scales.data_ptr()),
+                        reinterpret_cast<input_dtype*>(input.data_ptr()),
+                        nullptr,
+                        rows,
+                        cols,
+                        row_stride,
+                        oob_size,
+                        num_rows_ptr,
+                        num_rows_factor);
+                });
+        };
+
+        auto do_launch = [&](auto shuffle_tag, auto e8m0_tag) {
+            constexpr bool ee = decltype(e8m0_tag)::value;
+            if(out.dtype() == AITER_DTYPE_fp8)
+            {
+                launch(opus::fp8_t{}, shuffle_tag, e8m0_tag);
+            }
+            else if(out.dtype() == AITER_DTYPE_i8)
+            {
+                static_assert(true, "i8 path does not support e8m0 scale");
+                AITER_CHECK(!ee, __func__, " i8 output does not support e8m0 scale");
+                launch(opus::i8_t{}, shuffle_tag, std::false_type{});
+            }
 #if defined(__Float4_e2m1fn_x2)
-        if(shuffle_scale) {
-            AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
-                input.dtype(), "dynamic_per_group_scaled_quant_kernel", [&] {
-                    using input_dtype = typename aiter::hip2opus<scalar_t>::type;
-                    aiter::dynamic_per_group_scaled_quant_kernel<input_dtype, opus::fp4_t, thread_data_size, _GS, true, dynGroupQuantBlockSize>
-                        <<<grid, block, 0, stream>>>(
-                        reinterpret_cast<opus::fp4_t*>(out.data_ptr()),
-                        reinterpret_cast<float*>(scales.data_ptr()),
-                        reinterpret_cast<input_dtype*>(input.data_ptr()),
-                        nullptr,
-                        rows,
-                        cols,
-                        row_stride,
-                        oob_size,
-                        num_rows_ptr,
-                        num_rows_factor);
-                });
-        } else {
-            AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
-                input.dtype(), "dynamic_per_group_scaled_quant_kernel", [&] {
-                    using input_dtype = typename aiter::hip2opus<scalar_t>::type;
-                    aiter::dynamic_per_group_scaled_quant_kernel<input_dtype, opus::fp4_t, thread_data_size, _GS, false, dynGroupQuantBlockSize>
-                        <<<grid, block, 0, stream>>>(
-                        reinterpret_cast<opus::fp4_t*>(out.data_ptr()),
-                        reinterpret_cast<float*>(scales.data_ptr()),
-                        reinterpret_cast<input_dtype*>(input.data_ptr()),
-                        nullptr,
-                        rows,
-                        cols,
-                        row_stride,
-                        oob_size,
-                        num_rows_ptr,
-                        num_rows_factor);
-                });
-        }
-#else
-        AITER_CHECK(false, __func__, " device not support Float4_e2m1fn_x2 dtype");
+            else if(out.dtype() == AITER_DTYPE_fp4x2 || out.dtype() == AITER_DTYPE_u8)
+            {
+                // fp4 always uses e8m0 scale regardless of `use_e8m0_scale`.
+                launch(opus::fp4_t{}, shuffle_tag, std::true_type{});
+            }
 #endif
+            else
+            {
+                AITER_CHECK(false, __func__, " not support output type: ", AiterDtype_to_str(out.dtype()));
+            }
+        };
+
+        auto with_e8m0 = [&](auto shuffle_tag) {
+            if(use_e8m0_scale)
+                do_launch(shuffle_tag, std::true_type{});
+            else
+                do_launch(shuffle_tag, std::false_type{});
+        };
+        if(shuffle_scale)
+            with_e8m0(std::true_type{});
+        else
+            with_e8m0(std::false_type{});
     )
+}
+
+// Backward-compat thin forwarder. Asserts fp4x2/u8 output and delegates to
+// the dtype-aware canonical entry. Existing callers (Python compile_ops
+// binding `dynamic_per_group_scaled_quant_fp4`, downstream tests, etc.)
+// continue to work unchanged.
+void dynamic_per_group_scaled_quant_fp4(aiter_tensor_t& out,         // [..., d]
+                                        const aiter_tensor_t& input, // [..., d]
+                                        aiter_tensor_t& scales,
+                                        int group_size,
+                                        bool shuffle_scale,
+                                        std::optional<aiter_tensor_t> num_rows,
+                                        int num_rows_factor)
+{
+    AITER_CHECK(out.dtype() == AITER_DTYPE_fp4x2 || out.dtype() == AITER_DTYPE_u8,
+                __func__,
+                " expects fp4x2 / uint8 output; use dynamic_per_group_scaled_quant for fp8/i8");
+    dynamic_per_group_scaled_quant(
+        out, input, scales, group_size, shuffle_scale, num_rows, num_rows_factor);
 }
 
 #define SMOOTH_PER_TOKEN_SCALED_QUANT_KERNEL_IMPL(quant_kernel, DTYPE_O, THREAD_DATA, BLOCK_SIZE, TRANSPOSE_OUT_DIM01, HAS_MAP, HAS_HASH) \
@@ -1431,7 +1535,7 @@ __global__ void moe_smooth_per_token_scaled_quant_kernel_v2(DTYPE_O* __restrict_
             absMax = block_reduce<float, hipcub::Max, block_size, true>(absMax, hipcub::Max());
 
             float row_scale = std::is_same_v<DTYPE_O, opus::fp4_t>
-                                ? aiter::fp4_f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
+                                ? aiter::f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
                                 : absMax * inverted_DTYPE_MAX;
             
             int out_token_idx;
@@ -1571,8 +1675,14 @@ void moe_smooth_per_token_scaled_quant_v2(
 }
 
 
+// Fused dynamic MX (fp4 / fp8) quantization + MoE-sort writeback.
+// Template parameter DTYPE_O selects the element format (opus::fp4_t for MXFP4,
+// opus::fp8_t for MXFP8); both paths emit the same E8M0 scale byte layout via
+// `aiter::mx_scale_shuffle_idx`. The legacy kernel name
+// `mxfp4_quant_moe_sort_kernel` was misleading because it implied fp4-only
+// — the implementation has always been dtype-templated.
 template <typename DTYPE_I, typename DTYPE_O, int block_size, int thread_data_size = 16>
-__global__ void mxfp4_quant_moe_sort_kernel(
+__global__ void fused_mx_quant_moe_sort_kernel(
     DTYPE_O* __restrict__ out,
     uint8_t* __restrict__ scale,
     DTYPE_I const* __restrict__ input,
@@ -1668,16 +1778,16 @@ __global__ void mxfp4_quant_moe_sort_kernel(
 
             float row_scale =
                 std::is_same_v<DTYPE_O, opus::fp4_t>
-                    ? aiter::fp4_f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
+                    ? aiter::f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
                     : (std::is_same_v<DTYPE_O, opus::fp8_t>
-                           ? aiter::fp4_f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
+                           ? aiter::f32_to_e8m0_scale(absMax) * inverted_DTYPE_MAX
                            : absMax * inverted_DTYPE_MAX);
 
             const int sorted_row = sorted_ids_base + i * tgs_per_block_m;
             if(threadIdx.x % num_thread_per_group == 0 && scale_k < scaleN_valid)
             {
                 uint8_t bs_e8m0 = (__builtin_bit_cast(uint32_t, row_scale) >> 23) & 0xFF;
-                int addr        = aiter::fp4_scale_shuffle_idx(scaleN_pad, sorted_row, scale_k);
+                int addr        = aiter::mx_scale_shuffle_idx(scaleN_pad, sorted_row, scale_k);
                 scale[addr]     = bs_e8m0;
             }
 
@@ -1691,14 +1801,14 @@ __global__ void mxfp4_quant_moe_sort_kernel(
 }
 
 
-#define MXFP4_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, THREAD_DATA, BLOCK_SIZE)                    \
-    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(input.dtype(), "mxfp4_quant_moe_sort_kernel", [&] { \
-        using input_dtype = typename aiter::hip2opus<scalar_t>::type;                            \
+#define FUSED_MX_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, THREAD_DATA, BLOCK_SIZE)                       \
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(input.dtype(), "fused_mx_quant_moe_sort_kernel", [&] {  \
+        using input_dtype = typename aiter::hip2opus<scalar_t>::type;                               \
         AITER_CHECK(group_size % THREAD_DATA == 0, __func__, " group_size is not divisible by THREAD_DATA"); \
-        int blocks_per_cu = 8 * 4 / (BLOCK_SIZE / WARP_SIZE);                                  \
-        int num_tg = persistent_mode ? num_cu * blocks_per_cu : num_blocks;                     \
-        dim3 const grid(num_tg);                                                               \
-        mxfp4_quant_moe_sort_kernel<input_dtype, DTYPE_O, BLOCK_SIZE, THREAD_DATA>             \
+        int blocks_per_cu = 8 * 4 / (BLOCK_SIZE / WARP_SIZE);                                       \
+        int num_tg = persistent_mode ? num_cu * blocks_per_cu : num_blocks;                         \
+        dim3 const grid(num_tg);                                                                    \
+        fused_mx_quant_moe_sort_kernel<input_dtype, DTYPE_O, BLOCK_SIZE, THREAD_DATA>               \
             <<<grid, dim3(BLOCK_SIZE), 0, stream>>>(                                           \
                 reinterpret_cast<DTYPE_O*>(output.data_ptr()),                                  \
                 reinterpret_cast<uint8_t*>(scale.data_ptr()),                                   \
@@ -1717,26 +1827,26 @@ __global__ void mxfp4_quant_moe_sort_kernel(
     });
 
 
-#define MXFP4_QUANT_MOE_SORT_KERNEL_DISPATCH(DTYPE_O, cols_)                                   \
+#define FUSED_MX_QUANT_MOE_SORT_KERNEL_DISPATCH(DTYPE_O, cols_)                                \
     if(cols_ <= 2 * BlockSize)                                                                 \
     {                                                                                          \
-        MXFP4_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 8, BlockSize / 4)                           \
+        FUSED_MX_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 8, BlockSize / 4)                         \
     }                                                                                          \
     else if(cols_ <= 4 * BlockSize)                                                            \
     {                                                                                          \
-        MXFP4_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 8, BlockSize / 2)                           \
+        FUSED_MX_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 8, BlockSize / 2)                         \
     }                                                                                          \
     else if(cols_ <= 8 * BlockSize)                                                            \
     {                                                                                          \
-        MXFP4_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 8, BlockSize)                               \
+        FUSED_MX_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 8, BlockSize)                             \
     }                                                                                          \
     else if(cols_ <= 16 * BlockSize)                                                           \
     {                                                                                          \
-        MXFP4_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 16, BlockSize)                              \
+        FUSED_MX_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 16, BlockSize)                            \
     }                                                                                          \
     else if(cols_ <= 16 * BlockSize * 2)                                                       \
     {                                                                                          \
-        MXFP4_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 32, BlockSize)                              \
+        FUSED_MX_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, 32, BlockSize)                            \
     }                                                                                          \
     else                                                                                       \
     {                                                                                          \
@@ -1771,12 +1881,12 @@ void fused_dynamic_mx_quant_moe_sort_hip(
 
     if(output.dtype() == AITER_DTYPE_fp8)
     {
-        MXFP4_QUANT_MOE_SORT_KERNEL_DISPATCH(opus::fp8_t, cols);
+        FUSED_MX_QUANT_MOE_SORT_KERNEL_DISPATCH(opus::fp8_t, cols);
     }
 #if defined(__Float4_e2m1fn_x2)
     else if(output.dtype() == AITER_DTYPE_fp4x2 || output.dtype() == AITER_DTYPE_u8)
     {
-        MXFP4_QUANT_MOE_SORT_KERNEL_DISPATCH(opus::fp4_t, cols);
+        FUSED_MX_QUANT_MOE_SORT_KERNEL_DISPATCH(opus::fp4_t, cols);
     }
 #endif
     else
@@ -1841,7 +1951,7 @@ __global__ void mxfp4_moe_sort_kernel(
             {
                 if((scale_k + j) < scaleN_valid)
                 {
-                    int addr = aiter::fp4_scale_shuffle_idx(scaleN_pad, sorted_row, scale_k + j);
+                    int addr = aiter::mx_scale_shuffle_idx(scaleN_pad, sorted_row, scale_k + j);
                     out_scale[addr] = vec_scale[j];
                 }
             }

--- a/op_tests/test_moe_sorting_mxfp4.py
+++ b/op_tests/test_moe_sorting_mxfp4.py
@@ -1,5 +1,21 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Unified perf + accuracy harness for MoE-sort + (optional) MX quant.
+
+Covers two operations, dispatched by ``--quant-dtype``:
+
+  * ``test_moe_mxfp4_sort``: standalone e8m0 byte sort/swizzle
+    (``mxfp4_moe_sort_hip`` / Triton). The byte layout is dtype-agnostic
+    (same swizzle for MXFP4 and MXFP8 scales), so this test always runs
+    and is unaffected by ``--quant-dtype``.
+
+  * ``test_moe_mx_quant_sort``: fused dynamic MX quant + sort. Selects:
+      - ``--quant-dtype fp4x2`` (default): MXFP4, packed fp4 output +
+        e8m0 scale. Compared paths: ref / split / HIP-fused / Triton.
+      - ``--quant-dtype fp8``: MXFP8, fp8 e4m3 output + e8m0 scale.
+        Compared paths: ref / split / HIP-fused (no Triton).
+"""
+
 import torch
 import aiter
 from aiter.test_common import checkAllclose, benchmark, run_perftest
@@ -7,6 +23,10 @@ from aiter.fused_moe import moe_sorting, fused_topk
 from aiter.ops.triton.quant.fused_mxfp4_quant import fused_dynamic_mxfp4_quant_moe_sort
 from aiter.jit.utils.chip_info import get_gfx
 from aiter import get_torch_quant, dtypes
+from aiter.ops.quant import (
+    per_1x32_f8_scale_f8_quant,
+    per_1x32_mx_quant_hip,
+)
 from aiter.utility import fp4_utils
 import pandas as pd
 import itertools
@@ -32,9 +52,12 @@ def run_torch(scale, sorted_ids, num_valid_ids, token_num):
     scale = scale[sorted_ids]
     scale.view(torch.uint8)[mask] = 0
     sm, sn = scale.shape
-    tmp = torch.zeros(
-        ((sm + 31) // 32 * 32, sn), dtype=scale.dtype, device=scale.device
-    )
+    # Pad both dims to the tile boundaries the swizzle formula assumes:
+    # rows -> multiple of 32, cols -> multiple of 8 (e.g. inter_dim=384
+    # gives scaleN=12 which must be padded to 16).
+    sm_pad = (sm + 31) // 32 * 32
+    sn_pad = (sn + 7) // 8 * 8
+    tmp = torch.zeros((sm_pad, sn_pad), dtype=scale.dtype, device=scale.device)
     tmp[:sm, :sn] = scale
     scale = tmp
     sm, sn = scale.shape
@@ -44,18 +67,48 @@ def run_torch(scale, sorted_ids, num_valid_ids, token_num):
     return ref
 
 
-def run_split_quant_sort(scale, input, sorted_ids, num_valid_ids, token_num):
+def run_split_quant_sort(input, sorted_ids, num_valid_ids, token_num, quant_dtype):
+    """Two-pass split path: per-token quant + e8m0 byte sort/swizzle.
+
+    fp4 and fp8 share the same `mxfp4_moe_sort_hip` byte shuffle kernel
+    (dtype-agnostic); only the per-token quant kernel differs.
+    """
     model_dim = input.shape[-1]
-    out, scale_ = aiter.per_1x32_f4_quant_hip(input, None, dtypes.fp4x2)
+    out, scale_per_token = per_1x32_mx_quant_hip(
+        input,
+        scale=None,
+        quant_dtype=quant_dtype,
+        scale_type=dtypes.fp8_e8m0 if quant_dtype == dtypes.fp8 else None,
+        shuffle=False,
+    )
+    # Pad cols to multiple of 8 to match the kernel's swizzle stride.
+    scaleN_pad = ((model_dim // 32) + 7) // 8 * 8
+    out_scale_sorted = torch.zeros(
+        ((sorted_ids.shape[0] + 31) // 32 * 32, scaleN_pad),
+        dtype=dtypes.fp8_e8m0,
+        device=input.device,
+    )
     aiter.mxfp4_moe_sort_hip(
-        scale,
-        scale_,
+        out_scale_sorted,
+        scale_per_token,
         sorted_ids,
         num_valid_ids,
         token_num,
         model_dim,
     )
-    return out, scale
+    return out, out_scale_sorted
+
+
+def _ref_quant(input, quant_dtype):
+    """Per-row MX quant reference (no sort). Returns (fp_out, per_token_scale)."""
+    if quant_dtype == dtypes.fp4x2:
+        return get_torch_quant(aiter.QuantType.per_1x32)(
+            input, quant_dtype=dtypes.fp4x2
+        )
+    else:
+        return per_1x32_f8_scale_f8_quant(
+            input, quant_dtype=dtypes.fp8, scale_type=dtypes.fp8_e8m0
+        )
 
 
 @benchmark()
@@ -89,8 +142,13 @@ def test_moe_mxfp4_sort(dtype, token_num, model_dim, E, topk, block_size, stage)
         block_size,
     )
 
+    # Pad cols to multiple of 8: the swizzle formula `mx_scale_shuffle_idx`
+    # uses `scaleN_pad = pad8(scaleN)`, so the destination buffer needs
+    # `pad8(model_dim/32)` cols to avoid OOB writes when scaleN is not
+    # already a multiple of 8 (e.g. inter_dim=384 -> scaleN=12 -> 16).
+    scaleN_pad = ((model_dim // 32) + 7) // 8 * 8
     hip_scale = torch.zeros(
-        ((sorted_ids.shape[0] + 31) // 32 * 32, model_dim // 32),
+        ((sorted_ids.shape[0] + 31) // 32 * 32, scaleN_pad),
         dtype=torch.uint8,
         device=input.device,
     )
@@ -127,9 +185,21 @@ def test_moe_mxfp4_sort(dtype, token_num, model_dim, E, topk, block_size, stage)
 
 
 @benchmark()
-def test_moe_mxfp4_quant_sort(dtype, token_num, model_dim, E, topk, block_size, stage):
+def test_moe_mx_quant_sort(
+    dtype, token_num, model_dim, E, topk, block_size, stage, quant_dtype
+):
+    """Unified MXFP4 / MXFP8 quant + sort benchmark.
+
+    Compares 4 paths (3 for fp8 -- Triton is fp4-only):
+      * ref:    python ref quant + python sort
+      * split:  per_1x32_mx_quant_hip + mxfp4_moe_sort_hip (2 kernels)
+      * hip:    fused_dynamic_mx{fp4,fp8}_quant_moe_sort (1 kernel + dispatch)
+      * triton: fused_dynamic_mxfp4_quant_moe_sort (Triton, fp4 only)
+    """
     if get_gfx().startswith("gfx94"):
         return {}
+    is_fp8 = quant_dtype == dtypes.fp8
+    label = "mxfp8" if is_fp8 else "mxfp4"
     input = torch.randn((token_num, model_dim), dtype=dtype)
     score = torch.randn((token_num, E), dtype=dtype)
 
@@ -142,94 +212,121 @@ def test_moe_mxfp4_quant_sort(dtype, token_num, model_dim, E, topk, block_size, 
         dtype,
     )
     num_valid_ids = num_valid_ids[0]
+    topk_orig = topk  # keep before clobbering for stage1
     if stage != "stage1":
         input = torch.randn((token_num * topk, model_dim), dtype=dtype)
     else:
         topk = 1
-    ref_out, scale = get_torch_quant(aiter.QuantType.per_1x32)(
-        input, quant_dtype=dtypes.fp4x2
-    )
+
+    # Reference: per-row MX quant + python-side byte sort.
+    ref_out, scale = _ref_quant(input, quant_dtype)
+    # For stage2 the per-row scale is `(token_num * topk, scaleN)`. Reshape
+    # to 3D `(token_num, topk, scaleN)` so `run_torch` sees the topk dim
+    # and applies the proper `sorted_ids * topk + topk_ids` indexing
+    # instead of treating it as 2D (which collapses every slot onto
+    # token_idx 0..token_num-1 and produces ~3-5% byte mismatches versus
+    # the HIP/split paths in stage2).
+    if stage != "stage1":
+        scale = scale.view(token_num, topk_orig, -1)
     ref_scale = run_torch(scale.clone(), sorted_ids.clone(), num_valid_ids, token_num)
 
-    split_scale = torch.zeros(
-        ((sorted_ids.shape[0] + 31) // 32 * 32, model_dim // 32),
-        dtype=torch.uint8,
-        device=input.device,
-    )
+    # Split: per_1x32_mx_quant_hip + mxfp4_moe_sort_hip.
     (split_out, split_scale), split_us = run_perftest(
         run_split_quant_sort,
-        split_scale,
         input,
         sorted_ids,
         num_valid_ids,
         token_num,
+        quant_dtype,
     )
 
-    hip_scale = torch.zeros(
-        ((sorted_ids.shape[0] + 31) // 32 * 32, model_dim // 32),
-        dtype=torch.uint8,
-        device=input.device,
+    # HIP fused: the Python wrapper internally dispatches by M (small M ->
+    # single fused kernel; large M -> split path). For production-sized M
+    # (e.g. 15472) this auto-selects split, matching the split column.
+    hip_fn = (
+        aiter.fused_dynamic_mxfp8_quant_moe_sort
+        if is_fp8
+        else aiter.fused_dynamic_mxfp4_quant_moe_sort
     )
-    hip_out = torch.empty(
-        (token_num * topk, model_dim // 2),
-        dtype=dtypes.fp4x2,
-        device=input.device,
-    )
-    _, hip_us = run_perftest(
-        aiter.fused_dynamic_mx_quant_moe_sort_hip,
-        hip_out,
-        hip_scale,
+    (hip_out, hip_scale), hip_us = run_perftest(
+        hip_fn,
         input,
         sorted_ids,
         num_valid_ids,
         token_num,
+        topk,
         block_size,
     )
 
-    (triton_out, triton_scale), triton_us = run_perftest(
-        fused_dynamic_mxfp4_quant_moe_sort,
-        input,
-        sorted_ids=sorted_ids,
-        num_valid_ids=num_valid_ids,
-        token_num=token_num,
-        topk=topk,
-        block_size=block_size,
-    )
+    # Triton path: fp4 only. MUST run BEFORE the `num_valid_ids.item()`
+    # below -- the Triton kernel takes `num_valid_ids` as a 0-d tensor
+    # pointer (it does `tl.load(num_valid_ids_ptr)` internally), and
+    # would otherwise see a Python int and fail at compile time with
+    # "Unsupported ptr type triton.language.int32 in `tl.load`".
+    triton_out = triton_scale = None
+    triton_us = None
+    if not is_fp8:
+        (triton_out, triton_scale), triton_us = run_perftest(
+            fused_dynamic_mxfp4_quant_moe_sort,
+            input,
+            sorted_ids=sorted_ids,
+            num_valid_ids=num_valid_ids,
+            token_num=token_num,
+            topk=topk,
+            block_size=block_size,
+        )
 
-    mask = ref_scale == 0
-    triton_scale = triton_scale[: ref_scale.shape[0]]
-    triton_scale.view(torch.uint8)[mask] = 0
     num_valid_ids = num_valid_ids.item()
     num_valid_ids = (num_valid_ids + block_size - 1) // block_size * block_size
 
-    checkAllclose(ref_out.view(torch.uint8), hip_out.view(torch.uint8), msg="hip out")
+    checkAllclose(
+        ref_out.view(torch.uint8), hip_out.view(torch.uint8), msg=f"hip {label} out"
+    )
+    # The wrapper allocates `scale` with `torch.empty` (no zero-init) for
+    # perf, so positions the kernel does not write (padding rows within
+    # expert blocks; padding cols when `model_dim/32` is not a multiple
+    # of 8) contain allocator garbage. Production GEMM consumers never
+    # read those positions, but a byte-level `checkAllclose` would
+    # otherwise flag them. Mask out positions where ref is 0 (the
+    # un-written / zero-init slots), matching the trick the original
+    # mxfp4 test applied to the Triton path.
+    hip_mask = ref_scale == 0
+    hip_scale = hip_scale[: ref_scale.shape[0]]
+    hip_scale.view(torch.uint8)[hip_mask] = 0
+    split_scale = split_scale[: ref_scale.shape[0]]
+    split_scale.view(torch.uint8)[hip_mask] = 0
     hip_err = checkAllclose(
         ref_scale[:num_valid_ids].view(torch.uint8),
         hip_scale[:num_valid_ids].view(torch.uint8),
-        msg="hip sorted_mxfp4_scale",
-    )
-
-    # checkAllclose(ref_out.view(torch.uint8), triton_out.view(torch.uint8), msg="triton out")
-    triton_err = checkAllclose(
-        ref_scale[:num_valid_ids].view(torch.uint8),
-        triton_scale[:num_valid_ids].view(torch.uint8),
-        msg="triton sorted_mxfp4_scale",
+        msg=f"hip sorted_{label}_scale",
     )
 
     split_err = checkAllclose(
         ref_scale[:num_valid_ids].view(torch.uint8),
         split_scale[:num_valid_ids].view(torch.uint8),
-        msg="split sorted_mxfp4_scale",
+        msg=f"split sorted_{label}_scale",
     )
 
-    return {
-        "triton_us": triton_us,
-        "triton_err": triton_err,
+    result = {
         "hip_us": hip_us,
         "hip_err": hip_err,
         "split_us": split_us,
         "split_err": split_err,
     }
+
+    if not is_fp8 and triton_scale is not None:
+        mask = ref_scale == 0
+        triton_scale = triton_scale[: ref_scale.shape[0]]
+        triton_scale.view(torch.uint8)[mask] = 0
+        triton_err = checkAllclose(
+            ref_scale[:num_valid_ids].view(torch.uint8),
+            triton_scale[:num_valid_ids].view(torch.uint8),
+            msg=f"triton sorted_{label}_scale",
+        )
+        result["triton_us"] = triton_us
+        result["triton_err"] = triton_err
+
+    return result
 
 
 parser = argparse.ArgumentParser(
@@ -246,6 +343,16 @@ parser.add_argument(
     metavar="{bf16}",
     help="""Data type.
     e.g.: -d bf16""",
+)
+parser.add_argument(
+    "-q",
+    "--quant-dtype",
+    type=str,
+    choices=["fp4x2", "fp8"],
+    default="fp4x2",
+    help="""MX quant element format for the quant+sort test.
+    fp4x2 (default): MXFP4, packed fp4 output. Compares ref / split / HIP / Triton.
+    fp8:             MXFP8, fp8 e4m3 output.   Compares ref / split / HIP (no Triton).""",
 )
 parser.add_argument(
     "-dim1",
@@ -291,6 +398,41 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
+_quant_dtype = dtypes.fp4x2 if args.quant_dtype == "fp4x2" else dtypes.fp8
+_label = args.quant_dtype  # for log msg
+
+# Standalone byte sort/swizzle test. The underlying kernels
+# (`mxfp4_moe_sort_hip`, `fp4_utils.moe_mxfp4_sort`) are dtype-agnostic
+# (uint8 byte shuffle), but the Triton path is fp4-only by name, and the
+# HIP path is implicitly exercised inside `test_moe_mx_quant_sort`'s split
+# path. To avoid the misleading "triton_us" column when running with
+# `-q fp8`, only run this test for the fp4 mode.
+if _quant_dtype == dtypes.fp4x2:
+    df = []
+    for dtype in args.dtype:
+        for (
+            dim,
+            (E, topk),
+            m,
+        ) in itertools.product(args.dim1, args.expert_topk, args.m):
+            ret = test_moe_mxfp4_sort(dtype, m, dim, E, topk, args.block_m, "stage1")
+            df.append(ret)
+    df = pd.DataFrame(df)
+    df_md = df.to_markdown(index=False)
+    aiter.logger.info("moe_sorting_mxfp4_stage1 summary (markdown):\n%s", df_md)
+
+    df = []
+    for dtype in args.dtype:
+        for (
+            dim,
+            (E, topk),
+            m,
+        ) in itertools.product(args.dim2, args.expert_topk, args.m):
+            ret = test_moe_mxfp4_sort(dtype, m, dim, E, topk, args.block_m, "stage2")
+            df.append(ret)
+    df = pd.DataFrame(df)
+    df_md = df.to_markdown(index=False)
+    aiter.logger.info("moe_sorting_mxfp4_stage2 summary (markdown):\n%s", df_md)
 
 df = []
 for dtype in args.dtype:
@@ -299,11 +441,13 @@ for dtype in args.dtype:
         (E, topk),
         m,
     ) in itertools.product(args.dim1, args.expert_topk, args.m):
-        ret = test_moe_mxfp4_sort(dtype, m, dim, E, topk, args.block_m, "stage1")
+        ret = test_moe_mx_quant_sort(
+            dtype, m, dim, E, topk, args.block_m, "stage1", _quant_dtype
+        )
         df.append(ret)
 df = pd.DataFrame(df)
 df_md = df.to_markdown(index=False)
-aiter.logger.info("moe_sorting_mxfp4_stage1 summary (markdown):\n%s", df_md)
+aiter.logger.info("moe_%s_quant_sort_stage1 summary (markdown):\n%s", _label, df_md)
 
 df = []
 for dtype in args.dtype:
@@ -312,34 +456,10 @@ for dtype in args.dtype:
         (E, topk),
         m,
     ) in itertools.product(args.dim2, args.expert_topk, args.m):
-        ret = test_moe_mxfp4_sort(dtype, m, dim, E, topk, args.block_m, "stage2")
+        ret = test_moe_mx_quant_sort(
+            dtype, m, dim, E, topk, args.block_m, "stage2", _quant_dtype
+        )
         df.append(ret)
 df = pd.DataFrame(df)
 df_md = df.to_markdown(index=False)
-aiter.logger.info("moe_sorting_mxfp4_stage2 summary (markdown):\n%s", df_md)
-
-df = []
-for dtype in args.dtype:
-    for (
-        dim,
-        (E, topk),
-        m,
-    ) in itertools.product(args.dim1, args.expert_topk, args.m):
-        ret = test_moe_mxfp4_quant_sort(dtype, m, dim, E, topk, args.block_m, "stage1")
-        df.append(ret)
-df = pd.DataFrame(df)
-df_md = df.to_markdown(index=False)
-aiter.logger.info("moe_mxfp4_quant_sort_stage1 summary (markdown):\n%s", df_md)
-
-df = []
-for dtype in args.dtype:
-    for (
-        dim,
-        (E, topk),
-        m,
-    ) in itertools.product(args.dim2, args.expert_topk, args.m):
-        ret = test_moe_mxfp4_quant_sort(dtype, m, dim, E, topk, args.block_m, "stage2")
-        df.append(ret)
-df = pd.DataFrame(df)
-df_md = df.to_markdown(index=False)
-aiter.logger.info("moe_mxfp4_quant_sort_stage2 summary (markdown):\n%s", df_md)
+aiter.logger.info("moe_%s_quant_sort_stage2 summary (markdown):\n%s", _label, df_md)


### PR DESCRIPTION
##Motivation
Prefill-phase MXFP8 dynamic quant + MoE sort on DSv4-like shapes (token=15472, model_dim=7168, E=384, topk=6) was bottlenecked: the only MXFP8 path was the single-kernel fused one, which redundantly quantizes each token topk times in stage1.

What this PR does
Enable MXFP8 to use the two-pass split path (per_1x32 quant + e8m0 byte shuffle) that MXFP4 already had. Stage1 input is (token_num, model_dim) (not yet topk-replicated); fused re-quantizes each row topk times while split quantizes once and only byte-shuffles the e8m0 scale during sort.

Performance
token=15472, model_dim=7168, E=384, topk=6 (MI355):

| test | fused (us) | split (us) | speedup |
| --- | ---: | ---: | ---: |
| stage1 MXFP8 | 369 | 90 | **4.1x** |
| stage2 MXFP8 (inter_dim=384) | 29 | 23 | 1.26x |

stage2 input is already topk-replicated so fused has no redundancy to remove; split still narrowly wins from the simpler 2-kernel pipeline.

## Technical Details
1. Kernel (csrc/kernels/quant_kernels.cu): dynamic_per_group_scaled_quant_kernel gets a bool emit_e8m0_scale template parameter. With it, fp8 outputs produce an e8m0 byte scale (using f32_to_e8m0_scale + gfx-aware inverted_DTYPE_MAX: 1/256 on gfx950, 1/128 on gfx942), matching the byte layout mxfp4_moe_sort_hip consumes.
2. C++ host: dtype-aware dynamic_per_group_scaled_quant (dispatches by out.dtype() + scales.dtype()); legacy _fp4 symbol retained as forwarder.
3. Python wrapper (aiter/ops/quant.py):
   - per_1x32_mx_quant_hip(quant_dtype, scale_type) — dtype-aware, MXFP8 supports both dtypes.fp32 (default, existing behavior) and dtypes.fp8_e8m0 (new, byte-scale split path).
   - fused_dynamic_mx_quant_moe_sort(quant_dtype) — unified MoE-sort entry that dispatches by M (small → fused single kernel; large → split). Old fused_dynamic_mxfp{4,8}_quant_moe_sort kept as thin aliases.
   - get_hip_quant(QuantType.per_1x32) points at the new entry so MXFP8 is reachable via the standard dispatch table.
Helper rename: fp4_f32_to_e8m0_scale → f32_to_e8m0_scale, fp4_scale_shuffle_idx → mx_scale_shuffle_idx. Legacy names kept as __forceinline__ aliases.
4. Latent OOB fix: scale tensor cols now padded to pad8(scaleN_valid) (matches the swizzle stride the kernel assumes). Production shapes happen to have cols/32 divisible by 8 (7168/32=224); edge shapes like DSv4 stage2 inter_dim=384 (scaleN=12) trigger this.
5. Backward compat
6. Legacy entry points retained:
   - C++: dynamic_per_group_scaled_quant_fp4
   - Python: per_1x32_f4_quant_hip, fused_dynamic_mxfp4_quant_moe_sort, fused_dynamic_mxfp8_quant_moe_sort
fp8 + fp32-scale path (per_1x32_f8_scale_f8_quant ref, dynamic_per_token_scaled_quant HIP) intentionally untouched.

## Test Plan
op_tests/test_moe_sorting_mxfp4.py is now dtype-aware via -q/--quant-dtype {fp4x2, fp8} (replaces the separate test_moe_sorting_mxfp8.py):

MXFP4 (default, parity with old behavior)
python op_tests/test_moe_sorting_mxfp4.py 
python op_tests/test_moe_sorting_mxfp4.py -q fp8 -m 15472 -ek 384,6 -dim1 7168 -dim2 38
## TestResults
token=15472, model_dim=7168, E=384, topk=6 (MI355):

token_num	model_dim	E	topk 	block_m	fused (us)	split (us)	speedup
15472               7168             384      6             32            369.57             89.75        4.1×
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
