### PR TITLE
[Bugfix] Fix IPC publication ordering in custom all-reduce

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -154,9 +154,9 @@ DINLINE O downcast(V val)
 }
 
 // This function is meant to be used as the first synchronization in the all
-// reduce kernel. Thus, it doesn't need to make any visibility guarantees for
-// prior memory accesses. Note: volatile writes will not be reordered against
-// other volatile writes.
+// reduce kernel. In eager mode, the input is copied into an IPC-registered
+// buffer immediately before the kernel launch, so the ready signal must publish
+// that copy before peers read the buffer.
 template <int ngpus>
 DINLINE void start_sync(const RankSignals& sg,
 #ifndef USE_ROCM
@@ -169,20 +169,17 @@ DINLINE void start_sync(const RankSignals& sg,
     uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
     if(threadIdx.x < ngpus)
     {
-        // simultaneously write to the corresponding flag of all ranks.
-        // Latency = 1 p2p write
         __scoped_atomic_store_n(&sg.signals[threadIdx.x]->start[blockIdx.x][rank],
                                 flag,
-                                __ATOMIC_RELAXED,
+                                __ATOMIC_RELEASE,
                                 __MEMORY_SCOPE_SYSTEM);
-        // wait until we got true from all ranks
         while(__scoped_atomic_load_n(&self_sg->start[blockIdx.x][threadIdx.x],
                                      __ATOMIC_RELAXED,
-                                     __MEMORY_SCOPE_DEVICE) < flag)
+                                     __MEMORY_SCOPE_SYSTEM) < flag)
             ;
+        __scoped_atomic_thread_fence(__ATOMIC_ACQUIRE, __MEMORY_SCOPE_SYSTEM);
     }
     __syncthreads();
-    // use one thread to update flag
     if(threadIdx.x == 0)
         self_sg->_flag[blockIdx.x] = flag;
 #else
@@ -202,8 +199,10 @@ DINLINE void start_sync(const RankSignals& sg,
 }
 
 // This function is meant to be used as the second or the final synchronization
