### PR TITLE
perf: eliminate end_sync in custom allreduce by delaying input tensor release until next sync

### DIFF
--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -25,6 +25,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
     _ar_quant_no_prefill_max_bytes = int(
         os.environ.get("AITER_AR_QUANT_NO_PREFILL_MAX_BYTES", -1)
     )
+    _custom_ar_hold_inputs = (
+        os.environ.get("AITER_CUSTOM_AR_HOLD_INPUTS", "0") == "1"
+    )
 
     def __init__(
         self,
@@ -82,6 +85,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             self.ca_comm = CustomAllreduce(
                 group=self.cpu_group,
                 device=self.device,
+                hold_inputs=self._custom_ar_hold_inputs,
                 # symm_mem_enabled=(
                 #     self.symm_mem_comm is not None and not self.symm_mem_comm.disabled
                 # ),

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -351,6 +351,7 @@ class CustomAllreduce:
         device: Union[int, str, torch.device],
         max_size=1024 * 1024 * 1024,  # 2GB bf16/half
         enable_register_for_capturing: bool = True,
+        hold_inputs: bool = False,
     ) -> None:
         """
         Args:
@@ -364,6 +365,8 @@ class CustomAllreduce:
         """
         self._IS_CAPTURING = False
         self.disabled = True
+        self.hold_inputs = hold_inputs
+        self._inputs: List[torch.Tensor] = []
 
         if not custom_ar:
             # disable because of missing custom allreduce library
@@ -486,6 +489,24 @@ class CustomAllreduce:
             [h.data_ptr() for h in handles],
             offsets,
         )
+
+    def _record_collective_inputs(self, *inputs: torch.Tensor) -> None:
+        """Keep current inputs alive until the next collective is enqueued.
+
+        When final device-side end_sync is disabled, peer ranks may still
+        read a registered input after Python has returned from the launch. The
+        next custom collective's internal start_sync proves all ranks have
+        advanced past the prior collective, so replacing this list after that
+        next launch safely releases the previous inputs.
+        """
+        if not self.hold_inputs:
+            return
+        self._inputs = [
+            inp for inp in inputs if isinstance(inp, torch.Tensor)
+        ]
+
+    def flush_recorded_inputs(self) -> None:
+        self._inputs.clear()
 
     @contextmanager
     def capture(self):
@@ -706,7 +727,9 @@ class CustomAllreduce:
             split_dim,
             reg,
             reg_bytes,
+            end_sync=not self.hold_inputs,
         )
+        self._record_collective_inputs(inp)
 
     def custom_reduce_scatter(
         self, input: torch.Tensor, output: torch.Tensor, dim: int = 0
@@ -754,7 +777,9 @@ class CustomAllreduce:
             inp,
             out,
             dim,
+            end_sync=not self.hold_inputs,
         )
+        self._record_collective_inputs(inp)
         return out
 
     def all_gather_unreg(
@@ -851,6 +876,7 @@ class CustomAllreduce:
                     reg_bytes,
                     use_1stage,
                     gemma_norm,
+                    end_sync=not self.hold_inputs,
                 )
             else:
                 ops.fused_allreduce_rmsnorm_pad(
@@ -865,7 +891,9 @@ class CustomAllreduce:
                     reg_bytes,
                     use_1stage,
                     gemma_norm,
+                    end_sync=not self.hold_inputs,
                 )
+            self._record_collective_inputs(inp)
             return out, res_out
         else:
             if out is None:
@@ -888,7 +916,9 @@ class CustomAllreduce:
                 reg_bytes,
                 use_1stage,
                 gemma_norm,
+                end_sync=not self.hold_inputs,
             )
+            self._record_collective_inputs(inp)
             return out, res_out, scale_out
 
     def custom_fused_ar_rms(
@@ -1108,7 +1138,9 @@ class CustomAllreduce:
             use_1stage,
             bf16_ptr,
             transpose_scale,
+            end_sync=not self.hold_inputs,
         )
+        self._record_collective_inputs(inp)
         if emit_bf16:
             return out, res_out, scale_out, bf16_out
         return out, res_out, scale_out
@@ -1361,7 +1393,9 @@ class CustomAllreduce:
             reg_bytes,
             use_1stage,
             bf16_ptr,
+            end_sync=not self.hold_inputs,
         )
+        self._record_collective_inputs(inp)
         if emit_bf16:
             return out, res_out, scale_out, bf16_out
         return out, res_out, scale_out
@@ -1479,6 +1513,7 @@ class CustomAllreduce:
         )
 
     def close(self):
+        self.flush_recorded_inputs()
         if not self.disabled and getattr(self, "_ptr", 0):
             ops.dispose(self._ptr)
             self._ptr = 0

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -46,6 +46,7 @@ def reduce_scatter(
     split_dim: int,
     reg_ptr: int,
     reg_bytes: int,
+    end_sync: bool = True,
 ) -> None: ...
 
 
@@ -55,6 +56,7 @@ def all_gather_reg(
     inp: torch.Tensor,
     out: torch.Tensor,
     dim: int,
+    end_sync: bool = True,
 ) -> None: ...
 
 
@@ -66,6 +68,7 @@ def all_gather_unreg(
     out: torch.Tensor,
     reg_bytes: int,
     dim: int,
+    end_sync: bool = True,
 ) -> None: ...
 
 
@@ -82,6 +85,7 @@ def fused_allreduce_rmsnorm(
     reg_bytes: int,
     use_1stage: bool,
     gemma_norm: bool = False,
+    end_sync: bool = True,
 ) -> None: ...
 
 
@@ -98,6 +102,7 @@ def fused_allreduce_rmsnorm_pad(
     reg_bytes: int,
     use_1stage: bool,
     gemma_norm: bool = False,
+    end_sync: bool = True,
 ) -> None: ...
 
 
@@ -115,6 +120,7 @@ def fused_allreduce_rmsnorm_quant(
     reg_bytes: int,
     use_1stage: bool,
     gemma_norm: bool = False,
+    end_sync: bool = True,
 ) -> None: ...
 
 
@@ -134,6 +140,7 @@ def fused_allreduce_rmsnorm_quant_per_group(
     use_1stage: bool,
     bf16_out_ptr: int = 0,
     transpose_scale: bool = False,
+    end_sync: bool = True,
 ) -> None: ...
 
 
