### PR TITLE
fix(fused_moe): require KBatch >= 2 for block-fp8 split-k

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -3155,7 +3155,14 @@ def ck_moe_stage1(
     dtype=None,
 ):
     token_num = hidden_states.shape[0]
-    is_splitk = quant_type == QuantType.per_1x128 and splitk > 1
+    # Only enable split-k when each K partition owns >= 2 k-tiles
+    # (KBatch = K / (splitk * KPerBlock), KPerBlock == 256). When KBatch == 1 the
+    # CK kernel uses atomic-add but skips the output memset, accumulating onto
+    # uninitialized memory -> gibberish. This guards splitk from CSV / AITER_KSPLIT
+    # that bypass get_ksplit's KBatch >= 2 check.
+    KPerBlock = 256
+    k_batch = (hidden_states.shape[1] // splitk) // KPerBlock if splitk > 1 else 1
+    is_splitk = quant_type == QuantType.per_1x128 and splitk > 1 and k_batch >= 2
     if is_splitk:
         # CK kernel zeros this buffer via hipMemsetAsync when KBatch > 1
         sorted_size = min(token_num * topk * block_m, sorted_token_ids.shape[0])


### PR DESCRIPTION
## Motivation

get_ksplit could pick a split where each K partition owns a single k-tile (KBatch = model_dim / (split * 256) == 1). In that case the CK stage1 kernel still uses atomic-add but skips the output memset, accumulating onto uninitialized memory and producing gibberish at bs=1 (e.g. Qwen3.5-FP8 TP8, K=4096, split=16). Add the KBatch >= 2 condition in get_ksplit, and guard ck_moe_stage1 so splitk from tuned CSV / AITER_KSPLIT cannot bypass it.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Add op_tests/test_moe_blockscale_ksplit.py: exercises the high-level fused_moe() CK 2-stage path (which get_ksplit feeds, unlike test_moe_blockscale) against a bf16 pre-quant reference, asserting row-0 rel error stays within fp8 block-quant noise.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
