### PR TITLE
feat(flydsl): vendor cco-LSA v2 dispatch/combine op-layer into aiter

### DIFF
--- a/aiter/ops/flydsl/dispatch_combine_v2/README.md
+++ b/aiter/ops/flydsl/dispatch_combine_v2/README.md
@@ -1,0 +1,92 @@
+# cco-LSA intranode MoE dispatch / combine (ops v2, FlyDSL)
+
+Intranode (single-node, EP8) MoE dispatch + combine built on **mori-cco LSA**
+(intra-node P2P over the flat symmetric VA) and **FlyDSL** device kernels. A
+mori-parity reimplementation that swaps the mori-shmem provider for cco-LSA:
+peer addresses are computed in-kernel via `cco.Window(arena).lsa_ptr(pe, off)`,
+no host P2P tables. Reference = ROCm/FlyDSL PR #522
+(`dispatch_combine_intranode_{kernel,op}.py`).
+
+Supported token dtypes: **bf16**, **f32**, **fp8** (gather-only; OCP e4m3 on
+gfx950, e4m3**fnuz** max 240 on gfx942) and **fp4** (e2m1, gather-only,
+**gfx950-only** — the `cvt_scalef32_*_fp4` intrinsics don't exist on gfx942).
+Combine: gather (UseP2PRead) **and** scatter (`_nop2p`); weighted combine
+(`out_weights`); StdMoE (ConvertDispatchOutput / ConvertCombineInput, standalone
++ wired into the op); fp8 combine-wire **quant** (`fp8_direct_cast` **and**
+`fp8_blockwise`, scatter-only — distinct from the plain fp8 token dtype, which
+keeps a bf16 external payload); per-token scales forwarding;
+`max_total_recv_tokens` cap; mori-parity host op-layer + per-device,
+dtype-aware tuning table. Not done: `skip_stage1` (FlyDSL-only).
+
+> **Test-only, not a mori API (yet).** These modules import each other by
+> top-level name (`from intranode_kernels import ...`, `import flydsl_prims as P`)
+> and have no `__init__.py`; they only resolve after the tests do
+> `sys.path.insert(0, <this dir>)`. There is no `mori.ops.dispatch_combine_v2`
+> package export, so `import mori.ops.dispatch_combine_v2.dispatch_combine_op`
+> will fail. Use it via the test/bench harnesses below. Wiring it in as a real
+> package (relative imports + `__init__.py` + `ops/__init__.py` export) is a
+> follow-up.
+
+## Layout
+
+| file | role |
+|---|---|
+| `flydsl_prims.py` | device primitives: system atomics / ordered stores / fences / volatile-spin waits |
+| `intranode_kernels.py` | all FlyDSL intranode kernel factories: `make_dispatch` (+scales/replay), `make_combine` (gather) / `make_combine_scatter` (`_nop2p`, bf16/f32/fp8/fp4), `make_convert_dispatch_output` / `make_convert_combine_input` (StdMoE), `make_local_expert_count` |
+| `dispatch_combine_op.py` | `SymmArena` + `EpDispatchCombineOp` / `EpDispatchCombineConfig` (+`.tuned()`) / `EpDispatchRoutingHandle` — mori-parity host op-layer (scales, scatter/quant combine, StdMoE, recv cap, LEC, reset, replay) |
+| `tuning_configs.py` | per-(world,hidden,topk) block/warp lookup |
+
+Tests/bench live under `tests/python/ops/dispatch_combine_v2/`:
+
+| file | role |
+|---|---|
+| `test_dispatch_combine_v2_intranode.py` | pytest wrapper: runs `test_op.py` under torchrun for the representative modes and asserts every line PASS |
+| `test_op.py` | EP8 op-layer test (gather/scatter, quant, StdMoE, recv-cap, scales, LEC, reset, replay) |
+| `bench_dispatch_combine.py` | eager + CUDA-graph perf bench + e2e correctness. Envs: `DTYPE=bf16\|f32\|fp8\|fp4`, `COMBINE=gather\|scatter`, `QUANT=none\|fp8_direct_cast\|fp8_blockwise`, `STDMOE=1`, `SCALE_DIM`, `SWEEP`, `DISP_BLOCK`/`COMB_BLOCK`, `WARP_NUM`/`COMB_WARP`, `MODE`, `TUNED` |
+| `run_bench.sh` | bench launcher (runs `bench_dispatch_combine.py` in the container) |
+
+(Each script inlines a tiny torchrun/gloo `Dist` bootstrap — gloo only carries the cco unique-id and pass/fail counts.)
+
+## Run (inside the container, 8 GPUs)
+
+`torchrun --standalone` uses a localhost rendezvous, so no socket-iface env is
+needed. Intranode only (no GDA/RDMA).
+
+```bash
+cd tests/python/ops/dispatch_combine_v2
+
+pytest test_dispatch_combine_v2_intranode.py -v                       # EP8 correctness (all modes)
+torchrun --standalone --nproc_per_node=8 test_op.py                   # op-layer correctness (env-driven)
+torchrun --standalone --nproc_per_node=8 bench_dispatch_combine.py    # perf + e2e correctness
+```
+
+Config via env: `HIDDEN`, `TOPK`, `EPR`, `SWEEP`, `DTYPE`, `COMBINE`, `QUANT`,
+`DISP_BLOCK`/`COMB_BLOCK`, `WARP_NUM`/`COMB_WARP`, `MODE=eager|graph|both`, `TUNED`.
+
+## Design notes
+
+- **dispatch**: per (token, k) dedup same-dest-PE via ballot; lane0 remote
+  `atomic_add` allocates a recv slot; publish origin id + idx/wts + 16B dual-issue
+  token copy to the peer; grid barrier; per-peer count signal; collect `total_recv`.
+- **combine** (gather, = mori `UseP2PRead`): cross-device entry barrier, then each
+  local token gathers its k expert outputs **remotely** from `peer.out_tok[dest_tok_id]`
+  and reduces in f32. Register-light i32 reads (2 bf16 / `v2f32` accumulate) + 2-way
+  unroll keep VGPRs low so 16 warps/block run at high occupancy to hide xGMI read
+  latency; remote reads are latency-bound so combine needs ~128 blocks, while
+  dispatch's posted writes saturate at ~64 blocks (half the CUs).
+- Self-written volatile/atomic spin-waits (`flydsl_prims.spin_until_*`) — mori-shmem's
+  `wait_until_*` assert on a cco-only stack. Counters self-reset in-kernel → CUDAGraph-safe.
+
+## Perf (EP8, hidden=7168, top-k=8, 256 experts; dispatch 64blk / combine 128blk × 16warp, CUDA-graph, bf16)
+
+Per-rank bandwidth = `recv_tok * per_token_bytes / time` (the bench sizes the
+payload per dtype, `hidden*2` for bf16). Indicative bf16 numbers on **MI308X
+(gfx942)** xGMI:
+
+| tok/rank | dispatch | combine |
+|---:|---:|---:|
+| 512  | 268 GB/s | 213 GB/s |
+| 2048 | 306 GB/s | 294 GB/s |
+| 8192 | 314 GB/s | 323 GB/s |
+
+Cross-impl (v2 vs mori v1) latency tables for fp8/fp4 are in PR ROCm/mori#448.

--- a/aiter/ops/flydsl/dispatch_combine_v2/__init__.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/__init__.py
@@ -1,0 +1,17 @@
+# Vendored from mori python/mori/ops/dispatch_combine_v2 (cco-LSA v2 EP dispatch/combine).
+# The op/kernel layer lives here so gfx1250 kernel development happens in aiter; the
+# underlying cco communication substrate (mori.cco.Communicator + libmori_cco*.{so,bc})
+# and mori.jit/mori.tensor_utils remain installed-mori runtime dependencies.
+from .dispatch_combine_op import (
+    SymmArena,
+    EpDispatchCombineConfig,
+    EpDispatchCombineOp,
+    EpDispatchRoutingHandle,
+)
+
+__all__ = [
+    "SymmArena",
+    "EpDispatchCombineConfig",
+    "EpDispatchCombineOp",
+    "EpDispatchRoutingHandle",
+]

--- a/aiter/ops/flydsl/dispatch_combine_v2/dispatch_combine_op.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/dispatch_combine_op.py
@@ -1,0 +1,964 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""mori-parity host op-layer for the cco-LSA intranode dispatch/combine kernels.
+
+One SymmArena window holds the symmetric staging; per-rank metadata are plain
+device tensors surfaced to the caller via from_gpu_ptr.
+"""
+from dataclasses import dataclass
+
+import torch
+
+import flydsl.expr as fx
+from mori.tensor_utils import from_gpu_ptr
+
+from .intranode_kernels import (
+    make_dispatch,
+    make_combine,
+    make_combine_scatter,
+    make_convert_dispatch_output,
+    make_convert_combine_input,
+    make_local_expert_count,
+)
+
+_QUANT_TYPES = ("none", "fp8_direct_cast", "fp8_blockwise")
+
+_DT = {
+    torch.bfloat16: 2,
+    torch.float32: 4,
+    torch.float8_e4m3fnuz: 1,
+    torch.float8_e4m3fn: 1,
+}
+_FP8_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+
+
+def _align_up(x, a):
+    return (x + a - 1) // a * a
+
+
+class SymmArena:
+    """One cco symmetric window carved into named, aligned sub-regions. A kernel
+    reaches peer pe's copy of region R via cco.Window(handle).lsa_ptr(pe, off_R)."""
+
+    _ALIGN = 256
+
+    def __init__(self, comm, regions):
+        self._comm = comm
+        self._offsets = {}
+        self._sizes = {}
+        off = 0
+        for name, nbytes in regions:
+            off = _align_up(off, self._ALIGN)
+            self._offsets[name] = off
+            self._sizes[name] = nbytes
+            off += nbytes
+        self._total = max(_align_up(off, self._ALIGN), self._ALIGN)
+        self._mem = comm.alloc_mem(self._total)
+        self._win = comm.register_window(self._mem.ptr, self._total)
+
+    @property
+    def handle(self):
+        return self._win.handle
+
+    @property
+    def total_bytes(self):
+        return self._total
+
+    def offset(self, name):
+        return self._offsets[name]
+
+    def local_ptr(self, name):
+        return self._win.local_ptr + self._offsets[name]
+
+    def zero(self, name=None):
+        """Zero the whole window, or just region `name` if given. Wraps the raw
+        pointer as a zero-copy int8 torch view (borrowed via
+        __cuda_array_interface__ — no ownership taken) and memsets it."""
+        if name is None:
+            ptr, nbytes = self._win.local_ptr, self._total
+        else:
+            ptr, nbytes = self.local_ptr(name), self._sizes[name]
+        from_gpu_ptr(ptr, (nbytes,), torch.int8).zero_()
+
+    def close(self):
+        """Free the symmetric window (deregister before freeing the backing mem)."""
+        self._win.close()
+        self._mem.close()
+
+
+@dataclass
+class EpDispatchCombineConfig:
+    rank: int
+    world_size: int
+    hidden_dim: int
+    max_num_inp_token_per_rank: int
+    num_experts_per_rank: int
+    num_experts_per_token: int
+    # Base token dtype; dispatch_data_type / combine_data_type override it per-op
+    # (None => data_type). Asymmetric (fp8 dispatch -> bf16 combine) fits an expert
+    # op that converts dtype between the two. gather mode only.
+    data_type: torch.dtype = torch.bfloat16
+    dispatch_data_type: torch.dtype = None
+    combine_data_type: torch.dtype = None
+    # Per-token quant scales forwarded verbatim to dest out_scales (0 disables).
+    scale_dim: int = 0
+    scale_type_size: int = 0
+    # "gather" (UseP2PRead) or "scatter" (mori _nop2p, fp8 compression home).
+    combine_mode: str = "gather"
+    quant_type: str = "none"  # none | fp8_direct_cast | fp8_blockwise
+    # Geometry: None => auto (pull the tuned schedule for this device/shape/dtype
+    # from tuning_configs in __post_init__). Pin any of these to opt out and use a
+    # fixed geometry instead. Combine wants few warps (K-deep per-lane MLP already
+    # saturates), kept separate from dispatch's warp count.
+    dispatch_block_num: int = None
+    combine_block_num: int = None
+    warp_num_per_block: int = None
+    combine_warp_num_per_block: int = None
+    # Optional per-token plan: tuple of (max_tok_inclusive | None, disp_block,
+    # disp_warp, comb_block, comb_warp) buckets. When set, the op precompiles the
+    # distinct (block, warp) variants and picks one at runtime from
+    # cur_rank_num_token. None => auto (from tuning_configs) or single-shot fallback.
+    schedule: tuple = None
+    enable_std_moe: bool = False
+    max_total_recv_tokens: int = 0  # mori maxTotalRecvTokens; 0 = worst-case ws*M
+
+    def __post_init__(self):
+        # all-or-none: setting only one silently defaults the other to data_type.
+        if (self.dispatch_data_type is None) != (self.combine_data_type is None):
+            raise ValueError(
+                "dispatch_data_type / combine_data_type must be set together "
+                "(all-or-none): got dispatch_data_type="
+                f"{self.dispatch_data_type}, combine_data_type={self.combine_data_type}. "
+                "Set data_type alone for a symmetric op, or set both explicitly for "
+                "asymmetric dispatch/combine dtypes."
+            )
+        if self.quant_type not in _QUANT_TYPES:
+            raise ValueError(
+                f"quant_type must be one of {_QUANT_TYPES}, got {self.quant_type!r}"
+            )
+        if self.combine_mode not in ("gather", "scatter"):
+            raise ValueError(
+                f"combine_mode must be gather|scatter, got {self.combine_mode!r}"
+            )
+        if self.quant_type != "none":
+            self.combine_mode = "scatter"
+        # The dispatch grid barrier iterates peers as `range(lane, npes, 64)` and
+        # resets the barrier inside the loop, which is only correct when each lane
+        # runs it at most once (npes <= wavefront). Intranode is single-node so
+        # this always holds, but make the assumption explicit.
+        if self.world_size > 64:
+            raise ValueError(
+                f"intranode op supports world_size <= 64, got {self.world_size}"
+            )
+        # Token copy moves whole 16 B (vec4) chunks; a non-16 B-aligned per-token
+        # size would over-read/write a few dwords past the token.
+        if self.token_nbytes % 16 != 0:
+            raise ValueError(
+                f"per-token transport bytes must be 16 B aligned (vec4 copy); "
+                f"hidden_dim={self.hidden_dim}, dispatch_dtype={self.dispatch_dtype} -> "
+                f"token_nbytes={self.token_nbytes}"
+            )
+        if self.is_asymmetric_dtype:
+            # dispatch output (disp_out, dispatch dtype) and combine staging
+            # (out_tok, combine dtype) are separate buffers. gather/non-quant/
+            # non-StdMoE only (the asymmetric path is implemented for gather).
+            if (
+                self.combine_mode != "gather"
+                or self.quant_type != "none"
+                or self.enable_std_moe
+            ):
+                raise ValueError(
+                    "combine_data_type (asymmetric dtype) requires combine_mode=gather, "
+                    "quant_type=none, enable_std_moe=False"
+                )
+            if torch.float4_e2m1fn_x2 in (self.dispatch_dtype, self.combine_dtype):
+                raise ValueError(
+                    "asymmetric dispatch/combine dtype does not support fp4"
+                )
+            if self.combine_token_nbytes % 16 != 0:
+                raise ValueError(
+                    f"combine per-token bytes must be 16 B aligned; combine_data_type="
+                    f"{self.combine_data_type} -> {self.combine_token_nbytes}"
+                )
+        self._resolve_geometry()
+
+    def _resolve_geometry(self):
+        """Fill block/warp/schedule. Tuned-by-default: when the caller pinned
+        neither a schedule nor any block/warp, pull the tuned geometry for this
+        device/shape/dtype from tuning_configs.lookup (so the plain constructor is
+        tuned automatically — EpDispatchCombineConfig.tuned() is now just an
+        explicit alias). If any field is pinned, honor it and fill the rest with
+        the single-shot fallback (no schedule)."""
+        pinned = self.schedule is not None or any(
+            g is not None
+            for g in (
+                self.dispatch_block_num,
+                self.combine_block_num,
+                self.warp_num_per_block,
+                self.combine_warp_num_per_block,
+            )
+        )
+        if not pinned:
+            from .tuning_configs import lookup
+
+            t = lookup(
+                self.world_size,
+                self.hidden_dim,
+                self.num_experts_per_token,
+                dtype=self.dtype_str,
+            )
+            self.dispatch_block_num = t["dispatch_block_num"]
+            self.combine_block_num = t["combine_block_num"]
+            self.warp_num_per_block = t["warp_num_per_block"]
+            self.combine_warp_num_per_block = t["combine_warp_num_per_block"]
+            self.schedule = t["schedule"]
+        else:
+            # explicit geometry: fill any unset field with the single-shot default
+            if self.dispatch_block_num is None:
+                self.dispatch_block_num = 64
+            if self.combine_block_num is None:
+                self.combine_block_num = 80
+            if self.warp_num_per_block is None:
+                self.warp_num_per_block = 16
+            if self.combine_warp_num_per_block is None:
+                self.combine_warp_num_per_block = 4
+
+    @property
+    def is_scatter(self):
+        return self.combine_mode == "scatter"
+
+    @property
+    def fp8_direct_cast(self):
+        return self.quant_type == "fp8_direct_cast"
+
+    @property
+    def fp8_blockwise(self):
+        return self.quant_type == "fp8_blockwise"
+
+    @property
+    def combine_scale_dim(self):
+        """Per-token block count for fp8_blockwise combine (block_elems=128)."""
+        return self.hidden_dim // 128 if self.fp8_blockwise else 0
+
+    @property
+    def wire_elem_size(self):
+        """comb_inp transport element size: 1 byte for fp8 paths, else elem_size."""
+        return (
+            1
+            if self.quant_type in ("fp8_direct_cast", "fp8_blockwise")
+            else self.elem_size
+        )
+
+    @classmethod
+    def tuned(cls, **kwargs):
+        """Build a config with block/warp geometry pulled from tuning_configs
+        (unless explicitly overridden in kwargs). Kept for back-compat and to
+        force per-field tuning even when some geometry is overridden; the plain
+        constructor is now also tuned-by-default (see _resolve_geometry)."""
+        from .tuning_configs import lookup
+
+        dt = kwargs.get("data_type", torch.bfloat16)
+        dtype = (
+            "fp4"
+            if dt == torch.float4_e2m1fn_x2
+            else ("fp8" if dt in _FP8_DTYPES else "bf16")
+        )
+        t = lookup(
+            kwargs["world_size"],
+            kwargs["hidden_dim"],
+            kwargs["num_experts_per_token"],
+            dtype=dtype,
+        )
+        for k, v in t.items():
+            kwargs.setdefault(k, v)
+        return cls(**kwargs)
+
+    @property
+    def dispatch_dtype(self):
+        """Dispatch transport dtype (== data_type unless dispatch_data_type set)."""
+        return (
+            self.dispatch_data_type
+            if self.dispatch_data_type is not None
+            else self.data_type
+        )
+
+    @property
+    def is_fp4(self):
+        return self.dispatch_dtype == torch.float4_e2m1fn_x2
+
+    @property
+    def is_fp8(self):
+        return self.dispatch_dtype in _FP8_DTYPES
+
+    @property
+    def elem_size(self):
+        # fp4 is 0.5 B/elem; return a nominal 1 (kernels use the fp4 flag +
+        # token_nbytes for actual sizing, never elem_size for fp4 token buffers).
+        return 1 if self.is_fp4 else _DT[self.dispatch_dtype]
+
+    @property
+    def token_nbytes(self):
+        """Per-token transport bytes (fp4 packs 2 e2m1/byte -> hidden/2)."""
+        return self.hidden_dim // 2 if self.is_fp4 else self.hidden_dim * self.elem_size
+
+    @property
+    def combine_dtype(self):
+        """Combine transport dtype (== data_type unless combine_data_type set)."""
+        return (
+            self.combine_data_type
+            if self.combine_data_type is not None
+            else self.data_type
+        )
+
+    @property
+    def combine_elem_size(self):
+        cdt = self.combine_dtype
+        return 1 if cdt == torch.float4_e2m1fn_x2 else _DT[cdt]
+
+    @property
+    def combine_token_nbytes(self):
+        cdt = self.combine_dtype
+        return (
+            self.hidden_dim // 2
+            if cdt == torch.float4_e2m1fn_x2
+            else self.hidden_dim * self.combine_elem_size
+        )
+
+    @property
+    def is_asymmetric_dtype(self):
+        return self.dispatch_dtype != self.combine_dtype
+
+    @property
+    def dtype_str(self):
+        """Token/dispatch dtype key for tuning_configs.lookup (fp4/fp8/default)."""
+        if self.is_fp4:
+            return "fp4"
+        if self.is_fp8:
+            return "fp8"
+        return "bf16"
+
+    @property
+    def max_recv(self):
+        """Sentinel / sender-side atomic-add allocation bound (always ws*M)."""
+        return self.world_size * self.max_num_inp_token_per_rank
+
+    @property
+    def effective_max_recv_per_rank(self):
+        if self.max_total_recv_tokens <= 0:
+            return self.max_num_inp_token_per_rank
+        per = (self.max_total_recv_tokens + self.world_size - 1) // self.world_size
+        return min(per, self.max_num_inp_token_per_rank)
+
+    @property
+    def effective_max_recv(self):
+        """Recv-slot cap passed to the kernels as max_recv (mori MaxNumTokensToRecv)."""
+        return self.world_size * self.effective_max_recv_per_rank
+
+
+class EpDispatchRoutingHandle:
+    """Per-call routing snapshot (mori EpDispatchRoutingHandle parity).
+
+    disp_dest_tok_id_map: forward (src_tok,k)->dest flat slot (v2 tok_map).
+    disp_tok_id_to_src_tok_id_local: reverse recv-slot->src token (v2 tis).
+    inter_node_*: empty placeholders (v2 is intranode-only; kept for 5-tensor
+    shape parity so downstream unpacking works).
+
+    The reverse map (disp_tok_id_to_src_tok_id_local) is materialized LAZILY on
+    first access. recv_to_src_token is written into this rank's arena by peers via
+    P2P during dispatch and, per the mori contract, is only visible after the
+    caller's post-dispatch comm.barrier(). Cloning it eagerly inside dispatch()
+    (before that barrier) races those P2P writes and captures stale entries on
+    high-CU parts (seen flaky on MI355X at high occupancy). Deferring the clone to
+    first access lets it run after the barrier; it also skips the copy entirely for
+    the common combine path, which never reads the reverse map.
+    """
+
+    def __init__(
+        self,
+        disp_dest_tok_id_map,
+        inter_node_disp_dest_tok_id_map,
+        inter_node_disp_send_map,
+        total_recv_token_num,
+        disp_tok_id_to_src_tok_id_local=None,
+        cur_rank_num_token=0,
+        *,
+        reverse_src_view=None,
+    ):
+        self.disp_dest_tok_id_map = disp_dest_tok_id_map
+        self.inter_node_disp_dest_tok_id_map = inter_node_disp_dest_tok_id_map
+        self.inter_node_disp_send_map = inter_node_disp_send_map
+        self.total_recv_token_num = total_recv_token_num
+        self.cur_rank_num_token = cur_rank_num_token
+        # Either an already-materialized reverse map (from_tensors round-trip) or
+        # a live arena view to clone on first access (dispatch()).
+        self._reverse_cache = disp_tok_id_to_src_tok_id_local
+        self._reverse_src_view = reverse_src_view
+
+    @property
+    def disp_tok_id_to_src_tok_id_local(self):
+        if self._reverse_cache is None:
+            # First access (post-barrier): clone off the arena so it survives the
+            # next dispatch overwriting the region.
+            self._reverse_cache = self._reverse_src_view.clone()
+        return self._reverse_cache
+
+    def tensors(self):
+        return (
+            self.disp_dest_tok_id_map,
+            self.inter_node_disp_dest_tok_id_map,
+            self.inter_node_disp_send_map,
+            self.total_recv_token_num,
+            self.disp_tok_id_to_src_tok_id_local,
+        )
+
+    @classmethod
+    def from_tensors(cls, tensors, cur_rank_num_token=0):
+        return cls(*tensors, cur_rank_num_token=cur_rank_num_token)
+
+
+class EpDispatchCombineOp:
+    def __init__(self, cfg: EpDispatchCombineConfig, comm):
+        self.cfg = cfg
+        self.comm = comm
+        device = torch.device("cuda", torch.cuda.current_device())
+        self.dev = device
+        elem_size = cfg.elem_size
+        is_fp4 = cfg.is_fp4
+        is_fp8 = cfg.is_fp8
+        token_nbytes = cfg.token_nbytes  # per-token transport bytes (fp4 = hidden/2)
+        if (is_fp4 or is_fp8) and cfg.is_scatter:
+            raise ValueError(
+                "plain fp4/fp8 token dtype is gather-only "
+                "(fp8 quant uses quant_type=fp8_direct_cast, not data_type)"
+            )
+        topk = cfg.num_experts_per_token
+        hidden_dim = cfg.hidden_dim
+        max_tok_per_rank = cfg.max_num_inp_token_per_rank
+        recv_cap = cfg.effective_max_recv  # recv-slot cap (== ws*M unless capped)
+        self._recv_cap = recv_cap
+
+        self._scale_bytes = cfg.scale_dim * cfg.scale_type_size
+        self._scale_num_i32 = (self._scale_bytes + 3) // 4
+        self._enable_scales = self._scale_bytes > 0
+
+        regions = [
+            ("tok_off", 4),
+            ("recv_num", cfg.world_size * 4),
+            ("recv_to_src_token", recv_cap * 4),
+            ("out_idx", recv_cap * topk * 4),
+            ("out_wts", recv_cap * topk * 4),
+            # disp_out: dispatch scatter dest / expert-GEMM input (recv_x). Kept
+            # separate from out_tok so combine's copy-in never clobbers the
+            # dispatched tokens the expert still reads — callers can skip .clone().
+            ("disp_out", recv_cap * token_nbytes),
+            # out_tok: combine staging (post-expert results that peers gather).
+            ("out_tok", recv_cap * cfg.combine_token_nbytes),
+            ("cross_device_barrier", cfg.world_size * 8),
+        ]
+        if self._enable_scales:
+            regions.append(("out_scales", recv_cap * self._scale_num_i32 * 4))
+        # scatter combine needs its own staging regions
+        if cfg.is_scatter:
+            wire_elem_size = cfg.wire_elem_size
+            regions.append(
+                (
+                    "comb_inp",
+                    cfg.world_size * max_tok_per_rank * hidden_dim * wire_elem_size,
+                )
+            )
+            regions.append(("comb_wts", cfg.world_size * max_tok_per_rank * topk * 4))
+            if cfg.fp8_blockwise:
+                regions.append(
+                    (
+                        "comb_scales",
+                        cfg.world_size * max_tok_per_rank * cfg.combine_scale_dim * 4,
+                    )
+                )
+        self.arena = SymmArena(comm, regions)
+        self.arena.zero()
+
+        self.token_dest_map = torch.full(
+            (max_tok_per_rank * topk,), -1, dtype=torch.int32, device=device
+        )
+        self._empty_i32 = torch.empty(
+            0, dtype=torch.int32, device=device
+        )  # inter-node placeholders
+        self.dest_pe_counter = torch.zeros(
+            cfg.world_size, dtype=torch.int32, device=device
+        )
+        self.dispatch_barrier = torch.zeros(1, dtype=torch.int32, device=device)
+        self.total_recv = torch.zeros(1, dtype=torch.int32, device=device)
+        self.combine_barrier = torch.zeros(1, dtype=torch.int32, device=device)
+        self.cross_device_flag = torch.ones(1, dtype=torch.int64, device=device)
+        c_dt = cfg.combine_dtype  # combine output dtype
+        c_elem = cfg.combine_elem_size
+        if c_dt == torch.float4_e2m1fn_x2:  # fp4 combine outputs fp4 (hidden/2 B/token)
+            self.combine_out = torch.zeros(
+                max_tok_per_rank * (hidden_dim // 2), dtype=torch.int8, device=device
+            )
+        elif c_dt in _FP8_DTYPES:  # fp8 combine outputs fp8 (1 byte/elem)
+            self.combine_out = torch.zeros(
+                max_tok_per_rank * hidden_dim, dtype=torch.int8, device=device
+            )
+        else:
+            self.combine_out = torch.zeros(
+                max_tok_per_rank * hidden_dim,
+                dtype=torch.int16 if c_elem == 2 else torch.int32,
+                device=device,
+            )
+        self.combine_out_weights = torch.zeros(
+            max_tok_per_rank * topk, dtype=torch.float32, device=device
+        )
+
+        arena = self.arena
+        # Distinct (block, warp) variants to precompile. With a per-token schedule
+        # the op picks the best (block, warp) at runtime from cur_rank_num_token;
+        # otherwise it is single-shot. Scatter combine is not schedule-tuned.
+        schedule = cfg.schedule
+        if schedule:
+            dispatch_specs = sorted({(db, dw) for (_, db, dw, _, _) in schedule})
+            combine_specs = sorted({(cb, cw) for (_, _, _, cb, cw) in schedule})
+        else:
+            dispatch_specs = [(cfg.dispatch_block_num, cfg.warp_num_per_block)]
+            combine_specs = [(cfg.combine_block_num, cfg.combine_warp_num_per_block)]
+        if cfg.is_scatter:
+            combine_specs = [(cfg.combine_block_num, cfg.combine_warp_num_per_block)]
+        self._dispatch_specs = dispatch_specs
+        self._combine_specs = combine_specs
+
+        self._dispatch_kwargs = dict(
+            rank=cfg.rank,
+            npes=cfg.world_size,
+            experts_per_rank=cfg.num_experts_per_rank,
+            experts_per_token=topk,
+            hidden_dim=hidden_dim,
+            hidden_elem_size=elem_size,
+            max_tok_per_rank=max_tok_per_rank,
+            max_recv=recv_cap,
+            off_tok_off=arena.offset("tok_off"),
+            off_recv_num=arena.offset("recv_num"),
+            off_tis=arena.offset("recv_to_src_token"),
+            off_out_idx=arena.offset("out_idx"),
+            off_out_wts=arena.offset("out_wts"),
+            off_out_tok=arena.offset("disp_out"),
+            off_out_scales=arena.offset("out_scales") if self._enable_scales else 0,
+            scale_dim=cfg.scale_dim,
+            scale_type_size=cfg.scale_type_size,
+            fp4=is_fp4,
+        )
+        # (block, warp) -> compiled dispatch / combine kernel.
+        self._dispatch_variants = {
+            (b, w): make_dispatch(
+                block_num=b, warp_num_per_block=w, **self._dispatch_kwargs
+            )
+            for (b, w) in dispatch_specs
+        }
+        self._dispatch_replay_variants = {}  # lazily compiled per (block, warp)
+        if cfg.is_scatter:
+            self._combine_variants = {
+                (b, w): make_combine_scatter(
+                    rank=cfg.rank,
+                    npes=cfg.world_size,
+                    experts_per_token=topk,
+                    hidden_dim=hidden_dim,
+                    hidden_elem_size=elem_size,
+                    max_tok_per_rank=max_tok_per_rank,
+                    max_recv=recv_cap,
+                    block_num=b,
+                    warp_num_per_block=w,
+                    off_out_tok=arena.offset("out_tok"),
+                    off_comb_inp=arena.offset("comb_inp"),
+                    off_tis=arena.offset("recv_to_src_token"),
+                    off_xdb_mem=arena.offset("cross_device_barrier"),
+                    off_out_wts=arena.offset("out_wts"),
+                    off_comb_wts=arena.offset("comb_wts"),
+                    off_comb_scales=(
+                        arena.offset("comb_scales") if cfg.fp8_blockwise else 0
+                    ),
+                    fp8_direct_cast=cfg.fp8_direct_cast,
+                    fp8_blockwise=cfg.fp8_blockwise,
+                    scale_dim=cfg.combine_scale_dim,
+                    reset_total_recv=False,
+                )
+                for (b, w) in combine_specs
+            }
+        else:
+            self._combine_variants = {
+                (b, w): make_combine(
+                    rank=cfg.rank,
+                    npes=cfg.world_size,
+                    experts_per_token=topk,
+                    hidden_dim=hidden_dim,
+                    hidden_elem_size=cfg.combine_elem_size,
+                    max_tok_per_rank=max_tok_per_rank,
+                    max_recv=recv_cap,
+                    block_num=b,
+                    warp_num_per_block=w,
+                    off_out_tok=arena.offset("out_tok"),
+                    off_xdb_mem=arena.offset("cross_device_barrier"),
+                    off_out_wts=arena.offset("out_wts"),
+                    reset_total_recv=True,
+                    fp4=(cfg.combine_dtype == torch.float4_e2m1fn_x2),
+                )
+                for (b, w) in combine_specs
+            }
+
+        self._local_expert_count_buf = torch.zeros(
+            cfg.num_experts_per_rank, dtype=torch.int32, device=device
+        )
+        self._local_expert_count = make_local_expert_count(
+            rank=cfg.rank,
+            experts_per_rank=cfg.num_experts_per_rank,
+            experts_per_token=topk,
+            block_num=cfg.dispatch_block_num,
+            warp_num_per_block=cfg.warp_num_per_block,
+        )
+
+        if cfg.enable_std_moe:
+            assert elem_size == 2, "StdMoE convert path is bf16-only"
+            experts_per_rank = cfg.num_experts_per_rank
+            max_tok_per_expert = cfg.world_size * max_tok_per_rank
+            self._max_tok_per_expert = max_tok_per_expert
+            self.packed_x = torch.zeros(
+                experts_per_rank * max_tok_per_expert * hidden_dim,
+                dtype=torch.int16,
+                device=device,
+            )
+            self.packed_count = torch.zeros(
+                experts_per_rank, dtype=torch.int32, device=device
+            )
+            self.packed_src = torch.zeros(
+                experts_per_rank * max_tok_per_expert, dtype=torch.int32, device=device
+            )
+            self.slot_map = torch.full(
+                (recv_cap * topk,), -1, dtype=torch.int64, device=device
+            )
+            self._convert_dispatch = make_convert_dispatch_output(
+                rank=cfg.rank,
+                experts_per_rank=experts_per_rank,
+                experts_per_token=topk,
+                hidden_dim=hidden_dim,
+                hidden_elem_size=elem_size,
+                max_tok_per_expert=max_tok_per_expert,
+                block_num=cfg.dispatch_block_num,
+                warp_num_per_block=cfg.warp_num_per_block,
+            )
+            self._convert_combine = make_convert_combine_input(
+                rank=cfg.rank,
+                experts_per_rank=experts_per_rank,
+                experts_per_token=topk,
+                hidden_dim=hidden_dim,
+                hidden_elem_size=elem_size,
+                max_tok_per_expert=max_tok_per_expert,
+                block_num=cfg.combine_block_num,
+                warp_num_per_block=cfg.combine_warp_num_per_block,
+            )
+        self._closed = False
+
+    def close(self):
+        """Free this op's symmetric arena window. Call (or use as a context
+        manager) when the op is discarded but its Communicator lives on —
+        otherwise the arena stays in comm._resources until the comm is destroyed."""
+        if self._closed:
+            return
+        self._closed = True
+        self.arena.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def recv_tokens(self):
+        """Arena disp_out [max_recv, hidden] (dispatch dest / expert-GEMM input).
+        Separate from out_tok, so combine's copy-in never overwrites it — the
+        expert can read this in place without a defensive .clone().
+        fp4 packs 2 e2m1 per float4_e2m1fn_x2 element -> last dim is hidden/2."""
+        cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
+        return from_gpu_ptr(
+            self.arena.local_ptr("disp_out"),
+            (self._recv_cap, cols),
+            self.cfg.dispatch_dtype,
+        )
+
+    def combine_in_view(self):
+        """out_tok as combine dtype [max_recv, hidden] — combine()'s copy target."""
+        cdt = self.cfg.combine_dtype
+        cols = (
+            self.cfg.hidden_dim // 2
+            if cdt == torch.float4_e2m1fn_x2
+            else self.cfg.hidden_dim
+        )
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_tok"), (self._recv_cap, cols), cdt
+        )
+
+    def convert_dispatch_output(self):
+        """mori ConvertDispatchOutput: repack recv tokens into per-local-expert
+        buckets. Returns (packed_x, packed_count, packed_src); GEMM overwrites
+        packed_x in place."""
+        assert self.cfg.enable_std_moe, "op built without enable_std_moe"
+        self.packed_count.zero_()
+        self.slot_map.fill_(-1)
+        arena = self.arena
+        stream = fx.Stream(torch.cuda.current_stream())
+        self._convert_dispatch(
+            arena.local_ptr("disp_out"),
+            arena.local_ptr("out_idx"),
+            arena.local_ptr("recv_to_src_token"),
+            self.total_recv.data_ptr(),
+            self.packed_x.data_ptr(),
+            self.packed_count.data_ptr(),
+            self.packed_src.data_ptr(),
+            self.slot_map.data_ptr(),
+            stream,
+        )
+        experts_per_rank = self.cfg.num_experts_per_rank
+        max_tok_per_expert = self._max_tok_per_expert
+        hidden_dim = self.cfg.hidden_dim
+        packed_x_view = from_gpu_ptr(
+            self.packed_x.data_ptr(),
+            (experts_per_rank, max_tok_per_expert, hidden_dim),
+            self.cfg.dispatch_dtype,
+        )
+        return packed_x_view, self.packed_count, self.packed_src
+
+    def convert_combine_input(self, routing):
+        """mori ConvertCombineInput: weighted-reduce each recv token's local-expert
+        outputs from packed_x back into out_tok. Run after GEMM, before combine."""
+        assert self.cfg.enable_std_moe, "op built without enable_std_moe"
+        arena = self.arena
+        stream = fx.Stream(torch.cuda.current_stream())
+        self._convert_combine(
+            arena.local_ptr("out_tok"),
+            arena.local_ptr("out_wts"),
+            routing.total_recv_token_num.data_ptr(),
+            self.packed_x.data_ptr(),
+            self.slot_map.data_ptr(),
+            stream,
+        )
+
+    def recv_weights(self):
+        """Arena out_wts as [max_recv, topk] f32 (forwarded per-token weights)."""
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_wts"),
+            (self._recv_cap, self.cfg.num_experts_per_token),
+            torch.float32,
+        )
+
+    def recv_indices(self):
+        """Arena out_idx as [max_recv, topk] i32 (forwarded expert indices)."""
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_idx"),
+            (self._recv_cap, self.cfg.num_experts_per_token),
+            torch.int32,
+        )
+
+    def recv_scales(self):
+        """Forwarded per-token scales as opaque i32 dwords [max_recv, scale_num_i32],
+        or None if built without scales."""
+        if not self._enable_scales:
+            return None
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_scales"),
+            (self._recv_cap, self._scale_num_i32),
+            torch.int32,
+        )
+
+    def _pick(self, num_tokens):
+        """((disp_block, disp_warp), (comb_block, comb_warp)) for a runtime token
+        count via the per-token schedule; falls back to the single-shot specs
+        otherwise. Returned specs are clamped to the precompiled variants."""
+        schedule = self.cfg.schedule
+        disp_spec = comb_spec = None
+        if schedule:
+            for bucket in schedule:
+                max_tok = bucket[0]
+                if max_tok is None or num_tokens <= max_tok:
+                    disp_spec, comb_spec = (bucket[1], bucket[2]), (
+                        bucket[3],
+                        bucket[4],
+                    )
+                    break
+            if disp_spec is None:
+                last = schedule[-1]
+                disp_spec, comb_spec = (last[1], last[2]), (last[3], last[4])
+        else:
+            disp_spec, comb_spec = self._dispatch_specs[0], self._combine_specs[0]
+        if disp_spec not in self._dispatch_variants:
+            disp_spec = self._dispatch_specs[-1]
+        if comb_spec not in self._combine_variants:
+            comb_spec = self._combine_specs[-1]
+        return disp_spec, comb_spec
+
+    def dispatch(
+        self, input, weights, scales, indices, *, routing=None, return_routing=False
+    ):
+        """mori-parity dispatch. input [n_tok,hidden], weights [n_tok,topk] f32,
+        scales [n_tok,scale_dim] (or None), indices [n_tok,topk] i32.
+
+        routing=: replay a prior handle (reuse cached dest-slot layout, skip
+        atomic routing). return_routing=: also return the handle. Mutually
+        exclusive. Returns (out, out_weights, out_scales, out_indices,
+        total_recv[, routing]); out == arena disp_out (safe to read without
+        .clone() — combine stages into a separate out_tok buffer).
+        """
+        if routing is not None and return_routing:
+            raise ValueError(
+                "pass either routing= (replay) or return_routing=True, not both"
+            )
+        num_input_tokens = input.shape[0]
+        disp_spec, _ = self._pick(num_input_tokens)
+        # total_recv is self-reset inside the dispatch kernel (warp 0, Phase 2).
+        scale_ptr = (
+            scales.data_ptr() if (scales is not None and self._enable_scales) else 0
+        )
+        stream = fx.Stream(torch.cuda.current_stream())
+        weight_ptr = weights.data_ptr() if weights is not None else 0
+        if routing is not None:
+            kern = self._dispatch_replay_variants.get(disp_spec)
+            if kern is None:
+                kern = self._dispatch_replay_variants[disp_spec] = make_dispatch(
+                    replay=True,
+                    block_num=disp_spec[0],
+                    warp_num_per_block=disp_spec[1],
+                    **self._dispatch_kwargs,
+                )
+            dest_map_ptr = routing.disp_dest_tok_id_map.data_ptr()
+            kern(
+                self.arena.handle,
+                input.data_ptr(),
+                indices.data_ptr(),
+                weight_ptr,
+                dest_map_ptr,
+                self.dest_pe_counter.data_ptr(),
+                self.dispatch_barrier.data_ptr(),
+                self.total_recv.data_ptr(),
+                scale_ptr,
+                self.cfg.rank,
+                num_input_tokens,
+                stream,
+            )
+        else:
+            self._dispatch_variants[disp_spec](
+                self.arena.handle,
+                input.data_ptr(),
+                indices.data_ptr(),
+                weight_ptr,
+                self.token_dest_map.data_ptr(),
+                self.dest_pe_counter.data_ptr(),
+                self.dispatch_barrier.data_ptr(),
+                self.total_recv.data_ptr(),
+                scale_ptr,
+                self.cfg.rank,
+                num_input_tokens,
+                stream,
+            )
+
+        out = self.recv_tokens()
+        out_weights = self.recv_weights()
+        out_scales = self.recv_scales()
+        out_indices = self.recv_indices()
+        base = (out, out_weights, out_scales, out_indices, self.total_recv)
+        if not return_routing:
+            return base
+
+        # Pass a live arena view; the reverse map is cloned lazily on first
+        # access (post-barrier), see EpDispatchRoutingHandle.
+        recv_to_src_view = from_gpu_ptr(
+            self.arena.local_ptr("recv_to_src_token"), (self._recv_cap,), torch.int32
+        )
+        routing = EpDispatchRoutingHandle(
+            disp_dest_tok_id_map=self.token_dest_map.clone(),
+            inter_node_disp_dest_tok_id_map=self._empty_i32,
+            inter_node_disp_send_map=self._empty_i32,
+            total_recv_token_num=self.total_recv,
+            cur_rank_num_token=num_input_tokens,
+            reverse_src_view=recv_to_src_view,
+        )
+        return base + (routing,)
+
+    def combine(self, input, weights=None, indices=None, *, routing):
+        """mori-parity combine. input [<=max_recv,hidden] post-expert tokens
+        (copied into arena out_tok if not already there). weights/indices are
+        accepted for API parity but unused (weights come from forwarded out_wts,
+        routing carries the mapping). Returns (out [ct,hidden], out_weights [ct,topk]).
+        """
+        out_tok_ptr = self.arena.local_ptr("out_tok")
+        # StdMoE: convert_combine_input() has already staged the weighted-reduced
+        # tokens into out_tok, so `input` is unused here — copying it in would
+        # clobber that result. (Non-StdMoE: `input` holds the post-expert tokens
+        # to combine; since the disp_out/out_tok split it no longer aliases out_tok,
+        # so the copy is required.)
+        if not self.cfg.enable_std_moe and input.data_ptr() != out_tok_ptr:
+            # copy in the combine-dtype layout (not recv_tokens()'s dispatch view)
+            dst = self.combine_in_view().view(-1)[: input.numel()]
+            dst.copy_(input.reshape(-1))
+        self.combine_out.zero_()
+        stream = fx.Stream(torch.cuda.current_stream())
+        _, comb_spec = self._pick(routing.cur_rank_num_token)
+        self._combine_variants[comb_spec](
+            self.arena.handle,
+            routing.disp_dest_tok_id_map.data_ptr(),
+            self.combine_barrier.data_ptr(),
+            self.cross_device_flag.data_ptr(),
+            routing.total_recv_token_num.data_ptr(),
+            self.combine_out.data_ptr(),
+            self.combine_out_weights.data_ptr(),
+            self.cfg.rank,
+            routing.cur_rank_num_token,
+            stream,
+        )
+        count = routing.cur_rank_num_token
+        hidden_dim = self.cfg.hidden_dim
+        topk = self.cfg.num_experts_per_token
+        cdt = self.cfg.combine_dtype
+        cols = (
+            hidden_dim // 2 if cdt == torch.float4_e2m1fn_x2 else hidden_dim
+        )  # fp4 out is hidden/2 float4 elems
+        out = self.combine_out[: count * cols].view(cdt).view(count, cols)
+        return out, self.combine_out_weights[: count * topk].view(count, topk)
+
+    def local_expert_count(self):
+        """[num_experts_per_rank] i32: recv tokens per local expert. Call after
+        dispatch, before combine (gather resets total_recv)."""
+        self._local_expert_count_buf.zero_()
+        stream = fx.Stream(torch.cuda.current_stream())
+        self._local_expert_count(
+            self.arena.local_ptr("out_idx"),
+            self.total_recv.data_ptr(),
+            self._local_expert_count_buf.data_ptr(),
+            stream,
+        )
+        return self._local_expert_count_buf
+
+    def reset(self):
+        """Zero arena staging + per-rank counters/barriers (mori LaunchReset).
+        Kernels self-reset counters already; this forces a clean slate."""
+        self.arena.zero()
+        self.token_dest_map.fill_(-1)
+        self.dest_pe_counter.zero_()
+        self.dispatch_barrier.zero_()
+        self.total_recv.zero_()
+        self.combine_barrier.zero_()
+        self.cross_device_flag.fill_(1)

