### PR TITLE
[Perf] moe_sorting: route E>=512 tiny-token decode to MultiPhase block-scan

### DIFF
--- a/csrc/include/moe_sorting_opus.h
+++ b/csrc/include/moe_sorting_opus.h
@@ -1355,6 +1355,8 @@ OPUS_H bool moe_sorting_is_oneshot(int tokens_, int num_experts_)
 #endif
     auto sub_token_          = moe_sorting_get_sub_token(tokens_, num_experts_);
     bool is_sub_token_onshot = tokens_ <= sub_token_;
+    if(num_experts_ >= 512 && is_sub_token_onshot)
+        return false;
     return is_sub_token_onshot;
 }
 


### PR DESCRIPTION
## Motivation

At MoE decode with **very large expert counts** (E ≥ 512, e.g. Qwen3.5-397B-A17B MXFP4) and **tiny token counts**, `moe_sorting_is_oneshot()` selects the single-block *oneshot* sort kernel. That kernel's latency is dominated by the `num_experts`-wide serial cumsum executed on a **single block** (~13 µs at E=512, tokens ≤ 8). The existing `MoeSortingMultiPhase` block-scan path parallelizes that scan across blocks and is faster (~8 µs) for exactly these shapes.

`moe_sorting` runs serially before every MoE stage-1 GEMM each decode step, so this fixed overhead shows up directly in low-concurrency decode latency/throughput.

## Modifications

One dispatch-heuristic guard in `moe_sorting_is_oneshot()` (`csrc/include/moe_sorting_opus.h`):

```cpp
auto sub_token_          = moe_sorting_get_sub_token(tokens_, num_experts_);
bool is_sub_token_onshot = tokens_ <= sub_token_;
// E>=512 tiny-token decode: route to MultiPhase block-scan (oneshot's single-block
// E-wide cumsum dominates here). tokens>=16 already selects MP, so only the
// tiny-token decode regime changes.
if(num_experts_ >= 512 && is_sub_token_onshot)
    return false;
return is_sub_token_onshot;
```

- Pure dispatch change — no kernel math is modified; it switches which existing sort kernel is launched.
- The single edit covers both the launch path and `moe_sorting_get_workspace_size()` (both call `is_oneshot`), so workspace is sized correctly for the now-MultiPhase shapes.
- `tokens >= 16` is untouched (it already selects MultiPhase), so larger batches are unaffected.

## Benchmarking

Model: **Qwen3.5-397B-A17B-MXFP4**, MI355X, TP2, IL=8192 / OL=1024, decode.

**Sort-kernel time in the decode trace (summed `opus_moe_sorting` / `mxfp4_moe_sort`), base vs opt:**

| concurrency | base (µs) | opt (µs) | opt/base |
|---|---|---|---|
| 4  | 593,536 | 369,370 | **0.62 (−38%)** |
| 64 | 458,986 | 459,707 | 1.00 (unchanged — already MultiPhase) |

**End-to-end `sglang.bench_serving` total_throughput (tok/s), base vs opt:**

| concurrency | base | opt | Δ |
|---|---|---|---|
| 4  | 3293.7  | 3417.7  | **+3.8%** |
| 8  | 5222.5  | 5377.6  | **+3.0%** |
| 16 | 7666.8  | 7630.7  | −0.5% |
| 32 | 10172.4 | 10159.3 | −0.1% |
| 64 | 13033.4 | 13000.1 | −0.3% |

The gain is concentrated at conc 4/8 (the shapes that were hitting the slow oneshot path, tokens ≤ sub_token ≈ 8). At conc ≥ 16 the path was already MultiPhase, so those rows are run-to-run noise (≈0), not regressions.


**MI300X unit test (gfx942) — `moe_sorting_opus` kernel µs, auto-dispatch (`dispatch_policy=0`), base vs opt:**

This checkpoint cannot run end-to-end on MI300X due to pre-existing, PR-unrelated gfx942 gaps (`topk_softmax` has no gfx942 heuristic kernel; the `moe_sorting` torch binding segfaults on gfx942). To still validate the dispatch change on MI300X, the `moe_sorting_opus` kernel was exercised directly through a torch-free pure-HIP harness (raw device pointers, `hipEvent` timing, 200 iters), E=512 / topk=10 / model_dim=4096.

| concurrency | base (µs) | opt (µs) | opt/base |
|---|---|---|---|
| 1  | 11.57 | 6.55 | **0.57 (−43%)** |
| 2  | 11.65 | 6.48 | **0.56 (−44%)** |
| 4  | 11.79 | 6.34 | **0.54 (−46%)** |
| 8  | 12.45 | 6.37 | **0.51 (−49%)** |
| 16 | 6.96  | 6.58 | 0.95 (already MultiPhase) |
| 32 | 6.68  | 6.79 | 1.02 (already MultiPhase) |
| 64 | 6.96  | 6.71 | 0.96 (already MultiPhase) |

Same shape as MI355X: the low-concurrency decode regime (conc 1–8) sorts ~1.8–2.0× faster on MI300X, with no change at conc ≥ 16. Forcing the kernels directly (`dispatch_policy=1` oneshot / `=2` MultiPhase) yields identical µs before vs after, confirming the PR only changes which existing kernel auto-dispatch selects — so it is safe on gfx942.

## Accuracy Tests

- `op_tests/test_moe_sorting.py` — allclose of `sorted_token_ids` / `num_valid` vs the reference: **PASS (20/20)**. The two sort kernels produce **identical** sorted output, so this is behavior-preserving by construction.
- GSM8K (validation harness, this checkpoint has a known-low absolute score): 0.695 → 0.67. Since the kernel output is allclose-identical, this 0.025 delta is sampling noise, not a numerical change.

## Checklist

- [x] Pure dispatch change; no kernel math modified.
- [x] `op_tests/test_moe_sorting.py` allclose passes (20/20).
- [x] Benchmarked end-to-end + per-kernel profile on MI355X TP2.
- [x] No effect on `tokens >= 16` / `E < 512` paths.
