### PR TITLE
mhc bf16 compute optimize on gfx12xx

### DIFF
--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -313,6 +313,7 @@ def mhc_pre_fake(
     sinkhorn_repeat: int = 20,  # if 0, only do pre for hc_head
     norm_weight: Optional[torch.Tensor] = None,
     norm_eps: float = 1e-6,
+    large_m_splitk: bool = False,
     is_fn_pack_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -20,8 +20,25 @@ def mhc_pre_gemm_sqrsum(
     x: Tensor,
     fn: Tensor,
     tile_k: int = 128,  # 64 or 128
-    is_fn_pack_bf16: int = 0,
+    is_fn_pack_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
 ) -> None: ...
+
+
+@compile_ops("module_mhc")
+def mhc_pre_convert_fn(
+    fn_packed: Tensor,  # (hc_mult3, hc_hidden_size) int32 out
+    fn: Tensor,  # (hc_mult3, hc_hidden_size) fp32 in
+) -> None: ...
+
+
+def mhc_pre_convert_fn_ref(fn: torch.Tensor) -> torch.Tensor:
+    """Torch equivalent of the HIP ``mhc_pre_convert_fn`` kernel: pack fp32 fn into
+    int32 dwords (hi = bf16(fn) in [31:16], lo = bf16(fn - fp32(hi)) in [15:0])."""
+    hi = fn.to(torch.bfloat16)
+    lo = (fn - hi.to(torch.float32)).to(torch.bfloat16)
+    hi_bits = hi.view(torch.int16).to(torch.int32) & 0xFFFF
+    lo_bits = lo.view(torch.int16).to(torch.int32) & 0xFFFF
+    return ((hi_bits << 16) | lo_bits).to(torch.int32).contiguous()
 
 
 @compile_ops("module_mhc")
@@ -322,7 +339,7 @@ def mhc_pre(
     norm_weight: Optional[torch.Tensor] = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_fn_pack_bf16: int = 0,
+    is_fn_pack_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -342,6 +359,7 @@ def mhc_pre(
     )
     out = out_pad[:, :, :hc_mult3]
     sqrsum = torch.empty(selected_splitk, m, dtype=dtypes.fp32, device=device)
+    # is_fn_pack_bf16=1: fn is the pre-packed int32 tensor (bf16 hi/lo MFMA path).
     mhc_pre_gemm_sqrsum(out, sqrsum, residual, fn, selected_tile_k, is_fn_pack_bf16)
     # out = out.sum(0)
     # sqrsum = sqrsum.sum(0)

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -191,44 +191,57 @@ def _mhc_fused_config_gfx942_80(m, hidden_size, num_cu):
 
 
 def _mhc_fused_config_gfx1250_256(m, hidden_size, num_cu):
-    tile_k = 32 if hidden_size % 32 == 0 else 64
-    valid = _mhc_fused_valid_splitk(hidden_size, tile_k, num_cu)
-    if not valid:
-        return 1, 16, 32, tile_k
+    # Re-tuned on gfx1250/256 for the bf16-packed GEMM path (is_fn_pack_bf16=1,
+    # wave32 bf16 WMMA) under the relaxed split_k constraint: prefetch now needs only
+    # >=1 k-tile per split (was *2), so split_k can go deeper. Measured per (m, hidden)
+    # with fn pre-packed to int32 (mhc_pre_convert_fn); see mhc_fused_post_pre_tuning.md.
+    #
+    # Unlike gfx950 (where tile_m=64 spills and loses), on the gfx1250 bf16 wave32 path
+    # tile_m=64 is the fastest at large m; tile_k=64 wins only at m~=1024,hidden>=7168.
+    # The optima are jagged in m (no clean analytic rule), so this is a measured lookup.
+    tile_n = 32  # tile_n=16 never wins
 
-    tile_n = 32
-    # Re-tuned on gfx1250/256 (TDM residual load): fn-reuse (tile_m=32) wins from
-    # m=512 up; m<=256 is launch-bound and stays on tile_m=16.
-    tile_m = 16 if m <= 256 else 32
-
-    # (m upper bound, target split_k) measured per (m, hidden) then merged; the
-    # target is snapped to a legal divisor below so it stays valid for any hidden.
-    # Mid/large m follows blocks_m*split_k ~= 4*cu (~128*cu/m); small m is
-    # launch-bound (high split_k, config barely matters); very large m goes deeper.
+    # (m upper bound, (target_split_k, tile_m, tile_k)); target_split_k is the REAL
+    # split_k (== gemm_out_sqrsum.size(0)), snapped to a legal divisor for the actual
+    # hidden_size below. Small m is launch-bound (deep split fills the device); the
+    # large-m tile_m=64 path is a ~2-wave fill (split_k ~= 32768/m). tile_k=64 wins only
+    # at m~=1024, hidden>=7168. Picked by a round-robin shootout (interleaved candidates,
+    # min over rounds) because back-to-back timing drifts thermally on this kernel.
     if hidden_size >= 7168:
         table = [
-            (128, 32),
-            (256, 32),
-            (512, 32),
-            (1024, 32),
-            (2048, 16),
-            (4096, 8),
-            (8192, 14),
-            (1 << 30, 7),
+            (128, (112, 16, 32)),
+            (256, (56, 16, 32)),
+            (512, (28, 32, 32)),
+            (1024, (16, 32, 64)),
+            (2048, (7, 32, 32)),
+            (4096, (8, 64, 32)),
+            (8192, (4, 64, 32)),
+            (1 << 30, (2, 64, 32)),
         ]
     else:
         table = [
-            (128, 64),
-            (256, 32),
-            (512, 32),
-            (1024, 32),
-            (2048, 16),
-            (4096, 8),
-            (8192, 8),
-            (1 << 30, 8),
+            (128, (64, 32, 32)),
+            (256, (64, 32, 32)),
+            (512, (32, 32, 32)),
+            (1024, (16, 32, 32)),
+            (2048, (4, 16, 32)),
+            (4096, (4, 64, 32)),
+            (8192, (2, 64, 32)),
+            (1 << 30, (4, 32, 32)),
         ]
-    target = next(t for ub, t in table if m <= ub)
-    splitk = min(valid, key=lambda s: (abs(math.log(s) - math.log(target)), -s))
+    target_sk, tile_m, tile_k = next(cfg for ub, cfg in table if m <= ub)
+
+    # tile_k must divide hidden_size; fall back to the other legal tile_k if not
+    # (and drop the un-instantiated tile_m=64 + tile_k=64 combo down to tile_m=16).
+    if hidden_size % tile_k != 0:
+        tile_k = 32 if tile_k == 64 else 64
+        if tile_m == 64 and tile_k == 64:
+            tile_m = 16
+
+    valid = _mhc_fused_valid_splitk(hidden_size, tile_k, num_cu, prefetch_stages=1)
+    if not valid:
+        return 1, 16, tile_n, tile_k
+    splitk = min(valid, key=lambda s: (abs(math.log(s) - math.log(target_sk)), -s))
     return splitk, tile_m, tile_n, tile_k
 
 

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -10,9 +10,12 @@ namespace aiter {
 void mhc_pre_gemm_sqrsum(torch::Tensor& out,    // (split_k, m, hc_mult3) / (m, hc_mult3)
                          torch::Tensor& sqrsum, // (split_k, m) / (m)
                          torch::Tensor& x,      // (m, hc_hidden_size)
-                         torch::Tensor& fn,     // (hc_mult3, hc_hidden_size)
+                         torch::Tensor& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when is_fn_pack_bf16
                          int tile_k = 128,
                          int is_fn_pack_bf16 = 0);
+// Pre-convert fn (fp32) -> packed int32 (hi<<16 | lo) for the bf16 (is_fn_pack_bf16) gemm path.
+void mhc_pre_convert_fn(torch::Tensor& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
+                        torch::Tensor& fn);       // (hc_mult3, hc_hidden_size) fp32 in
 void mhc_pre_big_fuse(torch::Tensor& post_mix,        // (m, hc_mult)
                       torch::Tensor& comb_mix,        // (m, hc_mult * hc_mult)
                       torch::Tensor& layer_input,     // (m, hidden_size)

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2245,6 +2245,11 @@ namespace py = pybind11;
           py::arg("fn"),                        \
           py::arg("tile_k") = 128,              \
           py::arg("is_fn_pack_bf16") = 0);      \
+    m.def("mhc_pre_convert_fn",                 \
+          &aiter::mhc_pre_convert_fn,           \
+          "mhc_pre_convert_fn",                 \
+          py::arg("fn_packed"),                 \
+          py::arg("fn"));                       \
     m.def("mhc_pre_big_fuse",                   \
           &aiter::mhc_pre_big_fuse,             \
           "mhc_pre_big_fuse",                   \

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -2307,9 +2307,11 @@ namespace aiter {
         lds_load_residual_tile(0);
         v_fn0 = vgpr_load_fn_tile(0);
         __builtin_amdgcn_sched_barrier(0);
-        lds_load_x_tile(1);
-        lds_load_residual_tile(1);
-        v_fn1 = vgpr_load_fn_tile(1);
+        if (k_loop > 1) {
+            lds_load_x_tile(1);
+            lds_load_residual_tile(1);
+            v_fn1 = vgpr_load_fn_tile(1);
+        }
 
         float sqrsum_part[m_repeat];
         fp32xovec_t v_cf[m_repeat][repeat_n];
@@ -2571,8 +2573,8 @@ namespace aiter {
         dim3 grid(mb, n_blocks, split_k); \
         TORCH_CHECK(hidden_size % (tile_k * split_k) == 0, \
                     "hidden_size must be divisible by tile_k * split_k"); \
-        TORCH_CHECK(hidden_size >= (tile_k * split_k) * 2, \
-                    "hidden_size must be >= tile_k * split_k * 2 for prefetch"); \
+        TORCH_CHECK(hidden_size >= (tile_k * split_k), \
+                    "hidden_size must be >= tile_k * split_k (>=1 k-tile per split)"); \
         mhc_fused_post_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, 4, tile_m, tile_n, tile_k, store_nt, MHC_FUSED_BF16> \
             <<<grid, block, 0, stream>>>( \
                 reinterpret_cast<float*>(gemm_out_mul.data_ptr()), \

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -36,19 +36,6 @@ namespace aiter {
     static constexpr bool mhc_bf16_mma_avail = false;
 #endif
 
-    // Residual-load TDM completion helpers (mhc_fused_post_pre_gemm_sqrsum_kernel).
-    // On gfx1250 the residual tile is moved by the TDM engine and tracked by
-    // TENSORcnt (separate from load/async/ds counters). KEEP1 leaves the next
-    // prefetched stage in flight (<=2 inflight, within the <=3 budget); DRAIN
-    // waits for all residual TDMs. No-ops off gfx1250 (residual uses async_load).
-#if defined(__gfx1250__)
-#define MHC_TDM_KEEP1() opus::s_wait_tensorcnt(opus::number<1>{})
-#define MHC_TDM_DRAIN() opus::s_wait_tensorcnt(opus::number<0>{})
-#else
-#define MHC_TDM_KEEP1() ((void)0)
-#define MHC_TDM_DRAIN() ((void)0)
-#endif
-
     constexpr int ceil_pow2(int n) {
         if(n <= 1) return 1;
         int p = 1;
@@ -2220,31 +2207,6 @@ namespace aiter {
 
         static constexpr int tile_mk = tile_m * tile_k;
         static_assert(tile_mk % warp_size == 0, "tile_mk must be divisible by block_size");
-#if defined(__gfx1250__)
-        // ---- gfx1250 x (layer_input) load via TDM: a plain 2D tile ----
-        // x lands in LDS as row*tile_k + hidden (exactly what compute_store_tile
-        // reads); in global x[row][h] = row*x_stride + h. So a 2D TDM tile
-        // reproduces the async layout and leaves compute_store_tile unchanged:
-        //   dim0 = hidden (TileDim0 = tile_k, contiguous)
-        //   dim1 = row    (TileDim1 = tile_m,  stride = x_stride)
-        // Issued by warp 1 (residual is issued by warp 0), so each issuing wave
-        // keeps at most 2 TDM ops in flight (2-stage prefetch) -> still within the
-        // <=3 per-wave budget with both x and residual on TDM. tensor_dim1=m_oob
-        // gives free row OOB (out-of-range rows load 0), so no manual zero-fill and
-        // no async counter -> x is TENSORcnt-tracked, x_load_waitcnt = 0.
-        static constexpr int x_load_waitcnt = 0;
-        auto lds_load_x_tile = [&](int k){
-            if (warp_id == 1) {
-                opus::tdm_window<DTYPE_I, tile_k, tile_m> win;   // ndim=2, cpol=default_cpol=16
-                uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_x))
-                    + static_cast<uint32_t>((k & 1) * tile_mk * sizeof(DTYPE_I));
-                DTYPE_I* g = x_ptr + k_split_offset + k * tile_k;
-                // make(lds_addr, global_ptr, tensor_dim0, tensor_dim1, tensor_dim0_stride)
-                win.desc.make(lds, g, tile_k, m_oob, x_stride);
-                win.load_to_lds();
-            }
-        };
-#else
 #if defined(__gfx942__)
         static constexpr int x_async_load_vec = 4 / sizeof(DTYPE_I);
 #else
@@ -2279,42 +2241,7 @@ namespace aiter {
                 }
             }
         };
-#endif
 
-#if defined(__gfx1250__)
-        // ---- gfx1250 residual load via TDM (Tensor Data Mover) ----
-        // The residual tile is [head=hc_mult][row=tile_m][hidden=tile_k] and must
-        // land in LDS as h*tile_mk + row*tile_k + hidden (exactly what
-        // compute_store_tile reads), so a single 3D TDM tile reproduces the async
-        // layout and leaves compute_store_tile unchanged:
-        //   dim0 = hidden (TileDim0 = tile_k, contiguous)
-        //   dim1 = row    (TileDim1 = tile_m,  stride = residual_stride)
-        //   dim2 = head   (TileDim2 = hc_mult, stride = hidden_size)
-        // TDM writes dim0-fastest -> dim1 -> dim2, i.e. linear LDS index
-        //   dim2*(tile_m*tile_k) + dim1*tile_k + dim0 = h*tile_mk + row*tile_k + hidden.
-        // One TDM op per k-step; the 2-stage (n_stages) prefetch keeps at most 2
-        // in flight (<=3 inflight budget). tensor_dim1=m_oob gives free row OOB
-        // (out-of-range rows load 0). residual is TENSORcnt-tracked, so it no longer
-        // contributes to the async counter -> residual_load_waitcnt = 0.
-        static constexpr int residual_load_waitcnt = 0;
-        auto lds_load_residual_tile = [&](int k){
-            // TDM is a wave-level DMA (not per-lane, not EXEC-gated); a single wave
-            // issues one op that fills the whole all-head tile. Only warp 0 issues;
-            // the others see the data after the tensorcnt wait + workgroup barrier
-            // in wait_load_cnt(). Build the 3D descriptor by hand (tdm_window::make
-            // is 2D-only) and reuse the vetted load_to_lds() issue path (cpol=16).
-            if (warp_id == 0) {
-                opus::tdm_window<DTYPE_I, tile_k, tile_m, hc_mult> win;  // ndim=3, cpol=default_cpol=16
-                uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_residual))
-                    + static_cast<uint32_t>((k & 1) * (hc_mult * tile_mk) * sizeof(DTYPE_I));
-                DTYPE_I* g = residual_ptr + k_split_offset + k * tile_k;
-                // make(lds_addr, global_ptr, tensor_dim0, tensor_dim1, tensor_dim0_stride,
-                //      tensor_dim1_stride, lds_barrier_addr, tensor_dim2)
-                win.desc.make(lds, g, tile_k, m_oob, residual_stride, hidden_size, 0, hc_mult);
-                win.load_to_lds();
-            }
-        };
-#else
 #if defined(__gfx942__)
         static constexpr int r_async_load_vec = 4 / sizeof(DTYPE_I);
 #else
@@ -2346,8 +2273,7 @@ namespace aiter {
                 s_offset += s_offset_i;
             }
         };
-#endif
-        
+
         static constexpr int fn_load_vec = 16 / sizeof(float);
         static constexpr int fn_load_waitcnt = tile_n * tile_k / (warp_size * fn_load_vec);
         using fp32xfntile = opus::array<fp32xtile, repeat_n>;
@@ -2510,30 +2436,12 @@ namespace aiter {
             }
         };
 
-        // gfx9 only: x and residual share the async counter, so the "leave in flight"
-        // count is one stage's worth of async loads. On gfx1250 both x and residual
-        // are TDM (TENSORcnt), there are no async loads, and these are unused.
-        [[maybe_unused]] static constexpr int x_async_wait = mhc_async_load_oob_guard ? 0 : x_load_waitcnt + residual_load_waitcnt;
-        [[maybe_unused]] static constexpr int r_async_wait = mhc_async_load_oob_guard ? 0 : residual_load_waitcnt;
-#if defined(__gfx1250__)
+        // x and residual share the async counter; the "leave in flight" count is one
+        // stage's worth of async loads. On gfx1250 the OOB guard makes the per-stage
+        // async count data-dependent, so x_async_wait/r_async_wait drain to 0 there.
+        static constexpr int x_async_wait = mhc_async_load_oob_guard ? 0 : x_load_waitcnt + residual_load_waitcnt;
+        static constexpr int r_async_wait = mhc_async_load_oob_guard ? 0 : residual_load_waitcnt;
         auto wait_load_cnt = [&]() {
-            // x (warp 1) and residual (warp 0) are both TDM / TENSORcnt-tracked. Each
-            // issuing wave drains its current stage down to the single prefetch left in
-            // flight (KEEP1, per-wave counter; a no-op on the non-issuing warps), then
-            // the workgroup barrier publishes both tiles to all warps. fn stays on
-            // loadcnt; there are no async loads left, so the async count is -1
-            // (sentinel: suppress s_wait_asynccnt emission; 0 would emit a spurious
-            // s_wait_asynccnt 0).
-            MHC_TDM_KEEP1();
-            s_wait_all_loadcnt(opus::number<fn_load_waitcnt*2>{}, opus::number<-1>{});
-            __builtin_amdgcn_s_barrier();
-            s_wait_all_loadcnt(opus::number<fn_load_waitcnt>{}, opus::number<-1>{});
-        };
-#else
-        auto wait_load_cnt = [&]() {
-            // Ensure the current residual TDM stage is resident before the barrier
-            // below publishes it to all warps; leave the next prefetched stage in flight.
-            MHC_TDM_KEEP1();
             if(threadIdx.x < x_async_load_threads) {
                 s_wait_all_loadcnt(opus::number<fn_load_waitcnt*2>{}, opus::number<x_async_wait>{});
             }
@@ -2548,7 +2456,6 @@ namespace aiter {
                 s_wait_all_loadcnt(opus::number<fn_load_waitcnt>{}, opus::number<r_async_wait>{});
             }
         };
-#endif
 
         int i = 0;
         for(; i + 3 < k_loop ; i += 2) {
@@ -2579,19 +2486,16 @@ namespace aiter {
             }
             else {
                 s_wait_all_loadcnt(0_I, 0_I);
-                MHC_TDM_DRAIN();
                 __builtin_amdgcn_s_barrier();
             }
             compute_store_tile(i + 1, v_fn1);
             if (i + 2 < k_loop) {
                 s_wait_all_loadcnt(0_I, 0_I);
-                MHC_TDM_DRAIN();
                 __builtin_amdgcn_s_barrier();
                 compute_store_tile(i + 2, v_fn0);
             }
         } else if (i < k_loop) {
             s_wait_all_loadcnt(0_I, 0_I);
-            MHC_TDM_DRAIN();
             __builtin_amdgcn_s_barrier();
             compute_store_tile(i, v_fn0);
         }

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -947,6 +947,9 @@ namespace aiter {
             }
         }
 
+        const float hc_scale0 = hc_scale[0];
+        const float hc_base_v = hc_base[lane_id % hc_mult];
+
         if (threadIdx.x < num_rows * hc_mult3) {
             int row_idx = threadIdx.x / hc_mult3;
             int hc_idx = threadIdx.x % hc_mult3;
@@ -969,7 +972,7 @@ namespace aiter {
             float pre_mix_shared_v;
             if (lane_id < num_rows * hc_mult) {
                 pre_mix_shared_v = s_hc_mult3[lane_id / hc_mult * hc_mult3 + lane_id % hc_mult];
-                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale[0] + hc_base[lane_id % hc_mult]);
+                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale0 + hc_base_v);
                 pre_mix_shared_v += hc_pre_eps;
             }
             static_assert(warp_size % (num_rows * hc_mult) == 0, "warp_size must be divisible by num_rows * hc_mult");
@@ -1768,6 +1771,10 @@ namespace aiter {
             }
         }
 
