### PR TITLE
CI: run ATOM 8-GPU accuracy on MI35X runner

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -99,7 +99,7 @@ jobs:
 
           runner_overrides = {
               "atom-mi355-8gpu.predownload": "linux-aiter-mi35x-8",
-              "linux-atom-do-mi350x-8": "linux-aiter-do-mi350x-8",
+              "linux-atom-do-mi350x-8": "linux-aiter-mi35x-8",
               "linux-atom-mi35x-4": "linux-aiter-mi35x-4",
               "linux-atom-mi35x-1": "linux-aiter-mi35x-1",
           }


### PR DESCRIPTION
## Summary
- route ATOM 8-GPU accuracy jobs from linux-atom-do-mi350x-8 to linux-aiter-mi35x-8

## Testing
- git diff --check