### PR TITLE
Align aiter prebuild jobs with build runner CPU limit

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -26,7 +26,7 @@ env:
   GPU_ARCH_LIST: "gfx942;gfx950"
   AITER_TEST: "op_tests"
   AITER_WHEEL_ARTIFACT_NAME: aiter-whl-${{ github.run_id }}
-  AITER_PREBUILD_MAX_JOBS: "96"
+  AITER_PREBUILD_MAX_JOBS: "64"
   TRITON_WHEEL_ARTIFACT_NAME: triton_wheelhouse
 
 jobs:


### PR DESCRIPTION
## Summary

- Set `AITER_PREBUILD_MAX_JOBS` to `64` so the aiter prebuild concurrency matches the build-only runner CPU limit.
- This avoids oversubscribing the 64 CPU build pod with 96 compiler jobs and should reduce CPU contention during kernel prebuilds.

## Test plan

- Not run. Workflow configuration-only change.