### PR TITLE
op_tests: IFOE cross-node custom all-reduce (module_custom_all_reduce_ifoe)

### DIFF
--- a/aiter/dist/device_communicators/ifoe_custom_all_reduce.py
+++ b/aiter/dist/device_communicators/ifoe_custom_all_reduce.py
@@ -12,6 +12,7 @@ Usage::
     comm = IfoeCustomAllreduce(group, device, max_bytes=1 << 30)
     out = comm.all_reduce(x)                 # fp32, lossless
     out = comm.all_reduce(x, mode="bf16")    # bf16 on the wire (lossy)
+    out = comm.all_reduce(x, mode="fp8")     # fp8 e4m3 on the wire (lossier, fastest)
     comm.dispose()
 """
 
@@ -28,7 +29,7 @@ from aiter.ops.custom_all_reduce_ifoe import (
 )
 
 _HANDLE_BYTES = 64  # sizeof(hipMemFabricHandle_t)
-_MODES = {"fp32": 0, "bf16": 1}
+_MODES = {"fp32": 0, "bf16": 1, "fp8": 2}
 
 
 class IfoeCustomAllreduce:

--- a/aiter/dist/device_communicators/ifoe_custom_all_reduce.py
+++ b/aiter/dist/device_communicators/ifoe_custom_all_reduce.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""IFOE cross-node custom all-reduce communicator (gfx1250).
+
+Shares peer buffers via HIP *fabric* handles instead of IPC, so the identical
+2-stage kernel runs cross-node over the IFOE fabric.  Bootstrap and the
+64-byte fabric-handle exchange ride ``torch.distributed`` (works cross-node),
+mirroring ``custom_all_reduce.py``'s IPC-handle exchange.
+
+Usage::
+
+    comm = IfoeCustomAllreduce(group, device, max_bytes=1 << 30)
+    out = comm.all_reduce(x)                 # fp32, lossless
+    out = comm.all_reduce(x, mode="bf16")    # bf16 on the wire (lossy)
+    comm.dispose()
+"""
+
+import torch
+import torch.distributed as dist
+
+from aiter.ops.custom_all_reduce_ifoe import (
+    ifoe_alloc_fabric,
+    ifoe_import_fabric,
+    ifoe_init,
+    ifoe_all_reduce,
+    ifoe_meta_size,
+    ifoe_dispose,
+)
+
+_HANDLE_BYTES = 64  # sizeof(hipMemFabricHandle_t)
+_MODES = {"fp32": 0, "bf16": 1}
+
+
+class IfoeCustomAllreduce:
+    def __init__(self, group, device, max_bytes: int = 1 << 30):
+        """Register fabric buffers of capacity ``max_bytes`` and exchange handles.
+
+        ``group`` is a torch.distributed process group spanning all ranks (any
+        backend that supports ``all_gather_object``); ``max_bytes`` bounds the
+        largest fp32 tensor that can be all-reduced.
+        """
+        self.group = group
+        self.rank = dist.get_rank(group)
+        self.world = dist.get_world_size(group)
+        self.device = torch.device(device)
+        self.max_bytes = int(max_bytes)
+        self.ctx = None
+        if self.world < 2 or self.world > 8:
+            raise ValueError("IFOE all-reduce supports world size in [2, 8]")
+
+        torch.cuda.set_device(self.device)
+        self.sig_bytes = ifoe_meta_size() + self.max_bytes
+        self.bf_bytes = self.max_bytes // 2
+
+        # allocate local fabric buffers; each call writes a 64-byte export handle
+        self._h_in = torch.zeros(_HANDLE_BYTES, dtype=torch.uint8)
+        self._h_sig = torch.zeros(_HANDLE_BYTES, dtype=torch.uint8)
+        self._h_bf = torch.zeros(_HANDLE_BYTES, dtype=torch.uint8)
+        self.in_ptr = ifoe_alloc_fabric(self.max_bytes, self._h_in.data_ptr())
+        self.sig_ptr = ifoe_alloc_fabric(self.sig_bytes, self._h_sig.data_ptr())
+        self.bf_ptr = ifoe_alloc_fabric(self.bf_bytes, self._h_bf.data_ptr())
+
+        # all-gather the (input, signal, bf16) handles across the group
+        mine = (
+            bytes(self._h_in.numpy().tobytes()),
+            bytes(self._h_sig.numpy().tobytes()),
+            bytes(self._h_bf.numpy().tobytes()),
+        )
+        gathered = [None] * self.world
+        dist.all_gather_object(gathered, mine, group=self.group)
+
+        peer_in, peer_sig, peer_bf = [], [], []
+        for r in range(self.world):
+            if r == self.rank:
+                peer_in.append(self.in_ptr)
+                peer_sig.append(self.sig_ptr)
+                peer_bf.append(self.bf_ptr)
+                continue
+            hi, hs, hb = gathered[r]
+            peer_in.append(self._import(hi, self.max_bytes))
+            peer_sig.append(self._import(hs, self.sig_bytes))
+            peer_bf.append(self._import(hb, self.bf_bytes))
+
+        self.ctx = ifoe_init(
+            self.rank,
+            self.world,
+            self.in_ptr,
+            self.sig_ptr,
+            self.bf_ptr,
+            peer_in,
+            peer_sig,
+            peer_bf,
+        )
+
+    @staticmethod
+    def _import(handle: bytes, nbytes: int) -> int:
+        # import copies the handle immediately, so the staging tensor is transient
+        staging = torch.frombuffer(bytearray(handle), dtype=torch.uint8)
+        return ifoe_import_fabric(staging.data_ptr(), nbytes)
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        mode: str = "fp32",
+        out: torch.Tensor | None = None,
+        unroll: int = 0,
+        blocks: int = 0,
+    ) -> torch.Tensor:
+        if mode not in _MODES:
+            raise ValueError(f"mode must be one of {list(_MODES)}")
+        if inp.dtype != torch.float32:
+            raise ValueError("IFOE all-reduce currently supports fp32 tensors")
+        if not inp.is_contiguous():
+            inp = inp.contiguous()
+        nbytes = inp.numel() * inp.element_size()
+        if nbytes > self.max_bytes:
+            raise ValueError(
+                f"tensor ({nbytes} B) exceeds max_bytes ({self.max_bytes})"
+            )
+        if nbytes % 32 != 0:
+            raise ValueError("tensor byte size must be a multiple of 32")
+        if out is None:
+            out = torch.empty_like(inp)
+        ifoe_all_reduce(
+            self.ctx,
+            inp.data_ptr(),
+            out.data_ptr(),
+            inp.numel(),
+            inp.element_size(),
+            _MODES[mode],
+            unroll,
+            blocks,
+        )
+        return out
+
+    def dispose(self) -> None:
+        if self.ctx is not None:
+            ifoe_dispose(self.ctx)
+            self.ctx = None
+
+    def __del__(self):
+        try:
+            self.dispose()
+        except Exception:
+            pass

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -129,6 +129,18 @@
         "verbose": "False",
         "blob_gen_cmd": "''"
     },
+    "module_custom_all_reduce_ifoe": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/custom_all_reduce_ifoe_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/custom_all_reduce_ifoe.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [],
+        "extra_ldflags": "None",
+        "extra_include": [],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_quick_all_reduce": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/pybind/quick_all_reduce_pybind.cu'",

--- a/aiter/ops/custom_all_reduce_ifoe.py
+++ b/aiter/ops/custom_all_reduce_ifoe.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from typing import List
+
+from ..jit.core import compile_ops
+
+MD_NAME = "module_custom_all_reduce_ifoe"
+
+
+@compile_ops("module_custom_all_reduce_ifoe", develop=True)
+def ifoe_alloc_fabric(bytes: int, handle_out_ptr: int) -> int: ...
+
+
+@compile_ops("module_custom_all_reduce_ifoe", develop=True)
+def ifoe_import_fabric(handle_ptr: int, bytes: int) -> int: ...
+
+
+@compile_ops("module_custom_all_reduce_ifoe", develop=True)
+def ifoe_init(
+    rank: int,
+    world: int,
+    self_input_ptr: int,
+    self_signal_ptr: int,
+    self_bf_ptr: int,
+    peer_input_ptrs: List[int],
+    peer_signal_ptrs: List[int],
+    peer_bf_ptrs: List[int],
+) -> int: ...
+
+
+@compile_ops("module_custom_all_reduce_ifoe", develop=True)
+def ifoe_all_reduce(
+    ctx: int,
+    inp_ptr: int,
+    out_ptr: int,
+    numel: int,
+    elt_size: int,
+    mode: int,
+    unroll: int,
+    blocks: int,
+) -> None: ...
+
+
+@compile_ops("module_custom_all_reduce_ifoe", develop=True)
+def ifoe_meta_size() -> int: ...
+
+
+@compile_ops("module_custom_all_reduce_ifoe", develop=True)
+def ifoe_dispose(ctx: int) -> None: ...

