### PR TITLE
[TRITON] fused clamped-alpha SwiGLU gate activation (MiniMax-M3 / GPT-OSS)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
@@ -12,6 +12,49 @@ import triton.language as tl
 
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 
+
+def _fallback_config(n_rows: int, n_cols: int) -> dict:
+    """Heuristic config used when no tuned JSON exists for this arch.
+
+    Mirrors the tuned tables: small BLOCK_M at low concurrency so the grid
+    spreads across CUs, growing BLOCK_M as the op becomes bandwidth-bound.
+    """
+    block_n = min(128, triton.next_power_of_2(max(n_cols, 1)))
+    if n_rows <= 16:
+        block_m, num_warps = 8, 2
+    elif n_rows <= 512:
+        block_m, num_warps = 8, 4
+    elif n_rows <= 8192:
+        block_m, num_warps = 16, 4
+    else:
+        block_m, num_warps = 32, 4
+    return {
+        "BLOCK_M": block_m,
+        "BLOCK_N": block_n,
+        "num_warps": num_warps,
+        "waves_per_eu": 0,
+    }
+
+
+def _get_config(n_rows: int, n_cols: int) -> dict:
+    """Select a launch config, mirroring the GEMM config-selection logic.
+
+    Uses ``get_gemm_config`` (per-arch JSON, ``M_LEQ_x``/``M_GEQ_x`` buckets)
+    with a per-``n_cols`` specialized file ``{arch}-FUSED-SWIGLU-GATE-D={n_cols}
+    .json`` and a shared ``{arch}-FUSED-SWIGLU-GATE.json`` default. Falls back to
+    a heuristic on arches with no tuned tables.
+    """
+    from aiter.ops.triton.utils.gemm_config_utils import get_gemm_config
+
+    try:
+        config, _ = get_gemm_config(
+            "FUSED-SWIGLU-GATE", M=n_rows, specialized_filename=f"D={n_cols}"
+        )
+    except (AssertionError, KeyError):
+        config = _fallback_config(n_rows, n_cols)
+    return config
+
+
 _fused_swiglu_gate_repr = make_kernel_repr(
     "_fused_swiglu_gate_kernel",
     [

--- a/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fused clamp + sigmoid(alpha*gate) + mul + (up+1) on separated gate|up rows.
+
+Each program tile loads gate and up from ``[M, 2 * N]`` with the same layout as
+``torch.chunk(2, dim=-1)`` on gate-up GEMM output (MiniMax-M3 / GPT-OSS swigluoai).
+"""
+
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+
+_fused_swiglu_gate_repr = make_kernel_repr(
+    "_fused_swiglu_gate_kernel",
+    [
+        "BLOCK_M",
+        "BLOCK_N",
+        "HAVE_SWIGLU_CLAMP",
+        "ADD_RESIDUAL",
+    ],
+)
+
+
+@triton.jit(repr=_fused_swiglu_gate_repr)
+def _fused_swiglu_gate_kernel(
+    inp_ptr,
+    out_ptr,
+    n_rows,
+    n_cols,
+    row_stride_in,
+    col_stride_in,
+    row_stride_out,
+    col_stride_out,
+    swiglu_alpha,
+    swiglu_limit,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAVE_SWIGLU_CLAMP: tl.constexpr,
+    ADD_RESIDUAL: tl.constexpr,
+):
+    m_pid = tl.program_id(0)
+    n_pid = tl.program_id(1)
+    m_offs = tl.arange(0, BLOCK_M)
+    n_offs = tl.arange(0, BLOCK_N)
+    row_idx = m_pid * BLOCK_M + m_offs
+    col_idx = n_pid * BLOCK_N + n_offs
+
+    row_in = row_idx * row_stride_in
+    row_out = row_idx * row_stride_out
+
+    gate_ptrs = inp_ptr + row_in[:, None] + col_idx[None, :] * col_stride_in
+    up_ptrs = (
+        inp_ptr + row_in[:, None] + (n_cols + col_idx)[None, :] * col_stride_in
+    )
+    out_ptrs = out_ptr + row_out[:, None] + col_idx[None, :] * col_stride_out
+
+    mask = (row_idx < n_rows)[:, None] & (col_idx < n_cols)[None, :]
+    gate = tl.load(gate_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
+    up = tl.load(up_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
+
+    if HAVE_SWIGLU_CLAMP:
+        gate = tl.minimum(gate, swiglu_limit)
+        up = tl.clamp(up, -swiglu_limit, swiglu_limit)
+
+    s = gate / (1 + tl.exp2(-1.44269504089 * swiglu_alpha * gate))
+    if ADD_RESIDUAL:
+        out = tl.fma(s, up, s)
+    else:
+        out = s * up
+
+    tl.store(out_ptrs, out.to(out_ptr.dtype.element_ty), mask=mask)

--- a/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
@@ -76,7 +76,7 @@ def _fused_swiglu_gate_kernel(
     col_stride_in,
     row_stride_out,
     col_stride_out,
-    swiglu_alpha,
+    neg_log2e_alpha,
     swiglu_limit,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -98,17 +98,25 @@ def _fused_swiglu_gate_kernel(
     out_ptrs = out_ptr + row_out[:, None] + col_idx[None, :] * col_stride_out
 
     mask = (row_idx < n_rows)[:, None] & (col_idx < n_cols)[None, :]
-    gate = tl.load(gate_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
-    up = tl.load(up_ptrs, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
+    # Default (cached) loads outperform ".cg" here: this is a pure streaming op
+    # with no data reuse, and bypassing L1 via ".cg" adds coherence traffic that
+    # regresses large-M bandwidth. The output is write-once, so ".wt"
+    # (write-through) avoids polluting the cache with lines nobody reads back.
+    gate = tl.load(gate_ptrs, mask=mask, other=0.0).to(tl.float32)
+    up = tl.load(up_ptrs, mask=mask, other=0.0).to(tl.float32)
 
     if HAVE_SWIGLU_CLAMP:
         gate = tl.minimum(gate, swiglu_limit)
         up = tl.clamp(up, -swiglu_limit, swiglu_limit)
 
-    s = gate / (1 + tl.exp2(-1.44269504089 * swiglu_alpha * gate))
+    # sigmoid(alpha*g) = 1 / (1 + exp2(-log2(e) * alpha * g)); the -log2(e)*alpha
+    # scalar is folded into neg_log2e_alpha by the caller.
+    s = gate / (1 + tl.exp2(neg_log2e_alpha * gate))
     if ADD_RESIDUAL:
         out = tl.fma(s, up, s)
     else:
         out = s * up
 
-    tl.store(out_ptrs, out.to(out_ptr.dtype.element_ty), mask=mask)
+    tl.store(
+        out_ptrs, out.to(out_ptr.dtype.element_ty), mask=mask, cache_modifier=".wt"
+    )

--- a/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_swiglu_gate.py
@@ -51,9 +51,7 @@ def _fused_swiglu_gate_kernel(
     row_out = row_idx * row_stride_out
 
     gate_ptrs = inp_ptr + row_in[:, None] + col_idx[None, :] * col_stride_in
-    up_ptrs = (
-        inp_ptr + row_in[:, None] + (n_cols + col_idx)[None, :] * col_stride_in
-    )
+    up_ptrs = inp_ptr + row_in[:, None] + (n_cols + col_idx)[None, :] * col_stride_in
     out_ptrs = out_ptr + row_out[:, None] + col_idx[None, :] * col_stride_out
 
     mask = (row_idx < n_rows)[:, None] & (col_idx < n_cols)[None, :]

--- a/aiter/ops/triton/_triton_kernels/moe/activations.py
+++ b/aiter/ops/triton/_triton_kernels/moe/activations.py
@@ -10,23 +10,42 @@ def clip(x, limit, clip_lower: tl.constexpr):
     return res
 
 
+_LOG2E = tl.constexpr(1.44269504089)
+
+
+@triton.jit
+def _swiglu_pair(gate, up, alpha, limit, ADD_RESIDUAL: tl.constexpr):
+    """Clamped GPT-OSS / MiniMax swiglu on separated gate and up tensors."""
+    gate = gate.to(tl.float32)
+    up = up.to(tl.float32)
+    if limit is not None:
+        gate = clip(gate, limit, clip_lower=False)
+        up = clip(up, limit, clip_lower=True)
+    s = gate / (1 + tl.exp2(-_LOG2E * alpha * gate))
+    if ADD_RESIDUAL:
+        return tl.fma(s, up, s)  # s * (up + 1)
+    return s * up
+
+
+@triton.jit
+def _swiglu_separated(input, alpha, limit, ADD_RESIDUAL: tl.constexpr):
+    """
+    SwiGLU on non-interleaved gate|up layout: ``[..., 2 * d]`` with gate in the
+    first ``d`` columns and up in the second ``d`` columns.
+    """
+    half = input.shape[1] // 2
+    gate = input[:, :half]
+    up = input[:, half:]
+    return _swiglu_pair(gate, up, alpha, limit, ADD_RESIDUAL=ADD_RESIDUAL)
+
+
 @triton.jit
 def _swiglu(input, alpha, limit, ADD_RESIDUAL: tl.constexpr):
     """
-    SwiGLU activation
+    SwiGLU activation on interleaved gate/up layout.
 
-    s = silu(gelu), then returns s * (linear + 1) if ADD_RESIDUAL else s * linear.
-    if alpha=1.0, then this is the same as the SiLU activation.
+    s = gate * sigmoid(alpha * gate), then returns s * (up + 1) if ADD_RESIDUAL
+    else s * up. When alpha=1.0 this matches plain SiLU on the gate half.
     """
-    gelu, linear = tl.split(tl.reshape(input, (input.shape[0], input.shape[1] // 2, 2)))
-    gelu = gelu.to(tl.float32)
-    if limit is not None:
-        gelu = clip(gelu, limit, clip_lower=False)
-    linear = linear.to(tl.float32)
-    if limit is not None:
-        linear = clip(linear, limit, clip_lower=True)
-    s = gelu / (1 + tl.exp2(-1.44269504089 * alpha * gelu))
-    if ADD_RESIDUAL:
-        return tl.fma(s, linear, s)  # s * (linear + 1)
-    else:
-        return s * linear
+    gate, up = tl.split(tl.reshape(input, (input.shape[0], input.shape[1] // 2, 2)))
+    return _swiglu_pair(gate, up, alpha, limit, ADD_RESIDUAL=ADD_RESIDUAL)

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
@@ -6,7 +6,7 @@ import triton
 import triton.language as tl
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid
 from aiter.ops.triton._triton_kernels.moe.quant_moe import _compute_static_fp8_quant
-from aiter.ops.triton._triton_kernels.moe.activations import _swiglu
+from aiter.ops.triton._triton_kernels.moe.activations import _swiglu, _swiglu_separated
 from aiter.ops.triton._triton_kernels.quant.quant import _mxfp8_quant_op
 
 
@@ -146,6 +146,7 @@ def _moe_gemm_a8w4(
     limit,
     ACTIVATION_REDUCTION_N: tl.constexpr,
     SWIGLU_ADD_RESIDUAL: tl.constexpr,
+    SWIGLU_SEPARATED: tl.constexpr,
     # MoE config
     N_EXPTS_ACT: tl.constexpr,
     # optimization config
@@ -400,7 +401,12 @@ def _moe_gemm_a8w4(
             bias = tl.full([BLOCK_N], 0, dtype=tl.float32)
         acc = acc + bias[None, :]
     if APPLY_SWIGLU and SPLIT_K == 1:
-        out = _swiglu(acc, alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL)
+        if SWIGLU_SEPARATED:
+            out = _swiglu_separated(
+                acc, alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL
+            )
+        else:
+            out = _swiglu(acc, alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL)
         tl.static_assert(
             out.shape[1] == OUT_BLOCK_N,
             f"Activation fn out.shape[1] ({out.shape[1]}) doesn't match computed OUT_BLOCK_N ({OUT_BLOCK_N})",

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
@@ -402,9 +402,7 @@ def _moe_gemm_a8w4(
         acc = acc + bias[None, :]
     if APPLY_SWIGLU and SPLIT_K == 1:
         if SWIGLU_SEPARATED:
-            out = _swiglu_separated(
-                acc, alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL
-            )
+            out = _swiglu_separated(acc, alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL)
         else:
             out = _swiglu(acc, alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL)
         tl.static_assert(

--- a/aiter/ops/triton/_triton_kernels/moe/reduce.py
+++ b/aiter/ops/triton/_triton_kernels/moe/reduce.py
@@ -1,6 +1,6 @@
 import triton
 import triton.language as tl
-from aiter.ops.triton._triton_kernels.moe.activations import _swiglu
+from aiter.ops.triton._triton_kernels.moe.activations import _swiglu, _swiglu_separated
 
 
 @triton.jit
@@ -26,6 +26,7 @@ def _reduce_grouped(
     BLOCK_N: tl.constexpr,
     EVEN_N: tl.constexpr,
     SWIGLU_ADD_RESIDUAL: tl.constexpr,
+    SWIGLU_SEPARATED: tl.constexpr,
     USE_TDM: tl.constexpr,
     # Step 9: external residual fold-in. When HAS_EXT_RESIDUAL=True,
     # Residual[token, :] is added to `acc` before the writeback.
@@ -75,9 +76,14 @@ def _reduce_grouped(
 
         # apply nonlinearity to split-k output
         if APPLY_SWIGLU:
-            curr = _swiglu(
-                curr[None, :], alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL
-            )
+            if SWIGLU_SEPARATED:
+                curr = _swiglu_separated(
+                    curr[None, :], alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL
+                )
+            else:
+                curr = _swiglu(
+                    curr[None, :], alpha, limit, ADD_RESIDUAL=SWIGLU_ADD_RESIDUAL
+                )
         curr = tl.reshape(curr, [curr.shape[-1]])
         # update final accumulator
         acc += curr

--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-SWIGLU-GATE-D=384.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-SWIGLU-GATE-D=384.json
@@ -1,0 +1,26 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_M": 4,
+        "BLOCK_N": 128,
+        "num_warps": 2,
+        "waves_per_eu": 0
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 8,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "M_GEQ_8192": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-SWIGLU-GATE-D=512.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-SWIGLU-GATE-D=512.json
@@ -1,0 +1,26 @@
+{
+    "M_LEQ_512": {
+        "BLOCK_M": 8,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "M_GEQ_8192": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 256,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx950-FUSED-SWIGLU-GATE.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FUSED-SWIGLU-GATE.json
@@ -1,0 +1,26 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_M": 8,
+        "BLOCK_N": 128,
+        "num_warps": 2,
+        "waves_per_eu": 0
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 8,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    },
+    "M_GEQ_8192": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 128,
+        "num_warps": 4,
+        "waves_per_eu": 0
+    }
+}

--- a/aiter/ops/triton/fusions/fused_swiglu_gate.py
+++ b/aiter/ops/triton/fusions/fused_swiglu_gate.py
@@ -10,6 +10,7 @@ import triton
 
 from aiter.ops.triton._triton_kernels.fusions.fused_swiglu_gate import (
     _fused_swiglu_gate_kernel,
+    _get_config,
 )
 from aiter.ops.triton.utils.logger import AiterTritonLogger
 
@@ -20,48 +21,13 @@ _DEFAULT_SWIGLU_ALPHA = 1.702
 _DEFAULT_SWIGLU_LIMIT = 7.0
 
 
-def _pick_block_n(d: int, n_rows: int) -> int:
-    """Tile size along the reduced last dim (cap 1024); at least 32 for vectorization."""
-    n = max(d, 1)
-    if n == 512:
-        return 512 if n_rows > 4096 else 256
-    if n == 384:
-        return 256 if n_rows <= 128 else 128
-    upper = min(n, 1024)
-    p = 1
-    while p * 2 <= upper:
-        p *= 2
-    return max(32, p)
-
-
-def _pick_block_m(n_rows: int, block_n: int, d: int) -> int:
-    if n_rows <= 64:
-        return min(32, max(4, triton.next_power_of_2(n_rows)))
-    if d == 384 and n_rows > 128:
-        return 32 if n_rows > 8192 else 8
-    if d == 512 and n_rows > 4096:
-        return 8
-    if d == 512 and 128 < n_rows <= 4096:
-        return 8
-    if block_n >= 1024:
-        return 8
-    if block_n >= 512:
-        return 8
-    return 16
-
-
-def _pick_num_warps(n_rows: int, block_m: int, block_n: int) -> int:
-    if n_rows <= 128 and block_m >= 16 and block_n >= 128:
-        return 8
-    return 2
-
-
 def fused_swiglu_gate(
     inp: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     swiglu_alpha: float = _DEFAULT_SWIGLU_ALPHA,
     swiglu_limit: float = _DEFAULT_SWIGLU_LIMIT,
     add_residual: bool = True,
+    config: Optional[dict] = None,
 ):
     """
     Fused MiniMax / GPT-OSS gate activation on separated gate|up GEMM output.
@@ -80,6 +46,9 @@ def fused_swiglu_gate(
         swiglu_alpha: sigmoid scale on the gate half (default 1.702).
         swiglu_limit: clamp limit; pass ``<= 0`` to skip clamping.
         add_residual: when True, multiply by ``(up + 1)``; else ``up`` only.
+        config: optional launch config override (``BLOCK_M``, ``BLOCK_N``,
+            ``num_warps``, ``waves_per_eu``). When None, a tuned config is
+            selected per (n_rows, n_cols) via ``_get_config``.
     """
     assert inp.is_cuda, "fused_swiglu_gate requires a CUDA tensor"
     assert inp.is_contiguous(), "inp must be contiguous"
@@ -111,11 +80,16 @@ def fused_swiglu_gate(
     row_stride_out = n_cols
     col_stride_out = 1
 
-    block_n = _pick_block_n(n_cols, n_rows)
-    block_m = _pick_block_m(n_rows, block_n, n_cols)
+    if config is None:
+        config = _get_config(n_rows, n_cols)
+    block_m = config["BLOCK_M"]
+    # Clamp the column tile to the reduced dim (keeps it a power of 2 and avoids
+    # launching mostly-masked column blocks when n_cols < BLOCK_N).
+    block_n = min(config["BLOCK_N"], triton.next_power_of_2(n_cols))
+    num_warps = config.get("num_warps", 4)
+    waves_per_eu = config.get("waves_per_eu", 0)
     grid_m = triton.cdiv(n_rows, block_m)
     grid_n = triton.cdiv(n_cols, block_n)
-    num_warps = _pick_num_warps(n_rows, block_m, block_n)
 
     HAVE_SWIGLU_CLAMP = swiglu_limit > 0
 
@@ -135,6 +109,6 @@ def fused_swiglu_gate(
         HAVE_SWIGLU_CLAMP=HAVE_SWIGLU_CLAMP,
         ADD_RESIDUAL=add_residual,
         num_warps=num_warps,
-        waves_per_eu=0,
+        waves_per_eu=waves_per_eu,
     )
     return out

--- a/aiter/ops/triton/fusions/fused_swiglu_gate.py
+++ b/aiter/ops/triton/fusions/fused_swiglu_gate.py
@@ -20,6 +20,9 @@ _LOGGER = AiterTritonLogger()
 _DEFAULT_SWIGLU_ALPHA = 1.702
 _DEFAULT_SWIGLU_LIMIT = 7.0
 
+# log2(e); used to evaluate sigmoid via exp2 (faster than exp on the hardware).
+_LOG2E = 1.4426950408889634
+
 
 def fused_swiglu_gate(
     inp: torch.Tensor,
@@ -92,6 +95,8 @@ def fused_swiglu_gate(
     grid_n = triton.cdiv(n_cols, block_n)
 
     HAVE_SWIGLU_CLAMP = swiglu_limit > 0
+    # Fold the constant sigmoid scaling into a single scalar passed to the kernel.
+    neg_log2e_alpha = -_LOG2E * swiglu_alpha
 
     _fused_swiglu_gate_kernel[(grid_m, grid_n)](
         inp,
@@ -102,7 +107,7 @@ def fused_swiglu_gate(
         col_stride_in,
         row_stride_out,
         col_stride_out,
-        swiglu_alpha,
+        neg_log2e_alpha,
         swiglu_limit,
         BLOCK_M=block_m,
         BLOCK_N=block_n,

--- a/aiter/ops/triton/fusions/fused_swiglu_gate.py
+++ b/aiter/ops/triton/fusions/fused_swiglu_gate.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.fusions.fused_swiglu_gate import (
+    _fused_swiglu_gate_kernel,
+)
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+_LOGGER = AiterTritonLogger()
+
+# MiniMax-M3 / GPT-OSS defaults
+_DEFAULT_SWIGLU_ALPHA = 1.702
+_DEFAULT_SWIGLU_LIMIT = 7.0
+
+
+def _pick_block_n(d: int, n_rows: int) -> int:
+    """Tile size along the reduced last dim (cap 1024); at least 32 for vectorization."""
+    n = max(d, 1)
+    if n == 512:
+        return 512 if n_rows > 4096 else 256
+    if n == 384:
+        return 256 if n_rows <= 128 else 128
+    upper = min(n, 1024)
+    p = 1
+    while p * 2 <= upper:
+        p *= 2
+    return max(32, p)
+
+
+def _pick_block_m(n_rows: int, block_n: int, d: int) -> int:
+    if n_rows <= 64:
+        return min(32, max(4, triton.next_power_of_2(n_rows)))
+    if d == 384 and n_rows > 128:
+        return 32 if n_rows > 8192 else 8
+    if d == 512 and n_rows > 4096:
+        return 8
+    if d == 512 and 128 < n_rows <= 4096:
+        return 8
+    if block_n >= 1024:
+        return 8
+    if block_n >= 512:
+        return 8
+    return 16
+
+
+def _pick_num_warps(n_rows: int, block_m: int, block_n: int) -> int:
+    if n_rows <= 128 and block_m >= 16 and block_n >= 128:
+        return 8
+    return 2
+
+
+def fused_swiglu_gate(
+    inp: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    swiglu_alpha: float = _DEFAULT_SWIGLU_ALPHA,
+    swiglu_limit: float = _DEFAULT_SWIGLU_LIMIT,
+    add_residual: bool = True,
+):
+    """
+    Fused MiniMax / GPT-OSS gate activation on separated gate|up GEMM output.
+
+    Reference numerics (``swiglu_no_interleaved_with_alpha_and_limit``)::
+
+        gate, up = inp.chunk(2, dim=-1)
+        gate = gate.clamp(max=limit)
+        up = up.clamp(min=-limit, max=limit)
+        out = gate * sigmoid(gate * alpha) * (up + 1)
+
+    Args:
+        inp: ``[..., 2 * N]`` contiguous tensor; first ``N`` columns are gate,
+            second ``N`` are up.
+        out: optional pre-allocated output with shape ``[..., N]``.
+        swiglu_alpha: sigmoid scale on the gate half (default 1.702).
+        swiglu_limit: clamp limit; pass ``<= 0`` to skip clamping.
+        add_residual: when True, multiply by ``(up + 1)``; else ``up`` only.
+    """
+    assert inp.is_cuda, "fused_swiglu_gate requires a CUDA tensor"
+    assert inp.is_contiguous(), "inp must be contiguous"
+    last = inp.size(-1)
+    assert last % 2 == 0, "last dimension must be even (2 * N)"
+    n_cols = last // 2
+    leading = inp.shape[:-1]
+    n_rows = inp.numel() // (2 * n_cols)
+
+    _LOGGER.info(
+        f"fused_swiglu_gate: inp={tuple(inp.shape)} n_cols={n_cols} rows={n_rows} "
+        f"alpha={swiglu_alpha} limit={swiglu_limit}"
+    )
+
+    if n_rows == 0:
+        if out is None:
+            return torch.empty(*leading, n_cols, dtype=inp.dtype, device=inp.device)
+        return out
+
+    if out is None:
+        out = torch.empty(*leading, n_cols, dtype=inp.dtype, device=inp.device)
+    else:
+        assert out.is_contiguous(), "out must be contiguous"
+        assert out.shape == (*leading, n_cols)
+        assert out.dtype == inp.dtype and out.device == inp.device
+
+    row_stride_in = 2 * n_cols
+    col_stride_in = 1
+    row_stride_out = n_cols
+    col_stride_out = 1
+
+    block_n = _pick_block_n(n_cols, n_rows)
+    block_m = _pick_block_m(n_rows, block_n, n_cols)
+    grid_m = triton.cdiv(n_rows, block_m)
+    grid_n = triton.cdiv(n_cols, block_n)
+    num_warps = _pick_num_warps(n_rows, block_m, block_n)
+
+    HAVE_SWIGLU_CLAMP = swiglu_limit > 0
+
+    _fused_swiglu_gate_kernel[(grid_m, grid_n)](
+        inp,
+        out,
+        n_rows,
+        n_cols,
+        row_stride_in,
+        col_stride_in,
+        row_stride_out,
+        col_stride_out,
+        swiglu_alpha,
+        swiglu_limit,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        HAVE_SWIGLU_CLAMP=HAVE_SWIGLU_CLAMP,
+        ADD_RESIDUAL=add_residual,
+        num_warps=num_warps,
+        waves_per_eu=0,
+    )
+    return out

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -312,6 +312,7 @@ def moe_gemm_a8w4(
     limit=1.0,
     swiglu_add_residual=True,
     preshuffled=False,
+    swiglu_separated_layout=False,
     unpadded_N=None,
     unpadded_K=None,
     # Idea 1: emit (fp8 e4m3, ue8m0 per-1×32 scale) directly from the GEMM
@@ -592,6 +593,7 @@ def moe_gemm_a8w4(
             limit,
             reduction_n_matmul,
             swiglu_add_residual,
+            swiglu_separated_layout,
             routing_data.n_expts_act,
             config["block_m"],
             config["block_n"],
@@ -636,6 +638,7 @@ def moe_gemm_a8w4(
         reduction_n_reduction,
         out_dtype=out_dtype,
         swiglu_add_residual=swiglu_add_residual,
+        swiglu_separated_layout=swiglu_separated_layout,
         residual=residual,
     )
     return y_final

--- a/aiter/ops/triton/moe/reduce.py
+++ b/aiter/ops/triton/moe/reduce.py
@@ -24,6 +24,7 @@ def reduce_grouped(
     reduction_n=1,
     out_dtype=None,
     swiglu_add_residual: bool = True,
+    swiglu_separated_layout: bool = False,
     residual: Optional[torch.Tensor] = None,
 ):
     """
@@ -139,6 +140,7 @@ def reduce_grouped(
         EVEN_N=(x.shape[-1] % BLOCK_N == 0),
         K=K,  #
         SWIGLU_ADD_RESIDUAL=swiglu_add_residual,
+        SWIGLU_SEPARATED=swiglu_separated_layout,
         USE_TDM=is_tdm_avail(),
         Residual=residual,
         stride_extres_m=res_stride_m,

--- a/op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py
@@ -50,9 +50,7 @@ def run_point_bench(args):
     compiled = _compiled_swiglu_ref(x, _MINIMAX_ALPHA, _MINIMAX_LIMIT)
     _ = fused_swiglu_gate(x, out)
     torch.cuda.synchronize()
-    torch.testing.assert_close(
-        out, compiled.to(dtype), rtol=1e-2, atol=1e-2
-    )
+    torch.testing.assert_close(out, compiled.to(dtype), rtol=1e-2, atol=1e-2)
 
     ms_compile = bench_fn(
         lambda: _compiled_swiglu_ref(x, _MINIMAX_ALPHA, _MINIMAX_LIMIT),

--- a/op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Microbenchmark for fused MiniMax / GPT-OSS swiglu gate activation.
+
+Compares the aiter ``fused_swiglu_gate`` kernel against the torch.compile
+reference used by sglang (``swiglu_no_interleaved_with_alpha_and_limit``).
+
+Typical MiniMax-M3 TP4 gate-up shape: ``(M * top_k, 768)`` bf16 in,
+``(M * top_k, 384)`` bf16 out — one launch per MoE layer (60 layers/pass).
+"""
+
+import argparse
+import sys
+
+import torch
+import triton
+
+from aiter.ops.triton.fusions.fused_swiglu_gate import fused_swiglu_gate
+
+# MiniMax-M3 TP4 local dims
+_MINIMAX_LOCAL_D = 384
+_MINIMAX_LAST_DIM = 768
+_MINIMAX_TOP_K = 8
+_MINIMAX_ALPHA = 1.702
+_MINIMAX_LIMIT = 7.0
+
+
+@torch.compile
+def _compiled_swiglu_ref(x, alpha, limit):
+    gate, up = x.chunk(2, dim=-1)
+    gate = gate.clamp(min=None, max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    return gate * torch.sigmoid(gate * alpha) * (up + 1)
+
+
+def _make_inputs(n_rows: int, dtype: torch.dtype):
+    x = torch.randn(n_rows, _MINIMAX_LAST_DIM, device="cuda", dtype=dtype)
+    out = torch.empty(n_rows, _MINIMAX_LOCAL_D, device="cuda", dtype=dtype)
+    return x, out
+
+
+def bench_fn(fn, warmup: int = 25, rep: int = 100) -> float:
+    return triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+
+def run_point_bench(args):
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+    n_rows = args.M * _MINIMAX_TOP_K
+    x, out = _make_inputs(n_rows, dtype)
+
+    compiled = _compiled_swiglu_ref(x, _MINIMAX_ALPHA, _MINIMAX_LIMIT)
+    _ = fused_swiglu_gate(x, out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        out, compiled.to(dtype), rtol=1e-2, atol=1e-2
+    )
+
+    ms_compile = bench_fn(
+        lambda: _compiled_swiglu_ref(x, _MINIMAX_ALPHA, _MINIMAX_LIMIT),
+        warmup=args.warmup,
+        rep=args.rep,
+    )
+    ms_fused = bench_fn(
+        lambda: fused_swiglu_gate(x, out),
+        warmup=args.warmup,
+        rep=args.rep,
+    )
+    ms_eager = bench_fn(
+        lambda: torch_swiglu_eager(x, _MINIMAX_ALPHA, _MINIMAX_LIMIT),
+        warmup=args.warmup,
+        rep=args.rep,
+    )
+
+    us_compile = ms_compile * 1e3
+    us_fused = ms_fused * 1e3
+    us_eager = ms_eager * 1e3
+
+    elem = x.element_size()
+    mem_read = n_rows * _MINIMAX_LAST_DIM * elem
+    mem_write = n_rows * _MINIMAX_LOCAL_D * elem
+    mem_gb_s_fused = (mem_read + mem_write) / (ms_fused * 1e-3) / 1e9
+
+    print(f"Shape: ({n_rows}, {_MINIMAX_LAST_DIM}) -> ({n_rows}, {_MINIMAX_LOCAL_D})")
+    print(f"dtype={dtype}, alpha={_MINIMAX_ALPHA}, limit={_MINIMAX_LIMIT}")
+    print(f"warmup={args.warmup}, rep={args.rep}")
+    print()
+    print(f"  eager torch:     {us_eager:7.2f} µs/call  ({ms_eager:8.4f} ms)")
+    print(f"  torch.compile:   {us_compile:7.2f} µs/call  ({ms_compile:8.4f} ms)")
+    print(f"  fused_swiglu_gate: {us_fused:7.2f} µs/call  ({ms_fused:8.4f} ms)")
+    print(f"  speedup vs compile: {us_compile / us_fused:.2f}x")
+    print(f"  bandwidth (fused): {mem_gb_s_fused:.1f} GB/s")
+    if args.layers > 0:
+        print(
+            f"  est. {args.layers} layers/pass: "
+            f"{ms_fused * args.layers:.3f} ms (fused) vs "
+            f"{ms_compile * args.layers:.3f} ms (compile)"
+        )
+
+
+def torch_swiglu_eager(x, alpha, limit):
+    gate, up = x.chunk(2, dim=-1)
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    return gate * torch.sigmoid(gate * alpha) * (up + 1)
+
+
+def run_sweep(args):
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+    m_list = [int(x) for x in args.M_list.split(",")]
+
+    print(
+        f"{'M':>8} {'rows':>10} {'eager_us':>10} {'compile_us':>12} "
+        f"{'fused_us':>10} {'vs_compile':>12}"
+    )
+    for m in m_list:
+        n_rows = m * _MINIMAX_TOP_K
+        x, out = _make_inputs(n_rows, dtype)
+        ms_eager = bench_fn(
+            lambda: torch_swiglu_eager(x, _MINIMAX_ALPHA, _MINIMAX_LIMIT),
+            warmup=args.warmup,
+            rep=args.rep,
+        )
+        ms_compile = bench_fn(
+            lambda: _compiled_swiglu_ref(x, _MINIMAX_ALPHA, _MINIMAX_LIMIT),
+            warmup=args.warmup,
+            rep=args.rep,
+        )
+        ms_fused = bench_fn(
+            lambda: fused_swiglu_gate(x, out),
+            warmup=args.warmup,
+            rep=args.rep,
+        )
+        print(
+            f"{m:8d} {n_rows:10d} {ms_eager * 1e3:10.2f} "
+            f"{ms_compile * 1e3:12.2f} {ms_fused * 1e3:10.2f} "
+            f"{ms_compile / ms_fused:12.2f}x"
+        )
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Benchmark fused_swiglu_gate (MiniMax-M3 TP4 gate activation)"
+    )
+    p.add_argument(
+        "-M",
+        type=int,
+        default=4,
+        help="Token count M (rows = M * top_k, default top_k=8)",
+    )
+    p.add_argument(
+        "-M_list",
+        type=str,
+        default="1,4,32,256,8193,7238",
+        help="Comma-separated M values for sweep mode",
+    )
+    p.add_argument(
+        "--dtype",
+        choices=["bf16", "fp16"],
+        default="bf16",
+    )
+    p.add_argument("--warmup", type=int, default=25)
+    p.add_argument("--rep", type=int, default=100)
+    p.add_argument(
+        "--layers",
+        type=int,
+        default=60,
+        help="MoE layers per pass for aggregate time estimate (0 to skip)",
+    )
+    p.add_argument(
+        "--sweep",
+        action="store_true",
+        help="Sweep multiple M values",
+    )
+    return p.parse_args()
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("CUDA required", file=sys.stderr)
+        return 1
+    args = parse_args()
+    if args.sweep:
+        run_sweep(args)
+    else:
+        run_point_bench(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py
+++ b/op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py
@@ -12,7 +12,6 @@ import argparse
 import sys
 
 import torch
-import triton
 
 from aiter.ops.triton.fusions.fused_swiglu_gate import fused_swiglu_gate
 
@@ -39,7 +38,37 @@ def _make_inputs(n_rows: int, dtype: torch.dtype):
 
 
 def bench_fn(fn, warmup: int = 25, rep: int = 100) -> float:
-    return triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    """Per-call GPU time under a CUDA graph.
+
+    Wall-time benchmarking (``do_bench``) includes per-launch dispatch overhead.
+    In production, decode runs under a CUDA graph where that overhead is captured
+    once and elided on replay — so a launch-heavy path (e.g. one torch.compile
+    activation = several Inductor launches) looks artificially slow under wall
+    time but not in reality. Capturing ``rep`` iterations into a graph and timing
+    one replay isolates pure GPU time, which is what the serving perf report
+    reflects, so this benchmark always uses it.
+
+    ``warmup`` = pre-capture warmup calls (also lets torch.compile finish
+    compiling before capture); ``rep`` = number of captured iterations.
+    """
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        for _ in range(rep):
+            fn()
+    torch.cuda.synchronize()
+    for _ in range(3):
+        g.replay()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    g.replay()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / rep
 
 
 def run_point_bench(args):
@@ -79,7 +108,7 @@ def run_point_bench(args):
 
     print(f"Shape: ({n_rows}, {_MINIMAX_LAST_DIM}) -> ({n_rows}, {_MINIMAX_LOCAL_D})")
     print(f"dtype={dtype}, alpha={_MINIMAX_ALPHA}, limit={_MINIMAX_LIMIT}")
-    print(f"warmup={args.warmup}, rep={args.rep}")
+    print(f"warmup={args.warmup}, rep={args.rep}, timing=cudagraph GPU time")
     print()
     print(f"  eager torch:     {us_eager:7.2f} µs/call  ({ms_eager:8.4f} ms)")
     print(f"  torch.compile:   {us_compile:7.2f} µs/call  ({ms_compile:8.4f} ms)")
@@ -105,6 +134,7 @@ def run_sweep(args):
     dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
     m_list = [int(x) for x in args.M_list.split(",")]
 
+    print("timing=cudagraph GPU time")
     print(
         f"{'M':>8} {'rows':>10} {'eager_us':>10} {'compile_us':>12} "
         f"{'fused_us':>10} {'vs_compile':>12}"
@@ -155,8 +185,12 @@ def parse_args():
         choices=["bf16", "fp16"],
         default="bf16",
     )
-    p.add_argument("--warmup", type=int, default=25)
-    p.add_argument("--rep", type=int, default=100)
+    p.add_argument(
+        "--warmup", type=int, default=25, help="Pre-capture warmup call count"
+    )
+    p.add_argument(
+        "--rep", type=int, default=100, help="Iterations captured into the CUDA graph"
+    )
     p.add_argument(
         "--layers",
         type=int,

--- a/op_tests/triton_tests/fusions/test_fused_swiglu_gate.py
+++ b/op_tests/triton_tests/fusions/test_fused_swiglu_gate.py
@@ -42,15 +42,11 @@ def torch_swiglu_gate_ref(
 @pytest.mark.parametrize("swiglu_limit", [0.0, 7.0])
 @pytest.mark.parametrize("add_residual", [True, False])
 @pytest.mark.parametrize("use_explicit_out", [False, True])
-def test_fused_swiglu_gate(
-    shape, dtype, swiglu_limit, add_residual, use_explicit_out
-):
+def test_fused_swiglu_gate(shape, dtype, swiglu_limit, add_residual, use_explicit_out):
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
     x = torch.randn(shape, dtype=dtype, device="cuda")
-    ref = torch_swiglu_gate_ref(
-        x, limit=swiglu_limit, add_residual=add_residual
-    )
+    ref = torch_swiglu_gate_ref(x, limit=swiglu_limit, add_residual=add_residual)
     if use_explicit_out:
         out = torch.empty_like(ref)
         fused_swiglu_gate(

--- a/op_tests/triton_tests/fusions/test_fused_swiglu_gate.py
+++ b/op_tests/triton_tests/fusions/test_fused_swiglu_gate.py
@@ -1,0 +1,107 @@
+import torch
+import pytest
+
+from aiter.ops.triton.fusions.fused_swiglu_gate import fused_swiglu_gate
+
+# MiniMax-M3 TP4: local intermediate d = 1536 // 4 = 384, gate-up last dim = 768.
+_MINIMAX_TP4_LAST = 768
+_MINIMAX_TOP_K = 8
+_MINIMAX_ALPHA = 1.702
+_MINIMAX_LIMIT = 7.0
+
+
+def torch_swiglu_gate_ref(
+    x: torch.Tensor,
+    alpha: float = _MINIMAX_ALPHA,
+    limit: float = _MINIMAX_LIMIT,
+    add_residual: bool = True,
+) -> torch.Tensor:
+    gate, up = x.chunk(2, dim=-1)
+    if limit > 0:
+        gate = gate.clamp(max=limit)
+        up = up.clamp(min=-limit, max=limit)
+    out = gate * torch.sigmoid(gate * alpha)
+    if add_residual:
+        out = out * (up + 1)
+    else:
+        out = out * up
+    return out.to(x.dtype)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4, 64),
+        (128, 256),
+        (31, 500),
+        (2, 16, 128),
+        (1, 3, 7, 32),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("swiglu_limit", [0.0, 7.0])
+@pytest.mark.parametrize("add_residual", [True, False])
+@pytest.mark.parametrize("use_explicit_out", [False, True])
+def test_fused_swiglu_gate(
+    shape, dtype, swiglu_limit, add_residual, use_explicit_out
+):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    x = torch.randn(shape, dtype=dtype, device="cuda")
+    ref = torch_swiglu_gate_ref(
+        x, limit=swiglu_limit, add_residual=add_residual
+    )
+    if use_explicit_out:
+        out = torch.empty_like(ref)
+        fused_swiglu_gate(
+            x,
+            out,
+            swiglu_limit=swiglu_limit,
+            add_residual=add_residual,
+        )
+    else:
+        out = fused_swiglu_gate(
+            x,
+            swiglu_limit=swiglu_limit,
+            add_residual=add_residual,
+        )
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=0.15)
+
+
+def test_fused_swiglu_gate_requires_even_last_dim():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    x = torch.randn(2, 3, device="cuda")
+    with pytest.raises(AssertionError, match="even"):
+        fused_swiglu_gate(x)
+
+
+@pytest.mark.parametrize(
+    "n_rows,last_dim",
+    [
+        pytest.param(4 * _MINIMAX_TOP_K, _MINIMAX_TP4_LAST, id="minimax_tp4_decode4"),
+        pytest.param(
+            256 * _MINIMAX_TOP_K, _MINIMAX_TP4_LAST, id="minimax_tp4_rows256x8"
+        ),
+        pytest.param(
+            (8190 + 3) * _MINIMAX_TOP_K,
+            _MINIMAX_TP4_LAST,
+            id="minimax_tp4_pref8190_dec3",
+        ),
+        pytest.param(
+            (7235 + 3) * _MINIMAX_TOP_K,
+            _MINIMAX_TP4_LAST,
+            id="minimax_tp4_pref7235_dec3",
+        ),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_fused_swiglu_gate_minimax_m3_shapes(n_rows, last_dim, dtype):
+    """MoE / MLP gate activation as (tokens * top_k, 2 * local_d) under TP4."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    x = torch.randn(n_rows, last_dim, dtype=dtype, device="cuda")
+    ref = torch_swiglu_gate_ref(x)
+    out = fused_swiglu_gate(x)
+    # exp2-based sigmoid can differ slightly from torch.sigmoid at bf16 scale.
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=0.15)


### PR DESCRIPTION
Fused the MiniMax-M3 / GPT-OSS clamped-α SwiGLU gate activation (gate*sigmoid(alpha*gate)*(up+1) with gate/up clamping) into a single Triton kernel plus an optional MoE GEMM-epilogue path, replacing the standalone triton_poi_fused_add_clamp_mul_sigmoid_split launch.

Run it with:

```
python op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py -M 4
python op_tests/op_benchmarks/triton/bench_fused_swiglu_gate.py --sweep
```
Results:
```
       M       rows   eager_us   compile_us   fused_us   vs_compile
       1          8      29.71         9.78       6.60         1.48x
       4         32      26.85        11.67       6.52         1.79x
      32        256      27.75        10.27       6.49         1.58x
     256       2048      31.16         9.79       6.63         1.48x
    8193      65544     217.51        44.71      32.62         1.37x
    7238      57904     192.91        40.30      29.41         1.37x
```