### PR TITLE
Add refactoring and fused GEMM benchmarks and configs

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
 import triton.language as tl
+import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
 from aiter.ops.triton.utils.gemm_config_utils import get_gemm_config
@@ -620,5 +621,9 @@ def _get_config(
             K,
             bounds=(4, 8, 16, 31, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192),
         )
-    else:
-        return get_gemm_config("GEMM-AFP4WFP4", M, N, K)
+    # The non-preshuffled mul_add path has its own gfx950 tuning: the shared
+    # GEMM-AFP4WFP4 config regresses this op's large-M (>256) shapes.
+    if arch_info.get_arch() == "gfx950":
+        return get_gemm_config("FUSED-GEMM-AFP4WFP4-MUL_ADD", M, N, K)
+    # Other arches keep the base config file for this family
+    return get_gemm_config("GEMM-AFP4WFP4", M, N, K)

--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-MUL_ADD-N=7168-K=256.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-MUL_ADD-N=7168-K=256.json
@@ -1,0 +1,74 @@
+{
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 6,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 2,
+    "num_warps": 4,
+    "num_stages": 3,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 2,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-MUL_ADD.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-MUL_ADD.json
@@ -1,0 +1,14 @@
+{
+  "any": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 2,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 32,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_a16w16.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_a16w16.py
@@ -9,25 +9,29 @@ from op_tests.triton_tests.gemm.basic.test_gemm_a8w8_blockscale import (
 from op_tests.triton_tests.gemm.basic.test_gemm_a16w16 import (
     generate_gemm_a16w16_inputs,
 )
-from op_tests.op_benchmarks.triton.utils.argparse import (
-    get_parser,
-    add_argparse_ff,
-    get_ff_args,
-)
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     print_vgpr,
     get_caller_name_no_ext,
 )
+from op_tests.op_benchmarks.triton.bench_fused_gemm_commons import (
+    metric_to_scalar,
+    parse_fused_args,
+    run_fused_benchmark,
+)
 
 block_shape = (128, 128)  # matches module-level `block_shape` in similar kernels
+
+dimension = ["M", "N8", "N16", "K"]
+kernel_name = "Fused A8W8 Blockscale + A16W16 GEMM"
+kernel_label = "fused_gemm_a8w8_blockscale_a16w16"
+shape = "(N8=512, N16=256, K=7168)"
 
 
 def bench_fn(M: int, N8: int, N16: int, K: int, metric: str, **kwargs):
     """
     Single-shape timing of the fused kernel via its public wrapper.
-    Shapes/dtypes/scale layouts match what the wrapper expects.
-    Output buffers are pre-allocated and passed in to keep allocation out of the timed
-    ``do_bench`` window.
+    Output buffers are pre-allocated and passed in to keep allocation out of the
+    timed ``do_bench`` window.
     """
     block_shape_n, block_shape_k = block_shape
     c_dtype = torch.bfloat16
@@ -53,10 +57,8 @@ def bench_fn(M: int, N8: int, N16: int, K: int, metric: str, **kwargs):
         output=True,
         bias=False,
     )
-    # flops
     flops = 2.0 * M * (N8 + N16) * K  # summed across the two fused outputs
-    # memory transfer: numel * element_size() per tensor keeps the formula
-    # correct if dtypes change later (e.g. e5m2 / fp16 outputs).
+    # bytes moved, summed as numel() * element_size() per tensor
     mem = (
         x_fp8.numel() * x_fp8.element_size()
         + w_fp8.numel() * w_fp8.element_size()
@@ -84,27 +86,15 @@ def bench_fn(M: int, N8: int, N16: int, K: int, metric: str, **kwargs):
         rep=100,
     )
 
-    # Return exactly one scalar depending on which metric is active
-    if metric == "time":
-        return ms
-    elif metric == "throughput":
-        tflops = flops / ms * 1e-9
-        return tflops
-    elif metric == "bandwidth":
-        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
-        return bandwidth
-    else:
-        raise ValueError("Unknown metric: " + metric)
+    return metric_to_scalar(metric, ms, flops, mem)
 
 
 def get_x_vals(args=None):
     """Default (M, N8, N16, K) benchmarking shapes for the fused kernel.
 
-    Analogous to ``utils.benchmark_utils.get_x_vals`` (which yields (M, N, K)
-    tuples), but specialized to the single shape family this fused op is tuned
-    for: the ``gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-A16W16-N8=512-N16=256-K=7168``
-    config. N8, N16 and K are fixed and only M is swept based on the buckets.
-    As in the shared helper, ``-M`` selects a single M.
+    Specialized to the single shape family that this fused op is tuned for: the
+    ``gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-A16W16-N8=512-N16=256-K=7168`` config.
+    N8, N16 and K are fixed and only M is swept, where ``-M`` selects a single M.
 
     The default M sweep hits every bucket of that dedicated config file -
     (M_LEQ_{8,16,32,64,128,256,1024,2048}) plus the ``any`` bucket (M=4096).
@@ -117,116 +107,24 @@ def get_x_vals(args=None):
     return [(m, n8, n16, k) for m in m_vals]
 
 
-def get_shape_benchmark_object(plot_name, args, x_names=None):
-    """Build the Benchmark object for the (M, N8, N16, K) shape sweep.
-
-    A similar metric/ylabel/style convention to
-    ``utils.benchmark_utils.get_shape_benchmark_object`` but that shared helper
-    cannot be reused as-is because it only models (M, N, K) or (B, M, N, K);
-    there are two independent output-N dims (N8 for the FP8 branch, N16 for the BF16 branch)
-    sharing M and K.
-
-    A 4-element ``--shape`` is therefore (M, N8, N16, K) here,
-    NOT the batched (B, M, N, K) that the shared helper / ``get_ff_args`` assume.
-    """
-    if x_names is None:
-        x_names = ["M", "N8", "N16", "K"]
-
-    if args.shape:
-        # enforce the fused 4-tuple here.
-        if len(args.shape) != 4:
-            raise ValueError(
-                f"--shape expects 4 ints (M N8 N16 K); "
-                f"got {len(args.shape)}: {args.shape}"
-            )
-        x_vals_list = [args.shape]
-    else:
-        x_vals_list = get_x_vals(args=args)
-
-    if args.metric == "time":
-        ylabel = "Time (ms)"
-    elif args.metric == "throughput":
-        ylabel = "Throughput (TFLOPS)"
-    elif args.metric == "bandwidth":
-        ylabel = "Bandwidth (GB/s)"
-    else:
-        raise NotImplementedError(f"{args.metric} is not supported")
-
-    evaluation_metric_to_unit = {
-        "throughput": "TFLOPS",
-        "time": "Time_(ms)",
-        "bandwidth": "Bandwidth_(GB/s)",
-    }
-    benchmark = triton.testing.Benchmark(
-        x_names=x_names,
-        x_vals=x_vals_list,
-        x_log=True,
-        y_log=True,
-        line_arg="unit",
-        line_vals=[evaluation_metric_to_unit[args.metric]],
-        line_names=[evaluation_metric_to_unit[args.metric]],
-        styles=[("green", "-")],
-        ylabel=ylabel,
-        plot_name=plot_name,
-        args={"metric": args.metric},
-    )
-    return benchmark
-
-
-def run_shape_benchmark(args):
-    """Runs a benchmark with given tensor shapes."""
-    benchmark = get_shape_benchmark_object(get_caller_name_no_ext(), args)
-
-    @triton.testing.perf_report([benchmark])
-    def bench_fused_gemm_a8w8_blockscale_a16w16(M, N8, N16, K, metric, **kwargs):
-        return bench_fn(M, N8, N16, K, metric)
-
-    bench_fused_gemm_a8w8_blockscale_a16w16.run(
-        save_path="." if args.o else None, print_data=True
-    )
-
-
-def run_benchmark(args, defaults):
-    assert not (args.shape and args.model) or not (
-        args.shape and args.M
-    ), "User can specify --shape or --model MODEL -M VAL exclusively"
-
-    # --model has no meaning here: the op is tuned for one fixed shape family
-    # (N8=512, N16=256, K=7168), not model-derived hidden/intermediate dims.
-    if args.model:  # TODO: add in --model argument (via run_model_benchmark())
-        raise NotImplementedError(
-            "--model is not supported for fused_gemm_a8w8_blockscale_a16w16; "
-            "it targets a single fixed shape family (N8=512, N16=256, K=7168). "
-            "Use --shape M N8 N16 K or -M."
-        )
-    else:
-        unsupported_args = ["fc1", "fc2", "no_glu", "tp", "layout"]
-        for arg in unsupported_args:
-            if getattr(args, arg, None) != getattr(defaults, arg, None):
-                raise Exception(
-                    f"Argument '{arg}' is not supported for "
-                    f"fused_gemm_a8w8_blockscale_a16w16."
-                )
-        run_shape_benchmark(args)
-
-
-def parse_args(args: list[str] | None = None):
-    parser = get_parser(kernel_name="Fused A8W8 Blockscale + A16W16 GEMM")
-    parser = add_argparse_ff(parser)
-    # get_ff_args destructures a 4-element --shape as (B, M, N, K); for this op
-    # --shape is (M, N8, N16, K), so the shape path reads args.shape directly
-    # and ignores that (B, M, N, K) mapping.
-    return get_ff_args(parser, args=args)
-
-
 def main(args: list[str] | None = None) -> None:
-    parsed_args, defaults = parse_args(args=args)
+    parsed_args, defaults = parse_fused_args(kernel_name, args=args)
+    plot_name = get_caller_name_no_ext()
+    run = lambda: run_fused_benchmark(  # noqa: E731
+        parsed_args,
+        defaults,
+        kernel_label,
+        shape,
+        dimension,
+        bench_fn,
+        get_x_vals,
+        plot_name,
+    )
     if parsed_args.print_vgpr:
         print("Retrieving VGPR usage for Triton kernels...")
-        fun = lambda: run_benchmark(parsed_args, defaults)  # noqa: E731
-        print_vgpr(fun, get_caller_name_no_ext())
+        print_vgpr(run, plot_name)
         return
-    run_benchmark(parsed_args, defaults)
+    run()
 
 
 if __name__ == "__main__":

--- a/op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py
@@ -1,0 +1,129 @@
+import torch
+import triton
+from aiter.ops.triton.gemm.fused.fused_gemm_a8w8_blockscale_mul_add import (
+    fused_gemm_a8w8_blockscale_mul_add,
+)
+from op_tests.triton_tests.gemm.basic.test_gemm_a8w8_blockscale import (
+    generate_gemm_a8w8_blockscale_inputs,
+)
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    print_vgpr,
+    get_caller_name_no_ext,
+)
+from op_tests.op_benchmarks.triton.bench_fused_gemm_commons import (
+    metric_to_scalar,
+    parse_fused_args,
+    run_fused_benchmark,
+    make_mul_add_ab,
+)
+
+block_shape = (128, 128)  # matches module-level `block_shape` in similar kernels
+
+dimension = ["M", "N", "K"]
+kernel_name = "Fused A8W8 Blockscale GEMM + mul_add"
+kernel_label = "fused_gemm_a8w8_blockscale_mul_add"
+shape = "(N=7168, K=256)"
+
+
+def bench_fn(M: int, N: int, K: int, metric: str, **kwargs):
+    """
+    Single-shape timing of the fused A8W8 blockscale GEMM + mul_add epilogue via
+    its public wrapper.
+
+    This is a SINGLE-output (M, N) GEMM:
+    ``out = a * (A@B-dequant) + b`` with ``fuse_type=0``. The default measured
+    case uses full (M, N) tensor operands for both ``a`` (mul) and ``b`` (add),
+    so the timed path exercises the two extra (M, N) epilogue reads.
+
+    Output buffer is pre-allocated and passed in to keep allocation out of the
+    timed ``do_bench`` window.
+    """
+    block_shape_n, block_shape_k = block_shape
+    c_dtype = torch.bfloat16
+
+    # GEMM inputs. ``output=True`` pre-allocates ``y`` of shape (M, N).
+    x, w, _, x_scales, _, w_scales, y = generate_gemm_a8w8_blockscale_inputs(
+        M,
+        N,
+        K,
+        block_shape_n,
+        block_shape_k,
+        dtype=c_dtype,
+        output=True,
+    )
+    # mul/add operands: full (M, N) tensors (default operand case).
+    a, b = make_mul_add_ab(M, N, c_dtype, a_kind="tensor", b_kind="tensor")
+
+    flops = 2.0 * M * N * K  # single fused output
+    # bytes moved, summed as numel() * element_size() per tensor; the (M, N)
+    # mul/add tensors and the output are all counted.
+    mem = (
+        x.numel() * x.element_size()
+        + w.numel() * w.element_size()
+        + x_scales.numel() * x_scales.element_size()
+        + w_scales.numel() * w_scales.element_size()
+        + (a.numel() * a.element_size() if isinstance(a, torch.Tensor) else 0)
+        + (b.numel() * b.element_size() if isinstance(b, torch.Tensor) else 0)
+        + y.numel() * y.element_size()
+    )
+
+    ms = triton.testing.do_bench(
+        lambda: fused_gemm_a8w8_blockscale_mul_add(  # noqa: E731
+            x,
+            w,
+            x_scales,
+            w_scales,
+            a,
+            b,
+            dtype=c_dtype,
+            y=y,
+            fuse_type=0,
+        ),
+        warmup=25,
+        rep=100,
+    )
+
+    return metric_to_scalar(metric, ms, flops, mem)
+
+
+def get_x_vals(args=None):
+    """Default (M, N, K) benchmarking shapes for the fused mul_add kernel.
+
+    This kernel routes through ``_get_config`` to the BASE
+    ``GEMM-A8W8_BLOCKSCALE`` config family (not a dedicated fused config). The
+    fixed family ``N=7168, K=256`` matches the kernel's unit test and the
+    ``gfx950-GEMM-A8W8_BLOCKSCALE-N=7168-K=256.json`` specialized config, where ``-M``
+    selects a single M.
+
+    The default M sweep covers small-M buckets plus the ``any`` bucket
+    """
+    n, k = 7168, 256
+    if args is not None and getattr(args, "M", None) is not None:
+        m_vals = [args.M]
+    else:
+        m_vals = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096]
+    return [(m, n, k) for m in m_vals]
+
+
+def main(args: list[str] | None = None) -> None:
+    parsed_args, defaults = parse_fused_args(kernel_name, args=args)
+    plot_name = get_caller_name_no_ext()
+    run = lambda: run_fused_benchmark(  # noqa: E731
+        parsed_args,
+        defaults,
+        kernel_label,
+        shape,
+        dimension,
+        bench_fn,
+        get_x_vals,
+        plot_name,
+    )
+    if parsed_args.print_vgpr:
+        print("Retrieving VGPR usage for Triton kernels...")
+        print_vgpr(run, plot_name)
+        return
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py
@@ -1,4 +1,3 @@
-import sys
 import torch
 import triton
 from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_a16w16 import (
@@ -10,34 +9,32 @@ from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import (
 from op_tests.triton_tests.gemm.basic.test_gemm_a16w16 import (
     generate_gemm_a16w16_inputs,
 )
-from op_tests.op_benchmarks.triton.utils.argparse import (
-    get_parser,
-    add_argparse_ff,
-    get_ff_args,
-)
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     print_vgpr,
     get_caller_name_no_ext,
 )
+from op_tests.op_benchmarks.triton.bench_fused_gemm_commons import (
+    metric_to_scalar,
+    parse_fused_args,
+    run_fused_benchmark,
+)
+
+dimension = ["M", "N4", "N16", "K"]
+kernel_name = "Fused AFP4WFP4 + A16W16 GEMM"
+kernel_label = "fused_gemm_afp4wfp4_a16w16"
+shape = "(N4=512, N16=256, K=7168)"
 
 
 def bench_fn(M: int, N4: int, N16: int, K: int, metric: str, **kwargs):
     """
     Single-shape timing of the fused AFP4WFP4 + A16W16 kernel via its public wrapper.
 
-    Scope (intentional): this benchmark exercises the **non-preshuffled, no-bias**
-    FP4 path (``is_fp4_preshuffled=False``, ``bias_fp4=None``, ``bias_bf16=None``),
-    which is the path that maps to the shape-scoped config
-    ``gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json``. It deliberately
-    does NOT cover the wrapper's default preshuffled path
-    (``is_fp4_preshuffled=True`` -> ``FUSED-GEMM-AFP4WFP4_PRESHUFFLED-A16W16``) nor
-    the biased BF16 gating variant.
+    Scope (intentional for tuning): exercises the
+    **non-preshuffled, no-bias** FP4 path, which maps to the shape-scoped config
+    ``gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json``.
 
-    Note on K: ``--shape`` K is the *logical* K (e.g. 7168). The FP4 generator packs
-    two e2m1 values per byte, so ``x_fp4`` has K//2 columns; the wrapper's
-    ``_get_config`` rebuilds the config filename with ``2*K`` (= logical K), so
-    passing 7168 here is what selects the shape-scoped config file. Passing the
-    packed value (3584) would fall back to the generic ``any`` config.
+    Note on K: ``--shape`` K is the logical K (e.g. 7168). The FP4 generator
+    packs two e2m1 values per byte, so ``x_fp4`` has K//2 columns.
 
     Output buffers are pre-allocated and passed in to keep allocation out of the
     timed ``do_bench`` window.
@@ -47,15 +44,16 @@ def bench_fn(M: int, N4: int, N16: int, K: int, metric: str, **kwargs):
     # FP4 branch (non-preshuffled). ``output=True`` pre-allocates ``y_fp4``. With
     # shuffles off the ``_triton`` returns equal the plain ones; we pass the
     # ``_triton`` set to mirror the test's wrapper call exactly.
+    # Therefore ``w_fp4`` / scale returns are unused here.
     (
         x_fp4,
-        w_fp4,
+        _,
         w_fp4_triton,
-        x_fp4_scale,
-        w_fp4_scale,
+        _,
+        _,
         x_fp4_scale_triton,
         w_fp4_scale_triton,
-        _out_dtype,
+        _,
         y_fp4,
     ) = generate_gemm_afp4wfp4_inputs(
         M,
@@ -76,10 +74,8 @@ def bench_fn(M: int, N4: int, N16: int, K: int, metric: str, **kwargs):
         output=True,
         bias=False,
     )
-    # flops
     flops = 2.0 * M * (N4 + N16) * K  # summed across the two fused outputs
-    # memory transfer: numel * element_size() per tensor keeps the formula
-    # correct if dtypes change later (e.g. fp16 outputs).
+    # bytes moved, summed as numel() * element_size() per tensor.
     mem = (
         x_fp4.numel() * x_fp4.element_size()
         + w_fp4_triton.numel() * w_fp4_triton.element_size()
@@ -108,31 +104,18 @@ def bench_fn(M: int, N4: int, N16: int, K: int, metric: str, **kwargs):
         rep=100,
     )
 
-    # Return exactly one scalar depending on which metric is active
-    if metric == "time":
-        return ms
-    elif metric == "throughput":
-        tflops = flops / ms * 1e-9
-        return tflops
-    elif metric == "bandwidth":
-        bandwidth = mem / (ms * 1e-3) * 1e-9  # GB/s
-        return bandwidth
-    else:
-        raise ValueError("Unknown metric: " + metric)
+    return metric_to_scalar(metric, ms, flops, mem)
 
 
 def get_x_vals(args=None):
     """Default (M, N4, N16, K) benchmarking shapes for the fused kernel.
 
-    Specialized to the single shape family this fused op is tuned for: the
-    ``gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168`` config. N4, N16
-    and K are fixed and only M is swept. As in the shared helper, ``-M`` selects
-    a single M.
+    Specialized to ``gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168``.
+    N4, N16 and K are fixed and only M is swept, where ``-M`` selects a single M.
 
     The default M sweep hits every explicit bucket of that config
     (M_LEQ_{8,16,32,64,128,256}) plus the ``any`` bucket sampled at
-    M in {1024, 4096, 8192}. (This config has no M_LEQ_1024/2048 buckets, so all
-    M > 256 resolve to ``any``.)
+    M in {1024, 4096, 8192}.
     """
     n4, n16, k = 512, 256, 7168
     if args is not None and getattr(args, "M", None) is not None:
@@ -142,113 +125,25 @@ def get_x_vals(args=None):
     return [(m, n4, n16, k) for m in m_vals]
 
 
-def get_shape_benchmark_object(plot_name, args, x_names=None):
-    """Build the Benchmark object for the (M, N4, N16, K) shape sweep.
-
-    There are two independent output-N dims (N4 for the FP4 branch, N16 for the
-    BF16 branch) sharing M and K, so a 4-element ``--shape`` is (M, N4, N16, K)
-    here, NOT the batched (B, M, N, K) that the shared helper / ``get_ff_args``
-    assume.
-    """
-    if x_names is None:
-        x_names = ["M", "N4", "N16", "K"]
-
-    if args.shape:
-        # enforce the fused 4-tuple here.
-        if len(args.shape) != 4:
-            raise ValueError(
-                f"--shape expects 4 ints (M N4 N16 K); "
-                f"got {len(args.shape)}: {args.shape}"
-            )
-        x_vals_list = [args.shape]
-    else:
-        x_vals_list = get_x_vals(args=args)
-
-    if args.metric == "time":
-        ylabel = "Time (ms)"
-    elif args.metric == "throughput":
-        ylabel = "Throughput (TFLOPS)"
-    elif args.metric == "bandwidth":
-        ylabel = "Bandwidth (GB/s)"
-    else:
-        raise NotImplementedError(f"{args.metric} is not supported")
-
-    evaluation_metric_to_unit = {
-        "throughput": "TFLOPS",
-        "time": "Time_(ms)",
-        "bandwidth": "Bandwidth_(GB/s)",
-    }
-    benchmark = triton.testing.Benchmark(
-        x_names=x_names,
-        x_vals=x_vals_list,
-        x_log=True,
-        y_log=True,
-        line_arg="unit",
-        line_vals=[evaluation_metric_to_unit[args.metric]],
-        line_names=[evaluation_metric_to_unit[args.metric]],
-        styles=[("green", "-")],
-        ylabel=ylabel,
-        plot_name=plot_name,
-        args={"metric": args.metric},
-    )
-    return benchmark
-
-
-def run_shape_benchmark(args):
-    """Runs a benchmark with given tensor shapes."""
-    benchmark = get_shape_benchmark_object(get_caller_name_no_ext(), args)
-
-    @triton.testing.perf_report([benchmark])
-    def bench_fused_gemm_afp4wfp4_a16w16(M, N4, N16, K, metric, **kwargs):
-        return bench_fn(M, N4, N16, K, metric)
-
-    bench_fused_gemm_afp4wfp4_a16w16.run(
-        save_path="." if args.o else None, print_data=True
-    )
-
-
-def run_benchmark(args, defaults):
-    assert not (args.shape and args.model) or not (
-        args.shape and args.M
-    ), "User can specify --shape or --model MODEL -M VAL exclusively"
-
-    # --model has no meaning here: the op is tuned for one fixed shape family
-    # (N4=512, N16=256, K=7168), not model-derived hidden/intermediate dims.
-    if args.model:  # TODO: add in --model argument (via run_model_benchmark())
-        raise NotImplementedError(
-            "--model is not supported for fused_gemm_afp4wfp4_a16w16; "
-            "it targets a single fixed shape family (N4=512, N16=256, K=7168). "
-            "Use --shape M N4 N16 K or -M."
-        )
-    else:
-        unsupported_args = ["fc1", "fc2", "no_glu", "tp", "layout"]
-        for arg in unsupported_args:
-            if getattr(args, arg, None) != getattr(defaults, arg, None):
-                raise Exception(
-                    f"Argument '{arg}' is not supported for "
-                    f"fused_gemm_afp4wfp4_a16w16."
-                )
-        run_shape_benchmark(args)
-
-
-def parse_args(args: list[str] | None = None):
-    parser = get_parser(kernel_name="Fused AFP4WFP4 + A16W16 GEMM")
-    parser = add_argparse_ff(parser)
-    # get_ff_args destructures a 4-element --shape as (B, M, N, K); for this op
-    # --shape is (M, N4, N16, K), so the shape path reads args.shape directly
-    # and ignores that (B, M, N, K) mapping.
-    return get_ff_args(parser, args=args)
-
-
 def main(args: list[str] | None = None) -> None:
-    parsed_args, defaults = parse_args(args=args)
+    parsed_args, defaults = parse_fused_args(kernel_name, args=args)
+    plot_name = get_caller_name_no_ext()
+    run = lambda: run_fused_benchmark(  # noqa: E731
+        parsed_args,
+        defaults,
+        kernel_label,
+        shape,
+        dimension,
+        bench_fn,
+        get_x_vals,
+        plot_name,
+    )
     if parsed_args.print_vgpr:
         print("Retrieving VGPR usage for Triton kernels...")
-        fun = lambda: run_benchmark(parsed_args, defaults)  # noqa: E731
-        print_vgpr(fun, get_caller_name_no_ext())
+        print_vgpr(run, plot_name)
         return
-    run_benchmark(parsed_args, defaults)
+    run()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py
@@ -1,0 +1,147 @@
+import torch
+import triton
+from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_mul_add import (
+    fused_gemm_afp4wfp4_mul_add,
+)
+from op_tests.triton_tests.gemm.basic.test_gemm_afp4wfp4 import (
+    generate_gemm_afp4wfp4_inputs,
+)
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
+    print_vgpr,
+    get_caller_name_no_ext,
+)
+from op_tests.op_benchmarks.triton.bench_fused_gemm_commons import (
+    metric_to_scalar,
+    parse_fused_args,
+    run_fused_benchmark,
+    make_mul_add_ab,
+)
+
+dimension = ["M", "N", "K"]
+kernel_name = "Fused AFP4WFP4 GEMM + mul_add"
+kernel_label = "fused_gemm_afp4wfp4_mul_add"
+shape = "(N=7168, K=256)"
+
+
+def bench_fn(M: int, N: int, K: int, metric: str, **kwargs):
+    """
+    Single-shape timing of the fused AFP4WFP4 GEMM + mul_add via its
+    public wrapper.
+
+    This is a SINGLE-output (M, N) MXFP4 GEMM: ``out = a * (X @ W^T) + b`` with
+    ``fuse_type=0``. The default measured case uses full (M, N) tensor operands
+    for both ``a`` (mul) and ``b`` (add), so the timed path exercises the two
+    extra (M, N) epilogue reads.
+
+    Scope (intentional): the **non-preshuffled** FP4 path (``shuffle_*_fg=False``
+    -> ``fused_gemm_afp4wfp4_mul_add``), which routes to the base
+    ``GEMM-AFP4WFP4`` config family.
+
+    Note on K: ``--shape`` K is the *logical* K (e.g. 256). The FP4 generator
+    packs two e2m1 values per byte, so ``x_fp4`` has K//2 columns.
+
+    Output buffer is pre-allocated and passed in to keep allocation out of the
+    timed ``do_bench`` window.
+    """
+    c_dtype = torch.bfloat16
+
+    # FP4 branch (non-preshuffled). ``output=True`` pre-allocates ``y_fp4``. With
+    # shuffles off the ``_triton`` returns equal the plain ones; we pass the
+    # ``_triton`` set to mirror the test's wrapper call exactly, so the plain
+    # ``w`` / scale returns are unused here.
+    (
+        x_fp4,
+        _,
+        w_fp4_triton,
+        _,
+        _,
+        x_fp4_scale_triton,
+        w_fp4_scale_triton,
+        _,
+        y_fp4,
+    ) = generate_gemm_afp4wfp4_inputs(
+        M,
+        N,
+        K,
+        c_dtype,
+        layout="TN",
+        output=True,
+        shuffle_scales_fg=False,
+        shuffle_weight_fg=False,
+    )
+    # mul/add operands: full (M, N) tensors (default operand case).
+    a, b = make_mul_add_ab(M, N, c_dtype, a_kind="tensor", b_kind="tensor")
+
+    flops = 2.0 * M * N * K  # single fused output
+    # bytes moved, summed as numel() * element_size() per tensor; the (M, N)
+    # mul/add tensors and the output are all counted.
+    mem = (
+        x_fp4.numel() * x_fp4.element_size()
+        + w_fp4_triton.numel() * w_fp4_triton.element_size()
+        + x_fp4_scale_triton.numel() * x_fp4_scale_triton.element_size()
+        + w_fp4_scale_triton.numel() * w_fp4_scale_triton.element_size()
+        + (a.numel() * a.element_size() if isinstance(a, torch.Tensor) else 0)
+        + (b.numel() * b.element_size() if isinstance(b, torch.Tensor) else 0)
+        + y_fp4.numel() * y_fp4.element_size()
+    )
+
+    ms = triton.testing.do_bench(
+        lambda: fused_gemm_afp4wfp4_mul_add(  # noqa: E731
+            x_fp4,
+            w_fp4_triton,
+            x_fp4_scale_triton,
+            w_fp4_scale_triton,
+            a,
+            b,
+            dtype=c_dtype,
+            y=y_fp4,
+            fuse_type=0,
+        ),
+        warmup=25,
+        rep=100,
+    )
+
+    return metric_to_scalar(metric, ms, flops, mem)
+
+
+def get_x_vals(args=None):
+    """Default (M, N, K) benchmarking shapes for the fused mul_add kernel.
+
+    This kernel routes through ``_get_config`` to the base ``GEMM-AFP4WFP4``
+    config family. The fixed family ``N=7168, K=256`` matches the kernel's unit
+    test and the ``gfx950-GEMM-AFP4WFP4-N=7168-K=256.json`` specialized config.
+    ``-M`` selects a single M.
+
+    The default M sweep covers small-M buckets plus the ``any`` bucket. M=1 is
+    included here (the afp4wfp4 mul_add unit test exercises M=1 cleanly).
+    """
+    n, k = 7168, 256
+    if args is not None and getattr(args, "M", None) is not None:
+        m_vals = [args.M]
+    else:
+        m_vals = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096]
+    return [(m, n, k) for m in m_vals]
+
+
+def main(args: list[str] | None = None) -> None:
+    parsed_args, defaults = parse_fused_args(kernel_name, args=args)
+    plot_name = get_caller_name_no_ext()
+    run = lambda: run_fused_benchmark(  # noqa: E731
+        parsed_args,
+        defaults,
+        kernel_label,
+        shape,
+        dimension,
+        bench_fn,
+        get_x_vals,
+        plot_name,
+    )
+    if parsed_args.print_vgpr:
+        print("Retrieving VGPR usage for Triton kernels...")
+        print_vgpr(run, plot_name)
+        return
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/op_benchmarks/triton/bench_fused_gemm_commons.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_gemm_commons.py
@@ -1,0 +1,136 @@
+import torch
+import triton
+
+from op_tests.op_benchmarks.triton.utils.argparse import (
+    get_parser,
+    add_argparse_ff,
+    get_ff_args,
+)
+from op_tests.triton_tests.fusions.test_fused_mul_add import (
+    generate_fused_mul_add_inputs,
+)
+
+eval_metrics_to_units = {
+    "throughput": "TFLOPS",
+    "time": "Time_(ms)",
+    "bandwidth": "Bandwidth_(GB/s)",
+}
+
+default_unused_args = ("fc1", "fc2", "no_glu", "tp", "layout")
+
+
+def metric_to_scalar(metric, ms, flops, mem):
+    """Return the single scalar for the active metric."""
+    if metric == "time":
+        return ms
+    elif metric == "throughput":
+        return flops / ms * 1e-9  # TFLOPS
+    elif metric == "bandwidth":
+        return mem / (ms * 1e-3) * 1e-9  # GB/s
+    raise ValueError("Unknown metric: " + metric)
+
+
+def parse_fused_args(kernel_name, args=None):
+    """Build the standard FF parser and return (parsed_args, defaults).
+
+    get_ff_args destructures a 4-element --shape as (B, M, N, K); the fused
+    benches read args.shape directly, so that mapping is unused here.
+    """
+    parser = get_parser(kernel_name=kernel_name)
+    parser = add_argparse_ff(parser)
+    return get_ff_args(parser, args=args)
+
+
+def get_fused_shape_benchmark_object(plot_name, args, x_names, get_x_vals):
+    """triton.testing.Benchmark for a fused shape sweep with len(x_names) dims.
+
+    Unlike benchmark_utils.get_shape_benchmark_object (which models (M, N, K) /
+    (B, M, N, K)), this enforces an exact len(x_names)-tuple --shape and does NOT
+    apply the (B, M, N, K) remapping: a 4-tuple here is (M, N8, N16, K), etc.
+    """
+    if args.shape:
+        if len(args.shape) != len(x_names):
+            raise ValueError(
+                f"--shape expects {len(x_names)} ints "
+                f"({' '.join(x_names)}); got {len(args.shape)}: {args.shape}"
+            )
+        x_vals_list = [args.shape]
+    else:
+        x_vals_list = get_x_vals(args=args)
+
+    if args.metric == "time":
+        ylabel = "Time (ms)"
+    elif args.metric == "throughput":
+        ylabel = "Throughput (TFLOPS)"
+    elif args.metric == "bandwidth":
+        ylabel = "Bandwidth (GB/s)"
+    else:
+        raise NotImplementedError(f"{args.metric} is not supported")
+
+    benchmark = triton.testing.Benchmark(
+        x_names=x_names,
+        x_vals=x_vals_list,
+        x_log=True,
+        y_log=True,
+        line_arg="unit",
+        line_vals=[eval_metrics_to_units[args.metric]],
+        line_names=[eval_metrics_to_units[args.metric]],
+        styles=[("green", "-")],
+        ylabel=ylabel,
+        plot_name=plot_name,
+        args={"metric": args.metric},
+    )
+    return benchmark
+
+
+def run_fused_shape_benchmark(args, x_names, bench_fn, get_x_vals, plot_name):
+    """Wrap bench_fn in a perf_report over the fused Benchmark object and run it."""
+    benchmark = get_fused_shape_benchmark_object(plot_name, args, x_names, get_x_vals)
+
+    @triton.testing.perf_report([benchmark])
+    def _run(**kwargs):
+        shape = tuple(kwargs[name] for name in x_names)
+        return bench_fn(*shape, kwargs["metric"])
+
+    _run.run(save_path="." if args.o else None, print_data=True)
+
+
+def run_fused_benchmark(
+    args,
+    defaults,
+    kernel_label,
+    shape,
+    x_names,
+    bench_fn,
+    get_x_vals,
+    plot_name,
+    unsupported_args=default_unused_args,
+):
+    """Shared dispatcher: reject --model and unsupported FF args, else run sweep."""
+    assert not (args.shape and args.model) or not (
+        args.shape and args.M
+    ), "User can specify --shape or --model MODEL -M VAL exclusively"
+
+    # --model has no meaning here since we will not run models & single family shape
+    if args.model:
+        raise NotImplementedError(
+            f"--model is not supported for {kernel_label}; it targets a single "
+            f"fixed shape family {shape}. Use --shape "
+            f"{' '.join(x_names)} or -M."
+        )
+    for arg in unsupported_args:
+        if getattr(args, arg, None) != getattr(defaults, arg, None):
+            raise Exception(f"Argument '{arg}' is not supported for {kernel_label}.")
+    run_fused_shape_benchmark(args, x_names, bench_fn, get_x_vals, plot_name)
+
+
+def make_mul_add_ab(M, N, dtype, a_kind="tensor", b_kind="tensor"):
+    """Build the (a, b) mul/add operands for the fused mul_add benches.
+
+    a_kind/b_kind: "tensor" -> full (M, N) tensor; "scalar" -> python float scalar.
+    Delegates to the unit test's generator so bench inputs match the test exactly.
+    """
+    a_spec = (torch.Tensor, False) if a_kind == "tensor" else (float, True)
+    b_spec = (torch.Tensor, False) if b_kind == "tensor" else (float, True)
+    _, a, b = generate_fused_mul_add_inputs([M, N], a_spec, b_spec, dtype)
+    return a, b


