### PR TITLE
Fix e8m0 conversion to fp32

### DIFF
--- a/op_tests/triton_tests/gemm/basic/test_gemm_a16wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_a16wfp4.py
@@ -7,6 +7,7 @@ from aiter.ops.triton.gemm.basic.gemm_a16wfp4 import (
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import shuffle_scales
 from aiter.ops.shuffle import shuffle_weight
+from aiter.utility.fp4_utils import e8m0_to_f32
 
 # Note this is specified by the HW and cannot be changed.
 SCALE_GROUP_SIZE = 32
@@ -110,12 +111,6 @@ def mxfp4_to_f32(x):
     ]
     mxfp4_in_f32 = torch.tensor(mxfp4_list, dtype=torch.float32, device="cuda")
     return mxfp4_in_f32[x.long()]
-
-
-def e8m0_to_f32(x):
-    x_f32 = 2 ** (x.to(torch.float32) - 127)
-    x_f32[x_f32 == 128] = float("nan")
-    return x_f32
 
 
 def run_torch(x, w, w_scales, dtype):

--- a/op_tests/triton_tests/gemm/basic/test_gemm_a8wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_a8wfp4.py
@@ -7,6 +7,7 @@ from enum import Enum
 from aiter.ops.triton.gemm.basic.gemm_a8wfp4 import gemm_a8wfp4
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils import types
+from aiter.utility.fp4_utils import e8m0_to_f32
 from typing import Union
 
 # Debug
@@ -237,12 +238,6 @@ def mxfp4_to_f32(x):
     x[:, 1::2] = x[:, 1::2] >> 4
     mxfp4_in_f32 = torch.tensor(MXFP4_TABLE, dtype=torch.float32, device="cuda")
     return mxfp4_in_f32[x.long()]
-
-
-def e8m0_to_f32(x):
-    x_f32 = 2 ** ((x.to(torch.float32) - 127))
-    x_f32[x == 128] = float("nan")
-    return x_f32
 
 
 def dequantize_fp8(x_quantized, x_scales, dtype=torch.float32):

--- a/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
@@ -10,6 +10,7 @@ from aiter.ops.triton.gluon.gemm_afp4wfp4 import gemm_afp4wfp4 as gluon_gemm_afp
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils.types import str_to_torch_dtype
 from aiter.ops.shuffle import shuffle_weight
+from aiter.utility.fp4_utils import e8m0_to_f32
 
 DEVICE_ARCH = arch_info.get_arch()
 
@@ -165,12 +166,6 @@ def mxfp4_to_f32(x):
     ]
     mxfp4_in_f32 = torch.tensor(mxfp4_list, dtype=torch.float32, device="cuda")
     return mxfp4_in_f32[x.long()]
-
-
-def e8m0_to_f32(x):
-    x_f32 = 2 ** ((x - 127).to(torch.float32))
-    x_f32[x_f32 == 128] = float("nan")
-    return x_f32
 
 
 def run_torch(x, w, x_scales, w_scales, dtype):

--- a/op_tests/triton_tests/gemm/basic/test_gemm_afp8wfp8.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_afp8wfp8.py
@@ -10,16 +10,12 @@ from aiter.ops.triton.gemm.basic.gemm_afp8wfp8 import (
 )
 from aiter.ops.shuffle import shuffle_weight
 import aiter.ops.triton.utils._triton.arch_info as arch_info
+from aiter.utility.fp4_utils import e8m0_to_f32
 
 SCALE_GROUP_SIZE = 32  # A: 1x32 e8m0 scale group
 W_SCALE_K_GROUP = 128  # B: 128 in K direction
 W_SCALE_N_GROUP = 128  # B: 128 in N direction
 FP8_MAX = 448.0  # e4m3 max
-
-
-def e8m0_to_f32(x: torch.Tensor) -> torch.Tensor:
-    """Decode unsigned-biased e8m0 (uint8) to fp32. Bias 127, value = 2^(b-127)."""
-    return torch.exp2((x.to(torch.int32) - 127).to(torch.float32))
 
 
 def generate_inputs(M: int, N: int, K: int, shuffle: bool = False):

--- a/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
+++ b/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
@@ -4,6 +4,7 @@ from aiter.ops.triton.gemm.batched.batched_gemm_a16wfp4 import (
     batched_gemm_a16wfp4,
 )
 import aiter.ops.triton.utils._triton.arch_info as arch_info
