### PR TITLE
refactor(flydsl): vendor buffer_ops/vector into aiter

### DIFF
--- a/aiter/ops/flydsl/causal_conv1d_flydsl.py
+++ b/aiter/ops/flydsl/causal_conv1d_flydsl.py
@@ -10,11 +10,12 @@ try:
     import flydsl.compiler as flyc
     import flydsl.expr as fx
     from flydsl.expr import arith
-    from flydsl.expr.typing import T, Int32
-    from flydsl.expr import buffer_ops
+    from flydsl.expr.typing import Int32, T
+
+    from aiter.ops.flydsl.kernels import buffer_ops
 
     _FLYDSL_AVAILABLE = True
-except Exception:  # pragma: no cover - flydsl optional
+except Exception:  # pragma: no cover - flydsl optional  # noqa: BLE001
     _FLYDSL_AVAILABLE = False
 
 
@@ -577,7 +578,7 @@ def causal_conv1d_split_qkv_flydsl_fn(
     if compiled is None:
         try:
             launcher._fast_compiled = flyc.compile(launcher, *launch_args)
-        except Exception:
+        except Exception:  # noqa: BLE001
             launcher._fast_compiled = False  # fall back permanently
             launcher(*launch_args)
     elif compiled is not False:

--- a/aiter/ops/flydsl/kernels/buffer_ops.py
+++ b/aiter/ops/flydsl/kernels/buffer_ops.py
@@ -1,0 +1,684 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+# Modifications Copyright (C) 2026 Advanced Micro Devices, Inc.
+
+"""AMD buffer load/store operations, vendored into aiter.
+
+flydsl moved these from ``flydsl.expr.buffer_ops`` to its repo-level
+``kernels/common/``, which its wheel does not ship, so aiter keeps an
+equivalent copy here. Only published flydsl APIs are used.
+
+Buffer instructions are an AMD hardware feature (buffer resource descriptor
+plus ROCDL intrinsics) providing out-of-bounds protection and better memory
+throughput; plain memref load/store is not a substitute.
+
+Upstream: FlyDSL ``kernels/common/buffer_ops.py`` @ ROCm/FlyDSL#880.
+Behavior matches upstream; formatting and type annotations differ only to
+satisfy aiter's lint.
+
+Example:
+    >>> from aiter.ops.flydsl.kernels import buffer_ops
+    >>> from flydsl.expr import arith
+    >>>
+    >>> rsrc = buffer_ops.create_buffer_resource(A)
+    >>> offset = row * arith.index(4096) + col
+    >>> data = buffer_ops.buffer_load(rsrc, offset, vec_width=4)
+    >>> buffer_ops.buffer_store(data, rsrc, offset)
+"""
+
+from __future__ import annotations
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import arith as std_arith
+from flydsl._mlir.dialects import llvm, rocdl
+from flydsl._mlir.extras import types as T
+from flydsl.expr.meta import dsl_loc_tracing
+from flydsl.runtime.device import is_rdna_arch
+
+
+def _get_buffer_flags(arch=None):
+    """Get AMD buffer resource descriptor (V#) flags word (bits 127:96).
+
+    Constructs the 32-bit flags field for rocdl.make.buffer.rsrc, following the
+    same logic as LLVM's AMDGPUToROCDL makeBufferRsrc():
+      https://github.com/llvm/llvm-project/blob/main/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+
+    Bit layout (common to all architectures):
+      bits [11:0]  - DST_SEL: ignored by raw buffer intrinsics
+      bits [14:12] - DATA_FORMAT: must be nonzero, 7 = float
+      bits [18:15] - NUM_FORMAT:  must be nonzero, 4 = 32-bit
+      bit  [19]    - In nested heap (0)
+      bit  [20]    - Behavior on unmap (0 = return 0 / ignore)
+      bits [22:21] - Index stride for swizzles (0)
+      bit  [23]    - Add thread ID (0)
+      bit  [24]    - Reserved: must be 1 on RDNA, 0 on CDNA
+      bits [26:25] - Reserved (0)
+      bit  [27]    - Non-volatile (CDNA only, 0)
+      bits [29:28] - OOB_SELECT (RDNA only): 0=structured, 2=none, 3=check offset
+      bits [31:30] - Type (must be 0)
+
+    CDNA (gfx9xx):    (7 << 12) | (4 << 15)                         = 0x20070
+    RDNA (gfx10+):    (7 << 12) | (4 << 15) | (1 << 24) | (2 << 28) = 0x21020070
+      - bit 24 set to 1 (required on RDNA)
+      - OOB_SELECT=2 (no bounds checking, matching LLVM boundsCheck=false)
+    """
+    import os
+
+    if arch is None:
+        arch = os.environ.get("FLYDSL_GPU_ARCH")
+    flags = (7 << 12) | (4 << 15)
+    if is_rdna_arch(arch):
+        flags |= 1 << 24  # reserved bit, must be 1 on RDNA
+        flags |= 2 << 28  # OOB_SELECT = 2 (no bounds checking)
+    return flags
+
+
+__all__ = [
+    "BufferResourceDescriptor",
+    "buffer_load",
+    "buffer_store",
+    "create_buffer_resource",
+    "create_buffer_resource_from_addr",
+    "create_llvm_ptr",
+    "extract_base_index",
+    "get_element_ptr",
+]
+
+
+def _unwrap_value(value):
+    """Recursively unwrap ArithValue or similar wrappers to get the actual MLIR value.
+
+    Handles:
+    - FlyDSL ArithValue (has ._value)
+    - flyc DSL Numeric like fx.Int32 (has .ir_value() method)
+    - flyc ArithValue (is already ir.Value subclass)
+    """
+    # DSL Numeric (Int32, Float32, etc.) — use ir_value() to materialize
+    if hasattr(value, "ir_value") and not isinstance(value, ir.Value):
+        return value.ir_value()
+    max_depth = 10  # Safety limit
+    depth = 0
+    while depth < max_depth and not isinstance(value, ir.Value):
+        if hasattr(value, "_value"):
+            value = value._value
+        elif hasattr(value, "value"):
+            value = value.value
+        else:
+            break
+        depth += 1
+    return value
+
+
+@dsl_loc_tracing
+def _create_i32_constant(value: int) -> ir.Value:
+    """Create i32 constant using standard MLIR arith dialect."""
+    i32_type = T.i32()
+    if value > 0x7FFFFFFF:
+        value = int(value - 2**32)
+    attr = ir.IntegerAttr.get(i32_type, value)
+    op = std_arith.ConstantOp(i32_type, attr)
+    return _unwrap_value(op.result)
+
+
+@dsl_loc_tracing
+def _create_i16_constant(value: int) -> ir.Value:
+    """Create i16 constant using standard MLIR arith dialect."""
+    i16_type = T.i16()
+    attr = ir.IntegerAttr.get(i16_type, value)
+    op = std_arith.ConstantOp(i16_type, attr)
+    return _unwrap_value(op.result)
+
+
+@dsl_loc_tracing
+def _create_i64_constant(value: int) -> ir.Value:
+    """Create i64 constant using standard MLIR arith dialect."""
+    i64_type = T.i64()
+    attr = ir.IntegerAttr.get(i64_type, value)
+    op = std_arith.ConstantOp(i64_type, attr)
+    return _unwrap_value(op.result)
+
+
+@dsl_loc_tracing
+def _ptr8_to_v4i32(ptr8_val) -> ir.Value:
+    """Reinterpret a buffer resource (!llvm.ptr<8>) as a <4 x i32> vector.
+
+    Required by the scalar ``s.buffer.load`` intrinsic, whose resource operand is
+    a v4i32 rather than the opaque buffer pointer used by the vector path.
+    """
+    i128_ty = ir.IntegerType.get_signless(128)
+    v4i32_ty = ir.VectorType.get([4], ir.IntegerType.get_signless(32))
+    i128_val = llvm.ptrtoint(i128_ty, _unwrap_value(ptr8_val))
+    return llvm.bitcast(v4i32_ty, i128_val)
+
+
+@dsl_loc_tracing
+def create_llvm_ptr(value, address_space: int = 0) -> ir.Value:
+    """Create an LLVM pointer from an integer or index value."""
+    value = _unwrap_value(value)
+    if isinstance(value.type, ir.IndexType):
+        i64_type = T.i64()
+        value = _unwrap_value(std_arith.IndexCastOp(i64_type, value).result)
+    ptr_type = ir.Type.parse(f"!llvm.ptr<{address_space}>")
+    return llvm.IntToPtrOp(ptr_type, value).result
+
+
+@dsl_loc_tracing
+def extract_base_index(tensor, address_space: int = 1) -> ir.Value:
+    """Extract the base address of a fly.memref as an index value.
+
+    Inverse of :func:`create_llvm_ptr` (index -> ptr). Useful when ISA
+    requires a raw pointer instead of a buffer resource descriptor
+    (e.g. global_atomic_pk_add_bf16 on gfx942).
+    """
+    from flydsl._mlir.dialects import fly as _fly
+    from flydsl._mlir.dialects import memref as _memref
+
+    raw = _unwrap_value(tensor)
+    try:
+        ir.MemRefType(raw.type)
+        return _memref.extract_aligned_pointer_as_index(raw)
+    except ValueError:
+        pass
+
+    ptr_type = ir.Type.parse(f"!llvm.ptr<{address_space}>")
+    ptr = _fly.extract_aligned_pointer_as_index(ptr_type, raw)
+    i64_val = llvm.PtrToIntOp(ir.IntegerType.get_signless(64), ptr).result
+    return _unwrap_value(std_arith.IndexCastOp(ir.IndexType.get(), i64_val).result)
+
+
+@dsl_loc_tracing
+def get_element_ptr(
+    base_ptr,
+    byte_offset: int | ir.Value | None = None,
+    static_byte_offset: int = 0,
+    elem_type: ir.Type | None = None,
+    no_wrap_flags=None,
+) -> ir.Value:
+    """Build an LLVM GEP from a base pointer plus byte offsets."""
+    _gep_dynamic_index_sentinel = -(2**31)
+
+    base_ptr = _unwrap_value(base_ptr)
+    if not isinstance(static_byte_offset, int):
+        raise TypeError(
+            f"static_byte_offset must be int, got {type(static_byte_offset).__name__}"
+        )
+    if elem_type is None:
+        elem_type = T.i8()
+    elif callable(elem_type):
+        elem_type = elem_type()
+
+    if byte_offset is None:
+        dynamic_indices = []
+        raw_constant_indices = [int(static_byte_offset)]
+    elif isinstance(byte_offset, int):
+        dynamic_indices = []
+        raw_constant_indices = [int(byte_offset) + int(static_byte_offset)]
+    else:
+        offset_val = _unwrap_value(byte_offset)
+        if isinstance(offset_val.type, ir.IndexType):
+            i64_type = T.i64()
+            offset_val = _unwrap_value(
+                std_arith.IndexCastOp(i64_type, offset_val).result
+            )
+        elif not isinstance(offset_val.type, ir.IntegerType):
+            raise TypeError(
+                "byte_offset must be int, index, or integer-typed MLIR value; "
+                f"got {offset_val.type}"
+            )
+
+        if static_byte_offset != 0:
+            static_type = offset_val.type
+            static_attr = ir.IntegerAttr.get(static_type, int(static_byte_offset))
+            static_const = _unwrap_value(
+                std_arith.ConstantOp(static_type, static_attr).result
+            )
+            offset_val = _unwrap_value(
+                std_arith.AddIOp(offset_val, static_const).result
+            )
+
+        dynamic_indices = [offset_val]
+        raw_constant_indices = [_gep_dynamic_index_sentinel]
+
+    return llvm.GEPOp(
+        base_ptr.type,
+        base_ptr,
+        dynamic_indices,
+        raw_constant_indices,
+        elem_type,
+        no_wrap_flags,
+    ).result
+
+
+class BufferResourceDescriptor:
+    """AMD Buffer Resource Descriptor
+
+    A buffer resource descriptor contains:
+    - base_pointer: Scalar base pointer (wave-uniform, stored in SGPRs)
+    - stride: Stride for structured buffers (typically 0 for contiguous)
+    - num_records: Buffer size in bytes
+    - flags: Data format and access flags
+
+    The descriptor is stored in a special LLVM pointer type (!llvm.ptr<8>)
+    """
+
+    def __init__(self, rsrc: ir.Value):
+        """Initialize with ROCDL resource descriptor value."""
+        self.rsrc = rsrc
+
+    @staticmethod
+    @dsl_loc_tracing
+    def from_memref(
+        memref_val: ir.Value,
+        stride: int = 0,
+        max_size: bool = True,
+        data_format: str = "f32",
+        num_records_bytes: int | ir.Value | None = None,
+        base_byte_offset: int | ir.Value | None = None,
+    ) -> BufferResourceDescriptor:
+        """Create buffer resource descriptor from memref.
+
+        Args:
+            memref_val: Memref value to create descriptor for
+            stride: Stride in elements (0 for contiguous)
+            max_size: If True, use max buffer size for flexibility
+            num_records_bytes: Override buffer size (in BYTES) used by hardware OOB checking.
+                              If provided, this takes precedence over `max_size`.
+            base_byte_offset: Optional byte offset added to the descriptor base pointer.
+            data_format: Data format ('f32', 'f16', 'i32', etc.)
+
+        Returns:
+            BufferResourceDescriptor instance
+
+        Example:
+            >>> rsrc = BufferResourceDescriptor.from_memref(A)
+        """
+        # Extract raw pointer from fly.memref.
+        raw_val = _unwrap_value(memref_val)
+        from flydsl._mlir.dialects import fly as _fly
+
+        ptr_type = ir.Type.parse("!llvm.ptr")
+        base_ptr = _fly.extract_aligned_pointer_as_index(ptr_type, raw_val)
+        if base_byte_offset is not None:
+            base_ptr = get_element_ptr(base_ptr, byte_offset=base_byte_offset)
+
+        # Create buffer resource descriptor
+        flags_val = _get_buffer_flags()
+        flags = _create_i32_constant(flags_val)
+        stride_val = _create_i16_constant(stride)
+
+        def _num_records_from_memref_type() -> int | None:
+            """Best-effort: derive logical buffer size (in bytes) from static memref type."""
+            try:
+                mt = ir.MemRefType(_unwrap_value(memref_val).type)
+                shape = list(mt.shape)
+                if any(int(d) < 0 for d in shape):
+                    return None
+                # Compute element size in bytes (scalar element type).
+                elem_t = mt.element_type
+                elem_bits = getattr(elem_t, "width", None)
+                if elem_bits is None:
+                    return None
+                elem_bytes = int(elem_bits) // 8
+                if elem_bytes <= 0:
+                    return None
+                num_elems = 1
+                for d in shape:
+                    num_elems *= int(d)
+                return int(num_elems) * int(elem_bytes)
+            # best-effort size probe: any failure just means "unknown"
+            except Exception:  # noqa: BLE001
+                return None
+
+        if num_records_bytes is not None:
+            # Caller-provided size in BYTES (preferred for exact hardware OOB behavior).
+            if isinstance(num_records_bytes, int):
+                nbytes = int(num_records_bytes)
+                nbytes = max(0, nbytes)
+                # Descriptor uses i32 bytes; clamp to the max representable.
+                nbytes = min(nbytes, 0xFFFFFFFF)
+                num_records = _create_i64_constant(nbytes)
+            else:
+                v = _unwrap_value(num_records_bytes)
+                i64_type = T.i64()
+                if not isinstance(v.type, ir.IntegerType) or v.type.width != 64:
+                    if isinstance(v.type, ir.IndexType):
+                        op = std_arith.IndexCastOp(i64_type, v)
+                    else:
+                        op = std_arith.ExtSIOp(i64_type, v)
+                    v = _unwrap_value(op.result)
+                num_records = v
+        elif max_size:
+            # Use max for flexibility (hardware will check actual bounds)
+            # Note: FlyDSL's rocdl.make.buffer.rsrc requires i32, not i64
+            num_records = _create_i64_constant(0xFFFFFFFF)  # FALLBACK_MAX_SIZE
+        else:
+            # Use the logical memref size (in bytes) for hardware OOB checking.
+            nbytes = _num_records_from_memref_type()
+            if nbytes is None:
+                # Fall back to max-size if we can't infer statically.
+                num_records = _create_i64_constant(0xFFFFFFFF)
+            else:
+                nbytes = min(nbytes, 0xFFFFFFFF)
+                num_records = _create_i64_constant(int(nbytes))
+
+        # Create resource descriptor (returns !llvm.ptr<8>)
+        rsrc_type = ir.Type.parse("!llvm.ptr<8>")
+        rsrc = rocdl.MakeBufferRsrcOp(
+            rsrc_type, base_ptr, stride_val, num_records, flags
+        ).result
+
+        return BufferResourceDescriptor(rsrc)
+
+
+@dsl_loc_tracing
+def create_buffer_resource_from_addr(
+    addr_i64: ir.Value,
+    *,
+    num_records_bytes: int | ir.Value | None = None,
+) -> ir.Value:
+    """Create AMD buffer resource descriptor from a raw i64 device address.
+
+    Useful when working with runtime pointer arrays (e.g. IPC-mapped addresses
+    or device-side pointer tables) where no fly.memref is available.
+    The full address is encoded as the buffer base; callers should pass
+    byte offset 0 to buffer_load / buffer_store.
+
+    Args:
+        addr_i64: Raw 64-bit device address (i64 MLIR value).
+        num_records_bytes: Optional buffer size in bytes for hardware OOB checking.
+
+    Returns:
+        ROCDL buffer resource descriptor (!llvm.ptr<8>).
+
+    Example:
+        >>> rsrc = create_buffer_resource_from_addr(raw_addr_i64)
+        >>> data = buffer_load(rsrc, i32_zero, vec_width=4, dtype=T.i32)
+    """
+    addr_i64 = _unwrap_value(addr_i64)
+    ptr_type = ir.Type.parse("!llvm.ptr")
+    base_ptr = llvm.IntToPtrOp(ptr_type, addr_i64).result
+    flags = _create_i32_constant(_get_buffer_flags())
+    stride = _create_i16_constant(0)
+    if num_records_bytes is None:
+        num_records = _create_i64_constant(0xFFFFFFFF)
+    elif isinstance(num_records_bytes, int):
+        nbytes = max(0, min(int(num_records_bytes), 0xFFFFFFFF))
+        num_records = _create_i64_constant(nbytes)
+    else:
+        num_records = _unwrap_value(num_records_bytes)
+        i64_type = T.i64()
+        if (
+            not isinstance(num_records.type, ir.IntegerType)
+            or num_records.type.width != 64
+        ):
+            if isinstance(num_records.type, ir.IndexType):
+                num_records = _unwrap_value(
+                    std_arith.IndexCastOp(i64_type, num_records).result
+                )
+            else:
+                num_records = _unwrap_value(
+                    std_arith.ExtSIOp(i64_type, num_records).result
+                )
+    rsrc_type = ir.Type.parse("!llvm.ptr<8>")
+    return rocdl.MakeBufferRsrcOp(
+        rsrc_type, base_ptr, stride, num_records, flags
+    ).result
+
+
+@dsl_loc_tracing
+def create_buffer_resource(
+    memref_val: ir.Value,
+    stride: int = 0,
+    max_size: bool = True,
+    *,
+    num_records_bytes: int | ir.Value | None = None,
+    base_byte_offset: int | ir.Value | None = None,
+) -> ir.Value:
+    """Create AMD buffer resource descriptor from memref.
+
+    This is a simplified wrapper around BufferResourceDescriptor.from_memref()
+    that returns the raw ROCDL resource value.
+
+    Args:
+        memref_val: Memref value
+        stride: Buffer stride (0 for contiguous)
+        max_size: Use maximum buffer size
+        num_records_bytes: Override buffer size in bytes.
+        base_byte_offset: Optional byte offset added to the descriptor base pointer.
+
+    Returns:
+        ROCDL buffer resource descriptor (!llvm.ptr<8>)
+
+    Example:
+        >>> rsrc = create_buffer_resource(A)
+        >>> data = buffer_load(rsrc, offset)
+    """
+    desc = BufferResourceDescriptor.from_memref(
+        memref_val,
+        stride,
+        max_size,
+        num_records_bytes=num_records_bytes,
+        base_byte_offset=base_byte_offset,
+    )
+    return desc.rsrc
+
+
+@dsl_loc_tracing
+def buffer_load(
+    rsrc: ir.Value,
+    offset: ir.Value,
+    vec_width: int = 4,
+    dtype=None,
+    mask: ir.Value | None = None,
+    cache_modifier: int = 0,
+    soffset_bytes: int | ir.Value | None = None,
+    is_scalar: bool = False,
+) -> ir.Value:
+    """AMD buffer load operation.
+
+    Load data from global memory using buffer descriptor and offset.
+    Uses hardware-level bounds checking and vectorization.
+
+    Args:
+        rsrc: Buffer resource descriptor (!llvm.ptr<8>)
+        offset: Offset in elements (i32 type)
+        vec_width: Vector width (1, 2, or 4)
+        dtype: Element data type (None for f32, or ir.F32Type, etc.)
+        mask: Optional mask for predicated load (i1 type)
+        cache_modifier: Cache control flags (0 for default)
+        soffset_bytes: Optional scalar offset (in BYTES) added by the buffer instruction (soffset).
+                      Use this to fold small constant deltas into the instruction instead of emitting
+                      extra VGPR address arithmetic.
+        is_scalar: Emit a uniform/SGPR scalar load (llvm.amdgcn.s.buffer.load) instead of the
+                      vector buffer load. Use only for wave-uniform addresses to route through the
+                      SMEM cache and land the result directly in SGPRs. Restricted to vec_width 1 or 4;
+                      dtype is forced to i32 (the result is raw i32 dwords). mask and soffset_bytes
+                      are not supported in this mode and raise ValueError if provided.
+
+    Returns:
+        Loaded data (scalar or vector depending on vec_width)
+
+    Example:
+        >>> # Load 4xf32
+        >>> data = buffer_load(rsrc, offset, vec_width=4)
+        >>>
+        >>> # Load with mask
+        >>> data = buffer_load(rsrc, offset, vec_width=4, mask=valid)
+    """
+    # Scalar (uniform) loads return raw i32 dwords; force the element type so the
+    # element->byte offset math below uses 4 and the result type is i32 / v4i32.
+    if is_scalar:
+        if vec_width not in (1, 4):
+            raise ValueError(
+                f"buffer_load(is_scalar=True): unsupported vec_width={vec_width}"
+            )
+        if mask is not None or soffset_bytes is not None:
+            raise ValueError(
+                "buffer_load(is_scalar=True) does not support mask or soffset_bytes"
+            )
+        dtype = T.i32()
+    # Default dtype to f32
+    elif dtype is None:
+        dtype = T.f32()
+    # Accept DSL Numeric class (e.g. fx.Int32) as dtype: unwrap to ir.Type
+    elif hasattr(dtype, "ir_type"):
+        dtype = dtype.ir_type
+
+    # Unwrap offset first (accept Python ints and DSL Numeric values).
+    if isinstance(offset, int):
+        offset = _create_i32_constant(offset)
+    elif hasattr(offset, "ir_value"):
+        offset = offset.ir_value()
+    offset = _unwrap_value(offset)
+
+    # Convert offset to i32 if needed
+    if not isinstance(offset.type, ir.IntegerType) or offset.type.width != 32:
+        op = std_arith.IndexCastOp(T.i32(), offset)
+        offset = _unwrap_value(op.result)
+
+    # IMPORTANT: Buffer load offset is in BYTES, not elements!
+    # For vec4xf32, each element is 4 bytes, so multiply offset by 4
+    element_bytes = dtype.width // 8
+    bytes_const = _create_i32_constant(element_bytes)
+    op = std_arith.MulIOp(offset, bytes_const)
+    offset = _unwrap_value(op.result)
+
+    # Apply mask by setting invalid offsets to max
+    if mask is not None:
+        mask = _unwrap_value(mask)
+        max_offset = _create_i32_constant(0x7FFFFFFF)
+        op = std_arith.SelectOp(mask, offset, max_offset)
+        offset = _unwrap_value(op.result)
+
+    # Create vector type
+    if vec_width == 1:
+        result_type = dtype
+    else:
+        result_type = ir.VectorType.get([vec_width], dtype)
+
+    # Scalar/uniform load path: emit s.buffer.load with a v4i32 resource and the
+    # byte offset computed above. Returns i32 (vec_width 1) or v4i32 (vec_width 4).
+    if is_scalar:
+        rsrc_v4 = _ptr8_to_v4i32(rsrc)
+        cache_policy = _create_i32_constant(cache_modifier)
+        suffix = "i32" if vec_width == 1 else "v4i32"
+        return llvm.call_intrinsic(
+            result_type,
+            f"llvm.amdgcn.s.buffer.load.{suffix}",
+            [rsrc_v4, offset, cache_policy],
+            [],
+            [],
+        )
+
+    # Create instruction offset and aux flags
+    if soffset_bytes is None:
+        soffset = _create_i32_constant(0)
+    else:
+        if isinstance(soffset_bytes, int):
+            soffset = _create_i32_constant(soffset_bytes)
+        else:
+            soffset = _unwrap_value(soffset_bytes)
+            if not isinstance(soffset.type, ir.IntegerType) or soffset.type.width != 32:
+                op = std_arith.IndexCastOp(T.i32(), soffset)
+                soffset = _unwrap_value(op.result)
+    aux_flags = _create_i32_constant(cache_modifier)
+
+    # Emit buffer load
+    load_op = rocdl.RawPtrBufferLoadOp(
+        result_type,
+        rsrc,
+        offset,
+        soffset,
+        aux_flags,  # soffset (scalar byte offset)  # aux (cache modifiers)
+    )
+
+    return load_op.result
+
+
+@dsl_loc_tracing
+def buffer_store(
+    data: ir.Value,
+    rsrc: ir.Value,
+    offset: ir.Value,
+    mask: ir.Value | None = None,
+    cache_modifier: int = 0,
+    *,
+    soffset_bytes: int | ir.Value | None = None,
+    offset_is_bytes: bool = False,
+):
+    """AMD buffer store operation.
+
+    Store data to global memory using buffer descriptor and offset.
+
+    Args:
+        data: Data to store (scalar or vector)
+        rsrc: Buffer resource descriptor (!llvm.ptr<8>)
+        offset: Offset in elements (i32 type)
+        mask: Optional mask for predicated store (i1 type)
+        cache_modifier: Cache control flags (0 for default)
+
+    Example:
+        >>> buffer_store(data, rsrc, offset)
+        >>>
+        >>> # Store with mask
+        >>> buffer_store(data, rsrc, offset, mask=valid)
+    """
+    # Unwrap all inputs (accept DSL Numeric values via ir_value())
+    if hasattr(data, "ir_value"):
+        data = data.ir_value()
+    if isinstance(offset, int):
+        offset = _create_i32_constant(offset)
+    elif hasattr(offset, "ir_value"):
+        offset = offset.ir_value()
+    data = _unwrap_value(data)
+    rsrc = _unwrap_value(rsrc)
+    offset = _unwrap_value(offset)
+
+    # Convert offset to i32 if needed
+    if not isinstance(offset.type, ir.IntegerType) or offset.type.width != 32:
+        op = std_arith.IndexCastOp(T.i32(), offset)
+        offset = _unwrap_value(op.result)
+
+    # IMPORTANT: RawPtrBufferStoreOp offset is in BYTES.
+    # For backward compat, `buffer_store()` accepts element offsets by default
+    # and scales them to bytes. Set `offset_is_bytes=True` to skip scaling.
+    if not offset_is_bytes:
+        # Get element size from data type
+        data_type = data.type
+        if hasattr(data_type, "element_type"):  # Vector type
+            element_type = data_type.element_type
+        else:  # Scalar type
+            element_type = data_type
+        element_bytes = element_type.width // 8
+        bytes_const = _create_i32_constant(element_bytes)
+        op = std_arith.MulIOp(offset, bytes_const)
+        offset = _unwrap_value(op.result)
+
+    # Apply mask by setting invalid offsets to max
+    if mask is not None:
+        mask = _unwrap_value(mask)
+        max_offset = _create_i32_constant(0x7FFFFFFF)
+        op = std_arith.SelectOp(mask, offset, max_offset)
+        offset = _unwrap_value(op.result)
+
+    # Create instruction offset (soffset) and aux flags
+    if soffset_bytes is None:
+        soffset = _create_i32_constant(0)
+    else:
+        if isinstance(soffset_bytes, int):
+            soffset = _create_i32_constant(int(soffset_bytes))
+        else:
+            soffset = _unwrap_value(soffset_bytes)
+            if not isinstance(soffset.type, ir.IntegerType) or soffset.type.width != 32:
+                op = std_arith.IndexCastOp(T.i32(), soffset)
+                soffset = _unwrap_value(op.result)
+    aux_flags = _create_i32_constant(cache_modifier)
+
+    # Emit buffer store
+    rocdl.RawPtrBufferStoreOp(
+        data,
+        rsrc,
+        offset,
+        soffset,
+        aux_flags,  # soffset (scalar byte offset)  # aux (cache modifiers)
+    )

--- a/aiter/ops/flydsl/kernels/chunk_gated_delta_h.py
+++ b/aiter/ops/flydsl/kernels/chunk_gated_delta_h.py
@@ -16,10 +16,13 @@ import math
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl, vector
-from flydsl.expr.typing import T
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr.typing import T
+
+from aiter.ops.flydsl.kernels import vector
+
 from .tensor_shim import GTensor, _to_raw
 
 _LOG2E = math.log2(math.e)  # 1.4426950408889634

--- a/aiter/ops/flydsl/kernels/flash_attn_func_gfx1201.py
+++ b/aiter/ops/flydsl/kernels/flash_attn_func_gfx1201.py
@@ -35,24 +35,22 @@ import os
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import (
-    arith,
-    buffer_ops,
-    const_expr,
-    gpu,
-    range_constexpr,
-    rocdl,
-)
-from flydsl.expr import math as fmath
-from flydsl.expr.typing import T, Vector as Vec
-from flydsl.expr.utils.arith import ArithValue, _to_raw as _raw
-from .kernels_common import dtype_to_elem_type
-from .tensor_shim import _run_compiled
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import (
     llvm as _llvm,
 )
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+from flydsl.expr.utils.arith import ArithValue
+from flydsl.expr.utils.arith import _to_raw as _raw
+
+from aiter.ops.flydsl.kernels import buffer_ops
+
+from .kernels_common import dtype_to_elem_type
+from .tensor_shim import _run_compiled
 
 KERNEL_NAME = "flash_attn_func_gfx1201_c_exp_a_k_noswizzle_kernel"
 _LOG2E = host_math.log2(host_math.e)

--- a/aiter/ops/flydsl/kernels/flydsl_dispatch_combine_intranode_kernel.py
+++ b/aiter/ops/flydsl/kernels/flydsl_dispatch_combine_intranode_kernel.py
@@ -5,18 +5,12 @@
 
 from __future__ import annotations
 
-import mori.ir.flydsl as mori_shmem
-import torch
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
+import mori.ir.flydsl as mori_shmem
+import torch
 from flydsl._mlir import ir
 from flydsl.expr import T, arith, const_expr, range_constexpr
-from flydsl.expr.buffer_ops import (
-    buffer_load,
-    buffer_store,
-    create_buffer_resource_from_addr,
-)
 from flydsl.expr.rocdl import (
     ballot,
     cvt_pk_f32_fp8,
@@ -28,6 +22,12 @@ from flydsl.expr.rocdl import (
 )
 from flydsl.expr.typing import Stream
 from flydsl.expr.typing import Vector as Vec
+
+from aiter.ops.flydsl.kernels.buffer_ops import (
+    buffer_load,
+    buffer_store,
+    create_buffer_resource_from_addr,
+)
 
 from .communication_ops_utils import (
     atomic_add_global_at,

--- a/aiter/ops/flydsl/kernels/fmha_gfx1250/fmha_core_loop.py
+++ b/aiter/ops/flydsl/kernels/fmha_gfx1250/fmha_core_loop.py
@@ -16,19 +16,22 @@ Target: gfx1250, wave32, 4 waves (1TG), 1024 shared VGPRs (256 per bank).
 
 from __future__ import annotations
 
-from .fmha_schedule import (
-    GEMM1_SCHEDULE,
-    GEMM2_SCHEDULE,
-    g1_row_idx,
-    g2_row_idx,
-    PART2_EXP_START,  # ops index where pair_exp starts (=23)
-)
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as llvm_dialect
 from flydsl._mlir.dialects import rocdl as rocdl_dialect
-from flydsl.expr import arith, rocdl, vector
-from flydsl.expr.typing import T
+from flydsl.expr import arith, rocdl
 from flydsl.expr.primitive import const_expr, range_constexpr
+from flydsl.expr.typing import T
+
+from aiter.ops.flydsl.kernels import vector
+
+from .fmha_schedule import (
+    GEMM1_SCHEDULE,
+    GEMM2_SCHEDULE,
+    PART2_EXP_START,  # ops index where pair_exp starts (=23)
+    g1_row_idx,
+    g2_row_idx,
+)
 
 # run_id offset for PART2 pkfma (rid 5..8 → MSB 0..3)
 _P2_BASE = 5

--- a/aiter/ops/flydsl/kernels/fmha_gfx1250/fmha_kernel.py
+++ b/aiter/ops/flydsl/kernels/fmha_gfx1250/fmha_kernel.py
@@ -44,85 +44,85 @@ from __future__ import annotations
 import functools
 from contextlib import contextmanager
 
-import torch
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
+import torch
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as llvm_dialect
 from flydsl._mlir.dialects import scf
-from flydsl.expr import arith, buffer_ops, gpu, rocdl, vector
+from flydsl.compiler.kernel_function import (
+    CompilationContext,
+)
+from flydsl.expr import arith, gpu, rocdl
 from flydsl.expr.primitive import const_expr
 from flydsl.expr.rocdl import tdm_ops
 from flydsl.expr.typing import T
 from flydsl.utils.smem_allocator import SmemAllocator
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
+
 from ..tensor_shim import _run_compiled
-from flydsl.compiler.kernel_function import (
-    CompilationContext,
-)
-
-from .fmha_prologue import (
-    _emit_void,
-    _setreg,
-    _build_tdm_dgroup1,
-    _split_i64_to_lo_hi,
-    _phase4_q_load_flydsl,
-    _phase5_head_index_div_flydsl,
-    _compute_k_global_addr,
-    _compute_v_global_addr,
-    BLOCK_SIZE,
-    K_TILE_N,
-    _K_TDM_CONFIG,
-    _V_TDM_CONFIG,
-    K_ROW_BYTES,
-    V_ROW_BYTES,
-    K_SU_HALF_OFFSET,
-    V_SU_HALF_OFFSET,
-)
-
 from .fmha_core_loop import (
-    _get_types,
-    _make_v2f32,
-    _pair_k_tiles_for_wmma,
-    _load_v_two_sus_from_lds,
-    _pair_v_tiles_for_wmma,
-    _qk_pure_su,
-    _pv_pure_su,
-    _load_k_su_from_lds,
-    _sp_tiles_to_sp_pairs,
-    _softmax_part01_only,
+    ALU_PER_STAGE,
+    ALU_STAGES,
+    CNT_SU,
+    KV_BPP,
+    KV_K,
+    KV_NONE,
+    KV_V,
+    LDS_INST_COUNT,
+    LDS_K_SU_P_SIZE,
+    LDS_V_SU_P_SIZE,
+    N_LDS_PER_MSB,
+    N_LDS_V_PER_MSB,
+    N_PV_WMMA_N,
+    N_SP_PAIRS,
+    N_WMMA_K_TILES,
+    NUM_MSB,
+    PART2_SETUP_A,
+    PART2_SPLIT,
+    Q_WMMA_PER_MSB,
+    QK_HDIM,
+    RLTS_LEN,
+    SU_K_N,
+    V_HDIM,
+    WAVE_SIZE,
+    _atom_s_wait_dscnt,
+    _build_all_softmax_gemm2_ops,
+    _build_all_softmax_part2_ops,
     _build_p_tiles_from_softmax,
     _cl_su_v3_stage,
     _cl_su_v3_stage_gemm2,
-    _build_all_softmax_part2_ops,
-    _build_all_softmax_gemm2_ops,
-    _atom_s_wait_dscnt,
-    NUM_MSB,
-    WAVE_SIZE,
-    Q_WMMA_PER_MSB,
-    N_WMMA_K_TILES,
-    N_LDS_PER_MSB,
-    N_LDS_V_PER_MSB,
-    N_SP_PAIRS,
-    N_PV_WMMA_N,
-    CNT_SU,
-    SU_K_N,
-    LDS_K_SU_P_SIZE,
-    LDS_V_SU_P_SIZE,
-    KV_K,
-    KV_V,
-    KV_NONE,
-    LDS_INST_COUNT,
-    ALU_STAGES,
-    ALU_PER_STAGE,
-    RLTS_LEN,
-    QK_HDIM,
-    V_HDIM,
-    KV_BPP,
-    PART2_SPLIT,
-    PART2_SETUP_A,
+    _get_types,
+    _load_k_su_from_lds,
+    _load_v_two_sus_from_lds,
+    _make_v2f32,
+    _pair_k_tiles_for_wmma,
+    _pair_v_tiles_for_wmma,
+    _pv_pure_su,
+    _qk_pure_su,
     _rocdl_permlanex16,
+    _softmax_part01_only,
+    _sp_tiles_to_sp_pairs,
     set_vgpr_bank,
+)
+from .fmha_prologue import (
+    _K_TDM_CONFIG,
+    _V_TDM_CONFIG,
+    BLOCK_SIZE,
+    K_ROW_BYTES,
+    K_SU_HALF_OFFSET,
+    K_TILE_N,
+    V_ROW_BYTES,
+    V_SU_HALF_OFFSET,
+    _build_tdm_dgroup1,
+    _compute_k_global_addr,
+    _compute_v_global_addr,
+    _emit_void,
+    _phase4_q_load_flydsl,
+    _phase5_head_index_div_flydsl,
+    _setreg,
+    _split_i64_to_lo_hi,
 )
 
 
@@ -3222,6 +3222,7 @@ _launch_fns = {}  # {(is_causal, return_lse): launch_fn}
 
 def _patch_reusable_slot_specs():
     import ctypes
+
     from flydsl.expr.numeric import Float32, Float64
 
     if not hasattr(Float32, "_reusable_slot_spec"):

--- a/aiter/ops/flydsl/kernels/fmha_gfx1250/fmha_prologue.py
+++ b/aiter/ops/flydsl/kernels/fmha_gfx1250/fmha_prologue.py
@@ -14,13 +14,16 @@ from __future__ import annotations
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as llvm_dialect
-from flydsl.expr import arith, rocdl, vector
+from flydsl.expr import arith, rocdl
 from flydsl.expr.rocdl import tdm_ops
 from flydsl.expr.typing import T
+
+from aiter.ops.flydsl.kernels import vector
+
 from .fmha_core_loop import (
     QK_HDIM,
-    _rocdl_permlanex16,
     _rocdl_exp2,
+    _rocdl_permlanex16,
     set_vgpr_bank,
 )
 

--- a/aiter/ops/flydsl/kernels/fused_compress_attn.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn.py
@@ -72,21 +72,22 @@ from contextlib import contextmanager
 from functools import lru_cache
 from typing import Optional
 
-import torch
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, const_expr, gpu, range_constexpr, vector, buffer_ops
-from flydsl.expr import math as fmath
-from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
-from flydsl.expr.typing import T, Int32, Stream
+import torch
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, rocdl, scf
-from .tensor_shim import _to_raw, _run_compiled
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
+from flydsl.expr import math as fmath
+from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
+from flydsl.expr.typing import Int32, Stream, T
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 # Shared FP8 group_fp8 (V4 nm-asm) scatter emitter (single source of truth across
 # the CSA single-kernel + HCA 2-kernel paths). See fused_compress_attn_common.
 from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .tensor_shim import _run_compiled, _to_raw
 
 # --- shape constants --------------------------------------------------------
 BLOCK_THREADS = 64  # 1 wave64; D must be a multiple

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
@@ -13,19 +13,23 @@ byte-identical so the V4 nm-asm sparse-attn reader sees one layout).
 from contextlib import contextmanager
 from functools import lru_cache
 
-from flydsl.expr import arith, range_constexpr, vector, buffer_ops
-from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
-from flydsl.expr.typing import T
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import rocdl, scf
+from flydsl.expr import arith, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
+from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch
 
-from .tensor_shim import _to_raw
-from .quant_utils import emit_mx_e8m0_scale
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.utility.mx_types import (
-    MxDtypeInt as _MxD,
     MX_DEFAULT_ROUND_MODE as _MX_DEFAULT_MODE,
 )
+from aiter.utility.mx_types import (
+    MxDtypeInt as _MxD,
+)
+
+from .quant_utils import emit_mx_e8m0_scale
+from .tensor_shim import _to_raw
 
 
 @contextmanager

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
@@ -29,18 +29,20 @@ from contextlib import contextmanager
 from functools import lru_cache
 from typing import Optional
 
-import torch
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, const_expr, gpu, range_constexpr, vector, buffer_ops
-from flydsl.expr import math as fmath
-from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
-from flydsl.expr.typing import T, Int32, Stream
+import torch
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, rocdl, scf
-from .tensor_shim import _to_raw, _run_compiled
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
+from flydsl.expr import math as fmath
+from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
+from flydsl.expr.typing import Int32, Stream, T
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
+
 from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .tensor_shim import _run_compiled, _to_raw
 
 # --- shape constants --------------------------------------------------------
 BLOCK_THREADS = 32  # 1 wave32 (RDNA4 / gfx1250); D must be a multiple

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
@@ -45,18 +45,20 @@ from contextlib import contextmanager
 from functools import lru_cache
 from typing import Optional
 
-import torch
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, vector
+import torch
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, scf
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
 from flydsl.expr.typing import Int32, Stream, T
-from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm, scf
-from .tensor_shim import _to_raw, _run_compiled
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
+
 from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .tensor_shim import _run_compiled, _to_raw
 
 BLOCK_THREADS = 64  # 1 wave64
 SLICE = 64  # head_dim elements per block (grid-Y split)

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
@@ -19,18 +19,20 @@ from contextlib import contextmanager
 from functools import lru_cache
 from typing import Optional
 
-import torch
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, vector
+import torch
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, scf
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
 from flydsl.expr.typing import Int32, Stream, T
-from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm, scf
-from .tensor_shim import _to_raw, _run_compiled
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
+
 from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .tensor_shim import _run_compiled, _to_raw
 
 BLOCK_THREADS = 32  # 1 wave32 (RDNA4 / gfx1250)
 SLICE = 32  # head_dim elements per block (grid-Y split)

--- a/aiter/ops/flydsl/kernels/gdr_decode.py
+++ b/aiter/ops/flydsl/kernels/gdr_decode.py
@@ -5,22 +5,27 @@ import functools
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-
-from flydsl.expr.typing import T
+from flydsl._mlir import ir
 from flydsl._mlir.dialects import (
     gpu as mlir_gpu,
+)
+from flydsl._mlir.dialects import (
     math as mlir_math,
+)
+from flydsl._mlir.dialects import scf
+from flydsl._mlir.dialects import (
     vector as mlir_vector,
 )
-from flydsl.expr import range_constexpr, const_expr, arith, vector, rocdl
-from flydsl._mlir import ir
-from flydsl._mlir.dialects import scf
+from flydsl.expr import arith, const_expr, range_constexpr, rocdl
+from flydsl.expr.typing import T
+
+from aiter.ops.flydsl.kernels import vector
 
 from .tensor_shim import (
-    get_dtype_in_kernel,
-    get_dtype_bytes,
     GTensor,
     _to_raw,
+    get_dtype_bytes,
+    get_dtype_in_kernel,
 )
 
 fm_fast = arith.FastMathFlags.fast

--- a/aiter/ops/flydsl/kernels/gemm_common_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/gemm_common_gfx1250.py
@@ -3,7 +3,7 @@
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as llvm_dialect
 from flydsl._mlir.dialects import scf
-from flydsl.expr import arith, buffer_ops, gpu, rocdl, tdm_ops, vector
+from flydsl.expr import arith, gpu, rocdl, tdm_ops
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.rocdl import cluster
 from flydsl.expr.typing import T
@@ -12,6 +12,8 @@ from flydsl.utils.smem_allocator import (
     get_mlir_type_size,
     get_op_result_or_value,
 )
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 
 def get_lds_memref(lds_ptr):

--- a/aiter/ops/flydsl/kernels/gemm_fp8fp4_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/gemm_fp8fp4_gfx1250.py
@@ -17,7 +17,6 @@ from flydsl._mlir.dialects import fly, llvm, scf
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import (
     arith,
-    buffer_ops,
     const_expr,
     gpu,
     idx2crd,
@@ -29,6 +28,7 @@ from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr, check_smem_capacity
 
+from aiter.ops.flydsl.kernels import buffer_ops
 from aiter.ops.flydsl.kernels import tdm_oob as tdm_ops
 from aiter.ops.flydsl.kernels.gemm_common_gfx1250 import (
     extract_lds_base_idx,
@@ -41,6 +41,7 @@ from aiter.ops.flydsl.kernels.gemm_common_gfx1250 import (
     store_acc_vec8_to_buffer,
     store_acc_vec8_to_lds,
 )
+from aiter.ops.flydsl.kernels.gfx1250_cluster import compute_mcast_masks
 from aiter.ops.flydsl.kernels.pipeline_utils import (
     make_tail_plan,
     tdm_epilogue_fence_threshold_bytes,
@@ -684,7 +685,7 @@ def compile_fp8fp4_gemm(
 
         if const_expr(use_cluster):
             local_x, local_y = cluster.compute_cluster_position()
-            a_mcast_mask, b_mcast_mask = cluster.compute_mcast_masks(
+            a_mcast_mask, b_mcast_mask = compute_mcast_masks(
                 local_x, local_y, cluster_m, cluster_n
             )
         else:

--- a/aiter/ops/flydsl/kernels/gemm_mxscale_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/gemm_mxscale_gfx1250.py
@@ -10,13 +10,11 @@ import os
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import (
     arith,
-    buffer_ops,
     const_expr,
     gpu,
     idx2crd,
@@ -25,18 +23,20 @@ from flydsl.expr import (
     range_constexpr,
     rocdl,
     tdm_ops,
-    vector,
 )
 from flydsl.expr.arith import _to_raw as _raw
+from flydsl.expr.rocdl import cluster
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr, check_smem_capacity
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.ops.flydsl.kernels.gemm_common_gfx1250 import (
     extract_lds_base_idx,
     get_lds_memref,
     issue_tdm_loads,
-    lds_load_b128_raw,
     lds_load_b32_raw,
+    lds_load_b128_raw,
     lds_store_b64,
     lds_store_b128,
     pipeline_fence,
@@ -45,6 +45,7 @@ from aiter.ops.flydsl.kernels.gemm_common_gfx1250 import (
     store_acc_vec8_to_buffer,
     store_acc_vec8_to_lds,
 )
+from aiter.ops.flydsl.kernels.gfx1250_cluster import compute_mcast_masks
 from aiter.ops.flydsl.kernels.pipeline_utils import (
     make_tail_plan,
     tdm_epilogue_fence_threshold_bytes,
@@ -881,8 +882,8 @@ def compile_mxscale_gemm(
                 _oob_a_row_bound = group_m_base + arith.index_cast(T.index, valid_m_i32)
 
             if const_expr(use_cluster):
-                local_x, local_y = gpu.compute_cluster_position()
-                a_mcast_mask, b_mcast_mask = gpu.compute_mcast_masks(
+                local_x, local_y = cluster.compute_cluster_position()
+                a_mcast_mask, b_mcast_mask = compute_mcast_masks(
                     local_x, local_y, cluster_m, cluster_n
                 )
             else:

--- a/aiter/ops/flydsl/kernels/gfx1250_cluster.py
+++ b/aiter/ops/flydsl/kernels/gfx1250_cluster.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+# Modifications Copyright (C) 2026 Advanced Micro Devices, Inc.
+
+"""gfx1250 cluster MCAST mask helper, vendored into aiter.
+
+``compute_mcast_masks`` moved from ``flydsl.expr.rocdl.cluster`` to flydsl's
+repo-level ``kernels/common/``, which its wheel does not ship. This is pure
+index math with no ROCDL primitives; the remaining cluster primitives
+(``cluster_barrier`` / ``compute_cluster_position`` / ``cluster_wait``) still
+live in flydsl and are imported from there.
+
+Upstream: FlyDSL ``kernels/common/gfx1250_cluster.py`` @ ROCm/FlyDSL#880.
+"""
+
+from __future__ import annotations
+
+from flydsl.expr import arith as _arith_ext
+from flydsl.expr.meta import dsl_loc_tracing
+from flydsl.expr.typing import T
+
+
+@dsl_loc_tracing
+def compute_mcast_masks(local_x, local_y, cluster_m: int, cluster_n: int):
+    """Compute MCAST workgroup_mask values for A and B matrices.
+
+    Hardware flat WG index within a cluster uses X-inner ordering
+    (gfx1250 Shader Programming, TTMP6 layout, section 3.5.5.1):
+
+        flat_wg_id = wg_x + wg_y * nwg_x = local_x + local_y * cluster_m
+
+    where cluster_dims = (cluster_m, cluster_n, 1), so nwg_x = cluster_m.
+
+    A mask: WGs sharing the same M-tile row (same local_x, varying local_y).
+        Bits: {local_x + ly * cluster_m : ly in 0..cluster_n-1}
+    B mask: WGs sharing the same N-tile column (same local_y, varying local_x).
+        Bits: {lx + local_y * cluster_m : lx in 0..cluster_m-1}
+
+    Args:
+        local_x: WG row within cluster (MLIR index, 0..cluster_m-1).
+        local_y: WG column within cluster (MLIR index, 0..cluster_n-1).
+        cluster_m: Cluster rows (Python int).
+        cluster_n: Cluster columns (Python int).
+
+    Returns:
+        (a_mask, b_mask) as MLIR i32 values for TDM workgroup_mask.
+    """
+    local_x_i32 = _arith_ext.index_cast(T.i32, local_x)
+    local_y_i32 = _arith_ext.index_cast(T.i32, local_y)
+    cluster_m_i32 = _arith_ext.constant(cluster_m, type=T.i32)
+
+    # A mask: pattern has bits at strides of cluster_m, shifted by local_x.
+    a_pattern_val = 0
+    for ly in range(cluster_n):
+        a_pattern_val |= 1 << (ly * cluster_m)
+    a_pattern = _arith_ext.constant(a_pattern_val, type=T.i32)
+    a_mask = _arith_ext.shli(a_pattern, local_x_i32)
+
+    # B mask: cluster_m contiguous low bits, shifted by local_y * cluster_m.
+    b_pattern = _arith_ext.constant((1 << cluster_m) - 1, type=T.i32)
+    col_base = _arith_ext.muli(local_y_i32, cluster_m_i32)
+    b_mask = _arith_ext.shli(b_pattern, col_base)
+
+    return a_mask, b_mask
+
+
+__all__ = ["compute_mcast_masks"]

--- a/aiter/ops/flydsl/kernels/kernels_common.py
+++ b/aiter/ops/flydsl/kernels/kernels_common.py
@@ -5,15 +5,22 @@ but this module is intentionally small and MLIR-dialect facing.
 """
 
 from flydsl._mlir import ir
-from flydsl.expr.typing import T
 from flydsl._mlir.dialects import (
     arith as _std_arith,
+)
+from flydsl._mlir.dialects import (
     builtin,
+)
+from flydsl._mlir.dialects import (
     gpu as _gpu,
+)
+from flydsl._mlir.dialects import (
     llvm as _llvm,
 )
-from flydsl.expr import buffer_ops
+from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch, is_rdna_arch
+
+from aiter.ops.flydsl.kernels import buffer_ops
 
 
 def get_warp_size(arch=None):

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
@@ -43,10 +43,12 @@ from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, memref, scf
 from flydsl._mlir.dialects.arith import CmpIPredicate
 from flydsl._mlir.extras import types as _mT
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, rocdl, vector
+from flydsl.expr import arith, const_expr, gpu, rocdl
 from flydsl.expr.gpu import lds_space as _lds_space
 from flydsl.expr.typing import T
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 from .layout_utils import crd2idx, idx2crd
 from .layout_utils import get as layout_get

--- a/aiter/ops/flydsl/kernels/moe_contiguous_psum.py
+++ b/aiter/ops/flydsl/kernels/moe_contiguous_psum.py
@@ -10,17 +10,18 @@ torch.cumsum (avoids rocprim trampoline overhead for small E).
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate, _to_raw as _raw
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.arith import _to_raw as _raw
+from flydsl.expr.typing import Int32, T
 
+from aiter.ops.flydsl.kernels import buffer_ops
 from aiter.ops.flydsl.kernels.tensor_shim import (
-    ptr_rsrc,
     AITER_FLYDSL_KERNARG_PRELOAD,
     AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
 )
 
 MAX_EXPERTS_PER_BLOCK = 512

--- a/aiter/ops/flydsl/kernels/moe_fused_route_quant_scatter.py
+++ b/aiter/ops/flydsl/kernels/moe_fused_route_quant_scatter.py
@@ -62,27 +62,27 @@ from types import SimpleNamespace
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, ptrtoint, range_constexpr, const_expr, rocdl, vector, gpu
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
-from flydsl.expr import buffer_ops
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, const_expr, gpu, ptrtoint, range_constexpr, rocdl
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import Int32, T
 from flydsl.runtime.device import get_rocm_arch
 
-from aiter.ops.flydsl.kernels.quant_utils import emit_f32_to_e2m1, emit_mx_e8m0_scale
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.ops.flydsl.kernels.kernels_common import get_warp_size
+from aiter.ops.flydsl.kernels.quant_utils import emit_f32_to_e2m1, emit_mx_e8m0_scale
 from aiter.ops.flydsl.kernels.tensor_shim import (
-    ptr_rsrc,
     AITER_FLYDSL_KERNARG_PRELOAD,
     AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
 )
-
+from aiter.utility.mx_types import (
+    MX_DEFAULT_ROUND_MODE as _ROUND_MODE,
+)
 from aiter.utility.mx_types import (
     MxDtypeInt as _MxDtype,
-    MX_DEFAULT_ROUND_MODE as _ROUND_MODE,
 )
 
 BLOCK_THREADS = 256

--- a/aiter/ops/flydsl/kernels/moe_gather_reduce.py
+++ b/aiter/ops/flydsl/kernels/moe_gather_reduce.py
@@ -42,19 +42,18 @@ nothing and need no branch.
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, range_constexpr, vector
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import scf
-from flydsl.expr import buffer_ops
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import Int32, T
 
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.ops.flydsl.kernels.tensor_shim import (
-    ptr_rsrc,
     AITER_FLYDSL_KERNARG_PRELOAD,
     AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
 )
 
 BLOCK_THREADS = 256

--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -12,24 +12,23 @@ It is extracted from `tests/kernels/test_moe_gemm.py` so that:
 - `tests/` holds correctness/perf harnesses
 """
 
-import logging
-import os
 import functools
+import os
 from contextlib import contextmanager
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith
-from flydsl.expr import gpu, buffer_ops, vector, rocdl
-from flydsl.expr import range_constexpr, const_expr
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 
+from aiter.ops.flydsl.kernels import buffer_ops, vector
+
 try:
     from flydsl.runtime.device import (
-        supports_bf16_global_atomics,
         bf16_global_atomics_arch_description,
+        supports_bf16_global_atomics,
     )
 except ImportError:
     # Backward compatibility for runtime.device versions that only expose get_rocm_arch.
@@ -44,23 +43,22 @@ from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
 from flydsl.expr.typing import T
 
-
+from .mfma_epilogues import c_shuffle_epilog, default_epilog, mfma_epilog
 from .mfma_preshuffle_pipeline import (
     buffer_copy_gmem16_dwordx4,
+    crd2idx,
+    extract_bf16_scale,
     lds_store_4b_xor16,
     lds_store_8b_xor16,
     lds_store_16b_xor16,
-    make_preshuffle_b_layout,
     load_b_pack_k32,
     load_b_raw_w4a16,
-    unpack_b_w4a16,
     load_b_raw_w4a16_groupwise,
-    extract_bf16_scale,
-    tile_chunk_coord_i32,
+    make_preshuffle_b_layout,
     swizzle_xor16,
-    crd2idx,
+    tile_chunk_coord_i32,
+    unpack_b_w4a16,
 )
-from .mfma_epilogues import c_shuffle_epilog, default_epilog, mfma_epilog
 from .tensor_shim import _run_compiled
 
 

--- a/aiter/ops/flydsl/kernels/moe_grouped_gemm_mxscale_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/moe_grouped_gemm_mxscale_gfx1250.py
@@ -27,10 +27,12 @@ import torch
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, vector
-from flydsl.expr.arith import ArithValue, _to_raw as _raw
+from flydsl.expr import arith, const_expr, gpu, range_constexpr
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.typing import T
 
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.ops.flydsl.kernels.gemm_mxscale_gfx1250 import (
     compile_a8w4_gemm,
     compile_mxfp4_gemm,

--- a/aiter/ops/flydsl/kernels/moe_m_tile_map.py
+++ b/aiter/ops/flydsl/kernels/moe_m_tile_map.py
@@ -20,14 +20,15 @@ import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import scf
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, buffer_ops
+from flydsl.expr import arith
 from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.expr.typing import T, Int32
+from flydsl.expr.typing import Int32, T
 
+from aiter.ops.flydsl.kernels import buffer_ops
 from aiter.ops.flydsl.kernels.tensor_shim import (
-    ptr_rsrc,
     AITER_FLYDSL_KERNARG_PRELOAD,
     AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
 )
 
 BLOCK_THREADS = 256

--- a/aiter/ops/flydsl/kernels/moe_route_maps.py
+++ b/aiter/ops/flydsl/kernels/moe_route_maps.py
@@ -9,19 +9,18 @@ via per-expert atomicAdd. One thread per route, no host-side argsort.
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, ptrtoint
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
-from flydsl.expr import buffer_ops
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, ptrtoint
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import Int32, T
 
+from aiter.ops.flydsl.kernels import buffer_ops
 from aiter.ops.flydsl.kernels.tensor_shim import (
-    ptr_rsrc,
     AITER_FLYDSL_KERNARG_PRELOAD,
     AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
 )
 
 BLOCK_THREADS = 256

--- a/aiter/ops/flydsl/kernels/moe_scatter_copy_preshuffle_scale.py
+++ b/aiter/ops/flydsl/kernels/moe_scatter_copy_preshuffle_scale.py
@@ -63,19 +63,18 @@ Block : (BLOCK_THREADS, 1, 1)
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, range_constexpr
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import scf
-from flydsl.expr import buffer_ops, vector
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import Int32, T
 
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.ops.flydsl.kernels.tensor_shim import (
-    ptr_rsrc,
     AITER_FLYDSL_KERNARG_PRELOAD,
     AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
 )
 
 BLOCK_THREADS = 256

--- a/aiter/ops/flydsl/kernels/moe_scatter_copy_token.py
+++ b/aiter/ops/flydsl/kernels/moe_scatter_copy_token.py
@@ -35,19 +35,18 @@ Block : (BLOCK_THREADS, 1, 1)
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, range_constexpr
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import scf
-from flydsl.expr import buffer_ops
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import Int32, T
 
+from aiter.ops.flydsl.kernels import buffer_ops
 from aiter.ops.flydsl.kernels.tensor_shim import (
-    ptr_rsrc,
     AITER_FLYDSL_KERNARG_PRELOAD,
     AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
 )
 
 BLOCK_THREADS = 256

--- a/aiter/ops/flydsl/kernels/moe_sorting_kernel.py
+++ b/aiter/ops/flydsl/kernels/moe_sorting_kernel.py
@@ -22,16 +22,18 @@ Packed token ID format: (topk_position << 24) | token_id
 
 import functools
 
-import torch
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import buffer_ops, gpu, range_constexpr
+import torch
+from flydsl.expr import gpu, range_constexpr
 from flydsl.expr import rocdl as fly_rocdl
 from flydsl.expr.arith import ArithValue
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+
+from aiter.ops.flydsl.kernels import buffer_ops
+
 from .kernels_common import get_warp_size
 from .tensor_shim import _run_compiled
 

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm2.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm2.py
@@ -4,34 +4,37 @@
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir.dialects import llvm
-from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
+
+from aiter.ops.flydsl.kernels import buffer_ops
+
 from .mxfp4_gemm_common import (
-    kStages,
-    kBS_stride_k0_dw,
-    _raw,
-    _lds_ptr3,
+    _buffer_rsrc,
+    _e8m0_from_amax,
+    _fabs_f32,
+    _gep1,
     _gep3,
     _global_base_ptr1,
-    _gep1,
     _global_ptr1,
-    _buffer_rsrc,
-    _lds_swizzle_mask,
-    _fabs_f32,
-    _e8m0_from_amax,
     _inline_dpp_quad_amax,
-    kmchunks_for,
-    lds_acc_bytes_for,
-    k_half_for,
-    k_tiles_total_for,
-    kunroll_for,
-    kbs_stride_n0_dw_for,
-    kas_per_chunk_dw_for,
-    num_n_blocks_for,
-    kbs_per_expert_dw_for,
+    _lds_ptr3,
+    _lds_swizzle_mask,
+    _raw,
     bq_bytes_for,
     bscale_bytes_for,
+    k_half_for,
+    k_tiles_total_for,
+    kas_per_chunk_dw_for,
+    kbs_per_expert_dw_for,
+    kBS_stride_k0_dw,
+    kbs_stride_n0_dw_for,
+    kmchunks_for,
+    kStages,
+    kunroll_for,
+    lds_acc_bytes_for,
+    num_n_blocks_for,
 )
 
 NUM_CU = 256

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm_common.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm_common.py
@@ -5,8 +5,10 @@ import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm
 from flydsl._mlir.dialects import memref as memref_dialect
-from flydsl.expr import arith, buffer_ops
+from flydsl.expr import arith
 from flydsl.expr.typing import T
+
+from aiter.ops.flydsl.kernels import buffer_ops
 
 from . import dpp_utils
 

--- a/aiter/ops/flydsl/kernels/pa_mqa_logits_fp4.py
+++ b/aiter/ops/flydsl/kernels/pa_mqa_logits_fp4.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Optional
 
+import flydsl.compiler as flyc
+import flydsl.expr as fx
 import torch
 import triton
 import triton.language as tl
-
-import flydsl.compiler as flyc
-import flydsl.expr as fx
 from flydsl._mlir.dialects import llvm as _llvm
-from flydsl.expr import arith, buffer_ops, gpu, rocdl
+from flydsl.expr import arith, gpu, rocdl
 from flydsl.expr.primitive import range_constexpr
 from flydsl.expr.typing import Int32, T
+
+from aiter.ops.flydsl.kernels import buffer_ops
 
 DEFAULT_HEADS = 64
 DEFAULT_HEAD_DIM = 128

--- a/aiter/ops/flydsl/kernels/pa_mqa_logits_fp4_prefill.py
+++ b/aiter/ops/flydsl/kernels/pa_mqa_logits_fp4_prefill.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Optional
 
+import flydsl.compiler as flyc
+import flydsl.expr as fx
 import torch
 import triton
 import triton.language as tl
-
-import flydsl.compiler as flyc
-import flydsl.expr as fx
 from flydsl._mlir.dialects import llvm as _llvm
-from flydsl.expr import arith, buffer_ops, gpu, rocdl
+from flydsl.expr import arith, gpu, rocdl
 from flydsl.expr.primitive import range_constexpr
 from flydsl.expr.typing import Int32, T
+
+from aiter.ops.flydsl.kernels import buffer_ops
 
 DEFAULT_HEADS = 64
 DEFAULT_HEAD_DIM = 128

--- a/aiter/ops/flydsl/kernels/preshuffle_gemm.py
+++ b/aiter/ops/flydsl/kernels/preshuffle_gemm.py
@@ -9,7 +9,7 @@ from typing import Optional
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import const_expr, gpu, math, range_constexpr, rocdl, vector
+from flydsl.expr import const_expr, gpu, math, range_constexpr, rocdl
 from flydsl.expr.typing import (
     BFloat16,
     Float8E4M3FN,
@@ -22,6 +22,9 @@ from flydsl.expr.typing import (
 )
 from flydsl.expr.typing import Vector as Vec
 from flydsl.runtime.device import get_rocm_arch
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
+
 from .mfma_preshuffle_pipeline import xcd_remap_bx_by
 
 # (dsrd_preload, dvmem_preload) per (tile_m, tile_n, tile_k).
@@ -623,11 +626,11 @@ def compile_preshuffle_gemm(
             s_a = s_b = bias = None
             if const_expr(is_8bit):
                 # Per-row(scale_a) × per-col(scale_b) scaling, applied in the epilogue.
-                scale_b_rsrc = fx.buffer_ops.create_buffer_resource(
+                scale_b_rsrc = buffer_ops.create_buffer_resource(
                     arg_scale_b, max_size=True
                 )
                 s_b = [
-                    fx.buffer_ops.buffer_load(
+                    buffer_ops.buffer_load(
                         scale_b_rsrc,
                         fx.Int32(by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16),
                         vec_width=1,
@@ -635,12 +638,12 @@ def compile_preshuffle_gemm(
                     )
                     for ni in range_constexpr(num_acc_n)
                 ]
-                scale_a_rsrc = fx.buffer_ops.create_buffer_resource(
+                scale_a_rsrc = buffer_ops.create_buffer_resource(
                     arg_scale_a, max_size=True
                 )
                 s_a = [
                     Vec(
-                        fx.buffer_ops.buffer_load(
+                        buffer_ops.buffer_load(
                             scale_a_rsrc,
                             fx.Int32(bx_m + mi * 16 + lane_div_16 * 4),
                             vec_width=4,
@@ -651,13 +654,11 @@ def compile_preshuffle_gemm(
                 ]
             if const_expr(_has_bias):
                 # Per-column bias (out_dtype), one scalar per N-block, shared across rows.
-                bias_rsrc = fx.buffer_ops.create_buffer_resource(
-                    arg_bias, max_size=True
-                )
+                bias_rsrc = buffer_ops.create_buffer_resource(arg_bias, max_size=True)
                 bias_elem_ty = T.bf16 if out_dtype == "bf16" else T.f16
                 bias = [
                     fx.Float32(
-                        fx.buffer_ops.buffer_load(
+                        buffer_ops.buffer_load(
                             bias_rsrc,
                             fx.Int32(
                                 by_n + (ni * num_waves + wave_id) * 16 + lane_mod_16

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -48,9 +48,7 @@ who already have all buffers and want the lowest-overhead path.
 
 import math
 from functools import lru_cache
-from typing import Optional, Tuple
-
-import torch
+from typing import Optional, Tuple  # noqa: UP035
 
 # NOTE: ``aiter.utility.dtypes`` transitively imports ``aiter.ops.enum``,
 # whose ``ActivationType = type(_ActivationType(0))`` triggers a JIT call
@@ -59,18 +57,16 @@ import torch
 # module load time crashes setup with ``KeyError: 'module_aiter_core'``.
 # Defer the import until the first runtime call instead -- sibling modules
 # (moe_kernels._get_dtypes, gemm_kernels._get_dtypes) use the same pattern.
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, const_expr, range_constexpr, vector, buffer_ops
+import torch
+from flydsl._mlir.dialects import llvm, rocdl
+from flydsl.expr import arith, const_expr, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.arith import ArithValue, CmpFPredicate
-from flydsl.expr.typing import T, Int32, Stream
-from flydsl.expr.vector import ReductionOp
-from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl._mlir.dialects import llvm, rocdl
+from flydsl.expr.typing import Int32, ReductionOp, Stream, T
 
-from .tensor_shim import GTensor, _to_raw, _run_compiled
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 # JIT-free MX-format mode/dtype int mirrors. ``aiter.utility.mx_types``'s
 # pybind11 ``MxScaleRoundMode`` / ``MxDtype`` lazy-load on first attribute
@@ -78,9 +74,13 @@ from .tensor_shim import GTensor, _to_raw, _run_compiled
 # (mirrors the FlyDSL AOT-friendly pattern in ``quant_utils``).
 from aiter.ops.flydsl.kernels.quant_utils import emit_mx_e8m0_scale
 from aiter.utility.mx_types import (
-    MxDtypeInt as _D,
     MX_DEFAULT_ROUND_MODE as _DEFAULT_MODE,
 )
+from aiter.utility.mx_types import (
+    MxDtypeInt as _D,
+)
+
+from .tensor_shim import GTensor, _run_compiled, _to_raw
 
 # --- shape constants (V4-Pro MVP) -------------------------------------------
 BLOCK_THREADS = 64  # 1 wave64

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
@@ -43,9 +43,7 @@ path.
 
 import math
 from functools import lru_cache
-from typing import Optional, Tuple
-
-import torch
+from typing import Optional, Tuple  # noqa: UP035
 
 # NOTE: ``aiter.utility.dtypes`` transitively imports ``aiter.ops.enum``,
 # whose ``ActivationType = type(_ActivationType(0))`` triggers a JIT call
@@ -54,17 +52,16 @@ import torch
 # module load time crashes setup with ``KeyError: 'module_aiter_core'``.
 # Defer the import until the first runtime call instead -- sibling modules
 # (moe_kernels._get_dtypes, gemm_kernels._get_dtypes) use the same pattern.
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, const_expr, range_constexpr, vector, buffer_ops
+import torch
+from flydsl._mlir.dialects import llvm, rocdl
+from flydsl.expr import arith, const_expr, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.arith import ArithValue, CmpFPredicate, CmpIPredicate
-from flydsl.expr.typing import T, Int32, Stream
-from flydsl.expr.vector import ReductionOp
-from flydsl._mlir.dialects import llvm, rocdl
+from flydsl.expr.typing import Int32, ReductionOp, Stream, T
 
-from .tensor_shim import GTensor, _to_raw, _run_compiled
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 # JIT-free MX-format mode/dtype int mirrors. ``aiter.utility.mx_types``'s
 # pybind11 ``MxScaleRoundMode`` / ``MxDtype`` lazy-load on first attribute
@@ -72,9 +69,13 @@ from .tensor_shim import GTensor, _to_raw, _run_compiled
 # (mirrors the FlyDSL AOT-friendly pattern in ``quant_utils``).
 from aiter.ops.flydsl.kernels.quant_utils import emit_mx_e8m0_scale
 from aiter.utility.mx_types import (
-    MxDtypeInt as _D,
     MX_DEFAULT_ROUND_MODE as _DEFAULT_MODE,
 )
+from aiter.utility.mx_types import (
+    MxDtypeInt as _D,
+)
+
+from .tensor_shim import GTensor, _run_compiled, _to_raw
 
 _STATIC_ADAPTOR_CACHE = {}
 _STATIC_ADAPTOR_CACHE_MAX = 64

--- a/aiter/ops/flydsl/kernels/silu_and_mul_fq.py
+++ b/aiter/ops/flydsl/kernels/silu_and_mul_fq.py
@@ -22,21 +22,22 @@ Compile options:
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, vector, range_constexpr, const_expr
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, scf
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, const_expr, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import Int32, T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
 
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.ops.flydsl.kernels.quant_utils import emit_f32_to_e2m1, emit_mx_e8m0_scale
 from aiter.utility.mx_types import (
-    MxDtypeInt as _D,
     MX_DEFAULT_ROUND_MODE as _DEFAULT_MODE,
 )
-from flydsl._mlir.dialects import llvm, scf
-from flydsl.expr import buffer_ops
+from aiter.utility.mx_types import (
+    MxDtypeInt as _D,
+)
 
 BLOCK_THREADS = 256
 WARP_SIZE = 64

--- a/aiter/ops/flydsl/kernels/small_m_hgemm.py
+++ b/aiter/ops/flydsl/kernels/small_m_hgemm.py
@@ -39,13 +39,15 @@ import functools
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from aiter.jit.utils.chip_info import get_gfx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl, vector
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch
+
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.flydsl.kernels import vector
 
 from .splitk_hgemm import (
     OnlineScheduler,

--- a/aiter/ops/flydsl/kernels/splitk_hgemm.py
+++ b/aiter/ops/flydsl/kernels/splitk_hgemm.py
@@ -8,17 +8,11 @@ import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
-from flydsl.expr import (
-    arith,
-    buffer_ops,
-    const_expr,
-    gpu,
-    range_constexpr,
-    rocdl,
-    vector,
-)
+from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 from .tensor_shim import GTensor, get_dtype_in_kernel
 

--- a/aiter/ops/flydsl/kernels/swiglu_and_mul.py
+++ b/aiter/ops/flydsl/kernels/swiglu_and_mul.py
@@ -21,14 +21,14 @@ per iteration, avoiding read-modify-write races.
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl.expr import arith, range_constexpr
-from flydsl.expr.typing import T, Int32
-from flydsl.expr.arith import ArithValue, CmpIPredicate
-from flydsl.compiler.kernel_function import CompilationContext
-
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm, scf
-from flydsl.expr import buffer_ops
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import Int32, T
+
+from aiter.ops.flydsl.kernels import buffer_ops
 
 BLOCK_THREADS = 256
 NLANE = 16

--- a/aiter/ops/flydsl/kernels/tensor_shim.py
+++ b/aiter/ops/flydsl/kernels/tensor_shim.py
@@ -2,19 +2,19 @@
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
 import os
-
-import torch
-import numpy as np
-import flydsl.compiler as flyc
-from itertools import product
 from abc import ABC, abstractmethod
+from itertools import product
 
+import flydsl.compiler as flyc
+import numpy as np
+import torch
+from flydsl._mlir import ir
 from flydsl._mlir.dialects import fly, llvm
 from flydsl.compiler.protocol import extract_to_ir_values
-from flydsl._mlir import ir
+from flydsl.expr import arith, ptrtoint, range_constexpr
 from flydsl.expr.typing import T
 
-from flydsl.expr import buffer_ops, range_constexpr, vector, arith, ptrtoint
+from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 # Global toggle for the amdgpu-kernarg-preload compile hint used by the flydsl
 # kernels. Enabled by default; set AITER_FLYDSL_KERNARG_PRELOAD=0 to disable it

--- a/aiter/ops/flydsl/kernels/vector.py
+++ b/aiter/ops/flydsl/kernels/vector.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+# Modifications Copyright (C) 2026 Advanced Micro Devices, Inc.
+
+"""Vector dialect wrappers, vendored into aiter.
+
+flydsl deleted ``flydsl.expr.vector``; callers are now expected to use the raw
+``flydsl._mlir.dialects.vector`` and wrap every operand in ``as_ir_value``.
+aiter has 500+ vector call sites, so the auto-unwrapping layer is kept here
+instead — a missing ``as_ir_value`` or ``kDynamic`` sentinel only surfaces at
+trace time.
+
+Re-exports the whole raw dialect (``broadcast``, ``shuffle``, ``insert``,
+``extract_strided_slice``, ``reduction``, ...) and rebuilds the five wrappers
+that unwrap DSL values: ``from_elements``, ``store``, ``extract``,
+``load_op``, ``bitcast``. ``extract`` also supplies the ``kDynamic`` sentinel
+for dynamic positions. Only published flydsl APIs are used.
+
+Upstream: FlyDSL ``python/flydsl/expr/vector.py``, deleted before
+ROCm/FlyDSL#880; the five wrapper bodies are unchanged apart from imports
+being made absolute.
+"""
+
+from __future__ import annotations
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import vector as _vector
+
+# Re-export the raw dialect so vector.broadcast / vector.shuffle work directly
+from flydsl._mlir.dialects.vector import *
+from flydsl.expr.meta import dsl_loc_tracing
+
+# Vector and related types, which flydsl.expr.vector also re-exported
+from flydsl.expr.typing import (  # noqa: F401
+    ReductionOp,
+    Vector,
+    empty_like,
+    full,
+    full_like,
+    ones_like,
+    zeros_like,
+)
+
+# ═══════════════════════════════════════════════════════════════════════
+# Dialect helper wrappers (legacy, will be deprecated)
+# Prefer using Vector methods or _mlir.dialects.vector directly.
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@dsl_loc_tracing
+def from_elements(*args, **kwargs):
+    """Construct a vector from scalar elements, auto-unwrapping ArithValue wrappers."""
+    from flydsl.expr import arith as _arith_ext
+
+    if len(args) >= 2:
+        args = list(args)
+        elems = args[1]
+        if isinstance(elems, (list, tuple)):
+            args[1] = [_arith_ext.unwrap(v) for v in elems]
+        return _vector.from_elements(*args, **kwargs)
+
+    return _vector.from_elements(*args, **kwargs)
+
+
+@dsl_loc_tracing
+def store(value, memref, indices, **kwargs):
+    """Vector store wrapper that accepts ArithValue/wrappers for value/indices."""
+    from flydsl.expr import arith as _arith_ext
+
+    return _vector.store(
+        _arith_ext.unwrap(value),
+        _arith_ext.unwrap(memref),
+        [_arith_ext.unwrap(i, index=True) for i in indices],
+        **kwargs,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Thin wrappers for common op classes that otherwise require `.result` access.
+# -----------------------------------------------------------------------------
+
+
+@dsl_loc_tracing
+def extract(vector, static_position=None, dynamic_position=None):
+    """Wrapper around `vector.ExtractOp(...).result`.
+
+    When only ``dynamic_position`` is supplied (without explicit
+    ``static_position``), each dynamic index needs a corresponding
+    ``kDynamic`` sentinel in the static attribute so the ODS builder
+    pairs them correctly.  This wrapper fills in the sentinels
+    automatically.
+    """
+    from flydsl.expr import arith as _arith_ext
+
+    if static_position is None:
+        static_position = []
+    if dynamic_position is None:
+        dynamic_position = []
+    dynamic_position = [_arith_ext.unwrap(i, index=True) for i in dynamic_position]
+
+    n_static = len(static_position)
+    n_dynamic = len(dynamic_position)
+    if n_dynamic > 0 and n_static < n_dynamic:
+        kDynamic = ir.ShapedType.get_dynamic_size()
+        static_position = list(static_position) + [kDynamic] * (n_dynamic - n_static)
+
+    return _vector.ExtractOp(
+        _arith_ext.unwrap(vector),
+        static_position=static_position,
+        dynamic_position=dynamic_position,
+    ).result
+
+
+@dsl_loc_tracing
+def load_op(result_type, memref, indices):
+    """Wrapper around `vector.LoadOp(...).result`."""
+    from flydsl.expr import arith as _arith_ext
+
+    return _vector.LoadOp(
+        result_type,
+        _arith_ext.unwrap(memref),
+        [_arith_ext.unwrap(i, index=True) for i in indices],
+    ).result
+
+
+@dsl_loc_tracing
+def bitcast(result_type, source):
+    """Wrapper around `vector.BitCastOp(...).result`."""
+    from flydsl.expr import arith as _arith_ext
+
+    return _vector.BitCastOp(
+        result_type,
+        _arith_ext.unwrap(source),
+    ).result

--- a/aiter/ops/triton/gluon/pa_decode_gluon.py
+++ b/aiter/ops/triton/gluon/pa_decode_gluon.py
@@ -4,19 +4,19 @@
 from functools import lru_cache
 
 import torch
-
-import aiter
-import aiter.ops.triton.utils._triton.arch_info as arch_info
 import triton
 import triton.language as tl
 from triton.language.extra.hip import libdevice as hip_libdevice
+
+import aiter
+from aiter.ops.triton.utils._triton import arch_info
 
 CXX_PS_REDUCE_AVAILABLE = True
 try:
     from csrc.cpp_itfs.pa.pa_ps import (
         launch_pa_decode_ps_reduce as launch_pa_decode_ps_reduce_cxx,
     )
-except Exception:
+except Exception:  # noqa: BLE001
     CXX_PS_REDUCE_AVAILABLE = False
     launch_pa_decode_ps_reduce_cxx = None
 
@@ -24,14 +24,16 @@ FLYDSL_PS_REDUCE_AVAILABLE = True
 try:
     import flydsl.compiler as flyc
     import flydsl.expr as fx
-    from flydsl.expr import arith, gpu, rocdl, buffer_ops, range_constexpr
-    from flydsl.expr.typing import T, Int32
-    from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
-    from flydsl.runtime.device import get_rocm_arch as get_hip_arch
     from flydsl._mlir import ir
-    from flydsl.compiler.kernel_function import CompilationContext
     from flydsl._mlir.dialects import arith as _mlir_arith
-except Exception:
+    from flydsl.compiler.kernel_function import CompilationContext
+    from flydsl.expr import arith, gpu, range_constexpr, rocdl
+    from flydsl.expr.typing import Int32, T
+    from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+    from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+
+    from aiter.ops.flydsl.kernels import buffer_ops
+except Exception:  # noqa: BLE001
     FLYDSL_PS_REDUCE_AVAILABLE = False
     flyc = None
     fx = None
@@ -64,7 +66,11 @@ except ImportError:
 try:
     from triton.experimental.gluon.language.amd.cdna3 import (
         sched_barrier as _amd_iglp_sched_barrier,
+    )
+    from triton.experimental.gluon.language.amd.cdna3 import (
         sched_group_barrier as _amd_iglp_sched_group_barrier,
+    )
+    from triton.experimental.gluon.language.amd.cdna3 import (
         set_prio as _amd_set_prio,
     )
 except ImportError:


### PR DESCRIPTION
flydsl no longer ships buffer_ops/vector in its wheel, so provide equivalent modules under aiter/ops/flydsl/kernels/ and repoint imports. Also fixes gpu.compute_mcast_masks, which never existed in flydsl.
