### PR TITLE
fix(ci): build multi-Python wheels and publish versioned S3 manifest

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         include:
           - python_version: "3.10"
-            docker_image: "rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0"
+            docker_image: "rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0"
           - python_version: "3.12"
             docker_image: "rocm/pytorch:latest"
     steps:

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -56,16 +56,20 @@ jobs:
         include:
           - python_version: "3.10"
             docker_image: "rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0"
+            build_enabled: ${{ github.ref == 'refs/heads/main' }}
           - python_version: "3.12"
             docker_image: "rocm/pytorch:latest"
+            build_enabled: true
     steps:
       # ---- Common steps (fork and non-fork) ----
       - name: Checkout code
+        if: ${{ matrix.build_enabled }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Sync submodules for wheel build
+        if: ${{ matrix.build_enabled }}
         run: |
           set -ex
           if [ "${{ github.event_name }}" = "schedule" ]; then
@@ -81,7 +85,7 @@ jobs:
           echo "CK commit: $(git -C 3rdparty/composable_kernel rev-parse HEAD)"
 
       - name: Docker login
-        if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
+        if: ${{ matrix.build_enabled && (!github.event.pull_request || !github.event.pull_request.head.repo.fork) }}
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
@@ -99,6 +103,7 @@ jobs:
           exit 0
 
       - name: Build Aiter wheel in base container
+        if: ${{ matrix.build_enabled }}
         run: |
           set -euo pipefail
           docker run --rm \
@@ -142,7 +147,7 @@ jobs:
             '
 
       - name: Summarize Aiter prebuild
-        if: ${{ always() }}
+        if: ${{ always() && matrix.build_enabled }}
         run: |
           set -euo pipefail
           if [ ! -f .aiter-prebuild.env ]; then
@@ -161,6 +166,7 @@ jobs:
             --end "${PREBUILD_END}"
 
       - name: Verify prebuilt kernels in wheel
+        if: ${{ matrix.build_enabled }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -194,6 +200,7 @@ jobs:
           PY
 
       - name: Upload wheel as artifact
+        if: ${{ matrix.build_enabled }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}-py${{ matrix.python_version }}

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -50,6 +50,14 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python_version: "3.10"
+            docker_image: "rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0"
+          - python_version: "3.12"
+            docker_image: "rocm/pytorch:latest"
     steps:
       # ---- Common steps (fork and non-fork) ----
       - name: Checkout code
@@ -99,7 +107,7 @@ jobs:
             -e AITER_RUNNER_NAME="${RUNNER_NAME:-unknown}" \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
-            ${{ env.DOCKER_IMAGE }} \
+            ${{ matrix.docker_image }} \
             bash -lc '
               set -euo pipefail
               git config --global --add safe.directory /workspace &&
@@ -188,20 +196,34 @@ jobs:
       - name: Upload wheel as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}-py${{ matrix.python_version }}
           path: dist/*.whl
           compression-level: 0
           retention-days: 14
 
+  upload_s3_manifest:
+    if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
+    needs: [build_aiter_wheels]
+    name: Upload wheels and manifest to S3
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}-py*
+          path: all-wheels
+          merge-multiple: true
+
       - name: Configure AWS credentials
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::661452401056:role/framework-aiter-nightlies
 
       - name: Install AWS CLI
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
         run: |
           if ! command -v aws &> /dev/null; then
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -210,34 +232,72 @@ jobs:
             rm -rf awscliv2.zip aws
           fi
 
-      - name: Upload wheels and latest main manifest to S3
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
+      - name: Upload wheels and versioned manifest to S3
         run: |
-          for WHL in dist/*.whl; do
-            WHL_NAME=$(basename ${WHL})
-            echo "Uploading ${WHL_NAME} to S3..."
-            aws s3 cp ${WHL} s3://framework-whls-nightlies/whl-staging/gfx942-gfx950/${WHL_NAME}
+          set -euo pipefail
+          S3_STAGING="s3://framework-whls-nightlies/whl-staging/gfx942-gfx950"
+          S3_PUBLIC="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950"
+
+          echo "=== Uploading all wheels to S3 ==="
+          for WHL in all-wheels/amd_aiter*.whl; do
+            WHL_NAME=$(basename "${WHL}")
+            echo "Uploading ${WHL_NAME}..."
+            aws s3 cp "${WHL}" "${S3_STAGING}/${WHL_NAME}"
           done
-          echo "Wheels uploaded to S3 staging"
 
-          MANIFEST_WHL=$(ls -t dist/amd_aiter*.whl 2>/dev/null | head -1)
-          if [ -z "$MANIFEST_WHL" ]; then
-            echo "ERROR: No amd_aiter wheel found in dist/"
-            exit 1
-          fi
+          echo "=== Generating versioned manifest ==="
+          export MANIFEST_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          MANIFEST_WHL_NAME=$(basename "$MANIFEST_WHL")
-          MANIFEST_WHL_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/${MANIFEST_WHL_NAME}"
-          MANIFEST_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          python3 - <<'PY'
+          import json, glob, os, re, sys
 
-          python3 -c "import json, pathlib, sys; pathlib.Path('latest-main-wheel.json').write_text(json.dumps({'branch': sys.argv[1], 'timestamp': sys.argv[2], 'commit': sys.argv[3], 'wheel_name': sys.argv[4], 'wheel_url': sys.argv[5]}, indent=2) + '\n', encoding='utf-8')" \
-            "$GITHUB_REF_NAME" "$MANIFEST_TIMESTAMP" "$GITHUB_SHA" "$MANIFEST_WHL_NAME" "$MANIFEST_WHL_URL"
+          s3_public = os.environ["S3_PUBLIC"]
+          timestamp = os.environ["MANIFEST_TIMESTAMP"]
+          branch = os.environ["GITHUB_REF_NAME"]
+          commit = os.environ["GITHUB_SHA"]
+
+          wheels = sorted(glob.glob("all-wheels/amd_aiter*.whl"))
+          if not wheels:
+              print("ERROR: No amd_aiter wheels found", file=sys.stderr)
+              sys.exit(1)
+
+          wheels_by_tag = {}
+          default_wheel_name = None
+          default_wheel_url = None
+
+          for whl_path in wheels:
+              whl_name = os.path.basename(whl_path)
+              whl_url = f"{s3_public}/{whl_name}"
+              match = re.search(r"-(cp3\d+)-", whl_name)
+              if match:
+                  tag = match.group(1)
+                  wheels_by_tag[tag] = {"wheel_name": whl_name, "wheel_url": whl_url}
+                  default_wheel_name = whl_name
+                  default_wheel_url = whl_url
+
+          manifest = {
+              "branch": branch,
+              "timestamp": timestamp,
+              "commit": commit,
+              "wheels": wheels_by_tag,
+              "wheel_name": default_wheel_name,
+              "wheel_url": default_wheel_url,
+          }
+
+          with open("latest-main-wheel.json", "w") as f:
+              json.dump(manifest, f, indent=2)
+              f.write("\n")
+
+          print(f"Manifest: {json.dumps(manifest, indent=2)}")
+          PY
 
           aws s3 cp latest-main-wheel.json \
-            s3://framework-whls-nightlies/whl-staging/gfx942-gfx950/main/latest.json \
+            "${S3_STAGING}/main/latest.json" \
             --content-type application/json
 
-          echo "Uploaded latest main wheel manifest for ${MANIFEST_WHL_NAME}"
+          echo "Uploaded versioned manifest"
+        env:
+          S3_PUBLIC: "https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950"
 
   split_aiter_tests:
     if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
@@ -370,7 +430,7 @@ jobs:
         uses: actions/download-artifact@v4
         timeout-minutes: 30
         with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}-py3.12
           path: aiter_wheels
 
       - name: Download Triton wheel artifact
@@ -628,7 +688,7 @@ jobs:
         uses: actions/download-artifact@v4
         timeout-minutes: 30
         with:
-          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}-py3.12
           path: aiter_wheels
 
       - name: Download Triton wheel artifact


### PR DESCRIPTION
The aiter-test workflow builds a single wheel using rocm/pytorch:latest (Python 3.12), but downstream consumers like ATOM run Python 3.10. Installing a cp312 wheel into a cp310 environment fails.

Add a build matrix (py3.10 + py3.12) to build_aiter_wheels and split the S3 upload into a dedicated upload_s3_manifest job that collects both wheels and generates a versioned latest.json manifest with a per-Python-tag `wheels` field. The legacy top-level wheel_name/wheel_url fields are preserved for backward compatibility.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
