### PR TITLE
custom_all_reduce: gate gfx1250 transport by ROCm version 7.14

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -61,6 +61,78 @@ def _detect_gfx1250() -> bool:
 _IPC_MIN_ROCM = (7, 14)
 
 
+# Default custom-AR size cutoff (bytes): inputs at or below this run on the
+# custom kernels, larger ones fall back to RCCL. 64 MiB == 8192*8192, matching
+# the historical decode threshold.
+_DEFAULT_CAR_MAX_SIZE = 8192 * 8192
+
+# Env var to override the custom-AR size cutoff (in bytes). See
+# _resolve_car_max_size for the semantics.
+_CAR_MAX_SIZE_ENV = "AITER_CUSTOM_AR_MAX_SIZE"
+
+
+def _resolve_car_max_size(pool_size: int) -> int:
+    """Resolve the custom-AR size cutoff (bytes) from ``AITER_CUSTOM_AR_MAX_SIZE``.
+
+    Semantics:
+      * unset / empty / unparyable  -> default (64 MiB), i.e. unchanged behavior.
+      * 0                           -> 0: custom AR disabled, everything uses RCCL.
+      * 0 < v <= pool_size          -> v: custom AR used up to v bytes.
+      * v > pool_size               -> too large: the registered pool cannot hold
+                                       it. Raise (then catch), warn, and fall back
+                                       to the 64 MiB default.
+
+    ``pool_size`` is the registered input-buffer size (``CustomAllreduce.max_size``).
+    """
+    raw = os.environ.get(_CAR_MAX_SIZE_ENV, "").strip()
+    if raw == "":
+        return _DEFAULT_CAR_MAX_SIZE
+    try:
+        v = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an integer; using default %d bytes.",
+            _CAR_MAX_SIZE_ENV,
+            raw,
+            _DEFAULT_CAR_MAX_SIZE,
+        )
+        return _DEFAULT_CAR_MAX_SIZE
+    if v < 0:
+        logger.warning(
+            "%s=%d is negative; using default %d bytes.",
+            _CAR_MAX_SIZE_ENV,
+            v,
+            _DEFAULT_CAR_MAX_SIZE,
+        )
+        return _DEFAULT_CAR_MAX_SIZE
+    if v == 0:
+        logger.info(
+            "%s=0: custom allreduce disabled; all sizes fall back to RCCL.",
+            _CAR_MAX_SIZE_ENV,
+        )
+        return 0
+    try:
+        if v > pool_size:
+            raise ValueError(
+                f"{_CAR_MAX_SIZE_ENV}={v} exceeds the custom-AR pool size "
+                f"({pool_size} bytes); the registered buffer cannot hold inputs "
+                f"that large."
+            )
+    except ValueError as e:
+        logger.warning(
+            "%s Falling back to the default %d bytes (64 MiB).",
+            e,
+            _DEFAULT_CAR_MAX_SIZE,
+        )
+        return _DEFAULT_CAR_MAX_SIZE
+    logger.info(
+        "Custom allreduce size cutoff overridden to %d bytes via %s.",
+        v,
+        _CAR_MAX_SIZE_ENV,
+    )
+    return v
+
+
 def _should_use_vmm(is_gfx1250: bool) -> bool:
     """Decide the cross-device buffer transport for gfx1250.
 
@@ -697,6 +769,10 @@ class CustomAllreduce:
             8 * 1024 * 1024, dtype=torch.uint8, device=self.device
         )
         self.max_size = max_size
+        # Custom-AR size cutoff (bytes): inputs at or below this run on the
+        # custom kernels; larger ones fall back to RCCL. Overridable via
+        # AITER_CUSTOM_AR_MAX_SIZE (capped at the registered pool size == max_size).
+        self._car_max_size = _resolve_car_max_size(max_size)
         self.rank = rank
         self.world_size = world_size
 
@@ -783,8 +859,10 @@ class CustomAllreduce:
 
         Shared by the old-arch kernel and the gfx1250 kernel (ROCm >= 7.15):
         both consume handle+offset init/register ops. Only the meta buffer
-        layout differs — the gfx1250 kernel is 1-stage, so it needs no trailing
-        2x tmp region after the Signal struct.
+        layout differs — the gfx1250 kernel is 1-stage (no trailing 2x tmp
+        region), but its meta_size() now also carries the LL fast-path staging
+        scratch appended after the Signal struct (see meta_size() in
+        custom_all_reduce_gfx1250.cu).
         """
         # Meta/Signal buffer: uncached device memory (cross-GPU sync flags must
         # bypass the cache), zero-initialized by allocate_meta_buffer, exchanged
@@ -804,12 +882,12 @@ class CustomAllreduce:
         # old arch: meta_size() + 2x tmp region (2-stage kernel) is GB-scale, so
         # it lands in the first regime and exports fine despite meta_size()=5504
         # (not a page multiple).
