### PR TITLE
[CK][VSA] Add thin sparse attention operator

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -121,6 +121,7 @@ else:
     from .ops.topk import *
     from .ops.topk_plain import topk_plain  # noqa: F401
     from .ops.mha import *
+    from .ops.vsa_sparse_attention import vsa_sparse_attention  # noqa: F401
     from .ops.gradlib import *
     from .ops.trans_ragged_layout import *
     from .ops.sample import *

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1289,6 +1289,29 @@
             "f'{AITER_META_DIR}/hsa/codegen.py -m fmha_v3_fwd --output_dir {{}}'"
         ]
     },
+    "module_vsa_sparse_attention": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/py_itfs_ck/vsa_sparse_attention_kernels.cu'",
+            "f'{AITER_CSRC_DIR}/pybind/vsa_sparse_attention_pybind.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-fbracket-depth=1024'",
+            "'-DCK_TILE_FMHA_FWD_FAST_EXP2=1'",
+            "f'-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={os.environ.get(\"CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\", 2)}'"
+        ],
+        "extra_ldflags": "None",
+        "extra_include": [
+            "f'{CK_DIR}/example/ck_tile'",
+            "f'{CK_DIR}/example/ck_tile/50_sparse_attn'",
+            "f'{CK_DIR}/include/ck_tile/ops/sparse_attn'"
+        ],
+        "verbose": "False",
+        "hip_clang_path": "os.environ.get('MHA_HIP_CLANG_PATH')",
+        "blob_gen_cmd": [
+            "f'{CK_DIR}/example/ck_tile/50_sparse_attn/generate.py -d fwd_vsa --receipt 600 --output_dir {{}}'"
+        ]
+    },
     "module_mha_fwd": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/kernels/mha_common.cu'",

