### PR TITLE
fix: load fused-SWA batch_id_per_token as int32, not int64

### DIFF
--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -329,7 +329,7 @@ def _build_kernel(
         kv_in_row_stride: Int32,  # KV row stride in bf16 elements
         swa_kv: fx.Pointer,  # [num_slots, cache_size, D] bf16 (dummy if not kv_write)
         state_slot_mapping: fx.Pointer,  # [bs] i32 (dummy if not kv_write)
-        batch_id_per_token: fx.Pointer,  # [T] i64, -1 sentinel (dummy if not kv_write)
+        batch_id_per_token: fx.Pointer,  # [T] i32, -1 sentinel (dummy if not kv_write)
         swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
         swa_pos_stride: Int32,  # bf16 elements (= D)
         swa_cache_size: Int32,  # ring slot count
@@ -740,17 +740,16 @@ def _build_kernel(
                 # ---- Fused SWA scatter setup (kv_write only) ----
                 # Target swa_kv[slot, pos % cache_size, :] where
                 # slot = state_slot_mapping[batch_id_per_token[bid_t]].
-                # batch_id is i64 with -1 sentinel on CG-pad tokens; clamp it
-                # to 0 for the (predicated-off) slot load to keep the load
-                # in-bounds, and gate the actual store on do_swa = batch_id>=0.
+                # batch_id is i32 with -1 sentinel on CG-pad tokens; clamp it to
+                # 0 for the (predicated-off) slot load to keep the load in-bounds,
+                # and gate the actual store on do_swa = batch_id>=0.
                 swa_out_g = None
                 do_swa = None
                 if const_expr(kv_write):
                     bid_rsrc = _ptr_buffer_resource(batch_id_per_token)
-                    bid_i64 = buffer_ops.buffer_load(
-                        bid_rsrc, bid_t, vec_width=1, dtype=T.i64
+                    bid_i32 = buffer_ops.buffer_load(
+                        bid_rsrc, bid_t, vec_width=1, dtype=i32
                     )
-                    bid_i32 = arith.trunci(i32, bid_i64)
                     do_swa = bid_i32 >= fx.Int32(0)
                     bid_safe = arith.maxsi(bid_i32, arith.constant(0, type=i32))
                     slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
@@ -970,7 +969,7 @@ def flydsl_qk_norm_rope_quant(
             fusing the standalone ``swa_write``.
         state_slot_mapping: ``[bs]`` int32 — per-seq SWA ring slot. Required
             when ``swa_kv`` is set.
-        batch_id_per_token: ``[T]`` int64, ``-1`` on CG-pad tokens — token→seq
+        batch_id_per_token: ``[T]`` int32, ``-1`` on CG-pad tokens — token→seq
             map for the fused SWA scatter (store gated off on ``-1``). Required
             when ``swa_kv`` is set.
 
@@ -1098,8 +1097,8 @@ def flydsl_qk_norm_rope_quant(
             raise ValueError("swa_kv must be contiguous")
         if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
             raise TypeError("state_slot_mapping must be 1-D int32")
-        if batch_id_per_token.dim() != 1 or batch_id_per_token.dtype != torch.int64:
-            raise TypeError("batch_id_per_token must be 1-D int64")
+        if batch_id_per_token.dim() != 1 or batch_id_per_token.dtype != torch.int32:
+            raise TypeError("batch_id_per_token must be 1-D int32")
         if batch_id_per_token.shape[0] < T_tok:
             raise ValueError(
                 f"batch_id_per_token len {batch_id_per_token.shape[0]} < T={T_tok}"
@@ -1117,7 +1116,7 @@ def flydsl_qk_norm_rope_quant(
         swa_cache_size = 1
         swa_kv_arg = kv_out  # bf16 dummy
         ssm_arg = q.new_empty(1, dtype=torch.int32)
-        bid_arg = q.new_empty(1, dtype=torch.int64)
+        bid_arg = q.new_empty(1, dtype=torch.int32)
 
     launcher = compile_flydsl_qk_norm_rope_quant(
         num_q_heads=H,

--- a/op_tests/test_flydsl_qk_norm_rope_quant.py
+++ b/op_tests/test_flydsl_qk_norm_rope_quant.py
@@ -403,8 +403,10 @@ def test_flydsl_qk_norm_rope_quant_kv_write():
     pos = torch.randint(0, max_pos - 1, (T,), dtype=torch.int64, device=device)
 
     # batch_id_per_token: valid tokens map to seqs round-robin; pad tail = -1.
-    bid = torch.full((T,), -1, dtype=torch.int64, device=device)
-    bid[:T_valid] = torch.arange(T_valid, device=device) // tok_per_seq
+    bid = torch.full((T,), -1, dtype=torch.int32, device=device)
+    bid[:T_valid] = (torch.arange(T_valid, device=device) // tok_per_seq).to(
+        torch.int32
+    )
     # random per-seq state slot (distinct so collisions don't mask bugs)
     state_slot = torch.randperm(num_slots, device=device)[:bs].to(torch.int32)
 


### PR DESCRIPTION
## Summary
The fused decode SWA scatter added in #3776 hardcoded an **int64** `buffer_load` for `batch_id_per_token`. But the V4 decode producers are **not uniformly int64** — the MTP-draft decode path reuses the int32 `cu_seqlens_q` slice as the per-token batch id. Feeding that int32 tensor tripped the wrapper's `batch_id_per_token must be 1-D int64` check, so **DeepSeek-V4-Pro MTP decode raised a `TypeError` before the first token** → server never came up → the accuracy job timed out.

## Fix
`batch_id` values are bounded by the batch size (≪ 2³¹), so int32 is always sufficient. Standardize on **int32**:
- kernel loads `batch_id` at i32 width (drops the now-unneeded `trunci`)
- wrapper validates int32; the not-`kv_write` dummy is int32
- smoke test builds an int32 `batch_id`

No behavior change for the int64-free fast path; this only widens/realigns the SWA-scatter dtype contract.

> The matching ATOM change (metadata buffer + sglang/vllm bridges → int32) is in ROCm/ATOM#1272.

## Test plan
- [x] `test_flydsl_qk_norm_rope_quant_kv_write` (int32 batch_id) — bit-exact PASS
- [x] Cross-check vs the real `swa_write`, 24 configs (bs×mtp×pad) — all `max_diff=0`
- [x] **End-to-end**: DeepSeek-V4-Pro **MTP3** GSM8K 3-shot → flexible-extract **0.9477** / strict **0.9484** (CI threshold 0.94); decode drained cleanly, no `TypeError`