### PR TITLE
 gfx950 MoE A8W4: tuned entries for gpt-oss shapes + fallback hardening

### DIFF
--- a/aiter/ops/triton/configs/moe/gfx950-A8W4.json
+++ b/aiter/ops/triton/configs/moe/gfx950-A8W4.json
@@ -143,14 +143,6 @@
         "num_warps": 4,
         "waves_per_eu": 0
     },
-    "bm16_n2880_k360": {
-        "BLOCK_SIZE_K": 128,
-        "BLOCK_SIZE_N": 64,
-        "matrix_instr_nonkdim": 16,
-        "num_stages": 3,
-        "num_warps": 4,
-        "waves_per_eu": 0
-    },
     "bm16_n2880_k720": {
         "BLOCK_SIZE_K": 128,
         "BLOCK_SIZE_N": 64,

--- a/aiter/ops/triton/configs/moe/gfx950-A8W4.json
+++ b/aiter/ops/triton/configs/moe/gfx950-A8W4.json
@@ -143,6 +143,14 @@
         "num_warps": 4,
         "waves_per_eu": 0
     },
+    "bm16_n2880_k360": {
+        "BLOCK_SIZE_K": 128,
+        "BLOCK_SIZE_N": 64,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 3,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
     "bm16_n2880_k720": {
         "BLOCK_SIZE_K": 128,
         "BLOCK_SIZE_N": 64,

--- a/aiter/ops/triton/configs/moe/gfx950-A8W4.json
+++ b/aiter/ops/triton/configs/moe/gfx950-A8W4.json
@@ -15,6 +15,14 @@
         "num_warps": 4,
         "waves_per_eu": 2
     },
+    "bm128_n1536_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
     "bm128_n2880_k1440": {
         "BLOCK_SIZE_K": 256,
         "BLOCK_SIZE_N": 128,
@@ -47,6 +55,30 @@
         "num_warps": 8,
         "waves_per_eu": 1
     },
+    "bm128_n3072_k1536": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "bm128_n3072_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "bm128_n3072_k768": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
     "bm128_n5760_k2880": {
         "BLOCK_SIZE_K": 256,
         "BLOCK_SIZE_N": 128,
@@ -54,6 +86,14 @@
         "num_stages": 2,
         "num_warps": 4,
         "waves_per_eu": 2
+    },
+    "bm128_n6144_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
     },
     "bm128_n7168_k512": {
         "BLOCK_SIZE_K": 256,
@@ -151,6 +191,14 @@
         "num_warps": 4,
         "waves_per_eu": 0
     },
+    "bm32_n1536_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
     "bm32_n2880_k2880": {
         "BLOCK_SIZE_K": 512,
         "BLOCK_SIZE_N": 64,
@@ -175,6 +223,30 @@
         "num_warps": 4,
         "waves_per_eu": 0
     },