-        # gfx1250: the 1-stage kernel needs no tmp region, so meta is just
-        # meta_size_gfx1250() (~34 KB, and not a page multiple) -> it would land
-        # in the failing sub-2 MB case. Round the allocation up to 2 MB so it
-        # takes the always-safe coarse-grained path, exactly like the old-arch
-        # buffer. 2 MB is negligible (once per communicator) and the kernel only
-        # ever touches the leading Signal struct.
+        # gfx1250: meta_size_gfx1250() = Signal (~34 KB) + LL staging scratch
+        # (~4 MiB, see kLLScratchOffset/llScratchBytes). That is already well
+        # above 2 MB, so it lands in the always-safe coarse-grained regime; the
+        # round-up to a 2 MB multiple below is a no-op guard that also keeps the
+        # allocation 2 MB-aligned. The kernel touches the leading Signal struct
+        # (sync flags) plus the trailing scratch region (LL fast path).
         _COARSE_GRAIN = 2 * 1024 * 1024
         if self._is_gfx1250:
             meta_size = (
@@ -898,16 +976,19 @@ class CustomAllreduce:
         # custom allreduce requires input byte size to be multiples of 16
         if inp_size % 16 != 0:
             return False
+        # AITER_CUSTOM_AR_MAX_SIZE=0 disables custom AR entirely -> RCCL for all.
+        if self._car_max_size <= 0:
+            return False
         # for 4 or more non NVLink-capable GPUs, custom allreduce provides
         # little performance improvement over NCCL.
         # In allreduce 2stage writemode, use 2x tmp buffer
         if self.world_size == 2 or self.fully_connected:
-            # decode
+            # decode: env-controlled cutoff (default 64 MiB).
             if not prefill_support:
-                return inp_size <= 8192 * 8192
-            # prefill
+                return inp_size <= self._car_max_size
+            # prefill: also bounded by the 2x tmp buffer (max_size / 2).
             else:
-                return inp_size <= (self.max_size / 2)
+                return inp_size <= min(self._car_max_size, self.max_size / 2)
         return False
 
     def should_custom_ar(self, inp: torch.Tensor, prefill_support: bool = False):

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -15,6 +15,7 @@
 * limitations under the License.
 """
 
+import os
 import pickle
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple, Union
@@ -29,9 +30,18 @@ import aiter as ops
 from aiter.dist.parallel_state import in_the_same_node_as
 from aiter import logger
 from aiter.utility.dtypes import fp8
+from .rocm_version import get_rocm_version
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
 
 
 def _detect_gfx1250() -> bool:
+    # Escape hatch for validating the old-arch (IPC + old kernel) path on gfx1250
+    # hardware: forces the non-gfx1250 code path end to end.
+    if _env_flag("AITER_CUSTOM_AR_DISABLE_GFX1250"):
+        return False
     try:
         import torch
 
@@ -43,7 +53,47 @@ def _detect_gfx1250() -> bool:
         return False
 
 
+# ROCm release at which hipIpc is reported to work on gfx1250. Below this we fall
+# back to the HIP VMM transport (i.e. gfx1250 uses VMM only on ROCm < 7.14).
+# NOTE: bisect this across ROCm versions on real hardware (use
+# AITER_CUSTOM_AR_FORCE_IPC together with AITER_ROCM_VERSION) and update once
+# confirmed.
+_IPC_MIN_ROCM = (7, 14)
+
+
+def _should_use_vmm(is_gfx1250: bool) -> bool:
+    """Decide the cross-device buffer transport for gfx1250.
+
+    VMM (fd-based) is used on gfx1250 only while hipIpc is unusable — i.e. on
+    ROCm older than ``_IPC_MIN_ROCM`` (or when the version can't be determined).
+    On old archs hipIpc always works, so VMM is never used there.
+    """
+    if not is_gfx1250:
+        return False
+    if _env_flag("AITER_CUSTOM_AR_FORCE_IPC"):
+        return False
+    if _env_flag("AITER_CUSTOM_AR_FORCE_VMM"):
+        return True
+    v = get_rocm_version()
+    if v is None:
+        # Unknown version — keep the conservative VMM path (prior behavior).
+        logger.warning(
+            "Custom allreduce: ROCm version undetectable on gfx1250; "
+            "using VMM transport. Set AITER_CUSTOM_AR_FORCE_IPC=1 to override."
+        )
+        return True
+    use_vmm = v[:2] < _IPC_MIN_ROCM
+    logger.info(
+        "Custom allreduce gfx1250 transport: %s (ROCm %s, IPC threshold %s)",
+        "VMM" if use_vmm else "IPC",
+        v,
+        _IPC_MIN_ROCM,
+    )
+    return use_vmm
+
+
 _is_gfx1250 = _detect_gfx1250()
+_use_vmm = _should_use_vmm(_is_gfx1250)
 
 try:
     if _is_gfx1250:
@@ -426,7 +476,7 @@ class _GFX1250BufferProxy:
 
     def get_external_ipc_meta(self, tensor):
         """Exchange a tensor's pointer across ranks using VMM."""
-        from .vmm_allocator import VMMBuffer, vmm_exchange
+        from .vmm_allocator import VMMBuffer, vmm_exchange, load_hip_runtime
         import torch.distributed as dist
 
         ca = self._ca
@@ -437,7 +487,7 @@ class _GFX1250BufferProxy:
         # Copy tensor data into VMM buffer
         import ctypes
 
-        _hip = ctypes.CDLL("libamdhip64.so")
+        _hip = load_hip_runtime()
         _hip.hipMemcpyAsync(
             ctypes.c_void_p(vmm_buf.data_ptr),
             ctypes.c_void_p(tensor.data_ptr()),
@@ -467,19 +517,41 @@ class CustomAllreduce:
     _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
 
     def _select_ops(self):
-        """Select the correct ops backend based on GPU architecture."""
+        """Select the ops backend.
+
+        Two orthogonal dimensions:
+          * kernel — gfx1250 vs old, keyed on ``self._is_gfx1250`` (arch).
+            Covers meta_size / all_reduce / all_gather / reduce_scatter / dispose
+            and the graph-ptr helpers.
+          * transport — how peer pointers are shared, keyed on ``self._use_vmm``.
+            Covers init_custom_ar and register_input/output_buffer, whose
+            argument shape differs (VMM: raw ptr list; IPC: handles + offsets).
+
+        gfx1250 supports both transports: VMM (ptr-list ops) on old ROCm, and
+        IPC (the ``*_gfx1250_ipc`` ops, same handle+offset signature as the
+        old-arch ops) on ROCm >= 7.15.
+        """
         if self._is_gfx1250:
+            # kernel ops (arch)
             self._ops_meta_size = ops.meta_size_gfx1250
-            self._ops_init_custom_ar = ops.init_custom_ar_gfx1250
             self._ops_all_reduce = ops.all_reduce_gfx1250
             self._ops_all_gather = ops.all_gather_gfx1250
             self._ops_reduce_scatter = ops.reduce_scatter_gfx1250
             self._ops_dispose = ops.dispose_gfx1250
-            self._ops_register_input_buffer = ops.register_input_buffer_gfx1250
-            self._ops_register_output_buffer = ops.register_output_buffer_gfx1250
             self._ops_get_graph_buffer_count = ops.get_graph_buffer_count_gfx1250
             self._ops_get_graph_buffer_ptrs = ops.get_graph_buffer_ptrs_gfx1250
             self._ops_register_graph_buffers = ops.register_graph_buffers_gfx1250
+            # transport-coupled ops (init / register)
+            if self._use_vmm:
+                self._ops_init_custom_ar = ops.init_custom_ar_gfx1250
+                self._ops_register_input_buffer = ops.register_input_buffer_gfx1250
+                self._ops_register_output_buffer = ops.register_output_buffer_gfx1250
+            else:
+                self._ops_init_custom_ar = ops.init_custom_ar_gfx1250_ipc
+                self._ops_register_input_buffer = ops.register_input_buffer_gfx1250_ipc
+                self._ops_register_output_buffer = (
+                    ops.register_output_buffer_gfx1250_ipc
+                )
         else:
             self._ops_meta_size = ops.meta_size
             self._ops_init_custom_ar = ops.init_custom_ar
@@ -513,7 +585,8 @@ class CustomAllreduce:
         """
         self._IS_CAPTURING = False
         self.disabled = True
-        self._is_gfx1250 = _is_gfx1250
+        self._is_gfx1250 = _is_gfx1250  # kernel dimension (arch)
+        self._use_vmm = _use_vmm  # transport dimension (arch + ROCm version)
         self._select_ops()
 
         if not custom_ar:
@@ -604,13 +677,14 @@ class CustomAllreduce:
 
         self.disabled = False
         # gfx1250 (MI450) cannot register CUDA-graph-captured buffers across
-        # ranks: `flush_graph_buffers` / `register_graph_buffers` are no-ops
-        # there (VMM-based graph exchange not yet implemented). The "registered"
-        # capture path bakes raw input pointers that peers would dereference at
-        # replay without ever being registered → GPU page fault on the first
-        # graph replay (e.g. V4 TP=2 decode). Force the copy-in "unreg" path
-        # during capture, which routes through the pre-registered VMM pool
-        # (exchanged at init, address-stable across replays).
+        # ranks yet: cross-rank graph-buffer exchange is unimplemented for both
+        # gfx1250 transports (VMM fd exchange, and IPC graph-meta ops). The
+        # "registered" capture path bakes raw input pointers that peers would
+        # dereference at replay without ever being registered → GPU page fault
+        # on the first graph replay (e.g. V4 TP=2 decode). Force the copy-in
+        # "unreg" path during capture, which routes through the pre-registered
+        # pool (exchanged at init, address-stable across replays). Keyed on the
+        # kernel (arch), so both VMM and IPC gfx1250 paths use copy-in.
         if self._is_gfx1250:
             enable_register_for_capturing = False
         self.enable_register_for_capturing = enable_register_for_capturing
@@ -628,15 +702,16 @@ class CustomAllreduce:
 
         self.fully_connected = fully_connected
 
-        if self._is_gfx1250:
+        if self._use_vmm:
             self._init_gfx1250(rank, world_size, max_size)
         else:
             self._init_ipc(rank, world_size, max_size)
 
     def _init_gfx1250(self, rank: int, world_size: int, max_size: int):
-        """gfx1250 init: hipIpc unavailable, use HIP VMM API to share
-        GPU buffers across processes via exported fd + Unix socket."""
-        from .vmm_allocator import VMMBuffer, vmm_exchange
+        """gfx1250 VMM init: used when hipIpc is unusable (ROCm < 7.15). Shares
+        GPU buffers across processes via the HIP VMM API (exported fd + Unix
+        socket) instead of IPC handles."""
+        from .vmm_allocator import VMMBuffer, vmm_exchange, load_hip_runtime
 
         meta_sz = self._ops_meta_size()
         # gfx1250 is 1-stage only — no tmp buffer after Signal needed
@@ -653,7 +728,7 @@ class CustomAllreduce:
         self._vmm_meta = VMMBuffer(total_meta, device_id)
         import ctypes
 
-        _hip = ctypes.CDLL("libamdhip64.so")
+        _hip = load_hip_runtime()
         _hip.hipMemsetAsync(
             ctypes.c_void_p(self._vmm_meta.data_ptr),
             0,
@@ -704,10 +779,54 @@ class CustomAllreduce:
         self._pool = _GFX1250BufferProxy(self._vmm_meta, self._vmm_input, self)
 
     def _init_ipc(self, rank: int, world_size: int, max_size: int):
-        """Standard init path using hipIpc handles."""
+        """Init path using hipIpc handles.
+
+        Shared by the old-arch kernel and the gfx1250 kernel (ROCm >= 7.15):
+        both consume handle+offset init/register ops. Only the meta buffer
+        layout differs — the gfx1250 kernel is 1-stage, so it needs no trailing
+        2x tmp region after the Signal struct.
+        """
+        # Meta/Signal buffer: uncached device memory (cross-GPU sync flags must
+        # bypass the cache), zero-initialized by allocate_meta_buffer, exchanged
+        # over IPC. Same allocation mode as the old-arch path.
+        #
+        # hipIpcGetMemHandle on a hipDeviceMallocUncached allocation has two
+        # regimes, split at the 2 MB coarse-grained allocation granularity
+        # (what hipMemGetAllocationGranularity reports on this GPU):
+        #   * size >= 2 MB: backed coarse-grained (2 MB-aligned) -> the handle
+        #     always exports, regardless of page-multiple. Verified: 2 MB + 2 KB
+        #     (non-page-multiple) succeeds.
+        #   * size <  2 MB: backed fine-grained at page granularity -> the handle
+        #     exports only if the requested size is a whole number of 4 KB pages.
+        #     Verified: 34816 B / 100 KB / 1.5 MB (non-page-multiple) FAIL with
+        #     "invalid argument"; 36864 / 65536 (page-multiple) succeed.
+        #
+        # old arch: meta_size() + 2x tmp region (2-stage kernel) is GB-scale, so
+        # it lands in the first regime and exports fine despite meta_size()=5504
+        # (not a page multiple).
+        # gfx1250: the 1-stage kernel needs no tmp region, so meta is just
+        # meta_size_gfx1250() (~34 KB, and not a page multiple) -> it would land
+        # in the failing sub-2 MB case. Round the allocation up to 2 MB so it
+        # takes the always-safe coarse-grained path, exactly like the old-arch
+        # buffer. 2 MB is negligible (once per communicator) and the kernel only
+        # ever touches the leading Signal struct.
+        _COARSE_GRAIN = 2 * 1024 * 1024
+        if self._is_gfx1250:
+            meta_size = (
+                (self._ops_meta_size() + _COARSE_GRAIN - 1) // _COARSE_GRAIN
+            ) * _COARSE_GRAIN
+        else:
+            meta_size = self._ops_meta_size() + max_size * 2
+        # Wire the pool's graph helpers to the kernel-matching ops so that
+        # flush_graph_buffers() during capture never reinterpret_casts a gfx1250
+        # `fa` through the old-arch graph ops. Graph-buffer registration itself
+        # stays disabled on gfx1250 (copy-in path → count is always 0).
+        pool_kwargs = {}
+        if self._is_gfx1250:
+            pool_kwargs["graph_count_fn"] = self._ops_get_graph_buffer_count
         # Create IPC buffer pool and allocate all named buffers.
-        self._pool = IPCBufferPool(self.device, self.group)
-        self._pool.create("meta", self._ops_meta_size() + max_size * 2, uncached=True)
+        self._pool = IPCBufferPool(self.device, self.group, **pool_kwargs)
+        self._pool.create("meta", meta_size, uncached=True)
         self._pool.create("input", max_size)
 
         handles, offsets = self._pool.get_ipc_meta("meta")
@@ -746,7 +865,9 @@ class CustomAllreduce:
 
     def register_input_buffer(self, inp: torch.Tensor):
         """Register an external tensor as an IPC input buffer."""
-        if self._is_gfx1250:
+        # Branch on transport: VMM returns a raw peer-ptr list; IPC (both
+        # old-arch and gfx1250 kernels) returns handles + offsets.
+        if self._use_vmm:
             all_ptrs = self._pool.get_external_ipc_meta(inp)
             self._ops_register_input_buffer(self._ptr, inp.data_ptr(), all_ptrs)
         else:
@@ -757,7 +878,7 @@ class CustomAllreduce:
 
     def register_output_buffer(self, out: torch.Tensor):
         """Register an external tensor as an IPC output buffer."""
-        if self._is_gfx1250:
+        if self._use_vmm:
             all_ptrs = self._pool.get_external_ipc_meta(out)
             self._ops_register_output_buffer(self._ptr, out.data_ptr(), all_ptrs)
         else:

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -70,6 +70,16 @@ _DEFAULT_CAR_MAX_SIZE = 8192 * 8192
 # _resolve_car_max_size for the semantics.
 _CAR_MAX_SIZE_ENV = "AITER_CUSTOM_AR_MAX_SIZE"
 
+# Custom-AR lower size bound (bytes). Inputs at or below this run on RCCL
+# instead of the custom kernels; only inputs strictly above it are routed to
+# custom AR. Default 0 (no lower bound) — unchanged behavior. Together with
+# _CAR_MAX_SIZE_ENV this forms the (min, max] window in which custom AR runs.
+_DEFAULT_CAR_MIN_SIZE = 0
+
+# Env var to override the custom-AR lower size bound (in bytes). See
+# _resolve_car_min_size for the semantics.
+_CAR_MIN_SIZE_ENV = "AITER_CUSTOM_AR_MIN_SIZE"
+
 
 def _resolve_car_max_size(pool_size: int) -> int:
     """Resolve the custom-AR size cutoff (bytes) from ``AITER_CUSTOM_AR_MAX_SIZE``.
@@ -130,6 +140,51 @@ def _resolve_car_max_size(pool_size: int) -> int:
         v,
         _CAR_MAX_SIZE_ENV,
     )
+    return v
+
+
+def _resolve_car_min_size() -> int:
+    """Resolve the custom-AR lower size bound (bytes) from
+    ``AITER_CUSTOM_AR_MIN_SIZE``.
+
+    Semantics:
+      * unset / empty / unparsable -> default (0), i.e. no lower bound.
+      * negative                   -> default (0).
+      * v >= 0                     -> v: inputs at or below v bytes fall back to
+                                      RCCL; only inputs above v run on custom AR.
+
+    Bounds are combined in ``_fits_custom_ar_size`` as a (min, max] window; if
+    the resolved min is >= the max cutoff, no size fits and everything falls
+    back to RCCL.
+    """
+    raw = os.environ.get(_CAR_MIN_SIZE_ENV, "").strip()
+    if raw == "":
+        return _DEFAULT_CAR_MIN_SIZE
+    try:
+        v = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an integer; using default %d bytes.",
+            _CAR_MIN_SIZE_ENV,
+            raw,
+            _DEFAULT_CAR_MIN_SIZE,
+        )
+        return _DEFAULT_CAR_MIN_SIZE
+    if v < 0:
+        logger.warning(
+            "%s=%d is negative; using default %d bytes.",
+            _CAR_MIN_SIZE_ENV,
+            v,
+            _DEFAULT_CAR_MIN_SIZE,
+        )
+        return _DEFAULT_CAR_MIN_SIZE
+    if v > 0:
+        logger.info(
+            "Custom allreduce lower size bound set to %d bytes via %s; "
+            "inputs at or below this fall back to RCCL.",
+            v,
+            _CAR_MIN_SIZE_ENV,
+        )
     return v
 
 
@@ -773,6 +828,10 @@ class CustomAllreduce:
         # custom kernels; larger ones fall back to RCCL. Overridable via
         # AITER_CUSTOM_AR_MAX_SIZE (capped at the registered pool size == max_size).
         self._car_max_size = _resolve_car_max_size(max_size)
+        # Custom-AR lower size bound (bytes): inputs at or below this fall back
+        # to RCCL. Default 0 (no lower bound). Overridable via
+        # AITER_CUSTOM_AR_MIN_SIZE. Custom AR runs only in (min, max].
+        self._car_min_size = _resolve_car_min_size()
         self.rank = rank
         self.world_size = world_size
 
@@ -978,6 +1037,11 @@ class CustomAllreduce:
             return False
         # AITER_CUSTOM_AR_MAX_SIZE=0 disables custom AR entirely -> RCCL for all.
         if self._car_max_size <= 0:
+            return False
+        # AITER_CUSTOM_AR_MIN_SIZE lower bound: inputs at or below it fall back
+        # to RCCL (custom AR runs only in the (min, max] window). Default 0 keeps
+        # the historical behavior of accepting all sizes down to 16 bytes.
+        if inp_size <= self._car_min_size:
             return False
         # for 4 or more non NVLink-capable GPUs, custom allreduce provides
         # little performance improvement over NCCL.

--- a/aiter/dist/device_communicators/rocm_version.py
+++ b/aiter/dist/device_communicators/rocm_version.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""
+Best-effort ROCm version detection.
+
+Used to gate the cross-device buffer transport for custom communication ops:
+on gfx1250, ``hipIpcGetMemHandle`` is unusable on early ROCm releases, so we
+fall back to the HIP VMM path (see :mod:`vmm_allocator`). Once the runtime is
+recent enough that IPC works, the IPC path is preferred again. This module tells
+the caller which ROCm it is running on so that decision can be made.
+
+The version is detected from several sources, tried in priority order, so a
+missing ``/opt/rocm/.info/version`` (e.g. a versioned install under
+``/opt/rocm-<ver>`` or a container with a non-standard layout) does not defeat
+detection:
+
+    1. ``AITER_ROCM_VERSION`` env override (for testing the gate itself).
+    2. ``.info/version*`` files under candidate ROCm roots.
+    3. ``torch.version.hip`` (the HIP version torch was built against).
+    4. ``hipRuntimeGetVersion`` from the loaded ``libamdhip64.so``.
+
+Returns a ``(major, minor, patch)`` tuple that compares naturally against a
+threshold like ``(7, 15)``, or ``None`` if every source failed.
+"""
+
+import ctypes
+import functools
+import glob
+import os
+import re
+
+from aiter import logger
+
+
+def _parse(s):
+    """Extract the leading ``major.minor[.patch]`` from an arbitrary string."""
+    m = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", s or "")
+    if not m:
+        return None
+    return tuple(int(x) for x in m.groups(default="0"))
+
+
+def _candidate_roots():
+    """ROCm install roots to probe, highest priority first."""
+    roots = []
+    # Explicit env pointers win — they name the ROCm the user actually wired up.
+    for env in ("ROCM_PATH", "ROCM_HOME", "HIP_PATH"):
+        p = os.environ.get(env)
+        if p:
+            roots.append(p)
+    # Default unversioned symlink.
+    roots.append("/opt/rocm")
+    # Versioned installs — probe the highest version first.
+    roots.extend(sorted(glob.glob("/opt/rocm-*"), reverse=True))
+    # De-dup while preserving order.
+    seen = set()
+    ordered = []
+    for r in roots:
+        if r not in seen:
+            seen.add(r)
+            ordered.append(r)
+    return ordered
+
+
+def _from_info_files():
+    """Read ``.info/version*`` under each candidate root."""
+    filenames = (".info/version", ".info/version-dev", ".info/version-hip")
+    for root in _candidate_roots():
+        for fn in filenames:
+            path = os.path.join(root, fn)
+            try:
+                with open(path) as f:
+                    v = _parse(f.read())
+            except OSError:
+                continue
+            if v:
+                logger.info("ROCm version %s from %s", v, path)
+                return v
+    return None
+
+
+def _from_torch():
+    """``torch.version.hip`` — HIP version torch was built against.
+
+    On modern ROCm (>= 6.0) the HIP major.minor tracks the ROCm release, so
+    ``"7.15.xxxxx"`` -> ``(7, 15, xxxxx)``.
+    """
+    try:
+        import torch
+
+        hip = getattr(torch.version, "hip", None)
+    except Exception:
+        return None
+    v = _parse(hip)
+    if v:
+        logger.info("ROCm version %s from torch.version.hip=%r", v, hip)
+    return v
+
+
+def _from_hip_runtime():
+    """``hipRuntimeGetVersion`` from the live ``libamdhip64.so``.
+
+    HIP packs the version as ``major*1e7 + minor*1e5 + patch``. This is the HIP
+    *runtime* version; it aligns with the ROCm release from ROCm 6.0 onward,
+    which is the range that matters for the IPC gate.
+    """
+    hip = None
+    for name in ("libamdhip64.so", "libamdhip64.so.7", "libamdhip64.so.6"):
+        try:
+            hip = ctypes.CDLL(name)
+            break
+        except OSError:
+            continue
+    if hip is None:
+        return None
+    try:
+        raw = ctypes.c_int()
+        if hip.hipRuntimeGetVersion(ctypes.byref(raw)) != 0:
+            return None
+        val = raw.value
+    except Exception:
+        return None
+    v = (val // 10_000_000, (val // 100_000) % 100, val % 100_000)
+    logger.info("ROCm version %s from hipRuntimeGetVersion=%d", v, val)
+    return v
+
+
+@functools.lru_cache(maxsize=1)
+def get_rocm_version():
+    """Best-effort ``(major, minor, patch)`` of the active ROCm.
+
+    Returns ``None`` if no source could determine a version. Result is cached
+    for the process lifetime.
+    """
+    override = os.environ.get("AITER_ROCM_VERSION")
+    if override:
+        v = _parse(override)
+        logger.info("ROCm version %s from AITER_ROCM_VERSION=%r", v, override)
+        return v
+
+    for source in (_from_info_files, _from_torch, _from_hip_runtime):
+        v = source()
+        if v:
+            return v
+
+    logger.warning("Could not detect ROCm version from any source")
+    return None

--- a/aiter/dist/device_communicators/vmm_allocator.py
+++ b/aiter/dist/device_communicators/vmm_allocator.py
@@ -19,7 +19,30 @@ from typing import List
 
 from aiter import logger
 
-_hip = ctypes.CDLL("libamdhip64.so")
+
+def load_hip_runtime() -> ctypes.CDLL:
+    """Load the HIP runtime shared library robustly.
+
+    Split rocm-sdk pip layouts (e.g. `_rocm_sdk_core/lib`) ship only the
+    versioned soname `libamdhip64.so.N` on the runtime path; the unversioned
+    `libamdhip64.so` symlink lives in the -devel package which need not be on
+    LD_LIBRARY_PATH at runtime. Try the plain name first, then versioned
+    sonames so it works regardless of which package is present.
+    """
+    candidates = ["libamdhip64.so", "libamdhip64.so.7", "libamdhip64.so.6"]
+    last_err = None
+    for name in candidates:
+        try:
+            return ctypes.CDLL(name)
+        except OSError as e:
+            last_err = e
+    raise OSError(
+        f"Could not load the HIP runtime; tried {candidates}. "
+        f"Last error: {last_err}"
+    )
+
+
+_hip = load_hip_runtime()
 
 # ---- HIP VMM ctypes structs ----
 
@@ -29,8 +52,8 @@ _PINNED = 1
 _POSIX_FD = 1
 # hipMemLocationType
 _DEVICE = 1
-# hipMemAccessFlags
-_READ_WRITE = 1
+# hipMemAccessFlags (hipMemAccessFlagsProt*): None=0, Read=1, ReadWrite=3
+_READ_WRITE = 3
 # hipMemAllocationGranularity_flags
 _MINIMUM = 0
 _RECOMMENDED = 1

--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -177,6 +177,28 @@ def _find_rocm_home() -> Optional[str]:
     return rocm_home
 
 
+def _find_rocm_devel_include() -> Optional[str]:
+    """Locate the header tree shipped by the rocm-sdk-devel pip package.
+
+    The rocm-sdk split-package layout puts runtime bits in `_rocm_sdk_core`
+    (what ROCM_HOME/ROCM_PATH usually point at) but the full dev headers —
+    thrust, hipcub, hipblas, half, ... — live in `_rocm_sdk_devel/include`.
+    torch's own headers (e.g. torch/headeronly/util/complex.h -> thrust/complex.h)
+    need those, so when ROCM_HOME resolves to the core tree we must add the
+    devel include dir explicitly or the build fails with "'thrust/complex.h'
+    file not found". Returns None if the devel package isn't installed.
+    """
+    try:
+        spec = importlib.util.find_spec("_rocm_sdk_devel")
+    except (ImportError, ValueError):
+        return None
+    if spec is not None and spec.submodule_search_locations:
+        inc = os.path.join(spec.submodule_search_locations[0], "include")
+        if os.path.isdir(inc):
+            return inc
+    return None
+
+
 def _join_rocm_home(*paths) -> str:
     """
     Join paths with ROCM_HOME, or raises an error if it ROCM_HOME is not set.
@@ -988,7 +1010,14 @@ def include_paths(cuda: bool = False) -> List[str]:
     ]
     if cuda and IS_HIP_EXTENSION:
         paths.append(os.path.join(lib_include, "THH"))
