### PR TITLE
Add fused attention preprocessing op for MiniMax-M3 

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -118,6 +118,9 @@ else:
     from .ops.trans_ragged_layout import *  # noqa: F403,E402
     from .ops.sample import *  # noqa: F403,E402
     from .ops.fused_qk_norm_mrope_cache_quant import *  # noqa: F403,E402
+    from .ops.fused_qknorm_idxrqknorm import (  # noqa: F401,E402
+        fused_qknorm_idxrqknorm,
+    )
     from .ops.fused_qk_norm_rope_cache_quant import *  # noqa: F403,E402
     from .ops.fused_qk_rmsnorm_group_quant import *  # noqa: F403,E402
     from .ops.groupnorm import *  # noqa: F403,E402

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1061,6 +1061,23 @@
         "verbose": "False",
         "blob_gen_cmd": "''"
     },
+    "module_fused_qknorm_idxrqknorm": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/fused_qknorm_idxrqknorm_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/fused_qknorm_idxrqknorm.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-DENABLE_FP8'"
+        ],
+        "extra_ldflags": "None",
+        "extra_include": [
+            "f'{AITER_CSRC_DIR}/include/ck_tile'",
+            "f'{AITER_CSRC_DIR}/include/opus'"
+        ],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_fused_qk_norm_rope_cache_quant_shuffle": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/fused_qk_norm_rope_cache_quant_pybind.cu'",

--- a/aiter/ops/fused_qknorm_idxrqknorm.py
+++ b/aiter/ops/fused_qknorm_idxrqknorm.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from typing import Optional
+
+from torch import Tensor
+
+from ..jit.core import compile_ops
+
+
+@compile_ops(
+    "module_fused_qknorm_idxrqknorm",
+    fc_name="fused_qknorm_idxrqknorm",
+    develop=True,
+)
+def _fused_qknorm_idxrqknorm_hip(
+    qkv: Tensor,
+    q_norm_weight: Tensor,
+    k_norm_weight: Tensor,
+    cos_sin_cache: Tensor,
+    positions: Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    rotary_dim: int,
+    eps: float,
+    index_q_norm_weight: Optional[Tensor],
+    index_k_norm_weight: Optional[Tensor],
+    num_index_heads: int,
+    slot_mapping: Optional[Tensor],
+    kv_cache: Optional[Tensor],
+    index_cache: Optional[Tensor],
+    block_size: int,
+    q_out: Optional[Tensor],
+    index_q_out: Optional[Tensor],
+    index_slot_mapping: Optional[Tensor],
+) -> None:
+    pass
+
+
+@compile_ops(
+    "module_fused_qknorm_idxrqknorm",
+    fc_name="fused_qknorm_idxrqknorm_fp8",
+    develop=True,
+)
+def _fused_qknorm_idxrqknorm_fp8_hip(
+    qkv: Tensor,
+    q_norm_weight: Tensor,
+    k_norm_weight: Tensor,
+    cos_sin_cache: Tensor,
+    positions: Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    rotary_dim: int,
+    eps: float,
+    index_q_norm_weight: Tensor,
+    index_k_norm_weight: Tensor,
+    num_index_heads: int,
+    slot_mapping: Tensor,
+    kv_cache: Tensor,
+    index_cache: Tensor,
+    block_size: int,
+    q_out: Tensor,
+    index_q_out: Tensor,
+    index_slot_mapping: Tensor,
+    kv_cache_dtype: str,
+    k_scale: Tensor,
+    v_scale: Tensor,
+) -> None:
+    pass
+
+
+def fused_qknorm_idxrqknorm(
+    qkv: Tensor,
+    q_norm_weight: Tensor,
+    k_norm_weight: Tensor,
+    cos_sin_cache: Tensor,
+    positions: Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    rotary_dim: int,
+    eps: float,
+    index_q_norm_weight: Optional[Tensor] = None,
+    index_k_norm_weight: Optional[Tensor] = None,
+    num_index_heads: int = 0,
+    slot_mapping: Optional[Tensor] = None,
+    kv_cache: Optional[Tensor] = None,
+    index_cache: Optional[Tensor] = None,
+    block_size: int = 0,
+    q_out: Optional[Tensor] = None,
+    index_q_out: Optional[Tensor] = None,
+    index_slot_mapping: Optional[Tensor] = None,
+    kv_cache_dtype: str = "auto",
+    k_scale: Optional[Tensor] = None,
+    v_scale: Optional[Tensor] = None,
+) -> None:
+    if (
+        kv_cache is not None
+        and isinstance(kv_cache_dtype, str)
+        and kv_cache_dtype.startswith("fp8")
+    ):
+        if index_slot_mapping is None:
+            index_slot_mapping = slot_mapping
+        assert index_q_norm_weight is not None
+        assert index_k_norm_weight is not None
+        assert slot_mapping is not None
+        assert index_cache is not None
+        assert q_out is not None
+        assert index_q_out is not None
+        assert index_slot_mapping is not None
+        assert k_scale is not None
+        assert v_scale is not None
+        _fused_qknorm_idxrqknorm_fp8_hip(
+            qkv,
+            q_norm_weight,
+            k_norm_weight,
+            cos_sin_cache,
+            positions,
+            num_heads,
+            num_kv_heads,
+            rotary_dim,
+            eps,
+            index_q_norm_weight,
+            index_k_norm_weight,
+            num_index_heads,
+            slot_mapping,
+            kv_cache,
+            index_cache,
+            block_size,
+            q_out,
+            index_q_out,
+            index_slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+            v_scale,
+        )
+        return
+
+    _fused_qknorm_idxrqknorm_hip(
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        num_heads,
+        num_kv_heads,
+        rotary_dim,
+        eps,
+        index_q_norm_weight,
+        index_k_norm_weight,
+        num_index_heads,
+        slot_mapping,
+        kv_cache,
+        index_cache,
+        block_size,
+        q_out,
+        index_q_out,
+        index_slot_mapping,
+    )

--- a/csrc/include/fused_qknorm_idxrqknorm.h
+++ b/csrc/include/fused_qknorm_idxrqknorm.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "aiter_tensor.h"
+#include <optional>
+#include <string>
+
+namespace aiter {
+
+void fused_qknorm_idxrqknorm(
+    aiter_tensor_t& qkv,
+    const aiter_tensor_t& q_norm_weight,
+    const aiter_tensor_t& k_norm_weight,
+    const aiter_tensor_t& cos_sin_cache,
+    const aiter_tensor_t& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    std::optional<aiter_tensor_t> index_q_norm_weight,
+    std::optional<aiter_tensor_t> index_k_norm_weight,
+    int64_t num_index_heads,
+    std::optional<aiter_tensor_t> slot_mapping,
+    std::optional<aiter_tensor_t> kv_cache,
+    std::optional<aiter_tensor_t> index_cache,
+    int64_t block_size,
+    std::optional<aiter_tensor_t> q_out,
+    std::optional<aiter_tensor_t> index_q_out,
+    std::optional<aiter_tensor_t> index_slot_mapping);
+
+void fused_qknorm_idxrqknorm_fp8(
+    aiter_tensor_t& qkv,
+    const aiter_tensor_t& q_norm_weight,
+    const aiter_tensor_t& k_norm_weight,
+    const aiter_tensor_t& cos_sin_cache,
+    const aiter_tensor_t& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    const aiter_tensor_t& index_q_norm_weight,
+    const aiter_tensor_t& index_k_norm_weight,
+    int64_t num_index_heads,
+    const aiter_tensor_t& slot_mapping,
+    aiter_tensor_t& kv_cache,
+    aiter_tensor_t& index_cache,
+    int64_t block_size,
+    aiter_tensor_t& q_out,
+    aiter_tensor_t& index_q_out,
+    const aiter_tensor_t& index_slot_mapping,
+    const std::string& kv_cache_dtype,
+    const aiter_tensor_t& k_scale,
+    const aiter_tensor_t& v_scale);
+
+} // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1707,6 +1707,53 @@ namespace py = pybind11;
           py::arg("x"),                                     \
           py::arg("rotary_dim") = 0);
 
