### PR TITLE
Bump FlyDSL to 0.2.0.dev645

### DIFF
--- a/.github/requirements/triton-test.txt
+++ b/.github/requirements/triton-test.txt
@@ -8,7 +8,7 @@ pybind11==3.0.1
 ninja==1.11.1.4
 psutil
 packaging
-flydsl==0.2.0
+flydsl==0.2.0.dev645
 
 # Test deps.
 pandas==2.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "psutil",
     "ninja",
     "pandas",
-    "flydsl==0.2.0"
+    "flydsl==0.2.0.dev645"
 ]
 
 [tool.setuptools_scm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyyaml
 einops
 pybind11>=3.0.1
 ninja
-flydsl==0.2.0
+flydsl==0.2.0.dev645

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 OPT_COMPILER_CONFIG = os.path.join(this_dir, "aiter", "jit", "optCompilerConfig.json")
 PACKAGE_NAME = "amd-aiter"
 
-FLYDSL_VERSION = "flydsl==0.2.0"
+FLYDSL_VERSION = "flydsl==0.2.0.dev645"
 
 BUILD_TARGET = os.environ.get("BUILD_TARGET", "auto")
 PREBUILD_KERNELS = int(os.environ.get("PREBUILD_KERNELS", 0))


### PR DESCRIPTION
## Summary
Upgrade the pinned `flydsl` dependency from `0.2.0` to `0.2.0.dev645` across all version declarations.

## Changes
Updated the version pin in all four places it appears:
- `setup.py` — `FLYDSL_VERSION` constant (also drives the develop-mode auto-install and the build/runtime install requirement)
- `requirements.txt`
- `pyproject.toml` — `[build-system] requires`
- `.github/requirements/triton-test.txt` — CI triton-test deps

## Notes
- `aiter/ops/flydsl/__init__.py` keeps `_MIN_FLYDSL_VERSION = 0.1.8`; `0.2.0.dev645` satisfies that lower bound, so no change is needed there.

## Validation
- `pip install flydsl==0.2.0.dev645` resolves and installs from the index.
- With dev645 installed, the FlyDSL version gate passes (`__version__` base `0.2.0` ≥ `0.1.8`) and `flydsl` imports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)