### PR TITLE
[Feature][HIP] Support fused shared expert topk append

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -85,6 +85,9 @@ def biased_grouped_topk_hip(
     topk_grp: int,
     need_renorm: bool,
     routed_scaling_factor: float = 1.0,
+    num_fused_shared_experts: int = 0,
+    fused_shared_experts_scaling_factor: float = 1.0,
+    shared_expert_base: int = -1,
 ) -> None: ...
 
 
@@ -98,6 +101,9 @@ def grouped_topk(
     need_renorm: bool,
     is_softmax: bool = True,
     routed_scaling_factor: float = 1.0,
+    num_fused_shared_experts: int = 0,
+    fused_shared_experts_scaling_factor: float = 1.0,
+    shared_expert_base: int = -1,
 ) -> None: ...
 
 
@@ -144,11 +150,18 @@ def biased_grouped_topk(
     topk_group: int,
     need_renorm: bool,
     routed_scaling_factor: float = 1.0,  # mul to topk_weights
+    num_fused_shared_experts: int = 0,
+    fused_shared_experts_scaling_factor: float = 1.0,
+    shared_expert_base: int = -1,
 ):
     token_num = gating_output.shape[0]
     num_experts = gating_output.shape[1]
     cu_num = get_cu_num()
-    if token_num <= cu_num * 212 or num_experts // num_expert_group > 32:
+    if (
+        num_fused_shared_experts > 0
+        or token_num <= cu_num * 212
+        or num_experts // num_expert_group > 32
+    ):
         return biased_grouped_topk_hip(
             gating_output,
             correction_bias,
@@ -158,6 +171,9 @@ def biased_grouped_topk(
             topk_group,
             need_renorm,
             routed_scaling_factor,
+            num_fused_shared_experts,
+            fused_shared_experts_scaling_factor,
+            shared_expert_base,
         )
     else:
         topk = topk_ids.shape[1]

--- a/csrc/include/moe_op.h
+++ b/csrc/include/moe_op.h
@@ -11,7 +11,10 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
                          int num_expert_group,
                          int topk_group,
                          bool renormalize,
-                         const float routed_scaling_factor = 1.);
+                         const float routed_scaling_factor = 1.,
+                         int num_fused_shared_experts = 0,
+                         const float fused_shared_experts_scaling_factor = 1.,
+                         int shared_expert_base = -1);
 
 void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
                   torch::Tensor& topk_weights,  // [num_tokens, topk]
@@ -20,7 +23,10 @@ void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
                   int topk_grp,
                   bool need_renorm,
                   bool is_softmax                   = true,
-                  const float routed_scaling_factor = 1.);
+                  const float routed_scaling_factor = 1.,
+                  int num_fused_shared_experts = 0,
+                  const float fused_shared_experts_scaling_factor = 1.,
+                  int shared_expert_base = -1);
 
 std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
                                        at::Tensor& bias,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1300,7 +1300,7 @@ namespace py = pybind11;
           py::arg("num_fused_shared_experts") = 0,                             \
           py::arg("fused_shared_experts_scaling_factor") = 1.0f,               \
           py::arg("shared_expert_base") = -1,                                  \