@@ -151,6 +158,7 @@ def fused_allreduce_rmsnorm_mxfp4_quant(
     reg_bytes: int,
     use_1stage: bool,
     bf16_out_ptr: int = 0,
+    end_sync: bool = True,
 ) -> None: ...
 
 

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -688,7 +688,8 @@ __global__ void __launch_bounds__(512, 1)
  * */
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(512, 1) allgather_naive(
-    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size)
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size,
+    bool do_end_sync)
 {
     constexpr int tnum_gpu = THREAD_NUM / ngpus;
     int warp_id            = threadIdx.x / tnum_gpu;
@@ -709,12 +710,14 @@ __global__ void __launch_bounds__(512, 1) allgather_naive(
         int write_idx     = warp_id * size + idx;
         result[write_idx] = ptrs[warp_id][idx];
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    if(do_end_sync)
+        end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(512, 1) allgather_vec(
-    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size)
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size,
+    bool do_end_sync)
 {
     constexpr int tnum_gpu  = THREAD_NUM / ngpus;
     constexpr int pack_size = 16 / sizeof(T);
@@ -737,7 +740,8 @@ __global__ void __launch_bounds__(512, 1) allgather_vec(
         int write_idx                                   = warp_id * size + idx;
         *(reinterpret_cast<P*>(&result[0]) + write_idx) = ptrs[warp_id][idx];
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    if(do_end_sync)
+        end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, int ngpus>
@@ -747,7 +751,8 @@ __global__ void __launch_bounds__(512, 1) allgather_lastdim(RankData* _dp,
                                                             T* __restrict__ result,
                                                             int rank,
                                                             int size,
-                                                            int last_dim_size)
+                                                            int last_dim_size,
+                                                            bool do_end_sync)
 {
     constexpr int tnum_gpu  = THREAD_NUM / ngpus;
     constexpr int pack_size = 16 / sizeof(T);
@@ -774,7 +779,8 @@ __global__ void __launch_bounds__(512, 1) allgather_lastdim(RankData* _dp,
         int write_idx                                   = (ngpus * y + warp_id) * last_dim_size + x;
         *(reinterpret_cast<P*>(&result[0]) + write_idx) = ptrs[warp_id][idx];
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    if(do_end_sync)
+        end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // ========== reduce_scatter kernel start ==========
@@ -793,7 +799,8 @@ __global__ void __launch_bounds__(512, 1) allgather_lastdim(RankData* _dp,
 // cond: total_elems % (ngpus * pack_size) == 0
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(512, 1) reduce_scatter_split_first_dim(
-    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int range)
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int range,
+    bool do_end_sync)
 {
     int tid                 = blockIdx.x * blockDim.x + threadIdx.x;
     int stride              = blockDim.x * gridDim.x;
@@ -816,7 +823,8 @@ __global__ void __launch_bounds__(512, 1) reduce_scatter_split_first_dim(
         *(reinterpret_cast<P*>(result) + store_index) =
             packed_reduce<P, ngpus, A>(ptrs, load_index);
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    if(do_end_sync)
+        end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on last dim — naive (non-vectorized) fallback.
@@ -827,7 +835,8 @@ __global__ void __launch_bounds__(512, 1) reduce_scatter_split_first_dim(
 // shape: input (m, n) -> output (m, n / ngpus)
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim_naive(
-    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n,
+    bool do_end_sync
 )
 {
   int size = m * n / ngpus;
@@ -854,7 +863,8 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim_naive(
     }
     result[i] = downcast_s<T>(rslt_reg);
   }
-  end_sync<ngpus, true>(sg, self_sg, rank);
+  if(do_end_sync)
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on last dim — vectorized (16B / thread).
@@ -863,7 +873,8 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim_naive(
 // shape: input (m, n) -> output (m, n / ngpus)
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim(
-    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n,
+    bool do_end_sync
 )
 {
   constexpr int pack_size = 16 / sizeof(T);
@@ -888,7 +899,8 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim(
     int load_index = index_y * packed_dim_n + rank * splited_n + index_x;
     *(reinterpret_cast<P*>(result) + i) = packed_reduce<P, ngpus, A>(ptrs, load_index);
   }
-  end_sync<ngpus, true>(sg, self_sg, rank);
+  if(do_end_sync)
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on middle dim — naive (non-vectorized) fallback.
@@ -898,7 +910,8 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim(
 // shape: input (m, n, k) -> output (m, n / ngpus, k)
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) reduce_scatter_split_middim_naive(
-    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n, int k
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n, int k,
+    bool do_end_sync
 )
 {
   int size = m * n * k / ngpus;
@@ -926,7 +939,8 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_middim_naive(
     }
     result[i] = downcast_s<T>(rslt_reg);
   }
-  end_sync<ngpus, true>(sg, self_sg, rank);
+  if(do_end_sync)
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on middle dim — vectorized (16B / thread along k).
@@ -935,7 +949,8 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_middim_naive(
 // shape: input (m, n, k) -> output (m, n / ngpus, k)
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) reduce_scatter_split_middim(
-    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n, int k
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int m, int n, int k,
+    bool do_end_sync
 )
 {
   constexpr int pack_size = 16 / sizeof(T);
@@ -961,7 +976,8 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_middim(
     int load_index = index_m * (n * packed_dim_k) + (rank * splited_n + index_n) * packed_dim_k + index_k;
     *(reinterpret_cast<P*>(result) + i) = packed_reduce<P, ngpus, A>(ptrs, load_index);
   }
-  end_sync<ngpus, true>(sg, self_sg, rank);
+  if(do_end_sync)
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 // ========== reduce_scatter kernel end ==========
 
@@ -1942,7 +1958,8 @@ __global__ void __launch_bounds__(1024, 1)
                                    int input_hidden_dim,
                                    int hidden_dim,
                                    int out_hidden_dim,
-                                   float eps)
+                                   float eps,
+                                   bool do_end_sync)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -2037,7 +2054,8 @@ __global__ void __launch_bounds__(1024, 1)
             *reinterpret_cast<OP*>(output + out_idx) = zero_pack;
         }
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    if(do_end_sync)
+        end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // Per-group quant variant of the 1-stage fused allreduce+rmsnorm kernel.
@@ -2057,7 +2075,8 @@ __global__ void __launch_bounds__(1024, 1)
                                              int hidden_dim,
                                              int group_size,
                                              float eps,
-                                             T* __restrict__ bf16_output)
+                                             T* __restrict__ bf16_output,
+                                             bool do_end_sync)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -2121,7 +2140,8 @@ __global__ void __launch_bounds__(1024, 1)
             acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size,
             group_size, output, scale_out, active, bf16_output, token_num);
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    if(do_end_sync)
+        end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, typename OutT, int NGPUS>
@@ -2130,7 +2150,7 @@ void allreduce_fusion_kernel_1stage_per_group_launcher(
     T* residual_inp, T* residual_out, OutT* output, T* weight,
     float* scale_out, int size, int hidden_dim, int group_size,
     float eps, hipStream_t stream, T* bf16_output = nullptr,
-    bool transpose_scale = false)
+    bool transpose_scale = false, bool end_sync = true)
 {
     auto pack_size  = 16 / sizeof(T);
     int block_size  = hidden_dim / pack_size;
@@ -2149,7 +2169,7 @@ void allreduce_fusion_kernel_1stage_per_group_launcher(
                                          residual_inp, residual_out,
                                          output, weight, scale_out,
                                          size, hidden_dim, group_size, eps,
-                                         bf16_output);
+                                         bf16_output, end_sync);
     };
     if(transpose_scale)
         launch(std::true_type{});
@@ -2171,7 +2191,8 @@ __global__ void __launch_bounds__(1024, 1)
                                          int size,
                                          int hidden_dim,
                                          float eps,
-                                         T* __restrict__ bf16_output)
+                                         T* __restrict__ bf16_output,
+                                         bool do_end_sync)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -2231,7 +2252,8 @@ __global__ void __launch_bounds__(1024, 1)
             acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size,
             output, scale_out, active, bf16_output);
     }