+        const int pre_res_hc_id = (threadIdx.x % (pre_thread_num / num_rows)) % hc_mult;
+        const float hc_scale0 = hc_scale[0];
+        const float hc_base_v = hc_base[pre_res_hc_id];
+
         if (threadIdx.x < num_rows * hc_mult3) {
             int row_idx = threadIdx.x / hc_mult3;
             int hc_idx = threadIdx.x % hc_mult3;
@@ -1807,7 +1814,7 @@ namespace aiter {
             float pre_mix_shared_v = 0.0f;
             if (res_row_id < m_oob) {
                 pre_mix_shared_v = s_hc_mult3[res_row_id * hc_mult3 + res_hc_id];
-                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale[0] + hc_base[res_hc_id]);
+                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale0 + hc_base_v);
                 pre_mix_shared_v += hc_pre_eps;
             }
             

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -68,8 +68,48 @@ namespace aiter {
         ival = __builtin_bit_cast(int, val);
         val += __builtin_bit_cast(float,
             __builtin_amdgcn_ds_bpermute((lane_id ^ 16) * 4, ival));
-    
+
         return val;
+    }
+
+    // Pre-convert fn (fp32) into a packed dword: hi = bf16(fn) in [31:16], lo = bf16(fn -
+    // fp32(hi)) in [15:0]. Same 4-byte width as fp32 so the gemm's load / LDS / swizzle are
+    // unchanged; the bf16 gemm (is_fn_pack_bf16) then bit-extracts hi/lo instead of
+    // recomputing the fp32->bf16 split per (m_block, k) -- the split was redundant work
+    // repeated m_blocks times. fn are model weights (constant across forward passes), so
+    // this runs once and the packed int32 tensor is reused every forward.
+    template <typename DTYPE_I>
+    __global__ void mhc_pre_convert_fn_kernel(uint32_t* fn_packed, const float* fn, int64_t numel)
+    {
+        int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+        if (i >= numel) return;
+        float f = fn[i];
+        DTYPE_I hi = static_cast<DTYPE_I>(f);
+        DTYPE_I lo = static_cast<DTYPE_I>(f - static_cast<float>(hi));
+        uint32_t hi_bits = __builtin_bit_cast(uint16_t, hi);
+        uint32_t lo_bits = __builtin_bit_cast(uint16_t, lo);
+        fn_packed[i] = (hi_bits << 16) | lo_bits;
+    }
+
+    // The packed hi/lo are encoded as bf16 -- the activation/MFMA element type the gemm
+    // uses -- so the gemm's bit-extract round-trips.
+    void mhc_pre_convert_fn(
+        torch::Tensor& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
+        torch::Tensor& fn         // (hc_mult3, hc_hidden_size) fp32 in
+    )
+    {
+        TORCH_CHECK(fn.scalar_type() == at::kFloat, "fn must be fp32");
+        TORCH_CHECK(fn_packed.numel() == fn.numel(), "fn_packed and fn must have same numel");
+        int64_t numel = fn.numel();
+        const int block_size = 256;
+        int64_t grid = (numel + block_size - 1) / block_size;
+        const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(fn));
+        const hipStream_t stream = at::hip::getCurrentHIPStream();
+        using DTYPE_I = typename t2opus<c10::BFloat16>::type;
+        mhc_pre_convert_fn_kernel<DTYPE_I><<<grid, block_size, 0, stream>>>(
+            reinterpret_cast<uint32_t*>(fn_packed.data_ptr()),
+            reinterpret_cast<const float*>(fn.data_ptr()),
+            numel);
     }
 
 // Branch must match mma_pack_size (= warp_size == 64 ? 1 : 2): the MFMA path
