### PR TITLE
fix(topk): add __threadfence before cross-block barrier in radix_kern…

### DIFF
--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -501,7 +501,7 @@ __global__ void radix_kernel_persistent(T const* in,
             vectorized_process(global_tid, total_threads, in_buf, row_len, hist_vec);
         }
 
-        // Flush LDS histogram to global via atomicAdd (no __threadfence needed on gfx942/gfx950).
+        // Flush LDS histogram to global via atomicAdd.
         __syncthreads();
         for(int i = threadIdx.x; i < num_buckets; i += blockDim.x)
         {
@@ -511,6 +511,7 @@ __global__ void radix_kernel_persistent(T const* in,
             }
         }
         __syncthreads();
+        __threadfence();
 
         // Cross-block barrier via atomicInc + spin-wait.
         bool isLastBlock = false;


### PR DESCRIPTION
## fix: add missing `__threadfence()` before cross-block barrier in `radix_kernel_persistent`

### Summary

Add a device-scope `__threadfence()` in `radix_kernel_persistent` between the histogram `atomicAdd` flush (L510) and the cross-block barrier arrival counter (`atomicInc`, L519). This matches the fence already present in the non-persistent `radix_kernel` at L1643.     

Without the fence, a reader block that passes the barrier may observe an incomplete histogram, compute a different `choose_bucket` result, and diverge in the pass loop — leaving its sibling blocks spinning forever on the barrier counter (`while(pass_done < target) s_sleep`).

### Root cause

`radix_kernel_persistent` fuses all radix passes into a single launch and synchronizes blocks within a row via an intra-kernel spin barrier (`atomicInc(finished_block_cnt)` + `while(pass_done < target)`). Each block flushes its local histogram to global memory via `atomicAdd` (relaxed), then signals arrival.

The barrier uses release/acquire semantics only between the **last arriving block** and the waiting blocks. However, the histogram writes come from **all blocks**, and their `atomicAdd`s are not ordered relative to the arrival counter without a device-scope fence. Under heavy GPU load (e.g., full-model CUDAGraph replay with interleaved deepgemm/MoE/all-reduce kernels), the L2 visibility window for these `atomicAdd`s widens enough that a reader block can pass the barrier before a sibling's histogram contribution is visible. When the missing contribution happens to shift the k-th value across a bucket boundary, the two blocks compute different `local_len`/`early_stop` — one breaks out of the pass loop while the others spin forever.

The non-persistent `radix_kernel` (which launches one kernel per pass) already has this `__threadfence()` at L1643.

### Evidence

**Live GPU forensics (rocgdb `info dispatches` + wave PCs) on the hung production process:**

```
Dispatch 5:2:1 (PKID 180375220) [4096,60,1] [1024,1,1]
  radix_kernel_persistent<float, int, 11, 1024, false, false, (Phase)1>

Row y=38, workgroup coordinates of stuck waves:
  x=0  -> PC 0xb380 (spin-wait: while(pass_done < target))
  x=2  -> PC 0xb380
  x=3  -> PC 0xb380
  x=1  -> ABSENT (left the pass loop -> barrier count stuck at 3/4 forever)
```

The grid is `dim3(4, 60)` — only 4 blocks per row on a 256-CU GPU, well within co-residency limits. Block x=1 diverged in its `choose_bucket` due to an incomplete histogram read, hit a different `early_stop`/`break` path, and exited the pass loop. The remaining 3 blocks spin at `pass_done` indefinitely. The 3 other TP ranks are downstream victims, stuck in the subsequent custom all-reduce waiting for the straggler rank.

**End-to-end validation (GLM-5.1-MXFP4, TP=4, single-node, ISL=8192/OSL=1024, CONC=32+64):**

| Run | Variant | Result | Hang signatures | Bench phases | GSM8K strict-match |
|-----|---------|--------|-----------------|-------------|-------------------|
| 10183 | Baseline (unpatched) | **HUNG** | 4 (Watchdog BROADCAST) | 0/2 | — |
| 10194 | Baseline (unpatched) | **HUNG** | 4 (Watchdog BROADCAST) | 0/2 | — |
| 10186 | **+threadfence** | COMPLETED | 0 | 2/2 | — |
| 10188 | **+threadfence** | COMPLETED | 0 | 2/2 | 0.9295 |
| 10189 | **+threadfence** | COMPLETED | 0 | 2/2 | 0.9363 |
| 10190 | **+threadfence** | COMPLETED | 0 | 2/2 | 0.9295 |

Baseline: **2/2 hung** (both during high-concurrency decode, classic Watchdog BROADCAST timeout).
Patched: **4/4 survived** the identical workload, GSM8K accuracy normal (~93% strict-match).

**Kernel-level performance (graph-replay, cols=151552, k=2048, fair rebuild with identical flags):**

| Batch | Unpatched (µs) | +threadfence (µs) | Delta |
|-------|---------------|-------------------|-------|
| 16 | 57.6 | 57.6 | +0.1% |
| 32 | 58.6 | 59.1 | +0.9% |
| 48 | 62.0 | 62.6 | +1.0% |
| 64 | 64.6 | 64.4 | −0.4% |

**Performance impact: negligible (~0–1%).**

### Note on unit-test reproducibility

This is a classic memory-ordering race: triggering requires (1) a late `atomicAdd` visibility window (needs real full-model L2/HBM contention, not achievable with a side-stream thrasher), (2) a reader block passing the barrier in that window, and (3) the missing histogram contribution shifting the k-th bucket boundary. These three conditions only co-occur under full-model CUDAGraph replay with real weights. Isolated kernel benchmarks (120k+ iterations with L2 thrashers + knife-edge data) do not reproduce. The fix is justified by memory-model analysis (the non-persistent variant already has this fence), live forensic evidence (intra-row block divergence), and deterministic e2e results (2/2 baseline hung, 4/4 patched survived).