### PR TITLE
perf(expt_data): skip redundant TokenStart/TileStart stores in stage1

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
@@ -161,10 +161,10 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
     # Fill the pipeline
     for _ in gl.static_range(NUM_BUFFERS - 1):
         gl.amd.gfx1250.tdm.async_load(
-            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS), cache_modifier=".cv"
+            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
         )
         gl.amd.gfx1250.tdm.async_load(
-            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
+            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
         )
 
         if LAYOUT[0] == "T":
@@ -190,10 +190,10 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
     # Main pipeline loop
     for _ in range(num_k_tiles - (NUM_BUFFERS - 1) - 1):
         gl.amd.gfx1250.tdm.async_load(
-            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS), cache_modifier=".cv"
+            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
         )
         gl.amd.gfx1250.tdm.async_load(
-            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
+            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
         )
 
         gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
@@ -161,10 +161,10 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
     # Fill the pipeline
     for _ in gl.static_range(NUM_BUFFERS - 1):
         gl.amd.gfx1250.tdm.async_load(
-            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
+            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS), cache_modifier=".cv"
         )
         gl.amd.gfx1250.tdm.async_load(
-            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
+            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
         )
 
         if LAYOUT[0] == "T":
@@ -190,10 +190,10 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
     # Main pipeline loop
     for _ in range(num_k_tiles - (NUM_BUFFERS - 1) - 1):
         gl.amd.gfx1250.tdm.async_load(
-            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
+            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS), cache_modifier=".cv"
         )
         gl.amd.gfx1250.tdm.async_load(
-            b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
+            a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
         )
 
         gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)

--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing/expt_data.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing/expt_data.py
@@ -33,17 +33,25 @@ def _expt_data_compute_stage1(
         token_acc = tl.zeros([BLOCK], dtype=TokenStart.dtype.element_ty)
         tile_acc = tl.zeros([BLOCK], dtype=TileStart.dtype.element_ty)
         offs_n = tl.arange(0, BLOCK)
+        # pid==0 must run the full loop: it reads TileStart[n_expts_tot-1]
+        # below for the sentinel, so it must have written it first.
+        # All other blocks can stop once they've written their own chunk.
+        done = False
         for i in range(0, n_expts_tot, BLOCK):
-            mask_n = offs_n < n_expts_tot
-            hist_token = tl.load(Hist + offs_n, mask=mask_n, other=0)
-            hist_tile = _cdiv_pow2(hist_token, tile_dim_log2)
-            token_starts = tl.cumsum(hist_token, 0) - hist_token + token_acc
-            tile_starts = tl.cumsum(hist_tile, 0) - hist_tile + tile_acc
-            token_acc += tl.sum(hist_token, 0)
-            tile_acc += tl.sum(hist_tile, 0)
-            tl.store(TokenStart + offs_n, token_starts)
-            tl.store(TileStart + offs_n, tile_starts)
-            offs_n += BLOCK
+            if not done:
+                mask_n = offs_n < n_expts_tot
+                hist_token = tl.load(Hist + offs_n, mask=mask_n, other=0)
+                hist_tile = _cdiv_pow2(hist_token, tile_dim_log2)
+                token_starts = tl.cumsum(hist_token, 0) - hist_token + token_acc
+                tile_starts = tl.cumsum(hist_tile, 0) - hist_tile + tile_acc
+                token_acc += tl.sum(hist_token, 0)
+                tile_acc += tl.sum(hist_tile, 0)
+                if pid == 0 or pid < i + BLOCK:
+                    tl.store(TokenStart + offs_n, token_starts, mask=mask_n)
+                    tl.store(TileStart + offs_n, tile_starts, mask=mask_n)
+                if pid != 0 and pid < i + BLOCK:
+                    done = True
+                offs_n += BLOCK
 
     if pid == 0:
         tl.store(TokenStart + n_expts_tot, n_gates)

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -352,6 +352,8 @@ def get_kernel_config_gluon(m, n, k, routing_data):
                 block_k = 512 if k % 512 == 0 else 256
             else:
                 block_k = 512
+            while block_k > 32 and k % block_k != 0:
+                block_k //= 2
 
             if n_gates <= 32:
                 block_n = 64

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -243,36 +243,142 @@ def get_kernel_config_triton(m, n, k, routing_data, swizzle_mx_scale=None):
     }
 
 
