### PR TITLE
ci: extend Qwen 3.5 SGLang timeout

### DIFF
--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -58,7 +58,7 @@ TESTS = [
         "model_id": "Qwen/Qwen3.5-397B-A17B",
         "model_path_env": "QWEN35_MODEL_PATH",
         "test_type": "Accuracy",
-        "timeout_minutes": 70,
+        "timeout_minutes": 100,
         "extra_exec_args": "",
         "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-mi35x-qwen35 --nightly --timeout-per-file 3600",
         "run_on_pr": True,

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -14,6 +14,7 @@ on:
       - '!.gitignore'
       - '!.github/workflows/**'
       - '.github/workflows/aiter-test.yaml'
+      - '!.github/scripts/sglang_downstream.py'
 
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
## Summary
- Increase the Qwen 3.5 SGLang accuracy matrix timeout from 70 to 100 minutes.

## Testing
- python3 -m py_compile .github/scripts/sglang_downstream.py