--- a/aiter/ops/vsa_sparse_attention.py
+++ b/aiter/ops/vsa_sparse_attention.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import torch
+from torch import Tensor
+
+from ..jit.core import compile_ops
+from ..jit.utils.torch_guard import torch_compile_guard
+
+
+def _validate_vsa_inputs(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    block_lut: Tensor,
+    block_counts: Tensor,
+) -> None:
+    for name, tensor in (("q", q), ("k", k), ("v", v)):
+        if not isinstance(tensor, Tensor) or not tensor.is_cuda:
+            raise RuntimeError(f"{name} must be a GPU tensor")
+        if tensor.dim() != 4:
+            raise RuntimeError(f"{name} must have shape [B, H, S, D]")
+        if not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous BHSD")
+        if tensor.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError(f"{name} must have dtype float16 or bfloat16")
+
+    if q.device != k.device or q.device != v.device:
+        raise RuntimeError("q, k, and v must be on the same GPU")
+    if q.dtype != k.dtype or q.dtype != v.dtype:
+        raise RuntimeError("q, k, and v must have the same dtype")
+    if q.size(0) <= 0 or q.size(1) <= 0 or k.size(1) <= 0:
+        raise RuntimeError("batch size and head counts must be positive")
+    if q.size(0) != k.size(0) or q.size(0) != v.size(0):
+        raise RuntimeError("q, k, and v must have the same batch size")
+    if k.shape != v.shape:
+        raise RuntimeError("k and v must have the same shape")
+    if q.size(1) % k.size(1) != 0:
+        raise RuntimeError(
+            "the number of query heads must be divisible by the number of KV heads"
+        )
+    if q.size(3) != 128 or k.size(3) != 128:
+        raise RuntimeError(
+            "VSA sparse attention currently supports head dimension 128 only"
+        )
+    if q.size(2) <= 0 or k.size(2) <= 128:
+        raise RuntimeError(
+            "query length must be positive and key length must exceed 128"
+        )
+
+    for name, tensor in (("block_lut", block_lut), ("block_counts", block_counts)):
+        if not isinstance(tensor, Tensor) or not tensor.is_cuda:
+            raise RuntimeError(f"{name} must be a GPU tensor")
+        if tensor.device != q.device:
+            raise RuntimeError(f"{name} must be on the same GPU as q")
+        if tensor.dtype != torch.int32:
+            raise RuntimeError(f"{name} must have dtype int32")
+        if not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+
+    batch, query_heads, seqlen_q, _ = q.shape
+    query_blocks = (seqlen_q + 127) // 128
+    kv_blocks = (k.size(2) + 127) // 128
+    if block_lut.shape != (batch, query_heads, query_blocks, kv_blocks):
+        raise RuntimeError(
+            "block_lut must have shape [B, Hq, ceil(Sq/128), ceil(Sk/128)]"
+        )
+    if block_counts.shape != (batch, query_heads, query_blocks):
+        raise RuntimeError("block_counts must have shape [B, Hq, ceil(Sq/128)]")
+
+    min_count, max_count = torch.aminmax(block_counts)
+    if min_count.item() < 1:
+        raise RuntimeError("every query block must select at least one KV block")
+    if max_count.item() >= kv_blocks:
+        raise RuntimeError(
+            "block_counts must be smaller than the LUT row capacity; "
+            "the final slot is reserved for CK's lookahead"
+        )
+
+
+def _vsa_sparse_attention_fake(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    block_lut: Tensor,
+    block_counts: Tensor,
+) -> Tensor:
+    del k, v, block_lut, block_counts
+    return torch.empty_like(q)
+
+
+@compile_ops(
+    "module_vsa_sparse_attention",
+    fc_name="vsa_sparse_attention_fwd",
+    develop=True,
+)
+def _vsa_sparse_attention_fwd(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    block_lut: Tensor,
+    block_counts: Tensor,
+    out: Tensor,
+) -> None: ...
+
+
+@torch_compile_guard(gen_fake=_vsa_sparse_attention_fake)
+def vsa_sparse_attention(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    block_lut: Tensor,
+    block_counts: Tensor,
+) -> Tensor:
+    """Run VSA block-sparse attention on contiguous BHSD tensors.
+
+    ``block_lut`` stores one absolute K-block index followed by delta-encoded
+    indices for each 128-token Q block. ``block_counts`` gives the number of
+    active entries in each LUT row. The final LUT slot is reserved as a
+    lookahead sentinel by the current CK pipeline.
+    """
+    _validate_vsa_inputs(q, k, v, block_lut, block_counts)
+    out = torch.empty_like(q)
+    _vsa_sparse_attention_fwd(q, k, v, block_lut, block_counts, out)
+    return out

--- a/csrc/include/vsa_sparse_attention.h
+++ b/csrc/include/vsa_sparse_attention.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#pragma once
+
+#include "aiter_tensor.h"
+
+void vsa_sparse_attention_fwd(aiter_tensor_t& q,
+                              aiter_tensor_t& k,
+                              aiter_tensor_t& v,
+                              aiter_tensor_t& block_lut,
+                              aiter_tensor_t& block_counts,
+                              aiter_tensor_t& out);

