### PR TITLE
fea: support add fused allreduce

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -985,6 +985,128 @@ class CustomAllreduce:
         else:
             return self.reduce_scatter(input, output, dim, registered=False)
 
+    # ---- add_fused_allreduce dispatch ----
+    #
+    # Internal kernel selector values (the ``algo`` arg of the C++
+    # ``ops.add_fused_allreduce``). Not part of the public API — callers use
+    # ``add_fused_allreduce`` which auto-selects the fastest path.
+    _ADD_FUSED_2STAGE = 0  # fused kernel, reduce-scatter + all-gather
+    _ADD_FUSED_1STAGE = 1  # fused kernel, push-then-local-reduce
+    _ADD_FUSED_UNFUSED = 2  # torch.add + separate custom_all_reduce
+    #
+    # Per-world-size element-count thresholds derived from the bf16 graph-mode
+    # latency sweep in op_tests/multigpu_tests/bench_add_fused_allreduce.py.
+    # Each entry is (one_stage_max, two_stage_max) in element count:
+    #     numel <= one_stage_max                 -> 1stage
+    #     one_stage_max < numel <= two_stage_max -> 2stage
+    #     numel > two_stage_max                  -> unfused (torch.add + car),
+    #                                               falling back to 2stage when
+    #                                               the size exceeds the AR cap.
+    # 1stage wins only at small sizes (its cost grows linearly with numel);
+    # 2stage dominates the mid range; the separated torch.add + custom AR wins
+    # once tensors are large enough that fusion no longer hides the add.
+    _ADD_FUSED_AR_THRESHOLDS = {
+        2: (64 * 1024, 4 * 1024 * 1024),
+        4: (16 * 1024, 4 * 1024 * 1024),
+        8: (8 * 1024, 2 * 1024 * 1024),
+    }
+    # Conservative default for world sizes without measured data (e.g. 6):
+    # smallest 1stage window and smallest 2stage window observed.
+    _ADD_FUSED_AR_DEFAULT = (8 * 1024, 2 * 1024 * 1024)
+
+    def _select_add_fused_allreduce_algo(self, inp: torch.Tensor) -> int:
+        """Pick the fastest add_fused_allreduce path for ``inp``'s size.
+
+        Returns one of ``_ADD_FUSED_{1STAGE,2STAGE,UNFUSED}``. The unfused path
+        is only chosen when ``custom_all_reduce`` can actually service the
+        summed tensor; otherwise it stays on the fused 2stage kernel.
+        """
+        one_stage_max, two_stage_max = self._ADD_FUSED_AR_THRESHOLDS.get(
+            self.world_size, self._ADD_FUSED_AR_DEFAULT
+        )
+        numel = inp.numel()
+        if numel <= one_stage_max:
+            return self._ADD_FUSED_1STAGE
+        if numel <= two_stage_max:
+            return self._ADD_FUSED_2STAGE
+        # Large tensors: the separated path is fastest, but only if the summed
+        # tensor fits the custom_all_reduce size cap. Otherwise use 2stage.
+        if self.should_custom_ar(inp):
+            return self._ADD_FUSED_UNFUSED
+        return self._ADD_FUSED_2STAGE
+
+    def add_fused_allreduce(
+        self,
+        inp_a: torch.Tensor,
+        inp_b: torch.Tensor,
+        *,
+        out: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Fused (inp_a + inp_b) followed by an all-reduce across ranks.
+
+        out = allreduce_over_ranks(inp_a + inp_b)
+
+        inp_a/inp_b are same-shape, same-dtype tensors. Out-of-place. Inputs
+        are read locally by the kernel (no IPC-registered copy needed), so
+        there is no `registered` fast path here.
+
+        The fastest path is selected automatically from the input size and the
+        world size (see ``_select_add_fused_allreduce_algo``): the fused 1stage
+        kernel for small tensors, the fused 2stage kernel for the mid range, and
+        the separated ``torch.add`` + ``custom_all_reduce`` for large tensors.
+        """
+        assert inp_a.shape == inp_b.shape, "add_fused_allreduce inputs must match"
+        assert inp_a.dtype == inp_b.dtype, "add_fused_allreduce dtypes must match"
+
+        algo = self._select_add_fused_allreduce_algo(inp_a)
+        if algo == self._ADD_FUSED_UNFUSED:
+            return self._add_fused_allreduce_unfused(inp_a, inp_b, out=out)
+
+        if out is None:
+            out = torch.empty_like(inp_a)
+        assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
+        ops.add_fused_allreduce(self._ptr, inp_a, inp_b, out, algo)
+        return out
+
+    def _add_fused_allreduce_unfused(
+        self,
+        inp_a: torch.Tensor,
+        inp_b: torch.Tensor,
+        *,
+        out: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Separated (torch.add + custom_all_reduce) path for large tensors.
+
+        Mirrors ``custom_all_reduce``'s capture / warmup handling so it is safe
+        under CUDA-graph capture, and writes into ``out`` (via ``all_reduce``)
+        to avoid an extra device-to-device copy at large sizes. Falls back to
+        the fused 2stage kernel if the summed tensor cannot be serviced by the
+        custom all-reduce (e.g. it exceeds the size cap).
+        """
+        summed = torch.add(inp_a, inp_b)
+        if self.disabled or not self.should_custom_ar(summed):
+            if out is None:
+                out = torch.empty_like(inp_a)
+            assert is_weak_contiguous(out), "output tensor is not weak-contiguous"
+            ops.add_fused_allreduce(
+                self._ptr, inp_a, inp_b, out, self._ADD_FUSED_2STAGE
+            )
+            return out
+        if self._IS_CAPTURING:
+            if torch.cuda.is_current_stream_capturing():
+                return self.all_reduce(
+                    summed,
+                    out=out,
+                    registered_input=self.enable_register_for_capturing,
+                )
+            # warmup forward (pre-capture): mimic the out-of-place allocation
+            # pattern without running the real collective.
+            if out is None:
+                return torch.zeros_like(inp_a)
+            out.zero_()
+            return out
+        return self.all_reduce(summed, out=out, registered_input=False)
+
     def _allgather_out_shape(self, inp: torch.Tensor, dim: int):
         ndim = inp.dim()
         if dim == 0:

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -51,6 +51,16 @@ def reduce_scatter(
 
 
 @compile_ops("module_custom_all_reduce", develop=True)
+def add_fused_allreduce(
+    _fa: int,
+    inp_a: torch.Tensor,
+    inp_b: torch.Tensor,
+    out: torch.Tensor,
+    algo: int = 0,
+) -> None: ...
+
+
+@compile_ops("module_custom_all_reduce", develop=True)
 def all_gather_reg(
     _fa: int,
     inp: torch.Tensor,

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -774,6 +774,169 @@ __global__ void __launch_bounds__(512, 1) allgather_lastdim(RankData* _dp,
     }
 }
 
+// -------------------------------------------------
+// ----- add fuse allreduce
+// -------------------------------------------------
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) add_fused_allreduce_1stage(
+    T* __restrict__ input_a,
+    T* __restrict__ input_b,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size
+)
+{
+    constexpr int tnum_gpu = THREAD_NUM / ngpus;
+    constexpr int pack_size = 16 / sizeof(T);
+    int lane_id = threadIdx.x % tnum_gpu;
+    int warp_id = threadIdx.x / tnum_gpu;
+    using P = typename opus::vector_t<T, pack_size>;
+    using A = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int tid = blockIdx.x * tnum_gpu + lane_id;
+    int stride = gridDim.x * tnum_gpu;
+
+    P* tmps[ngpus];
+    __shared__ T smem[THREAD_NUM * pack_size];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+    }
+    // should only loop once
+    start_sync<ngpus>(sg, self_sg, rank);
+    for (int idx = tid; idx < size; idx += stride)
+    {
+      if (warp_id == 0)
+      {
+        P inp_a = *(reinterpret_cast<P*>(input_a) + idx);
+        P inp_b = *(reinterpret_cast<P*>(input_b) + idx);
+        P add_c;
+#pragma unroll
+        for (int i = 0; i < pack_size; ++i)
+        {
+          add_c[i] = downcast_s<T>(
+            upcast_s(inp_a[i]) + upcast_s(inp_b[i])
+          );
+        }
+        tmps[rank][idx] = add_c;
+      }
+      end_sync<ngpus>(sg, self_sg, rank);
+      *(reinterpret_cast<P*>(smem) + threadIdx.x) = tmps[warp_id][idx];
+      __syncthreads();
+      if (warp_id == 0)
+      {
+        P reduce_elem = *(reinterpret_cast<P*>(smem) + lane_id);
+        P reduce_rslt_T;
+        A reduce_rslt;
+#pragma unroll
+        for (int i = 0; i < pack_size; ++i)
+        {
+          reduce_rslt[i] = upcast_s(reduce_elem[i]);
+        }
+#pragma unroll
+        for (int i = 1; i < ngpus; ++i)
+        {
+          reduce_elem = *(reinterpret_cast<P*>(smem) + i * tnum_gpu + lane_id);
+#pragma unroll
+          for (int j = 0; j < pack_size; ++j)
+          {
+            reduce_rslt[j] += upcast_s(reduce_elem[j]);
+          }
+        }
+#pragma unroll
+        for (int i = 0; i < pack_size; ++i)
+        {
+          reduce_rslt_T[i] = downcast_s<T>(reduce_rslt[i]);
+        }
+        *(reinterpret_cast<P*>(result) + idx) = reduce_rslt_T;
+      }
+      __syncthreads();
+    }
+}
+
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) add_fused_allreduce_2stage(
+    T* __restrict__ input_a,
+    T* __restrict__ input_b,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size
+)
+{
+    constexpr int tnum_gpu = THREAD_NUM / ngpus;
+    constexpr int pack_size = 16 / sizeof(T);
+    using P = typename opus::vector_t<T, pack_size>;
+    using A = typename opus::vector_t<opus::fp32_t, pack_size>;
+    int warp_id = threadIdx.x / tnum_gpu;
+    int lane_id = threadIdx.x % tnum_gpu;
+    int tid = blockIdx.x * tnum_gpu + lane_id;
+    int stride = gridDim.x * tnum_gpu;
+    __shared__ T smem[THREAD_NUM * pack_size];
+
+    P* tmps[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; i++)
+    {
+        tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+    }
+    for (int idx = tid; idx < size; idx += stride)
+    {
+      P inp_a = *(reinterpret_cast<P*>(input_a) + warp_id * size + idx);
+      P inp_b = *(reinterpret_cast<P*>(input_b) + warp_id * size + idx);
+      P add_c;
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i)
+      {
+        add_c[i] = downcast_s<T>(
+          upcast_s(inp_a[i]) + upcast_s(inp_b[i])
+        );
+      }
+      tmps[rank][warp_id * size + idx] = add_c;
+    }
+    end_sync<ngpus>(sg, self_sg, rank);
+    for (int idx = tid; idx < size; idx += stride)
+    {
+      *(reinterpret_cast<P*>(&smem[0]) + threadIdx.x) = tmps[warp_id][rank * size + idx];
+      __syncthreads();
+      if (warp_id == 0)
+      {
+        P reduce_elem = *(reinterpret_cast<P*>(&smem[0]) + lane_id);
+        A reduce_rslt;
+#pragma unroll
+        for (int i = 0; i < pack_size; ++i)
+        {
+          reduce_rslt[i] = upcast_s(reduce_elem[i]);
+        }
+        for (int i = 1; i < ngpus; ++i)
+        {
+          reduce_elem = *(reinterpret_cast<P*>(&smem[0]) + i * tnum_gpu + lane_id);
+#pragma unroll
+          for (int j = 0; j < pack_size; ++j)
+          {
+            reduce_rslt[j] += upcast_s(reduce_elem[j]);
+          }
+        }
+        P rslt;
+#pragma unroll
+        for (int i = 0; i < pack_size; ++i)
+        {
+          rslt[i] = downcast_s<T>(reduce_rslt[i]);
+        }
+        tmps[rank][rank * size + idx] = rslt;
+      }
+      __syncthreads();
+    }
+    end_sync<ngpus>(sg, self_sg, rank);
+    for (int idx = tid; idx < size; idx += stride)
+    {
+      *(reinterpret_cast<P*>(result) + warp_id * size + idx) = tmps[warp_id][warp_id * size + idx];
+    }
+}
+
 // ========== reduce_scatter kernel start ==========
 //
 // reduce_scatter has 3 categories depending on where the scatter dim sits in
