### PR TITLE
[triton-mha] hint head-stride div-by-8 for vectorized global load

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/mha.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha.py
@@ -362,6 +362,7 @@ def _attn_fwd(
     USE_INT64_STRIDES: tl.constexpr,
     ENABLE_SINK: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
+    HEAD_STRIDE_ALIGNED_8: tl.constexpr = False,
 ):
     NUM_BLOCKS = (SEQLEN_Q + BLOCK_M - 1) // BLOCK_M
     # calculate offsets
@@ -564,9 +565,22 @@ def _attn_fwd(
         off_k_head = off_q_head
 
     # q,k,v offsets
+    # When the caller guarantees that the head-axis strides of Q/K/V are
+    # multiples of 8 elements (set via HEAD_STRIDE_ALIGNED_8), the head-axis
+    # byte offset is 16-byte aligned. Auto-specialization only fires at the
+    # 16-element threshold, so hint the smaller multiple explicitly to let
+    # AxisInfo widen the global load.
+    qh_off = off_q_head * stride_qh
+    kh_off = off_k_head * stride_kh
+    vh_off = off_k_head * stride_vh
+    if HEAD_STRIDE_ALIGNED_8:
+        qh_off = tl.multiple_of(qh_off, 8)
+        kh_off = tl.multiple_of(kh_off, 8)
+        vh_off = tl.multiple_of(vh_off, 8)
+
     q_offs = (
         off_z * stride_qz
-        + off_q_head * stride_qh
+        + qh_off
         + cu_seqlens_q_start * stride_qm
         + offs_m[:, None] * stride_qm
         + offs_d[None, :] * stride_qk
@@ -575,7 +589,7 @@ def _attn_fwd(
     if HAS_PE:
         q_pe_offs = (
             off_z * stride_qz
-            + off_q_head * stride_qh
+            + qh_off
             + cu_seqlens_q_start * stride_qm
             + offs_m[:, None] * stride_qm
             + offs_pe[None, :] * stride_qk
@@ -586,7 +600,7 @@ def _attn_fwd(
 
     k_offs = (
         off_z * stride_kz
-        + off_k_head * stride_kh
+        + kh_off
         + cu_seqlens_k_start * stride_kn
         + offs_d[:, None] * stride_kk
         + offs_n[None, :] * stride_kn
@@ -595,7 +609,7 @@ def _attn_fwd(
     if HAS_PE:
         k_pe_offs = (
             off_z * stride_kz
-            + off_k_head * stride_kh
+            + kh_off
             + cu_seqlens_k_start * stride_kn
             + offs_pe[:, None] * stride_kk
             + offs_n[None, :] * stride_kn
@@ -606,7 +620,7 @@ def _attn_fwd(
 
     v_offs = (
         off_z * stride_vz
-        + off_k_head * stride_vh
+        + vh_off
         + cu_seqlens_k_start * stride_vn
         + offs_n[:, None] * stride_vn
         + offs_d[None, :] * stride_vk

--- a/aiter/ops/triton/attention/mha.py
+++ b/aiter/ops/triton/attention/mha.py
@@ -305,6 +305,15 @@ def _flash_attn_forward(
             USE_INT64_STRIDES=_USE_INT64_STRIDES,
             ENABLE_SINK=sink is not None,
             SLIDING_WINDOW=sliding_window,
+            # Soundness precondition: only set when every Q/K/V head-axis
+            # stride is a multiple of 8 elements. q_strides[1]/k_strides[1]/
+            # v_strides[1] are the head-axis strides in both thd and bshd
+            # layouts (see q_strides assembly above).
+            HEAD_STRIDE_ALIGNED_8=(
+                q_strides[1] % 8 == 0
+                and k_strides[1] % 8 == 0
+                and v_strides[1] % 8 == 0
+            ),
             **config,
         )
 


### PR DESCRIPTION
For the packed `[seq, heads, dim]` layout used by varlen prefill, the head-axis stride equals `head_dim`. When `head_dim` is a multiple of 8 but not 16 (e.g. 72), Triton's integer-arg auto-specialization does not attach `tt.divisibility = 8` to `stride_*h` (its threshold is 16), so AxisInfo treats the K/V global load as 2-byte aligned and Coalesce emits scalar `buffer_load_u16` instead of vectorized `buffer_load_b128`.

Add a `HEAD_STRIDE_ALIGNED_8` constexpr to `_attn_fwd` and apply `tl.multiple_of(off_h_{q,k} * stride_{q,k,v}h, 8)` to the head-axis integer offset when the caller sets it. AddPtr propagates this through to the load pointer, so AxisInfo computes a 16-byte alignment and the load coalesces.

The wrapper checks `stride_*h % 8 == 0` against the actual runtime strides (not against `head_dim`), so the hint stays sound for non-contiguous Q/K/V views where `stride_*h != head_dim`. The constexpr defaults to `False`, so external callers of `_attn_fwd` are unaffected unless they opt in.

Mirrors the equivalent hint added to the `flash_attn_triton_amd` (`dao_ai`) prefill kernel; together with the gfx1151 tuning config  #3423 this closes the gap with the ck MHA on Strix Halo.

## Benchmark — gfx1151, `bench_mha -impl default`

Qwen3-Omni ViT prefill shape: B=1, S=3200, H=16, head_dim=72, fp16, varlen, non-causal. Toolchain: torch 2.11.0+rocm7.14.0a20260529, triton 3.7.0 (built from `triton-lang/triton` main, `d92727c2`).

| state                                                          | `bench_mha` time |
|----------------------------------------------------------------|-----------------:|
| #3423                      | **4.26 ms**      |
|  #3423 + this PR | 2.38 ms          |
| for reference: ck MHA on gfx11 | 2.40 ms |

### Reproducer

```bash
python op_tests/op_benchmarks/triton/bench_mha.py \
    -fn fwd_varlen -equal_seqlens \
    -b 1 -hq 16 -hk 16 -sq 3200 -sk 3200 -d 72 \
    --dtype fp16 -causal False \
    -impl default -metric time
```