--- a/csrc/py_itfs_ck/vsa_sparse_attention_kernels.cu
+++ b/csrc/py_itfs_ck/vsa_sparse_attention_kernels.cu
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include <cmath>
+
+#include "aiter_hip_common.h"
+#include "aiter_stream.h"
+#include "vsa_sparse_attention.h"
+#include "fmha_fwd_trek.hpp"
+
+namespace {
+
+constexpr int64_t kBlockSize = 128;
+
+void check_bhsd_tensor(const aiter_tensor_t& tensor, const char* name)
+{
+    AITER_CHECK(tensor.is_gpu(), name, " must be on a GPU");
+    AITER_CHECK(tensor.is_contiguous(), name, " must be contiguous BHSD");
+    AITER_CHECK(tensor.dim() == 4, name, " must have shape [B, H, S, D]");
+    AITER_CHECK(
+        tensor.dtype() == AITER_DTYPE_fp16 || tensor.dtype() == AITER_DTYPE_bf16,
+        name,
+        " must have dtype float16 or bfloat16");
+}
+
+bool same_shape(const aiter_tensor_t& lhs, const aiter_tensor_t& rhs)
+{
+    if(lhs.dim() != rhs.dim())
+        return false;
+    for(int index = 0; index < lhs.dim(); ++index)
+        if(lhs.size(index) != rhs.size(index))
+            return false;
+    return true;
+}
+
+} // namespace
+
+void vsa_sparse_attention_fwd(aiter_tensor_t& q,
+                              aiter_tensor_t& k,
+                              aiter_tensor_t& v,
+                              aiter_tensor_t& block_lut,
+                              aiter_tensor_t& block_counts,
+                              aiter_tensor_t& out)
+{
+    check_bhsd_tensor(q, "q");
+    check_bhsd_tensor(k, "k");
+    check_bhsd_tensor(v, "v");
+    check_bhsd_tensor(out, "out");
+
+    AITER_CHECK(q.device_id == k.device_id && q.device_id == v.device_id &&
+                    q.device_id == out.device_id,
+                "q, k, and v must be on the same GPU");
+    AITER_CHECK(q.dtype() == k.dtype() && q.dtype() == v.dtype() &&
+                    q.dtype() == out.dtype(),
+                "q, k, v, and out must have the same dtype");
+    AITER_CHECK(q.size(0) > 0 && q.size(1) > 0 && k.size(1) > 0,
+                "batch size and head counts must be positive");
+    AITER_CHECK(q.size(0) == k.size(0) && q.size(0) == v.size(0),
+                "q, k, and v must have the same batch size");
+    AITER_CHECK(same_shape(k, v), "k and v must have the same shape");
+    AITER_CHECK(same_shape(q, out), "out must have the same shape as q");
+    AITER_CHECK(q.size(1) % k.size(1) == 0,
+                "the number of query heads must be divisible by the number of KV heads");
+    AITER_CHECK(q.size(3) == 128 && k.size(3) == 128,
+                "VSA sparse attention currently supports head dimension 128 only");
+    AITER_CHECK(q.size(2) > 0 && k.size(2) > kBlockSize,
+                "query length must be positive and key length must exceed 128");
+
+    AITER_CHECK(block_lut.is_gpu() && block_counts.is_gpu(),
+                "block_lut and block_counts must be on a GPU");
+    AITER_CHECK(block_lut.device_id == q.device_id &&
+                    block_counts.device_id == q.device_id,
+                "block_lut and block_counts must be on the same GPU as q");
+    AITER_CHECK(block_lut.dtype() == AITER_DTYPE_i32 &&
+                    block_counts.dtype() == AITER_DTYPE_i32,
+                "block_lut and block_counts must have dtype int32");
+    AITER_CHECK(block_lut.is_contiguous() && block_counts.is_contiguous(),
+                "block_lut and block_counts must be contiguous");
+
+    const int64_t batch     = q.size(0);
+    const int64_t nhead_q   = q.size(1);
+    const int64_t nhead_k   = k.size(1);
+    const int64_t seqlen_q  = q.size(2);
+    const int64_t seqlen_k  = k.size(2);
+    const int64_t q_blocks  = (seqlen_q + kBlockSize - 1) / kBlockSize;
+    const int64_t kv_blocks = (seqlen_k + kBlockSize - 1) / kBlockSize;
+
+    AITER_CHECK(
+        block_lut.dim() == 4 && block_lut.size(0) == batch &&
+            block_lut.size(1) == nhead_q && block_lut.size(2) == q_blocks &&
+            block_lut.size(3) == kv_blocks,
+        "block_lut must have shape [B, Hq, ceil(Sq/128), ceil(Sk/128)]");
+    AITER_CHECK(
+        block_counts.dim() == 3 && block_counts.size(0) == batch &&
+            block_counts.size(1) == nhead_q && block_counts.size(2) == q_blocks,
+        "block_counts must have shape [B, Hq, ceil(Sq/128)]");
+
+    const auto mask = mask_info::decode("0", seqlen_q, seqlen_k);
+    fmha_vsa_fwd_traits traits{
+        128,
+        128,
+        q.dtype() == AITER_DTYPE_bf16 ? "bf16" : "fp16",
+        true,
+        mask.type};
+
+    fmha_vsa_fwd_args args{
+        q.data_ptr(),
+        k.data_ptr(),
+        v.data_ptr(),
+        block_lut.data_ptr(),
+        block_counts.data_ptr(),
+        out.data_ptr(),
+        static_cast<ck_tile::index_t>(seqlen_q),
+        static_cast<ck_tile::index_t>(seqlen_k),
+        static_cast<ck_tile::index_t>(batch),
+        static_cast<ck_tile::index_t>(seqlen_q),
+        128,
+        128,
+        static_cast<ck_tile::index_t>(nhead_q),
+        static_cast<ck_tile::index_t>(nhead_k),
+        1.0f / std::sqrt(128.0f),
+        static_cast<ck_tile::index_t>(q.stride(2)),
+        static_cast<ck_tile::index_t>(k.stride(2)),
+        static_cast<ck_tile::index_t>(v.stride(2)),
+        static_cast<ck_tile::index_t>(out.stride(2)),
+        static_cast<ck_tile::index_t>(q.stride(1)),
+        static_cast<ck_tile::index_t>(k.stride(1)),
+        static_cast<ck_tile::index_t>(v.stride(1)),
+        static_cast<ck_tile::index_t>(out.stride(1)),
+        static_cast<ck_tile::index_t>(q.stride(0)),
+        static_cast<ck_tile::index_t>(k.stride(0)),
+        static_cast<ck_tile::index_t>(v.stride(0)),
+        static_cast<ck_tile::index_t>(out.stride(0)),
+        mask.left,
+        mask.right,
+        static_cast<ck_tile::index_t>(mask.type)};
+
+    HipDeviceGuard device_guard(q.device_id);
+    const ck_tile::stream_config stream_config{aiter::getCurrentHIPStream()};
+    const float result = fmha_vsa_fwd(traits, args, stream_config);
+    AITER_CHECK(result >= 0, "no CK VSA kernel instance matched the input");
+}

