### PR TITLE
[FlyDSL] fix >4GB a4w4 weight buffer-offset overflow for pp8/pp4 kimi k2.6

### DIFF
--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
@@ -545,8 +545,6 @@ def compile_mixed_moe_gemm1(
             x_nbytes_i32 = arith.index_cast(T.i32, x_nbytes_idx)
             x_rsrc = ptr_buffer_resource(arg_x, x_nbytes_i32)
 
-            w_rsrc = ptr_buffer_resource(arg_w, w_nbytes)
-
             numids_rsrc = ptr_buffer_resource(
                 arg_num_valid_ids, arith.constant(4, type=T.i32)
             )
@@ -631,6 +629,17 @@ def compile_mixed_moe_gemm1(
             def moe_gemm1_body():
                 nonlocal k_base_idx, lds_x_pong, lds_x_ping
                 expert_off_idx = expert_idx * arith.constant(2 * inter_dim, index=True)
+
+                # per-expert 64-bit re-base: 32-bit buffer voffset overflows when w1 > 4GB
+                per_expert_w_bytes = w_nbytes // experts
+                w_addr_i64 = arith.index_cast(T.i64, fx.ptrtoint(arg_w))
+                expert_byte_off = arith.index_cast(
+                    T.i64, expert_idx * arith.constant(per_expert_w_bytes, index=True)
+                )
+                w_rsrc_e = buffer_ops.create_buffer_resource_from_addr(
+                    arith.addi(w_addr_i64, expert_byte_off),
+                    num_records_bytes=per_expert_w_bytes,
+                )
 
                 x_load_bytes = 16
                 num_x_loads = bytes_per_thread_x // x_load_bytes
@@ -765,7 +774,7 @@ def compile_mixed_moe_gemm1(
                         col_g_list.append(col_g)
 
                     global_n = by_n + n_tile_base + c_offset + lane_mod_16
-                    gate_row_w = expert_off_idx + global_n
+                    gate_row_w = global_n
                     gate_coord = idx2crd(fx.Int32(gate_row_w), layout_n_blk_intra)
                     gate_n_blk_list.append(layout_get(gate_coord, 0))
                     gate_n_intra_list.append(layout_get(gate_coord, 1))
@@ -829,7 +838,7 @@ def compile_mixed_moe_gemm1(
                         b16 = _buffer_load_vec(
                             buffer_ops,
                             vector,
-                            w_rsrc,
+                            w_rsrc_e,
                             idx_pack,
                             elem_type=w_elem_type(),
                             vec_elems=vec_elems,


### PR DESCRIPTION
# [FlyDSL] Fix >4GB a4w4 weight buffer-offset overflow in MoE stage1

## Summary

The a4w4 (MXFP4) fused MoE **stage1** kernel (`compile_mixed_moe_gemm1` in
`aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py`) produces garbage output whenever
the gate/up weight tensor `w1` exceeds **4 GB**. This happens for large models at
**tp1** — e.g. Kimi-K2.6 (`E=384, inter=2048, model=7168` → `w1 = 5.6 GB`). Ranks with
tp ≥ 2 shard `inter_dim` and stay under 4 GB, so the bug is invisible there, which is
why it only shows up at tp1.

This PR re-bases the weight buffer resource **per expert** so every load's 32-bit
offset stays within a single expert. It fixes tp1 precision (L2 rel_err ~0.76 → ~0.0)
with **no measurable performance change**, and is a **no-op for the < 4 GB path**
(tp ≥ 2), which is bit-for-bit unchanged.

## Root cause

`w1` is read with `buffer_load`, whose hardware voffset is **32-bit**. The kernel built
a single buffer resource spanning the whole `w1` tensor and addressed each expert with
an absolute row index:

```python
w_rsrc = ptr_buffer_resource(arg_w, w_nbytes)   # one resource over all of w1
...
gate_row_w = expert_off_idx + global_n           # absolute row -> byte offset can exceed 2**32
b16 = _buffer_load_vec(..., w_rsrc, idx_pack, ...)
```

Once `w1 > 2**32` bytes, the byte offset of a high-index expert wraps the 32-bit
voffset and the load returns the **wrong expert's weights** → garbage output. The
threshold is exact: `E=256` (3.5 GB) is fine, `E=320` (4.4 GB) and `E=384` (5.6 GB) are
corrupted.

## Fix

Re-base the weight buffer resource at each expert's start using a **64-bit** byte
offset, and make the weight rows **expert-relative**, so each per-load 32-bit offset
only ever spans one expert (~14.7 MB):

```python
def ptr_buffer_resource(ptr, num_records_bytes, byte_offset=None):
    addr_i64 = arith.index_cast(T.i64, fx.ptrtoint(ptr))
    if byte_offset is not None:
        addr_i64 = arith.addi(addr_i64, arith.index_cast(T.i64, byte_offset))
    return buffer_ops.create_buffer_resource_from_addr(addr_i64, num_records_bytes=num_records_bytes)
...
# in the gemm1 body, per expert:
per_expert_w_bytes = (2 * inter_dim * model_dim * b_elem_bytes) // pack_K
expert_byte_off    = expert_idx * arith.constant(per_expert_w_bytes, index=True)
w_rsrc_e           = ptr_buffer_resource(arg_w, per_expert_w_bytes, byte_offset=expert_byte_off)
...
gate_row_w = global_n            # expert-relative (w_rsrc_e already points at this expert)
b16        = _buffer_load_vec(..., w_rsrc_e, idx_pack, ...)
```

Stage2 (down-proj, `w2`) is left unchanged — it never exceeds 4 GB for supported shapes.

## Validation

Shape: Kimi-K2.6 `E=384, inter=2048, model=7168, topk=8`, MXFP4 stage1, gfx950.
Precision = L2 rel_err vs the torch reference (same quantized weights); latency =
median kernel time.

### tp1 (inter=2048, w1 = 5.6 GB, **> 4 GB** — the buggy case)

| tokens | rel_err before | rel_err after | rel_err gap | latency before (µs) | latency after (µs) | latency gap |
|------:|------:|------:|------:|------:|------:|------:|
| 8      | 0.7733 | **0.0000** | −0.7733 | 249.3 | 236.9 | −5.0% |
| 64     | 0.7715 | **0.0000** | −0.7715 | 829.3 | 832.4 | +0.4% |
| 256    | 0.7610 | **0.0000** | −0.7610 | 1039.3 | 1028.7 | −1.0% |
| 1024   | 0.7455 | **0.0000** | −0.7455 | 1096.3 | 1140.0 | +4.0% |
| 4096   | 0.7625 | **0.0000** | −0.7625 | 1557.6 | 1611.7 | +3.5% |
| 8192   | 0.7618 | **0.0000** | −0.7618 | 2242.7 | 2252.0 | +0.4% |
| 16384  | 0.7586 | **0.0000** | −0.7586 | 3754.6 | 3757.6 | +0.1% |
| 32768  | 0.7586 | **0.0000** | −0.7586 | 6709.8 | 6706.2 | −0.1% |

Precision is broken before the fix (rel_err ~0.75–0.84, independent of token count —
it is a weight-addressing bug) and exact after — a **rel_err gap of ~0.76** that the
fix closes to 0. The latency gap is **within measurement noise** (small-token jitter;
≤ 0.5 % from 4k tokens up), i.e. no performance cost.

### tp8 / per-rank (inter=256, w1 = 0.70 GB, **< 4 GB** — the existing path)

| tokens | rel_err before | rel_err after | rel_err gap | latency before (µs) | latency after (µs) | latency gap |
|------:|------:|------:|------:|------:|------:|------:|
| 8      | 0.0000 | 0.0000 | 0 | 92.6 | 92.3 | −0.3% * |
| 64     | 0.0000 | 0.0000 | 0 | 188.9 | 190.7 | +1.0% |
| 256    | 0.0001 | 0.0001 | 0 | 207.9 | 209.7 | +0.9% |
| 1024   | 0.0000 | 0.0000 | 0 | 202.6 | 205.6 | +1.5% |
| 4096   | 0.0000 | 0.0000 | 0 | 404.2 | 404.5 | +0.1% |
| 8192   | 0.0000 | 0.0000 | 0 | 727.4 | 729.7 | +0.3% |
| 16384  | 0.0000 | 0.0000 | 0 | 987.9 | 988.0 | +0.0% |
| 32768  | 0.0000 | 0.0000 | 0 | 1164.0 | 1162.0 | −0.2% |

Below 4 GB the fix is a **no-op**: the rel_err gap is **exactly 0** (both 0.0000) and
the latency gap is ~0 — the existing tp ≥ 2 behavior is unchanged. (* the 8-token row
was re-measured with warmup=20 / 200 iters × 3 runs; fixed and pristine medians are
statistically identical at ~92 µs, min ~91 µs both. The tiny ~0.1 ms kernel has
±100 µs tail jitter, so a short 10-iter sample can show a spurious gap.)

## Reproduction / regression

The existing a4w4 stage1 test reproduces the bug at a >4GB shape — no new test needed,
just run it with the K2.6 tp1 config and a tightened tolerance (the default `--atol 1.0`
targets fp4 quant noise and is too loose to catch a wrong-weight bug):

```bash
python aiter/ops/flydsl/test_flydsl_moe_a4w4.py \
    --stage stage1 -E 320 --inter-dim 2048 --model-dim 7168 -t 64 --atol 0.05
```

`E=320, inter=2048, model=7168` -> w1 = 4.7 GB > 4 GB (needs a large-memory GPU):

- unfixed kernel: 91.6% close (max_delta 8.09) -> **FAIL** (exit 1)
- fixed kernel:   100.0% close (max_delta 0.004) -> **PASS** (exit 0)
