### PR TITLE
fix(dist): remove in-function import from traced fused_allreduce_rmsnorm_quant

### DIFF
--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -353,10 +353,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
         transpose_scale: bool = False,
         gemma_norm: bool = False,
     ):
-        # Lazy import to avoid an aiter.dist import cycle.
-        from aiter.dist.communication_op import _normalize_fused_ar_rms_quant_type
-
-        quant_type = _normalize_fused_ar_rms_quant_type(quant_type)
+        # quant_type arrives already canonicalized to a string ("per_token"/
+        # "per_group"/"mxfp4") from the public API; an inline import here would
+        # graph-break Dynamo when this method is traced.
         if gemma_norm and quant_type != "per_token":
             raise NotImplementedError(
                 "gemma_norm fused quant currently supports per-token FP8 only"

--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -354,8 +354,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         gemma_norm: bool = False,
     ):
         # quant_type arrives already canonicalized to a string ("per_token"/
-        # "per_group"/"mxfp4") from the public API; an inline import here would
-        # graph-break Dynamo when this method is traced.
+        # "per_group"/"mxfp4") from the public API.
         if gemma_norm and quant_type != "per_token":
             raise NotImplementedError(
                 "gemma_norm fused quant currently supports per-token FP8 only"

--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -624,11 +624,8 @@ class GroupCoordinator:
         transpose_scale: bool = False,
         gemma_norm: bool = False,
     ):
-        from aiter.dist.device_communicators.communicator_cuda import (
-            _normalize_fused_ar_rms_quant_type,
-        )
-
-        quant_type = _normalize_fused_ar_rms_quant_type(quant_type)
+        # quant_type arrives already canonicalized to a string ("per_token"/
+        # "per_group"/"mxfp4") from the public API and the mxfp4 helper.
         if quant_type == "per_token" and group_size == 128 and not emit_bf16:
             return fused_allreduce_rmsnorm_quant_(
                 input_,


### PR DESCRIPTION

## Motivation

https://github.com/ROCm/aiter/pull/3981 added the inline import at https://github.com/ROCm/aiter/blob/main/aiter/dist/parallel_state.py#L627-L631, which will trigger import error after unify the api in https://github.com/ROCm/aiter/pull/4039.

The inline import is not needed as quant_type has already canonicalized to a string in the unified API.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
