### PR TITLE
test: use flydsl==0.3.0.dev20260725+7f363ef from devreleases for CI v…

### DIFF
--- a/.github/requirements/triton-test.txt
+++ b/.github/requirements/triton-test.txt
@@ -8,7 +8,8 @@ pybind11==3.0.1
 ninja==1.11.1.4
 psutil
 packaging
-flydsl==0.2.4
+--find-links https://rocm.frameworks-devreleases.amd.com/whl/gfx942-gfx950/flydsl/
+flydsl==0.3.0.dev20260725+7f363ef
 
 # Test deps.
 pandas==2.2.3

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+from importlib.metadata import version
+
+EXPECTED_FLYDSL_VERSION = "0.3.0.dev20260725+7f363ef"
+
+
+def pytest_configure(config):
+    v = version("flydsl")
+    if v != EXPECTED_FLYDSL_VERSION:
+        raise RuntimeError(
+            f"flydsl version mismatch: installed {v}, expected {EXPECTED_FLYDSL_VERSION}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "psutil",
     "ninja",
     "pandas",
-    "flydsl==0.2.4"
+    "flydsl==0.3.0.dev20260725+7f363ef"
 ]
 
 [tool.setuptools_scm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ pyyaml==6.0.3
 einops==0.8.2
 pybind11==3.0.4
 ninja==1.13.0
-flydsl==0.2.4
+--find-links https://rocm.frameworks-devreleases.amd.com/whl/gfx942-gfx950/flydsl/
+flydsl==0.3.0.dev20260725+7f363ef

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 OPT_COMPILER_CONFIG = os.path.join(this_dir, "aiter", "jit", "optCompilerConfig.json")
 PACKAGE_NAME = "amd-aiter"
 
-FLYDSL_VERSION = "flydsl==0.2.4"
+FLYDSL_VERSION = "flydsl==0.3.0.dev20260725+7f363ef"
 
 BUILD_TARGET = os.environ.get("BUILD_TARGET", "auto")
-PREBUILD_KERNELS = int(os.environ.get("PREBUILD_KERNELS", 0))
+PREBUILD_KERNELS = int(os.environ.get("PREBUILD_KERNELS", "0"))
 PRETUNE_MODULES = os.environ.get("PRETUNE_MODULES", "")
 ENABLE_CK = int(os.environ.get("ENABLE_CK", "1"))
 IS_WINDOWS = sys.platform == "win32"


### PR DESCRIPTION
…alidation

Point aiter at the flydsl dev wheel built from FlyDSL commit 7f363ef (dynamic control-flow Python-container carry work) to check it does not break aiter via CI. Install it with --find-links from the AMD devreleases mirror; conftest.py verifies the exact version at pytest startup. Mirrors the earlier dev-wheel pin (19cd1ccb5).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
