### PR TITLE
[Triton-Gluon-MLA-GFX950] add stage1 only kernel wrapper for MLA decode

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -93,7 +93,7 @@ for file in "${sharded_files[@]}"; do
     } | tee -a latest_test.log
 done
 
-# Extra parameterized invocations for MLA bh16 gluon variants (bh16bn64 + bh16bn128, gfx950-only gates).
+# Extra parameterized invocations for MLA bh16 gluon variants (bh16bn64 + bh16bn128 + bh16_dcp, gfx950-only gates).
 # Run only in whichever shard actually owns test_mla.py — the shard layout can shift as tests
 # are added/removed, so we can't hardcode SHARD_IDX.
 mla_in_shard=false
@@ -104,7 +104,10 @@ for f in "${sharded_files[@]}"; do
     fi
 done
 if [[ "$mla_in_shard" == "true" && "$MULTIGPU" != "TRUE" ]]; then
-    for args in "-c 49152 -b 1 -n 16,1 -kvd bf16" "-c 98304 -b 1 -n 16,1 -kvd fp8"; do
+    for args in \
+        "-c 49152 -b 1 -n 16,1 -kvd bf16" \
+        "-c 98304 -b 1 -n 16,1 -kvd fp8" \
+        "-c 10000 100000 -b 1 3 4 -n 12,1 -n 16,1 -kvd bf16"; do
         echo "=== extra: test_mla.py $args ===" | tee -a latest_test.log
         if ! timeout 10m python3 op_tests/test_mla.py $args 2>&1 | tee -a latest_test.log; then
             testFailed=true

--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -93,7 +93,7 @@ for file in "${sharded_files[@]}"; do
     } | tee -a latest_test.log
 done
 
-# Extra parameterized invocations for MLA bh16 gluon variants (bh16bn64 + bh16bn128 + dcp, gfx950-only gates).
+# Extra parameterized invocations for MLA bh16 gluon (bh16bn64 + bh16bn128, gfx950-only gates).
 # Run only in whichever shard actually owns test_mla.py — the shard layout can shift as tests
 # are added/removed, so we can't hardcode SHARD_IDX.
 mla_in_shard=false
@@ -107,7 +107,7 @@ if [[ "$mla_in_shard" == "true" && "$MULTIGPU" != "TRUE" ]]; then
     for args in \
         "-c 49152 -b 1 -n 16,1 -kvd bf16" \
         "-c 98304 -b 1 -n 16,1 -kvd fp8" \
-        "-c 10000 100000 -b 1 3 4 -n 12,1 16,1 -kvd bf16"; do
+        "-c 10000 100000 -b 1 3 4 -n 12,1 16,1 -kvd bf16 -lse"; do
         echo "=== extra: test_mla.py $args ===" | tee -a latest_test.log
         if ! timeout 10m python3 op_tests/test_mla.py $args 2>&1 | tee -a latest_test.log; then
             testFailed=true

--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -93,7 +93,7 @@ for file in "${sharded_files[@]}"; do
     } | tee -a latest_test.log
 done
 
-# Extra parameterized invocations for MLA bh16 gluon variants (bh16bn64 + bh16bn128 + bh16_dcp, gfx950-only gates).
+# Extra parameterized invocations for MLA bh16 gluon variants (bh16bn64 + bh16bn128 + dcp, gfx950-only gates).
 # Run only in whichever shard actually owns test_mla.py — the shard layout can shift as tests
 # are added/removed, so we can't hardcode SHARD_IDX.
 mla_in_shard=false
@@ -107,7 +107,7 @@ if [[ "$mla_in_shard" == "true" && "$MULTIGPU" != "TRUE" ]]; then
     for args in \
         "-c 49152 -b 1 -n 16,1 -kvd bf16" \
         "-c 98304 -b 1 -n 16,1 -kvd fp8" \
-        "-c 10000 100000 -b 1 3 4 -n 12,1 -n 16,1 -kvd bf16"; do
+        "-c 10000 100000 -b 1 3 4 -n 12,1 16,1 -kvd bf16"; do
         echo "=== extra: test_mla.py $args ===" | tee -a latest_test.log
         if ! timeout 10m python3 op_tests/test_mla.py $args 2>&1 | tee -a latest_test.log; then
             testFailed=true

--- a/aiter/ops/triton/gluon/README.md
+++ b/aiter/ops/triton/gluon/README.md
@@ -38,7 +38,7 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
   <td>~5.33<br>TB/s</td><td>~0.69<br>TB/s</td><td>—</td>
 </tr>
 <tr>
-  <td><code>mla_decode_gluon_bh16_dcp</code></td><td>MLA Decode<br>(stage-1, DCP)</td><td>CDNA4</td>
+  <td><code>mla_decode_gluon_dcp</code></td><td>MLA Decode<br>(stage-1, DCP)</td><td>CDNA4</td>
   <td nowrap>Q: bf16, KV: bf16<br>Out: bf16 acc + fp32 lse<br>nhead &le; 16<br>batch_size &ge; 1 (any)<br>NUM_KV_SPLITS=256//B<br>(B*splits &le; 256)<br>PAGE_SIZE=1<br>BLOCK_H=16, BLOCK_N=64<br>no intra-GPU reduce</td>
   <td>python op_tests/test_mla.py \<br>-c 100000 -b 4 -n 16,1 \<br>-d bf16 -kvd bf16</td>
   <td>~4.68<br>TB/s</td><td>—</td><td>—</td>
@@ -161,9 +161,9 @@ python op_tests/test_mla.py -c 10000000 -b 1 -n 16,1 -d bf16 -kvd bf16
 
 Gluon reaches ~82% of MI350's 6.5 TB/s HBM peak (wall-clock 2162 &mu;s vs ASM 16659 &mu;s).
 
-### `mla_decode_gluon_bh16_dcp` — Stage-1-only MLA Decode for DCP
+### `mla_decode_gluon_dcp` — Stage-1-only MLA Decode for DCP
 
-**Function:** `mla_decode_gluon_bh16_dcp(q_nope, q_pe, kv_c, attn_logits, lse, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1)`
+**Function:** `mla_decode_gluon_dcp(q_nope, q_pe, kv_c, attn_logits, lse, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1)`
 
 **Description:** Per-GPU stage-1 MLA decode for Decode-Context-Parallel (DCP) workloads where the KV cache is sharded across GPUs. Runs only stage-1 (`_mla_decode_gluon` with `REGIME='dcp_bh16'`) and returns per-split `(attn_logits, lse)` for the **host** to combine across GPUs. No intra-GPU stage-2 reduce is invoked.
 

--- a/aiter/ops/triton/gluon/README.md
+++ b/aiter/ops/triton/gluon/README.md
@@ -22,7 +22,7 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
   <td>TBD</td><td>—</td><td>TBD</td>
 </tr>
 <tr>
-  <td rowspan="3"><code>mla_decode_gluon</code></td><td rowspan="3">MLA<br>Decode</td><td rowspan="3">CDNA4</td>
+  <td rowspan="4"><code>mla_decode_gluon</code></td><td rowspan="4">MLA<br>Decode</td><td rowspan="4">CDNA4</td>
   <td nowrap>(bh64)<br>Q: bf16, KV: bf16, Out: bf16<br>batch_size in {64, 128, 256}<br>nhead in {64, 128}<br>PAGE_SIZE=1<br>BLOCK_H=BLOCK_N=64</td>
   <td>python op_tests/test_mla.py \<br>-c 16384 -b 64 128 \<br>-n 64,1 128,1 \<br>-d bf16 -kvd bf16</td>
   <td>~563<br>TFLOPS</td><td>~477<br>TFLOPS</td><td>—</td>
@@ -33,14 +33,12 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
   <td>~4.58<br>TB/s</td><td>—</td><td>—</td>
 </tr>
 <tr>
