### PR TITLE
configs: tune gfx1201 Qwen3-8B-FP8 blockscale GEMMs

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=24576-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=24576-K=4096.json
@@ -1,0 +1,50 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 1,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_1024": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=4096-K=12288.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=4096-K=12288.json
@@ -1,0 +1,50 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_1024": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=4096-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=4096-K=4096.json
@@ -1,0 +1,50 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_1024": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=6144-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx1201-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED-N=6144-K=4096.json
@@ -1,0 +1,50 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 1,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_1024": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}


### PR DESCRIPTION
## Summary
- Add gfx1201 shape-specific `GEMM-A8W8_BLOCKSCALE_PRESHUFFLED` tuning configs for Qwen3-8B-FP8 hot shapes.
- Cover both decode (`M_LEQ_8`) and prefill (`M_LEQ_512`, `M_LEQ_1024`) paths.
- Intended to support ROCm/ATOM#811 Qwen3-8B-FP8 on RX 9070 XT / gfx1201.

## Shapes
- `N=24576,K=4096` gate/up
- `N=4096,K=12288` down
- `N=6144,K=4096` qkv
- `N=4096,K=4096` out

## Test result
Measured through ATOM Qwen3-8B-FP8 serving on RX 9070 XT / gfx1201, BF16 KV, TP=1, `--level 0`, `ISL/OSL=549/256`.

| Concurrency | Baseline output tok/s | Tuned output tok/s | Baseline total tok/s | Tuned total tok/s | Tuned TTFT | Tuned TPOT |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 49.55 | 51.96 | 158.04 | 165.74 | 197.8 ms | 18.46 ms |
| 4 | 141.65 | 177.99 | 448.06 | 563.02 | 249.0 ms | 20.95 ms |
| 8 | 226.20 | 275.54 | 715.72 | 871.81 | 1190.8 ms | 22.03 ms |

## Notes
- Profiling showed GEMM dominates Qwen3-8B-FP8 on gfx1201: ~82% of decode GPU kernel time and ~96% of prefill GPU kernel time.
- A dynamic fused Silu+quant experiment was slower on gfx1201, so this PR keeps the optimization limited to tuning configs.