### PR TITLE
[OPUS]opus_gemm acc fix

### DIFF
--- a/csrc/opus_gemm/include/gfx950/opus_gemm_pipeline_a16w16_flatmm_splitk_gfx950.cuh
+++ b/csrc/opus_gemm/include/gfx950/opus_gemm_pipeline_a16w16_flatmm_splitk_gfx950.cuh
@@ -228,6 +228,13 @@ void gemm_a16w16_flatmm_splitk_kernel(opus_gemm_flatmm_splitk_kargs_gfx950 kargs
     int wave_id = __builtin_amdgcn_readfirstlane(opus::thread_id_x() / get_warp_size());
     int lane_id = opus::thread_id_x() % get_warp_size();
 
+    // Edge tile: partial-M or partial-N. OOB-zero buffer_loads on edge tiles
+    // make the counted `s_waitcnt_vmcnt(number<...>{})` producer drains
+    // unsafe — vmem completion is not FIFO and the count may not include
+    // slot 0 when the consumer crosses the barrier. Force full drain on
+    // edge tiles only; aligned tiles keep the counted fast path.
+    const bool tile_edge = (row + T::B_M > kargs.m) || (col + T::B_N > kargs.n);
+
     // K partitioning: chunk K into B_K-sized iters, distribute across splits.
     //   total_iters = ceil_div(K, B_K); iters_full = ceil_div(total_iters, split_k)
     //   First (split_k-1) splits each get `iters_full` full B_K iters (all in-range).
@@ -325,13 +332,15 @@ void gemm_a16w16_flatmm_splitk_kernel(opus_gemm_flatmm_splitk_kargs_gfx950 kargs
         // Prologue barriers R_0..R_{pfk-3}: leave 2*mb in flight for depth-2 pipeline entry.
         opus::static_for<T::prefetch_k_iter - 2>([&](auto i_c) {
             constexpr int p = T::prefetch_k_iter - 1 - decltype(i_c)::value;
-            s_waitcnt_vmcnt(number<mb * p>{});
+            if (tile_edge) s_waitcnt_vmcnt(0_I);
+            else           s_waitcnt_vmcnt(number<mb * p>{});
             __builtin_amdgcn_s_barrier();
         });
 
         if constexpr (T::prefetch_k_iter == 3) {
             // Depth-1 pipeline for pfk=3.
-            s_waitcnt_vmcnt(number<mb>{});
+            if (tile_edge) s_waitcnt_vmcnt(0_I);
+            else           s_waitcnt_vmcnt(number<mb>{});
             __builtin_amdgcn_s_barrier();   // R_1
             for (int i = T::prefetch_k_iter - 1; i < loops - 1; i++) {
                 int issue_k = i + 1;
@@ -347,7 +356,8 @@ void gemm_a16w16_flatmm_splitk_kernel(opus_gemm_flatmm_splitk_kargs_gfx950 kargs
                         async_load<T::VEC_B>(g_b, smem_b_at(slot, n, kg), u_gb, u_sb, b_offset(issue_k, n, kg));
                     });
                 });
-                s_waitcnt_vmcnt(number<mb>{});
+                if (tile_edge) s_waitcnt_vmcnt(0_I);
+                else           s_waitcnt_vmcnt(number<mb>{});
                 __builtin_amdgcn_s_barrier();
             }
             s_waitcnt_vmcnt(0_I);
@@ -369,12 +379,14 @@ void gemm_a16w16_flatmm_splitk_kernel(opus_gemm_flatmm_splitk_kargs_gfx950 kargs
                         async_load<T::VEC_B>(g_b, smem_b_at(slot, n, kg), u_gb, u_sb, b_offset(issue_k, n, kg));
                     });
                 });
-                s_waitcnt_vmcnt(number<2 * mb>{});
+                if (tile_edge) s_waitcnt_vmcnt(0_I);
+                else           s_waitcnt_vmcnt(number<2 * mb>{});
                 __builtin_amdgcn_s_barrier();
             }
 
             // Epilogue: drain the last two in-flight K's.
