### PR TITLE
[Triton] skip Flash attention v3 tests on RDNA

### DIFF
--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -254,6 +254,7 @@ jobs:
       # Flash Attention v3 (Hopper)
       # ===========================================
       - name: Generate Dockerfile (v3)
+        if: ${{ matrix.label == 'MI35X' }}
         run: |
           cat <<'EOF' > Dockerfile.triton_v3
           FROM ${{ env.BASE_IMAGE }}
@@ -277,9 +278,11 @@ jobs:
           EOF
 
       - name: Build Docker image (v3)
+        if: ${{ matrix.label == 'MI35X' }}
         run: docker build -t fa_triton_v3_test:ci -f Dockerfile.triton_v3 .
 
       - name: Start CI container (v3)
+        if: ${{ matrix.label == 'MI35X' }}
         run: |
           docker ps -aq -f name=fa_triton_v3_test | xargs -r docker stop | xargs -r docker rm || true
 
@@ -300,7 +303,7 @@ jobs:
             fa_triton_v3_test:ci
 
       - name: PR correctness tests (v3)
-        if: ${{ github.event_name != 'push' }}
+        if: ${{ github.event_name != 'push' && matrix.label == 'MI35X' }}
         timeout-minutes: 90
         run: |
           docker exec fa_triton_v3_test bash -c "
@@ -333,7 +336,7 @@ jobs:
           "
 
       - name: Clean up v3 container
-        if: always()
+        if: ${{ always() && matrix.label == 'MI35X' }}
         run: |
           docker stop fa_triton_v3_test || true
           docker rm -f fa_triton_v3_test || true


### PR DESCRIPTION
## Motivation

This skips fa v3 tests on RDNA. We only need the CDNA results. Flash attention v3 is mostly about fp8 support which is not supported in our RDNA hardware. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
