### PR TITLE
[Triton] Add New Features and Performance Improvement for GMM Kernel

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gmm.py
+++ b/aiter/ops/triton/_triton_kernels/gmm.py
@@ -351,7 +351,6 @@ def _work_stealing_gmm(
     tl.device_assert(total_tiles > 0, "total_tiles <= 0")
 
     tile = tl.program_id(0).to(INT_TYPE)
-    tl.device_assert(tile < total_tiles, "tile >= total_tiles")
 
     while tile < total_tiles:
         g, m, num_m_tiles, last_m, tile_in_mm = _resolve_gmm_tile(

--- a/aiter/ops/triton/_triton_kernels/gmm.py
+++ b/aiter/ops/triton/_triton_kernels/gmm.py
@@ -112,19 +112,22 @@ def gmm_kernel(
     tl.assume(N > 0)
     tl.assume(G > 0)
 
-    num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N)
+    int_type = group_sizes_ptr.type.element_ty
+    zero = tl.cast(0, int_type)
+
+    num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N).to(int_type)
     tl.device_assert(num_n_tiles > 0, "num_n_tiles <= 0")
 
     # Current tile. Each program computes multiple tiles of each group.
-    tile = tl.program_id(0)
+    tile = tl.program_id(0).to(int_type)
     tl.device_assert(tile >= 0, "tile < 0 (at initialization)")
 
     # Tile limit of last MM problem (inclusive).
-    last_mm_tile = 0
+    last_mm_tile = zero
 
     # Last input row of lhs and output row of out. Each group reads some rows of
     # lhs and writes some rows to out.
-    last_m = 0
+    last_m = zero
 
     # Loop through all (m, K, N) MM problems:
     #   (m, K) x (K, N) = (m, N)
@@ -283,25 +286,28 @@ def tgmm_persistent_kernel(
     tl.assume(N > 0)
     tl.assume(G > 0)
 
-    num_k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    int_type = group_sizes_ptr.type.element_ty
+    zero = tl.cast(0, int_type)
+
+    num_k_tiles = tl.cdiv(K, BLOCK_SIZE_K).to(int_type)
     tl.device_assert(num_k_tiles > 0, "num_k_tiles <= 0")
 
-    num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N)
+    num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N).to(int_type)
     tl.device_assert(num_n_tiles > 0, "num_n_tiles <= 0")
 
     num_tiles = num_k_tiles * num_n_tiles
     tl.device_assert(num_tiles > 0, "num_tiles <= 0")
 
     # Current tile. Each program computes multiple tiles of each group.
-    tile = tl.program_id(0)
+    tile = tl.program_id(0).to(int_type)
     tl.device_assert(tile >= 0, "tile < 0 (at initialization)")
 
     # Tile limit of last MM problem (inclusive).
-    last_mm_tile = 0
+    last_mm_tile = zero
 
     # Last input column of lhs and input row of rhs. Each group reads some
     # columns of lhs and some rows of rhs.
-    last_m = 0
+    last_m = zero
 
     # Loop through all (K, m, N) MM problems:
     #   (K, m) x (m, N) = (K, N)

