### PR TITLE
Add QuickReduce RMSNorm fusion kernel

### DIFF
--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -71,9 +71,6 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.ca_comm: CustomAllreduce | None = None
         self.qr_comm = None
         self.symm_mem_comm = None
-        self._log_qr_rmsnorm_dispatch = (
-            os.environ.get("AITER_LOG_QR_RMSNORM_DISPATCH", "0") == "1"
-        )
         self._logged_qr_rmsnorm_dispatch = False
         # if use_torch_symm_mem and current_platform.is_cuda():
         #     self.symm_mem_comm = SymmMemCommunicator(
@@ -267,20 +264,6 @@ class CudaCommunicator(DeviceCommunicatorBase):
             and not qr_comm.disabled
             and qr_comm.should_quick_allreduce_rmsnorm(input_, res_inp_, weight_, n)
         ):
-            if (
-                self._log_qr_rmsnorm_dispatch
-                and not self._logged_qr_rmsnorm_dispatch
-                and is_global_first_rank()
-            ):
-                logger.info(
-                    "AITER_FUSED_QR_RMSNORM_DISPATCH selected: "
-                    "shape=%s hidden_dim=%d world_size=%d total_bytes=%d",
-                    tuple(input_.shape),
-                    n,
-                    self.world_size,
-                    total_bytes,
-                )
-                self._logged_qr_rmsnorm_dispatch = True
             out, res_out = qr_comm.quick_all_reduce_rmsnorm(
                 input_, res_inp_, weight_, eps, n
             )

--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -71,6 +71,10 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.ca_comm: CustomAllreduce | None = None
         self.qr_comm = None
         self.symm_mem_comm = None
+        self._log_qr_rmsnorm_dispatch = (
+            os.environ.get("AITER_LOG_QR_RMSNORM_DISPATCH", "0") == "1"
+        )
+        self._logged_qr_rmsnorm_dispatch = False
         # if use_torch_symm_mem and current_platform.is_cuda():
         #     self.symm_mem_comm = SymmMemCommunicator(
         #         group=self.cpu_group,
@@ -252,6 +256,38 @@ class CudaCommunicator(DeviceCommunicatorBase):
             if self._ar_1stage_override is not None
             else (total_bytes <= total_bytes_limit)
         )
+        qr_comm = self.qr_comm
+        if (
+            not use_1stage
+            and not use_general_path
+            and x_pad_to_multiple == 0
+            and input_n == n
+            and not gemma_norm
+            and qr_comm is not None
+            and not qr_comm.disabled
+            and qr_comm.should_quick_allreduce_rmsnorm(input_, res_inp_, weight_, n)
+        ):
+            if (
+                self._log_qr_rmsnorm_dispatch
+                and not self._logged_qr_rmsnorm_dispatch
+                and is_global_first_rank()
+            ):
+                logger.info(
+                    "AITER_FUSED_QR_RMSNORM_DISPATCH selected: "
+                    "shape=%s hidden_dim=%d world_size=%d total_bytes=%d",
+                    tuple(input_.shape),
+                    n,
+                    self.world_size,
+                    total_bytes,
+                )
+                self._logged_qr_rmsnorm_dispatch = True
+            out, res_out = qr_comm.quick_all_reduce_rmsnorm(
+                input_, res_inp_, weight_, eps, n
+            )
+            assert out is not None
+            assert res_out is not None
+            return out, res_out
+
         if (
             not use_general_path
             and can_use_custom_ar

--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -71,7 +71,6 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.ca_comm: CustomAllreduce | None = None
         self.qr_comm = None
         self.symm_mem_comm = None
-        self._logged_qr_rmsnorm_dispatch = False
         # if use_torch_symm_mem and current_platform.is_cuda():
         #     self.symm_mem_comm = SymmMemCommunicator(
         #         group=self.cpu_group,

--- a/aiter/dist/device_communicators/quick_all_reduce.py
+++ b/aiter/dist/device_communicators/quick_all_reduce.py
@@ -279,6 +279,51 @@ class QuickAllReduce:
         )
         return out
 
+    def should_quick_allreduce_rmsnorm(
+        self,
+        inp: torch.Tensor,
+        residual_inp: torch.Tensor,
+        weight: torch.Tensor,
+        hidden_dim: int,
+    ):
+        if not self.should_quick_allreduce(inp):
+            return False
+        if inp.dtype != residual_inp.dtype or inp.dtype != weight.dtype:
+            return False
+        if not is_weak_contiguous(residual_inp) or not is_weak_contiguous(weight):
+            return False
+        if weight.numel() != hidden_dim or inp.numel() % hidden_dim != 0:
+            return False
+
+        row_size = hidden_dim * inp.element_size()
+        tile_size = 32 * 1024
+        return row_size > 0 and row_size <= tile_size and tile_size % row_size == 0
+
+    def quick_all_reduce_rmsnorm(
+        self,
+        inp: torch.Tensor,
+        residual_inp: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float,
+        hidden_dim: int,
+    ):
+        """Performs QR allreduce fused with residual add and RMSNorm."""
+        out = torch.empty_like(inp)
+        residual_out = torch.empty_like(residual_inp)
+        ops.qr_all_reduce_rmsnorm(
+            self._ptr,
+            inp,
+            residual_inp,
+            residual_out,
+            out,
+            weight,
+            eps,
+            hidden_dim,
+            self.qr_quant_level.value,
+            self.use_fp16_kernels,
+        )
+        return out, residual_out
+
     def close(self):
         if not self.disabled and getattr(self, "_ptr", None):
             if ops is not None:

--- a/aiter/ops/quick_all_reduce.py
+++ b/aiter/ops/quick_all_reduce.py
@@ -31,6 +31,21 @@ def qr_all_reduce(
 
 
 @compile_ops("module_quick_all_reduce")
+def qr_all_reduce_rmsnorm(
+    fa: int,
+    inp: torch.Tensor,
+    residual_inp: torch.Tensor,
+    residual_out: torch.Tensor,
+    out: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    hidden_dim: int,
+    quant_level: int,
+    cast_bf2half: bool = False,
+) -> None: ...
+
+
+@compile_ops("module_quick_all_reduce")
 def qr_get_handle(fa: int) -> torch.Tensor: ...
 
 

--- a/csrc/include/quick_all_reduce.cuh
+++ b/csrc/include/quick_all_reduce.cuh
@@ -914,6 +914,273 @@ struct AllReduceTwoshot
     }
 };
 
+template <typename T>
+__quickreduce_device_inline__ float qr_to_float(T val);
+
+template <>
+__quickreduce_device_inline__ float qr_to_float<half>(half val)
+{
+    return __half2float(val);
+}
+
+template <>
+__quickreduce_device_inline__ float qr_to_float<__hip_bfloat16>(__hip_bfloat16 val)
+{
+    return __bfloat162float(val);
+}
+
+template <typename T>
+__quickreduce_device_inline__ T qr_from_float(float val);
+
+template <>
+__quickreduce_device_inline__ half qr_from_float<half>(float val)
+{
+    return __float2half(val);
+}
+
+template <>
+__quickreduce_device_inline__ __hip_bfloat16 qr_from_float<__hip_bfloat16>(float val)
+{
+    return __float2bfloat16(val);
+}
+
+// Twoshot QR with an add+RMSNorm epilogue. Unlike the plain QR epilogue,
+// RMSNorm is row-local, so the host launcher only dispatches this variant when
+// each hidden row fits evenly inside one QR tile. For Qwen3.5 hidden_dim=4096
+// bf16 rows, one 32 KiB QR tile contains four independent rows.
+template <typename T, typename CommT, class Codec, bool cast_bf2half = false>
+struct AllReduceTwoshotRMSNorm
+{
+    static_assert(sizeof(T) == 2);
+    static_assert(sizeof(CommT) == 2);
+
+    static constexpr int kWorldSize = Codec::kWorldSize;
+    static constexpr int kElemsPerAtom = sizeof(int32x4_t) / sizeof(T);
+
+    __device__ static void run(T const* __restrict__ input,
+                               T const* __restrict__ residual_inp,
+                               T* __restrict__ residual_out,
+                               T* __restrict__ output,
+                               T const* __restrict__ weight,
+                               float eps,
+                               uint32_t const N,
+                               uint32_t const hidden_dim,
+                               int const block,
+                               int const rank,
+                               uint8_t** __restrict__ buffer_list,
+                               uint32_t const data_offset,
+                               uint32_t flag_color,
+                               int64_t data_size_per_phase)
+    {
+        int thread           = threadIdx.x + threadIdx.y * kWavefront;
+        uint8_t* rank_buffer = buffer_list[rank];
+        Codec codec(thread, rank);
+        int block_id = blockIdx.x;
+        uint8_t* buffer_ptr[kWorldSize];
+        for(int i = 0; i < kWorldSize; ++i)
+        {
+            buffer_ptr[i] = buffer_list[i];
+        }
+
+        int32x4_t tA[kAtoms];
+        BufferResource src_buffer(const_cast<T*>(input), N * sizeof(T));
+        uint32_t src_offset = block * kTileSize + thread * sizeof(int32x4_t);
+
+        for(int i = 0; i < kAtoms; i++)
+        {
+            tA[i] = buffer_load_dwordx4(src_buffer.descriptor, src_offset, 0, 0);
+            src_offset += kAtomStride * sizeof(int32x4_t);
+            if constexpr(cast_bf2half)
+            {
+                const nv_bfloat162* bf_buf = reinterpret_cast<const nv_bfloat162*>(&tA[i]);
+                half2 half_buf[4];
+#pragma unroll
+                for(int j = 0; j < 4; ++j)
+                {
+                    float2 f    = __bfloat1622float2(bf_buf[j]);
+                    half_buf[j] = __float22half2_rn(f);
+                }
+                tA[i] = *reinterpret_cast<const int32x4_t*>(half_buf);
+            }
+        }
+
+        uint32_t comm_data0_offset = data_offset + block_id * Codec::kTransmittedTileSize;
+        uint32_t comm_data1_offset = data_size_per_phase + comm_data0_offset;
+
+        uint32_t comm_flags0_offset = block_id * (kWorldSize * sizeof(uint32_t));
+        uint32_t comm_flags1_offset = (data_offset / 2) + comm_flags0_offset;
+
+        for(int r = 0; r < kWorldSize; r++)
+        {
+            int32x4_t* send_buffer = reinterpret_cast<int32x4_t*>(
+                buffer_ptr[r] + comm_data0_offset + rank * Codec::kRankTransmittedTileSize);
+            codec.send(send_buffer, &tA[r * Codec::kRankAtoms]);
+        }
+
+        __syncthreads();
+        if(thread < kWorldSize)
+        {
+            int r              = thread;
+            uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_ptr[r] + comm_flags0_offset +
+                                                             rank * sizeof(uint32_t));
+            set_sync_flag(flag_ptr, flag_color);
+        }
+
+        int32x4_t tR[Codec::kRankAtoms] = {};
+        {
+            int32x4_t* recv_buffer = reinterpret_cast<int32x4_t*>(rank_buffer + comm_data0_offset);
+            uint32_t* flag_ptr     = reinterpret_cast<uint32_t*>(rank_buffer + comm_flags0_offset);
+
+            for(int r = 0; r < kWorldSize; r++)
+            {
+                if(thread == 0)
+                {
+                    wait_sync_flag(&flag_ptr[r], flag_color);
+                }
+                __syncthreads();
+
+                codec.recv(&recv_buffer, tA);
+
+                for(int i = 0; i < Codec::kRankAtoms; i++)
+                {
+                    packed_assign_add<CommT>(&tR[i], &tA[i]);
+                }
+            }
+        }
+
+        for(int r = 0; r < kWorldSize; r++)
+        {
+            int32x4_t* send_buffer = reinterpret_cast<int32x4_t*>(
+                buffer_ptr[r] + comm_data1_offset + rank * Codec::kRankTransmittedTileSize);
+            codec.send(send_buffer, tR);
+        }
+
+        __syncthreads();
+        if(thread < kWorldSize)
+        {
+            int r              = thread;
+            uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_ptr[r] + comm_flags1_offset +
+                                                             rank * sizeof(uint32_t));
+            set_sync_flag(flag_ptr, flag_color);
+        }
+
+        {
+            int32x4_t* recv_buffer = reinterpret_cast<int32x4_t*>(rank_buffer + comm_data1_offset);
+            uint32_t* flag_ptr     = reinterpret_cast<uint32_t*>(rank_buffer + comm_flags1_offset);
+
+            for(int r = 0; r < kWorldSize; r++)
+            {
+                if(thread == 0)
+                {
+                    wait_sync_flag(&flag_ptr[r], flag_color);
+                }
+                __syncthreads();
+
+                codec.recv(&recv_buffer, &tA[r * Codec::kRankAtoms]);
+            }
+        }
+
+        BufferResource residual_buffer(const_cast<T*>(residual_inp), N * sizeof(T));
+        BufferResource output_buffer(output, N * sizeof(T));
+        BufferResource residual_out_buffer(residual_out, N * sizeof(T));
+        BufferResource weight_buffer(const_cast<T*>(weight), hidden_dim * sizeof(T));
+
+        uint32_t const row_bytes = hidden_dim * sizeof(T);
+        uint32_t const rows_per_tile = kTileSize / row_bytes;
+        uint32_t const tile_offset = block * kTileSize;
+        uint32_t const num_rows = N / hidden_dim;
+
+        __shared__ float smem[kBlockSize];
+
+        for(uint32_t row_in_tile = 0; row_in_tile < rows_per_tile; ++row_in_tile)
+        {
+            uint32_t const global_row = block * rows_per_tile + row_in_tile;
+            bool const row_active = global_row < num_rows;
+            float thread_square_sum = 0.0f;
+
+            for(int i = 0; i < kAtoms; i++)
+            {
+                uint32_t byte_in_tile =
+                    thread * sizeof(int32x4_t) + i * kAtomStride * sizeof(int32x4_t);
+                if(byte_in_tile / row_bytes != row_in_tile)
+                {
+                    continue;
+                }
+                uint32_t byte_offset = tile_offset + byte_in_tile;
+                int32x4_t residual_atom =
+                    buffer_load_dwordx4(residual_buffer.descriptor, byte_offset, 0, 0);
+                CommT* ar_vals = reinterpret_cast<CommT*>(&tA[i]);
+                T* res_vals = reinterpret_cast<T*>(&residual_atom);
+#pragma unroll
+                for(int j = 0; j < kElemsPerAtom; j++)
+                {
+                    float x = row_active
+                                  ? qr_to_float<CommT>(ar_vals[j]) + qr_to_float<T>(res_vals[j])
+                                  : 0.0f;
+                    thread_square_sum += x * x;
+                }
+            }
+
+            smem[thread] = thread_square_sum;
+            __syncthreads();
+            for(int stride = kBlockSize / 2; stride > 0; stride >>= 1)
+            {
+                if(thread < stride)
+                {
+                    smem[thread] += smem[thread + stride];
+                }
+                __syncthreads();
+            }
+            float denom = rsqrtf(smem[0] / hidden_dim + eps);
+
+            if(row_active)
+            {
+                for(int i = 0; i < kAtoms; i++)
+                {
+                    uint32_t byte_in_tile =
+                        thread * sizeof(int32x4_t) + i * kAtomStride * sizeof(int32x4_t);
+                    if(byte_in_tile / row_bytes != row_in_tile)
+                    {
+                        continue;
+                    }
+                    uint32_t byte_offset = tile_offset + byte_in_tile;
+                    uint32_t weight_offset = byte_in_tile - row_in_tile * row_bytes;
+                    int32x4_t residual_atom =
+                        buffer_load_dwordx4(residual_buffer.descriptor, byte_offset, 0, 0);
+                    int32x4_t weight_atom =
+                        buffer_load_dwordx4(weight_buffer.descriptor, weight_offset, 0, 0);
+                    CommT* ar_vals = reinterpret_cast<CommT*>(&tA[i]);
+                    T* res_vals = reinterpret_cast<T*>(&residual_atom);
+                    T* weight_vals = reinterpret_cast<T*>(&weight_atom);
+                    int32x4_t residual_atom_out;
+                    int32x4_t output_atom;
+                    T* residual_pack = reinterpret_cast<T*>(&residual_atom_out);
+                    T* output_pack = reinterpret_cast<T*>(&output_atom);
+#pragma unroll
+                    for(int j = 0; j < kElemsPerAtom; j++)
+                    {
+                        float x = qr_to_float<CommT>(ar_vals[j]) + qr_to_float<T>(res_vals[j]);
+                        residual_pack[j] = qr_from_float<T>(x);
+                        output_pack[j] =
+                            qr_from_float<T>(x * qr_to_float<T>(weight_vals[j]) * denom);
+                    }
+                    buffer_store_dwordx4(residual_atom_out,
+                                         residual_out_buffer.descriptor,
+                                         byte_offset,
+                                         0,
+                                         0);
+                    buffer_store_dwordx4(output_atom,
+                                         output_buffer.descriptor,
+                                         byte_offset,
+                                         0,
+                                         0);
+                }
+            }
+            __syncthreads();
+        }
+    }
+};
+
 // from quickreduce.h
 #define HIP_CHECK(err)                                                                             \
     do                                                                                             \
