### PR TITLE
[Kernel] Fuse fp8 quant into rope_rotate_activation (DSV4 indexer Q)

### DIFF
--- a/.github/scripts/split_tests.sh
+++ b/.github/scripts/split_tests.sh
@@ -131,7 +131,7 @@ if [[ "$TEST_TYPE" == "aiter" ]]; then
     FILE_TIMES[op_tests/test_indexer_k_quant_and_cache.py]=6
     FILE_TIMES[op_tests/test_mha_flydsl_varlen.py]=6
     FILE_TIMES[op_tests/test_mha_varlen_fp8.py]=6
-    FILE_TIMES[op_tests/test_rotate_fp4quant.py]=6
+    FILE_TIMES[op_tests/test_dsv4_rotate_quant.py]=14
     FILE_TIMES[op_tests/test_topk_row_prefill.py]=6
     FILE_TIMES[op_tests/test_fused_qk_rmsnorm_per_token_quant.py]=5
     FILE_TIMES[op_tests/test_gemm_a4w4.py]=5

--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -1233,6 +1233,16 @@ def rope_rotate_activation(
     sin: torch.Tensor,
     positions: torch.Tensor,
     rope_dim: int,
+    out_scale: Optional[torch.Tensor] = None,
+    group_size: int = 128,
 ) -> None:
-    """Apply interleaved RoPE to trailing ``rope_dim``, then Hadamard-rotate."""
+    """Apply interleaved RoPE to trailing ``rope_dim``, then Hadamard-rotate.
+
+    When ``out_scale`` is given, the rotated activation is additionally
+    fp8-quantized in-kernel (fusing what ``get_hip_quant(per_1x128)`` would do):
+    ``out`` must be fp8 and receives ``round(rotated / scale)``, while
+    ``out_scale`` (``[m, dim // group_size]`` fp32) receives the per-(row,
+    ``1 x group_size``) block scales ``scale = absMax / fp8_max``. Without
+    ``out_scale`` it is the bf16/fp16 in-place path (``out`` shares dtype with
+    ``input``)."""
     ...

--- a/csrc/include/dsv4_rotate_quant.h
+++ b/csrc/include/dsv4_rotate_quant.h
@@ -4,6 +4,7 @@
 
 #include "aiter_tensor.h"
 #include <cstdint>
+#include <optional>
 
 namespace aiter {
 
@@ -23,11 +24,17 @@ void rope_rotate_activation_fp4quant_inplace(aiter_tensor_t& out,
                                             int32_t rope_dim,
                                             int32_t group_size = 32);
 
+// rope+hadamard. When `out_scale` is provided, additionally fp8-quantize the
+// result: `out` is fp8 and `out_scale` receives per-(row, 1xGROUP) fp32 scales
+// ([m, dim/group_size]), matching get_hip_quant(per_1x128). Without `out_scale`
+// it is the bf16/fp16 in-place path (out shares dtype/stride with input).
 void rope_rotate_activation(aiter_tensor_t& out,
                             const aiter_tensor_t& input,
                             const aiter_tensor_t& cos,
                             const aiter_tensor_t& sin,
                             const aiter_tensor_t& positions,
-                            int32_t rope_dim);
+                            int32_t rope_dim,
+                            std::optional<aiter_tensor_t> out_scale = std::nullopt,
+                            int32_t group_size = 128);
 
 } // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1555,7 +1555,9 @@ namespace py = pybind11;
           py::arg("cos"),                                                                    \
           py::arg("sin"),                                                                    \
           py::arg("positions"),                                                              \