-        paths.append(_join_rocm_home("include"))
+        rocm_include = _join_rocm_home("include")
+        paths.append(rocm_include)
+        # ROCM_HOME may point at the runtime-only `_rocm_sdk_core` tree, which
+        # lacks the dev headers (thrust, hipcub, ...) that torch's headers pull
+        # in. Add the `_rocm_sdk_devel` include tree so they resolve.
+        devel_include = _find_rocm_devel_include()
+        if devel_include is not None and devel_include != rocm_include:
+            paths.append(devel_include)
     return paths
 
 

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -319,6 +319,35 @@ def register_output_buffer_gfx1250(
 ) -> None: ...
 
 
+# ---- gfx1250 IPC transport (ROCm >= 7.15) ----
+# Same signatures as the old-arch IPC ops (handles + offsets), so the Python
+# IPC init/register path is shared; only the C++ symbol (gfx1250 kernel) differs.
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="init_custom_ar_ipc", develop=True)
+def init_custom_ar_gfx1250_ipc(
+    meta_ptr: int,
+    rank_data_ptr: int,
+    rank_data_sz: int,
+    ipc_handle_ptrs: List[int],
+    offsets: List[int],
+    rank: int,
+    fully_connected: bool,
+) -> int: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="register_input_buffer_ipc", develop=True)
+def register_input_buffer_gfx1250_ipc(
+    _fa: int, self_ptr: int, ipc_handle_ptrs: List[int], offsets: List[int]
+) -> None: ...
+
+
+@compile_ops(GFX1250_MD_NAME, fc_name="register_output_buffer_ipc", develop=True)
+def register_output_buffer_gfx1250_ipc(
+    _fa: int, self_ptr: int, ipc_handle_ptrs: List[int], offsets: List[int]
+) -> None: ...
+
+
 @compile_ops(GFX1250_MD_NAME, fc_name="get_graph_buffer_count", develop=True)
 def get_graph_buffer_count_gfx1250(_fa: int) -> int: ...
 

