### PR TITLE
[Bugfix] Enable MXFP4 MoE at TP=4/8 via CKTile a4w4 kernels and quant fixes

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -767,6 +767,7 @@ class MOEMetadata:
     fuse_quant: str = ""
     stage2_has_bias: bool = False
     flat: bool = False
+    skip_inter_quant: bool = False
 
 
 def _needs_swiglu_bias_support(dtype, quant_type):
@@ -1206,6 +1207,12 @@ def get_2stage_cfgs(
     def get_block_m() -> int:
         if q_dtype_a == dtypes.fp8:
             return 32
+        elif q_dtype_a == dtypes.fp4x2:
+            # MXFP4 fused quant+sort requires block_size % 32 == 0.
+            # block_m=64 is significantly faster than 32 for fp4x2 on
+            # gfx950 across all tested batch sizes (up to 1.5x for
+            # prefill).  128 is not supported by current CKTile stage2.
+            return 64
         else:
             return 16 if token < 2048 else 32 if token < 16384 else 64
 
@@ -1451,6 +1458,7 @@ def get_2stage_cfgs(
         dtype in [dtypes.bf16, dtypes.fp16]
         and q_type == QuantType.per_1x32
         and q_dtype_w in [dtypes.fp4x2]
+        and q_dtype_a not in [dtypes.fp4x2]
         and is_shuffled
         and not (activation == ActivationType.Swiglu and q_dtype_a == dtypes.fp4x2)
         and (ksplit > 1 or swiglu_mxfp4_bf16_cktile)
@@ -1486,6 +1494,40 @@ def get_2stage_cfgs(
             run_1stage,
             has_bias=activation == ActivationType.Swiglu,
             stage2_has_bias=activation == ActivationType.Swiglu,
+        )
+    elif (
+        dtype in [dtypes.bf16, dtypes.fp16]
+        and q_type == QuantType.per_1x32
+        and q_dtype_a in [dtypes.fp4x2]
+        and q_dtype_w in [dtypes.fp4x2]
+    ):
+        # Stage1 uses JIT CK (DeviceMoeGemmMXBPreShuffle) which correctly
+        # handles fp4x2 activations x fp4x2 weights.  CKTile AOT stage1 is
+        # still broken (AQUANT_Pipeline misinterprets fp4 as fp8).
+        #
+        # Stage2 uses CKTile AOT with bf16 activations x fp4x2 weights
+        # (a16w4 path) which avoids the costly intermediate bf16->fp4x2
+        # quantization kernel between stages.  For decode (small M) this
+        # eliminates a full kernel launch + memory round-trip.
+        #
+        # NOTE: w1 must be pre-shuffled with shuffle_weight_a16w4(w1, 16, True)
+        # and w1_scale with shuffle_scale_a16w4(w1_scale, E, True).
+        return MOEMetadata(
+            functools.partial(
+                ck_moe_stage1,
+                quant_type=q_type,
+                activation=activation,
+            ),
+            functools.partial(
+                cktile_moe_stage2,
+                n_pad_zeros=hidden_pad // 64 * 64,
+                k_pad_zeros=intermediate_pad // 128 * 128,
+                activation=activation,
+            ),
+            get_block_m(),
+            0,
+            False,
+            skip_inter_quant=True,
         )
 
     if (kernelName1 and "ck2stages" in kernelName1) or (
@@ -1775,6 +1817,7 @@ def fused_moe_2stages(
             q_dtype_a in [dtypes.bf16, dtypes.fp16]
             and activation == ActivationType.Swiglu
             or (metadata.ksplit > 1 and is_shuffled)
+            or metadata.skip_inter_quant
         )
     ):
         a2_scale = None
@@ -1832,23 +1875,72 @@ def fused_moe_2stages(
         )
         a2 = a2.view(token_num, topk, inter_dim)
 
-    metadata.stage2(
-        a2,
-        w1,
-        w2,
-        sorted_ids,
-        sorted_expert_ids,
-        num_valid_ids,
-        moe_out,
-        topk,
-        w2_scale=(
-            w2_scale.view(dtypes.fp8_e8m0) if w2.dtype == dtypes.fp4x2 else w2_scale
-        ),
-        a2_scale=a2_scale,
-        block_m=block_size_M,
-        sorted_weights=sorted_weights if not doweight_stage1 else None,
-        **extra_stage2_args,
+    w2_scale_stage2 = (
+        w2_scale.view(dtypes.fp8_e8m0) if w2.dtype == dtypes.fp4x2 else w2_scale
     )
+    sorted_weights_stage2 = sorted_weights if not doweight_stage1 else None
+
+    try:
+        metadata.stage2(
+            a2,
+            w1,
+            w2,
+            sorted_ids,
+            sorted_expert_ids,
+            num_valid_ids,
+            moe_out,
+            topk,
+            w2_scale=w2_scale_stage2,
+            a2_scale=a2_scale,
+            block_m=block_size_M,
+            sorted_weights=sorted_weights_stage2,
+            **extra_stage2_args,
+        )
+    except RuntimeError as e:
+        # Some TP-sharded MXFP4 MoE tuples on gfx950 can fail in CK stage2
+        # with an unsupported device_gemm configuration. Fall back to cktile
+        # stage2 for the same problem shape to preserve functionality.
+        fallback_enabled = os.environ.get("AITER_MOE_STAGE2_CK_FALLBACK", "1") != "0"
+        ck_unsupported = "device_gemm" in str(e)
+        can_fallback = (
+            fallback_enabled
+            and ck_unsupported
+            and quant_type == QuantType.per_1x32
+            and activation == ActivationType.Silu
+            and dtype in [dtypes.bf16, dtypes.fp16]
+            and w1.dtype == dtypes.fp4x2
+            and w2.dtype == dtypes.fp4x2
+        )
+
+        if not can_fallback:
+            raise
+
+        logger.warning(
+            "[fused_moe] CK stage2 failed, retry with cktile stage2: "
+            f"err={e}; token={token_num}, topk={topk}, model_dim={model_dim}, "
+            f"inter_dim={inter_dim}, expert={E}, block_m={block_size_M}, "
+            f"ksplit={metadata.ksplit}, q_type={quant_type}, act={activation}, "
+            f"dtype={dtype}, q_dtype_a={q_dtype_a}, q_dtype_w={q_dtype_w}"
+        )
+
+        cktile_moe_stage2(
+            a2,
+            w1,
+            w2,
+            sorted_ids,
+            sorted_expert_ids,
+            num_valid_ids,
+            moe_out,
+            topk,
+            w2_scale=w2_scale_stage2,
+            a2_scale=a2_scale,
+            block_m=block_size_M,
+            activation=activation,
+            sorted_weights=sorted_weights_stage2,
+            n_pad_zeros=hidden_pad // 64 * 64,
+            k_pad_zeros=intermediate_pad // 128 * 128,
+            **extra_stage2_args,
+        )
 
     return moe_out
 
@@ -2208,6 +2300,16 @@ def torch_moe_stage2(
         hidden_states = hidden_states.view(a2_shape)
 
         w2_shape = w2.shape
+        # Some TP-sharded models carry padded per_1x32 scale groups in w2_scale.
+        # Align scale groups to runtime inter_dim groups for robust torch fallback.
+        w2_scale = w2_scale.view(E, model_dim, -1)
+        w2_groups = inter_dim // 32
+        if w2_scale.shape[2] > w2_groups:
+            w2_scale = w2_scale[:, :, :w2_groups]
+        elif w2_scale.shape[2] < w2_groups:
+            pad = w2_groups - w2_scale.shape[2]
+            w2_scale = torch.nn.functional.pad(w2_scale, (0, pad), value=1.0)
+
         w2 = w2.view(E, model_dim, inter_dim // 32, 32) * w2_scale.view(
             E, model_dim, inter_dim // 32, 1
         )
@@ -2333,8 +2435,12 @@ def cktile_moe_stage1(
     needs_post_activation = split_k > 1
     # Split-k reduces into a token-topk workspace and applies activation after
     # reduction. Non-split legacy A16W4 keeps CK-Tile's fused gate/up epilogue.
-    workspace_rows = token_num * topk
     if needs_post_activation:
+        # CKTile kernel zeros this buffer via hipMemsetAsync when split_k > 1.
+        # Must be large enough to cover sorted_token_ids (= max_num_tokens_padded),
+        # otherwise the kernel overflows and corrupts adjacent memory.
+        # Mirror the fix from ck_moe_stage1 (ROCm/aiter#2508).
+        workspace_rows = min(token_num * topk * block_m, sorted_token_ids.shape[0])
         tmp_out = torch.zeros(
             (workspace_rows, w1.shape[1]), dtype=dtype, device=out.device
         )

--- a/aiter/ops/triton/_triton_kernels/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/_triton_kernels/quant/fused_mxfp4_quant.py
@@ -839,6 +839,8 @@ def _fused_dynamic_mxfp4_quant_moe_sort_kernel(
     stride_o4,  #: tl.constexpr,
     token_num,  #: tl.constexpr,
     N_i,  #: tl.constexpr,
+    N_o,  # number of valid scale columns (= scaleN)
+    N_o_padded,  # scale columns per shuffle tile (multiple of BLOCK_SIZE_N)
     MXFP4_QUANT_BLOCK_SIZE: tl.constexpr,
     BLOCK_SIZE_Mx: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
@@ -995,6 +997,7 @@ def _fused_dynamic_mxfp4_quant_moe_sort_kernel(
     offs_2 = pid_n  # // 2
     offs_3 = pid_m  # // 2
     offs_4 = tl.arange(0, 4)
+    # Position of each scale byte in the padded e8m0 shuffle layout.
     offs = (
         offs_0[:, None, None] * stride_o0
         + offs_1[None, :, None] * stride_o1  # * BLOCK_SIZE_M
@@ -1002,11 +1005,16 @@ def _fused_dynamic_mxfp4_quant_moe_sort_kernel(
         + offs_3 * stride_o3  # * BLOCK_SIZE_M * BLOCK_SIZE_N * N_i // BLOCK_SIZE_N
         + offs_4[None, None, :] * stride_o4
     )
-    # blockscale_e8m0_sorted_mask = (blockscale_e8m0_sorted_offs_m < M_o)[:, None] & (
-    #     blockscale_e8m0_sorted_offs_n < N_o
-    # )[None, :]
+    # Compact to N_o columns on store: the shuffle tiling spans N_o_padded
+    # columns, so drop the pad columns (>= N_o) and write directly into a
+    # contiguous (rows, N_o) buffer.  Equivalent to the previous
+    # `view(-1, N_o_padded)[:, :N_o].contiguous()` but without the extra copy.
+    col = offs % N_o_padded
+    row = offs // N_o_padded
+    dest = row * N_o + col
+    store_mask = col < N_o
     tl.store(
-        blockscale_e8m0_sorted_ptr + offs,
+        blockscale_e8m0_sorted_ptr + dest,
         out,
-        # mask=blockscale_e8m0_sorted_mask,
+        mask=store_mask,
     )

--- a/aiter/ops/triton/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/quant/fused_mxfp4_quant.py
@@ -610,7 +610,13 @@ def fused_dynamic_mxfp4_quant_moe_sort(
 
     N_i = scaleN
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
+    # Pad N_o to next multiple of BLOCK_SIZE_N so blockscale elements are
+    # evenly divisible when viewed as (-1, N_o_padded).  The extra columns
+    # are stripped before returning.
+    N_o_padded = triton.cdiv(N_o, BLOCK_SIZE_N) * BLOCK_SIZE_N
+    # Note: the (N_i // 2) % 2 == 0 assertion was removed because the kernel
+    # handles non-aligned scaleN (e.g. scaleN=6 at TP=8) through load masking
+    # and output padding/slicing.  Only N % 4 == 0 is required (for fp4 packing).
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(
@@ -649,9 +655,12 @@ def fused_dynamic_mxfp4_quant_moe_sort(
         TOPK=topk,
     )
 
+    scale_out = blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o_padded)
+    if N_o_padded != N_o:
+        scale_out = scale_out[:, :N_o].contiguous()
     return (
         x_fp4.view(dtypes.fp4x2),
-        blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o),
+        scale_out,
     )
 
 

--- a/aiter/ops/triton/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/quant/fused_mxfp4_quant.py
@@ -610,44 +610,55 @@ def fused_dynamic_mxfp4_quant_moe_sort(
 
     N_i = scaleN
     M_o, N_o = sorted_ids.shape[0], N_i
-    # Pad N_o to next multiple of BLOCK_SIZE_N so blockscale elements are
-    # evenly divisible when viewed as (-1, N_o_padded).  The extra columns
-    # are stripped before returning.
+    # The e8m0 shuffle tiling addresses scale columns in groups of BLOCK_SIZE_N,
+    # so a tile spans N_o_padded columns even when scaleN is not a multiple of
+    # BLOCK_SIZE_N (e.g. scaleN=6 at TP=8, scaleN=12 at TP=4).  The kernel
+    # computes each scale byte's position in that padded layout, then compacts
+    # to exactly N_o columns on store (masking the pad columns) so the returned
+    # tensor is already contiguous -- no post-hoc `[:, :N_o].contiguous()` copy.
     N_o_padded = triton.cdiv(N_o, BLOCK_SIZE_N) * BLOCK_SIZE_N
     # Note: the (N_i // 2) % 2 == 0 assertion was removed because the kernel
-    # handles non-aligned scaleN (e.g. scaleN=6 at TP=8) through load masking
-    # and output padding/slicing.  Only N % 4 == 0 is required (for fp4 packing).
+    # handles non-aligned scaleN through load masking and store-time column
+    # masking.  Only N % 4 == 0 is required (for fp4 packing).
     assert block_size % BLOCK_SIZE_M == 0
 
-    blockscale_e8m0_sorted = torch.empty(
-        (
-            triton.cdiv(M_o, BLOCK_SIZE_M),
-            triton.cdiv(N_o, BLOCK_SIZE_N),
-            BLOCK_SIZE_N_u32,
-            BLOCK_SIZE_M_u32,
-            4,
-        ),
-        dtype=torch.uint8,
-        device=x.device,
-    )  # .fill_(0)
+    n_block_m = triton.cdiv(M_o, BLOCK_SIZE_M)
+    n_block_n = triton.cdiv(N_o, BLOCK_SIZE_N)
+    rows_padded = n_block_m * BLOCK_SIZE_M
+    scale_out = torch.empty((rows_padded, N_o), dtype=torch.uint8, device=x.device)
 
-    num_pid = triton.cdiv(M, BLOCK_SIZE_Mx) * scaleN + triton.cdiv(
-        M_o, BLOCK_SIZE_M
-    ) * triton.cdiv(N_i, BLOCK_SIZE_N)
+    # Contiguous strides of the padded shuffle buffer
+    # (n_block_m, n_block_n, BLOCK_SIZE_N_u32, BLOCK_SIZE_M_u32, 4); the kernel
+    # uses these to derive the padded flat position of each scale byte before
+    # compacting it into scale_out.
+    blockscale_numel = BLOCK_SIZE_N_u32 * BLOCK_SIZE_M_u32 * 4  # 256
+    o_stride3 = n_block_n * blockscale_numel
+    o_stride2 = blockscale_numel
+    o_stride1 = BLOCK_SIZE_M_u32 * 4
+    o_stride0 = 4
+    o_stride4 = 1
+
+    num_pid = triton.cdiv(M, BLOCK_SIZE_Mx) * scaleN + n_block_m * n_block_n
     _fused_dynamic_mxfp4_quant_moe_sort_kernel[(num_pid,)](
         x,
         x_fp4,
         sorted_ids,
         num_valid_ids,
-        blockscale_e8m0_sorted,
+        scale_out,
         M,
         N,
         scaleN,
         *x.stride(),
         *x_fp4.stride(),
-        *blockscale_e8m0_sorted.stride(),
+        o_stride3,
+        o_stride2,
+        o_stride1,
+        o_stride0,
+        o_stride4,
         token_num=token_num,
         N_i=N_i,
+        N_o=N_o,
+        N_o_padded=N_o_padded,
         MXFP4_QUANT_BLOCK_SIZE=MXFP4_QUANT_BLOCK_SIZE,
         BLOCK_SIZE_Mx=BLOCK_SIZE_Mx,
         BLOCK_SIZE_M=BLOCK_SIZE_M // 2,
@@ -655,12 +666,9 @@ def fused_dynamic_mxfp4_quant_moe_sort(
         TOPK=topk,
     )
 
-    scale_out = blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o_padded)
-    if N_o_padded != N_o:
-        scale_out = scale_out[:, :N_o].contiguous()
     return (
         x_fp4.view(dtypes.fp4x2),
-        scale_out,
+        scale_out.view(dtypes.fp8_e8m0),
     )
 
 

--- a/aiter/utility/fp4_utils.py
+++ b/aiter/utility/fp4_utils.py
@@ -75,6 +75,30 @@ def e8m0_shuffle(scale):
     return shuffle_scale(scale)
 
 
+def e8m0_unshuffle(scale):
+    """Inverse of the e8m0-shuffled layout written by fused_dynamic_mxfp4_quant_moe_sort_hip.
+    Converts from the C++ kernel's fp4_scale_shuffle_id layout back to linear row-major
+    layout, as expected by CK JIT kernels (DeviceMoeGemmMXBPreShuffle, Scale_Stride_AM).
+
+    The scale buffer has shape [m, K/32] where m is a multiple of 32 (not necessarily 256).
+    No padding is applied — the C++ and Python shuffle are equivalent for any m % 32 == 0.
+    """
+    if scale is None:
+        return scale
+    if scale.dtype == torch.float32:
+        return scale
+    assert scale.ndim == 2, "scale must be a 2D tensor"
+    m, n = scale.shape
+    assert m % 32 == 0 and n % 8 == 0, f"scale {m}×{n} not aligned for unshuffle"
+    # The C++ kernel wrote in [m//32, n//8, 4, 16, 2, 2] permuted order (equivalent to
+    # e8m0_shuffle's .view(m//32, 2, 16, n//8, 2, 4).permute(0,3,5,2,4,1)).
+    # Inverse permutation of (0, 3, 5, 2, 4, 1) is (0, 5, 3, 1, 4, 2).
+    t = scale.view(torch.uint8).view(m // 32, n // 8, 4, 16, 2, 2)
+    t = t.permute(0, 5, 3, 1, 4, 2).contiguous()
+    t = t.view(m, n)
+    return t.view(scale.dtype)
+
+
 def down_size(size):
     assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
     return (*size[:-1], size[-1] // 2)
@@ -631,7 +655,8 @@ def moe_mxfp4_sort(
         blockscale_e8m0 = blockscale_e8m0.view(-1, blockscale_e8m0.shape[-1])
     M_i, N_i = blockscale_e8m0.shape
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
+    # (N_i // 2) % 2 == 0 assertion removed: the kernel handles non-aligned
+    # scaleN (e.g. N_i=6 at TP=8) through load masking and output slicing.
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(
@@ -676,5 +701,11 @@ def moe_mxfp4_sort(
         grid = (triton.cdiv(M_o, BLOCK_SIZE_M), triton.cdiv(N_i, BLOCK_SIZE_N))
         _moe_mxfp4_sort_kernel[grid](*common_args, **common_kwargs)
 
-    # Reshape the output to the final shape
-    return blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o)
+    # The sort kernel stores data in BLOCK_SIZE_N=8-wide blocks.  Reshape via
+    # the block-aligned column count, then slice back to the actual N_o so the
+    # CK tile GEMM kernel sees the correct scale stride (K/32 columns).
+    N_o_aligned = triton.cdiv(N_o, BLOCK_SIZE_N) * BLOCK_SIZE_N
+    scale_out = blockscale_e8m0_sorted.view(dtypes.fp8_e8m0).view(-1, N_o_aligned)
+    if N_o_aligned != N_o:
+        scale_out = scale_out[:, :N_o].contiguous()
+    return scale_out

--- a/csrc/ck_tile_gemm_moe_2stages/gen_instances.py
+++ b/csrc/ck_tile_gemm_moe_2stages/gen_instances.py
@@ -252,8 +252,8 @@ template torch::Tensor
                 )
             ).write_text(body)
 
-        if (k.QuantType == "1x32") and (a_type in ["bf16", "fp16", "fp8"]):
-            fill_template(k.name, self.a_dtype, "pk_fp4", self.acc_dtype, self.c_dtype)
+        if (k.QuantType == "1x32") and (a_type in ["bf16", "fp16", "fp8", "fp4"]):
+            fill_template(k.name, self.a_dtype, "fp4", self.acc_dtype, self.c_dtype)
         else:
             for CDtype in ["bf16", "fp16"]:
                 for ABDtype in ["fp8"]:  # "bf16", "fp16",
@@ -615,6 +615,7 @@ if __name__ == "__main__":
     a_types = ["bf16"]
     if get_gfx() == "gfx950":
         a_types.append("fp8")
+        a_types.append("fp4")
     b_type = "fp4"
     quant_type = "1x32"
 
@@ -652,8 +653,8 @@ if __name__ == "__main__":
     ):
         has_bias = True if act_type == "swiglu" else False
 
-        # a8w8 do not support
-        if a_type in ["fp8", "bf8"] and is_split_k:
+        # a8w8/a4w4 do not support split_k
+        if a_type in ["fp8", "bf8", "fp4"] and is_split_k:
             continue
         codegen = cktile_moe_2stage_gemm_codegen(
             args.working_path,
@@ -697,7 +698,7 @@ if __name__ == "__main__":
         # Collect kernel names with their C++ type arguments for name dispatch
         for mnk, k in kernel_dict_merge.items():
             name_lookup_entries.append(
-                (k.name, codegen.a_dtype, "pk_fp4", codegen.acc_dtype, codegen.c_dtype)
+                (k.name, codegen.a_dtype, "fp4", codegen.acc_dtype, codegen.c_dtype)
             )
 
     generate_common_header(args.working_path, gen_dispatch_files, gen_manifest_files)

--- a/csrc/ck_tile_gemm_moe_2stages/include/moe_cktile2stages.h
+++ b/csrc/ck_tile_gemm_moe_2stages/include/moe_cktile2stages.h
@@ -42,7 +42,7 @@ using col_major        = ck_tile::tensor_layout::gemm::ColumnMajor;
 using bf16             = ck_tile::bf16_t;
 using fp16             = ck_tile::half_t;
 using fp8              = ck_tile::fp8_t;
-using pk_fp4           = ck_tile::pk_fp4_t;
+using fp4              = ck_tile::pk_fp4_t;
 
 template <typename ADataType,
           typename BDataType,

--- a/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
+++ b/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
@@ -332,7 +332,7 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
         // }
         if(WQ.dtype() == torch_fp4x2 && Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<fp8, pk_fp4, float, bf16, 1>(
+            moe_dispatch<fp8, fp4, float, bf16, 1>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -355,12 +355,12 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
     {
         // if (Y.dtype() == at::ScalarType::Half)
         // {
-        //    moe_dispatch<fp16, pk_fp4, float, fp16, 1>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
+        //    moe_dispatch<fp16, fp4, float, fp16, 1>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
         //    sorted_expert_ids, max_token_ids, topk, topk_weight, x_scale, w_scale, exp_bias);
         // }
         if(Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<bf16, pk_fp4, float, bf16, 1>(
+            moe_dispatch<bf16, fp4, float, bf16, 1>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -376,6 +376,32 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
                                                                exp_bias,
                                                                act_op,
                                                                k_batch);
+        }
+    }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<fp4, fp4, float, bf16, 1>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm1!");
         }
     }
     else
@@ -467,7 +493,7 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
         // }
         if(WQ.dtype() == torch_fp4x2 && Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<fp8, pk_fp4, float, bf16, 2>(
+            moe_dispatch<fp8, fp4, float, bf16, 2>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -490,12 +516,12 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
     {
         // if (Y.dtype() == at::ScalarType::Half)
         // {
-        //    moe_dispatch<fp16, pk_fp4, float, fp16, 2>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
+        //    moe_dispatch<fp16, fp4, float, fp16, 2>(M, N, K, MPerBlock)(XQ, WQ, Y, sorted_ids,
         //    sorted_expert_ids, max_token_ids, topk, topk_weight, x_scale, w_scale, exp_bias);
         // }
         if(Y.dtype() == at::ScalarType::BFloat16)
         {
-            moe_dispatch<bf16, pk_fp4, float, bf16, 2>(
+            moe_dispatch<bf16, fp4, float, bf16, 2>(
                 M, N, K, MPerBlock, act_op, has_bias, k_batch)(XQ,
                                                                WQ,
                                                                Y,
@@ -511,6 +537,32 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
                                                                exp_bias,
                                                                act_op,
                                                                k_batch);
+        }
+    }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<fp4, fp4, float, bf16, 2>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm2!");
         }
     }
     else

--- a/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages_common.py
+++ b/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages_common.py
@@ -243,6 +243,23 @@ a8w4_gemm2_kernels_list_gfx950= {
     # 4: kernelInstance(       2,        256,      256,        128,       128,           16,         16,          32,          1,        4,),
 }
 
+
+# gemm1 out:bf16 AB:fp4/fp4 (MXFP4 quantized activations x MXFP4 weights)
+a4w4_gemm1_kernels_list_gfx950= {
+    #  kernel:           stage| BLOCK_SIZE|MPerBLOCK|  NPerBLOCK| KPerBLOCK| WAVE_TILE_M| WAVE_TILE_N| WAVE_TILE_K| WAVE_MAP_M| WAVE_MAP_N| BlockPerCU|
+    0: kernelInstance(       1,        256,       16,        128,       256,          16,         16,         128,          1,           4,          2,),
+    1: kernelInstance(       1,        256,       32,        256,       256,          16,         16,         128,          1,           4,          2,),
+    3: kernelInstance(       1,        256,       64,        256,       256,          16,         16,         128,          1,           4,          1,),
+}
+# gemm2 out:bf16 AB:fp4/fp4 (MXFP4 quantized activations x MXFP4 weights)
+a4w4_gemm2_kernels_list_gfx950= {
+    #  kernel:           stage| BLOCK_SIZE|MPerBLOCK|  NPerBLOCK| KPerBLOCK| WAVE_TILE_M| WAVE_TILE_N| WAVE_TILE_K| WAVE_MAP_M| WAVE_MAP_N| BlockPerCU|
+    # KPerBlock min=256 for fp4 (CK tile mixed_prec pipeline requires K1*K2=256)
+    0: kernelInstance(       2,        256,       16,        128,       256,          16,         16,         128,          1,        4,            2,),
+    1: kernelInstance(       2,        256,       32,        256,       256,          16,         16,         128,          1,        4,            2,),
+    3: kernelInstance(       2,        256,       64,        256,       256,          16,         16,         128,          1,        4,            1,),
+}
+
 # fmt: on
 gemm1_kernels_dict = {
     tag: expand_blockpercu(kdict)
@@ -252,6 +269,7 @@ gemm1_kernels_dict = {
         "a16w4_gfx950": a16w4_gemm1_kernels_list_gfx950,
         "a16w4": a16w4_gemm1_kernels_list,
         "a8w4_gfx950": a8w4_gemm1_kernels_list_gfx950,
+        "a4w4_gfx950": a4w4_gemm1_kernels_list_gfx950,
     }.items()
 }
 
@@ -263,6 +281,7 @@ gemm2_kernels_dict = {
         "a16w4_gfx950": a16w4_gemm2_kernels_list_gfx950,
         "a16w4": a16w4_gemm2_kernels_list,
         "a8w4_gfx950": a8w4_gemm2_kernels_list_gfx950,
+        "a4w4_gfx950": a4w4_gemm2_kernels_list_gfx950,
     }.items()
 }
 
@@ -519,12 +538,77 @@ struct moe_gemm2_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_da
 }};
 """
 
+
+a4w4_gfx950_heuristic_dispatch = """#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "moe_cktile2stages.h"
+#include "moe_cktile2stages_heuristic_dispatch_common.h"
+
+template <>
+struct moe_gemm1_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}, {(activation)}, {(has_bias)}, {(split_k)}>
+{{
+    static MoeKernel dispatch(int M, int N, int K, int block_m)
+    {{
+        // Apply shape heuristics to find a suitable kernel implementation.
+        if (block_m == 16)
+        {{
+            return {(1, 0)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 32)
+        {{
+            return {(1, 1)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 64)
+        {{
+            return {(1, 3)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else
+        {{
+            TORCH_CHECK(
+                false,
+                "Unsupported block_m value for moe_gemm1 a4w4 heuristic dispatch: ",
+                block_m);
+        }}
+    }}
+}};
+
+template <>
+struct moe_gemm2_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}, {(activation)}, {(has_bias)}, {(split_k)}>
+{{
+    static MoeKernel dispatch(int M, int N, int K, int block_m)
+    {{
+        // KPerBlock=256 is the minimum for fp4 (CK tile mixed_prec pipeline
+        // requires K1*K2=256). The kernel handles K < KPerBlock via masking.
+        if (block_m == 16)
+        {{
+            return {(2, 0)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 32)
+        {{
+            return {(2, 1)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 64)
+        {{
+            return {(2, 3)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else
+        {{
+            TORCH_CHECK(
+                false,
+                "Unsupported block_m value for moe_gemm2 a4w4 heuristic dispatch: ",
+                block_m);
+        }}
+    }}
+}};
+"""
 heuristic_dispatch_dict = {
     "a8w8_gfx950": a8w8_gfx950_heuristic_dispatch,
     # "a8w8": a8w8_gemm2_kernels_list,
     "a16w4_gfx950": a16w4_gfx950_heuristic_dispatch,
     "a16w4": a16w4_heuristic_dispatch,
     "a8w4_gfx950": a8w4_gfx950_heuristic_dispatch,
+    "a4w4_gfx950": a4w4_gfx950_heuristic_dispatch,
 }
 
 
@@ -557,6 +641,13 @@ def get_gemm1_kernels_list(
     elif Adtype.lower() in bit8_list and Bdtype in bit4_list:
         if arch == "gfx950":
             tag = "a8w4_gfx950"
+        else:
+            raise ValueError(
+                f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
+            )
+    elif Adtype in bit4_list and Bdtype in bit4_list:
+        if arch == "gfx950":
+            tag = "a4w4_gfx950"
         else:
             raise ValueError(
                 f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
@@ -606,6 +697,13 @@ def get_gemm2_kernels_list(
     elif Adtype.lower() in bit8_list and Bdtype in bit4_list:
         if arch == "gfx950":
             tag = "a8w4_gfx950"
+        else:
+            raise ValueError(
+                f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
+            )
+    elif Adtype in bit4_list and Bdtype in bit4_list:
+        if arch == "gfx950":
+            tag = "a4w4_gfx950"
         else:
             raise ValueError(
                 f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -248,6 +248,18 @@ def test_fmoe(
         w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, True)
         w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
         w2_scale_aiter = shuffle_scale_a16w4(w2_scale, E, False)
+    elif (
+        qType == aiter.QuantType.per_1x32
+        and AQDType == dtypes.fp4x2
+        and WQDType == dtypes.fp4x2
+    ):  # a4w4: both stage1 and stage2 use JIT CK (DeviceMoeGemmMXBPreShuffle)
+        # Both use preShuffleBuffer format = shuffle_weight_a16w4(gate_up=False)
+        # / shuffle_scale_a16w4(gate_up=False). Unlike a16w4, the a4w4 kernel
+        # uses gate_up=False for stage1 even though w1 has 2*N rows.
+        w1_qt_aiter = shuffle_weight_a16w4(w1_qt_aiter, 16, False)
+        w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, False)
+        w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
+        w2_scale_aiter = shuffle_scale_a16w4(w2_scale, E, False)
     elif WQDType != dtypes.fp4x2 or preshuffle:
         w1_qt_aiter = shuffle_weight(w1_qt_aiter, layout=(16, 16))
         w2_qt_aiter = shuffle_weight(w2_qt_aiter, layout=(16, 16))


### PR DESCRIPTION
Based on [PR](https://github.com/ROCm/aiter/pull/2642)

```
HIP_VISIBLE_DEVICES=0,5,6,7 \
AITER_LOG_LEVEL=WARNING \
python -m atom.entrypoints.openai_server \
  --model /shareddata/amd/MiniMax-M2.1-MXFP4 \
  --trust-remote-code \
  -tp 4 \
  --port 5679 \
  --server-port 7778

lm_eval \
  --model local-completions \
  --model_args "model=/shareddata/amd/MiniMax-M2.1-MXFP4,base_url=http://localhost:7778/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto

```

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9287|±  |0.0071|
|     |       |strict-match    |     5|exact_match|↑  |0.9272|±  |0.0072|
