### PR TITLE
[FlyDSL] Fuse decode SWA cache-write into qk_norm_rope_quant

### DIFF
--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -224,6 +224,7 @@ def _build_kernel(
     group_size: int,
     scale_dtype: str,
     q_weighted: bool,
+    kv_write: bool = False,
 ):
     """Build the @flyc.kernel + @flyc.jit launcher for a given config.
 
@@ -307,6 +308,8 @@ def _build_kernel(
     if quant:
         _name_parts.append(f"g{group_size}")
         _name_parts.append(scale_dtype)
+    if kv_write:
+        _name_parts.append("kvw")
     _name_parts.append("flydsl")
     _kname = "_".join(_name_parts)
 
@@ -324,6 +327,12 @@ def _build_kernel(
         q_scale: fx.Pointer,  # [T, H, NG]        f32 or uint8 (e8m0)
         kv_scale: fx.Pointer,  # [T, NG]           f32 or uint8 (e8m0)
         kv_in_row_stride: Int32,  # KV row stride in bf16 elements
+        swa_kv: fx.Pointer,  # [num_slots, cache_size, D] bf16 (dummy if not kv_write)
+        state_slot_mapping: fx.Pointer,  # [bs] i32 (dummy if not kv_write)
+        batch_id_per_token: fx.Pointer,  # [T] i64, -1 sentinel (dummy if not kv_write)
+        swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
+        swa_pos_stride: Int32,  # bf16 elements (= D)
+        swa_cache_size: Int32,  # ring slot count
     ):
         f32 = T.f32
         i32 = T.i32
@@ -386,6 +395,8 @@ def _build_kernel(
             fp8_out_rsrc,  # (rsrc_token_shifted, row_base_bytes_within_token) when quant
             scale_rsrc,
             scale_base_off,  # base elem-offset; per-lane adds (tid // TPG)
+            swa_out_g=None,  # GTensor (swa ring, per-token base) when kv_write
+            do_swa=None,  # i1 predicate (batch_id >= 0); None when no kv_write
         ):
             """Apply RMSNorm + GPT-J RoPE (+ optional FP8 quant) for the row
             held by this block. ``x_f32_vec`` and (optional) ``w_f32_vec`` are