--- a/csrc/include/custom_all_reduce_gfx1250.cuh
+++ b/csrc/include/custom_all_reduce_gfx1250.cuh
@@ -24,6 +24,7 @@
 #include <hip/hip_runtime.h>
 #include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include <string>
@@ -94,6 +95,215 @@ DINLINE out_dtype downcast_s(opus::fp32_t val)
 template <>
 DINLINE opus::fp32_t downcast_s<opus::fp32_t>(opus::fp32_t val)
 { return val; }
+
+// ---------------------------------------------------------------------------
+// LL (low-latency) small-message all-reduce
+// ---------------------------------------------------------------------------
+// Ported from the standalone PoC (formerly custom_all_reduce_ll_poc.*), now
+// folded into the gfx1250 path. Flag-in-data, zero GPU barrier: each 16B line
+// carries 8B payload + two 4B epoch flags. A rank publishes its sendbuff into
+// every peer's staging scratch, then polls its own scratch for the peers' lines
+// (spinning on the flag) and reduces in fp32. The scratch lives appended to the
+// shared Signal meta buffer (offset kLLScratchOffset), so no extra cross-rank
+// exchange is needed — peer scratch base = (char*)sg_.signals[i] + off.
+
+// gfx1250 AR supports world_size <= 4; size scratch for the max.
+constexpr int    kLLMaxRanks       = 4;
+// Route to LL when bytes <= this (matches RCCL DDA_ALLREDUCE_LL_THRESHOLD).
+constexpr size_t kLLArMaxBytes     = 131072;            // 128 KiB
+// Hard per-message payload cap (one slot). Comfortably above the routing
+// threshold so all dtypes at <=128 KiB fit.
+constexpr size_t kLLScratchCapBytes = 262144;           // 256 KiB
+// Per-rank staging slot capacity, in 8-byte packets.
+constexpr size_t kLLPackCapacity   = kLLScratchCapBytes / 8;  // 32768
+
+// 16-byte LL line: two (4B data, 4B flag) pairs carrying 8B of payload.
+union LLPackedMsg
+{
+    struct
+    {
+        uint32_t data0;
+        uint32_t flag0;
+        uint32_t data1;
+        uint32_t flag1;
+    };
+    uint4 raw;
+};
+static_assert(sizeof(LLPackedMsg) == 16, "LLPackedMsg must be exactly 16 bytes");
+
+// Per-rank scratch footprint: 2 banks * kLLMaxRanks slots * slotStride * 16B.
+// 4 MiB at the 256 KiB / 4-rank defaults. Uniform across ranks so the
+// double-buffered slot layout is identical everywhere.
+constexpr size_t llScratchBytes()
+{
+    return (size_t)2 * kLLMaxRanks * kLLPackCapacity * sizeof(LLPackedMsg);
+}
+
+// Byte offset of the LL scratch within the shared meta buffer: right after the
+// Signal struct, 128-byte aligned. The meta buffer (see meta_size()) is sized
+// kLLScratchOffset + llScratchBytes() and zero-initialized, which doubles as the
+// LL flag reset (flag 0 == cleared line).
+constexpr size_t kLLScratchOffset =
+    ((sizeof(Signal) + 127) / 128) * 128;
+
+// gfx1250 128-bit global load/store at *system* scope ("" == system). A single
+// 16B transaction keeps a line's data and flags atomic w.r.t. a peer reader.
+#if defined(__HIP_DEVICE_COMPILE__) && defined(__gfx1250__) &&                   \
+    __has_builtin(__builtin_amdgcn_global_store_b128) &&                         \
+    __has_builtin(__builtin_amdgcn_global_load_b128)
+#define AITER_GFX1250_HAVE_B128 1
+using llx_v4u      = __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int;
+using llx_v4u_gptr = __attribute__((address_space(1))) llx_v4u*;
+#else
+#define AITER_GFX1250_HAVE_B128 0
+#endif
+
+DINLINE void ll_store_b128(uint32_t* dst, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3)
+{
+#if AITER_GFX1250_HAVE_B128
+    union
+    {
+        llx_v4u  v;
+        uint32_t w[4];
+    } u;
+    u.w[0] = a0;
+    u.w[1] = a1;
+    u.w[2] = a2;
+    u.w[3] = a3;
+    __builtin_amdgcn_global_store_b128((llx_v4u_gptr)dst, u.v, "");
+#else
+    __builtin_nontemporal_store(a0, dst + 0);
+    __builtin_nontemporal_store(a1, dst + 1);
+    __builtin_nontemporal_store(a2, dst + 2);
+    __builtin_nontemporal_store(a3, dst + 3);
+#endif
+    asm volatile("" ::: "memory");
+}
+
+DINLINE void ll_load_b128(
+    const uint32_t* src, uint32_t& o0, uint32_t& o1, uint32_t& o2, uint32_t& o3)
+{
+    asm volatile("" ::: "memory");
+#if AITER_GFX1250_HAVE_B128
+    union
+    {
+        llx_v4u  v;
+        uint32_t w[4];
+    } u;
+    u.v = __builtin_amdgcn_global_load_b128((llx_v4u_gptr)src, "");
+    o0  = u.w[0];
+    o1  = u.w[1];
+    o2  = u.w[2];
+    o3  = u.w[3];
+#else
+    o0 = __builtin_nontemporal_load(src + 0);
+    o1 = __builtin_nontemporal_load(src + 1);
+    o2 = __builtin_nontemporal_load(src + 2);
+    o3 = __builtin_nontemporal_load(src + 3);
+#endif
+}
+
+// LL flat all-reduce. 1D grid over 8-byte packets.
+//
+// Phase 1 (publish): rank writes its full sendbuff into every peer's scratch at
+// slot[rank], as LL lines carrying the epoch flag.
+// Phase 2 (reduce): rank polls its own scratch slots for the other ranks
+// (waiting on the flag), sums them with its own sendbuff (fp32 accumulation),
+// and writes recvbuff. Self is read directly from sendbuff.
+//
+// Graph-safe device epoch: each block owns a persistent device flag
+// block_flags[blockIdx.x] that the kernel itself bumps (mirrors Signal::_flag).
+// A packet is always published+consumed by the same (blockIdx, threadIdx) on
+// every rank, so only the *same block across ranks* must agree on the flag; each
+// block runs once per launch, keeping per-block flags in lockstep. Scratch is
+// double-buffered (bank = epoch & 1); the per-epoch flag disambiguates stale
+// lines, so no clearing is needed and it survives CUDA-graph replay.
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(256, 2) ar_ll_gfx1250(
+    T* const* __restrict__ peer_scratch, // ngpus scratch bases (device table)
+    T* __restrict__ recvbuff,
+    const T* __restrict__ sendbuff,
+    size_t nPk,          // number of 8-byte packets = bytes / 8
+    int rank,
+    uint32_t* __restrict__ block_flags) // device array[gridDim.x], persisted
+{
+    constexpr int LP = 8 / sizeof(T); // elements per 8-byte payload
+    using PL         = typename opus::vector_t<T, LP>;
+    using AL         = typename opus::vector_t<opus::fp32_t, LP>;
+    constexpr size_t slot = kLLPackCapacity;
+
+    __shared__ uint32_t s_flag;
+    if(threadIdx.x == 0)
+    {
+        uint32_t f = block_flags[blockIdx.x] + 1u;
+        if(f == 0u)
+            f = 1u; // flag is never 0 (0 == cleared scratch)
+        s_flag = f;
+    }
+    __syncthreads();
+    const uint32_t flag        = s_flag;
+    const size_t   bankOffPkts = (size_t)(flag & 1u) * (size_t)ngpus * slot;
+
+    const size_t gtid   = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t stride = (size_t)gridDim.x * blockDim.x;
+
+    const uint32_t* in = reinterpret_cast<const uint32_t*>(sendbuff);
+
+    // Phase 1: publish my payload into every peer's slot[rank].
+    for(size_t pk = gtid; pk < nPk; pk += stride)
+    {
+        const uint32_t d0 = in[2 * pk];
+        const uint32_t d1 = in[2 * pk + 1];
+#pragma unroll
+        for(int r = 1; r < ngpus; ++r)
+        {
+            int          peer = (rank + r) % ngpus;
+            LLPackedMsg* dst  = reinterpret_cast<LLPackedMsg*>(peer_scratch[peer]) +
+                               bankOffPkts + (size_t)rank * slot;
+            ll_store_b128(reinterpret_cast<uint32_t*>(&dst[pk]), d0, flag, d1, flag);
+        }
+    }
+
+    // Phase 2: poll my slots for the other ranks, reduce with my own data.
+    LLPackedMsg* myBase =
+        reinterpret_cast<LLPackedMsg*>(peer_scratch[rank]) + bankOffPkts;
+    for(size_t pk = gtid; pk < nPk; pk += stride)
+    {
+        PL selfv = *reinterpret_cast<const PL*>(&in[2 * pk]);
+        AL acc;
+#pragma unroll
+        for(int j = 0; j < LP; ++j)
+            acc[j] = upcast_s(selfv[j]);
+
+        for(int r = 1; r < ngpus; ++r)
+        {
+            int                   peer = (rank + r) % ngpus;
+            volatile LLPackedMsg* src  = myBase + (size_t)peer * slot;
+            uint32_t d0, f0, d1, f1;
+            do
+            {
+                ll_load_b128(
+                    reinterpret_cast<const uint32_t*>(const_cast<LLPackedMsg*>(&src[pk])),
+                    d0, f0, d1, f1);
+            } while(f0 != flag || f1 != flag);
+
+            const uint32_t w[2] = {d0, d1};
+            PL             pv   = *reinterpret_cast<const PL*>(w);
+#pragma unroll
+            for(int j = 0; j < LP; ++j)
+                acc[j] += upcast_s(pv[j]);
+        }
+
+        PL ov;
+#pragma unroll
+        for(int j = 0; j < LP; ++j)
+            ov[j] = downcast_s<T>(acc[j]);
+        reinterpret_cast<PL*>(recvbuff)[pk] = ov;
+    }
+
+    if(threadIdx.x == 0)
+        block_flags[blockIdx.x] = flag;
+}
 
 // ---------------------------------------------------------------------------
 // Synchronisation primitives (ROCm path only)