@@ -4067,6 +4230,59 @@ void dispatchAllGather(
         default: printf("allgather world_size error\n");
         }
     }
+}
+
+// Fused (A + B) followed by a 2-stage all-reduce.
+//   result = allreduce_over_ranks( input_a + input_b )
+// `input_a`/`input_b`/`result` are plain local device pointers: the kernel
+// reads A/B locally and only crosses devices through the temp buffers
+// (get_tmp_buf on the IPC-registered meta pool), so no get_buffer_RD /
+// IPC registration of the inputs is needed.
+//
+// `numel` is the element count of one rank's input tensor. The kernel indexes
+// as `warp_id * size + idx` with warp_id in [0, ngpus), so the per-launch
+// `size` is numel / (pack_size * world_size). Requires
+// numel % (pack_size * world_size) == 0.
+template <typename T>
+void dispatchAddFusedAllReduce(
+    hipStream_t stream, T* input_a, T* input_b, T* result, int64_t numel, int algo = 0)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    constexpr int threads   = THREAD_NUM;
+    if(numel % (int64_t)(pack_size * world_size_) != 0)
+    {
+        throw std::runtime_error(
+            "add_fused_allreduce requires numel to be a multiple of pack_size * world_size (" +
+            std::to_string(pack_size * world_size_) + ")");
+    }
+    // 2stage splits the input across ranks, so each rank processes numel/world_size
+    // packed elements. 1stage processes the full tensor locally and pushes it to
+    // every peer, so `size` is the full packed length.
+    int size_2stage  = (int)(numel / (pack_size * world_size_));
+    int size_1stage  = (int)(numel / pack_size);
+    int size         = (algo == 1) ? size_1stage : size_2stage;
+    int tnum_per_gpu  = threads / world_size_;
+    int blocks        = std::min(kMaxBlocks, (size + tnum_per_gpu - 1) / tnum_per_gpu);
+    blocks            = std::max(blocks, 1);
+    dim3 grid(blocks);
+    dim3 block(threads);
+#define ADD_FUSED_AR_CASE(NG)                                                    \
+    case NG:                                                                     \
+        if(algo == 1)                                                            \
+            add_fused_allreduce_1stage<T, NG><<<grid, block, 0, stream>>>(       \
+                input_a, input_b, sg_, self_sg_, result, rank_, size);          \
+        else                                                                    \
+            add_fused_allreduce_2stage<T, NG><<<grid, block, 0, stream>>>(       \
+                input_a, input_b, sg_, self_sg_, result, rank_, size);          \
+        break;
+    switch(world_size_)
+    {
+        ADD_FUSED_AR_CASE(2)
+        ADD_FUSED_AR_CASE(4)
+        ADD_FUSED_AR_CASE(8)
+    default: throw std::runtime_error("add_fused_allreduce only supports 2, 4, 8 gpus");
+    }
+#undef ADD_FUSED_AR_CASE
 }
 
 template <typename T>

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -54,6 +54,15 @@ void reduce_scatter(fptr_t _fa,
                     int64_t split_dim,
                     int64_t reg_ptr,
                     int64_t reg_bytes);