-          "Apply biased grouped topk softmax to the gating outputs.");         \
+          "Apply biased grouped topk sigmoid to the gating outputs.");         \
     m.def("moe_fused_gate",                                                    \
           &moe_fused_gate,                                                     \
           py::arg("input"),                                                    \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1283,7 +1283,10 @@ namespace py = pybind11;
           py::arg("need_renorm"),                                              \
           py::arg("is_softmax")            = true,                             \
           py::arg("routed_scaling_factor") = 1.0f,                             \
-          "Apply grouped topk softmax/sigmodd to the gating outputs.");        \
+          py::arg("num_fused_shared_experts") = 0,                             \
+          py::arg("fused_shared_experts_scaling_factor") = 1.0f,               \
+          py::arg("shared_expert_base") = -1,                                  \
+          "Apply grouped topk softmax/sigmoid to the gating outputs.");        \
     m.def("biased_grouped_topk",                                               \
           &biased_grouped_topk,                                                \
           py::arg("gating_output"),                                            \
@@ -1294,6 +1297,9 @@ namespace py = pybind11;
           py::arg("topk_grp"),                                                 \
           py::arg("need_renorm"),                                              \
           py::arg("routed_scaling_factor") = 1.0f,                             \
+          py::arg("num_fused_shared_experts") = 0,                             \
+          py::arg("fused_shared_experts_scaling_factor") = 1.0f,               \
+          py::arg("shared_expert_base") = -1,                                  \
           "Apply biased grouped topk softmax to the gating outputs.");         \
     m.def("moe_fused_gate",                                                    \
           &moe_fused_gate,                                                     \

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -74,11 +74,21 @@ static int validate_topk_output_contract(const torch::Tensor& topk_weights,
                 total_topk,
                 ", num_fused_shared_experts=",
                 num_fused_shared_experts);
-    TORCH_CHECK(topk_ids.stride(0) >= total_topk && topk_weights.stride(0) >= total_topk,
-                "topk output row stride must include all output columns, got topk_ids.stride(0)=",
+    TORCH_CHECK(routed_topk <= static_cast<int>(WARP_SIZE),
+                "routed_topk (",
+                routed_topk,
+                ") exceeds WARP_SIZE (",
+                WARP_SIZE,
+                "); the grouped_topk kernels write one routed expert per lane and cannot "
+                "support more routed columns than a single warp");
+    TORCH_CHECK(topk_ids.stride(0) == topk_weights.stride(0),
+                "topk_ids and topk_weights must have the same row stride, got topk_ids.stride(0)=",
                 topk_ids.stride(0),
                 ", topk_weights.stride(0)=",
-                topk_weights.stride(0),
+                topk_weights.stride(0));
+    TORCH_CHECK(topk_ids.stride(0) >= total_topk,
+                "topk output row stride must include all output columns, got stride(0)=",
+                topk_ids.stride(0),
                 ", total_topk=",
                 total_topk);
     if(num_fused_shared_experts > 0)
@@ -1317,6 +1327,12 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
     int num_experts     = gating_output.size(1);
     int topk            = aiter::validate_topk_output_contract(
         topk_weights, topk_ids, num_fused_shared_experts, shared_expert_base);
+    TORCH_CHECK(topk <= num_experts,
+                "routed_topk (",
+                topk,
+                ") exceeds num_experts (",
+                num_experts,
+                ")");
     size_t stride_tk    = topk_ids.stride(0);
     TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
                 "topk_grp must be in [1, num_expert_group], but got topk_grp=",
@@ -1368,6 +1384,12 @@ void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
     int num_experts     = gating_output.size(1);
     int topk            = aiter::validate_topk_output_contract(
         topk_weights, topk_ids, num_fused_shared_experts, shared_expert_base);
+    TORCH_CHECK(topk <= num_experts,
+                "routed_topk (",
+                topk,
+                ") exceeds num_experts (",
+                num_experts,
+                ")");
     size_t stride_tk     = topk_ids.stride(0);
     auto correction_bias = topk_ids;
     TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -67,6 +67,23 @@ static int validate_topk_output_contract(const torch::Tensor& topk_weights,
                 ", topk_weights.stride(1)=",
                 topk_weights.stride(1));
 
+    TORCH_CHECK(topk_ids.scalar_type() == at::kInt,
+                "topk_ids must be int32 to match the kernel's int* output contract, got ",
+                topk_ids.scalar_type());
+    TORCH_CHECK(topk_weights.scalar_type() == at::kFloat,
+                "topk_weights must be float32 to match the kernel's float* output contract, got ",
+                topk_weights.scalar_type());
+    TORCH_CHECK(topk_ids.is_cuda() && topk_weights.is_cuda(),
+                "topk output tensors must reside on the GPU, got topk_ids.device()=",
+                topk_ids.device(),
+                ", topk_weights.device()=",
+                topk_weights.device());
+    TORCH_CHECK(topk_ids.device() == topk_weights.device(),
+                "topk_ids and topk_weights must be on the same device, got topk_ids.device()=",
+                topk_ids.device(),
+                ", topk_weights.device()=",
+                topk_weights.device());
+
     const int total_topk  = static_cast<int>(topk_ids.size(1));
     const int routed_topk = total_topk - num_fused_shared_experts;
     TORCH_CHECK(routed_topk >= 1,

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -326,7 +326,10 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
                     const int topk,
                     const int topk_group,
                     const int num_tokens,
-                    const float routed_scaling_factor)
+                    const float routed_scaling_factor,
+                    const int num_fused_shared_experts,
+                    const float fused_shared_experts_scaling_factor,
+                    const int shared_expert_base)
 {
     static_assert(NUM_GRP <= WARP_SIZE, "NUM_GRP must be <= WARP_SIZE");
     static constexpr int THREAD_PER_GRP = (WARP_SIZE + NUM_GRP - 1) / NUM_GRP;
@@ -612,6 +615,12 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
         topk_weights[token_idx * stride_tk + k] = topk_value * sum;
         topk_ids[token_idx * stride_tk + k]     = topk_indice;
     }
+
+    for(int s = threadIdx.x; s < num_fused_shared_experts; s += blockDim.x)
+    {
+        topk_weights[token_idx * stride_tk + topk + s] = fused_shared_experts_scaling_factor;
+        topk_ids[token_idx * stride_tk + topk + s]     = shared_expert_base + s;
+    }
 }
 
 template <typename DTYPE_I,