+#define FUSED_QKNORM_IDXRQKNORM_PYBIND      \
+    m.def("fused_qknorm_idxrqknorm",        \
+          &aiter::fused_qknorm_idxrqknorm,  \
+          py::arg("qkv"),                                  \
+          py::arg("q_norm_weight"),                        \
+          py::arg("k_norm_weight"),                        \
+          py::arg("cos_sin_cache"),                        \
+          py::arg("positions"),                            \
+          py::arg("num_heads"),                            \
+          py::arg("num_kv_heads"),                         \
+          py::arg("rotary_dim"),                           \
+          py::arg("eps"),                                  \
+          py::arg("index_q_norm_weight"),                  \
+          py::arg("index_k_norm_weight"),                  \
+          py::arg("num_index_heads"),                       \
+          py::arg("slot_mapping"),                         \
+          py::arg("kv_cache"),                             \
+          py::arg("index_cache"),                          \
+          py::arg("block_size"),                           \
+          py::arg("q_out"),                                \
+          py::arg("index_q_out"),                          \
+          py::arg("index_slot_mapping"));                   \
+    m.def("fused_qknorm_idxrqknorm_fp8",     \
+          &aiter::fused_qknorm_idxrqknorm_fp8, \
+          py::arg("qkv"),                                  \
+          py::arg("q_norm_weight"),                        \
+          py::arg("k_norm_weight"),                        \
+          py::arg("cos_sin_cache"),                        \
+          py::arg("positions"),                            \
+          py::arg("num_heads"),                            \
+          py::arg("num_kv_heads"),                         \
+          py::arg("rotary_dim"),                           \
+          py::arg("eps"),                                  \
+          py::arg("index_q_norm_weight"),                  \
+          py::arg("index_k_norm_weight"),                  \
+          py::arg("num_index_heads"),                       \
+          py::arg("slot_mapping"),                         \
+          py::arg("kv_cache"),                             \
+          py::arg("index_cache"),                          \
+          py::arg("block_size"),                           \
+          py::arg("q_out"),                                \
+          py::arg("index_q_out"),                          \
+          py::arg("index_slot_mapping"),                   \
+          py::arg("kv_cache_dtype"),                       \
+          py::arg("k_scale"),                              \
+          py::arg("v_scale"))
+
 #define FUSED_QKNORM_ROPE_CACHE_QUANT_PYBIND                    \
     m.def("fused_qk_norm_rope_cache_quant_shuffle",             \
           &aiter::fused_qk_norm_rope_cache_quant_shuffle,       \

--- a/csrc/kernels/fused_qknorm_idxrqknorm.cu
+++ b/csrc/kernels/fused_qknorm_idxrqknorm.cu
@@ -1,0 +1,777 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Horizontally fused Q/K RMSNorm + partial NeoX RoPE, with optional
+// sparse-layer KV/index-cache insert. This ports the AME/vLLM operator into
+// aiter's pybind/JIT extension style.
+
+#include "fused_qknorm_idxrqknorm.h"
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "aiter_dispatch.h"
+#include "aiter_stream.h"
+#include "opus/opus.hpp"
+#include "quant_utils.cuh"
+
+namespace aiter {
+namespace fused_qknorm_idxrqknorm_ops {
+
+constexpr int kHeadDim = 128;
+constexpr int kNumLanes = 32;
+constexpr int kElemsPerLane = kHeadDim / kNumLanes;
+
+__device__ __forceinline__ float warpReduceSum(float val)
+{
+#pragma unroll
+    for(int mask = 16; mask > 0; mask >>= 1)
+    {
+        val += __shfl_xor(val, mask, 32);
+    }
+    return val;
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ void loadElems(const scalar_t* __restrict__ src,
+                                          float (&elems)[kElemsPerLane])
+{
+#pragma unroll
+    for(int i = 0; i < kElemsPerLane; ++i)
+    {
+        elems[i] = static_cast<float>(src[i]);
+    }
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ void storeElems(scalar_t* __restrict__ dst,
+                                           const float (&elems)[kElemsPerLane])
+{
+#pragma unroll
+    for(int i = 0; i < kElemsPerLane; ++i)
+    {
+        dst[i] = static_cast<scalar_t>(elems[i]);
+    }
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ void copyRawElems(const scalar_t* __restrict__ src,
+                                             scalar_t* __restrict__ dst)
+{
+    *reinterpret_cast<uint2*>(dst) = *reinterpret_cast<const uint2*>(src);
+}
+
+template <typename scalar_t, typename cache_t, vllm::Fp8KVCacheDataType kv_dt>
+__device__ __forceinline__ void storeCacheElems(cache_t* __restrict__ dst,
+                                                const float (&elems)[kElemsPerLane],
+                                                float scale)
+{
+#pragma unroll
+    for(int i = 0; i < kElemsPerLane; ++i)
+    {
+        if constexpr(kv_dt == vllm::Fp8KVCacheDataType::kAuto)
+        {
+            dst[i] = static_cast<cache_t>(elems[i]);
+        }
+        else
+        {
+            const scalar_t rounded = static_cast<scalar_t>(elems[i]);
+            dst[i] = opus::cast<cache_t>(static_cast<float>(rounded) / scale);
+        }
+    }
+}
+
+template <typename scalar_t, typename cache_t, vllm::Fp8KVCacheDataType kv_dt>
+__device__ __forceinline__ void copyOrQuantizeCacheElems(const scalar_t* __restrict__ src,
+                                                         cache_t* __restrict__ dst,
+                                                         float scale)
+{
+    if constexpr(kv_dt == vllm::Fp8KVCacheDataType::kAuto)
+    {
+        copyRawElems(src, dst);
+    }
+    else
+    {
+        float elems[kElemsPerLane];
+        loadElems(src, elems);
+        storeCacheElems<scalar_t, cache_t, kv_dt>(dst, elems, scale);
+    }
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ void normAndRope(
+    float (&elems)[kElemsPerLane],
+    int lane_id,
+    float eps,
+    const scalar_t* __restrict__ weight,
+    bool do_rope,
+    int rotary_dim,
+    const scalar_t* __restrict__ cos_ptr,
+    bool apply_norm)
+{
+    if(apply_norm)
+    {
+        float sumsq = 0.0f;
+#pragma unroll
+        for(int i = 0; i < kElemsPerLane; ++i)
+        {
+            sumsq += elems[i] * elems[i];
+        }
+        sumsq = warpReduceSum(sumsq);
+        const float rms_rcp = rsqrtf(sumsq / static_cast<float>(kHeadDim) + eps);
+#pragma unroll
+        for(int i = 0; i < kElemsPerLane; ++i)
+        {
+            const int dim = lane_id * kElemsPerLane + i;
+            elems[i] = elems[i] * rms_rcp * (1.0f + static_cast<float>(weight[dim]));
+        }
+    }
+
+    if(do_rope)
+    {
+        const int half = rotary_dim / 2;
+        const int dim0 = lane_id * kElemsPerLane;
+        const bool in_rope = dim0 < rotary_dim;
+
+        if(in_rope)
+        {
+            const bool first_half = dim0 < half;
+            const int i_base = first_half ? dim0 : dim0 - half;
+            const int partner_lane = first_half ? (dim0 + half) / kElemsPerLane
+                                                : (dim0 - half) / kElemsPerLane;
+            const scalar_t* sin_ptr = cos_ptr + half;
+#pragma unroll
+            for(int i = 0; i < kElemsPerLane; ++i)
+            {
+                const float c = static_cast<float>(cos_ptr[i_base + i]);
+                const float s = static_cast<float>(sin_ptr[i_base + i]);
+                const float partner = __shfl(elems[i], partner_lane, 32);
+                elems[i] = first_half ? elems[i] * c - partner * s
+                                      : elems[i] * c + partner * s;
+            }
+        }
+    }
+}
+
+template <typename scalar_t,
+          typename cache_t,
+          vllm::Fp8KVCacheDataType kv_dt,
+          bool kIsSparse,
+          bool kInsertKV>
+__global__ void fusedQKNormIdxrQKNormKernel(
+    scalar_t* __restrict__ qkv,
+    scalar_t* __restrict__ q_out,
+    scalar_t* __restrict__ index_q_out,
+    const scalar_t* __restrict__ q_norm_w,
+    const scalar_t* __restrict__ k_norm_w,
+    const scalar_t* __restrict__ iq_norm_w,
+    const scalar_t* __restrict__ ik_norm_w,
+    const scalar_t* __restrict__ cos_sin_cache,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int64_t* __restrict__ index_slot_mapping,
+    cache_t* __restrict__ kv_cache,
+    scalar_t* __restrict__ index_cache,
+    const float* __restrict__ k_scale,
+    const float* __restrict__ v_scale,
+    float eps,
+    int rotary_dim,
+    int num_tokens,
+    int nq,
+    int nkv,
+    int niq,
+    int block_size,
+    int64_t kv_s_block,
+    int64_t kv_s_kv,
+    int64_t kv_s_token,
+    int64_t kv_s_head)
+{
+    const int warps_per_block = blockDim.x / 32;
+    const int lane_id = threadIdx.x % 32;
+    const int global_warp_idx = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+
+    const int v_slots = kInsertKV ? nkv : 0;
+    const int idx_slots = kIsSparse ? niq + 1 : 0;
+    const int slots_per_token = nq + nkv + v_slots + idx_slots;
+
+    const int token_idx = global_warp_idx / slots_per_token;
+    const int slot = global_warp_idx % slots_per_token;
+    if(token_idx >= num_tokens)
+    {
+        return;
+    }
+
+    const int k_begin = nq;
+    const int v_begin = nq + nkv;
+    const int iq_begin = nq + nkv + v_slots;
+    const int ik_slot = iq_begin + niq;
+
+    const bool is_q = slot < k_begin;
+    const bool is_k = slot >= k_begin && slot < v_begin;
+    bool is_v = false;
+    if constexpr(kInsertKV)
+    {
+        is_v = slot >= v_begin && slot < v_begin + nkv;
+    }
+    bool is_iq = false;
+    bool is_ik = false;
+    if constexpr(kIsSparse)
+    {
+        is_iq = slot >= iq_begin && slot < ik_slot;
+        is_ik = slot == ik_slot;
+    }
+
+    const int dim_base = lane_id * kElemsPerLane;
+    const int qkv_row = (nq + 2 * nkv + (kIsSparse ? (niq + 1) : 0)) * kHeadDim;
+
+    scalar_t* row_ptr = nullptr;
+    const scalar_t* norm_w = nullptr;
+    bool do_rope = true;
+    int head = 0;
+
+    if(is_q)
+    {
+        row_ptr = qkv + static_cast<int64_t>(token_idx) * qkv_row + slot * kHeadDim;
+        norm_w = q_norm_w;
+    }
+    else if(is_k)
+    {
+        head = slot - k_begin;
+        row_ptr = qkv + static_cast<int64_t>(token_idx) * qkv_row + slot * kHeadDim;
+        norm_w = k_norm_w;
+    }
+    else if(is_v)
+    {
+        head = slot - v_begin;
+        row_ptr = qkv + static_cast<int64_t>(token_idx) * qkv_row + slot * kHeadDim;
+        do_rope = false;
+    }
+    else if(is_iq)
+    {
+        const int ih = slot - iq_begin;
+        row_ptr = qkv + static_cast<int64_t>(token_idx) * qkv_row + (nq + 2 * nkv + ih) * kHeadDim;
+        norm_w = iq_norm_w;
+    }
+    else
+    {
+        row_ptr = qkv + static_cast<int64_t>(token_idx) * qkv_row + (nq + 2 * nkv + niq) * kHeadDim;
+        norm_w = ik_norm_w;
+    }
+
+    scalar_t* store_ptr = row_ptr;
+    if(is_q && q_out != nullptr)
+    {
+        store_ptr = q_out + static_cast<int64_t>(token_idx) * nq * kHeadDim + slot * kHeadDim;
+    }
+    else if(is_iq && index_q_out != nullptr)
+    {
+        store_ptr = index_q_out + static_cast<int64_t>(token_idx) * niq * kHeadDim +
+                    (slot - iq_begin) * kHeadDim;
+    }
+
+    int64_t mapped_slot = -1;
+    if constexpr(kInsertKV)
+    {
+        mapped_slot = is_ik ? index_slot_mapping[token_idx]
+                            : ((is_k || is_v) ? slot_mapping[token_idx] : -1);
+    }
+
+    if constexpr(kInsertKV)
+    {
+        if(is_v)
+        {
+            if(mapped_slot >= 0)
+            {
+                const int64_t b = mapped_slot / block_size;
+                const int64_t t = mapped_slot % block_size;
+                const int64_t off = b * kv_s_block + kv_s_kv + t * kv_s_token + head * kv_s_head;
+                const float v_scale_val =
+                    (kv_dt == vllm::Fp8KVCacheDataType::kAuto) ? 1.0f : *v_scale;
+                copyOrQuantizeCacheElems<scalar_t, cache_t, kv_dt>(
+                    row_ptr + dim_base, kv_cache + off + dim_base, v_scale_val);
+            }
+            return;
+        }
+    }
+
+    float elems[kElemsPerLane];
+    loadElems(row_ptr + dim_base, elems);
+    const int64_t pos = positions[token_idx];
+    const scalar_t* cos_ptr = cos_sin_cache + pos * rotary_dim;
+    normAndRope(elems, lane_id, eps, norm_w, do_rope, rotary_dim, cos_ptr, norm_w != nullptr);
+
+    if constexpr(kInsertKV)
+    {
+        if(is_q || is_iq)
+        {
+            storeElems(store_ptr + dim_base, elems);
+        }
+
+        if(mapped_slot >= 0)
+        {
+            if(is_ik)
+            {
+                storeElems(index_cache + mapped_slot * kHeadDim + dim_base, elems);
+            }
+            else if(is_k)
+            {
+                const int64_t b = mapped_slot / block_size;
+                const int64_t t = mapped_slot % block_size;
+                const int64_t off = b * kv_s_block + t * kv_s_token + head * kv_s_head;
+                const float k_scale_val =
+                    (kv_dt == vllm::Fp8KVCacheDataType::kAuto) ? 1.0f : *k_scale;
+                storeCacheElems<scalar_t, cache_t, kv_dt>(
+                    kv_cache + off + dim_base, elems, k_scale_val);
+            }
+        }
+    }
+    else
+    {
+        storeElems(store_ptr + dim_base, elems);
+    }
+}
+
+template <typename scalar_t, typename cache_t, vllm::Fp8KVCacheDataType kv_dt>
+void launchFusedQKNormIdxrQKNorm(
+    scalar_t* qkv,
+    scalar_t* q_out,
+    scalar_t* index_q_out,
+    const scalar_t* q_norm_w,
+    const scalar_t* k_norm_w,
+    const scalar_t* iq_norm_w,
+    const scalar_t* ik_norm_w,
+    const scalar_t* cos_sin_cache,
+    const int64_t* positions,
+    const int64_t* slot_mapping,
+    const int64_t* index_slot_mapping,
+    cache_t* kv_cache,
+    scalar_t* index_cache,
+    const float* k_scale,
+    const float* v_scale,
+    float eps,
+    int rotary_dim,
+    int num_tokens,
+    int nq,
+    int nkv,
+    int niq,
+    int block_size,
+    int64_t kv_s_block,
+    int64_t kv_s_kv,
+    int64_t kv_s_token,
+    int64_t kv_s_head,
+    bool has_index,
+    bool insert_kv,
+    hipStream_t stream)
+{
+    const int v_slots = insert_kv ? nkv : 0;
+    const int idx_slots = has_index ? niq + 1 : 0;
+    const int slots_per_token = nq + nkv + v_slots + idx_slots;
+    constexpr int kBlockSize = 256;
+    constexpr int kWarpsPerBlock = kBlockSize / 32;
+    const int64_t total_warps = static_cast<int64_t>(num_tokens) * slots_per_token;
+    const int grid = static_cast<int>((total_warps + kWarpsPerBlock - 1) / kWarpsPerBlock);
+    if(grid == 0)
+    {
+        return;
+    }
+
+#define LAUNCH(IS_SPARSE, INSERT)                                                           \
+    fusedQKNormIdxrQKNormKernel<scalar_t, cache_t, kv_dt, IS_SPARSE, INSERT>      \
+        <<<grid, kBlockSize, 0, stream>>>(qkv,                                               \
+                                          q_out,                                             \
+                                          index_q_out,                                       \
+                                          q_norm_w,                                          \
+                                          k_norm_w,                                          \
+                                          iq_norm_w,                                         \
+                                          ik_norm_w,                                         \
+                                          cos_sin_cache,                                     \
+                                          positions,                                         \
+                                          slot_mapping,                                      \
+                                          index_slot_mapping,                                \
+                                          kv_cache,                                          \
+                                          index_cache,                                       \
+                                          k_scale,                                           \
+                                          v_scale,                                           \
+                                          eps,                                               \
+                                          rotary_dim,                                        \
+                                          num_tokens,                                        \
+                                          nq,                                                \
+                                          nkv,                                               \
+                                          niq,                                               \
+                                          block_size,                                        \
+                                          kv_s_block,                                        \
+                                          kv_s_kv,                                           \
+                                          kv_s_token,                                        \
+                                          kv_s_head)
+
+    if(has_index)
+    {
+        if(insert_kv)
+        {
+            LAUNCH(true, true);
+        }
+        else
+        {
+            LAUNCH(true, false);
+        }
+    }
+    else
+    {
+        if(insert_kv)
+        {
+            LAUNCH(false, true);
+        }
+        else
+        {
+            LAUNCH(false, false);
+        }
+    }
+#undef LAUNCH
+}
+
+} // namespace fused_qknorm_idxrqknorm_ops
+
+static void fused_qknorm_idxrqknorm_impl(
+    aiter_tensor_t& qkv,
+    const aiter_tensor_t& q_norm_weight,
+    const aiter_tensor_t& k_norm_weight,
+    const aiter_tensor_t& cos_sin_cache,
+    const aiter_tensor_t& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    std::optional<aiter_tensor_t> index_q_norm_weight,
+    std::optional<aiter_tensor_t> index_k_norm_weight,
+    int64_t num_index_heads,
+    std::optional<aiter_tensor_t> slot_mapping,
+    std::optional<aiter_tensor_t> kv_cache,
+    std::optional<aiter_tensor_t> index_cache,
+    int64_t block_size,
+    std::optional<aiter_tensor_t> q_out,
+    std::optional<aiter_tensor_t> index_q_out,
+    std::optional<aiter_tensor_t> index_slot_mapping,
+    const std::string& kv_cache_dtype,
+    std::optional<aiter_tensor_t> k_scale,
+    std::optional<aiter_tensor_t> v_scale)
+{
+    using namespace fused_qknorm_idxrqknorm_ops;
+
+    AITER_CHECK(qkv.is_gpu() && qkv.is_contiguous(), "qkv must be contiguous CUDA");
+    AITER_CHECK(positions.is_gpu() && positions.is_contiguous() &&
+                    positions.dtype() == AITER_DTYPE_i64,
+                "positions must be contiguous int64 CUDA");
+    AITER_CHECK(cos_sin_cache.is_gpu() && cos_sin_cache.is_contiguous(),
+                "cos_sin_cache must be contiguous CUDA");
+    AITER_CHECK(cos_sin_cache.dtype() == qkv.dtype(),
+                "cos_sin_cache dtype must match qkv");
+    AITER_CHECK(cos_sin_cache.dim() == 2 && cos_sin_cache.size(1) == rotary_dim,
+                "cos_sin_cache shape must be [max_pos, rotary_dim]");
+    AITER_CHECK(q_norm_weight.is_gpu() && k_norm_weight.is_gpu() &&
+                    q_norm_weight.is_contiguous() && k_norm_weight.is_contiguous(),
+                "q/k norm weights must be contiguous CUDA tensors");
+    AITER_CHECK(q_norm_weight.dtype() == qkv.dtype() &&
+                    k_norm_weight.dtype() == qkv.dtype(),
+                "q/k norm weight dtype must match qkv");
+    AITER_CHECK(q_norm_weight.numel() == kHeadDim && k_norm_weight.numel() == kHeadDim,
+                "q/k norm weight must have 128 elements");
+    AITER_CHECK(rotary_dim > 0 && rotary_dim % 8 == 0 && rotary_dim <= kHeadDim,
+                "rotary_dim must be a positive multiple of 8 and <= 128");
+
+    const int num_tokens = static_cast<int>(qkv.size(0));
+    const int nq = static_cast<int>(num_heads);
+    const int nkv = static_cast<int>(num_kv_heads);
+    const int niq = static_cast<int>(num_index_heads);
+    AITER_CHECK(nq > 0 && nkv > 0 && niq >= 0, "num_heads/num_kv_heads must be positive");
+    const bool has_index = niq > 0;
+    const bool insert_kv = kv_cache.has_value();
+    const bool fp8_kv_cache =
+        insert_kv && kv_cache_dtype.rfind("fp8", 0) == 0;
+    const int expected_row = (nq + 2 * nkv + (has_index ? niq + 1 : 0)) * kHeadDim;
+    AITER_CHECK(positions.dim() == 1 && positions.size(0) >= num_tokens,
+                "positions must be 1D with at least num_tokens elements");
+    AITER_CHECK(qkv.dim() == 2 && qkv.size(1) == expected_row,
+                "qkv must be [num_tokens, (num_heads + 2*num_kv_heads"
+                " + optional index heads) * 128]");
+    if(has_index)
+    {
+        AITER_CHECK(index_q_norm_weight.has_value() && index_k_norm_weight.has_value(),
+                    "index branch requires both index norm weights");
+        AITER_CHECK(index_q_norm_weight->is_gpu() && index_k_norm_weight->is_gpu() &&
+                        index_q_norm_weight->is_contiguous() &&
+                        index_k_norm_weight->is_contiguous(),
+                    "index norm weights must be contiguous CUDA tensors");
+        AITER_CHECK(index_q_norm_weight->dtype() == qkv.dtype() &&
+                        index_k_norm_weight->dtype() == qkv.dtype(),
+                    "index norm weights dtype must match qkv");
+        AITER_CHECK(index_q_norm_weight->numel() == kHeadDim &&
+                        index_k_norm_weight->numel() == kHeadDim,
+                    "index norm weights must have 128 elements");
+    }
+
+    int64_t kv_s_block = 0;
+    int64_t kv_s_kv = 0;
+    int64_t kv_s_token = 0;
+    int64_t kv_s_head = 0;
+    if(insert_kv)
+    {
+        AITER_CHECK(block_size > 0, "block_size must be positive in insert mode");
+        AITER_CHECK(slot_mapping.has_value() && slot_mapping->is_gpu() &&
+                        slot_mapping->is_contiguous() &&
+                        slot_mapping->dtype() == AITER_DTYPE_i64,
+                    "insert mode requires contiguous int64 CUDA slot_mapping");
+        AITER_CHECK(slot_mapping->dim() == 1 && slot_mapping->size(0) >= num_tokens,
+                    "slot_mapping must be 1D with at least num_tokens elements");
+        if(has_index && !index_slot_mapping.has_value())
+        {
+            index_slot_mapping = slot_mapping;
+        }
+        if(has_index)
+        {
+            AITER_CHECK(index_slot_mapping.has_value() && index_slot_mapping->is_gpu() &&
+                            index_slot_mapping->is_contiguous() &&
+                            index_slot_mapping->dtype() == AITER_DTYPE_i64,
+                        "sparse insert mode requires contiguous int64 CUDA index_slot_mapping");
+            AITER_CHECK(index_slot_mapping->dim() == 1 &&
+                            index_slot_mapping->size(0) >= num_tokens,
+                        "index_slot_mapping must be 1D with at least num_tokens elements");
+            AITER_CHECK(index_cache.has_value() && index_cache->is_gpu() &&
+                            index_cache->is_contiguous() &&
+                            index_cache->dtype() == qkv.dtype(),
+                        "sparse insert mode requires contiguous matching index_cache");
+        }
+        AITER_CHECK(kv_cache->is_gpu(), "kv_cache must be CUDA");
+        if(fp8_kv_cache)
+        {
+            AITER_CHECK(kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3",
+                        "fused_qknorm_idxrqknorm fp8 cache insert supports fp8_e4m3 only");
+            AITER_CHECK(kv_cache->dtype() == AITER_DTYPE_fp8 ||
+                            kv_cache->dtype() == AITER_DTYPE_u8,
+                        "fp8 kv_cache must use float8_e4m3 or uint8 storage");
+            AITER_CHECK(k_scale.has_value() && v_scale.has_value() &&
+                            k_scale->is_gpu() && v_scale->is_gpu() &&
+                            k_scale->is_contiguous() && v_scale->is_contiguous() &&
+                            k_scale->dtype() == AITER_DTYPE_fp32 &&
+                            v_scale->dtype() == AITER_DTYPE_fp32,
+                        "fp8 insert requires contiguous float32 CUDA k_scale/v_scale");
+            AITER_CHECK(k_scale->numel() >= 1 && v_scale->numel() >= 1,
+                        "k_scale/v_scale must contain at least one element");
+        }
+        else
+        {
+            AITER_CHECK(kv_cache_dtype == "auto",
+                        "non-fp8 fused_qknorm_idxrqknorm expects kv_cache_dtype='auto'");
+            AITER_CHECK(kv_cache->dtype() == qkv.dtype(),
+                        "kv_cache dtype must match qkv for non-fp8 cache");
+        }
+        AITER_CHECK(kv_cache->dim() == 5 && kv_cache->size(1) == 2 &&
+                        kv_cache->size(2) == block_size && kv_cache->size(3) == nkv &&
+                        kv_cache->size(4) == kHeadDim && kv_cache->stride(4) == 1,
+                    "kv_cache must be [num_blocks, 2, block_size, num_kv_heads, 128] "
+                    "with contiguous head_dim");
+        if(has_index)
+        {
+            AITER_CHECK(index_cache->numel() >= kv_cache->size(0) * block_size * kHeadDim,
+                        "index_cache must contain at least num_blocks * block_size * 128 elements");
+        }
+        kv_s_block = kv_cache->stride(0);
+        kv_s_kv = kv_cache->stride(1);
+        kv_s_token = kv_cache->stride(2);
+        kv_s_head = kv_cache->stride(3);
+    }
+
+    if(q_out.has_value())
+    {
+        AITER_CHECK(q_out->is_gpu() && q_out->is_contiguous() &&
+                        q_out->dtype() == qkv.dtype(),
+                    "q_out must be contiguous CUDA and match qkv dtype");
+        AITER_CHECK(q_out->numel() == static_cast<int64_t>(num_tokens) * nq * kHeadDim,
+                    "q_out must have num_tokens * num_heads * 128 elements");
+    }
+    if(index_q_out.has_value())
+    {
+        AITER_CHECK(has_index, "index_q_out requires num_index_heads > 0");
+        AITER_CHECK(index_q_out->is_gpu() && index_q_out->is_contiguous() &&
+                        index_q_out->dtype() == qkv.dtype(),
+                    "index_q_out must be contiguous CUDA and match qkv dtype");
+        AITER_CHECK(index_q_out->numel() == static_cast<int64_t>(num_tokens) * niq * kHeadDim,
+                    "index_q_out must have num_tokens * num_index_heads * 128 elements");
+    }
+
+    HipDeviceGuard device_guard(qkv.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(qkv.dtype(), "fused_qknorm_idxrqknorm", [&] {
+        using T = scalar_t;
+        if(fp8_kv_cache)
+        {
+            launchFusedQKNormIdxrQKNorm<T, opus::fp8_t, vllm::Fp8KVCacheDataType::kFp8E4M3>(
+                reinterpret_cast<T*>(qkv.data_ptr()),
+                q_out.has_value() ? reinterpret_cast<T*>(q_out->data_ptr()) : nullptr,
+                index_q_out.has_value() ? reinterpret_cast<T*>(index_q_out->data_ptr())
+                                        : nullptr,
+                reinterpret_cast<const T*>(q_norm_weight.data_ptr()),
+                reinterpret_cast<const T*>(k_norm_weight.data_ptr()),
+                has_index ? reinterpret_cast<const T*>(index_q_norm_weight->data_ptr())
+                          : nullptr,
+                has_index ? reinterpret_cast<const T*>(index_k_norm_weight->data_ptr())
+                          : nullptr,
+                reinterpret_cast<const T*>(cos_sin_cache.data_ptr()),
+                reinterpret_cast<int64_t*>(positions.data_ptr()),
+                insert_kv ? reinterpret_cast<int64_t*>(slot_mapping->data_ptr()) : nullptr,
+                (insert_kv && has_index) ? reinterpret_cast<int64_t*>(index_slot_mapping->data_ptr()) : nullptr,
+                insert_kv ? reinterpret_cast<opus::fp8_t*>(kv_cache->data_ptr()) : nullptr,
+                (insert_kv && has_index) ? reinterpret_cast<T*>(index_cache->data_ptr())
+                                         : nullptr,
+                insert_kv ? reinterpret_cast<float*>(k_scale->data_ptr()) : nullptr,
+                insert_kv ? reinterpret_cast<float*>(v_scale->data_ptr()) : nullptr,
+                static_cast<float>(eps),
+                static_cast<int>(rotary_dim),
+                num_tokens,
+                nq,
+                nkv,
+                niq,
+                static_cast<int>(block_size),
+                kv_s_block,
+                kv_s_kv,
+                kv_s_token,
+                kv_s_head,
+                has_index,
+                insert_kv,
+                stream);
+        }
+        else
+        {
+            launchFusedQKNormIdxrQKNorm<T, T, vllm::Fp8KVCacheDataType::kAuto>(
+                reinterpret_cast<T*>(qkv.data_ptr()),
+                q_out.has_value() ? reinterpret_cast<T*>(q_out->data_ptr()) : nullptr,
+                index_q_out.has_value() ? reinterpret_cast<T*>(index_q_out->data_ptr())
+                                        : nullptr,
+                reinterpret_cast<const T*>(q_norm_weight.data_ptr()),
+                reinterpret_cast<const T*>(k_norm_weight.data_ptr()),
+                has_index ? reinterpret_cast<const T*>(index_q_norm_weight->data_ptr())
+                          : nullptr,
+                has_index ? reinterpret_cast<const T*>(index_k_norm_weight->data_ptr())
+                          : nullptr,
+                reinterpret_cast<const T*>(cos_sin_cache.data_ptr()),
+                reinterpret_cast<int64_t*>(positions.data_ptr()),
+                insert_kv ? reinterpret_cast<int64_t*>(slot_mapping->data_ptr()) : nullptr,
+                (insert_kv && has_index) ? reinterpret_cast<int64_t*>(index_slot_mapping->data_ptr()) : nullptr,
+                insert_kv ? reinterpret_cast<T*>(kv_cache->data_ptr()) : nullptr,
+                (insert_kv && has_index) ? reinterpret_cast<T*>(index_cache->data_ptr())
+                                         : nullptr,
+                nullptr,
+                nullptr,
+                static_cast<float>(eps),
+                static_cast<int>(rotary_dim),
+                num_tokens,
+                nq,
+                nkv,
+                niq,
+                static_cast<int>(block_size),
+                kv_s_block,
+                kv_s_kv,
+                kv_s_token,
+                kv_s_head,
+                has_index,
+                insert_kv,
+                stream);
+        }
+    });
+}
+
+void fused_qknorm_idxrqknorm(
+    aiter_tensor_t& qkv,
+    const aiter_tensor_t& q_norm_weight,
+    const aiter_tensor_t& k_norm_weight,
+    const aiter_tensor_t& cos_sin_cache,
+    const aiter_tensor_t& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    std::optional<aiter_tensor_t> index_q_norm_weight,
+    std::optional<aiter_tensor_t> index_k_norm_weight,
+    int64_t num_index_heads,
+    std::optional<aiter_tensor_t> slot_mapping,
+    std::optional<aiter_tensor_t> kv_cache,
+    std::optional<aiter_tensor_t> index_cache,
+    int64_t block_size,
+    std::optional<aiter_tensor_t> q_out,
+    std::optional<aiter_tensor_t> index_q_out,
+    std::optional<aiter_tensor_t> index_slot_mapping)
+{
+    fused_qknorm_idxrqknorm_impl(qkv,
+                                                q_norm_weight,
+                                                k_norm_weight,
+                                                cos_sin_cache,
+                                                positions,
+                                                num_heads,
+                                                num_kv_heads,
+                                                rotary_dim,
+                                                eps,
+                                                index_q_norm_weight,
+                                                index_k_norm_weight,
+                                                num_index_heads,
+                                                slot_mapping,
+                                                kv_cache,
+                                                index_cache,
+                                                block_size,
+                                                q_out,
+                                                index_q_out,
+                                                index_slot_mapping,
+                                                "auto",
+                                                std::nullopt,
+                                                std::nullopt);
+}
+
+void fused_qknorm_idxrqknorm_fp8(
+    aiter_tensor_t& qkv,
+    const aiter_tensor_t& q_norm_weight,
+    const aiter_tensor_t& k_norm_weight,
+    const aiter_tensor_t& cos_sin_cache,
+    const aiter_tensor_t& positions,
+    int64_t num_heads,
+    int64_t num_kv_heads,
+    int64_t rotary_dim,
+    double eps,
+    const aiter_tensor_t& index_q_norm_weight,
+    const aiter_tensor_t& index_k_norm_weight,
+    int64_t num_index_heads,
+    const aiter_tensor_t& slot_mapping,
+    aiter_tensor_t& kv_cache,
+    aiter_tensor_t& index_cache,
+    int64_t block_size,
+    aiter_tensor_t& q_out,
+    aiter_tensor_t& index_q_out,
+    const aiter_tensor_t& index_slot_mapping,
+    const std::string& kv_cache_dtype,
+    const aiter_tensor_t& k_scale,
+    const aiter_tensor_t& v_scale)
+{
+    fused_qknorm_idxrqknorm_impl(qkv,
+                                                q_norm_weight,
+                                                k_norm_weight,
+                                                cos_sin_cache,
+                                                positions,
+                                                num_heads,
+                                                num_kv_heads,
+                                                rotary_dim,
+                                                eps,
+                                                index_q_norm_weight,
+                                                index_k_norm_weight,
+                                                num_index_heads,
+                                                slot_mapping,
+                                                kv_cache,
+                                                index_cache,
+                                                block_size,
+                                                q_out,
+                                                index_q_out,
+                                                index_slot_mapping,
+                                                kv_cache_dtype,
+                                                k_scale,
+                                                v_scale);
+}
+
+} // namespace aiter

--- a/csrc/pybind/fused_qknorm_idxrqknorm_pybind.cu
+++ b/csrc/pybind/fused_qknorm_idxrqknorm_pybind.cu
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "aiter_stream.h"
+#include "fused_qknorm_idxrqknorm.h"
+#include "rocm_ops.hpp"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    FUSED_QKNORM_IDXRQKNORM_PYBIND;
+}

--- a/op_tests/test_fused_qknorm_idxrqknorm.py
+++ b/op_tests/test_fused_qknorm_idxrqknorm.py
@@ -1,0 +1,607 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import argparse
+from typing import Optional
+
+import pandas as pd
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.test_common import benchmark, checkAllclose, perftest
+
+HEAD_DIM = 128
+
+
+def make_cos_sin_cache(
+    max_pos: int, rotary_dim: int, dtype: torch.dtype
+) -> torch.Tensor:
+    base = 5_000_000.0
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float32, device="cuda")
+            / rotary_dim
+        )
+    )
+    positions = torch.arange(max_pos, dtype=torch.float32, device="cuda")
+    freqs = torch.einsum("i,j->ij", positions, inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(dtype)
+
+
+def gemma_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    xf = x.float()
+    variance = xf.pow(2).mean(dim=-1, keepdim=True)
+    return xf * torch.rsqrt(variance + eps) * (1.0 + weight.float())
+
+
+def apply_rope_neox_partial(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    rotary_dim: int,
+) -> torch.Tensor:
+    half = rotary_dim // 2
+    cos_sin = cos_sin_cache[positions].float()
+    cos = cos_sin[..., :half].unsqueeze(1)
+    sin = cos_sin[..., half:].unsqueeze(1)
+
+    rot = x[..., :rotary_dim]
+    x1 = rot[..., :half]
+    x2 = rot[..., half:]
+    out = x.clone()
+    out[..., :half] = x1 * cos - x2 * sin
+    out[..., half:rotary_dim] = x2 * cos + x1 * sin
+    return out
+
+
+def norm_rope_ref(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    rotary_dim: int,
+    eps: float,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    normed = gemma_rmsnorm(x.float(), weight, eps)
+    return apply_rope_neox_partial(normed, positions, cos_sin_cache, rotary_dim).to(
+        dtype
+    )
+
+
+def make_case(
+    *,
+    dtype: torch.dtype,
+    num_tokens: int,
+    block_size: int = 16,
+    num_heads: int = 16,
+    num_kv_heads: int = 4,
+    num_index_heads: int = 4,
+    rotary_dim: int = 64,
+    seed: int = 123,
+):
+    torch.manual_seed(seed)
+    eps = 1e-6
+    max_pos = 4096
+
+    q_w = torch.randn(HEAD_DIM, dtype=dtype, device="cuda") * 0.1
+    k_w = torch.randn(HEAD_DIM, dtype=dtype, device="cuda") * 0.1
+    iq_w = (
+        torch.randn(HEAD_DIM, dtype=dtype, device="cuda") * 0.1
+        if num_index_heads > 0
+        else None
+    )
+    ik_w = (
+        torch.randn(HEAD_DIM, dtype=dtype, device="cuda") * 0.1
+        if num_index_heads > 0
+        else None
+    )
+    cos_sin = make_cos_sin_cache(max_pos, rotary_dim, dtype)
+    positions = torch.randint(
+        0, max_pos, (num_tokens,), dtype=torch.int64, device="cuda"
+    )
+
+    q_size = num_heads * HEAD_DIM
+    kv_size = num_kv_heads * HEAD_DIM
+    iq_size = num_index_heads * HEAD_DIM
+    ik_size = HEAD_DIM if num_index_heads > 0 else 0
+    qkv = torch.randn(
+        num_tokens,
+        q_size + 2 * kv_size + iq_size + ik_size,
+        dtype=dtype,
+        device="cuda",
+    )
+
+    num_blocks = (num_tokens + block_size - 1) // block_size + 1
+    slot_mapping = torch.randperm(
+        num_blocks * block_size, dtype=torch.int64, device="cuda"
+    )[:num_tokens]
+    index_slot_mapping = torch.randperm(
+        num_blocks * block_size, dtype=torch.int64, device="cuda"
+    )[:num_tokens]
+
+    return {
+        "qkv": qkv,
+        "q_norm_weight": q_w,
+        "k_norm_weight": k_w,
+        "index_q_norm_weight": iq_w,
+        "index_k_norm_weight": ik_w,
+        "cos_sin_cache": cos_sin,
+        "positions": positions,
+        "num_heads": num_heads,
+        "num_kv_heads": num_kv_heads,
+        "num_index_heads": num_index_heads,
+        "rotary_dim": rotary_dim,
+        "block_size": block_size,
+        "num_blocks": num_blocks,
+        "slot_mapping": slot_mapping,
+        "index_slot_mapping": index_slot_mapping,
+        "sizes": (q_size, kv_size, kv_size, iq_size, ik_size),
+        "eps": eps,
+        "dtype": dtype,
+    }
+
+
+def make_refs(case: dict, qkv_orig: torch.Tensor):
+    q_size, kv_size, _, iq_size, ik_size = case["sizes"]
+    split_sizes = [q_size, kv_size, kv_size]
+    if case["num_index_heads"] > 0:
+        split_sizes.extend([iq_size, ik_size])
+    splits = qkv_orig.split(split_sizes, dim=-1)
+    q_in, k_in, v_in = splits[:3]
+    num_tokens = qkv_orig.size(0)
+
+    q_ref = norm_rope_ref(
+        q_in.view(num_tokens, case["num_heads"], HEAD_DIM),
+        case["q_norm_weight"],
+        case["positions"],
+        case["cos_sin_cache"],
+        case["rotary_dim"],
+        case["eps"],
+        case["dtype"],
+    ).view(num_tokens, q_size)
+    k_ref = norm_rope_ref(
+        k_in.view(num_tokens, case["num_kv_heads"], HEAD_DIM),
+        case["k_norm_weight"],
+        case["positions"],
+        case["cos_sin_cache"],
+        case["rotary_dim"],
+        case["eps"],
+        case["dtype"],
+    )
+    v_ref = v_in.view(num_tokens, case["num_kv_heads"], HEAD_DIM)
+
+    refs = {"q": q_ref, "k": k_ref, "v": v_ref}
+    if case["num_index_heads"] > 0:
+        iq_in, ik_in = splits[3:]
+        refs["index_q"] = norm_rope_ref(
+            iq_in.view(num_tokens, case["num_index_heads"], HEAD_DIM),
+            case["index_q_norm_weight"],
+            case["positions"],
+            case["cos_sin_cache"],
+            case["rotary_dim"],
+            case["eps"],
+            case["dtype"],
+        ).view(num_tokens, iq_size)
+        refs["index_k"] = norm_rope_ref(
+            ik_in.view(num_tokens, 1, HEAD_DIM),
+            case["index_k_norm_weight"],
+            case["positions"],
+            case["cos_sin_cache"],
+            case["rotary_dim"],
+            case["eps"],
+            case["dtype"],
+        ).view(num_tokens, HEAD_DIM)
+    return refs
+
+
+def split_qkv(case: dict, qkv: torch.Tensor):
+    q_size, kv_size, _, iq_size, ik_size = case["sizes"]
+    split_sizes = [q_size, kv_size, kv_size]
+    if case["num_index_heads"] > 0:
+        split_sizes.extend([iq_size, ik_size])
+    return qkv.split(split_sizes, dim=-1)
+
+
+def make_insert_outputs(case: dict, *, kv_cache_dtype: Optional[torch.dtype] = None):
+    q_size, _, _, iq_size, _ = case["sizes"]
+    q_out = torch.empty(case["qkv"].size(0), q_size, dtype=case["dtype"], device="cuda")
+    index_q_out = torch.empty(
+        case["qkv"].size(0), iq_size, dtype=case["dtype"], device="cuda"
+    )
+    kv_cache = torch.zeros(
+        case["num_blocks"],
+        2,
+        case["block_size"],
+        case["num_kv_heads"],
+        HEAD_DIM,
+        dtype=kv_cache_dtype or case["dtype"],
+        device="cuda",
+    )
+    index_cache = torch.zeros(
+        case["num_blocks"],
+        case["block_size"],
+        HEAD_DIM,
+        dtype=case["dtype"],
+        device="cuda",
+    )
+    return q_out, index_q_out, kv_cache, index_cache
+
+
+def gather_cache_outputs(
+    case: dict,
+    kv_cache: torch.Tensor,
+    index_cache: Optional[torch.Tensor],
+    *,
+    index_slot_mapping: Optional[torch.Tensor] = None,
+    k_scale: Optional[torch.Tensor] = None,
+    v_scale: Optional[torch.Tensor] = None,
+):
+    index_slots = (
+        index_slot_mapping if index_slot_mapping is not None else case["slot_mapping"]
+    )
+    k_outs = []
+    v_outs = []
+    index_k_outs = []
+
+    for token in range(case["qkv"].size(0)):
+        slot = case["slot_mapping"][token].item()
+        block, offset = divmod(slot, case["block_size"])
+        k_out = kv_cache[block, 0, offset]
+        v_out = kv_cache[block, 1, offset]
+        if k_scale is not None and v_scale is not None:
+            k_out = maybe_view_fp8(k_out)
+            v_out = maybe_view_fp8(v_out)
+            k_out = k_out.float() * k_scale
+            v_out = v_out.float() * v_scale
+        k_outs.append(k_out)
+        v_outs.append(v_out)
+
+        if index_cache is not None:
+            index_slot = index_slots[token].item()
+            index_k_outs.append(index_cache.view(-1, HEAD_DIM)[index_slot])
+
+    index_k = torch.stack(index_k_outs) if index_k_outs else None
+    return torch.stack(k_outs), torch.stack(v_outs), index_k
+
+
+def check_close(actual, expected, *, msg: str, rtol: float, atol: float):
+    err = checkAllclose(actual, expected, msg=msg, rtol=rtol, atol=atol)
+    if err != 0:
+        raise AssertionError(f"{msg} mismatch ratio: {err}")
+
+
+def fp8_cache_dtype() -> Optional[torch.dtype]:
+    if dtypes.fp8 is not torch.uint8:
+        return dtypes.fp8
+    return getattr(torch, "float8_e4m3fnuz", getattr(torch, "float8_e4m3fn", None))
+
+
+def maybe_view_fp8(x: torch.Tensor) -> torch.Tensor:
+    if x.dtype is not torch.uint8:
+        return x
+    fp8_dtype = fp8_cache_dtype()
+    assert fp8_dtype is not None
+    return x.view(fp8_dtype)
+
+
+def fp8_cache_ref(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    fp8_dtype = fp8_cache_dtype()
+    assert fp8_dtype is not None
+    return (x.float() / scale).to(fp8_dtype).float() * scale
+
+
+@perftest(num_iters=10, num_warmup=1, num_rotate_args=1)
+def run_fused_qknorm_idxrqknorm(
+    case: dict,
+    mode: str,
+    use_index_slot_mapping: bool,
+    use_fp8_kv_cache: bool,
+):
+    qkv = case["qkv"].clone()
+    if mode == "inplace":
+        aiter.fused_qknorm_idxrqknorm(
+            qkv,
+            case["q_norm_weight"],
+            case["k_norm_weight"],
+            case["cos_sin_cache"],
+            case["positions"],
+            case["num_heads"],
+            case["num_kv_heads"],
+            case["rotary_dim"],
+            case["eps"],
+            case["index_q_norm_weight"],
+            case["index_k_norm_weight"],
+            case["num_index_heads"],
+        )
+        return qkv
+
+    use_uint8_kv_cache = mode == "fp8_kv_cache_uint8"
+    kv_cache_dtype = None
+    if use_fp8_kv_cache:
+        kv_cache_dtype = torch.uint8 if use_uint8_kv_cache else dtypes.fp8
+    q_out, index_q_out, kv_cache, index_cache = make_insert_outputs(
+        case,
+        kv_cache_dtype=kv_cache_dtype,
+    )
+    index_slot_mapping = case["index_slot_mapping"] if use_index_slot_mapping else None
+    index_q_out_arg = index_q_out
+    index_cache_arg = index_cache
+    if case["num_index_heads"] == 0:
+        index_q_out_arg = None
+        index_cache_arg = None
+        index_slot_mapping = None
+    k_scale = None
+    v_scale = None
+    kv_cache_dtype_arg = "auto"
+    if use_fp8_kv_cache:
+        k_scale = torch.tensor(0.75, dtype=torch.float32, device="cuda")
+        v_scale = torch.tensor(1.25, dtype=torch.float32, device="cuda")
+        kv_cache_dtype_arg = "fp8_e4m3"
+
+    aiter.fused_qknorm_idxrqknorm(
+        qkv,
+        case["q_norm_weight"],
+        case["k_norm_weight"],
+        case["cos_sin_cache"],
+        case["positions"],
+        case["num_heads"],
+        case["num_kv_heads"],
+        case["rotary_dim"],
+        case["eps"],
+        case["index_q_norm_weight"],
+        case["index_k_norm_weight"],
+        case["num_index_heads"],
+        case["slot_mapping"],
+        kv_cache,
+        index_cache_arg,
+        case["block_size"],
+        q_out,
+        index_q_out_arg,
+        index_slot_mapping,
+        kv_cache_dtype=kv_cache_dtype_arg,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    return (
+        q_out,
+        index_q_out_arg,
+        kv_cache,
+        index_cache_arg,
+        index_slot_mapping,
+        k_scale,
+        v_scale,
+    )
+
+
+@benchmark()
+def test_fused_qknorm_idxrqknorm(
+    mode: str,
+    dtype: torch.dtype,
+    num_tokens: int,
+    block_size: int,
+    rotary_dim: int,
+    num_index_heads: int = 4,
+):
+    use_fp8_kv_cache = mode.startswith("fp8_kv_cache")
+    if use_fp8_kv_cache and fp8_cache_dtype() is None:
+        aiter.logger.info("Skip fp8_kv_cache: torch FP8 dtype is unavailable")
+        return {
+            "dtype": str(dtype),
+            "num_tokens": num_tokens,
+            "block_size": block_size,
+            "rotary_dim": rotary_dim,
+            "num_index_heads": num_index_heads,
+            "status": "skipped",
+        }
+
+    case = make_case(
+        dtype=dtype,
+        num_tokens=num_tokens,
+        block_size=block_size,
+        num_index_heads=num_index_heads,
+        rotary_dim=rotary_dim,
+    )
+    refs = make_refs(case, case["qkv"])
+    rtol = 1e-2
+    atol = 1e-2
+    use_index_slot_mapping = mode != "slot_mapping_fallback"
+    result, avg_opt = run_fused_qknorm_idxrqknorm(
+        case,
+        mode,
+        use_index_slot_mapping,
+        use_fp8_kv_cache,
+    )
+
+    info = (
+        f"mode:{mode}, dtype:{dtype}, tokens:{num_tokens}, block:{block_size}, "
+        f"rotary:{rotary_dim}, index_heads:{num_index_heads}"
+    )
+    msg = f"[perf] === {info} === fused_kernel avg: {avg_opt:<8.2f} us "
+
+    if mode == "inplace":
+        qkv_out = result
+        q_out, k_out, v_out, *index_outs = split_qkv(case, qkv_out)
+        _, _, v_orig, *_ = split_qkv(case, case["qkv"])
+        check_close(q_out, refs["q"], msg=f"{msg}(q)", rtol=rtol, atol=atol)
+        check_close(
+            k_out.view(num_tokens, case["num_kv_heads"], HEAD_DIM),
+            refs["k"],
+            msg=f"{msg}(k)",
+            rtol=rtol,
+            atol=atol,
+        )
+        check_close(v_out, v_orig, msg=f"{msg}(v)", rtol=0, atol=0)
+        if num_index_heads > 0:
+            index_q_out, index_k_out = index_outs
+            check_close(
+                index_q_out,
+                refs["index_q"],
+                msg=f"{msg}(index_q)",
+                rtol=rtol,
+                atol=atol,
+            )
+            check_close(
+                index_k_out,
+                refs["index_k"],
+                msg=f"{msg}(index_k)",
+                rtol=rtol,
+                atol=atol,
+            )
+    else:
+        (
+            q_out,
+            index_q_out,
+            kv_cache,
+            index_cache,
+            index_slot_mapping,
+            k_scale,
+            v_scale,
+        ) = result
+        check_close(q_out, refs["q"], msg=f"{msg}(q_out)", rtol=rtol, atol=atol)
+        if num_index_heads > 0:
+            check_close(
+                index_q_out,
+                refs["index_q"],
+                msg=f"{msg}(index_q_out)",
+                rtol=rtol,
+                atol=atol,
+            )
+
+        k_out, v_out, index_k_out = gather_cache_outputs(
+            case,
+            kv_cache,
+            index_cache,
+            index_slot_mapping=index_slot_mapping,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+        if use_fp8_kv_cache:
+            k_ref = fp8_cache_ref(refs["k"], k_scale)
+            v_ref = fp8_cache_ref(refs["v"], v_scale)
+        else:
+            k_ref = refs["k"]
+            v_ref = refs["v"]
+        check_close(k_out, k_ref, msg=f"{msg}(k_cache)", rtol=rtol, atol=atol)
+        check_close(v_out, v_ref, msg=f"{msg}(v_cache)", rtol=rtol, atol=atol)
+        if num_index_heads > 0:
+            check_close(
+                index_k_out,
+                refs["index_k"],
+                msg=f"{msg}(index_cache)",
+                rtol=rtol,
+                atol=atol,
+            )
+
+    return {
+        "mode": mode,
+        "dtype": str(dtype),
+        "num_tokens": num_tokens,
+        "block_size": block_size,
+        "rotary_dim": rotary_dim,
+        "num_index_heads": num_index_heads,
+        "fused_kernel_us": avg_opt,
+        "status": "passed",
+    }
+
+
+DEFAULT_CASES = [
+    ("insert", "bf16", 1, 16, 64, 4),
+    ("insert", "bf16", 17, 16, 64, 4),
+    ("insert", "bf16", 19, 16, 96, 4),
+    ("insert", "fp16", 33, 8, 128, 4),
+    ("dense_insert", "bf16", 13, 8, 96, 0),
+    ("slot_mapping_fallback", "bf16", 9, 8, 64, 4),
+    ("inplace", "bf16", 11, 16, 64, 0),
+    ("inplace", "bf16", 11, 16, 64, 4),
+    ("inplace", "fp16", 11, 16, 64, 4),
+    ("fp8_kv_cache", "bf16", 17, 16, 64, 4),
+    ("fp8_kv_cache_uint8", "bf16", 17, 16, 64, 4),
+]
+
+l_mode = [
+    "insert",
+    "dense_insert",
+    "slot_mapping_fallback",
+    "inplace",
+    "fp8_kv_cache",
+    "fp8_kv_cache_uint8",
+]
+l_dtype = ["fp16", "bf16"]
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="Test fused_qknorm_idxrqknorm op",
+)
+parser.add_argument(
+    "--mode",
+    type=str,
+    choices=l_mode,
+    nargs="*",
+    default=None,
+    help="Mode(s) to test",
+)
+parser.add_argument(
+    "-d",
+    "--dtype",
+    type=str,
+    choices=l_dtype,
+    nargs="*",
+    default=None,
+    help="Data type(s). e.g. -d bf16 or -d bf16 fp16",
+)
+parser.add_argument("--num_tokens", type=int, nargs="*", default=None)
+parser.add_argument("--block_size", type=int, nargs="*", default=None)
+parser.add_argument("--rotary_dim", type=int, nargs="*", default=None)
+parser.add_argument("--num_index_heads", type=int, nargs="*", default=None)
+args = parser.parse_args()
+
+selected_cases = []
+for (
+    mode,
+    dtype_name,
+    num_tokens,
+    block_size,
+    rotary_dim,
+    num_index_heads,
+) in DEFAULT_CASES:
+    if args.mode is not None and mode not in args.mode:
+        continue
+    if args.dtype is not None and dtype_name not in args.dtype:
+        continue
+    if args.num_tokens is not None and num_tokens not in args.num_tokens:
+        continue
+    if args.block_size is not None and block_size not in args.block_size:
+        continue
+    if args.rotary_dim is not None and rotary_dim not in args.rotary_dim:
+        continue
+    if args.num_index_heads is not None and num_index_heads not in args.num_index_heads:
+        continue
+    selected_cases.append(
+        (mode, dtype_name, num_tokens, block_size, rotary_dim, num_index_heads)
+    )
+
+df = []
+for (
+    mode,
+    dtype_name,
+    num_tokens,
+    block_size,
+    rotary_dim,
+    num_index_heads,
+) in selected_cases:
+    ret = test_fused_qknorm_idxrqknorm(
+        mode=mode,
+        dtype=dtypes.d_dtypes[dtype_name],
+        num_tokens=num_tokens,
+        block_size=block_size,
+        rotary_dim=rotary_dim,
+        num_index_heads=num_index_heads,
+    )
+    df.append(ret)
+
+df = pd.DataFrame(df)
+df_md = df.to_markdown(index=False)
+aiter.logger.info("fused_qknorm_idxrqknorm summary (markdown):\n%s", df_md)


### PR DESCRIPTION
Add the fused QK-norm/RoPE/KV insert kernel and Python dispatch wrapper used by MiniMax-M3 serving.

## Motivation

MiniMax-M3 serving needs a fused preprocessing path for attention that applies QK normalization, RoPE, and KV-cache insertion. This reduces launch overhead and avoids extra intermediate memory traffic in the preprocessing path.

## Technical Details

This PR adds a fused kernel for the MiniMax-M3 attention preprocessing flow, covering:

- Q/K normalization before attention.
- RoPE application for query and key tensors.
- KV-cache insertion for serving-time decode.
- A Python dispatch wrapper so the fused path can be called from the existing AITER Python API.

The fused implementation is intended to replace separate preprocessing steps in MiniMax-M3 serving with a single dispatchable operation.

## Operator Constraints

`aiter.fused_qknorm_idxrqknorm` currently targets the MiniMax-style attention preprocessing layout with fixed `head_dim = 128`.

Input constraints:
- `qkv` must be a contiguous CUDA tensor with dtype `fp16` or `bf16`.
- `q_norm_weight`, `k_norm_weight`, and `cos_sin_cache` must use the same dtype as `qkv`.
- `q_norm_weight` and `k_norm_weight` must each contain 128 elements.
- `cos_sin_cache` must have shape `[max_position, rotary_dim]`.
- `positions` must be a contiguous CUDA `int64` tensor with at least `num_tokens` elements.
- `rotary_dim` must be positive, divisible by 8, and `<= 128`.
Layout constraints:
- Dense layout:
  `qkv.shape == [num_tokens, (num_heads + 2 * num_kv_heads) * 128]`
- Sparse/index layout:
  `qkv.shape == [num_tokens, (num_heads + 2 * num_kv_heads + num_index_heads + 1) * 128]`
- `num_heads > 0`, `num_kv_heads > 0`, and `num_index_heads >= 0`.
KV insert constraints:
- KV insert is enabled when `kv_cache` is provided.
- `slot_mapping` is required for KV insert and must be contiguous CUDA `int64`.
- `kv_cache` must have shape `[num_blocks, 2, block_size, num_kv_heads, 128]` with contiguous head dimension.
- Non-FP8 KV cache requires `kv_cache.dtype == qkv.dtype` and `kv_cache_dtype="auto"`.
- FP8 KV cache supports native torch e4m3 FP8 storage only, with `kv_cache_dtype="fp8"` or `"fp8_e4m3"`, and requires CUDA float32 scalar tensors `k_scale` and `v_scale`.
Sparse/index branch constraints:
- If `num_index_heads > 0`, both `index_q_norm_weight` and `index_k_norm_weight` are required and must match `qkv.dtype`.
- Sparse KV insert additionally requires `index_cache`; `index_slot_mapping` is optional and falls back to `slot_mapping` when omitted.
- Dense KV insert with `num_index_heads == 0` is supported and does not require `index_cache` or `index_slot_mapping`.

## Test Plan

- UT test
- model Accuracy

## Test Result

The fused MiniMax-M3 preprocessing kernel was built successfully and validated against the reference/unfused implementation for the serving path.
minimax m3
<img width="1871" height="343" alt="image" src="https://github.com/user-attachments/assets/5187a2d2-d94f-46ba-a32c-ccf1e4303778" />
<img width="1488" height="269" alt="image" src="https://github.com/user-attachments/assets/69d679e8-eba5-4110-8d26-85edb74fb1e7" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.