### PR TITLE
Add fused custom AllReduce + MHC post for TP paths

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1515,7 +1515,8 @@
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/fused_ar_mhc_post_pybind.cu'",
             "f'{AITER_CSRC_DIR}/kernels/fused_ar_mhc_post.cu'",
-            "f'{AITER_CSRC_DIR}/kernels/custom_all_reduce.cu'"
+            "f'{AITER_CSRC_DIR}/kernels/custom_all_reduce.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/mhc_kernels.cu'"
         ],
         "flags_extra_cc": [],
         "flags_extra_hip": [

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1511,6 +1511,21 @@
         "verbose": "False",
         "blob_gen_cmd": "''"
     },
+    "module_fused_ar_mhc": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/fused_ar_mhc_post_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/fused_ar_mhc_post.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/custom_all_reduce.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-DAITER_FUSED_AR_MHC_MODULE'"
+        ],
+        "extra_ldflags": "None",
+        "extra_include": [],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_mhc": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/mhc_pybind.cu'",

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -227,6 +227,21 @@ def fused_allreduce_mhc_post_only(
 
 
 @compile_ops(FUSED_AR_MHC_MD_NAME)
+def fused_allreduce_mhc_post_one_stage(
+    _fa: int,
+    inp: torch.Tensor,
+    next_residual: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+) -> None: ...
+
+
+@compile_ops(FUSED_AR_MHC_MD_NAME)
 def fused_allreduce_mhc_post_split(
     _fa: int,
     inp: torch.Tensor,

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -226,6 +226,57 @@ def fused_allreduce_mhc_post_only(
 ) -> None: ...
 
 
+@compile_ops(FUSED_AR_MHC_MD_NAME)
+def fused_allreduce_mhc_post_split(
+    _fa: int,
+    inp: torch.Tensor,
+    next_residual: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+) -> None: ...
+
+
+def _launch_fused_allreduce_mhc_post(
+    _fa: int,
+    inp: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    *,
+    next_residual: torch.Tensor | None = None,
+    split_path: bool = False,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+) -> torch.Tensor:
+    if post_layer_mix.ndim == 3:
+        post_layer_mix = post_layer_mix.squeeze(-1)
+    if next_residual is None:
+        next_residual = torch.empty_like(residual_in)
+    launch_fn = (
+        fused_allreduce_mhc_post_split if split_path else fused_allreduce_mhc_post_only
+    )
+    launch_fn(
+        _fa,
+        inp,
+        next_residual,
+        residual_in,
+        post_layer_mix,
+        comb_res_mix,
+        use_new,
+        open_fp8_quant,
+        reg_ptr,
+        reg_bytes,
+    )
+    return next_residual
+
+
 def launch_fused_allreduce_mhc_post_only(
     _fa: int,
     inp: torch.Tensor,
@@ -239,19 +290,44 @@ def launch_fused_allreduce_mhc_post_only(
     reg_bytes: int = 0,
 ) -> torch.Tensor:
     """Launch fused custom AllReduce + MHC post (no pre / RMSNorm)."""
-    if post_layer_mix.ndim == 3:
-        post_layer_mix = post_layer_mix.squeeze(-1)
-    next_residual = torch.empty_like(residual_in)
-    fused_allreduce_mhc_post_only(
+    return _launch_fused_allreduce_mhc_post(
         _fa,
         inp,
-        next_residual,
         residual_in,
         post_layer_mix,
         comb_res_mix,
-        use_new,
-        open_fp8_quant,
-        reg_ptr,
-        reg_bytes,
+        split_path=False,
+        use_new=use_new,
+        open_fp8_quant=open_fp8_quant,
+        reg_ptr=reg_ptr,
+        reg_bytes=reg_bytes,
     )
-    return next_residual
+
+
+def launch_fused_allreduce_mhc_post_split(
+    _fa: int,
+    inp: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    *,
+    next_residual: torch.Tensor | None = None,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+) -> torch.Tensor:
+    """Launch 2-stage split AR + MHC post (large-M optimized path)."""
+    return _launch_fused_allreduce_mhc_post(
+        _fa,
+        inp,
+        residual_in,
+        post_layer_mix,
+        comb_res_mix,
+        next_residual=next_residual,
+        split_path=True,
+        use_new=use_new,
+        open_fp8_quant=open_fp8_quant,
+        reg_ptr=reg_ptr,
+        reg_bytes=reg_bytes,
+    )

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -8,6 +8,7 @@ import torch
 from ..jit.core import compile_ops
 
 MD_NAME = "module_custom_all_reduce"
+FUSED_AR_MHC_MD_NAME = "module_fused_ar_mhc"
 
 
 @compile_ops("module_custom_all_reduce", develop=True)
@@ -208,3 +209,49 @@ def free_meta_buffer(ptr: int) -> None: ...
 
 @compile_ops("module_custom_all_reduce", develop=True)
 def get_meta_buffer_ipc_handle(inp_ptr: int, out_handle_ptr: int) -> None: ...
+
+
+@compile_ops(FUSED_AR_MHC_MD_NAME)
+def fused_allreduce_mhc_post_only(
+    _fa: int,
+    inp: torch.Tensor,
+    next_residual: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+) -> None: ...
+
+
+def launch_fused_allreduce_mhc_post_only(
+    _fa: int,
+    inp: torch.Tensor,
+    residual_in: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    *,
+    use_new: bool = True,
+    open_fp8_quant: bool = False,
+    reg_ptr: int = 0,
+    reg_bytes: int = 0,
+) -> torch.Tensor:
+    """Launch fused custom AllReduce + MHC post (no pre / RMSNorm)."""
+    if post_layer_mix.ndim == 3:
+        post_layer_mix = post_layer_mix.squeeze(-1)
+    next_residual = torch.empty_like(residual_in)
+    fused_allreduce_mhc_post_only(
+        _fa,
+        inp,
+        next_residual,
+        residual_in,
+        post_layer_mix,
+        comb_res_mix,
+        use_new,
+        open_fp8_quant,
+        reg_ptr,
+        reg_bytes,
+    )
+    return next_residual

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -4576,7 +4576,7 @@ void dispatchFusedQKNormAllReduce(hipStream_t stream,
 }
 
 template <typename T>
-void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
+void dispatchAllReduceMhcPost1Stage(hipStream_t stream,
                                     T* input,
                                     T* next_residual,
                                     T* residual,
@@ -4602,7 +4602,7 @@ void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
         throw std::runtime_error("AR+MHC post epilogue hidden dim too large for two-way CTA");
     }
 
-    RankData* ptrs = get_buffer_RD(stream, input);
+    RankData* ptrs        = get_buffer_RD(stream, input);
     const bool use_two_way = m >= 8192;
     dim3 block(use_two_way ? n_packs * 2 : n_packs);
     dim3 grid(std::min(m, kMaxBlocks));
@@ -4633,6 +4633,59 @@ void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
     }
 #undef DISPATCH_AR_MHC_POST_IMPL
 #undef DISPATCH_AR_MHC_POST
+}
+
+template <typename T>
+void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
+                                    T* input,
+                                    T* next_residual,
+                                    T* residual,
+                                    float* post_layer_mix,
+                                    float* comb_res_mix,
+                                    int m,
+                                    int input_hidden_dim,
+                                    int hidden_size,
+                                    int residual_stride)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    if(input_hidden_dim != hidden_size)
+    {
+        throw std::runtime_error("AR+MHC post epilogue requires full hidden input");
+    }
+    if(hidden_size % pack_size != 0 || residual_stride % pack_size != 0)
+    {
+        throw std::runtime_error("AR+MHC post epilogue requires pack-aligned hidden/stride");
+    }
+
+    const int64_t size_bytes = (int64_t)m * input_hidden_dim * sizeof(T);
+    // Same 512 KiB budget as fused AR+RMSNorm: TP>=4 large tensors use
+    // reduce-scatter + local epilogue instead of 1-stage row-wise IPC reduce.
+    constexpr int64_t kSplitMinBytes = 512 * 1024;
+    if(world_size_ >= 4 && size_bytes > kSplitMinBytes)
+    {
+        dispatchAllReduceMhcPostSplit<T>(stream,
+                                         input,
+                                         next_residual,
+                                         residual,
+                                         post_layer_mix,
+                                         comb_res_mix,
+                                         m,
+                                         input_hidden_dim,
+                                         hidden_size,
+                                         residual_stride);
+        return;
+    }
+
+    dispatchAllReduceMhcPost1Stage<T>(stream,
+                                      input,
+                                      next_residual,
+                                      residual,
+                                      post_layer_mix,
+                                      comb_res_mix,
+                                      m,
+                                      input_hidden_dim,
+                                      hidden_size,
+                                      residual_stride);
 }
 
 template <typename T>

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -2998,68 +2998,8 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
             sg, rank, residual_inp, residual_out, output, weight, scale_out, size, hidden_dim, eps);
 }
 
-// Stage 2 for split AR+MHC(post): read all-reduced activations from tmp and
-// apply mhc_post epilogue without materializing reduced layer_input.
-template <typename T, int hc_mult>
-__global__ void __launch_bounds__(1024, 1) local_device_mhc_post_from_tmp(
-    RankSignals sg,
-    int rank,
-    T* __restrict__ residual,
-    float* __restrict__ post_layer_mix,
-    float* __restrict__ comb_res_mix,
-    T* __restrict__ next_residual,
-    int m,
-    int hidden_size,
-    int residual_stride)
-{
-    constexpr int pack_size = 16 / sizeof(T);
-    using P                 = typename opus::vector_t<T, pack_size>;
-    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
-    static_assert(hc_mult == 4, "AR+MHC post split epilogue currently supports hc_mult=4");
-    P* tmps       = get_tmp_buf<P>(sg.signals[rank]);
-    const int lane = threadIdx.x;
-    const int n_packs = hidden_size / pack_size;
-    if(lane >= n_packs)
-        return;
-
-    for(int row = blockIdx.x; row < m; row += gridDim.x)
-    {
-        const int input_pack_idx = row * n_packs + lane;
-        P reduced_pack           = tmps[input_pack_idx];
-        A reduced;
-#pragma unroll
-        for(int v = 0; v < pack_size; ++v)
-            reduced[v] = upcast_s(reduced_pack[v]);
-
-#pragma unroll
-        for(int out_h = 0; out_h < hc_mult; ++out_h)
-        {
-            A out;
-            const float post_v = post_layer_mix[row * hc_mult + out_h];
-#pragma unroll
-            for(int v = 0; v < pack_size; ++v)
-                out[v] = reduced[v] * post_v;
-
-#pragma unroll
-            for(int in_h = 0; in_h < hc_mult; ++in_h)
-            {
-                const float comb_v =
-                    comb_res_mix[row * hc_mult * hc_mult + in_h * hc_mult + out_h];
-                const int residual_pack_idx =
-                    (row * residual_stride + in_h * hidden_size) / pack_size + lane;
-                P residual_pack = reinterpret_cast<P*>(residual)[residual_pack_idx];
-#pragma unroll
-                for(int v = 0; v < pack_size; ++v)
-                    out[v] += upcast_s(residual_pack[v]) * comb_v;
-            }
-
-            P out_pack = downcast<P>(out);
-            const int out_pack_idx =
-                (row * residual_stride + out_h * hidden_size) / pack_size + lane;
-            reinterpret_cast<P*>(next_residual)[out_pack_idx] = out_pack;
-        }
-    }
-}
+// Stage 2 for split AR+MHC(post) is launched via optimized mhc_post kernels on the
+// IPC tmp buffer (see launch_mhc_post_raw in fused_ar_mhc_post.cu).
 
 template <typename T, int NGPUS>
 void allreduce_mhc_post_split_launcher(RankData* _dp,
@@ -3098,14 +3038,6 @@ void allreduce_mhc_post_split_launcher(RankData* _dp,
         throw std::runtime_error("AR+MHC post split epilogue: unsupported NGPUS=" +
                                  std::to_string(NGPUS));
     }
-
-    constexpr int pack_size = 16 / sizeof(T);
-    const int block_size    = hidden_size / pack_size;
-    dim3 threadsPerBlock(block_size);
-    dim3 numBlocks(m);
-    local_device_mhc_post_from_tmp<T, 4><<<numBlocks, threadsPerBlock, 0, stream>>>(
-        sg, rank, residual, post_layer_mix, comb_res_mix, next_residual, m, hidden_size,
-        residual_stride);
 }
 
 using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
@@ -3225,6 +3157,12 @@ class CustomAllreduce
     std::vector<void*> graph_unreg_output_buffers_;
     // a map from IPC handles to opened IPC pointers
     std::map<IPC_KEY, char*> ipc_handles_;
