### PR TITLE
[feat](gemma_norm): Support GemmaRMSNorm in fused_qk_norm_mrope + fp8 KV on gfx1201.

### DIFF
--- a/aiter/ops/fused_qk_norm_mrope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_mrope_cache_quant.py
@@ -35,4 +35,5 @@ def fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(
     block_size: int,
     x: int,
     rotary_dim: int = 0,
+    gemma_norm: bool = False,
 ) -> None: ...

--- a/csrc/include/aiter_enum.h
+++ b/csrc/include/aiter_enum.h
@@ -87,5 +87,5 @@ static inline std::string AiterDtype_to_str(int dtype)
 // FP8 format mapping: which GPU architectures use OCP (e4m3fn) vs FNUZ (e4m3fnuz)
 // gfx950 (MI350): OCP e4m3fn  (bias=7, no negative-zero-as-NaN)
 // gfx942 (MI300): FNUZ e4m3fnuz (bias=8, negative-zero-as-NaN)
-static constexpr const char* fp8_ocp_archs[]  = {"gfx950", "gfx1250"};
+static constexpr const char* fp8_ocp_archs[]  = {"gfx950", "gfx1201", "gfx1250"};
 static constexpr const char* fp8_fnuz_archs[] = {"gfx942"};

--- a/csrc/include/fused_qk_norm_mrope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_mrope_cache_quant.h
@@ -34,4 +34,5 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                                                     bool use_shuffle_layout,
                                                     int64_t block_size,
                                                     int64_t x,
-                                                    int64_t rotary_dim = 0);
+                                                    int64_t rotary_dim = 0,
+                                                    bool gemma_norm = false);

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1747,7 +1747,8 @@ namespace py = pybind11;
           py::arg("use_shuffle_layout"),                    \
           py::arg("block_size"),                            \
           py::arg("x"),                                     \
-          py::arg("rotary_dim") = 0);
+          py::arg("rotary_dim") = 0,                       \
+          py::arg("gemma_norm") = false)
 
 #define FUSED_QKNORM_IDXRQKNORM_PYBIND      \
     m.def("fused_qknorm_idxrqknorm",        \

--- a/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
@@ -29,7 +29,8 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                                                     bool use_shuffle_layout,
                                                     int64_t block_size,
                                                     int64_t x,
-                                                    int64_t rotary_dim)
+                                                    int64_t rotary_dim,
+                                                    bool gemma_norm)
 {
     AITER_CHECK(mrope_section_.size() == 3);
     AITER_CHECK(qkv.is_contiguous() && qw.is_contiguous() && kw.is_contiguous() &&
@@ -89,7 +90,8 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                     use_shuffle_layout,
                     block_size,
                     x,
-                    rotary_dim);
+                    rotary_dim,
+                    gemma_norm);
             }
             else
             {
@@ -134,7 +136,8 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                             use_shuffle_layout,
                             block_size,
                             x,
-                            rotary_dim);
+                            rotary_dim,
+                            gemma_norm);
                     }
                     else
                     {
@@ -177,7 +180,8 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                             use_shuffle_layout,
                             block_size,
                             x,
-                            rotary_dim);
+                            rotary_dim,
+                            gemma_norm);
                     }
                 }
                 else

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -7577,7 +7577,11 @@ __device__ __forceinline__ void pack_f32_to_vec_t(vec_t<T, N>& dst, const float 
 
 template <typename T, int VEC_SIZE>
 __device__ __forceinline__ void
-warp_rms_norm_(vec_t<T, VEC_SIZE>& input, vec_t<T, VEC_SIZE>& gamma, float rms_dim, float rms_eps)
+warp_rms_norm_(vec_t<T, VEC_SIZE>& input,
+               vec_t<T, VEC_SIZE>& gamma,
+               float rms_dim,
+               float rms_eps,
+               bool gemma_norm = false)
 {
     vec_t<T, VEC_SIZE> norm_out;
     float acc = 0.f;
@@ -7593,7 +7597,8 @@ warp_rms_norm_(vec_t<T, VEC_SIZE>& input, vec_t<T, VEC_SIZE>& gamma, float rms_d
 #pragma unroll
     for(int i = 0; i < VEC_SIZE; ++i)
     {
-        input[i] = static_cast<T>((float)input[i] * s_val * (float)gamma[i]);
+        const float weight = gemma_norm ? (1.0f + (float)gamma[i]) : (float)gamma[i];
+        input[i] = static_cast<T>((float)input[i] * s_val * weight);
     }
 }
 
@@ -7783,7 +7788,8 @@ __global__ void fused_mrope_rms_kv_kernel(const T* qkv,
                                           int x                    = 0,
                                           int rotary_dim           = 0,
                                           int64_t k_block_stride   = 0,
-                                          int64_t v_block_stride   = 0)
+                                          int64_t v_block_stride   = 0,
+                                          bool gemma_norm          = false)
 {
     constexpr int VEC_SIZE        = HEAD_SIZE / WARP_SIZE;
     constexpr int HALF_HEAD_SIZE  = HEAD_SIZE / 2;
@@ -7880,7 +7886,7 @@ __global__ void fused_mrope_rms_kv_kernel(const T* qkv,
                     cos_sin_vec.load(&cos_sin[position_ * rotary_dim_ + access_id_in_head]);
                 }
             }
-            warp_rms_norm_<T, VEC_SIZE>(x_vec, w_vec, HEAD_SIZE, eps);
+            warp_rms_norm_<T, VEC_SIZE>(x_vec, w_vec, HEAD_SIZE, eps, gemma_norm);
             if(in_rotary)
             {
                 const int rotary_neighbor_offset = access_id_in_head < half_rotary
@@ -7959,7 +7965,7 @@ __global__ void fused_mrope_rms_kv_kernel(const T* qkv,
                         &cos_sin[position_ * rotary_dim_ + access_id_in_head / 2 + half_rotary]);
                 }
             }