@@ -520,6 +531,19 @@ def _build_kernel(
                     _store_fp8_packed(rope_out, rsrc, row_base, tid, VEC)
                 else:
                     _store_bf16_vec_g(rope_out, bf16_out_g, bf16_out_row_off, tid, VEC)
+                    if const_expr(kv_write):
+                        # Fused SWA scatter: same post-norm/rope bf16 row also
+                        # lands in swa_kv[slot, pos%cache_size, :]. swa_out_g
+                        # base is already shifted to that ring slot. Predicate
+                        # on do_swa (batch_id >= 0) to skip CG-pad tokens.
+                        if do_swa:
+                            _store_bf16_vec_g(
+                                rope_out,
+                                swa_out_g,
+                                arith.constant(0, type=i32),
+                                tid,
+                                VEC,
+                            )
             else:
                 # ---- NOPE path: direct scaled store ----
                 scaled = []
@@ -536,6 +560,15 @@ def _build_kernel(
                     _store_fp8_packed(scaled, rsrc, row_base, tid, VEC)
                 else:
                     _store_bf16_vec_g(scaled, bf16_out_g, bf16_out_row_off, tid, VEC)
+                    if const_expr(kv_write):
+                        if do_swa:
+                            _store_bf16_vec_g(
+                                scaled,
+                                swa_out_g,
+                                arith.constant(0, type=i32),
+                                tid,
+                                VEC,
+                            )
 
         # ============ runtime dispatch on bid_x < H ============
         # Per-token byte offsets fold ``bid_t`` into the buffer descriptor
@@ -703,6 +736,42 @@ def _build_kernel(
                     shape=(D,),
                     static_bytes_offset_i64=kv_tok_off_bf16,
                 )
+
+                # ---- Fused SWA scatter setup (kv_write only) ----
+                # Target swa_kv[slot, pos % cache_size, :] where
+                # slot = state_slot_mapping[batch_id_per_token[bid_t]].
+                # batch_id is i64 with -1 sentinel on CG-pad tokens; clamp it
+                # to 0 for the (predicated-off) slot load to keep the load
+                # in-bounds, and gate the actual store on do_swa = batch_id>=0.
+                swa_out_g = None
+                do_swa = None
+                if const_expr(kv_write):
+                    bid_rsrc = _ptr_buffer_resource(batch_id_per_token)
+                    bid_i64 = buffer_ops.buffer_load(
+                        bid_rsrc, bid_t, vec_width=1, dtype=T.i64
+                    )
+                    bid_i32 = arith.trunci(i32, bid_i64)
+                    do_swa = bid_i32 >= fx.Int32(0)
+                    bid_safe = arith.maxsi(bid_i32, arith.constant(0, type=i32))
+                    slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
+                    slot = buffer_ops.buffer_load(
+                        slot_rsrc, bid_safe, vec_width=1, dtype=i32
+                    )
+                    ring = arith.remsi(pos_i32, _to_raw(swa_cache_size))
+                    swa_off_elems = ArithValue(slot) * ArithValue(
+                        swa_slot_stride
+                    ) + ArithValue(ring) * ArithValue(swa_pos_stride)
+                    swa_off_bytes = (
+                        arith.index_cast(T.index, _to_raw(swa_off_elems))
+                        * arith.constant(2, type=T.index)
+                    )
+                    swa_out_g = GTensor(
+                        swa_kv,
+                        dtype=T.bf16,
+                        shape=(D,),
+                        static_bytes_offset_i64=swa_off_bytes,
+                    )
+
                 emit_body(
                     weighted=True,
                     x_f32_vec=x_f32,
@@ -712,6 +781,8 @@ def _build_kernel(
                     fp8_out_rsrc=None,
                     scale_rsrc=None,
                     scale_base_off=None,
+                    swa_out_g=swa_out_g,
+                    do_swa=do_swa,
                 )
 
     # Name the launcher explicitly so the flydsl disk cache directory becomes
@@ -732,6 +803,12 @@ def _build_kernel(
         q_scale: fx.Pointer,
         kv_scale: fx.Pointer,
         kv_in_row_stride: fx.Int32,
+        swa_kv: fx.Pointer,
+        state_slot_mapping: fx.Pointer,
+        batch_id_per_token: fx.Pointer,
+        swa_slot_stride: fx.Int32,
+        swa_pos_stride: fx.Int32,
+        swa_cache_size: fx.Int32,
         num_tokens: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
@@ -749,6 +826,12 @@ def _build_kernel(
             q_scale,
             kv_scale,
             kv_in_row_stride,
+            swa_kv,
+            state_slot_mapping,
+            batch_id_per_token,
+            swa_slot_stride,
+            swa_pos_stride,
+            swa_cache_size,
         )
         k.launch(
             grid=(H + 1, idx_tokens, 1),
@@ -787,13 +870,14 @@ def compile_flydsl_qk_norm_rope_quant(
     group_size: int,
     scale_dtype: str,
     q_weighted: bool,
+    kv_write: bool = False,
 ):
     """Compile (and cache) the launcher for a given config.
 
-    Cache key includes (H, D, RD, quant, group_size, scale_dtype, q_weighted).
-    Returns the @flyc.jit launcher; call it directly if you've already
-    allocated outputs and want to avoid the per-call torch-side overhead in
-    ``flydsl_qk_norm_rope_quant``.
+    Cache key includes (H, D, RD, quant, group_size, scale_dtype, q_weighted,
+    kv_write). Returns the @flyc.jit launcher; call it directly if you've
+    already allocated outputs and want to avoid the per-call torch-side
+    overhead in ``flydsl_qk_norm_rope_quant``.
     """
     launcher = _build_kernel(
         num_q_heads=num_q_heads,
@@ -803,6 +887,7 @@ def compile_flydsl_qk_norm_rope_quant(
         group_size=group_size,
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
+        kv_write=kv_write,
     )
     launcher.compile_hints = dict(_DEFAULT_COMPILE_HINTS)
     return launcher
@@ -827,6 +912,9 @@ def flydsl_qk_norm_rope_quant(
     kv_out: Optional[torch.Tensor] = None,
     q_scale: Optional[torch.Tensor] = None,
     kv_scale: Optional[torch.Tensor] = None,
+    swa_kv: Optional[torch.Tensor] = None,
+    state_slot_mapping: Optional[torch.Tensor] = None,
+    batch_id_per_token: Optional[torch.Tensor] = None,
     stream: Optional[torch.cuda.Stream] = None,
 ) -> Tuple[
     torch.Tensor,
@@ -875,6 +963,17 @@ def flydsl_qk_norm_rope_quant(
             stream. **Must NOT be left at ``fx.Stream(None)`` default in
             caller code unless you accept the default-stream pitfall under
             CUDA-graph capture** (NULL stream -> empty captured graph).
+        swa_kv: optional ``[num_slots, cache_size, D]`` bf16 SWA ring buffer.
+            When provided (BF16 only; incompatible with ``quant``), the
+            post-norm/rope KV row is additionally scattered into
+            ``swa_kv[slot, pos % cache_size, :] = kv_out[t]`` in the same
+            launch (``slot = state_slot_mapping[batch_id_per_token[t]]``),
+            fusing the standalone ``swa_write``.
+        state_slot_mapping: ``[bs]`` int32 — per-seq SWA ring slot. Required
+            when ``swa_kv`` is set.
+        batch_id_per_token: ``[T]`` int64, ``-1`` on CG-pad tokens — token→seq
+            map for the fused SWA scatter (store gated off on ``-1``). Required
+            when ``swa_kv`` is set.
 
     Returns:
         (q_out, kv_out, q_scale_or_None, kv_scale_or_None)
@@ -979,6 +1078,48 @@ def flydsl_qk_norm_rope_quant(
         q_scale_arg = q.new_empty(1, dtype=scale_torch_dtype)
         kv_scale_arg = q.new_empty(1, dtype=scale_torch_dtype)
 
+    # ---- Fused SWA cache-write (BF16 only) ----
+    # When swa_kv is provided, the KV row (post-norm/rope) is also scattered
+    # into swa_kv[slot, pos % cache_size, :] where
+    # slot = state_slot_mapping[batch_id_per_token[t]]. Avoids a separate
+    # swa_write launch + kv HBM round-trip. Requires bf16 output (quant off).
+    kv_write = swa_kv is not None
+    if kv_write:
+        if quant:
+            raise ValueError("kv_write (swa_kv) is BF16 only; not supported with quant")
+        if state_slot_mapping is None or batch_id_per_token is None:
+            raise ValueError(
+                "kv_write requires state_slot_mapping and batch_id_per_token"
+            )
+        if swa_kv.dim() != 3 or swa_kv.shape[2] != D:
+            raise ValueError(f"swa_kv must be [S, C, D={D}], got {tuple(swa_kv.shape)}")
+        if swa_kv.dtype != torch.bfloat16:
+            raise TypeError(f"swa_kv must be bf16, got {swa_kv.dtype}")
+        if not swa_kv.is_contiguous():
+            raise ValueError("swa_kv must be contiguous")
+        if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
+            raise TypeError("state_slot_mapping must be 1-D int32")
+        if batch_id_per_token.dim() != 1 or batch_id_per_token.dtype != torch.int64:
+            raise TypeError("batch_id_per_token must be 1-D int64")
+        if batch_id_per_token.shape[0] < T_tok:
+            raise ValueError(
+                f"batch_id_per_token len {batch_id_per_token.shape[0]} < T={T_tok}"
+            )
+        swa_slot_stride = swa_kv.stride(0)
+        swa_pos_stride = swa_kv.stride(1)
+        swa_cache_size = swa_kv.shape[1]
+        swa_kv_arg = swa_kv
+        ssm_arg = state_slot_mapping
+        bid_arg = batch_id_per_token
+    else:
+        # 1-elem dummies so the kernel param binding has valid pointers.
+        swa_slot_stride = 0
+        swa_pos_stride = 0
+        swa_cache_size = 1
+        swa_kv_arg = kv_out  # bf16 dummy
+        ssm_arg = q.new_empty(1, dtype=torch.int32)
+        bid_arg = q.new_empty(1, dtype=torch.int64)
+
     launcher = compile_flydsl_qk_norm_rope_quant(
         num_q_heads=H,
         head_dim=D,
@@ -987,6 +1128,7 @@ def flydsl_qk_norm_rope_quant(
         group_size=G,
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
+        kv_write=kv_write,
     )
 
     if stream is None:
@@ -1037,6 +1179,15 @@ def flydsl_qk_norm_rope_quant(
             _ptr_arg(q_scale_arg[start:end] if quant else q_scale_arg),
             _ptr_arg(kv_scale_arg[start:end] if quant else kv_scale_arg),
             kv.stride(0),
+            # swa_kv / state_slot_mapping are global (indexed by absolute slot /
+            # batch_id), so pass unsliced; batch_id_per_token is [T], sliced
+            # like positions.
+            _ptr_arg(swa_kv_arg),
+            _ptr_arg(ssm_arg),
+            _ptr_arg(bid_arg[start:end] if kv_write else bid_arg),
+            swa_slot_stride,
+            swa_pos_stride,
+            swa_cache_size,
             n,
             _stream_arg(),
         )

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -761,10 +761,9 @@ def _build_kernel(
                     swa_off_elems = ArithValue(slot) * ArithValue(
                         swa_slot_stride
                     ) + ArithValue(ring) * ArithValue(swa_pos_stride)
-                    swa_off_bytes = (
-                        arith.index_cast(T.index, _to_raw(swa_off_elems))
-                        * arith.constant(2, type=T.index)
-                    )
+                    swa_off_bytes = arith.index_cast(
+                        T.index, _to_raw(swa_off_elems)
+                    ) * arith.constant(2, type=T.index)
                     swa_out_g = GTensor(
                         swa_kv,
                         dtype=T.bf16,

--- a/op_tests/test_flydsl_qk_norm_rope_quant.py
+++ b/op_tests/test_flydsl_qk_norm_rope_quant.py
@@ -364,6 +364,89 @@ def test_flydsl_qk_norm_rope_quant_cos_sin_4d():
     torch.testing.assert_close(out_2d[1], out_4d[1], atol=0.0, rtol=0.0)
 
 
+def test_flydsl_qk_norm_rope_quant_kv_write():
+    """Cover the fused SWA cache-write path (BF16 only).
+
+    With ``swa_kv`` provided, the kernel scatters each token's post-norm/rope
+    KV row into ``swa_kv[slot, pos % cache_size, :]`` where
+    ``slot = state_slot_mapping[batch_id_per_token[t]]``. Since the scatter
+    stores the SAME bytes the kernel writes to ``kv_out``, the result must be
+    bit-exact against a gather built from ``kv_out``. A ``-1`` sentinel in
+    ``batch_id_per_token`` (CG-pad tokens) must be skipped, leaving those
+    ring slots untouched.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    H, D, RD = 16, 512, 64
+    bs = 5
+    mtp = 1  # MTP-1: 2 tokens/seq -> token->seq is NOT identity
+    tok_per_seq = 1 + mtp
+    T_valid = bs * tok_per_seq
+    pad = 3  # CG-pad sentinel tokens
+    T = T_valid + pad
+    cache_size = 129  # window 128 + 1 spec
+    num_slots = 8
+
+    max_pos = max(cache_size, 64)
+    inv_freq = 1.0 / (10000 ** (torch.arange(0, RD, 2, device=device).float() / RD))
+    freqs = torch.einsum(
+        "i,j->ij", torch.arange(max_pos, device=device).float(), inv_freq
+    )
+    cos = freqs.cos().to(torch.bfloat16).contiguous()
+    sin = freqs.sin().to(torch.bfloat16).contiguous()
+
+    q = torch.randn(T, H * D, dtype=torch.bfloat16, device=device) * 0.1
+    Q_LORA = 1536
+    qkv_a = torch.randn(T, Q_LORA + D, dtype=torch.bfloat16, device=device) * 0.1
+    _, kv = torch.split(qkv_a, [Q_LORA, D], dim=-1)
+    kv_w = torch.randn(D, dtype=torch.bfloat16, device=device).abs() + 0.5
+    pos = torch.randint(0, max_pos - 1, (T,), dtype=torch.int64, device=device)
+
+    # batch_id_per_token: valid tokens map to seqs round-robin; pad tail = -1.
+    bid = torch.full((T,), -1, dtype=torch.int64, device=device)
+    bid[:T_valid] = torch.arange(T_valid, device=device) // tok_per_seq
+    # random per-seq state slot (distinct so collisions don't mask bugs)
+    state_slot = torch.randperm(num_slots, device=device)[:bs].to(torch.int32)
+
+    swa_kv = torch.zeros(num_slots, cache_size, D, dtype=torch.bfloat16, device=device)
+
+    got_q, got_kv, _, _ = flydsl_qk_norm_rope_quant(
+        q,
+        kv,
+        kv_w,
+        cos,
+        sin,
+        pos,
+        num_q_heads=H,
+        head_dim=D,
+        rope_head_dim=RD,
+        swa_kv=swa_kv,
+        state_slot_mapping=state_slot,
+        batch_id_per_token=bid,
+    )
+
+    # Expected ring: for each valid token, swa_kv[slot, pos%cache] == kv_out.
+    expected = torch.zeros_like(swa_kv)
+    for t in range(T):
+        b = int(bid[t].item())
+        if b < 0:
+            continue
+        slot = int(state_slot[b].item())
+        ring = int(pos[t].item()) % cache_size
+        expected[slot, ring] = got_kv[t]
+
+    torch.testing.assert_close(swa_kv, expected, atol=0.0, rtol=0.0)
+
+    # kv_out itself must match the no-kv_write path bit-for-bit (scatter is a
+    # pure side write; it must not perturb the primary output).
+    ref_q, ref_kv, _, _ = flydsl_qk_norm_rope_quant(
+        q, kv, kv_w, cos, sin, pos, num_q_heads=H, head_dim=D, rope_head_dim=RD
+    )
+    torch.testing.assert_close(got_kv, ref_kv, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(got_q, ref_q, atol=0.0, rtol=0.0)
+    print("[kv_write] fused SWA scatter bit-exact; pad sentinel skipped — PASS")
+
+
 # ============================================================================
 # argparse + matrix sweep
 # ============================================================================
@@ -440,6 +523,8 @@ args = parser.parse_args()
 
 # Smoke-test the advertised 4D cos/sin layout once before sweeping.
 test_flydsl_qk_norm_rope_quant_cos_sin_4d()
+# Smoke-test the fused SWA cache-write path.
+test_flydsl_qk_norm_rope_quant_kv_write()
 
 quant_keys = ["bf16"] if args.no_quant else args.quant
 qweight_modes = [False, True] if args.qweight else [False]


### PR DESCRIPTION
## Summary
- Add an optional **fused SWA ring scatter** to `flydsl_qk_norm_rope_quant`. When `swa_kv` is provided, each token's post-norm/rope **bf16 KV row** is also written into `swa_kv[slot, pos % cache_size, :]` in the same launch, where `slot = state_slot_mapping[batch_id_per_token[t]]`.
- This replaces the standalone `swa_write` Triton launch + a full `[T, D]` KV HBM round-trip per layer per decode step — the row is already in registers right before the `kv_out` store, so the scatter is a second `_store_bf16_vec_g` of the same data.

## Details
- New constexpr `kv_write` flag on `_build_kernel` / `compile_flydsl_qk_norm_rope_quant`; gets its own disk-cache dir via the `"kvw"` kernel-name suffix.
- Kernel gains 6 params (`swa_kv`, `state_slot_mapping`, `batch_id_per_token`, `swa_slot_stride`, `swa_pos_stride`, `swa_cache_size`). `batch_id` is loaded i64 and **clamped** for an OOB-safe slot load; the store is **predicated on `batch_id >= 0`** so CG-pad tokens (`-1` sentinel) are skipped.
- **BF16 only** — raises if combined with `quant`. Passing no `swa_kv` reproduces the existing kernel exactly (dummy pointers bound, `kv_write=False`).

## Test plan
- [x] New bit-exact unit test `test_flydsl_qk_norm_rope_quant_kv_write` — MTP-1 (token→seq not identity), distinct per-seq slots, `-1` pad-sentinel skip; asserts the fused ring == gather of `kv_out` and that `kv_out`/`q_out` are unchanged vs the no-`swa_kv` path.
- [x] Independent cross-check vs the real standalone `swa_write` Triton kernel across 24 configs (bs∈{1,2,4,8} × MTP∈{0,1,3} × pad∈{0,3}): all `max_diff=0`.