-// barrier in the all reduce kernel. If it's the final synchronization barrier,
-// we don't need to make any visibility guarantees for prior memory accesses.
+// barrier in the all reduce kernel. A non-final barrier publishes intermediate
+// writes consumed by the next stage. A final barrier only waits for peer reads
+// to finish before the input can be reused; its uncached signal does not carry
+// output data.
 template <int ngpus, bool final_sync = false>
 DINLINE void end_sync(const RankSignals& sg,
 #ifndef USE_ROCM
@@ -214,10 +213,6 @@ DINLINE void end_sync(const RankSignals& sg,
 {
 #ifdef USE_ROCM
     __syncthreads();
-    // eliminate the case that prior writes are not visible after signals become
-    // visible. Note that I did not managed to make this happen through a lot of
-    // testing. Might be the case that hardware provides stronger guarantee than
-    // the memory model.
     uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
     if(threadIdx.x < ngpus)
     {
@@ -229,9 +224,12 @@ DINLINE void end_sync(const RankSignals& sg,
                                 __MEMORY_SCOPE_SYSTEM);
         // wait until we got true from all ranks
         while(__scoped_atomic_load_n(&self_sg->end[blockIdx.x][threadIdx.x],
-                                     final_sync ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE,
-                                     __MEMORY_SCOPE_DEVICE) < flag)
+                                     __ATOMIC_RELAXED,
+                                     final_sync ? __MEMORY_SCOPE_DEVICE : __MEMORY_SCOPE_SYSTEM) <
+              flag)
             ;
+        if constexpr(!final_sync)
+            __scoped_atomic_thread_fence(__ATOMIC_ACQUIRE, __MEMORY_SCOPE_SYSTEM);
     }
     __syncthreads();
     // use one thread to update flag

--- a/op_tests/multigpu_tests/test_custom_allreduce_ipc_ordering.py
+++ b/op_tests/multigpu_tests/test_custom_allreduce_ipc_ordering.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Stress custom all-reduce input publication across ranks."""
+
+import argparse
+import time
+from multiprocessing import Pool, freeze_support, set_start_method
+
+import torch
+import torch.distributed as dist
+
+from aiter.dist.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    ensure_model_parallel_initialized,
+    get_tp_group,
+    graph_capture,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+
+set_start_method("spawn", force=True)
+
+_EAGER_SHAPES = ((4096, 7168), (1, 7168), (4096, 7168), (1, 7168))
+_VALUES = (1, -2, 3, -4)
+_GRAPH_SHAPE = (4, 7168)
+
+
+def _check_across_ranks(message, group, device):
+    failed = torch.tensor(message is not None, dtype=torch.int32, device=device)
+    dist.all_reduce(failed, group=group)
+    if failed.item():
+        raise AssertionError(message or "custom all-reduce failed on a peer rank")
+
+
+def _run_eager_reuse(ca_comm, group, device, rank, world_size, iters, skew_s):
+    inputs = {
+        shape: torch.empty(shape, dtype=torch.bfloat16, device=device)
+        for shape in set(_EAGER_SHAPES)
+    }
+    for shape, input_ in inputs.items():
+        assert ca_comm.should_custom_ar(
+            input_
+        ), f"custom all-reduce does not accept eager regression {shape=}"
+
+    rank_sum = world_size * (world_size + 1) // 2
+    for iteration in range(iters):
+        pending = []
+        for call_idx, shape in enumerate(_EAGER_SHAPES):
+            value = _VALUES[(iteration + call_idx) % len(_VALUES)]
+            if rank == (iteration + call_idx) % world_size:
+                time.sleep(skew_s)
+
+            input_ = inputs[shape]
+            input_.fill_(value * (rank + 1))
+            output = ca_comm.custom_all_reduce(input_)
+            assert output is not None
+            pending.append((output, value * rank_sum, call_idx, shape))
+
+        torch.cuda.synchronize()
+        message = None
+        for output, expected, call_idx, shape in pending:
+            bad = torch.count_nonzero(output != expected).item()
+            if bad:
+                message = (
+                    "eager custom all-reduce IPC publication mismatch: "
+                    f"iteration={iteration} call={call_idx} rank={rank} "
+                    f"shape={shape} expected={expected} bad={bad} "
+                    f"min={output.min().item()} max={output.max().item()}"
+                )
+                break
+        _check_across_ranks(message, group, device)
+
+
+def _run_graph_reuse(ca_comm, group, device, rank, world_size, iters, skew_s):
+    input_ = torch.empty(_GRAPH_SHAPE, dtype=torch.bfloat16, device=device)
+    assert ca_comm.should_custom_ar(input_)
+    input_value = rank + 1
+    clobber_value = -(rank + 17)
+    graph = torch.cuda.CUDAGraph()
+    with graph_capture() as capture:
+        with torch.cuda.graph(graph, stream=capture.stream):
+            input_.fill_(input_value)
+            output = ca_comm.custom_all_reduce(input_)
+            assert output is not None
+            input_.fill_(clobber_value)
+
+    expected = world_size * (world_size + 1) // 2
+    for iteration in range(iters):
+        if rank == iteration % world_size:
+            time.sleep(skew_s)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        bad_output = torch.count_nonzero(output != expected).item()
+        bad_clobber = torch.count_nonzero(input_ != clobber_value).item()
+        message = None
+        if bad_output:
+            message = (
+                "graph custom all-reduce publication mismatch: "
+                f"iteration={iteration} rank={rank} expected={expected} "
+                f"bad={bad_output} min={output.min().item()} "
+                f"max={output.max().item()}"
+            )
+        elif bad_clobber:
+            message = (
+                "graph input clobber did not execute: "
+                f"iteration={iteration} rank={rank} bad={bad_clobber}"
+            )
+        _check_across_ranks(message, group, device)
+
+
+def _worker(rank, world_size, iters, skew_s, init_method):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        distributed_init_method=init_method,
+    )
+    ensure_model_parallel_initialized(world_size, 1)
+
+    try:
+        tp_group = get_tp_group()
+        group = tp_group.device_group
+        dist.all_reduce(torch.zeros(1, device=device), group=group)
+        torch.cuda.synchronize()
+
+        device_communicator = tp_group.device_communicator
+        assert device_communicator is not None
+        ca_comm = device_communicator.ca_comm
+        assert ca_comm is not None and not ca_comm.disabled
+
+        _run_eager_reuse(ca_comm, group, device, rank, world_size, iters, skew_s)
+        if ca_comm.enable_register_for_capturing:
+            _run_graph_reuse(ca_comm, group, device, rank, world_size, iters, skew_s)
+        return {"rank": rank, "iters": iters}
+    finally:
+        if dist.is_initialized():
+            destroy_model_parallel()
+            destroy_distributed_environment()
+            torch.cuda.empty_cache()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--rank-skew-ms", type=float, default=2.0)
+    parser.add_argument("--tp-size", type=int, choices=(2, 4, 6, 8), default=8)
+    args = parser.parse_args()
+    if args.iters <= 0:
+        parser.error("--iters must be positive")
+    if args.rank_skew_ms < 0:
+        parser.error("--rank-skew-ms must be non-negative")
+
+    init_method = get_distributed_init_method(get_ip(), get_open_port())
+    with Pool(processes=args.tp_size) as pool:
+        results = [
+            pool.apply_async(
+                _worker,
+                args=(
+                    rank,
+                    args.tp_size,
+                    args.iters,
+                    args.rank_skew_ms / 1000.0,
+                    init_method,
+                ),
+            )
+            for rank in range(args.tp_size)
+        ]
+        print([result.get() for result in results])
+
+
+if __name__ == "__main__":
+    freeze_support()
+    main()


### PR DESCRIPTION
## Summary

- Publish eager fixed-buffer copies and intermediate all-reduce writes with system-scoped release stores.
- Acquire system-scoped visibility after all peer ready signals are observed, before reading peer IPC buffers.
- Limit the change to the tested gfx9 synchronization helper while keeping final read-completion barriers relaxed; gfx1250 is intentionally unchanged.
- Add a TP8 stress test for repeated eager-buffer reuse and graph replay under rotating rank skew.

## Root cause

The eager path copies input into an IPC-registered fixed buffer immediately before launching the collective. The ready flag was system-scoped but relaxed, and peers polled it with device scope. That did not establish a system-scoped happens-before edge from the producer copy to peer buffer reads. The same gap existed for intermediate writes consumed after a non-final barrier.

## Duplicate-work check

I reviewed #4082 and #4084. Those changes protect buffer lifetime **after** peer reads by adding terminal synchronization or retaining caller tensors. This PR instead publishes data **before** peer reads. It intentionally excludes their terminal-barrier changes, so the fixes are complementary rather than duplicate. Searches for custom all-reduce IPC publication/order fixes found no other open PR.

## Validation

The original validation below ran on an 8x gfx950 host at `main` commit `dedc19d32bb31ec134ad0388f878e4cd7a83af16`. After rebasing, the TP8 ordering stress was rerun for 100 iterations on current `main` commit `632367677a6a7fc7a329262775f0a74e6eb8f78d` and passed on all ranks. The other results below predate the rebase.

```bash
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 PYTHONPATH=$PWD CK_DIR=$PWD/3rdparty/composable_kernel \
  /home/amd/vllm/.venv/bin/python \
  op_tests/multigpu_tests/test_custom_allreduce_ipc_ordering.py \
  --iters 100 --tp-size 8
```

Passed on all eight ranks, including graph capture/replay. This is a stress regression guard rather than a deterministic reproducer; an unpatched-main 20-iteration control also completed.

The fused all-reduce/RMS integration sweep passed 11,200/11,200 comparisons across M=1,4,8,16,32,64,4096 (100 iterations each), with maximum absolute error 0.125. A graph-free DeepSeek-V4-Pro GSM8K run completed 1,319 samples at 95.906% strict / 95.830% flexible accuracy; its server handled 1,351 successful HTTP responses with no GPU fault.

The stock TP8 graph benchmark was also run on main and this patch:

| BF16 shape | main min-max (us) | patched min-max (us) |
|---|---:|---:|
| `(2, 7168)` | 5.45-6.69 | 6.25-7.50 |
| `(128, 8192)` | 14.53-15.11 | 15.74-16.29 |

```bash
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 PYTHONPATH=$PWD CK_DIR=$PWD/3rdparty/composable_kernel \
  /home/amd/vllm/.venv/bin/python \
  op_tests/multigpu_tests/test_custom_allreduce.py \
  -d bf16 -s 2,7168 -g true
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 PYTHONPATH=$PWD CK_DIR=$PWD/3rdparty/composable_kernel \
  /home/amd/vllm/.venv/bin/python \
  op_tests/multigpu_tests/test_custom_allreduce.py \
  -d bf16 -s 128,8192 -g true
```

Static checks:

```bash
uvx --from black==26.3.0 black --check op_tests/multigpu_tests/test_custom_allreduce_ipc_ordering.py
uvx --from ruff==0.15.7 ruff check op_tests/multigpu_tests/test_custom_allreduce_ipc_ordering.py
/home/amd/vllm/.venv/bin/python -m py_compile op_tests/multigpu_tests/test_custom_allreduce_ipc_ordering.py
uvx --from clang-format==18.1.8 clang-format --dry-run --Werror --lines=154:236 csrc/include/custom_all_reduce.cuh
git diff --check origin/main...HEAD
```

The gfx1250 helper is intentionally unchanged because no gfx1250 hardware validation was available and that path is being reworked.

## AI assistance

OpenAI Codex was used to audit related PRs, prepare the patch and regression test, run validation, and draft this description. The human submitter is responsible for reviewing every changed line and defending the change end-to-end.
