### PR TITLE
Fix pa_mqa_logits MI300X divide-by-zero for small TileQCount

### DIFF
--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -77,6 +77,31 @@ else:
     enable_jit_gluon_pa_mqa_logits_kernel = False
 
 
+def _stage1_chunkq_splitkv(
+    batch_size: int,
+    next_n: int,
+    heads: int,
+    ChunkQ: int,
+    TotalCuCount: int,
+    WavePerEU: int,
+):
+    assert batch_size > 0, f"batch_size must be positive, got {batch_size}"
+    assert next_n > 0, f"next_n must be positive, got {next_n}"
+    assert heads > 0, f"heads must be positive, got {heads}"
+    assert ChunkQ > 0, f"ChunkQ must be positive, got {ChunkQ}"
+    assert TotalCuCount > 0, f"TotalCuCount must be positive, got {TotalCuCount}"
+    assert WavePerEU > 0, f"WavePerEU must be positive, got {WavePerEU}"
+
+    if heads < ChunkQ:
+        ChunkQ = heads
+
+    assert heads % ChunkQ == 0, f"heads {heads} must be divisible by ChunkQ {ChunkQ}"
+
+    TileQCount = batch_size * next_n * (heads // ChunkQ)
+    SplitKV = (max(1, TotalCuCount // TileQCount) + 4) // 5 * 5 * WavePerEU
+    return ChunkQ, SplitKV
+
+
 def deepgemm_fp8_paged_mqa_logits_ragged_k(
     q_fp8: torch.Tensor,  # dtype = float8
     kv_cache_fp8: torch.Tensor,  # dtype = float8
@@ -195,8 +220,9 @@ def deepgemm_fp8_paged_mqa_logits_stage1(
     batch_size, next_n, heads, hidden_dim = q_fp8.size()
     _, max_blk_len = kv_indices.size()
 
-    TileQCount = batch_size * next_n * (heads // ChunkQ)
-    SplitKV = (max(1, TotalCuCount // TileQCount) + 4) // 5 * 5 * WavePerEU
+    ChunkQ, SplitKV = _stage1_chunkq_splitkv(
+        batch_size, next_n, heads, ChunkQ, TotalCuCount, WavePerEU
+    )
 
     kv_cache_fp8, kv_cache_scale = (
         kv_cache_fp8[..., :hidden_dim],
@@ -212,7 +238,6 @@ def deepgemm_fp8_paged_mqa_logits_stage1(
         "HiddenDim": hidden_dim,
         "SplitKV": SplitKV,
     }
-    assert heads % config["ChunkQ"] == 0
 
     grid = (batch_size * next_n * (heads // config["ChunkQ"] * SplitKV),)
     _deepgemm_fp8_paged_mqa_logits_stage1[grid](

--- a/op_tests/triton_tests/attention/test_pa_mqa_logits.py
+++ b/op_tests/triton_tests/attention/test_pa_mqa_logits.py
@@ -1,0 +1,70 @@
+import pytest
+
+from aiter.ops.triton.attention.pa_mqa_logits import _stage1_chunkq_splitkv
+
+
+@pytest.mark.parametrize("heads", [8, 16, 32])
+def test_stage1_chunkq_splitkv_uses_small_head_count(heads):
+    chunk_q, split_kv = _stage1_chunkq_splitkv(
+        batch_size=1,
+        next_n=1,
+        heads=heads,
+        ChunkQ=64,
+        TotalCuCount=80,
+        WavePerEU=2,
+    )
+
+    assert chunk_q == heads
+    assert split_kv == 160
+
+
+def test_stage1_chunkq_splitkv_keeps_supported_chunkq():
+    chunk_q, split_kv = _stage1_chunkq_splitkv(
+        batch_size=2,
+        next_n=1,
+        heads=128,
+        ChunkQ=64,
+        TotalCuCount=80,
+        WavePerEU=2,
+    )
+
+    assert chunk_q == 64
+    assert split_kv == 40
+
+
+def test_stage1_chunkq_splitkv_rejects_non_divisible_heads():
+    with pytest.raises(AssertionError, match="must be divisible"):
+        _stage1_chunkq_splitkv(
+            batch_size=1,
+            next_n=1,
+            heads=96,
+            ChunkQ=64,
+            TotalCuCount=80,
+            WavePerEU=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"batch_size": 0}, "batch_size must be positive"),
+        ({"next_n": 0}, "next_n must be positive"),
+        ({"heads": 0}, "heads must be positive"),
+        ({"ChunkQ": 0}, "ChunkQ must be positive"),
+        ({"TotalCuCount": 0}, "TotalCuCount must be positive"),
+        ({"WavePerEU": 0}, "WavePerEU must be positive"),
+    ],
+)
+def test_stage1_chunkq_splitkv_rejects_non_positive_inputs(kwargs, match):
+    args = dict(
+        batch_size=1,
+        next_n=1,
+        heads=64,
+        ChunkQ=64,
+        TotalCuCount=80,
+        WavePerEU=2,
+    )
+    args.update(kwargs)
+
+    with pytest.raises(AssertionError, match=match):
+        _stage1_chunkq_splitkv(**args)


### PR DESCRIPTION
## Summary
- Fix `deepgemm_fp8_paged_mqa_logits_stage1` scheduling when the per-rank head count is smaller than the default `ChunkQ=64`.
- Add focused regression coverage for the split-KV scheduler so small head counts no longer produce `TileQCount == 0` / `ZeroDivisionError`.

## Reproduction / Root cause
`deepgemm_fp8_paged_mqa_logits_stage1` computed:

```python
TileQCount = batch_size * next_n * (heads // ChunkQ)
SplitKV = (max(1, TotalCuCount // TileQCount) + 4) // 5 * 5 * WavePerEU
```

For GLM-style sparse MLA decode with high tensor parallelism, `heads` can be smaller than the default `ChunkQ=64` (for example 8 heads per rank on TP=8). That makes `heads // ChunkQ == 0`, so `TileQCount == 0` and the wrapper raises `ZeroDivisionError` before the existing `heads % ChunkQ` check or kernel launch.

## Fix
- Clamp stage1 `ChunkQ` down to `heads` only for the `heads < ChunkQ` case, matching callers that already pass `ChunkQ=heads` explicitly.
- Keep the existing divisibility invariant for other unsupported tilings.
- Validate non-positive scheduler inputs before computing `SplitKV`.

## Tests
- `python -m py_compile aiter/ops/triton/attention/pa_mqa_logits.py op_tests/triton_tests/attention/test_pa_mqa_logits.py`
- Fleet MI300X/gfx942 smoke: `job-69158de0` on `vllm/vllm-openai-rocm:nightly`, ROCm HIP `7.2.53211`, patched the installed AITER wrapper, asserted the small-head scheduler path, and launched `deepgemm_fp8_paged_mqa_logits_stage1` with `heads=8` and default `ChunkQ=64` using a reduced `ChunkK=64` smoke shape.

## Caveats
- I did not validate full GLM-5.1-FP8 serving, so this PR should not be treated as complete model-level closure for ROCm/aiter#2749.
- Local Windows pytest collection is blocked by missing Triton. A source-tree Fleet pytest attempt was also blocked because `AITER_TRITON_ONLY=1` does not expose `aiter.dtypes`; the successful Fleet smoke used the installed AITER package from the ROCm vLLM image and overlaid only this changed wrapper file.
- A synthetic MI300X launch with `hidden_dim=128` and default `ChunkK=256` reached the fixed path but hit Triton shared-memory OOR in this image; the passing smoke reduces `ChunkK` to validate the small-head scheduling/launch path.

Fixes ROCm/aiter#2749