### PR TITLE
Add Kimi-K2.6 model in Aiter - vLLM DI CI

### DIFF
--- a/.github/model_prs/add-kimi-k26-model-in-vllm.md
+++ b/.github/model_prs/add-kimi-k26-model-in-vllm.md
@@ -1,0 +1,18 @@
+# Add Kimi-K2.6 Model in vLLM
+
+- Scope: vLLM + Kimi-K2.6
+- Repository: ROCm/aiter
+- Model: Kimi-K2.6-MXFP4
+- Image: vllm/vllm-openai-rocm:v0.23.0
+- Router type: vllm-router
+- RUN_AFTER_HEALTH: accuracy
+- Co-author: lcskrishna <lollachaitanya@gmail.com>
+- YAML change: add `Kimi-K2.6-MXFP4` to the vLLM benchmark matrix in `.github/workflows/vllm_benchmark.yaml`.
+- Note: no AITER runtime code change unless follow-up integration is requested.
+- Migration note: moved from the mistaken ATOM repo target to AITER.
+
+Provided command:
+
+```bash
+IMAGE=vllm/vllm-openai-rocm:v0.23.0 MODEL_NAME=Kimi-K2.6-MXFP4 NODES=2 GPUS_PER_NODE=8 WIDE_EP_MODE=0 MORIIO_READ_MODE=0 RUN_AFTER_HEALTH=accuracy ROUTER_TYPE=vllm-router WAIT=1 SLURM_TIME_LIMIT=08:30:00 bash .buildkite/amd-disagg/run-slurm-disagg-test.sh &
+```

--- a/.github/model_prs/add-kimi-k26-model-in-vllm.md
+++ b/.github/model_prs/add-kimi-k26-model-in-vllm.md
@@ -7,7 +7,9 @@
 - Router type: vllm-router
 - RUN_AFTER_HEALTH: accuracy
 - Co-author: lcskrishna <lollachaitanya@gmail.com>
-- YAML change: add `Kimi-K2.6-MXFP4` to the vLLM benchmark matrix in `.github/workflows/vllm_benchmark.yaml`.
+- YAML changes:
+  - Add `Kimi-K2.6-MXFP4` to the vLLM benchmark matrix in `.github/workflows/vllm_benchmark.yaml`.
+  - Point `.github/workflows/vllm-disagg-ci-smoke-workflow.yaml` at the vLLM disagg config that defines `Kimi-K2.6-MXFP4`.
 - Note: no AITER runtime code change unless follow-up integration is requested.
 - Migration note: moved from the mistaken ATOM repo target to AITER.
 

--- a/.github/workflows/vllm-disagg-ci-smoke-workflow.yaml
+++ b/.github/workflows/vllm-disagg-ci-smoke-workflow.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     # Nightly vLLM DI smoke run, 2:30 AM Beijing Time (UTC+8).
     - cron: '30 18 * * *'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+    paths:
+      - ".github/workflows/vllm-disagg-ci-smoke-workflow.yaml"
   workflow_dispatch:
     inputs:
       vllm_repository:

--- a/.github/workflows/vllm-disagg-ci-smoke-workflow.yaml
+++ b/.github/workflows/vllm-disagg-ci-smoke-workflow.yaml
@@ -10,17 +10,17 @@ on:
         description: "vLLM repository to clone"
         required: false
         type: string
-        default: "itej89/vllm"
+        default: "lcskrishna/vllm"
       vllm_ref:
-        description: "vLLM branch/ref with lcskrishna/vllm PR #5 changes"
+        description: "vLLM branch/ref with Kimi K2.6 disagg model config"
         required: false
         type: string
-        default: "fix/moriio-ep8-dp8-read-rdma-session-routing"
+        default: "3e90fd20a48f6b42c395224f10a7793117bf65a6"
       model_name:
         description: "MODEL_NAME passed to run_xPyD disagg Slurm script"
         required: false
         type: string
-        default: "DeepSeek-V3"
+        default: "Kimi-K2.6-MXFP4"
       disagg_scripts_stage:
         description: "DISAGG_SCRIPTS_STAGE visible to Spur login and compute nodes"
         required: false
