### PR TITLE
[Bugfix] Fix py3.10 wheel build broken by pandas==3.0.3 pin (#4091)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,18 @@
 # to reduce PyPI supply-chain risk (typosquat / upstream compromise pulling an
 # unexpected version).
 #
-# Baseline: rocm/atom-dev:latest, the canonical aiter build/test image
-#   digest sha256:7826a9a904a905b3b14418b267e8c40d17ca5606d72d620ff407df2129c2e5e7
-# Versions below match what that image ships, so `pip install -r requirements.txt`
-# is a no-op there and reproducible elsewhere.
+# aiter builds across multiple Python versions (CI wheels on py3.10 and py3.12),
+# so packages whose pinned release drops an older Python use environment markers
+# to keep a compatible pinned version per interpreter. Baseline versions track
+# rocm/atom-dev:latest (py3.12); the py<3.11 fallbacks are the latest release of
+# that package still supporting py3.10.
 #
 # Note: torch and triton are provided by the base image as ROCm-specific builds
 # (e.g. torch 2.10.0+rocm..., triton 3.7.0+amd.rocm...) that are not published on
 # PyPI, so they are intentionally NOT pinned here — their provenance is governed
 # by the base image, not this file.
-pandas==3.0.3
+pandas==3.0.3; python_version >= "3.11"
+pandas==2.3.3; python_version < "3.11"
 pytest==9.0.3
 psutil==7.2.2
 matplotlib==3.10.9


### PR DESCRIPTION
## Summary

Hotfix for main. #4091 pinned `pandas==3.0.3` (the version shipped by `rocm/atom-dev:latest`, which is Python 3.12), but the **py3.10** wheel-build container cannot install it — `pandas` 3.0 requires Python >= 3.11. So `build_aiter_wheels (3.10, rocm/pytorch:...py3.10..., true)` now fails on main:

```
ERROR: Ignored the following versions that require a different python version: ... 3.0.3 Requires-Python >=3.11
ERROR: No matching distribution found for pandas==3.0.3
```

(#4091's own checks passed because the py3.10 matrix leg on a PR only runs the `prebuild=false` no-op build; the real py3.10 build runs on push to `main`.)

## Fix

Use an environment marker so each interpreter pins to a compatible version:

```
pandas==3.0.3; python_version >= "3.11"   # py3.12 baseline (atom-dev:latest)
pandas==2.3.3; python_version <  "3.11"   # latest pandas supporting py3.10
```

All other pins are already compatible with the full supported Python range.

## Test plan

- [x] `pip install --dry-run -r requirements.txt` in `python:3.10-slim` → resolves `pandas==2.3.3` + all others, no error
- [x] `pip install --dry-run -r requirements.txt` in `rocm/atom-dev:latest` (py3.12) → `pandas==3.0.3`, everything already satisfied
- [ ] CI `build_aiter_wheels (3.10, ..., true)` green on merge