### PR TITLE
test(configs): add tuned config cross-file shape-collision guard + skill

### DIFF
--- a/.claude/skills/aiter-config-shape/SKILL.md
+++ b/.claude/skills/aiter-config-shape/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: aiter-config-shape
+description: How to add/upload tuned config CSVs under aiter/configs (incl. model_configs/) without introducing duplicate shapes, and how to find & resolve duplicate-shape collisions. Use whenever adding a model's tuned config, merging/uploading config CSVs, editing anything under aiter/configs/**, or when a run hits "duplicate shape entries during merge".
+argument-hint: [model name or aiter/configs/**/*.csv file]
+---
+
+# aiter config shape-collision standard
+
+Tuned config CSVs in `aiter/configs/` are **not read one file at a time**. At
+runtime `aiter/jit/core.py::AITER_CONFIGS.get_config_file` merges, per family,
+the canonical `aiter/configs/<name>.csv` **plus every**
+`aiter/configs/model_configs/*<name>*.csv`, and `update_config_files`
+de-duplicates that merge on a key derived from the matching **untuned** file's
+columns (+ `cu_num`/`gfx`/`_tag`). If two rows across the merged files share that
+key, the merge **raises** `RuntimeError: Found N duplicate shape entries during
+merge of '<family>'`.
+
+Consequence: a per-model config you add can be perfectly fine alone yet collide
+with a *different* model's config once both are on `main`. Single-PR CI only
+merges your file with current `main`, so two PRs that each add the same shape to
+different model files both pass, then break `main` after both land
+(**cross-PR / merge-skew hazard**). Reviewers routinely forget this.
+
+Follow this whenever you add "tuned configs for model Y", upload/merge config
+CSVs, or touch anything under `aiter/configs/**`.
+
+## The hard rules
+
+1. **A key is (untuned columns) + `cu_num` + `gfx` + `_tag`.** Never hand-pick
+   key columns — they come from the family's `*_untuned_*.csv` header, exactly as
+   runtime derives them. Do not assume `M,N,K` alone: e.g. `a8w8` also keys on
+   `q_dtype_w`, `bf16` on `bias,dtype,outdtype,scaleAB,bpreshuffle`, `fmoe` on the
+   full `token,model_dim,inter_dim,expert,topk,act_type,dtype,q_dtype_*,q_type,
+   use_g1u1,doweight_stage1` (+ `_tag`).
+2. **Your file is merged with the canonical file AND every other model file of
+   the same family.** Before uploading, check the merge, not just your file in
+   isolation. The family is decided by the substring in the filename
+   (`*<tuned_file_name>*`), e.g. `dsv4_bf16_tuned_gemm.csv` joins the
+   `bf16_tuned_gemm` family.
+3. **One shape, one row across the whole family.** If the shape already exists
+   (in the canonical file or another model's file), do **not** re-add it. If yours
+   is genuinely faster, replace the existing row rather than adding a second.
+4. **Run the collision guard and make it pass before you push.** (below)
+5. **Resolve, never suppress.** Fix by removing the redundant row (keeping the
+   lowest-`us` winner) — do not widen keys, rename shapes, or delete the guard.
+6. **`gfx` matters.** Archs that share a `cu_num` (e.g. gfx950 vs gfx1250 both
+   report 256) are only distinguishable by `gfx`. Keep the real `gfx` the tuner
+   wrote; don't drop the column. Legacy files without `gfx` are backfilled from
+   `cu_num` (256→gfx950, 80/304→gfx942) — do not rely on that for new archs.
+
+## Detect: run the guard
+
+The authoritative check drives the **real runtime merge** (no re-implemented
+logic, so it can't drift) against a temp copy of `aiter/configs/`:
+
+```bash
+python3 -m unittest op_tests.tuning_tests.test_config_shape_collision -v
+```
+
+- Requires torch (importing `aiter` pulls it in); it skips cleanly where torch is
+  absent, so run it in an env/container that has torch.
+- A failing family prints the offending rows and the exact key, e.g.
+  `bf16_tuned_gemm: ... duplicate shapes ...` listing the `_src` file of each
+  colliding row.
+
+To see it the way production does (and let runtime tell you the key + rows),
+trigger the merge directly on a scratch copy:
+
+```python
+import shutil, tempfile, aiter.jit.core as core
+tmp = tempfile.mkdtemp(); shutil.copytree("aiter/configs", f"{tmp}/aiter/configs")
+core.AITER_ROOT_DIR = tmp
+type(core.AITER_CONFIGS).get_config_file.cache_clear()
+core.AITER_CONFIGS.get_config_file(
+    "AITER_CONFIG_GEMM_BF16", f"{tmp}/aiter/configs/bf16_tuned_gemm.csv", "bf16_tuned_gemm"
+)  # raises RuntimeError listing duplicate rows + which files
+```
+
+## Find which rows/files collide
+
+The `RuntimeError` (and the test failure) already prints every duplicate row and
+its source file. To locate them yourself for a family, merge its files and group
+by the runtime key (read the key from the untuned header — don't invent it):
+
+```python
+import glob, os, pandas as pd
+name = "bf16_tuned_gemm"                      # the family
+untuned = f"aiter/configs/{name.replace('tuned','untuned')}.csv"
+key = pd.read_csv(untuned, nrows=0).columns.str.strip().tolist() + ["cu_num", "gfx"]
+files = [f"aiter/configs/{name}.csv"] + [
+    p for p in glob.glob(f"aiter/configs/model_configs/*{name}*.csv")
+    if "untuned" not in os.path.basename(p)
+]
+df = pd.concat([pd.read_csv(f).assign(_src=os.path.basename(f)) for f in files if os.path.exists(f)])
+key = [k for k in key if k in df.columns]
+print(df[df.duplicated(key, keep=False)].sort_values(key)[key + ["us", "_src"]].to_string(index=False))
+```
+
+## Resolve: the auto-dedup already exists — just trigger it on the real tree
+
+**Do not write a dedup script.** `update_config_files` (`aiter/jit/core.py`)
+already resolves collisions: for each duplicate key it keeps the lowest-`us` row,
+**writes the pruned CSVs back to the source files**, and raises asking you to
+re-run. Your job is only to trigger that write-back against the *real* tree and
+commit the result.
+
+- **Trigger it (one command):** run the guard's `--fix` mode. Unlike the default
+  detection (which runs on a temp copy to stay read-only), `--fix` runs on the
+  **real** checkout so `update_config_files`' write-back lands where you can
+  commit it:
+
+  ```bash
+  python3 op_tests/tuning_tests/test_config_shape_collision.py --fix
+  ```
+
+  It resolves every family, keeps the lowest-`us` row per shape, rewrites the
+  source CSVs, and prints which files/rows changed. (Equivalent to running the
+  model/op/tuner once, or calling `core.AITER_CONFIGS.get_config_file(...)` on the
+  real tree — same built-in auto-dedup, no extra logic.)
+- **Commit** the rewritten config CSVs (`git diff` shows the pruned rows), then
+  re-run without `--fix` to confirm clean.
+- **Manual alternative:** if you'd rather edit by hand, from the duplicate list
+  delete the slower-`us` copy — usually the shape already exists in the canonical
+  or an older model file, so remove it from the file you are adding. Keep exactly
+  one row per key (the lowest `us`).
+
+After resolving, re-run the guard until it passes.
+
+## Cross-PR awareness (for authors and reviewers)
+
+- Your green CI does **not** prove `main` stays green — it never saw the other
+  in-flight config PRs. When adding shapes shared across models (common decode
+  shapes, MoE token grids), assume another PR may add the same shape.
+- The same guard runs on **push to `main`** as the backstop: if two PRs race and
+  both land a colliding shape, `main` goes red immediately — fix forward by
+  pruning the duplicate (lowest-`us` wins).
+- Reviewing a config PR: skim other open PRs touching the same family, and trust
+  the guard rather than eyeballing shapes.
+
+## References (single source of truth — keep in sync)
+
+- Guard test: `op_tests/tuning_tests/test_config_shape_collision.py` (drives the
+  real merge; add a family here if you register a new `AITER_CONFIG_*` file).
+- Runtime merge + dedup: `aiter/jit/core.py::get_config_file` /
+  `update_config_files` (key derivation, gfx backfill, `_tag`, write-back).
+- GPU end-to-end counterpart: `op_tests/tuning_tests/test_run_config.py` (runs
+  every merged shape).
+
+## Anti-patterns
+
+- ❌ Checking only your new file, not the family-wide merge.
+- ❌ Hand-picking key columns (missing `gfx`, adding non-key `libtype`) instead of
+  reading the untuned header.
+- ❌ Adding a second row for a shape that already exists somewhere in the family.
+- ❌ "Fixing" a collision by widening the key, renaming a shape, or disabling the
+  guard.
+- ❌ Assuming green PR CI means `main` is safe (ignores concurrent config PRs).
+- ❌ Dropping/zeroing the `gfx` column so shapes look distinct.
+- ❌ Re-implementing the merge/dedup in a new script — call the runtime or the
+  guard test instead.

--- a/.claude/skills/aiter-config-shape/SKILL.md
+++ b/.claude/skills/aiter-config-shape/SKILL.md
@@ -26,9 +26,12 @@ CSVs, or touch anything under `aiter/configs/**`.
 
 ## The hard rules
 
-1. **A key is (untuned columns) + `cu_num` + `gfx` + `_tag`.** Never hand-pick
-   key columns — they come from the family's `*_untuned_*.csv` header, exactly as
-   runtime derives them. Do not assume `M,N,K` alone: e.g. `a8w8` also keys on
+1. **A key is (untuned columns) + `cu_num`, plus `gfx`/`_tag` when those columns
+   are present.** Never hand-pick key columns — they come from the family's
+   `*_untuned_*.csv` header, exactly as runtime derives them (`update_config_files`
+   appends `cu_num` if absent, `gfx` only when a `gfx` column exists in the merge,
+   and `_tag` only when a `_tag` column exists). Do not assume `M,N,K` alone: e.g.
+   `a8w8` also keys on
    `q_dtype_w`, `bf16` on `bias,dtype,outdtype,scaleAB,bpreshuffle`, `fmoe` on the
    full `token,model_dim,inter_dim,expert,topk,act_type,dtype,q_dtype_*,q_type,
    use_g1u1,doweight_stage1` (+ `_tag`).
@@ -59,12 +62,13 @@ python3 -m unittest op_tests.tuning_tests.test_config_shape_collision -v
 
 - Requires torch (importing `aiter` pulls it in); it skips cleanly where torch is
   absent, so run it in an env/container that has torch.
-- A failing family prints the offending rows and the exact key, e.g.
-  `bf16_tuned_gemm: ... duplicate shapes ...` listing the `_src` file of each
-  colliding row.
+- A failing family surfaces the runtime `RuntimeError`: a `Found N duplicate shape
+  entries during merge of '<family>'` message, the colliding rows as a
+  `Duplicate rows:` table (the merged config columns — no `_src`/key line is
+  printed), and an `Updated files:` list of the source CSVs that were rewritten.
 
-To see it the way production does (and let runtime tell you the key + rows),
-trigger the merge directly on a scratch copy:
+To see it the way production does (runtime prints the colliding rows), trigger
+the merge directly on a scratch copy:
 
 ```python
 import shutil, tempfile, aiter.jit.core as core
@@ -131,9 +135,10 @@ After resolving, re-run the guard until it passes.
 - Your green CI does **not** prove `main` stays green — it never saw the other
   in-flight config PRs. When adding shapes shared across models (common decode
   shapes, MoE token grids), assume another PR may add the same shape.
-- The same guard runs on **push to `main`** as the backstop: if two PRs race and
-  both land a colliding shape, `main` goes red immediately — fix forward by
-  pruning the duplicate (lowest-`us` wins).
+- Backstop (once wired): if this guard is added to a **push-to-`main`** job, two
+  PRs that race and both land a colliding shape turn `main` red immediately — fix
+  forward by pruning the duplicate (lowest-`us` wins). The guard is not wired into
+  CI yet, so today this is a manual/local check, not an automatic backstop.
 - Reviewing a config PR: skim other open PRs touching the same family, and trust
   the guard rather than eyeballing shapes.
 

--- a/op_tests/tuning_tests/test_config_shape_collision.py
+++ b/op_tests/tuning_tests/test_config_shape_collision.py
@@ -21,8 +21,10 @@ back to their source paths when it finds collisions. We copy the entire
 all globbing, untuned-key lookups, and any write-backs hit the copy, never the
 real repo.
 
-Requires torch (importing ``aiter`` pulls it in), so it is skipped in the
-torch-less pre-checks job and runs in the regular (GPU-free is fine) test image.
+Requires torch (importing ``aiter`` pulls it in); it does not need a GPU. It is
+**not yet wired into any CI workflow** -- run it manually in a torch-enabled
+environment, or add it to a suitable job (e.g. the CPU/level01 tuning tests) to
+make it an actual PR/main regression guard.
 
 Run:
     python3 -m unittest op_tests.tuning_tests.test_config_shape_collision -v

--- a/op_tests/tuning_tests/test_config_shape_collision.py
+++ b/op_tests/tuning_tests/test_config_shape_collision.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""
+Cross-file shape-collision guard for tuned config CSVs.
+
+At runtime ``aiter.jit.core.AITER_CONFIGS.get_config_file`` merges, per family,
+the canonical ``aiter/configs/<name>.csv`` with every
+``aiter/configs/model_configs/*<name>*.csv``, then ``update_config_files``
+de-duplicates on a key derived from the matching *untuned* CSV's columns and
+**raises** if two rows collide.
+
+A single PR's CI only ever merges *its own* changed file with current ``main``,
+so two PRs that each add the same shape to different model files both pass, then
+break ``main`` once both land (cross-PR / merge-skew hazard). This test drives
+the **real runtime merge** so the collision is caught statically -- there is no
+re-implementation of the merge/dedup/key logic here, so it cannot drift.
+
+How it stays side-effect free: ``update_config_files`` writes de-duplicated CSVs
+back to their source paths when it finds collisions. We copy the entire
+``aiter/configs/`` tree to a temp dir and point ``core.AITER_ROOT_DIR`` at it, so
+all globbing, untuned-key lookups, and any write-backs hit the copy, never the
+real repo.
+
+Requires torch (importing ``aiter`` pulls it in), so it is skipped in the
+torch-less pre-checks job and runs in the regular (GPU-free is fine) test image.
+
+Run:
+    python3 -m unittest op_tests.tuning_tests.test_config_shape_collision -v
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+try:  # importing aiter requires torch; skip cleanly where it is unavailable.
+    import aiter.jit.core as core
+
+    _IMPORT_ERR = None
+except Exception as e:  # noqa: BLE001
+    core = None
+    _IMPORT_ERR = e
+
+AITER_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
+# (env var name, tuned-file base name) for every family registered in
+# AITER_CONFIGS.*_FILE (aiter/jit/core.py). These are the families merged at
+# runtime; the merge set and dedup key are resolved entirely by get_config_file.
+FAMILIES = [
+    ("AITER_CONFIG_GEMM_A4W4", "a4w4_blockscale_tuned_gemm"),
+    ("AITER_CONFIG_GEMM_A8W8", "a8w8_tuned_gemm"),
+    ("AITER_CONFIG_GEMM_A8W8_BPRESHUFFLE", "a8w8_bpreshuffle_tuned_gemm"),
+    ("AITER_CONFIG_GEMM_A8W8_BLOCKSCALE", "a8w8_blockscale_tuned_gemm"),
+    (
+        "AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE",
+        "a8w8_blockscale_bpreshuffle_tuned_gemm",
+    ),
+    ("AITER_CONFIG_A8W8_BATCHED_GEMM", "a8w8_tuned_batched_gemm"),
+    ("AITER_CONFIG_BF16_BATCHED_GEMM", "bf16_tuned_batched_gemm"),
+    ("AITER_CONFIG_GEMM_BF16", "bf16_tuned_gemm"),
+    ("AITER_CONFIG_FMOE", "tuned_fmoe"),
+    ("AITER_CONFIG_GROUPED_FMOE", "tuned_grouped_fmoe"),
+]
+
+
+def _cache_clear():
+    # get_config_file is an lru_cache-wrapped method; clear via the class object.
+    type(core.AITER_CONFIGS).get_config_file.cache_clear()
+
+
+@unittest.skipUnless(core is not None, f"aiter.jit.core not importable: {_IMPORT_ERR}")
+class TestConfigShapeCollision(unittest.TestCase):
+    """Drive the real runtime merge against a temp copy; fail on collisions."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.mkdtemp(prefix="aiter_cfg_collision_")
+        shutil.copytree(
+            os.path.join(AITER_ROOT, "aiter", "configs"),
+            os.path.join(cls._tmp, "aiter", "configs"),
+        )
+        cls._orig_root = core.AITER_ROOT_DIR
+        core.AITER_ROOT_DIR = cls._tmp
+        _cache_clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        core.AITER_ROOT_DIR = cls._orig_root
+        _cache_clear()
+        shutil.rmtree(cls._tmp, ignore_errors=True)
+
+    @staticmethod
+    def _resolve(root, env_name, name):
+        """Drive the production (no-env) resolution path against `root`.
+        Raises RuntimeError on a duplicate-shape collision."""
+        os.environ.pop(env_name, None)
+        core.AITER_ROOT_DIR = root
+        _cache_clear()
+        default_file = os.path.join(root, "aiter", "configs", f"{name}.csv")
+        return core.AITER_CONFIGS.get_config_file(env_name, default_file, name)
+
+    def _check_family(self, env_name, name):
+        try:
+            self._resolve(self._tmp, env_name, name)
+        except RuntimeError as e:
+            if "duplicate shape" in str(e).lower():
+                self.fail(
+                    f"{name}: runtime merge of configs/ + model_configs/ reports "
+                    f"duplicate shapes (same key across files):\n{e}"
+                )
+            raise
+
+    # ---- self-check / control: prove the harness itself detects collisions ----
+
+    @staticmethod
+    def _build_synthetic_family(root, dup):
+        """Write a minimal isolated config tree for one family and return
+        (env_name, name). With dup=True the model file duplicates the canonical
+        row's key; with dup=False it uses a distinct shape. Uses the
+        a8w8_blockscale family (untuned key = M,N,K)."""
+        name = "a8w8_blockscale_tuned_gemm"
+        env_name = "AITER_CONFIG_GEMM_A8W8_BLOCKSCALE"
+        cfg = os.path.join(root, "aiter", "configs")
+        os.makedirs(os.path.join(cfg, "model_configs"), exist_ok=True)
+        # untuned header drives the dedup key columns.
+        with open(os.path.join(cfg, "a8w8_blockscale_untuned_gemm.csv"), "w") as f:
+            f.write("M,N,K\n")
+        header = "gfx,cu_num,M,N,K,us\n"
+        with open(os.path.join(cfg, f"{name}.csv"), "w") as f:
+            f.write(header)
+            f.write("gfx950,256,1,64,128,10.0\n")
+        model_shape = "1,64,128" if dup else "2,64,128"
+        with open(
+            os.path.join(cfg, "model_configs", f"selfcheck_{name}.csv"), "w"
+        ) as f:
+            f.write(header)
+            f.write(f"gfx950,256,{model_shape},20.0\n")
+        return env_name, name
+
+    def _run_synthetic(self, dup):
+        tmp = tempfile.mkdtemp(prefix="aiter_cfg_selfcheck_")
+        try:
+            env_name, name = self._build_synthetic_family(tmp, dup=dup)
+            try:
+                self._resolve(tmp, env_name, name)
+                return None
+            except RuntimeError as e:
+                return str(e)
+        finally:
+            core.AITER_ROOT_DIR = self._tmp  # restore for other tests
+            _cache_clear()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_selfcheck_detects_planted_duplicate(self):
+        """Positive control: a planted duplicate MUST be caught. If not, the
+        detection harness (temp copy / AITER_ROOT_DIR redirect / merge call) is
+        broken -- not the real config data."""
+        err = self._run_synthetic(dup=True)
+        self.assertIsNotNone(
+            err,
+            "harness FAILED to detect a planted duplicate shape -- the collision "
+            "check is broken; do not trust its PASS on real configs.",
+        )
+        self.assertIn("duplicate shape", err.lower())
+
+    def test_selfcheck_passes_on_clean(self):
+        """Negative control: distinct shapes must NOT be flagged (no false
+        positive)."""
+        err = self._run_synthetic(dup=False)
+        self.assertIsNone(err, f"harness false-positived on clean configs:\n{err}")
+
+    def test_a4w4_blockscale(self):
+        self._check_family("AITER_CONFIG_GEMM_A4W4", "a4w4_blockscale_tuned_gemm")
+
+    def test_a8w8(self):
+        self._check_family("AITER_CONFIG_GEMM_A8W8", "a8w8_tuned_gemm")
+
+    def test_a8w8_bpreshuffle(self):
+        self._check_family(
+            "AITER_CONFIG_GEMM_A8W8_BPRESHUFFLE", "a8w8_bpreshuffle_tuned_gemm"
+        )
+
+    def test_a8w8_blockscale(self):
+        self._check_family(
+            "AITER_CONFIG_GEMM_A8W8_BLOCKSCALE", "a8w8_blockscale_tuned_gemm"
+        )
+
+    def test_a8w8_blockscale_bpreshuffle(self):
+        self._check_family(
+            "AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE",
+            "a8w8_blockscale_bpreshuffle_tuned_gemm",
+        )
+
+    def test_a8w8_batched(self):
+        self._check_family("AITER_CONFIG_A8W8_BATCHED_GEMM", "a8w8_tuned_batched_gemm")
+
+    def test_bf16_batched(self):
+        self._check_family("AITER_CONFIG_BF16_BATCHED_GEMM", "bf16_tuned_batched_gemm")
+
+    def test_bf16(self):
+        self._check_family("AITER_CONFIG_GEMM_BF16", "bf16_tuned_gemm")
+
+    def test_fmoe(self):
+        self._check_family("AITER_CONFIG_FMOE", "tuned_fmoe")
+
+    def test_grouped_fmoe(self):
+        self._check_family("AITER_CONFIG_GROUPED_FMOE", "tuned_grouped_fmoe")
+
+
+def _fix_real_tree():
+    """Resolve every family against the REAL checkout (not a temp copy) so
+    `update_config_files`' existing auto-dedup (keep lowest-`us` per shape) writes
+    the pruned CSVs back to the actual source files. Prints what changed; commit
+    the result and re-run without --fix to confirm clean.
+
+    This adds NO dedup logic -- it just triggers the write-back that
+    aiter/jit/core.py::update_config_files already performs, on real files."""
+    if core is None:
+        raise SystemExit(f"aiter.jit.core not importable: {_IMPORT_ERR}")
+    core.AITER_ROOT_DIR = AITER_ROOT  # operate on this checkout's real configs
+    fixed = []
+    for env_name, name in FAMILIES:
+        os.environ.pop(env_name, None)
+        _cache_clear()
+        default_file = os.path.join(AITER_ROOT, "aiter", "configs", f"{name}.csv")
+        try:
+            core.AITER_CONFIGS.get_config_file(env_name, default_file, name)
+        except RuntimeError as e:
+            if "duplicate shape" in str(e).lower():
+                fixed.append((name, str(e)))
+            else:
+                raise
+    if not fixed:
+        print("No duplicate shapes found; nothing to fix.")
+        return
+    print(f"Resolved duplicate shapes in {len(fixed)} family(ies):\n")
+    for name, msg in fixed:
+        print(f"### {name}\n{msg}\n")
+    print(
+        "Source CSVs were rewritten (lowest-`us` row kept per shape). "
+        "Review `git diff`, commit, then re-run without --fix to confirm clean."
+    )
+
+
+if __name__ == "__main__":
+    if "--fix" in sys.argv:
+        # Modify the REAL config files in place. Read-only detection (the default)
+        # runs on a temp copy; --fix intentionally writes back to the checkout.
+        sys.argv.remove("--fix")
+        _fix_real_tree()
+    else:
+        unittest.main(verbosity=2)


### PR DESCRIPTION

## Motivation

Add op_tests/tuning_tests/test_config_shape_collision.py, a fast (no-GPU) guard that drives the real runtime merge (aiter/jit/core.py::get_config_file) against a temp copy of aiter/configs/ and fails if the canonical + model_configs merge for any family contains duplicate shapes. Includes positive/negative self-check controls that prove the harness itself detects collisions, and a --fix mode that resolves duplicates in the real files via the existing update_config_files auto-dedup (keep lowest us).

Also add .claude/skills/aiter-config-shape/SKILL.md documenting the add/find/resolve workflow for tuned config CSVs.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
