### PR TITLE
[HOTFIX][OPUS] enable fp8/bf8 scaled converters on gfx1200/gfx1201/gfx1250

### DIFF
--- a/csrc/include/aiter_opus_plus.h
+++ b/csrc/include/aiter_opus_plus.h
@@ -51,7 +51,8 @@ OPUS_D decltype(auto) fp32_to_fp8_scaled_x2(const S& s, float inverted_scale)
     constexpr float hi = 448.0f, lo = -448.0f;
 #endif
     float a = tmp[0], b = tmp[1];
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || \
+    defined(__gfx1201__) || defined(__gfx1250__)
     int w;
     asm volatile("v_med3_f32 %1, %1, %3, %4\n"
                  "v_med3_f32 %2, %2, %3, %4\n"
@@ -82,7 +83,8 @@ OPUS_D decltype(auto) fp32_to_bf8_scaled_x2(const S& s, float inverted_scale)
     fp32x2_t tmp       = pk_mul_f32(s, fp32x2_t{inverted_scale, inverted_scale});
     constexpr float hi = 57344.0f, lo = -57344.0f;
     float a = tmp[0], b = tmp[1];
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || \
+    defined(__gfx1201__) || defined(__gfx1250__)
     int w;
     asm volatile("v_med3_f32 %1, %1, %3, %4\n"
                  "v_med3_f32 %2, %2, %3, %4\n"


### PR DESCRIPTION
fp32_to_fp8_scaled_x2 and fp32_to_bf8_scaled_x2 in csrc/include/aiter_opus_plus.h guarded the real v_cvt_pk_{fp8,bf8}_f32 path with #if defined(__gfx942__) || defined(__gfx950__).

On gfx1250 (and the RDNA4 arches gfx1200/gfx1201) compilation therefore fell through to the #else compile-stub, which returns fp8x2_t{} / bf8x2_t{} — all zeros. Any kernel that goes through these scaled converters (fp8 KV-cache, quant, etc.) silently produced all-zero / garbage output on those arches.

opus.hpp::fp32_to_fp8 already treats {gfx942, gfx950, gfx1200, gfx1201, gfx1250} as the packed-cvt-capable set, and ck_tile::vec_convert uses the identical inline asm. This change simply aligns the scaled converters with that authoritative whitelist.

Notes:
- The non-gfx942 saturation clamp (OCP E4M3 448.0f / bf8 57344.0f) already covers gfx1200/gfx1201/gfx1250, so no clamp change is needed.
- RDNA3/3.5 (gfx1100/gfx115x) and host correctly remain on the compile-stub, where fp8/bf8 conversion is never executed.
- The x4 variants and the cast dispatchers call into these x2 functions, so they inherit the fix.