### PR TITLE
[FEAT]: add support for pool indexing of hidden states tensor in gated delta rule prefill kernel

### DIFF
--- a/aiter/ops/chunk_gated_delta_rule_fwd_h.py
+++ b/aiter/ops/chunk_gated_delta_rule_fwd_h.py
@@ -194,9 +194,7 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     g: Optional[Tensor] = None,
     gk: Optional[Tensor] = None,
     initial_state: Optional[Tensor] = None,
-    initial_state_indices: Optional[Tensor] = None,
     output_final_state: bool = False,
-    inplace_final_state: Optional[bool] = None,
     chunk_size: int = 64,
     save_new_value: bool = True,
     cu_seqlens: Optional[Tensor] = None,
@@ -204,6 +202,8 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     state_dtype: Optional[torch.dtype] = None,
     use_exp2: bool = True,
     g_head_major: bool = False,
+    initial_state_indices: Optional[Tensor] = None,
+    inplace_final_state: Optional[bool] = None,
 ) -> tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
     """
     HIP hidden-state forward with h layout [V, K] (K=128, V=128, bf16), always

--- a/aiter/ops/chunk_gated_delta_rule_fwd_h.py
+++ b/aiter/ops/chunk_gated_delta_rule_fwd_h.py
@@ -98,6 +98,7 @@ def chunk_gated_delta_rule_fwd_h_hip(
     g: Tensor,
     gk: Tensor,
     initial_state: Tensor,
+    initial_state_indices: Tensor,
     cu_seqlens: Tensor,
     chunk_offsets: Tensor,
     h: Tensor,
@@ -193,7 +194,9 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     g: Optional[Tensor] = None,
     gk: Optional[Tensor] = None,
     initial_state: Optional[Tensor] = None,
+    initial_state_indices: Optional[Tensor] = None,
     output_final_state: bool = False,
+    inplace_final_state: Optional[bool] = None,
     chunk_size: int = 64,
     save_new_value: bool = True,
     cu_seqlens: Optional[Tensor] = None,
@@ -203,18 +206,23 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     g_head_major: bool = False,
 ) -> tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
     """
-    HIP hidden state forward with h layout [V, K].
-
-    Drop-in replacement for ``chunk_gated_delta_rule_fwd_h_opt_vk``
-    when K=128, V=128, bf16.
+    HIP hidden-state forward with h layout [V, K] (K=128, V=128, bf16), always
+    returning ``(h, v_new, final_state)``.
 
     w, u: [B, H, T, K/V] head-major contiguous.
-    initial_state/final_state: [N, H, V, K].
-    h snapshots: [B, NT, H, V, K].
-    v_new output: [B, H, T_flat, V].
-    `g` is expected as a 3-D tensor in token-major [B, T, H] or
-    head-major [B, H, T] layout according to `g_head_major`.
+    h snapshots: [B, NT, H, V, K]; v_new output: [B, H, T_flat, V].
+    `g` is a 3-D tensor, token-major [B, T, H] or head-major [B, H, T].
     use_exp2 selects whether cumulative gates are interpreted in log2 space.
