### PR TITLE
[OPUS] Skip split-K workspace prewarm for non-split-K kids

### DIFF
--- a/aiter/ops/opus/gemm_op_a16w16.py
+++ b/aiter/ops/opus/gemm_op_a16w16.py
@@ -280,12 +280,35 @@ def _opus_gemm_bf16_dispatch(
 
 # ---- High-level shape-driven API -----------------------------------------
 
-# splitk kids (200..299) main kernel only has the <fp32_t> instantiation
-# (traits static_assert D_C==float, fp32 workspace). The reduce kernel
+# splitk kids main kernel only has the <fp32_t> instantiation (traits
+# static_assert D_C==float, fp32 workspace). The reduce kernel
 # (splitk_reduce_kernel) is templated on D_OUT and dispatches to either
 # __bf16 or float at launch time based on Y.dtype(), so both bf16 and fp32
-# outputs are valid. Kept here only as a documentation anchor; the dispatch
-# code below no longer needs to special-case Y.dtype against splitk kids.
+# outputs are valid. The dispatch code below no longer needs to special-case
+# Y.dtype against splitk kids.
+#
+# splitk kid ranges, one half-open [lo, hi) interval per device family. Kept
+# in exact lockstep with the C++ authority `opus_kid_is_splitk` in
+# csrc/opus_gemm/opus_gemm.cu -- adding a new device's splitk band means
+# appending one row HERE and there. Consumed by is_splitk_kid() below, which
+# gates the split-K workspace prewarm in aiter/tuned_gemm.py (non-splitk kids
+# never touch the workspace, so warming it for them is pure waste).
+_SPLITK_KID_RANGES = (
+    (200, 300),  # gfx950 base
+    (1200, 1300),  # gfx950 non-OOB mirror (+1000)
+    (10200, 10300),  # gfx942 (+10000)
+    (20000, 21000),  # gfx1250 cluster/TDM split-K
+)
+
+
+def is_splitk_kid(kid: int) -> bool:
+    """True iff `kid` selects a split-K opus a16w16 kernel (fp32 workspace +
+    reduce). Mirrors C++ `opus_kid_is_splitk`; keep the two in sync."""
+    kid = int(kid)
+    return any(lo <= kid < hi for lo, hi in _SPLITK_KID_RANGES)
+
+
+# Back-compat: the old gfx950-only single-band constants some callers imported.
 _SPLITK_KID_MIN = 200
 _SPLITK_KID_MAX = 299
 
@@ -533,4 +556,5 @@ __all__ = [
     "opus_gemm_a16w16_tune",
     "gemm_a16w16_opus",
     "opus_gemm_workspace_init",
+    "is_splitk_kid",
 ]

--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -44,9 +44,11 @@ try:
     from aiter.ops.opus.gemm_op_a16w16 import (
         opus_gemm_workspace_init as _opus_workspace_init,
     )
+    from aiter.ops.opus.gemm_op_a16w16 import is_splitk_kid as _opus_is_splitk_kid
 except Exception:
     _opus_tune = None
     _opus_workspace_init = None
+    _opus_is_splitk_kid = None
 
 # Every opus split-K arch (gfx950 / gfx942 / gfx1250) owns a per-stream fp32
 # workspace (process-global `opus_splitk_ws_get` registry, backed by raw
@@ -92,9 +94,15 @@ def _opus_prewarm_capture_workspace(inp, weights, solidx, splitK, bias, otype):
     """Eagerly size the opus split-K workspace on the graph capture stream.
 
     No-op when already capturing (too late to allocate), on non-registry archs,
-    or when this (shape, kid, splitK, bias) was already warmed.
+    for a non-split-K kid (never touches the workspace), or when this
+    (shape, kid, splitK, bias) was already warmed.
     """
     if not _opus_needs_ws_prewarm():
+        return
+    # Only split-K kids allocate/read the fp32 workspace; every other kid family
+    # (flatmm / persistent / mono_tile / nosplit) launches straight to its kernel
+    # and never touches the registry, so warming it for them is pure waste.
+    if _opus_is_splitk_kid is not None and not _opus_is_splitk_kid(solidx):
         return
     if torch.cuda.is_current_stream_capturing():
         return


### PR DESCRIPTION
gemm_a16w16 -> opus_gemm always called _opus_prewarm_capture_workspace, which registered and warmed the per-stream fp32 split-K workspace even when the selected kid was a non-split-K family (flatmm / persistent / mono_tile / nosplit) whose C++ launcher never touches the workspace.

Add is_splitk_kid() driven by a per-device-family range table kept in lockstep with C++ opus_kid_is_splitk, and gate the prewarm on it so only kids that actually use the workspace pay the one-time warm cost.
