### PR TITLE
Specialize batch prefill for paged KV layout

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -1420,11 +1420,11 @@ def cmdGenFunc_mha_batch_prefill(
     # Per-page descale for KV_BLOCKSCALE mode (Q per-tensor, K/V per-page)
     # Mutually exclusive with k_descale/v_descale
     kv_block_descale: Optional[Tensor] = None,  # [num_block, num_kv_head, 2]
-    sink_ptr: Optional[Tensor] = None,
-    gen: Optional[Generator] = None,
     kv_last_page_lens: Optional[Tensor] = None,
     block_table: Optional[Tensor] = None,
     seqlen_k: Optional[Tensor] = None,
+    sink_ptr: Optional[Tensor] = None,
+    gen: Optional[Generator] = None,
 ):
     # causal=true is the same as causal=false in this case
     causal = is_causal
@@ -1448,6 +1448,22 @@ def cmdGenFunc_mha_batch_prefill(
             filter_fwd += "fp8bf16*"
         else:
             raise NotImplementedError("Unsupported output dtype for FP8 MHA")
+    if k.dim() == 5:
+        page_size = k.size(-2)
+        kv_memory_layout = "vectorized"
+    elif k.dim() == 4:
+        page_size = k.size(1)
+        kv_memory_layout = "linear"
+    elif k.dim() == 3:
+        page_size = 1
+        kv_memory_layout = "linear"
+    else:
+        raise ValueError(f"Unsupported batch-prefill K-cache rank: {k.dim()}")
+    if page_size not in (1, 16, 1024, 2048):
+        raise ValueError(f"Unsupported batch-prefill page size: {page_size}")
+    kv_lookup_table = "vllm" if block_table is not None else "sglang"
+    md_name += f"_ps{page_size}_{kv_memory_layout}_{kv_lookup_table}"
+    filter_fwd += f"_ps{page_size}*"
     if 0.0 < logits_soft_cap:
         md_name += "_logits"
         filter_fwd += "_logits*"
@@ -1500,6 +1516,7 @@ def cmdGenFunc_mha_batch_prefill(
     else:
         md_name += "_nsink"
         filter_fwd += "_nsink*"
+    filter_fwd += f"_{kv_memory_layout}_{kv_lookup_table}*"
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d batch_prefill "
         "--receipt 200 --filter {} --output_dir {{}}".format(filter_fwd)
@@ -3704,11 +3721,11 @@ def mha_batch_prefill_fake_tensors(
     v_descale: Optional[torch.Tensor] = None,  # [1] per-tensor V descale
     # Per-page descale for KV_BLOCKSCALE mode (mutually exclusive with k_descale/v_descale)
     kv_block_descale: Optional[torch.Tensor] = None,  # [num_block, num_kv_head, 2]
-    sink_ptr: Optional[Tensor] = None,
-    gen: Optional[Generator] = None,
     kv_last_page_lens: Optional[torch.Tensor] = None,
     block_table: Optional[torch.Tensor] = None,
     seqlen_k: Optional[torch.Tensor] = None,
+    sink_ptr: Optional[Tensor] = None,
+    gen: Optional[Generator] = None,
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     # ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     is_vectorized = k.dim() == 5 and v.dim() == 5

--- a/op_tests/test_batch_prefill.py
+++ b/op_tests/test_batch_prefill.py
@@ -888,7 +888,7 @@ def test_batch_prefill_page_size_1_linear_sglang(
         (8192, 8192),
     ],
 )
-@pytest.mark.parametrize("page_size", [16, 1024])
+@pytest.mark.parametrize("page_size", [16, 1024, 2048])
 @pytest.mark.parametrize("num_qo_heads,num_kv_heads", [(8, 1), (16, 1)])
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("causal", [False, True])
@@ -1710,7 +1710,7 @@ def reference_attention_kv_blockscale(
 
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("kv_cache_size_gb", [4.5])
-@pytest.mark.parametrize("page_size", [1, 16, 1024])
+@pytest.mark.parametrize("page_size", [1, 16, 1024, 2048])
 @pytest.mark.parametrize("num_qo_heads,num_kv_heads", [(8, 8), (16, 8)])
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("causal", [False, True])
@@ -2591,11 +2591,11 @@ parser.add_argument(
     "--pagesize",
     type=int,
     const=None,
-    choices=[1, 16, 1024],
-    default=[1, 16, 1024],
+    choices=[1, 16, 1024, 2048],
+    default=[1, 16, 1024, 2048],
     nargs="*",
     help="""page size.
-    e.g.: -p 1024""",
+    e.g.: -p 2048""",
 )
 parser.add_argument(
     "-q",


### PR DESCRIPTION
## What this changes

Specialize the JIT batch-prefill build for the page size, KV memory layout, and
page-table layout used by the call. It also adds 2048-token pages to the batch
prefill tests and command-line test runner.

This lets vLLM send a shuffled paged KV cache directly to CK batch prefill
instead of gathering a long prefix into a temporary contiguous buffer.

The signature order is aligned with the registered operator schema so the
generated module and its fake implementation expose the same optional
arguments.

This draft depends on ROCm/composable_kernel#3760. I will update AITER's CK
submodule after that change is available on a compatible CK revision.

## Results

MI250X, BF16 MQA, four query heads, one KV head, head dimension 128:

| Context | Existing Triton paged prefill | CK batch prefill | Speedup |
| --- | ---: | ---: | ---: |
| 128K | 141.54 ms | 83.24 ms | 1.70x |
| 256K | 284.62 ms | 168.19 ms | 1.69x |

The isolated 2048-page correctness run covered both contiguous and strided
caches:

```text
python op_tests/test_batch_prefill.py \
  -p 2048 -c true -l 0 -d bf16 -s 8192 \
  -q 4 -k 1 -t vllm --kv_layout vectorized \
  --input_dtype bf16 --quant_method none \
  --head_dim 128 --return_lse false

Total: 2, Passed: 2, Skipped: 0
```

I also ran an end-to-end 128K TP8 serving test with NVIDIA Nemotron 3 Super.
All requests completed successfully, including a 40K prompt that exercises a
paged continuation.

The open-PR search did not find another batch-prefill change for 2048-token
pages.

The change was prepared with AI assistance and reviewed and tested by the
submitter.