+_GLUON_TUNED_CONFIGS = {
+    #                                      block_n  block_k  num_buffers
+    # --- K=384 (down-proj, inter_dim=384) ---
+    (16, 7168, 384, "tiny"):               (64,     128,     3),
+    (16, 7168, 384, "small"):              (64,     128,     3),
+    (16, 7168, 384, "medium"):             (64,     128,     3),
+    (16, 7168, 384, "medium2"):            (128,    128,     3),
+    (16, 7168, 384, "large"):              (256,    128,     1),
+    (16, 7168, 384, "xlarge"):             (256,    128,     2),
+    # --- K=512 (down-proj, inter_dim=512) ---
+    (16, 7168, 512, "tiny"):               (64,     256,     3),
+    (16, 7168, 512, "small"):              (512,    512,     2),
+    (16, 7168, 512, "medium"):             (512,    256,     2),
+    (16, 7168, 512, "medium2"):            (512,    512,     1),
+    (16, 7168, 512, "large"):              (512,    256,     1),
+    (16, 7168, 512, "xlarge"):             (512,    512,     1),
+    # --- K=768 (down-proj, inter_dim=768) ---
+    (16, 7168, 768, "tiny"):               (64,     256,     3),
+    (16, 7168, 768, "small"):              (64,     256,     3),
+    (16, 7168, 768, "medium"):             (512,    256,     2),
+    (16, 7168, 768, "medium2"):            (512,    256,     2),
+    (16, 7168, 768, "large"):              (512,    256,     1),
+    (16, 7168, 768, "xlarge"):             (512,    256,     2),
+    # --- K=1536 (down-proj, inter_dim=1536) ---
+    (16, 7168, 1536, "tiny"):              (256,    512,     2),
+    (16, 7168, 1536, "small"):             (512,    512,     2),
+    (16, 7168, 1536, "medium"):            (128,    512,     2),
+    (16, 7168, 1536, "medium2"):           (512,    512,     1),
+    (16, 7168, 1536, "large"):             (256,    256,     2),
+    (16, 7168, 1536, "xlarge"):            (512,    256,     2),
+    # --- K=2048 (down-proj, inter_dim=2048) ---
+    (16, 4096, 2048, "tiny"):              (64,     512,     3),
+    (16, 4096, 2048, "small"):             (64,     512,     3),
+    (16, 4096, 2048, "medium"):            (128,    512,     2),
+    (16, 4096, 2048, "medium2"):           (512,    512,     2),
+    (16, 4096, 2048, "large"):             (512,    512,     1),
+    (16, 4096, 2048, "xlarge"):            (512,    256,     3),
+    # --- K=4096 (gate_up, model_dim=4096) ---
+    (16, 4096, 4096, "tiny"):              (64,     512,     3),
+    (16, 4096, 4096, "small"):             (64,     512,     3),
+    (16, 4096, 4096, "medium"):            (128,    512,     2),
+    (16, 4096, 4096, "medium2"):           (128,    512,     2),
+    (16, 4096, 4096, "large"):             (512,    512,     1),
+    (16, 4096, 4096, "xlarge"):            (512,    256,     3),
+    # --- K=7168, N=768 (gate_up, inter_dim=384) ---
+    (16, 768, 7168, "tiny"):               (64,     512,     3),
+    (16, 768, 7168, "small"):              (64,     512,     3),
+    (16, 768, 7168, "medium"):             (64,     512,     3),
+    (16, 768, 7168, "medium2"):            (64,     512,     3),
+    (16, 768, 7168, "large"):              (64,     512,     3),
+    (16, 768, 7168, "xlarge"):             (256,    512,     2),
+    # --- K=7168, N=1024 (gate_up, inter_dim=512) ---
+    (16, 1024, 7168, "tiny"):              (64,     512,     3),
+    (16, 1024, 7168, "small"):             (64,     512,     3),
+    (16, 1024, 7168, "medium"):            (64,     512,     3),
+    (16, 1024, 7168, "medium2"):           (64,     512,     3),
+    (16, 1024, 7168, "large"):             (128,    512,     2),
+    (16, 1024, 7168, "xlarge"):            (512,    512,     1),
+    # --- K=7168, N=1536 (gate_up, inter_dim=768) ---
+    (16, 1536, 7168, "tiny"):              (64,     512,     3),
+    (16, 1536, 7168, "small"):             (64,     512,     3),
+    (16, 1536, 7168, "medium"):            (64,     512,     3),
+    (16, 1536, 7168, "medium2"):           (64,     512,     3),
+    (16, 1536, 7168, "large"):             (256,    512,     3),
+    (16, 1536, 7168, "xlarge"):            (256,    256,     2),
+    # --- K=7168, N=3072 (gate_up, inter_dim=1536) ---
+    (16, 3072, 7168, "tiny"):              (64,     512,     3),
+    (16, 3072, 7168, "small"):             (64,     512,     3),
+    (16, 3072, 7168, "medium"):            (512,    512,     2),
+    (16, 3072, 7168, "medium2"):           (512,    512,     2),
+    (16, 3072, 7168, "large"):             (256,    256,     2),
+    (16, 3072, 7168, "xlarge"):            (512,    256,     3),
+}
+
+
+def _ng_bucket(n_gates):
+    if n_gates <= 8:
+        return "tiny"
+    if n_gates <= 32:
+        return "small"
+    if n_gates <= 128:
+        return "medium"
+    if n_gates <= 256:
+        return "medium2"
+    if n_gates <= 512:
+        return "large"
+    return "xlarge"
+
+
 def get_kernel_config_gluon(m, n, k, routing_data):
     block_m = routing_data.block_m
     num_xcds = 1
     w_cache_modifier = ".cg" if block_m <= 32 else None
