### PR TITLE
fix(mhc): pass i_os=0 in the async_load callsite #3648 missed

### DIFF
--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -1727,7 +1727,7 @@ namespace aiter {
                 for(int i = 0; i < x_load_waitcnt; i++) {
                     int s_offset = i * s_offset_i + threadIdx.x * x_async_load_vec;
                     async_load<x_async_load_vec>(g_x, s_x_wr_ptr + s_offset,
-                        offset_base + rows_per_load * i * x_stride, 0, opus::number<GROUP_NT>{});
+                        offset_base + rows_per_load * i * x_stride, 0, opus::number<0>{}, opus::number<GROUP_NT>{});
                 }
             }
         };


### PR DESCRIPTION
## Summary

#3648 (*[OPUS] Expose ioffset from `opus::gmem::_async_load()`*) inserted a new compile-time `i_os` immediate-offset parameter **before** `aux` in `async_load`'s template/argument list and migrated most callsites — but missed one: the x-tile load in `mhc_kernels.cu`'s gfx950 (non-gfx942) path.

That callsite still passed `opus::number<GROUP_NT>{}` as the single trailing `number<>` argument. Under the new signature this binds to `i_os` instead of `aux`, so `GROUP_NT` (a non-zero cache-control value) became a bogus byte offset on every async global→LDS x load → corrupted x tile → garbage MoE GEMM output.

## Impact

DeepSeek-V4-Pro on MI355X/gfx950 GSM8K collapsed to **0** (gibberish) on aiter `main`.

## Fix

Insert `opus::number<0>{}` (`i_os=0`) before `opus::number<GROUP_NT>{}`, matching the three mhc callsites #3648 did migrate (and the gemm-pipeline callsites).

```diff
-    offset_base + rows_per_load * i * x_stride, 0, opus::number<GROUP_NT>{});
+    offset_base + rows_per_load * i * x_stride, 0, opus::number<0>{}, opus::number<GROUP_NT>{});
```

An exhaustive scan of every `async_load`/`async_load_if` callsite in `csrc` (parsing balanced call args and counting `number<>` arguments) confirms this was the **only** remaining single-`number<>` misbinding site on `main`:

| category | count |
|---|---|
| no `number<>` (i_os=aux=0 default) | 62 |
| ≥2 `number<>` (migrated i_os+aux) | 68 |
| **1 `number<>` (binds to i_os — bug)** | **1 (this one)** |

## Validation

Bisected the regression to #3648: the immediately-preceding commit `24b8bde0e` scores 0.9507; `a686872b1` (#3648) scores 0. On `main` + this one-line fix, DeepSeek-V4-Pro GSM8K is restored **0.0 → 0.9477** (3-shot flexible-extract).

cc @ruanjm (#3648 author)