### PR TITLE
[bugfix] Topk gating nan/inf inputs

### DIFF
--- a/csrc/kernels/topk_gating_kernels.cu
+++ b/csrc/kernels/topk_gating_kernels.cu
@@ -70,6 +70,16 @@ __device__ __forceinline__ float compute_score(float x)
     else
     {
         // sqrt(softplus(x)) = sqrt(log(1 + exp(x)))
+        // Clamp +Inf (and absurd) logits to a large finite value: softplus is
+        // unbounded, so an Inf logit would make sqrt(softplus) = Inf and then
+        // overflow the renorm sum to NaN. 1e30 keeps the expert the top-ranked
+        // one while staying finite; realistic logits (<< 1e30) are unchanged.
+        // NOTE: an explicit compare, not fminf -- fminf(NaN, 1e30) returns 1e30,
+        // which would turn a NaN logit into a huge finite score and defeat the
+        // NaN guard. `NaN > 1e30` is false, so NaN falls through unchanged and is
+        // rejected downstream.
+        if(x > 1.0e30f)
+            x = 1.0e30f;
         // Highest-precision path: pure libm (expf + log1pf), ≤1 ULP.
         // Faster alternatives (commented out, ~0.5-1 ULP extra error):
         //   float sp = x > 20.0f ? x : log1pf(exp2f(x * 1.4426950408889634f));   // exp2f HW
@@ -215,6 +225,10 @@ __global__ void topk_softplus_kernel_opt(
         idxs[i]     = e;
         if(correction_bias != nullptr)
             vals[i] += static_cast<float>(correction_bias[e]);
+        // A NaN selection score never wins the argmax and would stall this
+        // lane's cursor in the k-way merge (blocking its remaining experts);
+        // push NaN to the bottom so it is simply excluded.
+        vals[i] = ::isnan(vals[i]) ? -INFINITY : vals[i];
     }
 
     // Step 2: sort thread-local partition descending
@@ -327,6 +341,10 @@ __global__ void topk_softplus_kernel_opt_multiwave(
         idxs[i]     = e;
         if(correction_bias != nullptr)
             vals[i] += static_cast<float>(correction_bias[e]);
+        // A NaN selection score never wins the argmax and would stall this
+        // lane's cursor in the k-way merge (blocking its remaining experts);
+        // push NaN to the bottom so it is simply excluded.
+        vals[i] = ::isnan(vals[i]) ? -INFINITY : vals[i];
     }
 
     sort_network_desc<EPT>(vals, orig, idxs);
@@ -484,6 +502,10 @@ __global__ void topk_softplus_kernel_opt_n(
         idxs[i]     = e;
         if(correction_bias != nullptr)
             vals[i] += static_cast<float>(correction_bias[e]);
+        // A NaN selection score never wins the argmax and would stall this
+        // lane's cursor in the k-way merge (blocking its remaining experts);
+        // push NaN to the bottom so it is simply excluded.
+        vals[i] = ::isnan(vals[i]) ? -INFINITY : vals[i];
     }
 
     sort_network_desc<EPT>(vals, orig, idxs);
@@ -636,14 +658,16 @@ void topk_softplus_kernel_prefill(
 #pragma unroll
         for(int i = 0; i < VPT; i++)
         {
-            row_chunk[i] = exp2f((row_chunk[i] - local_max) * 1.4426950408889634f);
-            local_sum += row_chunk[i];
+            float ex     = exp2f((row_chunk[i] - local_max) * 1.4426950408889634f);
+            bool  bad    = ::isnan(ex);              // NaN/Inf logit
+            row_chunk[i] = bad ? -INFINITY : ex;     // exclude from selection & sum
+            local_sum += bad ? 0.0f : ex;
         }
 #pragma unroll
         for(int off = THREADS_PER_ROW >> 1; off >= 1; off >>= 1)
             local_sum += __shfl_xor(local_sum, off);
 
-        float inv_sum = __builtin_amdgcn_rcpf(local_sum);
+        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, 1e-20f));
 #pragma unroll
         for(int i = 0; i < VPT; i++)
         {
@@ -777,12 +801,14 @@ __global__ void topk_softplus_kernel(
         float local_sum = 0.0f;
         for(int e = threadIdx.x; e < num_experts; e += blockDim.x)
         {
-            scores[e] = exp2f((scores[e] - local_max) * 1.4426950408889634f);
-            local_sum += scores[e];
+            float ex  = exp2f((scores[e] - local_max) * 1.4426950408889634f);
+            bool  bad = ::isnan(ex);            // NaN/Inf logit
+            scores[e] = bad ? -INFINITY : ex;   // exclude from selection (stays -inf
+            local_sum += bad ? 0.0f : ex;       // through *inv_sum +bias) and from sum
         }
         local_sum = wave_reduce(local_sum, [](float a, float b) { return a + b; });
 
-        float inv_sum = __builtin_amdgcn_rcpf(local_sum);
+        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, 1e-20f));
         for(int e = threadIdx.x; e < num_experts; e += blockDim.x)
         {
             scores[e] *= inv_sum;
@@ -936,14 +962,16 @@ __global__ void topk_softplus_kernel_smem_n(
         float local_sum = 0.0f;
         for(int e = lane_in_row; e < num_experts; e += THREADS_PER_ROW)
         {
-            scores[e] = exp2f((scores[e] - local_max) * 1.4426950408889634f);
-            local_sum += scores[e];
+            float ex  = exp2f((scores[e] - local_max) * 1.4426950408889634f);
+            bool  bad = ::isnan(ex);            // NaN/Inf logit
+            scores[e] = bad ? -INFINITY : ex;   // exclude from selection (stays -inf
+            local_sum += bad ? 0.0f : ex;       // through *inv_sum +bias) and from sum
         }
 #pragma unroll
         for(int off = THREADS_PER_ROW >> 1; off >= 1; off >>= 1)
             local_sum += __shfl_xor(local_sum, off);
 
-        float inv_sum = __builtin_amdgcn_rcpf(local_sum);
+        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, 1e-20f));
         for(int e = lane_in_row; e < num_experts; e += THREADS_PER_ROW)
         {
             scores[e] *= inv_sum;

--- a/csrc/kernels/topk_gating_kernels.cu
+++ b/csrc/kernels/topk_gating_kernels.cu
@@ -228,6 +228,10 @@ __global__ void topk_softplus_kernel_opt(
         // A NaN selection score never wins the argmax and would stall this
         // lane's cursor in the k-way merge (blocking its remaining experts);
         // push NaN to the bottom so it is simply excluded.
+        // NOTE: ::isnan() is compiled away under -ffast-math (-ffinite-math-only).
+        // aiter does not use -ffast-math; if that ever changes, replace with a
+        // bit-pattern check: (bit_cast<uint32_t>(v) & 0x7F800000) == 0x7F800000
+        //                 && (bit_cast<uint32_t>(v) & 0x007FFFFF) != 0
         vals[i] = ::isnan(vals[i]) ? -INFINITY : vals[i];
     }
 
@@ -344,6 +348,7 @@ __global__ void topk_softplus_kernel_opt_multiwave(
         // A NaN selection score never wins the argmax and would stall this
         // lane's cursor in the k-way merge (blocking its remaining experts);
         // push NaN to the bottom so it is simply excluded.
+        // NOTE: ::isnan() is compiled away under -ffast-math; see opt kernel.
         vals[i] = ::isnan(vals[i]) ? -INFINITY : vals[i];
     }
 
@@ -505,6 +510,7 @@ __global__ void topk_softplus_kernel_opt_n(
         // A NaN selection score never wins the argmax and would stall this
         // lane's cursor in the k-way merge (blocking its remaining experts);
         // push NaN to the bottom so it is simply excluded.
+        // NOTE: ::isnan() is compiled away under -ffast-math; see opt kernel.
         vals[i] = ::isnan(vals[i]) ? -INFINITY : vals[i];
     }
 
@@ -646,6 +652,27 @@ void topk_softplus_kernel_prefill(
     // then add bias for topk selection.  row_orig[] holds unbiased softmax weights.
     if constexpr(SCORE_FUNC == SCORE_SOFTMAX)
     {
+        // Exclude NaN logits before the max: a NaN in the max would make every
+        // exp(x - NaN) = NaN, poisoning the entire row.  +Inf logits are kept
+        // so that softmax(+Inf) = 1.0, the limit as one logit dominates.  (NOTE:
+        // this diverges from torch.softmax, whose max-subtraction still hits
+        // exp(+inf - +inf) = exp(nan) = nan, so torch.softmax(row_with_inf) is
+        // all-NaN -- see the diff-is-NaN check below for how this kernel avoids
+        // that.)
+        // is_nan[] is remembered (not re-derived from the probability) because
+        // a NaN expert's probability normalizes to the same 0.0 a genuinely
+        // low-but-finite expert can reach -- without the flag, adding bias
+        // below would let a NaN logit win a slot purely on a favorable bias,
+        // the same bug being fixed here for the -Inf/argmax paths.
+        // NOTE: ::isnan() is compiled away under -ffast-math; see opt kernel.
+        bool is_nan[VPT];
+#pragma unroll
+        for(int i = 0; i < VPT; i++)
+        {
+            is_nan[i]    = ::isnan(row_chunk[i]);
+            row_chunk[i] = is_nan[i] ? -INFINITY : row_chunk[i];
+        }
+
         float local_max = row_chunk[0];
 #pragma unroll
         for(int i = 1; i < VPT; i++)
@@ -658,10 +685,16 @@ void topk_softplus_kernel_prefill(
 #pragma unroll
         for(int i = 0; i < VPT; i++)
         {
-            float ex     = exp2f((row_chunk[i] - local_max) * 1.4426950408889634f);
-            bool  bad    = ::isnan(ex);              // NaN/Inf logit
-            row_chunk[i] = bad ? -INFINITY : ex;     // exclude from selection & sum
-            local_sum += bad ? 0.0f : ex;
+            // When local_max == +Inf (row has a +Inf logit):
+            //   +Inf expert: +Inf - +Inf = NaN → exp = NaN, but we know this
+            //     logit equals local_max, so the correct softmax exp is 1.0.
+            //   finite expert: finite - +Inf = -Inf → exp = 0 (correct).
+            // When local_max is finite, no special case needed.
+            float diff   = row_chunk[i] - local_max;
+            float ex     = ::isnan(diff) ? 1.0f
+                         : exp2f(diff * 1.4426950408889634f);
+            row_chunk[i] = ex;
+            local_sum += ex;
         }
 #pragma unroll
         for(int off = THREADS_PER_ROW >> 1; off >= 1; off >>= 1)
@@ -675,6 +708,10 @@ void topk_softplus_kernel_prefill(
             row_orig[i]   = row_chunk[i];
             if(correction_bias != nullptr)
                 row_chunk[i] += static_cast<float>(correction_bias[lane_in_group * VPT + i]);
+            // A NaN expert's probability is 0.0, same as a genuinely low
+            // finite expert's -- bias alone could otherwise win it a slot.
+            // Force it back below any real selection score.
+            if(is_nan[i]) row_chunk[i] = -INFINITY;
         }
     }
 
@@ -793,6 +830,13 @@ __global__ void topk_softplus_kernel(
     // The topk loop subtracts bias back to get unbiased softmax weights.
     if constexpr(SCORE_FUNC == SCORE_SOFTMAX)
     {
+        // Exclude NaN logits before the max so they don't poison the row.
+        // +Inf logits are kept: softmax(+Inf) should be 1.0.
+        // NOTE: ::isnan() is compiled away under -ffast-math; see opt kernel.
+        for(int e = threadIdx.x; e < num_experts; e += blockDim.x)
+            scores[e] = ::isnan(scores[e]) ? -INFINITY : scores[e];
+        __syncthreads();
+
         float local_max = -INFINITY;
         for(int e = threadIdx.x; e < num_experts; e += blockDim.x)
             local_max = fmaxf(local_max, scores[e]);
@@ -801,10 +845,11 @@ __global__ void topk_softplus_kernel(
         float local_sum = 0.0f;
         for(int e = threadIdx.x; e < num_experts; e += blockDim.x)
         {
-            float ex  = exp2f((scores[e] - local_max) * 1.4426950408889634f);
-            bool  bad = ::isnan(ex);            // NaN/Inf logit
-            scores[e] = bad ? -INFINITY : ex;   // exclude from selection (stays -inf
-            local_sum += bad ? 0.0f : ex;       // through *inv_sum +bias) and from sum
+            float diff = scores[e] - local_max;
+            float ex   = ::isnan(diff) ? 1.0f
+                       : exp2f(diff * 1.4426950408889634f);
+            scores[e]  = ex;
+            local_sum += ex;
         }
         local_sum = wave_reduce(local_sum, [](float a, float b) { return a + b; });
 
@@ -814,6 +859,11 @@ __global__ void topk_softplus_kernel(
             scores[e] *= inv_sum;
             if(correction_bias != nullptr)
                 scores[e] += static_cast<float>(correction_bias[e]);
+            // A NaN expert's probability is 0.0, same as a genuinely low
+            // finite expert's -- bias alone could otherwise win it a slot.
+            // Force it back below any real selection score.
+            if(::isnan(static_cast<float>(input_ptr[e])))
+                scores[e] = -INFINITY;
         }
         __syncthreads();
     }
@@ -952,6 +1002,12 @@ __global__ void topk_softplus_kernel_smem_n(
     // -----------------------------------------------------------------------
     if constexpr(SCORE_FUNC == SCORE_SOFTMAX)
     {
+        // Exclude NaN logits before the max so they don't poison the row.
+        // +Inf logits are kept: softmax(+Inf) should be 1.0.
+        // NOTE: ::isnan() is compiled away under -ffast-math; see opt kernel.
+        for(int e = lane_in_row; e < num_experts; e += THREADS_PER_ROW)
+            scores[e] = ::isnan(scores[e]) ? -INFINITY : scores[e];
+
         float local_max = -INFINITY;
         for(int e = lane_in_row; e < num_experts; e += THREADS_PER_ROW)
             local_max = fmaxf(local_max, scores[e]);
@@ -962,10 +1018,11 @@ __global__ void topk_softplus_kernel_smem_n(
         float local_sum = 0.0f;
         for(int e = lane_in_row; e < num_experts; e += THREADS_PER_ROW)
         {
-            float ex  = exp2f((scores[e] - local_max) * 1.4426950408889634f);
-            bool  bad = ::isnan(ex);            // NaN/Inf logit
-            scores[e] = bad ? -INFINITY : ex;   // exclude from selection (stays -inf
-            local_sum += bad ? 0.0f : ex;       // through *inv_sum +bias) and from sum
+            float diff = scores[e] - local_max;
+            float ex   = ::isnan(diff) ? 1.0f
+                       : exp2f(diff * 1.4426950408889634f);
+            scores[e]  = ex;
+            local_sum += ex;
         }
 #pragma unroll
         for(int off = THREADS_PER_ROW >> 1; off >= 1; off >>= 1)
@@ -977,6 +1034,11 @@ __global__ void topk_softplus_kernel_smem_n(
             scores[e] *= inv_sum;
             if(correction_bias != nullptr)
                 scores[e] += static_cast<float>(correction_bias[e]);
+            // A NaN expert's probability is 0.0, same as a genuinely low
+            // finite expert's -- bias alone could otherwise win it a slot.
+            // Force it back below any real selection score.
+            if(::isnan(static_cast<float>(input_ptr[e])))
+                scores[e] = -INFINITY;
         }
         __syncthreads();
     }

--- a/csrc/kernels/topk_gating_kernels.cu
+++ b/csrc/kernels/topk_gating_kernels.cu
@@ -19,6 +19,7 @@
 #include "hip_reduce.h"
 #include "aiter_opus_plus.h"
 #include <hip/hip_runtime.h>
+#include <cfloat>
 #include <type_traits>
 
 namespace aiter {
@@ -36,6 +37,19 @@ inline bool topk_gating_prefer_optn_e128()
 // ---------------------------------------------------------------------------
 
 enum { SCORE_SQRTSOFTPLUS = 0, SCORE_SIGMOID = 1, SCORE_SOFTMAX = 2 };
+
+// Finite sentinel that +Inf logits are clamped to before sqrt(softplus) (see
+// compute_score). FLT_MAX is the largest finite float, so the clamp fires only
+// for +Inf (no finite logit exceeds it) and leaves every finite logit untouched.
+// After sqrt(softplus) the score is sqrt(FLT_MAX) ~= 1.84e19, so even summing it
+// across all experts stays well within fp32 range and cannot overflow the renorm.
+constexpr float SOFTPLUS_LOGIT_CLAMP = FLT_MAX;
+
+// Lower floor for the normalization denominator. This is only a degeneracy
+// guard for zero/subnormal sums (e.g. every expert masked out / NaN), not a
+// regular damping epsilon: top-k routing should preserve tiny-but-valid sums.
+// Keep it far below any real routing sum while still preventing division by 0.
+constexpr float RENORM_SUM_FLOOR = 1e-20f;
 
 // Fused DPP warp argmax: 6× v_max_f32+DPP + ballot + ctzll + readlane ≈ 9 instr.
 // NaN-safe: if all lanes have NaN (val_o == max_val is always false), ballot is 0
@@ -70,16 +84,16 @@ __device__ __forceinline__ float compute_score(float x)
     else
     {
         // sqrt(softplus(x)) = sqrt(log(1 + exp(x)))
-        // Clamp +Inf (and absurd) logits to a large finite value: softplus is
-        // unbounded, so an Inf logit would make sqrt(softplus) = Inf and then
-        // overflow the renorm sum to NaN. 1e30 keeps the expert the top-ranked
-        // one while staying finite; realistic logits (<< 1e30) are unchanged.
-        // NOTE: an explicit compare, not fminf -- fminf(NaN, 1e30) returns 1e30,
-        // which would turn a NaN logit into a huge finite score and defeat the
-        // NaN guard. `NaN > 1e30` is false, so NaN falls through unchanged and is
-        // rejected downstream.
-        if(x > 1.0e30f)
-            x = 1.0e30f;
+        // Clamp +Inf logits to SOFTPLUS_LOGIT_CLAMP: softplus is unbounded, so an
+        // Inf logit would make sqrt(softplus) = Inf and then overflow the renorm
+        // sum to NaN. The clamp keeps the expert top-ranked while staying finite
+        // (see the constant for the magnitude rationale).
+        // NOTE: an explicit compare, not fminf -- fminf(NaN, clamp) returns the
+        // clamp, which would turn a NaN logit into a huge finite score and defeat
+        // the NaN guard. `NaN > clamp` is false, so NaN falls through unchanged
+        // and is rejected downstream.
+        if(x > SOFTPLUS_LOGIT_CLAMP)
+            x = SOFTPLUS_LOGIT_CLAMP;
         // Highest-precision path: pure libm (expf + log1pf), ≤1 ULP.
         // Faster alternatives (commented out, ~0.5-1 ULP extra error):
         //   float sp = x > 20.0f ? x : log1pf(exp2f(x * 1.4426950408889634f));   // exp2f HW
@@ -271,7 +285,7 @@ __global__ void topk_softplus_kernel_opt(
 
     // Step 4: renorm + scale + write
     if constexpr(need_renorm)
-        sum = routed_scaling_factor / fmaxf(sum, 1e-20f);
+        sum = routed_scaling_factor / fmaxf(sum, RENORM_SUM_FLOOR);
     else
         sum = routed_scaling_factor;
 
@@ -409,7 +423,7 @@ __global__ void topk_softplus_kernel_opt_multiwave(
         }
 
         if constexpr(need_renorm)
-            out_scale = routed_scaling_factor / fmaxf(sum, 1e-20f);
+            out_scale = routed_scaling_factor / fmaxf(sum, RENORM_SUM_FLOOR);
         else
             out_scale = routed_scaling_factor;
     }
@@ -544,7 +558,7 @@ __global__ void topk_softplus_kernel_opt_n(
     }
 
     if constexpr(need_renorm)
-        sum = routed_scaling_factor / fmaxf(sum, 1e-20f);
+        sum = routed_scaling_factor / fmaxf(sum, RENORM_SUM_FLOOR);
     else
         sum = routed_scaling_factor;
 
@@ -700,7 +714,7 @@ void topk_softplus_kernel_prefill(
         for(int off = THREADS_PER_ROW >> 1; off >= 1; off >>= 1)
             local_sum += __shfl_xor(local_sum, off);
 
-        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, 1e-20f));
+        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, RENORM_SUM_FLOOR));
 #pragma unroll
         for(int i = 0; i < VPT; i++)
         {
@@ -756,7 +770,7 @@ void topk_softplus_kernel_prefill(
     }
 
     if constexpr(need_renorm)
-        sum = routed_scaling_factor / fmaxf(sum, 1e-20f);
+        sum = routed_scaling_factor / fmaxf(sum, RENORM_SUM_FLOOR);
     else
         sum = routed_scaling_factor;
 
@@ -853,7 +867,7 @@ __global__ void topk_softplus_kernel(
         }
         local_sum = wave_reduce(local_sum, [](float a, float b) { return a + b; });
 
-        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, 1e-20f));
+        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, RENORM_SUM_FLOOR));
         for(int e = threadIdx.x; e < num_experts; e += blockDim.x)
         {
             scores[e] *= inv_sum;
@@ -897,7 +911,7 @@ __global__ void topk_softplus_kernel(
     }
 
     if(need_renorm)
-        sum = routed_scaling_factor / fmaxf(sum, 1e-20f);
+        sum = routed_scaling_factor / fmaxf(sum, RENORM_SUM_FLOOR);
     else
         sum = routed_scaling_factor;
 
@@ -1028,7 +1042,7 @@ __global__ void topk_softplus_kernel_smem_n(
         for(int off = THREADS_PER_ROW >> 1; off >= 1; off >>= 1)
             local_sum += __shfl_xor(local_sum, off);
 
-        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, 1e-20f));
+        float inv_sum = __builtin_amdgcn_rcpf(fmaxf(local_sum, RENORM_SUM_FLOOR));
         for(int e = lane_in_row; e < num_experts; e += THREADS_PER_ROW)
         {
             scores[e] *= inv_sum;
@@ -1087,7 +1101,7 @@ __global__ void topk_softplus_kernel_smem_n(
     }
 
     if constexpr(need_renorm)
-        sum = routed_scaling_factor / fmaxf(sum, 1e-20f);
+        sum = routed_scaling_factor / fmaxf(sum, RENORM_SUM_FLOOR);
     else
         sum = routed_scaling_factor;
 

--- a/csrc/kernels/topk_gating_kernels.cu
+++ b/csrc/kernels/topk_gating_kernels.cu
@@ -607,9 +607,15 @@ void topk_softplus_kernel_prefill(
             float score         = compute_score<SCORE_FUNC>(static_cast<float>(vec[j]));
             row_orig[elt]       = score;
             row_chunk[elt]      = score;
-            if(correction_bias != nullptr) {
-                int global_e    = lane_in_group * VPT + elt;
-                row_chunk[elt] += static_cast<float>(correction_bias[global_e]);
+            // Softmax adds bias AFTER normalization (see block below), matching
+            // the smem kernels. Adding it here would make softmax normalize over
+            // (logit+bias) and double-count bias in the selection score.
+            if constexpr(SCORE_FUNC != SCORE_SOFTMAX)
+            {
+                if(correction_bias != nullptr) {
+                    int global_e    = lane_in_group * VPT + elt;
+                    row_chunk[elt] += static_cast<float>(correction_bias[global_e]);
+                }
             }
         }
     }

--- a/op_tests/test_moe_topk_gating.py
+++ b/op_tests/test_moe_topk_gating.py
@@ -2,15 +2,16 @@
 # Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
 
 """
-Test topk_sigmoid operation with various configurations.
+Test topk_gating (topk_sigmoid / topk_softplus / topk_softmax) operations with
+various configurations.
 
 This test can be run in two ways:
 
 1. Using pytest (for automated testing):
-   pytest test_moe_topk_sigmoid.py -v
+   pytest test_moe_topk_gating.py -v
 
 2. Using command line arguments (for benchmarking with summary table):
-   python test_moe_topk_sigmoid.py --num-experts 64,128 --topk 2,4,8 --dtype fp16
+   python test_moe_topk_gating.py --num-experts 64,128 --topk 2,4,8 --dtype fp16
 """
 
 import argparse
@@ -25,18 +26,17 @@ import aiter
 from aiter.test_common import (
     benchmark,
     checkAllclose,
-    perftest,
     run_perftest,
 )
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.utility.dtypes import str2Dtype, str2tuple
 
 # NOTE on correctness metrics by score function:
-# - sigmoid uses element-wise comparison (score_errors/index_errors) because
-#   both torch/topk and fused paths return sorted top-K.
-# - softplus/softmax use set-based ID matching (id_errors/max_weight_err)
-#   because torch references intentionally use `topk(..., sorted=False)` to
-#   mirror routing behavior where top-K order is not semantically required.
+# - sigmoid uses element-wise comparison (score_err/idx_err) because both
+#   torch and the fused kernel return sorted top-K.
+# - softplus/softmax use set-based ID matching (err/max_weight_err) because
+#   torch references intentionally use `topk(..., sorted=False)` to mirror
+#   routing behavior where top-K order is not semantically required.
 #
 # Tie-aware selection: the fused kernel scores experts with hardware-approximate
 # math (exp2f/log2f, ~1e-6 ULP), while the torch reference uses exact libm. When
@@ -52,6 +52,10 @@ from aiter.utility.dtypes import str2Dtype, str2tuple
 # noise (~1e-6 on O(1) scores), so genuine routing bugs (gaps >> 1e-4) are still
 # caught while harmless tie flips are excused.
 _TIE_TOL = 1e-4
+
+# Max abs weight error for matched expert ids (softplus/softmax). ~100x the
+# kernel's exp2f/log2f approximation noise on O(1) weights.
+_WEIGHT_TOL = 1e-4
 
 
 def _selection_scores(
@@ -119,7 +123,7 @@ def _count_routing_mismatches(
     ref_full = ref_mask.sum(dim=1) == topk
     match = (fused_mask == ref_mask).all(dim=1) & fused_full
 
-    extra = fused_mask & ~ref_mask   # kernel-only -> must be >= cutoff - tol
+    extra = fused_mask & ~ref_mask  # kernel-only -> must be >= cutoff - tol
     missing = ref_mask & ~fused_mask  # ref-only    -> must be <= cutoff + tol
     extra_ok = ((~extra) | (sel >= (cutoff - tol))).all(dim=1)
     missing_ok = ((~missing) | (sel <= (cutoff + tol))).all(dim=1)
@@ -159,190 +163,15 @@ def _count_routing_mismatches(
     return mism
 
 
-@perftest(num_iters=10, num_warmup=1)
-def run_torch(gating_output: torch.Tensor, topk: int):
-    # llama4 maverick custom routing function
-    router_scores, router_indices = torch.topk(gating_output, topk, dim=-1)
-    router_scores = torch.sigmoid(router_scores.float())
-    return router_scores, router_indices.to(torch.int32)
-
-
-@perftest(num_iters=100, num_warmup=1)
-def run_fused(gating_output: torch.Tensor, topk: int):
-    tokens, num_experts = gating_output.shape
-    router_scores = torch.empty(
-        (tokens, topk), dtype=torch.float32, device=gating_output.device
+def _make_gating(num_experts, num_tokens, dtype):
+    """Shuffled uniform gating output -- each row has unique values."""
+    gating_output = (
+        torch.arange(-1, 1, 2.0 / num_experts)
+        .repeat((num_tokens, 1))
+        .to(dtype=dtype, device="cuda")
     )
-    router_indices = torch.empty(
-        (tokens, topk), dtype=torch.int32, device=gating_output.device
-    )
-    aiter.topk_gating(
-        router_scores,
-        router_indices,
-        gating_output,
-        score_func="sigmoid",
-        need_renorm=False,
-    )
-    return router_scores, router_indices
-
-
-# -- topk_softplus (DeepSeek V4-Pro sqrtsoftplus routing) --------------
-@perftest(num_iters=10, num_warmup=1)
-def run_torch_softplus(
-    gating_output: torch.Tensor,
-    bias: torch.Tensor,
-    topk: int,
-    renormalize: bool,
-    route_scale: float,
-):
-    scores = torch.nn.functional.softplus(gating_output.float()).sqrt()
-    scores_biased = scores + bias.float()
-    topk_ids = scores_biased.topk(topk, dim=-1, sorted=False)[1]
-    topk_weights = scores.gather(1, topk_ids)
-    if renormalize:
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
-    topk_weights = topk_weights * route_scale
-    return topk_weights, topk_ids.to(torch.int32)
-
-
-@perftest(num_iters=100, num_warmup=1)
-def run_fused_softplus(
-    gating_output: torch.Tensor,
-    bias: torch.Tensor,
-    topk: int,
-    renormalize: bool,
-    route_scale: float,
-):
-    tokens, _ = gating_output.shape
-    topk_weights = torch.empty(
-        (tokens, topk), dtype=torch.float32, device=gating_output.device
-    )
-    topk_ids = torch.empty(
-        (tokens, topk), dtype=torch.int32, device=gating_output.device
-    )
-    aiter.topk_softplus(
-        topk_weights, topk_ids, gating_output, bias, renormalize, route_scale
-    )
-    return topk_weights, topk_ids
-
-
-# -- topk_softmax ( classic MoE softmax routing) --------------
-@perftest(num_iters=10, num_warmup=1)
-def run_torch_softmax(
-    gating_output: torch.Tensor,
-    bias: torch.Tensor,
-    topk: int,
-    route_scale: float,
-):
-    scores = torch.softmax(gating_output.float(), dim=-1)
-    scores_biased = scores + bias.float() if bias.numel() > 0 else scores
-    topk_ids = scores_biased.topk(topk, dim=-1, sorted=False)[1]
-    topk_weights = scores.gather(1, topk_ids) * route_scale
-    return topk_weights, topk_ids.to(torch.int32)
-
-
-@perftest(num_iters=100, num_warmup=1)
-def run_fused_softmax(
-    gating_output: torch.Tensor,
-    bias: torch.Tensor,
-    topk: int,
-    route_scale: float,
-):
-    tokens, _ = gating_output.shape
-    topk_weights = torch.empty(
-        (tokens, topk), dtype=torch.float32, device=gating_output.device
-    )
-    topk_ids = torch.empty(
-        (tokens, topk), dtype=torch.int32, device=gating_output.device
-    )
-    aiter.topk_gating(
-        topk_weights,
-        topk_ids,
-        gating_output,
-        bias,
-        need_renorm=False,  # softmax is already normalized
-        routed_scaling_factor=route_scale,
-        score_func="softmax",
-    )
-    return topk_weights, topk_ids
-
-
-@perftest(num_iters=100, num_warmup=1)
-def run_vllm_softmax(
-    gating_output: torch.Tensor,
-    topk: int,
-    route_scale: float,
-):
-    """vLLM-adapted topkGatingSoftmax kernel (topk_softmax_kernels.cu)."""
-    tokens, _ = gating_output.shape
-    topk_weights = torch.empty(
-        (tokens, topk), dtype=torch.float32, device=gating_output.device
-    )
-    topk_ids = torch.empty(
-        (tokens, topk), dtype=torch.int32, device=gating_output.device
-    )
-    token_expert_indices = torch.empty(
-        (tokens, topk), dtype=torch.int32, device=gating_output.device
-    )
-    # need_renorm=True: renorm among top-K (matches softmax-route convention)
-    aiter.topk_softmax(
-        topk_weights, topk_ids, token_expert_indices, gating_output, need_renorm=False
-    )
-    if route_scale != 1.0:
-        topk_weights.mul_(route_scale)
-    return topk_weights, topk_ids
-
-
-def benchmark_topk_sigmoid(
-    num_experts: int = 128,
-    num_tokens: int = 1024,
-    topk: int = 4,
-    dtype: torch.dtype = torch.float16,
-):
-    torch.random.manual_seed(0)
-    gating_output = _make_gating(num_experts, num_tokens, dtype)
-    # run benchmarks
-    (scores_torch, indices_torch), avg_torch = run_torch(gating_output.clone(), topk)
-    (scores_fused, indices_fused), avg_fused = run_fused(gating_output.clone(), topk)
-
-    # check correctness
-    score_errors = checkAllclose(scores_torch, scores_fused, tol_err_ratio=0.01)
-    index_errors = checkAllclose(indices_torch, indices_fused, tol_err_ratio=0.01)
-
-    # Collect results for summary
-    result = {
-        "num_experts": num_experts,
-        "num_tokens": num_tokens,
-        "topk": topk,
-        "dtype": str(dtype).split(".")[-1],
-        "torch_us": avg_torch,
-        "fused_us": avg_fused,
-        "uplift": avg_torch / avg_fused,
-        "score_errors": score_errors,
-        "index_errors": index_errors,
-    }
-
-    # print some failed rows if errors are significant
-    if score_errors > 0.01 or index_errors > 0.01:
-        failed_rows = (indices_torch != indices_fused).sum(dim=-1) > 0
-        print(
-            f"\n[ERROR] Configuration: num_experts={num_experts}, num_tokens={num_tokens}, topk={topk}, dtype={str(dtype).split('.')[-1]}"
-        )
-        print("Wrong scores:")
-        print(scores_torch[failed_rows][:5])
-        print(scores_fused[failed_rows][:5])
-        print("Wrong indices:")
-        print(indices_torch[failed_rows][:5])
-        print(indices_fused[failed_rows][:5])
-        print("Gating outputs:")
-        failed_values = gating_output[failed_rows][:5]
-        failed_values, _ = failed_values.sort(dim=-1, descending=True)
-        print(failed_values[:, :10])
-        print(
-            f"Number of wrong tokens: {sum(failed_rows)} / {len(failed_rows)}, {100 * sum(failed_rows) / len(failed_rows):.2f} %"
-        )
-
-    return result
+    permutation = torch.argsort(torch.rand_like(gating_output), dim=-1)
+    return torch.gather(gating_output, dim=-1, index=permutation).contiguous()
 
 
 def _torch_weight_aligned_to_fused(w_fused, i_fused, w_torch, i_torch):
@@ -371,193 +200,202 @@ def _max_weight_error(w_fused, i_fused, w_torch, i_torch):
     return float(diff[matched].max())
 
 
-def _assert_weights_close(w_fused, i_fused, w_torch, i_torch):
-    """Assert matched expert weights are close; skip tie-swapped experts."""
-    ref, matched = _torch_weight_aligned_to_fused(w_fused, i_fused, w_torch, i_torch)
-    torch.testing.assert_close(
-        w_fused.to(torch.float32)[matched], ref[matched], atol=1e-5, rtol=1e-4
-    )
+# ---------------------------------------------------------------------------
+# torch references (fp32, untimed -- never enter the perf table, see
+# .claude/skills/aiter-op-test/SKILL.md rule 4)
+# ---------------------------------------------------------------------------
 
 
-def _make_gating(num_experts, num_tokens, dtype):
-    """Shuffled uniform gating output -- each row has unique values."""
-    gating_output = (
-        torch.arange(-1, 1, 2.0 / num_experts)
-        .repeat((num_tokens, 1))
-        .to(dtype=dtype, device="cuda")
-    )
-    permutation = torch.argsort(torch.rand_like(gating_output), dim=-1)
-    return torch.gather(gating_output, dim=-1, index=permutation).contiguous()
+def ref_sigmoid(gating_output: torch.Tensor, topk: int):
+    """Llama4 routing: select top-K by raw logit, weight = sigmoid(selected)."""
+    scores, indices = torch.topk(gating_output, topk, dim=-1)
+    return torch.sigmoid(scores.float()), indices.to(torch.int32)
 
 
-def benchmark_topk_softplus(
-    num_experts: int = 256,
-    num_tokens: int = 1024,
-    topk: int = 8,
-    dtype: torch.dtype = torch.bfloat16,
-    renormalize: bool = True,
-    route_scale: float = 2.5,
+def ref_softplus(
+    gating_output: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    route_scale: float,
 ):
-    torch.random.manual_seed(1)
-    gating_output = _make_gating(num_experts, num_tokens, dtype)
-    bias = torch.randn(num_experts, dtype=dtype, device="cuda") * 0.1
+    scores = torch.nn.functional.softplus(gating_output.float()).sqrt()
+    scores_biased = scores + bias.float()
+    topk_ids = scores_biased.topk(topk, dim=-1, sorted=False)[1]
+    topk_weights = scores.gather(1, topk_ids)
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    topk_weights = topk_weights * route_scale
+    return topk_weights, topk_ids.to(torch.int32)
 
-    (w_torch, i_torch), avg_torch = run_torch_softplus(
-        gating_output.clone(), bias, topk, renormalize, route_scale
+
+def ref_softmax(
+    gating_output: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    route_scale: float,
+):
+    scores = torch.softmax(gating_output.float(), dim=-1)
+    scores_biased = scores + bias.float() if bias.numel() > 0 else scores
+    topk_ids = scores_biased.topk(topk, dim=-1, sorted=False)[1]
+    topk_weights = scores.gather(1, topk_ids) * route_scale
+    return topk_weights, topk_ids.to(torch.int32)
+
+
+# ---------------------------------------------------------------------------
+# topk_sigmoid (Llama4 routing, via topk_gating score_func="sigmoid")
+# ---------------------------------------------------------------------------
+
+
+@benchmark()
+def bench_topk_sigmoid(num_experts, num_tokens, topk, dtype):
+    """Single fused candidate. Both torch and the fused kernel return
+    sorted-descending top-K here, so scores/indices compare element-wise."""
+    torch.random.manual_seed(0)
+    gating_output = _make_gating(num_experts, num_tokens, dtype)
+    ref_scores, ref_idx = ref_sigmoid(gating_output, topk)
+
+    def run_fused():
+        topk_weights = torch.empty(
+            (num_tokens, topk), dtype=torch.float32, device="cuda"
+        )
+        topk_ids = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+        aiter.topk_gating(
+            topk_weights,
+            topk_ids,
+            gating_output,
+            score_func="sigmoid",
+            need_renorm=False,
+        )
+        return topk_weights, topk_ids
+
+    candidates = {"fused": run_fused}
+
+    # Memory-bound: reads the [T, E] gating matrix, writes T*topk ids + weights.
+    nbytes = (
+        num_tokens * num_experts * gating_output.element_size()
+        + num_tokens * topk * (4 + 4)
     )
-    (w_fused, i_fused), avg_fused = run_fused_softplus(
-        gating_output.clone(), bias, topk, renormalize, route_scale
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        (w, ids), us = run_perftest(fn)
+        ret[f"{name} us"] = us
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} score_err"] = checkAllclose(
+            ref_scores,
+            w.to(torch.float32),
+            tol_err_ratio=0.01,
+            msg=f"{name}: sigmoid scores",
+        )
+        ret[f"{name} idx_err"] = checkAllclose(
+            ref_idx, ids, tol_err_ratio=0.01, msg=f"{name}: sigmoid indices"
+        )
+    return ret
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("topk", [1, 2, 4, 8])
+@pytest.mark.parametrize("num_tokens", [64, 1024, 2048])
+@pytest.mark.parametrize("num_experts", [64, 128, 256, 384])
+def test_topk_sigmoid_correctness(num_experts, num_tokens, topk, dtype):
+    row = bench_topk_sigmoid(num_experts, num_tokens, topk, dtype)
+    assert row["fused score_err"] <= 0.01, (
+        f"E={num_experts},T={num_tokens},topk={topk},{dtype}: "
+        f"score error {row['fused score_err']} exceeds tolerance"
     )
+    assert row["fused idx_err"] <= 0.01, (
+        f"E={num_experts},T={num_tokens},topk={topk},{dtype}: "
+        f"index error {row['fused idx_err']} exceeds tolerance"
+    )
+
+
+# ---------------------------------------------------------------------------
+# topk_softplus (DeepSeek V4-Pro sqrtsoftplus routing, via topk_gating)
+# ---------------------------------------------------------------------------
+
+
+@benchmark()
+def bench_topk_softplus(
+    num_experts,
+    num_tokens,
+    topk,
+    dtype,
+    bias_dtype=torch.float32,
+    renormalize=True,
+    route_scale=2.5,
+):
+    """Single fused candidate (topk_softplus and topk_gating(score_func=
+    "sqrtsoftplus") share the same underlying kernel). Default bias_dtype=fp32
+    matches the DeepSeek-V4 real model: bf16 router logits + fp32 correction
+    bias."""
+    torch.random.manual_seed(0)
+    gating_output = _make_gating(num_experts, num_tokens, dtype)
+    bias = (torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1).to(
+        bias_dtype
+    )
+
+    w_torch, i_torch = ref_softplus(gating_output, bias, topk, renormalize, route_scale)
+
+    def run_fused():
+        topk_weights = torch.empty(
+            (num_tokens, topk), dtype=torch.float32, device="cuda"
+        )
+        topk_ids = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+        aiter.topk_gating(
+            topk_weights,
+            topk_ids,
+            gating_output,
+            bias,
+            need_renorm=renormalize,
+            routed_scaling_factor=route_scale,
+            score_func="sqrtsoftplus",
+        )
+        return topk_weights, topk_ids
+
+    candidates = {"fused": run_fused}
 
     sel = _selection_scores(gating_output, bias, "softplus")
-    id_err = (
-        _count_routing_mismatches(
-            i_fused,
+    nbytes = (
+        num_tokens * num_experts * gating_output.element_size()
+        + num_tokens * topk * (4 + 4)
+    )
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        (w, ids), us = run_perftest(fn)
+        n_mism = _count_routing_mismatches(
+            ids,
             i_torch,
             sel,
             topk,
             bias=bias,
-            label=f"softplus E={num_experts} T={num_tokens} k={topk} {dtype}",
+            label=f"softplus {name} E={num_experts} T={num_tokens} k={topk} {dtype}",
         )
-        / num_tokens
-    )
-
-    result = {
-        "num_experts": num_experts,
-        "num_tokens": num_tokens,
-        "topk": topk,
-        "dtype": str(dtype).split(".")[-1],
-        "torch_us": avg_torch,
-        "fused_us": avg_fused,
-        "uplift": avg_torch / avg_fused,
-        "id_errors": id_err,
-        "max_weight_err": _max_weight_error(w_fused, i_fused, w_torch, i_torch),
-    }
-    if id_err > 0.01:
-        print(
-            f"\n[ERROR] softplus: num_experts={num_experts}, num_tokens={num_tokens}, "
-            f"topk={topk}, dtype={str(dtype).split('.')[-1]}, id_err={id_err:.4f}"
-        )
-    return result
+        ret[f"{name} us"] = us
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} err"] = n_mism / num_tokens
+        ret[f"{name} max_weight_err"] = _max_weight_error(w, ids, w_torch, i_torch)
+    return ret
 
 
-def benchmark_topk_softmax(
-    num_experts: int = 256,
-    num_tokens: int = 1024,
-    topk: int = 8,
-    dtype: torch.dtype = torch.bfloat16,
-    route_scale: float = 1.0,
-    use_bias: bool = False,
-):
-    torch.random.manual_seed(2)
-    gating_output = _make_gating(num_experts, num_tokens, dtype)
-    bias = (
-        torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1
-        if use_bias
-        else torch.empty(0, device="cuda")
-    )
-
-    (w_torch, i_torch), avg_torch = run_torch_softmax(
-        gating_output.clone(), bias, topk, route_scale
-    )
-    (w_fused, i_fused), avg_fused = run_fused_softmax(
-        gating_output.clone(), bias, topk, route_scale
-    )
-    # vLLM kernel: no bias support, pass gating_output directly
-    (w_vllm, i_vllm), avg_vllm = run_vllm_softmax(
-        gating_output.clone(), topk, route_scale
-    )
-
-    sel = _selection_scores(gating_output, bias, "softmax")
-    id_err_fused = (
-        _count_routing_mismatches(
-            i_fused,
-            i_torch,
-            sel,
-            topk,
-            bias=bias,
-            label=f"softmax/fused E={num_experts} T={num_tokens} k={topk} {dtype}",
-        )
-        / num_tokens
-    )
-    # vLLM kernel compared against torch (no bias, sel_scores == softmax(x))
-    sel_nobias = _selection_scores(gating_output, torch.empty(0), "softmax")
-    id_err_vllm = (
-        _count_routing_mismatches(
-            i_vllm,
-            i_torch,
-            sel_nobias,
-            topk,
-            label=f"softmax/vllm E={num_experts} T={num_tokens} k={topk} {dtype}",
-        )
-        / num_tokens
-    )
-
-    result = {
-        "num_experts": num_experts,
-        "num_tokens": num_tokens,
-        "topk": topk,
-        "dtype": str(dtype).split(".")[-1],
-        "torch_us": avg_torch,
-        "fused_us": avg_fused,
-        "vllm_us": avg_vllm,
-        "fused_uplift": avg_torch / avg_fused,
-        "vllm_uplift": avg_torch / avg_vllm,
-        "id_err_fused": id_err_fused,
-        "id_err_vllm": id_err_vllm,
-    }
-    for label, id_err in (("fused", id_err_fused), ("vllm", id_err_vllm)):
-        if id_err > 0.01:
-            print(
-                f"\n[ERROR] softmax/{label}: num_experts={num_experts}, num_tokens={num_tokens}, "
-                f"topk={topk}, dtype={str(dtype).split('.')[-1]}, id_err={id_err:.4f}"
-            )
-    return result
-
-
-# Pytest-parametrized test functions -- topk_softplus
-# Mirrors DeepSeek-V4 model integration: gating fp32 + bias fp32 is the default.
+# Mirrors DeepSeek-V4 model integration: gating fp32 + bias fp32 is the default,
+# swept here against fp16/bf16 gating with mixed bias dtypes.
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("bias_dtype", [torch.float16, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("topk", [1, 2, 4, 6, 8])
 @pytest.mark.parametrize("num_tokens", [64, 1024, 2048])
 @pytest.mark.parametrize("num_experts", [64, 128, 256, 384])
 def test_topk_softplus_correctness(num_experts, num_tokens, topk, dtype, bias_dtype):
-    """Pytest test for correctness of topk_softplus (sqrtsoftplus) operation.
-
-    Covers the DeepSeek-V4-Pro use case: router_logits=fp32, bias=fp32.
-    Also covers fp16/bf16 gating with mixed bias dtypes.
-    """
-    torch.random.manual_seed(0)
-    route_scale = 2.5
-
-    gating_output = _make_gating(num_experts, num_tokens, dtype)
-    bias = (torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1).to(
-        bias_dtype
+    row = bench_topk_softplus(
+        num_experts, num_tokens, topk, dtype, bias_dtype=bias_dtype
     )
-
-    (w_torch, i_torch), _ = run_torch_softplus(
-        gating_output.clone(), bias, topk, True, route_scale
-    )
-    (w_fused, i_fused), _ = run_fused_softplus(
-        gating_output.clone(), bias, topk, True, route_scale
-    )
-
-    sel = _selection_scores(gating_output, bias, "softplus")
-    n_mism = _count_routing_mismatches(
-        i_fused,
-        i_torch,
-        sel,
-        topk,
-        bias=bias,
-        label=f"softplus gating={dtype} bias={bias_dtype} E={num_experts} k={topk}",
-    )
-    assert n_mism == 0, (
+    assert row["fused err"] == 0.0, (
         f"gating={dtype},bias={bias_dtype},E={num_experts},topk={topk}: "
-        f"{n_mism}/{num_tokens} tokens have non-tie ID mismatches"
+        f"{row['fused err'] * num_tokens:.0f}/{num_tokens} tokens have non-tie ID mismatches"
     )
-
-    _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
+    assert row["fused max_weight_err"] < _WEIGHT_TOL, (
+        f"gating={dtype},bias={bias_dtype},E={num_experts},topk={topk}: "
+        f"max weight error {row['fused max_weight_err']:.2e} exceeds tolerance"
+    )
 
 
 # sqrtsoftplus token sweep (DeepSeek-V4 default): exercise every dispatch tier
@@ -566,100 +404,148 @@ def test_topk_softplus_correctness(num_experts, num_tokens, topk, dtype, bias_dt
 #   T=1/64/256  -> reg opt (TPW=1) decode
 #   T=1024/2048 -> smem_n / opt_n mid
 #   T>=4096     -> opt_n (E=64 TPW=8) and prefill_n large-prefill paths
-# DeepSeek real dtype: bf16 logits + fp32 correction_bias.
 @pytest.mark.parametrize("num_tokens", [1, 64, 256, 1024, 4096, 8192, 16384])
 @pytest.mark.parametrize("topk", [2, 8])
 @pytest.mark.parametrize("num_experts", [64, 128, 256, 384])
 def test_topk_softplus_token_sweep(num_experts, num_tokens, topk):
-    torch.random.manual_seed(0)
-    route_scale = 2.5
-    dtype = torch.bfloat16
-
-    gating_output = _make_gating(num_experts, num_tokens, dtype)
-    bias = torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1
-
-    (w_torch, i_torch), _ = run_torch_softplus(
-        gating_output.clone(), bias, topk, True, route_scale
-    )
-    (w_fused, i_fused), _ = run_fused_softplus(
-        gating_output.clone(), bias, topk, True, route_scale
-    )
-
-    sel = _selection_scores(gating_output, bias, "softplus")
-    n_mism = _count_routing_mismatches(
-        i_fused,
-        i_torch,
-        sel,
-        topk,
-        bias=bias,
-        label=f"softplus-sweep E={num_experts} T={num_tokens} k={topk}",
-    )
-    assert n_mism == 0, (
+    row = bench_topk_softplus(num_experts, num_tokens, topk, torch.bfloat16)
+    assert row["fused err"] == 0.0, (
         f"E={num_experts},topk={topk},T={num_tokens}: "
-        f"{n_mism}/{num_tokens} tokens have non-tie ID mismatches"
+        f"{row['fused err'] * num_tokens:.0f}/{num_tokens} tokens have non-tie ID mismatches"
+    )
+    assert row["fused max_weight_err"] < _WEIGHT_TOL, (
+        f"E={num_experts},topk={topk},T={num_tokens}: "
+        f"max weight error {row['fused max_weight_err']:.2e} exceeds tolerance"
     )
 
-    _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
+
+# ---------------------------------------------------------------------------
+# topk_softmax (classic MoE softmax routing, via topk_gating + vLLM-adapted
+# topk_softmax kernel as a second candidate)
+# ---------------------------------------------------------------------------
 
 
-# Pytest-parametrized test functions -- topk_sigmoid
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("topk", [1, 2, 4, 8])
-@pytest.mark.parametrize("num_tokens", [64, 1024, 2048])
-@pytest.mark.parametrize("num_experts", [64, 128, 256, 384])
-def test_topk_sigmoid_correctness(num_experts, num_tokens, topk, dtype):
-    """Pytest test for correctness of topk_sigmoid operation."""
+@benchmark()
+def bench_topk_softmax(
+    num_experts,
+    num_tokens,
+    topk,
+    dtype,
+    bias_dtype=torch.float32,
+    use_bias=False,
+    route_scale=1.0,
+):
+    """Two candidates: aiter's fused topk_gating (bias-capable) and the
+    vLLM-adapted topk_softmax kernel (no bias support -- always compared
+    against the no-bias reference, regardless of use_bias)."""
     torch.random.manual_seed(0)
     gating_output = _make_gating(num_experts, num_tokens, dtype)
+    bias = (
+        (torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1).to(
+            bias_dtype
+        )
+        if use_bias
+        else torch.empty(0, device="cuda")
+    )
 
-    # run both implementations
-    (scores_torch, indices_torch), _ = run_torch(gating_output.clone(), topk)
-    (scores_fused, indices_fused), _ = run_fused(gating_output.clone(), topk)
+    w_torch, i_torch = ref_softmax(gating_output, bias, topk, route_scale)
+    w_torch_nobias, i_torch_nobias = ref_softmax(
+        gating_output, torch.empty(0, device="cuda"), topk, route_scale
+    )
 
-    # check correctness
-    score_errors = checkAllclose(scores_torch, scores_fused, tol_err_ratio=0.01)
-    index_errors = checkAllclose(indices_torch, indices_fused, tol_err_ratio=0.01)
+    def run_fused():
+        topk_weights = torch.empty(
+            (num_tokens, topk), dtype=torch.float32, device="cuda"
+        )
+        topk_ids = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+        aiter.topk_gating(
+            topk_weights,
+            topk_ids,
+            gating_output,
+            bias,
+            need_renorm=False,  # softmax is already normalized
+            routed_scaling_factor=route_scale,
+            score_func="softmax",
+        )
+        return topk_weights, topk_ids
 
-    # Assert correctness
-    assert score_errors <= 0.01, f"Score errors {score_errors} exceed tolerance"
-    assert index_errors <= 0.01, f"Index errors {index_errors} exceed tolerance"
+    def run_vllm():
+        topk_weights = torch.empty(
+            (num_tokens, topk), dtype=torch.float32, device="cuda"
+        )
+        topk_ids = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+        token_expert_indices = torch.empty(
+            (num_tokens, topk), dtype=torch.int32, device="cuda"
+        )
+        aiter.topk_softmax(
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            need_renorm=False,
+        )
+        if route_scale != 1.0:
+            topk_weights.mul_(route_scale)
+        return topk_weights, topk_ids
+
+    candidates = {"fused": run_fused, "vllm": run_vllm}
+    # vllm ignores bias entirely, so it is always graded against the no-bias
+    # reference; fused is graded against the (possibly biased) reference.
+    refs = {
+        "fused": (
+            w_torch,
+            i_torch,
+            bias,
+            _selection_scores(gating_output, bias, "softmax"),
+        ),
+        "vllm": (
+            w_torch_nobias,
+            i_torch_nobias,
+            None,
+            _selection_scores(gating_output, torch.empty(0, device="cuda"), "softmax"),
+        ),
+    }
+
+    nbytes = (
+        num_tokens * num_experts * gating_output.element_size()
+        + num_tokens * topk * (4 + 4)
+    )
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        w_ref, i_ref, ref_bias, sel = refs[name]
+        (w, ids), us = run_perftest(fn)
+        n_mism = _count_routing_mismatches(
+            ids,
+            i_ref,
+            sel,
+            topk,
+            bias=ref_bias,
+            label=f"softmax/{name} E={num_experts} T={num_tokens} k={topk} {dtype}",
+        )
+        ret[f"{name} us"] = us
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} err"] = n_mism / num_tokens
+        ret[f"{name} max_weight_err"] = _max_weight_error(w, ids, w_ref, i_ref)
+    return ret
 
 
-# Pytest-parametrized test functions -- topk_softmax (via topk_gating)
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("topk", [1, 2, 4, 6, 8])
 @pytest.mark.parametrize("num_tokens", [64, 1024, 2048])
 @pytest.mark.parametrize("num_experts", [64, 128, 256, 384])
 def test_topk_softmax_correctness(num_experts, num_tokens, topk, dtype):
-    """Pytest test for correctness of topk_gating with score_func='softmax'."""
-    torch.random.manual_seed(0)
-    route_scale = 1.0
-
-    gating_output = _make_gating(num_experts, num_tokens, dtype)
-    bias = torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1
-
-    (w_torch, i_torch), _ = run_torch_softmax(
-        gating_output.clone(), bias, topk, route_scale
-    )
-    (w_fused, i_fused), _ = run_fused_softmax(
-        gating_output.clone(), bias, topk, route_scale
-    )
-
-    sel = _selection_scores(gating_output, bias, "softmax")
-    n_mism = _count_routing_mismatches(
-        i_fused,
-        i_torch,
-        sel,
-        topk,
-        bias=bias,
-        label=f"softmax E={num_experts} k={topk} dtype={dtype}",
-    )
-    assert n_mism == 0, (
-        f"E={num_experts},topk={topk},dtype={dtype}: "
-        f"{n_mism}/{num_tokens} tokens have non-tie ID mismatches"
-    )
-
-    _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
+    """Pytest test for correctness of topk_gating with score_func='softmax'
+    (fused candidate) and the vLLM-adapted topk_softmax kernel."""
+    row = bench_topk_softmax(num_experts, num_tokens, topk, dtype, use_bias=False)
+    for name in ("fused", "vllm"):
+        assert row[f"{name} err"] == 0.0, (
+            f"{name}: E={num_experts},topk={topk},dtype={dtype}: "
+            f"{row[f'{name} err'] * num_tokens:.0f}/{num_tokens} tokens have non-tie ID mismatches"
+        )
+        assert row[f"{name} max_weight_err"] < _WEIGHT_TOL, (
+            f"{name}: E={num_experts},topk={topk},dtype={dtype}: "
+            f"max weight error {row[f'{name} max_weight_err']:.2e} exceeds tolerance"
+        )
 
 
 # Regression test for the softmax + correction_bias path.
@@ -674,47 +560,34 @@ def test_topk_softmax_correctness(num_experts, num_tokens, topk, dtype):
 # This also exercises the type-erased bias path (bias dtype is a runtime tag,
 # not a template arg) for score_func="softmax" across all supported bias dtypes.
 # num_tokens covers both the decode/TPW=1 prefill path (64) and the higher-TPW
-# multi-token prefill path (1024).
+# multi-token prefill path (1024). Only the fused candidate is checked here --
+# the vLLM kernel has no bias support.
 @pytest.mark.parametrize("bias_dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("topk", [2, 8])
 @pytest.mark.parametrize("num_tokens", [64, 1024])
 @pytest.mark.parametrize("num_experts", [128, 256])
-def test_topk_softmax_bias_correctness(num_experts, num_tokens, topk, dtype, bias_dtype):
-    """topk_gating softmax with correction_bias: routing + unbiased weights must
-    match the fp32 reference across gating/bias dtype combinations."""
-    torch.random.manual_seed(0)
-    route_scale = 1.0
-
-    gating_output = _make_gating(num_experts, num_tokens, dtype)
-    bias = (torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1).to(
-        bias_dtype
+def test_topk_softmax_bias_correctness(
+    num_experts, num_tokens, topk, dtype, bias_dtype
+):
+    row = bench_topk_softmax(
+        num_experts, num_tokens, topk, dtype, bias_dtype=bias_dtype, use_bias=True
     )
-
-    (w_torch, i_torch), _ = run_torch_softmax(
-        gating_output.clone(), bias, topk, route_scale
-    )
-    (w_fused, i_fused), _ = run_fused_softmax(
-        gating_output.clone(), bias, topk, route_scale
-    )
-
-    sel = _selection_scores(gating_output, bias, "softmax")
-    n_mism = _count_routing_mismatches(
-        i_fused,
-        i_torch,
-        sel,
-        topk,
-        bias=bias,
-        label=f"softmax+bias E={num_experts} k={topk} gating={dtype} bias={bias_dtype}",
-    )
-    assert n_mism == 0, (
+    assert row["fused err"] == 0.0, (
         f"E={num_experts},topk={topk},gating={dtype},bias={bias_dtype}: "
-        f"{n_mism}/{num_tokens} tokens have non-tie ID mismatches"
+        f"{row['fused err'] * num_tokens:.0f}/{num_tokens} tokens have non-tie ID mismatches"
     )
-
     # The reported weights must be the *unbiased* softmax weights; the old bug
     # made these normalize over (logit+bias) and could even exceed max softmax.
-    _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
+    assert row["fused max_weight_err"] < _WEIGHT_TOL, (
+        f"E={num_experts},topk={topk},gating={dtype},bias={bias_dtype}: "
+        f"max weight error {row['fused max_weight_err']:.2e} exceeds tolerance"
+    )
+
+
+# ---------------------------------------------------------------------------
+# NaN/Inf robustness (topk_gating, all score functions)
+# ---------------------------------------------------------------------------
 
 
 def _ref_selection_with_nan(gating_output, bias, score_func):
@@ -724,19 +597,30 @@ def _ref_selection_with_nan(gating_output, bias, score_func):
     Non-finite semantics (per score function), mirroring the kernel:
     - NaN: always excluded (never selected).
     - +Inf: sigmoid saturates to 1 (selectable); sqrt(softplus) clamps the logit
-      to 1e30 (selectable, top-ranked, finite); softmax excludes it (its exp is
-      mapped to -inf so it neither poisons the sum nor gets selected).
+      to 1e30 (selectable, top-ranked, finite); softmax treats a dominant +Inf
+      logit as the limit x->+inf: prob 1.0 for the +Inf expert(s) (split evenly
+      on ties), 0 for the rest.
     - -Inf: score -> 0 (low, not selected) for every function.
+
+    NOTE: torch.softmax does NOT compute the +Inf case this way -- its
+    max-subtraction still evaluates exp(+inf - +inf) = exp(nan) = nan, so
+    torch.softmax(row_with_inf) is all-NaN, not [0, ..., 1, ..., 0]. The
+    softmax branch below is hand-rolled (max-subtract, exp, but treat a NaN
+    diff -- which only occurs at the position(s) equal to +Inf -- as exp=1)
+    to mirror the kernel's actual (intentional, PyTorch-diverging) behaviour.
     """
     gf = gating_output.float()
     nan = torch.isnan(gf)
-    posinf = torch.isposinf(gf)
     b = bias.float() if (bias is not None and bias.numel() > 0) else 0.0
     if score_func == "softmax":
-        # NaN and +Inf are excluded from the normalization and from selection.
-        s = torch.softmax(gf.masked_fill(nan | posinf, float("-inf")), dim=-1)
+        gf_masked = gf.masked_fill(nan, float("-inf"))  # NaN excluded from max/sum
+        row_max = gf_masked.max(dim=-1, keepdim=True).values
+        diff = gf_masked - row_max
+        exp = torch.where(torch.isnan(diff), torch.ones_like(diff), torch.exp(diff))
+        row_sum = exp.sum(dim=-1, keepdim=True).clamp(min=1e-20)
+        s = exp / row_sum
         sel = s + b
-        exclude = nan | posinf
+        exclude = nan
     elif score_func == "sigmoid":
         sel = torch.sigmoid(gf) + b  # sigmoid(+inf)=1, sigmoid(-inf)=0
         exclude = nan
@@ -760,21 +644,27 @@ def bench_topk_gating_nan(num_experts, num_tokens, topk, score_func, dtype):
     """
     torch.random.manual_seed(0)
     gating_output = _make_gating(num_experts, num_tokens, dtype)
-    bias = (torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1).to(dtype)
+    # fp32 bias (not cast to `dtype`): when a +Inf logit collapses softmax to
+    # an exact 0.0/1.0 split, ranking among the zero-probability experts is
+    # driven entirely by bias, and bf16's ~2-3 significant digits produce
+    # frequent exact collisions among ~128 random values -- creating a mass of
+    # genuine ties beyond what the tie-tolerant comparison can disambiguate.
+    # fp32 (or fp16) bias avoids this test artifact; it also matches the real
+    # DeepSeek-V4 usage (bias kept at higher precision than gating logits).
+    bias = torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1
 
     # Scatter NaN across token-dependent positions (so it lands anywhere in a
-    # lane's sorted partition) plus a -Inf per token.
+    # lane's sorted partition) plus a -Inf and +Inf per token.
     tok = torch.arange(num_tokens, device="cuda")
     for j in range(4):
         gating_output[tok, (tok * (7 * j + 3) + j) % num_experts] = float("nan")
     gating_output[tok, (tok * 11 + 2) % num_experts] = float("-inf")
-    # +Inf is a valid extreme logit for the per-element scores (sigmoid saturates
-    # to 1; sqrt(softplus) clamps to a finite top-ranked score). Softmax is
-    # excluded here: a +Inf makes the row-max +Inf so every exp(finite-inf)=0 and
-    # the row collapses -- excluding +Inf from the softmax max/selection is a
-    # separate hardening not covered by this test.
-    if score_func != "softmax":
-        gating_output[tok, (tok * 5 + 1) % num_experts] = float("inf")
+    # +Inf is a valid extreme logit for all scoring functions: sigmoid saturates
+    # to 1, sqrt(softplus) clamps to a finite top-ranked score, and softmax gives
+    # +Inf experts prob 1.0 (the kernel's intentional limit-case handling; see
+    # _ref_selection_with_nan -- this diverges from plain torch.softmax, which
+    # produces NaN for a row containing +Inf).
+    gating_output[tok, (tok * 5 + 1) % num_experts] = float("inf")
 
     # Preallocated output buffers, matching the real model call.
     topk_weights = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
@@ -829,18 +719,78 @@ def test_topk_gating_nan(num_experts, num_tokens, topk, score_func):
     row = bench_topk_gating_nan(
         num_experts, num_tokens, topk, score_func, torch.bfloat16
     )
-    assert not row["nan_leak"], (
-        f"{score_func} E={num_experts} T={num_tokens} k={topk}: NaN leaked into weights"
-    )
+    assert not row[
+        "nan_leak"
+    ], f"{score_func} E={num_experts} T={num_tokens} k={topk}: NaN leaked into weights"
     assert row["fused err"] == 0.0, (
         f"{score_func} E={num_experts} T={num_tokens} k={topk}: routed top-k set "
         f"differs from the NaN-excluding reference (err={row['fused err']})"
     )
 
 
-if __name__ == "__main__":
+# Softmax + +Inf correctness test.
+#
+# The kernel treats a dominant +Inf logit as the limit x->+inf, NOT via plain
+# torch.softmax (which produces NaN for a row containing +Inf, since its
+# max-subtraction still evaluates exp(+inf - +inf) = exp(nan) = nan):
+#   +Inf expert: softmax prob = 1.0 (NaN logits are pre-excluded, then
+#     +Inf - +Inf = NaN in the diff is recognized as "logit == max" -> exp = 1.0)
+#   finite experts: exp(finite - +Inf) = 0 -> softmax prob = 0
+# So the +Inf expert(s) should be selected and carry weight 1.0. The reference
+# (_ref_selection_with_nan) hand-rolls this instead of calling torch.softmax.
+# This test verifies both safety (no NaN/Inf leak) and routing correctness.
+@pytest.mark.parametrize("topk", [2, 8])
+@pytest.mark.parametrize("num_tokens", [64, 2048])
+@pytest.mark.parametrize("num_experts", [64, 128, 256])
+def test_topk_softmax_posinf(num_experts, num_tokens, topk):
+    torch.random.manual_seed(0)
+    gating_output = _make_gating(num_experts, num_tokens, torch.bfloat16)
+    # fp32 bias: see the comment in bench_topk_gating_nan -- a +Inf-collapsed
+    # softmax ranks the zero-probability experts by bias alone, and bf16
+    # precision creates spurious exact collisions among ~128 random values.
+    bias = torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1
+    tok = torch.arange(num_tokens, device="cuda")
+    gating_output[tok, (tok * 5 + 1) % num_experts] = float("inf")
+
+    topk_weights = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_ids = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+
+    aiter.topk_gating(
+        topk_weights,
+        topk_ids,
+        gating_output,
+        bias,
+        need_renorm=False,
+        routed_scaling_factor=1.0,
+        score_func="softmax",
+    )
+    assert not topk_weights.isnan().any(), "softmax + +Inf: NaN leaked into weights"
+    assert not topk_weights.isinf().any(), "softmax + +Inf: Inf leaked into weights"
+    assert (topk_ids >= 0).all() and (
+        topk_ids < num_experts
+    ).all(), "softmax + +Inf: expert ID out of range"
+
+    # Routing correctness: selection should match the NaN-excluding reference.
+    sel = _ref_selection_with_nan(gating_output, bias, "softmax")
+    i_ref = sel.topk(topk, dim=-1, sorted=False)[1].to(torch.int32)
+    n_mism = _count_routing_mismatches(
+        topk_ids,
+        i_ref,
+        sel,
+        topk,
+        bias=bias,
+        label=f"softmax+posinf E={num_experts} T={num_tokens} k={topk}",
+    )
+    assert n_mism == 0, (
+        f"softmax+posinf E={num_experts} T={num_tokens} k={topk}: "
+        f"{n_mism}/{num_tokens} tokens have non-tie routing mismatches"
+    )
+
+
+def main():
     parser = argparse.ArgumentParser(
-        description="Test topk_sigmoid and topk_softplus operations"
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="config input of test",
     )
     parser.add_argument(
         "--num-experts",
@@ -852,7 +802,7 @@ if __name__ == "__main__":
         "--num-tokens",
         type=str2tuple,
         default=[16384, 4096, 1024, 256, 64, 1],
-        help="Comma-separated list of number of tokens (default: 64,1024,2048)",
+        help="Comma-separated list of number of tokens (default: 16384,4096,1024,256,64,1)",
     )
     parser.add_argument(
         "--topk",
@@ -861,19 +811,13 @@ if __name__ == "__main__":
         help="Comma-separated list of topk values (default: 1,2,4,6,8)",
     )
     parser.add_argument(
+        "-d",
         "--dtype",
         type=str2Dtype,
+        nargs="*",
         default=[torch.float16, torch.bfloat16, torch.float32],
         help="Comma-separated list of dtypes: fp16, bf16, fp32 (default: fp16,bf16,fp32)",
     )
-    parser.add_argument(
-        "--test",
-        type=str,
-        default="all",
-        choices=["sigmoid", "softplus", "softmax", "nan", "all"],
-        help="Which test to run (default: all)",
-    )
-
     args = parser.parse_args()
 
     def to_list(x):
@@ -884,122 +828,93 @@ if __name__ == "__main__":
     topk_list = to_list(args.topk)
     dtype_list = to_list(args.dtype)
 
-    # Track whether any benchmark section saw a correctness regression
-    # (id_errors > 1%); exit non-zero at the end so CI catches it.
+    # Track whether any benchmark section saw a correctness regression;
+    # exit non-zero at the end so CI catches it.
     failed_sections: list[str] = []
 
-    if args.test in ("sigmoid", "all"):
-        sigmoid_experts = [e for e in num_experts_list]
-        sigmoid_dtypes = [d for d in dtype_list if d != torch.float32]
-        sigmoid_configs = list(
-            itertools.product(
-                sigmoid_experts, num_tokens_list, topk_list, sigmoid_dtypes
-            )
-        )
-        print("=" * 80)
-        print("topk_sigmoid benchmark")
-        print("=" * 80)
-        collected = []
-        for num_experts, num_tokens, topk, dtype in sigmoid_configs:
-            result = benchmark_topk_sigmoid(
-                num_experts=num_experts, num_tokens=num_tokens, topk=topk, dtype=dtype
-            )
-            collected.append(result)
-        df = pd.DataFrame(collected)
-        print(df.to_string(index=False))
-        print(f"\nAverage uplift: {df['uplift'].mean():.2f}x")
-        # benchmark_topk_sigmoid uses {score,index}_errors columns
-        errors = df[(df["index_errors"] > 0.01) | (df["score_errors"] > 0.01)]
-        if len(errors) > 0:
-            print(f"\nERROR: {len(errors)} sigmoid config(s) had errors > 1%!")
-            print(errors.to_string(index=False))
-            failed_sections.append("sigmoid")
+    # -- topk_sigmoid --------------------------------------------------
+    sigmoid_dtypes = [d for d in dtype_list if d != torch.float32]
+    sigmoid_configs = list(
+        itertools.product(num_experts_list, num_tokens_list, topk_list, sigmoid_dtypes)
+    )
+    df = [bench_topk_sigmoid(*cfg) for cfg in sigmoid_configs]
+    df = pd.DataFrame(df)
+    aiter.logger.info(
+        "topk_sigmoid summary (markdown):\n%s", df.to_markdown(index=False)
+    )
+    errors = df[(df["fused score_err"] > 0.01) | (df["fused idx_err"] > 0.01)]
+    if len(errors) > 0:
+        print(f"\nERROR: {len(errors)} sigmoid config(s) had errors > 1%!")
+        print(errors.to_string(index=False))
+        failed_sections.append("sigmoid")
 
-    if args.test in ("softplus", "all"):
-        softplus_configs = list(
-            itertools.product(num_experts_list, num_tokens_list, topk_list, dtype_list)
-        )
-        print("\n" + "=" * 80)
-        print("topk_softplus benchmark")
-        print("=" * 80)
-        collected = []
-        for num_experts, num_tokens, topk, dtype in softplus_configs:
-            result = benchmark_topk_softplus(
-                num_experts=num_experts, num_tokens=num_tokens, topk=topk, dtype=dtype
-            )
-            collected.append(result)
-        df = pd.DataFrame(collected)
-        print(df.to_string(index=False))
-        print(f"\nAverage uplift: {df['uplift'].mean():.2f}x")
-        errors = df[df["id_errors"] > 0.01]
-        if len(errors) > 0:
-            print(f"\nERROR: {len(errors)} softplus config(s) had id errors > 1%!")
-            print(errors.to_string(index=False))
-            failed_sections.append("softplus")
-        else:
-            print("All softplus tests passed!")
+    # -- topk_softplus ---------------------------------------------------
+    softplus_configs = list(
+        itertools.product(num_experts_list, num_tokens_list, topk_list, dtype_list)
+    )
+    df = [bench_topk_softplus(*cfg) for cfg in softplus_configs]
+    df = pd.DataFrame(df)
+    aiter.logger.info(
+        "topk_softplus summary (markdown):\n%s", df.to_markdown(index=False)
+    )
+    errors = df[(df["fused err"] > 0.01) | (df["fused max_weight_err"] > _WEIGHT_TOL)]
+    if len(errors) > 0:
+        print(f"\nERROR: {len(errors)} softplus config(s) had errors!")
+        print(errors.to_string(index=False))
+        failed_sections.append("softplus")
 
-    if args.test in ("softmax", "all"):
-        softmax_configs = list(
-            itertools.product(num_experts_list, num_tokens_list, topk_list, dtype_list)
-        )
-        print("\n" + "=" * 80)
-        print("topk_softmax benchmark: topk_gating (fused) vs topk_softmax (vLLM)")
-        print("=" * 80)
-        collected = []
-        for num_experts, num_tokens, topk, dtype in softmax_configs:
-            result = benchmark_topk_softmax(
-                num_experts=num_experts, num_tokens=num_tokens, topk=topk, dtype=dtype
-            )
-            collected.append(result)
-        df = pd.DataFrame(collected)
-        print(df.to_string(index=False))
-        print(f"\nAverage fused uplift: {df['fused_uplift'].mean():.2f}x")
-        print(f"Average vllm  uplift: {df['vllm_uplift'].mean():.2f}x")
-        errors = df[(df["id_err_fused"] > 0.01) | (df["id_err_vllm"] > 0.01)]
-        if len(errors) > 0:
-            print(f"\nERROR: {len(errors)} softmax config(s) had id errors > 1%!")
-            print(errors.to_string(index=False))
-            failed_sections.append("softmax")
-        else:
-            print("All softmax tests passed!")
+    # -- topk_softmax: topk_gating (fused) vs topk_softmax (vLLM) --------
+    softmax_configs = list(
+        itertools.product(num_experts_list, num_tokens_list, topk_list, dtype_list)
+    )
+    df = [bench_topk_softmax(*cfg) for cfg in softmax_configs]
+    df = pd.DataFrame(df)
+    aiter.logger.info(
+        "topk_softmax summary (markdown):\n%s", df.to_markdown(index=False)
+    )
+    errors = df[
+        (df["fused err"] > 0.01)
+        | (df["vllm err"] > 0.01)
+        | (df["fused max_weight_err"] > _WEIGHT_TOL)
+        | (df["vllm max_weight_err"] > _WEIGHT_TOL)
+    ]
+    if len(errors) > 0:
+        print(f"\nERROR: {len(errors)} softmax config(s) had errors!")
+        print(errors.to_string(index=False))
+        failed_sections.append("softmax")
 
-    if args.test in ("nan", "all"):
-        nan_dtypes = [d for d in dtype_list if d != torch.float32]
-        nan_configs = list(
-            itertools.product(
-                num_experts_list,
-                num_tokens_list,
-                topk_list,
-                ["sqrtsoftplus", "sigmoid", "softmax"],
-                nan_dtypes,
-            )
+    # -- topk_gating NaN/Inf robustness -----------------------------------
+    nan_dtypes = [d for d in dtype_list if d != torch.float32]
+    nan_configs = list(
+        itertools.product(
+            num_experts_list,
+            num_tokens_list,
+            topk_list,
+            ["sqrtsoftplus", "sigmoid", "softmax"],
+            nan_dtypes,
         )
-        print("\n" + "=" * 80)
-        print("topk_gating NaN/Inf robustness")
-        print("=" * 80)
-        collected = [
-            bench_topk_gating_nan(num_experts, num_tokens, topk, score_func, dtype)
-            for num_experts, num_tokens, topk, score_func, dtype in nan_configs
-        ]
-        df = pd.DataFrame(collected)
-        aiter.logger.info(
-            "topk_gating NaN/Inf robustness summary (markdown):\n%s",
-            df.to_markdown(index=False),
-        )
-        errors = df[(df["fused err"] > 0) | (df["nan_leak"])]
-        if len(errors) > 0:
-            print(f"\nERROR: {len(errors)} nan config(s) failed (err>0 or nan_leak)!")
-            print(errors.to_string(index=False))
-            failed_sections.append("nan")
-        else:
-            print("All nan robustness tests passed!")
-    print("=" * 80)
+    )
+    df = [bench_topk_gating_nan(*cfg) for cfg in nan_configs]
+    df = pd.DataFrame(df)
+    aiter.logger.info(
+        "topk_gating NaN/Inf robustness summary (markdown):\n%s",
+        df.to_markdown(index=False),
+    )
+    errors = df[(df["fused err"] > 0) | (df["nan_leak"])]
+    if len(errors) > 0:
+        print(f"\nERROR: {len(errors)} nan config(s) failed (err>0 or nan_leak)!")
+        print(errors.to_string(index=False))
+        failed_sections.append("nan")
 
     if failed_sections:
         print(
-            f"FAIL: correctness regression in section(s): "
-            f"{', '.join(failed_sections)}",
+            f"FAIL: correctness regression in section(s): {', '.join(failed_sections)}",
             file=sys.stderr,
         )
         sys.exit(1)
+    else:
+        print("All topk_gating benchmarks passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/test_moe_topk_gating.py
+++ b/op_tests/test_moe_topk_gating.py
@@ -609,6 +609,61 @@ def test_topk_softmax_correctness(num_experts, num_tokens, topk, dtype):
     _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
 
 
+# Regression test for the softmax + correction_bias path.
+#
+# The prefill kernel (topk_softplus_kernel_prefill) must add bias AFTER softmax
+# normalization: softmax is computed over the raw logits and bias is only added
+# to the selection score. A previous version added bias in the vectorized-load
+# phase (missing the `if constexpr(SCORE_FUNC != SCORE_SOFTMAX)` guard the smem
+# kernels have), which normalized over (logit+bias) and double-counted bias,
+# corrupting both the routing and the reported unbiased weights.
+#
+# This also exercises the type-erased bias path (bias dtype is a runtime tag,
+# not a template arg) for score_func="softmax" across all supported bias dtypes.
+# num_tokens covers both the decode/TPW=1 prefill path (64) and the higher-TPW
+# multi-token prefill path (1024).
+@pytest.mark.parametrize("bias_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("topk", [2, 8])
+@pytest.mark.parametrize("num_tokens", [64, 1024])
+@pytest.mark.parametrize("num_experts", [128, 256])
+def test_topk_softmax_bias_correctness(num_experts, num_tokens, topk, dtype, bias_dtype):
+    """topk_gating softmax with correction_bias: routing + unbiased weights must
+    match the fp32 reference across gating/bias dtype combinations."""
+    torch.random.manual_seed(0)
+    route_scale = 1.0
+
+    gating_output = _make_gating(num_experts, num_tokens, dtype)
+    bias = (torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1).to(
+        bias_dtype
+    )
+
+    (w_torch, i_torch), _ = run_torch_softmax(
+        gating_output.clone(), bias, topk, route_scale
+    )
+    (w_fused, i_fused), _ = run_fused_softmax(
+        gating_output.clone(), bias, topk, route_scale
+    )
+
+    sel = _selection_scores(gating_output, bias, "softmax")
+    n_mism = _count_routing_mismatches(
+        i_fused,
+        i_torch,
+        sel,
+        topk,
+        bias=bias,
+        label=f"softmax+bias E={num_experts} k={topk} gating={dtype} bias={bias_dtype}",
+    )
+    assert n_mism == 0, (
+        f"E={num_experts},topk={topk},gating={dtype},bias={bias_dtype}: "
+        f"{n_mism}/{num_tokens} tokens have non-tie ID mismatches"
+    )
+
+    # The reported weights must be the *unbiased* softmax weights; the old bug
+    # made these normalize over (logit+bias) and could even exceed max softmax.
+    _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Test topk_sigmoid and topk_softplus operations"

--- a/op_tests/test_moe_topk_gating.py
+++ b/op_tests/test_moe_topk_gating.py
@@ -560,6 +560,48 @@ def test_topk_softplus_correctness(num_experts, num_tokens, topk, dtype, bias_dt
     _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
 
 
+# sqrtsoftplus token sweep (DeepSeek-V4 default): exercise every dispatch tier
+# from decode to large prefill, which test_topk_softplus_correctness (T in
+# {64,1024,2048}) does not fully cover:
+#   T=1/64/256  -> reg opt (TPW=1) decode
+#   T=1024/2048 -> smem_n / opt_n mid
+#   T>=4096     -> opt_n (E=64 TPW=8) and prefill_n large-prefill paths
+# DeepSeek real dtype: bf16 logits + fp32 correction_bias.
+@pytest.mark.parametrize("num_tokens", [1, 64, 256, 1024, 4096, 8192, 16384])
+@pytest.mark.parametrize("topk", [2, 8])
+@pytest.mark.parametrize("num_experts", [64, 128, 256, 384])
+def test_topk_softplus_token_sweep(num_experts, num_tokens, topk):
+    torch.random.manual_seed(0)
+    route_scale = 2.5
+    dtype = torch.bfloat16
+
+    gating_output = _make_gating(num_experts, num_tokens, dtype)
+    bias = torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1
+
+    (w_torch, i_torch), _ = run_torch_softplus(
+        gating_output.clone(), bias, topk, True, route_scale
+    )
+    (w_fused, i_fused), _ = run_fused_softplus(
+        gating_output.clone(), bias, topk, True, route_scale
+    )
+
+    sel = _selection_scores(gating_output, bias, "softplus")
+    n_mism = _count_routing_mismatches(
+        i_fused,
+        i_torch,
+        sel,
+        topk,
+        bias=bias,
+        label=f"softplus-sweep E={num_experts} T={num_tokens} k={topk}",
+    )
+    assert n_mism == 0, (
+        f"E={num_experts},topk={topk},T={num_tokens}: "
+        f"{n_mism}/{num_tokens} tokens have non-tie ID mismatches"
+    )
+
+    _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
+
+
 # Pytest-parametrized test functions -- topk_sigmoid
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("topk", [1, 2, 4, 8])

--- a/op_tests/test_moe_topk_gating.py
+++ b/op_tests/test_moe_topk_gating.py
@@ -192,12 +192,31 @@ def _torch_weight_aligned_to_fused(w_fused, i_fused, w_torch, i_torch):
 
 
 def _max_weight_error(w_fused, i_fused, w_torch, i_torch):
-    """Max absolute weight error across tokens for matched expert ids."""
+    """Max absolute weight error, restricted to tokens whose fused and torch
+    selected SETS are identical.
+
+    With renormalization the weight of even a commonly-selected expert depends on
+    the whole selected set (shared denominator = sum over the top-k). A benign
+    boundary tie-swap in one slot -- the exp/log HW approximation ranking two
+    near-equal experts differently from exact libm, already accepted by
+    _count_routing_mismatches -- therefore shifts the *other* experts' weights by
+    a non-trivial amount. Comparing weights across a swapped set is a false
+    mismatch, so only same-set tokens are measured here."""
+    T = w_fused.shape[0]
+    dev = w_fused.device
+    E = int(max(int(i_fused.max()), int(i_torch.max())) + 1)
+    fused_mask = torch.zeros((T, E), dtype=torch.bool, device=dev)
+    fused_mask.scatter_(1, i_fused.long(), True)
+    torch_mask = torch.zeros((T, E), dtype=torch.bool, device=dev)
+    torch_mask.scatter_(1, i_torch.long(), True)
+    same_set = (fused_mask == torch_mask).all(dim=1)  # [T]
+
     ref, matched = _torch_weight_aligned_to_fused(w_fused, i_fused, w_torch, i_torch)
-    if not bool(matched.any()):
+    use = matched & same_set.unsqueeze(1)
+    if not bool(use.any()):
         return 0.0
     diff = (w_fused.to(torch.float32) - ref).abs()
-    return float(diff[matched].max())
+    return float(diff[use].max())
 
 
 # ---------------------------------------------------------------------------

--- a/op_tests/test_moe_topk_gating.py
+++ b/op_tests/test_moe_topk_gating.py
@@ -23,9 +23,12 @@ import pytest
 import torch
 import aiter
 from aiter.test_common import (
+    benchmark,
     checkAllclose,
     perftest,
+    run_perftest,
 )
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.utility.dtypes import str2Dtype, str2tuple
 
 # NOTE on correctness metrics by score function:
@@ -94,63 +97,65 @@ def _count_routing_mismatches(
     and the gap to the cutoff -- evidence that disagreements are genuine ties
     created by the bias bringing two experts' biased scores nearly equal.
     """
-    debug = os.environ.get("TOPK_TIE_DEBUG", "0") != "0"
-    # Copy small tensors to CPU once to avoid per-token CUDA syncs.
-    i_fused_cpu = i_fused.cpu()
-    i_torch_cpu = i_torch.cpu()
-    sel_cpu = sel_scores.cpu()
-    sorted_sel, _ = sel_cpu.sort(dim=-1, descending=True)
-    cutoff = sorted_sel[:, topk - 1]  # k-th largest selection score per token
-    has_bias = bias is not None and bias.numel() > 0
-    bias_cpu = bias.cpu() if has_bias else None
-    mism = 0
-    for t in range(i_fused_cpu.shape[0]):
-        fused_row = i_fused_cpu[t].tolist()
-        torch_row = i_torch_cpu[t].tolist()
-        kset = set(fused_row)
-        rset = set(torch_row)
-        # Duplicate expert IDs collapse in set(); treat as real mismatch.
-        if kset == rset and len(kset) == topk:
-            continue
-        thr = cutoff[t].item()
-        extra = kset - rset  # kernel picked, ref didn't -> must be >= thr - tol
-        missing = rset - kset  # ref picked, kernel didn't -> must be <= thr + tol
-        excused = (
-            len(kset) == topk
-            and len(rset) == topk
-            and all(sel_cpu[t, e].item() >= thr - tol for e in extra)
-            and all(sel_cpu[t, e].item() <= thr + tol for e in missing)
-        )
-        if not excused:
-            mism += 1
+    # Fully vectorized on-device (no per-token Python loop): build boolean
+    # [T, E] expert masks for the fused and reference selections and evaluate
+    # the tie condition with tensor ops.
+    T, E = sel_scores.shape
+    dev = sel_scores.device
+    sel = sel_scores.to(torch.float32)
+    i_fused = i_fused.long()
+    i_torch = i_torch.long()
 
-        if debug:
+    # Cutoff = k-th largest selection score per token.
+    cutoff = sel.topk(topk, dim=-1).values.amin(dim=-1, keepdim=True)  # [T, 1]
+
+    fused_mask = torch.zeros((T, E), dtype=torch.bool, device=dev)
+    fused_mask.scatter_(1, i_fused, True)
+    ref_mask = torch.zeros((T, E), dtype=torch.bool, device=dev)
+    ref_mask.scatter_(1, i_torch, True)
+
+    # Duplicate ids collapse in the mask; a full selection covers topk experts.
+    fused_full = fused_mask.sum(dim=1) == topk
+    ref_full = ref_mask.sum(dim=1) == topk
+    match = (fused_mask == ref_mask).all(dim=1) & fused_full
+
+    extra = fused_mask & ~ref_mask   # kernel-only -> must be >= cutoff - tol
+    missing = ref_mask & ~fused_mask  # ref-only    -> must be <= cutoff + tol
+    extra_ok = ((~extra) | (sel >= (cutoff - tol))).all(dim=1)
+    missing_ok = ((~missing) | (sel <= (cutoff + tol))).all(dim=1)
+    excused = fused_full & ref_full & extra_ok & missing_ok
+
+    bad = (~match) & (~excused)
+    mism = int(bad.sum().item())
+
+    if os.environ.get("TOPK_TIE_DEBUG", "0") != "0":
+        has_bias = bias is not None and bias.numel() > 0
+        bias_cpu = bias.float().cpu() if has_bias else None
+        sel_cpu = sel.cpu()
+        cut_cpu = cutoff.squeeze(1).cpu()
+        extra_cpu, missing_cpu, bad_cpu = extra.cpu(), missing.cpu(), bad.cpu()
+        for t in (~match).cpu().nonzero(as_tuple=True)[0].tolist():
+            thr = float(cut_cpu[t])
 
             def _fmt(e):
-                sel = sel_cpu[t, e].item()
+                s = float(sel_cpu[t, e])
                 b = float(bias_cpu[e]) if has_bias else 0.0
                 return (
-                    f"      expert {e:4d}: f(x)={sel - b:+.7f}  bias={b:+.7f}  "
-                    f"f(x)+bias={sel:+.7f}  gap_to_cutoff={sel - thr:+.2e}"
+                    f"      expert {e:4d}: f(x)={s - b:+.7f}  bias={b:+.7f}  "
+                    f"f(x)+bias={s:+.7f}  gap_to_cutoff={s - thr:+.2e}"
                 )
 
-            tag = "TIE (excused)" if excused else "REAL MISMATCH"
+            tag = "REAL MISMATCH" if bool(bad_cpu[t]) else "TIE (excused)"
             print(
                 f"[TIE_DEBUG]{(' ' + label) if label else ''} token {t}: {tag}  "
                 f"cutoff(k={topk})={thr:+.7f}"
             )
             print("    kernel-only (picked by fused, not ref):")
-            for e in sorted(extra):
+            for e in extra_cpu[t].nonzero(as_tuple=True)[0].tolist():
                 print(_fmt(e))
             print("    ref-only (picked by torch, not fused):")
-            for e in sorted(missing):
+            for e in missing_cpu[t].nonzero(as_tuple=True)[0].tolist():
                 print(_fmt(e))
-            for ek in sorted(extra):
-                for er in sorted(missing):
-                    d = abs(sel_cpu[t, ek].item() - sel_cpu[t, er].item())
-                    print(
-                        f"    |f(x)+bias gap| between kernel#{ek} and ref#{er} = {d:.2e}"
-                    )
     return mism
 
 
@@ -340,32 +345,38 @@ def benchmark_topk_sigmoid(
     return result
 
 
+def _torch_weight_aligned_to_fused(w_fused, i_fused, w_torch, i_torch):
+    """Scatter the torch (ref) weights into a dense [T, E] map, then gather them
+    back in the fused id order. Returns (ref_w_aligned, matched_mask) so callers
+    can compare fused vs ref weights for the experts both selected -- fully
+    vectorized, no per-token Python loop."""
+    T = w_fused.shape[0]
+    dev = w_fused.device
+    E = int(max(int(i_fused.max()), int(i_torch.max())) + 1)
+    dense = torch.zeros((T, E), dtype=torch.float32, device=dev)
+    mask = torch.zeros((T, E), dtype=torch.bool, device=dev)
+    dense.scatter_(1, i_torch.long(), w_torch.to(torch.float32))
+    mask.scatter_(1, i_torch.long(), True)
+    ref = dense.gather(1, i_fused.long())
+    matched = mask.gather(1, i_fused.long())
+    return ref, matched
+
+
 def _max_weight_error(w_fused, i_fused, w_torch, i_torch):
     """Max absolute weight error across tokens for matched expert ids."""
-    max_err = 0.0
-    for t in range(w_fused.shape[0]):
-        for k in range(w_fused.shape[1]):
-            kid = i_fused[t, k].item()
-            ref_k = (i_torch[t] == kid).nonzero(as_tuple=True)[0]
-            if len(ref_k) > 0:
-                max_err = max(
-                    max_err,
-                    abs(w_fused[t, k].item() - w_torch[t, ref_k[0]].item()),
-                )
-    return max_err
+    ref, matched = _torch_weight_aligned_to_fused(w_fused, i_fused, w_torch, i_torch)
+    if not bool(matched.any()):
+        return 0.0
+    diff = (w_fused.to(torch.float32) - ref).abs()
+    return float(diff[matched].max())
 
 
 def _assert_weights_close(w_fused, i_fused, w_torch, i_torch):
     """Assert matched expert weights are close; skip tie-swapped experts."""
-    for t in range(w_fused.shape[0]):
-        for k in range(w_fused.shape[1]):
-            kid = i_fused[t, k].item()
-            ref_k = (i_torch[t] == kid).nonzero(as_tuple=True)[0]
-            if len(ref_k) == 0:
-                continue
-            torch.testing.assert_close(
-                w_fused[t, k], w_torch[t, ref_k[0]], atol=1e-5, rtol=1e-4
-            )
+    ref, matched = _torch_weight_aligned_to_fused(w_fused, i_fused, w_torch, i_torch)
+    torch.testing.assert_close(
+        w_fused.to(torch.float32)[matched], ref[matched], atol=1e-5, rtol=1e-4
+    )
 
 
 def _make_gating(num_experts, num_tokens, dtype):
@@ -664,6 +675,127 @@ def test_topk_softmax_bias_correctness(num_experts, num_tokens, topk, dtype, bia
     _assert_weights_close(w_fused, i_fused, w_torch, i_torch)
 
 
+def _ref_selection_with_nan(gating_output, bias, score_func):
+    """fp32 reference selection score matching the kernel's non-finite handling.
+    Reference only -- not timed, not in the table.
+
+    Non-finite semantics (per score function), mirroring the kernel:
+    - NaN: always excluded (never selected).
+    - +Inf: sigmoid saturates to 1 (selectable); sqrt(softplus) clamps the logit
+      to 1e30 (selectable, top-ranked, finite); softmax excludes it (its exp is
+      mapped to -inf so it neither poisons the sum nor gets selected).
+    - -Inf: score -> 0 (low, not selected) for every function.
+    """
+    gf = gating_output.float()
+    nan = torch.isnan(gf)
+    posinf = torch.isposinf(gf)
+    b = bias.float() if (bias is not None and bias.numel() > 0) else 0.0
+    if score_func == "softmax":
+        # NaN and +Inf are excluded from the normalization and from selection.
+        s = torch.softmax(gf.masked_fill(nan | posinf, float("-inf")), dim=-1)
+        sel = s + b
+        exclude = nan | posinf
+    elif score_func == "sigmoid":
+        sel = torch.sigmoid(gf) + b  # sigmoid(+inf)=1, sigmoid(-inf)=0
+        exclude = nan
+    else:  # sqrtsoftplus: kernel clamps the logit to 1e30 before softplus
+        sel = torch.sqrt(torch.nn.functional.softplus(torch.clamp(gf, max=1.0e30))) + b
+        exclude = nan
+    return sel.masked_fill(exclude, float("-inf"))
+
+
+@benchmark()
+def bench_topk_gating_nan(num_experts, num_tokens, topk, score_func, dtype):
+    """NaN/Inf robustness as an aiter-standard benchmark.
+
+    Injects NaN, +Inf and -Inf experts scattered per token, times the fused
+    topk_gating kernel with run_perftest (preallocated output buffers, as the
+    model calls it), and checks the routed top-k SET against a reference that
+    mirrors the kernel's non-finite handling (see _ref_selection_with_nan).
+    Routing is a set match (with tie tolerance), so ``err`` is the fraction of
+    tokens whose selected expert set differs; ``nan_leak`` flags any NaN in the
+    output weights. Memory-bound op -> TB/s (no meaningful FLOPs).
+    """
+    torch.random.manual_seed(0)
+    gating_output = _make_gating(num_experts, num_tokens, dtype)
+    bias = (torch.randn(num_experts, dtype=torch.float32, device="cuda") * 0.1).to(dtype)
+
+    # Scatter NaN across token-dependent positions (so it lands anywhere in a
+    # lane's sorted partition) plus a -Inf per token.
+    tok = torch.arange(num_tokens, device="cuda")
+    for j in range(4):
+        gating_output[tok, (tok * (7 * j + 3) + j) % num_experts] = float("nan")
+    gating_output[tok, (tok * 11 + 2) % num_experts] = float("-inf")
+    # +Inf is a valid extreme logit for the per-element scores (sigmoid saturates
+    # to 1; sqrt(softplus) clamps to a finite top-ranked score). Softmax is
+    # excluded here: a +Inf makes the row-max +Inf so every exp(finite-inf)=0 and
+    # the row collapses -- excluding +Inf from the softmax max/selection is a
+    # separate hardening not covered by this test.
+    if score_func != "softmax":
+        gating_output[tok, (tok * 5 + 1) % num_experts] = float("inf")
+
+    # Preallocated output buffers, matching the real model call.
+    topk_weights = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_ids = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    need_renorm = score_func != "softmax"
+
+    _, us = run_perftest(
+        aiter.topk_gating,
+        topk_weights,
+        topk_ids,
+        gating_output,
+        bias,
+        need_renorm=need_renorm,
+        routed_scaling_factor=2.5,
+        score_func=score_func,
+    )
+
+    # Correctness: routed set vs the NaN-excluding fp32 reference (tie-tolerant).
+    sel = _ref_selection_with_nan(gating_output, bias, score_func)
+    i_ref = sel.topk(topk, dim=-1, sorted=False)[1].to(torch.int32)
+    n_mism = _count_routing_mismatches(
+        topk_ids,
+        i_ref,
+        sel,
+        topk,
+        bias=bias,
+        label=f"nan {score_func} E={num_experts} T={num_tokens} k={topk}",
+    )
+    nan_leak = bool(topk_weights.isnan().any().item())
+
+    # Memory-bound: reads the [T, E] gating matrix, writes T*topk ids + weights.
+    nbytes = (
+        num_tokens * num_experts * gating_output.element_size()
+        + num_tokens * topk * (4 + 4)
+    )
+    ret = {"gfx": get_gfx()}
+    ret["fused us"] = us
+    ret["fused TB/s"] = nbytes / us / 1e6
+    ret["fused err"] = n_mism / num_tokens
+    ret["nan_leak"] = nan_leak
+    return ret
+
+
+# pytest wrapper: NaN experts must never be selected (top-k set matches the
+# NaN-excluding reference) and must never leak into the output weights. Covers
+# decode (T=64) and prefill (T=2048) dispatch paths.
+@pytest.mark.parametrize("score_func", ["sqrtsoftplus", "sigmoid", "softmax"])
+@pytest.mark.parametrize("topk", [2, 8])
+@pytest.mark.parametrize("num_tokens", [64, 2048])
+@pytest.mark.parametrize("num_experts", [64, 128, 256])
+def test_topk_gating_nan(num_experts, num_tokens, topk, score_func):
+    row = bench_topk_gating_nan(
+        num_experts, num_tokens, topk, score_func, torch.bfloat16
+    )
+    assert not row["nan_leak"], (
+        f"{score_func} E={num_experts} T={num_tokens} k={topk}: NaN leaked into weights"
+    )
+    assert row["fused err"] == 0.0, (
+        f"{score_func} E={num_experts} T={num_tokens} k={topk}: routed top-k set "
+        f"differs from the NaN-excluding reference (err={row['fused err']})"
+    )
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Test topk_sigmoid and topk_softplus operations"
@@ -696,7 +828,7 @@ if __name__ == "__main__":
         "--test",
         type=str,
         default="all",
-        choices=["sigmoid", "softplus", "softmax", "all"],
+        choices=["sigmoid", "softplus", "softmax", "nan", "all"],
         help="Which test to run (default: all)",
     )
 
@@ -789,6 +921,37 @@ if __name__ == "__main__":
             failed_sections.append("softmax")
         else:
             print("All softmax tests passed!")
+
+    if args.test in ("nan", "all"):
+        nan_dtypes = [d for d in dtype_list if d != torch.float32]
+        nan_configs = list(
+            itertools.product(
+                num_experts_list,
+                num_tokens_list,
+                topk_list,
+                ["sqrtsoftplus", "sigmoid", "softmax"],
+                nan_dtypes,
+            )
+        )
+        print("\n" + "=" * 80)
+        print("topk_gating NaN/Inf robustness")
+        print("=" * 80)
+        collected = [
+            bench_topk_gating_nan(num_experts, num_tokens, topk, score_func, dtype)
+            for num_experts, num_tokens, topk, score_func, dtype in nan_configs
+        ]
+        df = pd.DataFrame(collected)
+        aiter.logger.info(
+            "topk_gating NaN/Inf robustness summary (markdown):\n%s",
+            df.to_markdown(index=False),
+        )
+        errors = df[(df["fused err"] > 0) | (df["nan_leak"])]
+        if len(errors) > 0:
+            print(f"\nERROR: {len(errors)} nan config(s) failed (err>0 or nan_leak)!")
+            print(errors.to_string(index=False))
+            failed_sections.append("nan")
+        else:
+            print("All nan robustness tests passed!")
     print("=" * 80)
 
     if failed_sections:


### PR DESCRIPTION
## Motivation

- Fix a routing/weight bug in `topk_softplus_kernel_prefill`: for `score_func=softmax` with a `correction_bias`, bias was added in the vectorized-load phase (missing the `if constexpr(SCORE_FUNC != SCORE_SOFTMAX)` guard the smem kernels have), so softmax normalized over `logit+bias`, wrote the biased value as the "unbiased" weight, and double-counted bias — corrupting routing and weights. Introduced in #3985. Bias is now added only after normalization.
- Harden `topk_gating` against NaN/Inf: NaN selection scores → `-INF` (opt/opt_n/opt_multiwave, avoids a sort+cursor stall); `sqrt(softplus)` clamps the logit to 1e30 (so a +Inf can't overflow the renorm to NaN); softmax excludes NaN/Inf experts from the sum and selection; reciprocal divisors clamped. No-ops for finite inputs (bit-identical normal path).
- Vectorize the test's routing/weight checks (scatter/gather masks instead of per-token Python loops): full `test_moe_topk_gating.py` ~15min → ~1.5min.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

`test_moe_topk_gating.py`: **840 passed** on gfx950 (softplus/sigmoid/softmax correctness incl. all gating×bias dtypes, decode+prefill).
- `test_topk_gating_nan` (+ `--test nan` markdown table): NaN experts never selected / never leak; routed top-k set matches a NaN-excluding reference.
- Note: wave32-only paths (multiwave, E=384) compile with the same guards but were not exercised on gfx950 — need gfx1250 to validate.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
