### PR TITLE
[fused_moe] Opt-in fused stage1 activation-quant kernel selection

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -990,9 +990,7 @@ def _get_proven_fp4_stage1(tune_file):
                     if kn.startswith("flydsl_moe1") and kn.endswith("_fp4"):
                         result.add(kn)
     except Exception as e:  # pragma: no cover - defensive
-        logger.warning(
-            f"[fused_moe] could not collect fused-quant stage1 kernels: {e}"
-        )
+        logger.warning(f"[fused_moe] could not collect fused-quant stage1 kernels: {e}")
     _proven_fp4_stage1_cache[tune_file] = result
     return result
 
@@ -1041,9 +1039,7 @@ def _maybe_fuse_stage1_quant(kernelName1, q_dtype_a, tune_file, token=None):
         candidates.append(f"{kernelName1[: -len('_bnt0')]}_fp4")
     for cand in candidates:
         if cand in proven:
-            logger.info(
-                f"[fused_moe] AITER_FUSE_STAGE1_QUANT: {kernelName1} -> {cand}"
-            )
+            logger.info(f"[fused_moe] AITER_FUSE_STAGE1_QUANT: {kernelName1} -> {cand}")
             return cand
     return kernelName1
 

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -969,6 +969,85 @@ def _flydsl_stage2_wrapper(
     )
 
 
