### PR TITLE
CI: reuse prepared Aiter source in test jobs

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -26,6 +26,7 @@ env:
   GPU_ARCH_LIST: "gfx942;gfx950"
   AITER_TEST: "op_tests"
   AITER_WHEEL_ARTIFACT_NAME: aiter-whl-${{ github.run_id }}
+  AITER_SOURCE_ARTIFACT_NAME: aiter-source-${{ github.run_id }}
   AITER_PREBUILD_MAX_JOBS: "64"
   TRITON_WHEEL_ARTIFACT_NAME: triton_wheelhouse
 
@@ -242,12 +243,20 @@ jobs:
   split_aiter_tests:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    needs: [check-signal, build_aiter_wheels]
+    needs: [check-signal, build_aiter_wheels, prepare_triton_wheel]
     outputs:
       shard_count: 8
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Download Aiter source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AITER_SOURCE_ARTIFACT_NAME }}
+
+      - name: Extract Aiter source artifact
+        run: |
+          set -euo pipefail
+          tar -xzf aiter-source.tar.gz
+          chmod +x .github/scripts/*.sh
 
       - name: Split Aiter Tests (8 shards)
         run: ./.github/scripts/split_tests.sh --shards 8 --test-type aiter
@@ -266,6 +275,8 @@ jobs:
     with:
       docker-image: rocm/pytorch:latest
       artifact-name: triton_wheelhouse
+      checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      source-artifact-name: aiter-source-${{ github.run_id }}
       retention-days: 3
 
   standard:
@@ -345,10 +356,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Download Aiter source artifact
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: ${{ env.AITER_SOURCE_ARTIFACT_NAME }}
+
+      - name: Extract Aiter source artifact
+        run: |
+          set -euo pipefail
+          tar -xzf aiter-source.tar.gz
+          chmod +x .github/scripts/*.sh
 
       - name: Download test shard lists
         uses: actions/download-artifact@v4
@@ -436,20 +453,6 @@ jobs:
           else
             status=$?
             echo "::warning::GPU visibility check failed with exit code ${status}; continuing"
-          fi
-
-      - name: Sync CK submodule
-        run: |
-          set -ex
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "Nightly build: syncing latest CK from develop branch..."
-            git submodule set-branch --branch develop 3rdparty/composable_kernel
-            git submodule sync
-            git submodule update --init --recursive --remote --jobs 4
-          else
-            echo "Using pinned CK commit..."
-            git submodule sync
-            git submodule update --init --recursive --depth 1 --jobs 4
           fi
 
       - name: Install Aiter wheel
@@ -619,10 +622,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Download Aiter source artifact
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: ${{ env.AITER_SOURCE_ARTIFACT_NAME }}
+
+      - name: Extract Aiter source artifact
+        run: |
+          set -euo pipefail
+          tar -xzf aiter-source.tar.gz
+          chmod +x .github/scripts/*.sh
 
       - name: Download Aiter wheel artifact
         uses: actions/download-artifact@v4
@@ -693,20 +702,6 @@ jobs:
           else
             status=$?
             echo "::warning::GPU visibility check failed with exit code ${status}; continuing"
-          fi
-
-      - name: Sync CK submodule
-        run: |
-          set -ex
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "Nightly build: syncing latest CK from develop branch..."
-            git submodule set-branch --branch develop 3rdparty/composable_kernel
-            git submodule sync
-            git submodule update --init --recursive --remote --jobs 4
-          else
-            echo "Using pinned CK commit..."
-            git submodule sync
-            git submodule update --init --recursive --depth 1 --jobs 4
           fi
 
       - name: Install Aiter wheel

--- a/.github/workflows/prepare-triton-wheel.yaml
+++ b/.github/workflows/prepare-triton-wheel.yaml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ inputs.source-artifact-name != '' }}
         run: |
           set -euo pipefail
-          SOURCE_ARCHIVE=aiter-source.tar.gz
+          SOURCE_ARCHIVE="${RUNNER_TEMP}/aiter-source.tar.gz"
           rm -f "${SOURCE_ARCHIVE}"
           tar \
             --exclude=".git" \
@@ -80,7 +80,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.source-artifact-name }}
-          path: aiter-source.tar.gz
+          path: ${{ runner.temp }}/aiter-source.tar.gz
           retention-days: ${{ inputs.retention-days }}
 
       - name: Download Triton wheel

--- a/.github/workflows/prepare-triton-wheel.yaml
+++ b/.github/workflows/prepare-triton-wheel.yaml
@@ -66,12 +66,12 @@ jobs:
           tar \
             --exclude=".git" \
             --exclude="*/.git" \
-            --exclude="dist" \
-            --exclude="build" \
-            --exclude="aiter_meta" \
-            --exclude="*.egg-info" \
+            --exclude="./dist" \
+            --exclude="./build" \
+            --exclude="./aiter_meta" \
+            --exclude="./*.egg-info" \
             --exclude=".aiter-prebuild.*" \
-            --exclude="triton_wheels" \
+            --exclude="./triton_wheels" \
             --exclude="${SOURCE_ARCHIVE}" \
             -czf "${SOURCE_ARCHIVE}" .
 

--- a/.github/workflows/prepare-triton-wheel.yaml
+++ b/.github/workflows/prepare-triton-wheel.yaml
@@ -13,6 +13,16 @@ on:
         required: false
         type: string
         default: triton_wheelhouse
+      checkout-ref:
+        description: Git ref or SHA to check out before preparing artifacts.
+        required: false
+        type: string
+        default: ""
+      source-artifact-name:
+        description: Name of the source archive artifact uploaded for the caller workflow run.
+        required: false
+        type: string
+        default: ""
       retention-days:
         description: Number of days to keep the Triton wheel artifact.
         required: false
@@ -28,6 +38,50 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref || github.sha }}
+
+      - name: Sync submodules for source archive
+        if: ${{ inputs.source-artifact-name != '' }}
+        run: |
+          set -ex
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Nightly build: syncing latest CK from develop branch..."
+            git submodule set-branch --branch develop 3rdparty/composable_kernel
+            git submodule sync
+            git submodule update --init --recursive --remote --jobs 4
+          else
+            echo "Using pinned CK commit..."
+            git submodule sync
+            git submodule update --init --recursive --depth 1 --jobs 4
+          fi
+          echo "CK commit: $(git -C 3rdparty/composable_kernel rev-parse HEAD)"
+
+      - name: Create source archive
+        if: ${{ inputs.source-artifact-name != '' }}
+        run: |
+          set -euo pipefail
+          SOURCE_ARCHIVE=aiter-source.tar.gz
+          rm -f "${SOURCE_ARCHIVE}"
+          tar \
+            --exclude=".git" \
+            --exclude="*/.git" \
+            --exclude="dist" \
+            --exclude="build" \
+            --exclude="aiter_meta" \
+            --exclude="*.egg-info" \
+            --exclude=".aiter-prebuild.*" \
+            --exclude="triton_wheels" \
+            --exclude="${SOURCE_ARCHIVE}" \
+            -czf "${SOURCE_ARCHIVE}" .
+
+      - name: Upload source archive artifact
+        if: ${{ inputs.source-artifact-name != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.source-artifact-name }}
+          path: aiter-source.tar.gz
+          retention-days: ${{ inputs.retention-days }}
 
       - name: Download Triton wheel
         id: download_triton_wheel

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -26,6 +26,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  AITER_SOURCE_ARTIFACT_NAME: aiter-source-${{ github.run_id }}
+  TRITON_WHEEL_ARTIFACT_NAME: triton_wheelhouse
+
 jobs:
   check-signal:
     if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') }}
