### PR TITLE
Support emit_bf16 for per-token fused AllReduce+RMSNorm+FP8 quant

### DIFF
--- a/aiter/dist/device_communicators/communicator_cuda.py
+++ b/aiter/dist/device_communicators/communicator_cuda.py
@@ -379,8 +379,11 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 prefill_support=prefill_support,
                 emit_bf16=emit_bf16,
             )
-        if emit_bf16:
-            raise ValueError("emit_bf16 is not supported for per-token FP8 quant")
+        # emit_bf16 additionally returns the pre-quantization bf16/fp16 normed
+        # output alongside the per-token FP8 result. Used by v32 DSA models
+        # (e.g. GLM-5.2) whose indexer GEMMs run in bf16 while attention QKV
+        # keeps per-token FP8.
+        bf16_out = None
         hidden_dim = int(input_.shape[-1])
         element_size = input_.element_size()
         total_bytes = input_.numel() * element_size
@@ -411,14 +414,19 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 if self._ar_1stage_override is not None
                 else (total_bytes <= total_bytes_limit)
             )
-            out, res_out, scale_out = self.ca_comm.custom_fused_ar_rms_quant(
+            result = self.ca_comm.custom_fused_ar_rms_quant(
                 input_,
                 res_inp_,
                 weight_,
                 eps,
                 use_1stage,
                 gemma_norm=gemma_norm,
+                emit_bf16=emit_bf16,
             )
+            if emit_bf16:
+                out, res_out, scale_out, bf16_out = result
+            else:
+                out, res_out, scale_out = result
         else:
             out_, res_out = self.fused_allreduce_rmsnorm(
                 input_,
@@ -430,9 +438,15 @@ class CudaCommunicator(DeviceCommunicatorBase):
             )
             hip_quant = get_hip_quant(QuantType.per_Token)
             out, scale_out = hip_quant(out_, quant_dtype=fp8)
+            if emit_bf16:
+                # out_ is the pre-quantization bf16/fp16 normed activation.
+                bf16_out = out_
         assert out is not None
         assert res_out is not None
         assert scale_out is not None
+        if emit_bf16:
+            assert bf16_out is not None
+            return out, res_out, scale_out, bf16_out
         return out, res_out, scale_out
 
     def fused_allreduce_rmsnorm_quant_per_group(

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -823,6 +823,7 @@ class CustomAllreduce:
         post_per_token_quant: bool = False,
         out_hidden_dim: int = 0,
         gemma_norm: bool = False,
+        emit_bf16: bool = False,
     ):
         valid_dim = w.numel()
         if res_out is None:
@@ -875,6 +876,15 @@ class CustomAllreduce:
                 scale_out = torch.empty(
                     inp.shape[:-1] + (1,), dtype=torch.float32, device=inp.device
                 )
+            # Optional pre-quantization bf16/fp16 mirror of the normed output.
+            # Requested by v32 DSA models (e.g. GLM-5.2) whose indexer GEMMs run
+            # in bf16 while attention QKV keeps per-token FP8. Zero-overhead when
+            # not requested because the kernel branches on the pointer being null.
+            bf16_out = None
+            bf16_ptr = 0
+            if emit_bf16:
+                bf16_out = torch.empty_like(inp)
+                bf16_ptr = int(bf16_out.data_ptr())
             ops.fused_allreduce_rmsnorm_quant(
                 self._ptr,
                 inp,
@@ -888,7 +898,10 @@ class CustomAllreduce:
                 reg_bytes,
                 use_1stage,
                 gemma_norm,
+                bf16_ptr,
             )
+            if emit_bf16:
+                return out, res_out, scale_out, bf16_out
             return out, res_out, scale_out
 
     def custom_fused_ar_rms(
@@ -1003,6 +1016,7 @@ class CustomAllreduce:
         eps: float,
         use_1stage: bool,
         gemma_norm: bool = False,
+        emit_bf16: bool = False,
     ):
         # when custom allreduce is disabled, this will be None
         if self.disabled or not self.should_custom_ar(input):
@@ -1018,12 +1032,20 @@ class CustomAllreduce:
                     use_1stage=use_1stage,
                     post_per_token_quant=True,
                     gemma_norm=gemma_norm,
+                    emit_bf16=emit_bf16,
                 )
             else:
                 dummy_out = torch.zeros(input.shape, dtype=fp8, device=input.device)
                 dummy_scale_out = torch.zeros(
                     input.shape[:-1] + (1,), dtype=torch.float32, device=input.device
                 )