+// Fused element-wise add followed by all-reduce:
+//   out = allreduce_over_ranks(inp_a + inp_b)
+// inp_a/inp_b/out are same-shape, same-dtype tensors. numel must be a multiple
+// of (16/sizeof(dtype)) * world_size.
+void add_fused_allreduce(fptr_t _fa,
+                         const aiter_tensor_t& inp_a,
+                         const aiter_tensor_t& inp_b,
+                         const aiter_tensor_t& out,
+                         int64_t algo = 0);
 void all_gather_reg(fptr_t _fa,
                     const aiter_tensor_t& inp,
                     const aiter_tensor_t& out,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -488,6 +488,13 @@ namespace py = pybind11;
           py::arg("split_dim"),                                                                \
           py::arg("reg_ptr"),                                                                  \
           py::arg("reg_bytes"));                                                               \
+    m.def("add_fused_allreduce",                                                               \
+          &aiter::add_fused_allreduce,                                                         \
+          py::arg("_fa"),                                                                      \
+          py::arg("inp_a"),                                                                    \
+          py::arg("inp_b"),                                                                    \
+          py::arg("out"),                                                                      \
+          py::arg("algo") = 0);                                                                \
     m.def("all_gather_reg",                                                                    \
           &aiter::all_gather_reg,                                                              \
           py::arg("_fa"),                                                                      \

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -154,6 +154,44 @@ static void _reduce_scatter(fptr_t _fa, void* inp, void* out,
     }
 }
 