-            warp_rms_norm_<T, VEC_SIZE>(x_vec, w_vec, HEAD_SIZE, eps);
+            warp_rms_norm_<T, VEC_SIZE>(x_vec, w_vec, HEAD_SIZE, eps, gemma_norm);
             if(in_rotary)
             {
 #pragma unroll
@@ -8116,7 +8122,8 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             bool use_shuffle_layout  = false,
                             int64_t block_size       = 0,
                             int64_t x                = 0,
-                            int64_t rotary_dim       = 0)
+                            int64_t rotary_dim       = 0,
+                            bool gemma_norm          = false)
 {
     TORCH_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
     auto dim           = std::accumulate(mrope_section.begin(), mrope_section.end(), 0);
@@ -8162,7 +8169,10 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         use_shuffle_layout,          \
                                                         block_size,                  \
                                                         x,                           \
-                                                        (int)rotary_dim);            \
+                                                        (int)rotary_dim,             \
+                                                        (int64_t)0,                  \
+                                                        (int64_t)0,                  \
+                                                        gemma_norm);                 \
     }                                                                                \
     else                                                                             \
     {                                                                                \
@@ -8192,7 +8202,10 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         use_shuffle_layout,          \
                                                         block_size,                  \
                                                         x,                           \
-                                                        (int)rotary_dim);            \
+                                                        (int)rotary_dim,             \
+                                                        (int64_t)0,                  \
+                                                        (int64_t)0,                  \
+                                                        gemma_norm);                 \
     }
 
     if(is_interleaved)

--- a/op_tests/test_fused_qk_norm_mrope_cache_quant.py
+++ b/op_tests/test_fused_qk_norm_mrope_cache_quant.py
@@ -21,6 +21,14 @@ def rms_norm_forward(x: Tensor, weight: Tensor, eps: float):
     return weight * x
 
 
