### PR TITLE
fea: gfx1250 comm kernel naive impl

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -30,8 +30,26 @@ from aiter.dist.parallel_state import in_the_same_node_as
 from aiter import logger
 from aiter.utility.dtypes import fp8
 
+
+def _detect_gfx1250() -> bool:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return False
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        return "gfx1250" in getattr(props, "gcnArchName", "")
+    except Exception:
+        return False
+
+
+_is_gfx1250 = _detect_gfx1250()
+
 try:
-    ops.meta_size()
+    if _is_gfx1250:
+        ops.meta_size_gfx1250()
+    else:
+        ops.meta_size()
     custom_ar = True
 except Exception as e:
     # For CPUs
@@ -165,12 +183,16 @@ class IPCBuffer:
         size: int,
         device: torch.device,
         uncached: bool = False,
+        alloc_fn=None,
+        free_fn=None,
     ):
         self._size = size
         self._uncached = uncached
+        self._free_fn = free_fn or ops.free_meta_buffer
         if uncached:
             self._buffer = None
-            self._raw_ptr = ops.allocate_meta_buffer(size)
+            _alloc = alloc_fn or ops.allocate_meta_buffer
+            self._raw_ptr = _alloc(size)
         else:
             self._buffer = torch.empty(size, dtype=torch.uint8, device=device)
             self._raw_ptr = self._buffer.data_ptr()
@@ -197,7 +219,7 @@ class IPCBuffer:
 
     def __del__(self):
         if self._uncached and self._raw_ptr:
-            ops.free_meta_buffer(self._raw_ptr)
+            self._free_fn(self._raw_ptr)
             self._raw_ptr = 0
 
 
@@ -221,12 +243,28 @@ class IPCBufferPool:
 
     _pool_seq: int = 0
 
-    def __init__(self, device: torch.device, group: ProcessGroup):
+    def __init__(
+        self,
+        device: torch.device,
+        group: ProcessGroup,
+        ipc_handle_fn=None,
+        graph_count_fn=None,
+        graph_ipc_meta_fn=None,
+        graph_register_fn=None,
+        alloc_fn=None,
+        free_fn=None,
+    ):
         self._device = device
         self._group = group
         self._rank = dist.get_rank(group=group)
         self._world_size = dist.get_world_size(group=group)
         self._buffers: Dict[str, IPCBuffer] = {}
+        self._ipc_handle_fn = ipc_handle_fn or ops.get_meta_buffer_ipc_handle
+        self._graph_count_fn = graph_count_fn or ops.get_graph_buffer_count
+        self._graph_ipc_meta_fn = graph_ipc_meta_fn or ops.get_graph_buffer_ipc_meta
+        self._graph_register_fn = graph_register_fn or ops.register_graph_buffers
+        self._alloc_fn = alloc_fn or ops.allocate_meta_buffer
+        self._free_fn = free_fn or ops.free_meta_buffer
 
         self._store = dist.distributed_c10d._get_default_store()
         self._assert_pure_tcp_store(self._store)
@@ -263,7 +301,13 @@ class IPCBufferPool:
         """
         if key in self._buffers:
             raise KeyError(f"IPCBuffer '{key}' already exists in the pool")
-        buf = IPCBuffer(size, self._device, uncached=uncached)
+        buf = IPCBuffer(
+            size,
+            self._device,
+            uncached=uncached,
+            alloc_fn=self._alloc_fn,
+            free_fn=self._free_fn,
+        )
         self._buffers[key] = buf
         return buf
 
@@ -293,16 +337,16 @@ class IPCBufferPool:
         are not yet IPC-registered.  After capture ends this method exchanges
         their IPC handles across all ranks and completes registration.
         """
-        count = ops.get_graph_buffer_count(ar_ptr)
+        count = self._graph_count_fn(ar_ptr)
         if count == 0:
             return
         handle_sz = 64  # sizeof(hipIpcMemHandle_t)
         handle = torch.empty(count * handle_sz, dtype=torch.uint8)
         offset = torch.empty(count, dtype=torch.int64)
-        ops.get_graph_buffer_ipc_meta(ar_ptr, handle.data_ptr(), offset.data_ptr())
+        self._graph_ipc_meta_fn(ar_ptr, handle.data_ptr(), offset.data_ptr())
         handles, offsets = self._gather_ipc_meta((handle, offset))
         logger.info("Registering %d cuda graph addresses", count)
