### PR TITLE
CI: increase Aiter test shards to 8

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -243,13 +243,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-signal, build_aiter_wheels]
     outputs:
-      shard_count: 5
+      shard_count: 8
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Split Aiter Tests (5 shards)
-        run: ./.github/scripts/split_tests.sh --shards 5 --test-type aiter
+      - name: Split Aiter Tests (8 shards)
+        run: ./.github/scripts/split_tests.sh --shards 8 --test-type aiter
 
       - name: Upload test shard lists as artifact
         uses: actions/upload-artifact@v4
@@ -279,44 +279,68 @@ jobs:
         include:
           - runner: linux-aiter-mi35x-1
             label: MI35X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 0
           - runner: linux-aiter-mi35x-1
             label: MI35X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 1
           - runner: linux-aiter-mi35x-1
             label: MI35X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 2
           - runner: linux-aiter-mi35x-1
             label: MI35X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 3
           - runner: linux-aiter-mi35x-1
             label: MI35X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 4
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            shard_total: 8
+            shard_idx: 5
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            shard_total: 8
+            shard_idx: 6
+          - runner: linux-aiter-mi35x-1
+            label: MI35X
+            shard_total: 8
+            shard_idx: 7
           - runner: aiter-1gpu-runner
             label: MI300X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 0
           - runner: aiter-1gpu-runner
             label: MI300X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 1
           - runner: aiter-1gpu-runner
             label: MI300X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 2
           - runner: aiter-1gpu-runner
             label: MI300X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 3
           - runner: aiter-1gpu-runner
             label: MI300X
-            shard_total: 5
+            shard_total: 8
             shard_idx: 4
+          - runner: aiter-1gpu-runner
+            label: MI300X
+            shard_total: 8
+            shard_idx: 5
+          - runner: aiter-1gpu-runner
+            label: MI300X
+            shard_total: 8
+            shard_idx: 6
+          - runner: aiter-1gpu-runner
+            label: MI300X
+            shard_total: 8
+            shard_idx: 7
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -559,7 +583,7 @@ jobs:
           set -ex
           echo "Checking Standard Test Results..."
           all_passed=true
-          for shard in {0..4}; do
+          for shard in {0..7}; do
             for runner in {linux-aiter-mi35x-1,aiter-1gpu-runner}; do
               if [ ! -f standard-test-log-${runner}-shard-${shard}/latest_test.log ]; then
                 echo "Test report for ${runner} shard ${shard} not found."

--- a/.github/workflows/update-split-tests.yaml
+++ b/.github/workflows/update-split-tests.yaml
@@ -52,7 +52,7 @@ jobs:
             --summary-path split-tests-update-summary.md
 
       - name: Dry run rebalance check (aiter)
-        run: bash .github/scripts/split_tests.sh --shards 5 --test-type aiter --dry-run
+        run: bash .github/scripts/split_tests.sh --shards 8 --test-type aiter --dry-run
 
       - name: Dry run rebalance check (triton)
         run: bash .github/scripts/split_tests.sh --shards 8 --test-type triton --dry-run
@@ -65,7 +65,7 @@ jobs:
             cat split-tests-update-summary.md
             echo ""
             echo "## Test plan"
-            echo "- [x] bash .github/scripts/split_tests.sh --shards 5 --test-type aiter --dry-run"
+            echo "- [x] bash .github/scripts/split_tests.sh --shards 8 --test-type aiter --dry-run"
             echo "- [x] bash .github/scripts/split_tests.sh --shards 8 --test-type triton --dry-run"
           } > pr-body.md
 

--- a/pr-body.md
+++ b/pr-body.md
@@ -29,5 +29,5 @@
 - defaulted files list: `none`
 
 ## Test plan
-- [x] bash .github/scripts/split_tests.sh --shards 5 --test-type aiter --dry-run
+- [x] bash .github/scripts/split_tests.sh --shards 8 --test-type aiter --dry-run
 - [x] bash .github/scripts/split_tests.sh --shards 8 --test-type triton --dry-run


### PR DESCRIPTION
## Summary
- Increase the Aiter standard test split from 5 shards to 8 shards.
- Expand both MI35X and MI300X standard test matrices to run shards 0 through 7.
- Update split-test rebalance workflow references to use 8 Aiter shards.

## Test plan
- [x] bash .github/scripts/split_tests.sh --shards 8 --test-type aiter --dry-run
- [x] git diff --check