### PR TITLE
Add fused custom AllReduce + MHC post/pre + RMSNorm for TP paths

### DIFF
--- a/aiter/dist/communication_op.py
+++ b/aiter/dist/communication_op.py
@@ -163,6 +163,60 @@ def tensor_model_parallel_fused_qknorm_allreduce(
     )
 
 
+def tensor_model_parallel_fused_allreduce_mhc_fused_post_pre_rmsnorm(
+    input_: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    *,
+    rms_eps: float = 1e-6,
+    hc_pre_eps: float = 1e-6,
+    hc_sinkhorn_eps: float = 1e-6,
+    hc_post_mult_value: float = 1.0,
+    sinkhorn_repeat: int = 20,
+    norm_eps: float = 1e-6,
+    force_fused: bool = True,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    prefill_support: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Tensor-parallel native AllReduce + MHC post/pre + RMSNorm.
+
+    Uses the custom-allreduce + MHC fused module when custom AR is available.
+    The native entry launches custom allreduce and the existing MHC fused
+    post/pre + RMSNorm kernels on one HIP stream without a Python-level
+    ``all_reduce`` -> ``mhc_fused_post_pre`` split. Falls back to the composed
+    path when custom AR is disabled or unsupported for the shape.
+    """
+    _assert_no_custom_group(
+        "tensor_model_parallel_fused_allreduce_mhc_fused_post_pre_rmsnorm"
+    )
+    return get_tp_group().fused_allreduce_mhc_fused_post_pre_rmsnorm(
+        input_,
+        residual_in,
+        post_layer_mix,
+        comb_res_mix,
+        fn,
+        hc_scale,
+        hc_base,
+        norm_weight,
+        rms_eps=rms_eps,
+        hc_pre_eps=hc_pre_eps,
+        hc_sinkhorn_eps=hc_sinkhorn_eps,
+        hc_post_mult_value=hc_post_mult_value,
+        sinkhorn_repeat=sinkhorn_repeat,
+        norm_eps=norm_eps,
+        force_fused=force_fused,
+        use_new=use_new,
+        open_fp8_quant=open_fp8_quant,
+        prefill_support=prefill_support,
+    )
+
+
 def tensor_model_parallel_custom_all_gather(input_: torch.Tensor) -> torch.Tensor:
     _assert_no_custom_group("tensor_model_parallel_custom_all_gather")
     return get_tp_group().custom_all_gather(input_)

--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -504,6 +504,100 @@ class CudaCommunicator(DeviceCommunicatorBase):
         assert v_out is not None
         return q_out, k_out, v_out
 
+    def fused_allreduce_mhc_fused_post_pre_rmsnorm(
+        self,
+        input_,
+        residual_in,
+        post_layer_mix,
+        comb_res_mix,
+        fn,
+        hc_scale,
+        hc_base,
+        norm_weight,
+        *,
+        rms_eps: float = 1e-6,
+        hc_pre_eps: float = 1e-6,
+        hc_sinkhorn_eps: float = 1e-6,
+        hc_post_mult_value: float = 1.0,
+        sinkhorn_repeat: int = 20,
+        norm_eps: float = 1e-6,
+        force_fused: bool = True,
+        use_new: bool = True,
+        open_fp8_quant: bool = False,
+        prefill_support: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        ca_comm = self.ca_comm
+        if (
+            ca_comm is not None
+            and not ca_comm.disabled
+            and ca_comm.should_custom_ar(input_, prefill_support)
+        ):
+            return ca_comm.custom_fused_ar_mhc_fused_post_pre_rmsnorm(
+                input_,
+                residual_in,
+                post_layer_mix,
+                comb_res_mix,
+                fn,
+                hc_scale,
+                hc_base,
+                norm_weight,
+                rms_eps=rms_eps,
+                hc_pre_eps=hc_pre_eps,
+                hc_sinkhorn_eps=hc_sinkhorn_eps,
+                hc_post_mult_value=hc_post_mult_value,
+                sinkhorn_repeat=sinkhorn_repeat,
+                norm_eps=norm_eps,
+                use_new=use_new,
+                open_fp8_quant=open_fp8_quant,
+            )
+
+        reduced = self.all_reduce(
+            input_, use_new, open_fp8_quant, prefill_support=prefill_support
+        )
+        from aiter.ops.mhc import mhc_fused_post_pre, mhc_fused_post_pre_large_m
+        from aiter.jit.utils.chip_info import get_gfx_runtime
+
+        m = reduced.size(0)
+        if (
+            force_fused
+            and get_gfx_runtime() == "gfx950"
+            and m > 1024
+        ):
+            return mhc_fused_post_pre_large_m(
+                reduced,
+                residual_in,
+                post_layer_mix,
+                comb_res_mix,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+                norm_weight,
+                norm_eps,
+            )
+
+        return mhc_fused_post_pre(
+            reduced,
+            residual_in,
+            post_layer_mix,
+            comb_res_mix,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            norm_weight,
+            norm_eps,
+            force_fused,
+        )
+
     def fused_allreduce_rmsnorm_mxfp4_quant(
         self,
         input_,

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -1112,6 +1112,68 @@ class CustomAllreduce:
         )
         return q_out, k_out, v_out
 
+    def custom_fused_ar_mhc_fused_post_pre_rmsnorm(
+        self,
+        inp: torch.Tensor,
+        residual_in: torch.Tensor,
+        post_layer_mix: torch.Tensor,
+        comb_res_mix: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        norm_weight: torch.Tensor,
+        *,
+        rms_eps: float = 1e-6,
+        hc_pre_eps: float = 1e-6,
+        hc_sinkhorn_eps: float = 1e-6,
+        hc_post_mult_value: float = 1.0,
+        sinkhorn_repeat: int = 20,
+        norm_eps: float = 1e-6,
+        use_new: bool = True,
+        open_fp8_quant: bool = False,
+        registered: bool = False,
+    ):
+        from aiter.ops.custom_all_reduce import (
+            launch_fused_allreduce_mhc_fused_post_pre_rmsnorm,
+        )
+
+        if self.disabled:
+            m = inp.size(0)
+            hidden_size = inp.size(-1)
+            hc_mult = residual_in.size(1)
+            device = inp.device
+            return (
+                torch.empty(m, hc_mult, 1, dtype=torch.float32, device=device),
+                torch.empty(m, hc_mult, hc_mult, dtype=torch.float32, device=device),
+                torch.empty(m, hidden_size, dtype=inp.dtype, device=device),
+                torch.empty_like(residual_in),
+            )
+
+        reg = 0 if registered else self._pool["input"].data_ptr
+        reg_bytes = 0 if registered else self._pool["input"].max_size
+        return launch_fused_allreduce_mhc_fused_post_pre_rmsnorm(
+            self._ptr,
+            inp,
+            residual_in,
+            post_layer_mix,
+            comb_res_mix,
+            fn,
+            hc_scale,
+            hc_base,
+            norm_weight,
+            rms_eps=rms_eps,
+            hc_pre_eps=hc_pre_eps,
+            hc_sinkhorn_eps=hc_sinkhorn_eps,
+            hc_post_mult_value=hc_post_mult_value,
+            sinkhorn_repeat=sinkhorn_repeat,
+            norm_eps=norm_eps,
+            use_new=use_new,
+            open_fp8_quant=open_fp8_quant,
+            reg_ptr=reg,
+            reg_bytes=reg_bytes,
+            force_fused=True,
+        )
+
     def custom_fused_qknorm_ar(
         self,
         qkv_in: torch.Tensor,

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -1149,6 +1149,23 @@ class CustomAllreduce:
                 torch.empty_like(residual_in),
             )
 
+        if self._IS_CAPTURING:
+            if torch.cuda.is_current_stream_capturing():
+                registered = True
+            else:
+                m = inp.size(0)
+                hidden_size = inp.size(-1)
+                hc_mult = residual_in.size(1)
+                device = inp.device
+                return (
+                    torch.empty(m, hc_mult, 1, dtype=torch.float32, device=device),
+                    torch.empty(
+                        m, hc_mult, hc_mult, dtype=torch.float32, device=device
+                    ),
+                    torch.empty(m, hidden_size, dtype=inp.dtype, device=device),
+                    torch.empty_like(residual_in),
+                )
+
         reg = 0 if registered else self._pool["input"].data_ptr
         reg_bytes = 0 if registered else self._pool["input"].max_size
         return launch_fused_allreduce_mhc_fused_post_pre_rmsnorm(

--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -555,6 +555,51 @@ class GroupCoordinator:
             raise ValueError("No device communicator found")
         return self.device_communicator.fused_qknorm_allreduce(qkv_in, q_w, k_w, eps)
 
+    def fused_allreduce_mhc_fused_post_pre_rmsnorm(
+        self,
+        input_: torch.Tensor,
+        residual_in: torch.Tensor,
+        post_layer_mix: torch.Tensor,
+        comb_res_mix: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        norm_weight: torch.Tensor,
+        *,
+        rms_eps: float = 1e-6,
+        hc_pre_eps: float = 1e-6,
+        hc_sinkhorn_eps: float = 1e-6,
+        hc_post_mult_value: float = 1.0,
+        sinkhorn_repeat: int = 20,
+        norm_eps: float = 1e-6,
+        force_fused: bool = True,
+        use_new: bool = True,
+        open_fp8_quant: bool = False,
+        prefill_support: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.device_communicator is None:
+            raise ValueError("No device communicator found")
+        return self.device_communicator.fused_allreduce_mhc_fused_post_pre_rmsnorm(
+            input_,
+            residual_in,
+            post_layer_mix,
+            comb_res_mix,
+            fn,
+            hc_scale,
+            hc_base,
+            norm_weight,
+            rms_eps=rms_eps,
+            hc_pre_eps=hc_pre_eps,
+            hc_sinkhorn_eps=hc_sinkhorn_eps,
+            hc_post_mult_value=hc_post_mult_value,
+            sinkhorn_repeat=sinkhorn_repeat,
+            norm_eps=norm_eps,
+            force_fused=force_fused,
+            use_new=use_new,
+            open_fp8_quant=open_fp8_quant,
+            prefill_support=prefill_support,
+        )
+
     def _fused_allreduce_rmsnorm_out_place(
         self,
         input_: torch.Tensor,

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1494,6 +1494,22 @@
         "verbose": "False",
         "blob_gen_cmd": "''"
     },
+    "module_fused_ar_mhc": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/fused_ar_mhc_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/fused_ar_mhc_rmsnorm.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/custom_all_reduce.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/mhc_kernels.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-DAITER_FUSED_AR_MHC_MODULE'"
+        ],
+        "extra_ldflags": "None",
+        "extra_include": [],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_mhc": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/mhc_pybind.cu'",

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -1,13 +1,25 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-from typing import List
+import os
+from typing import List, Optional, Tuple
 
 import torch
+
+from aiter import dtypes
+from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime
+from aiter.ops.mhc import (
+    get_mhc_fused_post_pre_config,
+    get_mhc_pre_splitk,
+    get_mhc_pre_splitk_large_m,
+)
 
 from ..jit.core import compile_ops
 
 MD_NAME = "module_custom_all_reduce"
+FUSED_AR_MHC_MD_NAME = "module_fused_ar_mhc"
+
+GFX950_LARGE_M_BOUND = 1024
 
 
 @compile_ops("module_custom_all_reduce", develop=True)
@@ -208,3 +220,223 @@ def free_meta_buffer(ptr: int) -> None: ...
 
 @compile_ops("module_custom_all_reduce", develop=True)
 def get_meta_buffer_ipc_handle(inp_ptr: int, out_handle_ptr: int) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Fused AllReduce + MHC(post+pre) + RMSNorm (separate JIT module, custom AR IPC)
+# Same family as fused_allreduce_rmsnorm / fused_qknorm_allreduce above.
+# ---------------------------------------------------------------------------
+
+
+def _parse_splitk_tilek_env(
+    env_name: str, hc_hidden_size: int
+) -> Optional[tuple[int, int]]:
+    forced = os.environ.get(env_name, "").strip()
+    if not forced:
+        return None
+    splitk_s, _, tilek_s = forced.partition(",")
+    splitk = int(splitk_s)
+    tilek = int(tilek_s) if tilek_s else 64
+    if hc_hidden_size % (splitk * tilek) == 0:
+        return splitk, tilek
+    return None
+
+
+def get_mhc_fused_post_pre_config_ar_mhc(
+    m: int, hidden_size: int
+) -> tuple[int, int, int, int]:
+    """TP fused post+pre GEMM tiles; may differ from single-card PR #3651 policy."""
+    forced = os.environ.get("AITER_AR_MHC_FUSED_POST_PRE_CONFIG", "").strip()
+    if forced:
+        parts = [int(x.strip()) for x in forced.split(",")]
+        if len(parts) == 4:
+            return tuple(parts)  # type: ignore[return-value]
+    return get_mhc_fused_post_pre_config(m, hidden_size)
+
+
+def get_mhc_pre_splitk_ar_mhc(m: int, hc_hidden_size: int) -> tuple[int, int]:
+    """TP pre GEMM split-K for small/medium M; falls back to single-card policy."""
+    parsed = _parse_splitk_tilek_env("AITER_AR_MHC_PRE_SPLITK", hc_hidden_size)
+    if parsed is not None:
+        return parsed
+    return get_mhc_pre_splitk(m, hc_hidden_size)
+
+
+def get_mhc_pre_splitk_ar_mhc_large_m(m: int, hc_hidden_size: int) -> tuple[int, int]:
+    """TP large-M pre GEMM split-K; may differ from single-card PR #3651 policy."""
+    parsed = _parse_splitk_tilek_env("AITER_AR_MHC_PRE_LARGE_M_SPLITK", hc_hidden_size)
+    if parsed is not None:
+        return parsed
+    if get_gfx_runtime() == "gfx950" and m >= 8192 and hc_hidden_size % (4 * 64) == 0:
+        return 4, 64
+    return get_mhc_pre_splitk_large_m(m, hc_hidden_size)
+
+
+@compile_ops(FUSED_AR_MHC_MD_NAME)
+def fused_allreduce_mhc_fused_post_pre_rmsnorm(
+    _fa: int,
+    inp: torch.Tensor,
+    layer_input: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    gemm_out: torch.Tensor,
+    gemm_out_sqrsum: torch.Tensor,
+    next_residual: torch.Tensor,
+    post_mix: torch.Tensor,
+    comb_mix: torch.Tensor,
+    layer_input_out: torch.Tensor,
+    rms_eps: float = 1e-6,
+    hc_pre_eps: float = 1e-6,
+    hc_sinkhorn_eps: float = 1e-6,
+    norm_eps: float = 1e-6,
+    hc_post_mult_value: float = 1.0,
+    sinkhorn_repeat: int = 20,
+    tile_m: int = 16,
+    tile_n: int = 32,
+    tile_k: int = 32,
+    pre_tile_k: int = 64,
+    post_store_nt: int = -1,
+    use_large_m: bool = False,
+    use_ar_mhc_full_fusion: bool = False,
+    use_ar_mhc_post_epilogue: bool = False,
+    use_large_m_post_epilogue: bool = False,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+) -> None: ...
+
+
+def launch_fused_allreduce_mhc_fused_post_pre_rmsnorm(
+    _fa: int,
+    inp: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    *,
+    rms_eps: float = 1e-6,
+    hc_pre_eps: float = 1e-6,
+    hc_sinkhorn_eps: float = 1e-6,
+    hc_post_mult_value: float = 1.0,
+    sinkhorn_repeat: int = 20,
+    norm_eps: float = 1e-6,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+    force_fused: bool = True,
+    force_full_fusion: bool = False,
+    force_large_m_post_epilogue: Optional[bool] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Allocate workspaces and launch native AR+MHC(post+pre)+RMSNorm via custom AR."""
+    m = inp.size(0)
+    hidden_size = inp.size(-1)
+    hc_mult = residual_in.size(1)
+    hc_mult3 = fn.size(0)
+    hc_hidden_size = hc_mult * hidden_size
+    device = inp.device
+    arch = get_gfx_runtime()
+
+    if post_layer_mix.ndim == 3:
+        post_layer_mix = post_layer_mix.squeeze(-1)
+
+    use_large_m = bool(
+        force_fused
+        and arch == "gfx950"
+        and m > GFX950_LARGE_M_BOUND
+        and not force_full_fusion
+    )
+    use_ar_mhc_full_fusion = bool(
+        force_fused
+        and hidden_size % 256 == 0
+        and (not use_large_m or force_full_fusion)
+    )
+    use_ar_mhc_post_epilogue = False
+    if force_large_m_post_epilogue is None:
+        env = os.environ.get("AITER_AR_MHC_LARGE_M_POST_EPILOGUE", "1").strip().lower()
+        force_large_m_post_epilogue = env not in ("0", "false", "off", "no")
+    use_large_m_post_epilogue = bool(
+        use_large_m
+        and force_large_m_post_epilogue
+        and m in (2048, 8192)
+        and hidden_size % (16 // inp.element_size()) == 0
+        and hc_mult == 4
+        and inp.is_contiguous()
+        and residual_in.is_contiguous()
+        and post_layer_mix.is_contiguous()
+        and comb_res_mix.is_contiguous()
+    )
+
+    if use_large_m:
+        selected_splitk, pre_tile_k = get_mhc_pre_splitk_ar_mhc_large_m(
+            m, hc_hidden_size
+        )
+        selected_tile_m = selected_tile_n = selected_tile_k = 16
+        post_store_nt = 0 if m > 8 * get_cu_num() else -1
+    else:
+        selected_splitk, selected_tile_m, selected_tile_n, selected_tile_k = (
+            get_mhc_fused_post_pre_config_ar_mhc(m, hidden_size)
+        )
+        _, pre_tile_k = get_mhc_pre_splitk_ar_mhc(m, hc_hidden_size)
+        post_store_nt = -1
+
+    n_splits = selected_splitk
+
+    layer_input = torch.empty_like(inp)
+    gemm_out_pad = torch.empty(
+        n_splits, m, (hc_mult3 + 31) // 32 * 32, dtype=dtypes.fp32, device=device
+    )
+    gemm_out = gemm_out_pad[:, :, :hc_mult3]
+    gemm_out_sqrsum = torch.empty(n_splits, m, dtype=dtypes.fp32, device=device)
+    next_residual = torch.empty_like(residual_in)
+    post_mix = torch.empty(m, hc_mult, 1, dtype=dtypes.fp32, device=device)
+    comb_mix = torch.empty(m, hc_mult, hc_mult, dtype=dtypes.fp32, device=device)
+    layer_input_out = torch.empty(m, hidden_size, dtype=dtypes.bf16, device=device)
+
+    fused_allreduce_mhc_fused_post_pre_rmsnorm(
+        _fa,
+        inp,
+        layer_input,
+        residual_in,
+        post_layer_mix,
+        comb_res_mix,
+        fn,
+        hc_scale,
+        hc_base,
+        norm_weight,
+        gemm_out,
+        gemm_out_sqrsum,
+        next_residual,
+        post_mix,
+        comb_mix,
+        layer_input_out,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        norm_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        selected_tile_m,
+        selected_tile_n,
+        selected_tile_k,
+        pre_tile_k,
+        post_store_nt,
+        use_large_m,
+        use_ar_mhc_full_fusion,
+        use_ar_mhc_post_epilogue,
+        use_large_m_post_epilogue,
+        use_new,
+        open_fp8_quant,
+        reg_ptr,
+        reg_bytes,
+    )
+    return post_mix, comb_mix, layer_input_out, next_residual

--- a/aiter/ops/fused_ar_mhc.py
+++ b/aiter/ops/fused_ar_mhc.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Backward-compatible re-exports. Implementation lives in custom_all_reduce.py."""
+
+from aiter.ops.custom_all_reduce import (  # noqa: F401
+    FUSED_AR_MHC_MD_NAME,
+    GFX950_LARGE_M_BOUND,
+    fused_allreduce_mhc_fused_post_pre_rmsnorm,
+    get_mhc_fused_post_pre_config_ar_mhc,
+    get_mhc_pre_splitk_ar_mhc,
+    get_mhc_pre_splitk_ar_mhc_large_m,
+    launch_fused_allreduce_mhc_fused_post_pre_rmsnorm,
+)
+
+MD_NAME = FUSED_AR_MHC_MD_NAME

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -346,7 +346,10 @@ def mhc_post(
 
 
 def get_mhc_pre_splitk_large_m(m: int, hc_hidden_size: int) -> tuple[int, int]:
-    """Split-K policy for gfx950 large-M post_pre kernel (M > 1024)."""
+    """Split-K policy for gfx950 large-M post_pre kernel (M > 1024).
+
+    PR #3651 single-card tuning only. TP-specific overrides live in fused_ar_mhc.py.
+    """
     if get_gfx_runtime() == "gfx950" and m >= 8192 and hc_hidden_size % (8 * 64) == 0:
         return 8, 64
     return get_mhc_pre_splitk(m, hc_hidden_size)
@@ -413,7 +416,7 @@ def mhc_fused_post_pre_large_m(
     norm_weight: Optional[torch.Tensor] = None,
     norm_eps: float = 1e-6,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """gfx950 large-M post+pre (M > 1024): upstream ``mhc_post`` + ``mhc_pre``."""
+    """gfx950 large-M post+pre (M > 1024): separate mhc_post + mhc_pre with large split-K."""
     m = residual_in.size(0)
 
     if post_layer_mix.ndim == 3:

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -3002,6 +3002,129 @@ using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
 static_assert(sizeof(IPC_KEY) == sizeof(hipIpcMemHandle_t));
 static_assert(alignof(IPC_KEY) == alignof(hipIpcMemHandle_t));
 
+// Prototype phase-2: gather reduced activations from IPC tmps into layer_input.
+template <typename T, int tnum, int n_loop>
+__global__ void __launch_bounds__(tnum, 1) local_device_load_layer_input_gather(
+    RankSignals sg,
+    int rank,
+    T* __restrict__ layer_input,
+    int m,
+    int n)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    P* tmps                 = get_tmp_buf<P>(sg.signals[rank]);
+    int in_pack_count       = n / pack_size;
+
+    for(int bid = blockIdx.x; bid < m; bid += gridDim.x)
+    {
+#pragma unroll
+        for(int n_iter = 0; n_iter < n_loop; ++n_iter)
+        {
+            if(n_iter * tnum + threadIdx.x < in_pack_count)
+            {
+                int read_idx        = bid * in_pack_count + n_iter * tnum + threadIdx.x;
+                P reduce_out_pack   = tmps[read_idx];
+                *(reinterpret_cast<P*>(layer_input) + read_idx) = reduce_out_pack;
+            }
+        }
+    }
+}
+
+// Large-M AR+MHC(post) epilogue: reduce input across ranks and write next_residual
+// directly. This mirrors mhc_post's math but avoids materializing layer_input.
+template <typename T, int ngpus, int hc_mult, bool two_way>
+__global__ void __launch_bounds__(1024, 1) allreduce_mhc_post_large_m_kernel(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    int rank,
+    T* __restrict__ next_residual,
+    T* __restrict__ residual,
+    float* __restrict__ post_layer_mix,
+    float* __restrict__ comb_res_mix,
+    int m,
+    int input_hidden_dim,
+    int hidden_size,
+    int residual_stride)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    static_assert(hc_mult == 4, "AR+MHC post epilogue currently supports hc_mult=4");
+
+    const int n_packs = hidden_size / pack_size;
+    const int lane    = two_way ? (threadIdx.x % n_packs) : threadIdx.x;
+    const int group   = two_way ? (threadIdx.x / n_packs) : 0;
+    __shared__ P s_reduced[512];
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int r = 0; r < ngpus; ++r)
+    {
+        ptrs[r] = reinterpret_cast<const P*>(_dp->ptrs[r]);
+    }
+
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int row = blockIdx.x; row < m; row += gridDim.x)
+    {
+        P reduced_pack;
+        if constexpr(two_way)
+        {
+            if(group == 0)
+            {
+                const int input_pack_idx = row * (input_hidden_dim / pack_size) + lane;
+                s_reduced[lane]          = packed_reduce<P, ngpus, A>(ptrs, input_pack_idx);
+            }
+            __syncthreads();
+            reduced_pack = s_reduced[lane];
+        }
+        else
+        {
+            const int input_pack_idx = row * (input_hidden_dim / pack_size) + lane;
+            reduced_pack             = packed_reduce<P, ngpus, A>(ptrs, input_pack_idx);
+        }
+        A reduced;
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            reduced[v] = upcast_s(reduced_pack[v]);
+
+#pragma unroll
+        for(int iter = 0; iter < (two_way ? 2 : hc_mult); ++iter)
+        {
+            const int out_h = two_way ? (iter * 2 + group) : iter;
+            A out;
+            const float post_v = post_layer_mix[row * hc_mult + out_h];
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+            {
+                out[v] = reduced[v] * post_v;
+            }
+
+#pragma unroll
+            for(int in_h = 0; in_h < hc_mult; ++in_h)
+            {
+                const float comb_v = comb_res_mix[row * hc_mult * hc_mult + in_h * hc_mult + out_h];
+                const int residual_pack_idx =
+                    (row * residual_stride + in_h * hidden_size) / pack_size + lane;
+                P residual_pack = reinterpret_cast<P*>(residual)[residual_pack_idx];
+#pragma unroll
+                for(int v = 0; v < pack_size; ++v)
+                {
+                    out[v] += upcast_s(residual_pack[v]) * comb_v;
+                }
+            }
+
+            P out_pack = downcast<P>(out);
+            const int out_pack_idx =
+                (row * residual_stride + out_h * hidden_size) / pack_size + lane;
+            reinterpret_cast<P*>(next_residual)[out_pack_idx] = out_pack;
+        }
+        if constexpr(two_way)
+            __syncthreads();
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
 class CustomAllreduce
 {
     public:
@@ -4371,6 +4494,149 @@ void dispatchFusedQKNormAllReduce(hipStream_t stream,
 #undef DISPATCH_QKNORM_AR_FUSION_KERNEL
 }
 
+// Prototype AR+MHC(post) epilogue dispatch: reduce-scatter + gather layer_input.
+// Caller should invoke mhc_post(layer_input, ...) on the same stream immediately
+// after this returns (native chain, avoids generic allreduce output path).
+template <typename T>
+void dispatchAllReduceGatherLayerInputPrototype(hipStream_t stream,
+                                                T* input,
+                                                T* layer_input,
+                                                int m,
+                                                int input_hidden_dim,
+                                                int n)
+{
+    auto d   = 16 / sizeof(T);
+    int size = m * n;
+    if(size % d != 0)
+    {
+        throw std::runtime_error("AR+MHC post epilogue prototype requires hidden dim "
+                                 "multiple of pack size");
+    }
+    RankData* ptrs = get_buffer_RD(stream, input);
+
+    dim3 block(512);
+    int block_num = ((size / world_size_) + 512 - 1) / 512;
+    dim3 grid(std::min(block_num, 80));
+
+#define DISPATCH_AR_GATHER_RS(NGPUS)                                           \
+    reduce_scatter_cross_device_store<T, NGPUS>                                \
+        <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, rank_, m, n,         \
+                                     input_hidden_dim);                        \
+    break
+
+    switch(world_size_)
+    {
+    case 8: DISPATCH_AR_GATHER_RS(8);
+    case 4: DISPATCH_AR_GATHER_RS(4);
+    case 2: DISPATCH_AR_GATHER_RS(2);
+    default:
+        throw std::runtime_error(
+            "AR+MHC post epilogue prototype: unsupported world_size=" +
+            std::to_string(world_size_));
+    }
+#undef DISPATCH_AR_GATHER_RS
+
+    hipDevice_t dev;
+    hipDeviceProp_t dev_prop;
+    hipGetDevice(&dev);
+    hipGetDeviceProperties(&dev_prop, dev);
+    uint32_t num_cu = dev_prop.multiProcessorCount;
+
+    constexpr int ar_pack_size = 16 / sizeof(T);
+    int n_packs                = n / ar_pack_size;
+    int n_loop                 = (n_packs + 511) / 512;
+    int naive_grid_size        = m;
+    dim3 gather_block(512);
+    dim3 gather_grid(naive_grid_size);
+
+    auto setGrid = [&](int naive_grid_sz, const void* kernel_ptr) {
+        int occupancy;
+        hipOccupancyMaxActiveBlocksPerMultiprocessor(&occupancy, kernel_ptr, gather_block.x, 0);
+        gather_grid.x = naive_grid_sz < num_cu * occupancy ? naive_grid_sz : num_cu * occupancy;
+    };
+
+#define LAUNCH_LAYER_INPUT_GATHER(NLOOP)                                       \
+    do {                                                                       \
+        auto kernel_ptr = reinterpret_cast<const void*>(                      \
+            local_device_load_layer_input_gather<T, 512, NLOOP>);              \
+        setGrid(naive_grid_size, kernel_ptr);                                   \
+        local_device_load_layer_input_gather<T, 512, NLOOP>                    \
+            <<<gather_grid, gather_block, 0, stream>>>(sg_, rank_, layer_input, m, n); \
+    } while(0)
+
+    switch(n_loop)
+    {
+    case 1: LAUNCH_LAYER_INPUT_GATHER(1); break;
+    case 2: LAUNCH_LAYER_INPUT_GATHER(2); break;
+    case 3: LAUNCH_LAYER_INPUT_GATHER(3); break;
+    case 4: LAUNCH_LAYER_INPUT_GATHER(4); break;
+    default:
+        throw std::runtime_error(
+            "AR+MHC post epilogue prototype: hidden dim too large for gather kernel");
+    }
+#undef LAUNCH_LAYER_INPUT_GATHER
+}
+
+template <typename T>
+void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
+                                    T* input,
+                                    T* next_residual,
+                                    T* residual,
+                                    float* post_layer_mix,
+                                    float* comb_res_mix,
+                                    int m,
+                                    int input_hidden_dim,
+                                    int hidden_size,
+                                    int residual_stride)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    if(input_hidden_dim != hidden_size)
+    {
+        throw std::runtime_error("AR+MHC post epilogue requires full hidden input");
+    }
+    if(hidden_size % pack_size != 0 || residual_stride % pack_size != 0)
+    {
+        throw std::runtime_error("AR+MHC post epilogue requires pack-aligned hidden/stride");
+    }
+    const int n_packs = hidden_size / pack_size;
+    if(n_packs > 512)
+    {
+        throw std::runtime_error("AR+MHC post epilogue hidden dim too large for two-way CTA");
+    }
+
+    RankData* ptrs = get_buffer_RD(stream, input);
+    const bool use_two_way = m >= 8192;
+    dim3 block(use_two_way ? n_packs * 2 : n_packs);
+    dim3 grid(std::min(m, kMaxBlocks));
+
+#define DISPATCH_AR_MHC_POST_IMPL(NGPUS, TWO_WAY)                               \
+    allreduce_mhc_post_large_m_kernel<T, NGPUS, 4, TWO_WAY>                     \
+        <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, rank_, next_residual, \
+                                     residual, post_layer_mix, comb_res_mix, m, \
+                                     input_hidden_dim, hidden_size,             \
+                                     residual_stride)
+
+#define DISPATCH_AR_MHC_POST(NGPUS)                                             \
+    do {                                                                        \
+        if(use_two_way)                                                         \
+            DISPATCH_AR_MHC_POST_IMPL(NGPUS, true);                             \
+        else                                                                    \
+            DISPATCH_AR_MHC_POST_IMPL(NGPUS, false);                            \
+    } while(0)
+
+    switch(world_size_)
+    {
+    case 8: DISPATCH_AR_MHC_POST(8); break;
+    case 4: DISPATCH_AR_MHC_POST(4); break;
+    case 2: DISPATCH_AR_MHC_POST(2); break;
+    default:
+        throw std::runtime_error("AR+MHC post epilogue: unsupported world_size=" +
+                                 std::to_string(world_size_));
+    }
+#undef DISPATCH_AR_MHC_POST_IMPL
+#undef DISPATCH_AR_MHC_POST
+}
+
 ~CustomAllreduce()
 {
     for(auto [_, ptr] : ipc_handles_)
@@ -4378,7 +4644,7 @@ void dispatchFusedQKNormAllReduce(hipStream_t stream,
         HIP_CALL(hipIpcCloseMemHandle(ptr));
     }
 }
