### PR TITLE
Route MXFP4 1-stage decode through fused quant+sort path

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -563,7 +563,33 @@ def fused_moe_1stage(
             activation,
         )
     else:
-        if xbf16:
+        token_num = hidden_states.shape[0]
+        E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+        if quant_type == QuantType.per_1x32:
+            if hidden_states.dtype == q_dtype_a:
+                assert a1_scale is not None, \
+                    "a1_scale must be provided for pre-quantized FP4 input"
+                a1 = hidden_states
+                a1_scale = mxfp4_moe_sort_fwd(
+                    a1_scale,
+                    sorted_ids=sorted_ids,
+                    num_valid_ids=num_valid_ids,
+                    token_num=token_num,
+                    cols=model_dim,
+                )
+            else:
+                a1, a1_scale = fused_dynamic_mxfp4_quant_moe_sort(
+                    hidden_states,
+                    sorted_ids=sorted_ids,
+                    num_valid_ids=num_valid_ids,
+                    token_num=token_num,
+                    topk=topk,
+                    block_size=block_size_M,
+                    num_rows=num_local_tokens,
+                )
+            w1_scale = w1_scale.view(E, -1)
+            w2_scale = w2_scale.view(E, -1)
+        elif xbf16:
             # xquant happens inside the asm kernel for per_1x128
             a1 = hidden_states
             a1_scale = torch.empty(0, device="cuda")
@@ -589,19 +615,6 @@ def fused_moe_1stage(
                         scale_t, a1_scale, num_rows=num_local_tokens
                     )
                     a1_scale = scale_t
-
-        token_num = hidden_states.shape[0]
-        E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
-        if quant_type == QuantType.per_1x32:
-            a1_scale = mxfp4_moe_sort_fwd(
-                a1_scale,
-                sorted_ids=sorted_ids,
-                num_valid_ids=num_valid_ids,
-                token_num=token_num,
-                cols=model_dim,
-            )
-            w1_scale = w1_scale.view(E, -1)
-            w2_scale = w2_scale.view(E, -1)
 
         if quant_type == QuantType.per_1x128:
             fmoe_func = functools.partial(


### PR DESCRIPTION
## Motivation

The 1-stage MXFP4 MoE decode path quantizes activations and sorts them by expert in two separate kernel launches. The activation scale is written to VRAM by the quantization kernel and immediately read back by `mxfp4_moe_sort_fwd` — a global memory roundtrip for data that could stay on-chip.

The fused kernel `fused_dynamic_mxfp4_quant_moe_sort` already exists and handles both operations in a single launch at small M (decode batch sizes), but the 1-stage dispatch path (`fused_moe_1stage`) was not using it.

## Technical Details

Single-file change to `aiter/fused_moe.py`. In the `fused_moe_1stage` else-branch, the `per_1x32` (MXFP4) case is now handled before the `xbf16`/generic branches:

- **Fresh bf16/fp16 activations**: routed through `fused_dynamic_mxfp4_quant_moe_sort`, which collapses quant+sort into one launch at small M and internally falls back to the same split kernels at large M. Results are byte-identical.
- **Pre-quantized FP4 inputs** (from FP4 dispatch): kept on the existing `mxfp4_moe_sort_fwd` sort-only path since there is nothing to re-quantize.

The redundant standalone `per_1x32` block that ran `mxfp4_moe_sort_fwd` after the generic quantization is removed.

Note: the 2-stage path (`fused_moe_2stages`) already uses `fused_dynamic_mxfp4_quant_moe_sort` at lines 1691/1806. This change brings the 1-stage path to parity.

## Test Plan

- Verified that `fused_dynamic_mxfp4_quant_moe_sort` supports all arguments passed by the 1-stage path (`sorted_ids`, `num_valid_ids`, `token_num`, `topk`, `block_size`, `num_rows`).
- E2E serving benchmarks on GPT-OSS-120b (gfx950 / MI355X, vLLM 0.22.0, MXFP4 quantization).

## Test Result

Measured on gfx950 (MI355X), 3-repeat, ISL=1000/OSL=100:

| Model | conc=16 | conc=32 |
|---|---|---|
| openai/gpt-oss-120b (128 experts, TP=1) | +3.2% throughput, −2.0% TPOT | +4.2% throughput, −4.3% TPOT |

No regressions. Only affects models using MXFP4 quantization (`quant_type == per_1x32`).

