### PR TITLE
refactor(flydsl): migrate mxfp4_gemm1 memory ops to fx.copy

### DIFF
--- a/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
@@ -84,8 +84,7 @@ def _scalar_store(tiles, idx, value, numeric_cls):
 
 
 def _layout_idx(layout, *coords):
-    # crd2idx's static-stride path wants index-typed coords.
-    idx_coords = [fx.Index(c) for c in coords]
+    idx_coords = [fx.Int64(c) for c in coords]
     flat = crd2idx(idx_coords, layout)
     return fx.Int32(flat)
 
@@ -153,26 +152,27 @@ def _gemm1_body(
     BM,
     BN,
     BK,
-    KH_TILE,
-    kAStages,
-    kSubBlocks,
-    kMChunks,
     inline_quant=False,
     K,
-    K_HALF,
-    K_TILES_TOTAL,
-    kUnroll,
-    kAS_per_chunk_dw,
-    kBS_stride_n0_dw,
-    kBS_per_expert_dw,
-    BQ_BYTES,
-    BSCALE_BYTES,
     N_OUT,
-    NUM_N_BLOCKS,
-    OUT_AS_PER_CHUNK_DW,
-    K_G2_HALF,
+    NE,
     interleave=False,
 ):
+    KH_TILE = BK // 2
+    K_HALF = k_half_for(K)
+    K_TILES_TOTAL = k_tiles_total_for(K, BK)
+    kUnroll = kunroll_for(K, BK)
+    kAS_per_chunk_dw = kas_per_chunk_dw_for(K)
+    kBS_stride_n0_dw = kbs_stride_n0_dw_for(K)
+    kBS_per_expert_dw = kbs_per_expert_dw_for(N_OUT, K)
+    BQ_BYTES = bq_bytes_for(NE, N_OUT, K)
+    BSCALE_BYTES = bscale_bytes_for(NE, N_OUT, K)
+    NUM_N_BLOCKS = num_n_blocks_for(N_OUT, BN)
+    inter = N_OUT // 2
+    OUT_AS_PER_CHUNK_DW = kas_per_chunk_dw_for(inter)
+    K_G2_HALF = k_half_for(inter)
+    kAStages, kSubBlocks, kMChunks, _ = _bm_constants(BM, BN, KH_TILE, K_TILES_TOTAL)
+
     BN_INT = BN // 2
     b_aux = 2 if use_nt else 0
     M_REPS = BM // 16
