### PR TITLE
fix(opus): guard gfx942 bf16ws splitk reduce

### DIFF
--- a/csrc/opus_gemm/codegen/gen_instances_gfx942.py
+++ b/csrc/opus_gemm/codegen/gen_instances_gfx942.py
@@ -111,6 +111,13 @@ EXACT_N_ROWBLOCK_REDUCE_CONFIGS = (
 
 def splitk_reduce_extra_forward_decls():
     return (
+        "template<int VEC_, int BLOCK_, typename D_OUT,\n"
+        "         bool HAS_BIAS_, typename D_BIAS_, bool HAS_OOB_>\n"
+        "__global__ void splitk_reduce_kernel_bf16ws_fallback(\n"
+        "    const opus_splitk_ws_handle* ws_handle, D_OUT* c_out,\n"
+        "    int split_k, int M, int N, int batch,\n"
+        "    int padded_M, int padded_N,\n"
+        "    const D_BIAS_* bias, int stride_bias_batch);\n"
         "template<int SPLIT_K, int N_VEC, int ROWS_PER_BLOCK, int VEC_,\n"
         "         typename D_WS, typename D_OUT, bool HAS_BIAS_, typename D_BIAS_>\n"
         "__global__ void splitk_reduce_kernel_exact_n_rowblock(\n"
@@ -123,6 +130,15 @@ def splitk_reduce_extra_forward_decls():
 
 def splitk_reduce_extra_device_instantiations():
     contents = "// Exact-N row-block reduce instantiations (BLOCK=N_VEC*ROWS)\n"
+    for out_type in ("__bf16", "float"):
+        contents += (
+            f"template __global__ void splitk_reduce_kernel_bf16ws_fallback<16, 64, {out_type}, true,  {out_type}, true>(\n"
+            f"    const opus_splitk_ws_handle*, {out_type}*, int, int, int, int, int, int,\n"
+            f"    const {out_type}*, int);\n"
+            f"template __global__ void splitk_reduce_kernel_bf16ws_fallback<16, 64, {out_type}, false, {out_type}, true>(\n"
+            f"    const opus_splitk_ws_handle*, {out_type}*, int, int, int, int, int, int,\n"
+            f"    const {out_type}*, int);\n"
+        )
     for vec, nvec, rows in EXACT_N_ROWBLOCK_REDUCE_CONFIGS:
         for sk in SPLITK_REDUCE_SUPPORTED_SPLITKS:
             for ws_type in ("float", "__bf16"):
@@ -240,8 +256,13 @@ using {k.name}_Traits = {traits_name}<{k.BLOCK_SIZE},
             if hasbias
             else f"\n{indent}            nullptr, 0);"
         )
+        reduce_kernel = (
+            "splitk_reduce_kernel_bf16ws_fallback"
+            if bf16ws
+            else "splitk_reduce_kernel_fallback"
+        )
         return (
-            f"{indent}splitk_reduce_kernel_fallback<REDUCE_VEC, REDUCE_BS, {dtype}, {hb}, {dtype}, true>\n"
+            f"{indent}{reduce_kernel}<REDUCE_VEC, REDUCE_BS, {dtype}, {hb}, {dtype}, true>\n"
             f"{indent}    <<<grid_reduce, block_reduce, 0, stream>>>(\n"
             f"{indent}        ws_handle_,\n"
             f"{indent}        reinterpret_cast<{dtype}*>(Y.data_ptr()),\n"
@@ -254,25 +275,37 @@ using {k.name}_Traits = {traits_name}<{k.BLOCK_SIZE},
     fp32_t = _baseline_call("float", True, "            ")
     fp32_f = _baseline_call("float", False, "            ")
     bf16_y_check = ""
-    bf16ws_reduce_check = ""
+    bf16ws_fallback_decl = ""
+    bf16ws_host_redirect = ""
     if bf16ws:
-        n_conditions = " || ".join(
+        fp32ws_name = k.name.replace("_bf16ws", "")
+        exact_reduce_shape_conditions = " ||\n        ".join(
             f"(N == {vec * nvec} && (M % {rows} == 0))"
             for vec, nvec, rows in EXACT_N_ROWBLOCK_REDUCE_CONFIGS
         )
-        sk_conditions = " || ".join(
-            f"split_k == {sk}" for sk in SPLITK_REDUCE_SUPPORTED_SPLITKS
-        )
+        bf16ws_fallback_decl = f"""
+#if !defined(__HIP_DEVICE_COMPILE__) && !defined(__HIPCC_RTC__)
+template <typename D_C>
+void {fp32ws_name}(
+    aiter_tensor_t &XQ,
+    aiter_tensor_t &WQ,
+    aiter_tensor_t &Y,
+    std::optional<aiter_tensor_t> bias,
+    int splitK);
+#endif
+"""
+        bf16ws_host_redirect = f"""
+    const bool bf16ws_exact_reduce_shape =
+        {exact_reduce_shape_conditions};
+    if (!bf16ws_exact_reduce_shape) {{
+        {fp32ws_name}<D_C>(XQ, WQ, Y, bias, splitK);
+        return;
+    }}
+"""
         bf16_y_check = (
             "    AITER_CHECK(Y.dtype() == AITER_DTYPE_bf16,\n"
             f'    "{err_label} bf16 workspace currently supports only bf16 Y");\n'
         )
-        bf16ws_reduce_check = f"""
-    AITER_CHECK(padded_N == N && ({n_conditions}),
-    "{err_label} bf16 workspace requires an exact-N row-block reduce shape");
-    AITER_CHECK({sk_conditions},
-    "{err_label} bf16 workspace requires an instantiated split_k");
-"""
     reduce_launch = f"""
     constexpr int REDUCE_VEC = 16;
     constexpr int REDUCE_BS  = 64;
@@ -314,6 +347,7 @@ using {k.name}_Traits = {traits_name}<{k.BLOCK_SIZE},
 #else
 #include "{pipeline_header}"
 #endif
+{bf16ws_fallback_decl}
 {traits_aliases}
 #if !defined(__HIP_DEVICE_COMPILE__) && !defined(__HIPCC_RTC__)
 template <typename D_C>
@@ -333,6 +367,7 @@ void
     int N = WQ.size(1);
     int K = XQ.size(2);
 
+{bf16ws_host_redirect}
 {bf16_y_check}
     AITER_CHECK(Y.dtype() == AITER_DTYPE_bf16
             || Y.dtype() == AITER_DTYPE_fp32,
@@ -418,7 +453,6 @@ void
     int num_tiles_n = (N + {k.B_N} - 1) / {k.B_N};
     int padded_M    = num_tiles_m * {k.B_M};
     int padded_N    = num_tiles_n * {k.B_N};
-{bf16ws_reduce_check}
 
     auto stream = aiter::getCurrentHIPStream();
     hipStreamCaptureStatus capture_status = hipStreamCaptureStatusNone;

--- a/csrc/opus_gemm/include/gfx942/splitk_reduce_gfx942.cuh
+++ b/csrc/opus_gemm/include/gfx942/splitk_reduce_gfx942.cuh
@@ -8,10 +8,10 @@
 #include "opus_gemm_traits_a16w16.cuh"  // opus_splitk_ws_handle
 #include <cstdint>
 
-template<int VEC_ = 16, int BLOCK_ = 64, typename D_OUT = __bf16,
-         bool HAS_BIAS_ = false, typename D_BIAS_ = D_OUT,
-         bool HAS_OOB_ = true>
-__global__ void splitk_reduce_kernel_fallback(
+template<int VEC_ = 16, int BLOCK_ = 64, typename D_WS = float,
+         typename D_OUT = __bf16, bool HAS_BIAS_ = false,
+         typename D_BIAS_ = D_OUT, bool HAS_OOB_ = true>
+__device__ __forceinline__ void splitk_reduce_kernel_fallback_body(
     const opus_splitk_ws_handle* __restrict__ ws_handle,
     D_OUT*       __restrict__ c_out,
     int split_k, int M, int N, int batch,
@@ -26,6 +26,8 @@ __global__ void splitk_reduce_kernel_fallback(
     constexpr bool HAS_BIAS = HAS_BIAS_;
     constexpr bool HAS_OOB = HAS_OOB_;
     using D_BIAS = D_BIAS_;
+    static_assert(sizeof(D_WS) == 2 || sizeof(D_WS) == 4,
+                  "splitk_reduce fallback supports fp32/bf16 workspace");
 
     constexpr int STEP = 16 / sizeof(D_OUT);
     static_assert(STEP * sizeof(D_OUT) == 16,
@@ -45,7 +47,7 @@ __global__ void splitk_reduce_kernel_fallback(
 
     const int b = bm_id / M;
     const int m = bm_id - b * M;
-    const float* workspace = reinterpret_cast<const float*>(ws_handle->ptr);
+    const D_WS* workspace = reinterpret_cast<const D_WS*>(ws_handle->ptr);
 
     opus::vector_t<float, VEC> bias_fp32;
     if constexpr (HAS_BIAS) {
@@ -68,7 +70,7 @@ __global__ void splitk_reduce_kernel_fallback(
     const long split_stride = (long)batch * padded_M * padded_N;
 
     auto g_ws = opus::make_gmem(workspace,
-                                (unsigned int)(split_stride * split_k * sizeof(float)));
+                                (unsigned int)(split_stride * split_k * sizeof(D_WS)));
 
     opus::vector_t<float, VEC> acc;
     #pragma unroll
@@ -76,11 +78,26 @@ __global__ void splitk_reduce_kernel_fallback(
 
     for (int s = 0; s < split_k; ++s) {
         int ws_idx = ws_row_base + (int)(s * split_stride);
-        #pragma unroll
-        for (int g = 0; g < VEC / 4; ++g) {
-            auto v4 = g_ws.template load<4>(ws_idx + g * 4);
+        if constexpr (sizeof(D_WS) == 2 && VEC % 8 == 0) {
             #pragma unroll
-            for (int j = 0; j < 4; ++j) acc[g * 4 + j] += v4[j];
+            for (int g = 0; g < VEC / 8; ++g) {
+                auto v8 = g_ws.template load<8>(ws_idx + g * 8);
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) {
+                    acc[g * 8 + j] += static_cast<float>(v8[j]);
+                }
+            }
+        } else {
+            static_assert(VEC % 4 == 0,
+                          "splitk_reduce fallback fp32 workspace needs VEC % 4 == 0");
+            #pragma unroll
+            for (int g = 0; g < VEC / 4; ++g) {
+                auto v4 = g_ws.template load<4>(ws_idx + g * 4);
+                #pragma unroll
+                for (int j = 0; j < 4; ++j) {
+                    acc[g * 4 + j] += static_cast<float>(v4[j]);
+                }
+            }
         }
     }
 
@@ -171,6 +188,36 @@ __global__ void splitk_reduce_kernel_fallback(
     // Non-gfx942 device pass: empty stub.
 #endif  // __gfx942__
 #endif  // __HIP_DEVICE_COMPILE__
+}
+
+template<int VEC_ = 16, int BLOCK_ = 64, typename D_OUT = __bf16,
+         bool HAS_BIAS_ = false, typename D_BIAS_ = D_OUT,
+         bool HAS_OOB_ = true>
+__global__ void splitk_reduce_kernel_fallback(
+    const opus_splitk_ws_handle* __restrict__ ws_handle,
+    D_OUT*       __restrict__ c_out,
+    int split_k, int M, int N, int batch,
+    int padded_M, int padded_N,
+    const D_BIAS_* __restrict__ bias,
+    int bias_stride_batch)
+{
+    splitk_reduce_kernel_fallback_body<VEC_, BLOCK_, float, D_OUT, HAS_BIAS_, D_BIAS_, HAS_OOB_>(
+        ws_handle, c_out, split_k, M, N, batch, padded_M, padded_N, bias, bias_stride_batch);
+}
+
+template<int VEC_ = 16, int BLOCK_ = 64, typename D_OUT = __bf16,
+         bool HAS_BIAS_ = false, typename D_BIAS_ = D_OUT,
+         bool HAS_OOB_ = true>
+__global__ void splitk_reduce_kernel_bf16ws_fallback(
+    const opus_splitk_ws_handle* __restrict__ ws_handle,
+    D_OUT*       __restrict__ c_out,
+    int split_k, int M, int N, int batch,
+    int padded_M, int padded_N,
+    const D_BIAS_* __restrict__ bias,
+    int bias_stride_batch)
+{
+    splitk_reduce_kernel_fallback_body<VEC_, BLOCK_, __bf16, D_OUT, HAS_BIAS_, D_BIAS_, HAS_OOB_>(
+        ws_handle, c_out, split_k, M, N, batch, padded_M, padded_N, bias, bias_stride_batch);
 }
 
 // Exact-N row-block fast path: static split_k unroll, no N tail/OOB.


### PR DESCRIPTION
 ## Motivation

  This PR fixes a gfx942 OPUS bf16-workspace splitK routing issue for padded-M GEMM shapes.

  The problematic case is when the high-level tuned GEMM lookup matches a padded-M config row but launches the
  OPUS kernel with the original, unpadded `M`. For example:

  - Actual shape: `M=511, N=256, K=4096`
  - `get_padded_m(...) -> 512`
  - Tuned DSV4 config row `512x256x4096` selects OPUS `kid=10210`
  - `kid=10210` uses the gfx942 bf16-workspace splitK path
  - Actual `M=511` does not satisfy the exact row-block reduce requirement for `N=256`

  Before this fix, that path could fail with:

  ```text
  a16w16_kbuf1_sk bf16 workspace requires an exact-N row-block reduce shape

  The goal is to keep the optimized gfx942 bf16-workspace path for exact supported shapes, while safely handling
  padded-M/non-exact runtime shapes without adding gfx942-specific routing logic to shared Python/public entry
  points.

  ## Technical Details

  The fix is intentionally scoped to gfx942-specific OPUS codegen/reduce code.

  Changed files:

  - csrc/opus_gemm/codegen/gen_instances_gfx942.py
  - csrc/opus_gemm/include/gfx942/splitk_reduce_gfx942.cuh

  Main changes:

  1. Add a gfx942-generated host-side guard for bf16-workspace splitK wrappers.

     For bf16ws kernels such as kid=10210, the generated gfx942 wrapper now checks whether the actual runtime (M,
     N) satisfies the exact row-block reduce shape supported by the bf16ws fast path.

     If the runtime shape is not exact-rowblock-compatible, the wrapper redirects to the corresponding fp32-
     workspace splitK sibling, for example:

     10210 bf16ws -> 10200 fp32 workspace

     This preserves the high-level tuned config selection while avoiding invalid exact-rowblock reduce launches
     for padded-M shapes.

  2. Generate the exact-rowblock condition from EXACT_N_ROWBLOCK_REDUCE_CONFIGS.

     The guard is generated from the existing gfx942 exact reduce configuration table instead of hard-coding shape
     rules separately.

  3. Keep public/shared routing files unchanged.

     This PR does not modify:
      - csrc/opus_gemm/gen_instances.py
      - aiter/ops/opus/gemm_op_a16w16.py
      - aiter/ops/opus/common.py

     The gfx942-specific behavior stays in gfx942 codegen/header paths.

  4. Add a gfx942-only bf16-workspace fallback reduce kernel.

     splitk_reduce_gfx942.cuh now factors the existing fallback reduce body by workspace dtype and adds:

     splitk_reduce_kernel_bf16ws_fallback

     The original fp32-workspace fallback kernel name/signature is preserved.

  Behavior after this PR:

  - Exact row-block bf16ws shapes still use the existing optimized bf16-workspace exact reduce path.
  - Non-exact runtime shapes that enter a bf16ws wrapper due to padded-M lookup are redirected to the fp32-
    workspace sibling path.

  - The fix remains gfx942-local and does not affect gfx950 OPUS code paths.

  ## Test Plan

  Validation was done inside the yifehuan_aiter docker environment.

  Formatting/checks:

  python3 -m ruff check csrc/opus_gemm/codegen/gen_instances_gfx942.py
  python3 -m black --check csrc/opus_gemm/codegen/gen_instances_gfx942.py
  git diff --check

  Codegen/JIT validation:

  AITER_REBUILD=1 PYTHONPATH=. \
  python3 /mnt/raid0/yifehuan/script/bf16ws_rowblock_repro/repro_tuned_gemm_padded_m_10210.py --expect pass

  Padded-M repro shape:

  actual_shape=(M=511, N=256, K=4096)
  get_padded_m gl0=512 gl1=512
  dsv4 padded row: M=512, N=256, K=4096
  runtime_config: lib=opus, kid=10210

  Exact-shape sanity:

  PYTHONPATH=. \
  python3 /mnt/raid0/yifehuan/script/bf16ws_rowblock_repro/repro_tuned_gemm_padded_m_10210.py \
    --m 512 --n 256 --k 4096 --expect pass

  ## Test Result

  Formatting/check results:

  ruff check: passed
  black --check: passed
  git diff --check: passed

  Padded-M repro result:

  actual_shape=(M=511, N=256, K=4096)
  runtime_config=lib=opus kid=10210
  gemm_a16w16 completed: err_ratio=0.000000 max_abs=0.500000
  result=expected_post_fix_pass

  This confirms the high-level tuned GEMM path can still select kid=10210, while the generated gfx942 wrapper
  safely redirects the non-exact runtime shape to the fp32-workspace sibling path.

  Exact-shape sanity result:

  actual_shape=(M=512, N=256, K=4096)
  runtime_config=lib=opus kid=10210
  gemm_a16w16 completed: err_ratio=0.010025 max_abs=2.000000
  result=expected_post_fix_pass

  This confirms the exact supported shape still runs through the bf16-workspace kid=10210 path.

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at
    https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.