### PR TITLE
feat(mha): add FlyDSL BSHD batch-mode dispatch for gfx1250

### DIFF
--- a/aiter/ops/flydsl/fmha_kernels.py
+++ b/aiter/ops/flydsl/fmha_kernels.py
@@ -32,6 +32,7 @@ from .kernels.fmha_gfx1250.fmha_kernel import flash_attn_varlen_d192_gfx1250
 
 __all__ = [
     "flydsl_flash_attn_func",
+    "flydsl_flash_attn_batch_func",
     "flydsl_flash_attn_varlen_func",
 ]
 
@@ -206,6 +207,88 @@ def flydsl_flash_attn_func(
     if seq_len_pad != seq_len_real:
         return o_p[:, :seq_len_real, :, :].contiguous()
     return o_p
+
+
+def flydsl_flash_attn_batch_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    return_lse: bool = False,
+    dropout_p: float = 0.0,
+    window_size=(-1, -1),
+    bias=None,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    sink=None,
+):
+    """FlyDSL MHA forward, BSHD batch layout (gfx1250).
+
+    Thin wrapper: reshapes BSHD → THD, constructs uniform cu_seqlens,
+    calls the varlen kernel, and reshapes output back to BSHD.
+
+    Returns the result if FlyDSL can handle this configuration,
+    otherwise returns None so the caller falls through to Triton/CK.
+    """
+    from ...jit.utils.chip_info import get_gfx
+
+    supported = (
+        get_gfx() == "gfx1250"
+        and q.shape[-1] == 192
+        and v.shape[-1] == 128
+        and q.dtype == torch.bfloat16
+        and dropout_p == 0.0
+        and tuple(window_size[:2]) == (-1, -1)
+        and bias is None
+        and alibi_slopes is None
+        and sink is None
+        and not deterministic
+        and not return_attn_probs
+    )
+    if not supported:
+        return None
+
+    B, S_q, H_q, D_qk = q.shape
+    S_k = k.shape[1]
+
+    # BSHD → THD (zero-copy reshape)
+    q_thd = q.reshape(B * S_q, H_q, D_qk).contiguous()
+    k_thd = k.reshape(B * S_k, k.shape[2], k.shape[3]).contiguous()
+    v_thd = v.reshape(B * S_k, v.shape[2], v.shape[3]).contiguous()
+
+    # Uniform cu_seqlens for equal-length batches
+    cu_seqlens_q = torch.arange(
+        0, (B + 1) * S_q, S_q, dtype=torch.int32, device=q.device
+    )
+    cu_seqlens_k = torch.arange(
+        0, (B + 1) * S_k, S_k, dtype=torch.int32, device=q.device
+    )
+
+    out_thd = torch.empty(
+        B * S_q, H_q, v.shape[-1], dtype=torch.bfloat16, device=q.device
+    )
+
+    result = flash_attn_varlen_d192_gfx1250(
+        q_thd,
+        k_thd,
+        v_thd,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        S_q,
+        S_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        out=out_thd,
+        return_lse=return_lse,
+    )
+
+    if return_lse:
+        o, lse = result
+        # lse: [B*S_q, H] → [B, H, S_q] to match flash_attn_func convention
+        return o.reshape(B, S_q, H_q, -1), lse.reshape(B, S_q, H_q).permute(0, 2, 1)
+    return result.reshape(B, S_q, H_q, -1)
 
 
 def flydsl_flash_attn_varlen_func(

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -2369,6 +2369,27 @@ def flash_attn_func(
             The output of softmax (possibly with different scaling). It also encodes the dropout
             pattern (negative means that location was dropped, nonnegative means it was kept).
     """
+    # FlyDSL batch path — returns result if supported, None otherwise.
+    from .flydsl.fmha_kernels import flydsl_flash_attn_batch_func
+
+    _flydsl_result = flydsl_flash_attn_batch_func(
+        q,
+        k,
+        v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        return_lse=return_lse,
+        dropout_p=dropout_p,
+        window_size=window_size,
+        bias=bias,
+        alibi_slopes=alibi_slopes,
+        deterministic=deterministic,
+        return_attn_probs=return_attn_probs,
+        sink=sink_ptr,
+    )
+    if _flydsl_result is not None:
+        return _flydsl_result
+
     if not ENABLE_CK:
         from .triton.attention.mha import flash_attn_func as flash_attn_func_triton
 

--- a/op_tests/test_mha_flydsl_batch.py
+++ b/op_tests/test_mha_flydsl_batch.py
@@ -105,14 +105,20 @@ def _tflops(flop, ms):
 
 
 def run_batch_test(
-    B, S_q, S_k, H, causal=False, return_lse=False, warmup=1, repeat=5
+    B, S_q, S_k, H, causal=False, return_lse=False, warmup=1, repeat=5,
+    random_value=True,
 ):
     device = torch.device("cuda")
-    torch.manual_seed(42)
 
-    q = torch.randn(B, S_q, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
-    k = torch.randn(B, S_k, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
-    v = torch.randn(B, S_k, H, HEAD_DIM_V, dtype=torch.bfloat16, device=device)
+    if random_value:
+        torch.manual_seed(42)
+        q = torch.randn(B, S_q, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+        k = torch.randn(B, S_k, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+        v = torch.randn(B, S_k, H, HEAD_DIM_V, dtype=torch.bfloat16, device=device)
+    else:
+        q = torch.full((B, S_q, H, HEAD_DIM_QK), 0.25, dtype=torch.bfloat16, device=device)
+        k = torch.full((B, S_k, H, HEAD_DIM_QK), 0.25, dtype=torch.bfloat16, device=device)
+        v = torch.full((B, S_k, H, HEAD_DIM_V), 0.25, dtype=torch.bfloat16, device=device)
 
     scale = 1.0 / math.sqrt(HEAD_DIM_QK)
 
@@ -234,6 +240,13 @@ if __name__ == "__main__":
         "--cmp-triton", action="store_true",
         help="Also time Triton for each case and print speedup.",
     )
+    parser.add_argument(
+        "--random-value",
+        type=str,
+        default="true",
+        help="Use random input data (default true). Set false to use fixed 0.25.\n"
+        "e.g.: --random-value false",
+    )
     args = parser.parse_args()
 
     def _parse_bool(s):
@@ -311,6 +324,7 @@ if __name__ == "__main__":
                 return_lse=return_lse,
                 warmup=args.warmup,
                 repeat=args.repeat,
+                random_value=_parse_bool(args.random_value),
             )
             if args.cmp_triton:
                 device = torch.device("cuda")

--- a/op_tests/test_mha_flydsl_batch.py
+++ b/op_tests/test_mha_flydsl_batch.py
@@ -1,0 +1,348 @@
+"""Unit test for FlyDSL MHA batch-mode kernel on gfx1250.
+
+Tests with BSHD layout [B, S, H, D] and fixed-length sequences.
+Covers causal, non-causal, sq!=sk (cross-attention),
+sq<<sk (decode-like), GQA, and return_lse.
+
+The batch-mode wrapper reshapes BSHD -> THD and calls the
+existing varlen kernel with uniform cu_seqlens.
+
+Usage:
+    python op_tests/test_mha_flydsl_batch.py
+    python op_tests/test_mha_flydsl_batch.py -b 2 -nh 128 -sq 256 -sk 256
+    python op_tests/test_mha_flydsl_batch.py -c true -l false
+"""
+
+import argparse
+import math
+import sys
+
+import pandas as pd
+import torch
+
+import aiter
+from aiter.ops.mha import flash_attn_func
+from aiter.ops.flydsl.fmha_kernels import flydsl_flash_attn_batch_func
+from aiter.test_common import checkAllclose
+from aiter.utility import dtypes
+
+if aiter.get_gfx() != "gfx1250":
+    print("Skipping: test requires gfx1250 " f"(current: {aiter.get_gfx()})")
+    sys.exit(0)
+
+HEAD_DIM_QK = 192
+HEAD_DIM_V = 128
+
+
+def _time_fn(fn, warmup, repeat):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    latencies = []
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    for _ in range(repeat):
+        start_event.record()
+        fn()
+        end_event.record()
+        end_event.synchronize()
+        latencies.append(start_event.elapsed_time(end_event))
+    return sum(latencies) / len(latencies)
+
+
+def _ref_mha_batch(q, k, v, scale, causal=False, return_lse=False):
+    """PyTorch reference for BSHD layout.
+
+    q: [B, S_q, H, D_qk]
+    k: [B, S_k, H, D_qk]
+    v: [B, S_k, H, D_v]
+    """
+    B, S_q, H, D_qk = q.shape
+    S_k = k.shape[1]
+
+    # [B, S, H, D] -> [B, H, S, D]
+    qf = q.float().permute(0, 2, 1, 3)
+    kf = k.float().permute(0, 2, 1, 3)
+    vf = v.float().permute(0, 2, 1, 3)
+
+    # QK^T: [B, H, S_q, S_k]
+    qk = torch.matmul(qf, kf.transpose(-2, -1)) * scale
+
+    if causal:
+        # Bottom-right aligned causal mask
+        mask = torch.triu(
+            torch.ones(S_q, S_k, device=qk.device, dtype=torch.bool),
+            diagonal=S_k - S_q + 1,
+        )
+        qk = qk.masked_fill(mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    if return_lse:
+        lse = torch.logsumexp(qk, dim=-1)  # [B, H, S_q]
+
+    p = torch.softmax(qk, dim=-1)
+    p = torch.nan_to_num(p, nan=0.0)
+
+    # PV: [B, H, S_q, D_v] -> [B, S_q, H, D_v]
+    out = torch.matmul(p, vf).permute(0, 2, 1, 3)
+
+    if return_lse:
+        return out, lse
+    return out
+
+
+def _fwd_flops(B, S_q, S_k, H, d_qk, d_v, causal):
+    """FLOPs for batch forward: QK^T + PV, causal halves."""
+    f = B * H * (2 * S_q * S_k * d_qk + 2 * S_q * S_k * d_v)
+    if causal:
+        f //= 2
+    return f
+
+
+def _tflops(flop, ms):
+    if ms <= 0:
+        return float("inf")
+    return flop / ms / 1e9
+
+
+def run_batch_test(
+    B, S_q, S_k, H, causal=False, return_lse=False, warmup=1, repeat=5
+):
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+
+    q = torch.randn(B, S_q, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+    k = torch.randn(B, S_k, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+    v = torch.randn(B, S_k, H, HEAD_DIM_V, dtype=torch.bfloat16, device=device)
+
+    scale = 1.0 / math.sqrt(HEAD_DIM_QK)
+
+    def _run():
+        return flydsl_flash_attn_batch_func(
+            q,
+            k,
+            v,
+            softmax_scale=scale,
+            causal=causal,
+            return_lse=return_lse,
+        )
+
+    avg_ms = _time_fn(_run, warmup, repeat)
+    result = _run()
+
+    if return_lse:
+        o, lse = result
+    else:
+        o = result
+
+    fwd_flop = _fwd_flops(B, S_q, S_k, H, HEAD_DIM_QK, HEAD_DIM_V, causal)
+    fwd_tflops = _tflops(fwd_flop, avg_ms)
+    avg_us = avg_ms * 1000
+
+    tag = f"B={B} H={H} Sq={S_q} Sk={S_k} causal={causal} lse={return_lse}"
+    print(f"  [{tag}] avg: {avg_ms:.3f}ms ({avg_us:.1f} us)  {fwd_tflops:.1f} TFLOPS")
+
+    ref_result = _ref_mha_batch(
+        q, k, v, scale, causal=causal, return_lse=return_lse,
+    )
+    if return_lse:
+        ref, ref_lse = ref_result
+    else:
+        ref = ref_result
+
+    err = checkAllclose(
+        o.cpu().float(), ref.cpu().float(), rtol=1e-2, atol=1e-2, msg=f"  [{tag}] out: "
+    )
+
+    if return_lse:
+        lse_err = checkAllclose(
+            lse.cpu().float(),
+            ref_lse.cpu().float(),
+            rtol=1e-2,
+            atol=1e-2,
+            msg=f"  [{tag}] lse: ",
+        )
+        err = max(err, lse_err)
+
+    if err > 0.0 and B > 1:
+        o_f = o.cpu().float()
+        r_f = ref.cpu().float()
+        for b in range(B):
+            ob = o_f[b]
+            rb = r_f[b]
+            isC = torch.isclose(ob, rb, rtol=1e-2, atol=1e-2)
+            bad = (~isC).sum().item()
+            if bad > 0:
+                delta = (ob[~isC] - rb[~isC]).abs()
+                print(
+                    f"    batch {b}: {bad} bad, max_err={delta.max():.6f}"
+                )
+
+    passed = err < 0.05
+    ret = {
+        "B": B,
+        "H": H,
+        "S_q": S_q,
+        "S_k": S_k,
+        "causal": causal,
+        "lse": return_lse,
+        "avg_us": round(avg_us, 2),
+        "tflops": round(fwd_tflops, 2),
+        "pass": passed,
+    }
+    return passed, ret
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="FlyDSL MHA batch-mode unit test & benchmark\n"
+        "(gfx1250, D_qk=192, D_v=128, bf16, BSHD layout)",
+    )
+    parser.add_argument(
+        "-b", "--batch_size", type=int, default=None,
+        help="Batch size. When set with -nh/-sq/-sk, runs a single shape.\ne.g.: -b 2",
+    )
+    parser.add_argument(
+        "-nh", "--nheads", type=int, default=None,
+        help="Number of attention heads.\ne.g.: -nh 128",
+    )
+    parser.add_argument(
+        "-sq", "--seqlen_q", type=int, default=None,
+        help="Sequence length of query.\ne.g.: -sq 256",
+    )
+    parser.add_argument(
+        "-sk", "--seqlen_k", type=int, default=None,
+        help="Sequence length of key.\ne.g.: -sk 512",
+    )
+    parser.add_argument(
+        "-c", "--causal", type=str, default=None,
+        help="Causal mode: true/false. Default runs both.\ne.g.: -c true",
+    )
+    parser.add_argument(
+        "-l", "--return_lse", type=str, default=None,
+        help="Return LSE: true/false. Default runs both.\ne.g.: -l false",
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=2,
+        help="Warmup iterations for benchmark (default 2).",
+    )
+    parser.add_argument(
+        "--repeat", type=int, default=5,
+        help="Repeat iterations for benchmark (default 5).",
+    )
+    parser.add_argument(
+        "--cmp-triton", action="store_true",
+        help="Also time Triton for each case and print speedup.",
+    )
+    args = parser.parse_args()
+
+    def _parse_bool(s):
+        if s is None:
+            return None
+        return s.lower() in ("true", "1", "yes")
+
+    causal_filter = _parse_bool(args.causal)
+    lse_filter = _parse_bool(args.return_lse)
+    single_shape = all(
+        x is not None
+        for x in [args.batch_size, args.nheads, args.seqlen_q, args.seqlen_k]
+    )
+
+    # =====================================================================
+    # Run all cases: correctness + timing in one pass
+    # =====================================================================
+    print("=" * 60)
+    print("FlyDSL MHA Batch-Mode Tests (BSHD)")
+    print("=" * 60)
+
+    if single_shape:
+        base_shapes = [
+            (args.batch_size, args.seqlen_q, args.seqlen_k, args.nheads),
+        ]
+    else:
+        base_shapes = [
+            # --- basic sq == sk ---
+            (1, 128, 128, 1),
+            (1, 184, 184, 128),
+            (1, 256, 256, 128),
+            (1, 341, 341, 128),
+            # --- multi-batch ---
+            (2, 256, 256, 128),
+            (4, 128, 128, 128),
+            # --- sq != sk (cross-attention) ---
+            (1, 128, 512, 1),
+            (1, 128, 256, 1),
+            (2, 128, 512, 2),
+            (2, 256, 512, 2),
+            # --- sq << sk (decode-like) ---
+            (1, 1, 512, 1),
+            (1, 1, 512, 2),
+            (2, 1, 512, 128),
+            (1, 16, 1024, 2),
+            (4, 72, 600, 2),
+            # --- larger shapes ---
+            (1, 512, 512, 128),
+            (1, 1024, 1024, 128),
+            (2, 512, 512, 128),
+            (1, 128, 2048, 128),
+        ]
+
+    causal_list = [causal_filter] if causal_filter is not None else [False, True]
+    lse_list = [lse_filter] if lse_filter is not None else [False, True]
+
+    tests = []
+    for B, S_q, S_k, H in base_shapes:
+        for causal in causal_list:
+            for return_lse in lse_list:
+                tests.append((B, S_q, S_k, H, causal, return_lse))
+
+    if args.cmp_triton:
+        from aiter.ops.triton.attention.mha import (
+            flash_attn_func as triton_flash_attn_func,
+        )
+
+    n_pass = 0
+    collected = []
+    for B, S_q, S_k, H, causal, return_lse in tests:
+        try:
+            ok, ret = run_batch_test(
+                B, S_q, S_k, H,
+                causal=causal,
+                return_lse=return_lse,
+                warmup=args.warmup,
+                repeat=args.repeat,
+            )
+            if args.cmp_triton:
+                device = torch.device("cuda")
+                scale = 1.0 / math.sqrt(HEAD_DIM_QK)
+                torch.manual_seed(42)
+                q = torch.randn(B, S_q, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+                k = torch.randn(B, S_k, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+                v = torch.randn(B, S_k, H, HEAD_DIM_V, dtype=torch.bfloat16, device=device)
+                tri_ms = _time_fn(
+                    lambda: triton_flash_attn_func(
+                        q=q, k=k, v=v,
+                        softmax_scale=scale,
+                        causal=causal,
+                    ),
+                    args.warmup,
+                    args.repeat,
+                )
+                fwd_flop = _fwd_flops(B, S_q, S_k, H, HEAD_DIM_QK, HEAD_DIM_V, causal)
+                ret["triton_us"] = round(tri_ms * 1000, 2)
+                ret["triton_tflops"] = round(_tflops(fwd_flop, tri_ms), 2)
+                ret["speedup"] = round(tri_ms / ret["avg_us"] * 1000, 2)
+            collected.append(ret)
+            if ok:
+                n_pass += 1
+        except Exception as e:
+            print(f"  [B={B} Sq={S_q} Sk={S_k} H={H} causal={causal} lse={return_lse}] ERROR: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"{n_pass}/{len(tests)} passed")
+    print(f"{'='*60}")
+    if collected:
+        df = pd.DataFrame(collected)
+        aiter.logger.info(f"flydsl_mha_batch summary:\n{df.to_string(index=False)}")

--- a/op_tests/test_mha_flydsl_varlen.py
+++ b/op_tests/test_mha_flydsl_varlen.py
@@ -80,11 +80,10 @@ def _ref_mha_varlen(q, k, v, cu_q, cu_k, scale, causal=False, return_lse=False):
 
 
 def run_varlen_test(
-    cu_q_list, cu_k_list, H=1, causal=False, return_lse=False, warmup=1, repeat=5
+    cu_q_list, cu_k_list, H=1, causal=False, return_lse=False, warmup=1, repeat=5,
+    random_value=True,
 ):
     device = torch.device("cuda")
-    torch.manual_seed(42)
-
     cu_q, cu_k = cu_q_list, cu_k_list
     B = len(cu_q) - 1
     total_q, total_k = cu_q[-1], cu_k[-1]
@@ -92,9 +91,15 @@ def run_varlen_test(
     max_sq = max(cu_q[i + 1] - cu_q[i] for i in range(B))
     max_sk = max(cu_k[i + 1] - cu_k[i] for i in range(B))
 
-    q = torch.randn(total_q, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
-    k = torch.randn(total_k, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
-    v = torch.randn(total_k, H, HEAD_DIM_V, dtype=torch.bfloat16, device=device)
+    if random_value:
+        torch.manual_seed(42)
+        q = torch.randn(total_q, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+        k = torch.randn(total_k, H, HEAD_DIM_QK, dtype=torch.bfloat16, device=device)
+        v = torch.randn(total_k, H, HEAD_DIM_V, dtype=torch.bfloat16, device=device)
+    else:
+        q = torch.full((total_q, H, HEAD_DIM_QK), 0.25, dtype=torch.bfloat16, device=device)
+        k = torch.full((total_k, H, HEAD_DIM_QK), 0.25, dtype=torch.bfloat16, device=device)
+        v = torch.full((total_k, H, HEAD_DIM_V), 0.25, dtype=torch.bfloat16, device=device)
 
     scale = 1.0 / math.sqrt(HEAD_DIM_QK)
 
@@ -297,6 +302,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Also time Triton for each case and print speedup.",
     )
+    parser.add_argument(
+        "--random-value",
+        type=str,
+        default="true",
+        help="Use random input data (default true). Set false to use fixed 0.25.\n"
+        "e.g.: --random-value false",
+    )
     args = parser.parse_args()
 
     for d_qk_v in args.d_qk_v:
@@ -426,6 +438,7 @@ if __name__ == "__main__":
                 return_lse=return_lse,
                 warmup=args.warmup,
                 repeat=args.repeat,
+                random_value=_parse_bool(args.random_value),
             )
             if args.cmp_triton:
                 device = torch.device("cuda")

--- a/run-mha-perf.sh
+++ b/run-mha-perf.sh
@@ -1,0 +1,2 @@
+python op_tests/test_mha_flydsl_varlen.py -b 1 -nh 64 -sq 16384 -sk 16384 --random-value false --warmup 5 --repeat 20
+python op_tests/test_mha_flydsl_varlen.py -b 1 -nh 64 -sq 16384 -sk 16384 --random-value true --warmup 5 --repeat 20

--- a/run-mha-perf.sh
+++ b/run-mha-perf.sh
@@ -1,2 +1,4 @@
 python op_tests/test_mha_flydsl_varlen.py -b 1 -nh 64 -sq 16384 -sk 16384 --random-value false --warmup 5 --repeat 20
 python op_tests/test_mha_flydsl_varlen.py -b 1 -nh 64 -sq 16384 -sk 16384 --random-value true --warmup 5 --repeat 20
+python op_tests/test_mha_flydsl_batch.py -b 1 -nh 64 -sq 16384 -sk 16384 --random-value false --warmup 5 --repeat 20
+python op_tests/test_mha_flydsl_batch.py -b 1 -nh 64 -sq 16384 -sk 16384 --random-value true --warmup 5 --repeat 20


### PR DESCRIPTION

Add batch-mode for MI450 bf16 deepseek mha kernel

Add flydsl_flash_attn_batch_func that wraps the existing varlen (THD) kernel with BSHD→THD reshape and uniform cu_seqlens, so flash_attn_func now routes to FlyDSL on gfx1250 (bf16, D_qk=192, D_v=128). Includes batch-mode test suite covering causal/non-causal, sq!=sk, decode-like shapes, and return_lse.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