### PR DESCRIPTION
## Motivation

This PR adds benchmark coverage and targeted gfx950 config routing for the fused GEMM mul_add kernels, while also refactoring the recently added fused GEMM benchmarks to share common benchmark infrastructure.

## Technical Details

### Refactoring
This PR adds a fused GEMM benchmark common helper: 

op_tests/op_benchmarks/triton/bench_fused_gemm_commons.py

The helper keeps the common fused GEMM benchmark pieces in one place, including: 
- metric conversion for `time`, `throughput`, and `bandwidth`
- fused shape benchmark object creation
- shared `run_fused_shape benchmark`
- shared `run_fused_benchmark`
- shared argument parsing helpers
- shared `main`/`print_vgpr` dispatch pattern

This reduces duplicated benchmark code while keeping operation-specific logic local to each benchmark. Tensor generation, wrappers, FLOP calculations, memory traffic, and shape-family definitions and specific dimensions remain in the individual benchmark files.

This PR refactors:
```bash
op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_a16w16.py
op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py
```

and adds:
```bash
op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py
op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py
```

### Benchmarks and Configs
The new `mul_add` benchmarks use the public wrappers and follow the shape convention: 
`--shape M N K`

For the default benchmark family: 
```bash
N = 7168
K = 256
```

The AFP4WFP4 `mul_add` path also adds gfx950 routing to the dedicated config family: 
`FUSED-GEMM-AFP4WFP4-MUL_ADD`