+                if emit_bf16:
+                    return (
+                        dummy_out,
+                        torch.zeros_like(input),
+                        dummy_scale_out,
+                        torch.zeros_like(input),
+                    )
                 return dummy_out, torch.zeros_like(input), dummy_scale_out
         else:
             return self.fused_ar_rms(
@@ -1035,6 +1057,7 @@ class CustomAllreduce:
                 use_1stage=use_1stage,
                 post_per_token_quant=True,
                 gemma_norm=gemma_norm,
+                emit_bf16=emit_bf16,
             )
 
     def fused_ar_rms_per_group_quant(

--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -176,10 +176,15 @@ def fused_allreduce_rmsnorm_quant_fake(
     prefill_support: bool = False,
     gemma_norm: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Real op returns (out_fp8, residual_out, scale). ``out`` is per-token FP8,
+    # NOT bf16 -- declare the correct dtype so torch.compile's assert_size_stride
+    # / dtype checks agree with the runtime tensor.
+    from aiter.utility.dtypes import fp8
+
     del gemma_norm
     return (
+        torch.empty_like(inp, dtype=fp8),
         torch.empty_like(res_inp),
-        torch.empty_like(inp),
         torch.empty(inp.shape[:-1] + (1,), dtype=torch.float32, device=inp.device),
     )
 
@@ -200,6 +205,47 @@ def fused_allreduce_rmsnorm_quant_(
         raise ValueError(f"Group {group_name} is destroyed.")
     return group._fused_allreduce_rmsnorm_quant_out_place(
         inp, res_inp, w, eps, prefill_support, gemma_norm=gemma_norm
+    )
+
+
+def fused_allreduce_rmsnorm_quant_emit_bf16_fake(
+    inp: torch.Tensor,
+    res_inp: torch.Tensor,
+    w: torch.Tensor,
+    eps: float,
+    group_name: str,
+    prefill_support: bool = False,
+    gemma_norm: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Real op returns (out_fp8, residual_out, scale, bf16) -- the 4th tensor is
+    # the pre-quantization bf16/fp16 normed activation for v32 DSA indexer GEMMs.
+    from aiter.utility.dtypes import fp8
+
+    del gemma_norm
+    return (
+        torch.empty_like(inp, dtype=fp8),
+        torch.empty_like(res_inp),
+        torch.empty(inp.shape[:-1] + (1,), dtype=torch.float32, device=inp.device),
+        torch.empty_like(res_inp),
+    )
+
+
+@torch_compile_guard(gen_fake=fused_allreduce_rmsnorm_quant_emit_bf16_fake)
+def fused_allreduce_rmsnorm_quant_emit_bf16_(
+    inp: torch.Tensor,
+    res_inp: torch.Tensor,
+    w: torch.Tensor,
+    eps: float,
+    group_name: str,
+    prefill_support: bool = False,
+    gemma_norm: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    return group._fused_allreduce_rmsnorm_quant_out_place(
+        inp, res_inp, w, eps, prefill_support, gemma_norm=gemma_norm, emit_bf16=True
     )
 
 
@@ -626,7 +672,21 @@ class GroupCoordinator:
     ):
         # quant_type arrives already canonicalized to a string ("per_token"/
         # "per_group"/"mxfp4") from the public API and the mxfp4 helper.
-        if quant_type == "per_token" and group_size == 128 and not emit_bf16:
+        if quant_type == "per_token" and group_size == 128:
+            # Both paths go through torch.library-registered ops so they lower
+            # into the compiled graph (Dynamo-traceable + CUDAGraph-capturable).
+            # The emit_bf16 variant returns a 4th tensor (the pre-quant bf16
+            # normed output) for v32 DSA models whose indexer GEMMs need it.
+            if emit_bf16:
+                return fused_allreduce_rmsnorm_quant_emit_bf16_(
+                    input_,
+                    residual_inp_,
+                    weight_,
+                    eps,
+                    group_name=self.unique_name,
+                    prefill_support=prefill_support,
+                    gemma_norm=gemma_norm,
+                )
             return fused_allreduce_rmsnorm_quant_(
                 input_,
                 residual_inp_,
@@ -781,7 +841,8 @@ class GroupCoordinator:
         eps: float,
         prefill_support: bool = False,
         gemma_norm: bool = False,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        emit_bf16: bool = False,
+    ):
         if self.device_communicator is None:
             raise ValueError("No device communicator found")
         return self.device_communicator.fused_allreduce_rmsnorm_quant(
@@ -790,6 +851,7 @@ class GroupCoordinator:
             weight_,
             eps,
             prefill_support,
+            emit_bf16=emit_bf16,
             gemma_norm=gemma_norm,
         )
 

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -115,6 +115,7 @@ def fused_allreduce_rmsnorm_quant(
     reg_bytes: int,
     use_1stage: bool,
     gemma_norm: bool = False,
+    bf16_out_ptr: int = 0,
 ) -> None: ...
 
 

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -1797,7 +1797,8 @@ __device__ __forceinline__ void ar_fusion_epilogue(A& in,
                                                    int block_size,
                                                    OutT* __restrict__ output,
                                                    float* __restrict__ scale_out,
-                                                   bool active = true)
+                                                   bool active            = true,
+                                                   T* __restrict__ bf16_output = nullptr)
 {
     if constexpr(std::is_same_v<T, OutT>)
     {
@@ -1815,6 +1816,18 @@ __device__ __forceinline__ void ar_fusion_epilogue(A& in,
         A out;
         ar_fusion_epilogue_rms_norm<P, A, A, float, PACK_SIZE, 32, GEMMA_NORM>(
             out, in, weight, eps, hidden_dim, block_size);
+        // Optionally write the pre-quantization bf16/fp16 normed output so
+        // v32 DSA models (e.g. GLM-5.2) whose indexer GEMMs run in bf16 can
+        // reuse the same normed activation while attention QKV keeps per-token
+        // FP8. Zero-overhead when not requested (branch on the pointer).
+        if(bf16_output != nullptr && active)
+        {
+            P bf16_pack;
+#pragma unroll
+            for(int i = 0; i < PACK_SIZE; ++i)
+                bf16_pack[i] = downcast_s<T>(out[i]);
+            *reinterpret_cast<P*>(bf16_output + idx) = bf16_pack;
+        }
         float amax  = ar_fusion_epilogue_reduce_abs_max<A, PACK_SIZE>(out, block_size);
         float scale = amax == 0.f ? 1.f : amax / FP8_UPBOUND;
         out_quant   = packQuant<opus::fp32_t, PACK_SIZE>(out, scale);
@@ -1934,7 +1947,8 @@ __global__ void __launch_bounds__(1024, 1)
                                    int input_hidden_dim,
                                    int hidden_dim,
                                    int out_hidden_dim,
-                                   float eps)
+                                   float eps,
+                                   T* __restrict__ bf16_output = nullptr)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -2022,7 +2036,8 @@ __global__ void __launch_bounds__(1024, 1)
             padded_block_size,
             output,
             scale_out,
-            active);
+            active,
+            bf16_output);
         if(active_tail)
         {
             OP zero_pack{};
@@ -2400,7 +2415,8 @@ void allreduce_fusion_kernel_1stage_launcher(RankData* _dp,
                                              int hidden_dim,
                                              int out_hidden_dim,
                                              float eps,
-                                             hipStream_t stream)
+                                             hipStream_t stream,
+                                             T* bf16_output = nullptr)
 {
     constexpr int PACK_SIZE  = 16 / sizeof(T);
     constexpr int WARP_SIZE  = 32;
@@ -2425,7 +2441,8 @@ void allreduce_fusion_kernel_1stage_launcher(RankData* _dp,
                                                     input_hidden_dim,
                                                     hidden_dim,
                                                     out_hidden_dim,
-                                                    eps);
+                                                    eps,
+                                                    bf16_output);
 }
 
 template <typename T, int PACK_SIZE>
@@ -2733,7 +2750,8 @@ __global__ void __launch_bounds__(1024, 1)
                                    float* __restrict__ scale_out,
                                    int size,
                                    int hidden_dim,
-                                   float eps)
+                                   float eps,
+                                   T* __restrict__ bf16_output = nullptr)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -2811,7 +2829,8 @@ __global__ void __launch_bounds__(1024, 1)
             acc[v] = upcast_s(vec[v]);
         }
         ar_fusion_epilogue<P, A, T, OutT, pack_size, GEMMA_NORM>(
-            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out);
+            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out,
+            /*active=*/true, bf16_output);
     }
 }
 
