### PR TITLE
flydsl: skip unsupported architectures instead of crashing at import

### DIFF
--- a/aiter/ops/flydsl/utils.py
+++ b/aiter/ops/flydsl/utils.py
@@ -68,5 +68,15 @@ def get_shared_memory_per_block(device=None, fallback_gfx: str = "") -> int:
     return _get_shared_memory_per_block_cached(device, fallback_gfx)
 
 
+@lru_cache(maxsize=1)
 def is_flydsl_available() -> bool:
-    return importlib.util.find_spec("flydsl") is not None
+    if importlib.util.find_spec("flydsl") is None:
+        return False
+    # flydsl only ships kernels for the architectures in its SMEM_CAPACITY_MAP.
+    # On other archs (e.g. gfx1100 / RDNA3) importing the kernel modules crashes
+    # during config registration, so report flydsl as unavailable there instead
+    # of failing the import.
+    from flydsl.runtime.device import get_rocm_arch
+    from flydsl.utils.smem_allocator import SMEM_CAPACITY_MAP
+
+    return get_rocm_arch() in SMEM_CAPACITY_MAP


### PR DESCRIPTION
is_flydsl_available() returned True whenever the flydsl package was installed, even on architectures flydsl ships no kernels for. On such archs (e.g. gfx1100 / RDNA3) importing aiter.ops.flydsl eagerly registers GEMM configs and dies with KeyError on flydsl's SMEM_CAPACITY_MAP lookup, taking down any flash_attn import on that GPU.

Gate availability on the live arch being present in flydsl's SMEM_CAPACITY_MAP, so flydsl is reported unavailable (and its kernels / tests are cleanly skipped) on unsupported archs.

Should fix https://github.com/ROCm/aiter/actions/runs/27307596614/job/80669630761?pr=3419 