--- a/csrc/pybind/vsa_sparse_attention_pybind.cu
+++ b/csrc/pybind/vsa_sparse_attention_pybind.cu
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "aiter_stream.h"
+#include "rocm_ops.hpp"
+#include "vsa_sparse_attention.h"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    m.def("vsa_sparse_attention_fwd",
+          &vsa_sparse_attention_fwd,
+          "vsa_sparse_attention_fwd(q, k, v, block_lut, block_counts, out)",
+          py::arg("q"),
+          py::arg("k"),
+          py::arg("v"),
+          py::arg("block_lut"),
+          py::arg("block_counts"),
+          py::arg("out"));
+}

--- a/op_tests/test_vsa_sparse_attention.py
+++ b/op_tests/test_vsa_sparse_attention.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import math
+from pathlib import Path
+
+import pytest
+import torch
+
+import aiter
+
+BLOCK_SIZE = 128
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def make_delta_lut(batch, heads, seqlen_q, seqlen_k, active_blocks, device):
+    q_blocks = math.ceil(seqlen_q / BLOCK_SIZE)
+    kv_blocks = math.ceil(seqlen_k / BLOCK_SIZE)
+    assert 1 <= active_blocks < kv_blocks
+
+    lut = torch.zeros(
+        batch, heads, q_blocks, kv_blocks, dtype=torch.int32, device=device
+    )
+    counts = torch.full(
+        (batch, heads, q_blocks),
+        active_blocks,
+        dtype=torch.int32,
+        device=device,
+    )
+    selected = torch.empty(
+        batch, heads, q_blocks, active_blocks, dtype=torch.int64, device=device
+    )
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(7)
+    for b in range(batch):
+        for h in range(heads):
+            for qb in range(q_blocks):
+                indices = (
+                    torch.randperm(kv_blocks, generator=generator, device=device)[
+                        :active_blocks
+                    ]
+                    .sort()
+                    .values
+                )
+                selected[b, h, qb] = indices
+                lut[b, h, qb, 0] = indices[0]
+                if active_blocks > 1:
+                    lut[b, h, qb, 1:active_blocks] = (indices[1:] - indices[:-1]).to(
+                        torch.int32
+                    )
+    return lut, counts, selected
+
+
+def masked_dense_reference(q, k, v, selected):
+    batch, heads, seqlen_q, _ = q.shape
+    seqlen_k = k.size(2)
+    q_blocks = math.ceil(seqlen_q / BLOCK_SIZE)
+
+    block_mask = torch.zeros(
+        batch, heads, seqlen_q, seqlen_k, dtype=torch.bool, device=q.device
+    )
+    for qb in range(q_blocks):
+        q_start = qb * BLOCK_SIZE
+        q_end = min(q_start + BLOCK_SIZE, seqlen_q)
+        for b in range(batch):
+            for h in range(heads):
+                for block in selected[b, h, qb].tolist():
+                    k_start = block * BLOCK_SIZE
+                    k_end = min(k_start + BLOCK_SIZE, seqlen_k)
+                    block_mask[b, h, q_start:q_end, k_start:k_end] = True
+
+    scores = torch.matmul(q.float(), k.float().transpose(-1, -2)) / math.sqrt(
+        q.size(-1)
+    )
+    probs = torch.softmax(scores.masked_fill(~block_mask, -torch.inf), dim=-1)
+    return torch.matmul(probs, v.float()).to(q.dtype)
+
+
+@pytest.mark.parametrize(
+    "source_path",
+    [
+        "csrc/include/vsa_sparse_attention.h",
+        "csrc/py_itfs_ck/vsa_sparse_attention_kernels.cu",
+        "csrc/pybind/vsa_sparse_attention_pybind.cu",
+    ],
+)
+def test_vsa_compiled_sources_are_torch_free(source_path):
+    source = (REPOSITORY_ROOT / source_path).read_text()
+    for forbidden in ("torch", "ATen", "TORCH_CHECK"):
+        assert forbidden not in source
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("active_blocks", [1, 3])
+def test_vsa_sparse_attention_parity(dtype, active_blocks):
+    device = torch.device("cuda")
+    batch, heads, seqlen_q, seqlen_k, dim = 1, 2, 257, 481, 128
+    torch.manual_seed(11)
+    q = torch.randn(batch, heads, seqlen_q, dim, device=device, dtype=dtype)
+    k = torch.randn(batch, heads, seqlen_k, dim, device=device, dtype=dtype)
+    v = torch.randn_like(k)
+    lut, counts, selected = make_delta_lut(
+        batch, heads, seqlen_q, seqlen_k, active_blocks, device
+    )
+
+    actual = aiter.vsa_sparse_attention(q, k, v, lut, counts)
+    expected = masked_dense_reference(q, k, v, selected)
+
+    torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
+
+
+def test_vsa_sparse_attention_uses_current_stream():
+    device = torch.device("cuda")
+    q = torch.randn(1, 1, 129, 128, device=device, dtype=torch.float16)
+    k = torch.randn(1, 1, 384, 128, device=device, dtype=torch.float16)
+    v = torch.randn_like(k)
+    lut, counts, selected = make_delta_lut(1, 1, 129, 384, 2, device)
+
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        actual = aiter.vsa_sparse_attention(q, k, v, lut, counts)
+    torch.cuda.current_stream().wait_stream(stream)
+
+    expected = masked_dense_reference(q, k, v, selected)
+    torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda q, k, v, lut, counts: (q.cpu(), k, v, lut, counts),
+            "GPU tensor",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q.squeeze(0),
+                k,
+                v,
+                lut,
+                counts,
+            ),
+            "shape \\[B, H, S, D\\]",
+        ),
+        (
+            lambda q, k, v, lut, counts: (q.float(), k, v, lut, counts),
+            "float16 or bfloat16",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q.transpose(2, 3),
+                k,
+                v,
+                lut,
+                counts,
+            ),
+            "contiguous BHSD",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k.to(torch.bfloat16),
+                v,
+                lut,
+                counts,
+            ),
+            "same dtype",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q[:0],
+                k[:0],
+                v[:0],
+                lut,
+                counts,
+            ),
+            "positive",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k[:, :0],
+                v[:, :0],
+                lut,
+                counts,
+            ),
+            "positive",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k.expand(2, -1, -1, -1).contiguous(),
+                v.expand(2, -1, -1, -1).contiguous(),
+                lut,
+                counts,
+            ),
+            "same batch size",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k,
+                v[:, :, :-1],
+                lut,
+                counts,
+            ),
+            "same shape",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q.expand(-1, 3, -1, -1).contiguous(),
+                k.expand(-1, 2, -1, -1).contiguous(),
+                v.expand(-1, 2, -1, -1).contiguous(),
+                lut,
+                counts,
+            ),
+            "divisible",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q[..., :64].contiguous(),
+                k,
+                v,
+                lut,
+                counts,
+            ),
+            "head dimension 128",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q[:, :, :0],
+                k,
+                v,
+                lut,
+                counts,
+            ),
+            "query length must be positive",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k[:, :, :128],
+                v[:, :, :128],
+                lut,
+                counts,
+            ),
+            "key length must exceed 128",
+        ),
+        (
+            lambda q, k, v, lut, counts: (q, k, v, lut.cpu(), counts),
+            "GPU tensor",
+        ),
+        (
+            lambda q, k, v, lut, counts: (q, k, v, lut, counts.cpu()),
+            "GPU tensor",
+        ),
+        (
+            lambda q, k, v, lut, counts: (q, k, v, lut.long(), counts),
+            "dtype int32",
+        ),
+        (
+            lambda q, k, v, lut, counts: (q, k, v, lut, counts.long()),
+            "dtype int32",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k,
+                v,
+                lut.expand(2, -1, -1, -1),
+                counts,
+            ),
+            "contiguous",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k,
+                v,
+                lut,
+                counts.expand(2, -1, -1),
+            ),
+            "contiguous",
+        ),
+        (
+            lambda q, k, v, lut, counts: (q, k, v, lut[..., :-1], counts),
+            "block_lut must have shape",
+        ),
+        (
+            lambda q, k, v, lut, counts: (q, k, v, lut, counts[..., :0]),
+            "block_counts must have shape",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k,
+                v,
+                lut,
+                counts.zero_(),
+            ),
+            "at least one KV block",
+        ),
+        (
+            lambda q, k, v, lut, counts: (
+                q,
+                k,
+                v,
+                lut,
+                counts.fill_(lut.size(-1)),
+            ),
+            "final slot is reserved",
+        ),
+    ],
+)
+def test_vsa_sparse_attention_validation(mutate, match):
+    device = torch.device("cuda")
+    q = torch.randn(1, 1, 128, 128, device=device, dtype=torch.float16)
+    k = torch.randn(1, 1, 384, 128, device=device, dtype=torch.float16)
+    v = torch.randn_like(k)
+    lut, counts, _ = make_delta_lut(1, 1, 128, 384, 1, device)
+
+    args = mutate(q, k, v, lut, counts)
+    with pytest.raises(RuntimeError, match=match):
+        aiter.vsa_sparse_attention(*args)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two GPUs")
+@pytest.mark.parametrize("tensor_name", ["k", "block_lut"])
+def test_vsa_sparse_attention_rejects_cross_device_inputs(tensor_name):
+    q = torch.randn(1, 1, 128, 128, device="cuda:0", dtype=torch.float16)
+    k = torch.randn(1, 1, 384, 128, device="cuda:0", dtype=torch.float16)
+    v = torch.randn_like(k)
+    lut, counts, _ = make_delta_lut(1, 1, 128, 384, 1, q.device)
+
+    if tensor_name == "k":
+        k = k.to("cuda:1")
+        v = v.to("cuda:1")
+    else:
+        lut = lut.to("cuda:1")
+
+    with pytest.raises(RuntimeError, match="same GPU"):
+        aiter.vsa_sparse_attention(q, k, v, lut, counts)


