### PR TITLE
CI: extend large artifact download timeouts

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -575,7 +575,7 @@ jobs:
     steps:
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           pattern: aiter-whl-packages-py*
           path: all-wheels

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -368,14 +368,14 @@ jobs:
 
       - name: Download Aiter wheel artifact
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         with:
           name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}
@@ -626,14 +626,14 @@ jobs:
 
       - name: Download Aiter wheel artifact
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         with:
           name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}

--- a/.github/workflows/test-whl.yaml
+++ b/.github/workflows/test-whl.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Download wheel artifacts
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           pattern: aiter-whl-packages-py*
           path: dist

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Download Triton wheel artifact
         id: download_triton_wheel
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         with:
           name: triton_wheelhouse
@@ -235,7 +235,7 @@ jobs:
       - name: Download Triton wheel artifact
         id: download_triton_wheel
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         with:
           name: triton_wheelhouse

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -169,14 +169,14 @@ jobs:
 
       - name: Download Aiter wheel artifact
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
         uses: actions/download-artifact@v4
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         with:
           name: ${{ env.TRITON_WHEEL_ARTIFACT_NAME }}


### PR DESCRIPTION
## Summary
- Increase timeout for large wheel and wheelhouse artifact downloads from 15 to 30 minutes.
- Cover Aiter, Triton, vLLM benchmark, wheel test, and release wheel collection workflows.
- Keep small shard, log, documentation, and monitoring artifact downloads unchanged.

## Test plan
- Parsed all changed workflow YAML files with PyYAML.
- Ran `git diff --check`.