### PR TITLE
fix(fmoe): correct 1-stage tuner data-key mapping; surface worker errors

### DIFF
--- a/aiter/utility/mp_tuner.py
+++ b/aiter/utility/mp_tuner.py
@@ -282,10 +282,10 @@ def work_group(GPUIDMap, fast_mode, err_ratio, in_data, tasks, verbose=False):
         return rets
 
     except Exception as e:
-        print(f"Critical error in work_group: {e}")
-        # import traceback
+        import traceback
 
-        # traceback.print_exc()
+        print(f"Critical error in work_group: {e!r}")
+        traceback.print_exc()
         # Return dummy failed results for all tasks in the group
         if isinstance(tasks, list):
             return [

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -128,6 +128,34 @@ def cosine_diff_compare(ref, res, msg="", printLog=True):
     return cos_diff if cos_diff >= COS_DIFF_THRESHOLD else 0.0
 
 
+# Positional order of the dict returned by ``FmoeTuner.generate_data_1stage``.
+# The asm 1-stage tasks select/reorder their kernel inputs by integer index
+# (``_data_idx``); work_group looks tensors up by *name* in that dict, so the
+# integer indices must be translated to names through this list. Keep it in
+# sync with the return dict of ``generate_data_1stage``.
+_GEN_DATA_1STAGE_KEYS = [
+    "input",  # 0
+    "a1_qt",  # 1
+    "w1_qt_shffle",  # 2
+    "w2_qt_shffle",  # 3
+    "sorted_ids",  # 4
+    "sorted_weights",  # 5
+    "sorted_expert_ids",  # 6
+    "num_valid_ids",  # 7
+    "moe_buf",  # 8
+    "a1_scale",  # 9
+    "w1_scale",  # 10
+    "w2_scale",  # 11
+    "w1_qt",  # 12
+    "w2_qt",  # 13
+    "topk_weights",  # 14
+    "topk_ids",  # 15
+    "fc1_smooth_scale",  # 16
+    "fc2_smooth_scale",  # 17
+    "a1_scale_t",  # 18
+]
+
+
 class FmoeTuner(TunerCommon):
     ARG_DEFAULTS = {
         **TunerCommon.ARG_DEFAULTS,
@@ -1884,6 +1912,7 @@ class FmoeTuner(TunerCommon):
                     _data_idx = [0, 1, 2, 3, 15, 14, 15, 15, 18, 10, 11, 17]
                 else:
                     _data_idx = [0, 1, 2, 3, 4, 5, 6, 7, 18, 10, 11, 17]
+                _data_names = [_GEN_DATA_1STAGE_KEYS[i] for i in _data_idx]
                 task_1stage.append(
                     (
                         (info, "asm_1stage", el, tile_m, flat_flag),
@@ -1904,21 +1933,7 @@ class FmoeTuner(TunerCommon):
                         ),
                         fmoe_func,
                         (
-                            _data_idx,
-                            [
-                                "input",
-                                "a1_qt",
-                                "w1_qt_shffle",
-                                "w2_qt_shffle",
-                                "sorted_ids",
-                                "sorted_weights",
-                                "sorted_expert_ids",
-                                "num_valid_ids",
-                                "a1_scale_t",
-                                "w1_scale",
-                                "w2_scale",
-                                "fc2_smooth_scale",
-                            ],
+                            _data_names,
                             q_type,
                             use_g1u1,
                             act_type,
@@ -2001,6 +2016,7 @@ class FmoeTuner(TunerCommon):
                         _data_idx = [0, 0, 2, 3, 15, 14, 15, 15, 18, 10, 11, 17]
                     else:
                         _data_idx = [0, 0, 2, 3, 4, 5, 6, 7, 18, 10, 11, 17]
+                    _data_names = [_GEN_DATA_1STAGE_KEYS[i] for i in _data_idx]
                     task_1stage.append(
                         (
                             (info, "asm_1stage_xbf16", el, tile_m, flat_flag),
@@ -2021,21 +2037,7 @@ class FmoeTuner(TunerCommon):
                             ),
                             fmoe_func,
                             (
-                                _data_idx,
-                                [
-                                    "input",
-                                    "input",
-                                    "w1_qt_shffle",
-                                    "w2_qt_shffle",
-                                    "sorted_ids",
-                                    "sorted_weights",
-                                    "sorted_expert_ids",
-                                    "num_valid_ids",
-                                    "a1_scale_t",
-                                    "w1_scale",
-                                    "w2_scale",
-                                    "fc2_smooth_scale",
-                                ],
+                                _data_names,
                                 q_type,
                                 use_g1u1,
                                 act_type,


### PR DESCRIPTION
The asm 1-stage / xbf16 tuning tasks passed integer ``_data_idx`` values as the data-key list, but work_group looks tensors up by name in the dict from generate_data_1stage, so every such task raised KeyError(0) and was counted as a timeout/hang (e.g. per_1x128 blockscale shapes ended up with no valid candidate). Translate ``_data_idx`` to the matching tensor names via _GEN_DATA_1STAGE_KEYS and drop the now-redundant literal name list so the kernel receives the right tensors plus (quant_type, isG1U1, activation, kernel_name, topk, dtype).

Also stop swallowing the real exception in mp_tuner.work_group: print repr(e) and the traceback instead of just str(e).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
