### PR TITLE
[Bugfix] base_tuner: gfx-aware tuned CSV handling and column-safe row…

### DIFF
--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -393,6 +393,19 @@ class TunerCommon:
             return df_old
         key_columns = self.keys
         df_updates = df_updates.loc[:, self.columns]
+        # Backfill columns present in the new results but missing from a legacy
+        # tuned CSV (for example a newly added gfx key column), so that the
+        # key construction and per-column assignment below do not KeyError
+        # during migration. gfx/cu_num default to the running device; any other
+        # missing column defaults to NA.
+        for col in df_updates.columns:
+            if col not in df_old.columns:
+                if col == "gfx":
+                    df_old[col] = self.get_gfx()
+                elif col == "cu_num":
+                    df_old[col] = self.get_cu_num()
+                else:
+                    df_old[col] = pd.NA
         # Widen integer columns to object so that float/string updates don't
         # trigger a Pandas dtype-coercion error (e.g. tflops=0 stored as int64
         # cannot accept a float like 2.61).
@@ -1552,6 +1565,10 @@ class GemmCommonTuner(TunerCommon):
             self.untunedf["cu_num"] = self.get_cu_num()
             self.untunedf = self.untunedf[self.keys]
             self.tunedf = self.get_tuned_gemm_list(args.tune_file)
+            # Backfill gfx for legacy tuned CSVs so the key-based skip mask
+            # below does not KeyError when gfx is part of the tuner keys.
+            if "gfx" not in self.tunedf.columns and "gfx" in self.untunedf.columns:
+                self.tunedf["gfx"] = self.get_gfx()
 
             untunedf_cols = self.untunedf.columns
             if len(self.tunedf) != 0:

--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -372,6 +372,8 @@ class TunerCommon:
                 untunedf = untunedf[target_mask]
             self.untunedf = untunedf[self.keys]
             self.tunedf = self.get_tuned_gemm_list(args.tune_file)
+            if "gfx" not in self.tunedf.columns and "gfx" in self.untunedf.columns:
+                self.tunedf["gfx"] = gfx
 
             untunedf_cols = self.untunedf.columns
             mask = (
@@ -412,9 +414,11 @@ class TunerCommon:
             "_tmp_key"
         ].tolist()
         for key in matched_keys:
-            df_old.loc[df_old.index[df_old["_tmp_key"] == key][0]] = df_updates.loc[
-                df_updates["_tmp_key"] == key
-            ].values[0]
+            old_idx = df_old.index[df_old["_tmp_key"] == key][0]
+            update_row = df_updates.loc[df_updates["_tmp_key"] == key].iloc[0]
+            # Assign by column name so migrated legacy CSVs with newly inserted
+            # columns (for example gfx) do not corrupt rows by positional shift.
+            df_old.loc[old_idx, df_updates.columns] = update_row
         if unmatched_keys:
             unmatched_rows = df_updates[
                 df_updates["_tmp_key"].isin(unmatched_keys)
@@ -1337,6 +1341,9 @@ class TunerCommon:
             tunedf = self.get_tuned_gemm_list(run_config_file)
             if not tunedf.empty and self.keys[0] in tunedf.columns:
                 cu = self.get_cu_num()
+                gfx = self.get_gfx()
+                if "gfx" in tunedf.columns:
+                    tunedf = tunedf[tunedf["gfx"].astype(str) == str(gfx)]
                 if "cu_num" in tunedf.columns:
                     tunedf = tunedf[tunedf["cu_num"] == cu]
                 self.untunedf = tunedf.drop_duplicates(subset=self.keys).reset_index(

--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -373,7 +373,7 @@ class TunerCommon:
             self.untunedf = untunedf[self.keys]
             self.tunedf = self.get_tuned_gemm_list(args.tune_file)
             if "gfx" not in self.tunedf.columns and "gfx" in self.untunedf.columns:
-                self.tunedf["gfx"] = gfx
+                self.tunedf.insert(0, "gfx", gfx)
 
             untunedf_cols = self.untunedf.columns
             mask = (
@@ -401,7 +401,10 @@ class TunerCommon:
         for col in df_updates.columns:
             if col not in df_old.columns:
                 if col == "gfx":
-                    df_old[col] = self.get_gfx()
+                    # Keep gfx as the leading key column (canonical layout)
+                    # rather than appending it at the end when migrating a
+                    # legacy CSV.
+                    df_old.insert(0, col, self.get_gfx())
                 elif col == "cu_num":
                     df_old[col] = self.get_cu_num()
                 else:
@@ -443,6 +446,10 @@ class TunerCommon:
 
     def sortResults(self, tune_file, issorted, values):
         tunedf = _read_csv(tune_file)
+        # Migrate legacy tuned files lacking a gfx column so the gfx-aware
+        # dedup/sort keys below do not KeyError; keep gfx as the leading column.
+        if "gfx" in self.keys and "gfx" not in tunedf.columns:
+            tunedf.insert(0, "gfx", self.get_gfx())
         if issorted:
             tunedf = tunedf.sort_values(by=values)
         dedup_keys = self.keys
@@ -1568,7 +1575,7 @@ class GemmCommonTuner(TunerCommon):
             # Backfill gfx for legacy tuned CSVs so the key-based skip mask
             # below does not KeyError when gfx is part of the tuner keys.
             if "gfx" not in self.tunedf.columns and "gfx" in self.untunedf.columns:
-                self.tunedf["gfx"] = self.get_gfx()
+                self.tunedf.insert(0, "gfx", self.get_gfx())
 
             untunedf_cols = self.untunedf.columns
             if len(self.tunedf) != 0:


### PR DESCRIPTION
… update

Make tuner CSV migration robust to legacy tuned files that predate the `gfx` column:

- get_retune_gemm_list: add a `gfx` column to tunedf when it is missing but present in untunedf, so the key-based retune mask does not KeyError.
- update_tunedf: assign matched rows by column name (df_updates.columns) instead of positional `.values[0]`, so migrated CSVs with newly inserted columns (e.g. gfx) are not corrupted by positional shift.
- run_config: filter the tuned list by the current `gfx` (in addition to cu_num) so a gfx950 run does not pick up rows tuned for another arch.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