@@ -187,9 +187,9 @@ def _gemm1_body(
     lane_div_8 = lane // fx.Int32(8)
     lane_mod_8 = lane % fx.Int32(8)
 
-    aq_num_records = fx.Index(i32_ntok * fx.Int32(K_HALF))
+    aq_num_records = fx.Int64(i32_ntok * fx.Int32(K_HALF))
     _asc_per_mb = max(BM // 32, 1) * kAS_per_chunk_dw * 4
-    ascale_num = fx.Index(i32_total_m_blocks) * fx.Index(_asc_per_mb)
+    ascale_num = fx.Int64(i32_total_m_blocks) * fx.Int64(_asc_per_mb)
 
     # fx.copy's BufferCopy/BufferCopyLDS atoms take soffset as an element count,
     # not the bytes buffer_ops.buffer_load's soffset_bytes expects.
@@ -232,7 +232,7 @@ def _gemm1_body(
     ascale_dma_atom4 = fx.make_copy_atom(fx.rocdl.BufferCopyLDS32b(), fx.Int32)
 
     if const_expr(inline_quant):
-        hidden_num = fx.Index(i32_ntok * fx.Int32(K * 2))
+        hidden_num = fx.Int64(i32_ntok * fx.Int32(K * 2))
         hidden_tiles = _global_i32_buffer_tiles(arg_hidden, hidden_num, 4)
         hidden_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Int32)
         hidden_reg_lay = fx.make_layout(4, 1)
@@ -807,21 +807,10 @@ def compile_gemm1_a4w4_port(
         _N_OUT % BN == 0
     ), f"2*D_INTER (N_OUT) must be a multiple of {BN}, got {_N_OUT}"
     _NE = NE
-    _K_HALF = k_half_for(_K)
     _K_TILES_TOTAL = k_tiles_total_for(_K, BK)
-    _kUnroll = kunroll_for(_K, BK)
-    _kAS_per_chunk_dw = kas_per_chunk_dw_for(_K)
-    _kBS_stride_n0_dw = kbs_stride_n0_dw_for(_K)
-    _kBS_per_expert_dw = kbs_per_expert_dw_for(_N_OUT, _K)
-    _BQ_BYTES = bq_bytes_for(_NE, _N_OUT, _K)
-    _BSCALE_BYTES = bscale_bytes_for(_NE, _N_OUT, _K)
     _NUM_N_BLOCKS = num_n_blocks_for(_N_OUT, BN)
-    _OUT_AS_PER_CHUNK_DW = kas_per_chunk_dw_for(_INTER)
-    _K_G2_HALF = k_half_for(_INTER)
 
-    kAStages, kSubBlocks, kMChunks, lds_bytes = _bm_constants(
-        BM, BN, KH_TILE, _K_TILES_TOTAL
-    )
+    _, _, _, lds_bytes = _bm_constants(BM, BN, KH_TILE, _K_TILES_TOTAL)
 
     variant_tag = "iq" if inline_quant else ("nt" if use_nt else "cached")
     # Tag with H/INTER/NE so different shape specializations get distinct
@@ -907,24 +896,10 @@ def compile_gemm1_a4w4_port(
                 BM=BM,
                 BN=BN,
                 BK=BK,
-                KH_TILE=KH_TILE,
-                kAStages=kAStages,
-                kSubBlocks=kSubBlocks,
-                kMChunks=kMChunks,
                 inline_quant=inline_quant,
                 K=_K,
-                K_HALF=_K_HALF,
-                K_TILES_TOTAL=_K_TILES_TOTAL,
-                kUnroll=_kUnroll,
-                kAS_per_chunk_dw=_kAS_per_chunk_dw,
-                kBS_stride_n0_dw=_kBS_stride_n0_dw,
-                kBS_per_expert_dw=_kBS_per_expert_dw,
-                BQ_BYTES=_BQ_BYTES,
-                BSCALE_BYTES=_BSCALE_BYTES,
                 N_OUT=_N_OUT,
-                NUM_N_BLOCKS=_NUM_N_BLOCKS,
-                OUT_AS_PER_CHUNK_DW=_OUT_AS_PER_CHUNK_DW,
-                K_G2_HALF=_K_G2_HALF,
+                NE=_NE,
                 interleave=interleave,
             )
 
@@ -944,7 +919,7 @@ def compile_gemm1_a4w4_port(
         arg_hidden: fx.Int64,
         stream: fx.Stream,
     ):
-        grid_x = fx.Index(i32_grid)
+        grid_x = fx.Int64(i32_grid)
         gemm1_kernel(
             arg_aq,
             arg_ascale,

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
@@ -5,21 +5,16 @@ import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
 
 from . import dpp_utils
+from .layout_utils import crd2idx
 from .mxfp4_gemm_common import (
     kStages,
     kBS_stride_k0_dw,
     _raw,
-    _lds_ptr3,
-    _gep3,
-    _global_base_ptr1,
-    _gep1,
-    _global_ptr1,
-    _buffer_rsrc,
     _lds_swizzle_mask,
     _fabs_f32,
     _e8m0_roundup,
@@ -50,6 +45,66 @@ def _umod(a, c):
     return fx.Int32(arith.remui(_raw(a), _raw(cc)))
 
 
+def _global_i32_ptr(addr_i64):
+    ptr_ty = fx.PointerType.get(
+        T.i32, address_space=fx.AddressSpace.Global, alignment=4
+    )
+    return fx.inttoptr(ptr_ty, fx.Int64(addr_i64))
+
+
+def _global_i32_at(addr_i64, idx):
+    # fx.ptr_load/add_offset for a plain scalar read -- no tiling needed, so
+    # skip the Tensor/tile/register-fragment machinery fx.copy requires.
+    return fx.Int32(fx.ptr_load(fx.add_offset(_global_i32_ptr(addr_i64), idx)))
+
+
+def _global_i32_tiles(addr_i64):
+    # 1<<24 is a placeholder: layout shape only affects profile checks, not the
+    # computed index.
+    ptr_ty = fx.PointerType.get(
+        T.i32, address_space=fx.AddressSpace.Global, alignment=4
+    )
+    ptr = fx.inttoptr(ptr_ty, fx.Int64(addr_i64))
+    flat = fx.make_view(ptr, fx.make_layout(1 << 24, 1))
+    return fx.logical_divide(flat, fx.make_layout(1, 1))
+
+
+def _global_i32_load(tiles, idx):
+    # Must build atom/types here, not as module globals -- they need an active
+    # MLIR trace context.
+    atom = fx.make_copy_atom(fx.UniversalCopy(32), fx.Int32)
+    reg_ty = fx.MemRefType.get(T.i32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register)
+    reg_lay = fx.make_layout(1, 1)
+    r = fx.memref_alloca(reg_ty, reg_lay)
+    fx.copy_atom_call(atom, fx.slice(tiles, (None, idx)), r)
+    return fx.Vector(fx.memref_load_vec(r))[0]
+
+
+def _global_scalar_tiles(addr_i64, numeric_cls, ir_ty, num_elems):
+    ptr_ty = fx.PointerType.get(
+        ir_ty, address_space=fx.AddressSpace.Global, alignment=numeric_cls.width // 8
+    )
+    ptr = fx.inttoptr(ptr_ty, fx.Int64(addr_i64))
+    flat = fx.make_view(ptr, fx.make_layout(num_elems, 1))
+    return fx.logical_divide(flat, fx.make_layout(1, 1))
+
+
+def _scalar_store(tiles, idx, value, numeric_cls, ir_ty):
+    atom = fx.make_copy_atom(fx.UniversalCopy(numeric_cls.width), numeric_cls)
+    reg_ty = fx.MemRefType.get(ir_ty, fx.LayoutType.get(1, 1), fx.AddressSpace.Register)
+    reg_lay = fx.make_layout(1, 1)
+    r = fx.memref_alloca(reg_ty, reg_lay)
+    fx.memref_store_vec(Vec.from_elements([numeric_cls(value)], numeric_cls), r)
+    fx.copy_atom_call(atom, r, fx.slice(tiles, (None, idx)))
+
+
+def _layout_idx(layout, *coords):
+    # crd2idx's static-stride path wants index-typed coords.
+    idx_coords = [fx.Index(c) for c in coords]
+    flat = crd2idx(idx_coords, layout)
+    return fx.Int32(flat)
+
+
 def n_out_for(inter):
     return 2 * inter
 
@@ -63,12 +118,6 @@ def k_g2_half_for(inter):
 
 
 LOG2E = 1.4426950408889634
-
-
-def _silu_mul(g, u):
-    e = fx.Float32(rocdl.exp2(T.f32, _raw(g * fx.Float32(-LOG2E))))
-    sig = fx.Float32(rocdl.rcp(T.f32, _raw(fx.Float32(1.0) + e)))
-    return g * sig * u
 
 
 def _silu_mul_batch(gs, us):
@@ -153,9 +202,7 @@ def _gemm1_body(
 
     n_block_idx = bx_i32 % fx.Int32(NUM_N_BLOCKS)
     m_block_idx = bx_i32 // fx.Int32(NUM_N_BLOCKS)
-    e = rocdl.readfirstlane(
-        T.i32, llvm.load(T.i32, _global_ptr1(arg_eids, m_block_idx * fx.Int32(4)))
-    )
+    e = rocdl.readfirstlane(T.i32, _raw(_global_i32_at(arg_eids, m_block_idx)))
     m_row = m_block_idx * fx.Int32(BM)
 
     lane_div_16 = lane // fx.Int32(16)
@@ -163,39 +210,78 @@ def _gemm1_body(
     lane_div_8 = lane // fx.Int32(8)
     lane_mod_8 = lane % fx.Int32(8)
 
-    aq_num_records = arith.index_cast(T.index, _raw(i32_ntok * fx.Int32(K_HALF)))
-    aq_rsrc = _buffer_rsrc(arg_aq, aq_num_records)
+    aq_num_records = fx.Index(i32_ntok * fx.Int32(K_HALF))
     _asc_per_mb = max(BM // 32, 1) * kAS_per_chunk_dw * 4
-    ascale_num = arith.index_cast(T.index, _raw(i32_total_m_blocks)) * fx.Index(
-        _asc_per_mb
-    )
-    ascale_rsrc = _buffer_rsrc(arg_ascale, ascale_num)
-    bq_rsrc = _buffer_rsrc(arg_bq, BQ_BYTES)
-    bscale_rsrc = _buffer_rsrc(arg_bscale, BSCALE_BYTES)
-    hidden_rsrc = None
-    if const_expr(inline_quant):
-        hidden_num = arith.index_cast(T.index, _raw(i32_ntok * fx.Int32(K * 2)))
-        hidden_rsrc = _buffer_rsrc(arg_hidden, hidden_num)
+    ascale_num = fx.Index(i32_total_m_blocks) * fx.Index(_asc_per_mb)
 
-    # Union LDS region: [s_aq | s_asc] during the main loop, reused as lds_acc
-    # (f32 accumulator) in the epilogue. All three views share one byte region;
-    # s_aq/lds_acc start at offset 0, s_asc after the s_aq bytes.
-    s_aq_base_i32 = fx.Int32(fx.ptrtoint(lds_raw_ptr))
-    s_asc_base_i32 = s_aq_base_i32 + fx.Int32(kAStages * BM * KH_TILE)
+    # fx.copy's BufferCopy/BufferCopyLDS atoms take soffset as an element count,
+    # not the bytes buffer_ops.buffer_load's soffset_bytes expects.
+    def _global_i32_buffer_view(addr_i64, num_bytes):
+        # make_layout's dynamic-shape leaf must be i32/i64, not fx.Index.
+        num_bytes_i64 = fx.Int64(num_bytes)
+        ptr_ty = fx.PointerType.get(
+            T.i32, address_space=fx.AddressSpace.Global, alignment=4
+        )
+        ptr = fx.inttoptr(ptr_ty, fx.Int64(addr_i64))
+        view = fx.Tensor(
+            fx.make_view(ptr, fx.make_layout(num_bytes_i64 // fx.Int64(4), 1))
+        )
+        return fx.rocdl.make_buffer_tensor(
+            view, max_size=False, num_records_bytes=num_bytes_i64
+        )
+
+    def _global_i32_buffer_tiles(addr_i64, num_bytes, tile_elems):
+        return fx.logical_divide(
+            _global_i32_buffer_view(addr_i64, num_bytes), fx.make_layout(tile_elems, 1)
+        )
+
+    bq_tiles = _global_i32_buffer_tiles(arg_bq, BQ_BYTES, 4)
+    bq_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(128, b_aux), fx.Int32)
+    bq_reg_ty = fx.MemRefType.get(
+        T.i32, fx.LayoutType.get(4, 1), fx.AddressSpace.Register
+    )
+    bq_reg_lay = fx.make_layout(4, 1)
+
+    bscale_tiles = _global_i32_buffer_tiles(arg_bscale, BSCALE_BYTES, 1)
+    bscale_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Int32)
+    bscale_reg_ty = fx.MemRefType.get(
+        T.i32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
+    )
+    bscale_reg_lay = fx.make_layout(1, 1)
+
+    # aq/ascale: global->LDS async DMA (no register fragment), via BufferCopyLDS.
+    aq_buf = _global_i32_buffer_view(arg_aq, aq_num_records)
+    aq_dma_tiles4 = fx.logical_divide(aq_buf, fx.make_layout(4, 1))
+    aq_dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS(128), fx.Int32)
+
+    ascale_buf = _global_i32_buffer_view(arg_ascale, ascale_num)
+    ascale_dma_tiles4 = fx.logical_divide(ascale_buf, fx.make_layout(4, 1))
+    ascale_dma_tiles1 = fx.logical_divide(ascale_buf, fx.make_layout(1, 1))
+    ascale_dma_atom16 = fx.make_copy_atom(fx.rocdl.BufferCopyLDS(128), fx.Int32)
+    ascale_dma_atom4 = fx.make_copy_atom(fx.rocdl.BufferCopyLDS(32), fx.Int32)
+
+    if const_expr(inline_quant):
+        hidden_num = fx.Index(i32_ntok * fx.Int32(K * 2))
+        hidden_tiles = _global_i32_buffer_tiles(arg_hidden, hidden_num, 4)
+        hidden_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(128), fx.Int32)
+        hidden_reg_ty = fx.MemRefType.get(
+            T.i32, fx.LayoutType.get(4, 1), fx.AddressSpace.Register
+        )
+        hidden_reg_lay = fx.make_layout(4, 1)
+
+    # Union LDS region [s_aq | s_asc], reused as lds_acc (f32 accumulator) in
+    # the epilogue. s_aq/lds_acc start at lds_raw_ptr; s_asc follows at
+    # +kAStages*BM*KH_TILE.
 
     cached_actual_row = []
     cached_row_inline = []
     if const_expr(inline_quant):
         rcls = wave * fx.Int32(4) + lane_div_16
-        cached_row_inline = [
-            llvm.load(T.i32, _global_ptr1(arg_mind, (m_row + rcls) * fx.Int32(4)))
-        ]
+        cached_row_inline = [_global_i32_at(arg_mind, m_row + rcls)]
     else:
         for sub in range_constexpr(kSubBlocks):
             idx = m_row + wave * fx.Int32(BM // 4) + fx.Int32(sub * 8) + lane_div_8
-            cached_actual_row.append(
-                llvm.load(T.i32, _global_ptr1(arg_mind, idx * fx.Int32(4)))
-            )
+            cached_actual_row.append(_global_i32_at(arg_mind, idx))
 
     # -- b_load_s_base[j] (HIP 412-416), readfirstlane'd uniform per wave ------
     N0_HALF = N_OUT // 32
@@ -241,19 +327,45 @@ def _gemm1_body(
                 sub
             ] * fx.Int32(K_HALF)
             off = fx.Int32(slot * (BM * KH_TILE)) + lds_row * fx.Int32(KH_TILE)
-            rocdl.raw_ptr_buffer_load_lds(
-                aq_rsrc,
-                _lds_ptr3(s_aq_base_i32, off),
-                fx.Int32(16),
-                voffset,
-                fx.Int32(kt * KH_TILE),
-                fx.Int32(0),
-                fx.Int32(0),
+            fx.copy(
+                aq_dma_atom,
+                fx.slice(aq_dma_tiles4, (None, voffset // fx.Int32(16))),
+                fx.slice(s_aq_i32x4_tiles, (None, off // fx.Int32(16))),
+                soffset=fx.Int32(kt * KH_TILE) // fx.Int32(4),
             )
+
+    # s_aq as flat i32, divided into 4-element (128-bit) and 1-element tiles.
+    s_aq_i32_flat = fx.make_view(
+        fx.recast_iter(fx.Int32, lds_raw_ptr),
+        fx.make_layout(kAStages * BM * KH_TILE // 4, 1),
+    )
+    s_aq_i32x4_tiles = fx.logical_divide(s_aq_i32_flat, fx.make_layout(4, 1))
+    s_aq_i32x1_tiles = fx.logical_divide(s_aq_i32_flat, fx.make_layout(1, 1))
+    i32x4_copy_atom = fx.make_copy_atom(fx.UniversalCopy(128), fx.Int32)
+    i32x4_reg_ty = fx.MemRefType.get(
+        T.i32, fx.LayoutType.get(4, 1), fx.AddressSpace.Register
+    )
+    i32x4_reg_lay = fx.make_layout(4, 1)
+
+    def _lds_i32_store(tiles, idx, value):
+        atom = fx.make_copy_atom(fx.UniversalCopy(32), fx.Int32)
+        reg_ty = fx.MemRefType.get(
+            T.i32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
+        )
+        reg_lay = fx.make_layout(1, 1)
+        r = fx.memref_alloca(reg_ty, reg_lay)
+        fx.memref_store_vec(Vec.from_elements([fx.Int32(value)], fx.Int32), r)
+        fx.copy_atom_call(atom, r, fx.slice(tiles, (None, idx)))
+
+    def _lds_i32x4_load(tile_idx):
+        r = fx.memref_alloca(i32x4_reg_ty, i32x4_reg_lay)
+        fx.copy_atom_call(
+            i32x4_copy_atom, fx.slice(s_aq_i32x4_tiles, (None, tile_idx)), r
+        )
+        return fx.memref_load_vec(r)
 
     def issue_a_ds_read(slot):
         mask = _lds_swizzle_mask(lane_mod_16)
-        base_ptr = _lds_ptr3(s_aq_base_i32, fx.Int32(0))
         a = [[None, None] for _ in range(kMChunks)]
         for k in range_constexpr(2):
             lds_col = (lane_div_16 * fx.Int32(16) + fx.Int32(k * 64)) ^ mask
@@ -264,45 +376,53 @@ def _gemm1_body(
                     + lds_row * fx.Int32(KH_TILE)
                     + lds_col
                 )
-                a[i][k] = llvm.load(T.vec(4, T.i32), _gep3(base_ptr, off))
+                a[i][k] = _lds_i32x4_load(off // fx.Int32(16))
         return a
 
     def issue_a_scale_load():
         chunk_base = m_row // fx.Int32(32)
         v16 = (wave * fx.Int32(64) + lane) * fx.Int32(16)
         v4 = (wave * fx.Int32(64) + lane) * fx.Int32(4)
-        asc_base = s_asc_base_i32
         for sub in range_constexpr(kSubBlocks):
             s_chunk = rocdl.readfirstlane(
                 T.i32, (chunk_base + fx.Int32(sub)) * fx.Int32(kAS_per_chunk_dw * 4)
             )
             lds_sub = fx.Int32(sub * kAS_per_chunk_dw * 4)
-            rocdl.raw_ptr_buffer_load_lds(
-                ascale_rsrc,
-                _lds_ptr3(asc_base, lds_sub + wave * fx.Int32(1024)),
-                fx.Int32(16),
-                v16,
-                s_chunk,
-                fx.Int32(0),
-                fx.Int32(0),
+            fx.copy(
+                ascale_dma_atom16,
+                fx.slice(ascale_dma_tiles4, (None, v16 // fx.Int32(16))),
+                fx.slice(
+                    asc_i32x4_tiles,
+                    (None, (lds_sub + wave * fx.Int32(1024)) // fx.Int32(16)),
+                ),
+                soffset=s_chunk // fx.Int32(4),
             )
             for d in range_constexpr(3):
                 byte_off = 4096 + d * 1024
                 s_off = rocdl.readfirstlane(T.i32, s_chunk + fx.Int32(byte_off))
-                rocdl.raw_ptr_buffer_load_lds(
-                    ascale_rsrc,
-                    _lds_ptr3(
-                        asc_base, lds_sub + fx.Int32(byte_off) + wave * fx.Int32(256)
+                fx.copy(
+                    ascale_dma_atom4,
+                    fx.slice(ascale_dma_tiles1, (None, v4 // fx.Int32(4))),
+                    fx.slice(
+                        asc_i32_tiles,
+                        (
+                            None,
+                            (lds_sub + fx.Int32(byte_off) + wave * fx.Int32(256))
+                            // fx.Int32(4),
+                        ),
                     ),
-                    fx.Int32(4),
-                    v4,
-                    s_off,
-                    fx.Int32(0),
-                    fx.Int32(0),
+                    soffset=s_off // fx.Int32(4),
                 )
 
+    # s_asc as flat i32.
+    s_asc_i32_flat = fx.make_view(
+        fx.recast_iter(fx.Int32, fx.add_offset(lds_raw_ptr, kAStages * BM * KH_TILE)),
+        fx.make_layout(kSubBlocks * K_TILES_TOTAL * 64, 1),
+    )
+    asc_i32_tiles = fx.logical_divide(s_asc_i32_flat, fx.make_layout(1, 1))
+    asc_i32x4_tiles = fx.logical_divide(s_asc_i32_flat, fx.make_layout(4, 1))
+
     def issue_a_scale_ds_read(kt):
-        base_ptr = _lds_ptr3(s_asc_base_i32, fx.Int32(0))
         out = []
         for sub in range_constexpr(kSubBlocks):
             lds_dw = (
@@ -311,7 +431,7 @@ def _gemm1_body(
                 + lane_div_16 * fx.Int32(16)
                 + lane_mod_16
             )
-            out.append(llvm.load(T.i32, _gep3(base_ptr, lds_dw * fx.Int32(4))))
+            out.append(_raw(_global_i32_load(asc_i32_tiles, lds_dw)))
         return out
 
     lib = lane & fx.Int32(3)
@@ -325,14 +445,14 @@ def _gemm1_body(
             + lib * fx.Int32(16)
         )
         s_soff = rocdl.readfirstlane(T.i32, fx.Int32(kt * (BK * 2) + B128_IDX * 256))
-        frag = buffer_ops.buffer_load(
-            hidden_rsrc,
-            v_voff // fx.Int32(4),
-            vec_width=4,
-            dtype=T.i32,
-            soffset_bytes=s_soff,
+        r = fx.memref_alloca(hidden_reg_ty, hidden_reg_lay)
+        fx.copy(
+            hidden_copy_atom,
+            fx.slice(hidden_tiles, (None, v_voff // fx.Int32(16))),
+            r,
+            soffset=s_soff // fx.Int32(4),
         )
-        return Vec(frag)
+        return Vec(fx.memref_load_vec(r))
 
     def _inline_quant_core(B128_IDX, SUB, slot, kt, h_v, scale_accum):
         h_dw = [fx.Int32(_raw(h_v[j])) for j in range_constexpr(4)]
@@ -358,14 +478,13 @@ def _gemm1_body(
         kb_in_kt = fx.Int32(B128_IDX * 4) + lane_shr2_and3
         mask_r = _lds_swizzle_mask(r)
         b_off = lib * fx.Int32(4)
-        aq_base = s_aq_base_i32
         off = (
             fx.Int32(slot * (BM * KH_TILE))
             + r * fx.Int32(KH_TILE)
             + ((kb_in_kt * fx.Int32(16)) ^ mask_r)
             + b_off
         )
-        llvm.StoreOp(_raw(pk), _lds_ptr3(aq_base, off))
+        _lds_i32_store(s_aq_i32x1_tiles, off // fx.Int32(4), pk)
         pack_byte = B128_IDX * 2 + SUB
         scale_accum[0] = scale_accum[0] | (e8m0 << fx.Int32(pack_byte * 8))
 
@@ -414,14 +533,13 @@ def _gemm1_body(
             kb_in_kt = fx.Int32(B128_IDX * 4) + lane_shr2_and3
             mask_r = _lds_swizzle_mask(r)
             b_off = lib * fx.Int32(4)
-            aq_base = s_aq_base_i32
             off = (
                 fx.Int32(slot * (BM * KH_TILE))
                 + r * fx.Int32(KH_TILE)
                 + ((kb_in_kt * fx.Int32(16)) ^ mask_r)
                 + b_off
             )
-            llvm.StoreOp(_raw(pk), _lds_ptr3(aq_base, off))
+            _lds_i32_store(s_aq_i32x1_tiles, off // fx.Int32(4), pk)
             pack_byte = B128_IDX * 2 + SUB
             scale_accum[0] = scale_accum[0] | (e8[i] << fx.Int32(pack_byte * 8))
 
@@ -429,14 +547,10 @@ def _gemm1_body(
         h_v = inline_quant_load_kt(B128_IDX, kt, row_token)
         _inline_quant_core(B128_IDX, SUB, slot, kt, h_v, scale_accum)
 
-    def inline_quant_finish_kt(B128_IDX, SUB, slot, kt, h_v, scale_accum):
-        _inline_quant_core(B128_IDX, SUB, slot, kt, h_v, scale_accum)
-
     def inline_quant_pack_write(kt, scale_accum):
         lane_tgt = lane_shr2_and3 * fx.Int32(16) + r_in_chunk
-        asc_base = s_asc_base_i32
         off = fx.Int32(kt * 256) + lane_tgt * fx.Int32(4)
-        llvm.StoreOp(_raw(scale_accum[0]), _lds_ptr3(asc_base, off))
+        _lds_i32_store(asc_i32_tiles, off // fx.Int32(4), scale_accum[0])
 
     def issue_b_load_j(b_slot, K_C, j):
         v = (
@@ -445,14 +559,15 @@ def _gemm1_body(
             + fx.Int32(K_C * 2048)
         )
         for half in range_constexpr(2):
-            frag = buffer_ops.buffer_load(
-                bq_rsrc,
-                (v + fx.Int32(half * 1024)) // fx.Int32(4),
-                vec_width=4,
-                dtype=T.i32,
-                cache_modifier=b_aux,
-                soffset_bytes=b_load_s_base[j],
+            tile_idx = (v + fx.Int32(half * 1024)) // fx.Int32(16)
+            r = fx.memref_alloca(bq_reg_ty, bq_reg_lay)
+            fx.copy(
+                bq_copy_atom,
+                fx.slice(bq_tiles, (None, tile_idx)),
+                r,
+                soffset=b_load_s_base[j] // fx.Int32(4),
             )
+            frag = fx.memref_load_vec(r)
             b_slot[j][half] = Vec(frag)
 
     def issue_b_scale_load(bs_slot, K_C):
@@ -461,13 +576,15 @@ def _gemm1_body(
         imm = (K_C - K_C_HI * 16) * (kBS_stride_k0_dw * 4)
         for mw in range_constexpr(2):
             s_off = b_scale_s_base[mw] if K_C_HI == 0 else b_scale_s_base_hi[mw]
-            bs_slot[mw] = buffer_ops.buffer_load(
-                bscale_rsrc,
-                (v + fx.Int32(imm)) // fx.Int32(4),
-                vec_width=1,
-                dtype=T.i32,
-                soffset_bytes=s_off,
+            idx = (v + fx.Int32(imm)) // fx.Int32(4)
+            r = fx.memref_alloca(bscale_reg_ty, bscale_reg_lay)
+            fx.copy(
+                bscale_copy_atom,
+                fx.slice(bscale_tiles, (None, idx)),
+                r,
+                soffset=s_off // fx.Int32(4),
             )
+            bs_slot[mw] = fx.Vector(fx.memref_load_vec(r))[0]
 
     mfma_ty = T.f32x4
     zero4 = Vec.filled(4, 0.0, fx.Float32)
@@ -601,31 +718,55 @@ def _gemm1_body(
 
     gpu.barrier()
 
-    wave_n = wave
     # lds_acc reuses the s_aq region (offset 0) as an f32 accumulator.
-    lds_acc_base = _lds_ptr3(s_aq_base_i32, fx.Int32(0))
+    acc_layout = fx.make_layout((BM, BN), (BN, 1))
+
+    def acc_idx(row, col):
+        return _layout_idx(acc_layout, row, col)
+
+    acc_copy_atom = fx.make_copy_atom(fx.UniversalCopy(32), fx.Float32)
+    acc_reg_ty = fx.MemRefType.get(
+        T.f32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
+    )
+    acc_reg_lay = fx.make_layout(1, 1)
+    acc_flat_view = fx.make_view(
+        fx.recast_iter(fx.Float32, lds_raw_ptr), fx.make_layout(BM * BN, 1)
+    )
+    acc_flat_tiles = fx.logical_divide(acc_flat_view, fx.make_layout(1, 1))
+
+    def acc_store(idx, value):
+        r = fx.memref_alloca(acc_reg_ty, acc_reg_lay)
+        fx.memref_store_vec(Vec.from_elements([fx.Float32(value)], fx.Float32), r)
+        fx.copy_atom_call(acc_copy_atom, r, fx.slice(acc_flat_tiles, (None, idx)))
+
+    def acc_load(idx):
+        r = fx.memref_alloca(acc_reg_ty, acc_reg_lay)
+        fx.copy_atom_call(acc_copy_atom, fx.slice(acc_flat_tiles, (None, idx)), r)
+        return fx.Float32(Vec(fx.memref_load_vec(r))[0])
 
     for i in range_constexpr(kMChunks):
         row_base = fx.Int32(i * 16) + lane_div_16 * fx.Int32(4)
         for J in range_constexpr(4):
             is_up = (J % 2) == 1
             J_local = J // 2
-            col_local = wave_n * fx.Int32(32) + fx.Int32(J_local * 16) + lane_mod_16
+            col_local = wave * fx.Int32(32) + fx.Int32(J_local * 16) + lane_mod_16
             lds_col = (fx.Int32(128) + col_local) if is_up else col_local
             vec = Vec(accm[i][J])
             for v in range_constexpr(4):
-                idx = (row_base + fx.Int32(v)) * fx.Int32(BN) + lds_col
-                llvm.StoreOp(_raw(vec[v]), _gep3(lds_acc_base, idx * fx.Int32(4)))
+                idx = acc_idx(row_base + fx.Int32(v), lds_col)
+                acc_store(idx, vec[v])
 
     gpu.barrier()
 
-    tx_i32 = arith.index_cast(T.i32, gpu.thread_id("x"))
+    tx_i32 = fx.Int32(gpu.thread_id("x"))
     m_lane = tx_i32 // fx.Int32(16)
     n_lane = tx_i32 % fx.Int32(16)
     wave_grp = n_lane // fx.Int32(4)
     kk = n_lane % fx.Int32(4)
 
-    aqout_base = _global_base_ptr1(arg_aqout)
+    aqout_layout = fx.make_layout((BM, K_G2_HALF), (K_G2_HALF, 1))
+    # UniversalCopy has no nontemporal/cache-hint knob; dropped (perf-neutral).
+    aqout_tiles = _global_i32_tiles(arg_aqout)
     scales_per_mr = [None] * M_REPS
 
     for mr in range_constexpr(M_REPS):
@@ -637,10 +778,8 @@ def _gemm1_body(
             col_in_grp = fx.Int32(8) * kk + fx.Int32(ee)
             gate_col = wave_grp * fx.Int32(32) + col_in_grp
             up_col = fx.Int32(128) + gate_col
-            gate_off = (row_local * fx.Int32(BN) + gate_col) * fx.Int32(4)
-            up_off = (row_local * fx.Int32(BN) + up_col) * fx.Int32(4)
-            gate_vs[ee] = fx.Float32(llvm.load(T.f32, _gep3(lds_acc_base, gate_off)))
-            up_vs[ee] = fx.Float32(llvm.load(T.f32, _gep3(lds_acc_base, up_off)))
+            gate_vs[ee] = acc_load(acc_idx(row_local, gate_col))
+            up_vs[ee] = acc_load(acc_idx(row_local, up_col))
         result = _silu_mul_batch(gate_vs, up_vs)
 
         local_max = _fabs_f32(result[0])
@@ -671,47 +810,33 @@ def _gemm1_body(
             + kk * fx.Int32(4)
         )
         out_row = m_row + row_local
-        store_off = out_row * fx.Int32(K_G2_HALF) + byte_pos
-        llvm.StoreOp(
-            _raw(packed),
-            _gep1(aqout_base, store_off),
-            alignment=4,
-            nontemporal=True,
-        )
+        store_off = _layout_idx(aqout_layout, out_row, byte_pos)
+        _scalar_store(aqout_tiles, store_off // fx.Int32(4), packed, fx.Int32, T.i32)
 
-    ascaleout_base = _global_base_ptr1(arg_ascaleout)
+    # (chunk, ku, wave_grp, m_lane) -> dword index; shape is a placeholder.
+    ascaleout_layout = fx.make_layout(
+        (1 << 20, 2, 4, 16), (OUT_AS_PER_CHUNK_DW, 64, 16, 1)
+    )
+    ascaleout_i8_tiles = _global_scalar_tiles(arg_ascaleout, fx.Int8, T.i8, 1 << 26)
+    ascaleout_i16_tiles = _global_scalar_tiles(arg_ascaleout, fx.Int16, T.i16, 1 << 25)
     if kk == fx.Int32(0):
         ku = n_block_idx >> fx.Int32(1)
         ikxdl = n_block_idx & fx.Int32(1)
         if const_expr(BM == 16):
             chunk = m_block_idx
-            dword_off = (
-                chunk * fx.Int32(OUT_AS_PER_CHUNK_DW)
-                + ku * fx.Int32(64)
-                + wave_grp * fx.Int32(16)
-                + m_lane
-            )
+            dword_off = _layout_idx(ascaleout_layout, chunk, ku, wave_grp, m_lane)
             addr = dword_off * fx.Int32(4) + ikxdl * fx.Int32(2)
-            byte_i8 = arith.TruncIOp(T.i8, _raw(scales_per_mr[0])).result
-            llvm.StoreOp(byte_i8, _gep1(ascaleout_base, addr), alignment=1)
+            _scalar_store(ascaleout_i8_tiles, addr, scales_per_mr[0], fx.Int8, T.i8)
         else:
             for sub in range_constexpr(kSubBlocks):
                 chunk = m_block_idx * fx.Int32(kSubBlocks) + fx.Int32(sub)
-                dword_off = (
-                    chunk * fx.Int32(OUT_AS_PER_CHUNK_DW)
-                    + ku * fx.Int32(64)
-                    + wave_grp * fx.Int32(16)
-                    + m_lane
-                )
+                dword_off = _layout_idx(ascaleout_layout, chunk, ku, wave_grp, m_lane)
                 pair_i32 = scales_per_mr[sub * 2 + 0] | (
                     scales_per_mr[sub * 2 + 1] << fx.Int32(8)
                 )
-                pair_i16 = arith.TruncIOp(T.i16, _raw(pair_i32)).result
                 addr = dword_off * fx.Int32(4) + ikxdl * fx.Int32(2)
-                llvm.StoreOp(
-                    pair_i16,
-                    _gep1(ascaleout_base, addr),
-                    alignment=2,
+                _scalar_store(
+                    ascaleout_i16_tiles, addr // fx.Int32(2), pair_i32, fx.Int16, T.i16
                 )
 
 
@@ -806,11 +931,11 @@ def compile_gemm1_a4w4_port(
         lds_raw_ptr = fx.SharedAllocator().allocate(SharedStorage).peek().raw.ptr
         tx = gpu.thread_id("x")
         bx = gpu.block_id("x")
-        tx_i32 = arith.index_cast(T.i32, tx)
-        bx_i32 = arith.index_cast(T.i32, bx)
+        tx_i32 = fx.Int32(tx)
+        bx_i32 = fx.Int32(bx)
         lane = tx_i32 % fx.Int32(64)
         wave = rocdl.readfirstlane(T.i32, tx_i32 // fx.Int32(64))
-        cumsum0 = llvm.load(T.i32, _global_ptr1(arg_cumsum, fx.Int32(0)))
+        cumsum0 = _global_i32_at(arg_cumsum, fx.Int32(0))
         total_m_blocks = cumsum0 // fx.Int32(BM)
         bound = total_m_blocks * fx.Int32(_NUM_N_BLOCKS)
 
@@ -898,7 +1023,7 @@ def compile_gemm1_a4w4_port(
         arg_hidden: fx.Int64,
         stream: fx.Stream,
     ):
-        grid_x = arith.index_cast(T.index, i32_grid)
+        grid_x = fx.Index(i32_grid)
         gemm1_kernel(
             arg_aq,
             arg_ascale,

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
@@ -80,18 +80,22 @@ def _global_i32_load(tiles, idx):
     return fx.Vector(fx.memref_load_vec(r))[0]
 
 
-def _global_scalar_tiles(addr_i64, numeric_cls, ir_ty, num_elems):
+def _global_scalar_tiles(addr_i64, numeric_cls, num_elems):
     ptr_ty = fx.PointerType.get(
-        ir_ty, address_space=fx.AddressSpace.Global, alignment=numeric_cls.width // 8
+        numeric_cls.ir_type,
+        address_space=fx.AddressSpace.Global,
+        alignment=numeric_cls.width // 8,
     )
     ptr = fx.inttoptr(ptr_ty, fx.Int64(addr_i64))
     flat = fx.make_view(ptr, fx.make_layout(num_elems, 1))
     return fx.logical_divide(flat, fx.make_layout(1, 1))
 
 
-def _scalar_store(tiles, idx, value, numeric_cls, ir_ty):
+def _scalar_store(tiles, idx, value, numeric_cls):
     atom = fx.make_copy_atom(fx.UniversalCopy(numeric_cls.width), numeric_cls)
-    reg_ty = fx.MemRefType.get(ir_ty, fx.LayoutType.get(1, 1), fx.AddressSpace.Register)
+    reg_ty = fx.MemRefType.get(
+        numeric_cls.ir_type, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
+    )
     reg_lay = fx.make_layout(1, 1)
     r = fx.memref_alloca(reg_ty, reg_lay)
     fx.memref_store_vec(Vec.from_elements([numeric_cls(value)], numeric_cls), r)
@@ -811,14 +815,14 @@ def _gemm1_body(
         )
         out_row = m_row + row_local
         store_off = _layout_idx(aqout_layout, out_row, byte_pos)
-        _scalar_store(aqout_tiles, store_off // fx.Int32(4), packed, fx.Int32, T.i32)
+        _scalar_store(aqout_tiles, store_off // fx.Int32(4), packed, fx.Int32)
 
     # (chunk, ku, wave_grp, m_lane) -> dword index; shape is a placeholder.
     ascaleout_layout = fx.make_layout(
         (1 << 20, 2, 4, 16), (OUT_AS_PER_CHUNK_DW, 64, 16, 1)
     )
-    ascaleout_i8_tiles = _global_scalar_tiles(arg_ascaleout, fx.Int8, T.i8, 1 << 26)
-    ascaleout_i16_tiles = _global_scalar_tiles(arg_ascaleout, fx.Int16, T.i16, 1 << 25)
+    ascaleout_i8_tiles = _global_scalar_tiles(arg_ascaleout, fx.Int8, 1 << 26)
+    ascaleout_i16_tiles = _global_scalar_tiles(arg_ascaleout, fx.Int16, 1 << 25)
     if kk == fx.Int32(0):
         ku = n_block_idx >> fx.Int32(1)
         ikxdl = n_block_idx & fx.Int32(1)
@@ -826,7 +830,7 @@ def _gemm1_body(
             chunk = m_block_idx
             dword_off = _layout_idx(ascaleout_layout, chunk, ku, wave_grp, m_lane)
             addr = dword_off * fx.Int32(4) + ikxdl * fx.Int32(2)
-            _scalar_store(ascaleout_i8_tiles, addr, scales_per_mr[0], fx.Int8, T.i8)
+            _scalar_store(ascaleout_i8_tiles, addr, scales_per_mr[0], fx.Int8)
         else:
             for sub in range_constexpr(kSubBlocks):
                 chunk = m_block_idx * fx.Int32(kSubBlocks) + fx.Int32(sub)
@@ -836,7 +840,7 @@ def _gemm1_body(
                 )
                 addr = dword_off * fx.Int32(4) + ikxdl * fx.Int32(2)
                 _scalar_store(
-                    ascaleout_i16_tiles, addr // fx.Int32(2), pair_i32, fx.Int16, T.i16
+                    ascaleout_i16_tiles, addr // fx.Int32(2), pair_i32, fx.Int16
                 )
 
 

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
@@ -3,11 +3,9 @@
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
 from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T
-from flydsl.expr.typing import Vector as Vec
 
 from . import dpp_utils
 from .layout_utils import crd2idx
@@ -36,13 +34,11 @@ from .mxfp4_gemm_common import (
 
 
 def _udiv(a, c):
-    cc = fx.Int32(c) if isinstance(c, int) else c
-    return fx.Int32(arith.divui(_raw(a), _raw(cc)))
+    return fx.Int32(fx.Uint32(a) // fx.Uint32(c))
 
 
 def _umod(a, c):
-    cc = fx.Int32(c) if isinstance(c, int) else c
-    return fx.Int32(arith.remui(_raw(a), _raw(cc)))
+    return fx.Int32(fx.Uint32(a) % fx.Uint32(c))
 
 
 def _global_i32_ptr(addr_i64):
@@ -55,29 +51,17 @@ def _global_i32_ptr(addr_i64):
 def _global_i32_at(addr_i64, idx):
     # fx.ptr_load/add_offset for a plain scalar read -- no tiling needed, so
     # skip the Tensor/tile/register-fragment machinery fx.copy requires.
-    return fx.Int32(fx.ptr_load(fx.add_offset(_global_i32_ptr(addr_i64), idx)))
-
-
-def _global_i32_tiles(addr_i64):
-    # 1<<24 is a placeholder: layout shape only affects profile checks, not the
-    # computed index.
-    ptr_ty = fx.PointerType.get(
-        T.i32, address_space=fx.AddressSpace.Global, alignment=4
-    )
-    ptr = fx.inttoptr(ptr_ty, fx.Int64(addr_i64))
-    flat = fx.make_view(ptr, fx.make_layout(1 << 24, 1))
-    return fx.logical_divide(flat, fx.make_layout(1, 1))
+    return _global_i32_ptr(addr_i64)[idx]
 
 
 def _global_i32_load(tiles, idx):
     # Must build atom/types here, not as module globals -- they need an active
     # MLIR trace context.
-    atom = fx.make_copy_atom(fx.UniversalCopy(32), fx.Int32)
-    reg_ty = fx.MemRefType.get(T.i32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register)
+    atom = fx.make_copy_atom(fx.UniversalCopy32b(), fx.Int32)
     reg_lay = fx.make_layout(1, 1)
-    r = fx.memref_alloca(reg_ty, reg_lay)
+    r = fx.make_rmem_tensor(reg_lay, fx.Int32)
     fx.copy_atom_call(atom, fx.slice(tiles, (None, idx)), r)
-    return fx.Vector(fx.memref_load_vec(r))[0]
+    return r.load()[0]
 
 
 def _global_scalar_tiles(addr_i64, numeric_cls, num_elems):
@@ -93,12 +77,9 @@ def _global_scalar_tiles(addr_i64, numeric_cls, num_elems):
 
 def _scalar_store(tiles, idx, value, numeric_cls):
     atom = fx.make_copy_atom(fx.UniversalCopy(numeric_cls.width), numeric_cls)
-    reg_ty = fx.MemRefType.get(
-        numeric_cls.ir_type, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
-    )
     reg_lay = fx.make_layout(1, 1)
-    r = fx.memref_alloca(reg_ty, reg_lay)
-    fx.memref_store_vec(Vec.from_elements([numeric_cls(value)], numeric_cls), r)
+    r = fx.make_rmem_tensor(reg_lay, numeric_cls)
+    r.store(fx.Vector.from_elements([numeric_cls(value)], numeric_cls))
     fx.copy_atom_call(atom, r, fx.slice(tiles, (None, idx)))
 
 
@@ -113,14 +94,6 @@ def n_out_for(inter):
     return 2 * inter
 
 
-def out_as_per_chunk_dw_for(inter):
-    return ((inter // 32) // 4 // 2) * 64
-
-
-def k_g2_half_for(inter):
-    return inter // 2
-
-
 LOG2E = 1.4426950408889634
 
 
@@ -131,7 +104,7 @@ def _silu_mul_batch(gs, us):
 
 
 def _pkmax_u16(a_i32, b_i32):
-    _v2i16 = ir.Type.parse("vector<2xi16>")
+    _v2i16 = T.vec(2, T.i16)
     va = llvm.BitcastOp(_v2i16, _raw(a_i32)).result
     vb = llvm.BitcastOp(_v2i16, _raw(b_i32)).result
     vm = arith.MaxUIOp(va, vb).result
@@ -240,37 +213,28 @@ def _gemm1_body(
         )
 
     bq_tiles = _global_i32_buffer_tiles(arg_bq, BQ_BYTES, 4)
-    bq_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(128, b_aux), fx.Int32)
-    bq_reg_ty = fx.MemRefType.get(
-        T.i32, fx.LayoutType.get(4, 1), fx.AddressSpace.Register
-    )
+    bq_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(b_aux), fx.Int32)
     bq_reg_lay = fx.make_layout(4, 1)
 
     bscale_tiles = _global_i32_buffer_tiles(arg_bscale, BSCALE_BYTES, 1)
-    bscale_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Int32)
-    bscale_reg_ty = fx.MemRefType.get(
-        T.i32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
-    )
+    bscale_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
     bscale_reg_lay = fx.make_layout(1, 1)
 
     # aq/ascale: global->LDS async DMA (no register fragment), via BufferCopyLDS.
     aq_buf = _global_i32_buffer_view(arg_aq, aq_num_records)
     aq_dma_tiles4 = fx.logical_divide(aq_buf, fx.make_layout(4, 1))
-    aq_dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS(128), fx.Int32)
+    aq_dma_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), fx.Int32)
 
     ascale_buf = _global_i32_buffer_view(arg_ascale, ascale_num)
     ascale_dma_tiles4 = fx.logical_divide(ascale_buf, fx.make_layout(4, 1))
     ascale_dma_tiles1 = fx.logical_divide(ascale_buf, fx.make_layout(1, 1))
-    ascale_dma_atom16 = fx.make_copy_atom(fx.rocdl.BufferCopyLDS(128), fx.Int32)
-    ascale_dma_atom4 = fx.make_copy_atom(fx.rocdl.BufferCopyLDS(32), fx.Int32)
+    ascale_dma_atom16 = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), fx.Int32)
+    ascale_dma_atom4 = fx.make_copy_atom(fx.rocdl.BufferCopyLDS32b(), fx.Int32)
 
     if const_expr(inline_quant):
         hidden_num = fx.Index(i32_ntok * fx.Int32(K * 2))
         hidden_tiles = _global_i32_buffer_tiles(arg_hidden, hidden_num, 4)
-        hidden_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(128), fx.Int32)
-        hidden_reg_ty = fx.MemRefType.get(
-            T.i32, fx.LayoutType.get(4, 1), fx.AddressSpace.Register
-        )
+        hidden_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Int32)
         hidden_reg_lay = fx.make_layout(4, 1)
 
     # Union LDS region [s_aq | s_asc], reused as lds_acc (f32 accumulator) in
@@ -278,10 +242,10 @@ def _gemm1_body(
     # +kAStages*BM*KH_TILE.
 
     cached_actual_row = []
-    cached_row_inline = []
+    cached_row_inline = None
     if const_expr(inline_quant):
         rcls = wave * fx.Int32(4) + lane_div_16
-        cached_row_inline = [_global_i32_at(arg_mind, m_row + rcls)]
+        cached_row_inline = _global_i32_at(arg_mind, m_row + rcls)
     else:
         for sub in range_constexpr(kSubBlocks):
             idx = m_row + wave * fx.Int32(BM // 4) + fx.Int32(sub * 8) + lane_div_8
@@ -345,28 +309,15 @@ def _gemm1_body(
     )
     s_aq_i32x4_tiles = fx.logical_divide(s_aq_i32_flat, fx.make_layout(4, 1))
     s_aq_i32x1_tiles = fx.logical_divide(s_aq_i32_flat, fx.make_layout(1, 1))
-    i32x4_copy_atom = fx.make_copy_atom(fx.UniversalCopy(128), fx.Int32)
-    i32x4_reg_ty = fx.MemRefType.get(
-        T.i32, fx.LayoutType.get(4, 1), fx.AddressSpace.Register
-    )
+    i32x4_copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), fx.Int32)
     i32x4_reg_lay = fx.make_layout(4, 1)
 
-    def _lds_i32_store(tiles, idx, value):
-        atom = fx.make_copy_atom(fx.UniversalCopy(32), fx.Int32)
-        reg_ty = fx.MemRefType.get(
-            T.i32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
-        )
-        reg_lay = fx.make_layout(1, 1)
-        r = fx.memref_alloca(reg_ty, reg_lay)
-        fx.memref_store_vec(Vec.from_elements([fx.Int32(value)], fx.Int32), r)
-        fx.copy_atom_call(atom, r, fx.slice(tiles, (None, idx)))
-
     def _lds_i32x4_load(tile_idx):
-        r = fx.memref_alloca(i32x4_reg_ty, i32x4_reg_lay)
+        r = fx.make_rmem_tensor(i32x4_reg_lay, fx.Int32)
         fx.copy_atom_call(
             i32x4_copy_atom, fx.slice(s_aq_i32x4_tiles, (None, tile_idx)), r
         )
-        return fx.memref_load_vec(r)
+        return r.load()
 
     def issue_a_ds_read(slot):
         mask = _lds_swizzle_mask(lane_mod_16)
@@ -449,50 +400,16 @@ def _gemm1_body(
             + lib * fx.Int32(16)
         )
         s_soff = rocdl.readfirstlane(T.i32, fx.Int32(kt * (BK * 2) + B128_IDX * 256))
-        r = fx.memref_alloca(hidden_reg_ty, hidden_reg_lay)
+        r = fx.make_rmem_tensor(hidden_reg_lay, fx.Int32)
         fx.copy(
             hidden_copy_atom,
             fx.slice(hidden_tiles, (None, v_voff // fx.Int32(16))),
             r,
             soffset=s_soff // fx.Int32(4),
         )
-        return Vec(fx.memref_load_vec(r))
+        return r.load()
 
-    def _inline_quant_core(B128_IDX, SUB, slot, kt, h_v, scale_accum):
-        h_dw = [fx.Int32(_raw(h_v[j])) for j in range_constexpr(4)]
-        hm = [h_dw[j] & fx.Int32(0x7FFF7FFF) for j in range_constexpr(4)]
-        m01 = _pkmax_u16(hm[0], hm[1])
-        m23 = _pkmax_u16(hm[2], hm[3])
-        m0123 = _pkmax_u16(m01, m23)
-        lo = m0123 & fx.Int32(0xFFFF)
-        hi = m0123.shrui(fx.Int32(16)) & fx.Int32(0xFFFF)
-        local_amax = _umax_i32(lo, hi)
-        amax_u32 = _inline_dpp_quad_amax(local_amax)
-        e8m0 = _inline_e8m0(amax_u32)
-        qs = fx.Float32(_raw(e8m0 << fx.Int32(23)).bitcast(T.f32))
-        pk = _raw(fx.Int32(0))
-        qs_raw = _raw(qs)
-        for j in range_constexpr(4):
-            src_bf16x2 = _raw(
-                Vec.from_elements([h_dw[j]], fx.Int32).bitcast(fx.BFloat16)
-            )
-            pk = rocdl.cvt_scalef32_pk_fp4_bf16(T.i32, pk, src_bf16x2, qs_raw, j)
-        pk = fx.Int32(pk)
-        r = fx.Int32(SUB * 16) + r_in_chunk
-        kb_in_kt = fx.Int32(B128_IDX * 4) + lane_shr2_and3
-        mask_r = _lds_swizzle_mask(r)
-        b_off = lib * fx.Int32(4)
-        off = (
-            fx.Int32(slot * (BM * KH_TILE))
-            + r * fx.Int32(KH_TILE)
-            + ((kb_in_kt * fx.Int32(16)) ^ mask_r)
-            + b_off
-        )
-        _lds_i32_store(s_aq_i32x1_tiles, off // fx.Int32(4), pk)
-        pack_byte = B128_IDX * 2 + SUB
-        scale_accum[0] = scale_accum[0] | (e8m0 << fx.Int32(pack_byte * 8))
-
-    def _inline_quant_core_pair(specs, slot, kt, scale_accum):
+    def _inline_quant_core_batch(specs, slot, scale_accum):
         n = len(specs)
         h_dw = [
             [fx.Int32(_raw(h_v[j])) for j in range_constexpr(4)]
@@ -529,7 +446,7 @@ def _gemm1_body(
             pk = _raw(fx.Int32(0))
             for j in range_constexpr(4):
                 src_bf16x2 = _raw(
-                    Vec.from_elements([h_dw[i][j]], fx.Int32).bitcast(fx.BFloat16)
+                    fx.Vector.from_elements([h_dw[i][j]], fx.Int32).bitcast(fx.BFloat16)
                 )
                 pk = rocdl.cvt_scalef32_pk_fp4_bf16(T.i32, pk, src_bf16x2, qs_raw, j)
             pk = fx.Int32(pk)
@@ -543,18 +460,19 @@ def _gemm1_body(
                 + ((kb_in_kt * fx.Int32(16)) ^ mask_r)
                 + b_off
             )
-            _lds_i32_store(s_aq_i32x1_tiles, off // fx.Int32(4), pk)
+            _scalar_store(s_aq_i32x1_tiles, off // fx.Int32(4), pk, fx.Int32)
             pack_byte = B128_IDX * 2 + SUB
-            scale_accum[0] = scale_accum[0] | (e8[i] << fx.Int32(pack_byte * 8))
+            scale_accum = scale_accum | (e8[i] << fx.Int32(pack_byte * 8))
+        return scale_accum
 
     def inline_quant_kt(B128_IDX, SUB, slot, kt, row_token, scale_accum):
         h_v = inline_quant_load_kt(B128_IDX, kt, row_token)
-        _inline_quant_core(B128_IDX, SUB, slot, kt, h_v, scale_accum)
+        return _inline_quant_core_batch([(B128_IDX, SUB, h_v)], slot, scale_accum)
 
     def inline_quant_pack_write(kt, scale_accum):
         lane_tgt = lane_shr2_and3 * fx.Int32(16) + r_in_chunk
         off = fx.Int32(kt * 256) + lane_tgt * fx.Int32(4)
-        _lds_i32_store(asc_i32_tiles, off // fx.Int32(4), scale_accum[0])
+        _scalar_store(asc_i32_tiles, off // fx.Int32(4), scale_accum, fx.Int32)
 
     def issue_b_load_j(b_slot, K_C, j):
         v = (
@@ -564,15 +482,14 @@ def _gemm1_body(
         )
         for half in range_constexpr(2):
             tile_idx = (v + fx.Int32(half * 1024)) // fx.Int32(16)
-            r = fx.memref_alloca(bq_reg_ty, bq_reg_lay)
+            r = fx.make_rmem_tensor(bq_reg_lay, fx.Int32)
             fx.copy(
                 bq_copy_atom,
                 fx.slice(bq_tiles, (None, tile_idx)),
                 r,
                 soffset=b_load_s_base[j] // fx.Int32(4),
             )
-            frag = fx.memref_load_vec(r)
-            b_slot[j][half] = Vec(frag)
+            b_slot[j][half] = r.load()
 
     def issue_b_scale_load(bs_slot, K_C):
         v = ((lane_div_16 * fx.Int32(16)) + lane_mod_16) * fx.Int32(4)
@@ -581,17 +498,17 @@ def _gemm1_body(
         for mw in range_constexpr(2):
             s_off = b_scale_s_base[mw] if K_C_HI == 0 else b_scale_s_base_hi[mw]
             idx = (v + fx.Int32(imm)) // fx.Int32(4)
-            r = fx.memref_alloca(bscale_reg_ty, bscale_reg_lay)
+            r = fx.make_rmem_tensor(bscale_reg_lay, fx.Int32)
             fx.copy(
                 bscale_copy_atom,
                 fx.slice(bscale_tiles, (None, idx)),
                 r,
                 soffset=s_off // fx.Int32(4),
             )
-            bs_slot[mw] = fx.Vector(fx.memref_load_vec(r))[0]
+            bs_slot[mw] = r.load()[0]
 
     mfma_ty = T.f32x4
-    zero4 = Vec.filled(4, 0.0, fx.Float32)
+    zero4 = fx.Vector.filled(4, 0.0, fx.Float32)
 
     def mfma_cluster(b_slot, a, a_scale, bs_slot, J, init):
         if const_expr(interleave):
@@ -646,11 +563,15 @@ def _gemm1_body(
         issue_a_scale_load()
     for K_C in range_constexpr(kStages):
         if const_expr(inline_quant):
-            scale_accum = [fx.Int32(0)]
-            inline_quant_kt(0, 0, K_C, K_C, cached_row_inline[0], scale_accum)
+            scale_accum = fx.Int32(0)
+            scale_accum = inline_quant_kt(
+                0, 0, K_C, K_C, cached_row_inline, scale_accum
+            )
             issue_b_load_j(b[K_C], K_C, 0)
             issue_b_load_j(b[K_C], K_C, 1)
-            inline_quant_kt(1, 0, K_C, K_C, cached_row_inline[0], scale_accum)
+            scale_accum = inline_quant_kt(
+                1, 0, K_C, K_C, cached_row_inline, scale_accum
+            )
             issue_b_load_j(b[K_C], K_C, 2)
             issue_b_load_j(b[K_C], K_C, 3)
             inline_quant_pack_write(K_C, scale_accum)
@@ -683,8 +604,8 @@ def _gemm1_body(
         if const_expr(not inline_quant):
             issue_a_load_lds(write_slot, K_C)
         if const_expr(inline_quant):
-            h_v0 = inline_quant_load_kt(0, K_C, cached_row_inline[0])
-            h_v1 = inline_quant_load_kt(1, K_C, cached_row_inline[0])
+            h_v0 = inline_quant_load_kt(0, K_C, cached_row_inline)
+            h_v1 = inline_quant_load_kt(1, K_C, cached_row_inline)
             rocdl.sched_barrier(0)
         for J in range_constexpr(4):
             if const_expr(BM != 128):
@@ -700,9 +621,8 @@ def _gemm1_body(
             rocdl.sched_barrier(0)
         issue_b_scale_load(b_scale_v[slot_b], K_C)
         if const_expr(inline_quant):
-            scale_accum = [fx.Int32(0)]
-            _inline_quant_core_pair(
-                [(0, 0, h_v0), (1, 0, h_v1)], write_slot, K_C, scale_accum
+            scale_accum = _inline_quant_core_batch(
+                [(0, 0, h_v0), (1, 0, h_v1)], write_slot, fx.Int32(0)
             )
             inline_quant_pack_write(K_C, scale_accum)
 
@@ -728,10 +648,7 @@ def _gemm1_body(
     def acc_idx(row, col):
         return _layout_idx(acc_layout, row, col)
 
-    acc_copy_atom = fx.make_copy_atom(fx.UniversalCopy(32), fx.Float32)
-    acc_reg_ty = fx.MemRefType.get(
-        T.f32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
-    )
+    acc_copy_atom = fx.make_copy_atom(fx.UniversalCopy32b(), fx.Float32)
     acc_reg_lay = fx.make_layout(1, 1)
     acc_flat_view = fx.make_view(
         fx.recast_iter(fx.Float32, lds_raw_ptr), fx.make_layout(BM * BN, 1)
@@ -739,14 +656,14 @@ def _gemm1_body(
     acc_flat_tiles = fx.logical_divide(acc_flat_view, fx.make_layout(1, 1))
 
     def acc_store(idx, value):
-        r = fx.memref_alloca(acc_reg_ty, acc_reg_lay)
-        fx.memref_store_vec(Vec.from_elements([fx.Float32(value)], fx.Float32), r)
+        r = fx.make_rmem_tensor(acc_reg_lay, fx.Float32)
+        r.store(fx.Vector.from_elements([fx.Float32(value)], fx.Float32))
         fx.copy_atom_call(acc_copy_atom, r, fx.slice(acc_flat_tiles, (None, idx)))
 
     def acc_load(idx):
-        r = fx.memref_alloca(acc_reg_ty, acc_reg_lay)
+        r = fx.make_rmem_tensor(acc_reg_lay, fx.Float32)
         fx.copy_atom_call(acc_copy_atom, fx.slice(acc_flat_tiles, (None, idx)), r)
-        return fx.Float32(Vec(fx.memref_load_vec(r))[0])
+        return r.load()[0]
 
     for i in range_constexpr(kMChunks):
         row_base = fx.Int32(i * 16) + lane_div_16 * fx.Int32(4)
@@ -755,7 +672,7 @@ def _gemm1_body(
             J_local = J // 2
             col_local = wave * fx.Int32(32) + fx.Int32(J_local * 16) + lane_mod_16
             lds_col = (fx.Int32(128) + col_local) if is_up else col_local
-            vec = Vec(accm[i][J])
+            vec = fx.Vector(accm[i][J])
             for v in range_constexpr(4):
                 idx = acc_idx(row_base + fx.Int32(v), lds_col)
                 acc_store(idx, vec[v])
@@ -770,7 +687,7 @@ def _gemm1_body(
 
     aqout_layout = fx.make_layout((BM, K_G2_HALF), (K_G2_HALF, 1))
     # UniversalCopy has no nontemporal/cache-hint knob; dropped (perf-neutral).
-    aqout_tiles = _global_i32_tiles(arg_aqout)
+    aqout_tiles = _global_scalar_tiles(arg_aqout, fx.Int32, 1 << 24)
     scales_per_mr = [None] * M_REPS
 
     for mr in range_constexpr(M_REPS):
@@ -899,8 +816,8 @@ def compile_gemm1_a4w4_port(
     _BQ_BYTES = bq_bytes_for(_NE, _N_OUT, _K)
     _BSCALE_BYTES = bscale_bytes_for(_NE, _N_OUT, _K)
     _NUM_N_BLOCKS = num_n_blocks_for(_N_OUT, BN)
-    _OUT_AS_PER_CHUNK_DW = out_as_per_chunk_dw_for(_INTER)
-    _K_G2_HALF = k_g2_half_for(_INTER)
+    _OUT_AS_PER_CHUNK_DW = kas_per_chunk_dw_for(_INTER)
+    _K_G2_HALF = k_half_for(_INTER)
 
     kAStages, kSubBlocks, kMChunks, lds_bytes = _bm_constants(
         BM, BN, KH_TILE, _K_TILES_TOTAL


### PR DESCRIPTION
## Summary
- Replace all raw `llvm.load`/`llvm.StoreOp`, `buffer_ops.*`, and `rocdl.raw_ptr_buffer_load_lds` calls in `aiter/ops/flydsl/kernels/mxfp4_gemm1.py` with `fx.copy`/`fx.copy_atom_call`/`fx.ptr_load`/`fx.ptr_store`, aligning the kernel with FlyDSL's tile-programming model.
- Remove a dead `wave_n = wave` alias and simplify scalar loads through the typed FlyDSL pointer API.
- Use typed numeric/copy helpers and derive compile-time constants inside `_gemm1_body`, removing redundant type and specialization plumbing without changing final ISA.

## Performance
GPU-only GEMM1 timings for the tuned Kimi-K2 shape `H=7168, inter=512, E=385, topk=9` from `kimik2_fp4_tuned_fmoe.csv`:

- Hardware: gfx950
- Software: ROCm 7.2.3, PyTorch 2.10
- Comparison: main `84493f0e5` vs PR `362b7822c`
- Method: `rocprofv3 --stats --kernel-trace`; five interleaved runs per version, reporting the median of per-run medians (35 dispatches per run)
- Negative PR delta means the PR is faster

| Tokens | BM | Main (us) | PR (us) | PR delta | Speedup |
|---:|---:|---:|---:|---:|---:|
| 1 | 16 | 18.720 | 18.840 | +0.64% | 0.994x |
| 2 | 16 | 21.680 | 22.161 | +2.22% | 0.978x |
| 4 | 16 | 26.161 | 25.641 | -1.99% | 1.020x |
| 8 | 16 | 55.121 | 55.361 | +0.44% | 0.996x |
| 16 | 16 | 74.921 | 74.681 | -0.32% | 1.003x |
| 32 | 16 | 130.682 | 130.681 | -0.00% | 1.000x |
| 64 | 16 | 182.602 | 181.362 | -0.68% | 1.007x |
| 128 | 16 | 217.522 | 217.322 | -0.09% | 1.001x |
| 256 | 32 | 227.363 | 225.643 | -0.76% | 1.008x |
| 512 | 32 | 239.443 | 235.402 | -1.69% | 1.017x |
| 1024 | 32 | 271.442 | 270.363 | -0.40% | 1.004x |
| 2048 | 32 | 454.805 | 454.885 | +0.02% | 1.000x |
| 4096 | 128 | 327.923 | 323.884 | -1.23% | 1.012x |
| 8192 | 128 | 591.286 | 594.326 | +0.51% | 0.995x |
| 16384 | 128 | 702.887 | 697.687 | -0.74% | 1.007x |
| 32768 | 128 | 1186.453 | 1168.172 | -1.54% | 1.016x |

Geometric-mean speedup is **1.004x (+0.36%)**. Per-case movement stays within -1.99% to +2.22%, so the migration is perf-neutral across the tuned token range. VGPR, SGPR, LDS, scratch, and spill usage are unchanged for each BM variant.

## Test plan
- [x] Bit-exact correctness verified via `Mxfp4FlydslTuner` (BM=128 deterministic path) on gfx950 hardware after each conversion step.
- [x] Tuned Kimi-K2 token sweep profiled with `rocprofv3` against the exact main base and PR head.
- [x] Representative BM16/BM32/BM128 final ISA compared against the pre-refactor kernel; instruction ordering and resources are unchanged.
- [x] `ruff check` / `black --check` pass on the changed file.
- [x] Confirmed `numeric_cls.ir_type == ir_ty` equivalence in-context for all types used (Int32/Int8/Int16) before removing the parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