@@ -422,12 +462,15 @@ namespace aiter {
                 _Pragma("unroll")                                                                 \
                 for (int n = 0; n < repeat_n; n++) {                                              \
                     opus::vector_t<opus::bf16_t, 8> fn_hi, fn_lo;                                 \
+                    /* fn is pre-packed (hi<<16|lo, from mhc_pre_convert_fn); bit-extract both */  \
+                    /* bf16, no fp32->bf16 split -- the redundant per-(m_block,k) work removed. */ \
                     _Pragma("unroll")                                                             \
-                    for (int e = 0; e < 8; e++) fn_hi[e] = opus::fp32_to_bf16(raw[n][e]);         \
+                    for (int e = 0; e < 8; e++) {                                                 \
+                        uint32_t bits = __builtin_bit_cast(uint32_t, raw[n][e]);                  \
+                        fn_hi[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));      \
+                        fn_lo[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));  \
+                    }                                                                             \
                     v_cf[n] = opus::mfma_f32_16x16x32_bf16{}(fn_hi, x_bf[c], v_cf[n]);            \
-                    _Pragma("unroll")                                                             \
-                    for (int e = 0; e < 8; e++)                                                   \
-                        fn_lo[e] = opus::fp32_to_bf16(raw[n][e] - opus::bf16_to_fp32(fn_hi[e]));  \
                     v_cf[n] = opus::mfma_f32_16x16x32_bf16{}(fn_lo, x_bf[c], v_cf[n]);            \
                     __builtin_amdgcn_sched_barrier(0);                                            \
                 }                                                                                 \
