### PR TITLE
add get_getamdgpu_arch to support The Rock

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -39,13 +39,25 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 AITER_CORE_DIR = os.path.abspath(f"{this_dir}/../../")
 if os.path.exists(os.path.join(AITER_CORE_DIR, "aiter_meta")):
     AITER_CORE_DIR = os.path.join(AITER_CORE_DIR, "aiter_meta")
-DEFAULT_GPU_ARCH = (
-    subprocess.run(
-        "/opt/rocm/llvm/bin/amdgpu-arch", shell=True, capture_output=True, text=True
+
+
+def get_amdgpu_arch():
+    """Find amdgpu-arch and return the detected GPU architecture."""
+    result = subprocess.run(
+        "which amdgpu-arch", shell=True, capture_output=True, text=True
     )
-    .stdout.strip()
-    .split("\n")[0]
-)
+    amdgpu_arch_path = (
+        result.stdout.strip()
+        if result.returncode == 0
+        else "/opt/rocm/llvm/bin/amdgpu-arch"
+    )
+    result = subprocess.run(
+        amdgpu_arch_path, shell=True, capture_output=True, text=True
+    )
+    return result.stdout.strip().split("\n")[0]
+
+
+DEFAULT_GPU_ARCH = get_amdgpu_arch()
 GPU_ARCH = os.environ.get("GPU_ARCHS", DEFAULT_GPU_ARCH)
 AITER_REBUILD = int(os.environ.get("AITER_REBUILD", 0))
 


### PR DESCRIPTION
## Motivation

In the current `AITER`, the `DEFAULT_GPU_ARCH `that gets populated only searchs `/opt/rocm/llvm/amdgpu-arch`, however this is not the correct path for amdgpu-arch in `The Rock`.  It lives at` /opt/python/lib/python3.14/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdgpu-arch` in `The Rock`.  This PR adds `get_amdgpu_arch `to help AITER get the correct path.

## Technical Details

The `get_amdgpu_arch `uses which to get the full path to `amdgpu-arch`, which lets  `validate_and_update_archs` function properly without failing the assert that checks for `allowed_archs`.

## Test Plan
The vLLM test that was failing due to this error was:

`pytest -sv "compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fusions[inductor_partition-+rms_norm-4-TRITON_ATTN-openai/gpt-oss-20b-<lambda>-model_kwargs2-<lambda>]"`

It now passes, after a little more work with The Rock, but this [assert ](https://github.com/ROCm/aiter/blob/55d6e42f9b809f0c40b23562525fe7354622b085/csrc/cpp_itfs/utils.py#L147) no longer fails.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