--- a/csrc/include/custom_all_reduce_ifoe.cuh
+++ b/csrc/include/custom_all_reduce_ifoe.cuh
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// IFOE cross-node custom all-reduce kernels for gfx1250.
+//
+// This reuses aiter's 2-stage custom all-reduce structure (reduce-scatter +
+// allgather, guarded by start_sync / end_sync per-block barriers).  The only
+// difference from the intra-node IPC path is that peer buffers are shared with
+// HIP *fabric* handles (see custom_all_reduce_ifoe.cu), which are node
+// independent -- so the identical kernel runs cross-node over the IFOE fabric.
+//
+// Two data paths are provided:
+//   * allreduce2_opt  -- fp32, MLP-unrolled (U float4 in flight per thread).
+//   * allreduce2_bf16 -- bf16 on the wire (half the fabric bytes, fp32
+//                        accumulate); lossy.
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+#include <cstdint>
+
+namespace aiter {
+namespace ifoe {
+
+constexpr int kMaxBlocks = 304; // >= CU count for full occupancy
+
+struct Signal
+{
+    alignas(128) uint32_t start[kMaxBlocks][8];
+    alignas(128) uint32_t end[kMaxBlocks][8];
+    alignas(128) uint32_t _flag[kMaxBlocks];
+};
+struct __align__(16) RankData { const void* ptrs[8]; };
+struct __align__(16) RankSignals { Signal* signals[8]; };
+
+#define IFOE_DINLINE __device__ __forceinline__
+
+// Per-block cross-rank barrier: publish own arrival to every peer, spin on all
+// peers' arrival for this block.  System scope so the atomics traverse the
+// fabric; the peer data ordering is provided by the surrounding kernel launch
+// boundaries (inputs / bf16 casts are produced by prior kernels).
+template <int ngpus>
+IFOE_DINLINE void start_sync(const RankSignals& sg, Signal* self_sg, int rank)
+{
+    uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+    if(threadIdx.x < ngpus)
+    {
+        __scoped_atomic_store_n(&sg.signals[threadIdx.x]->start[blockIdx.x][rank],
+                                flag,
+                                __ATOMIC_RELAXED,
+                                __MEMORY_SCOPE_SYSTEM);
+        while(__scoped_atomic_load_n(&self_sg->start[blockIdx.x][threadIdx.x],
+                                     __ATOMIC_RELAXED,
+                                     __MEMORY_SCOPE_DEVICE) < flag)
+            ;
+    }
+    __syncthreads();
+    if(threadIdx.x == 0)
+        self_sg->_flag[blockIdx.x] = flag;
+}
+
+template <int ngpus>
+IFOE_DINLINE void end_sync(const RankSignals& sg, Signal* self_sg, int rank)
+{
+    __syncthreads();
+    uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+    if(threadIdx.x < ngpus)
+    {
+        __scoped_atomic_store_n(&sg.signals[threadIdx.x]->end[blockIdx.x][rank],
+                                flag,
+                                __ATOMIC_RELEASE,
+                                __MEMORY_SCOPE_SYSTEM);
+        while(__scoped_atomic_load_n(&self_sg->end[blockIdx.x][threadIdx.x],
+                                     __ATOMIC_ACQUIRE,
+                                     __MEMORY_SCOPE_DEVICE) < flag)
+            ;
+    }
+    __syncthreads();
+    if(threadIdx.x == 0)
+        self_sg->_flag[blockIdx.x] = flag;
+}
+
+template <typename P>
+IFOE_DINLINE P* tmp_buf(Signal* s)
+{
+    return (P*)(s + 1); // reduced-shard scratch lives right after the Signal
+}
+
+// ---- fp32 MLP-optimized path -------------------------------------------------
+// size is the float4 count of the (whole) tensor.
+template <int ngpus, int U>
+__global__ void __launch_bounds__(512, 1)
+    allreduce2_opt(RankData* in_dp, RankSignals sg, Signal* self_sg, float* result, int rank, int size)
+{
+    int tid = blockIdx.x * blockDim.x + threadIdx.x, stride = gridDim.x * blockDim.x;
+    int part = size / ngpus, start = rank * part, end = (rank == ngpus - 1) ? size : start + part,
+        largest = part + size % ngpus;
+    const float4* ptrs[ngpus];
+    float4* tmps[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int t   = (rank + i) % ngpus;
+        ptrs[i] = (const float4*)in_dp->ptrs[t];
+        tmps[i] = tmp_buf<float4>(sg.signals[t]);
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    // reduce-scatter: U float4 in flight per thread across the whole peer set
+    for(int i0 = start + tid; i0 < end; i0 += stride * U)
+    {
+        float4 acc[U];
+#pragma unroll
+        for(int u = 0; u < U; u++)
+        {
+            int idx = i0 + u * stride;
+            acc[u]  = idx < end ? ptrs[0][idx] : float4{0, 0, 0, 0};
+        }
+#pragma unroll
+        for(int p = 1; p < ngpus; p++)
+        {
+#pragma unroll
+            for(int u = 0; u < U; u++)
+            {
+                int idx = i0 + u * stride;
+                if(idx < end)
+                {
+                    float4 v = ptrs[p][idx];
+                    acc[u].x += v.x;
+                    acc[u].y += v.y;
+                    acc[u].z += v.z;
+                    acc[u].w += v.w;
+                }
+            }
+        }
+#pragma unroll
+        for(int u = 0; u < U; u++)
+        {
+            int idx = i0 + u * stride;
+            if(idx < end)
+                tmps[0][idx - start] = acc[u];
+        }
+    }
+    end_sync<ngpus>(sg, self_sg, rank);
+    // allgather: each peer's reduced shard copied contiguously
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int gr = (rank + i) % ngpus, cnt = (gr == ngpus - 1) ? largest : part;
+        float4* dst       = (float4*)result + (size_t)gr * part;
+        const float4* src = tmps[i];
+        for(int i0 = tid; i0 < cnt; i0 += stride * U)
+        {
+#pragma unroll
+            for(int u = 0; u < U; u++)
+            {
+                int idx = i0 + u * stride;
+                if(idx < cnt)
+                    dst[idx] = src[idx];
+            }
+        }
+    }
+}
+
+// ---- bf16 on-wire path -------------------------------------------------------
+// One "octet" = 8 fp32 elems = 2 float4 = a bf16x8 (16B) on the wire.
+using bf16 = __hip_bfloat16;
+struct __align__(16) bf16x8 { bf16 v[8]; };
+
+IFOE_DINLINE bf16x8 cvt_f2b(float4 a, float4 b)
+{
+    bf16x8 o;
+    o.v[0] = __float2bfloat16(a.x);
+    o.v[1] = __float2bfloat16(a.y);
+    o.v[2] = __float2bfloat16(a.z);
+    o.v[3] = __float2bfloat16(a.w);
+    o.v[4] = __float2bfloat16(b.x);
+    o.v[5] = __float2bfloat16(b.y);
+    o.v[6] = __float2bfloat16(b.z);
+    o.v[7] = __float2bfloat16(b.w);
+    return o;
+}
+IFOE_DINLINE void cvt_b2f(bf16x8 o, float4& a, float4& b)
+{
+    a.x = __bfloat162float(o.v[0]);
+    a.y = __bfloat162float(o.v[1]);
+    a.z = __bfloat162float(o.v[2]);
+    a.w = __bfloat162float(o.v[3]);
+    b.x = __bfloat162float(o.v[4]);
+    b.y = __bfloat162float(o.v[5]);
+    b.z = __bfloat162float(o.v[6]);
+    b.w = __bfloat162float(o.v[7]);
+}
+
+// Cast own fp32 input -> own bf16 wire buffer.  Separate kernel so its writes
+// are grid-globally visible (kernel boundary) before the reduce reads them
+// cross-block.  size8 = element count / 8.
+__global__ void cast_bf16(const float4* own_in, bf16x8* my_bf, int size8)
+{
+    int tid = blockIdx.x * blockDim.x + threadIdx.x, stride = gridDim.x * blockDim.x;
+    for(int o = tid; o < size8; o += stride)
+        my_bf[o] = cvt_f2b(own_in[2 * o], own_in[2 * o + 1]);
+}
+
+// size8 = element count / 8 (octets).  in_bf_dp: peer bf16 buffers (already cast).
+template <int ngpus, int U>
+__global__ void __launch_bounds__(512, 1) allreduce2_bf16(
+    RankData* in_bf_dp, RankSignals sg, Signal* self_sg, float4* result, int rank, int size8)
+{
+    int tid = blockIdx.x * blockDim.x + threadIdx.x, stride = gridDim.x * blockDim.x;
+    int part = size8 / ngpus, start = rank * part, end = (rank == ngpus - 1) ? size8 : start + part,
+        largest = part + size8 % ngpus;
+    const bf16x8* ptrs[ngpus];
+    bf16x8* tmps[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int t   = (rank + i) % ngpus;
+        ptrs[i] = (const bf16x8*)in_bf_dp->ptrs[t];
+        tmps[i] = tmp_buf<bf16x8>(sg.signals[t]);
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    // reduce-scatter: bf16 reads, fp32 accumulate, U-way MLP
+    for(int o0 = start + tid; o0 < end; o0 += stride * U)
+    {
+        float4 accA[U], accB[U];
+#pragma unroll
+        for(int u = 0; u < U; u++)
+        {
+            int o = o0 + u * stride;
+            if(o < end)
+                cvt_b2f(ptrs[0][o], accA[u], accB[u]);
+        }
+#pragma unroll
+        for(int p = 1; p < ngpus; p++)
+        {
+#pragma unroll
+            for(int u = 0; u < U; u++)
+            {
+                int o = o0 + u * stride;
+                if(o < end)
+                {
+                    float4 va, vb;
+                    cvt_b2f(ptrs[p][o], va, vb);
+                    accA[u].x += va.x;
+                    accA[u].y += va.y;
+                    accA[u].z += va.z;
+                    accA[u].w += va.w;
+                    accB[u].x += vb.x;
+                    accB[u].y += vb.y;
+                    accB[u].z += vb.z;
+                    accB[u].w += vb.w;
+                }
+            }
+        }
+#pragma unroll
+        for(int u = 0; u < U; u++)
+        {
+            int o = o0 + u * stride;
+            if(o < end)
+                tmps[0][o - start] = cvt_f2b(accA[u], accB[u]);
+        }
+    }
+    end_sync<ngpus>(sg, self_sg, rank);
+    // allgather: read peers' bf16 reduced shards, cast to fp32 result
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int gr = (rank + i) % ngpus, cnt = (gr == ngpus - 1) ? largest : part;
+        for(int o = tid; o < cnt; o += stride)
+        {
+            float4 a, b;
+            cvt_b2f(tmps[i][o], a, b);
+            result[2 * ((size_t)gr * part + o)]     = a;
+            result[2 * ((size_t)gr * part + o) + 1] = b;
+        }
+    }
+}
+
+} // namespace ifoe
+} // namespace aiter

--- a/csrc/include/custom_all_reduce_ifoe.cuh
+++ b/csrc/include/custom_all_reduce_ifoe.cuh
@@ -9,14 +9,17 @@
 // HIP *fabric* handles (see custom_all_reduce_ifoe.cu), which are node
 // independent -- so the identical kernel runs cross-node over the IFOE fabric.
 //
-// Two data paths are provided:
+// Three data paths are provided:
 //   * allreduce2_opt  -- fp32, MLP-unrolled (U float4 in flight per thread).
 //   * allreduce2_bf16 -- bf16 on the wire (half the fabric bytes, fp32
 //                        accumulate); lossy.
+//   * allreduce2_fp8  -- fp8 e4m3 on the wire (quarter the fabric bytes, fp32
+//                        accumulate); lossier, highest busbw.
 #pragma once
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_bf16.h>
+#include <hip/hip_fp8.h>
 #include <cstdint>
 
 namespace aiter {
@@ -272,6 +275,107 @@ __global__ void __launch_bounds__(512, 1) allreduce2_bf16(
             cvt_b2f(tmps[i][o], a, b);
             result[2 * ((size_t)gr * part + o)]     = a;
             result[2 * ((size_t)gr * part + o) + 1] = b;
+        }
+    }
+}
+
+// ---- fp8 (e4m3) on-wire path -------------------------------------------------
+// One "hex" = 16 fp32 elems = 4 float4 = an fp8x16 (16B) on the wire; quarter the
+// fabric bytes, fp32 accumulate. Lossy (fp8 rounding); higher busbw than bf16.
+using fp8 = __hip_fp8_e4m3;
+struct __align__(16) fp8x16 { fp8 v[16]; };
+
+IFOE_DINLINE fp8x16 cvt_f2f8(float4 a, float4 b, float4 c, float4 d)
+{
+    fp8x16 o;
+    o.v[0]=fp8(a.x);  o.v[1]=fp8(a.y);  o.v[2]=fp8(a.z);  o.v[3]=fp8(a.w);
+    o.v[4]=fp8(b.x);  o.v[5]=fp8(b.y);  o.v[6]=fp8(b.z);  o.v[7]=fp8(b.w);
+    o.v[8]=fp8(c.x);  o.v[9]=fp8(c.y);  o.v[10]=fp8(c.z); o.v[11]=fp8(c.w);
+    o.v[12]=fp8(d.x); o.v[13]=fp8(d.y); o.v[14]=fp8(d.z); o.v[15]=fp8(d.w);
+    return o;
+}
+IFOE_DINLINE void cvt_f82f(fp8x16 o, float4& a, float4& b, float4& c, float4& d)
+{
+    a.x=float(o.v[0]);  a.y=float(o.v[1]);  a.z=float(o.v[2]);  a.w=float(o.v[3]);
+    b.x=float(o.v[4]);  b.y=float(o.v[5]);  b.z=float(o.v[6]);  b.w=float(o.v[7]);
+    c.x=float(o.v[8]);  c.y=float(o.v[9]);  c.z=float(o.v[10]); c.w=float(o.v[11]);
+    d.x=float(o.v[12]); d.y=float(o.v[13]); d.z=float(o.v[14]); d.w=float(o.v[15]);
+}
+
+__global__ void cast_fp8(const float4* own_in, fp8x16* my_f8, int size16)
+{
+    int tid = blockIdx.x * blockDim.x + threadIdx.x, stride = gridDim.x * blockDim.x;
+    for(int o = tid; o < size16; o += stride)
+        my_f8[o] = cvt_f2f8(own_in[4*o], own_in[4*o+1], own_in[4*o+2], own_in[4*o+3]);
+}
+
+// size16 = element count / 16. in_f8_dp: peer fp8 buffers (already cast).
+template <int ngpus, int U>
+__global__ void __launch_bounds__(512, 1) allreduce2_fp8(
+    RankData* in_f8_dp, RankSignals sg, Signal* self_sg, float4* result, int rank, int size16)
+{
+    int tid = blockIdx.x * blockDim.x + threadIdx.x, stride = gridDim.x * blockDim.x;
+    int part = size16 / ngpus, start = rank * part, end = (rank == ngpus - 1) ? size16 : start + part,
+        largest = part + size16 % ngpus;
+    const fp8x16* ptrs[ngpus];
+    fp8x16* tmps[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int t   = (rank + i) % ngpus;
+        ptrs[i] = (const fp8x16*)in_f8_dp->ptrs[t];
+        tmps[i] = tmp_buf<fp8x16>(sg.signals[t]);
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+    // reduce-scatter: fp8 reads, fp32 accumulate, U-way MLP
+    for(int o0 = start + tid; o0 < end; o0 += stride * U)
+    {
+        float4 A[U], B[U], C[U], D[U];
+#pragma unroll
+        for(int u = 0; u < U; u++)
+        {
+            int o = o0 + u * stride;
+            if(o < end) cvt_f82f(ptrs[0][o], A[u], B[u], C[u], D[u]);
+        }
+#pragma unroll
+        for(int p = 1; p < ngpus; p++)
+        {
+#pragma unroll
+            for(int u = 0; u < U; u++)
+            {
+                int o = o0 + u * stride;
+                if(o < end)
+                {
+                    float4 a, b, c, d;
+                    cvt_f82f(ptrs[p][o], a, b, c, d);
+                    A[u].x+=a.x; A[u].y+=a.y; A[u].z+=a.z; A[u].w+=a.w;
+                    B[u].x+=b.x; B[u].y+=b.y; B[u].z+=b.z; B[u].w+=b.w;
+                    C[u].x+=c.x; C[u].y+=c.y; C[u].z+=c.z; C[u].w+=c.w;
+                    D[u].x+=d.x; D[u].y+=d.y; D[u].z+=d.z; D[u].w+=d.w;
+                }
+            }
+        }
+#pragma unroll
+        for(int u = 0; u < U; u++)
+        {
+            int o = o0 + u * stride;
+            if(o < end) tmps[0][o - start] = cvt_f2f8(A[u], B[u], C[u], D[u]);
+        }
+    }
+    end_sync<ngpus>(sg, self_sg, rank);
+    // allgather: read peers' fp8 reduced shards, cast to fp32 result
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        int gr = (rank + i) % ngpus, cnt = (gr == ngpus - 1) ? largest : part;
+        for(int o = tid; o < cnt; o += stride)
+        {
+            float4 a, b, c, d;
+            cvt_f82f(tmps[i][o], a, b, c, d);
+            result[4 * ((size_t)gr * part + o)]     = a;
+            result[4 * ((size_t)gr * part + o) + 1] = b;
+            result[4 * ((size_t)gr * part + o) + 2] = c;
+            result[4 * ((size_t)gr * part + o) + 3] = d;
         }
     }
 }

--- a/csrc/include/custom_all_reduce_ifoe.h
+++ b/csrc/include/custom_all_reduce_ifoe.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Host API for the IFOE cross-node custom all-reduce (gfx1250).  Peer buffers
+// are shared with HIP fabric handles (node independent), so the same kernel
+// runs cross-node over the IFOE fabric.  Bootstrap / handle exchange is done in
+// Python via torch.distributed; this layer only allocates fabric buffers,
+// imports peer handles, and launches the kernel.
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+// Raw-pointer API on purpose: this module must not pull in aiter_tensor.h /
+// ck_tile, which does not device-compile on gfx1250.
+using fptr_t = int64_t;
+
+namespace aiter {
+
+// Allocate a fabric-exportable VMM buffer of `bytes`; write its 64-byte
+// hipMemFabricHandle_t to the host buffer at `handle_out_ptr`.  Returns the
+// device pointer (as int64).
+int64_t ifoe_alloc_fabric(int64_t bytes, int64_t handle_out_ptr);
+
+// Import a peer's fabric buffer from the 64-byte handle at `handle_ptr`.
+// Returns the mapped device pointer (as int64).
+int64_t ifoe_import_fabric(int64_t handle_ptr, int64_t bytes);
+
+// Build an all-reduce context.  The peer_* vectors are length `world`, indexed
+// by rank, and include this rank's own pointers at index `rank`.
+fptr_t ifoe_init(int64_t rank,
+                 int64_t world,
+                 int64_t self_input_ptr,
+                 int64_t self_signal_ptr,
+                 int64_t self_bf_ptr,
+                 const std::vector<int64_t>& peer_input_ptrs,
+                 const std::vector<int64_t>& peer_signal_ptrs,
+                 const std::vector<int64_t>& peer_bf_ptrs);
+
+// Run one all-reduce.  mode: 0 = fp32 (opt), 1 = bf16 on-wire.  unroll/blocks
+// <= 0 select tuned defaults.  The tensor at `inp_ptr` (numel * elt_size bytes,
+// fp32) is copied into the registered fabric input buffer; the reduced result
+// is written directly to `out_ptr`.
+void ifoe_all_reduce(fptr_t ctx,
+                     int64_t inp_ptr,
+                     int64_t out_ptr,
+                     int64_t numel,
+                     int64_t elt_size,
+                     int64_t mode,
+                     int64_t unroll,
+                     int64_t blocks);
+
+int64_t ifoe_meta_size(); // sizeof(Signal)
+void ifoe_dispose(fptr_t ctx);
+
+} // namespace aiter

--- a/csrc/kernels/custom_all_reduce_ifoe.cu
+++ b/csrc/kernels/custom_all_reduce_ifoe.cu
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Host side of the IFOE cross-node custom all-reduce: fabric VMM allocation /
+// import, the all-reduce context, and kernel launch dispatch.
+#include "custom_all_reduce_ifoe.cuh"
+#include "custom_all_reduce_ifoe.h"
+#include "aiter_stream.h"
+#include <cstring>
+#include <stdexcept>
+
+using fptr_t = int64_t;
+static_assert(sizeof(void*) == sizeof(fptr_t));
+
+namespace aiter {
+
+using ifoe::bf16x8;
+using ifoe::kMaxBlocks;
+using ifoe::RankData;
+using ifoe::RankSignals;
+using ifoe::Signal;
+
+#define IFOE_CK(x)                                                                       \
+    do                                                                                   \
+    {                                                                                    \
+        hipError_t e = (x);                                                              \
+        if(e != hipSuccess)                                                              \
+            throw std::runtime_error(std::string("ifoe hip error: ") +                  \
+                                     hipGetErrorString(e) + " @ " + __FILE__ + ":" +     \
+                                     std::to_string(__LINE__));                          \
+    } while(0)
+
+// Round `bytes` up to the recommended fabric allocation granularity.
+static size_t fabric_tot(size_t bytes, int dev)
+{
+    hipMemAllocationProp pr = {};
+    pr.type                 = hipMemAllocationTypePinned;
+    pr.requestedHandleTypes = hipMemHandleTypeFabric;
+    pr.location.type        = hipMemLocationTypeDevice;
+    pr.location.id          = dev;
+    size_t g                = 0;
+    IFOE_CK(hipMemGetAllocationGranularity(&g, &pr, hipMemAllocationGranularityRecommended));
+    return ((bytes + g - 1) / g) * g;
+}
+
+static void* fab(size_t bytes, int dev, hipMemFabricHandle_t& fh)
+{
+    hipMemAllocationProp pr = {};
+    pr.type                 = hipMemAllocationTypePinned;
+    pr.requestedHandleTypes = hipMemHandleTypeFabric;
+    pr.location.type        = hipMemLocationTypeDevice;
+    pr.location.id          = dev;
+    size_t tot              = fabric_tot(bytes, dev);
+    hipMemGenericAllocationHandle_t h;
+    IFOE_CK(hipMemCreate(&h, tot, &pr, 0));
+    void* p = 0;
+    IFOE_CK(hipMemAddressReserve(&p, tot, 0, 0, 0));
+    IFOE_CK(hipMemMap(p, tot, 0, h, 0));
+    hipMemAccessDesc ad = {};
+    ad.location.type    = hipMemLocationTypeDevice;
+    ad.location.id      = dev;
+    ad.flags            = hipMemAccessFlagsProtReadWrite;
+    IFOE_CK(hipMemSetAccess(p, tot, &ad, 1));
+    IFOE_CK(hipMemExportToShareableHandle(&fh, h, hipMemHandleTypeFabric, 0));
+    return p;
+}
+
+static void* imp(const hipMemFabricHandle_t& fh, size_t bytes, int dev)
+{
+    size_t tot = fabric_tot(bytes, dev);
+    hipMemGenericAllocationHandle_t h;
+    IFOE_CK(hipMemImportFromShareableHandle(&h, (void*)&fh, hipMemHandleTypeFabric));
+    void* p = 0;
+    IFOE_CK(hipMemAddressReserve(&p, tot, 0, 0, 0));
+    IFOE_CK(hipMemMap(p, tot, 0, h, 0));
+    hipMemAccessDesc ad = {};
+    ad.location.type    = hipMemLocationTypeDevice;
+    ad.location.id      = dev;
+    ad.flags            = hipMemAccessFlagsProtReadWrite;
+    IFOE_CK(hipMemSetAccess(p, tot, &ad, 1));
+    return p;
+}
+
+int64_t ifoe_alloc_fabric(int64_t bytes, int64_t handle_out_ptr)
+{
+    int dev;
+    IFOE_CK(hipGetDevice(&dev));
+    hipMemFabricHandle_t fh;
+    void* p = fab((size_t)bytes, dev, fh);
+    std::memcpy((void*)handle_out_ptr, &fh, sizeof(hipMemFabricHandle_t));
+    return (int64_t)p;
+}
+
+int64_t ifoe_import_fabric(int64_t handle_ptr, int64_t bytes)
+{
+    int dev;
+    IFOE_CK(hipGetDevice(&dev));
+    hipMemFabricHandle_t fh;
+    std::memcpy(&fh, (void*)handle_ptr, sizeof(hipMemFabricHandle_t));
+    return (int64_t)imp(fh, (size_t)bytes, dev);
+}
+
+struct IfoeAR
+{
+    int rank, world;
+    void* self_input;
+    void* self_bf;
+    Signal* self_sg;
+    RankData* in_dp; // device: peer input ptrs
+    RankData* bf_dp; // device: peer bf16 ptrs
+    RankSignals sg;  // peer signal ptrs (by value into kernel)
+};
+
+fptr_t ifoe_init(int64_t rank,
+                 int64_t world,
+                 int64_t self_input_ptr,
+                 int64_t self_signal_ptr,
+                 int64_t self_bf_ptr,
+                 const std::vector<int64_t>& peer_input_ptrs,
+                 const std::vector<int64_t>& peer_signal_ptrs,
+                 const std::vector<int64_t>& peer_bf_ptrs)
+{
+    if(world < 2 || world > 8)
+        throw std::invalid_argument("ifoe: world must be in [2, 8]");
+    if((int)peer_input_ptrs.size() != world || (int)peer_signal_ptrs.size() != world ||
+       (int)peer_bf_ptrs.size() != world)
+        throw std::invalid_argument("ifoe: peer ptr list length must equal world");
+
+    auto* ar        = new IfoeAR();
+    ar->rank        = (int)rank;
+    ar->world       = (int)world;
+    ar->self_input  = (void*)self_input_ptr;
+    ar->self_bf     = (void*)self_bf_ptr;
+    ar->self_sg     = (Signal*)self_signal_ptr;
+    IFOE_CK(hipMemset(ar->self_sg, 0, sizeof(Signal)));
+
+    RankData h_rd, h_bf;
+    for(int i = 0; i < world; i++)
+    {
+        h_rd.ptrs[i]    = (const void*)peer_input_ptrs[i];
+        h_bf.ptrs[i]    = (const void*)peer_bf_ptrs[i];
+        ar->sg.signals[i] = (Signal*)peer_signal_ptrs[i];
+    }
+    IFOE_CK(hipMalloc(&ar->in_dp, sizeof(RankData)));
+    IFOE_CK(hipMemcpy(ar->in_dp, &h_rd, sizeof(RankData), hipMemcpyHostToDevice));
+    IFOE_CK(hipMalloc(&ar->bf_dp, sizeof(RankData)));
+    IFOE_CK(hipMemcpy(ar->bf_dp, &h_bf, sizeof(RankData), hipMemcpyHostToDevice));
+    return (fptr_t)ar;
+}
+
+#define IFOE_OPT(NG, U) \
+    ifoe::allreduce2_opt<NG, U><<<nb, TH, 0, st>>>(ar->in_dp, ar->sg, ar->self_sg, (float*)out_ptr, ar->rank, nvec)
+#define IFOE_BF(NG, U) \
+    ifoe::allreduce2_bf16<NG, U><<<nb, TH, 0, st>>>(ar->bf_dp, ar->sg, ar->self_sg, (float4*)out_ptr, ar->rank, size8)
+
+template <int U>
+static void launch_opt(IfoeAR* ar, void* out_ptr, int nb, int TH, int nvec, hipStream_t st)
+{
+    switch(ar->world)
+    {
+    case 2: IFOE_OPT(2, U); break;
+    case 4: IFOE_OPT(4, U); break;
+    case 8: IFOE_OPT(8, U); break;
+    default: throw std::invalid_argument("ifoe: unsupported world");
+    }
+}
+template <int U>
+static void launch_bf(IfoeAR* ar, void* out_ptr, int nb, int TH, int size8, hipStream_t st)
+{
+    switch(ar->world)
+    {
+    case 2: IFOE_BF(2, U); break;
+    case 4: IFOE_BF(4, U); break;
+    case 8: IFOE_BF(8, U); break;
+    default: throw std::invalid_argument("ifoe: unsupported world");
+    }
+}
+
+void ifoe_all_reduce(fptr_t ctx,
+                     int64_t inp_ptr,
+                     int64_t out_ptr_,
+                     int64_t numel,
+                     int64_t elt_size,
+                     int64_t mode,
+                     int64_t unroll,
+                     int64_t blocks)
+{
+    auto* ar         = (IfoeAR*)ctx;
+    void* out_ptr    = (void*)out_ptr_;
+    hipStream_t st   = getCurrentHIPStream();
+    size_t bytes     = (size_t)numel * (size_t)elt_size;
+    if(bytes % 32 != 0)
+        throw std::invalid_argument("ifoe: tensor bytes must be a multiple of 32");
+    int nvec         = (int)(bytes / 16); // float4 count
+    int size8        = (int)(bytes / 32); // octet count (bf16 path)
+    int TH           = 512;
+    int U            = unroll > 0 ? (int)unroll : 8;
+
+    // stage the input into the fabric-visible buffer peers read
+    IFOE_CK(hipMemcpyAsync(ar->self_input, (void*)inp_ptr, bytes, hipMemcpyDeviceToDevice, st));
+
+    int blkcap = (mode == 1) ? 256 : 208; // bf16 moves half the bytes -> more blocks
+    int nb     = blocks > 0 ? (int)blocks : (nvec / ar->world + TH - 1) / TH;
+    if(blocks <= 0 && nb > blkcap)
+        nb = blkcap;
+    if(nb > kMaxBlocks)
+        nb = kMaxBlocks;
+    if(nb < 1)
+        nb = 1;
+
+    if(mode == 1)
+    {
+        ifoe::cast_bf16<<<nb, TH, 0, st>>>((const float4*)ar->self_input, (bf16x8*)ar->self_bf, size8);
+        switch(U)
+        {
+        case 2: launch_bf<2>(ar, out_ptr, nb, TH, size8, st); break;
+        case 4: launch_bf<4>(ar, out_ptr, nb, TH, size8, st); break;
+        default: launch_bf<8>(ar, out_ptr, nb, TH, size8, st); break;
+        }
+    }
+    else
+    {
+        switch(U)
+        {
+        case 1: launch_opt<1>(ar, out_ptr, nb, TH, nvec, st); break;
+        case 2: launch_opt<2>(ar, out_ptr, nb, TH, nvec, st); break;
+        case 4: launch_opt<4>(ar, out_ptr, nb, TH, nvec, st); break;
+        default: launch_opt<8>(ar, out_ptr, nb, TH, nvec, st); break;
+        }
+    }
+    IFOE_CK(hipGetLastError());
+}
+
+int64_t ifoe_meta_size() { return (int64_t)sizeof(Signal); }
+
+void ifoe_dispose(fptr_t ctx)
+{
+    auto* ar = (IfoeAR*)ctx;
+    if(!ar)
+        return;
+    if(ar->in_dp)
+        (void)hipFree(ar->in_dp);
+    if(ar->bf_dp)
+        (void)hipFree(ar->bf_dp);
+    delete ar;
+}
+
+} // namespace aiter

--- a/csrc/kernels/custom_all_reduce_ifoe.cu
+++ b/csrc/kernels/custom_all_reduce_ifoe.cu
@@ -152,6 +152,8 @@ fptr_t ifoe_init(int64_t rank,
     ifoe::allreduce2_opt<NG, U><<<nb, TH, 0, st>>>(ar->in_dp, ar->sg, ar->self_sg, (float*)out_ptr, ar->rank, nvec)
 #define IFOE_BF(NG, U) \
     ifoe::allreduce2_bf16<NG, U><<<nb, TH, 0, st>>>(ar->bf_dp, ar->sg, ar->self_sg, (float4*)out_ptr, ar->rank, size8)
+#define IFOE_FP8(NG, U) \
+    ifoe::allreduce2_fp8<NG, U><<<nb, TH, 0, st>>>(ar->bf_dp, ar->sg, ar->self_sg, (float4*)out_ptr, ar->rank, size16)
 
 template <int U>
 static void launch_opt(IfoeAR* ar, void* out_ptr, int nb, int TH, int nvec, hipStream_t st)
@@ -175,6 +177,17 @@ static void launch_bf(IfoeAR* ar, void* out_ptr, int nb, int TH, int size8, hipS
     default: throw std::invalid_argument("ifoe: unsupported world");
     }
 }
