### PR TITLE
ci: pin triton==3.7.0 and triton-kernels==1.0.0 for triton wheels

### DIFF
--- a/.github/scripts/download_triton_wheel.sh
+++ b/.github/scripts/download_triton_wheel.sh
@@ -24,7 +24,7 @@ python3 -m pip download \
     --dest "${TRITON_WHEEL_DIR}" \
     --index-url "${TRITON_INDEX_URL}" \
     --extra-index-url https://pypi.org/simple \
-    triton
+    "triton==3.7.0"
 
 echo "Downloading triton-kernels wheel from ${TRITON_INDEX_URL} into ${TRITON_WHEEL_DIR}"
 python3 -m pip download \
@@ -32,6 +32,6 @@ python3 -m pip download \
     --dest "${TRITON_WHEEL_DIR}" \
     --index-url "${TRITON_INDEX_URL}" \
     --extra-index-url https://pypi.org/simple \
-    triton-kernels
+    "triton-kernels==1.0.0"
 
 ls -lh "${TRITON_WHEEL_DIR}"

--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -70,10 +70,10 @@ fi
 TRITON_WHEEL_DIR=${TRITON_WHEEL_DIR:-}
 if ! install_triton_from_wheelhouse "${TRITON_WHEEL_DIR}"; then
     echo "Installing triton from $TRITON_INDEX_URL"
-    python3 -m pip install --extra-index-url "$TRITON_INDEX_URL" triton
+    python3 -m pip install --extra-index-url "$TRITON_INDEX_URL" "triton==3.7.0"
 
     echo "Installing triton-kernels from $TRITON_INDEX_URL"
-    python3 -m pip install --extra-index-url "$TRITON_INDEX_URL" triton-kernels
+    python3 -m pip install --extra-index-url "$TRITON_INDEX_URL" "triton-kernels==1.0.0"
 fi
 
 python3 - <<'PY'


### PR DESCRIPTION
Public PyPI now ships triton 3.7.1, which outranks AMD's 3.7.0+amd.rocm<ver> local-version wheel under --extra-index-url and gets installed instead of the ROCm build. Pinning the exact release keeps pip resolving to the AMD ROCm wheels in both install_triton.sh and download_triton_wheel.sh.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
