### PR TITLE
Tune fused GEMM AFP4WFP4 A16W16 gfx950 config and add benchmark

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json
@@ -14,14 +14,14 @@
     "M_LEQ_16": {
         "BLOCK_SIZE_M": 8,
         "BLOCK_SIZE_N": 16,
-        "BLOCK_SIZE_K": 512,
+        "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 2,
         "num_stages": 2,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": null,
-        "NUM_KSPLIT": 8
+        "NUM_KSPLIT": 16
     },
     "M_LEQ_32": {
         "BLOCK_SIZE_M": 32,
@@ -38,10 +38,10 @@
     "M_LEQ_64": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 16,
-        "BLOCK_SIZE_K": 512,
+        "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 1,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg",
@@ -65,19 +65,19 @@
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 2,
+        "num_stages": 3,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": null,
-        "NUM_KSPLIT": 4
+        "NUM_KSPLIT": 1
     },
     "any": {
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 64,
-        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 8,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 3,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": null,

--- a/op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py
@@ -1,0 +1,254 @@
+import sys
+import torch
+import triton
+from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_a16w16 import (
+    fused_gemm_afp4wfp4_a16w16,
+)
+from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import (
+    generate_gemm_afp4wfp4_inputs,
+)
+from op_tests.triton_tests.gemm.basic.test_gemm_a16w16 import (
+    generate_gemm_a16w16_inputs,
+)
+from op_tests.op_benchmarks.triton.utils.argparse import (
+    get_parser,
+    add_argparse_ff,
+    get_ff_args,
+)
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    print_vgpr,
+    get_caller_name_no_ext,
+)
+
+
+def bench_fn(M: int, N4: int, N16: int, K: int, metric: str, **kwargs):
+    """
+    Single-shape timing of the fused AFP4WFP4 + A16W16 kernel via its public wrapper.
+
+    Scope (intentional): this benchmark exercises the **non-preshuffled, no-bias**
+    FP4 path (``is_fp4_preshuffled=False``, ``bias_fp4=None``, ``bias_bf16=None``),
+    which is the path that maps to the shape-scoped config
+    ``gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json``. It deliberately
+    does NOT cover the wrapper's default preshuffled path
+    (``is_fp4_preshuffled=True`` -> ``FUSED-GEMM-AFP4WFP4_PRESHUFFLED-A16W16``) nor
+    the biased BF16 gating variant.
+
+    Note on K: ``--shape`` K is the *logical* K (e.g. 7168). The FP4 generator packs
+    two e2m1 values per byte, so ``x_fp4`` has K//2 columns; the wrapper's
+    ``_get_config`` rebuilds the config filename with ``2*K`` (= logical K), so
+    passing 7168 here is what selects the shape-scoped config file. Passing the
+    packed value (3584) would fall back to the generic ``any`` config.
+
+    Output buffers are pre-allocated and passed in to keep allocation out of the
+    timed ``do_bench`` window.
+    """
+    c_dtype = torch.bfloat16
+
+    # FP4 branch (non-preshuffled). ``output=True`` pre-allocates ``y_fp4``. With
+    # shuffles off the ``_triton`` returns equal the plain ones; we pass the
+    # ``_triton`` set to mirror the test's wrapper call exactly.
+    (
+        x_fp4,
+        w_fp4,
+        w_fp4_triton,
+        x_fp4_scale,
+        w_fp4_scale,
+        x_fp4_scale_triton,
+        w_fp4_scale_triton,
+        _out_dtype,
+        y_fp4,
+    ) = generate_gemm_afp4wfp4_inputs(
+        M,
+        N4,
+        K,
+        c_dtype,
+        layout="TN",
+        output=True,
+        shuffle_scales_fg=False,
+        shuffle_weight_fg=False,
+    )
+    # BF16 branch inputs (N16 = N_bf16). Same M, same logical K, and no bias.
+    x_bf16, w_bf16, _, _, y_bf16 = generate_gemm_a16w16_inputs(
+        M,
+        N16,
+        K,
+        c_dtype,
+        output=True,
+        bias=False,
+    )
+    # flops
+    flops = 2.0 * M * (N4 + N16) * K  # summed across the two fused outputs
+    # memory transfer: numel * element_size() per tensor keeps the formula
+    # correct if dtypes change later (e.g. fp16 outputs).
+    mem = (
+        x_fp4.numel() * x_fp4.element_size()
+        + w_fp4_triton.numel() * w_fp4_triton.element_size()
+        + x_fp4_scale_triton.numel() * x_fp4_scale_triton.element_size()
+        + w_fp4_scale_triton.numel() * w_fp4_scale_triton.element_size()
+        + x_bf16.numel() * x_bf16.element_size()
+        + w_bf16.numel() * w_bf16.element_size()
+        + y_fp4.numel() * y_fp4.element_size()
+        + y_bf16.numel() * y_bf16.element_size()
+    )
+
+    ms = triton.testing.do_bench(
+        lambda: fused_gemm_afp4wfp4_a16w16(  # noqa: E731
+            x_fp4,
+            w_fp4_triton,
+            x_fp4_scale_triton,
+            w_fp4_scale_triton,
+            x_bf16,
+            w_bf16,
+            is_fp4_preshuffled=False,
+            dtype=c_dtype,
+            y_fp4=y_fp4,
+            y_bf16=y_bf16,
+        ),
+        warmup=25,
+        rep=100,
+    )
+
+    # Return exactly one scalar depending on which metric is active
+    if metric == "time":
+        return ms
+    elif metric == "throughput":
+        tflops = flops / ms * 1e-9
+        return tflops
+    elif metric == "bandwidth":
+        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
+        return bandwidth
+    else:
+        raise ValueError("Unknown metric: " + metric)
+
+
+def get_x_vals(args=None):
+    """Default (M, N4, N16, K) benchmarking shapes for the fused kernel.
+
+    Specialized to the single shape family this fused op is tuned for: the
+    ``gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168`` config. N4, N16
+    and K are fixed and only M is swept. As in the shared helper, ``-M`` selects
+    a single M.
+
+    The default M sweep hits every explicit bucket of that config
+    (M_LEQ_{8,16,32,64,128,256}) plus the ``any`` bucket sampled at
+    M in {1024, 4096, 8192}. (This config has no M_LEQ_1024/2048 buckets, so all
+    M > 256 resolve to ``any``.)
+    """
+    n4, n16, k = 512, 256, 7168
+    if args is not None and getattr(args, "M", None) is not None:
+        m_vals = [args.M]
+    else:
+        m_vals = [1, 8, 16, 32, 64, 128, 256, 1024, 4096, 8192]
+    return [(m, n4, n16, k) for m in m_vals]
+
+
+def get_shape_benchmark_object(plot_name, args, x_names=None):
+    """Build the Benchmark object for the (M, N4, N16, K) shape sweep.
+
+    There are two independent output-N dims (N4 for the FP4 branch, N16 for the
+    BF16 branch) sharing M and K, so a 4-element ``--shape`` is (M, N4, N16, K)
+    here, NOT the batched (B, M, N, K) that the shared helper / ``get_ff_args``
+    assume.
+    """
+    if x_names is None:
+        x_names = ["M", "N4", "N16", "K"]
+
+    if args.shape:
+        # enforce the fused 4-tuple here.
+        if len(args.shape) != 4:
+            raise ValueError(
+                f"--shape expects 4 ints (M N4 N16 K); "
+                f"got {len(args.shape)}: {args.shape}"
+            )
+        x_vals_list = [args.shape]
+    else:
+        x_vals_list = get_x_vals(args=args)
+
+    if args.metric == "time":
+        ylabel = "Time (ms)"
+    elif args.metric == "throughput":
+        ylabel = "Throughput (TFLOPS)"
+    elif args.metric == "bandwidth":
+        ylabel = "Bandwidth (GB/s)"
+    else:
+        raise NotImplementedError(f"{args.metric} is not supported")
+
+    evaluation_metric_to_unit = {
+        "throughput": "TFLOPS",
+        "time": "Time_(ms)",
+        "bandwidth": "Bandwidth_(GB/s)",
+    }
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names,
+        x_vals=x_vals_list,
+        x_log=True,
+        y_log=True,
+        line_arg="unit",
+        line_vals=[evaluation_metric_to_unit[args.metric]],
+        line_names=[evaluation_metric_to_unit[args.metric]],
+        styles=[("green", "-")],
+        ylabel=ylabel,
+        plot_name=plot_name,
+        args={"metric": args.metric},
+    )
+    return benchmark
+
+
+def run_shape_benchmark(args):
+    """Runs a benchmark with given tensor shapes."""
+    benchmark = get_shape_benchmark_object(get_caller_name_no_ext(), args)
+
+    @triton.testing.perf_report([benchmark])
+    def bench_fused_gemm_afp4wfp4_a16w16(M, N4, N16, K, metric, **kwargs):
+        return bench_fn(M, N4, N16, K, metric)
+
+    bench_fused_gemm_afp4wfp4_a16w16.run(
+        save_path="." if args.o else None, print_data=True
+    )
+
+
+def run_benchmark(args, defaults):
+    assert not (args.shape and args.model) or not (
+        args.shape and args.M
+    ), "User can specify --shape or --model MODEL -M VAL exclusively"
+
+    # --model has no meaning here: the op is tuned for one fixed shape family
+    # (N4=512, N16=256, K=7168), not model-derived hidden/intermediate dims.
+    if args.model:  # TODO: add in --model argument (via run_model_benchmark())
+        raise NotImplementedError(
+            "--model is not supported for fused_gemm_afp4wfp4_a16w16; "
+            "it targets a single fixed shape family (N4=512, N16=256, K=7168). "
+            "Use --shape M N4 N16 K or -M."
+        )
+    else:
+        unsupported_args = ["fc1", "fc2", "no_glu", "tp", "layout"]
+        for arg in unsupported_args:
+            if getattr(args, arg, None) != getattr(defaults, arg, None):
+                raise Exception(
+                    f"Argument '{arg}' is not supported for "
+                    f"fused_gemm_afp4wfp4_a16w16."
+                )
+        run_shape_benchmark(args)
+
+
+def parse_args(args: list[str] | None = None):
+    parser = get_parser(kernel_name="Fused AFP4WFP4 + A16W16 GEMM")
+    parser = add_argparse_ff(parser)
+    # get_ff_args destructures a 4-element --shape as (B, M, N, K); for this op
+    # --shape is (M, N4, N16, K), so the shape path reads args.shape directly
+    # and ignores that (B, M, N, K) mapping.
+    return get_ff_args(parser, args=args)
+
+
+def main(args: list[str] | None = None) -> None:
+    parsed_args, defaults = parse_args(args=args)
+    if parsed_args.print_vgpr:
+        print("Retrieving VGPR usage for Triton kernels...")
+        fun = lambda: run_benchmark(parsed_args, defaults)  # noqa: E731
+        print_vgpr(fun, get_caller_name_no_ext())
+        return
+    run_benchmark(parsed_args, defaults)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