--- a/aiter/ops/flydsl/dispatch_combine_v2/flydsl_prims.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/flydsl_prims.py
@@ -1,0 +1,216 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Shared FlyDSL device primitives for the cco-LSA dispatch/combine kernels.
+
+Thin wrappers over flydsl._mlir.dialects.llvm for system-scope atomics / ordered
+stores / fences, plus uncached buffer load/store and a spin-wait helper — the
+building blocks both the dispatch and combine kernels need on top of cco's
+peer pointers (cco.Window(h).lsa_ptr(pe, off)).
+"""
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm as _llvm_d
+from flydsl._mlir.dialects import scf
+from flydsl.expr import arith
+from flydsl.expr.typing import T
+import flydsl.expr as fx
+
+
+def _I64():
+    return ir.IntegerType.get_signless(64)
+
+
+def _I32():
+    return ir.IntegerType.get_signless(32)
+
+
+def _NUW():
+    return ir.Attribute.parse("#llvm.overflow<none>")
+
+
+def _gptr(addr_i64):
+    return _llvm_d.IntToPtrOp(
+        _llvm_d.PointerType.get(address_space=1), arith.unwrap(addr_i64)
+    ).result
+
+
+def _addr_plus(base_i64, offset, elem_bytes):
+    """base + offset*elem_bytes as an i64 SSA value (offset may be i32 or i64)."""
+    base = arith.unwrap(base_i64)
+    off = arith.unwrap(offset)
+    off64 = _llvm_d.ZExtOp(_I64(), off).res if off.type == _I32() else off
+    eb = _llvm_d.ConstantOp(_I64(), ir.IntegerAttr.get(_I64(), elem_bytes)).result
+    byte_off = _llvm_d.MulOp(off64, eb, _NUW()).result
+    return _llvm_d.AddOp(base, byte_off, _NUW()).result
+
+
+def atomic_add_global(addr_i64, val):
+    """Monotonic remote global fetch-and-add at addr_i64; returns old (i64/i32 per val)."""
+    return _llvm_d.AtomicRMWOp(
+        _llvm_d.AtomicBinOp.add,
+        _gptr(addr_i64),
+        arith.unwrap(val),
+        _llvm_d.AtomicOrdering.monotonic,
+    ).res
+
+
+def store_i32_system(addr_i64, offset, val):
+    """System-release i32 store at addr + offset*4."""
+    addr = _addr_plus(addr_i64, offset, 4)
+    gptr = _llvm_d.IntToPtrOp(_llvm_d.PointerType.get(address_space=1), addr).result
+    _llvm_d.StoreOp(
+        arith.unwrap(val),
+        gptr,
+        alignment=4,
+        ordering=_llvm_d.AtomicOrdering.release,
+        syncscope="one-as",
+    )
+
+
+def store_i64_system(addr_i64, offset, val):
+    """System-release i64 store at addr + offset*8."""
+    addr = _addr_plus(addr_i64, offset, 8)
+    gptr = _llvm_d.IntToPtrOp(_llvm_d.PointerType.get(address_space=1), addr).result
+    _llvm_d.StoreOp(
+        arith.unwrap(val),
+        gptr,
+        alignment=8,
+        ordering=_llvm_d.AtomicOrdering.release,
+        syncscope="one-as",
+    )
+
+
+def fence_system_acquire():
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.acquire, syncscope="one-as")
+
+
+def fence_system_release():
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.release, syncscope="one-as")
+
+
+def _unwrap(v):
+    return v.ir_value() if hasattr(v, "ir_value") else v
+
+
+def load_i32_acquire(addr_i64):
+    """Volatile monotonic i32 load at addr_i64 (global addrspace 1).
+
+    Volatile + atomic ordering keeps the spin re-read from being hoisted/CSE'd
+    out of the wait loop — a plain (even uncached) buffer_load can be lifted by
+    LICM, making the loop spin forever on a stale value.
+    """
+    gptr = _gptr(addr_i64)
+    return _llvm_d.LoadOp(
+        _I32(),
+        gptr,
+        alignment=4,
+        volatile_=True,
+        ordering=_llvm_d.AtomicOrdering.monotonic,
+        syncscope="one-as",
+    ).res
+
+
+def load_i64_acquire(addr_i64):
+    """Volatile monotonic i64 load at addr_i64 (global addrspace 1)."""
+    gptr = _gptr(addr_i64)
+    return _llvm_d.LoadOp(
+        _I64(),
+        gptr,
+        alignment=8,
+        volatile_=True,
+        ordering=_llvm_d.AtomicOrdering.monotonic,
+        syncscope="one-as",
+    ).res
+
+
+def load_i32_nt(base_i64, offset):
+    """Non-temporal global i32 load at base + offset*4 (addrspace 1). A raw global
+    load (VGPR address) avoids the per-expert buffer-descriptor waterfall, keeping
+    the K combine loads in flight. Caller must ensure the address is in-bounds."""
+    addr = _addr_plus(base_i64, offset, 4)
+    gptr = _llvm_d.IntToPtrOp(_llvm_d.PointerType.get(address_space=1), addr).result
+    return _llvm_d.LoadOp(_I32(), gptr, alignment=4, nontemporal=True).res
+
+
+def _V4I32():
+    return ir.VectorType.get([4], _I32())
+
+
+def load_v4i32_nt(base_i64, offset):
+    """Non-temporal global vec4 i32 load at base + offset*4 (addrspace 1).
+    Returns vector<4xi32> (16 bytes, codegen: global_load_dwordx4). offset is in
+    i32 units; alignment=4 since the caller's per-warp offset is only 4B-aligned
+    (AMDGPU emits dwordx4 for a 4B-aligned global vector load)."""
+    addr = _addr_plus(base_i64, offset, 4)
+    gptr = _llvm_d.IntToPtrOp(_llvm_d.PointerType.get(address_space=1), addr).result
+    return _llvm_d.LoadOp(_V4I32(), gptr, alignment=4, nontemporal=True).res
+
+
+def _spin(addr_i64, keep_waiting):
+    """Spin on a volatile/atomic i32 load at addr_i64; keep_waiting(cur_fx_i32)
+    returns the fx-bool "should keep spinning". Returns the awaited fx.Int32.
+
+    Self-contained — mori.ir.flydsl's wait_until_* are tied to ShmemStates and
+    cannot run on a cco-only stack (they assert without ShmemInit).
+    """
+    i32 = T.i32
+    first = load_i32_acquire(addr_i64)
+    loop = scf.WhileOp([i32], [_unwrap(first)])
+    cond = ir.Block.create_at_start(loop.before, [i32])
+    body = ir.Block.create_at_start(loop.after, [i32])
+    with ir.InsertionPoint(cond):
+        cur = fx.Int32(cond.arguments[0])
+        scf.ConditionOp(_unwrap(keep_waiting(cur)), [cond.arguments[0]])
+    with ir.InsertionPoint(body):
+        nxt = load_i32_acquire(addr_i64)
+        scf.YieldOp([_unwrap(nxt)])
+    return fx.Int32(loop.results[0])
+
+
+def _spin64(addr_i64, keep_waiting):
+    """i64 analogue of _spin (volatile monotonic loads)."""
+    i64 = T.i64
+    first = load_i64_acquire(addr_i64)
+    loop = scf.WhileOp([i64], [_unwrap(first)])
+    cond = ir.Block.create_at_start(loop.before, [i64])
+    body = ir.Block.create_at_start(loop.after, [i64])
+    with ir.InsertionPoint(cond):
+        cur = fx.Int64(cond.arguments[0])
+        scf.ConditionOp(_unwrap(keep_waiting(cur)), [cond.arguments[0]])
+    with ir.InsertionPoint(body):
+        nxt = load_i64_acquire(addr_i64)
+        scf.YieldOp([_unwrap(nxt)])
+    return fx.Int64(loop.results[0])
+
+
+def spin_until_eq_i64(addr_i64, val):
+    """Spin until *addr (i64) == val."""
+    return _spin64(addr_i64, lambda cur: cur != fx.Int64(val))
+
+
+def spin_until_eq_i32(addr_i64, val):
+    """Spin until *addr == val."""
+    return _spin(addr_i64, lambda cur: cur != fx.Int32(val))
+
+
+def spin_until_gt_i32(addr_i64, val):
+    """Spin until *addr > val (signed); return the value seen."""
+    return _spin(addr_i64, lambda cur: cur <= fx.Int32(val))

--- a/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels.py
@@ -1,0 +1,1605 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""FlyDSL intranode device kernels for the cco-LSA dispatch/combine op.
+
+All kernels here are single-node (cco-LSA P2P over the flat symmetric VA);
+internode (RDMA) kernels would live in a separate internode_kernels.py.
+
+Merged factories: dispatch (+scales/replay), combine (gather + scatter/quant),
+StdMoE convert (ConvertDispatchOutput/CombineInput), and local expert count.
+Each is a compile-time-parameterised @flyc.jit factory; peer addressing goes
+through cco.Window(handle).lsa_ptr(pe, off).
+
+Recurring conventions used throughout:
+  * `window.lsa_ptr(pe, off)` -> address of peer `pe`'s copy of arena region `off`.
+  * `rsrc_*` = a buffer resource descriptor (create_buffer_resource_from_addr).
+  * `safe_*` = a value that is the real one on live lanes but a harmless
+    in-bounds fallback (0 / self-rank) on dropped lanes, so invalid (duplicate
+    or overflow) slots never issue an out-of-bounds load/store.
+  * "sentinel" = the dropped-slot marker in tok_map: a (src_tok, k) whose dest
+    encodes PE == npes (>= any real PE), telling combine to skip it.
+  * "tis" = the per-peer "recv slot -> source token" reverse map; dispatch
+    stores the global source token id (rank*max_tok_per_rank + src_tok) there so
+    combine/scatter can route each result back to its origin.
+  * "xdb" = cross-device barrier: a monotonically bumped i64 flag each rank
+    writes into every peer's xdb_mem slot, then spins until its own slot matches
+    — an all-ranks handshake that publishes peers' writes before the next stage.
+"""
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, const_expr, range_constexpr, T, vector
+from flydsl.expr.buffer_ops import (
+    buffer_load,
+    buffer_store,
+    create_buffer_resource_from_addr,
+)
+from flydsl.expr.rocdl import (
+    ballot,
+    readlane,
+    ds_bpermute,
+    fmed3,
+    cvt_pk_f32_fp8,
+    cvt_pk_fp8_f32,
+    cvt_scalef32_pk_f32_fp4,
+    cvt_scalef32_pk_fp4_f32,
+    cvt_scale_pk8_f32_fp4,
+    cvt_scalef32_pk8_fp4_f32,
+)
+from flydsl.expr.typing import Int32, Int64
+
+import mori.cco.device.flydsl as cco
+from . import flydsl_prims as P
+
+# Wavefront size: gfx9 (MI300/MI350) = 64, gfx12 (MI400/gfx1250) = 32. Detected
+# once per process; override with MORI_WAVE_SIZE. get_warp_size(gfx1250) wrongly
+# reports 64, so key off the arch string.
+import os as _os
+
+
+def _detect_wave_size():
+    v = _os.environ.get("MORI_WAVE_SIZE")
+    if v:
+        return int(v)
+    try:
+        from mori.jit.config import detect_gpu_arch
+
+        return 32 if detect_gpu_arch().startswith("gfx12") else 64
+    except Exception:
+        return 64
+
+
+WAVE = _detect_wave_size()
+LANE_MASK = WAVE - 1
+LOG2_WAVE = WAVE.bit_length() - 1
+_BALLOT_INT = T.i64 if WAVE == 64 else T.i32
+_LANE_STRIDE_I32 = WAVE * 4  # one wave of lanes, vec4 (16B) each
+_MAIN_STRIDE_I32 = 2 * _LANE_STRIDE_I32
+_BUTTERFLY_OFFSETS = tuple(WAVE >> i for i in range(1, LOG2_WAVE + 1))
+
+# ── dispatch ──────────────────────────────────────────────────────────────
+
+
+def make_dispatch(
+    *,
+    rank,
+    npes,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_tok_off,
+    off_recv_num,
+    off_tis,
+    off_out_idx,
+    off_out_wts,
+    off_out_tok,
+    off_out_scales=0,
+    scale_dim=0,
+    scale_type_size=0,
+    enable_signal=True,
+    replay=False,
+    fp4=False,
+):
+    # fp4 (e2m1) packs 2 values per byte, so a token is hidden_dim/2 bytes; dispatch
+    # is a pure byte mover (no fp4 decode), matching mori v1's plain-fp4 path.
+    nbytes = hidden_dim // 2 if fp4 else hidden_dim * hidden_elem_size
+    n_i32 = nbytes // 4
+    # Dropped-slot marker stored in tok_map (see module docstring "sentinel"):
+    # its encoded dest_pe (value // max_recv) equals npes, i.e. no real PE.
+    sentinel_val = npes * max_recv
+    # Optional per-token scales (e.g. fp4/blockwise quant inputs): forwarded
+    # verbatim alongside the token to the dest peer's out_scales (mori parity).
+    scale_bytes = scale_dim * scale_type_size
+    scale_num_i32 = (scale_bytes + 3) // 4
+    enable_scales = scale_bytes > 0
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def ep_dispatch(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_inp_scales: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+        work_limit = inp_cur_tok * experts_per_token
+
+        window = cco.Window(arena)
+        rsrc_inp_idx = create_buffer_resource_from_addr(addr_inp_idx)
+        rsrc_inp_wts = create_buffer_resource_from_addr(addr_inp_wts)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_dest_ctr = create_buffer_resource_from_addr(addr_dest_pe_ctr)
+        rsrc_disp_bar = create_buffer_resource_from_addr(addr_disp_bar)
+
+        # ── Phase 1: P2P-scatter each (src_tok, k_slot) to its dest PE ──
+        for work_idx in range(global_warp_id, work_limit, global_warp_num):
+            src_tok = work_idx // experts_per_token
+            k_slot = work_idx % experts_per_token
+            dest_expert = buffer_load(
+                rsrc_inp_idx, work_idx, vec_width=1, dtype=T.i32()
+            )
+            # Dedup: one token routed to several experts on the SAME dest PE must
+            # be sent only once. Each lane l (< k) inspects this token's l-th
+            # expert; if a LOWER lane already targets our dest_pe, this
+            # (src_tok, k_slot) is a duplicate and gets dropped. safe_lane keeps
+            # the probe in-bounds for lanes >= k_slot.
+            safe_lane = arith.select(lane < k_slot, lane, 0)
+            lane_expert = buffer_load(
+                rsrc_inp_idx,
+                src_tok * experts_per_token + safe_lane,
+                vec_width=1,
+                dtype=T.i32(),
+            )
+            dest_pe = dest_expert // experts_per_rank
+            lane_dest_pe = lane_expert // experts_per_rank
+            dup_per_lane = arith.select(
+                lane_dest_pe == dest_pe, arith.select(lane < k_slot, lane, WAVE), WAVE
+            )
+            dup_ballot = ballot(_BALLOT_INT(), dup_per_lane < WAVE)
+            is_dup = dup_ballot != 0
+
+            if const_expr(replay):
+                # decode dest_tok_id from cached tok_map (skip atomic alloc; same layout)
+                cached = buffer_load(rsrc_tok_map, work_idx, vec_width=1, dtype=T.i32())
+                is_dup_or_overflow = cached >= sentinel_val
+                do_publish = cached < sentinel_val
+                dest_tok_id = cached - dest_pe * max_recv
+            else:
+                dest_tok_lane0 = arith.constant(0)
+                if lane == 0:
+                    if dup_ballot == 0:
+                        peer_tok_off = fx.Int64(window.lsa_ptr(dest_pe, off_tok_off))
+                        dest_tok_lane0 = P.atomic_add_global(peer_tok_off, fx.Int32(1))
+                dest_tok_id = readlane(T.i32(), dest_tok_lane0, 0)
+                overflow = dest_tok_id >= max_recv
+                is_dup_or_overflow = arith.select(is_dup, is_dup, overflow)
+                no_dup = dup_ballot == 0
+                in_cap = dest_tok_id < max_recv
+                do_publish = arith.select(no_dup, in_cap, no_dup)
+                tok_map_entry = arith.select(
+                    is_dup_or_overflow, sentinel_val, dest_pe * max_recv + dest_tok_id
+                )
+                if lane == 0:
+                    buffer_store(tok_map_entry, rsrc_tok_map, work_idx)
+
+            if lane == 0:
+                if do_publish:
+                    # publish this recv slot's origin into the dest peer's tis
+                    # (recv slot -> global source token id) for combine routing.
+                    src_tok_encoded = rank * max_tok_per_rank + src_tok
+                    peer_tis = fx.Int64(window.lsa_ptr(dest_pe, off_tis))
+                    buffer_store(
+                        src_tok_encoded,
+                        create_buffer_resource_from_addr(peer_tis),
+                        dest_tok_id,
+                    )
+                    dest_ctr_addr = fx.Int64(addr_dest_pe_ctr) + fx.Int64(
+                        dest_pe
+                    ) * fx.Int64(4)
+                    P.atomic_add_global(dest_ctr_addr, fx.Int32(1))
+
+            # Per-lane (weight, expert-idx) scatter (lanes < k).
+            if lane < experts_per_token:
+                if do_publish:
+                    weight_src_off = src_tok * experts_per_token + lane
+                    weight_val = buffer_load(
+                        rsrc_inp_wts, weight_src_off, vec_width=1, dtype=T.f32()
+                    )
+                    idx_val = buffer_load(
+                        rsrc_inp_idx, weight_src_off, vec_width=1, dtype=T.i32()
+                    )
+                    dest_slot = dest_tok_id * experts_per_token + lane
+                    peer_wts = fx.Int64(window.lsa_ptr(dest_pe, off_out_wts))
+                    buffer_store(
+                        arith.bitcast(T.i32(), weight_val),
+                        create_buffer_resource_from_addr(peer_wts),
+                        dest_slot,
+                    )
+                    peer_idx = fx.Int64(window.lsa_ptr(dest_pe, off_out_idx))
+                    buffer_store(
+                        idx_val, create_buffer_resource_from_addr(peer_idx), dest_slot
+                    )
+
+            # Per-token scales scatter: forward the src token's scale_num_i32 dwords
+            # to the dest peer's out_scales[dest_tok_id] (lane-strided to cover
+            # scale_dim > one wavefront). Verbatim copy (opaque bytes).
+            if const_expr(enable_scales):
+                if do_publish:
+                    rsrc_inp_scales = create_buffer_resource_from_addr(addr_inp_scales)
+                    peer_scales = fx.Int64(window.lsa_ptr(dest_pe, off_out_scales))
+                    rsrc_peer_scales = create_buffer_resource_from_addr(peer_scales)
+                    for k_off in range(lane, scale_num_i32, WAVE):
+                        scale_val = buffer_load(
+                            rsrc_inp_scales,
+                            src_tok * scale_num_i32 + k_off,
+                            vec_width=1,
+                            dtype=T.i32(),
+                        )
+                        buffer_store(
+                            scale_val,
+                            rsrc_peer_scales,
+                            dest_tok_id * scale_num_i32 + k_off,
+                        )
+
+            # Token-embedding scatter: each lane owns 4 i32 (16B). Two vec4 streams
+            # (chunk and chunk+_LANE_STRIDE_I32, stride _MAIN_STRIDE_I32) for
+            # memory-level parallelism; a one-stream tail covers the remainder.
+            # Dropped slots (dup/overflow) set copy_end == lane_i32_off → no-op.
+            peer_tok_base = fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
+            remote_tok_addr = peer_tok_base + fx.Int64(dest_tok_id) * fx.Int64(nbytes)
+            local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
+                nbytes
+            )
+            rsrc_src = create_buffer_resource_from_addr(local_tok_addr)
+            rsrc_dst = create_buffer_resource_from_addr(remote_tok_addr)
+            lane_i32_off = lane * 4
+            safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
+            if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
+                copy_end_main = arith.select(
+                    is_dup_or_overflow, lane_i32_off, safe_end_i32
+                )
+                for chunk in range(lane_i32_off, copy_end_main, _MAIN_STRIDE_I32):
+                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                    vec_b = buffer_load(
+                        rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                    )
+                    buffer_store(vec_a, rsrc_dst, chunk)
+                    buffer_store(vec_b, rsrc_dst, chunk + _LANE_STRIDE_I32)
+            if const_expr(safe_end_i32 < n_i32):
+                copy_end_tail = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
+                for chunk in range(
+                    lane_i32_off + safe_end_i32, copy_end_tail, _LANE_STRIDE_I32
+                ):
+                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                    buffer_store(vec_a, rsrc_dst, chunk)
+            elif const_expr(n_i32 < _MAIN_STRIDE_I32):
+                copy_end_small = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
+                for chunk in range(lane_i32_off, copy_end_small, _LANE_STRIDE_I32):
+                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                    buffer_store(vec_a, rsrc_dst, chunk)
+
+        if const_expr(enable_signal):
+            # Self-reset total_recv (replaces the host-side total_recv.zero_()):
+            # only warp 0 accumulates into it in Phase 3, so warp 0 zeros it here
+            # and release-fences before the grid barrier; the Phase-2 acquire then
+            # orders the Phase-3 atomic adds after this zero. No other warp touches
+            # total_recv, so there is no cross-block race.
+            if global_warp_id == 0:
+                if lane == 0:
+                    buffer_store(
+                        arith.constant(0),
+                        create_buffer_resource_from_addr(addr_total_recv),
+                        0,
+                    )
+                P.fence_system_release()
+
+            # ── Phase 2: grid barrier + per-peer count signal ──
+            fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_disp_bar), arith.constant(1))
+
+            local_recv_num = fx.Int64(window.lsa_ptr(my_lsa_rank, off_recv_num))
+            for dest_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    P.spin_until_eq_i32(fx.Int64(addr_disp_bar), block_num)
+                    P.fence_system_acquire()
+                    buffer_store(arith.constant(0), rsrc_disp_bar, 0)
+                    signal_value = (
+                        buffer_load(rsrc_dest_ctr, dest_pe, vec_width=1, dtype=T.i32())
+                        + 1
+                    )
+                    peer_recv_num = fx.Int64(window.lsa_ptr(dest_pe, off_recv_num))
+                    recv_num_remote_addr = peer_recv_num + fx.Int64(rank) * fx.Int64(4)
+                    P.spin_until_eq_i32(recv_num_remote_addr, 0)
+                    P.store_i32_system(
+                        recv_num_remote_addr, arith.constant(0), signal_value
+                    )
+
+            # ── Phase 3: collect per-source counts into total_recv ──
+            for src_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    recv_num_src_addr = local_recv_num + fx.Int64(src_pe) * fx.Int64(4)
+                    signal_value = P.spin_until_gt_i32(recv_num_src_addr, 0)
+                    peer_recv_count = signal_value - 1
+                    P.store_i32_system(
+                        recv_num_src_addr, arith.constant(0), arith.constant(0)
+                    )
+                    P.atomic_add_global(fx.Int64(addr_total_recv), peer_recv_count)
+                    buffer_store(arith.constant(0), rsrc_dest_ctr, src_pe)
+
+            if global_warp_id == 0:
+                if lane == 0:
+                    local_tok_off = fx.Int64(window.lsa_ptr(my_lsa_rank, off_tok_off))
+                    P.store_i32_system(
+                        local_tok_off, arith.constant(0), arith.constant(0)
+                    )
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_inp_scales: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_dispatch(
+            arena,
+            addr_inp_tok,
+            addr_inp_idx,
+            addr_inp_wts,
+            addr_tok_map,
+            addr_dest_pe_ctr,
+            addr_disp_bar,
+            addr_total_recv,
+            addr_inp_scales,
+            my_lsa_rank,
+            inp_cur_tok,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+# ── combine (gather + scatter/quant) ──────────────────────────────────────
+
+
+def _V2BF16():
+    return T.VectorType.get([2], T.bf16())
+
+
+def _V2F32():
+    return T.VectorType.get([2], T.f32())
+
+
+def _V4F32():
+    return T.VectorType.get([4], T.f32())
+
+
+def _V8F32():
+    return T.VectorType.get([8], T.f32())
+
+
+def _V1I32():
+    return T.VectorType.get([1], T.i32())
+
+
+def _accum_funcs(hidden_elem_size, fp8_direct_cast=False, fp4=False):
+    if fp4:  # fp4 e2m1: i32 = 8 packed fp4 -> v8f32
+        if WAVE == 32:
+            # gfx1250: one pack-8 instr converts all 8 fp4/i32 at once. The
+            # gfx950 pk-2 (cvt_scalef32_pk_*_fp4, src/dst_sel) don't exist here
+            # ("Cannot select"); dequant only has the E8M0 scale family
+            # (cvt_scale_pk8_f32_fp4), quant has scalef32 (cvt_scalef32_pk8_fp4_f32).
+            # Plain fp4 (no microscaling) => scale 1.0, scale_sel 0.
+            def to_accum(i32_scalar):
+                # dequant uses the E8M0 block-scale (i32); 1.0 == 2^(127-127) => 127.
+                return cvt_scale_pk8_f32_fp4(
+                    res=_V8F32(),
+                    src=i32_scalar,
+                    scale=arith.constant(127, type=T.i32()),
+                    scale_sel=0,
+                )
+
+            def from_accum(acc):
+                return cvt_scalef32_pk8_fp4_f32(
+                    res=T.i32(), src=acc, scale=arith.constant(1.0, type=T.f32())
+                )
+
+            def zero_accum():
+                return arith.constant_vector(0.0, _V8F32())
+
+            return to_accum, from_accum, zero_accum
+
+        # NOTE: cvt_scalef32_pk_*_fp4 are gfx950-only (MI350). On gfx942
+        # (MI300X) codegen fails "instruction not supported on this GPU".
+        # Faithful port of the FlyDSL reference fp4 branch; opt-in (fp4=True).
+        def to_accum(i32_scalar):
+            one = arith.constant(1.0, type=T.f32())
+            pairs = [
+                cvt_scalef32_pk_f32_fp4(
+                    res=_V2F32(), src=i32_scalar, scale=one, src_sel_index=s
+                )
+                for s in range(4)
+            ]
+            lo4 = vector.shuffle(pairs[0], pairs[1], [0, 1, 2, 3])
+            hi4 = vector.shuffle(pairs[2], pairs[3], [0, 1, 2, 3])
+            return vector.shuffle(lo4, hi4, [0, 1, 2, 3, 4, 5, 6, 7])
+
+        def from_accum(acc):
+            one = arith.constant(1.0, type=T.f32())
+            old = arith.constant(0, type=T.i32())
+            for s in range(4):
+                fa = vector.extract(acc, static_position=[s * 2])
+                fb = vector.extract(acc, static_position=[s * 2 + 1])
+                old = cvt_scalef32_pk_fp4_f32(
+                    res=T.i32(),
+                    old_vdst=old,
+                    src0=fa,
+                    src1=fb,
+                    scale=one,
+                    dst_sel_index=s,
+                )
+            return old
+
+        def zero_accum():
+            return arith.constant_vector(0.0, _V8F32())
+
+        return to_accum, from_accum, zero_accum
+    return _accum_funcs_int(hidden_elem_size, fp8_direct_cast)
+
+
+def _accum_funcs_int(hidden_elem_size, fp8_direct_cast=False):
+    """Return (to_accum, from_accum, zero_accum) for one i32 'unit' of the
+    transport dtype, mirroring the FlyDSL reference's per-dtype branches.
+
+    Each i32 packs: 2 bf16 (v2f32), 1 f32 (scalar), or 4 fp8 (v4f32).
+    """
+    if hidden_elem_size == 2:  # bf16: i32 = 2 bf16
+
+        def to_accum(i32_scalar):
+            return vector.bitcast(
+                _V2BF16(), vector.from_elements(_V1I32(), [i32_scalar])
+            ).extf(_V2F32())
+
+        def from_accum(acc):
+            return vector.extract(
+                vector.bitcast(_V1I32(), acc.truncf(_V2BF16())), static_position=[0]
+            )
+
+        def zero_accum():
+            return to_accum(arith.constant(0))
+
+    elif hidden_elem_size == 4:  # f32: i32 = 1 f32
+
+        def to_accum(i32_scalar):
+            return fx.Float32(arith.bitcast(T.f32(), arith.unwrap(i32_scalar)))
+
+        def from_accum(acc):
+            return fx.Int32(arith.bitcast(T.i32(), arith.unwrap(acc)))
+
+        def zero_accum():
+            return fx.Float32(arith.constant(0.0, type=T.f32()))
+
+    elif hidden_elem_size == 1:  # fp8 (OCP e4m3): i32 = 4 fp8
+
+        def to_accum(i32_scalar):
+            lo = cvt_pk_f32_fp8(res=_V2F32(), src=i32_scalar, word_sel=False)
+            hi = cvt_pk_f32_fp8(res=_V2F32(), src=i32_scalar, word_sel=True)
+            return vector.shuffle(lo, hi, [0, 1, 2, 3])
+
+        def from_accum(acc):
+            f0 = vector.extract(acc, static_position=[0])
+            f1 = vector.extract(acc, static_position=[1])
+            f2 = vector.extract(acc, static_position=[2])
+            f3 = vector.extract(acc, static_position=[3])
+            if fp8_direct_cast:  # wire fp8 -> external bf16: v4f32 -> v4bf16 -> 2 i32
+                v4bf16 = acc.truncf(T.VectorType.get([4], T.bf16()))
+                return vector.bitcast(T.VectorType.get([2], T.i32()), v4bf16)
+            zero = arith.constant(0, type=T.i32())
+            lo = cvt_pk_fp8_f32(
+                res=T.i32(), src_a=f0, src_b=f1, old=zero, word_sel=False
+            )
+            return cvt_pk_fp8_f32(
+                res=T.i32(), src_a=f2, src_b=f3, old=lo, word_sel=True
+            )
+
+        def zero_accum():
+            return arith.constant_vector(0.0, _V4F32())
+
+    else:
+        raise ValueError(f"unsupported hidden_elem_size {hidden_elem_size}")
+    return to_accum, from_accum, zero_accum
+
+
+def make_combine(
+    *,
+    rank,
+    npes,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_out_tok,
+    off_xdb_mem,
+    off_out_wts=0,
+    enable_weights=True,
+    fp8_direct_cast=False,
+    fp4=False,
+    reset_total_recv=True,
+    _s3_cache=2,
+    _unroll=2,
+):
+    # Transport dtype = external dtype, except fp8_direct_cast wires fp8 while
+    # the output (comb_out) stays bf16 (2 i32 per fp8 i32 unit). fp4: i32 = 8 fp4.
+    _to_accum2, _from_accum2, _zero_accum = _accum_funcs(
+        hidden_elem_size, fp8_direct_cast, fp4
+    )
+    nbytes = hidden_dim // 2 if fp4 else hidden_dim * hidden_elem_size
+    n_i32 = hidden_dim // 8 if fp4 else nbytes // 4
+    # fp8_direct_cast: output stride is bf16 (2 i32 per fp8 unit) vs input fp8.
+    out_n_i32 = (hidden_dim * 2) // 4 if fp8_direct_cast else n_i32
+    # vec4 gather: 4 i32 per load (global_load_dwordx4) when output is 1:1.
+    _use_vec4 = (n_i32 % 4 == 0) and not fp8_direct_cast
+    out_step_mult = 2 if fp8_direct_cast else 1
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def ep_combine(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
+
+        window = cco.Window(arena)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_comb_bar = create_buffer_resource_from_addr(addr_comb_bar)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        rsrc_out = create_buffer_resource_from_addr(addr_out)
+        xdb_cur_flag = P.load_i64_acquire(fx.Int64(addr_xdb_flag))
+
+        # ── Stage 1: cross-device entry barrier (xdb, see module docstring) ──
+        # Gather reads only out_tok from the prior dispatch/expert kernel, so a
+        # cross-device barrier suffices (no Stage-1 scatter). The grid barrier
+        # (comb_bar) is REQUIRED: it guarantees every block has already read
+        # xdb_cur_flag before block 0 increments xdb_flag — otherwise a slow
+        # block reads the bumped flag and the per-peer == handshake deadlocks.
+        fx.barrier()
+        if tid == 0:
+            P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
+        if grid_thread_id < npes:
+            P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num)
+            P.fence_system_acquire()
+            buffer_store(arith.constant(0), rsrc_comb_bar, 0)
+            xdb_remote = fx.Int64(
+                window.lsa_ptr(grid_thread_id, off_xdb_mem)
+            ) + fx.Int64(rank) * fx.Int64(8)
+            P.store_i64_system(xdb_remote, arith.constant(0), xdb_cur_flag)
+        if grid_thread_id == 0:
+            P.atomic_add_global(
+                fx.Int64(addr_xdb_flag), arith.constant(1, type=T.i64())
+            )
+        if tid < npes:
+            xdb_peer_slot = fx.Int64(
+                window.lsa_ptr(my_lsa_rank, off_xdb_mem)
+            ) + fx.Int64(tid) * fx.Int64(8)
+            P.spin_until_eq_i64(xdb_peer_slot, xdb_cur_flag)
+            P.fence_system_acquire()
+        fx.barrier()
+        P.fence_system_acquire()  # ALL threads: peers' out_tok visible
+        if const_expr(reset_total_recv):
+            if tid == 0:
+                buffer_store(arith.constant(0), rsrc_total_recv, 0)
+
+        rsrc_out_wts = create_buffer_resource_from_addr(addr_out_wts)
+
+        # ── Stage 2: warp-partitioned remote gather + f32 accumulate ──
+        # Register-light i32 (2 bf16, v2f32) reads + `_unroll`-way unroll: each
+        # lane keeps `_unroll` independent loads/accumulators in flight per k so
+        # a warp hides xGMI read latency with fewer warps (mori WarpAccum,
+        # VecBytes=4, Unroll=2). Partition each token's hidden across
+        # warps_per_tok warps so small batches still fill the grid.
+        STEP = _unroll * WAVE
+        safe_tok = arith.select(
+            cur_rank_num_token == arith.constant(0),
+            arith.constant(1),
+            cur_rank_num_token,
+        )
+        warps_per_tok = (
+            arith.constant(global_warp_num) + safe_tok - arith.constant(1)
+        ) // safe_tok
+        units_per_warp = (
+            arith.constant(n_i32) + warps_per_tok - arith.constant(1)
+        ) // warps_per_tok
+        stage3_total = cur_rank_num_token * warps_per_tok
+        for stage3_idx in range(global_warp_id, stage3_total, global_warp_num):
+            tok_id = stage3_idx // warps_per_tok
+            part_id = stage3_idx % warps_per_tok
+            unit_base = part_id * units_per_warp
+            tok_map_base = tok_id * experts_per_token
+            expert_bases = []
+            expert_valids = []
+            expert_pes = []
+            expert_toks = []
+            for k_slot in range_constexpr(experts_per_token):
+                encoded_k = buffer_load(
+                    rsrc_tok_map, tok_map_base + k_slot, vec_width=1, dtype=T.i32()
+                )
+                dest_pe_k = encoded_k // max_recv  # sentinel: dest_pe == npes
+                dest_tok_k = encoded_k % max_recv  # peer-local recv slot
+                valid_k = dest_pe_k < npes
+                safe_pe = arith.select(valid_k, dest_pe_k, arith.constant(rank))
+                safe_tok_k = arith.select(valid_k, dest_tok_k, arith.constant(0))
+                # Remote base peer[dest_pe].out_tok[dest_tok]; gather via global
+                # loads (no per-expert buffer descriptor) to keep all K loads in
+                # flight — see P.load_i32_nt.
+                slot_addr = fx.Int64(window.lsa_ptr(safe_pe, off_out_tok)) + fx.Int64(
+                    safe_tok_k
+                ) * fx.Int64(nbytes)
+                expert_bases.append(slot_addr)
+                expert_valids.append(valid_k)
+                expert_pes.append(safe_pe)
+                expert_toks.append(safe_tok_k)
+
+            # Weights (mori UseWeights): once per token (part 0), reduce the K
+            # forwarded weight vectors -> out_weights[tok][e]. Reuses the decode
+            # above and overlaps with this warp's hidden gather.
+            if const_expr(enable_weights):
+                if part_id == arith.constant(0):
+                    if lane < experts_per_token:
+                        weight_acc = arith.constant(0.0, type=T.f32())
+                        for k_slot in range_constexpr(experts_per_token):
+                            weight_addr = fx.Int64(
+                                window.lsa_ptr(expert_pes[k_slot], off_out_wts)
+                            ) + (
+                                fx.Int64(expert_toks[k_slot])
+                                * fx.Int64(experts_per_token)
+                                + fx.Int64(lane)
+                            ) * fx.Int64(
+                                4
+                            )
+                            weight_val = buffer_load(
+                                create_buffer_resource_from_addr(weight_addr),
+                                0,
+                                vec_width=1,
+                                dtype=T.f32(),
+                            )
+                            weight_acc = weight_acc + arith.select(
+                                expert_valids[k_slot],
+                                weight_val,
+                                arith.constant(0.0, type=T.f32()),
+                            )
+                        buffer_store(weight_acc, rsrc_out_wts, tok_map_base + lane)
+            rem = arith.constant(n_i32) - unit_base
+            eff = arith.select(
+                rem < units_per_warp, rem, units_per_warp
+            )  # i32 units this warp
+            out_base = tok_id * out_n_i32
+
+            # Nested fn: closure over expert_bases/valids (lists can't be loop-carried).
+            def _one(off):  # reduce k contributions for one i32 unit
+                vals = []
+                for k_slot in range_constexpr(experts_per_token):
+                    v = P.load_i32_nt(expert_bases[k_slot], off)
+                    vals.append(
+                        arith.select(expert_valids[k_slot], v, arith.constant(0))
+                    )
+                acc = _zero_accum()
+                for k_slot in range_constexpr(experts_per_token):
+                    acc = acc + _to_accum2(vals[k_slot])
+                buffer_store(
+                    _from_accum2(acc), rsrc_out, out_base + off * out_step_mult
+                )
+
+            if const_expr(_use_vec4):
+                # Vec4 path: load 4 i32 (16B, global_load_dwordx4) per expert
+                # per iteration, reducing xGMI load count 4×.
+                VEC = 4
+                STEP_CHUNK = WAVE * VEC
+                STEP_V4 = _unroll * STEP_CHUNK
+
+                def _load_expert_vecs(off):
+                    vecs = []
+                    valids = []
+                    for k_slot in range_constexpr(experts_per_token):
+                        vecs.append(P.load_v4i32_nt(expert_bases[k_slot], off))
+                        valids.append(expert_valids[k_slot])
+                    return vecs, valids
+
+                def _accum_loop():
+                    main_end = (eff // STEP_V4) * STEP_V4
+                    for u in range(lane * VEC, main_end, STEP_V4):
+                        base = unit_base + u
+                        # Issue all remote loads first (both unroll rounds) so stores
+                        # in the j/r nest cannot block the next load batch.
+                        pre_vecs = []
+                        pre_valids = []
+                        for r in range_constexpr(_unroll):
+                            off_r = base + r * STEP_CHUNK
+                            vecs_r, valids_r = _load_expert_vecs(off_r)
+                            pre_vecs.append(vecs_r)
+                            pre_valids.append(valids_r)
+                        # Reduce+store: j outer, r inner (unroll innermost).
+                        for j in range_constexpr(VEC):
+                            for r in range_constexpr(_unroll):
+                                off = base + r * STEP_CHUNK
+                                acc = _zero_accum()
+                                for k_slot in range_constexpr(experts_per_token):
+                                    elem = vector.extract(
+                                        pre_vecs[r][k_slot], static_position=[j]
+                                    )
+                                    v = arith.select(
+                                        pre_valids[r][k_slot], elem, arith.constant(0)
+                                    )
+                                    acc = acc + _to_accum2(v)
+                                buffer_store(
+                                    _from_accum2(acc), rsrc_out, out_base + off + j
+                                )
+                    for u in range(main_end + lane, eff, WAVE):
+                        _one(unit_base + u)
+
+            else:
+
+                def _accum_loop():
+                    main_end = (eff // STEP) * STEP
+                    for u in range(lane, main_end, STEP):
+                        base = unit_base + u
+                        pre_vals = []
+                        for r in range_constexpr(_unroll):
+                            off_r = base + r * WAVE
+                            vals_r = []
+                            for k_slot in range_constexpr(experts_per_token):
+                                v = P.load_i32_nt(expert_bases[k_slot], off_r)
+                                vals_r.append(
+                                    arith.select(
+                                        expert_valids[k_slot], v, arith.constant(0)
+                                    )
+                                )
+                            pre_vals.append(vals_r)
+                        for r in range_constexpr(_unroll):
+                            off = base + r * WAVE
+                            acc = _zero_accum()
+                            for k_slot in range_constexpr(experts_per_token):
+                                acc = acc + _to_accum2(pre_vals[r][k_slot])
+                            buffer_store(
+                                _from_accum2(acc),
+                                rsrc_out,
+                                out_base + off * out_step_mult,
+                            )
+                    for u in range(main_end + lane, eff, WAVE):
+                        _one(unit_base + u)
+
+            _accum_loop()
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_combine(
+            arena,
+            addr_tok_map,
+            addr_comb_bar,
+            addr_xdb_flag,
+            addr_total_recv,
+            addr_out,
+            addr_out_wts,
+            my_lsa_rank,
+            cur_rank_num_token,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+_FP8_MAX = 240.0  # gfx942 native fp8 is e4m3fnuz: max finite 240 (NOT OCP 448);
+# clamping above 240 yields NaN from cvt_pk_fp8_f32 on this arch
+
+
+def _fabs(f):
+    return arith.maximumf(f, arith.negf(f))
+
+
+def _bf16x2(i32_scalar):  # i32 (2 bf16) -> v2f32
+    return vector.bitcast(_V2BF16(), vector.from_elements(_V1I32(), [i32_scalar])).extf(
+        _V2F32()
+    )
+
+
+def _warp_amax(lane, v):
+    """Max-reduce an f32 across the wavefront (butterfly via ds_bpermute, per-lane
+    gather index). Every lane returns the wavefront max; raw values in/out."""
+    for off in _BUTTERFLY_OFFSETS:
+        idx = arith.unwrap((lane ^ off) * 4)  # byte addr = lane*4
+        o = ds_bpermute(T.i32(), idx, arith.bitcast(T.i32(), arith.unwrap(v)))
+        v = arith.maximumf(v, arith.bitcast(T.f32(), o))
+    return v
+
+
+def make_combine_scatter(
+    *,
+    rank,
+    npes,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_out_tok,
+    off_comb_inp,
+    off_tis,
+    off_xdb_mem,
+    off_out_wts=0,
+    off_comb_wts=0,
+    off_comb_scales=0,
+    enable_weights=True,
+    fp8_direct_cast=False,
+    fp8_blockwise=False,
+    scale_dim=0,
+    reset_total_recv=True,
+    _s3_cache=2,
+):
+    """Scatter combine (mori useExternalInpBuffer / _nop2p path).
+
+    Stage 1  each computing rank P2P-WRITES its post-expert tokens back to the
+             ORIGIN rank's comb_inp[computing_rank*M + origin_lid] (origin from
+             tis); under fp8_direct_cast the bf16 token is cast to fp8 on write.
+    Stage 2  cross-device barrier.
+    Stage 3  origin rank LOCAL-reads comb_inp[dest_pe*M + tok] for its token's k
+             expert PEs (from tok_map) and reduces (fp8->bf16 dequant if cast).
+
+    vs the gather path: 2 passes (remote write + local read) but compresses the
+    transport to fp8; the natural home for fp8_direct_cast (gather has no
+    Stage-1 writer to compress at)."""
+    if fp8_blockwise and WAVE != 64:
+        raise NotImplementedError(
+            "fp8_blockwise combine's coalesced path assumes wave64 (one wave == one "
+            "128-elem block); wave32 (gfx12) port is TODO"
+        )
+    # blockwise reuses the fp8->bf16 accum (output bf16, wire fp8) + per-block scale.
+    _fp8_out = fp8_direct_cast or fp8_blockwise
+    wire_elem_size = 1 if _fp8_out else hidden_elem_size
+    to_acc, from_acc, zero_acc = _accum_funcs(wire_elem_size, _fp8_out)
+    inp_nbytes = hidden_dim * hidden_elem_size  # source out_tok (bf16/f32)
+    wire_nbytes = hidden_dim * wire_elem_size  # comb_inp transport
+    wire_n_i32 = wire_nbytes // 4
+    out_n_i32 = (hidden_dim * 2) // 4 if _fp8_out else wire_n_i32
+    out_step_mult = 2 if _fp8_out else 1
+    if fp8_blockwise:
+        block_elems = hidden_dim // scale_dim
+        assert (
+            hidden_dim % scale_dim == 0 and block_elems == 128
+        ), "blockwise (coalesced path): block_elems must be 128 (scale_dim = hidden/128)"
+        block_i32_fp8 = block_elems // 4  # fp8 i32 units per block (=32)
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def ep_combine_s(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
+
+        window = cco.Window(arena)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_comb_bar = create_buffer_resource_from_addr(addr_comb_bar)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        rsrc_tis = create_buffer_resource_from_addr(
+            fx.Int64(window.lsa_ptr(my_lsa_rank, off_tis))
+        )
+        rsrc_out = create_buffer_resource_from_addr(addr_out)
+        rsrc_out_wts = create_buffer_resource_from_addr(addr_out_wts)
+        xdb_cur_flag = P.load_i64_acquire(fx.Int64(addr_xdb_flag))
+        total_recv = buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32())
+
+        # ── Stage 1: scatter post-expert tokens back to origin's comb_inp ──
+        src_tok_base = fx.Int64(window.lsa_ptr(my_lsa_rank, off_out_tok))
+        for recv_slot in range(global_warp_id, total_recv, global_warp_num):
+            # tis encodes origin = src_pe*max_tok_per_rank + local_id
+            encoded_origin = buffer_load(
+                rsrc_tis, recv_slot, vec_width=1, dtype=T.i32()
+            )
+            origin_pe = encoded_origin // max_tok_per_rank
+            origin_lid = encoded_origin % max_tok_per_rank
+            dst = fx.Int64(window.lsa_ptr(origin_pe, off_comb_inp)) + (
+                fx.Int64(rank * max_tok_per_rank + origin_lid)
+            ) * fx.Int64(wire_nbytes)
+            src = src_tok_base + fx.Int64(recv_slot) * fx.Int64(inp_nbytes)
+            rsrc_src = create_buffer_resource_from_addr(src)
+            rsrc_dst = create_buffer_resource_from_addr(dst)
+            if const_expr(fp8_blockwise):
+                # Blockwise fp8 quant, COALESCED + warp-reduce (block_elems==128
+                # so one i32/lane spans a full block). Per block scale_block:
+                # lanes load the block coalesced (lane l -> elems 2l,2l+1),
+                # ds_bpermute butterfly gives every lane the block amax, then
+                # lane-pairs combine their 2 fp8 each into one i32 (even lane
+                # writes, coalesced). scale = (amax>MAX)? amax/MAX : 1;
+                # quant = clamp(v*MAX/amax). Token sign sentinel: if ANY block
+                # scaled, negate block-0 scale.
+                scale_dst = fx.Int64(
+                    window.lsa_ptr(origin_pe, off_comb_scales)
+                ) + fx.Int64(rank * max_tok_per_rank + origin_lid) * fx.Int64(
+                    scale_dim
+                ) * fx.Int64(
+                    4
+                )
+                rsrc_scales = create_buffer_resource_from_addr(scale_dst)
+                fp8max = arith.constant(_FP8_MAX, type=T.f32())
+                nlim = arith.constant(-_FP8_MAX, type=T.f32())
+                any_scaled = arith.constant(0) != arith.constant(0)  # False (uniform)
+                for scale_block in range_constexpr(scale_dim):
+                    v2 = _bf16x2(
+                        buffer_load(
+                            rsrc_src,
+                            scale_block * 64 + lane,
+                            vec_width=1,
+                            dtype=T.i32(),
+                        )
+                    )
+                    e0 = vector.extract(v2, static_position=[0])
+                    e1 = vector.extract(v2, static_position=[1])
+                    amax = _warp_amax(lane, arith.maximumf(_fabs(e0), _fabs(e1)))
+                    scaled = amax > fp8max
+                    any_scaled = arith.select(scaled, scaled, any_scaled)
+                    scale = arith.select(
+                        scaled,
+                        arith.divf(amax, fp8max),
+                        arith.constant(1.0, type=T.f32()),
+                    )
+                    inv = arith.select(
+                        scaled,
+                        arith.divf(fp8max, amax),
+                        arith.constant(1.0, type=T.f32()),
+                    )
+                    if lane == 0:
+                        buffer_store(scale, rsrc_scales, scale_block)
+                    f0 = fmed3(T.f32(), arith.mulf(e0, inv), fp8max, nlim)
+                    f1 = fmed3(T.f32(), arith.mulf(e1, inv), fp8max, nlim)
+                    my_packed = cvt_pk_fp8_f32(
+                        res=T.i32(),
+                        src_a=f0,
+                        src_b=f1,
+                        old=arith.constant(0, type=T.i32()),
+                        word_sel=False,
+                    )
+                    # neighbour (lane^1)'s 2 fp8 (its low 16) via ds_bpermute.
+                    nbr_packed = ds_bpermute(
+                        T.i32(),
+                        arith.unwrap((lane ^ arith.constant(1)) * arith.constant(4)),
+                        arith.unwrap(my_packed),
+                    )
+                    my_lo16 = my_packed & arith.constant(0xFFFF)
+                    packed_pair = my_lo16 | (
+                        (nbr_packed & arith.constant(0xFFFF)) << arith.constant(16)
+                    )
+                    if (lane & arith.constant(1)) == arith.constant(0):
+                        buffer_store(
+                            packed_pair,
+                            rsrc_dst,
+                            scale_block * block_i32_fp8 + (lane >> arith.constant(1)),
+                        )
+                if any_scaled:
+                    if lane == 0:
+                        s0 = buffer_load(rsrc_scales, 0, vec_width=1, dtype=T.f32())
+                        buffer_store(arith.negf(s0), rsrc_scales, 0)
+            elif const_expr(fp8_direct_cast):
+                # 2 bf16 i32 -> v4f32 -> cvt_pk_fp8 x2 -> 1 fp8 i32
+                for elem in range(lane, wire_n_i32, WAVE):
+                    bf = buffer_load(rsrc_src, elem * 2, vec_width=2, dtype=T.i32())
+                    v4 = vector.bitcast(T.VectorType.get([4], T.bf16()), bf).extf(
+                        _V4F32()
+                    )
+                    f0 = vector.extract(v4, static_position=[0])
+                    f1 = vector.extract(v4, static_position=[1])
+                    f2 = vector.extract(v4, static_position=[2])
+                    f3 = vector.extract(v4, static_position=[3])
+                    z = arith.constant(0, type=T.i32())
+                    lo = cvt_pk_fp8_f32(
+                        res=T.i32(), src_a=f0, src_b=f1, old=z, word_sel=False
+                    )
+                    fp8 = cvt_pk_fp8_f32(
+                        res=T.i32(), src_a=f2, src_b=f3, old=lo, word_sel=True
+                    )
+                    buffer_store(fp8, rsrc_dst, elem)
+            else:
+                for elem in range(lane, wire_n_i32, WAVE):
+                    v = buffer_load(rsrc_src, elem, vec_width=1, dtype=T.i32())
+                    buffer_store(v, rsrc_dst, elem)
+            if const_expr(enable_weights):
+                # forward this recv slot's weights (dispatch put them in out_wts[recv_slot])
+                # to the ORIGIN's comb_wts[computing_rank*M + lid] (dedicated
+                # region; reusing out_wts would collide with dispatch's layout).
+                weight_src = fx.Int64(
+                    window.lsa_ptr(my_lsa_rank, off_out_wts)
+                ) + fx.Int64(recv_slot) * fx.Int64(experts_per_token) * fx.Int64(4)
+                weight_dst = fx.Int64(
+                    window.lsa_ptr(origin_pe, off_comb_wts)
+                ) + fx.Int64(rank * max_tok_per_rank + origin_lid) * fx.Int64(
+                    experts_per_token
+                ) * fx.Int64(
+                    4
+                )
+                if lane < experts_per_token:
+                    weight_val = buffer_load(
+                        create_buffer_resource_from_addr(weight_src),
+                        lane,
+                        vec_width=1,
+                        dtype=T.i32(),
+                    )
+                    buffer_store(
+                        weight_val, create_buffer_resource_from_addr(weight_dst), lane
+                    )
+
+        # ── Stage 2: cross-device barrier ──
+        # release Stage-1's P2P comb_inp writes before signaling peers (else
+        # Stage-3's acquire races them -> dropped contributions)
+        P.fence_system_release()
+        fx.barrier()
+        if tid == 0:
+            P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
+        if grid_thread_id < npes:
+            P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num)
+            P.fence_system_acquire()
+            buffer_store(arith.constant(0), rsrc_comb_bar, 0)
+            xdb_remote = fx.Int64(
+                window.lsa_ptr(grid_thread_id, off_xdb_mem)
+            ) + fx.Int64(rank) * fx.Int64(8)
+            P.store_i64_system(xdb_remote, arith.constant(0), xdb_cur_flag)
+        if grid_thread_id == 0:
+            P.atomic_add_global(
+                fx.Int64(addr_xdb_flag), arith.constant(1, type=T.i64())
+            )
+        if tid < npes:
+            xdb_slot = fx.Int64(window.lsa_ptr(my_lsa_rank, off_xdb_mem)) + fx.Int64(
+                tid
+            ) * fx.Int64(8)
+            P.spin_until_eq_i64(xdb_slot, xdb_cur_flag)
+            P.fence_system_acquire()
+        fx.barrier()
+        P.fence_system_acquire()
+        if const_expr(reset_total_recv):
+            if tid == 0:
+                buffer_store(arith.constant(0), rsrc_total_recv, 0)
+
+        # ── Stage 3: local read of comb_inp + reduce ──
+        comb_inp_base = fx.Int64(window.lsa_ptr(my_lsa_rank, off_comb_inp))
+        safe_tok = arith.select(
+            cur_rank_num_token == arith.constant(0),
+            arith.constant(1),
+            cur_rank_num_token,
+        )
+        warps_per_tok = (
+            arith.constant(global_warp_num) + safe_tok - arith.constant(1)
+        ) // safe_tok
+        units_per_warp = (
+            arith.constant(wire_n_i32) + warps_per_tok - arith.constant(1)
+        ) // warps_per_tok
+        stage3_total = cur_rank_num_token * warps_per_tok
+        for stage3_idx in range(global_warp_id, stage3_total, global_warp_num):
+            tok_id = stage3_idx // warps_per_tok
+            part_id = stage3_idx % warps_per_tok
+            unit_base = part_id * units_per_warp
+            tok_map_base = tok_id * experts_per_token
+            expert_rsrcs = []
+            expert_valids = []
+            expert_pes = []
+            expert_scales = []
+            for k_slot in range_constexpr(experts_per_token):
+                encoded_k = buffer_load(
+                    rsrc_tok_map, tok_map_base + k_slot, vec_width=1, dtype=T.i32()
+                )
+                dest_pe = encoded_k // max_recv
+                valid = dest_pe < npes
+                safe_pe = arith.select(valid, dest_pe, arith.constant(rank))
+                # LOCAL comb_inp[computing_pe*M + tok_id]
+                src_addr = comb_inp_base + (
+                    fx.Int64(safe_pe) * fx.Int64(max_tok_per_rank) + fx.Int64(tok_id)
+                ) * fx.Int64(wire_nbytes)
+                expert_rsrcs.append(create_buffer_resource_from_addr(src_addr))
+                expert_valids.append(valid)
+                expert_pes.append(safe_pe)
+                if const_expr(fp8_blockwise):
+                    scale_addr = fx.Int64(
+                        window.lsa_ptr(my_lsa_rank, off_comb_scales)
+                    ) + (
+                        fx.Int64(safe_pe) * fx.Int64(max_tok_per_rank)
+                        + fx.Int64(tok_id)
+                    ) * fx.Int64(
+                        scale_dim
+                    ) * fx.Int64(
+                        4
+                    )
+                    expert_scales.append(create_buffer_resource_from_addr(scale_addr))
+            if const_expr(enable_weights):
+                if part_id == arith.constant(0):
+                    if lane < experts_per_token:
+                        weight_acc = arith.constant(0.0, type=T.f32())
+                        for k_slot in range_constexpr(experts_per_token):
+                            # LOCAL comb_wts[computing_pe*M + tok_id] (scattered in S1)
+                            weight_addr = (
+                                fx.Int64(window.lsa_ptr(my_lsa_rank, off_comb_wts))
+                                + (
+                                    fx.Int64(expert_pes[k_slot])
+                                    * fx.Int64(max_tok_per_rank)
+                                    + fx.Int64(tok_id)
+                                )
+                                * fx.Int64(experts_per_token)
+                                * fx.Int64(4)
+                                + fx.Int64(lane) * fx.Int64(4)
+                            )
+                            weight_val = buffer_load(
+                                create_buffer_resource_from_addr(weight_addr),
+                                0,
+                                vec_width=1,
+                                dtype=T.f32(),
+                            )
+                            weight_acc = weight_acc + arith.select(
+                                expert_valids[k_slot],
+                                weight_val,
+                                arith.constant(0.0, type=T.f32()),
+                            )
+                        buffer_store(weight_acc, rsrc_out_wts, tok_map_base + lane)
+            rem = arith.constant(wire_n_i32) - unit_base
+            eff = arith.select(rem < units_per_warp, rem, units_per_warp)
+            out_base = tok_id * out_n_i32
+
+            def _one(off):
+                acc = zero_acc()
+                # blockwise: 4 fp8 per i32 unit are 4 consecutive elements in the
+                # same block -> one scale per unit. scale_block = (off*4)//block_elems.
+                if const_expr(fp8_blockwise):
+                    scale_block = (off * arith.constant(4)) // arith.constant(
+                        block_elems
+                    )
+                    is_b0 = scale_block == arith.constant(0)
+                for k_slot in range_constexpr(experts_per_token):
+                    v = buffer_load(
+                        expert_rsrcs[k_slot],
+                        off,
+                        vec_width=1,
+                        dtype=T.i32(),
+                        cache_modifier=_s3_cache,
+                    )
+                    v = arith.select(expert_valids[k_slot], v, arith.constant(0))
+                    if const_expr(fp8_blockwise):
+                        scale = buffer_load(
+                            expert_scales[k_slot],
+                            scale_block,
+                            vec_width=1,
+                            dtype=T.f32(),
+                        )
+                        scale = arith.select(
+                            is_b0, _fabs(scale), scale
+                        )  # undo block-0 sign sentinel
+                        # invalid expert -> v already 0; force finite scale so a
+                        # stale/garbage comb_scales slot can't make 0*NaN = NaN.
+                        scale = arith.select(
+                            expert_valids[k_slot],
+                            scale,
+                            arith.constant(1.0, type=T.f32()),
+                        )
+                        acc = acc + to_acc(v) * scale
+                    else:
+                        acc = acc + to_acc(v)
+                buffer_store(from_acc(acc), rsrc_out, out_base + off * out_step_mult)
+
+            def _loop():
+                for u in range(lane, eff, WAVE):
+                    _one(unit_base + u)
+
+            _loop()
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_combine_s(
+            arena,
+            addr_tok_map,
+            addr_comb_bar,
+            addr_xdb_flag,
+            addr_total_recv,
+            addr_out,
+            addr_out_wts,
+            my_lsa_rank,
+            cur_rank_num_token,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+# ── StdMoE convert ────────────────────────────────────────────────────────
+
+
+def _to_accum2(i32_scalar):  # i32 (2 bf16) -> v2f32
+    return vector.bitcast(_V2BF16(), vector.from_elements(_V1I32(), [i32_scalar])).extf(
+        _V2F32()
+    )
+
+
+def _from_accum2(v2f32):  # v2f32 -> i32 (2 bf16)
+    return vector.extract(
+        vector.bitcast(_V1I32(), v2f32.truncf(_V2BF16())), static_position=[0]
+    )
+
+
+def _splat2(f32_scalar):  # f32 -> v2f32 (broadcast)
+    return vector.from_elements(_V2F32(), [f32_scalar, f32_scalar])
+
+
+def make_convert_dispatch_output(
+    *,
+    rank,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_expert,
+    block_num,
+    warp_num_per_block,
+):
+    """Per-expert packing of dispatched tokens. One warp per (recv_tok, k_slot):
+    lane0 bumps packed_cnt[localExpert] to claim a slot, then the warp copies the
+    token embedding into packed_x[slot]."""
+    assert hidden_elem_size == 2, "stdmoe convert is bf16-only"
+    nbytes = hidden_dim * hidden_elem_size
+    n_i32 = nbytes // 4
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def convert_disp(
+        addr_out_tok: Int64,
+        addr_out_idx: Int64,
+        addr_tis: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_packed_cnt: Int64,
+        addr_packed_src: Int64,
+        addr_slot_map: Int64,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+
+        rsrc_out_idx = create_buffer_resource_from_addr(addr_out_idx)
+        rsrc_tis = create_buffer_resource_from_addr(addr_tis)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        rsrc_packed_src = create_buffer_resource_from_addr(addr_packed_src)
+
+        total_recv = buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32())
+        work_limit = total_recv * experts_per_token
+        for i in range(global_warp_id, work_limit, global_warp_num):
+            recv_tok = i // experts_per_token
+            expert = buffer_load(rsrc_out_idx, i, vec_width=1, dtype=T.i32())
+            local_expert = expert - arith.constant(rank * experts_per_rank)
+            # MUST be unsigned ult: signed slt would treat negative local_expert
+            # (non-local experts) as in-range and trigger an OOB copy.
+            is_local = arith.cmpi(
+                arith.CmpIPredicate.ult, local_expert, arith.constant(experts_per_rank)
+            )
+            # lane0 claims a per-expert packing slot, then broadcasts.
+            slot_lane0 = arith.constant(0)
+            if lane == 0:
+                if is_local:
+                    cnt_addr = fx.Int64(addr_packed_cnt) + fx.Int64(
+                        local_expert
+                    ) * fx.Int64(4)
+                    slot_lane0 = P.atomic_add_global(cnt_addr, fx.Int32(1))
+            slot = readlane(T.i32(), slot_lane0, 0)
+            safe_local_expert = arith.select(is_local, local_expert, arith.constant(0))
+            packed_lin_idx = (
+                safe_local_expert * arith.constant(max_tok_per_expert) + slot
+            )
+            slot_val = arith.select(
+                is_local, fx.Int64(packed_lin_idx), arith.constant(-1, type=T.i64())
+            )
+            if lane == 0:
+                P.store_i64_system(
+                    fx.Int64(addr_slot_map) + fx.Int64(i) * fx.Int64(8),
+                    arith.constant(0),
+                    slot_val,
+                )
+                if is_local:
+                    src = buffer_load(rsrc_tis, recv_tok, vec_width=1, dtype=T.i32())
+                    buffer_store(src, rsrc_packed_src, packed_lin_idx)
+            if is_local:
+                dst = fx.Int64(addr_packed_x) + fx.Int64(packed_lin_idx) * fx.Int64(
+                    nbytes
+                )
+                src_t = fx.Int64(addr_out_tok) + fx.Int64(recv_tok) * fx.Int64(nbytes)
+                rsrc_dst = create_buffer_resource_from_addr(dst)
+                rsrc_src = create_buffer_resource_from_addr(src_t)
+                for chunk in range(lane * 4, n_i32, _LANE_STRIDE_I32):
+                    v = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                    buffer_store(v, rsrc_dst, chunk)
+
+    @flyc.jit
+    def run(
+        addr_out_tok: Int64,
+        addr_out_idx: Int64,
+        addr_tis: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_packed_cnt: Int64,
+        addr_packed_src: Int64,
+        addr_slot_map: Int64,
+        stream=fx.Stream(None),
+    ):
+        convert_disp(
+            addr_out_tok,
+            addr_out_idx,
+            addr_tis,
+            addr_total_recv,
+            addr_packed_x,
+            addr_packed_cnt,
+            addr_packed_src,
+            addr_slot_map,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+def make_convert_combine_input(
+    *,
+    rank,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_expert,
+    block_num,
+    warp_num_per_block,
+):
+    """Inverse: reduce each recv token's local-expert outputs with routing
+    weights back into out_tok (the combine input staging). Warp-partitioned over
+    hidden; out_tok[recv_t][e] = sum_{k: slot_k valid} wts[k]*packed_x[slot_k][e]."""
+    assert hidden_elem_size == 2, "stdmoe convert is bf16-only"
+    nbytes = hidden_dim * hidden_elem_size
+    n_i32 = nbytes // 4
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def convert_comb(
+        addr_out_tok: Int64,
+        addr_out_wts: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_slot_map: Int64,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+
+        rsrc_out_wts = create_buffer_resource_from_addr(addr_out_wts)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+
+        total_recv = buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32())
+        safe_recv = arith.select(
+            total_recv == arith.constant(0), arith.constant(1), total_recv
+        )
+        warps_per_tok = (
+            arith.constant(global_warp_num) + safe_recv - arith.constant(1)
+        ) // safe_recv
+        units_per_warp = (
+            arith.constant(n_i32) + warps_per_tok - arith.constant(1)
+        ) // warps_per_tok
+        stage_total = total_recv * warps_per_tok
+        for stage_idx in range(global_warp_id, stage_total, global_warp_num):
+            recv_tok = stage_idx // warps_per_tok
+            part_id = stage_idx % warps_per_tok
+            unit_base = part_id * units_per_warp
+            slot_map_base = recv_tok * experts_per_token
+            expert_rsrcs = []
+            expert_valids = []
+            expert_weights = []
+            for k_slot in range_constexpr(experts_per_token):
+                slot = P.load_i64_acquire(
+                    fx.Int64(addr_slot_map)
+                    + fx.Int64(slot_map_base + k_slot) * fx.Int64(8)
+                )
+                valid = slot != arith.constant(-1, type=T.i64())
+                safe_slot = arith.select(valid, slot, arith.constant(0, type=T.i64()))
+                x_addr = fx.Int64(addr_packed_x) + safe_slot * fx.Int64(nbytes)
+                expert_rsrcs.append(create_buffer_resource_from_addr(x_addr))
+                expert_valids.append(valid)
+                expert_weights.append(
+                    buffer_load(
+                        rsrc_out_wts, slot_map_base + k_slot, vec_width=1, dtype=T.f32()
+                    )
+                )
+            rsrc_out = create_buffer_resource_from_addr(
+                fx.Int64(addr_out_tok) + fx.Int64(recv_tok) * fx.Int64(nbytes)
+            )
+            rem = arith.constant(n_i32) - unit_base
+            eff = arith.select(rem < units_per_warp, rem, units_per_warp)
+
+            def _one(off):
+                acc = _to_accum2(arith.constant(0))
+                for k_slot in range_constexpr(experts_per_token):
+                    v = buffer_load(
+                        expert_rsrcs[k_slot], off, vec_width=1, dtype=T.i32()
+                    )
+                    weight_val = arith.select(
+                        expert_valids[k_slot],
+                        expert_weights[k_slot],
+                        arith.constant(0.0, type=T.f32()),
+                    )
+                    # v2f32 vector * f32 scalar (broadcast), matching the
+                    # FlyDSL reference _weighted_accum_experts.
+                    acc = acc + _to_accum2(v) * weight_val
+                buffer_store(_from_accum2(acc), rsrc_out, off)
+
+            def _loop():
+                for u in range(lane, eff, WAVE):
+                    _one(unit_base + u)
+
+            _loop()
+
+    @flyc.jit
+    def run(
+        addr_out_tok: Int64,
+        addr_out_wts: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_slot_map: Int64,
+        stream=fx.Stream(None),
+    ):
+        convert_comb(
+            addr_out_tok, addr_out_wts, addr_total_recv, addr_packed_x, addr_slot_map
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+# ── local expert count ────────────────────────────────────────────────────
+
+
+def make_local_expert_count(
+    *, rank, experts_per_rank, experts_per_token, block_num, warp_num_per_block
+):
+    expert_base = rank * experts_per_rank
+    block_size = warp_num_per_block * WAVE
+
+    @flyc.kernel(known_block_size=[block_size, 1, 1])
+    def local_expert_count_kernel(
+        addr_out_idx: Int64, addr_total_recv: Int64, addr_count: Int64
+    ):
+        global_thread_id = fx.block_idx.x * block_size + fx.thread_idx.x
+        global_thread_num = block_num * block_size
+        rsrc_out_idx = create_buffer_resource_from_addr(addr_out_idx)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        limit = (
+            buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32())
+            * experts_per_token
+        )
+        for i in range(global_thread_id, limit, global_thread_num):
+            local_expert = (
+                buffer_load(rsrc_out_idx, i, vec_width=1, dtype=T.i32()) - expert_base
+            )
+            if local_expert >= 0:
+                if local_expert < experts_per_rank:
+                    P.atomic_add_global(
+                        fx.Int64(addr_count) + fx.Int64(local_expert) * fx.Int64(4),
+                        fx.Int32(1),
+                    )
+
+    @flyc.jit
+    def run(
+        addr_out_idx: Int64,
+        addr_total_recv: Int64,
+        addr_count: Int64,
+        stream=fx.Stream(None),
+    ):
+        local_expert_count_kernel(addr_out_idx, addr_total_recv, addr_count).launch(
+            grid=(block_num, 1, 1), block=[block_size, 1, 1], stream=stream
+        )
+
+    return run

--- a/aiter/ops/flydsl/dispatch_combine_v2/tuning_configs.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/tuning_configs.py
@@ -1,0 +1,305 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Per-device, per-shape block/warp tuning for the cco-LSA dispatch/combine
+kernels.
+
+Geometry is picked per device (MI308X / MI300X / MI355X), then by
+(world_size, hidden_dim, topk). Devices are told apart by PCI device id (MI300X
+and MI308X are both gfx942, differing only in CU count), falling back to arch for
+gfx950 — all from KFD sysfs, no torch/HIP dependency. block_num must stay
+<= CU count; re-tune per GPU.
+"""
+
+import functools
+import glob
+
+
+# ── MI308X (gfx942, 80 CU) — measured 2026-07-08, EP8, from a block x warp sweep.
+# Best (block, warp) is token-count dependent, so this is a per-token SCHEDULE of
+# (max_tok_inclusive | None, disp_block, disp_warp, comb_block, comb_warp) buckets;
+# the op precompiles the distinct (block, warp) variants and picks by token count.
+_MI308X_SCHEDULE = (
+    (256, 64, 8, 64, 4),
+    (2048, 64, 16, 64, 4),
+    (None, 64, 16, 80, 4),
+)
+# Single-shot fallback (schedule ignored) = peak-optimal.
+_MI308X_DEFAULT = dict(
+    dispatch_block_num=64,
+    combine_block_num=80,
+    warp_num_per_block=16,
+    combine_warp_num_per_block=4,
+    schedule=_MI308X_SCHEDULE,
+)
+# Per-shape -> per-dtype schedules. These were tuned as fp8-dispatch + bf16-combine,
+# so they live under "fp8" (the default / fallback for any untuned dtype).
+# hidden 4096 / 2048 reuse the 7168 schedule until separately tuned.
+_MI308X_TABLE = {
+    (8, 7168, 8): {"fp8": _MI308X_SCHEDULE},
+    (8, 4096, 8): {"fp8": _MI308X_SCHEDULE},
+    (8, 2048, 8): {"fp8": _MI308X_SCHEDULE},
+}
+
+# ── MI325X (gfx942, 304 CU, DID 0x74a5) — measured 2026-07-08, EP8, full 2D block x
+# warp sweep (graph, ITERS>=300, tok 8..8192), selected by min LATENCY (us). Key
+# lessons vs MI308X: (a) dispatch always wants warp 8 (not 16), block grows with tok
+# (64->152->228->304); (b) combine is latency-bound at small/mid tok — on this big
+# 304-CU part a SMALL block (64) + warp 4 wins (the 0.5*CU block's grid-barrier cost
+# dominates), only bandwidth-bound large tok (>1024) want b~0.5*CU (152) + warp 2;
+# at the tiniest tok (8) combine warp 2 edges warp 4. b64 combine beats MI308X at
+# every small size. Measured combine us: 8=20 64=38 128=53 256=83 512=145 1024=267
+# 2048=497 4096=961 8192=1839; dispatch us: 8=18 64=30 128=47 256=78 512=138 1024=256
+# 2048=490 4096=960 8192=1881.
+_MI325X_SCHEDULE = (
+    (8, 64, 8, 64, 2),  # <=8 tok: tiny, combine warp 2
+    (64, 64, 8, 64, 4),  # <=64:   small block both
+    (1024, 152, 8, 64, 4),  # <=1024: disp 0.5*CU, comb small-block/warp4 (latency)
+    (4096, 228, 8, 152, 2),  # <=4096: comb 0.5*CU/warp2 (bandwidth)
+    (None, 304, 8, 152, 2),  # >4096 (peak)
+)
+_MI325X_DEFAULT = dict(
+    dispatch_block_num=304,
+    combine_block_num=152,
+    warp_num_per_block=8,
+    combine_warp_num_per_block=2,
+    schedule=_MI325X_SCHEDULE,
+)
+# hidden 4096 / 2048 reuse the 7168 schedule until separately tuned.
+_MI325X_TABLE = {
+    (8, 7168, 8): {"fp8": _MI325X_SCHEDULE},
+    (8, 4096, 8): {"fp8": _MI325X_SCHEDULE},
+    (8, 2048, 8): {"fp8": _MI325X_SCHEDULE},
+}
+
+# ── MI300X (gfx942, 304 CU) — TODO: re-tune. Falls back to CU-scaled default. ──
+_MI300X_DEFAULT = None  # None => derive from CU count (see _cu_scaled_default)
+_MI300X_TABLE = {}
+
+# ── MI355X (gfx950, wave64) — re-tuned 2026-07-13 for the vec4 combine gather,
+# EP8, 8x gfx950 single-node xGMI, 2-pass block x warp sweep (tok 8..8192). vec4
+# combine wants a small block (32-48) + warp up to 16; dispatch grows block 96->160.
+# wave64 => warp <= 16 (1024-thread block). Geometry is topk-independent.
+# bf16 dispatch + bf16 combine:
+_MI355X_SCHED_BF16 = (
+    (128, 128, 8, 32, 8),
+    (256, 96, 8, 64, 8),
+    (1024, 96, 8, 32, 16),
+    (4096, 160, 8, 32, 16),
+    (None, 128, 16, 48, 16),
+)
+# fp8 dispatch + bf16 combine (combine geometry shared with bf16):
+_MI355X_SCHED_FP8 = (
+    (128, 128, 8, 32, 8),
+    (256, 160, 8, 64, 8),
+    (1024, 128, 8, 32, 16),
+    (4096, 160, 8, 32, 16),
+    (None, 128, 16, 48, 16),
+)
+# fp4 dispatch + fp4 combine (0.5 B/elem):
+_MI355X_SCHED_FP4 = (
+    (256, 128, 4, 32, 8),
+    (2048, 144, 4, 64, 16),
+    (None, 128, 8, 64, 16),
+)
+_MI355X_DEFAULT = dict(
+    dispatch_block_num=128,
+    combine_block_num=48,
+    warp_num_per_block=16,
+    combine_warp_num_per_block=16,
+    schedule=_MI355X_SCHED_BF16,
+)
+_MI355X_TABLE = {
+    (8, 7168, 8): {
+        "bf16": _MI355X_SCHED_BF16,
+        "fp8": _MI355X_SCHED_FP8,
+        "fp4": _MI355X_SCHED_FP4,
+    },
+    (8, 7168, 6): {
+        "bf16": _MI355X_SCHED_BF16,
+        "fp8": _MI355X_SCHED_FP8,
+        "fp4": _MI355X_SCHED_FP4,
+    },
+}
+
+# ── gfx1250 (256 CU, wave32) — RE-TUNED 2026-07-15 EP4, bf16, with the vec4 combine
+# kernel + inner-unroll load-first scheduling, FINE 2-pass block x warp sweep
+# (tok 16..16384; comb block 48..192, warp 2..16). Key lessons: (a) dispatch
+# unchanged by vec4 — warp grows to 32, block 192; peaks ~287 GB/s @16384.
+# (b) combine SHIFTED with vec4 AND is very warp-sensitive at small tok: warp 2 wins
+# <=128 (64/2: 64tok 27 vs warp4 21 vs warp16 11 — over-parallelizing the gather+xdb
+# barrier collapses it), warp 4 for mid, warp 8 for large; block grows 64->96->128.
+# The old pre-vec4 schedule (comb block->192, warp 16) is stale: comb @8192 189->242
+# (+28%), mid 512 55->102 (+84%), tiny 64 ~11->27 (2.4x). (c) GUARDRAIL: block_num
+# < CU (256); 192 safe ceiling (Phase-2 grid barrier needs co-residence). Measured
+# vec4 GB/s (disp/comb): 64=29/27 128=56/47 256=114/74 512=182/102 1024=214/132
+# 2048=248/174 4096=264/207 8192=282/242 16384=287/273.
+_GFX1250_SCHED_BF16 = (
+    (128, 128, 8, 64, 2),  # <=128:  latency-bound; combine warp 2 (fewest warps win)
+    (512, 192, 32, 64, 4),  # <=512:  disp peak; comb 64/4
+    (1536, 192, 32, 96, 4),  # <=1536: comb block 96
+    (4096, 192, 32, 128, 4),  # <=4096: comb block 128
+    (None, 192, 32, 128, 8),  # >4096:  comb warp 8 (242/273 GB/s @8192/16384)
+)
+_GFX1250_DEFAULT = dict(
+    dispatch_block_num=192,
+    combine_block_num=192,
+    warp_num_per_block=32,
+    combine_warp_num_per_block=16,
+    schedule=_GFX1250_SCHED_BF16,
+)
+# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts). RE-VALIDATED 2026-07-15
+# EP4 bf16 vec4 at the topk=8 schedule geometries: geometry is topk-independent
+# (tracks token count, not topk) — per-size optimum matches topk=8, so reuse the
+# same schedule. Measured vec4 GB/s (disp/comb): 16=6/4 256=95/67 512=164/93
+# 1024=212/116 2048=252/164 4096=281/200 8192=293/238 16384=300/272.
+_GFX1250_SCHED_BF16_T6 = _GFX1250_SCHED_BF16
+# EP8 (world_size=8) RE-TUNED 2026-07-13 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
+# over the UALink fabric), bf16, with the vec4 combine-gather kernel, full 2-pass
+# block x warp sweep (tok 8..8192). dispatch unchanged by vec4: block 128, warp
+# ramps 16->32. combine SHIFTED: block 64 is now uniformly best (128 loses even at
+# 8192 with vec4's wider loads), warp ramps 4->8->16. Cross-node fabric caps disp
+# ~200 GB/s; geometry is world_size-independent so this also serves single-node EP8.
+# Measured vec4 GB/s at scheduled geom (disp/comb): 8=5/3 64=17/23 128=71/47
+# 256=127/76 512=162/105 1024=187/135 2048=198/152 4096=200/176 8192=200/200
+# (<=64 disp is launch-latency noise). vs pre-vec4 scalar tuned comb 8192=173
+# 512=63 256=42 -> +15% / +67% / +80%. topk6 (384 exp) reuses this schedule,
+# comb 8192=198 512=99 256=68 (geometry is topk-independent).
+_GFX1250_SCHED_BF16_EP8 = (
+    (256, 128, 16, 64, 4),  # <=256:  disp warp 16, comb 64/4 (latency-bound)
+    (1024, 128, 32, 64, 8),  # <=1024: disp warp 32, comb 64/8
+    (None, 128, 32, 64, 16),  # >1024 (peak): disp ~200 / comb ~200 GB/s
+)
+# bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
+_GFX1250_TABLE = {
+    (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
+    (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
+    (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
+    # V4-Pro topk=6 EP8 cross-node (measured 2026-07-12, full tok 8..8192 sweep):
+    # geometry is topk-independent (tracks token count) — per-size optimum matches
+    # topk=8, so reuse the same schedule. Measured GB/s (disp/comb): 8=4/3 64=32/16
+    # 128=65/25 256=119/39 512=163/56 1024=178/81 2048=199/113 4096=200/145 8192=206/171.
+    (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
+}
+
+_DEVICES = {
+    "mi308x": (_MI308X_DEFAULT, _MI308X_TABLE),
+    "mi325x": (_MI325X_DEFAULT, _MI325X_TABLE),
+    "mi300x": (_MI300X_DEFAULT, _MI300X_TABLE),
+    "mi355x": (_MI355X_DEFAULT, _MI355X_TABLE),
+    "gfx1250": (_GFX1250_DEFAULT, _GFX1250_TABLE),
+}
+
+
+# PCI device IDs (KFD `device_id`) → device table key. gfx942 family only; the
+# gfx950 parts (MI350/MI355X) are matched by arch below since their DIDs vary.
+_DID_TO_KEY = {
+    0x74A1: "mi300x",  # MI300X
+    0x74A5: "mi325x",  # MI325X (304-CU gfx942; tuned 2026-07-08)
+    0x74A2: "mi308x",  # MI308X (80 CU)
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _topology():
+    """(cu_count, gfx_target_version, device_id) of the first GPU node from KFD
+    sysfs. torch/HIP-free. gfx_target_version is e.g. 90402 (gfx942), 90500
+    (gfx950); device_id is the PCI DID (e.g. 0x74a2 = MI308X). Homogeneous host
+    assumed. Returns (0, 0, 0) if sysfs is unavailable (no KFD mounted)."""
+    for props in sorted(glob.glob("/sys/class/kfd/kfd/topology/nodes/*/properties")):
+        try:
+            vals = {}
+            with open(props) as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) == 2:
+                        vals[parts[0]] = int(parts[1])
+            simd = vals.get("simd_count", 0)
+            if simd <= 0:  # CPU / non-GPU node
+                continue
+            spc = vals.get("simd_per_cu", 0) or 1
+            return (
+                simd // spc,
+                vals.get("gfx_target_version", 0),
+                vals.get("device_id", 0),
+            )
+        except Exception:
+            continue
+    return 0, 0, 0
+
+
+def _cu_count():
+    return _topology()[0]
+
+
+def _device_key():
+    """Map the current GPU to a device table key: exact PCI DID first, then arch
+    for gfx950. Returns None if unknown (caller uses a CU-scaled default)."""
+    _, gfx, did = _topology()
+    key = _DID_TO_KEY.get(did)
+    if key is not None:
+        return key
+    if gfx == 90500:  # gfx950 (MI350 / MI355X), DID varies
+        return "mi355x"
+    if gfx == 120500:  # gfx1250 (256 CU, wave32), DID varies
+        return "gfx1250"
+    return None
+
+
+def _cu_scaled_default():
+    """Untuned fallback: ~1 block/CU for combine (<= CU count), many warps for
+    dispatch, few warps for combine, no per-token schedule (single-shot). Used
+    for devices without a measured table."""
+    cu = _cu_count() or 80
+    return dict(
+        dispatch_block_num=cu,
+        combine_block_num=cu,
+        warp_num_per_block=16,
+        combine_warp_num_per_block=4,
+        schedule=None,
+    )
+
+
+def lookup(world_size, hidden_dim, topk, dtype="fp8"):
+    """Return {dispatch_block_num, combine_block_num, warp_num_per_block,
+    combine_warp_num_per_block, schedule} for the current GPU, shape, and dtype.
+
+    `dtype` (the token / dispatch dtype: "bf16" | "fp8" | "fp4") selects the
+    per-dtype schedule, because dtype sets the communication volume (fp4 = 0.5 B,
+    fp8 = 1 B, bf16 = 2 B per element) and thus the best block/warp. It falls back
+    to the "fp8" schedule, then to the device default, when a dtype isn't tuned.
+
+    `schedule` (or None) is a per-token-count launch plan: a tuple of
+    (max_tok_inclusive | None, disp_block, disp_warp, comb_block, comb_warp)
+    buckets, ascending; the op precompiles the distinct (block, warp) variants
+    and picks a bucket at runtime from cur_rank_num_token. dispatch_block_num /
+    warp_num_per_block / combine_block_num / combine_warp_num_per_block are the
+    single-shot fallback used when schedule is None."""
+    key = _device_key()
+    if key is None or key not in _DEVICES:
+        return _cu_scaled_default()
+    dev_default, dev_table = _DEVICES[key]
+    base = dict(dev_default) if dev_default is not None else _cu_scaled_default()
+    base.setdefault("schedule", None)
+    entry = dev_table.get((world_size, hidden_dim, topk))
+    if entry:
+        base["schedule"] = entry.get(dtype) or entry.get("fp8") or base["schedule"]
+    return base

--- a/op_tests/multigpu_tests/test_mega_moe.py
+++ b/op_tests/multigpu_tests/test_mega_moe.py
@@ -25,14 +25,15 @@ Launcher: torchrun (one process per rank / GPU), mirroring test_moe_layer_ep.py.
 Launch (4x gfx1250, must build CK-free on gfx1250 -> ENABLE_CK=0):
     cd <dir not under /app>   # avoid the /app/triton namespace shadow
     ENABLE_CK=0 AITER_FORCE_A8W4=1 AITER_USE_GROUPED_GEMM=1 AITER_BF16_FP8_MOE_BOUND=0 \
-    MORI_ROOT=/app/mori MORI_CCO_BC=<...>/libmori_cco_device.bc FLYDSL_GPU_ARCH=gfx1250 \
+    FLYDSL_GPU_ARCH=gfx1250 \
     torchrun --standalone --nproc_per_node=4 test_mega_moe.py \
       -q a8w4_mxfp4 -e 384 -k 6 -hd 7168 -id 3072 --layers 61
+    # cco v2 op-layer is vendored in aiter; only an installed mori (mori.cco) is
+    # required. Set MORI_CCO_BC to a prebuilt libmori_cco_device.bc to skip JIT.
 
 Env / CLI: --layers --logits_tol --acc_verify --dispatch_commu_dtype -m -hd -id -e -k --shared_E -q
 """
 import os
-import sys
 import argparse
 
 import torch
@@ -59,12 +60,11 @@ os.environ.setdefault("AITER_FORCE_A8W4", "1")
 os.environ.setdefault("AITER_USE_GROUPED_GEMM", "1")
 os.environ.setdefault("AITER_BF16_FP8_MOE_BOUND", "0")
 
-# mori v2 (dispatch_combine_v2) lives outside the aiter tree; import by top-level
-# module name after inserting its dir on sys.path. MORI_ROOT is the mori checkout.
-MORI_ROOT = os.environ.get("MORI_ROOT", "/home/yashao/mori")
-os.environ.setdefault(
-    "MORI_CCO_BC", os.path.join(MORI_ROOT, "lib", "libmori_cco_device.bc")
-)
+# The cco v2 dispatch/combine op-layer is vendored into aiter
+# (aiter.ops.flydsl.dispatch_combine_v2). Only the cco comm substrate stays an
+# installed-mori dependency (mori.cco.Communicator + libmori_cco*.{so,bc}).
+# MORI_CCO_BC optionally points at a prebuilt libmori_cco_device.bc; when unset,
+# cco JIT-compiles the device bitcode on first use.
 os.environ.setdefault("FLYDSL_GPU_ARCH", get_gfx())
 
 _FP8_DTYPE = dtypes.fp8
@@ -74,14 +74,25 @@ _FP8_KEYS = ("per_Token", "per_128x128")
 
 
 def _import_mori_v2():
-    """Import the mori v2 op-layer + cco helpers (compiles FlyDSL on first use)."""
-    sys.path.insert(
-        0, os.path.join(MORI_ROOT, "python", "mori", "ops", "dispatch_combine_v2")
-    )
-    sys.path.insert(0, os.path.join(MORI_ROOT, "examples", "cco", "python"))
+    """Import the vendored cco v2 op-layer (compiles FlyDSL on first use).
+
+    The dispatch/combine op + kernels are vendored into aiter
+    (aiter.ops.flydsl.dispatch_combine_v2). Only the cco communication substrate
+    (mori.cco.Communicator + libmori_cco*.{so,bc}) stays an installed-mori dep.
+    set_device / sync are inlined here on torch (they were trivial hip wrappers).
+    """
     from mori.cco import Communicator
-    from cco_example_common import set_device, sync
-    from dispatch_combine_op import EpDispatchCombineConfig, EpDispatchCombineOp
+    from aiter.ops.flydsl.dispatch_combine_v2 import (
+        EpDispatchCombineConfig,
+        EpDispatchCombineOp,
+    )
+
+    def set_device(rank: int) -> None:
+        gpu = int(os.environ.get("CCO_GPU", rank % torch.cuda.device_count()))
+        torch.cuda.set_device(gpu)
+
+    def sync() -> None:
+        torch.cuda.synchronize()
 
     return Communicator, set_device, sync, EpDispatchCombineConfig, EpDispatchCombineOp
 


### PR DESCRIPTION
Move mori's cco-based EP dispatch/combine op + FlyDSL kernels into aiter/ops/flydsl/dispatch_combine_v2/ so gfx1250 kernel dev happens in aiter. test_mega_moe.py imports from the vendored package instead of a MORI_ROOT sys.path hack; set_device/sync inlined on torch. The cco comm substrate (mori.cco.Communicator + libmori_cco*.{so,bc}) remains an installed-mori runtime dependency.