@@ -724,6 +934,13 @@ public:
     using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
     std::map<IPC_KEY, char*> ipc_handles_;
 
+    // LL small-message fast path. Device table of per-rank scratch bases (each
+    // = peer meta base + kLLScratchOffset, i.e. the region right after the peer
+    // Signal in the shared meta buffer) and a persistent per-block epoch array.
+    // Allocated lazily by ensure_ll_tables_() on the first LL launch.
+    void**    d_ll_peers_       = nullptr;
+    uint32_t* d_ll_block_flags_ = nullptr;
+
     // gfx1250: hipIpc is not available. Instead, each rank's Signal buffer
     // is a torch-shared tensor whose device pointer is exchanged via the
     // distributed store.  The constructor receives the remote pointers
@@ -803,6 +1020,67 @@ public:
         {
             HIP_CALL(hipIpcCloseMemHandle(ptr));
         }
+        if(d_ll_peers_)
+            (void)hipFree(d_ll_peers_);
+        if(d_ll_block_flags_)
+            (void)hipFree(d_ll_block_flags_);
+    }
+
+    // Whether the LL small-message fast path is enabled. On by default; set
+    // AITER_CUSTOM_AR_DISABLE_LL=1 to force the naive kernel for all sizes.
+    static bool ll_enabled()
+    {
+        static const bool disabled = []() {
+            const char* e = std::getenv("AITER_CUSTOM_AR_DISABLE_LL");
+            if(!e)
+                return false;
+            std::string v(e);
+            return v == "1" || v == "true" || v == "yes" || v == "on" ||
+                   v == "TRUE" || v == "YES" || v == "ON";
+        }();
+        return !disabled;
+    }
+
+    // Lazily build the per-rank LL scratch pointer table and per-block epoch.
+    // sg_.signals[i] is each rank's meta base (populated by both constructors);
+    // the LL scratch sits at + kLLScratchOffset. The shared meta buffer is
+    // zero-initialized by the caller, which resets the LL flags (0 == cleared).
+    void ensure_ll_tables_()
+    {
+        if(d_ll_peers_)
+            return;
+        std::vector<void*> peers(world_size_);
+        for(int i = 0; i < world_size_; ++i)
+            peers[i] = reinterpret_cast<char*>(sg_.signals[i]) + kLLScratchOffset;
+        HIP_CALL(hipMalloc(&d_ll_peers_, sizeof(void*) * world_size_));
+        HIP_CALL(hipMemcpy(
+            d_ll_peers_, peers.data(), sizeof(void*) * world_size_, hipMemcpyHostToDevice));
+        HIP_CALL(hipMalloc(&d_ll_block_flags_, sizeof(uint32_t) * kMaxBlocks));
+        HIP_CALL(hipMemset(d_ll_block_flags_, 0, sizeof(uint32_t) * kMaxBlocks));
+    }
+
+    // LL small-message all-reduce. Reads `input` locally, pushes to peer scratch,
+    // reduces into `output`. numel is the element count; bytes must be a multiple
+    // of 16 and <= kLLScratchCapBytes (guaranteed by the routing threshold).
+    template <typename T>
+    void allreduce_ll(hipStream_t stream, const T* input, T* output, int numel)
+    {
+        ensure_ll_tables_();
+        const size_t bytes = (size_t)numel * sizeof(T);
+        const size_t nPk   = bytes >> 3; // 8 payload bytes per packet
+
+        constexpr int threads = 256;
+        int blocks = std::min<int>(kMaxBlocks, (int)((nPk + threads - 1) / threads));
+        if(blocks < 1)
+            blocks = 1;
+
+        T* const* peers = reinterpret_cast<T* const*>(d_ll_peers_);
+        if(world_size_ == 2)
+            ar_ll_gfx1250<T, 2><<<blocks, threads, 0, stream>>>(
+                peers, output, input, nPk, rank_, d_ll_block_flags_);
+        else
+            ar_ll_gfx1250<T, 4><<<blocks, threads, 0, stream>>>(
+                peers, output, input, nPk, rank_, d_ll_block_flags_);
     }
 
     // gfx1250: return raw device pointers (no hipIpc handles).
