### PR TITLE
[module_moe_asm] refactor and rm torch

### DIFF
--- a/aiter/ops/moe_op.py
+++ b/aiter/ops/moe_op.py
@@ -12,7 +12,19 @@ import functools
 torch.int4 = getattr(torch, "int4", torch.uint32)
 
 
-@compile_ops("module_moe_asm")
+@compile_ops("module_moe_asm", fc_name="topk_softmax", develop=True)
+def _topk_softmax(
+    topk_weights: Tensor,
+    topk_indices: Tensor,
+    token_expert_indices: Tensor,
+    gating_output: Tensor,
+    softmax_workspace: Tensor,
+    need_renorm: bool,
+    num_shared_experts: int = 0,
+    shared_expert_scoring_func: str = "",
+) -> None: ...
+
+
 def topk_softmax(
     topk_weights: Tensor,
     topk_indices: Tensor,
@@ -21,7 +33,36 @@ def topk_softmax(
     need_renorm: bool,
     num_shared_experts: int = 0,
     shared_expert_scoring_func: str = "",
-) -> None: ...
+) -> None:
+    # The softmax workspace is only touched on the non-power-of-2 / >256-expert
+    # path, but is always allocated here (torch caching allocator) and passed in so
+    # the C side stays torch-free. Size logic mirrors the original C implementation.
+    num_experts_total = gating_output.shape[-1]
+    num_tokens = gating_output.numel() // num_experts_total
+    num_routing_experts = (
+        num_experts_total - num_shared_experts
+        if num_shared_experts > 0
+        else num_experts_total
+    )
+    is_pow_2 = (
+        num_routing_experts != 0
+        and (num_routing_experts & (num_routing_experts - 1)) == 0
+    )
+    needs_workspace = (not is_pow_2) or num_routing_experts > 256
+    workspace_size = num_tokens * num_routing_experts if needs_workspace else 0
+    softmax_workspace = torch.empty(
+        workspace_size, dtype=dtypes.fp32, device=gating_output.device
+    )
+    _topk_softmax(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        softmax_workspace,
+        need_renorm,
+        num_shared_experts,
+        shared_expert_scoring_func,
+    )
 
 
 @compile_ops(
@@ -42,11 +83,21 @@ def topk_sigmoid(
 ) -> None: ...
 
 
-@compile_ops("module_moe_asm")
-def moe_sum(input: Tensor, output: Tensor) -> None: ...
+@compile_ops("module_moe_asm", fc_name="moe_sum", develop=True)
+def _moe_sum(input: Tensor, output: Tensor) -> None: ...
 
 
-@compile_ops("module_moe_asm")
+def moe_sum(input: Tensor, output: Tensor) -> None:
+    # C side only implements topk in {2, 4, 5}; other topk values fall back to
+    # torch.sum on the Python side so the C side stays torch-free.
+    topk = input.shape[1]
+    if topk in (2, 4, 5):
+        _moe_sum(input, output)
+    else:
+        torch.sum(input, dim=1, out=output)
+
+
+@compile_ops("module_moe_asm", develop=True)
 def moe_align_block_size(
     topk_ids: Tensor,
     num_experts: int,

--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -4,7 +4,7 @@
 # user interface
 
 import functools
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -75,7 +75,7 @@ def topk_gating(
     )
 
 
-@compile_ops("module_moe_asm", fc_name="biased_grouped_topk")
+@compile_ops("module_moe_asm", fc_name="biased_grouped_topk", develop=True)
 def biased_grouped_topk_hip(
     gating_output: torch.Tensor,
     correction_bias: torch.Tensor,
@@ -88,7 +88,7 @@ def biased_grouped_topk_hip(
 ) -> None: ...
 
 
-@compile_ops("module_moe_asm")
+@compile_ops("module_moe_asm", develop=True)
 def grouped_topk(
     gating_output: torch.Tensor,
     topk_weights: torch.Tensor,
@@ -111,7 +111,7 @@ def gen_moe_fused_gate_fake_tensor(
     topk: int,
     n_share_experts_fusion: int,
     routed_scaling_factor: float = 1.0,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     output = torch.empty_like(
         topk_weights, dtype=topk_weights.dtype, device=topk_weights.device
     )
@@ -121,7 +121,20 @@ def gen_moe_fused_gate_fake_tensor(
     return [output, indices]
 
 
-@compile_ops("module_moe_asm", gen_fake=gen_moe_fused_gate_fake_tensor)
+@compile_ops("module_moe_asm", fc_name="moe_fused_gate", develop=True)
+def _moe_fused_gate(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    n_share_experts_fusion: int,
+    routed_scaling_factor: float = 1.0,
+) -> None: ...
+
+
 def moe_fused_gate(
     input: torch.Tensor,
     bias: torch.Tensor,
@@ -132,7 +145,21 @@ def moe_fused_gate(
     topk: int,
     n_share_experts_fusion: int,
     routed_scaling_factor: float = 1.0,
-) -> Tuple[torch.Tensor, torch.Tensor]: ...
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # C side fills topk_weights / topk_ids in place and returns void; return the
+    # (aliased) tensors to preserve the original API.
+    _moe_fused_gate(
+        input,
+        bias,
+        topk_weights,
+        topk_ids,
+        num_expert_group,
+        topk_group,
+        topk,
+        n_share_experts_fusion,
+        routed_scaling_factor,
+    )
+    return topk_weights, topk_ids
 
 
 def biased_grouped_topk(

--- a/csrc/include/moe_op.h
+++ b/csrc/include/moe_op.h
@@ -2,66 +2,56 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #include "aiter_enum.h"
-#include <torch/extension.h>
+#include "aiter_tensor.h"
+#include <string>
 
-void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_experts]
-                         torch::Tensor& correction_bias, // [num_expert]
-                         torch::Tensor& topk_weights,    // [num_tokens, topk]
-                         torch::Tensor& topk_ids,        // [num_tokens, topk]
+void biased_grouped_topk(const aiter_tensor_t& gating_output,   // [num_tokens, num_experts]
+                         const aiter_tensor_t& correction_bias, // [num_expert]
+                         const aiter_tensor_t& topk_weights,    // [num_tokens, topk]
+                         const aiter_tensor_t& topk_ids,        // [num_tokens, topk]
                          int num_expert_group,
                          int topk_group,
                          bool renormalize,
                          const float routed_scaling_factor = 1.);
 
-void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
-                  torch::Tensor& topk_weights,  // [num_tokens, topk]
-                  torch::Tensor& topk_ids,      // [num_tokens, topk]
+void grouped_topk(const aiter_tensor_t& gating_output, // [num_tokens, num_experts]
+                  const aiter_tensor_t& topk_weights,  // [num_tokens, topk]
+                  const aiter_tensor_t& topk_ids,      // [num_tokens, topk]
                   int num_expert_group,
                   int topk_grp,
                   bool need_renorm,
                   bool is_softmax                   = true,
                   const float routed_scaling_factor = 1.);
 
-std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
-                                       at::Tensor& bias,
-                                       at::Tensor& topk_weights,
-                                       at::Tensor& topk_ids,
-                                       int64_t num_expert_group,
-                                       int64_t topk_group,
-                                       int64_t topk,
-                                       int64_t n_share_experts_fusion,
-                                       double routed_scaling_factor);
-
-void moe_align_block_size(torch::Tensor topk_ids,
-                          int64_t num_experts,
-                          int64_t block_size,
-                          torch::Tensor sorted_token_ids,
-                          torch::Tensor experts_ids,
-                          torch::Tensor token_nums,
-                          torch::Tensor num_tokens_post_pad);
+void moe_fused_gate(const aiter_tensor_t& input,
+                    const aiter_tensor_t& bias,
+                    const aiter_tensor_t& topk_weights,
+                    const aiter_tensor_t& topk_ids,
+                    int64_t num_expert_group,
+                    int64_t topk_group,
+                    int64_t topk,
+                    int64_t n_share_experts_fusion,
+                    double routed_scaling_factor);
 
 namespace aiter {
 
-void topk_softmax(torch::Tensor& topk_weights,
-                  torch::Tensor& topk_indices,
-                  torch::Tensor& token_expert_indices,
-                  torch::Tensor& gating_output,
+void topk_softmax(const aiter_tensor_t& topk_weights,
+                  const aiter_tensor_t& topk_indices,
+                  const aiter_tensor_t& token_expert_indices,
+                  const aiter_tensor_t& gating_output,
+                  const aiter_tensor_t& softmax_workspace,
                   bool need_renorm,
                   int num_shared_experts                        = 0,
                   const std::string& shared_expert_scoring_func = "");
 
-void moe_align_block_size(torch::Tensor topk_ids,
+void moe_align_block_size(const aiter_tensor_t& topk_ids,
                           int64_t num_experts,
                           int64_t block_size,
-                          torch::Tensor sorted_token_ids,
-                          torch::Tensor experts_ids,
-                          torch::Tensor token_nums,
-                          torch::Tensor num_tokens_post_pad);
+                          const aiter_tensor_t& sorted_token_ids,
+                          const aiter_tensor_t& experts_ids,
+                          const aiter_tensor_t& token_nums,
+                          const aiter_tensor_t& num_tokens_post_pad);
 
-void moe_sum(torch::Tensor& input, torch::Tensor& output);
-
-void topk_sigmoid(torch::Tensor topk_weights,   // [tokens, topk]
-                  torch::Tensor topk_indices,   // [tokens, topk]
-                  torch::Tensor gating_output); // [tokens, experts]
+void moe_sum(const aiter_tensor_t& input, const aiter_tensor_t& output);
 
 } // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1311,6 +1311,7 @@ namespace py = pybind11;
           py::arg("topk_indices"),                                             \
           py::arg("token_expert_indices"),                                     \
           py::arg("gating_output"),                                            \
+          py::arg("softmax_workspace"),                                        \
           py::arg("need_renorm"),                                              \
           py::arg("num_shared_experts")         = 0,                           \
           py::arg("shared_expert_scoring_func") = "",                          \

--- a/csrc/kernels/moe_align_block_size_kernels.cu
+++ b/csrc/kernels/moe_align_block_size_kernels.cu
@@ -14,14 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
-#include <torch/all.h>
-
-#include <ATen/ATen.h>
-
 #include "aiter_hip_common.h"
-#include "dispatch_utils.h"
+#include "aiter_dispatch.h"
+#include "aiter_stream.h"
+#include "moe_op.h"
 
 #define CEILDIV(x, y) (((x) + (y) - 1) / (y))
 
@@ -131,17 +127,17 @@ namespace aiter {
 #define VLLM_DevFuncAttribute_SET_MaxDynamicSharedMemorySize(FUNC, VAL) \
     hipFuncSetAttribute(FUNC, hipFuncAttributeMaxDynamicSharedMemorySize, VAL)
 
-void moe_align_block_size(torch::Tensor topk_ids,
+void moe_align_block_size(const aiter_tensor_t& topk_ids,
                           int64_t num_experts,
                           int64_t block_size,
-                          torch::Tensor sorted_token_ids,
-                          torch::Tensor experts_ids,
-                          torch::Tensor token_nums,
-                          torch::Tensor num_tokens_post_pad)
+                          const aiter_tensor_t& sorted_token_ids,
+                          const aiter_tensor_t& experts_ids,
+                          const aiter_tensor_t& token_nums,
+                          const aiter_tensor_t& num_tokens_post_pad)
 {
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(topk_ids));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
-    VLLM_DISPATCH_INTEGRAL_TYPES(topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
+    HipDeviceGuard device_guard(topk_ids.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+    VLLM_DISPATCH_INTEGRAL_TYPES_rmTorch(topk_ids.dtype(), "moe_align_block_size_kernel", [&] {
         // Optimized shared memory: O(num_experts) instead of O(num_experts^2)
         // expert_token_counts[num_experts] + cumsum[num_experts + 1] + write_positions[num_experts]
         const int32_t shared_mem = (3 * num_experts + 1) * sizeof(int32_t);
@@ -150,14 +146,15 @@ void moe_align_block_size(torch::Tensor topk_ids,
         auto kernel = vllm::moe_align_block_size_kernel<scalar_t>;
         HIP_CALL(
             VLLM_DevFuncAttribute_SET_MaxDynamicSharedMemorySize((void*)kernel, shared_mem));
-        kernel<<<1, num_experts, shared_mem, stream>>>(topk_ids.data_ptr<scalar_t>(),
-                                                       sorted_token_ids.data_ptr<int32_t>(),
-                                                       experts_ids.data_ptr<int32_t>(),
-                                                       token_nums.data_ptr<int32_t>(),
-                                                       num_tokens_post_pad.data_ptr<int32_t>(),
-                                                       num_experts,
-                                                       block_size,
-                                                       topk_ids.numel());
+        kernel<<<1, num_experts, shared_mem, stream>>>(
+            reinterpret_cast<scalar_t*>(topk_ids.data_ptr()),
+            reinterpret_cast<int32_t*>(sorted_token_ids.data_ptr()),
+            reinterpret_cast<int32_t*>(experts_ids.data_ptr()),
+            reinterpret_cast<int32_t*>(token_nums.data_ptr()),
+            reinterpret_cast<int32_t*>(num_tokens_post_pad.data_ptr()),
+            num_experts,
+            block_size,
+            topk_ids.numel());
     });
 }
 

--- a/csrc/kernels/moe_fused_gate.cu
+++ b/csrc/kernels/moe_fused_gate.cu
@@ -18,15 +18,15 @@
 #include "aiter_hip_common.h"
 #include "hip_reduce.h"
 #include "opus/opus.hpp"
-#include <ATen/hip/HIPContext.h>
+#include "aiter_stream.h"
+#include "moe_op.h"
+#include <algorithm>
 #include <cfloat>
 #include <hip/hip_runtime.h>
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
 #include <stdio.h>
-#include <torch/all.h>
 #include <type_traits>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 
 /// Aligned array type
 template <typename T,
@@ -467,16 +467,17 @@ __global__ void moe_fused_gate_kernel(void* input,
                               (EXPERTS),                                                      \
                               (EXPERT_GROUP),                                                 \
                               WARPS_PER_CTA>                                                  \
-            <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),            \
-                                                                 bias.data_ptr(),             \
-                                                                 output.data_ptr<float>(),    \
-                                                                 indices.data_ptr<int32_t>(), \
-                                                                 num_rows,                    \
-                                                                 topk_group,                  \
-                                                                 topk,                        \
-                                                                 num_fused_shared_experts,    \
-                                                                 routed_scaling_factor,       \
-                                                                 out_stride);                 \
+            <<<num_blocks, block_dim, shared_mem_size, stream>>>(                             \
+                input.data_ptr(),                                                            \
+                bias.data_ptr(),                                                             \
+                reinterpret_cast<float*>(output.data_ptr()),                                 \
+                reinterpret_cast<int32_t*>(indices.data_ptr()),                              \
+                num_rows,                                                                    \
+                topk_group,                                                                  \
+                topk,                                                                        \
+                num_fused_shared_experts,                                                    \
+                routed_scaling_factor,                                                       \
+                out_stride);                                                                 \
         dispatched = true;                                                                    \
     } while(0)
 
@@ -533,23 +534,22 @@ __global__ void moe_fused_gate_kernel_dynamic(void* input,
 //------------------------------------------------------------------------------
 // Host Launcher Function
 //------------------------------------------------------------------------------
-std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
-                                       at::Tensor& bias,
-                                       at::Tensor& topk_weights,
-                                       at::Tensor& topk_ids,
-                                       int64_t num_expert_group,
-                                       int64_t topk_group,
-                                       int64_t topk,
-                                       int64_t num_fused_shared_experts,
-                                       double routed_scaling_factor)
+void moe_fused_gate(const aiter_tensor_t& input,
+                    const aiter_tensor_t& bias,
+                    const aiter_tensor_t& topk_weights,
+                    const aiter_tensor_t& topk_ids,
+                    int64_t num_expert_group,
+                    int64_t topk_group,
+                    int64_t topk,
+                    int64_t num_fused_shared_experts,
+                    double routed_scaling_factor)
 {
-    int64_t num_rows     = input.size(0);
-    int32_t num_experts  = input.size(1);
-    auto options         = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
-    auto output          = topk_weights;
-    auto indices         = topk_ids;
-    const int out_stride = topk_ids.stride(0);
-    TORCH_CHECK(topk_weights.stride(0) == out_stride,
+    int64_t num_rows                = input.size(0);
+    int32_t num_experts             = input.size(1);
+    const aiter_tensor_t& output    = topk_weights;
+    const aiter_tensor_t& indices   = topk_ids;
+    const int out_stride            = topk_ids.stride(0);
+    AITER_CHECK(topk_weights.stride(0) == out_stride,
                 "topk_weights and topk_ids must have the same stride in dim 0");
 
     // Compute grid dimensions based on runtime value for num_expert_group.
@@ -559,18 +559,18 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
     int ROWS_PER_WARP     = std::max<int64_t>(1, WARP_SIZE / num_expert_group);
     size_t shared_mem_size =
         ((topk * sizeof(float) + topk * sizeof(int)) * ROWS_PER_WARP + 255) & ~255;
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(input.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
     dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
 
     // // Check 1: Ensure that num_experts is a power of 2.
-    // TORCH_CHECK((num_experts & (num_experts - 1)) == 0,
+    // AITER_CHECK((num_experts & (num_experts - 1)) == 0,
     //             "num_experts must be a power of 2, but got ",
     //             num_experts);
 
     // Check 2: Ensure that num_experts is divisible by num_expert_group. (this also means
     // num_expert_group is power of 2)
-    TORCH_CHECK(num_experts % num_expert_group == 0,
+    AITER_CHECK(num_experts % num_expert_group == 0,
                 "num_experts must be divisible by num_expert_group, but got ",
                 num_experts,
                 " / ",
@@ -579,7 +579,7 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
     int computed_vpt = num_experts / num_expert_group;
     // Check 3: Ensure that num_experts/num_expert_group does not exceed MAX_VPT=32. Maximum VPT
     // indicate max value per threads we can process.
-    TORCH_CHECK(computed_vpt <= MAX_VPT,
+    AITER_CHECK(computed_vpt <= MAX_VPT,
                 "Per group experts: num_experts / num_expert_group = (",
                 computed_vpt,
                 ") exceeds the maximum supported (",
@@ -599,15 +599,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         {
             // This is deepseek v3 case. Here VPT = 256/8 = 32, ROWS_PER_WARP = 32/8 = 4,
             // ROWS_PER_CTA = 6 * 4 = 24.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input.dtype() == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 256, 8);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input.dtype() == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 256, 8);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input.dtype() == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 256, 8);
             }
@@ -615,15 +615,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         else if(num_expert_group == 16)
         {
             // Here VPT = 256/16 = 16, ROWS_PER_WARP = 32/16 = 2, ROWS_PER_CTA = 6 * 2 = 12.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input.dtype() == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 256, 16);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input.dtype() == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 256, 16);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input.dtype() == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 256, 16);
             }
@@ -634,15 +634,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         {
             // This is deepseek v3 case. Here VPT = 192/8 = 24, ROWS_PER_WARP = 32/8 = 4,
             // ROWS_PER_CTA = 6 * 4 = 24.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input.dtype() == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 192, 8);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input.dtype() == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 192, 8);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input.dtype() == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 192, 8);
             }
@@ -652,15 +652,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         if(num_expert_group == 4)
         {
             // VPT = 128/4 = 32, ROWS_PER_WARP = 32/16 = 2, ROWS_PER_CTA = 6 * 2 = 12.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input.dtype() == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 128, 4);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input.dtype() == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 128, 4);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input.dtype() == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 128, 4);
             }
@@ -668,15 +668,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         else if(num_expert_group == 8)
         {
             // VPT = 128/8 = 16, ROWS_PER_WARP = 32/8 = 4, ROWS_PER_CTA = 6 * 4 = 24.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input.dtype() == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 128, 8);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input.dtype() == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 128, 8);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input.dtype() == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 128, 8);
             }
@@ -687,15 +687,15 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         {
             // This is deepseek v3 case. Here VPT = 96/8 = 12, ROWS_PER_WARP = 32/8 = 4,
             // ROWS_PER_CTA = 6 * 4 = 24.
-            if(input.scalar_type() == at::kBFloat16)
+            if(input.dtype() == AITER_DTYPE_bf16)
             {
                 LAUNCH_MOE_GATE_CONFIG(bfloat16_t, 96, 8);
             }
-            else if(input.scalar_type() == at::kHalf)
+            else if(input.dtype() == AITER_DTYPE_fp16)
             {
                 LAUNCH_MOE_GATE_CONFIG(float16_t, 96, 8);
             }
-            else if(input.scalar_type() == at::kFloat)
+            else if(input.dtype() == AITER_DTYPE_fp32)
             {
                 LAUNCH_MOE_GATE_CONFIG(float32_t, 96, 8);
             }
@@ -707,13 +707,13 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
     {
         // Fallback to the dynamic kernel if none of the supported combinations match.
         // currently only support num_experts / num_expert_group <= 32 for dynamic kernels
-        if(input.scalar_type() == at::kBFloat16)
+        if(input.dtype() == AITER_DTYPE_bf16)
         {
             moe_fused_gate_kernel_dynamic<bfloat16_t>
                 <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),
                                                                      bias.data_ptr(),
-                                                                     output.data_ptr<float>(),
-                                                                     indices.data_ptr<int32_t>(),
+                                                                     reinterpret_cast<float*>(output.data_ptr()),
+                                                                     reinterpret_cast<int32_t*>(indices.data_ptr()),
                                                                      num_rows,
                                                                      num_experts,
                                                                      num_expert_group,
@@ -723,13 +723,13 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
                                                                      routed_scaling_factor,
                                                                      out_stride);
         }
-        else if(input.scalar_type() == at::kHalf)
+        else if(input.dtype() == AITER_DTYPE_fp16)
         {
             moe_fused_gate_kernel_dynamic<float16_t>
                 <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),
                                                                      bias.data_ptr(),
-                                                                     output.data_ptr<float>(),
-                                                                     indices.data_ptr<int32_t>(),
+                                                                     reinterpret_cast<float*>(output.data_ptr()),
+                                                                     reinterpret_cast<int32_t*>(indices.data_ptr()),
                                                                      num_rows,
                                                                      num_experts,
                                                                      num_expert_group,
@@ -739,13 +739,13 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
                                                                      routed_scaling_factor,
                                                                      out_stride);
         }
-        else if(input.scalar_type() == at::kFloat)
+        else if(input.dtype() == AITER_DTYPE_fp32)
         {
             moe_fused_gate_kernel_dynamic<float32_t>
                 <<<num_blocks, block_dim, shared_mem_size, stream>>>(input.data_ptr(),
                                                                      bias.data_ptr(),
-                                                                     output.data_ptr<float>(),
-                                                                     indices.data_ptr<int32_t>(),
+                                                                     reinterpret_cast<float*>(output.data_ptr()),
+                                                                     reinterpret_cast<int32_t*>(indices.data_ptr()),
                                                                      num_rows,
                                                                      num_experts,
                                                                      num_expert_group,
@@ -757,8 +757,9 @@ std::vector<at::Tensor> moe_fused_gate(at::Tensor& input,
         }
         else
         {
-            TORCH_CHECK(false, "Unsupported data type for moe_fused_gate");
+            AITER_CHECK(false, "Unsupported data type for moe_fused_gate");
         }
     }
-    return {output, indices};
+    // output/indices alias the caller-provided topk_weights/topk_ids (filled in place);
+    // Python already holds them, so nothing is returned.
 }

--- a/csrc/kernels/topk_softmax_kernels.cu
+++ b/csrc/kernels/topk_softmax_kernels.cu
@@ -18,15 +18,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dispatch_utils.h"
+#include "aiter_dispatch.h"
 #include "aiter_hip_common.h"
 #include "hip_reduce.h"
 #include "aiter_opus_plus.h"
-#include "py_itfs_common.h"
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
-#include <torch/all.h>
+#include "aiter_stream.h"
+#include "moe_op.h"
 
+#include <algorithm>
+#include <cfloat>
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
 
@@ -615,12 +615,12 @@ void topkGatingSoftmaxLauncherHelper(const DTYPE* input,
             case 8: LAUNCH_SOFTMAX_WITH_SHARED(NUM_EXPERTS, WARPS_PER_TB, 8,               \
                                               SharedExpertScoringFunc::SIGMOID); break;     \
             default:                                                                        \
-                TORCH_CHECK(false, "Unsupported num_shared_experts: " +                    \
+                AITER_CHECK(false, "Unsupported num_shared_experts: " +                    \
                             std::to_string(num_shared_experts) +                            \
                             ". Supported values: 1, 2, 4, 8");                              \
             }                                                                               \
         } else {                                                                            \
-            TORCH_CHECK(false, "Unsupported scoring function");                             \
+            AITER_CHECK(false, "Unsupported scoring function");                             \
         }                                                                                   \
     } while(0)
 
@@ -678,7 +678,7 @@ void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
         }
         else
         {
-            TORCH_CHECK(false, "Unsupported shared expert scoring function: " + shared_experts_scoring_func);
+            AITER_CHECK(false, "Unsupported shared expert scoring function: " + shared_experts_scoring_func);
         }
     }
 
@@ -698,7 +698,7 @@ void topkGatingSoftmaxKernelLauncher(const DTYPE* gating_output,
     case 256: LAUNCH_SOFTMAX(256, WARPS_PER_TB); break;
     case 512: LAUNCH_SOFTMAX(512, 2); break;
     default: {
-        TORCH_CHECK(
+        AITER_CHECK(
             softmax_workspace != nullptr,
             "softmax_workspace must be provided for num_experts that are not a power of 2.");
         static constexpr int TPB = 256;
@@ -742,13 +742,15 @@ __global__ void moe_sum_kernel(scalar_t* __restrict__ out,         // [..., d]
     const int64_t token_idx = blockIdx.x;
     for(int64_t idx = threadIdx.x; idx < d; idx += blockDim.x)
     {
-        scalar_t x = 0.0;
+        // Accumulate in fp32 (matches torch.sum accumulation dtype) so the native
+        // HIP scalar types (__half / hip_bfloat16) sum correctly.
+        float x = 0.0f;
 #pragma unroll
         for(int k = 0; k < TOPK; ++k)
         {
-            x += *(&input[token_idx * TOPK * d + k * d + idx]);
+            x += static_cast<float>(input[token_idx * TOPK * d + k * d + idx]);
         }
-        out[token_idx * d + idx] = x;
+        out[token_idx * d + idx] = static_cast<scalar_t>(x);
     }
 }
 
@@ -757,10 +759,11 @@ __global__ void moe_sum_kernel(scalar_t* __restrict__ out,         // [..., d]
 
 namespace aiter {
 
-void topk_softmax(torch::Tensor& topk_weights,         // [num_tokens, topk + num_shared_experts]
-                  torch::Tensor& topk_indices,         // [num_tokens, topk]
-                  torch::Tensor& token_expert_indices, // [num_tokens, topk]
-                  torch::Tensor& gating_output,        // [num_tokens, num_experts + num_shared_experts]
+void topk_softmax(const aiter_tensor_t& topk_weights,         // [num_tokens, topk + num_shared_experts]
+                  const aiter_tensor_t& topk_indices,         // [num_tokens, topk]
+                  const aiter_tensor_t& token_expert_indices, // [num_tokens, topk]
+                  const aiter_tensor_t& gating_output,        // [num_tokens, num_experts + num_shared_experts]
+                  const aiter_tensor_t& softmax_workspace,    // [num_tokens * num_routing_experts] fp32, python-allocated
                   bool need_renorm,
                   int num_shared_experts,
                   const std::string& shared_expert_scoring_func)
@@ -778,29 +781,25 @@ void topk_softmax(torch::Tensor& topk_weights,         // [num_tokens, topk + nu
     // Validate shared expert scoring function
     if(num_shared_experts > 0 && !shared_expert_scoring_func.empty())
     {
-        TORCH_CHECK(shared_expert_scoring_func == "sigmoid",
+        AITER_CHECK(shared_expert_scoring_func == "sigmoid",
                    "Only 'sigmoid' scoring function is supported for shared experts, got: " +
                    shared_expert_scoring_func);
     }
 
-    const bool is_pow_2          = (num_routing_experts != 0) && ((num_routing_experts & (num_routing_experts - 1)) == 0);
-    const bool needs_workspace   = !is_pow_2 || num_routing_experts > 256;
-    const int64_t workspace_size = needs_workspace ? num_tokens * num_routing_experts : 0;
-
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
-    torch::Tensor softmax_workspace =
-        torch::empty({workspace_size}, gating_output.options().dtype(torch::kFloat32));
+    // Workspace (softmax_workspace) is sized/allocated on the Python side; only the
+    // non-power-of-2 / >256-expert path actually reads it.
+    HipDeviceGuard device_guard(gating_output.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     // Process routing experts with softmax + topk, and shared experts with sigmoid in one kernel
-    VLLM_DISPATCH_FLOATING_TYPES(gating_output.scalar_type(), "topk_softmax", [&] {
-        using input_dtype = typename t2opus<scalar_t>::type;
+    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(gating_output.dtype(), "topk_softmax", [&] {
+        using input_dtype = typename aiter::hip2opus<scalar_t>::type;
         vllm::moe::topkGatingSoftmaxKernelLauncher(
             reinterpret_cast<input_dtype*>(gating_output.data_ptr()),
-            topk_weights.data_ptr<float>(),
-            topk_indices.data_ptr<int>(),
-            token_expert_indices.data_ptr<int>(),
-            softmax_workspace.data_ptr<float>(),
+            reinterpret_cast<float*>(topk_weights.data_ptr()),
+            reinterpret_cast<int*>(topk_indices.data_ptr()),
+            reinterpret_cast<int*>(token_expert_indices.data_ptr()),
+            reinterpret_cast<float*>(softmax_workspace.data_ptr()),
             num_tokens,
             num_routing_experts,  // Only routing experts for softmax
             num_shared_experts,   // Number of shared experts to process with sigmoid
@@ -814,8 +813,11 @@ void topk_softmax(torch::Tensor& topk_weights,         // [num_tokens, topk + nu
     });
 }
 
-void moe_sum(torch::Tensor& input,  // [num_tokens, topk, hidden_size]
-             torch::Tensor& output) // [num_tokens, hidden_size]
+// Only topk in {2, 4, 5} is handled here. Other topk values are summed on the
+// Python side via torch.sum (see aiter/ops/moe_op.py::moe_sum), so the C side
+// stays torch-free.
+void moe_sum(const aiter_tensor_t& input,  // [num_tokens, topk, hidden_size]
+             const aiter_tensor_t& output) // [num_tokens, hidden_size]
 {
     const int hidden_size = input.size(-1);
     const int num_tokens  = output.numel() / hidden_size;
@@ -824,32 +826,43 @@ void moe_sum(torch::Tensor& input,  // [num_tokens, topk, hidden_size]
     dim3 grid(num_tokens);
     dim3 block(std::min(hidden_size, 1024));
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(output.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     switch(topk)
     {
     case 2:
-        VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
+        VLLM_DISPATCH_FLOATING_TYPES_rmTorch(input.dtype(), "moe_sum_kernel", [&] {
             vllm::moe::moe_sum_kernel<scalar_t, 2><<<grid, block, 0, stream>>>(
-                output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), hidden_size);
+                reinterpret_cast<scalar_t*>(output.data_ptr()),
+                reinterpret_cast<scalar_t*>(input.data_ptr()),
+                hidden_size);
         });
         break;
 
     case 4:
-        VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
+        VLLM_DISPATCH_FLOATING_TYPES_rmTorch(input.dtype(), "moe_sum_kernel", [&] {
             vllm::moe::moe_sum_kernel<scalar_t, 4><<<grid, block, 0, stream>>>(
-                output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), hidden_size);
+                reinterpret_cast<scalar_t*>(output.data_ptr()),
+                reinterpret_cast<scalar_t*>(input.data_ptr()),
+                hidden_size);
         });
         break;
 
     case 5:
-        VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum_kernel", [&] {
+        VLLM_DISPATCH_FLOATING_TYPES_rmTorch(input.dtype(), "moe_sum_kernel", [&] {
             vllm::moe::moe_sum_kernel<scalar_t, 5><<<grid, block, 0, stream>>>(
-                output.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), hidden_size);
+                reinterpret_cast<scalar_t*>(output.data_ptr()),
+                reinterpret_cast<scalar_t*>(input.data_ptr()),
+                hidden_size);
         });
         break;
-    default: at::sum_out(output, input, 1); break;
+    default:
+        AITER_CHECK(false,
+                    "moe_sum: topk=",
+                    topk,
+                    " must be handled on the Python side (torch.sum fallback).");
+        break;
     }
 }
 

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -10,18 +10,17 @@
  * @Description: This is description.
  */
 
-#include "dispatch_utils.h"
+#include "aiter_dispatch.h"
 #include "hip_reduce.h"
-#include "py_itfs_common.h"
 #include "aiter_hip_common.h"
+#include "aiter_stream.h"
 #include "warp_sort.h"
 #include "aiter_opus_plus.h"
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include "moe_op.h"
+#include <cfloat>
 #include <hip/hip_runtime.h>
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
-#include <torch/all.h>
 
 #ifndef AITER_TOPK_SOFTMAX_GROUP_PERMUTE_SCORE
 #define AITER_TOPK_SOFTMAX_GROUP_PERMUTE_SCORE 0
@@ -361,7 +360,7 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
 
     f32vec* scores_vec            = reinterpret_cast<f32vec*>(scores);
     f32vec* sig_vec               = reinterpret_cast<f32vec*>(sig_scores);
-    using cktype_i                = typename t2opus<DTYPE_I>::type;
+    using cktype_i                = typename aiter::hip2opus<DTYPE_I>::type;
     static constexpr int vec_size = opus::vector_traits<f32vec>::size();
     using vec_i                   = opus::vector_t<cktype_i, vec_size>;
     const int num_experts_vec     = num_experts / vec_size;
@@ -674,7 +673,7 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
     // float *topk_values_f = reinterpret_cast<float *>(ptr);
 
     f32vec* scores_vec            = reinterpret_cast<f32vec*>(scores);
-    using cktype_i                = typename t2opus<DTYPE_I>::type;
+    using cktype_i                = typename aiter::hip2opus<DTYPE_I>::type;
     static constexpr int vec_size = opus::vector_traits<f32vec>::size();
     using vec_i                   = opus::vector_t<cktype_i, vec_size>;
     const int num_experts_vec     = num_experts / vec_size;
@@ -1119,7 +1118,7 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
     case 4: LAUNCHER3(VEC_F, 4) break;                                                      \
     case 2: LAUNCHER3(VEC_F, 2) break;                                                      \
     case 1: LAUNCHER3(VEC_F, 1) break;                                                      \
-    default: TORCH_CHECK(false, "Unsupported num_expert_group: ", num_expert_group); break; \
+    default: AITER_CHECK(false, "Unsupported num_expert_group: ", num_expert_group); break; \
     }
 #define LAUNCHER3(VEC_F, NUM_GRP)                     \
     switch(need_renorm)                               \
@@ -1153,7 +1152,7 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
     }
 
 #define LAUNCHER_biased_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)      \
-    VLLM_DISPATCH_FLOATING_TYPES(gating_output.scalar_type(), "biased_grouped_topk_kernel", [&] {  \
+    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(gating_output.dtype(), "biased_grouped_topk_kernel", [&] {  \
         hipLaunchKernelGGL(                                                                        \
             (aiter::                                                                               \
                  grouped_topk_kernel<scalar_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>), \
@@ -1161,10 +1160,10 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
             dim3(block),                                                                           \
             shared_mem_size,                                                                       \
             stream,                                                                                \
-            gating_output.data_ptr<scalar_t>(),                                                    \
-            correction_bias.data_ptr<scalar_t>(),                                                  \
-            topk_weights.data_ptr<float>(),                                                        \
-            topk_ids.data_ptr<int>(),                                                              \
+            reinterpret_cast<scalar_t*>(gating_output.data_ptr()),                                                    \
+            reinterpret_cast<scalar_t*>(correction_bias.data_ptr()),                                                  \
+            reinterpret_cast<float*>(topk_weights.data_ptr()),                                                        \
+            reinterpret_cast<int*>(topk_ids.data_ptr()),                                                              \
             stride_tk,                                                                             \
             num_experts,                                                                           \
             topk,                                                                                  \
@@ -1174,7 +1173,7 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
     });
 
 #define LAUNCHER_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)             \
-    VLLM_DISPATCH_FLOATING_TYPES(gating_output.scalar_type(), "grouped_topk_kernel", [&] {         \
+    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(gating_output.dtype(), "grouped_topk_kernel", [&] {         \
         hipLaunchKernelGGL(                                                                        \
             (aiter::                                                                               \
                  grouped_topk_kernel<scalar_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>), \
@@ -1182,10 +1181,10 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
             dim3(block),                                                                           \
             shared_mem_size,                                                                       \
             stream,                                                                                \
-            gating_output.data_ptr<scalar_t>(),                                                    \
+            reinterpret_cast<scalar_t*>(gating_output.data_ptr()),                                                    \
             nullptr,                                                                               \
-            topk_weights.data_ptr<float>(),                                                        \
-            topk_ids.data_ptr<int>(),                                                              \
+            reinterpret_cast<float*>(topk_weights.data_ptr()),                                                        \
+            reinterpret_cast<int*>(topk_ids.data_ptr()),                                                              \
             stride_tk,                                                                             \
             num_experts,                                                                           \
             topk,                                                                                  \
@@ -1196,8 +1195,8 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
 
 #define LAUNCHER_biased_grouped_topk_opt_sort_kernel(                             \
     VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)                             \
-    VLLM_DISPATCH_FLOATING_TYPES(                                                 \
-        gating_output.scalar_type(), "biased_grouped_topk_opt_sort_kernel", [&] { \
+    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(                                         \
+        gating_output.dtype(), "biased_grouped_topk_opt_sort_kernel", [&] { \
             hipLaunchKernelGGL((aiter::grouped_topk_opt_sort_kernel<scalar_t,     \
                                                                     VEC_F,        \
                                                                     NUM_GRP,      \
@@ -1208,10 +1207,10 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
                                dim3(block),                                       \
                                shared_mem_size,                                   \
                                stream,                                            \
-                               gating_output.data_ptr<scalar_t>(),                \
-                               correction_bias.data_ptr<scalar_t>(),              \
-                               topk_weights.data_ptr<float>(),                    \
-                               topk_ids.data_ptr<int>(),                          \
+                               reinterpret_cast<scalar_t*>(gating_output.data_ptr()),                \
+                               reinterpret_cast<scalar_t*>(correction_bias.data_ptr()),              \
+                               reinterpret_cast<float*>(topk_weights.data_ptr()),                    \
+                               reinterpret_cast<int*>(topk_ids.data_ptr()),                          \
                                stride_tk,                                         \
                                num_experts,                                       \
                                topk,                                              \
@@ -1220,14 +1219,14 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
                                routed_scaling_factor);                            \
         });
 
-void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_experts]
-                         torch::Tensor& correction_bias, // [num_expert]
-                         torch::Tensor& topk_weights,    // [num_tokens, topk]
-                         torch::Tensor& topk_ids,        // [num_tokens, topk]
+void biased_grouped_topk(const aiter_tensor_t& gating_output,   // [num_tokens, num_experts]
+                         const aiter_tensor_t& correction_bias, // [num_expert]
+                         const aiter_tensor_t& topk_weights,    // [num_tokens, topk]
+                         const aiter_tensor_t& topk_ids,        // [num_tokens, topk]
                          int num_expert_group,
                          int topk_grp,
                          bool need_renorm,
-                         const float routed_scaling_factor = 1.)
+                         const float routed_scaling_factor)
 {
     const bool isBiased = true;
     bool isSoftmax      = false;
@@ -1235,7 +1234,7 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
     int num_experts     = gating_output.size(1);
     int topk            = topk_ids.size(1);
     size_t stride_tk    = topk_ids.stride(0);
-    TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
+    AITER_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
                 "topk_grp must be in [1, num_expert_group], but got topk_grp=",
                 topk_grp,
                 ", num_expert_group=",
@@ -1261,20 +1260,20 @@ void biased_grouped_topk(torch::Tensor& gating_output,   // [num_tokens, num_exp
                               //    + 64 / num_expert_group * sizeof(float) /* for sorting */
                              );
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(gating_output.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     LAUNCH_KERNEL()
 }
 
-void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
-                  torch::Tensor& topk_weights,  // [num_tokens, topk]
-                  torch::Tensor& topk_ids,      // [num_tokens, topk]
+void grouped_topk(const aiter_tensor_t& gating_output, // [num_tokens, num_experts]
+                  const aiter_tensor_t& topk_weights,  // [num_tokens, topk]
+                  const aiter_tensor_t& topk_ids,      // [num_tokens, topk]
                   int num_expert_group,
                   int topk_grp,
                   bool need_renorm,
-                  bool is_softmax                   = true,
-                  const float routed_scaling_factor = 1.)
+                  bool is_softmax,
+                  const float routed_scaling_factor)
 {
     const bool isBiased  = false;
     bool isSoftmax       = is_softmax;
@@ -1282,8 +1281,8 @@ void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
     int num_experts      = gating_output.size(1);
     int topk             = topk_ids.size(1);
     size_t stride_tk     = topk_ids.stride(0);
-    auto correction_bias = topk_ids;
-    TORCH_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
+    const aiter_tensor_t& correction_bias = topk_ids;
+    AITER_CHECK(topk_grp >= 1 && topk_grp <= num_expert_group,
                 "topk_grp must be in [1, num_expert_group], but got topk_grp=",
                 topk_grp,
                 ", num_expert_group=",
@@ -1298,8 +1297,8 @@ void grouped_topk(torch::Tensor& gating_output, // [num_tokens, num_experts]
                               topk * sizeof(int) + topk * sizeof(float) + 255) &
                              ~255;
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(gating_output));
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(gating_output.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     LAUNCH_KERNEL()
 }

--- a/csrc/pybind/moe_op_pybind.cu
+++ b/csrc/pybind/moe_op_pybind.cu
@@ -1,7 +1,12 @@
 /* SPDX-License-Identifier: MIT
    Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 */
-#include "moe_op.h"
 #include "rocm_ops.hpp"
+#include "aiter_stream.h"
+#include "moe_op.h"
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { MOE_OP_PYBIND; }
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    MOE_OP_PYBIND;
+}

--- a/csrc/pybind/moe_topk_ck_pybind.cu
+++ b/csrc/pybind/moe_topk_ck_pybind.cu
@@ -1,8 +1,16 @@
 /* SPDX-License-Identifier: MIT
    Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
 */
-#include "moe_op.h"
 #include "rocm_ops.hpp"
+#include <torch/all.h>
+
+// topk_sigmoid is still a torch-based op (module_moe_topk_ck); declared here so it
+// does not pull a torch dependency into the now torch-free moe_op.h.
+namespace aiter {
+void topk_sigmoid(torch::Tensor topk_weights,   // [tokens, topk]
+                  torch::Tensor topk_indices,   // [tokens, topk]
+                  torch::Tensor gating_output); // [tokens, experts]
+} // namespace aiter
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {


### PR DESCRIPTION
## Summary

Remove the `torch` dependency from `module_moe_asm`'s C/HIP sources.
The [module_moe_asm] build time drop from 33.8s to 16.4s **(-51.5%)**

## Compile-time improvement (single-file `hipcc`, gfx950)

| source file | before (torch) | after (torch-free) | saved |
|---|---:|---:|---:|
| `topk_softmax_kernels.cu` | 29.6 s | 12.5 s | −17.1 s (58%) |
| `topk_softmax_kernels_group.cu` | 27.1 s | 9.8 s | −17.3 s (64%) |
| `moe_fused_gate.cu` | 19.4 s | 5.4 s | −14.0 s (72%) |
| `moe_align_block_size_kernels.cu` | 19.3 s | 1.8 s | −17.5 s (91%) |
| `moe_op_pybind.cu` | 19.8 s | 5.6 s | −14.2 s (72%) |
| **total (serial)** | **115.2 s** | **35.1 s** | **−80.1 s (70%)** |

