### PR TITLE
[jit] Rebuild a module when its prebuilt .so lacks the running GPU arch (fixes gfx1201 crash)

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -21,7 +21,7 @@ from packaging.version import Version, parse
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{this_dir}/utils/")
-from chip_info import get_gfx, get_gfx_list  # noqa: E402
+from chip_info import get_gfx, get_gfx_list, get_gfx_runtime  # noqa: E402
 from cpp_extension import _jit_compile, executable_path, get_hip_version  # noqa: E402
 from file_baton import FileBaton  # noqa: E402
 from torch_guard import torch_compile_guard  # noqa: E402
@@ -596,15 +596,49 @@ def check_numa():
 __mds = {}
 
 
+def _so_offload_archs(so_path: str) -> set:
+    """Return the GPU code-object targets embedded in a built module .so,
+    parsed from its clang offload-bundle entry ids (e.g. the 'gfx942' in
+    'hipv4-amdgcn-amd-amdhsa--gfx942'). An empty set means the file has no
+    device code (host-only module) or could not be read."""
+    try:
+        with open(so_path, "rb") as f:
+            data = f.read()
+    except OSError:
+        return set()
+    return {m.decode() for m in re.findall(rb"amdhsa--(gfx[0-9a-f]+)", data)}
+
+
 @torch_compile_guard()
 def get_module_custom_op(md_name: str) -> None:
     global __mds
-    if md_name not in __mds:
-        if "AITER_JIT_DIR" in os.environ:
-            __mds[md_name] = importlib.import_module(md_name)
-        else:
-            __mds[md_name] = importlib.import_module(f"{__package__}.{md_name}")
-        logger.info(f"import [{md_name}] under {__mds[md_name].__file__}")
+    if md_name in __mds:
+        return
+    # Arch-coverage guard: a prebuilt .so is a valid *host* extension on any
+    # GPU, so importing one built for the wrong arch succeeds and only faults
+    # later at kernel launch (missing code object -> uncatchable device fault).
+    # Before importing, if the on-disk .so carries device code for other arches
+    # but NOT the running GPU, force a JIT rebuild for the native arch instead.
+    try:
+        run_arch = get_gfx_runtime()
+        so_path = os.path.join(get_user_jit_dir(), f"{md_name}.so")
+        archs = _so_offload_archs(so_path)
+        if archs and run_arch not in archs:
+            logger.warning(
+                f"[{md_name}] prebuilt .so targets {sorted(archs)} but not the "
+                f"running arch {run_arch}; rebuilding for {run_arch}"
+            )
+            raise ModuleNotFoundError(md_name)
+    except ModuleNotFoundError:
+        raise
+    except Exception:
+        # running arch undetectable (e.g. no GPU) -> fall back to normal import
+        pass
+    if "AITER_JIT_DIR" in os.environ:
+        __mds[md_name] = importlib.import_module(md_name)
+    else:
+        __mds[md_name] = importlib.import_module(f"{__package__}.{md_name}")
+    logger.info(f"import [{md_name}] under {__mds[md_name].__file__}")
     return
 
 

--- a/op_tests/test_jit_arch_guard.py
+++ b/op_tests/test_jit_arch_guard.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Unit test for the JIT arch-coverage guard offload-target parser."""
+
+import os
+import tempfile
+
+from aiter.jit.core import _so_offload_archs
+
+
+def test_parse_offload_archs():
+    blob = (
+        b"\x00ELF junk hipv4-amdgcn-amd-amdhsa--gfx942 more "
+        b"hipv4-amdgcn-amd-amdhsa--gfx950 host__amdhsa--gfx1201 tail"
+    )
+    with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as f:
+        f.write(blob)
+        path = f.name
+    try:
+        assert _so_offload_archs(path) == {"gfx942", "gfx950", "gfx1201"}
+    finally:
+        os.remove(path)
+
+
+def test_parse_host_only_is_empty():
+    with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as f:
+        f.write(b"pure host extension, no device code")
+        path = f.name
+    try:
+        assert _so_offload_archs(path) == set()
+    finally:
+        os.remove(path)
+
+
+def test_missing_file_is_empty():
+    assert _so_offload_archs("/no/such/module.so") == set()
+
+
+if __name__ == "__main__":
+    test_parse_offload_archs()
+    test_parse_host_only_is_empty()
+    test_missing_file_is_empty()
+    print("ALL_PASS")


### PR DESCRIPTION
## Summary
Make the JIT loader **rebuild a module for the running GPU when its prebuilt `.so` doesn't cover that arch**, instead of importing a wrong-arch prebuilt that then faults at kernel launch.

## Problem
A prebuilt module `.so` is a valid *host* Python extension on **any** GPU. So `get_module_custom_op`'s `importlib.import_module` **succeeds** even when the `.so` was built for a different arch (e.g. a `gfx942;gfx950` wheel imported on gfx1201). The missing **device code object** then only surfaces later, at kernel launch, as an **uncatchable HIP fault (SIGSEGV)** — never as the `ModuleNotFoundError` that would make `compile_ops` JIT-rebuild. Net: a CDNA-only prebuilt silently shadows the JIT and **crashes instead of rebuilding** for the running arch.

This is the root cause behind the gfx1201 (RDNA4) KV-cache crash, and it generalizes to any wheel whose prebuilt set omits the user's GPU.

## Fix
Add an arch-coverage check **before** importing (a stale extension can't be reloaded once loaded into the process):

```python
run_arch = get_gfx_runtime()
archs = _so_offload_archs(os.path.join(get_user_jit_dir(), f"{md_name}.so"))  # parse clang offload targets
if archs and run_arch not in archs:
    raise ModuleNotFoundError(md_name)   # -> compile_ops rebuilds for the native arch
```

- `_so_offload_archs` parses the `.so`'s clang offload-bundle entry ids (the `gfxNNNN` in `…amdhsa--gfxNNNN`).
- **Host-only** modules (no offload targets) and **arch-undetectable** environments fall through to a normal import — no behavior change.
- When triggered, `build_module` overwrites the `.so` with a native-arch build and the subsequent import loads it.

Any reachable module now auto-JITs for the running GPU instead of faulting.

## Validation (RX 9070 XT, gfx1201)
**Unit** (`op_tests/test_jit_arch_guard.py`): offload-target parser — multi-arch, host-only, missing-file.

**End-to-end**, the real shipped-prebuilt scenario: restored a **CDNA-only** `module_cache.so` (`gfx942;gfx950`, no gfx1201), then ran ATOM + aiter on gfx1201. The loader logged

```
[module_cache] prebuilt .so targets ['gfx942', 'gfx950'] but not the running arch gfx1201; rebuilding for gfx1201
```

rebuilt in place, and the server **booted clean (no SIGSEGV)**:

| Model | gsm8k strict/flex (n=200) | TPOT (549/256) | tok/s |
|---|---|--:|--:|
| Qwen3-8B-FP8 | 0.885 / 0.895 | 18.64 ms | 52.8 |
| Ministral-3-8B | 0.775 / 0.775 | 21.74 ms | 45.5 |

Matches prior runs exactly — correctness and perf unchanged; the only difference is it no longer crashes.

## Relationship to other PRs
- Supersedes the need for **#3837** (dedicated CK-free reshape module) and for **#3319's `_hip_cache_supported()` allowlist** — with this guard, gfx1201 just JITs `module_cache`. I'll close #3837 if this lands.
- **#3319's triton fallback is still useful** for installs with **no hipcc/CK toolchain** at runtime (can't JIT at all) — there triton is the zero-build escape hatch. This guard is for from-source / toolchain-available environments.
