### PR TITLE
[EXPERIMENT] Kimi CI gates + cherry-pick DSv3.2 indexer fix (#3451) — verify V3.2 passes

### DIFF
--- a/.github/scripts/kimi_sglang_accuracy.sh
+++ b/.github/scripts/kimi_sglang_accuracy.sh
@@ -4,8 +4,26 @@
 # PR's AITER already installed. Launches sglang.launch_server, runs lm_eval
 # gsm8k 3-shot, prints `KIMI_FLEX_EXTRACT=<value>`.
 #
-# NOTE: SGLang currently fails to load AMD Quark MXFP4 per-expert weights
-# (loader bug). This gate is wired non-blocking until that is fixed upstream.
+# Two launcher flags are REQUIRED to serve the Quark MXFP4 checkpoint on MI350X
+# (gfx950). Both work around upstream-SGLang bugs, not AITER:
+#
+# 1) --disable-shared-experts-fusion
+#    With fusion ON (SGLang default for DeepseekV3-style models) the MoE weight
+#    loader crashes during load:
+#      fused_moe_triton/layer.py:490 _load_w13 -> expert_data.copy_(loaded_weight)
+#      RuntimeError: The size of tensor a (3584) must match the size of tensor b
+#      (7168) at non-singleton dimension 1
+#    The fusion concatenates the shared-expert gate/up into the routed-expert w13
+#    tensor, but the per-expert Quark MXFP4 shards have the unfused (half) shape.
+#
+# 2) --attention-backend aiter   (and DO NOT use --kv-cache-dtype fp8_e4m3)
+#    The default SGLang triton/MLA path for this model is broken on gfx950:
+#      forward_mla_fused_rope_rocm.py:75 torch.bmm(q_nope, w_kc)
+#      RuntimeError: Expected ... batch2 ... [8,128] but got [8,64]
+#    (head-dim mismatch, fires at CUDA-graph capture). With fp8 KV cache it slips
+#    past capture and instead dies in decode with the upstream triton dot
+#    rejecting fp8 lhs ("Unsupported lhs dtype fp8e4nv"). Routing attention
+#    through AITER's MLA backend + bf16 KV cache avoids both and serves cleanly.
 set -uo pipefail
 
 MODEL_PATH=${MODEL_PATH:-amd/Kimi-K2.5-MXFP4}
@@ -33,10 +51,11 @@ python3 -m sglang.launch_server \
     --host 127.0.0.1 --port "$PORT" \
     --tensor-parallel-size "$TP" \
     --trust-remote-code \
-    --kv-cache-dtype fp8_e4m3 \
+    --attention-backend aiter \
     --mem-fraction-static 0.8 \
     --page-size 1 \
     --disable-radix-cache \
+    --disable-shared-experts-fusion \
     > "$SLOG" 2>&1 &
 SVPID=$!
 

--- a/.github/scripts/kimi_sglang_accuracy.sh
+++ b/.github/scripts/kimi_sglang_accuracy.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Self-contained Kimi-K2.5 SGLang (upstream native kimi_k25) gsm8k accuracy check.
+# Runs inside an official ROCm SGLang image (lmsysorg/sglang-rocm:...) with the
+# PR's AITER already installed. Launches sglang.launch_server, runs lm_eval
+# gsm8k 3-shot, prints `KIMI_FLEX_EXTRACT=<value>`.
+#
+# NOTE: SGLang currently fails to load AMD Quark MXFP4 per-expert weights
+# (loader bug). This gate is wired non-blocking until that is fixed upstream.
+set -uo pipefail
+
+MODEL_PATH=${MODEL_PATH:-amd/Kimi-K2.5-MXFP4}
+TP=${TP:-8}
+PORT=${PORT:-8000}
+FEWSHOT=${FEWSHOT:-3}
+OUT=${OUT:-/tmp/kimi_sglang_acc}
+mkdir -p "$OUT"
+SLOG="$OUT/server.log"
+
+export SGLANG_USE_AITER=${SGLANG_USE_AITER:-1}
+export AITER_QUICK_REDUCE_QUANTIZATION=${AITER_QUICK_REDUCE_QUANTIZATION:-INT4}
+export SGLANG_AITER_FP8_PREFILL_ATTN=${SGLANG_AITER_FP8_PREFILL_ATTN:-0}
+
+if [ -d "/models/${MODEL_PATH}" ]; then MODEL="/models/${MODEL_PATH}"; else MODEL="${MODEL_PATH}"; fi
+echo "== Kimi SGLang accuracy =="; echo "model=$MODEL tp=$TP"
+pip show amd-aiter 2>/dev/null | grep -E '^Version' || pip show aiter 2>/dev/null | grep -E '^Version' || true
+command -v lm_eval >/dev/null 2>&1 || pip install -q "lm-eval[api]"
+
+if ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then echo "ERROR: port $PORT busy"; exit 3; fi
+
+echo "== launching sglang.launch_server =="
+python3 -m sglang.launch_server \
+    --model-path "$MODEL" \
+    --host 127.0.0.1 --port "$PORT" \
+    --tensor-parallel-size "$TP" \
+    --trust-remote-code \
+    --kv-cache-dtype fp8_e4m3 \
+    --mem-fraction-static 0.8 \
+    --page-size 1 \
+    --disable-radix-cache \
+    > "$SLOG" 2>&1 &
+SVPID=$!
+
+echo "== waiting for /v1/models =="
+ready=0
+for i in $(seq 1 2400); do
+  curl -fsS "http://127.0.0.1:${PORT}/v1/models" >/dev/null 2>&1 && { ready=1; break; }
+  kill -0 $SVPID 2>/dev/null || { echo "SERVER DIED"; tail -n 80 "$SLOG"; exit 4; }
+  sleep 1
+done
+[ "$ready" -eq 1 ] || { echo "SERVER NOT READY"; tail -n 80 "$SLOG"; exit 5; }
+echo "SERVER READY after ${i}s"
+
+echo "== lm_eval gsm8k ${FEWSHOT}-shot =="
+lm_eval --model local-completions \
+  --model_args model="$MODEL",base_url="http://127.0.0.1:${PORT}/v1/completions",num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True \
+  --tasks gsm8k --num_fewshot "$FEWSHOT" \
+  --output_path "$OUT/acc" 2>&1 | tee "$OUT/accuracy.txt"
+
+kill $SVPID 2>/dev/null || true; sleep 3
+pkill -9 -f "sglang.launch_server" 2>/dev/null || true
+
+rf=$(find "$OUT/acc" -name '*.json' 2>/dev/null | head -1)
+if [ -z "$rf" ]; then echo "ERROR: no lm_eval result JSON"; exit 6; fi
+val=$(python3 -c "import json;d=json.load(open('$rf'));print(d['results']['gsm8k']['exact_match,flexible-extract'])")
+echo "KIMI_FLEX_EXTRACT=${val}"

--- a/.github/scripts/kimi_sglang_perf.sh
+++ b/.github/scripts/kimi_sglang_perf.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Self-contained Kimi-K2.5 SGLang (upstream native kimi_k25) throughput PERFORMANCE gate.
+# Runs inside an official ROCm SGLang image (lmsysorg/sglang-rocm:...) with the
+# PR's AITER already installed. Launches sglang.launch_server with the EXACT flags
+# that pass the accuracy gate (kimi_sglang_accuracy.sh), warms up, then runs a
+# throughput sweep over concurrency and prints
+# `KIMI_PERF_C64_OUT_TOKS=<output token throughput at concurrency 64>` for the
+# workflow to gate on.
+#
+# The launch flags MUST match kimi_sglang_accuracy.sh exactly. Both flags below
+# work around upstream-SGLang bugs (not AITER) when serving the Quark MXFP4
+# checkpoint on MI350X (gfx950):
+#
+# 1) --disable-shared-experts-fusion
+#    With fusion ON (SGLang default for DeepseekV3-style models) the MoE weight
+#    loader crashes during load (w13 shape 3584 vs 7168 mismatch): the fused
+#    shared-expert gate/up does not match the per-expert Quark MXFP4 shard shape.
+#
+# 2) --attention-backend aiter   (and DO NOT use --kv-cache-dtype fp8_e4m3)
+#    The default SGLang triton/MLA path is broken on gfx950 (head-dim mismatch at
+#    CUDA-graph capture). With fp8 KV cache it instead dies in decode on the
+#    triton fp8 dot ("Unsupported lhs dtype fp8e4nv"). AITER MLA + bf16 KV cache
+#    serves cleanly.
+set -uo pipefail
+
+MODEL_PATH=${MODEL_PATH:-amd/Kimi-K2.5-MXFP4}
+TP=${TP:-8}
+PORT=${PORT:-8000}
+ISL=${ISL:-1024}
+OSL=${OSL:-1024}
+CONCURRENCIES=${CONCURRENCIES:-"4 8 16 32 64"}
+OUT=${OUT:-/tmp/kimi_sglang_perf}
+mkdir -p "$OUT"
+SLOG="$OUT/server.log"
+
+export SGLANG_USE_AITER=${SGLANG_USE_AITER:-1}
+export AITER_QUICK_REDUCE_QUANTIZATION=${AITER_QUICK_REDUCE_QUANTIZATION:-INT4}
+export SGLANG_AITER_FP8_PREFILL_ATTN=${SGLANG_AITER_FP8_PREFILL_ATTN:-0}
+
+# Prefer a /models mount if the weights are pre-cached there, else use the path
+# as given (e.g. a local /data mount).
+if [ -d "/models/${MODEL_PATH}" ]; then MODEL="/models/${MODEL_PATH}"; else MODEL="${MODEL_PATH}"; fi
+echo "== Kimi SGLang perf =="; echo "model=$MODEL tp=$TP isl=$ISL osl=$OSL concurrencies=[$CONCURRENCIES]"
+pip show amd-aiter 2>/dev/null | grep -E '^Version' || pip show aiter 2>/dev/null | grep -E '^Version' || true
+
+if ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then echo "ERROR: port $PORT busy"; exit 3; fi
+
+echo "== launching sglang.launch_server =="
+python3 -m sglang.launch_server \
+    --model-path "$MODEL" \
+    --host 127.0.0.1 --port "$PORT" \
+    --tensor-parallel-size "$TP" \
+    --trust-remote-code \
+    --attention-backend aiter \
+    --mem-fraction-static 0.8 \
+    --page-size 1 \
+    --disable-radix-cache \
+    --disable-shared-experts-fusion \
+    > "$SLOG" 2>&1 &
+SVPID=$!
+
+cleanup() {
+  kill "$SVPID" 2>/dev/null || true; sleep 3
+  pkill -9 -f "sglang.launch_server" 2>/dev/null || true
+  pkill -9 -f "sglang::scheduler" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "== waiting for /v1/models =="
+ready=0
+for i in $(seq 1 2400); do
+  curl -fsS "http://127.0.0.1:${PORT}/v1/models" >/dev/null 2>&1 && { ready=1; break; }
+  kill -0 $SVPID 2>/dev/null || { echo "SERVER DIED"; tail -n 80 "$SLOG"; exit 4; }
+  sleep 1
+done
+[ "$ready" -eq 1 ] || { echo "SERVER NOT READY"; tail -n 80 "$SLOG"; exit 5; }
+echo "SERVER READY after ${i}s"
+
+run_sweep_point() {
+  local C="$1"
+  local jf="$OUT/bench_c${C}.jsonl"
+  rm -f "$jf"
+  echo "== bench_serving concurrency=${C} prompts=$((C*10)) =="
+  python3 -m sglang.bench_serving \
+    --backend sglang-oai \
+    --host 127.0.0.1 --port "$PORT" \
+    --model "$MODEL" \
+    --tokenizer "$MODEL" \
+    --dataset-name random \
+    --random-input-len "$ISL" \
+    --random-output-len "$OSL" \
+    --random-range-ratio 1.0 \
+    --num-prompts $((C*10)) \
+    --max-concurrency "$C" \
+    --request-rate inf \
+    --output-file "$jf" \
+    2>&1 | tee "$OUT/bench_c${C}.log"
+}
+
+# Warmup: a small dedicated bench pass before measuring.
+echo "== warmup =="
+python3 -m sglang.bench_serving \
+  --backend sglang-oai \
+  --host 127.0.0.1 --port "$PORT" \
+  --model "$MODEL" --tokenizer "$MODEL" \
+  --dataset-name random \
+  --random-input-len "$ISL" --random-output-len "$OSL" --random-range-ratio 1.0 \
+  --num-prompts 16 --max-concurrency 8 --request-rate inf \
+  > "$OUT/warmup.log" 2>&1 || echo "warmup pass returned non-zero (continuing)"
+
+C64_OUT="NA"
+echo ""
+printf "%-12s %-22s %-16s %-16s\n" "concurrency" "out_tok/s" "mean_ttft_ms" "mean_tpot_ms"
+RESULTS=""
+for C in $CONCURRENCIES; do
+  run_sweep_point "$C"
+  jf="$OUT/bench_c${C}.jsonl"
+  # sglang.bench_serving --output-file appends one JSON object per line; take the
+  # last line for this run. Console labels map to JSON keys:
+  #   "Output token throughput (tok/s)" -> output_throughput
+  #   "Mean TTFT (ms)"                  -> mean_ttft_ms
+  #   "Mean TPOT (ms)"                  -> mean_tpot_ms
+  read -r OUTTOK TTFT TPOT < <(python3 - "$jf" "$OUT/bench_c${C}.log" <<'PY'
+import json,sys,re
+jf, logf = sys.argv[1], sys.argv[2]
+d=None
+try:
+    lines=[l for l in open(jf) if l.strip()]
+    if lines: d=json.loads(lines[-1])
+except Exception:
+    d=None
+def from_json():
+    def g(k):
+        return d[k] if (d and k in d and d[k] is not None) else None
+    return g('output_throughput'), g('mean_ttft_ms'), g('mean_tpot_ms')
+ot,tt,tp=from_json()
+# Fallback: parse the console log if JSON missing/incomplete.
+if ot is None or tt is None or tp is None:
+    txt=open(logf,errors='ignore').read()
+    def grab(label):
+        m=re.search(re.escape(label)+r'\s*:\s*([0-9.]+)', txt)
+        return float(m.group(1)) if m else None
+    ot = ot if ot is not None else grab('Output token throughput (tok/s)')
+    tt = tt if tt is not None else grab('Mean TTFT (ms)')
+    tp = tp if tp is not None else grab('Mean TPOT (ms)')
+def f(x): return 'NA' if x is None else x
+print(f(ot), f(tt), f(tp))
+PY
+)
+  [ -z "$OUTTOK" ] && OUTTOK="NA"
+  printf "%-12s %-22s %-16s %-16s\n" "$C" "$OUTTOK" "$TTFT" "$TPOT"
+  RESULTS="${RESULTS}${C} ${OUTTOK} ${TTFT} ${TPOT}\n"
+  if [ "$C" = "64" ]; then C64_OUT="$OUTTOK"; fi
+done
+
+echo ""
+echo "== SWEEP SUMMARY (concurrency out_tok/s mean_ttft_ms mean_tpot_ms) =="
+printf "%b" "$RESULTS"
+echo ""
+echo "KIMI_PERF_C64_OUT_TOKS=${C64_OUT}"
+
+cleanup
+trap - EXIT
+sleep 2
+echo "== done =="

--- a/.github/scripts/kimi_vllm_accuracy.sh
+++ b/.github/scripts/kimi_vllm_accuracy.sh
@@ -26,10 +26,17 @@ command -v lm_eval >/dev/null 2>&1 || pip install -q "lm-eval[api]"
 if ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then echo "ERROR: port $PORT busy"; exit 3; fi
 
 echo "== launching vllm serve =="
+# NOTE: do NOT pass `--load-format fastsafetensors` here. The official
+# rocm/vllm-dev:nightly image does not bundle the `fastsafetensors` package, so
+# that flag makes every TP worker die during weight load with
+# `ImportError: Please install vllm[fastsafetensors] for fastsafetensors support`
+# (surfaced only as "WorkerProc initialization failed" in the parent). The
+# default safetensors loader loads this 521GB checkpoint in ~27s/worker on
+# MI355X, so fastsafetensors buys nothing here. The reference 0.9409 run used it
+# only because the ATOM image happened to ship the package.
 vllm serve "$MODEL" \
     --host 127.0.0.1 --port "$PORT" \
     --async-scheduling \
-    --load-format fastsafetensors \
     --tensor-parallel-size "$TP" \
     --trust-remote-code \
     --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \

--- a/.github/scripts/kimi_vllm_accuracy.sh
+++ b/.github/scripts/kimi_vllm_accuracy.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Self-contained Kimi-K2.5 vLLM (upstream) gsm8k accuracy check.
+# Runs inside an official ROCm vLLM image (e.g. rocm/vllm-dev:nightly) with the
+# PR's AITER already installed. Launches `vllm serve`, runs lm_eval gsm8k 3-shot,
+# and prints `KIMI_FLEX_EXTRACT=<value>` for the workflow to gate on.
+set -uo pipefail
+
+MODEL_PATH=${MODEL_PATH:-amd/Kimi-K2.5-MXFP4}
+TP=${TP:-8}
+PORT=${PORT:-8000}
+FEWSHOT=${FEWSHOT:-3}
+OUT=${OUT:-/tmp/kimi_vllm_acc}
+mkdir -p "$OUT"
+SLOG="$OUT/server.log"
+
+export AITER_QUICK_REDUCE_QUANTIZATION=${AITER_QUICK_REDUCE_QUANTIZATION:-INT4}
+export VLLM_ROCM_USE_AITER=${VLLM_ROCM_USE_AITER:-1}
+
+# Prefer a /models mount if the weights are pre-cached there.
+if [ -d "/models/${MODEL_PATH}" ]; then MODEL="/models/${MODEL_PATH}"; else MODEL="${MODEL_PATH}"; fi
+echo "== Kimi vLLM accuracy =="; echo "model=$MODEL tp=$TP"
+python3 -c "import vllm;print('vllm',vllm.__version__)" 2>/dev/null | tail -1
+pip show amd-aiter 2>/dev/null | grep -E '^Version' || true
+command -v lm_eval >/dev/null 2>&1 || pip install -q "lm-eval[api]"
+
+if ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then echo "ERROR: port $PORT busy"; exit 3; fi
+
+echo "== launching vllm serve =="
+vllm serve "$MODEL" \
+    --host 127.0.0.1 --port "$PORT" \
+    --async-scheduling \
+    --load-format fastsafetensors \
+    --tensor-parallel-size "$TP" \
+    --trust-remote-code \
+    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
+    --kv-cache-dtype fp8 \
+    --max-num-batched-tokens 16384 \
+    --max-model-len 16384 \
+    --no-enable-prefix-caching \
+    > "$SLOG" 2>&1 &
+SVPID=$!
+
+echo "== waiting for /health =="
+ready=0
+for i in $(seq 1 2400); do
+  curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1 && { ready=1; break; }
+  kill -0 $SVPID 2>/dev/null || { echo "SERVER DIED"; tail -n 80 "$SLOG"; exit 4; }
+  sleep 1
+done
+[ "$ready" -eq 1 ] || { echo "SERVER NOT READY"; tail -n 80 "$SLOG"; exit 5; }
+echo "SERVER READY after ${i}s"
+
+echo "== lm_eval gsm8k ${FEWSHOT}-shot =="
+lm_eval --model local-completions \
+  --model_args model="$MODEL",base_url="http://127.0.0.1:${PORT}/v1/completions",num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True \
+  --tasks gsm8k --num_fewshot "$FEWSHOT" \
+  --output_path "$OUT/acc" 2>&1 | tee "$OUT/accuracy.txt"
+
+kill $SVPID 2>/dev/null || true; sleep 3
+pkill -9 -f "vllm serve" 2>/dev/null || true
+pkill -9 -f "multiprocessing.spawn" 2>/dev/null || true
+
+rf=$(ls -1t "$OUT"/acc/**/*.json "$OUT"/acc/*.json 2>/dev/null | head -1)
+[ -z "$rf" ] && rf=$(find "$OUT/acc" -name '*.json' 2>/dev/null | head -1)
+if [ -z "$rf" ]; then echo "ERROR: no lm_eval result JSON"; exit 6; fi
+val=$(python3 -c "import json,sys;d=json.load(open('$rf'));print(d['results']['gsm8k']['exact_match,flexible-extract'])")
+echo "KIMI_FLEX_EXTRACT=${val}"

--- a/.github/scripts/kimi_vllm_perf.sh
+++ b/.github/scripts/kimi_vllm_perf.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Self-contained Kimi-K2.5 vLLM (upstream) throughput PERFORMANCE gate.
+# Runs inside an official ROCm vLLM image (e.g. rocm/vllm-dev:nightly) with the
+# PR's AITER already installed. Launches `vllm serve` (the exact flags that pass
+# the accuracy gate), warms up, then runs a throughput sweep over concurrency
+# and prints `KIMI_PERF_C64_OUT_TOKS=<output token throughput at concurrency 64>`
+# for the workflow to gate on.
+set -uo pipefail
+
+MODEL_PATH=${MODEL_PATH:-amd/Kimi-K2.5-MXFP4}
+TP=${TP:-8}
+PORT=${PORT:-8000}
+ISL=${ISL:-1024}
+OSL=${OSL:-1024}
+CONCURRENCIES=${CONCURRENCIES:-"4 8 16 32 64"}
+OUT=${OUT:-/tmp/kimi_vllm_perf}
+mkdir -p "$OUT"
+SLOG="$OUT/server.log"
+
+export AITER_QUICK_REDUCE_QUANTIZATION=${AITER_QUICK_REDUCE_QUANTIZATION:-INT4}
+export VLLM_ROCM_USE_AITER=${VLLM_ROCM_USE_AITER:-1}
+
+# Prefer a /models mount if the weights are pre-cached there.
+if [ -d "/models/${MODEL_PATH}" ]; then MODEL="/models/${MODEL_PATH}"; else MODEL="${MODEL_PATH}"; fi
+echo "== Kimi vLLM perf =="; echo "model=$MODEL tp=$TP isl=$ISL osl=$OSL concurrencies=[$CONCURRENCIES]"
+python3 -c "import vllm;print('vllm',vllm.__version__)" 2>/dev/null | tail -1
+pip show amd-aiter 2>/dev/null | grep -E '^Version' || true
+
+if ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then echo "ERROR: port $PORT busy"; exit 3; fi
+
+echo "== launching vllm serve =="
+# Same launch as the accuracy gate. Do NOT pass `--load-format fastsafetensors`:
+# the official rocm/vllm-dev:nightly image does not bundle the package, so the
+# flag kills every TP worker during weight load.
+vllm serve "$MODEL" \
+    --host 127.0.0.1 --port "$PORT" \
+    --async-scheduling \
+    --tensor-parallel-size "$TP" \
+    --trust-remote-code \
+    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
+    --kv-cache-dtype fp8 \
+    --max-num-batched-tokens 16384 \
+    --max-model-len 16384 \
+    --no-enable-prefix-caching \
+    > "$SLOG" 2>&1 &
+SVPID=$!
+
+cleanup() {
+  kill "$SVPID" 2>/dev/null || true; sleep 3
+  pkill -9 -f "vllm serve" 2>/dev/null || true
+  pkill -9 -f "multiprocessing.spawn" 2>/dev/null || true
+  pkill -9 -f "VLLM::EngineCore" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "== waiting for /health =="
+ready=0
+for i in $(seq 1 2400); do
+  curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1 && { ready=1; break; }
+  kill -0 $SVPID 2>/dev/null || { echo "SERVER DIED"; tail -n 80 "$SLOG"; exit 4; }
+  sleep 1
+done
+[ "$ready" -eq 1 ] || { echo "SERVER NOT READY"; tail -n 80 "$SLOG"; exit 5; }
+echo "SERVER READY after ${i}s"
+
+BASE_URL="http://127.0.0.1:${PORT}"
+
+run_sweep_point() {
+  local C="$1"
+  local jf="$OUT/bench_c${C}.json"
+  echo "== bench serve concurrency=${C} prompts=$((C*10)) =="
+  vllm bench serve \
+    --backend vllm \
+    --base-url "$BASE_URL" \
+    --endpoint /v1/completions \
+    --model "$MODEL" \
+    --trust-remote-code \
+    --dataset-name random \
+    --random-input-len "$ISL" \
+    --random-output-len "$OSL" \
+    --max-concurrency "$C" \
+    --num-prompts $((C*10)) \
+    --num-warmups 8 \
+    --request-rate inf \
+    --ignore-eos \
+    --disable-tqdm \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --save-result --result-filename "$jf" \
+    2>&1 | tee "$OUT/bench_c${C}.log"
+}
+
+# Warmup: a small dedicated bench pass before measuring.
+echo "== warmup =="
+vllm bench serve --backend vllm --base-url "$BASE_URL" --endpoint /v1/completions \
+  --model "$MODEL" --trust-remote-code --dataset-name random \
+  --random-input-len "$ISL" --random-output-len "$OSL" \
+  --max-concurrency 8 --num-prompts 16 --num-warmups 8 \
+  --request-rate inf --ignore-eos --disable-tqdm \
+  > "$OUT/warmup.log" 2>&1 || echo "warmup pass returned non-zero (continuing)"
+
+C64_OUT="NA"
+echo ""
+printf "%-12s %-22s %-16s %-16s\n" "concurrency" "out_tok/s" "mean_ttft_ms" "mean_tpot_ms"
+RESULTS=""
+for C in $CONCURRENCIES; do
+  run_sweep_point "$C"
+  jf="$OUT/bench_c${C}.json"
+  if [ -f "$jf" ]; then
+    read -r OUTTOK TTFT TPOT < <(python3 - "$jf" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+def g(*keys):
+    for k in keys:
+        if k in d and d[k] is not None: return d[k]
+    return float('nan')
+print(g('output_throughput'), g('mean_ttft_ms'), g('mean_tpot_ms'))
+PY
+)
+  else
+    OUTTOK="NA"; TTFT="NA"; TPOT="NA"
+  fi
+  printf "%-12s %-22s %-16s %-16s\n" "$C" "$OUTTOK" "$TTFT" "$TPOT"
+  RESULTS="${RESULTS}${C} ${OUTTOK} ${TTFT} ${TPOT}\n"
+  if [ "$C" = "64" ]; then C64_OUT="$OUTTOK"; fi
+done
+
+echo ""
+echo "== SWEEP SUMMARY (concurrency out_tok/s mean_ttft_ms mean_tpot_ms) =="
+printf "%b" "$RESULTS"
+echo ""
+echo "KIMI_PERF_C64_OUT_TOKS=${C64_OUT}"
+
+cleanup
+trap - EXIT
+sleep 2
+echo "== done =="

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -78,6 +78,15 @@ jobs:
               # Kimi-K2.5 ATOM (in-tree) downstream gate. Config (model_path,
               # extraArgs -tp4, threshold) is pulled from ATOM models_accuracy.json.
               {"model_name": "Kimi-K2.5-MXFP4"},
+              # Expanded coverage to match the InferenceX (SemiAnalysisAI) MI355X
+              # frontier set. All configs (model_path, extraArgs, threshold) come
+              # from ATOM models_accuracy.json; runners pinned below to the MI350X
+              # pool. GLM-5.1 is used instead of GLM-5 (GLM-5 has a known ATOM
+              # sparse-attn-indexer crash around the gsm8k request count).
+              {"model_name": "DeepSeek-V4-Pro"},
+              {"model_name": "Qwen3.5-397B-A17B-FP8"},
+              {"model_name": "MiniMax-M2.7"},
+              {"model_name": "GLM-5.1-FP8"},
           ]
 
           labels_raw = os.environ.get("LABELS_JSON") or "[]"
@@ -98,6 +107,10 @@ jobs:
           # runs the downstream gate on the AITER MI350X pool (TP4 -> 4 GPUs).
           model_runner_overrides = {
               "Kimi-K2.5-MXFP4": "linux-aiter-do-mi350x-4",
+              "DeepSeek-V4-Pro": "linux-aiter-do-mi350x-8",       # -tp 8
+              "Qwen3.5-397B-A17B-FP8": "linux-aiter-do-mi350x-4",  # -tp 4
+              "MiniMax-M2.7": "linux-aiter-do-mi350x-2",           # -tp 2
+              "GLM-5.1-FP8": "linux-aiter-do-mi350x-8",            # -tp 8
           }
 
           def prepare_model(model):

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -72,21 +72,20 @@ jobs:
           import json
           import os
 
+          # Always-on PR gate set (every ci:atom / ci:all). Kept small so the
+          # do-mi350x pool isn't overloaded (overload was flaking the Kimi +
+          # perf gates). The InferenceX frontier models (DeepSeek-V4-Pro,
+          # Qwen3.5-397B-A17B-FP8, GLM-5.1-FP8 — all validated PASS on do-mi350x)
+          # are covered on-demand via the ci:atom_full label, which runs every
+          # pr/main model in ATOM models_accuracy.json with the runner pins below.
+          # MiniMax-M2.7 currently fails (needs an ATOM-side HSA_NO_SCRATCH_RECLAIM
+          # env), so it is only exercised under ci:atom_full, never on every PR.
           default_models = [
               {"model_name": "DeepSeek-R1-0528"},
               {"model_name": "gpt-oss-120b"},
               # Kimi-K2.5 ATOM (in-tree) downstream gate. Config (model_path,
               # extraArgs -tp4, threshold) is pulled from ATOM models_accuracy.json.
               {"model_name": "Kimi-K2.5-MXFP4"},
-              # Expanded coverage to match the InferenceX (SemiAnalysisAI) MI355X
-              # frontier set. All configs (model_path, extraArgs, threshold) come
-              # from ATOM models_accuracy.json; runners pinned below to the MI350X
-              # pool. GLM-5.1 is used instead of GLM-5 (GLM-5 has a known ATOM
-              # sparse-attn-indexer crash around the gsm8k request count).
-              {"model_name": "DeepSeek-V4-Pro"},
-              {"model_name": "Qwen3.5-397B-A17B-FP8"},
-              {"model_name": "MiniMax-M2.7"},
-              {"model_name": "GLM-5.1-FP8"},
           ]
 
           labels_raw = os.environ.get("LABELS_JSON") or "[]"

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -75,6 +75,9 @@ jobs:
           default_models = [
               {"model_name": "DeepSeek-R1-0528"},
               {"model_name": "gpt-oss-120b"},
+              # Kimi-K2.5 ATOM (in-tree) downstream gate. Config (model_path,
+              # extraArgs -tp4, threshold) is pulled from ATOM models_accuracy.json.
+              {"model_name": "Kimi-K2.5-MXFP4"},
           ]
 
           labels_raw = os.environ.get("LABELS_JSON") or "[]"
@@ -91,9 +94,16 @@ jobs:
               "linux-atom-mi35x-1": "linux-aiter-mi35x-1",
           }
 
+          # Per-model runner pin (overrides the generic mapping above). Kimi-K2.5
+          # runs the downstream gate on the AITER MI350X pool (TP4 -> 4 GPUs).
+          model_runner_overrides = {
+              "Kimi-K2.5-MXFP4": "linux-aiter-do-mi350x-4",
+          }
+
           def prepare_model(model):
               model = dict(model)
               model["runner"] = runner_overrides.get(model["runner"], model["runner"])
+              model["runner"] = model_runner_overrides.get(model["model_name"], model["runner"])
               model["label"] = model.get("runner", "")
               model["accuracy_test_threshold"] = str(model.get("accuracy_threshold", 0))
               model["run_on_pr"] = True

--- a/.github/workflows/kimi-downstream.yaml
+++ b/.github/workflows/kimi-downstream.yaml
@@ -9,8 +9,10 @@ name: Kimi Downstream Test
 # self-contained launcher runs gsm8k. The ATOM (in-tree) path is covered in
 # atom-test.yaml.
 #
-# Verified on MI355X (gfx950) 2026-05-30 (aiter ef114b0d4), vllm serve TP8:
-# gsm8k 3-shot flexible-extract 0.9409. Threshold 0.92 leaves margin.
+# Verified on MI350X (gfx950) TP8, gsm8k 3-shot flexible-extract, threshold 0.92:
+#   vLLM   2026-05-30 aiter ef114b0d4  -> 0.9409
+#   SGLang 2026-05-31 aiter 1ec891b44  -> 0.9272  (--attention-backend aiter +
+#          --disable-shared-experts-fusion; see kimi_sglang_accuracy.sh header)
 
 on:
   pull_request:
@@ -50,9 +52,20 @@ jobs:
             # periodically. See https://hub.docker.com/r/lmsysorg/sglang-rocm/tags
             base_image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260531
             script: kimi_sglang_accuracy.sh
-            # Non-blocking: SGLang can't yet load AMD Quark MXFP4 per-expert
-            # weights (loader bug). Visible signal that greens on the fix.
-            continue_on_error: true
+            # Blocking. Two SGLang-side bugs in this Kimi-K2.5 path on MI350X
+            # (gfx950) are worked around in the launcher (kimi_sglang_accuracy.sh):
+            #  1) MoE loader: shared-experts fusion vs unfused per-expert Quark
+            #     MXFP4 shard shape -> _load_w13 copy_ mismatch 3584 vs 7168.
+            #     Fixed with --disable-shared-experts-fusion.
+            #  2) MLA forward: SGLang's default triton/fused-MLA path
+            #     (forward_mla_fused_rope_rocm.py) crashes on Kimi-K2.5 head dims
+            #     ("batch2 ... [8,128] but got [8,64]"); fp8 KV cache instead dies
+            #     in decode on the triton fp8 dot. Fixed by routing attention
+            #     through AITER's MLA backend (--attention-backend aiter) + bf16
+            #     KV cache. This exercises the PR's AITER kernels end to end.
+            # Verified on MI350X (gfx950) TP8, aiter 1ec891b44: gsm8k 3-shot
+            # flexible-extract 0.9272 (strict 0.9265). Threshold 0.92.
+            continue_on_error: false
     runs-on: linux-aiter-do-mi350x-8
     continue-on-error: ${{ matrix.continue_on_error }}
     timeout-minutes: 180

--- a/.github/workflows/kimi-downstream.yaml
+++ b/.github/workflows/kimi-downstream.yaml
@@ -1,16 +1,16 @@
 name: Kimi Downstream Test
 
-# End-to-end Kimi-K2.5-MXFP4 accuracy regression for AITER across the vLLM
-# (OOT plugin) and SGLang downstream serving stacks. The ATOM (in-tree) path
-# is covered separately in atom-test.yaml.
+# End-to-end Kimi-K2.5-MXFP4 accuracy regression for AITER against the official
+# nightly downstream serving images:
+#   vLLM   -> rocm/vllm-dev:nightly                 (upstream-native KimiK25)
+#   SGLang -> lmsysorg/sglang-rocm:<mi35x rocm720>  (upstream-native kimi_k25)
 #
-# Each job rebuilds the PR's AITER into the corresponding atom-dev backend image
-# (gfx950) and runs the gsm8k accuracy check via the launch scripts shipped in
-# the image (.github/scripts/atom_oot_test.sh / atom_sglang_test.sh).
+# The PR's AITER is built from source into the image at runtime (gfx950), then a
+# self-contained launcher runs gsm8k. The ATOM (in-tree) path is covered in
+# atom-test.yaml.
 #
-# Verified on MI355X (gfx950) 2026-05-30 with atom-dev:vllm-latest
-# (aiter ef114b0d4), vllm serve TP8: gsm8k 3-shot flexible-extract 0.9409
-# (== amd/Kimi-K2.5-MXFP4 reference). Threshold 0.92 leaves margin.
+# Verified on MI355X (gfx950) 2026-05-30 (aiter ef114b0d4), vllm serve TP8:
+# gsm8k 3-shot flexible-extract 0.9409. Threshold 0.92 leaves margin.
 
 on:
   pull_request:
@@ -18,17 +18,12 @@ on:
   push:
     branches: [main]
   schedule:
-    # Nightly, off-peak minute to avoid the top-of-hour stampede.
     - cron: '17 19 * * *'
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
-  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
 
 jobs:
   kimi-downstream:
@@ -45,54 +40,34 @@ jobs:
       matrix:
         include:
           - backend: vllm
-            base_image: rocm/atom-dev:vllm-latest
-            # OOT vllm serve flags (default serve args added by atom_oot_test.sh).
-            extra_args: "--tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384"
-            model_env: "AITER_QUICK_REDUCE_QUANTIZATION=INT4"
+            # Official ROCm vLLM nightly (floating tag).
+            base_image: rocm/vllm-dev:nightly
+            script: kimi_vllm_accuracy.sh
             continue_on_error: false
           - backend: sglang
-            base_image: rocm/atom-dev:sglang-latest
-            extra_args: "--tensor-parallel-size 8 --trust-remote-code"
-            model_env: "SGLANG_USE_AITER=1"
-            # Non-blocking: SGLang Kimi-K2.5 currently fails to load AMD Quark
-            # MXFP4 per-expert weights (sglang loader bug, tracked separately).
-            # Kept as a visible signal that turns green once the loader is fixed.
+            # Official ROCm SGLang image. lmsysorg/sglang-rocm has no floating
+            # nightly tag; pin to the latest MI35X / ROCm7.2 date build and bump
+            # periodically. See https://hub.docker.com/r/lmsysorg/sglang-rocm/tags
+            base_image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260531
+            script: kimi_sglang_accuracy.sh
+            # Non-blocking: SGLang can't yet load AMD Quark MXFP4 per-expert
+            # weights (loader bug). Visible signal that greens on the fix.
             continue_on_error: true
     runs-on: linux-aiter-do-mi350x-8
     continue-on-error: ${{ matrix.continue_on_error }}
     timeout-minutes: 180
     env:
-      MODEL_NAME: "Kimi-K2.5-MXFP4"
       MODEL_PATH: "amd/Kimi-K2.5-MXFP4"
       ACC_THRESHOLD: "0.92"
       CONTAINER: "kimi_${{ matrix.backend }}_aiter_test"
     steps:
-      - name: Download backend base image
+      - name: Checkout AITER (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Pull base image
         run: docker pull ${{ matrix.base_image }}
-
-      - name: Generate Dockerfile (rebuild PR AITER into backend image)
-        run: |
-          cat <<EOF > Dockerfile.kimi
-          FROM ${{ matrix.base_image }}
-
-          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
-          RUN pip uninstall -y amd-aiter || true
-          RUN pip install --upgrade "pybind11>=3.0.1"
-          RUN rm -rf /app/aiter-test && \\
-              git clone ${{ env.GITHUB_REPO_URL }} /app/aiter-test && \\
-              cd /app/aiter-test && \\
-              git checkout ${{ env.GITHUB_COMMIT_SHA }} && \\
-              git submodule sync && git submodule update --init --recursive && \\
-              MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 pip install -e .
-          RUN echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true
-          EOF
-          cat Dockerfile.kimi
-
-      - name: Build the Kimi test image
-        run: |
-          docker build --network=host --no-cache \
-            -t rocm/aiter-ci:kimi-${{ matrix.backend }} \
-            -f Dockerfile.kimi .
 
       - name: Start CI container
         run: |
@@ -108,49 +83,36 @@ jobs:
             --ulimit memlock=-1 --ulimit stack=67108864 \
             --network=host \
             -e HF_TOKEN="${HF_TOKEN:-${{ secrets.HF_TOKEN_TEST }}}" \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
             -v /models:/models \
             --name ${CONTAINER} \
-            rocm/aiter-ci:kimi-${{ matrix.backend }}
+            ${{ matrix.base_image }}
+          docker exec ${CONTAINER} git config --global --add safe.directory /workspace || true
 
-      - name: Check versions
+      - name: Build & install PR AITER (gfx950)
         run: |
-          docker exec ${CONTAINER} bash -lc "pip show amd-aiter | grep -E 'Version|Location' || true; cd /app/aiter-test && git rev-parse --short HEAD"
+          docker exec ${CONTAINER} bash -lc '
+            set -e
+            pip uninstall -y amd-aiter aiter 2>/dev/null || true
+            pip install --upgrade "pybind11>=3.0.1"
+            cd /workspace
+            MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 pip install -e .
+            (pip show amd-aiter || pip show aiter) | grep -E "^Version|^Location" || true
+          '
 
       - name: Run Kimi-K2.5 gsm8k accuracy
         timeout-minutes: 120
         run: |
-          set -euo pipefail
-          docker exec \
-            -e OOT_MODEL_NAME="${MODEL_NAME}" \
-            -e OOT_MODEL_PATH="${MODEL_PATH}" \
-            -e OOT_EXTRA_ARGS="${{ matrix.extra_args }}" \
-            -e OOT_ENV_VARS="${{ matrix.model_env }}" \
-            -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
-            -e SGLANG_MODEL_PATH="${MODEL_PATH}" \
-            -e SGLANG_EXTRA_ARGS="${{ matrix.extra_args }}" \
-            -e SGLANG_ENV_VARS="${{ matrix.model_env }}" \
-            ${CONTAINER} bash -lc '
-              set -e
-              cd /app/ATOM
-              if [ "${{ matrix.backend }}" = "vllm" ]; then
-                .github/scripts/atom_oot_test.sh accuracy ci
-              else
-                .github/scripts/atom_sglang_test.sh accuracy
-              fi
-            ' 2>&1 | tee kimi_${{ matrix.backend }}_output.txt
+          set -uo pipefail
+          docker exec ${CONTAINER} bash -lc '
+            chmod +x /workspace/.github/scripts/${{ matrix.script }}
+            bash /workspace/.github/scripts/${{ matrix.script }}
+          ' 2>&1 | tee kimi_${{ matrix.backend }}_output.txt
 
       - name: Check gsm8k threshold
         run: |
-          if [ "${{ matrix.backend }}" = "vllm" ]; then
-            RD=/tmp/oot_accuracy_results
-          else
-            RD=/tmp/atom_sglang_accuracy_results
-          fi
-          rf=$(docker exec ${CONTAINER} bash -lc "ls -1t ${RD}/*.json 2>/dev/null | head -1" || true)
-          if [ -z "$rf" ]; then
-            echo "ERROR: no result JSON under ${RD}"; exit 2
-          fi
-          val=$(docker exec ${CONTAINER} bash -lc "jq '.results.gsm8k[\"exact_match,flexible-extract\"]' ${rf}")
+          val=$(grep -oE 'KIMI_FLEX_EXTRACT=[0-9.]+' kimi_${{ matrix.backend }}_output.txt | tail -1 | cut -d= -f2)
+          if [ -z "$val" ]; then echo "ERROR: no KIMI_FLEX_EXTRACT in output"; exit 2; fi
           echo "Kimi-K2.5 ${{ matrix.backend }} flexible-extract=${val} threshold=${ACC_THRESHOLD}"
           if awk -v v="$val" -v t="${ACC_THRESHOLD}" 'BEGIN{exit (v<t)?0:1}'; then
             echo "Accuracy test FAILED: ${val} < ${ACC_THRESHOLD}"; exit 1

--- a/.github/workflows/kimi-downstream.yaml
+++ b/.github/workflows/kimi-downstream.yaml
@@ -1,0 +1,171 @@
+name: Kimi Downstream Test
+
+# End-to-end Kimi-K2.5-MXFP4 accuracy regression for AITER across the vLLM
+# (OOT plugin) and SGLang downstream serving stacks. The ATOM (in-tree) path
+# is covered separately in atom-test.yaml.
+#
+# Each job rebuilds the PR's AITER into the corresponding atom-dev backend image
+# (gfx950) and runs the gsm8k accuracy check via the launch scripts shipped in
+# the image (.github/scripts/atom_oot_test.sh / atom_sglang_test.sh).
+#
+# Verified on MI355X (gfx950) 2026-05-30 with atom-dev:vllm-latest
+# (aiter ef114b0d4), vllm serve TP8: gsm8k 3-shot flexible-extract 0.9409
+# (== amd/Kimi-K2.5-MXFP4 reference). Threshold 0.92 leaves margin.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+  push:
+    branches: [main]
+  schedule:
+    # Nightly, off-peak minute to avoid the top-of-hour stampede.
+    - cron: '17 19 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
+  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
+
+jobs:
+  kimi-downstream:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      (contains(github.event.pull_request.labels.*.name, 'ci:kimi') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:vllm') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:sglang') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:all')))
+    name: Kimi-K2.5 (${{ matrix.backend }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: vllm
+            base_image: rocm/atom-dev:vllm-latest
+            # OOT vllm serve flags (default serve args added by atom_oot_test.sh).
+            extra_args: "--tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384"
+            model_env: "AITER_QUICK_REDUCE_QUANTIZATION=INT4"
+            continue_on_error: false
+          - backend: sglang
+            base_image: rocm/atom-dev:sglang-latest
+            extra_args: "--tensor-parallel-size 8 --trust-remote-code"
+            model_env: "SGLANG_USE_AITER=1"
+            # Non-blocking: SGLang Kimi-K2.5 currently fails to load AMD Quark
+            # MXFP4 per-expert weights (sglang loader bug, tracked separately).
+            # Kept as a visible signal that turns green once the loader is fixed.
+            continue_on_error: true
+    runs-on: linux-aiter-do-mi350x-8
+    continue-on-error: ${{ matrix.continue_on_error }}
+    timeout-minutes: 180
+    env:
+      MODEL_NAME: "Kimi-K2.5-MXFP4"
+      MODEL_PATH: "amd/Kimi-K2.5-MXFP4"
+      ACC_THRESHOLD: "0.92"
+      CONTAINER: "kimi_${{ matrix.backend }}_aiter_test"
+    steps:
+      - name: Download backend base image
+        run: docker pull ${{ matrix.base_image }}
+
+      - name: Generate Dockerfile (rebuild PR AITER into backend image)
+        run: |
+          cat <<EOF > Dockerfile.kimi
+          FROM ${{ matrix.base_image }}
+
+          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
+          RUN pip uninstall -y amd-aiter || true
+          RUN pip install --upgrade "pybind11>=3.0.1"
+          RUN rm -rf /app/aiter-test && \\
+              git clone ${{ env.GITHUB_REPO_URL }} /app/aiter-test && \\
+              cd /app/aiter-test && \\
+              git checkout ${{ env.GITHUB_COMMIT_SHA }} && \\
+              git submodule sync && git submodule update --init --recursive && \\
+              MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 pip install -e .
+          RUN echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true
+          EOF
+          cat Dockerfile.kimi
+
+      - name: Build the Kimi test image
+        run: |
+          docker build --network=host --no-cache \
+            -t rocm/aiter-ci:kimi-${{ matrix.backend }} \
+            -f Dockerfile.kimi .
+
+      - name: Start CI container
+        run: |
+          docker ps -aq -f name=${CONTAINER} | xargs -r docker stop | xargs -r docker rm
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+            --ipc=host --group-add video --shm-size=16G --privileged \
+            --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+            --ulimit memlock=-1 --ulimit stack=67108864 \
+            --network=host \
+            -e HF_TOKEN="${HF_TOKEN:-${{ secrets.HF_TOKEN_TEST }}}" \
+            -v /models:/models \
+            --name ${CONTAINER} \
+            rocm/aiter-ci:kimi-${{ matrix.backend }}
+
+      - name: Check versions
+        run: |
+          docker exec ${CONTAINER} bash -lc "pip show amd-aiter | grep -E 'Version|Location' || true; cd /app/aiter-test && git rev-parse --short HEAD"
+
+      - name: Run Kimi-K2.5 gsm8k accuracy
+        timeout-minutes: 120
+        run: |
+          set -euo pipefail
+          docker exec \
+            -e OOT_MODEL_NAME="${MODEL_NAME}" \
+            -e OOT_MODEL_PATH="${MODEL_PATH}" \
+            -e OOT_EXTRA_ARGS="${{ matrix.extra_args }}" \
+            -e OOT_ENV_VARS="${{ matrix.model_env }}" \
+            -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
+            -e SGLANG_MODEL_PATH="${MODEL_PATH}" \
+            -e SGLANG_EXTRA_ARGS="${{ matrix.extra_args }}" \
+            -e SGLANG_ENV_VARS="${{ matrix.model_env }}" \
+            ${CONTAINER} bash -lc '
+              set -e
+              cd /app/ATOM
+              if [ "${{ matrix.backend }}" = "vllm" ]; then
+                .github/scripts/atom_oot_test.sh accuracy ci
+              else
+                .github/scripts/atom_sglang_test.sh accuracy
+              fi
+            ' 2>&1 | tee kimi_${{ matrix.backend }}_output.txt
+
+      - name: Check gsm8k threshold
+        run: |
+          if [ "${{ matrix.backend }}" = "vllm" ]; then
+            RD=/tmp/oot_accuracy_results
+          else
+            RD=/tmp/atom_sglang_accuracy_results
+          fi
+          rf=$(docker exec ${CONTAINER} bash -lc "ls -1t ${RD}/*.json 2>/dev/null | head -1" || true)
+          if [ -z "$rf" ]; then
+            echo "ERROR: no result JSON under ${RD}"; exit 2
+          fi
+          val=$(docker exec ${CONTAINER} bash -lc "jq '.results.gsm8k[\"exact_match,flexible-extract\"]' ${rf}")
+          echo "Kimi-K2.5 ${{ matrix.backend }} flexible-extract=${val} threshold=${ACC_THRESHOLD}"
+          if awk -v v="$val" -v t="${ACC_THRESHOLD}" 'BEGIN{exit (v<t)?0:1}'; then
+            echo "Accuracy test FAILED: ${val} < ${ACC_THRESHOLD}"; exit 1
+          fi
+          echo "Accuracy test PASSED: ${val} >= ${ACC_THRESHOLD}"
+
+      - name: Upload output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kimi-${{ matrix.backend }}-output
+          path: kimi_${{ matrix.backend }}_output.txt
+
+      - name: Clean up
+        if: always()
+        run: |
+          docker stop ${CONTAINER} || true
+          docker rm ${CONTAINER} || true

--- a/.github/workflows/kimi-perf-downstream.yaml
+++ b/.github/workflows/kimi-perf-downstream.yaml
@@ -1,0 +1,133 @@
+name: Kimi Perf Downstream
+
+# End-to-end Kimi-K2.5-MXFP4 PERFORMANCE regression for AITER against the
+# official nightly downstream images (vLLM + SGLang) on MI350X (gfx950, TP8).
+# Companion to kimi-downstream.yaml (accuracy). Each job builds the PR's AITER
+# from source into the official image, launches the server with the same
+# validated flags as the accuracy gate, runs a throughput sweep
+# (ISL/OSL 1024/1024, concurrency 4..64) and gates on the c=64 output token
+# throughput staying above a conservative floor.
+#
+# Triggered by the `ci:performance` (or `ci:all`) label, nightly schedule, and
+# manual dispatch. NOT run on every push (heavy: builds AITER + loads 521GB).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+  schedule:
+    # Nightly, off-peak, offset from the accuracy run (19:17 UTC).
+    - cron: '43 20 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/aiter.git' }}
+  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
+
+jobs:
+  kimi-perf:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      (contains(github.event.pull_request.labels.*.name, 'ci:performance') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:all')))
+    name: Kimi-K2.5 perf (${{ matrix.backend }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: vllm
+            base_image: rocm/vllm-dev:nightly
+            script: kimi_vllm_perf.sh
+            # Validated MI350X gfx950 TP8: c=64 output 3126.4 tok/s. Floor =
+            # 2250 (~28% margin) absorbs JIT/run-to-run variance.
+            floor_c64: "2250"
+          - backend: sglang
+            base_image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260531
+            script: kimi_sglang_perf.sh
+            # Validated MI350X gfx950 TP8: c=64 output 3284.7 tok/s. Floor =
+            # 2400 (~27% margin) absorbs JIT/run-to-run variance.
+            floor_c64: "2400"
+    runs-on: linux-aiter-do-mi350x-8
+    timeout-minutes: 180
+    env:
+      MODEL_PATH: "amd/Kimi-K2.5-MXFP4"
+      CONTAINER: "kimi_perf_${{ matrix.backend }}_aiter_test"
+      FLOOR_C64: ${{ matrix.floor_c64 }}
+    steps:
+      - name: Checkout AITER (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Pull base image
+        run: docker pull ${{ matrix.base_image }}
+
+      - name: Start CI container
+        run: |
+          docker ps -aq -f name=${CONTAINER} | xargs -r docker stop | xargs -r docker rm
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+            --ipc=host --group-add video --shm-size=16G --privileged \
+            --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+            --ulimit memlock=-1 --ulimit stack=67108864 \
+            --network=host \
+            -e HF_TOKEN="${HF_TOKEN:-${{ secrets.HF_TOKEN_TEST }}}" \
+            -v "${{ github.workspace }}:/workspace" -w /workspace \
+            -v /models:/models \
+            --name ${CONTAINER} \
+            ${{ matrix.base_image }}
+          docker exec ${CONTAINER} git config --global --add safe.directory /workspace || true
+
+      - name: Build & install PR AITER (gfx950)
+        run: |
+          docker exec ${CONTAINER} bash -lc '
+            set -e
+            pip uninstall -y amd-aiter aiter 2>/dev/null || true
+            pip install --upgrade "pybind11>=3.0.1"
+            cd /workspace
+            MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 pip install -e .
+          '
+
+      - name: Run Kimi-K2.5 throughput sweep
+        timeout-minutes: 120
+        run: |
+          set -uo pipefail
+          docker exec ${CONTAINER} bash -lc '
+            chmod +x /workspace/.github/scripts/${{ matrix.script }}
+            bash /workspace/.github/scripts/${{ matrix.script }}
+          ' 2>&1 | tee kimi_perf_${{ matrix.backend }}_output.txt
+
+      - name: Check perf floor (c=64 output tok/s)
+        run: |
+          val=$(grep -oE 'KIMI_PERF_C64_OUT_TOKS=[0-9.]+' kimi_perf_${{ matrix.backend }}_output.txt | tail -1 | cut -d= -f2)
+          if [ -z "$val" ]; then echo "ERROR: no KIMI_PERF_C64_OUT_TOKS in output"; exit 2; fi
+          echo "Kimi-K2.5 ${{ matrix.backend }} c=64 output tok/s = ${val}  (floor ${FLOOR_C64})"
+          if [ "${FLOOR_C64}" = "0" ]; then
+            echo "Floor not set (record-only run); reporting throughput without gating."
+            exit 0
+          fi
+          if awk -v v="$val" -v f="${FLOOR_C64}" 'BEGIN{exit (v<f)?0:1}'; then
+            echo "PERF REGRESSION: ${val} < floor ${FLOOR_C64}"; exit 1
+          fi
+          echo "Perf OK: ${val} >= floor ${FLOOR_C64}"
+
+      - name: Upload output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kimi-perf-${{ matrix.backend }}-output
+          path: kimi_perf_${{ matrix.backend }}_output.txt
+
+      - name: Clean up
+        if: always()
+        run: |
+          docker stop ${CONTAINER} || true
+          docker rm ${CONTAINER} || true

--- a/csrc/kernels/cache_kernels.cu
+++ b/csrc/kernels/cache_kernels.cu
@@ -1256,8 +1256,9 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
     const scalar_t* __restrict__ k,           // [num_tokens, head_dim]
     cache_t* __restrict__ kv_cache,           // [num_blocks, block_size, cache_stride]
     const int64_t* __restrict__ slot_mapping, // [num_tokens]
-    const scalar_t* __restrict__ norm_weight, // [head_dim]
-    const scalar_t* __restrict__ norm_bias,   // [head_dim]
+    // fp32 to match caller's LN params (bf16 cast drops precision).
+    const float* __restrict__ norm_weight,    // [head_dim]
+    const float* __restrict__ norm_bias,      // [head_dim]
     const int64_t* __restrict__ positions,    // [num_tokens]
     const scalar_t* __restrict__ cos_cache,   // [max_position, ..., rope_dim / 2]
     const scalar_t* __restrict__ sin_cache,   // [max_position, ..., rope_dim / 2]
@@ -1341,9 +1342,13 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
     q_amax = block_reduce<float, decltype(max_func), HEAD_DIM, true>(q_amax, max_func);
 
     const float q_fp8_max = static_cast<float>(opus::finfo<cache_t>::max());
-    // Q scale is consumed by weights_out and must match the unfused quant path;
-    // only the K cache scale is encoded as UE8M0 for cache layout compatibility.
-    const float q_scale = fmaxf(q_amax, 1e-10f) / q_fp8_max;
+    // Match unfused per_token_group_quant_fp8: reciprocal-multiply + UE8M0.
+    const float q_inv_fp8_max = 1.0f / q_fp8_max;
+    float q_scale             = fmaxf(q_amax, 1e-10f) * q_inv_fp8_max;
+    if(use_ue8m0)
+    {
+        q_scale = exp2f(ceilf(log2f(q_scale)));
+    }
     const float q_inv_scale = 1.0f / q_scale;
     q_out[token_idx * q_out_stride_t + head_idx * q_out_stride_h + dim * q_out_stride_d] =
         opus::cast<cache_t>(q_val * q_inv_scale);
@@ -1370,8 +1375,7 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
     float ss = block_reduce<float, decltype(sum_func), HEAD_DIM, true>(centered * centered, sum_func);
     const float inv_std = rsqrtf(ss / static_cast<float>(HEAD_DIM) + epsilon);
 
-    float k_val = centered * inv_std * static_cast<float>(norm_weight[dim]) +
-                  static_cast<float>(norm_bias[dim]);
+    float k_val = centered * inv_std * norm_weight[dim] + norm_bias[dim];
     k_val = static_cast<float>(static_cast<scalar_t>(k_val));
     normed[dim] = k_val;
     __syncthreads();
@@ -3151,8 +3155,8 @@ void reshape_and_cache_flash(
                                      reinterpret_cast<KV_T*>(k.data_ptr()),                       \
                                      reinterpret_cast<CACHE_T*>(kv_cache.data_ptr()),             \
                                      reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),          \
-                                     reinterpret_cast<KV_T*>(norm_weight.data_ptr()),              \
-                                     reinterpret_cast<KV_T*>(norm_bias.data_ptr()),                \
+                                     reinterpret_cast<float*>(norm_weight.data_ptr()),             \
+                                     reinterpret_cast<float*>(norm_bias.data_ptr()),               \
                                      reinterpret_cast<int64_t*>(positions.data_ptr()),             \
                                      reinterpret_cast<KV_T*>(cos_cache.data_ptr()),                \
                                      reinterpret_cast<KV_T*>(sin_cache.data_ptr()),                \
@@ -3689,8 +3693,8 @@ void indexer_qk_rope_quant_and_cache(
     AITER_CHECK(q_out.dtype() == AITER_DTYPE_fp8, "q_out dtype must be fp8");
     AITER_CHECK(weights.dtype() == q.dtype(), "weights dtype must match q dtype");
     AITER_CHECK(weights_out.dtype() == AITER_DTYPE_fp32, "weights_out dtype must be fp32");
-    AITER_CHECK(norm_weight.dtype() == q.dtype(), "norm_weight dtype must match q dtype");
-    AITER_CHECK(norm_bias.dtype() == q.dtype(), "norm_bias dtype must match q dtype");
+    AITER_CHECK(norm_weight.dtype() == AITER_DTYPE_fp32, "norm_weight dtype must be fp32");
+    AITER_CHECK(norm_bias.dtype() == AITER_DTYPE_fp32, "norm_bias dtype must be fp32");
     AITER_CHECK(cos_cache.dtype() == q.dtype(), "cos_cache dtype must match q dtype");
     AITER_CHECK(sin_cache.dtype() == q.dtype(), "sin_cache dtype must match q dtype");
     AITER_CHECK(norm_weight.size(0) == head_dim, "norm_weight size must match head_dim");


### PR DESCRIPTION
Experimental: PR #3441's Kimi/ATOM CI gates + cherry-pick of frida-andersson's DSv3.2 indexer kernel fix (commit 423f22a8 from #3451, `csrc/kernels/cache_kernels.cu`). Purpose: verify the fix makes `Sglang DeepSeek-V3.2 Accuracy` pass (it fails on main today). NOT for merge — if green, the real fix is #3451. Credit: @frida-andersson.