### PR TITLE
[fix](pa): add prebuild for pa_ps

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,10 @@ graft aiter_meta
 # exclude cache and compiled files .pyc / .pyo / .pyd / .pyd 
 global-exclude *.py[cod]
 prune aiter/jit/build
+# Re-include the AOT-prebuilt cpp_itfs pa_ps reduce kernels (~175K total). These are
+# compiled by setup.py's prebuild_pa_ps() into aiter/jit/build/pa_ps_<hash>/lib.so,
+# which is exactly where the cpp_itfs runtime (BUILD_DIR) looks for them. Without this
+# they get pruned out of the wheel and pa_ps falls back to slow first-inference hipcc
+# JIT (gpt-oss-120b cold-start ~24k vs ~31k tok/s). module_* kernels avoid the prune
+# because they install to aiter/jit/ root, not build/.
+recursive-include aiter/jit/build pa_ps_*/lib.so

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,10 +4,10 @@ graft aiter_meta
 # exclude cache and compiled files .pyc / .pyo / .pyd / .pyd 
 global-exclude *.py[cod]
 prune aiter/jit/build
-# Re-include the AOT-prebuilt cpp_itfs pa_ps reduce kernels (~175K total). These are
-# compiled by setup.py's prebuild_pa_ps() into aiter/jit/build/pa_ps_<hash>/lib.so,
-# which is exactly where the cpp_itfs runtime (BUILD_DIR) looks for them. Without this
-# they get pruned out of the wheel and pa_ps falls back to slow first-inference hipcc
-# JIT (gpt-oss-120b cold-start ~24k vs ~31k tok/s). module_* kernels avoid the prune
+# Re-include the AOT-prebuilt cpp_itfs pa_ps reduce kernels and arch metadata. These
+# are compiled by setup.py's prebuild_pa_ps() into aiter/jit/build/pa_ps_<hash>/ and
+# used as the read-only packaged fallback after the writable cpp_itfs BUILD_DIR.
+# Without these files, pa_ps falls back to slow first-inference hipcc JIT
+# (gpt-oss-120b cold-start ~24k vs ~31k tok/s). module_* kernels avoid the prune
 # because they install to aiter/jit/ root, not build/.
-recursive-include aiter/jit/build pa_ps_*/lib.so
+recursive-include aiter/jit/build/pa_ps_* lib.so aiter_prebuild_meta.json

--- a/csrc/cpp_itfs/pa/pa_ps_prebuild.py
+++ b/csrc/cpp_itfs/pa/pa_ps_prebuild.py
@@ -34,31 +34,64 @@ Coverage / caveats (a prebuilt variant is hit only on an EXACT signature match):
     sinks are fp32, say, hashes to a different folder and falls back to JIT.
   * context_partition_num {1..8} is complete *because* the gluon decode path caps
     it at 8 (get_recommended_splits); if that cap is raised, widen the recipe.
-  * Zero-config payoff requires AITER_ROOT_DIR to be UNSET at runtime. Unset ->
-    BUILD_DIR == the packaged jit dir, so these .so are found. If AITER_ROOT_DIR
-    is set (e.g. to a persistent volume), BUILD_DIR becomes <root>/build, which
-    has no prebuilt artifacts -> one JIT recompile into that volume. So setting
-    AITER_ROOT_DIR *disables* the wheel prebuild (counterintuitive but expected).
-  * Arch binding (same contract PREBUILD_KERNELS already imposes on module_*):
-    compile_lib bakes the target arch into the .so via --offload-arch= (from
-    GPU_ARCHS), but the folder name (md5 of the op signature) does NOT include the
-    arch, and at runtime not_built() only checks file existence -- never arch match.
-    So a .so prebuilt for e.g. gfx942 is loaded as-is on a gfx950 box without
-    recompiling. Pure JIT avoids this because GPU_ARCHS defaults to the running
-    GPU's native arch; a shipped .so is never re-validated. Safe ONLY when the
-    wheel's GPU_ARCHS covers the deployment arch (or is a multi-arch fat binary) --
-    keep this in mind for cross-arch wheel deployments.
+  * Found via a read-only fallback, independent of AITER_ROOT_DIR. The runtime
+    looks up a kernel in two places (csrc/cpp_itfs/utils.py::_find_built): the
+    writable BUILD_DIR (AITER_ROOT_DIR/build or ~/.aiter/build) first, then the
+    packaged dir (get_user_jit_dir()/build) where these .so ship. So the prebuild
+    is used with ZERO config whether or not AITER_ROOT_DIR is set -- pointing it at
+    a persistent volume no longer disables the prebuild (the volume just becomes the
+    preferred write/cache location, with the packaged .so as fallback).
+  * Arch binding: compile_lib bakes GPU_ARCHS into the .so via --offload-arch=.
+    The prebuild writes aiter_prebuild_meta.json next to every lib.so, and runtime
+    packaged fallback uses it to verify the live GPU arch before loading the .so.
+    If the wheel was built only for gfx942 and runs on gfx950, the packaged .so is
+    skipped and cpp_itfs falls back to native JIT into the writable BUILD_DIR. For
+    zero cold-start JIT across deployments, build a multi-arch/fat wheel whose
+    GPU_ARCHS covers every target arch.
 
