### PR TITLE
Feat/fused qk norm rope 1way fp8 perhead

### DIFF
--- a/aiter/ops/fused_qk_norm_rope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_rope_cache_quant.py
@@ -692,17 +692,29 @@ def fused_qk_norm_rope_1way_fp8_perhead_quant(
         dtype=fp8_dtype,
         device=k.device,
     )
-    q_descale = torch.empty((batch_size, num_heads_q), dtype=torch.float32, device=q.device)
-    k_descale = torch.empty((batch_size, num_heads_k), dtype=torch.float32, device=k.device)
+    q_descale = torch.empty(
+        (batch_size, num_heads_q), dtype=torch.float32, device=q.device
+    )
+    k_descale = torch.empty(
+        (batch_size, num_heads_k), dtype=torch.float32, device=k.device
+    )
     q_unquantized = (
         out_q
         if out_q is not None
-        else torch.empty((batch_size, num_tokens, num_heads_q, head_size), dtype=q.dtype, device=q.device)
+        else torch.empty(
+            (batch_size, num_tokens, num_heads_q, head_size),
+            dtype=q.dtype,
+            device=q.device,
+        )
     )
     k_unquantized = (
         out_k
         if out_k is not None
-        else torch.empty((batch_size, num_tokens, num_heads_k, head_size), dtype=k.dtype, device=k.device)
+        else torch.empty(
+            (batch_size, num_tokens, num_heads_k, head_size),
+            dtype=k.dtype,
+            device=k.device,
+        )
     )
 
     _fused_qk_norm_rope_1way_fp8_perhead_quant_kernel(
@@ -905,6 +917,8 @@ def v_1way_per_head_fp8_quant(v: Tensor) -> tuple[Tensor, Tensor]:
         dtype=fp8_dtype,
         device=v.device,
     )
-    v_descale = torch.empty((batch_size, num_heads), dtype=torch.float32, device=v.device)
+    v_descale = torch.empty(
+        (batch_size, num_heads), dtype=torch.float32, device=v.device
+    )
     _v_1way_per_head_fp8_quant_kernel(v, v_fp8, v_descale)
     return v_fp8, v_descale

