### PR TITLE
[DO NOT MERGE] CI: download triton wheels with --no-deps and use release_tmp index

### DIFF
--- a/.github/scripts/download_triton_wheel.sh
+++ b/.github/scripts/download_triton_wheel.sh
@@ -9,17 +9,18 @@ python3 -m pip config set global.retries 15
 python3 -m pip config set global.timeout 120
 
 TRITON_DEFAULT_ROCM_VERSION="${TRITON_DEFAULT_ROCM_VERSION:-7.2.0}"
-TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${TRITON_DEFAULT_ROCM_VERSION}/simple/"
+TRITON_INDEX_URL="https://pypi.amd.com/triton/release_tmp/rocm-${TRITON_DEFAULT_ROCM_VERSION}/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
 if [[ -n "${ROCM_VERSION}" ]]; then
     ROCM_MAJOR_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f1,2)
-    TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
+    TRITON_INDEX_URL="https://pypi.amd.com/triton/release_tmp/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
 else
     echo "rocm-core not found; using default ROCm version ${TRITON_DEFAULT_ROCM_VERSION}"
 fi
 
 echo "Downloading triton wheel from ${TRITON_INDEX_URL} into ${TRITON_WHEEL_DIR}"
 python3 -m pip download \
+    --no-deps \
     --only-binary=:all: \
     --dest "${TRITON_WHEEL_DIR}" \
     --index-url "${TRITON_INDEX_URL}" \
@@ -28,6 +29,7 @@ python3 -m pip download \
 
 echo "Downloading triton-kernels wheel from ${TRITON_INDEX_URL} into ${TRITON_WHEEL_DIR}"
 python3 -m pip download \
+    --no-deps \
     --only-binary=:all: \
     --dest "${TRITON_WHEEL_DIR}" \
     --index-url "${TRITON_INDEX_URL}" \

--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -64,7 +64,7 @@ TRITON_INDEX_URL="https://pypi.amd.com/triton/release_tmp/rocm-7.0.0/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}' || true)
 if [[ -n "$ROCM_VERSION" ]]; then
     ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | cut -d. -f1,2)
-    TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
+    TRITON_INDEX_URL="https://pypi.amd.com/triton/release_tmp/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
 fi
 
 TRITON_WHEEL_DIR=${TRITON_WHEEL_DIR:-}

--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -60,7 +60,7 @@ install_triton_from_wheelhouse() {
     return 0
 }
 
-TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/"
+TRITON_INDEX_URL="https://pypi.amd.com/triton/release_tmp/rocm-7.0.0/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}' || true)
 if [[ -n "$ROCM_VERSION" ]]; then
     ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | cut -d. -f1,2)


### PR DESCRIPTION
Avoid pulling transitive deps during triton wheel download, and point the triton index URL at the release_tmp channel for rocm-7.0.0.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
  The triton wheel download step was pulling in transitive dependencies, bloating the wheelhouse and risking version conflicts with packages already managed elsewhere in the CI  environment. Additionally, the triton index URL needed to point at the `release_tmp` channel for rocm-7.0.0.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
  - Added `--no-deps` to both `pip download` invocations in `.github/scripts/download_triton_wheel.sh` (the `triton` and `triton-kernels` wheel downloads), so only the requested
  wheels are fetched without their transitive dependencies.
  - Updated `TRITON_INDEX_URL` in `.github/scripts/install_triton.sh` from `https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/` to `https://pypi.amd.com/triton/release_tmp/rocm-7.0.0/simple/`.
## Test Plan

- Run the CI triton wheel download step and confirm only the `triton` and `triton-kernels` wheels are downloaded into the wheelhouse, with no transitive dependencies.
- Confirm the triton install resolves wheels from the `release_tmp` index.
## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
