### PR TITLE
[opus] Optimize Opus MoE A8W4 stage2 candidate set

### DIFF
--- a/aiter/ops/opus/moe_stage2_a8w4_meta.py
+++ b/aiter/ops/opus/moe_stage2_a8w4_meta.py
@@ -18,7 +18,7 @@ OPUS_A8W4_OUT_MODE_BF16 = 1
 OPUS_A8W4_OUT_MODE_FP8 = 2
 
 # Kid layout:
-# - 2000-2099: K3 decode candidates, assigned contiguously.
+# - 2000-2099: K3 decode candidates.
 # - 2100-2109: K5 direct atomic bring-up candidates.
 # - 2110-2119: K5 route-output bring-up candidates.
 OPUS_A8W4_KID_K3_ATOMIC_BM16_BN64_B3_WS2 = 2000
@@ -27,6 +27,9 @@ OPUS_A8W4_KID_K3_ROUTE_FP8_BM32_OCC5_RBN2304 = 2002
 OPUS_A8W4_KID_K3_ROUTE_FP8_BM64_RBN3072 = 2003
 OPUS_A8W4_KID_K3_ROUTE_FP8_BM64_RBN3584 = 2004
 OPUS_A8W4_KID_K3_ROUTE_BF16_BM64_FULL_N7168 = 2005
+OPUS_A8W4_KID_K3_ATOMIC_BM32_BN128_OCC1_B3_WS2 = 2006
+OPUS_A8W4_KID_K3_ROUTE_FP8_BM64_RBN3072_B3 = 2007
+OPUS_A8W4_KID_K3_ROUTE_BF16_BM32_FULL_N7168_SMALL = 2008
 OPUS_A8W4_KID_K5_ATOMIC_BM16_BN64_OCC6_B2_WS2 = 2100
 OPUS_A8W4_KID_K5_ATOMIC_BM16_BN64_B3_WS2 = 2101
 OPUS_A8W4_KID_K5_ROUTE_BF16_BM64_FULL_N7168 = 2110