--- a/aiter/ops/fused_qk_norm_rope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_rope_cache_quant.py
@@ -637,6 +637,104 @@ def fused_qk_norm_rope_2way_fp8_perhead_quant(
 
 @compile_ops(
     "module_fused_qk_norm_rope_cache_quant_shuffle",
+    fc_name="fused_qk_norm_rope_1way_fp8_perhead_quant",
+    develop=True,
+)
+def _fused_qk_norm_rope_1way_fp8_perhead_quant_kernel(
+    q: Tensor,
+    k: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    cos_sin: Tensor,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    is_interleaved: bool,
+    eps: float,
+    q_fp8: Tensor,
+    k_fp8: Tensor,
+    q_descale: Tensor,
+    k_descale: Tensor,
+    q_unquantized: Tensor,
+    k_unquantized: Tensor,
+) -> None: ...
+
+
+def fused_qk_norm_rope_1way_fp8_perhead_quant(
+    q: Tensor,
+    k: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    cos_sin: Tensor,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    is_interleaved: bool,
+    eps: float,
+    out_q: Optional[Tensor] = None,
+    out_k: Optional[Tensor] = None,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+    """Z-Image single-stream fused RoPE+RMSNorm with per-(batch, head) FP8 Q/K."""
+    want_bf16 = out_q is not None or out_k is not None
+    fp8_dtype = get_dtype_fp8()
+
+    q_fp8 = torch.empty(
+        (batch_size, num_tokens, num_heads_q, head_size),
+        dtype=fp8_dtype,
+        device=q.device,
+    )
+    k_fp8 = torch.empty(
+        (batch_size, num_tokens, num_heads_k, head_size),
+        dtype=fp8_dtype,
+        device=k.device,
+    )
+    q_descale = torch.empty((batch_size, num_heads_q), dtype=torch.float32, device=q.device)
+    k_descale = torch.empty((batch_size, num_heads_k), dtype=torch.float32, device=k.device)
+    q_unquantized = (
+        out_q
+        if out_q is not None
+        else torch.empty((batch_size, num_tokens, num_heads_q, head_size), dtype=q.dtype, device=q.device)
+    )
+    k_unquantized = (
+        out_k
+        if out_k is not None
+        else torch.empty((batch_size, num_tokens, num_heads_k, head_size), dtype=k.dtype, device=k.device)
+    )
+
+    _fused_qk_norm_rope_1way_fp8_perhead_quant_kernel(
+        q,
+        k,
+        w_q,
+        w_k,
+        cos_sin,
+        batch_size,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        head_size,
+        is_interleaved,
+        eps,
+        q_fp8,
+        k_fp8,
+        q_descale,
+        k_descale,
+        q_unquantized,
+        k_unquantized,
+    )
+
+    if not want_bf16:
+        q_unquantized = torch.empty(0, dtype=q.dtype, device=q.device)
+        k_unquantized = torch.empty(0, dtype=k.dtype, device=k.device)
+
+    return q_fp8, k_fp8, q_descale, k_descale, q_unquantized, k_unquantized
+
+
+@compile_ops(
+    "module_fused_qk_norm_rope_cache_quant_shuffle",
     fc_name="fused_kv_norm_rope_group_quant",
     develop=True,
 )
@@ -780,4 +878,33 @@ def v_2way_per_head_fp8_quant(v0: Tensor, v1: Tensor) -> tuple[Tensor, Tensor]:
         (batch_size, num_heads), dtype=torch.float32, device=v0.device
     )
     _v_2way_per_head_fp8_quant_kernel(v0, v1, v_fp8, v_descale)
+    return v_fp8, v_descale
+
+
+@compile_ops(
+    "module_fused_qk_norm_rope_cache_quant_shuffle",
+    fc_name="v_1way_per_head_fp8_quant",
+    develop=True,
+)
+def _v_1way_per_head_fp8_quant_kernel(
+    v: Tensor,
+    v_fp8: Tensor,
+    v_descale: Tensor,
+) -> None: ...
+
+
+def v_1way_per_head_fp8_quant(v: Tensor) -> tuple[Tensor, Tensor]:
+    """Per-(batch, head) FP8 quant for single-stream V [B, T, H, D]."""
+    batch_size = v.size(0)
+    num_heads = v.size(2)
+    head_size = v.size(3)
+    num_tokens = v.size(1)
+    fp8_dtype = get_dtype_fp8()
+    v_fp8 = torch.empty(
+        (batch_size, num_tokens, num_heads, head_size),
+        dtype=fp8_dtype,
+        device=v.device,
+    )
+    v_descale = torch.empty((batch_size, num_heads), dtype=torch.float32, device=v.device)
+    _v_1way_per_head_fp8_quant_kernel(v, v_fp8, v_descale)
     return v_fp8, v_descale

--- a/csrc/include/fused_qk_norm_rope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_rope_cache_quant.h
@@ -92,6 +92,25 @@ void fused_qk_norm_rope_1way(aiter_tensor_t& q,
                              aiter_tensor_t& out_q,
                              aiter_tensor_t& out_k);
 
+void fused_qk_norm_rope_1way_fp8_perhead_quant(aiter_tensor_t& q,
+                                               aiter_tensor_t& k,
+                                               aiter_tensor_t& w_q,
+                                               aiter_tensor_t& w_k,
+                                               aiter_tensor_t& cos_sin,
+                                               int64_t batch_size,
+                                               int64_t num_tokens,
+                                               int64_t num_heads_q,
+                                               int64_t num_heads_k,
+                                               int64_t head_size,
+                                               bool is_interleaved,
+                                               double eps,
+                                               aiter_tensor_t& q_fp8,
+                                               aiter_tensor_t& k_fp8,
+                                               aiter_tensor_t& q_descale,
+                                               aiter_tensor_t& k_descale,
+                                               aiter_tensor_t& q_unquantized,
+                                               aiter_tensor_t& k_unquantized);
+
 // Same signature as the pertensor variant, but writes per-(batch, head) descales:
 //   q_descale shape [batch_size, num_heads_q]
 //   k_descale shape [batch_size, num_heads_k]
@@ -125,6 +144,11 @@ void fused_qk_norm_rope_2way_fp8_perhead_quant(aiter_tensor_t& q0,
 // v0/v1: [B, T0/T1, H, D]; v_fp8: [B, T0+T1, H, D]; v_descale: [B, H].
 void v_2way_per_head_fp8_quant(aiter_tensor_t& v0,
                                aiter_tensor_t& v1,
+                               aiter_tensor_t& v_fp8,
+                               aiter_tensor_t& v_descale);
+
+// Per-(batch, head) FP8 quant for single-stream V [B, T, H, D].
+void v_1way_per_head_fp8_quant(aiter_tensor_t& v,
                                aiter_tensor_t& v_fp8,
                                aiter_tensor_t& v_descale);
 

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1960,6 +1960,15 @@ namespace py = pybind11;
             py::arg("scale_dtype")       = std::string("e8m0"));                        \
     m.def("fused_qk_norm_rope_2way", &aiter::fused_qk_norm_rope_2way);                  \
     m.def("fused_qk_norm_rope_1way", &aiter::fused_qk_norm_rope_1way);                  \
+    m.def("fused_qk_norm_rope_1way_fp8_perhead_quant",                                  \
+          &aiter::fused_qk_norm_rope_1way_fp8_perhead_quant,                            \
+          py::arg("q"), py::arg("k"), py::arg("w_q"), py::arg("w_k"),                   \
+          py::arg("cos_sin"),                                                           \
+          py::arg("batch_size"), py::arg("num_tokens"),                                 \
+          py::arg("num_heads_q"), py::arg("num_heads_k"), py::arg("head_size"),         \
+          py::arg("is_interleaved"), py::arg("eps"),                                    \
+          py::arg("q_fp8"), py::arg("k_fp8"), py::arg("q_descale"), py::arg("k_descale"), \
+          py::arg("q_unquantized"), py::arg("k_unquantized"));                            \
     m.def("fused_qk_norm_rope_2way_fp8_perhead_quant",                                  \
           &aiter::fused_qk_norm_rope_2way_fp8_perhead_quant,                            \
           py::arg("q0"), py::arg("k0"), py::arg("q1"), py::arg("k1"),                   \
@@ -1975,6 +1984,11 @@ namespace py = pybind11;
           py::arg("v0"),                                                                  \
           py::arg("v1"),                                                                  \
           py::arg("v_fp8"),                                                               \
+          py::arg("v_descale"));                                                          \
+    m.def("v_1way_per_head_fp8_quant",                                                    \
+          &aiter::v_1way_per_head_fp8_quant,                                              \
+          py::arg("v"),                                                                   \
+          py::arg("v_fp8"),                                                                 \
           py::arg("v_descale"));
 
 #define SMOOTHQUANT_PYBIND                      \

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -3525,6 +3525,207 @@ void fused_qk_norm_rope_1way(aiter_tensor_t& q,
     });
 }
 