@@ -957,6 +1224,51 @@ allreduce_prototype_twoshot(T const* A,
         flag_color++;
     }
     if (threadIdx.x == 0 && threadIdx.y == 0)
+        d_flag_color[blockIdx.x] = flag_color;
+}
+
+template <typename AllReduceKernel, typename T>
+__global__ __quickreduce_launch_bounds_two_shot__ static void
+allreduce_rmsnorm_prototype_twoshot(T const* A,
+                                    T const* residual_inp,
+                                    T* residual_out,
+                                    T* B,
+                                    T const* weight,
+                                    float eps,
+                                    uint32_t N,
+                                    uint32_t hidden_dim,
+                                    uint32_t num_blocks,
+                                    int rank,
+                                    uint8_t** dbuffer_list,
+                                    uint32_t data_offset,
+                                    uint32_t* d_flag_color,
+                                    int64_t data_size_per_phase)
+{
+    int block = blockIdx.x;
+    int grid  = gridDim.x;
+
+    uint32_t flag_color = d_flag_color[blockIdx.x];
+
+    while(block < num_blocks)
+    {
+        AllReduceKernel::run(A,
+                             residual_inp,
+                             residual_out,
+                             B,
+                             weight,
+                             eps,
+                             N,
+                             hidden_dim,
+                             block,
+                             rank,
+                             dbuffer_list,
+                             data_offset,
+                             flag_color,
+                             data_size_per_phase);
+        block += grid;
+        flag_color++;
+    }
+    if(threadIdx.x == 0 && threadIdx.y == 0)
         d_flag_color[blockIdx.x] = flag_color;
 }
 