@@ -2828,7 +2847,8 @@ void allreduce_fusion_kernel_2stage_launcher(RankData* _dp,
                                              int size,
                                              int hidden_dim,
                                              float eps,
-                                             hipStream_t stream)
+                                             hipStream_t stream,
+                                             T* bf16_output = nullptr)
 {
     constexpr int PACK_SIZE = 16 / sizeof(T);
     int BLOCK_SIZE          = hidden_dim / PACK_SIZE;
@@ -2849,7 +2869,8 @@ void allreduce_fusion_kernel_2stage_launcher(RankData* _dp,
                                                             scale_out,
                                                             size,
                                                             hidden_dim,
-                                                            eps);
+                                                            eps,
+                                                            bf16_output);
 }
 
 // Per-group quant variant of the 2-stage kernel.
@@ -2982,7 +3003,8 @@ __global__ void __launch_bounds__(1024, 1)
                                           float* __restrict__ scale_out,
                                           int size,
                                           int hidden_dim,
-                                          float eps)
+                                          float eps,
+                                          T* __restrict__ bf16_output = nullptr)
 {
     constexpr int pack_size = 16 / sizeof(T);
     int block_size          = hidden_dim / pack_size;
@@ -3009,7 +3031,8 @@ __global__ void __launch_bounds__(1024, 1)
             acc[v] = upcast_s(vec[v]);
         }
         ar_fusion_epilogue<P, A, T, OutT, pack_size, GEMMA_NORM>(
-            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out);
+            acc, weight_p, hidden_dim, eps, idx, tidx, block_size, output, scale_out,
+            /*active=*/true, bf16_output);
     }
 }
 
