### PR TITLE
[Bugfix][Triton] Define zero-row and padded FP8/int8 quantization

### DIFF
--- a/aiter/ops/triton/_triton_kernels/quant/quant.py
+++ b/aiter/ops/triton/_triton_kernels/quant/quant.py
@@ -15,7 +15,6 @@ def _static_per_tensor_quant_fp8_i8_kernel(
     NUM_COL_POW2: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
-    tl.assume(pid > 0)
     tl.assume(x_in_stride_r > 0)
 
     offs = pid * x_in_stride_r + tl.arange(0, NUM_COL_POW2)
@@ -40,14 +39,14 @@ def _dynamic_per_tensor_quant_fp8_i8_kernel(
     DTYPE_MAX: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
-    tl.assume(pid > 0)
     tl.assume(x_in_stride_r > 0)
 
     offs = pid * x_in_stride_r + tl.arange(0, NUM_COL_POW2)
     mask = tl.arange(0, NUM_COL_POW2) < cols
-    x = tl.load(x_in_ptr + offs, mask=mask, cache_modifier=".cg")
+    x = tl.load(x_in_ptr + offs, mask=mask, other=0.0, cache_modifier=".cg")
 
-    m = tl.max(tl.abs(x))
+    m = tl.max(tl.abs(x)).to(tl.float32)
+    m = tl.maximum(m, 1e-10)
     tl.atomic_max(scale_out_ptr, m / DTYPE_MAX, sem="relaxed")
 
 
@@ -62,15 +61,15 @@ def _dynamic_per_token_quant_fp8_i8_kernel(
     DTYPE_MAX: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
-    tl.assume(pid > 0)
     tl.assume(x_in_stride_r > 0)
 
     offs = pid * x_in_stride_r + tl.arange(0, NUM_COL_POW2)
     mask = tl.arange(0, NUM_COL_POW2) < cols
-    x = tl.load(x_in_ptr + offs, mask=mask, cache_modifier=".cg")
+    x = tl.load(x_in_ptr + offs, mask=mask, other=0.0, cache_modifier=".cg")
 
-    m = tl.max(tl.abs(x), axis=-1)
-    scale_out = m.to(tl.float32) / DTYPE_MAX
+    m = tl.max(tl.abs(x), axis=-1).to(tl.float32)
+    m = tl.maximum(m, 1e-10)
+    scale_out = m / DTYPE_MAX
     scale_recip = 1 / scale_out
 
     qx = x * scale_recip

--- a/op_tests/triton_tests/quant/test_quant.py
+++ b/op_tests/triton_tests/quant/test_quant.py
@@ -55,6 +55,20 @@ def test_static_per_tensor_quant(M: int, N: int, dtype_in, dtype_quant):
     )
 
 
+@pytest.mark.parametrize("dtype_quant", [torch.int8, get_fp8_e4m3_dtype()])
+def test_static_per_tensor_quant_processes_row_zero(dtype_quant):
+    x = torch.arange(1, 14, dtype=torch.float32, device="cuda").reshape(1, 13)
+    scale = torch.ones(1, dtype=torch.float32, device="cuda")
+    expected = x.to(dtype_quant)
+    output = torch.zeros_like(x, dtype=dtype_quant)
+
+    static_per_tensor_quant_fp8_i8(output, x, scale)
+
+    torch.testing.assert_close(
+        output.to(torch.float32), expected.to(torch.float32), atol=0, rtol=0
+    )
+
+
 def torch_dynamic_per_tensor_quant_fp8_i8(x, dtype_quant):
     # Triton does max and scale in f32 so we need to match precision here.
     x_f32 = x.to(torch.float32)
@@ -101,6 +115,25 @@ def test_dynamic_per_tensor_quant(M: int, N: int, dtype_in, dtype_quant):
         torch_out.to(dtype=torch.float32),
         atol=1e-01,
         rtol=1e-01,
+    )
+
+
+@pytest.mark.parametrize("dtype_in", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("dtype_quant", [torch.int8, get_fp8_e4m3_dtype()])
+def test_dynamic_per_tensor_quant_zero_input(dtype_in, dtype_quant):
+    x = torch.zeros((1, 13), dtype=dtype_in, device="cuda")
+    output = torch.empty_like(x, dtype=dtype_quant)
+    scale = torch.zeros(1, dtype=torch.float32, device="cuda")
+
+    dynamic_per_tensor_quant_fp8_i8(output, x, scale)
+
+    assert torch.isfinite(scale).all()
+    assert (scale > 0).all()
+    torch.testing.assert_close(
+        output.to(torch.float32),
+        torch.zeros_like(x, dtype=torch.float32),
+        atol=0,
+        rtol=0,
     )
 
 
@@ -170,4 +203,35 @@ def test_dynamic_per_token_quant(M: int, N: int, dtype_in, dtype_quant):
         torch_out.to(dtype=torch.float32),
         atol=1e-01,
         rtol=1e-01,
+    )
+
+
+@pytest.mark.parametrize("dtype_in", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("dtype_quant", [torch.int8, get_fp8_e4m3_dtype()])
+def test_dynamic_per_token_quant_zero_and_nonzero_rows(dtype_in, dtype_quant):
+    x = torch.stack(
+        (
+            torch.zeros(13, dtype=dtype_in, device="cuda"),
+            torch.arange(-6, 7, dtype=dtype_in, device="cuda"),
+        )
+    )
+    dtype_max = (
+        torch.iinfo(dtype_quant).max
+        if dtype_quant == torch.int8
+        else torch.finfo(dtype_quant).max
+    )
+    expected_max = torch.maximum(
+        x.float().abs().amax(dim=-1), torch.tensor(1e-10, device=x.device)
+    )
+    expected_scale = expected_max / dtype_max
+    expected_output = (x / expected_scale[:, None]).to(dtype_quant)
+    output = torch.empty_like(x, dtype=dtype_quant)
+    scale = torch.empty(x.shape[0], dtype=torch.float32, device="cuda")
+
+    dynamic_per_token_quant_fp8_i8(output, x, scale)
+
+    assert torch.isfinite(scale).all()
+    torch.testing.assert_close(scale, expected_scale, atol=0, rtol=0)
+    torch.testing.assert_close(
+        output.to(torch.float32), expected_output.to(torch.float32), atol=0, rtol=0
     )


### PR DESCRIPTION
## Summary

Define row-zero, padded-lane, and zero-input behavior in the basic Triton FP8/int8 quantization kernels.

This change removes the invalid `pid > 0` assumptions, supplies zero for masked reduction lanes, and gives all-zero dynamic inputs a finite FP32 scale. Public-interface regressions cover each case.

Fixes #4288.

## Correctness proof

### Program zero

Each wrapper launches `grid=(rows,)`. For any nonempty input, the program-ID domain is:

```text
P = {0, 1, ..., rows - 1}
```

Program ID zero belongs to this set, contradicting `tl.assume(pid > 0)`. The Triton interpreter concretely rejects the original row-zero program with `Assume failed`.

### Padded reduction lanes

Let `B` be the next power of two greater than or equal to `N`. When `B > N`, the old reduction included undefined masked values:

```text
max(|x[0]|, ..., |x[N-1]|, u[N], ..., u[B-1])
```

Using `other=0.0` gives:

```text
max(|x[0]|, ..., |x[N-1]|, 0, ..., 0)
    = max(|x[j]| for 0 <= j < N)
```

This identity holds because absolute values are nonnegative.

### Zero-input scale

For an all-zero row, the old calculation is:

```text
m = 0
scale = m / dtype_max = 0
quantized = 0 * (1 / scale) = NaN
```

The corrected calculation is:

```text
guarded_max = max(m, 1e-10)
scale = guarded_max / dtype_max
```

For the supported output maxima, `dtype_max <= 448`, so:

```text
scale >= 1e-10 / 448 ~= 2.23e-13 > 0
```

Thus the reciprocal is finite and zero inputs quantize exactly to zero. Inputs with `m >= 1e-10` retain the existing scale.

## Changes

- Remove `tl.assume(pid > 0)` from static per-tensor, dynamic per-tensor, and dynamic per-token quantization.
- Supply `other=0.0` for masked loads participating in dynamic reductions.
- Convert maxima to FP32 and clamp them to at least `1e-10`.
- Add regression coverage for row zero, width 13, all-zero tensors, mixed zero/nonzero rows, FP16/BF16/FP32 inputs, and int8/FP8 outputs.

## Testing

- Triton interpreter exact checks for FP16, BF16, and FP32 inputs with int8 and `float8_e4m3fn` outputs.
- Offline compilation of 30 kernel/type combinations for gfx942 and gfx950, including `fp8e4b8` and `fp8e4nv`.
- Generated TTIR confirms zero-valued masked loads and FP32 maximum operations.
- `ruff check aiter/ops/triton/_triton_kernels/quant/quant.py op_tests/triton_tests/quant/test_quant.py`
- `ruff format --check op_tests/triton_tests/quant/test_quant.py`
- `python3 -m py_compile aiter/ops/triton/_triton_kernels/quant/quant.py op_tests/triton_tests/quant/test_quant.py`
- `git diff --check`

## Performance

Launch geometry and memory traffic are unchanged. The dynamic paths add one scalar FP32 maximum after the existing reduction.

## Dependencies

No new dependencies.

## Breaking Changes

None.