-            s_waitcnt_vmcnt(number<mb>{});
+            if (tile_edge) s_waitcnt_vmcnt(0_I);
+            else           s_waitcnt_vmcnt(number<mb>{});
             __builtin_amdgcn_s_barrier();
             s_waitcnt_vmcnt(0_I);
             __builtin_amdgcn_s_barrier();

--- a/csrc/opus_gemm/include/gfx950/opus_gemm_pipeline_a16w16_gfx950.cuh
+++ b/csrc/opus_gemm/include/gfx950/opus_gemm_pipeline_a16w16_gfx950.cuh
@@ -212,17 +212,39 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gemm_a16w16_kernel(opus
         constexpr int C = T::SWIZZLE_C;
         int xy = wgid;
         int blocks_per_cycle = nXCD * C;
+        int tid_per_group = W * num_tiles_n;
         int limit = (total_wgs / blocks_per_cycle) * blocks_per_cycle;
         if (xy >= limit) {
-            tile_m_id = xy / num_tiles_n;
-            tile_n_id = xy % num_tiles_n;
+            // Swizzle covers new_xy ∈ [0, limit) contiguously. Within that,
+            // (limit / tid_per_group) groups are full; the remainder lands in
+            // a partial last group covering (covered_cols) complete tn
+            // columns. The original fallback `xy/num_tiles_n` jumps row-major
+            // from xy without accounting for those holes, dropping the
+            // (partial_first_row..end, covered_cols..num_tiles_n) rectangle.
+            int full_groups = limit / tid_per_group;
+            int covered_cols = (limit - full_groups * tid_per_group) / W;
+            int partial_first_row = full_groups * W;
+            int partial_row_extent = num_tiles_m - partial_first_row;
+            if (partial_row_extent > W) partial_row_extent = W;
+            int f = xy - limit;
+            int remaining_in_partial =
+                (partial_row_extent > 0)
+                    ? (num_tiles_n - covered_cols) * partial_row_extent
+                    : 0;
+            if (f < remaining_in_partial) {
+                tile_m_id = partial_first_row + (f % partial_row_extent);
+                tile_n_id = covered_cols + (f / partial_row_extent);
+            } else {
+                int g = f - remaining_in_partial;
+                tile_m_id = (partial_first_row + partial_row_extent) + g / num_tiles_n;
+                tile_n_id = g % num_tiles_n;
+            }
         } else {
             int xcd = xy % nXCD;
             int local = xy / nXCD;
             int chunk_idx = local / C;
             int pos = local % C;
             int new_xy = xcd * C + chunk_idx * blocks_per_cycle + pos;
-            int tid_per_group = W * num_tiles_n;
             int group_id = new_xy / tid_per_group;
             int first_row = group_id * W;
             int win_h = num_tiles_m - first_row;


### PR DESCRIPTION
splitk flatmm pipeline (kids 200-222, 1200-1222): the producer's counted `s_waitcnt_vmcnt(number<...>{})` before `s_barrier` is unsafe on edge tiles — vmcnt doesn't reliably track LDS-write commit for buffer_load_to_lds, so the consumer can cross the barrier and ds_read stale smem. Gate full-drain `s_waitcnt_vmcnt(0_I)` on edge tiles only; aligned tiles keep the counted fast path so pipeline depth is preserved. Five producer drain sites covered (prologue, pfk==3 R_1, pfk==3 main, pfk>=4 main, pfk>=4 epilogue).

SB pipeline (kid 2009 family): the HipKittens Algorithm 1 XCD swizzle's fallback `xy/num_tiles_n` assumed limit was a multiple of num_tiles_n, which it isn't when total_wgs % blocks_per_cycle leaves a partial swizzle group. For M=9382 N=2112 this dropped 16 of 333 tiles (the (tm=24..27, tn=5..8) rectangle was never launched, leaving fp32 zeros in the output). Rewrite fallback to (1) finish the partial group's missing columns, then (2) row-major over fully uncovered rows beyond.

Verification: 20 opus kids x 161 partial-M CI shapes x 20 cudagraph replays + 400 random-M stress = 3620 replays, 0 BAD, worst max_abs = 2 (bf16 noise floor). Pre-fix: 21/1040 BAD on splitk kid 1200 family, 40/40 BAD on kid 2009 large-M. Kid 2009 perf cost +2-3% (intrinsic — the missed workgroups now run).