@@ -493,12 +536,14 @@ namespace aiter {
                 _Pragma("unroll")                                                                 \
                 for (int n = 0; n < repeat_n; n++) {                                              \
                     opus::vector_t<opus::bf16_t, 16> fn_hi, fn_lo;                                \
+                    /* fn is pre-packed (hi<<16|lo); bit-extract both bf16 -- no fp split. */      \
                     _Pragma("unroll")                                                             \
-                    for (int i = 0; i < 16; i++) fn_hi[i] = opus::fp32_to_bf16(raw[n][i]);        \
+                    for (int i = 0; i < 16; i++) {                                                \
+                        uint32_t bits = __builtin_bit_cast(uint32_t, raw[n][i]);                  \
+                        fn_hi[i] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));      \
+                        fn_lo[i] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));  \
+                    }                                                                             \
                     v_cf[n] = opus::wmma_f32_16x16x32_bf16{}(fn_hi, x_bf[c], v_cf[n]);            \
-                    _Pragma("unroll")                                                             \
-                    for (int i = 0; i < 16; i++)                                                  \
-                        fn_lo[i] = opus::fp32_to_bf16(raw[n][i] - opus::bf16_to_fp32(fn_hi[i]));  \
                     v_cf[n] = opus::wmma_f32_16x16x32_bf16{}(fn_lo, x_bf[c], v_cf[n]);            \
                     __builtin_amdgcn_sched_barrier(0);                                            \
                 }                                                                                 \
