### PR TITLE
perf(flydsl-moe): reduce a8w4 GEMM2 VGPR pressure for DSV4

### DIFF
--- a/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
@@ -1246,12 +1246,15 @@ def mxfp4_moe_gemm2(
         raise AssertionError(f"D_HIDDEN (N_OUT) must be a multiple of 256, got {D_HIDDEN}")
     if D_HIDDEN > HIDDEN_MAX_DEFAULT:
         raise AssertionError(f"D_HIDDEN ({D_HIDDEN}) exceeds compile cap HIDDEN_MAX ({HIDDEN_MAX_DEFAULT})")
+    # INTER_MAX caps compile-time B-view / A-scale-LDS bounds; env override lets shapes with small
+    # inter_dim compile a tighter cap (e.g. 512 -> K_TILES_MAX==2) to unlock the straight-line K2 gemm2.
+    inter_max = int(os.environ.get("MXFP4_G2_INTER_MAX", str(INTER_MAX_DEFAULT)))
     launch = get_g2(
         BM,
         use_nt,
         HIDDEN_MAX_DEFAULT,
         epilog,
-        INTER_MAX_DEFAULT,
+        inter_max,
         a_dtype,
         topk=topk,
         SBM=SBM,
@@ -1259,8 +1262,8 @@ def mxfp4_moe_gemm2(
         cu_num=cu_num,
         has_pad=has_pad,
     )
-    if D_INTER > INTER_MAX_DEFAULT:
-        raise AssertionError(f"D_INTER ({D_INTER}) exceeds compile cap INTER_MAX ({INTER_MAX_DEFAULT})")
+    if D_INTER > inter_max:
+        raise AssertionError(f"D_INTER ({D_INTER}) exceeds compile cap INTER_MAX ({inter_max})")
     max_m_blocks = (max_sorted + BM - 1) // BM
     if persist:
         # Fixed grid: cu_num m-slots; each block loops over its m-tiles.

--- a/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
@@ -627,6 +627,7 @@ def compile_gemm2_a4w4_port(
     g2_bhoist=None,
     g2_ascale_pf=None,
     g2_spart=None,
+    g2_bf16_lds=None,
 ):
     """Compile gemm2 a4w4 down-proj; epilog 'atomic' (weighted atomic-fadd) or 'reduce' (store into out[token_id*topk+slot]). inter_dim runtime; SBM None -> SBM==BM byte-identical."""
     SBM = _norm_sbm(SBM, BM)
@@ -660,10 +661,20 @@ def compile_gemm2_a4w4_port(
         raise AssertionError(f"a_dtype must be 'fp4' or 'fp8', got {a_dtype!r}")
     assert INTER_MAX % BK == 0, f"INTER_MAX must be a multiple of {BK}, got {INTER_MAX}"
     is_f8 = a_dtype == "fp8"
+    # g2_bf16_lds: store the cshuffle C tile as bf16 (BM*BN*2) instead of f32 (BM*BN*4) so the
+    # kernel occupies more CTA slots (Opus/old-FlyDSL style). Reduce-only for now (atomic keeps the
+    # f32 LDS + bf16 atomic-fadd path); the down-projection out is bf16, so weight is applied then
+    # truncated to bf16 before the LDS store. Enabled by default only for the a8w4 reduce route.
+    if g2_bf16_lds is None:
+        g2_bf16_lds = os.environ.get("MXFP4_G2_BF16_LDS", "1") == "1" and use_reduce and is_f8
+    g2_bf16_lds = bool(g2_bf16_lds) and use_reduce
     KH_TILE_A = BK // (1 if is_f8 else 2)  # A LDS K-tile bytes (fp8 256, fp4 128)
     slot_bytes = BM * KH_TILE_A
-    aStages = 3  # runtime K-loop: triple-buffered A LDS (handles both K_TILES==2 and larger)
-    lds_bytes = max(BM * BN * 4, aStages * slot_bytes)
+    # bf16 C LDS shrinks the output tile to BM*BN*2; with only K_TILES<=2 for the reduce shapes the
+    # A stream is fully prologue-loaded (kStages==2, no in-loop prefetch), so 2 A slots don't alias.
+    aStages = 2 if g2_bf16_lds else 3
+    c_lds_bytes = BM * BN * (2 if g2_bf16_lds else 4)
+    lds_bytes = max(c_lds_bytes, aStages * slot_bytes)
     # N_OUT = model_dim/hidden is a runtime arg (i32_hidden); num_n_blocks = N_OUT//256 is computed runtime in the body/launch (HIDDEN_MAX only caps host checks).
     assert HIDDEN_MAX % BK == 0, f"HIDDEN_MAX must be a multiple of {BK}, got {HIDDEN_MAX}"
 
@@ -685,7 +696,8 @@ def compile_gemm2_a4w4_port(
     bh_tag = "_bhoist" if g2_bhoist else ""
     apf_tag = "_apf" if g2_ascale_pf else ""
     spart_tag = f"_spart{g2_group_num}x{g2_m01}" if g2_spart > 0 else ""
-    tag = f"hmax{HIDDEN_MAX}_imax{INTER_MAX}_bm{BM}{'_nt' if use_nt else ''}_{etag}{atag}{sbm_tag}{persist_tag}{pad_tag}{ks_tag}{bh_tag}{apf_tag}{spart_tag}_v2"
+    bf16lds_tag = "_bf16lds" if g2_bf16_lds else ""
+    tag = f"hmax{HIDDEN_MAX}_imax{INTER_MAX}_bm{BM}{'_nt' if use_nt else ''}_{etag}{atag}{sbm_tag}{persist_tag}{pad_tag}{ks_tag}{bh_tag}{apf_tag}{spart_tag}{bf16lds_tag}_v2"
     name = f"gemm2_a4w4_port_{tag}"
 
     @fx.struct
@@ -773,6 +785,7 @@ def compile_gemm2_a4w4_port(
                 g2_kstages=g2_kstages,
                 g2_bhoist=g2_bhoist,
                 g2_ascale_pf=g2_ascale_pf,
+                g2_bf16_lds=g2_bf16_lds,
             )
 
         if const_expr(not persist and g2_spart <= 0):
@@ -1052,6 +1065,8 @@ def get_g2(
     g2_bhoist = os.environ.get("MXFP4_G2_BHOIST", "1") == "1"
     g2_ascale_pf = os.environ.get("MXFP4_G2_ASCALE_PF", "1") == "1"
     g2_spart = int(os.environ.get("MXFP4_G2_SPART", "402"))
+    # bf16 cshuffle LDS: reduce-only, a8w4 default (byte-identical for all other routes).
+    g2_bf16_lds = os.environ.get("MXFP4_G2_BF16_LDS", "1") == "1" and epilog == "reduce" and a_dtype == "fp8"
     key = (
         BM,
         use_nt,
@@ -1068,6 +1083,7 @@ def get_g2(
         g2_bhoist,
         g2_ascale_pf,
         g2_spart,
+        g2_bf16_lds,
     )
     launch = G2_CACHE.get(key)
     if launch is None:
@@ -1087,6 +1103,7 @@ def get_g2(
             g2_bhoist=g2_bhoist,
             g2_ascale_pf=g2_ascale_pf,
             g2_spart=g2_spart,
+            g2_bf16_lds=g2_bf16_lds,
         )
         G2_CACHE[key] = launch
     return launch

--- a/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
@@ -1044,6 +1044,7 @@ def gemm2_body_v2(
     g2_kstages=2,
     g2_bhoist=True,
     g2_ascale_pf=True,
+    g2_bf16_lds=False,
 ):
     # gemm2 K-loop perf knobs (default ON, no-op unless g2_kstages==2): kstages=2 double-buffers B weight+scale one tile ahead; bhoist issues that prefetch above the LDS barrier; ascale_pf prefetches A-scale one tile ahead.
     if g2_kstages not in (1, 2):
@@ -1413,6 +1414,7 @@ def gemm2_body_v2(
         use_reduce=use_reduce,
         topk=topk,
         SBM=SBM,
+        g2_bf16_lds=g2_bf16_lds,
     )
 
 
@@ -1434,6 +1436,7 @@ def atomic_bf16_epilog(
     use_reduce=False,
     topk=1,
     SBM=None,
+    g2_bf16_lds=False,
 ):
     if SBM is None:
         SBM = BM
@@ -1442,6 +1445,10 @@ def atomic_bf16_epilog(
     lane_div_16 = lane // 16
     lane_mod_16 = lane % 16
     lds_base_fptr = lds_typed_ptr(lds_acc_base, T.f32)
+    # bf16 cshuffle LDS: half the C tile footprint (BM*BN*2). Weight is folded in f32 during the
+    # write phase and the tile is truncated to bf16 before the LDS store (single rounding, as old
+    # FlyDSL); readback then loads the already-weighted bf16 pair and stores it straight to out.
+    lds_base_bf16 = lds_typed_ptr(lds_acc_base, T.bf16, align=2) if const_expr(g2_bf16_lds) else None
 
     tx_i32 = fx.Int32(gpu.thread_id("x"))
     m_lane = tx_i32 // 32
@@ -1462,15 +1469,32 @@ def atomic_bf16_epilog(
     # pre-store fence+barrier (HIP run_one __syncthreads() before the epilog).
     gpu.barrier()
 
-    # write accm -> lds_acc cshuffle (scalar f32 stores, as HIP does)
-    for i in range_constexpr(kMChunks):
-        row_base = fx.Int32(i * 16) + lane_div_16 * 4
-        for J in range_constexpr(4):
-            col = wave * 64 + J * 16 + lane_mod_16
-            vec = Vec(accm[i][J])
-            for v in range_constexpr(4):
-                idx = (row_base + v) * BN + col
-                lds_base_fptr[idx] = fx.Float32(vec[v])
+    # write accm -> lds_acc cshuffle. f32 path: scalar f32 stores (weight applied on readback).
+    # bf16 path: fold the route weight in f32 (per block-row from sorted_weights) then truncate to
+    # bf16 so LDS holds the final weighted output tile.
+    if const_expr(g2_bf16_lds):
+        for i in range_constexpr(kMChunks):
+            row_base = fx.Int32(i * 16) + lane_div_16 * 4
+            # one f32 route-weight per write-phase block row (row_base+v); sorted_weights is padded.
+            w_row = [
+                llvm.load(T.f32, gep1(sweights_base, (m_row + row_base + v) * 4), invariant=True)
+                for v in range_constexpr(4)
+            ]
+            for J in range_constexpr(4):
+                col = wave * 64 + J * 16 + lane_mod_16
+                vec = Vec(accm[i][J])
+                for v in range_constexpr(4):
+                    idx = (row_base + v) * BN + col
+                    lds_base_bf16[idx] = fx.BFloat16(fx.Float32(vec[v]) * fx.Float32(w_row[v]))
+    else:
+        for i in range_constexpr(kMChunks):
+            row_base = fx.Int32(i * 16) + lane_div_16 * 4
+            for J in range_constexpr(4):
+                col = wave * 64 + J * 16 + lane_mod_16
+                vec = Vec(accm[i][J])
+                for v in range_constexpr(4):
+                    idx = (row_base + v) * BN + col
+                    lds_base_fptr[idx] = fx.Float32(vec[v])
 
     gpu.barrier()
 
@@ -1494,10 +1518,14 @@ def atomic_bf16_epilog(
             out_row = token_id
             row_base_addr = out_row * N_OUT + n_block_idx * BN + col_start
         for s in range_constexpr(4):
-            # adjacent ee=0,1 contiguous -> one <2xf32> load (as HIP vectorizes)
+            # adjacent ee=0,1 contiguous -> one 2-wide load.
             idx0 = row_in_block * BN + col_start + s * 64
-            v2 = Vec(lds_vec_load(lds_acc_base, idx0 * 4, Vec.make_type(2, fx.Float32), fx.Float32, align=8))
-            pk = Vec.from_elements([v2[0] * weight[mr], v2[1] * weight[mr]], fx.Float32).to(fx.BFloat16)
+            if const_expr(g2_bf16_lds):
+                # LDS already holds the weighted bf16 pair (4B = 2xbf16): load + store straight through.
+                pk = Vec(lds_vec_load(lds_acc_base, idx0 * 2, Vec.make_type(2, fx.BFloat16), fx.BFloat16, align=4))
+            else:
+                v2 = Vec(lds_vec_load(lds_acc_base, idx0 * 4, Vec.make_type(2, fx.Float32), fx.Float32, align=8))
+                pk = Vec.from_elements([v2[0] * weight[mr], v2[1] * weight[mr]], fx.Float32).to(fx.BFloat16)
             if const_expr(use_reduce):
                 off = (row_base_addr + fx.Int64(s * 64)) * fx.Int64(2)  # bf16 byte off (i64)
             else:

--- a/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
@@ -1237,6 +1237,30 @@ def gemm2_body_v2(
                     i0=2 * sub,
                 )
 
+    # Step 2: N-half B split (straight-line K2 only; BM64 -> not is_bm16). One N-half's B (J in
+    # {2*half_n, 2*half_n+1} -> 4 frags = 16 regs) + its single B-scale word are loaded and consumed
+    # before the other half loads, halving the peak B live set (32 -> 16). accm[i][J] keys on absolute
+    # J so J stays absolute; bqf is a length-4 list with only this half's two J-slots populated.
+    def stream_b_half(kt_rt, half_n):
+        bqf = [None, None, None, None]
+        for j in (2 * half_n, 2 * half_n + 1):
+            bqf[j] = [fx.make_fragment_like(frag_tmpl) for _ in range_constexpr(2)]
+            for half in range_constexpr(2):
+                fx.copy(b_catom, bq_views[j][lane_div_16, lane_mod_16, kt_rt, half, None], bqf[j][half])
+        bsf = fx.make_fragment_like(bs_frag_tmpl)
+        fx.copy(bs_copy_atom, bscale_views[half_n][lane_div_16, lane_mod_16, kt_rt, None], bsf)
+        return bqf, bsf
+
+    def mfma_cluster_half(bqf, bsf, sa, half_n):
+        # Both J in this half share mni==half_n -> one B-scale word (sb) for the pair.
+        sb = _raw(Vec(bsf.load())[0])
+        for j in (2 * half_n, 2 * half_n + 1):
+            in_b = j % 2
+            for sub in range_constexpr(kSubBlocks):
+                mma_one_j(
+                    j, in_b, sa[sub], sb, bqf, is_f8_a, cbsz_a, a_vals, a_frags, accm, c_frags, mma_atoms, i0=2 * sub
+                )
+
     # zero C (fp4 fragments accumulate in place; fp8 accm pre-init above).
     if const_expr(not is_f8_a):
         for i in range_constexpr(kMChunks):
@@ -1272,13 +1296,15 @@ def gemm2_body_v2(
         gpu.barrier()  # A prologue vmem->LDS (both slots) visible before ds-reads
         for kt in range_constexpr(2):
             issue_a_ds_read(fx.Int32(kt))  # const slot 0/1 (no runtime mod)
-            bqf, bsf = stream_b_tile(fx.Int32(kt))  # dies after this tile's mfma_cluster
             sa = load_a_scale_tile(fx.Int32(kt))
-            rocdl.sched_barrier(0)
-            rocdl.s_setprio(1)
-            mfma_cluster(bqf, bsf, sa)
-            rocdl.s_setprio(0)
-            rocdl.sched_barrier(0)
+            # Step 2: process each N-half's B just-in-time so its 4 frags die before the other half loads.
+            for half_n in range_constexpr(2):
+                bqf, bsf = stream_b_half(fx.Int32(kt), half_n)
+                rocdl.sched_barrier(0)
+                rocdl.s_setprio(1)
+                mfma_cluster_half(bqf, bsf, sa, half_n)
+                rocdl.s_setprio(0)
+                rocdl.sched_barrier(0)
     elif const_expr(g2_kstages == 1):
         # 1-deep pipe: synchronous B load per K-tile.
         for kt_iv, state in range(fx.Index(0), fx.Index(K_TILES_RT), fx.Index(1), init=load_c_carry()):

--- a/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
@@ -1260,7 +1260,26 @@ def gemm2_body_v2(
                 n += 1
         return n
 
-    if const_expr(g2_kstages == 1):
+    # Step 1: shape-gated, fully-unrolled K_TILES=2 straight-line mainloop (a8w4 reduce / bf16 LDS, BM64).
+    # When the compile cap INTER_MAX//BK == 2 the runtime trip is 1 or 2, so we drop the scf.for entirely
+    # and emit two straight-line tile bodies. This removes the C/B loop-carry (load_c_carry/store_c_carry,
+    # cur/nxt B double-buffer, A-scale carry): each tile's B fragments die before the next stream_b_tile,
+    # so cur+nxt B are never simultaneously live -> lower VGPR. A is fully prologue-staged into both slots
+    # (kStages==2, aStages==2, no in-loop A prefetch). When runtime inter_dim spans only 1 tile
+    # (K_TILES_RT==1) tile-1's A/B/A-scale buffer loads clamp OOB->0, a zero MFMA contribution -> correct.
+    straight_line_k2 = is_f8_a and use_reduce and g2_bf16_lds and (BM == 64) and (K_TILES_MAX == 2)
+    if const_expr(straight_line_k2):
+        gpu.barrier()  # A prologue vmem->LDS (both slots) visible before ds-reads
+        for kt in range_constexpr(2):
+            issue_a_ds_read(fx.Int32(kt))  # const slot 0/1 (no runtime mod)
+            bqf, bsf = stream_b_tile(fx.Int32(kt))  # dies after this tile's mfma_cluster
+            sa = load_a_scale_tile(fx.Int32(kt))
+            rocdl.sched_barrier(0)
+            rocdl.s_setprio(1)
+            mfma_cluster(bqf, bsf, sa)
+            rocdl.s_setprio(0)
+            rocdl.sched_barrier(0)
+    elif const_expr(g2_kstages == 1):
         # 1-deep pipe: synchronous B load per K-tile.
         for kt_iv, state in range(fx.Index(0), fx.Index(K_TILES_RT), fx.Index(1), init=load_c_carry()):
             store_c_carry(state)

--- a/bench_gemm12_v2_vs_baseline.py
+++ b/bench_gemm12_v2_vs_baseline.py
@@ -1,0 +1,672 @@
+"""Per-M gemm1/gemm2 launch comparison for dsv4 a8w4 (fp8 a / fp4 w):
+
+  baseline = current vendored FlyDSL mixed_moe stage1 (aiter.ops.flydsl.flydsl_moe_stage1)
+  v2       = FlyDSL#753 "mxmoe v2" gemm1 (aiter.ops.flydsl.kernels.mxmoe_dispatcher.mxfp4_moe_gemm1)
+
+Both kernels compute the same a8w4 up/gate MoE gemm but through different input
+pipelines (baseline: aiter sort + unsorted a-scale, gather+fused-quant-out; v2:
+opus sort + sorted/shuffled mxfp8 a-scale). We time ONLY each kernel's launch in
+isolation (identical run_perftest settings), so the differing input prep does not
+affect the comparison -- mirroring test_moe_2stage.py --kernel.
+
+Baseline config per M comes from the tuned CSV's kernelName1 (parsed via
+get_flydsl_kernel_params); v2 config per M comes from the #753 dispatcher's own
+select_pipe_config / gemm1_use_nt (its production choice).
+
+Usage:
+  /opt/venv/bin/python bench_gemm1_v2_vs_baseline.py \
+      --csv aiter/configs/model_configs/dsv4_fp8fp4_tuned_fmoe.csv \
+      --model-dim 7168 --inter-dim 512 -E 384 -k 6
+
+  /opt/venv/bin/python bench_gemm1_v2_vs_baseline.py --stage gemm2 \
+      --csv aiter/configs/model_configs/dsv4_fp8fp4_tuned_fmoe.csv \
+      --model-dim 7168 --inter-dim 512 -E 384 -k 6
+"""
+
+import argparse
+import csv as _csv
+
+import torch
+
+import aiter
+from aiter import dtypes, QuantType, ActivationType
+from aiter.fused_moe import fused_topk, moe_sorting, torch_moe_stage1, torch_moe_stage2
+from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.quant import per_1x32_f8_scale_f8_quant, per_1x32_f4_quant
+from aiter.utility import fp4_utils
+from aiter.utility.fp4_utils import e8m0_shuffle, moe_mxfp4_sort
+from aiter.test_common import run_perftest
+from aiter.ops.flydsl.moe_kernels import (
+    flydsl_moe_stage1,
+    flydsl_moe_stage2,
+    get_flydsl_kernel_params,
+)
+from aiter.ops.flydsl.kernels.moe_sorting_kernel import moe_sorting_flydsl
+from aiter.ops.flydsl.kernels.mxmoe_dispatcher import (
+    mxfp4_moe_gemm1,
+    mxfp4_moe_gemm2,
+    select_pipe_config,
+    gemm1_use_nt,
+    gemm2_use_nt,
+)
+from aiter.ops.opus import moe_stage2_a8w4_fused_adapter as _opus_a8w4
+
+torch.set_default_device("cuda")
+
+WARMUP, ITERS = 10, 50
+
+
+# --- balanced routing / quant (mirror bench_stage1_a8w4.py) ------------------
+def balanced_score(token, E, topk, dtype):
+    score = torch.zeros((token, E), dtype=dtype)
+    start = 0
+    for t in range(token):
+        idx = (torch.arange(start, start + topk)) % E
+        score[t, idx] = 1.0
+        start = (start + topk) % E
+    return score
+
+
+def quant_a_fp8(x):
+    return per_1x32_f8_scale_f8_quant(
+        x, quant_dtype=dtypes.fp8, scale_type=dtypes.fp8_e8m0
+    )
+
+
+def quant_w_fp4(w):
+    return per_1x32_f4_quant(w, quant_dtype=dtypes.fp4x2, shuffle=False)
+
+
+# --- v2 (#753) CK a16w4 layout helpers (ported verbatim from the PR test) ----
+def _mxfp4_shuffle_weight_a16w4(x, gate_up, NLane=16, KPack=16):
+    """CK a16w4 weight preshuffle (is_guinterleave path)."""
+    x_type = x.dtype
+    if hasattr(torch, "float4_e2m1fn_x2") and x_type == torch.float4_e2m1fn_x2:
+        x = x.view(torch.uint8)
+    E, N, K_pk = x.shape
+    if gate_up:
+        N = N // 2
+    KLane = 64 // NLane
+    N0 = N // NLane
+    K0 = K_pk // (KLane * KPack)
+    if gate_up:
+        x_ = x.view(E, 2, N0, NLane, K0, KLane, KPack).permute(0, 2, 1, 4, 5, 3, 6)
+    else:
+        x_ = x.view(E, N0, NLane, K0, KLane, KPack).permute(0, 1, 3, 4, 2, 5)
+    return x_.contiguous().view(*x.shape).contiguous().view(x_type)
+
+
+def _mxfp4_shuffle_scale_a16w4(src, E, gate_up):
+    """CK a16w4 e8m0 scale preshuffle (is_guinterleave path)."""
+    n_experts, k_ = src.shape
+    n_ = n_experts // E
+    K_Pack, N_Pack, N_Lane = 2, 2, 16
+    K_Lane = 64 // N_Lane
+    K1 = k_ // K_Pack // K_Lane
+    N1 = n_ // N_Lane // N_Pack
+    if gate_up:
+        s = src.view(E, N_Pack, N1, N_Lane, K1, K_Pack, K_Lane).permute(0, 2, 4, 6, 3, 5, 1)
+    else:
+        s = src.view(E, N1, N_Pack, N_Lane, K1, K_Pack, K_Lane).permute(0, 1, 4, 6, 3, 5, 2)
+    return s.contiguous().view(*src.shape).contiguous()
+
+
+def _mxfp4_a_scale_sorted_shuffled(asc, sti, cumsum, max_sorted, H, BM=32, BK=256):
+    """Torch reconstruction of moe_sort_scales: sort + CK-shuffle the e8m0 A-scale
+    by sorted row, exactly as gemm1 consumes it (opus gather: sti & 0xFFFFFF)."""
+    device = asc.device
+    is_bm16 = BM < 32
+    CHUNK_ROWS = 32 if is_bm16 else BM
+    MN_PACK = 2
+    K_PACK = BK // 128
+    C_M1 = CHUNK_ROWS // (16 * MN_PACK)
+    C_K1 = (H // 32) // (4 * K_PACK)
+    K_LANE, N_LANE = 4, 16
+    DWORDS_PER_CHUNK = C_M1 * C_K1 * K_LANE * N_LANE
+    block_rows = 16 if is_bm16 else BM
+    n_chunks = max_sorted // block_rows
+    actual_sorted = int(cumsum[0].item())
+    actual_n_chunks = (actual_sorted + block_rows - 1) // block_rows
+    total_work = n_chunks * DWORDS_PER_CHUNK
+    sti_c = sti & 0x00FFFFFF
+    out = torch.zeros((total_work, 4), dtype=torch.uint8, device=device)
+    wid = torch.arange(total_work, device=device)
+    r = wid.clone()
+    n_lane = r % N_LANE
+    r //= N_LANE
+    k_lane = r % K_LANE
+    r //= K_LANE
+    ku = r % C_K1
+    r //= C_K1
+    mi = r % C_M1
+    r //= C_M1
+    chunk = r
+    valid_chunk = chunk < actual_n_chunks
+    M = asc.shape[0]
+    for ikxdl in range(K_PACK):
+        for im_a in range(MN_PACK):
+            if is_bm16 and im_a == 1:
+                continue
+            sorted_row = chunk * block_rows + (mi * MN_PACK + im_a) * 16 + n_lane
+            rowok = (sorted_row < actual_sorted) & valid_chunk
+            srow = torch.clamp(sorted_row, max=max_sorted - 1)
+            stiv = sti_c[srow]
+            tid = torch.where((stiv < M) & rowok, stiv, torch.zeros_like(stiv))
+            k_idx = ku * K_PACK * 4 + ikxdl * 4 + k_lane
+            byte = asc[tid.long(), k_idx.long()]
+            out[:, ikxdl * MN_PACK + im_a] = torch.where(rowok, byte, torch.zeros_like(byte))
+    return out.reshape(-1).contiguous()
+
+
+def _u8v(t):
+    return t.view(torch.uint8) if (t is not None and t.element_size() == 1 and t.dtype != torch.uint8) else t
+
+
+# --- shared input build ------------------------------------------------------
+def gen(token, model_dim, inter_dim, E, topk, block_m):
+    torch.manual_seed(0)
+    inp = torch.randn((token, model_dim), dtype=dtypes.bf16) / 10
+    w1 = torch.randn((E, inter_dim * 2, model_dim), dtype=dtypes.bf16) / 10
+    w2 = torch.randn((E, model_dim, inter_dim), dtype=dtypes.bf16) / 10
+    score = balanced_score(token, E, topk, dtypes.bf16)
+    topk_weights, topk_ids = fused_topk(inp, score, topk, True)
+
+    w1_qt, w1_scale = quant_w_fp4(w1)   # fp4x2 weights + e8m0 scale
+    w2_qt, w2_scale = quant_w_fp4(w2)   # fp4x2 weights + e8m0 scale
+    a1_qt, a1_scale = quant_a_fp8(inp)  # fp8 activations + e8m0 scale
+
+    # torch reference stage1 (dequant the SAME quantized operands the kernels read)
+    a_deq = (
+        a1_qt.float().view(token, model_dim // 32, 32)
+        * fp4_utils.e8m0_to_f32(a1_scale).view(token, model_dim // 32, 1)
+    ).view(token, model_dim).to(dtypes.bf16)
+    w1_deq = (
+        fp4_utils.mxfp4_to_f32(w1_qt).view(E, inter_dim * 2, model_dim // 32, 32)
+        * fp4_utils.e8m0_to_f32(w1_scale).view(E, inter_dim * 2, model_dim // 32, 1)
+    ).view(E, inter_dim * 2, model_dim).to(dtypes.bf16)
+    w2_deq = (
+        fp4_utils.mxfp4_to_f32(w2_qt).view(E, model_dim, inter_dim // 32, 32)
+        * fp4_utils.e8m0_to_f32(w2_scale).view(E, model_dim, inter_dim // 32, 1)
+    ).view(E, model_dim, inter_dim).to(dtypes.bf16)
+    ref1 = torch_moe_stage1(
+        a_deq, w1_deq, w2_deq, topk_weights, topk_ids, dtype=dtypes.bf16,
+        activation=ActivationType.Silu, quant_type=QuantType.No, doweight=False,
+    )  # [token, topk, inter]
+    ref2 = torch_moe_stage2(
+        ref1, w1_deq, w2_deq, topk_weights, topk_ids, dtype=dtypes.bf16,
+        quant_type=QuantType.No, doweight=True,
+    )  # [token, hidden]
+
+    # ---- baseline (aiter mixed_moe stage1) prep ----
+    sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, _ = moe_sorting(
+        topk_ids, topk_weights, E, model_dim, dtypes.bf16, block_m
+    )
+    base = dict(
+        a1_qt=a1_qt,
+        w1_qt_shuf=shuffle_weight(w1_qt, (16, 16)),
+        w1_scale_shuf=e8m0_shuffle(w1_scale),
+        w2_qt_shuf=_mxfp4_shuffle_weight_a16w4(w2_qt, gate_up=False),
+        w2_scale_shuf=_mxfp4_shuffle_scale_a16w4(w2_scale, E, gate_up=False),
+        a1_scale_sort=moe_mxfp4_sort(
+            a1_scale[:token, :].view(token, 1, -1), sorted_ids=sorted_ids,
+            num_valid_ids=num_valid_ids, token_num=token, block_size=block_m,
+        ),
+        a2_qt=None,
+        a2_scale=None,
+        sorted_ids=sorted_ids, sorted_expert_ids=sorted_expert_ids,
+        sorted_weights=sorted_weights, num_valid_ids=num_valid_ids,
+    )
+    a2_qt, a2_scale = aiter.fused_dynamic_mxfp8_quant_moe_sort(
+        ref1.contiguous().view(token * topk, inter_dim),
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=token,
+        topk=topk,
+        block_size=block_m,
+        sorted_weights=sorted_weights,
+    )
+    base["a2_qt"] = a2_qt.view(token, topk, inter_dim)
+    base["a2_scale"] = a2_scale
+
+    # ---- v2 (#753) prep: opus sort + CK a16w4 shuffles + sorted/shuffled a-scale ----
+    H, INTER, NE = model_dim, inter_dim, E
+    SBM = block_m  # sort unit == stage1 tile (BM_S1 chosen per M at bench time; SBM re-derived there)
+    return dict(
+        ref1=ref1, ref2=ref2, topk_ids=topk_ids, topk_weights=topk_weights,
+        w1_qt=w1_qt, w1_scale=w1_scale, w2_qt=w2_qt, w2_scale=w2_scale,
+        a1_qt=a1_qt, a1_scale=a1_scale,
+        inp=inp, base=base,
+    )
+
+
+def build_v2_inputs(d, token, model_dim, inter_dim, E, topk, BM_S1):
+    """Build v2 gemm1 inputs for the chosen stage1 tile BM_S1 (SBM==BM_S1)."""
+    device = "cuda"
+    H, INTER, NE, TOPK = model_dim, inter_dim, E, topk
+    SBM = BM_S1
+    w1u8 = _u8v(_mxfp4_shuffle_weight_a16w4(d["w1_qt"], gate_up=True))
+    w1sc = _u8v(_mxfp4_shuffle_scale_a16w4(d["w1_scale"], NE, gate_up=True))
+    w2u8 = _u8v(_mxfp4_shuffle_weight_a16w4(d["w2_qt"], gate_up=False))
+    w2sc = _u8v(_mxfp4_shuffle_scale_a16w4(d["w2_scale"], NE, gate_up=False))
+
+    topk_ids_i32 = d["topk_ids"].to(torch.int32)
+    topk_w_f32 = d["topk_weights"].to(torch.float32)
+    max_padded = token * TOPK + NE * SBM - TOPK
+    max_sorted = ((max_padded + SBM - 1) // SBM) * SBM
+    sti = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    swt = torch.empty(max_sorted, dtype=torch.float32, device=device)
+    sei = torch.empty(max_sorted // SBM, dtype=torch.int32, device=device)
+    nv = torch.empty(2, dtype=torch.int32, device=device)
+    moe_buf = torch.empty((token, H), dtype=torch.bfloat16, device=device)
+    moe_sorting_flydsl(topk_ids_i32, topk_w_f32, sti, swt, sei, nv, moe_buf, NE, SBM)
+    torch.cuda.synchronize()
+    cumsum = nv
+    n = int(cumsum[0].item())
+
+    aq = d["a1_qt"].view(torch.uint8).view(token, H).contiguous()
+    asc = d["a1_scale"].view(torch.uint8).view(token, H // 32).contiguous()
+    assh = _mxfp4_a_scale_sorted_shuffled(asc, sti, cumsum, max_sorted, H, BM=BM_S1)
+
+    inter_cols = INTER  # fp8 out (a8w4)
+    isq = torch.zeros((max_sorted, inter_cols), device=device, dtype=torch.uint8)
+    isc_cols = INTER // 32
+    isr = (((max_sorted * ((2 * INTER) // 64) * 4) + isc_cols - 1) // isc_cols + 31) // 32 * 32
+    iss = torch.zeros((isr, isc_cols), device=device, dtype=torch.uint8)
+    return dict(
+        aq=aq, assh=assh, w1u8=w1u8, w1sc=w1sc, w2u8=w2u8, w2sc=w2sc,
+        sei=sei, cumsum=cumsum, sti=sti, swt=swt,
+        isq=isq, iss=iss, hidden=d["inp"], n=n, max_sorted=max_sorted,
+    )
+
+
+def time_baseline(d, token, topk, params):
+    b = d["base"]
+    def fn():
+        return flydsl_moe_stage1(
+            a=b["a1_qt"], w1=b["w1_qt_shuf"],
+            sorted_token_ids=b["sorted_ids"],
+            sorted_expert_ids=b["sorted_expert_ids"],
+            num_valid_ids=b["num_valid_ids"], topk=topk,
+            tile_m=params["tile_m"], tile_n=params["tile_n"], tile_k=params["tile_k"],
+            a_dtype="fp8", b_dtype="fp4", out_dtype="bf16",
+            w1_scale=b["w1_scale_shuf"], a1_scale=b["a1_scale_sort"],
+            sorted_weights=None,
+            k_batch=params.get("k_batch", 1),
+            waves_per_eu=params.get("waves_per_eu", 3),
+            gate_mode=params.get("gate_mode", "interleave"),
+            b_nt=params.get("b_nt", 2),
+            k_wave=params.get("k_wave", 1),
+        )
+    out = fn()
+    if isinstance(out, tuple):
+        out = out[0]
+    torch.cuda.synchronize()
+    ref = d["ref1"]
+    o = out.float().reshape(ref.shape)
+    ok = torch.isclose(ref.float(), o, atol=1.0, rtol=0.05).float().mean().item() * 100
+    _, us = run_perftest(fn, num_warmup=WARMUP, num_iters=ITERS)
+    return us, ok
+
+
+def _stage2_out_for_check(out, mode, token, topk, model_dim):
+    if mode == "reduce":
+        return out.view(token, topk, model_dim).sum(dim=1)
+    return out
+
+
+def time_baseline_gemm2(d, token, model_dim, topk, params, row=None):
+    b = d["base"]
+    row = row or {}
+    kn2 = row.get("kernelName2", "")
+    is_opus2 = _opus_a8w4.is_opus_a8w4_stage2_kernel(kn2)
+    mode = params.get("mode", "atomic")
+    out_shape = (
+        (token, model_dim)
+        if is_opus2 else
+        ((token, topk, model_dim) if mode == "reduce" else (token, model_dim))
+    )
+    out = torch.empty(out_shape, dtype=dtypes.bf16, device="cuda")
+
+    if is_opus2:
+        opus_values = _opus_a8w4.stage2_cfg_values(row, row.get("block_m", params["tile_m"]))
+
+        def fn():
+            return _opus_a8w4.opus_a8w4_stage2_wrapper(
+                inter_states=b["a2_qt"],
+                w1=None,
+                w2=b["w2_qt_shuf"],
+                sorted_token_ids=b["sorted_ids"],
+                sorted_expert_ids=b["sorted_expert_ids"],
+                num_valid_ids=b["num_valid_ids"],
+                out=out,
+                topk=topk,
+                kernelName=kn2,
+                w2_scale=b["w2_scale_shuf"].view(dtypes.fp8_e8m0),
+                a2_scale=b["a2_scale"],
+                sorted_weights=b["sorted_weights"],
+                block_m=int(row.get("block_m", params["tile_m"])),
+                **opus_values,
+            )
+
+        out.zero_()
+        fn()
+        torch.cuda.synchronize()
+        ref = d["ref2"].float()
+        got = out.float()
+        ok = torch.isclose(ref, got, atol=1.0, rtol=0.05).float().mean().item() * 100
+        _, us = run_perftest(fn, num_warmup=WARMUP, num_iters=ITERS)
+        return us, ok
+
+    def fn():
+        return flydsl_moe_stage2(
+            inter_states=b["a2_qt"],
+            w2=b["w2_qt_shuf"],
+            sorted_token_ids=b["sorted_ids"],
+            sorted_expert_ids=b["sorted_expert_ids"],
+            num_valid_ids=b["num_valid_ids"],
+            out=out,
+            topk=topk,
+            tile_m=params["tile_m"],
+            tile_n=params["tile_n"],
+            tile_k=params["tile_k"],
+            a_dtype="fp8",
+            b_dtype="fp4",
+            out_dtype="bf16",
+            mode=mode,
+            w2_scale=b["w2_scale_shuf"].view(dtypes.fp8_e8m0),
+            a2_scale=b["a2_scale"],
+            sorted_weights=b["sorted_weights"],
+            sort_block_m=params.get("sort_block_m", 0),
+            persist=params.get("persist", None),
+            waves_per_eu=params.get("waves_per_eu", None),
+            b_nt=params.get("b_nt", 0),
+            xcd_swizzle=params.get("xcd_swizzle", 0),
+            return_per_slot=(mode == "reduce"),
+        )
+
+    if mode != "reduce":
+        out.zero_()
+    fn()
+    torch.cuda.synchronize()
+    ref = d["ref2"].float()
+    got = _stage2_out_for_check(out, mode, token, topk, model_dim).float()
+    ok = torch.isclose(ref, got, atol=1.0, rtol=0.05).float().mean().item() * 100
+    _, us = run_perftest(fn, num_warmup=WARMUP, num_iters=ITERS)
+    return us, ok
+
+
+def _v2_group_cosine(d, v, token, inter_dim, E, BM_S1, sample=64):
+    """Per-32-group-normalized cosine of v2's dequant intermediate vs ref1.
+    Group-normalizing removes the per-32 e8m0 scale, so we validate the gemm
+    math + fp8 values without de-shuffling the (kernel-written) e8m0 scale."""
+    isq, sti, sei = v["isq"], v["sti"], v["sei"]
+    ref1 = d["ref1"]  # [token, topk, inter]
+    topk_ids = d["topk_ids"]
+    n = v["n"]
+    tok_of = (sti[:n] & 0x00FFFFFF)
+    real = (tok_of < token).nonzero(as_tuple=True)[0]
+    if real.numel() == 0:
+        return float("nan")
+    idx = real[torch.linspace(0, real.numel() - 1, min(sample, real.numel())).long()]
+    cos_all = []
+    for r in idx.tolist():
+        t = int(tok_of[r].item())
+        e = int(sei[r // BM_S1].item())
+        slot = (topk_ids[t] == e).nonzero(as_tuple=True)[0]
+        if slot.numel() == 0:
+            continue
+        s = int(slot[0].item())
+        vval = isq[r].view(torch.float8_e4m3fn).float()          # [inter]
+        ref = ref1[t, s].float()                                  # [inter]
+        vg = vval.view(inter_dim // 32, 32)
+        rg = ref.view(inter_dim // 32, 32)
+        vn = vg / (vg.norm(dim=1, keepdim=True) + 1e-8)
+        rn = rg / (rg.norm(dim=1, keepdim=True) + 1e-8)
+        cos_all.append((vn * rn).sum(dim=1).mean().item())
+    return sum(cos_all) / len(cos_all) * 100 if cos_all else float("nan")
+
+
+def time_v2(d, v, token, model_dim, inter_dim, E, topk, BM_S1, use_nt, BN, k_wave):
+    def fn():
+        return mxfp4_moe_gemm1(
+            a_quant=v["aq"], a_scale_sorted_shuffled=v["assh"],
+            w1_u8=v["w1u8"], w1_scale_u8=v["w1sc"],
+            sorted_expert_ids=v["sei"], cumsum_tensor=v["cumsum"],
+            sorted_token_ids=v["sti"], inter_sorted_quant=v["isq"],
+            inter_sorted_shuffled_scale=v["iss"], hidden_states=v["hidden"],
+            n_tokens=token, NE=E, D_HIDDEN=model_dim, D_INTER=inter_dim, topk=topk,
+            BM=BM_S1, use_nt=use_nt, interleave=True,
+            a_dtype="fp8", out_dtype="fp8", act="silu", swiglu_limit=0.0,
+            SBM=BM_S1, k_wave=k_wave, BN=BN, n_sorted_padded=v["n"],
+            model_dim_pad=0, inter_dim_pad=0,
+        )
+    v["isq"].zero_()
+    fn()
+    torch.cuda.synchronize()
+    ok = _v2_group_cosine(d, v, token, inter_dim, E, BM_S1)
+    _, us = run_perftest(fn, num_warmup=WARMUP, num_iters=ITERS)
+    return us, ok
+
+
+def time_v2_gemm2(d, v, token, model_dim, inter_dim, E, topk, BM_S1, BM_S2, use_nt,
+                  epilog, persist, BN, k_wave):
+    # Populate the sorted fp8 intermediate exactly as v2 production gemm2 consumes it.
+    mxfp4_moe_gemm1(
+        a_quant=v["aq"], a_scale_sorted_shuffled=v["assh"],
+        w1_u8=v["w1u8"], w1_scale_u8=v["w1sc"],
+        sorted_expert_ids=v["sei"], cumsum_tensor=v["cumsum"],
+        sorted_token_ids=v["sti"], inter_sorted_quant=v["isq"],
+        inter_sorted_shuffled_scale=v["iss"], hidden_states=v["hidden"],
+        n_tokens=token, NE=E, D_HIDDEN=model_dim, D_INTER=inter_dim, topk=topk,
+        BM=BM_S1, use_nt=gemm1_use_nt(E, topk, token, BM_S1), interleave=True,
+        a_dtype="fp8", out_dtype="fp8", act="silu", swiglu_limit=0.0,
+        SBM=BM_S1, k_wave=k_wave, BN=BN, n_sorted_padded=v["n"],
+        model_dim_pad=0, inter_dim_pad=0,
+    )
+    torch.cuda.synchronize()
+
+    out_shape = (token, topk, model_dim) if epilog == "reduce" else (token, model_dim)
+    out = torch.empty(out_shape, dtype=dtypes.bf16, device="cuda")
+
+    def fn():
+        return mxfp4_moe_gemm2(
+            inter_sorted_quant=v["isq"],
+            inter_sorted_shuffled_scale=v["iss"],
+            w2_u8=v["w2u8"],
+            w2_scale_u8=v["w2sc"],
+            sorted_expert_ids=v["sei"],
+            cumsum_tensor=v["cumsum"],
+            sorted_token_ids=v["sti"],
+            sorted_weights=v["swt"],
+            out=out,
+            M_logical=token,
+            max_sorted=v["max_sorted"],
+            NE=E,
+            D_HIDDEN=model_dim,
+            D_INTER=inter_dim,
+            topk=topk,
+            BM=BM_S2,
+            use_nt=use_nt,
+            a_dtype="fp8",
+            epilog=epilog,
+            SBM=BM_S1,
+            persist=persist,
+            n_sorted_padded=v["n"],
+            model_dim_pad=0,
+            inter_dim_pad=0,
+        )
+
+    if epilog != "reduce":
+        out.zero_()
+    fn()
+    torch.cuda.synchronize()
+    ref = d["ref2"].float()
+    got = _stage2_out_for_check(out, epilog, token, topk, model_dim).float()
+    ok = torch.isclose(ref, got, atol=1.0, rtol=0.05).float().mean().item() * 100
+    _, us = run_perftest(fn, num_warmup=WARMUP, num_iters=ITERS)
+    return us, ok
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--stage", choices=("gemm1", "gemm2"), default="gemm1")
+    p.add_argument("--csv", default="aiter/configs/model_configs/dsv4_fp8fp4_tuned_fmoe.csv")
+    p.add_argument("--model-dim", type=int, default=7168)
+    p.add_argument("--inter-dim", type=int, default=512)
+    p.add_argument("-E", "--experts", type=int, default=384)
+    p.add_argument("-k", "--topk", type=int, default=6)
+    p.add_argument("--tokens", type=int, nargs="+", default=None,
+                   help="override; default = all tuned M for the shape in the CSV")
+    p.add_argument("--same-tile", action="store_true",
+                   help="force v2 onto the baseline's tile config (BM=tile_m, k_wave, "
+                        "use_nt=b_nt==2, BN=64 if k_wave>1 else 256) instead of v2's "
+                        "own select_pipe_config -- isolates kernel-vs-kernel.")
+    args = p.parse_args()
+
+    # gather tuned (token, block_m, kernelName1) for the requested shape
+    rows = []
+    with open(args.csv, newline="") as f:
+        for r in _csv.DictReader(f):
+            if (int(r["model_dim"]) == args.model_dim and int(r["inter_dim"]) == args.inter_dim
+                    and int(r["expert"]) == args.experts and int(r["topk"]) == args.topk):
+                rows.append(r)
+    # dedup by token (keep first occurrence per tuned M)
+    _seen = set()
+    _uniq = []
+    for r in sorted(rows, key=lambda r: int(r["token"])):
+        t = int(r["token"])
+        if t in _seen:
+            continue
+        _seen.add(t)
+        _uniq.append(r)
+    rows = _uniq
+    if args.tokens is not None:
+        want = set(args.tokens)
+        rows = [r for r in rows if int(r["token"]) in want]
+    if not rows:
+        print("no matching CSV rows for shape")
+        return
+
+    print(f"dsv4 a8w4 {args.stage}  md={args.model_dim} id={args.inter_dim} "
+          f"E={args.experts} topk={args.topk}  (BALANCED, launch-only)")
+    if args.stage == "gemm1":
+        print("baseline = flydsl mixed_moe stage1 (CSV kernelName1) | "
+              "v2 = FlyDSL#753 mxfp4_moe_gemm1\n")
+    else:
+        print("baseline = CSV kernelName2 stage2 (flydsl/opus) | "
+              "v2 = FlyDSL#753 mxfp4_moe_gemm2\n")
+    hdr = f"{'M':>7} {'blk':>4} | {'base us':>9} {'ok%':>5} | {'v2 us':>9} {'cos%':>5} {'v2 cfg':>18} | {'delta%':>7}"
+    print(hdr)
+    print("-" * len(hdr))
+
+    results = []
+    for r in rows:
+        token = int(r["token"])
+        bm_csv = int(r["block_m"])
+        kn1 = r["kernelName1"]
+        params1 = get_flydsl_kernel_params(kn1) or {}
+        params1.setdefault("tile_m", bm_csv)
+        params1.setdefault("tile_n", 64)
+        params1.setdefault("tile_k", 256)
+        sort_bm = params1["tile_m"]
+
+        kn2 = r.get("kernelName2", "")
+        is_opus2 = _opus_a8w4.is_opus_a8w4_stage2_kernel(kn2)
+        params2 = get_flydsl_kernel_params(kn2) or {}
+        params2.setdefault("tile_m", bm_csv)
+        params2.setdefault("tile_n", 256)
+        params2.setdefault("tile_k", 256)
+        params2.setdefault("mode", "atomic")
+        if is_opus2:
+            opus_values = _opus_a8w4.stage2_cfg_values(r, bm_csv)
+            params2["tile_m"] = int(opus_values["stage2_block_m"])
+            params2["mode"] = "opus-route" if bool(opus_values["route_out"]) else "opus-atomic"
+
+        d = gen(token, args.model_dim, args.inter_dim, args.experts, args.topk, sort_bm)
+        try:
+            if args.stage == "gemm1":
+                base_us, base_ok = time_baseline(d, token, args.topk, params1)
+            else:
+                base_us, base_ok = time_baseline_gemm2(
+                    d, token, args.model_dim, args.topk, params2, row=r
+                )
+        except Exception as e:
+            base_us, base_ok = float("nan"), -1
+            print(f"{token:>7} {bm_csv:>4} | baseline FAIL: {str(e)[:70]}")
+
+        if args.same_tile:
+            # match the baseline tuned tile: BM, k_wave, nt; map baseline tile_n -> v2 BN.
+            if args.stage == "gemm1":
+                BM_S1 = params1["tile_m"]
+                BM_v2 = BM_S1
+                epilog = "atomic"
+                persist = False
+                KW_v2 = params1.get("k_wave", 1)
+                use_nt = params1.get("b_nt", 2) == 2
+                tn = params1.get("tile_n", 256)
+            else:
+                BM_S1 = sort_bm
+                BM_v2 = min(params2["tile_m"], 64)
+                epilog = params2.get("mode", "atomic")
+                persist = bool(params2.get("persist", False))
+                KW_v2 = params1.get("k_wave", 1)
+                use_nt = params2.get("b_nt", 0) == 2
+                tn = params1.get("tile_n", 256)
+            # v2 BN in {64,256}: tile_n<=64 -> BN64, tile_n>=128 -> BN256 (v2 has no BN128,
+            # so tile_n=128 is only approximated). BN64 structurally needs k_wave>=2.
+            if tn <= 64:
+                BN_v2 = 64
+            elif tn <= 128:
+                BN_v2 = 128
+            else:
+                BN_v2 = 256
+            if BN_v2 == 64 and KW_v2 < 2:
+                KW_v2 = 2
+        else:
+            # v2 dispatcher's own config for this M
+            BM_v2, epilog, BM_S1, persist, BN_v2, KW_v2 = select_pipe_config(
+                args.model_dim, args.inter_dim, args.experts, args.topk, token
+            )
+            if args.stage == "gemm2" and BM_S1 % BM_v2 != 0:
+                # gemm2 consumes an SBM-strided sorted stream and requires SBM
+                # to be a multiple of its BM. Tiny-M gemm1 may choose BM16, so
+                # promote the standalone gemm2 bench input stream to BM32.
+                BM_S1 = BM_v2
+            if args.stage == "gemm1":
+                use_nt = gemm1_use_nt(args.experts, args.topk, token, BM_S1)
+            else:
+                use_nt = gemm2_use_nt(args.experts, args.topk, token, BM_v2)
+        try:
+            v = build_v2_inputs(d, token, args.model_dim, args.inter_dim,
+                                args.experts, args.topk, BM_S1)
+            if args.stage == "gemm1":
+                v2_us, v2_nz = time_v2(
+                    d, v, token, args.model_dim, args.inter_dim,
+                    args.experts, args.topk, BM_S1, use_nt, BN_v2, KW_v2
+                )
+            else:
+                v2_us, v2_nz = time_v2_gemm2(
+                    d, v, token, args.model_dim, args.inter_dim,
+                    args.experts, args.topk, BM_S1, BM_v2, use_nt, epilog, persist,
+                    BN_v2, KW_v2
+                )
+        except Exception as e:
+            v2_us, v2_nz = float("nan"), -1
+            print(f"{token:>7} {bm_csv:>4} | v2 FAIL: {str(e)[:80]}")
+
+        delta = (v2_us - base_us) / base_us * 100 if base_us == base_us and v2_us == v2_us else float("nan")
+        if args.stage == "gemm1":
+            cfg = f"bm{BM_S1}bn{BN_v2}kw{KW_v2}{'nt' if use_nt else ''}"
+        else:
+            cfg = f"bm{BM_v2}{epilog[0]}sbm{BM_S1}{'p' if persist else ''}{'nt' if use_nt else ''}"
+        print(f"{token:>7} {bm_csv:>4} | {base_us:9.3f} {base_ok:5.1f} | "
+              f"{v2_us:9.3f} {v2_nz:5.1f} {cfg:>18} | {delta:+7.1f}")
+        results.append((token, base_us, v2_us, delta))
+
+    print(f"\nsummary {args.stage} (v2 delta% vs baseline; negative = v2 faster):")
+    for token, b, vv, dl in results:
+        print(f"  M={token:>7}: base {b:8.3f}us  v2 {vv:8.3f}us  {dl:+6.1f}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR optimizes the FlyDSL MXFP4/MXFP8 MoE v2 GEMM2 down-projection path for DSV4 a8w4 reduce-mode shapes.

- Adds a bf16 LDS cshuffle path for a8w4 GEMM2 reduce output, cutting C-tile LDS footprint from f32 to bf16 while preserving the existing atomic path.
- Adds `MXFP4_G2_INTER_MAX` so small-intermediate shapes such as DSV4 `inter_dim=512` can compile with a tighter K cap and hit a straight-line K=2 GEMM2 mainloop.
- Splits GEMM2 B consumption by N-half in the straight-line K2 path, reducing peak live B fragments and lowering final ISA VGPR usage from 219 -> 184 -> 168 for the target shape.
- Adds `bench_gemm12_v2_vs_baseline.py` to compare v2 GEMM1/GEMM2 launch latency and correctness against the tuned DSV4 baseline kernels.

MXFP4_G2_INTER_MAX=512 python bench_gemm12_v2_vs_baseline.py --stage gemm2   --csv aiter/configs/model_configs/dsv4_fp8fp4_tuned_fmoe.csv   --model-dim 7168 --inter-dim 512 -E 384 -k 6

## Test Plan

- Verified target GEMM2 kernel via `FLYDSL_DUMP_IR=1 MXFP4_G2_INTER_MAX=512` on DSV4 a8w4 shape:
  `model_dim=7168, inter_dim=512, E=384, topk=6`.
- Checked final ISA VGPR progression for the target reduce kernel:
  baseline v2 219 VGPR, straight-line K2 184 VGPR, N-half B split 168 VGPR, with no spill.
- Ran/used the new launch-only benchmark flow to validate v2 output correctness against the torch/reference-backed baseline path.