@@ -1017,6 +1329,80 @@ allreduce_prototype_twoshot(T const* A,
                            data_offset,                                       \
                            d_flag_color,                                        \
                            this->kMaxProblemSize);                            \
+    }
+
+#define TWOSHOT_RMSNORM_DISPATCH(__codec)                                             \
+    if(world_size == 2)                                                               \
+    {                                                                                 \
+        using LineCodec       = __codec<CommT, 2>;                                    \
+        using AllReduceKernel = AllReduceTwoshotRMSNorm<T, CommT, LineCodec, cast_bf2half>; \
+        hipLaunchKernelGGL((allreduce_rmsnorm_prototype_twoshot<AllReduceKernel, T>), \
+                           dim3(grid),                                                \
+                           dim3(kBlockTwoShot),                                       \
+                           0,                                                         \
+                           stream,                                                    \
+                           A,                                                         \
+                           residual_inp,                                              \
+                           residual_out,                                              \
+                           B,                                                         \
+                           weight,                                                    \
+                           eps,                                                       \
+                           N,                                                         \
+                           hidden_dim,                                                \
+                           num_blocks,                                                \
+                           rank,                                                      \
+                           dbuffer_list,                                              \
+                           data_offset,                                               \
+                           d_flag_color,                                              \
+                           this->kMaxProblemSize);                                    \
+    }                                                                                 \
+    else if(world_size == 4)                                                          \
+    {                                                                                 \
+        using LineCodec       = __codec<CommT, 4>;                                    \
+        using AllReduceKernel = AllReduceTwoshotRMSNorm<T, CommT, LineCodec, cast_bf2half>; \
+        hipLaunchKernelGGL((allreduce_rmsnorm_prototype_twoshot<AllReduceKernel, T>), \
+                           dim3(grid),                                                \
+                           dim3(kBlockTwoShot),                                       \
+                           0,                                                         \
+                           stream,                                                    \
+                           A,                                                         \
+                           residual_inp,                                              \
+                           residual_out,                                              \
+                           B,                                                         \
+                           weight,                                                    \
+                           eps,                                                       \
+                           N,                                                         \
+                           hidden_dim,                                                \
+                           num_blocks,                                                \
+                           rank,                                                      \
+                           dbuffer_list,                                              \
+                           data_offset,                                               \
+                           d_flag_color,                                              \
+                           this->kMaxProblemSize);                                    \
+    }                                                                                 \
+    else if(world_size == 8)                                                          \
+    {                                                                                 \
+        using LineCodec       = __codec<CommT, 8>;                                    \
+        using AllReduceKernel = AllReduceTwoshotRMSNorm<T, CommT, LineCodec, cast_bf2half>; \
+        hipLaunchKernelGGL((allreduce_rmsnorm_prototype_twoshot<AllReduceKernel, T>), \
+                           dim3(grid),                                                \
+                           dim3(kBlockTwoShot),                                       \
+                           0,                                                         \
+                           stream,                                                    \
+                           A,                                                         \
+                           residual_inp,                                              \
+                           residual_out,                                              \
+                           B,                                                         \
+                           weight,                                                    \
+                           eps,                                                       \
+                           N,                                                         \
+                           hidden_dim,                                                \
+                           num_blocks,                                                \
+                           rank,                                                      \
+                           dbuffer_list,                                              \
+                           data_offset,                                               \
+                           d_flag_color,                                              \
+                           this->kMaxProblemSize);                                    \
     }
 
 // INT3 only retains good performance on TP2 (world_size == 2). On TP4/TP8 the
