### PR TITLE
CI: cap Triton shard runtime

### DIFF
--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -75,6 +75,7 @@ jobs:
     if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') }}
     name: Triton Tests (MI35X) / Shard ${{ matrix.shard }}
     runs-on: linux-aiter-mi35x-1
+    timeout-minutes: 60
     needs: [split_triton_tests, prepare_triton_wheel, check-signal]
     strategy:
       fail-fast: false
@@ -210,6 +211,7 @@ jobs:
     if: ${{ (!github.event.pull_request || github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:triton-300x') && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:triton-300x'))) }}
     name: Triton Tests (MI300X) / Shard ${{ matrix.shard }}
     runs-on: aiter-1gpu-runner
+    timeout-minutes: 60
     needs: [split_triton_tests, prepare_triton_wheel, check-signal]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Add 60-minute job timeout to MI35X Triton shard jobs
- Add 60-minute job timeout to MI300X Triton shard jobs

## Test plan
- git diff --check
- bash .github/scripts/split_tests.sh --shards 8 --test-type triton --dry-run