### PR TITLE
CI: move downstream jobs off DO MI350X runners

### DIFF
--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 TESTS = [
     {
-        "runner": "linux-aiter-do-mi350x-8",
+        "runner": "linux-aiter-mi35x-8",
         "label": "MI35X",
         "model": "DeepSeek-R1-MXFP4",
         "model_id": "amd/DeepSeek-R1-MXFP4-Preview",
@@ -24,7 +24,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-do-mi350x-8",
+        "runner": "linux-aiter-mi35x-8",
         "label": "MI35X",
         "model": "DeepSeek-R1-MXFP4",
         "model_id": "amd/DeepSeek-R1-MXFP4-Preview",
@@ -38,7 +38,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-do-mi350x-8",
+        "runner": "linux-aiter-mi35x-8",
         "label": "MI35X",
         "model": "Qwen3-235B-MXFP4",
         "model_id": "amd/Qwen3-235B-A22B-Instruct-2507-mxfp4",
@@ -52,7 +52,7 @@ TESTS = [
         "comment": "issue https://github.com/ROCm/aiter/issues/2857 not resolved yet",
     },
     {
-        "runner": "linux-aiter-do-mi350x-8",
+        "runner": "linux-aiter-mi35x-8",
         "label": "MI35X",
         "model": "Qwen 3.5",
         "model_id": "Qwen/Qwen3.5-397B-A17B",
@@ -65,7 +65,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-do-mi350x-8",
+        "runner": "linux-aiter-mi35x-8",
         "label": "MI35X",
         "model": "Qwen 3.5 FP8",
         "model_id": "Qwen/Qwen3.5-397B-A17B-FP8",
@@ -78,7 +78,7 @@ TESTS = [
         "run_on_schedule": True,
     },
     {
-        "runner": "linux-aiter-do-mi350x-8",
+        "runner": "linux-aiter-mi35x-8",
         "label": "MI35X",
         "model": "DeepSeek-V3.2",
         "model_id": "deepseek-ai/DeepSeek-V3.2",
@@ -96,7 +96,7 @@ TESTS = [
         "run_on_schedule": False,
     },
     {
-        "runner": "linux-aiter-do-mi350x-8",
+        "runner": "linux-aiter-mi35x-8",
         "label": "MI35X",
         "model": "DeepSeek-V3.2 Basic",
         "model_id": "deepseek-ai/DeepSeek-V3.2",

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -107,11 +107,11 @@ jobs:
           # Per-model runner pin (overrides the generic mapping above). Kimi-K2.5
           # runs the downstream gate on the AITER MI350X pool (TP4 -> 4 GPUs).
           model_runner_overrides = {
-              "Kimi-K2.5-MXFP4": "linux-aiter-do-mi350x-4",
-              "DeepSeek-V4-Pro": "linux-aiter-do-mi350x-8",       # -tp 8
-              "Qwen3.5-397B-A17B-FP8": "linux-aiter-do-mi350x-4",  # -tp 4
-              "MiniMax-M2.7-MXFP4": "linux-aiter-do-mi350x-2",     # -tp 2 (MXFP4)
-              "GLM-5.1-FP8": "linux-aiter-do-mi350x-8",            # -tp 8
+              "Kimi-K2.5-MXFP4": "linux-aiter-mi35x-4",
+              "DeepSeek-V4-Pro": "linux-aiter-mi35x-8",       # -tp 8
+              "Qwen3.5-397B-A17B-FP8": "linux-aiter-mi35x-4",  # -tp 4
+              "MiniMax-M2.7-MXFP4": "linux-aiter-mi35x-4",     # -tp 2 (MXFP4)
+              "GLM-5.1-FP8": "linux-aiter-mi35x-8",            # -tp 8
           }
 
           # Per-model extra env injected into the test container (one KEY=VALUE per

--- a/.github/workflows/kimi-downstream.yaml
+++ b/.github/workflows/kimi-downstream.yaml
@@ -66,7 +66,7 @@ jobs:
             # Verified on MI350X (gfx950) TP8, aiter 1ec891b44: gsm8k 3-shot
             # flexible-extract 0.9272 (strict 0.9265). Threshold 0.92.
             continue_on_error: false
-    runs-on: linux-aiter-do-mi350x-8
+    runs-on: linux-aiter-mi35x-8
     continue-on-error: ${{ matrix.continue_on_error }}
     timeout-minutes: 180
     env:

--- a/.github/workflows/kimi-perf-downstream.yaml
+++ b/.github/workflows/kimi-perf-downstream.yaml
@@ -51,7 +51,7 @@ jobs:
             # Validated MI350X gfx950 TP8: c=64 output 3284.7 tok/s. Floor =
             # 2400 (~27% margin) absorbs JIT/run-to-run variance.
             floor_c64: "2400"
-    runs-on: linux-aiter-do-mi350x-8
+    runs-on: linux-aiter-mi35x-8
     timeout-minutes: 180
     env:
       MODEL_PATH: "amd/Kimi-K2.5-MXFP4"


### PR DESCRIPTION
## Summary
- route remaining downstream CI jobs away from linux-aiter-do-mi350x-* runner labels
- move 8-GPU jobs to linux-aiter-mi35x-8 and 4-GPU jobs to linux-aiter-mi35x-4
- temporarily run the MiniMax TP2 ATOM job on linux-aiter-mi35x-4 because there is no non-DO 2-GPU AITER runner label available

## Testing
- rg --hidden -n "linux-aiter-do-mi350x" /tmp/aiter-atom-kimi-use-mi350x-4
- git diff --check