### PR TITLE
[FlyDSL][AOT] Fix cktile_epilogue_silu AOT arg mismatch on release/v0.1.16.post4

### DIFF
--- a/aiter/aot/flydsl/moe.py
+++ b/aiter/aot/flydsl/moe.py
@@ -843,7 +843,6 @@ def _precompile_epilogue_to_cache(act: str, inter_dim: int, topk: int):
                 _ptr_view_safe(empty_f32),
                 rows,
                 sorted_token_ids.shape[0],
-                float("inf"),  # swiglu_limit (unused for silu)
                 0,  # stream: null/default (compile-only, kernel is never launched)
             ),
         )


### PR DESCRIPTION
## Problem

Building the aiter wheel on `release/v0.1.16.post4` (`PREBUILD_KERNELS=1`) fails in FlyDSL AOT: every `cktile_epilogue_silu` config (inter_dim 256–1536, topk 6–9, gfx950) fails with `too many positional arguments`, aborting the build (`FlyDSL MOE AOT: 12 failed`). This blocks vllm-project/vllm#48683 (post3→post4 bump).

## Cause

This branch's `silu_and_mul_fq.py` uses the compile-time-`swiglu_limit` design (pre-#3767): the kernel/launcher take **no** runtime swiglu arg (`launch_silu_and_mul_fq` is 10-arg). But `_precompile_epilogue_to_cache`'s silu branch still passes the runtime-style tuple with a stale `float("inf")` swiglu_limit → 11 args into a 10-arg launcher. (swiglu uses a separate 4-arg launcher, so only silu breaks.)

## Fix

Drop the stale `float("inf")` so the tuple matches the launcher. `swiglu_limit` stays compile-time (default `0.0` = no clamp, correct for silu).

## Test

`flydsl==0.2.2`, `COMPILE_ONLY=1`, gfx950 — the 12 CI-failing configs:

| | result |
|---|---|
| before | 0 ok, **12 failed** (`too many positional arguments`) |
| after  | **12 ok, 0 failed** |

## Notes

Release-local consistency fix, not a cherry-pick: `main` uses the newer runtime-`swiglu_limit` design (#3767, for DSV4/gfx1250); this branch predates it. AI assistance was used; the human submitter has reviewed the one-line diff and verification.
