### PR TITLE
[Feat][HIP]: Support causal_conv1d_fwd_split_qkv with channel-last layout

### DIFF
--- a/csrc/kernels/causal_conv1d_fwd_split_qkv.cu
+++ b/csrc/kernels/causal_conv1d_fwd_split_qkv.cu
@@ -38,6 +38,176 @@ static constexpr int TN  = 64;   // feature tile
 static constexpr int KW  = 4;    // kernel width (conv window)
 static constexpr int NT  = 256;  // threads per block
 
+// SGLang prefill supplies a logical [D,T] view backed by contiguous [T,D]
+// storage: stride_dim=1, stride_token=D.  Assign one thread to one feature so
+// every wave reads/writes adjacent features.  A four-value rolling window
+// avoids LDS and loads each body input only once.
+template <int TM>
+__global__ __launch_bounds__(256) void conv1d_split_qkv_channel_last_t(
+    const unsigned short* __restrict__ x,
+    const unsigned short* __restrict__ w,
+    const unsigned short* __restrict__ bias_ptr,
+    unsigned short* __restrict__ q_out,
+    unsigned short* __restrict__ k_out,
+    unsigned short* __restrict__ v_out,
+    unsigned short* __restrict__ conv_states,
+    const int* __restrict__ cache_indices,
+    const unsigned char* __restrict__ has_initial_state,
+    const int* __restrict__ query_start_loc,
+    const int* __restrict__ batch_ptr,
+    const int* __restrict__ token_chunk_offset_ptr,
+    int dim,
+    int k_dim,
+    int T,
+    int stride_x_dim,
+    int stride_x_token,
+    int stride_q_tok,
+    int stride_q_dim,
+    int stride_k_tok,
+    int stride_k_dim,
+    int stride_v_tok,
+    int stride_v_dim,
+    int scs0,
+    int scs1,
+    int scs2,
+    int sci,
+    int has_bias,
+    int do_silu,
+    int pad_slot_id)
+{
+    const int pid     = blockIdx.x;
+    const int seq_idx = batch_ptr[pid];
+    const int cache_idx = cache_indices[seq_idx * sci];
+    if(cache_idx == pad_slot_id)
+        return;
+
+    const int chunk_idx = token_chunk_offset_ptr[pid];
+    const int seq_start = query_start_loc[seq_idx];
+    const int seqlen    = query_start_loc[seq_idx + 1] - seq_start;
+    const int tok_start = chunk_idx * TM;
+    const int gfeat     = (int)blockIdx.y * NT + threadIdx.x;
+    if(gfeat >= dim || tok_start >= seqlen)
+        return;
+
+    const unsigned short* wp = w + (long long)gfeat * KW;
+    const unsigned int w_raw0 = *(const unsigned int*)wp;
+    const unsigned int w_raw1 = *(const unsigned int*)(wp + 2);
+    const float wr0 = bf16_to_f32((unsigned short)w_raw0);
+    const float wr1 = bf16_to_f32((unsigned short)(w_raw0 >> 16));
+    const float wr2 = bf16_to_f32((unsigned short)w_raw1);
+    const float wr3 = bf16_to_f32((unsigned short)(w_raw1 >> 16));
+    const float bias = has_bias ? bf16_to_f32(bias_ptr[gfeat]) : 0.f;
+
+    float x0 = 0.f, x1 = 0.f, x2 = 0.f;
+    if(tok_start >= 3)
+    {
+        const long long base = (long long)gfeat * stride_x_dim +
+                               (long long)(seq_start + tok_start - 3) * stride_x_token;
+        x0 = bf16_to_f32(x[base]);
+        x1 = bf16_to_f32(x[base + stride_x_token]);
+        x2 = bf16_to_f32(x[base + 2LL * stride_x_token]);
+    }
+    else
+    {
+        // Only chunk zero can start before token 3.
+        const bool use_state = has_initial_state[seq_idx] != 0;
+        const long long state_base = (long long)cache_idx * scs0 +
+                                     (long long)gfeat * scs1;
+        x0 = use_state ? bf16_to_f32(conv_states[state_base]) : 0.f;
+        x1 = use_state ? bf16_to_f32(conv_states[state_base + scs2]) : 0.f;
+        x2 = use_state ? bf16_to_f32(conv_states[state_base + 2LL * scs2]) : 0.f;
+    }
+
+    unsigned short* out_ptr;
+    int out_ts, out_ds, out_feat;
+    if(gfeat < k_dim)
+    {
+        out_ptr = q_out;
+        out_ts = stride_q_tok;
+        out_ds = stride_q_dim;
+        out_feat = gfeat;
+    }
+    else if(gfeat < 2 * k_dim)
+    {
+        out_ptr = k_out;
+        out_ts = stride_k_tok;
+        out_ds = stride_k_dim;
+        out_feat = gfeat - k_dim;
+    }
+    else
+    {
+        out_ptr = v_out;
+        out_ts = stride_v_tok;
+        out_ds = stride_v_dim;
+        out_feat = gfeat - 2 * k_dim;
+    }
+
+    const int count = min(TM, seqlen - tok_start);
+    long long in_addr = (long long)gfeat * stride_x_dim +
+                        (long long)(seq_start + tok_start) * stride_x_token;
+    long long out_addr = (long long)(seq_start + tok_start) * out_ts +
+                         (long long)out_feat * out_ds;
+#pragma unroll
+    for(int i = 0; i < TM; ++i)
+    {
+        if(i < count)
+        {
+            const float x3 = bf16_to_f32(x[in_addr]);
+            float acc = bias + wr0 * x0 + wr1 * x1 + wr2 * x2 + wr3 * x3;
+            if(do_silu)
+            {
+                const float exp2v = __builtin_amdgcn_exp2f(acc * (-1.4426950408889634f));
+                acc *= __builtin_amdgcn_rcpf(1.f + exp2v);
+            }
+            out_ptr[out_addr] = f32_to_bf16(acc);
+            x0 = x1;
+            x1 = x2;
+            x2 = x3;
+            in_addr += stride_x_token;
+            out_addr += out_ts;
+        }
+    }
+
+    // Exactly one chunk updates the persistent tail for each sequence.
+    if(chunk_idx == 0)
+    {
+        const long long state_base = (long long)cache_idx * scs0 +
+                                     (long long)gfeat * scs1;
+        if(seqlen >= 3)
+        {
+            const long long tail = (long long)gfeat * stride_x_dim +
+                                   (long long)(seq_start + seqlen - 3) * stride_x_token;
+            conv_states[state_base] = x[tail];
+            conv_states[state_base + scs2] = x[tail + stride_x_token];
+            conv_states[state_base + 2LL * scs2] = x[tail + 2LL * stride_x_token];
+        }
+        else
+        {
+            // Preserve the required suffix of the initial state for T < 3.
+            unsigned short old0 = conv_states[state_base];
+            unsigned short old1 = conv_states[state_base + scs2];
+            unsigned short old2 = conv_states[state_base + 2LL * scs2];
+            if(!has_initial_state[seq_idx])
+                old0 = old1 = old2 = 0;
+            if(seqlen == 1)
+            {
+                conv_states[state_base] = old1;
+                conv_states[state_base + scs2] = old2;
+                conv_states[state_base + 2LL * scs2] =
+                    x[(long long)gfeat * stride_x_dim + (long long)seq_start * stride_x_token];
+            }
+            else if(seqlen == 2)
+            {
+                const long long tail = (long long)gfeat * stride_x_dim +
+                                       (long long)seq_start * stride_x_token;
+                conv_states[state_base] = old2;
+                conv_states[state_base + scs2] = x[tail];
+                conv_states[state_base + 2LL * scs2] = x[tail + stride_x_token];
+            }
+        }
+    }
+}
+
 // Cooperative-staging load + full conv_state, templated on TM in {8,16,32,64}.
 // Fast path covers fully-interior tiles; the slow path applies
 // sequence-relative bounds at chunk/sequence boundaries and blends conv_states.
