### PR TITLE
fix deepgemm_fp8_paged_mqa_logits kernel input parameter mismatch issue

### DIFF
--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -506,6 +506,7 @@ def deepgemm_fp8_paged_mqa_logits(
         )
         if triton_version >= Version("3.5.0"):
             cdna_version = get_cdna_version()
+            is_gfx1250 = get_gfx() == "gfx1250"
             kernel[grid](
                 batch_size,
                 next_n,
@@ -533,6 +534,7 @@ def deepgemm_fp8_paged_mqa_logits(
                 KVBlockSize,
                 hidden_dim,
                 cdna_version,
+                is_gfx1250,
             )
         else:  #  load AOT compiled gluon kernel
             assert triton_version < Version(


### PR DESCRIPTION
## Motivation

fix deepgemm_fp8_paged_mqa_logits kernel input parameter mismatch issue(caused by https://github.com/ROCm/aiter/commit/d863d2f89028b397a4b4efa7a944b470bfdd3214)

## Technical Details

add parameter of IS_GFX1250 when run kernel

## Test Plan

Accuracy test

## Test Result

`model_path=/shared/data/amd_int/models/deepseek-ai/DeepSeek-V3.2
lm_eval --model local-completions \
        --model_args model=$model_path,base_url=http://localhost:8001/v1/completions,num_concurrent=65,max_retries=1,tokenized_requests=False,trust_remote_code=True \
        --tasks gsm8k \
        --num_fewshot 20`

<img width="689" height="195" alt="image" src="https://github.com/user-attachments/assets/45c1bd79-773b-41fe-8639-2ec610f4bbc9" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
