### PR TITLE
CI: retry Aiter wheel artifact download

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -434,8 +434,18 @@ jobs:
           echo "$AITER_TEST"
 
       - name: Download Aiter wheel artifact
+        id: download_aiter_wheel
         uses: actions/download-artifact@v4
-        timeout-minutes: 30
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}-py3.12
+          path: aiter_wheels
+
+      - name: Retry Download Aiter wheel artifact
+        if: steps.download_aiter_wheel.outcome == 'failure'
+        uses: actions/download-artifact@v4
+        timeout-minutes: 5
         with:
           name: ${{ env.AITER_WHEEL_ARTIFACT_NAME }}-py3.12
           path: aiter_wheels


### PR DESCRIPTION
## Summary
- Add a short 5-minute timeout to the Aiter wheel artifact download in standard tests.
- Retry the download once before failing the job, so hung artifact downloads fail fast instead of consuming the full job timeout.

## Test plan
- Ran `git diff --check`.
- Parsed `.github/workflows/aiter-test.yaml` with PyYAML.