### PR TITLE
[gfx1250] Launch v4 NM MLA decode .co directly from Python (no C++ host bridge)

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -14,8 +14,8 @@ import aiter
 from aiter import dtypes
 from aiter.jit.core import is_experimental_enabled
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx
-from aiter.ops.attention import get_mla_decode_fwd_max_splits
 from aiter.ops.asm.mla_decode_v4 import mla_decode_v4_asm_gfx1250
+from aiter.ops.attention import get_mla_decode_fwd_max_splits
 
 
 @triton.jit

--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -15,6 +15,7 @@ from aiter import dtypes
 from aiter.jit.core import is_experimental_enabled
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx
 from aiter.ops.attention import get_mla_decode_fwd_max_splits
+from aiter.ops.asm.mla_decode_v4 import mla_decode_v4_asm_gfx1250
 
 
 @triton.jit
@@ -1511,27 +1512,55 @@ def mla_decode_fwd_v4_nm(
 
     use_valid_split_count_reduce = int(num_kv_splits > 1)
 
-    aiter.mla_decode_v4_asm(
-        q,
-        qrope,
-        kv_buffer,
-        kvrope,
-        qo_indptr,
-        kv_indptr,
-        kv_page_indices,
-        split_indptr,
-        sink,
-        max_seqlen_q,
-        sm_scale_arg,
-        int(out_16_nosplit),
-        int(num_kv_splits),
-        logits,
-        attn_lse,
-        output,
-        valid_split_count,
-        use_valid_split_count_reduce,
-        kv_last_page_lens,  # tail: unused on nm path, None -> nullptr
-    )
+    # gfx1250 launches the v4 nm `.co` directly from Python (no C++ host
+    # bridge) via the thin wrapper in aiter.ops.mla_v4_pyco, which reproduces
+    # asm_mla_v4.cu's gfx1250 "preload" kernarg path. Every other arch (e.g.
+    # gfx950) keeps going through the canonical C-ABI dispatcher. The two share
+    # an identical call signature, so this is a pure routing decision.
+    if get_gfx() == "gfx1250":
+        mla_decode_v4_asm_gfx1250(
+            q,
+            qrope,
+            kv_buffer,
+            kvrope,
+            qo_indptr,
+            kv_indptr,
+            kv_page_indices,
+            split_indptr,
+            sink,
+            max_seqlen_q,
+            sm_scale_arg,
+            int(out_16_nosplit),
+            int(num_kv_splits),
+            logits,
+            attn_lse,
+            output,
+            valid_split_count,
+            use_valid_split_count_reduce,
+            kv_last_page_lens,  # tail: unused on nm path, None -> nullptr
+        )
+    else:
+        aiter.mla_decode_v4_asm(
+            q,
+            qrope,
+            kv_buffer,
+            kvrope,
+            qo_indptr,
+            kv_indptr,
+            kv_page_indices,
+            split_indptr,
+            sink,
+            max_seqlen_q,
+            sm_scale_arg,
+            int(out_16_nosplit),
+            int(num_kv_splits),
+            logits,
+            attn_lse,
+            output,
+            valid_split_count,
+            use_valid_split_count_reduce,
+            kv_last_page_lens,  # tail: unused on nm path, None -> nullptr
+        )
 
     # ---- Cross-split FlashAttention merge via _fwd_kernel_stage2_asm ------
     if num_kv_splits > 1:

--- a/aiter/ops/asm/__init__.py
+++ b/aiter/ops/asm/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.

--- a/aiter/ops/asm/asm_utils.py
+++ b/aiter/ops/asm/asm_utils.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Generic, kernel-agnostic helpers to load and launch a HIP ``.co`` (code
+object) directly from Python via ctypes — no C++ host bridge required.
+
+Nothing here is MLA- or op-specific; it is the shared "launch a
+prebuilt asm kernel" layer meant to be reused when porting other aiter asm
+kernels off their C++ dispatchers:
+
+  * device / arch info            -> get_warp_size
+  * HIP ``.co`` launch via ctypes -> load_hip / hip_check / get_function /
+                                     launch_co
+  * asm kernel registry helpers   -> dtype_str / strip_csv_comments /
+                                     load_asm_cfg_csv
+
+The HIP handle is deliberately the SAME ``libamdhip64`` that torch already
+mapped (found by scanning ``/proc/self/maps``), so module-load / launch share
+torch's driver context and stream state and we avoid ROCR symbol-version
+clashes with a second copy under /opt/rocm.
+
+Only depends on PyTorch (for device streams) + ctypes.
+"""
+
+import csv
+import ctypes
+import functools
+import glob
+import os
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Device / arch info
+# ---------------------------------------------------------------------------
+def get_warp_size() -> int:
+    """Hardware wave size of device 0 (32 on RDNA-family gfx1250, 64 on CDNA)."""
+    try:
+        return int(torch.cuda.get_device_properties(0).warp_size)
+    except AttributeError:
+        return 32  # gfx1250 (RDNA-family) is wave32
+
+
+# ---------------------------------------------------------------------------
+# HIP runtime binding (ctypes). torch owns device memory; we only module-load
+# and launch. Bind the SAME libamdhip64 torch already mapped, to avoid ROCR
+# symbol-version clashes with /opt/rocm and keep stream/context state consistent.
+# ---------------------------------------------------------------------------
+# HIP magic launch-param constants (hip_runtime_api.h).
+HIP_LAUNCH_PARAM_BUFFER_POINTER = ctypes.c_void_p(0x01)
+HIP_LAUNCH_PARAM_BUFFER_SIZE = ctypes.c_void_p(0x02)
+HIP_LAUNCH_PARAM_END = ctypes.c_void_p(0x03)
+
+
+def load_hip():
+    """Return a ctypes handle to the libamdhip64 torch has already loaded.
+
+    Preference order: the .so mapped into this process (per /proc/self/maps) ->
+    the one shipped inside the torch wheel -> the system SONAME. Sharing torch's
+    handle keeps the HIP context / stream state consistent with torch.
+    """
+    candidates = []
+    try:
+        with open("/proc/self/maps") as f:
+            for line in f:
+                path = line.rstrip().split(" ")[-1]
+                if "libamdhip64.so" in path and os.path.exists(path):
+                    candidates.append(path)
+    except OSError:
+        pass
+    candidates += glob.glob(
+        os.path.join(os.path.dirname(torch.__file__), "lib", "libamdhip64.so*")
+    )
+    candidates.append("libamdhip64.so")
+    last = None
+    for cand in candidates:
+        try:
+            return ctypes.CDLL(cand)
+        except OSError as exc:
+            last = exc
+    raise RuntimeError(f"could not load libamdhip64: {last}")
+
+
+_hip = None
+
+
+def _get_hip():
+    """Lazily bind libamdhip64 on first launch (NOT at import time).
+
+    Deferring the bind keeps ``import aiter.mla`` side-effect-free on hosts
+    where this launcher is never exercised (e.g. non-gfx1250 arches that still
+    route through the C++ dispatcher), and avoids a hard import failure if HIP
+    is momentarily unavailable.
+    """
+    global _hip
+    if _hip is not None:
+        return _hip
+    hip = load_hip()
+    hip.hipGetErrorString.restype = ctypes.c_char_p
+    hip.hipGetErrorString.argtypes = [ctypes.c_int]
+    hip.hipModuleLoad.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+    hip.hipModuleGetFunction.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+    ]
+    hip.hipModuleLaunchKernel.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    _hip = hip
+    return _hip
+
+
+def hip_check(err, what):
+    if err != 0:
+        msg = _get_hip().hipGetErrorString(err).decode()
+        raise RuntimeError(f"HIP error in {what}: ({err}) {msg}")
+
+
+_module_cache = {}
+_func_cache = {}
+
+
+def get_function(co_path, symbol):
+    """Load ``co_path`` once (process-cached) and resolve ``symbol`` to a
+    function handle (also cached). Mirrors the ``AiterAsmKernel`` /
+    ``SynchronizedCache`` behaviour of the C++ dispatcher: a given .co is mapped
+    exactly once and reused across launches.
+    """
+    hip = _get_hip()
+    module = _module_cache.get(co_path)
+    if module is None:
+        module = ctypes.c_void_p()
+        hip_check(
+            hip.hipModuleLoad(ctypes.byref(module), co_path.encode()),
+            "hipModuleLoad",
+        )
+        _module_cache[co_path] = module
+    key = (co_path, symbol)
+    func = _func_cache.get(key)
+    if func is None:
+        func = ctypes.c_void_p()
+        hip_check(
+            hip.hipModuleGetFunction(ctypes.byref(func), module, symbol.encode()),
+            "hipModuleGetFunction",
+        )
+        _func_cache[key] = func
+    return func
+
+
+def launch_co(func, grid, block, kernarg, stream=None, shared_mem=0):
+    """Launch ``func`` with a single packed ctypes.Structure kernarg via the HIP
+    BUFFER_POINTER/SIZE extra-config protocol (== ``AiterAsmKernel::launch``).
+
+    ``grid`` / ``block`` are (x, y, z) tuples. ``stream`` defaults to the current
+    torch stream so the launch is stream- and CUDA-graph-correct. ``kernarg`` is
+    kept alive by the caller for the duration of this call (ctypes holds a
+    borrowed pointer into it).
+    """
+    arg_size = ctypes.c_size_t(ctypes.sizeof(kernarg))
+    extra = (ctypes.c_void_p * 5)(
+        HIP_LAUNCH_PARAM_BUFFER_POINTER,
+        ctypes.cast(ctypes.byref(kernarg), ctypes.c_void_p),
+        HIP_LAUNCH_PARAM_BUFFER_SIZE,
+        ctypes.cast(ctypes.byref(arg_size), ctypes.c_void_p),
+        HIP_LAUNCH_PARAM_END,
+    )
+    if stream is None:
+        stream = torch.cuda.current_stream().cuda_stream
+    gx, gy, gz = grid
+    bx, by, bz = block
+    hip_check(
+        _get_hip().hipModuleLaunchKernel(
+            func,
+            gx,
+            gy,
+            gz,
+            bx,
+            by,
+            bz,
+            shared_mem,
+            ctypes.c_void_p(stream),
+            None,
+            extra,
+        ),
+        "hipModuleLaunchKernel",
+    )
+
+
+# ---------------------------------------------------------------------------
+# asm kernel registry (.csv) helpers. The aiter `hsa/<arch>/<op>/*.csv` files
+# map a shape/dtype tuple to a kernel symbol + .co name; the C++ dispatchers
+# consume them via hsa/codegen.py. These helpers let a Python launcher read the
+# SAME csv directly (no codegen), so the kernel registry stays single-sourced.
+# Nothing here is op-specific — pass the csv path (and which columns are
+# strings) at the call site.
+# ---------------------------------------------------------------------------
+# torch dtype -> short kernel-table string. Kept generic (the asm csv `qType` /
+# `kvType` columns use these). Extend as new kernel dtypes ship.
+_DTYPE_TO_STR = {
+    torch.float8_e4m3fn: "fp8",
+    torch.float8_e4m3fnuz: "fp8",
+    torch.bfloat16: "bf16",
+}
+
+
+def dtype_str(t: torch.Tensor) -> str:
+    """torch tensor/dtype -> short kernel-table string ('fp8' / 'bf16')."""
+    dt = t.dtype if isinstance(t, torch.Tensor) else t
+    s = _DTYPE_TO_STR.get(dt)
+    if s is None:
+        raise RuntimeError(f"unsupported dtype {dt} (no kernel-table string)")
+    return s
+
+
+def strip_csv_comments(lines):
+    """Yield only the header + data lines of an asm-registry csv, dropping blank
+    lines and ``//`` / ``#`` / ``;`` line comments and ``/* ... */`` blocks.
+
+    Mirrors the comment stripping hsa/codegen.py applies, so a Python reader
+    sees exactly the rows codegen would. Generic — works on any such csv."""
+    in_block = False
+    for line in lines:
+        s = line.strip()
+        if in_block:
+            if "*/" in s:
+                in_block = False
+            continue
+        if s.startswith("/*"):
+            if "*/" not in s:
+                in_block = True
+            continue
+        if not s or s.startswith(("//", "#", ";")):
+            continue
+        yield line
+
+
+# Columns that stay as strings; every other column is coerced to int. Matches
+# the asm-csv convention (all shape/flag columns are integers; only the dtype
+# and name columns are text). Callers may override via `str_cols`.
+DEFAULT_ASM_CSV_STR_COLS = frozenset({"qType", "kvType", "knl_name", "co_name"})
+
+
+@functools.lru_cache(maxsize=None)
+def load_asm_cfg_csv(csv_path, str_cols=DEFAULT_ASM_CSV_STR_COLS):
+    """Parse an asm-registry csv into a list of dict rows (process-cached per
+    path). Integer columns are coerced to int; `str_cols` stay as text. Rows
+    whose first column is empty (defensive) are skipped.
+
+    Reading the shipped csv at runtime keeps the kernel registry single-sourced
+    with the C++ codegen path instead of duplicating it in Python."""
+    if not os.path.isfile(csv_path):
+        raise FileNotFoundError(f"asm registry csv not found: {csv_path}")
+    cfgs = []
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(strip_csv_comments(f))
+        first_field = reader.fieldnames[0] if reader.fieldnames else None
+        for row in reader:
+            if first_field is not None and not (row.get(first_field) or "").strip():
+                continue
+            parsed = {}
+            for k, v in row.items():
+                if k is None or v is None:
+                    continue
+                v = v.strip()
+                parsed[k] = v if k in str_cols else int(v)
+            cfgs.append(parsed)
+    if not cfgs:
+        raise RuntimeError(f"no kernel rows parsed from {csv_path}")
+    return cfgs

--- a/aiter/ops/asm/asm_utils.py
+++ b/aiter/ops/asm/asm_utils.py
@@ -13,6 +13,7 @@ kernels off their C++ dispatchers:
                                      launch_co
   * asm kernel registry helpers   -> dtype_str / strip_csv_comments /
                                      load_asm_cfg_csv
+  * torch.compile interop          -> register_asm_custom_op
 
 The HIP handle is deliberately the SAME ``libamdhip64`` that torch already
 mapped (found by scanning ``/proc/self/maps``), so module-load / launch share
@@ -252,7 +253,7 @@ def strip_csv_comments(lines):
 DEFAULT_ASM_CSV_STR_COLS = frozenset({"qType", "kvType", "knl_name", "co_name"})
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def load_asm_cfg_csv(csv_path, str_cols=DEFAULT_ASM_CSV_STR_COLS):
     """Parse an asm-registry csv into a list of dict rows (process-cached per
     path). Integer columns are coerced to int; `str_cols` stay as text. Rows
@@ -279,3 +280,70 @@ def load_asm_cfg_csv(csv_path, str_cols=DEFAULT_ASM_CSV_STR_COLS):
     if not cfgs:
         raise RuntimeError(f"no kernel rows parsed from {csv_path}")
     return cfgs
+
+
+# ---------------------------------------------------------------------------
+# torch.compile interop
+#
+# A pure-Python ctypes ``.co`` launcher (see launch_co above) is opaque to
+# TorchDynamo: it can neither be traced into (untraceable C builtins + the
+# ctypes FFI) nor fake-run (it calls ``data_ptr()`` on FakeTensors). So any
+# function that reaches such a launch graph-breaks, and `torch.compile(
+# fullgraph=True)` over it raises.
+#
+# Registering the launch as an aiter custom op (schema inferred from the op
+# function's type hints, plus a fake/meta impl) makes Dynamo treat it as ONE
+# opaque graph node with known metadata: no graph break, and the real ctypes
+# launch still runs at execution time. This helper is the generic, op-agnostic
+# glue; each asm op only has to supply a schema-clean, type-annotated launch
+# function and the list of buffers it mutates.
+# ---------------------------------------------------------------------------
+def register_asm_custom_op(
+    op_name,
+    op_func,
+    mutates_args,
+    fake_impl=None,
+    dispatch_key="CUDA",
+):
+    """Register a pure-Python asm ``.co`` launcher as an aiter custom op so it is
+    ``torch.compile(fullgraph=True)``-safe.
+
+    Args:
+        op_name: op name under the ``aiter`` torch library (callable as
+            ``torch.ops.aiter.<op_name>``). Must be unique process-wide.
+        op_func: the launch function. It MUST be fully type-annotated (Tensor /
+            Optional[Tensor] / int / float / bool ...) because the op schema is
+            inferred from those hints via ``torch.library.infer_schema``; it may
+            NOT take a ``torch.cuda.Stream`` or other non-schema types (wrap the
+            real launcher in a thin, schema-clean adapter if needed).
+        mutates_args: names of the tensor args the kernel writes in place (the
+            aliasing the schema must record). For a pure in-place launch, list
+            every output/scratch buffer here.
+        fake_impl: meta/fake implementation. Omit it for a pure in-place op that
+            returns nothing (a no-op fake is registered); supply one that returns
+            correctly-shaped ``torch.empty_like``/``new_empty`` tensors if the op
+            has real return values.
+        dispatch_key: backend dispatch key (default "CUDA").
+
+    Returns:
+        The registered op callable (``torch.ops.aiter.<op_name>``).
+    """
+    # Lazy import: keeps this module import-light and dependency-scoped to torch
+    # + ctypes for callers that never register a compile-safe op.
+    from csrc.cpp_itfs.torch_utils import direct_register_custom_op
+
+    if fake_impl is None:
+
+        def fake_impl(*args, **kwargs):
+            # Pure in-place op: mutated buffers are declared via `mutates_args`,
+            # so the fake produces no new tensors.
+            return None
+
+    direct_register_custom_op(
+        op_name,
+        op_func,
+        mutates_args=list(mutates_args),
+        fake_impl=fake_impl,
+        dispatch_key=dispatch_key,
+    )
+    return getattr(torch.ops.aiter, op_name)

--- a/aiter/ops/asm/mla_decode_v4.py
+++ b/aiter/ops/asm/mla_decode_v4.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Pure-Python launcher for the gfx1250 v4 MLA decode ``.co`` kernel.
+
+This is the Python peer of ``csrc/py_itfs_cu/asm_mla_v4.cu`` for **gfx1250
+only**. It reproduces that dispatcher's gfx1250 "preload" path (the compact
+120-byte DIRECT_PARAM kernarg ABI) without the C++/ctypes-FFI host bridge:
+the shipped ``.co`` is loaded and launched directly from Python through the
+generic :mod:`aiter.ops.asm.asm_utils` helpers.
+
+Scope is intentionally narrow — it is a thin wrapper, exactly like the .cu:
+  * resolve the kernel binary via the shipped ``hsa/gfx1250/mla_v4`` registry
+    (``mla_v4_asm.csv``), using the same lookup keys as the C++ dispatcher;
+  * pack the 120-byte preload kernarg;
+  * compute the same launch geometry;
+  * launch.
+
+It does NOT handle gfx950 (that arch uses the legacy 21-slot kernarg and keeps
+going through the C++ dispatcher ``aiter.mla_decode_v4_asm``) and it does NOT
+touch v3. The public entry :func:`mla_decode_v4_asm_gfx1250` mirrors the
+signature of ``aiter.mla_decode_v4_asm`` so callers can swap between the two.
+"""
+
+import ctypes
+import math
+import os
+
+import torch
+
+from aiter.jit.core import get_asm_dir
+from aiter.ops.asm.asm_utils import (
+    dtype_str,
+    get_function,
+    get_warp_size,
+    launch_co,
+    load_asm_cfg_csv,
+)
+
+# kV4DimNope + kV4DimRope = 448 + 64 = 512. The kernel hardcodes 1/sqrt(512)
+# as its softmax pre-scale, independent of head_size (mirror asm_mla_v4.cu).
+_KV4_DIM_NOPE = 448
+_KV4_DIM_ROPE = 64
+
+_MLA_V4_SUBDIR = "mla_v4"
+_MLA_V4_CSV = "mla_v4_asm.csv"
+
+
+class MlaV4KernelArgsPreload(ctypes.Structure):
+    """120-byte compact preload kernarg (gfx1250 DIRECT_PARAM=1 ABI).
+
+    Byte-for-byte identical to ``MlaV4KernelArgsPreload`` in asm_mla_v4.cu
+    (the ``#if EN_MLA_V4_KERNARG_PRELOAD`` struct). Offsets are annotated to keep
+    the two definitions in lock-step.
+    """
+
+    _pack_ = 1
+    _fields_ = [
+        ("ptr_R", ctypes.c_void_p),  # 0x00 splitData (logits) FP32 (rw)
+        ("ptr_Q", ctypes.c_void_p),  # 0x08 Q packed FP8 + e8m0 scale
+        ("ptr_KV", ctypes.c_void_p),  # 0x10 KV packed FP8
+        ("ptr_LTP", ctypes.c_void_p),  # 0x18 kv_indptr
+        ("ptr_LTL", ctypes.c_void_p),  # 0x20 kv_last_page_lens
+        ("ptr_QTP", ctypes.c_void_p),  # 0x28 qo_indptr
+        ("ptr_QROPE", ctypes.c_void_p),  # 0x30 Q rope BF16
+        ("ptr_KVROPE", ctypes.c_void_p),  # 0x38 KV rope BF16
+        ("scalar_f", ctypes.c_float),  # 0x40 1/sqrt(512)
+        ("s_gqa_ratio", ctypes.c_uint32),  # 0x44 gqa_ratio * max_seqlen_q (MQA)
+        ("s_kv_split", ctypes.c_uint32),  # 0x48 num_kv_splits == passes
+        ("s_total_kv", ctypes.c_uint32),  # 0x4C kv_seq_lens * num_seqs
+        ("out_16_nosplit", ctypes.c_uint32),  # 0x50 0=fp32 split, 1=bf16 nosplit
+        ("ptr_LSE", ctypes.c_void_p),  # 0x54 splitLse (attn_lse) FP32 (rw)
+        ("ptr_LTD", ctypes.c_void_p),  # 0x5C kv_page_indices
+        ("ptr_valid_split", ctypes.c_void_p),  # 0x64 [num_seqs] i32 scratch (rw)
+        ("s_use_valid_split", ctypes.c_uint32),  # 0x6C gates valid_split write
+        ("ptr_sink", ctypes.c_void_p),  # 0x70 [num_heads] FP32 sink logit
+    ]
+
+
+assert ctypes.sizeof(MlaV4KernelArgsPreload) == 120, ctypes.sizeof(
+    MlaV4KernelArgsPreload
+)
+
+
+def _mla_v4_csv_path() -> str:
+    """Path to the shipped gfx1250 v4 kernel registry (``mla_v4_asm.csv``)."""
+    return os.path.join(get_asm_dir(), _MLA_V4_SUBDIR, _MLA_V4_CSV)
+
+
+def _get_heuristic_kernel(q_type, kv_type, gqa, ps, prefill, causal, qseqlen, lse):
+    """Return the CSV row matching the 8 lookup keys, or raise (mirror
+    asm_mla_v4.cu::get_heuristic_kernel_mla_v4). The registry is parsed once
+    (process-cached) by :func:`aiter.ops.asm.asm_utils.load_asm_cfg_csv`."""
+    for cfg in load_asm_cfg_csv(_mla_v4_csv_path()):
+        if cfg["qType"] != q_type or cfg["kvType"] != kv_type:
+            continue
+        if cfg["Gqa"] != gqa or cfg["ps"] != ps or cfg["prefill"] != prefill:
+            continue
+        if cfg["causal"] != causal or cfg["qSeqLen"] != qseqlen:
+            continue
+        if cfg["lse"] != lse:
+            continue
+        return cfg
+    raise RuntimeError(
+        f"mla_decode_v4_asm_gfx1250: no shipped variant for q_type:{q_type} "
+        f"kv_type:{kv_type} gqa:{gqa} ps:{ps} qSeqLen:{qseqlen} prefill:{prefill} "
+        f"causal:{causal} lse:{lse} arch:gfx1250"
+    )
+
+
+def mla_decode_v4_asm_gfx1250(
+    Q,
+    qrope,
+    KV,
+    kvrope,
+    qo_indptr,
+    kv_indptr,
+    kv_page_indices,
+    split_indptr,
+    sink,
+    max_seqlen_q,
+    softmax_scale,
+    out_16_nosplit,
+    num_kv_splits,
+    splitData,
+    splitLse,
+    output,
+    valid_split_count=None,
+    use_valid_split_count_reduce=0,
+    kv_last_page_lens=None,
+    stream=None,
+):
+    """gfx1250 v4 nm decode stage1 launch — Python peer of
+    ``aiter.mla_decode_v4_asm`` (asm_mla_v4.cu) restricted to the gfx1250
+    preload path. Same call signature; ``softmax_scale`` and ``split_indptr``
+    are accepted for parity but unused on this ABI (the preload kernarg carries
+    neither: the kernel hardcodes 1/sqrt(512) and derives splits from
+    s_kv_split)."""
+    del softmax_scale  # kernel hardcodes 1/sqrt(512)
+    del split_indptr  # not part of the compact preload kernarg
+
+    # ---- contract checks (mirror the AITER_CHECKs in the .cu) --------------
+    if sink is None or sink.data_ptr() == 0:
+        raise ValueError("mla_decode_v4_asm_gfx1250: `sink` must not be NULL")
+    if not (Q.is_contiguous() and KV.is_contiguous()):
+        raise ValueError(
+            "mla_decode_v4_asm_gfx1250: only support Q/KV.is_contiguous() for now"
+        )
+    if not (qrope.is_contiguous() and kvrope.is_contiguous()):
+        raise ValueError(
+            "mla_decode_v4_asm_gfx1250: only support qrope/kvrope.is_contiguous()"
+        )
+
+    num_seqs = qo_indptr.shape[0] - 1
+    num_heads = Q.size(1)
+    num_kv_heads = KV.size(2)
+    gqa_ratio = num_heads // num_kv_heads
+    page_size = KV.size(1)
+    dim_qk_packed = KV.size(3)
+    q_type = dtype_str(Q)
+    kv_type = dtype_str(KV)
+    scalar_f = 1.0 / math.sqrt(float(_KV4_DIM_NOPE + _KV4_DIM_ROPE))
+    ps = prefill = causal = lse_flag = 0
+
+    if num_kv_heads != 1:
+        raise ValueError(
+            "mla_decode_v4_asm_gfx1250: only support num_kv_heads==1 for now"
+        )
+    if Q.size(2) != dim_qk_packed:
+        raise ValueError(
+            "mla_decode_v4_asm_gfx1250: Q head_size must equal KV head_size "
+            "(= dim_qk_packed)"
+        )
+
+    # ---- Kernel selection: pure CSV table lookup (no computed heuristic) ---
+    cfg = _get_heuristic_kernel(
+        q_type, kv_type, gqa_ratio, ps, prefill, causal, max_seqlen_q, lse_flag
+    )
+    sub_Q = int(cfg["sub_Q"])
+    co_path = os.path.join(get_asm_dir(), _MLA_V4_SUBDIR, cfg["co_name"])
+    func = get_function(co_path, cfg["knl_name"])
+
+    # ---- pack the 120-byte preload kernarg ---------------------------------
+    args = MlaV4KernelArgsPreload()
+    args.ptr_R = splitData.data_ptr()
+    args.ptr_Q = Q.data_ptr()
+    args.ptr_KV = KV.data_ptr()
+    args.ptr_LTP = kv_indptr.data_ptr()
+    args.ptr_LTL = kv_last_page_lens.data_ptr() if kv_last_page_lens is not None else None
+    args.ptr_QTP = qo_indptr.data_ptr()
+    args.ptr_QROPE = qrope.data_ptr()
+    args.ptr_KVROPE = kvrope.data_ptr()
+    args.scalar_f = scalar_f
+    args.s_gqa_ratio = gqa_ratio * max_seqlen_q
+    args.s_kv_split = int(num_kv_splits)
+    args.s_total_kv = KV.size(0) * page_size
+    args.out_16_nosplit = int(out_16_nosplit)
+    args.ptr_LSE = splitLse.data_ptr()
+    args.ptr_LTD = kv_page_indices.data_ptr()
+    if use_valid_split_count_reduce != 0:
+        if valid_split_count is None or valid_split_count.data_ptr() == 0:
+            raise ValueError(
+                "mla_decode_v4_asm_gfx1250: gfx1250 requires valid_split_count "
+                "scratch tensor when use_valid_split_count_reduce!=0"
+            )
+    if valid_split_count is not None and valid_split_count.data_ptr() != 0:
+        if valid_split_count.dtype != torch.int32:
+            raise ValueError(
+                "mla_decode_v4_asm_gfx1250: valid_split_count must be int32"
+            )
+        if valid_split_count.size(0) < num_seqs:
+            raise ValueError(
+                "mla_decode_v4_asm_gfx1250: valid_split_count must have at least "
+                "num_seqs entries"
+            )
+        args.ptr_valid_split = valid_split_count.data_ptr()
+    else:
+        args.ptr_valid_split = None
+    args.s_use_valid_split = 1 if use_valid_split_count_reduce != 0 else 0
+    args.ptr_sink = sink.data_ptr()
+
+    # ---- launch geometry (mirror asm_mla_v4.cu) ----------------------------
+    #   gdx = ceil(gqa*max_seqlen_q / sub_Q), gdy = num_seqs, gdz = num_kv_splits
+    #   block = 4 * warp_size
+    block_dim = 4 * get_warp_size()
+    q_seq_lens_internal = gqa_ratio * max_seqlen_q
+    gdx = (q_seq_lens_internal + sub_Q - 1) // sub_Q
+    gdy = num_seqs
+    gdz = int(num_kv_splits)
+
+    launch_co(func, (gdx, gdy, gdz), (block_dim, 1, 1), args, stream=stream)

--- a/aiter/ops/asm/mla_decode_v4.py
+++ b/aiter/ops/asm/mla_decode_v4.py
@@ -35,6 +35,7 @@ from aiter.ops.asm.asm_utils import (
     get_warp_size,
     launch_co,
     load_asm_cfg_csv,
+    register_asm_custom_op,
 )
 
 # kV4DimNope + kV4DimRope = 448 + 64 = 512. The kernel hardcodes 1/sqrt(512)
@@ -108,34 +109,37 @@ def _get_heuristic_kernel(q_type, kv_type, gqa, ps, prefill, causal, qseqlen, ls
     )
 
 
-def mla_decode_v4_asm_gfx1250(
-    Q,
-    qrope,
-    KV,
-    kvrope,
-    qo_indptr,
-    kv_indptr,
-    kv_page_indices,
-    split_indptr,
-    sink,
-    max_seqlen_q,
-    softmax_scale,
-    out_16_nosplit,
-    num_kv_splits,
-    splitData,
-    splitLse,
-    output,
-    valid_split_count=None,
-    use_valid_split_count_reduce=0,
-    kv_last_page_lens=None,
-    stream=None,
+def mla_decode_v4_asm_gfx1250_eager(
+    Q: torch.Tensor,
+    qrope: torch.Tensor,
+    KV: torch.Tensor,
+    kvrope: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_page_indices: torch.Tensor,
+    split_indptr: torch.Tensor,
+    sink: torch.Tensor,
+    max_seqlen_q: int,
+    softmax_scale: float,
+    out_16_nosplit: int,
+    num_kv_splits: int,
+    splitData: torch.Tensor,
+    splitLse: torch.Tensor,
+    output: torch.Tensor,
+    valid_split_count: torch.Tensor | None = None,
+    use_valid_split_count_reduce: int = 0,
+    kv_last_page_lens: torch.Tensor | None = None,
 ):
-    """gfx1250 v4 nm decode stage1 launch — Python peer of
-    ``aiter.mla_decode_v4_asm`` (asm_mla_v4.cu) restricted to the gfx1250
+    """gfx1250 v4 nm decode stage1 launch (eager, pure Python + ctypes) — Python
+    peer of ``aiter.mla_decode_v4_asm`` (asm_mla_v4.cu) restricted to the gfx1250
     preload path. Same call signature; ``softmax_scale`` and ``split_indptr``
     are accepted for parity but unused on this ABI (the preload kernarg carries
     neither: the kernel hardcodes 1/sqrt(512) and derives splits from
-    s_kv_split)."""
+    s_kv_split).
+
+    This is the raw launcher: lowest host overhead, but opaque to TorchDynamo.
+    Prefer the :func:`mla_decode_v4_asm_gfx1250` dispatcher, which routes to the
+    ``torch.compile``-safe custom op while tracing and here otherwise."""
     del softmax_scale  # kernel hardcodes 1/sqrt(512)
     del split_indptr  # not part of the compact preload kernarg
 
@@ -186,7 +190,9 @@ def mla_decode_v4_asm_gfx1250(
     args.ptr_Q = Q.data_ptr()
     args.ptr_KV = KV.data_ptr()
     args.ptr_LTP = kv_indptr.data_ptr()
-    args.ptr_LTL = kv_last_page_lens.data_ptr() if kv_last_page_lens is not None else None
+    args.ptr_LTL = (
+        kv_last_page_lens.data_ptr() if kv_last_page_lens is not None else None
+    )
     args.ptr_QTP = qo_indptr.data_ptr()
     args.ptr_QROPE = qrope.data_ptr()
     args.ptr_KVROPE = kvrope.data_ptr()
@@ -197,12 +203,13 @@ def mla_decode_v4_asm_gfx1250(
     args.out_16_nosplit = int(out_16_nosplit)
     args.ptr_LSE = splitLse.data_ptr()
     args.ptr_LTD = kv_page_indices.data_ptr()
-    if use_valid_split_count_reduce != 0:
-        if valid_split_count is None or valid_split_count.data_ptr() == 0:
-            raise ValueError(
-                "mla_decode_v4_asm_gfx1250: gfx1250 requires valid_split_count "
-                "scratch tensor when use_valid_split_count_reduce!=0"
-            )
+    if use_valid_split_count_reduce != 0 and (
+        valid_split_count is None or valid_split_count.data_ptr() == 0
+    ):
+        raise ValueError(
+            "mla_decode_v4_asm_gfx1250: gfx1250 requires valid_split_count "
+            "scratch tensor when use_valid_split_count_reduce!=0"
+        )
     if valid_split_count is not None and valid_split_count.data_ptr() != 0:
         if valid_split_count.dtype != torch.int32:
             raise ValueError(
@@ -228,4 +235,161 @@ def mla_decode_v4_asm_gfx1250(
     gdy = num_seqs
     gdz = int(num_kv_splits)
 
-    launch_co(func, (gdx, gdy, gdz), (block_dim, 1, 1), args, stream=stream)
+    launch_co(func, (gdx, gdy, gdz), (block_dim, 1, 1), args)
+
+
+# ---------------------------------------------------------------------------
+# torch.compile support.
+#
+# The launcher above is pure Python + ctypes, so it graph-breaks under
+# `torch.compile(fullgraph=True)`. Exposing it as an aiter custom op via the
+# generic `register_asm_custom_op` helper (asm_utils) makes Dynamo treat the
+# launch as one opaque graph node. This does NOT change the eager dispatch in
+# aiter/mla.py; callers opt in via
+# `torch.ops.aiter.mla_decode_v4_asm_gfx1250(...)`. Only the schema-clean,
+# type-annotated adapter below is op-specific — the registration + no-op fake
+# are shared.
+# ---------------------------------------------------------------------------
+# TODO(mla-pyco): remove this adapter once ``mla_decode_v4_asm_gfx1250_eager``
+# can be registered as a custom op directly. ``_eager`` is now fully type
+# annotated, so ``torch.library.infer_schema`` can derive a schema from it.
+# The ONLY remaining reason this adapter still exists is ARG ORDER (verified
+# empirically): ``_eager`` uses the C-ABI parity order (SymInt scalars BEFORE
+# the mutated buffers), and registering that order makes ``fullgraph=True`` fail
+# ("Attempted to call function marked as skipped"), because a SymInt ahead of
+# the mutated tensors breaks torch's auto-functionalization arg boxing. The
+# buffer-first order below is what makes fullgraph pass (12/12); this adapter
+# just reorders to buffer-first and forwards to ``_eager``.
+#
+# To drop it in the future, move the mutated buffers (``splitData`` /
+# ``splitLse`` / ``output`` / ``valid_split_count``) ahead of the SymInt scalars
+# in ``_eager`` itself, then pass ``_eager`` straight to
+# ``register_asm_custom_op`` and update the ``mla_decode_v4_asm_gfx1250``
+# dispatcher to the new arg order. The cost is that ``_eager`` stops mirroring
+# ``aiter.mla_decode_v4_asm``'s C-ABI signature. Alternatively, revisit if a
+# newer torch fixes the SymInt-before-mutated-tensor auto-functionalization
+# ordering constraint, which would remove the need entirely.
+def _mla_decode_v4_asm_gfx1250_op(
+    Q: torch.Tensor,
+    qrope: torch.Tensor,
+    KV: torch.Tensor,
+    kvrope: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_page_indices: torch.Tensor,
+    split_indptr: torch.Tensor,
+    sink: torch.Tensor,
+    splitData: torch.Tensor,
+    splitLse: torch.Tensor,
+    output: torch.Tensor,
+    valid_split_count: torch.Tensor | None,
+    max_seqlen_q: int,
+    softmax_scale: float,
+    out_16_nosplit: int,
+    num_kv_splits: int,
+    use_valid_split_count_reduce: int,
+    kv_last_page_lens: torch.Tensor | None = None,
+) -> None:
+    """Schema-clean, `torch.compile`-safe entry point for the gfx1250 v4 nm
+    launch. Thin adapter: reorders args to the positional signature of
+    :func:`mla_decode_v4_asm_gfx1250` (which carries keyword defaults torch
+    schema inference cannot represent) and forwards to it.
+
+    NOTE: the mutated tensors (`splitData` / `splitLse` / `output` /
+    `valid_split_count`) are deliberately placed BEFORE the SymInt scalars here.
+    Putting a value-0 SymInt (e.g. out_16_nosplit=0) ahead of the mutated tensors
+    trips torch's auto-functionalization arg boxing under
+    `torch.compile(fullgraph=True)` (it mis-types a later SymInt as a Tensor), so
+    this buffer-first order is load-bearing, not cosmetic."""
+    mla_decode_v4_asm_gfx1250_eager(
+        Q,
+        qrope,
+        KV,
+        kvrope,
+        qo_indptr,
+        kv_indptr,
+        kv_page_indices,
+        split_indptr,
+        sink,
+        max_seqlen_q,
+        softmax_scale,
+        out_16_nosplit,
+        num_kv_splits,
+        splitData,
+        splitLse,
+        output,
+        valid_split_count,
+        use_valid_split_count_reduce,
+        kv_last_page_lens,
+    )
+
+
+# Pure in-place op (writes splitData/splitLse/output/valid_split_count), so the
+# default no-op fake in register_asm_custom_op suffices — no fake_impl needed.
+mla_decode_v4_asm_gfx1250_compiled = register_asm_custom_op(
+    "mla_decode_v4_asm_gfx1250",
+    _mla_decode_v4_asm_gfx1250_op,
+    mutates_args=["splitData", "splitLse", "output", "valid_split_count"],
+)
+
+
+def mla_decode_v4_asm_gfx1250(
+    Q,
+    qrope,
+    KV,
+    kvrope,
+    qo_indptr,
+    kv_indptr,
+    kv_page_indices,
+    split_indptr,
+    sink,
+    max_seqlen_q,
+    softmax_scale,
+    out_16_nosplit,
+    num_kv_splits,
+    splitData,
+    splitLse,
+    output,
+    valid_split_count=None,
+    use_valid_split_count_reduce=0,
+    kv_last_page_lens=None,
+):
+    """gfx1250 v4 nm decode stage1 launch — always via the registered custom op.
+
+    Signature-compatible drop-in for the raw launcher, so callers (aiter/mla.py)
+    need no change. It ALWAYS routes through the custom op
+    ``torch.ops.aiter.mla_decode_v4_asm_gfx1250``: in eager it dispatches
+    straight to the ctypes launcher, and under ``torch.compile`` /
+    ``torch.export`` it becomes ONE opaque, ``fullgraph=True``-safe graph node.
+    This is the idiomatic "just wrap it as a custom op" pattern — one code path
+    for eager + traced, no ``is_compiling()`` branch to keep in sync. The launch
+    always runs on torch's current stream (as compiled/traced graphs require).
+
+    The op reorders the mutated buffers (``splitData`` / ``splitLse`` /
+    ``output`` / ``valid_split_count``) ahead of the SymInt scalars, as required
+    by torch's auto-functionalization (see ``_mla_decode_v4_asm_gfx1250_op``).
+    ``valid_split_count`` is an optional mutated tensor (``Tensor(a!)?``), so
+    ``None`` is accepted (null scratch ptr) in eager and under compile alike —
+    no separate fallback path is needed.
+    """
+    torch.ops.aiter.mla_decode_v4_asm_gfx1250(
+        Q,
+        qrope,
+        KV,
+        kvrope,
+        qo_indptr,
+        kv_indptr,
+        kv_page_indices,
+        split_indptr,
+        sink,
+        splitData,
+        splitLse,
+        output,
+        valid_split_count,
+        max_seqlen_q,
+        softmax_scale,
+        int(out_16_nosplit),
+        int(num_kv_splits),
+        int(use_valid_split_count_reduce),
+        kv_last_page_lens,
+    )

--- a/csrc/py_itfs_cu/asm_mla_v4.cu
+++ b/csrc/py_itfs_cu/asm_mla_v4.cu
@@ -42,10 +42,6 @@
 // RuntimeError in Python instead of aborting the worker process.
 AITER_CTYPES_ERROR_DEF
 
-#ifndef EN_MLA_V4_KERNARG_PRELOAD
-#define EN_MLA_V4_KERNARG_PRELOAD 1
-#endif
-
 struct __attribute__((packed)) MlaV4KernelArgsLegacy
 {
     void* ptr_R;
@@ -91,30 +87,6 @@ struct __attribute__((packed)) MlaV4KernelArgsLegacy
     unsigned int s_use_valid_split;
     p3 _p_uvs; // 20 (0x140)
 };
-
-#if EN_MLA_V4_KERNARG_PRELOAD
-struct __attribute__((packed)) MlaV4KernelArgsPreload
-{
-    void* ptr_R;                    // 0x00  preload  splitData (logits) [FP32] (rw)
-    void* ptr_Q;                    // 0x08  preload  Q packed FP8 + e8m0 scale
-    void* ptr_KV;                   // 0x10  preload  KV packed FP8
-    void* ptr_LTP;                  // 0x18  preload  kv_indptr
-    void* ptr_LTL;                  // 0x20  preload  kv_last_page_lens
-    void* ptr_QTP;                  // 0x28  preload  qo_indptr
-    void* ptr_QROPE;                // 0x30  preload  Q rope BF16
-    void* ptr_KVROPE;               // 0x38  preload  KV rope BF16
-    float scalar_f;                 // 0x40  preload  1.0f/sqrtf(kV4DimNope+kV4DimRope)
-    unsigned int s_gqa_ratio;       // 0x44  preload  q_seq_lens (MQA = gqa*max_seqlen_q)
-    unsigned int s_kv_split;        // 0x48  preload  num_kv_splits == passes
-    unsigned int s_total_kv;        // 0x4C  preload  kv_seq_lens * num_seqs
-    unsigned int out_16_nosplit;    // 0x50  preload  0 = fp32 split, 1 = bf16 nosplit
-    void* ptr_LSE;                  // 0x54  tail     splitLse (attn_lse) [FP32] (rw)
-    void* ptr_LTD;                  // 0x5C  tail     kv_page_indices
-    void* ptr_valid_split;          // 0x64  tail     [num_seqs] i32 scratch (rw)
-    unsigned int s_use_valid_split; // 0x6C  tail     gates the valid_split write
-    void* ptr_sink;                 // 0x70  tail     [num_heads] FP32 attention sink logit
-};
-#endif
 
 // ----------------------------------------------------------------------------
 // kV4DimNope + kV4DimRope = 448 + 64 = 512. The kernel hardcodes
@@ -290,42 +262,13 @@ AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
         a.scalar_f    = scalar_f;
         a.s_gqa_ratio = static_cast<unsigned int>(gqa_ratio);
         a.s_kv_split  = static_cast<unsigned int>(num_kv_splits);
-        // a.s_total_kv     left as 0 here — set per-arch in fill_gfx1250_kargs below.
+        // a.s_total_kv left as 0 here (default zero-init); the non-gfx1250
+        // legacy .co derives its KV extent from the indptr tables instead.
         a.ptr_QTP        = qo_indptr->data_ptr();
         a.out_16_nosplit = out_16_nosplit_derived;
         a.ptr_QROPE      = qrope->data_ptr();
         a.ptr_KVROPE     = kvrope->data_ptr();
         a.ptr_sink       = sink->data_ptr();
-    };
-
-    // gfx1250-specific overrides (shared by both legacy-on-gfx1250 and the
-    // compact preload ABI): s_gqa_ratio carries the flattened MQA, s_total_kv
-    // is real, and the valid_split scratch (slot 19/20) is validated+forwarded.
-    auto fill_gfx1250_kargs = [&](auto& a) {
-        a.s_gqa_ratio = static_cast<unsigned int>(gqa_ratio * max_seqlen_q);
-        a.s_total_kv  = static_cast<unsigned int>(KV->size(0) * page_size);
-        if(use_valid_split_count_reduce != 0)
-        {
-            AITER_CHECK(valid_split_count != nullptr && valid_split_count->data_ptr() != nullptr,
-                        __func__,
-                        ": gfx1250 requires valid_split_count scratch tensor when "
-                        "use_valid_split_count_reduce!=0");
-        }
-        if(valid_split_count != nullptr && valid_split_count->data_ptr() != nullptr)
-        {
-            AITER_CHECK(valid_split_count->dtype() == AITER_DTYPE_i32,
-                        __func__,
-                        ": valid_split_count must be int32");
-            AITER_CHECK(valid_split_count->size(0) >= num_seqs,
-                        __func__,
-                        ": valid_split_count must have at least num_seqs entries");
-            a.ptr_valid_split = valid_split_count->data_ptr();
-        }
-        else
-        {
-            a.ptr_valid_split = nullptr;
-        }
-        a.s_use_valid_split = (use_valid_split_count_reduce != 0) ? 1u : 0u;
     };
 
     // dtype dispatch
@@ -407,90 +350,54 @@ AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
     // the heuristic above — this remap only picks which CSV row (== which .co)
     // to load.
     const std::string arch_id = get_gpu_arch();
-    const bool is_gfx1250     = (arch_id == "gfx1250");
-    int csv_gqa               = gqa_ratio;
-    int csv_qseqlen           = config_max_seqlen_q;
-    if(!is_gfx1250)
+    // gfx1250 v4 nm is launched directly from Python via the .co launcher
+    // (aiter/ops/asm/mla_decode_v4.py, routed by aiter/mla.py); this C++
+    // dispatcher intentionally no longer supports it. Fail loudly rather than
+    // silently packing the wrong (legacy) kernarg ABI for a gfx1250 caller.
+    AITER_CHECK(arch_id != "gfx1250",
+                __func__,
+                ": gfx1250 v4 nm is handled by the Python .co launcher "
+                "(aiter/ops/asm/mla_decode_v4.py); this C++ dispatcher does not "
+                "support gfx1250");
+    int csv_gqa     = gqa_ratio;
+    int csv_qseqlen = config_max_seqlen_q;
+    // `supported` (fp8-gated, set in the sub_Q block above) drives BOTH the
+    // (sub_Q, config) setup AND this CSV lookup-key normalization, so the two
+    // can never disagree -- every whitelisted (gqa, msq) pair maps to the
+    // single shipped (Gqa=64, qSeqLen=1) row. NOTE: an intermediate change
+    // had narrowed this to only (gqa16,msq4)/(gqa64|128,msq1), which dropped
+    // the gqa16+msq{1,2} and gqa32+msq1 entry points -- they hit "cannot find
+    // suitable kernel" even though the qh64 .co serves them and the sub_Q
+    // block still whitelists them (see test_v4_nm_gqa16_qseqlen1_*).
+    if(supported)
     {
-        // `supported` (fp8-gated, set in the sub_Q block above) drives BOTH the
-        // (sub_Q, config) setup AND this CSV lookup-key normalization, so the two
-        // can never disagree -- every whitelisted (gqa, msq) pair maps to the
-        // single shipped (Gqa=64, qSeqLen=1) row. NOTE: an intermediate change
-        // had narrowed this to only (gqa16,msq4)/(gqa64|128,msq1), which dropped
-        // the gqa16+msq{1,2} and gqa32+msq1 entry points -- they hit "cannot find
-        // suitable kernel" even though the qh64 .co serves them and the sub_Q
-        // block still whitelists them (see test_v4_nm_gqa16_qseqlen1_*).
-        if(supported)
-        {
-            csv_gqa     = 64;
-            csv_qseqlen = 1;
-        }
-    }
-    else
-    {
-        // shared kernel mla_a8w8_qh64_1tg_16mx4_64nx1_sparse
-        if(q_type == "fp8" && kv_type == "fp8" &&
-           ((gqa_ratio == 64 || gqa_ratio == 128) && config_max_seqlen_q == 1))
-        {
-            csv_gqa     = 64;
-            csv_qseqlen = 1;
-        }
+        csv_gqa     = 64;
+        csv_qseqlen = 1;
     }
 
     const int block_dim = 4 * static_cast<int>(get_warp_size_func());
 
-#if EN_MLA_V4_KERNARG_PRELOAD
-    const bool use_preload = is_gfx1250;
-#else
-    const bool use_preload = false;
-#endif
-
     MlaV4KernelArgsLegacy args_legacy = {};
-#if EN_MLA_V4_KERNARG_PRELOAD
-    MlaV4KernelArgsPreload args_preload = {};
-#endif
-    void* arg_buf   = nullptr;
-    size_t arg_size = 0;
-
-    if(use_preload)
+    fill_common_kargs(args_legacy);
+    args_legacy.s_log2_page = log2_page;
+    args_legacy.ptr_STP     = split_indptr->data_ptr();
+    if(valid_split_count != nullptr && valid_split_count->data_ptr() != nullptr)
     {
-#if EN_MLA_V4_KERNARG_PRELOAD
-        fill_common_kargs(args_preload);
-        fill_gfx1250_kargs(args_preload);
-        arg_buf  = &args_preload;
-        arg_size = sizeof(args_preload);
-#endif
+        AITER_CHECK(valid_split_count->dtype() == AITER_DTYPE_i32,
+                    __func__,
+                    ": valid_split_count must be int32");
+        AITER_CHECK(valid_split_count->size(0) >= num_seqs,
+                    __func__,
+                    ": valid_split_count must have at least num_seqs entries");
+        args_legacy.ptr_valid_split = valid_split_count->data_ptr();
     }
     else
     {
-        fill_common_kargs(args_legacy);
-        args_legacy.s_log2_page = log2_page;
-        args_legacy.ptr_STP     = split_indptr->data_ptr();
-        if(is_gfx1250)
-        {
-            fill_gfx1250_kargs(args_legacy);
-        }
-        else
-        {
-            if(valid_split_count != nullptr && valid_split_count->data_ptr() != nullptr)
-            {
-                AITER_CHECK(valid_split_count->dtype() == AITER_DTYPE_i32,
-                            __func__,
-                            ": valid_split_count must be int32");
-                AITER_CHECK(valid_split_count->size(0) >= num_seqs,
-                            __func__,
-                            ": valid_split_count must have at least num_seqs entries");
-                args_legacy.ptr_valid_split = valid_split_count->data_ptr();
-            }
-            else
-            {
-                args_legacy.ptr_valid_split = nullptr;
-            }
-            args_legacy.s_use_valid_split = (use_valid_split_count_reduce != 0) ? 1u : 0u;
-        }
-        arg_buf  = &args_legacy;
-        arg_size = sizeof(args_legacy);
+        args_legacy.ptr_valid_split = nullptr;
     }
+    args_legacy.s_use_valid_split = (use_valid_split_count_reduce != 0) ? 1u : 0u;
+    void* arg_buf                 = &args_legacy;
+    size_t arg_size               = sizeof(args_legacy);
 
     CFG* config_map = &cfg_mla_v4_asm;
     static SynchronizedCache<std::string_view, AiterAsmKernel> impl_ptr_map;

--- a/hsa/gfx1250/mla_v4/mla_v4_asm.csv
+++ b/hsa/gfx1250/mla_v4/mla_v4_asm.csv
@@ -1,3 +1,10 @@
-qType,kvType,Gqa,ps,qSeqLen,prefill,causal,lse,knl_name,co_name
-fp8,fp8,64,0,1,0,0,0,_ZN5aiter35mla_a8w8_qh64_1tg_16mx4_64nx1_sparseE,mla_a8w8_qh64_1tg_16mx4_64nx1_sparse.co
-fp8,fp8,16,0,4,0,0,0,_ZN5aiter35mla_a8w8_qh16_1tg_16mx4_64nx1_sparseE,mla_a8w8_qh16_1tg_16mx4_64nx1_sparse.co
+// `sub_Q` (per-workgroup Q-row tile) is a property baked into each .co, so it
+// lives here as a column instead of being recomputed by the dispatcher. The
+// Python launcher (aiter/ops/asm/mla_decode_v4.py) reads it verbatim and uses it for
+// grid math (gdx = ceil(gqa*max_seqlen_q / sub_Q)). NOTE: the C++ dispatcher
+// (asm_mla_v4.cu) does NOT read this column (it computes sub_Q itself); the
+// column is only consumed by the Python gfx1250 path.
+qType,kvType,Gqa,ps,qSeqLen,prefill,causal,lse,sub_Q,knl_name,co_name
+fp8,fp8,64,0,1,0,0,0,64,_ZN5aiter35mla_a8w8_qh64_1tg_16mx4_64nx1_sparseE,mla_a8w8_qh64_1tg_16mx4_64nx1_sparse.co
+fp8,fp8,128,0,1,0,0,0,64,_ZN5aiter35mla_a8w8_qh64_1tg_16mx4_64nx1_sparseE,mla_a8w8_qh64_1tg_16mx4_64nx1_sparse.co
+fp8,fp8,16,0,4,0,0,0,64,_ZN5aiter35mla_a8w8_qh16_1tg_16mx4_64nx1_sparseE,mla_a8w8_qh16_1tg_16mx4_64nx1_sparse.co


### PR DESCRIPTION
## Motivation

The gfx1250 v4 "nm" MLA decode kernel currently reaches its shipped `.co`
through the C++ host dispatcher (`csrc/py_itfs_cu/asm_mla_v4.cu`), which
requires building and maintaining a C++/ctypes-FFI bridge just to load and
launch a prebuilt asm kernel. This PR removes that dependency for gfx1250 by
launching the `.co` directly from Python, making the path easier to iterate on
and reuse when porting other aiter asm kernels off their C++ dispatchers.

## Technical Details

- Add a generic, kernel-agnostic launch layer `aiter/ops/asm/asm_utils.py`:
  loads the *same* `libamdhip64` that torch already mapped (scanned via
  `/proc/self/maps`) so module-load / launch share torch's driver context and
  stream state and avoid ROCR symbol-version clashes. Provides
  `get_warp_size`, `load_hip` / `hip_check` / `get_function` / `launch_co`,
  and CSV registry helpers (`dtype_str` / `strip_csv_comments` /
  `load_asm_cfg_csv`). HIP is bound lazily on first launch, so
  `import aiter.mla` stays side-effect-free on non-gfx1250 hosts.
- Add `aiter/ops/asm/mla_decode_v4.py`: a thin Python peer of the gfx1250
  "preload" path in `asm_mla_v4.cu`. It reproduces the compact 120-byte
  `DIRECT_PARAM` kernarg ABI (`MlaV4KernelArgsPreload`, byte-for-byte identical
  offsets to the `.cu` struct, guarded by a `ctypes.sizeof(...) == 120`
  assert), resolves the kernel via the shipped registry, computes launch
  geometry (`gdx = ceil(gqa*max_seqlen_q / sub_Q)`), and launches. The public
  `mla_decode_v4_asm_gfx1250` mirrors the signature of
  `aiter.mla_decode_v4_asm` so the two are drop-in swappable.
- Route in `aiter/mla.py::mla_decode_fwd_v4_nm`: gfx1250 dispatches to the new
  Python launcher; every other arch (e.g. gfx950, which uses the legacy 21-slot
  kernarg) keeps going through the canonical C-ABI dispatcher. Pure routing
  decision — identical call signatures.
- Extend the gfx1250 registry `hsa/gfx1250/mla_v4/mla_v4_asm.csv` with a
  `sub_Q` column (per-workgroup Q-row tile, baked into each `.co`) consumed
  only by the Python launcher for grid math, plus support for CSV comments.
  Adds the `Gqa=128, qSeqLen=1` entry aliased to the shipped qh64 `.co`.
- Add `aiter/ops/asm/__init__.py` (license header only).

## Test Plan

Ran the v4 nm op-test on gfx1250 (accuracy vs a torch fp8-dequant reference +
perf sweep): 
```python ./test_mla_v4_kargpreld.py```
