### PR TITLE
Fix AITER JIT builds on gfx90a

### DIFF
--- a/csrc/include/opus/opus.hpp
+++ b/csrc/include/opus/opus.hpp
@@ -1302,24 +1302,44 @@ template<> struct finfo<e8m0_t> {
 #pragma clang diagnostic ignored "-Wc++20-extensions"
 template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x2(const S& s, number<sel> = {}) {
+#if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    return fp8x2_t{};
+#else
     int w ; w = __builtin_amdgcn_cvt_pk_fp8_f32(s[0], s[1], w, sel);
     return __builtin_bit_cast(fp8x2_t, static_cast<short>(w));
+#endif
 }
 template<typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x4(const S& s) {
+#if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    return fp8x4_t{};
+#else
     int w ; w = __builtin_amdgcn_cvt_pk_fp8_f32(s[0], s[1], w, 0); w = __builtin_amdgcn_cvt_pk_fp8_f32(s[2], s[3], w, 1);
     return __builtin_bit_cast(fp8x4_t, w);
+#endif
 }
 template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp8x2_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x2(const S& s, number<sel> = {}) {
+#if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    return fp32x2_t{0.0f, 0.0f};
+#else
     union { int bitwise; S f8_packs[2]; } value; value.f8_packs[0] = s;
     return __builtin_amdgcn_cvt_pk_f32_fp8(value.bitwise, sel);
+#endif
 }
 template<typename S, std::enable_if_t<std::is_same_v<S, fp8x4_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x4(const S& s) {
+#if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    return fp32x4_t{0.0f, 0.0f, 0.0f, 0.0f};
+#else
     int bitwise = __builtin_bit_cast(int, s);
     auto x = __builtin_amdgcn_cvt_pk_f32_fp8(bitwise, 0); auto y = __builtin_amdgcn_cvt_pk_f32_fp8(bitwise, 1);
     return fp32x4_t{x[0], x[1], y[0], y[1]};
+#endif
 }
 
 namespace impl {

--- a/csrc/include/opus/opus.hpp
+++ b/csrc/include/opus/opus.hpp
@@ -1303,7 +1303,7 @@ template<> struct finfo<e8m0_t> {
 template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x2(const S& s, number<sel> = {}) {
 #if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
-    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    __builtin_trap();
     return fp8x2_t{};
 #else
     int w ; w = __builtin_amdgcn_cvt_pk_fp8_f32(s[0], s[1], w, sel);
@@ -1313,7 +1313,7 @@ OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x2(const S& s, number<sel> = 
 template<typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x4(const S& s) {
 #if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
-    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    __builtin_trap();
     return fp8x4_t{};
 #else
     int w ; w = __builtin_amdgcn_cvt_pk_fp8_f32(s[0], s[1], w, 0); w = __builtin_amdgcn_cvt_pk_fp8_f32(s[2], s[3], w, 1);
@@ -1323,7 +1323,7 @@ OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x4(const S& s) {
 template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp8x2_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x2(const S& s, number<sel> = {}) {
 #if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
-    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    __builtin_trap();
     return fp32x2_t{0.0f, 0.0f};
 #else
     union { int bitwise; S f8_packs[2]; } value; value.f8_packs[0] = s;
@@ -1333,7 +1333,7 @@ OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x2(const S& s, number<sel> = 
 template<typename S, std::enable_if_t<std::is_same_v<S, fp8x4_t>, bool> = true>
 OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x4(const S& s) {
 #if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
-    static_assert(!std::is_same_v<S, S>, "packed FP8 conversion is not supported on this architecture");
+    __builtin_trap();
     return fp32x4_t{0.0f, 0.0f, 0.0f, 0.0f};
 #else
     int bitwise = __builtin_bit_cast(int, s);

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -87,20 +87,24 @@ static void _all_reduce(fptr_t _fa, void* inp, void* out,
         break;
     }
     case AITER_DTYPE_fp16: {
+#if defined(__gfx90a__)
+        if(open_fp8_quant && numel >= 128 * 2048)
+            throw std::runtime_error(
+                "FP8 quantized all-reduce is not supported on gfx90a");
+#else
         if(open_fp8_quant && numel >= 128 * 2048)
         {
             fa->runFp8QuantKernel<opus::fp16_t>(stream,
                                         reinterpret_cast<opus::fp16_t*>(inp),
                                         reinterpret_cast<opus::fp16_t*>(out),
                                         numel);
+            break;
         }
-        else
-        {
-            fa->allreduce<opus::fp16_t>(stream,
-                                reinterpret_cast<opus::fp16_t*>(inp),
-                                reinterpret_cast<opus::fp16_t*>(out),
-                                numel, use_new, is_broadcast_reg_outptr);
-        }
+#endif
+        fa->allreduce<opus::fp16_t>(stream,
+                            reinterpret_cast<opus::fp16_t*>(inp),
+                            reinterpret_cast<opus::fp16_t*>(out),
+                            numel, use_new, is_broadcast_reg_outptr);
         break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))

--- a/csrc/kernels/custom_kernels.cu
+++ b/csrc/kernels/custom_kernels.cu
@@ -30,6 +30,10 @@
 #define __HIP__MI350_MI300_MI250__
 #endif
 
+#if defined(__HIPCC__) && (defined(__gfx942__) || defined(__gfx950__))
+#define __HIP__FP8_MFMA__
+#endif
+
 #if defined(NDEBUG)
 #undef NDEBUG
 #include <assert.h>
@@ -1769,7 +1773,7 @@ void wvSplitK_(void* in_a,
     });
 }
 
-#if defined(__HIP__MI350_MI300_MI250__) // TODO: Add NAVI support
+#if defined(__HIP__FP8_MFMA__) // TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -1966,7 +1970,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) wvSplitKQ_hf_sml_(const int K,
         m += CuCount * _WvPrGrp * YTILE;
     }
 }
-#else  // !defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#else  // !defined(__HIP__FP8_MFMA__) TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -1988,9 +1992,9 @@ __global__ void wvSplitKQ_hf_sml_(const int K,
 {
     UNREACHABLE_CODE
 }
-#endif // defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#endif // defined(__HIP__FP8_MFMA__) TODO: Add NAVI support
 
-#if defined(__HIP__MI350_MI300_MI250__) // TODO: Add NAVI support
+#if defined(__HIP__FP8_MFMA__) // TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -2183,7 +2187,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) wvSplitKQ_hf_(const int K,
         m += CuCount * _WvPrGrp * YTILE;
     }
 }
-#else  // !defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#else  // !defined(__HIP__FP8_MFMA__) TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -2205,7 +2209,7 @@ __global__ void wvSplitKQ_hf_(const int K,
 {
     UNREACHABLE_CODE
 }
-#endif // defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#endif // defined(__HIP__FP8_MFMA__) TODO: Add NAVI support
 
 void wvSplitKQ_(void* in_a,
                 void* in_b,


### PR DESCRIPTION
## What

- Build FP8 MFMA skinny GEMMs only on architectures that provide those
  instructions.
- Keep the packed FP8 helper templates parseable on other architectures.
  Unsupported device-side conversion calls trap instead of silently returning
  bad data.
- Reject FP8-quantized all-reduce on gfx90a without instantiating unsupported
  FP8 conversion code.

## Why

`module_custom` currently groups MI250 with MI300 and MI350 for its FP8
kernels. On gfx90a, that makes HIP compile FP8 builtins and MFMA instructions
the architecture does not provide. The affected JIT modules then fail to
build, including their supported BF16 kernels.

The architecture guard leaves the existing gfx942 and gfx950 FP8 paths
unchanged.

## Testing

- Built `module_custom` and `module_custom_all_reduce` for gfx90a with ROCm 7.1
  on MI250X.
- Cross-built `module_custom` for gfx942 with the same source.
- Compiled an `opus.hpp` probe for both gfx90a and gfx942.
- `git diff --check`
