### PR TITLE
[CI] release: default torch<2.13 + expose torch_pin/torch_index_url on dispatch

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -53,16 +53,6 @@ on:
         description: 'Use pytorch/manylinux2_28-builder ROCm image (AlmaLinux 8 + devtoolset, glibc 2.28). Produces wheels ABI-compatible with vLLM/Ubuntu 22 containers.'
         type: boolean
         default: false
-      torch_pin:
-        description: 'Optional torch version pin for the manylinux build (e.g. 2.11.0 or 2.10.0+rocm7.1). Empty = default constraint (torch<2.13).'
-        type: string
-        required: false
-        default: ''
-      torch_index_url:
-        description: 'Optional override for the torch wheel index URL. Empty = auto-derive from the builder image ROCm tag.'
-        type: string
-        required: false
-        default: ''
   workflow_call:
     inputs:
       release_type:

--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -208,9 +208,22 @@ jobs:
           # CMD of /bin/bash, which exits immediately for `docker run -d`.
           # Force a long-lived `sleep infinity` so subsequent `docker exec`
           # invocations succeed for both legacy and manylinux images.
+          # Pass GPU devices into the build container when the runner has them:
+          # setup.py start_aot() JIT-loads HIP modules and fails with
+          # hipErrorNoDevice if the container cannot reach a GPU. On GPU-less
+          # runners (build-only-aiter) /dev/kfd is absent, so the flags are
+          # omitted and the container starts as before.
+          GPU_FLAGS=""
+          if [ -e /dev/kfd ]; then
+            GPU_FLAGS="--device=/dev/kfd --device=/dev/dri --group-add video"
+            echo "GPU devices detected; passing ${GPU_FLAGS} to build container"
+          else
+            echo "No /dev/kfd on runner; starting build container without GPU access"
+          fi
           docker run -dt \
           --shm-size=16G \
           --network=host \
+          ${GPU_FLAGS} \
           --entrypoint="" \
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \

--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -53,6 +53,16 @@ on:
         description: 'Use pytorch/manylinux2_28-builder ROCm image (AlmaLinux 8 + devtoolset, glibc 2.28). Produces wheels ABI-compatible with vLLM/Ubuntu 22 containers.'
         type: boolean
         default: false
+      torch_pin:
+        description: 'Optional torch version pin for the manylinux build (e.g. 2.11.0 or 2.10.0+rocm7.1). Empty = default constraint (torch<2.13).'
+        type: string
+        required: false
+        default: ''
+      torch_index_url:
+        description: 'Optional override for the torch wheel index URL. Empty = auto-derive from the builder image ROCm tag.'
+        type: string
+        required: false
+        default: ''
   workflow_call:
     inputs:
       release_type:
@@ -309,11 +319,16 @@ jobs:
           else
             TORCH_INDEX="https://download.pytorch.org/whl/rocm${ROCM_NUM}"
           fi
-          # Optional torch version pin (e.g. 2.10.0+rocm7.1). Empty = latest.
+          # Optional torch version pin (e.g. 2.10.0+rocm7.1). Empty = default
+          # constraint torch<2.13. torch 2.13.0 breaks the build: its
+          # torch.library._clear_torch_ops_cache() does qualname.split("::")
+          # expecting exactly one "::", which raises on aiter custom-op names
+          # during interpreter teardown of setup.py start_aot(). Pin below 2.13
+          # until the op-name incompatibility is resolved.
           if [ -n "${TORCH_PIN}" ]; then
             TORCH_SPEC="torch==${TORCH_PIN}"
           else
-            TORCH_SPEC="torch"
+            TORCH_SPEC="torch<2.13"
           fi
           echo "Torch index: ${TORCH_INDEX}"
           echo "Torch spec:  ${TORCH_SPEC}"


### PR DESCRIPTION
## What

Fix the release workflow so it can build wheels for recent aiter tags again. Two changes to `.github/workflows/aiter-release.yaml`:

1. **Default torch to `torch<2.13`** for the manylinux build. torch `2.13.0` breaks the build: `torch.library._clear_torch_ops_cache()` does `qualname.split("::")` expecting exactly one `::`, which raises `ValueError: too many values to unpack` on an aiter custom-op name during interpreter teardown of `setup.py` `start_aot()`. The wheel is never produced.
2. **Expose `torch_pin` and `torch_index_url` on `workflow_dispatch`** (they existed only under `workflow_call`), so a manual release dispatch can pin torch when needed.

## Why

`v0.1.16.post4` and `v0.1.17-longctx` were published with **0 wheels** because the release CI could not build them. See #4304 for full root-cause analysis.

## Not covered here (tracked in #4304)

`setup.py` `start_aot` also now requires a GPU at build time (`hipErrorNoDevice` on the GPU-less `build-only-aiter` runner). Until `start_aot` degrades gracefully without a device, release builds must select a GPU runner (`aiter-1gpu-runner` / `linux-aiter-mi35x-1`). This PR does not change the default runner.

## Test plan

Dispatch `aiter-release.yaml` from this branch on a GPU runner against a recent tag and confirm 6 wheels are produced. Validation to be attached.

Refs #4304