@@ -30,7 +30,7 @@ on:
         description: "Optional comma-separated Spur nodes for the 2-node smoke job"
         required: false
         type: string
-        default: "ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16"
+        default: "ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15"
       image:
         description: "Docker image passed to run_xPyD disagg Slurm script"
         required: false
@@ -59,9 +59,9 @@ jobs:
     runs-on: [self-hosted, aiter-di-ci-spur-login-vllm]
     timeout-minutes: 480
     env:
-      VLLM_REPOSITORY_DEFAULT: itej89/vllm
-      VLLM_REF_DEFAULT: fix/moriio-ep8-dp8-read-rdma-session-routing
-      MODEL_NAME_DEFAULT: DeepSeek-V3
+      VLLM_REPOSITORY_DEFAULT: lcskrishna/vllm
+      VLLM_REF_DEFAULT: 3e90fd20a48f6b42c395224f10a7793117bf65a6
+      MODEL_NAME_DEFAULT: Kimi-K2.6-MXFP4
       DISAGG_SCRIPTS_STAGE_DEFAULT: /data/xinhuang/vllm-disagg-logs/
       SPUR_NODELIST_DEFAULT: ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15
       IMAGE_DEFAULT: vllm/vllm-openai-rocm:v0.23.0
@@ -160,6 +160,19 @@ jobs:
           cd "${workdir}"
 
           script="${SLURM_SCRIPT}"
+          if [[ -f models.yaml ]]; then
+            echo "models.yaml entries matching MODEL_NAME=${MODEL_NAME}:"
+            if ! grep -nF "${MODEL_NAME}" models.yaml; then
+              echo "MODEL_NAME=${MODEL_NAME} was not found in models.yaml" >&2
+              echo "Known model-like models.yaml lines:" >&2
+              grep -nE '(^[[:space:]]{0,2}[A-Za-z0-9_.-]+:|name:)' models.yaml \
+                | head -120 >&2 || true
+              exit 1
+            fi
+          else
+            echo "No models.yaml found under ${PWD}; continuing with ${script}"
+          fi
+
           if [[ ! -f "${script}" ]]; then
             for candidate in run_xPyD_disagg.slurm run_xPyD_diagg.slurm; do
               if [[ -f "${candidate}" ]]; then

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -140,6 +140,13 @@ jobs:
               --tokenizer-mode deepseek_v4
               --reasoning-parser deepseek_v4
             extra_env_args: ""
+          - model: Kimi-K2.6-MXFP4
+            runner: linux-aiter-do-mi350x-8
+            kv_cache_dtype: default_kvcache
+            tp: 8
+            extra_args: >-
+              --moe-backend aiter
+            extra_env_args: ""
           - model: amd/MiniMax-M3-MXFP4
             runner: linux-aiter-do-mi350x-8
             kv_cache_dtype: default_kvcache


### PR DESCRIPTION
# Add Kimi-K2.6 Model in Aiter - vLLM DI CI

- Scope: vLLM + Kimi-K2.6
- Repository: ROCm/aiter
- Model: Kimi-K2.6-MXFP4
- Image: vllm/vllm-openai-rocm:v0.23.0
- Router type: vllm-router
- RUN_AFTER_HEALTH: accuracy
- Co-author: lcskrishna <lollachaitanya@gmail.com>
- Note: no runtime behavior change unless follow-up integration is requested.
- Migration note: moved from the mistaken ATOM repo target to AITER.

Provided command:

```bash
IMAGE=vllm/vllm-openai-rocm:v0.23.0 MODEL_NAME=Kimi-K2.6-MXFP4 NODES=2 GPUS_PER_NODE=8 WIDE_EP_MODE=0 MORIIO_READ_MODE=0 RUN_AFTER_HEALTH=accuracy ROUTER_TYPE=vllm-router WAIT=1 SLURM_TIME_LIMIT=08:30:00 bash .buildkite/amd-disagg/run-slurm-disagg-test.sh &
```
