### PR TITLE
[Sampling] Add top_k_first fast path for top_k_top_p_sampling_from_probs

### DIFF
--- a/aiter/ops/sampling.py
+++ b/aiter/ops/sampling.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
 import torch
 from typing import Optional
@@ -58,6 +58,116 @@ direct_register_custom_op(
 )
 
 
+# ---------------------------------------------------------------------------
+# "top-k first" fast path for top_k_top_p_sampling_from_probs.
+#
+# Mirrors flashinfer PR #3461: for a modest scalar top_k over a large vocab,
+# selecting the top-k entries first and running top-p over only those k
+# survivors is far cheaper than the fused full-vocab rejection kernel, which
+# launches a single CTA per row and underutilizes the GPU at small batch.
+#
+# Semantic note (why this is NOT a verbatim port of flashinfer): aiter's fused
+# TopKTopPSamplingFromProbKernel applies the top-p threshold on the ORIGINAL
+# (un-renormalized) probability mass (`aggregate_gt_pivot.value < p`),
+# intersected with the top-k count. flashinfer's `top_k_first` instead
+# renormalizes after top-k and then applies top-p. To stay distribution-
+# equivalent to aiter's existing kernel we renormalize the k survivors (mass S
+# per row, needed so the top-p kernel's proportional draw u~U[0,1) is valid)
+# and scale the threshold to p' = p / S (clamped to 1), so that
+#     mass_k(x > pivot) < p'   <=>   mass_orig(x > pivot) < p .
+# This makes the accepted set identical to the fused kernel's, modulo
+# measure-zero floating-point ties at the boundary.
+# ---------------------------------------------------------------------------
+_TOPK_FIRST_FAST_MAX_K = 256
+_TOPK_FIRST_FAST_MIN_VOCAB = 65536
+
+
+def _topk_first_fast_path_applicable(
+    probs: torch.Tensor,
+    indices: Optional[torch.Tensor],
+    maybe_top_k_arr: Optional[torch.Tensor],
+    top_k_val: int,
+) -> bool:
+    return (
+        indices is None
+        and maybe_top_k_arr is None
+        and isinstance(top_k_val, int)
+        and 0 < top_k_val <= _TOPK_FIRST_FAST_MAX_K
+        and probs.dim() == 2
+        and probs.size(-1) >= _TOPK_FIRST_FAST_MIN_VOCAB
+        and top_k_val < probs.size(-1)
+    )
+
+
+def _select_topk(probs: torch.Tensor, k: int):
+    """Top-k selection for the fast path.
+
+    Uses aiter's native radix-select kernel `top_k_per_row_prefill`, which is the
+    fastest top-k option in this repo for small k over a large vocab at small
+    batch (the regime this fast path targets): measured ~1.5-7x faster than both
+    `topk_plain` and `torch.topk`. Order of the survivors does not matter here -
+    they are renormalized and fed to top-p as a set. The full row is selected by
+    passing rowStarts=0 and rowEnds=vocab. Returns (values: float32,
+    indices: int64).
+    """
+    from aiter.ops.topk import top_k_per_row_prefill
+
+    bs, vocab = probs.size(0), probs.size(-1)
+    row_starts = torch.zeros(bs, dtype=torch.int32, device=probs.device)
+    row_ends = torch.full((bs,), vocab, dtype=torch.int32, device=probs.device)
+    ids = torch.empty((bs, k), dtype=torch.int32, device=probs.device)
+    vals = torch.empty((bs, k), dtype=torch.float32, device=probs.device)
+    top_k_per_row_prefill(
+        probs,
+        row_starts,
+        row_ends,
+        ids,
+        vals,
+        bs,
+        probs.stride(0),
+        probs.stride(1),
+        k=k,
+    )
+    return vals.float(), ids.long()
+
+
+def _topk_first_fast_path(
+    probs: torch.Tensor,
+    top_k_val: int,
+    maybe_top_p_arr: Optional[torch.Tensor],
+    top_p_val: float,
+    deterministic: bool,
+) -> torch.Tensor:
+    # 1. parallel top-k selection: shrinks the row the top-p kernel must scan
+    #    from `vocab` down to `k`.
+    values, gathered_indices = _select_topk(probs, top_k_val)
+    # 2. renormalize over the k survivors so the top-p kernel's proportional
+    #    draw stays well-defined; clamp guards degenerate (all-zero) rows.
+    denom = values.sum(dim=-1, keepdim=True).clamp_min(1e-8)
+    probs_k = values / denom
+    # 3. scale the top-p threshold to compensate for renormalization so the
+    #    accepted set matches aiter's original-mass top-p semantics.
+    s = denom.squeeze(-1)
+    if maybe_top_p_arr is not None:
+        top_p_eff = (maybe_top_p_arr.float() / s).clamp_(max=1.0)
+    else:
+        top_p_eff = (torch.full_like(s, float(top_p_val)) / s).clamp_(max=1.0)
+    # 4. top-p sampling over the k-element distribution -> local index in [0, k).
+    local = top_p_sampling_from_probs_core(
+        probs_k,
+        None,
+        top_p_eff,
+        0.0,
+        deterministic,
+    )
+    # 5. map the local choice back to the global vocab index. The gathered
+    #    indices are always valid in [0, vocab), so the output is in-range even
+    #    on degenerate rows.
+    return (
+        gathered_indices.gather(1, local.view(-1, 1).long()).squeeze(1).to(torch.int32)
+    )
+
+
 def top_k_top_p_sampling_from_probs(
     probs: torch.Tensor,
     indices: torch.Tensor,
@@ -67,6 +177,14 @@ def top_k_top_p_sampling_from_probs(
     top_p_val: float,
     deterministic: bool = False,
 ) -> torch.Tensor:
+    if _topk_first_fast_path_applicable(probs, indices, maybe_top_k_arr, top_k_val):
+        return _topk_first_fast_path(
+            probs,
+            top_k_val,
+            maybe_top_p_arr,
+            top_p_val,
+            deterministic,
+        )
     return top_k_top_p_sampling_from_probs_core(
         probs,
         indices,

--- a/op_tests/test_sampling.py
+++ b/op_tests/test_sampling.py
@@ -434,6 +434,165 @@ def test_top_k_top_p_sampling_degenerate_row(batch_size, vocab_size, mode, k, p)
         )
 
 
+# ---------------------------------------------------------------------------
+# "top-k first" fast path (aiter port of flashinfer PR #3461).
+#
+# For a SCALAR top_k (maybe_top_k_arr=None) that is modest (<=256) over a large
+# vocab (>=65536), `top_k_top_p_sampling_from_probs` routes through a Python fast
+# path: parallel top-k -> renorm over the k survivors -> top-p over k elements
+# -> gather back to the global index. It must stay distribution-equivalent to
+# the fused full-vocab kernel.
+#
+# NOTE: the existing joint tests pass top_k as a TENSOR, which does NOT trigger
+# the fast path. These tests pass top_k as a Python int to exercise it.
+# ---------------------------------------------------------------------------
+
+
+def _joint_mask(normalized_prob, k, p, eps=1e-4):
+    """aiter joint semantics: top-k count mask AND top-p ORIGINAL-mass mask."""
+    batch_size, vocab_size = normalized_prob.shape
+    # top-p mask (cumulative over ORIGINAL probs, matches the fused kernel)
+    sorted_prob, indices = torch.sort(normalized_prob, descending=False)
+    cdf = torch.cumsum(sorted_prob, dim=-1)
+    mask_top_p = torch.zeros(batch_size, vocab_size, dtype=torch.int32, device="cuda")
+    mask_top_p.scatter_add_(1, indices, (cdf > (1 - p) - eps).int())
+    # top-k mask
+    sorted_prob_desc, _ = torch.sort(normalized_prob, descending=True)
+    pivot = sorted_prob_desc[:, k - 1]
+    mask_top_k = (normalized_prob >= pivot.unsqueeze(-1)).int()
+    return torch.minimum(mask_top_p, mask_top_k)
+
+
+# Real-world vocab sizes that exceed the fast-path threshold (>= 65536):
+#   128256 Llama-3 / Llama-3.1
+#   129280 DeepSeek-V3/R1
+#   151936 Qwen2.5 / Qwen3
+#   248320 Qwen3.6-A3B
+#   256000 Gemma-2/3
+_COMMON_VOCABS = [128256, 129280, 151936, 248320, 256000]
+
+
+@pytest.mark.parametrize("batch_size", [1, 8])
+@pytest.mark.parametrize("vocab_size", _COMMON_VOCABS)
+@pytest.mark.parametrize("k", [10, 50, 200])  # all <= 256 (fast path)
+@pytest.mark.parametrize("p", [0.5, 0.9])
+def test_top_k_top_p_fast_path_validity(batch_size, vocab_size, k, p):
+    """Every fast-path sample must lie inside the fused kernel's valid set.
+
+    The fast path is (by construction) never looser than the original mask, so
+    this is a strict containment check.
+    """
+    torch.manual_seed(42)
+    pre_norm_prob = torch.rand(batch_size, vocab_size, device="cuda")
+    normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
+    mask = _joint_mask(normalized_prob, k, p)
+
+    for _ in range(200):
+        # scalar k + scalar p -> triggers the fast path
+        samples = torch.ops.aiter.top_k_top_p_sampling_from_probs(
+            normalized_prob,
+            None,
+            None,  # maybe_top_k_arr -> scalar path
+            k,
+            None,  # maybe_top_p_arr -> scalar path
+            p,
+            deterministic=True,
+        )
+        assert torch.all(samples >= 0) and torch.all(samples < vocab_size)
+        assert torch.all(
+            mask[torch.arange(batch_size, device="cuda"), samples.long()] == 1
+        ), normalized_prob[torch.arange(batch_size, device="cuda"), samples.long()]
+
+
+@pytest.mark.parametrize("vocab_size", [131072])
+@pytest.mark.parametrize("k,p", [(50, 0.9), (10, 0.5)])
+def test_top_k_top_p_fast_path_distribution(vocab_size, k, p):
+    """Fast-path empirical distribution must match the theoretical (fused)
+    distribution: total-variation distance should be small (cf. flashinfer
+    TV ~ 0.007)."""
+    torch.manual_seed(7)
+    batch_size = 4
+    num_samples = 20000
+
+    pre_norm_prob = torch.rand(batch_size, vocab_size, device="cuda")
+    probs = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
+
+    expected = _compute_expected_distribution(probs.cpu(), k, p)  # original semantics
+
+    samples = []
+    for _ in range(num_samples):
+        s = torch.ops.aiter.top_k_top_p_sampling_from_probs(
+            probs, None, None, k, None, p, deterministic=True
+        )
+        samples.append(s)
+    observed_freq = _compute_frequencies(samples, vocab_size, batch_size).cpu()
+    observed = observed_freq / observed_freq.sum(dim=-1, keepdim=True)
+
+    for b in range(batch_size):
+        tv = 0.5 * (observed[b] - expected[b].cpu()).abs().sum().item()
+        if tv >= 0.05:
+            warnings.warn(
+                f"Fast-path distribution warning for batch {b}: TV distance "
+                f"{tv:.4f} >= 0.05 (cf. flashinfer ~0.007). This is a statistical "
+                f"test - occasional warnings are expected due to random chance. "
+                f"Consistent warnings across multiple runs indicate a real "
+                f"distribution bug. Test params: vocab_size={vocab_size}, "
+                f"k={k}, p={p}, num_samples={num_samples}.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+
+@pytest.mark.parametrize("vocab_size", [131072])
+@pytest.mark.parametrize("k,p", [(50, 0.9), (10, 0.5)])
+def test_top_k_top_p_fast_path_vs_core_equivalence(vocab_size, k, p):
+    """The scalar (fast) path and the tensor (fused core) path should produce
+    statistically equivalent samples on the same input."""
+    torch.manual_seed(123)
+    batch_size = 4
+    num_samples = 20000
+    pre_norm_prob = torch.rand(batch_size, vocab_size, device="cuda")
+    probs = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
+
+    top_k_tensor = torch.full((batch_size,), k, device="cuda")
+    top_p_tensor = torch.full((batch_size,), float(p), device="cuda")
+
+    fast, core = [], []
+    for _ in range(num_samples):
+        fast.append(
+            torch.ops.aiter.top_k_top_p_sampling_from_probs(
+                probs, None, None, k, None, p, deterministic=True
+            )
+        )
+        # tensor args -> NOT applicable -> fused core kernel
+        core.append(
+            torch.ops.aiter.top_k_top_p_sampling_from_probs(
+                probs,
+                None,
+                *_to_tensor_scalar_tuple(top_k_tensor),
+                *_to_tensor_scalar_tuple(top_p_tensor),
+                deterministic=True,
+            )
+        )
+    f_freq = _compute_frequencies(fast, vocab_size, batch_size).cpu()
+    c_freq = _compute_frequencies(core, vocab_size, batch_size).cpu()
+    f = f_freq / f_freq.sum(dim=-1, keepdim=True)
+    c = c_freq / c_freq.sum(dim=-1, keepdim=True)
+    for b in range(batch_size):
+        tv = 0.5 * (f[b] - c[b]).abs().sum().item()
+        if tv >= 0.05:
+            warnings.warn(
+                f"Fast-path vs core warning for batch {b}: TV distance {tv:.4f} "
+                f">= 0.05. This is a statistical test - occasional warnings are "
+                f"expected due to random chance. Consistent warnings across "
+                f"multiple runs indicate the fast path diverges from the fused "
+                f"kernel. Test params: vocab_size={vocab_size}, k={k}, p={p}, "
+                f"num_samples={num_samples}.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+
 if __name__ == "__main__":
     test_top_k_top_p_joint_sampling_from_probs(40, 129280, 0.6, 20)
     # test_top_k_top_p_statistical_distribution(10, 10000, 5, 0.3)


### PR DESCRIPTION



## Motivation

For a scalar top_k (<=256) over a large vocab (>=65536), route top_k_top_p_sampling_from_probs through a "top_k_first" fast path (parallel top-k via top_k_per_row_prefill -> renorm over the k survivors -> top-p over only k -> gather back to the global index), instead of the fused full-vocab kernel that launches a single CTA per row and underutilizes the GPU at small batch. Inspired by flashinfer PR #3461.

To stay distribution-equivalent to aiter's existing kernel (which applies top-p on the ORIGINAL un-renormalized mass), the k survivors are renormalized and the threshold scaled to p' = p/S (S = survivor mass), so the accepted set matches the fused kernel.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Adds op_tests/test_sampling.py coverage over common LLM vocab sizes; showing 1.6-6.7x speedup (geomean 3.25x) across the validity grid on MI355X.

## Test Result
```

  vocab  bs    k    p   core(ms)   fast(ms)  speedup
----------------------------------------------------
 128256   1   10  0.5     0.2631     0.1013    2.60x
 128256   1   10  0.9     0.2629     0.0986    2.67x
 128256   1   50  0.5     0.2167     0.0981    2.21x
 128256   1   50  0.9     0.2168     0.0980    2.21x
 128256   1  200  0.5     0.1835     0.0984    1.86x
 128256   1  200  0.9     0.1836     0.0984    1.87x
 128256   8   10  0.5     0.3615     0.0978    3.70x
 128256   8   10  0.9     0.3614     0.0975    3.71x
 128256   8   50  0.5     0.3124     0.0963    3.24x
 128256   8   50  0.9     0.3116     0.0955    3.26x
 128256   8  200  0.5     0.2726     0.0959    2.84x
 128256   8  200  0.9     0.2727     0.0965    2.83x
 129280   1   10  0.5     0.2535     0.0961    2.64x
 129280   1   10  0.9     0.2537     0.0960    2.64x
 129280   1   50  0.5     0.2088     0.0960    2.17x
 129280   1   50  0.9     0.2090     0.0962    2.17x
 129280   1  200  0.5     0.1725     0.1054    1.64x
 129280   1  200  0.9     0.1727     0.1048    1.65x
 129280   8   10  0.5     0.3693     0.1048    3.52x
 129280   8   10  0.9     0.3694     0.1061    3.48x
 129280   8   50  0.5     0.3204     0.1042    3.07x
 129280   8   50  0.9     0.3202     0.1039    3.08x
 129280   8  200  0.5     0.2809     0.1042    2.70x
 129280   8  200  0.9     0.2810     0.1051    2.67x
 151936   1   10  0.5     0.2982     0.1044    2.86x
 151936   1   10  0.9     0.2990     0.1051    2.85x
 151936   1   50  0.5     0.2544     0.1161    2.19x
 151936   1   50  0.9     0.2548     0.1043    2.44x
 151936   1  200  0.5     0.2197     0.1037    2.12x
 151936   1  200  0.9     0.2198     0.1041    2.11x
 151936   8   10  0.5     0.4369     0.1053    4.15x
 151936   8   10  0.9     0.4369     0.1047    4.17x
 151936   8   50  0.5     0.3741     0.1054    3.55x
 151936   8   50  0.9     0.3746     0.1061    3.53x
 151936   8  200  0.5     0.3243     0.1051    3.09x
 151936   8  200  0.9     0.3245     0.1046    3.10x
 248320   1   10  0.5     0.4701     0.1041    4.52x
 248320   1   10  0.9     0.4703     0.1050    4.48x
 248320   1   50  0.5     0.4047     0.1042    3.88x
 248320   1   50  0.9     0.4048     0.1041    3.89x
 248320   1  200  0.5     0.3524     0.1044    3.37x
 248320   1  200  0.9     0.3520     0.1040    3.39x
 248320   8   10  0.5     0.6730     0.1040    6.47x
 248320   8   10  0.9     0.6808     0.1041    6.54x
 248320   8   50  0.5     0.5872     0.1042    5.64x
 248320   8   50  0.9     0.5874     0.1042    5.64x
 248320   8  200  0.5     0.5100     0.1155    4.41x
 248320   8  200  0.9     0.5095     0.1033    4.93x
 256000   1   10  0.5     0.4771     0.1041    4.58x
 256000   1   10  0.9     0.4782     0.1044    4.58x
 256000   1   50  0.5     0.4032     0.1040    3.88x
 256000   1   50  0.9     0.4037     0.1050    3.84x
 256000   1  200  0.5     0.3496     0.1047    3.34x
 256000   1  200  0.9     0.3495     0.1043    3.35x
 256000   8   10  0.5     0.7149     0.1044    6.85x
 256000   8   10  0.9     0.7152     0.1046    6.84x
 256000   8   50  0.5     0.6212     0.1058    5.87x
 256000   8   50  0.9     0.6216     0.1046    5.94x
 256000   8  200  0.5     0.5436     0.1060    5.13x
 256000   8  200  0.9     0.5435     0.1055    5.15x
----------------------------------------------------
cases=60  speedup min=1.64x  max=6.85x  mean=3.62x  geomean=3.39x  fast-faster=60/60
```




## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
