### PR TITLE
Tune & include fuse-aware gfx950 fused GEMM A8W8 blockscale mul_add

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
@@ -3,7 +3,8 @@
 
 import triton
 import triton.language as tl
-import aiter.ops.triton.utils._triton.arch_info as arch_info
+
+from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid
 from aiter.ops.triton.utils.gemm_config_utils import get_gemm_config

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
@@ -345,7 +345,7 @@ def _get_config(
     # On gfx950 the dedicated FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD family recovers
     # this op's large-M regression (M > 512 -> the "any" bucket) with a fast
     # 64x64 tile. That same tile is numerically correct for fuse_type=0 (a*Y + b) but
-    # is miscompiled by Triton 3.8 for fuse_type=1 (a*b + Y) (fails correctness), so 
+    # is miscompiled by Triton 3.8 for fuse_type=1 (a*b + Y) (fails correctness), so
     # fuse_type=1 must fall back to the base GEMM-A8W8_BLOCKSCALE config (128x128), which is
     # correct. fuse_type=1 therefore does not get the large-M speedup.
     if arch_info.get_arch() == "gfx950" and fuse_type == 0:

--- a/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
@@ -3,7 +3,7 @@
 
 import triton
 import triton.language as tl
-
+import aiter.ops.triton.utils._triton.arch_info as arch_info
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid
 from aiter.ops.triton.utils.gemm_config_utils import get_gemm_config
@@ -340,6 +340,15 @@ def _get_config(
     M: int,
     N: int,
     K: int,
+    fuse_type: int = 0,
 ):
-
+    # On gfx950 the dedicated FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD family recovers
+    # this op's large-M regression (M > 512 -> the "any" bucket) with a fast
+    # 64x64 tile. That same tile is numerically correct for fuse_type=0 (a*Y + b) but
+    # is miscompiled by Triton 3.8 for fuse_type=1 (a*b + Y) (fails correctness), so 
+    # fuse_type=1 must fall back to the base GEMM-A8W8_BLOCKSCALE config (128x128), which is
+    # correct. fuse_type=1 therefore does not get the large-M speedup.
+    if arch_info.get_arch() == "gfx950" and fuse_type == 0:
+        return get_gemm_config("FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD", M, N, K)
+    # fuse_type=1 on gfx950 (64x64 miscompiles) and all other arches use the base.
     return get_gemm_config("GEMM-A8W8_BLOCKSCALE", M, N, K)

--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD-N=7168-K=256.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD-N=7168-K=256.json
@@ -1,0 +1,98 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 4,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 1,
+    "num_stages": 3,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 16,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 1,
+    "num_stages": 3,
+    "waves_per_eu": 6,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 4,
+    "num_stages": 3,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 8,
+    "num_warps": 1,
+    "num_stages": 3,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 1,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD.json
@@ -1,0 +1,14 @@
+{
+  "any": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/aiter/ops/triton/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
+++ b/aiter/ops/triton/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
@@ -127,7 +127,9 @@ def fused_gemm_a8w8_blockscale_mul_add(
         y = torch.empty((M, N), dtype=dtype, device=x.device)
 
     if config is None:
-        config, _ = _get_config(M, N, K)
+        # fuse_type is passed so gfx950 can route fuse_type=1 to the base config
+        # (the dedicated fast 64x64 tile is miscompiled for fuse_type=1 on Triton 3.8).
+        config, _ = _get_config(M, N, K, fuse_type)
 
     config["SPLITK_BLOCK_SIZE"] = triton.cdiv(
         K, config["NUM_KSPLIT"]


### PR DESCRIPTION
## Motivation

This PR adds gfx950-specific tuning for `fused_gemm_a8w8_blockscale_mul_add`.

The goal is to recover golden-vs-TOT performance regressions for the fused A8W8 blockscale + mul/add path, specifically for the benchmark shape family:

- `N = 7168`
- `K = 256`
- `M ∈ {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 4096}`

During validation, the initial gfx950 config reroute improved the `fuse_type=0` path but exposed correctness failures for `fuse_type=1`. The failing cases were caused by routing `fuse_type=1` through the same fast `64x64` fused config tile used by `fuse_type=0`.

The fix in this PR keeps the `fuse_type=0` performance path while preserving `fuse_type=1` correctness.

## Technical Details

This PR updates `fused_gemm_a8w8_blockscale_mul_add` routing and adds gfx950 config files.

Changes:

1. Implements the `arch_info` import in:

```text
aiter/ops/triton/_triton_kernels/gemm/fused/fused_gemm_a8w8_blockscale_mul_add.py
```

2. Makes `_get_config` fuse-type-aware.

For gfx950:

- `fuse_type == 0`
  - uses the new fused-specific config key:
    ```text
    FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD
    ```
  - this keeps the fast `64x64` path for the performance-sensitive fused mul/add benchmark path.

- `fuse_type == 1`
  - falls back to the existing base config:
    ```text
    GEMM-A8W8_BLOCKSCALE
    ```
  - this avoids the Triton 3.8 correctness issue observed when `fuse_type=1` is forced onto the fused `64x64` tile.

3. Updates the wrapper to pass `fuse_type` into `_get_config`.

The public wrapper signature is unchanged otherwise.

4. Adds gfx950 config files:

```text
aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD.json
aiter/ops/triton/configs/gemm/gfx950-FUSED-GEMM-A8W8_BLOCKSCALE-MUL_ADD-N=7168-K=256.json
```

The `N=7168, K=256` config contains the tuned buckets used by the benchmark shape family. The `M_LEQ_128` bucket was updated from the original TOT values to the `num_stages=2, waves_per_eu=1` setting, which solved the M=128 regression.

No shared `GEMM-A8W8_BLOCKSCALE` base config is modified.

### Why `fuse_type=1` uses the safe fallback

The fast fused `64x64` tile is correct for `fuse_type=0`, but it is not correctness-safe for `fuse_type=1` on Triton 3.8. Forcing the same tile through `config=` reproduces the issue, which points to a Triton 3.8 compiler/codegen issue on that specific tile/fuse-type combination.

Observed escape hatches:

- `64x64 + fuse_type=0` is correct and fast.
- `64x64 + fuse_type=1` miscompiles on Triton 3.8.
- `128x128 + fuse_type=1` is correct.

Therefore this PR routes:

```text
fuse_type=0 -> fast fused gfx950 config
fuse_type=1 -> safe base config
```

This preserves correctness for all tested fuse types while keeping the performance win for the tuned path.

## Test Plan

Rebuilt AITER against the active system Triton:
```bash
# use flag to avoid overlapping triton versions
AITER_USE_SYSTEM_TRITON=1 python setup.py develop
```

Cleared runtime caches:
```bash
rm -rf ~/.triton/cache ~/.cache/triton /workspace/.triton
```

Ran the full fused GEMM correctness test:
```bash
pytest op_tests/triton_tests/gemm/fused/test_fused_gemm_a8w8_blockscale_mul_add.py -v
```

Basic smoke test with `do_bench` to ensure compilation with numbers:
```bash
python op_tests/op_benchmarks/triton/bench_fused_gemm_a8w8_blockscale_mul_add.py --metric time
```

Ran **rocprofv3**-based golden-vs-TOT performance comparison for `fuse_type=0` and `fuse_type=1` across the full M sweep.

The performance comparison uses an updated existing trimmed-mean rocprof methodology that helps stabilize the variations between runs and provides a reliable single-value average number.

Regression rule:

```text
threshold_us = 1.005 * golden_us + 0.5
```

A shape is marked as a regression when:

```text
tot_us > threshold_us
```

Small shapes where golden is below the small-kernel cutoff are marked `below_threshold`.

## Test Result

### Correctness

```text
640 passed in 8.80s
```

The pytest run covers both `fuse_type=0` and `fuse_type=1` correctness at the tested shapes:

```text
M ∈ {2, 4, 8, 16, 1024}
```

This PR does not claim exhaustive `fuse_type=1` correctness coverage for every M bucket. It's good to note that `M=256` and `M=512` are not part of the pytest shape set, but have been included in the testing for performance comparison. Their base-config behavior is pre-existing and unchanged by this PR.

### fuse_type=0 rocprofv3 sweep

| kernel | M | N | K | golden_runs_us | tot_runs_us | golden_us_avg | tot_us_avg | delta_us | delta_% | threshold_us | status |
|---|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---|
| fused_gemm_a8w8_blockscale_mul_add | 2 | 7168 | 256 | 3.800; 3.800; 3.812 | 3.924; 3.899; 3.924 | 3.800 | 3.924 | 0.124 | 3.3 | 4.319 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 4 | 7168 | 256 | 3.858; 3.865; 3.823 | 3.938; 3.923; 3.955 | 3.858 | 3.938 | 0.080 | 2.1 | 4.377 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 8 | 7168 | 256 | 3.834; 3.855; 3.890 | 4.110; 4.129; 4.099 | 3.855 | 4.110 | 0.255 | 6.6 | 4.374 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 16 | 7168 | 256 | 3.919; 3.894; 3.864 | 3.735; 3.761; 3.726 | 3.894 | 3.735 | -0.159 | -4.1 | 4.413 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 32 | 7168 | 256 | 4.385; 4.379; 4.364 | 4.059; 4.029; 4.042 | 4.379 | 4.042 | -0.337 | -7.7 | 4.901 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 64 | 7168 | 256 | 4.577; 4.613; 4.611 | 4.653; 4.659; 4.655 | 4.611 | 4.655 | 0.044 | 1.0 | 5.134 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 128 | 7168 | 256 | 5.710; 6.021; 5.701 | 5.441; 5.420; 5.551 | 5.710 | 5.441 | -0.269 | -4.7 | 6.239 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 256 | 7168 | 256 | 7.384; 7.328; 7.398 | 7.094; 7.069; 7.059 | 7.384 | 7.069 | -0.315 | -4.3 | 7.921 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 512 | 7168 | 256 | 10.496; 10.981; 10.963 | 8.696; 8.565; 8.691 | 10.963 | 8.691 | -2.272 | -20.7 | 11.518 | improvement |
| fused_gemm_a8w8_blockscale_mul_add | 1024 | 7168 | 256 | 15.975; 16.030; 15.948 | 16.452; 16.345; 16.606 | 15.975 | 16.452 | 0.477 | 3.0 | 16.555 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 4096 | 7168 | 256 | 47.830; 48.273; 48.142 | 53.014; 52.757; 53.393 | 48.142 | 53.014 | 4.872 | 10.1 | 48.883 | regression |

Summary:

```text
fuse_type=0 regressions before this patch: [128, 1024, 4096]
fuse_type=0 regressions after this patch:  [4096]
fuse_type=1: unchanged by this PR; it stays on the base config. See fuse_type=1 note below.
```

The M=128 regression is fixed:

```text
M=128: +16.1% regression -> -4.7% ok
```

M=1024 is now under the regression threshold in the final sweep:

```text
M=1024: +3.0%, threshold 16.555 us, TOT 16.452 us -> ok
```

M=1024 is borderline and can flip depending on golden-side timing variance. In runs where the golden compiler clocks faster, the threshold tightens and M=1024 can cross it. TOT stayed around ~16.3–16.6 us across runs; the classification depends on the golden reference run.

M=4096 remains a known deferred residual:

```text
M=4096: +10.1%, regression
```

This case uses the same `64x64` tile shape as golden, but remains slower on Triton 3.8 than Triton 3.4. This looks like a Triton compiler/codegen performance residual rather than a missing AITER config. It should be handled in a follow-up compiler perf bisect or a separate any-bucket tuning pass.

### fuse_type=0 borderline snapshot

This run shows the M=1024 borderline behavior. TOT remains in the ~16.3 us band, but golden clocks faster in this run, tightening the threshold and causing M=1024 to classify as a regression.

| kernel | M | N | K | golden_runs_us | tot_runs_us | golden_us_avg | tot_us_avg | delta_us | delta_% | threshold_us | status |
|---|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---|
| fused_gemm_a8w8_blockscale_mul_add | 2 | 7168 | 256 | 3.794; 3.795; 3.781 | 3.875; 3.868; 3.903 | 3.794 | 3.875 | 0.081 | 2.1 | 4.313 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 4 | 7168 | 256 | 3.800; 3.820; 3.798 | 3.876; 3.891; 3.883 | 3.800 | 3.883 | 0.083 | 2.2 | 4.319 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 8 | 7168 | 256 | 3.805; 3.808; 3.831 | 4.050; 4.090; 4.079 | 3.808 | 4.079 | 0.271 | 7.1 | 4.327 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 16 | 7168 | 256 | 3.845; 3.849; 3.848 | 3.689; 3.680; 3.680 | 3.848 | 3.680 | -0.168 | -4.4 | 4.367 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 32 | 7168 | 256 | 4.301; 4.318; 4.294 | 3.984; 3.997; 3.992 | 4.301 | 3.992 | -0.309 | -7.2 | 4.823 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 64 | 7168 | 256 | 4.562; 4.574; 4.553 | 4.596; 4.604; 4.604 | 4.562 | 4.604 | 0.042 | 0.9 | 5.085 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 128 | 7168 | 256 | 5.631; 5.649; 5.608 | 5.362; 5.347; 5.387 | 5.631 | 5.362 | -0.269 | -4.8 | 6.159 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 256 | 7168 | 256 | 7.263; 7.231; 7.216 | 6.944; 6.938; 6.978 | 7.231 | 6.944 | -0.287 | -4.0 | 7.767 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 512 | 7168 | 256 | 10.776; 10.613; 10.954 | 8.314; 8.442; 8.184 | 10.776 | 8.314 | -2.462 | -22.8 | 11.330 | improvement |
| fused_gemm_a8w8_blockscale_mul_add | 1024 | 7168 | 256 | 15.697; 15.358; 15.344 | 16.246; 16.275; 16.304 | 15.358 | 16.275 | 0.917 | 6.0 | 15.935 | regression |
| fused_gemm_a8w8_blockscale_mul_add | 4096 | 7168 | 256 | 45.790; 47.434; 48.188 | 51.927; 51.265; 51.411 | 47.434 | 51.411 | 3.977 | 8.4 | 48.171 | regression |

### fuse_type=1 sweep note

The following `fuse_type=1` sweep is included only to document the current state of the safe fallback path. These regressions are **pre-existing** and by design, not introduced by this PR.

Both before and after this change, `fuse_type=1` routes to the base `GEMM-A8W8_BLOCKSCALE` config. The golden-vs-TOT gap comes from the base config itself differing per environment:

- Golden's base `any` bucket uses the fast `64x64` tile, which is correct on Triton 3.4.
- TOT's base `any` bucket uses the safe `128x128` tile.
- TOT cannot use the fast `64x64` tile for `fuse_type=1` because that tile **miscompiles** on Triton 3.8 for the problematic operand combinations.

Therefore this PR does not change `fuse_type=1` routing or performance. It restores correctness by keeping `fuse_type=1` on the safe path. The `fuse_type=1` performance gap should close only after the Triton compiler issue is fixed or after a separate `fuse_type=1`-specific tuning pass finds a correctness-safe faster tile.

### fuse_type=1 rocprofv3 sweep

| kernel | M | N | K | golden_runs_us | tot_runs_us | golden_us_avg | tot_us_avg | delta_us | delta_% | threshold_us | status |
|---|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---|
| fused_gemm_a8w8_blockscale_mul_add | 2 | 7168 | 256 | 3.712; 3.733; 3.704 | 3.804; 3.821; 3.802 | 3.712 | 3.804 | 0.092 | 2.5 | 4.231 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 4 | 7168 | 256 | 3.752; 3.718; 3.735 | 3.805; 3.823; 3.837 | 3.735 | 3.823 | 0.088 | 2.4 | 4.254 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 8 | 7168 | 256 | 3.727; 3.745; 3.737 | 3.965; 3.943; 3.967 | 3.737 | 3.965 | 0.228 | 6.1 | 4.256 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 16 | 7168 | 256 | 3.761; 3.780; 3.769 | 3.727; 3.743; 3.731 | 3.769 | 3.731 | -0.038 | -1.0 | 4.288 | below_threshold |
| fused_gemm_a8w8_blockscale_mul_add | 32 | 7168 | 256 | 4.196; 4.185; 4.211 | 3.885; 3.881; 3.864 | 4.196 | 3.881 | -0.315 | -7.5 | 4.717 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 64 | 7168 | 256 | 4.505; 4.516; 4.487 | 4.617; 4.597; 4.588 | 4.505 | 4.597 | 0.092 | 2.0 | 5.028 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 128 | 7168 | 256 | 5.583; 5.589; 5.596 | 5.296; 5.302; 5.337 | 5.589 | 5.302 | -0.287 | -5.1 | 6.117 | ok |
| fused_gemm_a8w8_blockscale_mul_add | 256 | 7168 | 256 | 7.355; 7.308; 7.326 | 6.781; 6.785; 6.807 | 7.326 | 6.785 | -0.541 | -7.4 | 7.863 | improvement |
| fused_gemm_a8w8_blockscale_mul_add | 512 | 7168 | 256 | 10.625; 10.452; 10.390 | 8.608; 8.433; 8.197 | 10.452 | 8.433 | -2.019 | -19.3 | 11.004 | improvement |
| fused_gemm_a8w8_blockscale_mul_add | 1024 | 7168 | 256 | 15.898; 15.917; 15.683 | 35.455; 33.613; 34.660 | 15.898 | 34.660 | 18.762 | 118.0 | 16.477 | regression |
| fused_gemm_a8w8_blockscale_mul_add | 4096 | 7168 | 256 | 50.162; 51.192; 50.121 | 127.880; 131.600; 129.662 | 50.162 | 129.662 | 79.500 | 158.5 | 50.913 | regression |

## Follow-up work

This PR intentionally does not attempt to solve every remaining performance issue.

Follow-up items to consider after this PR:

1. M=4096 compiler/perf residual

   M=4096 remains the only `fuse_type=0` regression after this patch. Since it already uses the same `64x64` tile shape as golden, the remaining slowdown appears to be a Triton 3.8 vs Triton 3.4 compiler/codegen residual.

   A follow-up should either:
   - bisect Triton compiler performance for this exact shape, or
   - perform a bounded any-bucket tuning search that validates both M=1024 and M=4096 together.

2. fuse_type=1 performance tuning

   This PR restores `fuse_type=1` correctness at the pytest-tested shapes by routing it to the safe base config. It does not attempt to optimize `fuse_type=1` performance due to the correctness failures. 

   A future tuning pass can screen candidate configs by forcing `config=` directly, validating correctness for `fuse_type=1`, and only then adding a dedicated fuse1 config/routing path if a faster correctness-safe tile is found.

3. Triton compiler issue

   The fast `64x64` tile is correct for `fuse_type=0` but miscompiles for `fuse_type=1` on Triton 3.8 for specific operand-kind combinations. The long-term fix should come from the Triton compiler side, after which `fuse_type=1` can potentially use the same fast tile as golden.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