@@ -1125,6 +1403,18 @@ public:
         if(size % d != 0)
             throw std::runtime_error(
                 "custom allreduce requires input length to be multiple of " + std::to_string(d));
+
+        // LL small-message fast lane: bytes <= kLLArMaxBytes (128 KiB) route to
+        // the flag-in-data kernel, which reads input locally and pushes to the
+        // shared peer scratch — no registered peer-input table (_input_dp) is
+        // needed, so branch before get_buffer_RD.
+        const size_t bytes = (size_t)size * sizeof(T);
+        if(ll_enabled() && bytes <= kLLArMaxBytes &&
+           (world_size_ == 2 || world_size_ == 4))
+        {
+            allreduce_ll<T>(stream, input, output, size);
+            return;
+        }
 
         RankData* input_ptrs = get_buffer_RD(stream, input);
         RankData* output_ptrs = nullptr;

--- a/csrc/include/custom_all_reduce_gfx1250.cuh
+++ b/csrc/include/custom_all_reduce_gfx1250.cuh
@@ -962,6 +962,14 @@ public:
         {
             sg_.signals[i] = reinterpret_cast<Signal*>(all_meta_ptrs[i]);
         }
+        // Build the LL scratch/epoch tables now, at construction, rather than
+        // lazily on the first LL launch. The lazy path would run hipMalloc /
+        // hipMemcpy / hipMemset the first time allreduce() routes to LL, and if
+        // that first call happens inside a CUDA-graph capture (no eager warm-up
+        // before capture) those runtime calls are illegal mid-capture and abort.
+        // sg_.signals[] is populated above, so the peer scratch bases are ready.
+        if(ll_enabled())
+            ensure_ll_tables_();
     }
 
     // IPC transport overload (ROCm >= 7.15): hipIpc works on gfx1250, so peer
