### PR TITLE
perf(dsv4): hoist q/kv data load in fine-grained qk-norm-rope kernel

### DIFF
--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -5115,15 +5115,21 @@ namespace aiter {
       if (token_idx >= params.num_tokens) return;
       const bool is_k_wave = (combined_head_idx == 0);  // V4 MQA: single K wave
 
-      // Clamp position into [0, max_position) before indexing the RoPE tables so a
-      // stale / OOB position on a CG-pad token can't read cos/sin out of bounds.
-      int32_t rope_pos = static_cast<int32_t>(positions[token_idx]);
-      if (params.max_position > 0)
-        rope_pos = rope_pos < 0 ? 0
-                 : (rope_pos >= params.max_position ? params.max_position - 1 : rope_pos);
-      const int32_t cos_sin_offset = rope_pos * (pe_dim >> 1);
-      const scalar_t* cos_ptr = cos_cache + cos_sin_offset;
-      const scalar_t* sin_ptr = sin_cache + cos_sin_offset;
+      // Perf (load hoisting): the RoPE cos/sin pointers need positions[token_idx], a
+      // dependent (pointer-chase) scalar load. Computing them here (up front) makes that
+      // load stall ahead of the main q/kv global load. Instead, each branch below issues
+      // its q/kv data load FIRST, then computes these ptrs -- so the data load's long
+      // global-memory latency overlaps the positions load + address setup. Measured
+      // ~5-10% faster at small-T (decode, latency-bound); numerically identical.
+      auto compute_rope_ptrs = [&](const scalar_t*& cos_ptr, const scalar_t*& sin_ptr) {
+        int32_t rope_pos = static_cast<int32_t>(positions[token_idx]);
+        if (params.max_position > 0)
+          rope_pos = rope_pos < 0 ? 0
+                   : (rope_pos >= params.max_position ? params.max_position - 1 : rope_pos);
+        const int32_t cos_sin_offset = rope_pos * (pe_dim >> 1);
+        cos_ptr = cos_cache + cos_sin_offset;
+        sin_ptr = sin_cache + cos_sin_offset;
+      };
 
       if (is_k_wave) {
         // ===== K: RMSNorm over head_dim, e8m0 group-quant nope, RoPE pe (bf16) =====
@@ -5133,6 +5139,15 @@ namespace aiter {
         auto* ptr_o = kv_cache + kv_cache_offset + nope_offset; // single KV head
         auto buffer_kv = opus::make_gmem<scalar_t>(kv_ptr, oob_i * sizeof(scalar_t));
         auto buffer_o  = opus::make_gmem<cache_t>(ptr_o, oob_o * sizeof(cache_t));
+
+        // Load hoisting: issue the main K data load FIRST so its latency overlaps the
+        // positions load + scalar setup below (instead of stacking after them).
+        opus_vec_i vec_kv =
+            load_vector_nbytes<scalar_t, vec_size_i, in_chunk_bytes, IN_LOAD_AUX>(
+                buffer_kv, tid * vec_size_i);
+        opus_vec_i vec_k_weight = *reinterpret_cast<const opus_vec_i*>(&k_weight[tid * vec_size_i]);
+        const scalar_t *cos_ptr, *sin_ptr;
+        compute_rope_ptrs(cos_ptr, sin_ptr);
 
         // Optional fused SWA scatter (decode-only): mirror this post-norm/rope K row
         // (nope fp8 + inline dup e8m0 scale, and rope bf16) into the paged SWA pool
@@ -5166,11 +5181,7 @@ namespace aiter {
 
         const bool is_nope_thread = (tid < static_cast<int32_t>(nope_vec));
         constexpr bool K_QUANT = (kv_dt != vllm::Fp8KVCacheDataType::kAuto);
-
-        opus_vec_i vec_kv =
-            load_vector_nbytes<scalar_t, vec_size_i, in_chunk_bytes, IN_LOAD_AUX>(
-                buffer_kv, tid * vec_size_i);
-        opus_vec_i vec_k_weight = *reinterpret_cast<const opus_vec_i*>(&k_weight[tid * vec_size_i]);
+        // (vec_kv / vec_k_weight already loaded above -- load hoisting)
 
         // Per-thread partials: sum(x^2) over the row, and (quant only) amax(|x*w|)
         // over this thread's slice -- both on the RAW input (pre-norm), so the
@@ -5310,6 +5321,9 @@ namespace aiter {
       opus_vec_i vec_q =
           load_vector_nbytes<scalar_t, vec_size_i, in_chunk_bytes, IN_LOAD_AUX>(
               q_buf, tid * vec_size_i);
+      // Load hoisting: q data load issued above; compute rope ptrs (positions load) after.
+      const scalar_t *cos_ptr, *sin_ptr;
+      compute_rope_ptrs(cos_ptr, sin_ptr);
 
       opus_vec_i vec_q_weight;
       if constexpr (HAS_Q_WEIGHT) {

--- a/op_tests/test_fused_qk_norm_rope_group_quant.py
+++ b/op_tests/test_fused_qk_norm_rope_group_quant.py
@@ -38,6 +38,7 @@ import torch
 
 import aiter
 from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.test_common import benchmark, checkAllclose, run_perftest
 from aiter.utility.fp4_utils import f32_to_mx_e8m0_scale
 from aiter.utility.mx_types import MxDtypeInt, MxScaleRoundModeInt
@@ -54,6 +55,9 @@ torch.set_default_device("cuda")
 
 _FP8 = dtypes.fp8
 _FP8_MAX = float(torch.finfo(_FP8).max)
+_FP8_MX_DTYPE = (
+    MxDtypeInt.FP8_E4M3_FNUZ if get_gfx() == "gfx942" else MxDtypeInt.FP8_E4M3
+)
 _DEV = "cuda"
 PE_BYTE_OFFSET = 464
 # MI355X HBM3e peak. Used only for the "%peak" perf column.
@@ -106,13 +110,14 @@ def _norm_rope_nope_fp8(x, weight, cos, sin, pos, eps, *, is_neox, group_size):
     nope, pe = normed[..., :nope_dim], normed[..., nope_dim:]
     pe_rotated = _apply_gptj_rope(pe, cos, sin, pos, is_neox=is_neox)
 
-    # nope: per-group amax -> e8m0 scale (MX RoundUp, FP8 E4M3) -> fp8. Uses the shared
-    # reference helper (== the kernel's fp_f32_to_e8m0_scale<RoundUp, FP8_E4M3>).
+    # nope: per-group amax -> e8m0 scale (MX RoundUp, HW-native FP8 E4M3) -> fp8.
+    # gfx942 uses E4M3_FNUZ (max=240), while gfx950+ uses OCP E4M3 (max=448),
+    # matching kHwFp8E4m3Dtype in the HIP kernel.
     amax = (
         nope.reshape(T, n_heads, n_groups, group_size).abs().amax(-1).clamp_min(1e-12)
     )
     scale_e8m0 = f32_to_mx_e8m0_scale(
-        amax, mode=MxScaleRoundModeInt.RoundUp, dtype=MxDtypeInt.FP8_E4M3
+        amax, mode=MxScaleRoundModeInt.RoundUp, dtype=_FP8_MX_DTYPE
     ).view(
         torch.uint8
     )  # reinterpret the e8m0 byte (== biased exponent), not numeric cast


### PR DESCRIPTION
At small-T decode (low occupancy / latency-bound) the fine-grained fused_qk_norm_rope kernel computed the RoPE cos/sin pointers -- which need a dependent positions[token_idx] scalar load -- BEFORE issuing the main q/kv global load. That made the positions load stall ahead of the data load, fully exposing the data load's global-memory latency (ATT: s_waitcnt vmcnt ~14568).

Reorder so each K/Q branch issues its q/kv buffer_load FIRST, then computes the RoPE pointers (compute_rope_ptrs lambda). The data-load latency now overlaps the positions load + address setup (ATT vmcnt stall 14568 -> ~7800).

Pure reordering: numerically identical (err_q/k/kpe = 0), dynamic strides and output layout unchanged, fully inlined (341 vs 343 exec instrs, 0 extra calls).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<img width="775" height="269" alt="image" src="https://github.com/user-attachments/assets/5da52f65-ebc2-4a61-ac3f-d40cfc884f42" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
