### PR TITLE
perf: use vectorized LDS loads for mhc_pre_gemm_sqrsum on gfx942

### DIFF
--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -161,17 +161,8 @@ namespace aiter {
         static constexpr int32_t interleave_size = warp_size / mfma_m;
         float sqrsum_part = 0.0f;
 
-#if defined(__gfx942__)
-        // gfx942 path keeps 32-bit async copies.
-        static constexpr int fn_vec_size = 1;
-        static constexpr int fn_xor_shift = 0;
-#else
-        // Swizzle at 4-float granularity so LDS reads can use 128-bit contiguous loads.
-        // The row mask occupies bits [2:5], spreading 16 rows across 64 banks while
-        // preserving the low 2 bits of K for ds_read_b128.
         static constexpr int fn_vec_size = 4;
         static constexpr int fn_xor_shift = 2;
-#endif
         const int fn_row_base = warp_id * (tile_n / warp_per_block);
         auto lds_load_fn_tile = [&](int k){
             float* s_fn_wr_ptr = k % 2 == 0 ? s_fn : (s_fn + tile_n * tile_k);


### PR DESCRIPTION
## Motivation

Optimize the `mhc_pre_gemm_sqrsum` kernel for AMD MI300X (gfx942) to reduce latency for DeepSeek-V4 inference (hidden_size=7168, hc_mult=4). The kernel currently uses a scalar LDS load path (`fn_vec_size=1`) on gfx942 while the non-gfx942 path already uses faster 128-bit vectorized loads with bank-conflict-avoiding swizzle.

## Technical Details

Remove the `#if defined(__gfx942__)` branch that forces scalar 32-bit async copies (`fn_vec_size=1, fn_xor_shift=0`) and always use the vectorized path (`fn_vec_size=4, fn_xor_shift=2`). This enables `ds_read_b128` loads with XOR-based swizzle that spreads 16 rows across 64 LDS banks, eliminating bank conflicts.

Net change: 9 lines deleted (the `#if`/`#else`/`#endif` and scalar constants).

## Test Plan

Run `test_mhc.py` with DeepSeek-V4 config across 9 token counts:
```
python op_tests/test_mhc.py -m 1 32 64 128 256 512 1024 2048 8192 -n 7168
```

## Test Result

All correctness checks passed (checkAllclose atol=0.01, rtol=0.01) across 23 independent pipeline runs (100% pass rate).

Benchmark (`hip_us`, MI300X, hidden_size=7168, hc_mult=4):

| m | baseline (µs) | optimized (µs) | speedup |
|---|---|---|---|
| 1 | 12.46 | 2.79 | +77.6% |
| 32 | 13.19 | 3.39 | +74.3% |
| 64 | 14.56 | 4.27 | +70.7% |
| 128 | 18.49 | 6.10 | +67.0% |
| 256 | 25.73 | 10.62 | +58.7% |
| 512 | 38.01 | 18.04 | +52.5% |
| 1024 | 68.68 | 31.88 | +53.6% |
| 2048 | 118.15 | 62.10 | +47.5% |
| 8192 | 448.52 | 297.32 | +33.7% |

## Submission Checklist

- [x] Reviewed contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests