### PR TITLE
[GFX942] add BATCHED_GEMM A16W16 triton tuning config for N=1024 K=4096

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx942-BATCHED_GEMM-A16W16-N=1024-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx942-BATCHED_GEMM-A16W16-N=1024-K=4096.json
@@ -1,0 +1,96 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_1024": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}


### PR DESCRIPTION
## Motivation

Improve Batched GEMM A16W16 performance on gfx942 by providing tuned triton kernel configurations instead of relying on default parameters

## Technical Details

 - Add pre-tuned Triton kernel config for Batched GEMM A16W16 on gfx942 (MI300) with shape N=1024, K=4096
  - Covers 8 M-range buckets (M≤8, 16, 32, 64, 128, 256, 1024, and fallback `any`), each with optimized tile sizes, warp counts, and cache modifiers


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Batch=4 N=1024 K=4096
  | M    | Default (any 128×128×32) | Tuned  | Speedup |
  |------|--------------------------|------------------|---------|
  | 4    | 143.16 us                | 74.35 us         | 1.93x   |
  | 8    | 144.55 us                | 76.37 us         | 1.89x   |
  | 16   | 144.10 us                | 75.52 us         | 1.91x   |
  | 32   | 147.07 us                | 83.00 us         | 1.77x   |
  | 64   | 144.79 us                | 96.89 us         | 1.49x   |
  | 128  | 148.44 us                | 137.27 us        | 1.08x   |
  | 256  | 148.69 us                | 136.48 us        | 1.09x   |
  | 1024 | 172.33 us                | 167.19 us        | 1.03x   |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