-    end_sync<ngpus, true>(sg, self_sg, rank);
+    if(do_end_sync)
+        end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, int NGPUS>
@@ -2239,7 +2261,7 @@ void allreduce_fusion_kernel_1stage_mxfp4_launcher(
     RankData* _dp, RankSignals sg, Signal* self_sg, int rank,
     T* residual_inp, T* residual_out, uint8_t* output, T* weight,
     uint8_t* scale_out, int size, int hidden_dim, float eps,
-    hipStream_t stream, T* bf16_output = nullptr)
+    hipStream_t stream, T* bf16_output = nullptr, bool end_sync = true)
 {
     auto pack_size  = 16 / sizeof(T);
     int block_size  = hidden_dim / pack_size;
@@ -2252,7 +2274,7 @@ void allreduce_fusion_kernel_1stage_mxfp4_launcher(
                                      residual_inp, residual_out,
                                      output, weight, scale_out,
                                      size, hidden_dim, eps,
-                                     bf16_output);
+                                     bf16_output, end_sync);
 }
 
 // 2-stage variant of the MXFP4 fused AR+RMSNorm+quant kernel.
@@ -2411,7 +2433,8 @@ void allreduce_fusion_kernel_1stage_launcher(RankData* _dp,
                                              int hidden_dim,
                                              int out_hidden_dim,
                                              float eps,
-                                             hipStream_t stream)
+                                             hipStream_t stream,
+                                             bool end_sync = true)
 {
     constexpr int PACK_SIZE  = 16 / sizeof(T);
     constexpr int WARP_SIZE  = 32;
@@ -2436,7 +2459,8 @@ void allreduce_fusion_kernel_1stage_launcher(RankData* _dp,
                                                     input_hidden_dim,
                                                     hidden_dim,
                                                     out_hidden_dim,
-                                                    eps);
+                                                    eps,
+                                                    end_sync);
 }
 
 template <typename T, int PACK_SIZE>
@@ -3886,7 +3910,8 @@ class CustomAllreduce
 template <typename T>
 void dispatchReduceScatter(hipStream_t stream, T* input, T* output,
                            int m, int n, int k,
-                           ReduceScatterSplitDim split_dim)
+                           ReduceScatterSplitDim split_dim,
+                           bool end_sync = true)
 {
     RankData* ptrs          = get_buffer_RD(stream, input);
     constexpr int pack_size = 16 / sizeof(T);
@@ -3903,15 +3928,15 @@ void dispatchReduceScatter(hipStream_t stream, T* input, T* output,
         {
         case 8:
             reduce_scatter_split_first_dim<T, 8>
-                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range);
+                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range, end_sync);
             break;
         case 4:
             reduce_scatter_split_first_dim<T, 4>
-                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range);
+                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range, end_sync);
             break;
         case 2:
             reduce_scatter_split_first_dim<T, 2>
-                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range);
+                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range, end_sync);
             break;
         default: printf("reduce_scatter world_size error!\n");
         }
@@ -3925,23 +3950,34 @@ void dispatchReduceScatter(hipStream_t stream, T* input, T* output,
                         : (n * k) / world_size_;
         dim3 block(256);
         dim3 grid(std::min(kGridCap, (size + 255) / 256));
-#define LAUNCH_LAST(NG)                                                                       \
-    do {                                                                                      \
-        if(vec)                                                                               \
-            reduce_scatter_split_lastdim<T, NG>                                               \
-                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k);       \
-        else                                                                                  \
-            reduce_scatter_split_lastdim_naive<T, NG>                                         \
-                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k);       \
-    } while(0)
         switch(world_size_)
         {
-        case 8: LAUNCH_LAST(8); break;
-        case 4: LAUNCH_LAST(4); break;
-        case 2: LAUNCH_LAST(2); break;
+        case 8:
+            if(vec)
+                reduce_scatter_split_lastdim<T, 8>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k, end_sync);
+            else
+                reduce_scatter_split_lastdim_naive<T, 8>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k, end_sync);
+            break;
+        case 4:
+            if(vec)
+                reduce_scatter_split_lastdim<T, 4>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k, end_sync);
+            else
+                reduce_scatter_split_lastdim_naive<T, 4>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k, end_sync);
+            break;
+        case 2:
+            if(vec)
+                reduce_scatter_split_lastdim<T, 2>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k, end_sync);
+            else
+                reduce_scatter_split_lastdim_naive<T, 2>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, n, k, end_sync);
+            break;
         default: printf("reduce_scatter world_size error!\n");
         }
