### PR TITLE
[opus] Fix Opus MoE atomic fallback

### DIFF
--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
@@ -631,7 +631,14 @@ inline __device__ void opus_moe_stage2_a8w4_decode_atomic_add_bf16x2(
 {
     const opus_moe_stage2_a8w4_decode_bf16x2_t data =
         __builtin_bit_cast(opus_moe_stage2_a8w4_decode_bf16x2_t, packed_bf16x2);
+#if OPUS_HAS_RAW_PTR_ATOMIC_FADD_V2F16_BUILTIN
     __builtin_amdgcn_raw_ptr_buffer_atomic_fadd_v2f16(data, out_rsrc, byte_offset, 0, 0);
+#else
+    opus::i32x4_t rsrc;
+    __builtin_memcpy(&rsrc, &out_rsrc, sizeof(opus::i32x4_t));
+    opus::llvm_amdgcn_raw_buffer_atomic_fadd_v2f16(
+        __builtin_bit_cast(opus::fp16x2_t, data), rsrc, byte_offset, 0, 0);
+#endif
 }
 
 template<typename T, typename CAcc>


### PR DESCRIPTION
  Description

  ## Motivation

  Opus MoE A8W4 stage2 currently calls `__builtin_amdgcn_raw_ptr_buffer_atomic_fadd_v2f16`
  directly in the direct-atomic path.

  That builtin is only available with newer ROCm/clang toolchains, such as ROCm 7.2 / clang 22.
  On older supported toolchains, for example ROCm 7.0 / clang 20, the build fails with:

  `use of undeclared identifier '__builtin_amdgcn_raw_ptr_buffer_atomic_fadd_v2f16'`

  This PR fixes the Opus MoE build compatibility issue without changing runtime kernel selection,
  tuned configs, or performance behavior on newer toolchains.

  ## Technical Details

  - Update the Opus MoE A8W4 stage2 direct-atomic helper to use the existing Opus compile-time
    capability macro:

    `OPUS_HAS_RAW_PTR_ATOMIC_FADD_V2F16_BUILTIN`

  - Keep the current raw-ptr builtin path for toolchains that support it, such as ROCm 7.2+.
  - Add a fallback path for older toolchains using the LLVM intrinsic wrapper already provided by
    `opus.hpp`:

    `opus::llvm_amdgcn_raw_buffer_atomic_fadd_v2f16`

  - The fallback converts `__amdgpu_buffer_rsrc_t` to the `i32x4` resource form expected by the
    LLVM intrinsic, matching the compatibility pattern already used in Opus common code.

  Scope is intentionally small:

  - One Opus MoE A8W4 stage2 header changed.
  - No tuner changes.
  - No tuned CSV changes.
  - No Python API changes.
  - No production kernel selection changes.

  ## Test Plan

  - Run formatting checks.
  - Run Ruff checks for the Opus MoE Python/codegen files touched by this feature area.
  - Confirm the actual Opus MoE A8W4 stage2 pipeline header compiles after codegen with multi-arch
    targets.
  - Validate both the old-toolchain fallback path and the new-toolchain builtin path.

  Commands / coverage:

  - `python3 -m black --check .`
  - `python3 -m ruff check csrc/opus_moe/gen_instances.py csrc/opus_moe/opus_moe_common.py aiter/ops/opus/
  moe_stage2_a8w4.py aiter/ops/opus/moe_stage2_a8w4_fused_adapter.py aiter/ops/opus/moe_stage2_a8w4_meta.py --no-
  fix`
  - ROCm 7.0 / clang 20:
    - run `csrc/opus_moe/gen_instances.py`
    - compile a TU including `gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh`
    - target `gfx942` and `gfx950`
  - ROCm 7.2 / clang 22:
    - run `csrc/opus_moe/gen_instances.py`
    - compile a TU including `gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh`
    - target `gfx942` and `gfx950`

  ## Test Result

  - `python3 -m black --check .`: passed.
  - Targeted Ruff check for Opus MoE Python/codegen files: passed.
  - Full-repo Ruff still reports pre-existing repository-wide lint findings unrelated to this PR;
    this PR does not modify Python files.
  - ROCm 7.0 / clang 20 multi-arch header compile for `gfx942;gfx950`: passed.
  - ROCm 7.2 / clang 22 multi-arch header compile for `gfx942;gfx950`: passed.

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at
  https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.