### PR TITLE
fix FIPS crash in hash_signature

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -278,7 +278,7 @@ def run_lib(func_name, folder=None):
 
 
 def hash_signature(signature: str):
-    return hashlib.md5(signature.encode("utf-8")).hexdigest()
+    return hashlib.md5(signature.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
in FIPS enabled environments, not having `usedforsecurity=False` causes aiter to crash