@@ -1204,6 +1590,50 @@ struct DeviceComms
         case QuickReduceQuantLevel::INT4: TWOSHOT_DISPATCH(CodecQ4) break;
         case QuickReduceQuantLevel::INT3: TWOSHOT_DISPATCH_TP2_ONLY(CodecQ3) break;
         default: TWOSHOT_DISPATCH(CodecFP) break;
+        }
+        HIP_CHECK(hipGetLastError());
+        // flag color advances on-device now (see kernel), no host rotation.
+    }
+
+    template <typename T, typename CommT = T, bool cast_bf2half = false>
+    void allreduce_rmsnorm(T const* A,
+                           T const* residual_inp,
+                           T* residual_out,
+                           T* B,
+                           T const* weight,
+                           float eps,
+                           uint32_t N,
+                           uint32_t hidden_dim,
+                           int quant_level,
+                           hipStream_t stream)
+    {
+        if(world_size != 2 && world_size != 4 && world_size != 8)
+        {
+            throw std::runtime_error("All Reduce not supported for world_size = " +
+                                     std::to_string(world_size));
+        }
+        uint32_t row_bytes = hidden_dim * sizeof(T);
+        if(row_bytes == 0 || row_bytes > kTileSize || kTileSize % row_bytes != 0)
+        {
+            throw std::runtime_error(
+                "QR fused RMSNorm requires hidden_dim * element_size to divide " +
+                std::to_string(kTileSize));
+        }
+        if(N % hidden_dim != 0)
+        {
+            throw std::runtime_error("QR fused RMSNorm requires numel divisible by hidden_dim");
+        }
+
+        uint32_t msg_size   = N * sizeof(T);
+        uint32_t num_blocks = divceil(msg_size, kTileSize);
+        uint32_t grid       = min(kMaxNumBlocks, num_blocks);
+        auto quant_level_   = static_cast<QuickReduceQuantLevel>(quant_level);
+        switch(quant_level_)
+        {
+        case QuickReduceQuantLevel::FP8: TWOSHOT_RMSNORM_DISPATCH(CodecFP8) break;
+        case QuickReduceQuantLevel::INT6: TWOSHOT_RMSNORM_DISPATCH(CodecQ6) break;
+        case QuickReduceQuantLevel::INT4: TWOSHOT_RMSNORM_DISPATCH(CodecQ4) break;
+        default: TWOSHOT_RMSNORM_DISPATCH(CodecFP) break;
         }
         HIP_CHECK(hipGetLastError());
         // flag color advances on-device now (see kernel), no host rotation.

--- a/csrc/include/quick_all_reduce.h
+++ b/csrc/include/quick_all_reduce.h
@@ -18,6 +18,16 @@ void qr_all_reduce(fptr_t _fa,
                    torch::Tensor& out,
                    int64_t quant_level,
                    bool cast_bf2half = false);
+void qr_all_reduce_rmsnorm(fptr_t _fa,
+                           torch::Tensor& inp,
+                           torch::Tensor& residual_inp,
+                           torch::Tensor& residual_out,
+                           torch::Tensor& out,
+                           torch::Tensor& weight,
+                           double eps,
+                           int64_t hidden_dim,
+                           int64_t quant_level,
+                           bool cast_bf2half = false);
 int64_t qr_max_size();
 
 } // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1645,6 +1645,21 @@ namespace py = pybind11;
           py::arg("out"),                                                                  \
           py::arg("quant_level"),                                                          \
           py::arg("cast_bf2half") = false);                                                \