-    num_buffers = 3
+    num_warps = 4
     split_k = 1
-    block_k = 512
+    n_gates = m
 
     if block_m == 16:
-        block_k = 512
-        num_warps = 4
-        if n <= 3072:
-            block_n = 128
-            num_buffers = 2
+        bucket = _ng_bucket(n_gates)
+        key = (block_m, n, k, bucket)
+        if key in _GLUON_TUNED_CONFIGS:
+            block_n, block_k, num_buffers = _GLUON_TUNED_CONFIGS[key]
         else:
-            block_n = 256
-            num_buffers = 1
+            if k <= 512:
+                block_k = 256
+            elif k <= 1024:
+                block_k = 512 if k % 512 == 0 else 256
+            else:
+                block_k = 512
+
+            if n_gates <= 32:
+                block_n = 64
+                num_buffers = 3
+            elif n_gates <= 256:
+                block_n = 64 if n <= 1536 else 512
+                num_buffers = 3 if n <= 1536 else 2
+            elif n_gates <= 512:
+                block_n = 256
+                num_buffers = 2
+            else:
+                block_n = 256 if n <= 1536 else 512
+                num_buffers = 2
+                block_k = min(block_k, 256)
 
     elif block_m == 32:
         if n <= 1024:
             block_n = 128
-            num_warps = 4
         else:
             block_n = 256
-            num_warps = 4
+        block_k = 512
+        num_buffers = 3
 
     else:
         block_n = 256
         block_k = 256