+template <int U>
+static void launch_fp8(IfoeAR* ar, void* out_ptr, int nb, int TH, int size16, hipStream_t st)
+{
+    switch(ar->world)
+    {
+    case 2: IFOE_FP8(2, U); break;
+    case 4: IFOE_FP8(4, U); break;
+    case 8: IFOE_FP8(8, U); break;
+    default: throw std::invalid_argument("ifoe: unsupported world");
+    }
+}
 
 void ifoe_all_reduce(fptr_t ctx,
                      int64_t inp_ptr,
@@ -191,15 +204,18 @@ void ifoe_all_reduce(fptr_t ctx,
     size_t bytes     = (size_t)numel * (size_t)elt_size;
     if(bytes % 32 != 0)
         throw std::invalid_argument("ifoe: tensor bytes must be a multiple of 32");
+    if(mode == 2 && bytes % 64 != 0)
+        throw std::invalid_argument("ifoe fp8: tensor bytes must be a multiple of 64");
     int nvec         = (int)(bytes / 16); // float4 count
     int size8        = (int)(bytes / 32); // octet count (bf16 path)
+    int size16       = (int)(bytes / 64); // hex count (fp8 path)
     int TH           = 512;
-    int U            = unroll > 0 ? (int)unroll : 8;
+    int U            = unroll > 0 ? (int)unroll : (mode == 2 ? 4 : 8); // fp8 default U=4
 
     // stage the input into the fabric-visible buffer peers read
     IFOE_CK(hipMemcpyAsync(ar->self_input, (void*)inp_ptr, bytes, hipMemcpyDeviceToDevice, st));
 
-    int blkcap = (mode == 1) ? 256 : 208; // bf16 moves half the bytes -> more blocks
+    int blkcap = (mode >= 1) ? 256 : 208; // lower-precision moves fewer bytes -> more blocks
     int nb     = blocks > 0 ? (int)blocks : (nvec / ar->world + TH - 1) / TH;
     if(blocks <= 0 && nb > blkcap)
         nb = blkcap;
@@ -208,7 +224,17 @@ void ifoe_all_reduce(fptr_t ctx,
     if(nb < 1)
         nb = 1;
 
-    if(mode == 1)
+    if(mode == 2)
+    {
+        ifoe::cast_fp8<<<nb, TH, 0, st>>>((const float4*)ar->self_input, (ifoe::fp8x16*)ar->self_bf, size16);
+        switch(U)
+        {
+        case 1: launch_fp8<1>(ar, out_ptr, nb, TH, size16, st); break;
+        case 2: launch_fp8<2>(ar, out_ptr, nb, TH, size16, st); break;
+        default: launch_fp8<4>(ar, out_ptr, nb, TH, size16, st); break;
+        }
+    }
+    else if(mode == 1)
     {
         ifoe::cast_bf16<<<nb, TH, 0, st>>>((const float4*)ar->self_input, (bf16x8*)ar->self_bf, size8);
         switch(U)

--- a/csrc/pybind/custom_all_reduce_ifoe_pybind.cu
+++ b/csrc/pybind/custom_all_reduce_ifoe_pybind.cu
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Self-contained pybind (does not include rocm_ops.hpp / aiter_tensor.h, which
+// would pull ck_tile into the gfx1250 device compile).
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "aiter_stream.h"
+#include "custom_all_reduce_ifoe.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def(
+        "_set_current_hip_stream",
+        [](int64_t stream_ptr) { aiter::setCurrentHIPStream((hipStream_t)stream_ptr); },
+        py::arg("stream_ptr"));
+    m.def("ifoe_alloc_fabric",
+          &aiter::ifoe_alloc_fabric,
+          py::arg("bytes"),
+          py::arg("handle_out_ptr"));
+    m.def("ifoe_import_fabric",
+          &aiter::ifoe_import_fabric,
+          py::arg("handle_ptr"),
+          py::arg("bytes"));
+    m.def("ifoe_init",
+          &aiter::ifoe_init,
+          py::arg("rank"),
+          py::arg("world"),
+          py::arg("self_input_ptr"),
+          py::arg("self_signal_ptr"),
+          py::arg("self_bf_ptr"),
+          py::arg("peer_input_ptrs"),
+          py::arg("peer_signal_ptrs"),
+          py::arg("peer_bf_ptrs"));
+    m.def("ifoe_all_reduce",
+          &aiter::ifoe_all_reduce,
+          py::arg("ctx"),
+          py::arg("inp_ptr"),
+          py::arg("out_ptr"),
+          py::arg("numel"),
+          py::arg("elt_size"),
+          py::arg("mode"),
+          py::arg("unroll"),
+          py::arg("blocks"));
+    m.def("ifoe_meta_size", &aiter::ifoe_meta_size);
+    m.def("ifoe_dispose", &aiter::ifoe_dispose, py::arg("ctx"));
+}

--- a/op_tests/multigpu_tests/ifoe_custom_ar/README.md
+++ b/op_tests/multigpu_tests/ifoe_custom_ar/README.md
@@ -1,0 +1,84 @@
+# IFOE cross-node custom all-reduce (gfx1250)
+
+Runs a custom all-reduce **across nodes** over the UALink-over-Ethernet (IFOE)
+fabric by sharing peer buffers with HIP **fabric handles** instead of IPC
+handles. Packaged as the `module_custom_all_reduce_ifoe` JIT module.
+
+## Layout
+
+| file | role |
+|---|---|
+| `csrc/include/custom_all_reduce_ifoe.cuh` | device kernels (opt fp32 + bf16), sync, structs |
+| `csrc/include/custom_all_reduce_ifoe.h` | host API declarations |
+| `csrc/kernels/custom_all_reduce_ifoe.cu` | fabric alloc/import, context, launch dispatch |
+| `csrc/pybind/custom_all_reduce_ifoe_pybind.cu` | pybind entry |
+| `aiter/ops/custom_all_reduce_ifoe.py` | `@compile_ops` stubs |
+| `aiter/dist/device_communicators/ifoe_custom_all_reduce.py` | `IfoeCustomAllreduce` communicator |
+| `op_tests/multigpu_tests/ifoe_custom_ar/test_ifoe_allreduce.py` | this driver |
+
+## Why this works with no kernel change
+
+On gfx1250 the fabric (IFOE) makes a remote GPU's memory addressable like a local
+peer's. Two primitives the all-reduce relies on both work cross-node:
+
+- **peer data read/write** — a remote GPU's fabric buffer is read/written like a
+  local peer's.
+- **peer atomic signals** — the `start_sync`/`end_sync` barrier (system-scope
+  atomic store into a peer's flag + spin-load on own flag) completes cross-node.
+
+So the 2-stage reduce-scatter/allgather structure is reused; only the
+buffer-sharing mechanism changes:
+
+| | intra-node (IPC) | cross-node (this) |
+|---|---|---|
+| export | `hipIpcGetMemHandle` | `hipMemExportToShareableHandle` (fabric) |
+| import | `hipIpcOpenMemHandle` | `hipMemImportFromShareableHandle` (fabric) |
+| buffer alloc | any `hipMalloc` | VMM (`hipMemCreate` + map, fabric-exportable) |
+| handle exchange | 1 node | `torch.distributed` all-gather (any node) |
+
+The 64-byte fabric handles are exchanged over `torch.distributed`, so the same
+code path runs TP4 (1 node) and TP8 (2 nodes).
+
+> **Requirement:** HIP fabric export (`hipMemExportToShareableHandle` with
+> `hipMemHandleTypeFabric`) needs **ROCm ≥ 7.15**. Older runtimes (e.g. the
+> ROCm 7.12 / HIP 7.2 bundled in some aiter containers) return `invalid
+> argument` on export. Run inside an image whose ROCm matches the host driver.
+
+## Run
+
+```bash
+# TP4, single node (4 GPUs):
+torchrun --nproc_per_node=4 test_ifoe_allreduce.py --mb 256
+
+# TP8, two nodes x 4 GPUs (run on each node, node_rank 0 then 1):
+torchrun --nnodes=2 --node_rank=0 --nproc_per_node=4 \
+    --master_addr=<node0-ip> --master_port=29500 test_ifoe_allreduce.py --mb 256
+```
+
+The first run JIT-compiles `module_custom_all_reduce_ifoe`. The driver runs both
+the `fp32` and `bf16` modes and checks correctness.
+
+### API
+
+```python
+from aiter.dist.device_communicators.ifoe_custom_all_reduce import IfoeCustomAllreduce
+comm = IfoeCustomAllreduce(group, torch.device("cuda", local_rank), max_bytes=1 << 30)
+out = comm.all_reduce(x)                  # fp32, lossless
+out = comm.all_reduce(x, mode="bf16")     # bf16 on the wire (lossy)
+comm.dispose()
+```
+
+`all_reduce` copies `inp` into the registered fabric buffer and writes the result
+into `out` (a production integration would allocate the model buffer directly as
+the fabric buffer to skip the copy-in). `unroll` / `blocks` override the launch
+geometry; both default to tuned values.
+
+## Modes
+
+- **`fp32`** (`allreduce2_opt`) — lossless. MLP-unrolled reduce-scatter (U float4
+  in flight per thread) + per-peer contiguous allgather.
+- **`bf16`** (`allreduce2_bf16`) — casts each rank's fp32 input to bf16 (a
+  separate kernel, for grid-wide visibility), does the reduce-scatter/allgather
+  in bf16, and accumulates in fp32. Lossy (bf16 rounds the addends before
+  summing — standard for ML gradient all-reduce); the test's correctness check
+  passes because the small-integer test values are exact in bf16.

--- a/op_tests/multigpu_tests/ifoe_custom_ar/README.md
+++ b/op_tests/multigpu_tests/ifoe_custom_ar/README.md
@@ -8,7 +8,7 @@ handles. Packaged as the `module_custom_all_reduce_ifoe` JIT module.
 
 | file | role |
 |---|---|
-| `csrc/include/custom_all_reduce_ifoe.cuh` | device kernels (opt fp32 + bf16), sync, structs |
+| `csrc/include/custom_all_reduce_ifoe.cuh` | device kernels (opt fp32 + bf16 + fp8), sync, structs |
 | `csrc/include/custom_all_reduce_ifoe.h` | host API declarations |
 | `csrc/kernels/custom_all_reduce_ifoe.cu` | fabric alloc/import, context, launch dispatch |
 | `csrc/pybind/custom_all_reduce_ifoe_pybind.cu` | pybind entry |
@@ -56,7 +56,7 @@ torchrun --nnodes=2 --node_rank=0 --nproc_per_node=4 \
 ```
 
 The first run JIT-compiles `module_custom_all_reduce_ifoe`. The driver runs both
-the `fp32` and `bf16` modes and checks correctness.
+the `fp32`, `bf16`, and `fp8` modes and checks correctness.
 
 ### API
 
@@ -65,6 +65,7 @@ from aiter.dist.device_communicators.ifoe_custom_all_reduce import IfoeCustomAll
 comm = IfoeCustomAllreduce(group, torch.device("cuda", local_rank), max_bytes=1 << 30)
 out = comm.all_reduce(x)                  # fp32, lossless
 out = comm.all_reduce(x, mode="bf16")     # bf16 on the wire (lossy)
+out = comm.all_reduce(x, mode="fp8")      # fp8 e4m3 on the wire (lossier, fastest)
 comm.dispose()
 ```
 
@@ -79,6 +80,9 @@ geometry; both default to tuned values.
   in flight per thread) + per-peer contiguous allgather.
 - **`bf16`** (`allreduce2_bf16`) — casts each rank's fp32 input to bf16 (a
   separate kernel, for grid-wide visibility), does the reduce-scatter/allgather
-  in bf16, and accumulates in fp32. Lossy (bf16 rounds the addends before
-  summing — standard for ML gradient all-reduce); the test's correctness check
-  passes because the small-integer test values are exact in bf16.
+  in bf16 (half the fabric bytes), and accumulates in fp32. Lossy (bf16 rounds
+  the addends before summing — standard for ML gradient all-reduce); the test's
+  correctness check passes because the small-integer test values are exact in bf16.
+- **`fp8`** (`allreduce2_fp8`) — same idea with fp8 e4m3 (quarter the fabric
+  bytes, fp32 accumulate); lossier than bf16 but the highest throughput.
+  Requires the tensor byte size to be a multiple of 64.

--- a/op_tests/multigpu_tests/ifoe_custom_ar/README.md
+++ b/op_tests/multigpu_tests/ifoe_custom_ar/README.md
@@ -86,3 +86,24 @@ geometry; both default to tuned values.
 - **`fp8`** (`allreduce2_fp8`) — same idea with fp8 e4m3 (quarter the fabric
   bytes, fp32 accumulate); lossier than bf16 but the highest throughput.
   Requires the tensor byte size to be a multiple of 64.
+
+## Benchmark / reproduce
+
+`--bench` reports `us/iter` and busbw; `--sweep` runs a latency sweep over a
+range of element counts (`--elems N1 N2 ...` for custom sizes). Example — the
+TP4 latency sweep across all three modes:
+
+```bash
+torchrun --nproc_per_node=4 test_ifoe_allreduce.py --sweep --bench --modes fp32 bf16 fp8
+```
+
+TP8 sweep (two nodes, run on each with the coordinator on node 0):
+
+```bash
+torchrun --nnodes=2 --node_rank=<0|1> --nproc_per_node=4 \
+    --master_addr=<node0-ip> --master_port=29500 \
+    test_ifoe_allreduce.py --sweep --bench
+```
+
+Each line prints `us/iter` per (size, mode); compare against your reference
+all-reduce (e.g. RCCL / the stock aiter path) at the same shapes.

--- a/op_tests/multigpu_tests/ifoe_custom_ar/test_ifoe_allreduce.py
+++ b/op_tests/multigpu_tests/ifoe_custom_ar/test_ifoe_allreduce.py
@@ -16,6 +16,9 @@ the same code path):
   # TP8, two nodes x 4 GPUs (run on each node; NODE_RANK 0 then 1):
   torchrun --nnodes=2 --node_rank=0 --nproc_per_node=4 \
       --master_addr=<node0-ip> --master_port=29500 test_ifoe_allreduce.py --mb 256
