### PR TITLE
change default pa reduce kernel from cxx to flydsl

### DIFF
--- a/aiter/aot/flydsl/common.py
+++ b/aiter/aot/flydsl/common.py
@@ -36,6 +36,7 @@ class OpKind(enum.Enum):
     GEMM = "gemm"
     GROUPED_MOE = "grouped_moe"
     CHUNK_GDN_H = "chunk_gdn_h"
+    PA_DECODE = "pa_decode"
 
 
 @dataclass(frozen=True)
@@ -231,6 +232,10 @@ def _collect_aot_jobs_for(kind: OpKind) -> list[dict[str, Any]]:
         return []
     elif kind is OpKind.CHUNK_GDN_H:
         from .chunk_gdn_h import DEFAULT_CSVS, parse_csv
+    elif kind is OpKind.PA_DECODE:
+        from .pa_decode import collect_jobs
+
+        return collect_jobs()
     else:
         raise ValueError(f"unknown FlyDSL AOT kind: {kind!r}")
     return collect_aot_jobs(DEFAULT_CSVS, parse_csv)
@@ -250,6 +255,8 @@ def _compile_one(kind: OpKind, job: dict[str, Any]) -> tuple[OpKind, dict[str, A
         return kind, {}
     elif kind is OpKind.CHUNK_GDN_H:
         from .chunk_gdn_h import compile_one_config
+    elif kind is OpKind.PA_DECODE:
+        from .pa_decode import compile_one_config
     else:
         raise ValueError(f"unknown FlyDSL AOT kind: {kind!r}")
     return kind, compile_one_config(**job)

--- a/aiter/aot/flydsl/pa_decode.py
+++ b/aiter/aot/flydsl/pa_decode.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""AOT pre-compilation for the FlyDSL PS-reduce kernel used by pa_decode_gluon.
+
+The set of compile-time constant combinations to precompile is hand-specified as
+a cartesian product of axes in ``PA_DECODE_AOT_SPEC``. Each combination is
+compiled under ``COMPILE_ONLY=1`` with CPU dummy tensors, calling the same
+``compile_pa_decode_ps_reduce_flydsl`` builder the runtime uses, so the AOT cache
+key equals the runtime lookup.
+
+Runs on a GPU host (importing pa_decode_gluon needs a GPU); arch is auto-detected
+by FlyDSL and matches the runtime arch on the same host.
+
+Usage:
+    python -m aiter.aot.flydsl.pa_decode
+"""
+
+import argparse
+import itertools
+import time
+
+import torch
+
+from aiter.aot.flydsl.common import compile_only_env
+from aiter.ops.triton.gluon.pa_decode_gluon import (
+    FLYDSL_PS_REDUCE_AVAILABLE,
+    PA_DECODE_MAX_SPLITS,
+    _flydsl_dtype_str,
+    compile_pa_decode_ps_reduce_flydsl,
+)
+
+# Hand-edited cartesian-product spec. Replace these starter values with the real
+# target model configs. Axes map 1:1 onto the kernel's compile-time constants
+# (sink_dtype is pinned to output_dtype when use_sinks is False; see _expand_spec).
+PA_DECODE_AOT_SPEC = {
+    "head_size": [64],
+    "query_seq_len": [1, 2, 3, 4],
+    "query_group_size": [8],
+    "output_dtype": [torch.bfloat16],
+    "logits_dtype": [torch.bfloat16],
+    "use_sinks": [True],
+    "sink_dtype": [torch.bfloat16],
+    "max_context_partition_num": list(range(1, PA_DECODE_MAX_SPLITS + 1)),
+}
+
+_AXES = (
+    "head_size",
+    "query_seq_len",
+    "query_group_size",
+    "output_dtype",
+    "logits_dtype",
+    "use_sinks",
+    "sink_dtype",
+    "max_context_partition_num",
+)
+
+
+def _job_kernel_name(job: dict) -> str:
+    return (
+        "pa_decode_ps_reduce "
+        f"hs={job['head_size']} ql={job['query_seq_len']} "
+        f"g={job['query_group_size']} out={job['output_dtype']} "
+        f"logits={job['logits_dtype']} sink={job['use_sinks']}/{job['sink_dtype']} "
+        f"n={job['max_context_partition_num']}"
+    )
+
+
+def _expand_spec(spec: dict) -> list[dict]:
+    """Cartesian product of the spec axes into a deduped list of job dicts.
+
+    When use_sinks is False, sink_dtype is pinned to output_dtype to match the
+    runtime funnel (which sets sink_dtype = output dtype when no sink is passed),
+    then duplicates are removed.
+    """
+    value_lists = [spec[axis] for axis in _AXES]
+    seen = set()
+    jobs = []
+    for combo in itertools.product(*value_lists):
+        job = dict(zip(_AXES, combo))
+        if not job["use_sinks"]:
+            job["sink_dtype"] = job["output_dtype"]
+        key = tuple(job[axis] for axis in _AXES)
+        if key in seen:
+            continue
+        seen.add(key)
+        job["kernel_name"] = _job_kernel_name(job)
+        jobs.append(job)
+    return jobs
+
+
+def collect_jobs() -> list[dict]:
+    """Jobs for the build-time AOT harness. Empty when FlyDSL is unavailable."""
+    if not FLYDSL_PS_REDUCE_AVAILABLE:
+        return []
+    return _expand_spec(PA_DECODE_AOT_SPEC)
+
+
+def compile_one_config(
+    *,
+    head_size: int,
+    query_seq_len: int,
+    query_group_size: int,
+    output_dtype: torch.dtype,
+    logits_dtype: torch.dtype,
+    use_sinks: bool,
+    sink_dtype: torch.dtype,
+    max_context_partition_num: int,
+    kernel_name: str = "",
+) -> dict:
+    """Compile one PS-reduce variant to the FlyDSL cache (COMPILE_ONLY, no exec).
+
+    Uses CPU dummy tensors and the inner ``compiled["launch"]`` (default stream)
+    so it is safe inside a forked process pool and needs no live CUDA context.
+    Only dtype/rank/contiguity of the dummy tensors matter for the cache key, so
+    sizes are minimal (batch=1, num_kv_heads=1).
+    """
+    result = {"kernel_name": kernel_name, "compile_time": None}
+    n = max_context_partition_num
+    eq_group = query_seq_len * query_group_size
+    dev = torch.device("cpu")
+
+    output = torch.empty(
+        1, query_seq_len, 1, query_group_size, head_size, device=dev, dtype=output_dtype
+    )
+    exp_sums = torch.zeros(1, 1, n, eq_group, device=dev, dtype=torch.float32)
+    max_logits = torch.zeros(1, 1, n, eq_group, device=dev, dtype=torch.float32)
+    temporary_output = torch.zeros(
+        1, 1, n, eq_group, head_size, device=dev, dtype=logits_dtype
+    )
+    if use_sinks:
+        # num_query_heads = num_kv_heads(1) * query_group_size
+        sink = torch.empty(query_group_size, device=dev, dtype=sink_dtype)
+        sink_dtype_str = _flydsl_dtype_str(sink_dtype)
+    else:
+        sink = torch.empty(0, device=dev, dtype=output_dtype)
+        sink_dtype_str = _flydsl_dtype_str(output_dtype)
+
+    t0 = time.time()
+    try:
+        with compile_only_env():
+            compiled = compile_pa_decode_ps_reduce_flydsl(
+                max_context_partition_num=n,
+                query_seq_len=query_seq_len,
+                query_group_size=query_group_size,
+                head_size=head_size,
+                output_dtype_str=_flydsl_dtype_str(output_dtype),
+                logits_dtype_str=_flydsl_dtype_str(logits_dtype),
+                sink_dtype_str=sink_dtype_str,
+                use_sinks=use_sinks,
+            )
+            # Inner launch: omit the stream arg (defaults to fx.Stream(None)).
+            compiled["launch"](
+                output,
+                exp_sums,
+                max_logits,
+                temporary_output,
+                sink,
+                output.stride(0),
+                output.stride(1),
+                output.stride(2),
+                output.stride(3),
+                exp_sums.stride(0),
+                exp_sums.stride(1),
+                exp_sums.stride(2),
+                temporary_output.stride(0),
+                temporary_output.stride(1),
+                temporary_output.stride(2),
+                temporary_output.stride(3),
+                output.shape[0],
+                output.shape[2],
+            )
+        result["compile_time"] = time.time() - t0
+        print(f"  [OK] compile  {result['compile_time']:6.1f}s  {kernel_name}")
+    except Exception as e:
+        print(f"  [FAIL] compile  {kernel_name}: {e}")
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="AOT pre-compile FlyDSL PS-reduce kernels from PA_DECODE_AOT_SPEC",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.parse_args()
+
+    jobs = collect_jobs()
+    print("=" * 72)
+    print("FlyDSL pa_decode PS-reduce AOT Pre-compilation")
+    print(f"  Total jobs: {len(jobs)}")
+    print("=" * 72)
+
+    t0 = time.time()
+    ok = 0
+    for i, job in enumerate(jobs, 1):
+        res = compile_one_config(**job)
+        if res["compile_time"] is not None:
+            ok += 1
+        print(f"  ... {i}/{len(jobs)} complete")
+    elapsed = time.time() - t0
+
+    print("=" * 72)
+    print(f"  compiled {ok} ok, {len(jobs) - ok} failed in {elapsed:.1f}s")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/aiter/aot/flydsl/pa_decode.py
+++ b/aiter/aot/flydsl/pa_decode.py
@@ -37,8 +37,6 @@ from aiter.ops.triton.gluon.pa_decode_gluon import (
 # (sink_dtype is pinned to output_dtype when use_sinks is False; see _expand_spec).
 PA_DECODE_AOT_SPEC = {
     "head_size": [64],
-    "query_seq_len": [1, 2, 3, 4],
-    "query_group_size": [8],
     "output_dtype": [torch.bfloat16],
     "logits_dtype": [torch.bfloat16],
     "use_sinks": [True],
@@ -48,8 +46,6 @@ PA_DECODE_AOT_SPEC = {
 
 _AXES = (
     "head_size",
-    "query_seq_len",
-    "query_group_size",
     "output_dtype",
     "logits_dtype",
     "use_sinks",
@@ -57,12 +53,17 @@ _AXES = (
     "max_context_partition_num",
 )
 
+# query_seq_len / query_group_size are passed at launch time and no longer affect
+# the compiled kernel's cache key, so they are not AOT axes. Fixed dummy values
+# are used only to shape the COMPILE_ONLY dummy tensors.
+_DUMMY_QUERY_SEQ_LEN = 1
+_DUMMY_QUERY_GROUP_SIZE = 8
+
 
 def _job_kernel_name(job: dict) -> str:
     return (
         "pa_decode_ps_reduce "
-        f"hs={job['head_size']} ql={job['query_seq_len']} "
-        f"g={job['query_group_size']} out={job['output_dtype']} "
+        f"hs={job['head_size']} out={job['output_dtype']} "
         f"logits={job['logits_dtype']} sink={job['use_sinks']}/{job['sink_dtype']} "
         f"n={job['max_context_partition_num']}"
     )
@@ -101,8 +102,6 @@ def collect_jobs() -> list[dict]:
 def compile_one_config(
     *,
     head_size: int,
-    query_seq_len: int,
-    query_group_size: int,
     output_dtype: torch.dtype,
     logits_dtype: torch.dtype,
     use_sinks: bool,
@@ -115,10 +114,13 @@ def compile_one_config(
     Uses CPU dummy tensors and the inner ``compiled["launch"]`` (default stream)
     so it is safe inside a forked process pool and needs no live CUDA context.
     Only dtype/rank/contiguity of the dummy tensors matter for the cache key, so
-    sizes are minimal (batch=1, num_kv_heads=1).
+    sizes are minimal (batch=1, num_kv_heads=1). query_seq_len/query_group_size
+    are launch-time args (not cache keys), so fixed dummy values are used here.
     """
     result = {"kernel_name": kernel_name, "compile_time": None}
     n = max_context_partition_num
+    query_seq_len = _DUMMY_QUERY_SEQ_LEN
+    query_group_size = _DUMMY_QUERY_GROUP_SIZE
     eq_group = query_seq_len * query_group_size
     dev = torch.device("cpu")
 
@@ -143,8 +145,6 @@ def compile_one_config(
         with compile_only_env():
             compiled = compile_pa_decode_ps_reduce_flydsl(
                 max_context_partition_num=n,
-                query_seq_len=query_seq_len,
-                query_group_size=query_group_size,
                 head_size=head_size,
                 output_dtype_str=_flydsl_dtype_str(output_dtype),
                 logits_dtype_str=_flydsl_dtype_str(logits_dtype),
@@ -169,6 +169,8 @@ def compile_one_config(
                 temporary_output.stride(1),
                 temporary_output.stride(2),
                 temporary_output.stride(3),
+                query_seq_len,
+                query_group_size,
                 output.shape[0],
                 output.shape[2],
             )

--- a/aiter/aot/flydsl/pa_decode.py
+++ b/aiter/aot/flydsl/pa_decode.py
@@ -24,7 +24,7 @@ import time
 
 import torch
 
-from aiter.aot.flydsl.common import compile_only_env
+from aiter.aot.flydsl.common import compile_only_env, run_jobs_parallel
 from aiter.ops.triton.gluon.pa_decode_gluon import (
     FLYDSL_PS_REDUCE_AVAILABLE,
     PA_DECODE_MAX_SPLITS,
@@ -36,11 +36,11 @@ from aiter.ops.triton.gluon.pa_decode_gluon import (
 # target model configs. Axes map 1:1 onto the kernel's compile-time constants
 # (sink_dtype is pinned to output_dtype when use_sinks is False; see _expand_spec).
 PA_DECODE_AOT_SPEC = {
-    "head_size": [64],
-    "output_dtype": [torch.bfloat16],
-    "logits_dtype": [torch.bfloat16],
-    "use_sinks": [True],
-    "sink_dtype": [torch.bfloat16],
+    "head_size": [64, 128],
+    "output_dtype": [torch.bfloat16, torch.float16, torch.float32],
+    "logits_dtype": [torch.bfloat16, torch.float16, torch.float32],
+    "use_sinks": [True, False],
+    "sink_dtype": [torch.bfloat16, torch.float16, torch.float32],
     "max_context_partition_num": list(range(1, PA_DECODE_MAX_SPLITS + 1)),
 }
 
@@ -195,16 +195,14 @@ def main():
     print("=" * 72)
 
     t0 = time.time()
-    ok = 0
-    for i, job in enumerate(jobs, 1):
-        res = compile_one_config(**job)
-        if res["compile_time"] is not None:
-            ok += 1
-        print(f"  ... {i}/{len(jobs)} complete")
+    results = run_jobs_parallel(compile_one_config, jobs)
     elapsed = time.time() - t0
 
+    ok = sum(1 for r in results if r["compile_time"] is not None)
+    fail = len(results) - ok
+
     print("=" * 72)
-    print(f"  compiled {ok} ok, {len(jobs) - ok} failed in {elapsed:.1f}s")
+    print(f"  compiled {ok} ok, {fail} failed in {elapsed:.1f}s")
     print("=" * 72)
 
 

--- a/aiter/ops/triton/gluon/pa_decode_gluon.py
+++ b/aiter/ops/triton/gluon/pa_decode_gluon.py
@@ -24,7 +24,7 @@ FLYDSL_PS_REDUCE_AVAILABLE = True
 try:
     import flydsl.compiler as flyc
     import flydsl.expr as fx
-    from flydsl.expr import arith, gpu, rocdl, buffer_ops, range_constexpr
+    from flydsl.expr import arith, gpu, rocdl, buffer_ops, range_constexpr, const_expr
     from flydsl.expr.typing import T, Int32
     from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
     from flydsl.runtime.device import get_rocm_arch as get_hip_arch
@@ -40,6 +40,7 @@ except Exception:
     rocdl = None
     buffer_ops = None
     range_constexpr = None
+    const_expr = None
     T = None
     Int32 = None
     SmemAllocator = None
@@ -4568,7 +4569,7 @@ def compile_pa_decode_ps_reduce_flydsl(
         smem_base = allocator.get_base()
         red_scratch = SmemPtr(smem_base, red_off, T.f32, shape=(red_slots,))
         red_scratch.get()
-        if max_context_partition_num > FLYDSL_WARP_SIZE:
+        if const_expr(max_context_partition_num > FLYDSL_WARP_SIZE):
             part_weights_lds = SmemPtr(
                 smem_base, part_weights_off, T.f32, shape=(max_context_partition_num,)
             )
@@ -4578,7 +4579,7 @@ def compile_pa_decode_ps_reduce_flydsl(
         es_rsrc = buffer_ops.create_buffer_resource(exp_sums_ptr, max_size=True)
         ml_rsrc = buffer_ops.create_buffer_resource(max_logits_ptr, max_size=True)
         logits_rsrc = buffer_ops.create_buffer_resource(logits_ptr, max_size=True)
-        if use_sinks:
+        if const_expr(use_sinks):
             sink_rsrc = buffer_ops.create_buffer_resource(sink_token_ptr, max_size=True)
 
         c_zero_f = arith.constant(0.0, type=T.f32)
@@ -4648,7 +4649,7 @@ def compile_pa_decode_ps_reduce_flydsl(
 
             return red_scratch.load([arith.constant(0, index=True)])
 
-        if max_context_partition_num <= FLYDSL_WARP_SIZE:
+        if const_expr(max_context_partition_num <= FLYDSL_WARP_SIZE):
             c_part_num = arith.constant(max_context_partition_num, type=T.i32)
             c_reduce_width = arith.constant(reduce_width, type=T.i32)
             c_four = arith.constant(4, type=T.i32)
@@ -4704,13 +4705,13 @@ def compile_pa_decode_ps_reduce_flydsl(
             )
             scaled_sum = part_sum * part_scale
             global_exp_sum = _wave_reduce_sum(scaled_sum)
-            if use_sinks:
+            if const_expr(use_sinks):
                 sink_off = kv_head_idx * c_qgs + group_idx
-                if sink_dtype_str == "f32":
+                if const_expr(sink_dtype_str == "f32"):
                     sink_value = buffer_ops.buffer_load(
                         sink_rsrc, sink_off, vec_width=1, dtype=T.f32
                     )
-                elif sink_dtype_str == "f16":
+                elif const_expr(sink_dtype_str == "f16"):
                     sink_value_raw = buffer_ops.buffer_load(
                         sink_rsrc, sink_off, vec_width=1, dtype=T.f16
                     )
@@ -4732,7 +4733,7 @@ def compile_pa_decode_ps_reduce_flydsl(
                 c_one_f,
             )
             weight_local = scaled_sum / safe_global_exp_sum
-            weight_local_i32 = arith.bitcast(T.i32, weight_local)
+            weight_local_i32 = arith.bitcast(T.i32, arith.unwrap(weight_local))
 
             acc = c_zero_f
             for part_idx in range_constexpr(max_context_partition_num):
@@ -4749,11 +4750,11 @@ def compile_pa_decode_ps_reduce_flydsl(
                     + eqgs_idx * stride_logits_group
                     + tid
                 )
-                if logits_dtype_str == "f32":
+                if const_expr(logits_dtype_str == "f32"):
                     part_logits = buffer_ops.buffer_load(
                         logits_rsrc, logits_off, vec_width=1, dtype=T.f32
                     )
-                elif logits_dtype_str == "f16":
+                elif const_expr(logits_dtype_str == "f16"):
                     part_logits_raw = buffer_ops.buffer_load(
                         logits_rsrc, logits_off, vec_width=1, dtype=T.f16
                     )
@@ -4819,13 +4820,13 @@ def compile_pa_decode_ps_reduce_flydsl(
                 chunk_sum = _block_reduce(part_sum * part_scale, "sum")
                 global_exp_sum = global_exp_sum + chunk_sum
 
-            if use_sinks:
+            if const_expr(use_sinks):
                 sink_off = kv_head_idx * c_qgs + group_idx
-                if sink_dtype_str == "f32":
+                if const_expr(sink_dtype_str == "f32"):
                     sink_value = buffer_ops.buffer_load(
                         sink_rsrc, sink_off, vec_width=1, dtype=T.f32
                     )
-                elif sink_dtype_str == "f16":
+                elif const_expr(sink_dtype_str == "f16"):
                     sink_value_raw = buffer_ops.buffer_load(
                         sink_rsrc, sink_off, vec_width=1, dtype=T.f16
                     )
@@ -4892,11 +4893,11 @@ def compile_pa_decode_ps_reduce_flydsl(
                     + eqgs_idx * stride_logits_group
                     + tid
                 )
-                if logits_dtype_str == "f32":
+                if const_expr(logits_dtype_str == "f32"):
                     part_logits = buffer_ops.buffer_load(
                         logits_rsrc, logits_off, vec_width=1, dtype=T.f32
                     )
-                elif logits_dtype_str == "f16":
+                elif const_expr(logits_dtype_str == "f16"):
                     part_logits_raw = buffer_ops.buffer_load(
                         logits_rsrc, logits_off, vec_width=1, dtype=T.f16
                     )
@@ -4917,9 +4918,9 @@ def compile_pa_decode_ps_reduce_flydsl(
             + group_idx * stride_output_group_size
             + tid
         )
-        if output_dtype_str == "f32":
+        if const_expr(output_dtype_str == "f32"):
             out_val = acc
-        elif output_dtype_str == "f16":
+        elif const_expr(output_dtype_str == "f16"):
             out_val = arith.trunc_f(T.f16, acc)
         else:
             out_val = arith.trunc_f(T.bf16, acc)

--- a/aiter/ops/triton/gluon/pa_decode_gluon.py
+++ b/aiter/ops/triton/gluon/pa_decode_gluon.py
@@ -103,6 +103,11 @@ def get_occupancy():
     return 2
 
 
+# Upper bound on the partition count get_recommended_splits returns at runtime;
+# also the default set of variants the FlyDSL PS-reduce AOT precompiles.
+PA_DECODE_MAX_SPLITS = 8
+
+
 def get_recommended_splits(num_sequences, num_kv_heads, split_kv_blocks=1):
     props = torch.cuda.get_device_properties()
     num_sm = props.multi_processor_count * get_occupancy()
@@ -110,7 +115,7 @@ def get_recommended_splits(num_sequences, num_kv_heads, split_kv_blocks=1):
         num_sm, num_sequences * num_kv_heads * split_kv_blocks
     )
     max_context_partition_num *= split_kv_blocks
-    return min(max_context_partition_num, 8)
+    return min(max_context_partition_num, PA_DECODE_MAX_SPLITS)
 
 
 DS_WRITE = gl.constexpr(0x200)

--- a/aiter/ops/triton/gluon/pa_decode_gluon.py
+++ b/aiter/ops/triton/gluon/pa_decode_gluon.py
@@ -4516,8 +4516,6 @@ def _flydsl_dtype_str(dtype: torch.dtype) -> str:
 def compile_pa_decode_ps_reduce_flydsl(
     *,
     max_context_partition_num: int,
-    query_seq_len: int,
-    query_group_size: int,
     head_size: int,
     output_dtype_str: str,
     logits_dtype_str: str,
@@ -4565,6 +4563,7 @@ def compile_pa_decode_ps_reduce_flydsl(
         stride_logits_head: Int32,
         stride_logits_part: Int32,
         stride_logits_group: Int32,
+        query_group_size: Int32,
     ):
         tid = gpu.thread_idx.x
         batch_idx = gpu.block_idx.x
@@ -4599,7 +4598,7 @@ def compile_pa_decode_ps_reduce_flydsl(
         c_red_slots = arith.constant(red_slots, type=T.i32)
         lane = tid & c_wave_mask
         wave = tid >> c_wave_shift
-        c_qgs = arith.constant(query_group_size, type=T.i32)
+        c_qgs = query_group_size
         group_idx = eqgs_idx % c_qgs
 
         def _wave_reduce_max_full(val):
@@ -4949,6 +4948,8 @@ def compile_pa_decode_ps_reduce_flydsl(
         stride_logits_head,
         stride_logits_part,
         stride_logits_group,
+        query_seq_len,
+        query_group_size,
         batch_size,
         num_kv_heads,
         stream: fx.Stream = fx.Stream(None),
@@ -4974,6 +4975,7 @@ def compile_pa_decode_ps_reduce_flydsl(
             stride_logits_head,
             stride_logits_part,
             stride_logits_group,
+            query_group_size,
         ).launch(
             grid=(batch_size, num_kv_heads, query_seq_len * query_group_size),
             block=(block_threads, 1, 1),
@@ -5016,8 +5018,6 @@ def launch_pa_decode_ps_reduce_flydsl(
 
     compiled = compile_pa_decode_ps_reduce_flydsl(
         max_context_partition_num=context_partition_num,
-        query_seq_len=query_seq_len,
-        query_group_size=query_group_size,
         head_size=head_size,
         output_dtype_str=_flydsl_dtype_str(output_ptr.dtype),
         logits_dtype_str=_flydsl_dtype_str(logits_ptr.dtype),
@@ -5048,6 +5048,8 @@ def launch_pa_decode_ps_reduce_flydsl(
         stride_logits_head,
         stride_logits_part,
         stride_logits_group,
+        query_seq_len,
+        query_group_size,
         output_ptr.shape[0],
         output_ptr.shape[2],
         torch.cuda.current_stream(output_ptr.device),

--- a/aiter/ops/triton/gluon/pa_decode_gluon.py
+++ b/aiter/ops/triton/gluon/pa_decode_gluon.py
@@ -5084,6 +5084,33 @@ def _paged_attention_decode_v2_reduce_kernel_wrapper(
         All parameters from the reduction kernel plus execution grid configuration
     """
     if PS:
+        if FLYDSL_PS_REDUCE_AVAILABLE:
+            try:
+                launch_pa_decode_ps_reduce_flydsl(
+                    output_ptr,
+                    exp_sums_ptr,
+                    max_logits_ptr,
+                    logits_ptr,
+                    sink_token_ptr,
+                    stride_output_bs,
+                    stride_output_len,
+                    stride_output_kv_head,
+                    stride_output_group_size,
+                    stride_exp_sums_seq,
+                    stride_exp_sums_head,
+                    stride_exp_sums_part,
+                    stride_logits_seq,
+                    stride_logits_head,
+                    stride_logits_part,
+                    stride_logits_group,
+                    query_seq_len=query_seq_len,
+                    query_group_size=query_group_size,
+                    head_size=head_size,
+                    context_partition_num=context_partition_num,
+                )
+                return
+            except ImportError:
+                pass
         if CXX_PS_REDUCE_AVAILABLE:
             try:
                 launch_pa_decode_ps_reduce_cxx(
@@ -5111,56 +5138,31 @@ def _paged_attention_decode_v2_reduce_kernel_wrapper(
                 return
             except ImportError:
                 pass
-        try:
-            launch_pa_decode_ps_reduce_flydsl(
-                output_ptr,
-                exp_sums_ptr,
-                max_logits_ptr,
-                logits_ptr,
-                sink_token_ptr,
-                stride_output_bs,
-                stride_output_len,
-                stride_output_kv_head,
-                stride_output_group_size,
-                stride_exp_sums_seq,
-                stride_exp_sums_head,
-                stride_exp_sums_part,
-                stride_logits_seq,
-                stride_logits_head,
-                stride_logits_part,
-                stride_logits_group,
-                query_seq_len=query_seq_len,
-                query_group_size=query_group_size,
-                head_size=head_size,
-                context_partition_num=context_partition_num,
-            )
-            return
-        except ImportError:
-            ps_reduce_grid = (grid[0], grid[1], query_seq_len * query_group_size)
-            paged_attention_decode_ps_reduce_kernel[ps_reduce_grid](
-                output_ptr,
-                exp_sums_ptr,
-                max_logits_ptr,
-                logits_ptr,
-                sink_token_ptr,
-                stride_output_bs,
-                stride_output_len,
-                stride_output_kv_head,
-                stride_output_group_size,
-                stride_exp_sums_seq,
-                stride_exp_sums_head,
-                stride_exp_sums_part,
-                stride_logits_seq,
-                stride_logits_head,
-                stride_logits_part,
-                stride_logits_group,
-                query_group_size=query_group_size,
-                head_size=head_size,
-                context_partition_num=context_partition_num,
-                HEAD_SIZE_POW2=triton.next_power_of_2(head_size),
-                USE_SINKS=sink_token_ptr is not None,
-                MAX_CONTEXT_PARTITION_NUM=triton.next_power_of_2(context_partition_num),
-            )
+        ps_reduce_grid = (grid[0], grid[1], query_seq_len * query_group_size)
+        paged_attention_decode_ps_reduce_kernel[ps_reduce_grid](
+            output_ptr,
+            exp_sums_ptr,
+            max_logits_ptr,
+            logits_ptr,
+            sink_token_ptr,
+            stride_output_bs,
+            stride_output_len,
+            stride_output_kv_head,
+            stride_output_group_size,
+            stride_exp_sums_seq,
+            stride_exp_sums_head,
+            stride_exp_sums_part,
+            stride_logits_seq,
+            stride_logits_head,
+            stride_logits_part,
+            stride_logits_group,
+            query_group_size=query_group_size,
+            head_size=head_size,
+            context_partition_num=context_partition_num,
+            HEAD_SIZE_POW2=triton.next_power_of_2(head_size),
+            USE_SINKS=sink_token_ptr is not None,
+            MAX_CONTEXT_PARTITION_NUM=triton.next_power_of_2(context_partition_num),
+        )
     else:
         paged_attention_decode_v2_reduce_kernel[grid](
             output_ptr,


### PR DESCRIPTION
## Motivation
The Gluon paged-attention decode partition-softmax (PS) reduce step previously
defaulted to the C++ (HIP) implementation, with the FlyDSL reduce kernel kept
only as a secondary fallback. This PR makes the FlyDSL reduce kernel the default
backend for the PS reduce path. Because the FlyDSL kernel had been sitting behind
the C++ path, it had never actually been compiled/executed, so promoting it to
default also required fixing several latent bugs in it.
## Technical Details
- **Backend selection reorder** (`_paged_attention_decode_v2_reduce_kernel_wrapper`,
  `PS` path): the selection order is now FlyDSL → C++ → Triton (was C++ → FlyDSL → Triton).
- **Hardened fallback chain**: each backend is now guarded by its own availability
  flag (`FLYDSL_PS_REDUCE_AVAILABLE`, `CXX_PS_REDUCE_AVAILABLE`), and the Triton
  kernel is the unconditional final fallback. Previously the second branch called
  the C++ launcher unconditionally; when the C++ extension is not built that symbol
  is `None`, so `None(...)` raised `TypeError` (not caught by `except ImportError`)
  and the Triton fallback was skipped.
- **FlyDSL compile-time branching fix** (`compile_pa_decode_ps_reduce_flydsl`):
  all compile-time-constant conditions are now wrapped with `const_expr(...)` 
## Test Plan
- `python op_tests/triton_tests/test_pa_decode_gluon.py` (full sweep, 128 cases,
  bf16, with/without sinks, PS enabled), run with the FlyDSL reduce backend as default.