### PR TITLE
[Triton] Fix flaky graph capture tests

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/interface_v2.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/interface_v2.py
@@ -13,6 +13,10 @@ from .utils import (
     round_multiple,
 )
 
+# Built once at import, not per call: a per-call alloc inherits the default
+# device and does an illegal H2D under CUDA graph capture.
+_RNG_STATE = torch.tensor([PHILOX_SEED, PHILOX_OFFSET])
+
 
 def fwd(
     q: torch.Tensor,
@@ -78,7 +82,7 @@ def fwd(
 
     # Dropout + RNG seed
     philox_seed, philox_offset = PHILOX_SEED, PHILOX_OFFSET
-    rng_state = torch.as_tensor([philox_seed, philox_offset])
+    rng_state = _RNG_STATE
 
     # argument checks
     assert q.dim() == 4 and k.dim() == 4 and v.dim() == 4
@@ -454,7 +458,7 @@ def varlen_fwd(
         assert alibi_slopes.shape == (batch, nheads_q)
 
     philox_seed, philox_offset = PHILOX_SEED, PHILOX_OFFSET
-    rng_state = torch.as_tensor([philox_seed, philox_offset])
+    rng_state = _RNG_STATE
 
     # Inline checks (subset appropriate for varlen)
     assert q.dim() == 3 and k.dim() == 3 and v.dim() == 3

--- a/op_tests/triton_tests/attention/test_mha_dao_ai.py
+++ b/op_tests/triton_tests/attention/test_mha_dao_ai.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+import contextlib
+
 import torch
 import pytest
 from aiter.ops.triton.attention.mha import (
@@ -13,6 +15,28 @@ from aiter.test_mha_common import (
     generate_random_padding_mask,
     generate_qkv,
 )
+
+
+@contextlib.contextmanager
+def _with_default_device(device):
+    """Run the capture under an explicit torch default device, restored on exit.
+
+    Graph-capture safety is relative to global state: a sibling test that leaks
+    ``torch.set_default_device("cuda")`` (some set it at module scope and never
+    reset it) makes any tensor constructor in the op that omits ``device=``
+    allocate on CUDA, an illegal H2D during capture. Parametrizing the graph
+    tests over the default device makes both regimes deterministic and
+    ordering-independent: the "cpu" case checks capture correctness; the "cuda"
+    case reproduces the leaked-global-state regime that surfaces device-implicit
+    allocations. (Host<->device syncs inside a captured region are already
+    illegal under torch.cuda.graph, so capture catches those too.)
+    """
+    prev_device = torch.get_default_device()
+    try:
+        torch.set_default_device(device)
+        yield
+    finally:
+        torch.set_default_device(prev_device)
 
 
 @pytest.fixture
@@ -182,8 +206,9 @@ def test_mha_dao_ai(
         )
 
 
+@pytest.mark.parametrize("default_device", ["cpu", "cuda"])
 @pytest.mark.parametrize("mha_type", ["mha", "gqa"])
-def test_mha_dao_ai_graph(dao_ai_impl, mha_type):
+def test_mha_dao_ai_graph(dao_ai_impl, mha_type, default_device):
     """graph capture for flash_attn_func with dao_ai impl."""
     d = 128
     device = "cuda"
@@ -212,7 +237,7 @@ def test_mha_dao_ai_graph(dao_ai_impl, mha_type):
     v.copy_(v_orig)
 
     g = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(g):
+    with _with_default_device(default_device), torch.cuda.graph(g):
         out_graph = flash_attn_func(q, k, v, causal=True)
 
     q.copy_(q_orig)
@@ -231,8 +256,9 @@ def test_mha_dao_ai_graph(dao_ai_impl, mha_type):
     assert diff < 1e-5, f"Graph replay vs eager max diff {diff:.6e} exceeds 1e-5"
 
 
+@pytest.mark.parametrize("default_device", ["cpu", "cuda"])
 @pytest.mark.parametrize("mha_type", ["mha", "gqa"])
-def test_mha_dao_ai_varlen_graph(dao_ai_impl, mha_type):
+def test_mha_dao_ai_varlen_graph(dao_ai_impl, mha_type, default_device):
     """graph capture for flash_attn_varlen_func with dao_ai impl."""
     d = 128
     device = "cuda"
@@ -292,7 +318,7 @@ def test_mha_dao_ai_varlen_graph(dao_ai_impl, mha_type):
         v_unpad.copy_(v_orig)
 
     g = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(g):
+    with _with_default_device(default_device), torch.cuda.graph(g):
         out_graph = flash_attn_varlen_func(
             q_unpad,
             k_unpad,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This pr fixes an issue where graph capture tests for flash attention fail randomly based on the global state. See https://github.com/ROCm/aiter/actions/runs/27446436985/job/81133382314?pr=3701

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
