### PR TITLE
fix(fmoe): correct padded SEPARATED w13 in bf16 CK-Tile gate-up

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1746,10 +1746,17 @@ def get_2stage_cfgs(
         _min_split_k = 2 if swiglu_mxfp4_bf16_cktile else 1
         _split_k = max(int(ksplit), _min_split_k)
         _cktile_block_m = 16 if token < 2048 else 32 if token < 16384 else 64
+        _stage1_n_pad_zeros = (
+            0
+            if swiglu_mxfp4_bf16_cktile
+            else intermediate_pad // 64 * 64 * (2 if use_g1u1 else 1)
+        )
         return MOEMetadata(
             functools.partial(
                 cktile_moe_stage1,
-                n_pad_zeros=intermediate_pad // 64 * 64 * (2 if use_g1u1 else 1),
+                # Keep Swiglu bf16-cktile on full padded N (n_pad_zeros=0);
+                # generic ksplit paths retain the legacy n_pad_zeros formula.
+                n_pad_zeros=_stage1_n_pad_zeros,
                 k_pad_zeros=hidden_pad // 128 * 128,
                 activation=activation,
                 split_k=_split_k,

--- a/op_tests/test_moe_2stage_npad_guard.py
+++ b/op_tests/test_moe_2stage_npad_guard.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import aiter
+import pytest
+from aiter import dtypes
+from aiter.fused_moe import get_2stage_cfgs
+from aiter.ops.flydsl.moe_common import GateMode
+
+
+@pytest.fixture(autouse=True)
+def _bypass_tuned_cfg(monkeypatch):
+    monkeypatch.setenv("AITER_BYPASS_TUNE_CONFIG", "1")
+
+
+def test_swiglu_bf16_fp4_cktile_uses_zero_npad_for_padded_separated_w13():
+    metadata = get_2stage_cfgs(
+        token=128,
+        model_dim=6144,
+        inter_dim=768,
+        expert=129,
+        topk=5,
+        dtype=dtypes.bf16,
+        q_dtype_a=dtypes.bf16,
+        q_dtype_w=dtypes.fp4x2,
+        q_type=aiter.QuantType.per_1x32,
+        use_g1u1=True,
+        activation=aiter.ActivationType.Swiglu,
+        doweight_stage1=False,
+        hidden_pad=0,
+        intermediate_pad=128,
+        is_shuffled=True,
+        gate_mode=GateMode.SEPARATED.value,
+    )
+
+    assert metadata.stage1.func.__name__ == "cktile_moe_stage1"
+    assert metadata.stage1.keywords["n_pad_zeros"] == 0
+    assert metadata.stage1.keywords["post_activation_layout"] == "standard"
+
+
+def test_non_swiglu_ksplit_cktile_preserves_legacy_npad_formula():
+    token = 8
+    topk = 1
+    inter_dim = 3072
+    model_dim = 3072
+    intermediate_pad = 128
+
+    metadata = get_2stage_cfgs(
+        token=token,
+        model_dim=model_dim,
+        inter_dim=inter_dim,
+        expert=128,
+        topk=topk,
+        dtype=dtypes.bf16,
+        q_dtype_a=dtypes.bf16,
+        q_dtype_w=dtypes.fp4x2,
+        q_type=aiter.QuantType.per_1x32,
+        use_g1u1=True,
+        activation=aiter.ActivationType.Silu,
+        doweight_stage1=False,
+        hidden_pad=0,
+        intermediate_pad=intermediate_pad,
+        is_shuffled=True,
+        gate_mode=GateMode.SEPARATED.value,
+    )
+
+    assert metadata.stage1.func.__name__ == "cktile_moe_stage1"
+    assert metadata.ksplit > 1
+    assert metadata.stage1.keywords["post_activation_layout"] == "auto"
+    expected_npad = intermediate_pad // 64 * 64 * 2
+    assert metadata.stage1.keywords["n_pad_zeros"] == expected_npad


### PR DESCRIPTION
For Swiglu MXFP4 bf16-activation CK-Tile dispatch, use n_pad_zeros=0 so padded SEPARATED w13 layouts are handled correctly while keeping the fast bf16 path.

Scope the behavior to swiglu_mxfp4_bf16_cktile only; preserve the legacy n_pad_zeros formula for generic ksplit>1 paths to avoid impacting other models.

Add regression guards for both target and non-target paths in op_tests/test_moe_2stage_npad_guard.py.

## Motivation

Properly run MiniMax M3 MXFP4 on ATOM with TP=8

## Test Result

Tested with ATOM with TP=8:
```
python -m atom.entrypoints.openai_server \
  --model amd/MiniMax-M3-MXFP4-AttnFP8 \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --block-size 128 \
  --server-port 8000
```

lm-eval
```
lm_eval \
  --model local-chat-completions \
  --model_args "model=amd/MiniMax-M3-MXFP4-AttnFP8,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=32,max_gen_toks=16384" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size 1 \
  --apply_chat_template \
  --fewshot_as_multiturn
```

Results, for reference with TP=1  gsm8k gives ~0.9424:
| Build                                          | flexible-extract     | strict-match         |
| ---------------------------------------------- | -------------------- | -------------------- |
| Baseline — `origin/main` (no fix)              | 0.7665 &pm; 0.0117   | 0.7657 &pm; 0.0117   |
| Fixed — this branch | **0.9409 &pm; 0.0065** | **0.9416 &pm; 0.0065** |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
