### PR TITLE
[Bugfix] Fix MLA metadata reduce_partial_map worst-case over-allocation OOM

### DIFF
--- a/aiter/ops/attention.py
+++ b/aiter/ops/attention.py
@@ -1164,12 +1164,19 @@ def get_mla_metadata_info_v1(
         max_split_tiles = tile_cnt * cu_num
 
     # Metadata's global split cap is `min(cu_num, max_split_per_batch * batch_size)`
-    # (see csrc/kernels/mla/metadata/v1_2_device.cuh:560-562). A single tile can in
-    # the worst case absorb the entire global budget, so reduce_partial_map must
-    # hold up to tile_cnt * per_tile_cap entries.
+    # (see csrc/kernels/mla/metadata/v1_2_device.cuh:560-562). This is a GLOBAL
+    # budget shared across all tiles, so the total number of partial reduce
+    # entries is bounded by the base tiles (one per tile) plus at most the global
+    # split budget of EXTRA splits distributed across them:
+    #     reduce_partial_map <= tile_cnt + per_tile_cap
+    # The previous `tile_cnt * per_tile_cap` assumed every tile could individually
+    # absorb the whole global budget simultaneously, which the shared budget
+    # forbids. With cudagraph batch_size >> cu_num that product collapsed to
+    # tile_cnt * cu_num (e.g. 512 * 256 = 131072), and aiter mla_decode_fwd sizes
+    # its fp32 `logits` from reduce_partial_map.size(0) -> ~32 GiB OOM at capture.
     if max_split_per_batch > 0:
         per_tile_cap = min(cu_num, max_split_per_batch * batch_size)
-        max_split_tiles = max(max_split_tiles, tile_cnt * per_tile_cap)
+        max_split_tiles = max(max_split_tiles, tile_cnt + per_tile_cap)
 
     if not intra_batch_mode:
         return (


### PR DESCRIPTION
## Summary
`get_mla_metadata_info_v1` sizes `reduce_partial_map` as `tile_cnt * per_tile_cap`
when `max_split_per_batch > 0`. `per_tile_cap = min(cu_num, max_split_per_batch * batch_size)`
is a **global** split budget shared across all tiles, but the product assumes every
tile could individually absorb the whole budget *simultaneously*, which the shared
budget forbids.

With cudagraph `batch_size >> cu_num` (e.g. bs=512, cu_num=256) the product collapses
to `tile_cnt * cu_num` (512 × 256 = **131072**) for **any** positive `max_split_per_batch`.
`mla_decode_fwd` then allocates its fp32 `logits`/`attn_lse` from
`reduce_partial_map.size(0) * max_seqlen_q * nhead * v_head_dim`, which for DeepSeek-R1
MLA (TP4, nhead=32, qo=4, v=512) is exactly **32.00 GiB** → `HIP OutOfMemoryError`
during cudagraph capture, crashing all ranks.

## Fix
The correct upper bound on total partial reduce entries is base tiles (one per tile)
plus at most the **global** split budget of extra splits distributed across them:

```
reduce_partial_map <= tile_cnt + per_tile_cap     # not tile_cnt * per_tile_cap
```

This stays `max(...)` with the fast-mode sizing (the proven-safe lower bound) so it
never under-allocates, while removing the quadratic blow-up.

## Impact (gfx950, cu_num=256, bs=512)
| case | reduce_partial_map | logits |
|---|---|---|
| before (`* per_tile_cap`) | 131072 | 32.00 GiB |
| after (`+ per_tile_cap`)  | 768    | 0.19 GiB |

nhead=128 drops from 512 GiB → 2.25 GiB.

## Test plan
- [x] Numerically verified on gfx950 (cu_num=256): `get_mla_metadata_info_v1` returns
      768 (nhead=32) / 2304 (nhead=128); `768 >= fast_mode(510)` so no under-allocation.
- [ ] End-to-end DeepSeek-R1-FP4 MTP TP4 serve (blocked on free GPUs at submission time;
      reproduced the 32 GiB OOM at capture with the old formula on the same machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)