+    m.def("qr_all_reduce_rmsnorm",                                                         \
+          &aiter::qr_all_reduce_rmsnorm,                                                    \
+          "qr_all_reduce_rmsnorm(int fa, Tensor inp, Tensor residual_inp, "                 \
+          "Tensor residual_out, Tensor out, Tensor weight, float eps, int hidden_dim, "     \
+          "int quant_level, bool cast_bf2half) -> ()",                                     \
+          py::arg("fa"),                                                                   \
+          py::arg("inp"),                                                                  \
+          py::arg("residual_inp"),                                                         \
+          py::arg("residual_out"),                                                         \
+          py::arg("out"),                                                                  \
+          py::arg("weight"),                                                               \
+          py::arg("eps"),                                                                  \
+          py::arg("hidden_dim"),                                                           \
+          py::arg("quant_level"),                                                          \
+          py::arg("cast_bf2half") = false);                                                \
     m.def("qr_get_handle", &aiter::qr_get_handle, "qr_get_handle(int fa)", py::arg("fa")); \
     m.def("qr_open_handles",                                                               \
           &aiter::qr_open_handles,                                                         \

--- a/csrc/kernels/quick_all_reduce.cu
+++ b/csrc/kernels/quick_all_reduce.cu
@@ -87,6 +87,60 @@ void qr_all_reduce(fptr_t _fa, torch::Tensor& inp,
   }
 }
 
