### PR TITLE
bf16 asm mha: enable doubleq and kv reverse to improve perf

### DIFF
--- a/csrc/py_itfs_cu/asm_fmha_fwd_with_sink_varlen.cu
+++ b/csrc/py_itfs_cu/asm_fmha_fwd_with_sink_varlen.cu
@@ -217,7 +217,7 @@ AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
     // s_opt: bit0 reverse_kv | bit1 double_q | bit2 remap_xy.
     // 6 = 0b110 -> reverse_kv=0, double_q=1, remap_xy=1.  Must match how the
     // shipped VARLEN .co was built.
-    args.opt        = 4;
+    args.opt        = 7;
     args.lse        = return_lse ? 1 : 0;
     args.max_q_len  = max_seqlen_q;
     args.sink_addr  = sink ? sink->data_ptr() : nullptr;


### PR DESCRIPTION
## Motivation

[gfx1250] fmha fwd bf16 hdim128/64 support per tensor bf16 for gfx1250: enable doubleq and kv reverse to improve perf

## Technical Details

change a runtime arg in csrc/py_itfs_cu/asm_fmha_fwd_with_sink_varlen.cu

## Test Plan

python3 op_tests/test_fmha_fwd_with_sink_varlen_asm.py

## Test Result

Function test:
pytest op_tests/test_fmha_fwd_with_sink_varlen_asm.py::test_fmha_fwd_with_sink_varlen_asm_correctness -v -s
test pass

Perf test:
pytest op_tests/test_fmha_fwd_with_sink_varlen_asm.py::test_fmha_fwd_with_sink_varlen_asm_perf -v -s
perf would be improved by ~2% with doubleq and kv reverse

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
