### PR TITLE
feat(mxfp4-moe): AOT pre-compile + flyc.compile low-overhead launch f…

### DIFF
--- a/aiter/aot/flydsl/common.py
+++ b/aiter/aot/flydsl/common.py
@@ -33,6 +33,7 @@ class OpKind(enum.Enum):
     construction errors instead of silently routing to the wrong code path."""
 
     MOE = "moe"
+    MXFP4_MOE = "mxfp4_moe"
     GEMM = "gemm"
     GROUPED_MOE = "grouped_moe"
     CHUNK_GDN_H = "chunk_gdn_h"
@@ -224,6 +225,8 @@ def _collect_aot_jobs_for(kind: OpKind) -> list[dict[str, Any]]:
     parent process, just shifted once out of every child."""
     if kind is OpKind.MOE:
         from .moe import DEFAULT_CSVS, parse_csv
+    elif kind is OpKind.MXFP4_MOE:
+        from .mxfp4_moe import DEFAULT_CSVS, parse_csv
     elif kind is OpKind.GEMM:
         from .gemm import DEFAULT_CSVS, parse_csv
     elif kind is OpKind.GROUPED_MOE:
@@ -242,6 +245,8 @@ def _compile_one(kind: OpKind, job: dict[str, Any]) -> tuple[OpKind, dict[str, A
     the pickle wire payload is just (kind, job-dict)."""
     if kind is OpKind.MOE:
         from .moe import compile_one_config
+    elif kind is OpKind.MXFP4_MOE:
+        from .mxfp4_moe import compile_one_config
     elif kind is OpKind.GEMM:
         from .gemm import compile_one_config
     elif kind is OpKind.GROUPED_MOE:

--- a/aiter/aot/flydsl/mxfp4_moe.py
+++ b/aiter/aot/flydsl/mxfp4_moe.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""AOT pre-compile for the FlyDSL mxfp4 a4w4 MoE port (gemm1 / gemm2).
+
+The ``*_fp4_tuned_fmoe.csv`` configs carry ``mxfp4_moe_g{1,2}_a4w4_*`` port
+kernels alongside other fp4 backends. ``moe.py``'s ``parse_csv`` only handles
+``flydsl_*`` names, so these rows were never AOT-built. This driver parses the
+mxfp4 port names and warms the FlyDSL disk cache via the same
+``_get_compiled_mxfp4_gemm{1,2}_port`` entry points the runtime uses, keying the
+artifact identically so inference gets a cache hit.
+
+Standalone:
+    python -m aiter.aot.flydsl.mxfp4_moe [--csv /path/to/foo_fp4_tuned_fmoe.csv]
+"""
+
+import argparse
+import csv
+import glob
+import os
+import sys
+import time
+
+from aiter.aot.flydsl.common import collect_aot_jobs, compile_only_env
+from aiter.jit.core import AITER_ROOT_DIR
+
+# fp4 tuned CSVs live under model_configs/; resolved by glob so adding a new
+# model's tuned file requires no edit here. parse_csv keeps only the mxfp4
+# a4w4 port rows, so non-mxfp4 fp4 backends in these CSVs are ignored.
+_MODEL_CONFIG_DIR = f"{AITER_ROOT_DIR}/aiter/configs/model_configs"
+DEFAULT_CSVS = sorted(glob.glob(f"{_MODEL_CONFIG_DIR}/*_fp4_tuned_fmoe.csv"))
+
+
+def _job_key(job: dict) -> tuple:
+    """Dedup key == the runtime FlyDSL cache key (the args forwarded to
+    ``_get_compiled_mxfp4_gemm{1,2}_port``). Rows that differ only in token
+    count / timing collapse to one compile job."""
+    if job["stage"] == 1:
+        return (
+            1,
+            job["BM"],
+            job["use_nt"],
+            job["inline_quant"],
+            job["D_HIDDEN"],
+            job["D_INTER"],
+            job["NE"],
+            job["topk"],
+        )
+    return (
+        2,
+        job["BM"],
+        job["use_nt"],
+        job["NE"],
+        job["N_OUT"],
+        job["epilog"],
+        job["D_INTER"],
+        job["D_INTER_REAL"],
+    )
+
+
+def parse_csv(csv_path: str):
+    """Parse an fp4 tuned CSV into unique mxfp4-port compile jobs.
+
+    Each row carries a stage1 (kernelName1) and stage2 (kernelName2) kernel;
+    mxfp4 a4w4 port names emit a job per stage. Non-mxfp4 names (the CSV mixes
+    fp4 backends) are skipped -- those belong to moe.py's driver.
+    """
+    from aiter.fused_moe import (
+        _is_mxfp4_kname,
+        _parse_mxfp4_g1_kname,
+        _parse_mxfp4_g2_kname,
+    )
+    from aiter.ops.flydsl.mxfp4_gemm2_kernels import _epilog_of
+
+    jobs = []
+    seen = set()
+
+    def _add(job):
+        key = _job_key(job)
+        if key in seen:
+            return
+        seen.add(key)
+        jobs.append(job)
+
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            topk = int(row["topk"])
+            # CSV inter_dim is the model's *real* (unpadded) inter; the kernel
+            # name's E token is the *padded* D_INTER the weight is stored at.
+            # They differ only for non-256-aligned shards -> D_INTER_REAL.
+            inter_dim = int(row["inter_dim"])
+
+            kn1 = (row.get("kernelName1") or "").strip()
+            if _is_mxfp4_kname(kn1):
+                p1 = _parse_mxfp4_g1_kname(kn1)
+                _add(
+                    {
+                        "stage": 1,
+                        "kernel_name": kn1,
+                        "BM": p1["BM"],
+                        "use_nt": p1["use_nt"],
+                        "inline_quant": p1["inline_quant"],
+                        "D_HIDDEN": p1["H"],
+                        "D_INTER": p1["D_INTER"],
+                        "NE": p1["NE"],
+                        "topk": topk,
+                    }
+                )
+
+            kn2 = (row.get("kernelName2") or "").strip()
+            if _is_mxfp4_kname(kn2):
+                p2 = _parse_mxfp4_g2_kname(kn2)
+                d_inter_real = inter_dim if inter_dim != p2["D_INTER"] else None
+                _add(
+                    {
+                        "stage": 2,
+                        "kernel_name": kn2,
+                        "BM": p2["BM"],
+                        "use_nt": p2["use_nt"],
+                        "NE": p2["NE"],
+                        "N_OUT": p2["H"],
+                        "epilog": _epilog_of(
+                            p2["atomic"], p2["mxfp4out"], p2["cshuffle"]
+                        ),
+                        "D_INTER": p2["D_INTER"],
+                        "D_INTER_REAL": d_inter_real,
+                        # gemm2's kernel is topk-independent (hence not in
+                        # _job_key); kept only for the runtime entry signature.
+                        "topk": topk,
+                    }
+                )
+
+    return jobs
+
+
+def _dummy(nbytes=256):
+    import torch
+
+    # Only .data_ptr() / .device are read by the port entry points; values and
+    # exact sizes are irrelevant under COMPILE_ONLY (no kernel actually runs).
+    return torch.zeros(nbytes, dtype=torch.uint8, device="cuda")
+
+
+def _compile_stage1(job):
+    """Compile + persist the gemm1 @flyc.jit artifact via a COMPILE_ONLY launch.
+
+    Calls the same ``flydsl_mxfp4_gemm1`` runtime entry the op uses, so the cache
+    key written equals the one looked up at inference. Under COMPILE_ONLY the
+    launch only compiles+caches (no dispatch); building the launcher alone does
+    not, which is why these kernels were never AOT-built."""
+    from aiter.ops.flydsl.mxfp4_gemm1_kernels import flydsl_mxfp4_gemm1
+
+    d = _dummy()
+    flydsl_mxfp4_gemm1(
+        a_quant=d,
+        a_scale_sorted_shuffled=d,
+        w1_u8=d,
+        w1_scale_u8=d,
+        sorted_expert_ids=d,
+        cumsum_tensor=d,
+        m_indices=d,
+        inter_sorted_quant=d,
+        inter_sorted_shuffled_scale=d,
+        hidden_states=d,
+        n_tokens=job["BM"],
+        BM=job["BM"],
+        use_nt=job["use_nt"],
+        inline_quant=job["inline_quant"],
+        NE=job["NE"],
+        D_HIDDEN=job["D_HIDDEN"],
+        D_INTER=job["D_INTER"],
+        topk=job["topk"],
+    )
+
+
+def _compile_stage2(job):
+    """Trigger + persist the gemm2 @flyc.jit artifact via a COMPILE_ONLY launch."""
+    from aiter.ops.flydsl.mxfp4_gemm2_kernels import flydsl_mxfp4_gemm2
+
+    epilog = job["epilog"]
+    mxfp4out = epilog == "nonatomic_mxfp4"
+    d = _dummy()
+    flydsl_mxfp4_gemm2(
+        inter_sorted_quant=d,
+        inter_sorted_shuffled_scale=d,
+        w2_u8=d,
+        w2_scale_u8=d,
+        sorted_expert_ids=d,
+        cumsum_tensor=d,
+        sorted_token_ids=d,
+        sorted_weights=d,
+        flat_out=d,
+        M_logical=job["BM"],
+        max_sorted=job["BM"],
+        BM=job["BM"],
+        use_nt=job["use_nt"],
+        atomic=epilog == "atomic",
+        mxfp4out=mxfp4out,
+        NE=job["NE"],
+        D_HIDDEN=job["N_OUT"],
+        D_INTER=job["D_INTER"],
+        topk=job["topk"],
+        flat_out_scale=_dummy() if mxfp4out else None,
+        cshuffle=epilog == "nonatomic_cshuffle",
+        D_INTER_REAL=job["D_INTER_REAL"],
+    )
+
+
+def compile_one_config(**job):
+    """Compile + persist one mxfp4 port kernel into the FlyDSL disk cache.
+
+    ``COMPILE_ONLY=1`` makes the @flyc.jit launch compile and serialize the
+    artifact without dispatching a kernel, so dummy tensors are sufficient."""
+    stage = job["stage"]
+    shape_str = (
+        f"{job['kernel_name']} NE={job['NE']} D_INTER={job['D_INTER']} BM={job['BM']}"
+    )
+    result = {"kernel_name": job["kernel_name"], "stage": stage, "compile_time": None}
+
+    t0 = time.time()
+    try:
+        with compile_only_env():
+            if stage == 1:
+                _compile_stage1(job)
+            else:
+                _compile_stage2(job)
+        elapsed = time.time() - t0
+        result["compile_time"] = elapsed
+        print(f"  [OK] compile  {elapsed:6.1f}s  stage{stage}  {shape_str}")
+    except Exception as e:
+        print(f"  [FAIL] compile  stage{stage}  {shape_str}: {e}")
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="AOT pre-compile FlyDSL mxfp4 a4w4 MoE port kernels from fp4 tuned CSVs",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "--csv",
+        type=str,
+        nargs="+",
+        default=DEFAULT_CSVS,
+        help="Path(s) to fp4 tuned CSV(s); default: all *_fp4_tuned_fmoe.csv",
+    )
+    args = parser.parse_args()
+
+    csv_paths = [os.path.abspath(p) for p in args.csv]
+    for csv_path in csv_paths:
+        if not os.path.isfile(csv_path):
+            print(f"Error: CSV file not found: {csv_path}")
+            sys.exit(1)
+    if not csv_paths:
+        print("Error: no fp4 tuned CSVs found and none given via --csv")
+        sys.exit(1)
+
+    all_jobs = collect_aot_jobs(csv_paths, parse_csv)
+    stage1_jobs = [j for j in all_jobs if j["stage"] == 1]
+    stage2_jobs = [j for j in all_jobs if j["stage"] == 2]
+
+    print("=" * 72)
+    print("FlyDSL mxfp4 a4w4 MoE-port AOT Pre-compilation")
+    print("=" * 72)
+    for csv_path in csv_paths:
+        print(f"  CSV:          {csv_path}")
+    print(f"  Stage1 jobs:  {len(stage1_jobs)}")
+    print(f"  Stage2 jobs:  {len(stage2_jobs)}")
+    print(f"  Total jobs:   {len(all_jobs)}")
+    print("=" * 72)
+
+    total_t0 = time.time()
+    results = []
+    for i, job in enumerate(stage1_jobs + stage2_jobs, 1):
+        print(f"\n[{i}/{len(all_jobs)}] ", end="")
+        results.append(compile_one_config(**job))
+
+    ok = sum(1 for r in results if r["compile_time"] is not None)
+    fail = sum(1 for r in results if r["compile_time"] is None)
+    print("\n" + "=" * 72)
+    print("Summary")
+    print("=" * 72)
+    print(f"  Total time:   {time.time() - total_t0:.1f}s")
+    print(f"  Compiled:     {ok} ok, {fail} failed")
+    sys.exit(1 if fail else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/aiter/ops/flydsl/mxfp4_gemm1_kernels.py
+++ b/aiter/ops/flydsl/mxfp4_gemm1_kernels.py
@@ -12,6 +12,10 @@ import functools
 
 import torch
 
+# Shared low-overhead launch helper (flyc.compile + cached CompiledFunction).
+# Imported as a module so the AOT cache-miss gate's monkeypatch is seen here.
+from aiter.ops.flydsl import moe_kernels as _moe_kernels
+
 # Supported (BM, use_nt, inline_quant) variant combinations.
 _SUPPORTED = {
     (32, True, False),
@@ -105,18 +109,21 @@ def flydsl_mxfp4_gemm1(
     # gemm1 only needs base pointers (it assumes contiguity + derives sizes
     # from n_tokens / compile-time consts), so pass raw data_ptr() addresses
     # instead of full memref descriptors -> contiguous, coalescible kernargs.
-    launch(
-        a_quant.data_ptr(),
-        a_scale_sorted_shuffled.data_ptr(),
-        w1_u8.data_ptr(),
-        w1_scale_u8.data_ptr(),
-        sorted_expert_ids.data_ptr(),
-        cumsum_tensor.data_ptr(),
-        m_indices.data_ptr(),
-        n_tokens,
-        grid,
-        inter_sorted_quant.data_ptr(),
-        inter_sorted_shuffled_scale.data_ptr(),
-        hidden_states.data_ptr(),
-        torch.cuda.current_stream(),
+    _moe_kernels._run_compiled(
+        launch,
+        (
+            a_quant.data_ptr(),
+            a_scale_sorted_shuffled.data_ptr(),
+            w1_u8.data_ptr(),
+            w1_scale_u8.data_ptr(),
+            sorted_expert_ids.data_ptr(),
+            cumsum_tensor.data_ptr(),
+            m_indices.data_ptr(),
+            n_tokens,
+            grid,
+            inter_sorted_quant.data_ptr(),
+            inter_sorted_shuffled_scale.data_ptr(),
+            hidden_states.data_ptr(),
+            torch.cuda.current_stream(),
+        ),
     )

--- a/aiter/ops/flydsl/mxfp4_gemm2_kernels.py
+++ b/aiter/ops/flydsl/mxfp4_gemm2_kernels.py
@@ -18,6 +18,10 @@ import functools
 
 import torch
 
+# Shared low-overhead launch helper (see mxfp4_gemm1_kernels); imported as a
+# module so the AOT cache-miss gate's monkeypatch is seen here.
+from aiter.ops.flydsl import moe_kernels as _moe_kernels
+
 # Supported (BM, use_nt, epilog) combinations (mirrors the prebuilt HIP set).
 _SUPPORTED = {
     # atomic: BM in {16,32,64} x {ATOMIC, NT}
@@ -160,18 +164,21 @@ def flydsl_mxfp4_gemm2(
     # gemm2 only needs base pointers (assumes contiguity + derives sizes from
     # compile-time consts), so pass raw data_ptr() addresses instead of full
     # memref descriptors -> contiguous, coalescible kernargs (ported from gemm1).
-    launch(
-        inter_sorted_quant.data_ptr(),
-        inter_sorted_shuffled_scale.data_ptr(),
-        w2_u8.data_ptr(),
-        w2_scale_u8.data_ptr(),
-        sorted_expert_ids.data_ptr(),
-        cumsum_tensor.data_ptr(),
-        sorted_token_ids.data_ptr(),
-        sorted_weights.data_ptr(),
-        M_logical,
-        max_m_blocks,
-        flat_out.data_ptr(),
-        out_scale.data_ptr(),
-        torch.cuda.current_stream(),
+    _moe_kernels._run_compiled(
+        launch,
+        (
+            inter_sorted_quant.data_ptr(),
+            inter_sorted_shuffled_scale.data_ptr(),
+            w2_u8.data_ptr(),
+            w2_scale_u8.data_ptr(),
+            sorted_expert_ids.data_ptr(),
+            cumsum_tensor.data_ptr(),
+            sorted_token_ids.data_ptr(),
+            sorted_weights.data_ptr(),
+            M_logical,
+            max_m_blocks,
+            flat_out.data_ptr(),
+            out_scale.data_ptr(),
+            torch.cuda.current_stream(),
+        ),
     )


### PR DESCRIPTION
…or FlyDSL a4w4 MoE

Builds on the RadeonFlow FlyDSL a4w4 MoE port (dev/randomflow_pr); kernel codegen is left untouched. Adds only:

- AOT enablement: new OpKind.MXFP4_MOE driver (aot/flydsl/mxfp4_moe.py) that warms the FlyDSL disk cache from the guitlv tuned CSVs via COMPILE_ONLY dummy launches, keyed identically to the runtime entry points so inference hits the cache instead of JIT-compiling on first use.
- Launch latency: route gemm1/gemm2 launches through moe_kernels._run_compiled (flyc.compile + cached CompiledFunction) instead of calling launch() directly.
- A 128k-chunk MoE test.