-}; // namespace aiter
+};
 /**
  * To inspect PTX/SASS, copy paste this header file to compiler explorer and add
  a template instantiation:

--- a/csrc/include/fused_ar_mhc_rmsnorm.h
+++ b/csrc/include/fused_ar_mhc_rmsnorm.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <torch/extension.h>
+#include "custom_all_reduce.h"
+
+namespace aiter {
+
+// Native AllReduce + MHC(post+pre) + RMSNorm entry point.
+void fused_allreduce_mhc_fused_post_pre_rmsnorm(
+    fptr_t _fa,
+    torch::Tensor& inp,
+    torch::Tensor& layer_input,
+    torch::Tensor& residual_in,
+    torch::Tensor& post_layer_mix,
+    torch::Tensor& comb_res_mix,
+    torch::Tensor& fn,
+    torch::Tensor& hc_scale,
+    torch::Tensor& hc_base,
+    torch::Tensor& norm_weight,
+    torch::Tensor& gemm_out,
+    torch::Tensor& gemm_out_sqrsum,
+    torch::Tensor& next_residual,
+    torch::Tensor& post_mix,
+    torch::Tensor& comb_mix,
+    torch::Tensor& layer_input_out,
+    float rms_eps,
+    float hc_pre_eps,
+    float hc_sinkhorn_eps,
+    float norm_eps,
+    float hc_post_mult_value,
+    int sinkhorn_repeat,
+    int tile_m,
+    int tile_n,
+    int tile_k,
+    int pre_tile_k,
+    int post_store_nt,
+    bool use_large_m,
+    bool use_ar_mhc_full_fusion,
+    bool use_ar_mhc_post_epilogue,
+    bool use_large_m_post_epilogue,
+    bool use_new,
+    bool open_fp8_quant,
+    int64_t reg_ptr,
+    int64_t reg_bytes);
+
+} // namespace aiter

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <torch/extension.h>
+#include "custom_all_reduce.h"
 
 namespace aiter {
 void mhc_pre_gemm_sqrsum(torch::Tensor& out,    // (split_k, m, hc_mult3) / (m, hc_mult3)
@@ -45,6 +46,32 @@ void mhc_post(torch::Tensor& out,            // (m, hc_mult, hidden_size)
               torch::Tensor& post_layer_mix, // (m, hc_mult)
               torch::Tensor& comb_res_mix,   // (m, hc_mult, hc_mult)
               int store_nt                   = -1);
+void launch_fused_ar_mhc_gemm_sqrsum_unified(
+    fptr_t _fa,
+    torch::Tensor& inp,
+    torch::Tensor& gemm_out_mul,
+    torch::Tensor& gemm_out_sqrsum,
+    torch::Tensor& next_residual,
+    torch::Tensor& residual_in,
+    torch::Tensor& post_layer_mix,
+    torch::Tensor& comb_res_mix,
+    torch::Tensor& fn,
+    torch::Tensor& post_mix,
+    torch::Tensor& comb_mix,
+    torch::Tensor& layer_input_out,
+    torch::Tensor& hc_scale,
+    torch::Tensor& hc_base,
+    torch::Tensor& norm_weight,
+    float rms_eps,
+    float hc_pre_eps,
+    float hc_sinkhorn_eps,
+    float norm_eps,
+    float hc_post_mult_value,
+    int sinkhorn_repeat,
+    int tile_m,
+    int tile_n,
+    int tile_k,
+    int64_t reg_ptr = 0);
 void mhc_fused_post_pre_gemm_sqrsum(
     torch::Tensor& gemm_out_mul,    // (split_k * hc_mult, m, hc_mult3)
     torch::Tensor& gemm_out_sqrsum, // (split_k * hc_mult, m)

--- a/csrc/kernels/fused_ar_mhc_rmsnorm.cu
+++ b/csrc/kernels/fused_ar_mhc_rmsnorm.cu
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "fused_ar_mhc_rmsnorm.h"
+#include "custom_all_reduce.cuh"
+#include "mhc.h"
+#include "aiter_enum.h"
+#include "aiter_hip_common.h"
+#include "py_itfs_common.h"
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+
+namespace aiter {
+
+namespace {
+
+aiter_tensor_t make_aiter_tensor(const torch::Tensor& t)
+{
+    AITER_CHECK(t.is_cuda(), "fused AR+MHC requires CUDA tensors");
+    AITER_CHECK(t.dim() <= 8, "tensor rank too large for aiter_tensor_t");
+
+    aiter_tensor_t at{};
+    at.ptr     = t.data_ptr();
+    at.numel_  = static_cast<size_t>(t.numel());
+    at.ndim    = t.dim();
+    for(int i = 0; i < t.dim(); ++i)
+    {
+        at.shape[i]   = t.size(i);
+        at.strides[i] = t.stride(i);
+    }
+    at.device_id = static_cast<int>(t.device().index());
+    switch(t.scalar_type())
+    {
+    case at::ScalarType::Float: at.dtype_ = AITER_DTYPE_fp32; break;
+    case at::ScalarType::Half: at.dtype_ = AITER_DTYPE_fp16; break;
+    case at::ScalarType::BFloat16: at.dtype_ = AITER_DTYPE_bf16; break;
+    default: throw std::runtime_error("fused AR+MHC only supports fp32/fp16/bf16");
+    }
+    return at;
+}
+
+void copy_input_to_registered_buffer(const aiter_tensor_t& inp,
+                                     int m,
+                                     int input_n,
+                                     hipStream_t stream,
+                                     int64_t reg_ptr,
+                                     int64_t reg_bytes)
+{
+    int64_t data_bytes = inp.numel() * inp.element_size();
+    if(reg_ptr == 0)
+        return;
+    if(data_bytes > reg_bytes)
+        throw std::runtime_error("registered buffer is too small to contain the input");
+    HIP_CALL(hipMemcpyAsync((void*)reg_ptr, inp.data_ptr(), data_bytes,
+                            hipMemcpyDeviceToDevice, stream));
+}
+
+template <typename T>
+void run_ar_input_prototype(CustomAllreduce* fa,
+                            hipStream_t stream,
+                            T* inp_ptr,
+                            T* layer_input_ptr,
+                            int m,
+                            int input_n,
+                            int n,
+                            int64_t reg_ptr,
+                            int64_t reg_bytes)
+{
+    void* actual_inp = inp_ptr;
+    if(reg_ptr != 0)
+        actual_inp = (void*)reg_ptr;
+    fa->dispatchAllReduceGatherLayerInputPrototype<T>(
+        stream,
+        reinterpret_cast<T*>(actual_inp),
+        layer_input_ptr,
+        m,
+        input_n,
+        n);
+}
+
+template <typename T>
+void run_ar_mhc_post_large_m(CustomAllreduce* fa,
+                             hipStream_t stream,
+                             T* inp_ptr,
+                             T* next_residual_ptr,
+                             T* residual_ptr,
+                             float* post_layer_mix_ptr,
+                             float* comb_res_mix_ptr,
+                             int m,
+                             int input_n,
+                             int hidden_size,
+                             int residual_stride,
+                             int64_t reg_ptr,
+                             int64_t reg_bytes)
+{
+    void* actual_inp = inp_ptr;
+    if(reg_ptr != 0)
+        actual_inp = (void*)reg_ptr;
+    fa->dispatchAllReduceMhcPostLargeM<T>(stream,
+                                          reinterpret_cast<T*>(actual_inp),
+                                          next_residual_ptr,
+                                          residual_ptr,
+                                          post_layer_mix_ptr,
+                                          comb_res_mix_ptr,
+                                          m,
+                                          input_n,
+                                          hidden_size,
+                                          residual_stride);
+}
+
+template <typename T>
+void dispatch_ar_input(fptr_t _fa,
+                       CustomAllreduce* fa,
+                       hipStream_t stream,
+                       const aiter_tensor_t& inp,
+                       const aiter_tensor_t& layer_input,
+                       bool use_ar_mhc_post_epilogue,
+                       bool use_new,
+                       bool open_fp8_quant,
+                       int64_t reg_ptr,
+                       int64_t reg_bytes)
+{
+    int input_n  = static_cast<int>(inp.size(-1));
+    int n        = static_cast<int>(layer_input.size(-1));
+    int m        = static_cast<int>(inp.numel() / input_n);
+    T* inp_ptr   = reinterpret_cast<T*>(inp.data_ptr());
+    T* layer_ptr = reinterpret_cast<T*>(layer_input.data_ptr());
+
+    if(use_ar_mhc_post_epilogue && input_n == n)
+    {
+        copy_input_to_registered_buffer(inp, m, input_n, stream, reg_ptr, reg_bytes);
+        run_ar_input_prototype<T>(fa, stream, inp_ptr, layer_ptr, m, input_n, n, reg_ptr,
+                                  reg_bytes);
+        return;
+    }
+
+    all_reduce(_fa, inp, layer_input, use_new, open_fp8_quant, reg_ptr, reg_bytes);
+}
+
+void run_mhc_pre_large_m(torch::Tensor& post_mix,
+                         torch::Tensor& comb_mix,
+                         torch::Tensor& layer_input_out,
+                         torch::Tensor& gemm_out,
+                         torch::Tensor& gemm_out_sqrsum,
+                         torch::Tensor& next_residual,
+                         torch::Tensor& fn,
+                         torch::Tensor& hc_scale,
+                         torch::Tensor& hc_base,
+                         torch::Tensor& norm_weight,
+                         int pre_tile_k,
+                         float rms_eps,
+                         float hc_pre_eps,
+                         float hc_sinkhorn_eps,
+                         float norm_eps,
+                         float hc_post_mult_value,
+                         int sinkhorn_repeat)
+{
+    mhc_pre_gemm_sqrsum(gemm_out, gemm_out_sqrsum, next_residual, fn, pre_tile_k);
+    mhc_pre_big_fuse_rmsnorm(post_mix,
+                               comb_mix,
+                               layer_input_out,
+                               gemm_out,
+                               gemm_out_sqrsum,
+                               hc_scale,
+                               hc_base,
+                               next_residual,
+                               norm_weight,
+                               rms_eps,
+                               hc_pre_eps,
+                               hc_sinkhorn_eps,
+                               norm_eps,
+                               hc_post_mult_value,
+                               sinkhorn_repeat);
+}
+
+} // namespace
+
+void fused_allreduce_mhc_fused_post_pre_rmsnorm(
+    fptr_t _fa,
+    torch::Tensor& inp,
+    torch::Tensor& layer_input,
+    torch::Tensor& residual_in,
+    torch::Tensor& post_layer_mix,
+    torch::Tensor& comb_res_mix,
+    torch::Tensor& fn,
+    torch::Tensor& hc_scale,
+    torch::Tensor& hc_base,
+    torch::Tensor& norm_weight,
+    torch::Tensor& gemm_out,
+    torch::Tensor& gemm_out_sqrsum,
+    torch::Tensor& next_residual,
+    torch::Tensor& post_mix,
+    torch::Tensor& comb_mix,
+    torch::Tensor& layer_input_out,
+    float rms_eps,
+    float hc_pre_eps,
+    float hc_sinkhorn_eps,
+    float norm_eps,
+    float hc_post_mult_value,
+    int sinkhorn_repeat,
+    int tile_m,
+    int tile_n,
+    int tile_k,
+    int pre_tile_k,
+    int post_store_nt,
+    bool use_large_m,
+    bool use_ar_mhc_full_fusion,
+    bool use_ar_mhc_post_epilogue,
+    bool use_large_m_post_epilogue,
+    bool use_new,
+    bool open_fp8_quant,
+    int64_t reg_ptr,
+    int64_t reg_bytes)
+{
+    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
+    hipStream_t stream = at::hip::getCurrentHIPStream();
+    auto fa            = reinterpret_cast<CustomAllreduce*>(_fa);
+    auto inp_at        = make_aiter_tensor(inp);
+    auto layer_at      = make_aiter_tensor(layer_input);
+
+    if(use_ar_mhc_full_fusion)
+    {
+        copy_input_to_registered_buffer(inp_at,
+                                        static_cast<int>(inp_at.numel() / inp_at.size(-1)),
+                                        static_cast<int>(inp_at.size(-1)),
+                                        stream,
+                                        reg_ptr,
+                                        reg_bytes);
+        launch_fused_ar_mhc_gemm_sqrsum_unified(_fa,
+                                                inp,
+                                                gemm_out,
+                                                gemm_out_sqrsum,
+                                                next_residual,
+                                                residual_in,
+                                                post_layer_mix,
+                                                comb_res_mix,
+                                                fn,
+                                                post_mix,
+                                                comb_mix,
+                                                layer_input_out,
+                                                hc_scale,
+                                                hc_base,
+                                                norm_weight,
+                                                rms_eps,
+                                                hc_pre_eps,
+                                                hc_sinkhorn_eps,
+                                                norm_eps,
+                                                hc_post_mult_value,
+                                                sinkhorn_repeat,
+                                                tile_m,
+                                                tile_n,
+                                                tile_k,
+                                                reg_ptr);
+        return;
+    }
+
+    if(use_large_m && use_large_m_post_epilogue)
+    {
+        const int m       = static_cast<int>(inp_at.numel() / inp_at.size(-1));
+        const int input_n = static_cast<int>(inp_at.size(-1));
+        const int hidden  = static_cast<int>(residual_in.size(-1));
+        const int stride  = static_cast<int>(residual_in.stride(0));
+        copy_input_to_registered_buffer(inp_at, m, input_n, stream, reg_ptr, reg_bytes);
+
+        switch(inp.scalar_type())
+        {
+        case at::ScalarType::BFloat16: {
+            run_ar_mhc_post_large_m<opus::bf16_t>(
+                fa,
+                stream,
+                reinterpret_cast<opus::bf16_t*>(inp.data_ptr()),
+                reinterpret_cast<opus::bf16_t*>(next_residual.data_ptr()),
+                reinterpret_cast<opus::bf16_t*>(residual_in.data_ptr()),
+                reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+                reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+                m,
+                input_n,
+                hidden,
+                stride,
+                reg_ptr,
+                reg_bytes);
+            break;
+        }
+        case at::ScalarType::Half: {
+            run_ar_mhc_post_large_m<opus::fp16_t>(
+                fa,
+                stream,
+                reinterpret_cast<opus::fp16_t*>(inp.data_ptr()),
+                reinterpret_cast<opus::fp16_t*>(next_residual.data_ptr()),
+                reinterpret_cast<opus::fp16_t*>(residual_in.data_ptr()),
+                reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+                reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+                m,
+                input_n,
+                hidden,
+                stride,
+                reg_ptr,
+                reg_bytes);
+            break;
+        }
+        default:
+            throw std::runtime_error("fused AR+MHC only supports fp16/bf16 activations");
+        }
+
+        run_mhc_pre_large_m(post_mix,
+                            comb_mix,
+                            layer_input_out,
+                            gemm_out,
+                            gemm_out_sqrsum,
+                            next_residual,
+                            fn,
+                            hc_scale,
+                            hc_base,
+                            norm_weight,
+                            pre_tile_k,
+                            rms_eps,
+                            hc_pre_eps,
+                            hc_sinkhorn_eps,
+                            norm_eps,
+                            hc_post_mult_value,
+                            sinkhorn_repeat);
+        return;
+    }
+
+    switch(inp.scalar_type())
+    {
+    case at::ScalarType::BFloat16: {
+        dispatch_ar_input<opus::bf16_t>(_fa,
+                                        fa,
+                                        stream,
+                                        inp_at,
+                                        layer_at,
+                                        use_ar_mhc_post_epilogue,
+                                        use_new,
+                                        open_fp8_quant,
+                                        reg_ptr,
+                                        reg_bytes);
+        break;
+    }
+    case at::ScalarType::Half: {
+        dispatch_ar_input<opus::fp16_t>(_fa,
+                                        fa,
+                                        stream,
+                                        inp_at,
+                                        layer_at,
+                                        use_ar_mhc_post_epilogue,
+                                        use_new,
+                                        open_fp8_quant,
+                                        reg_ptr,
+                                        reg_bytes);
+        break;
+    }
+    default:
+        throw std::runtime_error("fused AR+MHC only supports fp16/bf16 activations");
+    }
+
+    if(use_large_m)
+    {
+        mhc_post(next_residual,
+                 layer_input,
+                 residual_in,
+                 post_layer_mix,
+                 comb_res_mix,
+                 post_store_nt);
+        run_mhc_pre_large_m(post_mix,
+                            comb_mix,
+                            layer_input_out,
+                            gemm_out,
+                            gemm_out_sqrsum,
+                            next_residual,
+                            fn,
+                            hc_scale,
+                            hc_base,
+                            norm_weight,
+                            pre_tile_k,
+                            rms_eps,
+                            hc_pre_eps,
+                            hc_sinkhorn_eps,
+                            norm_eps,
+                            hc_post_mult_value,
+                            sinkhorn_repeat);
+        return;
+    }
+
+    if(use_ar_mhc_post_epilogue)
+    {
+        mhc_post(next_residual,
+                 layer_input,
+                 residual_in,
+                 post_layer_mix,
+                 comb_res_mix,
+                 post_store_nt);
+        run_mhc_pre_large_m(post_mix,
+                            comb_mix,
+                            layer_input_out,
+                            gemm_out,
+                            gemm_out_sqrsum,
+                            next_residual,
+                            fn,
+                            hc_scale,
+                            hc_base,
+                            norm_weight,
+                            pre_tile_k,
+                            rms_eps,
+                            hc_pre_eps,
+                            hc_sinkhorn_eps,
+                            norm_eps,
+                            hc_post_mult_value,
+                            sinkhorn_repeat);
+        return;
+    }
+
+    mhc_fused_post_pre_gemm_sqrsum(gemm_out,
+                                   gemm_out_sqrsum,
+                                   next_residual,
+                                   layer_input,
+                                   residual_in,
+                                   post_layer_mix,
+                                   comb_res_mix,
+                                   fn,
+                                   tile_m,
+                                   tile_n,
+                                   tile_k);
+
+    mhc_pre_big_fuse_rmsnorm(post_mix,
+                               comb_mix,
+                               layer_input_out,
+                               gemm_out,
+                               gemm_out_sqrsum,
+                               hc_scale,
+                               hc_base,
+                               next_residual,
+                               norm_weight,
+                               rms_eps,
+                               hc_pre_eps,
+                               hc_sinkhorn_eps,
+                               norm_eps,
+                               hc_post_mult_value,
+                               sinkhorn_repeat);
+}
+
+} // namespace aiter

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -10,6 +10,10 @@
 #include "rocprim/rocprim.hpp"
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <hipcub/hipcub.hpp>
+#ifdef AITER_FUSED_AR_MHC_MODULE
+#include "custom_all_reduce.h"
+#include "custom_all_reduce.cuh"
+#endif
 
 
 namespace aiter {
@@ -1088,7 +1092,7 @@ namespace aiter {
 
     void mhc_post(
         torch::Tensor& out,
-        torch::Tensor& x, // (m, hc_mult, h)
+        torch::Tensor& x, // (m, hidden_size)
         torch::Tensor& residual, // (m, hc_mult, hidden_size)
         torch::Tensor& post_layer_mix, // (m, hc_mult)
         torch::Tensor& comb_res_mix, // (m, hc_mult, hc_mult)
@@ -1116,8 +1120,7 @@ namespace aiter {
 
 
     template <typename DTYPE_I, int block_size, int hc_mult, int num_rows, int hidden_size, int residual_block, int norm_block, bool use_nt>
-    __global__ __launch_bounds__(block_size,2)
-    void mhc_pre_big_fuse_rmsnorm_kernel(
+    __device__ void mhc_pre_big_fuse_rmsnorm_impl(
         float* post_mix,
         float* comb_mix,
         DTYPE_I* out,
@@ -1136,8 +1139,9 @@ namespace aiter {
         float norm_eps,
         float hc_post_mult_value,
         int sinkhorn_repeat,
-        int n_splits
-    )
+        int n_splits,
+        int bf_block_idx,
+        char* s_work)
     {
         static constexpr int cache_policy = use_nt ? GROUP_NT : RT;
         using opus::operator""_I;
@@ -1157,7 +1161,6 @@ namespace aiter {
         static_assert(num_rows * hc_mult * residual_block % pre_thread_num == 0 && pre_thread_num > 0, 
             "num_rows * hc_mult * residual_block must be divisible by pre_thread_num");
         __shared__ float s_hc_mult3[num_rows * hc_mult3];
-        extern __shared__ char s_work[];
         DTYPE_I* s_layer_input = reinterpret_cast<DTYPE_I*>(s_work);
         float* s_pre_rms_partial = reinterpret_cast<float*>(s_work);
         float* s_hc_mult3_partial = reinterpret_cast<float*>(s_work) + num_rows * warp_num_pow2;
@@ -1165,7 +1168,7 @@ namespace aiter {
         using fp32x4_t = opus::vector_t<float, 4>;
         using floatx8_t = opus::vector_t<float, 8>;
         using halfx8_t = opus::vector_t<DTYPE_I, 8>;
-        const int m_idx = num_rows * blockIdx.x;
+        const int m_idx = num_rows * bf_block_idx;
         const int lane_id = threadIdx.x % warp_size;
         int warp_id = __builtin_amdgcn_readfirstlane(threadIdx.x / warp_size);
         const int m_oob = m < m_idx + num_rows ? (m - m_idx) : num_rows;
@@ -1531,6 +1534,54 @@ namespace aiter {
         }
     }
 
+    template <typename DTYPE_I, int block_size, int hc_mult, int num_rows, int hidden_size, int residual_block, int norm_block, bool use_nt>
+    __global__ __launch_bounds__(block_size, 2)
+    void mhc_pre_big_fuse_rmsnorm_kernel(
+        float* post_mix,
+        float* comb_mix,
+        DTYPE_I* out,
+        float* gemm_out_mul,
+        float* gemm_out_sqrsum,
+        float* hc_scale,
+        float* hc_base,
+        DTYPE_I* residual,
+        DTYPE_I* norm_weight,
+        int m,
+        int gemm_out_mul_stride,
+        int residual_stride,
+        float rms_eps,
+        float hc_pre_eps,
+        float hc_sinkhorn_eps,
+        float norm_eps,
+        float hc_post_mult_value,
+        int sinkhorn_repeat,
+        int n_splits)
+    {
+        extern __shared__ char s_work[];
+        mhc_pre_big_fuse_rmsnorm_impl<DTYPE_I, block_size, hc_mult, num_rows, hidden_size, residual_block, norm_block, use_nt>(
+            post_mix,
+            comb_mix,
+            out,
+            gemm_out_mul,
+            gemm_out_sqrsum,
+            hc_scale,
+            hc_base,
+            residual,
+            norm_weight,
+            m,
+            gemm_out_mul_stride,
+            residual_stride,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            norm_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits,
+            blockIdx.x,
+            s_work);
+    }
+
 #define MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(block_size, hc_mult, num_rows, hidden_size, residual_block, norm_block, use_nt) \
     TORCH_CHECK(hidden_size % residual_block == 0, "hidden_size must be divisible by residual_block"); \
     TORCH_CHECK(hidden_size >= residual_block * 2, "hidden_size must be >= residual_block * 2 stages prefetch"); \
@@ -1640,8 +1691,7 @@ namespace aiter {
     }
 
     template <typename DTYPE_I, int block_size, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt>
-    __global__ __launch_bounds__(block_size, 1)
-    void mhc_fused_post_pre_gemm_sqrsum_kernel(
+    __device__ void mhc_fused_post_pre_gemm_sqrsum_impl(
         float* out,
         float* sqrsum,
         DTYPE_I* next_residual,
@@ -1969,6 +2019,39 @@ namespace aiter {
         }
     }
 
+    template <typename DTYPE_I, int block_size, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt>
+    __global__ __launch_bounds__(block_size, 1)
+    void mhc_fused_post_pre_gemm_sqrsum_kernel(
+        float* out,
+        float* sqrsum,
+        DTYPE_I* next_residual,
+        DTYPE_I* x,
+        DTYPE_I* residual,
+        float* fn,
+        float* post_layer_mix,
+        float* comb_res_mix,
+        int m,
+        int hidden_size,
+        int x_stride,
+        int out_stride,
+        int split_k = 1)
+    {
+        mhc_fused_post_pre_gemm_sqrsum_impl<DTYPE_I, block_size, hc_mult, tile_m, tile_n, tile_k, store_nt>(
+            out,
+            sqrsum,
+            next_residual,
+            x,
+            residual,
+            fn,
+            post_layer_mix,
+            comb_res_mix,
+            m,
+            hidden_size,
+            x_stride,
+            out_stride,
+            split_k);
+    }
+
 #define MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(block_size, tile_m, tile_n, tile_k, store_nt) \
     AITER_DISPATCH_FLOATING16_TYPES(layer_input.scalar_type(), "mhc_fused_post_pre_gemm_sqrsum", [&] { \
         using DTYPE_I = typename t2opus<scalar_t>::type; \
@@ -2091,5 +2174,617 @@ namespace aiter {
         MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
     }
 
+#ifdef AITER_FUSED_AR_MHC_MODULE
+    // -------------------------------------------------------------------------
+    // AR reduce-scatter + MHC fused post/pre GEMM + big_fuse RMSNorm in ONE kernel.
+    // Phase 1: custom AR RS writes reduced activations into IPC tmps (no layer_input).
+    // Phase 2: mhc_fused_post_pre_gemm_sqrsum_impl reads x directly from tmps.
+    // Phase 3: mhc_pre_big_fuse_rmsnorm_impl on bf blocks after GEMM grid sync.
+    // sync_flags[0]=rs_done, sync_flags[1]=gemm_done, sync_flags[2]=gemm_count
+    // -------------------------------------------------------------------------
+
+    template <typename T, int NGPUS, typename DTYPE_I>
+    __global__ void __launch_bounds__(512, 1) fused_ar_mhc_rs_kernel(
+        RankData* _dp,
+        RankSignals sg,
+        Signal* self_sg,
+        int rank,
+        int rs_grid_x,
+        int m,
+        int hidden_dim,
+        int input_hidden_dim)
+    {
+        constexpr int pack_size = 16 / sizeof(T);
+        constexpr int tnum_gpu  = THREAD_NUM / NGPUS;
+        using P                 = typename opus::vector_t<T, pack_size>;
+        using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+
+        if(blockIdx.y != 0 || blockIdx.z != 0 || blockIdx.x >= rs_grid_x)
+        {
+            return;
+        }
+
+        __shared__ T tmp_smem[tnum_gpu * NGPUS * pack_size];
+        int warp_id = threadIdx.x / tnum_gpu;
+        int lane_id = threadIdx.x % tnum_gpu;
+        int tid     = blockIdx.x * tnum_gpu + lane_id;
+        int valid_pack_count = hidden_dim / pack_size;
+        int input_pack_count = input_hidden_dim / pack_size;
+        const P* ptrs[NGPUS];
+        P* tmps[NGPUS];
+#pragma unroll
+        for(int i = 0; i < NGPUS; ++i)
+        {
+            ptrs[i] = (const P*)_dp->ptrs[i];
+            tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+        }
+        start_sync<NGPUS>(sg, self_sg, rank);
+
+        int part = m * valid_pack_count / NGPUS;
+        for(int idx = tid; idx < part; idx += rs_grid_x * tnum_gpu)
+        {
+            int flat_idx  = rank * part + idx;
+            int row       = flat_idx / valid_pack_count;
+            int col       = flat_idx % valid_pack_count;
+            int input_idx = row * input_pack_count + col;
+            P input_reg   = ptrs[warp_id][input_idx];
+            *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x) = input_reg;
+            __syncthreads();
+            if(warp_id == 0)
+            {
+                A add_reg{};
+#pragma unroll
+                for(int i = 0; i < pack_size; ++i)
+                {
+                    add_reg[i] = upcast_s(tmp_smem[pack_size * threadIdx.x + i]);
+                }
+#pragma unroll
+                for(int i = 1; i < NGPUS; ++i)
+                {
+#pragma unroll
+                    for(int j = 0; j < pack_size; ++j)
+                    {
+                        add_reg[j] +=
+                            upcast_s(tmp_smem[i * pack_size * tnum_gpu + pack_size * threadIdx.x + j]);
+                    }
+                }
+                P add_rslt;
+#pragma unroll
+                for(int i = 0; i < pack_size; ++i)
+                {
+                    add_rslt[i] = downcast_s<T>(add_reg[i]);
+                }
+                *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id) = add_rslt;
+            }
+            __syncthreads();
+            P rslt                           = *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id);
+            tmps[warp_id][rank * part + idx] = rslt;
+        }
+        end_sync<NGPUS, false>(sg, self_sg, rank);
+    }
+
+    template <typename T,
+              int NGPUS,
+              typename DTYPE_I,
+              int gemm_block_size,
+              int hc_mult,
+              int tile_m,
+              int tile_n,
+              int tile_k,
+              bool store_nt,
+              int bf_block_size,
+              int bf_num_rows,
+              int bf_hidden,
+              int bf_res_block,
+              int bf_norm_block,
+              bool bf_use_nt>
+    __global__ void __launch_bounds__(512, 2)
+    fused_ar_mhc_full_unified_kernel(
+        RankData* _dp,
+        RankSignals sg,
+        Signal* self_sg,
+        int rank,
+        int rs_grid_x,
+        int mb,
+        int m_blocks_bf,
+        unsigned gemm_blocks_total,
+        int* sync_flags,
+        float* gemm_out,
+        float* sqrsum,
+        DTYPE_I* next_residual,
+        DTYPE_I* residual,
+        float* fn,
+        float* post_layer_mix,
+        float* comb_res_mix,
+        float* post_mix,
+        float* comb_mix,
+        DTYPE_I* layer_input_out,
+        float* hc_scale,
+        float* hc_base,
+        DTYPE_I* norm_weight,
+        int m,
+        int hidden_dim,
+        int input_hidden_dim,
+        int out_stride,
+        int residual_stride,
+        int split_k,
+        float rms_eps,
+        float hc_pre_eps,
+        float hc_sinkhorn_eps,
+        float norm_eps,
+        float hc_post_mult_value,
+        int sinkhorn_repeat)
+    {
+        constexpr int pack_size = 16 / sizeof(T);
+        constexpr int tnum_gpu  = THREAD_NUM / NGPUS;
+        using P                   = typename opus::vector_t<T, pack_size>;
+        using A                   = typename opus::vector_t<opus::fp32_t, pack_size>;
+
+        const bool rs_block =
+            (blockIdx.y == 0 && blockIdx.z == 0 && blockIdx.x < rs_grid_x);
+
+        if(rs_block)
+        {
+            __shared__ T tmp_smem[tnum_gpu * NGPUS * pack_size];
+            int warp_id = threadIdx.x / tnum_gpu;
+            int lane_id = threadIdx.x % tnum_gpu;
+            int tid     = blockIdx.x * tnum_gpu + lane_id;
+            int valid_pack_count  = hidden_dim / pack_size;
+            int input_pack_count  = input_hidden_dim / pack_size;
+            const P* ptrs[NGPUS];
+            P* tmps[NGPUS];
+#pragma unroll
+            for(int i = 0; i < NGPUS; ++i)
+            {
+                ptrs[i] = (const P*)_dp->ptrs[i];
+                tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+            }
+            start_sync<NGPUS>(sg, self_sg, rank);
+
+            int part = m * valid_pack_count / NGPUS;
+            for(int idx = tid; idx < part; idx += rs_grid_x * tnum_gpu)
+            {
+                int flat_idx  = rank * part + idx;
+                int row       = flat_idx / valid_pack_count;
+                int col       = flat_idx % valid_pack_count;
+                int input_idx = row * input_pack_count + col;
+                P input_reg   = ptrs[warp_id][input_idx];
+                *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x) = input_reg;
+                __syncthreads();
+                if(warp_id == 0)
+                {
+                    A add_reg{};
+#pragma unroll
+                    for(int i = 0; i < pack_size; ++i)
+                    {
+                        add_reg[i] = upcast_s(tmp_smem[pack_size * threadIdx.x + i]);
+                    }
+#pragma unroll
+                    for(int i = 1; i < NGPUS; ++i)
+                    {
+#pragma unroll
+                        for(int j = 0; j < pack_size; ++j)
+                        {
+                            add_reg[j] +=
+                                upcast_s(tmp_smem[i * pack_size * tnum_gpu + pack_size * threadIdx.x + j]);
+                        }
+                    }
+                    P add_rslt;
+#pragma unroll
+                    for(int i = 0; i < pack_size; ++i)
+                    {
+                        add_rslt[i] = downcast_s<T>(add_reg[i]);
+                    }
+                    *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id) = add_rslt;
+                }
+                __syncthreads();
+                P rslt                           = *(reinterpret_cast<P*>(&tmp_smem[0]) + lane_id);
+                tmps[warp_id][rank * part + idx] = rslt;
+            }
+            end_sync<NGPUS, false>(sg, self_sg, rank);
+            __syncthreads();
+            if(threadIdx.x == 0)
+            {
+                atomicExch(reinterpret_cast<unsigned*>(&sync_flags[0]), 1u);
+            }
+        }
+
+        if(!rs_block)
+        {
+            while(atomicAdd(reinterpret_cast<unsigned*>(&sync_flags[0]), 0u) == 0u)
+            {
+            }
+        }
+        __threadfence_system();
+
+        const int mb_local = (m + tile_m - 1) / tile_m;
+        if(blockIdx.x < mb_local && threadIdx.x < gemm_block_size)
+        {
+            DTYPE_I* x_tmps = reinterpret_cast<DTYPE_I*>(get_tmp_buf<T>(self_sg));
+            mhc_fused_post_pre_gemm_sqrsum_impl<DTYPE_I,
+                                                gemm_block_size,
+                                                hc_mult,
+                                                tile_m,
+                                                tile_n,
+                                                tile_k,
+                                                store_nt>(gemm_out,
+                                                          sqrsum,
+                                                          next_residual,
+                                                          x_tmps,
+                                                          residual,
+                                                          fn,
+                                                          post_layer_mix,
+                                                          comb_res_mix,
+                                                          m,
+                                                          hidden_dim,
+                                                          hidden_dim,
+                                                          out_stride,
+                                                          split_k);
+        }
+
+        if(blockIdx.x < mb_local && threadIdx.x == 0)
+        {
+            unsigned* gemm_count = reinterpret_cast<unsigned*>(&sync_flags[2]);
+            if(atomicAdd(gemm_count, 1u) + 1u == gemm_blocks_total)
+            {
+                atomicExch(reinterpret_cast<unsigned*>(&sync_flags[1]), 1u);
+            }
+        }
+
+        const int bf_x = static_cast<int>(blockIdx.x) - mb;
+        const bool bf_block =
+            (blockIdx.y == 0 && blockIdx.z == 0 && bf_x >= 0 && bf_x < m_blocks_bf);
+        const bool gemm_block = (blockIdx.x < mb_local);
+        if(gemm_block || bf_block)
+        {
+            while(atomicAdd(reinterpret_cast<unsigned*>(&sync_flags[1]), 0u) == 0u)
+            {
+            }
+            __threadfence_system();
+        }
+
+        if(bf_block && threadIdx.x < bf_block_size)
+        {
+            extern __shared__ char s_bf_work[];
+            mhc_pre_big_fuse_rmsnorm_impl<DTYPE_I,
+                                          bf_block_size,
+                                          hc_mult,
+                                          bf_num_rows,
+                                          bf_hidden,
+                                          bf_res_block,
+                                          bf_norm_block,
+                                          bf_use_nt>(post_mix,
+                                                     comb_mix,
+                                                     layer_input_out,
+                                                     gemm_out,
+                                                     sqrsum,
+                                                     hc_scale,
+                                                     hc_base,
+                                                     next_residual,
+                                                     norm_weight,
+                                                     m,
+                                                     out_stride,
+                                                     residual_stride,
+                                                     rms_eps,
+                                                     hc_pre_eps,
+                                                     hc_sinkhorn_eps,
+                                                     norm_eps,
+                                                     hc_post_mult_value,
+                                                     sinkhorn_repeat,
+                                                     split_k,
+                                                     bf_x,
+                                                     s_bf_work);
+        }
+    }
+
+    // Keep legacy alias for tooling; full path uses fused_ar_mhc_full_unified_kernel.
+    template <typename T,
+              int NGPUS,
+              typename DTYPE_I,
+              int block_size,
+              int hc_mult,
+              int tile_m,
+              int tile_n,
+              int tile_k,
+              bool store_nt>
+    __global__ void __launch_bounds__(256, 1) fused_ar_mhc_gemm_sqrsum_unified_kernel(
+        RankData* _dp,
+        RankSignals sg,
+        Signal* self_sg,
+        int rank,
+        float* gemm_out,
+        float* sqrsum,
+        DTYPE_I* next_residual,
+        DTYPE_I* residual,
+        float* fn,
+        float* post_layer_mix,
+        float* comb_res_mix,
+        int m,
+        int hidden_dim,
+        int out_stride,
+        int split_k)
+    {
+        const int mb = (m + tile_m - 1) / tile_m;
+        if(blockIdx.x < mb && threadIdx.x < block_size)
+        {
+            DTYPE_I* x_tmps = reinterpret_cast<DTYPE_I*>(get_tmp_buf<T>(self_sg));
+            mhc_fused_post_pre_gemm_sqrsum_impl<DTYPE_I,
+                                                block_size,
+                                                hc_mult,
+                                                tile_m,
+                                                tile_n,
+                                                tile_k,
+                                                store_nt>(gemm_out,
+                                                          sqrsum,
+                                                          next_residual,
+                                                          x_tmps,
+                                                          residual,
+                                                          fn,
+                                                          post_layer_mix,
+                                                          comb_res_mix,
+                                                          m,
+                                                          hidden_dim,
+                                                          hidden_dim,
+                                                          out_stride,
+                                                          split_k);
+        }
+    }
+
+#define FUSED_AR_MHC_FULL_UNIFIED_KERNEL_IMPL_(gemm_block_size, tile_m, tile_n, tile_k, store_nt, bf_block_size, bf_num_rows, bf_hidden, bf_res_block, bf_norm_block, bf_use_nt, ngpus) \
+    AITER_DISPATCH_FLOATING16_TYPES(inp.scalar_type(), "fused_ar_mhc_full_unified", [&] { \
+        using DTYPE_I = typename t2opus<scalar_t>::type; \
+        using T       = DTYPE_I; \
+        int mb        = (m + tile_m - 1) / tile_m; \
+        int n_blocks  = (hc_mult3 + tile_n - 1) / tile_n; \
+        int m_blocks_bf = (m + bf_num_rows - 1) / bf_num_rows; \
+        dim3 grid(std::max(rs_grid_x, mb), n_blocks, split_k); \
+        dim3 block(gemm_block_size); \
+        unsigned gemm_blocks_total = static_cast<unsigned>(mb * n_blocks * split_k); \
+        size_t layer_input_smem = static_cast<size_t>(bf_num_rows) * static_cast<size_t>(bf_hidden) * sizeof(DTYPE_I); \
+        constexpr int hc_mult3_local = 4 * 4 + 2 * 4; \
+        constexpr int hc_mult3_threads = bf_num_rows * hc_mult3_local / 4; \
+        constexpr int reduce_splits_per_round = bf_block_size / hc_mult3_threads; \
+        size_t hc_partial_smem = static_cast<size_t>(reduce_splits_per_round) * static_cast<size_t>(bf_num_rows) * static_cast<size_t>(hc_mult3_local) * sizeof(float); \
+        size_t smem_bytes = layer_input_smem > hc_partial_smem ? layer_input_smem : hc_partial_smem; \
+        fused_ar_mhc_full_unified_kernel<T, ngpus, DTYPE_I, gemm_block_size, 4, tile_m, tile_n, tile_k, store_nt, bf_block_size, bf_num_rows, bf_hidden, bf_res_block, bf_norm_block, bf_use_nt> \
+            <<<grid, block, smem_bytes, stream>>>(ptrs, \
+                                                  fa->sg_, \
+                                                  fa->self_sg_, \
+                                                  fa->rank_, \
+                                                  rs_grid_x, \
+                                                  mb, \
+                                                  m_blocks_bf, \
+                                                  gemm_blocks_total, \
+                                                  sync_flags_ptr, \
+                                                  reinterpret_cast<float*>(gemm_out_mul.data_ptr()), \
+                                                  reinterpret_cast<float*>(gemm_out_sqrsum.data_ptr()), \
+                                                  reinterpret_cast<DTYPE_I*>(next_residual.data_ptr()), \
+                                                  reinterpret_cast<DTYPE_I*>(residual_in.data_ptr()), \
+                                                  reinterpret_cast<float*>(fn.data_ptr()), \
+                                                  reinterpret_cast<float*>(post_layer_mix.data_ptr()), \
+                                                  reinterpret_cast<float*>(comb_res_mix.data_ptr()), \
+                                                  reinterpret_cast<float*>(post_mix.data_ptr()), \
+                                                  reinterpret_cast<float*>(comb_mix.data_ptr()), \
+                                                  reinterpret_cast<DTYPE_I*>(layer_input_out.data_ptr()), \
+                                                  reinterpret_cast<float*>(hc_scale.data_ptr()), \
+                                                  reinterpret_cast<float*>(hc_base.data_ptr()), \
+                                                  reinterpret_cast<DTYPE_I*>(norm_weight.data_ptr()), \
+                                                  m, \
+                                                  hidden_size, \
+                                                  input_hidden_dim, \
+                                                  out_stride, \
+                                                  residual_stride, \
+                                                  split_k, \
+                                                  rms_eps, \
+                                                  hc_pre_eps, \
+                                                  hc_sinkhorn_eps, \
+                                                  norm_eps, \
+                                                  hc_post_mult_value, \
+                                                  sinkhorn_repeat); \
+    });
+
+#define FUSED_AR_MHC_FULL_UNIFIED_KERNEL_IMPL(gemm_block_size, tile_m, tile_n, tile_k, bf_block_size, bf_num_rows, bf_hidden, bf_res_block, bf_norm_block, bf_use_nt, ngpus) \
+    if(m >= 8 * cu_num) { \
+        FUSED_AR_MHC_FULL_UNIFIED_KERNEL_IMPL_(gemm_block_size, tile_m, tile_n, tile_k, true, bf_block_size, bf_num_rows, bf_hidden, bf_res_block, bf_norm_block, bf_use_nt, ngpus); \
+    } else { \
+        FUSED_AR_MHC_FULL_UNIFIED_KERNEL_IMPL_(gemm_block_size, tile_m, tile_n, tile_k, false, bf_block_size, bf_num_rows, bf_hidden, bf_res_block, bf_norm_block, bf_use_nt, ngpus); \
+    }
+
+#define FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(TM, TN, TK, bf_block_size, bf_num_rows, bf_hidden, bf_res_block, bf_norm_block, bf_use_nt, ngpus) \
+    if(tile_m == TM && tile_n == TN && tile_k == TK) { \
+        FUSED_AR_MHC_FULL_UNIFIED_KERNEL_IMPL(256, TM, TN, TK, bf_block_size, bf_num_rows, bf_hidden, bf_res_block, bf_norm_block, bf_use_nt, ngpus); \
+    } else
+
+#define FUSED_AR_MHC_FULL_UNIFIED_DISPATCH_4096(ngpus) \
+    if(m < 4 * cu_num) { \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 16, 32, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 32, 32, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 16, 32, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 32, 32, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(64, 16, 32, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(64, 32, 32, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 16, 64, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 32, 64, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 16, 64, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 32, 64, (64 + 64 * 4), 1, 4096, 1024, 1024, false, ngpus) \
+        { TORCH_CHECK(false, "fused AR+MHC full: unsupported tile config"); } \
+    } else if(m <= 8 * cu_num) { \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 16, 32, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 32, 32, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 16, 32, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 32, 32, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(64, 16, 32, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(64, 32, 32, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 16, 64, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 32, 64, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 16, 64, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 32, 64, (64 + 64 * 4), 2, 4096, 512, 512, false, ngpus) \
+        { TORCH_CHECK(false, "fused AR+MHC full: unsupported tile config"); } \
+    } else { \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 16, 32, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 32, 32, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 16, 32, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 32, 32, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(64, 16, 32, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(64, 32, 32, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 16, 64, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(16, 32, 64, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 16, 64, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        FUSED_AR_MHC_FULL_UNIFIED_TILE_BF_CASE(32, 32, 64, (64 + 64 * 4), 2, 4096, 512, 512, true, ngpus) \
+        { TORCH_CHECK(false, "fused AR+MHC full: unsupported tile config"); } \
+    }
+
+#define FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_IMPL_(block_size, tile_m, tile_n, tile_k, store_nt, ngpus) \
+    AITER_DISPATCH_FLOATING16_TYPES(inp.scalar_type(), "fused_ar_mhc_gemm_sqrsum_unified", [&] { \
+        using DTYPE_I = typename t2opus<scalar_t>::type; \
+        using T       = DTYPE_I; \
+        int mb        = (m + tile_m - 1) / tile_m; \
+        int n_blocks  = (hc_mult3 + tile_n - 1) / tile_n; \
+        dim3 rs_grid(rs_grid_x, 1, 1); \
+        dim3 rs_block(THREAD_NUM); \
+        fused_ar_mhc_rs_kernel<T, ngpus, DTYPE_I><<<rs_grid, rs_block, 0, stream>>>(ptrs, \
+                                                                                    fa->sg_, \
+                                                                                    fa->self_sg_, \
+                                                                                    fa->rank_, \
+                                                                                    rs_grid_x, \
+                                                                                    m, \
+                                                                                    hidden_size, \
+                                                                                    input_hidden_dim); \
+        dim3 grid(mb, n_blocks, split_k); \
+        dim3 block(block_size); \
+        fused_ar_mhc_gemm_sqrsum_unified_kernel<T, ngpus, DTYPE_I, block_size, 4, tile_m, tile_n, tile_k, store_nt> \
+            <<<grid, block, 0, stream>>>(ptrs, \
+                                         fa->sg_, \
+                                         fa->self_sg_, \
+                                         fa->rank_, \
+                                         reinterpret_cast<float*>(gemm_out_mul.data_ptr()), \
+                                         reinterpret_cast<float*>(gemm_out_sqrsum.data_ptr()), \
+                                         reinterpret_cast<DTYPE_I*>(next_residual.data_ptr()), \
+                                         reinterpret_cast<DTYPE_I*>(residual_in.data_ptr()), \
+                                         reinterpret_cast<float*>(fn.data_ptr()), \
+                                         reinterpret_cast<float*>(post_layer_mix.data_ptr()), \
+                                         reinterpret_cast<float*>(comb_res_mix.data_ptr()), \
+                                         m, \
+                                         hidden_size, \
+                                         out_stride, \
+                                         split_k); \
+    });
+
+#define FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_IMPL(block_size, tile_m, tile_n, tile_k, ngpus) \
+    if(m >= 8 * cu_num) { \
+        FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_IMPL_(block_size, tile_m, tile_n, tile_k, true, ngpus); \
+    } else { \
+        FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_IMPL_(block_size, tile_m, tile_n, tile_k, false, ngpus); \
+    }
+
+#define FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(TM, TN, TK, ngpus) \
+    if(tile_m == TM && tile_n == TN && tile_k == TK) { \
+        FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_IMPL(256, TM, TN, TK, ngpus); \
+    } else
+
+#define FUSED_AR_MHC_GEMM_UNIFIED_DISPATCH(ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(16, 16, 32, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(16, 32, 32, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(32, 16, 32, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(32, 32, 32, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(64, 16, 32, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(64, 32, 32, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(16, 16, 64, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(16, 32, 64, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(32, 16, 64, ngpus) \
+    FUSED_AR_MHC_GEMM_UNIFIED_KERNEL_CASE(32, 32, 64, ngpus) \
+    { \
+        TORCH_CHECK(false, "fused AR+MHC GEMM: unsupported tile config"); \
+    }
+
+    void launch_fused_ar_mhc_gemm_sqrsum_unified(
+        fptr_t _fa,
+        torch::Tensor& inp,
+        torch::Tensor& gemm_out_mul,
+        torch::Tensor& gemm_out_sqrsum,
+        torch::Tensor& next_residual,
+        torch::Tensor& residual_in,
+        torch::Tensor& post_layer_mix,
+        torch::Tensor& comb_res_mix,
+        torch::Tensor& fn,
+        torch::Tensor& post_mix,
+        torch::Tensor& comb_mix,
+        torch::Tensor& layer_input_out,
+        torch::Tensor& hc_scale,
+        torch::Tensor& hc_base,
+        torch::Tensor& norm_weight,
+        float rms_eps,
+        float hc_pre_eps,
+        float hc_sinkhorn_eps,
+        float norm_eps,
+        float hc_post_mult_value,
+        int sinkhorn_repeat,
+        int tile_m,
+        int tile_n,
+        int tile_k,
+        int64_t reg_ptr)
+    {
+        const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
+        auto fa                  = reinterpret_cast<CustomAllreduce*>(_fa);
+        const hipStream_t stream = at::hip::getCurrentHIPStream();
+        void* ar_inp             = inp.data_ptr();
+        if(reg_ptr != 0)
+            ar_inp = reinterpret_cast<void*>(reg_ptr);
+        RankData* ptrs = fa->get_buffer_RD(stream, ar_inp);
+
+        int m                 = inp.size(0);
+        int input_hidden_dim  = inp.size(-1);
+        int hidden_size       = input_hidden_dim;
+        int hc_mult3          = fn.size(0);
+        int split_k           = gemm_out_sqrsum.size(0);
+        int out_stride        = gemm_out_mul.stride(1);
+        int residual_stride   = next_residual.stride(1);
+        const int cu_num      = get_num_cu_func();
+
+        TORCH_CHECK(inp.scalar_type() == residual_in.scalar_type(),
+                    "inp/residual dtype mismatch");
+        TORCH_CHECK(hidden_size % 256 == 0,
+                    "fused AR+MHC GEMM requires hidden_size % 256 == 0");
+        TORCH_CHECK(input_hidden_dim == hidden_size,
+                    "fused AR+MHC GEMM requires full hidden shard in inp");
+        TORCH_CHECK(hidden_size % (tile_k * split_k) == 0,
+                    "hidden_size must be divisible by tile_k * split_k");
+
+        int size      = m * hidden_size;
+        int block_num = ((size / fa->world_size_) + THREAD_NUM - 1) / THREAD_NUM;
+        int rs_grid_x = std::min(block_num, kMaxBlocks);
+
+        switch(fa->world_size_)
+        {
+        case 2:
+            FUSED_AR_MHC_GEMM_UNIFIED_DISPATCH(2);
+            break;
+        case 4:
+            FUSED_AR_MHC_GEMM_UNIFIED_DISPATCH(4);
+            break;
+        case 8:
+            FUSED_AR_MHC_GEMM_UNIFIED_DISPATCH(8);
+            break;
+        default:
+            throw std::runtime_error("fused AR+MHC GEMM: unsupported world_size");
+        }
+
+        mhc_pre_big_fuse_rmsnorm(post_mix,
+                                 comb_mix,
+                                 layer_input_out,
+                                 gemm_out_mul,
+                                 gemm_out_sqrsum,
+                                 hc_scale,
+                                 hc_base,
+                                 next_residual,
+                                 norm_weight,
+                                 rms_eps,
+                                 hc_pre_eps,
+                                 hc_sinkhorn_eps,
+                                 norm_eps,
+                                 hc_post_mult_value,
+                                 sinkhorn_repeat);
+    }
+#endif // AITER_FUSED_AR_MHC_MODULE
 
 } // namespace aiter

--- a/csrc/pybind/fused_ar_mhc_pybind.cu
+++ b/csrc/pybind/fused_ar_mhc_pybind.cu
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include <torch/extension.h>
+#include "aiter_stream.h"
+#include "fused_ar_mhc_rmsnorm.h"
+#include "rocm_ops.hpp"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND;
+    m.def("fused_allreduce_mhc_fused_post_pre_rmsnorm",
+          &aiter::fused_allreduce_mhc_fused_post_pre_rmsnorm,
+          py::arg("_fa"),
+          py::arg("inp"),
+          py::arg("layer_input"),
+          py::arg("residual_in"),
+          py::arg("post_layer_mix"),
+          py::arg("comb_res_mix"),
+          py::arg("fn"),
+          py::arg("hc_scale"),
+          py::arg("hc_base"),
+          py::arg("norm_weight"),
+          py::arg("gemm_out"),
+          py::arg("gemm_out_sqrsum"),
+          py::arg("next_residual"),
+          py::arg("post_mix"),
+          py::arg("comb_mix"),
+          py::arg("layer_input_out"),
+          py::arg("rms_eps") = 1e-6f,
+          py::arg("hc_pre_eps") = 1e-6f,
+          py::arg("hc_sinkhorn_eps") = 1e-6f,
+          py::arg("norm_eps") = 1e-6f,
+          py::arg("hc_post_mult_value") = 1.0f,
+          py::arg("sinkhorn_repeat") = 20,
+          py::arg("tile_m") = 16,
+          py::arg("tile_n") = 32,
+          py::arg("tile_k") = 32,
+          py::arg("pre_tile_k") = 64,
+          py::arg("post_store_nt") = -1,
+          py::arg("use_large_m") = false,
+          py::arg("use_ar_mhc_full_fusion") = false,
+          py::arg("use_ar_mhc_post_epilogue") = false,
+          py::arg("use_large_m_post_epilogue") = false,
+          py::arg("use_new") = true,
+          py::arg("open_fp8_quant") = false,
+          py::arg("reg_ptr") = static_cast<int64_t>(0),
+          py::arg("reg_bytes") = static_cast<int64_t>(0));
+}

--- a/op_tests/multigpu_tests/test_fused_ar_mhc_rms.py
+++ b/op_tests/multigpu_tests/test_fused_ar_mhc_rms.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import argparse
+import itertools
+import logging
+import os
+from multiprocessing import Pool, freeze_support, set_start_method
+from statistics import median
+from typing import Optional
+
+import pandas as pd
+import torch
+import torch.distributed as dist
+
+import aiter
+from aiter import dtypes
+from aiter.dist.communication_op import (
+    tensor_model_parallel_all_reduce,
+    tensor_model_parallel_fused_allreduce_mhc_fused_post_pre_rmsnorm,
+)
+from aiter.dist.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    ensure_model_parallel_initialized,
+    get_tp_group,
+    graph_capture,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+from aiter.test_common import benchmark, checkAllclose, perftest
+
+logger = logging.getLogger("aiter")
+
+set_start_method("spawn", force=True)
+
+JIT_WARMUP_ITERS = 5
+BENCH_WARMUP = 2
+BENCH_ITERS = 101
+
+EXTRA_ARGS = {
+    "rms_eps": 1e-6,
+    "hc_pre_eps": 1e-6,
+    "hc_sinkhorn_eps": 1e-6,
+    "hc_post_mult_value": 2.0,
+    "sinkhorn_repeat": 20,
+}
+
+
+def _make_inputs(
+    m: int,
+    hidden_size: int,
+    rank: int,
+    device: torch.device,
+    *,
+    hc_mult: int = 4,
+) -> dict[str, torch.Tensor]:
+    torch.manual_seed(20260611)
+    hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
+    base_layer_input = torch.randn(m, hidden_size, dtype=dtypes.bf16, device=device)
+    return {
+        "layer_input": base_layer_input * float(rank + 1),
+        "residual_in": torch.randn(
+            m, hc_mult, hidden_size, dtype=dtypes.bf16, device=device
+        ),
+        "post_layer_mix": torch.randn(m, hc_mult, 1, dtype=dtypes.fp32, device=device),
+        "comb_res_mix": torch.randn(
+            m, hc_mult, hc_mult, dtype=dtypes.fp32, device=device
+        ),
+        "fn": torch.randn(
+            hc_mult3, hc_mult * hidden_size, dtype=dtypes.fp32, device=device
+        ),
+        "hc_scale": torch.randn((3,), dtype=dtypes.fp32, device=device) * 0.1,
+        "hc_base": torch.randn((hc_mult3,), dtype=dtypes.fp32, device=device) * 0.1,
+        "norm_weight": torch.randn(hidden_size, dtype=dtypes.bf16, device=device),
+    }
+
+
+def _run_split_mhc(tensors: dict[str, torch.Tensor], *, force_fused: bool):
+    reduced = tensor_model_parallel_all_reduce(tensors["layer_input"])
+    return aiter.mhc_fused_post_pre(
+        reduced,
+        tensors["residual_in"],
+        tensors["post_layer_mix"],
+        tensors["comb_res_mix"],
+        tensors["fn"],
+        tensors["hc_scale"],
+        tensors["hc_base"],
+        norm_weight=tensors["norm_weight"],
+        norm_eps=1e-6,
+        force_fused=force_fused,
+        **EXTRA_ARGS,
+    )
+
+
+def _run_fused_mhc(tensors: dict[str, torch.Tensor], *, force_fused: bool):
+    return tensor_model_parallel_fused_allreduce_mhc_fused_post_pre_rmsnorm(
+        tensors["layer_input"],
+        tensors["residual_in"],
+        tensors["post_layer_mix"],
+        tensors["comb_res_mix"],
+        tensors["fn"],
+        tensors["hc_scale"],
+        tensors["hc_base"],
+        tensors["norm_weight"],
+        norm_eps=1e-6,
+        force_fused=force_fused,
+        **EXTRA_ARGS,
+    )
+
+
+def _max_mhc_err(ref, out, *, m: int, rank: int, tag: str) -> float:
+    return max(
+        checkAllclose(ref[0], out[0], msg=f"{tag}/post_mix m={m} rank={rank}"),
+        checkAllclose(ref[1], out[1], msg=f"{tag}/comb_mix m={m} rank={rank}"),
+        checkAllclose(ref[2], out[2], msg=f"{tag}/layer_input m={m} rank={rank}"),
+        checkAllclose(ref[3], out[3], msg=f"{tag}/next_residual m={m} rank={rank}"),
+    )
+
+
+def _jit_warmup(
+    tensors: dict[str, torch.Tensor],
+    *,
+    force_fused: bool,
+    run_split: bool,
+    run_fused: bool,
+    jit_warmup_iters: int,
+):
+    for _ in range(jit_warmup_iters):
+        if run_split:
+            _run_split_mhc(tensors, force_fused=force_fused)
+        if run_fused:
+            _run_fused_mhc(tensors, force_fused=force_fused)
+    torch.cuda.synchronize()
+
+
+def _bench_path(fn, *, with_graph: bool, graph_holder: dict):
+    if with_graph:
+        if "graph" not in graph_holder:
+            graph = torch.cuda.CUDAGraph()
+            with graph_capture() as gc:
+                with torch.cuda.graph(graph, stream=gc.stream):
+                    fn()
+            graph_holder["graph"] = graph
+
+        graph = graph_holder["graph"]
+
+        @perftest(num_warmup=BENCH_WARMUP, num_iters=BENCH_ITERS)
+        def run_replay():
+            graph.replay()
+
+        _, us = run_replay()
+        return us
+
+    @perftest(num_warmup=BENCH_WARMUP, num_iters=BENCH_ITERS)
+    def run_eager():
+        return fn()
+
+    _, us = run_eager()
+    return us
+
+
+def ar_mhc_rmsnorm_worker(
+    tp_size,
+    pp_size,
+    rankID,
+    shape,
+    force_fused,
+    withGraph,
+    distributed_init_method,
+    run_split,
+    run_fused,
+    jit_warmup_iters,
+):
+    device = torch.device(f"cuda:{rankID}")
+    torch.cuda.set_device(device)
+    logger.info("RANK: %s tp=%s init_process_group...", rankID, tp_size)
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=tp_size,
+        rank=rankID,
+        distributed_init_method=distributed_init_method,
+    )
+    ensure_model_parallel_initialized(tp_size, pp_size)
+    m, hidden_size = shape
+    tensors = _make_inputs(m, hidden_size, rankID, device=device)
+
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, device=device), group=group)
+    torch.cuda.synchronize()
+
+    _jit_warmup(
+        tensors,
+        force_fused=force_fused,
+        run_split=run_split,
+        run_fused=run_fused,
+        jit_warmup_iters=jit_warmup_iters,
+    )
+
+    err = 0.0
+    if run_fused:
+        ref = _run_split_mhc(tensors, force_fused=force_fused)
+        fused_out = _run_fused_mhc(tensors, force_fused=force_fused)
+        err = _max_mhc_err(ref, fused_out, m=m, rank=rankID, tag="fused_ar_mhc")
+
+    split_us = None
+    fused_us = None
+    split_graph_holder: dict = {}
+    fused_graph_holder: dict = {}
+
+    if run_split:
+        split_us = _bench_path(
+            lambda: _run_split_mhc(tensors, force_fused=force_fused),
+            with_graph=withGraph,
+            graph_holder=split_graph_holder,
+        )
+
+    if run_fused:
+        fused_us = _bench_path(
+            lambda: _run_fused_mhc(tensors, force_fused=force_fused),
+            with_graph=withGraph,
+            graph_holder=fused_graph_holder,
+        )
+
+    if dist.is_initialized():
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        torch.cuda.empty_cache()
+
+    return {
+        "split_us": split_us,
+        "fused_us": fused_us,
+        "err": err,
+    }
+
+
+def _aggregate_us(values: list[float], prefix: str) -> dict[str, float]:
+    if not values:
+        return {}
+    return {
+        f"{prefix}_median_us": median(values),
+        f"{prefix}_min_us": min(values),
+        f"{prefix}_max_us": max(values),
+    }
+
+
+@benchmark()
+def test_ar_mhc_rmsnorm(
+    tp_size,
+    pp_size,
+    shape,
+    force_fused,
+    withGraph=False,
+    distributed_init_method: Optional[str] = None,
+    run_tests=None,
+    jit_warmup_iters: int = JIT_WARMUP_ITERS,
+):
+    if run_tests is None:
+        run_tests = ("split", "fused")
+    run_split = "split" in run_tests
+    run_fused = "fused" in run_tests
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "49373"
+    pool = Pool(processes=tp_size)
+    rets = []
+    for rank in range(tp_size):
+        rets.append(
+            pool.apply_async(
+                ar_mhc_rmsnorm_worker,
+                args=(
+                    tp_size,
+                    pp_size,
+                    rank,
+                    shape,
+                    force_fused,
+                    withGraph,
+                    distributed_init_method,
+                    run_split,
+                    run_fused,
+                    jit_warmup_iters,
+                ),
+            )
+        )
+    pool.close()
+    pool.join()
+    rets = [el.get() for el in rets]
+
+    m, hidden_size = shape
+    out: dict = {}
+    if run_split:
+        split_us = [r["split_us"] for r in rets if r["split_us"] is not None]
+        out.update(_aggregate_us(split_us, "split"))
+    if run_fused:
+        fused_us = [r["fused_us"] for r in rets if r["fused_us"] is not None]
+        out.update(_aggregate_us(fused_us, "fused"))
+        out["fused_err"] = max(r["err"] for r in rets)
+
+    for rank, r in enumerate(rets):
+        msg = (
+            f"test_ar_mhc_rmsnorm: shape={(m, hidden_size)} tp={tp_size} "
+            f"force_fused={force_fused} withGraph={withGraph} rank={rank} "
+            f"split_us={r['split_us']} fused_us={r['fused_us']}"
+        )
+        if run_fused:
+            logger.info("%s err=%s", msg, r["err"])
+        else:
+            logger.info("%s", msg)
+
+    if run_split and run_fused:
+        split_med = out.get("split_median_us")
+        fused_med = out.get("fused_median_us")
+        if split_med and fused_med and split_med > 0:
+            out["speedup_pct"] = (split_med - fused_med) / split_med * 100.0
+
+    return out
+
+
+try:
+    import pytest
+
+    def test_fused_ar_mhc_rms_tp2_smoke():
+        if torch.cuda.device_count() < 2:
+            pytest.skip(f"requires >=2 GPUs, got {torch.cuda.device_count()}")
+        ret = test_ar_mhc_rmsnorm(
+            tp_size=2,
+            pp_size=1,
+            shape=(16, 4096),
+            force_fused=True,
+            withGraph=True,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(), get_open_port()
+            ),
+            run_tests=("split", "fused"),
+        )
+        assert ret["fused_err"] == 0
+
+except ImportError:
+    pass
+
+
+l_shape = [
+    (1, 4096),
+    (2, 4096),
+    (4, 4096),
+    (16, 4096),
+    (32, 4096),
+    (128, 4096),
+    (1024, 4096),
+    (2048, 4096),
+    (8192, 4096),
+]
+l_tp = [2]
+l_pp = [1]
+l_graph = [True]
+l_force_fused = [True]
+
+parser = argparse.ArgumentParser(description="config input of test")
+parser.add_argument(
+    "-s",
+    "--shape",
+    type=dtypes.str2tuple,
+    nargs="*",
+    default=None,
+    help="shape(s) as M,hidden_size. e.g. -s 16,4096 128,4096",
+)
+parser.add_argument(
+    "-t",
+    "--tp",
+    type=int,
+    nargs="?",
+    const=None,
+    default=None,
+    help="tp size (single). e.g. -t 2. Ignored if --tp-sizes is set.",
+)
+parser.add_argument(
+    "--tp-sizes",
+    type=lambda s: [int(x) for x in s.split(",") if x.strip()],
+    default=None,
+    help="comma-separated TP sizes from {2, 4, 6, 8}, e.g. --tp-sizes 2,4,8",
+)
+parser.add_argument(
+    "-p",
+    "--pp",
+    type=int,
+    nargs="?",
+    const=None,
+    default=None,
+    help="pp size. e.g. -p 1",
+)
+parser.add_argument(
+    "-g",
+    "--graphon",
+    type=int,
+    nargs="?",
+    const=None,
+    default=None,
+    help="use CUDA graph: 1=on (default), 0=off. e.g. -g 0",
+)
+parser.add_argument(
+    "--jit-warmup",
+    type=int,
+    default=JIT_WARMUP_ITERS,
+    help=f"JIT warmup iterations per path before timing (default {JIT_WARMUP_ITERS})",
+)
+parser.add_argument(
+    "--force-fused",
+    action="store_true",
+    help="use force_fused=True in mhc_fused_post_pre / fused AR+MHC path",
+)
+l_test_types = ["split", "fused"]
+parser.add_argument(
+    "--test",
+    type=str,
+    choices=l_test_types,
+    nargs="*",
+    default=None,
+    help="test type(s) to run. e.g. --test split fused",
+)
+
+
+if __name__ == "__main__":
+    freeze_support()
+    args = parser.parse_args()
+    if args.shape is not None:
+        l_shape = args.shape
+    if args.tp_sizes is not None:
+        l_tp = args.tp_sizes
+    elif args.tp is not None:
+        l_tp = [args.tp]
+    if args.pp is not None:
+        l_pp = [args.pp]
+    if args.graphon is not None:
+        l_graph = [bool(args.graphon)]
+    if args.force_fused:
+        l_force_fused = [True]
+    run_tests = tuple(args.test if args.test else l_test_types)
+    df = []
+    for shape, tp, pp, graph_on, force_fused in itertools.product(
+        l_shape, l_tp, l_pp, l_graph, l_force_fused
+    ):
+        row = {
+            "tp_size": tp,
+            "shape": shape,
+            "force_fused": force_fused,
+            "withGraph": graph_on,
+            "jit_warmup": args.jit_warmup,
+        }
+        ret = test_ar_mhc_rmsnorm(
+            tp,
+            pp,
+            shape,
+            force_fused,
+            withGraph=graph_on,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(), get_open_port()
+            ),
+            run_tests=run_tests,
+            jit_warmup_iters=args.jit_warmup,
+        )
+        row.update(ret)
+        df.append(row)
+    df = pd.DataFrame(df)
+    show_cols = [
+        "tp_size",
+        "shape",
+        "force_fused",
+        "withGraph",
+        "jit_warmup",
+        "split_median_us",
+        "split_min_us",
+        "split_max_us",
+        "fused_median_us",
+        "fused_min_us",
+        "fused_max_us",
+        "fused_err",
+        "speedup_pct",
+    ]
+    show_cols = [c for c in show_cols if c in df.columns]
+    logger.info(
+        "fused allreduce mhc rmsnorm summary (markdown):\n%s",
+        df[show_cols].to_markdown(index=False),
+    )

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -16,8 +16,9 @@ import pandas as pd
 from typing import Optional
 
 try:
-    from aiter.ops.mhc import mhc_fused_post_pre_large_m
+    from aiter.ops.mhc import get_mhc_pre_splitk_large_m, mhc_fused_post_pre_large_m
 except ImportError:
+    get_mhc_pre_splitk_large_m = None
     mhc_fused_post_pre_large_m = None
 
 # gfx950 large-M path (mhc_fused_post_pre_large_m) applies when M > 1024.
@@ -925,6 +926,10 @@ def test_mhc_post_pre(m, hidden_size, hc_mult, fuse_rmsnorm=False, large_m=False
         elif mhc_fused_post_pre_large_m is None:
             aiter.logger.info("skip large_m_us: mhc_fused_post_pre_large_m unavailable")
         else:
+            if get_mhc_pre_splitk_large_m is not None:
+                splitk, tile_k = get_mhc_pre_splitk_large_m(m, hc_hidden_size)
+                ret["large_m_splitk"] = splitk
+                ret["large_m_tile_k"] = tile_k
             (_, _, layer_input_large_m, _), large_m_us = run_perftest(
                 mhc_fused_post_pre_large_m,
                 layer_input,

--- a/scripts/bench_ar_mhc_m1_8192.sh
+++ b/scripts/bench_ar_mhc_m1_8192.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG="${1:-/tmp/ar_mhc_bench_shapes.log}"
+REPO="/home/yinfeliu/aiter-ar-mhc-rmsnorm"
+HIP_DEV="${HIP_VISIBLE_DEVICES:-0,1}"
+M_LIST="${M_LIST:-1,2,4,16,32,128,1024,2048,8192}"
+
+SHAPES=""
+IFS=',' read -ra MS <<< "$M_LIST"
+for m in "${MS[@]}"; do
+  SHAPES+=" ${m},4096"
+done
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== AR+MHC+RMSNorm benchmark selected shapes ==="
+echo "started: $(date -Is)"
+echo "HIP_VISIBLE_DEVICES=$HIP_DEV"
+echo "M_LIST=$M_LIST"
+echo "log: $LOG"
+
+echo "=== GPU sanity (must be idle before trusting μs) ==="
+rocm-smi --showuse 2>/dev/null || true
+rocm-smi --showpids 2>/dev/null || true
+
+docker run --rm --entrypoint /bin/bash \
+  --device=/dev/kfd --device=/dev/dri --group-add video \
+  --ipc=host --shm-size 32G \
+  -v "$REPO:/workspace/aiter-ar-mhc-rmsnorm" \
+  -w /workspace/aiter-ar-mhc-rmsnorm \
+  -e PYTHONPATH=/workspace/aiter-ar-mhc-rmsnorm \
+  -e HIP_VISIBLE_DEVICES="$HIP_DEV" \
+  -e AITER_REBUILD=1 \
+  -e AITER_USE_SYSTEM_TRITON=1 \
+  vllm/vllm-openai-rocm:nightly \
+  -lc "
+    set -euo pipefail
+    python3 -m pip install -q --no-cache-dir flydsl==0.2.0 tabulate pandas
+    echo '=== smoke m=16 (rebuild) ==='
+    python3 op_tests/multigpu_tests/test_fused_ar_mhc_rms.py \
+      -t 2 -s 16,4096 --test split fused --force-fused
+    export AITER_REBUILD=0
+    echo '=== benchmark shapes (TP=2, split+fused, cudagraph default -g 1) ==='
+    python3 -u op_tests/multigpu_tests/test_fused_ar_mhc_rms.py \
+      -t 2 --test split fused --force-fused \
+      -s${SHAPES}
+  "
+
+echo "finished: $(date -Is)"


### PR DESCRIPTION
Fuse custom AR with MHC fused post/pre and RMSNorm epilogues to avoid materializing reduced activations between collectives and MHC on MI355X. Includes small/large-M dispatch, multigpu op test, and bench script.

## Motivation

DeepSeek-V4 TP paths often execute:

```text
Custom AllReduce -> MHC fused post/pre -> RMSNorm
```

The existing path materializes the reduced activation after custom AllReduce, then reads it back in the MHC post stage. This PR adds a fused semantic path for:

```text
Custom AllReduce + MHC fused post/pre + RMSNorm
```

so TP users can avoid the global-memory round trip between the collective and MHC, while reusing the existing MHC pre/RMSNorm epilogue implementation.

## Technical Details

- Adds a new fused AR+MHC entry point:
  - `tensor_model_parallel_fused_allreduce_mhc_fused_post_pre_rmsnorm`
  - `launch_fused_allreduce_mhc_fused_post_pre_rmsnorm`
- Adds native fused AR+MHC kernels under a separate JIT module:
  - `module_fused_ar_mhc`
- Supports both small-M and large-M dispatch:
  - Small M uses fused custom AR + MHC post/pre/RMSNorm path when shape constraints allow it.
  - Large M uses a post-epilogue route to avoid materializing the reduced layer input before MHC post.
- Keeps fallback behavior through the existing split path:
  - `tensor_model_parallel_all_reduce`
  - `aiter.mhc_fused_post_pre(..., norm_weight=...)`
- Adds multigpu accuracy/perf coverage for TP=2.
- Adds a benchmark helper script for the canonical M sweep.

## Test Plan

Run the TP=2 multigpu test:

```bash
python3 op_tests/multigpu_tests/test_fused_ar_mhc_rms.py \
  -t 2 --test split fused --force-fused \
  -s 1,4096 2,4096 4,4096 16,4096 32,4096 128,4096 1024,4096 2048,4096 8192,4096
```

Run eager-mode benchmark matching the reported table:

```bash
python3 op_tests/multigpu_tests/test_fused_ar_mhc_rms.py \
  -t 2 -g 0 --test split fused --force-fused \
  -s 1,4096 2,4096 4,4096 16,4096 32,4096 128,4096 1024,4096 2048,4096 8192,4096
```

Run formatting check:

```bash
black --check .
```

## Test Result

Environment:

- GPU: MI355X
- TP: 2
- Hidden size: 4096
- Correctness: all `fused_err = 0`

### CUDA Graph On (`-g 1`)

This is the primary performance result because production decode/prefill paths are expected to use CUDA Graph replay where possible. The fused path follows the same graph-capture pattern as PR #3163: during graph capture it uses the registered custom-AR input path directly instead of capturing an extra copy into the registered IPC buffer.

- Mode: CUDA Graph replay (`-g 1`)
- Metric: median latency across ranks
- Correctness: all `fused_err = 0`

| M | split us | fused us | speedup |
|---:|---:|---:|---:|
| 1 | 14.3 | 13.9 | +2.7% |
| 2 | 15.1 | 14.5 | +4.0% |
| 4 | 14.5 | 14.1 | +2.7% |
| 16 | 16.4 | 15.6 | +4.8% |
| 32 | 19.3 | 18.3 | +5.5% |
| 128 | 37.8 | 37.0 | +2.1% |
| 1024 | 203.4 | 207.5 | -2.0% |
| 2048 | 369.2 | 371.4 | -0.6% |
| 8192 | 1443.5 | 1393.5 | +3.5% |

### Eager Mode (`-g 0`)

This supplemental table matches the fused allreduce benchmark style used by existing AITER fused-AR tests and shows the launch-chain reduction benefit outside CUDA Graph replay.

- Mode: eager, no CUDA Graph (`-g 0`)
- Metric: median latency across ranks
- Correctness: all `fused_err = 0`

| M | split us | fused us | speedup |
|---:|---:|---:|---:|
| 1 | 34.2 | 26.4 | +23.0% |
| 2 | 34.1 | 27.0 | +20.8% |
| 4 | 35.5 | 28.1 | +21.1% |
| 16 | 37.0 | 28.0 | +24.5% |
| 32 | 38.0 | 29.7 | +21.7% |
| 128 | 48.1 | 42.3 | +12.0% |
| 1024 | 209.7 | 212.7 | -1.4% |
| 2048 | 377.3 | 376.5 | +0.2% |
| 8192 | 1457.3 | 1421.0 | +2.5% |

Formatting:

```text
black --check .
All done.
```

## Submission Checklist

- [x] Added fused custom AllReduce + MHC post/pre + RMSNorm API.
- [x] Added native small-M and large-M dispatch paths.
- [x] Added multigpu TP=2 correctness and benchmark test.
- [x] Added benchmark script for canonical M sweep.
- [x] Verified fused outputs against split baseline (`fused_err = 0`).
- [x] Ran Black formatting check.
