### PR TITLE
[triton] [mha]: split-D forward for non-power-of-2 head_dim

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/mha.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha.py
@@ -75,13 +75,17 @@ def _compute_alibi_block(
 @triton.jit
 def _attn_fwd_inner(
     acc,
+    acc_t,
     l_i,
     m_i,
     q,
     q_pe,
+    qt,
     k_ptrs,
     k_pe_ptrs,
+    kt_ptrs,
     v_ptrs,
+    vt_ptrs,
     stride_kn,
     stride_vk,
     stride_sn,
@@ -110,6 +114,7 @@ def _attn_fwd_inner(
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_DMODEL_POW2: tl.constexpr,
     BLOCK_DMODEL_PE: tl.constexpr,  # it's zero or a power of 2
+    BLOCK_DMODEL_TAIL: tl.constexpr,  # zero (single-block) or a power of 2
     SM_SCALE: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     MASK_STEPS: tl.constexpr,
@@ -123,6 +128,14 @@ def _attn_fwd_inner(
 ):
     RCP_LN2: tl.constexpr = 1.4426950408889634
     HAS_PE: tl.constexpr = BLOCK_DMODEL_PE > 0
+    # Split-D tail: when BLOCK_DMODEL_TAIL>0 the head_dim is covered as a
+    # power-of-2 main block (BLOCK_DMODEL_POW2) plus a power-of-2 tail block,
+    # instead of padding to next_pow2. Tail D indices live in
+    # [BLOCK_DMODEL_POW2, BLOCK_DMODEL_POW2+BLOCK_DMODEL_TAIL); valid up to the
+    # real head_dim (BLOCK_DMODEL).
+    HAS_TAIL: tl.constexpr = BLOCK_DMODEL_TAIL > 0
+    if HAS_TAIL:
+        tail_offs_d = BLOCK_DMODEL_POW2 + tl.arange(0, BLOCK_DMODEL_TAIL)
 
     # loop over k, v, and update accumulator
 
@@ -146,8 +159,12 @@ def _attn_fwd_inner(
                 (BLOCK_DMODEL + BLOCK_DMODEL_PE),
                 seqlen_k,
             )
+        if HAS_TAIL:
+            kt = _load_fn(kt_ptrs, tail_offs_d, k_offs_n, BLOCK_DMODEL, seqlen_k)
         if PRELOAD_V:
             v = _load_fn(v_ptrs, k_offs_n, k_offs_k, seqlen_k, BLOCK_DMODEL)
+            if HAS_TAIL:
+                vt = _load_fn(vt_ptrs, k_offs_n, tail_offs_d, seqlen_k, BLOCK_DMODEL)
 
         # We start from end of seqlen_k so only the first iteration would need
         # to be checked for padding if it is not a multiple of block_n
@@ -180,6 +197,8 @@ def _attn_fwd_inner(
         if HAS_PE:
             qk = tl.dot(q_pe, k_pe, acc=qk)
         qk = tl.dot(q, k, acc=qk)
+        if HAS_TAIL:
+            qk = tl.dot(qt, kt, acc=qk)
         if IS_FP8:
             qk = qk * (qk_scale * descale_q * descale_k)
         else:
@@ -244,12 +263,16 @@ def _attn_fwd_inner(
             # (no rescaling needed since max didn't change).
             alpha = tl.where(m_i == m_ij, 1.0, alpha)
         acc = acc * alpha[:, None]
+        if HAS_TAIL:
+            acc_t = acc_t * alpha[:, None]
         # -- update m_i and l_i
         l_i = l_i * alpha + l_ij
         # update m_i and l_i
         m_i = m_ij
         if not PRELOAD_V:
             v = _load_fn(v_ptrs, k_offs_n, k_offs_k, seqlen_k, BLOCK_DMODEL)
+            if HAS_TAIL:
+                vt = _load_fn(vt_ptrs, k_offs_n, tail_offs_d, seqlen_k, BLOCK_DMODEL)
         if IS_FP8:
             scale_p, descale_p = _compute_fp8_scaling_factors(p, FP8_MAX)
             acc += (
@@ -257,10 +280,15 @@ def _attn_fwd_inner(
             )
         else:
             acc = tl.dot(p.to(v.type.element_ty), v, acc=acc)
+            if HAS_TAIL:
+                acc_t = tl.dot(p.to(vt.type.element_ty), vt, acc=acc_t)
 
         k_ptrs += BLOCK_N * stride_kn
         if HAS_PE:
             k_pe_ptrs += BLOCK_N * stride_kn
+        if HAS_TAIL:
+            kt_ptrs += BLOCK_N * stride_kn
+            vt_ptrs += BLOCK_N * stride_vk
         v_ptrs += BLOCK_N * stride_vk
         if RETURN_SCORES:
             sd_mask_ptrs += BLOCK_N * stride_sn
@@ -269,7 +297,7 @@ def _attn_fwd_inner(
             dropout_mask_ptrs += BLOCK_N * stride_sn
             philox_ptrs += BLOCK_N * stride_sn
 
-    return acc, l_i, m_i
+    return acc, acc_t, l_i, m_i
 
 
 _attn_fwd_repr = make_kernel_repr(
@@ -352,6 +380,7 @@ def _attn_fwd(
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_DMODEL_POW2: tl.constexpr,
     BLOCK_DMODEL_PE: tl.constexpr,  # it's zero or a power of 2
+    BLOCK_DMODEL_TAIL: tl.constexpr,  # zero (single-block) or a power of 2
     RETURN_SCORES: tl.constexpr,
     ENABLE_DROPOUT: tl.constexpr,
     IS_FP8: tl.constexpr,
@@ -383,6 +412,12 @@ def _attn_fwd(
     HAS_PE: tl.constexpr = BLOCK_DMODEL_PE > 0
     if HAS_PE:
         offs_pe = BLOCK_DMODEL + tl.arange(0, BLOCK_DMODEL_PE)
+    # Split-D tail: cover head_dim as BLOCK_DMODEL_POW2 (main) + BLOCK_DMODEL_TAIL
+    # (tail) instead of padding to next_pow2. Tail D indices start right after
+    # the main block; valid lanes are those < BLOCK_DMODEL (real head_dim).
+    HAS_TAIL: tl.constexpr = BLOCK_DMODEL_TAIL > 0
+    if HAS_TAIL:
+        offs_dt = BLOCK_DMODEL_POW2 + tl.arange(0, BLOCK_DMODEL_TAIL)
 
     # NOTE:
     # Workaround for int64 strides, In the absence of strides being int64, parts of the offset
@@ -598,6 +633,18 @@ def _attn_fwd(
     else:
         q_pe_ptrs = None
 
+    if HAS_TAIL:
+        qt_offs = (
+            off_z * stride_qz
+            + qh_off
+            + cu_seqlens_q_start * stride_qm
+            + offs_m[:, None] * stride_qm
+            + offs_dt[None, :] * stride_qk
+        )
+        qt_ptrs = q_ptr + qt_offs
+    else:
+        qt_ptrs = None
+
     k_offs = (
         off_z * stride_kz
         + kh_off
@@ -618,6 +665,18 @@ def _attn_fwd(
     else:
         k_pe_ptrs = None
 
+    if HAS_TAIL:
+        kt_offs = (
+            off_z * stride_kz
+            + kh_off
+            + cu_seqlens_k_start * stride_kn
+            + offs_dt[:, None] * stride_kk
+            + offs_n[None, :] * stride_kn
+        )
+        kt_ptrs = k_ptr + kt_offs
+    else:
+        kt_ptrs = None
+
     v_offs = (
         off_z * stride_vz
         + vh_off
@@ -626,6 +685,17 @@ def _attn_fwd(
         + offs_d[None, :] * stride_vk
     )
     v_ptrs = v_ptr + v_offs
+    if HAS_TAIL:
+        vt_offs = (
+            off_z * stride_vz
+            + vh_off
+            + cu_seqlens_k_start * stride_vn
+            + offs_n[:, None] * stride_vn
+            + offs_dt[None, :] * stride_vk
+        )
+        vt_ptrs = v_ptr + vt_offs
+    else:
+        vt_ptrs = None
 
     # alibi slopes
     if alibi_slopes_ptr is not None:
@@ -675,6 +745,10 @@ def _attn_fwd(
     m_i = tl.full([BLOCK_M], m_i_value, dtype=tl.float32)
     l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, BLOCK_DMODEL_POW2], dtype=tl.float32)
+    if HAS_TAIL:
+        acc_t = tl.zeros([BLOCK_M, BLOCK_DMODEL_TAIL], dtype=tl.float32)
+    else:
+        acc_t = None
     if BLOCK_DMODEL == BLOCK_DMODEL_POW2:
         q_mask = offs_m[:, None] < seqlen_q
     else:
@@ -690,6 +764,11 @@ def _attn_fwd(
     else:
         q_pe = None
     q = tl.load(q_ptrs, mask=q_mask, other=0.0, cache_modifier=q_cache_mod)
+    if HAS_TAIL:
+        qt_mask = (offs_m[:, None] < seqlen_q) & (offs_dt[None, :] < BLOCK_DMODEL)
+        qt = tl.load(qt_ptrs, mask=qt_mask, other=0.0, cache_modifier=q_cache_mod)
+    else:
+        qt = None
     if IS_FP8:
         descale_q = tl.load(descale_q_ptr + off_z * stride_descale_q_z + off_q_head)
         descale_k = tl.load(descale_k_ptr + off_z * stride_descale_k_z + off_k_head)
@@ -733,6 +812,9 @@ def _attn_fwd(
         k_ptrs += skipped_blocks * BLOCK_N * stride_kn
         if HAS_PE:
             k_pe_ptrs += skipped_blocks * BLOCK_N * stride_kn
+        if HAS_TAIL:
+            kt_ptrs += skipped_blocks * BLOCK_N * stride_kn
+            vt_ptrs += skipped_blocks * BLOCK_N * stride_vn
         v_ptrs += skipped_blocks * BLOCK_N * stride_vn
         if RETURN_SCORES:
             s_dmask_ptrs += skipped_blocks * BLOCK_N * stride_sd_n
@@ -743,15 +825,19 @@ def _attn_fwd(
     # value because there is no masking. Similarly we do not need padding.
     if n_full_blocks > 0:
         block_max = block_min + n_full_blocks * BLOCK_N
-        acc, l_i, m_i = _attn_fwd_inner(
+        acc, acc_t, l_i, m_i = _attn_fwd_inner(
             acc,
+            acc_t,
             l_i,
             m_i,
             q,
             q_pe,
+            qt,
             k_ptrs,
             k_pe_ptrs,
+            kt_ptrs,
             v_ptrs,
+            vt_ptrs,
             stride_kn,
             stride_vn,
             stride_sd_n,
@@ -780,6 +866,7 @@ def _attn_fwd(
             BLOCK_DMODEL,
             BLOCK_DMODEL_POW2,
             BLOCK_DMODEL_PE,
+            BLOCK_DMODEL_TAIL,
             sm_scale,
             False,
             MASK_STEPS=False,
@@ -803,20 +890,27 @@ def _attn_fwd(
         k_ptrs += n_full_blocks * BLOCK_N * stride_kn
         if HAS_PE:
             k_pe_ptrs += n_full_blocks * BLOCK_N * stride_kn
+        if HAS_TAIL:
+            kt_ptrs += n_full_blocks * BLOCK_N * stride_kn
+            vt_ptrs += n_full_blocks * BLOCK_N * stride_vn
         v_ptrs += n_full_blocks * BLOCK_N * stride_vn
         if RETURN_SCORES:
             s_dmask_ptrs += n_full_blocks * BLOCK_N * stride_sd_n
         if ENABLE_DROPOUT:
             dropout_mask_ptrs += n_full_blocks * BLOCK_N * stride_sd_n
-        acc, l_i, m_i = _attn_fwd_inner(
+        acc, acc_t, l_i, m_i = _attn_fwd_inner(
             acc,
+            acc_t,
             l_i,
             m_i,
             q,
             q_pe,
+            qt,
             k_ptrs,
             k_pe_ptrs,
+            kt_ptrs,
             v_ptrs,
+            vt_ptrs,
             stride_kn,
             stride_vn,
             stride_sd_n,
@@ -845,6 +939,7 @@ def _attn_fwd(
             BLOCK_DMODEL,
             BLOCK_DMODEL_POW2,
             BLOCK_DMODEL_PE,
+            BLOCK_DMODEL_TAIL,
             sm_scale,
             IS_CAUSAL,
             MASK_STEPS=True,
@@ -860,9 +955,13 @@ def _attn_fwd(
     # This helps the compiler do Newton Raphson on l_i vs on acc which is much larger.
     l_recip = 1 / l_i[:, None]
     acc = acc * l_recip
+    if HAS_TAIL:
+        acc_t = acc_t * l_recip
     if ENABLE_DROPOUT:
         dropout_scale = 1 / (1 - dropout_p)
         acc = acc * dropout_scale
+        if HAS_TAIL:
+            acc_t = acc_t * dropout_scale
     # If seqlen_q > seqlen_k but the delta is not a multiple of BLOCK_M,
     # then we have one block with a row of all NaNs which come from computing
     # softmax over a row of all -infs (-inf - inf = NaN). We check for that here
@@ -879,6 +978,14 @@ def _attn_fwd(
             out_ptrs_mask = mask_m_offsets[:, None] >= out_mask_boundary[None, :]
             z = 0.0
             acc = tl.where(out_ptrs_mask, acc, z.to(acc.type.element_ty))
+            if HAS_TAIL:
+                out_ptrs_mask_t = (
+                    mask_m_offsets[:, None]
+                    >= tl.full((BLOCK_DMODEL_TAIL,), causal_start_idx, dtype=tl.int32)[
+                        None, :
+                    ]
+                )
+                acc_t = tl.where(out_ptrs_mask_t, acc_t, z.to(acc_t.type.element_ty))
 
     # write back LSE(Log Sum Exponents), the log of the normalization constant
     overflow_size = end_m_idx - seqlen_q
@@ -928,6 +1035,20 @@ def _attn_fwd(
         out_mask = out_mask & (offs_d[None, :] < BLOCK_DMODEL)
     op = acc.to(out_ptr.dtype.element_ty)
     tl.store(out_ptr + offs_out, op, mask=out_mask)
+    if HAS_TAIL:
+        offs_out_t = (
+            off_z * stride_oz
+            + off_q_head * stride_oh
+            + cu_seqlens_q_start * stride_om
+            + offs_m[:, None] * stride_om
+            + offs_dt[None, :] * stride_on
+        )
+        out_mask_t = tl.full([BLOCK_M, 1], 1, dtype=tl.int1)
+        if overflow_size > 0:
+            out_mask_t = out_mask_t & (offs_m[:, None] < seqlen_q)
+        out_mask_t = out_mask_t & (offs_dt[None, :] < BLOCK_DMODEL)
+        op_t = acc_t.to(out_ptr.dtype.element_ty)
+        tl.store(out_ptr + offs_out_t, op_t, mask=out_mask_t)
 
 
 @functools.lru_cache(maxsize=1024)

--- a/aiter/ops/triton/attention/mha.py
+++ b/aiter/ops/triton/attention/mha.py
@@ -51,6 +51,22 @@ def _get_sliding_window_size(window_size: Tuple[int, int]) -> int:
     return int(window_size[0]) if int(window_size[0]) >= 0 else 0
 
 
+def _split_head_dim(head_dim: int) -> Tuple[int, int]:
+    """Pick (BLOCK_DMODEL_MAIN, BLOCK_DMODEL_TAIL) covering ``head_dim``.
+
+    Power-of-2 head_dim -> (head_dim, 0) (single-block, unchanged kernel).
+    Otherwise: largest power-of-2 main block strictly below head_dim plus a
+    power-of-2 tail block, so D is covered at ~ceil(head_dim/16)*16 instead of
+    next_pow2(head_dim) (e.g. 72 -> 64 + 16 = 80 vs 128).
+    """
+    npo2 = triton.next_power_of_2(head_dim)
+    if npo2 == head_dim:
+        return npo2, 0
+    main = npo2 // 2
+    tail = max(16, triton.next_power_of_2(head_dim - main))
+    return main, tail
+
+
 def _flash_attn_forward(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -252,6 +268,21 @@ def _flash_attn_forward(
             batch * num_q_heads * triton.cdiv(seqlen_q, META["BLOCK_M"]),
         )
 
+        # Split-D: cover a non-power-of-2 head_dim as a power-of-2 main block
+        # plus a power-of-2 tail block (e.g. 72 -> 64 + 16 = 80) instead of
+        # padding to next_pow2 (128), cutting wasted WMMA K/N passes. Limited to
+        # the simple path (no positional encoding, not FP8, qk dim == v dim);
+        # everything else uses the original padded single block (tail == 0).
+        if (
+            pe_head_dim == 0
+            and not IS_FP8
+            and qk_head_dim == v_head_dim
+            and triton.next_power_of_2(v_head_dim) != v_head_dim
+        ):
+            block_dmodel_main, block_dmodel_tail = _split_head_dim(v_head_dim)
+        else:
+            block_dmodel_main, block_dmodel_tail = BLOCK_DMODEL_POW2, 0
+
         _attn_fwd[grid](
             q,
             k,
@@ -293,8 +324,9 @@ def _flash_attn_forward(
             NUM_Q_HEADS=num_q_heads,
             NUM_K_HEADS=num_k_heads,
             BLOCK_DMODEL=v_head_dim,
-            BLOCK_DMODEL_POW2=BLOCK_DMODEL_POW2,
+            BLOCK_DMODEL_POW2=block_dmodel_main,
             BLOCK_DMODEL_PE=pe_head_dim,
+            BLOCK_DMODEL_TAIL=block_dmodel_tail,
             RETURN_SCORES=return_softmax,
             ENABLE_DROPOUT=enable_dropout,
             IS_FP8=IS_FP8,


### PR DESCRIPTION
## Summary

The Triton MHA forward kernel (`_attn_fwd`, the `default` impl) pads the head-dim tile to `next_pow2(head_dim)`. For a non-power-of-2 `head_dim` this runs the `qk`/`pv` WMMAs at the padded width — e.g. `d=72` is computed at `128` (8 K-passes when only ~5 are needed), and `d=160` at `256`.

This PR covers the head dim as a **power-of-2 main block plus a power-of-2 tail block** instead of rounding up to the next power of two:

```
72  -> 64 + 16 = 80    (was 128)
80  -> 64 + 16 = 80    (was 128)
88  -> 64 + 32 = 96    (was 128)
96  -> 64 + 32 = 96    (was 128)
160 -> 128 + 32 = 160  (was 256)
```

### How it works

- `_attn_fwd` / `_attn_fwd_inner` gain an optional tail D-block controlled by a new `BLOCK_DMODEL_TAIL` constexpr. The QK dot is summed across main+tail; the PV dot accumulates a separate `acc_t` for the tail output columns; both are stored.
- It is **constexpr-guarded**: `BLOCK_DMODEL_TAIL == 0` reproduces the previous single-block kernel exactly (the tail code is dead-code-eliminated), so power-of-2 head dims are byte-identical to before.
- `_flash_attn_forward` adds `_split_head_dim()` and enables the split **only** for the simple path: non-power-of-2 `head_dim`, no positional encoding (`pe_head_dim == 0`), not FP8, and `qk_head_dim == v_head_dim`. Every other case (power-of-2 dims, PE/MLA, FP8) keeps the original padded single block.

### Regression safety

- Power-of-2 head dims (64, 128, …) → split gate is False → `BLOCK_DMODEL_TAIL == 0` → identical executed kernel. Cannot be affected (confirmed empirically below).
- PE / MLA path (`qk_head_dim != v_head_dim`, e.g. d=192/dv=128) and FP8 are explicitly excluded → unchanged (confirmed below).
- Backward is **not** modified (this is a forward-only change).

## Environment

| Component | Version |
|---|---|
| GPU | gfx1151 (Strix Halo / RDNA3.5) |
| torch | 2.11.0+rocm7.14.0a20260616 |
| HIP | 7.14.60850 |
| ROCm SDK | 7.14.0a20260616 |
| triton | 3.7.1 |
| aiter | base `40b342715` → this change `a0636a4d2` |


## Correctness

`flash_attn_varlen_func` (default impl) vs `torch.nn.functional.scaled_dot_product_attention`, across head dims `40, 59, 64, 72, 96, 111, 128, 160, 192`, fp16 + bf16, causal + non-causal, varlen. **All pass**: max abs diff ≤ `1e-4` (fp16) / `~1e-3` (bf16), split-D dims and power-of-2 controls alike.

Additionally, the split-D build was checked **bit-for-bit against the padded kernel** (the unmodified single-block path) for cases the SDPA sweep doesn't cover; max abs diff `0.0` in every case:

- **Sliding-window attention** (`window_size=(W, -1)`, exercising the `skipped_blocks > 0` path), d=72/88, causal & non-causal, W ∈ {128, 256, 512}. This guards the tail-pointer advance through the sliding-window block skip.
- **Forward + backward** (autograd `dq`/`dk`/`dv`), d=72/88, causal & non-causal. The backward kernels are unchanged by this PR (forward-only); this confirms the split forward output and `softmax_lse` feed the existing backward correctly.

```bash
# reference-comparison sweep (default impl)
python - <<'PY'
import torch, triton, torch.nn.functional as F
from aiter.ops.triton.mha import flash_attn_varlen_func, mha_set_impl
mha_set_impl("default")
for dt in (torch.float16, torch.bfloat16):
  for d in [40,59,64,72,96,111,128,160,192]:
    for T in (256,1024):
      for causal in (False,True):
        q,k,v=(torch.randn(T,8,d,device="cuda",dtype=dt) for _ in range(3))
        cu=torch.tensor([0,T],dtype=torch.int32,device="cuda")
        o=flash_attn_varlen_func(q,k,v,cu,cu,T,T,causal=causal,softmax_scale=d**-0.5)
        r=F.scaled_dot_product_attention(q.transpose(0,1)[None].float(),
            k.transpose(0,1)[None].float(),v.transpose(0,1)[None].float(),
            is_causal=causal).squeeze(0).transpose(0,1)
        assert (o.float()-r.float()).abs().max() < (2e-2 if dt==torch.float16 else 4e-2)
print("ALL PASS")
PY
```

## Performance — gfx1151

B=1, H=16, dtype=fp16. Both `fwd` (bshd) and `fwd_varlen` (packed `[total, heads, dim]`), causal and non-causal. Times in ms (lower = better), **min of 2 `do_bench` medians**.

Measurement protocol (for low noise):
- Each run holds the GPU exclusively via `amd-gpu-lock` (no concurrent workloads).
- 30 s initial settle + 12 s cooldown between cells (consistent thermal baseline).
- `before` = split-D reverted to the padded kernel; `after` = this PR. Same config (`fwd.default`) in both.

| fn | head_dim | seq | causal | before (ms) | after (ms) | Δ |
|----|---------:|----:|:------:|------------:|-----------:|---:|
| fwd_varlen | 64 | 512 | ✗ | 0.073 | 0.073 | -0.1% |
| fwd_varlen | 64 | 512 | ✓ | 0.054 | 0.054 | +0.2% |
| fwd_varlen | 64 | 1024 | ✗ | 0.192 | 0.191 | -0.6% |
| fwd_varlen | 64 | 1024 | ✓ | 0.129 | 0.129 | -0.2% |
| fwd_varlen | 64 | 2048 | ✗ | 0.611 | 0.612 | +0.1% |
| fwd_varlen | 64 | 2048 | ✓ | 0.368 | 0.369 | +0.1% |
| fwd_varlen | 64 | 3200 | ✗ | 1.404 | 1.386 | -1.3% |
| fwd_varlen | 64 | 3200 | ✓ | 0.815 | 0.815 | +0.0% |
| fwd_varlen | **72** | 512 | ✗ | 0.121 | 0.089 | **-26%** |
| fwd_varlen | **72** | 512 | ✓ | 0.081 | 0.064 | **-21%** |
| fwd_varlen | **72** | 1024 | ✗ | 0.331 | 0.237 | **-28%** |
| fwd_varlen | **72** | 1024 | ✓ | 0.197 | 0.155 | **-21%** |
| fwd_varlen | **72** | 2048 | ✗ | 1.073 | 0.791 | **-26%** |
| fwd_varlen | **72** | 2048 | ✓ | 0.614 | 0.464 | **-24%** |
| fwd_varlen | **72** | 3200 | ✗ | 2.567 | 1.839 | **-28%** |
| fwd_varlen | **72** | 3200 | ✓ | 1.480 | 1.035 | **-30%** |
| fwd_varlen | **80** | 512 | ✗ | 0.126 | 0.095 | **-24%** |
| fwd_varlen | **80** | 512 | ✓ | 0.087 | 0.069 | **-20%** |
| fwd_varlen | **80** | 1024 | ✗ | 0.337 | 0.245 | **-27%** |
| fwd_varlen | **80** | 1024 | ✓ | 0.203 | 0.170 | **-16%** |
| fwd_varlen | **80** | 2048 | ✗ | 1.092 | 0.807 | **-26%** |
| fwd_varlen | **80** | 2048 | ✓ | 0.619 | 0.477 | **-23%** |
| fwd_varlen | **80** | 3200 | ✗ | 2.590 | 1.898 | **-27%** |
| fwd_varlen | **80** | 3200 | ✓ | 1.410 | 1.079 | **-24%** |
| fwd_varlen | 128 | 512 | ✗ | 0.162 | 0.163 | +0.2% |
| fwd_varlen | 128 | 512 | ✓ | 0.130 | 0.130 | +0.1% |
| fwd_varlen | 128 | 1024 | ✗ | 0.428 | 0.429 | +0.2% |
| fwd_varlen | 128 | 1024 | ✓ | 0.322 | 0.322 | +0.1% |
| fwd_varlen | 128 | 2048 | ✗ | 1.303 | 1.302 | -0.1% |
| fwd_varlen | 128 | 2048 | ✓ | 0.920 | 0.922 | +0.2% |
| fwd_varlen | 128 | 3200 | ✗ | 2.935 | 2.940 | +0.2% |
| fwd_varlen | 128 | 3200 | ✓ | 1.823 | 1.839 | +0.9% |
| fwd (bshd) | 64 | 512 | ✗ | 0.072 | 0.072 | +0.6% |
| fwd (bshd) | 64 | 512 | ✓ | 0.054 | 0.054 | -0.4% |
| fwd (bshd) | 64 | 1024 | ✗ | 0.191 | 0.192 | +0.3% |
| fwd (bshd) | 64 | 1024 | ✓ | 0.128 | 0.128 | -0.2% |
| fwd (bshd) | 64 | 2048 | ✗ | 0.610 | 0.611 | +0.1% |
| fwd (bshd) | 64 | 2048 | ✓ | 0.367 | 0.369 | +0.5% |
| fwd (bshd) | 64 | 3200 | ✗ | 1.385 | 1.391 | +0.4% |
| fwd (bshd) | 64 | 3200 | ✓ | 0.814 | 0.811 | -0.4% |
| fwd (bshd) | **72** | 512 | ✗ | 0.118 | 0.089 | **-25%** |
| fwd (bshd) | **72** | 512 | ✓ | 0.081 | 0.064 | **-21%** |
| fwd (bshd) | **72** | 1024 | ✗ | 0.328 | 0.237 | **-28%** |
| fwd (bshd) | **72** | 1024 | ✓ | 0.197 | 0.157 | **-20%** |
| fwd (bshd) | **72** | 2048 | ✗ | 1.065 | 0.885 | **-17%** |
| fwd (bshd) | **72** | 2048 | ✓ | 0.611 | 0.476 | **-22%** |
| fwd (bshd) | **72** | 3200 | ✗ | 2.543 | 2.009 | **-21%** |
| fwd (bshd) | **72** | 3200 | ✓ | 1.399 | 1.117 | **-20%** |
| fwd (bshd) | **80** | 512 | ✗ | 0.123 | 0.094 | **-23%** |
| fwd (bshd) | **80** | 512 | ✓ | 0.086 | 0.068 | **-21%** |
| fwd (bshd) | **80** | 1024 | ✗ | 0.332 | 0.246 | **-26%** |
| fwd (bshd) | **80** | 1024 | ✓ | 0.204 | 0.162 | **-21%** |
| fwd (bshd) | **80** | 2048 | ✗ | 1.079 | 0.851 | **-21%** |
| fwd (bshd) | **80** | 2048 | ✓ | 0.622 | 0.495 | **-20%** |
| fwd (bshd) | **80** | 3200 | ✗ | 2.591 | 2.041 | **-21%** |
| fwd (bshd) | **80** | 3200 | ✓ | 1.407 | 1.187 | **-16%** |
| fwd (bshd) | 128 | 512 | ✗ | 0.161 | 0.161 | +0.2% |
| fwd (bshd) | 128 | 512 | ✓ | 0.140 | 0.142 | +1.6% |
| fwd (bshd) | 128 | 1024 | ✗ | 0.419 | 0.419 | +0.0% |
| fwd (bshd) | 128 | 1024 | ✓ | 0.341 | 0.344 | +1.0% |
| fwd (bshd) | 128 | 2048 | ✗ | 1.306 | 1.306 | +0.0% |
| fwd (bshd) | 128 | 2048 | ✓ | 0.953 | 0.960 | +0.7% |
| fwd (bshd) | 128 | 3200 | ✗ | 2.922 | 2.922 | +0.0% |
| fwd (bshd) | 128 | 3200 | ✓ | 1.857 | 1.857 | +0.0% |

### PE / MLA path control (`qk_head_dim != v_head_dim` → split-D inactive)

bf16, causal, B=1, hq=hk=128, d=192, dv=128, sq=sk=4096 (pe_head_dim=64).

| fn | before (ms) | after (ms) | Δ |
|---|--:|--:|--:|
| fwd (bshd) | 71.694 | 73.440 | +2.4% (noise) |
| fwd_varlen | 67.171 | 67.731 | +0.8% (noise) |

## Summary of results

- **head_dim 72**: −17% … −30% across all seq_lens, both layouts, both causal modes.
- **head_dim 80**: −16% … −27% (also non-power-of-2; covered as 64+16=80 vs padded 128).
- **head_dim 64, 128**: no-op (identical kernel) — within measurement noise.
- **PE/MLA path (d=192/dv=128)**: unaffected — split-D correctly skips it.

## Commands

Single-cell timing via the in-tree benchmark (sweep `fn ∈ {fwd, fwd_varlen}`, `d ∈ {64,72,80,128}`, `seq ∈ {512,1024,2048,3200}`, `causal ∈ {True,False}`):

```bash
# example cell: fwd_varlen, d=72, seq=3200, non-causal, fp16
python op_tests/op_benchmarks/triton/bench_mha.py \
    -fn fwd_varlen -equal_seqlens \
    -b 1 -hq 16 -hk 16 -sq 3200 -sk 3200 -d 72 \
    --dtype fp16 -causal False \
    -impl default -metric time

# bshd variant: -fn fwd  (drop -equal_seqlens)
```

PE / MLA-path no-regression control:

```bash
python op_tests/op_benchmarks/triton/bench_mha.py \
    -impl default -metric time -causal true --dtype bf16 \
    -b 1 -hq 128 -hk 128 -d 192 -dv 128 -sq 4096 -sk 4096 -fn fwd

python op_tests/op_benchmarks/triton/bench_mha.py \
    -impl default -metric time -causal true --dtype bf16 \
    -b 1 -hq 128 -hk 128 -d 192 -dv 128 -sq 4096 -sk 4096 \
    -fn fwd_varlen -equal_seqlens
```

> The before/after table swept the matrix via a `triton.testing.do_bench` harness (one process, min-of-2, cooldowns) calling `flash_attn_func` / `flash_attn_varlen_func` directly — the same timing primitive `bench_mha.py` uses — to keep thermal conditions consistent across all cells. `before` numbers were taken with the split-D commit reverted.

### Why not `model_benchmarking_tool/bench_attn_models.py`?

`bench_attn_models.py` sweeps the shapes in `op_tests/op_benchmarks/triton/model_benchmarking_tool/model_shapes.json`, which is a basket of popular **text** LLMs. Every entry there uses a **power-of-2 `head_dim` (only 64 and 128)**. For those, the split gate (`next_pow2(head_dim) != head_dim`) is False → `BLOCK_DMODEL_TAIL == 0` → the executed kernel is byte-identical to before this PR, so the tool would report an all-~0% table and exercise none of the changed code path.

This change targets a **vision-transformer head_dim (72)** (and other non-power-of-2 dims), which is not represented in `model_shapes.json`. `bench_mha.py` with custom shapes is therefore the appropriate driver and is what we used; the power-of-2 no-regression case is covered by the d=64 / d=128 rows above and the PE/MLA control.
