### PR TITLE
Use flyc.compile for MOE kernel fast dispatch

### DIFF
--- a/aiter/ops/flydsl/kernels/flash_attn_func_gfx1201.py
+++ b/aiter/ops/flydsl/kernels/flash_attn_func_gfx1201.py
@@ -779,12 +779,18 @@ def build_flash_attn_func_module_primary(
 
     def _launch(*args, **kwargs):
         args, kwargs = _wrap_qkvo(args, kwargs)
+        stream = kwargs.pop("stream", fx.Stream(None))
+        all_args = args + (stream,)
+        cf = getattr(launch_flash_attn_func, "_cf", None)
+        if cf is not None:
+            return cf(*all_args)
         with CompilationContext.compile_hints(_fmha_compile_hints):
-            return launch_flash_attn_func(*args, **kwargs)
+            cf = flyc.compile(launch_flash_attn_func, *all_args)
+            launch_flash_attn_func._cf = cf
 
     def _compile(Q, K, V, O, batch_size, seq_len, stream=None):  # noqa: E741
         with CompilationContext.compile_hints(_fmha_compile_hints):
-            return flyc.compile(
+            cf = flyc.compile(
                 launch_flash_attn_func,
                 _ptr_arg(Q),
                 _ptr_arg(K),
@@ -794,6 +800,8 @@ def build_flash_attn_func_module_primary(
                 seq_len,
                 fx.Stream(stream),
             )
+            launch_flash_attn_func._cf = cf
+            return cf
 
     _launch.compile = _compile
     return _launch

--- a/aiter/ops/flydsl/kernels/fused_compress_attn.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn.py
@@ -1422,7 +1422,7 @@ def flydsl_fused_compress_attn(
         stream = torch.cuda.current_stream()
     fx_stream = Stream(stream)
 
-    launcher(
+    args = (
         kv_in,
         kv_in.stride(0),
         score_in,
@@ -1447,5 +1447,11 @@ def flydsl_fused_compress_attn(
         bt_arg,
         bt_seq_stride,
         plan_capacity,
-        stream=fx_stream,
+        fx_stream,
     )
+    cf = getattr(launcher, "_cf", None)
+    if cf is not None:
+        cf(*args)
+    else:
+        cf = flyc.compile(launcher, *args)
+        launcher._cf = cf

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
@@ -1203,7 +1203,7 @@ def flydsl_hca_compress_attn(
         k_split_num_waves=k_split_num_waves,
         slice_size=slice_size,
     )
-    compress_fn(
+    compress_args = (
         kv_in,
         int(kv_in.stride(0)),
         score_in,
@@ -1220,8 +1220,14 @@ def flydsl_hca_compress_attn(
         kv_compressed,
         int(kv_compressed.stride(0)),
         int(plan_capacity),
-        stream=stream_obj,
+        stream_obj,
     )
+    cf = getattr(compress_fn, "_cf", None)
+    if cf is not None:
+        cf(*compress_args)
+    else:
+        cf = flyc.compile(compress_fn, *compress_args)
+        compress_fn._cf = cf
 
     rms_weight_is_bf16 = rms_weight.dtype == torch.bfloat16
     norm_fn = compile_hca_norm_rope_scatter(
@@ -1232,7 +1238,7 @@ def flydsl_hca_compress_attn(
         rms_weight_is_bf16=rms_weight_is_bf16,
         rms_eps=rms_eps,
     )
-    norm_fn(
+    norm_args = (
         kv_compressed,
         int(kv_compressed.stride(0)),
         plan_gpu,
@@ -1245,5 +1251,11 @@ def flydsl_hca_compress_attn(
         block_tables,
         int(block_tables.stride(0)),
         int(plan_capacity),
-        stream=stream_obj,
+        stream_obj,
     )
+    cf = getattr(norm_fn, "_cf", None)
+    if cf is not None:
+        cf(*norm_args)
+    else:
+        cf = flyc.compile(norm_fn, *norm_args)
+        norm_fn._cf = cf

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -992,7 +992,7 @@ def flydsl_qk_norm_rope_quant(
     for start in range(0, T_tok, MAX_GRID_Y):
         n = min(MAX_GRID_Y, T_tok - start)
         end = start + n
-        launcher(
+        args = (
             _ptr_arg(q_view[start:end]),
             _ptr_arg(kv[start:end]),
             q_weight_static,
@@ -1006,7 +1006,13 @@ def flydsl_qk_norm_rope_quant(
             _ptr_arg(kv_scale_arg[start:end] if quant else kv_scale_arg),
             kv.stride(0),
             n,
-            stream=fx_stream,
+            fx_stream,
         )
+        cf = getattr(launcher, "_cf", None)
+        if cf is not None:
+            cf(*args)
+        else:
+            cf = flyc.compile(launcher, *args)
+            launcher._cf = cf
 
     return q_out, kv_out, (q_scale if quant else None), (kv_scale if quant else None)

--- a/aiter/ops/flydsl/linear_attention_prefill_kernels.py
+++ b/aiter/ops/flydsl/linear_attention_prefill_kernels.py
@@ -264,7 +264,7 @@ def _launch_kernel(
 ):
     grid_v = triton.cdiv(V, BV)
     grid_nh = N * H
-    launch_fn(
+    args = (
         k,
         u,
         w,
@@ -283,6 +283,14 @@ def _launch_kernel(
         grid_nh,
         stream,
     )
+    cf = getattr(launch_fn, "_cf", None)
+    if cf is not None:
+        cf(*args)
+        return
+    import flydsl.compiler as flyc
+
+    cf = flyc.compile(launch_fn, *args)
+    launch_fn._cf = cf
 
 
 def chunk_gated_delta_rule_fwd_h_flydsl(

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -625,11 +625,18 @@ def _s2_args_std(
 
 
 def _run_compiled(exe, args):
-    """Call the JitFunction with the given args.
-    JitFunction.__call__ handles compilation caching internally.
+    """First call: JIT-compile via flyc.compile (compiles + executes + returns CompiledFunction).
+    Subsequent calls: fast dispatch via the cached CompiledFunction.
     """
+    import flydsl.compiler as flyc
+
+    cf = getattr(exe, "_cf", None)
+    if cf is not None:
+        cf(*args)
+        return
     try:
-        exe(*args)
+        cf = flyc.compile(exe, *args)
+        exe._cf = cf
     except Exception:
         # JitFunction.__call__ leaks ir.Context on compilation failure,
         # causing all subsequent JitFunction calls to take a wrong code path


### PR DESCRIPTION
Replace exe(*args) with flyc.compile-based caching: first call compiles and executes via flyc.compile(), subsequent calls use the cached CompiledFunction for ~5µs dispatch instead of full JitFunction overhead.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