@@ -630,7 +639,10 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
                              const int topk,
                              const int topk_group,
                              const int num_tokens,
-                             const float routed_scaling_factor)
+                             const float routed_scaling_factor,
+                             const int num_fused_shared_experts,
+                             const float fused_shared_experts_scaling_factor,
+                             const int shared_expert_base)
 {
     static_assert(NUM_GRP <= WARP_SIZE, "NUM_GRP must be <= WARP_SIZE");
     // number of lanes responsible for a expert group
@@ -1092,6 +1104,13 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
             topk_ids[token_idx * stride_tk + threadIdx.x]     = topk_i;
         }
 #endif
+        for(int shared_idx = threadIdx.x; shared_idx < num_fused_shared_experts;
+            shared_idx += blockDim.x)
+        {
+            topk_weights[token_idx * stride_tk + topk + shared_idx] =
+                fused_shared_experts_scaling_factor;
+            topk_ids[token_idx * stride_tk + topk + shared_idx] = shared_expert_base + shared_idx;
+        }
     }
 }
 } // namespace aiter
@@ -1170,7 +1189,10 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
             topk,                                                                                  \
             topk_grp,                                                                              \
             num_tokens,                                                                            \
-            routed_scaling_factor);                                                                \
+            routed_scaling_factor,                                                                 \
+            num_fused_shared_experts,                                                              \
+            fused_shared_experts_scaling_factor,                                                   \
+            shared_expert_base);                                                                   \
     });
 
 #define LAUNCHER_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)             \
@@ -1191,7 +1213,10 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
             topk,                                                                                  \
             topk_grp,                                                                              \
             num_tokens,                                                                            \
-            routed_scaling_factor);                                                                \
+            routed_scaling_factor,                                                                 \
+            num_fused_shared_experts,                                                              \
+            fused_shared_experts_scaling_factor,                                                   \
+            shared_expert_base);                                                                   \
     });
 
 #define LAUNCHER_biased_grouped_topk_opt_sort_kernel(                             \
@@ -1217,7 +1242,10 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
                                topk,                                              \
                                topk_grp,                                          \
                                num_tokens,                                        \
-                               routed_scaling_factor);                            \
+                               routed_scaling_factor,                             \
+                               num_fused_shared_experts,                          \
+                               fused_shared_experts_scaling_factor,               \
+                               shared_expert_base);                               \
         });
 
 void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_experts]
@@ -1227,14 +1255,28 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
                          int num_expert_group,
                          int topk_grp,
                          bool need_renorm,
