### PR TITLE
[jit] auto-rebuild module on new GPU arch

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -27,10 +27,6 @@ from file_baton import FileBaton  # noqa: E402
 from torch_guard import torch_compile_guard  # noqa: E402
 
 AITER_REBUILD = int(os.environ.get("AITER_REBUILD", "0"))
-# When enabled (default), a prebuilt .so whose embedded GPU code objects do not
-# cover the GPU we are actually running on is treated as missing, so it gets
-# rebuilt for the current arch automatically (no need to set AITER_REBUILD=1).
-AITER_REBUILD_ON_NEW_ARCH = int(os.environ.get("AITER_REBUILD_ON_NEW_ARCH", "1")) != 0
 ENABLE_CK = int(os.environ.get("ENABLE_CK", "1")) != 0
 AITER_DISABLE_KERNARG_PRELOAD = (
     int(os.environ.get("AITER_DISABLE_KERNARG_PRELOAD", "0")) != 0
@@ -635,8 +631,6 @@ def _needs_arch_rebuild(md_name):
     # built for the wrong arch succeeds and only faults later at kernel launch.
     # if the .so carries device code for other arches but NOT the running GPU,
     # force a JIT rebuild for the native arch instead.
-    if not AITER_REBUILD_ON_NEW_ARCH:
-        return False
     try:
         cur = get_gfx_runtime()
     except Exception:

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -21,12 +21,16 @@ from packaging.version import Version, parse
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{this_dir}/utils/")
-from chip_info import get_gfx, get_gfx_list  # noqa: E402
+from chip_info import get_gfx, get_gfx_list, get_gfx_runtime  # noqa: E402
 from cpp_extension import _jit_compile, executable_path, get_hip_version  # noqa: E402
 from file_baton import FileBaton  # noqa: E402
 from torch_guard import torch_compile_guard  # noqa: E402
 
 AITER_REBUILD = int(os.environ.get("AITER_REBUILD", "0"))
+# When enabled (default), a prebuilt .so whose embedded GPU code objects do not
+# cover the GPU we are actually running on is treated as missing, so it gets
+# rebuilt for the current arch automatically (no need to set AITER_REBUILD=1).
+AITER_REBUILD_ON_NEW_ARCH = int(os.environ.get("AITER_REBUILD_ON_NEW_ARCH", "1")) != 0
 ENABLE_CK = int(os.environ.get("ENABLE_CK", "1")) != 0
 AITER_DISABLE_KERNARG_PRELOAD = (
     int(os.environ.get("AITER_DISABLE_KERNARG_PRELOAD", "0")) != 0
@@ -608,9 +612,52 @@ def get_module_custom_op(md_name: str) -> None:
     return
 
 
+def _so_offload_archs(so_path):
+    # parse the gfx targets embedded in a built module .so from its clang
+    # offload-bundle entry ids (e.g. the 'gfx942' in '...amdhsa--gfx942').
+    # the .so is mmap'd, not read whole, since CK modules can be hundreds of MB.
+    # an empty set means host-only module, missing file, or unreadable.
+    import mmap
+
+    archs = set()
+    try:
+        with open(so_path, "rb") as f:
+            with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                for m in re.finditer(rb"amdhsa--(gfx[0-9a-z]+)", mm):
+                    archs.add(m.group(1).decode())
+    except (OSError, ValueError):
+        pass
+    return archs
+
+
+def _needs_arch_rebuild(md_name):
+    # a prebuilt .so is a valid host extension on any GPU, so importing one
+    # built for the wrong arch succeeds and only faults later at kernel launch.
+    # if the .so carries device code for other arches but NOT the running GPU,
+    # force a JIT rebuild for the native arch instead.
+    if not AITER_REBUILD_ON_NEW_ARCH:
+        return False
+    try:
+        cur = get_gfx_runtime()
+    except Exception:
+        # running arch undetectable (e.g. no GPU) -> keep normal behaviour
+        return False
+    so_path = os.path.join(get_user_jit_dir(), f"{md_name}.so")
+    built = _so_offload_archs(so_path)
+    if not built or cur in built:
+        return False
+    logger.warning(
+        f"[{md_name}] prebuilt .so targets {sorted(built)} but not the "
+        f"running arch {cur}; rebuilding for {cur}"
+    )
+    return True
+
+
 @functools.lru_cache(maxsize=1024)
 def get_module(md_name):
     check_numa()
+    if _needs_arch_rebuild(md_name):
+        raise ModuleNotFoundError(md_name)
     get_module_custom_op(md_name)
     return __mds[md_name]
 
@@ -1210,7 +1257,7 @@ def _ctypes_call(func, fc_name, md_name):
         if _cache:
             return
         so_path = os.path.join(get_user_jit_dir(), f"{md_name}.so")
-        if not os.path.exists(so_path):
+        if not os.path.exists(so_path) or _needs_arch_rebuild(md_name):
             d_args = get_args_of_build(md_name)
             d_args["torch_exclude"] = True
             build_module(

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -621,7 +621,7 @@ def _so_offload_archs(so_path):
             with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
                 for m in re.finditer(rb"amdhsa--(gfx[0-9a-z]+)", mm):
                     archs.add(m.group(1).decode())
-    except (OSError, ValueError):
+    except (OSError, ValueError, OverflowError):
         pass
     return archs
 

--- a/op_tests/test_jit_arch_guard.py
+++ b/op_tests/test_jit_arch_guard.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Unit tests for the JIT arch-coverage guard offload-target parser."""
+
+import os
+import tempfile
+
+import aiter.jit.core as core
+from aiter.jit.core import _so_offload_archs
+
+
+def _patch_jit_dir(tmpdir):
+    """Point the arch helpers at an isolated jit dir."""
+    orig = core.get_user_jit_dir
+    core.get_user_jit_dir = lambda: tmpdir
+    return orig
+
+
+def _restore_jit_dir(orig):
+    core.get_user_jit_dir = orig
+
+
+def test_parse_offload_archs():
+    blob = (
+        b"\x00ELF junk hipv4-amdgcn-amd-amdhsa--gfx942 more "
+        b"hipv4-amdgcn-amd-amdhsa--gfx950 host__amdhsa--gfx1201 tail"
+    )
+    with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as f:
+        f.write(blob)
+        path = f.name
+    try:
+        assert _so_offload_archs(path) == {"gfx942", "gfx950", "gfx1201"}
+    finally:
+        os.remove(path)
+
+
+def test_parse_host_only_is_empty():
+    with tempfile.NamedTemporaryFile(suffix=".so", delete=False) as f:
+        f.write(b"pure host extension, no device code")
+        path = f.name
+    try:
+        assert _so_offload_archs(path) == set()
+    finally:
+        os.remove(path)
+
+
+def test_missing_file_is_empty():
+    assert _so_offload_archs("/no/such/module.so") == set()
+
+
+def test_needs_arch_rebuild():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        orig = _patch_jit_dir(tmpdir)
+        orig_runtime = core.get_gfx_runtime
+        orig_flag = core.AITER_REBUILD_ON_NEW_ARCH
+        try:
+            so_path = os.path.join(tmpdir, "module_dummy.so")
+            with open(so_path, "wb") as f:
+                f.write(
+                    b"\x00ELF junk hipv4-amdgcn-amd-amdhsa--gfx942 more "
+                    b"hipv4-amdgcn-amd-amdhsa--gfx950 tail"
+                )
+            core.AITER_REBUILD_ON_NEW_ARCH = True
+
+            # Running on an arch the .so does NOT cover -> rebuild.
+            core.get_gfx_runtime = lambda: "gfx1201"
+            assert core._needs_arch_rebuild("module_dummy") is True
+
+            # Running on a covered arch -> no rebuild.
+            core.get_gfx_runtime = lambda: "gfx942"
+            assert core._needs_arch_rebuild("module_dummy") is False
+
+            # Toggle off -> never rebuild.
+            core.AITER_REBUILD_ON_NEW_ARCH = False
+            core.get_gfx_runtime = lambda: "gfx1201"
+            assert core._needs_arch_rebuild("module_dummy") is False
+
+            # Unknown build archs (no manifest, no .so) -> no rebuild.
+            core.AITER_REBUILD_ON_NEW_ARCH = True
+            assert core._needs_arch_rebuild("module_unknown") is False
+        finally:
+            core.get_gfx_runtime = orig_runtime
+            core.AITER_REBUILD_ON_NEW_ARCH = orig_flag
+            _restore_jit_dir(orig)
+
+
+if __name__ == "__main__":
+    test_parse_offload_archs()
+    test_parse_host_only_is_empty()
+    test_missing_file_is_empty()
+    test_needs_arch_rebuild()
+    print("ALL_PASS")

--- a/op_tests/test_jit_arch_guard.py
+++ b/op_tests/test_jit_arch_guard.py
@@ -52,7 +52,6 @@ def test_needs_arch_rebuild():
     with tempfile.TemporaryDirectory() as tmpdir:
         orig = _patch_jit_dir(tmpdir)
         orig_runtime = core.get_gfx_runtime
-        orig_flag = core.AITER_REBUILD_ON_NEW_ARCH
         try:
             so_path = os.path.join(tmpdir, "module_dummy.so")
             with open(so_path, "wb") as f:
@@ -60,7 +59,6 @@ def test_needs_arch_rebuild():
                     b"\x00ELF junk hipv4-amdgcn-amd-amdhsa--gfx942 more "
                     b"hipv4-amdgcn-amd-amdhsa--gfx950 tail"
                 )
-            core.AITER_REBUILD_ON_NEW_ARCH = True
 
             # Running on an arch the .so does NOT cover -> rebuild.
             core.get_gfx_runtime = lambda: "gfx1201"
@@ -70,17 +68,10 @@ def test_needs_arch_rebuild():
             core.get_gfx_runtime = lambda: "gfx942"
             assert core._needs_arch_rebuild("module_dummy") is False
 
-            # Toggle off -> never rebuild.
-            core.AITER_REBUILD_ON_NEW_ARCH = False
-            core.get_gfx_runtime = lambda: "gfx1201"
-            assert core._needs_arch_rebuild("module_dummy") is False
-
             # Unknown build archs (no manifest, no .so) -> no rebuild.
-            core.AITER_REBUILD_ON_NEW_ARCH = True
             assert core._needs_arch_rebuild("module_unknown") is False
         finally:
             core.get_gfx_runtime = orig_runtime
-            core.AITER_REBUILD_ON_NEW_ARCH = orig_flag
             _restore_jit_dir(orig)
 
 


### PR DESCRIPTION

## Motivation

Guard module import by checking embedded offload archs in prebuilt .so files so runs on a new GPU trigger JIT rebuild instead of crashing at kernel launch. Add focused tests for arch parsing and rebuild decisions, and cover both pybind and ctypes paths.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
