### PR TITLE
CI: remove internal pip index from vLLM benchmark

### DIFF
--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -98,7 +98,6 @@ jobs:
               pip uninstall -y aiter amd-aiter || true
               pip config set global.default-timeout 60
               pip config set global.retries 10
-              pip config set global.index-url https://ausartifactory.amd.com/artifactory/api/pypi/hw-cpe-prod-remote/simple
               pip install -r requirements.txt
               pip install --upgrade pandas pyzmq einops numpy==1.26.2
               pip install --upgrade "pybind11>=3.0.1"


### PR DESCRIPTION
## Summary
- Remove the AMD Artifactory pip index override from the vLLM benchmark wheel build.
- Let pip use its default package index so transient internal mirror failures do not block CI dependency installation.

## Test plan
- python3 - <<'PY'
import yaml
with open('.github/workflows/vllm_benchmark.yaml') as f:
    yaml.safe_load(f)
print('vllm_benchmark.yaml parsed successfully')
PY
- git diff --check -- .github/workflows/vllm_benchmark.yaml