### PR TITLE
[fix] correct the fake register of fused_allreduce_rmsnorm_quant

### DIFF
--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -178,11 +178,11 @@ def fused_allreduce_rmsnorm_quant_fake(
     return (
         torch.empty_like(res_inp),
         torch.empty_like(inp),
-        torch.empty(inp.shape[:-1] + (1,), dtype=torch.float32, device=inp.device()),
+        torch.empty(inp.shape[:-1] + (1,), dtype=torch.float32, device=inp.device),
     )
 
 
-@torch_compile_guard(gen_fake=fused_allreduce_rmsnorm_fake)
+@torch_compile_guard(gen_fake=fused_allreduce_rmsnorm_quant_fake)
 def fused_allreduce_rmsnorm_quant_(
     inp: torch.Tensor,
     res_inp: torch.Tensor,


### PR DESCRIPTION
## Motivation

Cherry-pick of #3744 to main. Fixes the fake registration of fused_allreduce_rmsnorm_quant (inp.device property and correct gen_fake target).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