+static void _add_fused_allreduce(fptr_t _fa, void* inp_a, void* inp_b, void* out,
+                                 int64_t numel, AiterDtype dtype, int algo)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    switch(dtype)
+    {
+    case AITER_DTYPE_fp32: {
+        fa->dispatchAddFusedAllReduce<opus::fp32_t>(stream,
+                                    reinterpret_cast<opus::fp32_t*>(inp_a),
+                                    reinterpret_cast<opus::fp32_t*>(inp_b),
+                                    reinterpret_cast<opus::fp32_t*>(out),
+                                    numel, algo);
+        break;
+    }
+    case AITER_DTYPE_fp16: {
+        fa->dispatchAddFusedAllReduce<opus::fp16_t>(stream,
+                                    reinterpret_cast<opus::fp16_t*>(inp_a),
+                                    reinterpret_cast<opus::fp16_t*>(inp_b),
+                                    reinterpret_cast<opus::fp16_t*>(out),
+                                    numel, algo);
+        break;
+    }
+#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
+    case AITER_DTYPE_bf16: {
+        fa->dispatchAddFusedAllReduce<opus::bf16_t>(stream,
+                                    reinterpret_cast<opus::bf16_t*>(inp_a),
+                                    reinterpret_cast<opus::bf16_t*>(inp_b),
+                                    reinterpret_cast<opus::bf16_t*>(out),
+                                    numel, algo);
+        break;
+    }
+#endif
+    default:
+        throw std::runtime_error("custom allreduce only supports float32, float16 and bfloat16");
+    }
+}
+
 static void _all_gather(fptr_t _fa, void* inp, void* out,
                         int64_t size, AiterDtype dtype,
                         int64_t last_dim_size, int64_t gather_dim)
@@ -469,6 +507,21 @@ void reduce_scatter(fptr_t _fa,
                         static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
                         sd, dtype);
     }