-#undef LAUNCH_LAST
         break;
     }
     case ReduceScatterSplitDim::kMid: {
@@ -3951,23 +3987,34 @@ void dispatchReduceScatter(hipStream_t stream, T* input, T* output,
                         : (m * n * k) / world_size_;
         dim3 block(256);
         dim3 grid(std::min(kGridCap, (size + 255) / 256));
-#define LAUNCH_MID(NG)                                                                        \
-    do {                                                                                      \
-        if(vec)                                                                               \
-            reduce_scatter_split_middim<T, NG>                                                \
-                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k);    \
-        else                                                                                  \
-            reduce_scatter_split_middim_naive<T, NG>                                          \
-                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k);    \
-    } while(0)
         switch(world_size_)
         {
-        case 8: LAUNCH_MID(8); break;
-        case 4: LAUNCH_MID(4); break;
-        case 2: LAUNCH_MID(2); break;
+        case 8:
+            if(vec)
+                reduce_scatter_split_middim<T, 8>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k, end_sync);
+            else
+                reduce_scatter_split_middim_naive<T, 8>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k, end_sync);
+            break;
+        case 4:
+            if(vec)
+                reduce_scatter_split_middim<T, 4>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k, end_sync);
+            else
+                reduce_scatter_split_middim_naive<T, 4>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k, end_sync);
+            break;
+        case 2:
+            if(vec)
+                reduce_scatter_split_middim<T, 2>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k, end_sync);
+            else
+                reduce_scatter_split_middim_naive<T, 2>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, m, n, k, end_sync);
+            break;
         default: printf("reduce_scatter world_size error!\n");
         }
-#undef LAUNCH_MID
         break;
     }
     default: printf("reduce_scatter split_dim error!\n");
@@ -3976,7 +4023,8 @@ void dispatchReduceScatter(hipStream_t stream, T* input, T* output,
 
 template <typename T>
 void dispatchAllGather(
-    hipStream_t stream, T* input, T* output, int size, int last_dim_size, int gather_dim)
+    hipStream_t stream, T* input, T* output, int size, int last_dim_size, int gather_dim,
+    bool end_sync = true)
 {
     RankData* ptrs = get_buffer_RD(stream, input);
     auto d         = 16 / sizeof(T);
@@ -3993,15 +4041,15 @@ void dispatchAllGather(
             {
             case 8:
                 allgather_naive<T, 8>
-                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size, end_sync);
                 break;
             case 4:
                 allgather_naive<T, 4>
-                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size, end_sync);
                 break;
             case 2:
                 allgather_naive<T, 2>
-                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size, end_sync);
                 break;
             default: printf("allgather world_size error\n");
             }
@@ -4016,15 +4064,15 @@ void dispatchAllGather(
             {
             case 8:
                 allgather_vec<T, 8>
-                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size, end_sync);
                 break;
             case 4:
                 allgather_vec<T, 4>
-                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size, end_sync);
                 break;
             case 2:
                 allgather_vec<T, 2>
-                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size, end_sync);
                 break;
             default: printf("allgather world_size error\n");
             }
@@ -4040,15 +4088,15 @@ void dispatchAllGather(
         {
         case 8:
             allgather_lastdim<T, 8><<<grid, block, 0, stream>>>(
-                ptrs, sg_, self_sg_, output, rank_, size, last_dim_size);
+                ptrs, sg_, self_sg_, output, rank_, size, last_dim_size, end_sync);
             break;
         case 4:
             allgather_lastdim<T, 4><<<grid, block, 0, stream>>>(
-                ptrs, sg_, self_sg_, output, rank_, size, last_dim_size);
+                ptrs, sg_, self_sg_, output, rank_, size, last_dim_size, end_sync);
             break;
         case 2:
             allgather_lastdim<T, 2><<<grid, block, 0, stream>>>(
-                ptrs, sg_, self_sg_, output, rank_, size, last_dim_size);
+                ptrs, sg_, self_sg_, output, rank_, size, last_dim_size, end_sync);
             break;
         default: printf("allgather world_size error\n");
         }
@@ -4068,7 +4116,8 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
                                    int n,
                                    int out_n,
                                    bool use_1stage,
-                                   bool gemma_norm = false)
+                                   bool gemma_norm = false,
+                                   bool end_sync = true)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -4118,7 +4167,8 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
                                                                        n,                  \
                                                                        out_n,              \
                                                                        eps,                \
-                                                                       stream);            \
+                                                                       stream,             \
+                                                                       end_sync);          \
         }                                                                                  \
         else                                                                               \
         {                                                                                  \
@@ -4136,7 +4186,8 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
                                                                         n,                 \
                                                                         out_n,             \
                                                                         eps,               \
-                                                                        stream);           \
+                                                                        stream,            \
+                                                                        end_sync);         \
         }                                                                                  \
         return;                                                                            \
     }
@@ -4386,7 +4437,8 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
                                         int m,
                                         int n,
                                         bool use_1stage,
-                                        bool gemma_norm = false)
+                                        bool gemma_norm = false,
+                                        bool end_sync = true)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -4409,12 +4461,13 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
         {                                                                               \
             gemma_template_launcher(ptrs, sg_, self_sg_, rank_, residual_inp,           \
                                     residual_out, output, weight, scale_out, size, n, n, \
-                                    n, eps, stream);                                    \
+                                    n, eps, stream, end_sync);                          \
         }                                                                               \
         else                                                                            \
         {                                                                               \
             template_launcher(ptrs, sg_, self_sg_, rank_, residual_inp, residual_out,    \
-                              output, weight, scale_out, size, n, n, n, eps, stream);   \
+                              output, weight, scale_out, size, n, n, n, eps, stream,    \
+                              end_sync);                                                \
         }                                                                               \
     } while(0)
 
@@ -4489,7 +4542,8 @@ void dispatchFusedAllReduceRMSNormQuantPerGroup(hipStream_t stream,
                                                 int group_size,
                                                 bool use_1stage,
                                                 T* bf16_output = nullptr,
-                                                bool transpose_scale = false)
+                                                bool transpose_scale = false,
+                                                bool end_sync = true)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -4566,7 +4620,7 @@ void dispatchFusedAllReduceRMSNormQuantPerGroup(hipStream_t stream,
         allreduce_fusion_kernel_1stage_per_group_launcher<T, QT, NGPUS>(                   \
             ptrs, sg_, self_sg_, rank_,                                                     \
             residual_inp, residual_out, output, weight, scale_out,                          \
-            size, n, group_size, eps, stream, bf16_output, transpose_scale);               \
+            size, n, group_size, eps, stream, bf16_output, transpose_scale, end_sync);     \
         return;                                                                             \
     }                                                                                      \
     else if(n_constrain && (size * sizeof(T) <= 512 * 1024))                               \
