### PR TITLE
[module_groupnorm] refactor

### DIFF
--- a/aiter/ops/groupnorm.py
+++ b/aiter/ops/groupnorm.py
@@ -5,26 +5,45 @@ from typing import Optional
 from torch import Tensor
 
 
-def gen_groupnorm_fake_tensors(
+# JIT-compiled binding to the C++ kernel. Output `y` and scratch `workspace`
+# are allocated by the Python wrapper below and passed in; the kernel writes
+# into them in-place and returns None.
+@compile_ops("module_groupnorm", fc_name="_groupnorm_run", develop=True)
+def _groupnorm_run(
+    y: Tensor,
+    workspace: Tensor,
+    input: Tensor,
+    num_groups: int,
+    weight: Tensor,
+    bias: Tensor,
+    eps: float,
+) -> None: ...
+
+
+def groupnorm_run(
     input: Tensor,
     num_groups: int,
     weight: Tensor,
     bias: Tensor,
     eps: float,
 ) -> Tensor:
-    return torch.empty_like(input)
+    """Group Normalization. Allocates output and scratch workspace, then calls
+    the HIP kernel. Returns the normalized output tensor."""
+    input = input.contiguous()
+    weight = weight.contiguous()
+    bias = bias.contiguous()
 
+    y = torch.empty_like(input)
 
-@compile_ops(
-    "module_groupnorm", fc_name="_groupnorm_run", gen_fake=gen_groupnorm_fake_tensors
-)
-def _groupnorm_run(
-    input: Tensor,
-    num_groups: int,
-    weight: Tensor,
-    bias: Tensor,
-    eps: float,
-) -> Tensor: ...
+    # Workspace upper bound that matches the C-side grid cap (see groupnorm.cu):
+    # num_acc_slots = gridx * outer, with gridx <= ceil(4096 / outer);
+    # the kernel needs 2 * num_acc_slots float32 slots.
+    outer = input.shape[0] * num_groups
+    ws_slots = 2 * ((4096 + outer - 1) // outer * outer)
+    workspace = torch.empty(ws_slots, dtype=torch.float32, device=input.device)
+
+    _groupnorm_run(y, workspace, input, num_groups, weight, bias, eps)
+    return y
 
 
 class GroupNorm(torch.nn.Module):
@@ -64,4 +83,4 @@ class GroupNorm(torch.nn.Module):
                 eps=self.eps,
             )
         else:
-            return _groupnorm_run(x, self.num_groups, self.weight, self.bias, self.eps)
+            return groupnorm_run(x, self.num_groups, self.weight, self.bias, self.eps)

--- a/aiter/ops/groupnorm.py
+++ b/aiter/ops/groupnorm.py
@@ -20,6 +20,43 @@ def _groupnorm_run(
 ) -> None: ...
 
 
+# Grow-only scratch workspace cache, keyed by device. The C++ kernel must not
+# allocate; it reuses whatever buffer we hand it (empty is fine — the kernel
+# overwrites every slot it reads). Reusing across calls avoids a per-call
+# allocation that otherwise dominates small-shape latency.
+#
+# Resident memory is bounded, not unbounded: ws_slots = 2 * gridx * outer, and
+# gridx is capped by the 4096 grid limit in groupnorm.cu, so the cached buffer
+# never exceeds ~8192 float32 (~32 KB) per device regardless of input size.
+# This matches main's C++ mean_accumulator_, which was likewise grow-only and
+# resident; no extra shrink/free logic is warranted.
+_workspace_cache: dict[torch.device, Tensor] = {}
+
+
+def _groupnorm_ws_slots(input: Tensor, num_groups: int) -> int:
+    # Exact float32-slot count the kernel needs: 2 * gridx * outer_size.
+    # gridx derivation mirrors launchGroupNormKernel in groupnorm.cu; keep in sync.
+    THREADS_PER_BLOCK = 1024
+    STEPS_PER_THREAD = 8
+    outer = input.shape[0] * num_groups
+    inner = input.numel() // outer
+    gridx = (inner + STEPS_PER_THREAD * THREADS_PER_BLOCK - 1) // (
+        STEPS_PER_THREAD * THREADS_PER_BLOCK
+    )
+    if inner % 4 == 0 and gridx >= 16:
+        gridx = max(1, gridx // 4)
+    gridx = min((4096 + outer - 1) // outer, gridx)
+    return 2 * gridx * outer
+
+
+def _groupnorm_workspace(ws_slots: int, device: torch.device) -> Tensor:
+    ws = _workspace_cache.get(device)
+    if ws is None or ws.numel() < ws_slots:
+        ws = torch.empty(ws_slots, dtype=torch.float32, device=device)
+        _workspace_cache[device] = ws
+    return ws
+
+
 def groupnorm_run(
     input: Tensor,
     num_groups: int,
@@ -27,20 +64,16 @@ def groupnorm_run(
     bias: Tensor,
     eps: float,
 ) -> Tensor:
-    """Group Normalization. Allocates output and scratch workspace, then calls
-    the HIP kernel. Returns the normalized output tensor."""
+    """Group Normalization. Allocates output and reuses a cached scratch
+    workspace, then calls the HIP kernel. Returns the normalized output."""
     input = input.contiguous()
     weight = weight.contiguous()
     bias = bias.contiguous()
 
     y = torch.empty_like(input)
 
-    # Workspace upper bound that matches the C-side grid cap (see groupnorm.cu):
-    # num_acc_slots = gridx * outer, with gridx <= ceil(4096 / outer);
-    # the kernel needs 2 * num_acc_slots float32 slots.
-    outer = input.shape[0] * num_groups
-    ws_slots = 2 * ((4096 + outer - 1) // outer * outer)
-    workspace = torch.empty(ws_slots, dtype=torch.float32, device=input.device)
+    ws_slots = _groupnorm_ws_slots(input, num_groups)
+    workspace = _groupnorm_workspace(ws_slots, input.device)
 
     _groupnorm_run(y, workspace, input, num_groups, weight, bias, eps)
     return y

--- a/csrc/include/groupnorm.hpp
+++ b/csrc/include/groupnorm.hpp
@@ -1,34 +1,27 @@
-#include <torch/extension.h>
+#pragma once
 
-#include "aiter_hip_common.h"
-#include <optional>
+#include "aiter_tensor.h"
 
-namespace rocm_torch_x {
+namespace aiter {
 
-class __attribute__((visibility("hidden"))) GroupNorm final
-{
-    public:
-    explicit GroupNorm() = default;
-    ~GroupNorm()         = default;
+// Group Normalization. All memory (output and scratch workspace) is allocated by
+// the caller (Python) and passed in; the C side only computes.
+//
+//   y:         output, same shape/dtype as x
+//   workspace: float32 scratch, capacity (in elements) must be
+//              >= 2 * ceil(4096 / (num_tokens * num_groups)) * (num_tokens * num_groups)
+//   x:         input [num_tokens, num_channels, ...], contiguous
+//   weight:    affine weight [num_channels], contiguous
+//   bias:      affine bias   [num_channels], contiguous
+//   epsilon:   numerical stability term
+//
+// Supported dtypes for x/y/weight/bias: fp32, fp16, bf16.
+void groupnorm_run(aiter_tensor_t& y,
+                   aiter_tensor_t& workspace,
+                   const aiter_tensor_t& x,
+                   int num_groups,
+                   const aiter_tensor_t& weight,
+                   const aiter_tensor_t& bias,
+                   double epsilon);
 
-    public:
-    // return empty if not supported
-    std::optional<torch::Tensor>
-    Run(torch::Tensor x, int num_groups, torch::Tensor weights, torch::Tensor bias, float epsilon);
-
-    private:
-    template <typename T>
-    torch::Tensor launchGroupNormKernel(uint32_t num_groups,
-                                        float epsilon,
-                                        const torch::Tensor x,
-                                        const torch::Tensor weights,
-                                        const torch::Tensor bias,
-                                        hipStream_t stream);
-
-    void reserveMeanAccumulator(uint32_t nums_to_reserve, torch::Device device);
-
-    private:
-    torch::Tensor mean_accumulator_;
-};
-
-} // namespace rocm_torch_x
+} // namespace aiter

--- a/csrc/kernels/groupnorm.cu
+++ b/csrc/kernels/groupnorm.cu
@@ -1,11 +1,11 @@
 #include "groupnorm.hpp"
-
-#include <c10/hip/HIPStream.h>
-#include <c10/hip/HIPGuard.h>
+#include "aiter_hip_common.h"
+#include "aiter_stream.h"
 
 #include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
 
+#include <algorithm>
 #include <sstream>
 #include <vector>
 #include <string>
@@ -273,19 +273,24 @@ __global__ void groupnorm_kernel_dispatch_down(uint32_t num_groups, uint32_t num
 
 } // namespace
 
-namespace rocm_torch_x {
+namespace aiter {
+
+namespace {
 
 template<typename T>
-torch::Tensor GroupNorm::launchGroupNormKernel(uint32_t num_groups, float epsilon,
-    const torch::Tensor x, const torch::Tensor weights, const torch::Tensor bias, hipStream_t stream)
+void launchGroupNormKernel(aiter_tensor_t& y, aiter_tensor_t& workspace,
+    const aiter_tensor_t& x, uint32_t num_groups, float epsilon,
+    const aiter_tensor_t& weights, const aiter_tensor_t& bias, hipStream_t stream)
 {
-    torch::Tensor y = torch::empty_like(x);
-    const std::vector<int64_t> & dims = x.sizes().vec();
-    int64_t numel = std::accumulate(dims.begin(), dims.end(), 1LL, std::multiplies<int64_t>());
-    int64_t numel_per_channel = numel / dims[0] / dims[1];
-    uint32_t num_channels = dims[1];
+    int ndim = x.dim();
+    int64_t numel = 1;
+    for(int i = 0; i < ndim; ++i) {
+        numel *= x.size(i);
+    }
+    int64_t numel_per_channel = numel / x.size(0) / x.size(1);
+    uint32_t num_channels = x.size(1);
 
-    uint32_t outer_size = dims[0] * num_groups;
+    uint32_t outer_size = x.size(0) * num_groups;
     int64_t inner_size = numel / outer_size;
 
     constexpr uint32_t THREADS_PER_BLOCK = 1024;
@@ -303,7 +308,10 @@ torch::Tensor GroupNorm::launchGroupNormKernel(uint32_t num_groups, float epsilo
     constexpr dim3 block_dim(THREADS_PER_BLOCK, 1, 1);
 
     uint32_t num_acc_slots = gridx * outer_size;
-    reserveMeanAccumulator(num_acc_slots*2, x.device());
+    AITER_CHECK(workspace.numel() >= static_cast<int64_t>(num_acc_slots) * 2,
+                "groupnorm workspace too small: need ", num_acc_slots * 2,
+                " float slots, got ", workspace.numel());
+    float* mean_acc = reinterpret_cast<float*>(workspace.data_ptr());
 
     // there are some other ways:
     //    1) use sequential atomicAdd in the first function to reduce, this may influence precision, and need an another memset kenrel
@@ -316,9 +324,9 @@ torch::Tensor GroupNorm::launchGroupNormKernel(uint32_t num_groups, float epsilo
         num_channels,
         numel_per_channel,
         align4,
-        static_cast<const T*>(x.data_ptr()),
-        mean_accumulator_.mutable_data_ptr<float>(),
-        mean_accumulator_.mutable_data_ptr<float>()+num_acc_slots);
+        reinterpret_cast<const T*>(x.data_ptr()),
+        mean_acc,
+        mean_acc+num_acc_slots);
     HIP_CALL(hipGetLastError());
 
     groupnorm_kernel_dispatch_down<T, THREADS_PER_BLOCK><<<grid_dim, block_dim, 0, stream>>>(
@@ -327,72 +335,49 @@ torch::Tensor GroupNorm::launchGroupNormKernel(uint32_t num_groups, float epsilo
         numel_per_channel,
         epsilon,
         align4,
-        static_cast<const T*>(x.data_ptr()),
-        static_cast<const T*>(weights.data_ptr()),
-        static_cast<const T*>(bias.data_ptr()),
-        mean_accumulator_.data_ptr<float>(),
-        mean_accumulator_.data_ptr<float>()+num_acc_slots,
-        static_cast<T*>(y.mutable_data_ptr()));
+        reinterpret_cast<const T*>(x.data_ptr()),
+        reinterpret_cast<const T*>(weights.data_ptr()),
+        reinterpret_cast<const T*>(bias.data_ptr()),
+        mean_acc,
+        mean_acc+num_acc_slots,
+        reinterpret_cast<T*>(y.data_ptr()));
     HIP_CALL(hipGetLastError());
-
-    return y;
 }
 
-std::optional<torch::Tensor> GroupNorm::Run(
-    torch::Tensor x,
+} // namespace
+
+void groupnorm_run(
+    aiter_tensor_t& y,
+    aiter_tensor_t& workspace,
+    const aiter_tensor_t& x,
     int num_groups,
-    torch::Tensor weights,
-    torch::Tensor bias,
-    float epsilon)
+    const aiter_tensor_t& weights,
+    const aiter_tensor_t& bias,
+    double epsilon)
 {
-    at::DeviceGuard device_guard(x.device());
+    HipDeviceGuard device_guard(x.device_id);
 
-    auto hip_stream = c10::hip::getCurrentHIPStream();
+    hipStream_t stream = aiter::getCurrentHIPStream();
 
-    if (x.requires_grad()) {
-        return std::nullopt;
-    }
+    AITER_CHECK(weights.numel() > 0 && bias.numel() > 0,
+                "groupnorm requires non-empty affine weight and bias");
+    // x/weights/bias contiguity is guaranteed by the Python wrapper; check defensively.
+    AITER_CHECK(x.is_contiguous(), "groupnorm input x must be contiguous");
 
-    if(weights.numel() == 0 || bias.numel() == 0) {
-        return std::nullopt;
-    }
-
-    // TODO(limou) :
-    if(!x.is_contiguous()) {
-        x = x.contiguous();
-    }
-    weights = weights.contiguous();
-    bias = bias.contiguous();
-
-    torch::Tensor y;
-    switch(x.scalar_type()) {
-        case c10::ScalarType::Float:
-            y = launchGroupNormKernel<float>(num_groups, epsilon, x, weights, bias, hip_stream.stream());
+    switch(x.dtype()) {
+        case AITER_DTYPE_fp32:
+            launchGroupNormKernel<float>(y, workspace, x, num_groups, epsilon, weights, bias, stream);
             break;
-        case c10::ScalarType::Half:
-            y = launchGroupNormKernel<__half>(num_groups, epsilon, x, weights, bias, hip_stream.stream());
+        case AITER_DTYPE_fp16:
+            launchGroupNormKernel<__half>(y, workspace, x, num_groups, epsilon, weights, bias, stream);
             break;
-        case c10::ScalarType::BFloat16:
-            y = launchGroupNormKernel<__hip_bfloat16>(num_groups, epsilon, x, weights, bias, hip_stream.stream());
+        case AITER_DTYPE_bf16:
+            launchGroupNormKernel<__hip_bfloat16>(y, workspace, x, num_groups, epsilon, weights, bias, stream);
             break;
         default:
-            return std::nullopt;
+            AITER_CHECK(false, "groupnorm unsupported dtype: ", AiterDtype_to_str(x.dtype()));
     }
-    return y;
 }
 
-void GroupNorm::reserveMeanAccumulator(uint32_t nums_to_reserve, torch::Device device)
-{
-    if(nums_to_reserve <= mean_accumulator_.numel()) {
-        return;
-    }
-    auto options = torch::TensorOptions()
-        .dtype(c10::ScalarType::Float)
-        .device(device)
-        .requires_grad(false);
-
-    mean_accumulator_ = at::empty({nums_to_reserve}, options);
-}
-
-} // rocm_torch_x
+} // namespace aiter
 

--- a/csrc/pybind/groupnorm_pybind.cu
+++ b/csrc/pybind/groupnorm_pybind.cu
@@ -1,25 +1,20 @@
-#include <torch/extension.h>
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "aiter_stream.h"
+#include "rocm_ops.hpp"
 #include "../include/groupnorm.hpp"
 
-torch::Tensor _groupnorm_run_wrapper(
-    torch::Tensor input,
-    int64_t num_groups,
-    torch::Tensor weight,
-    torch::Tensor bias,
-    double eps
-) {
-    rocm_torch_x::GroupNorm gn;
-    auto result = gn.Run(
-        input,
-        static_cast<int>(num_groups),
-        weight,
-        bias,
-        static_cast<float>(eps)
-    );
-    TORCH_CHECK(result.has_value(), "GroupNorm kernel returned nullopt");
-    return result.value();
-}
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("_groupnorm_run", &_groupnorm_run_wrapper);  
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    m.def("_groupnorm_run",
+          &aiter::groupnorm_run,
+          py::arg("y"),
+          py::arg("workspace"),
+          py::arg("x"),
+          py::arg("num_groups"),
+          py::arg("weight"),
+          py::arg("bias"),
+          py::arg("epsilon"),
+          "Group Normalization (caller-allocated output and workspace)");
 }


### PR DESCRIPTION
## Motivation

De-torching module_groupnorm (replacing torch::Tensor with the aiter_tensor_t ABI) significantly reduces compilation time.
**From 39.5s to 15s (-62%)**

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
