### PR TITLE
[pa_mqa_logits] Replace IS_GFX1250 bool constexpr with an ARCH string

### DIFF
--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -310,7 +310,7 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
     fn_signature["KVBlockSize"] = "constexpr"
     fn_signature["HiddenDim"] = "constexpr"
     fn_signature["CDNA_VERSION"] = "constexpr"
-    fn_signature["IS_GFX1250"] = "constexpr"
+    fn_signature["ARCH"] = "constexpr"
 
     effective_wave_per_eu = 1 if is_gfx1250 and not Preshuffle else WavePerEU
     options = {
@@ -355,7 +355,7 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
             "KVBlockSize": KVBlockSize,
             "HiddenDim": HiddenDim,
             "CDNA_VERSION": cdna_version,
-            "IS_GFX1250": is_gfx1250,
+            "ARCH": gfx_version,
         },
         attrs={
             (2,): [["tt.divisibility", 16]],  # heads_num
@@ -533,6 +533,7 @@ def deepgemm_fp8_paged_mqa_logits(
                 KVBlockSize,
                 hidden_dim,
                 cdna_version,
+                get_gfx(),
             )
         else:  #  load AOT compiled gluon kernel
             assert triton_version < Version(

--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -78,8 +78,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
     HiddenDim: tl.constexpr,
     KVBlockSize: tl.constexpr = 1,
     CDNA_VERSION: gl.constexpr = 3,
-    IS_GFX1250: gl.constexpr = False,
+    ARCH: gl.constexpr = "gfx942",
 ):
+    IS_GFX1250: gl.constexpr = ARCH == "gfx1250"
     pid = tl.program_id(0)
     num_block_q_head = tl.cdiv(heads_num, ChunkQ)
 
@@ -365,8 +366,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
     HiddenDim: tl.constexpr,
     KVBlockSize: tl.constexpr = 16,
     CDNA_VERSION: gl.constexpr = 3,
-    IS_GFX1250: gl.constexpr = False,
+    ARCH: gl.constexpr = "gfx942",
 ):
+    IS_GFX1250: gl.constexpr = ARCH == "gfx1250"
     # ===---------------------------------------------------
     # Gluon Layout
     # ===---------------------------------------------------
@@ -1345,7 +1347,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
     HiddenDim: tl.constexpr,
     KVBlockSize: tl.constexpr = 16,
     CDNA_VERSION: gl.constexpr = 3,
-    IS_GFX1250: gl.constexpr = False,
+    ARCH: gl.constexpr = "gfx942",
 ):
     # ===---------------------------------------------------
     # Gluon Layout


### PR DESCRIPTION
## Motivation

The gluon `pa_mqa_logits` kernels gated gfx1250-specific code paths on a boolean constexpr `IS_GFX1250`. This doesn't scale: every new architecture (e.g. gfx1200) would require adding yet another `IS_GFX1XXX` boolean parameter and threading it through the signature, the compile signature dict, and the launch site.

It also surfaced a concrete bug: the JIT (`triton >= 3.5.0`) launch path in `deepgemm_fp8_paged_mqa_logits` did not pass the trailing constexpr, so running the benchmark on gfx1250 errored due to a missing kernel argument:


## Changes

Replace the boolean `IS_GFX1250` constexpr with a single `ARCH` string constexpr that carries the gfx target verbatim:

- **`aiter/ops/triton/gluon/pa_mqa_logits.py`**: the three kernels now take`ARCH: gl.constexpr = "gfx942"` instead of `IS_GFX1250`. The two kernels that need the flag derive it locally with `IS_GFX1250: gl.constexpr = ARCH == "gfx1250"`; all internal branches are unchanged. The varctx kernel (which never used the flag) just renames the
  parameter.
- **`aiter/ops/triton/attention/pa_mqa_logits.py`**: the compile signature and constexpr dict pass `ARCH = gfx_version`, and the JIT launch site now passes `get_gfx()` as the trailing constexpr (fixing the missing argument).

Future archs only need a new string comparison inside the kernel (`ARCH == "gfx1200"`); no new parameter or signature change is required. This is also more precise than reusing `cdna_version`, whose `-1` is a catch-all ("not gfx942/gfx950") and cannot distinguish gfx1250 from a future gfx1200.