+
+    State handling:
+      * Dense (default): ``initial_state`` is ``[N, H, V, K]`` (``slot == i_n``)
+        and ``final_state`` is a freshly allocated ``[N, H, V, K]`` tensor.
+      * Indexed pool: pass ``initial_state`` as the pool ``[pool_size, H, V, K]``
+        plus ``initial_state_indices`` ``[N]`` (int32); each sequence's slot is
+        gathered from the index array.
+      * ``inplace_final_state`` (default: ``True`` when ``initial_state_indices``
+        is given) writes the final state back into ``initial_state`` in place and
+        returns that same buffer as ``final_state`` (no extra allocation).
     """
     if chunk_size != 64:
         raise ValueError("HIP kernel requires chunk_size=64.")
@@ -229,11 +237,18 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     T_flat = w.shape[2]
     is_varlen = cu_seqlens is not None
     NT = triton.cdiv(T, chunk_size)
-    state = _prepare_state_args(
-        initial_state=initial_state,
-        state_dtype=state_dtype,
-        device=k.device,
-    )
+
+    has_indices = initial_state_indices is not None
+    inplace = has_indices if inplace_final_state is None else inplace_final_state
+    if inplace and initial_state is None:
+        raise ValueError("`inplace_final_state` requires `initial_state`.")
+    # Indexed slots address the pool, so the final state must be written back
+    # into that pool in place; a dense `[N, ...]` final_state cannot hold them.
+    if has_indices and not inplace:
+        raise ValueError(
+            "`initial_state_indices` requires in-place update; "
+            "leave `inplace_final_state` unset or set it to True."
+        )
 
     k_hip = k.contiguous()
     w_hip = w.contiguous()
@@ -297,11 +312,47 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
         if save_new_value
         else torch.empty(0, device=k.device, dtype=torch.bfloat16)
     )
-    final_state = (
-        torch.empty((N, H, V, K), device=k.device, dtype=state.tensor.dtype)
-        if output_final_state
-        else torch.empty(0, device=k.device, dtype=state.tensor.dtype)
-    )
+    # In-place mode runs directly on the caller's `initial_state` and writes the
+    # final state back into it; otherwise use the copy/cast path.
+    if inplace:
+        if initial_state.dtype not in (torch.float32, torch.bfloat16):
+            raise ValueError(
+                f"`initial_state.dtype` must be fp32 or bf16, got {initial_state.dtype}."
+            )
+        if state_dtype is not None and initial_state.dtype != state_dtype:
+            raise ValueError(
+                f"`initial_state.dtype` ({initial_state.dtype}) must match "
+                f"`state_dtype` ({state_dtype})."
+            )
+        if not initial_state.is_contiguous():
+            raise ValueError("`initial_state` must be contiguous for in-place update.")
+        state_tensor = initial_state
+        has_initial_state = True
+        resolved_state_dtype = initial_state.dtype
+    else:
+        state = _prepare_state_args(
+            initial_state=initial_state,
+            state_dtype=state_dtype,
+            device=k.device,
+        )
+        state_tensor = state.tensor
+        has_initial_state = state.has_initial_state
+        resolved_state_dtype = state_tensor.dtype
+
+    if not output_final_state:
+        final_state = torch.empty(0, device=k.device, dtype=resolved_state_dtype)
+    elif inplace:
+        final_state = state_tensor
+    else:
+        final_state = torch.empty(
+            (N, H, V, K), device=k.device, dtype=resolved_state_dtype
+        )
+
+    # No indices => dense identity mapping (slot == i_n).
+    if has_indices:
+        state_indices = initial_state_indices.to(torch.int32).contiguous()
+    else:
+        state_indices = torch.empty(0, device=k.device, dtype=torch.int32)
 
     chunk_gated_delta_rule_fwd_h_hip(
         k_hip,
@@ -309,14 +360,15 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
         u_hip,
         g_hip,
         gk_arg,
-        state.tensor,
+        state_tensor,
+        state_indices,
         cu_seqlens_int32,
         chunk_offsets_int32,
         h,
         v_new,
         final_state,
         selected_bv,
-        state.has_initial_state,
+        has_initial_state,
         output_final_state,
         save_new_value,
         use_exp2,

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
@@ -1000,6 +1000,7 @@ def chunk_gated_delta_rule_fwd_h_opt(
         "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
         "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_STATE_INDICES": lambda args: args["state_indices"] is not None,
     }
 )
 @triton.autotune(
@@ -1026,6 +1027,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
     h,
     h0,
     ht,
+    state_indices,
     cu_seqlens,
     chunk_offsets,
     T,
@@ -1042,10 +1044,17 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
     STORE_FINAL_STATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_STATE_INDICES: tl.constexpr,
     USE_EXP2: tl.constexpr = False,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
+    # Indexed pool: each sequence's state slot is gathered from `state_indices`;
+    # otherwise the slot is the dense sequence index (slot == i_n).
+    if USE_STATE_INDICES:
+        i_ss = tl.load(state_indices + i_n).to(tl.int32)
+    else:
+        i_ss = i_n
     if IS_VARLEN:
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int32),
@@ -1085,10 +1094,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
             v_new += (((i_n * H + i_h) * T_flat) * V).to(tl.int64)
     stride_h = H * V * K
     stride_k = Hg * K
+    # `i_ss * H + i_h` == `i_nh` on the dense path; the int64 cast happens before
+    # the `V * K` scale so pool offsets never overflow int32.
     if USE_INITIAL_STATE:
-        h0 = h0 + i_nh * V * K
+        h0 = h0 + (i_ss * H + i_h).to(tl.int64) * V * K
     if STORE_FINAL_STATE:
-        ht = ht + i_nh * V * K
+        ht = ht + (i_ss * H + i_h).to(tl.int64) * V * K
 
     if USE_G:
         if IS_VARLEN:
@@ -1292,6 +1303,8 @@ def chunk_gated_delta_rule_fwd_h_opt_vk(
     state_dtype: torch.dtype | None = None,
     num_decodes: int = 0,
     num_decode_tokens: int = 0,
+    initial_state_indices: torch.Tensor | None = None,
+    inplace_final_state: bool | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     """
     Optimized hidden state forward with h layout [V, K].
