### PR TITLE
sglang downstream: run 8-GPU tests on the DO MI350X runner label

### DIFF
--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 TESTS = [
     {
-        "runner": "linux-aiter-mi35x-8",
+        "runner": "linux-aiter-do-mi350x-8",
         "label": "MI35X",
         "model": "DeepSeek-R1-MXFP4",
         "model_id": "amd/DeepSeek-R1-MXFP4-Preview",
@@ -24,7 +24,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-mi35x-8",
+        "runner": "linux-aiter-do-mi350x-8",
         "label": "MI35X",
         "model": "DeepSeek-R1-MXFP4",
         "model_id": "amd/DeepSeek-R1-MXFP4-Preview",
@@ -38,7 +38,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-mi35x-8",
+        "runner": "linux-aiter-do-mi350x-8",
         "label": "MI35X",
         "model": "Qwen3-235B-MXFP4",
         "model_id": "amd/Qwen3-235B-A22B-Instruct-2507-mxfp4",
@@ -52,7 +52,7 @@ TESTS = [
         "comment": "issue https://github.com/ROCm/aiter/issues/2857 not resolved yet",
     },
     {
-        "runner": "linux-aiter-mi35x-8",
+        "runner": "linux-aiter-do-mi350x-8",
         "label": "MI35X",
         "model": "Qwen 3.5",
         "model_id": "Qwen/Qwen3.5-397B-A17B",
@@ -65,7 +65,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-mi35x-8",
+        "runner": "linux-aiter-do-mi350x-8",
         "label": "MI35X",
         "model": "Qwen 3.5 FP8",
         "model_id": "Qwen/Qwen3.5-397B-A17B-FP8",
@@ -78,7 +78,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-mi35x-8",
+        "runner": "linux-aiter-do-mi350x-8",
         "label": "MI35X",
         "model": "DeepSeek-V3.2",
         "model_id": "deepseek-ai/DeepSeek-V3.2",
@@ -91,7 +91,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-mi35x-8",
+        "runner": "linux-aiter-do-mi350x-8",
         "label": "MI35X",
         "model": "DeepSeek-V3.2 Basic",
         "model_id": "deepseek-ai/DeepSeek-V3.2",


### PR DESCRIPTION
Repoint all 7 sglang 8-GPU test entries from linux-aiter-mi35x-8 to linux-aiter-do-mi350x-8 so the downstream suite lands on the DigitalOcean DOKS MI350X runners (8-GPU, bin-packed). Exercises the new labels with a real aiter workload (source install + sglang nightly) instead of the smoke test.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