@@ -44,12 +48,20 @@ jobs:
   split_triton_tests:
     if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') }}
     runs-on: ubuntu-latest
-    needs: [check-signal]
+    needs: [check-signal, prepare_triton_wheel]
     outputs:
       shard_count: 8
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Download Aiter source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AITER_SOURCE_ARTIFACT_NAME }}
+
+      - name: Extract Aiter source artifact
+        run: |
+          set -euo pipefail
+          tar -xzf aiter-source.tar.gz
+          chmod +x .github/scripts/*.sh
 
       - name: Split Triton Tests (8 shards)
         run: ./.github/scripts/split_tests.sh --shards 8 --test-type triton
@@ -68,6 +80,8 @@ jobs:
     with:
       docker-image: rocm/pytorch:latest
       artifact-name: triton_wheelhouse
+      checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      source-artifact-name: aiter-source-${{ github.run_id }}
       retention-days: 3
 
   # Step 2: MI35X matrix jobs
@@ -85,11 +99,16 @@ jobs:
       TRITON_TEST: "op_tests/triton_tests/"
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Download Aiter source artifact
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 1
-          submodules: 'recursive'
+          name: ${{ env.AITER_SOURCE_ARTIFACT_NAME }}
+
+      - name: Extract Aiter source artifact
+        run: |
+          set -euo pipefail
+          tar -xzf aiter-source.tar.gz
+          chmod +x .github/scripts/*.sh
 
       - name: Download test shard lists
         uses: actions/download-artifact@v4
@@ -103,7 +122,7 @@ jobs:
         timeout-minutes: 15
         continue-on-error: true
         with:
-          name: triton_wheelhouse
+          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
           path: triton_wheels
 
       - name: List test shard files
@@ -220,11 +239,16 @@ jobs:
       TRITON_TEST: "op_tests/triton_tests/"
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Download Aiter source artifact
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 1
-          submodules: 'recursive'
+          name: ${{ env.AITER_SOURCE_ARTIFACT_NAME }}
+
+      - name: Extract Aiter source artifact
+        run: |
+          set -euo pipefail
+          tar -xzf aiter-source.tar.gz
+          chmod +x .github/scripts/*.sh
 
       - name: Download test shard lists
         uses: actions/download-artifact@v4
@@ -238,7 +262,7 @@ jobs:
         timeout-minutes: 15
         continue-on-error: true
         with:
-          name: triton_wheelhouse
+          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
           path: triton_wheels
 
       - name: List test shard files


### PR DESCRIPTION
## Summary
- Extend the Triton wheel preparation workflow to optionally upload a source archive with CK submodules already synced.
- Reuse the prepared source archive in Aiter split, standard, and multi-GPU test jobs instead of repeating checkout and CK submodule sync in each shard.

## Test plan
- Parsed `.github/workflows/aiter-test.yaml` and `.github/workflows/prepare-triton-wheel.yaml` with PyYAML.
- Ran `git diff --check`.
- Checked workflow markers to confirm shard jobs consume the source artifact and no longer contain the `Sync CK submodule` step.