### PR TITLE
CI: sync ATOM Kimi default model name

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -84,9 +84,9 @@ jobs:
           default_models = [
               {"model_name": "DeepSeek-R1-0528"},
               {"model_name": "gpt-oss-120b"},
-              # Kimi-K2.5 ATOM (in-tree) downstream gate. Config (model_path,
+              # Kimi-K2.7 ATOM (in-tree) downstream gate. Config (model_path,
               # extraArgs -tp4, threshold) is pulled from ATOM models_accuracy.json.
-              {"model_name": "Kimi-K2.5-MXFP4"},
+              {"model_name": "Kimi-K2.7-Code-MXFP4"},
           ]
 
           labels_raw = os.environ.get("LABELS_JSON") or "[]"
@@ -104,10 +104,10 @@ jobs:
               "linux-atom-mi35x-1": "linux-aiter-do-mi350x-1",
           }
 
-          # Per-model runner pin (overrides the generic mapping above). Kimi-K2.5
+          # Per-model runner pin (overrides the generic mapping above). Kimi-K2.7
           # runs the downstream gate on the AITER MI350X pool (TP4 -> 4 GPUs).
           model_runner_overrides = {
-              "Kimi-K2.5-MXFP4": "linux-aiter-do-mi350x-4",
+              "Kimi-K2.7-Code-MXFP4": "linux-aiter-do-mi350x-4",
               "DeepSeek-V4-Pro": "linux-aiter-do-mi350x-8",       # -tp 8
               "Qwen3.5-397B-A17B-FP8": "linux-aiter-do-mi350x-4",  # -tp 4
               "MiniMax-M2.7-MXFP4": "linux-aiter-do-mi350x-2",     # -tp 2 (MXFP4)


### PR DESCRIPTION
## Motivation

The `ci:atom` workflow currently fails in `load-atom-models` before running any jobs because AITER still requests the old ATOM default model name `Kimi-K2.5-MXFP4`. ATOM main replaced that exact entry with `Kimi-K2.7-Code-MXFP4`, so the workflow matrix loader exits with `Missing default model(s) in ATOM accuracy config: Kimi-K2.5-MXFP4`.

## Technical Details

- Update `.github/workflows/atom-test.yaml` default ATOM Kimi model from `Kimi-K2.5-MXFP4` to `Kimi-K2.7-Code-MXFP4`.
- Update the matching per-model runner override key.
- Keep the existing TP4 runner pin behavior.

## Test Plan

- Run `git diff --check`.
- Simulate the workflow exact-match lookup against `ROCm/ATOM@main` `.github/benchmark/models_accuracy.json`.

## Test Result

- `git diff --check`: passed.
- Default model lookup against ATOM main: passed; missing model list is empty.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.