### PR TITLE
[Communication] add quickreduce int3

### DIFF
--- a/aiter/dist/device_communicators/quick_all_reduce.py
+++ b/aiter/dist/device_communicators/quick_all_reduce.py
@@ -18,11 +18,13 @@ logger = logging.getLogger(__name__)
 
 
 class QuickReduceRegime(Enum):
+    # Keep integer ids aligned with csrc/include/quick_all_reduce.cuh
     FP = 0
     FP8 = 1
     INT6 = 2
     INT4 = 3
-    NONE = 4
+    INT3 = 4
+    NONE = 5
 
 
 try:
@@ -62,14 +64,16 @@ class QuickAllReduce:
     _SUPPORTED_WORLD_SIZES = [2, 4, 8]
     _SUPPORTED_DTYPES = [torch.float16, torch.bfloat16]
     # The following data is based on kernel tests.
-    # In this order [FP, FP8, INT6, INT4].
+    # In this order [FP, FP8, INT6, INT4, INT3].
+    # INT3 is TP2-only; its entries for world_size 4/8 are unused but kept
+    # to keep the per-quant-level list indexable by QuickReduceRegime.value.
     _QR_MIN_SIZE = {
-        (torch.float16, 2): [1 * MB, 2 * MB, 2 * MB, 1 * MB],
-        (torch.float16, 4): [1 * MB, 16 * MB, 4 * MB, 2 * MB],
-        (torch.float16, 8): [16 * MB, 4 * MB, 4 * MB, 8 * MB],
-        (torch.bfloat16, 2): [2 * MB, 8 * MB, 8 * MB, 8 * MB],
-        (torch.bfloat16, 4): [8 * MB, 64 * MB, 64 * MB, 16 * MB],
-        (torch.bfloat16, 8): [16 * MB, 2048 * MB, 2048 * MB, 2048 * MB],
+        (torch.float16, 2): [1 * MB, 2 * MB, 2 * MB, 1 * MB, 1 * MB],
+        (torch.float16, 4): [1 * MB, 16 * MB, 4 * MB, 2 * MB, 2 * MB],
+        (torch.float16, 8): [16 * MB, 4 * MB, 4 * MB, 8 * MB, 8 * MB],
+        (torch.bfloat16, 2): [2 * MB, 8 * MB, 8 * MB, 8 * MB, 8 * MB],
+        (torch.bfloat16, 4): [8 * MB, 64 * MB, 64 * MB, 16 * MB, 16 * MB],
+        (torch.bfloat16, 8): [16 * MB, 2048 * MB, 2048 * MB, 2048 * MB, 2048 * MB],
     }
 
     def __init__(
@@ -77,8 +81,10 @@ class QuickAllReduce:
     ) -> None:
         """
         Quick allreduce leverages quantization for further
-        acceleration on ROCm. It currently supports FP8, Q6, and Q4
-        quantization formats and FP(float16, bfloat16).
+        acceleration on ROCm. It currently supports FP8, Q6, Q4, and Q3
+        quantization formats and FP(float16, bfloat16). Q3 (INT3) is
+        restricted to TP2 (world_size == 2) due to poor performance on
+        larger world sizes.
         Quick allreduce is designed as a complement to custom allreduce.
         Its initialization requires even stricter conditions.
         Only the ROCm MI300 series is supported for quick allreduce at
@@ -192,6 +198,22 @@ class QuickAllReduce:
             )
             return
         self.qr_quant_level = QuickReduceRegime[regime_str]
+
+        # INT3 is only enabled for TP2 (world_size == 2).
+        # Kernel benchmarks show INT3 all-reduce on TP4/TP8 has poor
+        # performance (the extra ranks make the 3-bit codec's pack/unpack
+        # overhead outweigh the reduced communication volume), so INT3 is
+        # restricted to 2-GPU tensor parallelism. For TP4/TP8 use a wider
+        # codec (e.g. INT4) or NONE instead.
+        if self.qr_quant_level == QuickReduceRegime.INT3 and self.world_size != 2:
+            logger.warning(
+                "Custom quick allreduce is disabled: INT3 quantization is "
+                "only supported for TP2 (world_size == 2), but world_size "
+                "is %d. INT3 on TP4/TP8 is disabled due to poor kernel "
+                "performance. Use INT4/NONE for this world size.",
+                self.world_size,
+            )
+            return
 
         # TODO: If the dtype is not bfloat16 or then float16,
         # quickallreduce should not be created.

--- a/csrc/include/quick_all_reduce.cuh
+++ b/csrc/include/quick_all_reduce.cuh
@@ -214,6 +214,170 @@ struct CodecQ4 : public CodecBase
     }
 };
 
+// Int3 symmetric quantization codec.
+// We quantize the FP16 data to block-scaled Int3 in blocks of 4 *
+// kThreadGroupSize. Uniform symmetric quantization (round-to-int + clip),
+// matching the structure of CodecQ4. Signed range is [-4, +3].
+template <typename T, int world_size>
+struct CodecQ3 : public CodecBase
+{
+    static constexpr int kWorldSize = world_size;
+
+    // Layout per quantization block (32 values = 8 threads * 4 fp16x2 lanes):
+    //  - each thread owns 8 values and writes:
+    //      * q2 payload : 8 * 2 bits -> uint16 (2 bytes)
+    //      * q1 payload : 8 * 1 bit  -> uint8  (1 byte)
+    //  - one scale is shared per 32 values and written by group leader.
+    //
+    // kRankTileStride is split as:
+    //   [0   .. 511] : q2 payload region (256 threads * 2 bytes)
+    //   [512 .. 767] : q1 payload region (256 threads * 1 byte)
+    //   [768 .. 895] : scale region (32 groups * 4 bytes)
+    static constexpr int kRankAtoms               = kAtoms / kWorldSize;
+    static constexpr int kRankTileStride          = 896;
+    static constexpr int kRankTileQ1Offset        = 512;
+    static constexpr int kRankTileScaleOffset     = 768;
+    static constexpr int kRankTransmittedTileSize = kRankTileStride * kRankAtoms;
+    static_assert(kRankTransmittedTileSize % 16 == 0,
+                  "kRankTransmittedTileSize must be 16B aligned.");
+
+    static constexpr int kRankBufferTileStride = kRankTileStride / sizeof(int32x4_t);
+
+    // Total tile size for the collective communication.
+    static constexpr int kTransmittedTileSize = kRankTransmittedTileSize * kWorldSize;
+
+    // {-1/4.0h, -1/4.0h}, f16x2_t / bf16x2_t. Sign-flipped so absmax maps
+    // to -4; the sign cancels with decoding_scale on the recv side.
+    static constexpr int kScaleFactor = std::is_same<T, half>::value ? 0xB400B400 : 0xBE80BE80;
+
+    // {1e-7, 1e-7}, f16x2_t
+    static constexpr int kScaleEpsilon = std::is_same<T, half>::value ? 0x00010001 : 0x33D733D7;
+
+    // {-4, -4}, f16x2_t / bf16x2_t
+    static constexpr int kRangeMin = std::is_same<T, half>::value ? 0xC400C400 : 0xC080C080;
+
+    // {+3, +3}, f16x2_t / bf16x2_t
+    static constexpr int kRangeMax = std::is_same<T, half>::value ? 0x42004200 : 0x40404040;
+
+    // {+4, +4}, int16x2_t -- shifts signed [-4, +3] to unsigned [0, 7].
+    static constexpr int kRangeBias = 0x00040004;
+
+    __quickreduce_device_inline__ CodecQ3(int thread, int rank) : CodecBase(thread, rank) {}
+
+    __quickreduce_device_inline__ void send(int32x4_t* __restrict__ send_buffer,
+                                            const int32x4_t* __restrict__ data)
+    {
+        for(int k = 0; k < kRankAtoms; k++)
+        {
+            int32x4_t const atom = data[k];
+
+            // 1) Per-group dynamic scale (shared across 32 values).
+            int wblockmax      = group_abs_max<T>(atom);
+            int decoding_scale = packed_mul<T>(wblockmax, kScaleFactor);
+            int encoding_scale = packed_add<T>(decoding_scale, kScaleEpsilon);
+            encoding_scale     = packed_rcp<T>(encoding_scale);
+
+            // 2) Scale + clip to signed int3 range [-4, +3].
+            int32x4_t w;
+            for(int i = 0; i < 4; i++)
+            {
+                w[i] = packed_mul<T>(atom[i], encoding_scale);
+                w[i] = packed_max<T>(w[i], kRangeMin);
+                w[i] = packed_min<T>(w[i], kRangeMax);
+            }
+
+            // 3) Round to integer and bias to unsigned domain [0, 7].
+            int32x4_t q;
+            {
+                int16_t* qi = reinterpret_cast<int16_t*>(&q);
+                T* wh       = reinterpret_cast<T*>(&w);
+                for(int i = 0; i < 8; i++)
+                    qi[i] = (int16_t)rintf(T2float_cast(wh[i]));
+
+                for(int i = 0; i < 4; i++)
+                {
+                    q[i] = packed_add<int16_t>(q[i], kRangeBias);
+                }
+            }
+
+            // 4) Split each 3-bit unsigned value into low-2-bit and high-1-bit
+            // halves, packed into one uint16 (low 2 bits per value) plus one
+            // uint8 (high 1 bit per value).
+            uint16_t q2w = 0;
+            uint8_t q1w  = 0;
+            {
+                int16_t* tw = reinterpret_cast<int16_t*>(&q);
+#pragma unroll
+                for(int i = 0; i < 8; i++)
+                {
+                    uint32_t v = static_cast<uint32_t>(tw[i]) & 0x7u;
+                    q2w |= static_cast<uint16_t>((v & 0x3u) << (i * 2));
+                    q1w |= static_cast<uint8_t>(((v >> 2) & 0x1u) << i);
+                }
+            }
+
+            uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+            uint16_t* q2w_ptr = reinterpret_cast<uint16_t*>(atom_ptr) + thread;
+            uint8_t* q1w_ptr  = reinterpret_cast<uint8_t*>(atom_ptr + kRankTileQ1Offset) + thread;
+            int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+            __builtin_nontemporal_store(q2w, q2w_ptr);
+            *q1w_ptr = q1w;
+            if(threadIdx.x == group_leader)
+            {
+                __builtin_nontemporal_store(decoding_scale, qs_ptr);
+            }
+        }
+    }
+
+    __quickreduce_device_inline__ void recv(int32x4_t** __restrict__ recv_buffer,
+                                            int32x4_t* __restrict__ data)
+    {
+        for(int k = 0; k < kRankAtoms; k++)
+        {
+            uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+            uint16_t* q2w_ptr = reinterpret_cast<uint16_t*>(atom_ptr) + thread;
+            uint8_t* q1w_ptr  = reinterpret_cast<uint8_t*>(atom_ptr + kRankTileQ1Offset) + thread;
+            int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+            uint16_t q2w = __builtin_nontemporal_load(q2w_ptr);
+            uint8_t q1w  = *q1w_ptr;
+            int qs       = __builtin_nontemporal_load(qs_ptr);
+
+            *recv_buffer += kRankBufferTileStride;
+
+            // Unpack unsigned values [0, 7] then shift back to signed domain
+            // [-4, +3] by adding kRangeMin.
+            int32x4_t w;
+            {
+                int16_t qv[8];
+#pragma unroll
+                for(int i = 0; i < 8; i++)
+                {
+                    uint32_t low2  = (q2w >> (2 * i)) & 0x3u;
+                    uint32_t high1 = (q1w >> i) & 0x1u;
+                    qv[i]          = static_cast<int16_t>(low2 | (high1 << 2));
+                }
+
+#pragma unroll
+                for(int i = 0; i < 4; i++)
+                {
+                    int qpack = packed_from_int16_pair<T>(qv[2 * i], qv[2 * i + 1]);
+                    w[i]      = packed_add<T>(qpack, kRangeMin);
+                }
+            }
+
+            // Apply decode scale to reconstruct fp16/bf16 lanes.
+            for(int i = 0; i < 4; i++)
+            {
+                w[i] = packed_mul<T>(w[i], qs);
+            }
+
+            data[k] = w;
+        }
+    }
+};
+
 // Int6 symmetric quantization codec.
 // We quantize the FP16 data to block-scaled Int6 in blocks of 4 *
 // kThreadGroupSize.
@@ -849,12 +1013,42 @@ allreduce_prototype_twoshot(T const* A,
                            this->kMaxProblemSize);                            \
     }
 
+// INT3 only retains good performance on TP2 (world_size == 2). On TP4/TP8 the
+// 3-bit codec's pack/unpack overhead outweighs the reduced communication
+// volume, so INT3 is restricted to a TP2-only dispatch here.
+#define TWOSHOT_DISPATCH_TP2_ONLY(__codec)                                                  \
+    if(world_size == 2)                                                                     \
+    {                                                                                       \
+        using LineCodec       = __codec<T, 2>;                                              \
+        using AllReduceKernel = AllReduceTwoshot<T, LineCodec, cast_bf2half>;               \
+        hipLaunchKernelGGL((allreduce_prototype_twoshot<AllReduceKernel, T>),               \
+                           dim3(grid),                                                      \
+                           dim3(kBlockTwoShot),                                             \
+                           0,                                                               \
+                           stream,                                                          \
+                           A,                                                               \
+                           B,                                                               \
+                           N,                                                               \
+                           num_blocks,                                                      \
+                           rank,                                                            \
+                           dbuffer_list,                                                    \
+                           data_offset,                                                     \
+                           flag_color,                                                      \
+                           this->kMaxProblemSize);                                          \
+    }                                                                                       \
+    else                                                                                    \
+    {                                                                                       \
+        throw std::runtime_error("INT3 quick all-reduce is only supported for world_size "  \
+                                 "== 2 (TP2); use INT4/NONE for larger world sizes.");      \
+    }
+
 enum QuickReduceQuantLevel
 {
     F16  = 0,
     FP8  = 1,
     INT6 = 2,
     INT4 = 3,
+    INT3 = 4,
 };
 
 struct DeviceComms
@@ -983,6 +1177,7 @@ struct DeviceComms
         case QuickReduceQuantLevel::FP8: TWOSHOT_DISPATCH(CodecFP8) break;
         case QuickReduceQuantLevel::INT6: TWOSHOT_DISPATCH(CodecQ6) break;
         case QuickReduceQuantLevel::INT4: TWOSHOT_DISPATCH(CodecQ4) break;
+        case QuickReduceQuantLevel::INT3: TWOSHOT_DISPATCH_TP2_ONLY(CodecQ3) break;
         default: TWOSHOT_DISPATCH(CodecFP) break;
         }
         HIP_CHECK(hipGetLastError());

--- a/csrc/include/quick_all_reduce_base.h
+++ b/csrc/include/quick_all_reduce_base.h
@@ -311,6 +311,28 @@ __quickreduce_device_inline__ int packed_rcp<__hip_bfloat16>(int a)
     return R.i;
 }
 
+template <typename T>
+__quickreduce_device_inline__ int packed_from_int16_pair(int16_t low, int16_t high);
+
+template <>
+__quickreduce_device_inline__ int packed_from_int16_pair<half>(int16_t low, int16_t high)
+{
+    // Convert two signed integers to one fp16x2 packed 32-bit lane.
+    half2 h =
+        __halves2half2(__int2half_rn(static_cast<int>(low)), __int2half_rn(static_cast<int>(high)));
+    return __builtin_bit_cast(int, h);
+}
+
+template <>
+__quickreduce_device_inline__ int packed_from_int16_pair<__hip_bfloat16>(int16_t low, int16_t high)
+{
+    // Convert two signed integers to one bf16x2 packed 32-bit lane.
+    nv_bfloat16 bf_low  = __float2bfloat16(static_cast<float>(low));
+    nv_bfloat16 bf_high = __float2bfloat16(static_cast<float>(high));
+    nv_bfloat162 bf2    = __halves2bfloat162(bf_low, bf_high);
+    return *reinterpret_cast<int*>(&bf2);
+}
+
 // changes dtype
 __quickreduce_device_inline__ float T2float_cast(half a) { return __half2float(a); }
 

--- a/csrc/kernels/quick_all_reduce.cu
+++ b/csrc/kernels/quick_all_reduce.cu
@@ -97,19 +97,27 @@ int64_t qr_max_size() {
     template struct AllReduceTwoshot<T, Codec<T, 4>, cast_bf2half>;          \
     template struct AllReduceTwoshot<T, Codec<T, 8>, cast_bf2half>;          \
 
+  // INT3 (CodecQ3) is restricted to TP2 only, so we only instantiate the
+  // world_size == 2 kernel for it.
+  #define INSTANTIATE_FOR_WORLDSIZE_TP2_ONLY(T, Codec, cast_bf2half)                \
+    template struct AllReduceTwoshot<T, Codec<T, 2>, cast_bf2half>;
+
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecFP, false)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecQ4, false)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecQ6, false)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecFP8, false)
+INSTANTIATE_FOR_WORLDSIZE_TP2_ONLY(__hip_bfloat16, CodecQ3, false)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecFP, true)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecQ4, true)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecQ6, true)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecFP8, true)
+INSTANTIATE_FOR_WORLDSIZE_TP2_ONLY(__hip_bfloat16, CodecQ3, true)
 
 INSTANTIATE_FOR_WORLDSIZE(half, CodecFP, false)
 INSTANTIATE_FOR_WORLDSIZE(half, CodecQ4, false)
 INSTANTIATE_FOR_WORLDSIZE(half, CodecQ6, false)
 INSTANTIATE_FOR_WORLDSIZE(half, CodecFP8, false)
+INSTANTIATE_FOR_WORLDSIZE_TP2_ONLY(half, CodecQ3, false)
 
 #endif  // USE_ROCM
 } // namespace aiter

--- a/op_tests/multigpu_tests/test_quick_all_reduce.py
+++ b/op_tests/multigpu_tests/test_quick_all_reduce.py
@@ -99,10 +99,13 @@ def test_allreduce_quick(
     dtype,
     withGraph=False,
     distributed_init_method: Optional[str] = None,
+    quantization: str = "INT4",
 ):
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = "49373"
-    os.environ["AITER_QUICK_REDUCE_QUANTIZATION"] = "INT4"
+    # Quantization regime: FP / FP8 / INT6 / INT4 / INT3 / NONE.
+    # INT3 is only supported on TP2 (world_size == 2).
+    os.environ["AITER_QUICK_REDUCE_QUANTIZATION"] = quantization
     pool = Pool(processes=tp_size)
     ref = torch.zeros(shape, dtype=dtype)
     rets = []
@@ -167,7 +170,7 @@ def qr_variable_input(rank, world_size):
             s2 = 2048
             inp1 = torch.ones((s1, s2), dtype=dtype, device=torch.cuda.current_device())
         result = torch.empty_like(inp1)
-        # FP = 0 INT8 = 1 INT6 = 2 INT4 = 3 NONE = 4
+        # FP = 0 FP8 = 1 INT6 = 2 INT4 = 3 INT3 = 4 NONE = 5
         ops.qr_all_reduce(_ptr, inp1, result, 3, cast_bf2half=True)
         try:
             if inp1[0, 0] == 0:
@@ -254,6 +257,21 @@ if __name__ == "__main__":
                 distributed_init_method=get_distributed_init_method(
                     get_ip(), get_open_port()
                 ),
+            )
+
+    # INT3 quantization is only supported on TP2 (world_size == 2).
+    for dtype in l_dtype:
+        for shape in l_shape:
+            test_allreduce_quick(
+                2,
+                1,
+                shape,
+                dtype,
+                withGraph=False,
+                distributed_init_method=get_distributed_init_method(
+                    get_ip(), get_open_port()
+                ),
+                quantization="INT3",
             )
 
     # check variable input for qr


### PR DESCRIPTION
1.According to our kernel experiments, INT3 demonstrated better performance under TP2 (see figure below), but
under TP=4 and TP=8 conditions, the performance of INT3 and INT4 was very close.
This is likely because, as TP increases, the number of GPUs that need to communicate with each other grows exponentially, thereby requiring more synchronization and scheduling time;
In this scenario, synchronization and latency overhead—rather than the amount of data being transferred—gradually become the bottleneck. Consequently, the proportion of total time saved by further bit-width compression (INT3) decreases, and its benefits diminish accordingly.

2.On accuracy, INT3 preserves accuracy well across the MoE models and the stronger dense model; the only model with a clearly visible drop is Qwen3-32B. Our analysis is as follows:

On one hand, compared to INT4, INT3 has fewer quantization levels (8 vs 16) and therefore injects more quantization noise. The three MoE models (DeepSeek-V4-Flash, MiniMax-M2.5, and Qwen3-235B-A22B) are the most robust — each retains at least 99% of its baseline accuracy (Accuracy Recovery 0.9922, 0.9953, and 1.0055, respectively). For MoE models, the output is a weighted sum of multiple experts, and combined with their larger parameter redundancy and hidden dimension, the quantization noise is further diluted and averaged out during computation, making them less sensitive.

On the other hand, the determining factor is the strength of the baseline rather than the Dense-vs-MoE distinction. Qwen3-32B is the only model with a notable drop (Accuracy Recovery 0.9462), and it already has a low GSM8K baseline (0.62), indicating limited inherent capability: many problems sit near the decision boundary, so the extra noise introduced by INT3 can easily flip their conclusions. By contrast, the other dense model, Qwen2.5-72B-Instruct, has a stronger baseline (0.712) and is essentially unaffected (Accuracy Recovery 1.0122). For models that are inherently strong and have high baseline scores, most problems are answered with high confidence, and 3-bit noise is not enough to change the correct outcome.


**kernel test**
<img width="866" height="522" alt="image" src="https://github.com/user-attachments/assets/a4f73c02-4474-4fba-bcae-be4aaa017974" />


**ACC&Performance test**
**Server launch command:**
```
VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT3 vllm serve <model_path> \
    --no-enable-prefix-caching \
    --trust-remote-code \
    -tp 2 \
    --dtype auto \
    --port 12340
```

**Client commands:**

```
# Accuracy evaluation
python3 vllm/tests/evals/gsm8k/gsm8k_eval.py --port 12340

# Performance benchmark
vllm bench serve \
    --model <model_path> \
    --backend vllm \
    --endpoint /v1/completions \
    --dataset-name random \
    --random-input-len 4096 \
    --random-output-len 10 \
    --num-prompts 500 \
    --ignore-eos \
    --request-rate inf \
    --max-concurrency 128 \
    --port 12340
```
#### DeepSeek-V4-Flash (MoE)

| Quantization | TTFT (ms) | TPOT (ms) | Output Throughput (tok/s) | TTFT Speedup | TPOT Speedup | Throughput Gain | GSM8K  | Accuracy Recovery |
|:------------:|----------:|----------:|--------------------------:|-------------:|-------------:|----------------:|-------:|------------------:|
| NONE         |  26226.98 |    519.49 |                     37.50 |        1.000 |        1.000 |           1.000 | 0.9447 |            1.0000 |
| INT4         |  24329.79 |    479.63 |                     40.55 |        1.078 |        1.083 |           1.081 | 0.9443 |            0.9996 |
| **INT3**     |**23794.17**|**465.70**|                **41.48**  |    **1.102** |    **1.116** |       **1.106** | 0.9373 |            0.9922 |

#### Qwen3-32B (Dense)

| Quantization | TTFT (ms) | TPOT (ms) | Output Throughput (tok/s) | TTFT Speedup | TPOT Speedup | Throughput Gain | GSM8K  | Accuracy Recovery |
|:------------:|----------:|----------:|--------------------------:|-------------:|-------------:|----------------:|-------:|------------------:|
| NONE         |  25671.79 |    513.31 |                     37.94 |        1.000 |        1.000 |           1.000 | 0.6200 |            1.0000 |
| INT4         |  19903.11 |    395.44 |                     48.83 |        1.290 |        1.298 |           1.287 | 0.6670 |            1.0758 |
| **INT3**     |**18962.92**|**377.71**|                **51.20**  |    **1.354** |    **1.359** |       **1.349** | 0.5867 |            0.9462 |

#### Qwen2.5-72B-Instruct (Dense)

| Quantization | TTFT (ms)  | TPOT (ms) | Output Throughput (tok/s) | TTFT Speedup | TPOT Speedup | Throughput Gain | GSM8K  | Accuracy Recovery |
|:------------:|-----------:|----------:|--------------------------:|-------------:|-------------:|----------------:|-------:|------------------:|
| NONE         |   48670.30 |    971.36 |                     20.06 |        1.000 |        1.000 |           1.000 | 0.7120 |            1.0000 |
| INT4         |   35127.15 |    698.54 |                     27.69 |        1.386 |        1.391 |           1.380 | 0.7290 |            1.0239 |
| **INT3**     |**33363.36**|**664.74** |                **29.11**  |    **1.459** |    **1.461** |       **1.451** | 0.7207 |            1.0122 |

#### MiniMax-M2.5 (MoE)

| Quantization | TTFT (ms) | TPOT (ms) | Output Throughput (tok/s) | TTFT Speedup | TPOT Speedup | Throughput Gain | GSM8K  | Accuracy Recovery |
|:------------:|----------:|----------:|--------------------------:|-------------:|-------------:|----------------:|-------:|------------------:|
| NONE         |  18668.83 |    372.06 |                     52.06 |        1.000 |        1.000 |           1.000 | 0.9317 |            1.0000 |
| INT4         |  15575.94 |    304.56 |                     62.67 |        1.199 |        1.222 |           1.204 | 0.9307 |            0.9989 |
| **INT3**     |**15121.72**|**295.86**|                **64.54**  |    **1.235** |    **1.258** |       **1.240** | 0.9273 |            0.9953 |

#### Qwen3-235B-A22B (MoE)

| Quantization | TTFT (ms) | TPOT (ms) | Output Throughput (tok/s) | TTFT Speedup | TPOT Speedup | Throughput Gain | GSM8K  | Accuracy Recovery |
|:------------:|----------:|----------:|--------------------------:|-------------:|-------------:|----------------:|-------:|------------------:|
| NONE         |  33496.04 |    673.56 |                     28.88 |        1.000 |        1.000 |           1.000 | 0.9067 |            1.0000 |
| INT4         |  26412.86 |    531.00 |                     36.50 |        1.268 |        1.268 |           1.264 | 0.9057 |            0.9989 |
| **INT3**     |**25501.79**|**512.93**|                **37.75**  |    **1.313** |    **1.313** |       **1.307** | 0.9117 |            1.0055 |



