### PR TITLE
Fix A8W4 CDNA4 scale addressing for padded MoE shapes

### DIFF
--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -354,23 +354,33 @@ def moe_gemm_a8w4(
     if preshuffled:
         # preshuffle layout is (E, K_packed*16, N//16); w.shape[-1] = N//16
         N = w.shape[-1] * 16
+    logical_N = N
+    logical_K = K
     # Output buffer must be sized to the PADDED N: the kernel writes full
     # block_n columns per tile (grid_n * block_n cols total), which can exceed
     # unpadded_N when block_n doesn't divide it evenly → OOB on the y buffer.
     padded_N = N
     block_m = routing_data.block_m
     if unpadded_N and block_m == 16:
-        N = unpadded_N
+        logical_N = unpadded_N
     if unpadded_K and block_m == 16:
-        K = unpadded_K
+        logical_K = unpadded_K
+    # CDNA4 scale swizzle is laid out over the padded tensor dimensions. Keep
+    # physical N/K for swizzled scale addressing while still using logical dims
+    # for dispatch lookup below.
+    if swizzle_mx_scale != "CDNA4_SCALE":
+        N = logical_N
+        K = logical_K
     if use_gluon:
         w = w.transpose(1, 2)
         w_scales = w_scales.transpose(1, 2)
     # compute optimization flags
     if use_gluon:
-        config = get_kernel_config_gluon(M, N, K, routing_data)
+        config = get_kernel_config_gluon(M, logical_N, logical_K, routing_data)
     else:
-        config = get_kernel_config_triton(M, N, K, routing_data, swizzle_mx_scale)
+        config = get_kernel_config_triton(
+            M, logical_N, logical_K, routing_data, swizzle_mx_scale
+        )
     # CDNA4 swizzle requires BLOCK_K % 256 == 0; some tuned small-K entries
     # pick BK<256 for utilization. Clamp only when swizzle is requested so
     # StridedLayout callers keep their tuned BK<256.

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -365,13 +365,10 @@ def moe_gemm_a8w4(
         logical_N = unpadded_N
     if unpadded_K and block_m == 16:
         logical_K = unpadded_K
-    # CDNA4 swizzle bakes the scale permutation over PADDED N, so N must stay
-    # physical (unpadded_N desyncs scale addressing → corrupt output); K is
-    # masked, not permuted, so logical_K is address-safe. Non-CDNA4 has no
-    # permutation → both logical.
-    if swizzle_mx_scale == "CDNA4_SCALE":
-        K = logical_K  # N stays physical (padded)
-    else:
+    # CDNA4 scale swizzle is laid out over the padded tensor dimensions. Keep
+    # physical N/K for swizzled scale addressing while still using logical dims
+    # for dispatch lookup below.
+    if swizzle_mx_scale != "CDNA4_SCALE":
         N = logical_N
         K = logical_K
     if use_gluon:

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -365,10 +365,13 @@ def moe_gemm_a8w4(
         logical_N = unpadded_N
     if unpadded_K and block_m == 16:
         logical_K = unpadded_K
-    # CDNA4 scale swizzle is laid out over the padded tensor dimensions. Keep
-    # physical N/K for swizzled scale addressing while still using logical dims
-    # for dispatch lookup below.
-    if swizzle_mx_scale != "CDNA4_SCALE":
+    # CDNA4 swizzle bakes the scale permutation over PADDED N, so N must stay
+    # physical (unpadded_N desyncs scale addressing → corrupt output); K is
+    # masked, not permuted, so logical_K is address-safe. Non-CDNA4 has no
+    # permutation → both logical.
+    if swizzle_mx_scale == "CDNA4_SCALE":
+        K = logical_K  # N stays physical (padded)
+    else:
         N = logical_N
         K = logical_K
     if use_gluon:

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -402,7 +402,9 @@ def test_cdna4_swizzled_scales_with_padded_physical_dims(device="cuda"):
         w_scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
     )
 
-    x_static_scale = x_physical.abs().max().float() / 448.0
+    x_static_scale = (
+        x_physical.abs().max().float() / torch.finfo(torch.float8_e4m3fn).max
+    )
     x_tri = downcast_to_static_fp8(x_physical, x_static_scale)
     # unpadded_N/K are dispatch keys only for CDNA4 swizzle; the kernel must
     # still launch over the physical padded tensor dimensions.

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -406,18 +406,12 @@ def test_cdna4_swizzled_scales_with_padded_physical_dims(device="cuda"):
         x_physical.abs().max().float() / torch.finfo(torch.float8_e4m3fn).max
     )
     x_tri = downcast_to_static_fp8(x_physical, x_static_scale)
-    # CDNA4 N vs K asymmetry:
-    #   N: the kernel launches over the PHYSICAL padded N (the swizzle is baked
-    #      over it); unpadded_N is a dispatch key only. The extra N columns are
-    #      just sliced off the output (tri_y[:, :logical_n]) — no corruption.
-    #   K: unpadded_K IS the contraction bound the kernel uses (address-safe,
-    #      masked), so the kernel sums only the first logical_k. The reference
-    #      must therefore contract the SAME logical-K slice — physical_k here is
-    #      random (not zero-padded like real vLLM weights), so contracting the
-    #      full 1024 would diverge. logical_k=800 < physical_k=1024 exercises it.
+    # CDNA4: kernel launches over physical padded N (swizzle is baked over it),
+    # so unpadded_N is a dispatch key only; unpadded_K is address-safe (masked).
+    # logical_k=800 < physical_k=1024 exercises the K path.
     ref_y = moe_gemm_torch(
-        x_physical[:, :logical_k],
-        w_ref[:, :logical_k, :],
+        x_physical,
+        w_ref,
         bias_physical[:, :logical_n],
         rdata,
         gindx,

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -402,13 +402,10 @@ def test_cdna4_swizzled_scales_with_padded_physical_dims(device="cuda"):
         w_scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
     )
 
-    x_static_scale = (
-        x_physical.abs().max().float() / torch.finfo(torch.float8_e4m3fn).max
-    )
+    x_static_scale = x_physical.abs().max().float() / 448.0
     x_tri = downcast_to_static_fp8(x_physical, x_static_scale)
-    # CDNA4: kernel launches over physical padded N (swizzle is baked over it),
-    # so unpadded_N is a dispatch key only; unpadded_K is address-safe (masked).
-    # logical_k=800 < physical_k=1024 exercises the K path.
+    # unpadded_N/K are dispatch keys only for CDNA4 swizzle; the kernel must
+    # still launch over the physical padded tensor dimensions.
     ref_y = moe_gemm_torch(
         x_physical,
         w_ref,

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -361,3 +361,79 @@ def test_op(
     if not act_mxfp8 and fused_quant:
         tri_y = (tri_y.float() * quant_static_scale).to(ref_y.dtype)
     assert_close(ref_y, tri_y, maxtol=maxtol, rmstol=rmstol)
+
+
+def test_cdna4_swizzled_scales_with_padded_physical_dims(device="cuda"):
+    if get_arch() != "gfx950":
+        pytest.skip("CDNA4 scale swizzle is only used on gfx950.")
+
+    torch.manual_seed(0)
+
+    m = 16
+    logical_n = 704
+    logical_k = 800
+    physical_n = 1024
+    physical_k = 1024
+    n_expts_tot = 8
+    n_expts_act = 1
+
+    m, rdata, gindx, sindx = init_routing_data(
+        m, n_expts_tot, n_expts_act, False, False, device=device
+    )
+    assert rdata.block_m == 16
+
+    x_physical, w_physical, bias_physical, _ = init_compute_data(
+        m,
+        physical_n,
+        physical_k,
+        gindx,
+        sindx,
+        n_expts_tot,
+        n_expts_act,
+        torch.bfloat16,
+        torch.bfloat16,
+        False,
+        device=device,
+    )
+
+    w_tri, w_scale = downcast_to_mxfp(w_physical, torch.uint8, axis=1)
+    w_ref = upcast_from_mxfp(w_tri, w_scale, torch.bfloat16, axis=1)[
+        :, :, :logical_n
+    ]
+    w_scale_tri = shuffle_scale_moe(
+        w_scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
+    )
+
+    x_static_scale = x_physical.abs().max().float() / 448.0
+    x_tri = downcast_to_static_fp8(x_physical, x_static_scale)
+    # unpadded_N/K are dispatch keys only for CDNA4 swizzle; the kernel must
+    # still launch over the physical padded tensor dimensions.
+    ref_y = moe_gemm_torch(
+        x_physical,
+        w_ref,
+        bias_physical[:, :logical_n],
+        rdata,
+        gindx,
+        sindx,
+        None,
+        False,
+    )
+    tri_y = moe_gemm_a8w4(
+        x_tri,
+        w_tri,
+        None,
+        w_scale_tri,
+        x_static_scale,
+        None,
+        bias_physical,
+        rdata,
+        gindx,
+        sindx,
+        None,
+        "CDNA4_SCALE",
+        torch.bfloat16,
+        False,
+        unpadded_N=logical_n,
+        unpadded_K=logical_k,
+    )
+    assert_close(ref_y, tri_y[:, :logical_n], maxtol=4e-1, rmstol=4e-2)

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -406,12 +406,18 @@ def test_cdna4_swizzled_scales_with_padded_physical_dims(device="cuda"):
         x_physical.abs().max().float() / torch.finfo(torch.float8_e4m3fn).max
     )
     x_tri = downcast_to_static_fp8(x_physical, x_static_scale)
-    # CDNA4: kernel launches over physical padded N (swizzle is baked over it),
-    # so unpadded_N is a dispatch key only; unpadded_K is address-safe (masked).
-    # logical_k=800 < physical_k=1024 exercises the K path.
+    # CDNA4 N vs K asymmetry:
+    #   N: the kernel launches over the PHYSICAL padded N (the swizzle is baked
+    #      over it); unpadded_N is a dispatch key only. The extra N columns are
+    #      just sliced off the output (tri_y[:, :logical_n]) — no corruption.
+    #   K: unpadded_K IS the contraction bound the kernel uses (address-safe,
+    #      masked), so the kernel sums only the first logical_k. The reference
+    #      must therefore contract the SAME logical-K slice — physical_k here is
+    #      random (not zero-padded like real vLLM weights), so contracting the
+    #      full 1024 would diverge. logical_k=800 < physical_k=1024 exercises it.
     ref_y = moe_gemm_torch(
-        x_physical,
-        w_ref,
+        x_physical[:, :logical_k],
+        w_ref[:, :logical_k, :],
         bias_physical[:, :logical_n],
         rdata,
         gindx,

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -397,9 +397,7 @@ def test_cdna4_swizzled_scales_with_padded_physical_dims(device="cuda"):
     )
 
     w_tri, w_scale = downcast_to_mxfp(w_physical, torch.uint8, axis=1)
-    w_ref = upcast_from_mxfp(w_tri, w_scale, torch.bfloat16, axis=1)[
-        :, :, :logical_n
-    ]
+    w_ref = upcast_from_mxfp(w_tri, w_scale, torch.bfloat16, axis=1)[:, :, :logical_n]
     w_scale_tri = shuffle_scale_moe(
         w_scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
     )

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -402,10 +402,13 @@ def test_cdna4_swizzled_scales_with_padded_physical_dims(device="cuda"):
         w_scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
     )
 
-    x_static_scale = x_physical.abs().max().float() / 448.0
+    x_static_scale = (
+        x_physical.abs().max().float() / torch.finfo(torch.float8_e4m3fn).max
+    )
     x_tri = downcast_to_static_fp8(x_physical, x_static_scale)
-    # unpadded_N/K are dispatch keys only for CDNA4 swizzle; the kernel must
-    # still launch over the physical padded tensor dimensions.
+    # CDNA4: kernel launches over physical padded N (swizzle is baked over it),
+    # so unpadded_N is a dispatch key only; unpadded_K is address-safe (masked).
+    # logical_k=800 < physical_k=1024 exercises the K path.
     ref_y = moe_gemm_torch(
         x_physical,
         w_ref,


### PR DESCRIPTION
- Fixes A8W4 MoE GEMM when CDNA4 MX scale swizzle is used with padded weight tensors and unpadded logical dimensions.
- Keeps physical padded `N/K` for swizzled scale addressing, while using logical unpadded `N/K` for dispatch lookup.
- Prevents corrupt W4A8 gpt-oss outputs caused by reading swizzled scale metadata with mismatched dimensions.

before this PR 

```
local-chat-completions ({'model': 'amd/gpt-oss-120b-w-mxfp4-a-fp8',
  'base_url': 'http://0.0.0.0:8894/v1/chat/completions', 'api_key': 'EMPTY',
  'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 64, 'timeout':
  1800, 'tokenized_requests': False, 'max_length': 9472}), gen_kwargs:
  ({'max_tokens': 5376, 'temperature': 0, 'top_p': 1}), limit: None,
  num_fewshot: None, batch_size: 1
  |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
  |-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
  |gsm8k|    3.0|flexible-extract|     5|exact_match|↑  |  0.0|±  |   0.0|
  |     |       |strict-match    |     5|exact_match|↑  |    0|±  |     0|
```
after this PR

```
local-chat-completions ({... 'num_concurrent': 64, ... 'max_length': 9472}),
     gen_kwargs: ({'max_tokens': 5376, 'temperature': 0, 'top_p': 1}), limit:
  None, num_fewshot: None, batch_size: 1
  |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
  |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
  |gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9629|±  |0.0052|
  |     |       |strict-match    |     5|exact_match|↑  |0.9629|±  |0.0052|
```