@@ -996,6 +1004,11 @@ public:
                 sg_.signals[i] = self_sg_;
             }
         }
+        // Eager LL-table build (see the VMM-overload constructor above): keeps
+        // hipMalloc/hipMemcpy/hipMemset out of the first LL allreduce, which may
+        // land inside a CUDA-graph capture and abort. sg_.signals[] is ready.
+        if(ll_enabled())
+            ensure_ll_tables_();
     }
 
     char* open_ipc_handle(const void* ipc_handle)

--- a/csrc/include/custom_all_reduce_gfx1250.cuh
+++ b/csrc/include/custom_all_reduce_gfx1250.cuh
@@ -718,6 +718,12 @@ public:
     std::vector<void*> graph_unreg_input_buffers_;
     std::vector<void*> graph_unreg_output_buffers_;
 
+    // Opened hipIpc handles, kept so they can be closed at destruction. Only
+    // populated on the IPC transport path (ROCm >= 7.15, where hipIpc works on
+    // gfx1250). Empty on the VMM path — the destructor is then a no-op.
+    using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
+    std::map<IPC_KEY, char*> ipc_handles_;
+
     // gfx1250: hipIpc is not available. Instead, each rank's Signal buffer
     // is a torch-shared tensor whose device pointer is exchanged via the
     // distributed store.  The constructor receives the remote pointers
@@ -738,6 +744,64 @@ public:
         for(int i = 0; i < world_size_; i++)
         {
             sg_.signals[i] = reinterpret_cast<Signal*>(all_meta_ptrs[i]);
+        }
+    }
+
+    // IPC transport overload (ROCm >= 7.15): hipIpc works on gfx1250, so peer
+    // meta buffers are shared via IPC handles instead of VMM-exported fds. This
+    // mirrors the old-arch path — resolve each remote handle to a local VA via
+    // hipIpcOpenMemHandle and add its offset. The kernel is unchanged; only how
+    // the peer pointers are obtained differs.
+    CustomAllreduce(Signal* meta,
+                    void* rank_data,
+                    size_t rank_data_sz,
+                    const hipIpcMemHandle_t* handles,
+                    const std::vector<int64_t>& offsets,
+                    int rank,
+                    bool fully_connected = true)
+        : rank_(rank),
+          world_size_(offsets.size()),
+          full_nvlink_(fully_connected),
+          self_sg_(meta),
+          d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+          d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData))
+    {
+        for(int i = 0; i < world_size_; i++)
+        {
+            if(i != rank_)
+            {
+                char* handle = open_ipc_handle(&handles[i]);
+                handle += offsets[i];
+                sg_.signals[i] = reinterpret_cast<Signal*>(handle);
+            }
+            else
+            {
+                sg_.signals[i] = self_sg_;
+            }
+        }
+    }
+
+    char* open_ipc_handle(const void* ipc_handle)
+    {
+        auto [it, new_handle] = ipc_handles_.insert({*((IPC_KEY*)ipc_handle), nullptr});
+        if(new_handle)
+        {
+            char* ipc_ptr;
+            HIP_CALL(hipIpcOpenMemHandle((void**)&ipc_ptr,
+                                         *((const hipIpcMemHandle_t*)ipc_handle),
+                                         hipIpcMemLazyEnablePeerAccess));
+            it->second = ipc_ptr;
+        }
+        return it->second;
+    }
+
+    ~CustomAllreduce()
+    {
+        // No-op on the VMM path (ipc_handles_ empty); closes opened peer
+        // handles on the IPC path.
+        for(auto [_, ptr] : ipc_handles_)
+        {
+            HIP_CALL(hipIpcCloseMemHandle(ptr));
         }
     }
 
@@ -780,6 +844,55 @@ public:
         RankData data;
         for(int i = 0; i < world_size_; i++)
             data.ptrs[i] = (i != rank_) ? (void*)all_ptrs[i] : self;
