### PR TITLE
CI: add fallback Triton wheel download

### DIFF
--- a/.github/scripts/download_triton_wheel.sh
+++ b/.github/scripts/download_triton_wheel.sh
@@ -8,11 +8,14 @@ mkdir -p "${TRITON_WHEEL_DIR}"
 python3 -m pip config set global.retries 15
 python3 -m pip config set global.timeout 120
 
-TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/"
+TRITON_DEFAULT_ROCM_VERSION="${TRITON_DEFAULT_ROCM_VERSION:-7.2.0}"
+TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${TRITON_DEFAULT_ROCM_VERSION}/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
 if [[ -n "${ROCM_VERSION}" ]]; then
     ROCM_MAJOR_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f1,2)
     TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
+else
+    echo "rocm-core not found; using default ROCm version ${TRITON_DEFAULT_ROCM_VERSION}"
 fi
 
 echo "Downloading triton wheel from ${TRITON_INDEX_URL} into ${TRITON_WHEEL_DIR}"

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -351,19 +351,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download test shard lists
-        id: download_aiter_shards
-        uses: actions/download-artifact@v4
-        timeout-minutes: 15
-        continue-on-error: true
-        with:
-          name: aiter_shards
-
-      - name: Clean up test shard list download before retry
-        if: ${{ steps.download_aiter_shards.outcome == 'failure' }}
-        run: rm -f aiter_shard_*.list
-
-      - name: Retry download test shard lists
-        if: ${{ steps.download_aiter_shards.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -380,20 +367,6 @@ jobs:
           echo "$AITER_TEST"
 
       - name: Download Aiter wheel artifact
-        id: download_aiter_wheel
-        uses: actions/download-artifact@v4
-        timeout-minutes: 15
-        continue-on-error: true
-        with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
-          path: aiter_wheels
-
-      - name: Clean up Aiter wheel download before retry
-        if: ${{ steps.download_aiter_wheel.outcome == 'failure' }}
-        run: rm -rf aiter_wheels
-
-      - name: Retry download Aiter wheel artifact
-        if: ${{ steps.download_aiter_wheel.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -401,20 +374,6 @@ jobs:
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
-        id: download_triton_wheel_artifact
-        uses: actions/download-artifact@v4
-        timeout-minutes: 15
-        continue-on-error: true
-        with:
-          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
-          path: triton_wheels
-
-      - name: Clean up Triton wheel download before retry
-        if: ${{ steps.download_triton_wheel_artifact.outcome == 'failure' }}
-        run: rm -rf triton_wheels
-
-      - name: Retry download Triton wheel artifact
-        if: ${{ steps.download_triton_wheel_artifact.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         continue-on-error: true
@@ -614,20 +573,6 @@ jobs:
     needs: [standard]
     steps:
       - name: Download all test logs
-        id: download_standard_test_logs
-        uses: actions/download-artifact@v4
-        timeout-minutes: 15
-        continue-on-error: true
-        with:
-          pattern: standard-test-log-*-shard-*
-          path: .
-
-      - name: Clean up standard test logs before retry
-        if: ${{ steps.download_standard_test_logs.outcome == 'failure' }}
-        run: rm -rf standard-test-log-*-shard-*
-
-      - name: Retry download all test logs
-        if: ${{ steps.download_standard_test_logs.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -680,20 +625,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download Aiter wheel artifact
-        id: download_multigpu_aiter_wheel
-        uses: actions/download-artifact@v4
-        timeout-minutes: 15
-        continue-on-error: true
-        with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
-          path: aiter_wheels
-
-      - name: Clean up multi-GPU Aiter wheel download before retry
-        if: ${{ steps.download_multigpu_aiter_wheel.outcome == 'failure' }}
-        run: rm -rf aiter_wheels
-
-      - name: Retry download Aiter wheel artifact
-        if: ${{ steps.download_multigpu_aiter_wheel.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -701,20 +632,6 @@ jobs:
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
-        id: download_multigpu_triton_wheel_artifact
-        uses: actions/download-artifact@v4
-        timeout-minutes: 15
-        continue-on-error: true
-        with:
-          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
-          path: triton_wheels
-
-      - name: Clean up multi-GPU Triton wheel download before retry
-        if: ${{ steps.download_multigpu_triton_wheel_artifact.outcome == 'failure' }}
-        run: rm -rf triton_wheels
-
-      - name: Retry download Triton wheel artifact
-        if: ${{ steps.download_multigpu_triton_wheel_artifact.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         continue-on-error: true
@@ -919,20 +836,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download standard test logs (mi35x only)
-        id: download_tuned_op_logs
-        uses: actions/download-artifact@v4
-        timeout-minutes: 15
-        continue-on-error: true
-        with:
-          pattern: standard-test-log-linux-aiter-mi35x-1-shard-*
-          path: /tmp/logs/
-
-      - name: Clean up tuned op logs before retry
-        if: ${{ steps.download_tuned_op_logs.outcome == 'failure' }}
-        run: rm -rf /tmp/logs
-
-      - name: Retry download standard test logs (mi35x only)
-        if: ${{ steps.download_tuned_op_logs.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         continue-on-error: true

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -351,6 +351,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download test shard lists
+        id: download_aiter_shards
+        uses: actions/download-artifact@v4
+        timeout-minutes: 15
+        continue-on-error: true
+        with:
+          name: aiter_shards
+
+      - name: Clean up test shard list download before retry
+        if: ${{ steps.download_aiter_shards.outcome == 'failure' }}
+        run: rm -f aiter_shard_*.list
+
+      - name: Retry download test shard lists
+        if: ${{ steps.download_aiter_shards.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -367,6 +380,20 @@ jobs:
           echo "$AITER_TEST"
 
       - name: Download Aiter wheel artifact
+        id: download_aiter_wheel
+        uses: actions/download-artifact@v4
+        timeout-minutes: 15
+        continue-on-error: true
+        with:
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          path: aiter_wheels
+
+      - name: Clean up Aiter wheel download before retry
+        if: ${{ steps.download_aiter_wheel.outcome == 'failure' }}
+        run: rm -rf aiter_wheels
+
+      - name: Retry download Aiter wheel artifact
+        if: ${{ steps.download_aiter_wheel.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -374,6 +401,20 @@ jobs:
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
+        id: download_triton_wheel_artifact
+        uses: actions/download-artifact@v4
+        timeout-minutes: 15
+        continue-on-error: true
+        with:
+          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
+          path: triton_wheels
+
+      - name: Clean up Triton wheel download before retry
+        if: ${{ steps.download_triton_wheel_artifact.outcome == 'failure' }}
+        run: rm -rf triton_wheels
+
+      - name: Retry download Triton wheel artifact
+        if: ${{ steps.download_triton_wheel_artifact.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         continue-on-error: true
@@ -573,6 +614,20 @@ jobs:
     needs: [standard]
     steps:
       - name: Download all test logs
+        id: download_standard_test_logs
+        uses: actions/download-artifact@v4
+        timeout-minutes: 15
+        continue-on-error: true
+        with:
+          pattern: standard-test-log-*-shard-*
+          path: .
+
+      - name: Clean up standard test logs before retry
+        if: ${{ steps.download_standard_test_logs.outcome == 'failure' }}
+        run: rm -rf standard-test-log-*-shard-*
+
+      - name: Retry download all test logs
+        if: ${{ steps.download_standard_test_logs.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -625,6 +680,20 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download Aiter wheel artifact
+        id: download_multigpu_aiter_wheel
+        uses: actions/download-artifact@v4
+        timeout-minutes: 15
+        continue-on-error: true
+        with:
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          path: aiter_wheels
+
+      - name: Clean up multi-GPU Aiter wheel download before retry
+        if: ${{ steps.download_multigpu_aiter_wheel.outcome == 'failure' }}
+        run: rm -rf aiter_wheels
+
+      - name: Retry download Aiter wheel artifact
+        if: ${{ steps.download_multigpu_aiter_wheel.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         with:
@@ -632,6 +701,20 @@ jobs:
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
+        id: download_multigpu_triton_wheel_artifact
+        uses: actions/download-artifact@v4
+        timeout-minutes: 15
+        continue-on-error: true
+        with:
+          name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
+          path: triton_wheels
+
+      - name: Clean up multi-GPU Triton wheel download before retry
+        if: ${{ steps.download_multigpu_triton_wheel_artifact.outcome == 'failure' }}
+        run: rm -rf triton_wheels
+
+      - name: Retry download Triton wheel artifact
+        if: ${{ steps.download_multigpu_triton_wheel_artifact.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         continue-on-error: true
@@ -836,6 +919,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download standard test logs (mi35x only)
+        id: download_tuned_op_logs
+        uses: actions/download-artifact@v4
+        timeout-minutes: 15
+        continue-on-error: true
+        with:
+          pattern: standard-test-log-linux-aiter-mi35x-1-shard-*
+          path: /tmp/logs/
+
+      - name: Clean up tuned op logs before retry
+        if: ${{ steps.download_tuned_op_logs.outcome == 'failure' }}
+        run: rm -rf /tmp/logs
+
+      - name: Retry download standard test logs (mi35x only)
+        if: ${{ steps.download_tuned_op_logs.outcome == 'failure' }}
         uses: actions/download-artifact@v4
         timeout-minutes: 15
         continue-on-error: true

--- a/.github/workflows/prepare-triton-wheel.yaml
+++ b/.github/workflows/prepare-triton-wheel.yaml
@@ -31,18 +31,32 @@ jobs:
 
       - name: Download Triton wheel
         id: download_triton_wheel
-        continue-on-error: true
+        env:
+          TRITON_DEFAULT_ROCM_VERSION: "7.2.0"
         run: |
-          set -ex
-          bash .github/scripts/docker_pull_with_retry.sh "${{ inputs.docker-image }}"
-          docker run --rm \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            "${{ inputs.docker-image }}" \
-            bash ./.github/scripts/download_triton_wheel.sh triton_wheels
+          set -euo pipefail
+          rm -rf triton_wheels
+
+          if bash .github/scripts/docker_pull_with_retry.sh "${{ inputs.docker-image }}"; then
+            if docker run --rm \
+              -v "${{ github.workspace }}:/workspace" \
+              -w /workspace \
+              "${{ inputs.docker-image }}" \
+              bash ./.github/scripts/download_triton_wheel.sh triton_wheels; then
+              echo "source=image" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            echo "::warning::Triton wheel download inside ${{ inputs.docker-image }} failed; falling back to ROCm ${TRITON_DEFAULT_ROCM_VERSION}"
+          else
+            echo "::warning::Failed to pull ${{ inputs.docker-image }}; falling back to ROCm ${TRITON_DEFAULT_ROCM_VERSION}"
+          fi
+
+          docker system prune -af || true
+          rm -rf triton_wheels
+          bash ./.github/scripts/download_triton_wheel.sh triton_wheels
+          echo "source=fallback-rocm-${TRITON_DEFAULT_ROCM_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload Triton wheel artifact
-        if: ${{ steps.download_triton_wheel.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}


### PR DESCRIPTION
## Summary
- Keep the Triton wheel preparation job using the target image when it can be pulled successfully.
- Fall back to downloading from the ROCm 7.2.0 Triton index when the image pull or in-image download fails, so downstream jobs still get a `triton_wheelhouse` artifact.

## Test plan
- `bash -n .github/scripts/download_triton_wheel.sh`
- Parsed `.github/workflows/prepare-triton-wheel.yaml` with PyYAML.
- Verified the ROCm 7.2.0 Triton simple index is reachable and contains cp310/cp311/cp312 wheels.