+_proven_fp4_stage1_cache = {}
+
+
+def _get_proven_fp4_stage1(tune_file):
+    """FlyDSL stage1 kernels with a fused activation-quant (``_fp4``) epilogue
+    that ship in the merged tuned config. Membership here means the kernel's
+    codegen is AMD-validated/known-good, so it is safe to JIT-compile on demand.
+    """
+    if tune_file in _proven_fp4_stage1_cache:
+        return _proven_fp4_stage1_cache[tune_file]
+    result = set()
+    try:
+        import pandas as pd
+
+        if os.path.exists(tune_file):
+            df = pd.read_csv(tune_file)
+            if "kernelName1" in df.columns:
+                for kn in df["kernelName1"].dropna().astype(str):
+                    if kn.startswith("flydsl_moe1") and kn.endswith("_fp4"):
+                        result.add(kn)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(
+            f"[fused_moe] could not collect fused-quant stage1 kernels: {e}"
+        )
+    _proven_fp4_stage1_cache[tune_file] = result
+    return result
+
+
+def _maybe_fuse_stage1_quant(kernelName1, q_dtype_a, tune_file, token=None):
+    """Opt-in upgrade of a FlyDSL stage1 kernel to its fused-quant sibling.
+
+    The fused stage1 kernel writes fp4 activations + sorted e8m0 scales directly
+    from the gate/up GEMM epilogue, which lets fused_moe skip the standalone
+    inter-stage activation-quant kernel (dynamic_mxfp4 quant + moe_sort).
+
+    Gated by ``AITER_FUSE_STAGE1_QUANT`` (default off) so default behavior is
+    unchanged. Only swaps to a kernel that ships in a tuned config, and falls
+    back silently to the original kernel when no proven fused sibling exists.
+
+    The fused epilogue (quant+sort+swizzle) carries a fixed per-launch cost that
+    is a larger fraction of a tiny GEMM, so at small token tiers it can run
+    slightly slower than the standalone split path. ``AITER_FUSE_STAGE1_MIN_TOKENS``
+    (default 0 = no gate, i.e. behavior unchanged) restricts the upgrade to
+    ``token >= threshold`` so the win is kept at large-M decode and the small-M
+    tail is left on the stock kernel. ``token`` is the padded per-local-expert
+    M tier (1,2,..,512,1024,2048,4096,..) used for the kernel-config lookup.
+    """
+    try:
+        _enabled = int(os.environ.get("AITER_FUSE_STAGE1_QUANT", "0"))
+    except ValueError:
+        _enabled = 0
+    if not _enabled:
+        return kernelName1
+    try:
+        _min_tokens = int(os.environ.get("AITER_FUSE_STAGE1_MIN_TOKENS", "0"))
+    except ValueError:
+        _min_tokens = 0
+    if _min_tokens > 0 and token is not None and token < _min_tokens:
+        return kernelName1
+    if q_dtype_a != dtypes.fp4x2:
+        return kernelName1
+    if not kernelName1.startswith("flydsl_moe1") or kernelName1.endswith("_fp4"):
+        return kernelName1
+    proven = _get_proven_fp4_stage1(tune_file)
+    if not proven:
+        return kernelName1
+    candidates = [f"{kernelName1}_fp4"]
+    if kernelName1.endswith("_bnt0"):
+        # The fused variants are not tuned with the b-non-temporal flag; drop it.
+        candidates.append(f"{kernelName1[: -len('_bnt0')]}_fp4")
+    for cand in candidates:
+        if cand in proven:
+            logger.info(
+                f"[fused_moe] AITER_FUSE_STAGE1_QUANT: {kernelName1} -> {cand}"
+            )
+            return cand
+    return kernelName1
+
+
 @functools.lru_cache(maxsize=2048)
 def get_2stage_cfgs(
     token,
@@ -1299,6 +1378,10 @@ def get_2stage_cfgs(
         enable_bias = (
             _needs_swiglu_bias_support(dtype, q_type) and q_dtype_w == dtypes.fp4x2
         )
+        if is_flydsl1:
+            kernelName1 = _maybe_fuse_stage1_quant(
+                kernelName1, q_dtype_a, tune_file, token=token
+            )
         _s1_fp4q = is_flydsl1 and "_fp4" in kernelName1.split("_t")[-1]
         if is_flydsl1:
             stage1_func = functools.partial(

--- a/op_tests/test_fused_stage1_quant.py
+++ b/op_tests/test_fused_stage1_quant.py
@@ -82,9 +82,7 @@ class TestFuseStage1Quant(unittest.TestCase):
         kn = "flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w2"
         f = self._csv([kn + "_fp4"])
         with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
-            self.assertEqual(
-                _maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn + "_fp4"
-            )
+            self.assertEqual(_maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn + "_fp4")
 
     def test_flag_on_drops_bnt0_suffix(self):
         base = "flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w2"

--- a/op_tests/test_fused_stage1_quant.py
+++ b/op_tests/test_fused_stage1_quant.py
@@ -1,0 +1,157 @@
+"""Unit tests for the opt-in fused stage1 activation-quant kernel selection.
+
+Covers ``_maybe_fuse_stage1_quant`` / ``_get_proven_fp4_stage1`` in
+``aiter.fused_moe``. These exercise the pure kernel-name selection logic
+(CSV-backed proven-sibling lookup + env gating) and require no GPU.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from aiter import dtypes
+import aiter.fused_moe as fm
+from aiter.fused_moe import _get_proven_fp4_stage1, _maybe_fuse_stage1_quant
+
+
+def _write_csv(rows):
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    with os.fdopen(fd, "w") as f:
+        f.write("kernelName1\n")
+        for r in rows:
+            f.write(r + "\n")
+    return path
+
+
+class TestFuseStage1Quant(unittest.TestCase):
+    def setUp(self):
+        # Cache is keyed by tune_file path; clear so each test sees fresh state.
+        fm._proven_fp4_stage1_cache.clear()
+        self._files = []
+
+    def tearDown(self):
+        for p in self._files:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+    def _csv(self, rows):
+        p = _write_csv(rows)
+        self._files.append(p)
+        return p
+
+    # ---- _get_proven_fp4_stage1 --------------------------------------------
+
+    def test_get_proven_collects_only_fp4_stage1(self):
+        f = self._csv(
+            [
+                "flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w2_fp4",  # kept
+                "flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w2_bnt0",  # not _fp4
+                "flydsl_moe2_afp4_wfp4_bf16_atomic_persist_fp4",  # moe2, not moe1
+                "cktile_moe1_something_fp4",  # not flydsl_moe1
+            ]
+        )
+        self.assertEqual(
+            _get_proven_fp4_stage1(f),
+            {"flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w2_fp4"},
+        )
+
+    def test_get_proven_is_cached(self):
+        f = self._csv(["flydsl_moe1_x_fp4"])
+        first = _get_proven_fp4_stage1(f)
+        self.assertIn(f, fm._proven_fp4_stage1_cache)
+        # Mutating the file after caching must not change the cached result.
+        with open(f, "a") as fh:
+            fh.write("flydsl_moe1_y_fp4\n")
+        self.assertEqual(_get_proven_fp4_stage1(f), first)
+
+    def test_get_proven_missing_file_is_empty(self):
+        self.assertEqual(_get_proven_fp4_stage1("/no/such/tune_file.csv"), set())
+
+    # ---- _maybe_fuse_stage1_quant gating -----------------------------------
+
+    def test_flag_off_is_noop(self):
+        kn = "flydsl_moe1_a_t64"
+        f = self._csv([kn + "_fp4"])
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "0"}):
+            self.assertEqual(_maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn)
+
+    def test_flag_on_upgrades_when_proven(self):
+        kn = "flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w2"
+        f = self._csv([kn + "_fp4"])
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
+            self.assertEqual(
+                _maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn + "_fp4"
+            )
+
+    def test_flag_on_drops_bnt0_suffix(self):
+        base = "flydsl_moe1_afp4_wfp4_bf16_t64x128x256_w2"
+        kn = base + "_bnt0"
+        f = self._csv([base + "_fp4"])  # fused variant tuned without _bnt0
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
+            self.assertEqual(
+                _maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), base + "_fp4"
+            )
+
+    def test_no_proven_sibling_unchanged(self):
+        kn = "flydsl_moe1_a_t64"
+        f = self._csv(["flydsl_moe1_other_t64_fp4"])  # different kernel
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
+            self.assertEqual(_maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn)
+
+    def test_empty_tune_file_unchanged(self):
+        kn = "flydsl_moe1_a_t64"
+        f = self._csv([])
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
+            self.assertEqual(_maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn)
+
+    def test_non_fp4_activation_dtype_unchanged(self):
+        kn = "flydsl_moe1_a_t64"
+        f = self._csv([kn + "_fp4"])
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
+            self.assertEqual(_maybe_fuse_stage1_quant(kn, dtypes.bf16, f), kn)
+
+    def test_already_fused_unchanged(self):
+        kn = "flydsl_moe1_a_t64_fp4"
+        f = self._csv([kn])
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
+            self.assertEqual(_maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn)
+
+    def test_non_flydsl_moe1_kernel_unchanged(self):
+        kn = "cktile_moe1_a_t64"
+        f = self._csv(["flydsl_moe1_a_t64_fp4"])
+        with mock.patch.dict(os.environ, {"AITER_FUSE_STAGE1_QUANT": "1"}):
+            self.assertEqual(_maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f), kn)
+
+    def test_min_tokens_gate(self):
+        kn = "flydsl_moe1_a_t64"
+        f = self._csv([kn + "_fp4"])
+        with mock.patch.dict(
+            os.environ,
+            {"AITER_FUSE_STAGE1_QUANT": "1", "AITER_FUSE_STAGE1_MIN_TOKENS": "256"},
+        ):
+            # Below threshold: keep stock kernel (small-M tail).
+            self.assertEqual(
+                _maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f, token=128), kn
+            )
+            # At/above threshold: upgrade to fused-quant sibling.
+            self.assertEqual(
+                _maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f, token=256), kn + "_fp4"
+            )
+
+    def test_min_tokens_zero_means_no_gate(self):
+        kn = "flydsl_moe1_a_t64"
+        f = self._csv([kn + "_fp4"])
+        with mock.patch.dict(
+            os.environ,
+            {"AITER_FUSE_STAGE1_QUANT": "1", "AITER_FUSE_STAGE1_MIN_TOKENS": "0"},
+        ):
+            self.assertEqual(
+                _maybe_fuse_stage1_quant(kn, dtypes.fp4x2, f, token=1), kn + "_fp4"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds AITER_FUSE_STAGE1_QUANT (default off): when a FlyDSL stage1 gate/up GEMM has a proven fused-quant (`_fp4`) sibling in the merged tuned config, swap to it so fused_moe can skip the standalone inter-stage activation-quant kernel (dynamic_mxfp4 quant + moe_sort).

## Motivation
On the FlyDSL 2-stage MoE path, the stage1 gate/up GEMM and the inter-stage activation quantization run as separate kernels: stage1 produces bf16 activations, then a standalone dynamic_mxfp4 quant + moe_sort pass converts them to fp4 with sorted e8m0 scales before stage2. Some FlyDSL stage1 kernels have a fused-quant (_fp4) sibling that emits the fp4 activations and sorted scales directly from the GEMM epilogue, which lets fused_moe skip that standalone quant/sort kernel entirely — a useful launch-latency win in decode where the MoE is latency-bound.

This PR adds an opt-in mechanism to select that fused-quant stage1 kernel when a tuned, validated variant is available, with safe fallbacks so default behavior is unchanged.

## Technical Details

Gated by AITER_FUSE_STAGE1_QUANT (default 0 = off), so behavior is identical to today unless explicitly enabled.

_get_proven_fp4_stage1(tune_file): collects the set of flydsl_moe1*_fp4 kernels that ship in the merged tuned config CSV. Membership means the kernel's codegen is AMD-validated/known-good, so it is safe to JIT-compile on demand. Result is cached per tune-file path.
_maybe_fuse_stage1_quant(kernelName1, q_dtype_a, tune_file, token): upgrades a stage1 kernel name to its _fp4 sibling only when all of the following hold — flag enabled, activation dtype is fp4x2, the kernel is a flydsl_moe1 kernel and not already fused, and a proven sibling exists. The _bnt0 (b-non-temporal) suffix is dropped before lookup because the fused variants are not tuned with that flag. Any miss returns the original kernel name unchanged.
AITER_FUSE_STAGE1_MIN_TOKENS (default 0 = no gate): the fused epilogue (quant+sort+swizzle) carries a fixed per-launch cost that is a larger fraction of a tiny GEMM, so at small token tiers it can be slightly slower. This optional threshold restricts the upgrade to token >= threshold, keeping the win at large-M decode and leaving the small-M tail on the stock split path.
Call site: hooked into the FlyDSL 2-stage selection in get_2stage_cfgs, immediately before stage1_func is bound, so the chosen kernel name flows through unchanged into the existing stage1 wrapper.
The selection logic is pure kernel-name/string handling driven by the tuned CSV — it does not change numerics or kernel codegen, only which (already-tuned) kernel is dispatched.

## Test Plan

1. Unit tests (op_tests/test_fused_stage1_quant.py, 13 cases, no GPU required):

  - _get_proven_fp4_stage1: collects only flydsl_moe1*_fp4 rows, is cached (post-cache file mutation ignored), empty set on missing file.
  - Gating/fallbacks: flag off is a no-op; upgrade when a proven sibling exists; _bnt0 suffix dropped before lookup; unchanged when no proven sibling, empty tune file, non-fp4x2 activation dtype, already-fused kernel, or non-flydsl_moe1 kernel.
  - AITER_FUSE_STAGE1_MIN_TOKENS: skips upgrade below threshold, upgrades at/above; 0 disables the gate.

All 13 passing on MI355X.

## Test Result

End-to-end accuracy (DeepSeek-R1, MoRI EP, MI355X) with AITER_FUSE_STAGE1_QUANT=1: GSM8k 1319 questions, 5-shot → 94.4%, Invalid 0.000, matching the expected R1 score (no regression).

Before - 
<img width="1315" height="990" alt="image" src="https://github.com/user-attachments/assets/862d0474-6f8c-4831-8892-341dc99a2d47" />

After -
<img width="1270" height="894" alt="image" src="https://github.com/user-attachments/assets/00e4fffe-138a-4854-96a3-72b8c7718fb3" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
