### PR TITLE
[Triton] Enable conv2d Triton kernels for gfx1100 (RDNA3) and gfx1151 (RDNA3.5)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/conv/conv_1x1.py
+++ b/aiter/ops/triton/_triton_kernels/conv/conv_1x1.py
@@ -207,6 +207,32 @@ AUTOTUNE_1x1_CONFIGS = [
         num_warps=4,
         num_stages=1,
     ),
+    # gfx1100 (RDNA3): smaller tiles / fewer warps for the many small conv shapes.
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 32, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
 ]
 
 

--- a/aiter/ops/triton/_triton_kernels/conv/conv_3x3.py
+++ b/aiter/ops/triton/_triton_kernels/conv/conv_3x3.py
@@ -347,6 +347,27 @@ AUTOTUNE_3x3_NHWC_CONFIGS = [
         num_warps=4,
         num_stages=1,
     ),
+    # gfx1100 (RDNA3): smaller tiles / fewer warps.
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
 ]
 
 AUTOTUNE_3x3_CBLOCKED_CONFIGS = [
@@ -373,6 +394,28 @@ AUTOTUNE_3x3_CBLOCKED_CONFIGS = [
     triton.Config(
         {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64, "GROUP_SIZE_M": 8},
         num_warps=8,
+        num_stages=1,
+    ),
+    # gfx1100 (RDNA3): smaller tiles / fewer warps. BLOCK_K kept <= Cb (64) to
+    # preserve coalesced channel loads (see DESIGN.md §5.3).
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
         num_stages=1,
     ),
 ]

--- a/aiter/ops/triton/_triton_kernels/conv/conv_3x3_winograd_f4x3.py
+++ b/aiter/ops/triton/_triton_kernels/conv/conv_3x3_winograd_f4x3.py
@@ -1102,16 +1102,36 @@ AUTOTUNE_WINO_GEMM_CONFIGS = [
         num_warps=4,
         num_stages=1,
     ),