@@ -688,7 +733,7 @@ namespace aiter {
         torch::Tensor& out, // (split_k, m, hc_mult3) / (m, hc_mult3)
         torch::Tensor& sqrsum, // (split_k, m) / (m)
         torch::Tensor& x, // (m, hc_hidden_size)
-        torch::Tensor& fn, // (hc_mult3, hc_hidden_size)
+        torch::Tensor& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 (hi<<16|lo) when is_fn_pack_bf16
         int tile_k = 128,
         int is_fn_pack_bf16 = 0
     )
@@ -2395,14 +2440,15 @@ namespace aiter {
                         }
                         for(int n = 0; n < repeat_n; n++) {
                             opus::vector_t<opus::bf16_t, ds_read_vec> fn_hi8, fn_lo8;
+                            // fn is pre-packed (hi<<16|lo, from mhc_pre_convert_fn); bit-extract
+                            // both bf16 -- no fp32->bf16 split recomputed per (m_block, k).
                             for (int e = 0; e < ds_read_vec; e++) {
-                                fn_hi8[e] = opus::fp32_to_bf16(v_fn[n][e + j * ds_read_vec]);
+                                float fv = v_fn[n][e + j * ds_read_vec];
+                                uint32_t bits = __builtin_bit_cast(uint32_t, fv);
+                                fn_hi8[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));
+                                fn_lo8[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));
                             }
                             v_cf[b][n] = opus::mfma_f32_16x16x32_bf16{}(fn_hi8, res_bf, v_cf[b][n]);