-        ops.register_graph_buffers(
+        self._graph_register_fn(
             ar_ptr,
             [h.data_ptr() for h in handles],
             [o.data_ptr() for o in offsets],
@@ -313,7 +357,7 @@ class IPCBufferPool:
     def _broadcast_ipc(self, data_ptr: int) -> Tuple[List, List]:
         """Get IPC handle for *data_ptr* and broadcast across all ranks."""
         handle = torch.empty(64, dtype=torch.uint8)  # sizeof(hipIpcMemHandle_t)
-        ops.get_meta_buffer_ipc_handle(data_ptr, handle.data_ptr())
+        self._ipc_handle_fn(data_ptr, handle.data_ptr())
         return self._gather_ipc_meta((handle, 0))
 
     def _gather_ipc_meta(self, shard_data) -> Tuple[List, List]:
@@ -340,9 +384,114 @@ class IPCBufferPool:
         return handles, offsets
 
 
+class _GFX1250BufferProxy:
+    """Minimal proxy that exposes pool-like access for gfx1250's VMM-based
+    buffers so the rest of CustomAllreduce can use self._pool["meta"] etc."""
+
+    def __init__(self, vmm_meta, vmm_input, ca):
+        self._meta = vmm_meta
+        self._input = vmm_input
+        self._ca = ca
+
+    class _Entry:
+        def __init__(self, vmm_buf):
+            self._buf = vmm_buf
+
+        @property
+        def data_ptr(self):
+            return self._buf.data_ptr
+
+        @property
+        def max_size(self):
+            return self._buf.alloc_size
+
+    def __getitem__(self, key):
+        if key == "meta":
+            return self._Entry(self._meta)
+        elif key == "input":
+            return self._Entry(self._input)
+        raise KeyError(key)
+
+    def flush_graph_buffers(self, ar_ptr):
+        # TODO: full CUDA graph support on gfx1250 requires VMM-based
+        # exchange for graph-captured buffers. For now, graph capture
+        # is not supported on gfx1250 — log a warning.
+        count = self._ca._ops_get_graph_buffer_count(ar_ptr)
+        if count > 0:
+            logger.warning(
+                "gfx1250: CUDA graph buffer registration not yet "
+                "supported (%d buffers skipped)",
+                count,
+            )
+
+    def get_external_ipc_meta(self, tensor):
+        """Exchange a tensor's pointer across ranks using VMM."""
+        from .vmm_allocator import VMMBuffer, vmm_exchange
+        import torch.distributed as dist
+
+        ca = self._ca
+        store = dist.distributed_c10d._get_default_store()
+        ranks_tag = "_".join(map(str, sorted(dist.get_process_group_ranks(ca.group))))
+        all_device_ids = list(range(ca.world_size))
+        vmm_buf = VMMBuffer(tensor.numel() * tensor.element_size(), ca.device.index)
+        # Copy tensor data into VMM buffer
+        import ctypes
+
+        _hip = ctypes.CDLL("libamdhip64.so")
+        _hip.hipMemcpyAsync(
+            ctypes.c_void_p(vmm_buf.data_ptr),
+            ctypes.c_void_p(tensor.data_ptr()),
+            tensor.numel() * tensor.element_size(),
+            4,
+            ctypes.c_void_p(0),  # hipMemcpyDeviceToDevice
+        )
+        _hip.hipDeviceSynchronize()
+        ptrs, imports = vmm_exchange(
+            ca.rank,
+            ca.world_size,
+            f"ext_{id(self)}_{tensor.data_ptr()}",
+            vmm_buf,
+            store,
+            ranks_tag,
+            all_device_ids,
+        )
+        if not hasattr(ca, "_vmm_ext_imports"):
+            ca._vmm_ext_imports = []
+        ca._vmm_ext_imports.extend(imports)
+        ca._vmm_ext_imports.append(vmm_buf)
+        return ptrs
+
+
 class CustomAllreduce:
 
     _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
+
+    def _select_ops(self):
+        """Select the correct ops backend based on GPU architecture."""
+        if self._is_gfx1250:
+            self._ops_meta_size = ops.meta_size_gfx1250
+            self._ops_init_custom_ar = ops.init_custom_ar_gfx1250
+            self._ops_all_reduce = ops.all_reduce_gfx1250
+            self._ops_all_gather = ops.all_gather_gfx1250
+            self._ops_reduce_scatter = ops.reduce_scatter_gfx1250
+            self._ops_dispose = ops.dispose_gfx1250
+            self._ops_register_input_buffer = ops.register_input_buffer_gfx1250
+            self._ops_register_output_buffer = ops.register_output_buffer_gfx1250
+            self._ops_get_graph_buffer_count = ops.get_graph_buffer_count_gfx1250
+            self._ops_get_graph_buffer_ptrs = ops.get_graph_buffer_ptrs_gfx1250
+            self._ops_register_graph_buffers = ops.register_graph_buffers_gfx1250
+        else:
+            self._ops_meta_size = ops.meta_size
+            self._ops_init_custom_ar = ops.init_custom_ar
+            self._ops_all_reduce = ops.all_reduce
+            self._ops_all_gather = None
+            self._ops_reduce_scatter = ops.reduce_scatter
+            self._ops_dispose = ops.dispose
+            self._ops_register_input_buffer = ops.register_input_buffer
+            self._ops_register_output_buffer = ops.register_output_buffer
+            self._ops_get_graph_buffer_count = ops.get_graph_buffer_count
+            self._ops_get_graph_buffer_ptrs = None
+            self._ops_register_graph_buffers = ops.register_graph_buffers
 
     # max_size: max supported allreduce size
     def __init__(
@@ -364,6 +513,8 @@ class CustomAllreduce:
         """
         self._IS_CAPTURING = False
         self.disabled = True
+        self._is_gfx1250 = _is_gfx1250
+        self._select_ops()
 
         if not custom_ar:
             # disable because of missing custom allreduce library
@@ -399,6 +550,15 @@ class CustomAllreduce:
                 str(CustomAllreduce._SUPPORTED_WORLD_SIZES),
             )
             return
+
+        props = torch.cuda.get_device_properties(device)
+        gcn_arch = getattr(props, "gcnArchName", "")
+        if "gfx1250" in gcn_arch and world_size > 4:
+            raise RuntimeError(
+                f"gfx1250 (MI450) custom allreduce only supports "
+                f"world_size <= 4, got world_size={world_size}. "
+                f"RCCL fallback is also not available on this platform."
+            )
 
         if isinstance(device, int):
             device = torch.device(f"cuda:{device}")
@@ -443,6 +603,16 @@ class CustomAllreduce:
         #     return
 
         self.disabled = False
+        # gfx1250 (MI450) cannot register CUDA-graph-captured buffers across
+        # ranks: `flush_graph_buffers` / `register_graph_buffers` are no-ops
+        # there (VMM-based graph exchange not yet implemented). The "registered"
+        # capture path bakes raw input pointers that peers would dereference at
+        # replay without ever being registered → GPU page fault on the first
+        # graph replay (e.g. V4 TP=2 decode). Force the copy-in "unreg" path
+        # during capture, which routes through the pre-registered VMM pool
+        # (exchanged at init, address-stable across replays).
+        if self._is_gfx1250:
+            enable_register_for_capturing = False
         self.enable_register_for_capturing = enable_register_for_capturing
         # This is a buffer for storing the tuples of pointers pointing to
         # IPC buffers from all ranks. Each registered tuple has size of
@@ -456,19 +626,92 @@ class CustomAllreduce:
         self.rank = rank
         self.world_size = world_size
 
+        self.fully_connected = fully_connected
+
+        if self._is_gfx1250:
+            self._init_gfx1250(rank, world_size, max_size)
+        else:
+            self._init_ipc(rank, world_size, max_size)
+
+    def _init_gfx1250(self, rank: int, world_size: int, max_size: int):
+        """gfx1250 init: hipIpc unavailable, use HIP VMM API to share
+        GPU buffers across processes via exported fd + Unix socket."""
+        from .vmm_allocator import VMMBuffer, vmm_exchange
+
+        meta_sz = self._ops_meta_size()
+        # gfx1250 is 1-stage only — no tmp buffer after Signal needed
+        total_meta = meta_sz
+        device_id = self.device.index
+
+        # Collect all device ids in this group for VMM access permissions
+        all_device_ids = list(range(world_size))
+
+        store = dist.distributed_c10d._get_default_store()
+        ranks_tag = "_".join(map(str, sorted(dist.get_process_group_ranks(self.group))))
+
+        # Allocate meta buffer via VMM and zero-init
+        self._vmm_meta = VMMBuffer(total_meta, device_id)
+        import ctypes
+
+        _hip = ctypes.CDLL("libamdhip64.so")
+        _hip.hipMemsetAsync(
+            ctypes.c_void_p(self._vmm_meta.data_ptr),
+            0,
+            self._vmm_meta.alloc_size,
+            ctypes.c_void_p(0),
+        )
+        _hip.hipDeviceSynchronize()
+
+        # Allocate input buffer via VMM
+        self._vmm_input = VMMBuffer(max_size, device_id)
+
+        # Exchange meta buffers across ranks
+        all_meta_ptrs, self._vmm_meta_imports = vmm_exchange(
+            rank,
+            world_size,
+            "meta",
+            self._vmm_meta,
+            store,
+            ranks_tag,
+            all_device_ids,
+        )
+        self._ptr = self._ops_init_custom_ar(
+            self._vmm_meta.data_ptr,
+            self.rank_data.data_ptr(),
+            self.rank_data.numel(),
+            all_meta_ptrs,
+            rank,
+            self.fully_connected,
+        )
+
+        # Exchange input buffers across ranks
+        all_input_ptrs, self._vmm_input_imports = vmm_exchange(
+            rank,
+            world_size,
+            "input",
+            self._vmm_input,
+            store,
+            ranks_tag,
+            all_device_ids,
+        )
+        self._ops_register_input_buffer(
+            self._ptr,
+            self._vmm_input.data_ptr,
+            all_input_ptrs,
+        )
+
+        # Expose pool-like interface for the rest of the class
+        self._pool = _GFX1250BufferProxy(self._vmm_meta, self._vmm_input, self)
+
+    def _init_ipc(self, rank: int, world_size: int, max_size: int):
+        """Standard init path using hipIpc handles."""
         # Create IPC buffer pool and allocate all named buffers.
-        # "meta" uses hipAlloc (uncached) for synchronization metadata +
-        # intermediate allreduce temp storage.
-        # "input" uses torchAlloc (cached) for D2D relay in eager mode.
         self._pool = IPCBufferPool(self.device, self.group)
-        self._pool.create("meta", ops.meta_size() + max_size * 2, uncached=True)
+        self._pool.create("meta", self._ops_meta_size() + max_size * 2, uncached=True)
         self._pool.create("input", max_size)
 
-        # Exchange meta buffer IPC handles to initialize C++ backend
         handles, offsets = self._pool.get_ipc_meta("meta")
-
-        self.fully_connected = fully_connected
-        self._ptr = ops.init_custom_ar(
+        self._ptr = self._ops_init_custom_ar(
             self._pool["meta"].data_ptr,
             self.rank_data.data_ptr(),
             self.rank_data.numel(),
@@ -478,9 +721,8 @@ class CustomAllreduce:
             self.fully_connected,
         )
 
-        # Register input IPC buffer with the C++ backend
         handles, offsets = self._pool.get_ipc_meta("input")
-        ops.register_input_buffer(
+        self._ops_register_input_buffer(
             self._ptr,
             self._pool["input"].data_ptr,
             [h.data_ptr() for h in handles],
@@ -504,17 +746,25 @@ class CustomAllreduce:
 
     def register_input_buffer(self, inp: torch.Tensor):
         """Register an external tensor as an IPC input buffer."""
-        handles, offsets = self._pool.get_external_ipc_meta(inp)
-        ops.register_input_buffer(
-            self._ptr, inp.data_ptr(), [h.data_ptr() for h in handles], offsets
-        )
+        if self._is_gfx1250:
+            all_ptrs = self._pool.get_external_ipc_meta(inp)
+            self._ops_register_input_buffer(self._ptr, inp.data_ptr(), all_ptrs)
+        else:
+            handles, offsets = self._pool.get_external_ipc_meta(inp)
+            self._ops_register_input_buffer(
+                self._ptr, inp.data_ptr(), [h.data_ptr() for h in handles], offsets
+            )
 
     def register_output_buffer(self, out: torch.Tensor):
         """Register an external tensor as an IPC output buffer."""
-        handles, offsets = self._pool.get_external_ipc_meta(out)
-        ops.register_output_buffer(
-            self._ptr, out.data_ptr(), [h.data_ptr() for h in handles], offsets
-        )
+        if self._is_gfx1250:
+            all_ptrs = self._pool.get_external_ipc_meta(out)
+            self._ops_register_output_buffer(self._ptr, out.data_ptr(), all_ptrs)
+        else:
+            handles, offsets = self._pool.get_external_ipc_meta(out)
+            self._ops_register_output_buffer(
+                self._ptr, out.data_ptr(), [h.data_ptr() for h in handles], offsets
+            )
 
     def register_graph_buffers(self):
         """Batch-register graph-captured buffer addresses."""
@@ -586,7 +836,7 @@ class CustomAllreduce:
         assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
         reg_inp = 0 if registered_input else self._pool["input"].data_ptr
         reg_inp_bytes = 0 if registered_input else self._pool["input"].max_size
-        ops.all_reduce(
+        self._ops_all_reduce(
             self._ptr,
             inp,
             out,
@@ -696,7 +946,7 @@ class CustomAllreduce:
         m, n, k, split_dim = self._compute_rs_args(tuple(inp.shape), dim, inp.numel())
         reg = 0 if registered else self._pool["input"].data_ptr
         reg_bytes = 0 if registered else self._pool["input"].max_size
-        ops.reduce_scatter(
+        self._ops_reduce_scatter(
             self._ptr,
             inp,
             out,
@@ -718,7 +968,12 @@ class CustomAllreduce:
             return None
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                return self.reduce_scatter(input, output, dim, registered=True)
+                # gfx1250 cannot register graph buffers cross-rank (see
+                # enable_register_for_capturing note in __init__); use the
+                # copy-in path so capture/replay reads the pre-registered pool.
+                return self.reduce_scatter(
+                    input, output, dim, registered=self.enable_register_for_capturing
+                )
             else:
                 # Warmup forward (pre-capture): run the REAL reduce_scatter via
                 # the copy-in path. Unlike custom_all_reduce, returning zeros
@@ -749,12 +1004,22 @@ class CustomAllreduce:
                 device=inp.device,
             )
         assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
-        ops.all_gather_reg(
-            self._ptr,
-            inp,
-            out,
-            dim,
-        )
+        if self._ops_all_gather is not None:
+            self._ops_all_gather(
+                self._ptr,
+                inp,
+                out,
+                dim,
+                0,  # reg_inp_ptr: 0 = already registered
+                0,  # reg_inp_bytes
+            )
+        else:
+            ops.all_gather_reg(
+                self._ptr,
+                inp,
+                out,
+                dim,
+            )
         return out
 
     def all_gather_unreg(
@@ -767,14 +1032,24 @@ class CustomAllreduce:
                 device=inp.device,
             )
         assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
-        ops.all_gather_unreg(
-            self._ptr,
-            inp,
-            self._pool["input"].data_ptr,
-            out,
-            self._pool["input"].max_size,
-            dim,
-        )
+        if self._ops_all_gather is not None:
+            self._ops_all_gather(
+                self._ptr,
+                inp,
+                out,
+                dim,
+                self._pool["input"].data_ptr,
+                self._pool["input"].max_size,
+            )
+        else:
+            ops.all_gather_unreg(
+                self._ptr,
+                inp,
+                self._pool["input"].data_ptr,
+                out,
+                self._pool["input"].max_size,
+                dim,
+            )
         return out
 
     # Int dtypes have no fp counterpart in the C++ dispatch enum, but the
@@ -795,7 +1070,13 @@ class CustomAllreduce:
 
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                out = self.all_gather_reg(inp.view(view_dtype), dim=dim)
+                # gfx1250 cannot register graph buffers cross-rank (see
+                # enable_register_for_capturing note in __init__); use the
+                # copy-in path so capture/replay reads the pre-registered pool.
+                if self.enable_register_for_capturing:
+                    out = self.all_gather_reg(inp.view(view_dtype), dim=dim)
+                else:
+                    out = self.all_gather_unreg(inp.view(view_dtype), dim=dim)
             else:
                 # Warmup forward (pre-capture): run the REAL all_gather via the
                 # copy-in (unreg) path. Returning zeros here corrupts V4 MoE
@@ -1071,7 +1352,6 @@ class CustomAllreduce:
         registered: bool = False,
         use_1stage: bool = False,
         emit_bf16: bool = False,
-        transpose_scale: bool = False,
     ):
         K = inp.shape[-1]
         # Fail fast on bad ``group_size`` at the Python boundary. Mirrors
@@ -1083,28 +1363,9 @@ class CustomAllreduce:
         res_out = torch.empty_like(inp)
         num_groups = K // group_size
         out = torch.empty(inp.shape, dtype=fp8, device=inp.device)
-        if transpose_scale:
-            # Column-major scale: the kernel writes scale[group_id * M + tidx],
-            # i.e. it fills a (num_groups, M) row-major buffer. Expose it to the
-            # consumer as a logical (M, num_groups) tensor via transpose -> stride
-            # (1, M), the layout gemm_a8w8_blockscale_preshuffle consumes. This
-            # also matches the layout inductor re-strides the op output to (the
-            # op has no needs_fixed_stride_order tag on torch>=2.8), so the
-            # torch.compile fake (which declares the same (1, M) stride) agrees
-            # with the runtime tensor. Requires a 2D (M, K) input; the per-group
-            # fused path is always 2D in practice.
-            assert inp.dim() == 2, (
-                "transpose_scale per-group quant requires a 2D (M, K) input, "
-                f"got shape {tuple(inp.shape)}"
-            )
-            M = inp.shape[0]
-            scale_out = torch.empty(
-                (num_groups, M), dtype=torch.float32, device=inp.device
-            ).transpose(0, 1)
-        else:
-            scale_out = torch.empty(
-                inp.shape[:-1] + (num_groups,), dtype=torch.float32, device=inp.device
-            )
+        scale_out = torch.empty(
+            inp.shape[:-1] + (num_groups,), dtype=torch.float32, device=inp.device
+        )
         # Optional bf16/fp16 mirror of the pre-quantization normed output.
         # Requested by GDN-style layers that also need an unquantized view
         # (e.g. Qwen3.5 in_proj_ba). Zero-overhead when not requested
@@ -1130,7 +1391,6 @@ class CustomAllreduce:
             reg_bytes,
             use_1stage,
             bf16_ptr,
-            transpose_scale,
         )
         if emit_bf16:
             return out, res_out, scale_out, bf16_out
@@ -1398,7 +1658,6 @@ class CustomAllreduce:
         group_size: int = 128,
         use_1stage: bool = False,
         emit_bf16: bool = False,
-        transpose_scale: bool = False,
     ):
         if self.disabled or not self.should_custom_ar(input):
             return None
@@ -1413,23 +1672,16 @@ class CustomAllreduce:
                     registered=True,
                     use_1stage=use_1stage,
                     emit_bf16=emit_bf16,
-                    transpose_scale=transpose_scale,
                 )
             else:
                 K = input.shape[-1]
                 num_groups = K // group_size
                 dummy_out = torch.zeros(input.shape, dtype=fp8, device=input.device)
-                if transpose_scale:
-                    M = input.shape[0]
-                    dummy_scale = torch.zeros(
-                        (num_groups, M), dtype=torch.float32, device=input.device
-                    ).transpose(0, 1)
-                else:
-                    dummy_scale = torch.zeros(
-                        input.shape[:-1] + (num_groups,),
-                        dtype=torch.float32,
-                        device=input.device,
-                    )
+                dummy_scale = torch.zeros(
+                    input.shape[:-1] + (num_groups,),
+                    dtype=torch.float32,
+                    device=input.device,
+                )
                 if emit_bf16:
                     return (
                         dummy_out,
@@ -1448,7 +1700,6 @@ class CustomAllreduce:
                 registered=False,
                 use_1stage=use_1stage,
                 emit_bf16=emit_bf16,
-                transpose_scale=transpose_scale,
             )
 
     def custom_fused_ar_rms_mxfp4_quant(
@@ -1503,7 +1754,10 @@ class CustomAllreduce:
 
     def close(self):
         if not self.disabled and getattr(self, "_ptr", 0):
-            ops.dispose(self._ptr)
+            try:
+                self._ops_dispose(self._ptr)
+            except (AttributeError, RuntimeError):
+                pass
             self._ptr = 0
 
     def __del__(self):

--- a/aiter/dist/device_communicators/vmm_allocator.py
+++ b/aiter/dist/device_communicators/vmm_allocator.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""
+HIP Virtual Memory Management (VMM) allocator for gfx1250.
+
+hipIpcGetMemHandle / hipIpcOpenMemHandle are not available on gfx1250.
+This module provides an alternative using the HIP VMM API
+(hipMemCreate / hipMemExportToShareableHandle / hipMemImportFromShareableHandle)
+which exports a POSIX fd that can be passed across processes via Unix sockets.
+"""
+
+import ctypes
+import os
+import socket
+import struct
+import array
+import threading
+from typing import List
+
+from aiter import logger
+
+_hip = ctypes.CDLL("libamdhip64.so")
+
+# ---- HIP VMM ctypes structs ----
+
+# hipMemAllocationType
+_PINNED = 1
+# hipMemAllocationHandleType
+_POSIX_FD = 1
+# hipMemLocationType
+_DEVICE = 1
+# hipMemAccessFlags
+_READ_WRITE = 1
+# hipMemAllocationGranularity_flags
+_MINIMUM = 0
+_RECOMMENDED = 1
+
+
+class _hipMemAllocationProp(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("requestedHandleType", ctypes.c_int),
+        ("location_type", ctypes.c_int),
+        ("location_id", ctypes.c_int),
+        ("win32_handle", ctypes.c_void_p),
+        ("win32_name", ctypes.c_void_p),
+        ("allocFlags_compressionType", ctypes.c_ubyte),
+        ("allocFlags_gpuDirectRDMACapable", ctypes.c_ubyte),
+        ("allocFlags_usage", ctypes.c_ushort),
+        ("_pad", ctypes.c_byte * 4),
+    ]
+
+
+class _hipMemAccessDesc(ctypes.Structure):
+    _fields_ = [
+        ("location_type", ctypes.c_int),
+        ("location_id", ctypes.c_int),
+        ("flags", ctypes.c_int),
+    ]
+
+
+def _check(ret, msg=""):
+    if ret != 0:
+        raise RuntimeError(f"HIP VMM error {ret}: {msg}")
+
+
+def _make_prop(device_id: int) -> _hipMemAllocationProp:
+    prop = _hipMemAllocationProp()
+    prop.type = _PINNED
+    prop.requestedHandleType = _POSIX_FD
+    prop.location_type = _DEVICE
+    prop.location_id = device_id
+    return prop
+
+
+def _get_granularity(device_id: int) -> int:
+    prop = _make_prop(device_id)
+    gran = ctypes.c_size_t()
+    _check(
+        _hip.hipMemGetAllocationGranularity(
+            ctypes.byref(gran), ctypes.byref(prop), _RECOMMENDED
+        ),
+        "hipMemGetAllocationGranularity",
+    )
+    return gran.value
+
+
+def _round_up(size: int, gran: int) -> int:
+    return ((size + gran - 1) // gran) * gran
+
+
+# ---- VMMBuffer ----
+
+
+class VMMBuffer:
+    """GPU buffer allocated via HIP VMM, shareable across processes via fd."""
+
+    def __init__(self, size: int, device_id: int):
+        self._device_id = device_id
+        self._gran = _get_granularity(device_id)
+        self._alloc_size = _round_up(size, self._gran)
+        self._is_imported = False
+
+        prop = _make_prop(device_id)
+        self._phys_handle = ctypes.c_void_p()
+        _check(
+            _hip.hipMemCreate(
+                ctypes.byref(self._phys_handle),
+                self._alloc_size,
+                ctypes.byref(prop),
+                0,
+            ),
+            "hipMemCreate",
+        )
+
+        self._va = ctypes.c_void_p()
+        _check(
+            _hip.hipMemAddressReserve(
+                ctypes.byref(self._va),
+                self._alloc_size,
+                self._gran,
+                ctypes.c_void_p(0),
+                0,
+            ),
+            "hipMemAddressReserve",
+        )
+
+        _check(
+            _hip.hipMemMap(self._va, self._alloc_size, 0, self._phys_handle, 0),
+            "hipMemMap",
+        )
+
+        self._set_access([device_id])
+
+    def _set_access(self, device_ids: List[int]):
+        for dev in device_ids:
+            desc = _hipMemAccessDesc(_DEVICE, dev, _READ_WRITE)
+            _check(
+                _hip.hipMemSetAccess(self._va, self._alloc_size, ctypes.byref(desc), 1),
+                f"hipMemSetAccess dev={dev}",
+            )
+
+    @property
+    def data_ptr(self) -> int:
+        return self._va.value
+
+    @property
+    def alloc_size(self) -> int:
+        return self._alloc_size
+
+    def export_fd(self) -> int:
+        fd = ctypes.c_int()
+        _check(
+            _hip.hipMemExportToShareableHandle(
+                ctypes.byref(fd), self._phys_handle, _POSIX_FD, 0
+            ),
+            "hipMemExportToShareableHandle",
+        )
+        return fd.value
+
+    @classmethod
+    def import_from_fd(
+        cls,
+        fd: int,
+        alloc_size: int,
+        local_device_id: int,
+        access_device_ids: List[int],
+    ) -> "VMMBuffer":
+        obj = object.__new__(cls)
+        obj._device_id = local_device_id
+        obj._gran = _get_granularity(local_device_id)
+        obj._alloc_size = alloc_size
+        obj._is_imported = True
+
+        obj._phys_handle = ctypes.c_void_p()
+        _check(
+            _hip.hipMemImportFromShareableHandle(
+                ctypes.byref(obj._phys_handle), ctypes.c_void_p(fd), _POSIX_FD
+            ),
+            "hipMemImportFromShareableHandle",
+        )
+
+        obj._va = ctypes.c_void_p()
+        _check(
+            _hip.hipMemAddressReserve(
+                ctypes.byref(obj._va),
+                alloc_size,
+                obj._gran,
+                ctypes.c_void_p(0),
+                0,
+            ),
+            "hipMemAddressReserve (import)",
+        )
+
+        _check(
+            _hip.hipMemMap(obj._va, alloc_size, 0, obj._phys_handle, 0),
+            "hipMemMap (import)",
+        )
+
+        obj._set_access(access_device_ids)
+        return obj
+
+    def close(self):
+        if hasattr(self, "_va") and self._va.value:
+            _hip.hipMemUnmap(self._va, self._alloc_size)
+            _hip.hipMemAddressFree(self._va, self._alloc_size)
+            self._va = ctypes.c_void_p(0)
+        if hasattr(self, "_phys_handle") and self._phys_handle.value:
+            _hip.hipMemRelease(self._phys_handle)
+            self._phys_handle = ctypes.c_void_p(0)
+
+    def __del__(self):
+        self.close()
+
+
+# ---- Unix socket fd passing ----
+
+
+def _send_fd(sock_path: str, fd: int, timeout: float = 120.0):
+    """Connect to a Unix socket and send a file descriptor via SCM_RIGHTS."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+                s.settimeout(timeout)
+                s.connect(sock_path)
+                fds = array.array("i", [fd])
+                s.sendmsg(
+                    [b"\x00"],
+                    [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)],
+                )
+                return
+        except (ConnectionRefusedError, FileNotFoundError):
+            if time.monotonic() > deadline:
+                raise
+            time.sleep(0.01)
+
+
+def _recv_fd(sock_path: str, timeout: float = 120.0) -> int:
+    """Listen on a Unix socket and receive one file descriptor via SCM_RIGHTS."""
+    if os.path.exists(sock_path):
+        os.unlink(sock_path)
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(sock_path)
+        server.listen(1)
+        server.settimeout(timeout)
+        conn, _ = server.accept()
+        with conn:
+            msg, ancdata, _, _ = conn.recvmsg(
+                1, socket.CMSG_LEN(ctypes.sizeof(ctypes.c_int))
+            )
+            for cmsg_level, cmsg_type, cmsg_data in ancdata:
+                if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
+                    fds = array.array("i")
+                    fds.frombytes(cmsg_data[: ctypes.sizeof(ctypes.c_int)])
+                    return fds[0]
+        raise RuntimeError("No fd received")
+
+
+def vmm_exchange(
+    rank: int,
+    world_size: int,
+    key: str,
+    local_buf: VMMBuffer,
+    store,
+    ranks_tag: str,
+    all_device_ids: List[int],
+) -> List[int]:
+    """Exchange a VMMBuffer across all ranks and return device pointers.
+
+    Each rank exports its buffer as an fd, sends it to every other rank via
+    Unix sockets, imports the received fds, and returns a list of local VA
+    pointers (one per rank) that can be used to access all ranks' buffers.
+    """
+    local_device = local_buf._device_id
+    alloc_size = local_buf.alloc_size
+    prefix = f"aiter_vmm/{ranks_tag}/{key}"
+
+    # Publish socket paths for receiving fds
+    sock_dir = f"/tmp/aiter_vmm_{os.getpid()}"
+    os.makedirs(sock_dir, exist_ok=True)
+
+    recv_paths = []
+    for r in range(world_size):
+        if r == rank:
+            continue
+        path = f"{sock_dir}/{key}_from_r{r}"
+        recv_paths.append((r, path))
+        store.set(f"{prefix}/sock/r{rank}_from_r{r}", path.encode())
+
+    # Export fd
+    export_fd = local_buf.export_fd()
+
+    # Start receiver threads
+    received_fds = {}
+    recv_errors = {}
+
+    def _do_recv(src_rank, path):
+        try:
+            received_fds[src_rank] = _recv_fd(path)
+        except Exception as e:
+            recv_errors[src_rank] = e
+
+    threads = []
+    for r, path in recv_paths:
+        t = threading.Thread(target=_do_recv, args=(r, path), daemon=True)
+        t.start()
+        threads.append(t)
+
+    # Store alloc_size so importers know the size
+    store.set(f"{prefix}/size/r{rank}", struct.pack("Q", alloc_size))
+
+    # Send our fd to each other rank
+    for r in range(world_size):
+        if r == rank:
+            continue
+        target_path = store.get(f"{prefix}/sock/r{r}_from_r{rank}").decode()
+        dup_fd = os.dup(export_fd)
+        os.set_inheritable(dup_fd, True)
+        _send_fd(target_path, dup_fd)
+        os.close(dup_fd)
+
+    os.close(export_fd)
+
+    # Wait for all receives
+    for t in threads:
+        t.join(timeout=120)
+
+    if recv_errors:
+        raise RuntimeError(f"VMM fd exchange failed: {recv_errors}")
+
+    # Import received fds and build pointer list
+    ptrs = [0] * world_size
+    ptrs[rank] = local_buf.data_ptr
+    imported_bufs = []
+
+    for r in range(world_size):
+        if r == rank:
+            continue
+        fd = received_fds[r]
+        raw_size = store.get(f"{prefix}/size/r{r}")
+        remote_size = struct.unpack("Q", raw_size)[0]
+        buf = VMMBuffer.import_from_fd(fd, remote_size, local_device, all_device_ids)
+        os.close(fd)
+        imported_bufs.append(buf)
+        ptrs[r] = buf.data_ptr
+
+    # Cleanup socket files
+    for r, path in recv_paths:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    return ptrs, imported_bufs

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -57,19 +57,23 @@ def mp_lock(
     Using FileBaton for multiprocessing.
     """
     baton = FileBaton(lockPath)
-    if baton.try_acquire():
-        try:
-            ret = MainFunc()
-        finally:
-            if FinalFunc is not None:
-                FinalFunc()
-            baton.release()
-    else:
-        baton.wait()
-        if WaitFunc is not None:
-            ret = WaitFunc()
-        ret = None
-    return ret
+    while True:
+        if baton.try_acquire():
+            try:
+                ret = MainFunc()
+            finally:
+                if FinalFunc is not None:
+                    FinalFunc()
+                baton.release()
+            return ret
+        # Could not acquire: another process holds the lock. Wait for it.
+        # wait() returns True if the holder released normally (work done),
+        # or False if it broke a stale lock left by a dead/abandoned holder —
+        # in which case we loop and try to acquire + build ourselves.
+        if baton.wait():
+            if WaitFunc is not None:
+                return WaitFunc()
+            return None
 
 
 logger = logging.getLogger("aiter")
@@ -1066,7 +1070,6 @@ def _get_ck_exclude_modules():
     ck_modules |= {
         "module_activation",
         "module_cache",
-        "module_custom_all_reduce",
         "module_fused_qk_norm_mrope_cache_quant_shuffle",
         "module_fused_qk_norm_rope_cache_quant_shuffle",
         "module_mla_metadata",

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -129,6 +129,18 @@
         "verbose": "False",
         "blob_gen_cmd": "''"
     },
+    "module_custom_all_reduce_gfx1250": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/custom_all_reduce_gfx1250_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/custom_all_reduce_gfx1250.cu'"
+        ],
+        "flags_extra_cc": ["'-DENABLE_CK=0'"],
+        "flags_extra_hip": [],
+        "extra_ldflags": "None",
+        "extra_include": [],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_quick_all_reduce": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/quick_all_reduce_pybind.cu'",

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -1241,7 +1241,18 @@ def _jit_compile(
         name = f"{name}_v{version}"
 
     baton = FileBaton(os.path.join(build_directory, "lock"))
-    if baton.try_acquire():
+    need_build = True
+    while True:
+        if baton.try_acquire():
+            break  # we own the lock; fall through and build below
+        # Another process holds the lock. wait() returns True if that holder
+        # finished normally (module is built — just import it), or False if we
+        # broke a stale lock left by a dead holder, in which case we loop and
+        # re-acquire so we build it ourselves instead of importing nothing.
+        if baton.wait():
+            need_build = False
+            break
+    if need_build:
         try:
             if version != old_version:
                 with GeneratedFileCleaner(
@@ -1309,8 +1320,6 @@ def _jit_compile(
                 )
         finally:
             baton.release()
-    else:
-        baton.wait()
 
     if verbose:
         print(f"Loading extension module {name}...", file=sys.stderr)

--- a/aiter/jit/utils/file_baton.py
+++ b/aiter/jit/utils/file_baton.py
@@ -4,6 +4,7 @@
 # mypy: allow-untyped-defs
 import multiprocessing
 import os
+import socket
 import time
 import logging
 
@@ -11,9 +12,16 @@ logger = logging.getLogger("aiter")
 
 
 class FileBaton:
-    """A primitive, file-based synchronization utility."""
+    """A primitive, file-based synchronization utility.
 
-    def __init__(self, lock_file_path, wait_seconds=0.2):
+    The lock file records the owning ``pid`` and host so that a crashed or
+    killed builder (which never reaches :meth:`release`) leaves behind a
+    *stale* lock that waiters can detect and break, instead of deadlocking
+    forever. This also covers the empty/0-byte lock left when a process dies
+    between creating and writing the file.
+    """
+
+    def __init__(self, lock_file_path, wait_seconds=0.2, stale_grace_seconds=10.0):
         """
         Create a new :class:`FileBaton`.
 
@@ -21,41 +29,131 @@ class FileBaton:
             lock_file_path: The path to the file used for locking.
             wait_seconds: The seconds to periodically sleep (spin) when
                 calling ``wait()``.
+            stale_grace_seconds: For an orphaned lock with no readable owner
+                info (e.g. a 0-byte lock from a crash), how old it must be
+                before being treated as stale. Protects the brief window
+                between create and write in a healthy builder.
         """
         self.lock_file_path = lock_file_path
         self.wait_seconds = wait_seconds
+        self.stale_grace_seconds = stale_grace_seconds
         self.fd = None
 
     def try_acquire(self):
         """
-        Try to atomically create a file under exclusive access.
+        Try to atomically create a file under exclusive access and stamp it
+        with the current owner (pid + host) for stale detection.
 
         Returns:
             True if the file could be created, else False.
         """
         try:
-            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL)
-            return True
+            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
         except FileExistsError:
             return False
+        try:
+            os.write(self.fd, f"{os.getpid()}\n{socket.gethostname()}\n".encode())
+            os.fsync(self.fd)
+        except OSError:
+            pass
+        return True
 
     def wait(self):
         """
-        Periodically sleeps for a certain amount until the baton is released.
+        Periodically sleep until the baton is released by its holder, or break
+        the lock if its holder is dead.
 
-        The amount of time slept depends on the ``wait_seconds`` parameter
-        passed to the constructor.
+        Returns:
+            True if the holder released the lock normally (its work is done).
+            False if a stale lock was broken — the caller should re-acquire
+            and redo the work, since no holder ever finished it.
         """
         logger.info(
             f"[pid={os.getpid()} pname={multiprocessing.current_process().name}] "
             f"waiting for baton release at {self.lock_file_path}"
         )
-        while os.path.exists(self.lock_file_path):
+        while True:
+            if not os.path.exists(self.lock_file_path):
+                return True
+            if self._is_stale() and self._try_break_stale():
+                logger.warning(
+                    f"[pid={os.getpid()}] broke stale lock at "
+                    f"{self.lock_file_path} (dead/abandoned holder)"
+                )
+                return False
             time.sleep(self.wait_seconds)
 
     def release(self):
-        """Release the baton and removes its file."""
+        """Release the baton and remove its file."""
         if self.fd is not None:
             os.close(self.fd)
+            self.fd = None
+        try:
+            os.remove(self.lock_file_path)
+        except FileNotFoundError:
+            pass
 
-        os.remove(self.lock_file_path)
+    # ---- stale-lock detection ----
+
+    def _read_owner(self):
+        """Return (pid, host) recorded in the lock file, or (None, None)."""
+        try:
+            with open(self.lock_file_path, "r") as f:
+                lines = f.read().splitlines()
+        except (FileNotFoundError, OSError):
+            return None, None
+        if len(lines) < 2 or not lines[0].strip().isdigit():
+            return None, None
+        return int(lines[0].strip()), lines[1].strip()
+
+    @staticmethod
+    def _pid_alive(pid):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True  # exists but owned by another user
+        return True
+
+    def _is_stale(self):
+        """A lock is stale if its recorded holder is dead, or if it carries no
+        owner info and has outlived the grace period (orphaned/0-byte lock)."""
+        pid, host = self._read_owner()
+        if pid is None:
+            # No readable owner: only trust mtime, and only for our own host
+            # cannot be verified, so fall back to an age-based grace window.
+            try:
+                age = time.time() - os.path.getmtime(self.lock_file_path)
+            except OSError:
+                return False
+            return age > self.stale_grace_seconds
+        if host != socket.gethostname():
+            # Different host (e.g. shared filesystem): can't check liveness,
+            # never steal — avoid breaking a live remote builder's lock.
+            return False
+        return not self._pid_alive(pid)
+
+    def _try_break_stale(self):
+        """Atomically break a stale lock. A secondary ``.steal`` lock ensures
+        only one waiter removes it; the rest just loop and re-check."""
+        steal_path = self.lock_file_path + ".steal"
+        try:
+            sfd = os.open(steal_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            return False
+        try:
+            # Re-verify under the steal lock to avoid racing a fresh acquire.
+            if os.path.exists(self.lock_file_path) and self._is_stale():
+                try:
+                    os.remove(self.lock_file_path)
+                except FileNotFoundError:
+                    pass
+                return True
+            return False
+        finally:
+            os.close(sfd)
+            try:
+                os.remove(steal_path)
+            except FileNotFoundError:
+                pass

--- a/aiter/ops/communication.py
+++ b/aiter/ops/communication.py
@@ -62,13 +62,21 @@ def init_dist_env(
         # hack custom_allreduce
         tp_grp = get_tp_group()
         ca_comm = tp_grp.device_communicator.ca_comm
-        # signal
-        signal = torch.zeros(
-            tensor_model_parallel_size * 64, dtype=torch.int64, device=rankID
-        )
-        ca_comm.signal = signal
-        ca_comm.register_input_buffer(signal)
-        ca_comm.buffer = ca_comm._pool["input"].tensor
+        # gfx1250 (MI450) uses a VMM-based custom allreduce whose input buffer
+        # is already registered in CustomAllreduce._init_gfx1250(). The extra
+        # register_input_buffer(signal) below routes through get_external_ipc_meta,
+        # whose vmm_exchange rendezvous key is process-local (id(self)+data_ptr),
+        # so it can never align across TP ranks and deadlocks at startup. The
+        # `signal`/`buffer` attributes set here are never read anywhere, so skip
+        # the whole block on gfx1250.
+        if ca_comm is not None and not getattr(ca_comm, "_is_gfx1250", False):
+            # signal
+            signal = torch.zeros(
+                tensor_model_parallel_size * 64, dtype=torch.int64, device=rankID
+            )
+            ca_comm.signal = signal
+            ca_comm.register_input_buffer(signal)
+            ca_comm.buffer = ca_comm._pool["input"].tensor
     logger.debug(f"RANK: {rankID}/{tensor_model_parallel_size} init_dist_env...")
 
 

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -8,6 +8,7 @@ import torch
 from ..jit.core import compile_ops
 
 MD_NAME = "module_custom_all_reduce"
+GFX1250_MD_NAME = "module_custom_all_reduce_gfx1250"
 FUSED_AR_MHC_MD_NAME = "module_fused_ar_mhc"
 
 
@@ -134,7 +135,6 @@ def fused_allreduce_rmsnorm_quant_per_group(
     reg_bytes: int,
     use_1stage: bool,
     bf16_out_ptr: int = 0,
-    transpose_scale: bool = False,
 ) -> None: ...
 
 
@@ -233,6 +233,114 @@ def free_meta_buffer(ptr: int) -> None: ...
 
 @compile_ops("module_custom_all_reduce", develop=True)
 def get_meta_buffer_ipc_handle(inp_ptr: int, out_handle_ptr: int) -> None: ...
+
+
+# ---- gfx1250 (MI450) dedicated module ----
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="init_custom_ar", develop=True)
+def init_custom_ar_gfx1250(
+    meta_ptr: int,
+    rank_data_ptr: int,
+    rank_data_sz: int,
+    all_meta_ptrs: List[int],
+    rank: int,
+    fully_connected: bool,
+) -> int: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="all_reduce", develop=True)
+def all_reduce_gfx1250(
+    _fa: int,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    use_new: bool,
+    open_fp8_quant: bool,
+    reg_inp_ptr: int,
+    reg_inp_bytes: int,
+) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="reduce_scatter", develop=True)
+def reduce_scatter_gfx1250(
+    _fa: int,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    m: int,
+    n: int,
+    k: int,
+    split_dim: int,
+    reg_ptr: int,
+    reg_bytes: int,
+) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="all_gather", develop=True)
+def all_gather_gfx1250(
+    _fa: int,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    dim: int,
+    reg_inp_ptr: int,
+    reg_inp_bytes: int,
+) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="p2p_bw_test", develop=True)
+def p2p_bw_test_gfx1250(
+    _fa: int,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    unroll: int,
+    threads: int,
+    blocks: int,
+    reg_inp_ptr: int,
+    reg_inp_bytes: int,
+) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="dispose", develop=True)
+def dispose_gfx1250(_fa: int) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="meta_size", develop=True)
+def meta_size_gfx1250() -> int: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="register_input_buffer", develop=True)
+def register_input_buffer_gfx1250(
+    _fa: int, self_ptr: int, all_ptrs: List[int]
+) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="register_output_buffer", develop=True)
+def register_output_buffer_gfx1250(
+    _fa: int, self_ptr: int, all_ptrs: List[int]
+) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="get_graph_buffer_count", develop=True)
+def get_graph_buffer_count_gfx1250(_fa: int) -> int: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="get_graph_buffer_ptrs", develop=True)
+def get_graph_buffer_ptrs_gfx1250(_fa: int, ptrs_out: int) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="register_graph_buffers", develop=True)
+def register_graph_buffers_gfx1250(_fa: int, ptrs_per_rank: List[int]) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="start_sync_latency", develop=True)
+def start_sync_latency_gfx1250(_fa: int, blocks: int) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="end_sync_latency", develop=True)
+def end_sync_latency_gfx1250(_fa: int, blocks: int) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="two_sync_latency", develop=True)
+def two_sync_latency_gfx1250(_fa: int, blocks: int) -> None: ...
 
 
 @compile_ops(FUSED_AR_MHC_MD_NAME)

