### PR TITLE
[BugFix] Fix get_dtype_fp8 to always return the correct fp8 dtype on MI300

### DIFF
--- a/aiter/utility/dtypes.py
+++ b/aiter/utility/dtypes.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 import torch
-from ..jit.utils.chip_info import get_gfx
+from ..jit.utils.chip_info import get_gfx_runtime
 from ..ops.enum import QuantType, ActivationType
 from .aiter_types import aiter_dtypes, aiter_tensor_t
 import argparse

--- a/aiter/utility/dtypes.py
+++ b/aiter/utility/dtypes.py
@@ -18,7 +18,7 @@ _8bit_fallback = torch.uint8
 
 
 def get_dtype_fp8():
-    return defaultDtypes.get(get_gfx(), {"fp8": _8bit_fallback})["fp8"]
+    return defaultDtypes.get(get_gfx_runtime(), {"fp8": _8bit_fallback})["fp8"]
 
 
 i4x2 = getattr(torch, "int4", _8bit_fallback)


### PR DESCRIPTION
## Motivation

This is to make it so `get_dtype_fp8 `always returns the correct fp8 dtype by making sure `get_dtype_fp8 `always gets the correct GPU arch string by using `get_gfx_runtime` instead of `get_gfx`.

## Technical Details
I encountered the following failing unit test when triaging unit test failures for the upcoming The Rock 7.14 release:

```
FAILED tests/compile/fusions_e2e/test_tp1_quant.py::test_tp1_fp8_fusions[inductor_partition-+quant_fp8,+rms_norm-6-TRITON_ATTN-Qwen/Qwen3-30B-A3B-FP8-<lambda>-model_kwargs1-<lambda>-False]
FAILED tests/compile/fusions_e2e/test_tp1_quant.py::test_tp1_fp8_fusions[inductor_partition-+quant_fp8,+rms_norm-6-ROCM_ATTN-Qwen/Qwen3-30B-A3B-FP8-<lambda>-model_kwargs1-<lambda>-False]
FAILED tests/compile/fusions_e2e/test_tp1_quant.py::test_tp1_fp8_fusions[inductor_partition-+quant_fp8,+rms_norm-6-ROCM_AITER_UNIFIED_ATTN-Qwen/Qwen3-30B-A3B-FP8-<lambda>-model_kwargs1-<lambda>-False]

```

These all fail with the following assertion:

`AssertionError: Unsupported dtype: torch.float8_e4m3fnuz`

This failure occurs when `torch_to_aiter `is called on a tensor with the correct fp8 dtype on MI300, `torch.float8_e4m3fnuz`, 

```
(EngineCore pid=350238)   File "/opt/python/lib/python3.12/site-packages/aiter/jit/core.py", line 1319, in caller
(EngineCore pid=350238)     at = torch_to_aiter(value)
(EngineCore pid=350238)          ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=350238)   File "/opt/python/lib/python3.12/site-packages/aiter/utility/dtypes.py", line 78, in torch_to_aiter
(EngineCore pid=350238)     assert tensor.dtype in _torch_to_aiter_dtype, f"Unsupported dtype: {tensor.dtype}"
(EngineCore pid=350238)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=350238) AssertionError: Unsupported dtype: torch.float8_e4m3fnuz
```

but the `torch_to_aiter_dtype` has cached `torch.float8_e4m3fn`, the wrong dtype for fp8 on MI300. 

Changing `get_dtype_fp8 `to use `get_gfx_runtime `instead, avoids this issue, since it always gets the correct GPU arch string.

get_gfx gets returns the wrong GPU argch string when 

GPU_ARCHS="gfx942;gfx950

which is the case in `The Rock 7.14` and this causes `get_dtype_fp8 `to return the wrong fp8 dtype on MI300 in this case.

## Test Plan

 I did this on an MI300 machine:
 
```
# export GPU_ARCHS="gfx942;gfx950
# python
>>> from aiter.utility.dtypes import get_dtype_fp8
[aiter] import [module_aiter_core] under /opt/python/lib/python3.12/site-packages/aiter/jit/module_aiter_core.so
>>> get_dtype_fp8()
torch.float8_e4m3fnuz
```

without this the result will be:
```
>>> get_dtype_fp8()
torch.float8_e4m3fn
```

## Test Result
As demonstrated above, the function now returns the correct fp8 dtype on MI300.
## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.