@@ -1308,6 +1321,16 @@ def chunk_gated_delta_rule_fwd_h_opt_vk(
     ORIGINAL cu_seqlens (data tensors are expected pre-sliced); offsets are
     rebased internally via the cached prologue helpers so the chunk-index /
     offset build stays cache-warm across forward calls.
+
+    State handling:
+      * Dense (default): ``initial_state`` is ``[N, H, V, K]`` (slot == i_n) and
+        ``final_state`` is a freshly allocated ``[N, H, V, K]`` tensor.
+      * Indexed pool: pass ``initial_state`` as the pool ``[pool_size, H, V, K]``
+        plus ``initial_state_indices`` ``[N]``; each sequence's slot is gathered
+        from the index array.
+      * ``inplace_final_state`` (default: ``True`` when ``initial_state_indices``
+        is given) writes the final state back into ``initial_state`` in place and
+        returns that same buffer as ``final_state`` (no extra allocation).
     """
     B, T, Hg, K = k.shape
     BT = chunk_size
@@ -1352,6 +1375,23 @@ def chunk_gated_delta_rule_fwd_h_opt_vk(
             f"`state_dtype` ({_state_dtype})."
         )
 
+    has_indices = initial_state_indices is not None
+    inplace = has_indices if inplace_final_state is None else inplace_final_state
+    if inplace and initial_state is None:
+        raise ValueError("`inplace_final_state` requires `initial_state`.")
+    # Indexed slots address the shared pool, so the final state must be written
+    # back into that pool in place; a dense `[N, ...]` buffer cannot hold them.
+    if has_indices and not inplace:
+        raise ValueError(
+            "`initial_state_indices` requires in-place update; "
+            "leave `inplace_final_state` unset or set it to True."
+        )
+    if inplace and not initial_state.is_contiguous():
+        raise ValueError("`initial_state` must be contiguous for in-place update.")
+    state_indices = (
+        initial_state_indices.to(torch.int32).contiguous() if has_indices else None
+    )
+
     if gk is not None:
         gk = gk.contiguous()
         if use_exp2:
@@ -1359,9 +1399,14 @@ def chunk_gated_delta_rule_fwd_h_opt_vk(
             gk = gk * RCP_LN2
 
     h = k.new_empty(B, NT, H, V, K)
-    final_state = (
-        k.new_empty(N, H, V, K, dtype=_state_dtype) if output_final_state else None
-    )
+    if not output_final_state:
+        final_state = None
+    elif inplace:
+        # Alias the caller's pool: the kernel loads h0 fully before storing ht,
+        # so writing the final state back into `initial_state` is safe.
+        final_state = initial_state
+    else:
+        final_state = k.new_empty(N, H, V, K, dtype=_state_dtype)
     v_new = k.new_empty(B, H, T_flat, V, dtype=u.dtype) if save_new_value else None
 
     def grid(meta):
@@ -1377,6 +1422,7 @@ def chunk_gated_delta_rule_fwd_h_opt_vk(
         h=h,
         h0=initial_state,
         ht=final_state,
+        state_indices=state_indices,
         cu_seqlens=kernel_cu_seqlens,
         chunk_offsets=chunk_offsets,
         T=T,

--- a/csrc/include/chunk_gated_delta_rule_fwd_h.h
+++ b/csrc/include/chunk_gated_delta_rule_fwd_h.h
@@ -15,6 +15,7 @@ void chunk_gated_delta_rule_fwd_h_hip(
     aiter_tensor_t g,
     aiter_tensor_t gk,
     aiter_tensor_t initial_state,
+    aiter_tensor_t initial_state_indices,
     aiter_tensor_t cu_seqlens,
     aiter_tensor_t chunk_offsets,
     aiter_tensor_t h,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2357,6 +2357,7 @@ namespace py = pybind11;
           py::arg("g"),                             \
           py::arg("gk"),                            \
           py::arg("initial_state"),                 \
+          py::arg("initial_state_indices"),         \
           py::arg("cu_seqlens"),                    \
           py::arg("chunk_offsets"),                 \
           py::arg("h"),                             \

--- a/csrc/kernels/chunk_gated_delta_rule_fwd_h.cu
+++ b/csrc/kernels/chunk_gated_delta_rule_fwd_h.cu
@@ -1017,10 +1017,11 @@ void chunk_gated_delta_rule_fwd_h_hip_kernel(
     const hip_bfloat16* __restrict__ u,
     const float* __restrict__ g,
     const float* __restrict__ gk,
-    const void* __restrict__ h0,
+    const void* h0,
+    const int32_t* __restrict__ initial_state_indices,
     hip_bfloat16* __restrict__ h,
     hip_bfloat16* __restrict__ v_new,
-    void* __restrict__ ht,
+    void* ht,
     const int32_t* __restrict__ cu_seqlens,
     const int32_t* __restrict__ chunk_offsets,
     int total_chunks,
@@ -1039,6 +1040,8 @@ void chunk_gated_delta_rule_fwd_h_hip_kernel(
     const int i_nh = static_cast<int>(blockIdx.y);
     const int i_n = i_nh / H;
     const int i_h = i_nh % H;
+    // Per-sequence state slot; a null index array means slot == i_n.
+    const int slot = initial_state_indices ? initial_state_indices[i_n] : i_n;
     const int tid = static_cast<int>(threadIdx.x);
     const int wave_id = tid / WAVE_SIZE;
     const int lane_id = tid % WAVE_SIZE;
@@ -1084,7 +1087,7 @@ void chunk_gated_delta_rule_fwd_h_hip_kernel(
 
     if constexpr (USE_INITIAL_STATE) {
         const void* h0_base = reinterpret_cast<const char*>(h0)
-            + (static_cast<int64_t>(i_n) * H + i_h) * V_DIM * K_DIM
+            + (static_cast<int64_t>(slot) * H + i_h) * V_DIM * K_DIM
                 * static_cast<int64_t>(STATE_BF16 ? sizeof(bf16_t) : sizeof(float));
         load_vk_hreg_from_global<BV_P, STATE_BF16>(
             h_reg, h0_base, global_v_base, v_idx, h_row_base_lo, h_row_base_hi);
@@ -1186,7 +1189,7 @@ void chunk_gated_delta_rule_fwd_h_hip_kernel(
 
     if constexpr (STORE_FINAL_STATE) {
         void* ht_base = reinterpret_cast<char*>(ht)
-            + (static_cast<int64_t>(i_n) * H + i_h) * V_DIM * K_DIM
+            + (static_cast<int64_t>(slot) * H + i_h) * V_DIM * K_DIM
                 * static_cast<int64_t>(STATE_BF16 ? sizeof(bf16_t) : sizeof(float));
         store_vk_hreg_to_global<BV_P, STATE_BF16>(
             h_reg, ht_base, global_v_base, v_idx, h_row_base_lo, h_row_base_hi);
@@ -1205,6 +1208,7 @@ void chunk_gated_delta_rule_fwd_h_hip_kernel(
         reinterpret_cast<const float*>(g.data_ptr()),                                                                                 \
         has_gk ? reinterpret_cast<const float*>(gk.data_ptr()) : nullptr,                                                            \
         has_initial_state ? initial_state.data_ptr() : nullptr,                                                                       \
+        has_initial_state_indices ? reinterpret_cast<const int32_t*>(initial_state_indices.data_ptr()) : nullptr,                     \
         reinterpret_cast<hip_bfloat16*>(h.data_ptr()),                                                                                \
         save_new_value ? reinterpret_cast<hip_bfloat16*>(v_new.data_ptr()) : nullptr,                                                 \
         output_final_state ? final_state.data_ptr() : nullptr,                                                                        \
@@ -1280,6 +1284,7 @@ void chunk_gated_delta_rule_fwd_h_hip_impl(
     aiter_tensor_t g,
     aiter_tensor_t gk,
     aiter_tensor_t initial_state,
+    aiter_tensor_t initial_state_indices,
     aiter_tensor_t cu_seqlens,
     aiter_tensor_t chunk_offsets,
     aiter_tensor_t h,
@@ -1294,6 +1299,7 @@ void chunk_gated_delta_rule_fwd_h_hip_impl(
 {
     const bool is_varlen = cu_seqlens.numel() > 0;
     const bool has_gk = gk.numel() > 0;
+    const bool has_initial_state_indices = initial_state_indices.numel() > 0;
     AITER_CHECK(k.is_gpu(), "`k` must be a CUDA/HIP tensor.");
     AITER_CHECK(w.is_gpu(), "`w` must be a CUDA/HIP tensor.");
     AITER_CHECK(u.is_gpu(), "`u` must be a CUDA/HIP tensor.");
@@ -1384,12 +1390,21 @@ void chunk_gated_delta_rule_fwd_h_hip_impl(
     if (has_initial_state) {
         AITER_CHECK(initial_state.is_gpu(), "`initial_state` must be a CUDA/HIP tensor.");
         AITER_CHECK(initial_state.dim() == 4,
-                    "`initial_state` must have shape [N, H, V, K].");
-        AITER_CHECK(initial_state.size(0) == N && initial_state.size(1) == H,
-                    "`initial_state` shape mismatch.");
+                    "`initial_state` must have shape [N, H, V, K] (dense) or [pool_size, H, V, K] (indexed).");
+        AITER_CHECK(initial_state.size(0) >= N && initial_state.size(1) == H,
+                    "`initial_state` shape mismatch; first dim must be >= N.");
         AITER_CHECK(initial_state.size(2) == V_DIM && initial_state.size(3) == K_DIM,
                     "`initial_state` shape mismatch for VK layout.");
         AITER_CHECK(initial_state.is_contiguous(), "`initial_state` must be contiguous.");
+    }
+    if (has_initial_state_indices) {
+        AITER_CHECK(initial_state_indices.is_gpu(), "`initial_state_indices` must be a CUDA/HIP tensor.");
+        AITER_CHECK(initial_state_indices.dtype() == AITER_DTYPE_i32,
+                    "`initial_state_indices` must be int32, got ",
+                    AiterDtype_to_str(initial_state_indices.dtype()));
+        AITER_CHECK(initial_state_indices.dim() == 1 && initial_state_indices.size(0) == N,
+                    "`initial_state_indices` must have shape [N].");
+        AITER_CHECK(initial_state_indices.is_contiguous(), "`initial_state_indices` must be contiguous.");
     }
     if (save_new_value) {
         AITER_CHECK(v_new.is_gpu(), "`v_new` must be a CUDA/HIP tensor.");
@@ -1406,9 +1421,9 @@ void chunk_gated_delta_rule_fwd_h_hip_impl(
         AITER_CHECK(final_state.dtype() == state_dtype,
                     "`final_state` dtype must match `initial_state`, got ",
                     AiterDtype_to_str(final_state.dtype()));
-        AITER_CHECK(final_state.dim() == 4 && final_state.size(0) == N && final_state.size(1) == H &&
+        AITER_CHECK(final_state.dim() == 4 && final_state.size(0) >= N && final_state.size(1) == H &&
                         final_state.size(2) == V_DIM && final_state.size(3) == K_DIM,
-                    "`final_state` shape mismatch; expected [N, H, V, K].");
+                    "`final_state` shape mismatch; expected [>=N, H, V, K].");
         AITER_CHECK(final_state.is_contiguous(), "`final_state` must be contiguous.");
     }
 
@@ -1448,6 +1463,7 @@ void chunk_gated_delta_rule_fwd_h_hip(
     aiter_tensor_t g,
     aiter_tensor_t gk,
     aiter_tensor_t initial_state,
+    aiter_tensor_t initial_state_indices,
     aiter_tensor_t cu_seqlens,
     aiter_tensor_t chunk_offsets,
     aiter_tensor_t h,
@@ -1461,7 +1477,7 @@ void chunk_gated_delta_rule_fwd_h_hip(
     bool g_head_major)
 {
     chunk_gated_delta_rule_fwd_h_hip_impl(
-        k, w, u, g, gk, initial_state, cu_seqlens, chunk_offsets, h, v_new, final_state,
+        k, w, u, g, gk, initial_state, initial_state_indices, cu_seqlens, chunk_offsets, h, v_new, final_state,
         selected_bv, has_initial_state, output_final_state, save_new_value, use_exp2, g_head_major);
 }
 

--- a/op_tests/test_gated_delta_rule.py
+++ b/op_tests/test_gated_delta_rule.py
@@ -16,6 +16,9 @@ from aiter.ops.triton.gated_delta_net import (
     chunk_gated_delta_rule_opt,
     chunk_gated_delta_rule_opt_vk,
 )
+from aiter.ops.chunk_gated_delta_rule_fwd_h import (
+    chunk_gated_delta_rule_fwd_h_hip_fn,
+)
 from aiter.ops.triton._triton_kernels.gated_delta_rule.decode.fused_sigmoid_gating_recurrent import (
     fused_sigmoid_gating_delta_rule_update,
 )
@@ -934,6 +937,126 @@ def test_chunk_opt_varlen_hip(
     assert tri_ht.dtype == state_dtype
     assert_close("o", ref.float(), tri.float(), tol)
     assert_close("ht", ref_ht.float(), tri_ht.transpose(-1, -2).float(), tol)
+
+
+@pytest.mark.parametrize(
+    ("H", "D", "mask_p", "cu_seqlens"),
+    [
+        pytest.param(*test, id="hip-indice-H{}-D{}-mask_p{}-cu_seqlens{}".format(*test))
+        for test in [
+            (4, 128, 0, [0, 15]),
+            (4, 128, 0, [0, 256, 500, 1000]),
+            (4, 128, 0.5, [0, 256, 500, 1000]),
+            (4, 128, 0, [0, 15, 100, 300, 1200, 2000]),
+        ]
+    ],
+)
+@pytest.mark.parametrize(
+    "state_dtype",
+    [
+        pytest.param(torch.float32, id="state_fp32"),
+        pytest.param(torch.bfloat16, id="state_bf16"),
+    ],
+)
+@pytest.mark.skipif(
+    os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
+    reason="Skipping test_chunk_opt_vk_indice_hip because SKIP_TEST_CHUNK_VARLEN is set",
+)
+@pytest.mark.skipif(not IS_AMD, reason="Skipping HIP-only test on non-AMD backend")
+@pytest.mark.skipif(
+    _is_gfx12_runtime(),
+    reason="chunk_gated_delta_rule_fwd_h_hip_fn kernel does not support gfx12!",
+)
+def test_chunk_opt_vk_indice_hip(
+    H: int,
+    D: int,
+    mask_p: float,
+    cu_seqlens: list[int],
+    state_dtype: torch.dtype,
+):
+    """Functional test for the indexed state-pool HIP fwd_h.
+
+    Both paths go through the single ``chunk_gated_delta_rule_fwd_h_hip_fn`` and
+    the same kernel; the only differences are the per-sequence slot gather
+    (``initial_state_indices``) on read and the in-place write-back into that
+    slot. So when the pool holds the same initial states at (scattered) slots,
+    dense vs indexed must be bit-identical, and non-indexed pool slots must stay
+    untouched.
+    """
+    if D != 128:
+        pytest.skip(reason="HIP kernel requires D=128 and bfloat16")
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
+    T = int(cu_seqlens[-1])
+    N = len(cu_seqlens) - 1
+    B = 1
+
+    # fwd_h-stage inputs (layout unchanged): k [B,T,Hg,K] token-major,
+    # w/u [B,H,T,K|V] head-major, g [B,T,H] token-major. Hg == H (no GQA).
+    k = torch.randn(B, T, H, D, dtype=torch.bfloat16, device=device)
+    w = torch.randn(B, H, T, D, dtype=torch.bfloat16, device=device)
+    u = torch.randn(B, H, T, D, dtype=torch.bfloat16, device=device)
+    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32, device=device))
+    g = g * (torch.rand_like(g) > mask_p)
+
+    # Dense per-sequence initial states [N, H, V, K] (random, so the gather is
+    # actually exercised -- a wrong slot would read different values).
+    h0 = torch.randn(N, H, D, D, dtype=state_dtype, device=device)
+
+    # --- dense reference: slot == i_n ---
+    h_ref, vnew_ref, ht_ref = chunk_gated_delta_rule_fwd_h_hip_fn(
+        k=k.clone(),
+        w=w.clone(),
+        u=u.clone(),
+        g=g.clone(),
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        state_dtype=state_dtype,
+        g_head_major=False,
+    )
+
+    # --- indexed pool: scatter the N states into a larger pool at unique,
+    # non-identity slots to prove the gather honours initial_state_indices ---
+    pool_size = N + 7
+    perm = torch.randperm(pool_size, device=device)
+    indices = perm[:N].to(torch.int32)
+    pool = torch.randn(pool_size, H, D, D, dtype=state_dtype, device=device)
+    pool_before = pool.clone()
+    pool[indices.long()] = h0.clone()
+
+    # Indexed pool path via the unified entry: passing initial_state_indices
+    # switches to slot gather + in-place write-back (final_state aliases pool).
+    h_idx, vnew_idx, ht_idx = chunk_gated_delta_rule_fwd_h_hip_fn(
+        k=k.clone(),
+        w=w.clone(),
+        u=u.clone(),
+        g=g.clone(),
+        initial_state=pool,
+        initial_state_indices=indices,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        g_head_major=False,
+    )
+    assert ht_idx is pool  # in-place: final state aliases the pool buffer
+
+    # 1. snapshots + recomputed values are bit-identical to the dense path
+    assert torch.equal(h_idx, h_ref), "h snapshots differ between dense and indexed"
+    assert torch.equal(vnew_idx, vnew_ref), "v_new differs between dense and indexed"
+
+    # 2. in-place write-back: the final state landed in the indexed pool slots
+    # and equals the dense final state
+    assert torch.equal(
+        pool[indices.long()], ht_ref
+    ), "in-place final state at indexed slots differs from dense final_state"
+
+    # 3. non-indexed pool slots must be left exactly as they were
+    untouched = torch.ones(pool_size, dtype=torch.bool, device=device)
+    untouched[indices.long()] = False
+    assert torch.equal(
+        pool[untouched], pool_before[untouched]
+    ), "non-indexed pool slots were modified by the kernel"
 
 
 @pytest.mark.parametrize(

--- a/op_tests/test_gated_delta_rule.py
+++ b/op_tests/test_gated_delta_rule.py
@@ -19,6 +19,9 @@ from aiter.ops.triton.gated_delta_net import (
 from aiter.ops.chunk_gated_delta_rule_fwd_h import (
     chunk_gated_delta_rule_fwd_h_hip_fn,
 )
+from aiter.ops.triton._triton_kernels.gated_delta_rule.prefill import (
+    chunk_gated_delta_rule_fwd_h_opt_vk,
+)
 from aiter.ops.triton._triton_kernels.gated_delta_rule.decode.fused_sigmoid_gating_recurrent import (
     fused_sigmoid_gating_delta_rule_update,
 )
@@ -940,9 +943,28 @@ def test_chunk_opt_varlen_hip(
 
 
 @pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("triton", id="triton"),
+        pytest.param(
+            "hip",
+            id="hip",
+            marks=[
+                pytest.mark.skipif(
+                    not IS_AMD, reason="HIP backend requires an AMD device"
+                ),
+                pytest.mark.skipif(
+                    _is_gfx12_runtime(),
+                    reason="chunk_gated_delta_rule_fwd_h_hip_fn does not support gfx12!",
+                ),
+            ],
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     ("H", "D", "mask_p", "cu_seqlens"),
     [
-        pytest.param(*test, id="hip-indice-H{}-D{}-mask_p{}-cu_seqlens{}".format(*test))
+        pytest.param(*test, id="indice-H{}-D{}-mask_p{}-cu_seqlens{}".format(*test))
         for test in [
             (4, 128, 0, [0, 15]),
             (4, 128, 0, [0, 256, 500, 1000]),
@@ -960,31 +982,37 @@ def test_chunk_opt_varlen_hip(
 )
 @pytest.mark.skipif(
     os.getenv("SKIP_TEST_CHUNK_VARLEN") == "1",
-    reason="Skipping test_chunk_opt_vk_indice_hip because SKIP_TEST_CHUNK_VARLEN is set",
+    reason="Skipping test_chunk_opt_vk_indice because SKIP_TEST_CHUNK_VARLEN is set",
 )
-@pytest.mark.skipif(not IS_AMD, reason="Skipping HIP-only test on non-AMD backend")
-@pytest.mark.skipif(
-    _is_gfx12_runtime(),
-    reason="chunk_gated_delta_rule_fwd_h_hip_fn kernel does not support gfx12!",
-)
-def test_chunk_opt_vk_indice_hip(
+def test_chunk_opt_vk_indice(
+    backend: str,
     H: int,
     D: int,
     mask_p: float,
     cu_seqlens: list[int],
     state_dtype: torch.dtype,
 ):
-    """Functional test for the indexed state-pool HIP fwd_h.
+    """Functional test for the indexed state-pool fwd_h on both backends.
 
-    Both paths go through the single ``chunk_gated_delta_rule_fwd_h_hip_fn`` and
-    the same kernel; the only differences are the per-sequence slot gather
-    (``initial_state_indices``) on read and the in-place write-back into that
-    slot. So when the pool holds the same initial states at (scattered) slots,
-    dense vs indexed must be bit-identical, and non-indexed pool slots must stay
-    untouched.
+    The Triton (``chunk_gated_delta_rule_fwd_h_opt_vk``) and HIP
+    (``chunk_gated_delta_rule_fwd_h_hip_fn``) entries share the same dense/indexed
+    contract: the only differences from the dense path are the per-sequence slot
+    gather (``initial_state_indices``) on read and the in-place write-back into
+    that slot. So when the pool holds the same initial states at (scattered)
+    slots, dense vs indexed must be bit-identical, and non-indexed pool slots must
+    stay untouched. The check is a same-backend self-comparison, so it does not
+    depend on the gate layout being interpreted a particular way.
     """
-    if D != 128:
-        pytest.skip(reason="HIP kernel requires D=128 and bfloat16")
+    if backend == "hip":
+        fwd_h = chunk_gated_delta_rule_fwd_h_hip_fn
+        # HIP kernel is specialized for D=128 / bf16 and reads head-major gates.
+        if D != 128:
+            pytest.skip(reason="HIP kernel requires D=128 and bfloat16")
+        extra_kwargs = {"g_head_major": True}
+    else:
+        fwd_h = chunk_gated_delta_rule_fwd_h_opt_vk
+        extra_kwargs = {}
+
     torch.manual_seed(42)
     os.environ["TRITON_F32_DEFAULT"] = "ieee"
     cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
@@ -992,12 +1020,12 @@ def test_chunk_opt_vk_indice_hip(
     N = len(cu_seqlens) - 1
     B = 1
 
-    # fwd_h-stage inputs (layout unchanged): k [B,T,Hg,K] token-major,
-    # w/u [B,H,T,K|V] head-major, g [B,T,H] token-major. Hg == H (no GQA).
+    # fwd_h-stage inputs: k [B,T,H,K] token-major, w/u [B,H,T,K|V] head-major,
+    # g head-major [B,H,T]. Hg == H (no GQA).
     k = torch.randn(B, T, H, D, dtype=torch.bfloat16, device=device)
     w = torch.randn(B, H, T, D, dtype=torch.bfloat16, device=device)
     u = torch.randn(B, H, T, D, dtype=torch.bfloat16, device=device)
-    g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32, device=device))
+    g = F.logsigmoid(torch.rand(B, H, T, dtype=torch.float32, device=device))
     g = g * (torch.rand_like(g) > mask_p)
 
     # Dense per-sequence initial states [N, H, V, K] (random, so the gather is