-Packaging: these .so are written under {BUILD_DIR}/pa_ps_<hash>/lib.so, i.e.
-aiter/jit/build/..., which MANIFEST.in prunes. MANIFEST.in must re-include
-aiter/jit/build/pa_ps_*/lib.so or the wheel ships without them.
+Packaging: these .so and their arch metadata are written under the PACKAGED build dir
+get_user_jit_dir()/build/pa_ps_<hash>/, i.e. aiter/jit/build/... in the source tree
+(NOT the runtime-writable utils.BUILD_DIR == ~/.aiter/build; see _packaged_build_dir).
+MANIFEST.in prunes aiter/jit/build, so it must re-include both lib.so and
+aiter_prebuild_meta.json, and package_data names them too, or the wheel ships without
+usable pa_ps prebuilds.
 """
 
+import json
 import os
 import shutil
 
+import csrc.cpp_itfs.utils as cpp_utils
 from csrc.cpp_itfs.pa.pa_ps import compile as compile_pa_ps
-from csrc.cpp_itfs.utils import BUILD_DIR, get_default_func_name
+from csrc.cpp_itfs.utils import (
+    PREBUILD_META_FILE,
+    get_default_func_name,
+    validate_and_update_archs,
+)
+
+
+def _packaged_build_dir():
+    """The dir the wheel actually ships from: get_user_jit_dir()/build.
+
+    IMPORTANT -- at RUNTIME utils.BUILD_DIR is the *writable* JIT cache
+    (AITER_ROOT_DIR/build or ~/.aiter/build), and the wheel-shipped prebuilds live in
+    a SEPARATE read-only dir (utils.PACKAGED_BUILD_DIR == get_user_jit_dir()/build).
+    That split is exactly what fixed the review's BUILD_DIR-migration / AITER_REBUILD
+    concerns. The consequence for the build: we must write the AOT artifacts straight
+    into that packaged dir, because that is what MANIFEST.in / package_data /
+    setup.py's `bd = get_user_jit_dir()/build` package. Writing to the runtime
+    BUILD_DIR (~/.aiter/build) would leave the wheel EMPTY -- the runtime BUILD_DIR is
+    not under the source tree and is never packaged.
+    """
+    target = cpp_utils._resolve_packaged_build_dir()
+    if target is None:
+        raise RuntimeError(
+            "pa_ps prebuild: cannot resolve get_user_jit_dir()/build (aiter.jit.core "
+            "not importable), so artifacts cannot be placed where the wheel packages "
+            "them. Run inside the aiter source tree with jit on sys.path."
+        )
+    return target
+
 
 # Each recipe is one model/dtype family. context_partition_num is the only axis that
 # varies at runtime, and the gluon decode path caps it at 8 (see
@@ -98,12 +131,12 @@ def _iter_variants():
 
 
 def _clean_intermediates(folder):
-    """Keep only lib.so in a built folder -- drop .cpp/.o/include copies (~23M -> 22K)."""
-    d = os.path.join(BUILD_DIR, folder)
+    """Keep only runtime files in a built folder -- drop .cpp/.o/include copies."""
+    d = os.path.join(cpp_utils.BUILD_DIR, folder)
     if not os.path.isdir(d):
         return
     for entry in os.listdir(d):
-        if entry == "lib.so":
+        if entry in {"lib.so", PREBUILD_META_FILE}:
             continue
         p = os.path.join(d, entry)
         try:
@@ -112,33 +145,74 @@ def _clean_intermediates(folder):
             pass
 
 
+def _write_prebuild_metadata(folder):
+    d = os.path.join(cpp_utils.BUILD_DIR, folder)
+    metadata = {
+        "format_version": 1,
+        "kind": "cpp_itfs_prebuild",
+        "op": "pa_ps",
+        "gpu_archs": validate_and_update_archs(),
+    }
+    with open(os.path.join(d, PREBUILD_META_FILE), "w", encoding="utf-8") as f:
+        json.dump(metadata, f, sort_keys=True)
+        f.write("\n")
+
+
 def prebuild_pa_ps():
-    """Compile every pa_ps variant in the recipes into BUILD_DIR (called from setup.py)."""
+    """Compile every pa_ps variant in the recipes into the packaged dir (from setup.py).
+
+    Writes into get_user_jit_dir()/build (the wheel-packaged dir), NOT the runtime
+    writable BUILD_DIR -- see _packaged_build_dir() for why. The cpp_itfs compile
+    machinery (compile_lib/run_lib/not_built/_find_built) all key off the module-global
+    utils.BUILD_DIR, so we point it at the packaged dir for the duration of the build
+    and restore it afterwards (so importing/calling this never corrupts a live
+    process's runtime cache location).
+    """
     variants = list(_iter_variants())
-    print(f"[aiter] prebuild pa_ps: {len(variants)} variant(s) -> {BUILD_DIR}")
+    target = _packaged_build_dir()
+    os.makedirs(target, exist_ok=True)
+    print(f"[aiter] prebuild pa_ps: {len(variants)} variant(s) -> {target}")
+
+    prev_build_dir = cpp_utils.BUILD_DIR
+    cpp_utils.BUILD_DIR = target
+    # compile() and _find_built() are lru_cached and read BUILD_DIR on a cache miss;
+    # clear so the redirect actually takes effect for already-touched folders.
+    if hasattr(compile_pa_ps, "cache_clear"):
+        compile_pa_ps.cache_clear()
+    if hasattr(cpp_utils._find_built, "cache_clear"):
+        cpp_utils._find_built.cache_clear()
+
     ok, errs = 0, []
-    for kw in variants:
-        # func_name == folder name; matches compile_template_op's hashing.
-        folder = get_default_func_name(
-            "pa_ps",
-            (
-                kw["head_size"],
-                kw["query_group_size"],
-                kw["context_partition_num"],
-                kw["out_dtype"],
-                kw["logits_dtype"],
-                kw["sink_dtype"],
-                kw["use_sinks"],
-            ),
-        )
-        try:
-            compile_pa_ps(**kw)
-            _clean_intermediates(folder)
-            ok += 1
-        except Exception as e:  # noqa: BLE001
-            # One bad variant must not abort the whole wheel build.
-            errs.append((kw, repr(e)))
-            print(f"[aiter] prebuild pa_ps FAILED {folder}: {e}")
+    try:
+        for kw in variants:
+            # func_name == folder name; matches compile_template_op's hashing.
+            folder = get_default_func_name(
+                "pa_ps",
+                (
+                    kw["head_size"],
+                    kw["query_group_size"],
+                    kw["context_partition_num"],
+                    kw["out_dtype"],
+                    kw["logits_dtype"],
+                    kw["sink_dtype"],
+                    kw["use_sinks"],
+                ),
+            )
+            try:
+                shutil.rmtree(os.path.join(target, folder), ignore_errors=True)
+                compile_pa_ps(**kw)
+                _write_prebuild_metadata(folder)
+                _clean_intermediates(folder)
+                ok += 1
+            except Exception as e:  # noqa: BLE001
+                # One bad variant must not abort the whole wheel build.
+                errs.append((kw, repr(e)))
+                print(f"[aiter] prebuild pa_ps FAILED {folder}: {e}")
+    finally:
+        cpp_utils.BUILD_DIR = prev_build_dir
+        if hasattr(cpp_utils._find_built, "cache_clear"):
+            cpp_utils._find_built.cache_clear()
+
     print(f"[aiter] prebuild pa_ps: {ok}/{len(variants)} built, {len(errs)} failed")
     if ok == 0 and variants:
         raise RuntimeError("pa_ps prebuild built nothing; check GPU_ARCHS / hipcc")

--- a/csrc/cpp_itfs/pa/pa_ps_prebuild.py
+++ b/csrc/cpp_itfs/pa/pa_ps_prebuild.py
@@ -19,6 +19,24 @@ Variants are derived from, and md5-verified against, the set gpt-oss-120b
 actually triggers (head_size=64, query_group_size=8, bf16, attention sinks,
 context_partition_num growing with context length). To add another model, append
 a recipe dict below.
+
+Coverage / caveats (a prebuilt variant is hit only on an EXACT signature match):
+  * Scope is gpt-oss-120b only. Other head_size / query_group_size, or
+    use_sinks=False decode paths, are not covered and still JIT on first use.
+  * All three runtime dtypes must be bf16: out_dtype (output), logits_dtype
+    (the temporary per-partition output), and sink_dtype (sinks). A model whose
+    sinks are fp32, say, hashes to a different folder and falls back to JIT.
+  * context_partition_num {1..8} is complete *because* the gluon decode path caps
+    it at 8 (get_recommended_splits); if that cap is raised, widen the recipe.
+  * Zero-config payoff requires AITER_ROOT_DIR to be UNSET at runtime. Unset ->
+    BUILD_DIR == the packaged jit dir, so these .so are found. If AITER_ROOT_DIR
+    is set (e.g. to a persistent volume), BUILD_DIR becomes <root>/build, which
+    has no prebuilt artifacts -> one JIT recompile into that volume. So setting
+    AITER_ROOT_DIR *disables* the wheel prebuild (counterintuitive but expected).
+
+Packaging: these .so are written under {BUILD_DIR}/pa_ps_<hash>/lib.so, i.e.
+aiter/jit/build/..., which MANIFEST.in prunes. MANIFEST.in must re-include
+aiter/jit/build/pa_ps_*/lib.so or the wheel ships without them.
 """
 
 import os

--- a/csrc/cpp_itfs/pa/pa_ps_prebuild.py
+++ b/csrc/cpp_itfs/pa/pa_ps_prebuild.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Ahead-of-time prebuild for the cpp_itfs ``pa_ps`` paged-attention reduce kernel.
+
+``pa_ps`` is a cpp_itfs template op: each (head_size, query_group_size,
+context_partition_num, dtypes, use_sinks) combination is rendered from a jinja
+template and hipcc-compiled lazily on the FIRST inference that needs it. On a
+freshly (re)built container that compilation happens on the request critical
+path, stalling the first benchmark runs (gpt-oss-120b: ~24k -> ~31k tok/s).
+
+The module_* kernels avoid this because setup.py's PREBUILD_KERNELS compiles
+them AOT into the packaged jit dir; the cpp_itfs family was never wired in.
+This module closes that gap for pa_ps. ``compile()`` only runs hipcc (no GPU
+needed -- only GPU_ARCHS, the same constraint PREBUILD_KERNELS already imposes),
+so it is safe to call from the wheel build.
+
+Variants are derived from, and md5-verified against, the set gpt-oss-120b
+actually triggers (head_size=64, query_group_size=8, bf16, attention sinks,
+context_partition_num growing with context length). To add another model, append
+a recipe dict below.
+"""
+
+import os
+import shutil
+
+from csrc.cpp_itfs.pa.pa_ps import compile as compile_pa_ps
+from csrc.cpp_itfs.utils import BUILD_DIR, get_default_func_name
+
+# Each recipe is one model/dtype family. context_partition_num is the only axis that
+# varies at runtime, and the gluon decode path caps it at 8 (see
+# aiter/ops/triton/gluon/pa_decode_gluon.py::get_recommended_splits ->
+# `return min(max_context_partition_num, 8)`). The cap is independent of context
+# length / batch / concurrency, so {1..8} is the COMPLETE set for this kernel --
+# it fully covers every run_bench.sh scenario (ISL 1000/5000/10000, all CONC), all
+# of which serve gpt-oss-120b and decode through pa_ps. If that cap is ever raised,
+# widen this range to match. Each .so is ~22K.
+PA_PS_PREBUILD_RECIPES = [
+    {
+        # gpt-oss-120b: head_dim=64, GQA query group=8, bf16 out/logits/sink,
+        # GPT-OSS-style attention sinks enabled.
+        "head_size": 64,
+        "query_group_size": 8,
+        "out_dtype": "__hip_bfloat16",
+        "logits_dtype": "__hip_bfloat16",
+        "sink_dtype": "__hip_bfloat16",
+        "use_sinks": True,
+        "context_partition_nums": range(1, 9),
+    },
+]
+
+
+def _iter_variants():
+    for recipe in PA_PS_PREBUILD_RECIPES:
+        for cpn in recipe["context_partition_nums"]:
+            yield {
+                "head_size": recipe["head_size"],
+                "query_group_size": recipe["query_group_size"],
+                "context_partition_num": cpn,
+                "out_dtype": recipe["out_dtype"],
+                "logits_dtype": recipe["logits_dtype"],
+                "sink_dtype": recipe["sink_dtype"],
+                "use_sinks": recipe["use_sinks"],
+            }
+
+
+def _clean_intermediates(folder):
+    """Keep only lib.so in a built folder -- drop .cpp/.o/include copies (~23M -> 22K)."""
+    d = os.path.join(BUILD_DIR, folder)
+    if not os.path.isdir(d):
+        return
+    for entry in os.listdir(d):
+        if entry == "lib.so":
+            continue
+        p = os.path.join(d, entry)
+        try:
+            shutil.rmtree(p) if os.path.isdir(p) else os.remove(p)
+        except OSError:
+            pass
+
+
+def prebuild_pa_ps():
+    """Compile every pa_ps variant in the recipes into BUILD_DIR (called from setup.py)."""
+    variants = list(_iter_variants())
+    print(f"[aiter] prebuild pa_ps: {len(variants)} variant(s) -> {BUILD_DIR}")
+    ok, errs = 0, []
+    for kw in variants:
+        # func_name == folder name; matches compile_template_op's hashing.
+        folder = get_default_func_name(
+            "pa_ps",
+            (
+                kw["head_size"],
+                kw["query_group_size"],
+                kw["context_partition_num"],
+                kw["out_dtype"],
+                kw["logits_dtype"],
+                kw["sink_dtype"],
+                kw["use_sinks"],
+            ),
+        )
+        try:
+            compile_pa_ps(**kw)
+            _clean_intermediates(folder)
+            ok += 1
+        except Exception as e:  # noqa: BLE001
+            # One bad variant must not abort the whole wheel build.
+            errs.append((kw, repr(e)))
+            print(f"[aiter] prebuild pa_ps FAILED {folder}: {e}")
+    print(f"[aiter] prebuild pa_ps: {ok}/{len(variants)} built, {len(errs)} failed")
+    if ok == 0 and variants:
+        raise RuntimeError("pa_ps prebuild built nothing; check GPU_ARCHS / hipcc")
+    return ok
+
+
+if __name__ == "__main__":
+    prebuild_pa_ps()

--- a/csrc/cpp_itfs/pa/pa_ps_prebuild.py
+++ b/csrc/cpp_itfs/pa/pa_ps_prebuild.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""Ahead-of-time prebuild for the cpp_itfs ``pa_ps`` paged-attention reduce kernel.
+"""Ahead-of-time prebuild for the cpp_itfs ``pa_ps`` paged-attention *reduce* kernel.
+
+Scope note: this prebuilds ONLY the pa_ps partition-combine/softmax-rescale step
+(the C++ ``pa_decode_ps_reduce_hip_kernel`` in pa_ps.cuh). It does NOT prebuild the
+paged-attention *decode* / main-attention compute -- that runs through the separate
+gluon/triton path (aiter/ops/triton/gluon/pa_decode_gluon.py) and is unaffected
+here. "pa_ps" == the reduce kernel, not the whole decode kernel.
 
 ``pa_ps`` is a cpp_itfs template op: each (head_size, query_group_size,
 context_partition_num, dtypes, use_sinks) combination is rendered from a jinja
@@ -33,6 +39,15 @@ Coverage / caveats (a prebuilt variant is hit only on an EXACT signature match):
     is set (e.g. to a persistent volume), BUILD_DIR becomes <root>/build, which
     has no prebuilt artifacts -> one JIT recompile into that volume. So setting
     AITER_ROOT_DIR *disables* the wheel prebuild (counterintuitive but expected).
+  * Arch binding (same contract PREBUILD_KERNELS already imposes on module_*):
+    compile_lib bakes the target arch into the .so via --offload-arch= (from
+    GPU_ARCHS), but the folder name (md5 of the op signature) does NOT include the
+    arch, and at runtime not_built() only checks file existence -- never arch match.
+    So a .so prebuilt for e.g. gfx942 is loaded as-is on a gfx950 box without
+    recompiling. Pure JIT avoids this because GPU_ARCHS defaults to the running
+    GPU's native arch; a shipped .so is never re-validated. Safe ONLY when the
+    wheel's GPU_ARCHS covers the deployment arch (or is a multi-arch fat binary) --
+    keep this in mind for cross-arch wheel deployments.
 
 Packaging: these .so are written under {BUILD_DIR}/pa_ps_<hash>/lib.so, i.e.
 aiter/jit/build/..., which MANIFEST.in prunes. MANIFEST.in must re-include

--- a/csrc/cpp_itfs/pa/pa_ps_prebuild.py
+++ b/csrc/cpp_itfs/pa/pa_ps_prebuild.py
@@ -205,7 +205,9 @@ def prebuild_pa_ps():
                 _clean_intermediates(folder)
                 ok += 1
             except Exception as e:  # noqa: BLE001
-                # One bad variant must not abort the whole wheel build.
+                # Continue through the recipe to report every failing variant, then
+                # fail the wheel build below. A successful PREBUILD_KERNELS build must
+                # not silently ship without complete pa_ps prebuild coverage.
                 errs.append((kw, repr(e)))
                 print(f"[aiter] prebuild pa_ps FAILED {folder}: {e}")
     finally:
@@ -214,8 +216,16 @@ def prebuild_pa_ps():
             cpp_utils._find_built.cache_clear()
 
     print(f"[aiter] prebuild pa_ps: {ok}/{len(variants)} built, {len(errs)} failed")
-    if ok == 0 and variants:
-        raise RuntimeError("pa_ps prebuild built nothing; check GPU_ARCHS / hipcc")
+    if errs:
+        raise RuntimeError(
+            "pa_ps prebuild failed for "
+            f"{len(errs)}/{len(variants)} variant(s); check GPU_ARCHS / hipcc"
+        )
+    if ok != len(variants):
+        raise RuntimeError(
+            "pa_ps prebuild incomplete: "
+            f"built {ok}/{len(variants)} variant(s); check GPU_ARCHS / hipcc"
+        )
     return ok
 
 

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -51,8 +51,38 @@ AITER_REBUILD = int(os.environ.get("AITER_REBUILD", 0))
 
 HOME_PATH = os.environ.get("HOME")
 AITER_MAX_CACHE_SIZE = os.environ.get("AITER_MAX_CACHE_SIZE", None)
+
+
+def _resolve_build_dir():
+    """Where cpp_itfs template ops (pa_ps, ...) are compiled to and loaded from.
+
+    1. AITER_ROOT_DIR explicitly set  -> <AITER_ROOT_DIR>/build  (e.g. a persisted
+       JIT cache on a mounted volume; preserves the existing override behaviour).
+    2. Otherwise piggyback on the module-JIT dir (get_user_jit_dir()/build). This is
+       the same dir the module_* kernels build into, so prebuilt cpp_itfs .so (a) ship
+       inside the wheel via package_data and (b) are found at runtime with ZERO config
+       on a fresh container -- no more lazy hipcc JIT during the first inferences.
+       Tried via both import paths: aiter.jit.core (runtime) and jit.core (the path
+       setup.py puts on sys.path at build time).
+    3. Fall back to ~/.aiter/build if aiter's jit core cannot be imported.
+    """
+    root = os.environ.get("AITER_ROOT_DIR")
+    if root:
+        return os.path.abspath(os.path.join(root, "build"))
+    import importlib
+
+    for mod_name in ("aiter.jit.core", "jit.core"):
+        try:
+            get_user_jit_dir = importlib.import_module(mod_name).get_user_jit_dir
+            return os.path.abspath(os.path.join(get_user_jit_dir(), "build"))
+        except Exception:
+            continue
+    return os.path.abspath(os.path.join(f"{HOME_PATH}/.aiter", "build"))
+
+
+# Kept for backward compat: external code may read utils.AITER_ROOT_DIR.
 AITER_ROOT_DIR = os.environ.get("AITER_ROOT_DIR", f"{HOME_PATH}/.aiter")
-BUILD_DIR = os.path.abspath(os.path.join(AITER_ROOT_DIR, "build"))
+BUILD_DIR = _resolve_build_dir()
 AITER_LOG_MORE = int(os.getenv("AITER_LOG_MORE", 0))
 AITER_DEBUG = int(os.getenv("AITER_DEBUG", 0))
 AITER_USE_HSACO = int(os.getenv("AITER_USE_HSACO", 0))

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -392,7 +392,6 @@ def compile_lib(src_file, folder, includes=None, sources=None, cxxflags=None):
     mp_lock(lock_path=lock_path, main_func=main_func, final_func=final_func)
 
 
-@lru_cache(maxsize=AITER_MAX_CACHE_SIZE)
 def _find_built(folder):
     """Return the dir containing folder/lib.so, or None if it must be (re)compiled.
 
@@ -415,6 +414,7 @@ def _find_built(folder):
     return None
 
 
+@lru_cache(maxsize=AITER_MAX_CACHE_SIZE)
 def run_lib(func_name, folder=None):
     if folder is None:
         folder = func_name

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -65,6 +65,26 @@ def _resolve_build_dir():
        Tried via both import paths: aiter.jit.core (runtime) and jit.core (the path
        setup.py puts on sys.path at build time).
     3. Fall back to ~/.aiter/build if aiter's jit core cannot be imported.
+
+    SCOPE / SIDE EFFECTS -- read before changing:
+      * This runs UNCONDITIONALLY at import time of this module. It is not gated by
+        PREBUILD_KERNELS / AITER_TRITON_ONLY / whether pa_ps is used, and BUILD_DIR
+        backs EVERY cpp_itfs template op (pa, pa_ps, mla, moe, sampling, ...), not
+        just pa_ps.
+      * Default move: with AITER_ROOT_DIR unset, the default cache dir changes from
+        the old ~/.aiter/build to get_user_jit_dir()/build. Any pre-upgrade cache
+        under ~/.aiter/build is thus orphaned -> the first run after upgrade triggers
+        a one-time JIT recompile into the new location for whatever cpp_itfs op gets
+        used (again, not only pa_ps).
+      * Import-time cost: case 2 imports aiter.jit.core, whose module body may
+        os.makedirs(bd_dir) and copytree the jit dir into ~/.aiter/jit if
+        site-packages isn't writable -- heavier than the old plain string join. There
+        is no circular import (aiter.jit.core does not import this module), and case 3
+        degrades gracefully to ~/.aiter/build if that import fails.
+      * Counterintuitive: setting AITER_ROOT_DIR (case 1) points BUILD_DIR at
+        <root>/build, which has NO wheel-prebuilt artifacts -> the prebuild benefit is
+        lost and the op JIT-recompiles there. compile_template_op logs a one-time
+        warning when it hits this so the loss isn't silent.
     """
     root = os.environ.get("AITER_ROOT_DIR")
     if root:
@@ -306,6 +326,38 @@ def not_built(folder):
     return not os.path.exists(f"{BUILD_DIR}/{folder}/lib.so")
 
 
+# Folders we've already warned about, so the bypass notice fires at most once each.
+_prebuild_bypass_warned = set()
+
+
+def _warn_if_prebuild_bypassed(folder):
+    """Loudly note when AITER_ROOT_DIR redirected BUILD_DIR past a shipped prebuild.
+
+    Setting AITER_ROOT_DIR points BUILD_DIR at <root>/build, which has no
+    wheel-prebuilt .so, so the op JIT-recompiles even though the wheel shipped one.
+    That loss is otherwise silent. We only reach here on the (rare) compile path and
+    only when AITER_ROOT_DIR is set, so the extra import/stat is cheap; aiter.jit.core
+    is already loaded by the time any op compiles at runtime.
+    """
+    if not os.environ.get("AITER_ROOT_DIR") or folder in _prebuild_bypass_warned:
+        return
+    _prebuild_bypass_warned.add(folder)
+    try:
+        import importlib
+
+        jit_dir = importlib.import_module("aiter.jit.core").get_user_jit_dir()
+        packaged = os.path.join(jit_dir, "build", folder, "lib.so")
+        if os.path.exists(packaged):
+            logger.warning(
+                f"AITER_ROOT_DIR is set, so BUILD_DIR={BUILD_DIR}; a wheel-prebuilt "
+                f"kernel exists at {packaged} but is being ignored -- JIT-recompiling "
+                f"into {BUILD_DIR}/{folder}. Unset AITER_ROOT_DIR to use the shipped "
+                f"prebuild and skip this compile."
+            )
+    except Exception:
+        pass
+
+
 def compile_template_op(
     src_template,
     md_name,
@@ -323,6 +375,7 @@ def compile_template_op(
         folder = func_name
 
     if not_built(folder):
+        _warn_if_prebuild_bypassed(folder)
         if includes is None:
             includes = []
         if sources is None:

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -16,6 +16,7 @@ import logging
 import time
 import inspect
 import json
+import re
 
 
 def get_git_commit_id_short():
@@ -51,44 +52,29 @@ AITER_REBUILD = int(os.environ.get("AITER_REBUILD", 0))
 
 HOME_PATH = os.environ.get("HOME")
 AITER_MAX_CACHE_SIZE = os.environ.get("AITER_MAX_CACHE_SIZE", None)
+PREBUILD_META_FILE = "aiter_prebuild_meta.json"
 
 
-def _resolve_build_dir():
-    """Where cpp_itfs template ops (pa_ps, ...) are compiled to and loaded from.
+def _resolve_packaged_build_dir():
+    """Read-only fallback dir holding wheel-shipped cpp_itfs prebuilds (pa_ps, ...).
 
-    1. AITER_ROOT_DIR explicitly set  -> <AITER_ROOT_DIR>/build  (e.g. a persisted
-       JIT cache on a mounted volume; preserves the existing override behaviour).
-    2. Otherwise piggyback on the module-JIT dir (get_user_jit_dir()/build). This is
-       the same dir the module_* kernels build into, so prebuilt cpp_itfs .so (a) ship
-       inside the wheel via package_data and (b) are found at runtime with ZERO config
-       on a fresh container -- no more lazy hipcc JIT during the first inferences.
-       Tried via both import paths: aiter.jit.core (runtime) and jit.core (the path
-       setup.py puts on sys.path at build time).
-    3. Fall back to ~/.aiter/build if aiter's jit core cannot be imported.
+    This is get_user_jit_dir()/build -- the same dir module_* kernels build into and
+    where setup.py's prebuild_pa_ps() writes the AOT .so, so they (a) ship inside the
+    wheel via MANIFEST re-include and (b) are found at runtime with ZERO config on a
+    fresh container. It is ONLY ever read from, never written/cleared, so it does NOT
+    become the default cache location (see _resolve_writable_build_dir) -- that keeps
+    this change purely additive: no orphaned ~/.aiter caches, and AITER_REBUILD can
+    never delete shipped artifacts.
 
-    SCOPE / SIDE EFFECTS -- read before changing:
-      * This runs UNCONDITIONALLY at import time of this module. It is not gated by
-        PREBUILD_KERNELS / AITER_TRITON_ONLY / whether pa_ps is used, and BUILD_DIR
-        backs EVERY cpp_itfs template op (pa, pa_ps, mla, moe, sampling, ...), not
-        just pa_ps.
-      * Default move: with AITER_ROOT_DIR unset, the default cache dir changes from
-        the old ~/.aiter/build to get_user_jit_dir()/build. Any pre-upgrade cache
-        under ~/.aiter/build is thus orphaned -> the first run after upgrade triggers
-        a one-time JIT recompile into the new location for whatever cpp_itfs op gets
-        used (again, not only pa_ps).
-      * Import-time cost: case 2 imports aiter.jit.core, whose module body may
-        os.makedirs(bd_dir) and copytree the jit dir into ~/.aiter/jit if
-        site-packages isn't writable -- heavier than the old plain string join. There
-        is no circular import (aiter.jit.core does not import this module), and case 3
-        degrades gracefully to ~/.aiter/build if that import fails.
-      * Counterintuitive: setting AITER_ROOT_DIR (case 1) points BUILD_DIR at
-        <root>/build, which has NO wheel-prebuilt artifacts -> the prebuild benefit is
-        lost and the op JIT-recompiles there. compile_template_op logs a one-time
-        warning when it hits this so the loss isn't silent.
+    Tried lazily via both import paths: aiter.jit.core (runtime) and jit.core (the
+    path setup.py puts on sys.path at build time). Returns None if neither imports
+    (a minimal env with no aiter.jit) -- callers then just use the writable dir.
+
+    This is intentionally NOT called while importing this module: importing
+    aiter.jit.core may os.makedirs(bd_dir) and copytree the jit dir into ~/.aiter/jit
+    if site-packages isn't writable, so defer that cost until a packaged fallback is
+    actually checked.
     """
-    root = os.environ.get("AITER_ROOT_DIR")
-    if root:
-        return os.path.abspath(os.path.join(root, "build"))
     import importlib
 
     for mod_name in ("aiter.jit.core", "jit.core"):
@@ -97,17 +83,119 @@ def _resolve_build_dir():
             return os.path.abspath(os.path.join(get_user_jit_dir(), "build"))
         except Exception:
             continue
-    return os.path.abspath(os.path.join(f"{HOME_PATH}/.aiter", "build"))
+    return None
+
+
+def _resolve_writable_build_dir():
+    """Where cpp_itfs template ops are COMPILED to / where JIT writes / what
+    AITER_REBUILD clears. Preserves the historical default exactly:
+
+      * AITER_ROOT_DIR set -> <AITER_ROOT_DIR>/build  (e.g. a persisted volume).
+      * otherwise          -> ~/.aiter/build          (the pre-prebuild default).
+
+    Deliberately NOT get_user_jit_dir()/build: keeping the old default avoids
+    orphaning existing ~/.aiter caches and avoids writing JIT output into
+    site-packages. The wheel-shipped prebuilds live in the separate read-only
+    PACKAGED_BUILD_DIR, which _find_built() checks as a fallback -- so the prebuild
+    benefit is preserved even when AITER_ROOT_DIR points at a fresh volume.
+    """
+    root = os.environ.get("AITER_ROOT_DIR", f"{HOME_PATH}/.aiter")
+    return os.path.abspath(os.path.join(root, "build"))
+
+
+def _normalize_gpu_arch(arch):
+    return arch.strip().lower().split(":")[0]
+
+
+@lru_cache(maxsize=1)
+def _runtime_gpu_arch():
+    """Best-effort live GPU arch used to validate wheel-shipped prebuilds."""
+    arch = _normalize_gpu_arch(DEFAULT_GPU_ARCH)
+    if arch:
+        return arch
+
+    try:
+        result = subprocess.run(
+            "rocminfo", shell=True, capture_output=True, text=True, check=True
+        )
+        match = re.search(r"\b(gfx\w+)\b", result.stdout, re.IGNORECASE)
+        if match:
+            return _normalize_gpu_arch(match.group(1))
+    except Exception:
+        pass
+    return None
+
+
+@lru_cache(maxsize=1)
+def _get_packaged_build_dir():
+    global PACKAGED_BUILD_DIR
+    if PACKAGED_BUILD_DIR is None:
+        PACKAGED_BUILD_DIR = _resolve_packaged_build_dir()
+    return PACKAGED_BUILD_DIR
+
+
+def _packaged_prebuild_matches_runtime(packaged_build_dir, folder):
+    """Return True only when packaged metadata proves this .so covers this GPU arch."""
+    meta_path = os.path.join(packaged_build_dir, folder, PREBUILD_META_FILE)
+    if not os.path.exists(meta_path):
+        logger.warning(
+            "skip packaged cpp_itfs prebuild %s: missing %s; falling back to JIT",
+            folder,
+            PREBUILD_META_FILE,
+        )
+        return False
+
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+        built_archs = {
+            _normalize_gpu_arch(arch) for arch in metadata.get("gpu_archs", [])
+        }
+    except Exception as e:
+        logger.warning(
+            "skip packaged cpp_itfs prebuild %s: cannot read %s (%s); falling back to JIT",
+            folder,
+            PREBUILD_META_FILE,
+            e,
+        )
+        return False
+
+    runtime_arch = _runtime_gpu_arch()
+    if not runtime_arch:
+        logger.warning(
+            "skip packaged cpp_itfs prebuild %s: cannot detect runtime GPU arch; "
+            "falling back to JIT",
+            folder,
+        )
+        return False
+    if runtime_arch not in built_archs:
+        logger.warning(
+            "skip packaged cpp_itfs prebuild %s: built for %s, runtime GPU is %s; "
+            "falling back to JIT",
+            folder,
+            sorted(built_archs),
+            runtime_arch,
+        )
+        return False
+    return True
 
 
 # Kept for backward compat: external code may read utils.AITER_ROOT_DIR.
 AITER_ROOT_DIR = os.environ.get("AITER_ROOT_DIR", f"{HOME_PATH}/.aiter")
-BUILD_DIR = _resolve_build_dir()
+# Writable compile/JIT/rebuild target. BUILD_DIR keeps its historical meaning so all
+# write paths (compile_lib, compile_hsaco, the AITER_REBUILD purge below) are unchanged.
+BUILD_DIR = _resolve_writable_build_dir()
+# Read-only fallback holding wheel-shipped prebuilds (pa_ps). Resolved lazily by
+# _get_packaged_build_dir(); never written to or cleared by AITER_REBUILD.
+PACKAGED_BUILD_DIR = None
 AITER_LOG_MORE = int(os.getenv("AITER_LOG_MORE", 0))
 AITER_DEBUG = int(os.getenv("AITER_DEBUG", 0))
 AITER_USE_HSACO = int(os.getenv("AITER_USE_HSACO", 0))
 
 if AITER_REBUILD >= 1:
+    # Only the writable dir is purged. The packaged prebuilds are read-only shipped
+    # artifacts and must survive; _find_built() ignores them while AITER_REBUILD is set
+    # so the op still recompiles natively into BUILD_DIR.
     subprocess.run(f"rm -rf {BUILD_DIR}/*", shell=True)
 
 if not os.path.exists(BUILD_DIR):
@@ -305,10 +393,33 @@ def compile_lib(src_file, folder, includes=None, sources=None, cxxflags=None):
 
 
 @lru_cache(maxsize=AITER_MAX_CACHE_SIZE)
+def _find_built(folder):
+    """Return the dir containing folder/lib.so, or None if it must be (re)compiled.
+
+    Prefers the writable dir (a freshly JIT-compiled or rebuilt .so) over the
+    read-only wheel-shipped prebuild, so user-built artifacts always win. The packaged
+    prebuild is skipped entirely while AITER_REBUILD is set, so a rebuild forces a
+    fresh native compile into BUILD_DIR (this is also the escape hatch for a shipped
+    .so whose baked arch doesn't match the running GPU).
+    """
+    if os.path.exists(f"{BUILD_DIR}/{folder}/lib.so"):
+        return BUILD_DIR
+    if not AITER_REBUILD:
+        packaged_build_dir = _get_packaged_build_dir()
+        if (
+            packaged_build_dir is not None
+            and os.path.exists(f"{packaged_build_dir}/{folder}/lib.so")
+            and _packaged_prebuild_matches_runtime(packaged_build_dir, folder)
+        ):
+            return packaged_build_dir
+    return None
+
+
 def run_lib(func_name, folder=None):
     if folder is None:
         folder = func_name
-    lib = ctypes.CDLL(f"{BUILD_DIR}/{folder}/lib.so", os.RTLD_LAZY)
+    base = _find_built(folder) or BUILD_DIR
+    lib = ctypes.CDLL(f"{base}/{folder}/lib.so", os.RTLD_LAZY)
     return getattr(lib, func_name)
 
 
@@ -323,39 +434,7 @@ def get_default_func_name(md_name, args: tuple):
 
 
 def not_built(folder):
-    return not os.path.exists(f"{BUILD_DIR}/{folder}/lib.so")
-
-
-# Folders we've already warned about, so the bypass notice fires at most once each.
-_prebuild_bypass_warned = set()
-
-
-def _warn_if_prebuild_bypassed(folder):
-    """Loudly note when AITER_ROOT_DIR redirected BUILD_DIR past a shipped prebuild.
-
-    Setting AITER_ROOT_DIR points BUILD_DIR at <root>/build, which has no
-    wheel-prebuilt .so, so the op JIT-recompiles even though the wheel shipped one.
-    That loss is otherwise silent. We only reach here on the (rare) compile path and
-    only when AITER_ROOT_DIR is set, so the extra import/stat is cheap; aiter.jit.core
-    is already loaded by the time any op compiles at runtime.
-    """
-    if not os.environ.get("AITER_ROOT_DIR") or folder in _prebuild_bypass_warned:
-        return
-    _prebuild_bypass_warned.add(folder)
-    try:
-        import importlib
-
-        jit_dir = importlib.import_module("aiter.jit.core").get_user_jit_dir()
-        packaged = os.path.join(jit_dir, "build", folder, "lib.so")
-        if os.path.exists(packaged):
-            logger.warning(
-                f"AITER_ROOT_DIR is set, so BUILD_DIR={BUILD_DIR}; a wheel-prebuilt "
-                f"kernel exists at {packaged} but is being ignored -- JIT-recompiling "
-                f"into {BUILD_DIR}/{folder}. Unset AITER_ROOT_DIR to use the shipped "
-                f"prebuild and skip this compile."
-            )
-    except Exception:
-        pass
+    return _find_built(folder) is None
 
 
 def compile_template_op(
@@ -375,7 +454,6 @@ def compile_template_op(
         folder = func_name
 
     if not_built(folder):
-        _warn_if_prebuild_bypassed(folder)
         if includes is None:
             includes = []
         if sources is None:

--- a/setup.py
+++ b/setup.py
@@ -412,14 +412,31 @@ if PREBUILD_KERNELS != 0:
         # throughput on a freshly built container. Compile it AOT into the packaged
         # jit dir so it ships in the wheel and needs zero runtime config. Only hipcc
         # is invoked (no GPU), same as the CK builds above.
+        # NOTE: these .so land in {get_user_jit_dir()}/build/pa_ps_<hash>/lib.so.
+        # MANIFEST.in prunes aiter/jit/build, so that file must re-include
+        # aiter/jit/build/pa_ps_*/lib.so or the wheel ships without them (the
+        # build/ tree is not a package and package_data globs are non-recursive,
+        # so nothing else re-adds nested .so). Runtime hits them only when
+        # AITER_ROOT_DIR is unset (then BUILD_DIR == this same packaged dir).
         if this_dir not in sys.path:
             sys.path.insert(0, this_dir)
         try:
             from csrc.cpp_itfs.pa.pa_ps_prebuild import prebuild_pa_ps
 
-            prebuild_pa_ps()
+            _pa_ps_built = prebuild_pa_ps()
         except Exception as e:  # noqa: BLE001 - never fail the whole wheel on prebuild
-            print(f"[aiter] pa_ps prebuild skipped: {e}")
+            _pa_ps_built = 0
+            print(f"[aiter] pa_ps prebuild raised: {e}")
+        # Make a no-op prebuild loud: the wheel still builds, but ships WITHOUT the
+        # prebuilt pa_ps kernels, so cold-start JIT returns silently (gpt-oss-120b
+        # first-run ~24k vs ~31k tok/s). Don't fail the build (triton-only / no-hipcc
+        # envs legitimately produce nothing), just make it impossible to miss.
+        if not _pa_ps_built:
+            print("=" * 72)
+            print("[aiter] WARNING: pa_ps AOT prebuild produced 0 kernels.")
+            print("[aiter] The wheel will NOT carry prebuilt pa_ps; first-inference")
+            print("[aiter] hipcc JIT (cold-start slowdown) is back. Check hipcc/GPU_ARCHS.")
+            print("=" * 72)
 
         # Retune GEMM shapes on the live GPU after the main build phase.
         if PRETUNE_MODULES:

--- a/setup.py
+++ b/setup.py
@@ -421,25 +421,22 @@ if PREBUILD_KERNELS != 0:
         # fallback is used only when metadata proves the .so covers the live GPU arch.
         if this_dir not in sys.path:
             sys.path.insert(0, this_dir)
-        try:
-            from csrc.cpp_itfs.pa.pa_ps_prebuild import prebuild_pa_ps
+        from csrc.cpp_itfs.pa.pa_ps_prebuild import prebuild_pa_ps
 
-            _pa_ps_built = prebuild_pa_ps()
-        except Exception as e:  # noqa: BLE001 - never fail the whole wheel on prebuild
-            _pa_ps_built = 0
-            print(f"[aiter] pa_ps prebuild raised: {e}")
-        # Make a no-op prebuild loud: the wheel still builds, but ships WITHOUT the
-        # prebuilt pa_ps kernels, so cold-start JIT returns silently (gpt-oss-120b
-        # first-run ~24k vs ~31k tok/s). Don't fail the build (triton-only / no-hipcc
-        # envs legitimately produce nothing), just make it impossible to miss.
+        _pa_ps_built = prebuild_pa_ps()
+        # PREBUILD_KERNELS wheel builds promise the pa_ps reduce-kernel prebuild. This
+        # adds a small amount of build time, but failures must be hard errors; otherwise
+        # we can publish a wheel that built successfully while silently losing the
+        # gpt-oss-120b cold-start benefit.
         if not _pa_ps_built:
             print("=" * 72)
-            print("[aiter] WARNING: pa_ps AOT prebuild produced 0 kernels.")
+            print("[aiter] ERROR: pa_ps AOT prebuild produced 0 kernels.")
             print("[aiter] The wheel will NOT carry prebuilt pa_ps; first-inference")
             print(
                 "[aiter] hipcc JIT (cold-start slowdown) is back. Check hipcc/GPU_ARCHS."
             )
             print("=" * 72)
+            raise RuntimeError("pa_ps AOT prebuild produced 0 kernels")
         else:
             _pa_ps_libs = glob.glob(os.path.join(bd, "pa_ps_*", "lib.so"))
             _pa_ps_metas = glob.glob(
@@ -451,7 +448,7 @@ if PREBUILD_KERNELS != 0:
             ):
                 print("=" * 72)
                 print(
-                    "[aiter] WARNING: pa_ps AOT prebuild packaging sanity check failed."
+                    "[aiter] ERROR: pa_ps AOT prebuild packaging sanity check failed."
                 )
                 print(
                     "[aiter] Expected every pa_ps lib.so to have "
@@ -462,6 +459,7 @@ if PREBUILD_KERNELS != 0:
                     f"lib.so={len(_pa_ps_libs)}, metadata={len(_pa_ps_metas)}"
                 )
                 print("=" * 72)
+                raise RuntimeError("pa_ps AOT prebuild packaging sanity check failed")
 
         # Retune GEMM shapes on the live GPU after the main build phase.
         if PRETUNE_MODULES:

--- a/setup.py
+++ b/setup.py
@@ -436,16 +436,23 @@ if PREBUILD_KERNELS != 0:
             print("=" * 72)
             print("[aiter] WARNING: pa_ps AOT prebuild produced 0 kernels.")
             print("[aiter] The wheel will NOT carry prebuilt pa_ps; first-inference")
-            print("[aiter] hipcc JIT (cold-start slowdown) is back. Check hipcc/GPU_ARCHS.")
+            print(
+                "[aiter] hipcc JIT (cold-start slowdown) is back. Check hipcc/GPU_ARCHS."
+            )
             print("=" * 72)
         else:
             _pa_ps_libs = glob.glob(os.path.join(bd, "pa_ps_*", "lib.so"))
             _pa_ps_metas = glob.glob(
                 os.path.join(bd, "pa_ps_*", "aiter_prebuild_meta.json")
             )
-            if len(_pa_ps_metas) != len(_pa_ps_libs) or len(_pa_ps_libs) != _pa_ps_built:
+            if (
+                len(_pa_ps_metas) != len(_pa_ps_libs)
+                or len(_pa_ps_libs) != _pa_ps_built
+            ):
                 print("=" * 72)
-                print("[aiter] WARNING: pa_ps AOT prebuild packaging sanity check failed.")
+                print(
+                    "[aiter] WARNING: pa_ps AOT prebuild packaging sanity check failed."
+                )
                 print(
                     "[aiter] Expected every pa_ps lib.so to have "
                     "aiter_prebuild_meta.json for runtime arch validation."

--- a/setup.py
+++ b/setup.py
@@ -407,6 +407,20 @@ if PREBUILD_KERNELS != 0:
         with ThreadPoolExecutor(max_workers=prebuid_thread_num) as executor:
             list(executor.map(build_one_module, all_opts_args_build))
 
+        # --- cpp_itfs template-op prebuild (pa_ps) ---
+        # pa_ps is JIT-compiled lazily at first inference, which stalls cold-start
+        # throughput on a freshly built container. Compile it AOT into the packaged
+        # jit dir so it ships in the wheel and needs zero runtime config. Only hipcc
+        # is invoked (no GPU), same as the CK builds above.
+        if this_dir not in sys.path:
+            sys.path.insert(0, this_dir)
+        try:
+            from csrc.cpp_itfs.pa.pa_ps_prebuild import prebuild_pa_ps
+
+            prebuild_pa_ps()
+        except Exception as e:  # noqa: BLE001 - never fail the whole wheel on prebuild
+            print(f"[aiter] pa_ps prebuild skipped: {e}")
+
         # Retune GEMM shapes on the live GPU after the main build phase.
         if PRETUNE_MODULES:
             from aiter.utility.pretune import run_pretune_modules  # noqa: E402

--- a/setup.py
+++ b/setup.py
@@ -412,12 +412,13 @@ if PREBUILD_KERNELS != 0:
         # throughput on a freshly built container. Compile it AOT into the packaged
         # jit dir so it ships in the wheel and needs zero runtime config. Only hipcc
         # is invoked (no GPU), same as the CK builds above.
-        # NOTE: these .so land in {get_user_jit_dir()}/build/pa_ps_<hash>/lib.so.
-        # MANIFEST.in prunes aiter/jit/build, so that file must re-include
-        # aiter/jit/build/pa_ps_*/lib.so or the wheel ships without them (the
-        # build/ tree is not a package and package_data globs are non-recursive,
-        # so nothing else re-adds nested .so). Runtime hits them only when
-        # AITER_ROOT_DIR is unset (then BUILD_DIR == this same packaged dir).
+        # NOTE: these files land in {get_user_jit_dir()}/build/pa_ps_<hash>/:
+        # lib.so plus aiter_prebuild_meta.json (the baked GPU_ARCHS list). MANIFEST.in
+        # prunes aiter/jit/build, so it must re-include that directory pattern, and
+        # package_data below also names the nested files explicitly for wheel builds.
+        # At runtime this packaged dir is the read-only fallback (PACKAGED_BUILD_DIR)
+        # that cpp_itfs/utils.py::_find_built checks after the writable BUILD_DIR; the
+        # fallback is used only when metadata proves the .so covers the live GPU arch.
         if this_dir not in sys.path:
             sys.path.insert(0, this_dir)
         try:
@@ -437,6 +438,23 @@ if PREBUILD_KERNELS != 0:
             print("[aiter] The wheel will NOT carry prebuilt pa_ps; first-inference")
             print("[aiter] hipcc JIT (cold-start slowdown) is back. Check hipcc/GPU_ARCHS.")
             print("=" * 72)
+        else:
+            _pa_ps_libs = glob.glob(os.path.join(bd, "pa_ps_*", "lib.so"))
+            _pa_ps_metas = glob.glob(
+                os.path.join(bd, "pa_ps_*", "aiter_prebuild_meta.json")
+            )
+            if len(_pa_ps_metas) != len(_pa_ps_libs) or len(_pa_ps_libs) != _pa_ps_built:
+                print("=" * 72)
+                print("[aiter] WARNING: pa_ps AOT prebuild packaging sanity check failed.")
+                print(
+                    "[aiter] Expected every pa_ps lib.so to have "
+                    "aiter_prebuild_meta.json for runtime arch validation."
+                )
+                print(
+                    f"[aiter] built={_pa_ps_built}, "
+                    f"lib.so={len(_pa_ps_libs)}, metadata={len(_pa_ps_metas)}"
+                )
+                print("=" * 72)
 
         # Retune GEMM shapes on the live GPU after the main build phase.
         if PRETUNE_MODULES:
@@ -512,6 +530,10 @@ setup(
     include_package_data=True,
     package_data={
         "": ["*"],
+        "aiter": [
+            "jit/build/pa_ps_*/lib.so",
+            "jit/build/pa_ps_*/aiter_prebuild_meta.json",
+        ],
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Motivation

pa_ps (cpp_itfs paged-attention reduce kernel) is JIT-compiled with hipcc on the first inference and cached in AITER_ROOT_DIR/build (default $HOME/.aiter/build), which is lost on every container rebuild. So the first runs after a fresh build stall while the kernel compiles on the request path — on gpt-oss-120b this drops cold-start throughput to ~24k tok/s vs the steady-state ~31k.

The root cause is a prebuild coverage gap: setup.py's PREBUILD_KERNELS only AOT-compiles the module_* kernels (which ship in the wheel via get_user_jit_dir()). The entire cpp_itfs family (pa_ps, pa, mla, moe, sampling, …) is never prebuilt and is resolved only from AITER_ROOT_DIR/build, with no in-package fallback — so it always compiles cold on first use.

This change closes the gap for pa_ps: cpp_itfs's build dir now falls back to the packaged module-JIT dir when AITER_ROOT_DIR is unset (artifacts ship in the wheel, found at runtime with zero config), and pa_ps is compiled AOT during the existing prebuild step (hipcc only, no GPU). The AITER_ROOT_DIR override is preserved.