### PR TITLE
Fix gfx950 triton codegen crashes and numeric miscompiles on coming release

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/mla.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mla.py
@@ -218,7 +218,7 @@ def _mla_prefill_fwd_kernel(
     seq_offset = offs_t
 
     # iterate through tiles (now limited to the sliding window range)
-    for j in range(tile_start, tile_end):
+    for j in tl.range(tile_start, tile_end, num_stages=1):
         physical_block_idx = tl.load(block_tables_ptr_shifted + j).to(tl.int64)
 
         kv_offset = (
@@ -494,9 +494,10 @@ def _mla_decode_fwd_kernel(
     seq_offset = segm_idx * tiles_per_segment * TILE_SIZE + offs_t
 
     # iterate through tiles within current segment
-    for j in range(
+    for j in tl.range(
         segm_idx * tiles_per_segment,
         min((segm_idx + 1) * tiles_per_segment, num_tiles),
+        num_stages=1,
     ):
         physical_block_idx = tl.load(block_tables_ptr_shifted + j).to(tl.int64)
 

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -2894,7 +2894,7 @@ def _bwd_dkdv_inner(
     curr_philox_offset = batch_philox_offset
     RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
 
-    for blk_idx in range(num_steps):
+    for blk_idx in tl.range(num_steps, num_stages=1):
         if DEBUG_TRITON:
             print(f"iter {blk_idx}: curr_m = {curr_m}")  # noqa: E701
         offs_m = curr_m + tl.arange(0, BLOCK_M)
@@ -3099,7 +3099,7 @@ def _bwd_dq_inner(
     step_n = BLOCK_N2
     curr_philox_offset = batch_philox_offset
     RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
-    for blk_idx in range(num_steps):
+    for blk_idx in tl.range(num_steps, num_stages=1):
         if DEBUG_TRITON:
             print(f"iter {blk_idx}: curr_n = {curr_n}")  # noqa: E701
         offs_n = curr_n + tl.arange(0, BLOCK_N2)

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -329,7 +329,7 @@ def _attn_fwd_inner(
     seqlen_delta_qk = seqlen_k - seqlen_q
 
     # loop over k, v, and update accumulator
-    for start_n in range(block_min, block_max, BLOCK_N):
+    for start_n in tl.range(block_min, block_max, BLOCK_N, num_stages=1):
         # get ptrs
         k_ptrs = k_base_ptrs + start_n * stride_kn
         v_ptrs = v_base_ptrs + start_n * stride_vk

--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_gated.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16_gated.py
@@ -105,7 +105,7 @@ def _gemm_a16_w16_gated_kernel(
     acc0 = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N // 2), dtype=acc_dtype)
     acc1 = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N // 2), dtype=acc_dtype)
 
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=1):
         # Load the next block of A and B, generate a mask by checking the K dimension.
         # If it is out of bounds, set it to 0.
         if EVEN_K:

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-gated.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-gated.json
@@ -93,7 +93,7 @@
         "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 16,
         "num_warps": 8,
-        "num_stages": 2,
+        "num_stages": 1,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": null

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED.json
@@ -89,7 +89,7 @@
     "BLOCK_SIZE_K": 128,
     "GROUP_SIZE_M": 1,
     "num_warps": 8,
-    "num_stages": 2,
+    "num_stages": 3,
     "waves_per_eu": 4,
     "matrix_instr_nonkdim": 16,
     "cache_modifier": null,

--- a/aiter/ops/triton/configs/gfx950-MHA-DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950-MHA-DEFAULT.json
@@ -25,7 +25,7 @@
       "waves_per_eu": 2,
       "num_warps": 4,
       "num_ctas": 1,
-      "num_stages": 3
+      "num_stages": 1
     },
     "pe_dropout_or_fp32": {
       "BLOCK_M": 256,


### PR DESCRIPTION
## Motivation

The upcoming Triton release (`3.7.0+amd.rocm7.0.0.git89002410`, LLVM-based gfx950 backend) triggers two classes of gfx950 codegen bugs in AITER's Triton kernels:

1. **Compiler crash** — the software pipeliner emits machine IR that fails the verifier ("Bad machine code: Virtual register defs don't dominate all uses"), aborting compilation (SIGABRT) on several attention/GEMM kernels.
2. **Numeric miscompiles** — pipelined kernels produce wrong (deterministic) values on some config buckets.

This PR works around both so the gfx950 test suite passes on the coming release.

## Technical Details

Validated against the coming release wheels at `https://pypi.amd.com/triton/release/rocm-<ver>/simple/` (`triton==3.7.0+amd.rocm7.0.0.git89002410` + matching `triton-kernels`).

**Crash fix — force `num_stages=1` on the affected K-loops** so the buggy pipelined MIR is never generated (covers all shapes/layouts, unlike a per-bucket config tweak):
- `_triton_kernels/attention/mla.py` — prefill + decode tile loops
- `_triton_kernels/flash_attn_triton_amd/fwd_prefill.py` — attention fwd inner loop
- `_triton_kernels/flash_attn_triton_amd/bwd.py` — `_bwd_dkdv_inner` / `_bwd_dq_inner`
- `_triton_kernels/gemm/basic/gemm_a16w16_gated.py` — gated matmul K-loop

**Numeric-miscompile fix — lower `num_stages` on affected gfx950 config buckets:**
- `configs/gemm/gfx950-GEMM-A16W16-gated.json` — `any` bucket `num_stages` 2 → 1
- `configs/gemm/gfx950-GEMM-A8W8_BLOCKSCALE_PRESHUFFLED.json` — `num_stages` 2 → 3
- `configs/gfx950-MHA-DEFAULT.json` — `num_stages` 3 → 1

Note: the `num_stages=1` loop changes are not arch-gated — they apply on all arches. This is functionally correct everywhere (it only disables software pipelining on those loops); the gfx950 config changes are gfx950-only by file.

## Test Plan

- Run the AITER Triton test suite on gfx950 with the coming Triton release build.
- Confirm previously-crashing kernels compile (no SIGABRT / machine-verifier error) and produce correct results.

## Test Result

<!-- Fill in with the gfx950 CI run results. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
