### PR TITLE
[gfx1151] flash_attn_triton_amd: enable in-thread transpose

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -2,6 +2,7 @@ import warnings
 import torch
 import triton
 import triton.language as tl
+from triton import knobs
 from typing import Literal, Optional
 from .common import compute_alibi_block, compute_fp8_scaling_factors, apply_rotary
 from .utils import (
@@ -13,6 +14,15 @@ from .utils import (
     is_fp8,
     remap_xcd,
 )
+
+# gfx1151 (Strix Halo / RDNA3.5): enable Triton's in-thread transpose for the
+# prefill FMHA kernels. It is only enabled by default for gfx1151 on Triton's
+# main branch (the upcoming 3.8); the Triton version in use here still gates it
+# to gfx942, so enable it explicitly. It is a consistent win (e.g. ~11% faster
+# on ViT-style d=72, sq=sk>=3200 shapes). Only set it when the user has not made
+# an explicit choice via TRITON_HIP_USE_IN_THREAD_TRANSPOSE.
+if knobs.amd.use_in_thread_transpose is None and get_arch().name == "gfx1151":
+    knobs.amd.use_in_thread_transpose = True
 
 FWD_PREFILL_AUTOTUNE_KEYS = [
     "IS_CAUSAL",


### PR DESCRIPTION
Stacked on top of #3419.

Triton only enables its AMD in-thread-transpose pass for gfx1151 by default on
its main branch (the upcoming 3.8); the Triton version in use here still gates it
to gfx942 (`knobs.amd.use_in_thread_transpose` defaults to `None` →
`arch == "gfx942"`). On gfx1151 (RDNA3.5) the prefill FMHA kernels are LDS-bound
and benefit from it, so this turns it on at kernel import time — gated on arch
and on the user not having set `TRITON_HIP_USE_IN_THREAD_TRANSPOSE` explicitly.

### Benchmarks

gfx1151, triton `3.6.0+rocm7.14.0a20260601`, `dao_ai` `fwd_varlen`, fp16,
causal=False, b1 hq16 hk16.
Min ms over a warm-clock `do_bench` window (min is robust to the iGPU's DVFS):

| shape (sq=sk, d) | ITT off | ITT on | speedup |
|---|---|---|---|
| 1024, d72 | 0.447 | 0.443 | +0.9% |
| 2048, d72 | 1.299 | 1.198 | +7.8% |
| 3200, d72 | 2.801 | 2.479 | **+11.5%** |
| 4096, d72 | 4.545 | 4.045 | **+11.0%** |
| 3200, d64 | 1.660 | 1.592 | +4.1% |
| 3200, d128 | 3.314 | 3.096 | +6.6% |

Win is largest for the ViT-style d=72 long-sequence shapes this kernel targets;
no shape regressed. An explicit `TRITON_HIP_USE_IN_THREAD_TRANSPOSE` override is
still respected so the pass can be forced on/off for debugging.
