### PR TITLE
flydsl grouped moe: fuse scale route-gather + WMMA preshuffle

### DIFF
--- a/aiter/ops/flydsl/grouped_moe_gfx1250.py
+++ b/aiter/ops/flydsl/grouped_moe_gfx1250.py
@@ -537,8 +537,12 @@ def _maybe_grouped_gfx1250_a8w4_moe(
         grouped_a1 = torch.empty(
             (E, max_m, model_dim // 2), dtype=torch.uint8, device=device
         )
-        a1_scale_raw = torch.empty(
-            (E, max_m, model_dim // 32), dtype=torch.uint8, device=device
+        # Only the naive path needs the row-major scale buffer; the fast path
+        # gathers + preshuffles the scale in one fused kernel (no a1_scale_raw).
+        a1_scale_raw = (
+            torch.empty((E, max_m, model_dim // 32), dtype=torch.uint8, device=device)
+            if _use_naive
+            else None
         )
     else:
         # a8w4 stage1 input: per-block-32 MXFP8 quantization.
@@ -569,26 +573,42 @@ def _maybe_grouped_gfx1250_a8w4_moe(
         grouped_a1 = torch.empty(
             (E, max_m, model_dim), dtype=torch.uint8, device=device
         )
-        # Padding rows decode with scale=1.0.
-        a1_scale_raw = torch.empty(
-            (E, max_m, model_dim // 32), dtype=torch.uint8, device=device
+        # Padding rows decode with scale=1.0. Only the naive path needs the
+        # row-major scale buffer; the fast path fuses gather + preshuffle.
+        a1_scale_raw = (
+            torch.empty((E, max_m, model_dim // 32), dtype=torch.uint8, device=device)
+            if _use_naive
+            else None
         )
 
     # Route-gather into the grouped per-expert layout.
     if not _use_naive:
-        from aiter.ops.flydsl.moe_kernels import flydsl_moe_scatter_copy_token
+        from aiter.ops.flydsl.moe_kernels import (
+            flydsl_moe_scatter_copy_token,
+            flydsl_moe_scatter_preshuffle_scale,
+        )
 
         _grouped_dbg("start route gather (scatter-copy kernel)")
+        # Payload route-gather only; the e8m0 scale is route-gathered AND
+        # preshuffled into the WMMA layout in one fused pass below (no
+        # intermediate row-major a1_scale_raw + separate permute).
         flydsl_moe_scatter_copy_token(
             a1_payload,
-            a1_scale_token_u8,
+            None,
             rows_to_tokens,
             E,
             max_m,
             grouped_a1=grouped_a1,
-            a1_scale_raw=a1_scale_raw,
         )
-        _grouped_dbg("route gather done")
+        grouped_a1_scale = flydsl_moe_scatter_preshuffle_scale(
+            a1_scale_token_u8,
+            rows_to_tokens,
+            E,
+            max_m,
+            wmma_rep=warp_tile_m // 16,
+            scale_k_per_tile=tile_k // 32,
+        )
+        _grouped_dbg("route gather + scale preshuffle done")
     else:
         _grouped_dbg("start route gather (naive)")
         # Naive torch route-gather.
@@ -602,6 +622,9 @@ def _maybe_grouped_gfx1250_a8w4_moe(
         route_weights = torch.empty((E, max_m), dtype=dtype, device=device)
         route_weights.view(-1)[topids_to_rows.reshape(-1)] = topk_weight.reshape(-1).to(
             route_weights.dtype
+        )
+        grouped_a1_scale = _grouped_a8w4_preshuffle_e8m0_scale(
+            a1_scale_raw, warp_tile=warp_tile_m, scale_k_per_tile=tile_k // 32
         )
         _grouped_dbg("route gather done")
 
@@ -617,9 +640,8 @@ def _maybe_grouped_gfx1250_a8w4_moe(
         E, model_dim // _wmma_rep, (inter_dim // 32) * _wmma_rep
     )
 
-    grouped_a1_scale = _grouped_a8w4_preshuffle_e8m0_scale(
-        a1_scale_raw, warp_tile=warp_tile_m, scale_k_per_tile=tile_k // 32
-    )
+    # grouped_a1_scale is produced above: fused gather+preshuffle (fast path) or
+    # scatter + _grouped_a8w4_preshuffle_e8m0_scale (naive path).
     _grouped_dbg("scale layout done")
 
     grouped_a2 = torch.empty((E, max_m, inter_dim), dtype=dtype, device=device)
@@ -737,9 +759,22 @@ def _maybe_grouped_gfx1250_a8w4_moe(
         a2_scale_raw = torch.full(
             (E, max_m, inter_dim // 32), 127, dtype=torch.uint8, device=device
         )
-    grouped_a2_scale = _grouped_a8w4_preshuffle_e8m0_scale(
-        a2_scale_raw, warp_tile=warp_tile_m, scale_k_per_tile=tile_k // 32
-    )
+    if _use_naive:
+        grouped_a2_scale = _grouped_a8w4_preshuffle_e8m0_scale(
+            a2_scale_raw, warp_tile=warp_tile_m, scale_k_per_tile=tile_k // 32
+        )
+    else:
+        # a2_scale_raw is already grouped row-major (no route-gather), so use the
+        # in-kernel preshuffle (gather-less fused version, like stage1).
+        from aiter.ops.flydsl.moe_kernels import flydsl_moe_preshuffle_scale
+
+        grouped_a2_scale = flydsl_moe_preshuffle_scale(
+            a2_scale_raw,
+            E,
+            max_m,
+            wmma_rep=warp_tile_m // 16,
+            scale_k_per_tile=tile_k // 32,
+        )
     _grouped_dbg("a2 scale layout done")
     grouped_out = torch.empty((E, max_m, model_dim), dtype=dtype, device=device)
     stage2_compiler = (

--- a/aiter/ops/flydsl/kernels/moe_scatter_copy_preshuffle_scale.py
+++ b/aiter/ops/flydsl/kernels/moe_scatter_copy_preshuffle_scale.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fused MoE route-gather + e8m0-scale preshuffle kernel (FlyDSL).
+
+Background
+----------
+The grouped a8w4 stage1 path needs the per-token MXFP8 e8m0 scale both
+*route-gathered* into the grouped per-expert layout and *preshuffled* into the
+WMMA layout the masked grouped GEMM consumes. Previously this was two passes:
+
+    1. scatter-copy   a1_scale_token_u8[tok] -> a1_scale_raw[e, m]   (row-major)
+    2. preshuffle     a1_scale_raw -> grouped_a1_scale              (torch permute)
+
+where ``preshuffle`` (``_grouped_a8w4_preshuffle_e8m0_scale``) is the reshape::
+
+    g = scale.view(E, -1, wmma_rep, 16, k_groups, k_wmma_steps, 4)
+    g = g.permute(0, 1, 3, 4, 5, 2, 6).contiguous()
+    grouped = g.reshape(E, max_m // wmma_rep, k_scale * wmma_rep)
+
+i.e. for a source byte at ``(w, lane, kg, ks, kw)`` inside one row-tile of
+``(wmma_rep, 16)`` rows it lands at ``(lane, kg, ks, w, kw)``. The permute is
+*tile-local*: nothing crosses a ``wmma_rep*16`` row boundary.
+
+This kernel fuses the two passes: it gathers each token's scale row and writes
+it straight into the preshuffled layout, dropping the intermediate
+``a1_scale_raw`` buffer and the separate permute launch.
+
+Layout / index math
+-------------------
+``Ws = k_scale = model_dim // 32`` scale bytes per row. The scale row is copied
+as dword (4-byte) units: ``src_dwords = Ws // 4 = k_groups * k_wmma_steps``,
+where the innermost 4 (``kw``) is exactly one dword and is contiguous in *both*
+source and destination.
+
+The permute only relocates the ``wmma_rep`` axis next to the trailing ``4``, so
+in the output the innermost ``(wmma_rep, 4)`` is a *contiguous* ``wmma_rep*4``-
+byte block (``wmma_rep`` dwords). We give that whole block to one thread: it
+gathers the ``wmma_rep`` source dwords (one per source token-row, the only
+scattered part) into a register vector and issues a single ``dwordx{wmma_rep}``
+store (a 16B ``dwordx4`` when ``wmma_rep == 4`` -- the widest/fastest op). The
+permute is thus done in registers; the store is fully vectorized.
+
+One thread-block handles one row-tile (``wmma_rep*16`` grouped rows) of one
+expert -- a 2D grid ``(tiles_per_expert, E)``. One work item == one
+``(lane, sd)`` with ``sd = kg*k_wmma_steps + ks`` in ``[0, src_dwords)``:
+
+    out_row   = tile*16 + lane
+    dst_dword = e*(max_m*src_dwords) + out_row*(src_dwords*wmma_rep) + sd*wmma_rep
+    for w in range(wmma_rep):                      # the contiguous wmma_rep axis
+        grow  = e*max_m + tile*(wmma_rep*16) + w*16 + lane
+        srow  = rows_to_tokens[grow]               # source token (-1 => padding)
+        vec[w] = (srow >= 0) ? src[srow, sd] : 0   # 0 for padding lanes
+    store vec  (wmma_rep dwords) at dst_dword
+
+Padding lanes are written as 0 (matching the zero-init reference / harmless to
+the masked GEMM, which never reads padding rows). The whole output is written
+once -- same write volume as the old ``contiguous()`` permute it replaces.
+
+Grid  : (tiles_per_expert, E, 1)   -- tiles_per_expert = max_m // (wmma_rep*16)
+Block : (BLOCK_THREADS, 1, 1)
+"""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, range_constexpr
+from flydsl.expr.typing import T, Int32
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.compiler.kernel_function import CompilationContext
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import scf
+from flydsl.expr import buffer_ops, vector
+
+BLOCK_THREADS = 256
+
+
+def _emit_preshuffle_dword(gather, map_rsrc, src_rsrc, grow, sd, c_src_dwords, c0):
+    """Emit the load of one preshuffled source dword (grouped row ``grow``, scale
+    dword ``sd``).
+
+    This is a plain (non-``@flyc.kernel``) helper on purpose: the build-time
+    ``gather`` branch lives here, NOT inside the kernel body, so the kernel AST
+    rewriter never turns it into device control flow. ``gather=True`` indirects
+    through ``rows_to_tokens`` (padding -> 0); ``gather=False`` reads the grouped
+    row directly (identity, pure preshuffle).
+    """
+    i32 = T.i32
+    if gather:
+        srow = ArithValue(
+            buffer_ops.buffer_load(map_rsrc, grow, vec_width=1, dtype=i32)
+        )
+        valid = arith.cmpi(CmpIPredicate.sge, srow, c0)
+        # Clamp offset in-bounds when padding, then zero the result.
+        src_off = arith.select(valid, srow * c_src_dwords + sd, c0)
+        v_raw = buffer_ops.buffer_load(src_rsrc, src_off, vec_width=1, dtype=i32)
+        return arith.select(valid, v_raw, c0)
+    src_off = grow * c_src_dwords + sd
+    return buffer_ops.buffer_load(src_rsrc, src_off, vec_width=1, dtype=i32)
+
+
+def build_moe_scatter_copy_preshuffle_scale_module(
+    row_bytes: int, wmma_rep: int, scale_k_per_tile: int, gather: bool = True
+):
+    """Return a JIT launcher for scale WMMA preshuffle, with optional route-gather.
+
+    Parameters
+    ----------
+    row_bytes : int          scale bytes per row (``Ws = K // 32``).
+    wmma_rep : int           ``warp_tile_m // 16``.
+    scale_k_per_tile : int   ``tile_k // 32`` (scale bytes per k-tile).
+    gather : bool            if True (stage1), gather each grouped row from a
+                             source token via ``rows_to_tokens`` (-1 => pad to 0);
+                             if False (stage2), the source is already grouped
+                             row-major so the grouped row maps to itself (pure
+                             preshuffle, like the old torch permute but in-kernel).
+
+    Launcher signature::
+
+        gather=True:  (src, dst, rows_to_tokens, max_m, E, tiles_per_expert, stream=...)
+        gather=False: (src, dst, max_m, E, tiles_per_expert, stream=...)
+
+    ``src`` is the scale viewed (num_src, row_bytes) uint8; ``dst`` is the
+    preshuffled output viewed (E*(max_m//wmma_rep), row_bytes*wmma_rep) uint8;
+    ``rows_to_tokens`` is int32 (E*max_m,) grouped row -> token (-1 skip).
+    """
+    assert row_bytes > 0 and row_bytes % 4 == 0, "scale row must be dword-aligned"
+    assert wmma_rep >= 1, "wmma_rep must be >= 1"
+    assert scale_k_per_tile % 4 == 0, "scale_k_per_tile must be a multiple of 4"
+    assert row_bytes % scale_k_per_tile == 0, "scale_k_per_tile must divide row"
+
+    # Compile-time tile geometry (mirrors _grouped_a8w4_preshuffle_e8m0_scale).
+    src_dwords = row_bytes // 4               # k_groups * k_wmma_steps (dwords/row)
+    rows_per_tile = wmma_rep * 16             # grouped rows per row-tile
+    dpr = src_dwords * wmma_rep               # dst dwords per output row
+    # The contiguous (wmma_rep, 4) dst block is wmma_rep dwords. Buffer ops cap at
+    # dwordx4 (128b), so store it in chunks of `store_vw` (largest of {4,2,1}
+    # dividing wmma_rep); wmma_rep in {1,2,4} is a single chunk, 8 -> two dwordx4.
+    if wmma_rep % 4 == 0:
+        store_vw = 4
+    elif wmma_rep % 2 == 0:
+        store_vw = 2
+    else:
+        store_vw = 1
+    n_chunks = wmma_rep // store_vw
+    # One work item == one (lane, sd, chunk): it writes `store_vw` contiguous dst
+    # dwords as one dwordx{store_vw} store.
+    units_per_tile = 16 * src_dwords * n_chunks
+
+    _g = "g" if gather else "p"
+    module_name = (
+        f"moe_scatter_preshuffle_scale_b{row_bytes}_r{wmma_rep}_k{scale_k_per_tile}_{_g}"
+    )
+
+    @flyc.kernel(name=module_name)
+    def scatter_preshuffle_kernel(
+        src: fx.Tensor,  # (num_src, row_bytes) uint8
+        dst: fx.Tensor,  # (E*(max_m//wmma_rep), row_bytes*wmma_rep) uint8
+        rows_to_tokens: fx.Tensor,  # (E*max_m,) int32  -- -1 = skip (gather only)
+        max_m: Int32,
+    ):
+        i32 = T.i32
+        vec_ty = ir.VectorType.get([store_vw], i32) if store_vw > 1 else None
+
+        tile = ArithValue(fx.block_idx.x)
+        e = ArithValue(fx.block_idx.y)
+        tid = ArithValue(fx.thread_idx.x)
+        max_m_i32 = ArithValue(max_m)
+
+        c_rows_per_tile = arith.constant(rows_per_tile, type=i32)
+        c_src_dwords = arith.constant(src_dwords, type=i32)
+        c_dpr = arith.constant(dpr, type=i32)
+        c_wmma_rep = arith.constant(wmma_rep, type=i32)
+        c_n_chunks = arith.constant(n_chunks, type=i32)
+        c_store_vw = arith.constant(store_vw, type=i32)
+        c_units = arith.constant(units_per_tile, type=i32)
+        c16 = arith.constant(16, type=i32)
+        c0 = arith.constant(0, type=i32)
+
+        # Per-tile bases (runtime e/tile/max_m, compile-time geometry).
+        # grouped src-row base of this tile's first row.
+        row_base = e * max_m_i32 + tile * c_rows_per_tile
+        # dst dword base of this expert+tile (out_row 0 of the tile).
+        # expert stride (dwords) = max_m * src_dwords; tile adds 16 out-rows.
+        expert_dword_base = e * (max_m_i32 * c_src_dwords)
+        tile_out_row0 = tile * c16
+
+        # Created unconditionally (no in-body `if`): for gather=False the launcher
+        # passes a placeholder for rows_to_tokens and the helper never reads it.
+        map_rsrc = buffer_ops.create_buffer_resource(rows_to_tokens, max_size=True)
+        src_rsrc = buffer_ops.create_buffer_resource(src, max_size=True)
+        dst_rsrc = buffer_ops.create_buffer_resource(dst, max_size=True)
+
+        for it in range_constexpr((units_per_tile + BLOCK_THREADS - 1) // BLOCK_THREADS):
+            unit = tid + arith.constant(it * BLOCK_THREADS, type=i32)
+            u_ok = arith.cmpi(CmpIPredicate.ult, unit, c_units)
+            _if_u = scf.IfOp(u_ok)
+            with ir.InsertionPoint(_if_u.then_block):
+                # Decode (lane, sd, chunk) with chunk innermost so consecutive
+                # threads write consecutive dst dwords (coalesced).
+                chunk = unit % c_n_chunks
+                t2 = unit // c_n_chunks
+                sd = t2 % c_src_dwords
+                lane = t2 // c_src_dwords
+                out_row = tile_out_row0 + lane
+                w_base = chunk * c_store_vw  # first wmma_rep row of this chunk
+                # col = sd*wmma_rep + chunk*store_vw  (+ j for j in [0, store_vw))
+                dst_off = (
+                    expert_dword_base
+                    + out_row * c_dpr
+                    + sd * c_wmma_rep
+                    + w_base
+                )
+
+                # Collect this chunk's store_vw dwords (one per wmma_rep row). The
+                # gather/identity choice is resolved in the plain helper, so no
+                # build-time `if` appears inside this rewritten kernel body.
+                elems = []
+                for j in range_constexpr(store_vw):
+                    grow = (
+                        row_base
+                        + (w_base + arith.constant(j, type=i32)) * c16
+                        + lane
+                    )
+                    elems.append(
+                        _emit_preshuffle_dword(
+                            gather, map_rsrc, src_rsrc, grow, sd, c_src_dwords, c0
+                        )
+                    )
+
+                if store_vw == 1:
+                    buffer_ops.buffer_store(elems[0], dst_rsrc, dst_off)
+                else:
+                    vec = vector.from_elements(vec_ty, elems)
+                    buffer_ops.buffer_store(vec, dst_rsrc, dst_off)
+                scf.YieldOp([])
+
+    if gather:
+
+        @flyc.jit
+        def launch_scatter_preshuffle(
+            src: fx.Tensor,
+            dst: fx.Tensor,
+            rows_to_tokens: fx.Tensor,
+            max_m: fx.Int32,
+            E: fx.Int32,
+            tiles_per_expert: fx.Int32,
+            stream: fx.Stream = fx.Stream(None),
+        ):
+            ctx = CompilationContext.get_current()
+            with ir.InsertionPoint(ctx.gpu_module_body):
+                pass
+
+            idx_tiles = arith.index_cast(T.index, tiles_per_expert)
+            idx_e = arith.index_cast(T.index, E)
+            launcher = scatter_preshuffle_kernel(src, dst, rows_to_tokens, max_m)
+            launcher.launch(
+                grid=(idx_tiles, idx_e, 1),
+                block=(BLOCK_THREADS, 1, 1),
+                stream=stream,
+            )
+
+        return launch_scatter_preshuffle
+
+    @flyc.jit
+    def launch_preshuffle(
+        src: fx.Tensor,
+        dst: fx.Tensor,
+        max_m: fx.Int32,
+        E: fx.Int32,
+        tiles_per_expert: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            pass
+
+        idx_tiles = arith.index_cast(T.index, tiles_per_expert)
+        idx_e = arith.index_cast(T.index, E)
+        # rows_to_tokens is unused when gather=False; pass src as a placeholder.
+        launcher = scatter_preshuffle_kernel(src, dst, src, max_m)
+        launcher.launch(
+            grid=(idx_tiles, idx_e, 1),
+            block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    return launch_preshuffle

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1689,3 +1689,103 @@ def flydsl_moe_scatter_copy_token(
         )
 
     return grouped_a1, a1_scale_raw
+
+
+@functools.cache
+def _get_compiled_scatter_preshuffle_scale(
+    row_bytes: int, wmma_rep: int, scale_k_per_tile: int, gather: bool = True
+):
+    """Compile and cache the WMMA-preshuffle scale kernel (with/without gather)."""
+    from aiter.ops.flydsl.kernels.moe_scatter_copy_preshuffle_scale import (
+        build_moe_scatter_copy_preshuffle_scale_module,
+    )
+
+    return build_moe_scatter_copy_preshuffle_scale_module(
+        row_bytes, wmma_rep, scale_k_per_tile, gather=gather
+    )
+
+
+def flydsl_moe_scatter_preshuffle_scale(
+    a1_scale_token_u8: torch.Tensor,  # (token_num, Ws) uint8
+    rows_to_tokens: torch.Tensor,  # (E*max_m,) int32 grouped row -> token (-1 pad)
+    E: int,
+    max_m: int,
+    *,
+    wmma_rep: int,
+    scale_k_per_tile: int,
+    grouped_a1_scale: Optional[torch.Tensor] = None,  # (E, max_m//wmma_rep, Ws*wmma_rep)
+):
+    """Route-gather each token's e8m0 scale row AND preshuffle it into the WMMA
+    layout in a single kernel pass -- fusing ``flydsl_moe_scatter_copy_token``'s
+    scale copy with ``_grouped_a8w4_preshuffle_e8m0_scale``.
+
+    ``max_m`` must be a multiple of ``wmma_rep*16`` (the grouped path pads it to
+    a multiple of ``warp_tile_m``). Padding rows (``rows_to_tokens == -1``) are
+    left untouched -- the masked GEMM never reads them, matching the previous
+    uninitialized ``a1_scale_raw`` behaviour. Returns ``grouped_a1_scale``."""
+    device = a1_scale_token_u8.device
+    Ws = a1_scale_token_u8.shape[1]
+    rows_per_tile = wmma_rep * 16
+    assert max_m % rows_per_tile == 0, (
+        f"max_m ({max_m}) must be a multiple of wmma_rep*16 ({rows_per_tile})"
+    )
+    tiles_per_expert = max_m // rows_per_tile
+
+    if grouped_a1_scale is None:
+        grouped_a1_scale = torch.empty(
+            (E, max_m // wmma_rep, Ws * wmma_rep), dtype=torch.uint8, device=device
+        )
+
+    launch = _get_compiled_scatter_preshuffle_scale(
+        Ws, wmma_rep, scale_k_per_tile, True
+    )
+    launch(
+        a1_scale_token_u8.contiguous().view(-1, Ws),
+        grouped_a1_scale.view(E * (max_m // wmma_rep), Ws * wmma_rep),
+        rows_to_tokens,
+        max_m,
+        E,
+        tiles_per_expert,
+        stream=torch.cuda.current_stream(),
+    )
+    return grouped_a1_scale
+
+
+def flydsl_moe_preshuffle_scale(
+    scale_grouped_u8: torch.Tensor,  # (E, max_m, Ws) or (E*max_m, Ws) uint8
+    E: int,
+    max_m: int,
+    *,
+    wmma_rep: int,
+    scale_k_per_tile: int,
+    out: Optional[torch.Tensor] = None,  # (E, max_m//wmma_rep, Ws*wmma_rep)
+):
+    """Preshuffle an already-grouped row-major e8m0 scale into the WMMA layout in
+    one kernel pass -- the in-kernel equivalent of the torch
+    ``_grouped_a8w4_preshuffle_e8m0_scale`` permute (used by stage2, where the
+    scale is already grouped so no route-gather is needed). Returns ``out``."""
+    device = scale_grouped_u8.device
+    Ws = scale_grouped_u8.shape[-1]
+    rows_per_tile = wmma_rep * 16
+    assert max_m % rows_per_tile == 0, (
+        f"max_m ({max_m}) must be a multiple of wmma_rep*16 ({rows_per_tile})"
+    )
+    tiles_per_expert = max_m // rows_per_tile
+
+    if out is None:
+        out = torch.empty(
+            (E, max_m // wmma_rep, Ws * wmma_rep), dtype=torch.uint8, device=device
+        )
+
+    launch = _get_compiled_scatter_preshuffle_scale(
+        Ws, wmma_rep, scale_k_per_tile, False
+    )
+    launch(
+        scale_grouped_u8.contiguous().view(E * max_m, Ws),
+        out.view(E * (max_m // wmma_rep), Ws * wmma_rep),
+        max_m,
+        E,
+        tiles_per_expert,
+        stream=torch.cuda.current_stream(),
+    )
+    return out

--- a/op_tests/test_flydsl_grouped_gemm_gfx1250.py
+++ b/op_tests/test_flydsl_grouped_gemm_gfx1250.py
@@ -65,6 +65,11 @@ VERIFY_TOL_ALL_ONES = 0.01
 # Environment / arch guards
 # ---------------------------------------------------------------------------
 def _require_gfx1250() -> None:
+    # AITER_FORCE_GFX1250=1 forces the grouped path on other archs (e.g. gfx942)
+    # to exercise the tiny operators with the GEMM mocked (default; pass
+    # --real-gemm to call the real gfx1250 kernel instead).
+    if os.environ.get("AITER_FORCE_GFX1250", "0") in ("1", "true", "True", "yes"):
+        return
     try:
         from flydsl.runtime.device import get_rocm_arch
     except Exception as exc:
@@ -641,6 +646,38 @@ def _bench(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+def _mock_grouped_gemm() -> None:
+    """Run the grouped MoE path without the gfx1250-only kernels.
+
+    Two patches let the tiny operators (route maps, scatter/gather, quant,
+    scale preshuffle, m-tile map, gather-reduce) run on any arch (e.g. gfx942
+    via AITER_FORCE_GFX1250=1):
+
+    1. Replace the grouped WMMA GEMM compilers with no-op launchers -- the GEMM
+       executes nothing; stage outputs are left as-is.
+    2. Route the fp4 a1/a2 quant through the Triton implementation, since the
+       HIP ``per_1x32_f4_quant_hip`` has no fp4x2 output support off gfx1250.
+
+    The library imports all these names at call time, so patching the source
+    modules is enough -- no library edits required.
+    """
+    import aiter.ops.flydsl.kernels.moe_grouped_gemm_mxscale_gfx1250 as gk
+    import aiter.ops.quant as q
+
+    def _noop_compile(*_a, **_k):
+        return lambda *_a, **_k: None
+
+    for _name in (
+        "compile_moe_grouped_gemm1_a8w4_masked",
+        "compile_moe_grouped_gemm2_a8w4_masked",
+        "compile_moe_grouped_gemm1_mxfp4_masked",
+        "compile_moe_grouped_gemm2_mxfp4_masked",
+    ):
+        setattr(gk, _name, _noop_compile)
+
+    q.per_1x32_f4_quant_hip = q.per_1x32_f4_quant_triton
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scenario", choices=("bench", "verify"), default="bench")
@@ -673,6 +710,12 @@ def main() -> None:
         help="run with zero stage1/stage2 bias tensors",
     )
     parser.add_argument(
+        "--real-gemm",
+        action="store_true",
+        help="call the real grouped WMMA GEMM kernel (gfx1250 only). Default: "
+        "mock the GEMM (no-op) so the tiny operators run on any arch.",
+    )
+    parser.add_argument(
         "--all-ones",
         action="store_true",
         help="(verify only) hidden=1, weight bytes=0x22 (=+1.0), "
@@ -680,6 +723,8 @@ def main() -> None:
         "grouped and ref see the exact same dequantised values.",
     )
     args = parser.parse_args()
+    if not args.real_gemm:
+        _mock_grouped_gemm()
     if args.model_dim < 512 or args.inter_dim < 512:
         raise SystemExit(
             f"model_dim ({args.model_dim}) and inter_dim ({args.inter_dim}) must be "

--- a/op_tests/test_moe_scatter_copy_preshuffle_scale.py
+++ b/op_tests/test_moe_scatter_copy_preshuffle_scale.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Byte-exact tests for the fused scatter + e8m0-scale preshuffle kernel.
+
+Reference = the old two-pass path that the kernel fuses:
+    scatter a1_scale_token_u8 -> a1_scale_raw (row-major grouped layout)
+    _grouped_a8w4_preshuffle_e8m0_scale(a1_scale_raw)
+Fused = flydsl_moe_scatter_preshuffle_scale (single kernel).
+
+The fused kernel writes EVERY output position exactly once (valid rows get the
+gathered scale, padding lanes get 0). The zero-init reference is likewise fully
+defined (its padding rows are 0, permuted to 0). So a full-tensor byte compare
+is valid regardless of how the output buffer was initialised -- which the
+`init` variants (zero / garbage / None) also assert.
+
+The matrix sweeps the kernel's whole geometry space:
+  * model_dim  -> Ws = model_dim//32 -> src_dwords (incl. odd 7168 -> Ws=224)
+  * warp_tile_m -> wmma_rep in {1,2,4,8} (8 exercises the dwordx4-chunked store)
+  * scale_k_per_tile in {4,8,16} (k_wmma_steps in {1,2,4})
+  * routing patterns: randperm / single-expert-skew / subset-skew, and shapes
+    from a single token up to many tiles, empty experts, full experts, E==1,
+    topk==E, prime sizes.
+"""
+
+import torch
+import pytest
+
+from aiter.ops.flydsl.grouped_moe_gfx1250 import (
+    _build_route_maps_naive,
+    _grouped_a8w4_preshuffle_e8m0_scale,
+)
+from aiter.ops.flydsl.moe_kernels import (
+    flydsl_moe_scatter_preshuffle_scale,
+    flydsl_moe_preshuffle_scale,
+)
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _make_topk_ids(pattern, token_num, topk, E, seed):
+    assert topk <= E, (topk, E)
+    g = torch.Generator().manual_seed(seed)
+    if pattern == "randperm":
+        rows = [torch.randperm(E, generator=g)[:topk] for _ in range(token_num)]
+    elif pattern == "single":
+        # every token hits the same `topk` experts -> those experts are full,
+        # the remaining E-topk experts are entirely padding.
+        fixed = torch.arange(topk)
+        rows = [fixed.clone() for _ in range(token_num)]
+    elif pattern == "skew":
+        # concentrate routes into a subset -> mixed full/partial/empty experts.
+        sub = min(E, max(topk, E // 3 if E >= 3 else E))
+        rows = [torch.randperm(sub, generator=g)[:topk] for _ in range(token_num)]
+    else:
+        raise ValueError(pattern)
+    return torch.stack(rows).to(torch.int32)
+
+
+def _padded_max_m(token_num, warp_tile_m):
+    raw = token_num  # production static upper bound (<=1 row/expert/token)
+    return max(warp_tile_m, ((raw + warp_tile_m - 1) // warp_tile_m) * warp_tile_m)
+
+
+def _reference(a1_scale_token_u8, rows_to_tokens, E, max_m, warp_tile_m, scale_k_per_tile):
+    device = a1_scale_token_u8.device
+    Ws = a1_scale_token_u8.shape[1]
+    a1_scale_raw = torch.zeros((E, max_m, Ws), dtype=torch.uint8, device=device)
+    rows = torch.nonzero(rows_to_tokens >= 0, as_tuple=False).squeeze(1)
+    toks = rows_to_tokens[rows].to(torch.long)
+    a1_scale_raw.view(E * max_m, Ws)[rows] = a1_scale_token_u8[toks]
+    return _grouped_a8w4_preshuffle_e8m0_scale(
+        a1_scale_raw, warp_tile=warp_tile_m, scale_k_per_tile=scale_k_per_tile
+    )
+
+
+def _run_case(model_dim, warp_tile_m, scale_k_per_tile, token_num, topk, E, pattern,
+              init="zero", seed=0):
+    device = "cuda"
+    Ws = model_dim // 32
+    wmma_rep = warp_tile_m // 16
+    max_m = _padded_max_m(token_num, warp_tile_m)
+
+    topk_ids = _make_topk_ids(pattern, token_num, topk, E, seed).to(device)
+    _, rows_to_tokens, _ = _build_route_maps_naive(topk_ids, E, max_m)
+
+    gen = torch.Generator(device=device).manual_seed(seed + 1)
+    a1_scale_token_u8 = torch.randint(
+        0, 256, (token_num, Ws), dtype=torch.uint8, device=device, generator=gen
+    )
+
+    ref = _reference(
+        a1_scale_token_u8, rows_to_tokens, E, max_m, warp_tile_m, scale_k_per_tile
+    )
+
+    out_shape = (E, max_m // wmma_rep, Ws * wmma_rep)
+    if init == "none":
+        out = None
+    elif init == "garbage":
+        out = torch.full(out_shape, 0xAA, dtype=torch.uint8, device=device)
+    else:
+        out = torch.zeros(out_shape, dtype=torch.uint8, device=device)
+
+    got = flydsl_moe_scatter_preshuffle_scale(
+        a1_scale_token_u8,
+        rows_to_tokens,
+        E,
+        max_m,
+        wmma_rep=wmma_rep,
+        scale_k_per_tile=scale_k_per_tile,
+        grouped_a1_scale=out,
+    )
+
+    assert got.shape == ref.shape, (got.shape, ref.shape)
+    ndiff = (got != ref).sum().item()
+    assert ndiff == 0, (
+        f"mismatch {ndiff}/{ref.numel()} bytes for "
+        f"model_dim={model_dim} warp_tile_m={warp_tile_m} skpt={scale_k_per_tile} "
+        f"tok={token_num} topk={topk} E={E} pat={pattern} init={init}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# generated matrix (>100 cases sweeping the full geometry + routing space)
+# --------------------------------------------------------------------------- #
+_MODEL_DIMS = [256, 512, 1024, 2048, 4096, 7168, 8192]
+_WARP_TILES = [16, 32, 64, 128]           # wmma_rep = 1, 2, 4, 8
+_SKPTS = [4, 8, 16]                        # k_wmma_steps = 1, 2, 4
+
+# (token_num, topk, E): single token, empty experts, full experts, primes, many tiles.
+_SHAPES = [
+    (1, 1, 1),
+    (1, 1, 8),
+    (1, 4, 8),
+    (2, 1, 1),
+    (3, 2, 8),
+    (7, 3, 5),
+    (16, 2, 8),
+    (31, 4, 16),
+    (64, 1, 4),
+    (64, 8, 32),
+    (128, 6, 64),
+    (200, 4, 32),
+    (257, 8, 128),   # prime-ish token_num, many tiles
+]
+_PATTERNS = ["randperm", "single", "skew"]
+
+
+def _gen_geometries():
+    geos = []
+    for md in _MODEL_DIMS:
+        Ws = md // 32
+        for wt in _WARP_TILES:
+            for sk in _SKPTS:
+                if Ws % sk != 0:        # scale_k_per_tile must divide Ws
+                    continue
+                geos.append((md, wt, sk))
+    return geos
+
+
+def _gen_configs():
+    geos = _gen_geometries()
+    cfgs = []
+    # Two (shape, pattern) draws per geometry -> broad coverage, compile reuse.
+    for gi, (md, wt, sk) in enumerate(geos):
+        for off in (0, 6):
+            shp = _SHAPES[(gi + off) % len(_SHAPES)]
+            pat = _PATTERNS[(gi + off) % len(_PATTERNS)]
+            cfgs.append((md, wt, sk, *shp, pat))
+    # Plus every (shape x pattern) at least once on a fixed mid geometry.
+    for shp in _SHAPES:
+        for pat in _PATTERNS:
+            cfgs.append((512, 64, 8, *shp, pat))
+    return cfgs
+
+
+_CONFIGS = _gen_configs()
+
+
+def test_matrix_has_enough_cases():
+    assert len(_CONFIGS) >= 100, f"only {len(_CONFIGS)} cases"
+
+
+@pytest.mark.parametrize("cfg", _CONFIGS, ids=lambda c: "_".join(map(str, c)))
+def test_scatter_preshuffle_scale_matrix(cfg):
+    if not torch.cuda.is_available():
+        pytest.skip("needs GPU")
+    md, wt, sk, tok, topk, E, pat = cfg
+    seed = (md + wt * 7 + sk * 13 + tok * 17 + topk * 19 + E * 23 + len(pat)) & 0xFFFF
+    _run_case(md, wt, sk, tok, topk, E, pat, init="zero", seed=seed)
+
+
+# --------------------------------------------------------------------------- #
+# explicit corner cases
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("init", ["zero", "garbage", "none"])
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        (256, 128, 8, 1, 1, 1, "single"),    # wmma_rep=8, single row, one expert
+        (512, 64, 8, 1, 1, 8, "randperm"),   # one token, mostly-empty experts
+        (7168, 64, 8, 200, 8, 64, "skew"),   # production-ish odd Ws=224
+        (1024, 32, 16, 257, 4, 32, "randperm"),  # k_wmma_steps=4, many tiles
+        (256, 16, 4, 128, 1, 4, "single"),   # wmma_rep=1 (scalar store), full expert
+    ],
+)
+def test_init_variants(cfg, init):
+    if not torch.cuda.is_available():
+        pytest.skip("needs GPU")
+    md, wt, sk, tok, topk, E, pat = cfg
+    _run_case(md, wt, sk, tok, topk, E, pat, init=init, seed=7)
+
+
+@pytest.mark.parametrize("cfg", _CONFIGS, ids=lambda c: "_".join(map(str, c)))
+def test_preshuffle_only_matrix(cfg):
+    """Gather-less preshuffle (stage2 path): source already grouped row-major.
+
+    Compared byte-exact against the torch ``_grouped_a8w4_preshuffle_e8m0_scale``.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("needs GPU")
+    md, wt, sk, tok, _topk, E, _pat = cfg
+    device = "cuda"
+    Ws = md // 32
+    wmma_rep = wt // 16
+    max_m = _padded_max_m(tok, wt)
+    seed = (md + wt * 7 + sk * 13 + tok * 17 + E * 23) & 0xFFFF
+
+    gen = torch.Generator(device=device).manual_seed(seed)
+    scale_raw = torch.randint(
+        0, 256, (E, max_m, Ws), dtype=torch.uint8, device=device, generator=gen
+    )
+
+    ref = _grouped_a8w4_preshuffle_e8m0_scale(
+        scale_raw, warp_tile=wt, scale_k_per_tile=sk
+    )
+    got = flydsl_moe_preshuffle_scale(
+        scale_raw, E, max_m, wmma_rep=wmma_rep, scale_k_per_tile=sk
+    )
+    ndiff = (got != ref).sum().item()
+    assert ndiff == 0, f"preshuffle-only mismatch {ndiff}/{ref.numel()} for {cfg}"
+
+
+def test_all_padding_block_is_zero():
+    """A wholly-empty expert must yield an all-zero output slice."""
+    if not torch.cuda.is_available():
+        pytest.skip("needs GPU")
+    # E=4 experts, every token -> expert 0 only: experts 1..3 are all padding.
+    _run_case(512, 64, 8, 32, 1, 4, "single", init="garbage", seed=3)
+
+
+if __name__ == "__main__":
+    import sys
+
+    print(f"generated {len(_CONFIGS)} matrix cases")
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Stage1: fuse the per-token e8m0 scale route-gather (scatter) with the WMMA preshuffle into one kernel (moe_scatter_copy_preshuffle_scale), dropping the intermediate a1_scale_raw buffer and the torch permute pass. One wave per row-tile loads the contiguous (wmma_rep, 4) block and issues a single dwordx{store_vw} store (chunked to <=dwordx4 so wmma_rep=8 works).

Stage2: a2_scale is already grouped row-major, so add a gather-less mode of the same kernel (flydsl_moe_preshuffle_scale) to replace the torch preshuffle at the a2 scale layout step. The gather flag is resolved in a plain build-time helper (_emit_preshuffle_dword), not inside the @flyc.kernel body, so the AST rewriter never turns it into device control flow.

Naive path keeps the torch _grouped_a8w4_preshuffle_e8m0_scale reference.

Tests: op_tests/test_moe_scatter_copy_preshuffle_scale.py -- 415 byte-exact cases vs the torch reference, sweeping model_dim/Ws, wmma_rep in {1,2,4,8}, scale_k_per_tile in {4,8,16}, routing patterns, init variants, and the gather-less preshuffle path.

test_flydsl_grouped_gemm_gfx1250.py: add --real-gemm flag; default mocks the grouped WMMA GEMM (no-op launcher) and routes fp4 quant through Triton so the tiny operators run end-to-end on non-gfx1250 archs (AITER_FORCE_GFX1250=1).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
