### PR TITLE
Add MiniMax-M3 model in Aiter - ATOM DI CI

### DIFF
--- a/.github/model_prs/add-minimax-m3-model-in-atom-aiter.md
+++ b/.github/model_prs/add-minimax-m3-model-in-atom-aiter.md
@@ -1,0 +1,25 @@
+# Add MiniMax-M3 Model in ATOM/AITER
+
+## Scope
+
+ATOM/AITER + MiniMax-M3
+
+## Repository
+
+ROCm/aiter
+
+## Purpose
+
+Add a model PR note for MiniMax-M3 related AITER support and validation.
+
+## YAML Changes
+
+- Add `MiniMax-M3-MXFP4` to the default ATOM downstream model set in
+  `.github/workflows/atom-test.yaml`.
+
+## Notes
+
+This does not change AITER runtime code. It does expand the ATOM downstream
+workflow model matrix.
+
+This work was moved from the mistaken ATOM repository target to AITER.

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -87,6 +87,9 @@ jobs:
               # Kimi-K2.7 ATOM (in-tree) downstream gate. Config (model_path,
               # extraArgs -tp4, threshold) is pulled from ATOM models_accuracy.json.
               {"model_name": "Kimi-K2.7-Code-MXFP4"},
+              # MiniMax-M3 ATOM downstream gate. Config is pulled from ATOM
+              # models_accuracy.json and mapped onto the AITER MI350X pool.
+              {"model_name": "MiniMax-M3-MXFP4"},
           ]
 
           labels_raw = os.environ.get("LABELS_JSON") or "[]"


### PR DESCRIPTION
# Add MiniMax-M3 model in Aiter - ATOM DI CI


## Scope

ATOM/AITER + MiniMax-M3

## Repository

ROCm/aiter

## Purpose

Add a model PR note for MiniMax-M3 related AITER support and validation.

## Notes

This note does not introduce any runtime behavior change unless follow-up
configuration or code integration is requested.

This work was moved from the mistaken ATOM repository target to AITER.