@@ -4616,7 +4670,8 @@ void dispatchFusedAllReduceRMSNormQuantMXFP4(hipStream_t stream,
                                              int m,
                                              int n,
                                              bool use_1stage,
-                                             T* bf16_output = nullptr)
+                                             T* bf16_output = nullptr,
+                                             bool end_sync = true)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -4657,7 +4712,7 @@ void dispatchFusedAllReduceRMSNormQuantMXFP4(hipStream_t stream,
     {                                                                                        \
         allreduce_fusion_kernel_1stage_mxfp4_launcher<T, NGPUS>(                             \
             ptrs, sg_, self_sg_, rank_, residual_inp, residual_out, output, weight,           \
-            scale_out, size, n, eps, stream, bf16_output);                                    \
+            scale_out, size, n, eps, stream, bf16_output, end_sync);                          \
         return;                                                                              \
     }                                                                                        \
     else                                                                                     \

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -709,6 +709,7 @@ __global__ void __launch_bounds__(512, 1) allgather_naive(
         int write_idx     = warp_id * size + idx;
         result[write_idx] = ptrs[warp_id][idx];
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, int ngpus>
@@ -736,6 +737,7 @@ __global__ void __launch_bounds__(512, 1) allgather_vec(
         int write_idx                                   = warp_id * size + idx;
         *(reinterpret_cast<P*>(&result[0]) + write_idx) = ptrs[warp_id][idx];
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, int ngpus>
@@ -772,6 +774,7 @@ __global__ void __launch_bounds__(512, 1) allgather_lastdim(RankData* _dp,
         int write_idx                                   = (ngpus * y + warp_id) * last_dim_size + x;
         *(reinterpret_cast<P*>(&result[0]) + write_idx) = ptrs[warp_id][idx];
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // ========== reduce_scatter kernel start ==========
@@ -813,6 +816,7 @@ __global__ void __launch_bounds__(512, 1) reduce_scatter_split_first_dim(
         *(reinterpret_cast<P*>(result) + store_index) =
             packed_reduce<P, ngpus, A>(ptrs, load_index);
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on last dim — naive (non-vectorized) fallback.
@@ -850,6 +854,7 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim_naive(
     }
     result[i] = downcast_s<T>(rslt_reg);
   }
+  end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on last dim — vectorized (16B / thread).
@@ -883,6 +888,7 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_lastdim(
     int load_index = index_y * packed_dim_n + rank * splited_n + index_x;
     *(reinterpret_cast<P*>(result) + i) = packed_reduce<P, ngpus, A>(ptrs, load_index);
   }
+  end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on middle dim — naive (non-vectorized) fallback.
@@ -920,6 +926,7 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_middim_naive(
     }
     result[i] = downcast_s<T>(rslt_reg);
   }
+  end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // reduce_scatter, scatter on middle dim — vectorized (16B / thread along k).
@@ -954,6 +961,7 @@ __global__ void __launch_bounds__(256, 1) reduce_scatter_split_middim(
     int load_index = index_m * (n * packed_dim_k) + (rank * splited_n + index_n) * packed_dim_k + index_k;
     *(reinterpret_cast<P*>(result) + i) = packed_reduce<P, ngpus, A>(ptrs, load_index);
   }
+  end_sync<ngpus, true>(sg, self_sg, rank);
 }
 // ========== reduce_scatter kernel end ==========
 
@@ -2029,6 +2037,7 @@ __global__ void __launch_bounds__(1024, 1)
             *reinterpret_cast<OP*>(output + out_idx) = zero_pack;
         }
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // Per-group quant variant of the 1-stage fused allreduce+rmsnorm kernel.
@@ -2112,6 +2121,7 @@ __global__ void __launch_bounds__(1024, 1)
             acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size,
             group_size, output, scale_out, active, bf16_output, token_num);
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, typename OutT, int NGPUS>
@@ -2221,6 +2231,7 @@ __global__ void __launch_bounds__(1024, 1)
             acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size,
             output, scale_out, active, bf16_output);
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, int NGPUS>

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -53,17 +53,20 @@ void reduce_scatter(fptr_t _fa,
                     int64_t k,
                     int64_t split_dim,
                     int64_t reg_ptr,
-                    int64_t reg_bytes);
+                    int64_t reg_bytes,
+                    bool end_sync = true);
 void all_gather_reg(fptr_t _fa,
                     const aiter_tensor_t& inp,
                     const aiter_tensor_t& out,
-                    int64_t dim);
+                    int64_t dim,
+                    bool end_sync = true);
 void all_gather_unreg(fptr_t _fa,
                       const aiter_tensor_t& inp,
                       int64_t reg_buffer,
                       const aiter_tensor_t& out,
                       int64_t reg_bytes,
-                      int64_t dim);
+                      int64_t dim,
+                      bool end_sync = true);
 void fused_allreduce_rmsnorm(fptr_t _fa,
                              const aiter_tensor_t& inp,
                              const aiter_tensor_t& res_inp,
@@ -74,7 +77,8 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
                              int64_t reg_ptr,
                              int64_t reg_bytes,
                              bool use_1stage,
-                             bool gemma_norm = false);
+                             bool gemma_norm = false,
+                             bool end_sync = true);
 void fused_allreduce_rmsnorm_pad(fptr_t _fa,
                                  const aiter_tensor_t& inp,
                                  const aiter_tensor_t& res_inp,
@@ -85,7 +89,8 @@ void fused_allreduce_rmsnorm_pad(fptr_t _fa,
                                  int64_t reg_ptr,
                                  int64_t reg_bytes,
                                  bool use_1stage,
-                                 bool gemma_norm = false);
+                                 bool gemma_norm = false,
+                                 bool end_sync = true);
 void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    const aiter_tensor_t& inp,
                                    const aiter_tensor_t& res_inp,
@@ -97,7 +102,8 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    int64_t reg_ptr,
                                    int64_t reg_bytes,
                                    bool use_1stage,
-                                   bool gemma_norm = false);
+                                   bool gemma_norm = false,
+                                   bool end_sync = true);
 void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
                                              const aiter_tensor_t& inp,
                                              const aiter_tensor_t& res_inp,
@@ -111,7 +117,8 @@ void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
                                              int64_t reg_bytes,
                                              bool use_1stage,
                                              int64_t bf16_out_ptr = 0,
