### PR TITLE
[Triton] Detect rocm-core version via rpm on RPM-based systems

### DIFF
--- a/.github/scripts/download_triton_wheel.sh
+++ b/.github/scripts/download_triton_wheel.sh
@@ -11,6 +11,10 @@ python3 -m pip config set global.timeout 120
 TRITON_DEFAULT_ROCM_VERSION="${TRITON_DEFAULT_ROCM_VERSION:-7.2.0}"
 TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${TRITON_DEFAULT_ROCM_VERSION}/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}' || true)
+if [[ -z "${ROCM_VERSION}" ]]; then
+    # RPM-based systems (e.g. rocm-core-7.2.0.70200-43.el8.x86_64 -> 7.2.0.70200)
+    ROCM_VERSION=$(rpm -q --queryformat '%{VERSION}' rocm-core 2>/dev/null || true)
+fi
 if [[ -n "${ROCM_VERSION}" ]]; then
     ROCM_MAJOR_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f1,2)
     TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"

--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -63,6 +63,10 @@ install_triton_from_wheelhouse() {
 TRITON_DEFAULT_ROCM_VERSION="${TRITON_DEFAULT_ROCM_VERSION:-7.2.0}"
 TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${TRITON_DEFAULT_ROCM_VERSION}/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}' || true)
+if [[ -z "$ROCM_VERSION" ]]; then
+    # RPM-based systems (e.g. rocm-core-7.2.0.70200-43.el8.x86_64 -> 7.2.0.70200)
+    ROCM_VERSION=$(rpm -q --queryformat '%{VERSION}' rocm-core 2>/dev/null || true)
+fi
 if [[ -n "$ROCM_VERSION" ]]; then
     ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | cut -d. -f1,2)
     TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"


### PR DESCRIPTION
dpkg only works on Debian/Ubuntu. Fall back to
`rpm -q --queryformat '%{VERSION}' rocm-core` so ROCm version detection also works on RHEL/openEuler-style images
(e.g. rocm-core-7.2.0.70200-43.el8.x86_64 -> 7.2.0.70200 -> 7.2).

Applied to both install_triton.sh and download_triton_wheel.sh.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