@@ -3129,7 +3152,8 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
                                             int size,
                                             int hidden_dim,
                                             float eps,
-                                            hipStream_t stream)
+                                            hipStream_t stream,
+                                            T* bf16_output = nullptr)
 {
     // step 1, run reduce-scatter + allgather cross device save
     dim3 block(512);
@@ -3160,7 +3184,8 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
     dim3 numBlocks(nblocks);
     local_device_load_rmsnorm_quant_naive<T, OutT, GEMMA_NORM>
         <<<numBlocks, threadsPerBlock, 0, stream>>>(
-            sg, rank, residual_inp, residual_out, output, weight, scale_out, size, hidden_dim, eps);
+            sg, rank, residual_inp, residual_out, output, weight, scale_out, size, hidden_dim, eps,
+            bf16_output);
 }
 
 // Stage 2 for split AR+MHC(post) is launched via optimized mhc_post kernels on the
@@ -4375,7 +4400,8 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
                                         int m,
                                         int n,
                                         bool use_1stage,
-                                        bool gemma_norm = false)
+                                        bool gemma_norm = false,
+                                        T* bf16_output  = nullptr)
 {
     auto d   = 16 / sizeof(T);
     int size = m * n;
@@ -4398,12 +4424,13 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
         {                                                                               \
             gemma_template_launcher(ptrs, sg_, self_sg_, rank_, residual_inp,           \
                                     residual_out, output, weight, scale_out, size, n, n, \
-                                    n, eps, stream);                                    \
+                                    n, eps, stream, bf16_output);                       \
         }                                                                               \
         else                                                                            \
         {                                                                               \
             template_launcher(ptrs, sg_, self_sg_, rank_, residual_inp, residual_out,    \
-                              output, weight, scale_out, size, n, n, n, eps, stream);   \
+                              output, weight, scale_out, size, n, n, n, eps, stream,     \
+                              bf16_output);                                             \
         }                                                                               \
     } while(0)
 
@@ -4414,12 +4441,13 @@ void dispatchFusedAllReduceRMSNormQuant(hipStream_t stream,
         {                                                                                \
             gemma_template_launcher(ptrs, sg_, self_sg_, rank_, residual_inp,            \
                                     residual_out, output, weight, scale_out, size, n,     \
-                                    eps, stream);                                        \
+                                    eps, stream, bf16_output);                           \
         }                                                                                \
         else                                                                             \
         {                                                                                \
             template_launcher(ptrs, sg_, self_sg_, rank_, residual_inp, residual_out,     \
-                              output, weight, scale_out, size, n, eps, stream);          \
+                              output, weight, scale_out, size, n, eps, stream,            \
+                              bf16_output);                                              \
         }                                                                                \
     } while(0)
 

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -97,7 +97,8 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    int64_t reg_ptr,
                                    int64_t reg_bytes,
                                    bool use_1stage,