This PR adds benchmark coverage and gfx950 tuning for the non-preshuffled `fused_gemm_afp4wfp4_a16w16` fused GEMM. The kernel already had a wrapper, kernel, test, and config coverage, but did not have a dedicated benchmark under aiter's `op_tests/op_benchmarks/triton". This made it difficult to compare Golden-vs-TOT (aka old compiler vs new compiler) performance workflow used for the other GEMM/fused GEMM kernels.

This benchmark intentionally targets the non-preshuffled, no-bias path:
```bash
is_fp4_preshuffled=False 
bias_fp4=None 
bias_bf16=None
```

This routes to the shape-scoped config family:
`FUSED-GEMM-AFP4WFP4-A16W16`
and specifically:
`gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json`
It does not cover the wrapper's default _preshuffled_ path:
`is_fp4_preshuffled=True`

which routes to the `_PRESHUFFLED` config family. That path can be benchmarked/tuned separately because it uses a broader generic config and any tuning changes would affect a wider range of shapes and workloads.

## Technical Details

This PR adds: `op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py`
and tunes: `aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json`

The benchmark follows the same structure as the fused [A8W8 blockscale + A16W16 benchmark](https://github.com/ROCm/aiter/pull/3568/changes#diff-9904b624807b08e3c6651012846bde8ee24e9c0087f9ef7a91e17a0a9af9e077):
```bash
bench_fn()
get_x_vals()
get_shape_benchmark_object()
run_shape_benchmark()
run_benchmark()
parse_args()
main()
```

The benchmark supports explicit shapes as `--shape M N4 N16 K`

where:
```bash
M   = token dimension
N4  = FP4 output dimension
N16 = BF16 output dimension
K   = logical K dimension
```

The default shape sweep is:
```bash
M in [1, 8, 16, 32, 64, 128, 256, 1024, 4096, 8192]
N4 = 512
N16 = 256
K = 7168
```

The `K` value is the logical K. The FP4 input generator packs two FP4 values per byte, so internally the FP4 packed dimension is `K // 2`. The config routing doubles the packed K back to the logical K when selecting the specialized config file. Therefore `--shape ... 7168` correctly routes to:
`gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json`

The benchmark uses the public wrapper:
`fused_gemm_afp4wfp4_a16w16(...)`

with:
`is_fp4_preshuffled=False`

The FP4 tensors are generated using:
`generate_gemm_afp4wfp4_inputs(...)`

and the benchmark passes the _triton tensor variants to mirror the unit test's wrapper call:
```bash
w_fp4_triton
x_fp4_scale_triton
w_fp4_scale_triton
```

The BF16 branch uses:
`generate_gemm_a16w16_inputs(..., bias=False)`

Outputs are preallocated and passed into the wrapper as:
```bash
y_fp4=y_fp4
y_bf16=y_bf16
```

This keeps final output allocation out of the timed benchmark region.

The benchmark supports:
```bash
--metric time
--metric throughput
--metric bandwidth
```

However, for our tuning decisions we use `rocprofv3` kernel time in microseconds, rather than the default `do_bench` convention.

The benchmark rejects unsupported model/FF-style arguments. This kernel has two output dimensions `(N4, N16)` and does not map cleanly to the existing model-shape schema, so `--model` is intentionally not supported in this first version.

### Config tuning

The shape-scoped config originally had regressions in 6 of 10 measured shapes under TOT (newest Triton compiler).

Regression rule used: 
`ignore if golden_us < 4.0; regression iff tot_us > 1.005 * golden_us + 0.5`

The original regressions were the following: `M=16, 64, 256, 1024, 4096, 8192` which maps to the following buckets:
```bash
M=16 -> M_LEQ_16 
M=64 -> M_LEQ_64 
M=256 -> M_LEQ_256 
M=1024/4096/8192 -> any
```

This PR tunes for those four buckets. Generic and preshuffled configs are not modified.

Summary of tuned config changes:
```bash
M_LEQ_16:
  BLOCK_SIZE_K: 512 -> 256
  NUM_KSPLIT: 8 -> 16

M_LEQ_64:
  BLOCK_SIZE_K: 512 -> 256
  num_stages: 1 -> 2

M_LEQ_256:
  num_stages: 2 -> 3
  NUM_KSPLIT: 4 -> 1

any:
  BLOCK_SIZE_K: 256 -> 128
  num_stages: 1 -> 3
```

Note: The tuning recovered **5 of the 6** original regressions. The remaining `M=256` regression improved significantly, but still does not meet the regression rule criteria.

`M=256` improved from `27.60 us -> 18.86 us`
but the threshold is: `16.28 us`
so it remains a residual regression.

The remaining `M=256` case appears to be a Triton 3.7 codegen regression for this specific shape rather than a config-only issue. Approximately 75 candidate configs were explored across `NUM_KSPLIT, BLOCK_SIZE_K, num_stages, BLOCK_SIZE_M, BLOCK_SIZE_N, num_warps, waves_per_eu, and matrix_instr_nonkdim`.

The best found candidate for `M_LEQ_256` was:
```bash
BLOCK_SIZE_M=16
BLOCK_SIZE_N=64
BLOCK_SIZE_K=256
GROUP_SIZE_M=1
num_warps=4
num_stages=3
waves_per_eu=2
matrix_instr_nonkdim=16
cache_modifier=null
NUM_KSPLIT=1
```

Async-copy diagnostics for this same config:
```bash
Golden Triton 3.4, async_copy=0: 15.30 us
TOT Triton 3.7, async_copy=0:    24.59 us
TOT Triton 3.7, async_copy=1:    18.77 us
```

This shows that async copy **helps** the TOT result, but does not close the full gap. With async copy disabled in both Golden and TOT, Triton 3.7 is still substantially slower than Triton 3.4 for this exact shape. This suggests the remaining `M=256` issue is compiler/codegen-limited rather than config-limited.

## Test Plan

### Benchmark smoke tests

Ran:
```bash
python op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py \
  --shape 64 512 256 7168 \
  --metric time
```

Running the default sweep: 
``bash
python op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py \ 
  --metric time
```

Example result after tuning: 
| M | N4 | N16 | K | Config bucket |
|---:|---:|---:|---:|---|
| 1 | 512 | 256 | 7168 | `M_LEQ_8` |
| 8 | 512 | 256 | 7168 | `M_LEQ_8` |
| 16 | 512 | 256 | 7168 | `M_LEQ_16` |
| 32 | 512 | 256 | 7168 | `M_LEQ_32` |
| 64 | 512 | 256 | 7168 | `M_LEQ_64` |
| 128 | 512 | 256 | 7168 | `M_LEQ_128` |
| 256 | 512 | 256 | 7168 | `M_LEQ_256` |
| 1024 | 512 | 256 | 7168 | `any` |
| 4096 | 512 | 256 | 7168 | `any` |
| 8192 | 512 | 256 | 7168 | `any` |

### Golden-vs-TOT performance validation

Golden environment:
```bash
repo: /workspace/repos/aiter-baseline (pre-async copy changes)
python: /workspace/venvs/golden/bin/python
TRITON_HIP_USE_ASYNC_COPY=0
```

TOT environment:
```bash
repo: /workspace/repos/aiter
python: /workspace/venvs/tot/bin/python
TRITON_HIP_USE_ASYNC_COPY=1
```

Performance was measured with `rocprofv3` kernel trace/stats. Each shape was run 3 times. If the initial 3 runs were not stable within 5%, the workflow escalated up to 5 runs and selected a stable pair when applicable.

Regression rule:
```bash
ignore if golden_us < 4.0
regression iff tot_us > 1.005 * golden_us + 0.5
Correctness validation
```

Ran the fused GEMM unit test with the tuned config:
```bash
TRITON_HIP_USE_ASYNC_COPY=1 \
PYTHONPATH=/workspace/repos/aiter \
TRITON_CACHE_DIR=/workspace/.triton/cache-tot \
/workspace/venvs/tot/bin/python -m pytest \
op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_a16w16.py -v
```
## Test Result

Static checks:
```bash
py_compile: pass
black --check: pass
ruff check: pass
```
Correctness (pyest):
```bash
1152 passed
0 failed
0 error
0 skipped
```

### Golden-vs-TOT performance result

Final tuned comparison:

| M | N4 | N16 | K | Golden us | TOT us | Delta us | Delta % | Threshold us | Status |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 1 | 512 | 256 | 7168 | 8.57 | 8.16 | -0.41 | -4.80% | 9.09 | `ok_or_improvement` |
| 8 | 512 | 256 | 7168 | 8.86 | 8.76 | -0.10 | -1.13% | 9.32 | `ok_or_improvement` |
| 16 | 512 | 256 | 7168 | 9.56 | 9.02 | -0.54 | -5.65% | 10.19 | `ok_or_improvement` |
| 32 | 512 | 256 | 7168 | 9.76 | 9.60 | -0.16 | -1.64% | 10.26 | `ok_or_improvement` |
| 64 | 512 | 256 | 7168 | 10.82 | 10.83 | 0.01 | 0.09% | 11.23 | `ok_or_improvement` |
| 128 | 512 | 256 | 7168 | 13.31 | 13.01 | -0.30 | -2.25% | 13.84 | `ok_or_improvement` |
| 256 | 512 | 256 | 7168 | 15.70 | 18.86 | 3.15 | 20.08% | 16.28 | `regression` |
| 1024 | 512 | 256 | 7168 | 50.27 | 41.01 | -9.26 | -18.42% | 51.05 | `ok_or_improvement` |
| 4096 | 512 | 256 | 7168 | 78.07 | 66.22 | -11.85 | -15.18% | 79.01 | `ok_or_improvement` |
| 8192 | 512 | 256 | 7168 | 126.90 | 127.92 | 1.02 | 0.80% | 129.89 | `ok_or_improvement` |

Summary:
- Original regressions: 6 of 10 shapes.
- Fixed regressions: 5 of 6.
- Remaining residual regression: M=256.
- No previously passing shape regressed.
- All large-M any bucket regressions recovered.
- M=256 improved from 27.60 us to 18.86 us, but still remains above the threshold of 16.28 us.

The remaining M=256 regression is documented as a likely Triton 3.7 codegen limitation for this shape. Config tuning significantly improved it, and async-copy helps, but the residual gap remains after an extensive config search. Follow-up investigation may include ATT trace analysis, Triton/LLVM IR inspection, and assembly-level profiling to determine whether additional kernel or compiler optimizations can further reduce the regression.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
