### PR TITLE
Validate paged_attention input

### DIFF
--- a/csrc/cpp_itfs/pa/pa.py
+++ b/csrc/cpp_itfs/pa/pa.py
@@ -65,8 +65,10 @@ def validate_paged_attention_rocm_buffers(
 ):
     op_name = "paged_attention_rocm"
     max_num_partitions = math.ceil(max_context_len / partition_size)
-    max_context_len_val = int(context_lens.max().item())
-    min_blocks_per_seq = math.ceil(max_context_len_val / block_size)
+    # Use the launch-time upper bound rather than reading context_lens data.
+    # context_lens may live on GPU, and scalar extraction would force a sync
+    # and introduce tensor-data-dependent Python in torch.compile paths.
+    min_blocks_per_seq = math.ceil(max_context_len / block_size)
 
     def _check_partition_dim(name, tensor):
         if tensor.dim() < 3:
@@ -93,7 +95,7 @@ def validate_paged_attention_rocm_buffers(
     if block_tables.size(1) < min_blocks_per_seq:
         raise ValueError(
             f"{op_name}: block_tables.size(1)={block_tables.size(1)} is too small "
-            f"for max context_len={max_context_len_val} and block_size={block_size}; "
+            f"for max_context_len={max_context_len} and block_size={block_size}; "
             f"need at least {min_blocks_per_seq} block-table entries per sequence"
         )
     if context_lens.size(0) != block_tables.size(0):

--- a/csrc/cpp_itfs/pa/pa.py
+++ b/csrc/cpp_itfs/pa/pa.py
@@ -53,6 +53,56 @@ def compile(
     )
 
 
+def validate_paged_attention_rocm_buffers(
+    tmp_out,
+    exp_sums,
+    max_logits,
+    block_tables,
+    context_lens,
+    block_size,
+    max_context_len,
+    partition_size,
+):
+    op_name = "paged_attention_rocm"
+    max_num_partitions = math.ceil(max_context_len / partition_size)
+    max_context_len_val = int(context_lens.max().item())
+    min_blocks_per_seq = math.ceil(max_context_len_val / block_size)
+
+    def _check_partition_dim(name, tensor):
+        if tensor.dim() < 3:
+            raise ValueError(
+                f"{op_name}: {name} must have shape "
+                f"[..., max_num_partitions, head_size], got {tuple(tensor.shape)}"
+            )
+        if tensor.size(2) < max_num_partitions:
+            raise ValueError(
+                f"{op_name}: {name}.size(2)={tensor.size(2)} is too small for "
+                f"max_context_len={max_context_len} and partition_size={partition_size}; "
+                f"need at least {max_num_partitions} partition slots"
+            )
+
+    _check_partition_dim("tmp_out", tmp_out)
+    _check_partition_dim("exp_sums", exp_sums)
+    _check_partition_dim("max_logits", max_logits)
+
+    if block_tables.dim() != 2:
+        raise ValueError(
+            f"{op_name}: block_tables must be 2D "
+            f"[num_seqs, max_num_blocks_per_seq], got {tuple(block_tables.shape)}"
+        )
+    if block_tables.size(1) < min_blocks_per_seq:
+        raise ValueError(
+            f"{op_name}: block_tables.size(1)={block_tables.size(1)} is too small "
+            f"for max context_len={max_context_len_val} and block_size={block_size}; "
+            f"need at least {min_blocks_per_seq} block-table entries per sequence"
+        )
+    if context_lens.size(0) != block_tables.size(0):
+        raise ValueError(
+            f"{op_name}: context_lens.size(0)={context_lens.size(0)} must match "
+            f"block_tables.size(0)={block_tables.size(0)}"
+        )
+
+
 def paged_attention_rocm(
     out,
     exp_sums,
@@ -79,6 +129,17 @@ def paged_attention_rocm(
     import torch
 
     from csrc.cpp_itfs.torch_utils import torch_to_c_types
+
+    validate_paged_attention_rocm_buffers(
+        tmp_out,
+        exp_sums,
+        max_logits,
+        block_tables,
+        context_lens,
+        block_size,
+        max_context_len,
+        partition_size,
+    )
 
     dtype_map = {
         torch.bfloat16: "__hip_bfloat16",

--- a/csrc/cpp_itfs/pa/pa_v1.py
+++ b/csrc/cpp_itfs/pa/pa_v1.py
@@ -65,8 +65,10 @@ def validate_paged_attention_v1_workspace(
 ):
     op_name = "paged_attention_v1"
     max_num_partitions = math.ceil(max_context_len / partition_size)
-    max_context_len_val = int(context_lens.max().item())
-    min_blocks_per_seq = math.ceil(max_context_len_val / block_size)
+    # Use the launch-time upper bound rather than reading context_lens data.
+    # context_lens may live on GPU, and scalar extraction would force a sync
+    # and introduce tensor-data-dependent Python in torch.compile paths.
+    min_blocks_per_seq = math.ceil(max_context_len / block_size)
 
     if block_tables.dim() != 2:
         raise ValueError(
@@ -76,7 +78,7 @@ def validate_paged_attention_v1_workspace(
     if block_tables.size(1) < min_blocks_per_seq:
         raise ValueError(
             f"{op_name}: block_tables.size(1)={block_tables.size(1)} is too small "
-            f"for max context_len={max_context_len_val} and block_size={block_size}; "
+            f"for max_context_len={max_context_len} and block_size={block_size}; "
             f"need at least {min_blocks_per_seq} block-table entries per sequence"
         )
     if context_lens.size(0) != block_tables.size(0):

--- a/csrc/cpp_itfs/pa/pa_v1.py
+++ b/csrc/cpp_itfs/pa/pa_v1.py
@@ -53,6 +53,57 @@ def compile(
     )
 
 
+def validate_paged_attention_v1_workspace(
+    workspace_buffer,
+    query,
+    block_tables,
+    context_lens,
+    block_size,
+    max_context_len,
+    partition_size,
+    mtp=1,
+):
+    op_name = "paged_attention_v1"
+    max_num_partitions = math.ceil(max_context_len / partition_size)
+    max_context_len_val = int(context_lens.max().item())
+    min_blocks_per_seq = math.ceil(max_context_len_val / block_size)
+
+    if block_tables.dim() != 2:
+        raise ValueError(
+            f"{op_name}: block_tables must be 2D "
+            f"[num_seqs, max_num_blocks_per_seq], got {tuple(block_tables.shape)}"
+        )
+    if block_tables.size(1) < min_blocks_per_seq:
+        raise ValueError(
+            f"{op_name}: block_tables.size(1)={block_tables.size(1)} is too small "
+            f"for max context_len={max_context_len_val} and block_size={block_size}; "
+            f"need at least {min_blocks_per_seq} block-table entries per sequence"
+        )
+    if context_lens.size(0) != block_tables.size(0):
+        raise ValueError(
+            f"{op_name}: context_lens.size(0)={context_lens.size(0)} must match "
+            f"block_tables.size(0)={block_tables.size(0)}"
+        )
+
+    num_seqs = block_tables.size(0)
+    num_heads = query.size(1)
+    head_size = query.size(2)
+    tmp_out_elem_bytes = query.element_size()
+    required_bytes = (
+        num_seqs * mtp * num_heads * max_num_partitions * head_size * tmp_out_elem_bytes
+        + 2 * num_seqs * mtp * num_heads * max_num_partitions * 4
+    )
+    workspace_bytes = workspace_buffer.numel() * workspace_buffer.element_size()
+    if workspace_bytes < required_bytes:
+        raise ValueError(
+            f"{op_name}: workspace_buffer is too small ({workspace_bytes} bytes) for "
+            f"max_context_len={max_context_len}, partition_size={partition_size}, "
+            f"num_seqs={num_seqs}, num_heads={num_heads}, head_size={head_size}, mtp={mtp}; "
+            f"need at least {required_bytes} bytes "
+            f"({max_num_partitions} partition slots)"
+        )
+
+
 def paged_attention_v1(
     out,
     workspace_buffer,
@@ -114,6 +165,16 @@ def paged_attention_v1(
     head_size = query.size(2)
     q_stride = query.stride(0)
     block_size = key_cache.size(2) if kv_cache_layout == "HND" else key_cache.size(1)
+    validate_paged_attention_v1_workspace(
+        workspace_buffer,
+        query,
+        block_tables,
+        context_lens,
+        block_size,
+        max_context_len,
+        partition_size,
+        mtp,
+    )
     max_num_blocks_per_seq = block_tables.size(1)
     kv_block_stride = key_cache.stride(0)
     kv_head_stride = (


### PR DESCRIPTION
## Motivation


2 stage HIP kernels for paged attention rely on clients to allocate sufficient memory for scratch buffer between stages and also assume a sertain input shapes. Those assumptions are never validated, if they are not correct the host would just go ahead and dispatch a GPU work which will likely produce a fault if memory is not enough.

## Technical Details

Add pipeline validation for  input tensors for both pa and pa_v1.

## Test Plan

Negative tests when scratch memory is not enough should assert and not produce a page fault.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
