### PR TITLE
Pass --targets to ck-tile generate.py for non-gfx9 hosts

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -12,6 +12,7 @@ from ..jit.utils.torch_guard import torch_compile_guard
 from ..jit.utils.mha_recipes import (
     compose_mha_fwd_variant_suffix_and_filter,
     get_mha_varlen_prebuild_variants_by_names,
+    _ck_targets_flag,
 )
 from ..utility import dtypes
 
@@ -96,7 +97,8 @@ def cmdGenFunc_mha_fwd(
 
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d fwd "
-        "--receipt 100 --filter {} --output_dir {{}}".format(filter),
+        "--receipt 100 --filter {} --output_dir {{}}".format(filter)
+        + _ck_targets_flag(),
     ]
     return {
         "md_name": md_name,
@@ -432,10 +434,12 @@ def cmdGenFunc_mha_varlen_fwd(
         blob_gen_cmd = [
             f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d fwd "
             "--receipt 200 --filter {} --output_dir {{}}".format('" "')
+            + _ck_targets_flag()
         ]
         blob_gen_cmd.append(
             f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d fwd_splitkv "
             "--receipt 200 --filter {} --output_dir {{}}".format(filter_fwd_splitkv)
+            + _ck_targets_flag()
         )
     return {
         "md_name": md_name,
@@ -724,7 +728,8 @@ def cmdGenFunc_mha_bwd(
 
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d bwd "
-        "--receipt 300 --filter {} --output_dir {{}}".format(filter),
+        "--receipt 300 --filter {} --output_dir {{}}".format(filter)
+        + _ck_targets_flag(),
         f"{AITER_META_DIR}/hsa/codegen.py -m fmha_v3_bwd --output_dir {{}}",
     ]
     return {
@@ -982,7 +987,8 @@ def cmdGenFunc_mha_varlen_bwd(
 
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d bwd "
-        "--receipt 400 --filter {} --output_dir {{}}".format(filter),
+        "--receipt 400 --filter {} --output_dir {{}}".format(filter)
+        + _ck_targets_flag(),
         f"{AITER_META_DIR}/hsa/codegen.py -m fmha_v3_bwd --output_dir {{}}",
     ]
     return {
@@ -1104,6 +1110,7 @@ def cmdGenFunc_mha_batch_prefill(
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d batch_prefill "
         "--receipt 200 --filter {} --output_dir {{}}".format(filter_fwd)
+        + _ck_targets_flag()
     ]
     return {
         "md_name": md_name,


### PR DESCRIPTION
## Motivation

ck-tile's generate.py defaults to `--targets` gfx9,gfx950 (see [example/ck_tile/01_fmha/generate.py](https://github.com/ROCm/composable_kernel/blob/develop/example/ck_tile/01_fmha/generate.py#L102-L107)). On non-gfx9 hosts (e.g. gfx1151), the generated blob contains no matching kernels, causing mha_fwd dispatch to return t < 0 and triggering:  `"invalid argument for fmha_fwd"`


## Solution Description

According to https://github.com/ROCm/aiter/pull/3330,  `_ck_targets_flag()` already exists in mha_recipes.py to return `--targets <arch>` for non-gfx9 hosts and `""` for gfx9. Add it to blob_gen_cmd in all five cmdGenFunc_mha_* functions:
  - cmdGenFunc_mha_fwd
  - cmdGenFunc_mha_varlen_fwd (pagedkv branch, both fwd and fwd_splitkv)
  - cmdGenFunc_mha_bwd
  - cmdGenFunc_mha_varlen_bwd
  - cmdGenFunc_mha_batch_prefill


