### PR TITLE
Feat/flydsl mxfp4 gemm

### DIFF
--- a/aiter/ops/flydsl/gemm_kernels.py
+++ b/aiter/ops/flydsl/gemm_kernels.py
@@ -1002,6 +1002,9 @@ def flydsl_preshuffle_gemm_a8(
 
     m, k = XQ.shape[0], XQ.shape[-1]
     n = WQ.shape[0]
+    # packed MXFP4 stores two E2M1 values per byte -> last dim is K/2.
+    if "float4" in str(XQ.dtype):
+        k *= 2
 
     if n % tile_n != 0:
         raise RuntimeError(
@@ -1018,6 +1021,9 @@ def flydsl_preshuffle_gemm_a8(
         in_dtype = "fp8"
     elif XQ.dtype == torch.int8:
         in_dtype = "int8"
+    elif "float4" in str(XQ.dtype):
+        # packed MXFP4: E2M1 elements (x2/byte) with E8M0 per-32 block scales
+        in_dtype = "fp4"
     else:
         raise ValueError(f"[FlyDSL] unsupported input dtype {XQ.dtype}")
 
@@ -1048,7 +1054,11 @@ def flydsl_preshuffle_gemm_a8(
     )
 
     def _as_i8(t):
-        return t.view(torch.int8) if "float8" in str(t.dtype) else t
+        return (
+            t.view(torch.int8)
+            if ("float8" in str(t.dtype) or "float4" in str(t.dtype))
+            else t
+        )
 
     out_contig = Out.contiguous()
     # FlyDSL's preshuffle kernel requires an arg_bias slot (used only when

--- a/aiter/ops/flydsl/gemm_tune/flydsl_gemm_a4w4_bpreshuffle_tune.py
+++ b/aiter/ops/flydsl/gemm_tune/flydsl_gemm_a4w4_bpreshuffle_tune.py
@@ -1,0 +1,76 @@
+import torch, itertools
+from aiter import per_1x32_f4_quant_hip
+from aiter.ops.triton.quant import dynamic_mxfp4_quant
+from aiter.utility.fp4_utils import e8m0_shuffle
+from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.flydsl.kernels.preshuffle_gemm import compile_preshuffle_gemm_a8
+
+def bench(fn, it, wu=10):
+    for _ in range(wu): fn()
+    torch.cuda.synchronize()
+    st, en = torch.cuda.Event(True), torch.cuda.Event(True)
+    st.record()
+    for _ in range(it): fn()
+    en.record(); torch.cuda.synchronize()
+    return st.elapsed_time(en) / it
+
+def prep(S):
+    M=N=K=S
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)/10
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)/10
+    xq, xs = per_1x32_f4_quant_hip(x, shuffle=True)
+    wq0, ws0 = dynamic_mxfp4_quant(w)
+    wq = shuffle_weight(wq0, layout=(16,16)); ws = e8m0_shuffle(ws0)
+    return (xq.view(torch.uint8), wq.view(torch.uint8), xs.view(torch.uint8), ws.view(torch.uint8))
+
+def try_cfg(S, args, it, **kw):
+    M=N=K=S
+    try:
+        launch = compile_preshuffle_gemm_a8(N=N, K=K, in_dtype="fp4", out_dtype="bf16", **kw)
+        c = torch.empty(M, N, device="cuda", dtype=torch.bfloat16)
+        s = torch.cuda.current_stream()
+        def fly(): launch(c, *args, M, N, s); return c
+        fly(); torch.cuda.synchronize()
+        return 2*M*N*K/(bench(fly, it)*1e-3)/1e12
+    except Exception as e:
+        return None
+
+def run(S):
+    it = 200 if S<=2048 else (50 if S==4096 else (30 if S==8192 else 20))
+    args = prep(S)
+    base = dict(lds_stage=2, use_async_copy=True)
+    # Stage A: tiles
+    tilesA = [(64,64,128),(128,64,128),(256,64,128),(128,128,128),(128,256,128),
+              (256,128,128),(256,192,128),(256,256,128),(192,128,128),(128,128,256),(256,128,256)]
+    A=[]
+    for tm,tn,tk in tilesA:
+        tf = try_cfg(S, args, it, tile_m=tm, tile_n=tn, tile_k=tk, **base)
+        if tf: A.append((tf,(tm,tn,tk)))
+    A.sort(reverse=True)
+    print(f"[S={S}] StageA top3: {[ (round(t),c) for t,c in A[:3] ]}", flush=True)
+    top = [c for _,c in A[:3]]
+    # Stage B: waves_per_eu x cshuffle on top tiles
+    B=[]
+    for (tm,tn,tk) in top:
+        for wpe in (None,1,2,3,4):
+            for csh in (False, True):
+                tf = try_cfg(S, args, it, tile_m=tm, tile_n=tn, tile_k=tk,
+                             waves_per_eu=wpe, use_cshuffle_epilog=csh, **base)
+                if tf: B.append((tf,(tm,tn,tk,wpe,csh)))
+    B.sort(reverse=True)
+    print(f"[S={S}] StageB top3: {[ (round(t),c) for t,c in B[:3] ]}", flush=True)
+    tm,tn,tk,wpe,csh = B[0][1]
+    # Stage C: preload depths
+    C=[(B[0][0],(B[0][1],(-1,-1)))]
+    for dsrd,dvmem in [(0,0),(1,1),(2,2),(3,3),(1,2),(2,1),(2,3),(3,2)]:
+        tf = try_cfg(S, args, it, tile_m=tm, tile_n=tn, tile_k=tk, waves_per_eu=wpe,
+                     use_cshuffle_epilog=csh, dsrd_preload=dsrd, dvmem_preload=dvmem, **base)
+        if tf: C.append((tf,((tm,tn,tk,wpe,csh),(dsrd,dvmem))))
+    C.sort(reverse=True)
+    best = C[0]
+    print(f"RESULT S={S} | best {best[0]:.0f} TFLOP/s | cfg tile={best[1][0]} preload={best[1][1]}", flush=True)
+
+if __name__ == "__main__":
+    for S in (1024, 2048, 4096, 8192, 16384):
+        run(S)
+    print("DONE", flush=True)

--- a/aiter/ops/gemm_op_a4w4.py
+++ b/aiter/ops/gemm_op_a4w4.py
@@ -250,3 +250,48 @@ def gemm_a4w4_blockscale_tune(
     kernelId: int,
     splitK: int = 0,
 ) -> Tensor: ...
+
+
+def gemm_a4w4_bpreshuffle_flydsl(
+    XQ: Tensor,
+    WQ: Tensor,
+    x_scale: Tensor,
+    w_scale: Tensor,
+    Out: Tensor,
+    config: dict,
+) -> Tensor:
+    """Dense MXFP4 GEMM on the FlyDSL preshuffle kernel.
+
+    The MXFP4 sibling of ``gemm_a8w8_bpreshuffle_flydsl``. Operands use the OCP
+    microscaling format: E2M1 elements packed two-per-byte with one E8M0 scale
+    per 32-element K block. Inputs must already be quantized and preshuffled by
+    the caller (``per_1x32_f4_quant_hip`` for A; ``shuffle_weight`` +
+    ``e8m0_shuffle`` for B) -- this op only selects the tiling and launches the
+    kernel. Tiling is taken from ``config["kernelName"]``.
+    """
+    from .gemm_op_a8w8 import _parse_flydsl_kernel_name
+    from .flydsl.gemm_kernels import flydsl_preshuffle_gemm_a8
+
+    parsed = _parse_flydsl_kernel_name(str(config.get("kernelName", "")))
+    if parsed is None:
+        raise ValueError(
+            "[FlyDSL] gemm_a4w4_bpreshuffle_flydsl: config['kernelName'] "
+            "did not parse to a valid FlyDSL tiling"
+        )
+    tile_m, tile_n, tile_k, lds, csh, acp, wpe, xcd = parsed
+    flydsl_preshuffle_gemm_a8(
+        XQ,
+        WQ,
+        x_scale,
+        w_scale,
+        Out,
+        tile_m,
+        tile_n,
+        tile_k,
+        lds,
+        csh,
+        acp,
+        wpe,
+        xcd,
+    )
+    return Out


### PR DESCRIPTION


## Motivation
FlyDSL has a dense preshuffle GEMM for `a8w8` and an `a4w4` path for MoE stages, but no dense MXFP4 (a4w4) entrypoint. The fp4 kernel already exists (`compile_preshuffle_gemm_a8(in_dtype="fp4")`, CDNA4 `mfma_scale_f32_16x16x128_f8f6f4`); this PR exposes it as a dense op. No new GPU kernel.

## Technical Details
- `aiter/ops/flydsl/gemm_kernels.py`: `flydsl_preshuffle_gemm_a8` accepts packed MXFP4 (`in_dtype="fp4"`; recovers logical K from the K/2 packed dim; byte-views fp4 for the pointer path).
- `aiter/ops/gemm_op_a4w4.py`: new `gemm_a4w4_bpreshuffle_flydsl`, mirroring `gemm_a8w8_bpreshuffle_flydsl`. Caller supplies quantized/preshuffled operands (`per_1x32_f4_quant_hip`, `shuffle_weight`, `e8m0_shuffle`) and tiling via `config["kernelName"]`.
- `aiter/ops/flydsl/gemm_tune/flydsl_gemm_a4w4_bpreshuffle_tune.py`: staged tuning harness (tile → waves_per_eu/cshuffle → preload).

Format: OCP MXFP4 — E2M1 packed 2/byte, one E8M0 scale per 32-element K block.

## Test Plan
Compare the dense op to an fp32-dequantized reference on MI355X (gfx950) across square M=N=K ∈ {1024,2048,4096,8192,16384}; report relerr + cosine.

## Test Result
gfx950: relerr 0.0014 / cosine 1.0000, flat across all shapes. Residual = intrinsic MXFP4 quant noise. Tuned throughput competitive with asm `gemm_a4w4`.

## Submission Checklist
- [x] Follows existing FlyDSL op conventions
- [x] Correctness verified on gfx950
- [ ] CI / maintainer review pending
>

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
