### PR TITLE
fix(test): align mxfp4 reference to RNE on non-gfx950

### DIFF
--- a/op_tests/test_quant_mxfp4.py
+++ b/op_tests/test_quant_mxfp4.py
@@ -145,27 +145,10 @@ def fp32_to_e2m1_rne(val: torch.Tensor) -> torch.Tensor:
     return e2m1.to(torch.uint8)
 
 
-def fp32_to_e2m1_rha(val: torch.Tensor) -> torch.Tensor:
-    """E2M1 quantization with round-half-away (matches non-gfx950 SW fallback)."""
-    a = val.abs()
-    dev = val.device
-    mag = torch.zeros_like(val, dtype=torch.uint8)
-    mag = torch.where(a >= 0.25, torch.tensor(1, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 0.75, torch.tensor(2, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 1.25, torch.tensor(3, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 1.75, torch.tensor(4, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 2.5, torch.tensor(5, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 3.5, torch.tensor(6, dtype=torch.uint8, device=dev), mag)
-    mag = torch.where(a >= 5.0, torch.tensor(7, dtype=torch.uint8, device=dev), mag)
-    sign = torch.where(
-        val < 0,
-        torch.tensor(8, dtype=torch.uint8, device=dev),
-        torch.tensor(0, dtype=torch.uint8, device=dev),
-    )
-    return sign | mag
-
-
-fp32_to_e2m1 = fp32_to_e2m1_rne if get_gfx() == "gfx950" else fp32_to_e2m1_rha
+# Both the gfx950 hardware conversion and the non-gfx950 software fallback
+# (even_round_e2m1 in csrc/kernels/quant_mxfp4.cu) perform round-to-nearest-even,
+# so the reference uses RNE on every arch.
+fp32_to_e2m1 = fp32_to_e2m1_rne
 
 
 def ref_quant_mxfp4(inp: torch.Tensor, round_mode: int = 1, group_size: int = 32):


### PR DESCRIPTION
The non-gfx950 software fallback (even_round_e2m1 in quant_mxfp4.cu) was switched to round-to-nearest-even in #3992, but test_quant_mxfp4.py still used the round-half-away reference (fp32_to_e2m1_rha) on gfx942. This made the byte-level check fail on gfx942 at round_mode=Even (packed mismatch at the 0.25/1.25/2.5/5.0 midpoints), since the kernel rounds ties to even while the reference rounded away from zero.

Both the gfx950 hardware conversion and the non-gfx950 fallback now perform RNE, so use fp32_to_e2m1_rne on every arch and drop the stale RHA reference.

## Motivation

`op_tests/test_quant_mxfp4.py` fails on non-gfx950 GPUs (e.g. gfx942/MI300) at `round_mode=Even` with `packed mismatch (4096,128) mode=Even/EVEN`. This blocks CI on any PR whose runs include a gfx942 shard, unrelated to the PR's own changes.

## Technical Details

The MXFP4 (E2M1) software fallback `even_round_e2m1` in `csrc/kernels/quant_mxfp4.cu` was switched from round-half-away to round-to-nearest-even (RNE) in #3992, so the non-gfx950 path now matches the gfx950 hardware conversion.

However, the test's Python reference was not updated: it still selected the round-half-away helper (`fp32_to_e2m1_rha`) on non-gfx950 (`fp32_to_e2m1 = fp32_to_e2m1_rne if get_gfx() == "gfx950" else fp32_to_e2m1_rha`). At the exact midpoints `0.25 / 1.25 / 2.5 / 5.0` the kernel rounds ties to even (e.g. `2.5 -> 2.0`) while the RHA reference rounds away from zero (`2.5 -> 3.0`), so the byte-level `torch.equal` check fails. gfx950 was unaffected because it already used the RNE reference.

Since both the gfx950 hardware conversion and the non-gfx950 fallback now perform RNE, this PR uses `fp32_to_e2m1_rne` on every arch and removes the stale `fp32_to_e2m1_rha` reference. Test-only change; the kernel (correct per #3992) is untouched.

## Test Plan

Ran `op_tests/test_quant_mxfp4.py` on gfx942 against `origin/main` and with this fix. Also cross-checked `fp32_to_e2m1_rne` against the kernel's `even_round_e2m1` across the E2M1 midpoints plus random/boundary values.

## Test Result

- Reference-vs-kernel cross-check: `ALL MATCH` (midpoints, random, and boundary values).
- gfx942, before fix (`origin/main`): FAIL — `packed mismatch (4096,128) mode=Even/EVEN`, exit 1.
- gfx942, after fix: PASS for all shapes/dtypes at `round_mode=Even`, exit 0.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