@@ -75,7 +245,8 @@ __global__ __launch_bounds__(256) void conv1d_split_qkv_t(const unsigned short* 
 {
     const int pid     = blockIdx.x;
     const int seq_idx = batch_ptr[pid];
-    if(seq_idx == pad_slot_id)
+    const int cache_idx = cache_indices[seq_idx * sci];
+    if(cache_idx == pad_slot_id)
         return;
 
     const int chunk_idx  = token_chunk_offset_ptr[pid];
@@ -196,9 +367,8 @@ __global__ __launch_bounds__(256) void conv1d_split_qkv_t(const unsigned short* 
                 }
                 else if(wp < 0 && gf < dim && (chunk_idx == 0) && has_initial_state[seq_idx] != 0)
                 {
-                    int in_coord = cache_indices[seq_idx * sci];
                     int slot     = (KW - 1) + wp; // chunk0 -> tok_start+hc, in [0,KW-2]
-                    pv           = conv_states[(long long)in_coord * scs0 + (long long)gf * scs1 +
+                    pv           = conv_states[(long long)cache_idx * scs0 + (long long)gf * scs1 +
                                      (long long)slot * scs2];
                 }
                 shmem[hf * LDS_PAD + hc] = pv;
@@ -329,7 +499,6 @@ __global__ __launch_bounds__(256) void conv1d_split_qkv_t(const unsigned short* 
         const int slot = tok_group; // 0..3, only < KW-1 used
         if(slot < (KW - 1) && gfeat < dim)
         {
-            const int in_coord = cache_indices[seq_idx * sci];
             const int pos_x    = seqlen - (KW - 1) + slot;
             float val;
             if(pos_x >= 0)
@@ -340,14 +509,14 @@ __global__ __launch_bounds__(256) void conv1d_split_qkv_t(const unsigned short* 
             else if(has_initial_state[seq_idx] != 0)
             {
                 int src = slot + seqlen; // seqlen < KW-1 edge case
-                val     = bf16_to_f32(conv_states[(long long)in_coord * scs0 +
+                val     = bf16_to_f32(conv_states[(long long)cache_idx * scs0 +
                                               (long long)gfeat * scs1 + (long long)src * scs2]);
             }
             else
             {
                 val = 0.f;
             }
-            conv_states[(long long)in_coord * scs0 + (long long)gfeat * scs1 +
+            conv_states[(long long)cache_idx * scs0 + (long long)gfeat * scs1 +
                         (long long)slot * scs2] = f32_to_bf16(val);
         }
     }
@@ -377,6 +546,9 @@ void causal_conv1d_fwd_split_qkv_hip_impl(
     AITER_CHECK(x.dtype() == AITER_DTYPE_bf16,
                 "causal_conv1d HIP kernel requires bfloat16 input.");
     AITER_CHECK(x.dim() == 2, "`x` must be 2-D [dim, cu_seqlen].");
+    AITER_CHECK(x.stride(0) == 1 || x.stride(1) == 1,
+                "`x` must be contiguous in the feature dimension (stride(0)=1) or "
+                "the token dimension (stride(1)=1).");
     AITER_CHECK(block_m == 8 || block_m == 16 || block_m == 32 || block_m == 64,
                 "`block_m` must be 8, 16, 32, or 64.");
     AITER_CHECK(weight.dtype() == AITER_DTYPE_bf16, "`weight` must be bfloat16.");
@@ -424,6 +596,38 @@ void causal_conv1d_fwd_split_qkv_hip_impl(
         (int)conv_states.stride(1), (int)conv_states.stride(2), (int)cache_indices.stride(0), \
         has_bias ? 1 : 0, silu ? 1 : 0, (int)pad_slot_id
 
+#define CONV1D_CHANNEL_LAST_ARGS                                                             \
+    (const unsigned short*)x.data_ptr(), (const unsigned short*)weight.data_ptr(),        \
+        bias_data, (unsigned short*)q.data_ptr(), (unsigned short*)k.data_ptr(),          \
+        (unsigned short*)v.data_ptr(), (unsigned short*)conv_states.data_ptr(),           \
+        (const int*)cache_indices.data_ptr(), (const unsigned char*)has_initial_state.data_ptr(), \
+        (const int*)query_start_loc.data_ptr(), (const int*)batch_ptr.data_ptr(),         \
+        (const int*)token_chunk_offset_ptr.data_ptr(), dim, (int)k_dim, cu_seqlen,        \
+        (int)x.stride(0), (int)x.stride(1), (int)q.stride(0), (int)q.stride(1),           \
+        (int)k.stride(0), (int)k.stride(1), (int)v.stride(0), (int)v.stride(1),           \
+        (int)conv_states.stride(0), (int)conv_states.stride(1),                           \
+        (int)conv_states.stride(2), (int)cache_indices.stride(0),                         \
+        has_bias ? 1 : 0, silu ? 1 : 0, (int)pad_slot_id
+
+    if(x.stride(0) == 1)
+    {
+        dim3 channel_last_grid((unsigned)n_programs, (unsigned)((dim + NT - 1) / NT));
+        if(block_m == 8)
+            conv1d_split_qkv_channel_last_t<8><<<channel_last_grid, block, 0, stream>>>(
+                CONV1D_CHANNEL_LAST_ARGS);
+        else if(block_m == 16)
+            conv1d_split_qkv_channel_last_t<16><<<channel_last_grid, block, 0, stream>>>(
+                CONV1D_CHANNEL_LAST_ARGS);
+        else if(block_m == 32)
+            conv1d_split_qkv_channel_last_t<32><<<channel_last_grid, block, 0, stream>>>(
+                CONV1D_CHANNEL_LAST_ARGS);
+        else
+            conv1d_split_qkv_channel_last_t<64><<<channel_last_grid, block, 0, stream>>>(
+                CONV1D_CHANNEL_LAST_ARGS);
+        HIP_CALL_LAUNCH(hipGetLastError());
+        return;
+    }
+
     if(block_m == 8)
     {
         conv1d_split_qkv_t<8><<<grid, block, 0, stream>>>(CONV1D_ARGS);
@@ -441,6 +645,7 @@ void causal_conv1d_fwd_split_qkv_hip_impl(
         conv1d_split_qkv_t<64><<<grid, block, 0, stream>>>(CONV1D_ARGS);
     }
 #undef CONV1D_ARGS
+#undef CONV1D_CHANNEL_LAST_ARGS
     HIP_CALL_LAUNCH(hipGetLastError());
 }
 

--- a/op_tests/test_causal_conv1d_prefill_split_qkv.py
+++ b/op_tests/test_causal_conv1d_prefill_split_qkv.py
@@ -33,6 +33,7 @@ def torch_reference(
     k_dim,
     v_dim,
     activation="silu",
+    pad_slot_id=-1,
 ):
     """Unambiguous fp32 reference. Returns (q, k, v, new_conv_states)."""
     dim, T = x.shape
@@ -48,6 +49,8 @@ def torch_reference(
         start, end = qsl[s], qsl[s + 1]
         L = end - start
         ci = int(cache_indices[s])
+        if ci == pad_slot_id:
+            continue
         hi = bool(has_initial_state[s])
         for p in range(L):
             acc = bf.clone()
@@ -79,14 +82,25 @@ def torch_reference(
 
 
 def make_inputs(
-    cu_seqlens, with_initial_state=False, device="cuda", dtype=torch.bfloat16, seed=0
+    cu_seqlens,
+    with_initial_state=False,
+    with_bias=True,
+    channel_last=False,
+    device="cuda",
+    dtype=torch.bfloat16,
+    seed=0,
 ):
     torch.manual_seed(seed)
     T = cu_seqlens[-1]
     n = len(cu_seqlens) - 1
-    x = torch.randn(CONV_DIM, T, dtype=dtype, device=device) * 0.1
+    if channel_last:
+        x = (torch.randn(T, CONV_DIM, dtype=dtype, device=device) * 0.1).t()
+    else:
+        x = torch.randn(CONV_DIM, T, dtype=dtype, device=device) * 0.1
     weight = torch.randn(CONV_DIM, WIDTH, dtype=dtype, device=device) * 0.1
-    bias = torch.randn(CONV_DIM, dtype=dtype, device=device) * 0.1
+    bias = (
+        torch.randn(CONV_DIM, dtype=dtype, device=device) * 0.1 if with_bias else None
+    )
     conv_states = (
         torch.randn(n, STATE_LEN, CONV_DIM, dtype=dtype, device=device).transpose(1, 2)
         * 0.1
@@ -254,6 +268,149 @@ def test_backend_matches_reference(cu, with_is, backend):
     # conv_state writeback
     rel, absd = _max_abs_rel(cs_work, ref_cs)
     assert absd < 5e-2, f"{backend} conv_state mismatch: max_abs={absd:.4f}"
+
+
+@pytest.mark.parametrize("cu", [[0, 1], [0, 2], [0, 1, 3, 6], [0, 512]])
+@pytest.mark.parametrize("with_is", [False, True])
+def test_hip_channel_last_matches_reference(cu, with_is):
+    if not torch.cuda.is_available():
+        pytest.skip("needs GPU")
+
+    x, w, b, cs, ci, hi, qsl = make_inputs(
+        cu, with_initial_state=with_is, channel_last=True
+    )
+    assert x.stride() == (1, CONV_DIM)
+    ref_q, ref_k, ref_v, ref_cs = torch_reference(
+        x, w, b, cs.clone(), qsl, ci, hi, K_DIM, V_DIM
+    )
+    cs_work = cs.clone()
+    q, k, v = _call_backend(
+        "hip",
+        x=x,
+        weight=w,
+        bias=b,
+        conv_states=cs_work,
+        query_start_loc=qsl,
+        cache_indices=ci,
+        has_initial_state=hi,
+        k_dim=K_DIM,
+        v_dim=V_DIM,
+        seq_lens_cpu=qsl.diff().tolist(),
+        activation="silu",
+    )
+
+    for name, got, ref in (("q", q, ref_q), ("k", k, ref_k), ("v", v, ref_v)):
+        rel, absd = _max_abs_rel(got, ref)
+        assert absd < 5e-2, f"hip channel-last {name}: max_abs={absd:.4f} rel={rel:.4f}"
+    rel, absd = _max_abs_rel(cs_work, ref_cs)
+    assert absd < 5e-2, f"hip channel-last state: max_abs={absd:.4f} rel={rel:.4f}"
+
+
+@pytest.mark.parametrize(
+    ("activation", "with_bias"),
+    [
+        (None, True),
+        ("silu", False),
+        (None, False),
+    ],
+)
+def test_hip_channel_last_optional_activation_and_bias(activation, with_bias):
+    """Cover channel-last dispatch with SiLU and/or bias disabled."""
+    if not torch.cuda.is_available():
+        pytest.skip("needs GPU")
+
+    cu = [0, 7, 31, 90]
+    x, w, b, cs, ci, hi, qsl = make_inputs(
+        cu,
+        with_initial_state=True,
+        with_bias=with_bias,
+        channel_last=True,
+    )
+    assert x.stride() == (1, CONV_DIM)
+    assert (b is not None) == with_bias
+
+    ref_q, ref_k, ref_v, ref_cs = torch_reference(
+        x,
+        w,
+        b,
+        cs.clone(),
+        qsl,
+        ci,
+        hi,
+        K_DIM,
+        V_DIM,
+        activation=activation,
+    )
+    cs_work = cs.clone()
+    q, k, v = _call_backend(
+        "hip",
+        x=x,
+        weight=w,
+        bias=b,
+        conv_states=cs_work,
+        query_start_loc=qsl,
+        cache_indices=ci,
+        has_initial_state=hi,
+        k_dim=K_DIM,
+        v_dim=V_DIM,
+        seq_lens_cpu=qsl.diff().tolist(),
+        activation=activation,
+    )
+
+    case = f"activation={activation!r} with_bias={with_bias}"
+    for name, got, ref in (("q", q, ref_q), ("k", k, ref_k), ("v", v, ref_v)):
+        rel, absd = _max_abs_rel(got, ref)
+        assert (
+            absd < 5e-2
+        ), f"hip channel-last {name} {case}: max_abs={absd:.4f} rel={rel:.4f}"
+    rel, absd = _max_abs_rel(cs_work, ref_cs)
+    assert (
+        absd < 5e-2
+    ), f"hip channel-last state {case}: max_abs={absd:.4f} rel={rel:.4f}"
+
+
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("with_is", [False, True])
+def test_hip_cache_mapping_and_padding(channel_last, with_is):
+    if not torch.cuda.is_available():
+        pytest.skip("needs GPU")
+
+    cu = [0, 5, 12, 21]
+    x, w, b, cs, _, hi, qsl = make_inputs(
+        cu, with_initial_state=with_is, channel_last=channel_last
+    )
+    # Sequence 0 writes cache line 2, sequence 1 is padding, and sequence 2
+    # writes cache line 0. Cache line 1 must remain untouched.
+    ci = torch.tensor([2, -1, 0], dtype=torch.int32, device=x.device)
+    ref_q, ref_k, ref_v, ref_cs = torch_reference(
+        x, w, b, cs.clone(), qsl, ci, hi, K_DIM, V_DIM, pad_slot_id=-1
+    )
+
+    cs_work = cs.clone()
+    q, k, v = _call_backend(
+        "hip",
+        x=x,
+        weight=w,
+        bias=b,
+        conv_states=cs_work,
+        query_start_loc=qsl,
+        cache_indices=ci,
+        has_initial_state=hi,
+        k_dim=K_DIM,
+        v_dim=V_DIM,
+        seq_lens_cpu=qsl.diff().tolist(),
+        activation="silu",
+    )
+
+    # Padded output storage is intentionally unspecified; compare live ranges.
+    live = torch.cat(
+        (torch.arange(0, 5, device=x.device), torch.arange(12, 21, device=x.device))
+    )
+    for name, got, ref in (("q", q, ref_q), ("k", k, ref_k), ("v", v, ref_v)):
+        rel, absd = _max_abs_rel(got[live], ref[live])
+        assert absd < 5e-2, f"hip mapped {name}: max_abs={absd:.4f} rel={rel:.4f}"
+    rel, absd = _max_abs_rel(cs_work, ref_cs)
+    assert absd < 5e-2, f"hip mapped state: max_abs={absd:.4f} rel={rel:.4f}"
 
 
 def qsl_to(qsl):


### PR DESCRIPTION
## Motivation

SGLang GDN prefill produces `mixed_qkv` as a contiguous `[T, D]` tensor and
passes its logical `[D, T]` transpose view to causal conv1d. The resulting input
has stride `(1, D)`.

The existing AITER HIP kernel is optimized for contiguous `[D, T]` input with
stride `(T, 1)`. Supporting the SGLang layout previously required materializing
a transposed copy, introducing an extra `O(TD)` memory operation.

This PR adds a zero-copy channel-last path that directly consumes the SGLang
transpose view while preserving the existing contiguous-input implementation.

## Technical Details

- Add a channel-last HIP kernel for logical `[D, T]` input backed by contiguous
  `[T, D]` storage with stride `(1, D)`.
- Assign one thread to each feature/channel. Threads in a wave access adjacent
  features for the same token, enabling coalesced global-memory accesses.
- Maintain the width-4 causal-convolution window in registers and roll it
  forward one token at a time. This avoids input transposition, LDS staging,
  and block-wide barriers in the channel-last path.
- Directly write convolution results into separate contiguous Q/K/V outputs,
  preserving the existing output layout and API.
- Dispatch to the channel-last implementation when `x.stride(0) == 1`; retain
  the existing contiguous `[D, T]` implementation for other supported layouts.
- Use the mapped cache index consistently for conv-state reads and writeback.
- Add test coverage for channel-last inputs, short sequences, initial states,
  permuted cache mappings, and padded cache slots.

## Test Plan

- Run the corresponding AITER operator unit tests.
- Run the SGLang operator correctness tests against the native GDN causal-conv
  path.
- Run the SGLang Qwen3.6-35B-A3B performance benchmark using the TP4 production
  shape.

## Test Result

Tested on AMD Radeon AI PRO R9700 (`gfx1201`) with BF16 input and
causal-convolution width 4.

### AITER operator unit tests

```text
HIP_VISIBLE_DEVICES=0 pytest -q \
  op_tests/test_causal_conv1d_prefill_split_qkv.py

52 passed in 39.59s
```

### SGLang correctness and performance benchmark

Compared the AITER fused kernel against the SGLang native Triton path using the
Qwen3.6-35B-A3B TP4 per-rank dimensions:

- Q dimension: `512`
- K dimension: `512`
- V dimension: `1024`
- Packed QKV dimension: `D = 2048`

All Q/K/V and conv-state correctness checks passed.

| Prefill shape | SGLang + split views + contiguous (FLA ready) | AITER direct (FLA ready) | AITER vs SGLang speedup |
|---|---:|---:|---:|
| T=128 | 65.321 μs | 64.821 μs | 1.008x |
| T=256 | 64.817 μs | 64.431 μs | 1.006x |
| T=384 | 64.557 μs | 63.738 μs | 1.013x |
| T=512 | 64.400 μs | 64.530 μs | 0.998x |
| T=1024 | 64.205 μs | 63.478 μs | 1.011x |
| T=2048 | 69.855 μs | 63.893 μs | 1.093x |
| T=4096 | 84.243 μs | 62.851 μs | 1.340x |
| T=8192 | 268.019 μs | 68.140 μs | 3.933x |
| T=10240 | 437.510 μs | 181.173 μs | 2.415x |

The SGLang measurement includes native causal-conv, Q/K/V split views, and the
three contiguous materializations required by the downstream FLA input guard.
The AITER path directly produces contiguous Q/K/V outputs.

## Submission Checklist

- [ ] Look over the contributing guidelines at
  https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.