### PR TITLE
CI: skip Aiter Test for unrelated workflow edits

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -6,11 +6,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]  # Triggers on PRs targeting `main`
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+    paths:
+      - '**'
+      - '!**/*.md'
+      - '!docs/**'
+      - '!LICENSE'
+      - '!.gitignore'
+      - '!.github/workflows/**'
+      - '.github/workflows/aiter-test.yaml'
 
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Update Aiter Test pull_request path filters so edits to unrelated workflow files do not trigger Aiter Test, while keeping Aiter Test changes and normal code changes covered.