### PR TITLE
perf: remove redundant __syncthreads() in allreduce block reduce

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -1443,7 +1443,6 @@ __device__ __forceinline__ T ar_fusion_epilogue_block_reduce(T val, int block_si
     }
     __syncthreads();
     val = (w_tid < num_warps) ? shared[w_tid] : T(0);
-    __syncthreads();
     val = warpReduceRuntime<functor, T>(val, reduce_width);
     return val;
 }


### PR DESCRIPTION
## Motivation

Optimize the allreduce fusion epilogue kernel for AMD MI300X (gfx942) by removing a redundant synchronization barrier. The `ar_fusion_epilogue_block_reduce()` function is used in fused allreduce+RMSNorm and allreduce+amax epilogues for 8-GPU collective operations (bf16).

## Technical Details

Remove one unnecessary `__syncthreads()` in `ar_fusion_epilogue_block_reduce()`.

After each warp writes its partial reduction to `shared[wid]` and all threads synchronize, every thread reads its lane's value from `shared[]`. The original code then issued a second `__syncthreads()` before the final `warpReduceRuntime()` — but this warp-level shuffle reduce does not access shared memory at all, making the barrier redundant.

Both call sites (`allreduce_rmsnorm_epilogue` and `allreduce_amax_epilogue`) issue their own `__syncthreads()` after the block reduce returns and before the next shared memory write, so the removed barrier provided no correctness guarantee.

## Test Plan

Run multi-GPU allreduce tests:
```
python op_tests/test_allreduce.py
```

## Test Result

Benchmarked on 8× MI300X across 18 shapes (1–512 tokens × hidden dims 5120/7168/8192), bf16:

| tokens | hidden_dim | baseline µs | optimized µs | change |
|--------|-----------|------------|-------------|--------|
| 1 | 5120 | 5.21 | 6.08 | +16.7% |
| 2 | 5120 | 5.67 | 5.04 | -11.0% |
| 8 | 5120 | 6.39 | 6.60 | +3.3% |
| 32 | 5120 | 7.81 | 7.41 | -5.1% |
| 128 | 5120 | 15.05 | 15.05 | +0.0% |
| 512 | 5120 | 38.55 | 38.34 | -0.5% |
| 1 | 7168 | 5.19 | 5.23 | +0.7% |
| 2 | 7168 | 5.64 | 5.33 | -5.5% |
| 8 | 7168 | 7.12 | 6.29 | -11.7% |
| 32 | 7168 | 8.45 | 8.88 | +5.1% |
| 128 | 7168 | 18.01 | 18.30 | +1.6% |
| 512 | 7168 | 52.03 | 51.89 | -0.3% |
| 1 | 8192 | 7.30 | 5.33 | -26.9% |
| 2 | 8192 | 7.17 | 6.05 | -15.6% |
| 8 | 8192 | 7.36 | 6.86 | -6.8% |
| 32 | 8192 | 8.82 | 8.94 | +1.3% |
| 128 | 8192 | 20.66 | 20.77 | +0.6% |
| 512 | 8192 | 57.71 | 57.46 | -0.4% |

Mean latency reduction: **3.0%** (averaged over 2 runs per shape). Largest gains at small token counts where synchronization overhead dominates kernel time. Note: single-token shapes show high run-to-run variance due to the kernel being synchronization-bound rather than compute-bound at these sizes.

Updated E2E Benchmark:

● Allreduce PR https://github.com/ROCm/aiter/pull/3549 — E2E Serving Benchmark

Setup: GPT-OSS-120B, TP8, FP8 KV cache, 8x MI300X, ATOM serving
Config: concurrency=2, num_prompts=8

┌─────────────────┬────────────────┬───────────────┬───────┬────────────┬───────────┬───────┐
│ Config (in/out) │ TPOT base (ms) │ TPOT opt (ms) │ Δ │ tok/s base │ tok/s opt │ Δ │
├─────────────────┼────────────────┼───────────────┼───────┼────────────┼───────────┼───────┤
│ 1/1K │ 4.54 │ 4.52 │ -0.4% │ 423.85 │ 426.60 │ +0.6% │
├─────────────────┼────────────────┼───────────────┼───────┼────────────┼───────────┼───────┤
│ 8K/1K │ 4.64 │ 4.63 │ -0.2% │ 411.67 │ 411.45 │ -0.1% │
├─────────────────┼────────────────┼───────────────┼───────┼────────────┼───────────┼───────┤
│ 1K/8K │ 4.59 │ 4.58 │ -0.2% │ 433.48 │ 434.59 │ +0.3% │
├─────────────────┼────────────────┼───────────────┼───────┼────────────┼───────────┼───────┤
│ 1K/1K │ 4.54 │ 4.54 │ 0.0% │ 420.35 │ 421.44 │ +0.3% │
└─────────────────┴────────────────┴───────────────┴───────┴────────────┴───────────┴───────┘


############################### DEPRECATED #################################################
Model: `openai/gpt-oss-120b` (TP8, FP8 KV cache) on 8× MI300X via ATOM serving.
Benchmark flags: `--num-prompts=8 --max-concurrency=2 --random-range-ratio=1.0 --request-rate=inf --ignore-eos`

### Output Token Throughput (tok/s)

| Config (in/out) | Baseline | PR #3549 | Delta |
|-----------------|----------|----------|-------|
| 1/1K            | 75.67    | 98.85    | +31%  |
| 8K/1K           | 59.85    | 87.23    | +46%  |
| 1K/8K           | 85.45    | 104.73   | +23%  |
| 1K/1K           | 69.05    | 93.51    | +35%  |

### Mean TPOT (ms)

| Config (in/out) | Baseline | PR #3549 | Delta |
|-----------------|----------|----------|-------|
| 1/1K            | 25.03    | 18.95    | -24%  |
| 8K/1K           | 28.21    | 18.96    | -33%  |
| 1K/8K           | 23.07    | 18.83    | -18%  |
| 1K/1K           | 26.32    | 17.60    | -33%  |


############################### DEPRECATED #################################################


## Submission Checklist
- [x] Reviewed contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)