### PR TITLE
Honor CK padding for bpreshuffle padded K

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -5,6 +5,7 @@ import functools
 import os
 import re
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, Optional
 
 import aiter
@@ -22,8 +23,18 @@ from aiter.jit.utils.chip_info import (
     gfx_from_cu_num,
 )
 from aiter.jit.utils.torch_guard import torch_compile_guard
-from aiter.ops.flydsl.utils import is_flydsl_available
-from aiter.ops.flydsl.moe_common import GateMode
+try:
+    from aiter.ops.flydsl.utils import is_flydsl_available
+    from aiter.ops.flydsl.moe_common import GateMode
+except ImportError:
+
+    class GateMode(Enum):
+        SEPARATED = "separated"
+        INTERLEAVE = "interleave"
+
+    def is_flydsl_available():
+        return False
+
 from aiter import (
     fused_dynamic_mxfp4_quant_moe_sort,
     fused_dynamic_mxfp8_quant_moe_sort,
@@ -422,35 +433,41 @@ def fused_moe_(
         else:
             q_dtype_a = dtypes.fp4x2
 
-    from aiter.ops.flydsl.grouped_moe_gfx1250 import (
-        _maybe_grouped_gfx1250_a8w4_moe,
-    )
+    grouped_a8w4_out = None
+    if is_flydsl_available():
+        try:
+            from aiter.ops.flydsl.grouped_moe_gfx1250 import (
+                _maybe_grouped_gfx1250_a8w4_moe,
+            )
+        except ImportError:
+            _maybe_grouped_gfx1250_a8w4_moe = None
 
-    grouped_a8w4_out = _maybe_grouped_gfx1250_a8w4_moe(
-        hidden_states,
-        w1,
-        w2,
-        topk_weight,
-        topk_ids,
-        E=E,
-        model_dim=model_dim,
-        inter_dim=inter_dim,
-        dtype=dtype,
-        activation=activation,
-        quant_type=quant_type,
-        q_dtype_a=q_dtype_a,
-        q_dtype_w=q_dtype_w,
-        isG1U1=isG1U1,
-        doweight_stage1=doweight_stage1,
-        w1_scale=w1_scale,
-        w2_scale=w2_scale,
-        expert_mask=expert_mask,
-        hidden_pad=hidden_pad,
-        intermediate_pad=intermediate_pad,
-        bias1=bias1,
-        bias2=bias2,
-        gate_mode=gate_mode,
-    )
+        if _maybe_grouped_gfx1250_a8w4_moe is not None:
+            grouped_a8w4_out = _maybe_grouped_gfx1250_a8w4_moe(
+                hidden_states,
+                w1,
+                w2,
+                topk_weight,
+                topk_ids,
+                E=E,
+                model_dim=model_dim,
+                inter_dim=inter_dim,
+                dtype=dtype,
+                activation=activation,
+                quant_type=quant_type,
+                q_dtype_a=q_dtype_a,
+                q_dtype_w=q_dtype_w,
+                isG1U1=isG1U1,
+                doweight_stage1=doweight_stage1,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                expert_mask=expert_mask,
+                hidden_pad=hidden_pad,
+                intermediate_pad=intermediate_pad,
+                bias1=bias1,
+                bias2=bias2,
+                gate_mode=gate_mode,
+            )
     if grouped_a8w4_out is not None:
         return grouped_a8w4_out
 

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -23,6 +23,7 @@ from aiter.jit.utils.chip_info import (
     gfx_from_cu_num,
 )
 from aiter.jit.utils.torch_guard import torch_compile_guard
+
 try:
     from aiter.ops.flydsl.utils import is_flydsl_available
     from aiter.ops.flydsl.moe_common import GateMode
@@ -34,6 +35,7 @@ except ImportError:
 
     def is_flydsl_available():
         return False
+
 
 from aiter import (
     fused_dynamic_mxfp4_quant_moe_sort,

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -29,6 +29,7 @@ def is_flydsl_available():
         return False
     return _is_flydsl_available()
 
+
 aiter_lib = Library("aiter", "FRAGMENT")
 
 

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -20,7 +20,14 @@ from ..jit.utils.chip_info import get_cu_num, get_gfx_runtime as get_gfx
 from ..jit.utils.torch_guard import torch_compile_guard
 from ..ops.gemm_op_common import get_padded_m
 from ..utility import dtypes
-from ..ops.flydsl.utils import is_flydsl_available
+
+
+def is_flydsl_available():
+    try:
+        from ..ops.flydsl.utils import is_flydsl_available as _is_flydsl_available
+    except ImportError:
+        return False
+    return _is_flydsl_available()
 
 aiter_lib = Library("aiter", "FRAGMENT")
 

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -703,6 +703,8 @@ def gemm_a8w8_bpreshuffle(
                 XQ, WQ, x_scale, w_scale, Y, {"kernelName": ki.name}
             )
     try:
+        if w_k > k:
+            return gemm_a8w8_bpreshuffle_cktile(XQ, WQ, x_scale, w_scale, Y, 0)
         return gemm_a8w8_bpreshuffle_ck(XQ, WQ, x_scale, w_scale, Y, 0)
     except RuntimeError as e:
         raise RuntimeError(

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -635,10 +635,7 @@ def gemm_a8w8_bpreshuffle(
     n = WQ.shape[0]
     k = XQ.shape[-1]
     w_k = WQ.shape[-1]
-    if w_k > k:
-        XQ = F.pad(XQ.contiguous(), (0, w_k - k), value=0)
-        k = XQ.shape[-1]
-    elif w_k < k:
+    if w_k < k:
         raise RuntimeError(
             f"gemm_a8w8_bpreshuffle requires WQ K >= XQ K, got WQ K={w_k}, " f"XQ K={k}"
         )
@@ -664,6 +661,14 @@ def gemm_a8w8_bpreshuffle(
         dtypes.fp8,
         AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BPRESHUFFLE_FILE,
     )
+    if config is None and w_k > k:
+        config = get_GEMM_config_with_quant_type(
+            m,
+            n,
+            w_k,
+            dtypes.fp8,
+            AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BPRESHUFFLE_FILE,
+        )
     if config is not None:
         libtype = config["libtype"]
         splitK = int(config["splitK"])
@@ -672,6 +677,8 @@ def gemm_a8w8_bpreshuffle(
         elif libtype == "cktile":
             return gemm_a8w8_bpreshuffle_cktile(XQ, WQ, x_scale, w_scale, Y, splitK)
         elif libtype == "flydsl" and is_flydsl_available():
+            if w_k > k:
+                XQ = F.pad(XQ.contiguous(), (0, w_k - k), value=0)
             return gemm_a8w8_bpreshuffle_flydsl(XQ, WQ, x_scale, w_scale, Y, config)
 
     if get_gfx() == "gfx1250" and is_flydsl_available():
@@ -690,6 +697,8 @@ def gemm_a8w8_bpreshuffle(
                 f"[gfx1250] gemm_a8w8_bpreshuffle untuned M={m}, N={n}, K={k}; "
                 f"falling back to flydsl kernel '{ki.name}'."
             )
+            if w_k > k:
+                XQ = F.pad(XQ.contiguous(), (0, w_k - k), value=0)
             return gemm_a8w8_bpreshuffle_flydsl(
                 XQ, WQ, x_scale, w_scale, Y, {"kernelName": ki.name}
             )

--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -27,7 +27,13 @@ from aiter import dtypes, gemm_a16w16_asm, hipb_create_extension, hipb_mm, logge
 from aiter.jit.core import AITER_CONFIGS, AITER_LOG_TUNED_CONFIG
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx
 from aiter.jit.utils.torch_guard import torch_compile_guard
-from aiter.ops.flydsl.utils import is_flydsl_available
+try:
+    from aiter.ops.flydsl.utils import is_flydsl_available
+except ImportError:
+
+    def is_flydsl_available():
+        return False
+
 from aiter.ops.gemm_op_common import get_padded_m
 from torch import Tensor
 

--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -27,12 +27,14 @@ from aiter import dtypes, gemm_a16w16_asm, hipb_create_extension, hipb_mm, logge
 from aiter.jit.core import AITER_CONFIGS, AITER_LOG_TUNED_CONFIG
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx
 from aiter.jit.utils.torch_guard import torch_compile_guard
+
 try:
     from aiter.ops.flydsl.utils import is_flydsl_available
 except ImportError:
 
     def is_flydsl_available():
         return False
+
 
 from aiter.ops.gemm_op_common import get_padded_m
 from torch import Tensor

--- a/csrc/ck_gemm_a8w8_blockscale/gen_instances_cktile.py
+++ b/csrc/ck_gemm_a8w8_blockscale/gen_instances_cktile.py
@@ -289,8 +289,12 @@ torch::Tensor
             # generate code for default kernels
             self.gen_code(candidate_kernels_cktile_dict)
         else:
-            # generate code for tuned kernels from tune_file
-            self.gen_code(self.get_tune_dict(self.tune_file))
+            # Runtime dispatch is keyed by kernelName from Python-selected tuned
+            # rows. Build the full CKTile candidate registry so a newly tuned CSV
+            # cannot reference a valid candidate that is absent from the .so.
+            runtime_kernels = self.get_tune_dict(self.tune_file)
+            runtime_kernels.update(candidate_kernels_cktile_dict)
+            self.gen_code(runtime_kernels)
 
 
 if __name__ == "__main__":

--- a/csrc/ck_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle.cu
+++ b/csrc/ck_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle.cu
@@ -181,15 +181,22 @@ torch::Tensor gemm_a8w8_bpreshuffle(torch::Tensor& XQ,
     int M      = XQ.size(0);
     int N      = WQ.size(0);
     int K      = XQ.size(1);
+    int WQK    = WQ.size(1);
     int KBatch = 1 << splitK;
+
+    TORCH_CHECK(WQK >= K,
+                "gemm_a8w8_bpreshuffle requires WQ K >= XQ K, got WQ K=",
+                WQK,
+                ", XQ K=",
+                K);
 
     if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::Half)
     {
-        rowwise_dispatch<F32, F16>(M, N, K)(XQ, WQ, x_scale, w_scale, Y, KBatch);
+        rowwise_dispatch<F32, F16>(M, N, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::BFloat16)
     {
-        rowwise_dispatch<F32, B16>(M, N, K)(XQ, WQ, x_scale, w_scale, Y, KBatch);
+        rowwise_dispatch<F32, B16>(M, N, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else
     {

--- a/csrc/ck_gemm_a8w8_bpreshuffle/gen_instances.py
+++ b/csrc/ck_gemm_a8w8_bpreshuffle/gen_instances.py
@@ -61,7 +61,7 @@ torch::Tensor
     // Check if this input needs to be padded.
     int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
     int N = WQ.size(0);
-    int K = WQ.size(1);
+    int K = XQ.size(1);
     bool pad = (M % {k.MPerBLOCK} != 0) || (N % {k.NPerBLOCK} != 0) || (K % ({k.KPerBLOCK}) != 0);
     if (pad)
     {{{{

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -50,17 +50,27 @@ from aiter.utility import fp4_utils
 from aiter.utility.fp4_utils import moe_mxfp4_sort
 
 
-from aiter.ops.flydsl.utils import is_flydsl_available
+try:
+    from aiter.ops.flydsl.utils import is_flydsl_available
+except ImportError:
+
+    def is_flydsl_available():
+        return False
 
 if is_flydsl_available():
-    from aiter.ops.flydsl.moe_kernels import (
-        get_flydsl_stage1_kernels,
-        get_flydsl_stage2_kernels,
-        get_flydsl_stage1_kernels_int4_bf16,
-        get_flydsl_stage2_kernels_int4_bf16,
-        flydsl_moe_stage1,
-        flydsl_moe_stage2,
-    )
+    try:
+        from aiter.ops.flydsl.moe_kernels import (
+            get_flydsl_stage1_kernels,
+            get_flydsl_stage2_kernels,
+            get_flydsl_stage1_kernels_int4_bf16,
+            get_flydsl_stage2_kernels_int4_bf16,
+            flydsl_moe_stage1,
+            flydsl_moe_stage2,
+        )
+    except ImportError:
+
+        def is_flydsl_available():
+            return False
 
 sys.path.insert(0, f"{AITER_CSRC_DIR}/ck_gemm_moe_2stages_codegen/")
 from gemm_moe_ck2stages_common import get_gemm1_kernels_list, get_gemm2_kernels_list

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -49,13 +49,13 @@ from aiter.utility.base_tuner import TunerCommon
 from aiter.utility import fp4_utils
 from aiter.utility.fp4_utils import moe_mxfp4_sort
 
-
 try:
     from aiter.ops.flydsl.utils import is_flydsl_available
 except ImportError:
 
     def is_flydsl_available():
         return False
+
 
 if is_flydsl_available():
     try:
@@ -71,6 +71,7 @@ if is_flydsl_available():
 
         def is_flydsl_available():
             return False
+
 
 sys.path.insert(0, f"{AITER_CSRC_DIR}/ck_gemm_moe_2stages_codegen/")
 from gemm_moe_ck2stages_common import get_gemm1_kernels_list, get_gemm2_kernels_list

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
@@ -102,15 +102,22 @@ torch::Tensor gemm_a8w8_bpreshuffle_cktile(torch::Tensor& XQ,
     int M      = XQ.size(0);
     int N      = WQ.size(0);
     int K      = XQ.size(1);
+    int WQK    = WQ.size(1);
     int KBatch = 1 << splitK;
+
+    TORCH_CHECK(WQK >= K,
+                "gemm_a8w8_bpreshuffle_cktile requires WQ K >= XQ K, got WQ K=",
+                WQK,
+                ", XQ K=",
+                K);
 
     if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::Half)
     {
-        rowwise_dispatch<F32, F16>(M, N, K)(XQ, WQ, x_scale, w_scale, Y, KBatch);
+        rowwise_dispatch<F32, F16>(M, N, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::BFloat16)
     {
-        rowwise_dispatch<F32, B16>(M, N, K)(XQ, WQ, x_scale, w_scale, Y, KBatch);
+        rowwise_dispatch<F32, B16>(M, N, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else
     {

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
@@ -61,29 +61,52 @@ torch::Tensor
     // Check if this input needs to be padded.
     int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
     int N = WQ.size(0);
-    int K = WQ.size(1);
-    bool pad = (M % {k.MTile} != 0) || (N % {k.NTile} != 0) || (K % ({k.KTile}) != 0);
-    if (pad)
+    int K = XQ.size(1);
+    bool pad_m = M % {k.MTile} != 0;
+    bool pad_n = N % {k.NTile} != 0;
+    bool pad_k = K % ({k.KTile}) != 0;
+    if (pad_m && pad_n && pad_k)
     {{{{
-        // pad
-        {{INSTANCE_CONTENT_pad}}
-        // pad
+        {{INSTANCE_CONTENT_pad_mnk}}
+    }}}}
+    else if (pad_m && pad_n)
+    {{{{
+        {{INSTANCE_CONTENT_pad_mn}}
+    }}}}
+    else if (pad_m && pad_k)
+    {{{{
+        {{INSTANCE_CONTENT_pad_mk}}
+    }}}}
+    else if (pad_n && pad_k)
+    {{{{
+        {{INSTANCE_CONTENT_pad_nk}}
+    }}}}
+    else if (pad_m)
+    {{{{
+        {{INSTANCE_CONTENT_pad_m}}
+    }}}}
+    else if (pad_n)
+    {{{{
+        {{INSTANCE_CONTENT_pad_n}}
+    }}}}
+    else if (pad_k)
+    {{{{
+        {{INSTANCE_CONTENT_pad_k}}
     }}}}
     else
     {{{{
-        // no pad
         {{INSTANCE_CONTENT_nopad}}
-        // no pad
     }}}}
 }}}}
 
 """
 
-        INSTANCE_CONTENT_nobias = f"""using FlatmmInstance = CustomConfig<
+        def instance_content(pad_m: bool, pad_n: bool, pad_k: bool) -> str:
+            return f"""using FlatmmInstance = CustomConfig<
             DDataType, EDataType,
             {k.sTransposeC},{k.sUseStructuredSparsity}, {k.sTileParitionerGroupNum},
             {k.sTileParitionerM01}, {k.sNumWaveGroups}, {k.sDoubleSmemBuffer},
-            {k.PadM},  {k.PadN},  {k.PadK},
+            {int(pad_m)},  {int(pad_n)},  {int(pad_k)},
             {k.BlockPerCu},
             {k.MTile}, {k.NTile}, {k.KTile},
             {k.MWarp}, {k.NWarp}, {k.KWarp},
@@ -92,24 +115,22 @@ torch::Tensor
         // Run kernel instance.
         return gemm_a8w8_bpreshuffle_cktile_impl<DDataType, EDataType, FlatmmInstance>(XQ, WQ, x_scale, w_scale, Y, KBatch);
 """
+
+        INSTANCE_CONTENT_nopad = instance_content(k.PadM, k.PadN, k.PadK)
+        instance_replacements = {
+            "INSTANCE_CONTENT_nopad": INSTANCE_CONTENT_nopad,
+            "INSTANCE_CONTENT_pad_m": instance_content(True, k.PadN, k.PadK),
+            "INSTANCE_CONTENT_pad_n": instance_content(k.PadM, True, k.PadK),
+            "INSTANCE_CONTENT_pad_k": instance_content(k.PadM, k.PadN, True),
+            "INSTANCE_CONTENT_pad_mn": instance_content(True, True, k.PadK),
+            "INSTANCE_CONTENT_pad_mk": instance_content(True, k.PadN, True),
+            "INSTANCE_CONTENT_pad_nk": instance_content(k.PadM, True, True),
+            "INSTANCE_CONTENT_pad_mnk": instance_content(True, True, True),
+        }
         if self.istune:
-            INSTANCE_IMPL_str = INSTANCE_IMPL.format(
-                INSTANCE_CONTENT_pad=(
-                    INSTANCE_CONTENT_nobias.format(GemmSpec="MNKPadding")
-                ),
-                INSTANCE_CONTENT_nopad=(
-                    INSTANCE_CONTENT_nobias.format(GemmSpec="Default")
-                ),
-            )
+            INSTANCE_IMPL_str = INSTANCE_IMPL.format(**instance_replacements)
         else:
-            INSTANCE_IMPL_str = INSTANCE_IMPL.format(
-                INSTANCE_CONTENT_pad=INSTANCE_CONTENT_nobias.format(
-                    GemmSpec="MNKPadding"
-                ),
-                INSTANCE_CONTENT_nopad=INSTANCE_CONTENT_nobias.format(
-                    GemmSpec="Default"
-                ),
-            )
+            INSTANCE_IMPL_str = INSTANCE_IMPL.format(**instance_replacements)
 
         Path(os.path.join(self.impl_path, f"{k.name}.cuh")).write_text(
             INSTANCE_IMPL_str

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
@@ -337,8 +337,8 @@ gemm_a8w8_bpreshuffle_cktile_impl(torch::Tensor& XQ,
     args.M        = m;
     args.N        = n;
     args.K        = k;
-    args.stride_A = k;
-    args.stride_B = k;
+    args.stride_A = XQ.stride(-2);
+    args.stride_B = WQ.stride(-2);
     args.stride_C = n;
     args.stride_E = n;
 

--- a/op_tests/test_gemm_a8w8_bpreshuffle_pad_k.py
+++ b/op_tests/test_gemm_a8w8_bpreshuffle_pad_k.py
@@ -25,19 +25,20 @@ def test_shuffle_weight_pad_k_to_pads_last_dim():
     assert shuffled.aiter_padded_k == 128
 
 
-def test_gemm_a8w8_bpreshuffle_pads_activation_to_weight_k(monkeypatch):
+def test_gemm_a8w8_bpreshuffle_uses_logical_k_for_ck_config(monkeypatch):
     xq = torch.zeros((2, 96), device="cuda", dtype=dtypes.fp8)
     wq = torch.zeros((16, 128), device="cuda", dtype=dtypes.fp8)
     x_scale = torch.ones((2, 1), device="cuda", dtype=torch.float32)
     w_scale = torch.ones((16, 1), device="cuda", dtype=torch.float32)
     seen = {}
 
-    def fake_config(*args, **kwargs):
+    def fake_config(m, n, k, q_dtype_w, tuned_file):
+        seen["config_shape"] = (m, n, k)
         return {"libtype": "ck", "splitK": 0}
 
     def fake_ck(XQ, WQ, x_scale, w_scale, Y, splitK):
         seen["x_shape"] = tuple(XQ.shape)
-        seen["tail_is_zero"] = bool((XQ[:, 96:].to(torch.float32) == 0).all())
+        seen["w_shape"] = tuple(WQ.shape)
         return Y
 
     monkeypatch.setattr(gemm_mod, "get_GEMM_config_with_quant_type", fake_config)
@@ -47,6 +48,94 @@ def test_gemm_a8w8_bpreshuffle_pads_activation_to_weight_k(monkeypatch):
 
     assert out.shape == (2, 16)
     assert out.dtype == torch.bfloat16
+    assert seen["config_shape"] == (2, 16, 96)
+    assert seen["x_shape"] == (2, 96)
+    assert seen["w_shape"] == (16, 128)
+
+
+def test_gemm_a8w8_bpreshuffle_uses_logical_k_for_cktile_config(monkeypatch):
+    xq = torch.zeros((2, 96), device="cuda", dtype=dtypes.fp8)
+    wq = torch.zeros((16, 128), device="cuda", dtype=dtypes.fp8)
+    x_scale = torch.ones((2, 1), device="cuda", dtype=torch.float32)
+    w_scale = torch.ones((16, 1), device="cuda", dtype=torch.float32)
+    seen = {}
+
+    def fake_config(m, n, k, q_dtype_w, tuned_file):
+        seen["config_shape"] = (m, n, k)
+        return {"libtype": "cktile", "splitK": 0}
+
+    def fake_cktile(XQ, WQ, x_scale, w_scale, Y, splitK):
+        seen["x_shape"] = tuple(XQ.shape)
+        seen["w_shape"] = tuple(WQ.shape)
+        return Y
+
+    monkeypatch.setattr(gemm_mod, "get_GEMM_config_with_quant_type", fake_config)
+    monkeypatch.setattr(gemm_mod, "gemm_a8w8_bpreshuffle_cktile", fake_cktile)
+
+    out = gemm_mod.gemm_a8w8_bpreshuffle(xq, wq, x_scale, w_scale, dtype=torch.bfloat16)
+
+    assert out.shape == (2, 16)
+    assert out.dtype == torch.bfloat16
+    assert seen["config_shape"] == (2, 16, 96)
+    assert seen["x_shape"] == (2, 96)
+    assert seen["w_shape"] == (16, 128)
+
+
+def test_gemm_a8w8_bpreshuffle_falls_back_to_padded_k_config(monkeypatch):
+    xq = torch.zeros((2, 96), device="cuda", dtype=dtypes.fp8)
+    wq = torch.zeros((16, 128), device="cuda", dtype=dtypes.fp8)
+    x_scale = torch.ones((2, 1), device="cuda", dtype=torch.float32)
+    w_scale = torch.ones((16, 1), device="cuda", dtype=torch.float32)
+    seen = {"config_shapes": []}
+
+    def fake_config(m, n, k, q_dtype_w, tuned_file):
+        seen["config_shapes"].append((m, n, k))
+        if k == 128:
+            return {"libtype": "cktile", "splitK": 0}
+        return None
+
+    def fake_cktile(XQ, WQ, x_scale, w_scale, Y, splitK):
+        seen["x_shape"] = tuple(XQ.shape)
+        seen["w_shape"] = tuple(WQ.shape)
+        return Y
+
+    monkeypatch.setattr(gemm_mod, "get_GEMM_config_with_quant_type", fake_config)
+    monkeypatch.setattr(gemm_mod, "gemm_a8w8_bpreshuffle_cktile", fake_cktile)
+
+    out = gemm_mod.gemm_a8w8_bpreshuffle(xq, wq, x_scale, w_scale, dtype=torch.bfloat16)
+
+    assert out.shape == (2, 16)
+    assert out.dtype == torch.bfloat16
+    assert seen["config_shapes"] == [(2, 16, 96), (2, 16, 128)]
+    assert seen["x_shape"] == (2, 96)
+    assert seen["w_shape"] == (16, 128)
+
+
+def test_gemm_a8w8_bpreshuffle_pads_activation_for_flydsl(monkeypatch):
+    xq = torch.zeros((2, 96), device="cuda", dtype=dtypes.fp8)
+    wq = torch.zeros((16, 128), device="cuda", dtype=dtypes.fp8)
+    x_scale = torch.ones((2, 1), device="cuda", dtype=torch.float32)
+    w_scale = torch.ones((16, 1), device="cuda", dtype=torch.float32)
+    seen = {}
+
+    def fake_config(m, n, k, q_dtype_w, tuned_file):
+        seen["config_shape"] = (m, n, k)
+        return {"libtype": "flydsl", "splitK": 0, "kernelName": "fake"}
+
+    def fake_flydsl(XQ, WQ, x_scale, w_scale, Y, config):
+        seen["x_shape"] = tuple(XQ.shape)
+        seen["tail_is_zero"] = bool((XQ[:, 96:].to(torch.float32) == 0).all())
+        return Y
+
+    monkeypatch.setattr(gemm_mod, "get_GEMM_config_with_quant_type", fake_config)
+    monkeypatch.setattr(gemm_mod, "is_flydsl_available", lambda: True)
+    monkeypatch.setattr(gemm_mod, "gemm_a8w8_bpreshuffle_flydsl", fake_flydsl)
+
+    out = gemm_mod.gemm_a8w8_bpreshuffle(xq, wq, x_scale, w_scale, dtype=torch.bfloat16)
+
+    assert out.shape == (2, 16)
+    assert out.dtype == torch.bfloat16
+    assert seen["config_shape"] == (2, 16, 96)
     assert seen["x_shape"] == (2, 128)
     assert seen["tail_is_zero"]
 

--- a/op_tests/test_gemm_a8w8_bpreshuffle_pad_k.py
+++ b/op_tests/test_gemm_a8w8_bpreshuffle_pad_k.py
@@ -111,6 +111,38 @@ def test_gemm_a8w8_bpreshuffle_falls_back_to_padded_k_config(monkeypatch):
     assert seen["w_shape"] == (16, 128)
 
 
+def test_gemm_a8w8_bpreshuffle_uses_cktile_for_untuned_padded_k(monkeypatch):
+    xq = torch.zeros((2, 96), device="cuda", dtype=dtypes.fp8)
+    wq = torch.zeros((16, 128), device="cuda", dtype=dtypes.fp8)
+    x_scale = torch.ones((2, 1), device="cuda", dtype=torch.float32)
+    w_scale = torch.ones((16, 1), device="cuda", dtype=torch.float32)
+    seen = {"config_shapes": []}
+
+    def fake_config(m, n, k, q_dtype_w, tuned_file):
+        seen["config_shapes"].append((m, n, k))
+        return None
+
+    def fake_cktile(XQ, WQ, x_scale, w_scale, Y, splitK):
+        seen["x_shape"] = tuple(XQ.shape)
+        seen["w_shape"] = tuple(WQ.shape)
+        return Y
+
+    def fake_ck(*args, **kwargs):
+        raise AssertionError("padded-K untuned fallback should use CKTile")
+
+    monkeypatch.setattr(gemm_mod, "get_GEMM_config_with_quant_type", fake_config)
+    monkeypatch.setattr(gemm_mod, "gemm_a8w8_bpreshuffle_cktile", fake_cktile)
+    monkeypatch.setattr(gemm_mod, "gemm_a8w8_bpreshuffle_ck", fake_ck)
+
+    out = gemm_mod.gemm_a8w8_bpreshuffle(xq, wq, x_scale, w_scale, dtype=torch.bfloat16)
+
+    assert out.shape == (2, 16)
+    assert out.dtype == torch.bfloat16
+    assert seen["config_shapes"] == [(2, 16, 96), (2, 16, 128)]
+    assert seen["x_shape"] == (2, 96)
+    assert seen["w_shape"] == (16, 128)
+
+
 def test_gemm_a8w8_bpreshuffle_pads_activation_for_flydsl(monkeypatch):
     xq = torch.zeros((2, 96), device="cuda", dtype=dtypes.fp8)
     wq = torch.zeros((16, 128), device="cuda", dtype=dtypes.fp8)


### PR DESCRIPTION
### What

Follow-up to #3611 so padded bpreshuffle weights do not force Python-side activation padding for CK/CKTile:

- keep `gemm_a8w8_bpreshuffle` config lookup on logical activation K first;
- when a padded preshuffled weight is present and logical-K config is missing, fall back to the padded weight K config while still passing the original `XQ` into CK/CKTile;
- leave explicit activation padding only for FlyDSL paths that still require physical K equality;
- make CK and CKTile generated wrappers decide padding from `XQ.size(1)`, not `WQ.size(1)`;
- make CKTile generated wrappers instantiate precise padding configs (`PadK=true` for K-only padding, plus M/N combinations when needed);
- use tensor strides in CKTile runtime args so a padded preshuffled weight can keep its physical stride.

### Why

#3611 fixed the GLM-4.5-Air padded-K startup case by padding `XQ` before config lookup and dispatch. That can regress CK/CKTile because those backends already have padding-capable configs. The dispatcher should let CK/CKTile own padding instead of hiding the logical shape behind an externally padded activation tensor.

### Validation

Local syntax/diff checks:

```bash
python3 -m py_compile aiter/ops/gemm_op_a8w8.py aiter/ops/shuffle.py csrc/ck_gemm_a8w8_bpreshuffle/gen_instances.py csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py op_tests/test_gemm_a8w8_bpreshuffle_pad_k.py
git diff --check
```

MI300X GLM-4.5-Air targeted validation on `inst-vcw9p-oke-rdma` (`gfx942`) in `lmsysorg/sglang:v0.5.9-rocm700-mi30x`:

- generated CKTile code contains a `PadK=true` branch (`CODEGEN_PADK_OK`);
- `M=64,N=4096,K=10944` first looked up logical K and missed;
- dispatcher fell back to the padded-weight tuned row `K=11008`, `libtype=cktile`, `kernelId=21`;
- CKTile module built successfully;
- GEMM completed without externally padding `XQ`: `GLM45_PADK_GEMM_OK (64, 4096) torch.bfloat16`.

For that validation, the older GLM tuning CSV was temporarily migrated to include the newer `gfx` column (`gfx942`) so current AITER codegen could consume it.