+void qr_all_reduce_rmsnorm(fptr_t _fa, torch::Tensor& inp,
+                           torch::Tensor& residual_inp,
+                           torch::Tensor& residual_out, torch::Tensor& out,
+                           torch::Tensor& weight, double eps,
+                           int64_t hidden_dim, int64_t quant_level,
+                           bool cast_bf2half) {
+  auto fa = reinterpret_cast<DeviceComms*>(_fa);
+  const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
+  auto stream = at::hip::getCurrentHIPStream();
+
+  TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
+  TORCH_CHECK_EQ(inp.scalar_type(), residual_inp.scalar_type());
+  TORCH_CHECK_EQ(inp.scalar_type(), residual_out.scalar_type());
+  TORCH_CHECK_EQ(inp.scalar_type(), weight.scalar_type());
+  TORCH_CHECK_EQ(inp.numel(), out.numel());
+  TORCH_CHECK_EQ(inp.numel(), residual_inp.numel());
+  TORCH_CHECK_EQ(inp.numel(), residual_out.numel());
+  TORCH_CHECK_EQ(weight.numel(), hidden_dim);
+  TORCH_CHECK_GT(hidden_dim, 0);
+  TORCH_CHECK_EQ(inp.numel() % hidden_dim, 0);
+  TORCH_CHECK_LE(out.numel(), fa->kMaxProblemSize);
+
+  if (out.scalar_type() == at::ScalarType::Half) {
+    fa->allreduce_rmsnorm<half, half, false>(
+        reinterpret_cast<half*>(inp.data_ptr()),
+        reinterpret_cast<half*>(residual_inp.data_ptr()),
+        reinterpret_cast<half*>(residual_out.data_ptr()),
+        reinterpret_cast<half*>(out.data_ptr()),
+        reinterpret_cast<half*>(weight.data_ptr()), static_cast<float>(eps),
+        out.numel(), hidden_dim, quant_level, stream);
+  } else if (out.scalar_type() == at::ScalarType::BFloat16) {
+    if (cast_bf2half) {
+      fa->allreduce_rmsnorm<__hip_bfloat16, half, true>(
+          reinterpret_cast<__hip_bfloat16*>(inp.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(residual_inp.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(residual_out.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(out.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(weight.data_ptr()),
+          static_cast<float>(eps), out.numel(), hidden_dim, quant_level, stream);
+    } else {
+      fa->allreduce_rmsnorm<__hip_bfloat16, __hip_bfloat16, false>(
+          reinterpret_cast<__hip_bfloat16*>(inp.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(residual_inp.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(residual_out.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(out.data_ptr()),
+          reinterpret_cast<__hip_bfloat16*>(weight.data_ptr()),
+          static_cast<float>(eps), out.numel(), hidden_dim, quant_level, stream);
+    }
+  } else {
+    throw std::runtime_error(
+        "quick allreduce rmsnorm only supports float16 and bfloat16");
+  }
+}
+
 int64_t qr_max_size() {
   // The default is 2GB (2,147,483,648 bytes)
   return static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
@@ -101,6 +155,11 @@ int64_t qr_max_size() {
   // world_size == 2 kernel for it.
   #define INSTANTIATE_FOR_WORLDSIZE_TP2_ONLY(T, Codec, cast_bf2half)                \
     template struct AllReduceTwoshot<T, Codec<T, 2>, cast_bf2half>;
+
+  #define INSTANTIATE_RMSNORM_FOR_WORLDSIZE(T, CommT, Codec, cast_bf2half)          \
+    template struct AllReduceTwoshotRMSNorm<T, CommT, Codec<CommT, 2>, cast_bf2half>; \
+    template struct AllReduceTwoshotRMSNorm<T, CommT, Codec<CommT, 4>, cast_bf2half>; \
+    template struct AllReduceTwoshotRMSNorm<T, CommT, Codec<CommT, 8>, cast_bf2half>; \
 
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecFP, false)
 INSTANTIATE_FOR_WORLDSIZE(__hip_bfloat16, CodecQ4, false)
@@ -118,6 +177,20 @@ INSTANTIATE_FOR_WORLDSIZE(half, CodecQ4, false)
 INSTANTIATE_FOR_WORLDSIZE(half, CodecQ6, false)
 INSTANTIATE_FOR_WORLDSIZE(half, CodecFP8, false)
 INSTANTIATE_FOR_WORLDSIZE_TP2_ONLY(half, CodecQ3, false)
+
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, __hip_bfloat16, CodecFP, false)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, __hip_bfloat16, CodecQ4, false)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, __hip_bfloat16, CodecQ6, false)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, __hip_bfloat16, CodecFP8, false)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, half, CodecFP, true)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, half, CodecQ4, true)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, half, CodecQ6, true)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(__hip_bfloat16, half, CodecFP8, true)
+
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(half, half, CodecFP, false)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(half, half, CodecQ4, false)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(half, half, CodecQ6, false)
+INSTANTIATE_RMSNORM_FOR_WORLDSIZE(half, half, CodecFP8, false)
 
 #endif  // USE_ROCM
 } // namespace aiter

