### PR TITLE
Matthias.triton mha gfx1151 default

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/mha.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha.py
@@ -362,6 +362,7 @@ def _attn_fwd(
     USE_INT64_STRIDES: tl.constexpr,
     ENABLE_SINK: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
+    HEAD_STRIDE_ALIGNED_8: tl.constexpr = False,
 ):
     NUM_BLOCKS = (SEQLEN_Q + BLOCK_M - 1) // BLOCK_M
     # calculate offsets
@@ -564,9 +565,22 @@ def _attn_fwd(
         off_k_head = off_q_head
 
     # q,k,v offsets
+    # When the caller guarantees that the head-axis strides of Q/K/V are
+    # multiples of 8 elements (set via HEAD_STRIDE_ALIGNED_8), the head-axis
+    # byte offset is 16-byte aligned. Auto-specialization only fires at the
+    # 16-element threshold, so hint the smaller multiple explicitly to let
+    # AxisInfo widen the global load.
+    qh_off = off_q_head * stride_qh
+    kh_off = off_k_head * stride_kh
+    vh_off = off_k_head * stride_vh
+    if HEAD_STRIDE_ALIGNED_8:
+        qh_off = tl.multiple_of(qh_off, 8)
+        kh_off = tl.multiple_of(kh_off, 8)
+        vh_off = tl.multiple_of(vh_off, 8)
+
     q_offs = (
         off_z * stride_qz
-        + off_q_head * stride_qh
+        + qh_off
         + cu_seqlens_q_start * stride_qm
         + offs_m[:, None] * stride_qm
         + offs_d[None, :] * stride_qk
@@ -575,7 +589,7 @@ def _attn_fwd(
     if HAS_PE:
         q_pe_offs = (
             off_z * stride_qz
-            + off_q_head * stride_qh
+            + qh_off
             + cu_seqlens_q_start * stride_qm
             + offs_m[:, None] * stride_qm
             + offs_pe[None, :] * stride_qk
@@ -586,7 +600,7 @@ def _attn_fwd(
 
     k_offs = (
         off_z * stride_kz
-        + off_k_head * stride_kh
+        + kh_off
         + cu_seqlens_k_start * stride_kn
         + offs_d[:, None] * stride_kk
         + offs_n[None, :] * stride_kn
@@ -595,7 +609,7 @@ def _attn_fwd(
     if HAS_PE:
         k_pe_offs = (
             off_z * stride_kz
-            + off_k_head * stride_kh
+            + kh_off
             + cu_seqlens_k_start * stride_kn
             + offs_pe[:, None] * stride_kk
             + offs_n[None, :] * stride_kn
@@ -606,7 +620,7 @@ def _attn_fwd(
 
     v_offs = (
         off_z * stride_vz
-        + off_k_head * stride_vh
+        + vh_off
         + cu_seqlens_k_start * stride_vn
         + offs_n[:, None] * stride_vn
         + offs_d[None, :] * stride_vk

--- a/aiter/ops/triton/attention/mha.py
+++ b/aiter/ops/triton/attention/mha.py
@@ -305,6 +305,15 @@ def _flash_attn_forward(
             USE_INT64_STRIDES=_USE_INT64_STRIDES,
             ENABLE_SINK=sink is not None,
             SLIDING_WINDOW=sliding_window,
+            # Soundness precondition: only set when every Q/K/V head-axis
+            # stride is a multiple of 8 elements. q_strides[1]/k_strides[1]/
+            # v_strides[1] are the head-axis strides in both thd and bshd
+            # layouts (see q_strides assembly above).
+            HEAD_STRIDE_ALIGNED_8=(
+                q_strides[1] % 8 == 0
+                and k_strides[1] % 8 == 0
+                and v_strides[1] % 8 == 0
+            ),
             **config,
         )
 

--- a/aiter/ops/triton/configs/gfx1151-MHA-DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx1151-MHA-DEFAULT.json
@@ -1,0 +1,92 @@
+{
+  "fwd": {
+    "dropout_or_fp32": {
+      "BLOCK_M": 32,
+      "BLOCK_N": 32,
+      "PRELOAD_V": false,
+      "waves_per_eu": 1,
+      "num_warps": 2,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "default": {
+      "BLOCK_M": 128,
+      "BLOCK_N": 64,
+      "PRELOAD_V": false,
+      "waves_per_eu": 2,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "pe": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "pe_dropout_or_fp32": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    }
+  },
+  "bkwd_fused" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "dkdvdq_kernel_N64" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }, 
+    "dkdvdq_kernel_N128" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }
+  },
+  "bkwd_onekernel" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "onekernel" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 128,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 1
+    },
+    "onekernel_pe" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 64,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 2
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Make AITER's `default` MHA forward impl (`aiter.ops.triton.attention.mha._attn_fwd`) usable, and competitive with the `dao_ai` impl, on gfx1151 (Strix Halo / RDNA3.5).

Two commits:

1. **`[triton-mha] hint head-stride div-by-8 for vectorized global load`**
   Adds a `HEAD_STRIDE_ALIGNED_8` constexpr to `_attn_fwd` + `tl.multiple_of(off_h_{q,k} * stride_*h, 8)` on the head-axis offset. When `head_dim` is a multiple of 8 but not 16 (e.g. 72), Triton's integer-arg auto-specialization does not attach `tt.divisibility = 8` to `stride_*h` (its threshold is 16), so AxisInfo treats the K/V global load as 2-byte aligned and Coalesce emits scalar `buffer_load_u16` instead of vectorized `buffer_load_b128`. The wrapper checks the actual runtime stride (not `head_dim`) before opting in, so non-contiguous Q/K/V views stay sound. Constexpr defaults to `False`, external callers of `_attn_fwd` unaffected. Same pattern, same wrapper logic as the equivalent hint already applied to the `flash_attn_triton_amd` (`dao_ai`) prefill kernel.

2. **`[triton-mha] add gfx1151 tuning config`**
   `_attn_fwd` reads its tuning from `aiter/ops/triton/configs/<gfx>-MHA-DEFAULT.json` at call time. Without a matching file the wrapper raises `FileNotFoundError`, which made `mha_set_impl("default")` unusable on Strix Halo. The new `gfx1151-MHA-DEFAULT.json` mirrors gfx950's block sizes (BLOCK_M=128, BLOCK_N=64, waves_per_eu=2, num_stages=1) but uses `num_warps=8` to match the `dao_ai` prefill kernel's choice for the same arch (halves loop-dispatch overhead on the Qwen3-Omni ViT prefill shape vs `num_warps=4`). Backward, PE, and dropout entries follow the gfx950 defaults pending arch-specific validation.

## Benchmark — gfx1151, `bench_mha -impl default`

Qwen3-Omni ViT prefill shape: B=1, S=3200, H=16, head_dim=72, fp16, varlen, non-causal. Toolchain: torch 2.11.0+rocm7.14.0a20260529, triton 3.7.0 (built from `triton-lang/triton` main, `d92727c2`).

| state                                                    | `bench_mha` time |
|----------------------------------------------------------|-----------------:|
| `origin/main` (no gfx1151 config file)                   | **SKIP** — `FileNotFoundError: gfx1151-MHA-DEFAULT.json` |
| + config commit only (num_warps=8, no kernel hint)       | **4.40 ms**      |
| + hint commit only (no config — still skips)             | n/a              |
| this PR (both commits)                                   | **2.40 ms**      |

For context, the parallel PR for the `dao_ai` impl on the same shape lands at **2.41 ms** — the two impls now overlap within measurement noise.

### Reproducer (in-tree)

```bash
python op_tests/op_benchmarks/triton/bench_mha.py \
    -fn fwd_varlen -equal_seqlens \
    -b 1 -hq 16 -hk 16 -sq 3200 -sk 3200 -d 72 \
    --dtype fp16 -causal False \
    -impl default -metric time
```

## Correctness

- `op_tests/triton_tests/attention/test_mha.py::test_mha` — **171 PASSED, 9 OOM**. All 9 failures are `torch.OutOfMemoryError` on `B=30` / `B=50` × `S=2048` cases. The OOM happens at the `torch.randn` allocation, before the kernel runs. Not a correctness regression from this PR.
- The kernel hint defaults to `False` and is opt-in via the wrapper's runtime stride check; existing external callers of `_attn_fwd` are unaffected.

## Test plan

- [x] `bench_mha -impl default` on the Qwen3-Omni ViT prefill shape on gfx1151
- [x] Verify ablation: config-only vs config+hint
- [x] `op_tests/triton_tests/attention/test_mha.py::test_mha` (171 PASSED, 9 OOM on out-of-VRAM batch sizes — see above)