-                                             bool transpose_scale = false);
+                                             bool transpose_scale = false,
+                                             bool end_sync = true);
 void fused_allreduce_rmsnorm_mxfp4_quant(fptr_t _fa,
                                          const aiter_tensor_t& inp,
                                          const aiter_tensor_t& res_inp,
@@ -123,7 +130,8 @@ void fused_allreduce_rmsnorm_mxfp4_quant(fptr_t _fa,
                                          int64_t reg_ptr,
                                          int64_t reg_bytes,
                                          bool use_1stage,
-                                         int64_t bf16_out_ptr = 0);
+                                         int64_t bf16_out_ptr = 0,
+                                         bool end_sync = true);
 void fused_qknorm_allreduce(fptr_t _fa,
                             const aiter_tensor_t& qkv_in,
                             const aiter_tensor_t& q_w,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -487,13 +487,15 @@ namespace py = pybind11;
           py::arg("k"),                                                                        \
           py::arg("split_dim"),                                                                \
           py::arg("reg_ptr"),                                                                  \
-          py::arg("reg_bytes"));                                                               \
+          py::arg("reg_bytes"),                                                                \
+          py::arg("end_sync") = true);                                                        \
     m.def("all_gather_reg",                                                                    \
           &aiter::all_gather_reg,                                                              \
           py::arg("_fa"),                                                                      \
           py::arg("inp"),                                                                      \
           py::arg("out"),                                                                      \
-          py::arg("dim"));                                                                     \
+          py::arg("dim"),                                                                      \
+          py::arg("end_sync") = true);                                                        \
     m.def("all_gather_unreg",                                                                  \
           &aiter::all_gather_unreg,                                                            \
           py::arg("_fa"),                                                                      \
@@ -501,7 +503,8 @@ namespace py = pybind11;
           py::arg("reg_buffer"),                                                               \
           py::arg("out"),                                                                      \
           py::arg("reg_bytes"),                                                                \
-          py::arg("dim"));                                                                     \
+          py::arg("dim"),                                                                      \
+          py::arg("end_sync") = true);                                                        \
     m.def("fused_allreduce_rmsnorm",                                                           \
           &aiter::fused_allreduce_rmsnorm,                                                     \
           py::arg("_fa"),                                                                      \
@@ -514,7 +517,8 @@ namespace py = pybind11;
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"),                                                                \
           py::arg("use_1stage"),                                                               \
-          py::arg("gemma_norm") = false);                                                      \
+          py::arg("gemma_norm") = false,                                                       \
+          py::arg("end_sync") = true);                                                        \
     m.def("fused_allreduce_rmsnorm_pad",                                                       \
           &aiter::fused_allreduce_rmsnorm_pad,                                                 \
           py::arg("_fa"),                                                                      \
@@ -527,7 +531,8 @@ namespace py = pybind11;
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"),                                                                \
           py::arg("use_1stage"),                                                               \
-          py::arg("gemma_norm") = false);                                                      \
+          py::arg("gemma_norm") = false,                                                       \
+          py::arg("end_sync") = true);                                                        \
     m.def("fused_allreduce_rmsnorm_quant",                                                     \
           &aiter::fused_allreduce_rmsnorm_quant,                                               \
           py::arg("_fa"),                                                                      \
@@ -541,7 +546,8 @@ namespace py = pybind11;
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"),                                                                \
           py::arg("use_1stage"),                                                               \
-          py::arg("gemma_norm") = false);                                                      \
+          py::arg("gemma_norm") = false,                                                       \
+          py::arg("end_sync") = true);                                                        \
     m.def("fused_allreduce_rmsnorm_quant_per_group",                                            \
           &aiter::fused_allreduce_rmsnorm_quant_per_group,                                      \
           py::arg("_fa"),                                                                       \
@@ -557,7 +563,8 @@ namespace py = pybind11;
           py::arg("reg_bytes"),                                                                 \
           py::arg("use_1stage"),                                                                \
           py::arg("bf16_out_ptr") = static_cast<int64_t>(0),                                    \
-          py::arg("transpose_scale") = false);                                                  \
+          py::arg("transpose_scale") = false,                                                   \
+          py::arg("end_sync") = true);                                                         \
     m.def("fused_allreduce_rmsnorm_mxfp4_quant",                                                \
           &aiter::fused_allreduce_rmsnorm_mxfp4_quant,                                          \
           py::arg("_fa"),                                                                       \
@@ -571,7 +578,8 @@ namespace py = pybind11;
           py::arg("reg_ptr"),                                                                   \
           py::arg("reg_bytes"),                                                                 \
           py::arg("use_1stage"),                                                                \
-          py::arg("bf16_out_ptr") = static_cast<int64_t>(0));                                   \
+          py::arg("bf16_out_ptr") = static_cast<int64_t>(0),                                     \
+          py::arg("end_sync") = true);                                                         \
     m.def("fused_qknorm_allreduce",                                                             \
           &aiter::fused_qknorm_allreduce,                                                       \
           py::arg("_fa"),                                                                       \

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -120,7 +120,8 @@ static void _all_reduce(fptr_t _fa, void* inp, void* out,
 static void _reduce_scatter(fptr_t _fa, void* inp, void* out,
                             int m, int n, int k,
                             aiter::ReduceScatterSplitDim split_dim,
-                            AiterDtype dtype)
+                            AiterDtype dtype,
+                            bool end_sync)
 {
     hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
@@ -130,14 +131,14 @@ static void _reduce_scatter(fptr_t _fa, void* inp, void* out,
         fa->dispatchReduceScatter<opus::fp32_t>(stream,
                                      reinterpret_cast<opus::fp32_t*>(inp),
                                      reinterpret_cast<opus::fp32_t*>(out),
-                                     m, n, k, split_dim);
+                                     m, n, k, split_dim, end_sync);
         break;
     }
     case AITER_DTYPE_fp16: {
         fa->dispatchReduceScatter<opus::fp16_t>(stream,
                                     reinterpret_cast<opus::fp16_t*>(inp),
                                     reinterpret_cast<opus::fp16_t*>(out),
-                                    m, n, k, split_dim);
+                                    m, n, k, split_dim, end_sync);
         break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
@@ -145,7 +146,7 @@ static void _reduce_scatter(fptr_t _fa, void* inp, void* out,
         fa->dispatchReduceScatter<opus::bf16_t>(stream,
                                               reinterpret_cast<opus::bf16_t*>(inp),
                                               reinterpret_cast<opus::bf16_t*>(out),
-                                              m, n, k, split_dim);
+                                              m, n, k, split_dim, end_sync);
         break;
     }
 #endif
