### PR TITLE
fix(flydsl_moe_stage1): pre-zero output when inter_dim_pad > 0

### DIFF
--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -774,6 +774,34 @@ def flydsl_moe_stage1(
                 (token_num, topk, inter_dim), dtype=torch_out_dtype, device=dev
             )
 
+    # Workaround: stage1 launcher computes grid_x from the *valid* inter_dim
+    # (= inter_dim - 2*inter_dim_pad in the SEPARATED gate-mode path; see
+    # `launch_mixed_moe_gemm1` in kernels/mixed_moe_gemm_2stage.py around the
+    # `gx = (inter_in - inter_dim_pad_total + ...) / tile_n / 2` block).
+    # When the resulting CTA grid doesn't cover the *padded* output tail, the
+    # last output tile is never written by any CTA, and the consumer (swiglu /
+    # stage2 quant) ends up reading uninitialised memory.
+    #
+    # Concrete repro on gpt-oss-120b TP=2 (per-rank inter_dim=1536, valid=1440,
+    # pad=96) with the tuned kernel
+    # `flydsl_moe1_afp4_wfp4_bf16_t64x64x256_w4_bnt0`:
+    #   gx = (1536 - 192 + 128 - 1) / 64 / 2 = 11
+    # which covers 22 output tiles, missing tile index 23 -> output positions
+    # [1472:1536] retain whatever was previously in the buffer. GSM8K@TP=2
+    # collapses from 0.90+ to <0.10. Pre-zeroing the buffer makes the unwritten
+    # padded tail read as 0, which is the semantically correct value for the
+    # pad region (silu(0) * up = 0; downstream stage2 then contributes 0 from
+    # the padded columns).
+    #
+    # Note: torch.zero_() isn't implemented for Float4_e2m1fn_x2 / fp8 dtypes;
+    # for those out variants we view the buffer as uint8 (bit-pattern zero is
+    # the additive identity for both fp4_e2m1 and fp8_e4m3/e5m2).
+    if inter_dim_pad > 0 and not _is_splitk:
+        if out.dtype in (dtypes.bf16, dtypes.fp16, torch.float32):
+            out.zero_()
+        else:
+            out.view(torch.uint8).zero_()
+
     if _is_splitk:
         torch_tmp_out_dtype = dtypes.bf16 if _base_out_dtype == "bf16" else dtypes.fp16
         tmp_out = torch.zeros(


### PR DESCRIPTION
The stage1 launcher (`launch_mixed_moe_gemm1` in
`kernels/mixed_moe_gemm_2stage.py`) computes the N-direction grid from the
*valid* inter_dim — subtracting `2*inter_dim_pad` in the SEPARATED gate-mode
path — so the CTA grid covers only the valid output tiles. When the
resulting grid doesn't reach the *padded* output tail, the last output tile
is never written by any CTA, leaving its contents whatever was previously
in the buffer.

Concrete repro on gpt-oss-120b TP=2 (per-rank inter_dim=1536, valid=1440,
pad=96) with the tuned kernel
`flydsl_moe1_afp4_wfp4_bf16_t64x64x256_w4_bnt0`:

    gx = (1536 - 192 + 128 - 1) / 64 / 2 = 11   # covers 22 of 24 output tiles
                                                # tile 23 (= positions [1472:1536])
                                                # is never written

The unwritten tail is then read by swiglu / stage2 quant and causes GSM8K
accuracy to collapse from 0.90+ to <0.10. The `t64x128x256_w3_bnt0`
variant doesn't trip the bug because its grid happens to align with the
padded output (`gx = 6 * 2 = 12 == 1536/128 = 12 tiles`).

Fix: pre-zero `out` in the Python wrapper when `inter_dim_pad > 0` and not
split-K (split-K already needs a zeroed buffer for atomic accumulation).
Reading the padded tail as 0 is semantically correct: `silu(0) * up = 0`
so the padded columns contribute zero to downstream stage2.

`torch.zero_()` isn't implemented for `Float4_e2m1fn_x2` / fp8 dtypes, so
those out variants view the buffer as uint8 (bit-pattern zero is the
additive identity for both fp4_e2m1 and fp8_e4m3/e5m2).

## Motivation

Running SGLang gpt-oss-120b at TP=2 with the FlyDSL fp4 MoE path (the only
combination that fully utilises ROCm AITER for mxfp4 prefill) produced
catastrophic GSM8K regressions: flexible-extract dropped from 0.90+
(TP=1, or TP=2 with a different stage1 kernel selection) to 0.05–0.18 with
high run-to-run variance. The same regression reproduces across two
independent KV-cache layouts (NHD and SHUFFLE 5D) and across bf16 / fp8
KV dtypes, ruling out the SGLang side and isolating the bug to AITER's
stage1 dispatch.

This blocks gpt-oss-120b serving correctness at any TP>1 configuration on
gfx950 with the currently shipped `gptoss_fp4_tuned_fmoe.csv` entries.

## Technical Details

### Symptom isolation

CSV-level bisect on `aiter/configs/model_configs/gptoss_fp4_tuned_fmoe.csv`
narrowed the regression to a *single row* — inter_dim=1536, token=2048 —
whose tuned `kernelName1` is
`flydsl_moe1_afp4_wfp4_bf16_t64x64x256_w4_bnt0`. The fully-default
heuristic kernel `flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w3_bnt0` for the
same `(M, inter_dim)` is correct. Replacing just this one `kernelName1`
restores accuracy.

### Why this kernel?

The `t64x64x256_w4_bnt0` variant differs from the working one in
`tile_n` (64 vs 128) and `waves_per_eu` (4 vs 3). The bug is **not** in
the MFMA / accumulator: a head-to-head replay on a captured production
tensor snapshot (`a`, `w1`, scales, sorted_ids, bias, topk_ids; M=1030,
inter_dim=1536) shows the two kernels produce **bit-identical** output
*within the region they actually write*. The output beyond that region
matches whatever was previously in the buffer.

### What the kernel actually skips

Pre-filling the output buffer with a `-9999` sentinel before each kernel
call and re-running 6 times in the same process:

| Kernel | run0 abs_max | run1–5 abs_max | bit-exact across runs? |
|--------|--------:|--------:|:-:|
| `t64x64x256_w4_bnt0` (broken)  | 9984 | 9984 | yes — *all* runs leave the sentinel intact in the tail |
| `t64x128x256_w3_bnt0` (working) | 53.75 | 53.75 | yes — full output overwritten |

Per-tile garbage map (BROKEN run on first-call uninitialised buffer):

| N-tile (tile_n=64) | Range in output | Bad fraction |
|---|---|---:|
| 0–22 | `[0:1472]` | **0.000 %** |
| **23** | **`[1472:1536]`** | **99.811 %** |

Per-M-tile bad fraction is uniformly ~4.16 % (= 1 / 24 N-tiles); per-topk
slot is also uniform. So a *single, fixed* output tile is never visited
by any CTA.

### Root cause in the launcher

`launch_mixed_moe_gemm1` computes the N-direction grid as (SEPARATED path):

```python
# kernels/mixed_moe_gemm_2stage.py
gx = (
    (inter_in - inter_dim_pad_total + 2 * tile_n_index - 1)
    / tile_n_index
    / arith.constant(2, index=True)
)