### PR TITLE
docs(readme): announce Kimi-K3 support in News

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 ## News
 
+- **[2026/07]** [Kimi-K3 support](https://github.com/ROCm/aiter/pull/4397) — FlyDSL SiTUv2 fused-MoE kernels, strided grouped-topk router, and tuned GEMM/fused-MoE configs (BF16, A8W4, FP4) for Kimi-K3
 - **[2026/04]** [AITER v0.1.12.post1 Released](https://github.com/ROCm/aiter/releases/tag/v0.1.12.post1) — patch on v0.1.12 with GEMM and scale masking accuracy fixes; v0.1.12 highlights include blockwise sparse Sage Attention, fused gated RMSNorm+group quantization, etc., plus MI355X tuned configs for Kimi-K2.5 and DeepSeek-V3
 - **[2026/02]** [JAX-AITER: Bringing AMD's Optimized AI Kernels to JAX on ROCm](https://rocm.blogs.amd.com/software-tools-optimization/jax-aiter/README.html)
 - **[2026/02]** [Beyond Porting: How vLLM Orchestrates High-Performance Inference on AMD ROCm](https://blog.vllm.ai/2026/02/27/rocm-attention-backend.html)


### PR DESCRIPTION
Adds a News entry to the root README announcing Kimi-K3 support, landed in #4397 (FlyDSL SiTUv2 fused-MoE kernels, strided grouped-topk router, tuned BF16/A8W4/FP4 GEMM and fused-MoE configs).

README-only change; the Aiter Test workflow skips `*.md`-only PRs per its path filters.