### PR TITLE
[Triton-Gluon-MLA-GFX950] return_lse: full decode + merged fp32 lse

### DIFF
--- a/aiter/ops/triton/gluon/README.md
+++ b/aiter/ops/triton/gluon/README.md
@@ -82,11 +82,11 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
 
 The wrapper dispatches by `(nhead, kv_c.dtype)` to one of three compile-time regimes (single `@gluon.jit` kernel, REGIME constexpr gates layouts and grid mapping):
 
-- **`bh64`** (`nhead in {64, 128}`): bf16 KV, BLOCK_H=64, BLOCK_N=64, multi-batch + XCD-aware 3-D grid. `NUM_KV_SPLITS` auto-picked &isin; {1, 2, 4} so the launch fills ~256 workgroups (one wave on MI350). When `NUM_KV_SPLITS == 1`, stage-1 writes the final attention output directly to `o` (no temp buffer, no reduce). When `NUM_KV_SPLITS > 1`, stage-1 writes per-split normalized `acc` to a temp buffer and per-split fp32 `lse` to a separate `mid_lse` buffer, and stage-2 (`_mla_softmax_reducev_kernel`) reduces them into `o`.
+- **`bh64`** (`nhead in {64, 128}`): bf16 KV, BLOCK_H=64, BLOCK_N=64, multi-batch + XCD-aware 3-D grid. `NUM_KV_SPLITS` auto-picked &isin; {1, 2, 4} so the launch fills ~256 workgroups (one wave on MI350). When `NUM_KV_SPLITS == 1`, stage-1 writes the final attention output directly to `o` (no temp buffer, no reduce). When `NUM_KV_SPLITS > 1`, stage-1 writes per-split `(acc, fp32 lse)` and stage-2 (`_mla_softmax_reducev_kernel`) reduces them into `o`.
 - **`bh16bn128`** (`nhead &le; 16`, `batch_size == 1`, fp8 KV): BLOCK_H=16, BLOCK_N=128, 2-D grid `(1, NUM_KV_SPLITS=256)`. Optional `kv_scale` dequant. Always splits + always runs stage-2 reduce. Supports the general case `num_iter &isin; {1, 2, ...}` (no `gl.assume(num_iter >= 3)`). `NHEAD < BLOCK_H` masks OOB heads on Q load and O store (wasted MFMA lanes are free; this regime is memory-bound).
 - **`bh16bn64`** (`nhead &le; 16`, bf16 KV): BLOCK_H=16, BLOCK_N=64, 2-D grid `(batch_size, NUM_KV_SPLITS)` with `NUM_KV_SPLITS = max(1, 256 // batch_size)`. Use when KV is kept in bf16 (no fp8 quant). Same `NHEAD < BLOCK_H` masking. Full decode (stage-1 + stage-2 reduce into `o`).
 