+    # gfx1100 (RDNA3): smaller tiles / fewer warps for small-T buckets.
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
 ]
 
 AUTOTUNE_WINO4_INPUT_CONFIGS = [
     triton.Config({"BLOCK_C": 64}, num_warps=4, num_stages=1),
     triton.Config({"BLOCK_C": 32}, num_warps=4, num_stages=1),
+    # gfx1100 (RDNA3): wider channel tile + a warp-8 option.
+    triton.Config({"BLOCK_C": 128}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_C": 64}, num_warps=8, num_stages=1),
+    triton.Config({"BLOCK_C": 16}, num_warps=4, num_stages=1),
 ]
 
 AUTOTUNE_WINO4_OUTPUT_CONFIGS = [
     triton.Config({"BLOCK_K": 64}, num_warps=4, num_stages=1),
     triton.Config({"BLOCK_K": 128}, num_warps=4, num_stages=1),
+    # gfx1100 (RDNA3): BLOCK_K=128 pegged the old ceiling on 17/19 shapes —
+    # probe larger, plus warp-8 options.
+    triton.Config({"BLOCK_K": 256}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_K": 128}, num_warps=8, num_stages=1),
+    triton.Config({"BLOCK_K": 256}, num_warps=8, num_stages=1),
 ]
 
 

--- a/aiter/ops/triton/_triton_kernels/conv/conv_general.py
+++ b/aiter/ops/triton/_triton_kernels/conv/conv_general.py
@@ -202,6 +202,22 @@ AUTOTUNE_GENERAL_CONFIGS = [
         num_warps=4,
         num_stages=1,
     ),
+    # gfx1100 (RDNA3): smaller tiles / fewer warps.
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=2,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
+    triton.Config(
+        {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "GROUP_SIZE_M": 4},
+        num_warps=4,
+        num_stages=1,
+    ),
 ]
 
 

--- a/aiter/ops/triton/configs/conv/gfx1100-CONV-1X1.json
+++ b/aiter/ops/triton/configs/conv/gfx1100-CONV-1X1.json
@@ -1,0 +1,196 @@
+{
+    "shapes": {
+        "N=1,C=1024,H=14,W=14,K=2048,R=1,S=1,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=1024,H=14,W=14,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=1024,H=14,W=14,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=256,W=256,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=2048,H=7,W=7,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=1024,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=56,W=56,K=128,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=56,W=56,K=512,R=1,S=1,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=56,W=56,K=64,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=32,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=28,W=28,K=1024,R=1,S=1,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=28,W=28,K=128,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=28,W=28,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=2048,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=64,W=64,K=64,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_262144": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1100-CONV-3X3-CBLOCKED.json
+++ b/aiter/ops/triton/configs/conv/gfx1100-CONV-3X3-CBLOCKED.json
@@ -1,0 +1,276 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=513,W=513,K=128,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=56,W=56,K=128,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=257,W=257,K=256,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=28,W=28,K=256,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=3,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=129,W=129,K=512,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=14,W=14,K=512,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_16384": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_65536": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_262144": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1100-CONV-3X3-NHWC.json
+++ b/aiter/ops/triton/configs/conv/gfx1100-CONV-3X3-NHWC.json
@@ -1,0 +1,268 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=513,W=513,K=128,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=56,W=56,K=128,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=257,W=257,K=256,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=28,W=28,K=256,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=3,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=129,W=129,K=512,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=14,W=14,K=512,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_65536": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_262144": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1100-CONV-GENERAL.json
+++ b/aiter/ops/triton/configs/conv/gfx1100-CONV-GENERAL.json
@@ -1,0 +1,20 @@
+{
+    "shapes": {
+        "N=1,C=3,H=224,W=224,K=64,R=7,S=7,sh=2,sw=2,ph=3,pw=3,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1100-CONV-WINO-F4X3-GEMM.json
+++ b/aiter/ops/triton/configs/conv/gfx1100-CONV-WINO-F4X3-GEMM.json
@@ -1,0 +1,212 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_4": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_16384": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1100-CONV-WINO-F4X3-INPUT.json
+++ b/aiter/ops/triton/configs/conv/gfx1100-CONV-WINO-F4X3-INPUT.json
@@ -1,0 +1,114 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 32,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_4": {
+        "BLOCK_C": 32,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_C": 64,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_C": 128,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1100-CONV-WINO-F4X3-OUTPUT.json
+++ b/aiter/ops/triton/configs/conv/gfx1100-CONV-WINO-F4X3-OUTPUT.json
@@ -1,0 +1,114 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_4": {
+        "BLOCK_K": 256,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_K": 128,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_K": 256,
+        "num_warps": 8,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1151-CONV-1X1.json
+++ b/aiter/ops/triton/configs/conv/gfx1151-CONV-1X1.json
@@ -1,0 +1,228 @@
+{
+    "shapes": {
+        "N=1,C=1024,H=14,W=14,K=2048,R=1,S=1,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=1024,H=14,W=14,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=1024,H=14,W=14,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=256,W=256,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=2048,H=7,W=7,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=1024,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=56,W=56,K=128,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=56,W=56,K=512,R=1,S=1,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=56,W=56,K=64,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=32,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=28,W=28,K=1024,R=1,S=1,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=28,W=28,K=128,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=28,W=28,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=2048,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=256,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=64,W=64,K=64,R=1,S=1,sh=1,sw=1,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_16384": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1
+    },
+    "M_LEQ_262144": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1151-CONV-3X3-CBLOCKED.json
+++ b/aiter/ops/triton/configs/conv/gfx1151-CONV-3X3-CBLOCKED.json
@@ -1,0 +1,268 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=513,W=513,K=128,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=56,W=56,K=128,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=257,W=257,K=256,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=28,W=28,K=256,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=3,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=129,W=129,K=512,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=14,W=14,K=512,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_65536": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_262144": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1151-CONV-3X3-NHWC.json
+++ b/aiter/ops/triton/configs/conv/gfx1151-CONV-3X3-NHWC.json
@@ -1,0 +1,268 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=513,W=513,K=128,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=56,W=56,K=128,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=257,W=257,K=256,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=28,W=28,K=256,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=3,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=129,W=129,K=512,R=3,S=3,sh=2,sw=2,ph=0,pw=0,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=14,W=14,K=512,R=3,S=3,sh=2,sw=2,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 32,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_16384": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_65536": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1151-CONV-GENERAL.json
+++ b/aiter/ops/triton/configs/conv/gfx1151-CONV-GENERAL.json
@@ -1,0 +1,20 @@
+{
+    "shapes": {
+        "N=1,C=3,H=224,W=224,K=64,R=7,S=7,sh=2,sw=2,ph=3,pw=3,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1151-CONV-WINO-F4X3-GEMM.json
+++ b/aiter/ops/triton/configs/conv/gfx1151-CONV-WINO-F4X3-GEMM.json
@@ -1,0 +1,188 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 2,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_M": 32,
+            "BLOCK_N": 64,
+            "BLOCK_K": 64,
+            "GROUP_SIZE_M": 4,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_4": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_16384": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1151-CONV-WINO-F4X3-INPUT.json
+++ b/aiter/ops/triton/configs/conv/gfx1151-CONV-WINO-F4X3-INPUT.json
@@ -1,0 +1,124 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 64,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 32,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 16,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 32,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_C": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_64": {
+        "BLOCK_C": 128,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_C": 32,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_C": 64,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_16384": {
+        "BLOCK_C": 128,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_C": 64,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/configs/conv/gfx1151-CONV-WINO-F4X3-OUTPUT.json
+++ b/aiter/ops/triton/configs/conv/gfx1151-CONV-WINO-F4X3-OUTPUT.json
@@ -1,0 +1,124 @@
+{
+    "shapes": {
+        "N=1,C=128,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=28,W=28,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=128,H=512,W=512,K=3,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=16,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=14,W=14,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=128,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=256,H=512,W=512,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=32,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=128,W=128,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=256,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=256,W=256,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=32,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 4,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=64,W=64,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=512,H=7,W=7,K=512,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 128,
+            "num_warps": 8,
+            "num_stages": 1
+        },
+        "N=1,C=64,H=56,W=56,K=64,R=3,S=3,sh=1,sw=1,ph=1,pw=1,dh=1,dw=1": {
+            "BLOCK_K": 256,
+            "num_warps": 8,
+            "num_stages": 1
+        }
+    },
+    "M_LEQ_16": {
+        "BLOCK_K": 128,
+        "num_warps": 8,
+        "num_stages": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_K": 128,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_K": 256,
+        "num_warps": 8,
+        "num_stages": 1
+    },
+    "M_LEQ_16384": {
+        "BLOCK_K": 128,
+        "num_warps": 8,
+        "num_stages": 1
+    },
+    "any": {
+        "BLOCK_K": 256,
+        "num_warps": 8,
+        "num_stages": 1
+    }
+}

--- a/op_tests/triton_tests/conv/_helpers.py
+++ b/op_tests/triton_tests/conv/_helpers.py
@@ -102,7 +102,8 @@ def apply_activation(y: torch.Tensor, activation: str):
 # correctness tests can run on CDNA hardware without being skipped.
 # AITER Triton CI relies on CDNA runners.
 SUPPORTED_ARCHS = {
-    "RDNA": {"gfx1200", "gfx1201", "gfx1250"},
+    "RDNA": {"gfx1100", "gfx1200", "gfx1201", "gfx1250"},
+
     "CDNA": {"gfx942", "gfx950"},
 }
 

--- a/op_tests/triton_tests/conv/_helpers.py
+++ b/op_tests/triton_tests/conv/_helpers.py
@@ -102,8 +102,7 @@ def apply_activation(y: torch.Tensor, activation: str):
 # correctness tests can run on CDNA hardware without being skipped.
 # AITER Triton CI relies on CDNA runners.
 SUPPORTED_ARCHS = {
-    "RDNA": {"gfx1100", "gfx1200", "gfx1201", "gfx1250"},
-
+    "RDNA": {"gfx1100", "gfx1151", "gfx1200", "gfx1201", "gfx1250"},
     "CDNA": {"gfx942", "gfx950"},
 }
 


### PR DESCRIPTION
## Motivation
 Extends the Triton conv2d operator to two more RDNA targets:

  - **gfx1100** —  RDNA3 
  - **gfx1151** —  RDNA3.5 

  Previously the conv2d path only recognized RDNA4 (gfx1200/gfx1201) on the RDNA
  side. This PR adds the two arches to the supported set and ships per-arch tuned
  config JSONs for all five conv2d kernels, so both GPUs get shape-appropriate
  tile configs instead of falling through / being rejected.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
