### PR TITLE
Add PER_TOKEN_HEAD FP8 quantization and P-scale for mha_batch_prefill

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -980,13 +980,19 @@ def cmdGenFunc_mha_batch_prefill(
     kv_block_descale: Optional[Tensor] = None,  # [num_block, num_kv_head, 2]
     # PER_TOKEN_HEAD mode descales (mutually exclusive with above)
     q_descale_per_token: Optional[Tensor] = None,  # [total_q, nhead_q] fp32
-    k_descale_per_token: Optional[Tensor] = None,  # [num_total_pages, page_block_size, nhead_k] fp32
-    v_descale_per_head: Optional[Tensor] = None,   # [nhead_k] fp32
+    k_descale_per_token: Optional[
+        Tensor
+    ] = None,  # [num_total_pages, page_block_size, nhead_k] fp32
+    v_descale_per_head: Optional[Tensor] = None,  # [nhead_k] fp32
     sink_ptr: Optional[Tensor] = None,
     gen: Optional[Generator] = None,
     kv_last_page_lens: Optional[Tensor] = None,
     block_table: Optional[Tensor] = None,
     seqlen_k: Optional[Tensor] = None,
+    # PER_TOKEN_HEAD caller P scale: not part of the kernel cache key (handled
+    # at runtime), declared here only for positional-forwarding compatibility.
+    p_scale: Optional[Tensor] = None,
+    p_scale_inv: Optional[Tensor] = None,
 ):
     # causal=true is the same as causal=false in this case
     causal = is_causal
