### PR TITLE
[Bugfix][Triton] Correct ragged paged-MQA causal masks

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
@@ -93,7 +93,9 @@ def _deepgemm_fp8_paged_mqa_logits_stage1_ragged_k(
         o = tl.maximum(o, 0.0)
         o = o * scale_weight[None, :].T
 
-        mask = context_idx + tl.arange(0, ChunkK) <= context_length - pid_next_n
+        mask = (
+            context_idx + tl.arange(0, ChunkK) <= context_length - next_n + pid_next_n
+        )
         o = tl.where(mask[None, :], o, float("-inf"))
 
         tl.store(
@@ -188,7 +190,9 @@ def _deepgemm_fp8_paged_mqa_logits_ragged_k(
         o = tl.maximum(o, 0.0)
         o = o * scale_weight[None, :].T
 
-        mask = context_idx + tl.arange(0, ChunkK) <= context_length - pid_next_n
+        mask = (
+            context_idx + tl.arange(0, ChunkK) <= context_length - next_n + pid_next_n
+        )
         o = tl.where(mask[None, :], o, float("-inf"))
 
         logits = tl.reduce(o, axis=0, combine_fn=_sum_combine)

--- a/op_tests/test_pa_mqa_logits_ragged.py
+++ b/op_tests/test_pa_mqa_logits_ragged.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter import dtypes
+from aiter.ops.triton.pa_mqa_logits import (
+    deepgemm_fp8_paged_mqa_logits_ragged_k,
+    deepgemm_fp8_paged_mqa_logits_stage1_ragged_k,
+)
+
+
+NEXT_N = 4
+HEADS = 32
+HEAD_DIM = 128
+CONTEXT_LEN = 8
+CHUNK_K = 64
+QUERY_POSITIONS = (4, 5, 6, 7)
+
+
+def _make_inputs():
+    q_bits = torch.full(
+        (1, NEXT_N, HEADS, HEAD_DIM), 56, dtype=torch.uint8, device="cuda"
+    )
+    q_fp8 = q_bits.view(dtypes.fp8)
+
+    kv_bits = torch.full(
+        (CONTEXT_LEN, 1, 1, HEAD_DIM + 4),
+        56,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    kv_bits[..., HEAD_DIM:] = torch.tensor(
+        [0, 0, 128, 63], dtype=torch.uint8, device="cuda"
+    )
+    kv_cache_fp8 = kv_bits.view(dtypes.fp8)
+
+    weights = torch.ones((NEXT_N, HEADS), dtype=torch.float32, device="cuda")
+    prefix_sum_context_lens = torch.tensor(
+        [0, CONTEXT_LEN], dtype=torch.int32, device="cuda"
+    )
+    kv_indices = torch.arange(CONTEXT_LEN, dtype=torch.int32, device="cuda")
+    return q_fp8, kv_cache_fp8, weights, prefix_sum_context_lens, kv_indices
+
+
+def _expected_causal_mask(width):
+    query_positions = torch.tensor(QUERY_POSITIONS, device="cuda")
+    kv_positions = torch.arange(width, device="cuda")
+    return kv_positions[None, :] <= query_positions[:, None]
+
+
+def _assert_exact_causal_mask(out, expected):
+    assert torch.equal(torch.isfinite(out), expected)
+    assert bool(torch.isneginf(out[~expected]).all())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm GPU")
+def test_paged_mqa_logits_ragged_k_uses_per_query_causal_boundary():
+    q, kv, weights, prefix_lens, kv_indices = _make_inputs()
+    out = torch.full(
+        (NEXT_N, CHUNK_K), float("nan"), dtype=torch.float32, device="cuda"
+    )
+
+    deepgemm_fp8_paged_mqa_logits_ragged_k(
+        q,
+        kv,
+        weights,
+        out,
+        prefix_lens,
+        kv_indices,
+        CHUNK_K,
+        ChunkK=CHUNK_K,
+        SplitKV=1,
+    )
+    torch.cuda.synchronize()
+
+    _assert_exact_causal_mask(out, _expected_causal_mask(CHUNK_K))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm GPU")
+def test_paged_mqa_logits_stage1_ragged_k_uses_per_query_causal_boundary():
+    q, kv, weights, prefix_lens, kv_indices = _make_inputs()
+    out = torch.full(
+        (HEADS, NEXT_N, CHUNK_K),
+        float("nan"),
+        dtype=torch.float32,
+        device="cuda",
+    )
+
+    deepgemm_fp8_paged_mqa_logits_stage1_ragged_k(
+        q,
+        kv,
+        weights,
+        out,
+        prefix_lens,
+        kv_indices,
+        CHUNK_K,
+    )
+    torch.cuda.synchronize()
+
+    expected = _expected_causal_mask(CHUNK_K).unsqueeze(0).expand(HEADS, -1, -1)
+    _assert_exact_causal_mask(out, expected)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Summary

Correct the per-query causal boundary in both ragged-K paged-MQA logits kernels.

The affected kernels previously used `context_length - pid_next_n` as their inclusive KV boundary. The correct boundary is `context_length - next_n + pid_next_n`.

Fixes #4290.

## Correctness proof

Let `L` be `context_length`, `n` be `next_n`, `i` be `pid_next_n` with `0 <= i < n`, and `k` be a zero-based KV position.

The `n` new queries occupy positions:

```text
L - n, L - n + 1, ..., L - 1
```

Therefore:

```text
query_position(i) = L - n + i
valid KV positions = { k | 0 <= k <= L - n + i }
```

The old kernel instead used `k <= L-i`.

- For `i=0`, the old maximum within the real context is `L-1`, which is `n-1` positions beyond the correct maximum.
- For `i>0`, the old maximum is `L-i`; subtracting the correct maximum gives `n-2i`. Positive values expose future positions, while negative values mask valid positions.

For `L=8` and `n=4`:

| Query | Correct maximum | Old maximum within context | Result |
|---:|---:|---:|---|
| 0 | 4 | 7 | exposes positions 5-7 |
| 1 | 5 | 7 | exposes positions 6-7 |
| 2 | 6 | 6 | correct |
| 3 | 7 | 5 | masks positions 6-7 |

The corrected bound also guarantees every admitted position is inside the context:

```text
L - n + i <= L - n + (n - 1) = L - 1
```

## Changes

- Use `context_length - next_n + pid_next_n` in both ragged causal predicates.
- Add public-wrapper regressions for the final-logits and stage-one kernels.
- Verify exact finite/`-inf` boundaries for `next_n=4` across the complete 64-position tile.

Public function signatures and non-ragged kernels are unchanged.

## Testing

- Executable boundary proof confirms corrected maxima `4, 5, 6, 7`.
- The old predicate produces per-query mismatch counts `[4, 2, 0, 2]` over the tested tile.
- Both changed kernels compile for gfx942 and gfx950.
- `ruff check aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py op_tests/test_pa_mqa_logits_ragged.py`
- `ruff format --check aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py op_tests/test_pa_mqa_logits_ragged.py`
- `python3 -m py_compile aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py op_tests/test_pa_mqa_logits_ragged.py`
- `git diff --check`

## Performance

The change replaces one scalar bound expression with the expression already used by the non-ragged siblings. Launch geometry and memory access are unchanged.

## Dependencies

No new dependencies.

## Breaking Changes

None.
