### PR TITLE
[flydsl] qk_norm_rope: paged (block_tables) SWA cache-write variant

### DIFF
--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -211,6 +211,7 @@ def _build_kernel(
     scale_dtype: str,
     q_weighted: bool,
     kv_write: bool = False,
+    paged: bool = False,
 ):
     """Build the @flyc.kernel + @flyc.jit launcher for a given config.
 
@@ -297,6 +298,8 @@ def _build_kernel(
         _name_parts.append(scale_dtype)
     if kv_write:
         _name_parts.append("kvw")
+    if paged:
+        _name_parts.append("paged")
     _name_parts.append("flydsl")
     _kname = "_".join(_name_parts)
 
@@ -726,14 +729,40 @@ def _build_kernel(
                     )
                     do_swa = bid_i32 >= fx.Int32(0)
                     bid_safe = arith.maxsi(bid_i32, arith.constant(0, type=i32))
-                    slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
-                    slot = buffer_ops.buffer_load(
-                        slot_rsrc, bid_safe, vec_width=1, dtype=i32
-                    )
-                    ring = arith.remsi(pos_i32, _to_raw(swa_cache_size))
-                    swa_off_elems = ArithValue(slot) * ArithValue(
-                        swa_slot_stride
-                    ) + ArithValue(ring) * ArithValue(swa_pos_stride)
+                    if const_expr(paged):
+                        # paged / content-addressed SWA (DeepSeek-V4 #1417):
+                        # swa_kv is the FLAT [num_pages, D] pool; the ring params
+                        # are repurposed — state_slot_mapping is block_tables
+                        # [bs, max_blocks], swa_slot_stride is max_blocks (its row
+                        # stride), swa_cache_size is block_size, swa_pos_stride is
+                        # D. Physical row =
+                        #   block_tables[bid, pos//block_size]*block_size
+                        #   + pos % block_size
+                        # (identical addressing to the standalone _swa_write_kernel;
+                        # fuses it into this launch so decode drops a per-layer
+                        # kernel launch).
+                        blk = arith.divsi(pos_i32, _to_raw(swa_cache_size))
+                        bt_off = ArithValue(bid_safe) * ArithValue(
+                            swa_slot_stride
+                        ) + ArithValue(blk)
+                        bt_rsrc = _ptr_buffer_resource(state_slot_mapping)
+                        phys = buffer_ops.buffer_load(
+                            bt_rsrc, _to_raw(bt_off), vec_width=1, dtype=i32
+                        )
+                        in_blk = arith.remsi(pos_i32, _to_raw(swa_cache_size))
+                        row = ArithValue(phys) * ArithValue(
+                            swa_cache_size
+                        ) + ArithValue(in_blk)
+                        swa_off_elems = ArithValue(row) * ArithValue(swa_pos_stride)
+                    else:
+                        slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
+                        slot = buffer_ops.buffer_load(
+                            slot_rsrc, bid_safe, vec_width=1, dtype=i32
+                        )
+                        ring = arith.remsi(pos_i32, _to_raw(swa_cache_size))
+                        swa_off_elems = ArithValue(slot) * ArithValue(
+                            swa_slot_stride
+                        ) + ArithValue(ring) * ArithValue(swa_pos_stride)
                     swa_off_bytes = arith.index_cast(
                         T.index, _to_raw(swa_off_elems)
                     ) * arith.constant(2, type=T.index)
@@ -843,11 +872,12 @@ def compile_flydsl_qk_norm_rope_quant(
     scale_dtype: str,
     q_weighted: bool,
     kv_write: bool = False,
+    paged: bool = False,
 ):
     """Compile (and cache) the launcher for a given config.
 
     Cache key includes (H, D, RD, quant, group_size, scale_dtype, q_weighted,
-    kv_write). Returns the @flyc.jit launcher; call it directly if you've
+    kv_write, paged). Returns the @flyc.jit launcher; call it directly if you've
     already allocated outputs and want to avoid the per-call torch-side
     overhead in ``flydsl_qk_norm_rope_quant``.
     """
@@ -859,6 +889,7 @@ def compile_flydsl_qk_norm_rope_quant(
         group_size=group_size,
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
+        paged=paged,
         kv_write=kv_write,
     )
     launcher.compile_hints = dict(_DEFAULT_COMPILE_HINTS)
@@ -887,6 +918,8 @@ def flydsl_qk_norm_rope_quant(
     swa_kv: Optional[torch.Tensor] = None,
     state_slot_mapping: Optional[torch.Tensor] = None,
     batch_id_per_token: Optional[torch.Tensor] = None,
+    swa_block_tables: Optional[torch.Tensor] = None,
+    swa_block_size: Optional[int] = None,
     stream: Optional[torch.cuda.Stream] = None,
 ) -> Tuple[
     torch.Tensor,
@@ -1081,32 +1114,54 @@ def flydsl_qk_norm_rope_quant(
         kv_scale_arg = q.new_empty(1, dtype=scale_torch_dtype)
 
     # ---- Fused SWA cache-write (BF16 only) ----
-    # When swa_kv is provided, the KV row (post-norm/rope) is also scattered
-    # into swa_kv[slot, pos % cache_size, :] where
-    # slot = state_slot_mapping[batch_id_per_token[t]]. Avoids a separate
-    # swa_write launch + kv HBM round-trip. Requires bf16 output (quant off).
+    # Two modes (both write the post-norm/rope KV row in the same launch,
+    # avoiding a separate swa_write launch + kv HBM round-trip; bf16 only):
+    #   ring  (swa_kv 3-D):   swa_kv[slot, pos % cache_size, :],
+    #                         slot = state_slot_mapping[batch_id_per_token[t]]
+    #   paged (swa_block_tables given): content-addressed flat pool
+    #                         swa_kv[block_tables[bid, pos//bs]*bs + pos%bs, :]
+    #                         (DeepSeek-V4 #1417). Repurposes the ring scalars:
+    #                         ssm_arg=block_tables, swa_slot_stride=max_blocks,
+    #                         swa_cache_size=block_size, swa_pos_stride=D.
+    paged = swa_block_tables is not None
     kv_write = swa_kv is not None
+    if kv_write and quant:
+        raise ValueError("kv_write (swa_kv) is BF16 only; not supported with quant")
     if kv_write:
-        if quant:
-            raise ValueError("kv_write (swa_kv) is BF16 only; not supported with quant")
-        if state_slot_mapping is None or batch_id_per_token is None:
-            raise ValueError(
-                "kv_write requires state_slot_mapping and batch_id_per_token"
-            )
-        if swa_kv.dim() != 3 or swa_kv.shape[2] != D:
-            raise ValueError(f"swa_kv must be [S, C, D={D}], got {tuple(swa_kv.shape)}")
+        if batch_id_per_token is None:
+            raise ValueError("kv_write requires batch_id_per_token")
         if swa_kv.dtype != torch.bfloat16:
             raise TypeError(f"swa_kv must be bf16, got {swa_kv.dtype}")
         if not swa_kv.is_contiguous():
             raise ValueError("swa_kv must be contiguous")
-        if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
-            raise TypeError("state_slot_mapping must be 1-D int32")
         if batch_id_per_token.dim() != 1 or batch_id_per_token.dtype != torch.int32:
             raise TypeError("batch_id_per_token must be 1-D int32")
         if batch_id_per_token.shape[0] < T_tok:
             raise ValueError(
                 f"batch_id_per_token len {batch_id_per_token.shape[0]} < T={T_tok}"
             )
+    if kv_write and paged:
+        if swa_block_size is None:
+            raise ValueError("paged SWA write requires swa_block_size")
+        if swa_kv.dim() != 2 or swa_kv.shape[1] != D:
+            raise ValueError(
+                f"paged swa_kv must be flat [num_pages, D={D}], got {tuple(swa_kv.shape)}"
+            )
+        if swa_block_tables.dim() != 2 or swa_block_tables.dtype != torch.int32:
+            raise TypeError("swa_block_tables must be 2-D [bs, max_blocks] int32")
+        swa_slot_stride = swa_block_tables.stride(0)  # = max_blocks
+        swa_pos_stride = swa_kv.stride(0)  # = D (flat pool row stride)
+        swa_cache_size = swa_block_size
+        swa_kv_arg = swa_kv
+        ssm_arg = swa_block_tables
+        bid_arg = batch_id_per_token
+    elif kv_write:
+        if state_slot_mapping is None:
+            raise ValueError("ring kv_write requires state_slot_mapping")
+        if swa_kv.dim() != 3 or swa_kv.shape[2] != D:
+            raise ValueError(f"swa_kv must be [S, C, D={D}], got {tuple(swa_kv.shape)}")
+        if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
+            raise TypeError("state_slot_mapping must be 1-D int32")
         swa_slot_stride = swa_kv.stride(0)
         swa_pos_stride = swa_kv.stride(1)
         swa_cache_size = swa_kv.shape[1]
@@ -1131,6 +1186,7 @@ def flydsl_qk_norm_rope_quant(
         scale_dtype=scale_dtype,
         q_weighted=q_weighted,
         kv_write=kv_write,
+        paged=paged,
     )
 
     if stream is None:


### PR DESCRIPTION
Add a `paged` mode to the flydsl qk_norm_rope(_quant) kernel so DeepSeek-V4 paged-SWA can fuse its content-addressed SWA cache-write into the norm+rope launch (kvw_paged variant), matching the existing ring `kvw` fusion.

When `swa_block_tables` is provided (paged=True), the fused SWA scatter addresses the flat pool by
    swa_kv[block_tables[bid, pos // swa_block_size] * swa_block_size
           + pos % swa_block_size]
instead of the ring `swa_kv[slot, pos % cache_size]`, reusing the same 6 SWA scatter params + a `paged` const_expr. Kernel name gets a `paged` tag (qk_norm_rope_..._kvw_paged_flydsl). No behavior change when swa_block_tables is None (ring path unchanged). Consumed by ROCm/ATOM DeepSeek-V4 paged-SWA (fused decode SWA-write).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