--- a/csrc/include/custom_all_reduce_gfx1250.cuh
+++ b/csrc/include/custom_all_reduce_gfx1250.cuh
@@ -1,0 +1,1115 @@
+#pragma once
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Self-contained gfx1250 (MI450) custom allreduce.
+ * Does NOT include aiter_hip_common.h (avoids CK dependency).
+ */
+#include "opus/opus.hpp"
+#include "hip_float8.h"
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Utilities copied from aiter_hip_common.h to stay CK-free
+// ---------------------------------------------------------------------------
+#ifndef HIP_CALL
+#define HIP_CALL(call)                                                       \
+    do                                                                       \
+    {                                                                        \
+        hipError_t err = call;                                               \
+        if(err != hipSuccess) [[unlikely]]                                   \
+        {                                                                    \
+            std::cerr << "[AITER] " << __FILE__ << ":" << __LINE__           \
+                      << " fail to call " #call " ---> [HIP error]("        \
+                      << hipGetErrorString(err) << ')' << std::endl;         \
+            std::abort();                                                    \
+        }                                                                    \
+    } while(0)
+#endif
+
+#ifndef DINLINE
+#define DINLINE __device__ __forceinline__
+#endif
+
+namespace aiter {
+
+// ---------------------------------------------------------------------------
+// Constants & data structures
+// ---------------------------------------------------------------------------
+constexpr int kMaxBlocks = 512;
+
+struct Signal
+{
+    alignas(128) uint32_t start[kMaxBlocks][8];
+    alignas(128) uint32_t end[kMaxBlocks][8];
+    alignas(128) uint32_t _flag[kMaxBlocks];
+};
+
+struct __align__(16) RankData
+{
+    const void* ptrs[8];
+};
+
+struct __align__(16) RankSignals
+{
+    Signal* signals[8];
+};
+
+// ---------------------------------------------------------------------------
+// Scalar cast helpers
+// ---------------------------------------------------------------------------
+template <typename inp_dtype>
+DINLINE opus::fp32_t upcast_s(inp_dtype val)
+{ return opus::cast<opus::fp32_t>(val); }
+
+template <>
+DINLINE opus::fp32_t upcast_s<opus::fp32_t>(opus::fp32_t val)
+{ return val; }
+
+template <typename out_dtype>
+DINLINE out_dtype downcast_s(opus::fp32_t val)
+{ return opus::cast<out_dtype>(val); }
+
+template <>
+DINLINE opus::fp32_t downcast_s<opus::fp32_t>(opus::fp32_t val)
+{ return val; }
+
+// ---------------------------------------------------------------------------
+// Synchronisation primitives (ROCm path only)
+// ---------------------------------------------------------------------------
+template <int ngpus>
+DINLINE void start_sync(const RankSignals& sg, Signal* self_sg, int rank)
+{
+    uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+    if(threadIdx.x < ngpus)
+    {
+        __scoped_atomic_store_n(&sg.signals[threadIdx.x]->start[blockIdx.x][rank],
+                                flag,
+                                __ATOMIC_RELAXED,
+                                __MEMORY_SCOPE_SYSTEM);
+        while(__scoped_atomic_load_n(&self_sg->start[blockIdx.x][threadIdx.x],
+                                     __ATOMIC_RELAXED,
+                                     __MEMORY_SCOPE_DEVICE) < flag)
+            ;
+    }
+    __syncthreads();
+    if(threadIdx.x == 0)
+        self_sg->_flag[blockIdx.x] = flag;
+}
+
+template <int ngpus, bool final_sync = false>
+DINLINE void end_sync(const RankSignals& sg, Signal* self_sg, int rank)
+{
+    __syncthreads();
+    uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+    if(threadIdx.x < ngpus)
+    {
+        __scoped_atomic_store_n(&sg.signals[threadIdx.x]->end[blockIdx.x][rank],
+                                flag,
+                                final_sync ? __ATOMIC_RELAXED : __ATOMIC_RELEASE,
+                                __MEMORY_SCOPE_SYSTEM);
+        while(__scoped_atomic_load_n(&self_sg->end[blockIdx.x][threadIdx.x],
+                                     final_sync ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE,
+                                     __MEMORY_SCOPE_DEVICE) < flag)
+            ;
+    }
+    __syncthreads();
+    if(threadIdx.x == 0)
+        self_sg->_flag[blockIdx.x] = flag;
+}
+
+// ---------------------------------------------------------------------------
+// gfx1250 allreduce kernel
+// ---------------------------------------------------------------------------
+template <typename T, int ngpus, bool is_broadcast_reg_outptr = false>
+__global__ void __launch_bounds__(256, 2) ar_gfx1250_naive_unroll4(
+    RankData* _input_dp,
+    RankData* _output_dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    constexpr int unroll    = 4;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int tid    = blockIdx.x * blockDim.x + threadIdx.x;
+    int nthds  = blockDim.x * gridDim.x;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int target = (rank + i) % ngpus;
+        ptrs[i]    = (const P*)_input_dp->ptrs[target];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    int aligned_size = (size / unroll) * unroll;
+    for(int base = tid * unroll; base < aligned_size; base += nthds * unroll)
+    {
+      P inp_reg[ngpus][unroll];
+#pragma unroll
+      for (int i = 0; i < ngpus; ++i)
+      {
+#pragma unroll
+        for (int j = 0; j < unroll; ++j)
+          inp_reg[i][j] = ptrs[i][base + j];
+      }
+      A rslt_tmp[unroll];
+      P rslt_reg[unroll];
+#pragma unroll
+      for (int u = 0; u < unroll; ++u)
+      {
+#pragma unroll
+        for (int j = 0; j < pack_size; ++j)
+          rslt_tmp[u][j] = upcast_s(inp_reg[0][u][j]);
+#pragma unroll
+        for (int g = 1; g < ngpus; ++g)
+        {
+#pragma unroll
+          for (int j = 0; j < pack_size; ++j)
+            rslt_tmp[u][j] += upcast_s(inp_reg[g][u][j]);
+        }
+      }
+#pragma unroll
+      for (int u = 0; u < unroll; ++u)
+      {
+#pragma unroll
+        for (int j = 0; j < pack_size; ++j)
+          rslt_reg[u][j] = downcast_s<T>(rslt_tmp[u][j]);
+        *(reinterpret_cast<P*>(result) + base + u) = rslt_reg[u];
+      }
+    }
+    for(int idx = aligned_size + tid; idx < size; idx += nthds)
+    {
+      A acc;
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j)
+        acc[j] = upcast_s(ptrs[0][idx][j]);
+#pragma unroll
+      for (int i = 1; i < ngpus; ++i)
+      {
+#pragma unroll
+        for (int j = 0; j < pack_size; ++j)
+          acc[j] += upcast_s(ptrs[i][idx][j]);
+      }
+      P out_val;
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j)
+        out_val[j] = downcast_s<T>(acc[j]);
+      *(reinterpret_cast<P*>(result) + idx) = out_val;
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// ---------------------------------------------------------------------------
+// gfx1250 allgather kernel — scalar fallback (size not pack-aligned)
+// ---------------------------------------------------------------------------
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) ag_gfx1250_scalar(
+    RankData* _input_dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size)
+{
+    int tid    = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    const T* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        ptrs[i] = (const T*)_input_dp->ptrs[i];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int idx = tid; idx < size; idx += stride)
+    {
+#pragma unroll
+        for(int i = 0; i < ngpus; ++i)
+        {
+            int gpu_idx = (rank + i) % ngpus;
+            result[gpu_idx * size + idx] = ptrs[gpu_idx][idx];
+        }
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 2) ag_gfx1250_naive_vec(
+    RankData* _input_dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    int index    = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride  = blockDim.x * gridDim.x;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        ptrs[i] = (const P*)_input_dp->ptrs[i];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for (int idx = index; idx < size; idx += stride)
+    {
+#pragma unroll
+      for (int i = 0; i < ngpus; ++i)
+      {
+        int rank_idx = (rank + i) % ngpus;
+        *(reinterpret_cast<P*>(result) + size * rank_idx + idx) = ptrs[rank_idx][idx];
+      }
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// ---------------------------------------------------------------------------
+// gfx1250 allgather kernel — vectorized unroll4
+// ---------------------------------------------------------------------------
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 2) ag_gfx1250_naive_unroll4(
+    RankData* _input_dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    constexpr int unroll    = 4;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    int index    = blockIdx.x * blockDim.x * unroll + threadIdx.x;
+    int stride  = blockDim.x * gridDim.x * unroll;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        ptrs[i] = (const P*)_input_dp->ptrs[i];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for (int idx = index; idx + blockDim.x * (unroll - 1) < size; idx += stride)
+    {
+#pragma unroll
+      for (int i = 0; i < ngpus; ++i)
+      {
+        int rank_idx = (rank + i) % ngpus;
+#pragma unroll
+        for (int j = 0; j < unroll; ++j)
+        {
+          *(reinterpret_cast<P*>(result) + size * rank_idx + idx + j * blockDim.x) = ptrs[rank_idx][idx + j * blockDim.x];
+        }
+      }
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) ag_gfx1250_lastdim(RankData* _dp,
+                                                            RankSignals sg,
+                                                            Signal* self_sg,
+                                                            T* __restrict__ result,
+                                                            int rank,
+                                                            int size,
+                                                            int last_dim_size)
+{
+    constexpr int unroll    = 4;
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    int tid                 = blockIdx.x * blockDim.x * unroll + threadIdx.x;
+    int stride              = gridDim.x * blockDim.x * unroll;
+
+    last_dim_size /= pack_size;
+    const P* ptrs[ngpus];
+
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        ptrs[i] = (const P*)_dp->ptrs[i];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    for(int idx = tid; idx < size; idx += stride)
+    {
+#pragma unroll
+      for (int i = 0; i < ngpus; ++i)
+      {
+        int rank_idx = (rank + i) % ngpus;
+#pragma unroll
+        for (int j = 0; j < unroll; ++j)
+        {
+          int read_idx = idx + j * blockDim.x;
+          if (read_idx >= size) break;
+          int y = read_idx / last_dim_size;
+          int x = read_idx % last_dim_size;
+          int write_idx = (ngpus * y + rank_idx) * last_dim_size + x;
+          *(reinterpret_cast<P*>(result) + write_idx) = ptrs[rank_idx][read_idx];
+        }
+      }
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 2) ag_gfx1250_warpsplit_unroll4(
+    RankData* _input_dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    constexpr int unroll    = 4;
+    constexpr int tnum_gpu = 256 / ngpus;
+    using P                 = typename opus::vector_t<T, pack_size>;
+    int warp_id = threadIdx.x / tnum_gpu;
+    int lane_id = threadIdx.x % tnum_gpu;
+    int index    = blockIdx.x * tnum_gpu * unroll + lane_id;
+    int stride  = blockDim.x * tnum_gpu * unroll;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        ptrs[i] = (const P*)_input_dp->ptrs[i];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for (int idx = index; idx + tnum_gpu * (unroll - 1) < size; idx += stride)
+    {
+#pragma unroll
+      for (int i = 0; i < unroll; ++i)
+      {
+        P* rslt_addr = reinterpret_cast<P*>(result) + warp_id * size + idx + tnum_gpu * i;
+        *rslt_addr = ptrs[warp_id][idx + i * tnum_gpu];
+      }
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// ---------------------------------------------------------------------------
+// gfx1250 bandwidth test kernel
+// ---------------------------------------------------------------------------
+template <typename T, int unroll>
+__global__ void  p2p_bandwidth_test_kernel(
+    RankData* _input_dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    int index    = blockIdx.x * blockDim.x * unroll + threadIdx.x;
+    int stride  = blockDim.x * gridDim.x * unroll;
+    const P* ptrs[2];
+#pragma unroll
+    for(int i = 0; i < 2; i++)
+    {
+        ptrs[i] = (const P*)_input_dp->ptrs[i];
+    }
+    start_sync<2>(sg, self_sg, rank);
+    for (int idx = index; idx < size; idx += stride)
+    {
+      P reg[unroll];
+#pragma unroll
+      for (int i = 0; i < unroll; ++i)
+      {
+        reg[i] = ptrs[(rank + 1) % 2][idx + i * blockDim.x];
+      }
+#pragma unroll
+      for (int i = 0; i < unroll; ++i)
+      {
+        *(reinterpret_cast<P*>(result) + idx + i * blockDim.x) = reg[i];
+      }
+    }
+    // end_sync<2, true>(sg, self_sg, rank);
+}
+
+// ---------------------------------------------------------------------------
+// gfx1250 reduce_scatter kernels
+// ---------------------------------------------------------------------------
+enum class ReduceScatterSplitDim : int { kFirst = 0, kLast = 1, kMid = 2 };
+
+// reduce_scatter, scatter on first dim — vectorized.
+// cond: numel % (ngpus * pack_size) == 0
+// shape: input flat numel -> output flat numel / ngpus
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) rs_gfx1250_split_first_dim(
+    RankData* _dp, RankSignals sg, Signal* self_sg,
+    T* __restrict__ result, int rank, int range)
+{
+    int tid                 = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride              = blockDim.x * gridDim.x;
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int target = (rank + i) % ngpus;
+        ptrs[i]    = (const P*)_dp->ptrs[target];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int idx = tid; idx < range; idx += stride)
+    {
+        int load_index = rank * range + idx;
+        A acc;
+#pragma unroll
+        for(int j = 0; j < pack_size; ++j)
+            acc[j] = upcast_s(ptrs[0][load_index][j]);
+#pragma unroll
+        for(int g = 1; g < ngpus; ++g)
+        {
+#pragma unroll
+            for(int j = 0; j < pack_size; ++j)
+                acc[j] += upcast_s(ptrs[g][load_index][j]);
+        }
+        P out_val;
+#pragma unroll
+        for(int j = 0; j < pack_size; ++j)
+            out_val[j] = downcast_s<T>(acc[j]);
+        *(reinterpret_cast<P*>(result) + idx) = out_val;
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// reduce_scatter, scatter on last dim — scalar fallback.
+// cond: n % ngpus == 0
+// shape: input (m, n) -> output (m, n / ngpus)
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 1) rs_gfx1250_split_lastdim_naive(
+    RankData* _dp, RankSignals sg, Signal* self_sg,
+    T* __restrict__ result, int rank, int m, int n)
+{
+    int size      = m * n / ngpus;
+    int splited_n = n / ngpus;
+    int index     = blockIdx.x * blockDim.x + threadIdx.x;
+    const T* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        int target = (rank + i) % ngpus;
+        ptrs[i]    = (const T*)_dp->ptrs[target];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int i = index; i < size; i += blockDim.x * gridDim.x)
+    {
+        int index_x    = i % splited_n;
+        int index_y    = i / splited_n;
+        int load_index = index_y * n + rank * splited_n + index_x;
+        opus::fp32_t rslt_reg = 0.0f;
+#pragma unroll
+        for(int j = 0; j < ngpus; ++j)
+            rslt_reg += upcast_s(ptrs[j][load_index]);
+        result[i] = downcast_s<T>(rslt_reg);
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// reduce_scatter, scatter on last dim — vectorized.
+// cond: n % (ngpus * pack_size) == 0
+// shape: input (m, n) -> output (m, n / ngpus)
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 1) rs_gfx1250_split_lastdim(
+    RankData* _dp, RankSignals sg, Signal* self_sg,
+    T* __restrict__ result, int rank, int m, int n)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int size        = m * n / (ngpus * pack_size);
+    int splited_n   = n / (ngpus * pack_size);
+    int packed_dim_n = n / pack_size;
+    int index       = blockIdx.x * blockDim.x + threadIdx.x;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        int target = (rank + i) % ngpus;
+        ptrs[i]    = (const P*)_dp->ptrs[target];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int i = index; i < size; i += blockDim.x * gridDim.x)
+    {
+        int index_x    = i % splited_n;
+        int index_y    = i / splited_n;
+        int load_index = index_y * packed_dim_n + rank * splited_n + index_x;
+        P inp_reg[ngpus];
+#pragma unroll
+        for(int g = 0; g < ngpus; ++g)
+            inp_reg[g] = ptrs[g][load_index];
+        A acc;
+#pragma unroll
+        for(int j = 0; j < pack_size; ++j)
+            acc[j] = upcast_s(inp_reg[0][j]);
+#pragma unroll
+        for(int g = 1; g < ngpus; ++g)
+        {
+#pragma unroll
+            for(int j = 0; j < pack_size; ++j)
+                acc[j] += upcast_s(inp_reg[g][j]);
+        }
+        P out_val;
+#pragma unroll
+        for(int j = 0; j < pack_size; ++j)
+            out_val[j] = downcast_s<T>(acc[j]);
+        *(reinterpret_cast<P*>(result) + i) = out_val;
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// reduce_scatter, scatter on middle dim — scalar fallback.
+// cond: n % ngpus == 0
+// shape: input (m, n, k) -> output (m, n / ngpus, k)
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 1) rs_gfx1250_split_middim_naive(
+    RankData* _dp, RankSignals sg, Signal* self_sg,
+    T* __restrict__ result, int rank, int m, int n, int k)
+{
+    int size      = m * n * k / ngpus;
+    int splited_n = n / ngpus;
+    int index     = blockIdx.x * blockDim.x + threadIdx.x;
+    const T* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        int target = (rank + i) % ngpus;
+        ptrs[i]    = (const T*)_dp->ptrs[target];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int i = index; i < size; i += blockDim.x * gridDim.x)
+    {
+        int index_m    = i / (splited_n * k);
+        int index_n    = (i % (splited_n * k)) / k;
+        int index_k    = (i % (splited_n * k)) % k;
+        int load_index = index_m * (n * k) + (rank * splited_n + index_n) * k + index_k;
+        opus::fp32_t rslt_reg = 0.0f;
+#pragma unroll
+        for(int j = 0; j < ngpus; ++j)
+            rslt_reg += upcast_s(ptrs[j][load_index]);
+        result[i] = downcast_s<T>(rslt_reg);
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// reduce_scatter, scatter on middle dim — vectorized along k.
+// cond: n % ngpus == 0 && k % pack_size == 0
+// shape: input (m, n, k) -> output (m, n / ngpus, k)
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 1) rs_gfx1250_split_middim(
+    RankData* _dp, RankSignals sg, Signal* self_sg,
+    T* __restrict__ result, int rank, int m, int n, int k)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int size         = m * n * k / (pack_size * ngpus);
+    int splited_n    = n / ngpus;
+    int packed_dim_k = k / pack_size;
+    int index        = blockIdx.x * blockDim.x + threadIdx.x;
+    const P* ptrs[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        int target = (rank + i) % ngpus;
+        ptrs[i]    = (const P*)_dp->ptrs[target];
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    for(int i = index; i < size; i += blockDim.x * gridDim.x)
+    {
+        int index_m    = i / (splited_n * packed_dim_k);
+        int index_n    = (i % (splited_n * packed_dim_k)) / packed_dim_k;
+        int index_k    = (i % (splited_n * packed_dim_k)) % packed_dim_k;
+        int load_index = index_m * (n * packed_dim_k) + (rank * splited_n + index_n) * packed_dim_k + index_k;
+        P inp_reg[ngpus];
+#pragma unroll
+        for(int g = 0; g < ngpus; ++g)
+            inp_reg[g] = ptrs[g][load_index];
+        A acc;
+#pragma unroll
+        for(int j = 0; j < pack_size; ++j)
+            acc[j] = upcast_s(inp_reg[0][j]);
+#pragma unroll
+        for(int g = 1; g < ngpus; ++g)
+        {
+#pragma unroll
+            for(int j = 0; j < pack_size; ++j)
+                acc[j] += upcast_s(inp_reg[g][j]);
+        }
+        P out_val;
+#pragma unroll
+        for(int j = 0; j < pack_size; ++j)
+            out_val[j] = downcast_s<T>(acc[j]);
+        *(reinterpret_cast<P*>(result) + i) = out_val;
+    }
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// ---------------------------------------------------------------------------
+// sync latency
+// ---------------------------------------------------------------------------
+template <int ngpus>
+__global__ void start_sync_latency(RankSignals sg, Signal* self_sg, int rank)
+{
+  start_sync<ngpus>(sg, self_sg, rank);
+}
+
+template <int ngpus>
+__global__ void end_sync_latency(RankSignals sg, Signal* self_sg, int rank)
+{
+  end_sync<ngpus>(sg, self_sg, rank);
+}
+
+template <int ngpus>
+__global__ void two_sync_latency(RankSignals sg, Signal* self_sg, int rank)
+{
+  start_sync<ngpus>(sg, self_sg, rank);
+  end_sync<ngpus>(sg, self_sg, rank);
+}
+
+// ---------------------------------------------------------------------------
+// CustomAllreduce class (gfx1250-only, simplified)
+// ---------------------------------------------------------------------------
+// gfx1250: hipIpc is not available. Buffer sharing uses torch's
+// cross-process CUDA tensor sharing; the C++ layer receives direct
+// device pointers that torch already mapped into each process's VA.
+
+class CustomAllreduce
+{
+public:
+    int rank_;
+    int world_size_;
+    bool full_nvlink_;
+
+    RankSignals sg_;
+    std::unordered_map<void*, RankData*> input_buffer;
+    std::unordered_map<void*, RankData*> output_buffers_;
+    Signal* self_sg_;
+
+    RankData *d_rank_data_base_, *d_rank_data_end_;
+    std::vector<void*> graph_unreg_input_buffers_;
+    std::vector<void*> graph_unreg_output_buffers_;
+
+    // gfx1250: hipIpc is not available. Instead, each rank's Signal buffer
+    // is a torch-shared tensor whose device pointer is exchanged via the
+    // distributed store.  The constructor receives the remote pointers
+    // directly (torch already mapped them into this process's VA space).
+    CustomAllreduce(Signal* meta,
+                    void* rank_data,
+                    size_t rank_data_sz,
+                    const std::vector<int64_t>& all_meta_ptrs,
+                    int rank,
+                    bool fully_connected = true)
+        : rank_(rank),
+          world_size_(all_meta_ptrs.size()),
+          full_nvlink_(fully_connected),
+          self_sg_(meta),
+          d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+          d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData))
+    {
+        for(int i = 0; i < world_size_; i++)
+        {
+            sg_.signals[i] = reinterpret_cast<Signal*>(all_meta_ptrs[i]);
+        }
+    }
+
+    // gfx1250: return raw device pointers (no hipIpc handles).
+    std::vector<int64_t> get_graph_buffer_ptrs()
+    {
+        auto num_input_buffers  = graph_unreg_input_buffers_.size();
+        auto num_output_buffers = graph_unreg_output_buffers_.size();
+        auto num_buffers        = num_input_buffers + num_output_buffers;
+        std::vector<int64_t> ptrs(num_buffers);
+        for(size_t i = 0; i < num_input_buffers; i++)
+            ptrs[i] = (int64_t)graph_unreg_input_buffers_[i];
+        for(size_t i = 0; i < num_output_buffers; i++)
+            ptrs[num_input_buffers + i] = (int64_t)graph_unreg_output_buffers_[i];
+        return ptrs;
+    }
+
+    void check_rank_data_capacity(size_t num = 1)
+    {
+        if(d_rank_data_base_ + num > d_rank_data_end_)
+            throw std::runtime_error("Rank data buffer is overflowed by " +
+                                     std::to_string(d_rank_data_base_ + num - d_rank_data_end_));
+    }
+
+    // gfx1250: receive direct device pointers instead of IPC handles.
+    void register_input_buffer(const std::vector<int64_t>& all_ptrs, void* self)
+    {
+        check_rank_data_capacity();
+        RankData data;
+        for(int i = 0; i < world_size_; i++)
+            data.ptrs[i] = (i != rank_) ? (void*)all_ptrs[i] : self;
+        auto d_data = d_rank_data_base_++;
+        HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
+        input_buffer[self] = d_data;
+    }
+
+    void register_output_buffer(const std::vector<int64_t>& all_ptrs, void* self)
+    {
+        check_rank_data_capacity();
+        RankData data;
+        for(int i = 0; i < world_size_; i++)
+            data.ptrs[i] = (i != rank_) ? (void*)all_ptrs[i] : self;
+        auto d_data = d_rank_data_base_++;
+        HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
+        output_buffers_[self] = d_data;
+    }
+
+    RankData* get_buffer_RD(hipStream_t stream, void* input)
+    {
+        auto it = input_buffer.find(input);
+        if(it != input_buffer.end())
+            return it->second;
+        hipStreamCaptureStatus status;
+        HIP_CALL(hipStreamIsCapturing(stream, &status));
+        if(status == hipStreamCaptureStatusActive)
+        {
+            auto ptrs = d_rank_data_base_ + graph_unreg_input_buffers_.size();
+            graph_unreg_input_buffers_.push_back(input);
+            return ptrs;
+        }
+        throw std::runtime_error("buffer address " +
+                                 std::to_string(reinterpret_cast<uint64_t>(input)) +
+                                 " is not registered!");
+    }
+
+    RankData* get_output_buffer_RD(hipStream_t stream, void* output)
+    {
+        auto it = output_buffers_.find(output);
+        if(it != output_buffers_.end())
+            return it->second;
+        hipStreamCaptureStatus status;
+        HIP_CALL(hipStreamIsCapturing(stream, &status));
+        if(status == hipStreamCaptureStatusActive)
+        {
+            auto ptrs = d_rank_data_base_ + graph_unreg_input_buffers_.size() +
+                        graph_unreg_output_buffers_.size();
+            graph_unreg_output_buffers_.push_back(output);
+            return ptrs;
+        }
+        throw std::runtime_error("output buffer address " +
+                                 std::to_string(reinterpret_cast<uint64_t>(output)) +
+                                 " is not registered!");
+    }
+
+    // gfx1250: receive direct device pointers per rank per buffer.
+    // ptrs_per_rank[rank_j] points to a flat array of int64_t device pointers,
+    // one per buffer (inputs first, then outputs), in the same order as
+    // graph_unreg_input_buffers_ + graph_unreg_output_buffers_.
+    void register_graph_buffers(const int64_t* const* ptrs_per_rank)
+    {
+        auto num_input_buffers  = graph_unreg_input_buffers_.size();
+        auto num_output_buffers = graph_unreg_output_buffers_.size();
+        auto total_buffers      = num_input_buffers + num_output_buffers;
+        check_rank_data_capacity(total_buffers);
+        std::vector<RankData> rank_data(total_buffers);
+        for(size_t i = 0; i < num_input_buffers; i++)
+        {
+            auto self_ptr = graph_unreg_input_buffers_[i];
+            auto& rd      = rank_data[i];
+            for(int j = 0; j < world_size_; j++)
+                rd.ptrs[j] = (j != rank_) ? (void*)ptrs_per_rank[j][i] : self_ptr;
+        }
+        for(size_t i = 0; i < num_output_buffers; i++)
+        {
+            auto self_ptr = graph_unreg_output_buffers_[i];
+            auto& rd      = rank_data[num_input_buffers + i];
+            for(int j = 0; j < world_size_; j++)
+                rd.ptrs[j] = (j != rank_) ? (void*)ptrs_per_rank[j][num_input_buffers + i]
+                                          : self_ptr;
+            output_buffers_[self_ptr] = d_rank_data_base_ + num_input_buffers + i;
+        }
+        HIP_CALL(hipMemcpy(d_rank_data_base_,
+                           rank_data.data(),
+                           sizeof(RankData) * total_buffers,
+                           hipMemcpyHostToDevice));
+        d_rank_data_base_ += total_buffers;
+        graph_unreg_input_buffers_.clear();
+        graph_unreg_output_buffers_.clear();
+    }
+
+    template <typename T>
+    void allgather_scalar(hipStream_t stream,
+                          T* input,
+                          T* output,
+                          int size)
+    {
+        RankData* input_ptrs = get_buffer_RD(stream, input);
+
+        constexpr int threads = 512;
+        int blocks = std::min(kMaxBlocks,
+                              (size + threads - 1) / threads);
+        if(world_size_ == 2)
+            ag_gfx1250_scalar<T, 2><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+        else
+            ag_gfx1250_scalar<T, 4><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+    }
+
+    template <typename T>
+    void allgather_vec(hipStream_t stream,
+                       T* input,
+                       T* output,
+                       int size)
+    {
+        auto d = 16 / sizeof(T);
+        if(size % d != 0)
+            throw std::runtime_error(
+                "allgather_vec requires input length to be multiple of " + std::to_string(d));
+
+        RankData* input_ptrs = get_buffer_RD(stream, input);
+        size /= d;
+
+        constexpr int threads = 256;
+        int blocks = std::min(kMaxBlocks,
+                              (size + threads - 1) / threads);
+        if(world_size_ == 2)
+            ag_gfx1250_naive_vec<T, 2><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+        else
+            ag_gfx1250_naive_vec<T, 4><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+    }
+
+    template <typename T>
+    void allgather_naive(hipStream_t stream,
+                         T* input,
+                         T* output,
+                         int size)
+    {
+        auto d = 16 / sizeof(T);
+        if(size % d != 0)
+            throw std::runtime_error(
+                "allgather requires input length to be multiple of " + std::to_string(d));
+
+        RankData* input_ptrs = get_buffer_RD(stream, input);
+        size /= d;
+
+        constexpr int threads = 256;
+        int blocks = std::min(kMaxBlocks,
+                              (size + threads * 4 - 1) / (threads * 4));
+        if(world_size_ == 2)
+            ag_gfx1250_naive_unroll4<T, 2><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+        else
+            ag_gfx1250_naive_unroll4<T, 4><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+    }
+
+    template <typename T>
+    void allgather_warpsplit(hipStream_t stream,
+                             T* input,
+                             T* output,
+                             int size)
+    {
+        auto d = 16 / sizeof(T);
+        if(size % d != 0)
+            throw std::runtime_error(
+                "allgather requires input length to be multiple of " + std::to_string(d));
+
+        RankData* input_ptrs = get_buffer_RD(stream, input);
+        size /= d;
+
+        constexpr int threads = 256;
+        int blocks = std::min(kMaxBlocks,
+                              (size + threads * 4 - 1) / (threads * 4));
+        if(world_size_ == 2)
+            ag_gfx1250_warpsplit_unroll4<T, 2><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+        else
+            ag_gfx1250_warpsplit_unroll4<T, 4><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size);
+    }
+
+    template <typename T>
+    void allgather_lastdim(hipStream_t stream,
+                           T* input,
+                           T* output,
+                           int size,
+                           int last_dim_size)
+    {
+        auto d = 16 / sizeof(T);
+        if(size % d != 0 || last_dim_size % d != 0)
+            throw std::runtime_error(
+                "allgather_lastdim requires input length and last_dim_size "
+                "to be multiples of " + std::to_string(d));
+
+        RankData* input_ptrs = get_buffer_RD(stream, input);
+        size /= d;
+
+        constexpr int threads = 512;
+        constexpr int unroll  = 4;
+        int blocks = std::min(kMaxBlocks,
+                              (size + threads * unroll - 1) / (threads * unroll));
+        if(world_size_ == 2)
+            ag_gfx1250_lastdim<T, 2><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size, last_dim_size);
+        else
+            ag_gfx1250_lastdim<T, 4><<<blocks, threads, 0, stream>>>(
+                input_ptrs, sg_, self_sg_, output, rank_, size, last_dim_size);
+    }
+
+    template <typename T, int unroll>
+    void p2p_bw_test(hipStream_t stream,
+                     T* input,
+                     T* output,
+                     int size,
+                     int threads,
+                     int blocks)
+    {
+        auto d = 16 / sizeof(T);
+        if(size % d != 0)
+            throw std::runtime_error(
+                "p2p_bw_test requires input length to be multiple of " + std::to_string(d));
+
+        RankData* input_ptrs = get_buffer_RD(stream, input);
+        size /= d;
+
+        p2p_bandwidth_test_kernel<T, unroll><<<blocks, threads, 0, stream>>>(
+            input_ptrs, sg_, self_sg_, output, rank_, size);
+    }
+
+    template <typename T>
+    void allreduce(hipStream_t stream,
+                   T* input,
+                   T* output,
+                   int size,
+                   bool use_new                 = true,
+                   bool is_broadcast_reg_outptr = false)
+    {
+        auto d = 16 / sizeof(T);
+        if(size % d != 0)
+            throw std::runtime_error(
+                "custom allreduce requires input length to be multiple of " + std::to_string(d));
+
+        RankData* input_ptrs = get_buffer_RD(stream, input);
+        RankData* output_ptrs = nullptr;
+        if(is_broadcast_reg_outptr)
+            output_ptrs = get_output_buffer_RD(stream, output);
+
+        size /= d;
+
+        if(world_size_ > 4)
+            throw std::runtime_error(
+                "gfx1250 custom allreduce only supports world_size <= 4, got " +
+                std::to_string(world_size_));
+
+        constexpr int threads = 256;
+        int blocks = std::min(kMaxBlocks,
+                              (size + threads * 4 - 1) / (threads * 4));
+        if(world_size_ == 2)
+        {
+            ar_gfx1250_naive_unroll4<T, 2><<<blocks, threads, 0, stream>>>(
+                input_ptrs, output_ptrs, sg_, self_sg_, output, rank_, size);
+        }
+        else
+        {
+            ar_gfx1250_naive_unroll4<T, 4><<<blocks, threads, 0, stream>>>(
+                input_ptrs, output_ptrs, sg_, self_sg_, output, rank_, size);
+        }
+    }
+
+    template <typename T>
+    void dispatchReduceScatter(hipStream_t stream, T* input, T* output,
+                               int m, int n, int k,
+                               ReduceScatterSplitDim split_dim)
+    {
+        RankData* ptrs          = get_buffer_RD(stream, input);
+        constexpr int pack_size = 16 / sizeof(T);
+        constexpr int kGridCap  = kMaxBlocks;
+
+        switch(split_dim)
+        {
+        case ReduceScatterSplitDim::kFirst: {
+            int range = k / (world_size_ * pack_size);
+            dim3 block(512);
+            dim3 grid(std::min(kGridCap, (range + 511) / 512));
+            if(world_size_ == 2)
+                rs_gfx1250_split_first_dim<T, 2>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range);
+            else
+                rs_gfx1250_split_first_dim<T, 4>
+                    <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, range);
+            break;
+        }
+        case ReduceScatterSplitDim::kLast: {
+            bool vec  = (k % (world_size_ * pack_size) == 0);
+            int size  = vec ? (n * k) / (world_size_ * pack_size)
+                            : (n * k) / world_size_;
+            dim3 block(256);
+            dim3 grid(std::min(kGridCap, (size + 255) / 256));
+#define LAUNCH_LAST_1250(NG)                                                    \
+    do {                                                                        \
+        if(vec)                                                                 \
+            rs_gfx1250_split_lastdim<T, NG>                                     \
+                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output,       \
+                                             rank_, n, k);                      \
+        else                                                                    \
+            rs_gfx1250_split_lastdim_naive<T, NG>                               \
+                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output,       \
+                                             rank_, n, k);                      \
+    } while(0)
+            if(world_size_ == 2) { LAUNCH_LAST_1250(2); }
+            else                 { LAUNCH_LAST_1250(4); }
+#undef LAUNCH_LAST_1250
+            break;
+        }
+        case ReduceScatterSplitDim::kMid: {
+            bool vec  = (k % pack_size == 0);
+            int size  = vec ? (m * n * k) / (world_size_ * pack_size)
+                            : (m * n * k) / world_size_;
+            dim3 block(256);
+            dim3 grid(std::min(kGridCap, (size + 255) / 256));
+#define LAUNCH_MID_1250(NG)                                                     \
+    do {                                                                        \
+        if(vec)                                                                 \
+            rs_gfx1250_split_middim<T, NG>                                      \
+                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output,       \
+                                             rank_, m, n, k);                   \
+        else                                                                    \
+            rs_gfx1250_split_middim_naive<T, NG>                                \
+                <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, output,       \
+                                             rank_, m, n, k);                   \
+    } while(0)
+            if(world_size_ == 2) { LAUNCH_MID_1250(2); }
+            else                 { LAUNCH_MID_1250(4); }
+#undef LAUNCH_MID_1250
+            break;
+        }
+        default: printf("reduce_scatter split_dim error!\n");
+        }
+    }
+};
+
+} // namespace aiter