@@ -304,6 +307,7 @@ def _route_stage2_instance(
     shape_family: str,
     route_reduce: str,
     min_blocks_per_cu: int = 0,
+    cachectl_b: int = 0,
     tuner_candidate: bool = True,
     min_tuner_token: Optional[int] = None,
     max_tuner_token: Optional[int] = None,
@@ -319,6 +323,7 @@ def _route_stage2_instance(
         sort_block_m=sort_block_m,
         direct_atomic=False,
         min_blocks_per_cu=min_blocks_per_cu,
+        cachectl_b=cachectl_b,
         route_reduce=route_reduce,
         tuner_candidate=tuner_candidate,
         min_tuner_token=min_tuner_token,
@@ -353,7 +358,7 @@ OPUS_A8W4_K3_STAGE2_INSTANCES = (
         sort_block_m=32,
         route_reduce="rbn2240",
         min_blocks_per_cu=4,
-        min_tuner_token=512,
+        min_tuner_token=8,
         max_tuner_token=4096,
         shape_family=_K3,
     ),
@@ -365,7 +370,7 @@ OPUS_A8W4_K3_STAGE2_INSTANCES = (
         sort_block_m=32,
         route_reduce="rbn2304",
         min_blocks_per_cu=5,
-        min_tuner_token=512,
+        min_tuner_token=8,
         max_tuner_token=4096,
         shape_family=_K3,
     ),
@@ -376,6 +381,7 @@ OPUS_A8W4_K3_STAGE2_INSTANCES = (
         block_m=64,
         sort_block_m=64,
         route_reduce="rbn3072",
+        min_tuner_token=128,
         shape_family=_K3,
         mode_default=True,
     ),
@@ -386,6 +392,7 @@ OPUS_A8W4_K3_STAGE2_INSTANCES = (
         block_m=64,
         sort_block_m=64,
         route_reduce="rbn3584",
+        min_tuner_token=128,
         shape_family=_K3,
     ),
     _route_stage2_instance(
@@ -398,6 +405,42 @@ OPUS_A8W4_K3_STAGE2_INSTANCES = (
         min_tuner_token=4096,
         shape_family=_K3,
         mode_default=True,
+    ),
+    _atomic_stage2_instance(
+        kid=OPUS_A8W4_KID_K3_ATOMIC_BM32_BN128_OCC1_B3_WS2,
+        name="opus_moe2_afp8_wfp4_atomic_t32x128x256_sbm32_occ1_cache_b3_ws2",
+        block_m=32,
+        block_n=128,
+        sort_block_m=32,
+        block_threads=128,
+        min_blocks_per_cu=1,
+        cachectl_b=3,
+        cachectl_wscale=2,
+        min_tuner_token=1,
+        max_tuner_token=2048,
+        shape_family=_K3,
+    ),
+    _route_stage2_instance(
+        kid=OPUS_A8W4_KID_K3_ROUTE_FP8_BM64_RBN3072_B3,
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64_cache_b3",
+        out_mode=OPUS_A8W4_OUT_MODE_FP8,
+        block_m=64,
+        sort_block_m=64,
+        route_reduce="rbn3072",
+        cachectl_b=3,
+        min_tuner_token=128,
+        shape_family=_K3,
+    ),
+    _route_stage2_instance(
+        kid=OPUS_A8W4_KID_K3_ROUTE_BF16_BM32_FULL_N7168_SMALL,
+        name="opus_moe2_afp8_wfp4_bf16_t32x256x256_sbm32_small",
+        out_mode=OPUS_A8W4_OUT_MODE_BF16,
+        block_m=32,
+        sort_block_m=32,
+        route_reduce="full_model_n7168",
+        min_tuner_token=1,
+        max_tuner_token=64,
+        shape_family=_K3,
     ),
 )
 

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
@@ -164,10 +164,9 @@ inline __device__ bool opus_moe_stage2_a8w4_decode_load_route_metadata(
     }
     else
     {
-        if constexpr(T::IS_BM32_BN256)
+        if constexpr(T::IS_BM32_BN256 || T::IS_BM64_BN256)
         {
-            // Fast path for full sorted tiles. Store-side route_row guards are
-            // still kept so malformed metadata cannot write a negative route row.
+            // Full sorted tiles do not need a route-count reduction.
             if(route_base + T::B_M <= sorted_rows)
             {
                 __syncthreads();
@@ -620,24 +619,22 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
 }
 
 // Epilogue: direct atomic output or route-out store.
-typedef __bf16 opus_moe_stage2_a8w4_decode_bf16x2_t __attribute__((ext_vector_type(2)));
 typedef uint32_t opus_moe_stage2_a8w4_decode_u32x4_store_t
     __attribute__((ext_vector_type(4)));
 
 inline __device__ void opus_moe_stage2_a8w4_decode_atomic_add_bf16x2(
-    uint32_t packed_bf16x2,
-    __amdgpu_buffer_rsrc_t out_rsrc,
+    opus::bf16x2_t data,
+    opus::i32x4_t out_rsrc,
     int byte_offset)
 {
-    const opus_moe_stage2_a8w4_decode_bf16x2_t data =
-        __builtin_bit_cast(opus_moe_stage2_a8w4_decode_bf16x2_t, packed_bf16x2);
-#if OPUS_HAS_RAW_PTR_ATOMIC_FADD_V2F16_BUILTIN
-    __builtin_amdgcn_raw_ptr_buffer_atomic_fadd_v2f16(data, out_rsrc, byte_offset, 0, 0);
+#if OPUS_HAS_BUFFER_ATOMIC_PK_ADD_BF16
+    (void)opus::llvm_amdgcn_raw_buffer_atomic_fadd_v2bf16(
+        data, out_rsrc, byte_offset, 0, 0);
 #else
-    opus::i32x4_t rsrc;
-    __builtin_memcpy(&rsrc, &out_rsrc, sizeof(opus::i32x4_t));
-    opus::llvm_amdgcn_raw_buffer_atomic_fadd_v2f16(
-        __builtin_bit_cast(opus::fp16x2_t, data), rsrc, byte_offset, 0, 0);
+    (void)data;
+    (void)out_rsrc;
+    (void)byte_offset;
+    __builtin_trap();
 #endif
 }
 
@@ -708,7 +705,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_atomic_smem_to_out(
     const OpusMoeStage2A8W4CShuffleLayout<T>& c_layout,
     int col_base,
     int64_t output_row_stride,
-    __amdgpu_buffer_rsrc_t out_rsrc)
+    opus::i32x4_t out_rsrc)
 {
     constexpr int CSHUFFLE_NLANE =
         OpusMoeStage2A8W4CShuffleLayout<T>::CSHUFFLE_NLANE;
@@ -717,7 +714,6 @@ inline __device__ void opus_moe_stage2_a8w4_decode_atomic_smem_to_out(
     constexpr int PAIRS_PER_ROW =
         OpusMoeStage2A8W4CShuffleLayout<T>::PAIRS_PER_ROW;
     constexpr int ATOMIC_GROUPS = PAIRS_PER_ROW / CSHUFFLE_NLANE;
-    using Schedule = OpusMoeStage2A8W4DecodeSchedule<T>;
     static_assert(T::BLOCK_SIZE % CSHUFFLE_NLANE == 0);
     static_assert(T::B_M % CSHUFFLE_MLANE == 0);
     static_assert((PAIRS_PER_ROW & (PAIRS_PER_ROW - 1)) == 0);
@@ -737,12 +733,11 @@ inline __device__ void opus_moe_stage2_a8w4_decode_atomic_smem_to_out(
                 c_layout.output_byte_offset(token, output_row_stride, col_base, col0);
             opus::static_for<ATOMIC_GROUPS>([&](auto group) {
                 constexpr int pair_delta = group.value * CSHUFFLE_NLANE;
-                constexpr int byte_delta =
-                    pair_delta * static_cast<int>(sizeof(uint32_t));
+                constexpr int byte_delta = pair_delta * static_cast<int>(sizeof(uint32_t));
+                const auto data = __builtin_bit_cast(
+                    opus::bf16x2_t, smem_c_pair[pair_base + pair_delta]);
                 opus_moe_stage2_a8w4_decode_atomic_add_bf16x2(
-                    smem_c_pair[pair_base + pair_delta],
-                    out_rsrc,
-                    byte_offset + byte_delta);
+                    data, out_rsrc, byte_offset + byte_delta);
             });
         }
     }
@@ -905,7 +900,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_direct_epilogue(
     uint32_t* __restrict__ smem_c_pair,
     int col_base,
     int64_t output_row_stride,
-    __amdgpu_buffer_rsrc_t output_rsrc)
+    opus::i32x4_t output_rsrc)
 {
     using namespace opus;
     using opus::operator""_I;
@@ -1098,8 +1093,13 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
             static_cast<unsigned long long>(output_rows_per_token) *
             static_cast<unsigned long long>(kargs.stride_o_t) *
             static_cast<unsigned long long>(sizeof(hip_bfloat16)));
-        auto output_rsrc = opus::make_buffer_rsrc(static_cast<void*>(kargs.out_bf16),
-                                                  output_size_bytes);
+        const auto output_ptr_bits = reinterpret_cast<__UINTPTR_TYPE__>(kargs.out_bf16);
+        const opus::i32x4_t output_rsrc{
+            static_cast<int>(static_cast<unsigned int>(output_ptr_bits)),
+            static_cast<int>((static_cast<unsigned long long>(output_ptr_bits) >> 32) &
+                             0xffffu),
+            static_cast<int>(output_size_bytes),
+            static_cast<int>(opus::buffer_default_config())};
         opus_moe_stage2_a8w4_decode_direct_epilogue<T>(
             v_c,
             u_c,

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_traits_stage2_a8w4_decode_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_traits_stage2_a8w4_decode_gfx950.cuh
@@ -61,7 +61,8 @@ struct OpusMoeStage2A8W4DecodeShape
     // route_out XCD swizzle (gfx950=8 XCDs).
     static constexpr int NUM_XCD = DIRECT_ATOMIC_OUT ? 1 : 8;
     static constexpr int SWIZZLE_W = 2;
-    static constexpr int SWIZZLE_C = 0;
+    static constexpr int SWIZZLE_C =
+        (!DIRECT_ATOMIC_OUT && (IS_BM32_BN256 || IS_BM64_BN256)) ? 32 : 0;
     static constexpr bool DECODE_PACE_ROUTE_BLOCKS_TO_POW2 = PaceRouteBlocksToPow2;
     static constexpr int K_TILES = DECODE_EFFECTIVE_INTER_DIM / K_STEP_PACKED;
     static constexpr int A_LDS_STAGES = K_TILES, A_LDS_STAGE_ELEMS = B_M * K_STEP_PACKED;

--- a/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
@@ -62,7 +62,7 @@ opus_moe_stage2_route_reduce_pack_bf16x4(const float* acc, int base)
 //              unrolls and issues the route loads before the final reduction.
 // TOPK == 0 -> fallback to the runtime kargs.topk loop.
 template<int BLOCK_N, int BLOCK_THREADS, int TOPK = 0, bool ROUTE_FP8 = false>
-__global__ __launch_bounds__(BLOCK_THREADS, 4) void
+__global__ __launch_bounds__(BLOCK_THREADS, ROUTE_FP8 ? 2 : 4) void
 opus_moe_stage2_reduce_token_slot_route_output_kernel_gfx950(opus_moe_stage2_route_reduce_kargs kargs)
 {
 #ifdef __HIP_DEVICE_COMPILE__
@@ -106,7 +106,8 @@ opus_moe_stage2_reduce_token_slot_route_output_kernel_gfx950(opus_moe_stage2_rou
             {
                 const uint8_t* rp =
                     ro8 + static_cast<int64_t>(route_row_base + slot) * rstride;
-                const uint64_t f8 = *reinterpret_cast<const uint64_t*>(rp + col);
+                const uint64_t f8 =
+                    __builtin_nontemporal_load(reinterpret_cast<const uint64_t*>(rp + col));
                 const float sf = __builtin_bit_cast(
                     float, static_cast<uint32_t>(rp[scale_off + (col >> 3)]) << 23);
                 const f32x2 s2 = f32x2{sf, sf};


### PR DESCRIPTION
## Motivation

  This PR improves the Opus MoE A8W4 stage2 candidate set for gfx950 by keeping the measured useful performance candidates while trimming unused experimental
  variants. The goal is to reduce review and codegen noise while preserving the stage2 performance improvements for DSV4 A8W4 decode shapes.

  ## Technical Details

  - Adds retained A8W4 stage2 candidates:
    - BM32 direct atomic candidate for small and mid token counts.
    - BM64 FP8 route-out candidate with `cache_b3` and `rbn3072`.
    - BM32 BF16 route-out small-token candidate.
  - Removes experimental A8W4 candidates that did not become stable winners in the latest fixed-blockM tune pass.
  - Renumbers the retained K3 A8W4 kids so the K3 range is compact:
    - `2000-2008` for K3 decode candidates.
    - Existing K5 ranges remain under `2100+`.
  - Keeps the direct BF16 atomic path on raw-buffer atomic, with a small guarded helper around `llvm.amdgcn.raw.buffer.atomic.fadd.v2bf16`.
  - Keeps FP8 route-reduce route-out loads as nontemporal loads where focused A/B showed a small route-reduce improvement.
  - Does not change the public Opus API or broad pipeline structure.

  ## Test Plan

  - Python/static checks:
    - `black --check aiter/ops/opus/moe_stage2_a8w4_meta.py`
    - `ruff check aiter/ops/opus/moe_stage2_a8w4_meta.py`
    - `python3 -m py_compile aiter/ops/opus/moe_stage2_a8w4_meta.py csrc/opus_moe/gen_instances.py`
    - `git diff --check`
  - Codegen checks:
    - `python3 csrc/opus_moe/gen_instances.py --working_path /tmp/opus_moe_codegen_pre_amend --arch gfx950`
    - `python3 csrc/opus_moe/gen_instances.py --working_path /tmp/opus_moe_codegen_renumber_kids --arch gfx950`
  - Compile checks:
    - ROCm 7.1.1 / clang20 multiarch build for `module_moe_opus` with `GPU_ARCHS=gfx942;gfx950`.
    - Confirmed generated `module_moe_opus.so` contains both `amdhsa--gfx942` and `amdhsa--gfx950`.

  ## Test Result

  - `black --check`: passed.
  - `ruff check`: passed.
  - `py_compile`: passed.
  - `git diff --check`: passed.
  - A8W4 stage2 codegen: passed, generated 13 A8W4 stage2 kids.
  - ROCm 7.1.1 / clang20 multiarch `module_moe_opus` build: passed.
  - Generated multiarch `.so` contains:
    - `amdhsa--gfx942`
    - `amdhsa--gfx950`

  Performance validation was not rerun after the final metadata trim because GPUs were occupied. The retained candidates are based on the latest fixed-blockM tune
  results collected before the cleanup.

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.