### PR TITLE
feat(fmoe): key tuned configs by (gfx, cu_num) to disambiguate archs

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -15,7 +15,12 @@ from aiter import ActivationType, QuantType, dtypes
 from aiter import get_hip_quant as get_quant
 from aiter import logger
 from aiter.jit.core import AITER_CONFIGS, AITER_CSRC_DIR, PY, bd_dir, mp_lock
-from aiter.jit.utils.chip_info import get_cu_num, get_gfx
+from aiter.jit.utils.chip_info import (
+    get_cu_num,
+    get_gfx,
+    get_gfx_runtime,
+    gfx_from_cu_num,
+)
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.ops.flydsl.utils import is_flydsl_available
 from aiter.ops.flydsl.moe_common import GateMode
@@ -990,7 +995,12 @@ def get_2stage_cfgs(
     is_ep=False,
 ):
     gate_mode = GateMode(gate_mode)
+    # Configs are keyed on (gfx, cu_num, ...) so archs that share a cu_num
+    # (e.g. gfx950 vs gfx1250, both report 256 CU) don't collide. Legacy CSVs
+    # without a `gfx` column are backfilled from cu_num at load time via
+    # ``_ensure_gfx_column`` (see gfx_from_cu_num).
     _INDEX_COLS = [
+        "gfx",
         "cu_num",
         "token",
         "model_dim",
@@ -1006,10 +1016,25 @@ def get_2stage_cfgs(
         "doweight_stage1",
     ]
 
+    def _ensure_gfx_column(df):
+        """Guarantee a usable `gfx` column, migrating legacy cu_num-only CSVs."""
+        if "gfx" not in df.columns:
+            df = df.copy()
+            df["gfx"] = df["cu_num"].map(gfx_from_cu_num)
+            return df
+        # Backfill placeholder/missing gfx (e.g. 0 filled when merging a config
+        # that lacks the column against ones that have it).
+        bad = df["gfx"].isna() | df["gfx"].astype(str).isin(["0", "", "nan", "None"])
+        if bad.any():
+            df = df.copy()
+            df.loc[bad, "gfx"] = df.loc[bad, "cu_num"].map(gfx_from_cu_num)
+        return df
+
     def get_cfg_2stages(tune_file):
         import pandas as pd
 
         df = pd.read_csv(tune_file)
+        df = _ensure_gfx_column(df)
         if "_tag" in df.columns:
             df = df[df["_tag"].fillna("") == ""]
 
@@ -1051,6 +1076,7 @@ def get_2stage_cfgs(
             _flydsl_fallback_cache[tune_file] = {}
             return {}
         df = pd.read_csv(tune_file)
+        df = _ensure_gfx_column(df)
         if "_tag" not in df.columns:
             _flydsl_fallback_cache[tune_file] = {}
             return {}
@@ -1079,11 +1105,13 @@ def get_2stage_cfgs(
     if cfg_2stages is None:
         cfg_2stages = get_cfg_2stages(tune_file)
     cu_num = get_cu_num()
+    gfx = get_gfx_runtime()
     # EP convention: callers append one always-masked fake-expert slot to
     # topk_ids, so runtime `topk` is routed_topk + 1. Tuned configs are keyed
     # on routed_topk; strip the fake slot before building the lookup key.
     topk -= int(is_ep)
     keys = (
+        gfx,
         cu_num,
         token,
         model_dim,
@@ -1099,6 +1127,7 @@ def get_2stage_cfgs(
         doweight_stage1,
     )
     keys_disabled = (
+        gfx,
         cu_num,
         token,
         model_dim,
@@ -1146,8 +1175,11 @@ def get_2stage_cfgs(
         if result is None and token > _PADDED_M_TIERS[0]:
             tier_idx = _PADDED_M_TIERS.index(token) if token in _PADDED_M_TIERS else -1
             for fallback_tier in reversed(_PADDED_M_TIERS[:tier_idx]):
-                keys_fb = (keys[0], fallback_tier) + keys[2:]
-                keys_fb_disabled = (keys_disabled[0], fallback_tier) + keys_disabled[2:]
+                # keys layout: (gfx, cu_num, token, ...); replace token (idx 2).
+                keys_fb = keys[:2] + (fallback_tier,) + keys[3:]
+                keys_fb_disabled = (
+                    keys_disabled[:2] + (fallback_tier,) + keys_disabled[3:]
+                )
                 result = primary.get(keys_fb, None)
                 if result is None:
                     result = fallback.get(keys_fb_disabled, None)

--- a/aiter/fused_moe_dp_shared_expert.py
+++ b/aiter/fused_moe_dp_shared_expert.py
@@ -21,7 +21,7 @@ from aiter.jit.core import (
     bd_dir,
     mp_lock,
 )
-from aiter.jit.utils.chip_info import get_cu_num
+from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime, gfx_from_cu_num
 from aiter.fused_moe import moe_sorting
 
 BLOCK_SIZE_M = 32
@@ -383,8 +383,20 @@ def get_2stage_cfgs(
         import pandas as pd
 
         cfg_2stages = pd.read_csv(tune_file)
+        # Migrate legacy cu_num-only CSVs to the (gfx, cu_num, ...) schema.
+        if "gfx" not in cfg_2stages.columns:
+            cfg_2stages["gfx"] = cfg_2stages["cu_num"].map(gfx_from_cu_num)
+        else:
+            bad = cfg_2stages["gfx"].isna() | cfg_2stages["gfx"].astype(str).isin(
+                ["0", "", "nan", "None"]
+            )
+            if bad.any():
+                cfg_2stages.loc[bad, "gfx"] = cfg_2stages.loc[bad, "cu_num"].map(
+                    gfx_from_cu_num
+                )
         cfg_2stages = cfg_2stages.set_index(
             [
+                "gfx",
                 "cu_num",
                 "token",
                 "model_dim",
@@ -410,7 +422,9 @@ def get_2stage_cfgs(
     if cfg_2stages is None:
         cfg_2stages = get_cfg_2stages(tune_file)
     cu_num = get_cu_num()
+    gfx = get_gfx_runtime()
     keys = (
+        gfx,
         cu_num,
         token,
         model_dim,

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -228,7 +228,15 @@ class AITER_CONFIG(object):
         for i, (path, df) in enumerate(source_pairs):
             for c in all_cols:
                 if c not in df.columns:
-                    df[c] = _FILL_DEFAULTS.get(c, 0)
+                    if c == "gfx" and "cu_num" in df.columns:
+                        # Legacy config without a gfx column: infer the arch from
+                        # cu_num (256->gfx950, 80/304->gfx942) so archs that share
+                        # a cu_num stay distinguishable after the merge.
+                        from aiter.jit.utils.chip_info import gfx_from_cu_num
+
+                        df[c] = df["cu_num"].map(gfx_from_cu_num)
+                    else:
+                        df[c] = _FILL_DEFAULTS.get(c, 0)
             source_pairs[i] = (path, df[all_cols])
 
         non_empty = [df for _, df in source_pairs if not df.empty]

--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -9,7 +9,7 @@ import subprocess
 from cpp_extension import executable_path
 from torch_guard import torch_compile_guard
 
-from build_targets import (  # noqa: F401 — re-exported for callers
+from build_targets import (  # noqa: F401 -- re-exported for callers
     GFX_MAP,
     _parse_gpu_archs_env,
     filter_tune_df,
@@ -51,7 +51,7 @@ def get_gfx_custom_op_core() -> int:
     if gfx == "native":
         gfx = _detect_native()[0]
     elif ";" in gfx:
-        # TODO: multi-arch GPU_ARCHS (e.g. "gfx942;gfx950") — picking the
+        # TODO: multi-arch GPU_ARCHS (e.g. "gfx942;gfx950") -- picking the
         # last entry is a known limitation for build-time codegen callers.
         # For runtime dispatch, prefer get_gfx_runtime().
         gfx = gfx.split(";")[-1]
@@ -74,7 +74,7 @@ def get_gfx():
 def get_gfx_runtime() -> str:
     """Return the arch of the live GPU, always via rocminfo.
 
-    Unlike get_gfx(), ignores GPU_ARCHS — always detects the actual running
+    Unlike get_gfx(), ignores GPU_ARCHS -- always detects the actual running
     GPU.  Use for runtime dispatch decisions (selecting tuned kernels, picking
     code paths).  Use get_gfx() for build-time codegen paths (gen_instances,
     csrc module-level arch selection) where no GPU may be available.
@@ -87,6 +87,38 @@ def get_gfx_runtime() -> str:
             f"Supported architectures: {sorted(supported)}"
         )
     return gfx_arch
+
+
+# Backfill map for legacy tuned configs that predate the `gfx` column.
+# These cu_num values were only ever tuned on a single arch historically:
+#   256 -> gfx950, 80/304 -> gfx942.
+# Newer archs that happen to share a cu_num (e.g. gfx1250 also reports 256)
+# are always written with their real arch by the tuner, so they never rely on
+# this backfill.
+_LEGACY_CU_NUM_TO_GFX = {
+    256: "gfx950",
+    80: "gfx942",
+    304: "gfx942",
+}
+
+
+def gfx_from_cu_num(cu_num) -> str:
+    """Infer the gfx arch for a legacy config row that has no `gfx` column.
+
+    Used to migrate old tuned CSVs (keyed on cu_num only) to the new
+    (gfx, cu_num, ...) schema. Unknown cu_num falls back to the live GPU arch.
+    """
+    try:
+        cu_num = int(cu_num)
+    except (TypeError, ValueError):
+        return get_gfx_runtime()
+    gfx = _LEGACY_CU_NUM_TO_GFX.get(cu_num)
+    if gfx is not None:
+        return gfx
+    try:
+        return get_gfx_runtime()
+    except Exception:
+        return "gfx942"
 
 
 @functools.lru_cache(maxsize=1)
@@ -144,12 +176,12 @@ def get_build_targets() -> list[tuple[str, int]]:
     to exactly the right set of kernels for the target GPU(s).
 
     Priority:
-      1. GPU_ARCHS set to an explicit non-empty target list → delegate to
+      1. GPU_ARCHS set to an explicit non-empty target list -> delegate to
          get_build_targets_env() (no GPU needed).
-      2. GPU_ARCHS unset, empty/whitespace, or "native" → call get_gfx()
+      2. GPU_ARCHS unset, empty/whitespace, or "native" -> call get_gfx()
          (GPU_ARCHS-aware; falls back to rocminfo when GPU_ARCHS is unset) and
          get_cu_num(), which correctly reflect partition mode and binned variants.
-      3. Neither → raise RuntimeError with a clear message.
+      3. Neither -> raise RuntimeError with a clear message.
     """
     gpu_archs = os.getenv("GPU_ARCHS")
     gpu_archs_normalized = gpu_archs.strip() if gpu_archs is not None else ""
@@ -157,7 +189,7 @@ def get_build_targets() -> list[tuple[str, int]]:
         return get_build_targets_env()
 
     try:
-        # get_gfx() is intentional here — this is a build-time path; get_gfx_runtime()
+        # get_gfx() is intentional here -- this is a build-time path; get_gfx_runtime()
         # would fail in CI environments without a live GPU.
         return [(get_gfx(), get_cu_num())]
     except Exception as e:
@@ -180,12 +212,12 @@ def build_tune_dict(
     Args:
         tune_df:          pandas DataFrame already loaded from the tuning CSV.
         default_dict:     module-level fallback dict (negative-int keys) to start from.
-        kernels_list:     module-level dict mapping kernelId → kernelInstance.
+        kernels_list:     module-level dict mapping kernelId -> kernelInstance.
         libtype:          Optional string to filter the "libtype" column (e.g. "ck").
                           Required for CSVs that mix multiple library types (e.g.
                           a8w8_bpreshuffle_tuned_gemm.csv mixes "ck" and "cktile").
                           If None, no libtype filtering is applied.
-        kernels_by_name:  Optional dict mapping kernelName string → kernelInstance.
+        kernels_by_name:  Optional dict mapping kernelName string -> kernelInstance.
                           When provided and the CSV has a "kernelName" column, kernel
                           lookup uses the name instead of kernelId. Falls back to
                           kernelId if the kernelName column is absent from the CSV.
@@ -260,7 +292,7 @@ def build_tune_dict_batched(tune_df, default_dict, kernels_list, libtype=None):
     Args:
         tune_df:      pandas DataFrame loaded from the batched tuning CSV.
         default_dict: module-level fallback dict (negative-int keys) to start from.
-        kernels_list: module-level dict mapping kernelId → kernelInstance.
+        kernels_list: module-level dict mapping kernelId -> kernelInstance.
         libtype:      Optional string to filter the "libtype" column (same semantics
                       as build_tune_dict).
 
@@ -354,10 +386,10 @@ def write_lookup_header(
     type parameters), but the iteration and key-formatting logic is shared here.
 
     Key layout in kernels_dict:
-      - Negative ints          (default_dict entries) → skipped in non-tune mode.
-      - (gfx,cu_num,M,N,K) 5-tuples (tuned entries)  → written as {"gfx",cu_num,M,N,K} C++ key.
-      - (gfx,cu_num,B,M,N,K) 6-tuples (batched)      → written as {"gfx",cu_num,B,M,N,K} C++ key.
-      - Non-negative ints (tune mode only)            → written as plain integer kernel ID.
+      - Negative ints          (default_dict entries) -> skipped in non-tune mode.
+      - (gfx,cu_num,M,N,K) 5-tuples (tuned entries)  -> written as {"gfx",cu_num,M,N,K} C++ key.
+      - (gfx,cu_num,B,M,N,K) 6-tuples (batched)      -> written as {"gfx",cu_num,B,M,N,K} C++ key.
+      - Non-negative ints (tune mode only)            -> written as plain integer kernel ID.
 
     Args:
         output_path:     Full path of the .h file to write.

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -39,7 +39,7 @@ from aiter.int4_utils import (
 from aiter.ops.quant import per_1x32_i4_quant
 from aiter import dtypes
 from aiter import ActivationType as ActivationType
-from aiter.jit.utils.chip_info import get_gfx
+from aiter.jit.utils.chip_info import get_gfx, get_gfx_runtime, gfx_from_cu_num
 import torch.nn.functional as F
 from einops import rearrange
 from aiter.utility.base_tuner import TunerCommon
@@ -1712,6 +1712,7 @@ class FmoeTuner(TunerCommon):
     def calculate(self, results, bpes=(1, 1, 2)):
         key, stage, kernelName, block_m, us, err = results
         (
+            gfx,
             cu_num,
             token,
             model_dim,
@@ -1822,6 +1823,7 @@ class FmoeTuner(TunerCommon):
         task_1stage = []
         info = key
         (
+            gfx,
             cu_num,
             token,
             model_dim,
@@ -2074,6 +2076,7 @@ class FmoeTuner(TunerCommon):
         info = key
         tasks = []
         (
+            gfx,
             cu_num,
             token,
             model_dim,
@@ -2185,6 +2188,7 @@ class FmoeTuner(TunerCommon):
         info = key
         tasks_ck = []
         (
+            gfx,
             cu_num,
             token,
             model_dim,
@@ -2416,6 +2420,7 @@ class FmoeTuner(TunerCommon):
         """A8W4 (fp8 activation + fp4 weight + per_1x32) uses cktile path."""
         tasks_ck = []
         (
+            gfx,
             cu_num,
             token,
             model_dim,
@@ -2575,6 +2580,7 @@ class FmoeTuner(TunerCommon):
         if not is_flydsl_available():
             return tasks_flydsl
         (
+            gfx,
             cu_num,
             token,
             model_dim,
@@ -2840,6 +2846,7 @@ class FmoeTuner(TunerCommon):
         if not is_flydsl_available():
             return tasks_flydsl
         (
+            gfx,
             cu_num,
             token,
             model_dim,
@@ -3364,6 +3371,7 @@ class FmoeTuner(TunerCommon):
         in_data = []
         for line in untunedf[keys].values:
             (
+                gfx,
                 cu_num,
                 token,
                 model_dim,
@@ -3392,6 +3400,7 @@ class FmoeTuner(TunerCommon):
                 continue
             act_type = eval(act_type)
             info = (
+                gfx,
                 cu_num,
                 token,
                 model_dim,
@@ -3473,7 +3482,12 @@ class FmoeTuner(TunerCommon):
 
         for col in self.columns:
             if col not in old_tunedf.columns:
-                old_tunedf[col] = 0
+                # Migrate legacy tuned files lacking a gfx column: infer from
+                # cu_num so old rows stay matchable instead of collapsing to 0.
+                if col == "gfx" and "cu_num" in old_tunedf.columns:
+                    old_tunedf[col] = old_tunedf["cu_num"].map(gfx_from_cu_num)
+                else:
+                    old_tunedf[col] = 0
 
         new_fallbacks = getattr(self, "_flydsl_fallbacks", [])
         new_fb_keys = set()
@@ -3524,6 +3538,12 @@ class FmoeTuner(TunerCommon):
         resultdf = resultdf.astype(str).drop_duplicates(
             subset=self.keys + ["_tag"], keep="last"
         )
+        # Canonical column order (self.columns, so gfx stays the first column);
+        # any extra columns such as _tag are kept at the end. Without this an
+        # incremental tune of a legacy file would append gfx at the back.
+        ordered_cols = [c for c in self.columns if c in resultdf.columns]
+        ordered_cols += [c for c in resultdf.columns if c not in ordered_cols]
+        resultdf = resultdf[ordered_cols]
         resultdf.to_csv(file, index=False)
 
     def post_process(self, results, args, topk=-1, fast_mode=False):
@@ -3541,6 +3561,7 @@ class FmoeTuner(TunerCommon):
         for key, rets in grouped_results:
             us_qs_cache = {}
             (
+                gfx,
                 cu_num,
                 token,
                 model_dim,
@@ -3572,6 +3593,7 @@ class FmoeTuner(TunerCommon):
                 profileDF.append(
                     [
                         stage,
+                        gfx,
                         cu_num,
                         token,
                         model_dim,
@@ -3694,6 +3716,7 @@ class FmoeTuner(TunerCommon):
                 stage1_profileDF,
                 stage2_profileDF,
                 on=[
+                    "gfx",
                     "cu_num",
                     "token",
                     "model_dim",
@@ -3722,6 +3745,7 @@ class FmoeTuner(TunerCommon):
                 ret = []
                 ret.append(
                     [
+                        gfx,
                         cu_num,
                         token,
                         model_dim,
@@ -4212,7 +4236,16 @@ class FmoeTuner(TunerCommon):
                 )
             else:
                 self.tunedf = None
+            self.untunedf["gfx"] = get_gfx_runtime()
             self.untunedf["cu_num"] = self.get_cu_num()
+            # Migrate a legacy tuned file that predates the gfx column so the
+            # untuned-vs-tuned dedup below (which now includes gfx) doesn't fail.
+            if (
+                self.tunedf is not None
+                and "gfx" not in self.tunedf.columns
+                and "cu_num" in self.tunedf.columns
+            ):
+                self.tunedf["gfx"] = self.tunedf["cu_num"].map(gfx_from_cu_num)
             if args.last:
                 self.untunedf = self.untunedf.iloc[-1:]
 
@@ -4226,6 +4259,7 @@ class FmoeTuner(TunerCommon):
 
 if __name__ == "__main__":
     key = [
+        "gfx",
         "cu_num",
         "token",
         "model_dim",


### PR DESCRIPTION
fmoe tuned configs were keyed on cu_num only, so archs that report the same CU count (e.g. gfx950 and gfx1250 both 256) collided. Add gfx to the config key end to end:

- chip_info: gfx_from_cu_num() to backfill legacy cu_num-only rows (256->gfx950, 80/304->gfx942; unknown -> runtime arch).
- fused_moe / fused_moe_dp_shared_expert: look configs up by (gfx, cu_num, ...) using get_gfx_runtime(); backfill a missing gfx column from cu_num so legacy CSVs keep working (no behavior change).
- jit/core: when merging configs, fill a missing gfx column from cu_num instead of 0.
- gemm_moe_tune: thread gfx through the tuner key, stamp the real runtime arch on tuned rows, and keep gfx as the first CSV column on every write (full or incremental).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