-  <td nowrap>(bh16bn64)<br>Q: bf16, KV: bf16, Out: bf16<br>batch_size = 1<br>nhead &le; 16<br>PAGE_SIZE=1<br>BLOCK_H=16, BLOCK_N=64</td>
-  <td>python op_tests/test_mla.py \<br>-c 10000000 -b 1 -n 16,1 \<br>-d bf16 -kvd bf16</td>
+  <td rowspan="2" nowrap>(bh16bn64)<br>Q: bf16, KV: bf16<br>Out: bf16 (+fp32 lse<br>with -lse)<br>nhead &le; 16<br>batch_size &ge; 1<br>NUM_KV_SPLITS=<br>max(1,256//B)<br>(B*splits &le; 256)<br>PAGE_SIZE=1<br>BLOCK_H=16, BLOCK_N=64</td>
+  <td>python op_tests/test_mla.py \<br>-c 10000000 -b 1 -n 16,1 \<br>-d bf16 -kvd bf16<br>(full decode)</td>
   <td>~5.33<br>TB/s</td><td>~0.69<br>TB/s</td><td>—</td>
 </tr>
 <tr>
-  <td><code>mla_decode_gluon_dcp</code></td><td>MLA Decode<br>(stage-1, DCP)</td><td>CDNA4</td>
-  <td nowrap>Q: bf16, KV: bf16<br>Out: bf16 acc + fp32 lse<br>nhead &le; 16<br>batch_size &ge; 1 (any)<br>NUM_KV_SPLITS=256//B<br>(B*splits &le; 256)<br>PAGE_SIZE=1<br>BLOCK_H=16, BLOCK_N=64<br>no intra-GPU reduce</td>
-  <td>python op_tests/test_mla.py \<br>-c 100000 -b 4 -n 16,1 \<br>-d bf16 -kvd bf16</td>
+  <td>python op_tests/test_mla.py \<br>-c 100000 -b 4 -n 16,1 \<br>-d bf16 -kvd bf16 \<br>-lse<br>(stage-1 only, DCP)</td>
   <td>~4.68<br>TB/s</td><td>—</td><td>—</td>
 </tr>
 <tr>
@@ -78,15 +76,17 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
 
 ### `mla_decode_gluon.py` — MLA Decode
 
-**Function:** `mla_decode_gluon(q_nope, q_pe, kv_c, o, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1)`
+**Function:** `mla_decode_gluon(q_nope, q_pe, kv_c, o, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1, return_lse=False)`
 
 **Description:** Multi-head Latent Attention (DeepSeek MLA) decode kernel with split-KV. Q is split into compressed latent (`q_nope`, dim=kv_lora_rank) and rope positional encoding (`q_pe`, dim=qk_rope_head_dim). KV cache is a flat `[N, 576]` buffer (`kv_c`). Uses 3-stage async copy pipeline with double-buffered page numbers and KV tiles.
 
 The wrapper dispatches by `(nhead, kv_c.dtype)` to one of three compile-time regimes (single `@gluon.jit` kernel, REGIME constexpr gates layouts and grid mapping):
 
-- **`bh64`** (`nhead in {64, 128}`): bf16 KV, BLOCK_H=64, BLOCK_N=64, multi-batch + XCD-aware grid. `NUM_KV_SPLITS` auto-picked &isin; {1, 2, 4} so the launch fills ~256 workgroups (one wave on MI350). When `NUM_KV_SPLITS == 1`, stage-1 writes the final attention output directly to `o` (no temp buffer, no reduce). When `NUM_KV_SPLITS > 1`, stage-1 writes per-split `(acc, lse)` to a temp buffer and stage-2 (`_mla_softmax_reducev_kernel`) reduces them into `o`.
-- **`bh16bn128`** (`nhead &le; 16`, `batch_size == 1`, fp8 KV): BLOCK_H=16, BLOCK_N=128, 1-D grid `(NUM_KV_SPLITS=256,)`. Optional `kv_scale` dequant. Always splits + always runs stage-2 reduce. `NHEAD < BLOCK_H` masks OOB heads on Q load and O store (wasted MFMA lanes are free; this regime is memory-bound).
-- **`bh16bn64`** (`nhead &le; 16`, `batch_size == 1`, bf16 KV): BLOCK_H=16, BLOCK_N=64, same 1-D grid and split-then-reduce as bh16bn128. Use when KV is kept in bf16 (no fp8 quant). Same `NHEAD < BLOCK_H` masking.
+- **`bh64`** (`nhead in {64, 128}`): bf16 KV, BLOCK_H=64, BLOCK_N=64, multi-batch + XCD-aware 3-D grid. `NUM_KV_SPLITS` auto-picked &isin; {1, 2, 4} so the launch fills ~256 workgroups (one wave on MI350). When `NUM_KV_SPLITS == 1`, stage-1 writes the final attention output directly to `o` (no temp buffer, no reduce). When `NUM_KV_SPLITS > 1`, stage-1 writes per-split `(acc, lse)` to a temp buffer and stage-2 (`_mla_softmax_reducev_kernel`) reduces them into `o`.
+- **`bh16bn128`** (`nhead &le; 16`, `batch_size == 1`, fp8 KV): BLOCK_H=16, BLOCK_N=128, 2-D grid `(1, NUM_KV_SPLITS=256)`. Optional `kv_scale` dequant. Always splits + always runs stage-2 reduce. Supports the general case `num_iter &isin; {1, 2, ...}` (no `gl.assume(num_iter >= 3)`). `NHEAD < BLOCK_H` masks OOB heads on Q load and O store (wasted MFMA lanes are free; this regime is memory-bound).
+- **`bh16bn64`** (`nhead &le; 16`, bf16 KV): BLOCK_H=16, BLOCK_N=64, 2-D grid `(batch_size, NUM_KV_SPLITS)` with `NUM_KV_SPLITS = max(1, 256 // batch_size)`. Use when KV is kept in bf16 (no fp8 quant). Same `NHEAD < BLOCK_H` masking. Supports two modes:
+  - `return_lse=False` (default): full decode — stage-1 + stage-2 reduce into `o`.
+  - `return_lse=True`: **stage-1 only** (Decode-Context-Parallel, see section below) — skips stage-2, returns per-split `(o, lse)` for a host cross-GPU merge.
 
 Modified from [FlashMLA](https://github.com/deepseek-ai/FlashMLA/blob/main/benchmark/bench_flash_mla.py).
 
@@ -96,27 +96,17 @@ Modified from [FlashMLA](https://github.com/deepseek-ai/FlashMLA/blob/main/bench
 | Q dtype | bf16 | bf16 | bf16 |
 | KV dtype | bf16 | fp8 | bf16 |
 | Output | bf16 | bf16 | bf16 |
-| batch_size | 64, 128, or 256 | 1 | 1 |
+| batch_size | 64, 128, or 256 | 1 | &ge; 1 |
 | nhead | 64 or 128 | &le; 16 (tested: 4, 8, 16) | &le; 16 (tested: 4, 8, 16) |
 | Page size | 1 | 1 | 1 |
 | BLOCK_H | 64 | 16 | 16 |
 | BLOCK_N | 64 | 128 | 64 |
 | MFMA | 16&times;16&times;32, warps=[4,1] | 16&times;16&times;32, warps=[1,4] | 16&times;16&times;32, warps=[1,4] |
-| NUM_KV_SPLITS | auto &isin; {1, 2, 4} from (batch, nhead) | 256 (fixed) | 256 (fixed) |
+| Grid | 3-D XCD-aware | 2-D `(1, 256)` | 2-D `(batch, NUM_KV_SPLITS)` |
+| NUM_KV_SPLITS | auto &isin; {1, 2, 4} from (batch, nhead) | 256 (fixed) | `max(1, 256 // batch_size)` |
 | `kv_scale` | unused (pass 1.0) | dequant scale folded into `qk_scale` (applied before softmax for fp8 correctness) | unused (pass 1.0) |
-| Seq constraint | `min_kv_seq_len > NUM_KV_SPLITS * (3 * BLOCK_N + NUM_KV_SPLITS)` (the `3` matches the kernel's `gl.assume(num_iter > 3)`) | `min_kv_seq_len // 256 &ge; BLOCK_N * 3 = 384` | `min_kv_seq_len // 256 &ge; BLOCK_N * 3 = 192` |
-| Stage-2 reduce | skipped when `NUM_KV_SPLITS == 1` | always runs | always runs |
-
-**`bh64` NUM_KV_SPLITS selection** (NUM_XCDS=8, BLOCK_H=64):
-
-| batch | nhead | NUM_KV_SPLITS | min_kv_seq_len bound |
-|-------|-------|---------------|----------------------|
-| 64    | 64    | 4             | > 784                |
-| 64    | 128   | 2             | > 388                |
-| 128   | 64    | 2             | > 388                |
-| 128   | 128   | 1             | > 193                |
-| 256   | 64    | 1             | > 193                |
-| 256   | 128   | 1             | > 193                |
+| Seq constraint | `min_kv_seq_len > NUM_KV_SPLITS * (3 * BLOCK_N + NUM_KV_SPLITS)` (the `3` matches the kernel's `gl.assume(num_iter > 3)`) | `min_kv_seq_len &ge; NUM_KV_SPLITS` (= 256; non-empty splits, `num_iter &ge; 1`) | `min_kv_seq_len &ge; NUM_KV_SPLITS` (non-empty splits, `num_iter &ge; 1`; both modes) |
+| Stage-2 reduce | skipped when `NUM_KV_SPLITS == 1` | always runs | runs (skipped when `return_lse=True`, or `NUM_KV_SPLITS == 1`) |
 
 **Page table modes** (`use_2d_view`, both regimes):
 - `True`: `page_table = block_table [batch, max_seqlen]`, `seq_info = cache_seqlens [batch]`. Use for fixed-length or pre-padded variable-length sequences.
@@ -161,39 +151,14 @@ python op_tests/test_mla.py -c 10000000 -b 1 -n 16,1 -d bf16 -kvd bf16
 
 Gluon reaches ~82% of MI350's 6.5 TB/s HBM peak (wall-clock 2162 &mu;s vs ASM 16659 &mu;s).
 
-### `mla_decode_gluon_dcp` — Stage-1-only MLA Decode for DCP
+#### `bh16bn64` + `return_lse=True` — Stage-1-only MLA Decode for DCP
 
-**Function:** `mla_decode_gluon_dcp(q_nope, q_pe, kv_c, attn_logits, lse, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1)`
+Per-GPU stage-1 for Decode-Context-Parallel (DCP): KV is sharded across GPUs, so this runs stage-1 only and returns per-split `(o, lse)` for the **host** to merge — no intra-GPU stage-2 reduce. `o` is the caller-allocated per-split logits `[B, nhead, NUM_KV_SPLITS, kv_lora_rank]` (bf16); `lse` `[B, nhead, NUM_KV_SPLITS]` (fp32) is allocated and returned. Tuned for `B * ctx_len` in **10K..100K** total tokens. The only difference from full-decode `bh16bn64` (gated by `RETURN_LSE`): `lse` goes to a separate fp32 tensor (host merge is precision-sensitive) and stage-2 is skipped.
 
-**Description:** Per-GPU stage-1 MLA decode for Decode-Context-Parallel (DCP) workloads where the KV cache is sharded across GPUs. Runs only stage-1 (`_mla_decode_gluon` with `REGIME='dcp_bh16'`) and returns per-split `(attn_logits, lse)` for the **host** to combine across GPUs. No intra-GPU stage-2 reduce is invoked.
-
-Reuses the existing `_mla_decode_gluon` kernel via a new REGIME constexpr branch that:
-1. Lifts `gl.assume(num_iter >= 3)` to `gl.assume(num_iter >= 1)` — allows splits with as few as 1 BLOCK_N iteration.
-2. Gates epilogue 1 with `if num_iter >= 2:` — skips the prologue-K-reuse epi for `num_iter == 1` (epi 2 alone handles the single iter using prologue's iter-0 K, with `gl.where` mask at qk-time turning OOB lanes to -inf).
-3. Adds a 2-D grid `(batch, split)` mapping for multi-batch shards.
-4. Writes `lse` to a **separate fp32 tensor** (instead of the bf16-packed trailing slot used by legacy regimes) — host-side cross-GPU LSE merge is precision-sensitive.
-
-| Parameter | Details |
-|-----------|---------|
-| Arch | gfx950 (CDNA4) |
-| Q dtype | bf16 |
-| KV dtype | bf16 |
-| `attn_logits` | `[B, nhead, NUM_KV_SPLITS, kv_lora_rank]` bf16, caller-allocated |
-| `lse` | `[B, nhead, NUM_KV_SPLITS]` fp32, caller-allocated |
-| batch_size | any `B >= 1` |
-| nhead | 1..16 |
-| NUM_KV_SPLITS | `256 // batch_size` (floor); total WGs `= B * NUM_KV_SPLITS <= 256`. When `B` divides 256, fills all MI350 CUs exactly; otherwise a few CUs idle for the wave (worst case ~1.5% at B=6) |
-| BLOCK_H | 16 |
-| BLOCK_N | 64 |
-| Seq constraint | `min_kv_seq_len >= NUM_KV_SPLITS` (every split gets &ge; 1 token; `num_iter` per WG &isin; {1..7} for the target operating range) |
-| Stage-2 reduce | not invoked &mdash; host does cross-GPU LSE merge |
-
-**Operating window:** `B * ctx_lens` in **10K..100K** total tokens. At the low end (B&middot;ctx=10K), `num_iter == 1` per WG is common.
-
-**Perf** (MI350, bf16 Q + bf16 KV; memory-bound; stage-1 only &mdash; not directly comparable to full-decode kernels):
+**Perf** (MI350, bf16 Q + bf16 KV; memory-bound; stage-1 only):
 
 ```
-python op_tests/test_mla.py -c 10000 100000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16
+python op_tests/test_mla.py -c 10000 100000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16 -lse
 ```
 
 | ctx_lens | batch | NUM_KV_SPLITS | num_iter / split | us | TB/s |
@@ -204,8 +169,6 @@ python op_tests/test_mla.py -c 10000 100000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16
 | 100K     | 1     | 256           | 7                | 36.62 | 3.15 |
 | 100K     | 3     | 85            | 19               | 76.06 | 4.55 |
 | 100K     | 4     | 64            | 25               | 98.48 | 4.68 |
-
-`B=3` is the awkward case: total WGs = `3 * 85 = 255` (one CU idle for the wave). `B=4` divides 256 exactly (`4 * 64 = 256`). `num_iter` per WG scales as `ceil(ctx_lens / NUM_KV_SPLITS / BLOCK_N)`, so it grows quickly for larger B at fixed ctx.
 
 ### `pa_decode_gluon.py` — Paged Attention Decode
 

--- a/aiter/ops/triton/gluon/README.md
+++ b/aiter/ops/triton/gluon/README.md
@@ -38,6 +38,12 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
   <td>~5.33<br>TB/s</td><td>~0.69<br>TB/s</td><td>—</td>
 </tr>
 <tr>
+  <td><code>mla_decode_gluon_bh16_dcp</code></td><td>MLA Decode<br>(stage-1, DCP)</td><td>CDNA4</td>
+  <td nowrap>Q: bf16, KV: bf16<br>Out: bf16 acc + fp32 lse<br>nhead &le; 16<br>batch_size &ge; 1 (any)<br>NUM_KV_SPLITS=256//B<br>(B*splits &le; 256)<br>PAGE_SIZE=1<br>BLOCK_H=16, BLOCK_N=64<br>no intra-GPU reduce</td>
+  <td>python op_tests/test_mla.py \<br>-c 100000 -b 4 -n 16,1 \<br>-d bf16 -kvd bf16</td>
+  <td>~4.68<br>TB/s</td><td>—</td><td>—</td>
+</tr>
+<tr>
   <td><code>pa_decode_gluon</code></td><td>Paged Attn<br>Decode</td><td>CDNA3<br>CDNA4</td>
   <td nowrap>Q: fp8/bf16/fp16<br>KV: fp8/bf16/fp16<br>Out: bf16 or match<br>query_len &le; 4<br>query_len &times; group_size &le; 64<br>ctx_partition = 256</td>
   <td>python op_tests/triton_tests/<br>test_pa_decode_gluon.py</td>
@@ -154,6 +160,52 @@ python op_tests/test_mla.py -c 10000000 -b 1 -n 16,1 -d bf16 -kvd bf16
 | 1     | 16    | 0.69     | 5.33       | 7.71&times; |
 
 Gluon reaches ~82% of MI350's 6.5 TB/s HBM peak (wall-clock 2162 &mu;s vs ASM 16659 &mu;s).
+
+### `mla_decode_gluon_bh16_dcp` — Stage-1-only MLA Decode for DCP
+
+**Function:** `mla_decode_gluon_bh16_dcp(q_nope, q_pe, kv_c, attn_logits, lse, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1)`
+
+**Description:** Per-GPU stage-1 MLA decode for Decode-Context-Parallel (DCP) workloads where the KV cache is sharded across GPUs. Runs only stage-1 (`_mla_decode_gluon` with `REGIME='dcp_bh16'`) and returns per-split `(attn_logits, lse)` for the **host** to combine across GPUs. No intra-GPU stage-2 reduce is invoked.
+
+Reuses the existing `_mla_decode_gluon` kernel via a new REGIME constexpr branch that:
+1. Lifts `gl.assume(num_iter >= 3)` to `gl.assume(num_iter >= 1)` — allows splits with as few as 1 BLOCK_N iteration.
+2. Gates epilogue 1 with `if num_iter >= 2:` — skips the prologue-K-reuse epi for `num_iter == 1` (epi 2 alone handles the single iter using prologue's iter-0 K, with `gl.where` mask at qk-time turning OOB lanes to -inf).
+3. Adds a 2-D grid `(batch, split)` mapping for multi-batch shards.
+4. Writes `lse` to a **separate fp32 tensor** (instead of the bf16-packed trailing slot used by legacy regimes) — host-side cross-GPU LSE merge is precision-sensitive.
+
+| Parameter | Details |
+|-----------|---------|
+| Arch | gfx950 (CDNA4) |
+| Q dtype | bf16 |
+| KV dtype | bf16 |
+| `attn_logits` | `[B, nhead, NUM_KV_SPLITS, kv_lora_rank]` bf16, caller-allocated |
+| `lse` | `[B, nhead, NUM_KV_SPLITS]` fp32, caller-allocated |
+| batch_size | any `B >= 1` |
+| nhead | 1..16 |
+| NUM_KV_SPLITS | `256 // batch_size` (floor); total WGs `= B * NUM_KV_SPLITS <= 256`. When `B` divides 256, fills all MI350 CUs exactly; otherwise a few CUs idle for the wave (worst case ~1.5% at B=6) |
+| BLOCK_H | 16 |
+| BLOCK_N | 64 |
+| Seq constraint | `min_kv_seq_len >= NUM_KV_SPLITS` (every split gets &ge; 1 token; `num_iter` per WG &isin; {1..7} for the target operating range) |
+| Stage-2 reduce | not invoked &mdash; host does cross-GPU LSE merge |
+
+**Operating window:** `B * ctx_lens` in **10K..100K** total tokens. At the low end (B&middot;ctx=10K), `num_iter == 1` per WG is common.
+
+**Perf** (MI350, bf16 Q + bf16 KV; memory-bound; stage-1 only &mdash; not directly comparable to full-decode kernels):
+
+```
+python op_tests/test_mla.py -c 10000 100000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16
+```
+
+| ctx_lens | batch | NUM_KV_SPLITS | num_iter / split | us | TB/s |
+|----------|-------|---------------|------------------|-----|------|
+| 10K      | 1     | 256           | 1                | 9.14  | 1.26 |
+| 10K      | 3     | 85            | 2                | 17.56 | 1.97 |
+| 10K      | 4     | 64            | 3                | 19.02 | 2.43 |
+| 100K     | 1     | 256           | 7                | 36.62 | 3.15 |
+| 100K     | 3     | 85            | 19               | 76.06 | 4.55 |
+| 100K     | 4     | 64            | 25               | 98.48 | 4.68 |
+
+`B=3` is the awkward case: total WGs = `3 * 85 = 255` (one CU idle for the wave). `B=4` divides 256 exactly (`4 * 64 = 256`). `num_iter` per WG scales as `ceil(ctx_lens / NUM_KV_SPLITS / BLOCK_N)`, so it grows quickly for larger B at fixed ctx.
 
 ### `pa_decode_gluon.py` — Paged Attention Decode
 

--- a/aiter/ops/triton/gluon/mla_decode_gluon.py
+++ b/aiter/ops/triton/gluon/mla_decode_gluon.py
@@ -11,18 +11,27 @@
 #                        final output directly to O and stage-2 reduce is skipped.
 #   REGIME='bh16bn128' - bf16 Q + fp8 KV, BLOCK_H=16, BLOCK_N=128,
 #                        nhead <= 16, batch_size=1, NUM_KV_SPLITS=256.
-#                        Always splits + always reduces. NHEAD < BLOCK_H masks
-#                        OOB heads on Q load and O store.
+#                        2-D (batch, split) grid. Always splits + always
+#                        reduces. NHEAD < BLOCK_H masks OOB heads on Q load
+#                        and O store.
 #   REGIME='bh16bn64'  - bf16 Q + bf16 KV, BLOCK_H=16, BLOCK_N=64,
-#                        nhead <= 16, batch_size=1, NUM_KV_SPLITS=256.
-#                        Always splits + always reduces. NHEAD < BLOCK_H masks
-#                        OOB heads on Q load and O store.
+#                        nhead <= 16, batch_size >= 1, 2-D (batch, split) grid,
+#                        NUM_KV_SPLITS = max(1, 256 // batch_size). Two modes:
+#                          - return_lse=False: full decode (stage-1 + stage-2
+#                            reduce into the final O).
+#                          - return_lse=True: stage-1 only (Decode-Context-
+#                            Parallel) - writes per-split (acc, fp32 lse) and
+#                            skips stage-2; host does the cross-GPU merge.
+#                        NHEAD < BLOCK_H masks OOB heads on Q load and O store.
+#
+# The bh16 regimes support num_iter in {1, 2, ...} (no gl.assume(num_iter>=3));
+# only bh64 assumes >= 3. See RETURN_LSE / epilogue-1 handling below.
 #
 # Wrapper dispatch: nhead in {64,128} -> bh64; nhead <= 16 routes by KV dtype
 # (bf16 -> bh16bn64, fp8 -> bh16bn128).
 #
-# For NUM_KV_SPLITS>1 each program writes per-split (acc, lse) to a temp buffer
-# and stage-2 (_mla_softmax_reducev_kernel) combines them.
+# For full decode with NUM_KV_SPLITS>1 each program writes per-split (acc, lse)
+# to a temp buffer and stage-2 (_mla_softmax_reducev_kernel) combines them.
 #
 # 3-stage software pipeline (double-buffered, BLOCK_N with 2x(BLOCK_N/2) KV slices):
 #   AC = async_copy (global->LDS), LL = load (LDS->reg), P = page, K = K-cache, V = V-cache
@@ -68,7 +77,7 @@ def _mla_decode_gluon(
     stride_o_b,
     stride_o_h,
     stride_o_s,
-    Lse,  # dcp_bh16 only which requires a separate tensor
+    Lse,  # RETURN_LSE only; separate fp32 tensor (else pass None)
     stride_lse_b,
     stride_lse_h,
     stride_lse_s,
@@ -84,21 +93,18 @@ def _mla_decode_gluon(
     NUM_XCDS: gl.constexpr,
     NHEAD: gl.constexpr,
     REGIME: gl.constexpr,
+    RETURN_LSE: gl.constexpr,
 ):
-    # Grid mapping: bh64 uses 3-D XCD-aware multi-batch; bh16bn128 and bh16bn64 use 1-D split-only;
-    # dcp_bh16 uses 2-D (batch, split) for the per-GPU DCP shard with small B.
+    # Grid mapping: bh64 uses 3-D XCD-aware multi-batch; bh16bn64 and bh16bn128
+    # use 2-D (batch, split) — for batch_size=1 this is (1, NUM_KV_SPLITS).
     if REGIME == 'bh64':
         cur_batch = gl.program_id(0) + (gl.program_id(2) // NUM_KV_SPLITS) * NUM_XCDS
         cur_head_id = gl.program_id(1)
         split_kv_id = gl.program_id(2) % NUM_KV_SPLITS
-    elif REGIME == 'dcp_bh16':
+    else:
         cur_batch = gl.program_id(0)
         cur_head_id = 0
         split_kv_id = gl.program_id(1)
-    else:
-        cur_batch = 0
-        cur_head_id = 0
-        split_kv_id = gl.program_id(0)
 
     # USE_2D_VIEW=True: fixed len or max padded VarLen
     # Req_to_tokens = block_table[batch, max_seqlen], B_seq_len = cache_seqlens[batch]
@@ -320,9 +326,8 @@ def _mla_decode_gluon(
     acc = gl.zeros([BLOCK_H, HEAD_DIM_CKV], dtype=gl.float32, layout=mfma_layout)
 
     # split-KV: each program covers [split_kv_start, split_kv_end).
-    # OLD: ceil-based per_split. The LAST split could be empty (num_iter=0) or
-    # have num_iter < 3, violating gl.assume(num_iter >= 3) below for sequences
-    # just above the wrapper's min_seq_len_wg bound. Kept here as commented
+    # OLD: ceil-based per_split. The LAST split could be empty (num_iter=0),
+    # which breaks the unconditional epilogue-2 consume. Kept here as commented
     # reference; remove in cleanup.
     # kv_len_per_split = gl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
     # split_kv_start = kv_len_per_split * split_kv_id
@@ -330,8 +335,9 @@ def _mla_decode_gluon(
     #
     # NEW: floor per_split with the last split absorbing the remainder
     # (remainder = seq mod NUM_KV_SPLITS, in [0, NUM_KV_SPLITS)). Combined with
-    # the wrapper bound min_seq_len_wg >= BLOCK_N*3 this guarantees
-    # split_len >= floor >= BLOCK_N*3 for every split, hence num_iter >= 3.
+    # the wrapper bound min_kv_seq_len >= NUM_KV_SPLITS this guarantees every
+    # split is non-empty (split_len >= floor >= 1, hence num_iter >= 1); bh64
+    # additionally bounds min_kv_seq_len so num_iter >= 3 for its gl.assume.
     # Trade-off: at seqs just above the wrapper minimum the last CU does up to
     # ~(floor + NUM_KV_SPLITS - 1)/floor more work than the others.
     kv_len_per_split = cur_batch_seq_len // NUM_KV_SPLITS
@@ -426,11 +432,9 @@ def _mla_decode_gluon(
         gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kv1, Kv_c_cache + offs_k_c1)
     gl.amd.cdna4.async_copy.commit_group()
 
-    if REGIME == 'dcp_bh16':
-        # DCP shards can have splits with as few as 1 iteration; epilogue 1
-        # is gated below for num_iter < 2.
-        gl.assume(num_iter >= 1)
-    else:
+    if REGIME == 'bh64':
+        # bh64 guarantees >= 3 iters/split; this constant-folds the
+        # `if num_iter >= 2` epilogue-1 guard below so its codegen is unchanged.
         gl.assume(num_iter >= 3)
     buf_idx = 0
     ################ loop
@@ -525,9 +529,9 @@ def _mla_decode_gluon(
     LOG2E: gl.constexpr = 1.4426950408889634
 
     ################ epilogue 1
-    # Skip when num_iter < 2 (only possible under REGIME='dcp_bh16'; legacy
-    # regimes have gl.assume(num_iter >= 3) above so the compiler folds this
-    # branch out). 
+    # Skip when num_iter < 2 (possible for bh16bn64 / bh16bn128 in either mode).
+    # bh64 has gl.assume(num_iter >= 3) above so the compiler folds this branch
+    # out there; for the bh16 regimes it stays a runtime branch.
     if num_iter >= 2:
         async_idx = (buf_idx + 1) % 2
 
@@ -622,8 +626,9 @@ def _mla_decode_gluon(
         gl.amd.cdna4.buffer_store(stored_value, ptr=O, offsets=offs_o, mask=(cur_head_o < NHEAD)[:, None])
     else:
         gl.amd.cdna4.buffer_store(stored_value, ptr=O, offsets=offs_o)
-    if REGIME == 'dcp_bh16':
-        # Separate fp32 Lse tensor [B, H, NUM_KV_SPLITS] 
+    if RETURN_LSE:
+        # Stage-1-only: separate fp32 Lse tensor [B, H, NUM_KV_SPLITS] for the
+        # host cross-GPU merge (works even at NUM_KV_SPLITS == 1).
         offs_lse = cur_batch * stride_lse_b + cur_head_o * stride_lse_h + split_kv_id * stride_lse_s
         lse = e_max + gl.log(e_sum)
         if NHEAD < BLOCK_H:
@@ -631,7 +636,7 @@ def _mla_decode_gluon(
         else:
             gl.amd.cdna4.buffer_store(lse, ptr=Lse, offsets=offs_lse)
     elif NUM_KV_SPLITS > 1:
-        # Legacy: per-split lse packed into O at the trailing slot for stage-2 reduce.
+        # Full-decode: per-split lse packed into O at the trailing slot for stage-2 reduce.
         offs_o_lse = cur_batch * stride_o_b + cur_head_o * stride_o_h + split_kv_id * stride_o_s + HEAD_DIM_CKV
         lse = e_max + gl.log(e_sum)
         if NHEAD < BLOCK_H:
@@ -711,7 +716,9 @@ def mla_decode_gluon(
     # Shared: kv_c=[N, kv_lora_rank+qk_rope_head_dim], k_pe=None,              kv_pe_offset=kv_lora_rank
     # Split:  kv_c=[N, kv_lora_rank],                k_pe=[N,qk_rope_head_dim], kv_pe_offset=0
     kv_c,
-    o,  # [batch, nhead, kv_lora_rank] output buffer
+    # return_lse=False: final output [batch, nhead, kv_lora_rank].
+    # return_lse=True:  per-split logits [batch, nhead, NUM_KV_SPLITS, kv_lora_rank].
+    o,
     page_table,  # 2D: block_table [batch, max_seqlen] | 1D: kv_indices [total_kv]
     seq_info,  # 2D: cache_seqlens [batch]           | 1D: kv_indptr [batch+1]
     sm_scale,
@@ -720,7 +727,24 @@ def mla_decode_gluon(
     use_2d_view=True,
     kv_scale=1.0,
     min_kv_seq_len=1,
+    return_lse=False,
 ):
+    """
+    Gluon MLA decode (gfx950 / CDNA4).
+
+    return_lse=False (default): full decode. Runs stage-1 + stage-2 reduce and
+        writes the final attention into the caller's `o` ([batch, nhead,
+        kv_lora_rank]); returns (o, None).
+
+    return_lse=True: stage-1 only, for the Decode-Context-Parallel (DCP)
+        workload where the KV cache is sharded across GPUs and the host does
+        the cross-GPU softmax merge. Only the bh16bn64 regime (nhead<=16, bf16
+        KV) supports it. The stage-2 reduce is skipped; the caller's `o` is the
+        per-split logits buffer [batch, nhead, NUM_KV_SPLITS, kv_lora_rank]
+        (bf16), and a per-split fp32 lse [batch, nhead, NUM_KV_SPLITS] is
+        allocated here and returned: (o, lse). Tuned for batch*ctx_len in the
+        10K..100K total-token range; NUM_KV_SPLITS = max(1, 256 // batch_size).
+    """
     if k_pe is None:
         k_pe = kv_c
 
@@ -756,6 +780,10 @@ def mla_decode_gluon(
 
     PAGE_SIZE = 1
 
+    assert not (
+        return_lse and REGIME != "bh16bn64"
+    ), f"mla_decode_gluon: return_lse=True is only supported for the bh16bn64 regime (nhead<=16, bf16 KV), got REGIME={REGIME}"
+
     if REGIME == "bh64":
         BLOCK_H, BLOCK_N = 64, 64
         NUM_XCDS = get_num_xcds()
@@ -786,15 +814,23 @@ def mla_decode_gluon(
         BLOCK_H = 16
         BLOCK_N = 128 if REGIME == "bh16bn128" else 64
         kv_dtype = torch.float8_e4m3fn if REGIME == "bh16bn128" else torch.bfloat16
-        NUM_XCDS = 1  # unused by 1-D split-only grid mapping
-        NUM_KV_SPLITS = 256  # one workgroup per MI350 CU
+        NUM_XCDS = 1  # unused by 2-D split grid mapping
+        # 2-D grid (batch, split); float-floor keeps total WGs = B * NUM_KV_SPLITS
+        # <= 256 (one MI350 wave). For batch_size=1 this is 256, matching the
+        # original single-batch layout.
+        NUM_KV_SPLITS = max(1, 256 // batch_size)
+        if REGIME == "bh16bn128":
+            # fp8 path is not generalized to multi-batch.
+            assert (
+                batch_size == 1
+            ), f"mla_decode_gluon[bh16bn128] requires batch_size=1, got {batch_size}"
+        # The bh16 regimes support the general case num_iter in {1, 2, ...} (no
+        # gl.assume(num_iter >= 3) in the kernel), so the only requirement is that
+        # every split is non-empty: floor split size >= 1, i.e. min_kv_seq_len >=
+        # NUM_KV_SPLITS. Holds for both full-decode and return_lse modes.
         assert (
-            batch_size == 1
-        ), f"mla_decode_gluon[{REGIME}] requires batch_size=1, got {batch_size}"
-        min_seq_len_wg = min_kv_seq_len // NUM_KV_SPLITS
-        assert (
-            min_seq_len_wg >= BLOCK_N * 3
-        ), f"mla_decode_gluon[{REGIME}] requires min_seq_len_wg >= BLOCK_N * 3, got min_seq_len_wg={min_seq_len_wg}"
+            min_kv_seq_len >= NUM_KV_SPLITS
+        ), f"mla_decode_gluon[{REGIME}] requires min_kv_seq_len >= NUM_KV_SPLITS (= max(1, 256//B) = {NUM_KV_SPLITS}), got {min_kv_seq_len}"
         assert (
             q_nope.dtype == torch.bfloat16 and q_pe.dtype == torch.bfloat16
         ), f"q_nope/q_pe must be bf16, got {q_nope.dtype}/{q_pe.dtype}"
@@ -807,18 +843,41 @@ def mla_decode_gluon(
     max_kv_bytes = kv_c.shape[0] * kv_c.stride(0) * kv_c.element_size()
     within_2gb = max_kv_bytes <= 0x80000000  # 2 GB
 
-    if NUM_KV_SPLITS == 1:
+    if return_lse:
+        # Stage-1-only: the caller's `o` IS the per-split logits buffer; no temp,
+        # no reduce. lse is a separate fp32 tensor, allocated here and returned.
+        assert o.shape == (
+            batch_size,
+            nhead,
+            NUM_KV_SPLITS,
+            head_dim_ckv,
+        ), f"return_lse=True requires o of shape [{batch_size}, {nhead}, {NUM_KV_SPLITS}, {head_dim_ckv}], got {tuple(o.shape)}"
+        assert (
+            o.dtype == torch.bfloat16
+        ), f"return_lse=True requires o bf16, got {o.dtype}"
+        logits_buf = o
+        lse = torch.empty(
+            (batch_size, nhead, NUM_KV_SPLITS),
+            dtype=torch.float32,
+            device=q_nope.device,
+        )
+        stride_lse_b, stride_lse_h, stride_lse_s = lse.stride()
+    elif NUM_KV_SPLITS == 1:
         # Fast path: stage-1 writes the final attention output directly to o,
         # no temp buffer, no reduce.
-        attn_logits = o.view(batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv)
+        logits_buf = o.view(batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv)
+        lse = None
+        stride_lse_b, stride_lse_h, stride_lse_s = 0, 0, 0
     else:
         # Stage-1 writes per-split (acc, lse) to a temp buffer; the trailing
         # slot at index head_dim_ckv holds the per-split lse.
-        attn_logits = torch.empty(
+        logits_buf = torch.empty(
             (batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv + 1),
             dtype=o.dtype,
             device=o.device,
         )
+        lse = None
+        stride_lse_b, stride_lse_h, stride_lse_s = 0, 0, 0
 
     if REGIME == "bh64":
         grid = (
@@ -827,7 +886,7 @@ def mla_decode_gluon(
             (batch_size // NUM_XCDS) * NUM_KV_SPLITS,
         )
     else:
-        grid = (NUM_KV_SPLITS,)
+        grid = (batch_size, NUM_KV_SPLITS)
     stride_page_bs = page_table.stride(0) if use_2d_view else 0
 
     _mla_decode_gluon[grid](
@@ -837,7 +896,7 @@ def mla_decode_gluon(
         k_pe,
         page_table,
         seq_info,
-        attn_logits,
+        logits_buf,
         sm_scale,
         kv_scale,
         q_nope.stride(0),
@@ -847,13 +906,13 @@ def mla_decode_gluon(
         kv_c.stride(-2),
         k_pe.stride(-2),
         stride_page_bs,
-        attn_logits.stride(0),
-        attn_logits.stride(1),
-        attn_logits.stride(2),
-        attn_logits,  # Lse: dummy
-        0,  # stride_lse_b
-        0,  # stride_lse_h
-        0,  # stride_lse_s
+        logits_buf.stride(0),
+        logits_buf.stride(1),
+        logits_buf.stride(2),
+        lse,
+        stride_lse_b,
+        stride_lse_h,
+        stride_lse_s,
         BLOCK_H=BLOCK_H,
         BLOCK_N=BLOCK_N,
         NUM_KV_SPLITS=NUM_KV_SPLITS,
@@ -866,7 +925,12 @@ def mla_decode_gluon(
         NUM_XCDS=NUM_XCDS,
         NHEAD=nhead,
         REGIME=REGIME,
+        RETURN_LSE=return_lse,
     )
+
+    if return_lse:
+        # Host does the cross-GPU softmax merge over splits.
+        return o, lse
 
     if NUM_KV_SPLITS > 1:
         # Stage-2: combine per-split (acc, lse) into the final attention in o.
@@ -875,12 +939,12 @@ def mla_decode_gluon(
         # constexpr) is no longer needed in stage-2.
         grid_reduce = (batch_size, nhead)
         _mla_softmax_reducev_kernel[grid_reduce](
-            attn_logits,
+            logits_buf,
             seq_info,
             o,
-            attn_logits.stride(0),
-            attn_logits.stride(1),
-            attn_logits.stride(2),
+            logits_buf.stride(0),
+            logits_buf.stride(1),
+            logits_buf.stride(2),
             o.stride(0),
             o.stride(1),
             NUM_KV_SPLITS=NUM_KV_SPLITS,
@@ -890,141 +954,3 @@ def mla_decode_gluon(
         )
 
     return o, None
-
-
-def mla_decode_gluon_dcp(
-    q_nope,  # [batch, nhead, kv_lora_rank]
-    q_pe,  # [batch, nhead, qk_rope_head_dim]
-    kv_c,  # shared layout: [N, kv_lora_rank + qk_rope_head_dim]
-    attn_logits,  # caller-allocated [batch, nhead, NUM_KV_SPLITS, kv_lora_rank] bf16
-    lse,  # caller-allocated [batch, nhead, NUM_KV_SPLITS] fp32
-    page_table,  # 2D: block_table [batch, max_seqlen] | 1D: kv_indices [total_kv]
-    seq_info,  # 2D: cache_seqlens [batch]           | 1D: kv_indptr [batch+1]
-    sm_scale,
-    k_pe=None,
-    kv_pe_offset=512,
-    use_2d_view=True,
-    kv_scale=1.0,
-    min_kv_seq_len=1,
-):
-    """
-    Stage-1-only MLA decode for the DCP (Decode Context Parallel) workload.
-
-    Each call processes one GPU's slice of a context-parallel KV cache. The
-    host is responsible for combining splits across GPUs (cross-GPU reduce +
-    final softmax-merge). This wrapper does NOT run stage-2 reducev.
-
-    Operating window:
-      - gfx950 (CDNA4)
-      - nhead in [1-16], bf16 KV
-      - batch_size in [1, 256] (so NUM_KV_SPLITS = 256 // batch_size >= 1)
-      - NUM_KV_SPLITS = 256 // batch_size (floor); total WGs = B * NUM_KV_SPLITS
-        is <= 256. When B does not divide 256 (e.g., 3, 5, 6, 7) up to a few
-        CUs are idle for the wave (worst case ~1.5% at B=6).
-      - min_kv_seq_len >= NUM_KV_SPLITS (every split gets at least 1 token)
-
-    Outputs (caller-allocated):
-      attn_logits: [B, nhead, NUM_KV_SPLITS, kv_lora_rank] bf16. Per-split
-                   normalized softmax(acc).
-      lse:         [B, nhead, NUM_KV_SPLITS] fp32. Per-split log-sum-exp
-                   (= max + log(sum(exp(qk - max)))).
-    """
-    if k_pe is None:
-        k_pe = kv_c
-
-    batch_size, nhead, head_dim_ckv = q_nope.shape
-    head_dim_kpe = q_pe.shape[-1]
-
-    assert (
-        arch_info.get_arch() == "gfx950"
-    ), f"mla_decode_gluon_dcp requires gfx950 (CDNA4), got {arch_info.get_arch()}"
-    assert (
-        head_dim_ckv == 512
-    ), f"mla_decode_gluon_dcp requires head_dim_ckv=512, got {head_dim_ckv}"
-    assert (
-        head_dim_kpe == 64
-    ), f"mla_decode_gluon_dcp requires head_dim_kpe=64, got {head_dim_kpe}"
-    assert (
-        1 <= nhead <= 16
-    ), f"mla_decode_gluon_dcp requires nhead in [1, 16], got {nhead}"
-    assert (
-        1 <= batch_size <= 256
-    ), f"mla_decode_gluon_dcp requires batch_size in [1, 256] (NUM_KV_SPLITS = 256 // batch_size must be >= 1), got {batch_size}"
-    assert (
-        q_nope.dtype == torch.bfloat16 and q_pe.dtype == torch.bfloat16
-    ), f"q_nope/q_pe must be bf16, got {q_nope.dtype}/{q_pe.dtype}"
-    assert (
-        kv_c.dtype == torch.bfloat16 and k_pe.dtype == torch.bfloat16
-    ), f"kv_c/k_pe must be bf16, got {kv_c.dtype}/{k_pe.dtype}"
-
-    BLOCK_H = 16
-    BLOCK_N = 64
-    PAGE_SIZE = 1
-    REGIME = "dcp_bh16"
-    NUM_XCDS = 1  # unused by 2-D grid mapping
-    NUM_KV_SPLITS = 256 // batch_size
-
-    assert (
-        min_kv_seq_len >= NUM_KV_SPLITS
-    ), f"mla_decode_gluon_dcp requires min_kv_seq_len >= NUM_KV_SPLITS (= 256/B = {NUM_KV_SPLITS}), got {min_kv_seq_len}"
-    assert attn_logits.shape == (
-        batch_size,
-        nhead,
-        NUM_KV_SPLITS,
-        head_dim_ckv,
-    ), f"attn_logits must be [{batch_size}, {nhead}, {NUM_KV_SPLITS}, {head_dim_ckv}], got {tuple(attn_logits.shape)}"
-    assert (
-        attn_logits.dtype == torch.bfloat16
-    ), f"attn_logits must be bf16, got {attn_logits.dtype}"
-    assert lse.shape == (
-        batch_size,
-        nhead,
-        NUM_KV_SPLITS,
-    ), f"lse must be [{batch_size}, {nhead}, {NUM_KV_SPLITS}], got {tuple(lse.shape)}"
-    assert lse.dtype == torch.float32, f"lse must be fp32, got {lse.dtype}"
-
-    max_kv_bytes = kv_c.shape[0] * kv_c.stride(0) * kv_c.element_size()
-    within_2gb = max_kv_bytes <= 0x80000000
-
-    grid = (batch_size, NUM_KV_SPLITS)
-    stride_page_bs = page_table.stride(0) if use_2d_view else 0
-
-    _mla_decode_gluon[grid](
-        q_nope,
-        q_pe,
-        kv_c,
-        k_pe,
-        page_table,
-        seq_info,
-        attn_logits,
-        sm_scale,
-        kv_scale,
-        q_nope.stride(0),
-        q_nope.stride(1),
-        q_pe.stride(0),
-        q_pe.stride(1),
-        kv_c.stride(-2),
-        k_pe.stride(-2),
-        stride_page_bs,
-        attn_logits.stride(0),
-        attn_logits.stride(1),
-        attn_logits.stride(2),
-        lse,
-        lse.stride(0),
-        lse.stride(1),
-        lse.stride(2),
-        BLOCK_H=BLOCK_H,
-        BLOCK_N=BLOCK_N,
-        NUM_KV_SPLITS=NUM_KV_SPLITS,
-        PAGE_SIZE=PAGE_SIZE,
-        HEAD_DIM_CKV=head_dim_ckv,
-        HEAD_DIM_KPE=head_dim_kpe,
-        KV_PE_OFFSET=kv_pe_offset,
-        USE_2D_VIEW=use_2d_view,
-        WITHIN_2GB=within_2gb,
-        NUM_XCDS=NUM_XCDS,
-        NHEAD=nhead,
-        REGIME=REGIME,
-    )
-
-    return attn_logits, lse

--- a/aiter/ops/triton/gluon/mla_decode_gluon.py
+++ b/aiter/ops/triton/gluon/mla_decode_gluon.py
@@ -545,7 +545,8 @@ def _mla_decode_gluon(
         if WITHIN_2GB:
             gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kv.index(async_idx), Kv_c_cache, offs_k_c, mask=offs_n_nope[None, :] < split_kv_end)
         else:
-            gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kv.index(async_idx), Kv_c_cache + offs_k_c, mask=offs_n_nope[None, :] < split_kv_end, other=0)
+            # No mask needed: out-of-range positions are discarded by the qk score mask
+            gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kv.index(async_idx), Kv_c_cache + offs_k_c)
         gl.amd.cdna4.async_copy.commit_group()
         # global load K_pe
         offs_n_pe = start_n + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kpe))
@@ -554,7 +555,7 @@ def _mla_decode_gluon(
         if WITHIN_2GB:
             gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kpe.index(async_idx), K_pe_cache, offs_k_pe, mask=offs_n_pe[None, :] < split_kv_end)
         else:
-            gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kpe.index(async_idx), K_pe_cache + offs_k_pe, mask=offs_n_pe[None, :] < split_kv_end, other=0)
+            gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kpe.index(async_idx), K_pe_cache + offs_k_pe)
         gl.amd.cdna4.async_copy.commit_group()
 
         # dot, softmax, dot
@@ -891,7 +892,7 @@ def mla_decode_gluon(
     return o, None
 
 
-def mla_decode_gluon_bh16_dcp(
+def mla_decode_gluon_dcp(
     q_nope,  # [batch, nhead, kv_lora_rank]
     q_pe,  # [batch, nhead, qk_rope_head_dim]
     kv_c,  # shared layout: [N, kv_lora_rank + qk_rope_head_dim]
@@ -916,7 +917,7 @@ def mla_decode_gluon_bh16_dcp(
     Operating window:
       - gfx950 (CDNA4)
       - nhead in [1-16], bf16 KV
-      - batch_size >= 1 (any value)
+      - batch_size in [1, 256] (so NUM_KV_SPLITS = 256 // batch_size >= 1)
       - NUM_KV_SPLITS = 256 // batch_size (floor); total WGs = B * NUM_KV_SPLITS
         is <= 256. When B does not divide 256 (e.g., 3, 5, 6, 7) up to a few
         CUs are idle for the wave (worst case ~1.5% at B=6).
@@ -936,19 +937,19 @@ def mla_decode_gluon_bh16_dcp(
 
     assert (
         arch_info.get_arch() == "gfx950"
-    ), f"mla_decode_gluon_bh16_dcp requires gfx950 (CDNA4), got {arch_info.get_arch()}"
+    ), f"mla_decode_gluon_dcp requires gfx950 (CDNA4), got {arch_info.get_arch()}"
     assert (
         head_dim_ckv == 512
-    ), f"mla_decode_gluon_bh16_dcp requires head_dim_ckv=512, got {head_dim_ckv}"
+    ), f"mla_decode_gluon_dcp requires head_dim_ckv=512, got {head_dim_ckv}"
     assert (
         head_dim_kpe == 64
-    ), f"mla_decode_gluon_bh16_dcp requires head_dim_kpe=64, got {head_dim_kpe}"
+    ), f"mla_decode_gluon_dcp requires head_dim_kpe=64, got {head_dim_kpe}"
     assert (
         1 <= nhead <= 16
-    ), f"mla_decode_gluon_bh16_dcp requires nhead in [1, 16], got {nhead}"
+    ), f"mla_decode_gluon_dcp requires nhead in [1, 16], got {nhead}"
     assert (
-        batch_size >= 1
-    ), f"mla_decode_gluon_bh16_dcp requires batch_size >= 1, got {batch_size}"
+        1 <= batch_size <= 256
+    ), f"mla_decode_gluon_dcp requires batch_size in [1, 256] (NUM_KV_SPLITS = 256 // batch_size must be >= 1), got {batch_size}"
     assert (
         q_nope.dtype == torch.bfloat16 and q_pe.dtype == torch.bfloat16
     ), f"q_nope/q_pe must be bf16, got {q_nope.dtype}/{q_pe.dtype}"
@@ -965,7 +966,7 @@ def mla_decode_gluon_bh16_dcp(
 
     assert (
         min_kv_seq_len >= NUM_KV_SPLITS
-    ), f"mla_decode_gluon_bh16_dcp requires min_kv_seq_len >= NUM_KV_SPLITS (= 256/B = {NUM_KV_SPLITS}), got {min_kv_seq_len}"
+    ), f"mla_decode_gluon_dcp requires min_kv_seq_len >= NUM_KV_SPLITS (= 256/B = {NUM_KV_SPLITS}), got {min_kv_seq_len}"
     assert attn_logits.shape == (
         batch_size,
         nhead,

--- a/aiter/ops/triton/gluon/mla_decode_gluon.py
+++ b/aiter/ops/triton/gluon/mla_decode_gluon.py
@@ -68,6 +68,10 @@ def _mla_decode_gluon(
     stride_o_b,
     stride_o_h,
     stride_o_s,
+    Lse,  # dcp_bh16 only which requires a separate tensor
+    stride_lse_b,
+    stride_lse_h,
+    stride_lse_s,
     BLOCK_H: gl.constexpr,
     BLOCK_N: gl.constexpr,
     NUM_KV_SPLITS: gl.constexpr,
@@ -81,11 +85,16 @@ def _mla_decode_gluon(
     NHEAD: gl.constexpr,
     REGIME: gl.constexpr,
 ):
-    # Grid mapping: bh64 uses 3-D XCD-aware multi-batch; bh16bn128 and bh16bn64 use 1-D split-only.
+    # Grid mapping: bh64 uses 3-D XCD-aware multi-batch; bh16bn128 and bh16bn64 use 1-D split-only;
+    # dcp_bh16 uses 2-D (batch, split) for the per-GPU DCP shard with small B.
     if REGIME == 'bh64':
         cur_batch = gl.program_id(0) + (gl.program_id(2) // NUM_KV_SPLITS) * NUM_XCDS
         cur_head_id = gl.program_id(1)
         split_kv_id = gl.program_id(2) % NUM_KV_SPLITS
+    elif REGIME == 'dcp_bh16':
+        cur_batch = gl.program_id(0)
+        cur_head_id = 0
+        split_kv_id = gl.program_id(1)
     else:
         cur_batch = 0
         cur_head_id = 0
@@ -382,20 +391,22 @@ def _mla_decode_gluon(
     kv_loc0 = kv_page_number_0
 
     # global load K_nope slice 0
+    offs_n_nope0 = split_kv_start + gl.arange(0, BLOCK_N // 2, layout=gl.SliceLayout(0, blocked_kv_slice))
     offs_d_ckv_10 = gl.arange(0, HEAD_DIM_CKV, layout=gl.SliceLayout(1, blocked_kv_slice))
     offs_k_c0 = kv_loc0[None, :] * stride_kv_c_bs + offs_d_ckv_10[:, None]
     bufs_kv0 = bufs_kv.index(0).slice(0, BLOCK_N // 2, 1)
     if WITHIN_2GB:
-        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kv0, Kv_c_cache, offs_k_c0)
+        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kv0, Kv_c_cache, offs_k_c0, mask=offs_n_nope0[None, :] < split_kv_end)
     else:
         gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kv0, Kv_c_cache + offs_k_c0)
     gl.amd.cdna4.async_copy.commit_group()
 
     # global load K_pe
+    offs_n_pe0 = split_kv_start + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kpe))
     offs_d_kpe_1 = gl.arange(0, HEAD_DIM_KPE, layout=gl.SliceLayout(1, blocked_kpe))
     offs_k_pe = kv_loc_pe[None, :] * stride_k_pe_bs + offs_d_kpe_1[:, None] + KV_PE_OFFSET
     if WITHIN_2GB:
-        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kpe.index(0), K_pe_cache, offs_k_pe)
+        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kpe.index(0), K_pe_cache, offs_k_pe, mask=offs_n_pe0[None, :] < split_kv_end)
     else:
         gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kpe.index(0), K_pe_cache + offs_k_pe)
     gl.amd.cdna4.async_copy.commit_group()
@@ -406,15 +417,21 @@ def _mla_decode_gluon(
     kv_loc1 = kv_page_number_1
 
     # global load K_nope slice 1
+    offs_n_nope1 = offs_n_nope0 + BLOCK_N // 2
     bufs_kv1 = bufs_kv.index(0).slice(BLOCK_N // 2, BLOCK_N // 2, 1)
     offs_k_c1 = kv_loc1[None, :] * stride_kv_c_bs + offs_d_ckv_10[:, None]
     if WITHIN_2GB:
-        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kv1, Kv_c_cache, offs_k_c1)
+        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kv1, Kv_c_cache, offs_k_c1, mask=offs_n_nope1[None, :] < split_kv_end)
     else:
         gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kv1, Kv_c_cache + offs_k_c1)
     gl.amd.cdna4.async_copy.commit_group()
 
-    gl.assume(num_iter >= 3)
+    if REGIME == 'dcp_bh16':
+        # DCP shards can have splits with as few as 1 iteration; epilogue 1
+        # is gated below for num_iter < 2.
+        gl.assume(num_iter >= 1)
+    else:
+        gl.assume(num_iter >= 3)
     buf_idx = 0
     ################ loop
     for i in range(num_iter - 2):
@@ -505,64 +522,70 @@ def _mla_decode_gluon(
         start_n += BLOCK_N
         buf_idx = (buf_idx + 1) % 2
 
-    ################ epilogue
-    async_idx = (buf_idx + 1) % 2
-
-    #### global load K
-    # local load page number
-    gl.amd.cdna4.async_copy.wait_group(3)
-    kv_page_number = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(async_idx), gl.SliceLayout(0, blocked_kv))
-    kv_page_number_pe = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(async_idx), gl.SliceLayout(0, blocked_kpe))
-    kv_loc = kv_page_number
-    kv_loc_pe = kv_page_number_pe
-    # global load K_nope
-    offs_n_nope = start_n + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kv))
-    offs_d_ckv_1 = gl.arange(0, HEAD_DIM_CKV, layout=gl.SliceLayout(1, blocked_kv))
-    offs_k_c = kv_loc[None, :] * stride_kv_c_bs + offs_d_ckv_1[:, None]
-    if WITHIN_2GB:
-        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kv.index(async_idx), Kv_c_cache, offs_k_c, mask=offs_n_nope[None, :] < split_kv_end)
-    else:
-        gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kv.index(async_idx), Kv_c_cache + offs_k_c, mask=offs_n_nope[None, :] < split_kv_end, other=0)
-    gl.amd.cdna4.async_copy.commit_group()
-    # global load K_pe
-    offs_n_pe = start_n + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kpe))
-    offs_d_kpe_1 = gl.arange(0, HEAD_DIM_KPE, layout=gl.SliceLayout(1, blocked_kpe))
-    offs_k_pe = kv_loc_pe[None, :] * stride_k_pe_bs + offs_d_kpe_1[:, None] + KV_PE_OFFSET
-    if WITHIN_2GB:
-        gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kpe.index(async_idx), K_pe_cache, offs_k_pe, mask=offs_n_pe[None, :] < split_kv_end)
-    else:
-        gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kpe.index(async_idx), K_pe_cache + offs_k_pe, mask=offs_n_pe[None, :] < split_kv_end, other=0)
-    gl.amd.cdna4.async_copy.commit_group()
-
-    # dot, softmax, dot
-    gl.amd.cdna4.async_copy.wait_group(2)
-    k_c = bufs_kv.index(buf_idx).load(layout=mfma_layout_b)
-    zeros = gl.zeros([BLOCK_H, BLOCK_N], dtype=gl.float32, layout=mfma_layout)
-    qk = gl.amd.cdna4.mfma(q_nope, k_c.to(dtype), zeros)
-
-    k_pe = bufs_kpe.index(buf_idx).load(layout=mfma_layout_b)
-    qk = gl.amd.cdna4.mfma(q_pe, k_pe.to(dtype), qk)
-    qk *= qk_scale
-    offs_n_qk = split_kv_start + (num_iter - 2) * BLOCK_N + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))
-    qk = gl.where(offs_n_qk[None, :] < split_kv_end, qk, float("-inf"))
-    n_e_max = gl.maximum(gl.max(qk, 1), e_max)
     LOG2E: gl.constexpr = 1.4426950408889634
-    re_scale = gl.exp2((e_max - n_e_max) * LOG2E)
-    p = gl.exp2((qk - n_e_max[:, None]) * LOG2E)
-    e_sum = e_sum * re_scale + gl.sum(p, 1)
-    e_max = n_e_max
-    p = p.to(dtype)
-    p = gl.convert_layout(p, mfma_layout_a)
-    acc *= re_scale[:, None]
-    v_c = bufs_kv.index(buf_idx).load(layout=linear_v)
-    v_c = v_c.to(dtype)
-    v_c = gl.permute(v_c, [1, 0])
-    v_c = gl.convert_layout(v_c, mfma_layout_b)
-    acc = gl.amd.cdna4.mfma(p, v_c, acc)
 
-    start_n += BLOCK_N
-    buf_idx = (buf_idx + 1) % 2
+    ################ epilogue 1
+    # Skip when num_iter < 2 (only possible under REGIME='dcp_bh16'; legacy
+    # regimes have gl.assume(num_iter >= 3) above so the compiler folds this
+    # branch out). 
+    if num_iter >= 2:
+        async_idx = (buf_idx + 1) % 2
 
+        #### global load K
+        # local load page number
+        gl.amd.cdna4.async_copy.wait_group(3)
+        kv_page_number = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(async_idx), gl.SliceLayout(0, blocked_kv))
+        kv_page_number_pe = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(async_idx), gl.SliceLayout(0, blocked_kpe))
+        kv_loc = kv_page_number
+        kv_loc_pe = kv_page_number_pe
+        # global load K_nope
+        offs_n_nope = start_n + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kv))
+        offs_d_ckv_1 = gl.arange(0, HEAD_DIM_CKV, layout=gl.SliceLayout(1, blocked_kv))
+        offs_k_c = kv_loc[None, :] * stride_kv_c_bs + offs_d_ckv_1[:, None]
+        if WITHIN_2GB:
+            gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kv.index(async_idx), Kv_c_cache, offs_k_c, mask=offs_n_nope[None, :] < split_kv_end)
+        else:
+            gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kv.index(async_idx), Kv_c_cache + offs_k_c, mask=offs_n_nope[None, :] < split_kv_end, other=0)
+        gl.amd.cdna4.async_copy.commit_group()
+        # global load K_pe
+        offs_n_pe = start_n + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kpe))
+        offs_d_kpe_1 = gl.arange(0, HEAD_DIM_KPE, layout=gl.SliceLayout(1, blocked_kpe))
+        offs_k_pe = kv_loc_pe[None, :] * stride_k_pe_bs + offs_d_kpe_1[:, None] + KV_PE_OFFSET
+        if WITHIN_2GB:
+            gl.amd.cdna4.async_copy.buffer_load_to_shared(bufs_kpe.index(async_idx), K_pe_cache, offs_k_pe, mask=offs_n_pe[None, :] < split_kv_end)
+        else:
+            gl.amd.cdna4.async_copy.global_load_to_shared(bufs_kpe.index(async_idx), K_pe_cache + offs_k_pe, mask=offs_n_pe[None, :] < split_kv_end, other=0)
+        gl.amd.cdna4.async_copy.commit_group()
+
+        # dot, softmax, dot
+        gl.amd.cdna4.async_copy.wait_group(2)
+        k_c = bufs_kv.index(buf_idx).load(layout=mfma_layout_b)
+        zeros = gl.zeros([BLOCK_H, BLOCK_N], dtype=gl.float32, layout=mfma_layout)
+        qk = gl.amd.cdna4.mfma(q_nope, k_c.to(dtype), zeros)
+
+        k_pe = bufs_kpe.index(buf_idx).load(layout=mfma_layout_b)
+        qk = gl.amd.cdna4.mfma(q_pe, k_pe.to(dtype), qk)
+        qk *= qk_scale
+        offs_n_qk = split_kv_start + (num_iter - 2) * BLOCK_N + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))
+        qk = gl.where(offs_n_qk[None, :] < split_kv_end, qk, float("-inf"))
+        n_e_max = gl.maximum(gl.max(qk, 1), e_max)
+        re_scale = gl.exp2((e_max - n_e_max) * LOG2E)
+        p = gl.exp2((qk - n_e_max[:, None]) * LOG2E)
+        e_sum = e_sum * re_scale + gl.sum(p, 1)
+        e_max = n_e_max
+        p = p.to(dtype)
+        p = gl.convert_layout(p, mfma_layout_a)
+        acc *= re_scale[:, None]
+        v_c = bufs_kv.index(buf_idx).load(layout=linear_v)
+        v_c = v_c.to(dtype)
+        v_c = gl.permute(v_c, [1, 0])
+        v_c = gl.convert_layout(v_c, mfma_layout_b)
+        acc = gl.amd.cdna4.mfma(p, v_c, acc)
+
+        start_n += BLOCK_N
+        buf_idx = (buf_idx + 1) % 2
+
+    ################ epilogue 2
     #### dot, softmax, dot
     gl.amd.cdna4.async_copy.wait_group(0)
     k_c = bufs_kv.index(buf_idx).load(layout=mfma_layout_b)
