### PR TITLE
[gfx1151] [triton-fa]: tune FlashAttention backward configs

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -39,6 +39,40 @@ NONCAUSAL_AUTOTUNE_KEYS = [
 ]
 
 
+def _get_gfx1151_bwd_configs():
+    preprocess_configs = [
+        triton.Config({"PRE_BLOCK": 128}, num_stages=1, num_warps=4),
+    ]
+    noncausal_configs = [
+        triton.Config(
+            {
+                "BLOCK_M1": 16,
+                "BLOCK_N1": 64,
+                "BLOCK_M2": 64,
+                "BLOCK_N2": 16,
+                "BLK_SLICE_FACTOR": 2,
+                "waves_per_eu": 1,
+            },
+            num_stages=2,
+            num_warps=4,
+        ),
+    ]
+    causal_configs = [
+        triton.Config(
+            {
+                "BLOCK_M1": 32,
+                "BLOCK_N1": 32,
+                "BLOCK_M2": 32,
+                "BLOCK_N2": 32,
+                "BLK_SLICE_FACTOR": 2,
+            },
+            num_stages=1,
+            num_warps=4,
+        ),
+    ]
+    return (preprocess_configs, causal_configs, noncausal_configs)
+
+
 def get_bwd_configs(mode: AutotuneMode):
 
     if mode == "off":
@@ -180,6 +214,12 @@ def get_bwd_configs(mode: AutotuneMode):
                     num_warps=4,
                 ),
             ]
+            if arch.name == "gfx1151":
+                (
+                    preprocess_configs,
+                    causal_configs,
+                    noncausal_configs,
+                ) = _get_gfx1151_bwd_configs()
         else:
             preprocess_configs = [
                 triton.Config(
@@ -609,6 +649,12 @@ def get_bwd_configs(mode: AutotuneMode):
                     num_warps=4,
                 ),
             ]
+            if arch.name == "gfx1151":
+                (
+                    preprocess_configs,
+                    causal_configs,
+                    noncausal_configs,
+                ) = _get_gfx1151_bwd_configs()
         else:
             preprocess_configs = [
                 triton.Config(

--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -41,6 +41,40 @@ NONCAUSAL_AUTOTUNE_KEYS = [
 ]
 
 
+def _get_gfx1151_bwd_configs():
+    preprocess_configs = [
+        triton.Config({"PRE_BLOCK": 128}, num_stages=1, num_warps=4),
+    ]
+    noncausal_configs = [
+        triton.Config(
+            {
+                "BLOCK_M1": 16,
+                "BLOCK_N1": 64,
+                "BLOCK_M2": 64,
+                "BLOCK_N2": 16,
+                "BLK_SLICE_FACTOR": 2,
+                "waves_per_eu": 1,
+            },
+            num_stages=2,
+            num_warps=4,
+        ),
+    ]
+    causal_configs = [
+        triton.Config(
+            {
+                "BLOCK_M1": 32,
+                "BLOCK_N1": 32,
+                "BLOCK_M2": 32,
+                "BLOCK_N2": 32,
+                "BLK_SLICE_FACTOR": 2,
+            },
+            num_stages=1,
+            num_warps=4,
+        ),
+    ]
+    return (preprocess_configs, causal_configs, noncausal_configs)
+
+
 def get_bwd_configs(mode: AutotuneMode):
 
     if mode == "off":
@@ -182,6 +216,12 @@ def get_bwd_configs(mode: AutotuneMode):
                     num_warps=4,
                 ),
             ]
+            if arch.name == "gfx1151":
+                (
+                    preprocess_configs,
+                    causal_configs,
+                    noncausal_configs,
+                ) = _get_gfx1151_bwd_configs()
         else:
             preprocess_configs = [
                 triton.Config(
@@ -611,6 +651,12 @@ def get_bwd_configs(mode: AutotuneMode):
                     num_warps=4,
                 ),
             ]
+            if arch.name == "gfx1151":
+                (
+                    preprocess_configs,
+                    causal_configs,
+                    noncausal_configs,
+                ) = _get_gfx1151_bwd_configs()
         else:
             preprocess_configs = [
                 triton.Config(


### PR DESCRIPTION
## Summary

Tune the fixed FlashAttention backward configuration for `gfx1151` (Strix Halo / RDNA 3.5).

- use `PRE_BLOCK=128` for backward preprocessing;
- use asymmetric `16x64` / `64x16` tiles, four warps, two stages, and `waves_per_eu=1` for the non-causal backward kernel;
- keep the existing conservative `32x32` causal configuration unchanged;
- apply the same architecture-specific configuration in fixed and autotune dispatch.

The override is gated on `arch.name == "gfx1151"`; other architectures retain their existing configuration lists.

This follows the initial tuning direction and measurements reported by @woct0rdho in #3778. Thank you for identifying the issue and sharing the starting point.

Fixes #3778

## Performance

Measured on a clean Radeon 8060S (`gfx1151`) system. Each baseline and patched shape was run three times, with order alternated on the second repetition. The table reports median TFLOPS.

| Shape | Baseline | Patched | Delta |
|---|---:|---:|---:|
| B1/H16/S4096/D64, fp16, non-causal | 9.674 | 19.814 | **+104.82%** |
| B1/H32/S8192/D128, bf16, non-causal | 2.864 | 4.061 | **+41.79%** |
| B1/H16/S16384/D64, fp16, non-causal | 9.585 | 20.812 | **+117.12%** |
| B1/H16/S4096/D64, bf16, causal control | 8.250 | 8.490 | **+2.91%** |

The patched min/max spread was below 0.60% for every shape. The largest baseline spread was 1.50%.

Benchmark command pattern:

```bash
HSA_OVERRIDE_GFX_VERSION=11.5.1 \
FLASH_ATTENTION_TRITON_AMD_AUTOTUNE=0 \
python op_tests/op_benchmarks/triton/bench_mha.py \
  -fn bwd -b 1 -hq <heads> -hk <heads> -sq <seqlen> -sk <seqlen> \
  -d <head-dim> -causal <true|false> --dtype <fp16|bf16> \
  -impl dao_ai -metric throughput -o <output-dir>
```

Environment:

- kernel `6.19.4-061904-generic`;
- PyTorch `2.13.0a0+rocm7.13.0a20260422`;
- HIP `7.13.26154`;
- Triton `3.7.0`;
- `HSA_OVERRIDE_GFX_VERSION=11.5.1`.

## Validation

- Three targeted official `test_mha_dao_ai` backward cases passed: small causal, small non-causal, and production-size S4096 non-causal. These compare output and `dq`/`dk`/`dv` against the PyTorch reference.
- A full B1/H16/S4096/D64 fp16 non-causal output and gradient comparison against an upcast reference passed with maximum absolute error at most `0.000244141`.
- Black 26.3.0 passed.
- Ruff 0.15.7 passed.
- `python3 -m py_compile` passed.
- `git diff --check` passed.

A patched S4096 profiler anchor captured five backward iterations. `bwd_kernel_fused_noncausal` accounted for 41.234 ms (96.38% of GPU time), while `_bwd_preprocess` accounted for 1.348 ms (3.15%).
