### PR TITLE
[FlyDSL] Fix MoE 2-stage bf16 weight buffer overflow for weights >4GiB

### DIFF
--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -554,6 +554,24 @@ def compile_moe_gemm1(
                 inter2_idx = arith.index(2 * inter_dim)
                 expert_off_idx = expert_idx * inter2_idx  # index
 
+                # --- 64-bit per-expert weight base (fix >4GiB overflow) ---------------
+                # The whole-tensor buffer resource uses a 32-bit byte offset, which wraps
+                # once E*2*inter*model_dim*elem_bytes > 4GiB (e.g. MiniMax-M3: 9GiB).
+                # Rebase the weight resource to this expert's 64-bit address so the
+                # in-kernel offset (row*K) stays within one expert (<4GiB). Equivalent
+                # because expert_off_idx is a multiple of 16 (the preshuffle row group).
+                # Only f16/bf16 (validated). fp8/fp4/int4 keep the original whole-tensor
+                # path unchanged (packed dtypes need their own byte-offset validation).
+                if const_expr(is_f16_or_bf16):
+                    _w_base_addr = buffer_ops.extract_base_index(arg_w)
+                    _w_expert_byte = expert_off_idx * k_in * arith.index(int(w_elem_bytes))
+                    w_rsrc = buffer_ops.create_buffer_resource_from_addr(
+                        arith.index_cast(T.i64, _w_base_addr + _w_expert_byte)
+                    )
+                    w_row_off = arith.index(0)
+                else:
+                    w_row_off = expert_off_idx
+
                 # ---- X gmem->reg prefetch (match preshuffle GEMM mapping) ----
                 # Prefer 16B buffer-load (dwordx4). If the per-thread byte count isn't divisible by
                 # 16, fall back to 8B (dwordx2) or 4B (dword) loads. For fp16/bf16 we require 16B.
@@ -725,7 +743,7 @@ def compile_moe_gemm1(
                     col_g = col_g + lane_mod_16
                     col_g_list.append(col_g)
 
-                    row_gate = expert_off_idx + col_g
+                    row_gate = w_row_off + col_g
                     row_up = row_gate + inter_idx
 
                     coord_gate = fx.idx2crd(row_gate, layout_n_blk_intra)
@@ -2434,6 +2452,21 @@ def compile_moe_gemm2(
                 n_idx = fx.Index(model_dim)
                 expert_off_idx = expert_idx * n_idx  # index
 
+                # --- 64-bit per-expert weight base (fix >4GiB overflow) ---------------
+                # See stage1: rebase weight resource to this expert's 64-bit address so
+                # the 32-bit in-kernel byte offset stays within one expert. Stage2 weight
+                # is [experts*model_dim, inter], K=inter, so per-expert byte offset =
+                # expert_off_idx(rows) * inter(k_in) * w_elem_bytes. f16/bf16 only.
+                if const_expr(is_f16_or_bf16):
+                    _w_base_addr = buffer_ops.extract_base_index(arg_w)
+                    _w_expert_byte = expert_off_idx * k_in * arith.index(int(w_elem_bytes))
+                    w_rsrc = buffer_ops.create_buffer_resource_from_addr(
+                        arith.index_cast(T.i64, _w_base_addr + _w_expert_byte)
+                    )
+                    w_row_off = arith.index(0)
+                else:
+                    w_row_off = expert_off_idx
+
                 # ---- X gmem->reg prefetch (match preshuffle GEMM mapping) ----
                 # Prefer 16B buffer-load (dwordx4). If the per-thread byte count isn't divisible by
                 # 16, fall back to 8B (dwordx2) or 4B (dword) loads. For fp16/bf16 we require 16B.
@@ -2586,7 +2619,7 @@ def compile_moe_gemm2(
                     col_g = by_n + n_tile_base + offset + lane_mod_16
                     col_g_list.append(col_g)
 
-                    row_w = expert_off_idx + col_g
+                    row_w = w_row_off + col_g
                     coord_w = fx.idx2crd(row_w, layout_n_blk_intra)
                     n_blk_list.append(fx.get(coord_w, 0))
                     n_intra_list.append(fx.get(coord_w, 1))

--- a/op_tests/test_flydsl_moe_large_inter.py
+++ b/op_tests/test_flydsl_moe_large_inter.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+"""Kernel-level test for FlyDSL bf16 2-stage MoE across inter_dim, incl. >4GiB.
+
+Regression for the weight buffer 32-bit-offset overflow: the per-expert weight
+must be addressed via a 64-bit base, otherwise results corrupt once the whole
+[E, 2*inter, model_dim] weight exceeds 4 GiB (e.g. MiniMax-M3: inter=3072,
+model_dim=6144, E=128 -> 9 GiB). Validates BOTH stage1 paths:
+  * k_batch=1  -> stage1 fuses SiLU(gate)*up, writes inter-wide output
+  * k_batch>=2 -> split-K, stage1 writes raw 2*inter gate/up, SiLU applied here
+
+Run:  python op_tests/test_flydsl_moe_large_inter.py
+      pytest op_tests/test_flydsl_moe_large_inter.py
+"""
+import torch
+
+import flydsl.compiler as flyc
+from aiter.fused_moe import moe_sorting
+from aiter.ops.activation import silu_and_mul
+from aiter.ops.flydsl.kernels.moe_gemm_2stage import compile_moe_gemm1, compile_moe_gemm2
+from aiter.ops.shuffle import shuffle_weight
+
+H = 6144          # model_dim
+E = 128
+TOPK = 4
+DEV = "cuda"
+
+
+def _ref(x, w1, w2, tw, tid):
+    # Loop over experts (one fp32 weight materialized at a time) so the reference
+    # stays memory-light even for large token counts.
+    xf = x.float()
+    out = torch.zeros(x.shape[0], H, device=DEV, dtype=torch.float32)
+    for e in range(E):
+        sel = tid == e
+        if not sel.any():
+            continue
+        rows, slot = sel.nonzero(as_tuple=True)
+        gu = xf[rows] @ w1[e].float().t()
+        gate, up = gu.chunk(2, dim=-1)
+        act = torch.nn.functional.silu(gate) * up
+        down = act @ w2[e].float().t()
+        out[rows] += tw[rows, slot].unsqueeze(1) * down
+    return out
+
+
+def _cos(a, b):
+    a, b = a.flatten().float(), b.flatten().float()
+    return (1.0 - torch.nn.functional.cosine_similarity(a, b, dim=0)).item()
+
+
+def _make(ntok, inter, seed=0):
+    g = torch.Generator(device=DEV).manual_seed(seed)
+    x = torch.randn(ntok, H, device=DEV, dtype=torch.bfloat16, generator=g) * 0.1
+    w1 = torch.randn(E, 2 * inter, H, device=DEV, dtype=torch.bfloat16, generator=g) * 0.05
+    w2 = torch.randn(E, H, inter, device=DEV, dtype=torch.bfloat16, generator=g) * 0.05
+    logits = torch.randn(ntok, E, device=DEV, dtype=torch.float32, generator=g)
+    tw, tid = torch.topk(torch.softmax(logits, dim=-1), TOPK, dim=-1)
+    return x, w1, w2, tw.float().contiguous(), tid.int().contiguous()
+
+
+def run_flydsl(x, w1, w2, tw, tid, inter, *, tile_m, tile_k, k_batch):
+    ntok = x.shape[0]
+    split_k = k_batch > 1
+    s, sw, se, nv, _ = moe_sorting(tid, tw, E, H, torch.float16, tile_m)
+    if nv.numel() > 1:
+        nv = nv[:1].contiguous()
+    s, se = s.contiguous(), se.contiguous()
+    sw1d = sw.contiguous().view(-1)
+    blocks = int(se.numel())
+    w1s = shuffle_weight(w1, layout=(16, 16)).contiguous().view(-1)
+    w2s = shuffle_weight(w2, layout=(16, 16)).contiguous().view(-1)
+    sd = torch.empty(0, device=DEV, dtype=torch.float32)
+    st = torch.cuda.current_stream()
+
+    e1 = compile_moe_gemm1(
+        model_dim=H, inter_dim=inter, experts=E, topk=TOPK, in_dtype="bf16",
+        group_size=-1, tile_m=tile_m, tile_n=128, tile_k=tile_k,
+        doweight_stage1=False, use_cshuffle_epilog=False, out_dtype="bf16",
+        scale_is_bf16=False, k_batch=int(k_batch))
+    e2 = compile_moe_gemm2(
+        model_dim=H, inter_dim=inter, experts=E, topk=TOPK, in_dtype="bf16",
+        group_size=-1, tile_m=tile_m, tile_n=256, tile_k=tile_k,
+        doweight_stage2=True, use_cshuffle_epilog=True, accumulate=True,
+        out_dtype="bf16", scale_is_bf16=False)
+
+    s1_w = 2 * inter if split_k else inter
+    g1 = torch.zeros(ntok * TOPK, s1_w, device=DEV, dtype=torch.bfloat16)
+    a2 = g1 if not split_k else torch.empty(ntok * TOPK, inter, device=DEV, dtype=torch.bfloat16)
+    out = torch.zeros(ntok, H, device=DEV, dtype=torch.bfloat16)
+
+    c1 = flyc.compile(e1, g1.view(-1), x.view(-1), w1s, sd, sd, s, se, sw1d, nv,
+                      ntok, inter, H, blocks, st)
+    c2 = flyc.compile(e2, out.view(-1), a2.view(-1), w2s, sd, sd, s, se, sw1d, nv,
+                      ntok, H, inter, blocks, st)
+
+    def go():
+        if split_k:
+            g1.zero_()
+        c1(g1.view(-1), x.view(-1), w1s, sd, sd, s, se, sw1d, nv, ntok, inter, H, blocks, st)
+        if split_k:
+            silu_and_mul(a2, g1.view(-1, 2 * inter))
+        out.zero_()
+        c2(out.view(-1), a2.view(-1), w2s, sd, sd, s, se, sw1d, nv, ntok, H, inter, blocks, st)
+        return out
+
+    return go
+
+
+def _time_ms(fn, warmup=10, iters=30):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    s = torch.cuda.Event(enable_timing=True)
+    e = torch.cuda.Event(enable_timing=True)
+    s.record()
+    for _ in range(iters):
+        fn()
+    e.record()
+    torch.cuda.synchronize()
+    return s.elapsed_time(e) / iters
+
+
+# Sweep inter across the 4 GiB w13 boundary (E=128, model_dim=6144, bf16):
+#   total w13 bytes = E*2*inter*model_dim*2.  4 GiB at inter ~= 1365.
+#   inter<=1280 -> <4GiB (worked before the fix);  inter>=1408 -> >4GiB (broken
+#   before the fix);  inter=3072 -> M3 (9 GiB).  All must pass after the fix, and
+#   the small-inter cases must still pass (no regression).
+def _gib(inter):
+    return E * 2 * inter * H * 2 / 2**30
+
+
+CASES = []
+# decode (small M), fused (k_batch=1): sweep inter below/at/above the boundary
+for it in (384, 768, 1280, 1408, 1536, 2048, 3072):
+    CASES.append((16, it, 16, 128, 1, f"decode  fused    inter={it:<4} ({_gib(it):.2f}GiB)"))
+# decode, split-K (k_batch=6): small + M3
+for it in (384, 3072):
+    CASES.append((16, it, 16, 128, 6, f"decode  split-K  inter={it:<4} ({_gib(it):.2f}GiB)"))
+# prefill (large M): boundary + M3, both paths
+for it, kb in ((1408, 1), (3072, 1), (3072, 2)):
+    tag = "split-K" if kb > 1 else "fused  "
+    CASES.append((2048, it, 128, 64, kb, f"prefill {tag} inter={it:<4} ({_gib(it):.2f}GiB)"))
+
+
+def test_flydsl_moe_large_inter():
+    print(f"\n{'case':40s} {'inter':>5} {'kb':>3} {'cos_dist':>10} {'ms':>9}  status")
+    print("-" * 82)
+    bad = []
+    for ntok, inter, tm, tk, kb, name in CASES:
+        x, w1, w2, tw, tid = _make(ntok, inter)
+        ref = _ref(x, w1, w2, tw, tid)
+        go = run_flydsl(x, w1, w2, tw, tid, inter, tile_m=tm, tile_k=tk, k_batch=kb)
+        out = go()
+        cd = _cos(out.float(), ref)
+        ms = _time_ms(go)
+        ok = cd < 0.01
+        if not ok:
+            bad.append(name)
+        print(f"{name:40s} {inter:>5} {kb:>3} {cd:>10.2e} {ms:>9.4f}  {'OK' if ok else 'FAIL'}")
+        del x, w1, w2, ref, out
+        torch.cuda.empty_cache()
+    assert not bad, f"cos_dist >= 0.01 for: {bad}"
+
+
+if __name__ == "__main__":
+    test_flydsl_moe_large_inter()
+    print("\nAll cases PASS (cos_dist < 0.01).")


### PR DESCRIPTION
## Summary

The FlyDSL 2-stage MoE GEMM (`aiter/ops/flydsl/kernels/moe_gemm_2stage.py`) silently
produces **wrong results when the expert-weight tensor exceeds 4 GiB**. The kernel
addresses the whole `[E, 2*inter, model_dim]` weight through a single AMD buffer
resource whose `buffer_load` offset is **32-bit (bytes)**; once the tensor crosses
4 GiB the per-expert offset wraps and the kernel reads the wrong weights. No error is
raised — the output is just corrupt.

This is hit by **MiniMax-M3 bf16 MoE** (`E=128, inter=3072, model_dim=6144` →
`w13 = 9 GiB`), where the MoE output has `cos_dist ≈ 0.5` versus an fp32 reference.

The fix rebases the weight buffer to a **per-expert 64-bit base address** for the
`f16/bf16` path, keeping the in-kernel 32-bit offset within a single expert. Other
dtypes are left byte-for-byte unchanged.

> **Requires `flydsl >= 0.1.8`** — the fix uses the `buffer_ops.create_buffer_resource_from_addr`
> / `extract_base_index` primitives, which are only available from flydsl 0.1.8 onward.

## Root cause

In both `compile_moe_gemm1` and `compile_moe_gemm2` the weight resource is created
once over the entire tensor:

```python
w_rsrc = buffer_ops.create_buffer_resource(arg_w, max_size=False)
...
expert_off_idx = expert_idx * (2 * inter_dim)   # stage1 (rows); stage2 uses model_dim
row_gate = expert_off_idx + col_g               # N-row index into the whole tensor
```

`row_gate` is turned into a per-tile element/byte offset and passed to `buffer_load`,
which casts the offset to **i32 bytes**. The reachable byte offset is
`~E * 2*inter * model_dim * elem_bytes` = the full weight size. When that is `> 2^32`
(4 GiB), the high-expert offsets overflow and wrap.

### Exact boundary (evidence)

With `E=128, model_dim=6144, bf16`, total `w13 = E*2*inter*model_dim*2` bytes:

| inter | w13 size | result (before fix) |
|------:|---------:|---------------------|
| 1280  | 3.75 GiB | correct (`cos_dist ~6e-6`) |
| 1408  | 4.12 GiB | **broken** (`cos_dist ~3e-2`) |
| 1536  | 4.50 GiB | **broken** (`cos_dist ~0.11`) |
| 3072 (M3) | 9.00 GiB | **broken** (`cos_dist ~0.5`) |

The break is exactly at the 4 GiB / 2^32-byte line. It was never caught because the
existing FlyDSL MoE tests use `inter=384` (~1.1 GiB), well under the limit.

## Fix

For the `f16/bf16` path, rebase the weight buffer resource to **this expert's 64-bit
base address**, so the in-kernel 32-bit offset only ever spans one expert
(`2*inter*model_dim*elem_bytes`, e.g. 75 MB at M3 ≪ 4 GiB):

```python
if const_expr(is_f16_or_bf16):
    _w_base_addr   = buffer_ops.extract_base_index(arg_w)
    _w_expert_byte = expert_off_idx * k_in * arith.index(int(w_elem_bytes))
    w_rsrc = buffer_ops.create_buffer_resource_from_addr(
        arith.index_cast(T.i64, _w_base_addr + _w_expert_byte))
    w_row_off = arith.index(0)
else:
    w_row_off = expert_off_idx
...
row_gate = w_row_off + col_g     # stage1   (row_w = w_row_off + col_g in stage2)
```

**Why it is exact:** `expert_off_idx` is a multiple of 16 (the preshuffle row group),
so `base += expert_off_idx * K * elem_bytes` combined with `row = col_g` produces the
same element addresses as the original `row = expert_off_idx + col_g` against a
whole-tensor base — it is purely a 64-bit re-association of the same offset, with no
change to the tile/preshuffle math. `k_in` is the contraction dim of each stage
(`model_dim` for stage1, `inter` for stage2), so the formula
`expert_off_idx * k_in * w_elem_bytes` is the per-expert byte stride in both.

`create_buffer_resource_from_addr` / `extract_base_index` are existing `buffer_ops`
helpers (already used elsewhere, e.g. for `arg_out`).

## Scope & safety

- The change is behind a `const_expr(is_f16_or_bf16)` **compile-time** branch, so:
  - `fp8 / int8 / int4 / int4_bf16` (which also route through `compile_moe_gemm{1,2}`)
    take the original `else` path and generate **byte-for-byte identical** kernels.
  - `fp4` uses `compile_mixed_moe_gemm{1,2}` and is **not touched** at all.
- Verified that `bf16, fp16, fp8, int8, int4, int4_bf16` all still compile through the
  edited functions.
- No API/signature changes; no new dependencies.

## Tests

Adds `op_tests/test_flydsl_moe_large_inter.py`: a self-contained (aiter + torch only)
kernel-level test that sweeps `inter` across the 4 GiB boundary for both stage1 modes
(fused `k_batch=1`, split-K `k_batch>=2`), at decode and prefill token counts, and
asserts `cos_dist < 0.01` vs an fp32 reference.

Before vs after the fix (`E=128, model_dim=6144, bf16`, MI300X; `cos_dist` vs fp32 ref):

| case | inter | w13 | cos_dist **before** | cos_dist **after** |
|------|------:|----:|--------------------:|-------------------:|
| decode  fused   |  384 | 1.12 GiB | 6.1e-06 ✅ | 6.1e-06 ✅ |
| decode  fused   |  768 | 2.25 GiB | 6.3e-06 ✅ | 6.3e-06 ✅ |
| decode  fused   | 1280 | 3.75 GiB | 6.2e-06 ✅ | 6.1e-06 ✅ |
| decode  fused   | 1408 | 4.12 GiB | **1.3e-01 ❌** | 6.2e-06 ✅ |
| decode  fused   | 1536 | 4.50 GiB | **4.5e-02 ❌** | 6.3e-06 ✅ |
| decode  fused   | 2048 | 6.00 GiB | **3.1e-01 ❌** | 6.4e-06 ✅ |
| decode  fused   | 3072 | 9.00 GiB | **3.1e-01 ❌** | 6.4e-06 ✅ |
| decode  split-K |  384 | 1.12 GiB | 2.1e-05 ✅ | 2.2e-05 ✅ |
| decode  split-K | 3072 | 9.00 GiB | **3.1e-01 ❌** | 2.0e-05 ✅ |
| prefill fused   | 1408 | 4.12 GiB | **3.0e-02 ❌** | 6.2e-06 ✅ |
| prefill fused   | 3072 | 9.00 GiB | **5.5e-01 ❌** | 6.3e-06 ✅ |
| prefill split-K | 3072 | 9.00 GiB | **5.5e-01 ❌** | 1.3e-05 ✅ |

**Takeaways:**
- **Boundary is exactly 4 GiB.** `inter=1280` (3.75 GiB) passes before *and* after;
  `inter=1408` (4.12 GiB) is the first to break before the fix — the transition lands
  precisely on the 4 GiB / 2^32-byte line.
- **No regression.** Every `< 4 GiB` shape (`inter <= 1280`) is identical before/after.
- **All `> 4 GiB` shapes fixed.** Every `inter >= 1408` case goes from broken
  (`cos_dist ~0.03 .. 0.55`) to correct (`cos_dist ~1e-5`), for both fused and split-K
  stage1 modes and at decode and prefill token counts.
- **Latency unchanged.** Same math, just 64-bit-addressed — e.g. decode `inter=3072`
  ~1.5 ms, prefill `inter=3072` ~5.4 ms per call, before and after.

```
pytest op_tests/test_flydsl_moe_large_inter.py
# or: python op_tests/test_flydsl_moe_large_inter.py
```

## Notes / follow-ups

- `fp8/fp4` weights are packed, so the same overflow can affect them at large shapes;
  fixing those needs their own byte-offset validation and is intentionally **out of
  scope** here (left on the original path).
- This unblocks the bf16 FlyDSL MoE path used by the vLLM MiniMax-M3-MXFP8 emulation
  (vLLM PR vllm-project/vllm#46123), which depends on this kernel fix.