-                         const float routed_scaling_factor = 1.)
+                         const float routed_scaling_factor = 1.,
+                         int num_fused_shared_experts = 0,
+                         const float fused_shared_experts_scaling_factor = 1.,
+                         int shared_expert_base = -1)
 {
     const bool isBiased = true;
     bool isSoftmax      = false;
     int num_tokens      = gating_output.size(0);
     int num_experts     = gating_output.size(1);
-    int topk            = topk_ids.size(1);
+    int total_topk      = topk_ids.size(1);
+    int topk            = total_topk - num_fused_shared_experts;
     size_t stride_tk    = topk_ids.stride(0);
+    if(num_fused_shared_experts > 0)
+    {
+        TORCH_CHECK(shared_expert_base >= 0,
+                    "shared_expert_base must be provided when num_fused_shared_experts > 0");
+        TORCH_CHECK(topk >= 1,
+                    "topk output must include routed and shared expert columns: "
+                    "topk_ids.size(1) must be greater than num_fused_shared_experts");
+        TORCH_CHECK(static_cast<int64_t>(stride_tk) >= total_topk,
+                    "topk output row stride must include routed and shared expert columns");
+    }
     TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
                 "topk_grp must be in [1, num_expert_group], but got topk_grp=",
                 topk_grp,
@@ -1274,15 +1316,29 @@ void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
                   int topk_grp,
                   bool need_renorm,
                   bool is_softmax                   = true,
-                  const float routed_scaling_factor = 1.)
+                  const float routed_scaling_factor = 1.,
+                  int num_fused_shared_experts = 0,
+                  const float fused_shared_experts_scaling_factor = 1.,
+                  int shared_expert_base = -1)
 {
     const bool isBiased  = false;
     bool isSoftmax       = is_softmax;
     int num_tokens       = gating_output.size(0);
     int num_experts      = gating_output.size(1);
-    int topk             = topk_ids.size(1);
+    int total_topk       = topk_ids.size(1);
+    int topk             = total_topk - num_fused_shared_experts;
     size_t stride_tk     = topk_ids.stride(0);
     auto correction_bias = topk_ids;
+    if(num_fused_shared_experts > 0)
+    {
+        TORCH_CHECK(shared_expert_base >= 0,
+                    "shared_expert_base must be provided when num_fused_shared_experts > 0");
+        TORCH_CHECK(topk >= 1,
+                    "topk output must include routed and shared expert columns: "
+                    "topk_ids.size(1) must be greater than num_fused_shared_experts");
+        TORCH_CHECK(static_cast<int64_t>(stride_tk) >= total_topk,
+                    "topk output row stride must include routed and shared expert columns");
+    }
     TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
                 "topk_grp must be in [1, num_expert_group], but got topk_grp=",
                 topk_grp,

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -37,6 +37,58 @@
 #endif
 
 namespace aiter {
+static int validate_topk_output_contract(const torch::Tensor& topk_weights,
+                                         const torch::Tensor& topk_ids,
+                                         int num_fused_shared_experts,
+                                         int shared_expert_base)
+{
+    TORCH_CHECK(num_fused_shared_experts >= 0,
+                "num_fused_shared_experts must be non-negative, got ",
+                num_fused_shared_experts);
+    TORCH_CHECK(topk_ids.dim() == 2 && topk_weights.dim() == 2,
+                "topk output tensors must be rank-2 [num_tokens, topk], got topk_ids.dim()=",
+                topk_ids.dim(),
+                ", topk_weights.dim()=",
+                topk_weights.dim());
+    TORCH_CHECK(topk_ids.size(0) == topk_weights.size(0) &&
+                    topk_ids.size(1) == topk_weights.size(1),
+                "topk_ids and topk_weights must have the same shape, got topk_ids=(",
+                topk_ids.size(0),
+                ", ",
+                topk_ids.size(1),
+                "), topk_weights=(",
+                topk_weights.size(0),
+                ", ",
+                topk_weights.size(1),
+                ")");
+    TORCH_CHECK(topk_ids.stride(1) == 1 && topk_weights.stride(1) == 1,
+                "topk output tensors must have contiguous columns, got topk_ids.stride(1)=",
+                topk_ids.stride(1),
+                ", topk_weights.stride(1)=",
+                topk_weights.stride(1));
+
+    const int total_topk  = static_cast<int>(topk_ids.size(1));
+    const int routed_topk = total_topk - num_fused_shared_experts;
+    TORCH_CHECK(routed_topk >= 1,
+                "topk output must include at least one routed expert column, got total_topk=",
+                total_topk,
+                ", num_fused_shared_experts=",
+                num_fused_shared_experts);
+    TORCH_CHECK(topk_ids.stride(0) >= total_topk && topk_weights.stride(0) >= total_topk,
+                "topk output row stride must include all output columns, got topk_ids.stride(0)=",
+                topk_ids.stride(0),
+                ", topk_weights.stride(0)=",
+                topk_weights.stride(0),
+                ", total_topk=",
+                total_topk);
+    if(num_fused_shared_experts > 0)
+    {
+        TORCH_CHECK(shared_expert_base >= 0,
+                    "shared_expert_base must be provided when num_fused_shared_experts > 0");
+    }
+    return routed_topk;
+}
+
 namespace impl {
 // use this type for argsort
 template <typename KType, typename VType>
@@ -518,7 +570,7 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
             }
             __syncthreads();
         }
-    
+
         for(int k = 0; k < topk_group; k++)
         {
             float max_val = -INFINITY;
@@ -705,7 +757,7 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
             {
                 tmp2 = reinterpret_cast<vec_i const*>(correction_bias)[e];
             }
-            
+
 #pragma unroll
             for(size_t i = 0; i < vec_size; i++)
             {
@@ -976,7 +1028,6 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
             float o_y = warp_bitonic_merge_sort_combine(o_t, o_r, threadIdx.x, (threadIdx.x / 16) & 1, opus::number<16>{}, opus::number<1>{});
             float o_q = __shfl(o_y, threadIdx.x ^ twi_1_);
 
-            
             float o_w = warp_swap_(o_q, threadIdx.x, opus::number<16>{});
             float o_o = warp_bitonic_merge_sort_combine(o_q, o_w, threadIdx.x, 0, opus::number<16>{}, is_descending_);
             // printf("[%2d] v:%f, o_x:%f, o_t:%f, o_r:%f o_y:%f, o_q:%f, o_w:%f, o_o:%f\n", threadIdx.x, v_, o_x, o_t, o_r, o_y, o_q, o_w, o_o);
@@ -1255,28 +1306,18 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
                          int num_expert_group,
                          int topk_grp,
                          bool need_renorm,
-                         const float routed_scaling_factor = 1.,
-                         int num_fused_shared_experts = 0,
+                         const float routed_scaling_factor               = 1.,
+                         int num_fused_shared_experts                    = 0,
                          const float fused_shared_experts_scaling_factor = 1.,
-                         int shared_expert_base = -1)
+                         int shared_expert_base                          = -1)
 {
     const bool isBiased = true;
     bool isSoftmax      = false;
     int num_tokens      = gating_output.size(0);
     int num_experts     = gating_output.size(1);
-    int total_topk      = topk_ids.size(1);
-    int topk            = total_topk - num_fused_shared_experts;
+    int topk            = aiter::validate_topk_output_contract(
+        topk_weights, topk_ids, num_fused_shared_experts, shared_expert_base);
     size_t stride_tk    = topk_ids.stride(0);
-    if(num_fused_shared_experts > 0)
-    {
-        TORCH_CHECK(shared_expert_base >= 0,
-                    "shared_expert_base must be provided when num_fused_shared_experts > 0");
-        TORCH_CHECK(topk >= 1,
-                    "topk output must include routed and shared expert columns: "
-                    "topk_ids.size(1) must be greater than num_fused_shared_experts");
-        TORCH_CHECK(static_cast<int64_t>(stride_tk) >= total_topk,
-                    "topk output row stride must include routed and shared expert columns");
-    }
     TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
                 "topk_grp must be in [1, num_expert_group], but got topk_grp=",
                 topk_grp,
@@ -1290,8 +1331,8 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
 
     dim3 grid(num_tokens);
     dim3 block(get_warp_size_func());
-    size_t shared_mem_size =
-        (2 * num_experts * sizeof(float) + num_expert_group * sizeof(float)); // additional buf for sig_scores
+    size_t shared_mem_size = (2 * num_experts * sizeof(float) +
+                              num_expert_group * sizeof(float)); // additional buf for sig_scores
     shared_mem_size += !use_opt_sort
                            ? 0
                            : (num_expert_group * sizeof(int) /*group_map_idx*/
@@ -1315,30 +1356,20 @@ void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
                   int num_expert_group,
                   int topk_grp,
                   bool need_renorm,
-                  bool is_softmax                   = true,
-                  const float routed_scaling_factor = 1.,
-                  int num_fused_shared_experts = 0,
+                  bool is_softmax                                 = true,
+                  const float routed_scaling_factor               = 1.,
+                  int num_fused_shared_experts                    = 0,
                   const float fused_shared_experts_scaling_factor = 1.,
-                  int shared_expert_base = -1)
+                  int shared_expert_base                          = -1)
 {
-    const bool isBiased  = false;
-    bool isSoftmax       = is_softmax;
-    int num_tokens       = gating_output.size(0);
-    int num_experts      = gating_output.size(1);
-    int total_topk       = topk_ids.size(1);
-    int topk             = total_topk - num_fused_shared_experts;
+    const bool isBiased = false;
+    bool isSoftmax      = is_softmax;
+    int num_tokens      = gating_output.size(0);
+    int num_experts     = gating_output.size(1);
+    int topk            = aiter::validate_topk_output_contract(
+        topk_weights, topk_ids, num_fused_shared_experts, shared_expert_base);
     size_t stride_tk     = topk_ids.stride(0);
     auto correction_bias = topk_ids;
-    if(num_fused_shared_experts > 0)
-    {
-        TORCH_CHECK(shared_expert_base >= 0,
-                    "shared_expert_base must be provided when num_fused_shared_experts > 0");
-        TORCH_CHECK(topk >= 1,
-                    "topk output must include routed and shared expert columns: "
-                    "topk_ids.size(1) must be greater than num_fused_shared_experts");
-        TORCH_CHECK(static_cast<int64_t>(stride_tk) >= total_topk,
-                    "topk output row stride must include routed and shared expert columns");
-    }
     TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
                 "topk_grp must be in [1, num_expert_group], but got topk_grp=",
                 topk_grp,

--- a/op_tests/test_biased_grouped_topk_shared_append.py
+++ b/op_tests/test_biased_grouped_topk_shared_append.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+import aiter
+
+
+@pytest.mark.parametrize("tokens", [1, 4, 8])
+@pytest.mark.parametrize("num_experts", [256, 384])
+@pytest.mark.parametrize("topk", [8])
+@pytest.mark.parametrize("num_shared", [1, 2])
+def test_biased_grouped_topk_fused_shared_append(tokens, num_experts, topk, num_shared):
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        pytest.skip("AITER grouped topk shared append test requires ROCm")
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_expert_group = 8
+    topk_group = 4
+    scale = 1.0
+
+    gating_output = torch.randn(tokens, num_experts, device=device, dtype=dtype)
+    correction_bias = torch.randn(num_experts, device=device, dtype=dtype) * 0.01
+
+    routed_weights = torch.empty(tokens, topk, device=device, dtype=torch.float32)
+    routed_ids = torch.empty(tokens, topk, device=device, dtype=torch.int32)
+    aiter.biased_grouped_topk(
+        gating_output,
+        correction_bias,
+        routed_weights,
+        routed_ids,
+        num_expert_group,
+        topk_group,
+        True,
+        scale,
+    )
+
+    expected_ids = torch.empty(tokens, topk + num_shared, device=device, dtype=torch.int32)
+    expected_weights = torch.empty(
+        tokens, topk + num_shared, device=device, dtype=torch.float32
+    )
+    expected_ids[:, :topk] = routed_ids
+    expected_weights[:, :topk] = routed_weights
+    for i in range(num_shared):
+        expected_ids[:, topk + i] = num_experts + i
+        expected_weights[:, topk + i] = 1.0
+
+    fused_ids = torch.empty_like(expected_ids)
+    fused_weights = torch.empty_like(expected_weights)
+    aiter.biased_grouped_topk(
+        gating_output,
+        correction_bias,
+        fused_weights,
+        fused_ids,
+        num_expert_group,
+        topk_group,
+        True,
+        scale,
+        num_shared,
+        1.0,
+        num_experts,
+    )
+
+    torch.testing.assert_close(fused_ids, expected_ids, rtol=0, atol=0)
+    torch.testing.assert_close(fused_weights, expected_weights, rtol=1e-6, atol=1e-6)

--- a/op_tests/test_biased_grouped_topk_shared_append.py
+++ b/op_tests/test_biased_grouped_topk_shared_append.py
@@ -66,3 +66,63 @@ def test_biased_grouped_topk_fused_shared_append(tokens, num_experts, topk, num_
 
     torch.testing.assert_close(fused_ids, expected_ids, rtol=0, atol=0)
     torch.testing.assert_close(fused_weights, expected_weights, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("tokens", [1, 4, 8])
+@pytest.mark.parametrize("num_experts", [256, 384])
+@pytest.mark.parametrize("topk", [8])
+@pytest.mark.parametrize("num_shared", [1, 2])
+def test_grouped_topk_fused_shared_append(tokens, num_experts, topk, num_shared):
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        pytest.skip("AITER grouped topk shared append test requires ROCm")
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_expert_group = 8
+    topk_group = 4
+    scale = 1.0
+
+    gating_output = torch.randn(tokens, num_experts, device=device, dtype=dtype)
+
+    routed_weights = torch.empty(tokens, topk, device=device, dtype=torch.float32)
+    routed_ids = torch.empty(tokens, topk, device=device, dtype=torch.int32)
+    aiter.grouped_topk(
+        gating_output,
+        routed_weights,
+        routed_ids,
+        num_expert_group,
+        topk_group,
+        True,
+        True,
+        scale,
+    )
+
+    expected_ids = torch.empty(tokens, topk + num_shared, device=device, dtype=torch.int32)
+    expected_weights = torch.empty(
+        tokens, topk + num_shared, device=device, dtype=torch.float32
+    )
+    expected_ids[:, :topk] = routed_ids
+    expected_weights[:, :topk] = routed_weights
+    for i in range(num_shared):
+        expected_ids[:, topk + i] = num_experts + i
+        expected_weights[:, topk + i] = 1.0
+
+    fused_ids = torch.empty_like(expected_ids)
+    fused_weights = torch.empty_like(expected_weights)
+    aiter.grouped_topk(
+        gating_output,
+        fused_weights,
+        fused_ids,
+        num_expert_group,
+        topk_group,
+        True,
+        True,
+        scale,
+        num_shared,
+        1.0,
+        num_experts,
+    )
+
+    torch.testing.assert_close(fused_ids, expected_ids, rtol=0, atol=0)
+    torch.testing.assert_close(fused_weights, expected_weights, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## Motivation

SGLang can fuse shared experts into the MoE routing result by asking AITER's grouped top-K operator to return both routed experts and shared experts in the same output tensors.

Before this change, AITER's grouped top-K HIP path only populated the routed top-K entries. Callers that needed shared experts had to append those entries separately after the top-K call, which adds extra Python-side handling and makes it harder to use AITER as a drop-in fused routing backend.

This PR adds native support for appending fused shared expert entries directly inside the AITER grouped top-K HIP kernels. The routed top-K selection remains unchanged, and shared expert IDs/weights are written after the routed top-K columns when explicitly requested.

## Technical Details

This change extends the AITER grouped top-K API surface and HIP kernel implementation to support optional shared expert append behavior.

The following optional arguments were added to `grouped_topk` and `biased_grouped_topk`:

```
num_fused_shared_experts: int = 0
fused_shared_experts_scaling_factor: float = 1.0
shared_expert_base: int = -1
```

Their behavior is:

- `num_fused_shared_experts`: number of shared experts to append after the routed top-K results.
- `fused_shared_experts_scaling_factor`: weight assigned to each appended shared expert.
- `shared_expert_base`: base expert ID for the first shared expert. Appended shared expert IDs are written as `shared_expert_base + i`.

When `num_fused_shared_experts == 0`, the existing behavior is preserved.

When `num_fused_shared_experts > 0`, the kernels append shared expert entries after the routed top-K expert columns:

```
topk_ids[token]     = [routed_id_0, ..., routed_id_k, shared_base, shared_base + 1, ...]
topk_weights[token] = [routed_w_0,  ..., routed_w_k,  shared_scale, shared_scale, ...]
```

The implementation updates:

- **`aiter/ops/topk.py`**
  - Extends the Python operator signatures.
  - For `biased_grouped_topk`, routes fused shared expert append requests through the HIP implementation so the append happens in-kernel.
- **`csrc/include/moe_op.h`**
  - Extends the C++ declarations for `grouped_topk` and `biased_grouped_topk`.
- **`csrc/include/rocm_ops.hpp`**
  - Adds pybind arguments for the new optional parameters.
- **`csrc/kernels/topk_softmax_kernels_group.cu`**
  - Propagates the new parameters through the grouped top-K launch macros.
  - Appends shared expert weights and IDs in both grouped top-K kernel variants.
  - Adds validation for shared expert append mode:
    - `shared_expert_base` must be provided.
    - The output row stride must be large enough for routed plus shared expert columns.
- **`op_tests/test_biased_grouped_topk_shared_append.py`**
  - Adds a focused regression test for the new append behavior.

The test compares the fused kernel output against the existing routed top-K result plus an expected shared expert suffix. This verifies that routed expert selection is preserved and that shared expert IDs/weights are appended in the expected columns.

## Test Plan

Ran the new targeted regression test:

```bash
python -m pytest -q op_tests/test_biased_grouped_topk_shared_append.py
```

Also checked the staged diff for whitespace and patch formatting issues:

```bash
git diff --cached --check
```

## Test Result

The targeted regression test passed:

```
............                                                             [100%]
12 passed, 2 warnings in 41.38s
```

The warnings were unrelated Cython distutils deprecation warnings from the local Python environment.

The diff check also passed with no whitespace or formatting issues:

```bash
git diff --cached --check
# no output
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.