--- a/op_tests/multigpu_tests/test_quick_all_reduce_rmsnorm.py
+++ b/op_tests/multigpu_tests/test_quick_all_reduce_rmsnorm.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import multiprocessing as mp
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import aiter as ops
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+
+
+def _rmsnorm_reference(
+    allreduced: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    residual_out = allreduced + residual
+    variance = residual_out.float().pow(2).mean(dim=-1, keepdim=True)
+    out = residual_out.float() * torch.rsqrt(variance + eps) * weight.float()
+    return out.to(allreduced.dtype), residual_out.to(allreduced.dtype)
+
+
+def _qr_rmsnorm_worker(
+    rank: int,
+    world_size: int,
+    inputs: list[torch.Tensor],
+    residuals: list[torch.Tensor],
+    weight: torch.Tensor,
+    eps: float,
+    distributed_init_method: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    ptr = None
+    try:
+        dist.init_process_group(
+            backend="nccl",
+            init_method=distributed_init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        group = dist.new_group(list(range(world_size)), backend="nccl")
+
+        ptr = ops.init_custom_qr(rank, world_size, None)
+        handle = ops.qr_get_handle(ptr)
+        handles = [None] * world_size
+        dist.all_gather_object(handles, handle, group=group)
+        ops.qr_open_handles(ptr, handles)
+
+        inp = inputs[rank].to(device)
+        residual = residuals[rank].to(device)
+        weight = weight.to(device)
+        out = torch.empty_like(inp)
+        residual_out = torch.empty_like(residual)
+
+        # Align ranks before launching the custom IPC kernel.
+        dist.all_reduce(torch.zeros(1, device=device), group=group)
+        torch.cuda.synchronize()
+
+        ops.qr_all_reduce_rmsnorm(
+            ptr,
+            inp,
+            residual,
+            residual_out,
+            out,
+            weight,
+            eps,
+            inp.shape[-1],
+            0,  # QuickReduceRegime.FP
+            False,
+        )
+        torch.cuda.synchronize()
+        return out.cpu(), residual_out.cpu()
+    finally:
+        if ptr is not None:
+            ops.qr_destroy(ptr)
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        torch.cuda.empty_cache()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires at least 2 GPUs")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_qr_all_reduce_rmsnorm_matches_torch_reference(dtype: torch.dtype):
+    world_size = 2
+    hidden_dim = 4096
+    tokens = 256
+    eps = 1e-6
+
+    generator = torch.Generator().manual_seed(1234)
+    inputs = [
+        torch.randn((tokens, hidden_dim), dtype=dtype, generator=generator) * 0.1
+        for _ in range(world_size)
+    ]
+    residuals = [
+        torch.randn((tokens, hidden_dim), dtype=dtype, generator=generator) * 0.1
+        for _ in range(world_size)
+    ]
+    weight = torch.randn((hidden_dim,), dtype=dtype, generator=generator) * 0.1
+
+    allreduced = torch.stack(inputs).sum(dim=0)
+    refs = [
+        _rmsnorm_reference(allreduced, residuals[rank], weight, eps)
+        for rank in range(world_size)
+    ]
+
+    distributed_init_method = get_distributed_init_method(get_ip(), get_open_port())
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=world_size) as pool:
+        rets = [
+            pool.apply_async(
+                _qr_rmsnorm_worker,
+                args=(
+                    rank,
+                    world_size,
+                    inputs,
+                    residuals,
+                    weight,
+                    eps,
+                    distributed_init_method,
+                ),
+            )
+            for rank in range(world_size)
+        ]
+        results = [ret.get(timeout=120) for ret in rets]
+
+    rtol = 5e-3 if dtype == torch.float16 else 4e-2
+    atol = 5e-3 if dtype == torch.float16 else 4e-2
+    for (out, residual_out), (ref_out, ref_residual_out) in zip(results, refs):
+        torch.testing.assert_close(
+            residual_out.float(),
+            ref_residual_out.float(),
+            rtol=rtol,
+            atol=atol,
+        )
+        torch.testing.assert_close(
+            out.float(),
+            ref_out.float(),
+            rtol=rtol,
+            atol=atol,
+        )


### PR DESCRIPTION
## Motivation

The existing AITER fused all-reduce + RMSNorm path uses the custom all-reduce implementation instead of QuickReduce. QuickReduce is often the preferred all-reduce backend for larger tensors, such as those encountered in vLLM prefill.
This PR adds an AITER-native fused QuickReduce + RMSNorm API so downstream frameworks (e.g. vLLM) can keep all-reduce and RMSNorm fused while using QuickReduce for eligible shapes. 

## Technical Details

- Adds a QuickReduce two-shot all-reduce variant with a residual-add RMSNorm epilogue.
- Exposes the fused kernel through the QuickReduce C++/Python bindings as `qr_all_reduce_rmsnorm`.
- Adds Python-side QuickReduce helper methods for eligibility checking and dispatch.
- Routes eligible non-1stage `fused_allreduce_rmsnorm` calls through fused QuickReduce + RMSNorm while preserving the existing custom all-reduce path for 1-stage/decode cases and unsupported shapes.
- Falls back to existing behavior for unsupported dtypes, non-contiguous inputs, padded/Gemma norm cases, and row widths that do not divide the QR tile.

## Test Plan

Added a multi-GPU test for the new API:

`op_tests/multigpu_tests/test_quick_all_reduce_rmsnorm.py`

The test:
- Initializes AITER QuickReduce IPC handles directly.
- Calls `aiter.qr_all_reduce_rmsnorm(...)`.
- Compares both `out` and `residual_out` against a PyTorch reference using all-reduce + residual-add RMSNorm.
- Covers both `fp16` and `bf16`.
- Uses an eligible `256 x 4096` shape, where each row is 8 KiB and divides the 32 KiB QR tile.

```bash
> python3 -m pytest op_tests/multigpu_tests/test_quick_all_reduce_rmsnorm.py -q
2 passed in 51.09s
```

Downstream validation was also performed with vLLM and Qwen3.5 397B MoE on ROCm. A vLLM-side PR will be opened if this AITER change is accepted. Traces (ISL=8k, OSL=32, Conc=4) show that prefill picks up the new fused QR+RMSNorm kernel and runs approximately 2.7x faster, while decode continues to use the existing 1-stage fused custom all-reduce kernel.

* prefill baseline 
<img width="788" height="307" alt="baseline" src="https://github.com/user-attachments/assets/17526c41-e8b7-4525-84a8-ed05d0d57455" />
* prefill using this PR 
<img width="713" height="302" alt="qr_rmsnorm" src="https://github.com/user-attachments/assets/2ff2bca4-ad46-4ad9-a9cb-a8f03e186b4a" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Co-authored-by: Cursor

I have reviewed the implementation, validated that it addresses the intended prefill dispatch issue, and verified that quality of the downstream model outputs remain unaffected in my testing. I would still appreciate a careful review from someone with deeper C++/HIP kernel expertise, especially around the new native QuickReduce + RMSNorm implementation.