### PR TITLE
[triton] Add sliding-window support to flash-attention backward

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -2959,6 +2959,10 @@ def _bwd_dkdv_inner(
                 causal_mask = (offs_m[None, :] - delta_qk) >= offs_n[:, None]
                 mask = causal_mask & mask
             if USE_SLIDING_WINDOW:
+                # Per-element form of the band a query m attends:
+                #   m + (seqlen_k - seqlen_q) - L <= n <= m + (seqlen_k - seqlen_q) + R.
+                # _sliding_window_q_bounds() is the block-range inversion of this same
+                # inequality (it bounds m for a fixed K block); keep the two in sync.
                 causal_offset = seqlen_k - seqlen_q
                 if WINDOW_SIZE_LEFT < 0:
                     window_mask = offs_n[:, None] <= (
@@ -3161,6 +3165,10 @@ def _bwd_dq_inner(
                 causal_mask = (offs_m[:, None] - delta_qk) >= offs_n[None, :]
                 mask = causal_mask & mask
             if USE_SLIDING_WINDOW:
+                # Per-element form of the band a query m attends:
+                #   m + (seqlen_k - seqlen_q) - L <= n <= m + (seqlen_k - seqlen_q) + R.
+                # _sliding_window_k_bounds() is the block-range inversion of this same
+                # inequality (it bounds n for a fixed Q block); keep the two in sync.
                 causal_offset = seqlen_k - seqlen_q
                 if WINDOW_SIZE_LEFT < 0:
                     window_mask = offs_n[None, :] <= (

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -489,6 +489,19 @@ def get_bwd_configs(mode: AutotuneMode):
                     num_stages=2,
                     num_warps=8,
                 ),
+                # mid-tile, 2-stage variant
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 128,
+                        "BLOCK_M2": 128,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=2,
+                    num_warps=4,
+                ),
             ]
             causal_configs = [
                 triton.Config(
@@ -537,6 +550,32 @@ def get_bwd_configs(mode: AutotuneMode):
                         "waves_per_eu": 2,
                     },
                     num_stages=2,
+                    num_warps=4,
+                ),
+                # larger-tile variant (helps long-seq throughput; noncausal-proven)
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 256,
+                        "BLOCK_M2": 256,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=2,
+                    num_warps=8,
+                ),
+                # small-tile variant (helps short seqlen / wide-window cases)
+                triton.Config(
+                    {
+                        "BLOCK_M1": 16,
+                        "BLOCK_N1": 64,
+                        "BLOCK_M2": 64,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=1,
                     num_warps=4,
                 ),
             ]
