### PR TITLE
CI: move SGLang accuracy jobs to nightly

### DIFF
--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -61,7 +61,8 @@ TESTS = [
         "timeout_minutes": 100,
         "extra_exec_args": "",
         "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-mi35x-qwen35 --nightly --timeout-per-file 3600",
-        "run_on_pr": True,
+        "run_on_pr": False,
+        "comment": "Run in nightly first while failures are investigated.",
         "run_on_schedule": True,
     },
     {
@@ -87,7 +88,8 @@ TESTS = [
         "timeout_minutes": 70,
         "extra_exec_args": "",
         "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v32 --nightly --timeout-per-file 3600",
-        "run_on_pr": True,
+        "run_on_pr": False,
+        "comment": "Run in nightly first while failures are investigated.",
         "run_on_schedule": True,
     },
     {


### PR DESCRIPTION
## Summary
- Restore the SGLang Qwen 3.5 Accuracy and DeepSeek-V3.2 Accuracy runners to the original runner pool.
- Temporarily remove these two accuracy jobs from PR selection and keep them in nightly runs while the failures are investigated.

## Validation
- EVENT_NAME=pull_request python3 .github/scripts/sglang_downstream.py select-tests
- EVENT_NAME=schedule python3 .github/scripts/sglang_downstream.py select-tests
- python3 -m py_compile .github/scripts/sglang_downstream.py