### PR TITLE
CI: run SGLang DSV4Pro FP8 1P1D nightly

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,7 @@ self-hosted-runner:
   labels:
     - aiter-1gpu-runner
     - aiter-8gpu-runner
+    - aiter-di-ci-spur-login
     - aiter-gfx1100
     - build-only-aiter
     - linux-aiter-do-mi350x-1

--- a/.github/scripts/sglang_mi355x_disagg.py
+++ b/.github/scripts/sglang_mi355x_disagg.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-
 RECIPE_PATH = Path("scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d.yaml")
 LAUNCHER_PATH = Path("scripts/ci/slurm/launch_mi355x.sh")
 

--- a/.github/scripts/sglang_mi355x_disagg.py
+++ b/.github/scripts/sglang_mi355x_disagg.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Helpers for the SGLang MI355X disaggregation workflow.
+
+The workflow intentionally reuses SGLang's launcher from the upstream PR and
+keeps the aiter-side delta small. This helper patches the launcher for aiter's
+Spur/Slurm environment and narrows the recipe to the requested smoke surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+RECIPE_PATH = Path("scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d.yaml")
+LAUNCHER_PATH = Path("scripts/ci/slurm/launch_mi355x.sh")
+
+
+def replace_once(text: str, old: str, new: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"expected exactly one launcher match, got {count}: {old!r}")
+    return text.replace(old, new, 1)
+
+
+def patch_launcher(args: argparse.Namespace) -> None:
+    root = Path(args.sglang_workspace)
+    launcher = root / LAUNCHER_PATH
+    text = launcher.read_text(encoding="utf-8")
+
+    text = replace_once(
+        text,
+        'SLURM_PARTITION="${SLURM_PARTITION:-amd-sglang}"',
+        'SLURM_PARTITION="${SLURM_PARTITION-}"',
+    )
+    text = replace_once(
+        text,
+        'WORKDIR="$HOME/.mi355x_ci/${MATRIX_CONFIG_NAME}"',
+        'WORKDIR="${SHARED_WORKDIR_ROOT:-$HOME/.mi355x_ci}/${MATRIX_CONFIG_NAME}"',
+    )
+    text = replace_once(
+        text,
+        """DOCKER_COMMON="--rm --network host --ipc host --shm-size 32g --privileged \\
+--security-opt seccomp=unconfined \\
+--device /dev/kfd --device /dev/dri --device /dev/infiniband \\
+-v /it-share:/it-share:ro -v $HOME:/host_home"
+""",
+        """MODEL_MOUNT_ARGS=""
+for mount_root in ${MODEL_MOUNT_ROOTS:-/it-share /data /models}; do
+    if [[ -d "$mount_root" ]]; then
+        MODEL_MOUNT_ARGS+=" -v $mount_root:$mount_root:ro"
+    fi
+done
+
+AITER_MOUNT_ARGS=""
+if [[ -n "${AITER_SOURCE_DIR:-}" ]]; then
+    AITER_MOUNT_ARGS=" -v $AITER_SOURCE_DIR:/aiter-under-test:ro"
+fi
+
+DOCKER_COMMON="--rm --network host --ipc host --shm-size 32g --privileged \\
+--security-opt seccomp=unconfined \\
+--device /dev/kfd --device /dev/dri --device /dev/infiniband \\
+-v $WORKDIR:/ci_workdir $MODEL_MOUNT_ARGS $AITER_MOUNT_ARGS"
+""",
+    )
+    text = replace_once(
+        text,
+        "# ---------------------------------------------------------------------------\n"
+        "# Write per-role scripts that srun dispatches to each compute node.\n"
+        "# ---------------------------------------------------------------------------\n",
+        """# Install the aiter checkout under test inside each serving container. The
+# checkout is mounted read-only from shared storage; copy it to /tmp because
+# editable installs write metadata into the source tree.
+AITER_INSTALL_SNIPPET='
+if [ -d /aiter-under-test ]; then
+  rm -rf /tmp/aiter-under-test
+  cp -a /aiter-under-test /tmp/aiter-under-test
+  cd /tmp/aiter-under-test
+  python3 -m pip uninstall -y amd-aiter aiter || true
+  MAX_JOBS="${AITER_MAX_JOBS:-64}" PREBUILD_KERNELS="${AITER_PREBUILD_KERNELS:-0}" GPU_ARCHS="${GPU_ARCHS:-gfx950}" python3 -m pip install --no-build-isolation -e .
+  python3 -m pip show amd-aiter || python3 -m pip show aiter || true
+  cd - >/dev/null
+fi
+'
+
+# ---------------------------------------------------------------------------
+# Write per-role scripts that srun dispatches to each compute node.
+# ---------------------------------------------------------------------------
+""",
+    )
+    text = replace_once(
+        text,
+        """  $IMAGE python3 -m sglang.launch_server \\
+  --model-path $MODEL_PATH --host 0.0.0.0 --port $PPORT \\
+  $COMMON_FLAGS --disaggregation-mode prefill --disaggregation-bootstrap-port $PBOOT
+""",
+        """  $IMAGE bash -lc '
+    set -ex
+    $AITER_INSTALL_SNIPPET
+    exec python3 -m sglang.launch_server \\
+      --model-path $MODEL_PATH --host 0.0.0.0 --port $PPORT \\
+      $COMMON_FLAGS --disaggregation-mode prefill --disaggregation-bootstrap-port $PBOOT
+  '
+""",
+    )
+    text = replace_once(
+        text,
+        """  $IMAGE python3 -m sglang.launch_server \\
+  --model-path $MODEL_PATH --host 0.0.0.0 --port $DPORT \\
+  $COMMON_FLAGS --disaggregation-mode decode --disaggregation-bootstrap-port $DBOOT
+""",
+        """  $IMAGE bash -lc '
+    set -ex
+    $AITER_INSTALL_SNIPPET
+    exec python3 -m sglang.launch_server \\
+      --model-path $MODEL_PATH --host 0.0.0.0 --port $DPORT \\
+      $COMMON_FLAGS --disaggregation-mode decode --disaggregation-bootstrap-port $DBOOT
+  '
+""",
+    )
+    text = replace_once(
+        text,
+        "CIDIR=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}",
+        "CIDIR=/ci_workdir",
+    )
+    text = replace_once(
+        text,
+        "OUT=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}/raw_conc\\${C}.json",
+        "OUT=/ci_workdir/raw_conc\\${C}.json",
+    )
+    text = replace_once(
+        text,
+        """NODELIST_ARG=()
+[[ -n "${SLURM_NODELIST:-}" ]] && NODELIST_ARG=(--nodelist="$SLURM_NODELIST")
+""",
+        """NODELIST_ARG=()
+[[ -n "${SLURM_NODELIST:-}" ]] && NODELIST_ARG=(--nodelist="$SLURM_NODELIST")
+
+PARTITION_ARG=()
+[[ -n "${SLURM_PARTITION:-}" ]] && PARTITION_ARG=(-p "$SLURM_PARTITION")
+""",
+    )
+    text = replace_once(
+        text,
+        """salloc -p "$SLURM_PARTITION" -N"$TOTAL_NODES" "${NODELIST_ARG[@]}" "${EXCLUSIVE_ARG[@]}" \\
+    --job-name "$JOB_NAME" -t "$TIME_LIMIT" \\
+""",
+        """salloc "${PARTITION_ARG[@]}" -N"$TOTAL_NODES" "${NODELIST_ARG[@]}" "${EXCLUSIVE_ARG[@]}" \\
+    --job-name "$JOB_NAME" -t "$TIME_LIMIT" \\
+""",
+    )
+
+    launcher.write_text(text, encoding="utf-8")
+    print(f"patched {launcher}")
+
+
+def parse_concurrency_list(raw: str) -> list[int]:
+    values = [item for item in raw.replace(",", " ").split() if item]
+    if not values:
+        raise SystemExit("concurrency list cannot be empty")
+    try:
+        parsed = [int(item) for item in values]
+    except ValueError as exc:
+        raise SystemExit(f"invalid concurrency list {raw!r}: {exc}") from exc
+    if any(value <= 0 for value in parsed):
+        raise SystemExit(f"concurrency values must be positive: {parsed}")
+    return parsed
+
+
+def parse_bool(raw: str) -> bool:
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"invalid boolean value: {raw!r}")
+
+
+def configure_recipe(args: argparse.Namespace) -> None:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise SystemExit("PyYAML is required: python3 -m pip install pyyaml") from exc
+
+    root = Path(args.sglang_workspace)
+    recipe = root / RECIPE_PATH
+    payload = yaml.safe_load(recipe.read_text(encoding="utf-8"))
+
+    payload["bench"]["concurrencies"] = parse_concurrency_list(args.concurrency_list)
+    payload["bench"].setdefault("accuracy", {})["enabled"] = parse_bool(
+        args.accuracy_enabled
+    )
+
+    recipe.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    print(f"configured {recipe}")
+    print(f"concurrencies={payload['bench']['concurrencies']}")
+    print(f"accuracy_enabled={payload['bench']['accuracy']['enabled']}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    patch = subparsers.add_parser("patch-launcher")
+    patch.add_argument("sglang_workspace")
+    patch.set_defaults(func=patch_launcher)
+
+    recipe = subparsers.add_parser("configure-recipe")
+    recipe.add_argument("sglang_workspace")
+    recipe.add_argument("--concurrency-list", required=True)
+    recipe.add_argument("--accuracy-enabled", required=True)
+    recipe.set_defaults(func=configure_recipe)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/sglang_mi355x_disagg.py
+++ b/.github/scripts/sglang_mi355x_disagg.py
@@ -22,6 +22,15 @@ def replace_once(text: str, old: str, new: str) -> str:
     return text.replace(old, new, 1)
 
 
+def replace_all(text: str, old: str, new: str, min_count: int = 1) -> str:
+    count = text.count(old)
+    if count < min_count:
+        raise SystemExit(
+            f"expected at least {min_count} launcher match(es), got {count}: {old!r}"
+        )
+    return text.replace(old, new)
+
+
 def patch_launcher(args: argparse.Namespace) -> None:
     root = Path(args.sglang_workspace)
     launcher = root / LAUNCHER_PATH
@@ -42,7 +51,7 @@ def patch_launcher(args: argparse.Namespace) -> None:
         """DOCKER_COMMON="--rm --network host --ipc host --shm-size 32g --privileged \\
 --security-opt seccomp=unconfined \\
 --device /dev/kfd --device /dev/dri --device /dev/infiniband \\
--v /it-share:/it-share:ro -v $HOME:/host_home"
+-v /it-share:/it-share:ro -v $HOME:/host_home $CHECKOUT_DOCKER_ARGS"
 """,
         """MODEL_MOUNT_ARGS=""
 for mount_root in ${MODEL_MOUNT_ROOTS:-/it-share /data /models}; do
@@ -59,73 +68,70 @@ fi
 DOCKER_COMMON="--rm --network host --ipc host --shm-size 32g --privileged \\
 --security-opt seccomp=unconfined \\
 --device /dev/kfd --device /dev/dri --device /dev/infiniband \\
--v $WORKDIR:/ci_workdir $MODEL_MOUNT_ARGS $AITER_MOUNT_ARGS"
+-v $WORKDIR:/ci_workdir -v $HOME:/host_home $MODEL_MOUNT_ARGS $AITER_MOUNT_ARGS $CHECKOUT_DOCKER_ARGS"
 """,
     )
     text = replace_once(
         text,
-        "# ---------------------------------------------------------------------------\n"
-        "# Write per-role scripts that srun dispatches to each compute node.\n"
-        "# ---------------------------------------------------------------------------\n",
-        """# Install the aiter checkout under test inside each serving container. The
-# checkout is mounted read-only from shared storage; copy it to /tmp because
-# editable installs write metadata into the source tree.
-AITER_INSTALL_SNIPPET='
-if [ -d /aiter-under-test ]; then
-  rm -rf /tmp/aiter-under-test
-  cp -a /aiter-under-test /tmp/aiter-under-test
-  cd /tmp/aiter-under-test
-  python3 -m pip uninstall -y amd-aiter aiter || true
-  MAX_JOBS="${AITER_MAX_JOBS:-64}" PREBUILD_KERNELS="${AITER_PREBUILD_KERNELS:-0}" GPU_ARCHS="${GPU_ARCHS:-gfx950}" python3 -m pip install --no-build-isolation -e .
-  python3 -m pip show amd-aiter || python3 -m pip show aiter || true
-  cd - >/dev/null
-fi
-'
+        'CHECKOUT_DOCKER_ARGS="-e SGLANG_USE_CHECKOUT_RUNTIME=$SGLANG_USE_CHECKOUT_RUNTIME"',
+        'SGLANG_RUNTIME_WORKSPACE="${SGLANG_RUNTIME_WORKSPACE:-$GITHUB_WORKSPACE}"\n'
+        'CHECKOUT_DOCKER_ARGS="-e SGLANG_USE_CHECKOUT_RUNTIME=$SGLANG_USE_CHECKOUT_RUNTIME"',
+    )
+    text = replace_once(
+        text,
+        'CHECKOUT_SHA="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"',
+        'CHECKOUT_SHA="$(git -C "$SGLANG_RUNTIME_WORKSPACE" rev-parse HEAD)"',
+    )
+    text = replace_once(
+        text,
+        '-C "$GITHUB_WORKSPACE" -cf - . | tar -C "$CHECKOUT_STAGE" -xf -',
+        '-C "$SGLANG_RUNTIME_WORKSPACE" -cf - . | tar -C "$CHECKOUT_STAGE" -xf -',
+    )
+    text = replace_once(
+        text,
+        'cat > "$WORKDIR/prefill_entry.sh" <<EOF',
+        """cat > "$WORKDIR/install_checkout_aiter.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# Write per-role scripts that srun dispatches to each compute node.
-# ---------------------------------------------------------------------------
+if [[ ! -d /aiter-under-test ]]; then
+  echo "[checkout-aiter] /aiter-under-test not mounted; using image-baked aiter"
+  exit 0
+fi
+
+RUNTIME_AITER="${RUNTIME_AITER:-/tmp/aiter-under-test-runtime}"
+echo "[checkout-aiter] reinstalling aiter from /aiter-under-test"
+rm -rf "$RUNTIME_AITER"
+mkdir -p "$RUNTIME_AITER"
+tar --exclude='__pycache__' --exclude='*.pyc' \
+  -C /aiter-under-test -cf - . | tar -C "$RUNTIME_AITER" -xf -
+
+python3 -m pip uninstall -y amd-aiter aiter || true
+MAX_JOBS="${AITER_MAX_JOBS:-64}" PREBUILD_KERNELS="${AITER_PREBUILD_KERNELS:-0}" GPU_ARCHS="${GPU_ARCHS:-gfx950}" \
+  python3 -m pip install --no-build-isolation -e "$RUNTIME_AITER"
+python3 -m pip show amd-aiter || python3 -m pip show aiter || true
+EOF
+
+cat > "$WORKDIR/prefill_entry.sh" <<EOF
 """,
+    )
+    text = replace_all(
+        text,
+        'bash "\\$CIDIR/install_checkout_sglang.sh"\n',
+        'bash "\\$CIDIR/install_checkout_sglang.sh"\n'
+        'bash "\\$CIDIR/install_checkout_aiter.sh"\n',
+        min_count=2,
     )
     text = replace_once(
         text,
-        """  $IMAGE python3 -m sglang.launch_server \\
-  --model-path $MODEL_PATH --host 0.0.0.0 --port $PPORT \\
-  $COMMON_FLAGS --disaggregation-mode prefill --disaggregation-bootstrap-port $PBOOT
-""",
-        """  $IMAGE bash -lc '
-    set -ex
-    $AITER_INSTALL_SNIPPET
-    exec python3 -m sglang.launch_server \\
-      --model-path $MODEL_PATH --host 0.0.0.0 --port $PPORT \\
-      $COMMON_FLAGS --disaggregation-mode prefill --disaggregation-bootstrap-port $PBOOT
-  '
-""",
+        "    bash \\$CIDIR/install_checkout_sglang.sh\n",
+        "    bash \\$CIDIR/install_checkout_sglang.sh\n"
+        "    bash \\$CIDIR/install_checkout_aiter.sh\n",
     )
-    text = replace_once(
+    text = replace_all(
         text,
-        """  $IMAGE python3 -m sglang.launch_server \\
-  --model-path $MODEL_PATH --host 0.0.0.0 --port $DPORT \\
-  $COMMON_FLAGS --disaggregation-mode decode --disaggregation-bootstrap-port $DBOOT
-""",
-        """  $IMAGE bash -lc '
-    set -ex
-    $AITER_INSTALL_SNIPPET
-    exec python3 -m sglang.launch_server \\
-      --model-path $MODEL_PATH --host 0.0.0.0 --port $DPORT \\
-      $COMMON_FLAGS --disaggregation-mode decode --disaggregation-bootstrap-port $DBOOT
-  '
-""",
-    )
-    text = replace_once(
-        text,
-        "CIDIR=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}",
-        "CIDIR=/ci_workdir",
-    )
-    text = replace_once(
-        text,
-        "OUT=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}/raw_conc\\${C}.json",
-        "OUT=/ci_workdir/raw_conc\\${C}.json",
+        "/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}",
+        "/ci_workdir",
     )
     text = replace_once(
         text,
@@ -141,10 +147,10 @@ PARTITION_ARG=()
     )
     text = replace_once(
         text,
-        """salloc -p "$SLURM_PARTITION" -N"$TOTAL_NODES" "${NODELIST_ARG[@]}" "${EXCLUSIVE_ARG[@]}" \\
+        """salloc -p "$SLURM_PARTITION" -N"$TOTAL_NODES" "${NODELIST_ARG[@]}" "${EXCLUDE_ARG[@]}" "${EXCLUSIVE_ARG[@]}" \\
     --job-name "$JOB_NAME" -t "$TIME_LIMIT" \\
 """,
-        """salloc "${PARTITION_ARG[@]}" -N"$TOTAL_NODES" "${NODELIST_ARG[@]}" "${EXCLUSIVE_ARG[@]}" \\
+        """salloc "${PARTITION_ARG[@]}" -N"$TOTAL_NODES" "${NODELIST_ARG[@]}" "${EXCLUDE_ARG[@]}" "${EXCLUSIVE_ARG[@]}" \\
     --job-name "$JOB_NAME" -t "$TIME_LIMIT" \\
 """,
     )

--- a/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
+++ b/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
@@ -1,0 +1,345 @@
+name: SGLang MI355X DSV4Pro FP8 1P1D
+
+on:
+  schedule:
+    - cron: "43 18 * * *"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+    paths:
+      - ".github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml"
+      - ".github/scripts/sglang_mi355x_disagg.py"
+  workflow_dispatch:
+    inputs:
+      sglang_repository:
+        description: "SGLang repository containing the MI355X disagg launcher"
+        required: false
+        type: string
+        default: "Lzy17/sglang"
+      sglang_ref:
+        description: "SGLang ref to test; default tracks sgl-project/sglang#29084"
+        required: false
+        type: string
+        default: "amd-mi355x-disagg-nightly"
+      image:
+        description: "Optional SGLang ROCm image override. Empty uses the recipe default."
+        required: false
+        type: string
+        default: ""
+      model_path:
+        description: "DeepSeek-V4-Pro-FP8 path visible on the Spur compute nodes"
+        required: false
+        type: string
+        default: "/data/models2/DeepSeek-V4-Pro-FP8"
+      model_mount_roots:
+        description: "Space-separated host roots to mount read-only into SGLang containers"
+        required: false
+        type: string
+        default: "/it-share /data /models"
+      shared_workspace_root:
+        description: "Shared workspace root visible from the Spur submit and compute nodes"
+        required: false
+        type: string
+        default: "/data/xinhuang/sglang-aiter-ci"
+      slurm_nodelist:
+        description: "Comma-separated two-node override. Set to auto to let Slurm allocate."
+        required: false
+        type: string
+        default: "ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14"
+      slurm_partition:
+        description: "Optional Slurm partition. Empty omits -p."
+        required: false
+        type: string
+        default: ""
+      slurm_exclusive:
+        description: "Set to 1 to request exclusive nodes, 0 to disable."
+        required: false
+        type: choice
+        options: ["1", "0"]
+        default: "1"
+      conc_list:
+        description: "bench_serving max-concurrency sweep"
+        required: false
+        type: string
+        default: "1,8,16,32,64,128,256"
+      run_accuracy:
+        description: "Run the GSM8K correctness gate before the perf sweep"
+        required: false
+        type: choice
+        options: ["true", "false"]
+        default: "true"
+      time_limit:
+        description: "Slurm allocation time limit"
+        required: false
+        type: string
+        default: "02:30:00"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+env:
+  SGLANG_REPOSITORY_DEFAULT: Lzy17/sglang
+  SGLANG_REF_DEFAULT: amd-mi355x-disagg-nightly
+  IMAGE_OVERRIDE_DEFAULT: ""
+  MODEL_PATH_DEFAULT: /data/models2/DeepSeek-V4-Pro-FP8
+  MODEL_MOUNT_ROOTS_DEFAULT: /it-share /data /models
+  SHARED_WORKSPACE_ROOT_DEFAULT: /data/xinhuang/sglang-aiter-ci
+  SLURM_NODELIST_DEFAULT: ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14
+  SLURM_PARTITION_DEFAULT: ""
+  SLURM_EXCLUSIVE_DEFAULT: "1"
+  CONC_LIST_DEFAULT: "1,8,16,32,64,128,256"
+  RUN_ACCURACY_DEFAULT: "true"
+  TIME_LIMIT_DEFAULT: "02:30:00"
+
+jobs:
+  sglang-dsv4pro-fp8-1p1d:
+    runs-on: [self-hosted, aiter-di-ci-spur-login]
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout aiter under test
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Apply workflow inputs
+        run: |
+          set -euo pipefail
+          python3 - "$GITHUB_EVENT_PATH" <<'PY' >> "$GITHUB_ENV"
+          import json
+          import os
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as f:
+              event = json.load(f)
+
+          inputs = event.get("inputs") or {}
+
+          def value(name: str, default_env: str) -> str:
+              raw = inputs.get(name, "")
+              default = os.environ[default_env]
+              return raw if raw not in ("", None) else default
+
+          pairs = {
+              "SGLANG_REPOSITORY": value("sglang_repository", "SGLANG_REPOSITORY_DEFAULT"),
+              "SGLANG_REF": value("sglang_ref", "SGLANG_REF_DEFAULT"),
+              "IMAGE_OVERRIDE": value("image", "IMAGE_OVERRIDE_DEFAULT"),
+              "MODEL_PATH_OVERRIDE": value("model_path", "MODEL_PATH_DEFAULT"),
+              "MODEL_MOUNT_ROOTS": value("model_mount_roots", "MODEL_MOUNT_ROOTS_DEFAULT"),
+              "SHARED_WORKSPACE_ROOT": value(
+                  "shared_workspace_root", "SHARED_WORKSPACE_ROOT_DEFAULT"
+              ),
+              "SLURM_NODELIST_OVERRIDE": value("slurm_nodelist", "SLURM_NODELIST_DEFAULT"),
+              "SLURM_PARTITION_OVERRIDE": value("slurm_partition", "SLURM_PARTITION_DEFAULT"),
+              "SLURM_EXCLUSIVE_OVERRIDE": value("slurm_exclusive", "SLURM_EXCLUSIVE_DEFAULT"),
+              "CONC_LIST": value("conc_list", "CONC_LIST_DEFAULT"),
+              "RUN_ACCURACY": value("run_accuracy", "RUN_ACCURACY_DEFAULT"),
+              "TIME_LIMIT_OVERRIDE": value("time_limit", "TIME_LIMIT_DEFAULT"),
+          }
+          if pairs["SLURM_NODELIST_OVERRIDE"].strip().lower() == "auto":
+              pairs["SLURM_NODELIST_OVERRIDE"] = ""
+          for key, val in pairs.items():
+              print(f"{key}={val}")
+          PY
+
+      - name: Show runner and Slurm state
+        run: |
+          set -euo pipefail
+          hostname
+          whoami
+          pwd
+          command -v salloc
+          salloc --help | head -80 || true
+          command -v squeue
+          squeue --help | head -80 || true
+          command -v scancel
+          command -v spur && spur --help | head -120 || true
+
+      - name: Docker login
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DOCKER_PASSWORD:-}" ]; then
+            echo "DOCKER_PASSWORD is empty; skipping docker login"
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+              echo "Docker login succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Docker login attempt ${attempt} failed"
+            if [ "${attempt}" != 3 ]; then
+              sleep 10
+            fi
+          done
+          echo "Docker login failed after 3 attempts, continuing anyway"
+
+      - name: Prepare SGLang and shared aiter source
+        run: |
+          set -euo pipefail
+          python3 -m pip install pyyaml -q
+
+          SGLANG_WORKSPACE="${RUNNER_TEMP}/sglang-mi355x-disagg"
+          rm -rf "${SGLANG_WORKSPACE}"
+          git clone --depth 1 --branch "${SGLANG_REF}" \
+            "https://github.com/${SGLANG_REPOSITORY}.git" "${SGLANG_WORKSPACE}"
+          test -f "${SGLANG_WORKSPACE}/scripts/ci/slurm/launch_mi355x.sh"
+          test -f "${SGLANG_WORKSPACE}/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d.yaml"
+
+          python3 .github/scripts/sglang_mi355x_disagg.py patch-launcher "${SGLANG_WORKSPACE}"
+          python3 .github/scripts/sglang_mi355x_disagg.py configure-recipe \
+            "${SGLANG_WORKSPACE}" \
+            --concurrency-list "${CONC_LIST}" \
+            --accuracy-enabled "${RUN_ACCURACY}"
+
+          SHARED_ROOT="${SHARED_WORKSPACE_ROOT%/}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
+          AITER_SOURCE_DIR="${SHARED_ROOT}/aiter-source"
+          SHARED_WORKDIR_ROOT="${SHARED_ROOT}/mi355x-ci"
+          rm -rf "${SHARED_ROOT}"
+          mkdir -p "${AITER_SOURCE_DIR}" "${SHARED_WORKDIR_ROOT}"
+          tar --exclude=.git -C "${GITHUB_WORKSPACE}" -cf - . | tar -C "${AITER_SOURCE_DIR}" -xf -
+
+          {
+            echo "SGLANG_WORKSPACE=${SGLANG_WORKSPACE}"
+            echo "AITER_SOURCE_DIR=${AITER_SOURCE_DIR}"
+            echo "SHARED_WORKDIR_ROOT=${SHARED_WORKDIR_ROOT}"
+          } >> "${GITHUB_ENV}"
+
+          {
+            echo "### SGLang MI355X DSV4Pro FP8 1P1D setup"
+            echo "- SGLang: \`${SGLANG_REPOSITORY}@${SGLANG_REF}\`"
+            echo "- Model path: \`${MODEL_PATH_OVERRIDE}\`"
+            echo "- Slurm nodes: \`${SLURM_NODELIST_OVERRIDE:-scheduler allocated}\`"
+            echo "- Shared workspace: \`${SHARED_ROOT}\`"
+            echo "- Concurrency list: \`${CONC_LIST}\`"
+            echo "- GSM8K gate: \`${RUN_ACCURACY}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Clean up prior Slurm jobs from this runner
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if [ -z "${RUNNER_NAME:-}" ]; then
+            echo "RUNNER_NAME unset; skipping stale cleanup"
+            exit 0
+          fi
+          STALE_JOBS="$(
+            squeue --me --noheader --format="%i %200j" \
+              | grep -F "mi355x-ci-${RUNNER_NAME}-" \
+              | awk '{print $1}' || true
+          )"
+          if [ -n "${STALE_JOBS}" ]; then
+            echo "Cancelling stale jobs for ${RUNNER_NAME}: ${STALE_JOBS}"
+            scancel ${STALE_JOBS}
+          fi
+
+      - name: Launch SGLang DSV4Pro FP8 1P1D benchmark
+        id: benchmark
+        continue-on-error: true
+        timeout-minutes: 200
+        run: |
+          set -euo pipefail
+          cd "${SGLANG_WORKSPACE}"
+          export FRAMEWORK=sglang
+          export HW=mi355x
+          export MODEL=sgl-project/DeepSeek-V4-Pro-FP8
+          export MODEL_PREFIX=dsv4pro
+          export PRECISION=fp8
+          export ISL=1024
+          export OSL=1024
+          export CONFIG_FILE=scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d.yaml
+          export RESULT_FILENAME=mi355x-dsv4pro-fp8-1p1d
+          export MATRIX_CONFIG_NAME=dsv4pro-fp8-mi355x-sglang
+          export MODEL_PATH="${MODEL_PATH_OVERRIDE}"
+          export MODEL_MOUNT_ROOTS="${MODEL_MOUNT_ROOTS}"
+          export IMAGE_OVERRIDE="${IMAGE_OVERRIDE}"
+          export SLURM_NODELIST="${SLURM_NODELIST_OVERRIDE}"
+          export SLURM_PARTITION="${SLURM_PARTITION_OVERRIDE}"
+          export SLURM_EXCLUSIVE="${SLURM_EXCLUSIVE_OVERRIDE}"
+          export TIME_LIMIT="${TIME_LIMIT_OVERRIDE}"
+          export SHARED_WORKDIR_ROOT="${SHARED_WORKDIR_ROOT}"
+          export AITER_SOURCE_DIR="${AITER_SOURCE_DIR}"
+          bash scripts/ci/slurm/launch_mi355x.sh
+
+      - name: Process SGLang benchmark results
+        if: always()
+        run: |
+          set -euo pipefail
+          cd "${SGLANG_WORKSPACE}"
+          python3 -m pip install pyyaml tabulate -q
+          shopt -s nullglob
+          processed=0
+          for result_file in "${GITHUB_WORKSPACE}"/mi355x-dsv4pro-fp8-1p1d_*.json; do
+            basename_file="$(basename "${result_file}")"
+            ctx="$(echo "${basename_file}" | sed -n 's/.*_ctx_\([0-9]*\)_gen.*/\1/p')"
+            gen="$(echo "${basename_file}" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')"
+            [ -n "${ctx}" ] && [ -n "${gen}" ] || continue
+            RESULT_FILENAME="${result_file%.json}" \
+              PREFILL_GPUS="${ctx}" \
+              DECODE_GPUS="${gen}" \
+              RECIPE_FILE="${SGLANG_WORKSPACE}/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d.yaml" \
+              FRAMEWORK=sglang \
+              HW=mi355x \
+              MODEL_PREFIX=dsv4pro \
+              PRECISION=fp8 \
+              ISL=1024 \
+              OSL=1024 \
+              python3 scripts/ci/slurm/process_result.py
+            processed=$((processed + 1))
+          done
+          if [ "${processed}" -eq 0 ]; then
+            echo "No result files were produced."
+            exit 1
+          fi
+          python3 scripts/ci/slurm/summarize.py "${GITHUB_WORKSPACE}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Stage artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE}/sglang-mi355x-artifacts"
+          mkdir -p "${GITHUB_WORKSPACE}/sglang-mi355x-artifacts"
+          cp -a "${GITHUB_WORKSPACE}"/*.json "${GITHUB_WORKSPACE}/sglang-mi355x-artifacts/" 2>/dev/null || true
+          if [ -n "${SHARED_WORKDIR_ROOT:-}" ] && [ -d "${SHARED_WORKDIR_ROOT}" ]; then
+            cp -a "${SHARED_WORKDIR_ROOT}" "${GITHUB_WORKSPACE}/sglang-mi355x-artifacts/shared-workdir"
+          fi
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sglang-mi355x-dsv4pro-fp8-1p1d-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: sglang-mi355x-artifacts/
+
+      - name: Clean up Slurm jobs on failure or cancel
+        if: failure() || cancelled() || steps.benchmark.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if [ -z "${RUNNER_NAME:-}" ]; then
+            echo "RUNNER_NAME unset; skipping Slurm cleanup"
+            exit 0
+          fi
+          JOB_TAG="mi355x-ci-${RUNNER_NAME}-${GITHUB_RUN_ID}-dsv4pro-fp8-mi355x-sglang"
+          ACTIVE_JOBS="$(
+            squeue --me --noheader --format="%i %200j" \
+              | grep -F "${JOB_TAG}" \
+              | awk '{print $1}' || true
+          )"
+          if [ -n "${ACTIVE_JOBS}" ]; then
+            echo "Cancelling jobs for ${JOB_TAG}: ${ACTIVE_JOBS}"
+            scancel ${ACTIVE_JOBS}
+          fi
+
+      - name: Fail if benchmark failed
+        if: steps.benchmark.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
+++ b/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
@@ -1,14 +1,8 @@
-name: SGLang MI355X DSV4Pro FP8 1P1D
+name: Nightly SGLang MI355X DSV4Pro FP8 1P1D
 
 on:
   schedule:
     - cron: "43 18 * * *"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
-    paths:
-      - ".github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml"
-      - ".github/scripts/sglang_mi355x_disagg.py"
   workflow_dispatch:
     inputs:
       sglang_ref:
@@ -66,7 +60,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
+++ b/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
@@ -11,11 +11,6 @@ on:
       - ".github/scripts/sglang_mi355x_disagg.py"
   workflow_dispatch:
     inputs:
-      sglang_repository:
-        description: "SGLang repository containing the MI355X disagg launcher"
-        required: false
-        type: string
-        default: "Lzy17/sglang"
       sglang_ref:
         description: "SGLang ref to test; default tracks sgl-project/sglang#29084"
         required: false
@@ -31,11 +26,6 @@ on:
         required: false
         type: string
         default: "/data/models2/DeepSeek-V4-Pro-FP8"
-      model_mount_roots:
-        description: "Space-separated host roots to mount read-only into SGLang containers"
-        required: false
-        type: string
-        default: "/it-share /data /models"
       shared_workspace_root:
         description: "Shared workspace root visible from the Spur submit and compute nodes"
         required: false
@@ -82,11 +72,11 @@ permissions:
   contents: read
 
 env:
-  SGLANG_REPOSITORY_DEFAULT: Lzy17/sglang
+  SGLANG_REPOSITORY: Lzy17/sglang
   SGLANG_REF_DEFAULT: amd-mi355x-disagg-nightly
   IMAGE_OVERRIDE_DEFAULT: ""
   MODEL_PATH_DEFAULT: /data/models2/DeepSeek-V4-Pro-FP8
-  MODEL_MOUNT_ROOTS_DEFAULT: /it-share /data /models
+  MODEL_MOUNT_ROOTS: /it-share /data /models
   SHARED_WORKSPACE_ROOT_DEFAULT: /data/xinhuang/sglang-aiter-ci
   SLURM_NODELIST_DEFAULT: ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14
   SLURM_PARTITION_DEFAULT: ""
@@ -125,11 +115,9 @@ jobs:
               return raw if raw not in ("", None) else default
 
           pairs = {
-              "SGLANG_REPOSITORY": value("sglang_repository", "SGLANG_REPOSITORY_DEFAULT"),
               "SGLANG_REF": value("sglang_ref", "SGLANG_REF_DEFAULT"),
               "IMAGE_OVERRIDE": value("image", "IMAGE_OVERRIDE_DEFAULT"),
               "MODEL_PATH_OVERRIDE": value("model_path", "MODEL_PATH_DEFAULT"),
-              "MODEL_MOUNT_ROOTS": value("model_mount_roots", "MODEL_MOUNT_ROOTS_DEFAULT"),
               "SHARED_WORKSPACE_ROOT": value(
                   "shared_workspace_root", "SHARED_WORKSPACE_ROOT_DEFAULT"
               ),
@@ -184,7 +172,15 @@ jobs:
       - name: Prepare SGLang and shared aiter source
         run: |
           set -euo pipefail
-          python3 -m pip install pyyaml -q
+          PYTHON_VENV="${RUNNER_TEMP}/sglang-mi355x-venv"
+          if python3 -m venv "${PYTHON_VENV}"; then
+            SGLANG_CI_PYTHON="${PYTHON_VENV}/bin/python"
+            "${SGLANG_CI_PYTHON}" -m pip install --upgrade pip -q
+            "${SGLANG_CI_PYTHON}" -m pip install pyyaml tabulate -q
+          else
+            SGLANG_CI_PYTHON=python3
+            python3 -m pip install --break-system-packages --user pyyaml tabulate -q
+          fi
 
           SGLANG_WORKSPACE="${RUNNER_TEMP}/sglang-mi355x-disagg"
           rm -rf "${SGLANG_WORKSPACE}"
@@ -193,8 +189,8 @@ jobs:
           test -f "${SGLANG_WORKSPACE}/scripts/ci/slurm/launch_mi355x.sh"
           test -f "${SGLANG_WORKSPACE}/scripts/ci/slurm/recipes/mi355x-fp8/dsv4pro/1k1k/1p1d.yaml"
 
-          python3 .github/scripts/sglang_mi355x_disagg.py patch-launcher "${SGLANG_WORKSPACE}"
-          python3 .github/scripts/sglang_mi355x_disagg.py configure-recipe \
+          "${SGLANG_CI_PYTHON}" .github/scripts/sglang_mi355x_disagg.py patch-launcher "${SGLANG_WORKSPACE}"
+          "${SGLANG_CI_PYTHON}" .github/scripts/sglang_mi355x_disagg.py configure-recipe \
             "${SGLANG_WORKSPACE}" \
             --concurrency-list "${CONC_LIST}" \
             --accuracy-enabled "${RUN_ACCURACY}"
@@ -208,6 +204,7 @@ jobs:
 
           {
             echo "SGLANG_WORKSPACE=${SGLANG_WORKSPACE}"
+            echo "SGLANG_CI_PYTHON=${SGLANG_CI_PYTHON}"
             echo "AITER_SOURCE_DIR=${AITER_SOURCE_DIR}"
             echo "SHARED_WORKDIR_ROOT=${SHARED_WORKDIR_ROOT}"
           } >> "${GITHUB_ENV}"
@@ -231,7 +228,7 @@ jobs:
             exit 0
           fi
           STALE_JOBS="$(
-            squeue --me --noheader --format="%i %200j" \
+            squeue -u "${USER}" --noheader --format="%i %200j" \
               | grep -F "mi355x-ci-${RUNNER_NAME}-" \
               | awk '{print $1}' || true
           )"
@@ -273,7 +270,6 @@ jobs:
         run: |
           set -euo pipefail
           cd "${SGLANG_WORKSPACE}"
-          python3 -m pip install pyyaml tabulate -q
           shopt -s nullglob
           processed=0
           for result_file in "${GITHUB_WORKSPACE}"/mi355x-dsv4pro-fp8-1p1d_*.json; do
@@ -291,14 +287,14 @@ jobs:
               PRECISION=fp8 \
               ISL=1024 \
               OSL=1024 \
-              python3 scripts/ci/slurm/process_result.py
+              "${SGLANG_CI_PYTHON}" scripts/ci/slurm/process_result.py
             processed=$((processed + 1))
           done
           if [ "${processed}" -eq 0 ]; then
             echo "No result files were produced."
             exit 1
           fi
-          python3 scripts/ci/slurm/summarize.py "${GITHUB_WORKSPACE}" >> "${GITHUB_STEP_SUMMARY}"
+          "${SGLANG_CI_PYTHON}" scripts/ci/slurm/summarize.py "${GITHUB_WORKSPACE}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Stage artifacts
         if: always()
@@ -331,7 +327,7 @@ jobs:
           fi
           JOB_TAG="mi355x-ci-${RUNNER_NAME}-${GITHUB_RUN_ID}-dsv4pro-fp8-mi355x-sglang"
           ACTIVE_JOBS="$(
-            squeue --me --noheader --format="%i %200j" \
+            squeue -u "${USER}" --noheader --format="%i %200j" \
               | grep -F "${JOB_TAG}" \
               | awk '{print $1}' || true
           )"

--- a/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
+++ b/.github/workflows/sglang-mi355x-dsv4pro-fp8-1p1d.yaml
@@ -12,10 +12,10 @@ on:
   workflow_dispatch:
     inputs:
       sglang_ref:
-        description: "SGLang ref to test; default tracks sgl-project/sglang#29084"
+        description: "SGLang ref to test"
         required: false
         type: string
-        default: "amd-mi355x-disagg-nightly"
+        default: "main"
       image:
         description: "Optional SGLang ROCm image override. Empty uses the recipe default."
         required: false
@@ -72,8 +72,8 @@ permissions:
   contents: read
 
 env:
-  SGLANG_REPOSITORY: Lzy17/sglang
-  SGLANG_REF_DEFAULT: amd-mi355x-disagg-nightly
+  SGLANG_REPOSITORY: sgl-project/sglang
+  SGLANG_REF_DEFAULT: main
   IMAGE_OVERRIDE_DEFAULT: ""
   MODEL_PATH_DEFAULT: /data/models2/DeepSeek-V4-Pro-FP8
   MODEL_MOUNT_ROOTS: /it-share /data /models
@@ -262,6 +262,7 @@ jobs:
           export SLURM_EXCLUSIVE="${SLURM_EXCLUSIVE_OVERRIDE}"
           export TIME_LIMIT="${TIME_LIMIT_OVERRIDE}"
           export SHARED_WORKDIR_ROOT="${SHARED_WORKDIR_ROOT}"
+          export SGLANG_RUNTIME_WORKSPACE="${SGLANG_WORKSPACE}"
           export AITER_SOURCE_DIR="${AITER_SOURCE_DIR}"
           bash scripts/ci/slurm/launch_mi355x.sh
 


### PR DESCRIPTION
## Summary

Follow-up to ROCm/aiter#4182. This changes the SGLang MI355X DSV4Pro FP8 1P1D workflow into a nightly benchmark workflow:

- workflow name: `Nightly SGLang MI355X DSV4Pro FP8 1P1D`
- trigger: daily schedule plus manual `workflow_dispatch`
- removes the direct `pull_request` trigger from the benchmark workflow
- keeps `cancel-in-progress: false` so a long nightly run is not interrupted by another ref update

The benchmark itself remains scoped to the single bring-up target:

- model: `sgl-project/DeepSeek-V4-Pro-FP8`
- topology: 2-node `1P1D`, TP8 prefill + TP8 decode
- runner: `[self-hosted, aiter-di-ci-spur-login]`
- SGLang source: upstream `sgl-project/sglang@main`

## Notes

This PR is intentionally stacked conceptually on #4182. After #4182 lands, this is the small nightly enablement change: schedule/manual dispatch only, no PR benchmark trigger.

## Local Validation

- Parsed the workflow and `.github/actionlint.yaml` with PyYAML
- Ran actionlint 1.7.7 with `-shellcheck "" -pyflakes ""`
- Ran `git diff --check`
