### PR TITLE
[CK] Fix MoE 2-stage dispatch for non-128-divisible inter_dim

### DIFF
--- a/csrc/ck_gemm_moe_2stages_codegen/gen_instances.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gen_instances.py
@@ -84,7 +84,7 @@ A16W16_A8W8_gemm1_gfx950_heuristic_dispatch = """
         }}
         else if (block_m == 128)
         {{
-            if (inter_dim <= 192)
+            if (inter_dim <= 192 || inter_dim % 128 != 0)
             {{
                 return ck_moe_stage1_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 128, 64, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
             }}
@@ -95,7 +95,7 @@ A16W16_A8W8_gemm1_gfx950_heuristic_dispatch = """
         }}
         else if (block_m == 256)
         {{
-            if (inter_dim <= 192)
+            if (inter_dim <= 192 || inter_dim % 128 != 0)
             {{
                 return ck_moe_stage1_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 256, 64, 128/sizeof({A0DataType}), 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
             }}
@@ -370,7 +370,7 @@ A16W16_gemm2_gfx950_heuristic_dispatch = """
     {{
         if (block_m == 32)
         {{
-            if (inter_dim <= 192)
+            if (inter_dim <= 192 || inter_dim % 128 != 0)
             {{
                 return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 32, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
             }}
@@ -381,7 +381,7 @@ A16W16_gemm2_gfx950_heuristic_dispatch = """
         }}
         else if (block_m == 64)
         {{
-            if (inter_dim <= 192)
+            if (inter_dim <= 192 || inter_dim % 128 != 0)
             {{
                 return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V1, 256, 64, 128, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
             }}
@@ -392,7 +392,7 @@ A16W16_gemm2_gfx950_heuristic_dispatch = """
         }}
         else if (block_m == 128)
         {{
-            if (inter_dim <= 192)
+            if (inter_dim <= 192 || inter_dim % 128 != 0)
             {{
                 return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 128, 64, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
             }}
@@ -403,7 +403,7 @@ A16W16_gemm2_gfx950_heuristic_dispatch = """
         }}
         else if (block_m == 256)
         {{
-            if (inter_dim <= 192)
+            if (inter_dim <= 192 || inter_dim % 128 != 0)
             {{
                 return ck_moe_stage2_gemm<{A0DataType}, {B0DataType}, {AccDataType}, {EDataType}, {CDEElementOp}, V3, 256, 256, 128, 64, 1, 4, {Nswizzle}, {Quant} == static_cast<int>(QuantType::per_Tensor), {MulRoutedWeight}, {ActOP}>;
             }}


### PR DESCRIPTION
## Motivation

The gfx950 heuristic dispatch sent all inter_dim > 192 shapes to the NPerBlock/KPerBlock=128 fast path, which fails CK's N%NPerBlock (stage1) and K%KPerBlock (stage2) divisibility checks when inter_dim is not a multiple of 128 (e.g. DiffusionGemma moe_inter=704=64*11). Route those shapes to the PerBlock=64 instances, which divide any multiple of 64.

## Technical Details

Widen pre-existing dispatch heuristic `if (inter_dim <= 192)` to `if (inter_dim <= 192 || inter_dim % 128 != 0)`.

## Test Plan

 Verified on **gfx950** with the no-quant (a16w16) legacy CK 2-stage path at `inter_dim=704`, sweeping token counts from 1 to 163840 (covering all `block_m` selections: 32 / 64 / 128):

  ```bash
  python3 op_tests/test_moe_2stage.py --no-flydsl-csv -q 0 -dim 7168,704
  ```

## Test Result

```bash

  ┌────────┬─────────┬─────────────┐
  │ token  │ block_m │ logits_diff │
  ├────────┼─────────┼─────────────┤
  │      1 │      32 │    9.53e-06 │
  ├────────┼─────────┼─────────────┤
  │      3 │      32 │    9.13e-06 │
  ├────────┼─────────┼─────────────┤
  │      5 │      32 │    1.02e-05 │
  ├────────┼─────────┼─────────────┤
  │     16 │      32 │    1.04e-05 │
  ├────────┼─────────┼─────────────┤
  │     32 │      32 │    1.03e-05 │
  ├────────┼─────────┼─────────────┤
  │     64 │      32 │    1.03e-05 │
  ├────────┼─────────┼─────────────┤
  │    128 │      32 │    1.01e-05 │
  ├────────┼─────────┼─────────────┤
  │    256 │      64 │    1.01e-05 │
  ├────────┼─────────┼─────────────┤
  │   1024 │     128 │    1.01e-05 │
  ├────────┼─────────┼─────────────┤
  │   4096 │     128 │    1.01e-05 │
  ├────────┼─────────┼─────────────┤
  │   8192 │     128 │    1.01e-05 │
  ├────────┼─────────┼─────────────┤
  │ 163840 │     128 │    1.01e-05 │
  └────────┴─────────┴─────────────┘

```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
