### PR TITLE
refactor: de-torch module_fused_qk_norm_mrope_cache_quant_shuffle

### DIFF
--- a/aiter/ops/fused_qk_norm_mrope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_mrope_cache_quant.py
@@ -6,7 +6,7 @@ from ..jit.core import compile_ops
 from typing import List, Optional
 
 
-@compile_ops("module_fused_qk_norm_mrope_cache_quant_shuffle")
+@compile_ops("module_fused_qk_norm_mrope_cache_quant_shuffle", develop=True)
 def fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(
     qkv: Tensor,
     qw: Tensor,

--- a/csrc/include/fused_qk_norm_mrope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_mrope_cache_quant.h
@@ -3,15 +3,16 @@
 
 #pragma once
 
-#include <torch/extension.h>
+#include "aiter_tensor.h"
+#include <cstdint>
+#include <optional>
+#include <vector>
 
-using namespace at;
-
-void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(Tensor& qkv,
-                                                    Tensor& qw,
-                                                    Tensor& kw,
-                                                    Tensor& cos_sin,
-                                                    Tensor& positions,
+void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
+                                                    aiter_tensor_t& qw,
+                                                    aiter_tensor_t& kw,
+                                                    aiter_tensor_t& cos_sin,
+                                                    aiter_tensor_t& positions,
                                                     int64_t num_tokens,
                                                     int64_t num_heads_q,
                                                     int64_t num_heads_k,
@@ -21,14 +22,14 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(Tensor& qkv,
                                                     std::vector<int64_t> mrope_section_,
                                                     bool is_interleaved,
                                                     double eps,
-                                                    Tensor& q_out,
-                                                    Tensor& k_cache,
-                                                    Tensor& v_cache,
-                                                    Tensor& slot_mapping,
-                                                    Tensor& per_tensor_k_scale,
-                                                    Tensor& per_tensor_v_scale,
-                                                    std::optional<Tensor> k_out,
-                                                    std::optional<Tensor> v_out,
+                                                    aiter_tensor_t& q_out,
+                                                    aiter_tensor_t& k_cache,
+                                                    aiter_tensor_t& v_cache,
+                                                    aiter_tensor_t& slot_mapping,
+                                                    aiter_tensor_t& per_tensor_k_scale,
+                                                    aiter_tensor_t& per_tensor_v_scale,
+                                                    std::optional<aiter_tensor_t> k_out,
+                                                    std::optional<aiter_tensor_t> v_out,
                                                     bool return_kv,
                                                     bool use_shuffle_layout,
                                                     int64_t block_size,

--- a/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
@@ -1,30 +1,13 @@
+#include "aiter_dispatch.h"
+#include "aiter_stream.h"
+#include "fused_qk_norm_mrope_cache_quant.h"
 #include "rope/rope_common.h"
 
-using namespace at;
-
-template <typename T>
-struct KernelElementType
-{
-    using type = T;
-};
-
-template <>
-struct KernelElementType<c10::Half>
-{
-    using type = __half;
-};
-
-template <>
-struct KernelElementType<c10::BFloat16>
-{
-    using type = hip_bfloat16;
-};
-
-void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(Tensor& qkv,
-                                                    Tensor& qw,
-                                                    Tensor& kw,
-                                                    Tensor& cos_sin,
-                                                    Tensor& positions,
+void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
+                                                    aiter_tensor_t& qw,
+                                                    aiter_tensor_t& kw,
+                                                    aiter_tensor_t& cos_sin,
+                                                    aiter_tensor_t& positions,
                                                     int64_t num_tokens,
                                                     int64_t num_heads_q,
                                                     int64_t num_heads_k,
@@ -34,166 +17,174 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(Tensor& qkv,
                                                     std::vector<int64_t> mrope_section_,
                                                     bool is_interleaved,
                                                     double eps,
-                                                    Tensor& q_out,
-                                                    Tensor& k_cache,
-                                                    Tensor& v_cache,
-                                                    Tensor& slot_mapping,
-                                                    Tensor& per_tensor_k_scale,
-                                                    Tensor& per_tensor_v_scale,
-                                                    std::optional<Tensor> k_out,
-                                                    std::optional<Tensor> v_out,
+                                                    aiter_tensor_t& q_out,
+                                                    aiter_tensor_t& k_cache,
+                                                    aiter_tensor_t& v_cache,
+                                                    aiter_tensor_t& slot_mapping,
+                                                    aiter_tensor_t& per_tensor_k_scale,
+                                                    aiter_tensor_t& per_tensor_v_scale,
+                                                    std::optional<aiter_tensor_t> k_out,
+                                                    std::optional<aiter_tensor_t> v_out,
                                                     bool return_kv,
                                                     bool use_shuffle_layout,
                                                     int64_t block_size,
                                                     int64_t x,
                                                     int64_t rotary_dim)
 {
-    TORCH_CHECK(mrope_section_.size() == 3);
-    TORCH_CHECK(qkv.is_contiguous() && qw.is_contiguous() && kw.is_contiguous() &&
+    AITER_CHECK(mrope_section_.size() == 3);
+    AITER_CHECK(qkv.is_contiguous() && qw.is_contiguous() && kw.is_contiguous() &&
                 cos_sin.is_contiguous());
-    TORCH_CHECK(k_cache.is_contiguous() && v_cache.is_contiguous() && slot_mapping.is_contiguous());
+    AITER_CHECK(k_cache.is_contiguous() && v_cache.is_contiguous() && slot_mapping.is_contiguous());
     std::array<int64_t, 3> mrope_section;
     mrope_section[0] = mrope_section_[0];
     mrope_section[1] = mrope_section_[1];
     mrope_section[2] = mrope_section_[2];
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(qkv));
-    auto stream         = c10::hip::getCurrentHIPStreamMasqueradingAsCUDA().stream();
-    auto pos_strides    = positions.strides();
-    auto kv_cache_dtype = k_cache.scalar_type();
-    auto qkv_dtype      = qkv.scalar_type();
-    TORCH_CHECK(pos_strides.size() == 2);
-    float per_tensor_k_scale_ = per_tensor_k_scale.item<float>();
-    float per_tensor_v_scale_ = per_tensor_v_scale.item<float>();
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kBFloat16, kHalf, qkv_dtype, "fused_qk_norm_mrope_3d_cache_pts_quant_shuffle", [&] {
-            using T = KernelElementType<scalar_t>::type;
+    HipDeviceGuard device_guard(qkv.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+    auto kv_cache_dtype      = k_cache.dtype();
+    auto qkv_dtype           = qkv.dtype();
+    AITER_CHECK(positions.dim() == 2);
+    int64_t positions_stride_0 = positions.stride(0);
+    int64_t positions_stride_1 = positions.stride(1);
+    float per_tensor_k_scale_  = *reinterpret_cast<float*>(per_tensor_k_scale.data_ptr());
+    float per_tensor_v_scale_  = *reinterpret_cast<float*>(per_tensor_v_scale.data_ptr());
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+        qkv_dtype, "fused_qk_norm_mrope_3d_cache_pts_quant_shuffle", [&] {
+            using T = scalar_t;
 
             if(kv_cache_dtype == qkv_dtype)
             {
                 T* k_out_ptr = (return_kv && k_out.has_value())
-                                   ? (T*)k_out.value().data_ptr<scalar_t>()
+                                   ? reinterpret_cast<T*>(k_out.value().data_ptr())
                                    : nullptr;
                 T* v_out_ptr = (return_kv && v_out.has_value())
-                                   ? (T*)v_out.value().data_ptr<scalar_t>()
+                                   ? reinterpret_cast<T*>(v_out.value().data_ptr())
                                    : nullptr;
-                mrope_utils::fused_mrope_rms_set_kv<T, 3, T>((T*)qkv.data_ptr<scalar_t>(),
-                                                             (T*)qw.data_ptr<scalar_t>(),
-                                                             (T*)kw.data_ptr<scalar_t>(),
-                                                             (T*)cos_sin.data_ptr<scalar_t>(),
-                                                             positions.data_ptr<int64_t>(),
-                                                             pos_strides[0],
-                                                             pos_strides[1],
-                                                             num_tokens,
-                                                             num_heads_q,
-                                                             num_heads_k,
-                                                             num_heads_v,
-                                                             head_size,
-                                                             is_neox_style,
-                                                             eps,
-                                                             mrope_section,
-                                                             is_interleaved,
-                                                             (T*)q_out.data_ptr<scalar_t>(),
-                                                             (T*)k_cache.data_ptr<scalar_t>(),
-                                                             (T*)v_cache.data_ptr<scalar_t>(),
-                                                             slot_mapping.data_ptr<int64_t>(),
-                                                             stream,
-                                                             per_tensor_k_scale_,
-                                                             per_tensor_v_scale_,
-                                                             k_out_ptr,
-                                                             v_out_ptr,
-                                                             use_shuffle_layout,
-                                                             block_size,
-                                                             x,
-                                                             rotary_dim);
+                mrope_utils::fused_mrope_rms_set_kv<T, 3, T>(
+                    reinterpret_cast<T*>(qkv.data_ptr()),
+                    reinterpret_cast<T*>(qw.data_ptr()),
+                    reinterpret_cast<T*>(kw.data_ptr()),
+                    reinterpret_cast<T*>(cos_sin.data_ptr()),
+                    reinterpret_cast<int64_t*>(positions.data_ptr()),
+                    positions_stride_0,
+                    positions_stride_1,
+                    num_tokens,
+                    num_heads_q,
+                    num_heads_k,
+                    num_heads_v,
+                    head_size,
+                    is_neox_style,
+                    eps,
+                    mrope_section,
+                    is_interleaved,
+                    reinterpret_cast<T*>(q_out.data_ptr()),
+                    reinterpret_cast<T*>(k_cache.data_ptr()),
+                    reinterpret_cast<T*>(v_cache.data_ptr()),
+                    reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),
+                    stream,
+                    per_tensor_k_scale_,
+                    per_tensor_v_scale_,
+                    k_out_ptr,
+                    v_out_ptr,
+                    use_shuffle_layout,
+                    block_size,
+                    x,
+                    rotary_dim);
             }
             else
             {
-                // Check if kv_cache_dtype is fp8e4m3fnuz or fp8e4m3fn
-                if(kv_cache_dtype == at::ScalarType::Float8_e4m3fnuz)
+                if(kv_cache_dtype == AITER_DTYPE_fp8)
                 {
-                    mrope_utils::fp8e4m3fnuz* k_out_fp8_ptr =
-                        (return_kv && k_out.has_value())
-                            ? (mrope_utils::fp8e4m3fnuz*)k_out.value().data_ptr()
-                            : nullptr;
-                    mrope_utils::fp8e4m3fnuz* v_out_fp8_ptr =
-                        (return_kv && v_out.has_value())
-                            ? (mrope_utils::fp8e4m3fnuz*)v_out.value().data_ptr()
-                            : nullptr;
-                    mrope_utils::fused_mrope_rms_set_kv<T, 3, mrope_utils::fp8e4m3fnuz>(
-                        (T*)qkv.data_ptr<scalar_t>(),
-                        (T*)qw.data_ptr<scalar_t>(),
-                        (T*)kw.data_ptr<scalar_t>(),
-                        (T*)cos_sin.data_ptr<scalar_t>(),
-                        positions.data_ptr<int64_t>(),
-                        pos_strides[0],
-                        pos_strides[1],
-                        num_tokens,
-                        num_heads_q,
-                        num_heads_k,
-                        num_heads_v,
-                        head_size,
-                        is_neox_style,
-                        eps,
-                        mrope_section,
-                        is_interleaved,
-                        (T*)q_out.data_ptr<scalar_t>(),
-                        (mrope_utils::fp8e4m3fnuz*)k_cache.data_ptr(),
-                        (mrope_utils::fp8e4m3fnuz*)v_cache.data_ptr(),
-                        slot_mapping.data_ptr<int64_t>(),
-                        stream,
-                        per_tensor_k_scale_,
-                        per_tensor_v_scale_,
-                        k_out_fp8_ptr,
-                        v_out_fp8_ptr,
-                        use_shuffle_layout,
-                        block_size,
-                        x,
-                        rotary_dim);
-                }
-                else if(kv_cache_dtype == at::ScalarType::Float8_e4m3fn)
-                {
-                    mrope_utils::fp8e4m3fn* k_out_fp8_ptr =
-                        (return_kv && k_out.has_value())
-                            ? (mrope_utils::fp8e4m3fn*)k_out.value().data_ptr()
-                            : nullptr;
-                    mrope_utils::fp8e4m3fn* v_out_fp8_ptr =
-                        (return_kv && v_out.has_value())
-                            ? (mrope_utils::fp8e4m3fn*)v_out.value().data_ptr()
-                            : nullptr;
-                    mrope_utils::fused_mrope_rms_set_kv<T, 3, mrope_utils::fp8e4m3fn>(
-                        (T*)qkv.data_ptr<scalar_t>(),
-                        (T*)qw.data_ptr<scalar_t>(),
-                        (T*)kw.data_ptr<scalar_t>(),
-                        (T*)cos_sin.data_ptr<scalar_t>(),
-                        positions.data_ptr<int64_t>(),
-                        pos_strides[0],
-                        pos_strides[1],
-                        num_tokens,
-                        num_heads_q,
-                        num_heads_k,
-                        num_heads_v,
-                        head_size,
-                        is_neox_style,
-                        eps,
-                        mrope_section,
-                        is_interleaved,
-                        (T*)q_out.data_ptr<scalar_t>(),
-                        (mrope_utils::fp8e4m3fn*)k_cache.data_ptr(),
-                        (mrope_utils::fp8e4m3fn*)v_cache.data_ptr(),
-                        slot_mapping.data_ptr<int64_t>(),
-                        stream,
-                        per_tensor_k_scale_,
-                        per_tensor_v_scale_,
-                        k_out_fp8_ptr,
-                        v_out_fp8_ptr,
-                        use_shuffle_layout,
-                        block_size,
-                        x,
-                        rotary_dim);
+                    if(is_fp8_ocp_arch())
+                    {
+                        mrope_utils::fp8e4m3fn* k_out_fp8_ptr =
+                            (return_kv && k_out.has_value())
+                                ? reinterpret_cast<mrope_utils::fp8e4m3fn*>(k_out.value().data_ptr())
+                                : nullptr;
+                        mrope_utils::fp8e4m3fn* v_out_fp8_ptr =
+                            (return_kv && v_out.has_value())
+                                ? reinterpret_cast<mrope_utils::fp8e4m3fn*>(v_out.value().data_ptr())
+                                : nullptr;
+                        mrope_utils::fused_mrope_rms_set_kv<T, 3, mrope_utils::fp8e4m3fn>(
+                            reinterpret_cast<T*>(qkv.data_ptr()),
+                            reinterpret_cast<T*>(qw.data_ptr()),
+                            reinterpret_cast<T*>(kw.data_ptr()),
+                            reinterpret_cast<T*>(cos_sin.data_ptr()),
+                            reinterpret_cast<int64_t*>(positions.data_ptr()),
+                            positions_stride_0,
+                            positions_stride_1,
+                            num_tokens,
+                            num_heads_q,
+                            num_heads_k,
+                            num_heads_v,
+                            head_size,
+                            is_neox_style,
+                            eps,
+                            mrope_section,
+                            is_interleaved,
+                            reinterpret_cast<T*>(q_out.data_ptr()),
+                            reinterpret_cast<mrope_utils::fp8e4m3fn*>(k_cache.data_ptr()),
+                            reinterpret_cast<mrope_utils::fp8e4m3fn*>(v_cache.data_ptr()),
+                            reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),
+                            stream,
+                            per_tensor_k_scale_,
+                            per_tensor_v_scale_,
+                            k_out_fp8_ptr,
+                            v_out_fp8_ptr,
+                            use_shuffle_layout,
+                            block_size,
+                            x,
+                            rotary_dim);
+                    }
+                    else
+                    {
+                        mrope_utils::fp8e4m3fnuz* k_out_fp8_ptr =
+                            (return_kv && k_out.has_value())
+                                ? reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(
+                                      k_out.value().data_ptr())
+                                : nullptr;
+                        mrope_utils::fp8e4m3fnuz* v_out_fp8_ptr =
+                            (return_kv && v_out.has_value())
+                                ? reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(
+                                      v_out.value().data_ptr())
+                                : nullptr;
+                        mrope_utils::fused_mrope_rms_set_kv<T, 3, mrope_utils::fp8e4m3fnuz>(
+                            reinterpret_cast<T*>(qkv.data_ptr()),
+                            reinterpret_cast<T*>(qw.data_ptr()),
+                            reinterpret_cast<T*>(kw.data_ptr()),
+                            reinterpret_cast<T*>(cos_sin.data_ptr()),
+                            reinterpret_cast<int64_t*>(positions.data_ptr()),
+                            positions_stride_0,
+                            positions_stride_1,
+                            num_tokens,
+                            num_heads_q,
+                            num_heads_k,
+                            num_heads_v,
+                            head_size,
+                            is_neox_style,
+                            eps,
+                            mrope_section,
+                            is_interleaved,
+                            reinterpret_cast<T*>(q_out.data_ptr()),
+                            reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(k_cache.data_ptr()),
+                            reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(v_cache.data_ptr()),
+                            reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),
+                            stream,
+                            per_tensor_k_scale_,
+                            per_tensor_v_scale_,
+                            k_out_fp8_ptr,
+                            v_out_fp8_ptr,
+                            use_shuffle_layout,
+                            block_size,
+                            x,
+                            rotary_dim);
+                    }
                 }
                 else
                 {
-                    TORCH_CHECK(false, "Unsupported KV cache dtype: ", kv_cache_dtype);
+                    AITER_CHECK(false,
+                                "Unsupported KV cache dtype: ",
+                                AiterDtype_to_str(kv_cache_dtype));
                 }
             }
         });

--- a/csrc/pybind/fused_qk_norm_mrope_cache_quant_pybind.cu
+++ b/csrc/pybind/fused_qk_norm_mrope_cache_quant_pybind.cu
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "aiter_stream.h"
 #include "fused_qk_norm_mrope_cache_quant.h"
 #include "rocm_ops.hpp"
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { FUSED_QKNORM_MROPE_CACHE_QUANT_PYBIND; }
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    FUSED_QKNORM_MROPE_CACHE_QUANT_PYBIND;
+}


### PR DESCRIPTION

Build-time impact (from-scratch JIT build, container, 2 runs each):
  torch (old):   56.43s / 56.18s  -> **avg 56.3s**
  de-torch:      47.41s / 46.88s  -> **avg 47.1s**
  **~9.2s faster (~16%),**
  Expected to improve further once rope_common.h is also de-torched.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