@@ -598,8 +621,16 @@ def _mla_decode_gluon(
         gl.amd.cdna4.buffer_store(stored_value, ptr=O, offsets=offs_o, mask=(cur_head_o < NHEAD)[:, None])
     else:
         gl.amd.cdna4.buffer_store(stored_value, ptr=O, offsets=offs_o)
-    if NUM_KV_SPLITS > 1:
-        # Per-split lse for stage-2 reduce (stored at the trailing slot).
+    if REGIME == 'dcp_bh16':
+        # Separate fp32 Lse tensor [B, H, NUM_KV_SPLITS] 
+        offs_lse = cur_batch * stride_lse_b + cur_head_o * stride_lse_h + split_kv_id * stride_lse_s
+        lse = e_max + gl.log(e_sum)
+        if NHEAD < BLOCK_H:
+            gl.amd.cdna4.buffer_store(lse, ptr=Lse, offsets=offs_lse, mask=(cur_head_o < NHEAD))
+        else:
+            gl.amd.cdna4.buffer_store(lse, ptr=Lse, offsets=offs_lse)
+    elif NUM_KV_SPLITS > 1:
+        # Legacy: per-split lse packed into O at the trailing slot for stage-2 reduce.
         offs_o_lse = cur_batch * stride_o_b + cur_head_o * stride_o_h + split_kv_id * stride_o_s + HEAD_DIM_CKV
         lse = e_max + gl.log(e_sum)
         if NHEAD < BLOCK_H:
@@ -818,6 +849,10 @@ def mla_decode_gluon(
         attn_logits.stride(0),
         attn_logits.stride(1),
         attn_logits.stride(2),
+        attn_logits,  # Lse: dummy
+        0,  # stride_lse_b
+        0,  # stride_lse_h
+        0,  # stride_lse_s
         BLOCK_H=BLOCK_H,
         BLOCK_N=BLOCK_N,
         NUM_KV_SPLITS=NUM_KV_SPLITS,
@@ -854,3 +889,141 @@ def mla_decode_gluon(
         )
 
     return o, None
+
+
+def mla_decode_gluon_bh16_dcp(
+    q_nope,  # [batch, nhead, kv_lora_rank]
+    q_pe,  # [batch, nhead, qk_rope_head_dim]
+    kv_c,  # shared layout: [N, kv_lora_rank + qk_rope_head_dim]
+    attn_logits,  # caller-allocated [batch, nhead, NUM_KV_SPLITS, kv_lora_rank] bf16
+    lse,  # caller-allocated [batch, nhead, NUM_KV_SPLITS] fp32
+    page_table,  # 2D: block_table [batch, max_seqlen] | 1D: kv_indices [total_kv]
+    seq_info,  # 2D: cache_seqlens [batch]           | 1D: kv_indptr [batch+1]
+    sm_scale,
+    k_pe=None,
+    kv_pe_offset=512,
+    use_2d_view=True,
+    kv_scale=1.0,
+    min_kv_seq_len=1,
+):
+    """
+    Stage-1-only MLA decode for the DCP (Decode Context Parallel) workload.
+
+    Each call processes one GPU's slice of a context-parallel KV cache. The
+    host is responsible for combining splits across GPUs (cross-GPU reduce +
+    final softmax-merge). This wrapper does NOT run stage-2 reducev.
+
+    Operating window:
+      - gfx950 (CDNA4)
+      - nhead in [1-16], bf16 KV
+      - batch_size >= 1 (any value)
+      - NUM_KV_SPLITS = 256 // batch_size (floor); total WGs = B * NUM_KV_SPLITS
+        is <= 256. When B does not divide 256 (e.g., 3, 5, 6, 7) up to a few
+        CUs are idle for the wave (worst case ~1.5% at B=6).
+      - min_kv_seq_len >= NUM_KV_SPLITS (every split gets at least 1 token)
+
+    Outputs (caller-allocated):
+      attn_logits: [B, nhead, NUM_KV_SPLITS, kv_lora_rank] bf16. Per-split
+                   normalized softmax(acc).
+      lse:         [B, nhead, NUM_KV_SPLITS] fp32. Per-split log-sum-exp
+                   (= max + log(sum(exp(qk - max)))).
+    """
+    if k_pe is None:
+        k_pe = kv_c
+
+    batch_size, nhead, head_dim_ckv = q_nope.shape
+    head_dim_kpe = q_pe.shape[-1]
+
+    assert (
+        arch_info.get_arch() == "gfx950"
+    ), f"mla_decode_gluon_bh16_dcp requires gfx950 (CDNA4), got {arch_info.get_arch()}"
+    assert (
+        head_dim_ckv == 512
+    ), f"mla_decode_gluon_bh16_dcp requires head_dim_ckv=512, got {head_dim_ckv}"
+    assert (
+        head_dim_kpe == 64
+    ), f"mla_decode_gluon_bh16_dcp requires head_dim_kpe=64, got {head_dim_kpe}"
+    assert (
+        1 <= nhead <= 16
+    ), f"mla_decode_gluon_bh16_dcp requires nhead in [1, 16], got {nhead}"
+    assert (
+        batch_size >= 1
+    ), f"mla_decode_gluon_bh16_dcp requires batch_size >= 1, got {batch_size}"
+    assert (
+        q_nope.dtype == torch.bfloat16 and q_pe.dtype == torch.bfloat16
+    ), f"q_nope/q_pe must be bf16, got {q_nope.dtype}/{q_pe.dtype}"
+    assert (
+        kv_c.dtype == torch.bfloat16 and k_pe.dtype == torch.bfloat16
+    ), f"kv_c/k_pe must be bf16, got {kv_c.dtype}/{k_pe.dtype}"
+
+    BLOCK_H = 16
+    BLOCK_N = 64
+    PAGE_SIZE = 1
+    REGIME = "dcp_bh16"
+    NUM_XCDS = 1  # unused by 2-D grid mapping
+    NUM_KV_SPLITS = 256 // batch_size
+
+    assert (
+        min_kv_seq_len >= NUM_KV_SPLITS
+    ), f"mla_decode_gluon_bh16_dcp requires min_kv_seq_len >= NUM_KV_SPLITS (= 256/B = {NUM_KV_SPLITS}), got {min_kv_seq_len}"
+    assert attn_logits.shape == (
+        batch_size,
+        nhead,
+        NUM_KV_SPLITS,
+        head_dim_ckv,
+    ), f"attn_logits must be [{batch_size}, {nhead}, {NUM_KV_SPLITS}, {head_dim_ckv}], got {tuple(attn_logits.shape)}"
+    assert (
+        attn_logits.dtype == torch.bfloat16
+    ), f"attn_logits must be bf16, got {attn_logits.dtype}"
+    assert lse.shape == (
+        batch_size,
+        nhead,
+        NUM_KV_SPLITS,
+    ), f"lse must be [{batch_size}, {nhead}, {NUM_KV_SPLITS}], got {tuple(lse.shape)}"
+    assert lse.dtype == torch.float32, f"lse must be fp32, got {lse.dtype}"
+
+    max_kv_bytes = kv_c.shape[0] * kv_c.stride(0) * kv_c.element_size()
+    within_2gb = max_kv_bytes <= 0x80000000
+
+    grid = (batch_size, NUM_KV_SPLITS)
+    stride_page_bs = page_table.stride(0) if use_2d_view else 0
+
+    _mla_decode_gluon[grid](
+        q_nope,
+        q_pe,
+        kv_c,
+        k_pe,
+        page_table,
+        seq_info,
+        attn_logits,
+        sm_scale,
+        kv_scale,
+        q_nope.stride(0),
+        q_nope.stride(1),
+        q_pe.stride(0),
+        q_pe.stride(1),
+        kv_c.stride(-2),
+        k_pe.stride(-2),
+        stride_page_bs,
+        attn_logits.stride(0),
+        attn_logits.stride(1),
+        attn_logits.stride(2),
+        lse,
+        lse.stride(0),
+        lse.stride(1),
+        lse.stride(2),
+        BLOCK_H=BLOCK_H,
+        BLOCK_N=BLOCK_N,
+        NUM_KV_SPLITS=NUM_KV_SPLITS,
+        PAGE_SIZE=PAGE_SIZE,
+        HEAD_DIM_CKV=head_dim_ckv,
+        HEAD_DIM_KPE=head_dim_kpe,
+        KV_PE_OFFSET=kv_pe_offset,
+        USE_2D_VIEW=use_2d_view,
+        WITHIN_2GB=within_2gb,
+        NUM_XCDS=NUM_XCDS,
+        NHEAD=nhead,
+        REGIME=REGIME,
+    )
+
+    return attn_logits, lse

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -561,6 +561,72 @@ def test_mla(
         cal_diff(out_ref, out_gluon, f"out_gluon_{name}", use_fp8=(name == "bh16bn128"))
         return err, us_decode
 
+    def test_absorb_decode_gluon_bh16_dcp():
+        # DCP (Decode Context Parallel) wrapper: per-GPU stage-1 only, no
+        # intra-GPU reducev. Host-side LSE-merge over splits validates
+        # equivalence to the unified attention reference. Triggered for
+        # B in {1,2,4}, bf16, nhead<=16; min ctx_lens*B such that every
+        # split has >=1 token.
+        from aiter.ops.triton.gluon.mla_decode_gluon import mla_decode_gluon_bh16_dcp
+
+        out_gluon = torch.empty((total_q, nhead, v_head_dim), dtype=out_dtype).fill_(-1)
+        q_nope = q[:, :, :v_head_dim].view(batch_size, nhead, v_head_dim)
+        q_pe = q[:, :, v_head_dim:].view(batch_size, nhead, qk_head_dim - v_head_dim)
+        kv_c = kv_buffer.view(-1, qk_head_dim)
+
+        if not varlen:
+            page_table = kv_indices[:total_kv].view(batch_size, ctx_lens)
+            seq_info = seq_lens_kv
+            use_2d_view = True
+        else:
+            page_table = kv_indices
+            seq_info = kv_indptr
+            use_2d_view = False
+
+        NUM_KV_SPLITS = 256 // batch_size
+        Dckv = v_head_dim
+        attn_logits = torch.empty(
+            (batch_size, nhead, NUM_KV_SPLITS, Dckv),
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+        lse = torch.empty(
+            (batch_size, nhead, NUM_KV_SPLITS),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+        _, us_decode = run_perftest(
+            mla_decode_gluon_bh16_dcp,
+            q_nope,
+            q_pe,
+            kv_c,
+            attn_logits,
+            lse,
+            page_table,
+            seq_info,
+            sm_scale,
+            use_2d_view=use_2d_view,
+            kv_scale=1.0,
+            min_kv_seq_len=ctx_lens,
+        )
+
+        # Host-side log-sum-exp merge across splits:
+        #   final = sum_i acc_i * exp(lse_i - max_lse) / sum_i exp(lse_i - max_lse)
+        acc_f = attn_logits.float()
+        max_lse = lse.max(dim=-1, keepdim=True).values
+        w = torch.exp(lse - max_lse)
+        merged = (acc_f * w[..., None]).sum(dim=-2) / w.sum(dim=-1, keepdim=True)
+        out_gluon.copy_(merged.view(total_q, nhead, v_head_dim).to(out_dtype))
+
+        err = checkAllclose(
+            out_ref,
+            out_gluon,
+            msg=f"mla_decode-absorb    [golden vs gluon_dcp_bh16]: {us_decode:>8.2f} us......",
+        )
+        cal_diff(out_ref, out_gluon, "out_gluon_dcp_bh16")
+        return err, us_decode
+
     err = None
     us_asm_decode = 1e12
     if (dtype == torch.bfloat16 and kvtype == torch.bfloat16) and nhead in [
@@ -666,6 +732,31 @@ def test_mla(
         ret["decode:gluon_576"] = us_gluon_decode
         ret["decode:gluon_TFLOPS"] = flops / us_gluon_decode / 1e6
         ret["decode:gluon_TB/s"] = bytes / us_gluon_decode / 1e6
+
+    # Gluon MLA dcp_bh16 decode test (gfx950, bf16 Q + bf16 KV, nhead<=16,
+    # decode_qlen=1, head_dim_ckv=512, head_dim_kpe=64, page_size=1).
+    # NUM_KV_SPLITS = 256 // batch_size (floor); for B not dividing 256
+    # (e.g., 3, 5, 6, 7) total WGs is slightly under 256 (a few CUs idle for
+    # the wave). Wrapper asserts min_kv_seq_len >= NUM_KV_SPLITS so num_iter
+    # >= 1 per split. Target operating window is B * ctx_lens in 10K..100K.
+    # Example: -c 10000 -b 1 -n 16,1 -d bf16 -kvd bf16  (num_iter=1 boundary).
+    if (
+        get_gfx() == "gfx950"
+        and dtype == torch.bfloat16
+        and kvtype == torch.bfloat16
+        and nhead <= 16
+        and decode_qlen == 1
+        and batch_size >= 1
+        and v_head_dim == 512
+        and (qk_head_dim - v_head_dim) == 64
+        and page_size == 1
+        and ctx_lens >= (256 // batch_size)
+    ):
+        err_gluon_dcp, us_gluon_dcp_decode = test_absorb_decode_gluon_bh16_dcp()
+        ret["decode:gluon_dcp_err"] = err_gluon_dcp
+        ret["decode:gluon_dcp_576"] = us_gluon_dcp_decode
+        ret["decode:gluon_dcp_TFLOPS"] = flops / us_gluon_dcp_decode / 1e6
+        ret["decode:gluon_dcp_TB/s"] = bytes / us_gluon_dcp_decode / 1e6
 
     return ret
 

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -681,21 +681,28 @@ def test_mla(
 
     # Gluon MLA bh16bn64 decode test (gfx950, bf16 Q + bf16 KV, nhead in (4,8,16),
     # decode_qlen=1, head_dim_ckv=512, head_dim_kpe=64, page_size=1).
-    # NUM_KV_SPLITS = max(1, 256 // batch_size); wrapper asserts
-    # min_kv_seq_len >= NUM_KV_SPLITS (non-empty splits, num_iter >= 1). Both
-    # full decode and the stage-1-only DCP path (-lse) run here, for any
-    # batch_size (e.g. B in {1, 3, 4}). Example: -c 3000000 -b 1 -n 16,1 -d bf16 -kvd bf16
+    # Two modes with different accuracy envelopes, so different gates:
+    #   -lse (DCP stage-1): the cross-split merge runs in fp32 on the host, so it
+    #     meets cal_diff for any batch. Only requirement is non-empty splits:
+    #     NUM_KV_SPLITS = max(1, 256 // batch_size), so ctx >= 256 // batch_size.
+    #     Example: -c 10000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16 -lse
+    #   full decode: the per-split combine is the in-kernel bf16 stage-2 reduce,
+    #     which only meets cal_diff's strict cos_diff<1e-5 at batch_size==1
+    #     (NUM_KV_SPLITS=256) with min_seq_len_wg >= BLOCK_N*3, i.e.
+    #     ctx >= 256 * 64 * 3 = 49152. Example: -c 49152 -b 1 -n 16,1 -d bf16 -kvd bf16
     if (
         get_gfx() == "gfx950"
         and dtype == torch.bfloat16
         and kvtype == torch.bfloat16
         and nhead <= 16
         and decode_qlen == 1
-        and 1 <= batch_size <= 256  # NUM_KV_SPLITS = max(1, 256 // batch_size) >= 1
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
         and page_size == 1
-        and ctx_lens >= (256 // batch_size)
+        and (
+            (return_lse and 1 <= batch_size <= 256 and ctx_lens >= (256 // batch_size))
+            or (not return_lse and batch_size == 1 and ctx_lens >= 256 * 64 * 3)
+        )
     ):
         err_gluon, us_gluon_decode = test_absorb_decode_gluon_bh16("bh16bn64")
         ret["decode:gluon_err"] = err_gluon

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -518,9 +518,15 @@ def test_mla(
         return err, us_gluon_decode
 
     def test_absorb_decode_gluon_bh16(name):
-        # Shared bh16bn{64,128} runner. The wrapper dispatches on (nhead, kv dtype):
-        # name='bh16bn128' -> cast kv to fp8; name='bh16bn64' -> keep bf16.
+        # Shared bh16bn{64,128} runner. The wrapper dispatches on
+        # (nhead, kv dtype): name='bh16bn128' -> cast kv to fp8;
+        # name='bh16bn64' -> keep bf16. When the outer -lse/--return_lse flag is
+        # set, run the stage-1-only (DCP) path: per-GPU stage-1, no intra-GPU
+        # reducev. Host-side LSE-merge over splits validates equivalence to the
+        # unified attention reference.
         from aiter.ops.triton.gluon.mla_decode_gluon import mla_decode_gluon
+
+        is_1st_stage = return_lse
 
         out_gluon = torch.empty((total_q, nhead, v_head_dim), dtype=out_dtype).fill_(-1)
         q_nope = q[:, :, :v_head_dim].view(batch_size, nhead, v_head_dim)
@@ -539,19 +545,41 @@ def test_mla(
             seq_info = kv_indptr
             use_2d_view = False
 
-        (attn_logits, attn_lse), us_decode = run_perftest(
+        if is_1st_stage:
+            # Stage-1-only: kernel writes per-split (acc, lse); host merges.
+            NUM_KV_SPLITS = 256 // batch_size
+            Dckv = v_head_dim
+            out_buf = torch.empty(
+                (batch_size, nhead, NUM_KV_SPLITS, Dckv),
+                dtype=torch.bfloat16,
+                device=q.device,
+            )
+        else:
+            out_buf = out_gluon.view(batch_size, nhead, v_head_dim)
+
+        (_, lse), us_decode = run_perftest(
             mla_decode_gluon,
             q_nope,
             q_pe,
             kv_c,
-            out_gluon.view(batch_size, nhead, v_head_dim),
+            out_buf,
             page_table,
             seq_info,
             sm_scale,
             use_2d_view=use_2d_view,
             kv_scale=1.0,
             min_kv_seq_len=ctx_lens,
+            return_lse=is_1st_stage,
         )
+
+        if is_1st_stage:
+            # Host-side log-sum-exp merge across splits:
+            #   final = sum_i acc_i * exp(lse_i - max_lse) / sum_i exp(lse_i - max_lse)
+            acc_f = out_buf.float()
+            max_lse = lse.max(dim=-1, keepdim=True).values
+            w = torch.exp(lse - max_lse)
+            merged = (acc_f * w[..., None]).sum(dim=-2) / w.sum(dim=-1, keepdim=True)
+            out_gluon.copy_(merged.view(total_q, nhead, v_head_dim).to(out_dtype))
 
         err = checkAllclose(
             out_ref,
@@ -561,74 +589,15 @@ def test_mla(
         cal_diff(out_ref, out_gluon, f"out_gluon_{name}", use_fp8=(name == "bh16bn128"))
         return err, us_decode
 
-    def test_absorb_decode_gluon_bh16_dcp():
-        # DCP (Decode Context Parallel) wrapper: per-GPU stage-1 only, no
-        # intra-GPU reducev. Host-side LSE-merge over splits validates
-        # equivalence to the unified attention reference. Triggered for
-        # bf16, nhead<=16;
-        from aiter.ops.triton.gluon.mla_decode_gluon import mla_decode_gluon_dcp
-
-        out_gluon = torch.empty((total_q, nhead, v_head_dim), dtype=out_dtype).fill_(-1)
-        q_nope = q[:, :, :v_head_dim].view(batch_size, nhead, v_head_dim)
-        q_pe = q[:, :, v_head_dim:].view(batch_size, nhead, qk_head_dim - v_head_dim)
-        kv_c = kv_buffer.view(-1, qk_head_dim)
-
-        if not varlen:
-            page_table = kv_indices[:total_kv].view(batch_size, ctx_lens)
-            seq_info = seq_lens_kv
-            use_2d_view = True
-        else:
-            page_table = kv_indices
-            seq_info = kv_indptr
-            use_2d_view = False
-
-        NUM_KV_SPLITS = 256 // batch_size
-        Dckv = v_head_dim
-        attn_logits = torch.empty(
-            (batch_size, nhead, NUM_KV_SPLITS, Dckv),
-            dtype=torch.bfloat16,
-            device=q.device,
-        )
-        lse = torch.empty(
-            (batch_size, nhead, NUM_KV_SPLITS),
-            dtype=torch.float32,
-            device=q.device,
-        )
-
-        _, us_decode = run_perftest(
-            mla_decode_gluon_dcp,
-            q_nope,
-            q_pe,
-            kv_c,
-            attn_logits,
-            lse,
-            page_table,
-            seq_info,
-            sm_scale,
-            use_2d_view=use_2d_view,
-            kv_scale=1.0,
-            min_kv_seq_len=ctx_lens,
-        )
-
-        # Host-side log-sum-exp merge across splits:
-        #   final = sum_i acc_i * exp(lse_i - max_lse) / sum_i exp(lse_i - max_lse)
-        acc_f = attn_logits.float()
-        max_lse = lse.max(dim=-1, keepdim=True).values
-        w = torch.exp(lse - max_lse)
-        merged = (acc_f * w[..., None]).sum(dim=-2) / w.sum(dim=-1, keepdim=True)
-        out_gluon.copy_(merged.view(total_q, nhead, v_head_dim).to(out_dtype))
-
-        err = checkAllclose(
-            out_ref,
-            out_gluon,
-            msg=f"mla_decode-absorb    [golden vs gluon_dcp]: {us_decode:>8.2f} us......",
-        )
-        cal_diff(out_ref, out_gluon, "out_gluon_dcp")
-        return err, us_decode
-
     err = None
     us_asm_decode = 1e12
-    if (dtype == torch.bfloat16 and kvtype == torch.bfloat16) and nhead in [
+    # The ASM decode baseline has no LSE kernel for these MLA configs (e.g.
+    # nhead<=16 bf16 aborts in get_heuristic_kernel_mla with lse:1); skip it
+    # entirely when -lse is set. The -lse path exercises only the Gluon
+    # stage-1/DCP kernel.
+    if return_lse:
+        pass
+    elif (dtype == torch.bfloat16 and kvtype == torch.bfloat16) and nhead in [
         16,
         32,
         64,
@@ -690,8 +659,8 @@ def test_mla(
 
     # Gluon MLA bh16bn128 decode test (gfx950, bf16 Q + fp8 KV, nhead in (4,8,16),
     # batch=1, decode_qlen=1, head_dim_ckv=512, head_dim_kpe=64, page_size=1).
-    # NUM_KV_SPLITS=256 hardcoded; kernel asserts min_kv_seq_len // 256 >= BLOCK_N*3,
-    # i.e. min_kv_seq_len >= 98304. Example: -c 10000000 -b 1 -n 16,1 -d bf16 -kvd fp8
+    # NUM_KV_SPLITS=256 hardcoded; wrapper asserts min_kv_seq_len >= NUM_KV_SPLITS
+    # (=256; non-empty splits, num_iter >= 1). Example: -c 10000000 -b 1 -n 16,1 -d bf16 -kvd fp8
     if (
         get_gfx() == "gfx950"
         and dtype == torch.bfloat16
@@ -702,7 +671,7 @@ def test_mla(
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
         and page_size == 1
-        and ctx_lens >= 256 * 128 * 3
+        and ctx_lens >= 256
     ):
         err_gluon, us_gluon_decode = test_absorb_decode_gluon_bh16("bh16bn128")
         ret["decode:gluon_err"] = err_gluon
@@ -711,51 +680,28 @@ def test_mla(
         ret["decode:gluon_TB/s"] = bytes / us_gluon_decode / 1e6
 
     # Gluon MLA bh16bn64 decode test (gfx950, bf16 Q + bf16 KV, nhead in (4,8,16),
-    # batch=1, decode_qlen=1, head_dim_ckv=512, head_dim_kpe=64, page_size=1).
-    # NUM_KV_SPLITS=256 hardcoded; kernel asserts min_kv_seq_len // 256 >= BLOCK_N*3,
-    # i.e. min_kv_seq_len >= 49152. Example: -c 3000000 -b 1 -n 16,1 -d bf16 -kvd bf16
+    # decode_qlen=1, head_dim_ckv=512, head_dim_kpe=64, page_size=1).
+    # NUM_KV_SPLITS = max(1, 256 // batch_size); wrapper asserts
+    # min_kv_seq_len >= NUM_KV_SPLITS (non-empty splits, num_iter >= 1). Both
+    # full decode and the stage-1-only DCP path (-lse) run here, for any
+    # batch_size (e.g. B in {1, 3, 4}). Example: -c 3000000 -b 1 -n 16,1 -d bf16 -kvd bf16
     if (
         get_gfx() == "gfx950"
         and dtype == torch.bfloat16
         and kvtype == torch.bfloat16
         and nhead <= 16
         and decode_qlen == 1
-        and batch_size == 1
+        and 1 <= batch_size <= 256  # NUM_KV_SPLITS = max(1, 256 // batch_size) >= 1
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
         and page_size == 1
-        and ctx_lens >= 256 * 64 * 3
+        and ctx_lens >= (256 // batch_size)
     ):
         err_gluon, us_gluon_decode = test_absorb_decode_gluon_bh16("bh16bn64")
         ret["decode:gluon_err"] = err_gluon
         ret["decode:gluon_576"] = us_gluon_decode
         ret["decode:gluon_TFLOPS"] = flops / us_gluon_decode / 1e6
         ret["decode:gluon_TB/s"] = bytes / us_gluon_decode / 1e6
-
-    # Gluon MLA dcp_bh16 decode test (gfx950, bf16 Q + bf16 KV, nhead<=16,
-    # decode_qlen=1, head_dim_ckv=512, head_dim_kpe=64, page_size=1).
-    # NUM_KV_SPLITS = 256 // batch_size (floor); for B not dividing 256
-    # (e.g., 3, 5, 6, 7) total WGs is slightly under 256 (a few CUs idle for
-    # the wave). Wrapper asserts min_kv_seq_len >= NUM_KV_SPLITS so num_iter
-    # >= 1 per split. Target operating window is B * ctx_lens in 10K..100K.
-    # Example: -c 10000 -b 1 -n 16,1 -d bf16 -kvd bf16  (num_iter=1 boundary).
-    if (
-        get_gfx() == "gfx950"
-        and dtype == torch.bfloat16
-        and kvtype == torch.bfloat16
-        and nhead <= 16
-        and decode_qlen == 1
-        and 1 <= batch_size <= 256  # NUM_KV_SPLITS = 256 // batch_size must be >= 1
-        and v_head_dim == 512
-        and (qk_head_dim - v_head_dim) == 64
-        and page_size == 1
-        and ctx_lens >= (256 // batch_size)
-    ):
-        err_gluon_dcp, us_gluon_dcp_decode = test_absorb_decode_gluon_bh16_dcp()
-        ret["decode:gluon_dcp_err"] = err_gluon_dcp
-        ret["decode:gluon_dcp_576"] = us_gluon_dcp_decode
-        ret["decode:gluon_dcp_TFLOPS"] = flops / us_gluon_dcp_decode / 1e6
-        ret["decode:gluon_dcp_TB/s"] = bytes / us_gluon_dcp_decode / 1e6
 
     return ret
 

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -565,9 +565,8 @@ def test_mla(
         # DCP (Decode Context Parallel) wrapper: per-GPU stage-1 only, no
         # intra-GPU reducev. Host-side LSE-merge over splits validates
         # equivalence to the unified attention reference. Triggered for
-        # B in {1,2,4}, bf16, nhead<=16; min ctx_lens*B such that every
-        # split has >=1 token.
-        from aiter.ops.triton.gluon.mla_decode_gluon import mla_decode_gluon_bh16_dcp
+        # bf16, nhead<=16;
+        from aiter.ops.triton.gluon.mla_decode_gluon import mla_decode_gluon_dcp
 
         out_gluon = torch.empty((total_q, nhead, v_head_dim), dtype=out_dtype).fill_(-1)
         q_nope = q[:, :, :v_head_dim].view(batch_size, nhead, v_head_dim)
@@ -597,7 +596,7 @@ def test_mla(
         )
 
         _, us_decode = run_perftest(
-            mla_decode_gluon_bh16_dcp,
+            mla_decode_gluon_dcp,
             q_nope,
             q_pe,
             kv_c,
@@ -622,9 +621,9 @@ def test_mla(
         err = checkAllclose(
             out_ref,
             out_gluon,
-            msg=f"mla_decode-absorb    [golden vs gluon_dcp_bh16]: {us_decode:>8.2f} us......",
+            msg=f"mla_decode-absorb    [golden vs gluon_dcp]: {us_decode:>8.2f} us......",
         )
-        cal_diff(out_ref, out_gluon, "out_gluon_dcp_bh16")
+        cal_diff(out_ref, out_gluon, "out_gluon_dcp")
         return err, us_decode
 
     err = None
@@ -746,7 +745,7 @@ def test_mla(
         and kvtype == torch.bfloat16
         and nhead <= 16
         and decode_qlen == 1
-        and batch_size >= 1
+        and 1 <= batch_size <= 256  # NUM_KV_SPLITS = 256 // batch_size must be >= 1
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
         and page_size == 1


### PR DESCRIPTION
  Per-GPU stage-1 only (host does cross-GPU LSE merge). Reuses _mla_decode_gluon with separate fp32 lse tensor
batch_size: any B >= 1. NUM_KV_SPLITS = 256 // B (floor); when B doesn't divide 256, up to ~1.5% CUs idle for the wave (no tail).

`python op_tests/test_mla.py -c 10000 100000 -b 1 3 4 -n 12,1 16,1 -kvd bf16 -lse`
  Tests + CI sweep cover B in {1,3,4}. README updated with perf table (MI350 bf16, 1.26-4.68 TB/s across 10K-100K ctx).
