### PR TITLE
CI: install dependencies for vLLM benchmark wheel

### DIFF
--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -245,6 +245,8 @@ jobs:
                 bash ./.github/scripts/install_triton.sh
                 pip show triton
                 pip uninstall -y aiter amd-aiter || true
+                pip config set global.default-timeout 60
+                pip config set global.retries 10
                 pip install \"\${wheels[0]}\"
                 pip show amd-aiter || pip show aiter
                 if [ -d \"/models/${{ matrix.model }}\" ]; then

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -245,7 +245,7 @@ jobs:
                 bash ./.github/scripts/install_triton.sh
                 pip show triton
                 pip uninstall -y aiter amd-aiter || true
-                pip install --no-deps \"\${wheels[0]}\"
+                pip install \"\${wheels[0]}\"
                 pip show amd-aiter || pip show aiter
                 if [ -d \"/models/${{ matrix.model }}\" ]; then
                   model_path=\"/models/${{ matrix.model }}\"


### PR DESCRIPTION
## Summary
- Install the AITER wheel in the vLLM benchmark job with its declared dependencies instead of using `--no-deps`.
- Lets the benchmark environment pick up required runtime dependency versions such as `flydsl` from the tested wheel metadata.

## Test plan
- Ran `git diff --check`.
- Not run: full vLLM benchmark, requires CI GPU runners.