### PR TITLE
[gfx1201] Dedicated CK-free reshape_and_cache (paged KV write) for RDNA4

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -106,6 +106,20 @@
         "verbose": "False",
         "blob_gen_cmd": "''"
     },
+    "module_cache_reshape": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/cache_reshape_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/cache_reshape_kernels.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-DENABLE_FP8'"
+        ],
+        "extra_ldflags": "None",
+        "extra_include": [],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_custom_all_reduce": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/custom_all_reduce_pybind.cu'",

--- a/aiter/ops/cache.py
+++ b/aiter/ops/cache.py
@@ -19,7 +19,7 @@ def copy_blocks(
 ) -> None: ...
 
 
-@compile_ops("module_cache", develop=True)
+@compile_ops("module_cache_reshape", develop=True)
 def reshape_and_cache(
     key: torch.Tensor,
     value: torch.Tensor,
@@ -33,7 +33,7 @@ def reshape_and_cache(
 ) -> None: ...
 
 
-@compile_ops("module_cache", develop=True)
+@compile_ops("module_cache_reshape", develop=True)
 def reshape_and_cache_flash(
     key: Tensor,
     value: Tensor,

--- a/csrc/kernels/cache_reshape_kernels.cu
+++ b/csrc/kernels/cache_reshape_kernels.cu
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Dedicated, CK-free translation unit for the paged KV-cache *write* ops
+// (reshape_and_cache / reshape_and_cache_flash).
+//
+// These two kernels are byte-for-byte identical to the ones in
+// cache_kernels.cu; they are split into their own module
+// ("module_cache_reshape") so the KV-cache write builds and runs on any
+// architecture -- including gfx1201 / gfx1200 (RDNA4) -- without dragging in
+// the CK/ck_tile-heavy and CDNA-flavored kernels (MLA concat, DeepSeek
+// indexer, inline GCN asm) that also live in cache_kernels.cu and force that
+// TU onto the CK-only prebuilt path. The kernel logic here uses only the
+// opus:: dtype/dispatch layer (RDNA4-ready) and the ck_tile_shim fallback in
+// aiter_hip_common.h, so it compiles with or without composable_kernel.
+
+#include "aiter_dispatch.h"
+#include "aiter_hip_common.h"
+#include "aiter_stream.h"
+#include "cache.h"
+
+#include "aiter_opus_plus.h"
+#include "attention_dtypes.h"
+#include "opus/opus.hpp"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+
+#include <hip/hip_bf16.h>
+
+namespace aiter {
+
+template <typename scalar_t,
+          typename cache_t,
+          vllm::Fp8KVCacheDataType kv_dt,
+          bool asmLayout          = false,
+          typename slot_mapping_t = int64_t>
+__global__ void
+reshape_and_cache_kernel(const scalar_t* __restrict__ key,   // [num_tokens, num_heads, head_size]
+                         const scalar_t* __restrict__ value, // [num_tokens, num_heads, head_size]
+                         cache_t* __restrict__ key_cache,    // [num_blocks, num_heads, head_size/x,
+                                                             // block_size, x]
+                         cache_t* __restrict__ value_cache,  // [num_blocks, num_heads, head_size,
+                                                             // block_size]
+                         const slot_mapping_t* __restrict__ slot_mapping, // [num_tokens]
+                         const int key_stride,
+                         const int value_stride,
+                         const int num_heads,
+                         const int head_size,
+                         const int block_size,
+                         const int x,
+                         const float* k_scale,
+                         const float* v_scale)
+{
+    const int64_t token_idx       = blockIdx.x;
+    const slot_mapping_t slot_idx = slot_mapping[token_idx];
+    if(slot_idx < 0)
+    {
+        // Padding token that should be ignored.
+        return;
+    }
+
+    const int64_t block_idx    = static_cast<int64_t>(slot_idx) / block_size;
+    const int64_t block_offset = static_cast<int64_t>(slot_idx) % block_size;
+
+    const int n                 = num_heads * head_size;
+    const float inverted_kscale = k_scale == nullptr ? 1.0f : 1 / (*k_scale);
+    const float inverted_vscale = v_scale == nullptr ? 1.0f : 1 / (*v_scale);
+    for(int i = threadIdx.x; i < n; i += blockDim.x)
+    {
+        const int64_t src_key_idx   = token_idx * key_stride + i;
+        const int64_t src_value_idx = token_idx * value_stride + i;
+
+        const int head_idx    = i / head_size;
+        const int head_offset = i % head_size;
+        const int x_idx       = head_offset / x;
+        const int x_offset    = head_offset % x;
+
+        const int64_t tgt_key_idx = block_idx * num_heads * (head_size / x) * block_size * x +
+                                    head_idx * (head_size / x) * block_size * x +
+                                    x_idx * block_size * x + block_offset * x + x_offset;
+        int64_t tgt_value_idx;
+        if constexpr(asmLayout)
+        { //[num_blocks, num_heads, block_size/X, head_size, X]
+            const int x_idx_v    = block_offset / x;
+            const int x_offset_v = block_offset % x;
+            tgt_value_idx        = block_idx * num_heads * head_size * block_size +
+                                   head_idx * head_size * block_size + x_idx_v * head_size * x +
+                                   head_offset * x + x_offset_v;
+        }
+        else
+        { //[num_blocks, num_heads, head_size, block_size]
+            tgt_value_idx = block_idx * num_heads * head_size * block_size +
+                            head_idx * head_size * block_size + head_offset * block_size +
+                            block_offset;
+        }
+        scalar_t tgt_key   = key[src_key_idx];
+        scalar_t tgt_value = value[src_value_idx];
+        if constexpr(kv_dt == vllm::Fp8KVCacheDataType::kAuto)
+        {
+            key_cache[tgt_key_idx]     = tgt_key;
+            value_cache[tgt_value_idx] = tgt_value;
+        }
+        else
+        {
+            key_cache[tgt_key_idx] =
+                opus::cast<cache_t>(static_cast<float>(tgt_key) * inverted_kscale);
+            value_cache[tgt_value_idx] =
+                opus::cast<cache_t>(static_cast<float>(tgt_value) * inverted_vscale);
+        }
+    }
+}
+
+template <typename scalar_t, typename cache_t, vllm::Fp8KVCacheDataType kv_dt>
+__global__ void reshape_and_cache_flash_kernel(
+    const scalar_t* __restrict__ key,         // [num_tokens, num_heads, head_size]
+    const scalar_t* __restrict__ value,       // [num_tokens, num_heads, head_size]
+    cache_t* __restrict__ key_cache,          // [num_blocks, block_size, num_heads,
+                                              // head_size]
+    cache_t* __restrict__ value_cache,        // [num_blocks, block_size, num_heads,
+                                              // head_size]
+    const int64_t* __restrict__ slot_mapping, // [num_tokens]
+    const int block_stride,
+    const int key_stride,
+    const int value_stride,
+    const int num_heads,
+    const int head_size,
+    const int block_size,
+    const float* k_scale,
+    const float* v_scale)
+{
+    const int64_t token_idx = blockIdx.x;
+    const int64_t slot_idx  = slot_mapping[token_idx];
+    // NOTE: slot_idx can be -1 if the token is padded
+    if(slot_idx < 0)
+    {
+        return;
+    }
+    const int64_t block_idx     = slot_idx / block_size;
+    const int64_t block_offset  = slot_idx % block_size;
+    const int n                 = num_heads * head_size;
+    const float inverted_kscale = 1 / (*k_scale);
+    const float inverted_vscale = 1 / (*v_scale);
+    for(int i = threadIdx.x; i < n; i += blockDim.x)
+    {
+        const int64_t src_key_idx       = token_idx * key_stride + i;
+        const int64_t src_value_idx     = token_idx * value_stride + i;
+        const int head_idx              = i / head_size;
+        const int head_offset           = i % head_size;
+        const int64_t tgt_key_value_idx = block_idx * block_stride +
+                                          block_offset * num_heads * head_size +
+                                          head_idx * head_size + head_offset;
+        scalar_t tgt_key                = key[src_key_idx];
+        scalar_t tgt_value              = value[src_value_idx];
+        if constexpr(kv_dt == vllm::Fp8KVCacheDataType::kAuto)
+        {
+            key_cache[tgt_key_value_idx]   = tgt_key;
+            value_cache[tgt_key_value_idx] = tgt_value;
+        }
+        else
+        {
+            key_cache[tgt_key_value_idx] =
+                opus::cast<cache_t>(static_cast<float>(tgt_key) * inverted_kscale);
+            value_cache[tgt_key_value_idx] =
+                opus::cast<cache_t>(static_cast<float>(tgt_value) * inverted_vscale);
+        }
+    }
+}
+
+} // namespace aiter
+
+// KV_T is the stored data type of kv-cache.
+// CACHE_T is the data type of key and value tensors.
+// KV_DTYPE is the real data type of kv-cache.
+#define CALL_RESHAPE_AND_CACHE(KV_T, CACHE_T, KV_DTYPE)                                   \
+    aiter::reshape_and_cache_kernel<KV_T, CACHE_T, KV_DTYPE><<<grid, block, 0, stream>>>( \
+        reinterpret_cast<KV_T*>(key.data_ptr()),                                          \
+        reinterpret_cast<KV_T*>(value.data_ptr()),                                        \
+        reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),                                 \
+        reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),                               \
+        reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),                              \
+        key_stride,                                                                       \
+        value_stride,                                                                     \
+        num_heads,                                                                        \
+        head_size,                                                                        \
+        block_size,                                                                       \
+        x,                                                                                \
+        k_scale.has_value() ? reinterpret_cast<float*>(k_scale->data_ptr()) : nullptr,    \
+        v_scale.has_value() ? reinterpret_cast<float*>(v_scale->data_ptr()) : nullptr);
+
+#define CALL_RESHAPE_AND_CACHE_ASM(KV_T, CACHE_T, KV_DTYPE)                                     \
+    aiter::reshape_and_cache_kernel<KV_T, CACHE_T, KV_DTYPE, true><<<grid, block, 0, stream>>>( \
+        reinterpret_cast<KV_T*>(key.data_ptr()),                                                \
+        reinterpret_cast<KV_T*>(value.data_ptr()),                                              \
+        reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),                                       \
+        reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),                                     \
+        reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),                                    \
+        key_stride,                                                                             \
+        value_stride,                                                                           \
+        num_heads,                                                                              \
+        head_size,                                                                              \
+        block_size,                                                                             \
+        x,                                                                                      \
+        k_scale.has_value() ? reinterpret_cast<float*>(k_scale->data_ptr()) : nullptr,          \
+        v_scale.has_value() ? reinterpret_cast<float*>(v_scale->data_ptr()) : nullptr);
+
+namespace aiter {
+
+void reshape_and_cache(
+    aiter_tensor_t& key,          // [num_tokens, num_heads, head_size]
+    aiter_tensor_t& value,        // [num_tokens, num_heads, head_size]
+    aiter_tensor_t& key_cache,    // [num_blocks, num_heads, head_size/x, block_size, x]
+    aiter_tensor_t& value_cache,  // [num_blocks, num_heads, head_size, block_size]
+    aiter_tensor_t& slot_mapping, // [num_tokens]
+    const std::string& kv_cache_dtype,
+    std::optional<aiter_tensor_t> k_scale,
+    std::optional<aiter_tensor_t> v_scale,
+    const bool asm_layout)
+{
+    int num_tokens = key.size(0);
+    int num_heads  = key.size(1);
+    int head_size  = key.size(2);
+    int block_size = key_cache.size(3);
+    int x          = key_cache.size(4);
+
+    int key_stride   = key.stride(0);
+    int value_stride = value.stride(0);
+
+    dim3 grid(num_tokens);
+    dim3 block(std::min(num_heads * head_size, 512));
+    HipDeviceGuard device_guard(key.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    if(asm_layout)
+    {
+        DISPATCH_BY_KV_CACHE_DTYPE_OPUS_rmTorch(
+            key.dtype(), kv_cache_dtype, CALL_RESHAPE_AND_CACHE_ASM)
+    }
+    else
+    {
+        DISPATCH_BY_KV_CACHE_DTYPE_OPUS_rmTorch(key.dtype(), kv_cache_dtype, CALL_RESHAPE_AND_CACHE)
+    }
+}
+
+} // namespace aiter
+
+// KV_T is the stored data type of kv-cache.
+// CACHE_T is the data type of key and value tensors.
+// KV_DTYPE is the real data type of kv-cache.
+#define CALL_RESHAPE_AND_CACHE_FLASH(KV_T, CACHE_T, KV_DTYPE)                             \
+    aiter::reshape_and_cache_flash_kernel<KV_T, CACHE_T, KV_DTYPE>                        \
+        <<<grid, block, 0, stream>>>(reinterpret_cast<KV_T*>(key.data_ptr()),             \
+                                     reinterpret_cast<KV_T*>(value.data_ptr()),           \
+                                     reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),    \
+                                     reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),  \
+                                     reinterpret_cast<int64_t*>(slot_mapping.data_ptr()), \
+                                     block_stride,                                        \
+                                     key_stride,                                          \
+                                     value_stride,                                        \
+                                     num_heads,                                           \
+                                     head_size,                                           \
+                                     block_size,                                          \
+                                     reinterpret_cast<float*>(k_scale.data_ptr()),        \
+                                     reinterpret_cast<float*>(v_scale.data_ptr()));
+
+namespace aiter {
+
+void reshape_and_cache_flash(
+    aiter_tensor_t& key,          // [num_tokens, num_heads, head_size]
+    aiter_tensor_t& value,        // [num_tokens, num_heads, head_size]
+    aiter_tensor_t& key_cache,    // [num_blocks, block_size, num_heads, head_size]
+    aiter_tensor_t& value_cache,  // [num_blocks, block_size, num_heads, head_size]
+    aiter_tensor_t& slot_mapping, // [num_tokens]
+    const std::string& kv_cache_dtype,
+    aiter_tensor_t& k_scale,
+    aiter_tensor_t& v_scale)
+{
+    int num_tokens = key.size(0);
+    int num_heads  = key.size(1);
+    int head_size  = key.size(2);
+    int block_size = key_cache.size(1);
+
+    int key_stride   = key.stride(0);
+    int value_stride = value.stride(0);
+    int block_stride = key_cache.stride(0);
+    AITER_CHECK(key_cache.stride(0) == value_cache.stride(0));
+
+    dim3 grid(num_tokens);
+    dim3 block(std::min(num_heads * head_size, 512));
+    HipDeviceGuard device_guard(key.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    DISPATCH_BY_KV_CACHE_DTYPE_OPUS_rmTorch(
+        key.dtype(), kv_cache_dtype, CALL_RESHAPE_AND_CACHE_FLASH);
+}
+} // namespace aiter

--- a/csrc/pybind/cache_reshape_pybind.cu
+++ b/csrc/pybind/cache_reshape_pybind.cu
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// pybind for the dedicated CK-free KV-cache write module (module_cache_reshape).
+// Exposes the same reshape_and_cache / reshape_and_cache_flash symbols as
+// module_cache, but from a TU that builds on any arch (incl. gfx1201 RDNA4).
+#include "aiter_stream.h"
+#include "cache.h"
+#include "rocm_ops.hpp"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    m.def("reshape_and_cache",
+          &aiter::reshape_and_cache,
+          py::arg("key"),
+          py::arg("value"),
+          py::arg("key_cache"),
+          py::arg("value_cache"),
+          py::arg("slot_mapping"),
+          py::arg("kv_cache_dtype"),
+          py::arg("k_scale")    = std::nullopt,
+          py::arg("v_scale")    = std::nullopt,
+          py::arg("asm_layout") = false);
+    m.def("reshape_and_cache_flash", &aiter::reshape_and_cache_flash);
+}

