### PR TITLE
Fuse dynamic_per_tensor_quant_fp8_i8 into one launch for the decode regime

### DIFF
--- a/aiter/ops/triton/_triton_kernels/quant/quant.py
+++ b/aiter/ops/triton/_triton_kernels/quant/quant.py
@@ -52,6 +52,47 @@ def _dynamic_per_tensor_quant_fp8_i8_kernel(
 
 
 @triton.jit
+def _fused_dynamic_per_tensor_quant_fp8_i8_kernel(
+    qx_ptr,
+    x_in_ptr,
+    scale_out_ptr,
+    N: int,
+    DTYPE_MAX: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    # Single-workgroup fused amax + quantize for the small/decode regime.
+    # One program walks the whole (flattened, contiguous) tensor in a grid-stride
+    # loop, so the global scale is known without a cross-block reduction -> a
+    # single kernel launch instead of the atomic-max amax pass + separate quant
+    # pass. Byte-identical to _dynamic_per_tensor_quant_fp8_i8_kernel +
+    # _static_per_tensor_quant_fp8_i8_kernel: same scale (max commutes with
+    # / DTYPE_MAX), same 1 / scale, no clamp (dynamic scaling guarantees
+    # |x| / scale <= DTYPE_MAX).
+    offs = tl.arange(0, BLOCK)
+
+    amax = tl.zeros([BLOCK], dtype=tl.float32)
+    i = 0
+    while i < N:
+        idx = i + offs
+        mask = idx < N
+        x = tl.load(x_in_ptr + idx, mask=mask, other=0.0, cache_modifier=".cg")
+        amax = tl.maximum(amax, tl.abs(x.to(tl.float32)))
+        i += BLOCK
+    scale = tl.max(amax, axis=0) / DTYPE_MAX
+    tl.store(scale_out_ptr, scale)
+    scale_recip = 1 / scale
+
+    i = 0
+    while i < N:
+        idx = i + offs
+        mask = idx < N
+        x = tl.load(x_in_ptr + idx, mask=mask, other=0.0, cache_modifier=".cg")
+        qx = (x.to(tl.float32) * scale_recip).to(qx_ptr.dtype.element_ty)
+        tl.store(qx_ptr + idx, qx, mask=mask, cache_modifier=".cs")
+        i += BLOCK
+
+
+@triton.jit
 def _dynamic_per_token_quant_fp8_i8_kernel(
     qx_ptr,
     scale_out_ptr,

--- a/aiter/ops/triton/quant/quant.py
+++ b/aiter/ops/triton/quant/quant.py
@@ -8,6 +8,7 @@ import torch
 from aiter.ops.triton._triton_kernels.quant.quant import (
     _static_per_tensor_quant_fp8_i8_kernel,
     _dynamic_per_tensor_quant_fp8_i8_kernel,
+    _fused_dynamic_per_tensor_quant_fp8_i8_kernel,
     _dynamic_per_token_quant_fp8_i8_kernel,
     _dynamic_mxfp4_quant_kernel,
     _mxfp4_quant_op,
@@ -38,6 +39,12 @@ _MXFP8_LEGACY_BLOCK_SIZE = 128
 
 
 _LOGGER = AiterTritonLogger()
+
+# Below this element count the dynamic-per-tensor quant is launch / cuda-graph-node
+# bound (decode), so a single fused workgroup beats the 2-launch atomic-amax + quant
+# path. Above it the 2-launch path is used. Both produce byte-identical output.
+FUSED_PER_TENSOR_MAX_ELEMS = 40960
+_FUSED_PER_TENSOR_BLOCK = 16384
 
 
 def static_per_tensor_quant_fp8_i8(
@@ -83,6 +90,27 @@ def dynamic_per_tensor_quant_fp8_i8(
     - scale_out: Single scale value of shape (1,)
     """
     _LOGGER.info(f"DYNAMIC_PER_TENSOR_QUANT_FP8_I8: x={tuple(x_in.shape)}")
+
+    DTYPE_MAX = (
+        torch.finfo(qx.dtype).max
+        if torch.is_floating_point(qx)
+        else torch.iinfo(qx.dtype).max
+    )
+
+    # Decode regime: fuse amax + quantize into one launch (no atomic-max pass,
+    # no separate quant launch). Needs a contiguous input to address it flat.
+    N = x_in.numel()
+    if N <= FUSED_PER_TENSOR_MAX_ELEMS and x_in.is_contiguous():
+        _fused_dynamic_per_tensor_quant_fp8_i8_kernel[(1,)](
+            qx,
+            x_in,
+            scale_out,
+            N,
+            DTYPE_MAX=DTYPE_MAX,
+            BLOCK=min(triton.next_power_of_2(N), _FUSED_PER_TENSOR_BLOCK),
+        )
+        return qx, scale_out
+
     rows = x_in.shape[0]
     cols = x_in.shape[1]
     NUM_COL_POW2 = triton.next_power_of_2(cols)
@@ -93,11 +121,7 @@ def dynamic_per_tensor_quant_fp8_i8(
         cols,
         x_in.stride(0),
         NUM_COL_POW2=NUM_COL_POW2,
-        DTYPE_MAX=(
-            torch.finfo(qx.dtype).max
-            if torch.is_floating_point(qx)
-            else torch.iinfo(qx.dtype).max
-        ),
+        DTYPE_MAX=DTYPE_MAX,
     )
 
     _static_per_tensor_quant_fp8_i8_kernel[grid](


### PR DESCRIPTION
## Summary

`dynamic_per_tensor_quant_fp8_i8` launches **two** kernels: an atomic-max amax
pass (`_dynamic_per_tensor_quant_fp8_i8_kernel`) followed by a quantize pass
(`_static_per_tensor_quant_fp8_i8_kernel`). At decode-size tensors this is
**launch / CUDA-graph-node bound**, not bandwidth bound.

This PR adds `_fused_dynamic_per_tensor_quant_fp8_i8_kernel`: a single workgroup
computes the global amax and quantizes in **one launch** via a grid-stride loop
(no cross-block reduction is needed once one program walks the whole tensor).
`dynamic_per_tensor_quant_fp8_i8` routes to it for contiguous tensors with
`numel() <= 40960` (the decode regime); larger tensors keep the existing
two-launch path unchanged.

## Correctness

The fused kernel is **byte-identical** to the existing two-launch path:

- **scale:** `tl.max(|x|) / DTYPE_MAX`. `max` commutes with `/ DTYPE_MAX`, so a
  single global max divided once equals the existing per-row `max(row_amax/MAX)`
  via `atomic_max` — same fp32 bits.
- **quant:** `(x * (1 / scale)).to(out.dtype)` — identical to
  `_static_per_tensor_quant_fp8_i8_kernel`.
- **no clamp:** dynamic scaling guarantees `|x| / scale <= DTYPE_MAX`, matching
  the existing path (which also does not clamp).

Works for both fp8 and int8 (`DTYPE_MAX` derived from the output dtype).

## Motivation

Per-tensor dynamic fp8 activation quant fires once per linear input on the
decode hot path; collapsing 2 launches → 1 removes a CUDA-graph node per call.
Downstream (vLLM, Mistral-Small-3.1-24B FP8 on MI355X) an equivalent fusion
measured ~8% geomean interactivity uplift across concurrency, gsm8k unchanged.

## Testing

- [x] Imports / parse cleanly; dispatch threshold + block sizing reviewed.
- [x] Byte-identicality argued by construction (above) vs the two-launch path.
- [ ] **Recommended before merge:** GPU byte-equality test of the fused vs the
      two-launch path across decode shapes (M∈{1,8}, K∈{5120,4096,32768}; fp8 and
      int8), plus a microbench confirming the launch-count reduction.

## Follow-up

A separate change routes `per_tensor_quant_hip`'s dynamic-fp8 path to this fused
kernel so HIP-path consumers pick up the decode win without a caller change; kept
out of this PR to keep it byte-identical and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