+
+  # latency sweep over a range of element counts (prints us/iter per size+mode):
+  torchrun --nproc_per_node=4 test_ifoe_allreduce.py --sweep --bench
 """
 
 import argparse
@@ -43,14 +46,33 @@ def _bench(comm, x, mode, iters=100, warmup=20):
     return start.elapsed_time(end) / iters  # ms/iter
 
 
+# element-count sweep (fp32 elements): 1K up to 4096*8192 = 32M
+_SWEEP = [1 << k for k in range(10, 14)] + [
+    m * 8192 for m in (2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096)
+]
+
+
 def main():
     ap = argparse.ArgumentParser(description="IFOE custom all-reduce test")
     ap.add_argument("--mb", type=int, default=256, help="tensor size in MiB (fp32)")
     ap.add_argument("--modes", nargs="+", default=["fp32", "bf16", "fp8"])
     ap.add_argument(
-        "--bench", action="store_true", help="also time and report bandwidth"
+        "--bench", action="store_true", help="also time and report us/iter + busbw"
+    )
+    ap.add_argument(
+        "--sweep", action="store_true", help="latency sweep over the default size range"
+    )
+    ap.add_argument(
+        "--elems", type=int, nargs="+", help="explicit element counts to benchmark"
     )
     args = ap.parse_args()
+
+    if args.elems:
+        sizes = args.elems  # element counts
+    elif args.sweep:
+        sizes = _SWEEP
+    else:
+        sizes = [(args.mb << 20) // 4]
 
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     torch.cuda.set_device(local_rank)
@@ -58,29 +80,29 @@ def main():
     group = dist.group.WORLD
     rank, world = dist.get_rank(), dist.get_world_size()
 
-    bytes_ = args.mb << 20
+    max_bytes = max(sizes) * 4
     comm = IfoeCustomAllreduce(
-        group, torch.device("cuda", local_rank), max_bytes=bytes_
+        group, torch.device("cuda", local_rank), max_bytes=max_bytes
     )
-
-    numel = bytes_ // 4
-    x = torch.full((numel,), float(rank + 1), dtype=torch.float32, device="cuda")
     expected = world * (world + 1) / 2.0
 
     ok = True
-    for mode in args.modes:
-        out = comm.all_reduce(x, mode=mode)
-        torch.cuda.synchronize()
-        mism = int((out != expected).sum().item())
-        passed = mism == 0
-        ok = ok and passed
-        line = f"[world={world} {args.mb}MB {mode:>4}] {'PASS' if passed else f'FAIL(mism={mism})'}"
-        if args.bench:
-            ms = _bench(comm, x, mode)
-            busbw = 2.0 * (world - 1) / world * bytes_ / (ms / 1e3) / 1e9
-            line += f"  {ms * 1e3:.1f} us/iter  busbw {busbw:.1f} GB/s"
-        if rank == 0:
-            print(line, flush=True)
+    for numel in sizes:
+        bytes_ = numel * 4
+        x = torch.full((numel,), float(rank + 1), dtype=torch.float32, device="cuda")
+        for mode in args.modes:
+            out = comm.all_reduce(x, mode=mode)
+            torch.cuda.synchronize()
+            mism = int((out != expected).sum().item())
+            passed = mism == 0
+            ok = ok and passed
+            line = f"[world={world} {numel:>10} elem {mode:>4}] {'PASS' if passed else f'FAIL(mism={mism})'}"
+            if args.bench:
+                ms = _bench(comm, x, mode)
+                busbw = 2.0 * (world - 1) / world * bytes_ / (ms / 1e3) / 1e9
+                line += f"  {ms * 1e3:8.2f} us/iter  busbw {busbw:6.1f} GB/s"
+            if rank == 0:
+                print(line, flush=True)
 
     comm.dispose()
     dist.barrier(group=group)

--- a/op_tests/multigpu_tests/ifoe_custom_ar/test_ifoe_allreduce.py
+++ b/op_tests/multigpu_tests/ifoe_custom_ar/test_ifoe_allreduce.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""IFOE cross-node custom all-reduce test / benchmark (gfx1250).
+
+Driver only -- the kernels and host API live in
+``csrc/{include,kernels}/custom_all_reduce_ifoe.*`` and are exposed as the
+``module_custom_all_reduce_ifoe`` JIT module via
+``aiter.dist.device_communicators.ifoe_custom_all_reduce.IfoeCustomAllreduce``.
+
+Launch with torchrun (fabric handles are node independent, so TP4 and TP8 use
+the same code path):
+
+  # TP4, single node (4 GPUs):
+  torchrun --nproc_per_node=4 test_ifoe_allreduce.py --mb 256
+
+  # TP8, two nodes x 4 GPUs (run on each node; NODE_RANK 0 then 1):
+  torchrun --nnodes=2 --node_rank=0 --nproc_per_node=4 \
+      --master_addr=<node0-ip> --master_port=29500 test_ifoe_allreduce.py --mb 256
+"""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+from aiter.dist.device_communicators.ifoe_custom_all_reduce import IfoeCustomAllreduce
+
+
+def _bench(comm, x, mode, iters=100, warmup=20):
+    for _ in range(warmup):
+        comm.all_reduce(x, mode=mode)
+    torch.cuda.synchronize()
+    dist.barrier(group=comm.group)
+    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(
+        enable_timing=True
+    )
+    start.record()
+    for _ in range(iters):
+        comm.all_reduce(x, mode=mode)
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms/iter
+
+
+def main():
+    ap = argparse.ArgumentParser(description="IFOE custom all-reduce test")
+    ap.add_argument("--mb", type=int, default=256, help="tensor size in MiB (fp32)")
+    ap.add_argument("--modes", nargs="+", default=["fp32", "bf16"])
+    ap.add_argument(
+        "--bench", action="store_true", help="also time and report bandwidth"
+    )
+    args = ap.parse_args()
+
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="nccl")
+    group = dist.group.WORLD
+    rank, world = dist.get_rank(), dist.get_world_size()
+
+    bytes_ = args.mb << 20
+    comm = IfoeCustomAllreduce(
+        group, torch.device("cuda", local_rank), max_bytes=bytes_
+    )
+
+    numel = bytes_ // 4
+    x = torch.full((numel,), float(rank + 1), dtype=torch.float32, device="cuda")
+    expected = world * (world + 1) / 2.0
+
+    ok = True
+    for mode in args.modes:
+        out = comm.all_reduce(x, mode=mode)
+        torch.cuda.synchronize()
+        mism = int((out != expected).sum().item())
+        passed = mism == 0
+        ok = ok and passed
+        line = f"[world={world} {args.mb}MB {mode:>4}] {'PASS' if passed else f'FAIL(mism={mism})'}"
+        if args.bench:
+            ms = _bench(comm, x, mode)
+            busbw = 2.0 * (world - 1) / world * bytes_ / (ms / 1e3) / 1e9
+            line += f"  {ms * 1e3:.1f} us/iter  busbw {busbw:.1f} GB/s"
+        if rank == 0:
+            print(line, flush=True)
+
+    comm.dispose()
+    dist.barrier(group=group)
+    dist.destroy_process_group()
+    assert ok, "IFOE all-reduce correctness failed"
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/multigpu_tests/ifoe_custom_ar/test_ifoe_allreduce.py
+++ b/op_tests/multigpu_tests/ifoe_custom_ar/test_ifoe_allreduce.py
@@ -46,7 +46,7 @@ def _bench(comm, x, mode, iters=100, warmup=20):
 def main():
     ap = argparse.ArgumentParser(description="IFOE custom all-reduce test")
     ap.add_argument("--mb", type=int, default=256, help="tensor size in MiB (fp32)")