### PR DESCRIPTION
## Summary

- expose CK-Tile VSA block-sparse attention through AITER's Torch-free tensor ABI
- keep the public Python API unchanged: `aiter.vsa_sparse_attention(q, k, v, block_lut, block_counts) -> Tensor`
- allocate output and perform catchable input validation in Python before entering the compiled launcher
- reuse the pinned CK sparse-attention headers and receipt-600 codegen without vendoring generated kernels
- add source-level Torch/ATen exclusion tests plus comprehensive runtime validation tests

## Torch-free compiled path

The VSA `.cu`/`.h` sources now use `aiter_tensor_t`, `AITER_CHECK`, `HipDeviceGuard`, and `AITER_SET_STREAM_PYBIND`. They contain no Torch/ATen tensor APIs, `TORCH_CHECK`, `torch::`, `at::Tensor`, or Torch includes. `TORCH_EXTENSION_NAME` remains only as the standard pybind module-name macro.

## Scope and CK constraint

This remains VSA-only: no Jenga routing, Sparge, copied CK headers/codegen, generated instances, or binary fixtures. The pinned CK pipeline reads one lookahead LUT element, so every `block_counts` value must be smaller than the LUT row capacity; the Python wrapper validates this before launch.

## Validation

Hardware/software: 4× AMD Instinct MI308X (gfx942), PyTorch `2.9.1+gitff65f5b`, HIP `7.14.60850`, latest `main` CK pin `f33252ce`.

