### PR TITLE
ci(release): install flydsl from AMD mirror + fix install_triton.sh dpkg/pipefail

### DIFF
--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -30,7 +30,7 @@ install_triton_from_wheelhouse() {
 }
 
 TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/"
-ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
+ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}' || true)
 if [[ -n "$ROCM_VERSION" ]]; then
     ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | cut -d. -f1,2)
     TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"

--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -349,14 +349,12 @@ jobs:
               set -e
               ${PYBIN}/pip install --upgrade --timeout=60 --retries=10 pip
               ${PYBIN}/pip install --timeout=60 --retries=10 --index-url "${TORCH_INDEX}" "${TORCH_SPEC}"
-              # flydsl publishes only manylinux_2_35 wheels which cannot install
-              # on AlmaLinux 8 (glibc 2.28). FlyDSL AOT pre-compilation in
-              # setup.py is wrapped in try/except and is skipped gracefully when
-              # flydsl is missing, so we drop it here. The resulting wheel still
-              # contains all CK-free + Triton kernels; only the optional
-              # FlyDSL AOT cache is omitted (kernels JIT on first use).
-              grep -v "^flydsl" requirements.txt > /tmp/requirements-no-flydsl.txt
-              ${PYBIN}/pip install --timeout=60 --retries=10 -r /tmp/requirements-no-flydsl.txt
+              # flydsl 0.1.9.dev599+ ships manylinux_2_28 wheels via AMD mirror
+              # (see ROCm/FlyDSL#527 backport). Required at build time since
+              # v0.1.15 setup.py imports aiter.aot.flydsl.gemm during start_aot().
+              ${PYBIN}/pip install --timeout=60 --retries=10 \
+                --extra-index-url https://rocm.frameworks-devreleases.amd.com/whl-staging/gfx942-gfx950/ \
+                -r requirements.txt
               ${PYBIN}/pip install --timeout=60 --retries=10 "setuptools_scm<10" ninja auditwheel patchelf
             '
 


### PR DESCRIPTION
Two bugs blocked v0.1.15 6-wheel CI builds in `pytorch/manylinux2_28-builder:rocmX.Y` containers. Both already verified on `release/v0.1.15` (all 6 wheels built successfully). Backporting to `main` so the next release cut from main doesn't hit them again.

## Bug 1 — `install_triton.sh` silent fail under `pipefail`

`.github/scripts/install_triton.sh:33`

```bash
ROCM_VERSION=\$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print \$3}')
```

With `set -o pipefail`, when `dpkg` returns 1 (container has no `rocm-core` installed — true for any manylinux builder), the pipeline exits 1. With `set -e`, the whole script aborts at this assignment. `setup.py:_run_install_triton()` is wrapped in `try/except` and swallows the exception, leaving the build container with **no triton installed** after the uninstall step ran. Build later fails with:

```
AttributeError: module 'triton' has no attribute 'language'
```

**Fix:** append `|| true` after the `awk` pipe.

## Bug 2 — workflow drops flydsl from requirements

`.github/workflows/aiter-release.yaml:355`

```yaml
grep -v "^flydsl" requirements.txt > /tmp/requirements-no-flydsl.txt
\${PYBIN}/pip install -r /tmp/requirements-no-flydsl.txt
```

The comment explains this was a workaround for v0.1.13/v0.1.14 — flydsl was only available as manylinux_2_35 wheels and the old setup.py wrapped `start_aot` in try/except so missing flydsl was OK.

v0.1.15 calls `start_aot()` unconditionally in setup.py, importing `aiter.aot.flydsl.gemm` at build time. Builds without flydsl now fail with:

```
ModuleNotFoundError: No module named 'flydsl'
```

**Fix:** install full `requirements.txt` from the AMD nightlies mirror (which hosts `flydsl 0.1.9.dev599+` manylinux_2_28 wheels — backport from ROCm/FlyDSL#527).

## Validation

Both fixes applied to `release/v0.1.15` (commit `8ddfc7510`). All 6 wheels built successfully:

- rocm7.0 cp310 (448MB) + cp312 (448MB)
- rocm7.1 cp310 (440MB) + cp312 (441MB)
- rocm7.2 cp310 (434MB) + cp312 (435MB)

5/5 GSM8K accuracy validated on Option B base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)