### PR TITLE
fix: undeclared flag_color in TWOSHOT_DISPATCH_TP2_ONLY (breaks build after #3899)

### DIFF
--- a/csrc/include/quick_all_reduce.cuh
+++ b/csrc/include/quick_all_reduce.cuh
@@ -1039,7 +1039,7 @@ allreduce_prototype_twoshot(T const* A,
                            rank,                                                            \
                            dbuffer_list,                                                    \
                            data_offset,                                                     \
-                           flag_color,                                                      \
+                           d_flag_color,                                                    \
                            this->kMaxProblemSize);                                          \
     }                                                                                       \
     else                                                                                    \


### PR DESCRIPTION
## Summary

PR #3899 introduced `TWOSHOT_DISPATCH_TP2_ONLY` macro but used the kernel parameter name `flag_color` instead of the `DeviceComms` member variable `d_flag_color`, causing a **compile error that breaks the main branch build**:

```
quick_all_reduce.cuh:1205:43: error: use of undeclared identifier 'flag_color'
  case QuickReduceQuantLevel::INT3: TWOSHOT_DISPATCH_TP2_ONLY(CodecQ3) break;
                                    ^
quick_all_reduce.cuh:1042: expanded from macro 'TWOSHOT_DISPATCH_TP2_ONLY'
                           flag_color,
                           ^
quick_all_reduce.cuh:1069: note: 'd_flag_color' declared here
    uint32_t* d_flag_color = nullptr;
```

CI failure: https://github.com/ROCm/aiter/actions/runs/28769245234/job/85303791204

## Fix

One-line change: `flag_color` → `d_flag_color` in `TWOSHOT_DISPATCH_TP2_ONLY`.

All three existing `TWOSHOT_DISPATCH` macros already use `d_flag_color` correctly (lines 980, 999, 1018). The new macro simply missed this.

## Test plan

- [ ] Verify `module_quick_all_reduce` JIT build succeeds for gfx942 + gfx950
- [ ] Existing quick_all_reduce tests pass (F16/FP8/INT6/INT4 paths unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)