### PR TITLE
[Docs] Add RDNA support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ AITER is the **default kernel backend for LLM inference on AMD GPUs**, integrate
 | AMD Instinct MI325X | gfx942 (CDNA3) | Fully supported |
 | AMD Instinct MI350 | gfx950 (CDNA4) | Supported |
 | AMD Instinct MI355X | gfx950 (CDNA4) | Supported |
-| AMD Radeon AI PRO R9700 | gfx1201 (RDNA4) | Partially supported<sup>1</sup> |
+| AMD Pro W7900 | gfx1100 (RDNA3) | Experimental<sup>1</sup> |
+| AMD AI Max and Max Pro 400/300 Series | gfx1151 (RDNA3.5) | Experimental<sup>1</sup> |
+| AMD Radeon AI PRO R9700 | gfx1201 (RDNA4) | Experimental<sup>1</sup> |
 
-<sup>1</sup> On gfx1201, Triton and most FlyDSL kernels run, as do most HIP kernels (norm, RoPE, quant, activation, plus some GEMM/attention). Most CK and ASM kernels are CDNA-only.
+<sup>1</sup> On RDNA, Triton and most FlyDSL kernels run, as do most HIP kernels (norm, RoPE, quant, activation, plus some GEMM/attention). Most CK and ASM kernels are CDNA-only.
 
 ## Operators
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ AITER is the **default kernel backend for LLM inference on AMD GPUs**, integrate
 | AMD Instinct MI325X | gfx942 (CDNA3) | Fully supported |
 | AMD Instinct MI350 | gfx950 (CDNA4) | Supported |
 | AMD Instinct MI355X | gfx950 (CDNA4) | Supported |
+| AMD Radeon AI PRO R9700 | gfx1201 (RDNA4) | Partially supported<sup>1</sup> |
+
+<sup>1</sup> On gfx1201, Triton and most FlyDSL kernels run, as do most HIP kernels (norm, RoPE, quant, activation, plus some GEMM/attention). Most CK and ASM kernels are CDNA-only.
 
 ## Operators
 


### PR DESCRIPTION
## Motivation

Adds AMD Radeon AI PRO R9700 (gfx1201 / RDNA4) to the Supported Hardware table as Partially supported. gfx1201 now runs a large subset of AITER.

## Test Plan

```
python3 op_tests/test_*.py
```


## Test Result

# AITER op_tests on gfx1201 (RDNA4) — 100 tests

| Result | Type | # | Why |
|---|---|---|---|
| PASS | — | 54 | Runs correctly on gfx1201 |
| ERROR | Unsupported arch (CDNA/MI-only) | 34 | No gfx1201 kernel: ASM heuristic miss, arch allowlist/dict gate, CK GEMM/FMHA rejects shape, CDNA-only ISA won't build, `permlane16.swap` unlowerable, Triton LDS > 64 KB |
| ERROR | OOM (32 GB card) | 7 | Sweep peaks ~31 GB; `expandable_segments` unsupported here |
| ERROR | Numerical / correctness | 4 | Kernel runs, wrong output (allclose fail, planner diverge, packed mismatch, garbage index) |
| ERROR | Test-side bug | 1 | CPU tensor passed into a Triton kernel |

**Totals:** 54 pass · 46 error

## Failed tests

**Unsupported arch (34):** test_mla, test_mla_persistent, test_mla_persistent_round_robin, test_mla_prefill_ps, test_mla_sparse, test_pa_block_id_truncation, test_pa_ps, test_gemm_a16w16, test_gemm_a8w8_blockscale, test_moe, test_moe_blockscale, test_moe_dp_share_expert, test_jit_dir_with_enum, test_indexer_k_quant_and_cache, test_pa, test_pa_mtp, test_pa_ragged, test_pa_ragged_experimental, test_pa_v1, test_sampling, test_moe_2stage, test_moe_ep, test_moe_tkw1, test_gemm_a8w8, test_batched_gemm_a8w8, test_mha, test_mha_fp8, test_mha_varlen, test_batch_prefill, test_fused_qk_rmsnorm_group_quant, test_fused_qk_rmsnorm_per_token_quant, test_topk_plain, test_flydsl_qk_norm_rope_quant, test_fused_qk_norm_rope_group_quant, 

**OOM (7):** test_kvcache, test_kvcache_blockscale, test_quant, test_rope, test_topk_per_row, test_moe_sorting_mxfp4, test_mhc

**Numerical (4):** test_dsv4_rotate_quant, test_metadata, test_quant_mxfp4, test_moe_topk_gating

**Test-side bug (1):** test_gemm_codegen


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