-All three regimes run the full decode. `return_lse=True` additionally returns the merged log-sum-exp (`e_max + log(e_sum)` over the whole KV sequence, matching `logsumexp(dim=-1)`) as a separate fp32 tensor `[batch, nhead]`, so `mla_decode_gluon(...)` returns `(o, final_lse)` instead of `(o, None)`.
+All three regimes run the full decode. `return_lse=True` also returns the merged fp32 lse `[batch, nhead]`, so `mla_decode_gluon(...)` returns `(o, final_lse)` instead of `(o, None)`.
 
 Modified from [FlashMLA](https://github.com/deepseek-ai/FlashMLA/blob/main/benchmark/bench_flash_mla.py).
 

--- a/aiter/ops/triton/gluon/README.md
+++ b/aiter/ops/triton/gluon/README.md
@@ -38,8 +38,8 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
   <td>~5.33<br>TB/s</td><td>~0.69<br>TB/s</td><td>—</td>
 </tr>
 <tr>
-  <td>python op_tests/test_mla.py \<br>-c 100000 -b 4 -n 16,1 \<br>-d bf16 -kvd bf16 \<br>-lse<br>(stage-1 only, DCP)</td>
-  <td>~4.68<br>TB/s</td><td>—</td><td>—</td>
+  <td>python op_tests/test_mla.py \<br>-c 100000 -b 4 -n 16,1 \<br>-d bf16 -kvd bf16 \<br>-lse<br>(full decode + lse)</td>
+  <td>~4.31<br>TB/s</td><td>—</td><td>—</td>
 </tr>
 <tr>
   <td><code>pa_decode_gluon</code></td><td>Paged Attn<br>Decode</td><td>CDNA3<br>CDNA4</td>
@@ -82,11 +82,11 @@ Some features (e.g., scheduling hints like `sched_barrier`) require the [AMD Glu
 
 The wrapper dispatches by `(nhead, kv_c.dtype)` to one of three compile-time regimes (single `@gluon.jit` kernel, REGIME constexpr gates layouts and grid mapping):
 
-- **`bh64`** (`nhead in {64, 128}`): bf16 KV, BLOCK_H=64, BLOCK_N=64, multi-batch + XCD-aware 3-D grid. `NUM_KV_SPLITS` auto-picked &isin; {1, 2, 4} so the launch fills ~256 workgroups (one wave on MI350). When `NUM_KV_SPLITS == 1`, stage-1 writes the final attention output directly to `o` (no temp buffer, no reduce). When `NUM_KV_SPLITS > 1`, stage-1 writes per-split `(acc, lse)` to a temp buffer and stage-2 (`_mla_softmax_reducev_kernel`) reduces them into `o`.
+- **`bh64`** (`nhead in {64, 128}`): bf16 KV, BLOCK_H=64, BLOCK_N=64, multi-batch + XCD-aware 3-D grid. `NUM_KV_SPLITS` auto-picked &isin; {1, 2, 4} so the launch fills ~256 workgroups (one wave on MI350). When `NUM_KV_SPLITS == 1`, stage-1 writes the final attention output directly to `o` (no temp buffer, no reduce). When `NUM_KV_SPLITS > 1`, stage-1 writes per-split normalized `acc` to a temp buffer and per-split fp32 `lse` to a separate `mid_lse` buffer, and stage-2 (`_mla_softmax_reducev_kernel`) reduces them into `o`.
 - **`bh16bn128`** (`nhead &le; 16`, `batch_size == 1`, fp8 KV): BLOCK_H=16, BLOCK_N=128, 2-D grid `(1, NUM_KV_SPLITS=256)`. Optional `kv_scale` dequant. Always splits + always runs stage-2 reduce. Supports the general case `num_iter &isin; {1, 2, ...}` (no `gl.assume(num_iter >= 3)`). `NHEAD < BLOCK_H` masks OOB heads on Q load and O store (wasted MFMA lanes are free; this regime is memory-bound).
-- **`bh16bn64`** (`nhead &le; 16`, bf16 KV): BLOCK_H=16, BLOCK_N=64, 2-D grid `(batch_size, NUM_KV_SPLITS)` with `NUM_KV_SPLITS = max(1, 256 // batch_size)`. Use when KV is kept in bf16 (no fp8 quant). Same `NHEAD < BLOCK_H` masking. Supports two modes:
-  - `return_lse=False` (default): full decode — stage-1 + stage-2 reduce into `o`.
-  - `return_lse=True`: **stage-1 only** (Decode-Context-Parallel, see section below) — skips stage-2, returns per-split `(o, lse)` for a host cross-GPU merge.
+- **`bh16bn64`** (`nhead &le; 16`, bf16 KV): BLOCK_H=16, BLOCK_N=64, 2-D grid `(batch_size, NUM_KV_SPLITS)` with `NUM_KV_SPLITS = max(1, 256 // batch_size)`. Use when KV is kept in bf16 (no fp8 quant). Same `NHEAD < BLOCK_H` masking. Full decode (stage-1 + stage-2 reduce into `o`).
+
+All three regimes run the full decode. `return_lse=True` additionally returns the merged log-sum-exp (`e_max + log(e_sum)` over the whole KV sequence, matching `logsumexp(dim=-1)`) as a separate fp32 tensor `[batch, nhead]`, so `mla_decode_gluon(...)` returns `(o, final_lse)` instead of `(o, None)`.
 
 Modified from [FlashMLA](https://github.com/deepseek-ai/FlashMLA/blob/main/benchmark/bench_flash_mla.py).
 
@@ -105,8 +105,8 @@ Modified from [FlashMLA](https://github.com/deepseek-ai/FlashMLA/blob/main/bench
 | Grid | 3-D XCD-aware | 2-D `(1, 256)` | 2-D `(batch, NUM_KV_SPLITS)` |
 | NUM_KV_SPLITS | auto &isin; {1, 2, 4} from (batch, nhead) | 256 (fixed) | `max(1, 256 // batch_size)` |
 | `kv_scale` | unused (pass 1.0) | dequant scale folded into `qk_scale` (applied before softmax for fp8 correctness) | unused (pass 1.0) |
-| Seq constraint | `min_kv_seq_len > NUM_KV_SPLITS * (3 * BLOCK_N + NUM_KV_SPLITS)` (the `3` matches the kernel's `gl.assume(num_iter > 3)`) | `min_kv_seq_len &ge; NUM_KV_SPLITS` (= 256; non-empty splits, `num_iter &ge; 1`) | `min_kv_seq_len &ge; NUM_KV_SPLITS` (non-empty splits, `num_iter &ge; 1`; both modes) |
-| Stage-2 reduce | skipped when `NUM_KV_SPLITS == 1` | always runs | runs (skipped when `return_lse=True`, or `NUM_KV_SPLITS == 1`) |
+| Seq constraint | `min_kv_seq_len > NUM_KV_SPLITS * (3 * BLOCK_N + NUM_KV_SPLITS)` (the `3` matches the kernel's `gl.assume(num_iter > 3)`) | `min_kv_seq_len &ge; NUM_KV_SPLITS` (= 256; non-empty splits, `num_iter &ge; 1`) | `min_kv_seq_len &ge; NUM_KV_SPLITS` (non-empty splits, `num_iter &ge; 1`) |
+| Stage-2 reduce | skipped when `NUM_KV_SPLITS == 1` | always runs | skipped when `NUM_KV_SPLITS == 1` |
 
 **Page table modes** (`use_2d_view`, both regimes):
 - `True`: `page_table = block_table [batch, max_seqlen]`, `seq_info = cache_seqlens [batch]`. Use for fixed-length or pre-padded variable-length sequences.
@@ -151,11 +151,7 @@ python op_tests/test_mla.py -c 10000000 -b 1 -n 16,1 -d bf16 -kvd bf16
 
 Gluon reaches ~82% of MI350's 6.5 TB/s HBM peak (wall-clock 2162 &mu;s vs ASM 16659 &mu;s).
 
-#### `bh16bn64` + `return_lse=True` — Stage-1-only MLA Decode for DCP
-
-Per-GPU stage-1 for Decode-Context-Parallel (DCP): KV is sharded across GPUs, so this runs stage-1 only and returns per-split `(o, lse)` for the **host** to merge — no intra-GPU stage-2 reduce. `o` is the caller-allocated per-split logits `[B, nhead, NUM_KV_SPLITS, kv_lora_rank]` (bf16); `lse` `[B, nhead, NUM_KV_SPLITS]` (fp32) is allocated and returned. Tuned for `B * ctx_len` in **10K..100K** total tokens. The only difference from full-decode `bh16bn64` (gated by `RETURN_LSE`): `lse` goes to a separate fp32 tensor (host merge is precision-sensitive) and stage-2 is skipped.
-
-**Perf** (MI350, bf16 Q + bf16 KV; memory-bound; stage-1 only):
+**`return_lse` perf** (MI350, bf16 Q + bf16 KV; memory-bound; full decode + lse):
 
 ```
 python op_tests/test_mla.py -c 10000 100000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16 -lse
@@ -163,12 +159,12 @@ python op_tests/test_mla.py -c 10000 100000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16 -
 
 | ctx_lens | batch | NUM_KV_SPLITS | num_iter / split | us | TB/s |
 |----------|-------|---------------|------------------|-----|------|
-| 10K      | 1     | 256           | 1                | 9.14  | 1.26 |
-| 10K      | 3     | 85            | 2                | 17.56 | 1.97 |
-| 10K      | 4     | 64            | 3                | 19.02 | 2.43 |
-| 100K     | 1     | 256           | 7                | 36.62 | 3.15 |
-| 100K     | 3     | 85            | 19               | 76.06 | 4.55 |
-| 100K     | 4     | 64            | 25               | 98.48 | 4.68 |
+| 10K      | 1     | 256           | 1                | 39.76  | 0.29 |
+| 10K      | 3     | 85            | 2                | 32.33  | 1.07 |
+| 10K      | 4     | 64            | 3                | 26.35  | 1.75 |
+| 100K     | 1     | 256           | 7                | 63.78  | 1.81 |
+| 100K     | 3     | 85            | 19               | 88.77  | 3.89 |
+| 100K     | 4     | 64            | 25               | 106.96 | 4.31 |
 
 ### `pa_decode_gluon.py` — Paged Attention Decode
 

--- a/aiter/ops/triton/gluon/mla_decode_gluon.py
+++ b/aiter/ops/triton/gluon/mla_decode_gluon.py
@@ -26,11 +26,9 @@
 # Wrapper dispatch: nhead in {64,128} -> bh64; nhead <= 16 routes by KV dtype
 # (bf16 -> bh16bn64, fp8 -> bh16bn128).
 #
-# All regimes always run the full decode. For NUM_KV_SPLITS>1 each program writes
-# per-split normalized acc to a temp buffer and per-split fp32 lse to a separate
-# mid_lse buffer; stage-2 (_mla_softmax_reducev_kernel) combines them into the
-# final O. RETURN_LSE additionally returns the merged fp32 lse [B, H] (written by
-# stage-2 for NUM_KV_SPLITS>1, or by stage-1 for the NUM_KV_SPLITS==1 fast path).
+# Full decode for all regimes. For NUM_KV_SPLITS>1 stage-1 writes per-split acc +
+# fp32 lse; stage-2 (_mla_softmax_reducev_kernel) reduces into O. RETURN_LSE also
+# returns the merged fp32 lse [B, H] (stage-2 for splits>1, else stage-1).
 #
 # 3-stage software pipeline (double-buffered, BLOCK_N with 2x(BLOCK_N/2) KV slices):
 #   AC = async_copy (global->LDS), LL = load (LDS->reg), P = page, K = K-cache, V = V-cache
@@ -76,7 +74,7 @@ def _mla_decode_gluon(
     stride_o_b,
     stride_o_h,
     stride_o_s,
-    Mid_lse,  # K>1: per-split fp32 lse [B, H, NUM_KV_SPLITS] (else None)
+    Mid_lse,  # split>1: per-split fp32 lse [B, H, NUM_KV_SPLITS] (else None)
     stride_mid_lse_b,
     stride_mid_lse_h,
     stride_mid_lse_s,
@@ -629,9 +627,7 @@ def _mla_decode_gluon(
     else:
         gl.amd.cdna4.buffer_store(stored_value, ptr=O, offsets=offs_o)
     if RETURN_LSE and NUM_KV_SPLITS == 1:
-        # K==1 fast path: stage-1 writes the final attention directly, so it also
-        # writes the merged fp32 lse here (the single split spans the whole
-        # sequence, so its lse IS the final lse). No stage-2 reduce runs.
+        # split==1: single split is the whole sequence, so its lse is the final lse.
         offs_final_lse = cur_batch * stride_final_lse_b + cur_head_o * stride_final_lse_h
         lse = e_max + gl.log(e_sum)
         if NHEAD < BLOCK_H:
@@ -639,8 +635,7 @@ def _mla_decode_gluon(
         else:
             gl.amd.cdna4.buffer_store(lse, ptr=Final_lse, offsets=offs_final_lse)
     elif NUM_KV_SPLITS > 1:
-        # Full-decode: per-split fp32 lse to a separate Mid_lse tensor for the
-        # stage-2 reduce (fp32, not packed into the bf16 O buffer).
+        # per-split lse for stage-2 reduce.
         offs_mid_lse = cur_batch * stride_mid_lse_b + cur_head_o * stride_mid_lse_h + split_kv_id * stride_mid_lse_s
         lse = e_max + gl.log(e_sum)
         if NHEAD < BLOCK_H:
@@ -682,8 +677,7 @@ def _mla_softmax_reducev_kernel(
     e_max = -float("inf")
     acc = tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
 
-    # Stage-1's floor-with-remainder-on-last split scheme guarantees every split
-    # is non-empty, so all NUM_KV_SPLITS splits are merged unconditionally.
+    # all splits non-empty (floor-with-remainder-on-last), so merge unconditionally.
     for split_kv_id in range(0, NUM_KV_SPLITS):
         logits = tl.load(Logits + offs_l + split_kv_id * stride_l_s)
         logits_1 = tl.load(Mid_lse + offs_ml + split_kv_id * stride_ml_s)
@@ -715,8 +709,7 @@ def mla_decode_gluon(
     # Shared: kv_c=[N, kv_lora_rank+qk_rope_head_dim], k_pe=None,              kv_pe_offset=kv_lora_rank
     # Split:  kv_c=[N, kv_lora_rank],                k_pe=[N,qk_rope_head_dim], kv_pe_offset=0
     kv_c,
-    # return_lse=False: final output [batch, nhead, kv_lora_rank].
-    # return_lse=True:  per-split logits [batch, nhead, NUM_KV_SPLITS, kv_lora_rank].
+    # final output [batch, nhead, kv_lora_rank].
     o,
     page_table,  # 2D: block_table [batch, max_seqlen] | 1D: kv_indices [total_kv]
     seq_info,  # 2D: cache_seqlens [batch]           | 1D: kv_indptr [batch+1]
@@ -738,13 +731,7 @@ def mla_decode_gluon(
     return_lse=False (default): returns (o, None).
 
     return_lse=True: additionally returns the merged log-sum-exp, a separate
-        fp32 tensor [batch, nhead] allocated here: (o, final_lse). final_lse is
-        the post-reduce value (e_max + log(e_sum) over the whole KV sequence),
-        matching the asm path's final_lse and the torch reference's
-        logsumexp(dim=-1). Supported for all regimes. When NUM_KV_SPLITS>1 the
-        per-split lse is kept in a separate fp32 buffer (not packed into the bf16
-        O) and stage-2 produces final_lse; when NUM_KV_SPLITS==1 stage-1 writes
-        final_lse directly.
+        fp32 tensor [batch, nhead]
     """
     if k_pe is None:
         k_pe = kv_c
@@ -841,15 +828,12 @@ def mla_decode_gluon(
     within_2gb = max_kv_bytes <= 0x80000000  # 2 GB
 
     if NUM_KV_SPLITS == 1:
-        # Fast path: stage-1 writes the final attention output directly to o, no
-        # temp buffer, no stage-2 reduce. For return_lse it also writes the merged
-        # fp32 lse (the single split spans the whole sequence).
+        # Fast path: stage-1 writes the final attention (and lse) directly to o.
         logits_buf = o.view(batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv)
         mid_lse = None
         stride_mid_lse_b, stride_mid_lse_h, stride_mid_lse_s = 0, 0, 0
     else:
-        # Stage-1 writes per-split normalized acc to a temp buffer and per-split
-        # fp32 lse to a separate mid_lse; stage-2 reduces them into o.
+        # stage-1 -> per-split (acc, lse); stage-2 reduces into o.
         logits_buf = torch.empty(
             (batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv),
             dtype=o.dtype,
@@ -863,7 +847,6 @@ def mla_decode_gluon(
         stride_mid_lse_b, stride_mid_lse_h, stride_mid_lse_s = mid_lse.stride()
 
     if return_lse:
-        # Merged fp32 lse: written by stage-1 (K==1) or stage-2 (K>1).
         final_lse = torch.empty(
             (batch_size, nhead), dtype=torch.float32, device=q_nope.device
         )
@@ -925,14 +908,10 @@ def mla_decode_gluon(
     )
 
     if NUM_KV_SPLITS == 1:
-        # Fast path: stage-1 already wrote the final attention (and, for
-        # return_lse, the merged fp32 lse) directly to o.
+        # Fast path: stage-1 already wrote o (and lse) directly.
         return o, final_lse
 
-    # Stage-2: combine per-split (acc, fp32 lse) into the final attention in o,
-    # and (when return_lse) write the merged fp32 lse. Stage-1's
-    # floor-with-remainder-on-last split scheme guarantees every split is
-    # non-empty, so all splits are merged unconditionally.
+    # Stage-2: reduce per-split (acc, lse) into o (and lse when return_lse).
     grid_reduce = (batch_size, nhead)
     _mla_softmax_reducev_kernel[grid_reduce](
         logits_buf,

--- a/aiter/ops/triton/gluon/mla_decode_gluon.py
+++ b/aiter/ops/triton/gluon/mla_decode_gluon.py
@@ -16,22 +16,21 @@
 #                        and O store.
 #   REGIME='bh16bn64'  - bf16 Q + bf16 KV, BLOCK_H=16, BLOCK_N=64,
 #                        nhead <= 16, batch_size >= 1, 2-D (batch, split) grid,
-#                        NUM_KV_SPLITS = max(1, 256 // batch_size). Two modes:
-#                          - return_lse=False: full decode (stage-1 + stage-2
-#                            reduce into the final O).
-#                          - return_lse=True: stage-1 only (Decode-Context-
-#                            Parallel) - writes per-split (acc, fp32 lse) and
-#                            skips stage-2; host does the cross-GPU merge.
+#                        NUM_KV_SPLITS = max(1, 256 // batch_size). Full decode
+#                        (stage-1 + stage-2 reduce into the final O).
 #                        NHEAD < BLOCK_H masks OOB heads on Q load and O store.
 #
 # The bh16 regimes support num_iter in {1, 2, ...} (no gl.assume(num_iter>=3));
-# only bh64 assumes >= 3. See RETURN_LSE / epilogue-1 handling below.
+# only bh64 assumes >= 3. See epilogue-1 handling below.
 #
 # Wrapper dispatch: nhead in {64,128} -> bh64; nhead <= 16 routes by KV dtype
 # (bf16 -> bh16bn64, fp8 -> bh16bn128).
 #
-# For full decode with NUM_KV_SPLITS>1 each program writes per-split (acc, lse)
-# to a temp buffer and stage-2 (_mla_softmax_reducev_kernel) combines them.
+# All regimes always run the full decode. For NUM_KV_SPLITS>1 each program writes
+# per-split normalized acc to a temp buffer and per-split fp32 lse to a separate
+# mid_lse buffer; stage-2 (_mla_softmax_reducev_kernel) combines them into the
+# final O. RETURN_LSE additionally returns the merged fp32 lse [B, H] (written by
+# stage-2 for NUM_KV_SPLITS>1, or by stage-1 for the NUM_KV_SPLITS==1 fast path).
 #
 # 3-stage software pipeline (double-buffered, BLOCK_N with 2x(BLOCK_N/2) KV slices):
 #   AC = async_copy (global->LDS), LL = load (LDS->reg), P = page, K = K-cache, V = V-cache
@@ -77,10 +76,13 @@ def _mla_decode_gluon(
     stride_o_b,
     stride_o_h,
     stride_o_s,
-    Lse,  # RETURN_LSE only; separate fp32 tensor (else pass None)
-    stride_lse_b,
-    stride_lse_h,
-    stride_lse_s,
+    Mid_lse,  # K>1: per-split fp32 lse [B, H, NUM_KV_SPLITS] (else None)
+    stride_mid_lse_b,
+    stride_mid_lse_h,
+    stride_mid_lse_s,
+    Final_lse,  # RETURN_LSE only: merged fp32 lse [B, H] (else None)
+    stride_final_lse_b,
+    stride_final_lse_h,
     BLOCK_H: gl.constexpr,
     BLOCK_N: gl.constexpr,
     NUM_KV_SPLITS: gl.constexpr,
@@ -626,23 +628,25 @@ def _mla_decode_gluon(
         gl.amd.cdna4.buffer_store(stored_value, ptr=O, offsets=offs_o, mask=(cur_head_o < NHEAD)[:, None])
     else:
         gl.amd.cdna4.buffer_store(stored_value, ptr=O, offsets=offs_o)
-    if RETURN_LSE:
-        # Stage-1-only: separate fp32 Lse tensor [B, H, NUM_KV_SPLITS] for the
-        # host cross-GPU merge (works even at NUM_KV_SPLITS == 1).
-        offs_lse = cur_batch * stride_lse_b + cur_head_o * stride_lse_h + split_kv_id * stride_lse_s
+    if RETURN_LSE and NUM_KV_SPLITS == 1:
+        # K==1 fast path: stage-1 writes the final attention directly, so it also
+        # writes the merged fp32 lse here (the single split spans the whole
+        # sequence, so its lse IS the final lse). No stage-2 reduce runs.
+        offs_final_lse = cur_batch * stride_final_lse_b + cur_head_o * stride_final_lse_h
         lse = e_max + gl.log(e_sum)
         if NHEAD < BLOCK_H:
-            gl.amd.cdna4.buffer_store(lse, ptr=Lse, offsets=offs_lse, mask=(cur_head_o < NHEAD))
+            gl.amd.cdna4.buffer_store(lse, ptr=Final_lse, offsets=offs_final_lse, mask=(cur_head_o < NHEAD))
         else:
-            gl.amd.cdna4.buffer_store(lse, ptr=Lse, offsets=offs_lse)
+            gl.amd.cdna4.buffer_store(lse, ptr=Final_lse, offsets=offs_final_lse)
     elif NUM_KV_SPLITS > 1:
-        # Full-decode: per-split lse packed into O at the trailing slot for stage-2 reduce.
-        offs_o_lse = cur_batch * stride_o_b + cur_head_o * stride_o_h + split_kv_id * stride_o_s + HEAD_DIM_CKV
+        # Full-decode: per-split fp32 lse to a separate Mid_lse tensor for the
+        # stage-2 reduce (fp32, not packed into the bf16 O buffer).
+        offs_mid_lse = cur_batch * stride_mid_lse_b + cur_head_o * stride_mid_lse_h + split_kv_id * stride_mid_lse_s
         lse = e_max + gl.log(e_sum)
         if NHEAD < BLOCK_H:
-            gl.amd.cdna4.buffer_store(lse.to(dtype), ptr=O, offsets=offs_o_lse, mask=(cur_head_o < NHEAD))
+            gl.amd.cdna4.buffer_store(lse, ptr=Mid_lse, offsets=offs_mid_lse, mask=(cur_head_o < NHEAD))
         else:
-            gl.amd.cdna4.buffer_store(lse.to(dtype), ptr=O, offsets=offs_o_lse)
+            gl.amd.cdna4.buffer_store(lse, ptr=Mid_lse, offsets=offs_mid_lse)
 # fmt: on
 
 
@@ -650,49 +654,39 @@ def _mla_decode_gluon(
 @triton.jit
 def _mla_softmax_reducev_kernel(
     Logits,
-    B_seq_len,
+    Mid_lse,
     O,  # noqa: E741
+    Final_lse,
     stride_l_b,
     stride_l_h,
     stride_l_s,
+    stride_ml_b,
+    stride_ml_h,
+    stride_ml_s,
     stride_o_b,
     stride_o_h,
+    stride_fl_b,
+    stride_fl_h,
     NUM_KV_SPLITS: tl.constexpr,
     HEAD_DIM_CKV: tl.constexpr,
-    USE_2D_VIEW: tl.constexpr,
+    HAS_FINAL_LSE: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
 
     offs_d_ckv = tl.arange(0, HEAD_DIM_CKV)
     offs_l = cur_batch * stride_l_b + cur_head * stride_l_h + offs_d_ckv
-    offs_l_1 = cur_batch * stride_l_b + cur_head * stride_l_h + HEAD_DIM_CKV
+    offs_ml = cur_batch * stride_ml_b + cur_head * stride_ml_h
 
     e_sum = 0.0
     e_max = -float("inf")
     acc = tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
 
-    # OLD: conditional empty-split skip, needed because stage-1's ceil split
-    # could produce empty trailing splits. Kept here as commented reference;
-    # remove in cleanup. The B_seq_len arg is no longer read by this kernel.
-    # if not ALL_SPLITS_NONEMPTY:
-    #     if USE_2D_VIEW:
-    #         cur_batch_seq_len = tl.load(B_seq_len + cur_batch)
-    #     else:
-    #         cur_batch_seq_len = tl.load(B_seq_len + cur_batch + 1) - tl.load(
-    #             B_seq_len + cur_batch
-    #         )
-        # if not ALL_SPLITS_NONEMPTY:
-        #     kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
-        #     split_kv_start = kv_len_per_split * split_kv_id
-        #     split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
-        #     if split_kv_end <= split_kv_start:
-        #         continue
-
+    # Stage-1's floor-with-remainder-on-last split scheme guarantees every split
+    # is non-empty, so all NUM_KV_SPLITS splits are merged unconditionally.
     for split_kv_id in range(0, NUM_KV_SPLITS):
-
         logits = tl.load(Logits + offs_l + split_kv_id * stride_l_s)
-        logits_1 = tl.load(Logits + offs_l_1 + split_kv_id * stride_l_s)
+        logits_1 = tl.load(Mid_lse + offs_ml + split_kv_id * stride_ml_s)
 
         n_e_max = tl.maximum(logits_1, e_max)
         old_scale = tl.exp(e_max - n_e_max)
@@ -707,6 +701,11 @@ def _mla_softmax_reducev_kernel(
         O + cur_batch * stride_o_b + cur_head * stride_o_h + offs_d_ckv,
         acc / e_sum,
     )
+    if HAS_FINAL_LSE:
+        tl.store(
+            Final_lse + cur_batch * stride_fl_b + cur_head * stride_fl_h,
+            e_max + tl.log(e_sum),
+        )
 # fmt: on
 
 
@@ -732,18 +731,20 @@ def mla_decode_gluon(
     """
     Gluon MLA decode (gfx950 / CDNA4).
 
-    return_lse=False (default): full decode. Runs stage-1 + stage-2 reduce and
-        writes the final attention into the caller's `o` ([batch, nhead,
-        kv_lora_rank]); returns (o, None).
+    Always runs the full decode (stage-1 + stage-2 reduce, or the stage-1-only
+    fast path when NUM_KV_SPLITS==1) and writes the final attention into the
+    caller's `o` ([batch, nhead, kv_lora_rank]).
 
-    return_lse=True: stage-1 only, for the Decode-Context-Parallel (DCP)
-        workload where the KV cache is sharded across GPUs and the host does
-        the cross-GPU softmax merge. Only the bh16bn64 regime (nhead<=16, bf16
-        KV) supports it. The stage-2 reduce is skipped; the caller's `o` is the
-        per-split logits buffer [batch, nhead, NUM_KV_SPLITS, kv_lora_rank]
-        (bf16), and a per-split fp32 lse [batch, nhead, NUM_KV_SPLITS] is
-        allocated here and returned: (o, lse). Tuned for batch*ctx_len in the
-        10K..100K total-token range; NUM_KV_SPLITS = max(1, 256 // batch_size).
+    return_lse=False (default): returns (o, None).
+
+    return_lse=True: additionally returns the merged log-sum-exp, a separate
+        fp32 tensor [batch, nhead] allocated here: (o, final_lse). final_lse is
+        the post-reduce value (e_max + log(e_sum) over the whole KV sequence),
+        matching the asm path's final_lse and the torch reference's
+        logsumexp(dim=-1). Supported for all regimes. When NUM_KV_SPLITS>1 the
+        per-split lse is kept in a separate fp32 buffer (not packed into the bf16
+        O) and stage-2 produces final_lse; when NUM_KV_SPLITS==1 stage-1 writes
+        final_lse directly.
     """
     if k_pe is None:
         k_pe = kv_c
@@ -779,10 +780,6 @@ def mla_decode_gluon(
         )
 
     PAGE_SIZE = 1
-
-    assert not (
-        return_lse and REGIME != "bh16bn64"
-    ), f"mla_decode_gluon: return_lse=True is only supported for the bh16bn64 regime (nhead<=16, bf16 KV), got REGIME={REGIME}"
 
     if REGIME == "bh64":
         BLOCK_H, BLOCK_N = 64, 64
@@ -843,41 +840,37 @@ def mla_decode_gluon(
     max_kv_bytes = kv_c.shape[0] * kv_c.stride(0) * kv_c.element_size()
     within_2gb = max_kv_bytes <= 0x80000000  # 2 GB
 
-    if return_lse:
-        # Stage-1-only: the caller's `o` IS the per-split logits buffer; no temp,
-        # no reduce. lse is a separate fp32 tensor, allocated here and returned.
-        assert o.shape == (
-            batch_size,
-            nhead,
-            NUM_KV_SPLITS,
-            head_dim_ckv,
-        ), f"return_lse=True requires o of shape [{batch_size}, {nhead}, {NUM_KV_SPLITS}, {head_dim_ckv}], got {tuple(o.shape)}"
-        assert (
-            o.dtype == torch.bfloat16
-        ), f"return_lse=True requires o bf16, got {o.dtype}"
-        logits_buf = o
-        lse = torch.empty(
-            (batch_size, nhead, NUM_KV_SPLITS),
-            dtype=torch.float32,
-            device=q_nope.device,
-        )
-        stride_lse_b, stride_lse_h, stride_lse_s = lse.stride()
-    elif NUM_KV_SPLITS == 1:
-        # Fast path: stage-1 writes the final attention output directly to o,
-        # no temp buffer, no reduce.
+    if NUM_KV_SPLITS == 1:
+        # Fast path: stage-1 writes the final attention output directly to o, no
+        # temp buffer, no stage-2 reduce. For return_lse it also writes the merged
+        # fp32 lse (the single split spans the whole sequence).
         logits_buf = o.view(batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv)
-        lse = None
-        stride_lse_b, stride_lse_h, stride_lse_s = 0, 0, 0
+        mid_lse = None
+        stride_mid_lse_b, stride_mid_lse_h, stride_mid_lse_s = 0, 0, 0
     else:
-        # Stage-1 writes per-split (acc, lse) to a temp buffer; the trailing
-        # slot at index head_dim_ckv holds the per-split lse.
+        # Stage-1 writes per-split normalized acc to a temp buffer and per-split
+        # fp32 lse to a separate mid_lse; stage-2 reduces them into o.
         logits_buf = torch.empty(
-            (batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv + 1),
+            (batch_size, nhead, NUM_KV_SPLITS, head_dim_ckv),
             dtype=o.dtype,
             device=o.device,
         )
-        lse = None
-        stride_lse_b, stride_lse_h, stride_lse_s = 0, 0, 0
+        mid_lse = torch.empty(
+            (batch_size, nhead, NUM_KV_SPLITS),
+            dtype=torch.float32,
+            device=o.device,
+        )
+        stride_mid_lse_b, stride_mid_lse_h, stride_mid_lse_s = mid_lse.stride()
+
+    if return_lse:
+        # Merged fp32 lse: written by stage-1 (K==1) or stage-2 (K>1).
+        final_lse = torch.empty(
+            (batch_size, nhead), dtype=torch.float32, device=q_nope.device
+        )
+        stride_final_lse_b, stride_final_lse_h = final_lse.stride()
+    else:
+        final_lse = None
+        stride_final_lse_b, stride_final_lse_h = 0, 0
 
     if REGIME == "bh64":
         grid = (
@@ -909,10 +902,13 @@ def mla_decode_gluon(
         logits_buf.stride(0),
         logits_buf.stride(1),
         logits_buf.stride(2),
-        lse,
-        stride_lse_b,
-        stride_lse_h,
-        stride_lse_s,
+        mid_lse,
+        stride_mid_lse_b,
+        stride_mid_lse_h,
+        stride_mid_lse_s,
+        final_lse,
+        stride_final_lse_b,
+        stride_final_lse_h,
         BLOCK_H=BLOCK_H,
         BLOCK_N=BLOCK_N,
         NUM_KV_SPLITS=NUM_KV_SPLITS,
@@ -928,29 +924,35 @@ def mla_decode_gluon(
         RETURN_LSE=return_lse,
     )
 
-    if return_lse:
-        # Host does the cross-GPU softmax merge over splits.
-        return o, lse
+    if NUM_KV_SPLITS == 1:
+        # Fast path: stage-1 already wrote the final attention (and, for
+        # return_lse, the merged fp32 lse) directly to o.
+        return o, final_lse
 
-    if NUM_KV_SPLITS > 1:
-        # Stage-2: combine per-split (acc, lse) into the final attention in o.
-        # Stage-1's floor-with-remainder-on-last split scheme guarantees every
-        # split is non-empty, so the empty-split skip (and its ALL_SPLITS_NONEMPTY
-        # constexpr) is no longer needed in stage-2.
-        grid_reduce = (batch_size, nhead)
-        _mla_softmax_reducev_kernel[grid_reduce](
-            logits_buf,
-            seq_info,
-            o,
-            logits_buf.stride(0),
-            logits_buf.stride(1),
-            logits_buf.stride(2),
-            o.stride(0),
-            o.stride(1),
-            NUM_KV_SPLITS=NUM_KV_SPLITS,
-            HEAD_DIM_CKV=head_dim_ckv,
-            USE_2D_VIEW=use_2d_view,
-            num_warps=8,
-        )
+    # Stage-2: combine per-split (acc, fp32 lse) into the final attention in o,
+    # and (when return_lse) write the merged fp32 lse. Stage-1's
+    # floor-with-remainder-on-last split scheme guarantees every split is
+    # non-empty, so all splits are merged unconditionally.
+    grid_reduce = (batch_size, nhead)
+    _mla_softmax_reducev_kernel[grid_reduce](
+        logits_buf,
+        mid_lse,
+        o,
+        final_lse,
+        logits_buf.stride(0),
+        logits_buf.stride(1),
+        logits_buf.stride(2),
+        stride_mid_lse_b,
+        stride_mid_lse_h,
+        stride_mid_lse_s,
+        o.stride(0),
+        o.stride(1),
+        stride_final_lse_b,
+        stride_final_lse_h,
+        NUM_KV_SPLITS=NUM_KV_SPLITS,
+        HEAD_DIM_CKV=head_dim_ckv,
+        HAS_FINAL_LSE=return_lse,
+        num_warps=8,
+    )
 
-    return o, None
+    return o, final_lse

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -664,9 +664,8 @@ def test_mla(
         ret["decode:gluon_TFLOPS"] = flops / us_gluon_decode / 1e6
         ret["decode:gluon_TB/s"] = bytes / us_gluon_decode / 1e6
 
-    # Gluon MLA bh16bn64 decode test (gfx950, bf16 Q + bf16 KV). Full decode; `o`
-    # is identical with/without -lse (-lse only adds the merged fp32 lse, validated
-    # vs lse_ref). Same gate for both modes: splits must be non-empty, i.e.
+    # Gluon MLA bh16bn64 decode test (gfx950, bf16 Q + bf16 KV).
+    # Splits must be non-empty, i.e.
     # ctx >= NUM_KV_SPLITS = max(1, 256 // batch_size).
     # Example: -c 10000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16 [-lse]
     if (

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -526,13 +526,10 @@ def test_mla(
     def test_absorb_decode_gluon_bh16(name):
         # Shared bh16bn{64,128} runner. The wrapper dispatches on
         # (nhead, kv dtype): name='bh16bn128' -> cast kv to fp8;
-        # name='bh16bn64' -> keep bf16. When the outer -lse/--return_lse flag is
-        # set, run the stage-1-only (DCP) path: per-GPU stage-1, no intra-GPU
-        # reducev. Host-side LSE-merge over splits validates equivalence to the
-        # unified attention reference.
+        # name='bh16bn64' -> keep bf16. Always runs the full decode (stage-1 +
+        # stage-2 reduce). With -lse/--return_lse the kernel also returns the
+        # merged fp32 lse [batch, nhead], validated against lse_ref.
         from aiter.ops.triton.gluon.mla_decode_gluon import mla_decode_gluon
-
-        is_1st_stage = return_lse
 
         out_gluon = torch.empty((total_q, nhead, v_head_dim), dtype=out_dtype).fill_(-1)
         q_nope = q[:, :, :v_head_dim].view(batch_size, nhead, v_head_dim)
@@ -551,41 +548,20 @@ def test_mla(
             seq_info = kv_indptr
             use_2d_view = False
 
-        if is_1st_stage:
-            # Stage-1-only: kernel writes per-split (acc, lse); host merges.
-            NUM_KV_SPLITS = 256 // batch_size
-            Dckv = v_head_dim
-            out_buf = torch.empty(
-                (batch_size, nhead, NUM_KV_SPLITS, Dckv),
-                dtype=torch.bfloat16,
-                device=q.device,
-            )
-        else:
-            out_buf = out_gluon.view(batch_size, nhead, v_head_dim)
-
         (_, lse), us_decode = run_perftest(
             mla_decode_gluon,
             q_nope,
             q_pe,
             kv_c,
-            out_buf,
+            out_gluon.view(batch_size, nhead, v_head_dim),
             page_table,
             seq_info,
             sm_scale,
             use_2d_view=use_2d_view,
             kv_scale=1.0,
             min_kv_seq_len=ctx_lens,
-            return_lse=is_1st_stage,
+            return_lse=return_lse,
         )
-
-        if is_1st_stage:
-            # Host-side log-sum-exp merge across splits:
-            #   final = sum_i acc_i * exp(lse_i - max_lse) / sum_i exp(lse_i - max_lse)
-            acc_f = out_buf.float()
-            max_lse = lse.max(dim=-1, keepdim=True).values
-            w = torch.exp(lse - max_lse)
-            merged = (acc_f * w[..., None]).sum(dim=-2) / w.sum(dim=-1, keepdim=True)
-            out_gluon.copy_(merged.view(total_q, nhead, v_head_dim).to(out_dtype))
 
         err = checkAllclose(
             out_ref,
@@ -593,14 +569,17 @@ def test_mla(
             msg=f"mla_decode-absorb    [golden vs gluon_{name}]: {us_decode:>8.2f} us......",
         )
         cal_diff(out_ref, out_gluon, f"out_gluon_{name}", use_fp8=(name == "bh16bn128"))
+        if return_lse and lse is not None:
+            checkAllclose(
+                lse_ref,
+                lse.reshape(total_q, nhead),
+                msg=f"mla_decode-absorb    [lse_ref vs gluon_{name}_lse]: {us_decode:>8.2f} us......",
+            )
         return err, us_decode
 
     err = None
     us_asm_decode = 1e12
-    # The ASM decode baseline has no LSE kernel for these MLA configs (e.g.
-    # nhead<=16 bf16 aborts in get_heuristic_kernel_mla with lse:1); skip it
-    # entirely when -lse is set. The -lse path exercises only the Gluon
-    # stage-1/DCP kernel.
+    # The ASM decode baseline aborts for these MLA configs when lse is requested
     if return_lse:
         pass
     elif (dtype == torch.bfloat16 and kvtype == torch.bfloat16) and nhead in [
@@ -685,17 +664,11 @@ def test_mla(
         ret["decode:gluon_TFLOPS"] = flops / us_gluon_decode / 1e6
         ret["decode:gluon_TB/s"] = bytes / us_gluon_decode / 1e6
 
-    # Gluon MLA bh16bn64 decode test (gfx950, bf16 Q + bf16 KV, nhead in (4,8,16),
-    # decode_qlen=1, head_dim_ckv=512, head_dim_kpe=64, page_size=1).
-    # Two modes with different accuracy envelopes, so different gates:
-    #   -lse (DCP stage-1): the cross-split merge runs in fp32 on the host, so it
-    #     meets cal_diff for any batch. Only requirement is non-empty splits:
-    #     NUM_KV_SPLITS = max(1, 256 // batch_size), so ctx >= 256 // batch_size.
-    #     Example: -c 10000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16 -lse
-    #   full decode: the per-split combine is the in-kernel bf16 stage-2 reduce,
-    #     which only meets cal_diff's strict cos_diff<1e-5 at batch_size==1
-    #     (NUM_KV_SPLITS=256) with min_seq_len_wg >= BLOCK_N*3, i.e.
-    #     ctx >= 256 * 64 * 3 = 49152. Example: -c 49152 -b 1 -n 16,1 -d bf16 -kvd bf16
+    # Gluon MLA bh16bn64 decode test (gfx950, bf16 Q + bf16 KV). Full decode; `o`
+    # is identical with/without -lse (-lse only adds the merged fp32 lse, validated
+    # vs lse_ref). Same gate for both modes: splits must be non-empty, i.e.
+    # ctx >= NUM_KV_SPLITS = max(1, 256 // batch_size).
+    # Example: -c 10000 -b 1 3 4 -n 16,1 -d bf16 -kvd bf16 [-lse]
     if (
         get_gfx() == "gfx950"
         and dtype == torch.bfloat16
@@ -705,10 +678,8 @@ def test_mla(
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
         and page_size == 1
-        and (
-            (return_lse and 1 <= batch_size <= 256 and ctx_lens >= (256 // batch_size))
-            or (not return_lse and batch_size == 1 and ctx_lens >= 256 * 64 * 3)
-        )
+        and 1 <= batch_size <= 256
+        and ctx_lens >= (256 // batch_size)
     ):
         err_gluon, us_gluon_decode = test_absorb_decode_gluon_bh16("bh16bn64")
         ret["decode:gluon_err"] = err_gluon


### PR DESCRIPTION
return_lse now runs the full decode (stage-1 + stage-2 reduce) and returns the merged fp32 lse [batch, nhead] (e_max + log(e_sum) over the whole sequence), supported for all regimes.

- per-split lse kept in a separate fp32 mid_lse buffer (not packed into the bf16 O), fixing the bf16 precision loss in the stage-2 merge
- stage-2 (_mla_softmax_reducev_kernel) writes final_lse; NUM_KV_SPLITS==1 fast path writes it directly in stage-1
- test_mla.py: validate returned lse vs lse_ref; README updated