### PR TITLE
[Feat] Support FP4 gather_kv_b_proj

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
+++ b/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
@@ -59,6 +59,260 @@ def _load_unshuffle_segment(
 
 
 @triton.jit
+def _triton_gather_kv_b_proj_fp4(
+    batch_size,
+    k_buffer,  # [num_block, block_size, kv_c_dim + kv_pe_dim]
+    k_scale,  # [1] or None
+    kv_indptr,  # [batch_size + 1]
+    kv_indices,  # [total_kv]
+    kv_prefix_sum_context_lens,  # [batch_size + 1]
+    kv_proj_weight,  # packed fp4: [tp_heads * (qk_nope_head_dim + v_head_dim), kv_c_dim // 2]
+    kv_proj_scale,  # e8m0 per-1x32: [weight_n, kv_c_dim // 32]
+    k_prefix,  # [total_kv, tp_k_head_num, qk_nope_head_dim + kv_pe_dim]
+    v_prefix,  # [total_kv, tp_k_head_num, v_head_dim]
+    KBlockSize: tl.constexpr,
+    TpNumHeads: tl.constexpr,
+    QkNopeHeadDim: tl.constexpr,
+    VHeadDim: tl.constexpr,
+    KV_CDim: tl.constexpr,
+    KV_PeDim: tl.constexpr,
+    ChunkK: tl.constexpr,
+    PaddedK: tl.constexpr,
+    PaddedV: tl.constexpr,
+    ScaleCols: tl.constexpr,
+    WEIGHT_PRESHUFFLE: tl.constexpr = False,
+):
+    """FP4/per-1x32 gather + kv_b_proj expansion for raw MXFP4 weights."""
+    stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
+    stride_k_prefix = tl.full(
+        [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
+    )
+    stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
+
+    ScaleKGranularity: tl.constexpr = 32
+    PackedScaleKGranularity: tl.constexpr = ScaleKGranularity // 2
+    PackedKV_CDim: tl.constexpr = KV_CDim // 2
+    KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
+    NumKSegments: tl.constexpr = KV_CDim // ScaleKGranularity
+
+    pid = tl.program_id(0)
+    pid_batch = pid // TpNumHeads
+    pid_head = pid % TpNumHeads
+
+    kv_block_start = tl.load(kv_indptr + pid_batch)
+    kv_block_end = tl.load(kv_indptr + pid_batch + 1)
+
+    context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
+    context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
+
+    total_kv_block = kv_block_end - kv_block_start
+    total_kv_chunk = (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK
+
+    k_type = k_buffer.dtype.element_ty
+    if k_type == tl.bfloat16:
+        k_scalar_scale = 1.0
+    else:
+        k_scalar_scale = tl.load(k_scale)
+
+    offs_n_k = tl.arange(0, PaddedK)
+    offs_n_v = tl.arange(0, PaddedV)
+    mask_k = offs_n_k < QkNopeHeadDim
+    mask_v = offs_n_v < VHeadDim
+    offs_k = tl.arange(0, ScaleKGranularity)
+    offs_k_packed = tl.arange(0, PackedScaleKGranularity)
+
+    head_row_base = pid_head * (QkNopeHeadDim + VHeadDim)
+    k_abs_rows = head_row_base + offs_n_k
+    v_abs_rows = head_row_base + QkNopeHeadDim + offs_n_v
+
+    for chunk_id in range(total_kv_chunk):
+        block_lane_valid = (
+            chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
+            < total_kv_block
+        )
+        kv_block_idx = tl.load(
+            kv_indices
+            + kv_block_start
+            + chunk_id * KBlocksPerChunkK
+            + tl.arange(0, ChunkK) // KBlockSize,
+            mask=block_lane_valid,
+            other=0,
+        )
+
+        accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
+        accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
+        row_mask = block_lane_valid[:, None]
+
+        for seg in range(NumKSegments):
+            kv_c_data = tl.load(
+                k_buffer
+                + kv_block_idx[:, None] * stride_k_buffer
+                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+                + seg * ScaleKGranularity
+                + offs_k[None, :],
+                mask=row_mask,
+                other=0.0,
+            ).to(tl.bfloat16)
+
+            packed_cols = seg * PackedScaleKGranularity + offs_k_packed[:, None]
+
+            if WEIGHT_PRESHUFFLE:
+                # Inverse of aiter.ops.shuffle.shuffle_weight for uint8/packed-fp4
+                # tensors with layout=(16, 16).  It maps logical [N, K//2]
+                # coordinates back into the preshuffled storage.
+                k_n0 = k_abs_rows[None, :] // 16
+                k_bn = k_abs_rows[None, :] % 16
+                k_k0 = packed_cols // 32
+                k_r = (packed_cols % 32) // 16
+                k_c = packed_cols % 16
+                k_weight_offset = (
+                    ((k_n0 * (PackedKV_CDim // 32) + k_k0) * 2 + k_r) * 16 + k_bn
+                ) * 16 + k_c
+
+                v_n0 = v_abs_rows[None, :] // 16
+                v_bn = v_abs_rows[None, :] % 16
+                v_k0 = packed_cols // 32
+                v_r = (packed_cols % 32) // 16
+                v_c = packed_cols % 16
+                v_weight_offset = (
+                    ((v_n0 * (PackedKV_CDim // 32) + v_k0) * 2 + v_r) * 16 + v_bn
+                ) * 16 + v_c
+            else:
+                k_weight_offset = k_abs_rows[None, :] * PackedKV_CDim + packed_cols
+                v_weight_offset = v_abs_rows[None, :] * PackedKV_CDim + packed_cols
+
+            k_weight = tl.load(
+                kv_proj_weight + k_weight_offset,
+                mask=mask_k[None, :],
+                other=0,
+            )
+            v_weight = tl.load(
+                kv_proj_weight + v_weight_offset,
+                mask=mask_v[None, :],
+                other=0,
+            )
+
+            if WEIGHT_PRESHUFFLE:
+                # Inverse of fp4_utils.e8m0_shuffle / shuffle_scale.
+                k_scale_n = k_abs_rows[:, None]
+                k_scale_g = seg
+                k_scale_a = k_scale_n // 32
+                k_scale_b = (k_scale_n % 32) // 16
+                k_scale_c = k_scale_n % 16
+                k_scale_d = k_scale_g // 8
+                k_scale_e = (k_scale_g % 8) // 4
+                k_scale_f = k_scale_g % 4
+                k_scale_offset = (
+                    (
+                        ((k_scale_a * (ScaleCols // 8) + k_scale_d) * 4 + k_scale_f)
+                        * 16
+                        + k_scale_c
+                    )
+                    * 2
+                    + k_scale_e
+                ) * 2 + k_scale_b
+
+                v_scale_n = v_abs_rows[:, None]
+                v_scale_g = seg
+                v_scale_a = v_scale_n // 32
+                v_scale_b = (v_scale_n % 32) // 16
+                v_scale_c = v_scale_n % 16
+                v_scale_d = v_scale_g // 8
+                v_scale_e = (v_scale_g % 8) // 4
+                v_scale_f = v_scale_g % 4
+                v_scale_offset = (
+                    (
+                        ((v_scale_a * (ScaleCols // 8) + v_scale_d) * 4 + v_scale_f)
+                        * 16
+                        + v_scale_c
+                    )
+                    * 2
+                    + v_scale_e
+                ) * 2 + v_scale_b
+            else:
+                k_scale_offset = k_abs_rows[:, None] * ScaleCols + seg
+                v_scale_offset = v_abs_rows[:, None] * ScaleCols + seg
+
+            k_weight_scale = tl.load(
+                kv_proj_scale + k_scale_offset,
+                mask=mask_k[:, None],
+                other=0,
+            )
+            v_weight_scale = tl.load(
+                kv_proj_scale + v_scale_offset,
+                mask=mask_v[:, None],
+                other=0,
+            )
+
+            accum_k = tl.dot_scaled(
+                kv_c_data,
+                None,
+                "bf16",
+                k_weight,
+                k_weight_scale,
+                "e2m1",
+                acc=accum_k,
+                fast_math=True,
+            )
+            accum_v = tl.dot_scaled(
+                kv_c_data,
+                None,
+                "bf16",
+                v_weight,
+                v_weight_scale,
+                "e2m1",
+                acc=accum_v,
+                fast_math=True,
+            )
+
+        kv_pe_data = tl.load(
+            k_buffer
+            + kv_block_idx[:, None] * stride_k_buffer
+            + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+            + KV_CDim
+            + tl.arange(0, KV_PeDim)[None, :],
+            mask=row_mask,
+            other=0.0,
+        )
+
+        accum_k *= k_scalar_scale
+        accum_v *= k_scalar_scale
+        kv_pe_data *= k_scalar_scale
+
+        context_mask = (
+            context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
+        )
+        tl.store(
+            k_prefix
+            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+            * stride_k_prefix
+            + pid_head * (QkNopeHeadDim + KV_PeDim)
+            + QkNopeHeadDim
+            + tl.arange(0, KV_PeDim)[None, :],
+            kv_pe_data,
+            mask=context_mask[:, None],
+        )
+        tl.store(
+            k_prefix
+            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+            * stride_k_prefix
+            + pid_head * (QkNopeHeadDim + KV_PeDim)
+            + offs_n_k[None, :],
+            accum_k,
+            mask=context_mask[:, None] & mask_k[None, :],
+        )
+        tl.store(
+            v_prefix
+            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+            * stride_v_prefix
+            + pid_head * VHeadDim
+            + offs_n_v[None, :],
+            accum_v,
+            mask=context_mask[:, None] & mask_v[None, :],
+        )
+
+
+@triton.jit
 def _triton_gather_kv_b_proj(
     batch_size,
     k_buffer,  # [num_block, block_size, kv_c_dim + kv_pe_dim]

--- a/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
+++ b/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
@@ -59,260 +59,6 @@ def _load_unshuffle_segment(
 
 
 @triton.jit
-def _triton_gather_kv_b_proj_fp4(
-    batch_size,
-    k_buffer,  # [num_block, block_size, kv_c_dim + kv_pe_dim]
-    k_scale,  # [1] or None
-    kv_indptr,  # [batch_size + 1]
-    kv_indices,  # [total_kv]
-    kv_prefix_sum_context_lens,  # [batch_size + 1]
-    kv_proj_weight,  # packed fp4: [tp_heads * (qk_nope_head_dim + v_head_dim), kv_c_dim // 2]
-    kv_proj_scale,  # e8m0 per-1x32: [weight_n, kv_c_dim // 32]
-    k_prefix,  # [total_kv, tp_k_head_num, qk_nope_head_dim + kv_pe_dim]
-    v_prefix,  # [total_kv, tp_k_head_num, v_head_dim]
-    KBlockSize: tl.constexpr,
-    TpNumHeads: tl.constexpr,
-    QkNopeHeadDim: tl.constexpr,
-    VHeadDim: tl.constexpr,
-    KV_CDim: tl.constexpr,
-    KV_PeDim: tl.constexpr,
-    ChunkK: tl.constexpr,
-    PaddedK: tl.constexpr,
-    PaddedV: tl.constexpr,
-    ScaleCols: tl.constexpr,
-    WEIGHT_PRESHUFFLE: tl.constexpr = False,
-):
-    """FP4/per-1x32 gather + kv_b_proj expansion for raw MXFP4 weights."""
-    stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
-    stride_k_prefix = tl.full(
-        [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
-    )
-    stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
-
-    ScaleKGranularity: tl.constexpr = 32
-    PackedScaleKGranularity: tl.constexpr = ScaleKGranularity // 2
-    PackedKV_CDim: tl.constexpr = KV_CDim // 2
-    KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
-    NumKSegments: tl.constexpr = KV_CDim // ScaleKGranularity
-
-    pid = tl.program_id(0)
-    pid_batch = pid // TpNumHeads
-    pid_head = pid % TpNumHeads
-
-    kv_block_start = tl.load(kv_indptr + pid_batch)
-    kv_block_end = tl.load(kv_indptr + pid_batch + 1)
-
-    context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
-    context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
-
-    total_kv_block = kv_block_end - kv_block_start
-    total_kv_chunk = (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK
-
-    k_type = k_buffer.dtype.element_ty
-    if k_type == tl.bfloat16:
-        k_scalar_scale = 1.0
-    else:
-        k_scalar_scale = tl.load(k_scale)
-
-    offs_n_k = tl.arange(0, PaddedK)
-    offs_n_v = tl.arange(0, PaddedV)
-    mask_k = offs_n_k < QkNopeHeadDim
-    mask_v = offs_n_v < VHeadDim
-    offs_k = tl.arange(0, ScaleKGranularity)
-    offs_k_packed = tl.arange(0, PackedScaleKGranularity)
-
-    head_row_base = pid_head * (QkNopeHeadDim + VHeadDim)
-    k_abs_rows = head_row_base + offs_n_k
-    v_abs_rows = head_row_base + QkNopeHeadDim + offs_n_v
-
-    for chunk_id in range(total_kv_chunk):
-        block_lane_valid = (
-            chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
-            < total_kv_block
-        )
-        kv_block_idx = tl.load(
-            kv_indices
-            + kv_block_start
-            + chunk_id * KBlocksPerChunkK
-            + tl.arange(0, ChunkK) // KBlockSize,
-            mask=block_lane_valid,
-            other=0,
-        )
-
-        accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
-        accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
-        row_mask = block_lane_valid[:, None]
-
-        for seg in range(NumKSegments):
-            kv_c_data = tl.load(
-                k_buffer
-                + kv_block_idx[:, None] * stride_k_buffer
-                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-                + seg * ScaleKGranularity
-                + offs_k[None, :],
-                mask=row_mask,
-                other=0.0,
-            ).to(tl.bfloat16)
-
-            packed_cols = seg * PackedScaleKGranularity + offs_k_packed[:, None]
-
-            if WEIGHT_PRESHUFFLE:
-                # Inverse of aiter.ops.shuffle.shuffle_weight for uint8/packed-fp4
-                # tensors with layout=(16, 16).  It maps logical [N, K//2]
-                # coordinates back into the preshuffled storage.
-                k_n0 = k_abs_rows[None, :] // 16
-                k_bn = k_abs_rows[None, :] % 16
-                k_k0 = packed_cols // 32
-                k_r = (packed_cols % 32) // 16
-                k_c = packed_cols % 16
-                k_weight_offset = (
-                    ((k_n0 * (PackedKV_CDim // 32) + k_k0) * 2 + k_r) * 16 + k_bn
-                ) * 16 + k_c
-
-                v_n0 = v_abs_rows[None, :] // 16
-                v_bn = v_abs_rows[None, :] % 16
-                v_k0 = packed_cols // 32
-                v_r = (packed_cols % 32) // 16
-                v_c = packed_cols % 16
-                v_weight_offset = (
-                    ((v_n0 * (PackedKV_CDim // 32) + v_k0) * 2 + v_r) * 16 + v_bn
-                ) * 16 + v_c
-            else:
-                k_weight_offset = k_abs_rows[None, :] * PackedKV_CDim + packed_cols
-                v_weight_offset = v_abs_rows[None, :] * PackedKV_CDim + packed_cols
-
-            k_weight = tl.load(
-                kv_proj_weight + k_weight_offset,
-                mask=mask_k[None, :],
-                other=0,
-            )
-            v_weight = tl.load(
-                kv_proj_weight + v_weight_offset,
-                mask=mask_v[None, :],
-                other=0,
-            )
-
-            if WEIGHT_PRESHUFFLE:
-                # Inverse of fp4_utils.e8m0_shuffle / shuffle_scale.
-                k_scale_n = k_abs_rows[:, None]
-                k_scale_g = seg
-                k_scale_a = k_scale_n // 32
-                k_scale_b = (k_scale_n % 32) // 16
-                k_scale_c = k_scale_n % 16
-                k_scale_d = k_scale_g // 8
-                k_scale_e = (k_scale_g % 8) // 4
-                k_scale_f = k_scale_g % 4
-                k_scale_offset = (
-                    (
-                        ((k_scale_a * (ScaleCols // 8) + k_scale_d) * 4 + k_scale_f)
-                        * 16
-                        + k_scale_c
-                    )
-                    * 2
-                    + k_scale_e
-                ) * 2 + k_scale_b
-
-                v_scale_n = v_abs_rows[:, None]
-                v_scale_g = seg
-                v_scale_a = v_scale_n // 32
-                v_scale_b = (v_scale_n % 32) // 16
-                v_scale_c = v_scale_n % 16
-                v_scale_d = v_scale_g // 8
-                v_scale_e = (v_scale_g % 8) // 4
-                v_scale_f = v_scale_g % 4
-                v_scale_offset = (
-                    (
-                        ((v_scale_a * (ScaleCols // 8) + v_scale_d) * 4 + v_scale_f)
-                        * 16
-                        + v_scale_c
-                    )
-                    * 2
-                    + v_scale_e
-                ) * 2 + v_scale_b
-            else:
-                k_scale_offset = k_abs_rows[:, None] * ScaleCols + seg
-                v_scale_offset = v_abs_rows[:, None] * ScaleCols + seg
-
-            k_weight_scale = tl.load(
-                kv_proj_scale + k_scale_offset,
-                mask=mask_k[:, None],
-                other=0,
-            )
-            v_weight_scale = tl.load(
-                kv_proj_scale + v_scale_offset,
-                mask=mask_v[:, None],
-                other=0,
-            )
-
-            accum_k = tl.dot_scaled(
-                kv_c_data,
-                None,
-                "bf16",
-                k_weight,
-                k_weight_scale,
-                "e2m1",
-                acc=accum_k,
-                fast_math=True,
-            )
-            accum_v = tl.dot_scaled(
-                kv_c_data,
-                None,
-                "bf16",
-                v_weight,
-                v_weight_scale,
-                "e2m1",
-                acc=accum_v,
-                fast_math=True,
-            )
-
-        kv_pe_data = tl.load(
-            k_buffer
-            + kv_block_idx[:, None] * stride_k_buffer
-            + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-            + KV_CDim
-            + tl.arange(0, KV_PeDim)[None, :],
-            mask=row_mask,
-            other=0.0,
-        )
-
-        accum_k *= k_scalar_scale
-        accum_v *= k_scalar_scale
-        kv_pe_data *= k_scalar_scale
-
-        context_mask = (
-            context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
-        )
-        tl.store(
-            k_prefix
-            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-            * stride_k_prefix
-            + pid_head * (QkNopeHeadDim + KV_PeDim)
-            + QkNopeHeadDim
-            + tl.arange(0, KV_PeDim)[None, :],
-            kv_pe_data,
-            mask=context_mask[:, None],
-        )
-        tl.store(
-            k_prefix
-            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-            * stride_k_prefix
-            + pid_head * (QkNopeHeadDim + KV_PeDim)
-            + offs_n_k[None, :],
-            accum_k,
-            mask=context_mask[:, None] & mask_k[None, :],
-        )
-        tl.store(
-            v_prefix
-            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-            * stride_v_prefix
-            + pid_head * VHeadDim
-            + offs_n_v[None, :],
-            accum_v,
-            mask=context_mask[:, None] & mask_v[None, :],
-        )
-
-
-@triton.jit
 def _triton_gather_kv_b_proj(
     batch_size,
     k_buffer,  # [num_block, block_size, kv_c_dim + kv_pe_dim]
@@ -333,326 +79,562 @@ def _triton_gather_kv_b_proj(
     ChunkK: tl.constexpr,
     PaddedK: tl.constexpr,
     PaddedV: tl.constexpr,
+    ScaleCols: tl.constexpr = 1,
+    IS_FP4: tl.constexpr = False,
     WEIGHT_PRESHUFFLE: tl.constexpr = False,
     PER_ROW_SCALE: tl.constexpr = False,
     NO_SCALE: tl.constexpr = False,
 ):
-    # All three strides are multiplied by runtime indices that can overflow
-    # i32 at large scales. Promote the scalar (broadcast) side to i64 so the multiply
-    # is i32-zext x i64 -> i64
-    stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
-    stride_k_prefix = tl.full(
-        [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
-    )
-    stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
+    if IS_FP4:
+        # FP4/per-1x32 gather + kv_b_proj expansion for raw MXFP4 weights.
+        stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
+        stride_k_prefix = tl.full(
+            [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
+        )
+        stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
 
-    ScaleKGranularity: tl.constexpr = 128
-    ScaleNGranularity: tl.constexpr = 128
-    KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
-    assert KV_CDim == 4 * ScaleKGranularity
+        Fp4ScaleKGranularity: tl.constexpr = 32
+        PackedScaleKGranularity: tl.constexpr = Fp4ScaleKGranularity // 2
+        PackedKV_CDim: tl.constexpr = KV_CDim // 2
+        Fp4KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
+        NumKSegments: tl.constexpr = KV_CDim // Fp4ScaleKGranularity
 
-    # ===---------------------------------------------------
-    # Workload Partition
-    # ===---------------------------------------------------
-    pid = tl.program_id(0)
-    pid_batch = pid // TpNumHeads
-    pid_head = pid % TpNumHeads
+        pid = tl.program_id(0)
+        pid_batch = pid // TpNumHeads
+        pid_head = pid % TpNumHeads
 
-    kv_block_start = tl.load(kv_indptr + pid_batch)
-    kv_block_end = tl.load(kv_indptr + pid_batch + 1)
+        kv_block_start = tl.load(kv_indptr + pid_batch)
+        kv_block_end = tl.load(kv_indptr + pid_batch + 1)
 
-    context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
-    context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
+        context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
+        context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
 
-    total_kv_block = kv_block_end - kv_block_start
-    total_kv_chunk = (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK
+        total_kv_block = kv_block_end - kv_block_start
+        total_kv_chunk = (
+            total_kv_block + Fp4KBlocksPerChunkK - 1
+        ) // Fp4KBlocksPerChunkK
 
-    # ===---------------------------------------------------
-    # Pipeline Start
-    # ===---------------------------------------------------
-    k_type = k_buffer.dtype.element_ty
-    if k_type == tl.bfloat16:
-        k_scalar_scale = 1.0
+        k_type = k_buffer.dtype.element_ty
+        if k_type == tl.bfloat16:
+            k_scalar_scale = 1.0
+        else:
+            k_scalar_scale = tl.load(k_scale)
+
+        offs_n_k = tl.arange(0, PaddedK)
+        offs_n_v = tl.arange(0, PaddedV)
+        mask_k = offs_n_k < QkNopeHeadDim
+        mask_v = offs_n_v < VHeadDim
+        offs_k = tl.arange(0, Fp4ScaleKGranularity)
+        offs_k_packed = tl.arange(0, PackedScaleKGranularity)
+
+        head_row_base = pid_head * (QkNopeHeadDim + VHeadDim)
+        k_abs_rows = head_row_base + offs_n_k
+        v_abs_rows = head_row_base + QkNopeHeadDim + offs_n_v
+
+        for chunk_id in range(total_kv_chunk):
+            block_lane_valid = (
+                chunk_id * Fp4KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
+                < total_kv_block
+            )
+            kv_block_idx = tl.load(
+                kv_indices
+                + kv_block_start
+                + chunk_id * Fp4KBlocksPerChunkK
+                + tl.arange(0, ChunkK) // KBlockSize,
+                mask=block_lane_valid,
+                other=0,
+            )
+
+            accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
+            accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
+            row_mask = block_lane_valid[:, None]
+
+            for seg in range(NumKSegments):
+                kv_c_data = tl.load(
+                    k_buffer
+                    + kv_block_idx[:, None] * stride_k_buffer
+                    + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+                    + seg * Fp4ScaleKGranularity
+                    + offs_k[None, :],
+                    mask=row_mask,
+                    other=0.0,
+                ).to(tl.bfloat16)
+
+                packed_cols = seg * PackedScaleKGranularity + offs_k_packed[:, None]
+
+                if WEIGHT_PRESHUFFLE:
+                    # Inverse of aiter.ops.shuffle.shuffle_weight for uint8/packed-fp4
+                    # tensors with layout=(16, 16).  It maps logical [N, K//2]
+                    # coordinates back into the preshuffled storage.
+                    k_n0 = k_abs_rows[None, :] // 16
+                    k_bn = k_abs_rows[None, :] % 16
+                    k_k0 = packed_cols // 32
+                    k_r = (packed_cols % 32) // 16
+                    k_c = packed_cols % 16
+                    k_weight_offset = (
+                        ((k_n0 * (PackedKV_CDim // 32) + k_k0) * 2 + k_r) * 16 + k_bn
+                    ) * 16 + k_c
+
+                    v_n0 = v_abs_rows[None, :] // 16
+                    v_bn = v_abs_rows[None, :] % 16
+                    v_k0 = packed_cols // 32
+                    v_r = (packed_cols % 32) // 16
+                    v_c = packed_cols % 16
+                    v_weight_offset = (
+                        ((v_n0 * (PackedKV_CDim // 32) + v_k0) * 2 + v_r) * 16 + v_bn
+                    ) * 16 + v_c
+                else:
+                    k_weight_offset = k_abs_rows[None, :] * PackedKV_CDim + packed_cols
+                    v_weight_offset = v_abs_rows[None, :] * PackedKV_CDim + packed_cols
+
+                k_weight = tl.load(
+                    kv_proj_weight + k_weight_offset,
+                    mask=mask_k[None, :],
+                    other=0,
+                )
+                v_weight = tl.load(
+                    kv_proj_weight + v_weight_offset,
+                    mask=mask_v[None, :],
+                    other=0,
+                )
+
+                if WEIGHT_PRESHUFFLE:
+                    # Inverse of fp4_utils.e8m0_shuffle / shuffle_scale.
+                    k_scale_n = k_abs_rows[:, None]
+                    k_scale_g = seg
+                    k_scale_a = k_scale_n // 32
+                    k_scale_b = (k_scale_n % 32) // 16
+                    k_scale_c = k_scale_n % 16
+                    k_scale_d = k_scale_g // 8
+                    k_scale_e = (k_scale_g % 8) // 4
+                    k_scale_f = k_scale_g % 4
+                    k_scale_offset = (
+                        (
+                            ((k_scale_a * (ScaleCols // 8) + k_scale_d) * 4 + k_scale_f)
+                            * 16
+                            + k_scale_c
+                        )
+                        * 2
+                        + k_scale_e
+                    ) * 2 + k_scale_b
+
+                    v_scale_n = v_abs_rows[:, None]
+                    v_scale_g = seg
+                    v_scale_a = v_scale_n // 32
+                    v_scale_b = (v_scale_n % 32) // 16
+                    v_scale_c = v_scale_n % 16
+                    v_scale_d = v_scale_g // 8
+                    v_scale_e = (v_scale_g % 8) // 4
+                    v_scale_f = v_scale_g % 4
+                    v_scale_offset = (
+                        (
+                            ((v_scale_a * (ScaleCols // 8) + v_scale_d) * 4 + v_scale_f)
+                            * 16
+                            + v_scale_c
+                        )
+                        * 2
+                        + v_scale_e
+                    ) * 2 + v_scale_b
+                else:
+                    k_scale_offset = k_abs_rows[:, None] * ScaleCols + seg
+                    v_scale_offset = v_abs_rows[:, None] * ScaleCols + seg
+
+                k_weight_scale = tl.load(
+                    kv_proj_scale + k_scale_offset,
+                    mask=mask_k[:, None],
+                    other=0,
+                )
+                v_weight_scale = tl.load(
+                    kv_proj_scale + v_scale_offset,
+                    mask=mask_v[:, None],
+                    other=0,
+                )
+
+                accum_k = tl.dot_scaled(
+                    kv_c_data,
+                    None,
+                    "bf16",
+                    k_weight,
+                    k_weight_scale,
+                    "e2m1",
+                    acc=accum_k,
+                    fast_math=True,
+                )
+                accum_v = tl.dot_scaled(
+                    kv_c_data,
+                    None,
+                    "bf16",
+                    v_weight,
+                    v_weight_scale,
+                    "e2m1",
+                    acc=accum_v,
+                    fast_math=True,
+                )
+
+            kv_pe_data = tl.load(
+                k_buffer
+                + kv_block_idx[:, None] * stride_k_buffer
+                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+                + KV_CDim
+                + tl.arange(0, KV_PeDim)[None, :],
+                mask=row_mask,
+                other=0.0,
+            )
+
+            accum_k *= k_scalar_scale
+            accum_v *= k_scalar_scale
+            kv_pe_data *= k_scalar_scale
+
+            context_mask = (
+                context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
+            )
+            tl.store(
+                k_prefix
+                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+                * stride_k_prefix
+                + pid_head * (QkNopeHeadDim + KV_PeDim)
+                + QkNopeHeadDim
+                + tl.arange(0, KV_PeDim)[None, :],
+                kv_pe_data,
+                mask=context_mask[:, None],
+            )
+            tl.store(
+                k_prefix
+                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+                * stride_k_prefix
+                + pid_head * (QkNopeHeadDim + KV_PeDim)
+                + offs_n_k[None, :],
+                accum_k,
+                mask=context_mask[:, None] & mask_k[None, :],
+            )
+            tl.store(
+                v_prefix
+                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+                * stride_v_prefix
+                + pid_head * VHeadDim
+                + offs_n_v[None, :],
+                accum_v,
+                mask=context_mask[:, None] & mask_v[None, :],
+            )
+
+
     else:
-        k_scalar_scale = tl.load(k_scale)
-
-    offs_n_k = tl.arange(0, PaddedK)
-    offs_n_v = tl.arange(0, PaddedV)
-    mask_k = offs_n_k < QkNopeHeadDim
-    mask_v = offs_n_v < VHeadDim
-    offs_k = tl.arange(0, ScaleKGranularity)
-    k_head_base = kv_proj_weight + pid_head * (QkNopeHeadDim + VHeadDim) * KV_CDim
-    v_head_base = k_head_base + QkNopeHeadDim * KV_CDim
-
-    if NO_SCALE:
-        # weight is not quantized; skip scale loading entirely
-        pass
-    elif PER_ROW_SCALE:
-        k_row0 = pid_head * (QkNopeHeadDim + VHeadDim)
-        k_nope_scale_vec = tl.load(
-            kv_proj_scale + k_row0 + offs_n_k, mask=mask_k, other=1.0
-        ).to(tl.float32)
-        v_nope_scale_vec = tl.load(
-            kv_proj_scale + k_row0 + QkNopeHeadDim + offs_n_v, mask=mask_v, other=1.0
-        ).to(tl.float32)
-    else:
-        num_scale_cols: tl.constexpr = KV_CDim // ScaleKGranularity
-        k_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + offs_n_k
-        k_scale_n_idx = k_abs_rows // ScaleNGranularity
-        v_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + QkNopeHeadDim + offs_n_v
-        v_scale_n_idx = v_abs_rows // ScaleNGranularity
-
-    if WEIGHT_PRESHUFFLE:
-        # _load_unshuffle_segment returns [PaddedHeadDim, ScaleKGranularity]
-        # with zero-filled rows beyond HeadDim
-        k_nope_weight_0 = _load_unshuffle_segment(
-            k_head_base, 0, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-        k_nope_weight_1 = _load_unshuffle_segment(
-            k_head_base, 1, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-        k_nope_weight_2 = _load_unshuffle_segment(
-            k_head_base, 2, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-        k_nope_weight_3 = _load_unshuffle_segment(
-            k_head_base, 3, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-
-        v_nope_weight_0 = _load_unshuffle_segment(
-            v_head_base, 0, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-        v_nope_weight_1 = _load_unshuffle_segment(
-            v_head_base, 1, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-        v_nope_weight_2 = _load_unshuffle_segment(
-            v_head_base, 2, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-        v_nope_weight_3 = _load_unshuffle_segment(
-            v_head_base, 3, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-        ).to(k_type)
-    else:
-        k_nope_weight_base_offset = (
-            k_head_base + offs_n_k[:, None] * KV_CDim + offs_k[None, :]
+        # All three strides are multiplied by runtime indices that can overflow
+        # i32 at large scales. Promote the scalar (broadcast) side to i64 so the multiply
+        # is i32-zext x i64 -> i64
+        stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
+        stride_k_prefix = tl.full(
+            [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
         )
-        k_mask_2d = mask_k[:, None]
-        k_nope_weight_0 = tl.load(
-            k_nope_weight_base_offset + 0 * ScaleKGranularity,
-            mask=k_mask_2d,
-            other=0.0,
-        ).to(k_type)
-        k_nope_weight_1 = tl.load(
-            k_nope_weight_base_offset + 1 * ScaleKGranularity,
-            mask=k_mask_2d,
-            other=0.0,
-        ).to(k_type)
-        k_nope_weight_2 = tl.load(
-            k_nope_weight_base_offset + 2 * ScaleKGranularity,
-            mask=k_mask_2d,
-            other=0.0,
-        ).to(k_type)
-        k_nope_weight_3 = tl.load(
-            k_nope_weight_base_offset + 3 * ScaleKGranularity,
-            mask=k_mask_2d,
-            other=0.0,
-        ).to(k_type)
+        stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
 
-        v_nope_weight_base_offset = (
-            v_head_base + offs_n_v[:, None] * KV_CDim + offs_k[None, :]
-        )
-        v_mask_2d = mask_v[:, None]
-        v_nope_weight_0 = tl.load(
-            v_nope_weight_base_offset + 0 * ScaleKGranularity,
-            mask=v_mask_2d,
-            other=0.0,
-        ).to(k_type)
-        v_nope_weight_1 = tl.load(
-            v_nope_weight_base_offset + 1 * ScaleKGranularity,
-            mask=v_mask_2d,
-            other=0.0,
-        ).to(k_type)
-        v_nope_weight_2 = tl.load(
-            v_nope_weight_base_offset + 2 * ScaleKGranularity,
-            mask=v_mask_2d,
-            other=0.0,
-        ).to(k_type)
-        v_nope_weight_3 = tl.load(
-            v_nope_weight_base_offset + 3 * ScaleKGranularity,
-            mask=v_mask_2d,
-            other=0.0,
-        ).to(k_type)
+        ScaleKGranularity: tl.constexpr = 128
+        ScaleNGranularity: tl.constexpr = 128
+        KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
+        assert KV_CDim == 4 * ScaleKGranularity
 
-    if (not NO_SCALE) and (not PER_ROW_SCALE):
-        k_nope_scale_0 = tl.load(
-            kv_proj_scale + k_scale_n_idx * num_scale_cols + 0,
-            mask=mask_k,
-            other=0.0,
-        ).to(tl.float32)
-        k_nope_scale_1 = tl.load(
-            kv_proj_scale + k_scale_n_idx * num_scale_cols + 1,
-            mask=mask_k,
-            other=0.0,
-        ).to(tl.float32)
-        k_nope_scale_2 = tl.load(
-            kv_proj_scale + k_scale_n_idx * num_scale_cols + 2,
-            mask=mask_k,
-            other=0.0,
-        ).to(tl.float32)
-        k_nope_scale_3 = tl.load(
-            kv_proj_scale + k_scale_n_idx * num_scale_cols + 3,
-            mask=mask_k,
-            other=0.0,
-        ).to(tl.float32)
+        # ===---------------------------------------------------
+        # Workload Partition
+        # ===---------------------------------------------------
+        pid = tl.program_id(0)
+        pid_batch = pid // TpNumHeads
+        pid_head = pid % TpNumHeads
 
-        v_nope_scale_0 = tl.load(
-            kv_proj_scale + v_scale_n_idx * num_scale_cols + 0,
-            mask=mask_v,
-            other=0.0,
-        ).to(tl.float32)
-        v_nope_scale_1 = tl.load(
-            kv_proj_scale + v_scale_n_idx * num_scale_cols + 1,
-            mask=mask_v,
-            other=0.0,
-        ).to(tl.float32)
-        v_nope_scale_2 = tl.load(
-            kv_proj_scale + v_scale_n_idx * num_scale_cols + 2,
-            mask=mask_v,
-            other=0.0,
-        ).to(tl.float32)
-        v_nope_scale_3 = tl.load(
-            kv_proj_scale + v_scale_n_idx * num_scale_cols + 3,
-            mask=mask_v,
-            other=0.0,
-        ).to(tl.float32)
+        kv_block_start = tl.load(kv_indptr + pid_batch)
+        kv_block_end = tl.load(kv_indptr + pid_batch + 1)
 
-    for chunk_id in range(total_kv_chunk):
-        block_lane_valid = (
-            chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
-            < total_kv_block
-        )
-        kv_block_idx = tl.load(
-            kv_indices
-            + kv_block_start
-            + chunk_id * KBlocksPerChunkK
-            + tl.arange(0, ChunkK) // KBlockSize,
-            mask=block_lane_valid,
-            other=0,
-        )
-        kv_c_data_base_offset = (
-            kv_block_idx[:, None] * stride_k_buffer
-            + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-            + tl.arange(0, ScaleKGranularity)[None, :]
-        )  # [ChunkK, kv_c_dim]
+        context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
+        context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
 
-        accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
-        accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
+        total_kv_block = kv_block_end - kv_block_start
+        total_kv_chunk = (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK
 
-        row_mask = block_lane_valid[:, None]
-        kv_c_data_0 = tl.load(
-            k_buffer + kv_c_data_base_offset + 0 * ScaleKGranularity,
-            mask=row_mask,
-            other=0.0,
-        )
-        kv_c_data_1 = tl.load(
-            k_buffer + kv_c_data_base_offset + 1 * ScaleKGranularity,
-            mask=row_mask,
-            other=0.0,
-        )
-        kv_c_data_2 = tl.load(
-            k_buffer + kv_c_data_base_offset + 2 * ScaleKGranularity,
-            mask=row_mask,
-            other=0.0,
-        )
-        kv_c_data_3 = tl.load(
-            k_buffer + kv_c_data_base_offset + 3 * ScaleKGranularity,
-            mask=row_mask,
-            other=0.0,
-        )
-        kv_pe_data = tl.load(
-            k_buffer
-            + kv_block_idx[:, None] * stride_k_buffer
-            + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-            + KV_CDim
-            + tl.arange(0, KV_PeDim)[None, :],
-            mask=row_mask,
-            other=0.0,
-        )
+        # ===---------------------------------------------------
+        # Pipeline Start
+        # ===---------------------------------------------------
+        k_type = k_buffer.dtype.element_ty
+        if k_type == tl.bfloat16:
+            k_scalar_scale = 1.0
+        else:
+            k_scalar_scale = tl.load(k_scale)
+
+        offs_n_k = tl.arange(0, PaddedK)
+        offs_n_v = tl.arange(0, PaddedV)
+        mask_k = offs_n_k < QkNopeHeadDim
+        mask_v = offs_n_v < VHeadDim
+        offs_k = tl.arange(0, ScaleKGranularity)
+        k_head_base = kv_proj_weight + pid_head * (QkNopeHeadDim + VHeadDim) * KV_CDim
+        v_head_base = k_head_base + QkNopeHeadDim * KV_CDim
 
         if NO_SCALE:
-            accum_k = tl.dot(kv_c_data_0, k_nope_weight_0.T, acc=accum_k)
-            accum_v = tl.dot(kv_c_data_0, v_nope_weight_0.T, acc=accum_v)
-            accum_k = tl.dot(kv_c_data_1, k_nope_weight_1.T, acc=accum_k)
-            accum_v = tl.dot(kv_c_data_1, v_nope_weight_1.T, acc=accum_v)
-            accum_k = tl.dot(kv_c_data_2, k_nope_weight_2.T, acc=accum_k)
-            accum_v = tl.dot(kv_c_data_2, v_nope_weight_2.T, acc=accum_v)
-            accum_k = tl.dot(kv_c_data_3, k_nope_weight_3.T, acc=accum_k)
-            accum_v = tl.dot(kv_c_data_3, v_nope_weight_3.T, acc=accum_v)
+            # weight is not quantized; skip scale loading entirely
+            pass
         elif PER_ROW_SCALE:
-            accum_k += (
-                tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_vec[None, :]
-            )
-            accum_v += (
-                tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_vec[None, :]
-            )
-            accum_k += (
-                tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_vec[None, :]
-            )
-            accum_v += (
-                tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_vec[None, :]
-            )
-            accum_k += (
-                tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_vec[None, :]
-            )
-            accum_v += (
-                tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_vec[None, :]
-            )
-            accum_k += (
-                tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_vec[None, :]
-            )
-            accum_v += (
-                tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_vec[None, :]
-            )
+            k_row0 = pid_head * (QkNopeHeadDim + VHeadDim)
+            k_nope_scale_vec = tl.load(
+                kv_proj_scale + k_row0 + offs_n_k, mask=mask_k, other=1.0
+            ).to(tl.float32)
+            v_nope_scale_vec = tl.load(
+                kv_proj_scale + k_row0 + QkNopeHeadDim + offs_n_v, mask=mask_v, other=1.0
+            ).to(tl.float32)
         else:
-            accum_k += tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_0[None, :]
-            accum_v += tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_0[None, :]
-            accum_k += tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_1[None, :]
-            accum_v += tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_1[None, :]
-            accum_k += tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_2[None, :]
-            accum_v += tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_2[None, :]
-            accum_k += tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_3[None, :]
-            accum_v += tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_3[None, :]
+            num_scale_cols: tl.constexpr = KV_CDim // ScaleKGranularity
+            k_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + offs_n_k
+            k_scale_n_idx = k_abs_rows // ScaleNGranularity
+            v_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + QkNopeHeadDim + offs_n_v
+            v_scale_n_idx = v_abs_rows // ScaleNGranularity
 
-        accum_k *= k_scalar_scale
-        accum_v *= k_scalar_scale
-        kv_pe_data *= k_scalar_scale
+        if WEIGHT_PRESHUFFLE:
+            # _load_unshuffle_segment returns [PaddedHeadDim, ScaleKGranularity]
+            # with zero-filled rows beyond HeadDim
+            k_nope_weight_0 = _load_unshuffle_segment(
+                k_head_base, 0, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+            ).to(k_type)
+            k_nope_weight_1 = _load_unshuffle_segment(
+                k_head_base, 1, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+            ).to(k_type)
+            k_nope_weight_2 = _load_unshuffle_segment(
+                k_head_base, 2, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+            ).to(k_type)
+            k_nope_weight_3 = _load_unshuffle_segment(
+                k_head_base, 3, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+            ).to(k_type)
 
-        context_mask = (
-            context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
-        )
-        tl.store(
-            k_prefix
-            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-            * stride_k_prefix
-            + pid_head * (QkNopeHeadDim + KV_PeDim)
-            + QkNopeHeadDim
-            + tl.arange(0, KV_PeDim)[None, :],
-            kv_pe_data,
-            mask=context_mask[:, None],
-        )
-        tl.store(
-            k_prefix
-            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-            * stride_k_prefix
-            + pid_head * (QkNopeHeadDim + KV_PeDim)
-            + offs_n_k[None, :],
-            accum_k,
-            mask=context_mask[:, None] & mask_k[None, :],
-        )
-        tl.store(
-            v_prefix
-            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-            * stride_v_prefix
-            + pid_head * VHeadDim
-            + offs_n_v[None, :],
-            accum_v,
-            mask=context_mask[:, None] & mask_v[None, :],
-        )
+            v_nope_weight_0 = _load_unshuffle_segment(
+                v_head_base, 0, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+            ).to(k_type)
+            v_nope_weight_1 = _load_unshuffle_segment(
+                v_head_base, 1, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+            ).to(k_type)
+            v_nope_weight_2 = _load_unshuffle_segment(
+                v_head_base, 2, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+            ).to(k_type)
+            v_nope_weight_3 = _load_unshuffle_segment(
+                v_head_base, 3, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+            ).to(k_type)
+        else:
+            k_nope_weight_base_offset = (
+                k_head_base + offs_n_k[:, None] * KV_CDim + offs_k[None, :]
+            )
+            k_mask_2d = mask_k[:, None]
+            k_nope_weight_0 = tl.load(
+                k_nope_weight_base_offset + 0 * ScaleKGranularity,
+                mask=k_mask_2d,
+                other=0.0,
+            ).to(k_type)
+            k_nope_weight_1 = tl.load(
+                k_nope_weight_base_offset + 1 * ScaleKGranularity,
+                mask=k_mask_2d,
+                other=0.0,
+            ).to(k_type)
+            k_nope_weight_2 = tl.load(
+                k_nope_weight_base_offset + 2 * ScaleKGranularity,
+                mask=k_mask_2d,
+                other=0.0,
+            ).to(k_type)
+            k_nope_weight_3 = tl.load(
+                k_nope_weight_base_offset + 3 * ScaleKGranularity,
+                mask=k_mask_2d,
+                other=0.0,
+            ).to(k_type)
+
+            v_nope_weight_base_offset = (
+                v_head_base + offs_n_v[:, None] * KV_CDim + offs_k[None, :]
+            )
+            v_mask_2d = mask_v[:, None]
+            v_nope_weight_0 = tl.load(
+                v_nope_weight_base_offset + 0 * ScaleKGranularity,
+                mask=v_mask_2d,
+                other=0.0,
+            ).to(k_type)
+            v_nope_weight_1 = tl.load(
+                v_nope_weight_base_offset + 1 * ScaleKGranularity,
+                mask=v_mask_2d,
+                other=0.0,
+            ).to(k_type)
+            v_nope_weight_2 = tl.load(
+                v_nope_weight_base_offset + 2 * ScaleKGranularity,
+                mask=v_mask_2d,
+                other=0.0,
+            ).to(k_type)
+            v_nope_weight_3 = tl.load(
+                v_nope_weight_base_offset + 3 * ScaleKGranularity,
+                mask=v_mask_2d,
+                other=0.0,
+            ).to(k_type)
+
+        if (not NO_SCALE) and (not PER_ROW_SCALE):
+            k_nope_scale_0 = tl.load(
+                kv_proj_scale + k_scale_n_idx * num_scale_cols + 0,
+                mask=mask_k,
+                other=0.0,
+            ).to(tl.float32)
+            k_nope_scale_1 = tl.load(
+                kv_proj_scale + k_scale_n_idx * num_scale_cols + 1,
+                mask=mask_k,
+                other=0.0,
+            ).to(tl.float32)
+            k_nope_scale_2 = tl.load(
+                kv_proj_scale + k_scale_n_idx * num_scale_cols + 2,
+                mask=mask_k,
+                other=0.0,
+            ).to(tl.float32)
+            k_nope_scale_3 = tl.load(
+                kv_proj_scale + k_scale_n_idx * num_scale_cols + 3,
+                mask=mask_k,
+                other=0.0,
+            ).to(tl.float32)
+
+            v_nope_scale_0 = tl.load(
+                kv_proj_scale + v_scale_n_idx * num_scale_cols + 0,
+                mask=mask_v,
+                other=0.0,
+            ).to(tl.float32)
+            v_nope_scale_1 = tl.load(
+                kv_proj_scale + v_scale_n_idx * num_scale_cols + 1,
+                mask=mask_v,
+                other=0.0,
+            ).to(tl.float32)
+            v_nope_scale_2 = tl.load(
+                kv_proj_scale + v_scale_n_idx * num_scale_cols + 2,
+                mask=mask_v,
+                other=0.0,
+            ).to(tl.float32)
+            v_nope_scale_3 = tl.load(
+                kv_proj_scale + v_scale_n_idx * num_scale_cols + 3,
+                mask=mask_v,
+                other=0.0,
+            ).to(tl.float32)
+
+        for chunk_id in range(total_kv_chunk):
+            block_lane_valid = (
+                chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
+                < total_kv_block
+            )
+            kv_block_idx = tl.load(
+                kv_indices
+                + kv_block_start
+                + chunk_id * KBlocksPerChunkK
+                + tl.arange(0, ChunkK) // KBlockSize,
+                mask=block_lane_valid,
+                other=0,
+            )
+            kv_c_data_base_offset = (
+                kv_block_idx[:, None] * stride_k_buffer
+                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+                + tl.arange(0, ScaleKGranularity)[None, :]
+            )  # [ChunkK, kv_c_dim]
+
+            accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
+            accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
+
+            row_mask = block_lane_valid[:, None]
+            kv_c_data_0 = tl.load(
+                k_buffer + kv_c_data_base_offset + 0 * ScaleKGranularity,
+                mask=row_mask,
+                other=0.0,
+            )
+            kv_c_data_1 = tl.load(
+                k_buffer + kv_c_data_base_offset + 1 * ScaleKGranularity,
+                mask=row_mask,
+                other=0.0,
+            )
+            kv_c_data_2 = tl.load(
+                k_buffer + kv_c_data_base_offset + 2 * ScaleKGranularity,
+                mask=row_mask,
+                other=0.0,
+            )
+            kv_c_data_3 = tl.load(
+                k_buffer + kv_c_data_base_offset + 3 * ScaleKGranularity,
+                mask=row_mask,
+                other=0.0,
+            )
+            kv_pe_data = tl.load(
+                k_buffer
+                + kv_block_idx[:, None] * stride_k_buffer
+                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+                + KV_CDim
+                + tl.arange(0, KV_PeDim)[None, :],
+                mask=row_mask,
+                other=0.0,
+            )
+
+            if NO_SCALE:
+                accum_k = tl.dot(kv_c_data_0, k_nope_weight_0.T, acc=accum_k)
+                accum_v = tl.dot(kv_c_data_0, v_nope_weight_0.T, acc=accum_v)
+                accum_k = tl.dot(kv_c_data_1, k_nope_weight_1.T, acc=accum_k)
+                accum_v = tl.dot(kv_c_data_1, v_nope_weight_1.T, acc=accum_v)
+                accum_k = tl.dot(kv_c_data_2, k_nope_weight_2.T, acc=accum_k)
+                accum_v = tl.dot(kv_c_data_2, v_nope_weight_2.T, acc=accum_v)
+                accum_k = tl.dot(kv_c_data_3, k_nope_weight_3.T, acc=accum_k)
+                accum_v = tl.dot(kv_c_data_3, v_nope_weight_3.T, acc=accum_v)
+            elif PER_ROW_SCALE:
+                accum_k += (
+                    tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_vec[None, :]
+                )
+                accum_v += (
+                    tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_vec[None, :]
+                )
+                accum_k += (
+                    tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_vec[None, :]
+                )
+                accum_v += (
+                    tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_vec[None, :]
+                )
+                accum_k += (
+                    tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_vec[None, :]
+                )
+                accum_v += (
+                    tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_vec[None, :]
+                )
+                accum_k += (
+                    tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_vec[None, :]
+                )
+                accum_v += (
+                    tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_vec[None, :]
+                )
+            else:
+                accum_k += tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_0[None, :]
+                accum_v += tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_0[None, :]
+                accum_k += tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_1[None, :]
+                accum_v += tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_1[None, :]
+                accum_k += tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_2[None, :]
+                accum_v += tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_2[None, :]
+                accum_k += tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_3[None, :]
+                accum_v += tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_3[None, :]
+
+            accum_k *= k_scalar_scale
+            accum_v *= k_scalar_scale
+            kv_pe_data *= k_scalar_scale
+
+            context_mask = (
+                context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
+            )
+            tl.store(
+                k_prefix
+                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+                * stride_k_prefix
+                + pid_head * (QkNopeHeadDim + KV_PeDim)
+                + QkNopeHeadDim
+                + tl.arange(0, KV_PeDim)[None, :],
+                kv_pe_data,
+                mask=context_mask[:, None],
+            )
+            tl.store(
+                k_prefix
+                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+                * stride_k_prefix
+                + pid_head * (QkNopeHeadDim + KV_PeDim)
+                + offs_n_k[None, :],
+                accum_k,
+                mask=context_mask[:, None] & mask_k[None, :],
+            )
+            tl.store(
+                v_prefix
+                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+                * stride_v_prefix
+                + pid_head * VHeadDim
+                + offs_n_v[None, :],
+                accum_v,
+                mask=context_mask[:, None] & mask_v[None, :],
+            )

--- a/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
+++ b/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
@@ -59,7 +59,260 @@ def _load_unshuffle_segment(
 
 
 @triton.jit
-def _triton_gather_kv_b_proj(
+def _triton_gather_kv_b_proj_fp4_impl(
+    batch_size,
+    k_buffer,  # [num_block, block_size, kv_c_dim + kv_pe_dim]
+    k_scale,  # [1] or None
+    kv_indptr,  # [batch_size + 1]
+    kv_indices,  # [total_kv]
+    kv_prefix_sum_context_lens,  # [batch_size + 1]
+    kv_proj_weight,  # packed fp4: [tp_heads * (qk_nope_head_dim + v_head_dim), kv_c_dim // 2]
+    kv_proj_scale,  # e8m0 per-1x32: [weight_n, kv_c_dim // 32]
+    k_prefix,  # [total_kv, tp_k_head_num, qk_nope_head_dim + kv_pe_dim]
+    v_prefix,  # [total_kv, tp_k_head_num, v_head_dim]
+    KBlockSize: tl.constexpr,
+    TpNumHeads: tl.constexpr,
+    QkNopeHeadDim: tl.constexpr,
+    VHeadDim: tl.constexpr,
+    KV_CDim: tl.constexpr,
+    KV_PeDim: tl.constexpr,
+    ChunkK: tl.constexpr,
+    PaddedK: tl.constexpr,
+    PaddedV: tl.constexpr,
+    ScaleCols: tl.constexpr,
+    WEIGHT_PRESHUFFLE: tl.constexpr = False,
+):
+    """FP4/per-1x32 gather + kv_b_proj expansion for raw MXFP4 weights."""
+    stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
+    stride_k_prefix = tl.full(
+        [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
+    )
+    stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
+
+    ScaleKGranularity: tl.constexpr = 32
+    PackedScaleKGranularity: tl.constexpr = ScaleKGranularity // 2
+    PackedKV_CDim: tl.constexpr = KV_CDim // 2
+    KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
+    NumKSegments: tl.constexpr = KV_CDim // ScaleKGranularity
+
+    flat_pid = tl.program_id(0)
+    num_batch_heads = batch_size * TpNumHeads
+    pid = flat_pid % num_batch_heads
+    chunk_id = flat_pid // num_batch_heads
+    pid_batch = pid // TpNumHeads
+    pid_head = pid % TpNumHeads
+
+    kv_block_start = tl.load(kv_indptr + pid_batch)
+    kv_block_end = tl.load(kv_indptr + pid_batch + 1)
+
+    context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
+    context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
+
+    total_kv_block = kv_block_end - kv_block_start
+
+    k_type = k_buffer.dtype.element_ty
+    if k_type == tl.bfloat16:
+        k_scalar_scale = 1.0
+    else:
+        k_scalar_scale = tl.load(k_scale)
+
+    offs_n_k = tl.arange(0, PaddedK)
+    offs_n_v = tl.arange(0, PaddedV)
+    mask_k = offs_n_k < QkNopeHeadDim
+    mask_v = offs_n_v < VHeadDim
+    offs_k = tl.arange(0, ScaleKGranularity)
+    offs_k_packed = tl.arange(0, PackedScaleKGranularity)
+
+    head_row_base = pid_head * (QkNopeHeadDim + VHeadDim)
+    k_abs_rows = head_row_base + offs_n_k
+    v_abs_rows = head_row_base + QkNopeHeadDim + offs_n_v
+
+    block_lane_valid = (
+        chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
+        < total_kv_block
+    )
+    kv_block_idx = tl.load(
+        kv_indices
+        + kv_block_start
+        + chunk_id * KBlocksPerChunkK
+        + tl.arange(0, ChunkK) // KBlockSize,
+        mask=block_lane_valid,
+        other=0,
+    )
+
+    accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
+    accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
+    row_mask = block_lane_valid[:, None]
+
+    for seg in range(NumKSegments):
+        kv_c_data = tl.load(
+            k_buffer
+            + kv_block_idx[:, None] * stride_k_buffer
+            + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+            + seg * ScaleKGranularity
+            + offs_k[None, :],
+            mask=row_mask,
+            other=0.0,
+        ).to(tl.bfloat16)
+
+        packed_cols = seg * PackedScaleKGranularity + offs_k_packed[:, None]
+
+        if WEIGHT_PRESHUFFLE:
+            # Inverse of aiter.ops.shuffle.shuffle_weight for uint8/packed-fp4
+            # tensors with layout=(16, 16).  It maps logical [N, K//2]
+            # coordinates back into the preshuffled storage.
+            k_n0 = k_abs_rows[None, :] // 16
+            k_bn = k_abs_rows[None, :] % 16
+            k_k0 = packed_cols // 32
+            k_r = (packed_cols % 32) // 16
+            k_c = packed_cols % 16
+            k_weight_offset = (
+                ((k_n0 * (PackedKV_CDim // 32) + k_k0) * 2 + k_r) * 16 + k_bn
+            ) * 16 + k_c
+
+            v_n0 = v_abs_rows[None, :] // 16
+            v_bn = v_abs_rows[None, :] % 16
+            v_k0 = packed_cols // 32
+            v_r = (packed_cols % 32) // 16
+            v_c = packed_cols % 16
+            v_weight_offset = (
+                ((v_n0 * (PackedKV_CDim // 32) + v_k0) * 2 + v_r) * 16 + v_bn
+            ) * 16 + v_c
+        else:
+            k_weight_offset = k_abs_rows[None, :] * PackedKV_CDim + packed_cols
+            v_weight_offset = v_abs_rows[None, :] * PackedKV_CDim + packed_cols
+
+        k_weight = tl.load(
+            kv_proj_weight + k_weight_offset,
+            mask=mask_k[None, :],
+            other=0,
+        )
+        v_weight = tl.load(
+            kv_proj_weight + v_weight_offset,
+            mask=mask_v[None, :],
+            other=0,
+        )
+
+        if WEIGHT_PRESHUFFLE:
+            # Inverse of fp4_utils.e8m0_shuffle / shuffle_scale.
+            k_scale_n = k_abs_rows[:, None]
+            k_scale_g = seg
+            k_scale_a = k_scale_n // 32
+            k_scale_b = (k_scale_n % 32) // 16
+            k_scale_c = k_scale_n % 16
+            k_scale_d = k_scale_g // 8
+            k_scale_e = (k_scale_g % 8) // 4
+            k_scale_f = k_scale_g % 4
+            k_scale_offset = (
+                (
+                    ((k_scale_a * (ScaleCols // 8) + k_scale_d) * 4 + k_scale_f) * 16
+                    + k_scale_c
+                )
+                * 2
+                + k_scale_e
+            ) * 2 + k_scale_b
+
+            v_scale_n = v_abs_rows[:, None]
+            v_scale_g = seg
+            v_scale_a = v_scale_n // 32
+            v_scale_b = (v_scale_n % 32) // 16
+            v_scale_c = v_scale_n % 16
+            v_scale_d = v_scale_g // 8
+            v_scale_e = (v_scale_g % 8) // 4
+            v_scale_f = v_scale_g % 4
+            v_scale_offset = (
+                (
+                    ((v_scale_a * (ScaleCols // 8) + v_scale_d) * 4 + v_scale_f) * 16
+                    + v_scale_c
+                )
+                * 2
+                + v_scale_e
+            ) * 2 + v_scale_b
+        else:
+            k_scale_offset = k_abs_rows[:, None] * ScaleCols + seg
+            v_scale_offset = v_abs_rows[:, None] * ScaleCols + seg
+
+        k_weight_scale = tl.load(
+            kv_proj_scale + k_scale_offset,
+            mask=mask_k[:, None],
+            other=0,
+        )
+        v_weight_scale = tl.load(
+            kv_proj_scale + v_scale_offset,
+            mask=mask_v[:, None],
+            other=0,
+        )
+
+        accum_k = tl.dot_scaled(
+            kv_c_data,
+            None,
+            "bf16",
+            k_weight,
+            k_weight_scale,
+            "e2m1",
+            acc=accum_k,
+            fast_math=True,
+        )
+        accum_v = tl.dot_scaled(
+            kv_c_data,
+            None,
+            "bf16",
+            v_weight,
+            v_weight_scale,
+            "e2m1",
+            acc=accum_v,
+            fast_math=True,
+        )
+
+    kv_pe_data = tl.load(
+        k_buffer
+        + kv_block_idx[:, None] * stride_k_buffer
+        + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+        + KV_CDim
+        + tl.arange(0, KV_PeDim)[None, :],
+        mask=row_mask,
+        other=0.0,
+    )
+
+    accum_k *= k_scalar_scale
+    accum_v *= k_scalar_scale
+    kv_pe_data *= k_scalar_scale
+
+    context_mask = (
+        context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
+    )
+    tl.store(
+        k_prefix
+        + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+        * stride_k_prefix
+        + pid_head * (QkNopeHeadDim + KV_PeDim)
+        + QkNopeHeadDim
+        + tl.arange(0, KV_PeDim)[None, :],
+        kv_pe_data,
+        mask=context_mask[:, None],
+    )
+    tl.store(
+        k_prefix
+        + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+        * stride_k_prefix
+        + pid_head * (QkNopeHeadDim + KV_PeDim)
+        + offs_n_k[None, :],
+        accum_k,
+        mask=context_mask[:, None] & mask_k[None, :],
+    )
+    tl.store(
+        v_prefix
+        + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+        * stride_v_prefix
+        + pid_head * VHeadDim
+        + offs_n_v[None, :],
+        accum_v,
+        mask=context_mask[:, None] & mask_v[None, :],
+    )
+
+
+@triton.jit
+def _triton_gather_kv_b_proj_impl(
     batch_size,
     k_buffer,  # [num_block, block_size, kv_c_dim + kv_pe_dim]
     k_scale,  # [1] or None
@@ -79,6 +332,352 @@ def _triton_gather_kv_b_proj(
     ChunkK: tl.constexpr,
     PaddedK: tl.constexpr,
     PaddedV: tl.constexpr,
+    WEIGHT_PRESHUFFLE: tl.constexpr = False,
+    PER_ROW_SCALE: tl.constexpr = False,
+    NO_SCALE: tl.constexpr = False,
+):
+    # All three strides are multiplied by runtime indices that can overflow
+    # i32 at large scales. Promote the scalar (broadcast) side to i64 so the multiply
+    # is i32-zext x i64 -> i64
+    stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
+    stride_k_prefix = tl.full(
+        [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
+    )
+    stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
+
+    ScaleKGranularity: tl.constexpr = 128
+    ScaleNGranularity: tl.constexpr = 128
+    KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
+    assert KV_CDim == 4 * ScaleKGranularity
+
+    # ===---------------------------------------------------
+    # Workload Partition
+    # ===---------------------------------------------------
+    pid = tl.program_id(0)
+    pid_batch = pid // TpNumHeads
+    pid_head = pid % TpNumHeads
+
+    kv_block_start = tl.load(kv_indptr + pid_batch)
+    kv_block_end = tl.load(kv_indptr + pid_batch + 1)
+
+    context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
+    context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
+
+    total_kv_block = kv_block_end - kv_block_start
+    total_kv_chunk = (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK
+
+    # ===---------------------------------------------------
+    # Pipeline Start
+    # ===---------------------------------------------------
+    k_type = k_buffer.dtype.element_ty
+    if k_type == tl.bfloat16:
+        k_scalar_scale = 1.0
+    else:
+        k_scalar_scale = tl.load(k_scale)
+
+    offs_n_k = tl.arange(0, PaddedK)
+    offs_n_v = tl.arange(0, PaddedV)
+    mask_k = offs_n_k < QkNopeHeadDim
+    mask_v = offs_n_v < VHeadDim
+    offs_k = tl.arange(0, ScaleKGranularity)
+    k_head_base = kv_proj_weight + pid_head * (QkNopeHeadDim + VHeadDim) * KV_CDim
+    v_head_base = k_head_base + QkNopeHeadDim * KV_CDim
+
+    if NO_SCALE:
+        # weight is not quantized; skip scale loading entirely
+        pass
+    elif PER_ROW_SCALE:
+        k_row0 = pid_head * (QkNopeHeadDim + VHeadDim)
+        k_nope_scale_vec = tl.load(
+            kv_proj_scale + k_row0 + offs_n_k, mask=mask_k, other=1.0
+        ).to(tl.float32)
+        v_nope_scale_vec = tl.load(
+            kv_proj_scale + k_row0 + QkNopeHeadDim + offs_n_v, mask=mask_v, other=1.0
+        ).to(tl.float32)
+    else:
+        num_scale_cols: tl.constexpr = KV_CDim // ScaleKGranularity
+        k_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + offs_n_k
+        k_scale_n_idx = k_abs_rows // ScaleNGranularity
+        v_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + QkNopeHeadDim + offs_n_v
+        v_scale_n_idx = v_abs_rows // ScaleNGranularity
+
+    if WEIGHT_PRESHUFFLE:
+        # _load_unshuffle_segment returns [PaddedHeadDim, ScaleKGranularity]
+        # with zero-filled rows beyond HeadDim
+        k_nope_weight_0 = _load_unshuffle_segment(
+            k_head_base, 0, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+        k_nope_weight_1 = _load_unshuffle_segment(
+            k_head_base, 1, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+        k_nope_weight_2 = _load_unshuffle_segment(
+            k_head_base, 2, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+        k_nope_weight_3 = _load_unshuffle_segment(
+            k_head_base, 3, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+
+        v_nope_weight_0 = _load_unshuffle_segment(
+            v_head_base, 0, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+        v_nope_weight_1 = _load_unshuffle_segment(
+            v_head_base, 1, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+        v_nope_weight_2 = _load_unshuffle_segment(
+            v_head_base, 2, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+        v_nope_weight_3 = _load_unshuffle_segment(
+            v_head_base, 3, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
+        ).to(k_type)
+    else:
+        k_nope_weight_base_offset = (
+            k_head_base + offs_n_k[:, None] * KV_CDim + offs_k[None, :]
+        )
+        k_mask_2d = mask_k[:, None]
+        k_nope_weight_0 = tl.load(
+            k_nope_weight_base_offset + 0 * ScaleKGranularity,
+            mask=k_mask_2d,
+            other=0.0,
+        ).to(k_type)
+        k_nope_weight_1 = tl.load(
+            k_nope_weight_base_offset + 1 * ScaleKGranularity,
+            mask=k_mask_2d,
+            other=0.0,
+        ).to(k_type)
+        k_nope_weight_2 = tl.load(
+            k_nope_weight_base_offset + 2 * ScaleKGranularity,
+            mask=k_mask_2d,
+            other=0.0,
+        ).to(k_type)
+        k_nope_weight_3 = tl.load(
+            k_nope_weight_base_offset + 3 * ScaleKGranularity,
+            mask=k_mask_2d,
+            other=0.0,
+        ).to(k_type)
+
+        v_nope_weight_base_offset = (
+            v_head_base + offs_n_v[:, None] * KV_CDim + offs_k[None, :]
+        )
+        v_mask_2d = mask_v[:, None]
+        v_nope_weight_0 = tl.load(
+            v_nope_weight_base_offset + 0 * ScaleKGranularity,
+            mask=v_mask_2d,
+            other=0.0,
+        ).to(k_type)
+        v_nope_weight_1 = tl.load(
+            v_nope_weight_base_offset + 1 * ScaleKGranularity,
+            mask=v_mask_2d,
+            other=0.0,
+        ).to(k_type)
+        v_nope_weight_2 = tl.load(
+            v_nope_weight_base_offset + 2 * ScaleKGranularity,
+            mask=v_mask_2d,
+            other=0.0,
+        ).to(k_type)
+        v_nope_weight_3 = tl.load(
+            v_nope_weight_base_offset + 3 * ScaleKGranularity,
+            mask=v_mask_2d,
+            other=0.0,
+        ).to(k_type)
+
+    if (not NO_SCALE) and (not PER_ROW_SCALE):
+        k_nope_scale_0 = tl.load(
+            kv_proj_scale + k_scale_n_idx * num_scale_cols + 0,
+            mask=mask_k,
+            other=0.0,
+        ).to(tl.float32)
+        k_nope_scale_1 = tl.load(
+            kv_proj_scale + k_scale_n_idx * num_scale_cols + 1,
+            mask=mask_k,
+            other=0.0,
+        ).to(tl.float32)
+        k_nope_scale_2 = tl.load(
+            kv_proj_scale + k_scale_n_idx * num_scale_cols + 2,
+            mask=mask_k,
+            other=0.0,
+        ).to(tl.float32)
+        k_nope_scale_3 = tl.load(
+            kv_proj_scale + k_scale_n_idx * num_scale_cols + 3,
+            mask=mask_k,
+            other=0.0,
+        ).to(tl.float32)
+
+        v_nope_scale_0 = tl.load(
+            kv_proj_scale + v_scale_n_idx * num_scale_cols + 0,
+            mask=mask_v,
+            other=0.0,
+        ).to(tl.float32)
+        v_nope_scale_1 = tl.load(
+            kv_proj_scale + v_scale_n_idx * num_scale_cols + 1,
+            mask=mask_v,
+            other=0.0,
+        ).to(tl.float32)
+        v_nope_scale_2 = tl.load(
+            kv_proj_scale + v_scale_n_idx * num_scale_cols + 2,
+            mask=mask_v,
+            other=0.0,
+        ).to(tl.float32)
+        v_nope_scale_3 = tl.load(
+            kv_proj_scale + v_scale_n_idx * num_scale_cols + 3,
+            mask=mask_v,
+            other=0.0,
+        ).to(tl.float32)
+
+    for chunk_id in range(total_kv_chunk):
+        block_lane_valid = (
+            chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
+            < total_kv_block
+        )
+        kv_block_idx = tl.load(
+            kv_indices
+            + kv_block_start
+            + chunk_id * KBlocksPerChunkK
+            + tl.arange(0, ChunkK) // KBlockSize,
+            mask=block_lane_valid,
+            other=0,
+        )
+        kv_c_data_base_offset = (
+            kv_block_idx[:, None] * stride_k_buffer
+            + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+            + tl.arange(0, ScaleKGranularity)[None, :]
+        )  # [ChunkK, kv_c_dim]
+
+        accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
+        accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
+
+        row_mask = block_lane_valid[:, None]
+        kv_c_data_0 = tl.load(
+            k_buffer + kv_c_data_base_offset + 0 * ScaleKGranularity,
+            mask=row_mask,
+            other=0.0,
+        )
+        kv_c_data_1 = tl.load(
+            k_buffer + kv_c_data_base_offset + 1 * ScaleKGranularity,
+            mask=row_mask,
+            other=0.0,
+        )
+        kv_c_data_2 = tl.load(
+            k_buffer + kv_c_data_base_offset + 2 * ScaleKGranularity,
+            mask=row_mask,
+            other=0.0,
+        )
+        kv_c_data_3 = tl.load(
+            k_buffer + kv_c_data_base_offset + 3 * ScaleKGranularity,
+            mask=row_mask,
+            other=0.0,
+        )
+        kv_pe_data = tl.load(
+            k_buffer
+            + kv_block_idx[:, None] * stride_k_buffer
+            + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
+            + KV_CDim
+            + tl.arange(0, KV_PeDim)[None, :],
+            mask=row_mask,
+            other=0.0,
+        )
+
+        if NO_SCALE:
+            accum_k = tl.dot(kv_c_data_0, k_nope_weight_0.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_0, v_nope_weight_0.T, acc=accum_v)
+            accum_k = tl.dot(kv_c_data_1, k_nope_weight_1.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_1, v_nope_weight_1.T, acc=accum_v)
+            accum_k = tl.dot(kv_c_data_2, k_nope_weight_2.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_2, v_nope_weight_2.T, acc=accum_v)
+            accum_k = tl.dot(kv_c_data_3, k_nope_weight_3.T, acc=accum_k)
+            accum_v = tl.dot(kv_c_data_3, v_nope_weight_3.T, acc=accum_v)
+        elif PER_ROW_SCALE:
+            accum_k += (
+                tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_vec[None, :]
+            )
+            accum_v += (
+                tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_vec[None, :]
+            )
+            accum_k += (
+                tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_vec[None, :]
+            )
+            accum_v += (
+                tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_vec[None, :]
+            )
+            accum_k += (
+                tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_vec[None, :]
+            )
+            accum_v += (
+                tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_vec[None, :]
+            )
+            accum_k += (
+                tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_vec[None, :]
+            )
+            accum_v += (
+                tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_vec[None, :]
+            )
+        else:
+            accum_k += tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_0[None, :]
+            accum_v += tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_0[None, :]
+            accum_k += tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_1[None, :]
+            accum_v += tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_1[None, :]
+            accum_k += tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_2[None, :]
+            accum_v += tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_2[None, :]
+            accum_k += tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_3[None, :]
+            accum_v += tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_3[None, :]
+
+        accum_k *= k_scalar_scale
+        accum_v *= k_scalar_scale
+        kv_pe_data *= k_scalar_scale
+
+        context_mask = (
+            context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
+        )
+        tl.store(
+            k_prefix
+            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+            * stride_k_prefix
+            + pid_head * (QkNopeHeadDim + KV_PeDim)
+            + QkNopeHeadDim
+            + tl.arange(0, KV_PeDim)[None, :],
+            kv_pe_data,
+            mask=context_mask[:, None],
+        )
+        tl.store(
+            k_prefix
+            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+            * stride_k_prefix
+            + pid_head * (QkNopeHeadDim + KV_PeDim)
+            + offs_n_k[None, :],
+            accum_k,
+            mask=context_mask[:, None] & mask_k[None, :],
+        )
+        tl.store(
+            v_prefix
+            + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
+            * stride_v_prefix
+            + pid_head * VHeadDim
+            + offs_n_v[None, :],
+            accum_v,
+            mask=context_mask[:, None] & mask_v[None, :],
+        )
+
+
+@triton.jit
+def _triton_gather_kv_b_proj(
+    batch_size,
+    k_buffer,  # [num_block, block_size, kv_c_dim + kv_pe_dim]
+    k_scale,  # [1] or None
+    kv_indptr,  # [batch_size + 1]
+    kv_indices,  # [total_kv]
+    kv_prefix_sum_context_lens,  # [batch_size + 1]
+    kv_proj_weight,  # non-FP4: [N, K]; FP4: packed [N, K // 2] viewed as uint8
+    kv_proj_scale,  # non-FP4 block/per-row scale; FP4 e8m0 per-1x32 scale
+    k_prefix,  # [total_kv, tp_k_head_num, qk_nope_head_dim + kv_pe_dim]
+    v_prefix,  # [total_kv, tp_k_head_num, v_head_dim]
+    KBlockSize: tl.constexpr,
+    TpNumHeads: tl.constexpr,
+    QkNopeHeadDim: tl.constexpr,
+    VHeadDim: tl.constexpr,
+    KV_CDim: tl.constexpr,
+    KV_PeDim: tl.constexpr,
+    ChunkK: tl.constexpr,
+    PaddedK: tl.constexpr,
+    PaddedV: tl.constexpr,
     ScaleCols: tl.constexpr = 1,
     IS_FP4: tl.constexpr = False,
     WEIGHT_PRESHUFFLE: tl.constexpr = False,
@@ -86,555 +685,51 @@ def _triton_gather_kv_b_proj(
     NO_SCALE: tl.constexpr = False,
 ):
     if IS_FP4:
-        # FP4/per-1x32 gather + kv_b_proj expansion for raw MXFP4 weights.
-        stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
-        stride_k_prefix = tl.full(
-            [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
+        _triton_gather_kv_b_proj_fp4_impl(
+            batch_size,
+            k_buffer,
+            k_scale,
+            kv_indptr,
+            kv_indices,
+            kv_prefix_sum_context_lens,
+            kv_proj_weight,
+            kv_proj_scale,
+            k_prefix,
+            v_prefix,
+            KBlockSize,
+            TpNumHeads,
+            QkNopeHeadDim,
+            VHeadDim,
+            KV_CDim,
+            KV_PeDim,
+            ChunkK,
+            PaddedK,
+            PaddedV,
+            ScaleCols,
+            WEIGHT_PRESHUFFLE,
         )
-        stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
-
-        Fp4ScaleKGranularity: tl.constexpr = 32
-        PackedScaleKGranularity: tl.constexpr = Fp4ScaleKGranularity // 2
-        PackedKV_CDim: tl.constexpr = KV_CDim // 2
-        Fp4KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
-        NumKSegments: tl.constexpr = KV_CDim // Fp4ScaleKGranularity
-
-        pid = tl.program_id(0)
-        pid_batch = pid // TpNumHeads
-        pid_head = pid % TpNumHeads
-
-        kv_block_start = tl.load(kv_indptr + pid_batch)
-        kv_block_end = tl.load(kv_indptr + pid_batch + 1)
-
-        context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
-        context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
-
-        total_kv_block = kv_block_end - kv_block_start
-        total_kv_chunk = (
-            total_kv_block + Fp4KBlocksPerChunkK - 1
-        ) // Fp4KBlocksPerChunkK
-
-        k_type = k_buffer.dtype.element_ty
-        if k_type == tl.bfloat16:
-            k_scalar_scale = 1.0
-        else:
-            k_scalar_scale = tl.load(k_scale)
-
-        offs_n_k = tl.arange(0, PaddedK)
-        offs_n_v = tl.arange(0, PaddedV)
-        mask_k = offs_n_k < QkNopeHeadDim
-        mask_v = offs_n_v < VHeadDim
-        offs_k = tl.arange(0, Fp4ScaleKGranularity)
-        offs_k_packed = tl.arange(0, PackedScaleKGranularity)
-
-        head_row_base = pid_head * (QkNopeHeadDim + VHeadDim)
-        k_abs_rows = head_row_base + offs_n_k
-        v_abs_rows = head_row_base + QkNopeHeadDim + offs_n_v
-
-        for chunk_id in range(total_kv_chunk):
-            block_lane_valid = (
-                chunk_id * Fp4KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
-                < total_kv_block
-            )
-            kv_block_idx = tl.load(
-                kv_indices
-                + kv_block_start
-                + chunk_id * Fp4KBlocksPerChunkK
-                + tl.arange(0, ChunkK) // KBlockSize,
-                mask=block_lane_valid,
-                other=0,
-            )
-
-            accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
-            accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
-            row_mask = block_lane_valid[:, None]
-
-            for seg in range(NumKSegments):
-                kv_c_data = tl.load(
-                    k_buffer
-                    + kv_block_idx[:, None] * stride_k_buffer
-                    + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-                    + seg * Fp4ScaleKGranularity
-                    + offs_k[None, :],
-                    mask=row_mask,
-                    other=0.0,
-                ).to(tl.bfloat16)
-
-                packed_cols = seg * PackedScaleKGranularity + offs_k_packed[:, None]
-
-                if WEIGHT_PRESHUFFLE:
-                    # Inverse of aiter.ops.shuffle.shuffle_weight for uint8/packed-fp4
-                    # tensors with layout=(16, 16).  It maps logical [N, K//2]
-                    # coordinates back into the preshuffled storage.
-                    k_n0 = k_abs_rows[None, :] // 16
-                    k_bn = k_abs_rows[None, :] % 16
-                    k_k0 = packed_cols // 32
-                    k_r = (packed_cols % 32) // 16
-                    k_c = packed_cols % 16
-                    k_weight_offset = (
-                        ((k_n0 * (PackedKV_CDim // 32) + k_k0) * 2 + k_r) * 16 + k_bn
-                    ) * 16 + k_c
-
-                    v_n0 = v_abs_rows[None, :] // 16
-                    v_bn = v_abs_rows[None, :] % 16
-                    v_k0 = packed_cols // 32
-                    v_r = (packed_cols % 32) // 16
-                    v_c = packed_cols % 16
-                    v_weight_offset = (
-                        ((v_n0 * (PackedKV_CDim // 32) + v_k0) * 2 + v_r) * 16 + v_bn
-                    ) * 16 + v_c
-                else:
-                    k_weight_offset = k_abs_rows[None, :] * PackedKV_CDim + packed_cols
-                    v_weight_offset = v_abs_rows[None, :] * PackedKV_CDim + packed_cols
-
-                k_weight = tl.load(
-                    kv_proj_weight + k_weight_offset,
-                    mask=mask_k[None, :],
-                    other=0,
-                )
-                v_weight = tl.load(
-                    kv_proj_weight + v_weight_offset,
-                    mask=mask_v[None, :],
-                    other=0,
-                )
-
-                if WEIGHT_PRESHUFFLE:
-                    # Inverse of fp4_utils.e8m0_shuffle / shuffle_scale.
-                    k_scale_n = k_abs_rows[:, None]
-                    k_scale_g = seg
-                    k_scale_a = k_scale_n // 32
-                    k_scale_b = (k_scale_n % 32) // 16
-                    k_scale_c = k_scale_n % 16
-                    k_scale_d = k_scale_g // 8
-                    k_scale_e = (k_scale_g % 8) // 4
-                    k_scale_f = k_scale_g % 4
-                    k_scale_offset = (
-                        (
-                            ((k_scale_a * (ScaleCols // 8) + k_scale_d) * 4 + k_scale_f)
-                            * 16
-                            + k_scale_c
-                        )
-                        * 2
-                        + k_scale_e
-                    ) * 2 + k_scale_b
-
-                    v_scale_n = v_abs_rows[:, None]
-                    v_scale_g = seg
-                    v_scale_a = v_scale_n // 32
-                    v_scale_b = (v_scale_n % 32) // 16
-                    v_scale_c = v_scale_n % 16
-                    v_scale_d = v_scale_g // 8
-                    v_scale_e = (v_scale_g % 8) // 4
-                    v_scale_f = v_scale_g % 4
-                    v_scale_offset = (
-                        (
-                            ((v_scale_a * (ScaleCols // 8) + v_scale_d) * 4 + v_scale_f)
-                            * 16
-                            + v_scale_c
-                        )
-                        * 2
-                        + v_scale_e
-                    ) * 2 + v_scale_b
-                else:
-                    k_scale_offset = k_abs_rows[:, None] * ScaleCols + seg
-                    v_scale_offset = v_abs_rows[:, None] * ScaleCols + seg
-
-                k_weight_scale = tl.load(
-                    kv_proj_scale + k_scale_offset,
-                    mask=mask_k[:, None],
-                    other=0,
-                )
-                v_weight_scale = tl.load(
-                    kv_proj_scale + v_scale_offset,
-                    mask=mask_v[:, None],
-                    other=0,
-                )
-
-                accum_k = tl.dot_scaled(
-                    kv_c_data,
-                    None,
-                    "bf16",
-                    k_weight,
-                    k_weight_scale,
-                    "e2m1",
-                    acc=accum_k,
-                    fast_math=True,
-                )
-                accum_v = tl.dot_scaled(
-                    kv_c_data,
-                    None,
-                    "bf16",
-                    v_weight,
-                    v_weight_scale,
-                    "e2m1",
-                    acc=accum_v,
-                    fast_math=True,
-                )
-
-            kv_pe_data = tl.load(
-                k_buffer
-                + kv_block_idx[:, None] * stride_k_buffer
-                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-                + KV_CDim
-                + tl.arange(0, KV_PeDim)[None, :],
-                mask=row_mask,
-                other=0.0,
-            )
-
-            accum_k *= k_scalar_scale
-            accum_v *= k_scalar_scale
-            kv_pe_data *= k_scalar_scale
-
-            context_mask = (
-                context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
-            )
-            tl.store(
-                k_prefix
-                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-                * stride_k_prefix
-                + pid_head * (QkNopeHeadDim + KV_PeDim)
-                + QkNopeHeadDim
-                + tl.arange(0, KV_PeDim)[None, :],
-                kv_pe_data,
-                mask=context_mask[:, None],
-            )
-            tl.store(
-                k_prefix
-                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-                * stride_k_prefix
-                + pid_head * (QkNopeHeadDim + KV_PeDim)
-                + offs_n_k[None, :],
-                accum_k,
-                mask=context_mask[:, None] & mask_k[None, :],
-            )
-            tl.store(
-                v_prefix
-                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-                * stride_v_prefix
-                + pid_head * VHeadDim
-                + offs_n_v[None, :],
-                accum_v,
-                mask=context_mask[:, None] & mask_v[None, :],
-            )
-
-
     else:
-        # All three strides are multiplied by runtime indices that can overflow
-        # i32 at large scales. Promote the scalar (broadcast) side to i64 so the multiply
-        # is i32-zext x i64 -> i64
-        stride_k_buffer = tl.full([], KBlockSize * (KV_CDim + KV_PeDim), dtype=tl.int64)
-        stride_k_prefix = tl.full(
-            [], TpNumHeads * (QkNopeHeadDim + KV_PeDim), dtype=tl.int64
+        _triton_gather_kv_b_proj_impl(
+            batch_size,
+            k_buffer,
+            k_scale,
+            kv_indptr,
+            kv_indices,
+            kv_prefix_sum_context_lens,
+            kv_proj_weight,
+            kv_proj_scale,
+            k_prefix,
+            v_prefix,
+            KBlockSize,
+            TpNumHeads,
+            QkNopeHeadDim,
+            VHeadDim,
+            KV_CDim,
+            KV_PeDim,
+            ChunkK,
+            PaddedK,
+            PaddedV,
+            WEIGHT_PRESHUFFLE,
+            PER_ROW_SCALE,
+            NO_SCALE,
         )
-        stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
-
-        ScaleKGranularity: tl.constexpr = 128
-        ScaleNGranularity: tl.constexpr = 128
-        KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
-        assert KV_CDim == 4 * ScaleKGranularity
-
-        # ===---------------------------------------------------
-        # Workload Partition
-        # ===---------------------------------------------------
-        pid = tl.program_id(0)
-        pid_batch = pid // TpNumHeads
-        pid_head = pid % TpNumHeads
-
-        kv_block_start = tl.load(kv_indptr + pid_batch)
-        kv_block_end = tl.load(kv_indptr + pid_batch + 1)
-
-        context_start = tl.load(kv_prefix_sum_context_lens + pid_batch)
-        context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
-
-        total_kv_block = kv_block_end - kv_block_start
-        total_kv_chunk = (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK
-
-        # ===---------------------------------------------------
-        # Pipeline Start
-        # ===---------------------------------------------------
-        k_type = k_buffer.dtype.element_ty
-        if k_type == tl.bfloat16:
-            k_scalar_scale = 1.0
-        else:
-            k_scalar_scale = tl.load(k_scale)
-
-        offs_n_k = tl.arange(0, PaddedK)
-        offs_n_v = tl.arange(0, PaddedV)
-        mask_k = offs_n_k < QkNopeHeadDim
-        mask_v = offs_n_v < VHeadDim
-        offs_k = tl.arange(0, ScaleKGranularity)
-        k_head_base = kv_proj_weight + pid_head * (QkNopeHeadDim + VHeadDim) * KV_CDim
-        v_head_base = k_head_base + QkNopeHeadDim * KV_CDim
-
-        if NO_SCALE:
-            # weight is not quantized; skip scale loading entirely
-            pass
-        elif PER_ROW_SCALE:
-            k_row0 = pid_head * (QkNopeHeadDim + VHeadDim)
-            k_nope_scale_vec = tl.load(
-                kv_proj_scale + k_row0 + offs_n_k, mask=mask_k, other=1.0
-            ).to(tl.float32)
-            v_nope_scale_vec = tl.load(
-                kv_proj_scale + k_row0 + QkNopeHeadDim + offs_n_v, mask=mask_v, other=1.0
-            ).to(tl.float32)
-        else:
-            num_scale_cols: tl.constexpr = KV_CDim // ScaleKGranularity
-            k_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + offs_n_k
-            k_scale_n_idx = k_abs_rows // ScaleNGranularity
-            v_abs_rows = pid_head * (QkNopeHeadDim + VHeadDim) + QkNopeHeadDim + offs_n_v
-            v_scale_n_idx = v_abs_rows // ScaleNGranularity
-
-        if WEIGHT_PRESHUFFLE:
-            # _load_unshuffle_segment returns [PaddedHeadDim, ScaleKGranularity]
-            # with zero-filled rows beyond HeadDim
-            k_nope_weight_0 = _load_unshuffle_segment(
-                k_head_base, 0, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-            k_nope_weight_1 = _load_unshuffle_segment(
-                k_head_base, 1, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-            k_nope_weight_2 = _load_unshuffle_segment(
-                k_head_base, 2, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-            k_nope_weight_3 = _load_unshuffle_segment(
-                k_head_base, 3, QkNopeHeadDim, PaddedK, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-
-            v_nope_weight_0 = _load_unshuffle_segment(
-                v_head_base, 0, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-            v_nope_weight_1 = _load_unshuffle_segment(
-                v_head_base, 1, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-            v_nope_weight_2 = _load_unshuffle_segment(
-                v_head_base, 2, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-            v_nope_weight_3 = _load_unshuffle_segment(
-                v_head_base, 3, VHeadDim, PaddedV, KV_CDim, ScaleKGranularity
-            ).to(k_type)
-        else:
-            k_nope_weight_base_offset = (
-                k_head_base + offs_n_k[:, None] * KV_CDim + offs_k[None, :]
-            )
-            k_mask_2d = mask_k[:, None]
-            k_nope_weight_0 = tl.load(
-                k_nope_weight_base_offset + 0 * ScaleKGranularity,
-                mask=k_mask_2d,
-                other=0.0,
-            ).to(k_type)
-            k_nope_weight_1 = tl.load(
-                k_nope_weight_base_offset + 1 * ScaleKGranularity,
-                mask=k_mask_2d,
-                other=0.0,
-            ).to(k_type)
-            k_nope_weight_2 = tl.load(
-                k_nope_weight_base_offset + 2 * ScaleKGranularity,
-                mask=k_mask_2d,
-                other=0.0,
-            ).to(k_type)
-            k_nope_weight_3 = tl.load(
-                k_nope_weight_base_offset + 3 * ScaleKGranularity,
-                mask=k_mask_2d,
-                other=0.0,
-            ).to(k_type)
-
-            v_nope_weight_base_offset = (
-                v_head_base + offs_n_v[:, None] * KV_CDim + offs_k[None, :]
-            )
-            v_mask_2d = mask_v[:, None]
-            v_nope_weight_0 = tl.load(
-                v_nope_weight_base_offset + 0 * ScaleKGranularity,
-                mask=v_mask_2d,
-                other=0.0,
-            ).to(k_type)
-            v_nope_weight_1 = tl.load(
-                v_nope_weight_base_offset + 1 * ScaleKGranularity,
-                mask=v_mask_2d,
-                other=0.0,
-            ).to(k_type)
-            v_nope_weight_2 = tl.load(
-                v_nope_weight_base_offset + 2 * ScaleKGranularity,
-                mask=v_mask_2d,
-                other=0.0,
-            ).to(k_type)
-            v_nope_weight_3 = tl.load(
-                v_nope_weight_base_offset + 3 * ScaleKGranularity,
-                mask=v_mask_2d,
-                other=0.0,
-            ).to(k_type)
-
-        if (not NO_SCALE) and (not PER_ROW_SCALE):
-            k_nope_scale_0 = tl.load(
-                kv_proj_scale + k_scale_n_idx * num_scale_cols + 0,
-                mask=mask_k,
-                other=0.0,
-            ).to(tl.float32)
-            k_nope_scale_1 = tl.load(
-                kv_proj_scale + k_scale_n_idx * num_scale_cols + 1,
-                mask=mask_k,
-                other=0.0,
-            ).to(tl.float32)
-            k_nope_scale_2 = tl.load(
-                kv_proj_scale + k_scale_n_idx * num_scale_cols + 2,
-                mask=mask_k,
-                other=0.0,
-            ).to(tl.float32)
-            k_nope_scale_3 = tl.load(
-                kv_proj_scale + k_scale_n_idx * num_scale_cols + 3,
-                mask=mask_k,
-                other=0.0,
-            ).to(tl.float32)
-
-            v_nope_scale_0 = tl.load(
-                kv_proj_scale + v_scale_n_idx * num_scale_cols + 0,
-                mask=mask_v,
-                other=0.0,
-            ).to(tl.float32)
-            v_nope_scale_1 = tl.load(
-                kv_proj_scale + v_scale_n_idx * num_scale_cols + 1,
-                mask=mask_v,
-                other=0.0,
-            ).to(tl.float32)
-            v_nope_scale_2 = tl.load(
-                kv_proj_scale + v_scale_n_idx * num_scale_cols + 2,
-                mask=mask_v,
-                other=0.0,
-            ).to(tl.float32)
-            v_nope_scale_3 = tl.load(
-                kv_proj_scale + v_scale_n_idx * num_scale_cols + 3,
-                mask=mask_v,
-                other=0.0,
-            ).to(tl.float32)
-
-        for chunk_id in range(total_kv_chunk):
-            block_lane_valid = (
-                chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
-                < total_kv_block
-            )
-            kv_block_idx = tl.load(
-                kv_indices
-                + kv_block_start
-                + chunk_id * KBlocksPerChunkK
-                + tl.arange(0, ChunkK) // KBlockSize,
-                mask=block_lane_valid,
-                other=0,
-            )
-            kv_c_data_base_offset = (
-                kv_block_idx[:, None] * stride_k_buffer
-                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-                + tl.arange(0, ScaleKGranularity)[None, :]
-            )  # [ChunkK, kv_c_dim]
-
-            accum_k = tl.zeros((ChunkK, PaddedK), dtype=tl.float32)
-            accum_v = tl.zeros((ChunkK, PaddedV), dtype=tl.float32)
-
-            row_mask = block_lane_valid[:, None]
-            kv_c_data_0 = tl.load(
-                k_buffer + kv_c_data_base_offset + 0 * ScaleKGranularity,
-                mask=row_mask,
-                other=0.0,
-            )
-            kv_c_data_1 = tl.load(
-                k_buffer + kv_c_data_base_offset + 1 * ScaleKGranularity,
-                mask=row_mask,
-                other=0.0,
-            )
-            kv_c_data_2 = tl.load(
-                k_buffer + kv_c_data_base_offset + 2 * ScaleKGranularity,
-                mask=row_mask,
-                other=0.0,
-            )
-            kv_c_data_3 = tl.load(
-                k_buffer + kv_c_data_base_offset + 3 * ScaleKGranularity,
-                mask=row_mask,
-                other=0.0,
-            )
-            kv_pe_data = tl.load(
-                k_buffer
-                + kv_block_idx[:, None] * stride_k_buffer
-                + tl.arange(0, ChunkK)[:, None] % KBlockSize * (KV_CDim + KV_PeDim)
-                + KV_CDim
-                + tl.arange(0, KV_PeDim)[None, :],
-                mask=row_mask,
-                other=0.0,
-            )
-
-            if NO_SCALE:
-                accum_k = tl.dot(kv_c_data_0, k_nope_weight_0.T, acc=accum_k)
-                accum_v = tl.dot(kv_c_data_0, v_nope_weight_0.T, acc=accum_v)
-                accum_k = tl.dot(kv_c_data_1, k_nope_weight_1.T, acc=accum_k)
-                accum_v = tl.dot(kv_c_data_1, v_nope_weight_1.T, acc=accum_v)
-                accum_k = tl.dot(kv_c_data_2, k_nope_weight_2.T, acc=accum_k)
-                accum_v = tl.dot(kv_c_data_2, v_nope_weight_2.T, acc=accum_v)
-                accum_k = tl.dot(kv_c_data_3, k_nope_weight_3.T, acc=accum_k)
-                accum_v = tl.dot(kv_c_data_3, v_nope_weight_3.T, acc=accum_v)
-            elif PER_ROW_SCALE:
-                accum_k += (
-                    tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_vec[None, :]
-                )
-                accum_v += (
-                    tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_vec[None, :]
-                )
-                accum_k += (
-                    tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_vec[None, :]
-                )
-                accum_v += (
-                    tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_vec[None, :]
-                )
-                accum_k += (
-                    tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_vec[None, :]
-                )
-                accum_v += (
-                    tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_vec[None, :]
-                )
-                accum_k += (
-                    tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_vec[None, :]
-                )
-                accum_v += (
-                    tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_vec[None, :]
-                )
-            else:
-                accum_k += tl.dot(kv_c_data_0, k_nope_weight_0.T) * k_nope_scale_0[None, :]
-                accum_v += tl.dot(kv_c_data_0, v_nope_weight_0.T) * v_nope_scale_0[None, :]
-                accum_k += tl.dot(kv_c_data_1, k_nope_weight_1.T) * k_nope_scale_1[None, :]
-                accum_v += tl.dot(kv_c_data_1, v_nope_weight_1.T) * v_nope_scale_1[None, :]
-                accum_k += tl.dot(kv_c_data_2, k_nope_weight_2.T) * k_nope_scale_2[None, :]
-                accum_v += tl.dot(kv_c_data_2, v_nope_weight_2.T) * v_nope_scale_2[None, :]
-                accum_k += tl.dot(kv_c_data_3, k_nope_weight_3.T) * k_nope_scale_3[None, :]
-                accum_v += tl.dot(kv_c_data_3, v_nope_weight_3.T) * v_nope_scale_3[None, :]
-
-            accum_k *= k_scalar_scale
-            accum_v *= k_scalar_scale
-            kv_pe_data *= k_scalar_scale
-
-            context_mask = (
-                context_start + chunk_id * ChunkK + tl.arange(0, ChunkK) < context_end
-            )
-            tl.store(
-                k_prefix
-                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-                * stride_k_prefix
-                + pid_head * (QkNopeHeadDim + KV_PeDim)
-                + QkNopeHeadDim
-                + tl.arange(0, KV_PeDim)[None, :],
-                kv_pe_data,
-                mask=context_mask[:, None],
-            )
-            tl.store(
-                k_prefix
-                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-                * stride_k_prefix
-                + pid_head * (QkNopeHeadDim + KV_PeDim)
-                + offs_n_k[None, :],
-                accum_k,
-                mask=context_mask[:, None] & mask_k[None, :],
-            )
-            tl.store(
-                v_prefix
-                + (context_start + chunk_id * ChunkK + tl.arange(0, ChunkK))[:, None]
-                * stride_v_prefix
-                + pid_head * VHeadDim
-                + offs_n_v[None, :],
-                accum_v,
-                mask=context_mask[:, None] & mask_v[None, :],
-            )

--- a/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
+++ b/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
@@ -80,6 +80,7 @@ def _triton_gather_kv_b_proj_fp4_impl(
     PaddedK: tl.constexpr,
     PaddedV: tl.constexpr,
     ScaleCols: tl.constexpr,
+    Fp4ScaleKGranularity: tl.constexpr = 32,
     WEIGHT_PRESHUFFLE: tl.constexpr = False,
 ):
     """FP4/per-1x32 gather + kv_b_proj expansion for raw MXFP4 weights."""
@@ -89,7 +90,8 @@ def _triton_gather_kv_b_proj_fp4_impl(
     )
     stride_v_prefix = tl.full([], TpNumHeads * VHeadDim, dtype=tl.int64)
 
-    ScaleKGranularity: tl.constexpr = 32
+    ScaleKGranularity: tl.constexpr = Fp4ScaleKGranularity
+    ScaleGroupsPerSegment: tl.constexpr = ScaleKGranularity // 32
     PackedScaleKGranularity: tl.constexpr = ScaleKGranularity // 2
     PackedKV_CDim: tl.constexpr = KV_CDim // 2
     KBlocksPerChunkK: tl.constexpr = ChunkK // KBlockSize
@@ -109,6 +111,8 @@ def _triton_gather_kv_b_proj_fp4_impl(
     context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
 
     total_kv_block = kv_block_end - kv_block_start
+    if chunk_id >= (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK:
+        return
 
     k_type = k_buffer.dtype.element_ty
     if k_type == tl.bfloat16:
@@ -122,6 +126,7 @@ def _triton_gather_kv_b_proj_fp4_impl(
     mask_v = offs_n_v < VHeadDim
     offs_k = tl.arange(0, ScaleKGranularity)
     offs_k_packed = tl.arange(0, PackedScaleKGranularity)
+    offs_scale_g = tl.arange(0, ScaleGroupsPerSegment)
 
     head_row_base = pid_head * (QkNopeHeadDim + VHeadDim)
     k_abs_rows = head_row_base + offs_n_k
@@ -196,7 +201,7 @@ def _triton_gather_kv_b_proj_fp4_impl(
         if WEIGHT_PRESHUFFLE:
             # Inverse of fp4_utils.e8m0_shuffle / shuffle_scale.
             k_scale_n = k_abs_rows[:, None]
-            k_scale_g = seg
+            k_scale_g = seg * ScaleGroupsPerSegment + offs_scale_g[None, :]
             k_scale_a = k_scale_n // 32
             k_scale_b = (k_scale_n % 32) // 16
             k_scale_c = k_scale_n % 16
@@ -213,7 +218,7 @@ def _triton_gather_kv_b_proj_fp4_impl(
             ) * 2 + k_scale_b
 
             v_scale_n = v_abs_rows[:, None]
-            v_scale_g = seg
+            v_scale_g = seg * ScaleGroupsPerSegment + offs_scale_g[None, :]
             v_scale_a = v_scale_n // 32
             v_scale_b = (v_scale_n % 32) // 16
             v_scale_c = v_scale_n % 16
@@ -229,8 +234,16 @@ def _triton_gather_kv_b_proj_fp4_impl(
                 + v_scale_e
             ) * 2 + v_scale_b
         else:
-            k_scale_offset = k_abs_rows[:, None] * ScaleCols + seg
-            v_scale_offset = v_abs_rows[:, None] * ScaleCols + seg
+            k_scale_offset = (
+                k_abs_rows[:, None] * ScaleCols
+                + seg * ScaleGroupsPerSegment
+                + offs_scale_g[None, :]
+            )
+            v_scale_offset = (
+                v_abs_rows[:, None] * ScaleCols
+                + seg * ScaleGroupsPerSegment
+                + offs_scale_g[None, :]
+            )
 
         k_weight_scale = tl.load(
             kv_proj_scale + k_scale_offset,
@@ -364,7 +377,6 @@ def _triton_gather_kv_b_proj_impl(
     context_end = tl.load(kv_prefix_sum_context_lens + pid_batch + 1)
 
     total_kv_block = kv_block_end - kv_block_start
-    total_kv_chunk = (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK
 
     # ===---------------------------------------------------
     # Pipeline Start
@@ -523,7 +535,7 @@ def _triton_gather_kv_b_proj_impl(
             other=0.0,
         ).to(tl.float32)
 
-    for chunk_id in range(total_kv_chunk):
+    for chunk_id in range((total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK):
         block_lane_valid = (
             chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
             < total_kv_block
@@ -680,6 +692,7 @@ def _triton_gather_kv_b_proj(
     PaddedV: tl.constexpr,
     ScaleCols: tl.constexpr = 1,
     IS_FP4: tl.constexpr = False,
+    Fp4ScaleKGranularity: tl.constexpr = 32,
     WEIGHT_PRESHUFFLE: tl.constexpr = False,
     PER_ROW_SCALE: tl.constexpr = False,
     NO_SCALE: tl.constexpr = False,
@@ -706,6 +719,7 @@ def _triton_gather_kv_b_proj(
             PaddedK,
             PaddedV,
             ScaleCols,
+            Fp4ScaleKGranularity,
             WEIGHT_PRESHUFFLE,
         )
     else:

--- a/aiter/ops/triton/gather_kv_b_proj.py
+++ b/aiter/ops/triton/gather_kv_b_proj.py
@@ -6,7 +6,6 @@ import torch
 from aiter.ops.triton._triton_kernels.gather_kv_b_proj import (
     _next_pow2,
     _triton_gather_kv_b_proj,
-    _triton_gather_kv_b_proj_fp4,
 )
 
 
@@ -94,33 +93,9 @@ def gather_kv_b_proj(
     padded_v = _next_pow2(v_head_dim)
 
     grid = (batch_size * tp_k_head_num_k,)
-    if is_fp4_weight:
-        _triton_gather_kv_b_proj_fp4[grid](
-            batch_size,
-            k_buffer,
-            k_scale,
-            kv_indptr,
-            kv_indices,
-            kv_prefix_sum_context_lens,
-            kv_proj_weight.view(torch.uint8),
-            kv_proj_scale.view(torch.uint8),
-            k_prefix,
-            v_prefix,
-            KBlockSize=block_size,
-            TpNumHeads=tp_k_head_num_k,
-            QkNopeHeadDim=qk_nope_head_dim,
-            VHeadDim=v_head_dim,
-            KV_CDim=weight_k,
-            KV_PeDim=qk_nope_pe_dim - qk_nope_head_dim,
-            ChunkK=ChunkK,
-            PaddedK=padded_k,
-            PaddedV=padded_v,
-            ScaleCols=scale_k if not no_scale and not per_row_scale else 1,
-            WEIGHT_PRESHUFFLE=weight_preshuffle,
-            num_stages=3,
-        )
-        return
-
+    kernel_weight = kv_proj_weight.view(torch.uint8) if is_fp4_weight else kv_proj_weight
+    kernel_scale = kv_proj_scale.view(torch.uint8) if is_fp4_weight else kv_proj_scale
+    scale_cols = scale_k if is_fp4_weight and not no_scale and not per_row_scale else 1
     _triton_gather_kv_b_proj[grid](
         batch_size,
         k_buffer,
@@ -128,8 +103,8 @@ def gather_kv_b_proj(
         kv_indptr,
         kv_indices,
         kv_prefix_sum_context_lens,
-        kv_proj_weight,
-        kv_proj_scale,
+        kernel_weight,
+        kernel_scale,
         k_prefix,
         v_prefix,
         KBlockSize=block_size,
@@ -141,6 +116,8 @@ def gather_kv_b_proj(
         ChunkK=ChunkK,
         PaddedK=padded_k,
         PaddedV=padded_v,
+        ScaleCols=scale_cols,
+        IS_FP4=is_fp4_weight,
         WEIGHT_PRESHUFFLE=weight_preshuffle,
         PER_ROW_SCALE=per_row_scale,
         NO_SCALE=no_scale,

--- a/aiter/ops/triton/gather_kv_b_proj.py
+++ b/aiter/ops/triton/gather_kv_b_proj.py
@@ -6,6 +6,7 @@ import torch
 from aiter.ops.triton._triton_kernels.gather_kv_b_proj import (
     _next_pow2,
     _triton_gather_kv_b_proj,
+    _triton_gather_kv_b_proj_fp4,
 )
 
 
@@ -23,7 +24,12 @@ def gather_kv_b_proj(
 ):
     num_block, block_size, hidden_dim = k_buffer.shape
     batch_size = kv_indptr.shape[0] - 1
-    weight_n, weight_k = kv_proj_weight.shape
+    weight_n, packed_weight_k = kv_proj_weight.shape
+    fp4_weight_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    is_fp4_weight = (
+        fp4_weight_dtype is not None and kv_proj_weight.dtype == fp4_weight_dtype
+    )
+    weight_k = packed_weight_k * 2 if is_fp4_weight else packed_weight_k
     total_kv_k, tp_k_head_num_k, qk_nope_pe_dim = k_prefix.shape
     total_kv_v, tp_k_head_num_v, v_head_dim = v_prefix.shape
 
@@ -55,8 +61,28 @@ def gather_kv_b_proj(
             scale_n, scale_k = kv_proj_scale.shape
             scale_k_granularity = weight_k // scale_k
             scale_n_granularity = weight_n // scale_n
-            assert scale_k_granularity == 128
-            assert scale_n_granularity == 128
+            if is_fp4_weight:
+                if weight_preshuffle:
+                    assert scale_k >= (weight_k + 31) // 32, (
+                        "Preshuffled FP4 gather_kv_b_proj expects padded per-1x32 scale columns, "
+                        f"got scale cols {scale_k} for logical K {weight_k}"
+                    )
+                    assert scale_n >= weight_n, (
+                        "Preshuffled FP4 gather_kv_b_proj expects padded per-output-row MXFP4 scales, "
+                        f"got scale rows {scale_n} for weight rows {weight_n}"
+                    )
+                else:
+                    assert scale_k_granularity == 32, (
+                        "FP4 gather_kv_b_proj expects per-1x32 weight scales, "
+                        f"got K granularity {scale_k_granularity}"
+                    )
+                    assert scale_n_granularity == 1, (
+                        "FP4 gather_kv_b_proj expects per-output-row MXFP4 scales, "
+                        f"got N granularity {scale_n_granularity}"
+                    )
+            else:
+                assert scale_k_granularity == 128
+                assert scale_n_granularity == 128
 
     ChunkK = 16 if k_buffer.dtype in [torch.float16, torch.bfloat16] else 32
 
@@ -68,6 +94,33 @@ def gather_kv_b_proj(
     padded_v = _next_pow2(v_head_dim)
 
     grid = (batch_size * tp_k_head_num_k,)
+    if is_fp4_weight:
+        _triton_gather_kv_b_proj_fp4[grid](
+            batch_size,
+            k_buffer,
+            k_scale,
+            kv_indptr,
+            kv_indices,
+            kv_prefix_sum_context_lens,
+            kv_proj_weight.view(torch.uint8),
+            kv_proj_scale.view(torch.uint8),
+            k_prefix,
+            v_prefix,
+            KBlockSize=block_size,
+            TpNumHeads=tp_k_head_num_k,
+            QkNopeHeadDim=qk_nope_head_dim,
+            VHeadDim=v_head_dim,
+            KV_CDim=weight_k,
+            KV_PeDim=qk_nope_pe_dim - qk_nope_head_dim,
+            ChunkK=ChunkK,
+            PaddedK=padded_k,
+            PaddedV=padded_v,
+            ScaleCols=scale_k if not no_scale and not per_row_scale else 1,
+            WEIGHT_PRESHUFFLE=weight_preshuffle,
+            num_stages=3,
+        )
+        return
+
     _triton_gather_kv_b_proj[grid](
         batch_size,
         k_buffer,

--- a/aiter/ops/triton/gather_kv_b_proj.py
+++ b/aiter/ops/triton/gather_kv_b_proj.py
@@ -93,9 +93,39 @@ def gather_kv_b_proj(
     padded_v = _next_pow2(v_head_dim)
 
     grid = (batch_size * tp_k_head_num_k,)
-    kernel_weight = kv_proj_weight.view(torch.uint8) if is_fp4_weight else kv_proj_weight
-    kernel_scale = kv_proj_scale.view(torch.uint8) if is_fp4_weight else kv_proj_scale
-    scale_cols = scale_k if is_fp4_weight and not no_scale and not per_row_scale else 1
+    if is_fp4_weight:
+        # Use the actual output token count, not kv_indices capacity. Serving
+        # paths may pass a preallocated kv_indices buffer that is much larger
+        # than the valid range described by kv_indptr/k_prefix.
+        max_kv_chunks = max(1, (total_kv_k + ChunkK - 1) // ChunkK)
+        fp4_grid = (batch_size * tp_k_head_num_k * max_kv_chunks,)
+        _triton_gather_kv_b_proj[fp4_grid](
+            batch_size,
+            k_buffer,
+            k_scale,
+            kv_indptr,
+            kv_indices,
+            kv_prefix_sum_context_lens,
+            kv_proj_weight.view(torch.uint8),
+            kv_proj_scale.view(torch.uint8),
+            k_prefix,
+            v_prefix,
+            KBlockSize=block_size,
+            TpNumHeads=tp_k_head_num_k,
+            QkNopeHeadDim=qk_nope_head_dim,
+            VHeadDim=v_head_dim,
+            KV_CDim=weight_k,
+            KV_PeDim=qk_nope_pe_dim - qk_nope_head_dim,
+            ChunkK=ChunkK,
+            PaddedK=padded_k,
+            PaddedV=padded_v,
+            ScaleCols=scale_k if not no_scale and not per_row_scale else 1,
+            IS_FP4=True,
+            WEIGHT_PRESHUFFLE=weight_preshuffle,
+            num_stages=3,
+        )
+        return
+
     _triton_gather_kv_b_proj[grid](
         batch_size,
         k_buffer,
@@ -103,8 +133,8 @@ def gather_kv_b_proj(
         kv_indptr,
         kv_indices,
         kv_prefix_sum_context_lens,
-        kernel_weight,
-        kernel_scale,
+        kv_proj_weight,
+        kv_proj_scale,
         k_prefix,
         v_prefix,
         KBlockSize=block_size,
@@ -116,8 +146,7 @@ def gather_kv_b_proj(
         ChunkK=ChunkK,
         PaddedK=padded_k,
         PaddedV=padded_v,
-        ScaleCols=scale_cols,
-        IS_FP4=is_fp4_weight,
+        IS_FP4=False,
         WEIGHT_PRESHUFFLE=weight_preshuffle,
         PER_ROW_SCALE=per_row_scale,
         NO_SCALE=no_scale,

--- a/aiter/ops/triton/gather_kv_b_proj.py
+++ b/aiter/ops/triton/gather_kv_b_proj.py
@@ -83,7 +83,10 @@ def gather_kv_b_proj(
                 assert scale_k_granularity == 128
                 assert scale_n_granularity == 128
 
-    ChunkK = 16 if k_buffer.dtype in [torch.float16, torch.bfloat16] else 32
+    if is_fp4_weight:
+        ChunkK = 64
+    else:
+        ChunkK = 16 if k_buffer.dtype in [torch.float16, torch.bfloat16] else 32
 
     assert total_kv_k == total_kv_v
     assert tp_k_head_num_k == tp_k_head_num_v
@@ -98,6 +101,7 @@ def gather_kv_b_proj(
         # paths may pass a preallocated kv_indices buffer that is much larger
         # than the valid range described by kv_indptr/k_prefix.
         max_kv_chunks = max(1, (total_kv_k + ChunkK - 1) // ChunkK)
+        fp4_scale_k_granularity = 32 if weight_preshuffle else 128
         fp4_grid = (batch_size * tp_k_head_num_k * max_kv_chunks,)
         _triton_gather_kv_b_proj[fp4_grid](
             batch_size,
@@ -121,6 +125,7 @@ def gather_kv_b_proj(
             PaddedV=padded_v,
             ScaleCols=scale_k if not no_scale and not per_row_scale else 1,
             IS_FP4=True,
+            Fp4ScaleKGranularity=fp4_scale_k_granularity,
             WEIGHT_PRESHUFFLE=weight_preshuffle,
             num_stages=3,
         )

--- a/op_tests/triton_tests/test_gather_kv_b_proj.py
+++ b/op_tests/triton_tests/test_gather_kv_b_proj.py
@@ -8,8 +8,15 @@ import torch
 
 from aiter.test_common import checkAllclose, run_perftest
 from aiter.ops.triton.gather_kv_b_proj import gather_kv_b_proj
-from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.shuffle import shuffle_scale, shuffle_weight
 from aiter import dtypes
+from aiter.utility.fp4_utils import e8m0_to_f32, mxfp4_to_f32
+import aiter.ops.triton.utils._triton.arch_info as arch_info
+from op_tests.triton_tests.quant.test_quant_mxfp4 import torch_dynamic_mxfp4_quant
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA device is required"
+)
 
 
 def ref_gather_kv_b_proj(
@@ -137,6 +144,12 @@ def ref_gather_kv_b_proj(
         v_prefix_tp[context_start:context_end, :] = v_proj_tp
 
     return (k_prefix, v_prefix)
+
+
+def _dequant_mxfp4_weight(weight_fp4: torch.Tensor, scale_e8m0: torch.Tensor):
+    weight_f32 = mxfp4_to_f32(weight_fp4.view(torch.uint8))
+    scale_f32 = e8m0_to_f32(scale_e8m0.view(torch.uint8)).repeat_interleave(32, dim=1)
+    return weight_f32 * scale_f32
 
 
 def _make_kv_test_data(
@@ -764,6 +777,100 @@ def test_gather_kv_b_proj_asymmetric_dims(
 
     checkAllclose(k_ref, k_prefix, atol=1e-2, rtol=1e-2)
     checkAllclose(v_ref, v_prefix, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(
+    not arch_info.is_fp4_avail(), reason="MXFP4 not supported on this architecture"
+)
+@pytest.mark.parametrize("weight_preshuffle", [False, True])
+@pytest.mark.parametrize("k_buffer_type", [torch.bfloat16, dtypes.fp8])
+def test_gather_kv_b_proj_mxfp4_weight(k_buffer_type, weight_preshuffle):
+    """Validate the FP4 MXFP4 kv_b_proj path against a dequantized torch reference."""
+    fp4_weight_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    if fp4_weight_dtype is None:
+        pytest.skip("torch.float4_e2m1fn_x2 is unavailable")
+
+    torch.manual_seed(0)
+    random.seed(0)
+    batch_size = 2
+    block_size = 1
+    avg_kv_length = 32
+    kv_c_dim = 512
+    kv_pe_dim = 64
+    qk_nope_head_dim = 128
+    v_head_dim = 128
+    tp_k_head_num = 1
+    device = "cuda"
+    weight_n = tp_k_head_num * (qk_nope_head_dim + v_head_dim)
+
+    (
+        k_buffer,
+        k_scale,
+        kv_indptr,
+        kv_indices,
+        kv_prefix_sum_context_lens,
+        _context_lens,
+        _num_block,
+    ) = _make_kv_test_data(
+        batch_size,
+        block_size,
+        avg_kv_length,
+        kv_c_dim,
+        kv_pe_dim,
+        k_buffer_type,
+        device,
+    )
+
+    weight_src = torch.randn(
+        (weight_n, kv_c_dim), device=device, dtype=torch.bfloat16
+    )
+    kv_proj_weight_u8, kv_proj_scale = torch_dynamic_mxfp4_quant(weight_src)
+    kv_proj_weight_ref = _dequant_mxfp4_weight(kv_proj_weight_u8, kv_proj_scale)
+
+    k_ref, v_ref = ref_gather_kv_b_proj(
+        k_buffer,
+        k_scale,
+        kv_indptr,
+        kv_indices,
+        kv_prefix_sum_context_lens,
+        kv_proj_weight_ref,
+        torch.ones(weight_n, device=device, dtype=torch.float32),
+        qk_nope_head_dim=qk_nope_head_dim,
+        v_head_dim=v_head_dim,
+    )
+
+    total_kv = kv_prefix_sum_context_lens[-1].item()
+    k_prefix = torch.zeros(
+        (total_kv, tp_k_head_num * (qk_nope_head_dim + kv_pe_dim)),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v_prefix = torch.zeros(
+        (total_kv, tp_k_head_num * v_head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    kv_proj_weight = kv_proj_weight_u8.view(fp4_weight_dtype)
+    if weight_preshuffle:
+        kv_proj_weight = shuffle_weight(kv_proj_weight)
+        kv_proj_scale = shuffle_scale(kv_proj_scale)
+
+    gather_kv_b_proj(
+        k_buffer,
+        k_scale,
+        kv_indptr,
+        kv_indices,
+        kv_prefix_sum_context_lens,
+        kv_proj_weight,
+        kv_proj_scale,
+        k_prefix.view(-1, tp_k_head_num, qk_nope_head_dim + kv_pe_dim),
+        v_prefix.view(-1, tp_k_head_num, v_head_dim),
+        weight_preshuffle=weight_preshuffle,
+    )
+
+    checkAllclose(k_ref, k_prefix, atol=1e-1, rtol=1e-1)
+    checkAllclose(v_ref, v_prefix, atol=1e-1, rtol=1e-1)
 
 
 if __name__ == "__main__":

--- a/op_tests/triton_tests/test_gather_kv_b_proj.py
+++ b/op_tests/triton_tests/test_gather_kv_b_proj.py
@@ -821,9 +821,102 @@ def test_gather_kv_b_proj_mxfp4_weight(k_buffer_type, weight_preshuffle):
         device,
     )
 
-    weight_src = torch.randn(
-        (weight_n, kv_c_dim), device=device, dtype=torch.bfloat16
+    weight_src = torch.randn((weight_n, kv_c_dim), device=device, dtype=torch.bfloat16)
+    kv_proj_weight_u8, kv_proj_scale = torch_dynamic_mxfp4_quant(weight_src)
+    kv_proj_weight_ref = _dequant_mxfp4_weight(kv_proj_weight_u8, kv_proj_scale)
+
+    k_ref, v_ref = ref_gather_kv_b_proj(
+        k_buffer,
+        k_scale,
+        kv_indptr,
+        kv_indices,
+        kv_prefix_sum_context_lens,
+        kv_proj_weight_ref,
+        torch.ones(weight_n, device=device, dtype=torch.float32),
+        qk_nope_head_dim=qk_nope_head_dim,
+        v_head_dim=v_head_dim,
     )
+
+    total_kv = kv_prefix_sum_context_lens[-1].item()
+    k_prefix = torch.zeros(
+        (total_kv, tp_k_head_num * (qk_nope_head_dim + kv_pe_dim)),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v_prefix = torch.zeros(
+        (total_kv, tp_k_head_num * v_head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    kv_proj_weight = kv_proj_weight_u8.view(fp4_weight_dtype)
+    if weight_preshuffle:
+        kv_proj_weight = shuffle_weight(kv_proj_weight)
+        kv_proj_scale = shuffle_scale(kv_proj_scale)
+
+    gather_kv_b_proj(
+        k_buffer,
+        k_scale,
+        kv_indptr,
+        kv_indices,
+        kv_prefix_sum_context_lens,
+        kv_proj_weight,
+        kv_proj_scale,
+        k_prefix.view(-1, tp_k_head_num, qk_nope_head_dim + kv_pe_dim),
+        v_prefix.view(-1, tp_k_head_num, v_head_dim),
+        weight_preshuffle=weight_preshuffle,
+    )
+
+    checkAllclose(k_ref, k_prefix, atol=1e-1, rtol=1e-1)
+    checkAllclose(v_ref, v_prefix, atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.skipif(
+    not arch_info.is_fp4_avail(), reason="MXFP4 not supported on this architecture"
+)
+@pytest.mark.parametrize("weight_preshuffle", [False, True])
+def test_gather_kv_b_proj_mxfp4_oversized_kv_indices(weight_preshuffle):
+    # FP4 gather should size its launch from valid output tokens, not kv_indices capacity.
+    fp4_weight_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    if fp4_weight_dtype is None:
+        pytest.skip("torch.float4_e2m1fn_x2 is unavailable")
+
+    torch.manual_seed(0)
+    random.seed(0)
+    batch_size = 2
+    block_size = 1
+    avg_kv_length = 32
+    kv_c_dim = 512
+    kv_pe_dim = 64
+    qk_nope_head_dim = 128
+    v_head_dim = 128
+    tp_k_head_num = 1
+    device = "cuda"
+    weight_n = tp_k_head_num * (qk_nope_head_dim + v_head_dim)
+
+    (
+        k_buffer,
+        k_scale,
+        kv_indptr,
+        kv_indices_valid,
+        kv_prefix_sum_context_lens,
+        _context_lens,
+        _num_block,
+    ) = _make_kv_test_data(
+        batch_size,
+        block_size,
+        avg_kv_length,
+        kv_c_dim,
+        kv_pe_dim,
+        dtypes.fp8,
+        device,
+    )
+
+    oversized_numel = 70000 * 32
+    kv_indices = torch.zeros(oversized_numel, device=device, dtype=torch.int32)
+    kv_indices[: kv_indices_valid.numel()] = kv_indices_valid
+
+    weight_src = torch.randn((weight_n, kv_c_dim), device=device, dtype=torch.bfloat16)
     kv_proj_weight_u8, kv_proj_scale = torch_dynamic_mxfp4_quant(weight_src)
     kv_proj_weight_ref = _dequant_mxfp4_weight(kv_proj_weight_u8, kv_proj_scale)
 


### PR DESCRIPTION
## Motivation

Add an FP4 per-1x32 MXFP4 path for gather_kv_b_proj so cached MLA KV expansion can run with raw and preshuffled FP4 weights.

## Technical Details

Refactored `gather_kv_b_proj` to support FP4 MXFP4 weights through the existing Triton kernel entry point instead of maintaining a separate FP4-only kernel.

The updated path detects FP4 weights in the Python wrapper and dispatches to `_triton_gather_kv_b_proj` with `IS_FP4=True`. The FP4 branch handles per-1x32 MXFP4 scales, packed FP4 weights, and both raw and preshuffled weight/scale layouts. Existing non-FP4 paths remain behind the original kernel logic.

The PR also adds UT coverage for FP4 `gather_kv_b_proj`, including raw and preshuffled FP4 weight layouts with BF16 and FP8 KV buffers.

## Test Plan

- Ran the full `gather_kv_b_proj` unit test suite:
  - `pytest -q op_tests/triton_tests/test_gather_kv_b_proj.py`
  - Result: `29 passed, 2 warnings in 20.90s`
- Verified the new FP4 MXFP4 UT covers:
  - raw FP4 weight layout
  - preshuffled FP4 weight and scale layout
  - BF16 KV buffer
  - FP8 KV buffer
- Verified end-to-end GSM8K accuracy for both raw and preshuffled FP4 gather paths.

## Test Result

Synthetic accuracy validation passed for the new FP4 gather path. No linter errors were reported for the modified files.

**UT test:**
```
cd /app/aiter-test && pytest -q op_tests/triton_tests/test_gather_kv_b_proj.py
```
result:
<img width="558" height="163" alt="image" src="https://github.com/user-attachments/assets/28fd82e1-8ec2-4c6a-aaa1-c0f2bf97dbf1" />

**E2E accuracy:**
- for preshuffle layout
<img width="884" height="133" alt="image" src="https://github.com/user-attachments/assets/2296c674-8f68-4e60-b7bb-8ef79060ee0e" />

- for raw layout
<img width="879" height="137" alt="image" src="https://github.com/user-attachments/assets/9c4a3034-acff-4e63-a220-46c5686a5958" />


**UT Accuracy:**


| Shape | KV Cache Dtype | Weight Dtype | Layout | Status | Mean Abs Error | K Mean Abs | V Mean Abs | Mismatch |
|---|---|---|---|---|---:|---:|---:|---:|
| batch=1, avg_kv=2048 | FP8 | FP4 | Raw | PASS | 0 | 0 | 0 | 0% |
| batch=1, avg_kv=2048 | FP8 | FP4 | Preshuffle | PASS | 0 | 0 | 0 | 0% |
| batch=1, avg_kv=2048 | FP8 | FP8 | Raw | PASS | 5.19e-04 | 4.95e-04 | 5.44e-04 | 0% |
| batch=1, avg_kv=2048 | FP8 | FP8 | Preshuffle | PASS | 5.19e-04 | 4.95e-04 | 5.44e-04 | 0% |
| batch=1, avg_kv=2048 | FP8 | BF16 | Raw | PASS | 5.75e-04 | 5.77e-04 | 5.72e-04 | 0% |
| batch=1, avg_kv=2048 | BF16 | FP4 | Raw | PASS | 1.43e-08 | 2.79e-08 | 6.43e-10 | 0% |
| batch=1, avg_kv=2048 | BF16 | FP4 | Preshuffle | PASS | 1.43e-08 | 2.79e-08 | 6.43e-10 | 0% |
| batch=1, avg_kv=2048 | BF16 | FP8 | Raw | PASS | 5.43e-07 | 3.97e-07 | 6.89e-07 | 0% |
| batch=1, avg_kv=2048 | BF16 | FP8 | Preshuffle | PASS | 5.43e-07 | 3.97e-07 | 6.89e-07 | 0% |
| batch=1, avg_kv=2048 | BF16 | BF16 | Raw | PASS | 1.09e-06 | 1.18e-06 | 9.97e-07 | 0% |
| batch=4, avg_kv=512 | FP8 | FP4 | Raw | PASS | 0 | 0 | 0 | 0% |
| batch=4, avg_kv=512 | FP8 | FP4 | Preshuffle | PASS | 0 | 0 | 0 | 0% |
| batch=4, avg_kv=512 | FP8 | FP8 | Raw | PASS | 3.70e-05 | 3.74e-05 | 3.66e-05 | 0% |
| batch=4, avg_kv=512 | FP8 | FP8 | Preshuffle | PASS | 3.70e-05 | 3.74e-05 | 3.66e-05 | 0% |
| batch=4, avg_kv=512 | FP8 | BF16 | Raw | PASS | 4.07e-05 | 4.12e-05 | 4.02e-05 | 0% |
| batch=4, avg_kv=512 | BF16 | FP4 | Raw | PASS | 5.28e-09 | 1.04e-08 | 1.63e-10 | 0% |
| batch=4, avg_kv=512 | BF16 | FP4 | Preshuffle | PASS | 5.28e-09 | 1.04e-08 | 1.63e-10 | 0% |
| batch=4, avg_kv=512 | BF16 | FP8 | Raw | PASS | 5.39e-07 | 7.38e-07 | 3.40e-07 | 0% |
| batch=4, avg_kv=512 | BF16 | FP8 | Preshuffle | PASS | 5.39e-07 | 7.38e-07 | 3.40e-07 | 0% |
| batch=4, avg_kv=512 | BF16 | BF16 | Raw | PASS | 1.18e-06 | 8.78e-07 | 1.48e-06 | 0% |

- The `0.00e+00` FP4 rows are exact matches to the dequantized MXFP4 reference after storing the result in BF16. This is an implementation correctness check, not a comparison against the original pre-quantized BF16 source weight.

**Performance:**

Benchmark setup: TpNumHeads=32, QK/V=128, KV_CDim=512, KV_Pe=64, block_size=1, timed with cuda.Event, num_iters=50, num_warmup=10. Lower is better.

| Shape | KV Cache Dtype | FP4 Raw | FP4 Preshuffle | FP8 Raw | FP8 Preshuffle | BF16 Raw | BF16 Preshuffle |
|---|---|---:|---:|---:|---:|---:|---:|
| batch=1, avg_kv=2048 | FP8 | 29.27 us | 34.35 us | 124.89 us | 124.81 us | 119.24 us | 114.64 us |
| batch=1, avg_kv=2048 | BF16 | 28.43 us | 28.13 us | 218.39 us | 231.84 us | 233.14 us | 220.17 us |
| batch=4, avg_kv=512 | FP8 | 28.48 us | 32.24 us | 38.55 us | 38.70 us | 45.31 us | 44.32 us |
| batch=4, avg_kv=512 | BF16 | 27.95 us | 27.88 us | 67.19 us | 66.43 us | 67.57 us | 64.22 us |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