--- a/op_tests/test_reshape_and_cache_hip.py
+++ b/op_tests/test_reshape_and_cache_hip.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Correctness test for the dedicated CK-free HIP KV-cache write module
+(module_cache_reshape): aiter.ops.cache.reshape_and_cache vs a torch reference,
+for the HND and 5D-SHUFFLE (asm) paged layouts, bf16 + fp16, with -1 padding.
+Runs the HIP kernel on the live GPU (incl. gfx1201 RDNA4)."""
+
+import torch
+import aiter
+import aiter.ops.cache as cache
+
+
+def ref_scatter(key, value, slot, nb, KH, D, block_size, x, asm):
+    # reference on CPU; index math identical to reshape_and_cache_kernel
+    key, value, slot = key.cpu(), value.cpu(), slot.cpu()
+    dt = key.dtype
+    kc = torch.zeros((nb, KH, D // x, block_size, x), dtype=dt)
+    if asm:
+        vc = torch.zeros((nb, KH, block_size // x, D, x), dtype=dt)
+    else:
+        vc = torch.zeros((nb, KH, D, block_size), dtype=dt)
+    N = key.shape[0]
+    for t in range(N):
+        sl = int(slot[t].item())
+        if sl < 0:
+            continue
+        b, w = sl // block_size, sl % block_size
+        for h in range(KH):
+            for d in range(D):
+                kc[b, h, d // x, w, d % x] = key[t, h, d]
+                if asm:
+                    vc[b, h, w // x, d, w % x] = value[t, h, d]
+                else:
+                    vc[b, h, d, w] = value[t, h, d]
+    return kc, vc
+
+
+def run_case(dtype, asm):
+    dev = "cuda"
+    torch.manual_seed(0)
+    N, KH, D, block_size, nb = 20, 8, 128, 64, 4
+    x = 16 // torch.empty(0, dtype=dtype).element_size()
+    key = torch.randn(N, KH, D, device=dev, dtype=dtype)
+    value = torch.randn(N, KH, D, device=dev, dtype=dtype)
+    slot = torch.arange(N, device=dev, dtype=torch.int64)
+    slot[3] = -1
+    slot[7] = -1  # padded tokens must be skipped
+    kc = torch.zeros((nb, KH, D // x, block_size, x), device=dev, dtype=dtype)
+    if asm:
+        vc = torch.zeros((nb, KH, block_size // x, D, x), device=dev, dtype=dtype)
+    else:
+        vc = torch.zeros((nb, KH, D, block_size), device=dev, dtype=dtype)
+    cache.reshape_and_cache(key, value, kc, vc, slot, "auto", None, None, asm)
+    torch.cuda.synchronize()
+    rkc, rvc = ref_scatter(key, value, slot, nb, KH, D, block_size, x, asm)
+    okk = torch.equal(kc.cpu(), rkc)
+    okv = torch.equal(vc.cpu(), rvc)
+    tag = "SHUFFLE/asm" if asm else "HND"
+    print(f"[{tag:11s} {str(dtype):14s}] K match={okk}  V match={okv}")
+    assert okk and okv, f"mismatch: {tag} {dtype}"
+
+
+if __name__ == "__main__":
+    for asm in (True, False):
+        for dtype in (torch.bfloat16, torch.float16):
+            run_case(dtype, asm)
+    print("ALL_PASS")

--- a/op_tests/test_reshape_and_cache_hip.py
+++ b/op_tests/test_reshape_and_cache_hip.py
@@ -6,7 +6,6 @@ for the HND and 5D-SHUFFLE (asm) paged layouts, bf16 + fp16, with -1 padding.
 Runs the HIP kernel on the live GPU (incl. gfx1201 RDNA4)."""
 
 import torch
