### PR TITLE
ci: fix Triton wheel default ROCm fallback

### DIFF
--- a/.github/scripts/download_triton_wheel.sh
+++ b/.github/scripts/download_triton_wheel.sh
@@ -10,7 +10,7 @@ python3 -m pip config set global.timeout 120
 
 TRITON_DEFAULT_ROCM_VERSION="${TRITON_DEFAULT_ROCM_VERSION:-7.2.0}"
 TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${TRITON_DEFAULT_ROCM_VERSION}/simple/"
-ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}')
+ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}' || true)
 if [[ -n "${ROCM_VERSION}" ]]; then
     ROCM_MAJOR_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f1,2)
     TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"

--- a/.github/scripts/install_triton.sh
+++ b/.github/scripts/install_triton.sh
@@ -60,11 +60,14 @@ install_triton_from_wheelhouse() {
     return 0
 }
 
-TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-7.0.0/simple/"
+TRITON_DEFAULT_ROCM_VERSION="${TRITON_DEFAULT_ROCM_VERSION:-7.2.0}"
+TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${TRITON_DEFAULT_ROCM_VERSION}/simple/"
 ROCM_VERSION=$(dpkg -l rocm-core 2>/dev/null | awk '/^ii/{print $3}' || true)
 if [[ -n "$ROCM_VERSION" ]]; then
     ROCM_MAJOR_MINOR=$(echo "$ROCM_VERSION" | cut -d. -f1,2)
     TRITON_INDEX_URL="https://pypi.amd.com/triton/release_/rocm-${ROCM_MAJOR_MINOR}.0/simple/"
+else
+    echo "rocm-core not found; using default ROCm version ${TRITON_DEFAULT_ROCM_VERSION}"
 fi
 
 TRITON_WHEEL_DIR=${TRITON_WHEEL_DIR:-}


### PR DESCRIPTION
## Summary
- keep Triton wheel download fallback alive when rocm-core is absent on ubuntu-latest
- align install_triton.sh's no-ROCm fallback index with the ROCm 7.2 default used by wheel preparation

## Testing
- bash -n .github/scripts/download_triton_wheel.sh
- bash -n .github/scripts/install_triton.sh
- git diff --check
- verified no-rocm-core fallback resolves to https://pypi.amd.com/triton/release_/rocm-7.2.0/simple/