### PR TITLE
CI: Skip MI400-only PA decode ASM test

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -26,6 +26,7 @@ else
 fi
 
 skip_tests=(
+    "op_tests/test_pa_decode_bf16_asm.py" # MI400-only for now.
     "op_tests/multigpu_tests/test_dispatch_combine.py"
     "op_tests/multigpu_tests/test_communication.py"
     "op_tests/multigpu_tests/test_mori_all2all.py"


### PR DESCRIPTION
## Summary
- Skip `op_tests/test_pa_decode_bf16_asm.py` in the default aiter test script because it is currently MI400-only.

## Test plan
- `bash -n .github/scripts/aiter_test.sh`