### PR TITLE
[Fix][dist] wrap per_group emit_bf16 fused AR+RMSNorm+quant in a torch.library op

### DIFF
--- a/aiter/dist/parallel_state.py
+++ b/aiter/dist/parallel_state.py
@@ -308,6 +308,67 @@ def fused_allreduce_rmsnorm_quant_per_group_(
     )
 
 
+def fused_allreduce_rmsnorm_quant_per_group_emit_bf16_fake(
+    inp: torch.Tensor,
+    res_inp: torch.Tensor,
+    w: torch.Tensor,
+    eps: float,
+    group_name: str,
+    group_size: int = 128,
+    prefill_support: bool = False,
+    transpose_scale: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Meta/fake for fused AR+RMSNorm+per-group-FP8-quant with emit_bf16.
+
+    Identical to ``fused_allreduce_rmsnorm_quant_per_group_fake`` (same
+    out/residual/scale shapes and scale-stride rules -- see that docstring)
+    but returns a 4th tensor: the pre-quantization bf16/fp16 normed activation
+    for v32 DSA indexer GEMMs (mirrors the per_token emit_bf16 fake).
+    """
+    from aiter.utility.dtypes import fp8
+
+    M = inp.shape[0]
+    K = inp.shape[-1]
+    num_groups = K // group_size
+    out = torch.empty_like(inp, dtype=fp8)
+    res_out = torch.empty_like(res_inp)
+    if transpose_scale:
+        scale = torch.empty(
+            (num_groups, M), dtype=torch.float32, device=inp.device
+        ).transpose(0, 1)
+    else:
+        scale = torch.empty((M, num_groups), dtype=torch.float32, device=inp.device)
+    bf16_out = torch.empty_like(res_inp)
+    return out, res_out, scale, bf16_out
+
+
+@torch_compile_guard(gen_fake=fused_allreduce_rmsnorm_quant_per_group_emit_bf16_fake)
+def fused_allreduce_rmsnorm_quant_per_group_emit_bf16_(
+    inp: torch.Tensor,
+    res_inp: torch.Tensor,
+    w: torch.Tensor,
+    eps: float,
+    group_name: str,
+    group_size: int = 128,
+    prefill_support: bool = False,
+    transpose_scale: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    return group._fused_allreduce_rmsnorm_quant_per_group_out_place(
+        inp,
+        res_inp,
+        w,
+        eps,
+        group_size,
+        prefill_support,
+        transpose_scale,
+        emit_bf16=True,
+    )
+
+
 def fused_qknorm_allreduce_fake(
     qkv_in: torch.Tensor,
     q_w: torch.Tensor,
@@ -724,14 +785,17 @@ class GroupCoordinator:
     ):
         if self.device_communicator is None:
             raise ValueError("No device communicator found")
-        # The 3-output (fp8, residual, scale) case goes through a
-        # torch.library-registered op so it is traceable under torch.compile /
-        # inductor (mirrors the per_token fast-path in
+        # Both the 3-output (fp8, residual, scale) and the 4-output emit_bf16
+        # (+ pre-quant bf16 normed activation) cases go through a
+        # torch.library-registered op so they are traceable under torch.compile
+        # / inductor (mirrors the per_token fast-path in
         # fused_allreduce_rmsnorm_quant). Without this, the per_group call is a
-        # plain Python -> pybind chain that Dynamo cannot trace, so the fused op
-        # never lowers into the compiled graph and the model silently falls back
-        # to the plain AllReduce+RMSNorm path. The emit_bf16 case returns a 4th
-        # tensor and is rare/eager-only, so it stays on the direct path.
+        # plain Python -> pybind chain that Dynamo cannot trace: on a fused-kernel
+        # miss it falls back to the raw pynccl all_reduce, which constructs a
+        # ctypes c_void_p and graph-breaks inside the compiled region (the
+        # backend is then invoked twice and asserts). v32 DSA models (GLM-5.x)
+        # call the emit_bf16 path from a compiled layernorm, so it must be
+        # wrapped too -- it is no longer eager-only.
         if not emit_bf16:
             return fused_allreduce_rmsnorm_quant_per_group_(
                 input_,
@@ -743,14 +807,14 @@ class GroupCoordinator:
                 prefill_support=prefill_support,
                 transpose_scale=transpose_scale,
             )
-        return self.device_communicator.fused_allreduce_rmsnorm_quant_per_group(
+        return fused_allreduce_rmsnorm_quant_per_group_emit_bf16_(
             input_,
             residual_inp_,
             weight_,
             eps,
-            group_size,
-            prefill_support,
-            emit_bf16=emit_bf16,
+            group_name=self.unique_name,
+            group_size=group_size,
+            prefill_support=prefill_support,
             transpose_scale=transpose_scale,
         )
 
@@ -864,7 +928,8 @@ class GroupCoordinator:
         group_size: int = 128,
         prefill_support: bool = False,
         transpose_scale: bool = False,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        emit_bf16: bool = False,
+    ):
         if self.device_communicator is None:
             raise ValueError("No device communicator found")
         return self.device_communicator.fused_allreduce_rmsnorm_quant_per_group(
@@ -875,6 +940,7 @@ class GroupCoordinator:
             group_size=group_size,
             prefill_support=prefill_support,
             transpose_scale=transpose_scale,
+            emit_bf16=emit_bf16,
         )
 
     def _fused_qknorm_allreduce_out_place(


### PR DESCRIPTION
The per_group + emit_bf16 fused AllReduce+RMSNorm+FP8-quant path was the only fused-AR variant NOT routed through a torch.library-registered op:

  GroupCoordinator.fused_allreduce_rmsnorm_quant_per_group(emit_bf16=True)
    -> self.device_communicator.fused_allreduce_rmsnorm_quant_per_group(...)  # raw

The 3-output per_group case and the per_token emit_bf16 case both go through registered ops (opaque to Dynamo); only the per_group emit_bf16 branch called the device communicator directly. It was assumed "rare/eager-only", but v32 DSA models (GLM-5.x) call it from a torch.compile'd layernorm.

When traced, on a fused-kernel miss the method falls back to the raw pynccl all_reduce, which builds a ctypes c_void_p (buffer_type(data_ptr())). Dynamo cannot trace _SimpleCData.__new__ -> graph break inside the compiled backbone -> VllmBackend is invoked a second time and asserts "VllmBackend can only be called once" -> all TP ranks die during warmup and the server never starts (surfaced as GLM-5.1-FP8 accuracy CI failures).

Fix: add fused_allreduce_rmsnorm_quant_per_group_emit_bf16_ (+ its 4-output fake) mirroring the per_token emit_bf16 op and the 3-output per_group op, and route the emit_bf16 branch through it. The op body (incl. any pynccl fallback) then runs eagerly inside the opaque op, so no ctypes construction is ever traced. Scale-stride / transpose_scale handling is identical to the 3-output per_group fake.

Follow-up (not fixed here): the generic fused_allreduce_rmsnorm_quant fall- through (quant_type != per_token or group_size != 128, e.g. mxfp4) still calls the device communicator directly with emit_bf16; wrap it too if any model hits that path under torch.compile.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