@@ -2879,6 +2885,11 @@ def mha_batch_prefill(
     seqlen_k: Optional[Tensor] = None,
     sink_ptr: Optional[Tensor] = None,
     gen: Optional[Generator] = None,
+    # PER_TOKEN_HEAD optional per-q-head P scale [num_head_q] fp32.
+    # p_scale_inv is accepted for API parity but unused (the kernel folds
+    # log2(p_scale) into the exp2 row-max shift instead of dividing).
+    p_scale: Optional[torch.Tensor] = None,
+    p_scale_inv: Optional[torch.Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]: ...
 
 
@@ -2917,6 +2928,8 @@ def _mha_batch_prefill(
     k_descale_per_token: Optional[torch.Tensor] = None,
     v_descale_per_head: Optional[torch.Tensor] = None,
     sink_ptr: Optional[Tensor] = None,
+    p_scale: Optional[torch.Tensor] = None,
+    p_scale_inv: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
 
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
@@ -2954,6 +2967,8 @@ def _mha_batch_prefill(
         seqlen_k,
         sink_ptr,
         None,
+        p_scale,
+        p_scale_inv,
     )
     return out, softmax_lse, S_dmask, rng_state
 
@@ -2986,9 +3001,13 @@ def mha_batch_prefill_func(
     kv_block_descale=None,  # [num_block, num_kv_head, 2] per-page K/V descales
     q_descale_per_token=None,  # [total_q, nhead_q] fp32 (PER_TOKEN_HEAD mode)
     k_descale_per_token=None,  # [num_total_pages, page_block_size, nhead_k] fp32
-    v_descale_per_head=None,   # [nhead_k] fp32
+    v_descale_per_head=None,  # [nhead_k] fp32
     sink_ptr=None,
     sink_size: int = 0,
+    # PER_TOKEN_HEAD optional per-q-head P scale [num_head_q] fp32; p_scale_inv
+    # accepted for API parity but unused (folded via exp2-shift, see kernel).
+    p_scale=None,
+    p_scale_inv=None,
 ):
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
@@ -3057,6 +3076,8 @@ def mha_batch_prefill_func(
         k_descale_per_token=k_descale_per_token,
         v_descale_per_head=v_descale_per_head,
         sink_ptr=sink_ptr,
+        p_scale=p_scale,
+        p_scale_inv=p_scale_inv,
     )
     out = out_padded[..., :head_size_v_og]
 

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -980,10 +980,8 @@ def cmdGenFunc_mha_batch_prefill(
     kv_block_descale: Optional[Tensor] = None,  # [num_block, num_kv_head, 2]
     # PER_TOKEN_HEAD mode descales (mutually exclusive with above)
     q_descale_per_token: Optional[Tensor] = None,  # [total_q, nhead_q] fp32
-    k_descale_per_token: Optional[
-        Tensor
-    ] = None,  # [num_total_pages, page_block_size, nhead_k] fp32
-    v_descale_per_head: Optional[Tensor] = None,  # [nhead_k] fp32
+    k_descale_per_token: Optional[Tensor] = None,  # [num_total_pages, page_block_size, nhead_k] fp32
+    v_descale_per_head: Optional[Tensor] = None,   # [nhead_k] fp32
     sink_ptr: Optional[Tensor] = None,
     gen: Optional[Generator] = None,
     kv_last_page_lens: Optional[Tensor] = None,
@@ -3001,7 +2999,7 @@ def mha_batch_prefill_func(
     kv_block_descale=None,  # [num_block, num_kv_head, 2] per-page K/V descales
     q_descale_per_token=None,  # [total_q, nhead_q] fp32 (PER_TOKEN_HEAD mode)
     k_descale_per_token=None,  # [num_total_pages, page_block_size, nhead_k] fp32
-    v_descale_per_head=None,  # [nhead_k] fp32
+    v_descale_per_head=None,   # [nhead_k] fp32
     sink_ptr=None,
     sink_size: int = 0,
     # PER_TOKEN_HEAD optional per-q-head P scale [num_head_q] fp32; p_scale_inv
@@ -3020,13 +3018,22 @@ def mha_batch_prefill_func(
     # 16 bytes = 128-bit (dwordx4) vector width assumed by CK kernels.
     k_vector_size = 16 // k.element_size()
     is_vectorized = k.dim() == 5 and v.dim() == 5
+    # Decode-aligned VEC_K_COL_V layout: K is 5D vectorized, V is 4D ColumnMajor
+    # [Pages, NumHeads, HeadDim, PageSize].
+    is_vec_k_col_v = k.dim() == 5 and v.dim() == 4
     is_linear = (k.dim() == 4 and v.dim() == 4) or (k.dim() == 3 and v.dim() == 3)
-    if not (is_vectorized or is_linear):
+    if not (is_vectorized or is_vec_k_col_v or is_linear):
         raise ValueError(
-            "Batch prefill requires 5D vectorized, 4D linear, or 3D linear (page_size=1) K/V"
-            " tensors"
+            "Batch prefill requires 5D vectorized, 4D linear, 3D linear (page_size=1), or"
+            " VEC_K_COL_V (5D K + 4D V) K/V tensors"
         )
-    head_size_v_og = v.size(-2) if is_vectorized else v.size(-1)
+    if is_vectorized:
+        head_size_v_og = v.size(-2)
+    elif is_vec_k_col_v:
+        # V layout [Pages, NumHeads, HeadDim, PageSize] -> head_dim is dim -2
+        head_size_v_og = v.size(-2)
+    else:
+        head_size_v_og = v.size(-1)
     if head_size_q_og % k_vector_size != 0 or head_size_v_og % k_vector_size != 0:
         raise ValueError("Batch prefill requires head size divisible by vector size")
     if is_vectorized:
@@ -3038,6 +3045,25 @@ def mha_batch_prefill_func(
             )
         if v.size(-1) != k_vector_size:
             raise ValueError("Vectorized KV requires last dim equal to vector size")
+    elif is_vec_k_col_v:
+        # K constraints identical to is_vectorized branch above.
+        if k.size(-3) * k_vector_size != head_size_q_og:
+            raise ValueError("K vectorized layout does not match Q head size")
+        if k.size(-2) % k_vector_size != 0:
+            raise ValueError(
+                "VEC_K_COL_V requires K page size divisible by vector size"
+            )
+        # V is [Pages, NumHeads, HeadDim, PageSize]; PageSize must match K's page size,
+        # head count must match, and the contiguous (PageSize) dim must match.
+        page_size_k = k.size(-2)
+        if v.size(0) != k.size(0):
+            raise ValueError("VEC_K_COL_V V/K num_blocks mismatch")
+        if v.size(1) != k.size(1):
+            raise ValueError("VEC_K_COL_V V/K num_heads mismatch")
+        if v.size(-1) != page_size_k:
+            raise ValueError(
+                "VEC_K_COL_V V innermost (PageSize) dim must equal K page size"
+            )
     else:
         if k.size(-1) != head_size_q_og:
             raise ValueError("K linear layout does not match Q head size")

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -978,6 +978,10 @@ def cmdGenFunc_mha_batch_prefill(
     # Per-page descale for KV_BLOCKSCALE mode (Q per-tensor, K/V per-page)
     # Mutually exclusive with k_descale/v_descale
     kv_block_descale: Optional[Tensor] = None,  # [num_block, num_kv_head, 2]
+    # PER_TOKEN_HEAD mode descales (mutually exclusive with above)
+    q_descale_per_token: Optional[Tensor] = None,  # [total_q, nhead_q] fp32
+    k_descale_per_token: Optional[Tensor] = None,  # [num_total_pages, page_block_size, nhead_k] fp32
+    v_descale_per_head: Optional[Tensor] = None,   # [nhead_k] fp32
     sink_ptr: Optional[Tensor] = None,
     gen: Optional[Generator] = None,
     kv_last_page_lens: Optional[Tensor] = None,
@@ -1040,6 +1044,10 @@ def cmdGenFunc_mha_batch_prefill(
         # KV_BLOCKSCALE: Q per-tensor, K/V per-page
         md_name += "_kv_blockscale"
         filter_fwd += "_kv_blockscale*"
+    elif q_descale_per_token is not None:
+        # PER_TOKEN_HEAD mode
+        md_name += "_per_token_head"
+        filter_fwd += "_per_token_head*"
     elif q_descale is None or k_descale is None or v_descale is None:
         md_name += "_nqscale"
         filter_fwd += "_nqscale*"
@@ -2773,6 +2781,10 @@ def mha_batch_prefill_fake_tensors(
     v_descale: Optional[torch.Tensor] = None,  # [1] per-tensor V descale
     # Per-page descale for KV_BLOCKSCALE mode (mutually exclusive with k_descale/v_descale)
     kv_block_descale: Optional[torch.Tensor] = None,  # [num_block, num_kv_head, 2]
+    # PER_TOKEN_HEAD mode descales
+    q_descale_per_token: Optional[torch.Tensor] = None,
+    k_descale_per_token: Optional[torch.Tensor] = None,
+    v_descale_per_head: Optional[torch.Tensor] = None,
     sink_ptr: Optional[Tensor] = None,
     gen: Optional[Generator] = None,
     kv_last_page_lens: Optional[torch.Tensor] = None,
@@ -2858,6 +2870,10 @@ def mha_batch_prefill(
     v_descale: Optional[torch.Tensor] = None,  # [1] per-tensor V descale
     # Per-page descale for KV_BLOCKSCALE mode (mutually exclusive with k_descale/v_descale)
     kv_block_descale: Optional[torch.Tensor] = None,  # [num_block, num_kv_head, 2]
+    # PER_TOKEN_HEAD mode descales
+    q_descale_per_token: Optional[torch.Tensor] = None,
+    k_descale_per_token: Optional[torch.Tensor] = None,
+    v_descale_per_head: Optional[torch.Tensor] = None,
     kv_last_page_lens: Optional[Tensor] = None,
     block_table: Optional[Tensor] = None,
     seqlen_k: Optional[Tensor] = None,
@@ -2897,6 +2913,9 @@ def _mha_batch_prefill(
     kv_block_descale: Optional[
         torch.Tensor
     ] = None,  # [num_block, num_kv_head, 2] per-page K/V descales
+    q_descale_per_token: Optional[torch.Tensor] = None,
+    k_descale_per_token: Optional[torch.Tensor] = None,
+    v_descale_per_head: Optional[torch.Tensor] = None,
     sink_ptr: Optional[Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
 
@@ -2927,6 +2946,9 @@ def _mha_batch_prefill(
         k_descale,
         v_descale,
         kv_block_descale,
+        q_descale_per_token,
+        k_descale_per_token,
+        v_descale_per_head,
         kv_last_page_lens,
         block_table,
         seqlen_k,
@@ -2962,6 +2984,9 @@ def mha_batch_prefill_func(
     k_descale=None,
     v_descale=None,
     kv_block_descale=None,  # [num_block, num_kv_head, 2] per-page K/V descales
+    q_descale_per_token=None,  # [total_q, nhead_q] fp32 (PER_TOKEN_HEAD mode)
+    k_descale_per_token=None,  # [num_total_pages, page_block_size, nhead_k] fp32
+    v_descale_per_head=None,   # [nhead_k] fp32
     sink_ptr=None,
     sink_size: int = 0,
 ):
@@ -3028,6 +3053,9 @@ def mha_batch_prefill_func(
         k_descale=k_descale,
         v_descale=v_descale,
         kv_block_descale=kv_block_descale,
+        q_descale_per_token=q_descale_per_token,
+        k_descale_per_token=k_descale_per_token,
+        v_descale_per_head=v_descale_per_head,
         sink_ptr=sink_ptr,
     )
     out = out_padded[..., :head_size_v_og]

--- a/csrc/cpp_itfs/mha_fwd_batch_prefill.cu
+++ b/csrc/cpp_itfs/mha_fwd_batch_prefill.cu
@@ -17,7 +17,8 @@ get_mha_batch_prefill_traits(int head_size_q,
                              ck_tile::BlockAttentionKVCacheLookupTableEnum kv_lookup_table,
                              int page_size,
                              bool skip_min_seqlen_q = false,
-                             bool has_sink         = false)
+                             bool has_sink         = false,
+                             bool is_v_rowmajor    = true)
 {
     return mha_batch_prefill_traits(head_size_q,
                                     head_size_v,
@@ -33,7 +34,8 @@ get_mha_batch_prefill_traits(int head_size_q,
                                     has_sink,
                                     kv_memory_layout,
                                     kv_lookup_table,
-                                    page_size);
+                                    page_size,
+                                    is_v_rowmajor);
 }
 
 float mha_batch_prefill(mha_batch_prefill_args args,
@@ -56,6 +58,8 @@ float mha_batch_prefill(mha_batch_prefill_args args,
     // dispatcher in fmha_batch_prefill_api.cpp, where each arm knows its own
     // compile-time bn0 and dtype element size. The wrapper just forwards args;
     // no runtime trait field for it.
+    // The wrapper sets args.is_v_rowmajor=false only for the decode-aligned
+    // VEC_K_COL_V_LAYOUT path; all other paths keep V as RowMajor.
     auto traits      = get_mha_batch_prefill_traits(head_size_q,
                                                head_size_v,
                                                q_dtype_str,
@@ -70,7 +74,8 @@ float mha_batch_prefill(mha_batch_prefill_args args,
                                                args.kv_lookup_table,
                                                args.page_block_size,
                                                /*skip_min_seqlen_q=*/false,
-                                               has_sink);
+                                               has_sink,
+                                               args.is_v_rowmajor);
     return fmha_batch_prefill(traits, args, stream_config);
 }
 

--- a/csrc/include/mha_fwd.h
+++ b/csrc/include/mha_fwd.h
@@ -66,12 +66,15 @@ struct mha_batch_prefill_traits : public fmha_batch_prefill_traits
                              bool has_sink,
                              ck_tile::BlockAttentionKVCacheMemoryLayoutEnum kv_memory_layout,
                              ck_tile::BlockAttentionKVCacheLookupTableEnum kv_lookup_table,
-                             int page_size)
+                             int page_size,
+                             // false only for the decode-aligned VEC_K_COL_V_LAYOUT
+                             // (V is 4D ColumnMajor [Pages, Heads, HeadDim, PageSize]).
+                             bool is_v_rowmajor = true)
         : fmha_batch_prefill_traits{head_size_q,
                                     head_size_v,
                                     dtype,
                                     is_group_mode,
-                                    true, // is_v_rowmajor
+                                    is_v_rowmajor,
                                     has_logits_soft_cap,
                                     mask_type,
                                     bias_type,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1186,12 +1186,15 @@ namespace py = pybind11;
           py::arg("q_descale")         = std::nullopt, \
           py::arg("k_descale")         = std::nullopt, \
           py::arg("v_descale")         = std::nullopt, \
-          py::arg("kv_block_descale")  = std::nullopt, \
-          py::arg("kv_last_page_lens") = std::nullopt, \
-          py::arg("block_table")       = std::nullopt, \
-          py::arg("seqlen_k")          = std::nullopt, \
-          py::arg("sink_ptr")          = std::nullopt, \
-          py::arg("gen")               = std::nullopt);
+          py::arg("kv_block_descale")     = std::nullopt, \
+          py::arg("q_descale_per_token")  = std::nullopt, \
+          py::arg("k_descale_per_token")  = std::nullopt, \
+          py::arg("v_descale_per_head")   = std::nullopt, \
+          py::arg("kv_last_page_lens")    = std::nullopt, \
+          py::arg("block_table")          = std::nullopt, \
+          py::arg("seqlen_k")             = std::nullopt, \
+          py::arg("sink_ptr")             = std::nullopt, \
+          py::arg("gen")                  = std::nullopt);
 
 #define MOE_OP_PYBIND                                                          \
     m.def("topk_softmax",                                                      \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1194,7 +1194,9 @@ namespace py = pybind11;
           py::arg("block_table")          = std::nullopt, \
           py::arg("seqlen_k")             = std::nullopt, \
           py::arg("sink_ptr")             = std::nullopt, \
-          py::arg("gen")                  = std::nullopt);
+          py::arg("gen")                  = std::nullopt, \
+          py::arg("p_scale")              = std::nullopt, \
+          py::arg("p_scale_inv")          = std::nullopt);
 
 #define MOE_OP_PYBIND                                                          \
     m.def("topk_softmax",                                                      \

--- a/csrc/include/torch/mha_batch_prefill.h
+++ b/csrc/include/torch/mha_batch_prefill.h
@@ -43,7 +43,13 @@ mha_batch_prefill(at::Tensor& q,                  // [total_q, hq, d]
                   std::optional<const at::Tensor> block_table,
                   std::optional<const at::Tensor> seqlen_k,
                   std::optional<const at::Tensor> sink_ptr_, // [hq];
-                  std::optional<at::Generator> gen_);
+                  std::optional<at::Generator> gen_,
+                  // PER_TOKEN_HEAD optional per-q-head P scale [num_head_q]
+                  // fp32. ``p_scale_inv`` is accepted for API parity with
+                  // explicit-multiply implementations but unused internally;
+                  // the kernel folds log2(p_scale) into the exp2 row-max shift.
+                  std::optional<const at::Tensor> p_scale = std::nullopt,
+                  std::optional<const at::Tensor> p_scale_inv = std::nullopt);
 
 } // namespace torch_itfs
 } // namespace aiter

--- a/csrc/include/torch/mha_batch_prefill.h
+++ b/csrc/include/torch/mha_batch_prefill.h
@@ -34,6 +34,11 @@ mha_batch_prefill(at::Tensor& q,                  // [total_q, hq, d]
                   // Per-page descale for KV_BLOCKSCALE mode (Q per-tensor, K/V per-page)
                   // Mutually exclusive with k_descale/v_descale
                   std::optional<const at::Tensor> kv_block_descale, // [num_block, num_kv_head, 2]
+                  // PER_TOKEN_HEAD mode descales (Q/K per-token per-head, V per-head).
+                  // Mutually exclusive with q/k/v_descale and kv_block_descale.
+                  std::optional<const at::Tensor> q_descale_per_token,
+                  std::optional<const at::Tensor> k_descale_per_token,
+                  std::optional<const at::Tensor> v_descale_per_head,
                   std::optional<const at::Tensor> kv_last_page_lens,
                   std::optional<const at::Tensor> block_table,
                   std::optional<const at::Tensor> seqlen_k,

--- a/csrc/py_itfs_ck/mha_batch_prefill_kernels.cu
+++ b/csrc/py_itfs_ck/mha_batch_prefill_kernels.cu
@@ -44,6 +44,9 @@ get_ck_fmha_batch_prefill_args(bool has_lse,
                                std::optional<const at::Tensor>& q_descale_per_token,
                                std::optional<const at::Tensor>& k_descale_per_token,
                                std::optional<const at::Tensor>& v_descale_per_head,
+                               // PER_TOKEN_HEAD optional per-q-head P scale.
+                               std::optional<const at::Tensor>& p_scale,
+                               std::optional<const at::Tensor>& p_scale_inv,
                                at::Tensor out,
                                at::Tensor softmax_lse,
                                at::Tensor dropout_randval,
@@ -447,6 +450,37 @@ get_ck_fmha_batch_prefill_args(bool has_lse,
         args.stride_k_descale_token    = k_sc.stride(1);
         args.nhead_stride_k_descale    = k_sc.stride(2);
         args.nhead_stride_v_descale    = v_sc.stride(0);
+
+        // Optional per-q-head P scale. We fold log2(p_scale) into the exp2
+        // row-max shift in the kernel; p_scale_inv is accepted for API parity
+        // but unused (the shift-fold doesn't need a reciprocal).
+        if(p_scale.has_value())
+        {
+            auto p_sc = p_scale.value();
+            CHECK_DEVICE(p_sc);
+            TORCH_CHECK(p_sc.scalar_type() == at::kFloat,
+                        "p_scale must be float32");
+            TORCH_CHECK(p_sc.dim() == 1 && p_sc.size(0) == h,
+                        "p_scale must be 1D with shape [num_head_q]");
+            TORCH_CHECK(p_sc.stride(0) == 1,
+                        "p_scale must be contiguous along its head dim");
+            args.p_scale_ptr = p_sc.data_ptr();
+
+            if(p_scale_inv.has_value())
+            {
+                auto p_sc_inv = p_scale_inv.value();
+                CHECK_DEVICE(p_sc_inv);
+                TORCH_CHECK(p_sc_inv.scalar_type() == at::kFloat,
+                            "p_scale_inv must be float32");
+                TORCH_CHECK(p_sc_inv.dim() == 1 && p_sc_inv.size(0) == h,
+                            "p_scale_inv must be 1D with shape [num_head_q]");
+            }
+        }
+        else
+        {
+            TORCH_CHECK(!p_scale_inv.has_value(),
+                        "p_scale_inv may only be supplied together with p_scale.");
+        }
     }
 
     return args;
@@ -486,7 +520,10 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
                   std::optional<const at::Tensor> block_table_,
                   std::optional<const at::Tensor> seqlen_k_,
                   std::optional<const at::Tensor> sink_ptr,      // [hq]
-                  std::optional<at::Generator> gen_
+                  std::optional<at::Generator> gen_,
+                  // PER_TOKEN_HEAD optional per-q-head P scale (see header).
+                  std::optional<const at::Tensor> p_scale,
+                  std::optional<const at::Tensor> p_scale_inv
                 )
 {
     auto q_dtype = q.scalar_type();
@@ -845,6 +882,8 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
                                                    q_descale_per_token,
                                                    k_descale_per_token,
                                                    v_descale_per_head,
+                                                   p_scale,
+                                                   p_scale_inv,
                                                    out,
                                                    softmax_lse,
                                                    p,

--- a/csrc/py_itfs_ck/mha_batch_prefill_kernels.cu
+++ b/csrc/py_itfs_ck/mha_batch_prefill_kernels.cu
@@ -40,6 +40,10 @@ get_ck_fmha_batch_prefill_args(bool has_lse,
                                // Per-page descale for KV_BLOCKSCALE mode (Q per-tensor, K/V per-page)
                                // Mutually exclusive with k_descale/v_descale
                                std::optional<const at::Tensor>& kv_block_descale, // [num_block, num_kv_head, 2]
+                               // PER_TOKEN_HEAD mode descales.
+                               std::optional<const at::Tensor>& q_descale_per_token,
+                               std::optional<const at::Tensor>& k_descale_per_token,
+                               std::optional<const at::Tensor>& v_descale_per_head,
                                at::Tensor out,
                                at::Tensor softmax_lse,
                                at::Tensor dropout_randval,
@@ -401,6 +405,50 @@ get_ck_fmha_batch_prefill_args(bool has_lse,
         args.nhead_stride_kv_block_descale  = k_descale_view.stride(1);
     }
 
+    // PER_TOKEN_HEAD: Q/K per-token per-head, V per-head. All three tensors required.
+    // Reuses args.q_descale_ptr / args.k_descale_ptr / args.v_descale_ptr; layout & strides
+    // disambiguated by the kernel via qscale_type.
+    if(q_descale_per_token.has_value())
+    {
+        TORCH_CHECK(k_descale_per_token.has_value() && v_descale_per_head.has_value(),
+                    "PER_TOKEN_HEAD mode requires q_descale_per_token, k_descale_per_token, "
+                    "and v_descale_per_head to all be provided.");
+
+        auto q_sc = q_descale_per_token.value();
+        auto k_sc = k_descale_per_token.value();
+        auto v_sc = v_descale_per_head.value();
+        CHECK_DEVICE(q_sc);
+        CHECK_DEVICE(k_sc);
+        CHECK_DEVICE(v_sc);
+        TORCH_CHECK(q_sc.scalar_type() == at::kFloat, "q_descale_per_token must be float32");
+        TORCH_CHECK(k_sc.scalar_type() == at::kFloat, "k_descale_per_token must be float32");
+        TORCH_CHECK(v_sc.scalar_type() == at::kFloat, "v_descale_per_head must be float32");
+
+        TORCH_CHECK(q_sc.dim() == 2,
+                    "q_descale_per_token must be 2D [total_q, nhead_q]");
+        TORCH_CHECK(q_sc.size(0) == total_q && q_sc.size(1) == h,
+                    "q_descale_per_token must have shape [total_q, nhead_q]");
+
+        TORCH_CHECK(k_sc.dim() == 3,
+                    "k_descale_per_token must be 3D [num_total_pages, page_block_size, nhead_k]");
+        TORCH_CHECK(k_sc.size(0) == num_total_pages && k_sc.size(1) == page_block_size &&
+                        k_sc.size(2) == h_k,
+                    "k_descale_per_token must have shape [num_total_pages, page_block_size, nhead_k]");
+
+        TORCH_CHECK(v_sc.dim() == 1 && v_sc.size(0) == h_k,
+                    "v_descale_per_head must be 1D with shape [nhead_k]");
+
+        args.q_descale_ptr             = q_sc.data_ptr();
+        args.k_descale_ptr             = k_sc.data_ptr();
+        args.v_descale_ptr             = v_sc.data_ptr();
+        args.stride_q_descale_token    = q_sc.stride(0);
+        args.nhead_stride_q_descale    = q_sc.stride(1);
+        args.nblock_stride_k_descale_page = k_sc.stride(0);
+        args.stride_k_descale_token    = k_sc.stride(1);
+        args.nhead_stride_k_descale    = k_sc.stride(2);
+        args.nhead_stride_v_descale    = v_sc.stride(0);
+    }
+
     return args;
 }
 
@@ -430,6 +478,10 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
                   std::optional<const at::Tensor> k_descale,     // [1]
                   std::optional<const at::Tensor> v_descale,     // [1]
                   std::optional<const at::Tensor> kv_block_descale,      // [num_block, num_kv_head, 2] for KV_BLOCKSCALE
+                  // PER_TOKEN_HEAD: Q/K per-token per-head, V per-head. See header for layouts.
+                  std::optional<const at::Tensor> q_descale_per_token,
+                  std::optional<const at::Tensor> k_descale_per_token,
+                  std::optional<const at::Tensor> v_descale_per_head,
                   std::optional<const at::Tensor> kv_last_page_lens_,
                   std::optional<const at::Tensor> block_table_,
                   std::optional<const at::Tensor> seqlen_k_,
@@ -462,9 +514,24 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
     // Validate descale tensor combinations:
     // - PERTENSOR mode: q_descale, k_descale, v_descale all provided
     // - KV_BLOCKSCALE mode: q_descale + kv_block_descale provided, k_descale/v_descale NOT provided
+    // - PER_TOKEN_HEAD mode: q/k_descale_per_token + v_descale_per_head provided, all
+    //   per-tensor and kv_block_descale tensors NOT provided
     // - NO_SCALE mode: none provided
     quant_scale_enum qscale_type;
-    if(kv_block_descale.has_value())
+    if(q_descale_per_token.has_value() || k_descale_per_token.has_value() ||
+       v_descale_per_head.has_value())
+    {
+        TORCH_CHECK(q_descale_per_token.has_value() && k_descale_per_token.has_value() &&
+                        v_descale_per_head.has_value(),
+                    "PER_TOKEN_HEAD mode requires q_descale_per_token, k_descale_per_token, "
+                    "and v_descale_per_head to all be provided.");
+        TORCH_CHECK(!q_descale.has_value() && !k_descale.has_value() && !v_descale.has_value() &&
+                        !kv_block_descale.has_value(),
+                    "PER_TOKEN_HEAD descales are mutually exclusive with q/k/v_descale and "
+                    "kv_block_descale.");
+        qscale_type = quant_scale_enum::per_token_head;
+    }
+    else if(kv_block_descale.has_value())
     {
         // KV_BLOCKSCALE: Q per-tensor, K/V per-page
         TORCH_CHECK(q_descale.has_value(),
@@ -775,6 +842,9 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
                                                    k_descale,
                                                    v_descale,
                                                    kv_block_descale,
+                                                   q_descale_per_token,
+                                                   k_descale_per_token,
+                                                   v_descale_per_head,
                                                    out,
                                                    softmax_lse,
                                                    p,

--- a/csrc/py_itfs_ck/mha_batch_prefill_kernels.cu
+++ b/csrc/py_itfs_ck/mha_batch_prefill_kernels.cu
@@ -146,6 +146,70 @@ get_ck_fmha_batch_prefill_args(bool has_lse,
         TORCH_CHECK(v_stride_batch % k_vector_size == 0,
                     "V batch stride must be a multiple of vector size");
     }
+    else if(kv_memory_layout ==
+            ck_tile::BlockAttentionKVCacheMemoryLayoutEnum::VEC_K_COL_V_LAYOUT)
+    {
+        // Decode-aligned: K is 5D vectorized, V is 4D ColumnMajor.
+        TORCH_CHECK(k.dim() == 5,
+                    "K tensor must be 5D [NumBlocks, NumHeads, HeadDim/kVectorSize, PageSize, "
+                    "kVectorSize] for VEC_K_COL_V layout");
+        TORCH_CHECK(v.dim() == 4,
+                    "V tensor must be 4D [NumBlocks, NumHeads, HeadDim, PageSize] for "
+                    "VEC_K_COL_V layout");
+
+        // K strides: identical to VECTORIZED branch above; stride_k carries the PageSize
+        // stride (= kVectorSize for vectorized K).
+        stride_k = k.stride(-2);
+        TORCH_CHECK(stride_k == k_vector_size,
+                    "stride_k (PageSize stride) must be ",
+                    k_vector_size,
+                    " in 5D vectorized K");
+        TORCH_CHECK(k.stride(4) == 1 && k.size(-1) == k_vector_size,
+                    "K last dim must be ",
+                    k_vector_size,
+                    " and contiguous");
+        TORCH_CHECK(k.stride(3) == k_vector_size,
+                    "K page stride must be ",
+                    k_vector_size,
+                    " in 5D vectorized layout");
+        TORCH_CHECK(k.stride(2) == static_cast<int64_t>(page_block_size) * k_vector_size,
+                    "K head-dim stride must be page_size * vector_size");
+        TORCH_CHECK(k.stride(1) >= static_cast<int64_t>(d) * page_block_size,
+                    "K head stride must be >= head_dim * page_size");
+        TORCH_CHECK(k.stride(0) >= static_cast<int64_t>(h_k) * k.stride(1),
+                    "K batch stride must be >= num_heads * head_stride");
+        TORCH_CHECK(k.stride(1) % k_vector_size == 0,
+                    "K head stride must be a multiple of vector size");
+        TORCH_CHECK(k.stride(0) % k_vector_size == 0,
+                    "K batch stride must be a multiple of vector size");
+
+        // V strides for [NumBlocks, NumHeads, HeadDim, PageSize]:
+        // - dim 3 (PageSize) is contiguous (stride 1)
+        // - dim 2 (HeadDim) stride = page_block_size — the kernel uses this directly via
+        //   make_naive_tensor_view (see fmha_batch_prefill_kernel.hpp)
+        // - dim 1 (NumHeads) is folded into v_ptr per-head (nhead_stride_v = HeadDim*PageSize)
+        // - dim 0 (NumBlocks) stride is the per-page stride (batch_stride_v)
+        // We pass `stride_v = 1` (the per-token stride for the kernel's V offset transform).
+        const int64_t v_stride_batch = v.stride(0);
+        const int64_t v_stride_head  = v.stride(1);
+        const int64_t v_stride_dim   = v.stride(2);
+        const int64_t v_stride_tok   = v.stride(3);
+
+        TORCH_CHECK(v_stride_tok == 1,
+                    "V innermost (PageSize) stride must be 1 in VEC_K_COL_V layout");
+        TORCH_CHECK(v_stride_dim == static_cast<int64_t>(page_block_size),
+                    "V HeadDim stride must equal page_block_size in VEC_K_COL_V layout");
+        TORCH_CHECK(v_stride_head >= static_cast<int64_t>(d_v) * page_block_size,
+                    "V head stride must be >= head_dim * page_size");
+        TORCH_CHECK(v_stride_batch >= static_cast<int64_t>(h_k) * v_stride_head,
+                    "V batch stride must be >= num_heads * head_stride");
+        TORCH_CHECK(v_stride_head % k_vector_size == 0,
+                    "V head stride must be a multiple of vector size");
+        TORCH_CHECK(v_stride_batch % k_vector_size == 0,
+                    "V batch stride must be a multiple of vector size");
+
+        stride_v = 1;
+    }
     else
     {
         if(k.dim() == 4)
@@ -242,13 +306,15 @@ get_ck_fmha_batch_prefill_args(bool has_lse,
     ck_tile::index_t stride_o       = out.stride(-3);
     ck_tile::index_t stride_randval = has_dropout_randval ? dropout_randval.stride(1) : 0;
 
-    ck_tile::index_t nhead_stride_q       = q.stride(-2);
+    ck_tile::index_t nhead_stride_q = q.stride(-2);
     const bool is_vectorized_layout =
         kv_memory_layout == ck_tile::BlockAttentionKVCacheMemoryLayoutEnum::VECTORIZED_LAYOUT;
-    // Vectorized: head dim at index 1. Linear: head dim at index 2.
+    const bool is_vec_k_col_v_layout =
+        kv_memory_layout == ck_tile::BlockAttentionKVCacheMemoryLayoutEnum::VEC_K_COL_V_LAYOUT;
+    // Vectorized / VEC_K_COL_V: K head dim at index 1. Linear: head dim at index 2 (4D) or 1 (3D).
     ck_tile::index_t nhead_stride_k;
     ck_tile::index_t nhead_stride_v;
-    if(is_vectorized_layout)
+    if(is_vectorized_layout || is_vec_k_col_v_layout)
     {
         nhead_stride_k = k.stride(1);
         nhead_stride_v = v.stride(1);
@@ -340,6 +406,10 @@ get_ck_fmha_batch_prefill_args(bool has_lse,
     args.page_block_size   = page_block_size;
     args.kv_memory_layout  = kv_memory_layout;
     args.kv_lookup_table   = ck_tile::BlockAttentionKVCacheLookupTableEnum::SGLANG_PAGE_TABLE_1D;
+    // VEC_K_COL_V is the only layout in which V is logically transposed (ColumnMajor);
+    // every other layout keeps V as RowMajor.
+    args.is_v_rowmajor =
+        (kv_memory_layout != ck_tile::BlockAttentionKVCacheMemoryLayoutEnum::VEC_K_COL_V_LAYOUT);
     args.kv_indptr         = kv_indptr.data_ptr();
     args.kv_page_indices   = kv_page_indices.data_ptr();
     args.kv_last_page_lens = kv_last_page_lens_ptr;
@@ -625,12 +695,9 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
     int head_size_v     = 0;
     int num_blocks      = 0;
 
-    if(k.dim() == 5)
+    if(k.dim() == 5 && v.dim() == 5)
     {
         kv_memory_layout = ck_tile::BlockAttentionKVCacheMemoryLayoutEnum::VECTORIZED_LAYOUT;
-        TORCH_CHECK(
-            v.dim() == 5,
-            "V tensor must be 5D [NumBlocks, NumHeads, PageSize/kVectorSize, HeadDim, kVectorSize]");
 
         // K: [NumBlocks, NumHeads, HeadDim/kVectorSize, PageSize, kVectorSize]
         num_heads_k     = k.size(1);
@@ -641,6 +708,32 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
 
         // V: [NumBlocks, NumHeads, PageSize/kVector_size, HeadDim, kVector_size]
         head_size_v = v.size(3);
+        num_blocks  = k.size(0);
+    }
+    else if(k.dim() == 5 && v.dim() == 4)
+    {
+        // Decode-aligned VEC_K_COL_V_LAYOUT: K is 5D vectorized (same as VECTORIZED_LAYOUT)
+        // and V is 4D ColumnMajor [NumBlocks, NumHeads, HeadDim, PageSize] — produced by
+        // aiter's reshape_and_cache_kernel and consumed by the decode paged-attention
+        // kernel without an intermediate reshape.
+        kv_memory_layout = ck_tile::BlockAttentionKVCacheMemoryLayoutEnum::VEC_K_COL_V_LAYOUT;
+
+        // K: [NumBlocks, NumHeads, HeadDim/kVectorSize, PageSize, kVectorSize]
+        num_heads_k     = k.size(1);
+        page_block_size = k.size(3);
+        TORCH_CHECK(page_block_size % k_vector_size == 0,
+                    "Vectorized KV requires page size divisible by ",
+                    k_vector_size);
+
+        // V: [NumBlocks, NumHeads, HeadDim, PageSize]; PageSize must match K.size(3).
+        TORCH_CHECK(v.size(0) == k.size(0),
+                    "V num_blocks must match K num_blocks for VEC_K_COL_V layout");
+        TORCH_CHECK(v.size(1) == num_heads_k,
+                    "V num_heads must match K num_heads for VEC_K_COL_V layout");
+        TORCH_CHECK(v.size(3) == page_block_size,
+                    "V innermost (PageSize) dim must equal K.size(3) (page_block_size) for "
+                    "VEC_K_COL_V layout");
+        head_size_v = v.size(2);
         num_blocks  = k.size(0);
     }
     else if(k.dim() == 4)
@@ -751,6 +844,18 @@ mha_batch_prefill(at::Tensor& q,       // [total_q, hq, d]
                     page_block_size / k_vector_size,
                     head_size_v,
                     k_vector_size);
+    }
+    else if(kv_memory_layout ==
+            ck_tile::BlockAttentionKVCacheMemoryLayoutEnum::VEC_K_COL_V_LAYOUT)
+    {
+        // K: 5D vectorized (same as VECTORIZED); V: 4D ColumnMajor.
+        CHECK_SHAPE(k,
+                    num_blocks,
+                    num_heads_k,
+                    head_size_q / k_vector_size,
+                    page_block_size,
+                    k_vector_size);
+        CHECK_SHAPE(v, num_blocks, num_heads_k, head_size_v, page_block_size);
     }
     else
     {

--- a/op_tests/bench_batch_prefill_layout.py
+++ b/op_tests/bench_batch_prefill_layout.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Benchmark CK mha_batch_prefill across KV-cache layouts (dense, apples-to-apples).
+
+Compares the BF16 prefill kernel on:
+  - "linear"      : 3D linear KV (page_size=1) -- the layout the external
+                    reference bench uses, so these numbers are directly comparable.
+  - "vec_k_col_v" : decode-aligned layout (5D vectorized K + 4D ColumnMajor V
+                    [NumBlocks, NumHeads, HeadDim, PageSize]); requires page_size
+                    in (64, 1024). This is the layout that lets vLLM skip the
+                    prefill<->decode KV-cache reshape.
+
+Semantics mirror the external reference bench for an apples-to-apples comparison:
+dense full-length sequences (NO randomized lengths), GPU-event timing,
+warmup + timed iters, trimmed mean, and causal/full FLOPs. Defaults reproduce
+the reference config: batch=1, num_q_heads=64, num_kv_heads=8, head_dim=128, bf16,
+causal=True, seq_lens 1k/16k/32k/64k/128k.
+
+Examples:
+    python op_tests/bench_batch_prefill_layout.py
+    python op_tests/bench_batch_prefill_layout.py --layout linear --seq-lens 1k 16k 128k
+    python op_tests/bench_batch_prefill_layout.py --layout vec_k_col_v --page-size 64
+    python op_tests/bench_batch_prefill_layout.py --batch-size 1 --csv out.csv
+"""
+import argparse
+import csv
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, List
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import aiter
+from op_tests.test_batch_prefill import (
+    apply_kv_layout,
+    build_paged_kv_cache,
+    convert_lens_to_indptr,
+    extract_kv_caches,
+    get_vector_size,
+)
+
+DEFAULT_SEQ_LENS = [1024, 16384, 32768, 65536, 131072]
+# page_size used per layout when --page-size is left at the auto sentinel (0).
+AUTO_PAGE_SIZE = {"linear": 1, "vec_k_col_v": 64}
+VEC_K_COL_V_SUPPORTED_PAGE = (64, 1024)
+
+
+def parse_dtype(dtype: str) -> torch.dtype:
+    mapping = {"fp16": torch.float16, "bf16": torch.bfloat16, "fp32": torch.float32}
+    if dtype not in mapping:
+        raise ValueError(f"unsupported dtype: {dtype}")
+    return mapping[dtype]
+
+
+def parse_seq_len(token: str) -> int:
+    token = token.strip().lower()
+    if token.endswith("k"):
+        return int(float(token[:-1]) * 1024)
+    if token.endswith("m"):
+        return int(float(token[:-1]) * 1024 * 1024)
+    return int(token)
+
+
+def format_seq_len(seq_len: int) -> str:
+    return f"{seq_len // 1024}k" if seq_len % 1024 == 0 else str(seq_len)
+
+
+def trimmed_mean(values: List[float], trim_ratio: float) -> float:
+    if not values:
+        return float("nan")
+    if len(values) == 1 or trim_ratio <= 0:
+        return statistics.mean(values)
+    sorted_values = sorted(values)
+    trim = int(len(sorted_values) * trim_ratio)
+    if trim * 2 >= len(sorted_values):
+        return statistics.mean(sorted_values)
+    return statistics.mean(sorted_values[trim : len(sorted_values) - trim])
+
+
+def causal_flops_per_seq(q_len, k_len, num_q_heads, head_dim) -> float:
+    if q_len > k_len:
+        valid_elements = (k_len * k_len + k_len) / 2
+    else:
+        valid_elements = q_len * k_len - ((q_len * q_len - q_len) / 2)
+    return valid_elements * num_q_heads * head_dim * 4.0
+
+
+def full_flops_per_seq(q_len, k_len, num_q_heads, head_dim) -> float:
+    return q_len * k_len * num_q_heads * head_dim * 4.0
+
+
+def compute_total_flops(q_lens, k_lens, num_q_heads, head_dim, causal) -> float:
+    fn = causal_flops_per_seq if causal else full_flops_per_seq
+    return sum(fn(q, k, num_q_heads, head_dim) for q, k in zip(q_lens, k_lens))
+
+
+def summarize_times_ms(times_ms: List[float], trim_ratio: float) -> dict:
+    return {
+        "avg_ms": statistics.mean(times_ms),
+        "median_ms": statistics.median(times_ms),
+        "min_ms": min(times_ms),
+        "max_ms": max(times_ms),
+        "trimmed_mean_ms": trimmed_mean(times_ms, trim_ratio),
+        "std_ms": statistics.pstdev(times_ms) if len(times_ms) > 1 else 0.0,
+    }
+
+
+def benchmark_once(fn) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end)
+
+
+def resolve_page_size(layout: str, page_size: int) -> int:
+    if page_size == 0:
+        return AUTO_PAGE_SIZE[layout]
+    return page_size
+
+
+def make_inputs(args, seq_len: int, layout: str, page_size: int, dtype):
+    """Build DENSE (full-length) inputs for the requested layout.
+
+    Returns a zero-arg `fn` that invokes aiter.mha_batch_prefill_func and the
+    per-sequence q/k lengths used for the FLOPs accounting.
+    """
+    device = args.device
+    batch = args.batch_size
+    nhq, nhk, hd = args.num_q_heads, args.num_kv_heads, args.head_dim
+    # Dense: every sequence is exactly seq_len (no randomized lengths).
+    q_lens = [seq_len] * batch
+    kv_lens_t = torch.full((batch,), seq_len, dtype=torch.int32)
+    qo_lens_t = torch.full((batch,), seq_len, dtype=torch.int32)
+    total_q = seq_len * batch
+    softmax_scale = args.softmax_scale or (hd ** -0.5)
+
+    q = torch.randn(total_q, nhq, hd, device=device, dtype=dtype)
+    cu_seqlens_q = convert_lens_to_indptr(qo_lens_t).to(device)
+
+    if layout == "linear":
+        # 3D linear page_size=1 KV (matches the external reference bench exactly).
+        assert page_size == 1, "linear bench uses page_size=1 (3D KV)"
+        total_kv = seq_len * batch
+        k = torch.randn(total_kv, nhk, hd, device=device, dtype=dtype)
+        v = torch.randn(total_kv, nhk, hd, device=device, dtype=dtype)
+        kv_indptr = convert_lens_to_indptr(kv_lens_t).to(device)
+        kv_page_indices = torch.arange(total_kv, dtype=torch.int32, device=device)
+
+        def fn():
+            return aiter.mha_batch_prefill_func(
+                q, k, v, cu_seqlens_q, kv_indptr, kv_page_indices,
+                seq_len, seq_len,
+                softmax_scale=softmax_scale,
+                logits_soft_cap=args.logits_soft_cap,
+                causal=args.causal,
+                return_lse=args.return_lse,
+            )
+
+    elif layout == "vec_k_col_v":
+        if page_size not in VEC_K_COL_V_SUPPORTED_PAGE:
+            raise ValueError(
+                f"vec_k_col_v supports page_size in {VEC_K_COL_V_SUPPORTED_PAGE}, "
+                f"got {page_size}"
+            )
+        k_vector_size = get_vector_size(dtype)
+        kv_cache = build_paged_kv_cache(
+            batch, seq_len, page_size, nhk, hd, kv_lens_t, -5, 5, dtype,
+            use_uniform=False, contiguous_kv=True,
+        )
+        k_ref, v_ref = extract_kv_caches(kv_cache, True)
+        k_cache, v_cache = apply_kv_layout(
+            k_ref, v_ref, nhk, hd, page_size, k_vector_size, layout
+        )
+        kv_indptr = kv_cache["kv_indptr_cpu"].to(device)
+        kv_page_indices = kv_cache["kv_indices_cpu"].to(device)
+        kv_last_page_lens = kv_cache["kv_last_page_len_cpu"].to(device)
+
+        def fn():
+            return aiter.mha_batch_prefill_func(
+                q, k_cache, v_cache, cu_seqlens_q, kv_indptr, kv_page_indices,
+                seq_len, seq_len,
+                softmax_scale=softmax_scale,
+                logits_soft_cap=args.logits_soft_cap,
+                causal=args.causal,
+                return_lse=args.return_lse,
+                kv_last_page_lens=kv_last_page_lens,
+            )
+
+    else:
+        raise ValueError(f"unknown layout: {layout}")
+
+    return fn, q_lens, [seq_len] * batch
+
+
+def run_case(args, seq_len: int, layout: str, page_size: int) -> dict:
+    dtype = parse_dtype(args.dtype)
+    fn, q_lens, k_lens = make_inputs(args, seq_len, layout, page_size, dtype)
+
+    for _ in range(args.warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times_ms = [benchmark_once(fn) for _ in range(args.iters)]
+
+    stats = summarize_times_ms(times_ms, args.trim_ratio)
+    total_flops = compute_total_flops(
+        q_lens, k_lens, args.num_q_heads, args.head_dim, args.causal
+    )
+    stats["tflops_avg"] = total_flops / (stats["avg_ms"] * 1.0e9)
+    stats["tflops_med"] = total_flops / (stats["median_ms"] * 1.0e9)
+    stats["seq_len"] = seq_len
+    stats["seq_len_label"] = format_seq_len(seq_len)
+    stats["layout"] = layout
+    stats["page_size"] = page_size
+    stats["samples"] = len(times_ms)
+
+    torch.cuda.empty_cache()
+    return stats
+
+
+def print_results(rows: List[dict]) -> None:
+    headers = [
+        "layout", "page", "seq_len", "avg(ms)", "median(ms)", "min(ms)",
+        "max(ms)", "trimmed(ms)", "std(ms)", "TFLOPS(avg)", "TFLOPS(med)",
+    ]
+    table = []
+    for r in rows:
+        table.append([
+            r["layout"], str(r["page_size"]), r["seq_len_label"],
+            f"{r['avg_ms']:.3f}", f"{r['median_ms']:.3f}", f"{r['min_ms']:.3f}",
+            f"{r['max_ms']:.3f}", f"{r['trimmed_mean_ms']:.3f}", f"{r['std_ms']:.3f}",
+            f"{r['tflops_avg']:.3f}", f"{r['tflops_med']:.3f}",
+        ])
+    widths = [len(h) for h in headers]
+    for row in table:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    def fmt(cells):
+        return "  ".join(c.rjust(widths[i]) for i, c in enumerate(cells))
+
+    print(fmt(headers))
+    print("-" * (sum(widths) + 2 * (len(headers) - 1)))
+    for row in table:
+        print(fmt(row))
+
+
+def print_comparison(rows: List[dict]) -> None:
+    """Print median(ms) ratio of vec_k_col_v vs linear at matched seq_len."""
+    by_seq = {}
+    for r in rows:
+        by_seq.setdefault(r["seq_len"], {})[r["layout"]] = r
+    if not all("linear" in v and "vec_k_col_v" in v for v in by_seq.values()):
+        return
+    print("\nvec_k_col_v vs linear (median ms; <1.0 = vec_k_col_v faster):")
+    print(f"{'seq_len':>8}  {'linear':>12}  {'vec_k_col_v':>12}  {'ratio':>8}")
+    for seq_len in sorted(by_seq):
+        lin = by_seq[seq_len]["linear"]["median_ms"]
+        vkc = by_seq[seq_len]["vec_k_col_v"]["median_ms"]
+        print(
+            f"{format_seq_len(seq_len):>8}  {lin:>12.3f}  {vkc:>12.3f}  "
+            f"{vkc / lin:>7.3f}x"
+        )
+
+
+def write_csv(rows: List[dict], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cols = [
+        "layout", "page_size", "seq_len", "avg_ms", "median_ms", "min_ms",
+        "max_ms", "trimmed_mean_ms", "std_ms", "tflops_avg", "tflops_med", "samples",
+    ]
+    with output_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(cols)
+        for r in rows:
+            writer.writerow([
+                r["layout"], r["page_size"], r["seq_len_label"], r["avg_ms"],
+                r["median_ms"], r["min_ms"], r["max_ms"], r["trimmed_mean_ms"],
+                r["std_ms"], r["tflops_avg"], r["tflops_med"], r["samples"],
+            ])
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Benchmark aiter.mha_batch_prefill_func across KV layouts (dense).",
+    )
+    p.add_argument(
+        "--seq-lens", nargs="+",
+        default=[format_seq_len(x) for x in DEFAULT_SEQ_LENS],
+        help="seq_len list, accepts 1k/16k/32k/64k/128k style tokens",
+    )
+    p.add_argument(
+        "--layout", choices=["linear", "vec_k_col_v", "both"], default="both",
+        help="KV layout(s) to bench",
+    )
+    p.add_argument(
+        "--page-size", type=int, default=0,
+        help="page size; 0=auto (linear->1, vec_k_col_v->64)",
+    )
+    p.add_argument("--batch-size", type=int, default=1)
+    p.add_argument("--num-q-heads", type=int, default=64)
+    p.add_argument("--num-kv-heads", type=int, default=8)
+    p.add_argument("--head-dim", type=int, default=128)
+    p.add_argument("--dtype", choices=["fp16", "bf16", "fp32"], default="bf16")
+    p.add_argument("--causal", action=argparse.BooleanOptionalAction, default=True)
+    p.add_argument("--logits-soft-cap", type=float, default=0.0)
+    p.add_argument("--softmax-scale", type=float, default=None)
+    p.add_argument("--warmup", type=int, default=5)
+    p.add_argument("--iters", type=int, default=10)
+    p.add_argument("--trim-ratio", type=float, default=0.1)
+    p.add_argument("--return-lse", action=argparse.BooleanOptionalAction, default=False)
+    p.add_argument("--device", type=str, default="cuda")
+    p.add_argument("--csv", type=str, default="")
+    args = p.parse_args()
+    args.seq_lens = [parse_seq_len(x) for x in args.seq_lens]
+    return args
+
+
+def print_config(args, layouts):
+    print("=" * 100)
+    print("mha_batch_prefill layout benchmark (dense, apples-to-apples vs reference)")
+    print("=" * 100)
+    print(
+        f"config: batch_size={args.batch_size}, num_q_heads={args.num_q_heads}, "
+        f"num_kv_heads={args.num_kv_heads}, head_dim={args.head_dim}, "
+        f"dtype={args.dtype}, causal={args.causal}, logits_soft_cap={args.logits_soft_cap}, "
+        f"warmup={args.warmup}, iters={args.iters}, device={args.device}"
+    )
+    pages = {lay: resolve_page_size(lay, args.page_size) for lay in layouts}
+    print(f"layouts: {[f'{lay}(page={pages[lay]})' for lay in layouts]}")
+    print(f"seq_lens: {[format_seq_len(x) for x in args.seq_lens]}")
+    print("note: sequences are DENSE (full seq_len, no randomized lengths).\n")
+
+
+def main():
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("no GPU device available")
+    if args.batch_size <= 0 or args.num_q_heads <= 0 or args.num_kv_heads <= 0:
+        raise ValueError("batch_size / head counts must be > 0")
+    if not (0.0 <= args.trim_ratio < 0.5):
+        raise ValueError("trim_ratio must satisfy 0 <= trim_ratio < 0.5")
+    if args.warmup < 0 or args.iters <= 0:
+        raise ValueError("warmup >= 0 and iters > 0 required")
+
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+    torch.set_grad_enabled(False)
+
+    layouts = ["linear", "vec_k_col_v"] if args.layout == "both" else [args.layout]
+    print_config(args, layouts)
+
+    rows = []
+    total_start = time.time()
+    for layout in layouts:
+        page_size = resolve_page_size(layout, args.page_size)
+        for seq_len in args.seq_lens:
+            print(f"[run] layout={layout} page={page_size} seq_len={format_seq_len(seq_len)}", flush=True)
+            rows.append(run_case(args, seq_len, layout, page_size))
+    total_end = time.time()
+
+    print()
+    print_results(rows)
+    print_comparison(rows)
+    print(f"\ntotal_elapsed_s: {total_end - total_start:.3f}")
+
+    if args.csv:
+        write_csv(rows, Path(args.csv))
+        print(f"csv saved to: {args.csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/bench_per_token_head.py
+++ b/op_tests/bench_per_token_head.py
@@ -6,11 +6,14 @@ Examples:
     python op_tests/bench_per_token_head.py 1024
     python op_tests/bench_per_token_head.py 1024 16384
     BENCH_VERIFY=1 python op_tests/bench_per_token_head.py 1024
+    BENCH_KV_LAYOUT=vec_k_col_v python op_tests/bench_per_token_head.py 16384
 
 Environment variables:
     BENCH_VERIFY=0|1            verify outputs vs FP32 reference (default 0)
     BENCH_PAGE_SIZE=N           paged-KV page size (default 1024)
     BENCH_BYPASS_ROCM72_SKIP=1  bypass causal+soft_cap=0 skip guard (default 1)
+    BENCH_KV_LAYOUT=...         "linear" (default), "vectorized" (5D swizzled),
+                                or "vec_k_col_v" (decode-aligned: 5D K + 4D ColumnMajor V)
 """
 
 import argparse
@@ -29,8 +32,8 @@ if int(os.environ.get("BENCH_BYPASS_ROCM72_SKIP", "1")):
 
 PAGE_SIZE = int(os.environ.get("BENCH_PAGE_SIZE", "1024"))
 VERIFY = bool(int(os.environ.get("BENCH_VERIFY", "0")))
-# KV cache memory layout: "linear" (4D) or "vectorized" (5D swizzled).
-# Vectorized is the production layout used by serving frameworks.
+# KV cache memory layout: "linear" (4D), "vectorized" (5D swizzled), or
+# "vec_k_col_v" (decode-aligned: 5D vectorized K + 4D ColumnMajor V).
 KV_LAYOUT = os.environ.get("BENCH_KV_LAYOUT", "linear")
 
 DEFAULT_SEQS = (1024, 16384, 32768, 65536, 131072)

--- a/op_tests/bench_per_token_head.py
+++ b/op_tests/bench_per_token_head.py
@@ -1,19 +1,30 @@
 """Benchmark FP8 PER_TOKEN_HEAD batch_prefill kernel.
 
+Defaults exercise the production-target configuration: the decode-aligned
+VEC_K_COL_V_LAYOUT KV cache (5D vectorized K + 4D ColumnMajor V) plus the
+caller-supplied softmax-P scale fold. Both can be overridden via env vars.
+
 Sequence lengths can be passed as positional args.
 
 Examples:
     python op_tests/bench_per_token_head.py 1024
     python op_tests/bench_per_token_head.py 1024 16384
     BENCH_VERIFY=1 python op_tests/bench_per_token_head.py 1024
-    BENCH_KV_LAYOUT=vec_k_col_v python op_tests/bench_per_token_head.py 16384
+    BENCH_KV_LAYOUT=linear python op_tests/bench_per_token_head.py 16384
+    BENCH_P_SCALE=none python op_tests/bench_per_token_head.py 16384
 
 Environment variables:
     BENCH_VERIFY=0|1            verify outputs vs FP32 reference (default 0)
     BENCH_PAGE_SIZE=N           paged-KV page size (default 1024)
     BENCH_BYPASS_ROCM72_SKIP=1  bypass causal+soft_cap=0 skip guard (default 1)
-    BENCH_KV_LAYOUT=...         "linear" (default), "vectorized" (5D swizzled),
-                                or "vec_k_col_v" (decode-aligned: 5D K + 4D ColumnMajor V)
+    BENCH_KV_LAYOUT=...         "vec_k_col_v" (default; decode-aligned: 5D K +
+                                4D ColumnMajor V), "linear" (4D), or
+                                "vectorized" (5D swizzled)
+    BENCH_P_SCALE=...           "half" (default; constant 0.5 per q-head),
+                                "ones" (1.0 per q-head, exercises the path
+                                without changing magnitudes), "per_head_random"
+                                (uniform [0.25, 1.0] per q-head, fixed seed),
+                                or "none" (skip the p_scale fold)
 """
 
 import argparse
@@ -32,9 +43,33 @@ if int(os.environ.get("BENCH_BYPASS_ROCM72_SKIP", "1")):
 
 PAGE_SIZE = int(os.environ.get("BENCH_PAGE_SIZE", "1024"))
 VERIFY = bool(int(os.environ.get("BENCH_VERIFY", "0")))
-# KV cache memory layout: "linear" (4D), "vectorized" (5D swizzled), or
-# "vec_k_col_v" (decode-aligned: 5D vectorized K + 4D ColumnMajor V).
-KV_LAYOUT = os.environ.get("BENCH_KV_LAYOUT", "linear")
+# KV cache memory layout: "vec_k_col_v" (default; decode-aligned 5D K + 4D
+# ColumnMajor V), "linear" (4D), or "vectorized" (5D swizzled).
+KV_LAYOUT = os.environ.get("BENCH_KV_LAYOUT", "vec_k_col_v")
+# Softmax-P scale fold: see module docstring for modes.
+P_SCALE_MODE = os.environ.get("BENCH_P_SCALE", "half")
+_VALID_P_SCALE = ("none", "ones", "half", "per_head_random")
+if P_SCALE_MODE not in _VALID_P_SCALE:
+    raise SystemExit(
+        f"BENCH_P_SCALE={P_SCALE_MODE!r} is not one of {_VALID_P_SCALE}"
+    )
+
+
+def _build_p_scale(num_qo_heads):
+    """Build a [num_qo_heads] fp32 cuda tensor for the given mode, or None."""
+    if P_SCALE_MODE == "none":
+        return None
+    if P_SCALE_MODE == "ones":
+        return torch.ones(num_qo_heads, dtype=torch.float32, device="cuda")
+    if P_SCALE_MODE == "half":
+        return torch.full(
+            (num_qo_heads,), 0.5, dtype=torch.float32, device="cuda"
+        )
+    # per_head_random — fixed seed so successive runs are bit-identical.
+    g = torch.Generator(device="cuda").manual_seed(123)
+    return 0.25 + 0.75 * torch.rand(
+        num_qo_heads, dtype=torch.float32, device="cuda", generator=g
+    )
 
 DEFAULT_SEQS = (1024, 16384, 32768, 65536, 131072)
 _parser = argparse.ArgumentParser(
@@ -101,6 +136,7 @@ def _run_one(shape):
         dtype=torch.bfloat16,
         contiguous_kv=True,
         seed=42,
+        p_scale=_build_p_scale(nhq),
     )
     pth = _call_kernel(run_batch_prefill_per_token_head, **common)
     return pth
@@ -155,7 +191,7 @@ else:
 print(
     f"Config: nhq={_nhq}, nhk={_nhk}, hd={_hd}, "
     f"causal={_causal}, soft_cap={_sc}, page_size={PAGE_SIZE}, "
-    f"kv_layout={KV_LAYOUT}"
+    f"kv_layout={KV_LAYOUT}, p_scale={P_SCALE_MODE}"
 )
 _HEADER = f"{'batch':>5} | {'PER_TOKEN_HEAD':>27} {'vrf':>4}"
 print(_HEADER)

--- a/op_tests/bench_per_token_head.py
+++ b/op_tests/bench_per_token_head.py
@@ -89,7 +89,7 @@ _parser.add_argument(
 _args = _parser.parse_args()
 SEQS = tuple(_args.seqs)
 
-SHAPES = [(b, s, s, 8, 1, 128, True, 0.0) for s in SEQS for b in (2, 4, 6, 8)]
+SHAPES = [(b, s, s, 8, 1, 128, True, 0.0) for s in SEQS for b in (1, 2, 4, 6, 8)]
 
 
 def _fmt(r):

--- a/op_tests/bench_per_token_head.py
+++ b/op_tests/bench_per_token_head.py
@@ -1,6 +1,5 @@
 """Benchmark FP8 PER_TOKEN_HEAD batch_prefill kernel.
 
-Compares PER_TOKEN_HEAD against KV_BLOCKSCALE (when page_size >= 128).
 Sequence lengths can be passed as positional args.
 
 Examples:
@@ -23,16 +22,16 @@ import torch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import op_tests.test_batch_prefill as _tbp
-from op_tests.test_batch_prefill import (
-    run_batch_prefill_per_token_head,
-    run_batch_prefill_kv_blockscale,
-)
+from op_tests.test_batch_prefill import run_batch_prefill_per_token_head
 
 if int(os.environ.get("BENCH_BYPASS_ROCM72_SKIP", "1")):
     _tbp.should_skip_rocm72_issue = lambda *a, **k: False
 
 PAGE_SIZE = int(os.environ.get("BENCH_PAGE_SIZE", "1024"))
 VERIFY = bool(int(os.environ.get("BENCH_VERIFY", "0")))
+# KV cache memory layout: "linear" (4D) or "vectorized" (5D swizzled).
+# Vectorized is the production layout used by serving frameworks.
+KV_LAYOUT = os.environ.get("BENCH_KV_LAYOUT", "linear")
 
 DEFAULT_SEQS = (1024, 16384, 32768, 65536, 131072)
 _parser = argparse.ArgumentParser(
@@ -50,11 +49,7 @@ _parser.add_argument(
 _args = _parser.parse_args()
 SEQS = tuple(_args.seqs)
 
-SHAPES = [
-    (b, s, s, 8, 1, 128, True, 0.0)
-    for s in SEQS
-    for b in (2, 4, 6, 8)
-]
+SHAPES = [(b, s, s, 8, 1, 128, True, 0.0) for s in SEQS for b in (2, 4, 6, 8)]
 
 
 def _fmt(r):
@@ -89,7 +84,7 @@ def _call_kernel(fn, **kwargs):
 def _run_one(shape):
     b, qo, kv, nhq, nhk, hd, c, sc = shape
     common = dict(
-        kvcache_layout="linear",
+        kvcache_layout=KV_LAYOUT,
         table_layout="sglang",
         batch_size=b,
         qo_len=qo,
@@ -105,20 +100,12 @@ def _run_one(shape):
         seed=42,
     )
     pth = _call_kernel(run_batch_prefill_per_token_head, **common)
-    if PAGE_SIZE >= 128:
-        kvb = _call_kernel(run_batch_prefill_kv_blockscale, **common)
-    else:
-        kvb = {"status": "skipped"}
-    return pth, kvb
+    return pth
 
 
-def _format_row(shape, pth, kvb):
+def _format_row(shape, pth):
     b = shape[0]
-    return (
-        f"{b:>5} | "
-        f"{_fmt(kvb):>27} {_verify_str(kvb)} | "
-        f"{_fmt(pth):>27} {_verify_str(pth)}"
-    )
+    return f"{b:>5} | {_fmt(pth):>27} {_verify_str(pth)}"
 
 
 def _run_silent(shape):
@@ -152,7 +139,7 @@ def _run_silent(shape):
 
 
 print("Warming up kernels (one-time JIT setup, may take a moment)...", flush=True)
-_pth0, _kvb0 = _run_silent(SHAPES[0])
+_pth0 = _run_silent(SHAPES[0])
 
 _nhq, _nhk, _hd, _causal, _sc = SHAPES[0][3:8]
 for _s in SHAPES:
@@ -164,24 +151,20 @@ else:
     print("Verification: OFF (set BENCH_VERIFY=1 to enable)")
 print(
     f"Config: nhq={_nhq}, nhk={_nhk}, hd={_hd}, "
-    f"causal={_causal}, soft_cap={_sc}, page_size={PAGE_SIZE}"
+    f"causal={_causal}, soft_cap={_sc}, page_size={PAGE_SIZE}, "
+    f"kv_layout={KV_LAYOUT}"
 )
-_HEADER = (
-    f"{'batch':>5} | "
-    f"{'KV_BLOCKSCALE':>27} {'vrf':>4} | "
-    f"{'PER_TOKEN_HEAD':>27} {'vrf':>4}"
-)
+_HEADER = f"{'batch':>5} | {'PER_TOKEN_HEAD':>27} {'vrf':>4}"
 print(_HEADER)
 print("-" * len(_HEADER))
 
 failures = []
 
 
-def _record_failures(shape, pth, kvb):
+def _record_failures(shape, pth):
     b, _qo, kv, *_ = shape
-    for label, r in (("PER_TOKEN_HEAD", pth), ("KV_BLOCKSCALE", kvb)):
-        if r.get("verify") == "fail":
-            failures.append((b, kv, label, r.get("error", "")))
+    if pth.get("verify") == "fail":
+        failures.append((b, kv, "PER_TOKEN_HEAD", pth.get("error", "")))
 
 
 _groups = {}
@@ -193,12 +176,12 @@ for _seq, _shapes in _groups.items():
     print(f"seq={_seq}")
     for shape in _shapes:
         if shape == SHAPES[0] and not _warmup_done:
-            pth, kvb = _pth0, _kvb0
+            pth = _pth0
             _warmup_done = True
         else:
-            pth, kvb = _run_one(shape)
-        print(_format_row(shape, pth, kvb), flush=True)
-        _record_failures(shape, pth, kvb)
+            pth = _run_one(shape)
+        print(_format_row(shape, pth), flush=True)
+        _record_failures(shape, pth)
 
 if VERIFY:
     if failures:

--- a/op_tests/bench_per_token_head.py
+++ b/op_tests/bench_per_token_head.py
@@ -1,0 +1,212 @@
+"""Benchmark FP8 PER_TOKEN_HEAD batch_prefill kernel.
+
+Compares PER_TOKEN_HEAD against KV_BLOCKSCALE (when page_size >= 128).
+Sequence lengths can be passed as positional args.
+
+Examples:
+    python op_tests/bench_per_token_head.py 1024
+    python op_tests/bench_per_token_head.py 1024 16384
+    BENCH_VERIFY=1 python op_tests/bench_per_token_head.py 1024
+
+Environment variables:
+    BENCH_VERIFY=0|1            verify outputs vs FP32 reference (default 0)
+    BENCH_PAGE_SIZE=N           paged-KV page size (default 1024)
+    BENCH_BYPASS_ROCM72_SKIP=1  bypass causal+soft_cap=0 skip guard (default 1)
+"""
+
+import argparse
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import op_tests.test_batch_prefill as _tbp
+from op_tests.test_batch_prefill import (
+    run_batch_prefill_per_token_head,
+    run_batch_prefill_kv_blockscale,
+)
+
+if int(os.environ.get("BENCH_BYPASS_ROCM72_SKIP", "1")):
+    _tbp.should_skip_rocm72_issue = lambda *a, **k: False
+
+PAGE_SIZE = int(os.environ.get("BENCH_PAGE_SIZE", "1024"))
+VERIFY = bool(int(os.environ.get("BENCH_VERIFY", "0")))
+
+DEFAULT_SEQS = (1024, 16384, 32768, 65536, 131072)
+_parser = argparse.ArgumentParser(
+    description="Benchmark FP8 PER_TOKEN_HEAD batch_prefill kernel.",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+_parser.add_argument(
+    "seqs",
+    type=int,
+    nargs="*",
+    default=list(DEFAULT_SEQS),
+    metavar="SEQ",
+    help="Sequence length(s) to bench (qo_len = kv_len). Default: all.",
+)
+_args = _parser.parse_args()
+SEQS = tuple(_args.seqs)
+
+SHAPES = [
+    (b, s, s, 8, 1, 128, True, 0.0)
+    for s in SEQS
+    for b in (2, 4, 6, 8)
+]
+
+
+def _fmt(r):
+    if r.get("status") == "skipped":
+        return "skip"
+    if r.get("status") != "passed" or "tflops" not in r:
+        return "n/a"
+    return f"{r['time_us']:8.0f} us  {r['tflops']:7.2f} TFLOPS"
+
+
+def _verify_str(r):
+    v = r.get("verify")
+    if v is None:
+        return f"{'-':>4}"
+    return f"{'PASS' if v == 'pass' else 'FAIL':>4}"
+
+
+def _call_kernel(fn, **kwargs):
+    """Run a benchmark pass and optional correctness pass."""
+    bench = fn(**dict(kwargs, profile=True, skip_reference=True))
+    if not VERIFY or bench.get("status") != "passed":
+        return bench
+    try:
+        fn(**dict(kwargs, profile=False, skip_reference=False))
+        bench["verify"] = "pass"
+    except AssertionError as e:
+        bench["verify"] = "fail"
+        bench["error"] = str(e).splitlines()[0][:120]
+    return bench
+
+
+def _run_one(shape):
+    b, qo, kv, nhq, nhk, hd, c, sc = shape
+    common = dict(
+        kvcache_layout="linear",
+        table_layout="sglang",
+        batch_size=b,
+        qo_len=qo,
+        kv_len=kv,
+        page_size=PAGE_SIZE,
+        num_qo_heads=nhq,
+        num_kv_heads=nhk,
+        head_dim=hd,
+        causal=c,
+        logits_soft_cap=sc,
+        dtype=torch.bfloat16,
+        contiguous_kv=True,
+        seed=42,
+    )
+    pth = _call_kernel(run_batch_prefill_per_token_head, **common)
+    if PAGE_SIZE >= 128:
+        kvb = _call_kernel(run_batch_prefill_kv_blockscale, **common)
+    else:
+        kvb = {"status": "skipped"}
+    return pth, kvb
+
+
+def _format_row(shape, pth, kvb):
+    b = shape[0]
+    return (
+        f"{b:>5} | "
+        f"{_fmt(kvb):>27} {_verify_str(kvb)} | "
+        f"{_fmt(pth):>27} {_verify_str(pth)}"
+    )
+
+
+def _run_silent(shape):
+    """Run one shape with FD-level stdout/stderr suppression."""
+    import tempfile
+
+    capture = tempfile.TemporaryFile(mode="w+")
+    sys.stdout.flush()
+    sys.stderr.flush()
+    saved_out = os.dup(1)
+    saved_err = os.dup(2)
+    os.dup2(capture.fileno(), 1)
+    os.dup2(capture.fileno(), 2)
+    ok = True
+    try:
+        return _run_one(shape)
+    except BaseException:
+        ok = False
+        raise
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(saved_out)
+        os.close(saved_err)
+        if not ok:
+            capture.seek(0)
+            sys.stderr.write(capture.read())
+        capture.close()
+
+
+print("Warming up kernels (one-time JIT setup, may take a moment)...", flush=True)
+_pth0, _kvb0 = _run_silent(SHAPES[0])
+
+_nhq, _nhk, _hd, _causal, _sc = SHAPES[0][3:8]
+for _s in SHAPES:
+    assert _s[3:8] == (_nhq, _nhk, _hd, _causal, _sc)
+
+if VERIFY:
+    print("Verification: ON")
+else:
+    print("Verification: OFF (set BENCH_VERIFY=1 to enable)")
+print(
+    f"Config: nhq={_nhq}, nhk={_nhk}, hd={_hd}, "
+    f"causal={_causal}, soft_cap={_sc}, page_size={PAGE_SIZE}"
+)
+_HEADER = (
+    f"{'batch':>5} | "
+    f"{'KV_BLOCKSCALE':>27} {'vrf':>4} | "
+    f"{'PER_TOKEN_HEAD':>27} {'vrf':>4}"
+)
+print(_HEADER)
+print("-" * len(_HEADER))
+
+failures = []
+
+
+def _record_failures(shape, pth, kvb):
+    b, _qo, kv, *_ = shape
+    for label, r in (("PER_TOKEN_HEAD", pth), ("KV_BLOCKSCALE", kvb)):
+        if r.get("verify") == "fail":
+            failures.append((b, kv, label, r.get("error", "")))
+
+
+_groups = {}
+for _s in SHAPES:
+    _groups.setdefault(_s[2], []).append(_s)
+
+_warmup_done = False
+for _seq, _shapes in _groups.items():
+    print(f"seq={_seq}")
+    for shape in _shapes:
+        if shape == SHAPES[0] and not _warmup_done:
+            pth, kvb = _pth0, _kvb0
+            _warmup_done = True
+        else:
+            pth, kvb = _run_one(shape)
+        print(_format_row(shape, pth, kvb), flush=True)
+        _record_failures(shape, pth, kvb)
+
+if VERIFY:
+    if failures:
+        print("-" * len(_HEADER))
+        print(f"VERIFY FAILED on {len(failures)} configuration(s):")
+        for b, kv, label, err in failures:
+            print(f"  batch={b} seq={kv} {label}: {err}")
+        sys.exit(1)
+    else:
+        print("-" * len(_HEADER))
+        print("VERIFY PASSED on all configurations.")

--- a/op_tests/bench_per_token_head.py
+++ b/op_tests/bench_per_token_head.py
@@ -71,7 +71,9 @@ def _build_p_scale(num_qo_heads):
         num_qo_heads, dtype=torch.float32, device="cuda", generator=g
     )
 
-DEFAULT_SEQS = (1024, 16384, 32768, 65536, 131072)
+# Small seqlens (<=16) exercise the kM0=128 query tile with mostly padding rows;
+# they reproduce the PER_TOKEN_HEAD small-seqlen q_descale out-of-bounds coredump.
+DEFAULT_SEQS = (4, 8, 16, 1024, 16384, 32768, 65536, 131072)
 _parser = argparse.ArgumentParser(
     description="Benchmark FP8 PER_TOKEN_HEAD batch_prefill kernel.",
     formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -459,6 +459,25 @@ def split_kv_pages(kv_data):
     return k_cache_ref, v_cache_ref
 
 
+def vec_k_col_v_kv_cache(
+    k_cache, v_cache, num_kv_heads, head_dim, page_size, k_vector_size
+):
+    """Decode-aligned VEC_K_COL_V layout: K is 5D vectorized (same as VECTORIZED),
+    V is 4D ColumnMajor [Pages, Heads, HeadDim, PageSize]."""
+    k_cache = k_cache.contiguous()
+    v_cache = v_cache.contiguous()
+    k_cache = (
+        k_cache.view(
+            -1, page_size, num_kv_heads, head_dim // k_vector_size, k_vector_size
+        )
+        .permute(0, 2, 3, 1, 4)
+        .contiguous()
+    )
+    # v_cache_ref shape: [Pages, PageSize, Heads, HeadDim] -> [Pages, Heads, HeadDim, PageSize]
+    v_cache = v_cache.permute(0, 2, 3, 1).contiguous()
+    return k_cache, v_cache
+
+
 def apply_kv_layout(
     k_cache_ref,
     v_cache_ref,
@@ -470,6 +489,15 @@ def apply_kv_layout(
 ):
     if layout == "vectorized":
         return vectorize_kv_cache(
+            k_cache_ref,
+            v_cache_ref,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            k_vector_size,
+        )
+    if layout == "vec_k_col_v":
+        return vec_k_col_v_kv_cache(
             k_cache_ref,
             v_cache_ref,
             num_kv_heads,
@@ -2666,6 +2694,52 @@ def test_batch_prefill_per_token_head_pytest(
     )
 
 
+# Decode-aligned VEC_K_COL_V_LAYOUT pytest. Codegen only emits this variant for
+# fp8bf16 PER_TOKEN_HEAD with the sglang lookup table (see fmha_batch_prefill.py).
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("num_qo_heads,num_kv_heads", [(32, 8), (16, 16)])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("qo_len,kv_len", [(512, 2048), (1024, 4096)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
+@pytest.mark.parametrize("page_size", [64, 1024])
+def test_batch_prefill_per_token_head_vec_k_col_v_pytest(
+    batch_size,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    qo_len,
+    kv_len,
+    causal,
+    logits_soft_cap,
+    page_size,
+):
+    """Pytest wrapper for PER_TOKEN_HEAD FP8 batch prefill on the decode-aligned
+    VEC_K_COL_V layout (5D vectorized K + 4D ColumnMajor V)."""
+    if skip_test_if(
+        should_skip_rocm72_issue(causal, logits_soft_cap),
+        "ROCm 7.2 + gfx950 compiler issue with causal=True + logits_soft_cap=0.0",
+    ):
+        return
+
+    run_batch_prefill_per_token_head(
+        kvcache_layout="vec_k_col_v",
+        table_layout="sglang",
+        batch_size=batch_size,
+        qo_len=qo_len,
+        kv_len=kv_len,
+        page_size=page_size,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        dtype=torch.bfloat16,
+        contiguous_kv=True,
+        seed=42,
+    )
+
+
 # Caller-supplied softmax-P scale variants for PER_TOKEN_HEAD.
 # p_scale is per-q-head fp32 multiplier folded into the exp2 shift before fp8 P
 # quantization; it cancels mathematically in the final output, so the FP32
@@ -2675,7 +2749,9 @@ def test_batch_prefill_per_token_head_pytest(
 @pytest.mark.parametrize("num_qo_heads,num_kv_heads", [(32, 8)])
 @pytest.mark.parametrize("qo_len,kv_len", [(512, 2048)])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("p_scale_mode", ["none", "ones", "half", "per_head_random"])
+@pytest.mark.parametrize(
+    "p_scale_mode", ["none", "ones", "half", "per_head_random"]
+)
 def test_batch_prefill_per_token_head_p_scale_pytest(
     batch_size,
     num_qo_heads,
@@ -2697,11 +2773,17 @@ def test_batch_prefill_per_token_head_p_scale_pytest(
     elif p_scale_mode == "ones":
         p_scale = torch.ones(num_qo_heads, dtype=torch.float32, device="cuda")
     elif p_scale_mode == "half":
-        p_scale = torch.full((num_qo_heads,), 0.5, dtype=torch.float32, device="cuda")
+        p_scale = torch.full(
+            (num_qo_heads,), 0.5, dtype=torch.float32, device="cuda"
+        )
     else:  # per_head_random in [0.25, 1.0]
         g = torch.Generator(device="cuda").manual_seed(123)
-        p_scale = 0.25 + 0.75 * torch.rand(
-            num_qo_heads, dtype=torch.float32, device="cuda", generator=g
+        p_scale = (
+            0.25
+            + 0.75
+            * torch.rand(
+                num_qo_heads, dtype=torch.float32, device="cuda", generator=g
+            )
         )
 
     run_batch_prefill_per_token_head(
@@ -2757,7 +2839,7 @@ def run_batch_prefill_per_token_head(
         torch.manual_seed(seed)
 
     quant_dtype = dtypes.fp8
-    SUPPORTED_PAGE_SIZES = (16, 64, 1024)
+    SUPPORTED_PAGE_SIZES = (64, 1024)
     if page_size not in SUPPORTED_PAGE_SIZES:
         if skip_test_if(
             True,
@@ -2856,6 +2938,17 @@ def run_batch_prefill_per_token_head(
             page_size,
             k_vector_size,
         )
+    elif kvcache_layout == "vec_k_col_v":
+        # k_paged_fp8 / v_paged_fp8 currently have shape [Pages, PageSize, Heads, HeadDim].
+        # vec_k_col_v_kv_cache expects the same layout, so feed them directly without flattening.
+        k_paged, v_paged = vec_k_col_v_kv_cache(
+            k_paged_fp8,
+            v_paged_fp8,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            k_vector_size,
+        )
     else:
         k_paged = k_paged_fp8
         v_paged = v_paged_fp8
@@ -2872,6 +2965,12 @@ def run_batch_prefill_per_token_head(
             page_size,
             k_vector_size_bf16,
         )
+    elif kvcache_layout == "vec_k_col_v":
+        # bf16 reference also runs through the prefill kernel for correctness; bf16 has no
+        # PER_TOKEN_HEAD codegen variant for vec_k_col_v, so we keep the bf16 reference
+        # in plain linear layout (the prefill bf16 path supports linear K/V natively).
+        k_cache_bf16 = k_paged_ref
+        v_cache_bf16 = v_paged_ref
     else:
         k_cache_bf16 = k_paged_ref
         v_cache_bf16 = v_paged_ref

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -3120,7 +3120,7 @@ def run_batch_prefill_per_token_head(
         torch.manual_seed(seed)
 
     quant_dtype = dtypes.fp8
-    SUPPORTED_PAGE_SIZES = (64, 1024)
+    SUPPORTED_PAGE_SIZES = (16, 64, 1024)
     if page_size not in SUPPORTED_PAGE_SIZES:
         if skip_test_if(
             True,

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -195,6 +195,31 @@ def check_layout_skip_conditions(
         ):
             return True
 
+    if kvcache_layout == "vec_k_col_v":
+        # Decode-aligned col-V kernels are only generated for the non-quant
+        # bf16/fp16 path (and the separate fp8bf16 PER_TOKEN_HEAD path). The
+        # in-test fp8 pertensor path has no col-V kernel, so skip it here.
+        if skip_test_if(
+            is_input_fp8,
+            "vec_k_col_v has no in-test FP8 pertensor kernel (bf16/fp16 only)",
+        ):
+            return True
+        # The ColumnMajor V is loaded as a single merged (D, TotalSeqK) view, so a
+        # V tile must stay within one physical page. Small pages let a tile cross
+        # page boundaries and read wrong data (same kernel limitation the FP8
+        # PER_TOKEN_HEAD path guards). Supported page sizes match: (64, 1024).
+        if skip_test_if(
+            page_size not in (64, 1024),
+            f"vec_k_col_v only supports page_size in (64, 1024), got {page_size}",
+        ):
+            return True
+        # K is 5D vectorized, so it shares the vectorized layout's constraints.
+        if skip_test_if(
+            page_size % k_vector_size != 0 or head_dim % k_vector_size != 0,
+            "vec_k_col_v layout requires page/head dim divisible by vector size",
+        ):
+            return True
+
     return False
 
 
@@ -1115,7 +1140,7 @@ def test_batch_prefill_page_size_1_linear_sglang(
             assert_lse_matches_reference(lse_kernel, lse_ref)
 
 
-@pytest.mark.parametrize("kvcache_layout", ["linear", "vectorized"])
+@pytest.mark.parametrize("kvcache_layout", ["linear", "vectorized", "vec_k_col_v"])
 @pytest.mark.parametrize("table_layout", ["sglang", "vllm"])
 @pytest.mark.parametrize("input_dtype", ["bf16", "fp8"])
 @pytest.mark.parametrize("batch_size", [1, 3, 7])
@@ -3757,7 +3782,7 @@ def run_batch_prefill_sink(
 # (the bisect family that isolated the bug to total cache size, i.e. the page
 # table is read past the valid region).
 #
-# Crash shape from Tencent Hunyuan / MI-308X:
+# Crash shape (prefill paged-KV out-of-bounds page-table read):
 #   prefill (q=2042, kv=2042), 10 q-heads, 1 kv-head, head_dim=128,
 #   page_size=16, bf16, causal=True
 #

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -2933,6 +2933,48 @@ def test_batch_prefill_per_token_head_pytest(
     )
 
 
+# Small-seqlen regression for the PER_TOKEN_HEAD q_descale coredump. When
+# qo_len <= kM0 (128), the query tile is mostly padding rows; before the fix the
+# kernel read q_descale_per_token for those padding rows (past the [total_q]
+# tensor) and faulted. Exercises both supported page sizes; the q_descale
+# staging is layout-independent so "linear" coverage guards the crash.
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("qo_len,kv_len", [(1, 1), (4, 4), (16, 16), (16, 64)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("page_size", [64, 1024])
+def test_batch_prefill_per_token_head_small_seqlen_pytest(
+    batch_size,
+    qo_len,
+    kv_len,
+    causal,
+    page_size,
+):
+    """Regression: PER_TOKEN_HEAD must not OOB-read q_descale on padding rows
+    when the query tile (kM0=128) is larger than the valid sequence length."""
+    if skip_test_if(
+        should_skip_rocm72_issue(causal, 0.0),
+        "ROCm 7.2 + gfx950 compiler issue with causal=True + logits_soft_cap=0.0",
+    ):
+        return
+
+    run_batch_prefill_per_token_head(
+        kvcache_layout="linear",
+        table_layout="sglang",
+        batch_size=batch_size,
+        qo_len=qo_len,
+        kv_len=kv_len,
+        page_size=page_size,
+        num_qo_heads=32,
+        num_kv_heads=8,
+        head_dim=128,
+        causal=causal,
+        logits_soft_cap=0.0,
+        dtype=torch.bfloat16,
+        contiguous_kv=True,
+        seed=42,
+    )
+
+
 # Decode-aligned VEC_K_COL_V_LAYOUT pytest. Codegen only emits this variant for
 # fp8bf16 PER_TOKEN_HEAD with the sglang lookup table (see fmha_batch_prefill.py).
 @pytest.mark.parametrize("batch_size", [1, 4])

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -283,7 +283,27 @@ def construct_local_mask(
         )
 
 
-def ref_masked_attention(
+def _local_mask_rows(q_start, q_end, seqlen_q, seqlen_k, window_size, device):
+    """
+    Row-slice of construct_local_mask covering global Q indices [q_start, q_end).
+
+    This reproduces construct_local_mask semantics with key_padding_mask=None
+    and query_padding_mask=None (the only path the batch_prefill reference uses)
+    but only materializes [q_end - q_start, seqlen_k] booleans instead of the
+    full [seqlen_q, seqlen_k] mask, which would OOM at long sequences.
+    """
+    row_idx = torch.arange(q_start, q_end, device=device, dtype=torch.long).view(-1, 1)
+    col_idx = torch.arange(seqlen_k, device=device, dtype=torch.long)
+    if window_size[0] < 0:
+        return col_idx > row_idx + seqlen_k - seqlen_q + window_size[1]
+    sk_t = torch.full_like(col_idx, seqlen_k)
+    return torch.logical_or(
+        col_idx > torch.minimum(row_idx + seqlen_k - seqlen_q + window_size[1], sk_t),
+        col_idx < row_idx + seqlen_k - seqlen_q - window_size[0],
+    )
+
+
+def _ref_masked_attention_unchunked(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -293,20 +313,10 @@ def ref_masked_attention(
     return_lse: bool = False,
 ) -> torch.Tensor:
     """
-    Reference implementation of masked attention.
-
-    Args:
-        query: [seqlen_q, num_heads, head_dim]
-        key: [seqlen_k, num_heads, head_dim]
-        value: [seqlen_k, num_heads, head_dim]
-        causal: whether to use causal mask
-        window_left: left window size for sliding window attention
-        logits_soft_cap: soft cap for logits (0.0 = disabled)
-        return_lse: whether to return log-sum-exp values
-
-    Returns:
-        If return_lse=False: output [seqlen_q, num_heads, head_dim]
-        If return_lse=True: (output, lse) where lse is [num_heads, seqlen_q]
+    Canonical (pre-chunking) reference implementation, kept verbatim as the
+    semantic anchor for the chunked path. Used by the equivalence test only;
+    do not call from production paths — peak memory is H * Q * K * 4 bytes
+    which OOMs at long sequences (e.g. 137 GB at H=8, Q=K=65536).
     """
     if causal:
         window_size = (window_left, 0)
@@ -318,7 +328,6 @@ def ref_masked_attention(
     seqlen_k = key.shape[0]
     scale = 1.0 / math.sqrt(head_dim)
 
-    # Compute scaled attention scores: [num_heads, seqlen_q, seqlen_k]
     attn_weights = scale * torch.einsum("qhd,khd->hqk", query.float(), key.float())
 
     if 0 < logits_soft_cap:
@@ -339,11 +348,8 @@ def ref_masked_attention(
         )
         attn_weights.masked_fill_(local_mask, float("-inf"))
 
-    # Compute LSE before softmax using torch.logsumexp
-    # This correctly handles fully-masked rows (all -inf) by returning -inf instead of nan
     if return_lse:
-        # attn_weights: [num_heads, seqlen_q, seqlen_k]
-        lse = torch.logsumexp(attn_weights, dim=-1)  # [H, Q]
+        lse = torch.logsumexp(attn_weights, dim=-1)
 
     attn_weights = torch.softmax(attn_weights, dim=-1)
     if window_size[0] >= 0 or window_size[1] >= 0:
@@ -353,6 +359,131 @@ def ref_masked_attention(
     out = torch.einsum("hqk,khd->qhd", attn_weights, value.float())
 
     if return_lse:
+        return out.to(query), lse.float()
+    return out.to(query)
+
+
+def ref_masked_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    causal: bool = False,
+    window_left: int = -1,
+    logits_soft_cap: float = 0.0,
+    return_lse: bool = False,
+    q_chunk_size: int = None,
+) -> torch.Tensor:
+    """
+    Reference implementation of masked attention with Q-dimension chunking.
+
+    Args:
+        query: [seqlen_q, num_heads, head_dim]
+        key: [seqlen_k, num_heads, head_dim]
+        value: [seqlen_k, num_heads, head_dim]
+        causal: whether to use causal mask
+        window_left: left window size for sliding window attention
+        logits_soft_cap: soft cap for logits (0.0 = disabled)
+        return_lse: whether to return log-sum-exp values
+        q_chunk_size: rows of Q processed per iteration. Default reads
+            BENCH_REF_Q_CHUNK env var (fallback 1024). Set <= 0 to disable
+            chunking (single shot over the entire Q dim).
+
+    Returns:
+        If return_lse=False: output [seqlen_q, num_heads, head_dim]
+        If return_lse=True: (output, lse) where lse is [num_heads, seqlen_q]
+
+    Memory notes:
+        Peak intermediate is the per-chunk attention matrix [H, Q_chunk, K] in
+        fp32. For H=8, K=131072, Q_chunk=1024 that's ~4 GB — fits on a 192 GB
+        MI308X with plenty of headroom. The unchunked version peaks at
+        H * seqlen_q * seqlen_k * 4 bytes which OOMs at seq=65536+ on long
+        contexts (137 GB at H=8, Q=K=65536; ~550 GB at Q=K=131072).
+    """
+    if causal:
+        window_size = (window_left, 0)
+    else:
+        window_size = (-1, -1)
+
+    head_dim = query.shape[2]
+    seqlen_q = query.shape[0]
+    seqlen_k = key.shape[0]
+    num_heads = query.shape[1]
+    scale = 1.0 / math.sqrt(head_dim)
+    device = query.device
+
+    has_local_mask = window_size[0] >= 0 or window_size[1] >= 0
+
+    # Empty-query fast path: preserve the shape behavior of the original.
+    if seqlen_q == 0:
+        out = torch.empty(0, num_heads, head_dim, device=device, dtype=query.dtype)
+        if return_lse:
+            lse = torch.empty(num_heads, 0, device=device, dtype=torch.float32)
+            return out, lse
+        return out
+
+    if q_chunk_size is None:
+        q_chunk = int(os.environ.get("BENCH_REF_Q_CHUNK", "1024"))
+    else:
+        q_chunk = int(q_chunk_size)
+    if q_chunk <= 0 or q_chunk > seqlen_q:
+        q_chunk = seqlen_q
+
+    # Materialize fp32 K/V once and reuse across all Q chunks. For H=8,
+    # K=131072, D=128 that's ~537 MB per tensor in fp32, well within budget.
+    key_f32 = key.float()
+    value_f32 = value.float()
+
+    out_chunks = []
+    lse_chunks = [] if return_lse else None
+
+    for q_start in range(0, seqlen_q, q_chunk):
+        q_end = min(q_start + q_chunk, seqlen_q)
+        q_block = query[q_start:q_end].float()
+
+        # [num_heads, q_chunk, seqlen_k]
+        attn = scale * torch.einsum("qhd,khd->hqk", q_block, key_f32)
+
+        if 0 < logits_soft_cap:
+            mode = int(os.environ.get("CK_TILE_ATTENTION_LOGITS_SOFT_CAP_DEFAULT", 0))
+            if mode == 0:
+                attn = logits_soft_cap * torch.tanh(attn / logits_soft_cap)
+            else:
+                attn = attn / (1.0 + torch.abs(attn / logits_soft_cap))
+
+        local_mask = None
+        if has_local_mask:
+            # Construct only the rows we need. Uses global Q indices so the
+            # causal/window boundary stays consistent with the unchunked path.
+            local_mask = _local_mask_rows(
+                q_start, q_end, seqlen_q, seqlen_k, window_size, device
+            )
+            attn.masked_fill_(local_mask, float("-inf"))
+
+        # LSE is computed on the post-mask, pre-softmax logits — matches the
+        # unchunked implementation. logsumexp of an all -inf row is -inf, which
+        # propagates cleanly through downstream consumers.
+        if return_lse:
+            lse_chunks.append(torch.logsumexp(attn, dim=-1))
+
+        attn = torch.softmax(attn, dim=-1)
+        if has_local_mask:
+            # Zero out fully-masked rows so softmax(all -inf) = nan becomes 0.
+            attn = attn.masked_fill(
+                torch.all(local_mask, dim=-1, keepdim=True), 0.0
+            )
+
+        # [q_chunk, num_heads, head_dim]
+        out_chunks.append(torch.einsum("hqk,khd->qhd", attn, value_f32))
+
+        # Drop chunk-local refs so the caching allocator can reuse the slot for
+        # the next iteration's [H, Q_chunk, K] tensor.
+        del attn
+        if local_mask is not None:
+            del local_mask
+
+    out = torch.cat(out_chunks, dim=0)
+    if return_lse:
+        lse = torch.cat(lse_chunks, dim=1)
         return out.to(query), lse.float()
     return out.to(query)
 
@@ -638,6 +769,89 @@ def assert_lse_matches_reference(
         rtol=rtol,
         atol=atol,
     )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
+@pytest.mark.parametrize("return_lse", [False, True])
+@pytest.mark.parametrize("q_chunk_size", [256, 1000, 1024])
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+def test_ref_masked_attention_chunking_equivalence(
+    causal, logits_soft_cap, return_lse, q_chunk_size, input_dtype
+):
+    """
+    Guard against silent semantic drift between the chunked
+    ref_masked_attention and the canonical unchunked implementation.
+
+    Runs at qlen=klen=4096, nhq=8, hd=128 — fits in either path. Exercises
+    causal/non-causal, soft_cap on/off, return_lse on/off, plus a couple of
+    chunk sizes including one (1000) that does not evenly divide seqlen_q so
+    the final partial chunk gets covered too.
+
+    Tolerances:
+        - fp32 input: 1e-5 (true fp32 round-off scale; chunking and unchunked
+          differ only because cuBLAS routes shape-dependent einsum kernels
+          with different reduction order in the head_dim sum).
+        - bf16 input: 1e-3 (~1 bf16 ULP at output magnitudes near 0.1, set by
+          the final out.to(query) cast back to bf16). The pre-cast fp32 math
+          is bit-identical to the fp32-input case.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA/HIP device for fp32 attention")
+
+    torch.manual_seed(0)
+    seqlen_q = seqlen_k = 4096
+    num_heads = 8
+    head_dim = 128
+    device = "cuda"
+
+    q = torch.randn(seqlen_q, num_heads, head_dim, device=device, dtype=input_dtype)
+    k = torch.randn(seqlen_k, num_heads, head_dim, device=device, dtype=input_dtype)
+    v = torch.randn(seqlen_k, num_heads, head_dim, device=device, dtype=input_dtype)
+
+    unchunked = _ref_masked_attention_unchunked(
+        q, k, v,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        return_lse=return_lse,
+    )
+    chunked = ref_masked_attention(
+        q, k, v,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        return_lse=return_lse,
+        q_chunk_size=q_chunk_size,
+    )
+
+    out_atol = 1e-5 if input_dtype == torch.float32 else 1e-3
+    # LSE is always fp32 in both paths (no output cast); use the fp32 bound.
+    lse_atol = 1e-5
+
+    if return_lse:
+        out_u, lse_u = unchunked
+        out_c, lse_c = chunked
+        out_diff = (out_u.float() - out_c.float()).abs().max().item()
+        lse_diff = (lse_u - lse_c).abs().max().item()
+        assert out_diff <= out_atol, (
+            f"chunked output diverged from unchunked: max-abs={out_diff} "
+            f"(dtype={input_dtype}, causal={causal}, "
+            f"soft_cap={logits_soft_cap}, return_lse={return_lse}, "
+            f"q_chunk_size={q_chunk_size})"
+        )
+        assert lse_diff <= lse_atol, (
+            f"chunked LSE diverged from unchunked: max-abs={lse_diff} "
+            f"(dtype={input_dtype}, causal={causal}, "
+            f"soft_cap={logits_soft_cap}, return_lse={return_lse}, "
+            f"q_chunk_size={q_chunk_size})"
+        )
+    else:
+        out_diff = (unchunked.float() - chunked.float()).abs().max().item()
+        assert out_diff <= out_atol, (
+            f"chunked output diverged from unchunked: max-abs={out_diff} "
+            f"(dtype={input_dtype}, causal={causal}, "
+            f"soft_cap={logits_soft_cap}, return_lse={return_lse}, "
+            f"q_chunk_size={q_chunk_size})"
+        )
 
 
 @pytest.mark.parametrize("input_dtype", ["bf16", "fp8"])

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -1229,6 +1229,9 @@ def run_ck(
     k_descale=None,
     v_descale=None,
     kv_block_descale=None,
+    q_descale_per_token=None,
+    k_descale_per_token=None,
+    v_descale_per_head=None,
     kv_last_page_lens=None,
     block_table=None,
     seqlen_k=None,
@@ -1261,6 +1264,9 @@ def run_ck(
         k_descale=k_descale,
         v_descale=v_descale,
         kv_block_descale=kv_block_descale,
+        q_descale_per_token=q_descale_per_token,
+        k_descale_per_token=k_descale_per_token,
+        v_descale_per_head=v_descale_per_head,
         kv_last_page_lens=kv_last_page_lens,
         block_table=block_table,
         seqlen_k=seqlen_k,
@@ -1584,6 +1590,65 @@ def per_page_quant(tensor, page_size, quant_dtype):
     descales_broadcast = descales.unsqueeze(1).unsqueeze(-1)
     quantized = (tensor / descales_broadcast).to(quant_dtype)
 
+    return quantized, descales
+
+
+def per_token_per_head_quant_q(tensor, quant_dtype):
+    """
+    Quantize Q with per-token-per-head scale (PER_TOKEN_HEAD mode).
+
+    Args:
+        tensor: [total_q, num_heads, head_dim]
+        quant_dtype: target quantization dtype (fp8)
+
+    Returns:
+        quantized: [total_q, num_heads, head_dim]
+        descales:  [total_q, num_heads] fp32 per-token-per-head descale
+    """
+    fp8_max = torch.finfo(quant_dtype).max
+    abs_max = tensor.abs().amax(dim=-1).clamp(min=1e-12)  # [total_q, num_heads]
+    descales = (abs_max / fp8_max).float()
+    quantized = (tensor / descales.unsqueeze(-1)).to(quant_dtype)
+    return quantized, descales
+
+
+def per_token_per_head_quant_k_paged(tensor, quant_dtype):
+    """
+    Quantize paged K with per-token-per-head scale (PER_TOKEN_HEAD mode).
+
+    Args:
+        tensor: [num_pages, page_size, num_kv_heads, head_dim]
+        quant_dtype: target quantization dtype (fp8)
+
+    Returns:
+        quantized: [num_pages, page_size, num_kv_heads, head_dim]
+        descales:  [num_pages, page_size, num_kv_heads] fp32
+    """
+    fp8_max = torch.finfo(quant_dtype).max
+    abs_max = tensor.abs().amax(dim=-1).clamp(min=1e-12)
+    descales = (abs_max / fp8_max).float()
+    quantized = (tensor / descales.unsqueeze(-1)).to(quant_dtype)
+    return quantized, descales
+
+
+def per_head_quant_v_paged(tensor, quant_dtype):
+    """
+    Quantize paged V with per-head scale (PER_TOKEN_HEAD mode V scaling).
+
+    Args:
+        tensor: [num_pages, page_size, num_kv_heads, head_dim]
+        quant_dtype: target quantization dtype (fp8)
+
+    Returns:
+        quantized: [num_pages, page_size, num_kv_heads, head_dim]
+        descales:  [num_kv_heads] fp32
+    """
+    fp8_max = torch.finfo(quant_dtype).max
+    # Max over (num_pages, page_size, head_dim) -> [num_kv_heads]
+    abs_max = tensor.abs().amax(dim=(0, 1, 3)).clamp(min=1e-12)
+    descales = (abs_max / fp8_max).float()
+    # Broadcast: [1, 1, num_kv_heads, 1]
+    quantized = (tensor / descales.view(1, 1, -1, 1)).to(quant_dtype)
     return quantized, descales
 
 
@@ -2335,6 +2400,7 @@ def run_batch_prefill_kv_blockscale(
     contiguous_kv,
     seed,
     profile=False,
+    skip_reference=False,
 ):
     """
     Test FP8 batch prefill with per-page KV descale (KV_BLOCKSCALE mode).
@@ -2410,19 +2476,22 @@ def run_batch_prefill_kv_blockscale(
     q_indptr_cpu = convert_lens_to_indptr(qo_lens)
 
     # Build FP32 reference output (same as pertensor test)
-    o_ref = build_reference_output(
-        q,
-        q_indptr_cpu,
-        kv_data_fp32,
-        kv_indices,
-        kv_indptr,
-        kv_last_page_len_cpu,
-        num_kv_heads,
-        head_dim,
-        dtype,
-        causal,
-        logits_soft_cap,
-    )
+    if skip_reference:
+        o_ref = None
+    else:
+        o_ref = build_reference_output(
+            q,
+            q_indptr_cpu,
+            kv_data_fp32,
+            kv_indices,
+            kv_indptr,
+            kv_last_page_len_cpu,
+            num_kv_heads,
+            head_dim,
+            dtype,
+            causal,
+            logits_soft_cap,
+        )
 
     # Quantize K/V with per-page scale
     # k_paged_ref is [num_pages, page_size, num_kv_heads, head_dim]
@@ -2509,6 +2578,8 @@ def run_batch_prefill_kv_blockscale(
         out_fp8 = run_result
 
     # Run BF16 reference kernel (no quantization) - no profiling for reference
+    if skip_reference:
+        return profile_result
     out_bf16 = run_ck(
         batch_size,
         num_kv_heads,
@@ -2537,6 +2608,275 @@ def run_batch_prefill_kv_blockscale(
     verify_fp8_output(out_fp8, o_ref)
 
     # Compare BF16 kernel vs FP32 reference (same as pertensor test)
+    rtol, atol = get_tolerances(dtype, is_fp8=False)
+    torch.testing.assert_close(out_bf16, o_ref, rtol=rtol, atol=atol)
+
+    return profile_result
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("num_qo_heads,num_kv_heads", [(32, 8), (16, 16)])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("qo_len,kv_len", [(128, 1024), (512, 2048), (1024, 4096)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("table_layout", ["sglang", "vllm"])
+@pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
+@pytest.mark.parametrize("page_size", [64, 1024])
+def test_batch_prefill_per_token_head_pytest(
+    batch_size,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    qo_len,
+    kv_len,
+    causal,
+    table_layout,
+    logits_soft_cap,
+    page_size,
+):
+    """Pytest wrapper for PER_TOKEN_HEAD FP8 batch prefill test.
+
+    Q/K: per-token-per-head fp32 descale. V: per-head fp32 descale.
+    """
+    if skip_test_if(
+        should_skip_rocm72_issue(causal, logits_soft_cap),
+        "ROCm 7.2 + gfx950 compiler issue with causal=True + logits_soft_cap=0.0",
+    ):
+        return
+
+    run_batch_prefill_per_token_head(
+        kvcache_layout="linear",
+        table_layout=table_layout,
+        batch_size=batch_size,
+        qo_len=qo_len,
+        kv_len=kv_len,
+        page_size=page_size,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        dtype=torch.bfloat16,
+        contiguous_kv=True,
+        seed=42,
+    )
+
+
+def run_batch_prefill_per_token_head(
+    kvcache_layout,
+    table_layout,
+    batch_size,
+    qo_len,
+    kv_len,
+    page_size,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    causal,
+    logits_soft_cap,
+    dtype,
+    contiguous_kv,
+    seed,
+    profile=False,
+    skip_reference=False,
+):
+    """
+    FP8 batch prefill with PER_TOKEN_HEAD quantization:
+      Q descale: [total_q, nhead_q] fp32
+      K descale: [num_total_pages, page_block_size, nhead_k] fp32
+      V descale: [nhead_k] fp32
+    """
+    if seed is not None:
+        torch.manual_seed(seed)
+
+    quant_dtype = dtypes.fp8
+    SUPPORTED_PAGE_SIZES = (64, 1024)
+    if page_size not in SUPPORTED_PAGE_SIZES:
+        if skip_test_if(
+            True,
+            f"PER_TOKEN_HEAD only supports page_size in {SUPPORTED_PAGE_SIZES}, got {page_size}",
+        ):
+            return {"status": "skipped"}
+
+    k_vector_size = get_vector_size(quant_dtype)
+
+    if skip_test_if(
+        should_skip_rocm72_issue(causal, logits_soft_cap),
+        "ROCm 7.2 + gfx950 compiler issue with causal=True + logits_soft_cap=0.0",
+    ):
+        return {"status": "skipped"}
+
+    qo_lens = build_qo_lens(batch_size, qo_len, randomize=batch_size > 1)
+    kv_lens = build_kv_lens(batch_size, kv_len, qo_lens, randomize=batch_size > 1)
+    max_qo_len = qo_lens.max().item()
+    max_kv_len = kv_lens.max().item()
+
+    q = build_q_tensor_for_test(
+        qo_lens,
+        batch_size,
+        qo_len,
+        num_qo_heads,
+        head_dim,
+        dtype,
+        None,
+        None,
+        is_input_fp8=True,
+    )
+
+    kv_cache = build_paged_kv_cache(
+        batch_size,
+        kv_len,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        kv_lens,
+        None,
+        None,
+        dtype,
+        use_uniform=True,
+        contiguous_kv=contiguous_kv,
+    )
+
+    kv_data_fp32 = kv_cache["kv_data_fp32"]
+    kv_data = kv_cache["kv_data"]
+    kv_indptr = kv_cache["kv_indptr_cpu"]
+    kv_indices = kv_cache["kv_indices_cpu"]
+    kv_last_page_len_cpu = kv_cache["kv_last_page_len_cpu"]
+
+    k_paged_ref, v_paged_ref = split_kv_pages(kv_data)
+
+    cu_seqlens_q = convert_lens_to_indptr(qo_lens).cuda()
+    q_indptr_cpu = convert_lens_to_indptr(qo_lens)
+
+    # FP32 reference (bf16 ground truth)
+    if skip_reference:
+        o_ref = None
+    else:
+        o_ref = build_reference_output(
+            q,
+            q_indptr_cpu,
+            kv_data_fp32,
+            kv_indices,
+            kv_indptr,
+            kv_last_page_len_cpu,
+            num_kv_heads,
+            head_dim,
+            dtype,
+            causal,
+            logits_soft_cap,
+        )
+
+    # PER_TOKEN_HEAD quantization
+    q_fp8, q_descale_per_token = per_token_per_head_quant_q(q, quant_dtype)
+    q_descale_per_token = q_descale_per_token.cuda()
+
+    k_paged_fp8, k_descale_per_token = per_token_per_head_quant_k_paged(
+        k_paged_ref, quant_dtype
+    )
+    k_descale_per_token = k_descale_per_token.cuda()
+
+    v_paged_fp8, v_descale_per_head = per_head_quant_v_paged(v_paged_ref, quant_dtype)
+    v_descale_per_head = v_descale_per_head.cuda()
+
+    if kvcache_layout == "vectorized":
+        k_for_vec = k_paged_fp8.view(-1, num_kv_heads, head_dim)
+        v_for_vec = v_paged_fp8.view(-1, num_kv_heads, head_dim)
+        k_paged, v_paged = vectorize_kv_cache(
+            k_for_vec,
+            v_for_vec,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            k_vector_size,
+        )
+    else:
+        k_paged = k_paged_fp8
+        v_paged = v_paged_fp8
+
+    k_vector_size_bf16 = get_vector_size(dtype)
+    if kvcache_layout == "vectorized":
+        k_for_vec_bf16 = k_paged_ref.view(-1, num_kv_heads, head_dim)
+        v_for_vec_bf16 = v_paged_ref.view(-1, num_kv_heads, head_dim)
+        k_cache_bf16, v_cache_bf16 = vectorize_kv_cache(
+            k_for_vec_bf16,
+            v_for_vec_bf16,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            k_vector_size_bf16,
+        )
+    else:
+        k_cache_bf16 = k_paged_ref
+        v_cache_bf16 = v_paged_ref
+
+    max_num_pages_per_seq = (max_kv_len + page_size - 1) // page_size
+    block_table_cpu = torch.zeros(
+        (batch_size, max_num_pages_per_seq), dtype=torch.int32
+    )
+    for i in range(batch_size):
+        start, end = kv_indptr[i].item(), kv_indptr[i + 1].item()
+        block_table_cpu[i, : (end - start)] = kv_indices[start:end]
+    block_table_gpu = block_table_cpu.cuda()
+
+    kv_last_page_len_gpu = ((kv_lens - 1) % page_size + 1).int().cuda()
+    seqlen_k_gpu = kv_lens.cuda().int()
+
+    profile_result = {"status": "passed"}
+    run_result = run_ck(
+        batch_size,
+        num_kv_heads,
+        q_fp8,
+        k_paged,
+        v_paged,
+        cu_seqlens_q,
+        kv_indptr.cuda(),
+        kv_indices.cuda(),
+        max_qo_len,
+        max_kv_len,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        q_descale_per_token=q_descale_per_token,
+        k_descale_per_token=k_descale_per_token,
+        v_descale_per_head=v_descale_per_head,
+        kv_last_page_lens=kv_last_page_len_gpu,
+        block_table=block_table_gpu,
+        seqlen_k=seqlen_k_gpu,
+        profile=profile,
+    )
+    if profile:
+        out_fp8, time_us, tflops = run_result
+        profile_result = {"status": "passed", "time_us": time_us, "tflops": tflops}
+    else:
+        out_fp8 = run_result
+
+    if skip_reference:
+        return profile_result
+
+    out_bf16 = run_ck(
+        batch_size,
+        num_kv_heads,
+        q.cuda(),
+        k_cache_bf16.cuda(),
+        v_cache_bf16.cuda(),
+        cu_seqlens_q,
+        kv_indptr.cuda(),
+        kv_indices.cuda(),
+        max_qo_len,
+        max_kv_len,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        kv_last_page_lens=kv_last_page_len_gpu,
+        block_table=block_table_gpu,
+        seqlen_k=seqlen_k_gpu,
+        profile=False,
+    )
+
+    assert out_fp8.abs().max().item() > 1e-6, "FP8 kernel output is all zeros!"
+    assert out_bf16.abs().max().item() > 1e-6, "BF16 kernel output is all zeros!"
+    assert o_ref.abs().max().item() > 1e-6, "FP32 reference output is all zeros!"
+
+    verify_fp8_output(out_fp8, o_ref)
+
     rtol, atol = get_tolerances(dtype, is_fp8=False)
     torch.testing.assert_close(out_bf16, o_ref, rtol=rtol, atol=atol)
 

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -1235,6 +1235,8 @@ def run_ck(
     kv_last_page_lens=None,
     block_table=None,
     seqlen_k=None,
+    p_scale=None,
+    p_scale_inv=None,
     profile=False,
     return_lse=False,
 ):
@@ -1270,6 +1272,8 @@ def run_ck(
         kv_last_page_lens=kv_last_page_lens,
         block_table=block_table,
         seqlen_k=seqlen_k,
+        p_scale=p_scale,
+        p_scale_inv=p_scale_inv,
         return_lse=return_lse,
     )
 
@@ -2662,6 +2666,63 @@ def test_batch_prefill_per_token_head_pytest(
     )
 
 
+# Caller-supplied softmax-P scale variants for PER_TOKEN_HEAD.
+# p_scale is per-q-head fp32 multiplier folded into the exp2 shift before fp8 P
+# quantization; it cancels mathematically in the final output, so the FP32
+# reference comparison must hold regardless of the value. Values kept <= 1.0 to
+# stay clear of FP8 e4m3 saturation (internal P quantization scale is 256).
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("num_qo_heads,num_kv_heads", [(32, 8)])
+@pytest.mark.parametrize("qo_len,kv_len", [(512, 2048)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("p_scale_mode", ["none", "ones", "half", "per_head_random"])
+def test_batch_prefill_per_token_head_p_scale_pytest(
+    batch_size,
+    num_qo_heads,
+    num_kv_heads,
+    qo_len,
+    kv_len,
+    causal,
+    p_scale_mode,
+):
+    """PER_TOKEN_HEAD FP8 batch prefill with caller-supplied softmax-P scale."""
+    if skip_test_if(
+        should_skip_rocm72_issue(causal, 0.0),
+        "ROCm 7.2 + gfx950 compiler issue with causal=True + logits_soft_cap=0.0",
+    ):
+        return
+
+    if p_scale_mode == "none":
+        p_scale = None
+    elif p_scale_mode == "ones":
+        p_scale = torch.ones(num_qo_heads, dtype=torch.float32, device="cuda")
+    elif p_scale_mode == "half":
+        p_scale = torch.full((num_qo_heads,), 0.5, dtype=torch.float32, device="cuda")
+    else:  # per_head_random in [0.25, 1.0]
+        g = torch.Generator(device="cuda").manual_seed(123)
+        p_scale = 0.25 + 0.75 * torch.rand(
+            num_qo_heads, dtype=torch.float32, device="cuda", generator=g
+        )
+
+    run_batch_prefill_per_token_head(
+        kvcache_layout="linear",
+        table_layout="sglang",
+        batch_size=batch_size,
+        qo_len=qo_len,
+        kv_len=kv_len,
+        page_size=64,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=128,
+        causal=causal,
+        logits_soft_cap=0.0,
+        dtype=torch.bfloat16,
+        contiguous_kv=True,
+        seed=42,
+        p_scale=p_scale,
+    )
+
+
 def run_batch_prefill_per_token_head(
     kvcache_layout,
     table_layout,
@@ -2679,18 +2740,24 @@ def run_batch_prefill_per_token_head(
     seed,
     profile=False,
     skip_reference=False,
+    p_scale=None,
+    p_scale_inv=None,
 ):
     """
     FP8 batch prefill with PER_TOKEN_HEAD quantization:
       Q descale: [total_q, nhead_q] fp32
       K descale: [num_total_pages, page_block_size, nhead_k] fp32
       V descale: [nhead_k] fp32
+
+    p_scale (optional, [num_qo_heads] fp32 on device): folded into the softmax
+    exp2 shift before fp8 P quantization. p_scale cancels in the final output,
+    so the FP32 reference comparison is unaffected.
     """
     if seed is not None:
         torch.manual_seed(seed)
 
     quant_dtype = dtypes.fp8
-    SUPPORTED_PAGE_SIZES = (64, 1024)
+    SUPPORTED_PAGE_SIZES = (16, 64, 1024)
     if page_size not in SUPPORTED_PAGE_SIZES:
         if skip_test_if(
             True,
@@ -2841,6 +2908,8 @@ def run_batch_prefill_per_token_head(
         kv_last_page_lens=kv_last_page_len_gpu,
         block_table=block_table_gpu,
         seqlen_k=seqlen_k_gpu,
+        p_scale=p_scale,
+        p_scale_inv=p_scale_inv,
         profile=profile,
     )
     if profile:


### PR DESCRIPTION
Adds a FP8 quantization path (PER_TOKEN_HEAD) and optional per-query-head P-scale to mha_batch_prefill, with corresponding CK kernel support.
https://github.com/ROCm/rocm-libraries/pull/7883

**This PR should be merged after CK PR is merged and CK submodule is updated.**

## Motivation
Existing FP8 quant modes (PERTENSOR, KV_BLOCKSCALE) applies descaling that doesn't capture per-token or per-head variance in activation magnitudes. PER_TOKEN_HEAD enables descaling for Q and K at per-token-per-head granularity.

## Technical Details
Quantization scheme
Tensor	Descale granularity	Shape
Q	per-token, per-head	[total_q, nhead_q]
K	per-token, per-head (paged)	[num_total_pages, page_block_size, nhead_k]
V	per-head	[nhead_k]


P-scale
Optional per-q-head softmax P-scale [num_head_q] fp32. The kernel folds log2(p_scale) into the exp2 row-max shift — the factor appears in both P and rowsum l, cancelling in O = sum(P·V) / l without needing a separate output fixup.

## Test Plan
Test and benchmarking scripts have been added.



- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
