### PR TITLE
Make shuffle_scale_moe arch-agnostic  (Fix non-gfx950/gfx1250 regression)

### DIFF
--- a/aiter/ops/triton/utils/shuffle.py
+++ b/aiter/ops/triton/utils/shuffle.py
@@ -186,13 +186,16 @@ def shuffle_scale_moe(
         tiled = _shuffle_scale_tile_gfx1250(
             data.transpose(-1, -2), preshuffle_factor, scale_kwidth
         )
+        scale = tiled.transpose(-1, -2)
         layout = "GFX1250_SCALE"
-    elif (arch or get_arch()) == "gfx950":
+    elif arch == "gfx950":
         tiled = _shuffle_scale_tile_gfx950(
             data.transpose(-1, -2), preshuffle_factor, scale_kwidth
         )
+        scale = tiled.transpose(-1, -2)
         layout = "CDNA4_SCALE"
-    scale = tiled.transpose(-1, -2)
+    else:
+        scale = data
     return (scale, layout) if return_layout else scale
 
 


### PR DESCRIPTION
## Motivation

[#3900](https://github.com/ROCm/aiter/pull/3900) unified the scale-swizzle helpers into `shuffle_scale_moe`, but only the gfx1250/gfx950 branches assign `tiled`, so on any other arch (e.g. gfx1201) it raises `UnboundLocalError: ... 'tiled'` since `tiled` is never assigned.

The old `swizzle_scales` handled unknown archs with `else: return data, None`. The refactor dropped that fallback, this restores it. Non-gfx950/1250 arches skip shuffling and return the scale unchanged (`layout=None`).

No change for gfx1250/gfx950.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
