### PR TITLE
Add Kimi-K2 Thinking entry to per-model kernel benchmark sweep

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_tests/test_kernel_benchmarks.py
+++ b/op_tests/op_benchmarks/triton/bench_tests/test_kernel_benchmarks.py
@@ -1,8 +1,19 @@
 import importlib
+import json
 import os
+import re
 import warnings
 import argparse
 from op_tests.op_benchmarks.triton.utils.argparse import get_parser, add_argparse_ff
+
+MODEL_SHAPES_JSON = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "model_benchmarking_tool",
+        "model_shapes.json",
+    )
+)
 
 """
 Loads the appropriate kernel using importlib and runs the benchmark script.
@@ -78,3 +89,107 @@ def test_bench_gemm_a8w8_tp():
 
     os.remove(output_file)
     os.remove("GEMM A8W8 Benchmark.png")
+
+
+def test_kimi_k2_model_shapes_entry():
+    """Structural regression guard for the Kimi K2.6 (Kimi-K2 Thinking) entry
+    in model_shapes.json. Runs without a GPU.
+
+    Kimi K2 is a 1T-param DeepSeek-V3-style MoE with 384 experts, top_k=8,
+    64 attention heads, and MLA (q_lora=1536, kv_lora=512, qk_nope=128,
+    qk_rope=64, v_head=128). Source: huggingface.co/moonshotai/Kimi-K2-Thinking
+    config.json. Removing or misshaping this entry will silently drop Kimi K2.6
+    from the per-model kernel sweep and let regressions slip through.
+    """
+    from op_tests.op_benchmarks.triton.model_benchmarking_tool.bench_models import (
+        KERNEL_DICT,
+    )
+
+    with open(MODEL_SHAPES_JSON, "r") as f:
+        data = json.load(f)
+
+    assert "Kimi-K2 Thinking" in data, "Kimi-K2 Thinking entry missing"
+    kimi = data["Kimi-K2 Thinking"]
+
+    # Every declared kernel must be dispatchable by bench_models.py.
+    unknown = [k for k in kimi if k not in KERNEL_DICT]
+    assert not unknown, f"Kimi-K2 declares kernels not in KERNEL_DICT: {unknown}"
+
+    # MLA decode hot path (hq=64 distinguishes Kimi K2 from DeepSeek-R1's 128).
+    assert "mla" in kimi
+    mla = kimi["mla"][0]
+    assert (mla["hq"], mla["hkv"], mla["dqk"], mla["dv"]) == (64, 1, 576, 512)
+
+    # MHA prefill hot path.
+    assert "mha" in kimi
+    mha = kimi["mha"][0]
+    assert (mha["hq"], mha["hkv"], mha["dqk"], mha["dv"]) == (64, 64, 192, 128)
+
+    # Routed MoE GEMM must reflect Kimi K2's E=384, TopK=8, hidden=7168,
+    # 2*moe_intermediate_size=4096.
+    moe_kernels = [k for k in kimi if k.startswith("moe_op_gemm_")]
+    assert moe_kernels, "Kimi-K2 must exercise at least one MoE GEMM kernel"
+    for k in moe_kernels:
+        shape = kimi[k][0]
+        assert shape["E"] == 384, (k, shape)
+        assert shape["TopK"] == 8, (k, shape)
+        assert shape["Dim1"] == 7168, (k, shape)
+        assert shape["Dim2"] == 4096, (k, shape)
+
+    # MLA projection GEMMs (q_b, kv_b, o_proj) — these differ from DSR1
+    # because Kimi K2 halves the head count.
+    dense_gemm_kernels = [
+        k for k in kimi if k.startswith("gemm_") and "moe" not in k
+    ]
+    assert dense_gemm_kernels, "Kimi-K2 must exercise at least one dense GEMM"
+    for k in dense_gemm_kernels:
+        nk = {(s["N"], s["K"]) for s in kimi[k]}
+        if k in ("gemm_a8w8_blockscale", "gemm_afp4wfp4"):
+            assert (12288, 1536) in nk, f"{k} missing q_b_proj shape"
+            assert (16384, 512) in nk, f"{k} missing kv_b_proj shape"
+            assert (7168, 8192) in nk, f"{k} missing o_proj shape"
+
+    # --model 'kimi' regex (case-insensitive, from bench_models.parse_args)
+    # must match exactly this entry.
+    pat = re.compile("kimi", re.IGNORECASE)
+    assert [m for m in data if pat.search(m)] == ["Kimi-K2 Thinking"]
+
+
+def test_bench_models_kimi_k2_rmsnorm_runs():
+    """End-to-end smoke: bench_models.run_benchmarks() must execute at least
+    one Kimi-K2 kernel and produce a numeric result. Pinned to rmsnorm because
+    it has no FP4/MX arch gating and is GPU-cheap, while still validating the
+    full path: JSON load -> model filter -> handler dispatch -> kernel run.
+    """
+    warnings.filterwarnings("ignore", category=UserWarning)
+    from op_tests.op_benchmarks.triton.model_benchmarking_tool.bench_models import (
+        filter_models_and_kernels,
+        read_json,
+        run_benchmarks,
+    )
+
+    data = read_json("model_shapes.json")
+    data = filter_models_and_kernels(
+        data,
+        available_models=sorted(data.keys()),
+        model_pattern="kimi",
+        kernel_pattern="rmsnorm",
+    )
+    assert data is not None and "Kimi-K2 Thinking" in data
+
+    results = run_benchmarks(
+        data,
+        batch_sizes=[1],
+        seq_lens=[1024],
+        TP=1,
+        gemm_layout="TN",
+        mha_layout="thd",
+        metric="throughput",
+    )
+    assert results, "No results produced for Kimi-K2 rmsnorm benchmark"
+    for row in results:
+        assert row["Model"] == "Kimi-K2 Thinking"
+        assert row["Kernel"] == "rmsnorm"
+        value = row.get("throughput")
+        assert value not in (None, "N/A"), f"Benchmark failed for row: {row}"
+        assert float(value) > 0, f"Non-positive throughput for row: {row}"

--- a/op_tests/op_benchmarks/triton/bench_tests/test_kernel_benchmarks.py
+++ b/op_tests/op_benchmarks/triton/bench_tests/test_kernel_benchmarks.py
@@ -138,9 +138,7 @@ def test_kimi_k2_model_shapes_entry():
 
     # MLA projection GEMMs (q_b, kv_b, o_proj) — these differ from DSR1
     # because Kimi K2 halves the head count.
-    dense_gemm_kernels = [
-        k for k in kimi if k.startswith("gemm_") and "moe" not in k
-    ]
+    dense_gemm_kernels = [k for k in kimi if k.startswith("gemm_") and "moe" not in k]
     assert dense_gemm_kernels, "Kimi-K2 must exercise at least one dense GEMM"
     for k in dense_gemm_kernels:
         nk = {(s["N"], s["K"]) for s in kimi[k]}

--- a/op_tests/op_benchmarks/triton/model_benchmarking_tool/model_shapes.json
+++ b/op_tests/op_benchmarks/triton/model_benchmarking_tool/model_shapes.json
@@ -639,5 +639,211 @@
                 "dv": 128
             }
         ]
+    },
+    "Kimi-K2 Thinking": {
+        "gemm_a8w8_blockscale": [
+            {
+                "N": 36864,
+                "K": 7168,
+                "TP_dim": "N"
+            },
+            {
+                "N": 7168,
+                "K": 18432,
+                "TP_dim": "K"
+            },
+            {
+                "N": 4096,
+                "K": 7168,
+                "TP_dim": "N"
+            },
+            {
+                "N": 7168,
+                "K": 2048,
+                "TP_dim": "K"
+            },
+            {
+                "N": 2112,
+                "K": 7168,
+                "TP_dim": null
+            },
+            {
+                "N": 12288,
+                "K": 1536,
+                "TP_dim": "N"
+            },
+            {
+                "N": 16384,
+                "K": 512,
+                "TP_dim": "N"
+            },
+            {
+                "N": 7168,
+                "K": 8192,
+                "TP_dim": "K"
+            }
+        ],
+        "gemm_afp4wfp4": [
+            {
+                "N": 36864,
+                "K": 7168,
+                "TP_dim": "N"
+            },
+            {
+                "N": 7168,
+                "K": 18432,
+                "TP_dim": "K"
+            },
+            {
+                "N": 4096,
+                "K": 7168,
+                "TP_dim": "N"
+            },
+            {
+                "N": 7168,
+                "K": 2048,
+                "TP_dim": "K"
+            },
+            {
+                "N": 2112,
+                "K": 7168,
+                "TP_dim": null
+            },
+            {
+                "N": 12288,
+                "K": 1536,
+                "TP_dim": "N"
+            },
+            {
+                "N": 16384,
+                "K": 512,
+                "TP_dim": "N"
+            },
+            {
+                "N": 7168,
+                "K": 8192,
+                "TP_dim": "K"
+            }
+        ],
+        "gemm_a16w16": [
+            {
+                "N": 256,
+                "K": 7168,
+                "TP_dim": null
+            }
+        ],
+        "batched_gemm_a16wfp4": [
+            {
+                "B": 64,
+                "N": 512,
+                "K": 128,
+                "TP_dim": "B"
+            },
+            {
+                "B": 64,
+                "N": 128,
+                "K": 512,
+                "TP_dim": "B"
+            }
+        ],
+        "batched_gemm_a8w8": [
+            {
+                "B": 64,
+                "N": 512,
+                "K": 128,
+                "TP_dim": "B"
+            },
+            {
+                "B": 64,
+                "N": 128,
+                "K": 512,
+                "TP_dim": "B"
+            }
+        ],
+        "batched_gemm_afp4wfp4": [
+            {
+                "B": 64,
+                "N": 512,
+                "K": 128,
+                "TP_dim": "B"
+            },
+            {
+                "B": 64,
+                "N": 128,
+                "K": 512,
+                "TP_dim": "B"
+            }
+        ],
+        "moe_op_gemm_a8w8_blockscale": [
+            {
+                "E": 384,
+                "Dim1": 7168,
+                "Dim2": 4096,
+                "TopK": 8
+            }
+        ],
+        "moe_op_gemm_a8w4": [
+            {
+                "E": 384,
+                "Dim1": 7168,
+                "Dim2": 4096,
+                "TopK": 8
+            }
+        ],
+        "moe_op_gemm_a4w4": [
+            {
+                "E": 384,
+                "Dim1": 7168,
+                "Dim2": 4096,
+                "TopK": 8
+            }
+        ],
+	    "rmsnorm": [
+            {
+                "N": 7168
+            },
+            {
+                "N": 1536
+            },
+            {
+                "N": 512
+            }
+        ],
+	    "rope": [
+            {
+                "num_heads": 64,
+                "num_kv_heads": 64,
+                "head_dim": 64,
+                "two_inputs": "true",
+                "positions": "true",
+                "rotate_style": "gptj"
+            },
+            {
+                "num_heads": 64,
+                "num_kv_heads": 1,
+                "head_dim": 64,
+                "two_inputs": "true",
+                "positions": "true",
+                "rotate_style": "gptj"
+            }
+        ],
+        "mha": [
+            {
+                "comment": "Prefill",
+                "hq": 64,
+                "hkv": 64,
+                "dqk": 192,
+                "dv": 128
+            }
+        ],
+        "mla": [
+            {
+                "comment": "Decode",
+                "hq": 64,
+                "hkv": 1,
+                "dqk": 576,
+                "dv": 512
+            }
+        ]
     }
 }


### PR DESCRIPTION
## Motivation

Add Kimi-K2 Thinking to model_shapes.json so the per-model kernel sweep in op_tests/op_benchmarks/triton/model_benchmarking_tool exercises every aiter Triton kernel Kimi K2 hits in production serving (MLA projections, dense FFN, shared-expert FFN, 384-expert MoE GEMM, RMSNorm, RoPE, MHA prefill, MLA decode). Without this entry the sweep silently drops Kimi K2 and per-kernel regressions on Kimi go unnoticed even though the model is part of the active perf workload.

## Technical Details

Shape numbers were derived directly from the moonshotai/Kimi-K2-Thinking config.json: hidden=7168, dense intermediate=18432, moe_intermediate=2048, 64 heads, 384 routed experts, top_k=8, MLA q_lora=1536, kv_lora=512, qk_nope=128, qk_rope=64, v_head=128. Coverage is 13 kernels x 33 shapes.

## Test Plan

Add two regression tests in test_kernel_benchmarks.py:

- test_kimi_k2_model_shapes_entry: no-GPU structural guard that fails immediately if the Kimi entry is removed or any hot-path shape changes silently. Asserts MLA (64,1,576,512), MHA (64,64,192,128), MoE (E=384, TopK=8, Dim1=7168, Dim2=4096) and the q_b/kv_b/o_proj GEMM shapes, plus that every declared kernel is in KERNEL_DICT and the --model kimi regex matches exactly one model.
- test_bench_models_kimi_k2_rmsnorm_runs: end-to-end smoke that drives bench_models.run_benchmarks() through Kimi rmsnorm and asserts every
  row has positive throughput, validating the full path: JSON load ->
  model regex -> handler dispatch -> Triton kernel run.

## Test Result

Verified passing on MI355X (ROCm 7.2, PyTorch 2.10, Triton 3.6):
  test_kimi_k2_model_shapes_entry        PASSED
  test_bench_models_kimi_k2_rmsnorm_runs PASSED
  2 passed, 3 deselected in 13.67s

Full Kimi sweep at B=1, S=1024, TP=1 runs in ~17s on MI355X; a typical B in [1, 32, 128] x S in [1024, 8192] grid is ~1m40s.

3 rows produced, all positive throughput (test passes):

{"Model": "Kimi-K2 Thinking", "Kernel": "rmsnorm", "batch_size": null, "seq_len": null, "M": 1024, "N": 7168, "throughput": 2.632281}
{"Model": "Kimi-K2 Thinking", "Kernel": "rmsnorm", "batch_size": null, "seq_len": null, "M": 1024, "N": 1536, "throughput": 0.845229}
{"Model": "Kimi-K2 Thinking", "Kernel": "rmsnorm", "batch_size": null, "seq_len": null, "M": 1024, "N":  512, "throughput": 0.312582}