+        auto d_data = d_rank_data_base_++;
+        HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
+        output_buffers_[self] = d_data;
+    }
+
+    // IPC transport overloads (ROCm >= 7.15): resolve peer handles to VAs.
+    void register_input_buffer(const hipIpcMemHandle_t* handles,
+                               const int64_t* offsets,
+                               void* self)
+    {
+        check_rank_data_capacity();
+        RankData data;
+        for(int i = 0; i < world_size_; i++)
+        {
+            if(i != rank_)
+            {
+                char* handle = open_ipc_handle((void*)&handles[i]);
+                handle += offsets[i];
+                data.ptrs[i] = handle;
+            }
+            else
+            {
+                data.ptrs[i] = self;
+            }
+        }
+        auto d_data = d_rank_data_base_++;
+        HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
+        input_buffer[self] = d_data;
+    }
+
+    void register_output_buffer(const hipIpcMemHandle_t* handles,
+                                const int64_t* offsets,
+                                void* self)
+    {
+        check_rank_data_capacity();
+        RankData data;
+        for(int i = 0; i < world_size_; i++)
+        {
+            if(i != rank_)
+            {
+                char* handle = open_ipc_handle((void*)&handles[i]);
+                handle += offsets[i];
+                data.ptrs[i] = handle;
+            }
+            else
+            {
+                data.ptrs[i] = self;
+            }
+        }
         auto d_data = d_rank_data_base_++;
         HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
         output_buffers_[self] = d_data;

--- a/csrc/include/custom_all_reduce_gfx1250.h
+++ b/csrc/include/custom_all_reduce_gfx1250.h
@@ -32,6 +32,15 @@ fptr_t init_custom_ar(int64_t meta_ptr,
                       const std::vector<int64_t>& all_meta_ptrs,
                       int64_t rank,
                       bool fully_connected);
+// IPC transport variant (ROCm >= 7.15): peer buffers shared via hipIpc
+// handles+offsets instead of direct pointers. Same gfx1250 kernel.
+fptr_t init_custom_ar_ipc(int64_t meta_ptr,
+                          int64_t rank_data_ptr,
+                          int64_t rank_data_sz,
+                          const std::vector<int64_t>& ipc_handle_ptrs,
+                          const std::vector<int64_t>& offsets,
+                          int64_t rank,
+                          bool fully_connected);
 void all_reduce(fptr_t _fa,
                 const aiter_tensor_t& inp,
                 const aiter_tensor_t& out,
@@ -68,6 +77,15 @@ void register_input_buffer(fptr_t _fa,
 void register_output_buffer(fptr_t _fa,
                             int64_t self_ptr,
                             const std::vector<int64_t>& all_ptrs);
+// IPC transport variants (ROCm >= 7.15): peer buffers via handles+offsets.
+void register_input_buffer_ipc(fptr_t _fa,
+                               int64_t self_ptr,
+                               const std::vector<int64_t>& ipc_handle_ptrs,
+                               const std::vector<int64_t>& offsets);
+void register_output_buffer_ipc(fptr_t _fa,
+                                int64_t self_ptr,
+                                const std::vector<int64_t>& ipc_handle_ptrs,
+                                const std::vector<int64_t>& offsets);
 int64_t get_graph_buffer_count(fptr_t _fa);
 void get_graph_buffer_ptrs(fptr_t _fa, int64_t ptrs_out);
 void register_graph_buffers(fptr_t _fa,

--- a/csrc/kernels/custom_all_reduce_gfx1250.cu
+++ b/csrc/kernels/custom_all_reduce_gfx1250.cu
@@ -92,7 +92,14 @@ void dispose(fptr_t _fa)
     delete fa;
 }
 
-int64_t meta_size() { return sizeof(aiter::Signal); }
+// Shared meta buffer = Signal struct + LL staging scratch appended after it.
+// The LL fast path derives each peer's scratch base as (peer meta) +
+// kLLScratchOffset, reusing the existing cross-rank meta exchange. The whole
+// region is zero-initialized by the caller (which also resets the LL flags).
+int64_t meta_size()
+{
+    return (int64_t)(aiter::kLLScratchOffset + aiter::llScratchBytes());
+}
 
 // ---- Internal dispatch helper ----
 

--- a/csrc/kernels/custom_all_reduce_gfx1250.cu
+++ b/csrc/kernels/custom_all_reduce_gfx1250.cu
@@ -51,6 +51,41 @@ fptr_t init_custom_ar(int64_t meta_ptr,
                                                fully_connected);
 }
 
+// IPC transport init (ROCm >= 7.15): peer meta buffers are shared via hipIpc
+// handles+offsets (like the old-arch path) instead of VMM-exported fds. The
+// gfx1250 kernel is unchanged.
+fptr_t init_custom_ar_ipc(int64_t meta_ptr,
+                          int64_t rank_data_ptr,
+                          int64_t rank_data_sz,
+                          const std::vector<int64_t>& ipc_handle_ptrs,
+                          const std::vector<int64_t>& offsets,
+                          int64_t rank,
+                          bool fully_connected)
+{
+    int world_size = offsets.size();
+    if(world_size > 4)
+        throw std::invalid_argument("gfx1250 custom allreduce: world size > 4 is not supported");
+    if(world_size % 2 != 0)
+        throw std::invalid_argument("Odd num gpus is not supported for now");
+    if(world_size != (int)ipc_handle_ptrs.size())
+        throw std::invalid_argument("handles length should equal to offsets length");
+    if(rank < 0 || rank >= world_size)
+        throw std::invalid_argument("invalid rank passed in");
+
+    hipIpcMemHandle_t ipc_handles[4];
+    for(int i = 0; i < world_size; i++)
+    {
+        std::memcpy(&ipc_handles[i], (void*)ipc_handle_ptrs[i], sizeof(hipIpcMemHandle_t));
+    }
+    return (fptr_t) new aiter::CustomAllreduce(reinterpret_cast<aiter::Signal*>(meta_ptr),
+                                               (void*)rank_data_ptr,
+                                               rank_data_sz,
+                                               ipc_handles,
+                                               offsets,
+                                               rank,
+                                               fully_connected);
+}
+
 void dispose(fptr_t _fa)
 {
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
@@ -179,6 +214,38 @@ void register_output_buffer(fptr_t _fa,
 {
     auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
     fa->register_output_buffer(all_ptrs, (void*)self_ptr);
+}
+
+// ---- Buffer registration (IPC handle-based, ROCm >= 7.15) ----
+
+void register_input_buffer_ipc(fptr_t _fa,
+                               int64_t self_ptr,
+                               const std::vector<int64_t>& ipc_handle_ptrs,
+                               const std::vector<int64_t>& offsets)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    int world_size = ipc_handle_ptrs.size();
+    std::vector<hipIpcMemHandle_t> ipc_handles(world_size);
+    for(int i = 0; i < world_size; i++)
+    {
+        std::memcpy(&ipc_handles[i], (void*)ipc_handle_ptrs[i], sizeof(hipIpcMemHandle_t));
+    }
+    fa->register_input_buffer(ipc_handles.data(), offsets.data(), (void*)self_ptr);
+}
+
+void register_output_buffer_ipc(fptr_t _fa,
+                                int64_t self_ptr,
+                                const std::vector<int64_t>& ipc_handle_ptrs,
+                                const std::vector<int64_t>& offsets)
+{
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+    int world_size = ipc_handle_ptrs.size();
+    std::vector<hipIpcMemHandle_t> ipc_handles(world_size);
+    for(int i = 0; i < world_size; i++)
+    {
+        std::memcpy(&ipc_handles[i], (void*)ipc_handle_ptrs[i], sizeof(hipIpcMemHandle_t));
+    }
+    fa->register_output_buffer(ipc_handles.data(), offsets.data(), (void*)self_ptr);
 }
 
 int64_t get_graph_buffer_count(fptr_t _fa)

--- a/csrc/pybind/custom_all_reduce_gfx1250_pybind.cu
+++ b/csrc/pybind/custom_all_reduce_gfx1250_pybind.cu
@@ -17,6 +17,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
           py::arg("meta_ptr"), py::arg("rank_data_ptr"), py::arg("rank_data_sz"),
           py::arg("all_meta_ptrs"), py::arg("rank"),
           py::arg("fully_connected"));
+    m.def("init_custom_ar_ipc", &aiter::init_custom_ar_ipc,
+          py::arg("meta_ptr"), py::arg("rank_data_ptr"), py::arg("rank_data_sz"),
+          py::arg("ipc_handle_ptrs"), py::arg("offsets"), py::arg("rank"),
+          py::arg("fully_connected"));
     m.def("all_reduce", &aiter::all_reduce,
           py::arg("_fa"), py::arg("inp"), py::arg("out"),
           py::arg("use_new"), py::arg("open_fp8_quant"),
@@ -39,6 +43,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
           py::arg("_fa"), py::arg("self_ptr"), py::arg("all_ptrs"));
     m.def("register_output_buffer", &aiter::register_output_buffer,
           py::arg("_fa"), py::arg("self_ptr"), py::arg("all_ptrs"));
+    m.def("register_input_buffer_ipc", &aiter::register_input_buffer_ipc,
+          py::arg("_fa"), py::arg("self_ptr"), py::arg("ipc_handle_ptrs"),
+          py::arg("offsets"));
+    m.def("register_output_buffer_ipc", &aiter::register_output_buffer_ipc,
+          py::arg("_fa"), py::arg("self_ptr"), py::arg("ipc_handle_ptrs"),
+          py::arg("offsets"));
     m.def("get_graph_buffer_count", &aiter::get_graph_buffer_count, py::arg("_fa"));
     m.def("get_graph_buffer_ptrs", &aiter::get_graph_buffer_ptrs,
           py::arg("_fa"), py::arg("ptrs_out"));

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce.py
@@ -15,6 +15,14 @@
 import argparse
 import os
 import sys
+
+# gfx1250 has no CK support: the base custom_all_reduce module won't compile with
+# CK enabled (ck_tile warp_size is not constexpr on this arch). Force the CK-free
+# build here so the JIT build succeeds without a manual `ENABLE_CK=0` prefix.
+# Must run before importing torch/aiter — ENABLE_CK is read at aiter import time
+# (aiter/jit/core.py). setdefault keeps an explicit `ENABLE_CK=1` override working.
+os.environ.setdefault("ENABLE_CK", "0")
+
 from multiprocessing import (
     Pool,
     TimeoutError as MpTimeoutError,


### PR DESCRIPTION
 ## Motivation

  On gfx1250 (MI450) the custom all-reduce always used the HIP VMM transport because early ROCm releases could not share buffers via hipIpc. hipIpc now works on recent ROCm, so we select the transport by ROCm version while keeping the gfx1250 kernel, avoiding VMM's fd/socket exchange when it is no longer needed.

  ## Technical Details

  Decouple the single `_is_gfx1250` flag into a kernel dimension (`_is_gfx1250`) and a transport dimension (`_use_vmm = _is_gfx1250 and rocm_version < _IPC_MIN_ROCM`):

  - old arch, any ROCm       -> old kernel + IPC
  - gfx1250, ROCm <  7.14    -> gfx1250 kernel + VMM
  - gfx1250, ROCm >= 7.14    -> gfx1250 kernel + IPC (new)

  - New IPC + gfx1250-kernel path (C++): IPC constructor / `register_*_buffer` overloads that open hipIpc handles into peer pointers, plus a destructor that closes them; new pybind + ops wrappers (`init_custom_ar_gfx1250_ipc`, `register_{input,output}_buffer_gfx1250_ipc`) sharing the old-arch handle+offset signature.
  - New `rocm_version.py` `get_rocm_version()` (env override -> `/opt/rocm` `.info` files -> `torch.version.hip` ->  `hipRuntimeGetVersion`), plus env switches for validation/bisection (`AITER_CUSTOM_AR_{DISABLE_GFX1250,FORCE_IPC,FORCE_VMM}`, `AITER_ROCM_VERSION`).
  - gfx1250+IPC meta/Signal buffer stays uncached but is rounded up to 2 MB:  `hipIpcGetMemHandle` on a `hipDeviceMallocUncached` allocation only exports a handle at the >=2 MB coarse-grained granularity (or a whole number of 4 KB pages below that); the raw ~34 KB size fails with "invalid argument".
  - VMM fixes: robust `libamdhip64.so` loading across sonames; correct `hipMemAccessFlags` read-write value (3, not 1).
  - Build: add `_rocm_sdk_devel/include` so torch's `thrust/complex.h` resolves under the split rocm-sdk pip layout (no-op when that package is absent).

  ## Test Plan

  Ran the gfx1250 multi-GPU all-reduce test on 4x gfx1250 / ROCm 7.15.0 across tp2/tp4 x fp16/bf16 x 5 shapes, for both transports:
  - default (IPC + gfx1250 kernel)
  - `AITER_CUSTOM_AR_FORCE_VMM=1` (VMM + gfx1250 kernel)
  - `AITER_CUSTOM_AR_DISABLE_GFX1250=1` (old IPC + old kernel)

  ## Test Result

  All configs pass `checkAllclose` with err = 0 (a few bf16 ~1e-4 rounding) for both IPC and VMM transports. No hangs or IPC failures.

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.