### PR TITLE
CI(atom-di): track ATOM main + pin cases to 1p1d via --case

### DIFF
--- a/.github/workflows/atom-di-ci-smoke-workflow.yaml
+++ b/.github/workflows/atom-di-ci-smoke-workflow.yaml
@@ -64,7 +64,7 @@ permissions:
   contents: read
 
 env:
-  ATOM_REF_DEFAULT: 22577adb3ac909c3d0d8fe2209e64afe67b5c7bc
+  ATOM_REF_DEFAULT: main
   ATOMESH_IMAGE_DEFAULT: rocm/atom-dev:latest
   ATOMESH_MODEL_PATH_DEEPSEEK_V4_PRO_DEFAULT: /data/models2/DeepSeek-V4-Pro
   ATOMESH_MODEL_PATH_GLM_5_2_FP8_DEFAULT: /data/models2/GLM-5.2-FP8
@@ -293,7 +293,7 @@ jobs:
           def parse_int_list(value: str):
               return [int(item) for item in value.replace(",", " ").split() if item]
 
-          def build_matrix(model: str, conc: str, eval_conc: str, output: Path):
+          def build_matrix(model: str, case: str, conc: str, eval_conc: str, output: Path):
               subprocess.run(
                   [
                       "python3",
@@ -302,6 +302,8 @@ jobs:
                       "nightly",
                       "--model",
                       model,
+                      "--case",
+                      case,
                       "--image",
                       os.environ["ATOMESH_IMAGE"],
                       "--benchmark-concurrency",
@@ -318,6 +320,7 @@ jobs:
           requested = [
               {
                   "model": "DeepSeek-V4-Pro",
+                  "case": "ds-v4-1p1d-tp8",
                   "topology": "1p1d",
                   "osl": os.environ["OSL"],
                   "conc": os.environ["CONC_LIST"],
@@ -329,6 +332,7 @@ jobs:
               requested.append(
                   {
                       "model": "GLM-5.2-FP8",
+                      "case": "glm-5-2-fp8-1p1d-tp8",
                       "topology": "1p1d",
                       "osl": os.environ["GLM_OSL"],
                       "conc": os.environ["GLM_CONC_LIST"],
@@ -350,7 +354,7 @@ jobs:
 
           for index, cfg in enumerate(requested):
               matrix_path = Path(f"../atomesh-matrix-{index}.json")
-              matrix = build_matrix(cfg["model"], cfg["conc"], cfg["eval_conc"], matrix_path)
+              matrix = build_matrix(cfg["model"], cfg["case"], cfg["conc"], cfg["eval_conc"], matrix_path)
               combined_matrix["include"].extend(matrix.get("include", []))
               matches = [
                   cell


### PR DESCRIPTION
## What

Make the ATOM DI CI smoke track upstream ATOM `main` instead of a frozen SHA, and pass `--case` to `pd_matrix.py` so only the intended 1P1D cell is generated per model.

- `ATOM_REF_DEFAULT: <pinned SHA>` → `main` (cron + dispatch now consistently track ATOM main).
- `build_matrix` gains a `case` arg → `pd_matrix.py --case <name>`:
  - DeepSeek-V4-Pro → `ds-v4-1p1d-tp8`
  - GLM-5.2-FP8 → `glm-5-2-fp8-1p1d-tp8`

## Why

ATOM `main`'s DeepSeek-V4-Pro `nightly` suite now also contains `ds-v4-2p1d-dpa-tp8`, which needs 3 nodes, but only 2 are configured (`ATOMESH_2P1D_NODES`). Without `--case`, `pd_matrix.py` **errors while generating that 2p1d cell** (`needs at least 3 node(s)`) before the downstream 1p1d topology filter runs — so a manual dispatch against ATOM main fails at `load-config`. Filtering with `--case` at generation time keeps only the 1p1d cell, so we can track main without hitting the 2p1d node requirement.

Also fixes a footgun: the `atom_ref` input default was `main` while `ATOM_REF_DEFAULT` (used by cron) was a pinned SHA, so dispatch and cron ran different ATOM versions.

## Validation

Dispatched run 29473063986 on this branch: `load-config` generated exactly 1 cell (`Generated 1 ATOMesh benchmark cell(s)`, `ds-v4-1p1d-tp8`, no 2p1d), and `atom-di-ci-smoke` ran the full DeepSeek-V4-Pro 1P1D-TP8 disagg to success (~32 min).

GLM-5.2-FP8 stays opt-in (`run_glm_5_2_fp8=false`); it still crashes at init on `rocm/atom-dev:latest` with `NameError: name 'module_mla_metadata' is not defined` (baked-aiter MLA-metadata JIT op), independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)