### PR TITLE
[Bugfix] fix mxfp4 kernel even round method

### DIFF
--- a/csrc/kernels/quant_mxfp4.cu
+++ b/csrc/kernels/quant_mxfp4.cu
@@ -38,13 +38,17 @@ __device__ __forceinline__ uint32_t cvt_fp4_pk(uint32_t src, uint32_t pair, floa
 __device__ __forceinline__ uint8_t even_round_e2m1(float val) {
     float a = fabsf(val);
     uint8_t mag;
-    if      (a >= 5.0f)  mag = 7;
+    // Round-to-nearest-even: at an exact midpoint, round to the value whose
+    // E2M1 mantissa bit is 0. Midpoints where the larger neighbor is odd
+    // (5.0, 2.5, 1.25, 0.25) use strict '>' so the tie rounds down to even;
+    // midpoints where the larger neighbor is even (3.5, 1.75, 0.75) use '>='.
+    if      (a >  5.0f)  mag = 7;
     else if (a >= 3.5f)  mag = 6;
-    else if (a >= 2.5f)  mag = 5;
+    else if (a >  2.5f)  mag = 5;
     else if (a >= 1.75f) mag = 4;
-    else if (a >= 1.25f) mag = 3;
+    else if (a >  1.25f) mag = 3;
     else if (a >= 0.75f) mag = 2;
-    else if (a >= 0.25f) mag = 1;
+    else if (a >  0.25f) mag = 1;
     else                 mag = 0;
     uint8_t sign_bit = (val < 0.0f) ? 8u : 0u;
     return sign_bit | mag;


### PR DESCRIPTION
Fix: even_round_e2m1 did not strictly follow round-to-nearest-even on the non-gfx950 path

The software fallback (non-gfx950) path for FP4 (E2M1) quantization in quant_mxfp4.cu uses even_round_e2m1 to map scaled values to E2M1. Despite its name, the original implementation used >= for every interval boundary, which rounds exact midpoints away from zero (round-half-away-from-zero) instead of to the nearest even value.

The representable E2M1 magnitudes are {0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0}, with midpoints at 0.25 / 0.75 / 1.25 / 1.75 / 2.5 / 3.5 / 5.0. At 0.25 / 1.25 / 2.5 / 5.0 the larger neighbor is the odd code, so RNE should round down to the even value, but the original code rounded up to the odd one. Since the scale is a power of two and inputs are fp16/bf16, scaled values can land exactly on these midpoints, so this is a real numerical difference.

Change: the four boundaries 0.25 / 1.25 / 2.5 / 5.0 now use strict > (tie rounds down to even), while 0.75 / 1.75 / 3.5 keep >=. This makes the fallback path consistent with the gfx950 hardware conversion instruction, which already performs RNE.