with configs: 
```bash
aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-MUL_ADD.json 
aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-MUL_ADD-N=7168-K=256.json
```

The specialized `N=7168-K=256` config fixes the previously observed stable large-M AFP4WFP4 `mul_add` regressions by routing the large-M `any` bucket to the tuned `128x128x256` tile instead of the slower base `256x64x128` tile.

### A8W8 blockscale MUL_ADD note
The A8W8 blockscale `mul_add` benchmark is added, but this PR does not add a dedicated A8W8 `mul_add` config. The A8W8 large-M regression investigation indicated that the faster tile miscompiles for the `fuse_type=1` path under TOT/Triton 3.7, while the safe tile is slower. Therefore the A8W8 issue is treated as a follow-up compiler/kernel investigation rather than a clean config-tuning win in this PR.

## Test Plan

Static checks:
```bash
python -m py_compile \ op_tests/op_benchmarks/triton/bench_fused_gemm_commons.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_a16w16.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py .

black --check \ op_tests/op_benchmarks/triton/bench_fused_gemm_commons.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_a16w16.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py \ aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py 

ruff check \ op_tests/op_benchmarks/triton/bench_fused_gemm_commons.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_a16w16.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py \ op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py \ aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_mul_add.py
```

Benchmark runs and correctness:
```bash
# rocprofv3
rocprofv3 --kernel-trace --stats -f csv -d /tmp/rp_out -o run -- \
  python op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py --shape 1024 7168 256 --metric time
# to see the necessary data
awk -F, 'NR==1 || /fused_gemm_afp4wfp4_mul_add/' /tmp/rp_out/run_kernel_stats.csv

# perf (do_bench smoke tests):
python op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py --metric time
python op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py --metric time

# correctness tests:
pytest op_tests/triton_tests/gemm/fused/test_fused_gemm_afp4wfp4_mul_add.py -v
pytest op_tests/triton_tests/gemm/fused/test_fused_gemm_a8w8_blockscale_mul_add.py -v

# with shape: 
python op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_mul_add.py \ 
--shape 16 7168 256 \ 
--metric time

# refactored benchmark sweeps: 
python op_tests/op_benchmarks/triton/bench_fused_gemm_afp4wfp4_a16w16.py --metric time 
python op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_a16w16.py --metric time
```

