### PR TITLE
process group timeout from 600s to 1200s

### DIFF
--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -27,6 +27,7 @@ import weakref
 from collections import namedtuple
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
+from datetime import timedelta
 from multiprocessing import shared_memory
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from unittest.mock import patch
@@ -1620,6 +1621,7 @@ def init_distributed_environment(
             init_method=distributed_init_method,
             world_size=world_size,
             rank=rank,
+            timeout=timedelta(seconds=1200),
         )
     # set the local rank
     # local_rank is not available in torch ProcessGroup,


### PR DESCRIPTION
## Motivation
This can reslove an issue that ATOM's  Kimi model load may randomly failed due to the slow ssds, and the broadcast ended timeouts.

https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28670767395/job/85033302286#step:4:419

```python
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/app/ATOM/atom/model_engine/async_proc.py", line 130, in __init__
    self.runners = [runner_class(rank, *args, **kwargs)]
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/ATOM/atom/model_engine/model_runner.py", line 736, in __init__
    self.warmup_model()
  File "/app/ATOM/atom/model_engine/model_runner.py", line 1169, in warmup_model
    self.forward(dummy_batch)
  File "/opt/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/ATOM/atom/model_engine/model_runner.py", line 2193, in forward
    fwd_output = self.postprocess(
                 ^^^^^^^^^^^^^^^^^
  File "/app/ATOM/atom/model_engine/model_runner.py", line 2112, in postprocess
    sampled_tokens = get_tp_group().broadcast(sampled_tokens, src=0)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/aiter-test/aiter/dist/parallel_state.py", line 1018, in broadcast
    torch.distributed.broadcast(
  File "/opt/venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 83, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 2907, in broadcast
    work = group.broadcast([tensor], opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.distributed.DistBackendError: [2] is setting up NCCL communicator and retrieving ncclUniqueId from [0] via c10d key-value store by key '0', but store->get('0') got error: wait timeout after 600000ms, keys: /default_pg/0//3//cuda//0
```

## Technical Details

Change the timeout from 600s to 1200s. 
Should not effect any correctness.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
