### PR TITLE
[triton-mha] add gfx1151 tuning config

### DIFF
--- a/aiter/ops/triton/configs/gfx1151-MHA-DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx1151-MHA-DEFAULT.json
@@ -1,0 +1,92 @@
+{
+  "fwd": {
+    "dropout_or_fp32": {
+      "BLOCK_M": 32,
+      "BLOCK_N": 32,
+      "PRELOAD_V": false,
+      "waves_per_eu": 1,
+      "num_warps": 2,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "default": {
+      "BLOCK_M": 128,
+      "BLOCK_N": 64,
+      "PRELOAD_V": false,
+      "waves_per_eu": 2,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "pe": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "pe_dropout_or_fp32": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    }
+  },
+  "bkwd_fused" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "dkdvdq_kernel_N64" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }, 
+    "dkdvdq_kernel_N128" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }
+  },
+  "bkwd_onekernel" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "onekernel" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 128,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 1
+    },
+    "onekernel_pe" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 64,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 2
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `aiter/ops/triton/configs/gfx1151-MHA-DEFAULT.json` so that AITER's `default` MHA forward impl (`aiter.ops.triton.attention.mha._attn_fwd`) is usable on gfx1151 (Strix Halo / RDNA3.5).

Without a matching `<gfx>-MHA-DEFAULT.json` the wrapper raises `FileNotFoundError` at call time, which made `mha_set_impl("default")` unusable on Strix Halo. The other shipped tunings cover gfx942 (CDNA3), gfx950 (CDNA4), and gfx1250 (RDNA4) — gfx1151 was the only consumer-RDNA gap.

Block sizes mirror the gfx950 tuning (`BLOCK_M=128`, `BLOCK_N=64`, `waves_per_eu=2`, `num_stages=1`). The `default` forward profile picks **`num_warps=8`** (vs. gfx950's `4`) to match the `flash_attn_triton_amd` (`dao_ai`) prefill kernel's choice for the same arch — empirically it roughly halves loop-dispatch overhead on the Qwen3-Omni ViT prefill shape (B=1, S=3200, H=16, head_dim=72). Backward, PE, and dropout entries follow the gfx950 defaults pending arch-specific validation.

## Benchmark — gfx1151, `bench_mha -impl default`

Qwen3-Omni ViT prefill shape: B=1, S=3200, H=16, head_dim=72, fp16, varlen, non-causal. Toolchain: torch 2.11.0+rocm7.14.0a20260529, triton 3.7.0 (built from `triton-lang/triton` main, `d92727c2`).

| state                                                          | `bench_mha` time |
|----------------------------------------------------------------|-----------------:|
| `origin/main` (no gfx1151 config)                              | **SKIP** — `FileNotFoundError: gfx1151-MHA-DEFAULT.json` |
| this PR                       | **4.26 ms**      |
| this PR +#3424         | 2.38 ms          |
| for reference: ck MHA on gfx11 | 2.40 ms |

This PR by itself moves the `default` impl from "unusable" to "runs but ~2× slower than necessary on `head_dim=72`". To close the remaining gap and reach parity with the `dao_ai` impl (~2.41 ms on the same shape), pair it with the head-stride `tl.multiple_of(..., 8)` hint shipped as a separate, independent PR.

### Reproducer (in-tree)

```bash
python op_tests/op_benchmarks/triton/bench_mha.py \
    -fn fwd_varlen -equal_seqlens \
    -b 1 -hq 16 -hk 16 -sq 3200 -sk 3200 -d 72 \
    --dtype fp16 -causal False \
    -impl default -metric time
```

## Correctness

This PR adds a JSON configuration file only; no kernel code changes. `op_tests/triton_tests/attention/test_mha.py::test_mha` now collects and runs (previously: hard `FileNotFoundError` at collection / first call). 171 PASSED, 9 pre-existing `torch.OutOfMemoryError` failures (`attention_ref(upcast=True)` materialising `[B, H, S, S]` fp32 scores at B∈{30,50}, H=48, S=2048 — exceeds 64 GiB Strix Halo VRAM; identical behavior on `origin/main` with any impl).

## Test plan

- [x] `bench_mha -impl default` on gfx1151
- [x] `op_tests/triton_tests/attention/test_mha.py::test_mha` (171 PASSED, 9 pre-existing OOMs)
