### PR TITLE
Revert "[Triton] Unify the scale and weight shuffling into shuffle.py"

### DIFF
--- a/aiter/ops/shuffle.py
+++ b/aiter/ops/shuffle.py
@@ -3,29 +3,31 @@
 
 import torch
 import torch.nn.functional as F
-
-from aiter.ops.triton.utils._triton.arch_info import get_arch
-
-# =============================================================================
-# WEIGHTS
-# =============================================================================
+from aiter.jit.utils.chip_info import get_gfx
 
 
-def _shuffle_weight_gfx1250(w: torch.Tensor) -> torch.Tensor:
-    """gfx1250 WMMA weight preshuffle
-    Callers wanting the flattened (N//16, K*16) / transposed (E, K*16, N//16) TDM
-    view reshape it.
+def shuffle_weight_gfx1250(w: torch.Tensor) -> torch.Tensor:
+    """
+    Preshuffle weights for gfx1250 WMMA.
+
+    For 2D input (N, K): view as (N//16, 16, K//32, 2, 16) ->
+        permute(0, 2, 3, 1, 4) -> reshape (N//16, K*16).
+    For 3D input (E, N, K) or (E, K, N): transpose to (E, N, K) first,
+        then apply the same pattern per-expert.
+
+    The result is reshaped to (N//16, K*16) for TDM-optimal loading.
     """
     x_type = w.dtype
     if hasattr(torch, "float4_e2m1fn_x2") and x_type == torch.float4_e2m1fn_x2:
         w = w.view(torch.uint8)
+
     if w.ndim == 2:
         N, K = w.shape
         assert N % 16 == 0, f"N={N} must be divisible by 16"
         assert K % 32 == 0, f"K={K} must be divisible by 32"
         w = w.view(N // 16, 16, K // 32, 2, 16)
         w = w.permute(0, 2, 3, 1, 4).contiguous()
-        w = w.view(N, K)
+        w = w.view(N // 16, K * 16)
     elif w.ndim == 3:
         E, K, N = w.shape
         assert K % 32 == 0, f"K={K} must be divisible by 32"
@@ -33,11 +35,12 @@ def _shuffle_weight_gfx1250(w: torch.Tensor) -> torch.Tensor:
         w = w.transpose(-1, -2)  # (E, N, K)
         w = w.view(E, N // 16, 16, K // 32, 2, 16)
         w = w.permute(0, 1, 3, 4, 2, 5).contiguous()
-        w = w.view(E, K, N)
+        w = w.view(E, N // 16, K * 16)
+        w = w.transpose(-1, -2)  # (E, K*16, N//16)
     else:
         raise ValueError(f"Expected 2D or 3D tensor, got {w.ndim}D")
+
     w = w.view(x_type)
-    w.is_shuffled = True
     return w
 
 
@@ -48,15 +51,7 @@ def shuffle_weight(
     is_guinterleave=False,
     gate_up: bool = False,
     pad_k_to: int = 0,
-    arch=None,
 ) -> torch.Tensor:
-    if (arch or get_arch()) == "gfx1250":
-        if use_int4 or is_guinterleave or gate_up or pad_k_to:
-            raise NotImplementedError(
-                "shuffle_weight on gfx1250 does not support use_int4 / is_guinterleave / gate_up / pad_k_to "
-            )
-        return _shuffle_weight_gfx1250(x)
-
     x_type = x.dtype
     if hasattr(torch, "float4_e2m1fn_x2") and x_type == torch.float4_e2m1fn_x2:
         x = x.view(torch.uint8)
@@ -141,12 +136,6 @@ def shuffle_weight_NK(
     return x_.view(*x.shape)
 
 
-# =============================================================================
-# SCALES
-# =============================================================================
-
-
-# --- MXFP4 / grouped-MoE (B) scales ---
 def shuffle_scale_n32k4(src: torch.Tensor, experts_cnt: int = None) -> torch.Tensor:
     """Shuffle a raw per-expert e8m0 weight (B) scale into the n32k4 layout.
 
@@ -241,11 +230,10 @@ def moe_shuffle_scale(
     experts_cnt: int = None,
     is_guinterleave: bool = False,
     gate_up: bool = False,
-    arch=None,
 ) -> torch.Tensor:
     """Arch-aware MoE weight (B) scale shuffle."""
 
-    if (arch or get_arch()) == "gfx1250":
+    if get_gfx() == "gfx1250":
         if is_guinterleave:
             raise ValueError(
                 "moe_shuffle_scale: is_guinterleave is not supported on gfx1250; "
@@ -266,7 +254,6 @@ def shuffle_scale_a16w4(
     )
 
 
-# --- int4 (W4A16) packing & scales ---
 def pack_int8_to_packed_int4(x_shuf_i8: torch.Tensor) -> torch.Tensor:
     """Pack a preshuffled int8 tensor (values in [-8, 7]) into packed int4 bytes.
 
@@ -309,145 +296,3 @@ def shuffle_scale_for_int4(scale: torch.Tensor, group_size: int = 32) -> torch.T
         return scale.view(E, G // 2, 2, N).permute(0, 1, 3, 2).contiguous()
 
     return scale.contiguous()
-
-
-# --- shared gfx1250 scale tile (GEMM + MoE) ---
-def _shuffle_scale_tile_gfx1250(scales, preshuffle_factor, scale_kwidth):
-    """Shared gfx1250 scale tile-permute over the last two dims.
-
-    row = the output M/N axis, packed into stripes of ``preshuffle_factor`` lanes
-    col = the scale-K axis (K_groups / K_SCALE), packed into ``scale_kwidth`` groups
-
-    Shared by the GEMM ((M, K_groups)) and MoE ((E, N, K_SCALE), transposed) gfx1250 scale shuffles.
-    """
-    # rows and cols grab the last two dims, and *batch collects everything before them into a list (possibly empty)
-    *batch, rows, cols = scales.shape
-    num_stripes = rows // preshuffle_factor
-    num_kchunks = cols // scale_kwidth
-    x = scales.reshape(-1, rows, cols)  # fold batch/expert dims into one axis
-    x = x.view(-1, num_stripes, preshuffle_factor, num_kchunks, scale_kwidth)
-    x = x.permute(0, 1, 3, 2, 4).contiguous()  # swap lanes <-> k-chunks
-    out = x.view(-1, num_stripes, cols * preshuffle_factor)
-    return out.reshape(*batch, num_stripes, cols * preshuffle_factor)
-
-
-# --- shared gfx950 scale tile (GEMM + MoE) ---
-def _shuffle_scale_tile_gfx950(scales, preshuffle_factor, scale_kwidth):
-    """Shared gfx950 (CDNA4) scale tile-permute over the last two dims.
-
-    row = the output M/N axis, packed into stripes of ``preshuffle_factor`` lanes (split 2 x preshuffle_factor//2)
-    col = the scale-K axis (K_groups / K_SCALE), packed into ``scale_kwidth`` groups (split 2 x scale_kwidth//2)
-
-    Shared by the GEMM ((M, K_groups)) and MoE ((E, N, K_SCALE), transposed) gfx950 scale shuffles.
-    """
-    # rows and cols grab the last two dims, and *batch collects everything before them into a list (possibly empty)
-    *batch, rows, cols = scales.shape
-    num_stripes = rows // preshuffle_factor
-    num_kchunks = cols // scale_kwidth
-    x = scales.reshape(-1, rows, cols)  # fold batch/expert dims into one axis
-    x = x.view(
-        -1, num_stripes, 2, preshuffle_factor // 2, num_kchunks, 2, scale_kwidth // 2, 1
-    )
-    x = x.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
-    out = x.view(-1, num_stripes, cols * preshuffle_factor)
-    return out.reshape(*batch, num_stripes, cols * preshuffle_factor)
-
-
-# --- GEMM scales (afp4wfp4) ---
-
-
-def shuffle_scale_gemm(
-    scales: torch.Tensor,
-    arch=None,
-    preshuffle_factor: int = 16,
-    scale_kwidth: int = 4,
-) -> torch.Tensor:
-    """Arch-aware GEMM scale shuffle.
-
-    Inverse: ``unshuffle_scale_gemm`` (gfx950 only).
-    gfx950: preshuffle_factor = 32, scale_kwidth = 8
-    gfx1250: preshuffle_factor = 16, scale_kwidth = 4
-    """
-    if (arch or get_arch()) == "gfx1250":
-        return _shuffle_scale_tile_gfx1250(scales, preshuffle_factor, scale_kwidth)
-
-    if (arch or get_arch()) == "gfx950":
-        return _shuffle_scale_tile_gfx950(scales, preshuffle_factor, scale_kwidth)
-    raise ValueError(f"Unsupported arch: {arch or get_arch()}")
-
-
-def unshuffle_scale_gemm(scales_shuffled: torch.Tensor, arch=None) -> torch.Tensor:
-    """Inverse of ``shuffle_scale_gemm`` (gfx950 layout). gfx1250 has no consumer."""
-    if (arch or get_arch()) == "gfx1250":
-        raise NotImplementedError("unshuffle_scale_gemm is not implemented for gfx1250")
-    scales = scales_shuffled.clone()
-    sm, sn = scales.shape
-    scales = scales.view(sm * 32, sn // 32)
-    sm, sn = scales.shape
-    scales = scales.view(sm // 32, sn // 8, 4, 16, 2, 2, 1)
-    scales = scales.permute(0, 5, 3, 1, 4, 2, 6).contiguous()
-    scales = scales.view(sm, sn)
-    return scales
-
-
-# --- MoE MX scales (a8w4 / a8w8 / a16w4 / a4w4) ---
-def shuffle_scale_moe(
-    data: torch.Tensor,
-    arch=None,
-    preshuffle_factor: int = 32,
-    scale_kwidth: int = 8,
-) -> torch.Tensor:
-    """Arch-aware MoE scale shuffle (a8w4 / a8w8 / a16w4 / a4w4 family).
-
-    Returns the shuffled scale tensor; the caller supplies the matching
-    ``SWIZZLE_MX_SCALE`` label ("GFX1250_SCALE" for gfx1250, "CDNA4_SCALE" for gfx950).
-    gfx950: preshuffle_factor = 32, scale_kwidth = 8
-    gfx1250: preshuffle_factor = 32, scale_kwidth = 8
-    """
-
-    arch = arch or get_arch()
-    if arch == "gfx1250":
-        tiled = _shuffle_scale_tile_gfx1250(
-            data.transpose(-1, -2), preshuffle_factor, scale_kwidth
-        )
-        return tiled.transpose(-1, -2)
-    if (arch or get_arch()) == "gfx950":
-        tiled = _shuffle_scale_tile_gfx950(
-            data.transpose(-1, -2), preshuffle_factor, scale_kwidth
-        )
-    return tiled.transpose(-1, -2)
-
-
-# --- batched scales (FP4 blockscale16, attention) ---
-def shuffle_scale_batched(data: torch.Tensor, scale_k_width=None) -> torch.Tensor:
-    """Batched shuffle scales for the FP4 blockscale16 format.
-
-    Single-layout permute, no arch branch: the blockscale16 layout is
-    arch-independent and is consumed by the FP4 MLA KV-cache path on both gfx950
-    and gfx1250
-    https://github.com/triton-lang/triton/blob/main/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py#L1014
-    """
-    data_shape = data.shape
-    N = data_shape[-2]
-    SCALE_K = data_shape[-1]
-    PRESHUFFLE_FACTOR = 128
-    if scale_k_width is None:
-        SCALE_KWIDTH = (
-            min(16, 1 << (SCALE_K - 1).bit_length()) if SCALE_K >= 4 else SCALE_K
-        )
-    else:
-        assert scale_k_width in [4, 8, 16]
-        SCALE_KWIDTH = scale_k_width if SCALE_K >= 4 else SCALE_K
-    data = data.view(
-        -1,
-        N // PRESHUFFLE_FACTOR,
-        4,
-        PRESHUFFLE_FACTOR // 4,
-        SCALE_K // SCALE_KWIDTH,
-        SCALE_KWIDTH,
-    )
-    data = data.permute(0, 1, 4, 3, 2, 5).contiguous()
-    data = data.view(
-        *data_shape[:-2], N // PRESHUFFLE_FACTOR, SCALE_K * PRESHUFFLE_FACTOR
-    )
-    return data

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_mxfp4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_mxfp4.py
@@ -88,9 +88,8 @@ def depreshuffle_scales(
     BLOCK_M: gl.constexpr,
     K_GROUPS: gl.constexpr,
 ):
-    # Inverse of host aiter.ops.shuffle.shuffle_scale_gemm (gfx1250 path):
-    # PRESHUFFLE_FACTOR rows are packed per stripe, SCALE_KWIDTH scale-groups
-    # contiguous per row.
+    # Inverse of host shuffle_scales_gfx1250: PRESHUFFLE_FACTOR rows are packed
+    # per stripe, SCALE_KWIDTH scale-groups contiguous per row.
     PRESHUFFLE_FACTOR: gl.constexpr = 16
     SCALE_KWIDTH: gl.constexpr = 4
     NUM_STRIPES: gl.constexpr = K_GROUPS // SCALE_KWIDTH
@@ -174,8 +173,7 @@ def gemm_mxfp4_preshuffle_gfx1250(
     BLOCK_K_BYTES: gl.constexpr = BLOCK_SIZE_K // FP4_ELEMS_PER_BYTE
     K_GROUPS: gl.constexpr = BLOCK_SIZE_K // SCALE_GROUP_ELEMS
     # Scale preshuffle: PRESHUFFLE_FACTOR rows packed per stripe, SCALE_KWIDTH
-    # scale-groups contiguous per row (must match the host
-    # aiter.ops.shuffle.shuffle_scale_gemm, gfx1250 path).
+    # scale-groups contiguous per row (must match the host shuffle_scales_gfx1250).
     PRESHUFFLE_FACTOR: gl.constexpr = 16
     SCALE_KWIDTH: gl.constexpr = 4
 

--- a/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
@@ -118,6 +118,19 @@ def get_kernel_config(m, n, k, routing_data):
     return ret
 
 
+def swizzle_scales(data):
+    NON_K_PRESHUFFLE_BLOCK_SIZE = 32
+    block_shape = data.shape
+    SCALE_K = block_shape[-2]
+    N = block_shape[-1]
+    data = data.transpose(-1, -2)
+    data = data.view(-1, N // NON_K_PRESHUFFLE_BLOCK_SIZE, 2, 16, SCALE_K // 8, 2, 4, 1)
+    data = data.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
+    E = block_shape[0]
+    data = data.reshape(E, N // 32, SCALE_K * 32)
+    return data.transpose(-1, -2)
+
+
 # -----------------------------------------------------------------------------
 # Triton Implementation
 # -----------------------------------------------------------------------------

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -114,6 +114,19 @@ def get_kernel_config(m, n, k, routing_data):
     return ret
 
 
+def swizzle_scales(data):
+    NON_K_PRESHUFFLE_BLOCK_SIZE = 32
+    block_shape = data.shape
+    SCALE_K = block_shape[-2]
+    N = block_shape[-1]
+    data = data.transpose(-1, -2)
+    data = data.view(-1, N // NON_K_PRESHUFFLE_BLOCK_SIZE, 2, 16, SCALE_K // 8, 2, 4, 1)
+    data = data.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
+    E = block_shape[0]
+    data = data.reshape(E, N // 32, SCALE_K * 32)
+    return data.transpose(-1, -2)
+
+
 # -----------------------------------------------------------------------------
 # Triton Implementation
 # -----------------------------------------------------------------------------

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -290,6 +290,50 @@ def get_kernel_config_gluon(m, n, k, routing_data):
     return ret
 
 
+def swizzle_scales_gfx950(data):
+    NON_K_PRESHUFFLE_BLOCK_SIZE = 32
+    block_shape = data.shape
+    SCALE_K = block_shape[-2]
+    N = block_shape[-1]
+    data = data.transpose(-1, -2)
+    data = data.view(-1, N // NON_K_PRESHUFFLE_BLOCK_SIZE, 2, 16, SCALE_K // 8, 2, 4, 1)
+    data = data.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
+    E = block_shape[0]
+    data = data.reshape(E, N // 32, SCALE_K * 32)
+    return data.transpose(-1, -2)
+
+
+def swizzle_scales_gfx1250(data):
+    E, K_SCALE, N = data.shape
+    preshuffle_factor = 32
+    num_chunk_n = N // preshuffle_factor
+    SCALE_KWIDTH = 8
+    num_chunk_k = K_SCALE // SCALE_KWIDTH
+
+    data = data.transpose(-1, -2)
+    data = data.view(E, num_chunk_n, 32, num_chunk_k, SCALE_KWIDTH)
+    data = data.permute(0, 1, 3, 2, 4).contiguous()
+    data = data.view(E, N // preshuffle_factor, K_SCALE * preshuffle_factor)
+    data = data.transpose(-1, -2)
+
+    return data
+
+
+def swizzle_scales(data):
+    """Arch-agnostic scale swizzle for moe_gemm_a8w4.
+
+    Returns (swizzled_data, layout_string) where layout_string is the
+    SWIZZLE_MX_SCALE value the kernel expects, or None for unknown arches.
+    """
+    arch = get_arch()
+    if arch == "gfx1250":
+        return swizzle_scales_gfx1250(data), "GFX1250_SCALE"
+    elif arch == "gfx950":
+        return swizzle_scales_gfx950(data), "CDNA4_SCALE"
+    else:
+        return data, None
+
+
 # -----------------------------------------------------------------------------
 # Triton Implementation
 # -----------------------------------------------------------------------------

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w8.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w8.py
@@ -113,6 +113,19 @@ def get_kernel_config(m, n, k, routing_data):
     return ret
 
 
+def swizzle_scales(data):
+    NON_K_PRESHUFFLE_BLOCK_SIZE = 32
+    block_shape = data.shape
+    SCALE_K = block_shape[-2]
+    N = block_shape[-1]
+    data = data.transpose(-1, -2)
+    data = data.view(-1, N // NON_K_PRESHUFFLE_BLOCK_SIZE, 2, 16, SCALE_K // 8, 2, 4, 1)
+    data = data.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
+    E = block_shape[0]
+    data = data.reshape(E, N // 32, SCALE_K * 32)
+    return data.transpose(-1, -2)
+
+
 # -----------------------------------------------------------------------------
 # Triton Implementation
 # -----------------------------------------------------------------------------

--- a/aiter/ops/triton/moe/moe_op_gemm_int8_smoothquant.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_int8_smoothquant.py
@@ -14,7 +14,6 @@ from aiter.ops.triton._gluon_kernels.gfx942.moe.moe_op_gemm_int8_smoothquant imp
 )
 from aiter.ops.triton.moe.reduce import reduce_grouped
 from aiter.ops.triton.utils._triton import arch_info
-from aiter.ops.shuffle import shuffle_weight
 
 # -----------------------------------------------------------------------------
 #                    Matrix Multiplication + Outer Gather/Scatter
@@ -35,26 +34,46 @@ def should_upcast_indices(*args):
 
 def preshuffle_weights(w: torch.Tensor) -> torch.Tensor:
     """
-    Preshuffle int8 weight from (E, K, N) to the MFMA-friendly tile layout
-    (E, K*16, N//16).
+    Preshuffle int8 weight from (E, K, N) to MFMA-friendly layout (E, N//16, K*16).
 
-    This is the same transpose-first per-expert (16, 16) tiling that
-    ``aiter.ops.shuffle.shuffle_weight`` produces on its gfx1250 path, so the
-    host-side shuffle stays single-sourced in ``aiter.ops.shuffle``. The matching
-    in-kernel inverse is ``unshuffle_weights`` in the int8 smoothquant kernel.
+    Matches the shuffle_weight pattern from aiter.ops.shuffle for INT8:
+      layout=(16, 16), BK=32, K_lane=16, BN=16
+
+    The transformation:
+      1. Transpose to (E, N, K)
+      2. View as (E, N//16, 16, K//32, 2, 16) - decompose into MFMA tile blocks
+      3. Permute to (E, N//16, K//32, 2, 16, 16) - reorder for register layout
+      4. View as (E, N//16, K*16) - flatten K dimension
 
     Args:
-        w: int8 weight tensor of shape (E, K, N) where K % 32 == 0 and N % 16 == 0.
+        w: int8 weight tensor of shape (E, K, N) where
+           - E = number of experts
+           - K = input dimension (must be divisible by 32)
+           - N = output dimension (must be divisible by 16)
 
     Returns:
-        Preshuffled weight tensor of shape (E, K * 16, N // 16).
+        Preshuffled weight tensor of shape (E, K * 16, N // 16)
     """
     assert w.dtype == torch.int8, f"Expected int8 weights, got {w.dtype}"
     assert w.ndim == 3, f"Expected 3D weight tensor (E, K, N), got {w.ndim}D"
     E, K, N = w.shape
-    # shuffle_weight returns the (E, K, N) shuffled weight; reshape to the
-    # (E, K*16, N//16) TDM layout the int8 smoothquant kernel consumes.
-    return shuffle_weight(w, arch="gfx1250").view(E, N // 16, K * 16).transpose(-1, -2)
+    assert K % 32 == 0, f"K ({K}) must be divisible by 32 for MFMA preshuffling"
+    assert N % 16 == 0, f"N ({N}) must be divisible by 16 for MFMA preshuffling"
+
+    # Transpose to (E, N, K)
+    w = w.transpose(1, 2)
+
+    # Preshuffle
+    w = w.view(E, N // 16, 16, K // 32, 2, 16)
+    w = w.permute(0, 1, 3, 4, 2, 5).contiguous()
+
+    # Reshape to (E, N // 16, K * 16)
+    w = w.view(E, N // 16, K * 16)
+
+    # Transpose back to (E, K, N)
+    w = w.transpose(1, 2)
+
+    return w
 
 
 def allocate_output(

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a16w4.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a16w4.py
@@ -11,8 +11,8 @@ from aiter.ops.triton.moe.moe_routing.routing import routing
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a16w4 import (
     moe_gemm_a16w4,
+    swizzle_scales,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 import tempfile
 from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
@@ -134,11 +134,9 @@ def compute_roofline(
             )
 
 
-def check_and_shuffle_scales(scale, N, K):
+def check_and_swizzle_scales(scale, N, K):
     if N % 32 == 0 and K % (32 * 8) == 0:
-        scale = shuffle_scale_moe(
-            scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        scale = swizzle_scales(scale)
         return scale, "CDNA4_SCALE"
     else:
         return scale, None
@@ -189,8 +187,8 @@ def bench_mlp_single_weight_init(
     wg, _ = quantize(wg, "bf16")
     w1, w1_scale = quantize(w1, w_dtype)
     w2, w2_scale = quantize(w2, w_dtype)
-    w1_scale, swizzle_mx_scale1 = check_and_shuffle_scales(w1_scale, dim2 // TP, dim1)
-    w2_scale, swizzle_mx_scale2 = check_and_shuffle_scales(
+    w1_scale, swizzle_mx_scale1 = check_and_swizzle_scales(w1_scale, dim2 // TP, dim1)
+    w2_scale, swizzle_mx_scale2 = check_and_swizzle_scales(
         w2_scale, dim1, dim2 // TP // 2
     )
 

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4.py
@@ -11,8 +11,8 @@ from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     mxfp4_quant,
     moe_gemm_a4w4,
+    swizzle_scales,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 import tempfile
 from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
@@ -129,11 +129,9 @@ def compute_roofline(
             w.writerow(row)
 
 
-def check_and_shuffle_scales(scale, N, K):
+def check_and_swizzle_scales(scale, N, K):
     if N % 32 == 0 and K % (32 * 8) == 0:
-        scale = shuffle_scale_moe(
-            scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        scale = swizzle_scales(scale)
         return scale, "CDNA4_SCALE"
     else:
         return scale, None
@@ -186,8 +184,8 @@ def bench_mlp_single_weight_init(
     wg, _ = quantize(wg, "bf16")
     w1, w1_scale = quantize(w1, w_dtype)
     w2, w2_scale = quantize(w2, w_dtype)
-    w1_scale, swizzle_mx_scale1 = check_and_shuffle_scales(w1_scale, dim2 // TP, dim1)
-    w2_scale, swizzle_mx_scale2 = check_and_shuffle_scales(
+    w1_scale, swizzle_mx_scale1 = check_and_swizzle_scales(w1_scale, dim2 // TP, dim1)
+    w2_scale, swizzle_mx_scale2 = check_and_swizzle_scales(
         w2_scale, dim1, dim2 // TP // 2
     )
 

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w4.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w4.py
@@ -11,8 +11,9 @@ from aiter.ops.triton.moe.moe_routing.routing import routing
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a8w4 import (
     moe_gemm_a8w4,
+    swizzle_scales_gfx950,
+    swizzle_scales_gfx1250,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 import tempfile
 from aiter.ops.triton.moe.quant_moe import downcast_to_static_fp8, downcast_to_mxfp
@@ -132,16 +133,12 @@ def compute_roofline(
             )
 
 
-def check_and_shuffle_scales(scale, N, K):
+def check_and_swizzle_scales(scale, N, K):
     if get_arch() == "gfx950" and N % 32 == 0 and K % (32 * 8) == 0:
-        scale = shuffle_scale_moe(
-            scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        scale = swizzle_scales_gfx950(scale)
         return scale, "CDNA4_SCALE"
     elif get_arch() == "gfx1250" and N % 32 == 0 and K % (32 * 8) == 0:
-        scale = shuffle_scale_moe(
-            scale, arch="gfx1250", preshuffle_factor=32, scale_kwidth=8
-        )
+        scale = swizzle_scales_gfx1250(scale)
         return scale, "GFX1250_SCALE"
     else:
         return scale, None
@@ -192,8 +189,8 @@ def bench_mlp_single_weight_init(
     wg, _ = quantize(wg, "bf16")
     w1, w1_scale = quantize(w1, w_dtype)
     w2, w2_scale = quantize(w2, w_dtype)
-    w1_scale, swizzle_mx_scale1 = check_and_shuffle_scales(w1_scale, dim2 // TP, dim1)
-    w2_scale, swizzle_mx_scale2 = check_and_shuffle_scales(
+    w1_scale, swizzle_mx_scale1 = check_and_swizzle_scales(w1_scale, dim2 // TP, dim1)
+    w2_scale, swizzle_mx_scale2 = check_and_swizzle_scales(
         w2_scale, dim1, dim2 // TP // 2
     )
 

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w8.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w8.py
@@ -11,8 +11,8 @@ from aiter.ops.triton.moe.moe_routing.routing import routing
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a8w8 import (
     moe_gemm_a8w8,
+    swizzle_scales,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 import tempfile
 from aiter.ops.triton.moe.quant_moe import (
@@ -134,11 +134,9 @@ def compute_roofline(
             )
 
 
-def check_and_shuffle_scales(scale, N, K):
+def check_and_swizzle_scales(scale, N, K):
     if N % 32 == 0 and K % (32 * 8) == 0:
-        scale = shuffle_scale_moe(
-            scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        scale = swizzle_scales(scale)
         return scale, "CDNA4_SCALE"
     else:
         return scale, None
@@ -197,10 +195,10 @@ def bench_mlp_single_weight_init(
         wg, _ = quantize(wg, "bf16")
         w1, w1_scale = quantize(w1, w_dtype)
         w2, w2_scale = quantize(w2, w_dtype)
-        w1_scale, swizzle_mx_scale1 = check_and_shuffle_scales(
+        w1_scale, swizzle_mx_scale1 = check_and_swizzle_scales(
             w1_scale, dim2 // TP, dim1
         )
-        w2_scale, swizzle_mx_scale2 = check_and_shuffle_scales(
+        w2_scale, swizzle_mx_scale2 = check_and_swizzle_scales(
             w2_scale, dim1, dim2 // TP // 2
         )
 

--- a/op_tests/triton_tests/attention/test_mla.py
+++ b/op_tests/triton_tests/attention/test_mla.py
@@ -9,9 +9,10 @@ from aiter.ops.triton.attention.mla import (
     mla_prefill_fwd,
     mla_decode_fwd,
 )
-from aiter.ops.shuffle import shuffle_weight, shuffle_scale_batched
+from aiter.ops.shuffle import shuffle_weight
 from op_tests.triton_tests.quant.test_quant_mxfp4 import (
     torch_dynamic_mxfp4_quant,
+    batched_swizzle_scales_gfx1250,
 )
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils.types import e4m3_dtype
@@ -119,12 +120,12 @@ def dynamic_nvfp4_quant_kv_buffer(
         cache_shuffled_scale = cache_shuffled_scale.view(
             -1, num_kv_heads, block_size, scale_width
         )
-        cache_shuffled = shuffle_weight(cache_shuffled, arch="gfx950").view(
+        cache_shuffled = shuffle_weight(cache_shuffled).view(
             -1, num_kv_heads, block_size * quant_head_size
         )
-        cache_shuffled_scale = shuffle_scale_batched(cache_shuffled_scale).view(
-            -1, num_kv_heads, block_size * scale_width
-        )
+        cache_shuffled_scale = batched_swizzle_scales_gfx1250(
+            cache_shuffled_scale
+        ).view(-1, num_kv_heads, block_size * scale_width)
         cache_shuffled = torch.cat(
             [
                 cache_shuffled.view(torch.uint8),

--- a/op_tests/triton_tests/attention/test_unified_attention.py
+++ b/op_tests/triton_tests/attention/test_unified_attention.py
@@ -10,9 +10,10 @@ from aiter.ops.triton.attention.unified_attention import (
     unified_attention,
     is_2d_gluon_available,
 )
-from aiter.ops.shuffle import shuffle_weight, shuffle_scale_batched
+from aiter.ops.shuffle import shuffle_weight
 from op_tests.triton_tests.quant.test_quant_mxfp4 import (
     torch_dynamic_mxfp4_quant,
+    batched_swizzle_scales_gfx1250,
 )
 from aiter.ops.triton.utils.types import e4m3_dtype
 import aiter.ops.triton.utils._triton.arch_info as arch_info
@@ -110,12 +111,12 @@ def dynamic_nvfp4_quant_kv_cache(
         cache_shuffled_scale = cache_shuffled_scale.view(
             -1, num_kv_heads, block_size, scale_width
         )
-        cache_shuffled = shuffle_weight(cache_shuffled, arch="gfx950").view(
+        cache_shuffled = shuffle_weight(cache_shuffled).view(
             -1, num_kv_heads, block_size * quant_head_size
         )
-        cache_shuffled_scale = shuffle_scale_batched(cache_shuffled_scale).view(
-            -1, num_kv_heads, block_size * scale_width
-        )
+        cache_shuffled_scale = batched_swizzle_scales_gfx1250(
+            cache_shuffled_scale
+        ).view(-1, num_kv_heads, block_size * scale_width)
         cache_shuffled = torch.cat(
             [
                 cache_shuffled.view(torch.uint8),

--- a/op_tests/triton_tests/fusions/test_fused_clamp_act_mul.py
+++ b/op_tests/triton_tests/fusions/test_fused_clamp_act_mul.py
@@ -11,7 +11,7 @@ from op_tests.triton_tests.quant.test_fused_fp8_quant import (
     per_token_fp8_group_quant,
     upcast,
 )
-from aiter.ops.shuffle import unshuffle_scale_gemm
+from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import un_shuffle_scales
 
 
 def _torch_reference(inp, swiglu_limit, weights, dtype_quant):
@@ -179,12 +179,8 @@ def test_fused_clamp_act_mul_ue8m0(M, D, swiglu_limit, with_weights, shuffle_sca
         expected = fp4_utils.e8m0_shuffle(ref_scale)
         assert scale.shape == expected.shape
         sm = scale.shape[0]
-        got = unshuffle_scale_gemm(scale.view(sm // 32, -1), arch="gfx950")[
-            :M, :num_blocks
-        ]
-        exp = unshuffle_scale_gemm(expected.view(sm // 32, -1), arch="gfx950")[
-            :M, :num_blocks
-        ]
+        got = un_shuffle_scales(scale.view(sm // 32, -1))[:M, :num_blocks]
+        exp = un_shuffle_scales(expected.view(sm // 32, -1))[:M, :num_blocks]
         assert torch.equal(got, exp)
         assert torch.equal(got, ref_scale)
     else:

--- a/op_tests/triton_tests/gemm/basic/test_gemm_a16wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_a16wfp4.py
@@ -5,7 +5,7 @@ from aiter.ops.triton.gemm.basic.gemm_a16wfp4 import (
     gemm_a16wfp4_preshuffle,
 )
 import aiter.ops.triton.utils._triton.arch_info as arch_info
-from aiter.ops.shuffle import shuffle_scale_gemm
+from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import shuffle_scales
 from aiter.ops.shuffle import shuffle_weight
 
 # Note this is specified by the HW and cannot be changed.
@@ -65,10 +65,7 @@ def generate_gemm_a16wfp4_inputs(
             w.shape[1] * weight_shuffle_layout[0],
         )
 
-        # CDNA4-only triton kernel -> always the gfx950 scale layout.
-        w_scales_shuffled = shuffle_scale_gemm(
-            w_scales, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        w_scales_shuffled = shuffle_scales(w_scales)
     else:
         w_shuffed = w
         w_scales_shuffled = w_scales

--- a/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
@@ -13,13 +13,52 @@ from aiter.ops.triton.gluon.gemm_afp4wfp4 import (
 
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils.types import str_to_torch_dtype
-from aiter.ops.shuffle import shuffle_weight, shuffle_scale_gemm
+from aiter.ops.shuffle import shuffle_weight, shuffle_weight_gfx1250
 
 DEVICE_ARCH = arch_info.get_arch()
 
 pytestmark = pytest.mark.skipif(
     not arch_info.is_fp4_avail(), reason="MXFP4 not supported on this architecture"
 )
+
+
+def shuffle_scales(scales: torch.Tensor):
+    scales_shuffled = scales.clone()
+    sm, sn = scales_shuffled.shape
+    scales_shuffled = scales_shuffled.view(sm // 32, 2, 16, sn // 8, 2, 4, 1)
+    scales_shuffled = scales_shuffled.permute(0, 3, 5, 2, 4, 1, 6).contiguous()
+    scales_shuffled = scales_shuffled.view(sm // 32, sn * 32)
+    return scales_shuffled
+
+
+def un_shuffle_scales(scales_shuffled: torch.Tensor):
+    scales = scales_shuffled.clone()
+    sm, sn = scales.shape
+    scales = scales.view(sm * 32, sn // 32)
+    sm, sn = scales.shape
+    scales = scales.view(sm // 32, sn // 8, 4, 16, 2, 2, 1)
+    scales = scales.permute(0, 5, 3, 1, 4, 2, 6).contiguous()
+    scales = scales.view(sm, sn)
+    return scales
+
+
+def shuffle_scales_gfx1250(scales: torch.Tensor):
+    # PRESHUFFLE_FACTOR = 16        rows packed per stripe
+    # SCALE_KWIDTH      = 4         scale-groups contiguous per row
+    # (4 scale-groups × 32 K-per-group = 128 K elems contiguous per row)
+    PRESHUFFLE_FACTOR = 16
+    SCALE_KWIDTH = 4
+    M, K_groups = scales.shape
+
+    out = scales.view(
+        M // PRESHUFFLE_FACTOR,
+        PRESHUFFLE_FACTOR,  # rows  →  (m_tile, lane)
+        K_groups // SCALE_KWIDTH,
+        SCALE_KWIDTH,  # cols  →  (k_tile, kg_in_lane)
+    )
+    out = out.permute(0, 2, 1, 3).contiguous()  # (m_tile, k_tile, lane, kg_in_lane)
+    out = out.view(M // PRESHUFFLE_FACTOR, K_groups * PRESHUFFLE_FACTOR)
+    return out
 
 
 # Note this is specified by the HW and cannot be changed.
@@ -79,32 +118,33 @@ def generate_gemm_afp4wfp4_inputs(
     if shuffle_scales_fg:
         if DEVICE_ARCH == "gfx1250":
             if M >= 32:
-                x_scales_shuffled = shuffle_scale_gemm(
-                    x_scales, arch="gfx1250", preshuffle_factor=16, scale_kwidth=4
-                )
+                x_scales_shuffled = shuffle_scales_gfx1250(x_scales)
             else:
                 x_scales_shuffled = x_scales.contiguous()
-            w_scales_shuffled = shuffle_scale_gemm(
-                w_scales, arch="gfx1250", preshuffle_factor=16, scale_kwidth=4
-            )
+            w_scales_shuffled = shuffle_scales_gfx1250(w_scales)
         else:
             if M >= 32:
-                x_scales_shuffled = shuffle_scale_gemm(
-                    x_scales, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-                )
+                x_scales_shuffled = shuffle_scales(x_scales)
             else:
                 x_scales_shuffled = x_scales.contiguous()
-            w_scales_shuffled = shuffle_scale_gemm(
-                w_scales, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-            )
+            w_scales_shuffled = shuffle_scales(w_scales)
     else:
         x_scales_shuffled = x_scales
         w_scales_shuffled = w_scales
 
     if shuffle_weight_fg:
-        # shuffle_weight returns the (N, K) shuffled weight on both arches; reshape
-        # to the (N//16, K*16) layout the kernel consumes
-        w_shuffed = shuffle_weight(w).reshape(w.shape[0] // 16, w.shape[1] * 16)
+        if DEVICE_ARCH == "gfx1250":
+            # gfx1250: simple reshape for TDM coalescing (no tile permutation)
+            w_shuffed = shuffle_weight_gfx1250(w)
+        else:
+            use_int4 = False
+            weight_shuffle_layout = (16, 16)
+            w_shuffed = shuffle_weight(
+                w, layout=weight_shuffle_layout, use_int4=use_int4
+            ).reshape(
+                w.shape[0] // weight_shuffle_layout[0],
+                w.shape[1] * weight_shuffle_layout[0],
+            )
     else:
         w_shuffed = w
 

--- a/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_split_cat.py
+++ b/op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_split_cat.py
@@ -16,7 +16,7 @@ from aiter.ops.triton.utils.types import str_to_torch_dtype
 
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.shuffle import shuffle_weight
-from aiter.ops.shuffle import shuffle_scale_gemm
+from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import shuffle_scales
 
 SCALE_GROUP_SIZE = 32
 
@@ -137,16 +137,11 @@ def generate_fused_gemm_afp4wfp4_split_cat_inputs(
     x_scale = x_scale.T
     w_scale = w_scale.T
     if shuffle:
-        # CDNA4-only triton kernel -> always the gfx950 scale layout.
         if M >= 32:
-            x_scales_shuffled = shuffle_scale_gemm(
-                x_scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-            )
+            x_scales_shuffled = shuffle_scales(x_scale)
         else:
             x_scales_shuffled = x_scale.contiguous()
-        w_scales_shuffled = shuffle_scale_gemm(
-            w_scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        w_scales_shuffled = shuffle_scales(w_scale)
         use_int4 = False
         weight_shuffle_layout = (16, 16)
         w_shuffed = shuffle_weight(

--- a/op_tests/triton_tests/moe/test_moe_gemm_a16w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a16w4.py
@@ -12,8 +12,8 @@ from aiter.ops.triton.moe.moe_routing.routing import routing
 from aiter.ops.triton.moe.moe_op_gemm_a16w4 import (
     moe_gemm_a16w4,
     moe_gemm_torch,
+    swizzle_scales,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 
 # numerics utilities
 from aiter.ops.triton.moe.quant_moe import (
@@ -271,9 +271,7 @@ def test_op(
     w_ref = upcast_from_mxfp(w_tri, w_scale_tri, torch.bfloat16, axis=1)
     if hbm_swizzling:
         swizzle_mx_scale = "CDNA4_SCALE"
-        w_scale_tri = shuffle_scale_moe(
-            w_scale_tri, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        w_scale_tri = swizzle_scales(w_scale_tri)
     else:
         swizzle_mx_scale = None
 

--- a/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
@@ -13,8 +13,8 @@ from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     mxfp4_quant,
     moe_gemm_a4w4,
     moe_gemm_torch,
+    swizzle_scales,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 
 # numerics utilities
 from aiter.ops.triton.moe.quant_moe import (
@@ -265,9 +265,7 @@ def test_op(
     w_ref = upcast_from_mxfp(w_tri, w_scale_tri, torch.bfloat16, axis=1)
     if hbm_swizzling:
         swizzle_mx_scale = "CDNA4_SCALE"
-        w_scale_tri = shuffle_scale_moe(
-            w_scale_tri, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        w_scale_tri = swizzle_scales(w_scale_tri)
     else:
         swizzle_mx_scale = None
 

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -12,8 +12,9 @@ from aiter.ops.triton.moe.moe_routing.routing import routing
 from aiter.ops.triton.moe.moe_op_gemm_a8w4 import (
     moe_gemm_a8w4,
     moe_gemm_torch,
+    swizzle_scales_gfx950,
+    swizzle_scales_gfx1250,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 
 # numerics utilities
 from aiter.ops.triton.moe.quant_moe import (
@@ -287,15 +288,11 @@ def test_op(
     if hbm_swizzling:
         if get_arch() == "gfx1250":
             swizzle_mx_scale = "GFX1250_SCALE"
-            w_scale_tri = shuffle_scale_moe(
-                w_scale_tri, arch="gfx1250", preshuffle_factor=32, scale_kwidth=8
-            )
+            w_scale_tri = swizzle_scales_gfx1250(w_scale_tri)
         else:
             assert get_arch() == "gfx950"
             swizzle_mx_scale = "CDNA4_SCALE"
-            w_scale_tri = shuffle_scale_moe(
-                w_scale_tri, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-            )
+            w_scale_tri = swizzle_scales_gfx950(w_scale_tri)
     else:
         swizzle_mx_scale = None
 

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w8.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w8.py
@@ -12,8 +12,8 @@ from aiter.ops.triton.moe.moe_routing.routing import routing
 from aiter.ops.triton.moe.moe_op_gemm_a8w8 import (
     moe_gemm_a8w8,
     moe_gemm_torch,
+    swizzle_scales,
 )
-from aiter.ops.shuffle import shuffle_scale_moe
 
 # numerics utilities
 from aiter.ops.triton.moe.quant_moe import (
@@ -361,9 +361,7 @@ def test_op(
         w_static_scale = None
         if hbm_swizzling:
             swizzle_mx_scale = "CDNA4_SCALE"
-            w_scale_tri = shuffle_scale_moe(
-                w_scale_tri, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-            )
+            w_scale_tri = swizzle_scales(w_scale_tri)
         else:
             swizzle_mx_scale = None
     else:

--- a/op_tests/triton_tests/quant/test_fused_mxfp4_quant.py
+++ b/op_tests/triton_tests/quant/test_fused_mxfp4_quant.py
@@ -15,7 +15,10 @@ from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import (
     SCALE_GROUP_SIZE,
 )
 import aiter.ops.triton.utils._triton.arch_info as arch_info
-from aiter.ops.shuffle import shuffle_scale_gemm, unshuffle_scale_gemm
+from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import (
+    shuffle_scales,
+    un_shuffle_scales,
+)
 from aiter.ops.quant import per_1x32_f4_quant_hip
 from aiter.utility.fp4_utils import moe_mxfp4_sort, dynamic_mxfp4_quant
 
@@ -75,9 +78,7 @@ def calculate_target_w_torch(
             (scaleM, scaleN), dtype=out1_scale.dtype, device=out1_scale.device
         )
         out1_scale_pad[:M, :scaleN_valid] = out1_scale[:M, :scaleN_valid]
-        out1_scale = shuffle_scale_gemm(
-            out1_scale_pad, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        out1_scale = shuffle_scales(out1_scale_pad)
         out1_scale = out1_scale.view(out1_scale.shape[0] * 32, -1)
 
     if x3 is not None:
@@ -208,11 +209,11 @@ def test_fused_rms_quant(
         torch.testing.assert_close(y1_torch, y1_triton)
 
     if shuffle:
-        y1_scales_triton = unshuffle_scale_gemm(
-            y1_scales_triton.view(y1_scales_triton.shape[0] // 32, -1), arch="gfx950"
+        y1_scales_triton = un_shuffle_scales(
+            y1_scales_triton.view(y1_scales_triton.shape[0] // 32, -1)
         )
-        y1_scales_torch = unshuffle_scale_gemm(
-            y1_scales_torch.view(y1_scales_torch.shape[0] // 32, -1), arch="gfx950"
+        y1_scales_torch = un_shuffle_scales(
+            y1_scales_torch.view(y1_scales_torch.shape[0] // 32, -1)
         )
 
     scaleN_valid = (N1 + 31) // 32
@@ -257,9 +258,7 @@ def run_torch_reduce_act_mul_mxfp4_group_quant(x, x2, activation, dtype, shuffle
             (scaleM, scaleN), dtype=out_scale.dtype, device=out_scale.device
         )
         out_scale_pad[:M, :scaleN] = out_scale[:M, :scaleN]
-        out_scale = shuffle_scale_gemm(
-            out_scale_pad, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        out_scale = shuffle_scales(out_scale_pad)
         out_scale = out_scale.view(out_scale.shape[0] * 32, -1)
     return (out, out_scale), y2
 
@@ -342,12 +341,8 @@ def test_fused_reduce_act_mul_mxfp4_group_quant(
     )
 
     if shuffle:
-        y_s_triton = unshuffle_scale_gemm(
-            y_s_triton.view(y_s_triton.shape[0] // 32, -1), arch="gfx950"
-        )
-        y_s_torch = unshuffle_scale_gemm(
-            y_s_torch.view(y_s_torch.shape[0] // 32, -1), arch="gfx950"
-        )
+        y_s_triton = un_shuffle_scales(y_s_triton.view(y_s_triton.shape[0] // 32, -1))
+        y_s_torch = un_shuffle_scales(y_s_torch.view(y_s_torch.shape[0] // 32, -1))
 
     torch.testing.assert_close(y2_torch, y2_triton, atol=0.1, rtol=0.1)
 
@@ -461,11 +456,11 @@ def test_fuse_reduce_rms_quant(
         torch.testing.assert_close(y3_torch, y3_triton)
 
     if shuffle:
-        y1_scales_triton = unshuffle_scale_gemm(
-            y1_scales_triton.view(y1_scales_triton.shape[0] // 32, -1), arch="gfx950"
+        y1_scales_triton = un_shuffle_scales(
+            y1_scales_triton.view(y1_scales_triton.shape[0] // 32, -1)
         )
-        y1_scales_torch = unshuffle_scale_gemm(
-            y1_scales_torch.view(y1_scales_torch.shape[0] // 32, -1), arch="gfx950"
+        y1_scales_torch = un_shuffle_scales(
+            y1_scales_torch.view(y1_scales_torch.shape[0] // 32, -1)
         )
 
     scaleN_valid = (N1 + 31) // 32

--- a/op_tests/triton_tests/quant/test_quant_mxfp4.py
+++ b/op_tests/triton_tests/quant/test_quant_mxfp4.py
@@ -3,6 +3,7 @@
 
 import torch
 import pytest
+import triton
 
 from aiter.ops.triton.quant import dynamic_mxfp4_quant
 from aiter.ops.triton.quant import dynamic_nvfp4_quant
@@ -16,6 +17,37 @@ import aiter.ops.triton.utils._triton.arch_info as arch_info
 DEVICE_ARCH = arch_info.get_arch()
 
 DEBUG_MODE = False
+
+
+def batched_swizzle_scales_gfx1250(data, scale_k_width=None):
+    """
+    Batched swizzle scales for FP4 blockscale16 format.
+       https://github.com/triton-lang/triton/blob/main/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py#L1014
+    """
+    data_shape = data.shape
+    N = data_shape[-2]
+    SCALE_K = data_shape[-1]
+    PRESHUFFLE_FACTOR = 128
+    if scale_k_width is None:
+        SCALE_KWIDTH = (
+            min(16, triton.next_power_of_2(SCALE_K)) if SCALE_K >= 4 else SCALE_K
+        )
+    else:
+        assert scale_k_width in [4, 8, 16]
+        SCALE_KWIDTH = scale_k_width if SCALE_K >= 4 else SCALE_K
+    data = data.view(
+        -1,
+        N // PRESHUFFLE_FACTOR,
+        4,
+        PRESHUFFLE_FACTOR // 4,
+        SCALE_K // SCALE_KWIDTH,
+        SCALE_KWIDTH,
+    )
+    data = data.permute(0, 1, 4, 3, 2, 5).contiguous()
+    data = data.view(
+        *data_shape[:-2], N // PRESHUFFLE_FACTOR, SCALE_K * PRESHUFFLE_FACTOR
+    )
+    return data
 
 
 def torch_dynamic_mxfp4_quant(

--- a/op_tests/triton_tests/test_activation.py
+++ b/op_tests/triton_tests/test_activation.py
@@ -2,7 +2,10 @@ import torch
 import torch.nn.functional as F
 import pytest
 from op_tests.triton_tests.quant.test_quant_mxfp4 import torch_dynamic_mxfp4_quant
-from aiter.ops.shuffle import shuffle_scale_gemm, unshuffle_scale_gemm
+from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import (
+    shuffle_scales,
+    un_shuffle_scales,
+)
 from aiter.ops.triton.activation import act_mul_and_mxfp4_quant
 import aiter.ops.triton.utils._triton.arch_info as arch_info
 
@@ -49,9 +52,7 @@ def torch_act_mul_and_mxfp4_quant(
             (scaleM, scaleN), dtype=out_scale.dtype, device=out_scale.device
         )
         out_scale_pad[:M, :scaleN] = out_scale[:M, :scaleN]
-        out_scale = shuffle_scale_gemm(
-            out_scale_pad, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
-        )
+        out_scale = shuffle_scales(out_scale_pad)
         out_scale = out_scale.view(out_scale.shape[0] * 32, -1)
     return out, out_scale
 
@@ -122,11 +123,11 @@ def test_act_mul_and_mxfp4_quant(
     )
 
     if shuffle:
-        triton_scale = unshuffle_scale_gemm(
-            triton_scale.view(triton_scale.shape[0] // 32, -1), arch="gfx950"
+        triton_scale = un_shuffle_scales(
+            triton_scale.view(triton_scale.shape[0] // 32, -1)
         )
-        torch_scale = unshuffle_scale_gemm(
-            torch_scale.view(torch_scale.shape[0] // 32, -1), arch="gfx950"
+        torch_scale = un_shuffle_scales(
+            torch_scale.view(torch_scale.shape[0] // 32, -1)
         )
 
     if DEBUG_MODE:


### PR DESCRIPTION
Reverts ROCm/aiter#3823. Impacted scale shuffle of gfx1250 gemm and moe.