-                            for (int e = 0; e < ds_read_vec; e++) {
-                                float f = v_fn[n][e + j * ds_read_vec];
-                                fn_lo8[e] = opus::fp32_to_bf16(f - opus::bf16_to_fp32(fn_hi8[e]));
-                            }
                             v_cf[b][n] = opus::mfma_f32_16x16x32_bf16{}(fn_lo8, res_bf, v_cf[b][n]);
                         }
 #elif defined(__gfx1250__)
@@ -2424,17 +2470,18 @@ namespace aiter {
                             }
                             for (int n = 0; n < repeat_n; n++) {
                                 opus::vector_t<opus::bf16_t, 16> fn_hi, fn_lo;
+                                // fn is pre-packed (hi<<16|lo); bit-extract both bf16 -- no fp split.
                                 for (int e = 0; e < ds_read_vec; e++) {
-                                    fn_hi[e]              = opus::fp32_to_bf16(v_fn[n][e + (j - 1) * ds_read_vec]);
-                                    fn_hi[ds_read_vec + e] = opus::fp32_to_bf16(v_fn[n][e + j * ds_read_vec]);
+                                    float fv0 = v_fn[n][e + (j - 1) * ds_read_vec];
+                                    float fv1 = v_fn[n][e + j * ds_read_vec];
+                                    uint32_t b0 = __builtin_bit_cast(uint32_t, fv0);
+                                    uint32_t b1 = __builtin_bit_cast(uint32_t, fv1);
+                                    fn_hi[e]               = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b0 >> 16));
+                                    fn_hi[ds_read_vec + e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b1 >> 16));
+                                    fn_lo[e]               = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b0 & 0xFFFFu));
+                                    fn_lo[ds_read_vec + e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b1 & 0xFFFFu));
                                 }
                                 v_cf[b][n] = opus::wmma_f32_16x16x32_bf16{}(fn_hi, res_bf, v_cf[b][n]);
-                                for (int e = 0; e < ds_read_vec; e++) {
-                                    float f0 = v_fn[n][e + (j - 1) * ds_read_vec];
-                                    float f1 = v_fn[n][e + j * ds_read_vec];
-                                    fn_lo[e]              = opus::fp32_to_bf16(f0 - opus::bf16_to_fp32(fn_hi[e]));
-                                    fn_lo[ds_read_vec + e] = opus::fp32_to_bf16(f1 - opus::bf16_to_fp32(fn_hi[ds_read_vec + e]));
-                                }
                                 v_cf[b][n] = opus::wmma_f32_16x16x32_bf16{}(fn_lo, res_bf, v_cf[b][n]);
                             }
                         }

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -552,8 +552,6 @@ def test_mhc_pre(
             layer_input_ref, layer_input_bf16, msg="layer_input(bf16)"
         )
         ret["hip_bf16_us"] = hip_bf16_us