+
+    template <typename T>
+    T* local_tmp_reduced_ptr() const
+    {
+        return reinterpret_cast<T*>(self_sg_ + 1);
+    }
 
     /**
      * meta is a pointer to device metadata and temporary buffer for allreduce.
@@ -4647,35 +4585,6 @@ void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
                                     int hidden_size,
                                     int residual_stride)
 {
-    constexpr int pack_size = 16 / sizeof(T);
-    if(input_hidden_dim != hidden_size)
-    {
-        throw std::runtime_error("AR+MHC post epilogue requires full hidden input");
-    }
-    if(hidden_size % pack_size != 0 || residual_stride % pack_size != 0)
-    {
-        throw std::runtime_error("AR+MHC post epilogue requires pack-aligned hidden/stride");
-    }
-
-    const int64_t size_bytes = (int64_t)m * input_hidden_dim * sizeof(T);
-    // Same 512 KiB budget as fused AR+RMSNorm: TP>=4 large tensors use
-    // reduce-scatter + local epilogue instead of 1-stage row-wise IPC reduce.
-    constexpr int64_t kSplitMinBytes = 512 * 1024;
-    if(world_size_ >= 4 && size_bytes > kSplitMinBytes)
-    {
-        dispatchAllReduceMhcPostSplit<T>(stream,
-                                         input,
-                                         next_residual,
-                                         residual,
-                                         post_layer_mix,
-                                         comb_res_mix,
-                                         m,
-                                         input_hidden_dim,
-                                         hidden_size,
-                                         residual_stride);
-        return;
-    }
-
     dispatchAllReduceMhcPost1Stage<T>(stream,
                                       input,
                                       next_residual,

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -3002,6 +3002,100 @@ using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
 static_assert(sizeof(IPC_KEY) == sizeof(hipIpcMemHandle_t));
 static_assert(alignof(IPC_KEY) == alignof(hipIpcMemHandle_t));
 
+// Large-M AR+MHC(post) epilogue: reduce input across ranks and write next_residual
+// directly. This mirrors mhc_post's math but avoids materializing layer_input.
+template <typename T, int ngpus, int hc_mult, bool two_way>
+__global__ void __launch_bounds__(1024, 1) allreduce_mhc_post_large_m_kernel(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    int rank,
+    T* __restrict__ next_residual,
+    T* __restrict__ residual,
+    float* __restrict__ post_layer_mix,
+    float* __restrict__ comb_res_mix,
+    int m,
+    int input_hidden_dim,
+    int hidden_size,
+    int residual_stride)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    static_assert(hc_mult == 4, "AR+MHC post epilogue currently supports hc_mult=4");
+
+    const int n_packs = hidden_size / pack_size;
+    const int lane    = two_way ? (threadIdx.x % n_packs) : threadIdx.x;
+    const int group   = two_way ? (threadIdx.x / n_packs) : 0;
+    __shared__ P s_reduced[512];
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int r = 0; r < ngpus; ++r)
+    {
+        ptrs[r] = reinterpret_cast<const P*>(_dp->ptrs[r]);
+    }
+
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int row = blockIdx.x; row < m; row += gridDim.x)
+    {
+        P reduced_pack;
+        if constexpr(two_way)
+        {
+            if(group == 0)
+            {
+                const int input_pack_idx = row * (input_hidden_dim / pack_size) + lane;
+                s_reduced[lane]          = packed_reduce<P, ngpus, A>(ptrs, input_pack_idx);
+            }
+            __syncthreads();
+            reduced_pack = s_reduced[lane];
+        }
+        else
+        {
+            const int input_pack_idx = row * (input_hidden_dim / pack_size) + lane;
+            reduced_pack             = packed_reduce<P, ngpus, A>(ptrs, input_pack_idx);
+        }
+        A reduced;
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            reduced[v] = upcast_s(reduced_pack[v]);
+
+#pragma unroll
+        for(int iter = 0; iter < (two_way ? 2 : hc_mult); ++iter)
+        {
+            const int out_h = two_way ? (iter * 2 + group) : iter;
+            A out;
+            const float post_v = post_layer_mix[row * hc_mult + out_h];
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+            {
+                out[v] = reduced[v] * post_v;
+            }
+
+#pragma unroll
+            for(int in_h = 0; in_h < hc_mult; ++in_h)
+            {
+                const float comb_v = comb_res_mix[row * hc_mult * hc_mult + in_h * hc_mult + out_h];
+                const int residual_pack_idx =
+                    (row * residual_stride + in_h * hidden_size) / pack_size + lane;
+                P residual_pack = reinterpret_cast<P*>(residual)[residual_pack_idx];
+#pragma unroll
+                for(int v = 0; v < pack_size; ++v)
+                {
+                    out[v] += upcast_s(residual_pack[v]) * comb_v;
+                }
+            }
+
+            P out_pack = downcast<P>(out);
+            const int out_pack_idx =
+                (row * residual_stride + out_h * hidden_size) / pack_size + lane;
+            reinterpret_cast<P*>(next_residual)[out_pack_idx] = out_pack;
+        }
+        if constexpr(two_way)
+            __syncthreads();
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
 class CustomAllreduce
 {
     public:
@@ -4371,6 +4465,66 @@ void dispatchFusedQKNormAllReduce(hipStream_t stream,
 #undef DISPATCH_QKNORM_AR_FUSION_KERNEL
 }
 
+template <typename T>
+void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
+                                    T* input,
+                                    T* next_residual,
+                                    T* residual,
+                                    float* post_layer_mix,
+                                    float* comb_res_mix,
+                                    int m,
+                                    int input_hidden_dim,
+                                    int hidden_size,
+                                    int residual_stride)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    if(input_hidden_dim != hidden_size)
+    {
+        throw std::runtime_error("AR+MHC post epilogue requires full hidden input");
+    }
+    if(hidden_size % pack_size != 0 || residual_stride % pack_size != 0)
+    {
+        throw std::runtime_error("AR+MHC post epilogue requires pack-aligned hidden/stride");
+    }
+    const int n_packs = hidden_size / pack_size;
+    if(n_packs > 512)
+    {
+        throw std::runtime_error("AR+MHC post epilogue hidden dim too large for two-way CTA");
+    }
+
+    RankData* ptrs = get_buffer_RD(stream, input);
+    const bool use_two_way = m >= 8192;
+    dim3 block(use_two_way ? n_packs * 2 : n_packs);
+    dim3 grid(std::min(m, kMaxBlocks));
+
+#define DISPATCH_AR_MHC_POST_IMPL(NGPUS, TWO_WAY)                               \
+    allreduce_mhc_post_large_m_kernel<T, NGPUS, 4, TWO_WAY>                     \
+        <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, rank_, next_residual, \
+                                     residual, post_layer_mix, comb_res_mix, m, \
+                                     input_hidden_dim, hidden_size,             \
+                                     residual_stride)
+
+#define DISPATCH_AR_MHC_POST(NGPUS)                                             \
+    do {                                                                        \
+        if(use_two_way)                                                         \
+            DISPATCH_AR_MHC_POST_IMPL(NGPUS, true);                             \
+        else                                                                    \
+            DISPATCH_AR_MHC_POST_IMPL(NGPUS, false);                            \
+    } while(0)
+
+    switch(world_size_)
+    {
+    case 8: DISPATCH_AR_MHC_POST(8); break;
+    case 4: DISPATCH_AR_MHC_POST(4); break;
+    case 2: DISPATCH_AR_MHC_POST(2); break;
+    default:
+        throw std::runtime_error("AR+MHC post epilogue: unsupported world_size=" +
+                                 std::to_string(world_size_));
+    }
+#undef DISPATCH_AR_MHC_POST_IMPL
+#undef DISPATCH_AR_MHC_POST
+}
+
 ~CustomAllreduce()
 {
     for(auto [_, ptr] : ipc_handles_)
@@ -4378,7 +4532,7 @@ void dispatchFusedQKNormAllReduce(hipStream_t stream,
         HIP_CALL(hipIpcCloseMemHandle(ptr));
     }
 }
-}; // namespace aiter
+};
 /**
  * To inspect PTX/SASS, copy paste this header file to compiler explorer and add
  a template instantiation:

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -2998,6 +2998,116 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
             sg, rank, residual_inp, residual_out, output, weight, scale_out, size, hidden_dim, eps);
 }
 
+// Stage 2 for split AR+MHC(post): read all-reduced activations from tmp and
+// apply mhc_post epilogue without materializing reduced layer_input.
+template <typename T, int hc_mult>
+__global__ void __launch_bounds__(1024, 1) local_device_mhc_post_from_tmp(
+    RankSignals sg,
+    int rank,
+    T* __restrict__ residual,
+    float* __restrict__ post_layer_mix,
+    float* __restrict__ comb_res_mix,
+    T* __restrict__ next_residual,
+    int m,
+    int hidden_size,
+    int residual_stride)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    static_assert(hc_mult == 4, "AR+MHC post split epilogue currently supports hc_mult=4");
+    P* tmps       = get_tmp_buf<P>(sg.signals[rank]);
+    const int lane = threadIdx.x;
+    const int n_packs = hidden_size / pack_size;
+    if(lane >= n_packs)
+        return;
+
+    for(int row = blockIdx.x; row < m; row += gridDim.x)
+    {
+        const int input_pack_idx = row * n_packs + lane;
+        P reduced_pack           = tmps[input_pack_idx];
+        A reduced;
+#pragma unroll
+        for(int v = 0; v < pack_size; ++v)
+            reduced[v] = upcast_s(reduced_pack[v]);
+
+#pragma unroll
+        for(int out_h = 0; out_h < hc_mult; ++out_h)
+        {
+            A out;
+            const float post_v = post_layer_mix[row * hc_mult + out_h];
+#pragma unroll
+            for(int v = 0; v < pack_size; ++v)
+                out[v] = reduced[v] * post_v;
+
+#pragma unroll
+            for(int in_h = 0; in_h < hc_mult; ++in_h)
+            {
+                const float comb_v =
+                    comb_res_mix[row * hc_mult * hc_mult + in_h * hc_mult + out_h];
+                const int residual_pack_idx =
+                    (row * residual_stride + in_h * hidden_size) / pack_size + lane;
+                P residual_pack = reinterpret_cast<P*>(residual)[residual_pack_idx];
+#pragma unroll
+                for(int v = 0; v < pack_size; ++v)
+                    out[v] += upcast_s(residual_pack[v]) * comb_v;
+            }
+
+            P out_pack = downcast<P>(out);
+            const int out_pack_idx =
+                (row * residual_stride + out_h * hidden_size) / pack_size + lane;
+            reinterpret_cast<P*>(next_residual)[out_pack_idx] = out_pack;
+        }
+    }
+}
+
+template <typename T, int NGPUS>
+void allreduce_mhc_post_split_launcher(RankData* _dp,
+                                       RankSignals sg,
+                                       Signal* self_sg,
+                                       int rank,
+                                       T* next_residual,
+                                       T* residual,
+                                       float* post_layer_mix,
+                                       float* comb_res_mix,
+                                       int m,
+                                       int input_hidden_dim,
+                                       int hidden_size,
+                                       int residual_stride,
+                                       hipStream_t stream)
+{
+    const int size = m * input_hidden_dim;
+    dim3 block(512);
+    int block_num = ((size / NGPUS) + 512 - 1) / 512;
+    dim3 grid(std::min(block_num, kMaxBlocks));
+    switch(NGPUS)
+    {
+    case 8:
+        reduce_scatter_cross_device_store<T, 8><<<grid, block, 0, stream>>>(
+            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim);
+        break;
+    case 4:
+        reduce_scatter_cross_device_store<T, 4><<<grid, block, 0, stream>>>(
+            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim);
+        break;
+    case 2:
+        reduce_scatter_cross_device_store<T, 2><<<grid, block, 0, stream>>>(
+            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim);
+        break;
+    default:
+        throw std::runtime_error("AR+MHC post split epilogue: unsupported NGPUS=" +
+                                 std::to_string(NGPUS));
+    }
+
+    constexpr int pack_size = 16 / sizeof(T);
+    const int block_size    = hidden_size / pack_size;
+    dim3 threadsPerBlock(block_size);
+    dim3 numBlocks(m);
+    local_device_mhc_post_from_tmp<T, 4><<<numBlocks, threadsPerBlock, 0, stream>>>(
+        sg, rank, residual, post_layer_mix, comb_res_mix, next_residual, m, hidden_size,
+        residual_stride);
+}
+
 using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
 static_assert(sizeof(IPC_KEY) == sizeof(hipIpcMemHandle_t));
 static_assert(alignof(IPC_KEY) == alignof(hipIpcMemHandle_t));
@@ -4523,6 +4633,47 @@ void dispatchAllReduceMhcPostLargeM(hipStream_t stream,
     }
 #undef DISPATCH_AR_MHC_POST_IMPL
 #undef DISPATCH_AR_MHC_POST
+}
+
+template <typename T>
+void dispatchAllReduceMhcPostSplit(hipStream_t stream,
+                                   T* input,
+                                   T* next_residual,
+                                   T* residual,
+                                   float* post_layer_mix,
+                                   float* comb_res_mix,
+                                   int m,
+                                   int input_hidden_dim,
+                                   int hidden_size,
+                                   int residual_stride)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    if(input_hidden_dim != hidden_size)
+    {
+        throw std::runtime_error("AR+MHC post split epilogue requires full hidden input");
+    }
+    if(hidden_size % pack_size != 0 || residual_stride % pack_size != 0)
+    {
+        throw std::runtime_error("AR+MHC post split epilogue requires pack-aligned hidden/stride");
+    }
+
+    RankData* ptrs = get_buffer_RD(stream, input);
+
+#define DISPATCH_AR_MHC_POST_SPLIT(NGPUS)                                              \
+    allreduce_mhc_post_split_launcher<T, NGPUS>(                                       \
+        ptrs, sg_, self_sg_, rank_, next_residual, residual, post_layer_mix,            \
+        comb_res_mix, m, input_hidden_dim, hidden_size, residual_stride, stream)
+
+    switch(world_size_)
+    {
+    case 8: DISPATCH_AR_MHC_POST_SPLIT(8); break;
+    case 4: DISPATCH_AR_MHC_POST_SPLIT(4); break;
+    case 2: DISPATCH_AR_MHC_POST_SPLIT(2); break;
+    default:
+        throw std::runtime_error("AR+MHC post split epilogue: unsupported world_size=" +
+                                 std::to_string(world_size_));
+    }
+#undef DISPATCH_AR_MHC_POST_SPLIT
 }
 
 ~CustomAllreduce()

--- a/csrc/include/fused_ar_mhc_post.h
+++ b/csrc/include/fused_ar_mhc_post.h
@@ -19,4 +19,15 @@ void fused_allreduce_mhc_post_only(fptr_t _fa,
                                    int64_t reg_ptr,
                                    int64_t reg_bytes);
 
+void fused_allreduce_mhc_post_split(fptr_t _fa,
+                                    torch::Tensor& inp,
+                                    torch::Tensor& next_residual,
+                                    torch::Tensor& residual_in,
+                                    torch::Tensor& post_layer_mix,
+                                    torch::Tensor& comb_res_mix,
+                                    bool use_new,
+                                    bool open_fp8_quant,
+                                    int64_t reg_ptr,
+                                    int64_t reg_bytes);
+
 } // namespace aiter

--- a/csrc/include/fused_ar_mhc_post.h
+++ b/csrc/include/fused_ar_mhc_post.h
@@ -19,6 +19,17 @@ void fused_allreduce_mhc_post_only(fptr_t _fa,
                                    int64_t reg_ptr,
                                    int64_t reg_bytes);
 
+void fused_allreduce_mhc_post_one_stage(fptr_t _fa,
+                                        torch::Tensor& inp,
+                                        torch::Tensor& next_residual,
+                                        torch::Tensor& residual_in,
+                                        torch::Tensor& post_layer_mix,
+                                        torch::Tensor& comb_res_mix,
+                                        bool use_new,
+                                        bool open_fp8_quant,
+                                        int64_t reg_ptr,
+                                        int64_t reg_bytes);
+
 void fused_allreduce_mhc_post_split(fptr_t _fa,
                                     torch::Tensor& inp,
                                     torch::Tensor& next_residual,

--- a/csrc/include/fused_ar_mhc_post.h
+++ b/csrc/include/fused_ar_mhc_post.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include <torch/extension.h>
+#include "custom_all_reduce.h"
+
+namespace aiter {
+
+void fused_allreduce_mhc_post_only(fptr_t _fa,
+                                   torch::Tensor& inp,
+                                   torch::Tensor& next_residual,
+                                   torch::Tensor& residual_in,
+                                   torch::Tensor& post_layer_mix,
+                                   torch::Tensor& comb_res_mix,
+                                   bool use_new,
+                                   bool open_fp8_quant,
+                                   int64_t reg_ptr,
+                                   int64_t reg_bytes);
+
+} // namespace aiter

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <ATen/hip/HIPContext.h>
 #include <torch/extension.h>
 
 namespace aiter {
@@ -45,6 +46,19 @@ void mhc_post(torch::Tensor& out,            // (m, hc_mult, hidden_size)
               torch::Tensor& post_layer_mix, // (m, hc_mult)
               torch::Tensor& comb_res_mix,   // (m, hc_mult, hc_mult)
               int store_nt                   = -1);
+// Optimized mhc_post launch on raw device pointers (used by fused AR+MHC split epilogue).
+void launch_mhc_post_raw(hipStream_t stream,
+                         c10::ScalarType dtype,
+                         void* out,
+                         void* x,
+                         void* residual,
+                         void* post_layer_mix,
+                         void* comb_res_mix,
+                         int m,
+                         int hidden_size,
+                         int x_stride,
+                         int residual_stride,
+                         int store_nt = -1);
 void mhc_fused_post_pre_gemm_sqrsum(
     torch::Tensor& gemm_out_mul,    // (split_k, m, hc_mult3)
     torch::Tensor& gemm_out_sqrsum, // (split_k, m)

--- a/csrc/kernels/fused_ar_mhc_post.cu
+++ b/csrc/kernels/fused_ar_mhc_post.cu
@@ -113,6 +113,36 @@ void run_ar_mhc_post_split(CustomAllreduce* fa,
                                          residual_stride);
 }
 
+template <typename T>
+void run_ar_mhc_post_1stage(CustomAllreduce* fa,
+                            hipStream_t stream,
+                            T* inp_ptr,
+                            T* next_residual_ptr,
+                            T* residual_ptr,
+                            float* post_layer_mix_ptr,
+                            float* comb_res_mix_ptr,
+                            int m,
+                            int input_n,
+                            int hidden_size,
+                            int residual_stride,
+                            int64_t reg_ptr,
+                            int64_t reg_bytes)
+{
+    void* actual_inp = inp_ptr;
+    if(reg_ptr != 0)
+        actual_inp = (void*)reg_ptr;
+    fa->dispatchAllReduceMhcPost1Stage<T>(stream,
+                                          reinterpret_cast<T*>(actual_inp),
+                                          next_residual_ptr,
+                                          residual_ptr,
+                                          post_layer_mix_ptr,
+                                          comb_res_mix_ptr,
+                                          m,
+                                          input_n,
+                                          hidden_size,
+                                          residual_stride);
+}
+
 } // namespace
 
 void fused_allreduce_mhc_post_only(fptr_t _fa,
@@ -178,6 +208,72 @@ void fused_allreduce_mhc_post_only(fptr_t _fa,
     }
     default:
         throw std::runtime_error("fused AR+MHC post only supports fp16/bf16 activations");
+    }
+}
+
+void fused_allreduce_mhc_post_one_stage(fptr_t _fa,
+                                        torch::Tensor& inp,
+                                        torch::Tensor& next_residual,
+                                        torch::Tensor& residual_in,
+                                        torch::Tensor& post_layer_mix,
+                                        torch::Tensor& comb_res_mix,
+                                        bool use_new,
+                                        bool open_fp8_quant,
+                                        int64_t reg_ptr,
+                                        int64_t reg_bytes)
+{
+    (void)use_new;
+    (void)open_fp8_quant;
+    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
+    hipStream_t stream = at::hip::getCurrentHIPStream();
+    auto fa            = reinterpret_cast<CustomAllreduce*>(_fa);
+    auto inp_at        = make_aiter_tensor(inp);
+
+    const int m       = static_cast<int>(inp_at.numel() / inp_at.size(-1));
+    const int input_n = static_cast<int>(inp_at.size(-1));
+    const int hidden  = static_cast<int>(residual_in.size(-1));
+    const int stride  = static_cast<int>(residual_in.stride(0));
+
+    copy_input_to_registered_buffer(inp_at, m, input_n, stream, reg_ptr, reg_bytes);
+
+    switch(inp.scalar_type())
+    {
+    case at::ScalarType::BFloat16: {
+        run_ar_mhc_post_1stage<opus::bf16_t>(
+            fa,
+            stream,
+            reinterpret_cast<opus::bf16_t*>(inp.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(next_residual.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(residual_in.data_ptr()),
+            reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+            reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+            m,
+            input_n,
+            hidden,
+            stride,
+            reg_ptr,
+            reg_bytes);
+        break;
+    }
+    case at::ScalarType::Half: {
+        run_ar_mhc_post_1stage<opus::fp16_t>(
+            fa,
+            stream,
+            reinterpret_cast<opus::fp16_t*>(inp.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(next_residual.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(residual_in.data_ptr()),
+            reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+            reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+            m,
+            input_n,
+            hidden,
+            stride,
+            reg_ptr,
+            reg_bytes);
+        break;
+    }
+    default:
+        throw std::runtime_error("fused AR+MHC post one-stage supports fp16/bf16 activations");
     }
 }
 

--- a/csrc/kernels/fused_ar_mhc_post.cu
+++ b/csrc/kernels/fused_ar_mhc_post.cu
@@ -3,10 +3,12 @@
 
 #include "fused_ar_mhc_post.h"
 #include "custom_all_reduce.cuh"
+#include "mhc.h"
 #include "aiter_enum.h"
 #include "aiter_hip_common.h"
 #include "py_itfs_common.h"
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/core/ScalarType.h>
 
 namespace aiter {
 
@@ -54,6 +56,31 @@ void copy_input_to_registered_buffer(const aiter_tensor_t& inp,
 }
 
 template <typename T>
+c10::ScalarType scalar_type_for_ar_mhc_post()
+{
+    if constexpr(std::is_same_v<T, opus::bf16_t>)
+        return c10::ScalarType::BFloat16;
+    else
+        return c10::ScalarType::Half;
+}
+
+template <typename T>
+void run_ar_mhc_post_split(CustomAllreduce* fa,
+                           hipStream_t stream,
+                           c10::ScalarType dtype,
+                           T* inp_ptr,
+                           T* next_residual_ptr,
+                           T* residual_ptr,
+                           float* post_layer_mix_ptr,
+                           float* comb_res_mix_ptr,
+                           int m,
+                           int input_n,
+                           int hidden_size,
+                           int residual_stride,
+                           int64_t reg_ptr,
+                           int64_t reg_bytes);
+
+template <typename T>
 void run_ar_mhc_post_large_m(CustomAllreduce* fa,
                              hipStream_t stream,
                              T* inp_ptr,
@@ -68,10 +95,31 @@ void run_ar_mhc_post_large_m(CustomAllreduce* fa,
                              int64_t reg_ptr,
                              int64_t reg_bytes)
 {
+    const int64_t size_bytes = static_cast<int64_t>(m) * input_n * static_cast<int64_t>(sizeof(T));
+    constexpr int64_t kSplitMinBytes = 512 * 1024;
+    if(fa->world_size_ >= 4 && size_bytes > kSplitMinBytes)
+    {
+        run_ar_mhc_post_split(fa,
+                              stream,
+                              scalar_type_for_ar_mhc_post<T>(),
+                              inp_ptr,
+                              next_residual_ptr,
+                              residual_ptr,
+                              post_layer_mix_ptr,
+                              comb_res_mix_ptr,
+                              m,
+                              input_n,
+                              hidden_size,
+                              residual_stride,
+                              reg_ptr,
+                              reg_bytes);
+        return;
+    }
+
     void* actual_inp = inp_ptr;
     if(reg_ptr != 0)
         actual_inp = (void*)reg_ptr;
-    fa->dispatchAllReduceMhcPostLargeM<T>(stream,
+    fa->dispatchAllReduceMhcPost1Stage<T>(stream,
                                           reinterpret_cast<T*>(actual_inp),
                                           next_residual_ptr,
                                           residual_ptr,
@@ -86,6 +134,7 @@ void run_ar_mhc_post_large_m(CustomAllreduce* fa,
 template <typename T>
 void run_ar_mhc_post_split(CustomAllreduce* fa,
                            hipStream_t stream,
+                           c10::ScalarType dtype,
                            T* inp_ptr,
                            T* next_residual_ptr,
                            T* residual_ptr,
@@ -111,6 +160,17 @@ void run_ar_mhc_post_split(CustomAllreduce* fa,
                                          input_n,
                                          hidden_size,
                                          residual_stride);
+    launch_mhc_post_raw(stream,
+                        dtype,
+                        next_residual_ptr,
+                        fa->local_tmp_reduced_ptr<T>(),
+                        residual_ptr,
+                        post_layer_mix_ptr,
+                        comb_res_mix_ptr,
+                        m,
+                        hidden_size,
+                        hidden_size,
+                        residual_stride);
 }
 
 template <typename T>
@@ -308,6 +368,7 @@ void fused_allreduce_mhc_post_split(fptr_t _fa,
         run_ar_mhc_post_split<opus::bf16_t>(
             fa,
             stream,
+            at::ScalarType::BFloat16,
             reinterpret_cast<opus::bf16_t*>(inp.data_ptr()),
             reinterpret_cast<opus::bf16_t*>(next_residual.data_ptr()),
             reinterpret_cast<opus::bf16_t*>(residual_in.data_ptr()),
@@ -325,6 +386,7 @@ void fused_allreduce_mhc_post_split(fptr_t _fa,
         run_ar_mhc_post_split<opus::fp16_t>(
             fa,
             stream,
+            at::ScalarType::Half,
             reinterpret_cast<opus::fp16_t*>(inp.data_ptr()),
             reinterpret_cast<opus::fp16_t*>(next_residual.data_ptr()),
             reinterpret_cast<opus::fp16_t*>(residual_in.data_ptr()),

--- a/csrc/kernels/fused_ar_mhc_post.cu
+++ b/csrc/kernels/fused_ar_mhc_post.cu
@@ -83,6 +83,36 @@ void run_ar_mhc_post_large_m(CustomAllreduce* fa,
                                           residual_stride);
 }
 
+template <typename T>
+void run_ar_mhc_post_split(CustomAllreduce* fa,
+                           hipStream_t stream,
+                           T* inp_ptr,
+                           T* next_residual_ptr,
+                           T* residual_ptr,
+                           float* post_layer_mix_ptr,
+                           float* comb_res_mix_ptr,
+                           int m,
+                           int input_n,
+                           int hidden_size,
+                           int residual_stride,
+                           int64_t reg_ptr,
+                           int64_t reg_bytes)
+{
+    void* actual_inp = inp_ptr;
+    if(reg_ptr != 0)
+        actual_inp = (void*)reg_ptr;
+    fa->dispatchAllReduceMhcPostSplit<T>(stream,
+                                         reinterpret_cast<T*>(actual_inp),
+                                         next_residual_ptr,
+                                         residual_ptr,
+                                         post_layer_mix_ptr,
+                                         comb_res_mix_ptr,
+                                         m,
+                                         input_n,
+                                         hidden_size,
+                                         residual_stride);
+}
+
 } // namespace
 
 void fused_allreduce_mhc_post_only(fptr_t _fa,
@@ -148,6 +178,72 @@ void fused_allreduce_mhc_post_only(fptr_t _fa,
     }
     default:
         throw std::runtime_error("fused AR+MHC post only supports fp16/bf16 activations");
+    }
+}
+
+void fused_allreduce_mhc_post_split(fptr_t _fa,
+                                    torch::Tensor& inp,
+                                    torch::Tensor& next_residual,
+                                    torch::Tensor& residual_in,
+                                    torch::Tensor& post_layer_mix,
+                                    torch::Tensor& comb_res_mix,
+                                    bool use_new,
+                                    bool open_fp8_quant,
+                                    int64_t reg_ptr,
+                                    int64_t reg_bytes)
+{
+    (void)use_new;
+    (void)open_fp8_quant;
+    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
+    hipStream_t stream = at::hip::getCurrentHIPStream();
+    auto fa            = reinterpret_cast<CustomAllreduce*>(_fa);
+    auto inp_at        = make_aiter_tensor(inp);
+
+    const int m       = static_cast<int>(inp_at.numel() / inp_at.size(-1));
+    const int input_n = static_cast<int>(inp_at.size(-1));
+    const int hidden  = static_cast<int>(residual_in.size(-1));
+    const int stride  = static_cast<int>(residual_in.stride(0));
+
+    copy_input_to_registered_buffer(inp_at, m, input_n, stream, reg_ptr, reg_bytes);
+
+    switch(inp.scalar_type())
+    {
+    case at::ScalarType::BFloat16: {
+        run_ar_mhc_post_split<opus::bf16_t>(
+            fa,
+            stream,
+            reinterpret_cast<opus::bf16_t*>(inp.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(next_residual.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(residual_in.data_ptr()),
+            reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+            reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+            m,
+            input_n,
+            hidden,
+            stride,
+            reg_ptr,
+            reg_bytes);
+        break;
+    }
+    case at::ScalarType::Half: {
+        run_ar_mhc_post_split<opus::fp16_t>(
+            fa,
+            stream,
+            reinterpret_cast<opus::fp16_t*>(inp.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(next_residual.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(residual_in.data_ptr()),
+            reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+            reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+            m,
+            input_n,
+            hidden,
+            stride,
+            reg_ptr,
+            reg_bytes);
+        break;
+    }
+    default:
+        throw std::runtime_error("fused AR+MHC post split supports fp16/bf16 activations");
     }
 }
 

--- a/csrc/kernels/fused_ar_mhc_post.cu
+++ b/csrc/kernels/fused_ar_mhc_post.cu
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "fused_ar_mhc_post.h"
+#include "custom_all_reduce.cuh"
+#include "aiter_enum.h"
+#include "aiter_hip_common.h"
+#include "py_itfs_common.h"
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+
+namespace aiter {
+
+namespace {
+
+aiter_tensor_t make_aiter_tensor(const torch::Tensor& t)
+{
+    AITER_CHECK(t.is_cuda(), "fused AR+MHC requires CUDA tensors");
+    AITER_CHECK(t.dim() <= 8, "tensor rank too large for aiter_tensor_t");
+
+    aiter_tensor_t at{};
+    at.ptr     = t.data_ptr();
+    at.numel_  = static_cast<size_t>(t.numel());
+    at.ndim    = t.dim();
+    for(int i = 0; i < t.dim(); ++i)
+    {
+        at.shape[i]   = t.size(i);
+        at.strides[i] = t.stride(i);
+    }
+    at.device_id = static_cast<int>(t.device().index());
+    switch(t.scalar_type())
+    {
+    case at::ScalarType::Float: at.dtype_ = AITER_DTYPE_fp32; break;
+    case at::ScalarType::Half: at.dtype_ = AITER_DTYPE_fp16; break;
+    case at::ScalarType::BFloat16: at.dtype_ = AITER_DTYPE_bf16; break;
+    default: throw std::runtime_error("fused AR+MHC only supports fp32/fp16/bf16");
+    }
+    return at;
+}
+
+void copy_input_to_registered_buffer(const aiter_tensor_t& inp,
+                                     int m,
+                                     int input_n,
+                                     hipStream_t stream,
+                                     int64_t reg_ptr,
+                                     int64_t reg_bytes)
+{
+    int64_t data_bytes = inp.numel() * inp.element_size();
+    if(reg_ptr == 0)
+        return;
+    if(data_bytes > reg_bytes)
+        throw std::runtime_error("registered buffer is too small to contain the input");
+    HIP_CALL(hipMemcpyAsync((void*)reg_ptr, inp.data_ptr(), data_bytes,
+                            hipMemcpyDeviceToDevice, stream));
+}
+
+template <typename T>
+void run_ar_mhc_post_large_m(CustomAllreduce* fa,
+                             hipStream_t stream,
+                             T* inp_ptr,
+                             T* next_residual_ptr,
+                             T* residual_ptr,
+                             float* post_layer_mix_ptr,
+                             float* comb_res_mix_ptr,
+                             int m,
+                             int input_n,
+                             int hidden_size,
+                             int residual_stride,
+                             int64_t reg_ptr,
+                             int64_t reg_bytes)
+{
+    void* actual_inp = inp_ptr;
+    if(reg_ptr != 0)
+        actual_inp = (void*)reg_ptr;
+    fa->dispatchAllReduceMhcPostLargeM<T>(stream,
+                                          reinterpret_cast<T*>(actual_inp),
+                                          next_residual_ptr,
+                                          residual_ptr,
+                                          post_layer_mix_ptr,
+                                          comb_res_mix_ptr,
+                                          m,
+                                          input_n,
+                                          hidden_size,
+                                          residual_stride);
+}
+
+} // namespace
+
+void fused_allreduce_mhc_post_only(fptr_t _fa,
+                                   torch::Tensor& inp,
+                                   torch::Tensor& next_residual,
+                                   torch::Tensor& residual_in,
+                                   torch::Tensor& post_layer_mix,
+                                   torch::Tensor& comb_res_mix,
+                                   bool use_new,
+                                   bool open_fp8_quant,
+                                   int64_t reg_ptr,
+                                   int64_t reg_bytes)
+{
+    (void)use_new;
+    (void)open_fp8_quant;
+    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
+    hipStream_t stream = at::hip::getCurrentHIPStream();
+    auto fa            = reinterpret_cast<CustomAllreduce*>(_fa);
+    auto inp_at        = make_aiter_tensor(inp);
+
+    const int m       = static_cast<int>(inp_at.numel() / inp_at.size(-1));
+    const int input_n = static_cast<int>(inp_at.size(-1));
+    const int hidden  = static_cast<int>(residual_in.size(-1));
+    const int stride  = static_cast<int>(residual_in.stride(0));
+
+    copy_input_to_registered_buffer(inp_at, m, input_n, stream, reg_ptr, reg_bytes);
+
+    switch(inp.scalar_type())
+    {
+    case at::ScalarType::BFloat16: {
+        run_ar_mhc_post_large_m<opus::bf16_t>(
+            fa,
+            stream,
+            reinterpret_cast<opus::bf16_t*>(inp.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(next_residual.data_ptr()),
+            reinterpret_cast<opus::bf16_t*>(residual_in.data_ptr()),
+            reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+            reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+            m,
+            input_n,
+            hidden,
+            stride,
+            reg_ptr,
+            reg_bytes);
+        break;
+    }
+    case at::ScalarType::Half: {
+        run_ar_mhc_post_large_m<opus::fp16_t>(
+            fa,
+            stream,
+            reinterpret_cast<opus::fp16_t*>(inp.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(next_residual.data_ptr()),
+            reinterpret_cast<opus::fp16_t*>(residual_in.data_ptr()),
+            reinterpret_cast<float*>(post_layer_mix.data_ptr()),
+            reinterpret_cast<float*>(comb_res_mix.data_ptr()),
+            m,
+            input_n,
+            hidden,
+            stride,
+            reg_ptr,
+            reg_bytes);
+        break;
+    }
+    default:
+        throw std::runtime_error("fused AR+MHC post only supports fp16/bf16 activations");
+    }
+}
+
+} // namespace aiter

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -1171,6 +1171,36 @@ namespace aiter {
     }
 
 
+#define MHC_POST_KERNEL_IMPL_RAW_(kernel_name, hidden_size, residual_block, store_nt) \
+    AITER_CHECK(hidden_size % residual_block == 0, "hidden_size must be divisible by residual_block"); \
+    AITER_CHECK(hidden_size >= residual_block * 2, "hidden_size must be >= residual_block * 2 stages prefetch"); \
+    int block_size = 4 * WARP_SIZE; \
+    int num_tg_cu = 32 / (block_size / WARP_SIZE); \
+    int max_k_blocks = min(cu_num * num_tg_cu / m, hidden_size / (residual_block)); \
+    if (max_k_blocks < 1) max_k_blocks = 1; \
+    int k_blocks = max_k_blocks; \
+    for(; k_blocks > 1; k_blocks--) { \
+        if (hidden_size % (k_blocks * residual_block) == 0 && hidden_size / k_blocks >= residual_block) break; \
+    } \
+    int sub_hidden_size = hidden_size / k_blocks; \
+    dim3 grid(m, k_blocks); \
+    dim3 block(block_size); \
+    AITER_DISPATCH_FLOATING16_TYPES(dtype, "mhc_post_raw", [&] { \
+        using DTYPE_I = typename t2opus<scalar_t>::type; \
+        kernel_name<DTYPE_I, 4, 4, residual_block, store_nt><<<grid, block, 0, stream>>>( \
+            reinterpret_cast<DTYPE_I*>(out), \
+            reinterpret_cast<DTYPE_I*>(x), \
+            reinterpret_cast<DTYPE_I*>(residual), \
+            reinterpret_cast<float*>(post_layer_mix), \
+            reinterpret_cast<float*>(comb_res_mix), \
+            m, \
+            hidden_size, \
+            x_stride, \
+            residual_stride, \
+            sub_hidden_size \
+        ); \
+    });
+
 #define MHC_POST_KERNEL_IMPL_(kernel_name, hidden_size, residual_block, store_nt) \
     AITER_CHECK(hidden_size % residual_block == 0, "hidden_size must be divisible by residual_block"); \
     AITER_CHECK(hidden_size >= residual_block * 2, "hidden_size must be >= residual_block * 2 stages prefetch"); \
@@ -1220,6 +1250,19 @@ namespace aiter {
         AITER_CHECK(false, "hidden_size must be divisible by 256"); \
     }
 
+#define MHC_POST_KERNEL_DISPATCH_RAW(hidden_size, store_nt_val) \
+    do { \
+        if (arch_id != "gfx942" && hidden_size % 1024 == 0) { \
+            MHC_POST_KERNEL_IMPL_RAW_(mhc_post_kernel, hidden_size, 1024, store_nt_val); \
+        } else if (hidden_size % 512 == 0) { \
+            MHC_POST_KERNEL_IMPL_RAW_(mhc_post_kernel, hidden_size, 512, store_nt_val); \
+        } else if (hidden_size % 256 == 0) { \
+            MHC_POST_KERNEL_IMPL_RAW_(mhc_post_kernel_x2vgpr, hidden_size, 256, store_nt_val); \
+        } else { \
+            AITER_CHECK(false, "hidden_size must be divisible by 256"); \
+        } \
+    } while (0)
+
 #define MHC_POST_KERNEL_DISPATCH(hidden_size) \
     do { \
         if (m > 8 * cu_num) { \
@@ -1228,6 +1271,42 @@ namespace aiter {
             MHC_POST_KERNEL_DISPATCH_NT(hidden_size, false); \
         } \
     } while (0)
+
+    void launch_mhc_post_raw(hipStream_t stream,
+                             c10::ScalarType dtype,
+                             void* out,
+                             void* x,
+                             void* residual,
+                             void* post_layer_mix,
+                             void* comb_res_mix,
+                             int m,
+                             int hidden_size,
+                             int x_stride,
+                             int residual_stride,
+                             int store_nt)
+    {
+        const int cu_num = get_num_cu_func();
+        const std::string arch_id = get_gpu_arch();
+        if(store_nt < 0)
+        {
+            if(m > 8 * cu_num)
+            {
+                MHC_POST_KERNEL_DISPATCH_RAW(hidden_size, true);
+            }
+            else
+            {
+                MHC_POST_KERNEL_DISPATCH_RAW(hidden_size, false);
+            }
+        }
+        else if(store_nt != 0)
+        {
+            MHC_POST_KERNEL_DISPATCH_RAW(hidden_size, true);
+        }
+        else
+        {
+            MHC_POST_KERNEL_DISPATCH_RAW(hidden_size, false);
+        }
+    }
 
     void mhc_post(
         torch::Tensor& out,
@@ -1246,15 +1325,18 @@ namespace aiter {
 
         const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(residual));
         const hipStream_t stream = at::hip::getCurrentHIPStream();
-        const int cu_num = get_num_cu_func();
-        const std::string arch_id = get_gpu_arch();
-        if (store_nt < 0) {
-            MHC_POST_KERNEL_DISPATCH(hidden_size);
-        } else if (store_nt != 0) {
-            MHC_POST_KERNEL_DISPATCH_NT(hidden_size, true);
-        } else {
-            MHC_POST_KERNEL_DISPATCH_NT(hidden_size, false);
-        }
+        launch_mhc_post_raw(stream,
+                            x.scalar_type(),
+                            out.data_ptr(),
+                            x.data_ptr(),
+                            residual.data_ptr(),
+                            post_layer_mix.data_ptr(),
+                            comb_res_mix.data_ptr(),
+                            m,
+                            hidden_size,
+                            x_stride,
+                            residual_stride,
+                            store_nt);
     }
 
 

--- a/csrc/pybind/fused_ar_mhc_post_pybind.cu
+++ b/csrc/pybind/fused_ar_mhc_post_pybind.cu
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include <torch/extension.h>
+#include "aiter_stream.h"
+#include "fused_ar_mhc_post.h"
+#include "rocm_ops.hpp"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND;
+    m.def("fused_allreduce_mhc_post_only",
+          &aiter::fused_allreduce_mhc_post_only,
+          py::arg("_fa"),
+          py::arg("inp"),
+          py::arg("next_residual"),
+          py::arg("residual_in"),
+          py::arg("post_layer_mix"),
+          py::arg("comb_res_mix"),
+          py::arg("use_new") = true,
+          py::arg("open_fp8_quant") = false,
+          py::arg("reg_ptr") = static_cast<int64_t>(0),
+          py::arg("reg_bytes") = static_cast<int64_t>(0));
+}

--- a/csrc/pybind/fused_ar_mhc_post_pybind.cu
+++ b/csrc/pybind/fused_ar_mhc_post_pybind.cu
@@ -21,6 +21,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
           py::arg("open_fp8_quant") = false,
           py::arg("reg_ptr") = static_cast<int64_t>(0),
           py::arg("reg_bytes") = static_cast<int64_t>(0));
+    m.def("fused_allreduce_mhc_post_one_stage",
+          &aiter::fused_allreduce_mhc_post_one_stage,
+          py::arg("_fa"),
+          py::arg("inp"),
+          py::arg("next_residual"),
+          py::arg("residual_in"),
+          py::arg("post_layer_mix"),
+          py::arg("comb_res_mix"),
+          py::arg("use_new") = true,
+          py::arg("open_fp8_quant") = false,
+          py::arg("reg_ptr") = static_cast<int64_t>(0),
+          py::arg("reg_bytes") = static_cast<int64_t>(0));
     m.def("fused_allreduce_mhc_post_split",
           &aiter::fused_allreduce_mhc_post_split,
           py::arg("_fa"),

--- a/csrc/pybind/fused_ar_mhc_post_pybind.cu
+++ b/csrc/pybind/fused_ar_mhc_post_pybind.cu
@@ -21,4 +21,16 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
           py::arg("open_fp8_quant") = false,
           py::arg("reg_ptr") = static_cast<int64_t>(0),
           py::arg("reg_bytes") = static_cast<int64_t>(0));
+    m.def("fused_allreduce_mhc_post_split",
+          &aiter::fused_allreduce_mhc_post_split,
+          py::arg("_fa"),
+          py::arg("inp"),
+          py::arg("next_residual"),
+          py::arg("residual_in"),
+          py::arg("post_layer_mix"),
+          py::arg("comb_res_mix"),
+          py::arg("use_new") = true,
+          py::arg("open_fp8_quant") = false,
+          py::arg("reg_ptr") = static_cast<int64_t>(0),
+          py::arg("reg_bytes") = static_cast<int64_t>(0));
 }

--- a/op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py
+++ b/op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py
@@ -1,16 +1,19 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
-"""Benchmark split (AR + mhc_post) vs fused (AR+mhc_post epilogue only)."""
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Multigpu tests: split (AR + mhc_post) vs fused AR+mhc_post epilogue."""
 
 from __future__ import annotations
 
 import argparse
+import itertools
+import logging
 import os
-import sys
-from multiprocessing import Pool, set_start_method
+from multiprocessing import Pool, freeze_support, set_start_method
 from statistics import median
 from typing import Callable, Optional
 
+import pandas as pd
 import torch
 import torch.distributed as dist
 
@@ -27,11 +30,26 @@ from aiter.dist.parallel_state import (
 )
 from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
 from aiter.ops.custom_all_reduce import launch_fused_allreduce_mhc_post_only
+from aiter.test_common import benchmark, checkAllclose
+
+logger = logging.getLogger("aiter")
 
 set_start_method("spawn", force=True)
 
 WARMUP = 5
+BENCH_WARMUP = 2
 ITERS = 50
+DEFAULT_SHAPES = (
+    (1, 4096),
+    (2, 4096),
+    (4, 4096),
+    (16, 4096),
+    (32, 4096),
+    (128, 4096),
+    (1024, 4096),
+    (2048, 4096),
+    (8192, 4096),
+)
 
 
 def _make_inputs(m: int, hidden_size: int, rank: int, device: torch.device):
@@ -90,13 +108,15 @@ def _bench_graph(fn: Callable[[], None], *, warmup: int, iters: int) -> list[flo
     return samples
 
 
-def profile_worker(
+def _profile_worker(
     tp_size: int,
     rank_id: int,
     m: int,
     hidden_size: int,
     with_graph: bool,
     init_method: str,
+    *,
+    run_correctness: bool,
 ):
     device = torch.device(f"cuda:{rank_id}")
     torch.cuda.set_device(device)
@@ -148,19 +168,40 @@ def profile_worker(
             reg_bytes=reg_bytes,
         )
 
+    err = 0.0
+    if run_correctness:
+        split_ar_post()
+        ref = next_residual.clone()
+        out = launch_fused_allreduce_mhc_post_only(
+            ca_comm._ptr,
+            tensors["layer_input"],
+            tensors["residual_in"],
+            tensors["post_layer_mix"],
+            tensors["comb_res_mix"],
+            reg_ptr=_reg()[0],
+            reg_bytes=_reg()[1],
+        )
+        err = checkAllclose(
+            ref,
+            out,
+            msg=f"tp={tp_size} m={m} rank={rank_id}",
+        )
+
     for _ in range(WARMUP):
         split_ar_post()
         fused_ar_post()
     torch.cuda.synchronize()
 
     bench = _bench_graph if with_graph else _event_us
-    split_us = bench(split_ar_post, warmup=2, iters=ITERS)
+    split_us = bench(split_ar_post, warmup=BENCH_WARMUP, iters=ITERS)
     if with_graph:
         fused_us = bench(
-            lambda: fused_ar_post(graph_replay=True), warmup=2, iters=ITERS
+            lambda: fused_ar_post(graph_replay=True),
+            warmup=BENCH_WARMUP,
+            iters=ITERS,
         )
     else:
-        fused_us = bench(fused_ar_post, warmup=2, iters=ITERS)
+        fused_us = bench(fused_ar_post, warmup=BENCH_WARMUP, iters=ITERS)
 
     destroy_model_parallel()
     destroy_distributed_environment()
@@ -169,23 +210,27 @@ def profile_worker(
         "rank": rank_id,
         "split_median": median(split_us),
         "fused_median": median(fused_us),
+        "err": err,
     }
 
 
-def run_profile(
+def _run_profile(
     tp_size: int,
     m: int,
     hidden_size: int,
     with_graph: bool,
     init_method: Optional[str] = None,
+    *,
+    run_correctness: bool = False,
 ):
     if init_method is None:
         init_method = get_distributed_init_method(get_ip(), get_open_port())
     pool = Pool(processes=tp_size)
     rets = [
         pool.apply_async(
-            profile_worker,
+            _profile_worker,
             args=(tp_size, r, m, hidden_size, with_graph, init_method),
+            kwds={"run_correctness": run_correctness},
         )
         for r in range(tp_size)
     ]
@@ -196,47 +241,127 @@ def run_profile(
     fused = max(x["fused_median"] for x in rows)
     saved = split - fused
     speedup = (saved / split * 100.0) if split > 0 else 0.0
-    return split, fused, saved, speedup
+    err = max(x["err"] for x in rows)
+    return split, fused, saved, speedup, err
 
 
-def main():
-    parser = argparse.ArgumentParser(description="AR+mhc_post only profile TP=2")
-    parser.add_argument("-t", "--tp-size", type=int, default=2)
+@benchmark()
+def test_ar_mhc_post_only_profile(
+    tp_size: int,
+    m: int,
+    hidden_size: int,
+    with_graph: bool = False,
+    distributed_init_method: Optional[str] = None,
+    run_correctness: bool = False,
+):
+    split, fused, saved, speedup, err = _run_profile(
+        tp_size,
+        m,
+        hidden_size,
+        with_graph,
+        distributed_init_method,
+        run_correctness=run_correctness,
+    )
+    return {
+        "tp_size": tp_size,
+        "m": m,
+        "hidden_size": hidden_size,
+        "withGraph": with_graph,
+        "split_median_us": split,
+        "fused_median_us": fused,
+        "saved_us": saved,
+        "speedup_pct": speedup,
+        "err": err,
+    }
+
+
+try:
+    import pytest
+
+    @pytest.mark.parametrize("m", [16, 4096])
+    def test_fused_ar_mhc_post_only_tp2_smoke(m: int):
+        if torch.cuda.device_count() < 2:
+            pytest.skip(f"requires >=2 GPUs, got {torch.cuda.device_count()}")
+        ret = test_ar_mhc_post_only_profile(
+            tp_size=2,
+            m=m,
+            hidden_size=4096,
+            with_graph=False,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(), get_open_port()
+            ),
+            run_correctness=True,
+        )
+        assert ret["err"] == 0
+
+except ImportError:
+    pass
+
+
+def _parse_shapes(raw: str) -> list[tuple[int, int]]:
+    shapes = []
+    for tok in raw.split():
+        m_s, h_s = tok.split(",")
+        shapes.append((int(m_s), int(h_s)))
+    return shapes
+
+
+def _print_table(tp_size: int, with_graph: bool, rows: list[dict]):
+    mode = "graph-on" if with_graph else "graph-off"
+    print(f"## TP={tp_size} {mode}")
+    print("M\tsplit\tfused\tsaved\tspeedup")
+    for row in rows:
+        print(
+            f"{row['m']}\t{row['split_median_us']:.1f}\t"
+            f"{row['fused_median_us']:.1f}\t{row['saved_us']:.1f}\t"
+            f"{row['speedup_pct']:+.1f}%"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    freeze_support()
+    parser = argparse.ArgumentParser(
+        description="Profile split AR+mhc_post vs fused post-only epilogue"
+    )
+    parser.add_argument("-t", "--tp-size", type=int, nargs="+", default=[2])
     parser.add_argument(
         "-s",
         "--shapes",
         type=str,
-        default="1,4096 2,4096 4,4096 16,4096 32,4096 128,4096 1024,4096 2048,4096 8192,4096",
+        default=" ".join(f"{m},{h}" for m, h in DEFAULT_SHAPES),
     )
     parser.add_argument("-g", "--graph", type=int, default=-1, choices=[-1, 0, 1])
     args = parser.parse_args()
 
-    shapes = []
-    for tok in args.shapes.split():
-        m_s, h_s = tok.split(",")
-        shapes.append((int(m_s), int(h_s)))
-
+    shapes = _parse_shapes(args.shapes)
     graph_modes = [False, True] if args.graph < 0 else [bool(args.graph)]
 
     print("# AR + mhc_post only (split vs fused epilogue)")
     print(f"# HIP_VISIBLE_DEVICES={os.environ.get('HIP_VISIBLE_DEVICES', 'unset')}")
-    print(f"# warmup={WARMUP} iters={ITERS} metric=rank-max median (us)")
+    print(f"# warmup={WARMUP} bench_warmup={BENCH_WARMUP} iters={ITERS}")
+    print("# metric=rank-max median (us)")
     print()
 
+    df_rows = []
     init_method = get_distributed_init_method(get_ip(), get_open_port())
-    for with_graph in graph_modes:
-        mode = "graph-on" if with_graph else "graph-off"
-        print(f"## {mode}")
-        print("M\tsplit\tfused\tsaved\tspeedup")
-        for m, hidden_size in shapes:
-            split, fused, saved, sp = run_profile(
-                args.tp_size, m, hidden_size, with_graph, init_method
-            )
-            print(f"{m}\t{split:.1f}\t{fused:.1f}\t{saved:.1f}\t{sp:+.1f}%")
-        print()
+    for tp_size in args.tp_size:
+        for with_graph in graph_modes:
+            mode_rows = []
+            for m, hidden_size in shapes:
+                ret = test_ar_mhc_post_only_profile(
+                    tp_size,
+                    m,
+                    hidden_size,
+                    with_graph=with_graph,
+                    distributed_init_method=init_method,
+                )
+                mode_rows.append(ret)
+                df_rows.append(ret)
+            _print_table(tp_size, with_graph, mode_rows)
 
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+    df = pd.DataFrame(df_rows)
+    logger.info(
+        "AR+mhc_post profile summary (markdown):\n%s",
+        df.to_markdown(index=False),
+    )

--- a/op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py
+++ b/op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py
@@ -29,6 +29,7 @@ from aiter.dist.parallel_state import (
 from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
 from aiter.ops.custom_all_reduce import (
     fused_allreduce_mhc_post_only,
+    fused_allreduce_mhc_post_one_stage,
     fused_allreduce_mhc_post_split,
 )
 from aiter.test_common import benchmark, checkAllclose
@@ -99,6 +100,7 @@ def _profile_worker(
     *,
     run_correctness: bool,
     breakdown: bool = False,
+    compare_stages: bool = False,
 ):
     device = torch.device(f"cuda:{rank_id}")
     torch.cuda.set_device(device)
@@ -117,6 +119,7 @@ def _profile_worker(
     ca_comm = get_tp_group().device_communicator.ca_comm
     next_residual_split = torch.empty_like(tensors["residual_in"])
     next_residual_fused = torch.empty_like(tensors["residual_in"])
+    next_residual_1stage = torch.empty_like(tensors["residual_in"])
     next_residual_split_fused = torch.empty_like(tensors["residual_in"])
     reduced_buf = torch.empty_like(tensors["layer_input"])
     post_mix = tensors["post_layer_mix"]
@@ -144,6 +147,19 @@ def _profile_worker(
             ca_comm._ptr,
             tensors["layer_input"],
             next_residual_fused,
+            tensors["residual_in"],
+            tensors["post_layer_mix"],
+            tensors["comb_res_mix"],
+            reg_ptr=reg_ptr,
+            reg_bytes=reg_bytes,
+        )
+
+    def fused_ar_post_1stage(*, registered: bool):
+        reg_ptr, reg_bytes = (0, 0) if registered else _reg()
+        fused_allreduce_mhc_post_one_stage(
+            ca_comm._ptr,
+            tensors["layer_input"],
+            next_residual_1stage,
             tensors["residual_in"],
             tensors["post_layer_mix"],
             tensors["comb_res_mix"],
@@ -187,6 +203,15 @@ def _profile_worker(
             checkAllclose(
                 ref,
                 next_residual_fused,
+                msg=f"tp={tp_size} m={m} rank={rank_id} fused_auto",
+            ),
+        )
+        fused_ar_post_1stage(registered=False)
+        err = max(
+            err,
+            checkAllclose(
+                ref,
+                next_residual_1stage,
                 msg=f"tp={tp_size} m={m} rank={rank_id} fused_1stage",
             ),
         )
@@ -203,10 +228,11 @@ def _profile_worker(
     for _ in range(WARMUP):
         split_ar_post()
         fused_ar_post(registered=False)
+        fused_ar_post_1stage(registered=False)
         fused_ar_post_split(registered=False)
     torch.cuda.synchronize()
 
-    ar_us = mhc_us = fused_split_us = 0.0
+    ar_us = mhc_us = fused_split_us = fused_1stage_us = fused_auto_us = 0.0
 
     if with_graph:
         graph_split = torch.cuda.CUDAGraph()
@@ -244,10 +270,27 @@ def _profile_worker(
                 graph_fused_split.replay, warmup=BENCH_WARMUP, iters=BENCH_ITERS
             )
     else:
-        if breakdown:
+        if breakdown or compare_stages:
             ar_only()
             ar_us = _event_mean_us(ar_only, warmup=BENCH_WARMUP, iters=BENCH_ITERS)
             mhc_us = _event_mean_us(mhc_only, warmup=BENCH_WARMUP, iters=BENCH_ITERS)
+        if compare_stages:
+            fused_1stage_us = _event_mean_us(
+                lambda: fused_ar_post_1stage(registered=False),
+                warmup=BENCH_WARMUP,
+                iters=BENCH_ITERS,
+            )
+            fused_split_us = _event_mean_us(
+                lambda: fused_ar_post_split(registered=False),
+                warmup=BENCH_WARMUP,
+                iters=BENCH_ITERS,
+            )
+            fused_auto_us = _event_mean_us(
+                lambda: fused_ar_post(registered=False),
+                warmup=BENCH_WARMUP,
+                iters=BENCH_ITERS,
+            )
+        elif breakdown:
             fused_split_us = _event_mean_us(
                 lambda: fused_ar_post_split(registered=False),
                 warmup=BENCH_WARMUP,
@@ -270,6 +313,8 @@ def _profile_worker(
         "ar_us": ar_us,
         "mhc_us": mhc_us,
         "fused_split_us": fused_split_us,
+        "fused_1stage_us": fused_1stage_us,
+        "fused_auto_us": fused_auto_us,
         "err": err,
     }
 
@@ -283,6 +328,7 @@ def _run_profile(
     *,
     run_correctness: bool = False,
     breakdown: bool = False,
+    compare_stages: bool = False,
 ):
     if init_method is None:
         init_method = get_distributed_init_method(get_ip(), get_open_port())
@@ -291,7 +337,11 @@ def _run_profile(
         pool.apply_async(
             _profile_worker,
             args=(tp_size, r, m, hidden_size, with_graph, init_method),
-            kwds={"run_correctness": run_correctness, "breakdown": breakdown},
+            kwds={
+                "run_correctness": run_correctness,
+                "breakdown": breakdown,
+                "compare_stages": compare_stages,
+            },
         )
         for r in range(tp_size)
     ]
@@ -303,15 +353,31 @@ def _run_profile(
     ar = max(x["ar_us"] for x in rows)
     mhc = max(x["mhc_us"] for x in rows)
     fused_split = max(x["fused_split_us"] for x in rows)
+    fused_1stage = max(x["fused_1stage_us"] for x in rows)
+    fused_auto = max(x["fused_auto_us"] for x in rows)
     saved = split - fused
     speedup = (saved / split * 100.0) if split > 0 else 0.0
     err = max(x["err"] for x in rows)
+    input_bytes = m * hidden_size * 2
+    use_split = tp_size >= 4 and input_bytes > 512 * 1024
+    auto_path = "2stage" if use_split else "1stage"
+    best_fused = min(
+        (fused_1stage, "1stage"),
+        (fused_split, "2stage"),
+        (fused_auto, "auto"),
+        key=lambda x: x[0],
+    )[1]
     return {
         "split_mean_us": split,
         "fused_mean_us": fused,
         "ar_mean_us": ar,
         "mhc_mean_us": mhc,
         "fused_split_mean_us": fused_split,
+        "fused_1stage_mean_us": fused_1stage,
+        "fused_auto_mean_us": fused_auto if fused_auto > 0 else fused,
+        "input_bytes": input_bytes,
+        "auto_path": auto_path,
+        "best_fused_path": best_fused,
         "saved_us": saved,
         "speedup_pct": speedup,
         "err": err,
@@ -327,6 +393,7 @@ def test_ar_mhc_post_only_profile(
     distributed_init_method: Optional[str] = None,
     run_correctness: bool = False,
     breakdown: bool = False,
+    compare_stages: bool = False,
 ):
     stats = _run_profile(
         tp_size,
@@ -336,6 +403,7 @@ def test_ar_mhc_post_only_profile(
         distributed_init_method,
         run_correctness=run_correctness,
         breakdown=breakdown,
+        compare_stages=compare_stages,
     )
     return {
         "tp_size": tp_size,
@@ -365,6 +433,44 @@ try:
         )
         assert ret["err"] == 0
 
+    @pytest.mark.parametrize("m", [16, 128, 4096, 8192])
+    def test_fused_auto_dispatch_tp2(m: int):
+        if torch.cuda.device_count() < 2:
+            pytest.skip(f"requires >=2 GPUs, got {torch.cuda.device_count()}")
+        ret = test_ar_mhc_post_only_profile(
+            tp_size=2,
+            m=m,
+            hidden_size=4096,
+            with_graph=False,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(), get_open_port()
+            ),
+            run_correctness=True,
+        )
+        assert ret["err"] == 0
+        assert ret["auto_path"] == "1stage"
+
+    @pytest.mark.parametrize("m", [16, 8192])
+    def test_fused_auto_dispatch_tp4(m: int):
+        if torch.cuda.device_count() < 4:
+            pytest.skip(f"requires >=4 GPUs, got {torch.cuda.device_count()}")
+        ret = test_ar_mhc_post_only_profile(
+            tp_size=4,
+            m=m,
+            hidden_size=4096,
+            with_graph=False,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(), get_open_port()
+            ),
+            run_correctness=True,
+        )
+        assert ret["err"] == 0
+        input_bytes = m * 4096 * 2
+        if input_bytes > 512 * 1024:
+            assert ret["auto_path"] == "2stage"
+        else:
+            assert ret["auto_path"] == "1stage"
+
 except ImportError:
     pass
 
@@ -377,10 +483,26 @@ def _parse_shapes(raw: str) -> list[tuple[int, int]]:
     return shapes
 
 
-def _print_table(tp_size: int, with_graph: bool, rows: list[dict], *, breakdown: bool):
+def _print_table(
+    tp_size: int,
+    with_graph: bool,
+    rows: list[dict],
+    *,
+    breakdown: bool,
+    compare_stages: bool,
+):
     mode = "graph-on" if with_graph else "graph-off"
     print(f"## TP={tp_size} {mode}")
-    if breakdown:
+    if compare_stages:
+        print("M\tbytes\tsplit\t1stage\t2stage\tauto\tauto_path\tbest")
+        for row in rows:
+            print(
+                f"{row['m']}\t{row['input_bytes']}\t{row['split_mean_us']:.1f}\t"
+                f"{row['fused_1stage_mean_us']:.1f}\t{row['fused_split_mean_us']:.1f}\t"
+                f"{row['fused_auto_mean_us']:.1f}\t{row['auto_path']}\t"
+                f"{row['best_fused_path']}"
+            )
+    elif breakdown:
         print("M\tar\tmhc\tsplit\tfused_1stage\tfused_2stage")
         for row in rows:
             print(
@@ -417,10 +539,19 @@ if __name__ == "__main__":
         action="store_true",
         help="also report AR-only / mhc_post-only / fused 2-stage split path",
     )
+    parser.add_argument(
+        "--compare-stages",
+        action="store_true",
+        help="compare split vs fused 1-stage vs 2-stage vs auto-dispatch (graph-off)",
+    )
     args = parser.parse_args()
 
+    if args.compare_stages:
+        graph_modes = [False]
+    else:
+        graph_modes = [False, True] if args.graph < 0 else [bool(args.graph)]
+
     shapes = _parse_shapes(args.shapes)
-    graph_modes = [False, True] if args.graph < 0 else [bool(args.graph)]
 
     print("# AR + mhc_post only (split vs fused epilogue)")
     print(f"# HIP_VISIBLE_DEVICES={os.environ.get('HIP_VISIBLE_DEVICES', 'unset')}")
@@ -442,10 +573,17 @@ if __name__ == "__main__":
                     with_graph=with_graph,
                     distributed_init_method=init_method,
                     breakdown=args.breakdown,
+                    compare_stages=args.compare_stages,
                 )
                 mode_rows.append(ret)
                 df_rows.append(ret)
-            _print_table(tp_size, with_graph, mode_rows, breakdown=args.breakdown)
+            _print_table(
+                tp_size,
+                with_graph,
+                mode_rows,
+                breakdown=args.breakdown,
+                compare_stages=args.compare_stages,
+            )
 
     df = pd.DataFrame(df_rows)
     logger.info(

--- a/op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py
+++ b/op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py
@@ -6,12 +6,10 @@
 from __future__ import annotations
 
 import argparse
-import itertools
 import logging
 import os
 from multiprocessing import Pool, freeze_support, set_start_method
-from statistics import median
-from typing import Callable, Optional
+from typing import Optional
 
 import pandas as pd
 import torch
@@ -29,7 +27,10 @@ from aiter.dist.parallel_state import (
     set_custom_all_reduce,
 )
 from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
-from aiter.ops.custom_all_reduce import launch_fused_allreduce_mhc_post_only
+from aiter.ops.custom_all_reduce import (
+    fused_allreduce_mhc_post_only,
+    fused_allreduce_mhc_post_split,
+)
 from aiter.test_common import benchmark, checkAllclose
 
 logger = logging.getLogger("aiter")
@@ -38,7 +39,7 @@ set_start_method("spawn", force=True)
 
 WARMUP = 5
 BENCH_WARMUP = 2
-ITERS = 50
+BENCH_ITERS = 101
 DEFAULT_SHAPES = (
     (1, 4096),
     (2, 4096),
@@ -72,40 +73,20 @@ def _make_inputs(m: int, hidden_size: int, rank: int, device: torch.device):
     }
 
 
-def _event_us(fn: Callable[[], None], *, warmup: int, iters: int) -> list[float]:
+def _event_mean_us(fn, *, warmup: int, iters: int) -> float:
     for _ in range(warmup):
         fn()
     torch.cuda.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
-    samples: list[float] = []
+    latencies: list[float] = []
     for _ in range(iters):
         start.record()
         fn()
         end.record()
         end.synchronize()
-        samples.append(start.elapsed_time(end) * 1000.0)
-    return samples
-
-
-def _bench_graph(fn: Callable[[], None], *, warmup: int, iters: int) -> list[float]:
-    graph = torch.cuda.CUDAGraph()
-    with graph_capture() as gc:
-        with torch.cuda.graph(graph, stream=gc.stream):
-            fn()
-    for _ in range(warmup):
-        graph.replay()
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    samples: list[float] = []
-    for _ in range(iters):
-        start.record()
-        graph.replay()
-        end.record()
-        end.synchronize()
-        samples.append(start.elapsed_time(end) * 1000.0)
-    return samples
+        latencies.append(start.elapsed_time(end) * 1000.0)
+    return sum(latencies) / len(latencies)
 
 
 def _profile_worker(
@@ -117,6 +98,7 @@ def _profile_worker(
     init_method: str,
     *,
     run_correctness: bool,
+    breakdown: bool = False,
 ):
     device = torch.device(f"cuda:{rank_id}")
     torch.cuda.set_device(device)
@@ -133,7 +115,10 @@ def _profile_worker(
     torch.cuda.synchronize()
 
     ca_comm = get_tp_group().device_communicator.ca_comm
-    next_residual = torch.empty_like(tensors["residual_in"])
+    next_residual_split = torch.empty_like(tensors["residual_in"])
+    next_residual_fused = torch.empty_like(tensors["residual_in"])
+    next_residual_split_fused = torch.empty_like(tensors["residual_in"])
+    reduced_buf = torch.empty_like(tensors["layer_input"])
     post_mix = tensors["post_layer_mix"]
     if post_mix.ndim == 3:
         post_mix = post_mix.squeeze(-1)
@@ -146,21 +131,19 @@ def _profile_worker(
     def split_ar_post():
         reduced = tensor_model_parallel_all_reduce(tensors["layer_input"])
         aiter.mhc_post(
-            next_residual,
+            next_residual_split,
             reduced,
             tensors["residual_in"],
             post_mix,
             tensors["comb_res_mix"],
         )
 
-    def fused_ar_post(*, graph_replay: bool = False):
-        if graph_replay:
-            reg_ptr, reg_bytes = 0, 0
-        else:
-            reg_ptr, reg_bytes = _reg()
-        launch_fused_allreduce_mhc_post_only(
+    def fused_ar_post(*, registered: bool):
+        reg_ptr, reg_bytes = (0, 0) if registered else _reg()
+        fused_allreduce_mhc_post_only(
             ca_comm._ptr,
             tensors["layer_input"],
+            next_residual_fused,
             tensors["residual_in"],
             tensors["post_layer_mix"],
             tensors["comb_res_mix"],
@@ -168,48 +151,125 @@ def _profile_worker(
             reg_bytes=reg_bytes,
         )
 
-    err = 0.0
-    if run_correctness:
-        split_ar_post()
-        ref = next_residual.clone()
-        out = launch_fused_allreduce_mhc_post_only(
+    def fused_ar_post_split(*, registered: bool):
+        reg_ptr, reg_bytes = (0, 0) if registered else _reg()
+        fused_allreduce_mhc_post_split(
             ca_comm._ptr,
             tensors["layer_input"],
+            next_residual_split_fused,
             tensors["residual_in"],
             tensors["post_layer_mix"],
             tensors["comb_res_mix"],
-            reg_ptr=_reg()[0],
-            reg_bytes=_reg()[1],
+            reg_ptr=reg_ptr,
+            reg_bytes=reg_bytes,
         )
-        err = checkAllclose(
-            ref,
-            out,
-            msg=f"tp={tp_size} m={m} rank={rank_id}",
+
+    def ar_only():
+        nonlocal reduced_buf
+        reduced_buf = tensor_model_parallel_all_reduce(tensors["layer_input"])
+
+    def mhc_only():
+        aiter.mhc_post(
+            next_residual_split,
+            reduced_buf,
+            tensors["residual_in"],
+            post_mix,
+            tensors["comb_res_mix"],
+        )
+
+    err = 0.0
+    if run_correctness:
+        split_ar_post()
+        ref = next_residual_split.clone()
+        fused_ar_post(registered=False)
+        err = max(
+            err,
+            checkAllclose(
+                ref,
+                next_residual_fused,
+                msg=f"tp={tp_size} m={m} rank={rank_id} fused_1stage",
+            ),
+        )
+        fused_ar_post_split(registered=False)
+        err = max(
+            err,
+            checkAllclose(
+                ref,
+                next_residual_split_fused,
+                msg=f"tp={tp_size} m={m} rank={rank_id} fused_2stage",
+            ),
         )
 
     for _ in range(WARMUP):
         split_ar_post()
-        fused_ar_post()
+        fused_ar_post(registered=False)
+        fused_ar_post_split(registered=False)
     torch.cuda.synchronize()
 
-    bench = _bench_graph if with_graph else _event_us
-    split_us = bench(split_ar_post, warmup=BENCH_WARMUP, iters=ITERS)
+    ar_us = mhc_us = fused_split_us = 0.0
+
     if with_graph:
-        fused_us = bench(
-            lambda: fused_ar_post(graph_replay=True),
-            warmup=BENCH_WARMUP,
-            iters=ITERS,
+        graph_split = torch.cuda.CUDAGraph()
+        with graph_capture() as gc:
+            with torch.cuda.graph(graph_split, stream=gc.stream):
+                reduced = tensor_model_parallel_all_reduce(tensors["layer_input"])
+                aiter.mhc_post(
+                    next_residual_split,
+                    reduced,
+                    tensors["residual_in"],
+                    post_mix,
+                    tensors["comb_res_mix"],
+                )
+        next_residual_split.zero_()
+
+        graph_fused = torch.cuda.CUDAGraph()
+        with graph_capture() as gc:
+            with torch.cuda.graph(graph_fused, stream=gc.stream):
+                fused_ar_post(registered=True)
+        next_residual_fused.zero_()
+
+        split_us = _event_mean_us(
+            graph_split.replay, warmup=BENCH_WARMUP, iters=BENCH_ITERS
         )
+        fused_us = _event_mean_us(
+            graph_fused.replay, warmup=BENCH_WARMUP, iters=BENCH_ITERS
+        )
+        if breakdown:
+            graph_fused_split = torch.cuda.CUDAGraph()
+            with graph_capture() as gc:
+                with torch.cuda.graph(graph_fused_split, stream=gc.stream):
+                    fused_ar_post_split(registered=True)
+            next_residual_split_fused.zero_()
+            fused_split_us = _event_mean_us(
+                graph_fused_split.replay, warmup=BENCH_WARMUP, iters=BENCH_ITERS
+            )
     else:
-        fused_us = bench(fused_ar_post, warmup=BENCH_WARMUP, iters=ITERS)
+        if breakdown:
+            ar_only()
+            ar_us = _event_mean_us(ar_only, warmup=BENCH_WARMUP, iters=BENCH_ITERS)
+            mhc_us = _event_mean_us(mhc_only, warmup=BENCH_WARMUP, iters=BENCH_ITERS)
+            fused_split_us = _event_mean_us(
+                lambda: fused_ar_post_split(registered=False),
+                warmup=BENCH_WARMUP,
+                iters=BENCH_ITERS,
+            )
+        split_us = _event_mean_us(split_ar_post, warmup=BENCH_WARMUP, iters=BENCH_ITERS)
+        fused_us = _event_mean_us(
+            lambda: fused_ar_post(registered=False),
+            warmup=BENCH_WARMUP,
+            iters=BENCH_ITERS,
+        )
 
     destroy_model_parallel()
     destroy_distributed_environment()
 
     return {
         "rank": rank_id,
-        "split_median": median(split_us),
-        "fused_median": median(fused_us),
+        "split_us": split_us,
+        "fused_us": fused_us,
+        "ar_us": ar_us,
+        "mhc_us": mhc_us,
+        "fused_split_us": fused_split_us,
         "err": err,
     }
 
@@ -222,6 +282,7 @@ def _run_profile(
     init_method: Optional[str] = None,
     *,
     run_correctness: bool = False,
+    breakdown: bool = False,
 ):
     if init_method is None:
         init_method = get_distributed_init_method(get_ip(), get_open_port())
@@ -230,19 +291,31 @@ def _run_profile(
         pool.apply_async(
             _profile_worker,
             args=(tp_size, r, m, hidden_size, with_graph, init_method),
-            kwds={"run_correctness": run_correctness},
+            kwds={"run_correctness": run_correctness, "breakdown": breakdown},
         )
         for r in range(tp_size)
     ]
     pool.close()
     pool.join()
     rows = [r.get() for r in rets]
-    split = max(x["split_median"] for x in rows)
-    fused = max(x["fused_median"] for x in rows)
+    split = max(x["split_us"] for x in rows)
+    fused = max(x["fused_us"] for x in rows)
+    ar = max(x["ar_us"] for x in rows)
+    mhc = max(x["mhc_us"] for x in rows)
+    fused_split = max(x["fused_split_us"] for x in rows)
     saved = split - fused
     speedup = (saved / split * 100.0) if split > 0 else 0.0
     err = max(x["err"] for x in rows)
-    return split, fused, saved, speedup, err
+    return {
+        "split_mean_us": split,
+        "fused_mean_us": fused,
+        "ar_mean_us": ar,
+        "mhc_mean_us": mhc,
+        "fused_split_mean_us": fused_split,
+        "saved_us": saved,
+        "speedup_pct": speedup,
+        "err": err,
+    }
 
 
 @benchmark()
@@ -253,25 +326,23 @@ def test_ar_mhc_post_only_profile(
     with_graph: bool = False,
     distributed_init_method: Optional[str] = None,
     run_correctness: bool = False,
+    breakdown: bool = False,
 ):
-    split, fused, saved, speedup, err = _run_profile(
+    stats = _run_profile(
         tp_size,
         m,
         hidden_size,
         with_graph,
         distributed_init_method,
         run_correctness=run_correctness,
+        breakdown=breakdown,
     )
     return {
         "tp_size": tp_size,
         "m": m,
         "hidden_size": hidden_size,
         "withGraph": with_graph,
-        "split_median_us": split,
-        "fused_median_us": fused,
-        "saved_us": saved,
-        "speedup_pct": speedup,
-        "err": err,
+        **stats,
     }
 
 
@@ -306,16 +377,25 @@ def _parse_shapes(raw: str) -> list[tuple[int, int]]:
     return shapes
 
 
-def _print_table(tp_size: int, with_graph: bool, rows: list[dict]):
+def _print_table(tp_size: int, with_graph: bool, rows: list[dict], *, breakdown: bool):
     mode = "graph-on" if with_graph else "graph-off"
     print(f"## TP={tp_size} {mode}")
-    print("M\tsplit\tfused\tsaved\tspeedup")
-    for row in rows:
-        print(
-            f"{row['m']}\t{row['split_median_us']:.1f}\t"
-            f"{row['fused_median_us']:.1f}\t{row['saved_us']:.1f}\t"
-            f"{row['speedup_pct']:+.1f}%"
-        )
+    if breakdown:
+        print("M\tar\tmhc\tsplit\tfused_1stage\tfused_2stage")
+        for row in rows:
+            print(
+                f"{row['m']}\t{row['ar_mean_us']:.1f}\t{row['mhc_mean_us']:.1f}\t"
+                f"{row['split_mean_us']:.1f}\t{row['fused_mean_us']:.1f}\t"
+                f"{row['fused_split_mean_us']:.1f}"
+            )
+    else:
+        print("M\tsplit\tfused\tsaved\tspeedup")
+        for row in rows:
+            print(
+                f"{row['m']}\t{row['split_mean_us']:.1f}\t"
+                f"{row['fused_mean_us']:.1f}\t{row['saved_us']:.1f}\t"
+                f"{row['speedup_pct']:+.1f}%"
+            )
     print()
 
 
@@ -332,6 +412,11 @@ if __name__ == "__main__":
         default=" ".join(f"{m},{h}" for m, h in DEFAULT_SHAPES),
     )
     parser.add_argument("-g", "--graph", type=int, default=-1, choices=[-1, 0, 1])
+    parser.add_argument(
+        "--breakdown",
+        action="store_true",
+        help="also report AR-only / mhc_post-only / fused 2-stage split path",
+    )
     args = parser.parse_args()
 
     shapes = _parse_shapes(args.shapes)
@@ -339,8 +424,9 @@ if __name__ == "__main__":
 
     print("# AR + mhc_post only (split vs fused epilogue)")
     print(f"# HIP_VISIBLE_DEVICES={os.environ.get('HIP_VISIBLE_DEVICES', 'unset')}")
-    print(f"# warmup={WARMUP} bench_warmup={BENCH_WARMUP} iters={ITERS}")
-    print("# metric=rank-max median (us)")
+    print(f"# warmup={WARMUP} bench_warmup={BENCH_WARMUP} bench_iters={BENCH_ITERS}")
+    print("# graph capture: split via registered AR; fused reg_ptr=0 (registered=True)")
+    print("# metric=rank-max mean (us)")
     print()
 
     df_rows = []
@@ -355,10 +441,11 @@ if __name__ == "__main__":
                     hidden_size,
                     with_graph=with_graph,
                     distributed_init_method=init_method,
+                    breakdown=args.breakdown,
                 )
                 mode_rows.append(ret)
                 df_rows.append(ret)
-            _print_table(tp_size, with_graph, mode_rows)
+            _print_table(tp_size, with_graph, mode_rows, breakdown=args.breakdown)
 
     df = pd.DataFrame(df_rows)
     logger.info(

--- a/scripts/profile_ar_mhc_post_only.py
+++ b/scripts/profile_ar_mhc_post_only.py
@@ -37,12 +37,20 @@ ITERS = 50
 def _make_inputs(m: int, hidden_size: int, rank: int, device: torch.device):
     torch.manual_seed(20260617)
     hc_mult = 4
-    base_layer_input = torch.randn(m, hidden_size, dtype=aiter.dtypes.bf16, device=device)
+    base_layer_input = torch.randn(
+        m, hidden_size, dtype=aiter.dtypes.bf16, device=device
+    )
     return {
         "layer_input": base_layer_input * float(rank + 1),
-        "residual_in": torch.randn(m, hc_mult, hidden_size, dtype=aiter.dtypes.bf16, device=device),
-        "post_layer_mix": torch.randn(m, hc_mult, 1, dtype=aiter.dtypes.fp32, device=device),
-        "comb_res_mix": torch.randn(m, hc_mult, hc_mult, dtype=aiter.dtypes.fp32, device=device),
+        "residual_in": torch.randn(
+            m, hc_mult, hidden_size, dtype=aiter.dtypes.bf16, device=device
+        ),
+        "post_layer_mix": torch.randn(
+            m, hc_mult, 1, dtype=aiter.dtypes.fp32, device=device
+        ),
+        "comb_res_mix": torch.randn(
+            m, hc_mult, hc_mult, dtype=aiter.dtypes.fp32, device=device
+        ),
     }
 
 
@@ -148,7 +156,9 @@ def profile_worker(
     bench = _bench_graph if with_graph else _event_us
     split_us = bench(split_ar_post, warmup=2, iters=ITERS)
     if with_graph:
-        fused_us = bench(lambda: fused_ar_post(graph_replay=True), warmup=2, iters=ITERS)
+        fused_us = bench(
+            lambda: fused_ar_post(graph_replay=True), warmup=2, iters=ITERS
+        )
     else:
         fused_us = bench(fused_ar_post, warmup=2, iters=ITERS)
 

--- a/scripts/profile_ar_mhc_post_only.py
+++ b/scripts/profile_ar_mhc_post_only.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Benchmark split (AR + mhc_post) vs fused (AR+mhc_post epilogue only)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from multiprocessing import Pool, set_start_method
+from statistics import median
+from typing import Callable, Optional
+
+import torch
+import torch.distributed as dist
+
+import aiter
+from aiter.dist.communication_op import tensor_model_parallel_all_reduce
+from aiter.dist.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    ensure_model_parallel_initialized,
+    get_tp_group,
+    graph_capture,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+from aiter.ops.custom_all_reduce import launch_fused_allreduce_mhc_post_only
+
+set_start_method("spawn", force=True)
+
+WARMUP = 5
+ITERS = 50
+
+
+def _make_inputs(m: int, hidden_size: int, rank: int, device: torch.device):
+    torch.manual_seed(20260617)
+    hc_mult = 4
+    base_layer_input = torch.randn(m, hidden_size, dtype=aiter.dtypes.bf16, device=device)
+    return {
+        "layer_input": base_layer_input * float(rank + 1),
+        "residual_in": torch.randn(m, hc_mult, hidden_size, dtype=aiter.dtypes.bf16, device=device),
+        "post_layer_mix": torch.randn(m, hc_mult, 1, dtype=aiter.dtypes.fp32, device=device),
+        "comb_res_mix": torch.randn(m, hc_mult, hc_mult, dtype=aiter.dtypes.fp32, device=device),
+    }
+
+
+def _event_us(fn: Callable[[], None], *, warmup: int, iters: int) -> list[float]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples: list[float] = []
+    for _ in range(iters):
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0)
+    return samples
+
+
+def _bench_graph(fn: Callable[[], None], *, warmup: int, iters: int) -> list[float]:
+    graph = torch.cuda.CUDAGraph()
+    with graph_capture() as gc:
+        with torch.cuda.graph(graph, stream=gc.stream):
+            fn()
+    for _ in range(warmup):
+        graph.replay()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples: list[float] = []
+    for _ in range(iters):
+        start.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0)
+    return samples
+
+
+def profile_worker(
+    tp_size: int,
+    rank_id: int,
+    m: int,
+    hidden_size: int,
+    with_graph: bool,
+    init_method: str,
+):
+    device = torch.device(f"cuda:{rank_id}")
+    torch.cuda.set_device(device)
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=tp_size,
+        rank=rank_id,
+        distributed_init_method=init_method,
+    )
+    ensure_model_parallel_initialized(tp_size, 1)
+    tensors = _make_inputs(m, hidden_size, rank_id, device)
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, device=device), group=group)
+    torch.cuda.synchronize()
+
+    ca_comm = get_tp_group().device_communicator.ca_comm
+    next_residual = torch.empty_like(tensors["residual_in"])
+    post_mix = tensors["post_layer_mix"]
+    if post_mix.ndim == 3:
+        post_mix = post_mix.squeeze(-1)
+
+    def _reg():
+        if ca_comm is None or ca_comm.disabled:
+            return 0, 0
+        return ca_comm._pool["input"].data_ptr, ca_comm._pool["input"].max_size
+
+    def split_ar_post():
+        reduced = tensor_model_parallel_all_reduce(tensors["layer_input"])
+        aiter.mhc_post(
+            next_residual,
+            reduced,
+            tensors["residual_in"],
+            post_mix,
+            tensors["comb_res_mix"],
+        )
+
+    def fused_ar_post(*, graph_replay: bool = False):
+        if graph_replay:
+            reg_ptr, reg_bytes = 0, 0
+        else:
+            reg_ptr, reg_bytes = _reg()
+        launch_fused_allreduce_mhc_post_only(
+            ca_comm._ptr,
+            tensors["layer_input"],
+            tensors["residual_in"],
+            tensors["post_layer_mix"],
+            tensors["comb_res_mix"],
+            reg_ptr=reg_ptr,
+            reg_bytes=reg_bytes,
+        )
+
+    for _ in range(WARMUP):
+        split_ar_post()
+        fused_ar_post()
+    torch.cuda.synchronize()
+
+    bench = _bench_graph if with_graph else _event_us
+    split_us = bench(split_ar_post, warmup=2, iters=ITERS)
+    if with_graph:
+        fused_us = bench(lambda: fused_ar_post(graph_replay=True), warmup=2, iters=ITERS)
+    else:
+        fused_us = bench(fused_ar_post, warmup=2, iters=ITERS)
+
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+    return {
+        "rank": rank_id,
+        "split_median": median(split_us),
+        "fused_median": median(fused_us),
+    }
+
+
+def run_profile(
+    tp_size: int,
+    m: int,
+    hidden_size: int,
+    with_graph: bool,
+    init_method: Optional[str] = None,
+):
+    if init_method is None:
+        init_method = get_distributed_init_method(get_ip(), get_open_port())
+    pool = Pool(processes=tp_size)
+    rets = [
+        pool.apply_async(
+            profile_worker,
+            args=(tp_size, r, m, hidden_size, with_graph, init_method),
+        )
+        for r in range(tp_size)
+    ]
+    pool.close()
+    pool.join()
+    rows = [r.get() for r in rets]
+    split = max(x["split_median"] for x in rows)
+    fused = max(x["fused_median"] for x in rows)
+    saved = split - fused
+    speedup = (saved / split * 100.0) if split > 0 else 0.0
+    return split, fused, saved, speedup
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AR+mhc_post only profile TP=2")
+    parser.add_argument("-t", "--tp-size", type=int, default=2)
+    parser.add_argument(
+        "-s",
+        "--shapes",
+        type=str,
+        default="1,4096 2,4096 4,4096 16,4096 32,4096 128,4096 1024,4096 2048,4096 8192,4096",
+    )
+    parser.add_argument("-g", "--graph", type=int, default=-1, choices=[-1, 0, 1])
+    args = parser.parse_args()
+
+    shapes = []
+    for tok in args.shapes.split():
+        m_s, h_s = tok.split(",")
+        shapes.append((int(m_s), int(h_s)))
+
+    graph_modes = [False, True] if args.graph < 0 else [bool(args.graph)]
+
+    print("# AR + mhc_post only (split vs fused epilogue)")
+    print(f"# HIP_VISIBLE_DEVICES={os.environ.get('HIP_VISIBLE_DEVICES', 'unset')}")
+    print(f"# warmup={WARMUP} iters={ITERS} metric=rank-max median (us)")
+    print()
+
+    init_method = get_distributed_init_method(get_ip(), get_open_port())
+    for with_graph in graph_modes:
+        mode = "graph-on" if with_graph else "graph-off"
+        print(f"## {mode}")
+        print("M\tsplit\tfused\tsaved\tspeedup")
+        for m, hidden_size in shapes:
+            split, fused, saved, sp = run_profile(
+                args.tp_size, m, hidden_size, with_graph, init_method
+            )
+            print(f"{m}\t{split:.1f}\t{fused:.1f}\t{saved:.1f}\t{sp:+.1f}%")
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Fused Custom AllReduce + MHC Post

Fuse custom AllReduce with `mhc_post` on MI355X TP paths (bf16, hidden=4096, hc_mult=4). Scope: AR + post only — no pre / RMSNorm / E2E.

**API:** `launch_fused_allreduce_mhc_post_only` auto-dispatches in `run_ar_mhc_post_large_m`:

- `TP ≥ 4` and `m × hidden × sizeof(T) > 512 KiB` → 2-stage reduce-scatter + optimized `mhc_post` on IPC tmp
- else → 1-stage IPC reduce

For hidden=4096 bf16, 2-stage kicks in at **M ≥ 128**.

---

## Performance (auto-dispatch vs split baseline)

**Benchmark:** `python op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py -t 2 4 8`

Rank-max mean latency (μs), CUDA events, `bench_iters=101`. Split = `all_reduce` + `mhc_post`; fused = auto-dispatch.

### TP=2 (always 1-stage)

| M | Split off | Fused off | Δ | Split on | Fused on | Δ |
|--:|----------:|----------:|--:|---------:|---------:|--:|
| 1 | 29.9 | 23.4 | +21.7% | 18.8 | 15.9 | +15.3% |
| 2 | 30.0 | 17.1 | +42.8% | 18.0 | 15.6 | +13.3% |
| 4 | 29.9 | 17.5 | +41.5% | 19.1 | 16.4 | +14.0% |
| 16 | 30.5 | 27.0 | +11.6% | 19.6 | 16.9 | +14.0% |
| 32 | 32.6 | 23.9 | +26.8% | 23.2 | 20.4 | +12.3% |
| 128 | 48.1 | 34.8 | +27.8% | 37.6 | 33.3 | +11.4% |
| 1024 | 191.2 | 170.0 | +11.1% | 177.8 | 169.7 | +4.6% |
| 2048 | 352.2 | 336.7 | +4.4% | 338.1 | 335.4 | +0.8% |
| 8192 | 1329.1 | 1293.0 | +2.7% | 1296.3 | 1266.1 | +2.3% |

### TP=4 (M≥128 → 2-stage)

| M | Split off | Fused off | Δ | Split on | Fused on | Δ |
|--:|----------:|----------:|--:|---------:|---------:|--:|
| 1 | 31.5 | 18.2 | +42.3% | 19.3 | 17.0 | +11.7% |
| 2 | 31.0 | 18.9 | +39.0% | 22.6 | 18.9 | +16.2% |
| 4 | 31.7 | 23.2 | +26.7% | 20.8 | 18.4 | +11.7% |
| 16 | 63.2 | 27.3 | +56.7% | 22.2 | 19.5 | +11.9% |
| 32 | 31.6 | 25.6 | +19.1% | 20.4 | 20.4 | +0.2% |
| 128 | 36.7 | 29.6 | +19.5% | 28.3 | 28.7 | −1.4% |
| 1024 | 120.8 | 109.9 | +9.0% | 107.6 | 109.0 | −1.3% |
| 2048 | 216.1 | 201.6 | +6.7% | 194.8 | 203.1 | −4.3% |
| 8192 | 755.5 | 763.7 | −1.1% | 718.1 | 740.2 | −3.1% |

### TP=8 (M≥128 → 2-stage + optimized mhc_post epilogue)

| M | Split off | Fused off | Δ | Split on | Fused on | Δ |
|--:|----------:|----------:|--:|---------:|---------:|--:|
| 1 | 52.4 | 37.9 | +27.6% | 26.5 | 26.4 | +0.4% |
| 16 | 59.1 | 30.5 | +48.3% | 28.8 | 31.8 | −10.4% |
| 128 | 52.2 | 29.1 | +44.3% | 30.6 | 29.5 | +3.5% |
| 1024 | 113.5 | 77.1 | +32.1% | 77.2 | 79.3 | −2.8% |
| 2048 | 147.8 | 129.6 | +12.3% | 123.3 | 126.0 | −2.2% |
| 8192 | 449.4 | 449.3 | +0.0% | 415.2 | 432.1 | −4.1% |

**TP8 M=8192 breakdown (graph-off, μs):** AR=358, mhc=102, split=436, fused=449 (≈ parity after stage-2 uses `mhc_post_kernel_x2vgpr` on tmp).

**Takeaways:**

- **Graph-off:** strong wins on small/medium M; TP8 M=8192 ≈ split (was −3.6% with naive stage-2 kernel).
- **Graph-on:** TP2/4 small M still gains; TP8 small M (1-stage path) regresses; large M ≈ parity.

---

## Files

| File | Role |
|------|------|
| `csrc/include/custom_all_reduce.cuh` | Kernels + auto-dispatch |
| `csrc/kernels/mhc_kernels.cu` | `launch_mhc_post_raw` for split epilogue |
| `csrc/kernels/fused_ar_mhc_post.cu` | Host entry + auto-dispatch |
| `csrc/pybind/fused_ar_mhc_post_pybind.cu` | Pybind |
| `aiter/ops/custom_all_reduce.py` | Python launch |
| `op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py` | Benchmark + pytest |

---

## Test plan

```bash
AITER_REBUILD=1 python -c "from aiter.ops.custom_all_reduce import fused_allreduce_mhc_post_only"
pytest op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py -v
python op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py -t 2 4 8
```

---

## Limitations

- Not wired into `communication_op` / graph wrappers yet.
- TP8 graph-on small M (1-stage) still slower than split.
