### PR TITLE
[FlyDSL] Port qk_norm_rope_quant and compress_attn to gfx1250 (wave32)

### DIFF
--- a/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
@@ -416,7 +416,8 @@ def _build_kernel(
                     for chunk in range_constexpr(dwords // half_dw):
                         r = buffer_ops.buffer_load(
                             rsrc,
-                            ArithValue(off_dw) + arith.constant(chunk * half_dw, type=i32),
+                            ArithValue(off_dw)
+                            + arith.constant(chunk * half_dw, type=i32),
                             vec_width=half_dw,
                             dtype=i32,
                         )
@@ -454,13 +455,16 @@ def _build_kernel(
                     for q in range_constexpr(n_chunks):
                         r = buffer_ops.buffer_load(
                             rsrc,
-                            ArithValue(off_elems_i32) + arith.constant(q * quarter, type=i32),
+                            ArithValue(off_elems_i32)
+                            + arith.constant(q * quarter, type=i32),
                             vec_width=quarter,
                             dtype=f32,
                         )
                         for i in range_constexpr(quarter):
                             out.append(
-                                vector.extract(r, static_position=[i], dynamic_position=[])
+                                vector.extract(
+                                    r, static_position=[i], dynamic_position=[]
+                                )
                             )
                     return out
 
@@ -926,10 +930,18 @@ def _build_kernel(
                         # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
                         c4_i32 = arith.constant(4, type=i32)
                         lo = vector.extract_strided_slice(
-                            T.vec(4, T.i32), bf16_as_i32, offsets=[0], sizes=[4], strides=[1]
+                            T.vec(4, T.i32),
+                            bf16_as_i32,
+                            offsets=[0],
+                            sizes=[4],
+                            strides=[1],
                         )
                         hi = vector.extract_strided_slice(
-                            T.vec(4, T.i32), bf16_as_i32, offsets=[4], sizes=[4], strides=[1]
+                            T.vec(4, T.i32),
+                            bf16_as_i32,
+                            offsets=[4],
+                            sizes=[4],
+                            strides=[1],
                         )
                         buffer_ops.buffer_store(lo, out_rsrc, cache_off_dw)
                         buffer_ops.buffer_store(
@@ -1458,13 +1470,16 @@ def _build_kernel_ksplit(
                     for q in range_constexpr(n_chunks):
                         r = buffer_ops.buffer_load(
                             rsrc,
-                            ArithValue(off_elems_i32) + arith.constant(q * quarter, type=i32),
+                            ArithValue(off_elems_i32)
+                            + arith.constant(q * quarter, type=i32),
                             vec_width=quarter,
                             dtype=f32,
                         )
                         for i in range_constexpr(quarter):
                             out.append(
-                                vector.extract(r, static_position=[i], dynamic_position=[])
+                                vector.extract(
+                                    r, static_position=[i], dynamic_position=[]
+                                )
                             )
                     return out
 
@@ -1502,7 +1517,8 @@ def _build_kernel_ksplit(
                     for chunk in range_constexpr(dwords // half_dw):
                         r = buffer_ops.buffer_load(
                             rsrc,
-                            ArithValue(off_dw) + arith.constant(chunk * half_dw, type=i32),
+                            ArithValue(off_dw)
+                            + arith.constant(chunk * half_dw, type=i32),
                             vec_width=half_dw,
                             dtype=i32,
                         )
@@ -1867,10 +1883,18 @@ def _build_kernel_ksplit(
                         # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
                         c4_i32 = arith.constant(4, type=i32)
                         lo = vector.extract_strided_slice(
-                            T.vec(4, T.i32), bf16_as_i32, offsets=[0], sizes=[4], strides=[1]
+                            T.vec(4, T.i32),
+                            bf16_as_i32,
+                            offsets=[0],
+                            sizes=[4],
+                            strides=[1],
                         )
                         hi = vector.extract_strided_slice(
-                            T.vec(4, T.i32), bf16_as_i32, offsets=[4], sizes=[4], strides=[1]
+                            T.vec(4, T.i32),
+                            bf16_as_i32,
+                            offsets=[4],
+                            sizes=[4],
+                            strides=[1],
                         )
                         buffer_ops.buffer_store(lo, out_rsrc, cache_off_dw)
                         buffer_ops.buffer_store(
@@ -2281,7 +2305,7 @@ def flydsl_fused_compress_attn_gfx1250(
     """
     # gfx1250 overrides
     preshuffle = False  # MFMA preshuffle is gfx9-only; force linear layout
-    enable_prefetch_input = False  # VEC=16 VGPR pressure
+    enable_prefetch_input = False  # noqa: F841  # VEC=16 VGPR pressure
     # ---- input validation ----
     plan_capacity = plan_gpu.shape[0]
     if plan_capacity == 0:

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
@@ -1,66 +1,23 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""Fused Compressor boundary kernel for V4 attention (FlyDSL).
+"""Fused Compressor boundary kernel for V4 attention — **gfx1250 (RDNA4, wave32)**.
 
-Drop-in replacement for the Triton ``_fused_compress_attn_kernel`` in
-``atom/model_ops/v4_kernels/fused_compress.py``. Per-boundary online-softmax
-pool over K=2*RATIO source positions, RMSNorm (fp32), GPT-J interleaved RoPE,
-optional FP8 (ue8m0 scale + MFMA 16x16 preshuffle) cache scatter.
+Port of ``fused_compress_attn.py`` (wave64) to gfx1250 wave32.
+Key differences from the wave64 version:
+  - BLOCK_THREADS = 32 (wave32)
+  - VEC = D / 32 (D=512 → VEC=16; D=128 → VEC=4)
+  - VEC=16 load/store paths (4× dwordx4 for f32, 2× dwordx4 for bf16)
+  - preshuffle forced False (MFMA preshuffle is gfx9-only)
+  - Kernel names suffixed with "w32" to avoid JIT cache collision
+  - FP8 VEC=4 packing path (no pair-coop shuffle needed)
 
-Two kernel families share this file:
-  - Legacy single-wave (``_build_kernel``): 1 wave64 per boundary, K iters
-    serialized. Handles all shapes + the FP8/quant/preshuffle family.
-  - K-split multi-wave (``_build_kernel_ksplit``, BF16 + FP8 scatter): K split
-    across NW waves in one workgroup (block = 64*NW), LDS cross-wave
-    online-softmax reduce, single dispatch. Parallelizes the serial softmax
-    chain that bottlenecks the latency-bound small-N decode regime. On the
-    CSA Main (D=512, BF16) and CSA Indexer (D=128, FP8) shapes it auto-engages
-    via ``csa_ksplit_num_waves(plan_capacity)`` and wins ~1.3-1.4× (BF16) /
-    ~1.15-1.24× (FP8) at decode bs=1-32; it falls back to legacy at high N
-    where CU occupancy already saturates. See
-    ``flydsl_fused_compress_attn``'s ``k_split_num_waves`` arg.
+Two kernel families:
+  - Single-wave (``_build_kernel``): 1 wave32 per boundary
+  - K-split multi-wave (``_build_kernel_ksplit``): K split across NW waves,
+    block = 32*NW
 
-Grid: ``(plan_capacity, 1, 1)`` — one program per packed plan row
-``[ragged_id, batch_id, position, window_len]``. Position == -1 rows
-sentinel-skip; sentinel-skip is implemented as an scf.IfOp that wraps the
-entire body (flydsl ``if cond: return`` does NOT actually early-exit inside
-a @flyc.kernel — same trap as ``qk_norm_rope_quant``'s grid-Y chunk loop).
-
-Per-thread layout (single wave64, BLOCK_THREADS=64):
-  - VEC = D / 64 (V4-Pro Main: D=512 → VEC=8; Indexer: D=128 → VEC=2)
-  - Thread t owns ``D`` elements ``[t*VEC, t*VEC+VEC)`` of the BLOCK_D vector.
-  - Online-softmax accumulators ``m_acc/kv_acc/w_acc`` are per-thread fp32
-    arrays carried across K iterations via scf.for loop-carried state.
-
-Two-phase K loop (matches Triton perf split):
-  Phase 1 (state cache): k ∈ [0, window_len) — dynamic bound, scf.for with
-    loop-carry. Each iter loads kv_state/score_state at ``s = pos - K + 1 + k``,
-    masking padding (s < 0) via ``select(is_padding, NEG_INF, score_b)``.
-  Phase 2 (ragged input): k ∈ [window_len, K) — dynamic start, constexpr end.
-    Each iter loads kv_in/score_in/ape, then ``score_k = score_a + ape_v``.
-
-Both phases share the max-rescale update:
-  m_new = max(m_acc, score_k)
-  scale = (m_acc == -inf) ? 0 : exp(m_acc - m_new)
-  w_k   = (score_k == -inf) ? 0 : exp(score_k - m_new)
-  kv_acc = kv_acc * scale + w_k * kv_k
-  w_acc  = w_acc  * scale + w_k
-  m_acc  = m_new
-
-After the K loop:
-  compressed = kv_acc / w_acc                              # fp32 per-lane
-  rstd       = rsqrt(sum_wave(compressed^2) / D + eps)     # fp32 scalar
-  normed     = compressed * rstd * rms_weight              # fp32 per-lane
-  rotated    = GPT-J RoPE on rope_head_dim tail            # fp32 per-lane
-
-Scatter (only when block_table is non-null, i.e. not warmup):
-  QUANT=0: bf16 paged write to kv_cache[physical_block, slot_in_block, :]
-  QUANT=1: per-row amax → ue8m0 scale (silu_and_mul_fq encoding) → fp8 cast
-           → MFMA 16x16 preshuffled write + fp32 scale write into cache_scale.
-
-Correctness invariant (caller-side): kernel reads state cache as-of-end-of-
-previous-fwd. Caller MUST invoke BEFORE ``update_compressor_states``.
+See ``fused_compress_attn.py`` for the original wave64 documentation.
 """
 
 # NOTE: do NOT add `from __future__ import annotations` (see qk_norm_rope_quant
@@ -101,7 +58,7 @@ _FORCE_BIND_LDS = (
 )
 
 # --- shape constants --------------------------------------------------------
-BLOCK_THREADS = 64  # 1 wave64; D must be a multiple
+BLOCK_THREADS = 32  # 1 wave32 (RDNA4 / gfx1250); D must be a multiple
 
 # --- fp8 + e8m0 constants ---------------------------------------------------
 # Defer ``aiter.utility.dtypes`` import to first call (matches
@@ -166,7 +123,7 @@ def _build_kernel(
     preshuffle: bool,
     rms_weight_is_bf16: bool,
     rms_eps: float,
-    enable_prefetch_input: bool = True,
+    enable_prefetch_input: bool = False,
 ):
     """Build the @flyc.kernel + @flyc.jit launcher for a given config.
 
@@ -198,12 +155,12 @@ def _build_kernel(
     # --- per-thread vec layout ----
     ROPE_THREAD_LO = NOPE // VEC  # first rope-thread tid
     PAIRS_PER_THREAD = VEC // 2  # GPT-J pairs each rope-thread owns
-    # For Main (D=512, VEC=8) → 56 .. 63 are rope threads, 4 pairs each (=64 total).
-    # For Indexer (D=128, VEC=2) → 32 .. 63 are rope threads, 1 pair each (=64=2RD/2).
+    # For Main (D=512, VEC=16) → 28 .. 31 are rope threads, 8 pairs each (=64 total).
+    # For Indexer (D=128, VEC=4) → 16 .. 31 are rope threads, 2 pairs each (=64=2RD/2).
     # The RD%(2*VEC) == 0 invariant means rope threads cleanly own whole pairs.
 
     assert D % BLOCK_THREADS == 0, f"D={D} must divide BLOCK_THREADS={BLOCK_THREADS}"
-    assert VEC in (2, 4, 8), f"VEC={VEC} (D/{BLOCK_THREADS}) outside supported set"
+    assert VEC in (2, 4, 8, 16), f"VEC={VEC} (D/{BLOCK_THREADS}) outside supported set"
     assert NOPE >= 0 and NOPE % VEC == 0
     assert RD > 0 and RD % 2 == 0 and RD % VEC == 0
     assert state_size >= K, f"state_size={state_size} < K={K}"
@@ -217,7 +174,7 @@ def _build_kernel(
 
     # --- kernel name ----
     _name_parts = [
-        "fused_compress_attn",
+        "fused_compress_attn_w32",
         f"D{D}",
         f"RD{RD}",
         f"R{ratio}",
@@ -278,7 +235,7 @@ def _build_kernel(
 
         # --- thread / block ids ---
         pid = fx.block_idx.x  # one program per plan row
-        tid = fx.thread_idx.x  # 0 .. 63
+        tid = fx.thread_idx.x  # 0 .. 31
 
         # --- constants ---
         c_neg_inf = arith.constant(_NEG_INF, type=f32)
@@ -294,7 +251,7 @@ def _build_kernel(
             )
 
         def wave_reduce_add(x):
-            """Butterfly sum across wave64."""
+            """Butterfly sum across wave32."""
             w = _to_raw(x)
             for sh_exp in range_constexpr(log2_block):
                 off = BLOCK_THREADS // (2 << sh_exp)
@@ -303,7 +260,7 @@ def _build_kernel(
             return w
 
         def wave_reduce_max(x):
-            """Butterfly max across wave64 (used by quant path)."""
+            """Butterfly max across wave32 (used by quant path)."""
             w = _to_raw(x)
             for sh_exp in range_constexpr(log2_block):
                 off = BLOCK_THREADS // (2 << sh_exp)
@@ -415,36 +372,70 @@ def _build_kernel(
                 """Load VEC bf16 from byte-aligned dword stream → fp32 VEC scalars.
 
                 Returns a list of VEC fp32 MLIR values.
+                VEC=16 → dwords=8 → 2× dwordx4 loads, bitcast each to vec<8,bf16>.
                 """
                 off_dw = ArithValue(off_elems_i32) >> arith.constant(1, type=i32)
-                # bf16 VEC = VEC * 2 bytes; for VEC ∈ {2, 4, 8} that's
-                # {4, 8, 16} bytes = {1, 2, 4} dwords.
+                # bf16 VEC = VEC * 2 bytes; dwords = VEC/2.
                 dwords = (VEC + 1) // 2  # ceil(VEC*2 / 4)
                 if const_expr(dwords == 1):
                     # buffer_load(vec_width=1) returns a scalar i32; wrap into
                     # vec<1xi32> before bitcasting to vec<2xbf16>.
                     raw_s = buffer_ops.buffer_load(rsrc, off_dw, vec_width=1, dtype=i32)
                     raw = vector.from_elements(T.vec(1, T.i32), [raw_s])
-                else:
+                    vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
+                    out = []
+                    for i in range_constexpr(VEC):
+                        bf16_v = vector.extract(
+                            vec_bf16,
+                            static_position=[i],
+                            dynamic_position=[],
+                        )
+                        f32_v = arith.extf(f32, bf16_v)
+                        out.append(f32_v)
+                    return out
+                elif const_expr(dwords <= 4):
                     raw = buffer_ops.buffer_load(
                         rsrc, off_dw, vec_width=dwords, dtype=i32
                     )
-                vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
-                out = []
-                for i in range_constexpr(VEC):
-                    bf16_v = vector.extract(
-                        vec_bf16,
-                        static_position=[i],
-                        dynamic_position=[],
-                    )
-                    f32_v = arith.extf(f32, bf16_v)
-                    out.append(f32_v)
-                return out
+                    vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
+                    out = []
+                    for i in range_constexpr(VEC):
+                        bf16_v = vector.extract(
+                            vec_bf16,
+                            static_position=[i],
+                            dynamic_position=[],
+                        )
+                        f32_v = arith.extf(f32, bf16_v)
+                        out.append(f32_v)
+                    return out
+                else:
+                    # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
+                    half_dw = 4
+                    half_bf16 = half_dw * 2  # 8 bf16 per chunk
+                    out = []
+                    for chunk in range_constexpr(dwords // half_dw):
+                        r = buffer_ops.buffer_load(
+                            rsrc,
+                            ArithValue(off_dw) + arith.constant(chunk * half_dw, type=i32),
+                            vec_width=half_dw,
+                            dtype=i32,
+                        )
+                        vbf16 = vector.bitcast(T.vec(half_bf16, T.bf16), r)
+                        for i in range_constexpr(half_bf16):
+                            bf16_v = vector.extract(
+                                vbf16,
+                                static_position=[i],
+                                dynamic_position=[],
+                            )
+                            f32_v = arith.extf(f32, bf16_v)
+                            out.append(f32_v)
+                    return out
 
             def _load_f32_vec(rsrc, off_elems_i32):
                 """Load VEC fp32 from byte-aligned stream → list of VEC fp32 scalars.
 
-                For VEC=2 → dwordx2; VEC=4 → dwordx4; VEC=8 → 2× dwordx4 (HW max).
+                For VEC=2 → dwordx2; VEC=4 → dwordx4; VEC=8 → 2× dwordx4;
+                VEC=16 → 4× dwordx4 (HW max is dwordx4).
                 """
                 if const_expr(VEC <= 4):
                     vw = VEC
@@ -456,27 +447,21 @@ def _build_kernel(
                         for i in range(VEC)
                     ]
                 else:
-                    # VEC == 8 → 2× dwordx4
-                    assert VEC == 8
-                    half = VEC // 2
-                    r0 = buffer_ops.buffer_load(
-                        rsrc, off_elems_i32, vec_width=half, dtype=f32
-                    )
-                    r1 = buffer_ops.buffer_load(
-                        rsrc,
-                        ArithValue(off_elems_i32) + arith.constant(half, type=i32),
-                        vec_width=half,
-                        dtype=f32,
-                    )
+                    # VEC in {8, 16} → split into quarter=4 chunks
+                    quarter = 4
+                    n_chunks = VEC // quarter
                     out = []
-                    for i in range_constexpr(half):
-                        out.append(
-                            vector.extract(r0, static_position=[i], dynamic_position=[])
+                    for q in range_constexpr(n_chunks):
+                        r = buffer_ops.buffer_load(
+                            rsrc,
+                            ArithValue(off_elems_i32) + arith.constant(q * quarter, type=i32),
+                            vec_width=quarter,
+                            dtype=f32,
                         )
-                    for i in range_constexpr(half):
-                        out.append(
-                            vector.extract(r1, static_position=[i], dynamic_position=[])
-                        )
+                        for i in range_constexpr(quarter):
+                            out.append(
+                                vector.extract(r, static_position=[i], dynamic_position=[])
+                            )
                     return out
 
             # Buffer resources reused across K iters.
@@ -918,7 +903,7 @@ def _build_kernel(
                         + tid_x_vec
                     )
                     # Build a per-block GTensor and store VEC bf16 via dword path.
-                    # bf16 VEC ∈ {2, 4, 8} = {4, 8, 16} bytes = {1, 2, 4} dwords.
+                    # bf16 VEC ∈ {2, 4, 8, 16} = {4, 8, 16, 32} bytes = {1, 2, 4, 8} dwords.
                     out_vec_t = T.vec(VEC, T.bf16)
                     raw_vec = vector.from_elements(vecVf32, out_lane)
                     bf16_vec = raw_vec.truncf(out_vec_t)
@@ -935,8 +920,21 @@ def _build_kernel(
                             bf16_as_i32, static_position=[0], dynamic_position=[]
                         )
                         buffer_ops.buffer_store(scalar_i32, out_rsrc, cache_off_dw)
-                    else:
+                    elif const_expr(dwords <= 4):
                         buffer_ops.buffer_store(bf16_as_i32, out_rsrc, cache_off_dw)
+                    else:
+                        # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
+                        c4_i32 = arith.constant(4, type=i32)
+                        lo = vector.extract_strided_slice(
+                            T.vec(4, T.i32), bf16_as_i32, offsets=[0], sizes=[4], strides=[1]
+                        )
+                        hi = vector.extract_strided_slice(
+                            T.vec(4, T.i32), bf16_as_i32, offsets=[4], sizes=[4], strides=[1]
+                        )
+                        buffer_ops.buffer_store(lo, out_rsrc, cache_off_dw)
+                        buffer_ops.buffer_store(
+                            hi, out_rsrc, ArithValue(cache_off_dw) + c4_i32
+                        )
                 else:
                     # ── QUANT=1: FP8 per-row scaled write + fp32 scale ──
                     # Steps:
@@ -1041,21 +1039,28 @@ def _build_kernel(
                         )
                         dword = pk
                     else:
-                        # VEC == 8: 8 bytes = 2 dwords. Build separately.
-                        assert VEC == 8
-                        p0 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[0], fp8_inputs[1], c_p0, 0
-                        )
-                        p0 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[2], fp8_inputs[3], p0, 1
-                        )
-                        p1 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[4], fp8_inputs[5], c_p0, 0
-                        )
-                        p1 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[6], fp8_inputs[7], p1, 1
-                        )
-                        dword = (p0, p1)
+                        # VEC in {8, 16}: VEC bytes = VEC/4 dwords. Build per-dword.
+                        assert VEC in (8, 16)
+                        n_dwords = VEC // 4
+                        dword_list = []
+                        for dw_idx in range_constexpr(n_dwords):
+                            base = dw_idx * 4
+                            pk = rocdl.cvt_pk_fp8_f32(
+                                i32,
+                                fp8_inputs[base + 0],
+                                fp8_inputs[base + 1],
+                                c_p0,
+                                0,
+                            )
+                            pk = rocdl.cvt_pk_fp8_f32(
+                                i32,
+                                fp8_inputs[base + 2],
+                                fp8_inputs[base + 3],
+                                pk,
+                                1,
+                            )
+                            dword_list.append(pk)
+                        dword = tuple(dword_list)
 
                     # Compute store address (in BYTES from kv_cache base).
                     # Both layouts use the same base (= phys * block_stride);
@@ -1119,16 +1124,34 @@ def _build_kernel(
                             dword, out_rsrc, byte_off, offset_is_bytes=True
                         )
                     else:
-                        # VEC == 8: store 2 dwords (8 bytes) via vec<2xi32>
-                        store_vec = vector.from_elements(
-                            T.vec(2, i32), [dword[0], dword[1]]
-                        )
-                        buffer_ops.buffer_store(
-                            store_vec,
-                            out_rsrc,
-                            byte_off,
-                            offset_is_bytes=True,
-                        )
+                        # VEC in {8, 16}: store n_dwords via dwordx4 chunks
+                        n_dw = VEC // 4
+                        if const_expr(n_dw <= 4):
+                            store_vec = vector.from_elements(
+                                T.vec(n_dw, i32), list(dword)
+                            )
+                            buffer_ops.buffer_store(
+                                store_vec,
+                                out_rsrc,
+                                byte_off,
+                                offset_is_bytes=True,
+                            )
+                        else:
+                            # n_dw > 4 (VEC=16 → n_dw=4, actually fits dwordx4;
+                            # kept for future-proofing)
+                            for chunk_start in range_constexpr(n_dw // 4):
+                                base = chunk_start * 4
+                                sv = vector.from_elements(
+                                    T.vec(4, i32),
+                                    list(dword[base : base + 4]),
+                                )
+                                buffer_ops.buffer_store(
+                                    sv,
+                                    out_rsrc,
+                                    ArithValue(byte_off)
+                                    + arith.constant(base * 4, type=i32),
+                                    offset_is_bytes=True,
+                                )
 
                     # (f) lane-0 writes fp32 scale at cache_scale[phys, slot]
                     is_lane0 = arith.cmpi(
@@ -1214,7 +1237,7 @@ def _build_kernel(
 # K-split single-kernel builder (multi-wave LDS reduce)
 # ============================================================================
 #
-# Why this exists: the legacy single-wave kernel above runs ONE wave64 per
+# Why this exists: the legacy single-wave kernel above runs ONE wave32 per
 # boundary, serializing K iters of online-softmax. PMC on CSA Main (D=512,
 # K=8) showed VALU IPC ~0.33 with 53% of cycles in SQ_WAIT_ANY and only 128
 # VMEM insts — i.e. the wave is stalled on the *serial dependency chain*
@@ -1222,7 +1245,7 @@ def _build_kernel(
 # memory. At decode bs=1-32 each CU holds a single wave, so nothing hides the
 # chain latency.
 #
-# Fix: split K across NW waves in ONE workgroup (block = 64*NW), grid stays
+# Fix: split K across NW waves in ONE workgroup (block = 32*NW), grid stays
 # = plan_capacity (single dispatch → no extra ~2.2us launch floor). Each wave
 # runs K/NW iters; LDS cross-wave online-softmax merges the per-wave
 # accumulators; wave 0 then does RMSNorm + GPT-J RoPE + BF16 scatter inline
@@ -1248,23 +1271,16 @@ def _build_kernel_ksplit(
     rms_weight_is_bf16: bool,
     rms_eps: float,
 ):
-    """K-split single-kernel: NW-wave LDS-reduced compress + norm + rope +
-    scatter (BF16 or FP8). Constexpr knobs mirror :func:`_build_kernel` minus
-    ``enable_prefetch_input`` (each wave runs so few iters that prefetch is
-    moot). The FP8 / ue8m0 / preshuffle scatter is emitted in wave 0, where
-    ``lid`` (0..63) plays the single-wave ``tid`` role — pair-coop
-    shuffle_xor and wave_reduce_max stay within wave 0's 64 lanes, identical
-    to the legacy kernel's semantics.
+    """K-split single-kernel (wave32 / gfx1250): NW-wave LDS-reduced compress +
+    norm + rope + scatter (BF16 or FP8).
 
     Layout:
       - Grid:  (plan_capacity, 1, 1)  — one workgroup per plan row.
-      - Block: 64 * NW threads (NW waves).
-      - VEC = D / 64: each lane owns VEC contiguous D-columns. One wave's 64
+      - Block: 32 * NW threads (NW waves).
+      - VEC = D / 32: each lane owns VEC contiguous D-columns. One wave's 32
         lanes cover the full head_dim.
       - K = (2 if overlap else 1) * ratio, split into NW slices of K_PER_WAVE.
-      - LDS: 3 fp32 arrays of NW*D (m, kv, w). Each lane writes its VEC
-        accumulator values at wid*D + lid*VEC + i; wave 0 reads NW values per
-        owned element and folds them with a global-max online-softmax.
+      - LDS: 3 fp32 arrays of NW*D (m, kv, w).
     """
     D = head_dim
     RD = rope_head_dim
@@ -1280,7 +1296,7 @@ def _build_kernel_ksplit(
     PAIRS_PER_THREAD = VEC // 2
 
     assert D % BLOCK_THREADS == 0, f"D={D} must divide {BLOCK_THREADS}"
-    assert VEC in (2, 4, 8), f"VEC={VEC} outside supported set"
+    assert VEC in (2, 4, 8, 16), f"VEC={VEC} outside supported set"
     assert NOPE >= 0 and NOPE % VEC == 0
     assert RD > 0 and RD % 2 == 0 and RD % VEC == 0
     assert state_size >= K, f"state_size={state_size} < K={K}"
@@ -1309,7 +1325,7 @@ def _build_kernel_ksplit(
     allocator.ptr = lds_w_off + LDS_BYTES
 
     _name_parts = [
-        "fused_compress_attn",
+        "fused_compress_attn_w32",
         f"D{D}",
         f"RD{RD}",
         f"R{ratio}",
@@ -1369,7 +1385,7 @@ def _build_kernel_ksplit(
         c_zero_f32 = arith.constant(0.0, type=f32)
         c_zero_i32 = arith.constant(0, type=i32)
         c_one_i32 = arith.constant(1, type=i32)
-        c_64 = arith.constant(BLOCK_THREADS, type=i32)
+        c_WS = arith.constant(BLOCK_THREADS, type=i32)
         c_eps = arith.constant(rms_eps, type=f32)
         c_inv_D = arith.constant(1.0 / D, type=f32)
         c_log2e = arith.constant(_LOG2E, type=f32)
@@ -1384,8 +1400,8 @@ def _build_kernel_ksplit(
                 f32, "llvm.amdgcn.exp2.f32", [x * c_log2e], [], []
             )
 
-        wid = arith.divsi(_to_raw(tid), c_64)  # ∈ [0, NW)
-        lid = arith.remui(_to_raw(tid), c_64)  # ∈ [0, 64)
+        wid = arith.divsi(_to_raw(tid), c_WS)  # ∈ [0, NW)
+        lid = arith.remui(_to_raw(tid), c_WS)  # ∈ [0, 32)
 
         # ---- plan row (single dwordx4) ----
         plan_rsrc = buffer_ops.create_buffer_resource(plan, max_size=True)
@@ -1435,26 +1451,21 @@ def _build_kernel_ksplit(
                         for i in range(VEC)
                     ]
                 else:
-                    assert VEC == 8
-                    half = VEC // 2
-                    r0 = buffer_ops.buffer_load(
-                        rsrc, off_elems_i32, vec_width=half, dtype=f32
-                    )
-                    r1 = buffer_ops.buffer_load(
-                        rsrc,
-                        ArithValue(off_elems_i32) + arith.constant(half, type=i32),
-                        vec_width=half,
-                        dtype=f32,
-                    )
+                    # VEC in {8, 16} → split into quarter=4 chunks
+                    quarter = 4
+                    n_chunks = VEC // quarter
                     out = []
-                    for i in range_constexpr(half):
-                        out.append(
-                            vector.extract(r0, static_position=[i], dynamic_position=[])
+                    for q in range_constexpr(n_chunks):
+                        r = buffer_ops.buffer_load(
+                            rsrc,
+                            ArithValue(off_elems_i32) + arith.constant(q * quarter, type=i32),
+                            vec_width=quarter,
+                            dtype=f32,
                         )
-                    for i in range_constexpr(half):
-                        out.append(
-                            vector.extract(r1, static_position=[i], dynamic_position=[])
-                        )
+                        for i in range_constexpr(quarter):
+                            out.append(
+                                vector.extract(r, static_position=[i], dynamic_position=[])
+                            )
                     return out
 
             def _load_bf16_vec_then_f32(rsrc, off_elems_i32):
@@ -1463,18 +1474,45 @@ def _build_kernel_ksplit(
                 if const_expr(dwords == 1):
                     raw_s = buffer_ops.buffer_load(rsrc, off_dw, vec_width=1, dtype=i32)
                     raw = vector.from_elements(T.vec(1, T.i32), [raw_s])
-                else:
+                    vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
+                    out = []
+                    for i in range_constexpr(VEC):
+                        bf16_v = vector.extract(
+                            vec_bf16, static_position=[i], dynamic_position=[]
+                        )
+                        out.append(arith.extf(f32, bf16_v))
+                    return out
+                elif const_expr(dwords <= 4):
                     raw = buffer_ops.buffer_load(
                         rsrc, off_dw, vec_width=dwords, dtype=i32
                     )
-                vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
-                out = []
-                for i in range_constexpr(VEC):
-                    bf16_v = vector.extract(
-                        vec_bf16, static_position=[i], dynamic_position=[]
-                    )
-                    out.append(arith.extf(f32, bf16_v))
-                return out
+                    vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
+                    out = []
+                    for i in range_constexpr(VEC):
+                        bf16_v = vector.extract(
+                            vec_bf16, static_position=[i], dynamic_position=[]
+                        )
+                        out.append(arith.extf(f32, bf16_v))
+                    return out
+                else:
+                    # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
+                    half_dw = 4
+                    half_bf16 = half_dw * 2
+                    out = []
+                    for chunk in range_constexpr(dwords // half_dw):
+                        r = buffer_ops.buffer_load(
+                            rsrc,
+                            ArithValue(off_dw) + arith.constant(chunk * half_dw, type=i32),
+                            vec_width=half_dw,
+                            dtype=i32,
+                        )
+                        vbf16 = vector.bitcast(T.vec(half_bf16, T.bf16), r)
+                        for i in range_constexpr(half_bf16):
+                            bf16_v = vector.extract(
+                                vbf16, static_position=[i], dynamic_position=[]
+                            )
+                            out.append(arith.extf(f32, bf16_v))
+                    return out
 
             def _softmax_step(m_lane, kv_lane, w_lane, score_lane, kv_v_lane):
                 """Padding-aware per-lane online-softmax update. Phase 2 scores
@@ -1823,8 +1861,21 @@ def _build_kernel_ksplit(
                             bf16_as_i32, static_position=[0], dynamic_position=[]
                         )
                         buffer_ops.buffer_store(scalar_i32, out_rsrc, cache_off_dw)
-                    else:
+                    elif const_expr(dwords <= 4):
                         buffer_ops.buffer_store(bf16_as_i32, out_rsrc, cache_off_dw)
+                    else:
+                        # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
+                        c4_i32 = arith.constant(4, type=i32)
+                        lo = vector.extract_strided_slice(
+                            T.vec(4, T.i32), bf16_as_i32, offsets=[0], sizes=[4], strides=[1]
+                        )
+                        hi = vector.extract_strided_slice(
+                            T.vec(4, T.i32), bf16_as_i32, offsets=[4], sizes=[4], strides=[1]
+                        )
+                        buffer_ops.buffer_store(lo, out_rsrc, cache_off_dw)
+                        buffer_ops.buffer_store(
+                            hi, out_rsrc, ArithValue(cache_off_dw) + c4_i32
+                        )
                 else:
                     # ── FP8 per-row scaled write + fp32 scale (mirror legacy) ──
                     # Wave-reduce-max over wave 0's 64 lanes; pair-coop dword
@@ -1906,20 +1957,28 @@ def _build_kernel_ksplit(
                         )
                         dword = pk
                     else:
-                        assert VEC == 8
-                        p0 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[0], fp8_inputs[1], c_p0, 0
-                        )
-                        p0 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[2], fp8_inputs[3], p0, 1
-                        )
-                        p1 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[4], fp8_inputs[5], c_p0, 0
-                        )
-                        p1 = rocdl.cvt_pk_fp8_f32(
-                            i32, fp8_inputs[6], fp8_inputs[7], p1, 1
-                        )
-                        dword = (p0, p1)
+                        # VEC in {8, 16}: VEC bytes = VEC/4 dwords
+                        assert VEC in (8, 16)
+                        n_dwords = VEC // 4
+                        dword_list = []
+                        for dw_idx in range_constexpr(n_dwords):
+                            base = dw_idx * 4
+                            pk = rocdl.cvt_pk_fp8_f32(
+                                i32,
+                                fp8_inputs[base + 0],
+                                fp8_inputs[base + 1],
+                                c_p0,
+                                0,
+                            )
+                            pk = rocdl.cvt_pk_fp8_f32(
+                                i32,
+                                fp8_inputs[base + 2],
+                                fp8_inputs[base + 3],
+                                pk,
+                                1,
+                            )
+                            dword_list.append(pk)
+                        dword = tuple(dword_list)
 
                     out_rsrc = buffer_ops.create_buffer_resource(
                         kv_cache, max_size=True
@@ -1968,12 +2027,32 @@ def _build_kernel_ksplit(
                             dword, out_rsrc, byte_off, offset_is_bytes=True
                         )
                     else:
-                        store_vec = vector.from_elements(
-                            T.vec(2, i32), [dword[0], dword[1]]
-                        )
-                        buffer_ops.buffer_store(
-                            store_vec, out_rsrc, byte_off, offset_is_bytes=True
-                        )
+                        # VEC in {8, 16}: store n_dwords via dwordx4 chunks
+                        n_dw = VEC // 4
+                        if const_expr(n_dw <= 4):
+                            store_vec = vector.from_elements(
+                                T.vec(n_dw, i32), list(dword)
+                            )
+                            buffer_ops.buffer_store(
+                                store_vec,
+                                out_rsrc,
+                                byte_off,
+                                offset_is_bytes=True,
+                            )
+                        else:
+                            for chunk_start in range_constexpr(n_dw // 4):
+                                base = chunk_start * 4
+                                sv = vector.from_elements(
+                                    T.vec(4, i32),
+                                    list(dword[base : base + 4]),
+                                )
+                                buffer_ops.buffer_store(
+                                    sv,
+                                    out_rsrc,
+                                    ArithValue(byte_off)
+                                    + arith.constant(base * 4, type=i32),
+                                    offset_is_bytes=True,
+                                )
 
                     # (f) lane-0 writes fp32 scale at cache_scale[phys, slot]
                     is_lane0 = arith.cmpi(
@@ -2071,37 +2150,22 @@ _DEFAULT_COMPILE_HINTS = {
 }
 
 
-def hca_per_n_config(plan_capacity: int) -> tuple[int, int]:
-    """Return ``(slice_size, k_split_num_waves)`` for ``flydsl_hca_compress_attn``
-    tuned for V4-Pro HCA Main (D=512, ratio=128, overlap=False) on MI355X.
+def hca_per_n_config_gfx1250(plan_capacity: int) -> tuple[int, int]:
+    """Return ``(slice_size, k_split_num_waves)`` for gfx1250 HCA.
 
-    Dispatch on ``plan_capacity`` (NOT ``num_compress``): the HCA kernel's
-    grid is ``plan_capacity`` (sentinel rows bail inside), and only
-    ``plan_capacity`` is CUDAGraph-stable (it's fixed per (ratio,
-    batch_bucket) and baked into captured launch args). Dispatching on the
-    runtime-varying ``num_compress`` would silently mis-select kernels for
-    captured graphs.
+    Initial values — need hardware tuning.
     """
     if plan_capacity <= 64:
-        return 64, 8
+        return 32, 8
     if plan_capacity <= 256:
-        return 128, 8
-    if plan_capacity <= 384:
-        return 256, 8
-    if plan_capacity <= 768:
-        # HCA decode bs=512 (plan_cap = bs * ceil((1+MTP)/ratio) = 512 for
-        # ratio=128, MTP≤3) prefers k_split=4 over 8: 30.4 vs 34.9 us on
-        # MI355X (~14% win, ~5 us per HCA layer).
-        return 256, 4
+        return 64, 8
     if plan_capacity <= 1024:
-        return 512, 8
-    if plan_capacity <= 8192:
-        return 512, 4
+        return 256, 4
     return 512, 1
 
 
 @lru_cache(maxsize=32)
-def compile_flydsl_fused_compress_attn(
+def compile_flydsl_fused_compress_attn_gfx1250(
     *,
     head_dim: int,
     rope_head_dim: int,
@@ -2115,7 +2179,7 @@ def compile_flydsl_fused_compress_attn(
     preshuffle: bool,
     rms_weight_is_bf16: bool,
     rms_eps: float,
-    enable_prefetch_input: bool = True,
+    enable_prefetch_input: bool = False,
 ):
     launcher = _build_kernel(
         head_dim=head_dim,
@@ -2136,34 +2200,20 @@ def compile_flydsl_fused_compress_attn(
     return launcher
 
 
-def csa_ksplit_num_waves(plan_capacity: int) -> int:
-    """Auto-pick ``k_split_num_waves`` for the CSA Main BF16 path
-    (D=512, RD=64, ratio=4, overlap, K=8) and the CSA Indexer FP8 path
-    (D=128, RD=64, ratio=4, overlap, K=8) on MI355X. Returns 1 to mean
-    "use the legacy single-wave kernel".
+def csa_ksplit_num_waves_gfx1250(plan_capacity: int) -> int:
+    """Auto-pick ``k_split_num_waves`` for gfx1250 (wave32).
 
-    Rationale (measured, MI355X): the multi-wave LDS K-split parallelizes the
-    serial online-softmax chain that bottlenecks the latency-bound small-N
-    regime (decode: plan_capacity ≤ ~528 always). It wins ~22-30% (BF16) /
-    ~15-24% (FP8) there. At high N the per-boundary CU occupancy is already
-    saturated, so the extra NW× blocks + LDS reduce become pure overhead and
-    the kernel regresses past plan_capacity ≈ 1300. NW=4 beats NW=8 (8-wave
-    LDS fold costs more than the 2 extra K-iters it removes for K=8) and
-    beats NW=2 across both shapes' decode range.
-
-    Dispatch on ``plan_capacity`` (NOT num_compress): it's the grid size and
-    is CUDAGraph-stable (baked into captured launch args), so captured graphs
-    select the same kernel they were traced with.
+    Initial values — need hardware tuning.
     """
-    if plan_capacity <= 768:
+    if plan_capacity <= 512:
         return 4
-    if plan_capacity <= 1280:
+    if plan_capacity <= 1024:
         return 2
     return 1  # legacy single-wave
 
 
 @lru_cache(maxsize=32)
-def compile_flydsl_fused_compress_attn_ksplit(
+def compile_flydsl_fused_compress_attn_ksplit_gfx1250(
     *,
     head_dim: int,
     rope_head_dim: int,
@@ -2196,7 +2246,7 @@ def compile_flydsl_fused_compress_attn_ksplit(
     return launcher
 
 
-def flydsl_fused_compress_attn(
+def flydsl_fused_compress_attn_gfx1250(
     *,
     kv_in: torch.Tensor,  # [num_q_tokens, DIM_FULL] bf16
     score_in: torch.Tensor,  # [num_q_tokens, DIM_FULL] bf16
@@ -2223,54 +2273,15 @@ def flydsl_fused_compress_attn(
     k_split_num_waves: Optional[int] = None,
     stream: Optional[torch.cuda.Stream] = None,
 ) -> None:
-    """FlyDSL drop-in replacement for ``fused_compress_attn`` (Triton).
+    """gfx1250 (wave32) drop-in for ``flydsl_fused_compress_attn``.
 
-    Same side-effecting semantics: cache scatter IS the output. Caller MUST
-    invoke BEFORE ``update_compressor_states`` (state cache reads must see
-    previous-fwd data).
-
-    ``k_split_num_waves`` (BF16 or FP8 scatter): when set to NW > 1, routes to
-    the multi-wave LDS K-split kernel (block = 64*NW, K split across NW waves,
-    single dispatch). Speeds up the latency-bound decode regime (small N,
-    1 wave/CU) where the legacy single-wave serial K-chain stalls. Requires a
-    real ``block_tables`` (has_block_table). When None, auto-picks NW for the
-    tuned CSA Main (BF16) and CSA Indexer (FP8) shapes via
-    :func:`csa_ksplit_num_waves` and uses legacy elsewhere; when 1, forces
-    legacy. K must be divisible by NW.
+    Forces ``preshuffle=False`` (MFMA preshuffle is gfx9-only; gfx1250 uses
+    linear FP8 layout) and ``enable_prefetch_input=False`` (VEC=16 register
+    pressure on RDNA4's 512 VGPRs/wave).
     """
-    # ---- gfx1250 dispatch (wave32) ----
-    from aiter.jit.utils.chip_info import get_gfx as _get_gfx
-
-    if _get_gfx() == "gfx1250":
-        from .fused_compress_attn_gfx1250 import flydsl_fused_compress_attn_gfx1250
-
-        return flydsl_fused_compress_attn_gfx1250(
-            kv_in=kv_in,
-            score_in=score_in,
-            kv_state=kv_state,
-            score_state=score_state,
-            plan_gpu=plan_gpu,
-            state_slot_mapping=state_slot_mapping,
-            ape=ape,
-            rms_weight=rms_weight,
-            rms_eps=rms_eps,
-            cos_cache=cos_cache,
-            sin_cache=sin_cache,
-            kv_cache=kv_cache,
-            block_tables=block_tables,
-            k_per_block=k_per_block,
-            overlap=overlap,
-            ratio=ratio,
-            head_dim=head_dim,
-            rope_head_dim=rope_head_dim,
-            quant=quant,
-            cache_scale=cache_scale,
-            use_ue8m0=use_ue8m0,
-            preshuffle=preshuffle,
-            k_split_num_waves=k_split_num_waves,
-            stream=stream,
-        )
-
+    # gfx1250 overrides
+    preshuffle = False  # MFMA preshuffle is gfx9-only; force linear layout
+    enable_prefetch_input = False  # VEC=16 VGPR pressure
     # ---- input validation ----
     plan_capacity = plan_gpu.shape[0]
     if plan_capacity == 0:
@@ -2395,7 +2406,7 @@ def flydsl_fused_compress_attn(
         head_dim == 128 and rope_head_dim == 64 and ratio == 4 and overlap and quant
     )
     if k_split_num_waves is None and has_bt and (_is_csa_main or _is_csa_indexer):
-        nw_eff = csa_ksplit_num_waves(plan_capacity)
+        nw_eff = csa_ksplit_num_waves_gfx1250(plan_capacity)
     else:
         nw_eff = k_split_num_waves if k_split_num_waves is not None else 1
     use_ksplit = nw_eff > 1 and has_bt
@@ -2405,7 +2416,7 @@ def flydsl_fused_compress_attn(
             raise ValueError(
                 f"k_split_num_waves={k_split_num_waves} must divide K={K_pool}"
             )
-        ks_launcher = compile_flydsl_fused_compress_attn_ksplit(
+        ks_launcher = compile_flydsl_fused_compress_attn_ksplit_gfx1250(
             head_dim=head_dim,
             rope_head_dim=rope_head_dim,
             ratio=ratio,
@@ -2452,7 +2463,7 @@ def flydsl_fused_compress_attn(
         _run_compiled(ks_launcher, *ks_args)
         return
 
-    launcher = compile_flydsl_fused_compress_attn(
+    launcher = compile_flydsl_fused_compress_attn_gfx1250(
         head_dim=head_dim,
         rope_head_dim=rope_head_dim,
         ratio=ratio,

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
@@ -127,21 +127,21 @@ def _build_compress_forward_kernel(
     sub-loop reading kv_in + score_in. Phase 2 in_row is clamped to ≥ 0
     so wasted reads in pure-Phase-1 iters stay in-bounds.
     """
-    assert (
-        head_dim % slice_size == 0
-    ), f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
-    assert (
-        slice_size % 64 == 0
-    ), f"slice_size={slice_size} must be a multiple of 64 (wave width)"
+    assert head_dim % slice_size == 0, (
+        f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
+    )
+    assert slice_size % 64 == 0, (
+        f"slice_size={slice_size} must be a multiple of 64 (wave width)"
+    )
     assert slice_size // 64 in (
         1,
         2,
         4,
         8,
     ), f"VEC={slice_size // 64} must be 1, 2, 4, or 8"
-    assert (
-        ratio % k_split_num_waves == 0
-    ), f"K={ratio} must divide evenly across {k_split_num_waves} waves"
+    assert ratio % k_split_num_waves == 0, (
+        f"K={ratio} must divide evenly across {k_split_num_waves} waves"
+    )
     assert state_size >= ratio, f"state_size={state_size} must be >= K={ratio}"
     D = head_dim
     K = ratio

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
@@ -127,21 +127,21 @@ def _build_compress_forward_kernel(
     sub-loop reading kv_in + score_in. Phase 2 in_row is clamped to ≥ 0
     so wasted reads in pure-Phase-1 iters stay in-bounds.
     """
-    assert head_dim % slice_size == 0, (
-        f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
-    )
-    assert slice_size % 64 == 0, (
-        f"slice_size={slice_size} must be a multiple of 64 (wave width)"
-    )
+    assert (
+        head_dim % slice_size == 0
+    ), f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
+    assert (
+        slice_size % 64 == 0
+    ), f"slice_size={slice_size} must be a multiple of 64 (wave width)"
     assert slice_size // 64 in (
         1,
         2,
         4,
         8,
     ), f"VEC={slice_size // 64} must be 1, 2, 4, or 8"
-    assert ratio % k_split_num_waves == 0, (
-        f"K={ratio} must divide evenly across {k_split_num_waves} waves"
-    )
+    assert (
+        ratio % k_split_num_waves == 0
+    ), f"K={ratio} must divide evenly across {k_split_num_waves} waves"
     assert state_size >= ratio, f"state_size={state_size} must be >= K={ratio}"
     D = head_dim
     K = ratio

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
@@ -101,12 +101,12 @@ def _build_compress_forward_kernel(
     sub-loop reading kv_in + score_in. Phase 2 in_row is clamped to ≥ 0
     so wasted reads in pure-Phase-1 iters stay in-bounds.
     """
-    assert (
-        head_dim % slice_size == 0
-    ), f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
-    assert (
-        slice_size % 32 == 0
-    ), f"slice_size={slice_size} must be a multiple of 32 (wave width)"
+    assert head_dim % slice_size == 0, (
+        f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
+    )
+    assert slice_size % 32 == 0, (
+        f"slice_size={slice_size} must be a multiple of 32 (wave width)"
+    )
     assert slice_size // 32 in (
         1,
         2,
@@ -114,9 +114,9 @@ def _build_compress_forward_kernel(
         8,
         16,
     ), f"VEC={slice_size // 32} must be 1, 2, 4, 8, or 16"
-    assert (
-        ratio % k_split_num_waves == 0
-    ), f"K={ratio} must divide evenly across {k_split_num_waves} waves"
+    assert ratio % k_split_num_waves == 0, (
+        f"K={ratio} must divide evenly across {k_split_num_waves} waves"
+    )
     assert state_size >= ratio, f"state_size={state_size} must be >= K={ratio}"
     D = head_dim
     K = ratio
@@ -149,9 +149,7 @@ def _build_compress_forward_kernel(
     lds_w_off = allocator._align(allocator.ptr, 16)
     allocator.ptr = lds_w_off + LDS_W_BYTES
 
-    _kname = (
-        f"hca_compress_forward_w32_D{D}_R{ratio}_NW{NW}_SL{SLICE_SZ}_S{state_size}_flydsl"
-    )
+    _kname = f"hca_compress_forward_w32_D{D}_R{ratio}_NW{NW}_SL{SLICE_SZ}_S{state_size}_flydsl"
     fm_fast = arith.FastMathFlags.fast
 
     @flyc.kernel(name=_kname, known_block_size=[BLOCK_TH, 1, 1])
@@ -793,7 +791,8 @@ def _build_norm_rope_scatter_kernel(
                     for chunk in range_constexpr(dwords // half_dw):
                         r = buffer_ops.buffer_load(
                             rmsw_rsrc,
-                            ArithValue(off_dw) + arith.constant(chunk * half_dw, type=i32),
+                            ArithValue(off_dw)
+                            + arith.constant(chunk * half_dw, type=i32),
                             vec_width=half_dw,
                             dtype=i32,
                         )
@@ -819,13 +818,16 @@ def _build_norm_rope_scatter_kernel(
                     for q in range_constexpr(n_chunks):
                         r = buffer_ops.buffer_load(
                             rmsw_rsrc,
-                            ArithValue(tid_x_vec) + arith.constant(q * quarter, type=i32),
+                            ArithValue(tid_x_vec)
+                            + arith.constant(q * quarter, type=i32),
                             vec_width=quarter,
                             dtype=f32,
                         )
                         for i in range_constexpr(quarter):
                             rmsw_lane.append(
-                                vector.extract(r, static_position=[i], dynamic_position=[])
+                                vector.extract(
+                                    r, static_position=[i], dynamic_position=[]
+                                )
                             )
 
             normed_lane = [
@@ -958,9 +960,7 @@ def _build_norm_rope_scatter_kernel(
                     T.vec(4, T.i32), bf16_as_i32, offsets=[4], sizes=[4], strides=[1]
                 )
                 buffer_ops.buffer_store(lo, out_rsrc, cache_off_dw)
-                buffer_ops.buffer_store(
-                    hi, out_rsrc, ArithValue(cache_off_dw) + c4_i32
-                )
+                buffer_ops.buffer_store(hi, out_rsrc, ArithValue(cache_off_dw) + c4_i32)
 
     @flyc.jit
     def launch_hca_norm_rope_scatter(

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
@@ -1,43 +1,17 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""HCA-path FlyDSL compress + norm+rope+scatter kernels (2-kernel split).
+"""HCA-path compress + norm+rope+scatter kernels — **gfx1250 (RDNA4, wave32)**.
 
-Targeted optimization for V4-Pro HCA Main: D=512, RD=64, ratio=128, overlap=False.
-Inspired by SGLang's `c128_v2.cuh`, adapted to AMD wave64 / flydsl with a
-multi-wave LDS K-split (Phase 3 of the optimization series):
+Port of ``fused_compress_attn_hca.py`` (wave64) to gfx1250 wave32.
+Key differences:
+  - BLOCK_THREADS = 32 (wave32)
+  - SLICE = 32 (head_dim elements per block)
+  - VEC = SLICE_SZ / 32 (vs /64)
+  - Kernel B: D=512 → VEC=16, requires split load/store paths
+  - Kernel names suffixed with "w32"
 
-  Kernel A — flydsl_hca_compress_forward (multi-wave K-split)
-    Grid:  (num_compress, NUM_SPLIT=head_dim/SLICE)
-    Block: BLOCK_THREADS = 64 * k_split_num_waves (default 8 → 512 threads)
-    Each block covers SLICE=64 head_dim elements of one boundary.
-    K=128 split across NW waves (K_PER_WAVE = K/NW = 16). Per-wave local
-    online-softmax + cross-wave LDS reduction. Each wave's K range splits
-    at clamp(window_len, k_start, k_end) into a Phase 1 (state cache,
-    padded softmax) sub-loop followed by a Phase 2 (ragged input) sub-loop.
-    Output: kv_compressed[num_compress, head_dim] fp32 (compact, indexed by pid).
-
-  Kernel B — flydsl_hca_norm_rope_scatter
-    Grid:  (num_compress,)
-    Block: BLOCK_THREADS=64 (1 wave)
-    Each block reads one row of kv_compressed (full head_dim), does RMSNorm +
-    GPT-J RoPE on the RD tail, scatters to paged kv_cache (BF16 only — HCA
-    Main is the only HCA path that currently routes here; FP8 quant lives in
-    the legacy single-kernel for now).
-
-Why split into two kernels:
-  Single-kernel HCA has 1 wave per boundary × K=128 serial chain = poor CU
-  utilization at small N. Splitting head_dim into NUM_SPLIT=8 grid-Y blocks
-  and parallelising K across NW=8 waves gives 1024 blocks at N=16, drastically
-  cutting register pressure and shortening per-iter dependency chains.
-
-Cost: extra HBM r/w of kv_compressed = num_compress * head_dim * 4 bytes.
-For N=16384 D=512: 32 MB → ~4 us at 8 TB/s. Amortised by the compress kernel
-speedup; after the ``slice_size`` + VEC=8 refactor the 2-kernel path beats
-the legacy single-kernel at ALL N (1.06-3.7×, small N gets the largest win).
-
-NOTE: HCA-only and BF16-only by design. CSA / Indexer / FP8 paths continue
-to use the legacy single-kernel ``flydsl_fused_compress_attn``.
+See ``fused_compress_attn_hca.py`` for the original wave64 documentation.
 """
 
 import math
@@ -67,8 +41,8 @@ from .tensor_shim import STensor, _to_raw, _run_compiled
 # which formatters may not see).
 _FORCE_BIND_LDS = (CompilationContext, STensor, SmemAllocator, SmemPtr, get_rocm_arch)
 
-BLOCK_THREADS = 64  # 1 wave64
-SLICE = 64  # head_dim elements per block (grid-Y split)
+BLOCK_THREADS = 32  # 1 wave32 (RDNA4 / gfx1250)
+SLICE = 32  # head_dim elements per block (grid-Y split)
 _NEG_INF = float("-inf")
 _LOG2E = math.log2(math.e)
 
@@ -131,14 +105,15 @@ def _build_compress_forward_kernel(
         head_dim % slice_size == 0
     ), f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
     assert (
-        slice_size % 64 == 0
-    ), f"slice_size={slice_size} must be a multiple of 64 (wave width)"
-    assert slice_size // 64 in (
+        slice_size % 32 == 0
+    ), f"slice_size={slice_size} must be a multiple of 32 (wave width)"
+    assert slice_size // 32 in (
         1,
         2,
         4,
         8,
-    ), f"VEC={slice_size // 64} must be 1, 2, 4, or 8"
+        16,
+    ), f"VEC={slice_size // 32} must be 1, 2, 4, 8, or 16"
     assert (
         ratio % k_split_num_waves == 0
     ), f"K={ratio} must divide evenly across {k_split_num_waves} waves"
@@ -147,10 +122,10 @@ def _build_compress_forward_kernel(
     K = ratio
     DIM_FULL = D
     SLICE_SZ = slice_size
-    VEC = SLICE_SZ // 64  # per-lane head_dim element count
+    VEC = SLICE_SZ // BLOCK_THREADS  # per-lane head_dim element count
     NUM_SPLIT = D // SLICE_SZ
     NW = k_split_num_waves
-    BLOCK_TH = 64 * NW
+    BLOCK_TH = BLOCK_THREADS * NW
     K_PER_WAVE = K // NW
 
     # LDS layout: three independent fp32 arrays, each [NW * slice_size].
@@ -175,7 +150,7 @@ def _build_compress_forward_kernel(
     allocator.ptr = lds_w_off + LDS_W_BYTES
 
     _kname = (
-        f"hca_compress_forward_D{D}_R{ratio}_NW{NW}_SL{SLICE_SZ}_S{state_size}_flydsl"
+        f"hca_compress_forward_w32_D{D}_R{ratio}_NW{NW}_SL{SLICE_SZ}_S{state_size}_flydsl"
     )
     fm_fast = arith.FastMathFlags.fast
 
@@ -206,7 +181,7 @@ def _build_compress_forward_kernel(
 
         c_zero_i32 = arith.constant(0, type=i32)
         c_one_i32 = arith.constant(1, type=i32)
-        c_64 = arith.constant(64, type=i32)
+        c_WS = arith.constant(BLOCK_THREADS, type=i32)
         c_neg_inf = arith.constant(_NEG_INF, type=f32)
         c_zero_f32 = arith.constant(0.0, type=f32)
         c_log2e = arith.constant(_LOG2E, type=f32)
@@ -224,8 +199,8 @@ def _build_compress_forward_kernel(
             )
 
         # Per-thread wave / lane (block-local).
-        wid = arith.divsi(_to_raw(tid), c_64)  # ∈ [0, NW)
-        lid = arith.remui(_to_raw(tid), c_64)  # ∈ [0, 64)
+        wid = arith.divsi(_to_raw(tid), c_WS)  # ∈ [0, NW)
+        lid = arith.remui(_to_raw(tid), c_WS)  # ∈ [0, 32)
 
         # ── Load plan row ──────────────────────────────────────────────
         plan_rsrc = buffer_ops.create_buffer_resource(plan, max_size=True)
@@ -584,17 +559,20 @@ def _build_compress_forward_kernel(
                     out_vec = vector.from_elements(T.vec(VEC, T.f32), comp_list)
                     buffer_ops.buffer_store(out_vec, out_rsrc, out_off)
                 else:
-                    # VEC == 8: AMD HW max is dwordx4 → 2 stores.
-                    assert VEC == 8
-                    half = VEC // 2
-                    v0 = vector.from_elements(T.vec(half, T.f32), comp_list[0:half])
-                    v1 = vector.from_elements(T.vec(half, T.f32), comp_list[half:VEC])
-                    buffer_ops.buffer_store(v0, out_rsrc, out_off)
-                    buffer_ops.buffer_store(
-                        v1,
-                        out_rsrc,
-                        ArithValue(out_off) + arith.constant(half, type=i32),
-                    )
+                    # VEC > 4: AMD HW max is dwordx4 → split into N× dwordx4 stores.
+                    quarter = 4
+                    n_chunks = VEC // quarter
+                    for q in range_constexpr(n_chunks):
+                        base = q * quarter
+                        sv = vector.from_elements(
+                            T.vec(quarter, T.f32),
+                            comp_list[base : base + quarter],
+                        )
+                        buffer_ops.buffer_store(
+                            sv,
+                            out_rsrc,
+                            ArithValue(out_off) + arith.constant(base, type=i32),
+                        )
 
     @flyc.jit
     def launch_hca_compress_forward(
@@ -673,7 +651,7 @@ def _build_norm_rope_scatter_kernel(
     D = head_dim
     RD = rope_head_dim
     NOPE = D - RD
-    VEC = D // BLOCK_THREADS  # 8 for D=512
+    VEC = D // BLOCK_THREADS  # 16 for D=512 (wave32)
     ROPE_THREAD_LO = NOPE // VEC
     PAIRS_PER_THREAD = VEC // 2
 
@@ -681,7 +659,7 @@ def _build_norm_rope_scatter_kernel(
     assert RD > 0 and RD % 2 == 0 and RD % VEC == 0
 
     _kname = (
-        f"hca_norm_rope_scatter_D{D}_RD{RD}_R{ratio}_KB{k_per_block}"
+        f"hca_norm_rope_scatter_w32_D{D}_RD{RD}_R{ratio}_KB{k_per_block}"
         f"{'_rmsbf16' if rms_weight_is_bf16 else ''}_flydsl"
     )
     fm_fast = arith.FastMathFlags.fast
@@ -740,7 +718,7 @@ def _build_norm_rope_scatter_kernel(
             base_off = (
                 ArithValue(pid) * ArithValue(kv_compressed_row_stride) + tid_x_vec
             )
-            # VEC ∈ {2, 4, 8}: VEC <= 4 → single dwordx{VEC}; VEC=8 → 2× dwordx4.
+            # VEC ∈ {2, 4, 8, 16}: VEC <= 4 → single dwordx{VEC}; VEC>4 → N× dwordx4.
             if const_expr(VEC <= 4):
                 raw = buffer_ops.buffer_load(
                     kvc_rsrc, base_off, vec_width=VEC, dtype=f32
@@ -750,24 +728,20 @@ def _build_norm_rope_scatter_kernel(
                     for i in range(VEC)
                 ]
             else:
-                assert VEC == 8
-                half = 4
-                r0 = buffer_ops.buffer_load(
-                    kvc_rsrc, base_off, vec_width=half, dtype=f32
-                )
-                r1 = buffer_ops.buffer_load(
-                    kvc_rsrc,
-                    ArithValue(base_off) + arith.constant(half, type=i32),
-                    vec_width=half,
-                    dtype=f32,
-                )
-                comp_lane = [
-                    vector.extract(r0, static_position=[i], dynamic_position=[])
-                    for i in range(half)
-                ] + [
-                    vector.extract(r1, static_position=[i], dynamic_position=[])
-                    for i in range(half)
-                ]
+                quarter = 4
+                n_chunks = VEC // quarter
+                comp_lane = []
+                for q in range_constexpr(n_chunks):
+                    r = buffer_ops.buffer_load(
+                        kvc_rsrc,
+                        ArithValue(base_off) + arith.constant(q * quarter, type=i32),
+                        vec_width=quarter,
+                        dtype=f32,
+                    )
+                    for i in range_constexpr(quarter):
+                        comp_lane.append(
+                            vector.extract(r, static_position=[i], dynamic_position=[])
+                        )
 
             # ── RMSNorm (wave reduce-add of squares / D + eps; rsqrt) ──
             sq_local = arith.constant(0.0, type=f32)
@@ -793,17 +767,42 @@ def _build_norm_rope_scatter_kernel(
                         rmsw_rsrc, off_dw, vec_width=1, dtype=i32
                     )
                     raw = vector.from_elements(T.vec(1, T.i32), [raw_s])
-                else:
+                    vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
+                    rmsw_lane = []
+                    for i in range_constexpr(VEC):
+                        bf16_v = vector.extract(
+                            vec_bf16, static_position=[i], dynamic_position=[]
+                        )
+                        rmsw_lane.append(arith.extf(f32, bf16_v))
+                elif const_expr(dwords <= 4):
                     raw = buffer_ops.buffer_load(
                         rmsw_rsrc, off_dw, vec_width=dwords, dtype=i32
                     )
-                vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
-                rmsw_lane = []
-                for i in range_constexpr(VEC):
-                    bf16_v = vector.extract(
-                        vec_bf16, static_position=[i], dynamic_position=[]
-                    )
-                    rmsw_lane.append(arith.extf(f32, bf16_v))
+                    vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
+                    rmsw_lane = []
+                    for i in range_constexpr(VEC):
+                        bf16_v = vector.extract(
+                            vec_bf16, static_position=[i], dynamic_position=[]
+                        )
+                        rmsw_lane.append(arith.extf(f32, bf16_v))
+                else:
+                    # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
+                    half_dw = 4
+                    half_bf16 = half_dw * 2
+                    rmsw_lane = []
+                    for chunk in range_constexpr(dwords // half_dw):
+                        r = buffer_ops.buffer_load(
+                            rmsw_rsrc,
+                            ArithValue(off_dw) + arith.constant(chunk * half_dw, type=i32),
+                            vec_width=half_dw,
+                            dtype=i32,
+                        )
+                        vbf16 = vector.bitcast(T.vec(half_bf16, T.bf16), r)
+                        for i in range_constexpr(half_bf16):
+                            bf16_v = vector.extract(
+                                vbf16, static_position=[i], dynamic_position=[]
+                            )
+                            rmsw_lane.append(arith.extf(f32, bf16_v))
             else:
                 if const_expr(VEC <= 4):
                     raw = buffer_ops.buffer_load(
@@ -814,23 +813,20 @@ def _build_norm_rope_scatter_kernel(
                         for i in range(VEC)
                     ]
                 else:
-                    half = 4
-                    r0 = buffer_ops.buffer_load(
-                        rmsw_rsrc, tid_x_vec, vec_width=half, dtype=f32
-                    )
-                    r1 = buffer_ops.buffer_load(
-                        rmsw_rsrc,
-                        ArithValue(tid_x_vec) + arith.constant(half, type=i32),
-                        vec_width=half,
-                        dtype=f32,
-                    )
-                    rmsw_lane = [
-                        vector.extract(r0, static_position=[i], dynamic_position=[])
-                        for i in range(half)
-                    ] + [
-                        vector.extract(r1, static_position=[i], dynamic_position=[])
-                        for i in range(half)
-                    ]
+                    quarter = 4
+                    n_chunks = VEC // quarter
+                    rmsw_lane = []
+                    for q in range_constexpr(n_chunks):
+                        r = buffer_ops.buffer_load(
+                            rmsw_rsrc,
+                            ArithValue(tid_x_vec) + arith.constant(q * quarter, type=i32),
+                            vec_width=quarter,
+                            dtype=f32,
+                        )
+                        for i in range_constexpr(quarter):
+                            rmsw_lane.append(
+                                vector.extract(r, static_position=[i], dynamic_position=[])
+                            )
 
             normed_lane = [
                 arith.MulFOp(
@@ -950,8 +946,21 @@ def _build_norm_rope_scatter_kernel(
                     bf16_as_i32, static_position=[0], dynamic_position=[]
                 )
                 buffer_ops.buffer_store(scalar_i32, out_rsrc, cache_off_dw)
-            else:
+            elif const_expr(dwords <= 4):
                 buffer_ops.buffer_store(bf16_as_i32, out_rsrc, cache_off_dw)
+            else:
+                # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
+                c4_i32 = arith.constant(4, type=i32)
+                lo = vector.extract_strided_slice(
+                    T.vec(4, T.i32), bf16_as_i32, offsets=[0], sizes=[4], strides=[1]
+                )
+                hi = vector.extract_strided_slice(
+                    T.vec(4, T.i32), bf16_as_i32, offsets=[4], sizes=[4], strides=[1]
+                )
+                buffer_ops.buffer_store(lo, out_rsrc, cache_off_dw)
+                buffer_ops.buffer_store(
+                    hi, out_rsrc, ArithValue(cache_off_dw) + c4_i32
+                )
 
     @flyc.jit
     def launch_hca_norm_rope_scatter(
@@ -1005,7 +1014,7 @@ _DEFAULT_COMPILE_HINTS = {
 
 
 @lru_cache(maxsize=32)
-def compile_hca_compress_forward(
+def compile_hca_compress_forward_gfx1250(
     *,
     head_dim: int,
     ratio: int,
@@ -1042,7 +1051,7 @@ def compile_hca_compress_forward(
 
 
 @lru_cache(maxsize=8)
-def compile_hca_norm_rope_scatter(
+def compile_hca_norm_rope_scatter_gfx1250(
     *,
     head_dim: int,
     rope_head_dim: int,
@@ -1063,7 +1072,7 @@ def compile_hca_norm_rope_scatter(
     return launcher
 
 
-def flydsl_hca_compress_attn(
+def flydsl_hca_compress_attn_gfx1250(
     *,
     kv_in: torch.Tensor,  # [num_q_tokens, head_dim] bf16
     score_in: torch.Tensor,  # [num_q_tokens, head_dim] bf16
@@ -1103,42 +1112,10 @@ def flydsl_hca_compress_attn(
     docstring). Override only when bench-sweeping; the default matches the
     production tuning used by ATOM's compressor.
     """
-    # ---- gfx1250 dispatch (wave32) ----
-    from aiter.jit.utils.chip_info import get_gfx as _get_gfx
-
-    if _get_gfx() == "gfx1250":
-        from .fused_compress_attn_hca_gfx1250 import flydsl_hca_compress_attn_gfx1250
-
-        return flydsl_hca_compress_attn_gfx1250(
-            kv_in=kv_in,
-            score_in=score_in,
-            kv_state=kv_state,
-            score_state=score_state,
-            state_slot_mapping=state_slot_mapping,
-            plan_gpu=plan_gpu,
-            ape=ape,
-            rms_weight=rms_weight,
-            rms_eps=rms_eps,
-            cos_cache=cos_cache,
-            sin_cache=sin_cache,
-            kv_cache=kv_cache,
-            block_tables=block_tables,
-            k_per_block=k_per_block,
-            ratio=ratio,
-            head_dim=head_dim,
-            rope_head_dim=rope_head_dim,
-            kv_compressed_scratch=kv_compressed_scratch,
-            k_split_num_waves=k_split_num_waves,
-            slice_size=slice_size,
-            stream=stream,
-        )
-
     if k_split_num_waves is None or slice_size is None:
-        # Local import to avoid a circular import between the two HCA modules
-        # at package init time.
-        from .fused_compress_attn import hca_per_n_config
+        from .fused_compress_attn_gfx1250 import hca_per_n_config_gfx1250
 
-        auto_slice, auto_kw = hca_per_n_config(plan_gpu.shape[0])
+        auto_slice, auto_kw = hca_per_n_config_gfx1250(plan_gpu.shape[0])
         if slice_size is None:
             slice_size = auto_slice
         if k_split_num_waves is None:
@@ -1226,7 +1203,7 @@ def flydsl_hca_compress_attn(
         stream = torch.cuda.current_stream()
     stream_obj = Stream(stream)
 
-    compress_fn = compile_hca_compress_forward(
+    compress_fn = compile_hca_compress_forward_gfx1250(
         head_dim=head_dim,
         ratio=ratio,
         state_size=int(state_size),
@@ -1255,7 +1232,7 @@ def flydsl_hca_compress_attn(
     _run_compiled(compress_fn, *compress_args)
 
     rms_weight_is_bf16 = rms_weight.dtype == torch.bfloat16
-    norm_fn = compile_hca_norm_rope_scatter(
+    norm_fn = compile_hca_norm_rope_scatter_gfx1250(
         head_dim=head_dim,
         rope_head_dim=rope_head_dim,
         ratio=ratio,

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
@@ -101,12 +101,12 @@ def _build_compress_forward_kernel(
     sub-loop reading kv_in + score_in. Phase 2 in_row is clamped to ≥ 0
     so wasted reads in pure-Phase-1 iters stay in-bounds.
     """
-    assert head_dim % slice_size == 0, (
-        f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
-    )
-    assert slice_size % 32 == 0, (
-        f"slice_size={slice_size} must be a multiple of 32 (wave width)"
-    )
+    assert (
+        head_dim % slice_size == 0
+    ), f"head_dim={head_dim} must be divisible by slice_size={slice_size}"
+    assert (
+        slice_size % 32 == 0
+    ), f"slice_size={slice_size} must be a multiple of 32 (wave width)"
     assert slice_size // 32 in (
         1,
         2,
@@ -114,9 +114,9 @@ def _build_compress_forward_kernel(
         8,
         16,
     ), f"VEC={slice_size // 32} must be 1, 2, 4, 8, or 16"
-    assert ratio % k_split_num_waves == 0, (
-        f"K={ratio} must divide evenly across {k_split_num_waves} waves"
-    )
+    assert (
+        ratio % k_split_num_waves == 0
+    ), f"K={ratio} must divide evenly across {k_split_num_waves} waves"
     assert state_size >= ratio, f"state_size={state_size} must be >= K={ratio}"
     D = head_dim
     K = ratio

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -248,9 +248,9 @@ def _build_kernel(
     ROPE_THREAD_LO = NOPE // VEC
     PAIRS_PER_THREAD = VEC // 2
 
-    assert (
-        D % BLOCK_THREADS == 0
-    ), f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
+    assert D % BLOCK_THREADS == 0, (
+        f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
+    )
     assert NOPE % VEC == 0, f"NOPE={NOPE} must be divisible by VEC={VEC}"
     assert RD % 2 == 0, "rope_head_dim must be even (GPT-J pair layout)"
     assert RD % VEC == 0, f"RD={RD} must be divisible by VEC={VEC}"
@@ -270,20 +270,20 @@ def _build_kernel(
     # --- quant-group layout ------------------------------------------------
     # group_size must divide D evenly AND be a multiple of VEC (so a single
     # thread's VEC-wide slice never crosses a group boundary).
-    assert (
-        group_size > 0 and D % group_size == 0
-    ), f"group_size {group_size} must divide head_dim {D}"
-    assert (
-        group_size % VEC == 0
-    ), f"group_size {group_size} must be a multiple of VEC {VEC}"
+    assert group_size > 0 and D % group_size == 0, (
+        f"group_size {group_size} must divide head_dim {D}"
+    )
+    assert group_size % VEC == 0, (
+        f"group_size {group_size} must be a multiple of VEC {VEC}"
+    )
     TPG = group_size // VEC  # threads per group
     NG = D // group_size  # number of groups per row
-    assert (
-        TPG > 0 and (TPG & (TPG - 1)) == 0
-    ), f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
-    assert (
-        scale_dtype in SCALE_DTYPE_OPTIONS
-    ), f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
+    assert TPG > 0 and (TPG & (TPG - 1)) == 0, (
+        f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
+    )
+    assert scale_dtype in SCALE_DTYPE_OPTIONS, (
+        f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
+    )
 
     log2_block = int(math.log2(BLOCK_THREADS))
     log2_tpg = int(math.log2(TPG))
@@ -1047,7 +1047,7 @@ def flydsl_qk_norm_rope_quant(
     # Normalize Q to [T, H, D] (the kernel expects 3D).
     if q.dim() == 2:
         if q.shape[1] != H * D:
-            raise ValueError(f"q shape {tuple(q.shape)} != [T, H*D={H*D}]")
+            raise ValueError(f"q shape {tuple(q.shape)} != [T, H*D={H * D}]")
         if not q.is_contiguous():
             raise ValueError("2D q must be contiguous to .view as [T,H,D]")
         q_view = q.view(T_tok, H, D)

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -1001,6 +1001,9 @@ def flydsl_qk_norm_rope_quant(
             kv_out=kv_out,
             q_scale=q_scale,
             kv_scale=kv_scale,
+            swa_kv=swa_kv,
+            state_slot_mapping=state_slot_mapping,
+            batch_id_per_token=batch_id_per_token,
             stream=stream,
         )
 

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -248,9 +248,9 @@ def _build_kernel(
     ROPE_THREAD_LO = NOPE // VEC
     PAIRS_PER_THREAD = VEC // 2
 
-    assert D % BLOCK_THREADS == 0, (
-        f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
-    )
+    assert (
+        D % BLOCK_THREADS == 0
+    ), f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
     assert NOPE % VEC == 0, f"NOPE={NOPE} must be divisible by VEC={VEC}"
     assert RD % 2 == 0, "rope_head_dim must be even (GPT-J pair layout)"
     assert RD % VEC == 0, f"RD={RD} must be divisible by VEC={VEC}"
@@ -270,20 +270,20 @@ def _build_kernel(
     # --- quant-group layout ------------------------------------------------
     # group_size must divide D evenly AND be a multiple of VEC (so a single
     # thread's VEC-wide slice never crosses a group boundary).
-    assert group_size > 0 and D % group_size == 0, (
-        f"group_size {group_size} must divide head_dim {D}"
-    )
-    assert group_size % VEC == 0, (
-        f"group_size {group_size} must be a multiple of VEC {VEC}"
-    )
+    assert (
+        group_size > 0 and D % group_size == 0
+    ), f"group_size {group_size} must divide head_dim {D}"
+    assert (
+        group_size % VEC == 0
+    ), f"group_size {group_size} must be a multiple of VEC {VEC}"
     TPG = group_size // VEC  # threads per group
     NG = D // group_size  # number of groups per row
-    assert TPG > 0 and (TPG & (TPG - 1)) == 0, (
-        f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
-    )
-    assert scale_dtype in SCALE_DTYPE_OPTIONS, (
-        f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
-    )
+    assert (
+        TPG > 0 and (TPG & (TPG - 1)) == 0
+    ), f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
+    assert (
+        scale_dtype in SCALE_DTYPE_OPTIONS
+    ), f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
 
     log2_block = int(math.log2(BLOCK_THREADS))
     log2_tpg = int(math.log2(TPG))

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
@@ -62,7 +62,6 @@ from flydsl.expr import math as fmath
 from flydsl.expr.arith import ArithValue, CmpFPredicate
 from flydsl.expr.typing import T, Int32, Stream
 from flydsl.expr.vector import ReductionOp
-from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl._mlir.dialects import llvm, rocdl
 
 from .tensor_shim import GTensor, _to_raw, _run_compiled
@@ -266,9 +265,9 @@ def _build_kernel(
     ROPE_THREAD_LO = NOPE // VEC
     PAIRS_PER_THREAD = VEC // 2
 
-    assert (
-        D % BLOCK_THREADS == 0
-    ), f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
+    assert D % BLOCK_THREADS == 0, (
+        f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
+    )
     assert NOPE % VEC == 0, f"NOPE={NOPE} must be divisible by VEC={VEC}"
     assert RD % 2 == 0, "rope_head_dim must be even (GPT-J pair layout)"
     assert RD % VEC == 0, f"RD={RD} must be divisible by VEC={VEC}"
@@ -281,20 +280,20 @@ def _build_kernel(
     # --- quant-group layout ------------------------------------------------
     # group_size must divide D evenly AND be a multiple of VEC (so a single
     # thread's VEC-wide slice never crosses a group boundary).
-    assert (
-        group_size > 0 and D % group_size == 0
-    ), f"group_size {group_size} must divide head_dim {D}"
-    assert (
-        group_size % VEC == 0
-    ), f"group_size {group_size} must be a multiple of VEC {VEC}"
+    assert group_size > 0 and D % group_size == 0, (
+        f"group_size {group_size} must divide head_dim {D}"
+    )
+    assert group_size % VEC == 0, (
+        f"group_size {group_size} must be a multiple of VEC {VEC}"
+    )
     TPG = group_size // VEC  # threads per group
     NG = D // group_size  # number of groups per row
-    assert (
-        TPG > 0 and (TPG & (TPG - 1)) == 0
-    ), f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
-    assert (
-        scale_dtype in SCALE_DTYPE_OPTIONS
-    ), f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
+    assert TPG > 0 and (TPG & (TPG - 1)) == 0, (
+        f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
+    )
+    assert scale_dtype in SCALE_DTYPE_OPTIONS, (
+        f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
+    )
 
     log2_block = int(math.log2(BLOCK_THREADS))
     log2_tpg = int(math.log2(TPG))
@@ -371,6 +370,7 @@ def _build_kernel(
                 fx.copy_atom_call(full_atom, fx.slice(wdiv, (None, tid_val)), r)
                 return fx.memref_load_vec(r)
         else:
+
             def _load_weight_tensor(weight_tensor, tid_val):
                 """Load VEC bf16 from a 1D weight fx.Tensor via raw buffer_load.
                 Splits into dwordx4 chunks for VEC=16."""
@@ -396,9 +396,7 @@ def _build_kernel(
             dwords = VEC // 2
             out = []
             if const_expr(dwords <= 4):
-                raw = buffer_ops.buffer_load(
-                    rsrc, off_dw, vec_width=dwords, dtype=i32
-                )
+                raw = buffer_ops.buffer_load(rsrc, off_dw, vec_width=dwords, dtype=i32)
                 vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
                 for i in range_constexpr(VEC):
                     bf16_v = vector.extract(
@@ -411,8 +409,7 @@ def _build_kernel(
                 for chunk in range_constexpr(dwords // half_dw):
                     r = buffer_ops.buffer_load(
                         rsrc,
-                        ArithValue(off_dw)
-                        + arith.constant(chunk * half_dw, type=i32),
+                        ArithValue(off_dw) + arith.constant(chunk * half_dw, type=i32),
                         vec_width=half_dw,
                         dtype=i32,
                     )
@@ -875,7 +872,7 @@ def flydsl_qk_norm_rope_quant_gfx1250(
 
     if q.dim() == 2:
         if q.shape[1] != H * D:
-            raise ValueError(f"q shape {tuple(q.shape)} != [T, H*D={H*D}]")
+            raise ValueError(f"q shape {tuple(q.shape)} != [T, H*D={H * D}]")
         if not q.is_contiguous():
             raise ValueError("2D q must be contiguous to .view as [T,H,D]")
         q_view = q.view(T_tok, H, D)

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
@@ -243,6 +243,7 @@ def _build_kernel(
     group_size: int,
     scale_dtype: str,
     q_weighted: bool,
+    kv_write: bool = False,
 ):
     """Build the @flyc.kernel + @flyc.jit launcher for a given config.
 
@@ -315,6 +316,8 @@ def _build_kernel(
     if quant:
         _name_parts.append(f"g{group_size}")
         _name_parts.append(scale_dtype)
+    if kv_write:
+        _name_parts.append("kvw")
     _name_parts.append("w32")
     _name_parts.append("flydsl")
     _kname = "_".join(_name_parts)
@@ -333,6 +336,12 @@ def _build_kernel(
         q_scale: fx.Pointer,  # [T, H, NG]        f32 or uint8 (e8m0)
         kv_scale: fx.Pointer,  # [T, NG]           f32 or uint8 (e8m0)
         kv_in_row_stride: Int32,  # KV row stride in bf16 elements
+        swa_kv: fx.Pointer,  # [num_slots, cache_size, D] bf16 (dummy if not kv_write)
+        state_slot_mapping: fx.Pointer,  # [bs] i32 (dummy if not kv_write)
+        batch_id_per_token: fx.Pointer,  # [T] i32, -1 sentinel (dummy if not kv_write)
+        swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
+        swa_pos_stride: Int32,  # bf16 elements (= D)
+        swa_cache_size: Int32,  # ring slot count
     ):
         f32 = T.f32
         i32 = T.i32
@@ -467,6 +476,9 @@ def _build_kernel(
             fp8_out_rsrc,  # (rsrc_token_shifted, row_base_bytes_within_token) when quant
             scale_rsrc,
             scale_base_off,  # base elem-offset; per-lane adds (tid // TPG)
+            swa_out_rsrc=None,  # raw buffer resource for SWA scatter (kv_write only)
+            swa_out_row_base_bytes=None,  # byte offset for SWA target row
+            do_swa=None,  # i1 predicate (batch_id >= 0); None when no kv_write
         ):
             """Apply RMSNorm + GPT-J RoPE (+ optional FP8 quant) for the row
             held by this block. ``x_f32_vec`` and (optional) ``w_f32_vec`` are
@@ -570,6 +582,15 @@ def _build_kernel(
                     _store_bf16_vec(
                         rope_out, bf16_out_rsrc, bf16_out_row_base_bytes, tid, VEC
                     )
+                    if const_expr(kv_write):
+                        if do_swa:
+                            _store_bf16_vec(
+                                rope_out,
+                                swa_out_rsrc,
+                                swa_out_row_base_bytes,
+                                tid,
+                                VEC,
+                            )
             else:
                 # ---- NOPE path: direct scaled store ----
                 scaled = []
@@ -588,6 +609,15 @@ def _build_kernel(
                     _store_bf16_vec(
                         scaled, bf16_out_rsrc, bf16_out_row_base_bytes, tid, VEC
                     )
+                    if const_expr(kv_write):
+                        if do_swa:
+                            _store_bf16_vec(
+                                scaled,
+                                swa_out_rsrc,
+                                swa_out_row_base_bytes,
+                                tid,
+                                VEC,
+                            )
 
         # ============ runtime dispatch on bid_x < H ============
         q_tok_off_bytes = arith.MulIOp(
@@ -722,6 +752,38 @@ def _build_kernel(
                 )
                 kvo_rsrc = kvo_g_tmp.rsrc
                 row_base_bytes_kv = arith.constant(0, type=i32)
+
+                # ---- Fused SWA scatter setup (kv_write only) ----
+                swa_rsrc = None
+                swa_row_base = None
+                do_swa = None
+                if const_expr(kv_write):
+                    bid_rsrc = _ptr_buffer_resource(batch_id_per_token)
+                    bid_i32 = buffer_ops.buffer_load(
+                        bid_rsrc, bid_t, vec_width=1, dtype=i32
+                    )
+                    do_swa = bid_i32 >= fx.Int32(0)
+                    bid_safe = arith.maxsi(bid_i32, arith.constant(0, type=i32))
+                    slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
+                    slot = buffer_ops.buffer_load(
+                        slot_rsrc, bid_safe, vec_width=1, dtype=i32
+                    )
+                    ring = arith.remsi(pos_i32, _to_raw(swa_cache_size))
+                    swa_off_elems = ArithValue(slot) * ArithValue(
+                        swa_slot_stride
+                    ) + ArithValue(ring) * ArithValue(swa_pos_stride)
+                    swa_off_bytes = arith.index_cast(
+                        T.index, _to_raw(swa_off_elems)
+                    ) * arith.constant(2, type=T.index)
+                    swa_g_tmp = GTensor(
+                        swa_kv,
+                        dtype=T.bf16,
+                        shape=(D,),
+                        static_bytes_offset_i64=swa_off_bytes,
+                    )
+                    swa_rsrc = swa_g_tmp.rsrc
+                    swa_row_base = arith.constant(0, type=i32)
+
                 emit_body(
                     weighted=True,
                     x_f32_vec=x_vec_f32,
@@ -731,6 +793,9 @@ def _build_kernel(
                     fp8_out_rsrc=None,
                     scale_rsrc=None,
                     scale_base_off=None,
+                    swa_out_rsrc=swa_rsrc,
+                    swa_out_row_base_bytes=swa_row_base,
+                    do_swa=do_swa,
                 )
 
     @flyc.jit
@@ -747,6 +812,12 @@ def _build_kernel(
         q_scale: fx.Pointer,
         kv_scale: fx.Pointer,
         kv_in_row_stride: fx.Int32,
+        swa_kv: fx.Pointer,
+        state_slot_mapping: fx.Pointer,
+        batch_id_per_token: fx.Pointer,
+        swa_slot_stride: fx.Int32,
+        swa_pos_stride: fx.Int32,
+        swa_cache_size: fx.Int32,
         num_tokens: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
@@ -764,6 +835,12 @@ def _build_kernel(
             q_scale,
             kv_scale,
             kv_in_row_stride,
+            swa_kv,
+            state_slot_mapping,
+            batch_id_per_token,
+            swa_slot_stride,
+            swa_pos_stride,
+            swa_cache_size,
         )
         k.launch(
             grid=(H + 1, idx_tokens, 1),
@@ -795,6 +872,7 @@ def compile_flydsl_qk_norm_rope_quant_gfx1250(
     group_size: int,
     scale_dtype: str,
     q_weighted: bool,
+    kv_write: bool = False,
 ):
     """Compile (and cache) the gfx1250 wave32 launcher for a given config."""
     launcher = _build_kernel(
@@ -805,6 +883,7 @@ def compile_flydsl_qk_norm_rope_quant_gfx1250(
         group_size=group_size,
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
+        kv_write=kv_write,
     )
     launcher.compile_hints = dict(_DEFAULT_COMPILE_HINTS)
     return launcher
@@ -829,6 +908,9 @@ def flydsl_qk_norm_rope_quant_gfx1250(
     kv_out: Optional[torch.Tensor] = None,
     q_scale: Optional[torch.Tensor] = None,
     kv_scale: Optional[torch.Tensor] = None,
+    swa_kv: Optional[torch.Tensor] = None,
+    state_slot_mapping: Optional[torch.Tensor] = None,
+    batch_id_per_token: Optional[torch.Tensor] = None,
     stream: Optional[torch.cuda.Stream] = None,
 ) -> Tuple[
     torch.Tensor,
@@ -921,6 +1003,43 @@ def flydsl_qk_norm_rope_quant_gfx1250(
         q_scale_arg = q.new_empty(1, dtype=scale_torch_dtype)
         kv_scale_arg = q.new_empty(1, dtype=scale_torch_dtype)
 
+    # ---- Fused SWA cache-write (BF16 only) ----
+    kv_write = swa_kv is not None
+    if kv_write:
+        if quant:
+            raise ValueError("kv_write (swa_kv) is BF16 only; not supported with quant")
+        if state_slot_mapping is None or batch_id_per_token is None:
+            raise ValueError(
+                "kv_write requires state_slot_mapping and batch_id_per_token"
+            )
+        if swa_kv.dim() != 3 or swa_kv.shape[2] != D:
+            raise ValueError(f"swa_kv must be [S, C, D={D}], got {tuple(swa_kv.shape)}")
+        if swa_kv.dtype != torch.bfloat16:
+            raise TypeError(f"swa_kv must be bf16, got {swa_kv.dtype}")
+        if not swa_kv.is_contiguous():
+            raise ValueError("swa_kv must be contiguous")
+        if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
+            raise TypeError("state_slot_mapping must be 1-D int32")
+        if batch_id_per_token.dim() != 1 or batch_id_per_token.dtype != torch.int32:
+            raise TypeError("batch_id_per_token must be 1-D int32")
+        if batch_id_per_token.shape[0] < T_tok:
+            raise ValueError(
+                f"batch_id_per_token len {batch_id_per_token.shape[0]} < T={T_tok}"
+            )
+        swa_slot_stride = swa_kv.stride(0)
+        swa_pos_stride = swa_kv.stride(1)
+        swa_cache_size = swa_kv.shape[1]
+        swa_kv_arg = swa_kv
+        ssm_arg = state_slot_mapping
+        bid_arg = batch_id_per_token
+    else:
+        swa_slot_stride = 0
+        swa_pos_stride = 0
+        swa_cache_size = 1
+        swa_kv_arg = kv_out  # bf16 dummy
+        ssm_arg = q.new_empty(1, dtype=torch.int32)
+        bid_arg = q.new_empty(1, dtype=torch.int32)
+
     launcher = compile_flydsl_qk_norm_rope_quant_gfx1250(
         num_q_heads=H,
         head_dim=D,
@@ -929,6 +1048,7 @@ def flydsl_qk_norm_rope_quant_gfx1250(
         group_size=G,
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
+        kv_write=kv_write,
     )
 
     if stream is None:
@@ -969,6 +1089,12 @@ def flydsl_qk_norm_rope_quant_gfx1250(
             _ptr_arg(q_scale_arg[start:end] if quant else q_scale_arg),
             _ptr_arg(kv_scale_arg[start:end] if quant else kv_scale_arg),
             kv.stride(0),
+            _ptr_arg(swa_kv_arg),
+            _ptr_arg(ssm_arg),
+            _ptr_arg(bid_arg[start:end] if kv_write else bid_arg),
+            swa_slot_stride,
+            swa_pos_stride,
+            swa_cache_size,
             n,
             _stream_arg(),
         )

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
@@ -3,37 +3,32 @@
 
 """Fused per-token RMSNorm + GPT-J RoPE + optional FP8 quant (FlyDSL).
 
+gfx1250 (wave32) variant — BLOCK_THREADS=32, VEC=D/32 (=16 for D=512).
+
 Q + KV combined into a single kernel launch (grid Y = num_tokens, grid X =
-num_q_heads + 1: bid_x ? [0, H) handle Q heads, bid_x == H handles KV).
+num_q_heads + 1: bid_x ∈ [0, H) handle Q heads, bid_x == H handles KV).
 
-Hard-coded MVP shape: D=512, RD=64, BLOCK_THREADS=64. Each block uses one
-wave (64 threads x 8 bf16 = 512 elems = D), so reductions are wave-local
-(shuffle_xor, no LDS, no barrier).
+Layout per block (D=512, BLOCK_THREADS=32):
+  - VEC = D // 32 = 16
+  - thread t ∈ [0, ROPE_THREAD_LO) owns NOPE elements [t*16, t*16+16)
+  - thread t ∈ [ROPE_THREAD_LO, 32) owns ROPE elements [t*16, t*16+16) which
+    form ``PAIRS_PER_THREAD=8`` GPT-J pairs (2k, 2k+1)
 
-Layout per block:
-  - thread t ? [0, ROPE_THREAD_LO) owns NOPE elements [t*8, t*8+8)
-  - thread t ? [ROPE_THREAD_LO, 64) owns ROPE elements [t*8, t*8+8) which
-    form ``PAIRS_PER_THREAD`` GPT-J pairs (2k, 2k+1)
+Key wave32 changes vs wave64 original:
+  - BLOCK_THREADS = 32 (1 wave32 on RDNA4/gfx1250)
+  - VEC = 16 for D=512 (was 8); all load/store paths generalized for VEC>8
+  - shuffle_xor width = 32; butterfly reduction log2(32)=5 passes (was 6)
+  - FP8 packing: VEC/4 dwords (4 dwords for VEC=16) stored as dwordx4
+  - BF16 store: VEC=16 → 8 dwords, split into 2× dwordx4 via extract_strided_slice
+  - BF16 load: VEC=16 → 8 dwords, split into 2× dwordx4 buffer_load
+  - Rope CopyAtom: BufferCopy128b (16 bytes = 8 pairs for PAIRS_PER_THREAD=8)
+  - No preshuffle (gfx1250 uses linear FP8 layout)
 
-GPT-J RoPE with REUSE_FREQS_FRONT_PART=True: cos/sin shape (..., RD/2),
-each pair (2k, 2k+1) shares cos[k], sin[k]. Each rope-thread loads
-PAIRS_PER_THREAD cos + PAIRS_PER_THREAD sin (one dwordx2 buffer load each).
-
-FP8 fast-path uses the rstd-cancellation algebra (matches the Triton kernel
-in ``atom/model_ops/v4_kernels/qk_norm_rope_maybe_quant.py``):
-
-    scale  = abs_max(x_norm) * SQRT2 / FP8_MAX     (sqrt(2) upper bound on rope mag)
-    factor = FP8_MAX / (abs_max(x_in) * SQRT2)     (rstd cancels algebraically)
-    out_nope = x_in * factor              -> fp8
-    out_pe   = (pe_in * factor) RoPEd     -> fp8
-
-(For the weighted KV path the algebra carries the per-channel weight: amax
-is taken over |x_in * w|, factor multiplies in w on the store side.)
-
-Public API: ``flydsl_qk_norm_rope_quant`` (torch-friendly, allocates outputs,
-binds current stream, handles strided KV and 4D cos/sin views). Internal
-``compile_flydsl_qk_norm_rope_quant`` returns the cached launcher for callers
-who already have all buffers and want the lowest-overhead path.
+Public API: ``flydsl_qk_norm_rope_quant_gfx1250`` (torch-friendly, allocates
+outputs, binds current stream, handles strided KV and 4D cos/sin views).
+Internal ``compile_flydsl_qk_norm_rope_quant_gfx1250`` returns the cached
+launcher for callers who already have all buffers and want the lowest-overhead
+path.
 """
 
 # NOTE: do NOT add `from __future__ import annotations` to this file.
@@ -105,8 +100,8 @@ def _cached_from_dlpack(t: torch.Tensor):
     return adaptor
 
 
-# --- shape constants (V4-Pro MVP) -------------------------------------------
-BLOCK_THREADS = 64  # 1 wave64
+# --- shape constants (gfx1250 wave32) -----------------------------------------
+BLOCK_THREADS = 32  # 1 wave32 on RDNA4/gfx1250
 
 # SQRT2 has no aiter dependency, so it stays at module level.
 _SQRT2 = math.sqrt(2.0)
@@ -156,34 +151,57 @@ _TORCH_DTYPE_FOR_SCALE = {
 # ============================================================================
 
 
-def _store_bf16_vec_g(vals_list, g_out, row_off_elems, idx, vec):
-    """Convert VEC fp32 values to a bf16 vector and store via a GTensor whose
-    base is already shifted per-token. ``row_off_elems`` is this head's row
-    offset within the token (i32 elements); ``idx`` is the lane id."""
-    vec_t = T.vec(vec, T.f32)
+def _store_bf16_vec(vals_list, out_rsrc, row_base_bytes, idx, vec):
+    """Convert VEC fp32 values to bf16, reinterpret as i32 dwords, and store
+    via raw buffer_store. Handles VEC>8 by splitting into dwordx4 chunks.
+
+    ``row_base_bytes`` is byte offset to the start of this head's row within
+    the token (already token-shifted). ``idx`` is the lane id (tid).
+    """
+    i32 = T.i32
+    f32 = T.f32
+    vec_f32 = T.vec(vec, f32)
+    vec_bf16 = T.vec(vec, T.bf16)
     raw = [v.ir_value() if hasattr(v, "ir_value") else v for v in vals_list]
-    f32v = vector.from_elements(vec_t, raw)
-    bf16v = f32v.truncf(T.vec(vec, T.bf16))
-    my_off = ArithValue(row_off_elems) + ArithValue(idx) * arith.constant(
-        vec, type=T.i32
-    )
-    g_out.store(my_off, bf16v, vec_size=vec)
+    f32v = vector.from_elements(vec_f32, raw)
+    bf16v = f32v.truncf(vec_bf16)
+
+    # bf16 -> i32 dwords: VEC bf16 = VEC/2 dwords
+    dwords = vec // 2
+    bf16_as_i32 = vector.bitcast(T.vec(dwords, i32), bf16v)
+    off_bytes = row_base_bytes + ArithValue(idx) * arith.constant(vec * 2, type=i32)
+
+    if const_expr(dwords <= 4):
+        buffer_ops.buffer_store(bf16_as_i32, out_rsrc, off_bytes, offset_is_bytes=True)
+    else:
+        # dwords > 4 (VEC=16 → dwords=8): split into 2× dwordx4
+        c4_bytes = arith.constant(16, type=i32)  # 4 dwords = 16 bytes
+        lo = vector.extract_strided_slice(
+            T.vec(4, i32), bf16_as_i32, offsets=[0], sizes=[4], strides=[1]
+        )
+        hi = vector.extract_strided_slice(
+            T.vec(4, i32), bf16_as_i32, offsets=[4], sizes=[4], strides=[1]
+        )
+        buffer_ops.buffer_store(lo, out_rsrc, off_bytes, offset_is_bytes=True)
+        buffer_ops.buffer_store(
+            hi, out_rsrc, ArithValue(off_bytes) + c4_bytes, offset_is_bytes=True
+        )
 
 
 def _store_fp8_packed(vals_list, out_rsrc, row_base_bytes, idx, vec):
-    """Pack VEC fp32 -> VEC fp8 (e4m3fnuz) via cvt_pk_fp8_f32 and store.
+    """Pack VEC fp32 -> VEC fp8 via cvt_pk_fp8_f32 and store.
 
-    Emits one ``buffer_store_dwordx2`` per thread (VEC=8 -> 2 dwords = 8 bytes).
+    Generalized for VEC ∈ {8, 16}: packs into VEC//4 dwords, stores as a
+    single vector (dwordx2 for VEC=8, dwordx4 for VEC=16).
 
     Workaround for the e4m3fnuz NaN encoding 0x80: cvt_pk_fp8_f32 returns
     0x80 (NaN) for inputs that round to negative zero, which propagates
-    through downstream attention as NaN. Clamp v ? (-2^-8, 0) to +0 first.
+    through downstream attention as NaN. Clamp v ∈ (-2^-8, 0) to +0 first.
     """
     f32 = T.f32
     i32 = T.i32
     c0 = arith.constant(0.0, type=f32)
     c_neg_uf = arith.constant(-(2.0**-8), type=f32)
-    c8 = arith.constant(8, type=i32)
 
     safe = []
     for v in vals_list:
@@ -194,19 +212,21 @@ def _store_fp8_packed(vals_list, out_rsrc, row_base_bytes, idx, vec):
         )
         safe.append(arith.select(is_tn, c0, vv))
 
-    # Pack each pair (s[2i], s[2i+1]) into a packed-fp8 i32, then
-    # combine 4 fp8 into one i32 via cvt_pk_fp8_f32 (lane 0 + lane 1).
-    assert vec == 8, "fp8 store helper hardcoded for VEC=8"
-    p0 = arith.constant(0, type=i32)
-    p0 = rocdl.cvt_pk_fp8_f32(i32, safe[0], safe[1], p0, 0)
-    p0 = rocdl.cvt_pk_fp8_f32(i32, safe[2], safe[3], p0, 1)
-    p1 = arith.constant(0, type=i32)
-    p1 = rocdl.cvt_pk_fp8_f32(i32, safe[4], safe[5], p1, 0)
-    p1 = rocdl.cvt_pk_fp8_f32(i32, safe[6], safe[7], p1, 1)
+    # Pack each group of 4 fp32 into one i32 dword via cvt_pk_fp8_f32.
+    n_dwords = vec // 4
+    assert n_dwords in (2, 4), f"VEC={vec} -> n_dwords={n_dwords} unsupported"
+    dword_list = []
+    for dw_idx in range_constexpr(n_dwords):
+        base = dw_idx * 4
+        pk = arith.constant(0, type=i32)
+        pk = rocdl.cvt_pk_fp8_f32(i32, safe[base + 0], safe[base + 1], pk, 0)
+        pk = rocdl.cvt_pk_fp8_f32(i32, safe[base + 2], safe[base + 3], pk, 1)
+        dword_list.append(pk)
 
-    off_bytes = row_base_bytes + ArithValue(idx) * c8
-    vec2_i32 = T.vec(2, i32)
-    store_vec = vector.from_elements(vec2_i32, [p0, p1])
+    c_vec_bytes = arith.constant(vec, type=i32)  # VEC fp8 bytes per thread
+    off_bytes = row_base_bytes + ArithValue(idx) * c_vec_bytes
+    store_vec_ty = T.vec(n_dwords, i32)
+    store_vec = vector.from_elements(store_vec_ty, dword_list)
     buffer_ops.buffer_store(store_vec, out_rsrc, off_bytes, offset_is_bytes=True)
 
 
@@ -224,7 +244,6 @@ def _build_kernel(
     group_size: int,
     scale_dtype: str,
     q_weighted: bool,
-    kv_write: bool = False,
 ):
     """Build the @flyc.kernel + @flyc.jit launcher for a given config.
 
@@ -232,10 +251,9 @@ def _build_kernel(
     launchers with different (H, D, RD, group_size, scale_dtype, q_weighted)
     coexist safely. Returns the launcher.
 
-    quant=True writes fp8 (e4m3fnuz) with one scale per ``group_size``-wide
-    block of D. When ``group_size == head_dim`` the scale degenerates to
-    per-row (NG=1). scale_dtype controls the stored scale encoding
-    (``"fp32"`` or ``"e8m0"``).
+    quant=True writes fp8 with one scale per ``group_size``-wide block of D.
+    When ``group_size == head_dim`` the scale degenerates to per-row (NG=1).
+    scale_dtype controls the stored scale encoding (``"fp32"`` or ``"e8m0"``).
 
     q_weighted=True applies a per-channel weight to Q after RMSNorm (same
     pattern as KV). Default False keeps Q weightless (V4-Pro convention).
@@ -254,17 +272,10 @@ def _build_kernel(
     assert NOPE % VEC == 0, f"NOPE={NOPE} must be divisible by VEC={VEC}"
     assert RD % 2 == 0, "rope_head_dim must be even (GPT-J pair layout)"
     assert RD % VEC == 0, f"RD={RD} must be divisible by VEC={VEC}"
-    # Current MVP is hard-wired to VEC=8 (= D=512 with BLOCK_THREADS=64):
-    # - ``BufferCopy128b`` atom expects 16 bytes / thread
-    # - rope ``BufferCopy(64)`` atom expects 8 bytes / thread (= 4 bf16 pairs)
-    # - ``_store_fp8_packed`` is hand-rolled for VEC=8 -> 2 dwords
-    # Supporting other D values needs the atom widths + fp8 packing pattern
-    # generalised. Reject other VECs with a clear message rather than dump
-    # core inside LLVM lowering.
-    assert VEC == 8, (
-        f"VEC={VEC} unsupported (D={D}); only D=512 / VEC=8 is implemented. "
-        "Atom widths and fp8 packing assume VEC=8 -- generalising requires "
-        "a wider refactor."
+    # gfx1250 wave32: VEC = D/32. D=512 → VEC=16, D=128 → VEC=4.
+    assert VEC in (2, 4, 8, 16), (
+        f"VEC={VEC} unsupported (D={D}, BLOCK_THREADS={BLOCK_THREADS}); "
+        "supported set: {2, 4, 8, 16}."
     )
 
     # --- quant-group layout ------------------------------------------------
@@ -295,21 +306,17 @@ def _build_kernel(
     elem_dtype = fx.BFloat16
     is_e8m0 = scale_dtype == SCALE_DTYPE_E8M0
 
-    # The HW FP8 element dtype follows the arch (matches ``_fp8_const``):
-    # gfx942 ships e4m3fnuz (max_pos=240), gfx950+ ships OCP e4m3fn (max_pos=448).
-    # ``emit_mx_e8m0_scale`` uses this to pick the right ``max_pos`` reciprocal.
-    _fp8_mx_dtype = _D.FP8_E4M3_FNUZ if get_hip_arch() == "gfx942" else _D.FP8_E4M3
+    # gfx1250 ships OCP e4m3fn (max_pos=448).
+    _fp8_mx_dtype = _D.FP8_E4M3
 
-    # Kernel name: only include flags that affect the compiled binary.
-    # Default (not quant, not q_weighted) -> "qk_norm_rope_H16_D512_RD64_flydsl"
+    # Kernel name: include w32 suffix to avoid JIT cache collision with wave64.
     _name_parts = ["qk_norm_rope", f"H{H}", f"D{D}", f"RD{RD}"]
     if q_weighted:
         _name_parts.append("qw")
     if quant:
         _name_parts.append(f"g{group_size}")
         _name_parts.append(scale_dtype)
-    if kv_write:
-        _name_parts.append("kvw")
+    _name_parts.append("w32")
     _name_parts.append("flydsl")
     _kname = "_".join(_name_parts)
 
@@ -327,28 +334,95 @@ def _build_kernel(
         q_scale: fx.Pointer,  # [T, H, NG]        f32 or uint8 (e8m0)
         kv_scale: fx.Pointer,  # [T, NG]           f32 or uint8 (e8m0)
         kv_in_row_stride: Int32,  # KV row stride in bf16 elements
-        swa_kv: fx.Pointer,  # [num_slots, cache_size, D] bf16 (dummy if not kv_write)
-        state_slot_mapping: fx.Pointer,  # [bs] i32 (dummy if not kv_write)
-        batch_id_per_token: fx.Pointer,  # [T] i32, -1 sentinel (dummy if not kv_write)
-        swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
-        swa_pos_stride: Int32,  # bf16 elements (= D)
-        swa_cache_size: Int32,  # ring slot count
     ):
         f32 = T.f32
         i32 = T.i32
         fm_fast = arith.FastMathFlags.fast
 
-        full_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 16)
-        rope_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(64), 16)
-        full_lay = fx.make_layout(VEC, 1)
+        # --- vector load helpers (generalized for VEC ∈ {2..16}) ---
+        # CopyAtom-based loads work for VEC ≤ 8 (BufferCopy128b = 16 bytes
+        # = 8 bf16). For VEC=16 (32 bytes/thread), we use raw buffer_load
+        # split into dwordx4 chunks, matching the compress_attn gfx1250 pattern.
+
+        # Rope cos/sin: PAIRS_PER_THREAD bf16 pairs.
+        # VEC=16 → PAIRS=8 → 16 bytes → BufferCopy128b.
+        # VEC=8  → PAIRS=4 → 8 bytes  → BufferCopy(64).
+        # VEC=4  → PAIRS=2 → 4 bytes  → BufferCopy(32).
+        if const_expr(PAIRS_PER_THREAD <= 4):
+            rope_atom = fx.make_copy_atom(
+                fx.rocdl.BufferCopy(PAIRS_PER_THREAD * 16), 16
+            )
+        else:
+            rope_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 16)
         rope_lay = fx.make_layout(PAIRS_PER_THREAD, 1)
 
-        def load_vec(
-            div_tensor, idx, *, layout=full_lay, atom=full_atom, dt=elem_dtype
-        ):
-            r = fx.make_rmem_tensor(layout, dt)
-            fx.copy_atom_call(atom, fx.slice(div_tensor, (None, idx)), r)
+        # Full-row loads via CopyAtom (for weight tensors).
+        # VEC ≤ 8 → BufferCopy128b (16 bytes) is sufficient.
+        # VEC = 16 → need 32 bytes; use raw buffer_load split instead.
+        full_lay = fx.make_layout(VEC, 1)
+        if const_expr(VEC <= 8):
+            full_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), 16)
+
+            def _load_weight_tensor(weight_tensor, tid_val):
+                """Load VEC bf16 from a 1D weight fx.Tensor at tid*VEC."""
+                wbuf = fx.rocdl.make_buffer_tensor(weight_tensor)
+                wdiv = fx.logical_divide(wbuf, full_lay)
+                r = fx.make_rmem_tensor(full_lay, elem_dtype)
+                fx.copy_atom_call(full_atom, fx.slice(wdiv, (None, tid_val)), r)
+                return fx.memref_load_vec(r)
+        else:
+            def _load_weight_tensor(weight_tensor, tid_val):
+                """Load VEC bf16 from a 1D weight fx.Tensor via raw buffer_load.
+                Splits into dwordx4 chunks for VEC=16."""
+                wrsrc = buffer_ops.create_buffer_resource(weight_tensor, max_size=True)
+                tid_x_vec = ArithValue(tid_val) * arith.constant(VEC, type=i32)
+                # Element offset → dword offset (2 bf16 per dword)
+                off_dw = tid_x_vec >> arith.constant(1, type=i32)
+                f32_list = _load_bf16_raw(wrsrc, off_dw)
+                f32_vec = vector.from_elements(T.vec(VEC, f32), f32_list)
+                rmem = fx.make_rmem_tensor(full_lay, fx.Float32)
+                fx.memref_store_vec(f32_vec, rmem)
+                return fx.memref_load_vec(rmem)
+
+        def load_rope_vec(div_tensor, idx):
+            r = fx.make_rmem_tensor(rope_lay, elem_dtype)
+            fx.copy_atom_call(rope_atom, fx.slice(div_tensor, (None, idx)), r)
             return fx.memref_load_vec(r)
+
+        def _load_bf16_raw(rsrc, off_dw):
+            """Load VEC bf16 from a raw buffer resource at dword offset.
+            Returns list of VEC f32 scalars. Splits into dwordx4 chunks
+            when VEC > 8 (dwords > 4)."""
+            dwords = VEC // 2
+            out = []
+            if const_expr(dwords <= 4):
+                raw = buffer_ops.buffer_load(
+                    rsrc, off_dw, vec_width=dwords, dtype=i32
+                )
+                vec_bf16 = vector.bitcast(T.vec(VEC, T.bf16), raw)
+                for i in range_constexpr(VEC):
+                    bf16_v = vector.extract(
+                        vec_bf16, static_position=[i], dynamic_position=[]
+                    )
+                    out.append(arith.extf(f32, bf16_v))
+            else:
+                half_dw = 4
+                half_bf16 = half_dw * 2  # 8 bf16 per chunk
+                for chunk in range_constexpr(dwords // half_dw):
+                    r = buffer_ops.buffer_load(
+                        rsrc,
+                        ArithValue(off_dw)
+                        + arith.constant(chunk * half_dw, type=i32),
+                        vec_width=half_dw,
+                        dtype=i32,
+                    )
+                    vbf16 = vector.bitcast(T.vec(half_bf16, T.bf16), r)
+                    for i in range_constexpr(half_bf16):
+                        bf16_v = vector.extract(
+                            vbf16, static_position=[i], dynamic_position=[]
+                        )
+                        out.append(arith.extf(f32, bf16_v))
+            return out
 
         bid_x = fx.block_idx.x  # 0..H-1 (Q head) or H (KV)
         bid_t = fx.block_idx.y  # token id (chunked at MAX_GRID_Y per launch)
@@ -390,13 +464,11 @@ def _build_kernel(
             weighted: bool,
             x_f32_vec,
             w_f32_vec,  # None for Q
-            bf16_out_g,  # GTensor with per-token shifted base (when not quant)
-            bf16_out_row_off,  # i32 element offset of this head's row within token
+            bf16_out_rsrc,  # raw buffer resource for bf16 store (when not quant)
+            bf16_out_row_base_bytes,  # byte offset within token for this head
             fp8_out_rsrc,  # (rsrc_token_shifted, row_base_bytes_within_token) when quant
             scale_rsrc,
             scale_base_off,  # base elem-offset; per-lane adds (tid // TPG)
-            swa_out_g=None,  # GTensor (swa ring, per-token base) when kv_write
-            do_swa=None,  # i1 predicate (batch_id >= 0); None when no kv_write
         ):
             """Apply RMSNorm + GPT-J RoPE (+ optional FP8 quant) for the row
             held by this block. ``x_f32_vec`` and (optional) ``w_f32_vec`` are
@@ -412,15 +484,6 @@ def _build_kernel(
                     am_local = fmath.absf(x_f32_vec).reduce(ReductionOp.MAX)
 
                 # Fused wave reduce: interleave sumsq-ADD and amax-MAX
-                # shuffles in one loop so the LLVM scheduler can overlap the
-                # two shuffle chains (each shuffle has ~4-cycle XCC latency
-                # on gfx950; running them serially doubles latency).
-                #
-                # sumsq reduces over the FULL row (RMSNorm scope = D).
-                # amax reduces over a single QUANT GROUP (TPG threads,
-                # = group_size elements). Both can interleave in the loop's
-                # "tail" steps where shuffle offset < TPG; earlier steps do
-                # sumsq-only (amax would cross group boundaries).
                 w_sq = _to_raw(sq_local)
                 w_am = _to_raw(am_local)
                 for sh_exp in range_constexpr(log2_block):
@@ -443,32 +506,18 @@ def _build_kernel(
                 am_safe = arith.maximumf(am_group, arith.constant(1e-12, type=f32))
 
                 if const_expr(is_e8m0):
-                    # MX E8M0 RoundUp scale. ``amax_post`` folds rstd (per-row)
-                    # and SQRT2 (post-RoPE upper bound) so the forward factor
-                    # applied to x_norm bounds the result by ``max_pos`` of the
-                    # target FP8 dtype (e4m3fn 448 on gfx950+, e4m3fnuz 240 on
-                    # gfx942). The same NV ROUND_UP / torchao RCEIL formula is
-                    # used by silu_and_mul_fq and mixed_moe_gemm_2stage.
                     c_sqrt2 = arith.constant(_SQRT2, type=f32)
                     amax_post = am_safe * rstd * c_sqrt2
 
                     e8m0_biased = emit_mx_e8m0_scale(
                         amax_post, mode=_DEFAULT_MODE, dtype=_fp8_mx_dtype
                     )
-                    # quant_scale = 2^(127 - e8m0_biased) for x_norm. We apply
-                    # to x_in directly, so absorb the per-row rstd: factor =
-                    # rstd * quant_scale.
                     quant_exp = arith.constant(254, type=T.i32) - e8m0_biased
                     quant_scale = (quant_exp << arith.constant(23, type=T.i32)).bitcast(
                         T.f32
                     )
                     factor = rstd * quant_scale
                 else:
-                    # FP32 scale with the rstd-cancellation trick.
-                    # scale_val = amax * rstd * SQRT2 / FP8_MAX  (stored)
-                    # factor   = FP8_MAX / (amax * SQRT2)        (applied to x_in)
-                    # The rstd factor cancels algebraically: store(out) =
-                    # x_in * factor -> dequant: x_norm = scale * out = x_in * rstd.
                     rcp_am = llvm.call_intrinsic(
                         f32, "llvm.amdgcn.rcp.f32", [am_safe], [], []
                     )
@@ -478,13 +527,6 @@ def _build_kernel(
                         am_safe * rstd * arith.constant(_fc["inv_max_sqrt2"], type=f32)
                     )
 
-                # Group-leader lanes (one per quant group) write the scale.
-                # Predicate: tid & (TPG-1) == 0. For TPG=64 (per-row) this is
-                # `tid == 0`; for TPG<64 multiple lanes fire concurrently.
-                # Per-lane scale_off = scale_base_off + (tid / TPG).
-                # NOTE: tried buffer_ops.buffer_store(mask=...) for
-                # predication but the mask path sets offset to 0x7FFFFFFF on
-                # masked-off lanes -> OOB GPU fault on gfx950. Stay with scf.if.
                 group_idx = tid >> fx.Int32(log2_tpg)
                 lane_in_group = tid & fx.Int32(TPG - 1)
                 if lane_in_group == 0:
@@ -497,15 +539,12 @@ def _build_kernel(
 
             is_rope = tid >= fx.Int32(ROPE_THREAD_LO)
             if is_rope:
-                # ---- ROPE path: 8 elements in this thread = 4 GPT-J pairs ----
                 rope_rel = tid - fx.Int32(ROPE_THREAD_LO)
-                cos_vec = load_vec(cos_div, rope_rel, layout=rope_lay, atom=rope_atom)
-                sin_vec = load_vec(sin_div, rope_rel, layout=rope_lay, atom=rope_atom)
+                cos_vec = load_rope_vec(cos_div, rope_rel)
+                sin_vec = load_rope_vec(sin_div, rope_rel)
                 cos_f32 = cos_vec.to(fx.Float32)
                 sin_f32 = sin_vec.to(fx.Float32)
 
-                # pre-rotate values: x * factor (fp8) or x * rstd (bf16),
-                # with optional kv weight.
                 pe = []
                 for vi in range_constexpr(VEC):
                     xi = x_f32_vec[vi]
@@ -530,20 +569,9 @@ def _build_kernel(
                     rsrc, row_base = fp8_out_rsrc
                     _store_fp8_packed(rope_out, rsrc, row_base, tid, VEC)
                 else:
-                    _store_bf16_vec_g(rope_out, bf16_out_g, bf16_out_row_off, tid, VEC)
-                    if const_expr(kv_write):
-                        # Fused SWA scatter: same post-norm/rope bf16 row also
-                        # lands in swa_kv[slot, pos%cache_size, :]. swa_out_g
-                        # base is already shifted to that ring slot. Predicate
-                        # on do_swa (batch_id >= 0) to skip CG-pad tokens.
-                        if do_swa:
-                            _store_bf16_vec_g(
-                                rope_out,
-                                swa_out_g,
-                                arith.constant(0, type=i32),
-                                tid,
-                                VEC,
-                            )
+                    _store_bf16_vec(
+                        rope_out, bf16_out_rsrc, bf16_out_row_base_bytes, tid, VEC
+                    )
             else:
                 # ---- NOPE path: direct scaled store ----
                 scaled = []
@@ -559,29 +587,11 @@ def _build_kernel(
                     rsrc, row_base = fp8_out_rsrc
                     _store_fp8_packed(scaled, rsrc, row_base, tid, VEC)
                 else:
-                    _store_bf16_vec_g(scaled, bf16_out_g, bf16_out_row_off, tid, VEC)
-                    if const_expr(kv_write):
-                        if do_swa:
-                            _store_bf16_vec_g(
-                                scaled,
-                                swa_out_g,
-                                arith.constant(0, type=i32),
-                                tid,
-                                VEC,
-                            )
+                    _store_bf16_vec(
+                        scaled, bf16_out_rsrc, bf16_out_row_base_bytes, tid, VEC
+                    )
 
         # ============ runtime dispatch on bid_x < H ============
-        # Per-token byte offsets fold ``bid_t`` into the buffer descriptor
-        # base so the runtime offset within each load/store stays in i32
-        # range. This lets the kernel handle arbitrary T (only HW grid Y
-        # limits T per launch) without the bf16 element offset overflowing
-        # signed i32 at H*D = 65k+ per token.
-        # Per-token byte offset, computed in index type (= platform pointer
-        # width, 64-bit on AMD). GTensor.get_llvm_ptr does
-        # arith.index_cast(i64, ...) on this value, which is only valid when
-        # the input is index-typed. Doing the math in index avoids large
-        # H*D configs (e.g. H=128 D=512 -> 128 KB/token, max offset 8.6 GiB
-        # at bid_t=65534) silently producing garbage if we feed i64.
         q_tok_off_bytes = arith.MulIOp(
             bid_t_idx, arith.constant(H * D * 2, type=T.index)
         ).result
@@ -589,40 +599,31 @@ def _build_kernel(
         if bid_x < fx.Int32(H):
             # ---------- Q path ----------
             head_idx = bid_x
-            # Q in: per-token shifted base via GTensor. Each thread reads VEC
-            # bf16 at (head_idx, tid*VEC) -- element offset is bounded by H*D
-            # = 64K (fits i32 with huge headroom).
-            q_in_tok = GTensor(
-                q_in,
-                dtype=T.bf16,
-                shape=(H, D),
-                static_bytes_offset_i64=q_tok_off_bytes,
+            # Q load: use raw buffer_load to handle VEC=16 correctly.
+            q_in_rsrc = _ptr_buffer_resource(q_in)
+            # Per-token byte offset → dword offset for Q input.
+            q_row_off_elems = (
+                ArithValue(bid_t) * arith.constant(H * D, type=i32)
+                + ArithValue(head_idx) * arith.constant(D, type=i32)
+                + ArithValue(tid) * arith.constant(VEC, type=i32)
             )
-            q_my_off = ArithValue(head_idx) * arith.constant(D, type=i32) + ArithValue(
-                tid
-            ) * arith.constant(VEC, type=i32)
-            raw_x_vec = q_in_tok.load(q_my_off, vec_size=VEC)
-            # Round-trip through rmem so the rest of emit_body (.to/.reduce)
-            # sees a Fly-wrapped vec instead of a raw MLIR vec.
-            q_rmem = fx.make_rmem_tensor(full_lay, elem_dtype)
-            fx.memref_store_vec(raw_x_vec, q_rmem)
-            x_vec = fx.memref_load_vec(q_rmem)
-            x_f32 = x_vec.to(fx.Float32)
+            q_off_dw = q_row_off_elems >> arith.constant(1, type=i32)
+            q_f32_list = _load_bf16_raw(q_in_rsrc, q_off_dw)
 
-            # Optional per-channel Q weight (RMSNorm gamma for Q). Loaded only
-            # when q_weighted=True; otherwise q_weight tensor is a dummy and
-            # never read.
+            # Build Fly-wrapped VEC-wide f32 vector from raw scalars.
+            q_f32_fly_vec = vector.from_elements(T.vec(VEC, f32), q_f32_list)
+            q_rmem = fx.make_rmem_tensor(full_lay, fx.Float32)
+            fx.memref_store_vec(q_f32_fly_vec, q_rmem)
+            x_f32 = fx.memref_load_vec(q_rmem)
+
+            # Optional per-channel Q weight.
             if const_expr(q_weighted):
-                qw_buf = fx.rocdl.make_buffer_tensor(q_weight)
-                qw_div = fx.logical_divide(qw_buf, full_lay)
-                qw_vec = load_vec(qw_div, tid)
+                qw_vec = _load_weight_tensor(q_weight, tid)
                 qw_f32 = qw_vec.to(fx.Float32)
             else:
                 qw_f32 = None
 
-            row_off_q_elems = ArithValue(head_idx) * arith.constant(D, type=i32)
             if const_expr(quant):
-                # Per-token shifted base for q_out (fp8 = 1 byte/elem).
                 q_tok_off_fp8 = arith.MulIOp(
                     bid_t_idx, arith.constant(H * D, type=T.index)
                 ).result
@@ -633,11 +634,8 @@ def _build_kernel(
                     static_bytes_offset_i64=q_tok_off_fp8,
                 )
                 qo_rsrc = qo_g_tmp.rsrc
-                # row_base_bytes is now token-relative (head_idx * D bytes for fp8).
                 row_base_bytes = ArithValue(head_idx) * arith.constant(D, type=i32)
                 qs_rsrc = _ptr_buffer_resource(q_scale)
-                # q_scale layout (T, H, NG) flat: bid_t * H*NG + head_idx * NG.
-                # Per-lane adds group_idx inside emit_body.
                 scale_base_off_q = ArithValue(bid_t) * arith.constant(
                     H * NG, type=i32
                 ) + ArithValue(head_idx) * arith.constant(NG, type=i32)
@@ -645,61 +643,52 @@ def _build_kernel(
                     weighted=q_weighted,
                     x_f32_vec=x_f32,
                     w_f32_vec=qw_f32,
-                    bf16_out_g=None,
-                    bf16_out_row_off=None,
+                    bf16_out_rsrc=None,
+                    bf16_out_row_base_bytes=None,
                     fp8_out_rsrc=(qo_rsrc, row_base_bytes),
                     scale_rsrc=qs_rsrc,
                     scale_base_off=scale_base_off_q,
                 )
             else:
-                # Per-token shifted base for q_out (bf16 = 2 bytes/elem).
-                # Reuses q_tok_off_bytes computed above (the bf16 byte offset).
-                qo_g = GTensor(
+                # BF16 store via raw buffer_store (handles VEC=16).
+                qo_g_tmp = GTensor(
                     q_out,
                     dtype=T.bf16,
                     shape=(H, D),
                     static_bytes_offset_i64=q_tok_off_bytes,
                 )
+                qo_rsrc = qo_g_tmp.rsrc
+                row_base_bytes_q = ArithValue(head_idx) * arith.constant(
+                    D * 2, type=i32
+                )
                 emit_body(
                     weighted=q_weighted,
                     x_f32_vec=x_f32,
                     w_f32_vec=qw_f32,
-                    bf16_out_g=qo_g,
-                    bf16_out_row_off=row_off_q_elems,
+                    bf16_out_rsrc=qo_rsrc,
+                    bf16_out_row_base_bytes=row_base_bytes_q,
                     fp8_out_rsrc=None,
                     scale_rsrc=None,
                     scale_base_off=None,
                 )
         else:
             # ---------- KV path ----------
-            # KV is often a strided slice of a wider tensor (V4: kv = split of
-            # qkv_a -> row stride = q_lora + head_dim). fx.slice/logical_divide
-            # do not pull stride from torch.Tensor metadata, so use raw
-            # buffer_ops with the explicit kv_in_row_stride argument, then
-            # round-trip through an rmem tensor to get a Fly-wrapped vec that
-            # the rest of emit_body (.to/.reduce/[i]) expects.
             kv_rsrc = _ptr_buffer_resource(kv_in)
             kv_off_elems = ArithValue(bid_t) * ArithValue(
                 kv_in_row_stride
             ) + ArithValue(tid) * arith.constant(VEC, type=i32)
             kv_off_dw = kv_off_elems >> arith.constant(1, type=i32)
-            vec_bf16xV = T.vec(VEC, T.bf16)
-            x_raw = buffer_ops.buffer_load(
-                kv_rsrc, kv_off_dw, vec_width=VEC // 2, dtype=i32
-            )
-            x_vec_bf16_raw = vector.bitcast(vec_bf16xV, x_raw)
-            kv_rmem = fx.make_rmem_tensor(full_lay, elem_dtype)
-            fx.memref_store_vec(x_vec_bf16_raw, kv_rmem)
-            x_vec = fx.memref_load_vec(kv_rmem)
 
-            kvw_buf = fx.rocdl.make_buffer_tensor(kv_weight)
-            w_div = fx.logical_divide(kvw_buf, full_lay)
-            w_vec = load_vec(w_div, tid)
-            x_f32 = x_vec.to(fx.Float32)
+            kv_f32_list = _load_bf16_raw(kv_rsrc, kv_off_dw)
+            kv_f32_fly_vec = vector.from_elements(T.vec(VEC, f32), kv_f32_list)
+            kv_rmem = fx.make_rmem_tensor(full_lay, fx.Float32)
+            fx.memref_store_vec(kv_f32_fly_vec, kv_rmem)
+            x_vec_f32 = fx.memref_load_vec(kv_rmem)
+
+            w_vec = _load_weight_tensor(kv_weight, tid)
             w_f32 = w_vec.to(fx.Float32)
 
             if const_expr(quant):
-                # Per-token shifted base for kv_out (fp8 = 1 byte/elem).
                 kv_tok_off_fp8 = arith.MulIOp(
                     bid_t_idx, arith.constant(D, type=T.index)
                 ).result
@@ -710,83 +699,42 @@ def _build_kernel(
                     static_bytes_offset_i64=kv_tok_off_fp8,
                 )
                 kvo_rsrc = kvo_g_tmp.rsrc
-                row_base_bytes = arith.constant(0, type=i32)  # already at token base
+                row_base_bytes = arith.constant(0, type=i32)
                 kvs_rsrc = _ptr_buffer_resource(kv_scale)
-                # kv_scale layout (T, NG) flat: bid_t * NG. Per-lane adds
-                # group_idx inside emit_body.
                 scale_base_off_kv = ArithValue(bid_t) * arith.constant(NG, type=i32)
                 emit_body(
                     weighted=True,
-                    x_f32_vec=x_f32,
+                    x_f32_vec=x_vec_f32,
                     w_f32_vec=w_f32,
-                    bf16_out_g=None,
-                    bf16_out_row_off=None,
+                    bf16_out_rsrc=None,
+                    bf16_out_row_base_bytes=None,
                     fp8_out_rsrc=(kvo_rsrc, row_base_bytes),
                     scale_rsrc=kvs_rsrc,
                     scale_base_off=scale_base_off_kv,
                 )
             else:
-                # Per-token shifted base for kv_out (bf16 = 2 bytes/elem).
                 kv_tok_off_bf16 = arith.MulIOp(
                     bid_t_idx, arith.constant(D * 2, type=T.index)
                 ).result
-                kvo_g = GTensor(
+                kvo_g_tmp = GTensor(
                     kv_out,
                     dtype=T.bf16,
                     shape=(D,),
                     static_bytes_offset_i64=kv_tok_off_bf16,
                 )
-
-                # ---- Fused SWA scatter setup (kv_write only) ----
-                # Target swa_kv[slot, pos % cache_size, :] where
-                # slot = state_slot_mapping[batch_id_per_token[bid_t]].
-                # batch_id is i32 with -1 sentinel on CG-pad tokens; clamp it to
-                # 0 for the (predicated-off) slot load to keep the load in-bounds,
-                # and gate the actual store on do_swa = batch_id>=0.
-                swa_out_g = None
-                do_swa = None
-                if const_expr(kv_write):
-                    bid_rsrc = _ptr_buffer_resource(batch_id_per_token)
-                    bid_i32 = buffer_ops.buffer_load(
-                        bid_rsrc, bid_t, vec_width=1, dtype=i32
-                    )
-                    do_swa = bid_i32 >= fx.Int32(0)
-                    bid_safe = arith.maxsi(bid_i32, arith.constant(0, type=i32))
-                    slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
-                    slot = buffer_ops.buffer_load(
-                        slot_rsrc, bid_safe, vec_width=1, dtype=i32
-                    )
-                    ring = arith.remsi(pos_i32, _to_raw(swa_cache_size))
-                    swa_off_elems = ArithValue(slot) * ArithValue(
-                        swa_slot_stride
-                    ) + ArithValue(ring) * ArithValue(swa_pos_stride)
-                    swa_off_bytes = arith.index_cast(
-                        T.index, _to_raw(swa_off_elems)
-                    ) * arith.constant(2, type=T.index)
-                    swa_out_g = GTensor(
-                        swa_kv,
-                        dtype=T.bf16,
-                        shape=(D,),
-                        static_bytes_offset_i64=swa_off_bytes,
-                    )
-
+                kvo_rsrc = kvo_g_tmp.rsrc
+                row_base_bytes_kv = arith.constant(0, type=i32)
                 emit_body(
                     weighted=True,
-                    x_f32_vec=x_f32,
+                    x_f32_vec=x_vec_f32,
                     w_f32_vec=w_f32,
-                    bf16_out_g=kvo_g,
-                    bf16_out_row_off=arith.constant(0, type=i32),
+                    bf16_out_rsrc=kvo_rsrc,
+                    bf16_out_row_base_bytes=row_base_bytes_kv,
                     fp8_out_rsrc=None,
                     scale_rsrc=None,
                     scale_base_off=None,
-                    swa_out_g=swa_out_g,
-                    do_swa=do_swa,
                 )
 
-    # Name the launcher explicitly so the flydsl disk cache directory becomes
-    # `~/.flydsl/cache/launch_qk_norm_rope_quant_<hash>/` instead of the
-    # generic `launcher_<hash>/`, which collides visually with every other
-    # @flyc.jit function in the codebase.
     @flyc.jit
     def launch_qk_norm_rope_quant(
         q_in: fx.Pointer,
@@ -801,12 +749,6 @@ def _build_kernel(
         q_scale: fx.Pointer,
         kv_scale: fx.Pointer,
         kv_in_row_stride: fx.Int32,
-        swa_kv: fx.Pointer,
-        state_slot_mapping: fx.Pointer,
-        batch_id_per_token: fx.Pointer,
-        swa_slot_stride: fx.Int32,
-        swa_pos_stride: fx.Int32,
-        swa_cache_size: fx.Int32,
         num_tokens: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
@@ -824,12 +766,6 @@ def _build_kernel(
             q_scale,
             kv_scale,
             kv_in_row_stride,
-            swa_kv,
-            state_slot_mapping,
-            batch_id_per_token,
-            swa_slot_stride,
-            swa_pos_stride,
-            swa_cache_size,
         )
         k.launch(
             grid=(H + 1, idx_tokens, 1),
@@ -844,9 +780,6 @@ def _build_kernel(
 # Cached compile + public API
 # ============================================================================
 
-# Empirically (sweep on MI355X V4-Pro shape) ``waves_per_eu=8, fast_fp_math
-# =True, unsafe_fp_math=True`` gives the best occupancy at small/mid T with
-# no measurable regression at large T. See logs_claude/sweep_hints.py.
 _DEFAULT_COMPILE_HINTS = {
     "waves_per_eu": 8,
     "fast_fp_math": True,
@@ -854,12 +787,8 @@ _DEFAULT_COMPILE_HINTS = {
 }
 
 
-# Bounded to keep parity with sibling flydsl ops (see fmha_kernels._get_kernel).
-# In V4-Pro deployment only a handful of (H, D, RD, quant, group_size,
-# scale_dtype, q_weighted) combinations actually fire, so 32 leaves wide
-# headroom while preventing unbounded growth from sweep/test enumeration.
 @lru_cache(maxsize=32)
-def compile_flydsl_qk_norm_rope_quant(
+def compile_flydsl_qk_norm_rope_quant_gfx1250(
     *,
     num_q_heads: int,
     head_dim: int,
@@ -868,15 +797,8 @@ def compile_flydsl_qk_norm_rope_quant(
     group_size: int,
     scale_dtype: str,
     q_weighted: bool,
-    kv_write: bool = False,
 ):
-    """Compile (and cache) the launcher for a given config.
-
-    Cache key includes (H, D, RD, quant, group_size, scale_dtype, q_weighted,
-    kv_write). Returns the @flyc.jit launcher; call it directly if you've
-    already allocated outputs and want to avoid the per-call torch-side
-    overhead in ``flydsl_qk_norm_rope_quant``.
-    """
+    """Compile (and cache) the gfx1250 wave32 launcher for a given config."""
     launcher = _build_kernel(
         num_q_heads=num_q_heads,
         head_dim=head_dim,
@@ -885,13 +807,12 @@ def compile_flydsl_qk_norm_rope_quant(
         group_size=group_size,
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
-        kv_write=kv_write,
     )
     launcher.compile_hints = dict(_DEFAULT_COMPILE_HINTS)
     return launcher
 
 
-def flydsl_qk_norm_rope_quant(
+def flydsl_qk_norm_rope_quant_gfx1250(
     q: torch.Tensor,
     kv: torch.Tensor,
     kv_weight: torch.Tensor,
@@ -910,9 +831,6 @@ def flydsl_qk_norm_rope_quant(
     kv_out: Optional[torch.Tensor] = None,
     q_scale: Optional[torch.Tensor] = None,
     kv_scale: Optional[torch.Tensor] = None,
-    swa_kv: Optional[torch.Tensor] = None,
-    state_slot_mapping: Optional[torch.Tensor] = None,
-    batch_id_per_token: Optional[torch.Tensor] = None,
     stream: Optional[torch.cuda.Stream] = None,
 ) -> Tuple[
     torch.Tensor,
@@ -920,93 +838,12 @@ def flydsl_qk_norm_rope_quant(
     Optional[torch.Tensor],
     Optional[torch.Tensor],
 ]:
-    """Fused RMSNorm + GPT-J RoPE + optional FP8 quant for Q and KV in one launch.
+    """Fused RMSNorm + GPT-J RoPE + optional FP8 quant (gfx1250 wave32).
 
-    Args:
-        q: Q activations, shape ``[T, H*D]`` (will be ``.view``-reshaped to
-            ``[T, H, D]``) or already ``[T, H, D]``. Must be bf16 and contig
-            in the (H, D) inner dims.
-        kv: KV pre-RoPE/norm, shape ``[T, D]``, bf16. May be a strided view
-            of a wider tensor (e.g. the KV half of a ``torch.split``); the
-            row stride is read from ``kv.stride(0)`` and passed through.
-        kv_weight: per-channel RMSNorm weight for KV, shape ``[D]``, bf16.
-        cos_cache, sin_cache: RoPE cos/sin, last dim ``rope_head_dim/2``,
-            any leading shape that ``view``-reshapes to ``[max_pos, RD/2]``
-            (e.g. ``[max_pos, 1, 1, RD/2]`` from DeepSeek-V4). bf16.
-        positions: per-token RoPE position indices, shape ``[T]``, int64.
-        num_q_heads: H (per-rank Q head count).
-        head_dim: D (per-head hidden dim).
-        rope_head_dim: RD (size of the RoPE-rotated tail; first D-RD elements
-            are passed through as NOPE).
-        q_weight: optional per-channel RMSNorm weight for Q, shape ``[D]``,
-            bf16. When ``None`` (default, V4-Pro), Q is weightless. When
-            provided, applied just like ``kv_weight``.
-        quant: if True, write fp8 in the per-GFX native encoding selected by
-            ``aiter.dtypes.fp8`` (typically ``e4m3fnuz`` on gfx942 and
-            ``e4m3fn`` on gfx950); else bf16.
-        quant_group_size: width of the 1xG scale block. Defaults to
-            ``head_dim`` (per-row scale). Any value that divides ``head_dim``
-            is accepted by the wrapper; the underlying kernel currently
-            requires ``G`` to be a multiple of ``head_dim // BLOCK_THREADS``
-            (= 8 for V4-Pro at D=512, BLOCK_THREADS=64), so the typical
-            sub-row choices are ``{32, 64, 128}``.
-        scale_dtype: ``"fp32"`` (default) or ``"e8m0"`` (MX-format uint8).
-        q_out, kv_out, q_scale, kv_scale: output buffers; allocated if None.
-            ``q_out`` shape ``[T, H, D]``, ``kv_out`` shape ``[T, D]``,
-            ``q_scale`` shape ``[T, H, NG]``, ``kv_scale`` shape ``[T, NG]``
-            where ``NG = head_dim // quant_group_size``. Scale dtype is
-            ``torch.float32`` for ``scale_dtype="fp32"``, ``torch.uint8``
-            for ``"e8m0"`` (reinterpret as e8m0 downstream).
-        stream: torch CUDA stream to launch on. Defaults to the current
-            stream. **Must NOT be left at ``fx.Stream(None)`` default in
-            caller code unless you accept the default-stream pitfall under
-            CUDA-graph capture** (NULL stream -> empty captured graph).
-        swa_kv: optional ``[num_slots, cache_size, D]`` bf16 SWA ring buffer.
-            When provided (BF16 only; incompatible with ``quant``), the
-            post-norm/rope KV row is additionally scattered into
-            ``swa_kv[slot, pos % cache_size, :] = kv_out[t]`` in the same
-            launch (``slot = state_slot_mapping[batch_id_per_token[t]]``),
-            fusing the standalone ``swa_write``.
-        state_slot_mapping: ``[bs]`` int32 — per-seq SWA ring slot. Required
-            when ``swa_kv`` is set.
-        batch_id_per_token: ``[T]`` int32, ``-1`` on CG-pad tokens — token→seq
-            map for the fused SWA scatter (store gated off on ``-1``). Required
-            when ``swa_kv`` is set.
-
-    Returns:
-        (q_out, kv_out, q_scale_or_None, kv_scale_or_None)
-        Scales are ``None`` when ``quant=False``.
+    Same API as ``flydsl_qk_norm_rope_quant`` — see that docstring for full
+    parameter descriptions. This variant compiles with BLOCK_THREADS=32 for
+    RDNA4/gfx1250 wave32 hardware.
     """
-    # ---- gfx1250 dispatch (wave32) ----
-    from aiter.jit.utils.chip_info import get_gfx as _get_gfx
-
-    if _get_gfx() == "gfx1250":
-        from .qk_norm_rope_quant_gfx1250 import flydsl_qk_norm_rope_quant_gfx1250
-
-        return flydsl_qk_norm_rope_quant_gfx1250(
-            q=q,
-            kv=kv,
-            kv_weight=kv_weight,
-            cos_cache=cos_cache,
-            sin_cache=sin_cache,
-            positions=positions,
-            num_q_heads=num_q_heads,
-            head_dim=head_dim,
-            rope_head_dim=rope_head_dim,
-            q_weight=q_weight,
-            quant=quant,
-            quant_group_size=quant_group_size,
-            scale_dtype=scale_dtype,
-            q_out=q_out,
-            kv_out=kv_out,
-            q_scale=q_scale,
-            kv_scale=kv_scale,
-            stream=stream,
-        )
-
-    # Validate user-facing inputs with raise (not assert) so the checks are
-    # not stripped under ``python -O``. Internal codegen invariants inside
-    # _build_kernel/_store_*_vec_g remain as asserts on purpose.
     if q.dtype != torch.bfloat16:
         raise TypeError(f"q must be bf16, got {q.dtype}")
     if kv.dtype != torch.bfloat16:
@@ -1015,10 +852,6 @@ def flydsl_qk_norm_rope_quant(
         raise TypeError(f"kv_weight must be bf16, got {kv_weight.dtype}")
     if kv.stride(-1) != 1:
         raise ValueError(f"kv must be dense in the last dim, stride={kv.stride()}")
-    # The KV inner loop casts bf16 vectors to dword (i32) and computes the
-    # buffer-load offset as ``(row * kv.stride(0) + tid * VEC) >> 1``. That
-    # ``>> 1`` is only correct when the byte offset is dword-aligned for every
-    # row, which requires the row stride (in bf16 elements) to be even.
     if kv.stride(0) % 2 != 0:
         raise ValueError(
             "kv row stride (in bf16 elements) must be even for dword-cast "
@@ -1038,13 +871,8 @@ def flydsl_qk_norm_rope_quant(
     if D % G != 0:
         raise ValueError(f"head_dim {D} must be divisible by quant_group_size {G}")
     q_weighted = q_weight is not None
-    # Kernel always reads the q_weight parameter; pass a 1-elem dummy when
-    # q_weighted=False (the const_expr gate inside the kernel ensures the
-    # load is dead-code-eliminated, but the parameter binding still needs a
-    # valid tensor).
     q_weight_arg = q_weight if q_weighted else kv_weight
 
-    # Normalize Q to [T, H, D] (the kernel expects 3D).
     if q.dim() == 2:
         if q.shape[1] != H * D:
             raise ValueError(f"q shape {tuple(q.shape)} != [T, H*D={H*D}]")
@@ -1057,18 +885,12 @@ def flydsl_qk_norm_rope_quant(
                 f"q shape {tuple(q.shape)} != (T, H, D)=({T_tok}, {H}, {D})"
             )
         q_view = q
-        # The kernel linearly indexes q_in as if it were dense [T,H,D] with
-        # the (H,D) inner block contiguous. Strided views (e.g. a slice of a
-        # wider tensor along an inner axis) would silently read the wrong
-        # elements, so reject anything that is not dense in the (H,D) tail.
         if q_view.stride(-1) != 1 or q_view.stride(-2) != D:
             raise ValueError(
                 "3D q must be contiguous in the (H, D) inner block "
                 f"(stride(-1)==1 and stride(-2)==D={D}), got stride={q_view.stride()}"
             )
 
-    # Normalize cos/sin to 2D [max_pos, RD/2]. Accept any shape whose last
-    # dim is RD/2 (DeepSeek-V4 stores [max_pos, 1, 1, RD/2]).
     if cos_cache.shape[-1] != RD // 2:
         raise ValueError(
             f"cos_cache last dim {cos_cache.shape[-1]} != RD/2 ({RD // 2})"
@@ -1086,8 +908,6 @@ def flydsl_qk_norm_rope_quant(
     if kv_out is None:
         kv_out = torch.empty((T_tok, D), dtype=out_dtype, device=kv.device)
 
-    # Scale buffers must always be passed to the launcher (the kernel reads
-    # the parameter regardless of QUANT_*). Allocate dummies when not quant.
     scale_torch_dtype = _TORCH_DTYPE_FOR_SCALE[scale_dtype]
     if quant:
         if q_scale is None:
@@ -1103,49 +923,7 @@ def flydsl_qk_norm_rope_quant(
         q_scale_arg = q.new_empty(1, dtype=scale_torch_dtype)
         kv_scale_arg = q.new_empty(1, dtype=scale_torch_dtype)
 
-    # ---- Fused SWA cache-write (BF16 only) ----
-    # When swa_kv is provided, the KV row (post-norm/rope) is also scattered
-    # into swa_kv[slot, pos % cache_size, :] where
-    # slot = state_slot_mapping[batch_id_per_token[t]]. Avoids a separate
-    # swa_write launch + kv HBM round-trip. Requires bf16 output (quant off).
-    kv_write = swa_kv is not None
-    if kv_write:
-        if quant:
-            raise ValueError("kv_write (swa_kv) is BF16 only; not supported with quant")
-        if state_slot_mapping is None or batch_id_per_token is None:
-            raise ValueError(
-                "kv_write requires state_slot_mapping and batch_id_per_token"
-            )
-        if swa_kv.dim() != 3 or swa_kv.shape[2] != D:
-            raise ValueError(f"swa_kv must be [S, C, D={D}], got {tuple(swa_kv.shape)}")
-        if swa_kv.dtype != torch.bfloat16:
-            raise TypeError(f"swa_kv must be bf16, got {swa_kv.dtype}")
-        if not swa_kv.is_contiguous():
-            raise ValueError("swa_kv must be contiguous")
-        if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
-            raise TypeError("state_slot_mapping must be 1-D int32")
-        if batch_id_per_token.dim() != 1 or batch_id_per_token.dtype != torch.int32:
-            raise TypeError("batch_id_per_token must be 1-D int32")
-        if batch_id_per_token.shape[0] < T_tok:
-            raise ValueError(
-                f"batch_id_per_token len {batch_id_per_token.shape[0]} < T={T_tok}"
-            )
-        swa_slot_stride = swa_kv.stride(0)
-        swa_pos_stride = swa_kv.stride(1)
-        swa_cache_size = swa_kv.shape[1]
-        swa_kv_arg = swa_kv
-        ssm_arg = state_slot_mapping
-        bid_arg = batch_id_per_token
-    else:
-        # 1-elem dummies so the kernel param binding has valid pointers.
-        swa_slot_stride = 0
-        swa_pos_stride = 0
-        swa_cache_size = 1
-        swa_kv_arg = kv_out  # bf16 dummy
-        ssm_arg = q.new_empty(1, dtype=torch.int32)
-        bid_arg = q.new_empty(1, dtype=torch.int32)
-
-    launcher = compile_flydsl_qk_norm_rope_quant(
+    launcher = compile_flydsl_qk_norm_rope_quant_gfx1250(
         num_q_heads=H,
         head_dim=D,
         rope_head_dim=RD,
@@ -1153,7 +931,6 @@ def flydsl_qk_norm_rope_quant(
         group_size=G,
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
-        kv_write=kv_write,
     )
 
     if stream is None:
@@ -1177,16 +954,6 @@ def flydsl_qk_norm_rope_quant(
     cos_static = _cached_from_dlpack(cos_2d)
     sin_static = _cached_from_dlpack(sin_2d)
 
-    # HW grid Y is a 16-bit field on AMD HIP → cap 65535 blocks/launch. The
-    # kernel uses per-token GTensor base-shift so each chunk's resource span
-    # is small (just the chunk's tokens), but the grid Y dim itself is HW-
-    # bounded. We tried folding T across gridY+gridZ to do a single launch,
-    # but flydsl's ``if cond: return`` does NOT actually early-exit inside a
-    # @flyc.kernel body (the rest of the kernel still runs with bid_t past
-    # num_tokens, causing OOB memory faults at tail blocks). Wrapping the
-    # full kernel body in a positive ``if bid_t < num_tokens:`` works but
-    # requires indenting ~400 lines. The Python-loop chunk is the pragmatic
-    # solution -- overhead is one launch per 65k tokens.
     MAX_GRID_Y = 65535
     for start in range(0, T_tok, MAX_GRID_Y):
         n = min(MAX_GRID_Y, T_tok - start)
@@ -1204,15 +971,6 @@ def flydsl_qk_norm_rope_quant(
             _ptr_arg(q_scale_arg[start:end] if quant else q_scale_arg),
             _ptr_arg(kv_scale_arg[start:end] if quant else kv_scale_arg),
             kv.stride(0),
-            # swa_kv / state_slot_mapping are global (indexed by absolute slot /
-            # batch_id), so pass unsliced; batch_id_per_token is [T], sliced
-            # like positions.
-            _ptr_arg(swa_kv_arg),
-            _ptr_arg(ssm_arg),
-            _ptr_arg(bid_arg[start:end] if kv_write else bid_arg),
-            swa_slot_stride,
-            swa_pos_stride,
-            swa_cache_size,
             n,
             _stream_arg(),
         )

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
@@ -265,9 +265,9 @@ def _build_kernel(
     ROPE_THREAD_LO = NOPE // VEC
     PAIRS_PER_THREAD = VEC // 2
 
-    assert D % BLOCK_THREADS == 0, (
-        f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
-    )
+    assert (
+        D % BLOCK_THREADS == 0
+    ), f"D={D} must be divisible by BLOCK_THREADS={BLOCK_THREADS}"
     assert NOPE % VEC == 0, f"NOPE={NOPE} must be divisible by VEC={VEC}"
     assert RD % 2 == 0, "rope_head_dim must be even (GPT-J pair layout)"
     assert RD % VEC == 0, f"RD={RD} must be divisible by VEC={VEC}"
@@ -280,20 +280,20 @@ def _build_kernel(
     # --- quant-group layout ------------------------------------------------
     # group_size must divide D evenly AND be a multiple of VEC (so a single
     # thread's VEC-wide slice never crosses a group boundary).
-    assert group_size > 0 and D % group_size == 0, (
-        f"group_size {group_size} must divide head_dim {D}"
-    )
-    assert group_size % VEC == 0, (
-        f"group_size {group_size} must be a multiple of VEC {VEC}"
-    )
+    assert (
+        group_size > 0 and D % group_size == 0
+    ), f"group_size {group_size} must divide head_dim {D}"
+    assert (
+        group_size % VEC == 0
+    ), f"group_size {group_size} must be a multiple of VEC {VEC}"
     TPG = group_size // VEC  # threads per group
     NG = D // group_size  # number of groups per row
-    assert TPG > 0 and (TPG & (TPG - 1)) == 0, (
-        f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
-    )
-    assert scale_dtype in SCALE_DTYPE_OPTIONS, (
-        f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
-    )
+    assert (
+        TPG > 0 and (TPG & (TPG - 1)) == 0
+    ), f"TPG {TPG} must be a power of 2 (for butterfly reduce)"
+    assert (
+        scale_dtype in SCALE_DTYPE_OPTIONS
+    ), f"scale_dtype {scale_dtype!r} must be one of {SCALE_DTYPE_OPTIONS}"
 
     log2_block = int(math.log2(BLOCK_THREADS))
     log2_tpg = int(math.log2(TPG))
@@ -369,6 +369,7 @@ def _build_kernel(
                 r = fx.make_rmem_tensor(full_lay, elem_dtype)
                 fx.copy_atom_call(full_atom, fx.slice(wdiv, (None, tid_val)), r)
                 return fx.memref_load_vec(r)
+
         else:
 
             def _load_weight_tensor(weight_tensor, tid_val):

--- a/op_tests/test_flydsl_compress_attn_gfx1250.py
+++ b/op_tests/test_flydsl_compress_attn_gfx1250.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for gfx1250 (wave32) ``fused_compress_attn`` kernels.
+
+Directly imports the gfx1250 kernels (bypassing the dispatch routing) so that
+correctness can be verified independently. Tests the same three shape configs
+as the wave64 test, but with preshuffle forced False (gfx1250 uses linear
+FP8 layout).
+
+    CSA Main    : D=512, RD=64, ratio=4,   overlap=True,  BF16
+    CSA Indexer : D=128, RD=64, ratio=4,   overlap=True,  FP8 + ue8m0, no preshuffle
+    HCA Main    : D=512, RD=64, ratio=128, overlap=False, BF16
+
+Each shape swept across batch sizes and speculative-decode step counts.
+"""
+
+import argparse
+import itertools
+
+import pandas as pd
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.ops.flydsl.kernels.fused_compress_attn_gfx1250 import (
+    flydsl_fused_compress_attn_gfx1250,
+)
+from aiter.ops.flydsl.kernels.fused_compress_attn_hca_gfx1250 import (
+    flydsl_hca_compress_attn_gfx1250,
+)
+from aiter.ops.torch_ref.fused_compress_attn import (
+    fused_compress_attn as fused_compress_attn_reference,
+)
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+
+torch.set_default_device("cuda")
+
+# (label, head_dim, rope_head_dim, ratio, overlap, quant, use_ue8m0, preshuffle)
+# gfx1250: preshuffle forced False for all shapes
+SHAPES = [
+    ("csa_main", 512, 64, 4, True, False, False, False),
+    ("csa_indexer", 128, 64, 4, True, True, True, False),
+    ("hca_main", 512, 64, 128, False, False, False, False),
+]
+K_PER_BLOCK = 64
+RMS_EPS = 1e-6
+SEED = 2026
+PREFILL_CONTEXT_LEN = 256
+SENTINEL_PAD = 16
+CG_TOKEN_PAD = 32
+
+
+def _shape_by_label(label):
+    for s in SHAPES:
+        if s[0] == label:
+            return s
+    raise KeyError(label)
+
+
+def _build_inputs(shape, bs, mtp, mode):
+    """Build synthetic plan + tensors for one (shape, bs, mtp, mode) case."""
+    label, D, RD, ratio, overlap, quant, ue8m0, preshuffle = shape
+    dim_full = (2 if overlap else 1) * D
+    K_pool = (2 if overlap else 1) * ratio
+
+    if mode == "decode":
+        num_per_seq = max(1, -(-(mtp + 1) // ratio))
+        num_compress = bs * num_per_seq
+        extra_pad = K_pool - 1
+        num_valid_tokens = num_compress + extra_pad
+        state_size = K_pool + mtp
+    elif mode == "prefill":
+        num_per_seq = PREFILL_CONTEXT_LEN // ratio
+        num_compress = bs * num_per_seq
+        num_valid_tokens = bs * PREFILL_CONTEXT_LEN
+        state_size = K_pool
+    else:
+        raise ValueError(f"unknown mode {mode!r}")
+    plan_capacity = num_compress + SENTINEL_PAD
+    num_q_tokens = num_valid_tokens + CG_TOKEN_PAD
+
+    g = torch.Generator(device="cuda").manual_seed(SEED + bs * 1000 + mtp)
+
+    kv_in = torch.randn(num_q_tokens, dim_full, dtype=torch.bfloat16, generator=g) * 0.1
+    score_in = (
+        torch.randn(num_q_tokens, dim_full, dtype=torch.bfloat16, generator=g) * 0.5
+    )
+    kv_in[num_valid_tokens:] = float("nan")
+    score_in[num_valid_tokens:] = float("nan")
+    kv_state = (
+        torch.randn(bs, state_size, dim_full, dtype=torch.float32, generator=g) * 0.1
+    )
+    score_state = (
+        torch.randn(bs, state_size, dim_full, dtype=torch.float32, generator=g) * 0.5
+    )
+    state_slot_mapping = torch.arange(bs, dtype=torch.int32)
+    ape = torch.randn(ratio, dim_full, dtype=torch.float32, generator=g) * 0.1
+    rms_weight = torch.rand(D, dtype=torch.float32, generator=g) * 0.5 + 0.5
+
+    max_comp_pos = num_per_seq * ratio
+    max_pos = max(max_comp_pos + 1, 64)
+    inv_freq = 1.0 / (10000 ** (torch.arange(0, RD, 2, dtype=torch.float32) / RD))
+    freqs = torch.outer(torch.arange(max_pos, dtype=torch.float32), inv_freq)
+    cos_cache = freqs.cos().to(torch.bfloat16).contiguous()
+    sin_cache = freqs.sin().to(torch.bfloat16).contiguous()
+
+    plan = torch.full((plan_capacity, 4), -1, dtype=torch.int32)
+    for b in range(bs):
+        for s in range(num_per_seq):
+            pid = b * num_per_seq + s
+            if mode == "decode":
+                ragged_id = extra_pad + pid
+                window_len = K_pool // 2 if s == 0 else 0
+            else:
+                position_in_seq = (s + 1) * ratio - 1
+                ragged_id = b * PREFILL_CONTEXT_LEN + position_in_seq
+                window_len = max(0, K_pool - 1 - position_in_seq)
+            plan[pid, 0] = ragged_id
+            plan[pid, 1] = b
+            plan[pid, 2] = (s + 1) * ratio - 1
+            plan[pid, 3] = window_len
+
+    blocks_per_seq = (num_per_seq + K_PER_BLOCK - 1) // K_PER_BLOCK
+    total_blocks = bs * blocks_per_seq + 4
+    if quant:
+        kv_cache = torch.zeros(total_blocks, K_PER_BLOCK, D, dtype=dtypes.fp8)
+        cache_scale = torch.zeros(total_blocks, K_PER_BLOCK, dtype=torch.float32)
+    else:
+        kv_cache = torch.zeros(total_blocks, K_PER_BLOCK, D, dtype=torch.bfloat16)
+        cache_scale = None
+    block_tables = torch.zeros(bs, blocks_per_seq, dtype=torch.int32)
+    for b in range(bs):
+        for j in range(blocks_per_seq):
+            block_tables[b, j] = b * blocks_per_seq + j
+
+    return dict(
+        kv_in=kv_in,
+        score_in=score_in,
+        kv_state=kv_state,
+        score_state=score_state,
+        state_slot_mapping=state_slot_mapping,
+        ape=ape,
+        rms_weight=rms_weight,
+        cos_cache=cos_cache,
+        sin_cache=sin_cache,
+        plan_gpu=plan,
+        kv_cache=kv_cache,
+        cache_scale=cache_scale,
+        block_tables=block_tables,
+        k_per_block=K_PER_BLOCK,
+        head_dim=D,
+        rope_head_dim=RD,
+        ratio=ratio,
+        overlap=overlap,
+        quant=quant,
+        use_ue8m0=ue8m0,
+        preshuffle=preshuffle,
+        rms_eps=RMS_EPS,
+    )
+
+
+def _run_kernel(inp, *, use_2kernel):
+    """Run gfx1250 kernel into ``inp['kv_cache']`` / ``inp['cache_scale']``."""
+    common = dict(
+        kv_in=inp["kv_in"],
+        score_in=inp["score_in"],
+        kv_state=inp["kv_state"],
+        score_state=inp["score_state"],
+        state_slot_mapping=inp["state_slot_mapping"],
+        plan_gpu=inp["plan_gpu"],
+        ape=inp["ape"],
+        rms_weight=inp["rms_weight"],
+        rms_eps=inp["rms_eps"],
+        cos_cache=inp["cos_cache"],
+        sin_cache=inp["sin_cache"],
+        kv_cache=inp["kv_cache"],
+        block_tables=inp["block_tables"],
+        k_per_block=inp["k_per_block"],
+        ratio=inp["ratio"],
+        head_dim=inp["head_dim"],
+        rope_head_dim=inp["rope_head_dim"],
+    )
+    if use_2kernel:
+        flydsl_hca_compress_attn_gfx1250(**common)
+    else:
+        flydsl_fused_compress_attn_gfx1250(
+            **common,
+            overlap=inp["overlap"],
+            quant=inp["quant"],
+            cache_scale=inp["cache_scale"],
+            use_ue8m0=inp["use_ue8m0"],
+            preshuffle=inp["preshuffle"],
+        )
+
+
+@benchmark()
+def test_flydsl_compress_attn_gfx1250(shape_label, bs, mtp, mode, path):
+    """One case. ``mode`` in {'decode','prefill'}, ``path`` in {'single','2kernel'}."""
+    shape = _shape_by_label(shape_label)
+    _, D, RD, ratio, overlap, quant, ue8m0, preshuffle = shape
+    use_2kernel = path == "2kernel"
+    inp = _build_inputs(shape, bs, mtp, mode)
+
+    ref_inp = dict(inp)
+    ref_inp["kv_cache"] = inp["kv_cache"].clone()
+    ref_inp["cache_scale"] = (
+        inp["cache_scale"].clone() if inp["cache_scale"] is not None else None
+    )
+
+    _, us_kernel = run_perftest(_run_kernel, inp, use_2kernel=use_2kernel)
+
+    # Reference uses preshuffle=False for gfx1250 comparison
+    fused_compress_attn_reference(
+        kv_in=ref_inp["kv_in"],
+        score_in=ref_inp["score_in"],
+        kv_state=ref_inp["kv_state"],
+        score_state=ref_inp["score_state"],
+        plan_gpu=ref_inp["plan_gpu"],
+        state_slot_mapping=ref_inp["state_slot_mapping"],
+        ape=ref_inp["ape"],
+        rms_weight=ref_inp["rms_weight"],
+        rms_eps=ref_inp["rms_eps"],
+        cos_cache=ref_inp["cos_cache"],
+        sin_cache=ref_inp["sin_cache"],
+        kv_cache=ref_inp["kv_cache"],
+        block_tables=ref_inp["block_tables"],
+        k_per_block=ref_inp["k_per_block"],
+        overlap=overlap,
+        ratio=ratio,
+        head_dim=D,
+        rope_head_dim=RD,
+        quant=quant,
+        cache_scale=ref_inp["cache_scale"],
+        use_ue8m0=ue8m0,
+        preshuffle=False,  # gfx1250: always linear layout
+    )
+
+    msg = f"{shape_label}/{mode}/{path} bs={bs} mtp={mtp}"
+    if quant:
+        err = checkAllclose(
+            inp["kv_cache"].to(dtypes.fp32),
+            ref_inp["kv_cache"].to(dtypes.fp32),
+            rtol=1e-2,
+            atol=1e-2,
+            tol_err_ratio=0.05,
+            msg=f"{msg} kv_cache(fp8)",
+        )
+        checkAllclose(
+            inp["cache_scale"],
+            ref_inp["cache_scale"],
+            rtol=0,
+            atol=0,
+            tol_err_ratio=0.0,
+            msg=f"{msg} cache_scale(bit-exact)",
+        )
+    else:
+        err = checkAllclose(
+            inp["kv_cache"].to(dtypes.fp32),
+            ref_inp["kv_cache"].to(dtypes.fp32),
+            rtol=1e-2,
+            atol=2e-2,
+            tol_err_ratio=0.02,
+            msg=f"{msg} kv_cache(bf16)",
+        )
+    return {"us_kernel": us_kernel, "err_pct": err}
+
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="gfx1250 (wave32) compress_attn correctness + perf test",
+)
+parser.add_argument(
+    "-s",
+    "--shapes",
+    type=str,
+    nargs="*",
+    default=[s[0] for s in SHAPES],
+    choices=[s[0] for s in SHAPES],
+    help="Shape labels to run. e.g.: -s csa_main hca_main",
+)
+parser.add_argument(
+    "-b",
+    "--bs",
+    type=int,
+    nargs="*",
+    default=[1, 2, 4, 8, 16, 32, 128, 512],
+    help="Batch sizes. e.g.: -b 1 32 512",
+)
+parser.add_argument(
+    "-m",
+    "--mtp",
+    type=int,
+    nargs="*",
+    default=[0, 3],
+    help="Speculative-decode step counts. e.g.: -m 0 3",
+)
+parser.add_argument(
+    "--prefill-bs",
+    type=int,
+    nargs="*",
+    default=[1, 4, 32],
+    help="Batch sizes for prefill mode.",
+)
+parser.add_argument(
+    "--modes",
+    type=str,
+    nargs="*",
+    default=["decode", "prefill"],
+    choices=["decode", "prefill"],
+    help="Which modes to sweep.",
+)
+
+args = parser.parse_args()
+
+df = []
+for mode in args.modes:
+    bs_list = args.bs if mode == "decode" else args.prefill_bs
+    mtp_list = args.mtp if mode == "decode" else [0]
+    for shape_label, mtp, bs in itertools.product(args.shapes, mtp_list, bs_list):
+        df.append(
+            test_flydsl_compress_attn_gfx1250(shape_label, bs, mtp, mode, "single")
+        )
+        if shape_label == "hca_main":
+            df.append(
+                test_flydsl_compress_attn_gfx1250(
+                    shape_label, bs, mtp, mode, "2kernel"
+                )
+            )
+df = pd.DataFrame(df)
+aiter.logger.info(
+    "flydsl_compress_attn_gfx1250 summary (markdown):\n%s",
+    df.to_markdown(index=False),
+)

--- a/op_tests/test_flydsl_compress_attn_gfx1250.py
+++ b/op_tests/test_flydsl_compress_attn_gfx1250.py
@@ -323,9 +323,7 @@ for mode in args.modes:
         )
         if shape_label == "hca_main":
             df.append(
-                test_flydsl_compress_attn_gfx1250(
-                    shape_label, bs, mtp, mode, "2kernel"
-                )
+                test_flydsl_compress_attn_gfx1250(shape_label, bs, mtp, mode, "2kernel")
             )
 df = pd.DataFrame(df)
 aiter.logger.info(


### PR DESCRIPTION
## Summary
- Port `compress_attn` (standard + HCA variants) FlyDSL kernels to gfx1250 (wave32), adapting MFMA→WMMA, disabling preshuffle, and adjusting for RDNA4's 512 VGPRs/wave
- Port `qk_norm_rope_quant` kernel to gfx1250 (wave32) with similar wave32/WMMA adaptations
- Add gfx1250 compress_attn test suite
- Apply ruff format and lint fixes

## Test plan
- [x] Run `op_tests/test_flydsl_compress_attn_gfx1250.py` on gfx1250 hardware
- [x] Run `op_tests/test_flydsl_qk_norm_rope_quant.py` to verify qk_norm_rope_quant correctness on gfx1250
- [x] Confirm no regression on existing gfx942 kernels