+def gemma_rms_norm_forward(x: Tensor, weight: Tensor, eps: float):
+    input_dtype = x.dtype
+    variance = x.float().pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    x = x.to(input_dtype)
+    return (1.0 + weight) * x
+
+
 def apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.Tensor:
     """Apply interleaved MRoPE to 3D rotary embeddings.
     Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
@@ -192,6 +200,7 @@ def run_torch_mrope_3d_rms_set_kv_shuffle(
     use_shuffle_layout: bool = False,  # Whether to use shuffle layout
     page_size: int = 0,  # Page size (block_size) for shuffle layout
     rotary_dim: int = 0,  # Partial rotary dim (0 = full rotary = head_size)
+    gemma_norm: bool = False,
 ):
     rotary_dim_ = rotary_dim if rotary_dim > 0 else head_size
     q_size = num_heads_q * head_size
@@ -201,11 +210,12 @@ def run_torch_mrope_3d_rms_set_kv_shuffle(
     q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
 
     q_by_head = q.view(num_tokens, num_heads_q, head_size)
-    q_by_head = rms_norm_forward(q_by_head, qw, eps)
+    norm_fn = gemma_rms_norm_forward if gemma_norm else rms_norm_forward
+    q_by_head = norm_fn(q_by_head, qw, eps)
     q = q_by_head.view(q.shape)
 
     k_by_head = k.view(num_tokens, num_heads_k, head_size)
-    k_by_head = rms_norm_forward(k_by_head, kw, eps)
+    k_by_head = norm_fn(k_by_head, kw, eps)
     k = k_by_head.view(k.shape)
 
     # Infer max_positions from cos_sin shape
@@ -336,6 +346,7 @@ def run_fused_mrope_3d_rms_set_kv_shuffle(
     use_shuffle_layout: bool = False,  # Whether to use shuffle layout
     page_size: int = 0,  # Page size (block_size) for shuffle layout
     rotary_dim: int = 0,  # Partial rotary dim (0 = full rotary = head_size)
+    gemma_norm: bool = False,
 ):
     # qkv = qkv.clone()  # inplace op
     # Calculate x for shuffle layout: x = 16 // k_cache.element_size()
@@ -373,6 +384,7 @@ def run_fused_mrope_3d_rms_set_kv_shuffle(
             block_size,
             x,
             rotary_dim,
+            gemma_norm,
         )
     else:
         aiter.fused_qk_norm_rope_cache_pts_quant_shuffle(
@@ -424,6 +436,7 @@ def test_mrope_3d_rms_set_kv_shuffle(
     page_size=0,  # Page size (block_size) for shuffle layout
     max_positions=10000,
     rotary_dim=0,  # Partial rotary dim (0 = full rotary = head_size)
+    gemma_norm: bool = False,
 ):
     rotary_dim_ = rotary_dim if rotary_dim > 0 else head_size
     cos_sin_dim = rotary_dim_
@@ -543,6 +556,7 @@ def test_mrope_3d_rms_set_kv_shuffle(
         use_shuffle_layout,
         page_size,
         rotary_dim,
+        gemma_norm,
     )
     _, avg_cu = run_fused_mrope_3d_rms_set_kv_shuffle(
         qkv,
@@ -572,6 +586,7 @@ def test_mrope_3d_rms_set_kv_shuffle(
         use_shuffle_layout,
         page_size,
         rotary_dim,
+        gemma_norm,
     )
 
     info = f"dtype:{dtype}, kv_cache_dtype:{kv_cache_dtype}, num_tokens:{num_tokens}, num_heads_q:{num_heads_q}, num_heads_k:{num_heads_k}, num_heads_v:{num_heads_v}, head_size:{head_size}, is_neox_style:{is_neox_style}"
@@ -857,3 +872,47 @@ if __name__ == "__main__":
                                         max_positions=args.max_positions,
                                         rotary_dim=rotary_dim,
                                     )
+
+    # GemmaRMSNorm q_norm/k_norm tests (gemma_norm=True path).
+    # Exercises the (1 + gamma) weight in the fused kernel launch path, which is
+    # NOT covered by the loops above (they all default gemma_norm=False).
+    # Includes the exact Qwen3.6-35B-A3B full-attention layer config:
+    #   num_heads_q=16, num_kv=2, head_size=256, rotary_dim=64,
+    #   mrope_section=[11, 11, 10] (sum=32=rotary_dim/2), neox=True, interleaved=True.
+    print("\n=== GemmaRMSNorm (gemma_norm=True) MRoPE Tests ===", flush=True)
+    # (head_size, rotary_dim): mrope_section
+    gemma_mrope_sections = {
+        (256, 64): [11, 11, 10],  # Qwen3.6 full-attention layer
+        (128, 32): [4, 6, 6],
+    }
+    gemma_head_configs = [(16, 2), (8, 2)]  # (num_heads_q, num_kv_heads)
+    for kv_cache_dtype in args.kv_cache_dtypes:
+        for use_shuffle_layout in use_shuffle_layouts:
+            page_size_list = page_sizes if use_shuffle_layout else [0]
+            for page_size in page_size_list:
+                for num_token in args.token:
+                    for num_head_q, num_head_kv in gemma_head_configs:
+                        for (
+                            head_size,
+                            rotary_dim,
+                        ), mrope_sec in gemma_mrope_sections.items():
+                            test_mrope_3d_rms_set_kv_shuffle(
+                                args.dtype,
+                                num_token,
+                                num_head_q,
+                                num_head_kv,
+                                num_head_kv,
+                                head_size,
+                                True,  # is_neox_style (Qwen3.6 convention)
+                                mrope_sec,
+                                True,  # is_interleaved (Qwen3.6 convention)
+                                eps=1e-6,
+                                is_mrope=True,
+                                kv_cache_dtype=kv_cache_dtype,
+                                test_return_kv=True,
+                                use_shuffle_layout=use_shuffle_layout,
+                                page_size=page_size,
+                                max_positions=args.max_positions,
+                                rotary_dim=rotary_dim,
+                                gemma_norm=True,
+                            )


### PR DESCRIPTION

## Motivation

The fused_qk_norm_mrope fused op had two gaps that broke Qwen3.6-VL (hybrid GDN + full-attention, GemmaRMSNorm q/k norm) inference on RDNA4 (gfx1201):
fp8 KV cache written with the wrong encoding on gfx1201. is_fp8_ocp_arch() did not list gfx1200/gfx1201, so the kernel fell back to the FNUZ (e4m3fnuz, bias 8) path while the torch KV pool uses OCP e4m3fn (bias 7). The 1-bit exponent-bias difference makes every stored KV value read back exactly 2×, corrupting the cache and degenerating decode output.
No GemmaRMSNorm support in the fused op. The kernel only did standard RMSNorm, so models using GemmaRMSNorm (weight applied as (1 + γ)) for q_norm/k_norm could not use the fused decode path.

## Technical Details

csrc/include/aiter_enum.h — add gfx1200, gfx1201 to fp8_ocp_archs so is_fp8_ocp_arch() correctly selects the e4m3fn (OCP, bias 7) path on RDNA4. This is the root-cause fix for the fp8 2× bug. (Note: aiter/utility/dtypes.py already mapped gfx1201 → e4m3fn; this removes the C++/Python inconsistency.)
csrc/kernels/rope/rope_common.h — thread a new gemma_norm flag through the launch path; pass k_block_stride/v_block_stride explicitly at both launch sites so the added arg lines up correctly.
csrc/kernels/fused_qk_norm_mrope_cache_quant.cu — add the gemma_norm parameter; when enabled, apply the GemmaRMSNorm (1 + weight) scaling. fp8 branch dispatches on is_fp8_ocp_arch() (e4m3fn vs e4m3fnuz).
csrc/include/fused_qk_norm_mrope_cache_quant.h, csrc/include/rocm_ops.hpp, aiter/ops/fused_qk_norm_mrope_cache_quant.py — plumb the gemma_norm argument through the C++ signature, pybind registration, and Python wrapper.

## Test Plan

Extended op_tests/test_fused_qk_norm_mrope_cache_quant.py with an explicit gemma_norm=True test block (previously all cases defaulted to gemma_norm=False), sweeping:

dtype ∈ {bf16, fp8 (e4m3fn)}
shuffle ∈ {shuffled, non-shuffled} KV layout
head configs (num_heads, num_kv_heads) ∈ {(16, 2), (8, 2)}
MRoPE sections: (head_dim=256, rotary_dim=64) → [11,11,10] (Qwen3.6 full-attn) and (128, 32) → [4,6,6]
neox=True, interleaved=True
Reference path uses the torch GemmaRMSNorm + MRoPE + per-tensor fp8 quant, compared against the kernel via checkAllclose. Run:
python op_tests/test_fused_qk_norm_mrope_cache_quant.py

## Test Result
All new gemma_norm=True cases pass (bf16 and fp8, shuffled/non-shuffled, both head configs).

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
