### PR TITLE
fix(pa): launch MTP ASM with block table batch

### DIFF
--- a/csrc/py_itfs_cu/asm_pa.cu
+++ b/csrc/py_itfs_cu/asm_pa.cu
@@ -181,6 +181,10 @@ void pa_fwd(aiter_tensor_t* Q,              //   [num_seqs, num_heads, head_size
             hipStream_t stream)
 {
     int batch            = context_lens->size(0);
+    if(max_qlen > 1)
+    {
+        batch = block_tables->size(0);
+    }
     std::string arch_id = get_gpu_arch();
     int num_heads       = Q->size(1);
     int head_size       = Q->size(2);


### PR DESCRIPTION
## Summary
- Keep the non-MTP PA ASM launch batch as the original `context_lens.size(0)`.
- For MTP (`max_qlen > 1`), use `block_tables.size(0)` as the launch batch.
- This avoids launching graph-padded metadata rows when `context_lens/cu_seqlens/qo_indptr` are padded but `block_tables` is active-sized.

## Root cause
In ATOM Eagle3 MHA decode, MTP PA ASM can receive active-sized `Q`/`block_tables` while `context_lens` and `cu_seqlens/qo_indptr` are padded to graph batch. One observed failing launch had `Q=(320, 8, 128)`, `max_qlen=4`, `block_tables=(80, ...)`, `context_lens=(128,)`, `cu_seqlens=(129,)`. Launching with the padded metadata batch makes the kernel access `block_tables[80..127]`, which is out of bounds.

For MTP PA ASM, the launch `grid.y` indexes sequence rows and dereferences `block_tables[y]`, so `block_tables.size(0)` is the direct launch bound. Non-MTP decode is left unchanged from the original behavior.

## Testing
- Rebuilt `module_attention_asm.so` from this branch in `yhl_qshape_cleanjit_gsm8k_20260617`.
- `PYTHONPATH=$PWD python3 op_tests/test_pa_ragged.py -p Asm -q none i8 -c 128`: pass.
- `PYTHONPATH=$PWD python3 op_tests/test_pa_mtp.py -n 8,1 -q 3 4 -c 1024 -b 128 --block_size 16`: qlen 3/4 FP8 ASM pass.
- Padded metadata repro: `Q=(320, 8, 128)`, `block_tables=(80, 1024)`, `context_lens=(128,)`, `qo_indptr=(129,)`, `AMD_SERIALIZE_KERNEL=3 HIP_LAUNCH_BLOCKING=1`: pass.
- Previous ATOM server regression on this branch family with clean aiter `PYTHONPATH`, GSM8K `LIMIT=256`, `NUM_CONCURRENT=128`: pass, strict exact_match=0.8867, flexible exact_match=0.8828, final acceptance=57.03%.
- Note: `op_tests/test_pa_ragged.py::test_paged_attention_ragged_glm_gqa_fp8_kv_nhd` still fails with max abs diff `0.046875` under `rtol=atol=0.03`; the same failure reproduces on clean `origin/main`, so it is unrelated to this PA ASM change.