-          py::arg("rope_dim"));
+          py::arg("rope_dim"),                                                               \
+          py::arg("out_scale") = std::nullopt,                                               \
+          py::arg("group_size") = 128);
 
 #define QUICK_ALL_REDUCE_PYBIND                                                            \
     m.def("init_custom_qr",                                                                \

--- a/csrc/kernels/dsv4_rotate_quant.cu
+++ b/csrc/kernels/dsv4_rotate_quant.cu
@@ -152,6 +152,13 @@ __global__ void hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I* __re
 
     if constexpr(fp4quant)
     {
+        // MXFP4 (e8m0 microscaling) relies on the gfx950-only cvt_scalef32_pk_fp4
+        // intrinsics; on gfx942 those don't exist, so this branch must not codegen
+        // them. The host (rotate_activation_fp4quant_inplace) rejects gfx942 before
+        // launch, so the trap only guards a never-reached gfx942 device path.
+#if defined(__gfx942__)
+        __builtin_trap();
+#else
         constexpr float fp4_max   = static_cast<float>(opus::finfo<opus::fp4_t>::max());
         constexpr float eps_amax  = fp4_max * __builtin_bit_cast(float, 0x00800000u);
         float absMax              = eps_amax;
@@ -169,6 +176,7 @@ __global__ void hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I* __re
         auto a_fp4       = scaled_cast<opus::fp4_t>(af, scale);
         halfxvec_t a_out = scaled_cast<DTYPE_I>(a_fp4, scale);
         store_vector_nbytes<DTYPE_I, DTYPE_I, vec_size, 8 * sizeof(DTYPE_I)>(g_o, a_out, load_offset);
+#endif
     }
     else
     {
@@ -193,6 +201,9 @@ void rotate_activation_fp4quant_inplace(aiter_tensor_t& out,
                                         const aiter_tensor_t& input,
                                         const int32_t group_size)
 {
+    // MXFP4 (e8m0) quant uses gfx950-only microscaling cvt; not available on gfx942.
+    AITER_CHECK(get_gpu_arch() != "gfx942",
+                "rotate_activation_fp4quant_inplace requires gfx950 (MXFP4 microscaling); not supported on gfx942");
     AITER_CHECK(group_size == 32 || group_size == 64 || group_size == 128, "group_size must be 32, 64, 128");
     const int32_t dim = input.size(-1);
     AITER_CHECK(dim % group_size == 0, "dim must be divisible by group_size");
@@ -267,17 +278,29 @@ void rotate_activation(aiter_tensor_t& out,
 }
 
 
-template <typename DTYPE_I, int dim, bool fp4quant = false, int vec_size = 16>
-__global__ void rope_hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I* __restrict__ out,
-                                                                        DTYPE_I const* __restrict__ input,
-                                                                        DTYPE_I const* __restrict__ cos,
-                                                                        DTYPE_I const* __restrict__ sin,
-                                                                        int64_t const* __restrict__ positions,
-                                                                        const int32_t m,
-                                                                        const int32_t head_num,
-                                                                        const int32_t rope_dim,
-                                                                        const int32_t stride,
-                                                                        const int32_t group_size)
+// Quant modes for the rope+hadamard kernel. NONE/FP4 keep DTYPE_O == DTYPE_I and
+// write back into the (bf16/fp16) output in place; FP8 writes a fresh fp8 buffer
+// plus a per-(row, 1xGROUP) fp32 scale (mirrors get_hip_quant(per_1x128)).
+enum : int
+{
+    RQ_NONE = 0,
+    RQ_FP4  = 1,
+    RQ_FP8  = 2
+};
+
+template <typename DTYPE_I, typename DTYPE_O, int dim, int QMODE = RQ_NONE, int vec_size = 16>
+__global__ void rope_hadamard_rotate_activation_quant_kernel(DTYPE_O* __restrict__ out,
+                                                             DTYPE_I const* __restrict__ input,
+                                                             DTYPE_I const* __restrict__ cos,
+                                                             DTYPE_I const* __restrict__ sin,
+                                                             int64_t const* __restrict__ positions,
+                                                             float* __restrict__ out_scale,
+                                                             const int32_t m,
+                                                             const int32_t head_num,
+                                                             const int32_t rope_dim,
+                                                             const int32_t stride,
+                                                             const int32_t out_stride,
+                                                             const int32_t group_size)
 {
     constexpr int warp_size = opus::get_warp_size();
     static_assert(vec_size * warp_size % dim == 0, "vec_size * warp_size must be divisible by dim");
@@ -285,7 +308,7 @@ __global__ void rope_hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I*
     constexpr int m_block     = vec_size * warp_size / dim;
     constexpr float dim_rsqrt = rotate_dim_rsqrt<dim>();
 
-    using halfxvec_t  = opus::vector_t<DTYPE_I, vec_size>;
+    using halfxvec_t  = opus::vector_t<DTYPE_O, vec_size>;
     using floatxvec_t = opus::vector_t<float, vec_size>;
     using freqxvec_t  = opus::vector_t<DTYPE_I, vec_size / 2>;
 
@@ -295,6 +318,7 @@ __global__ void rope_hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I*
     const int32_t row_base      = blockIdx.x * m_block;
     const int m_oob            = m - row_base < m_block ? m - row_base : m_block;
     const int64_t row_offset   = static_cast<int64_t>(row_base) * stride;
+    const int64_t out_offset   = static_cast<int64_t>(row_base) * out_stride;
     const int load_offset      = threadIdx.x * vec_size;
     const int row_in_block     = load_offset / dim;
     const int col_offset       = load_offset - row_in_block * dim;
@@ -303,7 +327,7 @@ __global__ void rope_hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I*
     const int32_t token_id     = safe_row_idx >> log2_head_num;
     auto g_a = opus::make_gmem<DTYPE_I>(input + row_offset, stride * sizeof(DTYPE_I) * m_oob);
     auto a = load_vector_nbytes<DTYPE_I, vec_size, 8 * sizeof(DTYPE_I)>(g_a, load_offset);
-    auto g_o = opus::make_gmem<DTYPE_I>(out + row_offset, dim * sizeof(DTYPE_I) * m_oob);
+    auto g_o = opus::make_gmem<DTYPE_O>(out + out_offset, dim * sizeof(DTYPE_O) * m_oob);
 
     floatxvec_t af;
     if(col_offset >= rope_start)
@@ -373,8 +397,15 @@ __global__ void rope_hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I*
         af[i] = af[i] * dim_rsqrt;
     }
 
-    if constexpr(fp4quant)
+    if constexpr(QMODE == RQ_FP4)
     {
+        // MXFP4 (e8m0 microscaling) relies on the gfx950-only cvt_scalef32_pk_fp4
+        // intrinsics; on gfx942 those don't exist, so this branch must not codegen
+        // them. The host (rope_rotate_activation_fp4quant_inplace) rejects gfx942
+        // before launch, so the trap only guards a never-reached gfx942 device path.
+#if defined(__gfx942__)
+        __builtin_trap();
+#else
         constexpr float fp4_max   = static_cast<float>(opus::finfo<opus::fp4_t>::max());
         constexpr float eps_amax  = fp4_max * __builtin_bit_cast(float, 0x00800000u);
         float absMax              = eps_amax;
@@ -390,16 +421,56 @@ __global__ void rope_hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I*
         float scale = aiter::fp4_f32_to_e8m0_scale(absMax);
 
         auto a_fp4       = scaled_cast<opus::fp4_t>(af, scale);
-        halfxvec_t a_out = scaled_cast<DTYPE_I>(a_fp4, scale);
-        store_vector_nbytes<DTYPE_I, DTYPE_I, vec_size, 8 * sizeof(DTYPE_I)>(g_o, a_out, load_offset);
+        halfxvec_t a_out = scaled_cast<DTYPE_O>(a_fp4, scale);
+        store_vector_nbytes<DTYPE_O, DTYPE_O, vec_size, 8 * sizeof(DTYPE_O)>(g_o, a_out, load_offset);
+#endif
+    }
+    else if constexpr(QMODE == RQ_FP8)
+    {
+        // per-(row, 1xGROUP) e4m3 quant, strictly matching
+        // dynamic_per_group_scaled_quant_kernel (csrc/kernels/quant_kernels.cu):
+        //   absMax = max(1e-10f, group_max|x|)            (absMax seeded at 1e-10f)
+        //   scale  = absMax * (1 / fp8_max)               (stored per-group scale)
+        //   out_fp8 = round_to_nearest(af * (1 / scale))  (store reciprocal-multiply)
+        // finfo<fp8_t>::max() is arch-correct (448 OCP e4m3fn on gfx950, 240
+        // e4m3fnuz on gfx942), so the scale matches the torch reference per arch.
+        // 1/fp8_max uses double-then-narrow division to mirror the reference
+        // kernel's `inverted_DTYPE_MAX = 1. / static_cast<float>(max())`.
+        constexpr float fp8_max      = static_cast<float>(opus::finfo<opus::fp8_t>::max());
+        const float inverted_fp8_max = 1.0 / fp8_max;
+        float absMax                 = 1e-10f;
+#pragma unroll
+        for(int i = 0; i < vec_size; i++)
+        {
+            absMax = fmaxf(absMax, fabsf(af[i]));
+        }
+        auto max_op              = [](float a, float b) { return fmaxf(a, b); };
+        int num_thread_per_group = group_size / vec_size;
+        // DPP butterfly reduce -> every lane in the group holds the group absMax.
+        absMax      = multithread_reduce(absMax, max_op, num_thread_per_group);
+        float scale = absMax * inverted_fp8_max;
+
+        // One fp32 scale per (row, group); the group-leader lane writes it.
+        // Scale layout is [m, dim/group_size] row-major (contiguous), matching
+        // the python `q_scale.view(m, dim//group_size)`.
+        const int num_groups = dim / group_size;
+        if(col_offset % group_size == 0 && row_idx < m)
+        {
+            out_scale[static_cast<int64_t>(row_idx) * num_groups + col_offset / group_size] = scale;
+        }
+
+        // scaled_cast multiplies by the inverted scale: out_fp8 = af * (1/scale).
+        opus::vector_t<opus::fp8_t, vec_size> a_out = scaled_cast<opus::fp8_t>(af, 1.0f / scale);
+        store_vector_nbytes<opus::fp8_t, opus::fp8_t, vec_size, 8>(g_o, a_out, load_offset);
     }
     else
     {
-        store_vector_nbytes<DTYPE_I, float, vec_size, 8 * sizeof(DTYPE_I)>(g_o, af, load_offset);
+        store_vector_nbytes<DTYPE_O, float, vec_size, 8 * sizeof(DTYPE_O)>(g_o, af, load_offset);
     }
 }
 
-#define ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(dim, fp4quant, vec_size, name)         \
+// none/fp4 in-place variant: DTYPE_O == DTYPE_I, no scale output, out_stride == stride.
+#define ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(dim, QMODE, vec_size, name)                      \
     AITER_CHECK(vec_size * block_size % dim == 0, "vec_size * block_size must be divisible by dim"); \
     AITER_CHECK(rope_dim % vec_size == 0, "rope_dim must be divisible by vec_size");              \
     int32_t m_block = vec_size * WARP_SIZE / dim;                                            \
@@ -407,14 +478,34 @@ __global__ void rope_hadamard_rotate_activation_fp4quant_inplace_kernel(DTYPE_I*
     AITER_DISPATCH_FLOATING16_TYPES_rmTorch(input.dtype(), name,                                   \
                                             [&] {                                                  \
                                                 using DTYPE_I = typename aiter::hip2opus<scalar_t>::type; \
-                                                rope_hadamard_rotate_activation_fp4quant_inplace_kernel<DTYPE_I, dim, fp4quant, vec_size> \
+                                                rope_hadamard_rotate_activation_quant_kernel<DTYPE_I, DTYPE_I, dim, QMODE, vec_size> \
                                                     <<<grid, dim3(block_size), 0, stream>>>(       \
                                                         reinterpret_cast<DTYPE_I*>(out.data_ptr()), \
                                                         reinterpret_cast<DTYPE_I const*>(input.data_ptr()), \
                                                         reinterpret_cast<DTYPE_I const*>(cos.data_ptr()), \
                                                         reinterpret_cast<DTYPE_I const*>(sin.data_ptr()), \
                                                         reinterpret_cast<int64_t const*>(positions.data_ptr()), \
-                                                        m, head_num, rope_dim, stride, group_size); \
+                                                        nullptr, m, head_num, rope_dim, stride, stride, group_size); \
+                                            });
+
+// fp8 variant: DTYPE_O == fp8, writes out_fp8 + out_scale (fp32).
+#define ROPE_ROTATE_ACTIVATION_FP8QUANT_KERNEL_IMPL(dim, vec_size, name)                            \
+    AITER_CHECK(vec_size * block_size % dim == 0, "vec_size * block_size must be divisible by dim"); \
+    AITER_CHECK(rope_dim % vec_size == 0, "rope_dim must be divisible by vec_size");              \
+    int32_t m_block = vec_size * WARP_SIZE / dim;                                            \
+    dim3 const grid((m + m_block - 1) / m_block);                                                   \
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(input.dtype(), name,                                   \
+                                            [&] {                                                  \
+                                                using DTYPE_I = typename aiter::hip2opus<scalar_t>::type; \
+                                                rope_hadamard_rotate_activation_quant_kernel<DTYPE_I, opus::fp8_t, dim, RQ_FP8, vec_size> \
+                                                    <<<grid, dim3(block_size), 0, stream>>>(       \
+                                                        reinterpret_cast<opus::fp8_t*>(out.data_ptr()), \
+                                                        reinterpret_cast<DTYPE_I const*>(input.data_ptr()), \
+                                                        reinterpret_cast<DTYPE_I const*>(cos.data_ptr()), \
+                                                        reinterpret_cast<DTYPE_I const*>(sin.data_ptr()), \
+                                                        reinterpret_cast<int64_t const*>(positions.data_ptr()), \
+                                                        reinterpret_cast<float*>(out_scale_ptr->data_ptr()), \
+                                                        m, head_num, rope_dim, stride, out_stride, group_size); \
                                             });
 
 void rope_rotate_activation_fp4quant_inplace(aiter_tensor_t& out,
@@ -425,6 +516,9 @@ void rope_rotate_activation_fp4quant_inplace(aiter_tensor_t& out,
     const int32_t rope_dim,
     const int32_t group_size)
 {
+    // MXFP4 (e8m0) quant uses gfx950-only microscaling cvt; not available on gfx942.
+    AITER_CHECK(get_gpu_arch() != "gfx942",
+                "rope_rotate_activation_fp4quant_inplace requires gfx950 (MXFP4 microscaling); not supported on gfx942");
     AITER_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
                 "group_size must be 32, 64, 128");
     AITER_CHECK(input.dim() >= 2, "input must have at least 2 dims [..., head_num, dim]");
@@ -463,22 +557,22 @@ void rope_rotate_activation_fp4quant_inplace(aiter_tensor_t& out,
     AITER_CHECK(dim % block_size == 0, "dim must be divisible by block_size");
     if(dim == 128)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(128, true, 16,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(128, RQ_FP4, 16,
             "rope_rotate_activation_fp4quant_inplace");
     }
     else if(dim == 256)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(256, true, 16,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(256, RQ_FP4, 16,
             "rope_rotate_activation_fp4quant_inplace");
     }
     else if(dim == 512)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(512, true, 16,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(512, RQ_FP4, 16,
             "rope_rotate_activation_fp4quant_inplace");
     }
     else if(dim == 1024)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(1024, true, 32,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(1024, RQ_FP4, 32,
             "rope_rotate_activation_fp4quant_inplace");
     }
     else
@@ -494,11 +588,17 @@ void rope_rotate_activation(aiter_tensor_t& out,
     const aiter_tensor_t& cos,
     const aiter_tensor_t& sin,
     const aiter_tensor_t& positions,
-    const int32_t rope_dim)
+    const int32_t rope_dim,
+    std::optional<aiter_tensor_t> out_scale,
+    int32_t group_size)
 {
+    // out_scale present -> fused fp8 quant: out is fp8 and a per-(row, 1xGROUP)
+    // fp32 scale is produced (matches get_hip_quant(per_1x128)). Absent -> the
+    // bf16/fp16 in-place rope+hadamard path (out shares dtype/stride with input).
+    const bool fp8quant = out_scale.has_value();
+
     AITER_CHECK(input.dim() >= 2, "input must have at least 2 dims [..., head_num, dim]");
     AITER_CHECK(out.numel() == input.numel(), "input and out must have the same numel");
-    AITER_CHECK(out.dtype() == input.dtype(), "input and out dtype must be the same");
     AITER_CHECK(cos.dtype() == input.dtype() && sin.dtype() == input.dtype(),
                 "cos/sin dtype must match input dtype");
     AITER_CHECK(positions.dtype() == AITER_DTYPE_i64, "positions must be int64");
@@ -518,7 +618,6 @@ void rope_rotate_activation(aiter_tensor_t& out,
 
     const int32_t stride     = input.stride(-2);
     const int32_t out_stride = out.stride(-2);
-    AITER_CHECK(stride == out_stride, "input and out stride(-2) must be the same");
     const int32_t m = input.numel() / dim;
     AITER_CHECK(m % head_num == 0, "num rows must be divisible by head_num");
     AITER_CHECK(positions.numel() >= static_cast<size_t>(m / head_num),
@@ -530,25 +629,54 @@ void rope_rotate_activation(aiter_tensor_t& out,
     int32_t block_size = WARP_SIZE;
     AITER_CHECK(dim % block_size == 0, "dim must be divisible by block_size");
 
-    const int32_t group_size = 0;
+    if(fp8quant)
+    {
+        const std::optional<aiter_tensor_t>& out_scale_ptr = out_scale;
+        AITER_CHECK(out.dtype() == AITER_DTYPE_fp8, "fp8 quant: out must be fp8");
+        AITER_CHECK(out_scale_ptr->dtype() == AITER_DTYPE_fp32, "out_scale must be fp32");
+        AITER_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
+                    "group_size must be 32, 64, 128");
+        AITER_CHECK(dim % group_size == 0, "dim must be divisible by group_size");
+        const int32_t num_groups = dim / group_size;
+        AITER_CHECK(out_scale_ptr->numel() == static_cast<size_t>(m) * num_groups,
+                    "out_scale numel must equal m * (dim / group_size)");
+        AITER_CHECK(out_scale_ptr->stride(-1) == 1, "out_scale last dim must be contiguous");
+
+        if(dim == 128)
+            { ROPE_ROTATE_ACTIVATION_FP8QUANT_KERNEL_IMPL(128, 16, "rope_rotate_activation"); }
+        else if(dim == 256)
+            { ROPE_ROTATE_ACTIVATION_FP8QUANT_KERNEL_IMPL(256, 16, "rope_rotate_activation"); }
+        else if(dim == 512)
+            { ROPE_ROTATE_ACTIVATION_FP8QUANT_KERNEL_IMPL(512, 16, "rope_rotate_activation"); }
+        else if(dim == 1024)
+            { ROPE_ROTATE_ACTIVATION_FP8QUANT_KERNEL_IMPL(1024, 32, "rope_rotate_activation"); }
+        else
+            { AITER_CHECK(false, "dim must be 128, 256, 512 or 1024"); }
+        return;
+    }
+
+    AITER_CHECK(out.dtype() == input.dtype(), "input and out dtype must be the same");
+    AITER_CHECK(stride == out_stride, "input and out stride(-2) must be the same");
+
+    group_size = 0;  // unused on the non-quant path
     if(dim == 128)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(128, false, 16,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(128, RQ_NONE, 16,
             "rope_rotate_activation");
     }
     else if(dim == 256)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(256, false, 16,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(256, RQ_NONE, 16,
             "rope_rotate_activation");
     }
     else if(dim == 512)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(512, false, 16,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(512, RQ_NONE, 16,
             "rope_rotate_activation");
     }
     else if(dim == 1024)
     {
-        ROPE_ROTATE_ACTIVATION_FP4QUANT_INPLACE_KERNEL_IMPL(1024, false, 32,
+        ROPE_ROTATE_ACTIVATION_INPLACE_KERNEL_IMPL(1024, RQ_NONE, 32,
             "rope_rotate_activation");
     }
     else

--- a/op_tests/test_dsv4_rotate_quant.py
+++ b/op_tests/test_dsv4_rotate_quant.py
@@ -98,6 +98,95 @@ def rope_rotate_fp4quant_inplace_torch(
     return x
 
 
+def rope_rotate_fp8quant_torch(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    positions: torch.Tensor,
+    rope_dim: int,
+    group_size: int = 128,
+):
+    """Torch reference for the fused rope+hadamard+fp8 path.
+
+    The fp8 quant mirrors `dynamic_per_group_scaled_quant_kernel`
+    (csrc/kernels/quant_kernels.cu) in fp32:
+      absMax = max(1e-10, group_max|x|)            # kernel seeds absMax at 1e-10f
+      scale  = absMax * (1 / fp8_max)              # stored per-group scale
+      q      = round_to_nearest(x * (1 / scale))   # store multiplies by reciprocal
+    fp8 saturation comes from the cast (the kernel relies on the cvt intrinsic),
+    so no explicit pre-clamp — matching the dsv4 fused kernel's store path
+    (`scaled_cast<fp8>(af, 1.0f / scale)`).
+    Returns (dequant_bf16, scale[m, dim//group_size]).
+    """
+    rope_inplace_torch(x, cos, sin, positions, rope_dim)
+    x = rotate_activation(x)  # bf16 rotated activation
+
+    fp8_max = torch.finfo(dtypes.fp8).max
+    inv_fp8_max = 1.0 / fp8_max
+    *prefix, n = x.shape
+    assert n % group_size == 0
+    g = n // group_size
+    xf = x.float().reshape(-1, g, group_size)
+    absmax = xf.abs().amax(dim=-1, keepdim=True).clamp(min=1e-10)
+    scale = absmax * inv_fp8_max
+    q = (xf * scale.reciprocal()).to(dtypes.fp8)
+    deq = (q.float() * scale).reshape(*prefix, n).to(x.dtype)
+    return deq, scale.reshape(-1, g)
+
+
+@benchmark()
+def test_rope_rotate_fp8quant(M, head_num, N, dtype=torch.bfloat16):
+    # fp8 path is supported on both gfx950 (e4m3fn) and gfx942 (e4m3fnuz) -- the
+    # arch-only fp4 kernels are gfx942-gated out, so this module builds and runs
+    # on gfx942 too. fp8_max (448 vs 240) is taken from torch.finfo per arch.
+    rope_dim = 64
+    group_size = 128
+    max_pos = 2048
+    x = torch.randn((M, head_num, N), dtype=dtype, device="cuda")
+    positions = torch.randint(0, max_pos, (M,), dtype=torch.int64, device="cuda")
+    freqs = torch.randn((max_pos, rope_dim // 2), dtype=torch.float32, device="cuda")
+    cos = torch.cos(freqs).to(dtype)
+    sin = torch.sin(freqs).to(dtype)
+
+    ref_deq, ref_scale = rope_rotate_fp8quant_torch(
+        x.clone(), cos, sin, positions, rope_dim, group_size=group_size
+    )
+
+    g = N // group_size
+    q_fp8 = torch.empty_like(x, dtype=dtypes.fp8)
+    q_scale = torch.empty((M * head_num, g), dtype=torch.float32, device="cuda")
+    _, us = run_perftest(
+        aiter.rope_rotate_activation,
+        q_fp8,
+        x,
+        cos,
+        sin,
+        positions,
+        rope_dim,
+        out_scale=q_scale,
+        group_size=group_size,
+    )
+
+    # Compare on the dequantized result so the check isolates the kernel's
+    # rope+hadamard+quant from fp8 rounding (both paths round identically).
+    got_deq = (
+        q_fp8.float().reshape(M * head_num, g, group_size)
+        * q_scale.reshape(M * head_num, g, 1)
+    ).reshape(M, head_num, N)
+    err = checkAllclose(ref_deq.float(), got_deq, atol=1e-2, rtol=1e-2)
+    scale_err = checkAllclose(
+        ref_scale, q_scale.reshape(M * head_num, g), atol=1e-3, rtol=1e-3
+    )
+    ret = {}
+    ret["op"] = "rope_rotate_fp8"
+    ret["head_num"] = head_num
+    ret["rope_dim"] = rope_dim
+    ret["err"] = err
+    ret["scale_err"] = scale_err
+    ret["us"] = us
+    return ret
+
+
 @benchmark()
 def test_rotate_fp4quant_inplace(M, head_num, N, dtype=torch.bfloat16):
     if get_gfx() == "gfx942":
@@ -199,25 +288,38 @@ parser.add_argument(
     "-r",
     "--rope",
     action="store_true",
-    help="""rope. Default: False.
-    --rope # True""",
+    help="""run ONLY the rope+rotate+fp4 path.
+    Default (no flag): sweep both the fp4 and fused-fp8 paths.""",
+)
+parser.add_argument(
+    "--fp8",
+    action="store_true",
+    help="""run ONLY the fused rope+hadamard+fp8 quant path (implies --rope).
+    Default (no flag): sweep both the fp4 and fused-fp8 paths.""",
 )
 
 args = parser.parse_args()
 
+# Which quant paths to sweep. Explicit --fp8 / --rope still select a single
+# path (backward compat). With neither flag, the default sweep covers BOTH the
+# fp4 path and the fused rope+hadamard+fp8 path, so CI exercises the fp8 kernel
+# (aiter.rope_rotate_activation with out_scale) by default.
+if args.fp8:
+    test_fns = [test_rope_rotate_fp8quant]
+elif args.rope:
+    test_fns = [test_rope_rotate_fp4quant_inplace]
+else:
+    test_fns = [test_rotate_fp4quant_inplace, test_rope_rotate_fp8quant]
+
 df = []
-for dtype in args.dtype:
-    for head_num in args.head_num:
-        for dim in args.dim:
-            for m in args.m:
-                if args.rope:
-                    ret = test_rope_rotate_fp4quant_inplace(
-                        m, head_num, dim, dtype=dtype
-                    )
-                else:
-                    ret = test_rotate_fp4quant_inplace(m, head_num, dim, dtype=dtype)
-                df.append(ret)
+for test_fn in test_fns:
+    for dtype in args.dtype:
+        for head_num in args.head_num:
+            for dim in args.dim:
+                for m in args.m:
+                    ret = test_fn(m, head_num, dim, dtype=dtype)
+                    df.append(ret)
 
 df = pd.DataFrame(df)
 df_md = df.to_markdown(index=False)
-aiter.logger.info("rotate_fp4quant_inplace summary (markdown):\n%s", df_md)
+aiter.logger.info("dsv4_rotate_quant summary (markdown):\n%s", df_md)


### PR DESCRIPTION
## Motivation
The DSV4 indexer Q path runs `rope_rotate_activation` (RoPE + Hadamard, bf16
in-place) and then a separate `get_hip_quant(per_1x128)` fp8 quant. That
materializes the rotated bf16 Q to HBM only to read it straight back for
quantization. This PR fuses the fp8 quant into the rope kernel so the bf16
round-trip is dropped — the rotated activation is quantized in-registers and
only the fp8 output + per-(row,1xGROUP) scale are written.

## Summary
- **Optional fp8 path on `rope_rotate_activation`**: when `out_scale` is
  provided, `out` is fp8 and receives `round(rotated / scale)` while
  `out_scale` (`[m, dim/group_size]` fp32) gets the per-`1xGROUP` block scales
  `scale = absMax / fp8_max`. This matches `get_hip_quant(per_1x128)` exactly.
  Without `out_scale` it stays the bf16/fp16 in-place path (callers unchanged).
- **Kernel generalized** to a quant-mode template (`NONE`/`FP4`/`FP8`) with a
  distinct output dtype + optional scale output. The fp4/none paths are gated
  by `if constexpr`, so their codegen is unchanged.
- **Arch-correct fp8**: `finfo<fp8_t>::max()` and the cvt path clamp to 448
  (e4m3fn) on gfx950 and 240 (e4m3fnuz) on gfx942.
- **gfx942 build enabled**: the gfx950-only MXFP4 (e8m0) fp4 device path is now
  gated behind `#if defined(__gfx942__)`, so `module_dsv4_rotate_quant` builds
  on gfx942 and the bf16/fp8 paths run there too. The fp4 host entries reject
  gfx942 with a clear error.
- **Tests**: rename `op_tests/test_rotate_fp4quant.py` ->
  `test_dsv4_rotate_quant.py` (now covers rotate/fp4/fp8), add the fp8
  correctness test + `--fp8` CLI, and update the CI `FILE_TIMES` reference.

## Test plan
- [x] `op_tests/test_dsv4_rotate_quant.py --fp8` on gfx950 (MI355X): per-1x128
      scale matches the torch reference **exactly** (`scale_err = 0`); dequant
      within fp8 ULP.
- [x] fp4 (`--rope`) and bf16/none regressions on gfx950: unchanged vs main.
- [ ] gfx942 build + fp8 run — code-reasoned (fp4 intrinsics gated out, fp8
      `v_cvt_pk_fp8_f32` exists on gfx942) but not yet run on MI300 hardware.
- [ ] Upstream CI (gfx942/gfx950 matrix, wheel build).