### PR TITLE
[triton] Optimized Unified Attention for Gemma-4-31b

### DIFF
--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -89,7 +89,6 @@ def select_2d_config(
     # base prefill, for short cases
     if not all_decode:
         if head_size >= 512 and not arch.is_rdna:
-            BLOCK_M = max(16, triton.next_power_of_2(num_queries_per_kv))
             num_warps, num_stages_2d = 4, 2
             TILE_SIZE = 16
         elif head_size >= 256 and not arch.is_rdna:
@@ -215,13 +214,11 @@ def select_3d_config(
         MIN_SEGMENTS = min(8, MAX_SEGMENTS)
         if head_size >= 512 and not arch.is_rdna:
             MIN_SEGMENTS = min(16, MAX_SEGMENTS)
-        MIN_SEGMENTS = triton.next_power_of_2(MIN_SEGMENTS)
         if num_segments == 0:
             num_segments = math.ceil(target_num_prgms / num_2d_prgms)
             num_segments = min(num_segments, MAX_SEGMENTS)
-            num_segments = triton.next_power_of_2(num_segments)
-            num_segments = min(num_segments, 128)
             num_segments = max(num_segments, MIN_SEGMENTS)
+            num_segments = triton.next_power_of_2(num_segments)
 
         if num_segments == MIN_SEGMENTS:
             reduce_num_warps = 1

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -149,6 +149,7 @@ def select_3d_config(
     NUM_BLOCKS_GATHER_PER_TILE: int = 1,
     SLIDING_WINDOW: int | None = None,
 ):
+    arch = get_arch()
     # TODO: wait for Triton compiler to support ds_load_tr4 before we can include torch.uint8 kv_cache_dtype
     # assert kv_cache_dtype in (torch.bfloat16, e4m3_dtype, torch.uint8, ), f"kv_cache_dtype only supports BF16 ({torch.bfloat16}), FP8 ({e4m3_dtype}), FP4 ({torch.uint8})"
     assert kv_cache_dtype in (
@@ -201,7 +202,7 @@ def select_3d_config(
         #     attn_warps = max(attn_warps, 1)
         #     attn_warps = min(attn_warps, 4)
     else:
-        if head_size >= 512 and not get_arch().is_rdna:
+        if head_size >= 512 and not arch.is_rdna:
             attn_warps, attn_stages = 4, 1
 
         occ = waves_per_eu * 4 // attn_warps
@@ -211,7 +212,7 @@ def select_3d_config(
 
         MAX_SEGMENTS = min(128, math.ceil(max_seqlen_k / TILE_SIZE))
         MIN_SEGMENTS = min(8, MAX_SEGMENTS)
-        if head_size >= 512 and not get_arch().is_rdna:
+        if head_size >= 512 and not arch.is_rdna:
             MIN_SEGMENTS = min(16, MAX_SEGMENTS)
         if num_segments == 0:
             num_segments = math.ceil(target_num_prgms / num_2d_prgms)

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -214,6 +214,7 @@ def select_3d_config(
         MIN_SEGMENTS = min(8, MAX_SEGMENTS)
         if head_size >= 512 and not arch.is_rdna:
             MIN_SEGMENTS = min(16, MAX_SEGMENTS)
+        MIN_SEGMENTS = triton.next_power_of_2(MIN_SEGMENTS)
         if num_segments == 0:
             num_segments = math.ceil(target_num_prgms / num_2d_prgms)
             num_segments = min(num_segments, MAX_SEGMENTS)

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -90,7 +90,8 @@ def select_2d_config(
     if not all_decode:
         if head_size >= 512 and not arch.is_rdna:
             BLOCK_M = max(16, triton.next_power_of_2(num_queries_per_kv))
-            num_warps, num_stages_2d = 4, 1
+            num_warps, num_stages_2d = 4, 2
+            TILE_SIZE = 16
         elif head_size >= 256 and not arch.is_rdna:
             num_warps, num_stages_2d = 2, 2
             TILE_SIZE = 32
@@ -288,6 +289,9 @@ def use_2d_kernel(
     # if IS_DEVICE_ARCH_GFX12, always use 3D if all_decode and 2D otherwise
     if IS_DEVICE_ARCH_GFX12:
         return (sliding_window > 0) or (not all_decode)
+
+    if head_size >= 512 and not get_arch().is_rdna and not all_decode:
+        return True
 
     return (
         (sliding_window > 0)

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -88,7 +88,20 @@ def select_2d_config(
 
     # base prefill, for short cases
     if not all_decode:
-        num_stages_2d, num_warps = 1, 2
+        if head_size >= 512 and not arch.is_rdna:
+            BLOCK_M = max(16, triton.next_power_of_2(num_queries_per_kv))
+            num_warps, num_stages_2d = 4, 1
+        elif head_size >= 256 and not arch.is_rdna:
+            num_warps, num_stages_2d = 2, 2
+            TILE_SIZE = 32
+        else:
+            # large prefill config
+            if max_seqlen_q >= 256:
+                BLOCK_M = 64 if arch.is_rdna else 128
+                num_stages_2d, num_warps = 1, 4
+            else:
+                num_stages_2d, num_warps = 1, 2
+
     # pure decode config
     else:
         # to not have masking when loading KV
@@ -96,12 +109,10 @@ def select_2d_config(
         if arch.is_rdna:
             num_stages_2d, num_warps = 1, 4
         else:
-            num_stages_2d, num_warps = 3, 2
-
-    # large prefill config
-    if max_seqlen_q >= 256:
-        BLOCK_M = 64 if arch.is_rdna else 128
-        num_stages_2d, num_warps = 1, 4
+            if head_size >= 512:
+                num_stages_2d, num_warps = 1, 4
+            else:
+                num_stages_2d, num_warps = 3, 2
 
     BLOCK_Q = BLOCK_M // num_queries_per_kv
     num_stages_2d = min(max_num_stages_2d, num_stages_2d)
@@ -190,6 +201,9 @@ def select_3d_config(
         #     attn_warps = max(attn_warps, 1)
         #     attn_warps = min(attn_warps, 4)
     else:
+        if head_size >= 512 and not get_arch().is_rdna:
+            attn_warps, attn_stages = 4, 1
+
         occ = waves_per_eu * 4 // attn_warps
         target_num_prgms = target_num_prgms * occ
 
@@ -197,6 +211,8 @@ def select_3d_config(
 
         MAX_SEGMENTS = min(128, math.ceil(max_seqlen_k / TILE_SIZE))
         MIN_SEGMENTS = min(8, MAX_SEGMENTS)
+        if head_size >= 512 and not get_arch().is_rdna:
+            MIN_SEGMENTS = min(16, MAX_SEGMENTS)
         if num_segments == 0:
             num_segments = math.ceil(target_num_prgms / num_2d_prgms)
             num_segments = min(num_segments, MAX_SEGMENTS)

--- a/op_tests/triton_tests/attention/test_unified_attention.py
+++ b/op_tests/triton_tests/attention/test_unified_attention.py
@@ -556,7 +556,7 @@ def test_triton_unified_attn_3d(
     ],
 )
 @pytest.mark.parametrize("num_heads", [(8, 8), (8, 1)])
-@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("head_size", [64, 128, 256, 512])
 @pytest.mark.parametrize("block_size", [16, 64])
 @pytest.mark.parametrize("sliding_window", [None, 256])
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

On AMD CDNA4 (MI355X / gfx950), the vLLM **Triton** unified-attention backend was
significantly faster than AITER's `ROCM_AITER_UNIFIED_ATTN` for [`google/gemma-4-31B-it`](https://huggingface.co/google/gemma-4-31B-it/tree/main),
and AITER's **full-attention decode crashed outright** with `OutOfResources`. Gemma-4
interleaves two large-head attention layers that fall outside the range the AITER configs
were tuned for (`head_dim ≤ 128`):
| Layer | `head_dim` | GQA (q/kv) | `block_size` | Window |
|---|---|---|---|---|
| **full** (global) | 512 | 32 / 4 (`nqpkv=8`) | 64 | global |
| **sliding** | 256 | 32 / 16 (`nqpkv=2`) | 32 | 1024 |

This PR retunes `select_2d_config` / `select_3d_config` for these shapes. Changes are
**config-level only** (`BLOCK_M`, `TILE_SIZE`, `num_warps`, `num_stages`, `MIN_SEGMENTS`) —
no compute-kernel logic is touched, so outputs stay bit-comparable. Result: AITER goes
from 2.3–5.6× slower (and crashing on decode due to reaching LDS limits) to **parity-or-faster than the Triton
reference on every prefill/decode case**, with full-attention decode fixed.

## Technical Details

### `aiter/ops/triton/attention/unified_attention.py`

1. **`select_2d_config` — head-size-aware prefill/mixed config.** Replaces the
   single `num_stages=1, num_warps=2` default with tiered configs:
   - `head_size >= 512`: `TILE_SIZE=16`, `num_stages=2`, `num_warps=4`,
     `BLOCK_M=max(16, next_pow2(nqpkv))`. The narrow 16-wide KV tile fits LDS so
     it can double-buffer (hiding load latency) *and* keeps per-CU LDS/register
     pressure low, raising occupancy so many memory-bound rows run concurrently
     instead of a few stragglers. Turns the 5.3x mixed regression into a win and
     is also faster on pure prefill.
   - `head_size >= 256`: `TILE_SIZE=32`, `num_stages=2`, `num_warps=2` (tunes the
     sliding path).
   - otherwise: unchanged (`BLOCK_M=128, stages=1, warps=4` for
     `max_seqlen_q>=256`, else `stages=1, warps=2`).

2. **`select_2d_config` — decode config for large heads.** For
   `head_size >= 512` pure-decode routed to 2D, use `num_stages=1, num_warps=4`
   instead of the default `3, 2` (deep pipelining over-pressures registers/LDS at
   this head size).

3. **`select_3d_config` — large-head decode tuning.** Adds `arch = get_arch()`;
   for `head_size >= 512` (non-RDNA): `attn_warps=4, attn_stages=1`, and raise
   `MIN_SEGMENTS` to `min(16, MAX_SEGMENTS)` (then round to a power of two). This
   gives the split-KV decode path enough KV parallelism/occupancy for the
   512-wide head.

4. **`use_2d_kernel` — route large-head prefill/mixed to 2D.** Adds an early
   `return True` for `head_size >= 512 and not RDNA and not all_decode`, so
   full-attention prefill/mixed steps always use the (now well-tuned) 2D kernel
   instead of the decode-oriented 3D path. Pure decode still uses the existing
   heuristic (3D by default; 2D for short context or high program counts).

### `op_tests/triton_tests/attention/test_unified_attention.py`

5. **Test coverage.** Extends the 3D-attention parametrization from
   `head_size ∈ {64,128}` to `{64,128,256,512}`, covering the newly-tuned
   large-head paths.

## Test Plan

- `op_tests/triton_tests/attention/test_unified_attention.py`

## Test Result

Added tests for `head_dim` 256 and 512

## Benchmark Result

Validated on model [`google/gemma-4-31B-it`](https://huggingface.co/google/gemma-4-31B-it/tree/main) using vLLM v0.22, table below contains total token throughputs (t/s) 

| Configuration | TRITON_ATTN  | AITER_UNIFIED_ATTN main branch | AITER_UNIFIED_ATTN this branch |
|---|---|---|---|
| tp=1, 1k->1k, conc=8 | 929.61 | `OutOfResources` | 1071.4 |
| tp=1, 1k->1k, conc=16 | 1596.86 | `OutOfResources` | 1750.79 |
| tp=1, 8k->1k, conc=16 | 4358.84 | `OutOfResources` | 5315.78 |
| tp=4, 8k->1k, conc=16 | 9005.72 | `OutOfResources` | 9416.41 |
| tp=4, 8k->1k, conc=32 | 13219.82 | `OutOfResources` | 14201.55 |

This optimization allows user to use AITER's Unified attention kernel for Gemma-4-31b model and increases total token throughput in x1.05-x1.17 times in comparison with using triton unified attention from vLLM.

```
SAFETENSORS_FAST_GPU=1 \
HIP_FORCE_DEV_KERNARG=1 \
TORCH_BLAS_PREFER_HIPBLASLT=1 \
NCCL_MIN_NCHANNELS=112 \
VLLM_ROCM_USE_AITER_RMSNORM=0 \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1 \
vllm serve google/gemma-4-31B-it \
  --dtype bfloat16 \
  --tensor-parallel-size X \
  --max-model-len 32768 \
  --max-num-seqs 2048 \
  --gpu-memory-utilization 0.90 \
  --block-size 32 \
  --enable-auto-tool-choice \
  --tool-call-parser gemma4 \
  --port 1616 \
  --host 0.0.0.0 \
  --no-enable-prefix-caching \
  --attention-backend ROCM_AITER_UNIFIED_ATTN

vllm bench serve \
  --backend openai-chat \
  --model google/gemma-4-31B-it \
  --base-url http://0.0.0.0:1616 \
  --endpoint /v1/chat/completions \
  --dataset-name random \
  --random-input-len X \
  --random-output-len 1024 \
  --num-prompts X * 10 \
  --max-concurrency X
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
