### PR TITLE
[fix] route fused_qknorm_allreduce through compile guard

### DIFF
--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -551,9 +551,13 @@ class GroupCoordinator:
         k_w: torch.Tensor,
         eps: float,
     ):
-        if self.device_communicator is None:
-            raise ValueError("No device communicator found")
-        return self.device_communicator.fused_qknorm_allreduce(qkv_in, q_w, k_w, eps)
+        return fused_qknorm_allreduce_(
+            qkv_in,
+            q_w,
+            k_w,
+            eps,
+            group_name=self.unique_name,
+        )
 
     def _fused_allreduce_rmsnorm_out_place(
         self,


### PR DESCRIPTION
## Motivation

Use the registered torch.compile custom-op wrapper for fused qk norm all-reduce so Dynamo does not trace into communicator internals.
Recover the changed made in https://github.com/ROCm/aiter/pull/3478

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
