### PR TITLE
[GDN] Add gdn_chunk_prepare: fused intra-chunk GDN prefill prep kernel (opus, arch-specialized)

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1532,5 +1532,23 @@
         "extra_include": [],
         "verbose": "False",
         "blob_gen_cmd": "''"
+    },
+    "module_gdn_chunk_prepare": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/py_itfs_cu/opus_gdn_chunk_prepare.cu'",
+            "f'{AITER_CSRC_DIR}/py_itfs_cu/opus_gdn_chunk_prepare_launch.cu'",
+            "f'{AITER_CSRC_DIR}/pybind/opus_gdn_chunk_prepare_pybind.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-ffast-math'",
+            "'-std=c++20'"
+        ],
+        "extra_ldflags": "None",
+        "extra_include": [
+            "f'{AITER_CSRC_DIR}/include/opus'"
+        ],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
     }
 }

--- a/aiter/ops/gdn_chunk_prepare.py
+++ b/aiter/ops/gdn_chunk_prepare.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import torch
+import torch.nn.functional as F
+from ..jit.core import compile_ops
+
+
+@compile_ops("module_gdn_chunk_prepare")
+def gdn_chunk_prepare_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    w_bar: torch.Tensor,
+    u_bar: torch.Tensor,
+    g_cumsum: torch.Tensor,
+) -> None: ...
+
+
+def gdn_chunk_prepare(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    BT: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused intra-chunk GDN prefill preparation (forward only).
+
+    Fuses the four FLA prefill kernels that run before the h-recurrence:
+      chunk_local_cumsum + chunk_scaled_dot_kkt_fwd + solve_tril + recompute_w_u_fwd
+    into a single token-parallel HIP kernel (BT=64, K=V=128, gfx942/gfx950).
+
+    Args:
+        k: [B, T, H, K] bf16
+        v: [B, T, H, V] bf16
+        g: [B, T, H] — log-gate (cast to fp32)
+        beta: [B, T, H] — sigmoid gating (cast to fp32)
+        BT: chunk size (64).
+
+    Returns:
+        (w_bar, u_bar, g_cumsum):
+          w_bar    [B, T, H, K] bf16  — C @ (k * beta * exp(g_cumsum))
+          u_bar    [B, T, H, V] bf16  — C @ (v * beta)
+          g_cumsum [B, T, H]    fp32  — inclusive prefix sum of g within each chunk
+    """
+    B, T, H, K = k.shape
+    V = v.shape[-1]
+
+    k = k.contiguous().to(torch.bfloat16)
+    v = v.contiguous().to(torch.bfloat16)
+    g = g.contiguous().float()
+    beta = beta.contiguous().float()
+
+    pad_len = (BT - T % BT) % BT
+    if pad_len > 0:
+        k = F.pad(k, (0, 0, 0, 0, 0, pad_len))
+        v = F.pad(v, (0, 0, 0, 0, 0, pad_len))
+        g = F.pad(g, (0, 0, 0, pad_len))
+        beta = F.pad(beta, (0, 0, 0, pad_len))
+
+    Tp = k.shape[1]
+    opts_bf16 = dict(dtype=torch.bfloat16, device=k.device)
+    opts_fp32 = dict(dtype=torch.float32, device=k.device)
+    w_bar = torch.empty(B, Tp, H, K, **opts_bf16)
+    u_bar = torch.empty(B, Tp, H, V, **opts_bf16)
+    g_cumsum = torch.empty(B, Tp, H, **opts_fp32)
+
+    gdn_chunk_prepare_fwd(k, v, g, beta, w_bar, u_bar, g_cumsum)
+
+    if pad_len > 0:
+        w_bar = w_bar[:, :T]
+        u_bar = u_bar[:, :T]
+        g_cumsum = g_cumsum[:, :T]
+    return w_bar, u_bar, g_cumsum

--- a/csrc/include/opus_gdn/gdn_chunk_prepare_defs.h
+++ b/csrc/include/opus_gdn/gdn_chunk_prepare_defs.h
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Gated DeltaNet (GDN) chunk-prepare kernel — shared types, kargs, traits.
+//
+// `gdn_chunk_prepare` fuses the FOUR intra-chunk FLA prefill kernels that must
+// run before the h-state recurrence:
+//   1. chunk_local_cumsum        — inclusive prefix sum of the log-gate g
+//   2. chunk_scaled_dot_kkt_fwd  — gated KKT Gram  A = tril(K Kᵀ ⊙ decay)
+//   3. solve_tril                — triangular inverse  C = (I + A)⁻¹
+//   4. recompute_w_u_fwd         — WY factors  w_bar = C·(k·β·e^g), u_bar = C·(v·β)
+// into a single token-parallel HIP kernel.
+//
+// Target: gfx942 (MI300X) / gfx950 (MI350), MFMA bf16 16×16×16.
+#pragma once
+
+#ifdef __HIP_DEVICE_COMPILE__
+using bf16_t = __bf16;
+#else
+using bf16_t = unsigned short;
+#endif
+
+// --------------------------------------------------------------------------
+// Kernel arguments
+//   inputs : k[B,T,H,K] bf16, v[B,T,H,V] bf16, g[B,T,H] fp32, beta[B,T,H] fp32
+//   outputs: g_cumsum[B,T,H] fp32, w_bar[B,T,H,K] bf16, u_bar[B,T,H,V] bf16
+// --------------------------------------------------------------------------
+struct gdn_chunk_prepare_kargs {
+    const void* __restrict__ ptr_k;        // [B, T, H, K]   bf16
+    const void* __restrict__ ptr_v;        // [B, T, H, V]   bf16
+    const void* __restrict__ ptr_beta;     // [B, T, H]      fp32
+    const void* __restrict__ ptr_g;        // [B, T, H]      fp32
+    void* __restrict__ ptr_w_bar;          // [B, T, H, K]   bf16  output
+    void* __restrict__ ptr_u_bar;          // [B, T, H, V]   bf16  output
+    void* __restrict__ ptr_g_cumsum;       // [B, T, H]      fp32  output
+    int B;
+    int T;
+    int H;
+    int K;
+    int V;
+};
+
+// --------------------------------------------------------------------------
+// Traits
+//
+// Layout: [B, T, H, K] with stride_t = H*K, stride_h = K, stride_k = 1
+// MFMA: bf16 16×16×16 uniformly on gfx942/gfx950
+// --------------------------------------------------------------------------
+template<int BT_,
+         int K_  = 128,
+         int V_  = 128,
+         int NUM_WARPS_ = 4>
+struct gdn_chunk_prepare_traits {
+    static constexpr int BT = BT_;
+    static constexpr int K  = K_;
+    static constexpr int V  = V_;
+    static constexpr int NUM_WARPS = NUM_WARPS_;
+    static constexpr int WARP_SIZE = 64;
+    static constexpr int BLOCK_SIZE = NUM_WARPS * WARP_SIZE;
+
+    using D_ATTN = bf16_t;
+    using D_ACC  = float;
+
+    // MFMA tile: 16×16×16 bf16 → fp32
+    static constexpr int W_M = 16;
+    static constexpr int W_N = 16;
+    static constexpr int W_K = 16;
+
+    // KKT GEMM: [BT, K] × [K, BT] = [BT, BT]
+    static constexpr int KKT_E_M = BT / W_M;          // 4 (BT=64)
+    static constexpr int KKT_E_N = BT / W_N;          // 4
+    static constexpr int KKT_E_K = K / W_K;           // 8
+
+    // w_bar/u_bar GEMMs processed in 64-wide subtiles (BK_sub=BV_sub=64)
+    static constexpr int BK_SUB = 64;
+    static constexpr int BV_SUB = 64;
+    static constexpr int N_K_ITERS = K / BK_SUB;      // 2
+    static constexpr int N_V_ITERS = V / BV_SUB;      // 2
+
+    static constexpr int WY_E_M = BT / W_M;           // 4
+    static constexpr int WY_E_N = BK_SUB / W_N;       // 4
+    static constexpr int WY_E_K = BT / W_K;           // 4
+
+    static constexpr int VEC_KV = 8;                  // bf16x8 = 16 bytes
+
+    // LDS padding: +4 bf16/row to avoid bank conflicts (32-bank gfx942 / 64-bank gfx950)
+    static constexpr int SMEM_PAD = 4;
+    static constexpr int K_STRIDE = K + SMEM_PAD;
+    static constexpr int A_STRIDE = BT + 1;           // fp32 A padded to BT+1
+
+    // LDS layout (bytes)
+    static constexpr int smem_k_padded_bytes = BT * K_STRIDE * (int)sizeof(D_ATTN);
+    static constexpr int smem_A_bytes        = BT * A_STRIDE * (int)sizeof(D_ACC);
+    static constexpr int smem_scalar_bytes   = BT * 2 * (int)sizeof(D_ACC);
+
+    // OCC=3 size (C⁻¹ register-cached, no s_C_bf16). Used on gfx942 where the
+    // smaller LDS lifts occupancy 2→3.
+    static constexpr size_t smem_size_bytes() {
+        int phase1   = smem_k_padded_bytes + smem_scalar_bytes;
+        int phase2ab = smem_A_bytes + 16 * 16 * (int)sizeof(D_ACC) + smem_scalar_bytes;
+        return phase1 > phase2ab ? phase1 : phase2ab;
+    }
+
+    // OCC=2 size (C⁻¹ staged in LDS as s_C_bf16). Used on gfx950, whose 160KB
+    // LDS is not the occupancy limiter — register-caching gains nothing there.
+    static constexpr size_t smem_size_bytes_cinv_lds() {
+        int base = (int)smem_size_bytes();
+        int c_bf16_bytes = BT * (BT + SMEM_PAD) * (int)sizeof(D_ATTN);
+        int phase2c = smem_A_bytes + c_bf16_bytes + smem_scalar_bytes;
+        return (phase2c > base) ? phase2c : base;
+    }
+};

--- a/csrc/include/opus_gdn/gdn_chunk_prepare_kernel.hpp
+++ b/csrc/include/opus_gdn/gdn_chunk_prepare_kernel.hpp
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// GDN chunk-prepare kernel — unified template, arch-specialized (gfx942/gfx950).
+//
+// Fuses the FOUR intra-chunk FLA prefill kernels into one token-parallel kernel:
+//   1. chunk_local_cumsum        — inclusive prefix sum of log-gate g
+//   2. chunk_scaled_dot_kkt_fwd  — gated KKT Gram  A = tril(K Kᵀ ⊙ decay)
+//   3. solve_tril                — triangular inverse  C = (I + A)⁻¹  (Neumann squaring + Schur)
+//   4. recompute_w_u_fwd         — WY factors  w_bar = C·(k·β·e^g), u_bar = C·(v·β)
+//
+// Grid: (NT, B*H)   Block: (BLOCK_SIZE = 256, 4 warps)   MFMA bf16 16×16×16.
+//
+// Arch偏特化 (best-only per arch):
+//   gfx950 (MI350): OCC=2, C⁻¹ staged in LDS as bf16 (s_C_bf16). 160KB LDS is
+//                   not the occupancy limiter, so register-caching gains nothing.
+//   gfx942 (MI300): OCC=3, C⁻¹ register-cached (no s_C_bf16) → smaller LDS lifts
+//                   occupancy 2→3 (-30% on the LDS-bound MI300).
+//
+// opus.hpp usage: all global<->LDS traffic goes through opus layout descriptors
+// (make_gmem / make_smem / make_layout) for vectorized b128 load/store dispatch;
+// MFMA via opus::mfma<bf16,bf16,fp32,16,16,16>; LDS MFMA-tile access via
+// opus::make_smem. The fp32 triangular-inverse epilogue keeps its explicit
+// matrix-core fragment→coord mapping (numerically proven; an opus fragment-layout
+// rewrite there would risk silent bf16 corruption for no perf gain).
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include "opus/opus.hpp"
+#include "opus_gdn/gdn_chunk_prepare_defs.h"
+
+// ===========================================================================
+// MFMA bf16 16×16×16 helpers (opus-backed). Kept local to this kernel so the
+// chunk-prepare op is self-contained.
+// ===========================================================================
+namespace gdn_cp {
+
+using v4bf16_t = opus::bf16x4_t;
+using v4f32_t  = opus::fp32x4_t;
+
+__device__ inline v4f32_t mfma_f32_16x16x16_bf16(v4bf16_t a, v4bf16_t b, v4f32_t c) {
+    return opus::mfma<opus::bf16_t, opus::bf16_t, opus::fp32_t, 16, 16, 16>{}(a, b, c);
+}
+
+__device__ inline v4bf16_t load_mfma_tile(
+        const opus::bf16_t* __restrict__ lds, int row_base, int col_base,
+        int stride, int lane_id) {
+    int addr = (row_base + (lane_id & 15)) * stride + col_base + ((lane_id >> 4) << 2);
+    return opus::make_smem<opus::bf16_t>(const_cast<opus::bf16_t*>(lds)).template load<4>(addr);
+}
+
+template<int E_M, int E_N, int E_K>
+__device__ void tiled_gemm_mfma(
+        v4f32_t* __restrict__ c,
+        const opus::bf16_t* __restrict__ lds_a, int m_base, int stride_a,
+        const opus::bf16_t* __restrict__ lds_b, int n_base, int stride_b,
+        int lane_id) {
+    for (int ek = 0; ek < E_K; ek++) {
+        v4bf16_t a_tiles[E_M];
+        for (int em = 0; em < E_M; em++)
+            a_tiles[em] = load_mfma_tile(lds_a, m_base + em * 16, ek * 16, stride_a, lane_id);
+        v4bf16_t b_tiles[E_N];
+        for (int en = 0; en < E_N; en++)
+            b_tiles[en] = load_mfma_tile(lds_b, n_base + en * 16, ek * 16, stride_b, lane_id);
+        for (int em = 0; em < E_M; em++)
+            for (int en = 0; en < E_N; en++)
+                c[em * E_N + en] = mfma_f32_16x16x16_bf16(
+                    a_tiles[em], b_tiles[en], c[em * E_N + en]);
+    }
+}
+
+template<int N>
+__device__ inline void clear_v4f32(v4f32_t* c) {
+    for (int i = 0; i < N; i++) opus::clear(c[i]);
+}
+
+__device__ __forceinline__ opus::bf16_t fast_f32_to_bf16(float f) {
+    unsigned u = __builtin_bit_cast(unsigned, f);
+    u += 0x7FFF + ((u >> 16) & 1);
+    return __builtin_bit_cast(opus::bf16_t, static_cast<unsigned short>(u >> 16));
+}
+
+__device__ inline v4bf16_t load_fp32_tile(
+        const float* __restrict__ s, int row_base, int col_base,
+        int stride, int lane_id) {
+    int base = (row_base + (lane_id & 15)) * stride + col_base + ((lane_id >> 4) << 2);
+    return v4bf16_t{
+        fast_f32_to_bf16(s[base]),
+        fast_f32_to_bf16(s[base + 1]),
+        fast_f32_to_bf16(s[base + 2]),
+        fast_f32_to_bf16(s[base + 3])};
+}
+
+__device__ inline v4bf16_t load_fp32_tile_T(
+        const float* __restrict__ s, int row_base, int col_base,
+        int stride, int lane_id) {
+    int n = lane_id & 15;
+    int col = col_base + n;
+    int kb4 = (lane_id >> 4) << 2;
+    return v4bf16_t{
+        fast_f32_to_bf16(s[(row_base + kb4) * stride + col]),
+        fast_f32_to_bf16(s[(row_base + kb4 + 1) * stride + col]),
+        fast_f32_to_bf16(s[(row_base + kb4 + 2) * stride + col]),
+        fast_f32_to_bf16(s[(row_base + kb4 + 3) * stride + col])};
+}
+
+__device__ inline v4bf16_t accum_to_src(v4f32_t d) {
+    return v4bf16_t{
+        fast_f32_to_bf16(d[0]), fast_f32_to_bf16(d[1]),
+        fast_f32_to_bf16(d[2]), fast_f32_to_bf16(d[3])};
+}
+
+__device__ inline void store_fp32_tile(
+        float* __restrict__ s, int row_base, int col_base,
+        int stride, v4f32_t d, int lane_id) {
+    int n = lane_id & 15;
+    int mb4 = (lane_id >> 4) << 2;
+    s[(row_base + mb4) * stride + col_base + n] = d[0];
+    s[(row_base + mb4 + 1) * stride + col_base + n] = d[1];
+    s[(row_base + mb4 + 2) * stride + col_base + n] = d[2];
+    s[(row_base + mb4 + 3) * stride + col_base + n] = d[3];
+}
+
+}  // namespace gdn_cp
+
+// ===========================================================================
+// Arch-specialized occupancy: gfx942 register-caches C⁻¹ (OCC=3); gfx950 keeps
+// the simpler LDS path (OCC=2).
+// ===========================================================================
+#if defined(__gfx950__)
+#define GDN_CP_OCC 2
+#else
+#define GDN_CP_OCC 3
+#endif
+
+template<typename Traits>
+__global__ void __launch_bounds__(Traits::BLOCK_SIZE, GDN_CP_OCC)
+gdn_chunk_prepare_kernel(gdn_chunk_prepare_kargs kargs) {
+    using namespace gdn_cp;
+    using T = Traits;
+    using D_ATTN = typename T::D_ATTN;
+    using D_ACC  = typename T::D_ACC;
+
+    static_assert(T::BT == 64, "This template is for BT=64 only");
+
+    const int i_t  = blockIdx.x;
+    const int i_bh = blockIdx.y;
+    const int i_b  = i_bh / kargs.H;
+    const int i_h  = i_bh % kargs.H;
+
+    const int tid  = threadIdx.x;
+    const int warp_id = tid / T::WARP_SIZE;
+    const int lane_id = tid % T::WARP_SIZE;
+
+    constexpr int BT = T::BT;
+    constexpr int BS = T::BLOCK_SIZE;
+    constexpr int PAD = T::SMEM_PAD;
+    constexpr int K_STRIDE = T::K_STRIDE;
+    constexpr int BK_SUB = T::BK_SUB;
+    constexpr int A_STRIDE = T::A_STRIDE;
+    const int K  = kargs.K;
+    const int V  = kargs.V;
+    const int H  = kargs.H;
+
+    const int chunk_start = i_t * BT;
+    const int bos = i_b * kargs.T;
+
+    // ---- Shared memory ----
+    extern __shared__ char smem_buf[];
+    D_ACC*  s_g    = reinterpret_cast<D_ACC*>(smem_buf);
+    D_ACC*  s_beta = s_g + BT;
+    D_ATTN* s_k    = reinterpret_cast<D_ATTN*>(s_beta + BT);
+    D_ACC*  s_A    = reinterpret_cast<D_ACC*>(s_k);
+
+    // =====================================================================
+    // Phase 1 — chunk_local_cumsum: load g/beta, inclusive prefix sum of g
+    // =====================================================================
+    const D_ACC* g_base    = reinterpret_cast<const D_ACC*>(kargs.ptr_g)
+                             + (bos + chunk_start) * H + i_h;
+    const D_ACC* beta_base = reinterpret_cast<const D_ACC*>(kargs.ptr_beta)
+                             + (bos + chunk_start) * H + i_h;
+
+    for (int i = tid; i < BT; i += BS) {
+        int global_t = chunk_start + i;
+        s_beta[i] = (global_t < kargs.T) ? beta_base[i * H] : 0.0f;
+    }
+
+    // Single-warp __shfl_up prefix sum (BT == WARP_SIZE == 64): warp-lockstep
+    // register exchange — no LDS round-trip, no __syncthreads. Bit-identical to
+    // the block Hillis-Steele but drops ~6 of its barriers.
+    static_assert(BT == T::WARP_SIZE, "single-warp scan requires BT == WARP_SIZE");
+    if (warp_id == 0) {
+        int global_t = chunk_start + lane_id;
+        float val = (global_t < kargs.T) ? g_base[lane_id * H] : 0.0f;
+        #pragma unroll
+        for (int off = 1; off < BT; off <<= 1) {
+            float up = __shfl_up(val, off, BT);
+            if (lane_id >= off) val += up;
+        }
+        s_g[lane_id] = val;
+    }
+    __syncthreads();
+
+    D_ACC* g_cumsum_base = reinterpret_cast<D_ACC*>(kargs.ptr_g_cumsum)
+                           + (bos + chunk_start) * H + i_h;
+    for (int i = tid; i < BT; i += BS) {
+        int global_t = chunk_start + i;
+        if (global_t < kargs.T)
+            g_cumsum_base[i * H] = s_g[i];
+    }
+    __syncthreads();
+
+    // =====================================================================
+    // Phase 2 — chunk_scaled_dot_kkt_fwd: load k into LDS, KKT GEMM, gate-scale
+    // =====================================================================
+    const D_ATTN* k_base = reinterpret_cast<const D_ATTN*>(kargs.ptr_k)
+                           + ((bos + chunk_start) * H + i_h) * K;
+    {
+        // opus vectorized gmem->smem load (b128). Layouts describe the [BT,K]
+        // tile: gmem row stride = H*K (token-major), smem row stride = K_STRIDE.
+        constexpr int VEC = T::VEC_KV;        // 8 bf16 = 16 B
+        constexpr int K_VEC = T::K / VEC;
+        auto g_k   = opus::make_gmem(reinterpret_cast<const opus::bf16_t*>(k_base));
+        auto sm_k  = opus::make_smem(reinterpret_cast<opus::bf16_t*>(s_k));
+        auto lay_g = opus::make_layout(opus::make_tuple(BT, K), opus::make_tuple(H * K, 1));
+        auto lay_s = opus::make_layout(opus::make_tuple(BT, K), opus::make_tuple(K_STRIDE, 1));
+        for (int i = tid; i < BT * K_VEC; i += BS) {
+            int row = i / K_VEC;
+            int col = (i % K_VEC) * VEC;
+            auto val = (chunk_start + row < kargs.T)
+                           ? g_k.template load<VEC>(lay_g(row, col))
+                           : opus::vector_t<opus::bf16_t, VEC>{};
+            sm_k.template store<VEC>(val, lay_s(row, col));
+        }
+    }
+    __syncthreads();
+
+    constexpr int KKT_E_M = 1;
+    constexpr int KKT_E_N = BT / 16;       // 4
+    constexpr int KKT_E_K = T::K / 16;     // 8
+
+    v4f32_t kkt_c[KKT_E_M * KKT_E_N];
+    clear_v4f32<KKT_E_M * KKT_E_N>(kkt_c);
+    tiled_gemm_mfma<KKT_E_M, KKT_E_N, KKT_E_K>(
+        kkt_c, s_k, warp_id * 16, K_STRIDE,
+               s_k, 0,            K_STRIDE, lane_id);
+    __syncthreads();
+
+    // gate-scale lower triangle, zero upper+diagonal, write fp32 to s_A
+    for (int en = 0; en < KKT_E_N; en++) {
+        for (int p = 0; p < 4; p++) {
+            int s = warp_id * 16 + (lane_id >> 4) * 4 + p;
+            int r = en * 16 + (lane_id & 15);
+            float val = 0.0f;
+            if (s > r)
+                val = kkt_c[en][p] * s_beta[s] * __expf(s_g[s] - s_g[r]);
+            s_A[s * A_STRIDE + r] = val;
+        }
+    }
+    __syncthreads();
+
+    // =====================================================================
+    // Phase 3 — solve_tril: triangular inverse C = (I+A)⁻¹
+    //   3a. per-warp 16×16 diagonal block inverse via Neumann squaring
+    //   3b. Schur-complement merge (3-level warp-parallel DAG)
+    // =====================================================================
+    constexpr v4f32_t z4 = {0.f, 0.f, 0.f, 0.f};
+
+    {
+        int br = warp_id * 16;
+        v4bf16_t neg_A_tile;
+        {
+            int base = (br + (lane_id & 15)) * A_STRIDE + br + ((lane_id >> 4) << 2);
+            neg_A_tile = v4bf16_t{
+                static_cast<__bf16>(-s_A[base]),
+                static_cast<__bf16>(-s_A[base + 1]),
+                static_cast<__bf16>(-s_A[base + 2]),
+                static_cast<__bf16>(-s_A[base + 3])};
+        }
+        v4f32_t I_accum;
+        {
+            int n = lane_id & 15;
+            int m_base = (lane_id >> 4) * 4;
+            I_accum = v4f32_t{
+                (m_base == n) ? 1.0f : 0.0f,
+                ((m_base + 1) == n) ? 1.0f : 0.0f,
+                ((m_base + 2) == n) ? 1.0f : 0.0f,
+                ((m_base + 3) == n) ? 1.0f : 0.0f};
+        }
+        // (I+A)⁻¹ = Σ_{n=0}^{15} Bⁿ = (I+B)(I+B²)(I+B⁴)(I+B⁸), B = -A nilpotent.
+        // 6 MFMAs (3 squarings + 3 products) vs 15 Horner iterations.
+        v4f32_t  b2   = mfma_f32_16x16x16_bf16(neg_A_tile, neg_A_tile, z4);
+        v4bf16_t b2_o = accum_to_src(b2);
+        v4f32_t  b4   = mfma_f32_16x16x16_bf16(b2_o, b2_o, z4);
+        v4bf16_t b4_o = accum_to_src(b4);
+        v4f32_t  b8   = mfma_f32_16x16x16_bf16(b4_o, b4_o, z4);
+        v4bf16_t b8_o = accum_to_src(b8);
+        v4f32_t C_accum;
+        for (int n = 0; n < 4; n++) C_accum[n] = b8[n] + I_accum[n];
+        C_accum = mfma_f32_16x16x16_bf16(b4_o, accum_to_src(C_accum), C_accum);
+        C_accum = mfma_f32_16x16x16_bf16(b2_o, accum_to_src(C_accum), C_accum);
+        C_accum = mfma_f32_16x16x16_bf16(neg_A_tile, accum_to_src(C_accum), C_accum);
+
+        store_fp32_tile(s_A, br, br, A_STRIDE, C_accum, lane_id);
+        for (int idx = lane_id; idx < 16 * 16; idx += T::WARP_SIZE) {
+            int r = idx / 16, c = idx % 16;
+            if (r < c)
+                s_A[(br + r) * A_STRIDE + br + c] = 0.0f;
+        }
+    }
+    __syncthreads();
+
+    // Schur complement merge — 3-level warp-parallel DAG (3 barriers):
+    //   L1: C_21, C_32, C_43   L2: C_31, C_42   L3: C_41
+    v4bf16_t sav_L32, sav_L43, sav_L42;
+    if (warp_id == 0) {
+        sav_L32 = load_fp32_tile(s_A, 32, 16, A_STRIDE, lane_id);
+        sav_L43 = load_fp32_tile(s_A, 48, 32, A_STRIDE, lane_id);
+    } else if (warp_id == 1) {
+        sav_L43 = load_fp32_tile(s_A, 48, 32, A_STRIDE, lane_id);
+    }
+
+    v4f32_t kept_c21 = z4, kept_c32 = z4, kept_c31 = z4;
+
+    if (warp_id == 0) {
+        v4f32_t t = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 16, 0, A_STRIDE, lane_id),
+            load_fp32_tile_T(s_A, 0, 0, A_STRIDE, lane_id), z4);
+        kept_c21 = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 16, 16, A_STRIDE, lane_id),
+            accum_to_src(t), z4);
+        for (int p = 0; p < 4; p++) kept_c21[p] = -kept_c21[p];
+        store_fp32_tile(s_A, 16, 0, A_STRIDE, kept_c21, lane_id);
+    } else if (warp_id == 1) {
+        v4f32_t t = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 32, 16, A_STRIDE, lane_id),
+            load_fp32_tile_T(s_A, 16, 16, A_STRIDE, lane_id), z4);
+        kept_c32 = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 32, 32, A_STRIDE, lane_id),
+            accum_to_src(t), z4);
+        for (int p = 0; p < 4; p++) kept_c32[p] = -kept_c32[p];
+        store_fp32_tile(s_A, 32, 16, A_STRIDE, kept_c32, lane_id);
+    } else if (warp_id == 2) {
+        v4f32_t t = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 48, 32, A_STRIDE, lane_id),
+            load_fp32_tile_T(s_A, 32, 32, A_STRIDE, lane_id), z4);
+        v4f32_t c43 = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 48, 48, A_STRIDE, lane_id),
+            accum_to_src(t), z4);
+        for (int p = 0; p < 4; p++) c43[p] = -c43[p];
+        store_fp32_tile(s_A, 48, 32, A_STRIDE, c43, lane_id);
+    }
+    __syncthreads();
+
+    if (warp_id == 0)
+        sav_L42 = load_fp32_tile(s_A, 48, 16, A_STRIDE, lane_id);
+
+    if (warp_id == 0) {
+        v4f32_t t = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 32, 0, A_STRIDE, lane_id),
+            load_fp32_tile_T(s_A, 0, 0, A_STRIDE, lane_id), z4);
+        t = mfma_f32_16x16x16_bf16(sav_L32, accum_to_src(kept_c21), t);
+        kept_c31 = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 32, 32, A_STRIDE, lane_id),
+            accum_to_src(t), z4);
+        for (int p = 0; p < 4; p++) kept_c31[p] = -kept_c31[p];
+        store_fp32_tile(s_A, 32, 0, A_STRIDE, kept_c31, lane_id);
+    } else if (warp_id == 1) {
+        v4f32_t t = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 48, 16, A_STRIDE, lane_id),
+            load_fp32_tile_T(s_A, 16, 16, A_STRIDE, lane_id), z4);
+        t = mfma_f32_16x16x16_bf16(sav_L43, accum_to_src(kept_c32), t);
+        v4f32_t c42 = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 48, 48, A_STRIDE, lane_id),
+            accum_to_src(t), z4);
+        for (int p = 0; p < 4; p++) c42[p] = -c42[p];
+        store_fp32_tile(s_A, 48, 16, A_STRIDE, c42, lane_id);
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+        v4f32_t t = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 48, 0, A_STRIDE, lane_id),
+            load_fp32_tile_T(s_A, 0, 0, A_STRIDE, lane_id), z4);
+        t = mfma_f32_16x16x16_bf16(sav_L42, accum_to_src(kept_c21), t);
+        t = mfma_f32_16x16x16_bf16(sav_L43, accum_to_src(kept_c31), t);
+        v4f32_t c41 = mfma_f32_16x16x16_bf16(
+            load_fp32_tile(s_A, 48, 48, A_STRIDE, lane_id),
+            accum_to_src(t), z4);
+        for (int p = 0; p < 4; p++) c41[p] = -c41[p];
+        store_fp32_tile(s_A, 48, 0, A_STRIDE, c41, lane_id);
+    }
+    __syncthreads();
+    // s_A now holds C = (I + A)⁻¹
+
+    // =====================================================================
+    // Phase 4 — recompute_w_u_fwd: WY factor GEMMs
+    //   u_bar = C @ (v * beta)
+    //   w_bar = C @ (k * beta * exp(g_cumsum))
+    // =====================================================================
+#if defined(__gfx950__)
+    // gfx950 (OCC=2): stage C⁻¹ in LDS as bf16 (placed after s_A).
+    constexpr int C_STRIDE = BT + PAD;  // 68
+    D_ATTN* s_C_bf16 = reinterpret_cast<D_ATTN*>(
+        smem_buf + BT * 2 * sizeof(D_ACC) + BT * A_STRIDE * sizeof(D_ACC));
+    for (int i = tid; i < BT * BT; i += BS) {
+        int s = i / BT;
+        int j = i % BT;
+        s_C_bf16[s * C_STRIDE + j] = static_cast<D_ATTN>(s_A[s * A_STRIDE + j]);
+    }
+    __syncthreads();
+    constexpr int WY_EM = 1;
+#else
+    // gfx942 (OCC=3): cache C⁻¹ tiles in registers (no s_C_bf16 in LDS → OCC 2→3).
+    constexpr int WY_EK_C = BT / 16;  // 4
+    v4bf16_t cached_C[WY_EK_C];
+    for (int ek = 0; ek < WY_EK_C; ek++)
+        cached_C[ek] = load_fp32_tile(s_A, warp_id * 16, ek * 16, A_STRIDE, lane_id);
+#endif
+
+    constexpr int VT_STRIDE = BT + PAD;  // 68
+    D_ATTN* s_vT = s_k;                   // reuse freed s_A/s_k region
+
+    constexpr int WY_EN = BK_SUB / 16;   // 4
+    constexpr int WY_EK = BT / 16;       // 4
+
+    D_ATTN* w_bar_base = reinterpret_cast<D_ATTN*>(kargs.ptr_w_bar)
+                         + ((bos + chunk_start) * H + i_h) * K;
+    D_ATTN* u_bar_base = reinterpret_cast<D_ATTN*>(kargs.ptr_u_bar)
+                         + ((bos + chunk_start) * H + i_h) * V;
+    const D_ATTN* v_base = reinterpret_cast<const D_ATTN*>(kargs.ptr_v)
+                           + ((bos + chunk_start) * H + i_h) * V;
+
+    // --- u_bar = C @ (v * beta) ---
+    for (int iv = 0; iv < T::N_V_ITERS; iv++) {
+        int v_offset = iv * BK_SUB;
+        {
+            // opus vectorized gmem load; transposed β-scaled store stays scalar.
+            constexpr int VEC = T::VEC_KV;
+            constexpr int NVEC = BK_SUB / VEC;
+            auto g_v   = opus::make_gmem(reinterpret_cast<const opus::bf16_t*>(v_base));
+            auto lay_v = opus::make_layout(opus::make_tuple(BT, V), opus::make_tuple(H * V, 1));
+            for (int i = tid; i < BT * NVEC; i += BS) {
+                int j  = i / NVEC;
+                int vi = (i % NVEC) * VEC;
+                auto vals = (chunk_start + j < kargs.T)
+                                ? g_v.template load<VEC>(lay_v(j, v_offset + vi))
+                                : opus::vector_t<opus::bf16_t, VEC>{};
+                D_ACC beta_j = s_beta[j];
+                for (int vv = 0; vv < VEC; vv++)
+                    s_vT[(vi + vv) * VT_STRIDE + j] = static_cast<D_ATTN>(
+                        static_cast<D_ACC>(vals[vv]) * beta_j);
+            }
+        }
+        __syncthreads();
+
+#if defined(__gfx950__)
+        v4f32_t wy_c[WY_EM * WY_EN];
+        clear_v4f32<WY_EM * WY_EN>(wy_c);
+        tiled_gemm_mfma<WY_EM, WY_EN, WY_EK>(
+            wy_c, s_C_bf16, warp_id * 16, C_STRIDE,
+                  s_vT,     0,            VT_STRIDE, lane_id);
+#else
+        v4f32_t wy_c[WY_EN];
+        clear_v4f32<WY_EN>(wy_c);
+        for (int ek = 0; ek < WY_EK; ek++) {
+            v4bf16_t b_tiles[WY_EN];
+            for (int en = 0; en < WY_EN; en++)
+                b_tiles[en] = load_mfma_tile(s_vT, en * 16, ek * 16, VT_STRIDE, lane_id);
+            for (int en = 0; en < WY_EN; en++)
+                wy_c[en] = mfma_f32_16x16x16_bf16(cached_C[ek], b_tiles[en], wy_c[en]);
+        }
+#endif
+
+        for (int en = 0; en < WY_EN; en++) {
+            for (int p = 0; p < 4; p++) {
+                int s  = warp_id * 16 + (lane_id >> 4) * 4 + p;
+                int vi = en * 16 + (lane_id & 15);
+                if (chunk_start + s < kargs.T)
+                    u_bar_base[s * H * V + v_offset + vi] = static_cast<D_ATTN>(wy_c[en][p]);
+            }
+        }
+        __syncthreads();
+    }
+
+    // --- w_bar = C @ (k * beta * exp(g_cumsum)) ---
+    for (int ik = 0; ik < T::N_K_ITERS; ik++) {
+        int k_offset = ik * BK_SUB;
+        {
+            // opus vectorized gmem load; transposed (β·e^g)-scaled store stays scalar.
+            constexpr int VEC = T::VEC_KV;
+            constexpr int NVEC = BK_SUB / VEC;
+            auto g_kk  = opus::make_gmem(reinterpret_cast<const opus::bf16_t*>(k_base));
+            auto lay_k = opus::make_layout(opus::make_tuple(BT, K), opus::make_tuple(H * K, 1));
+            for (int i = tid; i < BT * NVEC; i += BS) {
+                int j  = i / NVEC;
+                int ki = (i % NVEC) * VEC;
+                auto vals = (chunk_start + j < kargs.T)
+                                ? g_kk.template load<VEC>(lay_k(j, k_offset + ki))
+                                : opus::vector_t<opus::bf16_t, VEC>{};
+                D_ACC scale_j = s_beta[j] * __expf(s_g[j]);
+                for (int vv = 0; vv < VEC; vv++)
+                    s_vT[(ki + vv) * VT_STRIDE + j] = static_cast<D_ATTN>(
+                        static_cast<D_ACC>(vals[vv]) * scale_j);
+            }
+        }
+        __syncthreads();
+
+#if defined(__gfx950__)
+        v4f32_t wy_c[WY_EM * WY_EN];
+        clear_v4f32<WY_EM * WY_EN>(wy_c);
+        tiled_gemm_mfma<WY_EM, WY_EN, WY_EK>(
+            wy_c, s_C_bf16, warp_id * 16, C_STRIDE,
+                  s_vT,     0,            VT_STRIDE, lane_id);
+#else
+        v4f32_t wy_c[WY_EN];
+        clear_v4f32<WY_EN>(wy_c);
+        for (int ek = 0; ek < WY_EK; ek++) {
+            v4bf16_t b_tiles[WY_EN];
+            for (int en = 0; en < WY_EN; en++)
+                b_tiles[en] = load_mfma_tile(s_vT, en * 16, ek * 16, VT_STRIDE, lane_id);
+            for (int en = 0; en < WY_EN; en++)
+                wy_c[en] = mfma_f32_16x16x16_bf16(cached_C[ek], b_tiles[en], wy_c[en]);
+        }
+#endif
+
+        for (int en = 0; en < WY_EN; en++) {
+            for (int p = 0; p < 4; p++) {
+                int s  = warp_id * 16 + (lane_id >> 4) * 4 + p;
+                int ki = en * 16 + (lane_id & 15);
+                if (chunk_start + s < kargs.T)
+                    w_bar_base[s * H * K + k_offset + ki] = static_cast<D_ATTN>(wy_c[en][p]);
+            }
+        }
+        __syncthreads();
+    }
+}

--- a/csrc/include/opus_gdn_chunk_prepare.h
+++ b/csrc/include/opus_gdn_chunk_prepare.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+#pragma once
+#include <torch/extension.h>
+
+// Fused intra-chunk GDN prefill preparation:
+//   chunk_local_cumsum + chunk_scaled_dot_kkt_fwd + solve_tril + recompute_w_u_fwd
+void gdn_chunk_prepare_fwd(
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor g,
+    torch::Tensor beta,
+    torch::Tensor w_bar,
+    torch::Tensor u_bar,
+    torch::Tensor g_cumsum);

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2207,3 +2207,16 @@ namespace py = pybind11;
           py::arg("split_output"),      \
           py::arg("split_lse"),         \
           py::arg("final_output"));
+
+// Fused intra-chunk GDN prefill preparation
+// (chunk_local_cumsum + chunk_scaled_dot_kkt_fwd + solve_tril + recompute_w_u_fwd)
+#define GDN_CHUNK_PREPARE_PYBIND               \
+    m.def("gdn_chunk_prepare_fwd",             \
+          &gdn_chunk_prepare_fwd,              \
+          py::arg("k"),                        \
+          py::arg("v"),                        \
+          py::arg("g"),                        \
+          py::arg("beta"),                     \
+          py::arg("w_bar"),                    \
+          py::arg("u_bar"),                    \
+          py::arg("g_cumsum"));

--- a/csrc/py_itfs_cu/opus_gdn_chunk_prepare.cu
+++ b/csrc/py_itfs_cu/opus_gdn_chunk_prepare.cu
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// gdn_chunk_prepare kernel instantiation (BT=64, K=V=128).
+// Fuses chunk_local_cumsum + chunk_scaled_dot_kkt_fwd + solve_tril + recompute_w_u_fwd.
+#include <hip/hip_runtime.h>
+#include "opus_gdn/gdn_chunk_prepare_defs.h"
+#ifndef __HIP_DEVICE_COMPILE__
+template<typename Traits> __global__ void gdn_chunk_prepare_kernel(gdn_chunk_prepare_kargs kargs) {}
+template __global__ void gdn_chunk_prepare_kernel<gdn_chunk_prepare_traits<64, 128, 128, 4>>(gdn_chunk_prepare_kargs);
+#else
+#include "opus_gdn/gdn_chunk_prepare_kernel.hpp"
+template __global__ void gdn_chunk_prepare_kernel<gdn_chunk_prepare_traits<64, 128, 128, 4>>(gdn_chunk_prepare_kargs);
+#endif

--- a/csrc/py_itfs_cu/opus_gdn_chunk_prepare_launch.cu
+++ b/csrc/py_itfs_cu/opus_gdn_chunk_prepare_launch.cu
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Host launcher for gdn_chunk_prepare — the fused intra-chunk GDN prefill prep
+// (chunk_local_cumsum + chunk_scaled_dot_kkt_fwd + solve_tril + recompute_w_u_fwd).
+// Target: gfx942 (MI300X) / gfx950 (MI350).
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <torch/all.h>
+#include <hip/hip_runtime.h>
+#include <cstring>
+
+#include "opus_gdn/gdn_chunk_prepare_defs.h"
+
+static inline int gdn_cp_ceil_div(int a, int b) { return (a + b - 1) / b; }
+
+// gfx950 uses the LDS C⁻¹ path (OCC=2); gfx942 the register-cached path (OCC=3).
+// Host can't see __gfx950__, so detect at runtime (JIT build is per-machine).
+static inline bool gdn_cp_is_gfx950() {
+    static int cached = -1;
+    if (cached < 0) {
+        hipDeviceProp_t p;
+        cached = (hipGetDeviceProperties(&p, 0) == hipSuccess &&
+                  std::strstr(p.gcnArchName, "gfx950") != nullptr) ? 1 : 0;
+    }
+    return cached != 0;
+}
+
+// Definition lives in opus_gdn_chunk_prepare.cu (separate TU to avoid ODR issues).
+template<typename Traits>
+__global__ void gdn_chunk_prepare_kernel(gdn_chunk_prepare_kargs kargs);
+
+// Inputs:  k[B,T,H,K] bf16, v[B,T,H,V] bf16, g[B,T,H] fp32, beta[B,T,H] fp32
+// Outputs: g_cumsum[B,T,H] fp32, w_bar[B,T,H,K] bf16, u_bar[B,T,H,V] bf16
+void gdn_chunk_prepare_fwd(
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor g,
+    torch::Tensor beta,
+    torch::Tensor w_bar,
+    torch::Tensor u_bar,
+    torch::Tensor g_cumsum)
+{
+    using K1Traits = gdn_chunk_prepare_traits<64, 128, 128, 4>;
+    constexpr int BT = K1Traits::BT;
+
+    const int B = k.size(0);
+    const int T = k.size(1);
+    const int H = k.size(2);
+    const int K = k.size(3);
+    const int V = v.size(3);
+    const int NT = gdn_cp_ceil_div(T, BT);
+
+    gdn_chunk_prepare_kargs kargs{};
+    kargs.ptr_k        = k.data_ptr();
+    kargs.ptr_v        = v.data_ptr();
+    kargs.ptr_beta     = beta.data_ptr();
+    kargs.ptr_g        = g.data_ptr();
+    kargs.ptr_w_bar    = w_bar.data_ptr();
+    kargs.ptr_u_bar    = u_bar.data_ptr();
+    kargs.ptr_g_cumsum = g_cumsum.data_ptr();
+    kargs.B = B; kargs.T = T; kargs.H = H; kargs.K = K; kargs.V = V;
+
+    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(at::device_of(k));
+    const hipStream_t stream = at::hip::getCurrentHIPStream();
+
+    dim3 grid(NT, B * H);
+    dim3 block(K1Traits::BLOCK_SIZE);
+    size_t smem = gdn_cp_is_gfx950()
+                      ? K1Traits::smem_size_bytes_cinv_lds()
+                      : K1Traits::smem_size_bytes();
+
+    gdn_chunk_prepare_kernel<K1Traits><<<grid, block, smem, stream>>>(kargs);
+}

--- a/csrc/pybind/opus_gdn_chunk_prepare_pybind.cu
+++ b/csrc/pybind/opus_gdn_chunk_prepare_pybind.cu
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "rocm_ops.hpp"
+#include "opus_gdn_chunk_prepare.h"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    GDN_CHUNK_PREPARE_PYBIND;
+}

--- a/op_tests/triton_tests/bench_gdn_chunk_prepare.py
+++ b/op_tests/triton_tests/bench_gdn_chunk_prepare.py
@@ -46,19 +46,30 @@ def rell2(a,b):
     a,b=a.float(),b.float()
     return (torch.linalg.vector_norm(a-b)/torch.linalg.vector_norm(b).clamp_min(1e-12)).item()
 
-print(f"{'config':>16} | {'opus(us)':>9} {'triton(us)':>10} {'speedup':>8} | {'w relL2':>9} {'u relL2':>9}")
-print("-"*72)
-for (B,T,H) in [(1,1024,4),(1,2048,16),(1,4096,8),(1,8192,32),(1,16384,16),(4,2048,8),(1,32768,16)]:
-    k,v,g,beta=make(B,T,H)
-    K=k.shape[-1]; V=v.shape[-1]
-    w=torch.empty(B,T,H,K,dtype=torch.bfloat16,device="cuda")
-    u=torch.empty(B,T,H,V,dtype=torch.bfloat16,device="cuda")
-    gc=torch.empty(B,T,H,dtype=torch.float32,device="cuda")
-    # precision vs triton non-fused
-    gT,wT,uT=triton_k14(k,v,g,beta)
-    opus_k14(k,v,g,beta,w,u,gc)
-    dw,du=rell2(w,wT),rell2(u,uT)
-    # cudagraph timing
-    to=graph_time(lambda: opus_k14(k,v,g,beta,w,u,gc))
-    tt=graph_time(lambda: triton_k14(k,v,g,beta))
-    print(f"B{B}T{T}H{H:<2}".rjust(16)+f" | {to:9.1f} {tt:10.1f} {tt/to:7.2f}x | {dw:9.2e} {du:9.2e}",flush=True)
+# Model configs (K=V=128): 35B-tp1=H32, 35B-tp2=H16, FULL-tp1=H64
+MODELS = [
+    ("35B-tp1",  32, [1024, 2048, 4096, 8192, 16384, 32768, 65536]),
+    ("35B-tp2",  16, [1024, 8192, 65536]),
+    ("FULL-tp1", 64, [1024, 8192, 65536]),
+]
+
+print(f"{'model':>9} {'T':>6} | {'Opus K1(us)':>11} {'Triton k14(us)':>14} {'speedup':>8} | {'w relL2':>9} {'u relL2':>9}")
+print("-"*80)
+for name, H, Ts in MODELS:
+    for T in Ts:
+        B = 1
+        k,v,g,beta=make(B,T,H)
+        K=k.shape[-1]; V=v.shape[-1]
+        w=torch.empty(B,T,H,K,dtype=torch.bfloat16,device="cuda")
+        u=torch.empty(B,T,H,V,dtype=torch.bfloat16,device="cuda")
+        gc=torch.empty(B,T,H,dtype=torch.float32,device="cuda")
+        # precision vs triton non-fused
+        gT,wT,uT=triton_k14(k,v,g,beta)
+        opus_k14(k,v,g,beta,w,u,gc)
+        dw,du=rell2(w,wT),rell2(u,uT)
+        # cudagraph timing
+        to=graph_time(lambda: opus_k14(k,v,g,beta,w,u,gc))
+        tt=graph_time(lambda: triton_k14(k,v,g,beta))
+        print(f"{name:>9} {T:>6} | {to:11.1f} {tt:14.1f} {tt/to:7.2f}x | {dw:9.2e} {du:9.2e}",flush=True)
+        del k,v,g,beta,w,u,gc,gT,wT,uT
+        torch.cuda.empty_cache()

--- a/op_tests/triton_tests/bench_gdn_chunk_prepare.py
+++ b/op_tests/triton_tests/bench_gdn_chunk_prepare.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+# CUDA-graph end-to-end bench: fused gdn_chunk_prepare (1 kernel) vs Triton
+# non-fused k14 (chunk_local_cumsum + chunk_scaled_dot_kkt_fwd + solve_tril +
+# recompute_w_u_fwd, 4 kernels). Also reports precision alignment vs Triton.
+import torch, torch.nn.functional as F
+from aiter.ops.gdn_chunk_prepare import gdn_chunk_prepare_fwd
+from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
+    chunk_local_cumsum, chunk_scaled_dot_kkt_fwd, solve_tril, recompute_w_u_fwd,
+)
+
+def make(B,T,H,K=128,V=128,seed=0):
+    torch.manual_seed(seed); dev="cuda"
+    k=F.normalize(torch.randn(B,T,H,K,dtype=torch.bfloat16,device=dev),p=2,dim=-1)
+    v=torch.randn(B,T,H,V,dtype=torch.bfloat16,device=dev)*0.5
+    g=F.logsigmoid(torch.randn(B,T,H,dtype=torch.float32,device=dev))
+    beta=torch.rand(B,T,H,dtype=torch.float32,device=dev)
+    return k,v,g,beta
+
+def triton_k14(k,v,g,beta):
+    g_cs=chunk_local_cumsum(g,chunk_size=64,cu_seqlens=None)
+    A=chunk_scaled_dot_kkt_fwd(k=k,g=g_cs,beta=beta,cu_seqlens=None,output_dtype=torch.float32)
+    A=solve_tril(A=A,cu_seqlens=None,output_dtype=k.dtype)
+    w,u=recompute_w_u_fwd(k=k,v=v,beta=beta,A=A,g=g_cs,cu_seqlens=None)
+    return g_cs,w,u
+
+def opus_k14(k,v,g,beta,w,u,gc):
+    gdn_chunk_prepare_fwd(k,v,g,beta,w,u,gc)
+
+def graph_time(fn, iters=50):
+    # warmup on side stream (required before capture)
+    s=torch.cuda.Stream(); s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(5): fn()
+    torch.cuda.current_stream().wait_stream(s)
+    g=torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g): fn()
+    for _ in range(5): g.replay()
+    torch.cuda.synchronize()
+    e0,e1=torch.cuda.Event(enable_timing=True),torch.cuda.Event(enable_timing=True)
+    e0.record()
+    for _ in range(iters): g.replay()
+    e1.record(); torch.cuda.synchronize()
+    return e0.elapsed_time(e1)/iters*1e3  # us
+
+def rell2(a,b):
+    a,b=a.float(),b.float()
+    return (torch.linalg.vector_norm(a-b)/torch.linalg.vector_norm(b).clamp_min(1e-12)).item()
+
+print(f"{'config':>16} | {'opus(us)':>9} {'triton(us)':>10} {'speedup':>8} | {'w relL2':>9} {'u relL2':>9}")
+print("-"*72)
+for (B,T,H) in [(1,1024,4),(1,2048,16),(1,4096,8),(1,8192,32),(1,16384,16),(4,2048,8),(1,32768,16)]:
+    k,v,g,beta=make(B,T,H)
+    K=k.shape[-1]; V=v.shape[-1]
+    w=torch.empty(B,T,H,K,dtype=torch.bfloat16,device="cuda")
+    u=torch.empty(B,T,H,V,dtype=torch.bfloat16,device="cuda")
+    gc=torch.empty(B,T,H,dtype=torch.float32,device="cuda")
+    # precision vs triton non-fused
+    gT,wT,uT=triton_k14(k,v,g,beta)
+    opus_k14(k,v,g,beta,w,u,gc)
+    dw,du=rell2(w,wT),rell2(u,uT)
+    # cudagraph timing
+    to=graph_time(lambda: opus_k14(k,v,g,beta,w,u,gc))
+    tt=graph_time(lambda: triton_k14(k,v,g,beta))
+    print(f"B{B}T{T}H{H:<2}".rjust(16)+f" | {to:9.1f} {tt:10.1f} {tt/to:7.2f}x | {dw:9.2e} {du:9.2e}",flush=True)

--- a/op_tests/triton_tests/test_gdn_chunk_prepare.py
+++ b/op_tests/triton_tests/test_gdn_chunk_prepare.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Correctness test for gdn_chunk_prepare (the fused intra-chunk GDN prefill prep).
+# Reference = the four Triton FLA kernels it fuses:
+#   chunk_local_cumsum + chunk_scaled_dot_kkt_fwd + solve_tril + recompute_w_u_fwd
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from aiter.ops.gdn_chunk_prepare import gdn_chunk_prepare
+from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
+    chunk_local_cumsum,
+    chunk_scaled_dot_kkt_fwd,
+    solve_tril,
+    recompute_w_u_fwd,
+)
+
+
+def _ref_triton(k, v, g, beta, BT=64):
+    g_cs = chunk_local_cumsum(g, chunk_size=BT, cu_seqlens=None)
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k, g=g_cs, beta=beta, cu_seqlens=None, output_dtype=torch.float32
+    )
+    A = solve_tril(A=A, cu_seqlens=None, output_dtype=k.dtype)
+    w, u = recompute_w_u_fwd(k=k, v=v, beta=beta, A=A, g=g_cs, cu_seqlens=None)
+    return g_cs, w, u
+
+
+def _ref_fp32(k, v, g, beta, BT=64):
+    """Exact chunk-prepare math in fp32 — ground truth (matches the kernel's
+    convention: A = tril(KKᵀ ⊙ β·decay, -1); C = (I+A)⁻¹; u = C(vβ); w = C(kβe^g))."""
+    B, T, H, K = k.shape
+    V = v.shape[-1]
+    kf, vf = k.float(), v.float()
+    gf, bf = g.float(), beta.float()
+    g_cs = torch.empty(B, T, H, dtype=torch.float32, device=k.device)
+    w = torch.empty(B, T, H, K, dtype=torch.float32, device=k.device)
+    u = torch.empty(B, T, H, V, dtype=torch.float32, device=k.device)
+    for c0 in range(0, T, BT):
+        c1 = min(c0 + BT, T)
+        L = c1 - c0
+        gc = gf[:, c0:c1].cumsum(dim=1)                      # [B,L,H]
+        g_cs[:, c0:c1] = gc
+        kb = kf[:, c0:c1].permute(0, 2, 1, 3)               # [B,H,L,K]
+        vb = vf[:, c0:c1].permute(0, 2, 1, 3)               # [B,H,L,V]
+        bb = bf[:, c0:c1].permute(0, 2, 1)                  # [B,H,L]
+        gch = gc.permute(0, 2, 1)                           # [B,H,L]
+        kk = torch.matmul(kb, kb.transpose(-1, -2))         # [B,H,L,L]
+        decay = torch.exp(gch.unsqueeze(-1) - gch.unsqueeze(-2))  # [B,H,L,L]
+        A = kk * decay * bb.unsqueeze(-1)                   # scale rows by beta[s]
+        A = torch.tril(A, diagonal=-1)
+        eye = torch.eye(L, device=k.device, dtype=torch.float32)
+        C = torch.linalg.inv(eye + A)                       # [B,H,L,L]
+        u_blk = torch.matmul(C, vb * bb.unsqueeze(-1))      # [B,H,L,V]
+        w_blk = torch.matmul(C, kb * (bb * torch.exp(gch)).unsqueeze(-1))
+        u[:, c0:c1] = u_blk.permute(0, 2, 1, 3)
+        w[:, c0:c1] = w_blk.permute(0, 2, 1, 3)
+    return g_cs, w, u
+
+
+def _rel_l2(a, b):
+    a, b = a.float(), b.float()
+    return (torch.linalg.vector_norm(a - b) / torch.linalg.vector_norm(b).clamp_min(1e-12)).item()
+
+
+def _make(B, T, H, K=128, V=128, seed=0):
+    torch.manual_seed(seed)
+    dev = "cuda"
+    q = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device=dev), p=2, dim=-1)
+    k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device=dev), p=2, dim=-1)
+    v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device=dev) * 0.5
+    g = F.logsigmoid(torch.randn(B, T, H, dtype=torch.float32, device=dev))
+    beta = torch.rand(B, T, H, dtype=torch.float32, device=dev)
+    return q, k, v, g, beta
+
+
+def _report(name, a, b):
+    a = a.float()
+    b = b.float()
+    diff = (a - b).abs()
+    denom = b.abs().clamp_min(1e-4)
+    print(
+        f"  {name:9}: max_abs={diff.max().item():.4e} "
+        f"mean_abs={diff.mean().item():.4e} "
+        f"max_rel={(diff/denom).max().item():.4e}"
+    )
+    return diff.max().item()
+
+
+@pytest.mark.parametrize("B,T,H", [
+    (1, 1024, 4), (1, 2048, 16), (1, 4096, 8), (1, 8192, 32),
+    (1, 16384, 16), (4, 2048, 8), (1, 1000, 4),  # last: non-multiple of BT
+])
+def test_gdn_chunk_prepare(B, T, H):
+    q, k, v, g, beta = _make(B, T, H)
+    gR, wR, uR = _ref_fp32(k, v, g, beta)            # fp32 ground truth
+    gT, wT, uT = _ref_triton(k, v, g, beta)          # Triton (bf16) baseline
+    w, u, g_cs = gdn_chunk_prepare(k, v, g, beta, BT=64)
+
+    # rel-L2 vs fp32 ground truth
+    k_g, k_w, k_u = _rel_l2(g_cs, gR), _rel_l2(w, wR), _rel_l2(u, uR)
+    t_g, t_w, t_u = _rel_l2(gT, gR), _rel_l2(wT, wR), _rel_l2(uT, uR)
+    print(f"\n[B{B} T{T} H{H}]  rel-L2 vs fp32 (kernel | triton)")
+    print(f"  g_cumsum: {k_g:.3e} | {t_g:.3e}")
+    print(f"  w_bar   : {k_w:.3e} | {t_w:.3e}")
+    print(f"  u_bar   : {k_u:.3e} | {t_u:.3e}")
+
+    # g_cumsum is fp32 -> should be ~exact
+    assert k_g < 1e-5, f"g_cumsum rel-L2 {k_g}"
+    # w_bar/u_bar are bf16 -> require the kernel be at least as accurate as Triton
+    # (small slack) against fp32 ground truth.
+    assert k_w <= max(1.5 * t_w, 2e-2), f"w_bar rel-L2 {k_w} vs triton {t_w}"
+    assert k_u <= max(1.5 * t_u, 2e-2), f"u_bar rel-L2 {k_u} vs triton {t_u}"
+
+
+if __name__ == "__main__":
+    import sys
+    cfgs = [(1, 1024, 4), (1, 2048, 16), (1, 4096, 8), (1, 8192, 32),
+            (1, 16384, 16), (4, 2048, 8), (1, 1000, 4)]
+    fail = 0
+    for (B, T, H) in cfgs:
+        try:
+            test_gdn_chunk_prepare(B, T, H)
+        except AssertionError as e:
+            print("  FAIL:", e); fail += 1
+    print("\n" + ("OK" if fail == 0 else f"{fail} FAILED"))
+    sys.exit(1 if fail else 0)


### PR DESCRIPTION
## Motivation

The Gated-DeltaNet (GDN) chunkwise prefill runs four separate FLA kernels before
the h-state recurrence:

  chunk_local_cumsum → chunk_scaled_dot_kkt_fwd → solve_tril → recompute_w_u_fwd

This costs 4 kernel launches, an `A_raw[B,T,H,64]` HBM round-trip, and repeated
reloads of g/beta/k. This PR fuses all four into a single token-parallel HIP
kernel, `gdn_chunk_prepare`, built on the `opus.hpp` template library, with
per-arch specialization that ships only the best-performing path for each target.

## Technical Details

- **New op `gdn_chunk_prepare`** (`module_gdn_chunk_prepare`): one HIP kernel that
  fuses cumsum + gated KKT Gram + triangular inverse + WY-factor recompute.
  Inputs `k,v` (bf16), `g,beta` (fp32); outputs `g_cumsum` (fp32), `w_bar,u_bar` (bf16).
  BT=64, K=V=128.
- **opus.hpp usage**: all global↔LDS traffic via `make_gmem`/`make_smem`/`make_layout`
  (vectorized b128 dispatch); MFMA via `opus::mfma<bf16,bf16,fp32,16,16,16>`;
  LDS MFMA-tile access via `opus::make_smem`.
- **Numerics**: triangular inverse via Neumann squaring `(I+B)(I+B²)(I+B⁴)(I+B⁸)`
  (6 MFMAs vs 15 Horner), 3-level warp-parallel Schur-complement merge, and a
  single-warp `__shfl_up` cumsum (drops ~6 block barriers).
- **Arch specialized (best-only)** via `#if defined(__gfx950__)`:
  - gfx950 (MI350): OCC=2, C⁻¹ staged in LDS as bf16 (160KB LDS is not the limiter).
  - gfx942 (MI300): OCC=3, C⁻¹ register-cached → smaller LDS lifts occupancy 2→3.
- Files: kernel template + defs (`csrc/include/opus_gdn/gdn_chunk_prepare_*`),
  TU + host launcher (`csrc/py_itfs_cu/opus_gdn_chunk_prepare*.cu`), pybind/header,
  Python op (`aiter/ops/gdn_chunk_prepare.py`), JIT config entry, and tests.

## Test Plan

- **Correctness** (`op_tests/triton_tests/test_gdn_chunk_prepare.py`): compares the
  fused output against an fp32 ground-truth reference and the Triton non-fused
  k14 across multiple shapes (incl. a non-BT-multiple T).
- **Performance** (`op_tests/triton_tests/bench_gdn_chunk_prepare.py`): CUDA-graph
  capture/replay, fused 1-kernel vs Triton 4-kernel k14, median µs, across the
  35B/FULL model configs (K=V=128).

## Test Result

**Precision** (vs fp32 ground truth and Triton non-fused, both arches): `g_cumsum`
exact (~1e-7); `w_bar` rel-L2 ~3e-3, `u_bar` rel-L2 ~4.3e-3 — bf16-level, aligned
with Triton.

**Performance** — fused `gdn_chunk_prepare` (1 kernel) vs Triton non-fused k14
(4 kernels), under CUDA graph (launch overhead removed). A structural win from
single-kernel fusion + LDS staging (no `A_raw` HBM round-trip): MI300X is flat at
**~2.4–2.5×**; MI350 is **~1.9–2.3×** (gfx950's 32×32×16 MFMA makes Triton's k14
GEMMs relatively faster, narrowing the margin slightly). Both arch-specialized
paths are runtime-validated.

### MI300X (gfx942)

| model | T | Opus K1 (µs) | Triton k14 (µs) | speedup | w relL2 | u relL2 |
|---|---:|---:|---:|---:|---:|---:|
| 35B-tp1 (H=32) | 1024  | 77.6   | 196.5   | 2.53× | 3.7e-3 | 4.3e-3 |
|                | 2048  | 130.0  | 324.0   | 2.49× | 3.0e-3 | 4.3e-3 |
|                | 4096  | 240.3  | 574.1   | 2.39× | 2.9e-3 | 4.3e-3 |
|                | 8192  | 470.0  | 1123.5  | 2.39× | 3.0e-3 | 4.3e-3 |
|                | 16384 | 996.7  | 2415.2  | 2.42× | 3.2e-3 | 4.3e-3 |
|                | 32768 | 1968.5 | 4854.7  | 2.47× | 3.1e-3 | 4.3e-3 |
|                | 65536 | 3963.2 | 9913.2  | 2.50× | 3.0e-3 | 4.3e-3 |
| 35B-tp2 (H=16) | 1024  | 51.0   | 114.1   | 2.24× | 3.3e-3 | 4.6e-3 |
|                | 8192  | 242.8  | 595.2   | 2.45× | 3.2e-3 | 4.4e-3 |
|                | 65536 | 1995.9 | 4896.7  | 2.45× | 3.1e-3 | 4.3e-3 |
| FULL-tp1 (H=64)| 1024  | 134.6  | 326.1   | 2.42× | 2.9e-3 | 4.3e-3 |
|                | 8192  | 1028.8 | 2491.2  | 2.42× | 2.9e-3 | 4.3e-3 |
|                | 65536 | 8469.6 | 20353.7 | 2.40× | 3.1e-3 | 4.3e-3 |

Anchor (35B-tp1 T=8192): **Opus K1 470 µs vs Triton k14 1124 µs (2.39×)**.

### MI350 (gfx950)

| model | T | Opus K1 (µs) | Triton k14 (µs) | speedup | w relL2 | u relL2 |
|---|---:|---:|---:|---:|---:|---:|
| 35B-tp1 (H=32) | 1024  | 23.8   | 53.6   | 2.26× | 3.1e-3 | 4.1e-3 |
|                | 2048  | 30.9   | 70.1   | 2.27× | 2.9e-3 | 4.3e-3 |
|                | 4096  | 53.0   | 121.7  | 2.30× | 3.2e-3 | 4.3e-3 |
|                | 8192  | 106.1  | 209.2  | 1.97× | 3.1e-3 | 4.3e-3 |
|                | 16384 | 211.9  | 398.4  | 1.88× | 3.3e-3 | 4.3e-3 |
|                | 32768 | 399.1  | 800.8  | 2.01× | 3.0e-3 | 4.3e-3 |
|                | 65536 | 780.3  | 1607.6 | 2.06× | 3.2e-3 | 4.3e-3 |
| 35B-tp2 (H=16) | 1024  | 20.0   | 45.1   | 2.26× | 2.9e-3 | 4.4e-3 |
|                | 8192  | 52.8   | 124.7  | 2.36× | 3.1e-3 | 4.3e-3 |
|                | 65536 | 391.4  | 796.3  | 2.03× | 2.9e-3 | 4.3e-3 |
| FULL-tp1 (H=64)| 1024  | 30.2   | 69.8   | 2.31× | 3.9e-3 | 4.3e-3 |
|                | 8192  | 210.2  | 402.8  | 1.92× | 3.3e-3 | 4.3e-3 |
|                | 65536 | 1565.0 | 3328.6 | 2.13× | 3.1e-3 | 4.3e-3 |

Anchor (35B-tp1 T=8192): **Opus K1 106.1 µs vs Triton k14 209.2 µs (1.97×)**.

Single-kernel profile (gfx950, B1T8192H32): 98.8 µs, VGPR=32, LDS=25.3 KB.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.