### PR TITLE
flydsl: gfx942 FP8 MQA logits indexer kernel (+ Triton FN/FNUZ fix)

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -41,6 +41,11 @@ if is_flydsl_available():
     from .moe_kernels import flydsl_moe_stage1, flydsl_moe_stage2
     from .fmha_kernels import flydsl_flash_attn_func
     from .kernels.qk_norm_rope_quant import flydsl_qk_norm_rope_quant
+    from .kernels.fp8_mqa_logits import (
+        flydsl_fp8_mqa_logits,
+        KERNEL_VARIANTS as FP8_MQA_LOGITS_VARIANTS,
+        DEFAULT_VARIANT as FP8_MQA_LOGITS_DEFAULT_VARIANT,
+    )
 
     # from .linear_attention_kernels import flydsl_gdr_decode
 
@@ -51,5 +56,8 @@ if is_flydsl_available():
         "flydsl_hgemm",
         "flydsl_flash_attn_func",
         "flydsl_qk_norm_rope_quant",
+        "flydsl_fp8_mqa_logits",
+        "FP8_MQA_LOGITS_VARIANTS",
+        "FP8_MQA_LOGITS_DEFAULT_VARIANT",
         # "flydsl_gdr_decode",
     ]

--- a/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
+++ b/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
@@ -121,17 +121,23 @@ def _build_kernel_mfma_r_w(
     WPB = waves_per_block
     MR_BLOCK_THREADS = 64 * WPB
 
-    assert H % 16 == 0, f"num_heads={H} must be a multiple of 16 for MFMA"
-    assert BKV % 16 == 0, f"block_kv={BKV} must be a multiple of 16 for MFMA"
-    assert D % 32 == 0, f"head_size={D} must be a multiple of 32 for MFMA K32"
+    # MFMA tile dims of the fp8 16x16x32 atom: MFMA_M x MFMA_N output tile,
+    # MFMA_K fp8 elements reduced per MFMA step.
+    MFMA_M = 16
+    MFMA_N = 16
+    MFMA_K = 32
+
+    assert H % MFMA_M == 0, f"num_heads={H} must be a multiple of MFMA_M={MFMA_M}"
+    assert BKV % MFMA_N == 0, f"block_kv={BKV} must be a multiple of MFMA_N={MFMA_N}"
+    assert D % MFMA_K == 0, f"head_size={D} must be a multiple of MFMA_K={MFMA_K}"
     assert RPB >= 1, "rows_per_block must be >= 1"
     assert WPB >= 1, "waves_per_block must be >= 1"
-    N_TILES = BKV // 16  # total column-tiles per BKV block
+    N_TILES = BKV // MFMA_N  # total column-tiles per BKV block
     assert (
         N_TILES % WPB == 0
-    ), f"BKV/16={N_TILES} must be divisible by waves_per_block={WPB}"
-    M_TILES = H // 16  # head row-tiles
-    K_STEPS = D // 32  # K32 MFMA steps over the head dim
+    ), f"BKV/MFMA_N={N_TILES} must be divisible by waves_per_block={WPB}"
+    M_TILES = H // MFMA_M  # head row-tiles
+    K_STEPS = D // MFMA_K  # MFMA K-steps over the head dim
     N_TILES_PER_WAVE = N_TILES // WPB  # column-tiles per wave
 
     fm_fast = arith.FastMathFlags.fast
