### PR TITLE
fix(triton/decode): honor real paged KV block stride (support non-contiguous cache)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
@@ -332,6 +332,8 @@ def _fwd_kernel_splitK(
     stride_vn_d,
     stride_bt_b,
     stride_bt_s,
+    stride_kb,  # paged K block stride (k_cache.stride(0)); supports non-contiguous cache
+    stride_vb,  # paged V block stride (v_cache.stride(0))
     stride_az,
     stride_ah,
     stride_q_descale_z,  # FP8 descale strides
@@ -377,6 +379,8 @@ def _fwd_kernel_splitK(
     stride_qd_i64 = tl.cast(stride_qd, tl.int64)
     stride_kz_i64 = tl.cast(stride_kz, tl.int64)
     stride_kn_i64 = tl.cast(stride_kn, tl.int64)
+    stride_kb_i64 = tl.cast(stride_kb, tl.int64)
+    stride_vb_i64 = tl.cast(stride_vb, tl.int64)
     stride_kg_i64 = tl.cast(stride_kg, tl.int64)
     stride_kh_i64 = tl.cast(stride_kh, tl.int64)
     stride_kd_i64 = tl.cast(stride_kd, tl.int64)
@@ -556,13 +560,13 @@ def _fwd_kernel_splitK(
                     # Calculate base addresses for K and V in this physical block
                     k_base = (
                         K
-                        + physical_block * BLOCK_SIZE_K * stride_kn_i64
+                        + physical_block * stride_kb_i64
                         + hk_id * stride_kh_i64
                         + g_id * stride_kg_i64
                     )
                     v_base = (
                         V
-                        + physical_block * BLOCK_SIZE_K * stride_vn_i64
+                        + physical_block * stride_vb_i64
                         + hv_id * stride_vh_i64
                         + g_id * stride_vg_i64
                     )
@@ -1372,6 +1376,11 @@ def attention_forward_decode_triton_impl(
         # block table strides
         stride_bt_b=stride_bt_b,
         stride_bt_s=stride_bt_s,
+        # paged KV block strides (real k/v_cache.stride(0)); lets the kernel
+        # index a non-contiguous paged cache instead of assuming the block
+        # stride equals BLOCK_SIZE_K * stride_kn (contiguous-only).
+        stride_kb=(k_cache.stride(0) if use_block_table else 0),
+        stride_vb=(v_cache.stride(0) if use_block_table else 0),
         # alibi strides
         stride_az=stride_az,
         stride_ah=stride_ah,

--- a/op_tests/triton_tests/attention/test_mha_v3.py
+++ b/op_tests/triton_tests/attention/test_mha_v3.py
@@ -174,6 +174,49 @@ def _generate_block_kvcache(
     return k_cache, v_cache, block_table, k_cache_paged, v_cache_paged, num_blocks
 
 
+def _generate_interleaved_block_kvcache(
+    seqlen_k, paged_kv_block_size, batch_size, nheads_k, d, device, dtype
+):
+    """Paged KV cache stored block-major with K and V interleaved per block
+    ([num_blocks, 2, block_size, nheads_k, d]) -- the layout vLLM hybrid
+    attention+mamba models use.
+
+    The per-component K/V caches are *non-contiguous* views of the backing
+    buffer: their block stride is ``2 * block_size * nheads_k * d`` (twice what a
+    contiguous ``[num_blocks, block_size, nheads_k, d]`` cache would have). This
+    is the case the split-K decode kernel must honor by reading the real
+    ``stride(0)`` instead of assuming ``block_size * slot_stride``.
+    """
+    num_blocks = math.ceil(seqlen_k / paged_kv_block_size) * batch_size * 3
+    kv_cache_paged = torch.randn(
+        num_blocks,
+        2,
+        paged_kv_block_size,
+        nheads_k,
+        d,
+        device=device,
+        dtype=dtype,
+    )
+    k_cache_paged = kv_cache_paged[:, 0]  # non-contiguous view, stride(0) = 2*...
+    v_cache_paged = kv_cache_paged[:, 1]
+    block_table = rearrange(
+        torch.randperm(num_blocks, dtype=torch.int32, device=device),
+        "(b nblocks) -> b nblocks",
+        b=batch_size,
+    )
+    k_cache = rearrange(
+        k_cache_paged[block_table.to(dtype=torch.long).flatten()],
+        "(b nblocks) block_size ... -> b (nblocks block_size) ...",
+        b=batch_size,
+    )[:, :seqlen_k]
+    v_cache = rearrange(
+        v_cache_paged[block_table.to(dtype=torch.long).flatten()],
+        "(b nblocks) block_size ... -> b (nblocks block_size) ...",
+        b=batch_size,
+    )[:, :seqlen_k]
+    return k_cache, v_cache, block_table, k_cache_paged, v_cache_paged, num_blocks
+
+
 @pytest.mark.parametrize("mha_type", ["mha", "gqa"])
 @pytest.mark.parametrize("new_kv", [False, True])
 @pytest.mark.parametrize("causal", [False, True])
@@ -344,6 +387,145 @@ def test_flash_attn_kvcache(
     assert our_max_diff <= mult * pt_max_diff + 1e-5, (
         f"Output max diff {our_max_diff:.6e} exceeds "
         f"{mult}x Pytorch baseline diff {pt_max_diff:.6e} + 1e-5"
+    )
+
+
+@pytest.mark.parametrize("mha_type", ["mha", "gqa"])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("paged_kv_block_size", [16, 256])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 339),
+        (3, 1024),
+        (17, 156),
+    ],
+)
+@pytest.mark.parametrize("d", [64, 128])
+def test_flash_attn_kvcache_noncontiguous_paged(
+    seqlen_q,
+    seqlen_k,
+    d,
+    paged_kv_block_size,
+    causal,
+    mha_type,
+):
+    """Paged decode against a non-contiguous (K/V-interleaved) paged cache.
+
+    Regression guard for the split-K decode kernel previously hard-coding the
+    paged block stride as ``block_size * slot_stride`` (contiguous-only). With an
+    interleaved ``[num_blocks, 2, block_size, nheads_k, d]`` cache the real block
+    stride is ``2 * block_size * nheads_k * d``; before the fix the kernel read
+    K/V-straddling block memory and produced garbage attention. The dense
+    reference is gathered from the same paged buffer, so this pins correct
+    numerics for any regular paged layout, contiguous or interleaved.
+    """
+    dtype = torch.bfloat16
+    device = "cuda"
+    torch.random.manual_seed(SEED)
+    torch.cuda.manual_seed(SEED)
+    batch_size = 2
+    nheads = 6
+    nheads_k = nheads if mha_type == "mha" else 3
+    assert nheads % nheads_k == 0
+
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
+
+    (
+        k_cache,
+        v_cache,
+        block_table,
+        k_cache_paged,
+        v_cache_paged,
+        num_blocks,
+    ) = _generate_interleaved_block_kvcache(
+        seqlen_k, paged_kv_block_size, batch_size, nheads_k, d, device, dtype
+    )
+
+    # Sanity: the views must really be non-contiguous (block stride == 2x), else
+    # this test would silently degrade to the contiguous case and stop guarding
+    # the fix.
+    assert not k_cache_paged.is_contiguous()
+    assert not v_cache_paged.is_contiguous()
+    assert k_cache_paged.stride(0) == 2 * paged_kv_block_size * nheads_k * d
+
+    cache_seqlens = torch.randint(
+        1, seqlen_k + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+
+    arange = rearrange(torch.arange(seqlen_k, device=device), "s -> 1 s")
+    key_padding_mask = arange < rearrange(cache_seqlens, "b -> b 1")
+
+    k_cache_rep = repeat(k_cache, "b s h d -> b s (h g) d", g=nheads // nheads_k)
+    v_cache_rep = repeat(v_cache, "b s h d -> b s (h g) d", g=nheads // nheads_k)
+
+    out = flash_attn_with_kvcache(
+        q,
+        k_cache_paged,
+        v_cache_paged,
+        cache_seqlens=cache_seqlens,
+        page_table=block_table,
+        causal=causal,
+    )
+    torch.cuda.synchronize()
+    if isinstance(out, tuple):
+        out = out[0]
+    out = out.to(dtype)
+
+    out_ref, _ = attention_ref(
+        q,
+        k_cache_rep,
+        v_cache_rep,
+        None,
+        key_padding_mask,
+        None,
+        0.0,
+        None,
+        causal=causal,
+        window_size=(-1, -1),
+    )
+    out_pt, _ = attention_ref(
+        q,
+        k_cache_rep,
+        v_cache_rep,
+        None,
+        key_padding_mask,
+        None,
+        0.0,
+        None,
+        causal=causal,
+        window_size=(-1, -1),
+        upcast=False,
+        reorder_ops=True,
+    )
+
+    pt_max_diff = (out_pt - out_ref).abs().max().item()
+    our_max_diff = (out - out_ref).abs().max().item()
+    mult = 3
+    assert our_max_diff <= mult * pt_max_diff + 1e-5, (
+        f"Non-contiguous paged output max diff {our_max_diff:.6e} exceeds "
+        f"{mult}x Pytorch baseline diff {pt_max_diff:.6e} + 1e-5"
+    )
+
+    # The exact same data laid out in a *contiguous* paged cache must produce the
+    # same result -- this directly pins the kernel to the real block stride
+    # rather than the contiguous-only assumption.
+    out_contig = flash_attn_with_kvcache(
+        q,
+        k_cache_paged.contiguous(),
+        v_cache_paged.contiguous(),
+        cache_seqlens=cache_seqlens,
+        page_table=block_table,
+        causal=causal,
+    )
+    torch.cuda.synchronize()
+    if isinstance(out_contig, tuple):
+        out_contig = out_contig[0]
+    out_contig = out_contig.to(dtype)
+    contig_diff = (out - out_contig).abs().max().item()
+    assert contig_diff < 1e-5, (
+        f"Non-contiguous vs contiguous paged cache differ by {contig_diff:.6e} "
+        "(> 1e-5): the kernel is not honoring the real paged block stride"
     )
 
 


### PR DESCRIPTION

attention_forward_decode_triton_impl's split-K kernel computed the paged block base address as `physical_block * BLOCK_SIZE_K * stride_kn`, i.e. it reconstructed the per-block stride as block_size * slot_stride and thus assumed the paged KV cache is contiguous.

This is wrong for callers whose key_cache / value_cache are non-contiguous views of the paged buffer. In particular, vLLM hybrid attention+mamba models store the KV cache block-major with K/V interleaved per block ([num_blocks, 2, block_size, num_kv_heads, head_size]); the attention halves obtained via kv_cache.unbind(0) are non-contiguous with block stride 2 * block_size * num_kv_heads * head_size, i.e. 2x what the kernel assumed. The kernel then reads the wrong block memory (straddling K and V) and produces garbage attention output.

Thread the real block stride (k_cache.stride(0) / v_cache.stride(0)) into the kernel and use it for the K/V block base instead of BLOCK_SIZE_K * stride_kn. This is a no-op for contiguous caches (stride(0) == BLOCK_SIZE_K * stride_kn) and makes the kernel correct for any regular paged layout, contiguous or interleaved.

Validated on an interleaved (stride(0)=8192) paged cache: max abs error vs a brute-force reference dropped from ~6.3 to bf16 noise (~0.09); contiguous caches are unchanged.

Internal ticket:
ROCM-25540