-        num_warps = 4
+        num_buffers = 3
 
     ret = {
         "block_m": block_m,

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -3,26 +3,22 @@
 
 import functools
 import itertools
-import json
 import os
+import json
 import warnings
-
 import torch
 import triton
-
-from aiter.ops.triton._gluon_kernels.gfx1250.moe.moe_op_gemm_a8w4 import (
-    _moe_gemm_a8w4_decode as _moe_gemm_a8w4_decode_gluon,
-)
-from aiter.ops.triton._gluon_kernels.gfx1250.moe.moe_op_gemm_a8w4 import (
-    _moe_gemm_a8w4_prefill as _moe_gemm_a8w4_prefill_gluon,
-)
+from aiter.ops.triton.moe.moe_routing.routing import RoutingData
 from aiter.ops.triton._triton_kernels.moe.moe_op_gemm_a8w4 import (
     _moe_gemm_a8w4 as _moe_gemm_a8w4_triton,
 )
-from aiter.ops.triton.moe.moe_routing.routing import RoutingData
+from aiter.ops.triton._gluon_kernels.gfx1250.moe.moe_op_gemm_a8w4 import (
+    _moe_gemm_a8w4_decode as _moe_gemm_a8w4_decode_gluon,
+    _moe_gemm_a8w4_prefill as _moe_gemm_a8w4_prefill_gluon,
+)
 from aiter.ops.triton.moe.reduce import reduce_grouped
-from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH
+from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.device_info import get_num_sms
 from aiter.ops.triton.utils.gemm_config_utils import pick_gemm_num_stages
 
@@ -250,75 +246,75 @@ def get_kernel_config_triton(m, n, k, routing_data, swizzle_mx_scale=None):
 _GLUON_TUNED_CONFIGS = {
     #                                      block_n  block_k  num_buffers
     # --- K=384 (down-proj, inter_dim=384) ---
-    (16, 7168, 384, "tiny"): (64, 128, 3),
-    (16, 7168, 384, "small"): (64, 128, 3),
-    (16, 7168, 384, "medium"): (64, 128, 3),
-    (16, 7168, 384, "medium2"): (128, 128, 3),
-    (16, 7168, 384, "large"): (256, 128, 1),
-    (16, 7168, 384, "xlarge"): (256, 128, 2),
+    (16, 7168, 384, "tiny"):               (64,     128,     3),
+    (16, 7168, 384, "small"):              (64,     128,     3),
+    (16, 7168, 384, "medium"):             (64,     128,     3),
+    (16, 7168, 384, "medium2"):            (128,    128,     3),
+    (16, 7168, 384, "large"):              (256,    128,     1),
+    (16, 7168, 384, "xlarge"):             (256,    128,     2),
     # --- K=512 (down-proj, inter_dim=512) ---
-    (16, 7168, 512, "tiny"): (64, 256, 3),
-    (16, 7168, 512, "small"): (512, 512, 2),
-    (16, 7168, 512, "medium"): (512, 256, 2),
-    (16, 7168, 512, "medium2"): (512, 512, 1),
-    (16, 7168, 512, "large"): (512, 256, 1),
-    (16, 7168, 512, "xlarge"): (512, 512, 1),
+    (16, 7168, 512, "tiny"):               (64,     256,     3),
+    (16, 7168, 512, "small"):              (512,    512,     2),
+    (16, 7168, 512, "medium"):             (512,    256,     2),
+    (16, 7168, 512, "medium2"):            (512,    512,     1),
+    (16, 7168, 512, "large"):              (512,    256,     1),
+    (16, 7168, 512, "xlarge"):             (512,    512,     1),
     # --- K=768 (down-proj, inter_dim=768) ---
-    (16, 7168, 768, "tiny"): (64, 256, 3),
-    (16, 7168, 768, "small"): (64, 256, 3),
-    (16, 7168, 768, "medium"): (512, 256, 2),
-    (16, 7168, 768, "medium2"): (512, 256, 2),
-    (16, 7168, 768, "large"): (512, 256, 1),
-    (16, 7168, 768, "xlarge"): (512, 256, 2),
+    (16, 7168, 768, "tiny"):               (64,     256,     3),
+    (16, 7168, 768, "small"):              (64,     256,     3),
+    (16, 7168, 768, "medium"):             (512,    256,     2),
+    (16, 7168, 768, "medium2"):            (512,    256,     2),
+    (16, 7168, 768, "large"):              (512,    256,     1),
+    (16, 7168, 768, "xlarge"):             (512,    256,     2),
     # --- K=1536 (down-proj, inter_dim=1536) ---
-    (16, 7168, 1536, "tiny"): (256, 512, 2),
-    (16, 7168, 1536, "small"): (512, 512, 2),
-    (16, 7168, 1536, "medium"): (128, 512, 2),
-    (16, 7168, 1536, "medium2"): (512, 512, 1),
-    (16, 7168, 1536, "large"): (256, 256, 2),
-    (16, 7168, 1536, "xlarge"): (512, 256, 2),
+    (16, 7168, 1536, "tiny"):              (256,    512,     2),
+    (16, 7168, 1536, "small"):             (512,    512,     2),
+    (16, 7168, 1536, "medium"):            (128,    512,     2),
+    (16, 7168, 1536, "medium2"):           (512,    512,     1),
+    (16, 7168, 1536, "large"):             (256,    256,     2),
+    (16, 7168, 1536, "xlarge"):            (512,    256,     2),
     # --- K=2048 (down-proj, inter_dim=2048) ---
-    (16, 4096, 2048, "tiny"): (64, 512, 3),
-    (16, 4096, 2048, "small"): (64, 512, 3),
-    (16, 4096, 2048, "medium"): (128, 512, 2),
-    (16, 4096, 2048, "medium2"): (512, 512, 2),
-    (16, 4096, 2048, "large"): (512, 512, 1),
-    (16, 4096, 2048, "xlarge"): (512, 256, 3),
+    (16, 4096, 2048, "tiny"):              (64,     512,     3),
+    (16, 4096, 2048, "small"):             (64,     512,     3),
+    (16, 4096, 2048, "medium"):            (128,    512,     2),
+    (16, 4096, 2048, "medium2"):           (512,    512,     2),
+    (16, 4096, 2048, "large"):             (512,    512,     1),
+    (16, 4096, 2048, "xlarge"):            (512,    256,     3),
     # --- K=4096 (gate_up, model_dim=4096) ---
-    (16, 4096, 4096, "tiny"): (64, 512, 3),
-    (16, 4096, 4096, "small"): (64, 512, 3),
-    (16, 4096, 4096, "medium"): (128, 512, 2),
-    (16, 4096, 4096, "medium2"): (128, 512, 2),
-    (16, 4096, 4096, "large"): (512, 512, 1),
-    (16, 4096, 4096, "xlarge"): (512, 256, 3),
+    (16, 4096, 4096, "tiny"):              (64,     512,     3),
+    (16, 4096, 4096, "small"):             (64,     512,     3),
+    (16, 4096, 4096, "medium"):            (128,    512,     2),
+    (16, 4096, 4096, "medium2"):           (128,    512,     2),
+    (16, 4096, 4096, "large"):             (512,    512,     1),
+    (16, 4096, 4096, "xlarge"):            (512,    256,     3),
     # --- K=7168, N=768 (gate_up, inter_dim=384) ---
-    (16, 768, 7168, "tiny"): (64, 512, 3),
-    (16, 768, 7168, "small"): (64, 512, 3),
-    (16, 768, 7168, "medium"): (64, 512, 3),
-    (16, 768, 7168, "medium2"): (64, 512, 3),
-    (16, 768, 7168, "large"): (64, 512, 3),
-    (16, 768, 7168, "xlarge"): (256, 512, 2),
+    (16, 768, 7168, "tiny"):               (64,     512,     3),
+    (16, 768, 7168, "small"):              (64,     512,     3),
+    (16, 768, 7168, "medium"):             (64,     512,     3),
+    (16, 768, 7168, "medium2"):            (64,     512,     3),
+    (16, 768, 7168, "large"):              (64,     512,     3),
+    (16, 768, 7168, "xlarge"):             (256,    512,     2),
     # --- K=7168, N=1024 (gate_up, inter_dim=512) ---
-    (16, 1024, 7168, "tiny"): (64, 512, 3),
-    (16, 1024, 7168, "small"): (64, 512, 3),
-    (16, 1024, 7168, "medium"): (64, 512, 3),
-    (16, 1024, 7168, "medium2"): (64, 512, 3),
-    (16, 1024, 7168, "large"): (128, 512, 2),
-    (16, 1024, 7168, "xlarge"): (512, 512, 1),
+    (16, 1024, 7168, "tiny"):              (64,     512,     3),
+    (16, 1024, 7168, "small"):             (64,     512,     3),
+    (16, 1024, 7168, "medium"):            (64,     512,     3),
+    (16, 1024, 7168, "medium2"):           (64,     512,     3),
+    (16, 1024, 7168, "large"):             (128,    512,     2),
+    (16, 1024, 7168, "xlarge"):            (512,    512,     1),
     # --- K=7168, N=1536 (gate_up, inter_dim=768) ---
-    (16, 1536, 7168, "tiny"): (64, 512, 3),
-    (16, 1536, 7168, "small"): (64, 512, 3),
-    (16, 1536, 7168, "medium"): (64, 512, 3),
-    (16, 1536, 7168, "medium2"): (64, 512, 3),
-    (16, 1536, 7168, "large"): (256, 512, 3),
-    (16, 1536, 7168, "xlarge"): (256, 256, 2),
+    (16, 1536, 7168, "tiny"):              (64,     512,     3),
+    (16, 1536, 7168, "small"):             (64,     512,     3),
+    (16, 1536, 7168, "medium"):            (64,     512,     3),
+    (16, 1536, 7168, "medium2"):           (64,     512,     3),
+    (16, 1536, 7168, "large"):             (256,    512,     3),
+    (16, 1536, 7168, "xlarge"):            (256,    256,     2),
     # --- K=7168, N=3072 (gate_up, inter_dim=1536) ---
-    (16, 3072, 7168, "tiny"): (64, 512, 3),
-    (16, 3072, 7168, "small"): (64, 512, 3),
-    (16, 3072, 7168, "medium"): (512, 512, 2),
-    (16, 3072, 7168, "medium2"): (512, 512, 2),
-    (16, 3072, 7168, "large"): (256, 256, 2),
-    (16, 3072, 7168, "xlarge"): (512, 256, 3),
+    (16, 3072, 7168, "tiny"):              (64,     512,     3),
+    (16, 3072, 7168, "small"):             (64,     512,     3),
+    (16, 3072, 7168, "medium"):            (512,    512,     2),
+    (16, 3072, 7168, "medium2"):           (512,    512,     2),
+    (16, 3072, 7168, "large"):             (256,    256,     2),
+    (16, 3072, 7168, "xlarge"):            (512,    256,     3),
 }
 
 
@@ -521,6 +517,8 @@ def moe_gemm_a8w4(
             "scatter+combine would need fp8-aware reduce_grouped"
         )
         out_dtype = torch.float8_e4m3fn
+    else:
+        out_dtype = out_dtype
     y, y_final = allocate_output(
         M,
         padded_N,

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -3,22 +3,26 @@
 
 import functools
 import itertools
-import os
 import json
+import os
 import warnings
+
 import torch
 import triton
-from aiter.ops.triton.moe.moe_routing.routing import RoutingData
+
+from aiter.ops.triton._gluon_kernels.gfx1250.moe.moe_op_gemm_a8w4 import (
+    _moe_gemm_a8w4_decode as _moe_gemm_a8w4_decode_gluon,
+)
+from aiter.ops.triton._gluon_kernels.gfx1250.moe.moe_op_gemm_a8w4 import (
+    _moe_gemm_a8w4_prefill as _moe_gemm_a8w4_prefill_gluon,
+)
 from aiter.ops.triton._triton_kernels.moe.moe_op_gemm_a8w4 import (
     _moe_gemm_a8w4 as _moe_gemm_a8w4_triton,
 )
-from aiter.ops.triton._gluon_kernels.gfx1250.moe.moe_op_gemm_a8w4 import (
-    _moe_gemm_a8w4_decode as _moe_gemm_a8w4_decode_gluon,
-    _moe_gemm_a8w4_prefill as _moe_gemm_a8w4_prefill_gluon,
-)
+from aiter.ops.triton.moe.moe_routing.routing import RoutingData
 from aiter.ops.triton.moe.reduce import reduce_grouped
-from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH
 from aiter.ops.triton.utils._triton.arch_info import get_arch
+from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH
 from aiter.ops.triton.utils.device_info import get_num_sms
 from aiter.ops.triton.utils.gemm_config_utils import pick_gemm_num_stages
 
@@ -246,75 +250,75 @@ def get_kernel_config_triton(m, n, k, routing_data, swizzle_mx_scale=None):
 _GLUON_TUNED_CONFIGS = {
     #                                      block_n  block_k  num_buffers
     # --- K=384 (down-proj, inter_dim=384) ---
-    (16, 7168, 384, "tiny"):               (64,     128,     3),
-    (16, 7168, 384, "small"):              (64,     128,     3),
-    (16, 7168, 384, "medium"):             (64,     128,     3),
-    (16, 7168, 384, "medium2"):            (128,    128,     3),
-    (16, 7168, 384, "large"):              (256,    128,     1),
-    (16, 7168, 384, "xlarge"):             (256,    128,     2),
+    (16, 7168, 384, "tiny"): (64, 128, 3),
+    (16, 7168, 384, "small"): (64, 128, 3),
+    (16, 7168, 384, "medium"): (64, 128, 3),
+    (16, 7168, 384, "medium2"): (128, 128, 3),
+    (16, 7168, 384, "large"): (256, 128, 1),
+    (16, 7168, 384, "xlarge"): (256, 128, 2),
     # --- K=512 (down-proj, inter_dim=512) ---
-    (16, 7168, 512, "tiny"):               (64,     256,     3),
-    (16, 7168, 512, "small"):              (512,    512,     2),
-    (16, 7168, 512, "medium"):             (512,    256,     2),
-    (16, 7168, 512, "medium2"):            (512,    512,     1),
-    (16, 7168, 512, "large"):              (512,    256,     1),
-    (16, 7168, 512, "xlarge"):             (512,    512,     1),
+    (16, 7168, 512, "tiny"): (64, 256, 3),
+    (16, 7168, 512, "small"): (512, 512, 2),
+    (16, 7168, 512, "medium"): (512, 256, 2),
+    (16, 7168, 512, "medium2"): (512, 512, 1),
+    (16, 7168, 512, "large"): (512, 256, 1),
+    (16, 7168, 512, "xlarge"): (512, 512, 1),
     # --- K=768 (down-proj, inter_dim=768) ---
-    (16, 7168, 768, "tiny"):               (64,     256,     3),
-    (16, 7168, 768, "small"):              (64,     256,     3),
-    (16, 7168, 768, "medium"):             (512,    256,     2),
-    (16, 7168, 768, "medium2"):            (512,    256,     2),
-    (16, 7168, 768, "large"):              (512,    256,     1),
-    (16, 7168, 768, "xlarge"):             (512,    256,     2),
+    (16, 7168, 768, "tiny"): (64, 256, 3),
+    (16, 7168, 768, "small"): (64, 256, 3),
+    (16, 7168, 768, "medium"): (512, 256, 2),
+    (16, 7168, 768, "medium2"): (512, 256, 2),
+    (16, 7168, 768, "large"): (512, 256, 1),
+    (16, 7168, 768, "xlarge"): (512, 256, 2),
     # --- K=1536 (down-proj, inter_dim=1536) ---
-    (16, 7168, 1536, "tiny"):              (256,    512,     2),
-    (16, 7168, 1536, "small"):             (512,    512,     2),
-    (16, 7168, 1536, "medium"):            (128,    512,     2),
-    (16, 7168, 1536, "medium2"):           (512,    512,     1),
-    (16, 7168, 1536, "large"):             (256,    256,     2),
-    (16, 7168, 1536, "xlarge"):            (512,    256,     2),
+    (16, 7168, 1536, "tiny"): (256, 512, 2),
+    (16, 7168, 1536, "small"): (512, 512, 2),
+    (16, 7168, 1536, "medium"): (128, 512, 2),
+    (16, 7168, 1536, "medium2"): (512, 512, 1),
+    (16, 7168, 1536, "large"): (256, 256, 2),
+    (16, 7168, 1536, "xlarge"): (512, 256, 2),
     # --- K=2048 (down-proj, inter_dim=2048) ---
-    (16, 4096, 2048, "tiny"):              (64,     512,     3),
-    (16, 4096, 2048, "small"):             (64,     512,     3),
-    (16, 4096, 2048, "medium"):            (128,    512,     2),
-    (16, 4096, 2048, "medium2"):           (512,    512,     2),
-    (16, 4096, 2048, "large"):             (512,    512,     1),
-    (16, 4096, 2048, "xlarge"):            (512,    256,     3),
+    (16, 4096, 2048, "tiny"): (64, 512, 3),
+    (16, 4096, 2048, "small"): (64, 512, 3),
+    (16, 4096, 2048, "medium"): (128, 512, 2),
+    (16, 4096, 2048, "medium2"): (512, 512, 2),
+    (16, 4096, 2048, "large"): (512, 512, 1),
+    (16, 4096, 2048, "xlarge"): (512, 256, 3),
     # --- K=4096 (gate_up, model_dim=4096) ---
-    (16, 4096, 4096, "tiny"):              (64,     512,     3),
-    (16, 4096, 4096, "small"):             (64,     512,     3),
-    (16, 4096, 4096, "medium"):            (128,    512,     2),
-    (16, 4096, 4096, "medium2"):           (128,    512,     2),
-    (16, 4096, 4096, "large"):             (512,    512,     1),
-    (16, 4096, 4096, "xlarge"):            (512,    256,     3),
+    (16, 4096, 4096, "tiny"): (64, 512, 3),
+    (16, 4096, 4096, "small"): (64, 512, 3),
+    (16, 4096, 4096, "medium"): (128, 512, 2),
+    (16, 4096, 4096, "medium2"): (128, 512, 2),
+    (16, 4096, 4096, "large"): (512, 512, 1),
+    (16, 4096, 4096, "xlarge"): (512, 256, 3),
     # --- K=7168, N=768 (gate_up, inter_dim=384) ---
-    (16, 768, 7168, "tiny"):               (64,     512,     3),
-    (16, 768, 7168, "small"):              (64,     512,     3),
-    (16, 768, 7168, "medium"):             (64,     512,     3),
-    (16, 768, 7168, "medium2"):            (64,     512,     3),
-    (16, 768, 7168, "large"):              (64,     512,     3),
-    (16, 768, 7168, "xlarge"):             (256,    512,     2),
+    (16, 768, 7168, "tiny"): (64, 512, 3),
+    (16, 768, 7168, "small"): (64, 512, 3),
+    (16, 768, 7168, "medium"): (64, 512, 3),
+    (16, 768, 7168, "medium2"): (64, 512, 3),
+    (16, 768, 7168, "large"): (64, 512, 3),
+    (16, 768, 7168, "xlarge"): (256, 512, 2),
     # --- K=7168, N=1024 (gate_up, inter_dim=512) ---
-    (16, 1024, 7168, "tiny"):              (64,     512,     3),
-    (16, 1024, 7168, "small"):             (64,     512,     3),
-    (16, 1024, 7168, "medium"):            (64,     512,     3),
-    (16, 1024, 7168, "medium2"):           (64,     512,     3),
-    (16, 1024, 7168, "large"):             (128,    512,     2),
-    (16, 1024, 7168, "xlarge"):            (512,    512,     1),
+    (16, 1024, 7168, "tiny"): (64, 512, 3),
+    (16, 1024, 7168, "small"): (64, 512, 3),
+    (16, 1024, 7168, "medium"): (64, 512, 3),
+    (16, 1024, 7168, "medium2"): (64, 512, 3),
+    (16, 1024, 7168, "large"): (128, 512, 2),
+    (16, 1024, 7168, "xlarge"): (512, 512, 1),
     # --- K=7168, N=1536 (gate_up, inter_dim=768) ---
-    (16, 1536, 7168, "tiny"):              (64,     512,     3),
-    (16, 1536, 7168, "small"):             (64,     512,     3),
-    (16, 1536, 7168, "medium"):            (64,     512,     3),
-    (16, 1536, 7168, "medium2"):           (64,     512,     3),
-    (16, 1536, 7168, "large"):             (256,    512,     3),
-    (16, 1536, 7168, "xlarge"):            (256,    256,     2),
+    (16, 1536, 7168, "tiny"): (64, 512, 3),
+    (16, 1536, 7168, "small"): (64, 512, 3),
+    (16, 1536, 7168, "medium"): (64, 512, 3),
+    (16, 1536, 7168, "medium2"): (64, 512, 3),
+    (16, 1536, 7168, "large"): (256, 512, 3),
+    (16, 1536, 7168, "xlarge"): (256, 256, 2),
     # --- K=7168, N=3072 (gate_up, inter_dim=1536) ---
-    (16, 3072, 7168, "tiny"):              (64,     512,     3),
-    (16, 3072, 7168, "small"):             (64,     512,     3),
-    (16, 3072, 7168, "medium"):            (512,    512,     2),
-    (16, 3072, 7168, "medium2"):           (512,    512,     2),
-    (16, 3072, 7168, "large"):             (256,    256,     2),
-    (16, 3072, 7168, "xlarge"):            (512,    256,     3),
+    (16, 3072, 7168, "tiny"): (64, 512, 3),
+    (16, 3072, 7168, "small"): (64, 512, 3),
+    (16, 3072, 7168, "medium"): (512, 512, 2),
+    (16, 3072, 7168, "medium2"): (512, 512, 2),
+    (16, 3072, 7168, "large"): (256, 256, 2),
+    (16, 3072, 7168, "xlarge"): (512, 256, 3),
 }
 
 
@@ -517,8 +521,6 @@ def moe_gemm_a8w4(
             "scatter+combine would need fp8-aware reduce_grouped"
         )
         out_dtype = torch.float8_e4m3fn
-    else:
-        out_dtype = out_dtype
     y, y_final = allocate_output(
         M,
         padded_N,


### PR DESCRIPTION
  ## Summary

  In `_expt_data_compute_stage1`, every block previously computed the full
  prefix-sum over all experts and wrote the entire `TokenStart` and `TileStart`
  arrays to global memory. This meant `n_expts_tot` blocks were all storing the
  same values to the same addresses — pure redundant traffic.

  This change gates the stores so each non-zero block only writes the
  BLOCK-sized chunk that contains its own expert. `pid==0` still runs the full
  loop and writes all chunks, as it must — it reads `TileStart[n_expts_tot-1]`
  afterwards to compute the sentinel value.

  The reduction in store traffic unblocks the loads in stage2 on architectures
  where the memory subsystem serializes stores and loads to overlapping cache
  lines. On MI450 this gives a **2x end-to-end speedup to `_combined_routing`**.

  ## Changes

  - `_expt_data_compute_stage1`: add `done` flag and per-chunk store gate
    (`pid == 0 or pid < i + BLOCK`) so non-zero blocks exit after writing
    their own chunk
  - No change to `_expt_data_compute_stage2`, kernel signatures, or call sites
  - Correctness validated across 108 scenarios (varied expert counts, token
    counts, topk, seeds) covering the EQUAL_BLOCK path and all three remainder
    cases of the unrolled loop