-import aiter
 import aiter.ops.cache as cache
 
 


### PR DESCRIPTION
## Summary
Adds a dedicated, **CK-free** HIP module (`module_cache_reshape`) for the paged KV-cache **write** (`reshape_and_cache` / `reshape_and_cache_flash`) so it builds and runs on **gfx1201 / gfx1200 (RDNA4)**.

## Problem
On RDNA4 the HIP `reshape_and_cache` launch faults at runtime with no catchable exception. The root cause is **not** the kernel source — it's a missing code object:
- `reshape_and_cache` lives in `csrc/kernels/cache_kernels.cu`, a TU that also contains CK/`ck_tile`-heavy and CDNA-flavored kernels (MLA concat with `ck_tile::` buffer views, the DeepSeek indexer with inline `v_max3_f32` asm, …). That pulls the whole module onto the prebuilt-CK path.
- The prebuilt `module_cache.so` ships only `gfx942`/`gfx950` code objects (`llvm-objdump --offloading`), so on gfx1201 `hipModuleLaunchKernel` finds no matching code object → fault.

The reshape kernels themselves are arch-clean: a plain scatter using only the `opus::` dtype/dispatch layer (RDNA4-ready) and the `ck_tile_shim` fallback in `aiter_hip_common.h` (`#if !ENABLE_CK`).