--- a/aiter/ops/triton/_triton_kernels/gmm.py
+++ b/aiter/ops/triton/_triton_kernels/gmm.py
@@ -78,14 +78,148 @@ def _remap_xcd_tile_grid(
 # ------------------------------------------------------------------------------
 
 
-@triton.heuristics(
-    {
-        "K_DIVISIBLE_BY_BLOCK_SIZE_K": lambda META: META["K"] % META["BLOCK_SIZE_K"]
-        == 0,
-    }
-)
 @triton.jit
-def gmm_kernel(
+def _total_gmm_tiles(
+    group_sizes_ptr,
+    G: int,
+    num_n_tiles: int,
+    BLOCK_SIZE_G: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    INT_TYPE: tl.constexpr,
+):
+    g_range = tl.arange(0, BLOCK_SIZE_G)
+    g_mask = g_range < G
+    group_sizes = tl.load(group_sizes_ptr + g_range, mask=g_mask, other=0)
+    num_m_tiles = tl.cdiv(group_sizes, BLOCK_SIZE_M)
+    num_tiles = num_m_tiles * num_n_tiles
+    cumsum_tile = tl.where(g_mask, tl.cumsum(num_tiles, dtype=INT_TYPE), 0)
+    total_tiles = tl.max(cumsum_tile)
+    return total_tiles
+
+
+@triton.jit
+def _resolve_gmm_tile(
+    group_sizes_ptr,
+    tile,
+    G: int,
+    num_n_tiles: int,
+    BLOCK_SIZE_G: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    INT_TYPE: tl.constexpr,
+):
+    g_range = tl.arange(0, BLOCK_SIZE_G)
+    g_mask = g_range < G
+    group_sizes = tl.load(group_sizes_ptr + g_range, mask=g_mask, other=0)
+    num_m_tiles = tl.cdiv(group_sizes, BLOCK_SIZE_M)
+    num_tiles = num_m_tiles * num_n_tiles
+    cumsum_tile = tl.where(g_mask, tl.cumsum(num_tiles, dtype=INT_TYPE), 0)
+    cumsum_m = tl.where(g_mask, tl.cumsum(group_sizes, dtype=INT_TYPE), 0)
+    g = tl.sum((cumsum_tile <= tile) & g_mask, dtype=INT_TYPE)
+    tl.device_assert(g < G, "g >= G")
+    prev_mask = g_range < g
+    prev_cumsum_m = tl.max(tl.where(prev_mask, cumsum_m, 0))
+    prev_cumsum_tile = tl.max(tl.where(prev_mask, cumsum_tile, 0))
+    g_cumsum_m = tl.max(tl.where(g_range == g, cumsum_m, 0))
+    m = g_cumsum_m - prev_cumsum_m
+    num_m_tiles_out = tl.cdiv(m, BLOCK_SIZE_M)
+    tile_in_mm = tile - prev_cumsum_tile
+    tl.device_assert(tile_in_mm >= 0, "tile_in_mm < 0")
+    #      g, m, num_m_tiles,     last_m,        tile_in_mm
+    return g, m, num_m_tiles_out, prev_cumsum_m, tile_in_mm
+
+
+@triton.jit
+def _process_gmm_tile(
+    # Tensor pointers:
+    lhs_ptr,
+    rhs_ptr,
+    out_ptr,
+    bias_ptr,
+    # Tensor shapes:
+    K: int,
+    N: int,
+    # Tile arguments:
+    g: int,  # group number
+    m: int,  # number of lhs / out rows
+    num_m_tiles: int,  # number of tiles in row dimension
+    num_n_tiles: int,  # number of tiles in column dimension
+    tile_in_mm: int,  # tile coordinates in current MM problem
+    last_m: int,  # last row of lhs / out
+    # Meta-parameters:
+    TRANS_RHS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    K_DIVISIBLE_BY_BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    USE_BIAS: tl.constexpr,
+):
+    tile_m, tile_n = _remap_xcd_tile_grid(
+        tile_in_mm, num_m_tiles, num_n_tiles, GROUP_SIZE=GROUP_SIZE
+    )
+
+    offs_lhs_m = (tile_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % m
+    offs_rhs_n = (tile_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+
+    lhs_ptrs = lhs_ptr + (last_m + offs_lhs_m[:, None]) * K + offs_k[None, :]
+
+    if TRANS_RHS:
+        rhs_ptrs = (
+            rhs_ptr + g.to(tl.int64) * K * N + offs_k[:, None] + offs_rhs_n[None, :] * K
+        )
+    else:
+        rhs_ptrs = (
+            rhs_ptr + g.to(tl.int64) * K * N + offs_k[:, None] * N + offs_rhs_n[None, :]
+        )
+
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        if K_DIVISIBLE_BY_BLOCK_SIZE_K:
+            lhs = tl.load(lhs_ptrs)
+            rhs = tl.load(rhs_ptrs)
+        else:
+            k_mask_limit = K - k * BLOCK_SIZE_K
+            lhs = tl.load(lhs_ptrs, mask=offs_k[None, :] < k_mask_limit, other=0)
+            rhs = tl.load(rhs_ptrs, mask=offs_k[:, None] < k_mask_limit, other=0)
+
+        acc = tl.dot(lhs, rhs, acc=acc)
+
+        lhs_ptrs += BLOCK_SIZE_K
+
+        if TRANS_RHS:
+            rhs_ptrs += BLOCK_SIZE_K
+        else:
+            rhs_ptrs += BLOCK_SIZE_K * N
+
+    # Add bias if enabled.
+    if USE_BIAS:
+        offs_bias_n = tile_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        bias_ptrs = bias_ptr + g.to(tl.int64) * N + offs_bias_n
+        bias = tl.load(bias_ptrs, mask=offs_bias_n < N, other=0.0)
+        # Convert bias to float32 to match accumulator precision.
+        bias = bias.to(tl.float32)
+        # Broadcast bias across M dimension and add in float32.
+        acc += bias[None, :]
+
+    # Convert to output dtype after all computations.
+    acc = acc.to(out_ptr.type.element_ty)
+
+    offs_out_m = tile_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_out_n = tile_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+    out_ptrs = out_ptr + (last_m + offs_out_m[:, None]) * N + offs_out_n[None, :]
+
+    tl.store(
+        out_ptrs,
+        acc,
+        mask=(offs_out_m[:, None] < m) & (offs_out_n[None, :] < N),
+    )
+
+
+@triton.jit
+def _gmm(
     # Tensor pointers:
     lhs_ptr,
     rhs_ptr,
@@ -97,6 +231,7 @@ def gmm_kernel(
     K: int,
     N: int,
     G: int,
+    num_n_tiles: int,
     # Meta-parameters:
     TRANS_RHS: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
@@ -106,21 +241,12 @@ def gmm_kernel(
     GROUP_SIZE: tl.constexpr,
     GRID_DIM: tl.constexpr,
     USE_BIAS: tl.constexpr,
+    INT_TYPE: tl.constexpr,
 ):
-    tl.assume(M > 0)
-    tl.assume(K > 0)
-    tl.assume(N > 0)
-    tl.assume(G > 0)
-
-    int_type = group_sizes_ptr.type.element_ty
-    zero = tl.cast(0, int_type)
-
-    num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N).to(int_type)
-    tl.device_assert(num_n_tiles > 0, "num_n_tiles <= 0")
+    zero = tl.cast(0, INT_TYPE)
 
     # Current tile. Each program computes multiple tiles of each group.
-    tile = tl.program_id(0).to(int_type)
-    tl.device_assert(tile >= 0, "tile < 0 (at initialization)")
+    tile = tl.program_id(0).to(INT_TYPE)
 
     # Tile limit of last MM problem (inclusive).
     last_mm_tile = zero
@@ -135,16 +261,11 @@ def gmm_kernel(
     for g in range(G):
         # Get m dimension of current MM problem.
         m = tl.load(group_sizes_ptr + g)
-        # m can be zero if group is empty
+        # m can be zero if group is empty.
         tl.device_assert(m >= 0, "m < 0")
 
         num_m_tiles = tl.cdiv(m, BLOCK_SIZE_M)
-        # num_m_tiles can be zero if group is empty
-        tl.device_assert(num_m_tiles >= 0, "num_m_tiles < 0")
-
         num_tiles = num_m_tiles * num_n_tiles
-        # num_tiles can be zero if group is empty
-        tl.device_assert(num_tiles >= 0, "num_tiles < 0")
 
         # Loop through tiles of current MM problem.
         while tile >= last_mm_tile and tile < last_mm_tile + num_tiles:
@@ -152,90 +273,30 @@ def gmm_kernel(
             tile_in_mm = tile - last_mm_tile
             tl.device_assert(tile_in_mm >= 0, "tile_in_mm < 0")
 
-            tile_m, tile_n = _remap_xcd_tile_grid(
-                tile_in_mm, num_m_tiles, num_n_tiles, GROUP_SIZE=GROUP_SIZE
-            )
-
-            # Do regular MM:
-
-            tl.device_assert(tile_m * BLOCK_SIZE_M >= 0, "tile_m * BLOCK_SIZE_M < 0")
-            tl.device_assert(tile_n * BLOCK_SIZE_N >= 0, "tile_n * BLOCK_SIZE_N < 0")
-
-            offs_lhs_m = (
-                tile_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-            ) % m
-            offs_rhs_n = (
-                tile_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-            ) % N
-            offs_k = tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
-
-            lhs_ptrs = lhs_ptr + (last_m + offs_lhs_m[:, None]) * K + offs_k[None, :]
-
-            if TRANS_RHS:
-                rhs_ptrs = (
-                    rhs_ptr
-                    + g.to(tl.int64) * K * N
-                    + offs_k[:, None]
-                    + offs_rhs_n[None, :] * K
-                )
-            else:
-                rhs_ptrs = (
-                    rhs_ptr
-                    + g.to(tl.int64) * K * N
-                    + offs_k[:, None] * N
-                    + offs_rhs_n[None, :]
-                )
-
-            acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-
-            for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-                if K_DIVISIBLE_BY_BLOCK_SIZE_K:
-                    lhs = tl.load(lhs_ptrs)
-                    rhs = tl.load(rhs_ptrs)
-                else:
-                    k_mask_limit = K - k * BLOCK_SIZE_K
-                    lhs = tl.load(
-                        lhs_ptrs, mask=offs_k[None, :] < k_mask_limit, other=0
-                    )
-                    rhs = tl.load(
-                        rhs_ptrs, mask=offs_k[:, None] < k_mask_limit, other=0
-                    )
-
-                acc = tl.dot(lhs, rhs, acc=acc)
-
-                lhs_ptrs += BLOCK_SIZE_K
-
-                if TRANS_RHS:
-                    rhs_ptrs += BLOCK_SIZE_K
-                else:
-                    rhs_ptrs += BLOCK_SIZE_K * N
-
-            # Add bias if enabled
-            if USE_BIAS:
-                offs_bias_n = tile_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(
-                    0, BLOCK_SIZE_N
-                )
-                bias_ptrs = bias_ptr + g.to(tl.int64) * N + offs_bias_n
-                bias = tl.load(bias_ptrs, mask=offs_bias_n < N, other=0.0)
-                # Convert bias to float32 to match accumulator precision
-                bias = bias.to(tl.float32)
-                # Broadcast bias across M dimension and add in float32
-                acc += bias[None, :]
-
-            # Convert to output dtype after all computations
-            acc = acc.to(out_ptr.type.element_ty)
-
-            offs_out_m = tile_m.to(tl.int64) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-            offs_out_n = tile_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-
-            out_ptrs = (
-                out_ptr + (last_m + offs_out_m[:, None]) * N + offs_out_n[None, :]
-            )
-
-            tl.store(
-                out_ptrs,
-                acc,
-                mask=(offs_out_m[:, None] < m) & (offs_out_n[None, :] < N),
+            _process_gmm_tile(
+                # Tensor pointers:
+                lhs_ptr,
+                rhs_ptr,
+                out_ptr,
+                bias_ptr,
+                # Tensor shapes:
+                K,
+                N,
+                # Tile arguments:
+                g,
+                m,
+                num_m_tiles,
+                num_n_tiles,
+                tile_in_mm,
+                last_m,
+                # Meta-parameters:
+                TRANS_RHS=TRANS_RHS,
+                BLOCK_SIZE_M=BLOCK_SIZE_M,
+                BLOCK_SIZE_K=BLOCK_SIZE_K,
+                BLOCK_SIZE_N=BLOCK_SIZE_N,
+                K_DIVISIBLE_BY_BLOCK_SIZE_K=K_DIVISIBLE_BY_BLOCK_SIZE_K,
+                GROUP_SIZE=GROUP_SIZE,
+                USE_BIAS=USE_BIAS,
             )
 
             # Go to the next tile by advancing number of programs.
@@ -252,6 +313,177 @@ def gmm_kernel(
         # last_m can be zero if group 0 is skipped
         tl.device_assert(last_m >= 0, "last_m < 0 (at update)")
         tl.device_assert(last_m <= M, "last_m > M (at update)")
+
+
+@triton.jit
+def _work_stealing_gmm(
+    # Tensor pointers:
+    lhs_ptr,
+    rhs_ptr,
+    group_sizes_ptr,
+    out_ptr,
+    bias_ptr,
+    tile_counter_ptr,
+    # Tensor shapes:
+    K: int,
+    N: int,
+    G: int,
+    num_n_tiles: int,
+    # Meta-parameters:
+    TRANS_RHS: tl.constexpr,
+    BLOCK_SIZE_G: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    K_DIVISIBLE_BY_BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    USE_BIAS: tl.constexpr,
+    INT_TYPE: tl.constexpr,
+):
+    total_tiles = _total_gmm_tiles(
+        group_sizes_ptr,
+        G,
+        num_n_tiles,
+        BLOCK_SIZE_G=BLOCK_SIZE_G,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        INT_TYPE=INT_TYPE,
+    )
+    tl.device_assert(total_tiles > 0, "total_tiles <= 0")
+
+    tile = tl.program_id(0).to(INT_TYPE)
+    tl.device_assert(tile < total_tiles, "tile >= total_tiles")
+
+    while tile < total_tiles:
+        g, m, num_m_tiles, last_m, tile_in_mm = _resolve_gmm_tile(
+            group_sizes_ptr,
+            tile,
+            G,
+            num_n_tiles,
+            BLOCK_SIZE_G=BLOCK_SIZE_G,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            INT_TYPE=INT_TYPE,
+        )
+        _process_gmm_tile(
+            # Tensor pointers:
+            lhs_ptr,
+            rhs_ptr,
+            out_ptr,
+            bias_ptr,
+            # Tensor shapes:
+            K,
+            N,
+            # Tile arguments:
+            g,
+            m,
+            num_m_tiles,
+            num_n_tiles,
+            tile_in_mm,
+            last_m,
+            # Meta-parameters:
+            TRANS_RHS=TRANS_RHS,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            K_DIVISIBLE_BY_BLOCK_SIZE_K=K_DIVISIBLE_BY_BLOCK_SIZE_K,
+            GROUP_SIZE=GROUP_SIZE,
+            USE_BIAS=USE_BIAS,
+        )
+        tile = tl.atomic_add(tile_counter_ptr, 1, sem="relaxed").to(INT_TYPE)
+
+
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_G": lambda META: triton.next_power_of_2(META["G"]),
+        "K_DIVISIBLE_BY_BLOCK_SIZE_K": lambda META: META["K"] % META["BLOCK_SIZE_K"]
+        == 0,
+    }
+)
+@triton.jit
+def gmm_kernel(
+    # Tensor pointers:
+    lhs_ptr,
+    rhs_ptr,
+    group_sizes_ptr,
+    out_ptr,
+    bias_ptr,
+    tile_counter_ptr,
+    # Tensor shapes:
+    M: int,
+    K: int,
+    N: int,
+    G: int,
+    # Meta-parameters:
+    TRANS_RHS: tl.constexpr,
+    BLOCK_SIZE_G: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    K_DIVISIBLE_BY_BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    GRID_DIM: tl.constexpr,
+    USE_BIAS: tl.constexpr,
+    WORK_STEALING: tl.constexpr,
+):
+    tl.assume(M > 0)
+    tl.assume(K > 0)
+    tl.assume(N > 0)
+    tl.assume(G > 0)
+
+    INT_TYPE: tl.constexpr = group_sizes_ptr.type.element_ty
+
+    num_n_tiles = tl.cdiv(N, BLOCK_SIZE_N).to(INT_TYPE)
+    tl.device_assert(num_n_tiles > 0, "num_n_tiles <= 0")
+
+    if WORK_STEALING:
+        _work_stealing_gmm(
+            # Tensor pointers:
+            lhs_ptr,
+            rhs_ptr,
+            group_sizes_ptr,
+            out_ptr,
+            bias_ptr,
+            tile_counter_ptr,
+            # Tensor shapes:
+            K,
+            N,
+            G,
+            num_n_tiles,
+            # Meta-parameters:
+            TRANS_RHS=TRANS_RHS,
+            BLOCK_SIZE_G=BLOCK_SIZE_G,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            K_DIVISIBLE_BY_BLOCK_SIZE_K=K_DIVISIBLE_BY_BLOCK_SIZE_K,
+            GROUP_SIZE=GROUP_SIZE,
+            USE_BIAS=USE_BIAS,
+            INT_TYPE=INT_TYPE,
+        )
+    else:
+        _gmm(
+            # Tensor pointers:
+            lhs_ptr,
+            rhs_ptr,
+            group_sizes_ptr,
+            out_ptr,
+            bias_ptr,
+            # Tensor shapes:
+            M,
+            K,
+            N,
+            G,
+            num_n_tiles,
+            # Meta-parameters:
+            TRANS_RHS=TRANS_RHS,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            K_DIVISIBLE_BY_BLOCK_SIZE_K=K_DIVISIBLE_BY_BLOCK_SIZE_K,
+            GROUP_SIZE=GROUP_SIZE,
+            GRID_DIM=GRID_DIM,
+            USE_BIAS=USE_BIAS,
+            INT_TYPE=INT_TYPE,
+        )
 
 
 # Persistent TGMM kernel.

--- a/aiter/ops/triton/configs/gfx950-GMM.json
+++ b/aiter/ops/triton/configs/gfx950-GMM.json
@@ -4,10 +4,10 @@
             "BLOCK_SIZE_M": 256,
             "BLOCK_SIZE_K": 64,
             "BLOCK_SIZE_N": 256,
-            "GROUP_SIZE": 1,
+            "GROUP_SIZE": 4,
             "GRID_DIM": 256,
-            "num_warps": 8,
-            "num_stages": 1
+            "num_warps": 4,
+            "num_stages": 2
         }
     },
     "ptgmm": {

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -48,6 +48,10 @@ def _gmm_grid(
     block_size_n: int,
     group_sizes: Tensor,
     grid_dim: int,
+    # It might be interesting to enable expensive assertions, that rely on GPU
+    # kernels to process group_sizes, in development time. These extra kernels
+    # harm the wrapper performance in production.
+    enable_expensive_assertions: bool = False,
 ) -> tuple[int]:
     assert N > 0, f"N must be positive, it's {N}."
     assert is_power_of_2(
@@ -56,15 +60,24 @@ def _gmm_grid(
     assert is_power_of_2(
         block_size_n
     ), f"N-dimension tile size must be a power of 2 (it's {block_size_n})."
-    assert torch.all(group_sizes >= 0).item(), "All group_sizes must be non-negative."
+    if enable_expensive_assertions:
+        assert torch.all(
+            group_sizes >= 0
+        ).item(), "All group_sizes must be non-negative."
     assert grid_dim > 0, f"Grid dimension must be positive (it's {grid_dim})."
-    num_m_tiles = (group_sizes + block_size_m - 1) // block_size_m
-    assert torch.all(num_m_tiles >= 0).item(), "All num_m_tiles must be non-negative."
+    if enable_expensive_assertions:
+        num_m_tiles = (group_sizes + block_size_m - 1) // block_size_m
+        assert torch.all(
+            num_m_tiles >= 0
+        ).item(), "All num_m_tiles must be non-negative."
     num_n_tiles = triton.cdiv(N, block_size_n)
     assert num_n_tiles > 0, f"num_n_tiles must be positive, it's {num_n_tiles}."
-    num_tiles = torch.sum(num_m_tiles * num_n_tiles).item()
-    assert num_tiles > 0, f"num_tiles must be positive, it's {num_tiles}."
-    num_programs = int(min(grid_dim, num_tiles))
+    if enable_expensive_assertions:
+        num_tiles = torch.sum(num_m_tiles * num_n_tiles).item()
+        assert num_tiles > 0, f"num_tiles must be positive, it's {num_tiles}."
+        num_programs = int(min(grid_dim, num_tiles))
+    else:
+        num_programs = grid_dim
     assert num_programs > 0, f"num_programs must be positive, it's {num_programs}."
     return (num_programs,)
 

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -48,9 +48,8 @@ def _gmm_grid(
     block_size_n: int,
     group_sizes: Tensor,
     grid_dim: int,
-    # It might be interesting to enable expensive assertions, that rely on GPU
-    # kernels to process group_sizes, in development time. These extra kernels
-    # harm the wrapper performance in production.
+    # Expensive assertions launch GPU kernels on `group_sizes` and dominate the
+    # host-side launch cost. Only enable them in development.
     enable_expensive_assertions: bool = False,
 ) -> tuple[int]:
     assert N > 0, f"N must be positive, it's {N}."
@@ -60,24 +59,26 @@ def _gmm_grid(
     assert is_power_of_2(
         block_size_n
     ), f"N-dimension tile size must be a power of 2 (it's {block_size_n})."
+    assert grid_dim > 0, f"Grid dimension must be positive (it's {grid_dim})."
+    num_n_tiles = triton.cdiv(N, block_size_n)
+    assert num_n_tiles > 0, f"num_n_tiles must be positive, it's {num_n_tiles}."
+
+    # Cheap-path default. The kernel handle the case where grid_dim exceeds the
+    # total tile count: extra programs just exit without doing any work.
+    num_programs = grid_dim
+
     if enable_expensive_assertions:
         assert torch.all(
             group_sizes >= 0
         ).item(), "All group_sizes must be non-negative."
-    assert grid_dim > 0, f"Grid dimension must be positive (it's {grid_dim})."
-    if enable_expensive_assertions:
         num_m_tiles = (group_sizes + block_size_m - 1) // block_size_m
         assert torch.all(
             num_m_tiles >= 0
         ).item(), "All num_m_tiles must be non-negative."
-    num_n_tiles = triton.cdiv(N, block_size_n)
-    assert num_n_tiles > 0, f"num_n_tiles must be positive, it's {num_n_tiles}."
-    if enable_expensive_assertions:
         num_tiles = torch.sum(num_m_tiles * num_n_tiles).item()
         assert num_tiles > 0, f"num_tiles must be positive, it's {num_tiles}."
         num_programs = int(min(grid_dim, num_tiles))
-    else:
-        num_programs = grid_dim
+
     assert num_programs > 0, f"num_programs must be positive, it's {num_programs}."
     return (num_programs,)
 

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -42,6 +42,22 @@ from aiter.ops.triton._triton_kernels.gmm import (
 # ------------------------------------------------------------------------------
 
 
+# Per-(device, stream) cache for the work stealing tile counter. A single `int32`
+# scratch buffer is reused across launches to avoid an allocator round-trip plus
+# 4-byte host to device copy on every call.
+_GMM_TILE_COUNTER_CACHE: dict[tuple[torch.device, int], Tensor] = {}
+
+
+def _get_gmm_tile_counter(device: torch.device, grid_dim: int) -> Tensor:
+    stream = torch.cuda.current_stream(device=device).cuda_stream
+    tile_counter = _GMM_TILE_COUNTER_CACHE.get((device, stream))
+    if tile_counter is None:
+        tile_counter = torch.empty(1, dtype=torch.int32, device=device)
+        _GMM_TILE_COUNTER_CACHE[(device, stream)] = tile_counter
+    tile_counter.fill_(grid_dim)
+    return tile_counter
+
+
 def _gmm_grid(
     N: int,
     block_size_m: int,
@@ -238,10 +254,8 @@ def gmm(
         config["GRID_DIM"],
     )
 
-    tile_counter: torch.Tensor | None = (
-        torch.tensor((config["GRID_DIM"],), dtype=torch.int32, device=lhs.device)
-        if work_stealing
-        else None
+    tile_counter: Tensor | None = (
+        _get_gmm_tile_counter(lhs.device, config["GRID_DIM"]) if work_stealing else None
     )
 
     # fmt: off

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -224,6 +224,10 @@ def gmm(
         warnings.warn(
             f"Overriding GMM grid dim with {grid_dim} (it was {config['GRID_DIM']})."
         )
+        # Copy before mutating: when `config` comes from `get_config` it's the
+        # dict cached by `@functools.lru_cache`, so an in-place write would leak
+        # the override into subsequent calls.
+        config = dict(config)
         config["GRID_DIM"] = grid_dim
 
     grid = _gmm_grid(
@@ -432,6 +436,10 @@ def ptgmm(
         warnings.warn(
             f"Overriding PTGMM grid dim with {grid_dim} (it was {config['GRID_DIM']})."
         )
+        # Copy before mutating: when `config` comes from `get_config` it's the
+        # dict cached by `@functools.lru_cache`, so an in-place write would leak
+        # the override into subsequent calls.
+        config = dict(config)
         config["GRID_DIM"] = grid_dim
 
     # Bias gradient handling.

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -89,6 +89,7 @@ def gmm(
     bias: Tensor | None = None,
     preferred_element_type: torch.dtype = DTYPE,
     existing_out: Tensor | None = None,
+    work_stealing: bool = False,
     config: dict[str, int] | None = None,
     grid_dim: int | None = None,
 ) -> Tensor:
@@ -137,6 +138,9 @@ def gmm(
         allocated.
         If provided then it must have shape (M, N), its data type must match preferred_element_type
         and it must be on the same device of other input tensors.
+    work_stealing : bool, defaults to False
+        Enable work stealing, i.e. dynamic load-balancing where CUs with no assigned tiles "steal"
+        the next available tile to be computed.
     config : dict[str, int] or None, optional
         Optional dictionary with kernel metaparameters. If absent, config will be queried from
         internal tuning database.
@@ -229,15 +233,22 @@ def gmm(
         config["GRID_DIM"],
     )
 
+    tile_counter: torch.Tensor | None = (
+        torch.tensor((config["GRID_DIM"],), dtype=torch.int32, device=lhs.device)
+        if work_stealing
+        else None
+    )
+
     # fmt: off
     gmm_kernel[grid](
         # Tensor pointers:
-        lhs, rhs, group_sizes, out, bias,
+        lhs, rhs, group_sizes, out, bias, tile_counter,
         # Tensor shapes:
         M, K, N, G,
         # Meta-parameters:
         TRANS_RHS=trans_rhs,
         USE_BIAS=use_bias,
+        WORK_STEALING=work_stealing,
         **config,
     )
     # fmt: on

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -104,7 +104,8 @@ def gmm(
         rhs must be on the same device of lhs and group_sizes.
     group_sizes : torch.Tensor
         1D input tensor describing group sizes. Shape: (G,).
-        group_sizes data type must be torch.int32 and all its elements must be non-negative.
+        group_sizes data type must be torch.int32 or torch.int64, and all its elements must be
+        non-negative.
         group_sizes must be on the same device of lhs and rhs.
     preferred_element_type : torch.dtype, optional
         Desired data type for output tensor. Default is torch.bfloat16.
@@ -289,7 +290,8 @@ def ptgmm(
         rhs must be on the same device of lhs and group_sizes.
     group_sizes : torch.Tensor
         1D input tensor describing group sizes. Shape: (G,).
-        group_sizes data type must be torch.int32 and all its elements must be non-negative.
+        group_sizes data type must be torch.int32 or torch.int64, and all its elements must be
+        non-negative.
         group_sizes must be on the same device of lhs and rhs.
     preferred_element_type : torch.dtype, optional
         Desired data type for output tensor. Default is torch.bfloat16.
@@ -485,7 +487,8 @@ def nptgmm(
         rhs must be on the same device of lhs and group_sizes.
     group_sizes : torch.Tensor
         1D input tensor describing group sizes. Shape: (G,).
-        group_sizes data type must be torch.int32 and all its elements must be non-negative.
+        group_sizes data type must be torch.int32 or torch.int64, and all its elements must be
+        non-negative.
         group_sizes must be on the same device of lhs and rhs.
     preferred_element_type : torch.dtype, optional
         Desired data type for output tensor. Default is torch.bfloat16.

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -5,6 +5,9 @@
 # Imports.
 # ------------------------------------------------------------------------------
 
+# Python standard library
+import warnings
+
 # PyTorch
 import torch
 from torch import Tensor
@@ -70,10 +73,11 @@ def gmm(
     lhs: Tensor,
     rhs: Tensor,
     group_sizes: Tensor,
+    bias: Tensor | None = None,
     preferred_element_type: torch.dtype = DTYPE,
     existing_out: Tensor | None = None,
     config: dict[str, int] | None = None,
-    bias: Tensor | None = None,
+    grid_dim: int | None = None,
 ) -> Tensor:
     """
     Perform Group Matrix Multiplication (GMM): out = lhs @ rhs + bias
@@ -107,6 +111,10 @@ def gmm(
         group_sizes data type must be torch.int32 or torch.int64, and all its elements must be
         non-negative.
         group_sizes must be on the same device of lhs and rhs.
+    bias : torch.Tensor or None, optional
+        Optional bias tensor. Shape: (G, N).
+        If provided, bias data type must match lhs and rhs data type, and bias must be on the same
+        device as other input tensors. Each group g adds bias[g] to the output.
     preferred_element_type : torch.dtype, optional
         Desired data type for output tensor. Default is torch.bfloat16.
         Supported output types are torch.float16 and torch.bfloat16.
@@ -119,10 +127,10 @@ def gmm(
     config : dict[str, int] or None, optional
         Optional dictionary with kernel metaparameters. If absent, config will be queried from
         internal tuning database.
-    bias : torch.Tensor or None, optional
-        Optional bias tensor. Shape: (G, N).
-        If provided, bias data type must match lhs and rhs data type, and bias must be on the same
-        device as other input tensors. Each group g adds bias[g] to the output.
+    grid_dim : positive int or None, optional
+        Optional override for GRID_DIM config. It's useful to override it while doing performance
+        experiments or launching the GMM kernel in parallel with a comms kernel (reserve some CUs
+        for comms).
 
     Returns
     -------
@@ -190,6 +198,16 @@ def gmm(
         }
     ), "Invalid GMM kernel config."
 
+    # Override grid dimension, if optional argument is provided.
+    assert (grid_dim is None) or (
+        grid_dim > 0
+    ), f"Invalid grid dimension {grid_dim}. It must be None or a positive integer."
+    if grid_dim is not None and grid_dim != config["GRID_DIM"]:
+        warnings.warn(
+            f"Overriding GMM grid dim with {grid_dim} (it was {config['GRID_DIM']})."
+        )
+        config["GRID_DIM"] = grid_dim
+
     grid = _gmm_grid(
         N,
         config["BLOCK_SIZE_M"],
@@ -251,11 +269,12 @@ def ptgmm(
     lhs: Tensor,
     rhs: Tensor,
     group_sizes: Tensor,
+    bias_grad: Tensor | None = None,
     preferred_element_type: torch.dtype = DTYPE,
     existing_out: Tensor | None = None,
-    config: dict[str, int] | None = None,
-    bias_grad: Tensor | None = None,
     accumulate: bool = False,
+    config: dict[str, int] | None = None,
+    grid_dim: int | None = None,
 ) -> Tensor:
     """
     Perform a Group Matrix Multiplication (GMM) variant: out = lhs @ rhs
@@ -293,6 +312,10 @@ def ptgmm(
         group_sizes data type must be torch.int32 or torch.int64, and all its elements must be
         non-negative.
         group_sizes must be on the same device of lhs and rhs.
+    bias_grad : torch.Tensor or None, optional
+        Optional bias gradient output tensor. Shape: (G, K).
+        If provided, the kernel will compute the bias gradient and write it to this tensor.
+        bias_grad must be torch.float32 (kernel uses atomic_add which requires float32),
     preferred_element_type : torch.dtype, optional
         Desired data type for output tensor. Default is torch.bfloat16.
         Supported output types are torch.float16 and torch.bfloat16.
@@ -302,17 +325,17 @@ def ptgmm(
         allocated.
         If provided then it must have shape (G, K, N), its data type must match
         preferred_element_type and it must be on the same device of other input tensors.
-    config : dict[str, int] or None, optional
-        Optional dictionary with kernel metaparameters. If absent, config will be queried from
-        internal tuning database.
-    bias_grad : torch.Tensor or None, optional
-        Optional bias gradient output tensor. Shape: (G, K).
-        If provided, the kernel will compute the bias gradient and write it to this tensor.
-        bias_grad must be torch.float32 (kernel uses atomic_add which requires float32),
     accumulate : bool, optional
         Whether to accumulate into existing output tensor values. Default is False.
         If False, output will be overwritten with fresh computation.
         If True, results will be added to existing output tensor values.
+    config : dict[str, int] or None, optional
+        Optional dictionary with kernel metaparameters. If absent, config will be queried from
+        internal tuning database.
+    grid_dim : positive int or None, optional
+        Optional override for GRID_DIM config. It's useful to override it while doing performance
+        experiments or launching the persistent TGMM kernel in parallel with a comms kernel (reserve
+        some CUs for comms).
 
     Returns
     -------
@@ -375,6 +398,16 @@ def ptgmm(
             "GRID_DIM",
         }
     ), "Invalid PTGMM kernel config."
+
+    # Override grid dimension, if optional argument is provided.
+    assert (grid_dim is None) or (
+        grid_dim > 0
+    ), f"Invalid grid dimension {grid_dim}. It must be None or a positive integer."
+    if grid_dim is not None and grid_dim != config["GRID_DIM"]:
+        warnings.warn(
+            f"Overriding PTGMM grid dim with {grid_dim} (it was {config['GRID_DIM']})."
+        )
+        config["GRID_DIM"] = grid_dim
 
     # Bias gradient handling.
     # -----------------------
@@ -448,11 +481,11 @@ def nptgmm(
     lhs: Tensor,
     rhs: Tensor,
     group_sizes: Tensor,
+    bias_grad: Tensor | None = None,
     preferred_element_type: torch.dtype = DTYPE,
     existing_out: Tensor | None = None,
-    config: dict[str, int] | None = None,
-    bias_grad: Tensor | None = None,
     accumulate: bool = False,
+    config: dict[str, int] | None = None,
 ) -> Tensor:
     """
     Perform a Group Matrix Multiplication (GMM) variant: out = lhs @ rhs
@@ -490,6 +523,10 @@ def nptgmm(
         group_sizes data type must be torch.int32 or torch.int64, and all its elements must be
         non-negative.
         group_sizes must be on the same device of lhs and rhs.
+    bias_grad : torch.Tensor or None, optional
+        Optional bias gradient output tensor. Shape: (G, K).
+        If provided, the kernel will compute the bias gradient and write it to this tensor.
+        bias_grad must be torch.float32 (kernel uses atomic_add which requires float32),
     preferred_element_type : torch.dtype, optional
         Desired data type for output tensor. Default is torch.bfloat16.
         Supported output types are torch.float16 and torch.bfloat16.
@@ -499,17 +536,13 @@ def nptgmm(
         allocated.
         If provided then it must have shape (G, K, N), its data type must match
         preferred_element_type and it must be on the same device of other input tensors.
-    config : dict[str, int] or None, optional
-        Optional dictionary with kernel metaparameters. If absent, config will be queried from
-        internal tuning database.
-    bias_grad : torch.Tensor or None, optional
-        Optional bias gradient output tensor. Shape: (G, K).
-        If provided, the kernel will compute the bias gradient and write it to this tensor.
-        bias_grad must be torch.float32 (kernel uses atomic_add which requires float32),
     accumulate : bool, optional
         Whether to accumulate into existing output tensor values. Default is False.
         If False, output will be overwritten with fresh computation.
         If True, results will be added to existing output tensor values.
+    config : dict[str, int] or None, optional
+        Optional dictionary with kernel metaparameters. If absent, config will be queried from
+        internal tuning database.
 
     Returns
     -------

--- a/aiter/ops/triton/gmm.py
+++ b/aiter/ops/triton/gmm.py
@@ -96,7 +96,10 @@ def gmm(
         lhs data type must be torch.float16 or torch.bfloat16, and must match rhs data type.
         lhs must be on the same device of rhs and group_sizes.
     rhs : torch.Tensor
-        Right-hand side 3D input tensor. Shape: (G, K, N).
+        Right-hand side 3D input tensor. Shape is (G, K, N) when rhs is non-transposed. When rhs is
+        transposed, two physically equivalent metadata layouts are supported: shape (G, K, N) with a
+        column-major-like stride, and shape (G, N, K) with a row-major stride. See Implementation
+        Notes below for the supported (shape, stride) combinations.
         rhs data type must be torch.float16 or torch.bfloat16, and must match lhs data type.
         rhs must be on the same device of lhs and group_sizes.
     group_sizes : torch.Tensor
@@ -131,11 +134,20 @@ def gmm(
     --------------------
     - GMM is implemented with a persistent Triton kernel.
     - lhs must be row-major (lhs.stride() == (K, 1)).
-    - rhs can be row-major (rhs.stride() == (K * N, N, 1)) or column-major (rhs.stride() ==
-      (K * N, 1, K)). If rhs is row-major then kernel parameter TRANS_RHS == False, this is useful
-      for implementing forward pass. If rhs is column-major then kernel parameter TRANS_RHS == True,
-      this is useful for computing the lhs derivative in the backward pass, while fusing the
-      transposition.
+    - rhs supports three storage layouts. The two transposed layouts are physically
+      equivalent (same memory ordering, K varies fastest, then N, then G); only the
+      tensor metadata (shape and stride) differs. Both transposed layouts select
+      kernel parameter TRANS_RHS == True and produce identical byte offsets in the
+      kernel's pointer arithmetic, so they execute the same code:
+        * Non-transposed: shape (G, K, N), stride (K*N, N, 1). Kernel parameter
+          TRANS_RHS == False. Useful for the forward pass.
+        * Transposed (layout 1): shape (G, K, N), stride (K*N, 1, K). Kernel parameter
+          TRANS_RHS == True. The (K, N) sub-matrix per group is column-major.
+        * Transposed (layout 2): shape (G, N, K), stride (K*N, K, 1). Kernel parameter
+          TRANS_RHS == True. The (N, K) sub-matrix per group is row-major.
+      Both transposed layouts are useful for computing the lhs derivative in the
+      backward pass while fusing the transposition. The choice between layout 1 and
+      layout 2 is purely a metadata preference of the calling code.
     - out must be row-major (out.stride() == (N, 1)).
     - bias must be row-major (bias.stride() == (N, 1)) if provided.
     """
@@ -265,7 +277,10 @@ def ptgmm(
     Parameters
     ----------
     lhs : torch.Tensor
-        Left-hand side 2D input tensor. Shape: (K, M).
+        Left-hand side 2D input tensor. Shape is (K, M) when lhs is non-transposed. When lhs is
+        transposed, two physically equivalent metadata layouts are supported: shape (K, M) with a
+        column-major stride, and shape (M, K) with a row-major stride. See Implementation Notes
+        below for the supported (shape, stride) combinations.
         lhs data type must be torch.float16 or torch.bfloat16, and must match rhs data type.
         lhs must be on the same device of rhs and group_sizes.
     rhs : torch.Tensor
@@ -307,10 +322,20 @@ def ptgmm(
     Implementation Notes
     --------------------
     - PTGMM is implemented with a persistent Triton kernel.
-    - lhs can be row-major (lhs.stride() == (M, 1)) or column-major (lhs.stride() == (1, K)). If lhs
-      is row-major then kernel parameter TRANS_LHS == False. If lhs is column-major then kernel
-      parameter TRANS_LHS == True, this is useful for computing the rhs derivative in the backward
-      pass, while fusing the transposition.
+    - lhs supports three storage layouts. The two transposed layouts are physically
+      equivalent (same memory ordering, K varies fastest, then M); only the tensor
+      metadata (shape and stride) differs. Both transposed layouts select kernel
+      parameter TRANS_LHS == True and produce identical byte offsets in the kernel's
+      pointer arithmetic, so they execute the same code:
+        * Non-transposed: shape (K, M), stride (M, 1). Kernel parameter
+          TRANS_LHS == False.
+        * Transposed (layout 1): shape (K, M), stride (1, K). Kernel parameter
+          TRANS_LHS == True. lhs is column-major.
+        * Transposed (layout 2): shape (M, K), stride (K, 1). Kernel parameter
+          TRANS_LHS == True. lhs is row-major over the swapped shape.
+      Both transposed layouts are useful for computing the rhs derivative in the
+      backward pass while fusing the transposition. The choice between layout 1 and
+      layout 2 is purely a metadata preference of the calling code.
     - rhs must be row-major (rhs.stride() == (N, 1)).
     - out must be row-major (out.stride() == (K * N, N, 1)).
     """
@@ -448,7 +473,10 @@ def nptgmm(
     Parameters
     ----------
     lhs : torch.Tensor
-        Left-hand side 2D input tensor. Shape: (K, M).
+        Left-hand side 2D input tensor. Shape is (K, M) when lhs is non-transposed. When lhs is
+        transposed, two physically equivalent metadata layouts are supported: shape (K, M) with a
+        column-major stride, and shape (M, K) with a row-major stride. See Implementation Notes
+        below for the supported (shape, stride) combinations.
         lhs data type must be torch.float16 or torch.bfloat16, and must match rhs data type.
         lhs must be on the same device of rhs and group_sizes.
     rhs : torch.Tensor
@@ -490,10 +518,20 @@ def nptgmm(
     Implementation Notes
     --------------------
     - NPTGMM is implemented with a non-persistent regular Triton kernel.
-    - lhs can be row-major (lhs.stride() == (M, 1)) or column-major (lhs.stride() == (1, K)). If lhs
-      is row-major then kernel parameter TRANS_LHS == False. If lhs is column-major then kernel
-      parameter TRANS_LHS == True, this is useful for computing the rhs derivative in the backward
-      pass, while fusing the transposition.
+    - lhs supports three storage layouts. The two transposed layouts are physically
+      equivalent (same memory ordering, K varies fastest, then M); only the tensor
+      metadata (shape and stride) differs. Both transposed layouts select kernel
+      parameter TRANS_LHS == True and produce identical byte offsets in the kernel's
+      pointer arithmetic, so they execute the same code:
+        * Non-transposed: shape (K, M), stride (M, 1). Kernel parameter
+          TRANS_LHS == False.
+        * Transposed (layout 1): shape (K, M), stride (1, K). Kernel parameter
+          TRANS_LHS == True. lhs is column-major.
+        * Transposed (layout 2): shape (M, K), stride (K, 1). Kernel parameter
+          TRANS_LHS == True. lhs is row-major over the swapped shape.
+      Both transposed layouts are useful for computing the rhs derivative in the
+      backward pass while fusing the transposition. The choice between layout 1 and
+      layout 2 is purely a metadata preference of the calling code.
     - rhs must be row-major (rhs.stride() == (N, 1)).
     - out must be row-major (out.stride() == (K * N, N, 1)).
     """

--- a/aiter/ops/triton/utils/_triton/pid_preprocessing.py
+++ b/aiter/ops/triton/utils/_triton/pid_preprocessing.py
@@ -34,7 +34,8 @@ def remap_xcd(pid, GRID_MN, NUM_XCDS: tl.constexpr = 8):
     # We calculate the number of xcds that have pids_per_xcd pids as
     # tall_xcds
     tall_xcds = GRID_MN % NUM_XCDS
-    tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+    if tall_xcds == 0:
+        tall_xcds = tl.cast(NUM_XCDS, tall_xcds.type)
     # Compute current XCD and local pid within the XCD
     xcd = pid % NUM_XCDS
     local_pid = pid // NUM_XCDS

--- a/aiter/ops/triton/utils/gmm_common.py
+++ b/aiter/ops/triton/utils/gmm_common.py
@@ -56,6 +56,55 @@ assert (
 DTYPE: torch.dtype = dtype_from_str(DTYPE_STR)
 
 
+# Supported integer data types for group sizes tensor.
+# ------------------------------------------------------------------------------
+
+# Supported group sizes data types, as strings.
+SUPPORTED_GROUP_SIZES_DTYPES_STR: set[str] = {"int32", "int64"}
+
+
+# Convert string data type to PyTorch data type.
+def group_sizes_dtype_from_str(dtype_str: str) -> torch.dtype:
+    dtype_str = dtype_str.strip().lower()
+    assert (
+        dtype_str in SUPPORTED_GROUP_SIZES_DTYPES_STR
+    ), "String data type isn't in set of supported string data types."
+    return {"int32": torch.int32, "int64": torch.int64}[dtype_str]
+
+
+# Supported data types, as PyTorch types.
+SUPPORTED_GROUP_SIZES_DTYPES: set[torch.dtype] = {
+    group_sizes_dtype_from_str(dtype_str)
+    for dtype_str in SUPPORTED_GROUP_SIZES_DTYPES_STR
+}
+
+
+# Convert PyTorch data type to string data type.
+def str_from_group_sizes_dtype(dtype: torch.dtype) -> str:
+    assert (
+        dtype in SUPPORTED_GROUP_SIZES_DTYPES
+    ), "PyTorch data type isn't in set of supported PyTorch data types."
+    return {torch.int32: "int32", torch.int64: "int64"}[dtype]
+
+
+# Default data type, as string.
+GROUP_SIZES_DTYPE_STR: str = "int32"
+assert (
+    GROUP_SIZES_DTYPE_STR in SUPPORTED_GROUP_SIZES_DTYPES_STR
+), "Default string data type isn't in set of supported string data types."
+
+
+# Default data type, as PyTorch type.
+GROUP_SIZES_DTYPE: torch.dtype = group_sizes_dtype_from_str(GROUP_SIZES_DTYPE_STR)
+
+
+def check_group_sizes_dtype(dtype: torch.dtype) -> None:
+    assert dtype in SUPPORTED_GROUP_SIZES_DTYPES, (
+        f"group_sizes data type must be one of {SUPPORTED_GROUP_SIZES_DTYPES}, "
+        f"got {dtype}."
+    )
+
+
 # Other defaults.
 # ------------------------------------------------------------------------------
 
@@ -90,7 +139,7 @@ def check_input_device_dtype(
     assert (
         lhs.dtype == rhs.dtype
     ), f"lhs and rhs types must match (lhs = {lhs.dtype}, rhs = {rhs.dtype})."
-    assert group_sizes.dtype == torch.int32, "group_sizes type must be int32."
+    check_group_sizes_dtype(group_sizes.dtype)
 
     if bias is not None:
         assert (
@@ -121,14 +170,16 @@ UNUSED_EXPERTS_PROB: float = 0.1
 def gen_uniform_group_sizes(
     M: int,
     G: int,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
     device: torch.device | str = DEVICE,
 ) -> Tensor:
     assert M >= 0, f"Number of tokens M must be non-negative (it's {M})."
     assert G > 0, f"Number of experts G must be positive (it's {G})."
+    check_group_sizes_dtype(group_sizes_dtype)
 
     base = M // G
     remainder = M % G
-    group_sizes = torch.full((G,), base, dtype=torch.int32, device=device)
+    group_sizes = torch.full((G,), base, dtype=group_sizes_dtype, device=device)
     if remainder > 0:
         group_sizes[:remainder] += 1
 
@@ -139,7 +190,9 @@ def gen_uniform_group_sizes(
     assert (
         torch.sum(group_sizes).item() == M
     ), f"Group sizes don't add up to total tokens {M}."
-    assert group_sizes.dtype == torch.int32, "Group sizes must be int32."
+    assert (
+        group_sizes.dtype == group_sizes_dtype
+    ), f"Group sizes must be {group_sizes_dtype} (it's {group_sizes.dtype})."
 
     return group_sizes
 
@@ -147,6 +200,7 @@ def gen_uniform_group_sizes(
 def gen_group_sizes(
     M: int,
     G: int,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
     device: torch.device | str = DEVICE,
     rng_seed: int | None = RNG_SEED,
     unused_tokens_prob: float = UNUSED_TOKENS_PROB,
@@ -160,6 +214,7 @@ def gen_group_sizes(
     assert (
         0 <= unused_experts_prob <= 1
     ), f"Probability of unused experts must be in [0, 1] interval (it's {unused_experts_prob})."
+    check_group_sizes_dtype(group_sizes_dtype)
 
     if rng_seed is not None:
         torch.manual_seed(rng_seed)
@@ -224,7 +279,7 @@ def gen_group_sizes(
             torch.randint(low=0, high=num_used_experts, size=(num_used_tokens,))
         ],
         minlength=G,
-    ).to(torch.int32)
+    ).to(group_sizes_dtype)
 
     assert (
         len(group_sizes) == G
@@ -233,7 +288,9 @@ def gen_group_sizes(
     assert (
         torch.sum(group_sizes).item() == num_used_tokens
     ), f"Group sizes don't add up to used tokens {num_used_tokens}."
-    assert group_sizes.dtype == torch.int32, "Group sizes must be int32."
+    assert (
+        group_sizes.dtype == group_sizes_dtype
+    ), f"Group sizes must be {group_sizes_dtype} (it's {group_sizes.dtype})."
 
     return group_sizes
 
@@ -242,6 +299,7 @@ def gen_multiple_group_sizes(
     num_group_sizes: int,
     M: int,
     G: int,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
     device: torch.device | str = DEVICE,
     rng_seed: int | None = RNG_SEED,
     unused_tokens_prob: float = UNUSED_TOKENS_PROB,
@@ -251,10 +309,17 @@ def gen_multiple_group_sizes(
     assert (
         num_group_sizes > 0
     ), f"Number of group sizes to be generated must be positive, it's {num_group_sizes}."
+    check_group_sizes_dtype(group_sizes_dtype)
+    if group_sizes_0 is not None:
+        assert group_sizes_0.dtype == group_sizes_dtype, (
+            f"group_sizes_0 dtype ({group_sizes_0.dtype}) must match requested "
+            f"group_sizes_dtype ({group_sizes_dtype})."
+        )
     multiple_group_sizes = [
         gen_group_sizes(
             M,
             G,
+            group_sizes_dtype=group_sizes_dtype,
             device=device,
             rng_seed=rng_seed if g == 0 else None,
             unused_tokens_prob=unused_tokens_prob,
@@ -281,8 +346,9 @@ def gen_gmm_input(
     K: int,
     N: int,
     G: int,
-    device: torch.device | str = DEVICE,
     preferred_element_type: torch.dtype = DTYPE,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
+    device: torch.device | str = DEVICE,
     trans_rhs: bool = TRANS_RHS,
     alt_trans: bool = False,
     rng_seed: int | None = RNG_SEED,
@@ -292,6 +358,7 @@ def gen_gmm_input(
     assert K > 0, f"Number of lhs columns / rhs rows K must be positive (K = {K})."
     assert N > 0, f"Number of rhs columns N must be positive (N = {N})."
     assert G > 0, f"Number of groups G must be positive (G = {G})."
+    check_group_sizes_dtype(group_sizes_dtype)
 
     if rng_seed is not None:
         torch.manual_seed(rng_seed)
@@ -320,9 +387,20 @@ def gen_gmm_input(
     rhs = rhs.to(preferred_element_type)
 
     group_sizes = (
-        gen_uniform_group_sizes(M, G, device=device)
+        gen_uniform_group_sizes(
+            M,
+            G,
+            group_sizes_dtype=group_sizes_dtype,
+            device=device,
+        )
         if unif_group_sizes
-        else gen_group_sizes(M, G, device=device, rng_seed=None)
+        else gen_group_sizes(
+            M,
+            G,
+            group_sizes_dtype=group_sizes_dtype,
+            device=device,
+            rng_seed=None,
+        )
     )
 
     return lhs, rhs, group_sizes
@@ -331,8 +409,8 @@ def gen_gmm_input(
 def gen_gmm_output(
     M: int,
     N: int,
-    device: torch.device | str = DEVICE,
     preferred_element_type: torch.dtype = DTYPE,
+    device: torch.device | str = DEVICE,
 ) -> Tensor:
     assert M > 0, f"Number of out rows M must be positive (M = {M})."
     assert N > 0, f"Number of out columns N must be positive (N = {N})."
@@ -348,9 +426,10 @@ def gen_gmm_tensors(
     N: int,
     G: int,
     num_group_sizes: int,
-    device: torch.device | str = DEVICE,
     input_type: torch.dtype = DTYPE,
     output_type: torch.dtype = DTYPE,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
+    device: torch.device | str = DEVICE,
     trans_lhs: bool = False,
     trans_rhs: bool = TRANS_RHS,
     alt_trans: bool = False,
@@ -363,17 +442,24 @@ def gen_gmm_tensors(
         K,
         N,
         G,
-        device=device,
         preferred_element_type=input_type,
+        group_sizes_dtype=group_sizes_dtype,
+        device=device,
         trans_rhs=trans_rhs,
         alt_trans=alt_trans,
         rng_seed=rng_seed,
         unif_group_sizes=unif_group_sizes,
     )
     multiple_group_sizes = gen_multiple_group_sizes(
-        num_group_sizes, M, G, device=device, rng_seed=None, group_sizes_0=group_sizes_0
+        num_group_sizes,
+        M,
+        G,
+        group_sizes_dtype=group_sizes_dtype,
+        device=device,
+        rng_seed=None,
+        group_sizes_0=group_sizes_0,
     )
-    out = gen_gmm_output(M, N, device=device, preferred_element_type=output_type)
+    out = gen_gmm_output(M, N, preferred_element_type=output_type, device=device)
     bias = None
     if use_bias:
         torch.manual_seed(rng_seed + 1000)  # Different seed for bias
@@ -547,8 +633,9 @@ def gen_tgmm_input(
     K: int,
     N: int,
     G: int,
-    device: torch.device | str = DEVICE,
     preferred_element_type: torch.dtype = DTYPE,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
+    device: torch.device | str = DEVICE,
     trans_lhs: bool = TRANS_LHS,
     alt_trans: bool = False,
     rng_seed: int | None = RNG_SEED,
@@ -558,6 +645,7 @@ def gen_tgmm_input(
     assert M > 0, f"Number of lhs columns / rhs rows M must be positive (K = {M})."
     assert N > 0, f"Number of rhs columns N must be positive (N = {N})."
     assert G > 0, f"Number of groups G must be positive (G = {G})."
+    check_group_sizes_dtype(group_sizes_dtype)
 
     if rng_seed is not None:
         torch.manual_seed(rng_seed)
@@ -583,9 +671,20 @@ def gen_tgmm_input(
     rhs = rhs.to(preferred_element_type)
 
     group_sizes = (
-        gen_uniform_group_sizes(M, G, device=device)
+        gen_uniform_group_sizes(
+            M,
+            G,
+            group_sizes_dtype=group_sizes_dtype,
+            device=device,
+        )
         if unif_group_sizes
-        else gen_group_sizes(M, G, device=device, rng_seed=None)
+        else gen_group_sizes(
+            M,
+            G,
+            group_sizes_dtype=group_sizes_dtype,
+            device=device,
+            rng_seed=None,
+        )
     )
 
     return lhs, rhs, group_sizes
@@ -595,8 +694,8 @@ def gen_tgmm_output(
     K: int,
     N: int,
     G: int,
-    device: torch.device | str = DEVICE,
     preferred_element_type: torch.dtype = DTYPE,
+    device: torch.device | str = DEVICE,
 ) -> Tensor:
     assert K > 0, f"Number of out rows K must be positive (K = {K})."
     assert N > 0, f"Number of out columns N must be positive (N = {N})."
@@ -630,9 +729,10 @@ def gen_tgmm_tensors(
     N: int,
     G: int,
     num_group_sizes: int,
-    device: torch.device | str = DEVICE,
     input_type: torch.dtype = DTYPE,
     output_type: torch.dtype = DTYPE,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
+    device: torch.device | str = DEVICE,
     trans_lhs: bool = TRANS_LHS,
     trans_rhs: bool = False,
     alt_trans: bool = False,
@@ -645,17 +745,24 @@ def gen_tgmm_tensors(
         K,
         N,
         G,
-        device=device,
         preferred_element_type=input_type,
+        group_sizes_dtype=group_sizes_dtype,
+        device=device,
         trans_lhs=trans_lhs,
         alt_trans=alt_trans,
         rng_seed=rng_seed,
         unif_group_sizes=unif_group_sizes,
     )
     multiple_group_sizes = gen_multiple_group_sizes(
-        num_group_sizes, M, G, device=device, rng_seed=None, group_sizes_0=group_sizes_0
+        num_group_sizes,
+        M,
+        G,
+        group_sizes_dtype=group_sizes_dtype,
+        device=device,
+        rng_seed=None,
+        group_sizes_0=group_sizes_0,
     )
-    out = gen_tgmm_output(K, N, G, device=device, preferred_element_type=output_type)
+    out = gen_tgmm_output(K, N, G, preferred_element_type=output_type, device=device)
     if use_bias:
         bias_grad = gen_tgmm_bias_grad(K, G, device=device, with_bias_grad=True)
     else:

--- a/aiter/ops/triton/utils/gmm_common.py
+++ b/aiter/ops/triton/utils/gmm_common.py
@@ -284,6 +284,7 @@ def gen_gmm_input(
     device: torch.device | str = DEVICE,
     preferred_element_type: torch.dtype = DTYPE,
     trans_rhs: bool = TRANS_RHS,
+    alt_trans: bool = False,
     rng_seed: int | None = RNG_SEED,
     unif_group_sizes: bool = False,
 ) -> tuple[Tensor, Tensor, Tensor]:
@@ -299,10 +300,22 @@ def gen_gmm_input(
     lhs = lhs.to(preferred_element_type)
 
     if trans_rhs:
-        rhs = torch.randn((G, N, K), dtype=torch.float32, device=device).permute(
-            0, 2, 1
-        )
+        # Two physically equivalent transposed layouts are supported. They share the
+        # same memory ordering (K varies fastest, then N, then G); only the tensor
+        # metadata (shape/stride) differs.
+        if alt_trans:
+            # Transposed layout 2: shape (G, N, K), stride (K*N, K, 1). The (N, K)
+            # sub-matrix per group is row-major.
+            rhs = torch.randn((G, N, K), dtype=torch.float32, device=device)
+        else:
+            # Transposed layout 1: shape (G, K, N), stride (K*N, 1, K). The (K, N)
+            # sub-matrix per group is column-major.
+            rhs = torch.randn((G, N, K), dtype=torch.float32, device=device).permute(
+                0, 2, 1
+            )
     else:
+        # alt_trans is ignored when trans_rhs is False; only the non-transposed
+        # row-major layout is supported in that case.
         rhs = torch.randn((G, K, N), dtype=torch.float32, device=device)
     rhs = rhs.to(preferred_element_type)
 
@@ -340,6 +353,7 @@ def gen_gmm_tensors(
     output_type: torch.dtype = DTYPE,
     trans_lhs: bool = False,
     trans_rhs: bool = TRANS_RHS,
+    alt_trans: bool = False,
     rng_seed: int | None = RNG_SEED,
     unif_group_sizes: bool = False,
     use_bias: bool = False,
@@ -352,6 +366,7 @@ def gen_gmm_tensors(
         device=device,
         preferred_element_type=input_type,
         trans_rhs=trans_rhs,
+        alt_trans=alt_trans,
         rng_seed=rng_seed,
         unif_group_sizes=unif_group_sizes,
     )
@@ -381,13 +396,27 @@ def get_gmm_shape(
     ), f"group_sizes must have 1 dimension (it's {group_sizes.dim()})."
 
     M, lhs_k = lhs.shape
-    rhs_g, rhs_k, N = rhs.shape
+    # rhs supports three layouts (see gmm() docstring):
+    #   * Non-transposed:        shape (G, K, N), stride (K*N, N, 1).
+    #   * Transposed (layout 1): shape (G, K, N), stride (K*N, 1, K).
+    #   * Transposed (layout 2): shape (G, N, K), stride (K*N, K, 1).
+    # Non-transposed and transposed layout 1 share shape (G, K, N), so K is taken
+    # from lhs to disambiguate which dimension of rhs is N.
+    rhs_g, rhs_d1, rhs_d2 = rhs.shape
+    K = lhs_k
+    if rhs_d1 == K:
+        # Either non-transposed or transposed layout 1: shape (G, K, N).
+        N = rhs_d2
+    elif rhs_d2 == K:
+        # Transposed layout 2: shape (G, N, K).
+        N = rhs_d1
+    else:
+        raise AssertionError(
+            f"rhs shape {tuple(rhs.shape)} doesn't match K = {K} from lhs"
+            f" (expected (G, K, N) or (G, N, K))."
+        )
     group_sizes_g = group_sizes.shape[0]
 
-    assert (
-        lhs_k == rhs_k
-    ), f"K dimension of lhs and rhs don't match (lhs = {lhs_k}, rhs = {rhs_k})."
-    K = lhs_k
     assert (
         rhs_g == group_sizes_g
     ), f"G dimension of rhs and group_sizes don't match (rhs = {rhs_g}, group_sizes = {group_sizes_g})."
@@ -438,21 +467,29 @@ def get_gmm_transposition(lhs: Tensor, rhs: Tensor, out: Tensor) -> tuple[bool, 
     assert out.dim() == 2, f"out must have 2 dimensions (it's {out.dim()})."
 
     lhs_m, lhs_k = lhs.shape
-    G, rhs_k, rhs_n = rhs.shape
     out_m, out_n = out.shape
 
     assert (
         lhs_m == out_m
-    ), f"M dimension of lhs and out don't match (lhs = {lhs_m}, rhs = {out_m})."
+    ), f"M dimension of lhs and out don't match (lhs = {lhs_m}, out = {out_m})."
     M = lhs_m
-    assert (
-        lhs_k == rhs_k
-    ), f"K dimension of lhs and rhs don't match (lhs = {lhs_k}, rhs = {rhs_k})."
     K = lhs_k
-    assert (
-        rhs_n == out_n
-    ), f"N dimension of rhs and out don't match (lhs = {rhs_n}, rhs = {out_n})."
-    N = rhs_n
+    N = out_n
+
+    # Three rhs layouts are accepted (see gmm() docstring):
+    #   * Non-transposed:        shape (G, K, N), stride (K*N, N, 1) -> TRANS_RHS=False.
+    #   * Transposed (layout 1): shape (G, K, N), stride (K*N, 1, K) -> TRANS_RHS=True.
+    #   * Transposed (layout 2): shape (G, N, K), stride (K*N, K, 1) -> TRANS_RHS=True.
+    # Both transposed layouts produce identical byte offsets in the kernel's
+    # TRANS_RHS branch and therefore execute the same code; the difference is
+    # purely metadata.
+    G, rhs_d1, rhs_d2 = rhs.shape
+    is_kn_shape = (rhs_d1 == K) and (rhs_d2 == N)  # (G, K, N)
+    is_nk_shape = (rhs_d1 == N) and (rhs_d2 == K)  # (G, N, K)
+    assert is_kn_shape or is_nk_shape, (
+        f"rhs shape {tuple(rhs.shape)} must be (G, K, N) = ({G}, {K}, {N}) or "
+        f"(G, N, K) = ({G}, {N}, {K})."
+    )
 
     assert M > 0, f"M must be positive, it's {M}."
     assert K > 0, f"K must be positive, it's {K}."
@@ -461,18 +498,44 @@ def get_gmm_transposition(lhs: Tensor, rhs: Tensor, out: Tensor) -> tuple[bool, 
 
     is_lhs_row_major = lhs.stride() == (K, 1)
     assert is_lhs_row_major, "lhs must be row-major."
-    is_rhs_row_major = rhs.stride() == (K * N, N, 1)
-    is_rhs_col_major = rhs.stride() == (K * N, 1, K)
-    assert (
-        is_rhs_row_major != is_rhs_col_major
-    ), "rhs must be row-major or column-major."
+
+    rhs_stride = rhs.stride()
+    is_rhs_not_transposed = is_kn_shape and rhs_stride == (K * N, N, 1)
+    is_rhs_transposed_layout_1 = is_kn_shape and rhs_stride == (K * N, 1, K)
+    is_rhs_transposed_layout_2 = is_nk_shape and rhs_stride == (K * N, K, 1)
+    num_matches = (
+        int(is_rhs_not_transposed)
+        + int(is_rhs_transposed_layout_1)
+        + int(is_rhs_transposed_layout_2)
+    )
+    # When K == N, shape (G, K, N) and (G, N, K) are indistinguishable, and so are
+    # the strides for non-transposed and transposed layout 2: (K*N, N, 1) and
+    # (K*N, K, 1) collapse to the same tuple. The two interpretations correspond
+    # to different mathematical operations (see TRANS_RHS branches in the kernel),
+    # so we cannot disambiguate from shape+stride alone in that case. Transposed
+    # layout 1 stays unambiguous because its stride pattern (K*N, 1, K) differs.
+    assert num_matches == 1, (
+        "rhs must match exactly one supported layout: "
+        "non-transposed (shape (G, K, N), stride (K*N, N, 1)), "
+        "transposed layout 1 (shape (G, K, N), stride (K*N, 1, K)), "
+        "or transposed layout 2 (shape (G, N, K), stride (K*N, K, 1)). "
+        f"Got shape {tuple(rhs.shape)}, stride {rhs_stride}."
+        + (
+            " Note: K == N makes non-transposed and transposed layout 2 ambiguous."
+            if K == N
+            else ""
+        )
+    )
     is_out_row_major = out.stride() == (N, 1)
     assert is_out_row_major, "out must be row-major."
 
-    # Get rhs leading dimension according to transposition configuration.
-    ld_rhs = N if is_rhs_row_major else K
+    is_rhs_transposed = is_rhs_transposed_layout_1 or is_rhs_transposed_layout_2
+    # Get rhs leading dimension according to transposition configuration. Both
+    # transposed layouts share the same leading dimension because they have the
+    # same physical memory ordering.
+    ld_rhs = N if is_rhs_not_transposed else K
 
-    return is_rhs_col_major, ld_rhs
+    return is_rhs_transposed, ld_rhs
 
 
 # TGMM helpers: tensor generation.
@@ -487,6 +550,7 @@ def gen_tgmm_input(
     device: torch.device | str = DEVICE,
     preferred_element_type: torch.dtype = DTYPE,
     trans_lhs: bool = TRANS_LHS,
+    alt_trans: bool = False,
     rng_seed: int | None = RNG_SEED,
     unif_group_sizes: bool = False,
 ) -> tuple[Tensor, Tensor, Tensor]:
@@ -499,8 +563,19 @@ def gen_tgmm_input(
         torch.manual_seed(rng_seed)
 
     if trans_lhs:
-        lhs = torch.randn((M, K), dtype=torch.float32, device=device).T
+        # Two physically equivalent transposed layouts are supported. They share the
+        # same memory ordering (K varies fastest, then M); only the tensor metadata
+        # (shape/stride) differs.
+        if alt_trans:
+            # Transposed layout 2: shape (M, K), stride (K, 1). lhs is row-major over
+            # the swapped shape.
+            lhs = torch.randn((M, K), dtype=torch.float32, device=device)
+        else:
+            # Transposed layout 1: shape (K, M), stride (1, K). lhs is column-major.
+            lhs = torch.randn((M, K), dtype=torch.float32, device=device).T
     else:
+        # alt_trans is ignored when trans_lhs is False; only the non-transposed
+        # row-major layout is supported in that case.
         lhs = torch.randn((K, M), dtype=torch.float32, device=device)
     lhs = lhs.to(preferred_element_type)
 
@@ -560,6 +635,7 @@ def gen_tgmm_tensors(
     output_type: torch.dtype = DTYPE,
     trans_lhs: bool = TRANS_LHS,
     trans_rhs: bool = False,
+    alt_trans: bool = False,
     rng_seed: int | None = RNG_SEED,
     unif_group_sizes: bool = False,
     use_bias: bool = False,
@@ -572,6 +648,7 @@ def gen_tgmm_tensors(
         device=device,
         preferred_element_type=input_type,
         trans_lhs=trans_lhs,
+        alt_trans=alt_trans,
         rng_seed=rng_seed,
         unif_group_sizes=unif_group_sizes,
     )
@@ -599,14 +676,28 @@ def get_tgmm_shape(
         group_sizes.dim() == 1
     ), f"group_sizes must have 1 dimension (it's {group_sizes.dim()})."
 
-    K, lhs_m = lhs.shape
     rhs_m, N = rhs.shape
+    M = rhs_m
     G = group_sizes.shape[0]
 
-    assert (
-        lhs_m == rhs_m
-    ), f"M dimension of lhs and rhs don't match (lhs = {lhs_m}, rhs = {rhs_m})."
-    M = lhs_m
+    # lhs supports three layouts (see ptgmm() / nptgmm() docstring):
+    #   * Non-transposed:        shape (K, M), stride (M, 1).
+    #   * Transposed (layout 1): shape (K, M), stride (1, K).
+    #   * Transposed (layout 2): shape (M, K), stride (K, 1).
+    # Non-transposed and transposed layout 1 share shape (K, M), so M is taken
+    # from rhs to disambiguate which dimension of lhs is K.
+    lhs_d1, lhs_d2 = lhs.shape
+    if lhs_d2 == M:
+        # Either non-transposed or transposed layout 1: shape (K, M).
+        K = lhs_d1
+    elif lhs_d1 == M:
+        # Transposed layout 2: shape (M, K).
+        K = lhs_d2
+    else:
+        raise AssertionError(
+            f"lhs shape {tuple(lhs.shape)} doesn't match M = {M} from rhs"
+            f" (expected (K, M) or (M, K))."
+        )
 
     assert M > 0, f"M must be positive, it's {M}."
     assert K > 0, f"K must be positive, it's {K}."
@@ -714,39 +805,71 @@ def get_tgmm_transposition(lhs: Tensor, rhs: Tensor, out: Tensor) -> tuple[bool,
     assert rhs.dim() == 2, f"rhs must have 2 dimensions (it's {rhs.dim()})."
     assert out.dim() == 3, f"out must have 3 dimensions (it's {out.dim()})."
 
-    lhs_k, lhs_m = lhs.shape
     rhs_m, rhs_n = rhs.shape
     G, out_k, out_n = out.shape
 
     assert (
-        lhs_m == rhs_m
-    ), f"M dimension of lhs and rhs don't match (lhs = {lhs_m}, rhs = {rhs_m})."
-    M = lhs_m
-    assert (
-        lhs_k == out_k
-    ), f"K dimension of lhs and out don't match (lhs = {lhs_k}, rhs = {out_k})."
-    K = lhs_k
-    assert (
         rhs_n == out_n
-    ), f"N dimension of rhs and out don't match (lhs = {rhs_n}, rhs = {out_n})."
+    ), f"N dimension of rhs and out don't match (rhs = {rhs_n}, out = {out_n})."
+    M = rhs_m
+    K = out_k
     N = rhs_n
+
+    # Three lhs layouts are accepted (see ptgmm() / nptgmm() docstring):
+    #   * Non-transposed:        shape (K, M), stride (M, 1) -> TRANS_LHS=False.
+    #   * Transposed (layout 1): shape (K, M), stride (1, K) -> TRANS_LHS=True.
+    #   * Transposed (layout 2): shape (M, K), stride (K, 1) -> TRANS_LHS=True.
+    # Both transposed layouts produce identical byte offsets in the kernel's
+    # TRANS_LHS branch and therefore execute the same code; the difference is
+    # purely metadata.
+    lhs_d1, lhs_d2 = lhs.shape
+    is_km_shape = (lhs_d1 == K) and (lhs_d2 == M)  # (K, M)
+    is_mk_shape = (lhs_d1 == M) and (lhs_d2 == K)  # (M, K)
+    assert is_km_shape or is_mk_shape, (
+        f"lhs shape {tuple(lhs.shape)} must be (K, M) = ({K}, {M}) or "
+        f"(M, K) = ({M}, {K})."
+    )
 
     assert M > 0, f"M must be positive, it's {M}."
     assert K > 0, f"K must be positive, it's {K}."
     assert N > 0, f"N must be positive, it's {N}"
     assert G > 0, f"G must be positive, it's {G}"
 
-    is_lhs_row_major = lhs.stride() == (M, 1)
-    is_lhs_col_major = lhs.stride() == (1, K)
-    assert (
-        is_lhs_row_major != is_lhs_col_major
-    ), "lhs must be row-major or column-major."
+    lhs_stride = lhs.stride()
+    is_lhs_not_transposed = is_km_shape and lhs_stride == (M, 1)
+    is_lhs_transposed_layout_1 = is_km_shape and lhs_stride == (1, K)
+    is_lhs_transposed_layout_2 = is_mk_shape and lhs_stride == (K, 1)
+    num_matches = (
+        int(is_lhs_not_transposed)
+        + int(is_lhs_transposed_layout_1)
+        + int(is_lhs_transposed_layout_2)
+    )
+    # When K == M, shape (K, M) and (M, K) are indistinguishable, and so are the
+    # strides for non-transposed and transposed layout 2: (M, 1) and (K, 1)
+    # collapse to the same tuple. Transposed layout 1 stays unambiguous because
+    # its stride pattern (1, K) differs.
+    assert num_matches == 1, (
+        "lhs must match exactly one supported layout: "
+        "non-transposed (shape (K, M), stride (M, 1)), "
+        "transposed layout 1 (shape (K, M), stride (1, K)), "
+        "or transposed layout 2 (shape (M, K), stride (K, 1)). "
+        f"Got shape {tuple(lhs.shape)}, stride {lhs_stride}."
+        + (
+            " Note: K == M makes non-transposed and transposed layout 2 ambiguous."
+            if K == M
+            else ""
+        )
+    )
+
     is_rhs_row_major = rhs.stride() == (N, 1)
     assert is_rhs_row_major, "rhs must be row-major."
     is_out_row_major = out.stride() == (K * N, N, 1)
     assert is_out_row_major, "out must be row-major."
 
-    # Get lhs leading dimension according to transposition configuration.
-    ld_lhs = M if is_lhs_row_major else K
+    is_lhs_transposed = is_lhs_transposed_layout_1 or is_lhs_transposed_layout_2
+    # Get lhs leading dimension according to transposition configuration. Both
+    # transposed layouts share the same leading dimension because they have the
+    # same physical memory ordering.
+    ld_lhs = M if is_lhs_not_transposed else K
 
-    return is_lhs_col_major, ld_lhs
+    return is_lhs_transposed, ld_lhs

--- a/op_tests/op_benchmarks/triton/bench_gmm.py
+++ b/op_tests/op_benchmarks/triton/bench_gmm.py
@@ -127,6 +127,7 @@ def benchmark_gmm(
     metric: str = DEFAULT_METRIC,
     use_bias: bool = False,
     accumulate: bool = False,
+    grid_dim: int | None = None,
     output: bool = False,
 ) -> None:
     assert gmm_type in GMM_TYPES, "Invalid GMM type."
@@ -134,15 +135,27 @@ def benchmark_gmm(
 
     desc, gen_tensors, kernel_wrapper = select_triton_kernel(gmm_type)
 
-    in_dtype_str = str_from_dtype(in_dtype)
-    out_dtype_str = str_from_dtype(out_dtype)
-    group_sizes_dtype_str = str_from_group_sizes_dtype(group_sizes_dtype)
-    dtypes_desc = f"i{in_dtype_str}_o{out_dtype_str}_g{group_sizes_dtype_str}"
-    layout_desc = (
-        "".join("t" if trans else "n" for trans in (trans_lhs, trans_rhs)) + "n"
-    )
-    unit = METRIC_UNITS[metric]
-    triton_provider = f"triton_{gmm_type}_{dtypes_desc}_{layout_desc}_{unit}"
+    in_dtype_str: str = str_from_dtype(in_dtype)
+    out_dtype_str: str = str_from_dtype(out_dtype)
+    group_sizes_dtype_str: str = str_from_group_sizes_dtype(group_sizes_dtype)
+    unit: str = METRIC_UNITS[metric]
+    has_grid_dim: bool = gmm_type != "nptgmm" and grid_dim is not None
+    triton_provider_desc: list[str] = [
+        "triton",
+        gmm_type,
+        # data types
+        f"i{in_dtype_str}",
+        f"o{out_dtype_str}",
+        f"g{group_sizes_dtype_str}",
+        # layout description
+        "".join("t" if trans else "n" for trans in (trans_lhs, trans_rhs)) + "n",
+    ]
+    # grid dim
+    if has_grid_dim:
+        triton_provider_desc.append(f"gd{grid_dim}")
+    # unit of benchmark metric
+    triton_provider_desc.append(unit)
+    triton_provider: str = "_".join(triton_provider_desc)
 
     @triton.testing.perf_report(
         triton.testing.Benchmark(
@@ -200,6 +213,9 @@ def benchmark_gmm(
             elif gmm_type == "ptgmm" or gmm_type == "nptgmm":
                 kwargs["bias_grad"] = bias
                 kwargs["accumulate"] = accumulate
+
+            if has_grid_dim:
+                kwargs["grid_dim"] = grid_dim
 
             p50_ms, p20_ms, p80_ms = triton.testing.do_bench(
                 lambda: kernel_wrapper(**kwargs),
@@ -293,6 +309,8 @@ def benchmark_gmm(
         num_group_sizes,
         unif_group_sizes,
     )
+    if has_grid_dim:
+        logging.info("  overridden persistent grid_dim = %d", grid_dim)
     logging.info(
         "  metric = %s (in %s)",
         metric,
@@ -434,7 +452,6 @@ def parse_args() -> argparse.Namespace:
     )
 
     # Other arguments
-    parser.add_argument("--verbose", action="store_true", help="enable verbose output")
     parser.add_argument(
         "--use-bias",
         action="store_true",
@@ -446,10 +463,17 @@ def parse_args() -> argparse.Namespace:
         help="accumulate bias gradient",
     )
     parser.add_argument(
+        "--grid-dim",
+        type=positive_int,
+        default=None,
+        help="override grid dimension config of persistent kernels",
+    )
+    parser.add_argument(
         "-o",
         action="store_true",
         help="write performance results to CSV file in the current directory",
     )
+    parser.add_argument("--verbose", action="store_true", help="enable verbose output")
 
     try:
         return validate_args(parser.parse_args())
@@ -493,6 +517,7 @@ def main() -> None:
         metric=args.metric,
         use_bias=args.use_bias,
         accumulate=args.accumulate,
+        grid_dim=args.grid_dim,
         output=args.o,
     )
 

--- a/op_tests/op_benchmarks/triton/bench_gmm.py
+++ b/op_tests/op_benchmarks/triton/bench_gmm.py
@@ -22,6 +22,11 @@ from aiter.ops.triton.utils.gmm_common import (
     dtype_from_str,
     DTYPE,
     str_from_dtype,
+    SUPPORTED_GROUP_SIZES_DTYPES_STR,
+    GROUP_SIZES_DTYPE_STR,
+    group_sizes_dtype_from_str,
+    GROUP_SIZES_DTYPE,
+    str_from_group_sizes_dtype,
     TRANS_LHS,
     TRANS_RHS,
     RNG_SEED,
@@ -113,6 +118,7 @@ def benchmark_gmm(
     bench_shape: tuple[int, int, int, int] | None = None,
     in_dtype: torch.dtype = DTYPE,
     out_dtype: torch.dtype = DTYPE,
+    group_sizes_dtype: torch.dtype = GROUP_SIZES_DTYPE,
     trans_lhs: bool = TRANS_LHS,
     trans_rhs: bool = TRANS_RHS,
     rng_seed: int = RNG_SEED,
@@ -130,7 +136,8 @@ def benchmark_gmm(
 
     in_dtype_str = str_from_dtype(in_dtype)
     out_dtype_str = str_from_dtype(out_dtype)
-    dtypes_desc = f"i{in_dtype_str}_o{out_dtype_str}"
+    group_sizes_dtype_str = str_from_group_sizes_dtype(group_sizes_dtype)
+    dtypes_desc = f"i{in_dtype_str}_o{out_dtype_str}_g{group_sizes_dtype_str}"
     layout_desc = (
         "".join("t" if trans else "n" for trans in (trans_lhs, trans_rhs)) + "n"
     )
@@ -160,6 +167,7 @@ def benchmark_gmm(
             num_group_sizes,
             input_type=in_dtype,
             output_type=out_dtype,
+            group_sizes_dtype=group_sizes_dtype,
             trans_lhs=trans_lhs,
             trans_rhs=trans_rhs,
             rng_seed=rng_seed,
@@ -267,9 +275,10 @@ def benchmark_gmm(
 
     logging.info("Benchmarking Triton %s kernel:", desc)
     logging.info(
-        "  input_type = %s, output_type = %s, rng_seed = %d, use_bias = %s, accumulate = %s",
+        "  input_type = %s, output_type = %s, group_sizes_type = %s, rng_seed = %d, use_bias = %s, accumulate = %s",
         in_dtype_str,
         out_dtype_str,
+        group_sizes_dtype_str,
         rng_seed,
         use_bias,
         accumulate,
@@ -384,6 +393,13 @@ def parse_args() -> argparse.Namespace:
         default=DTYPE_STR,
         help=f"output data type (default: {DTYPE_STR})",
     )
+    parser.add_argument(
+        "--group-sizes-type",
+        type=str.lower,
+        choices=SUPPORTED_GROUP_SIZES_DTYPES_STR,
+        default=GROUP_SIZES_DTYPE_STR,
+        help=f"group sizes data type (default: {GROUP_SIZES_DTYPE_STR})",
+    )
 
     # Transposition
     add_trans_arg(parser, "lhs", TRANS_LHS)
@@ -434,6 +450,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="write performance results to CSV file in the current directory",
     )
+
     try:
         return validate_args(parser.parse_args())
     except argparse.ArgumentError as arg_error:
@@ -460,12 +477,14 @@ def main() -> None:
     shape = (args.M, args.K, args.N, args.G)
     in_dtype = dtype_from_str(args.input_type)
     out_dtype = dtype_from_str(args.output_type)
+    group_sizes_dtype = group_sizes_dtype_from_str(args.group_sizes_type)
 
     benchmark_gmm(
         args.gmm_type,
         bench_shape=None if all(arg is None for arg in shape) else shape,
         in_dtype=in_dtype,
         out_dtype=out_dtype,
+        group_sizes_dtype=group_sizes_dtype,
         trans_lhs=args.trans_lhs,
         trans_rhs=args.trans_rhs,
         rng_seed=args.rng_seed,

--- a/op_tests/op_benchmarks/triton/bench_gmm.py
+++ b/op_tests/op_benchmarks/triton/bench_gmm.py
@@ -128,6 +128,7 @@ def benchmark_gmm(
     use_bias: bool = False,
     accumulate: bool = False,
     grid_dim: int | None = None,
+    work_stealing: bool = False,
     output: bool = False,
 ) -> None:
     assert gmm_type in GMM_TYPES, "Invalid GMM type."
@@ -140,6 +141,7 @@ def benchmark_gmm(
     group_sizes_dtype_str: str = str_from_group_sizes_dtype(group_sizes_dtype)
     unit: str = METRIC_UNITS[metric]
     has_grid_dim: bool = gmm_type != "nptgmm" and grid_dim is not None
+    has_work_stealing: bool = gmm_type == "gmm" and work_stealing
     triton_provider_desc: list[str] = [
         "triton",
         gmm_type,
@@ -153,6 +155,9 @@ def benchmark_gmm(
     # grid dim
     if has_grid_dim:
         triton_provider_desc.append(f"gd{grid_dim}")
+    # work stealing
+    if has_work_stealing:
+        triton_provider_desc.append("ws")
     # unit of benchmark metric
     triton_provider_desc.append(unit)
     triton_provider: str = "_".join(triton_provider_desc)
@@ -210,6 +215,7 @@ def benchmark_gmm(
 
             if gmm_type == "gmm":
                 kwargs["bias"] = bias
+                kwargs["work_stealing"] = work_stealing
             elif gmm_type == "ptgmm" or gmm_type == "nptgmm":
                 kwargs["bias_grad"] = bias
                 kwargs["accumulate"] = accumulate
@@ -311,6 +317,8 @@ def benchmark_gmm(
     )
     if has_grid_dim:
         logging.info("  overridden persistent grid_dim = %d", grid_dim)
+    if has_work_stealing:
+        logging.info("  work stealing enabled")
     logging.info(
         "  metric = %s (in %s)",
         metric,
@@ -469,6 +477,11 @@ def parse_args() -> argparse.Namespace:
         help="override grid dimension config of persistent kernels",
     )
     parser.add_argument(
+        "--work-stealing",
+        action="store_true",
+        help="enable work stealing dynamic load-balancing of persistent kernels",
+    )
+    parser.add_argument(
         "-o",
         action="store_true",
         help="write performance results to CSV file in the current directory",
@@ -518,6 +531,7 @@ def main() -> None:
         use_bias=args.use_bias,
         accumulate=args.accumulate,
         grid_dim=args.grid_dim,
+        work_stealing=args.work_stealing,
         output=args.o,
     )
 

--- a/op_tests/op_benchmarks/triton/bench_gmm.py
+++ b/op_tests/op_benchmarks/triton/bench_gmm.py
@@ -63,6 +63,7 @@ REAL_SHAPES: list[tuple[int, int, int, int]] = [
     ( 393216,  2048,  1408,  64),  # deepseekv2-16B
     (  32768,  6144, 16384,   8),  # Mixtral 8x22B
     (  32768, 16384,  6144,   8),  # Mixtral 8x22B
+    ( 267424,  1280,  2560,  32),  # real workload, but unknown model
 ]
 # fmt: on
 

--- a/op_tests/triton_tests/test_gmm.py
+++ b/op_tests/triton_tests/test_gmm.py
@@ -126,7 +126,7 @@ def torch_gmm(
 ) -> Tensor:
     check_input_device_dtype(lhs, rhs, group_sizes)
 
-    M, _, N, G = get_gmm_shape(lhs, rhs, group_sizes)
+    M, K, N, G = get_gmm_shape(lhs, rhs, group_sizes)
 
     out = get_gmm_output(
         M,
@@ -135,6 +135,17 @@ def torch_gmm(
         preferred_element_type=preferred_element_type,
         existing_out=existing_out,
     )
+
+    # rhs has three supported storage layouts (see gmm() docstring):
+    #   * Non-transposed:        shape (G, K, N), stride (K*N, N, 1).
+    #   * Transposed (layout 1): shape (G, K, N), stride (K*N, 1, K).
+    #   * Transposed (layout 2): shape (G, N, K), stride (K*N, K, 1).
+    # For PyTorch matmul, only the tensor metadata matters: when rhs has shape
+    # (G, N, K) (layout 2), we need to transpose rhs[g] from (N, K) to (K, N)
+    # before the matmul. For the other two layouts, rhs[g] already has the
+    # logical (K, N) shape; PyTorch handles the column-major stride of layout
+    # 1 transparently via strides.
+    is_rhs_layout_2 = rhs.shape[1] == N and rhs.shape[2] == K
 
     last_row = 0
 
@@ -148,7 +159,9 @@ def torch_gmm(
         start_idx = last_row
         end_idx = last_row + m
 
-        result = (lhs[start_idx:end_idx, :] @ rhs[g]).to(torch.float32)
+        # rhs_g is the (K, N) matrix for group g, regardless of storage layout.
+        rhs_g = rhs[g].T if is_rhs_layout_2 else rhs[g]
+        result = (lhs[start_idx:end_idx, :] @ rhs_g).to(torch.float32)
         if bias is not None:
             result += bias[g].to(torch.float32)
         out[start_idx:end_idx, :] = result.to(preferred_element_type)
@@ -267,6 +280,17 @@ def torch_tgmm(
         existing_bias_grad=bias_grad,
     )
 
+    # lhs has three supported storage layouts (see ptgmm() / nptgmm() docstring):
+    #   * Non-transposed:        shape (K, M), stride (M, 1).
+    #   * Transposed (layout 1): shape (K, M), stride (1, K).
+    #   * Transposed (layout 2): shape (M, K), stride (K, 1).
+    # For PyTorch slicing along the m-dimension we need lhs to logically have
+    # shape (K, M). Layout 2 has shape (M, K), so we transpose it. The other
+    # two layouts already have shape (K, M); PyTorch handles the column-major
+    # stride of layout 1 transparently via strides.
+    is_lhs_layout_2 = lhs.shape[0] == M
+    lhs_km = lhs.T if is_lhs_layout_2 else lhs
+
     last_col = 0
 
     for g in range(G):
@@ -278,12 +302,12 @@ def torch_tgmm(
 
         start_idx = last_col
         end_idx = last_col + m
-        mm = lhs[:, start_idx:end_idx] @ rhs[start_idx:end_idx, :]
+        mm = lhs_km[:, start_idx:end_idx] @ rhs[start_idx:end_idx, :]
         out[g] = mm.to(preferred_element_type)
 
         # Bias gradient: sum lhs across m-dimension (columns) for each group.
         if compute_bias_grad:
-            grad = lhs[:, start_idx:end_idx].sum(dim=1, dtype=torch.float32)
+            grad = lhs_km[:, start_idx:end_idx].sum(dim=1, dtype=torch.float32)
             bias_grad[g] += grad
 
         last_col += m

--- a/op_tests/triton_tests/test_gmm.py
+++ b/op_tests/triton_tests/test_gmm.py
@@ -131,8 +131,8 @@ def torch_gmm(
     out = get_gmm_output(
         M,
         N,
-        device=lhs.device,
         preferred_element_type=preferred_element_type,
+        device=lhs.device,
         existing_out=existing_out,
     )
 
@@ -265,8 +265,8 @@ def torch_tgmm(
         K,
         N,
         G,
-        device=lhs.device,
         preferred_element_type=preferred_element_type,
+        device=lhs.device,
         existing_out=existing_out,
     )
 

--- a/op_tests/triton_tests/test_gmm.py
+++ b/op_tests/triton_tests/test_gmm.py
@@ -214,9 +214,9 @@ def test_gmm(
             lhs,
             rhs,
             group_sizes,
+            bias=bias,
             preferred_element_type=out_dtype,
             existing_out=out_triton,
-            bias=bias,
         )
 
         m = int(torch.sum(group_sizes).item())
@@ -365,9 +365,9 @@ def test_tgmm(
             lhs,
             rhs,
             group_sizes,
+            bias_grad=bias_grad_torch,
             preferred_element_type=out_dtype,
             existing_out=out_torch,
-            bias_grad=bias_grad_torch,
             accumulate=False,
         )
 
@@ -469,9 +469,9 @@ def test_tgmm_accumulate(persistent_str: str, with_bias_grad: bool):
             lhs,
             rhs,
             group_sizes,
+            bias_grad=bias_grad_triton,
             preferred_element_type=out_dtype,
             existing_out=out_triton,
-            bias_grad=bias_grad_triton,
             accumulate=True,
         )
     else:
@@ -479,9 +479,9 @@ def test_tgmm_accumulate(persistent_str: str, with_bias_grad: bool):
             lhs,
             rhs,
             group_sizes,
+            bias_grad=bias_grad_triton,
             preferred_element_type=out_dtype,
             existing_out=out_triton,
-            bias_grad=bias_grad_triton,
             accumulate=True,
         )
 

--- a/op_tests/triton_tests/test_gmm.py
+++ b/op_tests/triton_tests/test_gmm.py
@@ -7,6 +7,7 @@
 
 # Python standard library
 from functools import partial
+import warnings
 
 # PyTorch
 import torch
@@ -64,6 +65,9 @@ REAL_SHAPES: list[tuple[int, int, int, int]] = [
 # Test shapes are test only + real ones.
 TEST_SHAPES: list[tuple[int, int, int, int]] = TEST_ONLY_SHAPES + REAL_SHAPES
 
+# Other production workload: unknown model
+#                                                   M,    K,    N,  G
+OTHER_REAL_SHAPE: tuple[int, int, int, int] = (267424, 1280, 2560, 32)
 
 # Transpositions.
 
@@ -241,6 +245,61 @@ def test_gmm(
             "Triton GMM doesn't match PyTorch reference GMM.",
             atol=atol,
             rtol=rtol,
+        )
+
+
+@pytest.mark.parametrize(
+    "M, K, N, G", [OTHER_REAL_SHAPE, OTHER_REAL_SHAPE[:-1] + (17,)]
+)
+@pytest.mark.parametrize(
+    "trans_rhs, alt_trans", [(False, False), (True, False), (True, True)]
+)
+@pytest.mark.parametrize("grid_dim", [None, 240])
+@pytest.mark.parametrize("work_stealing", [False, True])
+def test_gmm_alt_trans_rhs_int64_group_sizes_grid_dim_override_work_stealing(
+    M: int,
+    K: int,
+    N: int,
+    G: int,
+    trans_rhs: bool,
+    alt_trans: bool,
+    grid_dim: int | None,
+    work_stealing: bool,
+):
+    lhs, rhs, multiple_group_sizes, out_torch, _ = gen_gmm_tensors(
+        M,
+        K,
+        N,
+        G,
+        NUM_GROUP_SIZES,
+        group_sizes_dtype=torch.int64,  # feature under test
+        trans_rhs=trans_rhs,
+        alt_trans=alt_trans,  # feature under test
+        rng_seed=RNG_SEED,
+        unif_group_sizes=True,
+    )
+    out_triton = torch.empty_like(out_torch)
+
+    for group_sizes in multiple_group_sizes:
+        torch_gmm(lhs, rhs, group_sizes, existing_out=out_torch)
+
+        # Ignore expected warnings about grid dimension override.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore" if grid_dim is not None else "default")
+            triton_gmm(
+                lhs,
+                rhs,
+                group_sizes,
+                existing_out=out_triton,
+                grid_dim=grid_dim,  # feature under test
+                work_stealing=work_stealing,  # feature under test
+            )
+
+        m = int(torch.sum(group_sizes).item())
+        check_tensors(
+            out_triton[:m],
+            out_torch[:m],
+            "Triton GMM doesn't match PyTorch reference GMM.",
         )
 
 
@@ -497,4 +556,68 @@ def test_tgmm_accumulate(persistent_str: str, with_bias_grad: bool):
             bias_grad_triton[non_empty_groups],
             bias_grad_torch[non_empty_groups],
             "Triton persistent TGMM bias_grad with ACCUMULATE=True does not match reference.",
+        )
+
+
+@pytest.mark.parametrize("persistent_str", {"p", "np"})
+@pytest.mark.parametrize(
+    "M, K, N, G", [OTHER_REAL_SHAPE, OTHER_REAL_SHAPE[:-1] + (13,)]
+)
+@pytest.mark.parametrize(
+    "trans_lhs, alt_trans", [(False, False), (True, False), (True, True)]
+)
+@pytest.mark.parametrize("grid_dim", [None, 228])
+def test_tgmm_alt_trans_lhs_int64_group_sizes_grid_dim_override(
+    persistent_str: str,
+    M: int,
+    K: int,
+    N: int,
+    G: int,
+    trans_lhs: bool,
+    alt_trans: bool,
+    grid_dim: int | None,
+):
+    assert persistent_str in {"p", "np"}
+    persistent: bool = persistent_str == "p"
+    has_grid_dim: bool = grid_dim is not None
+
+    if not persistent and has_grid_dim:
+        pytest.skip("Grid dimension override is only applicable to persistent TGMM.")
+
+    lhs, rhs, multiple_group_sizes, out_torch, _ = gen_tgmm_tensors(
+        M,
+        K,
+        N,
+        G,
+        NUM_GROUP_SIZES,
+        group_sizes_dtype=torch.int64,  # feature under test
+        trans_lhs=trans_lhs,
+        alt_trans=alt_trans,  # feature under test
+        rng_seed=RNG_SEED,
+        unif_group_sizes=True,
+    )
+    out_triton = torch.empty_like(out_torch)
+
+    for group_sizes in multiple_group_sizes:
+        torch_tgmm(lhs, rhs, group_sizes, existing_out=out_torch)
+
+        if persistent:
+            # Ignore expected warnings about grid dimension override.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore" if has_grid_dim else "default")
+                triton_ptgmm(
+                    lhs,
+                    rhs,
+                    group_sizes,
+                    existing_out=out_triton,
+                    grid_dim=grid_dim,  # feature under test
+                )
+        else:
+            triton_nptgmm(lhs, rhs, group_sizes, existing_out=out_triton)
+
+        non_empty_groups = group_sizes > 0
+        check_tensors(
+            out_triton[non_empty_groups],
+            out_torch[non_empty_groups],
+            f"Triton {'persistent' if persistent else 'non-persistent'} TGMM doesn't match PyTorch reference TGMM.",
         )


### PR DESCRIPTION
## Motivation

A customer's workload required the following missing features in GMM with transposed RHS:

* Support transposed RHS tensor with shape = $(G, N, K)$ and stride = $(K \cdot N, K, 1)$.
* Support `int64` group sizes.
* Improved performance when running together with an all-gather comms kernel.

This PR adds the missing features and also optimizes the GMM kernel.

## Technical Details

### Description of Proposed Changes

* Add support for an additional transposed RHS layout in GMM [ shape $(G, N, K)$, stride $(K \cdot N, K, 1)$ ] and a transposed LHS layout in TGMM [ shape $(M, K)$, stride $(K, 1)$ ].
* Add `int64` support for the group sizes tensor, in addition to the existing `int32` path.
* Implement a work stealing scheduler for GMM to mitigate load imbalance under concurrent comms traffic, while keeping the original static tile scheduling available.
* Add a `grid_dim` override option to the persistent kernel wrappers (GMM and persistent TGMM), allowing callers to control how many CUs are dedicated to the kernel.
* Tune the `gfx950` GMM config for the target production shape, improving baseline GMM performance.
* Disable expensive GMM assertion logic that required GPU work, reducing host-side overhead in the launch path.
* Extend the GMM benchmark script with a new production shape and add unit tests covering all of the new features above.

### Impact of New Unit Tests in CI Performance

* Main branch: 76 tests, 76 passed in 54.28s
* Feature branch: 124 tests, 118 passed, 6 skipped in 83.97s (0:01:23)
* Difference: +42 tests, +29.69s

### Analysis of Kernel Performance

#### Main Branch vs. Feature Branch

Improvement in GMM kernel:

|       M |     K |     N |  G |   Main (ms) | Feature (ms) | Speedup |
|--------:|------:|------:|---:|------------:|-------------:|--------:|
|   49152 |  1408 |  2048 | 64 |       0.493 |        0.457 |    1.08 |
| 3145728 |  2048 |  1408 |  8 |      23.193 |       22.822 |    1.02 |
|  393216 |  2048 |  1408 | 64 |       2.957 |        2.891 |    1.02 |
|   32768 |  6144 | 16384 |  8 |       7.474 |        6.748 |    1.11 |
|   32768 | 16384 |  6144 |  8 |       7.307 |        6.866 |    1.06 |
|  267424 |  1280 |  2560 | 32 |       2.302 |        2.188 |    1.05 |
|         |       |       |    |             |      Geomean |    1.06 |

Improvement in GMM kernel with transposed RHS:

|       M |     K |     N |  G |   Main (ms) | Feature (ms) | Speedup |
|--------:|------:|------:|---:|------------:|-------------:|--------:|
|   49152 |  1408 |  2048 | 64 |       0.495 |        0.331 |    1.49 |
| 3145728 |  2048 |  1408 |  8 |      22.947 |       19.533 |    1.17 |
|  393216 |  2048 |  1408 | 64 |       2.949 |        2.487 |    1.19 |
|   32768 |  6144 | 16384 |  8 |       7.495 |        5.962 |    1.26 |
|   32768 | 16384 |  6144 |  8 |       7.396 |        6.159 |    1.20 |
|  267424 |  1280 |  2560 | 32 |       2.334 |        1.828 |    1.28 |
|         |       |       |    |             |      Geomean |    1.26 |

There's no change in the performance of all TGMM variants ($\{persistent, non\text{-}persistent\} \times \{ regular\ LHS, transposed\ LHS\}$).

#### Group Sizes Data Type - `int32` vs. `int64`

All performance metrics in this section were collected in the feature branch, given that there was no support for `int64` group sizes before.

Improvement in GMM kernel:

|       M |     K |     N |  G | `int32` (ms) | `int64` (ms) | Speedup |
|--------:|------:|------:|---:|-------------:|-------------:|--------:|
|   49152 |  1408 |  2048 | 64 |        0.457 |        0.332 |    1.38 |
| 3145728 |  2048 |  1408 |  8 |       22.822 |       22.477 |    1.02 |
|  393216 |  2048 |  1408 | 64 |        2.891 |        2.507 |    1.15 |
|   32768 |  6144 | 16384 |  8 |        6.748 |        6.024 |    1.12 |
|   32768 | 16384 |  6144 |  8 |        6.866 |        6.122 |    1.12 |
|  267424 |  1280 |  2560 | 32 |        2.188 |        1.834 |    1.19 |
|         |       |       |    |              |      Geomean |    1.16 |

Regression in persistent TGMM kernel:

|       M |     N |     K |  G | `int32` (ms) | `int64` (ms) | Speedup |
|--------:|------:|------:|---:|-------------:|-------------:|--------:|
|   49152 |  1408 |  2048 | 64 |        0.592 |        1.490 |    0.40 |
| 3145728 |  2048 |  1408 |  8 |       42.500 |       42.393 |    1.00 |
|  393216 |  2048 |  1408 | 64 |        3.423 |       10.737 |    0.32 |
|   32768 |  6144 | 16384 |  8 |        8.491 |       24.969 |    0.34 |
|   32768 | 16384 |  6144 |  8 |        8.301 |       23.882 |    0.35 |
|  267424 |  1280 |  2560 | 32 |        2.787 |        8.102 |    0.34 |
|         |       |       |    |              |      Geomean |    0.42 |

Regression in non-persistent TGMM kernel:

|       M |     K |     N |  G | `int32` (ms) | `int64` (ms) | Speedup |
|--------:|------:|------:|---:|-------------:|-------------:|--------:|
|   49152 |  1408 |  2048 | 64 |        0.568 |        1.703 |    0.33 |
| 3145728 |  2048 |  1408 |  8 |       43.677 |       43.607 |    1.00 |
|  393216 |  2048 |  1408 | 64 |        3.813 |       11.910 |    0.32 |
|   32768 |  6144 | 16384 |  8 |       24.604 |       34.010 |    0.72 |
|   32768 | 16384 |  6144 |  8 |       25.307 |       34.718 |    0.73 |
|  267424 |  1280 |  2560 | 32 |        9.919 |       11.891 |    0.83 |
|         |       |       |    |              |      Geomean |    0.60 |

The performance of all other kernels in the extended GMM family remains the same:

* GMM with transposed RHS
* Persistent TGMM with transposed LHS
* Non-persistent TGMM with transposed LHS

The improvement in GMM kernel with `int64` group sizes is unexpected.

It's important to highlight that the regressions in the TGMM kernels with `int64` group sizes were only observed and were not investigated in depth. The main goal of this PR is to enhance the GMM kernel, improving its performance and adding more features. Users of TGMM kernels can continue using `int32` group sizes as before, without any performance loss.

#### Grid Dimension Selection in Persistent Kernels

As expected, the more CUs allocated to the persistent kernels, the better the performance. The chart bellow depicts performance of GMM with transposed RHS and TGMM kernels for different grid sizes. Performance is in milliseconds, so the lower the better.

<img width="801" height="570" alt="image" src="https://github.com/user-attachments/assets/b513a22d-6a5c-4a2c-acda-f111f7c4f615" />

#### GMM Work Stealing Overhead

This section demonstrates the overhead introduced by GMM work stealing feature, when the GMM kernel is executed in isolation without any other concurrent kernel. The experiments were made with all 256 `gfx950` CUs in the feature branch, given that there was no work stealing implementation before.

Work stealing speedup in GMM kernel with `int32` group sizes:

|       M |     K |     N |  G | Static (ms) | Work Stealing (ms) | Speedup |
|--------:|------:|------:|---:|------------:|-------------------:|--------:|
|   49152 |  1408 |  2048 | 64 |       0.457 |              0.404 |    1.13 |
| 3145728 |  2048 |  1408 |  8 |      22.822 |             23.891 |    0.96 |
|  393216 |  2048 |  1408 | 64 |       2.891 |              2.791 |    1.04 |
|   32768 |  6144 | 16384 |  8 |       6.748 |              5.893 |    1.15 |
|   32768 | 16384 |  6144 |  8 |       6.866 |              6.054 |    1.13 |
|  267424 |  1280 |  2560 | 32 |       2.188 |              1.944 |    1.13 |
|         |       |       |    |             |            Geomean |    1.09 |

Work stealing overhead in GMM kernel with `int64` group sizes:

|       M |     K |     N |  G | Static (ms) | Work Stealing (ms) | Speedup |
|--------:|------:|------:|---:|------------:|-------------------:|--------:|
|   49152 |  1408 |  2048 | 64 |       0.332 |              0.364 |    0.91 |
| 3145728 |  2048 |  1408 |  8 |      22.477 |             24.178 |    0.93 |
|  393216 |  2048 |  1408 | 64 |       2.507 |              2.609 |    0.96 |
|   32768 |  6144 | 16384 |  8 |       6.024 |              5.845 |    1.03 |
|   32768 | 16384 |  6144 |  8 |       6.122 |              6.010 |    1.02 |
|  267424 |  1280 |  2560 | 32 |       1.834 |              1.962 |    0.93 |
|         |       |       |    |             |            Geomean |    0.96 |

Work stealing overhead in GMM kernel with transposed RHS and `int32` group sizes:

|       M |     K |     N |  G | Static (ms) | Work Stealing (ms) | Speedup |
|--------:|------:|------:|---:|------------:|-------------------:|--------:|
|   49152 |  1408 |  2048 | 64 |       0.331 |              0.366 |    0.90 |
| 3145728 |  2048 |  1408 |  8 |      19.533 |             24.178 |    0.81 |
|  393216 |  2048 |  1408 | 64 |       2.487 |              2.510 |    0.99 |
|   32768 |  6144 | 16384 |  8 |       5.962 |              6.107 |    0.98 |
|   32768 | 16384 |  6144 |  8 |       6.159 |              6.314 |    0.98 |
|  267424 |  1280 |  2560 | 32 |       1.828 |              1.984 |    0.92 |
|         |       |       |    |             |            Geomean |    0.93 |

Work stealing overhead in GMM kernel with transposed RHS and `int64` group sizes:

|       M |     K |     N |  G | Static (ms) | Work Stealing (ms) | Speedup |
|--------:|------:|------:|---:|------------:|-------------------:|--------:|
|   49152 |  1408 |  2048 | 64 |       0.333 |              0.367 |    0.91 |
| 3145728 |  2048 |  1408 |  8 |      19.613 |             23.108 |    0.85 |
|  393216 |  2048 |  1408 | 64 |       2.484 |              2.634 |    0.94 |
|   32768 |  6144 | 16384 |  8 |       5.974 |              6.097 |    0.98 |
|   32768 | 16384 |  6144 |  8 |       6.158 |              6.309 |    0.98 |
|  267424 |  1280 |  2560 | 32 |       1.828 |              1.995 |    0.92 |
|         |       |       |    |             |            Geomean |    0.93 |

It's fair to say that the work stealing feature can add up to 20% of overhead. On an eyeballed average, it introduces something between 4% and 7% of overhead. The more tiles the problem has, the greater the overhead. The global tile ID is resolved for each tile. We also have an atomic operation for each tile, to fetch the next tile. These two factors should be the source of the overhead.

Surprisingly, there is a performance improvement in GMM kernel with `int32` group sizes.

#### GMM Work Stealing with Concurrent Comms Kernel

Work stealing is a dynamic tile-scheduling strategy that relieves the load-imbalance problem caused by comms memory pressure. In the original implementation, each CU is pre-assigned a fixed stripe of tiles at launch time via a round-robin stride. Every CU must finish its entire stripe before the kernel can retire. Under concurrent comms traffic, some CUs stall on HBM latency; those CUs hold unfinished tiles while fast CUs sit idle. A single stalled CU stretches the whole kernel.

With work stealing, instead of striding through a pre-assigned range, each CU atomically claim the next available tile. CUs that finish quickly loop back and steal more tiles. CUs stalled by memory pressure naturally claim fewer. The kernel retires as soon as the last tile is computed and no CU waits for another.

The following table shows how work stealing version of GMM kernel performs better while overlapping with an all-gather comms kernel [ target shape is $(M, K, N, G) = (267424, 1280, 2560, 32)$ ]:

| Grouped GEMM scenario               | Static (ms) | Static slowdown | Work stealing (ms) | Work stealing slowdown |
|-------------------------------------|------------:|----------------:|-------------------:|-----------------------:|
| Grouped GEMM alone                  |       1.891 |            1.00 |              2.044 |                   1.00 |
| All-gather and grouped GEMM overlap |       3.996 |            2.11 |              2.419 |                   1.18 |

#### Best GMM Implementation Option

The most performant option for GMM is static tile scheduling (no work stealing) combined with `int64` group sizes. Work stealing combined with `int64` group sizes provides better performance only for $(M, K, N, G) = (32768, 6144, 16384, 8)$ and  $(M, K, N, G) = (32768, 16384, 6144, 8)$ shapes.

The most performance option for GMM with transposed RHS is static tile scheduling (no work stealing) combined with `int32` group sizes.

## Test Plan

Run GMM unit tests locally in a `gfx950` host:

```bash
pytest op_tests/triton_tests/test_gmm.py
```

Rely on CI runners to execute all Triton unit tests in `gfx950` and `gfx942` hosts.

## Test Result

* [x] GMM unit tests passing locally in `gfx950`.
* [x] All Triton unit tests passing in CI (`gfx950`).
* [x] All Triton unit tests passing in CI (`gfx942`).

## Submission Checklist

* [x] Look over the [contributing guidelines](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests).