+}
+
+void add_fused_allreduce(fptr_t _fa,
+                         const aiter_tensor_t& inp_a,
+                         const aiter_tensor_t& inp_b,
+                         const aiter_tensor_t& out,
+                         int64_t algo)
+{
+    HipDeviceGuard device_guard(inp_a.device_id);
+    auto dtype    = inp_a.dtype();
+    int64_t numel = inp_a.numel();
+    // A/B are read locally by the kernel and never accessed cross-device, so no
+    // IPC-registered buffer copy is required (unlike reduce_scatter/all_reduce).
+    _add_fused_allreduce(_fa, inp_a.data_ptr(), inp_b.data_ptr(), out.data_ptr(),
+                         numel, dtype, (int)algo);
 }
 
 void all_gather_reg(fptr_t _fa,

--- a/op_tests/multigpu_tests/test_add_fused_allreduce.py
+++ b/op_tests/multigpu_tests/test_add_fused_allreduce.py
@@ -287,7 +287,6 @@ def _bench_graph(fn):
         graph.replay()
 
     _, us = _replay()
-    del graph
     return us
 
 
@@ -338,7 +337,7 @@ def bench_worker(
         results[n] = row
 
         dist.barrier(group=group)
-        del a, b, out_f
+        a = b = out_f = None
         torch.cuda.empty_cache()
 
     _teardown()

--- a/op_tests/multigpu_tests/test_add_fused_allreduce.py
+++ b/op_tests/multigpu_tests/test_add_fused_allreduce.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Accuracy + latency benchmark for the fused add-then-allreduce path.
+
+    out = allreduce_over_ranks(a_i + b_i)
+
+Two paths are each compared against a CPU fp32 reference (the analytic sum over
+ranks of a_i + b_i, cast down to the kernel dtype):
+  - fused   : ca_comm.add_fused_allreduce(a, b)   (auto-dispatched kernel)
+  - unfused : torch.add(a, b) -> ca_comm.custom_all_reduce(...)
+The accuracy table reports the mismatch ratio of each path vs the reference.
+
+Just run it — no arguments. It runs both stages and prints all results at the
+end:
+  accuracy : fp32-reference mismatch ratio for fused + unfused on named shapes.
+  bench    : eager + cuda-graph latency sweep over element counts, one table
+             per world size (tp=2, 4, 8).
+
+    python test_add_fused_allreduce.py
+"""
+
+import logging
+import os
+from multiprocessing import Pool, freeze_support, set_start_method
+from typing import Optional
+
+import pandas as pd
+import torch
+import torch.distributed as dist
+
+from aiter import dtypes
+from aiter.dist.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    ensure_model_parallel_initialized,
+    get_tp_group,
+    graph_capture,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+from aiter.test_common import checkAllclose, perftest
+
+logger = logging.getLogger("aiter")
+
+set_start_method("spawn", force=True)
+
+KB = 1024
+MB = 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Shared per-rank setup
+# ---------------------------------------------------------------------------
+
+
+def _setup_rank(tp_size, pp_size, rankID, distributed_init_method):
+    """Init distributed env for this rank and return (ca_comm, device, group)."""
+    device = torch.device(f"cuda:{rankID}")
+    torch.cuda.set_device(device)
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=tp_size,
+        rank=rankID,
+        distributed_init_method=distributed_init_method,
+    )
+    ensure_model_parallel_initialized(tp_size, pp_size)
+
+    ca_comm = get_tp_group().device_communicator.ca_comm
+    assert ca_comm is not None and not ca_comm.disabled, "custom allreduce unavailable"
+
+    # warmup + barrier so first-call timing isn't polluted.
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1).cuda(), group=group)
+    torch.cuda.synchronize()
+    return ca_comm, device, group
+
+
+def _teardown():
+    if dist.is_initialized():
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        torch.cuda.empty_cache()
+
+
+# ---------------------------------------------------------------------------
+# Accuracy mode
+# ---------------------------------------------------------------------------
+
+
+def accuracy_worker(
+    tp_size,
+    pp_size,
+    rankID,
+    a,
+    b,
+    distributed_init_method: Optional[str] = None,
+):
+    """Per-rank worker. Runs the fused (auto-dispatched) and unfused
+    (add + allreduce) paths, returning both outputs for comparison against the
+    CPU fp32 reference."""
+    ca_comm, device, group = _setup_rank(
+        tp_size, pp_size, rankID, distributed_init_method
+    )
+    a = a.to(device)
+    b = b.to(device)
+
+    out_fused = ca_comm.add_fused_allreduce(a, b)
+    out_unfused = ca_comm.custom_all_reduce(torch.add(a, b))
+
+    result = {
+        "out_fused": out_fused.cpu(),
+        "out_unfused": out_unfused.cpu(),
+    }
+    _teardown()
+    return result
+
+
+def run_accuracy_parallel(tp_size, pp_size, a_list, b_list, distributed_init_method):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "49373"
+    pool = Pool(processes=tp_size)
+    rets = []
+    for i in range(tp_size):
+        rets.append(
+            pool.apply_async(
+                accuracy_worker,
+                args=(
+                    tp_size,
+                    pp_size,
+                    i,
+                    a_list[i],
+                    b_list[i],
+                    distributed_init_method,
+                ),
+            )
+        )
+    pool.close()
+    pool.join()
+    return [el.get() for el in rets]
+
+
+def run_accuracy_case(label, shape, dtype, tp_size, init_method_factory):
+    # Distinct per-rank inputs so the reduction is non-trivial.
+    a_list = [torch.randn(shape, dtype=dtype) for _ in range(tp_size)]
+    b_list = [torch.randn(shape, dtype=dtype) for _ in range(tp_size)]
+
+    # Analytic fp32 reference: sum over ranks of (a_i + b_i).
+    ref = torch.zeros(shape, dtype=torch.float32)
+    for a, b in zip(a_list, b_list):
+        ref += a.float() + b.float()
+
+    rets = run_accuracy_parallel(tp_size, 1, a_list, b_list, init_method_factory())
+
+    # Compare in fp32: cast the analytic ref down to the kernel dtype and back
+    # so rounding matches, then both sides are float32.
+    ref_cast = ref.to(dtype).float()
+
+    # Worst rank bounds accuracy: track the largest mismatch ratio against the
+    # CPU fp32 reference across all ranks, for each path.
+    max_err_fused = 0.0
+    max_err_unfused = 0.0
+    for rank, r in enumerate(rets):
+        e_f = checkAllclose(
+            ref_cast,
+            r["out_fused"].float(),
+            msg=f"{label} rank{rank} fused-vs-ref",
+            rtol=ACCURACY_RTOL,
+            atol=ACCURACY_ATOL,
+        )
+        e_u = checkAllclose(
+            ref_cast,
+            r["out_unfused"].float(),
+            msg=f"{label} rank{rank} unfused-vs-ref",
+            rtol=ACCURACY_RTOL,
+            atol=ACCURACY_ATOL,
+        )
+        max_err_fused = max(max_err_fused, e_f)
+        max_err_unfused = max(max_err_unfused, e_u)
+
+    return {
+        "case": label,
+        "shape": str(tuple(shape)),
+        "dtype": str(dtype).split(".")[-1],
+        f"add_fused_allreduce_err_ratio(atol={ACCURACY_ATOL},rtol={ACCURACY_RTOL})": max_err_fused,
+        f"add+custom_all_reduce_err_ratio(atol={ACCURACY_ATOL},rtol={ACCURACY_RTOL})": max_err_unfused,
+    }
+
+
+# pack_size for bf16/fp16 = 16//2 = 8; with tp_size=8 the divisibility
+# requirement is numel % (8 * 8) == 0. All shapes below satisfy it.
+ACCURACY_CASES = [
+    ("small", (2, 7168)),
+    ("medium", (128, 8192)),
+    ("large", (512, 8192)),
+]
+
+ACCURACY_DTYPES = ["fp16", "bf16"]
+ACCURACY_TP = 8
+ACCURACY_ATOL = 1e-2
+ACCURACY_RTOL = 1e-2
+
+
+def run_accuracy():
+    """Run all accuracy cases and return a summary DataFrame."""
+    dtypes_to_run = [dtypes.d_dtypes[k] for k in ACCURACY_DTYPES]
+
+    def init_method_factory():
+        return get_distributed_init_method(get_ip(), get_open_port())
+
+    rows = []
+    for dtype in dtypes_to_run:
+        for label, shape in ACCURACY_CASES:
+            row = run_accuracy_case(
+                label, shape, dtype, ACCURACY_TP, init_method_factory
+            )
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Bench mode
+# ---------------------------------------------------------------------------
+
+ELEM_NUMS = [
+    1 * KB,
+    2 * KB,
+    4 * KB,
+    8 * KB,
+    16 * KB,
+    32 * KB,
+    64 * KB,
+    128 * KB,
+    256 * KB,
+    512 * KB,
+    1 * MB,
+    2 * MB,
+    4 * MB,
+    8 * MB,
+    16 * MB,
+    32 * MB,
+    64 * MB,
+]
+
+BENCH_COLUMNS = [
+    "eager_fused",
+    "eager_unfused",
+    "graph_fused",
+    "graph_unfused",
+]
+
+
+def elem_label(n):
+    if n % MB == 0:
+        return f"{n // MB}m"
+    return f"{n // KB}k"
+
+
+def make_shape(n):
+    if n < 8 * KB:
+        return (n,)
+    assert n % 8192 == 0, f"elem_num {n} not divisible by 8192"
+    return (n // 8192, 8192)
+
+
+def _bench_eager(fn):
+    """Return kernel latency (us) of `fn` measured in eager mode."""
+
+    @perftest(num_rotate_args=1)
+    def _run():
+        return fn()
+
+    _, us = _run()
+    return us
+
+
+def _bench_graph(fn):
+    """Capture `fn` into a cuda graph and return replay latency (us)."""
+    graph = torch.cuda.CUDAGraph()
+    with graph_capture() as gc:
+        with torch.cuda.graph(graph, stream=gc.stream):
+            fn()
+
+    @perftest(num_rotate_args=1)
+    def _replay():
+        graph.replay()
+
+    _, us = _replay()
+    del graph
+    return us
+
+
+def _safe(bench_fn, call):
+    try:
+        return bench_fn(call)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"bench failed: {e}")
+        return float("nan")
+
+
+def bench_worker(
+    tp_size,
+    pp_size,
+    rankID,
+    elem_nums,
+    dtype,
+    distributed_init_method: Optional[str] = None,
+):
+    ca_comm, device, group = _setup_rank(
+        tp_size, pp_size, rankID, distributed_init_method
+    )
+
+    results = {}
+    for n in elem_nums:
+        shape = make_shape(n)
+        a = torch.randn(shape, dtype=dtype, device=device)
+        b = torch.randn(shape, dtype=dtype, device=device)
+        out_f = torch.empty(shape, dtype=dtype, device=device)
+
+        # unfused custom_all_reduce has a size cap (bf16: <= 32M elems); skip
+        # (record NaN) when the shape doesn't fit the custom kernel.
+        unfused_ok = ca_comm.should_custom_ar(out_f)
+
+        call_fused = lambda: ca_comm.add_fused_allreduce(a, b, out=out_f)  # noqa: E731
+        call_unf = lambda: ca_comm.custom_all_reduce(torch.add(a, b))  # noqa: E731
+
+        row = {
+            "eager_fused": _safe(_bench_eager, call_fused),
+            "eager_unfused": (
+                _safe(_bench_eager, call_unf) if unfused_ok else float("nan")
+            ),
+            "graph_fused": _safe(_bench_graph, call_fused),
+            "graph_unfused": (
+                _safe(_bench_graph, call_unf) if unfused_ok else float("nan")
+            ),
+        }
+        results[n] = row
+
+        dist.barrier(group=group)
+        del a, b, out_f
+        torch.cuda.empty_cache()
+
+    _teardown()
+    return results
+
+
+def run_bench_parallel(tp_size, pp_size, elem_nums, dtype, distributed_init_method):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "49373"
+    pool = Pool(processes=tp_size)
+    rets = []
+    for i in range(tp_size):
+        rets.append(
+            pool.apply_async(
+                bench_worker,
+                args=(tp_size, pp_size, i, elem_nums, dtype, distributed_init_method),
+            )
+        )
+    pool.close()
+    pool.join()
+    return [el.get() for el in rets]
+
+
+def bench_one_tp(tp_size, dtype):
+    """Run the benchmark for a single world size and return a formatted DataFrame."""
+
+    def init_method_factory():
+        return get_distributed_init_method(get_ip(), get_open_port())
+
+    rets = run_bench_parallel(tp_size, 1, ELEM_NUMS, dtype, init_method_factory())
+
+    rows = []
+    for n in ELEM_NUMS:
+        shape = make_shape(n)
+        row = {"elem_num": elem_label(n), "shape": str(tuple(shape))}
+        for col in BENCH_COLUMNS:
+            # worst rank bounds the collective latency.
+            vals = [r[n][col] for r in rets]
+            row[col] = max(vals)
+        rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+BENCH_TP = [8, 4, 2]
+
+
+def run_bench():
+    """Run the latency sweep for every world size; return {tp_size: DataFrame}."""
+    dtype = dtypes.bf16
+    return {tp_size: bench_one_tp(tp_size, dtype) for tp_size in BENCH_TP}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    freeze_support()
+
+    accuracy_df = run_accuracy()
+    bench_dfs = run_bench()
+
+    print("\n\n########## RESULTS ##########")
+
+    print("\n=== add_fused_allreduce accuracy summary ===")
+    print(accuracy_df.to_markdown(index=False))
+
+    for tp_size, df in bench_dfs.items():
+        print(
+            f"\n=== add_fused_allreduce latency (us, max over {tp_size} ranks), dtype=bf16 ==="
+        )
+        print(df.to_markdown(index=False, floatfmt=".2f"))


### PR DESCRIPTION
## Motivation

support add_fused_allreduce

## Technical Details

include 1stage kernel and 2stage kernel, when split kernel more fast, interface will call split kernel

## Test Plan

python op_tests/multigpu_tests/test_add_fused_allreduce.py

## Test Result

########## RESULTS ##########

=== add_fused_allreduce accuracy summary ===
| case   | shape       | dtype    |   add_fused_allreduce_err_ratio(atol=0.01,rtol=0.01) |   add+custom_all_reduce_err_ratio(atol=0.01,rtol=0.01) |
|:-------|:------------|:---------|-----------------------------------------------------:|-------------------------------------------------------:|
| small  | (2, 7168)   | float16  |                                            0         |                                             0          |
| medium | (128, 8192) | float16  |                                            0         |                                             0          |
| large  | (512, 8192) | float16  |                                            0         |                                             0          |
| small  | (2, 7168)   | bfloat16 |                                            0.0127651 |                                             0.00983538 |
| medium | (128, 8192) | bfloat16 |                                            0.0134125 |                                             0.010376   |
| large  | (512, 8192) | bfloat16 |                                            0.0104482 |                                             0.0104482  |

=== add_fused_allreduce latency (us, max over 8 ranks), dtype=bf16 ===
| elem_num   | shape        |   eager_fused |   eager_unfused |   graph_fused |   graph_unfused |
|:-----------|:-------------|--------------:|----------------:|--------------:|----------------:|
| 1k         | (1024,)      |         38.27 |           43.98 |          6.78 |           15.85 |
| 2k         | (2048,)      |         38.36 |           44.39 |          6.70 |           14.85 |
| 4k         | (4096,)      |         38.96 |           44.65 |          6.79 |           14.86 |
| 8k         | (1, 8192)    |         38.62 |           45.15 |          7.08 |           14.89 |
| 16k        | (2, 8192)    |         38.86 |           44.79 |          8.37 |           15.21 |
| 32k        | (4, 8192)    |         39.31 |           45.83 |          8.25 |           17.66 |
| 64k        | (8, 8192)    |         10.10 |           47.68 |          8.95 |           14.69 |
| 128k       | (16, 8192)   |         39.47 |           45.13 |         11.47 |           16.80 |
| 256k       | (32, 8192)   |         38.96 |           44.58 |         16.07 |           19.09 |
| 512k       | (64, 8192)   |         40.32 |           46.20 |         19.98 |           23.68 |
| 1m         | (128, 8192)  |         38.81 |           45.19 |         30.44 |           32.65 |
| 2m         | (256, 8192)  |         45.98 |           59.52 |         46.20 |           48.10 |
| 4m         | (512, 8192)  |         88.07 |           88.14 |         82.12 |           79.44 |
| 8m         | (1024, 8192) |        152.17 |          152.21 |        138.94 |          139.25 |
| 16m        | (2048, 8192) |        275.15 |          275.41 |        252.53 |          252.01 |
| 32m        | (4096, 8192) |        534.07 |          537.04 |        481.90 |          481.84 |
| 64m        | (8192, 8192) |       1179.79 |          nan    |       1177.20 |          nan    |

=== add_fused_allreduce latency (us, max over 4 ranks), dtype=bf16 ===
| elem_num   | shape        |   eager_fused |   eager_unfused |   graph_fused |   graph_unfused |
|:-----------|:-------------|--------------:|----------------:|--------------:|----------------:|
| 1k         | (1024,)      |         37.67 |           45.12 |          6.00 |           14.52 |
| 2k         | (2048,)      |         37.76 |           44.49 |          6.30 |           14.59 |
| 4k         | (4096,)      |         38.42 |           45.07 |          6.31 |           14.65 |
| 8k         | (1, 8192)    |         38.36 |           45.09 |          6.62 |           14.67 |
| 16k        | (2, 8192)    |         39.40 |           45.15 |          6.89 |           15.03 |
| 32k        | (4, 8192)    |         38.33 |           45.11 |          7.73 |           15.95 |
| 64k        | (8, 8192)    |         36.06 |           45.02 |          8.67 |           18.57 |
| 128k       | (16, 8192)   |         39.66 |           44.68 |         10.52 |           15.12 |
| 256k       | (32, 8192)   |         38.90 |           45.28 |         16.74 |           19.61 |
| 512k       | (64, 8192)   |         38.67 |           45.71 |         22.02 |           28.67 |
| 1m         | (128, 8192)  |         39.24 |           49.74 |         37.36 |           43.35 |
| 2m         | (256, 8192)  |         65.76 |           79.84 |         65.48 |           71.45 |
| 4m         | (512, 8192)  |        123.65 |          140.54 |        122.82 |          120.27 |
| 8m         | (1024, 8192) |        246.98 |          247.58 |        240.39 |          235.32 |
| 16m        | (2048, 8192) |        480.89 |          480.39 |        458.89 |          460.30 |
| 32m        | (4096, 8192) |        946.80 |          945.98 |        899.84 |          900.56 |
| 64m        | (8192, 8192) |       1900.14 |          nan    |       1900.19 |          nan    |

=== add_fused_allreduce latency (us, max over 2 ranks), dtype=bf16 ===
| elem_num   | shape        |   eager_fused |   eager_unfused |   graph_fused |   graph_unfused |
|:-----------|:-------------|--------------:|----------------:|--------------:|----------------:|
| 1k         | (1024,)      |         36.91 |           40.64 |          5.83 |           13.68 |
| 2k         | (2048,)      |         20.18 |           45.30 |          5.90 |           13.02 |
| 4k         | (4096,)      |         25.47 |           36.61 |          5.84 |           13.17 |
| 8k         | (1, 8192)    |         19.15 |           34.85 |          5.94 |           13.13 |
| 16k        | (2, 8192)    |         33.33 |           46.63 |          6.23 |           13.35 |
| 32k        | (4, 8192)    |         18.00 |           25.73 |          6.81 |           13.98 |
| 64k        | (8, 8192)    |         39.52 |           39.86 |          8.72 |           15.49 |
| 128k       | (16, 8192)   |         39.82 |           46.76 |         11.74 |           18.69 |
| 256k       | (32, 8192)   |         26.97 |           46.83 |         19.12 |           24.85 |
| 512k       | (64, 8192)   |         39.67 |           46.87 |         29.92 |           36.33 |
| 1m         | (128, 8192)  |         53.46 |           67.42 |         53.07 |           59.88 |
| 2m         | (256, 8192)  |         98.54 |          118.94 |         98.26 |          107.37 |
| 4m         | (512, 8192)  |        194.82 |          205.89 |        193.96 |          199.70 |
| 8m         | (1024, 8192) |        393.54 |          392.62 |        377.14 |          377.62 |
| 16m        | (2048, 8192) |        768.04 |          768.91 |        742.68 |          742.19 |
| 32m        | (4096, 8192) |       1517.70 |         1517.87 |       1472.44 |         1472.58 |
| 64m        | (8192, 8192) |       3086.16 |          nan    |       3081.43 |          nan    |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
