### PR TITLE
[Bugfix] Pin requirements.txt versions to reduce supply-chain risk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,22 @@
-pandas
-pytest
-psutil
-matplotlib
-pyyaml
-einops
-pybind11>=3.0.1
-ninja
+# Runtime / CI Python dependencies, version-pinned for reproducible builds and
+# to reduce PyPI supply-chain risk (typosquat / upstream compromise pulling an
+# unexpected version).
+#
+# Baseline: rocm/atom-dev:latest, the canonical aiter build/test image
+#   digest sha256:7826a9a904a905b3b14418b267e8c40d17ca5606d72d620ff407df2129c2e5e7
+# Versions below match what that image ships, so `pip install -r requirements.txt`
+# is a no-op there and reproducible elsewhere.
+#
+# Note: torch and triton are provided by the base image as ROCm-specific builds
+# (e.g. torch 2.10.0+rocm..., triton 3.7.0+amd.rocm...) that are not published on
+# PyPI, so they are intentionally NOT pinned here — their provenance is governed
+# by the base image, not this file.
+pandas==3.0.3
+pytest==9.0.3
+psutil==7.2.2
+matplotlib==3.10.9
+pyyaml==6.0.3
+einops==0.8.2
+pybind11==3.0.4
+ninja==1.13.0
 flydsl==0.2.2


### PR DESCRIPTION
## Summary

`requirements.txt` listed most dependencies by bare name (`pandas`, `pytest`, `psutil`, `matplotlib`, `pyyaml`, `einops`, `ninja`) or a lower bound (`pybind11>=3.0.1`), so each install could resolve to an arbitrary newer release. Static analysis flagged this as a PyPI supply-chain surface (typosquat / upstream compromise pulling an unexpected version) — findings SEC-00190 / SEC-00291 / SEC-00839.

This pins every entry to the version shipped by the canonical build/test image `rocm/atom-dev:latest`, so installs are reproducible and match a known-good baseline.

## What's pinned

| package | pinned version |
|---|---|
| pandas | 3.0.3 |
| pytest | 9.0.3 |
| psutil | 7.2.2 |
| matplotlib | 3.10.9 |
| pyyaml | 6.0.3 |
| einops | 0.8.2 |
| pybind11 | 3.0.4 (was `>=3.0.1`) |
| ninja | 1.13.0 |
| flydsl | 0.2.2 (already pinned) |

Baseline image digest: `sha256:7826a9a904a905b3b14418b267e8c40d17ca5606d72d620ff407df2129c2e5e7`.

## Deliberately not pinned here

`torch` / `triton` are **not** added: the base image ships ROCm-specific builds (e.g. `torch 2.10.0+rocm...`, `triton 3.7.0+amd.rocm...`) that are not on PyPI, so pinning them in `requirements.txt` would break `pip install` on any environment other than that exact image. Their provenance is governed by the base image, not this file.

## Test plan

- [x] `pip install --dry-run -r requirements.txt` inside `rocm/atom-dev:latest` — all entries already satisfied, no conflicts
- [ ] CI install on the runner

## Follow-up (not in this PR)

Full `--require-hashes` mode (via `pip-compile --generate-hashes`) would additionally defend against a compromised-but-same-version release. Left out here to keep the change minimal and avoid churn on transitive deps; can be a follow-up if desired.

https://amd-hub.atlassian.net/browse/ROCM-26829
https://amd-hub.atlassian.net/browse/ROCM-26902
https://amd-hub.atlassian.net/browse/ROCM-27182