### PR TITLE
Limit attention kernel dispatch to supported GPUs

### DIFF
--- a/aiter/ops/attention.py
+++ b/aiter/ops/attention.py
@@ -169,6 +169,9 @@ def _should_use_asm_kernel(
     kv_cache_tensor_dtype: torch.dtype,
     high_precision: int,
 ) -> bool:
+    if get_gfx() not in ("gfx942", "gfx950"):
+        return False
+
     # ASM kernel only supports head_size == 128; all other head sizes use HIP.
     if head_size != 128:
         return False

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -3593,32 +3593,32 @@ def flash_attn_varlen_func(
             sink_ptr,
         )
 
-    # FlyDSL path returns result if supported, None otherwise.
-    from .flydsl.fmha_kernels import flydsl_flash_attn_varlen_func
+    if get_gfx() == "gfx1201":
+        from .flydsl.fmha_kernels import flydsl_flash_attn_varlen_func
 
-    _flydsl_result = flydsl_flash_attn_varlen_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        max_seqlen_q,
-        max_seqlen_k,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        return_lse=return_lse,
-        dropout_p=dropout_p,
-        window_size=window_size,
-        bias=bias,
-        alibi_slopes=alibi_slopes,
-        deterministic=deterministic,
-        return_attn_probs=return_attn_probs,
-        block_table=block_table,
-        out=out,
-        sink=sink_ptr,
-    )
-    if _flydsl_result is not None:
-        return _flydsl_result
+        flydsl_result = flydsl_flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            return_lse=return_lse,
+            dropout_p=dropout_p,
+            window_size=window_size,
+            bias=bias,
+            alibi_slopes=alibi_slopes,
+            deterministic=deterministic,
+            return_attn_probs=return_attn_probs,
+            block_table=block_table,
+            out=out,
+            sink=sink_ptr,
+        )
+        if flydsl_result is not None:
+            return flydsl_result
 
     if not ENABLE_CK:
         from .triton.attention.mha import (

--- a/op_tests/test_pa_dispatch.py
+++ b/op_tests/test_pa_dispatch.py
@@ -1,0 +1,21 @@
+import torch
+
+from aiter.ops import attention
+
+
+def test_paged_attention_asm_dispatch_matches_packaged_architectures(monkeypatch):
+    args = (256, 4, 128, torch.bfloat16, 1)
+
+    for arch in ("gfx942", "gfx950"):
+        monkeypatch.setattr(attention, "get_gfx", lambda arch=arch: arch)
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+        monkeypatch.setattr(
+            torch.cuda,
+            "get_device_properties",
+            lambda _: type("Properties", (), {"multi_processor_count": 104})(),
+        )
+        assert attention._should_use_asm_kernel(*args)
+
+    for arch in ("gfx90a", "gfx1100", "gfx1201", "gfx1250"):
+        monkeypatch.setattr(attention, "get_gfx", lambda arch=arch: arch)
+        assert not attention._should_use_asm_kernel(*args)


### PR DESCRIPTION
## What this changes

Keep attention kernel selection within the GPU architectures supported by each
implementation:

- Paged-attention assembly kernels are selected only on gfx942 and gfx950,
  where AITER ships the required binaries.
- The current variable-length FlyDSL kernel is imported only on gfx1201, which
  is the architecture it supports.
- Other GPUs continue through the existing HIP, CK, or Triton fallback.

Previously, a sufficiently large paged-attention batch selected the assembly
path on gfx90a. Since no gfx90a binary is packaged, vLLM failed while capturing
its decode graphs. The FlyDSL import had a similar problem: it happened before
the architecture check inside the kernel wrapper.

The open-PR search did not find another change addressing these two dispatch
problems.

## Results

Tested on an MI250X (gfx90a) with BF16 MQA, four query heads per rank, one KV
head, and a 128-dimension head:

| Context | Existing Triton decode | AITER HIP fallback |
| --- | ---: | ---: |
| 128K | 2.450 ms | 0.621 ms |
| 256K | 4.595 ms | 1.205 ms |

I also started NVIDIA Nemotron 3 Super with vLLM at 128K context and TP8. Full
graph capture completed, and 1K, 8K, and 40K prompt smoke tests all returned
successfully. The 40K case exercises a paged continuation after the initial
prefill.

Validation:

```text
ruff check --ignore E712,F841 \
  aiter/ops/attention.py aiter/ops/mha.py op_tests/test_pa_dispatch.py
python -m py_compile \
  aiter/ops/attention.py aiter/ops/mha.py op_tests/test_pa_dispatch.py
python -m pytest -q op_tests/test_pa_dispatch.py
# 1 passed
```

The change was prepared with AI assistance and reviewed and tested by the
submitter.
