### PR TITLE
fix: no-copy-in DP collectives in CUDA graph via real warmup collective

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -136,9 +136,7 @@ def _validate_mxfp4_hidden_dim(n: int, element_size: int) -> None:
             f"(bf16/fp16: 2), got element_size={element_size}"
         )
     if n <= 0:
-        raise ValueError(
-            f"MXFP4 fused quant requires hidden_dim n > 0, got n={n}"
-        )
+        raise ValueError(f"MXFP4 fused quant requires hidden_dim n > 0, got n={n}")
     pack_size = 16 // element_size
     if n % 32 != 0:
         raise ValueError(f"MXFP4 fused quant requires n divisible by 32, got n={n}")
@@ -721,6 +719,14 @@ class CustomAllreduce:
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
                 return self.reduce_scatter(input, output, dim, registered=True)
+            else:
+                # Warmup forward (pre-capture): run the REAL reduce_scatter via
+                # the copy-in path. Unlike custom_all_reduce, returning zeros
+                # here corrupts DeepSeek-V4 hash-routed MoE accuracy (~5pp GSM8K
+                # drop) — the warmup result feeds downstream state baked into the
+                # captured graph. Out-of-place collective, so allocation pattern
+                # still matches the captured all_gather_reg path.
+                return self.reduce_scatter(input, output, dim, registered=False)
         else:
             return self.reduce_scatter(input, output, dim, registered=False)
 
@@ -785,18 +791,18 @@ class CustomAllreduce:
         self, inp: torch.Tensor, dim: int = 0
     ) -> Optional[torch.Tensor]:
         orig_dtype = inp.dtype
-        view_dtype = self._INT_TO_FP_VIEW.get(orig_dtype)
-        if view_dtype is not None:
-            inp = inp.view(view_dtype)
+        view_dtype = self._INT_TO_FP_VIEW.get(orig_dtype) or orig_dtype
 
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                out = self.all_gather_reg(inp, dim=dim)
+                out = self.all_gather_reg(inp.view(view_dtype), dim=dim)
             else:
-                print("allgather capture hipgraph error")
-                out = torch.zeros_like(inp)
+                # Warmup forward (pre-capture): run the REAL all_gather via the
+                # copy-in (unreg) path. Returning zeros here corrupts V4 MoE
+                # accuracy — see custom_reduce_scatter for the rationale.
+                out = self.all_gather_unreg(inp.view(view_dtype), dim=dim)
         else:
-            out = self.all_gather_unreg(inp, dim=dim)
+            out = self.all_gather_unreg(inp.view(view_dtype), dim=dim)
 
         if view_dtype is not None and out is not None:
             out = out.view(orig_dtype)
@@ -827,7 +833,9 @@ class CustomAllreduce:
         if not post_per_token_quant:
             if out is None:
                 out_dim = out_hidden_dim or inp.shape[-1]
-                out = torch.empty(inp.shape[:-1] + (out_dim,), dtype=inp.dtype, device=inp.device)
+                out = torch.empty(
+                    inp.shape[:-1] + (out_dim,), dtype=inp.dtype, device=inp.device
+                )
             assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
             if inp.shape[-1] == valid_dim and out.shape[-1] == inp.shape[-1]:
                 ops.fused_allreduce_rmsnorm(
@@ -1291,7 +1299,9 @@ class CustomAllreduce:
                     input.shape[:-1] + (K // 2,), dtype=torch.uint8, device=input.device
                 )
                 dummy_scale = torch.zeros(
-                    input.shape[:-1] + (K // 32,), dtype=torch.uint8, device=input.device
+                    input.shape[:-1] + (K // 32,),
+                    dtype=torch.uint8,
+                    device=input.device,
                 )
                 if emit_bf16:
                     return (

--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -1283,20 +1283,16 @@ def graph_capture():
     in order to explicitly distinguish the kernels to capture
     from other kernels possibly launched on background in the default stream.
     """
-    if _CUSTOM:
-        from contextlib import ExitStack
+    from contextlib import ExitStack
 
-        with ExitStack() as stack:
-            context = stack.enter_context(get_tp_group().graph_capture())
-            stack.enter_context(get_pp_group().graph_capture(context))
-            for group in _CUSTOM.values():
+    with ExitStack() as stack:
+        context = stack.enter_context(get_tp_group().graph_capture())
+        for group in (get_pp_group(), get_dp_group(), get_ep_group()):
+            if group is not None and group.device_communicator is not None:
                 stack.enter_context(group.graph_capture(context))
-            yield context
-    else:
-        with get_tp_group().graph_capture() as context, get_pp_group().graph_capture(
-            context
-        ):
-            yield context
+        for group in _CUSTOM.values():
+            stack.enter_context(group.graph_capture(context))
+        yield context
 
 
 _ENABLE_CUSTOM_ALL_REDUCE = True


### PR DESCRIPTION
## Summary

Eliminates the per-call `Memcpy DtoD` copy-in that preceded every DP `reduce_scatter` / `all_gather` in the captured decode graph, by routing DP/EP collectives through the IPC-registered (`reg_ptr=0`) path during graph capture — while fixing a latent warmup correctness bug that this exposed.

## Changes

1. **`parallel_state.py` — `graph_capture()`**: include the DP and EP groups (guarded by `device_communicator is not None`) so their custom collectives get `_IS_CAPTURING=True` and take the registered no-copy-in path during capture.

2. **`custom_all_reduce.py` — `custom_reduce_scatter` / `custom_all_gather` warmup branch**: run the **real** collective (copy-in path) instead of returning zeros.
   - The `return zeros` "mimic the allocation pattern" trick is safe for the shape-preserving `all_reduce`, but **not** for `reduce_scatter`/`all_gather`: the warmup-forward result feeds downstream state baked into the captured graph. Returning zeros corrupts DeepSeek-V4 hash-routed MoE accuracy.
   - The collectives are out-of-place, so the warmup copy-in path still matches the captured registered path's allocation pattern.

3. **`custom_all_gather` int-dtype view**: apply `_INT_TO_FP_VIEW` consistently across captured and warmup paths (needed for the int32 hash-gate ids gather).

## Why the warmup-zeros bug matters

| config | GSM8K (flexible) |
|---|---|
| DP **out** of graph_capture (old, d2d present) | 0.9545 |
| DP **in** graph_capture + warmup-zeros (buggy) | ~0.895 |
| DP **in** graph_capture + warmup real collective (this PR) | 0.9538 |

The ~5pp regression is independent of whether the capture path is registered vs copy-in — it is entirely the warmup-zeros side effect.

## Validation

- DeepSeek-V4-Pro, TP8, `--enable-dp-attention --enable-tbo`, fp8 KV, `--level 0`.
- GSM8K (nshot 5, conc 65): **0.9538** vs control baseline 0.9545 (within noise).
- Profiler trace confirms **0 `Memcpy DtoD`** before `reduce_scatter`/`all_gather` in the captured `bs=16` decode region; prefill keeps its eager copy-in path (correct).