### PR TITLE
CI: Set ATOM image build timeout

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -254,6 +254,7 @@ jobs:
 
       - name: Build the ATOM test image
         if: matrix.run_on_pr == true || github.event_name != 'pull_request'
+        timeout-minutes: 30
         run: |
           docker build --network=host \
             --no-cache \


### PR DESCRIPTION
## Summary
- Add a 30-minute timeout to the Atom Test workflow's `Build the ATOM test image` step.
- Prevent long-running Docker image builds from occupying MI35x runners for hours.

## Test plan
- Ran `git diff --check origin/main...HEAD`.
- Verified the diff only updates `.github/workflows/atom-test.yaml`.

Reference: https://github.com/ROCm/aiter/actions/runs/26928407214/job/79443182554