### PR TITLE
fix(moe): keep fp32 per-token scale layout for 2-stage asm stage1

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -2026,8 +2026,16 @@ def fused_moe_2stages(
         block_m=block_size_M,
         a1_scale=a1_scale,
         w1_scale=(
+            # Only reinterpret genuinely-packed (e8m0 / 1-byte) weight scales as
+            # fp8_e8m0. PR #3811 broadened this guard from fp4-only to all fp8 to
+            # add mxfp8 (per_1x32, e8m0 scale) support, but that also caught
+            # per_Token fp8 whose scale is fp32 -- reinterpreting fp32 bytes as
+            # e8m0 makes the host stride (eGUQs = stride(0)*sizeof(float)) 4x too
+            # large -> asm _pf stage1 reads weight scales OOB -> MEMORY_VIOLATION.
             w1_scale.view(dtypes.fp8_e8m0)
             if w1.dtype in (dtypes.fp4x2, dtypes.fp8)
+            and w1_scale is not None
+            and w1_scale.element_size() == 1
             else w1_scale
         ),
         sorted_weights=sorted_weights if doweight_stage1 else None,
@@ -2128,8 +2136,13 @@ def fused_moe_2stages(
         moe_out,
         topk,
         w2_scale=(
+            # See stage1 w1_scale note: only reinterpret packed (e8m0) scales;
+            # per_Token fp8 uses an fp32 scale and must be passed through as-is
+            # (PR #3811 regression fix).
             w2_scale.view(dtypes.fp8_e8m0)
             if w2.dtype in (dtypes.fp4x2, dtypes.fp8)
+            and w2_scale is not None
+            and w2_scale.element_size() == 1
             else w2_scale
         ),
         a2_scale=a2_scale,

--- a/csrc/py_itfs_cu/asm_moe_2stage.cu
+++ b/csrc/py_itfs_cu/asm_moe_2stage.cu
@@ -217,6 +217,15 @@ AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
     int stride_X = input->stride(0) * input->element_size();
     int stride_GU = dim * w1->element_size();
 
+    // This 2-stage ASM kernel only supports fp32 weight/activation scales
+    // (per_Token / per_1x128 quant). It must NOT receive an fp8_e8m0-viewed
+    // scale: eGUQs below assumes 4-byte fp32 elements, so a 1-byte e8m0 view
+    // inflates the expert stride 4x and reads weight scales out of bounds.
+    AITER_CHECK(!w1_scale || w1_scale->dtype() == AITER_DTYPE_fp32, __func__,
+                " expects fp32 w1_scale, got ", AiterDtype_to_str(w1_scale->dtype()));
+    AITER_CHECK(!a1_scale || a1_scale->dtype() == AITER_DTYPE_fp32, __func__,
+                " expects fp32 a1_scale, got ", AiterDtype_to_str(a1_scale->dtype()));
+
     int stride_expert_GU = stride_GU * inter_dim;
     int stride_expert_GUDQN = w1_scale ? w1_scale->stride(0) * sizeof(float) : 0;
     int stride_expert_SMTDQN = inter_dim * sizeof(float);


### PR DESCRIPTION
PR #3811 broadened the fused_moe fp8_e8m0 scale reinterpret from fp4-only to all fp8 weights, which also caught per_Token fp8 whose weight scale is fp32. Reinterpreting the fp32 scale as fp8_e8m0 rescales the tensor stride, so the asm moe_stage1_g1u1 host computes eGUQs = stride(0) * sizeof(float) 4x too large and reads weight scales out of bounds (MEMORY_VIOLATION on the _pf stage1 kernels).

- fused_moe: only reinterpret genuinely-packed (1-byte e8m0) scales as fp8_e8m0 (element_size() == 1); pass fp32 per-token/per-1x128 scales through unchanged.
- asm_moe_2stage: assert w1_scale/a1_scale are fp32, since this 2-stage kernel (get_cfg) only serves fp32-scale quant (per_Token / per_1x128), so the sizeof(float) expert stride stays valid.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
