### PR TITLE
Fix stale IPC addresses by pinning graph-captured tensors

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -363,6 +363,7 @@ class CustomAllreduce:
         are in the same node.
         """
         self._IS_CAPTURING = False
+        self._graph_capture_refs: list = []
         self.disabled = True
 
         if not custom_ar:
@@ -496,11 +497,13 @@ class CustomAllreduce:
         """
         try:
             self._IS_CAPTURING = True
+            self._graph_capture_refs.clear()
             yield
         finally:
             self._IS_CAPTURING = False
             if not self.disabled:
                 self._pool.flush_graph_buffers(self._ptr)
+            self._graph_capture_refs.clear()
 
     def register_input_buffer(self, inp: torch.Tensor):
         """Register an external tensor as an IPC input buffer."""
@@ -583,6 +586,8 @@ class CustomAllreduce:
         """
         if out is None:
             out = torch.empty_like(inp)
+            if self._IS_CAPTURING:
+                self._graph_capture_refs.append(out)
         assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
         reg_inp = 0 if registered_input else self._pool["input"].data_ptr
         reg_inp_bytes = 0 if registered_input else self._pool["input"].max_size
@@ -748,6 +753,8 @@ class CustomAllreduce:
                 dtype=inp.dtype,
                 device=inp.device,
             )
+            if self._IS_CAPTURING:
+                self._graph_capture_refs.append(out)
         assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
         ops.all_gather_reg(
             self._ptr,
@@ -829,6 +836,8 @@ class CustomAllreduce:
             res_out = torch.empty(
                 inp.shape[:-1] + (valid_dim,), dtype=inp.dtype, device=inp.device
             )
+            if self._IS_CAPTURING:
+                self._graph_capture_refs.append(res_out)
         reg = 0 if registered else self._pool["input"].data_ptr
         reg_bytes = 0 if registered else self._pool["input"].max_size
         if not post_per_token_quant:
@@ -837,6 +846,8 @@ class CustomAllreduce:
                 out = torch.empty(
                     inp.shape[:-1] + (out_dim,), dtype=inp.dtype, device=inp.device
                 )
+                if self._IS_CAPTURING:
+                    self._graph_capture_refs.append(out)
             assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
             if inp.shape[-1] == valid_dim and out.shape[-1] == inp.shape[-1]:
                 ops.fused_allreduce_rmsnorm(
@@ -870,11 +881,15 @@ class CustomAllreduce:
         else:
             if out is None:
                 out = torch.empty(inp.shape, dtype=fp8, device=inp.device)
+                if self._IS_CAPTURING:
+                    self._graph_capture_refs.append(out)
             assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
             if scale_out is None:
                 scale_out = torch.empty(
                     inp.shape[:-1] + (1,), dtype=torch.float32, device=inp.device
                 )
+                if self._IS_CAPTURING:
+                    self._graph_capture_refs.append(scale_out)
             ops.fused_allreduce_rmsnorm_quant(
                 self._ptr,
                 inp,
@@ -1058,15 +1073,15 @@ class CustomAllreduce:
         scale_out = torch.empty(
             inp.shape[:-1] + (num_groups,), dtype=torch.float32, device=inp.device
         )
-        # Optional bf16/fp16 mirror of the pre-quantization normed output.
-        # Requested by GDN-style layers that also need an unquantized view
-        # (e.g. Qwen3.5 in_proj_ba). Zero-overhead when not requested
-        # because the kernel branches on the pointer being non-null.
         bf16_out = None
         bf16_ptr = 0
         if emit_bf16:
             bf16_out = torch.empty_like(inp)
             bf16_ptr = int(bf16_out.data_ptr())
+        if self._IS_CAPTURING:
+            self._graph_capture_refs.extend(
+                [res_out, out, scale_out] + ([bf16_out] if bf16_out is not None else [])
+            )
         reg = 0 if registered else self._pool["input"].data_ptr
         reg_bytes = 0 if registered else self._pool["input"].max_size
         ops.fused_allreduce_rmsnorm_quant_per_group(
@@ -1105,6 +1120,8 @@ class CustomAllreduce:
         q_out = torch.empty((token_num, hidden_dim_q), dtype=dtype, device=device)
         k_out = torch.empty((token_num, hidden_dim_k), dtype=dtype, device=device)
         v_out = torch.empty((token_num, hidden_dim_v), dtype=dtype, device=device)
+        if self._IS_CAPTURING:
+            self._graph_capture_refs.extend([q_out, k_out, v_out])
         reg = 0 if registered else self._pool["input"].data_ptr
         reg_bytes = 0 if registered else self._pool["input"].max_size
         ops.fused_qknorm_allreduce(
@@ -1207,6 +1224,10 @@ class CustomAllreduce:
         if emit_bf16:
             bf16_out = torch.empty_like(inp)
             bf16_ptr = int(bf16_out.data_ptr())
+        if self._IS_CAPTURING:
+            self._graph_capture_refs.extend(
+                [res_out, out, scale_out] + ([bf16_out] if bf16_out is not None else [])
+            )
         reg = 0 if registered else self._pool["input"].data_ptr
         reg_bytes = 0 if registered else self._pool["input"].max_size
         ops.fused_allreduce_rmsnorm_mxfp4_quant(


### PR DESCRIPTION
# custom_all_reduce: graph buffer address invalidation during multi-bs CUDAGraph capture

## Bug

When capturing CUDAGraphs for multiple batch sizes inside a single `graph_capture()` context, `flush_graph_buffers()` crashes because temporary tensor addresses recorded by C++ become stale before IPC registration.

**Root cause:** `fused_ar_rms` / `all_reduce` allocate output tensors via `torch.empty()` during capture. The C++ side stores their raw `void*` addresses in `graph_unreg_*_buffers_`. No Python reference is held, so the CUDAGraph pool reclaims these allocations across batch-size iterations. When `flush_graph_buffers()` later calls `hipPointerGetAttribute()` on the stale pointers, it fails.

**Symptoms (environment-dependent):**
- `RuntimeError: failed to get pointer attr for output` — `hipPointerGetAttribute` fails on stale address
- `[AITER] hipIpcOpenMemHandle → [HIP error](invalid argument)` — stale address produces invalid IPC handle, peer rank aborts

## Reproduce

### Test script

`test_ca_graph_buffer_pin.py` — initializes AITER custom_all_reduce with TP=4, then captures 8 CUDAGraphs of different sizes inside one `graph_capture()` context.
```
import os
import sys
import torch
import torch.distributed as dist


def main():
    local_rank = int(os.environ.get("LOCAL_RANK", 0))
    world_size = int(os.environ.get("WORLD_SIZE", 1))

    if world_size < 2:
        print("SKIP: need torchrun --nproc_per_node>=2")
        sys.exit(0)

    torch.cuda.set_device(local_rank)
    dist.init_process_group(backend="nccl")

    from aiter.dist.parallel_state import (
        init_distributed_environment,
        initialize_model_parallel,
        get_tp_group,
        graph_capture,
        set_custom_all_reduce,
    )

    set_custom_all_reduce(True)
    init_distributed_environment(
        world_size=world_size,
        rank=local_rank,
        distributed_init_method="env://",
    )
    initialize_model_parallel(tensor_model_parallel_size=world_size)

    tp_group = get_tp_group()
    ca_comm = tp_group.device_communicator.ca_comm
    if ca_comm is None or ca_comm.disabled:
        if local_rank == 0:
            print("SKIP: ca_comm not available")
        dist.destroy_process_group()
        sys.exit(0)

    # Baseline: allreduce outside capture must work
    x = torch.ones(1024, dtype=torch.float16, device=f"cuda:{local_rank}") * (
        local_rank + 1
    )
    result = tp_group.all_reduce(x)
    expected = sum(range(1, world_size + 1))
    assert torch.allclose(
        result, torch.full_like(result, expected)
    ), f"baseline allreduce failed: got {result[0].item()}, expected {expected}"

    # Multi-bs CUDAGraph capture: this is where the bug happens.
    # Without the fix, flush_graph_buffers() crashes on exit with:
    #   RuntimeError: failed to get pointer attr for output
    # or on other ranks:
    #   [AITER] hipIpcOpenMemHandle → [HIP error](invalid argument)
    with graph_capture() as gc:
        for bs_size in [1024, 512, 256, 128, 64, 32, 16, 8]:
            inp = torch.ones(bs_size, dtype=torch.float16, device=f"cuda:{local_rank}")
            g = torch.cuda.CUDAGraph()
            with torch.cuda.graph(g, stream=gc.stream):
                tp_group.all_reduce(inp)

    # Post-capture: allreduce must still work
    x = torch.ones(1024, dtype=torch.float16, device=f"cuda:{local_rank}") * (
        local_rank + 1
    )
    result = tp_group.all_reduce(x)
    assert torch.allclose(
        result, torch.full_like(result, expected)
    ), f"post-capture allreduce failed: got {result[0].item()}, expected {expected}"

    dist.barrier()
    if local_rank == 0:
        print("PASSED: multi-bs CUDAGraph capture with custom_all_reduce")
    dist.destroy_process_group()


if __name__ == "__main__":
    main()
```

### Run 

```bash
    torchrun --nproc_per_node=4 test_ca_graph_buffer_pin.py
```

### Result (without fix)

All 4 ranks crash on `graph_capture()` exit:

```
[rank0]: RuntimeError: failed to get pointer attr for output
  File "custom_all_reduce.py", line 503, in capture
    self._pool.flush_graph_buffers(self._ptr)
  File "custom_all_reduce.py", line 302, in flush_graph_buffers
    ops.get_graph_buffer_ipc_meta(ar_ptr, handle.data_ptr(), offset.data_ptr())
```