+from aiter.utility.fp4_utils import e8m0_to_f32
 
 # Note this is specified by the HW and cannot be changed.
 SCALE_GROUP_SIZE = 32
@@ -149,12 +150,6 @@ def mxfp4_to_f32(x):
     ]
     mxfp4_in_f32 = torch.tensor(mxfp4_list, dtype=torch.float32, device="cuda")
     return mxfp4_in_f32[x.long()]
-
-
-def e8m0_to_f32(x):
-    x_f32 = 2 ** (x.to(torch.float32) - 127)
-    x_f32[x_f32 == 128] = float("nan")
-    return x_f32
 
 
 def run_torch(x, w, w_scales, dtype):

--- a/op_tests/triton_tests/gemm/batched/test_batched_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/gemm/batched/test_batched_gemm_afp4wfp4.py
@@ -2,6 +2,7 @@ import torch
 import pytest
 from aiter.ops.triton.gemm.batched.batched_gemm_afp4wfp4 import batched_gemm_afp4wfp4
 import aiter.ops.triton.utils._triton.arch_info as arch_info
+from aiter.utility.fp4_utils import e8m0_to_f32
 from typing import Union
 
 # Note this is specified by the HW and cannot be changed.
@@ -160,12 +161,6 @@ def mxfp4_to_f32(x):
     ]
     mxfp4_in_f32 = torch.tensor(mxfp4_list, dtype=torch.float32, device="cuda")
     return mxfp4_in_f32[x.long()]
-
-
-def e8m0_to_f32(x):
-    x_f32 = 2 ** ((x - 127).to(torch.float32))
-    x_f32[x_f32 == 128] = float("nan")
-    return x_f32
 
 
 def run_torch(x, w, x_scales, w_scales, dtype):

--- a/op_tests/triton_tests/moe/test_moe_mx.py
+++ b/op_tests/triton_tests/moe/test_moe_mx.py
@@ -14,6 +14,7 @@ from op_tests.triton_tests.moe.test_moe import (
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils.moe_config_utils import get_optimal_moe_config_func
 from aiter.ops.triton.utils.moe_common import torch_silu_and_mul_ref
+from aiter.utility.fp4_utils import e8m0_to_f32
 
 DEBUG_MODE = False
 
@@ -159,12 +160,6 @@ def mxfp4_to_f32(x):
     ]
     mxfp4_in_f32 = torch.tensor(mxfp4_list, dtype=torch.float32, device="cuda")
     return mxfp4_in_f32[x.long()]
-
-
-def e8m0_to_f32(x):
-    x_f32 = 2 ** ((x - 127).to(torch.float32))
-    x_f32[x_f32 == 128] = float("nan")
-    return x_f32
 
 
 def torch_mxfp4_to_fp32(x, x_scales):

--- a/op_tests/triton_tests/quant/test_quant_mxfp8.py
+++ b/op_tests/triton_tests/quant/test_quant_mxfp8.py
@@ -14,6 +14,7 @@ from aiter.ops.triton.quant.fused_mxfp8_quant import (
     fused_flatten_mxfp8_quant,
 )
 import aiter.ops.triton.utils._triton.arch_info as arch_info
+from aiter.utility.fp4_utils import e8m0_to_f32
 
 QUANT_BLOCK_SIZE = 32
 LEGACY_BLOCK_SIZE = 128
@@ -48,10 +49,6 @@ def torch_mxfp8_quant_from_fp32(x_fp32: torch.Tensor):
     y_fp8 = qx.to(torch.float8_e4m3fn)
     s = scale_e8m0.reshape(M, Ng)
     return y_fp8, s
-
-
-def e8m0_to_f32(x: torch.Tensor) -> torch.Tensor:
-    return torch.exp2((x.to(torch.int32) - 127).to(torch.float32))
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

`e8m0_to_f32()` function of many test modules incorrectly mapped legitimate e8m0 x==134 to NaN, while actual NaN (=255 in e8m0) was mapped to an infinity, which isn't a part of e8m0. It was replaced by aiter's own correct (but very suboptimal, which is out of scope of this PR) implementation from `aiter.utility.fp4_utils` module.


[x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