## Change
Split the two write kernels into their own module that builds on any arch, with or without `composable_kernel`:
- `csrc/kernels/cache_reshape_kernels.cu` — `reshape_and_cache` (+ `_flash`) kernels + launchers, **byte-for-byte identical** to the originals (extracted verbatim).
- `csrc/pybind/cache_reshape_pybind.cu` — pybind for the new module.
- `aiter/jit/optCompilerConfig.json` — `module_cache_reshape` entry; intentionally **not** in the CK-exclude set, so it builds in CK-free environments too.
- `aiter/ops/cache.py` — route `reshape_and_cache` / `reshape_and_cache_flash` to `module_cache_reshape`.
- `op_tests/test_reshape_and_cache_hip.py` — torch-reference test (HND + 5D-SHUFFLE asm, bf16/fp16, padded `slot=-1`).

The existing `module_cache` is untouched; all other cache ops keep using it.

## Validation
RX 9070 XT (**gfx1201**, ROCm 7.2): the new module builds in ~9 s and the HIP kernel output **matches the torch reference bitwise** for all 4 cases:

```
[SHUFFLE/asm bf16] K=True V=True    [HND bf16] K=True V=True
[SHUFFLE/asm fp16] K=True V=True    [HND fp16] K=True V=True
```

## Relationship to #3319
#3319 adds a **triton** fallback for the same write (incl. the SHUFFLE asm layout). The two are complementary:
- This HIP module makes the native kernel work for **from-source builds** on gfx1201 (and is a candidate to add to the prebuilt arch set so wheels work out of the box).
- The triton fallback in #3319 still serves **prebuilt wheels / zero-build installs** where no gfx1201 code object exists and `composable_kernel` may be absent.

## Scope / notes
- Covers `reshape_and_cache` (incl. the static per-tensor FP8-scale store path) and `reshape_and_cache_flash`. The per-token / block FP8 quant variants stay in `module_cache` (out of scope).
- `clang-format` applied; kernel logic unchanged.
