### PR TITLE
[MoE] Raise clear error for unsupported Swiglu+MXFP4 CK2stages dispatch

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1549,6 +1549,24 @@ def get_2stage_cfgs(
             stage2_has_bias=activation == ActivationType.Swiglu,
         )
 
+    # CK 2-stage MoE does not currently codegen a Swiglu specialization for
+    # MXFP4 (gen_instances.py only emits -act {silu,gelu}). If dispatch lands
+    # here for that combination the JIT compile fails with a missing lookup
+    # header. Refuse it explicitly rather than silently falling through.
+    # Tracked: ROCm/aiter#TODO
+    if (
+        activation == ActivationType.Swiglu
+        and q_type == QuantType.per_1x32
+        and q_dtype_w == dtypes.fp4x2
+        and not (kernelName1 and "ck2stages" in kernelName1)
+    ):
+        raise NotImplementedError(
+            "CK 2-stage MoE has no Swiglu+MXFP4 specialization; this "
+            "combination must be routed to CK-Tile or FlyDSL upstream. "
+            f"Got q_type={q_type}, q_dtype_a={q_dtype_a}, q_dtype_w={q_dtype_w}, "
+            f"is_shuffled={is_shuffled}, gate_mode={gate_mode}."
+        )
+
     if (kernelName1 and "ck2stages" in kernelName1) or (
         not kernelName1
         and (


### PR DESCRIPTION
## Motivation

When `(activation=Swiglu, q_type=per_1x32, q_dtype_w=fp4x2)` reaches
the CK 2-stage MoE fallback in `get_2stage_cfgs` without an explicit
`ck2stages` `kernelName1`, the JIT path tries to build the module
`module_moe_ck2stages_fp4x2_fp4x2_preshuffle_off_b16_swiglu_per_1x32_mulWeightStage2`.

The CK 2-stage codegen script
(`csrc/ck_gemm_moe_2stages_codegen/gen_instances.py`) only accepts
`-act {silu,gelu}` — there is no Swiglu specialization. The build
errors out with `argument -act/--activation: invalid choice: 'swiglu'`,
which surfaces in vLLM as a confusing `ModuleNotFoundError` on a CK2stages module name and is also responsible
for the silent accuracy-collapse seen in
`openai/gpt-oss-120b` TP=8 on aiter 0.1.14 (gsm8k flexible-extract
drops to 0.000).

## Technical Details

Add an explicit guard in `get_2stage_cfgs` that raises
`NotImplementedError` for this combination before the CK 2-stage
fallback runs, so callers get a clear, actionable error and routing
bugs upstream of aiter become obvious.

## Test Plan

Reproduced on MI355X with vLLM 0.21.0 + aiter 0.1.14 docker
(`rocm/vllm-dev:aiter0.1.14_rocm7.2.3_v0.21.0_20260528`):

```bash
# Before this PR — opaque JIT compile failure:
VLLM_ROCM_USE_AITER=1 vllm serve amd/gpt-oss-20b-w-mxfp4-a-bf16 \
    --tokenizer openai/gpt-oss-20b --tensor-parallel-size 2 \
    --enforce-eager --load-format dummy
# → ModuleNotFoundError on the swiglu CK2stages module + hipcc
#   "gemm_moe_ck2stages_lookup.h file not found"

# After this PR — explicit error:
# → NotImplementedError: CK 2-stage MoE has no Swiglu+MXFP4
#   specialization; this combination must be routed to CK-Tile or
#   FlyDSL upstream. Got q_type=QuantType.per_1x32,
#   q_dtype_a=torch.bfloat16, q_dtype_w=torch.float4_e2m1fn_x2,
#   is_shuffled=False, gate_mode=...
```

Note: this PR is a **diagnostic** change — it converts a silent /
opaque failure into an explicit one. It does not add the missing
Swiglu+MXFP4 CK2stages kernel itself; the longer-term fix is to either
codegen that specialization in `gen_instances.py` or to ensure the
upstream dispatch always routes this combination to CK-Tile or
FlyDSL (where Swiglu+MXFP4 is supported).

## Submission Checklist
- [x] Contributing guidelines reviewed.
