### PR TITLE
Swap the cache config for the default cases of gfx1250-GEMM-A8W8_BLOCKSCALE.json

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A8W8_BLOCKSCALE.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A8W8_BLOCKSCALE.json
@@ -8,7 +8,7 @@
       "num_stages": 2,
       "waves_per_eu": 1,
       "matrix_instr_nonkdim": 16,
-      "cache_modifier": ".cg",
+      "cache_modifier": ".ca",
       "NUM_KSPLIT": 1
     },
     "M_LEQ_32": {
@@ -20,7 +20,7 @@
       "num_stages": 2,
       "waves_per_eu": 1,
       "matrix_instr_nonkdim": 16,
-      "cache_modifier": ".cg",
+      "cache_modifier": ".ca",
       "NUM_KSPLIT": 1
     },
     "M_LEQ_64": {


### PR DESCRIPTION
## Motivation

Speed up vLLM DeepseekV4-Flash  

## Technical Details

ca shows much higher decode throughput 

## Test Plan

tested on lm_eval with around an 8x improvement e2e and micro benchmark  

```
│  #!/usr/bin/env python3
│  """Micro-benchmark: cache_modifier ".cg" vs ".ca" in aiter's gfx1250 block-scale
│  FP8 GEMM, at decode-sized M. Self-contained (torch + aiter only)."""
│  import time, copy, torch
│  from aiter.ops.triton.gemm.basic.gemm_a8w8_blockscale import gemm_a8w8_blockscale
│
│  N, K, M = 8192, 4096, 8                       # a DeepSeek-V4-Flash wo_a shape, decode M
│  dev = torch.device("cuda")
│
│  A  = torch.randn(M, K, device=dev).to(torch.float8_e4m3fn)
│  B  = torch.randn(N, K, device=dev).to(torch.float8_e4m3fn)
│  As = torch.ones(M, K // 128, device=dev)      # fp32 block scales
│  Bs = torch.ones(N // 128, K // 128, device=dev)
│
│  cfg = dict(BLOCK_SIZE_M=16, BLOCK_SIZE_N=32, BLOCK_SIZE_K=128, GROUP_SIZE_M=1,
│             num_warps=2, num_stages=2, waves_per_eu=1, matrix_instr_nonkdim=16, NUM_KSPLIT=1)
│
│  def bench(cache_modifier, iters=100):
│      c = dict(cfg, cache_modifier=cache_modifier)
│      run = lambda: gemm_a8w8_blockscale(A, B, As, Bs, dtype=torch.bfloat16,
│                                         config=copy.deepcopy(c), backend="gluon")
│      run(); torch.cuda.synchronize()           # warm up / JIT compile
│      t = time.perf_counter()
│      for _ in range(iters): run()
│      torch.cuda.synchronize()
│      return (time.perf_counter() - t) / iters * 1e3   # ms
│
│  cg = bench(".cg")
│  ca = bench(".ca")
│  print(f"shape (M={M}, N={N}, K={K})")
│  print(f".cg : {cg:.3f} ms")
│  print(f".ca : {ca:.3f} ms")
│  print(f"speedup: {cg/ca:.1f}x")
```

## Test Result
```
.cg : 2.321 ms
.ca : 0.048 ms
speedup: 48.5x
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