@@ -2821,7 +2860,10 @@ def _bwd_dkdv_inner(
     descale_q,
     descale_k,
     descale_v,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     MASK: tl.constexpr,  # causal masking, only apply to tiles on mask diagonal
+    USE_SLIDING_WINDOW: tl.constexpr,
     ENABLE_DROPOUT: tl.constexpr,  # activate dropout
     USE_ALIBI: tl.constexpr,
     USE_EXP2: tl.constexpr,  # activate exp2
@@ -2908,18 +2950,33 @@ def _bwd_dkdv_inner(
         else:
             pT = tl.math.exp(qkT_shifted)
 
-        # Autoregressive masking.
-        if MASK:
-            # offset offs_m with delta_qk since the causal mask starts at
-            # bottom right of the (seqlen_q, seqlen_k) matrix
-            causal_mask = (offs_m[None, :] - delta_qk) >= offs_n[:, None]
-            mask = causal_mask & mask_nm
+        # Causal and sliding-window masking.
+        if MASK or USE_SLIDING_WINDOW:
+            mask = mask_nm
+            if MASK:
+                # offset offs_m with delta_qk since the causal mask starts at
+                # bottom right of the (seqlen_q, seqlen_k) matrix
+                causal_mask = (offs_m[None, :] - delta_qk) >= offs_n[:, None]
+                mask = causal_mask & mask
+            if USE_SLIDING_WINDOW:
+                causal_offset = seqlen_k - seqlen_q
+                if WINDOW_SIZE_LEFT < 0:
+                    window_mask = offs_n[:, None] <= (
+                        offs_m[None, :] + causal_offset + WINDOW_SIZE_RIGHT
+                    )
+                else:
+                    left_bound = offs_m[None, :] + causal_offset - WINDOW_SIZE_LEFT
+                    right_bound = offs_m[None, :] + causal_offset + WINDOW_SIZE_RIGHT
+                    window_mask = (offs_n[:, None] >= left_bound) & (
+                        offs_n[:, None] <= right_bound
+                    )
+                mask = window_mask & mask
             if DEBUG_TRITON_DETAIL:
                 if start_n == 256:
-                    print(f"causal_mask: {causal_mask.shape}\n", causal_mask)
+                    print(f"mask: {mask.shape}\n", mask)
                     print(
-                        f"qkT after causal: {qkT.shape}\n",
-                        tl.where(causal_mask, qkT * sm_scale, 0.0),
+                        f"pT after mask: {pT.shape}\n",
+                        tl.where(mask, pT, 0.0),
                     )
             pT = tl.where(mask, pT, 0.0)
         do = tl.load(do_ptrs, mask=mask_do, other=0.0)
@@ -3004,7 +3061,10 @@ def _bwd_dq_inner(
     descale_q,
     descale_k,
     descale_v,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     MASK: tl.constexpr,
+    USE_SLIDING_WINDOW: tl.constexpr,
     ENABLE_DROPOUT: tl.constexpr,
     USE_ALIBI: tl.constexpr,
     USE_EXP2: tl.constexpr,
@@ -3094,10 +3154,25 @@ def _bwd_dq_inner(
         else:
             p = tl.math.exp(qk_shifted)
 
-        # Autoregressive masking.
-        if MASK:
-            causal_mask = (offs_m[:, None] - delta_qk) >= offs_n[None, :]
-            mask = causal_mask & mask_mn
+        # Causal and sliding-window masking.
+        if MASK or USE_SLIDING_WINDOW:
+            mask = mask_mn
+            if MASK:
+                causal_mask = (offs_m[:, None] - delta_qk) >= offs_n[None, :]
+                mask = causal_mask & mask
+            if USE_SLIDING_WINDOW:
+                causal_offset = seqlen_k - seqlen_q
+                if WINDOW_SIZE_LEFT < 0:
+                    window_mask = offs_n[None, :] <= (
+                        offs_m[:, None] + causal_offset + WINDOW_SIZE_RIGHT
+                    )
+                else:
+                    left_bound = offs_m[:, None] + causal_offset - WINDOW_SIZE_LEFT
+                    right_bound = offs_m[:, None] + causal_offset + WINDOW_SIZE_RIGHT
+                    window_mask = (offs_n[None, :] >= left_bound) & (
+                        offs_n[None, :] <= right_bound
+                    )
+                mask = window_mask & mask
             p = tl.where(mask, p, 0.0)
         # Compute dP and dS.
         if IS_FP8:
@@ -3124,6 +3199,75 @@ def _bwd_dq_inner(
         kT_ptrs += step_n * stride_kn
         vT_ptrs += step_n * stride_vn
     return dq
+
+
+@triton.jit
+def _sliding_window_q_bounds(
+    start_n,
+    seqlen_q,
+    seqlen_k,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """Query-block range that overlaps the sliding window for a fixed K block.
+
+    dKdV sweeps query blocks for the fixed key block [start_n, start_n+BLOCK_N).
+    A query m attends key n iff
+        m + (seqlen_k - seqlen_q) - L <= n <= m + (seqlen_k - seqlen_q) + R,
+    so the queries that touch any key in this block span
+        [start_n - R - off, (start_n + BLOCK_N - 1) + L - off]   (off = seqlen_k - seqlen_q).
+    Returns (start_m, num_steps) aligned to BLOCK_M; num_steps == 0 means the
+    block is entirely outside the window and can be skipped.
+    """
+    causal_offset = seqlen_k - seqlen_q
+    m_lo = start_n - WINDOW_SIZE_RIGHT - causal_offset
+    if WINDOW_SIZE_LEFT < 0:  # unbounded left -> no upper limit on contributing queries
+        m_hi = seqlen_q - 1
+    else:
+        m_hi = (start_n + BLOCK_N - 1) + WINDOW_SIZE_LEFT - causal_offset
+    m_lo = tl.maximum(m_lo, 0)
+    m_hi = tl.minimum(m_hi, seqlen_q - 1)
+    start_m = (m_lo // BLOCK_M) * BLOCK_M
+    if m_hi < m_lo:
+        num_steps = 0
+    else:
+        num_steps = tl.cdiv(m_hi + 1 - start_m, BLOCK_M)
+    return start_m, num_steps
+
+
+@triton.jit
+def _sliding_window_k_bounds(
+    start_m,
+    seqlen_q,
+    seqlen_k,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Key-block range that overlaps the sliding window for a fixed Q block.
+
+    dQ sweeps key blocks for the fixed query block [start_m, start_m+BLOCK_M).
+    The keys query m attends are [m + off - L, m + off + R] (off = seqlen_k - seqlen_q),
+    so across the block they span [start_m + off - L, (start_m + BLOCK_M - 1) + off + R].
+    Returns (start_n, num_steps) aligned to BLOCK_N; num_steps == 0 means skip.
+    """
+    causal_offset = seqlen_k - seqlen_q
+    if WINDOW_SIZE_LEFT < 0:  # unbounded left -> keys reach back to 0
+        n_lo = 0
+    else:
+        n_lo = start_m + causal_offset - WINDOW_SIZE_LEFT
+    n_hi = (start_m + BLOCK_M - 1) + causal_offset + WINDOW_SIZE_RIGHT
+    n_lo = tl.maximum(n_lo, 0)
+    n_hi = tl.minimum(n_hi, seqlen_k - 1)
+    start_n = (n_lo // BLOCK_N) * BLOCK_N
+    if n_hi < n_lo:
+        num_steps = 0
+    else:
+        num_steps = tl.cdiv(n_hi + 1 - start_n, BLOCK_N)
+    return start_n, num_steps
 
 
 @triton.autotune(
@@ -3218,6 +3362,9 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
     IS_FP8: tl.constexpr,
     FP8_MAX: tl.constexpr,
     USE_SEQUSED: tl.constexpr,  # Add flag for seqused
+    USE_SLIDING_WINDOW: tl.constexpr,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
     NUM_XCD: tl.constexpr = 1,
@@ -3431,7 +3578,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=True,  # causal masking
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3441,7 +3591,19 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
             )
             start_m += num_steps * MASK_BLOCK_M1
-            num_steps = tl.cdiv(seqlen_q - start_m, BLOCK_M1)
+            # The unmasked region runs from the diagonal to seqlen_q. With a
+            # finite left window, queries more than WINDOW_SIZE_LEFT past this
+            # K block attend nothing in it, so cap the sweep at that upper bound.
+            if USE_SLIDING_WINDOW and WINDOW_SIZE_LEFT >= 0:
+                # m_hi = (n_hi + WINDOW_SIZE_LEFT) - (seqlen_k - seqlen_q)
+                m_hi = (start_n + BLOCK_N1 - 1) + WINDOW_SIZE_LEFT + delta_qk
+                m_hi = tl.minimum(m_hi, seqlen_q - 1)
+                if m_hi < start_m:
+                    num_steps = 0
+                else:
+                    num_steps = tl.cdiv(m_hi + 1 - start_m, BLOCK_M1)
+            else:
+                num_steps = tl.cdiv(seqlen_q - start_m, BLOCK_M1)
             end_m = start_m + num_steps * BLOCK_M1
 
             if DEBUG_TRITON:
@@ -3491,7 +3653,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,  # causal masking
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3637,7 +3802,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=True,  #
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3647,8 +3815,22 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
             )
             end_n -= num_steps * MASK_BLOCK_N2
-            num_steps = tl.cdiv(end_n, BLOCK_N2)
-            start_n = max(end_n - num_steps * BLOCK_N2, 0)
+            # The unmasked region runs from 0 up to the diagonal (end_n). With a
+            # finite left window, keys more than WINDOW_SIZE_LEFT before this Q
+            # block fall outside the band, so raise the lower bound.
+            if USE_SLIDING_WINDOW and WINDOW_SIZE_LEFT >= 0:
+                # n_lo = start_m - (seqlen_q - seqlen_k) - WINDOW_SIZE_LEFT
+                n_lo = start_m - delta_qk - WINDOW_SIZE_LEFT
+                n_lo = tl.maximum(n_lo, 0)
+                n_lo = (n_lo // BLOCK_N2) * BLOCK_N2
+                if n_lo >= end_n:
+                    num_steps = 0
+                else:
+                    num_steps = tl.cdiv(end_n - n_lo, BLOCK_N2)
+                start_n = n_lo
+            else:
+                num_steps = tl.cdiv(end_n, BLOCK_N2)
+                start_n = max(end_n - num_steps * BLOCK_N2, 0)
             if DEBUG_TRITON:
                 print(
                     f"unMasked: start_m: {start_m}, start_n: {start_n}, end_n: {end_n}, num_steps: {num_steps}"
@@ -3692,7 +3874,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3801,6 +3986,9 @@ def bwd_kernel_fused_noncausal(
     IS_FP8: tl.constexpr,
     FP8_MAX: tl.constexpr,
     USE_SEQUSED: tl.constexpr,  # Add flag for seqused
+    USE_SLIDING_WINDOW: tl.constexpr,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
     NUM_XCD: tl.constexpr = 1,
@@ -3922,9 +4110,21 @@ def bwd_kernel_fused_noncausal(
             else:
                 descale_q, descale_k, descale_v = 1.0, 1.0, 1.0
 
-            # because there is no causal, we always start from the beginning
-            start_m = 0
-            num_steps = tl.cdiv(seqlen_q, BLOCK_M1)
+            # because there is no causal, we sweep all query blocks -- unless a
+            # sliding window lets us skip query blocks entirely outside the band.
+            if USE_SLIDING_WINDOW:
+                start_m, num_steps = _sliding_window_q_bounds(
+                    start_n,
+                    seqlen_q,
+                    seqlen_k,
+                    WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT,
+                    BLOCK_N1,
+                    BLOCK_M1,
+                )
+            else:
+                start_m = 0
+                num_steps = tl.cdiv(seqlen_q, BLOCK_M1)
             dk, dv = _bwd_dkdv_inner(
                 dk,
                 dv,  # output tensors
@@ -3962,7 +4162,10 @@ def bwd_kernel_fused_noncausal(
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,  # causal masking
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -4044,9 +4247,20 @@ def bwd_kernel_fused_noncausal(
                 descale_q, descale_k, descale_v = 1.0, 1.0, 1.0
 
             # start can only be 0 at minimum
-            start_n = 0
             end_n = seqlen_k
-            num_steps = tl.cdiv(seqlen_k, BLOCK_N2)
+            if USE_SLIDING_WINDOW:
+                start_n, num_steps = _sliding_window_k_bounds(
+                    start_m,
+                    seqlen_q,
+                    seqlen_k,
+                    WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT,
+                    BLOCK_M2,
+                    BLOCK_N2,
+                )
+            else:
+                start_n = 0
+                num_steps = tl.cdiv(seqlen_k, BLOCK_N2)
 
             dq = tl.zeros([BLOCK_M2, HEAD_DIM_QK], dtype=tl.float32)
             dq = _bwd_dq_inner(
@@ -4088,7 +4302,10 @@ def bwd_kernel_fused_noncausal(
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -4150,6 +4367,8 @@ def attention_backward_triton_impl(
     q_descale: Optional[torch.Tensor] = None,
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
+    window_size_left: int = -1,
+    window_size_right: int = -1,
 ):
     # get params, strides and shape
     IS_VARLEN = layout == "thd"
@@ -4406,6 +4625,28 @@ def attention_backward_triton_impl(
         (True, alibi_slopes.stride()) if alibi_slopes is not None else (False, (0, 0))
     )
 
+    # "Active" iff either edge differs from the -1 "off" sentinel. This mirrors
+    # the forward kernels (fwd_prefill.py / fwd_decode.py both test `!= -1`); the
+    # interface guards removed in this change used `>= 0`, which is equivalent for
+    # every valid input (-1 is the only negative either edge ever takes).
+    use_sliding_window = window_size_left != -1 or window_size_right != -1
+    if use_sliding_window and mode != "fused":
+        raise NotImplementedError(
+            "Sliding-window backward is currently implemented for fused mode only."
+        )
+    # The kernels only special-case an infinite *left* edge (WINDOW_SIZE_LEFT < 0).
+    # There is no infinite-right code path, so a negative right bound would collapse
+    # right_bound to (anchor - 1) and silently mask out almost everything. When the
+    # window is active, window_size_right must therefore be >= 0. (window_size_right
+    # == -1 is only valid as the "off" sentinel, i.e. together with
+    # window_size_left == -1, which leaves use_sliding_window False.)
+    if use_sliding_window and window_size_right < 0:
+        raise NotImplementedError(
+            "Sliding-window backward requires window_size_right >= 0 "
+            f"(got window_size_right={window_size_right}). An infinite right edge "
+            "is not supported; use window_size_right=0 for a causal window."
+        )
+
     # get closest power of 2 over or equal to 32.
     padded_d_model_qk = 1 << (head_size_qk - 1).bit_length()
     padded_d_model_qk = max(padded_d_model_qk, 32)
@@ -4598,6 +4839,9 @@ def attention_backward_triton_impl(
                 USE_SEQUSED=(
                     seqused_q is not None or seqused_k is not None
                 ),  # Add flag for seqused
+                USE_SLIDING_WINDOW=use_sliding_window,
+                WINDOW_SIZE_LEFT=window_size_left,
+                WINDOW_SIZE_RIGHT=window_size_right,
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 NUM_XCD=num_xcd,
@@ -4686,6 +4930,9 @@ def attention_backward_triton_impl(
                 USE_SEQUSED=(
                     seqused_q is not None or seqused_k is not None
                 ),  # Add flag for seqused
+                USE_SLIDING_WINDOW=use_sliding_window,
+                WINDOW_SIZE_LEFT=window_size_left,
+                WINDOW_SIZE_RIGHT=window_size_right,
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 NUM_XCD=num_xcd,

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
@@ -1059,6 +1059,16 @@ def attention_forward_decode_triton_impl(
     )
     use_cache_seqlens = cache_seqlens is not None
     use_sliding_window = window_size_left != -1 or window_size_right != -1
+    # As in the prefill kernel, WINDOW_SIZE_RIGHT is used as a literal finite
+    # offset (no infinite-right branch), so a negative right collapses the band
+    # and silently over-masks. Reject it instead. (right == -1 is only valid as
+    # the off sentinel, paired with left == -1, which leaves this flag False.)
+    if use_sliding_window and window_size_right < 0:
+        raise NotImplementedError(
+            "Sliding-window attention requires window_size_right >= 0 "
+            f"(got window_size_right={window_size_right}). An unbounded right edge "
+            "is not supported; use window_size_right=0 for a causal window."
+        )
     use_block_table = block_table is not None
 
     # get shapes and strides

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -1766,6 +1766,20 @@ def attention_forward_prefill_triton_impl(
 
     # check features
     use_sliding_window = window_size_left != -1 or window_size_right != -1
+    # The kernel only special-cases an infinite *left* edge (WINDOW_SIZE_LEFT < 0).
+    # WINDOW_SIZE_RIGHT is consumed as a literal finite offset everywhere (the
+    # per-element right_bound and the block-classification bounds), so a negative
+    # right does not mean "unbounded" -- it collapses right_bound to (anchor - 1)
+    # and silently over-masks. Reject it rather than return a wrong result.
+    # (window_size_right == -1 is only valid as the "off" sentinel, i.e. together
+    # with window_size_left == -1, which leaves use_sliding_window False.) This
+    # matches the backward guard in attention_backward_triton_impl.
+    if use_sliding_window and window_size_right < 0:
+        raise NotImplementedError(
+            "Sliding-window attention requires window_size_right >= 0 "
+            f"(got window_size_right={window_size_right}). An unbounded right edge "
+            "is not supported; use window_size_right=0 for a causal window."
+        )
     use_alibi, (stride_az, stride_ah) = (
         (True, alibi_slopes.stride()) if alibi_slopes is not None else (False, (0, 0))
     )

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/interface_v2.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/interface_v2.py
@@ -235,15 +235,6 @@ def bwd(
             "softcap is not supported in the AMD Triton FA2 interface (expected 0.0)."
         )
 
-    # Check for sliding window - backward doesn't support it yet
-    is_sliding_window = (window_size_left >= 0) or (window_size_right >= 0)
-    if is_sliding_window:
-        raise NotImplementedError(
-            f"Sliding window attention is not yet supported in the AMD Triton backward pass "
-            f"(window_size_left={window_size_left}, window_size_right={window_size_right}). "
-            f"Use window_size=(-1, -1) for full attention."
-        )
-
     if DEBUG:
         print()
         print("flash_attn_triton_amd.py::bwd inputs")
@@ -328,6 +319,8 @@ def bwd(
         philox_offset=philox_offset,
         use_exp2=USE_EXP2,
         mode=BWD_MODE,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
     )
 
     if DEBUG:
@@ -582,14 +575,6 @@ def varlen_bwd(
             "softcap is not supported in varlen_bwd (expected 0.0)."
         )
 
-    is_sliding_window = (window_size_left >= 0) or (window_size_right >= 0)
-    if is_sliding_window:
-        raise NotImplementedError(
-            f"Sliding window attention is not yet supported in the AMD Triton backward pass "
-            f"(window_size_left={window_size_left}, window_size_right={window_size_right}). "
-            f"Use window_size=(-1, -1) for full attention."
-        )
-
     if DEBUG:
         print()
         print("varlen_bwd")
@@ -676,6 +661,8 @@ def varlen_bwd(
         philox_offset=philox_offset,
         use_exp2=USE_EXP2,
         mode=BWD_MODE,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
     )
 
     if DEBUG:

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/interface_v3.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/interface_v3.py
@@ -470,15 +470,6 @@ def bwd(
 
     # Check for unsupported features in backward pass
 
-    # Handle sliding window - backward doesn't support it yet
-    is_sliding_window = (window_size_left >= 0) or (window_size_right >= 0)
-    if is_sliding_window:
-        raise NotImplementedError(
-            f"Sliding window attention is not yet supported in the AMD Triton backward pass "
-            f"(window_size_left={window_size_left}, window_size_right={window_size_right}). "
-            f"Use window_size=(-1, -1) for full attention."
-        )
-
     # Handle softcap
     if softcap != 0.0:
         raise NotImplementedError(
@@ -554,6 +545,8 @@ def bwd(
         philox_offset=philox_offset,
         use_exp2=USE_EXP2,
         mode=BWD_MODE,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
         q_descale=q_descale,
         k_descale=k_descale,
         v_descale=v_descale,

--- a/aiter/ops/triton/attention/mha.py
+++ b/aiter/ops/triton/attention/mha.py
@@ -77,7 +77,7 @@ def _flash_attn_forward(
 
     if bias is not None:
         raise ValueError("Bias is not supported yet in the Triton Backend")
-    if window_size_right != -1:
+    if _MHA_IMPL != "dao_ai" and window_size_right != -1:
         raise ValueError("window_size_right is not supported yet in the Triton Backend")
     sliding_window = window_size_left if window_size_left >= 0 else 0
 
@@ -191,9 +191,6 @@ def _flash_attn_forward(
         assert (
             not IS_FP8
         ), "dao_ai impl does not support FP8. Use the default impl or FA3 path."
-        assert (
-            window_size_left == -1 and window_size_right == -1
-        ), "dao_ai impl does not support sliding window attention."
         if is_varlen:
             o, softmax_lse, s_dmask, _ = flash_attn_2.varlen_fwd(
                 q,
@@ -212,8 +209,8 @@ def _flash_attn_forward(
                 softmax_scale=softmax_scale,
                 zero_tensors=False,
                 causal=causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=window_size_left,
+                window_size_right=window_size_right,
                 softcap=0.0,
                 return_softmax=return_softmax,
             )
@@ -227,8 +224,8 @@ def _flash_attn_forward(
                 dropout_p,
                 softmax_scale,
                 causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=window_size_left,
+                window_size_right=window_size_right,
                 softcap=0.0,
                 return_softmax=return_softmax,
             )
@@ -423,8 +420,8 @@ class _FlashAttnFunc(torch.autograd.Function):
                 ctx.dropout_p,
                 ctx.softmax_scale,
                 ctx.causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=ctx.window_size[0],
+                window_size_right=ctx.window_size[1],
                 softcap=0.0,
                 deterministic=ctx.deterministic,
             )
@@ -717,8 +714,8 @@ class _FlashAttnVarlenFunc(torch.autograd.Function):
                 softmax_scale=ctx.softmax_scale,
                 zero_tensors=False,
                 causal=ctx.causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=ctx.window_size[0],
+                window_size_right=ctx.window_size[1],
                 softcap=0.0,
                 deterministic=False,
             )

--- a/op_tests/triton_tests/attention/test_mha_dao_ai.py
+++ b/op_tests/triton_tests/attention/test_mha_dao_ai.py
@@ -48,13 +48,25 @@ def dao_ai_impl():
 
 
 @pytest.mark.parametrize(
-    "BATCH, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ, CAUSAL, VARLEN, BWD",
+    "BATCH, SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ, CAUSAL, VARLEN, BWD, WINDOW_SIZE",
     [
-        (1, 128, 128, 8, 8, 64, True, False, False),  # fwd causal
-        (2, 256, 256, 16, 4, 128, False, False, False),  # fwd GQA non-causal
-        (1, 128, 128, 8, 8, 64, True, True, False),  # fwd_varlen causal
-        (1, 128, 128, 8, 8, 64, True, False, True),  # bwd causal
-        (1, 128, 128, 8, 8, 64, True, True, True),  # bwd_varlen causal
+        (1, 128, 128, 8, 8, 64, True, False, False, (-1, -1)),  # fwd causal
+        (2, 256, 256, 16, 4, 128, False, False, False, (-1, -1)),  # fwd GQA non-causal
+        (1, 128, 128, 8, 8, 64, True, True, False, (-1, -1)),  # fwd_varlen causal
+        (1, 128, 128, 8, 8, 64, True, False, True, (-1, -1)),  # bwd causal
+        (1, 128, 128, 8, 8, 64, True, True, True, (-1, -1)),  # bwd_varlen causal
+        (1, 128, 128, 8, 8, 64, True, False, True, (32, 0)),  # causal window
+        (1, 128, 128, 8, 8, 64, True, True, True, (32, 0)),  # causal window varlen
+        (1, 128, 128, 8, 8, 64, False, False, True, (16, 16)),  # symmetric window
+        (1, 128, 128, 8, 8, 64, False, True, True, (16, 16)),  # symmetric win varlen
+        (1, 128, 128, 8, 8, 64, False, False, True, (-1, 32)),  # infinite-left window
+        # seqlen_q != seqlen_k exercises the causal_offset / delta_qk arithmetic
+        (1, 128, 256, 8, 8, 64, True, False, True, (32, 0)),  # causal, sq != sk
+        (1, 128, 256, 8, 8, 64, True, True, True, (32, 0)),  # causal varlen, sq != sk
+        (1, 128, 256, 8, 8, 64, False, False, True, (16, 16)),  # symmetric, sq != sk
+        # GQA (num_q_heads != num_k_heads) combined with sliding-window backward
+        (2, 128, 128, 16, 4, 64, True, False, True, (32, 0)),  # GQA causal window
+        (2, 128, 128, 16, 4, 64, False, True, True, (16, 16)),  # GQA symmetric varlen
     ],
 )
 def test_mha_dao_ai(
@@ -68,6 +80,7 @@ def test_mha_dao_ai(
     CAUSAL: bool,
     VARLEN: bool,
     BWD: bool,
+    WINDOW_SIZE: tuple[int, int],
     dtype=torch.float16,
 ):
     """Test dao_ai impl dispatch for fwd/bwd x varlen against PyTorch reference."""
@@ -138,12 +151,15 @@ def test_mha_dao_ai(
                 max_seqlen_q,
                 max_seqlen_k,
                 causal=CAUSAL,
+                window_size=WINDOW_SIZE,
             )
     else:
         query_padding_mask = None
         key_padding_mask = None
         with torch.set_grad_enabled(BWD):
-            triton_out = flash_attn_func(q, k, v, causal=CAUSAL)
+            triton_out = flash_attn_func(
+                q, k, v, causal=CAUSAL, window_size=WINDOW_SIZE
+            )
 
     # Forward check against PyTorch reference
     q_ref = q.detach().clone().requires_grad_(BWD)
@@ -154,6 +170,7 @@ def test_mha_dao_ai(
         k_ref,
         v_ref,
         causal=CAUSAL,
+        window_size=WINDOW_SIZE,
         query_padding_mask=query_padding_mask,
         key_padding_mask=key_padding_mask,
     )
@@ -204,6 +221,39 @@ def test_mha_dao_ai(
             rtol=1e-2,
             msg=lambda msg: f"dao_ai bwd dv mismatch\n\n{msg}\n",
         )
+
+
+def test_mha_dao_ai_negative_right_window_raises(dao_ai_impl):
+    """A negative right edge (window_size_right < 0) must be rejected.
+
+    Neither fwd nor bwd has an infinite-right code path: WINDOW_SIZE_RIGHT is used
+    as a literal finite offset everywhere (the per-element right_bound, the forward
+    block-classification bounds, and the m_lo/n_hi bounds in
+    _sliding_window_q_bounds/_k_bounds), so a value of -1 collapses right_bound to
+    "anchor - 1" -- over-masking per element AND skipping blocks that should
+    contribute. Both forward and backward guard against it instead of silently
+    returning a wrong result.
+
+    Forward is the reachable guard via the public API (it fires before grad can
+    run); the matching backward guard in attention_backward_triton_impl remains as
+    defense-in-depth. (window_size_right == -1 is only valid as the off sentinel,
+    paired with window_size_left == -1.)
+    """
+    torch.manual_seed(20)
+    q = torch.randn(
+        1, 128, 8, 64, device="cuda", dtype=torch.float16, requires_grad=True
+    )
+    k = torch.randn(
+        1, 128, 8, 64, device="cuda", dtype=torch.float16, requires_grad=True
+    )
+    v = torch.randn(
+        1, 128, 8, 64, device="cuda", dtype=torch.float16, requires_grad=True
+    )
+
+    # window_size=(32, -1): finite left, negative right -> sliding window active
+    # with window_size_right < 0. Forward must raise before any backward runs.
+    with pytest.raises(NotImplementedError):
+        flash_attn_func(q, k, v, causal=False, window_size=(32, -1))
 
 
 @pytest.mark.parametrize("default_device", ["cpu", "cuda"])

--- a/op_tests/triton_tests/attention/test_mha_dao_ai.py
+++ b/op_tests/triton_tests/attention/test_mha_dao_ai.py
@@ -67,6 +67,18 @@ def dao_ai_impl():
         # GQA (num_q_heads != num_k_heads) combined with sliding-window backward
         (2, 128, 128, 16, 4, 64, True, False, True, (32, 0)),  # GQA causal window
         (2, 128, 128, 16, 4, 64, False, True, True, (16, 16)),  # GQA symmetric varlen
+        # Production-size sequence lengths (beyond the upstream 2048 cap) with
+        # large windows (128/256). seqlen >> window means the window spans many
+        # key blocks, exercising the bwd full/partial/skipped block
+        # classification that the small (seqlen 128, window 16/32) cases barely
+        # reach.
+        (1, 4096, 4096, 8, 8, 64, True, False, True, (256, 0)),  # large causal window
+        (1, 4096, 4096, 8, 8, 64, True, True, True, (256, 0)),  # large causal varlen
+        (1, 4096, 4096, 8, 8, 64, False, False, True, (256, 256)),  # large symmetric
+        (2, 4096, 4096, 16, 4, 64, True, False, True, (128, 0)),  # GQA large causal
+        # seqlen_q != seqlen_k at production size exercises the causal_offset /
+        # delta_qk arithmetic with a window spanning many blocks.
+        (1, 4096, 8192, 8, 8, 64, True, False, True, (256, 0)),  # large causal sq != sk
     ],
 )
 def test_mha_dao_ai(

--- a/op_tests/triton_tests/attention/test_mha_v3.py
+++ b/op_tests/triton_tests/attention/test_mha_v3.py
@@ -1040,6 +1040,11 @@ def test_mha_backward_varlen_fp8(
         (False, (-1, 32)),  # non-causal infinite-left window
     ],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float16, torch.float32],
+    ids=["fp16", "fp32"],
+)
 def test_mha_v3_sliding_window_bwd(
     CAUSAL: bool,
     WINDOW_SIZE: tuple,
@@ -1048,7 +1053,7 @@ def test_mha_v3_sliding_window_bwd(
     NUM_Q_HEADS: int,
     NUM_K_HEADS: int,
     VARLEN: bool,
-    dtype=torch.float16,
+    dtype: torch.dtype,
 ):
     """Exercise the FA3 (interface_v3) backward path with sliding-window attention.
 
@@ -1059,6 +1064,10 @@ def test_mha_v3_sliding_window_bwd(
     """
     BATCH = 2
     HEAD_SZ = 64
+    # fp16 is limited by its ~1e-3 round-trip; fp32 is accumulated in fp32 end to
+    # end (observed max abs error < 4e-6 across these configs), so it gets a much
+    # tighter check.
+    atol, rtol = (1e-2, 1e-2) if dtype == torch.float16 else (1e-4, 1e-3)
     torch.cuda.empty_cache()
     torch.manual_seed(20)
 
@@ -1146,7 +1155,7 @@ def test_mha_v3_sliding_window_bwd(
 
     if VARLEN:
         triton_out = output_pad_fn(triton_out)
-    torch.testing.assert_close(triton_out, torch_out, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(triton_out, torch_out, atol=atol, rtol=rtol)
 
     do = torch.randn_like(torch_out)
     if VARLEN:
@@ -1166,22 +1175,22 @@ def test_mha_v3_sliding_window_bwd(
     torch.testing.assert_close(
         triton_dq,
         torch_dq,
-        atol=1e-2,
-        rtol=1e-2,
+        atol=atol,
+        rtol=rtol,
         msg=lambda m: f"FA3 sliding-window bwd dq mismatch\n\n{m}\n",
     )
     torch.testing.assert_close(
         triton_dk,
         torch_dk,
-        atol=1e-2,
-        rtol=1e-2,
+        atol=atol,
+        rtol=rtol,
         msg=lambda m: f"FA3 sliding-window bwd dk mismatch\n\n{m}\n",
     )
     torch.testing.assert_close(
         triton_dv,
         torch_dv,
-        atol=1e-2,
-        rtol=1e-2,
+        atol=atol,
+        rtol=rtol,
         msg=lambda m: f"FA3 sliding-window bwd dv mismatch\n\n{m}\n",
     )
 

--- a/op_tests/triton_tests/attention/test_mha_v3.py
+++ b/op_tests/triton_tests/attention/test_mha_v3.py
@@ -930,6 +930,75 @@ def test_mha_backward_fp8(
         assert_cosine_similarity(tri, ref)
 
 
+@pytest.mark.parametrize(
+    "CAUSAL, WINDOW_SIZE",
+    [
+        (True, (64, 0)),  # causal sliding window
+        (False, (64, 64)),  # non-causal symmetric window
+        (False, (-1, 64)),  # non-causal infinite-left window
+    ],
+)
+@pytest.mark.parametrize("SEQLEN_Q, SEQLEN_K", [(512, 512), (512, 1024)])
+def test_mha_backward_fp8_sliding_window(
+    SEQLEN_Q: int,
+    SEQLEN_K: int,
+    CAUSAL: bool,
+    WINDOW_SIZE: tuple,
+    dtype=torch.float16,
+):
+    """FP8 backward combined with sliding-window attention.
+
+    test_mha_backward_fp8 exercises the FP8 bwd without a window; this pins the
+    window x IS_FP8 interaction in the bwd kernels (the per-element mask is
+    applied to P before the FP8 dP/dS compute). Checks out/dq/dk/dv against the
+    FP8 PyTorch reference with the same window, including seqlen_q != seqlen_k.
+    """
+    if not _supports_fp8:
+        pytest.skip(f"FP8 not supported on {_arch}")
+
+    BATCH = 2
+    NUM_Q_HEADS = 16
+    NUM_K_HEADS = 8  # GQA
+    HEAD_SZ = 128
+
+    torch.cuda.empty_cache()
+    torch.manual_seed(20)
+
+    q = torch.randn(BATCH, SEQLEN_Q, NUM_Q_HEADS, HEAD_SZ, device="cuda", dtype=dtype)
+    k = torch.randn(BATCH, SEQLEN_K, NUM_K_HEADS, HEAD_SZ, device="cuda", dtype=dtype)
+    v = torch.randn(BATCH, SEQLEN_K, NUM_K_HEADS, HEAD_SZ, device="cuda", dtype=dtype)
+    q.requires_grad = True
+    k.requires_grad = True
+    v.requires_grad = True
+    do = torch.randn_like(q)
+
+    with torch.enable_grad():
+        triton_out = flash_attn_fp8_func(
+            q, k, v, causal=CAUSAL, window_size=WINDOW_SIZE
+        )
+    triton_dq, triton_dk, triton_dv = torch.autograd.grad(
+        triton_out, (q, k, v), do.clone()
+    )
+
+    torch_out, torch_grads, fwd_tol, bwd_tols = attention_ref_with_tol(
+        q,
+        k,
+        v,
+        do,
+        is_fp8=True,
+        causal=CAUSAL,
+        window_size=WINDOW_SIZE,
+    )
+    torch_dq, torch_dk, torch_dv = torch_grads
+
+    triton_vals = [triton_out, triton_dq, triton_dk, triton_dv]
+    ref_vals = [torch_out, torch_dq, torch_dk, torch_dv]
+    tols = [fwd_tol] + bwd_tols
+    for tri, ref, (atol, rtol) in zip(triton_vals, ref_vals, tols):
+        torch.testing.assert_close(tri, ref.to(tri.dtype), atol=atol, rtol=rtol)
+        assert_cosine_similarity(tri, ref)
+
+
 @pytest.mark.parametrize("SEQLEN_Q", [512, 2048])
 @pytest.mark.parametrize("SEQLEN_K", [512, 2048])
 @pytest.mark.parametrize("NUM_Q_HEADS", [32, 64])
@@ -1062,8 +1131,76 @@ def test_mha_v3_sliding_window_bwd(
     the PyTorch reference for causal, symmetric, and infinite-left windows, across
     equal/unequal seqlens and GQA, dense and varlen.
     """
-    BATCH = 2
-    HEAD_SZ = 64
+    _check_sliding_window_bwd(
+        CAUSAL,
+        WINDOW_SIZE,
+        SEQLEN_Q,
+        SEQLEN_K,
+        NUM_Q_HEADS,
+        NUM_K_HEADS,
+        VARLEN,
+        dtype,
+    )
+
+
+@pytest.mark.parametrize("VARLEN", [False, True])
+@pytest.mark.parametrize(
+    "SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS, CAUSAL, WINDOW_SIZE",
+    [
+        # Production-size sequence lengths (beyond the upstream 2048 cap) paired
+        # with large windows (128/256). seqlen >> window means the window spans
+        # many key blocks, so the bwd full/partial/skipped block classification
+        # is exercised across many blocks -- the small (seqlen 128, window 16/32)
+        # cases above barely span more than one block.
+        (4096, 4096, 8, 8, True, (256, 0)),  # large causal window
+        (4096, 4096, 16, 4, False, (128, 128)),  # GQA large symmetric window
+        (8192, 8192, 8, 8, True, (256, 0)),  # larger causal window
+        (4096, 8192, 8, 8, True, (256, 0)),  # large causal, seqlen_q != seqlen_k
+    ],
+)
+def test_mha_v3_sliding_window_bwd_large(
+    CAUSAL: bool,
+    WINDOW_SIZE: tuple,
+    SEQLEN_Q: int,
+    SEQLEN_K: int,
+    NUM_Q_HEADS: int,
+    NUM_K_HEADS: int,
+    VARLEN: bool,
+):
+    """Production-size FA3 sliding-window backward.
+
+    Same checks as ``test_mha_v3_sliding_window_bwd`` but at sequence lengths past
+    the upstream 2048 ceiling and with 128/256-wide windows. fp16 only: the fp32
+    reference materializes full [batch, heads, seqlen_q, seqlen_k] scores, so the
+    cross-product with fp32 would be needlessly heavy without adding coverage the
+    smaller fp32 matrix doesn't already give.
+    """
+    _check_sliding_window_bwd(
+        CAUSAL,
+        WINDOW_SIZE,
+        SEQLEN_Q,
+        SEQLEN_K,
+        NUM_Q_HEADS,
+        NUM_K_HEADS,
+        VARLEN,
+        torch.float16,
+    )
+
+
+def _check_sliding_window_bwd(
+    CAUSAL: bool,
+    WINDOW_SIZE: tuple,
+    SEQLEN_Q: int,
+    SEQLEN_K: int,
+    NUM_Q_HEADS: int,
+    NUM_K_HEADS: int,
+    VARLEN: bool,
+    dtype: torch.dtype,
+    BATCH: int = 2,
+    HEAD_SZ: int = 64,
+):
+    """Run one FA3 sliding-window backward and check out/dq/dk/dv vs the PyTorch
+    reference. Shared by the small-matrix and production-size tests above."""
     # fp16 is limited by its ~1e-3 round-trip; fp32 is accumulated in fp32 end to
     # end (observed max abs error < 4e-6 across these configs), so it gets a much
     # tighter check.

--- a/op_tests/triton_tests/attention/test_mha_v3.py
+++ b/op_tests/triton_tests/attention/test_mha_v3.py
@@ -1023,6 +1023,169 @@ def test_mha_backward_varlen_fp8(
         assert_cosine_similarity(tri, ref)
 
 
+@pytest.mark.parametrize("VARLEN", [False, True])
+@pytest.mark.parametrize(
+    "SEQLEN_Q, SEQLEN_K, NUM_Q_HEADS, NUM_K_HEADS",
+    [
+        (128, 128, 8, 8),  # baseline: equal seqlens, MHA
+        (128, 256, 8, 8),  # seqlen_q != seqlen_k exercises causal_offset / delta_qk
+        (128, 128, 16, 4),  # GQA combined with sliding window
+    ],
+)
+@pytest.mark.parametrize(
+    "CAUSAL, WINDOW_SIZE",
+    [
+        (True, (32, 0)),  # causal sliding window
+        (False, (16, 16)),  # non-causal symmetric window
+        (False, (-1, 32)),  # non-causal infinite-left window
+    ],
+)
+def test_mha_v3_sliding_window_bwd(
+    CAUSAL: bool,
+    WINDOW_SIZE: tuple,
+    SEQLEN_Q: int,
+    SEQLEN_K: int,
+    NUM_Q_HEADS: int,
+    NUM_K_HEADS: int,
+    VARLEN: bool,
+    dtype=torch.float16,
+):
+    """Exercise the FA3 (interface_v3) backward path with sliding-window attention.
+
+    The dao_ai tests cover interface_v2; this pins the interface_v3 bwd, whose
+    sliding-window guard was removed alongside v2's. Checks out/dq/dk/dv against
+    the PyTorch reference for causal, symmetric, and infinite-left windows, across
+    equal/unequal seqlens and GQA, dense and varlen.
+    """
+    BATCH = 2
+    HEAD_SZ = 64
+    torch.cuda.empty_cache()
+    torch.manual_seed(20)
+
+    q = torch.randn(
+        BATCH,
+        SEQLEN_Q,
+        NUM_Q_HEADS,
+        HEAD_SZ,
+        device="cuda",
+        dtype=dtype,
+        requires_grad=True,
+    )
+    k = torch.randn(
+        BATCH,
+        SEQLEN_K,
+        NUM_K_HEADS,
+        HEAD_SZ,
+        device="cuda",
+        dtype=dtype,
+        requires_grad=True,
+    )
+    v = torch.randn(
+        BATCH,
+        SEQLEN_K,
+        NUM_K_HEADS,
+        HEAD_SZ,
+        device="cuda",
+        dtype=dtype,
+        requires_grad=True,
+    )
+
+    if VARLEN:
+        query_padding_mask = generate_random_padding_mask(
+            SEQLEN_Q, BATCH, "cuda", mode="full"
+        )
+        key_padding_mask = generate_random_padding_mask(
+            SEQLEN_K, BATCH, "cuda", mode="full"
+        )
+        (
+            q_unpad,
+            k_unpad,
+            v_unpad,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            q,
+            k,
+            v,
+            output_pad_fn,
+            dq_pad_fn,
+            dk_pad_fn,
+        ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask, kvpacked=False)
+        q_unpad.requires_grad_(True)
+        k_unpad.requires_grad_(True)
+        v_unpad.requires_grad_(True)
+        triton_out = flash_attn_varlen_func(
+            q_unpad,
+            k_unpad,
+            v_unpad,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            causal=CAUSAL,
+            window_size=WINDOW_SIZE,
+        )
+    else:
+        query_padding_mask = None
+        key_padding_mask = None
+        triton_out = flash_attn_func(q, k, v, causal=CAUSAL, window_size=WINDOW_SIZE)
+
+    q_ref = q.detach().clone().requires_grad_(True)
+    k_ref = k.detach().clone().requires_grad_(True)
+    v_ref = v.detach().clone().requires_grad_(True)
+    torch_out, _ = attention_ref(
+        q_ref,
+        k_ref,
+        v_ref,
+        query_padding_mask=query_padding_mask,
+        key_padding_mask=key_padding_mask,
+        causal=CAUSAL,
+        window_size=WINDOW_SIZE,
+    )
+
+    if VARLEN:
+        triton_out = output_pad_fn(triton_out)
+    torch.testing.assert_close(triton_out, torch_out, atol=1e-2, rtol=1e-2)
+
+    do = torch.randn_like(torch_out)
+    if VARLEN:
+        triton_dq, triton_dk, triton_dv = torch.autograd.grad(
+            triton_out, (q_unpad, k_unpad, v_unpad), do
+        )
+        triton_dq = dq_pad_fn(triton_dq)
+        triton_dk = dk_pad_fn(triton_dk)
+        triton_dv = dk_pad_fn(triton_dv)
+    else:
+        triton_dq, triton_dk, triton_dv = torch.autograd.grad(triton_out, (q, k, v), do)
+
+    torch_dq, torch_dk, torch_dv = torch.autograd.grad(
+        torch_out, (q_ref, k_ref, v_ref), do
+    )
+
+    torch.testing.assert_close(
+        triton_dq,
+        torch_dq,
+        atol=1e-2,
+        rtol=1e-2,
+        msg=lambda m: f"FA3 sliding-window bwd dq mismatch\n\n{m}\n",
+    )
+    torch.testing.assert_close(
+        triton_dk,
+        torch_dk,
+        atol=1e-2,
+        rtol=1e-2,
+        msg=lambda m: f"FA3 sliding-window bwd dk mismatch\n\n{m}\n",
+    )
+    torch.testing.assert_close(
+        triton_dv,
+        torch_dv,
+        atol=1e-2,
+        rtol=1e-2,
+        msg=lambda m: f"FA3 sliding-window bwd dv mismatch\n\n{m}\n",
+    )
+
+
 @pytest.mark.parametrize("mha_type", ["mha", "gqa"])
 def test_flash_attn_kvcache_paged_graph(mha_type):
     """graph capture with paged KV cache (block_table)."""


### PR DESCRIPTION
**Motivation**:  Sliding-window (local) attention was supported in the AMD Triton flash-attention forward pass but not in the backward pass

This PR plumbs the window flags through the dKdV/dQ inner kernels and both fused kernels, with the backward mask following the forward convention (the backward pass recomputes softmax from the stored LSE, so the masks must match exactly). It also adds _sliding_window_q_bounds/_sliding_window_k_bounds to skip out-of-window blocks, while per-element masking remains the correctness guarantee. Windowed backward is restricted to fused mode, and an unbounded right edge is rejected.

## Performance

Benchmarked the windowed backward against full attention on the META-2.3B-style varlen GQA-SWA configs (`batch=4`, `seqlen_q=4096`, `num_heads=48`, `num_kv_heads=6`, `head_dim=64`, causal, **window = 2047**, bf16), Triton AMD backend. Before (stock) and after (this PR) were measured back-to-back in the same session on the same GPU. Wall-clock backward (ms), deterministic=FALSE:

| seqlen_kv | windowed bwd **before** | windowed bwd **after** | speedup | full (-1) bwd (after) | windowed vs full |
|----------:|------------------------:|-----------------------:|:-------:|----------------------:|:----------------:|
| 4096  | 5.11  | 6.29 | 0.81× | 5.03  | 1.25× (slower) |
| 8192  | 12.47 | 7.70 | 1.62× | 12.49 | 1.62× faster |
| 12288 | 20.05 | 7.98 | 2.51× | 20.10 | 2.52× faster |
| 16384 | 27.98 | 8.11 | 3.45× | 28.02 | 3.45× faster |


Assisted-by:  [Claude Code](https://claude.ai/code)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    