@@ -175,9 +181,9 @@ def _build_kernel_mfma_r_w(
         # Decompose tid into wave index and in-wave lane.
         wave = fx.Int32(arith.divui(_to_raw(tid), _to_raw(fx.Int32(64))))
         lane = fx.Int32(arith.remui(_to_raw(tid), _to_raw(fx.Int32(64))))
-        lane_div_16 = fx.Int32(arith.divui(_to_raw(lane), _to_raw(fx.Int32(16))))
-        lane_mod_16 = fx.Int32(arith.remui(_to_raw(lane), _to_raw(fx.Int32(16))))
-        lane8 = fx.Int32(arith.muli(_to_raw(lane_div_16), _to_raw(fx.Int32(8))))
+        lane_div_N = fx.Int32(arith.divui(_to_raw(lane), _to_raw(fx.Int32(MFMA_N))))
+        lane_mod_N = fx.Int32(arith.remui(_to_raw(lane), _to_raw(fx.Int32(MFMA_N))))
+        lane8 = fx.Int32(arith.muli(_to_raw(lane_div_N), _to_raw(fx.Int32(8))))
 
         # fp8 operands are read 8 bytes at a time as 2 i32 dwords (v8i8
         # buffer_load fails to lower on gfx942), bitcast to i64 for the MFMA.
@@ -260,29 +266,30 @@ def _build_kernel_mfma_r_w(
             starts[j] = fx.Int32(arith.maxsi(_to_raw(s), _to_raw(fx.Int32(0))))
             ends[j] = fx.Int32(arith.minsi(_to_raw(e), _to_raw(fx.Int32(seq_len_kv))))
 
-            # lane -> Q[row, h = mi*16 + lane%16, d = kk*32 + (lane//16)*8 + 0..7]
+            # lane -> Q[row, h = mi*MFMA_M + lane%MFMA_N,
+            #            d = kk*MFMA_K + (lane//MFMA_N)*8 + 0..7]
             row_a = [[None] * K_STEPS for _ in range_constexpr(M_TILES)]
             for mi in range_constexpr(M_TILES):
-                h_a = _i32_add(fx.Int32(mi * 16), lane_mod_16)
+                h_a = _i32_add(fx.Int32(mi * MFMA_M), lane_mod_N)
                 row_h = _i32_add(
                     fx.Int32(arith.muli(_to_raw(row), _to_raw(fx.Int32(H)))), h_a
                 )
                 base_a = fx.Int32(arith.muli(_to_raw(row_h), _to_raw(fx.Int32(D))))
                 for kk in range_constexpr(K_STEPS):
-                    d_a = _i32_add(fx.Int32(kk * 32), lane8)
+                    d_a = _i32_add(fx.Int32(kk * MFMA_K), lane8)
                     raw = _load_pack_i64(q_i32, _i32_add(base_a, d_a))
                     row_a[mi][kk] = _fn_to_fnuz_i64(raw) if convert_q_fn else raw
             a_packs[j] = row_a
 
-            # weights[row, h] preloaded per (mi, ii): head = mi*16 + lane_div_16*4 + ii
+            # weights[row, h] per (mi, ii): head = mi*MFMA_M + lane_div_N*4 + ii
             row_w = [[None] * 4 for _ in range_constexpr(M_TILES)]
             for mi in range_constexpr(M_TILES):
                 for ii in range_constexpr(4):
                     h_w = _i32_add(
-                        fx.Int32(mi * 16),
+                        fx.Int32(mi * MFMA_M),
                         _i32_add(
                             fx.Int32(
-                                arith.muli(_to_raw(lane_div_16), _to_raw(fx.Int32(4)))
+                                arith.muli(_to_raw(lane_div_N), _to_raw(fx.Int32(4)))
                             ),
                             fx.Int32(ii),
                         ),
@@ -338,9 +345,11 @@ def _build_kernel_mfma_r_w(
                 col = _i32_add(
                     _i32_add(
                         col0,
-                        fx.Int32(arith.muli(_to_raw(abs_ni), _to_raw(fx.Int32(16)))),
+                        fx.Int32(
+                            arith.muli(_to_raw(abs_ni), _to_raw(fx.Int32(MFMA_N)))
+                        ),
                     ),
-                    lane_mod_16,
+                    lane_mod_N,
                 )
                 cols[ni] = col
                 col_clamped = fx.Int32(
@@ -353,7 +362,7 @@ def _build_kernel_mfma_r_w(
                     arith.muli(_to_raw(col_clamped), _to_raw(fx.Int32(D)))
                 )
                 for kk in range_constexpr(K_STEPS):
-                    d_b = _i32_add(fx.Int32(kk * 32), lane8)
+                    d_b = _i32_add(fx.Int32(kk * MFMA_K), lane8)
                     raw = _load_pack_i64(kv_i32, _i32_add(base_b, d_b))
                     b_packs[ni][kk] = _fn_to_fnuz_i64(raw) if convert_kv_fn else raw
 
@@ -392,7 +401,7 @@ def _build_kernel_mfma_r_w(
                         peer = _to_raw(ArithValue(col_sum).shuffle_xor(sh, 64))
                         col_sum = arith.AddFOp(col_sum, peer, fastmath=fm_fast).result
 
-                    # Only lane_div_16==0 lanes hold the 16 distinct columns.
+                    # Only lane_div_N==0 lanes hold the MFMA_N distinct columns.
                     # `col >= start` is required: the tile loop is BKV-aligned
                     # below `start`, so it guards the pre-filled -inf in
                     # [aligned_start, start).
@@ -416,7 +425,7 @@ def _build_kernel_mfma_r_w(
                         _to_raw(
                             arith.cmpi(
                                 arith.CmpIPredicate.eq,
-                                _to_raw(lane_div_16),
+                                _to_raw(lane_div_N),
                                 _to_raw(fx.Int32(0)),
                             )
                         ),

--- a/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
+++ b/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
@@ -63,8 +63,9 @@ def _device_cu_count(device_index: int) -> int:
         return 304
 
 
-def _auto_num_splits(seq_len_padded: int, seq_len_kv: int, rpb: int,
-                     device_index: int) -> int:
+def _auto_num_splits(
+    seq_len_padded: int, seq_len_kv: int, rpb: int, device_index: int
+) -> int:
     """KV-column splits (grid.y) to fill the device when the row grid is small.
 
     For small-M / large-N shapes the ``ceil(seq_len/RPB)`` row grid leaves the
@@ -83,9 +84,16 @@ def _auto_num_splits(seq_len_padded: int, seq_len_kv: int, rpb: int,
     return max(1, min(math.ceil(target_blocks / grid_x), max_splits))
 
 
-def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
-                           rows_per_block: int, waves_per_block: int,
-                           convert_q_fn: bool = False, convert_kv_fn: bool = False):
+def _build_kernel_mfma_r_w(
+    *,
+    num_heads: int,
+    head_size: int,
+    block_kv: int,
+    rows_per_block: int,
+    waves_per_block: int,
+    convert_q_fn: bool = False,
+    convert_kv_fn: bool = False,
+):
     """Multi-row, multi-wave MFMA kernel.
 
     ``rows_per_block`` query rows share one KV tile load (cuts KV traffic by RPB).
@@ -116,13 +124,13 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
     assert D % 32 == 0, f"head_size={D} must be a multiple of 32 for MFMA K32"
     assert RPB >= 1, "rows_per_block must be >= 1"
     assert WPB >= 1, "waves_per_block must be >= 1"
-    N_TILES = BKV // 16                       # total column-tiles per BKV block
-    assert N_TILES % WPB == 0, (
-        f"BKV/16={N_TILES} must be divisible by waves_per_block={WPB}"
-    )
-    M_TILES = H // 16                         # head row-tiles
-    K_STEPS = D // 32                         # K32 MFMA steps over the head dim
-    N_TILES_PER_WAVE = N_TILES // WPB         # column-tiles per wave
+    N_TILES = BKV // 16  # total column-tiles per BKV block
+    assert (
+        N_TILES % WPB == 0
+    ), f"BKV/16={N_TILES} must be divisible by waves_per_block={WPB}"
+    M_TILES = H // 16  # head row-tiles
+    K_STEPS = D // 32  # K32 MFMA steps over the head dim
+    N_TILES_PER_WAVE = N_TILES // WPB  # column-tiles per wave
 
     fm_fast = arith.FastMathFlags.fast
     mfma_fn = rocdl.mfma_f32_16x16x32_fp8_fp8
@@ -136,17 +144,17 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
 
     @flyc.kernel(name=_kname, known_block_size=[MR_BLOCK_THREADS, 1, 1])
     def kernel(
-        Q: fx.Tensor,            # [seq_len, H, D]       fp8 (bytes passed raw)
-        KV: fx.Tensor,           # [seq_len_kv, D]       fp8 (bytes passed raw)
-        kv_scales: fx.Tensor,    # [seq_len_kv]          f32
-        weights: fx.Tensor,      # [seq_len, H]          f32
-        cu_starts: fx.Tensor,    # [seq_len]             i32
-        cu_ends: fx.Tensor,      # [seq_len]             i32
-        logits: fx.Tensor,       # [seq_len, seq_len_kv] f32
-        seq_len: fx.Int32,       # padded to a multiple of RPB
+        Q: fx.Tensor,  # [seq_len, H, D]       fp8 (bytes passed raw)
+        KV: fx.Tensor,  # [seq_len_kv, D]       fp8 (bytes passed raw)
+        kv_scales: fx.Tensor,  # [seq_len_kv]          f32
+        weights: fx.Tensor,  # [seq_len, H]          f32
+        cu_starts: fx.Tensor,  # [seq_len]             i32
+        cu_ends: fx.Tensor,  # [seq_len]             i32
+        logits: fx.Tensor,  # [seq_len, seq_len_kv] f32
+        seq_len: fx.Int32,  # padded to a multiple of RPB
         seq_len_kv: fx.Int32,
         stride_logits_s: fx.Int32,
-        num_splits: fx.Int32,    # grid.y KV-column splits (1 == no split)
+        num_splits: fx.Int32,  # grid.y KV-column splits (1 == no split)
     ):
         f32_0 = arith.constant(0.0, type=T.f32)
         mfma_res_ty = Vec.make_type(4, fx.Float32)
@@ -155,10 +163,12 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
         bid = fx.block_idx.x
         # Block bid (reversed) owns rows [r0, r0+RPB).
         n_blocks = fx.Int32(arith.ceildivui(_to_raw(seq_len), _to_raw(fx.Int32(RPB))))
-        r0 = fx.Int32(arith.muli(
-            _to_raw(n_blocks - bid - fx.Int32(1)),
-            _to_raw(fx.Int32(RPB)),
-        ))
+        r0 = fx.Int32(
+            arith.muli(
+                _to_raw(n_blocks - bid - fx.Int32(1)),
+                _to_raw(fx.Int32(RPB)),
+            )
+        )
 
         # Decompose tid into wave index and in-wave lane.
         wave = fx.Int32(arith.divui(_to_raw(tid), _to_raw(fx.Int32(64))))
@@ -175,12 +185,22 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
         w_t = GTensor(weights, dtype=T.f32, shape=(-1, H))
         cs_t = GTensor(cu_starts, dtype=T.i32, shape=(-1,))
         ce_t = GTensor(cu_ends, dtype=T.i32, shape=(-1,))
-        out_t = GTensor(
-            logits,
-            dtype=T.f32,
-            shape=(-1, -1),
-            stride=(stride_logits_s, fx.Int32(1)),
-        )
+        # Per-row 1-D output view: the row's i64 byte offset goes into the base
+        # pointer so the remaining column offset stays in i32. A 2-D (row, col)
+        # view computes row * stride + col in i32 and overflows past 2^31
+        # (~46k-square dense outputs), silently mis-writing.
+        _stride_i64 = arith.extui(T.i64, _to_raw(stride_logits_s))
+
+        def _make_out_row_t(row_i32):
+            """1-D output GTensor for row_i32; byte base computed in i64."""
+            _ri64 = arith.extui(T.i64, _to_raw(row_i32))
+            _byte = arith.muli(
+                arith.muli(_ri64, _stride_i64), arith.constant(4, type=T.i64)
+            )
+            _idx = arith.index_cast(T.index, _byte)
+            return GTensor(
+                logits, dtype=T.f32, shape=(-1,), static_bytes_offset_i64=_idx
+            )
 
         def _load_pack_i64(i32_view, byte_off_i32):
             dword_off = fx.Int32(
@@ -242,7 +262,9 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
             row_a = [[None] * K_STEPS for _ in range_constexpr(M_TILES)]
             for mi in range_constexpr(M_TILES):
                 h_a = _i32_add(fx.Int32(mi * 16), lane_mod_16)
-                row_h = _i32_add(fx.Int32(arith.muli(_to_raw(row), _to_raw(fx.Int32(H)))), h_a)
+                row_h = _i32_add(
+                    fx.Int32(arith.muli(_to_raw(row), _to_raw(fx.Int32(H)))), h_a
+                )
                 base_a = fx.Int32(arith.muli(_to_raw(row_h), _to_raw(fx.Int32(D))))
                 for kk in range_constexpr(K_STEPS):
                     d_a = _i32_add(fx.Int32(kk * 32), lane8)
@@ -257,7 +279,9 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
                     h_w = _i32_add(
                         fx.Int32(mi * 16),
                         _i32_add(
-                            fx.Int32(arith.muli(_to_raw(lane_div_16), _to_raw(fx.Int32(4)))),
+                            fx.Int32(
+                                arith.muli(_to_raw(lane_div_16), _to_raw(fx.Int32(4)))
+                            ),
                             fx.Int32(ii),
                         ),
                     )
@@ -301,22 +325,31 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
 
             # ---- Load B-frags: wave w owns its own disjoint slice of n-tiles
             # [w*N_TILES_PER_WAVE, (w+1)*N_TILES_PER_WAVE) (no cross-wave sharing). ----
-            wave_ni_base = fx.Int32(arith.muli(_to_raw(wave), _to_raw(fx.Int32(N_TILES_PER_WAVE))))
+            wave_ni_base = fx.Int32(
+                arith.muli(_to_raw(wave), _to_raw(fx.Int32(N_TILES_PER_WAVE)))
+            )
             b_packs = [[None] * K_STEPS for _ in range_constexpr(N_TILES_PER_WAVE)]
             kv_scales_tile = [None] * N_TILES_PER_WAVE
             cols = [None] * N_TILES_PER_WAVE
             for ni in range_constexpr(N_TILES_PER_WAVE):
                 abs_ni = _i32_add(wave_ni_base, fx.Int32(ni))
                 col = _i32_add(
-                    _i32_add(col0, fx.Int32(arith.muli(_to_raw(abs_ni), _to_raw(fx.Int32(16))))),
+                    _i32_add(
+                        col0,
+                        fx.Int32(arith.muli(_to_raw(abs_ni), _to_raw(fx.Int32(16)))),
+                    ),
                     lane_mod_16,
                 )
                 cols[ni] = col
                 col_clamped = fx.Int32(
-                    arith.minsi(_to_raw(col), _to_raw(fx.Int32(seq_len_kv) - fx.Int32(1)))
+                    arith.minsi(
+                        _to_raw(col), _to_raw(fx.Int32(seq_len_kv) - fx.Int32(1))
+                    )
                 )
                 kv_scales_tile[ni] = _to_raw(fx.Float32(sc_t[col_clamped]))
-                base_b = fx.Int32(arith.muli(_to_raw(col_clamped), _to_raw(fx.Int32(D))))
+                base_b = fx.Int32(
+                    arith.muli(_to_raw(col_clamped), _to_raw(fx.Int32(D)))
+                )
                 for kk in range_constexpr(K_STEPS):
                     d_b = _i32_add(fx.Int32(kk * 32), lane8)
                     raw = _load_pack_i64(kv_i32, _i32_add(base_b, d_b))
@@ -325,6 +358,7 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
             # ---- Per-row MFMA + epilogue (inner loop over RPB rows) ----
             for j in range_constexpr(RPB):
                 row = _i32_add(r0, fx.Int32(j))
+                out_row_t = _make_out_row_t(row)
                 for ni in range_constexpr(N_TILES_PER_WAVE):
                     col = cols[ni]
                     kv_scale = kv_scales_tile[ni]
@@ -343,8 +377,12 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
                         for ii in range_constexpr(4):
                             score = Vec(acc)[ii].ir_value()
                             relu = arith.maximumf(score, _to_raw(f32_0))
-                            wsc = arith.MulFOp(relu, w_frag[j][mi][ii], fastmath=fm_fast).result
-                            col_sum = arith.AddFOp(col_sum, wsc, fastmath=fm_fast).result
+                            wsc = arith.MulFOp(
+                                relu, w_frag[j][mi][ii], fastmath=fm_fast
+                            ).result
+                            col_sum = arith.AddFOp(
+                                col_sum, wsc, fastmath=fm_fast
+                            ).result
                     col_sum = arith.MulFOp(col_sum, kv_scale, fastmath=fm_fast).result
 
                     # Head-reduce within the wave (width=64): shuffle_xor offsets 16, 32.
@@ -357,27 +395,33 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
                     # below `start`, so it guards the pre-filled -inf in
                     # [aligned_start, start).
                     in_window = arith.andi(
-                        _to_raw(arith.cmpi(
-                            arith.CmpIPredicate.sge,
-                            _to_raw(col),
-                            _to_raw(starts[j]),
-                        )),
-                        _to_raw(arith.cmpi(
-                            arith.CmpIPredicate.slt,
-                            _to_raw(col),
-                            _to_raw(ends[j]),
-                        )),
+                        _to_raw(
+                            arith.cmpi(
+                                arith.CmpIPredicate.sge,
+                                _to_raw(col),
+                                _to_raw(starts[j]),
+                            )
+                        ),
+                        _to_raw(
+                            arith.cmpi(
+                                arith.CmpIPredicate.slt,
+                                _to_raw(col),
+                                _to_raw(ends[j]),
+                            )
+                        ),
                     )
                     is_writer = arith.andi(
-                        _to_raw(arith.cmpi(
-                            arith.CmpIPredicate.eq,
-                            _to_raw(lane_div_16),
-                            _to_raw(fx.Int32(0)),
-                        )),
+                        _to_raw(
+                            arith.cmpi(
+                                arith.CmpIPredicate.eq,
+                                _to_raw(lane_div_16),
+                                _to_raw(fx.Int32(0)),
+                            )
+                        ),
                         in_window,
                     )
                     with ir.InsertionPoint(scf.IfOp(is_writer).then_block):
-                        out_t[row, col] = fx.Float32(col_sum)
+                        out_row_t[col] = fx.Float32(col_sum)
                         scf.YieldOp([])
 
             scf.YieldOp([])
@@ -397,9 +441,7 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
         num_splits: fx.Int32,
         stream: fx.Stream = fx.Stream(None),
     ):
-        n_blocks = arith.ceildivui(
-            _to_raw(seq_len), _to_raw(fx.Int32(RPB))
-        )
+        n_blocks = arith.ceildivui(_to_raw(seq_len), _to_raw(fx.Int32(RPB)))
         gx = arith.index_cast(T.index, n_blocks)
         gy = arith.index_cast(T.index, _to_raw(num_splits))
         kernel._func.__name__ = _kname
@@ -425,13 +467,12 @@ def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
 # WPB must divide the column-tile count BKV/16 (=8 at the default BKV=128).
 def _mk_builder(rpb, wpb):
     return lambda **kw: _build_kernel_mfma_r_w(
-        **kw, rows_per_block=rpb, waves_per_block=wpb)
+        **kw, rows_per_block=rpb, waves_per_block=wpb
+    )
 
 
 _VARIANT_BUILDERS = {
-    f"mfma_r{r}_w{w}": _mk_builder(r, w)
-    for r in (1, 2, 4)
-    for w in (1, 2, 4)
+    f"mfma_r{r}_w{w}": _mk_builder(r, w) for r in (1, 2, 4) for w in (1, 2, 4)
 }
 KERNEL_VARIANTS = tuple(_VARIANT_BUILDERS.keys())
 DEFAULT_VARIANT = "mfma_r2_w4"
@@ -447,8 +488,11 @@ def _auto_variant(seq_len, seq_len_kv):
 
 def _resolve_variant(variant, seq_len, seq_len_kv):
     """Effective variant: explicit ``variant=`` > env var > shape-adaptive."""
-    tag = variant or os.environ.get("FLYDSL_FP8_MQA_LOGITS_VARIANT") \
+    tag = (
+        variant
+        or os.environ.get("FLYDSL_FP8_MQA_LOGITS_VARIANT")
         or _auto_variant(seq_len, seq_len_kv)
+    )
     if tag not in _VARIANT_BUILDERS:
         raise ValueError(
             f"unknown fp8_mqa_logits variant {tag!r}; "
@@ -486,8 +530,11 @@ def compile_fp8_mqa_logits(
             f"available: {list(KERNEL_VARIANTS)}"
         )
     launcher = _VARIANT_BUILDERS[variant](
-        num_heads=num_heads, head_size=head_size, block_kv=block_kv,
-        convert_q_fn=convert_q_fn, convert_kv_fn=convert_kv_fn,
+        num_heads=num_heads,
+        head_size=head_size,
+        block_kv=block_kv,
+        convert_q_fn=convert_q_fn,
+        convert_kv_fn=convert_kv_fn,
     )
     launcher.compile_hints = dict(_DEFAULT_COMPILE_HINTS)
     return launcher
@@ -546,9 +593,10 @@ def flydsl_fp8_mqa_logits(
     # logits = sum_h ReLU(QK*scale)*w is preserved.
     _fnuz = torch.float8_e4m3fnuz
     _fn = torch.float8_e4m3fn
-    assert Q.dtype in (_fnuz, _fn) and KV.dtype in (_fnuz, _fn), (
-        f"Q/KV must be e4m3 fp8 (fnuz or fn); got {Q.dtype}, {KV.dtype}"
-    )
+    assert Q.dtype in (_fnuz, _fn) and KV.dtype in (
+        _fnuz,
+        _fn,
+    ), f"Q/KV must be e4m3 fp8 (fnuz or fn); got {Q.dtype}, {KV.dtype}"
     convert_q_fn = Q.dtype != _fnuz
     convert_kv_fn = KV.dtype != _fnuz
     scale_mul = (2.0 if convert_q_fn else 1.0) * (2.0 if convert_kv_fn else 1.0)
@@ -583,13 +631,12 @@ def flydsl_fp8_mqa_logits(
         cu_ends = torch.cat([cu_ends, cu_ends.new_zeros(pad)], dim=0)
 
     # Match the Triton launcher's -inf-prefill / padding behavior so the two
-    # produce identically-shaped, identically-masked outputs. The kernel indexes
-    # logits with i32, so seq_len_padded * stride must stay < 2^31 (dense output
-    # ceiling ~46k square); real serving never materializes logits that large.
+    # produce identically-shaped, identically-masked outputs. The kernel writes
+    # the output through a per-row i64 byte-offset view, so the row*stride*4
+    # element offset no longer has to fit in i32 (the prior ~46k-square ceiling
+    # is gone); only the per-row column offset stays in i32.
     aligned_size = 256
-    seq_len_kv_aligned = (
-        (seq_len_kv + aligned_size - 1) // aligned_size * aligned_size
-    )
+    seq_len_kv_aligned = (seq_len_kv + aligned_size - 1) // aligned_size * aligned_size
     if clean_logits:
         logits = torch.full(
             (seq_len_padded, seq_len_kv_aligned),

--- a/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
+++ b/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
@@ -1,0 +1,629 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""FP8 MQA logits (DeepSeek lightning indexer) -- FlyDSL gfx942 kernel.
+
+Compute for each query row ``m`` and KV position ``n``
+inside that row's window ``[cu_starts[m], cu_ends[m])``::
+
+    logits[m, n] = sum_h ReLU(<Q[m, h, :], K[n, :]> * kv_scale[n]) * weights[m, h]
+
+The public ``flydsl_fp8_mqa_logits`` mirrors the Triton launcher
+``aiter.ops.triton.attention.fp8_mqa_logits.fp8_mqa_logits`` exactly (same
+arguments, same return tensor, same ``clean_logits`` semantics) so the two are
+drop-in interchangeable in tests and benchmarks.
+"""
+
+# No `from __future__ import annotations`: FlyDSL arg typing needs real
+# annotation objects, not PEP 563 strings.
+
+import math
+import os
+import re
+from functools import lru_cache
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, range_constexpr, rocdl
+from flydsl.expr.numeric import ArithValue
+from flydsl.expr.typing import T
+from flydsl._mlir.dialects import scf
+from flydsl._mlir import ir
+
+from .tensor_shim import GTensor, _run_compiled, _to_raw
+
+Vec = fx.Vector
+
+
+def _i32_add(a, b):
+    """i32 add (result stays Int32, not index type)."""
+    return fx.Int32(arith.addi(_to_raw(a), _to_raw(b)))
+
+
+# Default KV tile width (columns processed per inner-loop iteration).
+_BLOCK_KV = 128
+# Don't split a row's KV window into chunks smaller than this many BKV tiles --
+# below it the per-block Q/weight preload stops being amortized.
+_MIN_TILES_PER_SPLIT = 8
+
+_DEFAULT_COMPILE_HINTS = {
+    "waves_per_eu": 2,
+    "fast_fp_math": True,
+}
+
+
+@lru_cache(maxsize=8)
+def _device_cu_count(device_index: int) -> int:
+    """Compute-unit count for a CUDA/HIP device (cached); 304 if unavailable."""
+    try:
+        return torch.cuda.get_device_properties(device_index).multi_processor_count
+    except Exception:
+        return 304
+
+
+def _auto_num_splits(seq_len_padded: int, seq_len_kv: int, rpb: int,
+                     device_index: int) -> int:
+    """KV-column splits (grid.y) to fill the device when the row grid is small.
+
+    For small-M / large-N shapes the ``ceil(seq_len/RPB)`` row grid leaves the
+    device block-starved; splitting each row's window across ``grid.y`` recovers
+    occupancy at no correctness cost (logits[m,n] are independent across n).
+    Returns 1 once the row grid alone oversubscribes the device. Constants tuned
+    on MI300X (304 CU): ~4x oversubscription, chunks >= _MIN_TILES_PER_SPLIT.
+    """
+    grid_x = seq_len_padded // rpb
+    if grid_x == 0 or seq_len_kv < 4096:
+        return 1
+    target_blocks = 4 * _device_cu_count(device_index)
+    if grid_x >= target_blocks:
+        return 1
+    max_splits = max(1, (seq_len_kv // _BLOCK_KV) // _MIN_TILES_PER_SPLIT)
+    return max(1, min(math.ceil(target_blocks / grid_x), max_splits))
+
+
+def _build_kernel_mfma_r_w(*, num_heads: int, head_size: int, block_kv: int,
+                           rows_per_block: int, waves_per_block: int,
+                           convert_q_fn: bool = False, convert_kv_fn: bool = False):
+    """Multi-row, multi-wave MFMA kernel.
+
+    ``rows_per_block`` query rows share one KV tile load (cuts KV traffic by RPB).
+    ``waves_per_block`` waves execute per block; each wave owns a disjoint slice of
+    the BKV column tiles (``N_TILES // WPB`` tiles per wave), so all WPB waves can
+    execute in parallel with no cross-wave LDS or barrier.
+
+    Thread decomposition:
+      * ``tid = wave * 64 + lane``  (tid: 0..MR_BLOCK_THREADS-1)
+      * Wave ``w`` owns n-tiles ``[w*N_TILES_PER_WAVE, (w+1)*N_TILES_PER_WAVE)``
+        within each BKV tile.
+      * A-operand (Q) layout and head-reduce are per-lane within the wave (width 64).
+
+    Grid: ``(ceil(seq_len / RPB), num_splits, 1)``.  The host pads ``seq_len`` to
+    a multiple of ``RPB`` (every block owns exactly ``RPB`` rows) and may split
+    each row's KV window across ``grid.y`` blocks when the row grid alone is too
+    small to fill the device (see ``flydsl_fp8_mqa_logits``).
+    """
+    H = num_heads
+    D = head_size
+    BKV = block_kv
+    RPB = rows_per_block
+    WPB = waves_per_block
+    MR_BLOCK_THREADS = 64 * WPB
+
+    assert H % 16 == 0, f"num_heads={H} must be a multiple of 16 for MFMA"
+    assert BKV % 16 == 0, f"block_kv={BKV} must be a multiple of 16 for MFMA"
+    assert D % 32 == 0, f"head_size={D} must be a multiple of 32 for MFMA K32"
+    assert RPB >= 1, "rows_per_block must be >= 1"
+    assert WPB >= 1, "waves_per_block must be >= 1"
+    N_TILES = BKV // 16                       # total column-tiles per BKV block
+    assert N_TILES % WPB == 0, (
+        f"BKV/16={N_TILES} must be divisible by waves_per_block={WPB}"
+    )
+    M_TILES = H // 16                         # head row-tiles
+    K_STEPS = D // 32                         # K32 MFMA steps over the head dim
+    N_TILES_PER_WAVE = N_TILES // WPB         # column-tiles per wave
+
+    fm_fast = arith.FastMathFlags.fast
+    mfma_fn = rocdl.mfma_f32_16x16x32_fp8_fp8
+
+    _cvt_tag = ""
+    if convert_q_fn:
+        _cvt_tag += "_cq"
+    if convert_kv_fn:
+        _cvt_tag += "_ck"
+    _kname = f"fp8_mqa_logits_H{H}_D{D}_bkv{BKV}_mfma_r{RPB}_w{WPB}{_cvt_tag}_flydsl"
+
+    @flyc.kernel(name=_kname, known_block_size=[MR_BLOCK_THREADS, 1, 1])
+    def kernel(
+        Q: fx.Tensor,            # [seq_len, H, D]       fp8 (bytes passed raw)
+        KV: fx.Tensor,           # [seq_len_kv, D]       fp8 (bytes passed raw)
+        kv_scales: fx.Tensor,    # [seq_len_kv]          f32
+        weights: fx.Tensor,      # [seq_len, H]          f32
+        cu_starts: fx.Tensor,    # [seq_len]             i32
+        cu_ends: fx.Tensor,      # [seq_len]             i32
+        logits: fx.Tensor,       # [seq_len, seq_len_kv] f32
+        seq_len: fx.Int32,       # padded to a multiple of RPB
+        seq_len_kv: fx.Int32,
+        stride_logits_s: fx.Int32,
+        num_splits: fx.Int32,    # grid.y KV-column splits (1 == no split)
+    ):
+        f32_0 = arith.constant(0.0, type=T.f32)
+        mfma_res_ty = Vec.make_type(4, fx.Float32)
+
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        # Block bid (reversed) owns rows [r0, r0+RPB).
+        n_blocks = fx.Int32(arith.ceildivui(_to_raw(seq_len), _to_raw(fx.Int32(RPB))))
+        r0 = fx.Int32(arith.muli(
+            _to_raw(n_blocks - bid - fx.Int32(1)),
+            _to_raw(fx.Int32(RPB)),
+        ))
+
+        # Decompose tid into wave index and in-wave lane.
+        wave = fx.Int32(arith.divui(_to_raw(tid), _to_raw(fx.Int32(64))))
+        lane = fx.Int32(arith.remui(_to_raw(tid), _to_raw(fx.Int32(64))))
+        lane_div_16 = fx.Int32(arith.divui(_to_raw(lane), _to_raw(fx.Int32(16))))
+        lane_mod_16 = fx.Int32(arith.remui(_to_raw(lane), _to_raw(fx.Int32(16))))
+        lane8 = fx.Int32(arith.muli(_to_raw(lane_div_16), _to_raw(fx.Int32(8))))
+
+        # fp8 operands are read 8 bytes at a time as 2 i32 dwords (v8i8
+        # buffer_load fails to lower on gfx942), bitcast to i64 for the MFMA.
+        q_i32 = GTensor(Q, dtype=T.i32, shape=(-1,))
+        kv_i32 = GTensor(KV, dtype=T.i32, shape=(-1,))
+        sc_t = GTensor(kv_scales, dtype=T.f32, shape=(-1,))
+        w_t = GTensor(weights, dtype=T.f32, shape=(-1, H))
+        cs_t = GTensor(cu_starts, dtype=T.i32, shape=(-1,))
+        ce_t = GTensor(cu_ends, dtype=T.i32, shape=(-1,))
+        out_t = GTensor(
+            logits,
+            dtype=T.f32,
+            shape=(-1, -1),
+            stride=(stride_logits_s, fx.Int32(1)),
+        )
+
+        def _load_pack_i64(i32_view, byte_off_i32):
+            dword_off = fx.Int32(
+                arith.divui(_to_raw(byte_off_i32), _to_raw(fx.Int32(4)))
+            )
+            v2 = i32_view.vec_load((dword_off,), vec_size=2)
+            return Vec(v2).bitcast(fx.Int64)[0].ir_value()
+
+        def _fn_to_fnuz_i64(raw_i64):
+            """Map FN byte 0x80 (neg-zero) -> 0x00 in 8 packed fp8 bytes."""
+            lo_i32 = arith.TruncIOp(T.i32, raw_i64).result
+            hi_i64 = arith.ShRUIOp(raw_i64, arith.constant(32, type=T.i64)).result
+            hi_i32 = arith.TruncIOp(T.i32, hi_i64).result
+
+            def _fix_i32(src):
+                result = arith.constant(0, type=T.i32)
+                for byte_idx in range_constexpr(4):
+                    shift = arith.constant(byte_idx * 8, type=T.i32)
+                    byte_val = arith.andi(
+                        arith.shrui(src, shift),
+                        arith.constant(0xFF, type=T.i32),
+                    )
+                    is_0x80 = arith.cmpi(
+                        arith.CmpIPredicate.eq,
+                        byte_val,
+                        arith.constant(0x80, type=T.i32),
+                    )
+                    cleaned = arith.select(
+                        is_0x80,
+                        arith.constant(0, type=T.i32),
+                        byte_val,
+                    )
+                    result = arith.ori(result, arith.shli(cleaned, shift))
+                return result
+
+            lo_fix = _fix_i32(lo_i32)
+            hi_fix = _fix_i32(hi_i32)
+            lo_64 = arith.ExtUIOp(T.i64, lo_fix).result
+            hi_64 = arith.ShLIOp(
+                arith.ExtUIOp(T.i64, hi_fix).result, arith.constant(32, type=T.i64)
+            ).result
+            return arith.OrIOp(lo_64, hi_64).result
+
+        # ---- Preload window bounds, Q frags, and weights for all RPB rows ----
+        # A-operand layout is per in-wave lane, so `lane` (not `tid`) indexes Q.
+        starts = [None] * RPB
+        ends = [None] * RPB
+        a_packs = [None] * RPB
+        w_frag = [None] * RPB
+
+        for j in range_constexpr(RPB):
+            row = _i32_add(r0, fx.Int32(j))
+            s = fx.Int32(cs_t[row])
+            e = fx.Int32(ce_t[row])
+            starts[j] = fx.Int32(arith.maxsi(_to_raw(s), _to_raw(fx.Int32(0))))
+            ends[j] = fx.Int32(arith.minsi(_to_raw(e), _to_raw(fx.Int32(seq_len_kv))))
+
+            # lane -> Q[row, h = mi*16 + lane%16, d = kk*32 + (lane//16)*8 + 0..7]
+            row_a = [[None] * K_STEPS for _ in range_constexpr(M_TILES)]
+            for mi in range_constexpr(M_TILES):
+                h_a = _i32_add(fx.Int32(mi * 16), lane_mod_16)
+                row_h = _i32_add(fx.Int32(arith.muli(_to_raw(row), _to_raw(fx.Int32(H)))), h_a)
+                base_a = fx.Int32(arith.muli(_to_raw(row_h), _to_raw(fx.Int32(D))))
+                for kk in range_constexpr(K_STEPS):
+                    d_a = _i32_add(fx.Int32(kk * 32), lane8)
+                    raw = _load_pack_i64(q_i32, _i32_add(base_a, d_a))
+                    row_a[mi][kk] = _fn_to_fnuz_i64(raw) if convert_q_fn else raw
+            a_packs[j] = row_a
+
+            # weights[row, h] preloaded per (mi, ii): head = mi*16 + lane_div_16*4 + ii
+            row_w = [[None] * 4 for _ in range_constexpr(M_TILES)]
+            for mi in range_constexpr(M_TILES):
+                for ii in range_constexpr(4):
+                    h_w = _i32_add(
+                        fx.Int32(mi * 16),
+                        _i32_add(
+                            fx.Int32(arith.muli(_to_raw(lane_div_16), _to_raw(fx.Int32(4)))),
+                            fx.Int32(ii),
+                        ),
+                    )
+                    row_w[mi][ii] = _to_raw(fx.Float32(w_t[row, h_w]))
+            w_frag[j] = row_w
+
+        # ---- Union window across all RPB rows ----
+        tile_start = _to_raw(starts[0])
+        tile_end = _to_raw(ends[0])
+        for j in range_constexpr(1, RPB):
+            tile_start = arith.minsi(tile_start, _to_raw(starts[j]))
+            tile_end = arith.maxsi(tile_end, _to_raw(ends[j]))
+        # Align tile_start down to BKV boundary.
+        tile_start = arith.muli(
+            arith.divui(tile_start, _to_raw(fx.Int32(BKV))),
+            _to_raw(fx.Int32(BKV)),
+        )
+
+        # ---- KV-column split across grid.y. Block (.,by) takes a BKV-aligned
+        # slice of the union window; logits[m,n] are independent across n, so
+        # this is pure parallelism with no reduction. The slices tile [start,end)
+        # exactly (disjoint, gap-free), so each column has one writer.
+        # num_splits==1 collapses to the full window (by==0). ----
+        by = fx.block_idx.y
+        win_tiles = arith.ceildivui(
+            arith.subi(tile_end, tile_start), _to_raw(fx.Int32(BKV))
+        )
+        split_cols = arith.muli(
+            arith.ceildivui(win_tiles, _to_raw(num_splits)),
+            _to_raw(fx.Int32(BKV)),
+        )
+        tile_start = arith.addi(tile_start, arith.muli(_to_raw(by), split_cols))
+        tile_end = arith.minsi(arith.addi(tile_start, split_cols), tile_end)
+
+        tile_lo = _to_raw(fx.Index(fx.Int32(tile_start)))
+        tile_hi = _to_raw(fx.Index(fx.Int32(tile_end)))
+        tile_step = _to_raw(fx.Index(fx.Int32(BKV)))
+        tile_loop = scf.ForOp(tile_lo, tile_hi, tile_step, [])
+        with ir.InsertionPoint(tile_loop.body):
+            col0 = fx.Int32(arith.index_cast(T.i32, tile_loop.induction_variable))
+
+            # ---- Load B-frags: wave w owns its own disjoint slice of n-tiles
+            # [w*N_TILES_PER_WAVE, (w+1)*N_TILES_PER_WAVE) (no cross-wave sharing). ----
+            wave_ni_base = fx.Int32(arith.muli(_to_raw(wave), _to_raw(fx.Int32(N_TILES_PER_WAVE))))
+            b_packs = [[None] * K_STEPS for _ in range_constexpr(N_TILES_PER_WAVE)]
+            kv_scales_tile = [None] * N_TILES_PER_WAVE
+            cols = [None] * N_TILES_PER_WAVE
+            for ni in range_constexpr(N_TILES_PER_WAVE):
+                abs_ni = _i32_add(wave_ni_base, fx.Int32(ni))
+                col = _i32_add(
+                    _i32_add(col0, fx.Int32(arith.muli(_to_raw(abs_ni), _to_raw(fx.Int32(16))))),
+                    lane_mod_16,
+                )
+                cols[ni] = col
+                col_clamped = fx.Int32(
+                    arith.minsi(_to_raw(col), _to_raw(fx.Int32(seq_len_kv) - fx.Int32(1)))
+                )
+                kv_scales_tile[ni] = _to_raw(fx.Float32(sc_t[col_clamped]))
+                base_b = fx.Int32(arith.muli(_to_raw(col_clamped), _to_raw(fx.Int32(D))))
+                for kk in range_constexpr(K_STEPS):
+                    d_b = _i32_add(fx.Int32(kk * 32), lane8)
+                    raw = _load_pack_i64(kv_i32, _i32_add(base_b, d_b))
+                    b_packs[ni][kk] = _fn_to_fnuz_i64(raw) if convert_kv_fn else raw
+
+            # ---- Per-row MFMA + epilogue (inner loop over RPB rows) ----
+            for j in range_constexpr(RPB):
+                row = _i32_add(r0, fx.Int32(j))
+                for ni in range_constexpr(N_TILES_PER_WAVE):
+                    col = cols[ni]
+                    kv_scale = kv_scales_tile[ni]
+                    col_sum = _to_raw(f32_0)
+                    for mi in range_constexpr(M_TILES):
+                        acc = Vec.filled(4, 0.0, fx.Float32)
+                        for kk in range_constexpr(K_STEPS):
+                            acc = mfma_fn(
+                                mfma_res_ty,
+                                [a_packs[j][mi][kk], b_packs[ni][kk], acc, 0, 0, 0],
+                            )
+                        # kv_scale (>=0) is hoisted out of the head sum: ReLU is
+                        # positive-homogeneous, so ReLU(s*x)=s*ReLU(x) and the
+                        # whole column sum is scaled once (below) instead of every
+                        # head term -- drops M_TILES*4 muls to one.
+                        for ii in range_constexpr(4):
+                            score = Vec(acc)[ii].ir_value()
+                            relu = arith.maximumf(score, _to_raw(f32_0))
+                            wsc = arith.MulFOp(relu, w_frag[j][mi][ii], fastmath=fm_fast).result
+                            col_sum = arith.AddFOp(col_sum, wsc, fastmath=fm_fast).result
+                    col_sum = arith.MulFOp(col_sum, kv_scale, fastmath=fm_fast).result
+
+                    # Head-reduce within the wave (width=64): shuffle_xor offsets 16, 32.
+                    for sh in [16, 32]:
+                        peer = _to_raw(ArithValue(col_sum).shuffle_xor(sh, 64))
+                        col_sum = arith.AddFOp(col_sum, peer, fastmath=fm_fast).result
+
+                    # Only lane_div_16==0 lanes hold the 16 distinct columns.
+                    # `col >= start` is required: the tile loop is BKV-aligned
+                    # below `start`, so it guards the pre-filled -inf in
+                    # [aligned_start, start).
+                    in_window = arith.andi(
+                        _to_raw(arith.cmpi(
+                            arith.CmpIPredicate.sge,
+                            _to_raw(col),
+                            _to_raw(starts[j]),
+                        )),
+                        _to_raw(arith.cmpi(
+                            arith.CmpIPredicate.slt,
+                            _to_raw(col),
+                            _to_raw(ends[j]),
+                        )),
+                    )
+                    is_writer = arith.andi(
+                        _to_raw(arith.cmpi(
+                            arith.CmpIPredicate.eq,
+                            _to_raw(lane_div_16),
+                            _to_raw(fx.Int32(0)),
+                        )),
+                        in_window,
+                    )
+                    with ir.InsertionPoint(scf.IfOp(is_writer).then_block):
+                        out_t[row, col] = fx.Float32(col_sum)
+                        scf.YieldOp([])
+
+            scf.YieldOp([])
+
+    @flyc.jit
+    def launch_fp8_mqa_logits_mfma_r_w(
+        Q: fx.Tensor,
+        KV: fx.Tensor,
+        kv_scales: fx.Tensor,
+        weights: fx.Tensor,
+        cu_starts: fx.Tensor,
+        cu_ends: fx.Tensor,
+        logits: fx.Tensor,
+        seq_len: fx.Int32,
+        seq_len_kv: fx.Int32,
+        stride_logits_s: fx.Int32,
+        num_splits: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        n_blocks = arith.ceildivui(
+            _to_raw(seq_len), _to_raw(fx.Int32(RPB))
+        )
+        gx = arith.index_cast(T.index, n_blocks)
+        gy = arith.index_cast(T.index, _to_raw(num_splits))
+        kernel._func.__name__ = _kname
+        kernel(
+            Q,
+            KV,
+            kv_scales,
+            weights,
+            cu_starts,
+            cu_ends,
+            logits,
+            seq_len,
+            seq_len_kv,
+            stride_logits_s,
+            num_splits,
+        ).launch(grid=(gx, gy, 1), block=(MR_BLOCK_THREADS, 1, 1), stream=stream)
+
+    return launch_fp8_mqa_logits_mfma_r_w
+
+
+# Kernel variants are tagged ``"mfma_r<RPB>_w<WPB>"`` (RPB query rows per block,
+# WPB waves per block). All share the single ``_build_kernel_mfma_r_w`` factory.
+# WPB must divide the column-tile count BKV/16 (=8 at the default BKV=128).
+def _mk_builder(rpb, wpb):
+    return lambda **kw: _build_kernel_mfma_r_w(
+        **kw, rows_per_block=rpb, waves_per_block=wpb)
+
+
+_VARIANT_BUILDERS = {
+    f"mfma_r{r}_w{w}": _mk_builder(r, w)
+    for r in (1, 2, 4)
+    for w in (1, 2, 4)
+}
+KERNEL_VARIANTS = tuple(_VARIANT_BUILDERS.keys())
+DEFAULT_VARIANT = "mfma_r2_w4"
+
+
+def _auto_variant(seq_len, seq_len_kv):
+    """Pick (RPB, WPB) from the problem shape: RPB=2 always; WPB=2 packs more
+    column tiles per wave when M and N are both large, else WPB=4 for more
+    wavefronts on small-M / short-window shapes."""
+    wpb = 2 if (seq_len >= 2048 and seq_len_kv >= 8192) else 4
+    return f"mfma_r2_w{wpb}"
+
+
+def _resolve_variant(variant, seq_len, seq_len_kv):
+    """Effective variant: explicit ``variant=`` > env var > shape-adaptive."""
+    tag = variant or os.environ.get("FLYDSL_FP8_MQA_LOGITS_VARIANT") \
+        or _auto_variant(seq_len, seq_len_kv)
+    if tag not in _VARIANT_BUILDERS:
+        raise ValueError(
+            f"unknown fp8_mqa_logits variant {tag!r}; "
+            f"available: {list(KERNEL_VARIANTS)}"
+        )
+    return tag
+
+
+@lru_cache(maxsize=32)
+def compile_fp8_mqa_logits(
+    *,
+    num_heads: int,
+    head_size: int,
+    block_kv: int = _BLOCK_KV,
+    paged: bool = False,
+    variant: str = DEFAULT_VARIANT,
+    convert_q_fn: bool = False,
+    convert_kv_fn: bool = False,
+):
+    """Return a cached, compiled FlyDSL launcher for the given shape config.
+
+    ``num_heads``/``head_size`` are compile-time constants (powers of two, D in
+    {64, 128}); ``variant`` is an ``mfma_r<RPB>_w<WPB>`` tag (see
+    ``KERNEL_VARIANTS``); ``convert_q_fn``/``convert_kv_fn`` mark an FP8 FN
+    operand whose -0 (0x80) byte the kernel patches to FNUZ +0. ``paged`` is
+    reserved for a future variant and must be False.
+    """
+    if paged:
+        raise NotImplementedError(
+            "Paged FlyDSL fp8_mqa_logits is Phase 2 and not implemented yet."
+        )
+    if variant not in _VARIANT_BUILDERS:
+        raise ValueError(
+            f"unknown fp8_mqa_logits variant {variant!r}; "
+            f"available: {list(KERNEL_VARIANTS)}"
+        )
+    launcher = _VARIANT_BUILDERS[variant](
+        num_heads=num_heads, head_size=head_size, block_kv=block_kv,
+        convert_q_fn=convert_q_fn, convert_kv_fn=convert_kv_fn,
+    )
+    launcher.compile_hints = dict(_DEFAULT_COMPILE_HINTS)
+    return launcher
+
+
+def flydsl_fp8_mqa_logits(
+    Q,
+    KV,
+    kv_scales,
+    weights,
+    cu_starts,
+    cu_ends,
+    clean_logits=True,
+    stream=None,
+    variant=None,
+):
+    """FlyDSL gfx942 FP8 MQA logits -- drop-in for the Triton ``fp8_mqa_logits``.
+
+    Q:            [seq_len, NUM_HEADS, HEAD_SIZE], dtype float8
+    KV:           [seq_len_kv, HEAD_SIZE], dtype float8
+    kv_scales:    [seq_len_kv], dtype float32
+    weights:      [seq_len, NUM_HEADS], dtype float32
+    cu_starts:    [seq_len], dtype int32, per-row window start (inclusive)
+    cu_ends:      [seq_len], dtype int32, per-row window end (exclusive)
+    clean_logits: bool. If True, positions outside [cu_starts[i], cu_ends[i])
+                  in row i are written as -inf. If False, the kernel skips
+                  those positions and the caller owns whatever is left there.
+    stream:       optional HIP stream; defaults to the current stream.
+    variant:      optional kernel-variant tag (see ``KERNEL_VARIANTS``). If None,
+                  taken from ``FLYDSL_FP8_MQA_LOGITS_VARIANT`` or, failing that,
+                  chosen adaptively from the problem shape (``_auto_variant``).
+
+    Returns
+    -------
+    logits: [seq_len, seq_len_kv], dtype float32.
+    """
+    seq_len, num_heads, head_size = Q.shape
+    seq_len_kv = KV.shape[0]
+    assert num_heads & (num_heads - 1) == 0, "num q. heads should be power of 2."
+    assert head_size & (head_size - 1) == 0, "head size should be power of 2."
+
+    # FlyDSL's DLPack tensor adaptor rejects 0-dim tensors, but the per-token
+    # ``kv_scales`` collapses to a scalar when seq_len_kv == 1 (and ``weights``
+    # could too). Reshape the 1-D / 2-D inputs back to their logical rank so the
+    # kernel always sees indexable tensors (matches the Triton pointer path).
+    kv_scales = kv_scales.reshape(seq_len_kv)
+    weights = weights.reshape(seq_len, num_heads)
+    cu_starts = cu_starts.reshape(seq_len)
+    cu_ends = cu_ends.reshape(seq_len)
+
+    # The gfx942 fp8 MFMA reads operands as e4m3 FNUZ (bias 8). For an e4m3 FN
+    # operand (OCP, bias 7) the same byte encodes exactly 2x the FNUZ value (the
+    # only data byte that differs is FN -0 = 0x80, which is FNUZ NaN), so we pass
+    # the raw bytes through, let the kernel patch 0x80 -> +0, and undo the 2x per
+    # FN operand by scaling kv_scales -- ReLU is positive-homogeneous, so
+    # logits = sum_h ReLU(QK*scale)*w is preserved.
+    _fnuz = torch.float8_e4m3fnuz
+    _fn = torch.float8_e4m3fn
+    assert Q.dtype in (_fnuz, _fn) and KV.dtype in (_fnuz, _fn), (
+        f"Q/KV must be e4m3 fp8 (fnuz or fn); got {Q.dtype}, {KV.dtype}"
+    )
+    convert_q_fn = Q.dtype != _fnuz
+    convert_kv_fn = KV.dtype != _fnuz
+    scale_mul = (2.0 if convert_q_fn else 1.0) * (2.0 if convert_kv_fn else 1.0)
+    if scale_mul != 1.0:
+        kv_scales = kv_scales.to(torch.float32) * scale_mul
+
+    variant = _resolve_variant(variant, seq_len, seq_len_kv)
+
+    launcher = compile_fp8_mqa_logits(
+        num_heads=num_heads,
+        head_size=head_size,
+        block_kv=_BLOCK_KV,
+        paged=False,
+        variant=variant,
+        convert_q_fn=convert_q_fn,
+        convert_kv_fn=convert_kv_fn,
+    )
+
+    # mfma_r* kernels require seq_len padded to a multiple of rows_per_block so
+    # every block owns exactly RPB rows.  Padded rows get empty windows (start ==
+    # end == 0) so the kernel writes nothing for them; the output is sliced back
+    # to the original seq_len after the launch.
+    # Parse RPB from variant tag "mfma_r<N>_w<M>" -> N.
+    _rpb_match = re.match(r"mfma_r(\d+)", variant)
+    _RPB = int(_rpb_match.group(1)) if _rpb_match else 1
+    seq_len_padded = ((seq_len + _RPB - 1) // _RPB) * _RPB
+    if seq_len_padded != seq_len:
+        pad = seq_len_padded - seq_len
+        Q = torch.cat([Q, Q.new_zeros((pad, num_heads, head_size))], dim=0)
+        weights = torch.cat([weights, weights.new_zeros((pad, num_heads))], dim=0)
+        cu_starts = torch.cat([cu_starts, cu_starts.new_zeros(pad)], dim=0)
+        cu_ends = torch.cat([cu_ends, cu_ends.new_zeros(pad)], dim=0)
+
+    # Match the Triton launcher's -inf-prefill / padding behavior so the two
+    # produce identically-shaped, identically-masked outputs. The kernel indexes
+    # logits with i32, so seq_len_padded * stride must stay < 2^31 (dense output
+    # ceiling ~46k square); real serving never materializes logits that large.
+    aligned_size = 256
+    seq_len_kv_aligned = (
+        (seq_len_kv + aligned_size - 1) // aligned_size * aligned_size
+    )
+    if clean_logits:
+        logits = torch.full(
+            (seq_len_padded, seq_len_kv_aligned),
+            fill_value=-float("inf"),
+            dtype=torch.float32,
+            device=Q.device,
+        )[:, :seq_len_kv]
+    else:
+        logits = torch.empty(
+            (seq_len_padded, seq_len_kv_aligned),
+            dtype=torch.float32,
+            device=Q.device,
+        )[:, :seq_len_kv]
+
+    num_splits = _auto_num_splits(seq_len_padded, seq_len_kv, _RPB, Q.device.index)
+
+    if stream is None:
+        stream = torch.cuda.current_stream()
+
+    with torch.cuda.device(Q.device.index):
+        _run_compiled(
+            launcher,
+            Q,
+            KV,
+            kv_scales,
+            weights,
+            cu_starts,
+            cu_ends,
+            logits,
+            int(seq_len_padded),
+            int(seq_len_kv),
+            int(logits.stride(0)),
+            int(num_splits),
+            stream,
+        )
+
+    return logits[:seq_len, :]

--- a/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
+++ b/aiter/ops/flydsl/kernels/fp8_mqa_logits.py
@@ -24,6 +24,8 @@ from functools import lru_cache
 
 import torch
 
+from aiter.jit.utils.chip_info import get_gfx
+
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.expr import arith, range_constexpr, rocdl
@@ -597,8 +599,10 @@ def flydsl_fp8_mqa_logits(
         _fnuz,
         _fn,
     ), f"Q/KV must be e4m3 fp8 (fnuz or fn); got {Q.dtype}, {KV.dtype}"
-    convert_q_fn = Q.dtype != _fnuz
-    convert_kv_fn = KV.dtype != _fnuz
+    # Only gfx942 needs that conversion; other fp8 archs read operands in their
+    # native dtype, so the FN->FNUZ recast there would corrupt them.
+    convert_q_fn = get_gfx() == "gfx942" and Q.dtype != _fnuz
+    convert_kv_fn = get_gfx() == "gfx942" and KV.dtype != _fnuz
     scale_mul = (2.0 if convert_q_fn else 1.0) * (2.0 if convert_kv_fn else 1.0)
     if scale_mul != 1.0:
         kv_scales = kv_scales.to(torch.float32) * scale_mul

--- a/aiter/ops/triton/attention/fp8_mqa_logits.py
+++ b/aiter/ops/triton/attention/fp8_mqa_logits.py
@@ -124,6 +124,19 @@ def fp8_mqa_logits(
         if seq_len <= 1024:
             matrix_instr_nonkdim = 16
 
+        _fnuz = torch.float8_e4m3fnuz
+        convert_q_fn = Q.dtype != _fnuz
+        convert_kv_fn = KV.dtype != _fnuz
+        scale_mul = 1.0
+        if convert_q_fn:
+            scale_mul *= 2.0
+            Q = (Q.to(torch.float32) * 0.5).to(_fnuz)
+        if convert_kv_fn:
+            scale_mul *= 2.0
+            KV = (KV.to(torch.float32) * 0.5).to(_fnuz)
+        if scale_mul != 1.0:
+            kv_scales = kv_scales.to(torch.float32) * scale_mul
+
         _fp8_mqa_logits_kernel[(seq_len,)](
             Q_ptr=Q,
             KV_ptr=KV,

--- a/aiter/ops/triton/attention/fp8_mqa_logits.py
+++ b/aiter/ops/triton/attention/fp8_mqa_logits.py
@@ -125,8 +125,11 @@ def fp8_mqa_logits(
             matrix_instr_nonkdim = 16
 
         _fnuz = torch.float8_e4m3fnuz
-        convert_q_fn = Q.dtype != _fnuz
-        convert_kv_fn = KV.dtype != _fnuz
+        # The FN->FNUZ recast + scale compensation is only correct on gfx942,
+        # whose fp8 MFMA interprets operands as FNUZ. Other fp8 archs read the
+        # operands' native dtype, so converting there would corrupt them.
+        convert_q_fn = arch == "gfx942" and Q.dtype != _fnuz
+        convert_kv_fn = arch == "gfx942" and KV.dtype != _fnuz
         scale_mul = 1.0
         if convert_q_fn:
             scale_mul *= 2.0

--- a/op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py
+++ b/op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py
@@ -9,6 +9,7 @@ metric used by the Triton test) over the DeepSeek dims and window shapes.
 Run with:
     python3 -m pytest op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py -q
 """
+
 import pytest
 import torch
 
@@ -319,13 +320,13 @@ def test_auto_num_splits_unit(monkeypatch) -> None:
     monkeypatch.setattr(kmod, "_device_cu_count", lambda idx: 304)
     f = kmod._auto_num_splits
 
-    assert f(1024, 2048, 2, 0) == 1     # window too short (< 4096)
-    assert f(64, 4095, 2, 0) == 1       # just under the length threshold
-    assert f(0, 8192, 2, 0) == 1        # grid_x == 0 guard (no ZeroDivisionError)
-    assert f(4096, 8192, 2, 0) == 1     # row grid already saturates (2048 >= 1216)
-    assert f(64, 4096, 2, 0) == 4       # tiny grid; capped by max_splits=4
-    assert f(2, 4096, 2, 0) == 4        # grid_x=1; still capped by max_splits=4
-    assert f(512, 65536, 2, 0) == 5     # ceil(1216/256)=5 < max_splits=64
+    assert f(1024, 2048, 2, 0) == 1  # window too short (< 4096)
+    assert f(64, 4095, 2, 0) == 1  # just under the length threshold
+    assert f(0, 8192, 2, 0) == 1  # grid_x == 0 guard (no ZeroDivisionError)
+    assert f(4096, 8192, 2, 0) == 1  # row grid already saturates (2048 >= 1216)
+    assert f(64, 4096, 2, 0) == 4  # tiny grid; capped by max_splits=4
+    assert f(2, 4096, 2, 0) == 4  # grid_x=1; still capped by max_splits=4
+    assert f(512, 65536, 2, 0) == 5  # ceil(1216/256)=5 < max_splits=64
     # Never returns < 1 for any plausible shape.
     for slp in (0, 1, 64, 512, 4096, 200000):
         for slk in (1, 2048, 4096, 131072, 200000):
@@ -334,7 +335,9 @@ def test_auto_num_splits_unit(monkeypatch) -> None:
 
 @pytest.mark.parametrize("clean_logits", [True, False])
 @torch.inference_mode()
-def test_flydsl_fp8_mqa_logits_adaptive_split_organic(clean_logits, monkeypatch) -> None:
+def test_flydsl_fp8_mqa_logits_adaptive_split_organic(
+    clean_logits, monkeypatch
+) -> None:
     """End-to-end small-M / large-N shape that trips ``_auto_num_splits > 1``
     organically (heuristic NOT monkeypatched), so the real adaptive grid.y path
     runs and is graded against the reference."""

--- a/op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py
+++ b/op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Correctness harness for the FlyDSL gfx942 FP8 MQA logits kernel.
+
+Compares ``flydsl_fp8_mqa_logits`` against the torch reference
+``ref_fp8_mqa_logits`` (the same DeepGEMM-derived reference and ``calc_diff``
+metric used by the Triton test) over the DeepSeek dims and window shapes.
+
+Run with:
+    python3 -m pytest op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py -q
+"""
+import pytest
+import torch
+
+from aiter.ops.flydsl import is_flydsl_available
+from aiter.ops.triton.attention.fp8_mqa_logits import fp8_mqa_logits as triton_logits
+
+# Reuse the verified reference, fp8 cast, masking helpers and CP data generator
+# from the Triton test so both kernels are graded against an identical bar.
+from op_tests.triton_tests.attention.test_fp8_mqa_logits import (
+    calc_diff,
+    per_custom_dims_cast_to_fp8,
+    ref_fp8_mqa_logits,
+    generate_cp_test_data,
+    e4m3_type,
+)
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and is_flydsl_available()),
+    reason="requires a GPU and an installed, gfx-supported flydsl package",
+)
+
+
+def _flydsl_fp8_mqa_logits():
+    # Imported lazily so the module still collects when flydsl is absent.
+    from aiter.ops.flydsl import flydsl_fp8_mqa_logits
+
+    return flydsl_fp8_mqa_logits
+
+
+@pytest.mark.parametrize(
+    "s_q, s_k",
+    [
+        (1, 1),
+        (1, 16),
+        (1, 113),
+        (17, 76),
+        (61, 113),
+        (61, 1024),
+        (128, 1024),
+        (1024, 1024),
+        (1024, 1560),
+    ],
+)
+@pytest.mark.parametrize("num_heads", [64, 128])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("disable_cp", [True, False])
+@pytest.mark.parametrize("clean_logits", [True, False])
+# Cover both the native fp8 (fnuz on gfx942) and the e4m3 FN path, which on
+# gfx942 exercises the in-kernel FN->FNUZ byte conversion + kv_scales x2.
+@pytest.mark.parametrize(
+    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
+)
+@torch.inference_mode()
+def test_flydsl_fp8_mqa_logits(
+    s_q: int,
+    s_k: int,
+    num_heads: int,
+    head_dim: int,
+    disable_cp: bool,
+    clean_logits: bool,
+    q_fp8_dtype: torch.dtype,
+) -> None:
+    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
+
+    torch.manual_seed(0)
+    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
+    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
+
+    if disable_cp or s_k % s_q != 0 or s_q % 2 != 0:
+        ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
+        ke = torch.arange(s_q, dtype=torch.int, device="cuda") + (s_k - s_q)
+    else:
+        ks, ke = generate_cp_test_data(s_q, s_k)
+
+    q_fp8 = q.to(q_fp8_dtype)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+
+    ref_logits, _ = ref_fp8_mqa_logits(
+        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
+    )
+
+    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
+
+    def _rehydrate(out):
+        # When clean_logits is off, the kernel only writes the in-window region;
+        # rebuild the full [s_q, s_k] grid with -inf outside (matches Triton test).
+        if clean_logits:
+            return out
+        assert out.size() == (s_q, s_k)
+        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
+        for i in range(s_q):
+            full[i, ks[i] : ke[i]] = out[i, : ke[i] - ks[i]]
+        return full
+
+    logits = _rehydrate(logits)
+
+    # 1) Verify against the torch reference (ground-truth bar, calc_diff < 1e-3).
+    ref_neginf_mask = ref_logits == float("-inf")
+    neginf_mask = logits == float("-inf")
+    assert torch.equal(neginf_mask, ref_neginf_mask), "FlyDSL vs torch-ref mask"
+    if not ref_neginf_mask.all():
+        diff = calc_diff(
+            logits.masked_fill(neginf_mask, 0),
+            ref_logits.masked_fill(ref_neginf_mask, 0),
+        )
+        assert diff < 1e-3, f"FlyDSL vs torch-ref {diff=}"
+
+    # 2) Cross-check against the Triton kernel (ticket asks for both). Same fp8
+    #    inputs, same clean_logits, identical post-processing.
+    tri_logits = _rehydrate(
+        triton_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
+    )
+    tri_neginf_mask = tri_logits == float("-inf")
+    assert torch.equal(neginf_mask, tri_neginf_mask), "FlyDSL vs Triton mask"
+    if not tri_neginf_mask.all():
+        diff_tri = calc_diff(
+            logits.masked_fill(neginf_mask, 0),
+            tri_logits.masked_fill(tri_neginf_mask, 0),
+        )
+        assert diff_tri < 1e-3, f"FlyDSL vs Triton {diff_tri=}"
+
+
+@pytest.mark.parametrize("s_q, s_k", [(64, 512), (128, 1024), (61, 1024)])
+@pytest.mark.parametrize("clean_logits", [True, False])
+@pytest.mark.parametrize(
+    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
+)
+@torch.inference_mode()
+def test_flydsl_fp8_mqa_logits_windowed_starts(
+    s_q: int, s_k: int, clean_logits: bool, q_fp8_dtype: torch.dtype
+) -> None:
+    """Per-row windows with NONZERO, BKV-misaligned starts.
+
+    Exercises the writer's ``col >= start`` bound and the BKV-down-aligned tile
+    loop (the indexer's general ``[cu_starts, cu_ends)`` contract); the main test
+    only covers ``start == 0``.
+    """
+    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
+    num_heads, head_dim = 64, 128
+
+    torch.manual_seed(0)
+    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
+    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
+
+    # Nonzero, per-row-varying, intentionally BKV(=128)-misaligned windows.
+    rows = torch.arange(s_q, device="cuda")
+    ks = ((rows * 53 + 100) % max(1, s_k // 2)).to(torch.int32)
+    ke = torch.minimum(ks + max(1, s_k // 3), torch.full_like(ks, s_k)).to(torch.int32)
+
+    q_fp8 = q.to(q_fp8_dtype)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    ref_logits, _ = ref_fp8_mqa_logits(
+        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
+    )
+    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
+
+    if not clean_logits:
+        # clean_logits=False writes in-window logits at their real column
+        # positions and leaves the rest untouched; mask the out-of-window region.
+        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
+        for i in range(s_q):
+            full[i, ks[i] : ke[i]] = logits[i, ks[i] : ke[i]]
+        logits = full
+
+    ref_mask = ref_logits == float("-inf")
+    assert torch.equal(logits == float("-inf"), ref_mask), "windowed -inf mask"
+    if not ref_mask.all():
+        diff = calc_diff(
+            logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
+        )
+        assert diff < 1e-3, f"windowed FlyDSL vs torch-ref {diff=}"
+
+
+@pytest.mark.parametrize("num_splits", [1, 2, 3, 4, 7, 16])
+@pytest.mark.parametrize("clean_logits", [True, False])
+@pytest.mark.parametrize(
+    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
+)
+@torch.inference_mode()
+def test_flydsl_fp8_mqa_logits_column_split(
+    num_splits: int, clean_logits: bool, q_fp8_dtype: torch.dtype, monkeypatch
+) -> None:
+    """Force the grid.y KV-column split (incl. non-divisor counts).
+
+    Each block owns a BKV-aligned slice of the row window; the slices must tile
+    ``[cu_starts, cu_ends)`` with no gaps and no double-writes. Pinning
+    ``_auto_num_splits`` lets us exercise that independent of the shape heuristic
+    (the production tests above only hit the ``num_splits == 1`` collapse).
+    """
+    import aiter.ops.flydsl.kernels.fp8_mqa_logits as kmod
+
+    monkeypatch.setattr(kmod, "_auto_num_splits", lambda *a, **k: num_splits)
+    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
+
+    s_q, s_k, num_heads, head_dim = 70, 2048, 64, 128
+    torch.manual_seed(0)
+    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
+    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
+
+    # Nonzero, per-row-varying, BKV(=128)-misaligned windows.
+    rows = torch.arange(s_q, device="cuda")
+    ks = ((rows * 53 + 100) % (s_k // 2)).to(torch.int32)
+    ke = torch.minimum(ks + s_k // 3, torch.full_like(ks, s_k)).to(torch.int32)
+
+    q_fp8 = q.to(q_fp8_dtype)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    ref_logits, _ = ref_fp8_mqa_logits(
+        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
+    )
+    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
+
+    if not clean_logits:
+        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
+        for i in range(s_q):
+            full[i, ks[i] : ke[i]] = logits[i, ks[i] : ke[i]]
+        logits = full
+
+    ref_mask = ref_logits == float("-inf")
+    assert torch.equal(logits == float("-inf"), ref_mask), "split -inf mask"
+    diff = calc_diff(
+        logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
+    )
+    assert diff < 1e-3, f"column-split FlyDSL vs torch-ref {diff=}"
+
+
+def _kv_in_dtype(kv_fp8_fnuz, kv_dtype):
+    """Re-express fnuz-quantized KV in ``kv_dtype``.
+
+    For FN, store the fnuz numeric values in the FN grid; the kernel reads FN
+    bytes as fnuz (= value/2) and compensates with ``kv_scales *= 2``, so the
+    dequantized KV still matches the reference.
+    """
+    if kv_dtype == e4m3_type:
+        return kv_fp8_fnuz
+    return kv_fp8_fnuz.to(torch.float32).to(kv_dtype)
+
+
+@pytest.mark.parametrize("s_q, s_k", [(128, 1024), (61, 1024)])
+@pytest.mark.parametrize("clean_logits", [True, False])
+# q in {fnuz, fn} x kv = fn covers the convert_kv_fn path with scale_mul 2 (q
+# fnuz) and 4 (q fn) -- the all-fnuz path is already covered by the main test.
+@pytest.mark.parametrize(
+    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
+)
+@pytest.mark.parametrize("kv_fp8_dtype", [torch.float8_e4m3fn], ids=["kvfn"])
+@torch.inference_mode()
+def test_flydsl_fp8_mqa_logits_fn_kv(
+    s_q, s_k, clean_logits, q_fp8_dtype, kv_fp8_dtype
+) -> None:
+    """FP8 FN KV operand: exercises ``convert_kv_fn`` + the ``kv_scales`` x2/x4
+    compensation that the main test (always-fnuz KV) never hits."""
+    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
+    num_heads, head_dim = 64, 128
+
+    torch.manual_seed(0)
+    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
+    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
+    ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
+    ke = torch.arange(s_q, dtype=torch.int, device="cuda") + (s_k - s_q)
+
+    q_fp8 = q.to(q_fp8_dtype)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    kv_fp8 = _kv_in_dtype(kv_fp8, kv_fp8_dtype)
+    assert kv_fp8.dtype == kv_fp8_dtype
+
+    ref_logits, _ = ref_fp8_mqa_logits(
+        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
+    )
+    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
+
+    if not clean_logits:
+        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
+        for i in range(s_q):
+            full[i, ks[i] : ke[i]] = logits[i, : ke[i] - ks[i]]
+        logits = full
+
+    ref_mask = ref_logits == float("-inf")
+    assert torch.equal(logits == float("-inf"), ref_mask), "fn-kv mask"
+    if not ref_mask.all():
+        diff = calc_diff(
+            logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
+        )
+        assert diff < 1e-3, f"fn-kv FlyDSL vs torch-ref {diff=}"
+
+
+def test_auto_num_splits_unit(monkeypatch) -> None:
+    """Direct unit test of the split heuristic (pure host arithmetic).
+
+    The split tests above monkeypatch ``_auto_num_splits`` wholesale and the
+    other shapes all have ``seq_len_kv < 4096``, so the heuristic's own
+    ceil/clamp logic is otherwise never executed. Pin the CU count for
+    determinism (304 -> target 1216 blocks).
+    """
+    import aiter.ops.flydsl.kernels.fp8_mqa_logits as kmod
+
+    monkeypatch.setattr(kmod, "_device_cu_count", lambda idx: 304)
+    f = kmod._auto_num_splits
+
+    assert f(1024, 2048, 2, 0) == 1     # window too short (< 4096)
+    assert f(64, 4095, 2, 0) == 1       # just under the length threshold
+    assert f(0, 8192, 2, 0) == 1        # grid_x == 0 guard (no ZeroDivisionError)
+    assert f(4096, 8192, 2, 0) == 1     # row grid already saturates (2048 >= 1216)
+    assert f(64, 4096, 2, 0) == 4       # tiny grid; capped by max_splits=4
+    assert f(2, 4096, 2, 0) == 4        # grid_x=1; still capped by max_splits=4
+    assert f(512, 65536, 2, 0) == 5     # ceil(1216/256)=5 < max_splits=64
+    # Never returns < 1 for any plausible shape.
+    for slp in (0, 1, 64, 512, 4096, 200000):
+        for slk in (1, 2048, 4096, 131072, 200000):
+            assert f(slp, slk, 2, 0) >= 1
+
+
+@pytest.mark.parametrize("clean_logits", [True, False])
+@torch.inference_mode()
+def test_flydsl_fp8_mqa_logits_adaptive_split_organic(clean_logits, monkeypatch) -> None:
+    """End-to-end small-M / large-N shape that trips ``_auto_num_splits > 1``
+    organically (heuristic NOT monkeypatched), so the real adaptive grid.y path
+    runs and is graded against the reference."""
+    import aiter.ops.flydsl.kernels.fp8_mqa_logits as kmod
+
+    seen = {}
+    real = kmod._auto_num_splits
+
+    def spy(*a, **k):
+        seen["n"] = real(*a, **k)
+        return seen["n"]
+
+    monkeypatch.setattr(kmod, "_auto_num_splits", spy)
+    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
+
+    s_q, s_k, num_heads, head_dim = 64, 8192, 64, 128
+    torch.manual_seed(0)
+    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
+    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
+    ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
+    ke = torch.arange(s_q, dtype=torch.int, device="cuda") + (s_k - s_q)
+
+    q_fp8 = q.to(torch.float8_e4m3fn)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    ref_logits, _ = ref_fp8_mqa_logits(
+        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
+    )
+    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
+
+    assert seen.get("n", 1) >= 2, f"expected adaptive split > 1, got {seen.get('n')}"
+
+    if not clean_logits:
+        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
+        for i in range(s_q):
+            full[i, ks[i] : ke[i]] = logits[i, : ke[i] - ks[i]]
+        logits = full
+
+    ref_mask = ref_logits == float("-inf")
+    assert torch.equal(logits == float("-inf"), ref_mask), "organic-split mask"
+    diff = calc_diff(
+        logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
+    )
+    assert diff < 1e-3, f"organic-split FlyDSL vs torch-ref {diff=}"

--- a/op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py
+++ b/op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py
@@ -1,23 +1,16 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
-"""Correctness harness for the FlyDSL gfx942 FP8 MQA logits kernel.
 
-Compares ``flydsl_fp8_mqa_logits`` against the torch reference
-``ref_fp8_mqa_logits`` (the same DeepGEMM-derived reference and ``calc_diff``
-metric used by the Triton test) over the DeepSeek dims and window shapes.
+import argparse
+import itertools
 
-Run with:
-    python3 -m pytest op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py -q
-"""
-
-import pytest
+import aiter
+import pandas as pd
 import torch
-
-from aiter.ops.flydsl import is_flydsl_available
+from aiter import dtypes
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.triton.attention.fp8_mqa_logits import fp8_mqa_logits as triton_logits
-
-# Reuse the verified reference, fp8 cast, masking helpers and CP data generator
-# from the Triton test so both kernels are graded against an identical bar.
 from op_tests.triton_tests.attention.test_fp8_mqa_logits import (
     calc_diff,
     per_custom_dims_cast_to_fp8,
@@ -26,361 +19,220 @@ from op_tests.triton_tests.attention.test_fp8_mqa_logits import (
     e4m3_type,
 )
 
-pytestmark = pytest.mark.skipif(
-    not (torch.cuda.is_available() and is_flydsl_available()),
-    reason="requires a GPU and an installed, gfx-supported flydsl package",
-)
+torch.set_default_device("cuda")
 
+SUPPORTED_GFX = ["gfx942"]
+DTYPE_MAP = {"fnuz": e4m3_type, "fn": torch.float8_e4m3fn}
 
-def _flydsl_fp8_mqa_logits():
-    # Imported lazily so the module still collects when flydsl is absent.
+try:
     from aiter.ops.flydsl import flydsl_fp8_mqa_logits
+except ImportError:
+    flydsl_fp8_mqa_logits = None
 
-    return flydsl_fp8_mqa_logits
 
-
-@pytest.mark.parametrize(
-    "s_q, s_k",
-    [
-        (1, 1),
-        (1, 16),
-        (1, 113),
-        (17, 76),
-        (61, 113),
-        (61, 1024),
-        (128, 1024),
-        (1024, 1024),
-        (1024, 1560),
-    ],
-)
-@pytest.mark.parametrize("num_heads", [64, 128])
-@pytest.mark.parametrize("head_dim", [64, 128])
-@pytest.mark.parametrize("disable_cp", [True, False])
-@pytest.mark.parametrize("clean_logits", [True, False])
-# Cover both the native fp8 (fnuz on gfx942) and the e4m3 FN path, which on
-# gfx942 exercises the in-kernel FN->FNUZ byte conversion + kv_scales x2.
-@pytest.mark.parametrize(
-    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
-)
-@torch.inference_mode()
-def test_flydsl_fp8_mqa_logits(
-    s_q: int,
-    s_k: int,
-    num_heads: int,
-    head_dim: int,
-    disable_cp: bool,
-    clean_logits: bool,
-    q_fp8_dtype: torch.dtype,
-) -> None:
-    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
-
-    torch.manual_seed(0)
-    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
-    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
-
-    if disable_cp or s_k % s_q != 0 or s_q % 2 != 0:
+def _make_windows(s_q, s_k, mode):
+    if mode == "causal":
         ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
         ke = torch.arange(s_q, dtype=torch.int, device="cuda") + (s_k - s_q)
-    else:
-        ks, ke = generate_cp_test_data(s_q, s_k)
-
-    q_fp8 = q.to(q_fp8_dtype)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-
-    ref_logits, _ = ref_fp8_mqa_logits(
-        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
-    )
-
-    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
-
-    def _rehydrate(out):
-        # When clean_logits is off, the kernel only writes the in-window region;
-        # rebuild the full [s_q, s_k] grid with -inf outside (matches Triton test).
-        if clean_logits:
-            return out
-        assert out.size() == (s_q, s_k)
-        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
-        for i in range(s_q):
-            full[i, ks[i] : ke[i]] = out[i, : ke[i] - ks[i]]
-        return full
-
-    logits = _rehydrate(logits)
-
-    # 1) Verify against the torch reference (ground-truth bar, calc_diff < 1e-3).
-    ref_neginf_mask = ref_logits == float("-inf")
-    neginf_mask = logits == float("-inf")
-    assert torch.equal(neginf_mask, ref_neginf_mask), "FlyDSL vs torch-ref mask"
-    if not ref_neginf_mask.all():
-        diff = calc_diff(
-            logits.masked_fill(neginf_mask, 0),
-            ref_logits.masked_fill(ref_neginf_mask, 0),
+        return ks, ke
+    if mode == "cp":
+        return generate_cp_test_data(s_q, s_k)
+    if mode == "misaligned":
+        rows = torch.arange(s_q, device="cuda")
+        ks = ((rows * 53 + 100) % max(1, s_k // 2)).to(torch.int32)
+        ke = torch.minimum(ks + max(1, s_k // 3), torch.full_like(ks, s_k)).to(
+            torch.int32
         )
-        assert diff < 1e-3, f"FlyDSL vs torch-ref {diff=}"
-
-    # 2) Cross-check against the Triton kernel (ticket asks for both). Same fp8
-    #    inputs, same clean_logits, identical post-processing.
-    tri_logits = _rehydrate(
-        triton_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
-    )
-    tri_neginf_mask = tri_logits == float("-inf")
-    assert torch.equal(neginf_mask, tri_neginf_mask), "FlyDSL vs Triton mask"
-    if not tri_neginf_mask.all():
-        diff_tri = calc_diff(
-            logits.masked_fill(neginf_mask, 0),
-            tri_logits.masked_fill(tri_neginf_mask, 0),
-        )
-        assert diff_tri < 1e-3, f"FlyDSL vs Triton {diff_tri=}"
+        return ks, ke
+    raise ValueError(f"unknown window mode: {mode}")
 
 
-@pytest.mark.parametrize("s_q, s_k", [(64, 512), (128, 1024), (61, 1024)])
-@pytest.mark.parametrize("clean_logits", [True, False])
-@pytest.mark.parametrize(
-    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
-)
-@torch.inference_mode()
-def test_flydsl_fp8_mqa_logits_windowed_starts(
-    s_q: int, s_k: int, clean_logits: bool, q_fp8_dtype: torch.dtype
-) -> None:
-    """Per-row windows with NONZERO, BKV-misaligned starts.
-
-    Exercises the writer's ``col >= start`` bound and the BKV-down-aligned tile
-    loop (the indexer's general ``[cu_starts, cu_ends)`` contract); the main test
-    only covers ``start == 0``.
-    """
-    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
-    num_heads, head_dim = 64, 128
-
-    torch.manual_seed(0)
-    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
-    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
-
-    # Nonzero, per-row-varying, intentionally BKV(=128)-misaligned windows.
-    rows = torch.arange(s_q, device="cuda")
-    ks = ((rows * 53 + 100) % max(1, s_k // 2)).to(torch.int32)
-    ke = torch.minimum(ks + max(1, s_k // 3), torch.full_like(ks, s_k)).to(torch.int32)
-
-    q_fp8 = q.to(q_fp8_dtype)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    ref_logits, _ = ref_fp8_mqa_logits(
-        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
-    )
-    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
-
-    if not clean_logits:
-        # clean_logits=False writes in-window logits at their real column
-        # positions and leaves the rest untouched; mask the out-of-window region.
-        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
-        for i in range(s_q):
-            full[i, ks[i] : ke[i]] = logits[i, ks[i] : ke[i]]
-        logits = full
-
-    ref_mask = ref_logits == float("-inf")
-    assert torch.equal(logits == float("-inf"), ref_mask), "windowed -inf mask"
-    if not ref_mask.all():
-        diff = calc_diff(
-            logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
-        )
-        assert diff < 1e-3, f"windowed FlyDSL vs torch-ref {diff=}"
-
-
-@pytest.mark.parametrize("num_splits", [1, 2, 3, 4, 7, 16])
-@pytest.mark.parametrize("clean_logits", [True, False])
-@pytest.mark.parametrize(
-    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
-)
-@torch.inference_mode()
-def test_flydsl_fp8_mqa_logits_column_split(
-    num_splits: int, clean_logits: bool, q_fp8_dtype: torch.dtype, monkeypatch
-) -> None:
-    """Force the grid.y KV-column split (incl. non-divisor counts).
-
-    Each block owns a BKV-aligned slice of the row window; the slices must tile
-    ``[cu_starts, cu_ends)`` with no gaps and no double-writes. Pinning
-    ``_auto_num_splits`` lets us exercise that independent of the shape heuristic
-    (the production tests above only hit the ``num_splits == 1`` collapse).
-    """
-    import aiter.ops.flydsl.kernels.fp8_mqa_logits as kmod
-
-    monkeypatch.setattr(kmod, "_auto_num_splits", lambda *a, **k: num_splits)
-    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
-
-    s_q, s_k, num_heads, head_dim = 70, 2048, 64, 128
-    torch.manual_seed(0)
-    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
-    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
-
-    # Nonzero, per-row-varying, BKV(=128)-misaligned windows.
-    rows = torch.arange(s_q, device="cuda")
-    ks = ((rows * 53 + 100) % (s_k // 2)).to(torch.int32)
-    ke = torch.minimum(ks + s_k // 3, torch.full_like(ks, s_k)).to(torch.int32)
-
-    q_fp8 = q.to(q_fp8_dtype)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    ref_logits, _ = ref_fp8_mqa_logits(
-        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
-    )
-    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
-
-    if not clean_logits:
-        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
-        for i in range(s_q):
-            full[i, ks[i] : ke[i]] = logits[i, ks[i] : ke[i]]
-        logits = full
-
-    ref_mask = ref_logits == float("-inf")
-    assert torch.equal(logits == float("-inf"), ref_mask), "split -inf mask"
-    diff = calc_diff(
-        logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
-    )
-    assert diff < 1e-3, f"column-split FlyDSL vs torch-ref {diff=}"
+def _rehydrate(out, ks, ke, s_q, s_k, clean_logits):
+    if clean_logits:
+        return out
+    full = torch.full((s_q, s_k), float("-inf"), device="cuda")
+    for i in range(s_q):
+        full[i, ks[i] : ke[i]] = out[i, ks[i] : ke[i]]
+    return full
 
 
 def _kv_in_dtype(kv_fp8_fnuz, kv_dtype):
-    """Re-express fnuz-quantized KV in ``kv_dtype``.
-
-    For FN, store the fnuz numeric values in the FN grid; the kernel reads FN
-    bytes as fnuz (= value/2) and compensates with ``kv_scales *= 2``, so the
-    dequantized KV still matches the reference.
-    """
     if kv_dtype == e4m3_type:
         return kv_fp8_fnuz
     return kv_fp8_fnuz.to(torch.float32).to(kv_dtype)
 
 
-@pytest.mark.parametrize("s_q, s_k", [(128, 1024), (61, 1024)])
-@pytest.mark.parametrize("clean_logits", [True, False])
-# q in {fnuz, fn} x kv = fn covers the convert_kv_fn path with scale_mul 2 (q
-# fnuz) and 4 (q fn) -- the all-fnuz path is already covered by the main test.
-@pytest.mark.parametrize(
-    "q_fp8_dtype", [e4m3_type, torch.float8_e4m3fn], ids=["qfnuz", "qfn"]
-)
-@pytest.mark.parametrize("kv_fp8_dtype", [torch.float8_e4m3fn], ids=["kvfn"])
-@torch.inference_mode()
-def test_flydsl_fp8_mqa_logits_fn_kv(
-    s_q, s_k, clean_logits, q_fp8_dtype, kv_fp8_dtype
-) -> None:
-    """FP8 FN KV operand: exercises ``convert_kv_fn`` + the ``kv_scales`` x2/x4
-    compensation that the main test (always-fnuz KV) never hits."""
-    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
-    num_heads, head_dim = 64, 128
-
+@benchmark()
+def test_fp8_mqa_logits(
+    s_q, s_k, num_heads, head_dim, q_dtype, kv_dtype, clean_logits, window
+):
     torch.manual_seed(0)
-    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
+    q = torch.randn(s_q, num_heads, head_dim, dtype=torch.bfloat16)
+    kv = torch.randn(s_k, head_dim, dtype=torch.bfloat16)
     kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
     kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
-    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
-    ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
-    ke = torch.arange(s_q, dtype=torch.int, device="cuda") + (s_k - s_q)
+    weights = torch.randn(s_q, num_heads, dtype=torch.float32)
 
-    q_fp8 = q.to(q_fp8_dtype)
+    ks, ke = _make_windows(s_q, s_k, window)
+
+    q_fp8 = q.to(DTYPE_MAP[q_dtype])
     kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    kv_fp8 = _kv_in_dtype(kv_fp8, kv_fp8_dtype)
-    assert kv_fp8.dtype == kv_fp8_dtype
+    if kv_dtype != "fnuz":
+        kv_fp8 = _kv_in_dtype(kv_fp8, DTYPE_MAP[kv_dtype])
 
-    ref_logits, _ = ref_fp8_mqa_logits(
-        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
-    )
-    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
-
-    if not clean_logits:
-        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
-        for i in range(s_q):
-            full[i, ks[i] : ke[i]] = logits[i, : ke[i] - ks[i]]
-        logits = full
-
-    ref_mask = ref_logits == float("-inf")
-    assert torch.equal(logits == float("-inf"), ref_mask), "fn-kv mask"
-    if not ref_mask.all():
-        diff = calc_diff(
-            logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
+    with torch.inference_mode():
+        ref, cost = ref_fp8_mqa_logits(
+            q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
         )
-        assert diff < 1e-3, f"fn-kv FlyDSL vs torch-ref {diff=}"
+    ref_mask = ref == float("-inf")
 
-
-def test_auto_num_splits_unit(monkeypatch) -> None:
-    """Direct unit test of the split heuristic (pure host arithmetic).
-
-    The split tests above monkeypatch ``_auto_num_splits`` wholesale and the
-    other shapes all have ``seq_len_kv < 4096``, so the heuristic's own
-    ceil/clamp logic is otherwise never executed. Pin the CU count for
-    determinism (304 -> target 1216 blocks).
-    """
-    import aiter.ops.flydsl.kernels.fp8_mqa_logits as kmod
-
-    monkeypatch.setattr(kmod, "_device_cu_count", lambda idx: 304)
-    f = kmod._auto_num_splits
-
-    assert f(1024, 2048, 2, 0) == 1  # window too short (< 4096)
-    assert f(64, 4095, 2, 0) == 1  # just under the length threshold
-    assert f(0, 8192, 2, 0) == 1  # grid_x == 0 guard (no ZeroDivisionError)
-    assert f(4096, 8192, 2, 0) == 1  # row grid already saturates (2048 >= 1216)
-    assert f(64, 4096, 2, 0) == 4  # tiny grid; capped by max_splits=4
-    assert f(2, 4096, 2, 0) == 4  # grid_x=1; still capped by max_splits=4
-    assert f(512, 65536, 2, 0) == 5  # ceil(1216/256)=5 < max_splits=64
-    # Never returns < 1 for any plausible shape.
-    for slp in (0, 1, 64, 512, 4096, 200000):
-        for slk in (1, 2048, 4096, 131072, 200000):
-            assert f(slp, slk, 2, 0) >= 1
-
-
-@pytest.mark.parametrize("clean_logits", [True, False])
-@torch.inference_mode()
-def test_flydsl_fp8_mqa_logits_adaptive_split_organic(
-    clean_logits, monkeypatch
-) -> None:
-    """End-to-end small-M / large-N shape that trips ``_auto_num_splits > 1``
-    organically (heuristic NOT monkeypatched), so the real adaptive grid.y path
-    runs and is graded against the reference."""
-    import aiter.ops.flydsl.kernels.fp8_mqa_logits as kmod
-
-    seen = {}
-    real = kmod._auto_num_splits
-
-    def spy(*a, **k):
-        seen["n"] = real(*a, **k)
-        return seen["n"]
-
-    monkeypatch.setattr(kmod, "_auto_num_splits", spy)
-    flydsl_fp8_mqa_logits = _flydsl_fp8_mqa_logits()
-
-    s_q, s_k, num_heads, head_dim = 64, 8192, 64, 128
-    torch.manual_seed(0)
-    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
-    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
-    ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
-    ke = torch.arange(s_q, dtype=torch.int, device="cuda") + (s_k - s_q)
-
-    q_fp8 = q.to(torch.float8_e4m3fn)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    ref_logits, _ = ref_fp8_mqa_logits(
-        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
+    flops = cost.item() * num_heads * head_dim * 2
+    nbytes = (
+        s_q * num_heads * head_dim
+        + s_k * head_dim  # Q + KV (fp8)
+        + (s_k + s_q * num_heads) * 4  # scales + weights
+        + 2 * s_q * 4  # ks + ke
+        + s_q * s_k * 4  # output
     )
-    logits = flydsl_fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
 
-    assert seen.get("n", 1) >= 2, f"expected adaptive split > 1, got {seen.get('n')}"
+    candidates = {
+        "flydsl": lambda: flydsl_fp8_mqa_logits(
+            q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits
+        ),
+    }
+    if kv_dtype == "fnuz":
+        candidates["triton"] = lambda: triton_logits(
+            q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits
+        )
 
-    if not clean_logits:
-        full = torch.full((s_q, s_k), float("-inf"), device="cuda")
-        for i in range(s_q):
-            full[i, ks[i] : ke[i]] = logits[i, : ke[i] - ks[i]]
-        logits = full
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        with torch.inference_mode():
+            out, us = run_perftest(fn)
+        out = _rehydrate(out, ks, ke, s_q, s_k, clean_logits)
 
-    ref_mask = ref_logits == float("-inf")
-    assert torch.equal(logits == float("-inf"), ref_mask), "organic-split mask"
-    diff = calc_diff(
-        logits.masked_fill(ref_mask, 0), ref_logits.masked_fill(ref_mask, 0)
+        out_mask = out == float("-inf")
+        assert torch.equal(out_mask, ref_mask), f"{name}: -inf mask mismatch"
+
+        err = 0.0
+        if not ref_mask.all():
+            diff = calc_diff(out.masked_fill(out_mask, 0), ref.masked_fill(ref_mask, 0))
+            assert diff < 1e-3, f"{name} calc_diff={diff}"
+            err = diff.item()
+            checkAllclose(
+                ref.masked_fill(ref_mask, 0).to(dtypes.fp32),
+                out.masked_fill(out_mask, 0).to(dtypes.fp32),
+                rtol=1e-2,
+                atol=5.0,
+                msg=f"{name}: fp8_mqa_logits",
+                printLog=False,
+            )
+
+        ret[f"{name} us"] = us
+        ret[f"{name} TFLOPS"] = flops / us / 1e6 if us > 0 else 0
+        ret[f"{name} TB/s"] = nbytes / us / 1e6 if us > 0 else 0
+        ret[f"{name} err"] = err
+
+    return ret
+
+
+def _cp_eligible(s_q, s_k):
+    return s_k % s_q == 0 and s_q % 2 == 0
+
+
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning("fp8_mqa_logits unsupported on %s; skipping", get_gfx())
+        return
+    if flydsl_fp8_mqa_logits is None:
+        aiter.logger.warning("flydsl package not installed; skipping")
+        return
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="FlyDSL fp8_mqa_logits correctness + perf sweep",
     )
-    assert diff < 1e-3, f"organic-split FlyDSL vs torch-ref {diff=}"
+    parser.add_argument(
+        "-s",
+        "--shapes",
+        type=dtypes.str2tuple,
+        nargs="*",
+        default=[
+            (1, 1),
+            (1, 16),
+            (1, 113),
+            (17, 76),
+            (61, 113),
+            (61, 1024),
+            (128, 1024),
+            (1024, 1024),
+            (1024, 1560),
+            (64, 8192),
+        ],
+    )
+    parser.add_argument("--num-heads", type=int, nargs="*", default=[64, 128])
+    parser.add_argument("--head-dim", type=int, nargs="*", default=[64, 128])
+    parser.add_argument(
+        "--q-dtype",
+        type=str,
+        nargs="*",
+        default=["fnuz", "fn"],
+        choices=["fnuz", "fn"],
+    )
+    parser.add_argument(
+        "--kv-dtype",
+        type=str,
+        nargs="*",
+        default=["fnuz"],
+        choices=["fnuz", "fn"],
+    )
+    parser.add_argument(
+        "--clean-logits",
+        type=int,
+        nargs="*",
+        default=[0, 1],
+        choices=[0, 1],
+    )
+    parser.add_argument(
+        "-w",
+        "--window",
+        type=str,
+        nargs="*",
+        default=["causal", "cp", "misaligned"],
+        choices=["causal", "cp", "misaligned"],
+    )
+    args = parser.parse_args()
+
+    df = []
+    for (s_q, s_k), nh, hd, qd, kvd, cl, win in itertools.product(
+        args.shapes,
+        args.num_heads,
+        args.head_dim,
+        args.q_dtype,
+        args.kv_dtype,
+        args.clean_logits,
+        args.window,
+    ):
+        if win == "cp" and not _cp_eligible(s_q, s_k):
+            continue
+        df.append(
+            test_fp8_mqa_logits(
+                s_q,
+                s_k,
+                nh,
+                hd,
+                qd,
+                kvd,
+                bool(cl),
+                win,
+            )
+        )
+
+    df = pd.DataFrame(df)
+    aiter.logger.info(
+        "fp8_mqa_logits summary (markdown):\n%s", df.to_markdown(index=False)
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

DeepSeek-V4 Flash's sparse attention uses a lightning indexer (fp8 MQA logits). This PR adds a **FlyDSL gfx942 drop-in for the Triton `fp8_mqa_logits`** that is faster on the DSv4 prefill shapes for both the mono-dtype config (q/k both e4m3fnuz) as well as the currently vllm upstream's mixed config.

The uplift does **not** depend on operand dtype: even with both operands fnuz (no conversion on either side), FlyDSL is 1.5–2.5× faster at the kernel level and cuts end-to-end prefill TTFT by up to 17% at 128K and increases with increasing ctx size.

## Technical Details

1. **New FlyDSL gfx942 kernel** which is a drop-in for the Triton one (same args, return, and `clean_logits` semantics).
2. **(Optional safety net) Triton `fp8_mqa_logits` FN/FNUZ fix** by @vpietila-amd; a no-op for fnuz/fnuz, so existing callers are unchanged. This only matters while callers still send mixed q=fn/k=fnuz (see note below); it can be dropped if maintainers prefer the source-side fix only.

FlyDSL kernel initially translated from GEAK by @peyron-amd, with perf iterated by myself and @vpietila-amd.

## Test Plan

`pytest op_tests/flydsl_tests/test_flydsl_fp8_mqa_logits.py` — validated against the torch reference and cross-checked vs the Triton kernel (`calc_diff < 1e-3`): both fp8 dtype combos

## Test Result

**335/335 pass.**

Kernel speedup (gfx942, H=64, D=128). FlyDSL wins in both operand configs:

**Mixed** q=e4m3fn / k=e4m3fnuz (current vLLM behavior):

| S_q × S_kv   | Triton  | FlyDSL  | speedup |
| ------------ | ------- | ------- | ------- |
| 4096 × 4096  | 0.47 ms | 0.21 ms | 2.2×    |
| 8192 × 8192  | 1.48 ms | 0.70 ms | 2.1×    |
| 128 × 32768  | 0.30 ms | 0.12 ms | 2.4×    |
| 671 × 131072 | 3.14 ms | 1.94 ms | 1.6×    |

**Mono fnuz/fnuz** (the production config; gfx942, H=64, D=128):

| S_q × S_kv   | Triton  | FlyDSL  | speedup |
| ------------ | ------- | ------- | ------- |
| 4096 × 4096  | 0.34 ms | 0.22 ms | 1.5×    |
| 8192 × 8192  | 1.15 ms | 0.74 ms | 1.6×    |
| 128 × 32768  | 0.29 ms | 0.12 ms | 2.5×    |
| 671 × 131072 | 3.14 ms | 1.78 ms | 1.8×    |

**End-to-end** DeepSeek-V4 Flash TTFT (TP4, MI300-class gfx942, OSL=27, concurrency=1; Triton gfx942 indexer vs FlyDSL, leveraging PR 46730 on vLLM which fixes the mixed dtype):

| ISL  | Triton    | FlyDSL   | speedup | TTFT reduction |
| ---- | --------- | -------- | ------- | -------------- |
| 32K  | 2099 ms   | 1981 ms  | 1.06×   | −5.7%          |
| 128K | 11337 ms  | 9401 ms  | 1.21×   | −17.0%         |

The E2E gain grows with context length (the indexer logits cost scales with N), which is where prefill latency hurts most.

## Note on the mixed FN/FNUZ path (re: @valarLip)

You were right to push on the mixed dtype usage. The mixed q=fn/k=fnuz inputs come from vLLM, not aiter. Currently DSv4-Flash's `fused_indexer_q.py` quantizes Q to e4m3fn while the gfx942 KV cache is fnuz. The proper fix is at the source: vllm-project/vllm#46730 makes Q fnuz so both operands match. The Triton FN/FNUZ fix here is an optional bridge for the current vLLM behavior and can be dropped if you'd rather rely on the source fix.