## Test Result for `FUSED_GEMM_AFP4WFP4_MUL_ADD`

| kernel | M | N | K | golden_runs_us | tot_runs_us | golden_us (median) | tot_us (median) | delta_us | delta_% | threshold_us | status |
|---|---|---|---|---|---|---|---|---|---|---|---|
| fused_gemm_afp4wfp4_mul_add | 1 | 7168 | 256 | 3.616; 3.645; 3.621 | 3.512; 3.558; 3.476 | 3.621 | 3.512 | -0.109 | -3.0 | 4.139 | ok |
| fused_gemm_afp4wfp4_mul_add | 2 | 7168 | 256 | 3.849; 3.860; 3.872 | 3.715; 3.743; 3.730 | 3.86 | 3.73 | -0.13 | -3.4 | 4.379 | ok |
| fused_gemm_afp4wfp4_mul_add | 4 | 7168 | 256 | 3.996; 4.000; 3.957 | 3.876; 3.877; 3.837 | 3.996 | 3.876 | -0.12 | -3.0 | 4.516 | ok |
| fused_gemm_afp4wfp4_mul_add | 8 | 7168 | 256 | 4.004; 4.030; 4.066 | 3.880; 3.846; 3.869 | 4.03 | 3.869 | -0.161 | -4.0 | 4.55 | ok |
| fused_gemm_afp4wfp4_mul_add | 16 | 7168 | 256 | 3.539; 4.100; 4.106 | 3.926; 3.917; 3.895 | 4.1 | 3.917 | -0.183 | -4.5 | 4.62 | ok |
| fused_gemm_afp4wfp4_mul_add | 32 | 7168 | 256 | 4.203; 4.142; 4.190 | 3.913; 3.945; 3.965 | 4.19 | 3.945 | -0.245 | -5.8 | 4.711 | ok |
| fused_gemm_afp4wfp4_mul_add | 64 | 7168 | 256 | 4.670; 4.703; 4.708 | 4.465; 4.436; 4.445 | 4.703 | 4.445 | -0.258 | -5.5 | 5.227 | ok |
| fused_gemm_afp4wfp4_mul_add | 128 | 7168 | 256 | 5.727; 5.717; 5.748 | 5.131; 5.133; 5.167 | 5.727 | 5.133 | -0.594 | -10.4 | 6.256 | ok |
| fused_gemm_afp4wfp4_mul_add | 256 | 7168 | 256 | 7.419; 7.429; 7.397 | 6.361; 6.381; 6.383 | 7.419 | 6.381 | -1.038 | -14.0 | 7.956 | ok |
| fused_gemm_afp4wfp4_mul_add | 512 | 7168 | 256 | 11.188; 11.070; 10.941 | 9.182; 9.075; 9.244 | 11.07 | 9.182 | -1.888 | -17.1 | 11.625 | ok |
| fused_gemm_afp4wfp4_mul_add | 1024 | 7168 | 256 | 16.153; 16.103; 15.993 | 16.418; 16.368; 15.997 | 16.103 | 16.368 | 0.265 | 1.6 | 16.684 | ok |
| fused_gemm_afp4wfp4_mul_add | 4096 | 7168 | 256 | 53.043; 52.728; 53.357 | 51.311; 51.372; 51.239 | 53.043 | 51.311 | -1.732 | -3.3 | 53.808 | ok |

The previously stable large-M AFP4WFP4 mul_add regressions were:

M=512
M=1024
M=4096

After adding the gfx950 dedicated routing and tuning the specific family shape config file, all three targeted regressions are resolved. Please see [this spreadsheet here](https://amdcloud-my.sharepoint.com/:x:/r/personal/nidanial_amd_com/_layouts/15/doc2.aspx?sourcedoc=%7Bb73024da-391f-40e8-99e2-35ee08b92a1e%7D&action=edit&activeCell=%27Performance%27!D1&wdinitialsession=64aceda3-b715-9431-3010-12b958042046&wdrldsc=21&wdrldc=1&wdrldr=AccessTokenExpiredWarningUnauthenticated%2CRefreshin) for the full test rundown (same as table but values that are outliers are highlighted red).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
