### PR TITLE
[MLA v4 nm] Force occupancy-only split selection (ignore total_kv)

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -124,8 +124,21 @@ def _fwd_kernel_stage2_asm(
 
 @functools.lru_cache()
 def get_meta_param(
-    num_kv_splits, bs, total_kv, nhead, max_seqlen_q, dtype, tg_factor=1
+    num_kv_splits,
+    bs,
+    total_kv,
+    nhead,
+    max_seqlen_q,
+    dtype,
+    tg_factor=1,
+    ignore_total_kv=0,
 ):
+    # ignore_total_kv: experiment switch (default 0 = legacy behavior). When 1,
+    # the split-count search ignores `total_kv` entirely: the auto-search keeps
+    # only the CU-occupancy factor (drops the avg_kv / (avg_kv + overhead*i) HBM
+    # term) and the fp8 min-block cap is skipped. This yields the pure
+    # occupancy-driven pick (fill bs_occ*splits into cu_num, capped at 16),
+    # independent of how long each sequence's KV is.
     # tg_factor: number of thread-groups (workgroups) the kernel launches per
     # (seq, kv-split) along the head dim. Default 1. For variants that synthesize
     # a larger logical head count from multiple WGs -- e.g. the v4 nm gqa=128
@@ -149,17 +162,28 @@ def get_meta_param(
         is_gfx1250 = get_gfx() == "gfx1250"
         wg_per_split = 2 if nhead == 128 and is_gfx1250 else 1
         bs_occ = bs * max(tg_factor, wg_per_split)
-        tmp = [
-            (
-                bs_occ
-                * i
-                / ((bs_occ * i + cu_num - 1) // cu_num * cu_num)
-                * avg_kv
-                / (avg_kv + overhead * i),
-                i,
-            )
-            for i in range(1, 17)
-        ]
+        if ignore_total_kv:
+            # Occupancy-only: drop the avg_kv HBM term so the pick depends solely
+            # on how well bs_occ*i fills cu_num (ties -> smallest i).
+            tmp = [
+                (
+                    bs_occ * i / ((bs_occ * i + cu_num - 1) // cu_num * cu_num),
+                    i,
+                )
+                for i in range(1, 17)
+            ]
+        else:
+            tmp = [
+                (
+                    bs_occ
+                    * i
+                    / ((bs_occ * i + cu_num - 1) // cu_num * cu_num)
+                    * avg_kv
+                    / (avg_kv + overhead * i),
+                    i,
+                )
+                for i in range(1, 17)
+            ]
         num_kv_splits = sorted(tmp, key=lambda x: x[0], reverse=True)[0][1]
 
     get_block_n_fp8 = {
@@ -175,7 +199,7 @@ def get_meta_param(
         512: 32,
     }
 
-    if dtype == dtypes.fp8:
+    if dtype == dtypes.fp8 and not ignore_total_kv:
         min_block_n = get_block_n_fp8[int(nhead * max_seqlen_q)]
         # ceil(avg_kv / min_block_n) computed in pure integers (avg_kv = total_kv/bs).
         num_kv_splits = min(
@@ -1395,6 +1419,10 @@ def mla_decode_fwd_v4_nm(
     total_kv = kv_page_indices.shape[0]
     if num_kv_splits is None or split_indptr is None:
         tg_factor = max(1, -(-num_heads // 64))  # ceil(num_heads / 64)
+        # v4 nm forces occupancy-only split selection: ignore total_kv so the
+        # split count is driven purely by CU occupancy (drops the avg_kv HBM
+        # term + fp8 min-block cap in get_meta_param).
+        ignore_total_kv = 1
         meta_num_kv_splits, meta_split_indptr = get_meta_param(
             num_kv_splits,
             num_seqs,
@@ -1403,6 +1431,7 @@ def mla_decode_fwd_v4_nm(
             max_seqlen_q,
             q.dtype,
             tg_factor,
+            ignore_total_kv,
         )
         if num_kv_splits is None:
             num_kv_splits = meta_num_kv_splits

--- a/op_tests/test_mla_v4_nm.py
+++ b/op_tests/test_mla_v4_nm.py
@@ -1651,20 +1651,23 @@ def test_v4_nm_sink():
     args_b = _build_sink_test_args(batch=2, kv_seq_lens=64, q_seq_logical=1, seed=0)
     args_b["sink"] = torch.full((sink_size,), 10.0, dtype=torch.float32, device=device)
 
-    logits_a, _ = aiter.mla.mla_decode_fwd_v4_nm(**args_a)
+    aiter.mla.mla_decode_fwd_v4_nm(**args_a)
     torch.cuda.synchronize()
-    # Single-pass (V3-style) now returns packed-BF16 (2-byte) logits aliased
-    # onto `output`, so reinterpret the raw bits as int16 (not int32) to keep
-    # the last-dim aligned with the finite mask for the byte-level sink diff.
-    logits_a_bits = logits_a.view(torch.int16).clone()
+    # `output` is the authoritative BF16 result for BOTH single-pass (kernel
+    # writes packed-BF16 into it) and multi-pass (stage2 merges into it). Read
+    # it directly instead of the returned `logits` so the byte-level sink diff
+    # is robust to whatever split count the heuristic picks — v4 nm forces
+    # occupancy-only splits (ignore_total_kv), which can be >1 even for short
+    # KV, making `logits` an FP32 partial buffer rather than packed BF16.
+    out_a = args_a["output"]  # [total_q, num_heads, dv] BF16
+    out_a_bits = out_a.view(torch.int16).clone()
 
-    logits_b, _ = aiter.mla.mla_decode_fwd_v4_nm(**args_b)
+    aiter.mla.mla_decode_fwd_v4_nm(**args_b)
     torch.cuda.synchronize()
-    logits_b_bits = logits_b.view(torch.int16)
+    out_b = args_b["output"]
+    out_b_bits = out_b.view(torch.int16)
 
-    # logits is 4D [total_q, num_kv_splits=1, num_heads, dv]; only [:, 0]
-    # is kernel-written.
-    finite_both = torch.isfinite(logits_a[:, 0]) & torch.isfinite(logits_b[:, 0])
+    finite_both = torch.isfinite(out_a) & torch.isfinite(out_b)
     assert finite_both.any(), (
         "All output cells were NaN/inf under both sink values — the quant "
         "pipeline returned junk OR sink=10 pushed the running max into a "
@@ -1672,7 +1675,7 @@ def test_v4_nm_sink():
         "sink_b's magnitude."
     )
 
-    diff_finite = (logits_a_bits[:, 0] != logits_b_bits[:, 0]) & finite_both
+    diff_finite = (out_a_bits != out_b_bits) & finite_both
     assert diff_finite.any(), (
         "PR-2 regression: sink=-inf and sink=10.0 produced bit-identical "
         "output among finite cells. Either the dispatcher stopped writing "
@@ -1691,12 +1694,13 @@ def test_v4_nm_sink():
         (sink_size,), -1.0e9, dtype=torch.float32, device=device
     )
 
-    logits_inf, _ = aiter.mla.mla_decode_fwd_v4_nm(**args_inf)
-    logits_big, _ = aiter.mla.mla_decode_fwd_v4_nm(**args_big)
+    aiter.mla.mla_decode_fwd_v4_nm(**args_inf)
+    aiter.mla.mla_decode_fwd_v4_nm(**args_big)
     torch.cuda.synchronize()
 
-    nan_inf = torch.isnan(logits_inf[:, 0])
-    nan_big = torch.isnan(logits_big[:, 0])
+    # Compare the authoritative BF16 `output` (single/multi-pass agnostic).
+    nan_inf = torch.isnan(args_inf["output"])
+    nan_big = torch.isnan(args_big["output"])
 
     # -inf must not produce *more* NaNs than the -1e9 control. The inverse
     # would mean sink=-inf hits a kernel-side division-by-zero or


### PR DESCRIPTION
get_meta_param gains an `ignore_total_kv` flag (default 0 = legacy). When set, the auto split-count search uses only the CU-occupancy factor (drops the avg_kv HBM-efficiency term) and skips the fp8 min-block cap, giving a pure occupancy-driven pick independent of per-seq KV length.

mla_decode_fwd_v4_nm forces this on internally so v4 nm decode selects splits purely by CU occupancy. Because this can pick num_kv_splits > 1 even for short KV (where the fp8 cap previously forced single-pass), test_v4_nm_sink now compares the authoritative BF16 `output` buffer (populated for both single- and multi-pass) instead of the single-pass-only packed-BF16 `logits` view.
