### PR TITLE
[Sampling] Fix HSA OOB in TopP/TopKTopPSamplingFromProbKernel

### DIFF
--- a/csrc/cpp_itfs/sampling/sampling.cuh
+++ b/csrc/cpp_itfs/sampling/sampling.cuh
@@ -1029,6 +1029,10 @@ __global__ void TopPSamplingFromProbKernel(DType* probs,
     do
     {
         temp_storage.sampled_id = d;
+        // Initialize last_valid_id: when no thread satisfies the predicate
+        // (e.g. NaN/all-zero row), max_valid stays -1 and the writer below is
+        // skipped, so the fallback would read uninitialized shared memory.
+        if (tx == 0) temp_storage.last_valid_id = 0;
         __syncthreads();
         float u   = hiprand_uniform(&state) * q;
         aggregate = 0;
@@ -1069,6 +1073,8 @@ __global__ void TopPSamplingFromProbKernel(DType* probs,
         {
             sampled_id = temp_storage.last_valid_id;
         }
+        // Defensive clamp: guarantee the index used below is in-range.
+        if (sampled_id < 0 || (uint32_t)sampled_id >= d) sampled_id = 0;
 
         float pivot_0_f = probs[row_idx * d + sampled_id];
         double pivot_0 = pivot_0_f;
@@ -1183,6 +1189,10 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs,
     do
     {
         temp_storage.sampled_id = d;
+        // Initialize last_valid_id: when no thread satisfies the predicate
+        // (e.g. NaN/all-zero row), max_valid stays -1 and the writer below is
+        // skipped, so the fallback would read uninitialized shared memory.
+        if (tx == 0) temp_storage.last_valid_id = 0;
         __syncthreads();
         float u   = hiprand_uniform(&state) * q;
         aggregate = 0;
@@ -1223,6 +1233,8 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs,
         {
             sampled_id = temp_storage.last_valid_id;
         }
+        // Defensive clamp: guarantee the index used below is in-range.
+        if (sampled_id < 0 || (uint32_t)sampled_id >= d) sampled_id = 0;
 
         float pivot_0_f = probs[row_idx * d + sampled_id];
         double pivot_0 = pivot_0_f;

--- a/op_tests/test_sampling.py
+++ b/op_tests/test_sampling.py
@@ -356,6 +356,84 @@ def test_top_k_top_p_statistical_distribution(batch_size, vocab_size, k, p):
             )
 
 
+# ---------------------------------------------------------------------------
+# Regression: HSA OOB caused by uninitialized `temp_storage.last_valid_id`.
+#
+# When every thread in a block fails the predicate `x > low` on the first
+# iteration of the kernel's do-while loop (e.g. an all-zero or all-NaN probs
+# row), `max_valid` from the BlockReduce is -1, so the guarded write
+# `temp_storage.last_valid_id = max_valid` is skipped.  The recovery path
+# `sampled_id = temp_storage.last_valid_id` then reads uninitialized shared
+# memory and the subsequent `probs[row_idx * d + sampled_id]` faults at a
+# page boundary.  Reproduced as a page-aligned `Memory access fault by GPU`
+# inside TopKTopPSamplingFromProbKernel on Qwen3.6-A3B-FP8 (vocab=248320).
+#
+# These tests must produce only in-range token ids (and not segfault) for
+# both kernels (TopP-only and joint TopK+TopP).
+# ---------------------------------------------------------------------------
+
+
+def _make_degenerate_probs(batch_size, vocab_size, mode):
+    """Build a probs tensor whose first row triggers the all-fail-predicate
+    path; remaining rows are valid normalized distributions.
+
+    "zero" / "nan" are the OOB-triggering rows: the predicate `x > low` is
+    satisfied by NO thread on the first iter (`0 > 0` / `NaN > 0` are both
+    false), so `max_valid` stays -1, the guarded write to `last_valid_id` is
+    skipped, and the unfixed kernel reads uninitialized smem -> OOB.
+    """
+    probs = torch.rand(batch_size, vocab_size, device="cuda")
+    probs = probs / probs.sum(dim=-1, keepdim=True)
+    if mode == "zero":
+        probs[0] = 0.0
+    elif mode == "nan":
+        probs[0] = float("nan")
+    else:
+        raise ValueError(mode)
+    return probs
+
+
+@pytest.mark.parametrize("batch_size", [1, 8])
+# Include 248320 (Qwen3.6 — original crash) and 128256 (Llama-3) which both
+# satisfy vocab %% (BLOCK_THREADS * VEC_SIZE) != 0, where the last block has
+# fewer active threads and the bug surfaces most reliably.
+@pytest.mark.parametrize("vocab_size", [32000, 128256, 248320])
+@pytest.mark.parametrize("mode", ["zero", "nan"])
+def test_top_p_sampling_degenerate_row(batch_size, vocab_size, mode):
+    """Regression: TopPSamplingFromProbKernel must not OOB on degenerate rows."""
+    probs = _make_degenerate_probs(batch_size, vocab_size, mode)
+    p = 0.95
+    for _ in range(50):
+        samples = torch.ops.aiter.top_p_sampling_from_probs(
+            probs, None, *_to_tensor_scalar_tuple(p), deterministic=True
+        )
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size), (
+            f"OOB id from TopPSamplingFromProbKernel "
+            f"(mode={mode}, vocab={vocab_size}): {samples.tolist()}"
+        )
+
+
+@pytest.mark.parametrize("batch_size", [1, 8])
+@pytest.mark.parametrize("vocab_size", [32000, 128256, 248320])
+@pytest.mark.parametrize("mode", ["zero", "nan"])
+@pytest.mark.parametrize("k,p", [(20, 0.95), (1, 1.0), (50, 0.5)])
+def test_top_k_top_p_sampling_degenerate_row(batch_size, vocab_size, mode, k, p):
+    """Regression: TopKTopPSamplingFromProbKernel must not OOB on degenerate rows."""
+    probs = _make_degenerate_probs(batch_size, vocab_size, mode)
+    for _ in range(50):
+        samples = torch.ops.aiter.top_k_top_p_sampling_from_probs(
+            probs,
+            None,
+            *_to_tensor_scalar_tuple(k),
+            *_to_tensor_scalar_tuple(p),
+            deterministic=True,
+        )
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size), (
+            f"OOB id from TopKTopPSamplingFromProbKernel "
+            f"(mode={mode}, vocab={vocab_size}, k={k}, p={p}): {samples.tolist()}"
+        )
+
+
 if __name__ == "__main__":
     test_top_k_top_p_joint_sampling_from_probs(40, 129280, 0.6, 20)
     # test_top_k_top_p_statistical_distribution(10, 10000, 5, 0.3)


### PR DESCRIPTION
## Motivation
VLLM Qwen3.6-35B-A3B-FP8 reproduce steps:
1. VLLM_ROCM_USE_AITER=1 vllm serve Qwen/Qwen3.6-35B-A3B-FP8 --tensor-parallel-size 1 --trust-remote-code --no-enable-prefix-caching --gpu-memory-utilization 0.9
2. vllm bench serve --backend vllm --num-prompts 20 --max-concurrency 4 --dataset-nam random --random-input-len 8192 --random-output-len 1024

crashed with "Memory access fault by GPU node-N",

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Root cause
----------
`SamplingTempStorage::last_valid_id` was never initialized. In each iteration of the rejection loop, `DeviceSamplingFromProb` computes a per-thread `thread_last_valid` and then reduces with `hipcub::Max()` into `max_valid`. The write-back `temp_storage.last_valid_id = max_valid` is guarded by `max_valid != -1`, so when no thread satisfies the predicate `x > low` (e.g. a numerically all-zero row, or NaN/Inf probs coming out of an upstream op), the field is left untouched. The fallback path `if (sampled_id == d) sampled_id = temp_storage.last_valid_id;` then reads uninitialized shared memory, and the subsequent
`probs[row_idx * d + sampled_id]` dereferences a garbage index and HSA-faults on a page boundary.

Under CUDA Graph capture the shared-memory residue becomes stable across replays, which is why the fault is deterministic in graph mode but only occasionally reproducible in eager mode.

A standalone reproducer that forces an all-zero or NaN probs row and replays the kernel under a CUDA Graph reliably triggers the fault on the unfixed kernel and passes on the fixed one.

Fix
---
1. Initialize `temp_storage.last_valid_id = 0` at the top of each loop iteration (before the `__syncthreads()` that fences the writer).
2. Defensive clamp on the loaded `sampled_id` before it indexes `probs`.

Both changes are applied to `TopPSamplingFromProbKernel` and `TopKTopPSamplingFromProbKernel`, which share the same pattern.

## Test Plan

Validation
----------
- Standalone reproducer (all-zero / NaN ): HSA fault on pre-fix, 0 OOB ids on post-fix.
- New parametrized regression tests in `op_tests/test_sampling.py` all PASS on the fixed kernel.
- End-to-end vLLM serve+bench on Qwen3.6-35B-A3B-FP8: previously crashed with "Memory access fault by GPU node-N", now completes 80/80 requests (163840 tokens) with no fault.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
