### PR TITLE
Repining CK to f33252ce and fix build/test errors

### DIFF
--- a/csrc/ck_deepgemm/include/deepgemm_common.cuh
+++ b/csrc/ck_deepgemm/include/deepgemm_common.cuh
@@ -176,7 +176,7 @@ void grouped_flatmm(KernelArguments& args, ck_stream_config& s)
         auto kargs = Kernel::MakeKernelArgs(args);
 
         const dim3 grids      = Kernel::GridSize(kargs);
-        constexpr dim3 blocks = Kernel::BlockSize();
+        const dim3 blocks     = Kernel::BlockSize();
 
         ck_tile::launch_kernel(
             s, ck_tile::make_kernel<FlatmmConfig::kBlockPerCu>(Kernel{}, grids, blocks, 0, kargs));

--- a/csrc/ck_tile_gemm_moe_2stages/include/moe_cktile2stages_common.cuh
+++ b/csrc/ck_tile_gemm_moe_2stages/include/moe_cktile2stages_common.cuh
@@ -246,7 +246,7 @@ void moe_gemm(const MoeFlatmmHostArgs& args, const ck_stream_config& s)
         auto kargs = Kernel::MakeKernelArgs(args);
 
         const dim3 grids      = Kernel::GridSize(kargs);
-        constexpr dim3 blocks = Kernel::BlockSize();
+        const dim3 blocks     = Kernel::BlockSize();
 
         // if(!Kernel::IsSupportedArgument(kargs))
         // {

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
@@ -144,7 +144,7 @@ float flatmm_calc(const ck_tile::ScaleFlatmmHostArgs<ScaleM, ScaleN>& args,
         auto kargs = Kernel::MakeKernelArgs(args);
 
         const dim3 grids      = Kernel::GridSize(kargs);
-        constexpr dim3 blocks = Kernel::BlockSize();
+        const dim3 blocks = Kernel::BlockSize();
 
         if(!Kernel::IsSupportedArgument(kargs))
         {

--- a/csrc/cpp_itfs/mha_fwd_batch_prefill.cu
+++ b/csrc/cpp_itfs/mha_fwd_batch_prefill.cu
@@ -49,7 +49,7 @@ float mha_batch_prefill(mha_batch_prefill_args args,
     int head_size_q  = args.hdim_q;
     int head_size_v  = args.hdim_v;
     bool has_dropout = args.p_drop > 0.f;
-    bool has_sink    = args.sink_size > 0;
+    bool has_sink    = args.sink_size > 0 || args.sink_ptr != nullptr;
 
     // The kUseGlobalLoad decision (>2GB KV cache → use `global_load_lds_*`
     // instead of SRD `buffer_load_*`) is made per-arm inside the auto-generated

--- a/csrc/py_itfs_ck/mha_fwd_kernels.cu
+++ b/csrc/py_itfs_ck/mha_fwd_kernels.cu
@@ -109,7 +109,7 @@ mha_fwd_args get_ck_fmha_fwd_args(bool has_lse,
                         static_cast<int>(bias_type),
                         has_lse,
                         static_cast<int>(qscale_type),
-                        mask.sink > 0, // has_sink
+                        (mask.sink > 0) || (sink_ptr != nullptr), // has_sink: true for streaming-sink window OR a learned per-head sink_ptr (e.g. gpt-oss, sink_size==0)
                         q.data_ptr(),
                         k.data_ptr(),
                         v.data_ptr(),

--- a/csrc/py_itfs_ck/mha_varlen_fwd_kernels.cu
+++ b/csrc/py_itfs_ck/mha_varlen_fwd_kernels.cu
@@ -136,7 +136,7 @@ mha_fwd_args get_ck_fmha_varlen_fwd_args(bool has_lse,
                         static_cast<int>(bias_type),
                         has_lse,
                         static_cast<int>(qscale_type),
-                        mask.sink > 0, // hsa_sink
+                        (mask.sink > 0) || (sink_ptr != nullptr), // has_sink: true for streaming-sink window OR a learned per-head sink_ptr (e.g. gpt-oss, sink_size==0)
                         q.data_ptr(),
                         k.data_ptr(),
                         v.data_ptr(),
@@ -496,7 +496,7 @@ mha_varlen_fwd(
         std::string mask_identify = "b:" + std::to_string(window_size_left) + "," + std::to_string(window_size_right) + "," + std::to_string(sink_size);
         mask = mask_info::decode(mask_identify, max_seqlen_q, max_seqlen_k); // local
     }
-    bool has_sink = mask.sink > 0;
+    bool has_sink = (mask.sink > 0) || sink_ptr.has_value();
     CHECK_SHAPE(q, total_q, num_heads, head_size_q);
     if (!paged_KV) {
         const int total_k = k.size(0);


### PR DESCRIPTION
## Motivation

Update Composable Kernel submodule to the latest version.

## Technical Details

Pin CK to commit f33252ce
Fix BlockSize type to align with CK
Fix GTPOSS test regression.
Fix ATOM Qwen test regression.

## Test Plan
ci:all
Qwen3-Next-80B-A3B-Thinking
Qwen3.5-397B-A17B-FP8 MTP, 
Qwen3.5-397B-A17B-MXFP4 

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
