### PR TITLE
[Triton] unified_attention: mask V load and output store by value head size

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
@@ -80,6 +80,8 @@ def kernel_unified_attention_2d(
     TILE_SIZE: tl.constexpr,  # int must be power of 2
     HEAD_SIZE: tl.constexpr,  # int
     HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
+    V_HEAD_SIZE: tl.constexpr,  # int, value head size (may differ from HEAD_SIZE)
+    V_HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
     USE_ALIBI_SLOPES: tl.constexpr,  # bool
     USE_QQ_BIAS: tl.constexpr,  # bool
     USE_SOFTCAP: tl.constexpr,  # bool
@@ -134,6 +136,7 @@ def kernel_unified_attention_2d(
 
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+    offs_vd = tl.arange(0, V_HEAD_SIZE_PADDED)
     offs_t = tl.arange(0, TILE_SIZE)
     query_pos = q_block_local_idx * BLOCK_Q + offs_m // num_queries_per_kv
 
@@ -153,6 +156,10 @@ def kernel_unified_attention_2d(
         dim_mask = offs_d < HEAD_SIZE
     else:
         dim_mask = tl.full((1,), 1, dtype=tl.int1)
+    if V_HEAD_SIZE_PADDED != V_HEAD_SIZE:
+        v_dim_mask = offs_vd < V_HEAD_SIZE
+    else:
+        v_dim_mask = tl.full((1,), 1, dtype=tl.int1)
     query_mask_0 = query_pos < cur_batch_query_len
     query_mask_1 = query_offset_1 < num_query_heads
 
@@ -184,7 +191,7 @@ def kernel_unified_attention_2d(
         )
 
     L = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
-    acc = tl.zeros([BLOCK_M, HEAD_SIZE_PADDED], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, V_HEAD_SIZE_PADDED], dtype=tl.float32)
 
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
@@ -291,10 +298,10 @@ def kernel_unified_attention_2d(
             v_offset = (
                 physical_block_idx[:, None] * stride_v_cache_0
                 + kv_head_idx * stride_v_cache_2
-                + offs_d[None, :] * stride_v_cache_3
+                + offs_vd[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_mask = (offs_d < stride_v_cache_2)[None, :] & tile_mask[:, None]
+            v_mask = v_dim_mask[None, :] & tile_mask[:, None]
 
             k_offset = (
                 physical_block_idx[None, :] * stride_k_cache_0
@@ -427,15 +434,13 @@ def kernel_unified_attention_2d(
     output_offset = (
         query_offset_0[:, None] * output_stride_0
         + query_offset_1[:, None] * output_stride_1
-        + offs_d[None, :]
+        + offs_vd[None, :]
     )
 
     tl.store(
         output_ptr + output_offset,
         acc,
-        mask=(offs_d < output_stride_1)[None, :]
-        & query_mask_0[:, None]
-        & query_mask_1[:, None],
+        mask=v_dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
     )
 
 
@@ -489,6 +494,8 @@ def kernel_unified_attention_3d(
     TILE_SIZE: tl.constexpr,  # int, must be power of 2
     HEAD_SIZE: tl.constexpr,  # int
     HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
+    V_HEAD_SIZE: tl.constexpr,  # int, value head size (may differ from HEAD_SIZE)
+    V_HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
     USE_ALIBI_SLOPES: tl.constexpr,  # bool
     USE_QQ_BIAS: tl.constexpr,  # bool
     USE_SOFTCAP: tl.constexpr,  # bool
@@ -558,6 +565,7 @@ def kernel_unified_attention_3d(
 
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+    offs_vd = tl.arange(0, V_HEAD_SIZE_PADDED)
     offs_t = tl.arange(0, TILE_SIZE)
 
     offs_shfl = None
@@ -578,6 +586,10 @@ def kernel_unified_attention_3d(
         dim_mask = offs_d < HEAD_SIZE
     else:
         dim_mask = tl.full((1,), 1, dtype=tl.int1)
+    if V_HEAD_SIZE_PADDED != V_HEAD_SIZE:
+        v_dim_mask = offs_vd < V_HEAD_SIZE
+    else:
+        v_dim_mask = tl.full((1,), 1, dtype=tl.int1)
     query_mask_0 = query_pos < cur_batch_query_len
     query_mask_1 = query_offset_1 < num_query_heads
 
@@ -607,7 +619,7 @@ def kernel_unified_attention_3d(
         M = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
 
     L = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
-    acc = tl.zeros([BLOCK_M, HEAD_SIZE_PADDED], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, V_HEAD_SIZE_PADDED], dtype=tl.float32)
 
     # context length for this particular sequences
     context_len = seq_len - cur_batch_query_len
@@ -699,10 +711,10 @@ def kernel_unified_attention_3d(
             v_offset = (
                 physical_block_idx[:, None] * stride_v_cache_0
                 + kv_head_idx * stride_v_cache_2
-                + offs_d[None, :] * stride_v_cache_3
+                + offs_vd[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_mask = (offs_d < stride_v_cache_2)[None, :] & tile_mask[:, None]
+            v_mask = v_dim_mask[None, :] & tile_mask[:, None]
 
             k_offset = (
                 physical_block_idx[None, :] * stride_k_cache_0
@@ -827,15 +839,15 @@ def kernel_unified_attention_3d(
 
     segm_output_offset = (
         query_offset_0[:, None].to(tl.int64)
-        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + query_offset_1[:, None] * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + segm_idx * HEAD_SIZE_PADDED
-        + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
+        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * V_HEAD_SIZE_PADDED)
+        + query_offset_1[:, None] * (NUM_SEGMENTS_PER_SEQ * V_HEAD_SIZE_PADDED)
+        + segm_idx * V_HEAD_SIZE_PADDED
+        + offs_vd[None, :]
     )
     tl.store(
         segm_output_ptr + segm_output_offset,
         acc,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
+        mask=v_dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
     )
     if NUM_SEGMENTS_PER_SEQ > 1:
         segm_offset = (
@@ -875,6 +887,8 @@ def reduce_segments(
     TILE_SIZE: tl.constexpr,  # int
     HEAD_SIZE: tl.constexpr,  # int, must be power of 2
     HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
+    V_HEAD_SIZE: tl.constexpr,  # int, value head size (may differ from HEAD_SIZE)
+    V_HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
     query_start_len_ptr,  # [num_seqs+1]
     BLOCK_Q: tl.constexpr,  # int
     NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
@@ -905,11 +919,11 @@ def reduce_segments(
         [NUM_SEGMENTS_PER_SEQ], act_num_segments, dtype=tl.int32
     )
 
-    if HEAD_SIZE_PADDED != HEAD_SIZE:
-        offs_d = tl.arange(0, HEAD_SIZE_PADDED)
-        dim_mask = offs_d < HEAD_SIZE
+    offs_vd = tl.arange(0, V_HEAD_SIZE_PADDED)
+    if V_HEAD_SIZE_PADDED != V_HEAD_SIZE:
+        v_dim_mask = offs_vd < V_HEAD_SIZE
     else:
-        dim_mask = tl.full((1,), 1, dtype=tl.int1)
+        v_dim_mask = tl.full((1,), 1, dtype=tl.int1)
 
     # load segment maxima
     segm_offset = (
@@ -928,14 +942,14 @@ def reduce_segments(
     # load, rescale, and add segment attention outputs
     segm_output_offset = (
         query_token_idx.to(tl.int64)
-        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + query_head_idx * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
-        + tl.arange(0, NUM_SEGMENTS_PER_SEQ)[:, None] * HEAD_SIZE_PADDED
-        + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
+        * (num_query_heads * NUM_SEGMENTS_PER_SEQ * V_HEAD_SIZE_PADDED)
+        + query_head_idx * (NUM_SEGMENTS_PER_SEQ * V_HEAD_SIZE_PADDED)
+        + tl.arange(0, NUM_SEGMENTS_PER_SEQ)[:, None] * V_HEAD_SIZE_PADDED
+        + offs_vd[None, :]
     )
     segm_output = tl.load(
         segm_output_ptr + segm_output_offset,
-        mask=segm_mask[:, None] & dim_mask[None, :],
+        mask=segm_mask[:, None] & v_dim_mask[None, :],
         other=0.0,
     )
     segm_output *= tl.math.exp2(segm_max - overall_max)[:, None]
@@ -951,12 +965,10 @@ def reduce_segments(
 
     # write result
     output_offset = (
-        query_token_idx * output_stride_0
-        + query_head_idx * output_stride_1
-        + tl.arange(0, HEAD_SIZE_PADDED)
+        query_token_idx * output_stride_0 + query_head_idx * output_stride_1 + offs_vd
     )
     tl.store(
         output_ptr + output_offset,
         acc.to(output_ptr.type.element_ty),
-        mask=tl.arange(0, HEAD_SIZE_PADDED) < output_stride_1,
+        mask=v_dim_mask,
     )

--- a/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
@@ -294,7 +294,7 @@ def kernel_unified_attention_2d(
                 + offs_d[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_mask = dim_mask[None, :] & tile_mask[:, None]
+            v_mask = (offs_d < stride_v_cache_2)[None, :] & tile_mask[:, None]
 
             k_offset = (
                 physical_block_idx[None, :] * stride_k_cache_0
@@ -433,7 +433,9 @@ def kernel_unified_attention_2d(
     tl.store(
         output_ptr + output_offset,
         acc,
-        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
+        mask=(offs_d < output_stride_1)[None, :]
+        & query_mask_0[:, None]
+        & query_mask_1[:, None],
     )
 
 
@@ -700,7 +702,7 @@ def kernel_unified_attention_3d(
                 + offs_d[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_mask = dim_mask[None, :] & tile_mask[:, None]
+            v_mask = (offs_d < stride_v_cache_2)[None, :] & tile_mask[:, None]
 
             k_offset = (
                 physical_block_idx[None, :] * stride_k_cache_0
@@ -954,5 +956,7 @@ def reduce_segments(
         + tl.arange(0, HEAD_SIZE_PADDED)
     )
     tl.store(
-        output_ptr + output_offset, acc.to(output_ptr.type.element_ty), mask=dim_mask
+        output_ptr + output_offset,
+        acc.to(output_ptr.type.element_ty),
+        mask=tl.arange(0, HEAD_SIZE_PADDED) < output_stride_1,
     )

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -345,6 +345,15 @@ def unified_attention(
         K_WIDTH = 16 if kv_cache_dtype == e4m3_dtype else 8
         SCALE_K_WIDTH = 4
 
+    # value head size can differ from the query/key head size (e.g. MiMo: qk=192,
+    # v=128). The shuffled / packed layouts only support symmetric heads, so fall
+    # back to head_size there and read the value width from the plain cache layout.
+    if shuffled_kv_cache or q_dtype == torch.uint8:
+        v_head_size = head_size
+    else:
+        v_head_size = v.shape[-1]
+    V_HEAD_SIZE_PADDED = triton.next_power_of_2(v_head_size)
+
     num_seqs = len(seqused_k)
     num_queries_per_kv = num_query_heads // num_kv_heads
 
@@ -461,6 +470,8 @@ def unified_attention(
                 BLOCK_SIZE=block_size,
                 HEAD_SIZE=head_size,
                 HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
+                V_HEAD_SIZE=v_head_size,
+                V_HEAD_SIZE_PADDED=V_HEAD_SIZE_PADDED,
                 USE_ALIBI_SLOPES=use_alibi_slopes,
                 USE_QQ_BIAS=use_qq_bias,
                 USE_SOFTCAP=(softcap > 0),
@@ -503,7 +514,7 @@ def unified_attention(
                 q.shape[0],
                 num_query_heads,
                 NUM_SEGMENTS,
-                triton.next_power_of_2(head_size),
+                V_HEAD_SIZE_PADDED,
                 dtype=torch.float32,
                 device=q.device,
             )
@@ -626,6 +637,8 @@ def unified_attention(
                 BLOCK_SIZE=block_size,
                 HEAD_SIZE=head_size,
                 HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
+                V_HEAD_SIZE=v_head_size,
+                V_HEAD_SIZE_PADDED=V_HEAD_SIZE_PADDED,
                 USE_ALIBI_SLOPES=use_alibi_slopes,
                 USE_QQ_BIAS=use_qq_bias,
                 USE_SOFTCAP=(softcap > 0),
@@ -705,6 +718,8 @@ def unified_attention(
             block_table_stride=block_table.stride(0),
             HEAD_SIZE=head_size,
             HEAD_SIZE_PADDED=head_size_padded,
+            V_HEAD_SIZE=v_head_size,
+            V_HEAD_SIZE_PADDED=V_HEAD_SIZE_PADDED,
             query_start_len_ptr=cu_seqlens_q,
             BLOCK_Q=BLOCK_Q,
             **reduce_config,

--- a/op_tests/triton_tests/attention/test_unified_attention.py
+++ b/op_tests/triton_tests/attention/test_unified_attention.py
@@ -143,6 +143,7 @@ def generate_data(
     num_blocks=32768,
     block_size=32,
     head_size=64,
+    v_head_size=None,
     num_heads=(16, 2),
     sliding_window=None,
     q_dtype=torch.bfloat16,
@@ -161,6 +162,8 @@ def generate_data(
     num_query_heads = num_heads[0]
     num_kv_heads = num_heads[1]
     assert num_query_heads % num_kv_heads == 0
+    if v_head_size is None:
+        v_head_size = head_size
     max_query_len = max(query_lens)
     max_kv_len = max(kv_lens)
     if sliding_window is not None and sliding_window > 0:
@@ -203,7 +206,14 @@ def generate_data(
         dtype=torch.float32,
         device=device,
     )
-    value_cache = torch.randn_like(key_cache)
+    value_cache = torch.randn(
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        v_head_size,
+        dtype=torch.float32,
+        device=device,
+    )
     if kv_dtype == torch.uint8:
         # NVFP4 KV cache: kernel consumes packed+shuffled cache, reference uses e4m3.
         key_cache_orig = key_cache.to(e4m3_dtype)
@@ -236,7 +246,7 @@ def generate_data(
     sinks = torch.randn(num_query_heads, dtype=torch.float32, device=device)
 
     output = torch.empty(
-        sum(query_lens), num_query_heads, head_size, dtype=out_dtype, device=device
+        sum(query_lens), num_query_heads, v_head_size, dtype=out_dtype, device=device
     )
 
     # ---- descales / output scale ----
@@ -305,6 +315,7 @@ def ref_paged_attn(
     num_seqs = len(query_lens)
     block_tables = block_tables.cpu().numpy()
     _, block_size, num_kv_heads, head_size = key_cache.shape
+    v_head_size = value_cache.shape[-1]
     outputs: list[torch.Tensor] = []
     start_idx = 0
     query = query.to(torch.float32)
@@ -327,7 +338,7 @@ def ref_paged_attn(
 
         k = key_cache[block_indices].view(-1, num_kv_heads, head_size)
         k = k[:kv_len]
-        v = value_cache[block_indices].view(-1, num_kv_heads, head_size)
+        v = value_cache[block_indices].view(-1, num_kv_heads, v_head_size)
         v = v[:kv_len]
 
         if q.shape[1] != k.shape[1]:
@@ -706,3 +717,115 @@ def test_triton_unified_attn(
         torch.testing.assert_close(
             output, ref_output, atol=atol, rtol=rtol
         ), f"{torch.max(torch.abs(output - ref_output))}"
+
+
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [(1, 1328)],
+        [(1, 523), (1, 37), (1, 2011)],
+        [(256, 256)],
+        [(1, 137), (5, 1024), (1, 19)],
+    ],
+)
+@pytest.mark.parametrize("num_heads", [(64, 8), (8, 1)])
+@pytest.mark.parametrize(
+    "head_size, v_head_size",
+    [
+        # MiMo decode: qk head wider than the value head
+        (192, 128),
+        # symmetric, must stay identical to the single-mask path
+        (128, 128),
+        # value head wider than qk, the reverse ordering
+        (128, 192),
+    ],
+)
+@pytest.mark.parametrize("block_size", [16, 64])
+@torch.inference_mode()
+def test_triton_unified_attn_asym_head(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    v_head_size: int,
+    block_size: int,
+) -> None:
+    torch.manual_seed(0)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens_list = [x[1] for x in seq_lens]
+
+    (
+        query,
+        key_cache_orig,
+        value_cache_orig,
+        key_cache,
+        value_cache,
+        sinks,
+        output,
+        cu_query_lens,
+        kv_lens,
+        max_query_len,
+        max_kv_len,
+        scale,
+        window_size,
+        block_tables,
+        _maybe_quant_query,
+        _query_scales,
+        q_descale,
+        k_descale,
+        v_descale,
+        output_scale,
+    ) = generate_data(
+        seq_lens=seq_lens,
+        block_size=block_size,
+        head_size=head_size,
+        v_head_size=v_head_size,
+        num_heads=num_heads,
+        device="cuda",
+    )
+
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=output,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=scale,
+        causal=True,
+        window_size=window_size,
+        block_table=block_tables,
+        softcap=0,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        sinks=sinks,
+        output_scale=output_scale,
+    )
+
+    ref_output = ref_paged_attn(
+        query=query,
+        key_cache=key_cache_orig,
+        value_cache=value_cache_orig,
+        query_lens=query_lens,
+        kv_lens=kv_lens_list,
+        block_tables=block_tables,
+        scale=scale,
+        out_dtype=torch.bfloat16,
+        sinks=sinks,
+    )
+
+    atol, rtol = 1.5e-2, 1e-2
+    tol_err_ratio = 0.01
+    assert (
+        checkAllclose(
+            output.to(torch.bfloat16),
+            ref_output.to(torch.bfloat16),
+            atol=atol,
+            rtol=rtol,
+            tol_err_ratio=tol_err_ratio,
+            msg=f"unified_attn asym head qk={head_size} v={v_head_size}",
+        )
+        <= tol_err_ratio
+    )


### PR DESCRIPTION
`unified_attention` sizes everything off `HEAD_SIZE = q.shape[-1]` and reuses one `dim_mask = offs_d < HEAD_SIZE` for the Q load, the K load, the V load and the output store. That's fine when the qk and v head dims match, but asymmetric-head models (MiMo: qk=192, v=128) have a V cache and an output whose per-head width is the value head size, not `HEAD_SIZE`.

With the single 192-wide mask:
- the V load reads `offs_d` 0..191 out of a 128-wide head, so it spills into the next kv-head and, on the last head, past the buffer;
- the output store writes 0..191 into a row whose per-head stride is 128, so each head clobbers the first 64 dims of the next one and the last head writes past the output buffer.

On MiMo decode that shows up as garbled logits at low concurrency and a `hipErrorIllegalAddress` (worker death) under concurrency from the last-head out-of-bounds store. Prefill is unaffected; this is decode-only.

The fix masks the V load by the V cache head stride (`stride_v_cache_2`) and the output store by the output per-head stride (`output_stride_1`), both already passed into the kernels. Four masks across the 2d and 3d kernels plus `reduce_segments`, no signature or launcher change. For symmetric models `HEAD_SIZE`, `stride_v_cache_2` and `output_stride_1` are all equal, so it's a no-op.

Validated live on MI300X (gfx942), TP=8, decode path (`--decode-attention-backend aiter`, eager), patch applied in-image:
- GSM8K, full 1319-question 5-shot: strict-match 0.9515, flexible-extract 0.9522, 0 generation errors. The triton backend baseline on the same harness is 0.9424; unpatched aiter produced garbage and scored ~0.625 on a 40-q subset.
- conc-1: coherent on control prompts (was `,#,###,#`-style garbage before).
- conc-64 burst (192 requests): 192 ok / 0 errors, no illegal-address or HIP-error hits in the serve log. Unpatched, workers died with `hipErrorIllegalAddress` under the same load.

One note for reviewers: using the stride as a stand-in for the value head size is correct for the contiguous KV-cache and output views the caller passes, but it reads as a dependency on the caller's layout. A cleaner form would be an explicit `VALUE_HEAD_SIZE: tl.constexpr` (mirroring `HEAD_SIZE`), plumbed from `v.shape[-1]` and defaulting to `HEAD_SIZE` so existing callers stay byte-identical. Happy to respin it that way if preferred; this PR is the minimal in-place fix we validated.