@@ -156,7 +157,8 @@ static void _reduce_scatter(fptr_t _fa, void* inp, void* out,
 
 static void _all_gather(fptr_t _fa, void* inp, void* out,
                         int64_t size, AiterDtype dtype,
-                        int64_t last_dim_size, int64_t gather_dim)
+                        int64_t last_dim_size, int64_t gather_dim,
+                        bool end_sync)
 {
     hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
@@ -166,14 +168,14 @@ static void _all_gather(fptr_t _fa, void* inp, void* out,
         fa->dispatchAllGather<opus::fp32_t>(stream,
                                      reinterpret_cast<opus::fp32_t*>(inp),
                                      reinterpret_cast<opus::fp32_t*>(out),
-                                     size, last_dim_size, gather_dim);
+                                     size, last_dim_size, gather_dim, end_sync);
         break;
     }
     case AITER_DTYPE_fp16: {
         fa->dispatchAllGather<opus::fp16_t>(stream,
                                     reinterpret_cast<opus::fp16_t*>(inp),
                                     reinterpret_cast<opus::fp16_t*>(out),
-                                    size, last_dim_size, gather_dim);
+                                    size, last_dim_size, gather_dim, end_sync);
         break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
@@ -181,7 +183,7 @@ static void _all_gather(fptr_t _fa, void* inp, void* out,
         fa->dispatchAllGather<opus::bf16_t>(stream,
                                     reinterpret_cast<opus::bf16_t*>(inp),
                                     reinterpret_cast<opus::bf16_t*>(out),
-                                    size, last_dim_size, gather_dim);
+                                    size, last_dim_size, gather_dim, end_sync);
         break;
     }
 #endif
@@ -197,7 +199,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
                                      AiterDtype dtype, float eps,
                                      int m, int input_n, int n, int out_n,
                                      bool use_1stage,
-                                     bool gemma_norm)
+                                     bool gemma_norm,
+                                     bool end_sync)
 {
     hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
@@ -219,7 +222,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
             n,                                                   \
             out_n,                                               \
             use_1stage,                                          \
-            gemma_norm);                                         \
+            gemma_norm,                                          \
+            end_sync);                                           \
     }                                                            \
     else                                                         \
     {                                                            \
@@ -240,7 +244,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
             m,                                                   \
             n,                                                   \
             use_1stage,                                          \
-            gemma_norm);                                         \
+            gemma_norm,                                          \
+            end_sync);                                           \
     }
 
     switch(dtype)
@@ -443,7 +448,8 @@ void reduce_scatter(fptr_t _fa,
                     const aiter_tensor_t& out,
                     int64_t m, int64_t n, int64_t k,
                     int64_t split_dim,
-                    int64_t reg_ptr, int64_t reg_bytes)
+                    int64_t reg_ptr, int64_t reg_bytes,
+                    bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -459,25 +465,26 @@ void reduce_scatter(fptr_t _fa,
                                 hipMemcpyDeviceToDevice, stream));
         _reduce_scatter(_fa, (void*)reg_ptr, out.data_ptr(),
                         static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
-                        sd, dtype);
+                        sd, dtype, end_sync);
     }
     else
     {
         _reduce_scatter(_fa, inp.data_ptr(), out.data_ptr(),
                         static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
-                        sd, dtype);
+                        sd, dtype, end_sync);
     }
 }
 
 void all_gather_reg(fptr_t _fa,
                     const aiter_tensor_t& inp,
                     const aiter_tensor_t& out,
-                    int64_t dim)
+                    int64_t dim,
+                    bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     int64_t last_dim_size = inp.size(-1);
     _all_gather(_fa, inp.data_ptr(), out.data_ptr(), inp.numel(), inp.dtype(),
-                last_dim_size, dim);
+                last_dim_size, dim, end_sync);
 }
 
 void all_gather_unreg(fptr_t _fa,
@@ -485,7 +492,8 @@ void all_gather_unreg(fptr_t _fa,
                       int64_t reg_buffer,
                       const aiter_tensor_t& out,
                       int64_t reg_bytes,
-                      int64_t dim)
+                      int64_t dim,
+                      bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -497,7 +505,7 @@ void all_gather_unreg(fptr_t _fa,
     HIP_CALL(hipMemcpyAsync((void*)reg_buffer, inp.data_ptr(), data_bytes,
                             hipMemcpyDeviceToDevice, stream));
     _all_gather(_fa, (void*)reg_buffer, out.data_ptr(), inp.numel(), inp.dtype(),
-                last_dim_size, dim);
+                last_dim_size, dim, end_sync);
 }
 
 void fused_allreduce_rmsnorm(fptr_t _fa,
@@ -509,7 +517,8 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
                              double eps,
                              int64_t reg_ptr, int64_t reg_bytes,
                              bool use_1stage,
-                             bool gemma_norm)
+                             bool gemma_norm,
+                             bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -536,14 +545,16 @@ void fused_allreduce_rmsnorm(fptr_t _fa,
         _fused_allreduce_rmsnorm(_fa,
                                  (void*)reg_ptr, res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm,
+                                 end_sync);
     }
     else
     {
         _fused_allreduce_rmsnorm(_fa,
                                  inp.data_ptr(), res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm,
+                                 end_sync);
     }
 }
 
@@ -556,7 +567,8 @@ void fused_allreduce_rmsnorm_pad(fptr_t _fa,
                                  double eps,
                                  int64_t reg_ptr, int64_t reg_bytes,
                                  bool use_1stage,
-                                 bool gemma_norm)
+                                 bool gemma_norm,
+                                 bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -582,14 +594,16 @@ void fused_allreduce_rmsnorm_pad(fptr_t _fa,
         _fused_allreduce_rmsnorm(_fa,
                                  (void*)reg_ptr, res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm,
+                                 end_sync);
     }
     else
     {
         _fused_allreduce_rmsnorm(_fa,
                                  inp.data_ptr(), res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), nullptr, w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, out_n, use_1stage, gemma_norm,
+                                 end_sync);
     }
 }
 
@@ -603,7 +617,8 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    double eps,
                                    int64_t reg_ptr, int64_t reg_bytes,
                                    bool use_1stage,
-                                   bool gemma_norm)
+                                   bool gemma_norm,
+                                   bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -623,14 +638,16 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
         _fused_allreduce_rmsnorm(_fa,
                                  (void*)reg_ptr, res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), scale_out.data_ptr(), w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm,
+                                 end_sync);
     }
     else
     {
         _fused_allreduce_rmsnorm(_fa,
                                  inp.data_ptr(), res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), scale_out.data_ptr(), w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm,
+                                 end_sync);
     }
 }
 
@@ -646,7 +663,8 @@ void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
                                              int64_t reg_ptr, int64_t reg_bytes,
                                              bool use_1stage,
                                              int64_t bf16_out_ptr,
