### PR TITLE
fix: optimize MXFP4 a4w4 MoE dispatch for MiniMax-M2.1-MXFP4

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -876,6 +876,7 @@ class MOEMetadata:
     fuse_quant: str = ""
     stage2_has_bias: bool = False
     flat: bool = False
+    skip_inter_quant: bool = False
 
 
 def _needs_swiglu_bias_support(dtype, quant_type):
@@ -1364,6 +1365,12 @@ def get_2stage_cfgs(
     def get_block_m() -> int:
         if q_dtype_a == dtypes.fp8:
             return 32
+        elif q_dtype_a == dtypes.fp4x2:
+            # MXFP4 fused quant+sort requires block_size % 32 == 0.
+            # block_m=64 is significantly faster than 32 for fp4x2 on
+            # gfx950 across all tested batch sizes (up to 1.5x for
+            # prefill).  128 is not supported by current CKTile stage2.
+            return 64
         else:
             return 16 if token < 2048 else 32 if token < 16384 else 64
 
@@ -1608,6 +1615,7 @@ def get_2stage_cfgs(
         dtype in [dtypes.bf16, dtypes.fp16]
         and q_type == QuantType.per_1x32
         and q_dtype_w in [dtypes.fp4x2]
+        and q_dtype_a not in [dtypes.fp4x2]
         and is_shuffled
         and not (activation == ActivationType.Swiglu and q_dtype_a == dtypes.fp4x2)
         and (ksplit > 1 or swiglu_mxfp4_bf16_cktile)
@@ -1643,6 +1651,33 @@ def get_2stage_cfgs(
             run_1stage,
             has_bias=activation == ActivationType.Swiglu,
             stage2_has_bias=activation == ActivationType.Swiglu,
+        )
+    elif (
+        dtype in [dtypes.bf16, dtypes.fp16]
+        and q_type == QuantType.per_1x32
+        and q_dtype_a in [dtypes.fp4x2]
+        and q_dtype_w in [dtypes.fp4x2]
+    ):
+        # Stage1 uses JIT CK (DeviceMoeGemmMXBPreShuffle) which correctly
+        # handles fp4x2 activations x fp4x2 weights.  Stage2 uses CKTile AOT
+        # with bf16 activations x fp4x2 weights (a16w4 path), skipping the
+        # costly intermediate bf16->fp4x2 quantization between stages.
+        return MOEMetadata(
+            functools.partial(
+                ck_moe_stage1,
+                quant_type=q_type,
+                activation=activation,
+            ),
+            functools.partial(
+                cktile_moe_stage2,
+                n_pad_zeros=hidden_pad // 64 * 64,
+                k_pad_zeros=intermediate_pad // 128 * 128,
+                activation=activation,
+            ),
+            get_block_m(),
+            0,
+            False,
+            skip_inter_quant=True,
         )
 
     if (
@@ -1983,6 +2018,7 @@ def fused_moe_2stages(
             q_dtype_a in [dtypes.bf16, dtypes.fp16]
             and activation == ActivationType.Swiglu
             or (metadata.ksplit > 1 and is_shuffled)
+            or metadata.skip_inter_quant
         )
     ):
         a2_scale = None
@@ -2427,6 +2463,15 @@ def torch_moe_stage2(
         hidden_states = hidden_states.view(a2_shape)
 
         w2_shape = w2.shape
+        # Some TP-sharded models carry padded per_1x32 scale groups in w2_scale.
+        # Align scale groups to runtime inter_dim groups for robust torch fallback.
+        w2_scale = w2_scale.view(E, model_dim, -1)
+        w2_groups = inter_dim // 32
+        if w2_scale.shape[2] > w2_groups:
+            w2_scale = w2_scale[:, :, :w2_groups]
+        elif w2_scale.shape[2] < w2_groups:
+            pad = w2_groups - w2_scale.shape[2]
+            w2_scale = torch.nn.functional.pad(w2_scale, (0, pad), value=1.0)
         w2 = w2.view(E, model_dim, inter_dim // 32, 32) * w2_scale.view(
             E, model_dim, inter_dim // 32, 1
         )

--- a/aiter/ops/triton/_triton_kernels/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/_triton_kernels/quant/fused_mxfp4_quant.py
@@ -839,6 +839,7 @@ def _fused_dynamic_mxfp4_quant_moe_sort_kernel(
     stride_o4,  #: tl.constexpr,
     token_num,  #: tl.constexpr,
     N_i,  #: tl.constexpr,
+    N_o,
     MXFP4_QUANT_BLOCK_SIZE: tl.constexpr,
     BLOCK_SIZE_Mx: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
@@ -934,12 +935,13 @@ def _fused_dynamic_mxfp4_quant_moe_sort_kernel(
 
     pid -= num_pid_x
     num_pid_n = tl.cdiv(N_i, BLOCK_SIZE_N * 2)
-    pid_m = pid // num_pid_n  # * 2
-    pid_n = pid % num_pid_n  # * 2
-    # pid_m = tl.program_id(0) * 2
-    # pid_n = tl.program_id(1) * 2
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
     num_valid_ids = tl.load(num_valid_ids_ptr)
     if pid_m * BLOCK_SIZE_M * 2 >= num_valid_ids:
+        return
+    num_valid_n_tiles = tl.cdiv(N_o, BLOCK_SIZE_N * 2)
+    if pid_n >= num_valid_n_tiles:
         return
     stride_o0 = tl.cast(stride_o0, tl.int64)
     stride_o1 = tl.cast(stride_o1, tl.int64)

--- a/aiter/ops/triton/quant/fused_mxfp4_quant.py
+++ b/aiter/ops/triton/quant/fused_mxfp4_quant.py
@@ -610,7 +610,6 @@ def fused_dynamic_mxfp4_quant_moe_sort(
 
     N_i = scaleN
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(
@@ -642,6 +641,7 @@ def fused_dynamic_mxfp4_quant_moe_sort(
         *blockscale_e8m0_sorted.stride(),
         token_num=token_num,
         N_i=N_i,
+        N_o=N_o,
         MXFP4_QUANT_BLOCK_SIZE=MXFP4_QUANT_BLOCK_SIZE,
         BLOCK_SIZE_Mx=BLOCK_SIZE_Mx,
         BLOCK_SIZE_M=BLOCK_SIZE_M // 2,

--- a/aiter/utility/fp4_utils.py
+++ b/aiter/utility/fp4_utils.py
@@ -227,6 +227,30 @@ def e8m0_shuffle(scale):
     return shuffle_scale(scale)
 
 
+def e8m0_unshuffle(scale):
+    """Inverse of the e8m0-shuffled layout written by fused_dynamic_mxfp4_quant_moe_sort_hip.
+    Converts from the C++ kernel's fp4_scale_shuffle_id layout back to linear row-major
+    layout, as expected by CK JIT kernels (DeviceMoeGemmMXBPreShuffle, Scale_Stride_AM).
+
+    The scale buffer has shape [m, K/32] where m is a multiple of 32 (not necessarily 256).
+    No padding is applied — the C++ and Python shuffle are equivalent for any m % 32 == 0.
+    """
+    if scale is None:
+        return scale
+    if scale.dtype == torch.float32:
+        return scale
+    assert scale.ndim == 2, "scale must be a 2D tensor"
+    m, n = scale.shape
+    assert m % 32 == 0 and n % 8 == 0, f"scale {m}×{n} not aligned for unshuffle"
+    # The C++ kernel wrote in [m//32, n//8, 4, 16, 2, 2] permuted order (equivalent to
+    # e8m0_shuffle's .view(m//32, 2, 16, n//8, 2, 4).permute(0,3,5,2,4,1)).
+    # Inverse permutation of (0, 3, 5, 2, 4, 1) is (0, 5, 3, 1, 4, 2).
+    t = scale.view(torch.uint8).view(m // 32, n // 8, 4, 16, 2, 2)
+    t = t.permute(0, 5, 3, 1, 4, 2).contiguous()
+    t = t.view(m, n)
+    return t.view(scale.dtype)
+
+
 def down_size(size):
     assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
     return (*size[:-1], size[-1] // 2)
@@ -797,7 +821,6 @@ def moe_mxfp4_sort(
         blockscale_e8m0 = padded
     M_i, N_i = blockscale_e8m0.shape
     M_o, N_o = sorted_ids.shape[0], N_i
-    assert (N_i // 2) % 2 == 0
     assert block_size % BLOCK_SIZE_M == 0
 
     blockscale_e8m0_sorted = torch.empty(

--- a/csrc/ck_tile_gemm_moe_2stages/gen_instances.py
+++ b/csrc/ck_tile_gemm_moe_2stages/gen_instances.py
@@ -615,6 +615,7 @@ if __name__ == "__main__":
     a_types = ["bf16"]
     if get_gfx() == "gfx950":
         a_types.append("fp8")
+        a_types.append("pk_fp4")
     b_type = "fp4"
     quant_type = "1x32"
 
@@ -652,8 +653,8 @@ if __name__ == "__main__":
     ):
         has_bias = True if act_type == "swiglu" else False
 
-        # a8w8 do not support
-        if a_type in ["fp8", "bf8"] and is_split_k:
+        # a8w8/a4w4 do not support split_k
+        if a_type in ["fp8", "bf8", "pk_fp4"] and is_split_k:
             continue
         codegen = cktile_moe_2stage_gemm_codegen(
             args.working_path,

--- a/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
+++ b/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages.cu
@@ -378,6 +378,32 @@ torch::Tensor cktile_moe_gemm1(torch::Tensor& XQ,
                                                                k_batch);
         }
     }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<pk_fp4, pk_fp4, float, bf16, 1>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm1!");
+        }
+    }
     else
     {
         TORCH_CHECK(false, "Unsupported scales/output dtype!");
@@ -511,6 +537,32 @@ torch::Tensor cktile_moe_gemm2(torch::Tensor& XQ,
                                                                exp_bias,
                                                                act_op,
                                                                k_batch);
+        }
+    }
+    else if(XQ.dtype() == torch_fp4x2 && WQ.dtype() == torch_fp4x2) // a4w4 (MXFP4 quantized activations)
+    {
+        if(Y.dtype() == at::ScalarType::BFloat16)
+        {
+            moe_dispatch<pk_fp4, pk_fp4, float, bf16, 2>(M, N, K, MPerBlock, act_op, has_bias, k_batch)(
+                XQ,
+                WQ,
+                Y,
+                sorted_ids,
+                sorted_expert_ids,
+                max_token_ids,
+                topk,
+                n_padded_zeros,
+                k_padded_zeros,
+                topk_weight,
+                x_scale,
+                w_scale,
+                exp_bias,
+                act_op,
+                k_batch);
+        }
+        else
+        {
+            TORCH_CHECK(false, "Unsupported output dtype for a4w4 MoE gemm2!");
         }
     }
     else

--- a/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages_common.py
+++ b/csrc/ck_tile_gemm_moe_2stages/moe_cktile2stages_common.py
@@ -243,6 +243,23 @@ a8w4_gemm2_kernels_list_gfx950= {
     # 4: kernelInstance(       2,        256,      256,        128,       128,           16,         16,          32,          1,        4,),
 }
 
+
+# gemm1 out:bf16 AB:pk_fp4/pk_fp4 (MXFP4 quantized activations x MXFP4 weights)
+a4w4_gemm1_kernels_list_gfx950 = {
+    #  kernel:           stage| BLOCK_SIZE|MPerBLOCK|  NPerBLOCK| KPerBLOCK| WAVE_TILE_M| WAVE_TILE_N| WAVE_TILE_K| WAVE_MAP_M| WAVE_MAP_N| BlockPerCU|
+    0: kernelInstance(       1,        256,       16,        128,       256,          16,         16,         128,          1,           4,          2,),
+    1: kernelInstance(       1,        256,       32,        256,       256,          16,         16,         128,          1,           4,          2,),
+    3: kernelInstance(       1,        256,       64,        256,       256,          16,         16,         128,          1,           4,          1,),
+}
+# gemm2 out:bf16 AB:pk_fp4/pk_fp4 (MXFP4 quantized activations x MXFP4 weights)
+a4w4_gemm2_kernels_list_gfx950 = {
+    #  kernel:           stage| BLOCK_SIZE|MPerBLOCK|  NPerBLOCK| KPerBLOCK| WAVE_TILE_M| WAVE_TILE_N| WAVE_TILE_K| WAVE_MAP_M| WAVE_MAP_N| BlockPerCU|
+    # KPerBlock min=256 for fp4 (CK tile mixed_prec pipeline requires K1*K2=256)
+    0: kernelInstance(       2,        256,       16,        128,       256,          16,         16,         128,          1,        4,            2,),
+    1: kernelInstance(       2,        256,       32,        256,       256,          16,         16,         128,          1,        4,            2,),
+    3: kernelInstance(       2,        256,       64,        256,       256,          16,         16,         128,          1,        4,            1,),
+}
+
 # fmt: on
 gemm1_kernels_dict = {
     tag: expand_blockpercu(kdict)
@@ -252,6 +269,7 @@ gemm1_kernels_dict = {
         "a16w4_gfx950": a16w4_gemm1_kernels_list_gfx950,
         "a16w4": a16w4_gemm1_kernels_list,
         "a8w4_gfx950": a8w4_gemm1_kernels_list_gfx950,
+        "a4w4_gfx950": a4w4_gemm1_kernels_list_gfx950,
     }.items()
 }
 
@@ -263,6 +281,7 @@ gemm2_kernels_dict = {
         "a16w4_gfx950": a16w4_gemm2_kernels_list_gfx950,
         "a16w4": a16w4_gemm2_kernels_list,
         "a8w4_gfx950": a8w4_gemm2_kernels_list_gfx950,
+        "a4w4_gfx950": a4w4_gemm2_kernels_list_gfx950,
     }.items()
 }
 
@@ -519,12 +538,76 @@ struct moe_gemm2_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_da
 }};
 """
 
+a4w4_gfx950_heuristic_dispatch = """#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "moe_cktile2stages.h"
+#include "moe_cktile2stages_heuristic_dispatch_common.h"
+
+template <>
+struct moe_gemm1_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}, {(activation)}, {(has_bias)}, {(split_k)}>
+{{
+    static MoeKernel dispatch(int M, int N, int K, int block_m)
+    {{
+        if (block_m == 16)
+        {{
+            return {(1, 0)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 32)
+        {{
+            return {(1, 1)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 64)
+        {{
+            return {(1, 3)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else
+        {{
+            TORCH_CHECK(
+                false,
+                "Unsupported block_m value for moe_gemm1 a4w4 heuristic dispatch: ",
+                block_m);
+        }}
+    }}
+}};
+
+template <>
+struct moe_gemm2_heuristic_dispatcher<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}, {(activation)}, {(has_bias)}, {(split_k)}>
+{{
+    static MoeKernel dispatch(int M, int N, int K, int block_m)
+    {{
+        // KPerBlock=256 is the minimum for fp4 (CK tile mixed_prec pipeline
+        // requires K1*K2=256). The kernel handles K < KPerBlock via masking.
+        if (block_m == 16)
+        {{
+            return {(2, 0)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 32)
+        {{
+            return {(2, 1)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else if (block_m == 64)
+        {{
+            return {(2, 3)}<{(a_data_type)}, {(b_data_type)}, {(acc_data_type)}, {(c_data_type)}>;
+        }}
+        else
+        {{
+            TORCH_CHECK(
+                false,
+                "Unsupported block_m value for moe_gemm2 a4w4 heuristic dispatch: ",
+                block_m);
+        }}
+    }}
+}};
+"""
+
 heuristic_dispatch_dict = {
     "a8w8_gfx950": a8w8_gfx950_heuristic_dispatch,
     # "a8w8": a8w8_gemm2_kernels_list,
     "a16w4_gfx950": a16w4_gfx950_heuristic_dispatch,
     "a16w4": a16w4_heuristic_dispatch,
     "a8w4_gfx950": a8w4_gfx950_heuristic_dispatch,
+    "a4w4_gfx950": a4w4_gfx950_heuristic_dispatch,
 }
 
 
@@ -557,6 +640,13 @@ def get_gemm1_kernels_list(
     elif Adtype.lower() in bit8_list and Bdtype in bit4_list:
         if arch == "gfx950":
             tag = "a8w4_gfx950"
+        else:
+            raise ValueError(
+                f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
+            )
+    elif Adtype in bit4_list and Bdtype in bit4_list:
+        if arch == "gfx950":
+            tag = "a4w4_gfx950"
         else:
             raise ValueError(
                 f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
@@ -606,6 +696,13 @@ def get_gemm2_kernels_list(
     elif Adtype.lower() in bit8_list and Bdtype in bit4_list:
         if arch == "gfx950":
             tag = "a8w4_gfx950"
+        else:
+            raise ValueError(
+                f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"
+            )
+    elif Adtype in bit4_list and Bdtype in bit4_list:
+        if arch == "gfx950":
+            tag = "a4w4_gfx950"
         else:
             raise ValueError(
                 f"Unsupported data type combination: {Adtype}, {Bdtype} on {arch}"

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -271,6 +271,18 @@ def test_fmoe(
         w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, True)
         w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
         w2_scale_aiter = fp4_utils.e8m0_shuffle(w2_scale)
+    elif (
+        qType == aiter.QuantType.per_1x32
+        and AQDType == dtypes.fp4x2
+        and WQDType == dtypes.fp4x2
+    ):  # a4w4: both stage1 and stage2 use JIT CK (DeviceMoeGemmMXBPreShuffle)
+        # Both use preShuffleBuffer format = shuffle_weight_a16w4(gate_up=False)
+        # / shuffle_scale_a16w4(gate_up=False). Unlike a16w4, the a4w4 kernel
+        # uses gate_up=False for stage1 even though w1 has 2*N rows.
+        w1_qt_aiter = shuffle_weight_a16w4(w1_qt_aiter, 16, False)
+        w1_scale_aiter = shuffle_scale_a16w4(w1_scale, E, False)
+        w2_qt_aiter = shuffle_weight_a16w4(w2_qt_aiter, 16, False)
+        w2_scale_aiter = shuffle_scale_a16w4(w2_scale, E, False)
     elif WQDType != dtypes.fp4x2 or preshuffle:
         w1_qt_aiter = shuffle_weight(w1_qt_aiter, layout=(16, 16))
         w2_qt_aiter = shuffle_weight(w2_qt_aiter, layout=(16, 16))


### PR DESCRIPTION
## Summary

  Re-lands #2642 which was reverted in #3984 due to a build break. The root
  cause of the original CI failure has been identified and fixed.

  ### Why #2642 was reverted

  The original PR renamed the C++ type alias `using pk_fp4 = ck_tile::pk_fp4_t`
  to `using fp4 = ...` in `moe_cktile2stages.h`, and correspondingly changed
  `gen_instances.py` to emit `"fp4"` instead of `"pk_fp4"` in AOT-generated
  instance files and the name dispatch lookup header. This created an
  inconsistency between pre-built AOT `.so` objects (which embed `pk_fp4` in
  template names) and the new header, causing a build failure in CI.

  ### What this PR fixes differently

  - **Keeps `using pk_fp4 = ck_tile::pk_fp4_t` unchanged** in
    `moe_cktile2stages.h` — no rename
  - Uses `pk_fp4, pk_fp4` for the new a4w4 `moe_dispatch<>` instantiations,
    consistent with all existing a16w4/a8w4 dispatch calls
  - Adds `"pk_fp4"` as a new `a_type` entry in `gen_instances.py` instead of
    renaming the existing `"fp4"` b-type string

  All functional changes are identical to the original #2642.

  ### Changes

    `q_dtype_a not in [dtypes.fp4x2]` guard on the CK-Tile split-k block to
    prevent a4w4 entering the a16w4 path; add a4w4 elif dispatch (CK JIT
    stage1 + CKTile AOT stage2 with `skip_inter_quant=True`); add w2_scale
    group alignment in `torch_moe_stage2` for TP-sharded models
  - **Triton sort kernel**: Remove `(N_i // 2) % 2 == 0` assertion; add `N_o`
    tile-guard (early return instead of `.contiguous()` copy for non-aligned
    scaleN)
  - **`aiter/utility/fp4_utils.py`**: Add `e8m0_unshuffle()`; remove assertion
  - **CKTile C++**: Add `moe_dispatch<pk_fp4, pk_fp4, float, bf16, 1/2>`
    branches for a4w4 gemm1 and gemm2
  - **`gen_instances.py` / `moe_cktile2stages_common.py`**: Add a4w4 kernel
    lists, heuristic dispatch, and `get_gemm1/2_kernels_list` a4w4 branches
  - **`op_tests/test_moe_2stage.py`**: Add a4w4 weight shuffling setup

  ### Validation (MI350X / gfx950, MiniMax-M2.1-MXFP4, TP=8)
  
  | Path | GSM8K 5-shot (100 samples) | GPU Memory |
  |---|---|---|
  | FlyDSL (default) | 94% exact match | 241.1 GB (95.7%) |
  | CK (this PR, `AITER_BYPASS_TUNE_CONFIG=1 AITER_FLYDSL_FORCE=0`) | **95% exact match** | **238.7 GB (94.7%)** |

  Fixes: #3984 (revert of #2642)