-    ap.add_argument("--modes", nargs="+", default=["fp32", "bf16"])
+    ap.add_argument("--modes", nargs="+", default=["fp32", "bf16", "fp8"])
     ap.add_argument(
         "--bench", action="store_true", help="also time and report bandwidth"
     )


### PR DESCRIPTION
## Summary

Adds `module_custom_all_reduce_ifoe`: a custom all-reduce that runs **across nodes** over the UALink-over-Ethernet (IFOE) fabric on gfx1250 by sharing peer buffers with HIP **fabric handles** instead of IPC handles. The 2-stage reduce-scatter/allgather kernel is reused unchanged — only buffer *sharing* differs (IPC → fabric), because on gfx1250 both primitives the all-reduce needs (peer read/write and the `start_sync`/`end_sync` atomic-flag barrier) work cross-node. Handles are exchanged over `torch.distributed`, so the same path serves TP4 (1 node) and TP8 (2 nodes).

## Layout
- `csrc/{include,kernels,pybind}/custom_all_reduce_ifoe.*` — kernels, host API, fabric alloc/import + dispatch, pybind
- `aiter/ops/custom_all_reduce_ifoe.py` — `@compile_ops` stubs
- `aiter/dist/device_communicators/ifoe_custom_all_reduce.py` — `IfoeCustomAllreduce` communicator
- `op_tests/multigpu_tests/ifoe_custom_ar/` — torchrun driver + README

## Modes
- `fp32` — lossless, MLP-unrolled.
- `bf16` — bf16 on the wire (½ the fabric bytes), fp32 accumulate; lossy.
- `fp8` — fp8 e4m3 on the wire (¼ the bytes), fp32 accumulate; lossier, highest throughput (byte size must be a multiple of 64).

## Reproduce
```bash
# TP4 latency sweep across all modes (prints us/iter per size):
torchrun --nproc_per_node=4 test_ifoe_allreduce.py --sweep --bench --modes fp32 bf16 fp8
# TP8: run on each node with --nnodes=2 --node_rank=<0|1> --master_addr=<node0-ip>
```

## Notes
- Raw-pointer / self-contained pybind so the device TU avoids `aiter_tensor.h` → ck_tile (which does not device-compile on gfx1250).
- Requires **ROCm ≥ 7.15** for HIP fabric export (older runtimes return `invalid argument`).
- Python passes `black` + `ruff`.
