### PR TITLE
[opus] backport #4056: gate TDM/named-barrier on clang>=22 for ROCm 7.0/7.1 (release/v0.1.17)

### DIFF
--- a/csrc/include/opus/opus.hpp
+++ b/csrc/include/opus/opus.hpp
@@ -1627,8 +1627,8 @@ OPUS_D unsigned int lane_id() {
     else return __builtin_amdgcn_mbcnt_hi(-1, __builtin_amdgcn_mbcnt_lo(-1, 0));
 }
 
-//gfx1250 only feature
-#if defined(__gfx1250__) || !defined(__HIP_DEVICE_COMPILE__)
+//gfx1250 only feature. Named-barrier / cluster-sync builtins + __amdgpu_named_workgroup_barrier_t only exist on clang>=22 (ROCm>=7.2); gate the host pass too so clang-20 (ROCm 7.1) CI does not parse them.
+#if (defined(__gfx1250__) || !defined(__HIP_DEVICE_COMPILE__)) && (__clang_major__ >= 22)
 OPUS_D u32_t waveid_in_workgroup() { u32_t wave_id; asm volatile("s_bfe_u32 %0, ttmp8, 0x50019" : "=s"(wave_id)); return wave_id; }
 
 //Named Barrier define
@@ -2328,7 +2328,8 @@ template<typename T_> OPUS_D decltype(auto) make_smem(T_* ptr) { return smem<T_>
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 // tdm (gfx1250): tdm_desc = stateless D# (sg0..sg3 raw dwords); tdm_window = stateful tile window with make() + move(d0..d4, lds) + load_to_lds<cpol>(); cpol[6:0] = | rsvd | NV | scope[2] | th[3] |.
-#if defined(__gfx1250__) || !defined(__HIP_DEVICE_COMPILE__)
+// __builtin_amdgcn_tensor_load_to_lds only exists on clang>=22 (ROCm>=7.2); gate the host pass too so clang-20 (ROCm 7.1) CI does not parse it.
+#if (defined(__gfx1250__) || !defined(__HIP_DEVICE_COMPILE__)) && (__clang_major__ >= 22)
 
 enum class tdm_load_th : u8_t { rt=0, nt=1, ht=2, bypass=3, nt_rt=4, rt_nt=5, nt_ht=6 };           // bypass = LU (last-use)
 enum class tdm_scope   : u8_t { cu=0, se=1, dev=2, sys=3 };

--- a/csrc/opus_gemm/include/gfx1250/opus_gemm_traits_a16w16_gfx1250.cuh
+++ b/csrc/opus_gemm/include/gfx1250/opus_gemm_traits_a16w16_gfx1250.cuh
@@ -261,9 +261,10 @@ struct opus_cluster_tdm_splitk_ws_traits_gfx1250 {
     static constexpr int kSchedWmmaMask = 0x008;                 // WMMA group
     static constexpr int kSchedWmmaCount = kExpM * kExpN * kExpKHalf;
 
-#if defined(__gfx1250__) || !defined(__HIP_DEVICE_COMPILE__)
-    // tdm_window types live only where tdm_window is available (gfx1250
-    // device pass + host pass). Non-gfx1250 device passes never reference them.
+#if (defined(__gfx1250__) || !defined(__HIP_DEVICE_COMPILE__)) && (__clang_major__ >= 22)
+    // tdm_window types live only where tdm_window is available (gfx1250 device
+    // pass + host pass, clang>=22). Non-gfx1250 device passes and clang-20
+    // (ROCm 7.1) CI never reference them -- opus::tdm_window is gated identically.
     using WindowA = opus::tdm_window<DataA, kTdmK, kARows, 0, 0, 0,
                                        1, 0, 0, 0, 1, 0, 0, 0, 0,
                                        kLdsPadEn, kPadInterval, kPadAmount, opus::seq<>>;


### PR DESCRIPTION
Backport of #4056 into `release/v0.1.17` to fix #4077.

`release/v0.1.17` HEAD (`68b5f7be`) fails to build on ROCm 7.0/7.1 (clang-20) for `gfx942;gfx950` because the gfx1250-only TDM section (`tdm_desc`/`tdm_window`/`__builtin_amdgcn_tensor_load_to_lds`) and the named-barrier / cluster-sync block (`__amdgpu_named_workgroup_barrier_t`, `s_barrier_init`) in `opus.hpp` had their host-pass branch (`!defined(__HIP_DEVICE_COMPILE__)`) compiled unconditionally. Those builtins only exist on clang>=22 (ROCm>=7.2), so any `.cu` pulling in `opus.hpp` (e.g. `module_activation`) failed with `use of undeclared identifier '__builtin_amdgcn_tensor_load_to_lds'`.

This cherry-picks the fix already merged to `main` (#4056), adding `&& (__clang_major__ >= 22)` to both guards in `opus.hpp` and the matching `WindowA/WindowB` aliases in `opus_gemm_traits_a16w16_gfx1250.cuh`, so the whole block compiles out on clang-20 while remaining active on ROCm 7.2.

Cherry-pick applied cleanly (no conflicts). Verified guard counts after cherry-pick: `opus.hpp` = 2, traits header = 1 (matching `main`).

Fixes #4077.