@@ -1005,7 +1033,7 @@ def test_chunk_opt_vk_indice_hip(
     h0 = torch.randn(N, H, D, D, dtype=state_dtype, device=device)
 
     # --- dense reference: slot == i_n ---
-    h_ref, vnew_ref, ht_ref = chunk_gated_delta_rule_fwd_h_hip_fn(
+    h_ref, vnew_ref, ht_ref = fwd_h(
         k=k.clone(),
         w=w.clone(),
         u=u.clone(),
@@ -1014,7 +1042,7 @@ def test_chunk_opt_vk_indice_hip(
         output_final_state=True,
         cu_seqlens=cu_seqlens,
         state_dtype=state_dtype,
-        g_head_major=False,
+        **extra_kwargs,
     )
 
     # --- indexed pool: scatter the N states into a larger pool at unique,
@@ -1026,9 +1054,9 @@ def test_chunk_opt_vk_indice_hip(
     pool_before = pool.clone()
     pool[indices.long()] = h0.clone()
 
-    # Indexed pool path via the unified entry: passing initial_state_indices
-    # switches to slot gather + in-place write-back (final_state aliases pool).
-    h_idx, vnew_idx, ht_idx = chunk_gated_delta_rule_fwd_h_hip_fn(
+    # Indexed pool path: passing initial_state_indices switches to slot gather +
+    # in-place write-back (final_state aliases pool).
+    h_idx, vnew_idx, ht_idx = fwd_h(
         k=k.clone(),
         w=w.clone(),
         u=u.clone(),
@@ -1037,7 +1065,8 @@ def test_chunk_opt_vk_indice_hip(
         initial_state_indices=indices,
         output_final_state=True,
         cu_seqlens=cu_seqlens,
-        g_head_major=False,
+        state_dtype=state_dtype,
+        **extra_kwargs,
     )
     assert ht_idx is pool  # in-place: final state aliases the pool buffer
 


### PR DESCRIPTION
# Support indexed state pool for gated-delta-rule fwd_h (Triton + HIP)

## Summary

`chunk_gated_delta_rule_fwd_h` (the K5 hidden-state stage) previously assumed the
recurrent state is densely packed in batch order: `initial_state`/`final_state`
are `[N, H, V, K]` and the per-sequence slot is the program's sequence id
(`slot == i_n`).

sglang's mainline GDN backend instead keeps the state in a shared **pool**
`ssm_states [pool_size, H, V, K]` and passes a `cache_indices [N]` indirection,
updating each sequence's slot **in place**. To feed aiter's kernel it had to
gather the pool into a dense `[N, ...]` copy before the call and scatter the
result back afterwards — and because decode / prefix-cache also read that pool,
this gather+scatter can eat the kernel's benefit.

This PR teaches **both** the Triton and HIP `fwd_h` implementations to consume the
pool directly, matching sglang semantics and removing the gather/scatter round-trip:

- optional `initial_state_indices [N]`: per-sequence slot is gathered as
  `slot = initial_state_indices[i_n]` (dense path unchanged: `slot == i_n`);
- optional `inplace_final_state`: writes the final state back into
  `initial_state` in place and returns that same buffer as `final_state`
  (no extra allocation). Defaults to `True` when `initial_state_indices` is given.

## What changed

### HIP backend (`csrc/…/chunk_gated_delta_rule_fwd_h.cu`, headers, `aiter/ops/chunk_gated_delta_rule_fwd_h.py`)
- Kernel gains an `initial_state_indices` pointer; computes `slot` once per block
  (scalar, broadcast — no hot-loop cost) and uses it as the base for both the
  initial-state read and the final-state write.
- Dropped `__restrict__` on `h0`/`ht` so the in-place case (where `ht` aliases the
  `h0` pool) is well-defined; the kernel loads the initial state fully into
  registers before the final store, so the aliasing is safe.
- `size(0) == N` relaxed to `>= N` so a larger pool is accepted.
- Python wrapper `chunk_gated_delta_rule_fwd_h_hip_fn` gains `initial_state_indices`
  / `inplace_final_state` (appended at the end of the signature — see
  "Backward compatibility"), with validation and in-place pool aliasing.
- pybind (`rocm_ops.hpp`) + `@compile_ops` stub updated with the new argument.

### Triton backend (`aiter/ops/triton/.../prefill/chunk_delta_h.py`)
- Kernel `chunk_gated_delta_rule_fwd_kernel_h_opt_vk` gains a `state_indices`
  arg + `USE_STATE_INDICES` heuristic; gathers `slot` and uses
  `(slot*H + i_h)` as the `h0`/`ht` base. The int64 cast is applied before the
  `V*K` scale so large pool offsets never overflow int32 (this also hardens the
  dense path). Dense path is numerically identical (`slot == i_n → i_nh`).
- Wrapper `chunk_gated_delta_rule_fwd_h_opt_vk` gains `initial_state_indices`
  / `inplace_final_state` with the same contract and validation as HIP; in-place
  aliases the caller's pool as `final_state`.

### Tests (`op_tests/test_gated_delta_rule.py`)
- New `test_chunk_opt_vk_indice`, parametrized over **backend ∈ {triton, hip}**,
  `state_dtype ∈ {fp32, bf16}`, and 4 varlen `cu_seqlens` layouts. It scatters the
  N states into a larger pool at random non-identity slots and asserts, per
  backend, that:
  1. `h` snapshots and recomputed `v_new` are **bit-identical** to the dense path;
  2. the in-place final state landed at the indexed pool slots and equals the
     dense `final_state` (and `final_state is pool`);
  3. non-indexed pool slots are left untouched.

## Backward compatibility

- Both public entries keep the new params **at the end of the signature** with
  default `None`, so existing positional and keyword callers are unaffected.
- With `initial_state_indices=None` the behavior is the original dense path,
  bit-for-bit (verified by the dense-vs-indexed equality test and the existing
  `test_chunk_opt_vk` / `_varlen` tests).
- Triton's `chunk_gated_delta_rule_fwd_h_opt_vk` and HIP's
  `chunk_gated_delta_rule_fwd_h_hip_fn` are peer implementations selected upstream
  by `use_chunk_hip`; both now expose the same-named parameters. (Threading the
  indices through the high-level `chunk.py` dispatch is intentionally left out of
  this PR.)

## Performance

Main-kernel GPU time via `rocprofv3 --kernel-trace` on an idle GPU
(throughput = 1/time), shapes taken from the three reference suites
(dense / varlen / online), varlen B=1, D=128, H=16, bf16. Comparing indexing
**on vs off** (geomean of per-case throughput ratio, `indice / dense`, over 36
cases per backend):

| backend | indice / dense | idx_identity / dense | dense_inplace / dense | per-case range |
|---|---|---|---|---|
| Triton  | 0.999x | 0.999x | 1.003x | 0.955–1.041 |
| HIP     | 0.991x | 0.991x | 0.992x | 0.952–1.037 |

Indexing has **no measurable impact** on either backend: all geomeans sit at
0.99–1.00x, within the ±1–2% noise band (the index-free `dense_inplace/dense`
column shows the same spread). Even the worst-locality case — a large pool with
randomly scattered slots — shows no systematic slowdown, because the state
gather/scatter happens once per (sequence, head) block while the kernel cost is
dominated by the per-token chunk-scan matmuls. Combined with dropping the
external gather+scatter, total prefill memory traffic is a net decrease.

## Test plan

- [x] `pytest op_tests/test_gated_delta_rule.py::test_chunk_opt_vk_indice`
      (16 cases: triton + hip × fp32/bf16 × 4 varlen layouts) — all pass on gfx950.
- [x] Existing dense coverage `test_chunk_opt_vk`, `test_chunk_opt_vk_varlen`
      unaffected.