### PR TITLE
[TRITON][GFX1250] Fix 3d KV-split issue

### DIFF
--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -159,7 +159,7 @@ def select_3d_config(
             # GFX12 fallback
             waves_per_eu = 1
 
-        if SLIDING_WINDOW is not None:
+        if SLIDING_WINDOW is not None and SLIDING_WINDOW > 0:
             num_segments = 1
         else:
             occ = waves_per_eu * 4 // attn_warps


### PR DESCRIPTION
## Motivation

Existing 3d config selection has the following line:

```
        if SLIDING_WINDOW is not None:
            num_segments = 1
```

However, since SLIDING_WINDOW is never None, this practically disables kv_split logic.
 
 This PR changes that to:
 
```
         if SLIDING_WINDOW is not None and SLIDING_WINDOW > 0:
            num_segments = 1
```