--- a/csrc/include/custom_all_reduce_gfx1250.h
+++ b/csrc/include/custom_all_reduce_gfx1250.h
@@ -1,0 +1,79 @@
+#pragma once
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * gfx1250 (MI450) custom allreduce — pointer-based API (no hipIpc).
+ */
+#include <cstdint>
+#include <vector>
+#include "aiter_tensor.h"
+
+using fptr_t = int64_t;
+
+namespace aiter {
+
+// init_custom_ar receives direct device pointers for each rank's meta buffer
+// (already mapped by torch's cross-process sharing), not IPC handles.
+fptr_t init_custom_ar(int64_t meta_ptr,
+                      int64_t rank_data_ptr,
+                      int64_t rank_data_sz,
+                      const std::vector<int64_t>& all_meta_ptrs,
+                      int64_t rank,
+                      bool fully_connected);
+void all_reduce(fptr_t _fa,
+                const aiter_tensor_t& inp,
+                const aiter_tensor_t& out,
+                bool use_new,
+                bool open_fp8_quant,
+                int64_t reg_inp_ptr,
+                int64_t reg_inp_bytes);
+void all_gather(fptr_t _fa,
+                const aiter_tensor_t& inp,
+                const aiter_tensor_t& out,
+                int64_t dim,
+                int64_t reg_inp_ptr,
+                int64_t reg_inp_bytes);
+void p2p_bw_test(fptr_t _fa,
+                  const aiter_tensor_t& inp,
+                  const aiter_tensor_t& out,
+                  int64_t unroll,
+                  int64_t threads,
+                  int64_t blocks,
+                  int64_t reg_inp_ptr,
+                  int64_t reg_inp_bytes);
+void reduce_scatter(fptr_t _fa,
+                    const aiter_tensor_t& inp,
+                    const aiter_tensor_t& out,
+                    int64_t m, int64_t n, int64_t k,
+                    int64_t split_dim,
+                    int64_t reg_ptr, int64_t reg_bytes);
+void dispose(fptr_t _fa);
+int64_t meta_size();
+// register_input/output_buffer receive direct device pointers per rank.
+void register_input_buffer(fptr_t _fa,
+                           int64_t self_ptr,
+                           const std::vector<int64_t>& all_ptrs);
+void register_output_buffer(fptr_t _fa,
+                            int64_t self_ptr,
+                            const std::vector<int64_t>& all_ptrs);
+int64_t get_graph_buffer_count(fptr_t _fa);
+void get_graph_buffer_ptrs(fptr_t _fa, int64_t ptrs_out);
+void register_graph_buffers(fptr_t _fa,
+                            const std::vector<int64_t>& ptrs_per_rank);
+void start_sync_latency(fptr_t _fa, int64_t blocks);
+void end_sync_latency(fptr_t _fa, int64_t blocks);
+void two_sync_latency(fptr_t _fa, int64_t blocks);
+
+} // namespace aiter

