### PR TITLE
CI: add a16w16 GEMM to op tuning workflow

### DIFF
--- a/.github/scripts/op_tune.sh
+++ b/.github/scripts/op_tune.sh
@@ -18,6 +18,7 @@ testFailedFiles=()
 declare -a tune_jobs=(
   "ck_batched_gemm_a8w8:csrc/ck_batched_gemm_a8w8:op_tests/test_batched_gemm_a8w8.py:python3 csrc/ck_batched_gemm_a8w8/batched_gemm_a8w8_tune.py -i aiter/configs/a8w8_untuned_batched_gemm.csv -o aiter/configs/a8w8_tuned_batched_gemm.csv"
   "ck_batched_gemm_bf16:csrc/ck_batched_gemm_bf16:op_tests/test_batched_gemm_bf16.py:python3 csrc/ck_batched_gemm_bf16/batched_gemm_bf16_tune.py -i aiter/configs/bf16_untuned_batched_gemm.csv -o aiter/configs/bf16_tuned_batched_gemm.csv"
+  "gemm_a16w16:csrc/gemm_a16w16:op_tests/test_gemm_a16w16.py:python3 csrc/gemm_a16w16/gemm_a16w16_tune.py -i aiter/configs/bf16_untuned_gemm.csv -o aiter/configs/bf16_tuned_gemm.csv"
   "ck_gemm_a8w8:csrc/ck_gemm_a8w8:op_tests/test_gemm_a8w8.py:python3 csrc/ck_gemm_a8w8/gemm_a8w8_tune.py -i aiter/configs/a8w8_untuned_gemm.csv -o aiter/configs/a8w8_tuned_gemm.csv"
   "ck_gemm_a8w8_blockscale:csrc/ck_gemm_a8w8_blockscale:op_tests/test_gemm_a8w8_blockscale.py:python3 csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py -i aiter/configs/a8w8_blockscale_untuned_gemm.csv -o aiter/configs/a8w8_blockscale_tuned_gemm.csv"
   "ck_gemm_a8w8_blockscale_bpreshuffle:csrc/ck_gemm_a8w8_blockscale_bpreshuffle:op_tests/test_gemm_a8w8_blockscale.py:python3 csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py --preshuffle -i aiter/configs/a8w8_blockscale_bpreshuffle_untuned_gemm.csv -o aiter/configs/a8w8_blockscale_bpreshuffle_tuned_gemm.csv"

--- a/.github/scripts/op_tune.sh
+++ b/.github/scripts/op_tune.sh
@@ -18,7 +18,7 @@ testFailedFiles=()
 declare -a tune_jobs=(
   "ck_batched_gemm_a8w8:csrc/ck_batched_gemm_a8w8:op_tests/test_batched_gemm_a8w8.py:python3 csrc/ck_batched_gemm_a8w8/batched_gemm_a8w8_tune.py -i aiter/configs/a8w8_untuned_batched_gemm.csv -o aiter/configs/a8w8_tuned_batched_gemm.csv"
   "ck_batched_gemm_bf16:csrc/ck_batched_gemm_bf16:op_tests/test_batched_gemm_bf16.py:python3 csrc/ck_batched_gemm_bf16/batched_gemm_bf16_tune.py -i aiter/configs/bf16_untuned_batched_gemm.csv -o aiter/configs/bf16_tuned_batched_gemm.csv"
-  "gemm_a16w16:csrc/gemm_a16w16:op_tests/test_gemm_a16w16.py:python3 csrc/gemm_a16w16/gemm_a16w16_tune.py -i aiter/configs/bf16_untuned_gemm.csv -o aiter/configs/bf16_tuned_gemm.csv"
+  "gemm_a16w16:csrc/gemm_a16w16:op_tests/test_gemm_a16w16.py:python3 csrc/gemm_a16w16/gemm_tuner.py -i aiter/configs/bf16_untuned_gemm.csv -o aiter/configs/bf16_tuned_gemm.csv"
   "ck_gemm_a8w8:csrc/ck_gemm_a8w8:op_tests/test_gemm_a8w8.py:python3 csrc/ck_gemm_a8w8/gemm_a8w8_tune.py -i aiter/configs/a8w8_untuned_gemm.csv -o aiter/configs/a8w8_tuned_gemm.csv"
   "ck_gemm_a8w8_blockscale:csrc/ck_gemm_a8w8_blockscale:op_tests/test_gemm_a8w8_blockscale.py:python3 csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py -i aiter/configs/a8w8_blockscale_untuned_gemm.csv -o aiter/configs/a8w8_blockscale_tuned_gemm.csv"
   "ck_gemm_a8w8_blockscale_bpreshuffle:csrc/ck_gemm_a8w8_blockscale_bpreshuffle:op_tests/test_gemm_a8w8_blockscale.py:python3 csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py --preshuffle -i aiter/configs/a8w8_blockscale_bpreshuffle_untuned_gemm.csv -o aiter/configs/a8w8_blockscale_bpreshuffle_tuned_gemm.csv"

--- a/.github/workflows/operators-tuning.yaml
+++ b/.github/workflows/operators-tuning.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       shapes:
-        description: 'Comma separated shape names to run, e.g. ck_batched_gemm_a8w8, ck_gemm_a8w8, ck_gemm_a8w8_blockscale, ck_gemm_a8w8_blockscale_bpreshuffle, ck_gemm_a8w8_bpreshuffle etc. (leave empty for all)'
+        description: 'Comma separated shape names to run, e.g. ck_batched_gemm_a8w8, ck_batched_gemm_bf16, gemm_a16w16, ck_gemm_a8w8, ck_gemm_a8w8_blockscale, ck_gemm_a8w8_blockscale_bpreshuffle, ck_gemm_a8w8_bpreshuffle etc. (leave empty for all)'
         required: false
         default: ''
       arguments:


### PR DESCRIPTION
## Summary
- Add the `gemm_a16w16` job to the operator tuning script so bf16 GEMM tuning can refresh `bf16_tuned_gemm.csv` from `bf16_untuned_gemm.csv`.
- Include `gemm_a16w16` in the manual Operators Tuning workflow shape examples.

## Test plan
- `bash -n .github/scripts/op_tune.sh`
- `git diff --check`