### PR TITLE
Autotune MoE sorting dispatch: runtime kernel selection between oneshot and multi-phase paths

### DIFF
--- a/csrc/include/moe_sorting_opus.h
+++ b/csrc/include/moe_sorting_opus.h
@@ -37,6 +37,8 @@ void moe_sorting_opus_fwd(aiter_tensor_t& topk_ids,
 #include <hip/hip_runtime.h>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
+#include <utility>
 
 #include "opus/opus.hpp"
 
@@ -3238,9 +3240,11 @@ moe_sorting_opus_get_workspace_size(int tokens, int num_experts, int topk, int d
     return aiter::moe_sorting_get_workspace_size(tokens, num_experts, topk, dispatch_policy);
 }
 
-// Forward declaration
+// Forward declarations
 inline float
 moe_sorting_opus_mp(moe_sorting_opus_trait t, moe_sorting_opus_args a, aiter::stream_config s);
+inline float
+moe_sorting_opus_oneshot(moe_sorting_opus_trait t, moe_sorting_opus_args a, aiter::stream_config s);
 
 // ---------------------------------------------------------------------------
 // Dispatch macros
@@ -3495,15 +3499,10 @@ moe_sorting_opus_mp(moe_sorting_opus_trait t, moe_sorting_opus_args a, aiter::st
 // Main API functions
 
 inline float
-moe_sorting_opus(moe_sorting_opus_trait t, moe_sorting_opus_args a, aiter::stream_config s)
+moe_sorting_opus_oneshot(moe_sorting_opus_trait t, moe_sorting_opus_args a, aiter::stream_config s)
 {
     if(t.weight_type == "fp32" && t.index_type == "i32")
     {
-        if(moe_sorting_opus_get_workspace_size(
-               a.tokens, a.num_experts, a.topk, t.dispatch_policy) != 0)
-        {
-            return moe_sorting_opus_mp(t, a, s);
-        }
         using ms_weight_type         = float;
         auto sub_token_              = aiter::moe_sorting_get_sub_token(a.tokens, a.num_experts);
         auto row_                    = sub_token_ / 8;
@@ -3514,6 +3513,61 @@ moe_sorting_opus(moe_sorting_opus_trait t, moe_sorting_opus_args a, aiter::strea
         OPUS_MOE_SORTING_DISPATCH_EMASK_(row_);
     }
     return -1;
+}
+
+inline float
+moe_sorting_opus(moe_sorting_opus_trait t, moe_sorting_opus_args a, aiter::stream_config s)
+{
+    if(t.dispatch_policy == 1)
+        return moe_sorting_opus_oneshot(t, a, s);
+    if(t.dispatch_policy == 2)
+        return moe_sorting_opus_mp(t, a, s);
+
+    if(!aiter::moe_sorting_is_oneshot(a.tokens, a.num_experts))
+        return moe_sorting_opus_mp(t, a, s);
+
+    using autotune_key_t = std::pair<int, int>;
+    struct autotune_key_hash
+    {
+        std::size_t operator()(const autotune_key_t& k) const noexcept
+        {
+            return (static_cast<std::size_t>(static_cast<uint32_t>(k.first)) << 32) ^
+                   static_cast<uint32_t>(k.second);
+        }
+    };
+    static auto& cache =
+        *new std::unordered_map<autotune_key_t, bool, autotune_key_hash>();
+
+    autotune_key_t key{a.tokens, a.num_experts};
+    auto it = cache.find(key);
+    if(it != cache.end())
+        return it->second ? moe_sorting_opus_oneshot(t, a, s)
+                          : moe_sorting_opus_mp(t, a, s);
+
+    auto time_path = [&](float (*fn)(moe_sorting_opus_trait,
+                                     moe_sorting_opus_args,
+                                     aiter::stream_config)) -> float {
+        hipEvent_t ev_start = nullptr, ev_stop = nullptr;
+        hipEventCreate(&ev_start);
+        hipEventCreate(&ev_stop);
+        hipEventRecord(ev_start, s.stream_id_);
+        fn(t, a, s);
+        hipEventRecord(ev_stop, s.stream_id_);
+        hipEventSynchronize(ev_stop);
+        float ms = 0.0f;
+        hipEventElapsedTime(&ms, ev_start, ev_stop);
+        hipEventDestroy(ev_start);
+        hipEventDestroy(ev_stop);
+        return ms;
+    };
+
+    float t_oneshot  = time_path(moe_sorting_opus_oneshot);
+    float t_mp       = time_path(moe_sorting_opus_mp);
+    bool use_oneshot = t_oneshot <= t_mp;
+    cache[key]       = use_oneshot;
+
+    return use_oneshot ? moe_sorting_opus_oneshot(t, a, s)
+                       : moe_sorting_opus_mp(t, a, s);
 }
 
 inline float


### PR DESCRIPTION
## Motivation
The oneshot MoE sorting kernel runs on a single CU and wins for small token counts, but the multi-phase (MP) kernel distributes work across all CUs and is faster past a hardware-dependent crossover. The current dispatch heuristic (`moe_sorting_is_oneshot`) only checks LDS capacity — whether oneshot *can* run — not whether it *should*. On gfx950 with 128 experts, oneshot is selected up to ~61 tokens even though MP is faster past ~20 tokens.
A fixed threshold doesn't generalize: the crossover depends on CU count, memory subsystem, and expert count, which vary across CDNA generations (gfx90a/gfx942/gfx950) and models (8 to 256 experts).
## Technical Details
Refactors `moe_sorting_opus()` into `moe_sorting_opus_oneshot()` + an autotuned dispatcher in `csrc/include/moe_sorting_opus.h`.
On first encounter of each `(tokens, num_experts)` pair with `dispatch_policy=0`:
1. LDS capacity check — if oneshot doesn't fit, go straight to MP (unchanged behavior)
2. Time both oneshot and MP with `hipEvent` on the current stream
3. Cache the winner in a static `unordered_map`
4. Re-run the winner to produce correct output
Subsequent calls with the same pair hit the cache (~ns lookup, zero GPU overhead). Autotuning cost is ~80 unique pairs × 3 kernel launches = ~240 launches, absorbed by vLLM's existing warmup phase.
`dispatch_policy=1` (force oneshot) and `dispatch_policy=2` (force MP) bypass the autotune entirely and behave exactly as before.
### Safety
- **Strict superset of the old behavior:** above the LDS capacity limit the codepath is identical. Below it, the autotune either agrees with the old heuristic (same perf) or switches to MP (only if MP measured faster).
- **No impact on non-MoE models:** the function is never called for dense architectures.
- **No impact on few-expert MoE models** (e.g. Mixtral, 8 experts): `tokens × 8` rarely enters the autotunable zone; the LDS capacity check handles dispatch.
## Test Plan
- Existing `op_tests/test_moe_sorting.py` for correctness at all rerouted shapes
- 5-repeat A/B serving benchmarks (ISL=1000, OSL=100, random dataset) on two MoE models with different expert counts and TP configurations
## Test Result
Measured on gfx950 (MI355X), vLLM 0.22.0:
| Model | conc=16 | conc=32 | conc=64 |
|---|---|---|---|
| openai/gpt-oss-120b (128 experts, TP=1) | +4.1% tput, −1.9% TPOT | +2.0% tput, −1.7% TPOT | +1.3% tput (flat TPOT) |
| MiniMaxAI/MiniMax-M2.5 (TP=4) | +6.0% tput, −4.4% TPOT | +5.4% tput, −3.7% TPOT | +1.3% tput (flat TPOT) |
No regressions at any concurrency level on either model.