-                                   bool gemma_norm = false);
+                                   bool gemma_norm    = false,
+                                   int64_t bf16_out_ptr = 0);
 void fused_allreduce_rmsnorm_quant_per_group(fptr_t _fa,
                                              const aiter_tensor_t& inp,
                                              const aiter_tensor_t& res_inp,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -541,7 +541,8 @@ namespace py = pybind11;
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"),                                                                \
           py::arg("use_1stage"),                                                               \
-          py::arg("gemma_norm") = false);                                                      \
+          py::arg("gemma_norm")   = false,                                                     \
+          py::arg("bf16_out_ptr") = static_cast<int64_t>(0));                                  \
     m.def("fused_allreduce_rmsnorm_quant_per_group",                                            \
           &aiter::fused_allreduce_rmsnorm_quant_per_group,                                      \
           py::arg("_fa"),                                                                       \

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -197,7 +197,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
                                      AiterDtype dtype, float eps,
                                      int m, int input_n, int n, int out_n,
                                      bool use_1stage,
-                                     bool gemma_norm)
+                                     bool gemma_norm,
+                                     void* bf16_out = nullptr)
 {
     hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
@@ -240,7 +241,8 @@ static void _fused_allreduce_rmsnorm(fptr_t _fa,
             m,                                                   \
             n,                                                   \
             use_1stage,                                          \
-            gemma_norm);                                         \
+            gemma_norm,                                          \
+            reinterpret_cast<DTYPE*>(bf16_out));                 \
     }
 
     switch(dtype)
@@ -603,7 +605,8 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
                                    double eps,
                                    int64_t reg_ptr, int64_t reg_bytes,
                                    bool use_1stage,
-                                   bool gemma_norm)
+                                   bool gemma_norm,
+                                   int64_t bf16_out_ptr)
 {
     HipDeviceGuard device_guard(inp.device_id);
     hipStream_t stream = aiter::getCurrentHIPStream();
@@ -617,20 +620,27 @@ void fused_allreduce_rmsnorm_quant(fptr_t _fa,
             "fused allreduce rmsnorm quant requires input width == weight width");
     }
 
+    // bf16_out_ptr is an opaque data pointer (0 = not requested). When non-zero
+    // the kernel also writes the pre-quantization bf16/fp16 normed output, used
+    // by v32 DSA models (e.g. GLM-5.2) whose indexer GEMMs consume bf16.
+    void* bf16_out = reinterpret_cast<void*>(bf16_out_ptr);
+
     if(reg_ptr != 0)
     {
         _copy_input_to_registered_buffer(inp, m, input_n, stream, reg_ptr, reg_bytes);
         _fused_allreduce_rmsnorm(_fa,
                                  (void*)reg_ptr, res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), scale_out.data_ptr(), w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm,
+                                 bf16_out);
     }
     else
     {
         _fused_allreduce_rmsnorm(_fa,
                                  inp.data_ptr(), res_inp.data_ptr(), res_out.data_ptr(),
                                  out.data_ptr(), scale_out.data_ptr(), w.data_ptr(),
-                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm);
+                                 dtype, (float)eps, m, input_n, n, n, use_1stage, gemma_norm,
+                                 bf16_out);
     }
 }
 


### PR DESCRIPTION


## Motivation
The fused AllReduce+RMSNorm+FP8 quant path already supports emit_bf16 for the per-group and mxfp4 cases (emitting the pre-quantization bf16/fp16 normed activation alongside the fp8 output). Per-token FP8 was the only remaining case, and previously raised. Enable it here.

This is required by v32 DSA models (e.g. GLM-5.2) whose indexer GEMMs run in bf16 and therefore need the unquantized normed hidden state, while attention QKV keeps per-token FP8.

HIP kernels (csrc):
- ar_fusion_epilogue: add optional bf16_output; in the fp8 branch downcast the float normed result and store it when the pointer is non-null (mirrors ar_fusion_epilogue_per_group / _mxfp4).
- allreduce_fusion_kernel_1stage / _2stage and the naive split kernel plus their launchers: thread bf16_output through.
- dispatchFusedAllReduceRMSNormQuant and its launch macros: thread through.
- fused_allreduce_rmsnorm_quant wrapper: add bf16_out_ptr (opaque pointer, 0 = not requested); _fused_allreduce_rmsnorm helper forwards it.

Python:
- custom_all_reduce op stub / rocm_ops binding: add bf16_out_ptr.
- fused_ar_rms / custom_fused_ar_rms_quant: add emit_bf16, allocate the bf16 output, forward the pointer, return the 4-tuple when requested (incl. the capture-dummy path).
- communicator_cuda: remove the per-token emit_bf16 ValueError; return the 4-tuple from both the fused path and the AR+RMS-then-quant fallback.
- parallel_state: add a graph-traceable fused_allreduce_rmsnorm_quant_emit_bf16_ op + fake (4 outputs) and dispatch to it for per-token emit_bf16 so it lowers into the compiled graph (Dynamo-traceable + CUDAGraph-capturable). Also fix the pre-existing per-token fake to declare out as FP8, not bf16.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