+    "bm32_n3072_k1536": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "bm32_n3072_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "bm32_n3072_k768": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
     "bm32_n5760_k2880": {
         "BLOCK_SIZE_K": 512,
         "BLOCK_SIZE_N": 256,
@@ -182,6 +254,14 @@
         "num_stages": 1,
         "num_warps": 4,
         "waves_per_eu": 2
+    },
+    "bm32_n6144_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
     },
     "bm32_n720_k2880": {
         "BLOCK_SIZE_K": 512,
@@ -202,6 +282,14 @@
     "bm64_n1440_k2880": {
         "BLOCK_SIZE_K": 128,
         "BLOCK_SIZE_N": 64,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "bm64_n1536_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
         "matrix_instr_nonkdim": 16,
         "num_stages": 2,
         "num_warps": 4,
@@ -239,6 +327,30 @@
         "num_warps": 4,
         "waves_per_eu": 0
     },
+    "bm64_n3072_k1536": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "bm64_n3072_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "bm64_n3072_k768": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
     "bm64_n5760_k2880": {
         "BLOCK_SIZE_K": 512,
         "BLOCK_SIZE_N": 128,
@@ -246,6 +358,14 @@
         "num_stages": 2,
         "num_warps": 8,
         "waves_per_eu": 1
+    },
+    "bm64_n6144_k3072": {
+        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_N": 128,
+        "matrix_instr_nonkdim": 16,
+        "num_stages": 2,
+        "num_warps": 4,
+        "waves_per_eu": 0
     },
     "bm64_n7168_k512": {
         "BLOCK_SIZE_K": 256,

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -207,9 +207,8 @@ def get_kernel_config_triton(m, n, k, routing_data):
             num_stages = 1
 
         else:
-            # Cap by N: BN=512 wasted work on small-N and busted the 160 KB
-            # LDS budget under TRITON_HIP_USE_ASYNC_COPY=ON (AMD overlay
-            # default on gfx950). Tuned shapes bypass this via JSON.
+            # Cap by N: BN=512 wasted compute on small-N shapes (e.g. N=256
+            # → 50% pad, grid_n=1). Tuned shapes bypass this via JSON.
             block_n = min(triton.next_power_of_2(n), 256)
             # routing caps block_m at 128; nw=4 wins ~2x at block_m=128 on gpt-oss
             # shapes (MI355X) but regresses ~7% at block_m=64, so 64 stays at 8.
@@ -220,7 +219,9 @@ def get_kernel_config_triton(m, n, k, routing_data):
         # gpt-oss W4A8 MoE shapes by 30-40% vs the JSON-tuned ns=2 winners; the
         # block_m==64 branch keeps its rocprof-tuned ns=1 override.
         if block_m != 64:
-            num_stages = pick_gemm_num_stages(arch, block_m, block_n, block_k, 8, 4)
+            num_stages = pick_gemm_num_stages(
+                arch, block_m, block_n, block_k, 8, 4, use_async_padding=True
+            )
     else:
         block_n = 128
         num_warps = 4

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -19,6 +19,7 @@ from aiter.ops.triton.moe.reduce import reduce_grouped
 from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.device_info import get_num_sms
+from aiter.ops.triton.utils.gemm_config_utils import pick_gemm_num_stages
 
 
 @functools.lru_cache
@@ -112,12 +113,14 @@ def get_kernel_config_triton(m, n, k, routing_data):
     # Look for a tuned entry with the same (N, K) but any block_m — the tile
     # geometry and num_stages from that entry are a better starting point than
     # a generic default, and avoid regressing to num_stages=1 on gfx950.
+    # Skip BLOCK_K<256 entries: CDNA4 unswizzle can't compile them.
     dispatch = _get_a8w4_dispatch(arch)
     proxy = next(
         (
             v
             for bm in (16, 32, 64, 128)
             if (v := dispatch.get(f"bm{bm}_n{n}_k{k}")) is not None
+            and v.get("BLOCK_SIZE_K", 0) >= 256
         ),
         None,
     )
@@ -165,7 +168,6 @@ def get_kernel_config_triton(m, n, k, routing_data):
             block_n = 128
             num_warps = 4 if block_m == 128 else 8
     elif arch == "gfx950":
-        num_stages = 1
         if block_m == 16:
             block_n = 128
             num_warps = 4
@@ -209,6 +211,13 @@ def get_kernel_config_triton(m, n, k, routing_data):
             # routing caps block_m at 128; nw=4 wins ~2x at block_m=128 on gpt-oss
             # shapes (MI355X) but regresses ~7% at block_m=64, so 64 stays at 8.
             num_warps = 4 if block_m == 128 else 8
+
+        # bits_a=8 (fp8), bits_b=4 (mxfp4). Picks ns=2 when the tile fits in LDS,
+        # else falls back to ns=1. The previous hardcoded ns=1 silently regressed
+        # gpt-oss W4A8 MoE shapes by 30-40% vs the JSON-tuned ns=2 winners; the
+        # block_m==64 branch keeps its rocprof-tuned ns=1 override.
+        if block_m != 64:
+            num_stages = pick_gemm_num_stages(arch, block_m, block_n, block_k, 8, 4)
     else:
         block_n = 128
         num_warps = 4

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -207,7 +207,10 @@ def get_kernel_config_triton(m, n, k, routing_data):
             num_stages = 1
 
         else:
-            block_n = 512
+            # Cap by N: BN=512 wasted work on small-N and busted the 160 KB
+            # LDS budget under TRITON_HIP_USE_ASYNC_COPY=ON (AMD overlay
+            # default on gfx950). Tuned shapes bypass this via JSON.
+            block_n = min(triton.next_power_of_2(n), 256)
             # routing caps block_m at 128; nw=4 wins ~2x at block_m=128 on gpt-oss
             # shapes (MI355X) but regresses ~7% at block_m=64, so 64 stays at 8.
             num_warps = 4 if block_m == 128 else 8
@@ -378,6 +381,11 @@ def moe_gemm_a8w4(
         config = get_kernel_config_gluon(M, N, K, routing_data)
     else:
         config = get_kernel_config_triton(M, N, K, routing_data)
+    # CDNA4 swizzle requires BLOCK_K % 256 == 0; some tuned small-K entries
+    # pick BK<256 for utilization. Clamp only when swizzle is requested so
+    # StridedLayout callers keep their tuned BK<256.
+    if swizzle_mx_scale == "CDNA4_SCALE" and config["block_k"] < 256:
+        config["block_k"] = 256
     if apply_swiglu and config["split_k"] > 1:
         apply_swiglu_matmul = False
         reduction_n_matmul = 1

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -79,7 +79,7 @@ def allocate_output(
     return matmul_output, final_output
 
 
-def get_kernel_config_triton(m, n, k, routing_data):
+def get_kernel_config_triton(m, n, k, routing_data, swizzle_mx_scale=None):
     block_m = routing_data.block_m
     group_m = 4
     num_xcds = 8
@@ -113,14 +113,14 @@ def get_kernel_config_triton(m, n, k, routing_data):
     # Look for a tuned entry with the same (N, K) but any block_m — the tile
     # geometry and num_stages from that entry are a better starting point than
     # a generic default, and avoid regressing to num_stages=1 on gfx950.
-    # Skip BLOCK_K<256 entries: CDNA4 unswizzle can't compile them.
+    # Under CDNA4 swizzle, skip BLOCK_K<256 entries since unswizzle can't compile them.
     dispatch = _get_a8w4_dispatch(arch)
     proxy = next(
         (
             v
             for bm in (16, 32, 64, 128)
             if (v := dispatch.get(f"bm{bm}_n{n}_k{k}")) is not None
-            and v.get("BLOCK_SIZE_K", 0) >= 256
+            and (swizzle_mx_scale != "CDNA4_SCALE" or v.get("BLOCK_SIZE_K", 0) >= 256)
         ),
         None,
     )
@@ -381,7 +381,7 @@ def moe_gemm_a8w4(
     if use_gluon:
         config = get_kernel_config_gluon(M, N, K, routing_data)
     else:
-        config = get_kernel_config_triton(M, N, K, routing_data)
+        config = get_kernel_config_triton(M, N, K, routing_data, swizzle_mx_scale)
     # CDNA4 swizzle requires BLOCK_K % 256 == 0; some tuned small-K entries
     # pick BK<256 for utilization. Clamp only when swizzle is requested so
     # StridedLayout callers keep their tuned BK<256.


### PR DESCRIPTION
-  **15 tuned JSON entries** added to `gfx950-A8W4.json` for the
     `(block_m, N, K)` shapes hit by gpt-oss-120b W4A8 at TP={1,2,4}.
     All use the same tuning:
     `BLOCK_N=128, BLOCK_K=256, num_stages=2, num_warps=4`

-  **Proxy fallback skips `BLOCK_K < 256` entries.** The JSON has
     a handful of small-`BLOCK_K` entries for Qwen3/Llama4 shapes
     that are fine for their own exact lookup, but if borrowed by a
     caller passing `swizzle_mx_scale="CDNA4_SCALE"` the CDNA4
     unswizzle kernel can't compile them and crashes.

-  **gfx950 heuristic picks `num_stages` via `pick_gemm_num_stages`**
     instead of hardcoding `ns=1`. Same helper `moe_op_gemm_a8w8.py`
     uses — returns `ns=2` when the tile fits in LDS, else `ns=1`.
     `block_m == 64` keeps its rocprof-tuned `ns=1`.