### PR TITLE
Fix: add missing end_sync barrier in fused allreduce+rmsnorm kernel

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -2044,6 +2044,11 @@ __global__ void __launch_bounds__(1024, 1)
             *reinterpret_cast<OP*>(output + out_idx) = zero_pack;
         }
     }
+    // Pair start_sync with a final barrier before any rank can reuse the
+    // registered input buffer or this block's signal slot for the next fused
+    // collective. Without it, a faster rank may advance while a peer is still
+    // reading the previous invocation, causing silent cross-request corruption.
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 // Per-group quant variant of the 1-stage fused allreduce+rmsnorm kernel.
@@ -2127,6 +2132,7 @@ __global__ void __launch_bounds__(1024, 1)
             acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size,
             group_size, output, scale_out, active, bf16_output, token_num);
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, typename OutT, int NGPUS>
@@ -2236,6 +2242,7 @@ __global__ void __launch_bounds__(1024, 1)
             acc, weight_p, hidden_dim, eps, idx, tidx, padded_block_size,
             output, scale_out, active, bf16_output);
     }
+    end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
 template <typename T, int NGPUS>


### PR DESCRIPTION
## Motivation
Issue:
in sglang with fused allreduce+rmsnorm, it would have acc issue in lower concurrency(16), and the root cause is missing end_sync in all reduce fusion kernel.

How to reproduce:
image: lmsysorg/sglang-rocm:v0.5.15-rocm720-mi35x-20260713
model: amd/Qwen3.5-397B-A17B-MXFP4
start sglang server with: 
`CUDA_VISIBLE_DEVICES=0,1 \
SGLANG_USE_AITER=1 \
SGLANG_USE_AITER_UNIFIED_ATTN=1 \
AITER_FLYDSL_FORCE=1 \
SGLANG_MAMBA_SSM_DTYPE=bfloat16 \
SGLANG_USE_AITER_FP8_PER_TOKEN=1 \
python3 -m sglang.launch_server \
  --model-path /data/amd/Qwen3.5-397B-A17B-MXFP4 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port 6666 \
  --tensor-parallel-size 2 \
  --attention-backend aiter \
  --mem-fraction-static 0.8 \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 7200 \
  --disable-radix-cache \
  --enable-aiter-allreduce-fusion \
  --max-running-requests 16 \
  --page-size 16`
send prompt with:
'python3 /home/yuzho/inferencex_perf/run_refill_sequence_check.py \
  --base-url http://127.0.0.1:6666 \
  --model /data/amd/Qwen3.5-397B-A17B-MXFP4 \
  --concurrency 16 \
  --num-requests 160 \
  --timeout 7200 \
  --output /tmp/bf16_conc16_refill.json'
the content of 'run_refill_sequence_check.py' is:
`#!/usr/bin/env python3
import argparse
import asyncio
import json
import re
import time
from collections import Counter
from pathlib import Path

import aiohttp


EXPECTED = list(range(1, 101))
REPEATED_SYMBOL = re.compile(r"([^\w\s，,。；;：:\-])\1{5,}")


def classify(text, finish_reason):
    numbers = [int(value) for value in re.findall(r"\d+", text)]
    errors = []
    if not text.strip():
        errors.append("empty")
    if "\ufffd" in text:
        errors.append("replacement_character")
    if REPEATED_SYMBOL.search(text):
        errors.append("repeated_symbols")
    if numbers[:100] != EXPECTED:
        errors.append(f"sequence_mismatch_{len(numbers)}")
    if finish_reason not in ("stop", "length"):
        errors.append(f"finish_reason_{finish_reason}")
    return errors, numbers


async def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("--base-url", default="http://127.0.0.1:6666")
    parser.add_argument("--model", required=True)
    parser.add_argument("--concurrency", type=int, required=True)
    parser.add_argument("--num-requests", type=int, required=True)
    parser.add_argument("--timeout", type=float, default=7200)
    parser.add_argument("--output", required=True)
    args = parser.parse_args()

    output_path = Path(args.output)
    output_path.parent.mkdir(parents=True, exist_ok=True)
    timeout = aiohttp.ClientTimeout(total=args.timeout)
    connector = aiohttp.TCPConnector(limit=args.concurrency)
    queue = asyncio.Queue()
    for index in range(args.num_requests):
        queue.put_nowait(index)

    results = []
    started = time.monotonic()
    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
        async def worker():
            while True:
                try:
                    index = queue.get_nowait()
                except asyncio.QueueEmpty:
                    return
                request_started = time.monotonic()
                prompt = (
                    f"请求编号{index}。请从1到100按顺序输出整数，使用中文逗号分隔，"
                    "只输出数字序列，不要解释，不要省略。"
                )
                record = {"index": index}
                try:
                    async with session.post(
                        f"{args.base_url}/v1/chat/completions",
                        json={
                            "model": args.model,
                            "messages": [{"role": "user", "content": prompt}],
                            "temperature": 0,
                            "max_tokens": 512,
                            "chat_template_kwargs": {"enable_thinking": False},
                        },
                    ) as response:
                        body = await response.text()
                        record["http_status"] = response.status
                        if response.status != 200:
                            raise RuntimeError(body[:1000])
                        data = json.loads(body)
                        choice = data["choices"][0]
                        text = choice["message"]["content"] or ""
                        errors, numbers = classify(text, choice.get("finish_reason"))
                        record.update(
                            text=text,
                            errors=errors,
                            ok=not errors,
                            finish_reason=choice.get("finish_reason"),
                            number_count=len(numbers),
                        )
                except Exception as exc:
                    record.update(
                        text="",
                        errors=[f"request_error:{type(exc).__name__}:{exc}"],
                        ok=False,
                        finish_reason=None,
                        number_count=0,
                    )
                record["elapsed_seconds"] = time.monotonic() - request_started
                results.append(record)
                queue.task_done()

        await asyncio.gather(*(worker() for _ in range(args.concurrency)))

    results.sort(key=lambda item: item["index"])
    failures = [item for item in results if not item["ok"]]
    error_counts = Counter(error for item in failures for error in item["errors"])
    summary = {
        "model": args.model,
        "concurrency": args.concurrency,
        "num_requests": args.num_requests,
        "passed": len(results) - len(failures),
        "failed": len(failures),
        "elapsed_seconds": time.monotonic() - started,
        "error_counts": dict(sorted(error_counts.items())),
        "first_failure": failures[0] if failures else None,
        "results": results,
    }
    output_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2))
    print(json.dumps({key: value for key, value in summary.items() if key != "results"},
                     ensure_ascii=False))
    raise SystemExit(0 if not failures else 2)


if __name__ == "__main__":
    asyncio.run(main())
`
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
