### PR TITLE
[Bugfix] Avoid shell=True with interpolated paths in JIT build utils

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -58,7 +58,9 @@ AITER_DEBUG = int(os.getenv("AITER_DEBUG", 0))
 AITER_USE_HSACO = int(os.getenv("AITER_USE_HSACO", 0))
 
 if AITER_REBUILD >= 1:
-    subprocess.run(f"rm -rf {BUILD_DIR}/*", shell=True)
+    # Wipe the build dir without a shell: BUILD_DIR is recreated just below.
+    # Avoids shell interpolation of BUILD_DIR (derived from AITER_ROOT_DIR env).
+    shutil.rmtree(BUILD_DIR, ignore_errors=True)
 
 if not os.path.exists(BUILD_DIR):
     os.makedirs(BUILD_DIR, exist_ok=True)
@@ -236,8 +238,9 @@ def compile_lib(src_file, folder, includes=None, sources=None, cxxflags=None):
         with open(f"{sub_build_dir}/Makefile", "w") as f:
             f.write(makefile_file)
         subprocess.run(
-            f"cd {sub_build_dir} && make build -j{len(sources)}",
-            shell=True,
+            ["make", "build", f"-j{len(sources)}"],
+            cwd=sub_build_dir,
+            shell=False,
             capture_output=AITER_LOG_MORE < 2,
             check=True,
         )


### PR DESCRIPTION
## Summary

`csrc/cpp_itfs/utils.py` constructed two commands via f-string interpolation and executed them with `shell=True`:

- `rm -rf {BUILD_DIR}/*` — `BUILD_DIR` derives from the `AITER_ROOT_DIR` environment variable
- `cd {sub_build_dir} && make build -j...` — `sub_build_dir` derives from `BUILD_DIR`

This PR removes the shell-interpolation surface without changing behavior:

- clear the build dir with `shutil.rmtree(BUILD_DIR, ignore_errors=True)` (it is recreated immediately after)
- run make via an argv array `["make", "build", f"-j{len(sources)}"]` with `cwd=sub_build_dir` instead of `cd ... && make` under a shell

## Context

Flagged by an internal static security scan (Command Injection via `shell=True`, findings SEC-00289 / SEC-00770). In practice these calls are not reachable by untrusted input — the interpolated values come from environment variables and internal call args, and the compile `cxxflags` are hardcoded constants plus local GPU-arch detection. This change is defense-in-depth / removes the flagged pattern, and keeps behavior identical.

## Test plan

- [x] `python -m py_compile csrc/cpp_itfs/utils.py`
- [x] `black --check csrc/cpp_itfs/utils.py`
- [ ] JIT build smoke on a ROCm GPU host (`AITER_REBUILD=1` path + a `compile_lib` op) — please run in CI

https://amd-hub.atlassian.net/browse/ROCM-27178
https://amd-hub.atlassian.net/browse/ROCM-26628