### PR TITLE
[TRITON] MXFP4 Quantization Gluon implementation for gfx950 and gfx1250

### DIFF
--- a/aiter/ops/triton/gluon/quant_mxfp4.py
+++ b/aiter/ops/triton/gluon/quant_mxfp4.py
@@ -108,7 +108,7 @@ def _mxfp4_quant_op_gluon(
 
 
 @gluon.jit
-def _dynamic_mxfp4_quant_kernel_gluon(
+def _dynamic_mxfp4_quant_kernel_gluon_950(
     x_ptr,
     x_fp4_ptr,
     bs_ptr,
@@ -194,3 +194,162 @@ def _dynamic_mxfp4_quant_kernel_gluon(
                 bs_e8m0,
                 mask=bs_mask,
             )
+
+@gluon.jit
+def _dynamic_mxfp4_quant_kernel_gluon_1250(
+    x_ptr,
+    x_fp4_ptr,
+    bs_ptr,
+    stride_x_m_in,
+    stride_x_n_in,
+    stride_x_fp4_m_in,
+    stride_x_fp4_n_in,
+    stride_bs_m_in,
+    stride_bs_n_in,
+    M,
+    N,
+    BLOCK_SIZE_M: gl.constexpr,
+    BLOCK_SIZE_N: gl.constexpr,
+    NUM_ITER: gl.constexpr,
+    NUM_STAGES: gl.constexpr,
+    num_warps: gl.constexpr,
+    MXFP4_QUANT_BLOCK_SIZE: gl.constexpr,
+    EVEN_M_N: gl.constexpr,
+    SCALING_MODE: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr = 2,
+):
+    gl.static_assert(NUM_BUFFERS >= 2, "LDS kernel requires NUM_BUFFERS >= 2")
+
+    pid_m  = gl.program_id(0)
+    start_n = gl.program_id(1) * NUM_ITER
+
+    stride_x_m    = gl.cast(stride_x_m_in,    gl.int64)
+    stride_x_n    = gl.cast(stride_x_n_in,    gl.int64)
+    stride_x_fp4_m = gl.cast(stride_x_fp4_m_in, gl.int64)
+    stride_x_fp4_n = gl.cast(stride_x_fp4_n_in, gl.int64)
+    stride_bs_m   = gl.cast(stride_bs_m_in,   gl.int64)
+    stride_bs_n   = gl.cast(stride_bs_n_in,   gl.int64)
+
+    NUM_QUANT_BLOCKS: gl.constexpr = BLOCK_SIZE_N // MXFP4_QUANT_BLOCK_SIZE
+
+    # LDS layout: row-major, vec=8 elements = 128-bit stores, padded to avoid bank conflicts
+    SHARED_LAYOUT_X: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[BLOCK_SIZE_N, 8]], [BLOCK_SIZE_M, BLOCK_SIZE_N], [1, 0]
+    )
+
+    # Register layout for LDS reads: order=[1,0] = N fastest, matches row-major LDS
+    blocked_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 4],
+        threads_per_warp=[4, 8],
+        warps_per_cta=[1, num_warps],
+        order=[1, 0],
+    )
+
+    # LDS ring buffer
+    x_buffer = gl.allocate_shared_memory(
+        x_ptr.type.element_ty,
+        shape=[NUM_BUFFERS, BLOCK_SIZE_M, BLOCK_SIZE_N],
+        layout=SHARED_LAYOUT_X,
+    )
+
+    # TDM descriptor: base at this CTA's (M, N) origin
+    x_base = (
+        x_ptr
+        + pid_m * BLOCK_SIZE_M * stride_x_m
+        + start_n * BLOCK_SIZE_N * stride_x_n
+    )
+    x_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+        base=x_base,
+        shape=(M - pid_m * BLOCK_SIZE_M, N - start_n * BLOCK_SIZE_N),
+        strides=(stride_x_m, stride_x_n),
+        block_shape=(BLOCK_SIZE_M, BLOCK_SIZE_N),
+        layout=SHARED_LAYOUT_X,
+    )
+
+    load_idx    = 0
+    compute_idx = 0
+    num_tiles   = min(NUM_ITER, gl.cdiv(N, BLOCK_SIZE_N) - start_n)
+    # ---- Prologue: fill NUM_BUFFERS-1 slots ----
+    for _ in gl.static_range(NUM_BUFFERS - 1):
+        gl.amd.gfx1250.tdm.async_load(
+            x_desc, [0, 0], x_buffer.index(load_idx % NUM_BUFFERS)
+        )
+        x_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
+            x_desc, add_offsets=[0, BLOCK_SIZE_N]
+        )
+        load_idx += 1
+
+    # ---- Main loop: load tile ahead, wait for oldest, quant, store ----
+    for _ in range(num_tiles - (NUM_BUFFERS - 1)):
+        gl.amd.gfx1250.tdm.async_load(
+            x_desc, [0, 0], x_buffer.index(load_idx % NUM_BUFFERS)
+        )
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 1)  # 1 TDM op/tile
+        x_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
+            x_desc, add_offsets=[0, BLOCK_SIZE_N]
+        )
+        load_idx += 1
+
+        x_reg = gl.amd.cdna4.async_copy.load_shared_relaxed(
+            x_buffer.index(compute_idx % NUM_BUFFERS), blocked_layout
+        ).to(gl.float32)
+
+        out_fp4, bs_e8m0 = _mxfp4_quant_op_gluon(
+            x_reg, BLOCK_SIZE_N, BLOCK_SIZE_M, MXFP4_QUANT_BLOCK_SIZE
+        )
+
+        pid_n      = start_n + compute_idx
+        out_offs_m = pid_m * BLOCK_SIZE_M + gl.arange(0, BLOCK_SIZE_M)
+        out_offs_n = pid_n * BLOCK_SIZE_N // 2 + gl.arange(0, BLOCK_SIZE_N // 2)
+        out_offs   = out_offs_m[:, None] * stride_x_fp4_m + out_offs_n[None, :] * stride_x_fp4_n
+        if EVEN_M_N:
+            gl.store(x_fp4_ptr + out_offs, out_fp4)
+        else:
+            gl.store(x_fp4_ptr + out_offs, out_fp4,
+                     mask=(out_offs_m < M)[:, None] & (out_offs_n < (N // 2))[None, :])
+
+        bs_offs_m = pid_m * BLOCK_SIZE_M + gl.arange(0, BLOCK_SIZE_M)
+        bs_offs_n = pid_n * NUM_QUANT_BLOCKS + gl.arange(0, NUM_QUANT_BLOCKS)
+        bs_offs   = bs_offs_m[:, None] * stride_bs_m + bs_offs_n[None, :] * stride_bs_n
+        if EVEN_M_N:
+            gl.store(bs_ptr + bs_offs, bs_e8m0)
+        else:
+            gl.store(bs_ptr + bs_offs, bs_e8m0,
+                     mask=(bs_offs_m < M)[:, None] & (
+                         bs_offs_n < (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
+                     )[None, :])
+        compute_idx += 1
+
+    # ---- Epilogue: drain remaining NUM_BUFFERS-1 tiles ----
+    for i in gl.static_range(NUM_BUFFERS - 1):
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2 - i)
+
+        x_reg = gl.amd.cdna4.async_copy.load_shared_relaxed(
+            x_buffer.index(compute_idx % NUM_BUFFERS), blocked_layout
+        ).to(gl.float32)
+
+        out_fp4, bs_e8m0 = _mxfp4_quant_op_gluon(
+            x_reg, BLOCK_SIZE_N, BLOCK_SIZE_M, MXFP4_QUANT_BLOCK_SIZE
+        )
+
+        pid_n      = start_n + compute_idx
+        out_offs_m = pid_m * BLOCK_SIZE_M + gl.arange(0, BLOCK_SIZE_M)
+        out_offs_n = pid_n * BLOCK_SIZE_N // 2 + gl.arange(0, BLOCK_SIZE_N // 2)
+        out_offs   = out_offs_m[:, None] * stride_x_fp4_m + out_offs_n[None, :] * stride_x_fp4_n
+        if EVEN_M_N:
+            gl.store(x_fp4_ptr + out_offs, out_fp4)
+        else:
+            gl.store(x_fp4_ptr + out_offs, out_fp4,
+                     mask=(out_offs_m < M)[:, None] & (out_offs_n < (N // 2))[None, :])
+
+        bs_offs_m = pid_m * BLOCK_SIZE_M + gl.arange(0, BLOCK_SIZE_M)
+        bs_offs_n = pid_n * NUM_QUANT_BLOCKS + gl.arange(0, NUM_QUANT_BLOCKS)
+        bs_offs   = bs_offs_m[:, None] * stride_bs_m + bs_offs_n[None, :] * stride_bs_n
+        if EVEN_M_N:
+            gl.store(bs_ptr + bs_offs, bs_e8m0)
+        else:
+            gl.store(bs_ptr + bs_offs, bs_e8m0,
+                     mask=(bs_offs_m < M)[:, None] & (
+                         bs_offs_n < (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
+                     )[None, :])
+        compute_idx += 1

--- a/aiter/ops/triton/quant/quant.py
+++ b/aiter/ops/triton/quant/quant.py
@@ -18,7 +18,8 @@ from aiter.ops.triton._triton_kernels.quant.quant import (
     _nvfp4_quant_op,
 )
 from aiter.ops.triton.utils.logger import AiterTritonLogger
-from aiter.ops.triton.gluon.quant_mxfp4 import _dynamic_mxfp4_quant_kernel_gluon
+from aiter.ops.triton.gluon.quant_mxfp4 import _dynamic_mxfp4_quant_kernel_gluon_950
+from aiter.ops.triton.gluon.quant_mxfp4 import _dynamic_mxfp4_quant_kernel_gluon_1250
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.triton.utils.types import e4m3_dtype
 
@@ -160,7 +161,7 @@ def dynamic_mxfp4_quant(
         scaling_mode: The method to calculate MX block scaling.
             - "even" (default): `even_round` in `quark.torch.quantization.utils`.
             - etc.
-        use_gluon: Whether to use Gluon kernel (default: True). Only available on MI350 (gfx950).
+        use_gluon: Whether to use Gluon kernel (default: True). Only available on (gfx950/1250).
                   Falls back to Triton kernel on other GPUs.
     Returns:
         A tuple of (x_fp4, blockscale_e8m0).
@@ -215,7 +216,28 @@ def dynamic_mxfp4_quant(
     even_m_n = (M % BLOCK_SIZE_M == 0) and (N % (BLOCK_SIZE_N * NUM_ITER) == 0)
 
     if use_gluon and (get_gfx() == "gfx950"):
-        _dynamic_mxfp4_quant_kernel_gluon[grid](
+        _dynamic_mxfp4_quant_kernel_gluon_950[grid](
+            x,
+            x_fp4,
+            blockscale_e8m0,
+            *x.stride(),
+            *x_fp4.stride(),
+            *blockscale_e8m0.stride(),
+            M=M,
+            N=N,
+            MXFP4_QUANT_BLOCK_SIZE=MXFP4_QUANT_BLOCK_SIZE,
+            EVEN_M_N=even_m_n,
+            SCALING_MODE=0,
+            NUM_ITER=NUM_ITER,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            NUM_STAGES=NUM_STAGES,
+            num_warps=NUM_WARPS,
+            waves_per_eu=0,
+            num_stages=1,
+        )
+    elif use_gluon and (get_gfx() == "gfx1250"):
+        _dynamic_mxfp4_quant_kernel_gluon_1250[grid](
             x,
             x_fp4,
             blockscale_e8m0,


### PR DESCRIPTION
## Motivation

Using gluon instead of triton for performance improvement

## Technical Details

Gluon kernel, with sizes derived from the TTGIR of Triton kernel.

## Test Plan

Test suite as well as benchmark script for testing accuracy and speed of quant kernel.

## Test Result

Marginal improvement for gfx950 and around 10% improvement with usage of LDS in gfx1250

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
