### PR TITLE
CI: map ATOM MI350X runner label

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -99,7 +99,7 @@ jobs:
 
           runner_overrides = {
               "atom-mi355-8gpu.predownload": "linux-aiter-mi35x-8",
-              "linux-atom-do-mi350x-8": "linux-aiter-mi35x-8",
+              "linux-atom-do-mi350x-8": "linux-aiter-do-mi350x-8",
               "linux-atom-mi35x-4": "linux-aiter-mi35x-4",
               "linux-atom-mi35x-1": "linux-aiter-mi35x-1",
           }

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -202,6 +202,7 @@ jobs:
     name: ${{ matrix.job_name }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include: ${{ fromJson(needs.load-atom-models.outputs.models_json) }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -99,6 +99,7 @@ jobs:
 
           runner_overrides = {
               "atom-mi355-8gpu.predownload": "linux-aiter-mi35x-8",
+              "linux-atom-do-mi350x-8": "linux-aiter-mi35x-8",
               "linux-atom-mi35x-4": "linux-aiter-mi35x-4",
               "linux-atom-mi35x-1": "linux-aiter-mi35x-1",
           }

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.select-sglang-tests.outputs.matrix) }}
 
     env:


### PR DESCRIPTION
## Summary
- Map the new ATOM MI350X 8-GPU runner label to the existing AITER MI35x 8-GPU runner pool.

## Test plan
- Trigger ATOM CI with the ci:atom label.