### PR TITLE
WP-G2: FP8 rowwise batched GEMM via FlyDSL preshuffle kernel

### DIFF
--- a/aiter/ops/batched_gemm_op_a8w8.py
+++ b/aiter/ops/batched_gemm_op_a8w8.py
@@ -14,6 +14,7 @@ from ..jit.core import (
 from ..utility import dtypes
 from ..jit.utils.chip_info import get_cu_num, get_gfx_runtime as get_gfx
 from aiter import logger
+from ..ops.gemm_op_a8w8 import is_flydsl_available
 
 
 def gen_batched_gemm_a8w8_fake_tensors(
@@ -116,6 +117,24 @@ def get_CKBatchedGEMM_config(
     return config
 
 
+_batched_flydsl_failed = False
+
+
+def _select_batched_flydsl_kernel(n: int, k: int):
+    """Select a default FlyDSL tile config for batched GEMM."""
+    try:
+        from .flydsl.gemm_tune.flydsl_gemm_a8w8_bpreshuffle_common import (
+            default_kernels_dict,
+        )
+    except ImportError:
+        return None
+    fits = [ki for ki in default_kernels_dict.values()
+            if n % ki.tile_n == 0 and k % ki.tile_k == 0]
+    if not fits:
+        return None
+    return min(fits, key=lambda x: (-x.tile_n, -x.tile_k))
+
+
 def batched_gemm_a8w8_CK(
     XQ: Tensor,
     WQ: Tensor,
@@ -134,6 +153,35 @@ def batched_gemm_a8w8_CK(
     m = XQ.shape[1]
     n = WQ.shape[1]
     k = XQ.shape[2]
+
+    global _batched_flydsl_failed
+    if (
+        not _batched_flydsl_failed
+        and is_flydsl_available()
+        and XQ.dtype in [dtypes.fp8, dtypes.i8]
+        and dtype in [dtypes.bf16, dtypes.fp16]
+        and bias is None
+    ):
+        ki = _select_batched_flydsl_kernel(n, k)
+        if ki is not None:
+            from .shuffle import shuffle_weight
+            from .flydsl.gemm_kernels import flydsl_preshuffle_batched_gemm_a8
+
+            Y = torch.empty(b, m, n, dtype=dtype, device=XQ.device)
+            WQ_shuffled = torch.stack(
+                [shuffle_weight(WQ[i], layout=(16, 16)) for i in range(b)]
+            )
+            try:
+                return flydsl_preshuffle_batched_gemm_a8(
+                    XQ, WQ_shuffled, x_scale, w_scale, Y,
+                    ki.tile_m, ki.tile_n, ki.tile_k,
+                )
+            except Exception as e:
+                _batched_flydsl_failed = True
+                logger.warning(
+                    f"[FlyDSL] batched GEMM failed: {e}; falling back to CK"
+                )
+
     ck_config = get_CKBatchedGEMM_config(b, m, n, k)
     if splitK is None:
         if ck_config is not None:

--- a/aiter/ops/flydsl/gemm_kernels.py
+++ b/aiter/ops/flydsl/gemm_kernels.py
@@ -1066,3 +1066,42 @@ def flydsl_preshuffle_gemm_a8(
         Out.copy_(out_contig)
 
     return Out
+
+
+def flydsl_preshuffle_batched_gemm_a8(
+    XQ: Tensor,
+    WQ: Tensor,
+    x_scale: Tensor,
+    w_scale: Tensor,
+    Out: Tensor,
+    tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    use_async_copy: int = 0,
+    waves_per_eu: int = 0,
+    xcd_swizzle: int = 0,
+    lds_stage: int = 2,
+    enable_scheduler: bool = True,
+) -> Tensor:
+    """Batched FP8 preshuffle GEMM via per-batch dispatch of the non-batched kernel.
+
+    Shapes: XQ[B,M,K], WQ[B,N,K], x_scale[B,M,1], w_scale[B,1,N], Out[B,M,N].
+    """
+    B = XQ.shape[0]
+    for b in range(B):
+        flydsl_preshuffle_gemm_a8(
+            XQ[b],
+            WQ[b],
+            x_scale[b],
+            w_scale[b],
+            Out[b],
+            tile_m,
+            tile_n,
+            tile_k,
+            use_async_copy,
+            waves_per_eu,
+            xcd_swizzle,
+            lds_stage,
+            enable_scheduler,
+        )
+    return Out


### PR DESCRIPTION
## Summary
- Add `flydsl_preshuffle_batched_gemm_a8()` in `gemm_kernels.py` — per-batch dispatch wrapper over WP-G1's non-batched preshuffle kernel
- Wire into `batched_gemm_a8w8_CK()` with FlyDSL fallback, on-the-fly weight preshuffle, graceful CK fallback on failure
- Depends on WP-G1 (PR #4166) for the underlying preshuffle kernel

## Changes
- `aiter/ops/flydsl/gemm_kernels.py` — new `flydsl_preshuffle_batched_gemm_a8()` 
- `aiter/ops/batched_gemm_op_a8w8.py` — FlyDSL dispatch in `batched_gemm_a8w8_CK()`

## Test plan
- [x] Manual test: B=4 M=64 N=1280 K=8192, fp8 input, bf16 output — rel_err=0.01%
- [ ] Full `test_batched_gemm_a8w8.py` (requires CK module rebuild with matching torch)
- [ ] Performance benchmark vs CK batched