-        if hip_us and hip_bf16_us:
-            ret["bf16_speedup"] = hip_us / hip_bf16_us
     if fuse_rmsnorm:
         ret["hip_nofuse_us"] = hip_nofuse_us
         ret["TB/s"] = (
@@ -900,8 +898,9 @@ def test_mhc_post_pre(
     ret["hip_fused_err"] = hip_fused_err
 
     # bf16 compute path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn,
-    # then run the fused kernel with is_fn_pack_bf16=1 so it bit-extracts hi/lo. gfx950 native
-    # bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.
+    # then run with is_fn_pack_bf16=1 so the gemm bit-extracts hi/lo. Exercised on BOTH the
+    # unfused and fused paths. gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED);
+    # other arches fall back to fp32.
     if fn_pack_bf16:
         from aiter.ops.mhc import mhc_pre_convert_fn
 
@@ -909,6 +908,36 @@ def test_mhc_post_pre(
             fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
         )
         mhc_pre_convert_fn(fn_packed, fn)
+
+        # unfused path (mhc_post + mhc_pre) with packed fn
+        (
+            post_mix_unfused_bf16,
+            comb_mix_unfused_bf16,
+            layer_input_unfused_bf16,
+            next_residual_unfused_bf16,
+        ), unfused_bf16_us = run_perftest(
+            mhc_post_pre_unfused_hip,
+            layer_input,
+            residual_in,
+            post_layer_mix,
+            comb_res_mix,
+            fn_packed,
+            hc_scale,
+            hc_base,
+            is_fn_pack_bf16=1,
+            **hip_kwargs,
+        )
+        ret["unfused_bf16_err"] = checkAllclose(
+            layer_input_ref, layer_input_unfused_bf16, msg="unfused/layer_input(bf16)"
+        )
+        checkAllclose(
+            next_residual_ref,
+            next_residual_unfused_bf16,
+            msg="unfused/next_residual(bf16)",
+        )
+        ret["unfused_bf16_us"] = unfused_bf16_us
+
+        # fused path with packed fn
         (
             post_mix_bf16,
             comb_mix_bf16,
@@ -934,8 +963,6 @@ def test_mhc_post_pre(
             next_residual_ref, next_residual_bf16, msg="fused/next_residual(bf16)"
         )
         ret["fused_bf16_us"] = fused_bf16_us
-        if fused_us and fused_bf16_us:
-            ret["bf16_speedup"] = fused_us / fused_bf16_us
     # print(f"next_residual_ref: {next_residual_ref}")
     # print(f"next_residual_fused: {next_residual_fused}")
 
@@ -1071,7 +1098,7 @@ parser.add_argument(
     "--fn_pack_bf16",
     action="store_true",
     help="Also run the bf16 (fn hi/lo pack) compute path (is_fn_pack_bf16=1) and add "
-    "hip_bf16_err/hip_bf16_us (mhc_pre) and fused_bf16_err/fused_bf16_us + bf16_speedup "
+    "hip_bf16_err/hip_bf16_us (mhc_pre) and unfused_bf16_*/fused_bf16_* "
     "(mhc_post_pre). gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); "
     "other arches fall back to fp32.",
 )

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -788,7 +788,11 @@ def mhc_post_pre_unfused_hip(
 def test_mhc_post_pre(
     m, hidden_size, hc_mult, fuse_rmsnorm=False, large_m=False, fn_pack_bf16=False
 ):
-    """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton."""
+    """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton.
+
+    --fn_pack_bf16 toggles the gemm compute for ALL HIP paths (unfused, fused, large_m):
+    on -> pre-packed bf16 hi/lo MFMA (is_fn_pack_bf16=1); off -> fp32.
+    """
     if hidden_size < 512:
         aiter.logger.info(
             "skip mhc_post_pre: hidden_size=%s < 512 (big_fuse dispatch)", hidden_size
@@ -844,6 +848,24 @@ def test_mhc_post_pre(
     if fuse_rmsnorm:
         hip_kwargs["norm_weight"] = norm_weight
 
+    ret = {"fuse_rmsnorm": fuse_rmsnorm, "fn_pack_bf16": fn_pack_bf16}
+
+    # --fn_pack_bf16 toggles the gemm compute for all HIP paths: on -> pre-pack fn (fp32)
+    # into int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn and run with is_fn_pack_bf16=1 so
+    # the gemm bit-extracts hi/lo (gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA,
+    # UNVERIFIED; other arches fall back to fp32); off -> plain fp32 fn.
+    if fn_pack_bf16:
+        from aiter.ops.mhc import mhc_pre_convert_fn
+
+        fn_gemm = torch.empty(
+            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
+        )
+        mhc_pre_convert_fn(fn_gemm, fn)
+        pack_flag = 1
+    else:
+        fn_gemm = fn
+        pack_flag = 0
+
     (
         post_mix_unfused,
         comb_mix_unfused,
@@ -855,9 +877,10 @@ def test_mhc_post_pre(
         residual_in,
         post_layer_mix,
         comb_res_mix,
-        fn,
+        fn_gemm,
         hc_scale,
         hc_base,
+        is_fn_pack_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -872,10 +895,11 @@ def test_mhc_post_pre(
         residual_in,
         post_layer_mix,
         comb_res_mix,
-        fn,
+        fn_gemm,
         hc_scale,
         hc_base,
         force_fused=True,
+        is_fn_pack_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -891,78 +915,10 @@ def test_mhc_post_pre(
         layer_input_ref, layer_input_fused, msg="fused/layer_input"
     )
     checkAllclose(next_residual_ref, next_residual_fused, msg="fused/next_residual")
-    ret = {"fuse_rmsnorm": fuse_rmsnorm}
     ret["unfused_us"] = unfused_us
     ret["hip_unfused_err"] = hip_unfused_err
     ret["fused_us"] = fused_us
     ret["hip_fused_err"] = hip_fused_err
-
-    # bf16 compute path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn,
-    # then run with is_fn_pack_bf16=1 so the gemm bit-extracts hi/lo. Exercised on BOTH the
-    # unfused and fused paths. gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED);
-    # other arches fall back to fp32.
-    if fn_pack_bf16:
-        from aiter.ops.mhc import mhc_pre_convert_fn
-
-        fn_packed = torch.empty(
-            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
-        )
-        mhc_pre_convert_fn(fn_packed, fn)
-
-        # unfused path (mhc_post + mhc_pre) with packed fn
-        (
-            post_mix_unfused_bf16,
-            comb_mix_unfused_bf16,
-            layer_input_unfused_bf16,
-            next_residual_unfused_bf16,
-        ), unfused_bf16_us = run_perftest(
-            mhc_post_pre_unfused_hip,
-            layer_input,
-            residual_in,
-            post_layer_mix,
-            comb_res_mix,
-            fn_packed,
-            hc_scale,
-            hc_base,
-            is_fn_pack_bf16=1,
-            **hip_kwargs,
-        )
-        ret["unfused_bf16_err"] = checkAllclose(
-            layer_input_ref, layer_input_unfused_bf16, msg="unfused/layer_input(bf16)"
-        )
-        checkAllclose(
-            next_residual_ref,
-            next_residual_unfused_bf16,
-            msg="unfused/next_residual(bf16)",
-        )
-        ret["unfused_bf16_us"] = unfused_bf16_us
-
-        # fused path with packed fn
-        (
-            post_mix_bf16,
-            comb_mix_bf16,
-            layer_input_bf16,
-            next_residual_bf16,
-        ), fused_bf16_us = run_perftest(
-            aiter.mhc_fused_post_pre,
-            layer_input,
-            residual_in,
-            post_layer_mix,
-            comb_res_mix,
-            fn_packed,
-            hc_scale,
-            hc_base,
-            force_fused=True,
-            is_fn_pack_bf16=1,
-            **hip_kwargs,
-        )
-        ret["fused_bf16_err"] = checkAllclose(
-            layer_input_ref, layer_input_bf16, msg="fused/layer_input(bf16)"
-        )
-        checkAllclose(
-            next_residual_ref, next_residual_bf16, msg="fused/next_residual(bf16)"
-        )
-        ret["fused_bf16_us"] = fused_bf16_us
     # print(f"next_residual_ref: {next_residual_ref}")
     # print(f"next_residual_fused: {next_residual_fused}")
 
@@ -1031,9 +987,10 @@ def test_mhc_post_pre(
                 residual_in,
                 post_layer_mix,
                 comb_res_mix,
-                fn,
+                fn_gemm,
                 hc_scale,
                 hc_base,
+                is_fn_pack_bf16=pack_flag,
                 **hip_kwargs,
             )
             ret["large_m_us"] = large_m_us
@@ -1097,10 +1054,10 @@ parser.add_argument(
 parser.add_argument(
     "--fn_pack_bf16",
     action="store_true",
-    help="Also run the bf16 (fn hi/lo pack) compute path (is_fn_pack_bf16=1) and add "
-    "hip_bf16_err/hip_bf16_us (mhc_pre) and unfused_bf16_*/fused_bf16_* "
-    "(mhc_post_pre). gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); "
-    "other arches fall back to fp32.",
+    help="Use the bf16 (fn hi/lo pack) compute path (is_fn_pack_bf16=1). For mhc_pre this "
+    "adds hip_bf16_err/hip_bf16_us alongside fp32; for mhc_post_pre it switches ALL HIP "
+    "paths (unfused, fused, large_m) from fp32 to bf16. gfx950 native bf16 MFMA; gfx1250 "
+    "wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.",
 )
 
 args = parser.parse_args()

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -524,10 +524,17 @@ def test_mhc_pre(
     ret["hip_err"] = hip_err
     ret["hip_us"] = hip_us
 
-    # bf16 (fn hi/lo pack) GEMM path: same mhc_pre but is_fn_pack_bf16=1. On gfx950 this
-    # uses the native bf16 MFMA; on gfx1250 the wave32 bf16 WMMA (UNVERIFIED); on other
-    # arches it falls back to fp32 (so err/us == the fp32 columns).
+    # bf16 GEMM path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn
+    # (fn are constant weights), then run mhc_pre with is_fn_pack_bf16=1 so the gemm
+    # bit-extracts hi/lo instead of recomputing the fp32->bf16 split per (m_block, k).
+    # On gfx950 this uses the native bf16 MFMA; gfx1250 the wave32 bf16 WMMA (UNVERIFIED).
     if fn_pack_bf16:
+        from aiter.ops.mhc import mhc_pre_convert_fn
+
+        fn_packed = torch.empty(
+            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
+        )
+        mhc_pre_convert_fn(fn_packed, fn)
         (
             post_mix_bf16,
             comb_mix_bf16,
@@ -535,7 +542,7 @@ def test_mhc_pre(
         ), hip_bf16_us = run_perftest(
             aiter.mhc_pre,
             residual,
-            fn,
+            fn_packed,
             hc_scale,
             hc_base,
             is_fn_pack_bf16=1,
@@ -892,10 +899,16 @@ def test_mhc_post_pre(
     ret["fused_us"] = fused_us
     ret["hip_fused_err"] = hip_fused_err
 
-    # bf16 (fn hi/lo pack) compute path: same fused kernel but is_fn_pack_bf16=1. gfx950
-    # native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); other arches fall back to
-    # fp32 (err/us == the fp32 fused columns).
+    # bf16 compute path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn,
+    # then run the fused kernel with is_fn_pack_bf16=1 so it bit-extracts hi/lo. gfx950 native
+    # bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.
     if fn_pack_bf16:
+        from aiter.ops.mhc import mhc_pre_convert_fn
+
+        fn_packed = torch.empty(
+            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
+        )
+        mhc_pre_convert_fn(fn_packed, fn)
         (
             post_mix_bf16,
             comb_mix_bf16,
@@ -907,7 +920,7 @@ def test_mhc_post_pre(
             residual_in,
             post_layer_mix,
             comb_res_mix,
-            fn,
+            fn_packed,
             hc_scale,
             hc_base,
             force_fused=True,


### PR DESCRIPTION
old:
fp32 compute: python3 op_tests/test_mhc.py -n 4096 7168 --fuse_rmsnorm
<img width="1057" height="388" alt="image" src="https://github.com/user-attachments/assets/cc371621-4ecc-411f-984e-1a176536aa8b" />


new:
bf16 compute: python3 op_tests/test_mhc.py -n 4096 7168 --fuse_rmsnorm --fn_pack_bf16
<img width="1060" height="383" alt="image" src="https://github.com/user-attachments/assets/c88b22e0-ee40-4f78-b70a-a9058e78548c" />

fp32 compute: python3 op_tests/test_mhc.py -n 4096 7168 --fuse_rmsnorm
<img width="1057" height="373" alt="image" src="https://github.com/user-attachments/assets/db8cf532-9006-4708-867c-825a0cdc50bf" />