+// ---------- Z-Image 1-way per-(batch, head) FP8 Q/K RoPE quant ----------
+
+template <typename T, int HEAD_SIZE>
+__global__ void qk_1way_output_partial_amax_kernel(const T* __restrict__ out_q_,
+                                                   const T* __restrict__ out_k_,
+                                                   int num_tokens,
+                                                   int num_heads_q,
+                                                   int num_heads_k,
+                                                   int total_warps,
+                                                   float* __restrict__ q_partial_amax,
+                                                   float* __restrict__ k_partial_amax)
+{
+    using mrope_utils::WARP_SIZE;
+    constexpr int VEC_SIZE        = HEAD_SIZE / WARP_SIZE;
+    const int warp_id             = threadIdx.x / WARP_SIZE;
+    const int lane_id             = threadIdx.x % WARP_SIZE;
+    const int num_warps_per_block = blockDim.x / WARP_SIZE;
+    const int global_warp_id      = blockIdx.x * num_warps_per_block + warp_id;
+    if(global_warp_id >= total_warps)
+    {
+        return;
+    }
+
+    const int batch_id      = blockIdx.y;
+    const int access_id     = lane_id * VEC_SIZE;
+    const int warp_offset_k = num_tokens * num_heads_q;
+    const bool is_q         = global_warp_id < warp_offset_k;
+
+    auto out_q = out_q_ + batch_id * num_tokens * num_heads_q * HEAD_SIZE;
+    auto out_k = out_k_ + batch_id * num_tokens * num_heads_k * HEAD_SIZE;
+
+    int token_id;
+    const T* src;
+    if(is_q)
+    {
+        const int spec = global_warp_id;
+        token_id         = spec / num_heads_q;
+        const int head_id = spec % num_heads_q;
+        src              = out_q + (token_id * num_heads_q + head_id) * HEAD_SIZE;
+    }
+    else
+    {
+        const int spec = global_warp_id - warp_offset_k;
+        token_id         = spec / num_heads_k;
+        const int head_id = spec % num_heads_k;
+        src              = out_k + (token_id * num_heads_k + head_id) * HEAD_SIZE;
+    }
+
+    vec_t<T, VEC_SIZE> x;
+    x.load(src + access_id);
+    float local_max = 0.f;
+#pragma unroll
+    for(int i = 0; i < VEC_SIZE; ++i)
+        local_max = fmaxf(local_max, fabsf((float)x[i]));
+#pragma unroll
+    for(int mask = 16; mask > 0; mask >>= 1)
+        local_max = fmaxf(local_max, __shfl_xor(local_max, mask, WARP_SIZE));
+
+    if(lane_id == 0)
+    {
+        const int64_t slot = (int64_t)batch_id * total_warps + global_warp_id;
+        if(is_q)
+        {
+            q_partial_amax[slot] = local_max;
+            k_partial_amax[slot] = 0.f;
+        }
+        else
+        {
+            q_partial_amax[slot] = 0.f;
+            k_partial_amax[slot] = local_max;
+        }
+    }
+}
+
+void fused_qk_norm_rope_1way_fp8_perhead_quant(aiter_tensor_t& q,
+                                               aiter_tensor_t& k,
+                                               aiter_tensor_t& w_q,
+                                               aiter_tensor_t& w_k,
+                                               aiter_tensor_t& cos_sin,
+                                               int64_t batch_size,
+                                               int64_t num_tokens,
+                                               int64_t num_heads_q,
+                                               int64_t num_heads_k,
+                                               int64_t head_size,
+                                               bool is_interleaved,
+                                               double eps,
+                                               aiter_tensor_t& q_fp8,
+                                               aiter_tensor_t& k_fp8,
+                                               aiter_tensor_t& q_descale,
+                                               aiter_tensor_t& k_descale,
+                                               aiter_tensor_t& q_unquantized,
+                                               aiter_tensor_t& k_unquantized)
+{
+    AITER_CHECK(q.is_contiguous() && k.is_contiguous());
+    AITER_CHECK(w_q.is_contiguous() && w_k.is_contiguous());
+    AITER_CHECK(cos_sin.is_contiguous());
+    AITER_CHECK(q_fp8.is_contiguous() && k_fp8.is_contiguous());
+    AITER_CHECK(q_descale.is_contiguous() && k_descale.is_contiguous());
+    AITER_CHECK(q_unquantized.is_contiguous() && k_unquantized.is_contiguous());
+    AITER_CHECK(cos_sin.dtype() == AITER_DTYPE_fp32,
+                "fused_qk_norm_rope_1way_fp8_perhead_quant requires cos_sin float32");
+    AITER_CHECK(q.dtype() == k.dtype() && q.dtype() == w_q.dtype() && q.dtype() == w_k.dtype());
+    AITER_CHECK(q.dtype() == q_unquantized.dtype() && k.dtype() == k_unquantized.dtype());
+    AITER_CHECK(q_fp8.dtype() == AITER_DTYPE_fp8 && k_fp8.dtype() == AITER_DTYPE_fp8);
+    AITER_CHECK(q_descale.dtype() == AITER_DTYPE_fp32 && k_descale.dtype() == AITER_DTYPE_fp32);
+
+    HipDeviceGuard device_guard(q.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    fused_qk_norm_rope_1way(q,
+                            k,
+                            w_q,
+                            w_k,
+                            cos_sin,
+                            batch_size,
+                            num_tokens,
+                            num_heads_q,
+                            num_heads_k,
+                            head_size,
+                            is_interleaved,
+                            eps,
+                            q_unquantized,
+                            k_unquantized);
+
+    const int total_warps         = (int)(num_tokens * (num_heads_q + num_heads_k));
+    constexpr int block_size      = 256;
+    constexpr int warp_size       = 32;
+    const int num_warps_per_block = block_size / warp_size;
+    dim3 threadsPerBlock(block_size);
+    dim3 numBlocks((total_warps + num_warps_per_block - 1) / num_warps_per_block, batch_size);
+
+    AiterTensor q_partial_amax =
+        AiterTensor::empty({batch_size, total_warps}, AITER_DTYPE_fp32, q.device_id, stream);
+    AiterTensor k_partial_amax =
+        AiterTensor::empty({batch_size, total_warps}, AITER_DTYPE_fp32, q.device_id, stream);
+
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+        q.dtype(), "fused_qk_norm_rope_1way_fp8_perhead_amax", [&] {
+            using T = scalar_t;
+            auto launch_amax = [&]<int HS>() {
+                qk_1way_output_partial_amax_kernel<T, HS><<<numBlocks, threadsPerBlock, 0, stream>>>(
+                    reinterpret_cast<T*>(q_unquantized.data_ptr()),
+                    reinterpret_cast<T*>(k_unquantized.data_ptr()),
+                    (int)num_tokens,
+                    (int)num_heads_q,
+                    (int)num_heads_k,
+                    total_warps,
+                    reinterpret_cast<float*>(q_partial_amax.data_ptr()),
+                    reinterpret_cast<float*>(k_partial_amax.data_ptr()));
+            };
+            switch(head_size)
+            {
+            case 64: launch_amax.template operator()<64>(); break;
+            case 128: launch_amax.template operator()<128>(); break;
+            case 256: launch_amax.template operator()<256>(); break;
+            default: AITER_CHECK(false, "Unsupported head_size: ", head_size);
+            }
+        });
+
+    {
+        dim3 reduce_grid((unsigned)(num_heads_q + num_heads_k), (unsigned)batch_size);
+        dim3 reduce_block(256);
+        qk_partial_amax_to_perhead_scale_kernel<<<reduce_grid, reduce_block, 0, stream>>>(
+            reinterpret_cast<float*>(q_partial_amax.data_ptr()),
+            reinterpret_cast<float*>(k_partial_amax.data_ptr()),
+            (int)num_tokens,
+            0,
+            (int)num_heads_q,
+            (int)num_heads_k,
+            total_warps,
+            reinterpret_cast<float*>(q_descale.data_ptr()),
+            reinterpret_cast<float*>(k_descale.data_ptr()));
+    }
+
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+        q.dtype(), "fused_qk_norm_rope_1way_fp8_perhead_quant", [&] {
+            using T         = scalar_t;
+            int64_t q_numel = (int64_t)batch_size * num_tokens * num_heads_q * head_size;
+            int64_t k_numel = (int64_t)batch_size * num_tokens * num_heads_k * head_size;
+            dim3 quant_block(256);
+            dim3 q_grid((unsigned)((q_numel + quant_block.x - 1) / quant_block.x));
+            dim3 k_grid((unsigned)((k_numel + quant_block.x - 1) / quant_block.x));
+            static_fp8_quant_perhead_kernel<T><<<q_grid, quant_block, 0, stream>>>(
+                reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(q_fp8.data_ptr()),
+                reinterpret_cast<T*>(q_unquantized.data_ptr()),
+                reinterpret_cast<float*>(q_descale.data_ptr()),
+                (int)batch_size,
+                (int)num_tokens,
+                (int)num_heads_q,
+                (int)head_size);
+            static_fp8_quant_perhead_kernel<T><<<k_grid, quant_block, 0, stream>>>(
+                reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(k_fp8.data_ptr()),
+                reinterpret_cast<T*>(k_unquantized.data_ptr()),
+                reinterpret_cast<float*>(k_descale.data_ptr()),
+                (int)batch_size,
+                (int)num_tokens,
+                (int)num_heads_k,
+                (int)head_size);
+        });
+}
+
 void fused_qk_norm_rope_cache_block_quant_shuffle(
     aiter_tensor_t& qkv,           // Combined QKV tensor [num_tokens,
                                    // (num_heads_q+num_heads_k+num_heads_v)*head_dim]
@@ -3933,6 +4134,126 @@ void v_2way_per_head_fp8_quant(aiter_tensor_t& v0,
                     (int)num_heads,
                     reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(v_fp8.data_ptr()),
                     reinterpret_cast<float*>(v_descale.data_ptr()));
+        });
+}
+
+template <typename T, int TILE_T, int HEAD_SIZE>
+__global__ void __launch_bounds__(256) v_1way_per_head_amax_tiled_kernel(
+    const T* __restrict__ v_,
+    int num_tokens,
+    int num_heads,
+    float* __restrict__ v_amax)
+{
+    constexpr int BT = 256;
+    int b            = blockIdx.z;
+    int h            = blockIdx.y;
+    int tile         = blockIdx.x;
+    int t_start      = tile * TILE_T;
+    int t_end        = min(t_start + TILE_T, num_tokens);
+    int slab_h_stride = num_heads * HEAD_SIZE;
+    float local       = 0.f;
+
+    for(int idx = threadIdx.x; idx < (t_end - t_start) * HEAD_SIZE; idx += BT)
+    {
+        int local_t = idx / HEAD_SIZE;
+        int d       = idx % HEAD_SIZE;
+        int t       = t_start + local_t;
+        int64_t off = ((int64_t)b * num_tokens + t) * slab_h_stride + (int64_t)h * HEAD_SIZE + d;
+        float val   = (float)v_[off];
+        local       = fmaxf(local, fabsf(val));
+    }
+
+    __shared__ float sm[BT];
+    sm[threadIdx.x] = local;
+    __syncthreads();
+#pragma unroll
+    for(int s = BT / 2; s > 0; s >>= 1)
+    {
+        if(threadIdx.x < s) sm[threadIdx.x] = fmaxf(sm[threadIdx.x], sm[threadIdx.x + s]);
+        __syncthreads();
+    }
+    if(threadIdx.x == 0) atomic_fmax_pos(v_amax + b * num_heads + h, sm[0]);
+}
+
+template <typename T, int TILE_T, int HEAD_SIZE>
+__global__ void __launch_bounds__(256) v_1way_per_head_quant_tiled_kernel(
+    const T* __restrict__ v_,
+    int num_tokens,
+    int num_heads,
+    mrope_utils::fp8e4m3fnuz* __restrict__ v_fp8_,
+    const float* __restrict__ v_descale)
+{
+    constexpr int BT = 256;
+    int b            = blockIdx.z;
+    int h            = blockIdx.y;
+    int tile         = blockIdx.x;
+    int t_start      = tile * TILE_T;
+    int t_end        = min(t_start + TILE_T, num_tokens);
+    int slab_h_stride = num_heads * HEAD_SIZE;
+    float inv         = 1.0f / v_descale[b * num_heads + h];
+
+    for(int idx = threadIdx.x; idx < (t_end - t_start) * HEAD_SIZE; idx += BT)
+    {
+        int local_t = idx / HEAD_SIZE;
+        int d       = idx % HEAD_SIZE;
+        int t       = t_start + local_t;
+        int64_t off = ((int64_t)b * num_tokens + t) * slab_h_stride + (int64_t)h * HEAD_SIZE + d;
+        v_fp8_[off] = mrope_utils::fp8e4m3fnuz((float)v_[off] * inv);
+    }
+}
+
+void v_1way_per_head_fp8_quant(aiter_tensor_t& v,
+                               aiter_tensor_t& v_fp8,
+                               aiter_tensor_t& v_descale)
+{
+    AITER_CHECK(v.is_contiguous() && v_fp8.is_contiguous() && v_descale.is_contiguous());
+    AITER_CHECK(v.ndim == 4, "v must be 4D [B, T, H, D]");
+    int64_t batch_size = v.size(0);
+    int64_t num_tokens = v.size(1);
+    int64_t num_heads  = v.size(2);
+    int64_t head_size  = v.size(3);
+    AITER_CHECK(head_size == 128, "v_1way_per_head_fp8_quant currently only supports head_size=128");
+    AITER_CHECK(v_fp8.dtype() == AITER_DTYPE_fp8, "v_fp8 must be fp8");
+    AITER_CHECK(v_descale.dtype() == AITER_DTYPE_fp32, "v_descale must be fp32");
+
+    HipDeviceGuard device_guard(v.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    AiterTensor v_amax =
+        AiterTensor::empty({batch_size, num_heads}, AITER_DTYPE_fp32, v.device_id, stream);
+
+    constexpr int TILE_T    = 128;
+    constexpr int HEAD_SIZE = 128;
+    int num_tiles           = (int)((num_tokens + TILE_T - 1) / TILE_T);
+    dim3 grid((unsigned)num_tiles, (unsigned)num_heads, (unsigned)batch_size);
+    dim3 block(256);
+
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+        v.dtype(), "v_1way_per_head_amax_tiled", [&] {
+            v_1way_per_head_amax_tiled_kernel<scalar_t, TILE_T, HEAD_SIZE>
+                <<<grid, block, 0, stream>>>(reinterpret_cast<scalar_t*>(v.data_ptr()),
+                                            (int)num_tokens,
+                                            (int)num_heads,
+                                            reinterpret_cast<float*>(v_amax.data_ptr()));
+        });
+
+    {
+        dim3 fg((unsigned)((num_heads + 31) / 32), (unsigned)batch_size);
+        dim3 fb(32);
+        v_amax_to_descale_kernel<<<fg, fb, 0, stream>>>(
+            reinterpret_cast<float*>(v_amax.data_ptr()),
+            (int)num_heads,
+            reinterpret_cast<float*>(v_descale.data_ptr()));
+    }
+
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+        v.dtype(), "v_1way_per_head_quant_tiled", [&] {
+            v_1way_per_head_quant_tiled_kernel<scalar_t, TILE_T, HEAD_SIZE>
+                <<<grid, block, 0, stream>>>(reinterpret_cast<scalar_t*>(v.data_ptr()),
+                                            (int)num_tokens,
+                                            (int)num_heads,
+                                            reinterpret_cast<mrope_utils::fp8e4m3fnuz*>(v_fp8.data_ptr()),
+                                            reinterpret_cast<float*>(v_descale.data_ptr()));
         });
 }
 

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -3630,6 +3630,9 @@ void fused_qk_norm_rope_1way_fp8_perhead_quant(aiter_tensor_t& q,
     AITER_CHECK(q.dtype() == q_unquantized.dtype() && k.dtype() == k_unquantized.dtype());
     AITER_CHECK(q_fp8.dtype() == AITER_DTYPE_fp8 && k_fp8.dtype() == AITER_DTYPE_fp8);
     AITER_CHECK(q_descale.dtype() == AITER_DTYPE_fp32 && k_descale.dtype() == AITER_DTYPE_fp32);
+    AITER_CHECK(get_gpu_arch() == "gfx942",
+                "fused_qk_norm_rope_1way_fp8_perhead_quant is validated only on gfx942/MI308 "
+                "because this path uses fp8_e4m3fnuz with fp8_max=240");
 
     HipDeviceGuard device_guard(q.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
@@ -4215,6 +4218,9 @@ void v_1way_per_head_fp8_quant(aiter_tensor_t& v,
     AITER_CHECK(head_size == 128, "v_1way_per_head_fp8_quant currently only supports head_size=128");
     AITER_CHECK(v_fp8.dtype() == AITER_DTYPE_fp8, "v_fp8 must be fp8");
     AITER_CHECK(v_descale.dtype() == AITER_DTYPE_fp32, "v_descale must be fp32");
+    AITER_CHECK(get_gpu_arch() == "gfx942",
+                "v_1way_per_head_fp8_quant is validated only on gfx942/MI308 because this path "
+                "uses fp8_e4m3fnuz with fp8_max=240");
 
     HipDeviceGuard device_guard(v.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -4220,7 +4220,7 @@ void v_1way_per_head_fp8_quant(aiter_tensor_t& v,
     const hipStream_t stream = aiter::getCurrentHIPStream();
 
     AiterTensor v_amax =
-        AiterTensor::empty({batch_size, num_heads}, AITER_DTYPE_fp32, v.device_id, stream);
+        AiterTensor::zeros({batch_size, num_heads}, AITER_DTYPE_fp32, v.device_id, stream);
 
     constexpr int TILE_T    = 128;
     constexpr int HEAD_SIZE = 128;

--- a/op_tests/test_fused_qk_norm_rope_1way_perhead.py
+++ b/op_tests/test_fused_qk_norm_rope_1way_perhead.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Validate fused_qk_norm_rope_1way_fp8_perhead_quant and v_1way_per_head_fp8_quant.
+
+Compares HIP kernels against:
+  - Q/K: fused_qk_norm_rope_1way + torch per-head FP8 reference
+  - V:   torch per-head FP8 reference
+"""
+
+import argparse
+from typing import Optional
+
+import pandas as pd
+import pytest
+import torch
+from torch import Tensor
+
+import aiter
+from aiter import dtypes
+from aiter.test_common import benchmark, checkAllclose, perftest
+
+FP8_DTYPE = dtypes.fp8
+
+
+def _torch_per_head_fp8_quant(x: Tensor) -> tuple[Tensor, Tensor]:
+    """Reference per-(batch, head) fp8 quant (amax/240 descale)."""
+    batch_size, _, _, _ = x.shape
+    x32 = x.float()
+    amax = x32.abs().amax(dim=(1, 3), keepdim=True).clamp(min=1e-8)
+    descale = amax / 240.0
+    q = (x32 / descale).to(FP8_DTYPE)
+    scale = descale.view(batch_size, 1, -1, 1).squeeze(-1).squeeze(1)
+    return q, scale
+
+
+def _dequant_per_head(fp8: Tensor, descale: Tensor) -> Tensor:
+    b, _, h, _ = fp8.shape
+    return fp8.float() * descale.view(b, 1, h, 1).float()
+
+
+@perftest()
+def _run_qk_baseline(
+    q: Tensor,
+    k: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    cos_sin: Tensor,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    is_interleaved: bool,
+    eps: float,
+):
+    q_ref = torch.empty(
+        (batch_size, num_tokens, num_heads_q, head_size),
+        dtype=q.dtype,
+        device=q.device,
+    )
+    k_ref = torch.empty(
+        (batch_size, num_tokens, num_heads_k, head_size),
+        dtype=k.dtype,
+        device=k.device,
+    )
+    aiter.fused_qk_norm_rope_1way(
+        q,
+        k,
+        w_q,
+        w_k,
+        cos_sin,
+        batch_size,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        head_size,
+        is_interleaved,
+        eps,
+        q_ref,
+        k_ref,
+    )
+    return q_ref, k_ref
+
+
+@perftest()
+def _run_qk_perhead(
+    q: Tensor,
+    k: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    cos_sin: Tensor,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    is_interleaved: bool,
+    eps: float,
+    out_q: Optional[Tensor] = None,
+    out_k: Optional[Tensor] = None,
+):
+    return aiter.fused_qk_norm_rope_1way_fp8_perhead_quant(
+        q,
+        k,
+        w_q,
+        w_k,
+        cos_sin,
+        batch_size,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        head_size,
+        is_interleaved,
+        eps,
+        out_q,
+        out_k,
+    )
+
+
+@perftest()
+def _run_v_baseline(v: Tensor):
+    return _torch_per_head_fp8_quant(v)
+
+
+@perftest()
+def _run_v_perhead(v: Tensor):
+    return aiter.v_1way_per_head_fp8_quant(v)
+
+
+def _make_qk_inputs(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    seed: int,
+):
+    torch.manual_seed(seed)
+    dev = "cuda"
+
+    def rn(*shape, out_dtype: torch.dtype = dtype):
+        return torch.randn(*shape, dtype=out_dtype, device=dev)
+
+    q = rn(batch_size, num_tokens, num_heads_q, head_size)
+    k = rn(batch_size, num_tokens, num_heads_k, head_size)
+    w_q = rn(head_size)
+    w_k = rn(head_size)
+    cos_sin = rn(num_tokens, head_size, out_dtype=torch.float32)
+    return q, k, w_q, w_k, cos_sin
+
+
+def _validate_qk_perhead_case(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    is_interleaved: bool,
+    eps: float,
+    provide_outputs: bool,
+    collect_perf: bool = False,
+) -> dict:
+    q, k, w_q, w_k, cos_sin = _make_qk_inputs(
+        dtype,
+        batch_size,
+        num_tokens,
+        num_heads_q,
+        num_heads_k,
+        head_size,
+        seed=0,
+    )
+
+    out_q = None
+    out_k = None
+    if provide_outputs:
+        out_q = torch.empty(
+            (batch_size, num_tokens, num_heads_q, head_size),
+            dtype=dtype,
+            device="cuda",
+        )
+        out_k = torch.empty(
+            (batch_size, num_tokens, num_heads_k, head_size),
+            dtype=dtype,
+            device="cuda",
+        )
+
+    if collect_perf:
+        baseline_out, baseline_us = _run_qk_baseline(
+            q,
+            k,
+            w_q,
+            w_k,
+            cos_sin,
+            batch_size,
+            num_tokens,
+            num_heads_q,
+            num_heads_k,
+            head_size,
+            is_interleaved,
+            eps,
+        )
+        hip_out, hip_us = _run_qk_perhead(
+            q,
+            k,
+            w_q,
+            w_k,
+            cos_sin,
+            batch_size,
+            num_tokens,
+            num_heads_q,
+            num_heads_k,
+            head_size,
+            is_interleaved,
+            eps,
+            out_q,
+            out_k,
+        )
+    else:
+        baseline_out = _run_qk_baseline(
+            q,
+            k,
+            w_q,
+            w_k,
+            cos_sin,
+            batch_size,
+            num_tokens,
+            num_heads_q,
+            num_heads_k,
+            head_size,
+            is_interleaved,
+            eps,
+        )[0]
+        baseline_us = None
+        hip_out = _run_qk_perhead(
+            q,
+            k,
+            w_q,
+            w_k,
+            cos_sin,
+            batch_size,
+            num_tokens,
+            num_heads_q,
+            num_heads_k,
+            head_size,
+            is_interleaved,
+            eps,
+            out_q,
+            out_k,
+        )[0]
+        hip_us = None
+
+    q_ref, k_ref = baseline_out
+    q_fp8, k_fp8, q_descale, k_descale, q_out, k_out = hip_out
+
+    if provide_outputs:
+        q_bf16_err = checkAllclose(
+            q_ref,
+            q_out,
+            rtol=1e-2,
+            atol=0.05,
+            tol_err_ratio=0.0,
+            msg=f"check q_bf16 baseline vs perhead, B={batch_size}, T={num_tokens}, "
+            f"Hq={num_heads_q}: ",
+        )
+        k_bf16_err = checkAllclose(
+            k_ref,
+            k_out,
+            rtol=1e-2,
+            atol=0.05,
+            tol_err_ratio=0.0,
+            msg=f"check k_bf16 baseline vs perhead, B={batch_size}, T={num_tokens}, "
+            f"Hk={num_heads_k}: ",
+        )
+    else:
+        assert q_out.numel() == 0
+        assert k_out.numel() == 0
+        assert q_out.dtype == dtype
+        assert k_out.dtype == dtype
+        q_bf16_err = 0.0
+        k_bf16_err = 0.0
+
+    q_deq = _dequant_per_head(q_fp8, q_descale)
+    k_deq = _dequant_per_head(k_fp8, k_descale)
+    q_torch_fp8, q_torch_scale = _torch_per_head_fp8_quant(q_ref)
+    k_torch_fp8, k_torch_scale = _torch_per_head_fp8_quant(k_ref)
+
+    q_deq_err = checkAllclose(
+        q_ref.float(),
+        q_deq,
+        rtol=0.15,
+        atol=1.0,
+        tol_err_ratio=0.01,
+        msg=f"check q_dequant vs bf16 ref, head_size={head_size}: ",
+    )
+    k_deq_err = checkAllclose(
+        k_ref.float(),
+        k_deq,
+        rtol=0.15,
+        atol=1.0,
+        tol_err_ratio=0.01,
+        msg=f"check k_dequant vs bf16 ref, head_size={head_size}: ",
+    )
+
+    q_deq_torch = _dequant_per_head(q_torch_fp8, q_torch_scale)
+    k_deq_torch = _dequant_per_head(k_torch_fp8, k_torch_scale)
+    q_fp8_err = checkAllclose(
+        q_deq_torch,
+        q_deq,
+        rtol=0.1,
+        atol=1.0,
+        tol_err_ratio=0.01,
+        msg="check q_dequant hip vs torch per-head ref: ",
+    )
+    k_fp8_err = checkAllclose(
+        k_deq_torch,
+        k_deq,
+        rtol=0.1,
+        atol=1.0,
+        tol_err_ratio=0.01,
+        msg="check k_dequant hip vs torch per-head ref: ",
+    )
+    q_scale_err = checkAllclose(
+        q_torch_scale,
+        q_descale,
+        rtol=1e-2,
+        atol=1e-2,
+        tol_err_ratio=0.0,
+        msg="check q_descale vs torch per-head ref: ",
+    )
+    k_scale_err = checkAllclose(
+        k_torch_scale,
+        k_descale,
+        rtol=1e-2,
+        atol=1e-2,
+        tol_err_ratio=0.0,
+        msg="check k_descale vs torch per-head ref: ",
+    )
+
+    uplift = (baseline_us / hip_us - 1) if baseline_us and hip_us else None
+    info = (
+        f"dtype:{dtype}, batch_size:{batch_size}, num_tokens:{num_tokens}, "
+        f"num_heads_q:{num_heads_q}, num_heads_k:{num_heads_k}, "
+        f"head_size:{head_size}, is_interleaved:{is_interleaved}, "
+        f"provide_outputs:{provide_outputs}"
+    )
+    if hip_us is not None:
+        msg = (
+            f"[perf][qk_1way_perhead] === {info} === "
+            f"baseline avg: {baseline_us:<8.2f} us, hip avg: {hip_us:<8.2f} us, "
+            f"uplift: {uplift:<5.1%}"
+        )
+        print(msg, flush=True)
+
+    return {
+        "op": "qk_1way_perhead",
+        "dtype": str(dtype),
+        "gfx": aiter.get_gfx(),
+        "batch_size": batch_size,
+        "num_tokens": num_tokens,
+        "num_heads_q": num_heads_q,
+        "num_heads_k": num_heads_k,
+        "head_size": head_size,
+        "is_interleaved": is_interleaved,
+        "provide_outputs": provide_outputs,
+        "baseline_us": baseline_us,
+        "hip_us": hip_us,
+        "uplift": f"{uplift:.1%}" if uplift is not None else "N/A",
+        "q_bf16_err": q_bf16_err,
+        "k_bf16_err": k_bf16_err,
+        "q_deq_err": q_deq_err,
+        "k_deq_err": k_deq_err,
+        "q_fp8_err": q_fp8_err,
+        "k_fp8_err": k_fp8_err,
+        "q_scale_err": q_scale_err,
+        "k_scale_err": k_scale_err,
+    }
+
+
+def _validate_v_perhead_case(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    collect_perf: bool = False,
+) -> dict:
+    torch.manual_seed(1)
+    v = torch.randn(
+        batch_size, num_tokens, num_heads, head_size, dtype=dtype, device="cuda"
+    ).contiguous()
+
+    if collect_perf:
+        (v_torch_fp8, v_torch_scale), baseline_us = _run_v_baseline(v)
+        (v_ph, v_ph_s), hip_us = _run_v_perhead(v)
+    else:
+        v_torch_fp8, v_torch_scale = _run_v_baseline(v)[0]
+        baseline_us = None
+        v_ph, v_ph_s = _run_v_perhead(v)[0]
+        hip_us = None
+
+    v_deq = _dequant_per_head(v_ph, v_ph_s)
+    v_deq_torch = _dequant_per_head(v_torch_fp8, v_torch_scale)
+    v_fp8_err = checkAllclose(
+        v_deq_torch,
+        v_deq,
+        rtol=0.1,
+        atol=1.0,
+        tol_err_ratio=0.01,
+        msg=f"check v_dequant hip vs torch per-head ref, B={batch_size}: ",
+    )
+    v_scale_err = checkAllclose(
+        v_torch_scale,
+        v_ph_s,
+        rtol=0.15,
+        atol=0.5,
+        tol_err_ratio=0.25,
+        msg="check v_descale vs torch per-head ref: ",
+    )
+    v_deq_err = checkAllclose(
+        v.float(),
+        v_deq,
+        rtol=0.15,
+        atol=1.0,
+        tol_err_ratio=0.01,
+        msg="check v_dequant vs bf16 ref: ",
+    )
+
+    uplift = (baseline_us / hip_us - 1) if baseline_us and hip_us else None
+    info = (
+        f"dtype:{dtype}, batch_size:{batch_size}, num_tokens:{num_tokens}, "
+        f"num_heads:{num_heads}, head_size:{head_size}"
+    )
+    if hip_us is not None:
+        msg = (
+            f"[perf][v_1way_perhead] === {info} === "
+            f"baseline avg: {baseline_us:<8.2f} us, hip avg: {hip_us:<8.2f} us, "
+            f"uplift: {uplift:<5.1%}"
+        )
+        print(msg, flush=True)
+
+    return {
+        "op": "v_1way_perhead",
+        "dtype": str(dtype),
+        "gfx": aiter.get_gfx(),
+        "batch_size": batch_size,
+        "num_tokens": num_tokens,
+        "num_heads": num_heads,
+        "head_size": head_size,
+        "baseline_us": baseline_us,
+        "hip_us": hip_us,
+        "uplift": f"{uplift:.1%}" if uplift is not None else "N/A",
+        "v_fp8_err": v_fp8_err,
+        "v_scale_err": v_scale_err,
+        "v_deq_err": v_deq_err,
+    }
+
+
+@pytest.mark.parametrize(
+    "dtype,batch_size,num_tokens,num_heads_q,num_heads_k,head_size,is_interleaved,provide_outputs",
+    [
+        (torch.bfloat16, 1, 4096, 24, 24, 128, False, True),
+        (torch.bfloat16, 1, 512, 24, 8, 128, False, True),
+        (torch.bfloat16, 1, 64, 8, 8, 128, False, False),
+        (torch.float16, 2, 64, 8, 8, 128, False, True),
+        (torch.float16, 2, 512, 16, 8, 128, False, False),
+    ],
+)
+def test_fused_qk_norm_rope_1way_fp8_perhead(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    is_interleaved: bool,
+    provide_outputs: bool,
+) -> None:
+    _validate_qk_perhead_case(
+        dtype=dtype,
+        batch_size=batch_size,
+        num_tokens=num_tokens,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        head_size=head_size,
+        is_interleaved=is_interleaved,
+        eps=1e-6,
+        provide_outputs=provide_outputs,
+        collect_perf=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype,batch_size,num_tokens,num_heads,head_size",
+    [
+        (torch.bfloat16, 1, 4096, 24, 128),
+        (torch.bfloat16, 1, 512, 24, 128),
+        (torch.bfloat16, 1, 64, 8, 128),
+        (torch.float16, 2, 64, 8, 128),
+    ],
+)
+def test_v_1way_per_head_fp8_quant(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+) -> None:
+    _validate_v_perhead_case(
+        dtype=dtype,
+        batch_size=batch_size,
+        num_tokens=num_tokens,
+        num_heads=num_heads,
+        head_size=head_size,
+        collect_perf=False,
+    )
+
+
+@benchmark()
+def run_qk_perhead_case(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads_q: int,
+    num_heads_k: int,
+    head_size: int,
+    is_interleaved: bool,
+    provide_outputs: bool,
+):
+    return _validate_qk_perhead_case(
+        dtype=dtype,
+        batch_size=batch_size,
+        num_tokens=num_tokens,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        head_size=head_size,
+        is_interleaved=is_interleaved,
+        eps=1e-6,
+        provide_outputs=provide_outputs,
+        collect_perf=True,
+    )
+
+
+@benchmark()
+def run_v_perhead_case(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+):
+    return _validate_v_perhead_case(
+        dtype=dtype,
+        batch_size=batch_size,
+        num_tokens=num_tokens,
+        num_heads=num_heads,
+        head_size=head_size,
+        collect_perf=True,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=(
+            "Validate per-(batch, head) FP8 quant for fused QK norm/rope (1way) and V.\n"
+            "Use --bench to collect perf; default runs correctness sweeps."
+        ),
+    )
+    parser.add_argument(
+        "-d",
+        "--dtype",
+        type=str,
+        choices=["fp16", "bf16"],
+        nargs="*",
+        default=["bf16"],
+        help="Data type(s). e.g. -d bf16 fp16",
+    )
+    parser.add_argument(
+        "--bench",
+        action="store_true",
+        help="Collect perf via @benchmark (slower).",
+    )
+    args = parser.parse_args()
+
+    qk_cases = [
+        # Z-Image style
+        (1, 4096, 24, 24, 128, False, True),
+        # GQA/MQA shape
+        (1, 512, 24, 8, 128, False, True),
+        # smoke plus no out_q/out_k coverage
+        (1, 64, 8, 8, 128, False, False),
+        (2, 64, 8, 8, 128, False, True),
+    ]
+    v_cases = [
+        (1, 4096, 24, 128),
+        (1, 512, 24, 128),
+        (1, 64, 8, 128),
+        (2, 64, 8, 128),
+    ]
+
+    rows = []
+    for key in args.dtype:
+        dtype = dtypes.d_dtypes[key]
+        for batch_size, t, hq, hk, hs, interleaved, provide_outputs in qk_cases:
+            if args.bench:
+                row = run_qk_perhead_case(
+                    dtype, batch_size, t, hq, hk, hs, interleaved, provide_outputs
+                )
+            else:
+                row = _validate_qk_perhead_case(
+                    dtype=dtype,
+                    batch_size=batch_size,
+                    num_tokens=t,
+                    num_heads_q=hq,
+                    num_heads_k=hk,
+                    head_size=hs,
+                    is_interleaved=interleaved,
+                    eps=1e-6,
+                    provide_outputs=provide_outputs,
+                    collect_perf=False,
+                )
+            rows.append(row)
+        for batch_size, t, h, hs in v_cases:
+            if args.bench:
+                row = run_v_perhead_case(dtype, batch_size, t, h, hs)
+            else:
+                row = _validate_v_perhead_case(
+                    dtype=dtype,
+                    batch_size=batch_size,
+                    num_tokens=t,
+                    num_heads=h,
+                    head_size=hs,
+                    collect_perf=False,
+                )
+            rows.append(row)
+
+    df = pd.DataFrame(rows)
+    aiter.logger.info(
+        "fused_qk_norm_rope_1way_perhead summary:\n%s",
+        df.to_string(index=False),
+    )

--- a/op_tests/test_fused_qk_norm_rope_1way_perhead.py
+++ b/op_tests/test_fused_qk_norm_rope_1way_perhead.py
@@ -22,14 +22,20 @@ from aiter import dtypes
 from aiter.test_common import benchmark, checkAllclose, perftest
 
 FP8_DTYPE = dtypes.fp8
+FP8_MAX_GFX942 = 240.0
+
+pytestmark = pytest.mark.skipif(
+    aiter.get_gfx() != "gfx942",
+    reason="Z-Image 1way per-head FP8 tests are validated only on MI308/gfx942 (fp8_max=240)",
+)
 
 
 def _torch_per_head_fp8_quant(x: Tensor) -> tuple[Tensor, Tensor]:
-    """Reference per-(batch, head) fp8 quant (amax/240 descale)."""
+    """Reference per-(batch, head) fp8 quant for gfx942 fp8_e4m3fnuz."""
     batch_size, _, _, _ = x.shape
     x32 = x.float()
     amax = x32.abs().amax(dim=(1, 3), keepdim=True).clamp(min=1e-8)
-    descale = amax / 240.0
+    descale = amax / FP8_MAX_GFX942
     q = (x32 / descale).to(FP8_DTYPE)
     scale = descale.view(batch_size, 1, -1, 1).squeeze(-1).squeeze(1)
     return q, scale
@@ -585,6 +591,13 @@ if __name__ == "__main__":
         help="Collect perf via @benchmark (slower).",
     )
     args = parser.parse_args()
+
+    if aiter.get_gfx() != "gfx942":
+        print(
+            "Skipping: Z-Image 1way per-head FP8 tests require MI308/gfx942 (fp8_max=240)",
+            flush=True,
+        )
+        raise SystemExit(0)
 
     qk_cases = [
         # Z-Image style


### PR DESCRIPTION
## Motivation

Z-Image uses a 1way/single-stream Q/K/V layout, while the existing per-head FP8 fused RoPE path targets the 2way layout. This PR adds the matching 1way fused QK norm + RoPE + FP8 per-head quant path so Z-Image can use per-(batch, head) descale tensors and keep the CK FP8 flash-attention fast path instead of falling back to BF16 or per-tensor quantization.

This is the 1way counterpart of the 2way per-head FP8 quant support added in ROCm/aiter#3353.

## Technical Details

- Add `fused_qk_norm_rope_1way_fp8_perhead_quant`, a 1way fused Q/K RMSNorm + RoPE + FP8 quant API that emits per-head descale tensors for Q/K.
- Add `v_1way_per_head_fp8_quant` for matching V FP8 per-head quantization.
- Wire the new ops through the Python wrapper, C++ headers, ROCm op declarations, and HIP kernel implementation.
- Keep the descale layout compatible with CK FP8 flash attention, using per-(batch, head) scale granularity for better accuracy than per-tensor quantization.
- The separate PAIR_VEC_SIZE cos/sin vector fix is tracked in ROCm/aiter#4014.

## Test Plan

- Build AITER with the new 1way FP8 per-head quant kernels.
- Run the Z-Image text-to-image path using the new 1way fused Q/K RoPE + V FP8 per-head quant ops.
- Compare generated output against the baseline path to verify there is no visible quality regression.
- Let ROCm/aiter CI run the existing build and test coverage for affected fused RoPE/quant code paths.

## Test Result

- Verified the Z-Image 1way FP8 per-head quant path locally and compared generated images against the baseline output.
- Existing CI checks will provide build and regression coverage for the ROCm/aiter integration.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.