### PR TITLE
[fmoe] Add EP Support to Two-Stage MoE Op Tests

### DIFF
--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -75,9 +75,13 @@ def test_fmoe(
     strict_accuracy=True,
     check_aot_cache=True,
     swiglu_limit=0.0,
+    ep=1,
 ):
     if get_gfx() not in ["gfx950"] and qType in [aiter.QuantType.per_1x32]:
         return
+    if ep < 1:
+        raise ValueError(f"ep must be >= 1, got {ep}")
+    global_E = E * ep
     torch_quant = aiter.get_torch_quant(qType)
     input = torch.randn((token, model_dim), dtype=dtype)
     if use_g1u1:
@@ -98,17 +102,49 @@ def test_fmoe(
         w2[:, -hidden_pad:, :] = 0
     exp_bias2 = torch.clamp(torch.randn((E, model_dim), dtype=dtype), -1.0, 1.0)
     if AITER_MOE_EXPERT_BALANCE:
-        score = torch.zeros((token, E), dtype=dtype)
+        score = torch.zeros((token, global_E), dtype=dtype)
         start_col = 0
         end_col = topk
         for token_id in range(token):
             score[token_id, start_col:end_col] = 1.0
-            start_col = end_col % E
+            start_col = end_col % global_E
             end_col = start_col + topk
     else:
-        score = torch.randn((token, E), dtype=dtype)
+        score = torch.randn((token, global_E), dtype=dtype)
 
     topk_weights, topk_ids = fused_topk(input, score, topk, True)
+    expert_mask = None
+    num_local_tokens = None
+    if ep > 1:
+        padded_token = token
+        local_hit = topk_ids < E
+        token_mask = local_hit.any(dim=1)
+        if not token_mask.any():
+            logging.warning(
+                "skip EP case: no tokens routed to rank0 local experts "
+                "(%s global tokens, %s global experts, %s local experts)",
+                token,
+                global_E,
+                E,
+            )
+            return
+        local_input = input[token_mask]
+        local_topk_weights = topk_weights[token_mask]
+        local_topk_ids = topk_ids[token_mask]
+        local_token = local_input.shape[0]
+        num_local_tokens = torch.tensor(
+            [local_token], dtype=topk_ids.dtype, device=input.device
+        )
+
+        expert_mask = torch.zeros((global_E,), dtype=dtypes.i32)
+        expert_mask[:E] = 1
+
+        input = torch.zeros((padded_token, model_dim), dtype=input.dtype)
+        input[:local_token] = local_input
+        topk_weights = torch.zeros((padded_token, topk), dtype=topk_weights.dtype)
+        topk_weights[:local_token] = local_topk_weights
+        topk_ids = torch.zeros((padded_token, topk), dtype=topk_ids.dtype)
+        topk_ids[:local_token] = local_topk_ids
 
     if qType == aiter.QuantType.per_Tensor:
         w1_qt, w1_scale = aiter.pertoken_quant(w1.view(E, -1), quant_dtype=WQDType)
@@ -352,6 +388,8 @@ def test_fmoe(
         w2_qt_aiter,
         topk_weights,
         topk_ids,
+        expert_mask=expert_mask,
+        num_local_tokens=num_local_tokens,
         w1_scale=w1_scale_aiter,
         w2_scale=w2_scale_aiter,
         quant_type=qType,
@@ -366,6 +404,10 @@ def test_fmoe(
         num_iters=5,
         num_warmup=2,
     )
+    if num_local_tokens is not None:
+        valid_token = num_local_tokens.item()
+        out2_ref = out2_ref[:valid_token]
+        out2_ck = out2_ck[:valid_token]
     err = checkAllclose(
         out2_ref,
         out2_ck,
@@ -503,8 +545,16 @@ parser.add_argument(
     "--expert",
     type=int,
     default=257,
-    help="""Number of experts.
+    help="""Number of local experts.
     e.g.: -e 8""",
+)
+parser.add_argument(
+    "--ep",
+    type=int,
+    default=1,
+    help="""Expert parallel size. With EP > 1, routing is generated over
+    expert * ep global experts while this script simulates rank0.
+    e.g.: --ep 8""",
 )
 
 parser.add_argument(
@@ -741,6 +791,7 @@ def _iter_legacy_cases():
             doweight_stage1=doweight_stage1,
             strict_accuracy=False,
             check_aot_cache=False,
+            ep=args.ep,
             **over,
         )
 


### PR DESCRIPTION

## Motivation

The previous unit test only covered the common non-EP path. Add an EP mode that routes over global experts, simulates rank0 local expert ownership, pads local tokens back to the original shape, and passes num_local_tokens for the fused_moe path.

cc @Duyi-Wang 

## Technical Details

- Add an `ep` option to the legacy two-stage MoE UT path.
- Treat `--expert` as the number of local experts when `ep > 1`.
- Generate routing scores with shape `[token, expert * ep]` so top-k routing can select global experts.
- Simulate rank0 ownership by setting `expert_mask[:expert] = 1` and masking all remote experts through the existing `fused_moe` EP path.
- Filter tokens that have at least one rank0-local expert hit.
- Pad the filtered `input`, `topk_weights`, and `topk_ids` tensors back to the original token shape before calling `fused_moe`.
- Pass `num_local_tokens` to preserve the actual number of valid local tokens.
- Compare only the valid local-token portion of the output for EP cases.
- Preserve existing non-EP behavior when `ep == 1`.
## Test Plan
MI355
```
 python3 op_tests/test_moe_2stage.py \
                              --no-flydsl-csv \
                              -q 4 \
                              -d bf16 \
                              -dim 7168,2048 \
                              -t 128 256 512 \
                              -e 32 \
                              --ep 8 \
                              -k 8 \
                              -a silu \
                              -s f
```

## Test Result

```
| dtype          |   token |   model_dim |   inter_dim |   E |   topk |   actType | gateMode   |   qType | AQDType                | WQDType                | use_g1u1   | doweight_stage1   | strict_accuracy   | check_aot_cache   |   ep | preshuffle   |   hidden_pad |   intermediate_pad |   swiglu_limit |      us |   logits_diff | model   |
|:---------------|--------:|------------:|------------:|----:|-------:|----------:|:-----------|--------:|:-----------------------|:-----------------------|:-----------|:------------------|:------------------|:------------------|-----:|:-------------|-------------:|-------------------:|---------------:|--------:|--------------:|:--------|
| torch.bfloat16 |     128 |        7168 |        2048 |  32 |      8 |         0 | separated  |       3 | torch.float4_e2m1fn_x2 | torch.float4_e2m1fn_x2 | True       | False             | False             | False             |    8 | True         |            0 |                  0 |              0 | 580.948 |   2.59266e-06 | legacy  |
| torch.bfloat16 |     256 |        7168 |        2048 |  32 |      8 |         0 | separated  |       3 | torch.float4_e2m1fn_x2 | torch.float4_e2m1fn_x2 | True       | False             | False             | False             |    8 | True         |            0 |                  0 |              0 | 578.488 |   3.0777e-06  | legacy  |
| torch.bfloat16 |     512 |        7168 |        2048 |  32 |      8 |         0 | separated  |       3 | torch.float4_e2m1fn_x2 | torch.float4_e2m1fn_x2 | True       | False             | False             | False             |    8 | True         |            0 |                  0 |              0 | 562.167 |   2.73326e-06 | legacy  |
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