-                                             bool transpose_scale)
+                                             bool transpose_scale,
+                                             bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -684,7 +702,7 @@ void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
             reinterpret_cast<float*>(scale_out.data_ptr()),
             reinterpret_cast<opus::bf16_t*>(w.data_ptr()),
             (float)eps, m, n, (int)group_size, use_1stage,
-            reinterpret_cast<opus::bf16_t*>(bf16_out), transpose_scale);
+            reinterpret_cast<opus::bf16_t*>(bf16_out), transpose_scale, end_sync);
         break;
     }
 #endif
@@ -698,7 +716,7 @@ void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
             reinterpret_cast<float*>(scale_out.data_ptr()),
             reinterpret_cast<opus::fp16_t*>(w.data_ptr()),
             (float)eps, m, n, (int)group_size, use_1stage,
-            reinterpret_cast<opus::fp16_t*>(bf16_out), transpose_scale);
+            reinterpret_cast<opus::fp16_t*>(bf16_out), transpose_scale, end_sync);
         break;
     }
     default:
@@ -717,7 +735,8 @@ void fused_allreduce_rmsnorm_mxfp4_quant(fptr_t _fa,
                                          double eps,
                                          int64_t reg_ptr, int64_t reg_bytes,
                                          bool use_1stage,
-                                         int64_t bf16_out_ptr)
+                                         int64_t bf16_out_ptr,
+                                         bool end_sync)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -754,7 +773,7 @@ void fused_allreduce_rmsnorm_mxfp4_quant(fptr_t _fa,
             reinterpret_cast<uint8_t*>(scale_out.data_ptr()),
             reinterpret_cast<opus::bf16_t*>(w.data_ptr()),
             (float)eps, m, n, use_1stage,
-            reinterpret_cast<opus::bf16_t*>(bf16_out));
+            reinterpret_cast<opus::bf16_t*>(bf16_out), end_sync);
         break;
     }
 #endif
@@ -768,7 +787,7 @@ void fused_allreduce_rmsnorm_mxfp4_quant(fptr_t _fa,
             reinterpret_cast<uint8_t*>(scale_out.data_ptr()),
             reinterpret_cast<opus::fp16_t*>(w.data_ptr()),
             (float)eps, m, n, use_1stage,
-            reinterpret_cast<opus::fp16_t*>(bf16_out));
+            reinterpret_cast<opus::fp16_t*>(bf16_out), end_sync);
         break;
     }
     default:


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/ROCm/aiter/pull/4082.

PR #4082 fixed a custom collective race by adding an end-of-kernel cross-rank `end_sync`, ensuring peer ranks finish reading input buffers before the caller can reuse or overwrite them. That fix is correct, but the extra device-side synchronization adds measurable latency to small custom collective paths.

This PR keeps the race fix while providing a performance path that avoids the final `end_sync`. Instead of synchronizing at the end of each collective, Python keeps the input tensor alive until the next custom collective launch. The next collective's existing start synchronization proves all ranks have advanced past the previous collective, so the previous input can be safely released at that point.

cc @ColorsWind

## Technical Details

This change adds an optional `end_sync` flag through the custom allreduce Python/C++/HIP stack.

When `hold_inputs=False`, behavior stays unchanged and kernels still run the final `end_sync`.

When `hold_inputs=True`:

- custom collective launches pass `end_sync=False`
- kernels skip the final `end_sync<ngpus, true>(...)`
- `CustomAllreduce` records the input tensor in Python
- the recorded input is replaced on the next collective launch, after the next collective's start sync has established that all ranks are done with the previous input
- recorded inputs are cleared on communicator close

The feature is controlled through:

```bash
AITER_CUSTOM_AR_HOLD_INPUTS=1
```

Covered paths include:
- all-gather
- reduce-scatter
- fused all-reduce + RMSNorm
- fused all-reduce + RMSNorm quant variants

## Test Plan

You can find reproduce scripts here https://gist.github.com/jpy794/b21fd3c7b9a9ac1d0e87db62824cf78b

Race repro
```
rm -rf aiter/aiter/jit/module_custom_all_reduce.so \
       aiter/aiter/jit/build/module_custom_all_reduce

AITER_CUSTOM_AR_HOLD_INPUTS=1 python tools/custom_collective_race_repro.py
```

Performance microbench
```
AITER_CUSTOM_AR_HOLD_INPUTS=1 \
python tools/custom_collective_microbench.py \
  --graph-iters 100 \
  --label hold-inputs-graph100 \
  --output-json results/custom_collective_microbench/hold-inputs-graph100.json
```


## Test Result

**Correctness**

```
for case in ag rs ar1stage; do
  AITER_ROOT=/tmp/up-aiter-main python tools/custom_collective_race_repro.py --cases "$case" --lifetime-reuse --timeout-sec 420
  AITER_CUSTOM_AR_HOLD_INPUTS=0 python tools/custom_collective_race_repro.py --cases "$case" --lifetime-reuse --timeout-sec 420
  AITER_CUSTOM_AR_HOLD_INPUTS=1 python tools/custom_collective_race_repro.py --cases "$case" --lifetime-reuse --timeout-sec 420
done
```

- `ptr` denotes input tensor reuse after custom ar.
- `hold` denotes value of `AITER_CUSTOM_AR_HOLD_INPUTS`

Case | main | current + hold=0 | current + hold=1
-- | -- | -- | --
ag | FAIL, 1342 / 22937600, ptr 360 / 400 | PASS, 0 / 22937600, ptr 360 / 400 | PASS, 0 / 22937600, ptr 0 / 400
rs | FAIL, 871 / 5734400, ptr 400 / 400 | PASS, 0 / 5734400, ptr 400 / 400 | PASS, 0 / 5734400, ptr 0 / 400
ar1stage | FAIL, 16099 / 5734400, ptr 400 / 400 | PASS, 0 / 5734400, ptr 400 / 400 | PASS, 0 / 5734400, ptr 0 / 400

**Performance**

```
python tools/custom_collective_microbench.py --graph-iters 100
```

Case | main | current + hold=0 | current + hold=1
-- | -- | -- | --
ag | 6.928 us ±2.2% | 8.621 us ±4.3% | 7.321 us ±6.3%
rs | 7.546 us ±10.5% | 8.639 us ±4.4% | 6.896 us ±1.9%
ar1stage | 8.852 us ±2.8% | 10.247 us ±2.1% | 8.879 us ±2.6%


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
