### PR TITLE
[opus] fix(gfx942): retune stale GLM5 BF16 GEMM config

### DIFF
--- a/aiter/configs/model_configs/glm5_bf16_tuned_gemm.csv
+++ b/aiter/configs/model_configs/glm5_bf16_tuned_gemm.csv
@@ -135,7 +135,7 @@ gfx942,80,192,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,76
 gfx942,80,256,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,asm,5,5,16.6326,_ZN5aiter39bf16gemm_fp32bf16_tn_64x64_splitk_cleanE,0.0156,48.42,386.14
 gfx942,80,384,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,asm,8,5,22.1138,_ZN5aiter39bf16gemm_fp32bf16_tn_96x64_splitk_cleanE,0.0146,54.62,364.52
 gfx942,80,512,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,opus,10204,6,25.2282,opus_gemm_gfx942_splitk_em3en4_lds1_pgr2_256x128x96x128_2x2_16x16x16_0x0x0,0.0,63.84,384.46
-gfx942,80,768,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,opus,10211,3,36.6162,opus_gemm_gfx942_splitk_p1_bf16ws_256x64x64x64_2x2_16x16x16_0x0x0,0.0083,65.98,354.38
+gfx942,80,768,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,opus,10201,3,34.5862,opus_gemm_gfx942_splitk_p1_256x64x64x64_2x2_16x16x16_0x0x0,0.0,69.85,375.18
 gfx942,80,1024,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,torch,0,0,35.7927,native,0.0,90.0,454.08
 gfx942,80,1536,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,opus,10216,11,47.8542,opus_gemm_gfx942_splitk_quad_mfma32_bf16ws_256x256x256x32_2x2_32x32x8_6x0x0,0.0123,100.97,476.58
 gfx942,80,2048,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,opus,10216,0,52.3827,opus_gemm_gfx942_splitk_quad_mfma32_bf16ws_256x256x256x32_2x2_32x32x8_6x0x0,0.012,122.99,560.49


### PR DESCRIPTION
## Motivation

  The GLM5 BF16 tuned GEMM configuration referenced gfx942 Opus kernel 10211, which was removed in #4204. The stale row was later introduced in #4236.

  Because 10211 is no longer present in the current kernel registry, codegen silently filters this tuning entry and it is not included in the runtime lookup. This PR replaces it with the best valid kernel from a fresh tuning run.

  ## Technical Details

  Updated the gfx942 BF16 configuration for:

  - M=768
  - N=256
  - K=6144
  - BF16 input/output
  - No bias

  The configuration changes from:

  - Kernel: 10211
  - splitK: 3
  - Latency: 36.6162 us
  - Error ratio: 0.0083

  To:

  - Kernel: 10201
  - splitK: 3
  - Latency: 34.5862 us
  - Error ratio: 0
  - Throughput: 69.85 TFLOPS
  - Bandwidth: 375.18 GB/s

  No kernel implementation or dispatch code is changed.

  ## Test Plan

  - Restore 10211 temporarily and tune all valid gfx942 Opus candidates.
  - Remove 10211, rebuild in an isolated JIT directory, and repeat the same full candidate sweep.
  - Run a paired benchmark of 10211/splitK=3 and 10201/splitK=3 using:
      - The same input tensors and module
      - 30 warmup iterations
      - 9 timing samples
      - 200 launches per sample

  - Validate every gfx942 Opus entry in the BF16 model-config CSVs against the current kernel registry.

  ## Test Result

  Full candidate sweep:

   Configuration          Winner               Latency    Error ratio
  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━━━
   With 10211 restored    10211/splitK=3    34.4598 us         0.0084
  ─────────────────────  ────────────────  ────────────  ─────────────
   Current registry       10201/splitK=3    34.5862 us              0

  Paired benchmark median:

   Kernel            Workspace       Latency    Mean absolute error    Bad ratio
  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━
   10211/splitK=3    BF16         34.3804 us               0.198291     0.009013
  ────────────────  ───────────  ────────────  ─────────────────────  ───────────
   10201/splitK=3    FP32         34.5818 us              0.0000139            0

  10211 was only 0.58% faster in the paired benchmark while producing less accurate results. Restoring an additional kernel is therefore not justified.

  After updating the row, all gfx942 Opus BF16 model-config entries reference valid kernel IDs.

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.