### PR TITLE
Fix HIP fp8 paged-attention kPerHead scale OOB page fault.

### DIFF
--- a/csrc/cpp_itfs/pa/pa.cpp.jinja
+++ b/csrc/cpp_itfs/pa/pa.cpp.jinja
@@ -16,6 +16,7 @@
                       const int num_kv_heads,           \
                       const int num_heads,              \
                       const int max_num_blocks_per_seq, \
+                      const int num_kv_blocks,          \
                       const int q_stride,               \
                       const int kv_block_stride,        \
                       const int kv_head_stride,         \
@@ -72,7 +73,8 @@ FUNCTION_DEFINE
                                     block_tables_ptr,                  
                                     context_lens_ptr,
                                     nullptr,            
-                                    max_num_blocks_per_seq,          
+                                    max_num_blocks_per_seq,
+                                    num_kv_blocks,
                                     alibi_slopes_ptr,               
                                     q_stride,                       
                                     kv_block_stride,                

--- a/csrc/cpp_itfs/pa/pa.cuh
+++ b/csrc/cpp_itfs/pa/pa.cuh
@@ -61,6 +61,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const int* __restrict__ context_lens,   // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,   // [num_seqs]
     const int max_num_blocks_per_seq,
+    const int num_kv_blocks,
     const float* __restrict__ alibi_slopes, // [num_heads]
     const int q_stride,
     const int kv_block_stride,
@@ -82,7 +83,6 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const int rowid                  = laneid / 16;
 
     const auto seq_idx   = blockIdx.x;
-    const int num_blocks = max_num_blocks_per_seq * gridDim.x;
     // NOTE queries with sequence len > 1 are prefills and taken care by another
     // kernel.
     if(query_start_loc_ptr != nullptr &&
@@ -484,11 +484,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
                     }
                     else if constexpr(QUANT_METHOD == vllm::Fp8QuantMethod::kPerHead)
                     {
-                        const int klocal_token_idx =
-                            TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
-                        const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
                         const int k_scale_idx =
-                            wg_start_kv_head_idx * num_blocks * BLOCK_SIZE + kglobal_token_idx;
+                            wg_start_kv_head_idx * num_kv_blocks * BLOCK_SIZE +
+                            kphysical_block_number[token_depth] * BLOCK_SIZE +
+                            kphysical_block_offset[token_depth];
                         d_out[gqa_ratio_loop][mtp][token_depth] *=
                             k_scale_ptr ? *(k_scale_ptr + k_scale_idx) : float(1.0);
                     }
@@ -768,15 +767,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
                         }
                         else if constexpr(QUANT_METHOD == vllm::Fp8QuantMethod::kPerHead)
                         {
-                            const int vlocal_token_idx =
-                                vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
-                                rowid * VTOKENS_PER_LANE;
-                            // Safe to use an int32_t here assuming we are working with < 2 billion
-                            // tokens
-                            const int vglobal_token_idx =
-                                partition_start_token_idx + vlocal_token_idx;
                             const int v_scale_idx =
-                                wg_start_kv_head_idx * num_blocks * BLOCK_SIZE + vglobal_token_idx;
+                                wg_start_kv_head_idx * num_kv_blocks * BLOCK_SIZE +
+                                vphysical_block_number[vtoken_depth] * BLOCK_SIZE +
+                                vphysical_block_offset[vtoken_depth];
                             v_scale = v_scale_ptr ? *(v_scale_ptr + v_scale_idx) : float(1.0);
                         }
 
@@ -955,6 +949,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const int* __restrict__ context_lens,    // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
     const int max_num_blocks_per_seq,
+    const int num_kv_blocks,
     const float* __restrict__ alibi_slopes,  // [num_heads]
     const int q_stride,
     const int kv_block_stride,
@@ -964,6 +959,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     output_t* __restrict__ out,               // [num_seqs, num_heads, max_num_partitions, head_size]
     const float* q_scale_ptr,
     const float* k_scale_ptr, const float* v_scale_ptr) {
+  (void)num_kv_blocks;
   UNREACHABLE_CODE
 }
 

--- a/csrc/cpp_itfs/pa/pa.py
+++ b/csrc/cpp_itfs/pa/pa.py
@@ -105,6 +105,25 @@ def validate_paged_attention_rocm_buffers(
         )
 
 
+def _normalize_hip_fp8_scale(scale, key_cache, block_size, num_kv_heads):
+    """Convert vLLM block-major scales to HIP head-major layout."""
+    if scale is None:
+        return scale
+    num_kv_blocks = key_cache.size(0)
+    if (
+        scale.dim() == 3
+        and scale.size(0) == num_kv_blocks
+        and scale.size(1) == num_kv_heads
+        and scale.size(2) == block_size
+    ):
+        return (
+            scale.permute(1, 0, 2)
+            .contiguous()
+            .view(num_kv_heads, num_kv_blocks * block_size)
+        )
+    return scale
+
+
 def paged_attention_rocm(
     out,
     exp_sums,
@@ -161,12 +180,20 @@ def paged_attention_rocm(
     head_size = query.size(2)
     q_stride = query.stride(0)
     max_num_blocks_per_seq = block_tables.size(1)
+    num_kv_blocks = key_cache.size(0)
     kv_block_stride = key_cache.stride(0)
     kv_head_stride = key_cache.stride(1)
     gqa_ratio = int(num_heads / num_kv_heads)
     max_num_partitions = int(math.ceil(max_context_len / partition_size))
     npar_loops = int(math.ceil(max_num_partitions / warpSize))
     v_shuffle = value_cache.dim() == 5
+
+    key_scale = _normalize_hip_fp8_scale(
+        key_scale, key_cache, block_size, num_kv_heads
+    )
+    value_scale = _normalize_hip_fp8_scale(
+        value_scale, key_cache, block_size, num_kv_heads
+    )
 
     quant_method = "vllm::Fp8QuantMethod::kPerTensor"
     if key_scale is not None:
@@ -276,6 +303,7 @@ def paged_attention_rocm(
         num_kv_heads,
         num_heads,
         max_num_blocks_per_seq,
+        num_kv_blocks,
         q_stride,
         kv_block_stride,
         kv_head_stride,

--- a/csrc/cpp_itfs/pa/pa.py
+++ b/csrc/cpp_itfs/pa/pa.py
@@ -188,9 +188,7 @@ def paged_attention_rocm(
     npar_loops = int(math.ceil(max_num_partitions / warpSize))
     v_shuffle = value_cache.dim() == 5
 
-    key_scale = _normalize_hip_fp8_scale(
-        key_scale, key_cache, block_size, num_kv_heads
-    )
+    key_scale = _normalize_hip_fp8_scale(key_scale, key_cache, block_size, num_kv_heads)
     value_scale = _normalize_hip_fp8_scale(
         value_scale, key_cache, block_size, num_kv_heads
     )


### PR DESCRIPTION
Use physical KV block count and physical block offsets for fp8 scale indexing instead of block-table width, and normalize vLLM block-major scales to the HIP head-major layout before launch.

## Motivation

HIP pa kernel with SHUFFLED layout  is producing a page fault on certain inputs.

## Technical Details

number of physical pages is now passed down explicitly as an argument rather then being  derived by the kernel.

## Test Plan

Re-run the reproducer from Mikko Tukiainen and make sure it pass for both asm and hip.

## Test Result

No more gpu faults.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