--- a/csrc/kernels/custom_all_reduce_gfx1250.cu
+++ b/csrc/kernels/custom_all_reduce_gfx1250.cu
@@ -1,0 +1,436 @@
+/*
+ * Copyright (C) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Host-side dispatch for gfx1250 (MI450) custom allreduce.
+ * Pointer-based API — hipIpc is not available on gfx1250.
+ */
+#include "custom_all_reduce_gfx1250.cuh"
+#include "aiter_stream.h"
+#include "aiter_tensor.h"
+#include <cstring>
+
+using fptr_t = int64_t;
+static_assert(sizeof(void*) == sizeof(fptr_t));
+
+namespace aiter {
+
+// ---- init / dispose / meta_size ----
+
+fptr_t init_custom_ar(int64_t meta_ptr,
+                      int64_t rank_data_ptr,
+                      int64_t rank_data_sz,
+                      const std::vector<int64_t>& all_meta_ptrs,
+                      int64_t rank,
+                      bool fully_connected)
+{
+    int world_size = all_meta_ptrs.size();
+    if(world_size > 4)
+        throw std::invalid_argument("gfx1250 custom allreduce: world size > 4 is not supported");
+    if(world_size % 2 != 0)
+        throw std::invalid_argument("Odd num gpus is not supported for now");
+    if(rank < 0 || rank >= world_size)
+        throw std::invalid_argument("invalid rank passed in");
+
+    return (fptr_t) new aiter::CustomAllreduce(reinterpret_cast<aiter::Signal*>(meta_ptr),
+                                               (void*)rank_data_ptr,
+                                               rank_data_sz,
+                                               all_meta_ptrs,
+                                               rank,
+                                               fully_connected);
+}
+
+void dispose(fptr_t _fa)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    delete fa;
+}
+
+int64_t meta_size() { return sizeof(aiter::Signal); }
+
+// ---- Internal dispatch helper ----
+
+static void _all_reduce(fptr_t _fa, void* inp, void* out,
+                        int64_t numel, AiterDtype dtype,
+                        bool use_new, bool is_broadcast_reg_outptr)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    switch(dtype)
+    {
+    case AITER_DTYPE_fp32: {
+        fa->allreduce<opus::fp32_t>(stream,
+                             reinterpret_cast<opus::fp32_t*>(inp),
+                             reinterpret_cast<opus::fp32_t*>(out),
+                             numel, use_new, is_broadcast_reg_outptr);
+        break;
+    }
+    case AITER_DTYPE_fp16: {
+        fa->allreduce<opus::fp16_t>(stream,
+                                reinterpret_cast<opus::fp16_t*>(inp),
+                                reinterpret_cast<opus::fp16_t*>(out),
+                                numel, use_new, is_broadcast_reg_outptr);
+        break;
+    }
+    case AITER_DTYPE_bf16: {
+        fa->allreduce<opus::bf16_t>(stream,
+                                      reinterpret_cast<opus::bf16_t*>(inp),
+                                      reinterpret_cast<opus::bf16_t*>(out),
+                                      numel, use_new);
+        break;
+    }
+    default:
+        throw std::runtime_error("gfx1250 custom allreduce only supports float32, float16 and bfloat16");
+    }
+}
+
+// ---- reduce_scatter dispatch ----
+
+static void _reduce_scatter(fptr_t _fa, void* inp, void* out,
+                            int m, int n, int k,
+                            aiter::ReduceScatterSplitDim split_dim,
+                            AiterDtype dtype)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    switch(dtype)
+    {
+    case AITER_DTYPE_fp32: {
+        fa->dispatchReduceScatter<opus::fp32_t>(stream,
+                                     reinterpret_cast<opus::fp32_t*>(inp),
+                                     reinterpret_cast<opus::fp32_t*>(out),
+                                     m, n, k, split_dim);
+        break;
+    }
+    case AITER_DTYPE_fp16: {
+        fa->dispatchReduceScatter<opus::fp16_t>(stream,
+                                    reinterpret_cast<opus::fp16_t*>(inp),
+                                    reinterpret_cast<opus::fp16_t*>(out),
+                                    m, n, k, split_dim);
+        break;
+    }
+    case AITER_DTYPE_bf16: {
+        fa->dispatchReduceScatter<opus::bf16_t>(stream,
+                                              reinterpret_cast<opus::bf16_t*>(inp),
+                                              reinterpret_cast<opus::bf16_t*>(out),
+                                              m, n, k, split_dim);
+        break;
+    }
+    default:
+        throw std::runtime_error("gfx1250 reduce_scatter only supports float32, float16 and bfloat16");
+    }
+}
+
+void reduce_scatter(fptr_t _fa,
+                    const aiter_tensor_t& inp,
+                    const aiter_tensor_t& out,
+                    int64_t m, int64_t n, int64_t k,
+                    int64_t split_dim,
+                    int64_t reg_ptr, int64_t reg_bytes)
+{
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto dtype         = inp.dtype();
+    int64_t data_bytes = inp.numel() * inp.element_size();
+    auto sd            = static_cast<aiter::ReduceScatterSplitDim>(split_dim);
+
+    if(reg_ptr != 0)
+    {
+        if(data_bytes > reg_bytes)
+            throw std::runtime_error("registered buffer is too small to contain the input");
+        HIP_CALL(hipMemcpyAsync((void*)reg_ptr, inp.data_ptr(), data_bytes,
+                                hipMemcpyDeviceToDevice, stream));
+        _reduce_scatter(_fa, (void*)reg_ptr, out.data_ptr(),
+                        static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
+                        sd, dtype);
+    }
+    else
+    {
+        _reduce_scatter(_fa, inp.data_ptr(), out.data_ptr(),
+                        static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
+                        sd, dtype);
+    }
+}
+
+// ---- Buffer registration (pointer-based) ----
+
+void register_input_buffer(fptr_t _fa,
+                           int64_t self_ptr,
+                           const std::vector<int64_t>& all_ptrs)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    fa->register_input_buffer(all_ptrs, (void*)self_ptr);
+}
+
+void register_output_buffer(fptr_t _fa,
+                            int64_t self_ptr,
+                            const std::vector<int64_t>& all_ptrs)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    fa->register_output_buffer(all_ptrs, (void*)self_ptr);
+}
+
+int64_t get_graph_buffer_count(fptr_t _fa)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    return (int64_t)(fa->graph_unreg_input_buffers_.size() +
+                     fa->graph_unreg_output_buffers_.size());
+}
+
+void get_graph_buffer_ptrs(fptr_t _fa, int64_t ptrs_out)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    auto ptrs = fa->get_graph_buffer_ptrs();
+    std::memcpy((void*)ptrs_out, ptrs.data(), ptrs.size() * sizeof(int64_t));
+}
+
+void register_graph_buffers(fptr_t _fa,
+                            const std::vector<int64_t>& ptrs_per_rank)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    int world_size = fa->world_size_;
+    int total_buffers = fa->graph_unreg_input_buffers_.size() +
+                        fa->graph_unreg_output_buffers_.size();
+    // ptrs_per_rank is a flat list: [rank0_buf0, rank0_buf1, ..., rank1_buf0, ...]
+    std::vector<const int64_t*> per_rank(world_size);
+    for(int i = 0; i < world_size; i++)
+        per_rank[i] = &ptrs_per_rank[i * total_buffers];
+    fa->register_graph_buffers(per_rank.data());
+}
+
+// ---- Allgather dispatch helpers ----
+
+static void _all_gather(fptr_t _fa, void* inp, void* out,
+                        int64_t numel, AiterDtype dtype,
+                        int64_t last_dim_size, int64_t gather_dim)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+
+#define AG_DISPATCH_DIM0(T)                                         \
+    do {                                                            \
+        auto d = 16 / sizeof(T);                                    \
+        if(numel % d != 0)                                          \
+            fa->allgather_scalar<T>(stream,                         \
+                  reinterpret_cast<T*>(inp),                        \
+                  reinterpret_cast<T*>(out), numel);                \
+        else if(numel % (d * 256 * 4) != 0)                         \
+            fa->allgather_vec<T>(stream,                            \
+                  reinterpret_cast<T*>(inp),                        \
+                  reinterpret_cast<T*>(out), numel);                \
+        else                                                        \
+            fa->allgather_naive<T>(stream,                          \
+                  reinterpret_cast<T*>(inp),                        \
+                  reinterpret_cast<T*>(out), numel);                \
+    } while(0);                                                     \
+    break
+
+#define AG_DISPATCH_LASTDIM(T)                             \
+    fa->allgather_lastdim<T>(stream,                       \
+                  reinterpret_cast<T*>(inp),                \
+                  reinterpret_cast<T*>(out),                \
+                  numel, last_dim_size);                    \
+    break
+
+    switch(dtype)
+    {
+    case AITER_DTYPE_fp16:
+        if(gather_dim != 0) { AG_DISPATCH_LASTDIM(opus::fp16_t); }
+        else                { AG_DISPATCH_DIM0(opus::fp16_t); }
+    case AITER_DTYPE_bf16:
+        if(gather_dim != 0) { AG_DISPATCH_LASTDIM(opus::bf16_t); }
+        else                { AG_DISPATCH_DIM0(opus::bf16_t); }
+    case AITER_DTYPE_fp32:
+        if(gather_dim != 0) { AG_DISPATCH_LASTDIM(opus::fp32_t); }
+        else                { AG_DISPATCH_DIM0(opus::fp32_t); }
+    default:
+        throw std::runtime_error("gfx1250 allgather only supports fp32, fp16 and bf16");
+    }
+#undef AG_DISPATCH_DIM0
+#undef AG_DISPATCH_LASTDIM
+}
+
+// ---- P2P bandwidth test dispatch ----
+
+static void _p2p_bw_test(fptr_t _fa, void* inp, void* out,
+                          int64_t numel, AiterDtype dtype,
+                          int unroll, int threads, int blocks)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+
+#define BW_DISPATCH(T, U)                                     \
+    fa->p2p_bw_test<T, U>(stream,                             \
+        reinterpret_cast<T*>(inp),                             \
+        reinterpret_cast<T*>(out), numel, threads, blocks);    \
+    return
+
+#define BW_UNROLL(T)                           \
+    switch(unroll) {                           \
+    case 2: BW_DISPATCH(T, 2);                 \
+    case 4: BW_DISPATCH(T, 4);                 \
+    case 8: BW_DISPATCH(T, 8);                 \
+    default: throw std::runtime_error(         \
+        "p2p_bw_test: unroll must be 2, 4 or 8"); \
+    }
+
+    switch(dtype)
+    {
+    case AITER_DTYPE_fp16: BW_UNROLL(opus::fp16_t);
+    case AITER_DTYPE_bf16: BW_UNROLL(opus::bf16_t);
+    case AITER_DTYPE_fp32: BW_UNROLL(opus::fp32_t);
+    default:
+        throw std::runtime_error("p2p_bw_test only supports fp32, fp16, bf16");
+    }
+#undef BW_DISPATCH
+#undef BW_UNROLL
+}
+
+void p2p_bw_test(fptr_t _fa,
+                  const aiter_tensor_t& inp,
+                  const aiter_tensor_t& out,
+                  int64_t unroll,
+                  int64_t threads,
+                  int64_t blocks,
+                  int64_t reg_inp_ptr,
+                  int64_t reg_inp_bytes)
+{
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto dtype     = inp.dtype();
+    int64_t numel  = inp.numel();
+    int64_t data_bytes = numel * inp.element_size();
+
+    void* actual_inp = inp.data_ptr();
+    void* actual_out = out.data_ptr();
+
+    if(reg_inp_ptr != 0)
+    {
+        if(data_bytes > reg_inp_bytes)
+            throw std::runtime_error("registered buffer is too small");
+        HIP_CALL(hipMemcpyAsync((void*)reg_inp_ptr, actual_inp, data_bytes,
+                                hipMemcpyDeviceToDevice, stream));
+        actual_inp = (void*)reg_inp_ptr;
+    }
+
+    _p2p_bw_test(_fa, actual_inp, actual_out, numel, dtype,
+                  unroll, threads, blocks);
+}
+
+// ---- Public collective APIs ----
+
+void all_gather(fptr_t _fa,
+                const aiter_tensor_t& inp,
+                const aiter_tensor_t& out,
+                int64_t dim,
+                int64_t reg_inp_ptr,
+                int64_t reg_inp_bytes)
+{
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto dtype     = inp.dtype();
+    int64_t numel  = inp.numel();
+    int64_t data_bytes = numel * inp.element_size();
+    int64_t last_dim_size = inp.size(-1);
+
+    void* actual_inp = inp.data_ptr();
+    void* actual_out = out.data_ptr();
+
+    if(reg_inp_ptr != 0)
+    {
+        if(data_bytes > reg_inp_bytes)
+            throw std::runtime_error("registered buffer is too small to contain the input");
+        HIP_CALL(hipMemcpyAsync((void*)reg_inp_ptr, actual_inp, data_bytes,
+                                hipMemcpyDeviceToDevice, stream));
+        actual_inp = (void*)reg_inp_ptr;
+    }
+
+    _all_gather(_fa, actual_inp, actual_out, numel, dtype, last_dim_size, dim);
+}
+
+void all_reduce(fptr_t _fa,
+                const aiter_tensor_t& inp,
+                const aiter_tensor_t& out,
+                bool use_new, bool open_fp8_quant,
+                int64_t reg_inp_ptr, int64_t reg_inp_bytes)
+{
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto dtype     = inp.dtype();
+    int64_t numel  = inp.numel();
+    int64_t data_bytes = numel * inp.element_size();
+
+    void* actual_inp = inp.data_ptr();
+    void* actual_out = out.data_ptr();
+
+    bool is_broadcast_reg_outptr = (reg_inp_ptr == 0);
+
+    if(reg_inp_ptr != 0)
+    {
+        if(data_bytes > reg_inp_bytes)
+            throw std::runtime_error("registered buffer is too small to contain the input");
+        HIP_CALL(hipMemcpyAsync((void*)reg_inp_ptr, actual_inp, data_bytes,
+                                hipMemcpyDeviceToDevice, stream));
+        actual_inp = (void*)reg_inp_ptr;
+    }
+
+    _all_reduce(_fa, actual_inp, actual_out, numel, dtype,
+                use_new, is_broadcast_reg_outptr);
+}
+
+// ---- Sync latency measurement kernels ----
+
+void start_sync_latency(fptr_t _fa, int64_t blocks)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    int ws = fa->world_size_;
+    constexpr int threads = 256;
+    if(ws == 2)
+        aiter::start_sync_latency<2><<<blocks, threads, 0, stream>>>(
+            fa->sg_, fa->self_sg_, fa->rank_);
+    else
+        aiter::start_sync_latency<4><<<blocks, threads, 0, stream>>>(
+            fa->sg_, fa->self_sg_, fa->rank_);
+}
+
+void end_sync_latency(fptr_t _fa, int64_t blocks)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    int ws = fa->world_size_;
+    constexpr int threads = 256;
+    if(ws == 2)
+        aiter::end_sync_latency<2><<<blocks, threads, 0, stream>>>(
+            fa->sg_, fa->self_sg_, fa->rank_);
+    else
+        aiter::end_sync_latency<4><<<blocks, threads, 0, stream>>>(
+            fa->sg_, fa->self_sg_, fa->rank_);
+}
+
+void two_sync_latency(fptr_t _fa, int64_t blocks)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    int ws = fa->world_size_;
+    constexpr int threads = 256;
+    if(ws == 2)
+        aiter::two_sync_latency<2><<<blocks, threads, 0, stream>>>(
+            fa->sg_, fa->self_sg_, fa->rank_);
+    else
+        aiter::two_sync_latency<4><<<blocks, threads, 0, stream>>>(
+            fa->sg_, fa->self_sg_, fa->rank_);
+}
+
+} // namespace aiter

