### PR TITLE
[Gluon] deepgemm mqa logits optimizations

### DIFF
--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -300,6 +300,7 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
         "stride_out_batch": "i32",
         "max_model_len": "i32",
         "max_block_len": "i32",
+        "num_block": "i32",
     }
     if VarCtxOpt:
         fn_signature["safe_chunks_per_cta_ptr"] = "*i32"
@@ -317,8 +318,9 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
     fn_signature["ARCH"] = "constexpr"
 
     effective_wave_per_eu = 1 if is_gfx1250 and not Preshuffle else WavePerEU
+    effective_num_warps = 1 if is_gfx1250 and Preshuffle else 4
     options = {
-        "num_warps": 4,
+        "num_warps": effective_num_warps,
         "waves_per_eu": effective_wave_per_eu,
         "num_stages": 2,
         "num_ctas": 1,
@@ -461,14 +463,17 @@ def deepgemm_fp8_paged_mqa_logits(
     if TotalCuCount is None:
         TotalCuCount = get_num_sms()
     batch_size, next_n, heads, hidden_dim = q_fp8.size()
-    num_block, block_Size, _, index_dim = kv_cache.size()
+    _, block_Size, _, index_dim = kv_cache.size()
     _, max_block_len = kv_indices.size()
 
-    if get_gfx() == "gfx1250" and not Preshuffle:
-        WavePerEU = 1
+    if get_gfx() == "gfx1250":
+        if Preshuffle and hidden_dim <= 128:
+            WavePerEU = 4
+        else:
+            WavePerEU = 1
 
     TileQCount = batch_size * next_n
-    SplitKV = (max(1, TotalCuCount // TileQCount) + 4) // 5 * 5 * WavePerEU
+    SplitKV = (max(1, TotalCuCount // TileQCount) + 4) // 5 * 5 * WavePerEU * 2
 
     assert ChunkK % KVBlockSize == 0 or KVBlockSize % ChunkK == 0
     assert block_Size == KVBlockSize
@@ -478,6 +483,7 @@ def deepgemm_fp8_paged_mqa_logits(
         ), f"Preshuffle mode only supports KVBlockSize aligned to 16. Got KVBlockSize={KVBlockSize}"
 
     kv_cache = kv_cache.view(-1, KVBlockSize * index_dim)
+    num_block = kv_cache.shape[0]
     kv_cache_fp8, kv_cache_scale = (
         kv_cache[..., : KVBlockSize * hidden_dim],
         kv_cache[..., KVBlockSize * hidden_dim :],
@@ -534,6 +540,7 @@ def deepgemm_fp8_paged_mqa_logits(
                 out_logits.stride(0),
                 max_model_len,
                 max_block_len,
+                num_block,
                 SplitKV if not VarCtxOpt else VarCtxSchedule,
                 # constexpr
                 heads,

--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -72,6 +72,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
     stride_out_batch,
     max_model_len,
     max_block_len,
+    num_block,
     SplitKV,
     ChunkQ: tl.constexpr,
     ChunkK: tl.constexpr,
@@ -360,11 +361,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
     stride_out_batch,
     max_model_len,
     max_block_len,
-    SplitKV,
-    ChunkQ: tl.constexpr,
-    ChunkK: tl.constexpr,
-    HiddenDim: tl.constexpr,
-    KVBlockSize: tl.constexpr = 16,
+    num_block,
+    SplitKV: gl.constexpr,
+    ChunkQ: gl.constexpr,
+    ChunkK: gl.constexpr,
+    HiddenDim: gl.constexpr,
+    KVBlockSize: gl.constexpr = 16,
     CDNA_VERSION: gl.constexpr = 3,
     ARCH: gl.constexpr = "gfx942",
 ):
@@ -372,7 +374,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
     # ===---------------------------------------------------
     # Gluon Layout
     # ===---------------------------------------------------
-    NumWarps: gl.constexpr = 4
+    NumWarps: gl.constexpr = 1
     ThreadsPerWarp: gl.constexpr = 32 if IS_GFX1250 else 64
 
     ValQMPerThread: gl.constexpr = ChunkQ // (
@@ -440,7 +442,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
         )
         kv_shared = gl.allocate_shared_memory(
             KV_buffer.type.element_ty,
-            [NUM_BUFFERS, KVBlockSize, HiddenDim],
+            [NUM_BUFFERS, 1, KVBlockSize * HiddenDim],
+            KV_SHARED,
+        )
+        kv_scale_shared = gl.allocate_shared_memory(
+            scale_buffer.type.element_ty,
+            [NUM_BUFFERS, 1, KVBlockSize * HiddenDim // 128],
             KV_SHARED,
         )
 
@@ -489,38 +496,55 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
         kv_idx_base = kv_indices + pid_batch * max_block_len + cblk_base
 
         # Prologue: kick off the async_load for block 0 into buffer 0.
+        save_blk_idx: gl.int32 = n_blocks - 1
         blk_cur = gl.load(kv_idx_base)
+        blk_next = gl.load(kv_idx_base + gl.minimum(1, save_blk_idx))
         desc_cur = gl.amd.gfx1250.tdm.make_tensor_descriptor(
-            base=KV_buffer + blk_cur * stride_k_seq,
-            shape=(KVBlockSize, HiddenDim),
-            strides=(HiddenDim, 1),
-            block_shape=(KVBlockSize, HiddenDim),
+            base=KV_buffer,
+            shape=(num_block, KVBlockSize * HiddenDim),
+            strides=(stride_k_seq, 1),
+            block_shape=(1, KVBlockSize * HiddenDim),
             layout=KV_SHARED,
         )
-        gl.amd.gfx1250.tdm.async_load(desc_cur, [0, 0], kv_shared.index(0))
+        BLOCKSCALE_SIZE: gl.constexpr = 128
+        assert HiddenDim // BLOCKSCALE_SIZE == 1
+        desc_scale_cur = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+            base=scale_buffer,
+            shape=(num_block, KVBlockSize * HiddenDim // BLOCKSCALE_SIZE),
+            strides=(stride_scale_seq, 1),
+            block_shape=(1, KVBlockSize * HiddenDim // BLOCKSCALE_SIZE),
+            layout=KV_SHARED,
+        )
+        gl.amd.gfx1250.tdm.async_load(desc_cur, [blk_cur, 0], kv_shared.index(0))
+        gl.amd.gfx1250.tdm.async_load(
+            desc_scale_cur, [blk_cur, 0], kv_scale_shared.index(0)
+        )
 
         for j in range(0, n_blocks):
             buf = j % NUM_BUFFERS
             context_idx = split_context_start + j * KVBlockSize
-            blk = blk_cur
+            # blk = blk_cur
+            # k_scale_f = gl.amd.cdna3.buffer_load(
+            #     ptr=scale_buffer,
+            #     offsets=blk * stride_scale_seq + col,
+            # )
 
             # Prefetch block j+1 into the other buffer before waiting on block j.
             if j + 1 < n_blocks:
-                blk_cur = gl.load(kv_idx_base + (j + 1))
-                desc_cur = gl.amd.gfx1250.tdm.make_tensor_descriptor(
-                    base=KV_buffer + blk_cur * stride_k_seq,
-                    shape=(KVBlockSize, HiddenDim),
-                    strides=(HiddenDim, 1),
-                    block_shape=(KVBlockSize, HiddenDim),
-                    layout=KV_SHARED,
+                blk_cur = blk_next
+                blk_next = gl.load(kv_idx_base + gl.minimum(j + 2, save_blk_idx))
+                gl.amd.gfx1250.tdm.async_load(
+                    desc_cur, [blk_cur, 0], kv_shared.index((j + 1) % NUM_BUFFERS)
                 )
                 gl.amd.gfx1250.tdm.async_load(
-                    desc_cur, [0, 0], kv_shared.index((j + 1) % NUM_BUFFERS)
+                    desc_scale_cur,
+                    [blk_cur, 0],
+                    kv_scale_shared.index((j + 1) % NUM_BUFFERS),
                 )
                 # Leave exactly the just-issued load (block j+1) in flight.
-                gl.amd.gfx1250.tdm.async_wait(1)
+                gl.amd.gfx1250.tdm.async_wait(3)
             else:
-                gl.amd.gfx1250.tdm.async_wait(0)
+                gl.amd.gfx1250.tdm.async_wait(1)
 
             K_WIDTH: gl.constexpr = 16
             mfma_k = (
@@ -541,11 +565,17 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
             )
             o = gl.amd.gfx1250.wmma(mfma_q, mfma_k, zero_acc)
 
-            k_scale_f = gl.amd.cdna3.buffer_load(
-                ptr=scale_buffer,
-                offsets=blk * stride_scale_seq + col,
+            if j + 1 < n_blocks:
+                gl.amd.gfx1250.tdm.async_wait(2)
+            else:
+                gl.amd.gfx1250.tdm.async_wait(0)
+
+            k_scale_f = (
+                kv_scale_shared.index(buf)
+                .reshape((1, KVBlockSize))
+                .load(layout=mfma_layout)
             )
-            o = o * k_scale_f[None, :]
+            o = o * k_scale_f
             o = gl.maximum(o, 0.0)
             o = o * scale_weight[:, None]
 
@@ -1341,6 +1371,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
     stride_out_batch,
     max_model_len,
     max_block_len,
+    num_block,
     safe_chunks_per_cta_ptr,
     ChunkQ: tl.constexpr,
     ChunkK: tl.constexpr,


### PR DESCRIPTION
This PR removes in-loop make_tensor_descriptor, use tdm for scale, and tune config

On DSV4 Flash TP1 conc1, gfx1250: 9 us -> 7 us

before 
<img width="1676" height="316" alt="image" src="https://github.com/user-attachments/assets/bd06ce8e-a005-438a-8bad-bcd2d37d6a1f" />

after
<img width="1693" height="315" alt="image" src="https://github.com/user-attachments/assets/2bb14378-c78e-4163-945e-85f90f09a060" />