- clean JIT on the rebased commit: `module_vsa_sparse_attention` built in 27.4 s
- `pytest -q op_tests/test_vsa_sparse_attention.py -s`: **33 passed** in 51.70 s from a clean copy
- cached rerun: **33 passed** in 5.43 s with direct `.so` reuse
- FP16/BF16 masked-dense parity, active blocks 1/3, non-default HIP stream, cross-device inputs, and every validation branch passed; invalid inputs raised `RuntimeError` without abort
- source scan and regression test confirm the compiled VSA sources are Torch/ATen-free

Operator regression, shape `(1, 4, 4096, 128)`, identical seed/LUT, active blocks 1/3/16, five warmups and 30 measurements:

- Torch-free vs previous implementation output: max absolute error `0`, max relative error `0` in all 6 cases
- masked-dense max absolute error: FP16 `<= 9.77e-4`, BF16 `<= 1.5625e-2` (`atol=rtol=3e-2` passed)
- 50%-density public-call median: FP16 `0.2168 ms` vs `0.1733 ms`; BF16 `0.2188 ms` vs `0.1760 ms`. The ~0.043 ms fixed increase is the synchronous Python count-range validation needed to make invalid LUTs catchable rather than process-fatal; the CK device path and outputs are unchanged.

4-GPU paired Wan2.1-T2V-1.3B/xDiT validation used 50 steps, 480×832, 81 frames, Ulysses=4, guidance=6, flow shift=8, TeaCache disabled, 3 prompts × 3 seeds, and 3 Dense/VSA iterations per pair with warmup excluded:

- Dense mean: `65.36 s`; VSA mean: `62.18 s`; speedup: `1.0509×`
- previous pre-refactor paired speedup: `1.0477×`; no end-to-end regression
- mean PSNR: `30.543 dB`; mean SSIM: `0.95102`; mean LPIPS-Alex (frame stride 8): `0.01716`
- single-pair 50-step trace: mean sparse-step density `65.64%`; final latent cosine `0.999407`; final latent relative-L2 `0.03446`

The xDiT integration smoke also passed on four MI308X devices using the unchanged public API. Related integration: [xDiT PR #744](https://github.com/xdit-project/xDiT/pull/744).

## Test plan

- [x] Torch-free compiled source regression
- [x] Clean JIT build and cache reuse on latest main/CK pin
- [x] FP16/BF16 numerical parity and stream tests
- [x] Comprehensive catchable validation failures
- [x] Old/new operator output and latency comparison
- [x] Four-device xDiT smoke
- [x] 4-GPU paired Wan quality/performance and latent trace
- [x] One commit, sole author/committer, no co-author trailer