--- a/csrc/pybind/custom_all_reduce_gfx1250_pybind.cu
+++ b/csrc/pybind/custom_all_reduce_gfx1250_pybind.cu
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "aiter_stream.h"
+#include "custom_all_reduce_gfx1250.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("_set_current_hip_stream",
+          [](int64_t stream_ptr) { aiter::setCurrentHIPStream((hipStream_t)stream_ptr); },
+          py::arg("stream_ptr"));
+    m.def("init_custom_ar", &aiter::init_custom_ar,
+          py::arg("meta_ptr"), py::arg("rank_data_ptr"), py::arg("rank_data_sz"),
+          py::arg("all_meta_ptrs"), py::arg("rank"),
+          py::arg("fully_connected"));
+    m.def("all_reduce", &aiter::all_reduce,
+          py::arg("_fa"), py::arg("inp"), py::arg("out"),
+          py::arg("use_new"), py::arg("open_fp8_quant"),
+          py::arg("reg_inp_ptr"), py::arg("reg_inp_bytes"));
+    m.def("reduce_scatter", &aiter::reduce_scatter,
+          py::arg("_fa"), py::arg("inp"), py::arg("out"),
+          py::arg("m"), py::arg("n"), py::arg("k"),
+          py::arg("split_dim"),
+          py::arg("reg_ptr"), py::arg("reg_bytes"));
+    m.def("all_gather", &aiter::all_gather,
+          py::arg("_fa"), py::arg("inp"), py::arg("out"),
+          py::arg("dim"), py::arg("reg_inp_ptr"), py::arg("reg_inp_bytes"));
+    m.def("p2p_bw_test", &aiter::p2p_bw_test,
+          py::arg("_fa"), py::arg("inp"), py::arg("out"),
+          py::arg("unroll"), py::arg("threads"), py::arg("blocks"),
+          py::arg("reg_inp_ptr"), py::arg("reg_inp_bytes"));
+    m.def("dispose", &aiter::dispose, py::arg("_fa"));
+    m.def("meta_size", &aiter::meta_size);
+    m.def("register_input_buffer", &aiter::register_input_buffer,
+          py::arg("_fa"), py::arg("self_ptr"), py::arg("all_ptrs"));
+    m.def("register_output_buffer", &aiter::register_output_buffer,
+          py::arg("_fa"), py::arg("self_ptr"), py::arg("all_ptrs"));
+    m.def("get_graph_buffer_count", &aiter::get_graph_buffer_count, py::arg("_fa"));
+    m.def("get_graph_buffer_ptrs", &aiter::get_graph_buffer_ptrs,
+          py::arg("_fa"), py::arg("ptrs_out"));
+    m.def("register_graph_buffers", &aiter::register_graph_buffers,
+          py::arg("_fa"), py::arg("ptrs_per_rank"));
+    m.def("start_sync_latency", &aiter::start_sync_latency,
+          py::arg("_fa"), py::arg("blocks"));
+    m.def("end_sync_latency", &aiter::end_sync_latency,
+          py::arg("_fa"), py::arg("blocks"));
+    m.def("two_sync_latency", &aiter::two_sync_latency,
+          py::arg("_fa"), py::arg("blocks"));
+}

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allgather.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allgather.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Benchmark for gfx1250 (MI450) allgather kernels: naive vs warpsplit.
+# TP2 only. Reports latency (us) and XGMI bandwidth (GB/s).
+#
+# XGMI bandwidth = input_size_bytes / latency
+#   (each rank reads input_size bytes from the remote GPU via XGMI)
+
+import os
+from multiprocessing import Pool, set_start_method
+
+import torch
+import torch.distributed as dist
+
+from aiter import logger
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+from aiter.test_common import perftest
+
+set_start_method("spawn", force=True)
+
+_INIT_TIMEOUT_SEC = 120
+
+_SIZES = [
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1024 * 1024,
+    2 * 1024 * 1024,
+    4 * 1024 * 1024,
+    8 * 1024 * 1024,
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    64 * 1024 * 1024,
+    128 * 1024 * 1024,
+]
+
+
+def _size_str(n: int) -> str:
+    if n >= 1024 * 1024:
+        return f"{n // (1024 * 1024)}M"
+    return f"{n // 1024}K"
+
+
+def _worker(
+    rank: int,
+    size: int,
+    kernel_type: int,
+    distributed_init_method: str,
+):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    from aiter.dist.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        ensure_model_parallel_initialized,
+        get_tp_group,
+        init_distributed_environment,
+        set_custom_all_reduce,
+    )
+
+    set_custom_all_reduce(True)
+
+    init_distributed_environment(
+        world_size=2,
+        rank=rank,
+        distributed_init_method=distributed_init_method,
+    )
+    ensure_model_parallel_initialized(2, 1)
+
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, device=device), group=group)
+    torch.cuda.synchronize()
+
+    ca_comm = get_tp_group().device_communicator.ca_comm
+    if ca_comm is None or ca_comm.disabled:
+        raise RuntimeError("Custom allreduce not initialized")
+
+    import aiter as ops
+
+    _ptr = ca_comm._ptr
+    inp = torch.randn(size, dtype=torch.bfloat16, device=device)
+    out = torch.empty(size * 2, dtype=torch.bfloat16, device=device)
+
+    reg_inp = ca_comm._pool["input"].data_ptr
+    reg_inp_bytes = ca_comm._pool["input"].max_size
+
+    @perftest(use_cuda_event=True)
+    def run_ag():
+        ops.all_gather_gfx1250(_ptr, inp, out, kernel_type, reg_inp, reg_inp_bytes)
+
+    _, latency_us = run_ag()
+
+    # Correctness check: gather all inputs and compare
+    all_inputs = [torch.empty_like(inp) for _ in range(2)]
+    dist.all_gather(all_inputs, inp, group=group)
+    ref = torch.cat(all_inputs, dim=0)
+    max_err = (out.float() - ref.float()).abs().max().item()
+
+    if dist.is_initialized():
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        torch.cuda.empty_cache()
+
+    return latency_us, max_err
+
+
+def run_one(size: int, kernel_type: int, distributed_init_method: str):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "49374"
+    pool = Pool(processes=2)
+    rets = []
+    for rank in range(2):
+        rets.append(
+            pool.apply_async(
+                _worker,
+                args=(rank, size, kernel_type, distributed_init_method),
+            )
+        )
+    pool.close()
+
+    results = []
+    try:
+        for r in rets:
+            results.append(r.get(timeout=_INIT_TIMEOUT_SEC))
+    except Exception:
+        pool.terminate()
+        pool.join()
+        raise
+    pool.join()
+
+    latencies = [r[0] for r in results]
+    errors = [r[1] for r in results]
+    return max(latencies), max(errors)
+
+
+if __name__ == "__main__":
+    kernel_names = {0: "naive", 1: "warpsplit"}
+
+    rows = []
+    for size in _SIZES:
+        for kt in [0, 1]:
+            init_method = get_distributed_init_method(get_ip(), get_open_port())
+            try:
+                latency_us, max_err = run_one(size, kt, init_method)
+            except Exception as e:
+                logger.error(
+                    "size=%s kernel=%s FAILED: %s", _size_str(size), kernel_names[kt], e
+                )
+                continue
+
+            input_bytes = size * 2  # bf16 = 2 bytes
+            bw_gbs = input_bytes / (latency_us * 1e-6) / 1e9
+
+            rows.append(
+                {
+                    "size": _size_str(size),
+                    "kernel": kernel_names[kt],
+                    "latency_us": f"{latency_us:.1f}",
+                    "xgmi_bw_gbs": f"{bw_gbs:.2f}",
+                    "err": f"{max_err:.2e}",
+                }
+            )
+            logger.info(
+                "size=%s kernel=%-10s latency=%7.1f us  xgmi_bw=%6.2f GB/s  err=%s",
+                _size_str(size),
+                kernel_names[kt],
+                latency_us,
+                bw_gbs,
+                f"{max_err:.2e}",
+            )
+
+    # Print final table
+    header = f"{'size':>8s} | {'kernel':>10s} | {'latency(us)':>11s} | {'XGMI BW(GB/s)':>13s} | {'err':>10s}"
+    sep = "-" * len(header)
+    print(f"\n{sep}")
+    print(header)
+    print(sep)
+    for r in rows:
+        print(
+            f"{r['size']:>8s} | {r['kernel']:>10s} | {r['latency_us']:>11s} | {r['xgmi_bw_gbs']:>13s} | {r['err']:>10s}"
+        )
+    print(sep)

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Test for gfx1250 (MI450) dedicated allreduce kernel (ar_gfx1250_naive_unroll4).
+# Only tests tp2 and tp4 configurations.
+#
+# Known MI450 issues:
+#   - hipExtMallocWithFlags with hipDeviceMallocUncached may fail or produce
+#     buffers that cannot be shared via hipIpcGetMemHandle.
+#   - Multi-GPU IPC handle broadcast may hang if the above allocation fails
+#     silently (returns success but produces an unusable handle).
+#
+# This test wraps initialization in a timeout and provides clear diagnostics.
+
+import argparse
+import os
+import sys
+from multiprocessing import (
+    Pool,
+    TimeoutError as MpTimeoutError,
+    freeze_support,
+    set_start_method,
+)
+
+import torch
+import torch.distributed as dist
+import pandas as pd
+
+from aiter import dtypes
+from aiter import logger
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+from aiter.test_common import benchmark, checkAllclose, perftest
+
+set_start_method("spawn", force=True)
+
+_INIT_TIMEOUT_SEC = 120
+
+
+def _get_gpu_arch(device_idx: int = None) -> str:
+    if device_idx is None:
+        device_idx = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device_idx)
+    return getattr(props, "gcnArchName", "")
+
+
+def _is_gfx1250(device_idx: int = 0) -> bool:
+    return "gfx1250" in _get_gpu_arch(device_idx)
+
+
+def _worker(
+    tp_size: int,
+    rank: int,
+    tensor_on_cpu: torch.Tensor,
+    distributed_init_method: str,
+    with_graph: bool = False,
+):
+    """Per-rank worker: init custom allreduce and run the test."""
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    from aiter.dist.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        ensure_model_parallel_initialized,
+        get_tp_group,
+        graph_capture,
+        init_distributed_environment,
+        set_custom_all_reduce,
+    )
+    from aiter.dist.communication_op import tensor_model_parallel_all_reduce
+
+    arch = _get_gpu_arch()
+    logger.info("RANK %d: arch=%s, tp_size=%d, init...", rank, arch, tp_size)
+
+    set_custom_all_reduce(True)
+
+    try:
+        init_distributed_environment(
+            world_size=tp_size,
+            rank=rank,
+            distributed_init_method=distributed_init_method,
+        )
+        ensure_model_parallel_initialized(tp_size, 1)
+    except RuntimeError as e:
+        err_msg = str(e)
+        if "hipExtMallocWithFlags" in err_msg or "hipIpc" in err_msg:
+            logger.error(
+                "RANK %d: IPC initialization failed (likely hipExtMallocWithFlags "
+                "or hipIpcGetMemHandle issue on this GPU arch). Error: %s",
+                rank,
+                err_msg,
+            )
+        raise
+
+    x = tensor_on_cpu.to(device)
+
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, device=device), group=group)
+    torch.cuda.synchronize()
+
+    logger.info("RANK %d: initialization complete, running allreduce...", rank)
+
+    if with_graph:
+        graph = torch.cuda.CUDAGraph()
+        with graph_capture() as gc:
+            with torch.cuda.graph(graph, stream=gc.stream):
+                out = tensor_model_parallel_all_reduce(x)
+        out.fill_(0)
+
+        @perftest()
+        def run_ca():
+            graph.replay()
+
+        _, us = run_ca()
+        out = (out, us)
+    else:
+
+        @perftest()
+        def run_ca(x):
+            return tensor_model_parallel_all_reduce(x)
+
+        out = run_ca(x)
+
+    if dist.is_initialized():
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        torch.cuda.empty_cache()
+
+    return out
+
+
+@benchmark()
+def test_gfx1250_allreduce(
+    tp_size: int,
+    shape: tuple,
+    dtype: torch.dtype,
+    with_graph: bool = False,
+    distributed_init_method: str = None,
+):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "49373"
+    pool = Pool(processes=tp_size)
+    ref = torch.zeros(shape, dtype=dtype)
+    rets = []
+    for i in range(tp_size):
+        x = torch.randn(shape, dtype=dtype)
+        ref += x
+        rets.append(
+            pool.apply_async(
+                _worker,
+                args=(tp_size, i, x, distributed_init_method, with_graph),
+            )
+        )
+    pool.close()
+
+    # Collect results with a per-worker timeout to detect IPC hangs
+    results = []
+    try:
+        for i, r in enumerate(rets):
+            results.append(r.get(timeout=_INIT_TIMEOUT_SEC))
+    except Exception as e:
+        pool.terminate()
+        pool.join()
+        str(e)
+        if isinstance(e, (MpTimeoutError, TimeoutError)):
+            raise RuntimeError(
+                f"Worker timed out after {_INIT_TIMEOUT_SEC}s — likely hung "
+                f"in IPC handle exchange (hipIpcGetMemHandle/"
+                f"hipIpcOpenMemHandle). On MI450, "
+                f"hipExtMallocWithFlags(hipDeviceMallocUncached) may produce "
+                f"buffers incompatible with hipIpc*. Consider using regular "
+                f"torch allocations for the meta/signal buffer."
+            ) from e
+        raise
+    pool.join()
+
+    rets = results
+    all_us = [us for _, us in rets]
+    max_err = 0.0
+    for out, us in rets:
+        msg = (
+            f"test_gfx1250_allreduce: tp={tp_size} {shape=} {dtype=} "
+            f"{with_graph=} {us:>8.2f}"
+        )
+        err = checkAllclose(ref, out.to(ref), msg=msg)
+        max_err = max(max_err, err)
+    return {
+        "min_us": min(all_us),
+        "max_us": max(all_us),
+        "err": max_err,
+    }
+
+
+l_dtype = ["fp16", "bf16"]
+l_shape = [
+    (1, 7168),
+    (2, 7168),
+    (1, 8192),
+    (128, 8192),
+    (512, 8192),
+]
+l_tp_size = [2, 4]
+
+parser = argparse.ArgumentParser(
+    description="Test gfx1250 (MI450) dedicated allreduce kernel"
+)
+parser.add_argument(
+    "-d",
+    "--dtype",
+    type=str,
+    choices=["fp16", "bf16"],
+    default=None,
+    help="data type (default: test both fp16 and bf16)",
+)
+parser.add_argument(
+    "-s",
+    "--shape",
+    type=dtypes.str2tuple,
+    default=None,
+    help="shape, e.g. -s 128,8192",
+)
+parser.add_argument(
+    "-t",
+    "--tp-size",
+    type=int,
+    choices=[2, 4],
+    default=None,
+    help="tensor parallel size (default: test both 2 and 4)",
+)
+parser.add_argument(
+    "-g",
+    "--with-graph",
+    type=lambda x: str(x).lower() in ["true", "1", "yes"],
+    default=False,
+    help="use CUDA graph (default: False)",
+)
+parser.add_argument(
+    "--check-arch",
+    action="store_true",
+    help="check if running on gfx1250 and warn if not",
+)
+
+if __name__ == "__main__":
+    freeze_support()
+    args = parser.parse_args()
+
+    if args.check_arch:
+        torch.cuda.set_device(0)
+        if not _is_gfx1250():
+            arch = _get_gpu_arch(0)
+            logger.warning(
+                "Not running on gfx1250 (detected: %s). "
+                "The kernel will NOT dispatch to ar_gfx1250_naive_unroll4 — "
+                "test will exercise the generic allreduce path instead.",
+                arch,
+            )
+
+    num_gpus = torch.cuda.device_count()
+    if args.dtype is None:
+        test_dtypes = [dtypes.d_dtypes[key] for key in l_dtype]
+    else:
+        test_dtypes = [dtypes.d_dtypes[args.dtype]]
+    if args.shape is not None:
+        test_shapes = [args.shape]
+    else:
+        test_shapes = l_shape
+    if args.tp_size is not None:
+        test_tp_sizes = [args.tp_size]
+    else:
+        test_tp_sizes = [tp for tp in l_tp_size if tp <= num_gpus]
+
+    if not test_tp_sizes:
+        logger.error("Not enough GPUs: need at least 2, have %d", num_gpus)
+        sys.exit(1)
+
+    df = []
+    for tp_size in test_tp_sizes:
+        if tp_size > num_gpus:
+            logger.warning("Skipping tp=%d: only %d GPUs available", tp_size, num_gpus)
+            continue
+        for dtype in test_dtypes:
+            for shape in test_shapes:
+                ret = test_gfx1250_allreduce(
+                    tp_size,
+                    shape,
+                    dtype,
+                    with_graph=args.with_graph,
+                    distributed_init_method=get_distributed_init_method(
+                        get_ip(), get_open_port()
+                    ),
+                )
+                df.append(ret)
+
+    df = pd.DataFrame(df)
+    show_cols = [
+        "tp_size",
+        "shape",
+        "dtype",
+        "withGraph",
+        "min_us",
+        "max_us",
+        "err",
+    ]
+    show_cols = [c for c in show_cols if c in df.columns]
+    logger.info(
+        "gfx1250 allreduce summary (markdown):\n%s",
+        df[show_cols].to_markdown(index=False),
+    )

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_p2p_bw.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_p2p_bw.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# XGMI P2P bandwidth test for gfx1250 (MI450).
+# Pure remote-read + local-write kernel. TP2 only, bf16.
+# Tests unroll = 2, 4, 8 across a range of input sizes.
+#
+# XGMI bandwidth = input_size_bytes / latency
+#   (each rank reads input_size bytes from the remote GPU)
+
+import os
+from multiprocessing import Pool, set_start_method
+
+import torch
+import torch.distributed as dist
+
+from aiter import logger
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+from aiter.test_common import perftest
+
+set_start_method("spawn", force=True)
+
+_INIT_TIMEOUT_SEC = 120
+
+_SIZES = [
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1024 * 1024,
+    2 * 1024 * 1024,
+    4 * 1024 * 1024,
+    8 * 1024 * 1024,
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    64 * 1024 * 1024,
+    128 * 1024 * 1024,
+]
+
+_UNROLLS = [2, 4, 8]
+
+
+def _size_str(n: int) -> str:
+    if n >= 1024 * 1024:
+        return f"{n // (1024 * 1024)}M"
+    return f"{n // 1024}K"
+
+
+def _worker(
+    rank: int,
+    size: int,
+    unroll: int,
+    threads: int,
+    distributed_init_method: str,
+):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    from aiter.dist.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        ensure_model_parallel_initialized,
+        get_tp_group,
+        init_distributed_environment,
+        set_custom_all_reduce,
+    )
+
+    set_custom_all_reduce(True)
+
+    init_distributed_environment(
+        world_size=2,
+        rank=rank,
+        distributed_init_method=distributed_init_method,
+    )
+    ensure_model_parallel_initialized(2, 1)
+
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, device=device), group=group)
+    torch.cuda.synchronize()
+
+    ca_comm = get_tp_group().device_communicator.ca_comm
+    if ca_comm is None or ca_comm.disabled:
+        raise RuntimeError("Custom allreduce not initialized")
+
+    import aiter as ops
+
+    _ptr = ca_comm._ptr
+    inp = torch.randn(size, dtype=torch.bfloat16, device=device)
+    out = torch.empty(size, dtype=torch.bfloat16, device=device)
+
+    reg_inp = ca_comm._pool["input"].data_ptr
+    reg_inp_bytes = ca_comm._pool["input"].max_size
+
+    d = 16 // 2  # bf16 pack_size
+    packed = size // d
+    blocks = min(512, (packed + threads * unroll - 1) // (threads * unroll))
+
+    @perftest(use_cuda_event=True)
+    def run_bw():
+        ops.p2p_bw_test_gfx1250(
+            _ptr,
+            inp,
+            out,
+            unroll,
+            threads,
+            blocks,
+            reg_inp,
+            reg_inp_bytes,
+        )
+
+    _, latency_us = run_bw()
+
+    if dist.is_initialized():
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        torch.cuda.empty_cache()
+
+    return latency_us
+
+
+def run_one(size: int, unroll: int, threads: int, distributed_init_method: str):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "49375"
+    pool = Pool(processes=2)
+    rets = []
+    for rank in range(2):
+        rets.append(
+            pool.apply_async(
+                _worker,
+                args=(rank, size, unroll, threads, distributed_init_method),
+            )
+        )
+    pool.close()
+
+    results = []
+    try:
+        for r in rets:
+            results.append(r.get(timeout=_INIT_TIMEOUT_SEC))
+    except Exception:
+        pool.terminate()
+        pool.join()
+        raise
+    pool.join()
+
+    return max(results)
+
+
+if __name__ == "__main__":
+    threads = 256
+
+    rows = []
+    for size in _SIZES:
+        for unroll in _UNROLLS:
+            init_method = get_distributed_init_method(get_ip(), get_open_port())
+            try:
+                latency_us = run_one(size, unroll, threads, init_method)
+            except Exception as e:
+                logger.error(
+                    "size=%s unroll=%d FAILED: %s",
+                    _size_str(size),
+                    unroll,
+                    e,
+                )
+                continue
+
+            input_bytes = size * 2  # bf16
+            bw_gbs = input_bytes / (latency_us * 1e-6) / 1e9
+
+            rows.append(
+                {
+                    "size": _size_str(size),
+                    "unroll": str(unroll),
+                    "latency_us": f"{latency_us:.1f}",
+                    "xgmi_bw_gbs": f"{bw_gbs:.2f}",
+                }
+            )
+            logger.info(
+                "size=%s unroll=%d  latency=%7.1f us  xgmi_bw=%6.2f GB/s",
+                _size_str(size),
+                unroll,
+                latency_us,
+                bw_gbs,
+            )
+
+    # Print final table
+    header = (
+        f"{'size':>8s} | {'unroll':>6s} | {'latency(us)':>11s} | {'XGMI BW(GB/s)':>13s}"
+    )
+    sep = "-" * len(header)
+    print(f"\n{sep}")
+    print(header)
+    print(sep)
+    for r in rows:
+        print(
+            f"{r['size']:>8s} | {r['unroll']:>6s} | {r['latency_us']:>11s} | {r['xgmi_bw_gbs']:>13s}"
+        )
+    print(sep)

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_sync_latency.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_sync_latency.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Sync latency test for gfx1250 (MI450).
+# Measures start_sync, end_sync, and two_sync (start+end) latency
+# across grid sizes 1,2,4,8,16,32,64,128,256 with block=256.
+
+import argparse
+import os
+import sys
+from multiprocessing import Pool, set_start_method
+
+import torch
+import torch.distributed as dist
+
+from aiter import logger
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+from aiter.test_common import perftest
+
+set_start_method("spawn", force=True)
+
+_INIT_TIMEOUT_SEC = 120
+
+_GRIDS = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+_KERNELS = ["start_sync", "end_sync", "two_sync"]
+
+
+def _worker(
+    tp_size: int,
+    rank: int,
+    grid: int,
+    kernel: str,
+    distributed_init_method: str,
+):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    from aiter.dist.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        ensure_model_parallel_initialized,
+        get_tp_group,
+        init_distributed_environment,
+        set_custom_all_reduce,
+    )
+
+    set_custom_all_reduce(True)
+
+    init_distributed_environment(
+        world_size=tp_size,
+        rank=rank,
+        distributed_init_method=distributed_init_method,
+    )
+    ensure_model_parallel_initialized(tp_size, 1)
+
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, device=device), group=group)
+    torch.cuda.synchronize()
+
+    ca_comm = get_tp_group().device_communicator.ca_comm
+    if ca_comm is None or ca_comm.disabled:
+        raise RuntimeError("Custom allreduce not initialized")
+
+    import aiter as ops
+
+    _ptr = ca_comm._ptr
+
+    fn_map = {
+        "start_sync": ops.start_sync_latency_gfx1250,
+        "end_sync": ops.end_sync_latency_gfx1250,
+        "two_sync": ops.two_sync_latency_gfx1250,
+    }
+    fn = fn_map[kernel]
+
+    @perftest(use_cuda_event=True)
+    def run_sync():
+        fn(_ptr, grid)
+
+    _, latency_us = run_sync()
+
+    if dist.is_initialized():
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        torch.cuda.empty_cache()
+
+    return latency_us
+
+
+def run_one(tp_size: int, grid: int, kernel: str, distributed_init_method: str):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ.setdefault("MASTER_PORT", "49376")
+    pool = Pool(processes=tp_size)
+    rets = [
+        pool.apply_async(
+            _worker,
+            args=(tp_size, r, grid, kernel, distributed_init_method),
+        )
+        for r in range(tp_size)
+    ]
+    pool.close()
+
+    results = []
+    try:
+        for r in rets:
+            results.append(r.get(timeout=_INIT_TIMEOUT_SEC))
+    except Exception:
+        pool.terminate()
+        pool.join()
+        raise
+    pool.join()
+
+    return max(results)
+
+
+parser = argparse.ArgumentParser(
+    description="gfx1250 multi-GPU sync latency test "
+    "(start_sync / end_sync / two_sync)"
+)
+parser.add_argument(
+    "-t",
+    "--tp-size",
+    type=int,
+    choices=[2, 4],
+    default=2,
+    help="tensor-parallel size (default: 2)",
+)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    tp_size = args.tp_size
+
+    num_gpus = torch.cuda.device_count()
+    if num_gpus < tp_size:
+        logger.error("Need %d GPUs, have %d", tp_size, num_gpus)
+        sys.exit(1)
+
+    rows = []
+    for grid in _GRIDS:
+        row = {"grid": grid}
+        for kernel in _KERNELS:
+            init_method = get_distributed_init_method(get_ip(), get_open_port())
+            try:
+                latency_us = run_one(tp_size, grid, kernel, init_method)
+            except Exception as e:
+                import traceback
+
+                traceback.print_exc()
+                logger.error(
+                    "grid=%d kernel=%s FAILED: %s",
+                    grid,
+                    kernel,
+                    e,
+                )
+                latency_us = float("nan")
+            row[kernel] = latency_us
+        rows.append(row)
+
+    header = f"{'grid':>6s} | {'start_sync(us)':>14s} | {'end_sync(us)':>14s} | {'two_sync(us)':>14s}"
+    sep = "-" * len(header)
+    print(f"\ngfx1250 sync latency (tp={tp_size}, block=256)")
+    print(sep)
+    print(header)
+    print(sep)
+    for r in rows:
+        print(
+            f"{r['grid']:>6d} | "
+            f"{r['start_sync']:>14.2f} | "
+            f"{r['end_sync']:>14.2f} | "
+            f"{r['two_sync']:>14.2f}"
+        )
+    print(sep)

--- a/op_tests/multigpu_tests/test_allgather.py
+++ b/op_tests/multigpu_tests/test_allgather.py
@@ -243,6 +243,21 @@ l_shape = [
     # threshold: 64 MB (2 GPU) / 32 MB (4 GPU) / 16 MB (8 GPU)
     # this shape = 4097*8192*2 bytes ≈ 64.015 MB, exceeds even the 2-GPU threshold
     (4097, 8192),
+    # --- gfx1250 unrolled-allgather tail-coverage repro ---
+    # The gfx1250 ag_gfx1250_lastdim / ag_gfx1250_naive_unroll4 kernels loop
+    # with guard `idx + blockDim.x*(unroll-1) < size`, so any tail shorter than
+    # blockDim.x*unroll packed elements is never written (output is
+    # torch.empty -> garbage). Triggered only when the packed element count is
+    # NOT a multiple of that stride. Existing shapes all divide evenly so they
+    # never hit the tail; these do.
+    #
+    # dim=-1 (LM head geometry): DeepSeek-V4 vocab=129280, tp=4 -> per-rank
+    # shard 32320. packed last_dim = 32320/8 = 4040; size = 65*4040 = 262600,
+    # which is NOT a multiple of 512*4 = 2048 -> lastdim kernel drops the tail.
+    (65, 32320),
+    # dim=0 path: size = 65*7168/8 = 58240, NOT a multiple of 256*4 = 1024 ->
+    # naive_unroll4 kernel drops the tail.
+    (65, 7168),
 ]
 
 parser = argparse.ArgumentParser(description="config input of test")
@@ -265,6 +280,14 @@ parser.add_argument(
     default=None,
     help="shape. e.g. -s 128,8192",
 )
+parser.add_argument(
+    "-t",
+    "--tp_size",
+    type=int,
+    choices=[2, 4, 8],
+    default=4,
+    help="tensor-parallel world size (default: 4)",
+)
 
 
 if __name__ == "__main__":
@@ -276,6 +299,7 @@ if __name__ == "__main__":
         l_dtype = [dtypes.d_dtypes[args.dtype]]
     if args.shape is not None:
         l_shape = [args.shape]
+    tp_size = args.tp_size
     l_dim = [0, -1]
     df = []
     for dtype in l_dtype:
@@ -283,7 +307,7 @@ if __name__ == "__main__":
             for dim in l_dim:
                 for use_custom in [False, True]:
                     ret = allgather_perftest(
-                        8,
+                        tp_size,
                         1,
                         shape,
                         dtype,

--- a/op_tests/multigpu_tests/test_reduce_scatter.py
+++ b/op_tests/multigpu_tests/test_reduce_scatter.py
@@ -167,23 +167,62 @@ def run_case(label, shape, dim, dtype, tp_size, init_method_factory):
     }
 
 
-# Cases designed for tp_size=8 and bf16 (pack_size = 16 // 2 = 8).
-# Each case targets a specific kernel branch in dispatchReduceScatter:
-#
-#   first_dim_vec  : numel % (ngpus * pack_size) == 0  → split_first_dim
-#   last_dim_vec   : last % (ngpus * pack_size) == 0   → split_lastdim (vec)
-#   last_dim_naive : last % ngpus == 0 but % pack != 0 → split_lastdim_naive
-#   mid_dim_vec    : k % pack_size == 0                → split_middim (vec)
-#   mid_dim_naive  : k % pack_size != 0                → split_middim_naive
-#
-# All five satisfy shape[dim] % ngpus == 0 (Python wrapper's hard requirement).
-l_cases = [
-    ("first_dim_vec", (512, 1024), 0),
-    ("last_dim_vec", (256, 512), -1),
-    ("last_dim_naive", (256, 40), -1),
-    ("mid_dim_vec", (16, 64, 64), 1),
-    ("mid_dim_naive", (16, 64, 5), 1),
-]
+def build_cases(tp_size, dtype):
+    """Build test cases that target each kernel branch in dispatchReduceScatter.
+
+    Each case is designed so that shape[dim] % tp_size == 0 (hard requirement)
+    and the vectorisation / naive path is selected by the alignment of the
+    last dimension with pack_size.
+
+    Kernel branches:
+      first_dim_vec  : numel % (ngpus * pack_size) == 0  → split_first_dim
+      last_dim_vec   : last % (ngpus * pack_size) == 0   → split_lastdim (vec)
+      last_dim_naive : last % ngpus == 0 but % pack != 0 → split_lastdim_naive
+      mid_dim_vec    : k % pack_size == 0                → split_middim (vec)
+      mid_dim_naive  : k % pack_size != 0                → split_middim_naive
+    """
+    pack_size = 16 // dtype.itemsize
+
+    # first_dim_vec: 2-D, scatter on dim 0
+    #   shape[0] % tp_size == 0, numel % (tp_size * pack_size) == 0
+    first_rows = 64 * tp_size
+    first_cols = pack_size * tp_size
+    assert (first_rows * first_cols) % (tp_size * pack_size) == 0
+
+    # last_dim_vec: 2-D, scatter on last dim
+    #   shape[-1] % (tp_size * pack_size) == 0
+    last_vec_cols = pack_size * tp_size
+    last_vec_rows = 256
+
+    # last_dim_naive: 2-D, scatter on last dim
+    #   shape[-1] % tp_size == 0 BUT shape[-1] % (tp_size * pack_size) != 0
+    last_naive_cols = tp_size * (pack_size - 1) if pack_size > 1 else tp_size
+    if last_naive_cols % (tp_size * pack_size) == 0:
+        last_naive_cols = tp_size
+    last_naive_rows = 256
+
+    # mid_dim_vec: 3-D, scatter on dim 1
+    #   shape[1] % tp_size == 0, k (last dim) % pack_size == 0
+    mid_vec_m = 16
+    mid_vec_n = 8 * tp_size
+    mid_vec_k = pack_size * 8
+
+    # mid_dim_naive: 3-D, scatter on dim 1
+    #   shape[1] % tp_size == 0, k % pack_size != 0
+    mid_naive_m = 16
+    mid_naive_n = 8 * tp_size
+    mid_naive_k = pack_size + 1 if pack_size > 1 else 3
+    if mid_naive_k % pack_size == 0:
+        mid_naive_k += 1
+
+    return [
+        ("first_dim_vec", (first_rows, first_cols), 0),
+        ("last_dim_vec", (last_vec_rows, last_vec_cols), -1),
+        ("last_dim_naive", (last_naive_rows, last_naive_cols), -1),
+        ("mid_dim_vec", (mid_vec_m, mid_vec_n, mid_vec_k), 1),
+        ("mid_dim_naive", (mid_naive_m, mid_naive_n, mid_naive_k), 1),
+    ]
+
 
 l_dtype = ["bf16"]
 
@@ -203,6 +242,14 @@ parser.add_argument(
     default=None,
     help="run only one case by label, e.g. mid_dim_naive",
 )
+parser.add_argument(
+    "-t",
+    "--tp_size",
+    type=int,
+    choices=[2, 4, 8],
+    default=8,
+    help="tensor-parallel world size (default: 8)",
+)
 
 
 if __name__ == "__main__":
@@ -212,21 +259,24 @@ if __name__ == "__main__":
         dtypes_to_run = [dtypes.d_dtypes[k] for k in l_dtype]
     else:
         dtypes_to_run = [dtypes.d_dtypes[args.dtype]]
-    if args.case is None:
-        cases_to_run = l_cases
-    else:
-        cases_to_run = [c for c in l_cases if c[0] == args.case]
-        assert cases_to_run, f"no case named {args.case!r}"
 
-    tp_size = 8
+    tp_size = args.tp_size
 
     def init_method_factory():
         return get_distributed_init_method(get_ip(), get_open_port())
 
     rows = []
     for dtype in dtypes_to_run:
+        all_cases = build_cases(tp_size, dtype)
+        if args.case is None:
+            cases_to_run = all_cases
+        else:
+            cases_to_run = [c for c in all_cases if c[0] == args.case]
+            assert cases_to_run, f"no case named {args.case!r}"
         for label, shape, dim in cases_to_run:
-            print(f"\n=== {label}  shape={shape}  dim={dim}  dtype={dtype} ===")
+            print(
+                f"\n=== {label}  shape={shape}  dim={dim}  dtype={dtype}  tp={tp_size} ==="
+            )
             row = run_case(label, shape, dim, dtype, tp_size, init_method_factory)
             print(
                 f"  max_abs_err={row['max_abs_err']:.4g}  "


### PR DESCRIPTION
 ## Motivation

  `gfx1250` (MI450) does not support the HIP IPC APIs (`hipIpcGetMemHandle` / `hipIpcOpenMemHandle`) that the existing custom
  all-reduce path relies on for cross-process buffer sharing. As a result, the current collective-communication kernels cannot be
  initialized or run on MI450. This PR adds a dedicated, naive implementation of the custom communication kernels for `gfx1250`,
  along with the memory-sharing infrastructure needed to make them work without hipIpc.

  ## Technical Details

  - **VMM-based cross-process buffer sharing** (`aiter/dist/device_communicators/vmm_allocator.py`): Since hipIpc is unavailable on
  gfx1250, buffers are shared using the HIP Virtual Memory Management API (`hipMemCreate` / `hipMemExportToShareableHandle` /
  `hipMemImportFromShareableHandle`). The exported POSIX fd is passed across processes over Unix domain sockets.
  - **Pointer-based collective API** (`csrc/include/custom_all_reduce_gfx1250.{h,cuh}`, `csrc/kernels/custom_all_reduce_gfx1250.cu`,
  `csrc/pybind/custom_all_reduce_gfx1250_pybind.cu`): A self-contained gfx1250 custom all-reduce that takes direct device pointers
  (already mapped via VMM) instead of IPC handles. Implements naive kernels:
    - `ar_gfx1250_naive_unroll4` — all-reduce (fp32/fp16/bf16), unroll-4, supports TP2 and TP4.
    - `ag_gfx1250_naive_unroll4` / `ag_gfx1250_naive_vec` / `ag_gfx1250_scalar` / `ag_gfx1250_lastdim` — all-gather (vectorized,
  scalar fallback, last-dim variants).
    - `reduce_scatter` and a pure remote-read/local-write `p2p_bw_test` kernel for XGMI bandwidth measurement.
    - Sync-latency primitives (`start_sync_latency` / `end_sync_latency` / `two_sync_latency`).
  - **Python integration** (`aiter/ops/custom_all_reduce.py`, `aiter/ops/communication.py`,
  `aiter/dist/device_communicators/custom_all_reduce.py`): Adds a dedicated `module_custom_all_reduce_gfx1250` binding surface
  (`*_gfx1250` entry points) and an `_init_gfx1250` path. Skips the legacy `register_input_buffer(signal)` block on gfx1250, since
  its IPC-meta rendezvous key is process-local and would deadlock at startup across TP ranks.
  - **JIT / build support** (`aiter/jit/core.py`, `optCompilerConfig.json`, `cpp_extension.py`, `file_baton.py`): Registers the new
  `module_custom_all_reduce_gfx1250` module and related build-plumbing updates.
  - **Constraints:** world size must be even and ≤ 4 (TP2 / TP4 only for now).

  ## Test Plan

  - Added POC tests under `op_tests/multigpu_tests/gfx1250_poc/`:
    - `test_gfx1250_allreduce.py` — all-reduce correctness/perf for TP2 and TP4.
    - `test_gfx1250_allgather.py` — all-gather kernel benchmark (naive vs warpsplit), TP2.
    - `test_gfx1250_p2p_bw.py` — XGMI P2P bandwidth (unroll 2/4/8), TP2, bf16.
    - `test_gfx1250_sync_latency.py` — start/end/two-sync latency across grid sizes.
  - Updated existing `op_tests/multigpu_tests/test_allgather.py` and `test_reduce_scatter.py` to cover the gfx1250 path.

  ## Test Result
unit test pass

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.