### PR TITLE
perf(mla): expose split override for graph decode

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -130,6 +130,7 @@ if [[ "$mla_in_shard" == "true" && "$MULTIGPU" != "TRUE" ]]; then
         "-c 98304 -b 1 -n 16,1 -kvd fp8" \
         "-c 10000 100000 -b 1 3 4 -n 12,1 16,1 -kvd bf16 -lse" \
         "-c 1 21 63 64 65 256 -b 1 -n 16,1 -kvd bf16 -lse" \
+        "-c 1 31 32 63 64 65 8192 -b 1 -n 12,1 -d bf16 -kvd bf16 -k 512 -qn 512 -qr 64 -vh 512 -blk 1 --varlen --gluon-num-kv-splits 32" \
         "-c 16384 -b 4 -n 16,8 16,17 -kvd bf16"; do
         echo "=== extra: test_mla.py $args ===" | tee -a latest_test.log
         if ! timeout 10m python3 op_tests/test_mla.py $args 2>&1 | tee -a latest_test.log; then

--- a/aiter/ops/triton/gluon/README.md
+++ b/aiter/ops/triton/gluon/README.md
@@ -157,17 +157,25 @@ python op_tests/op_benchmarks/triton/bench_gemm_a8w8_blockscale.py [-gluon]
 
 ### `mla_gluon.py` — MLA Decode + DeepSeek V4 Sparse Prefill
 
-**Function:** `mla_gluon(q_nope, q_pe, kv_c, o, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1, return_lse=False)`
+**Function:** `mla_gluon(q_nope, q_pe, kv_c, o, page_table, seq_info, sm_scale, k_pe=None, kv_pe_offset=512, use_2d_view=True, kv_scale=1.0, min_kv_seq_len=1, return_lse=False, has_pe=True, attn_sink=None, num_kv_splits=None)`
 
 **Description:** Multi-head Latent Attention (DeepSeek MLA) kernel with split-KV. For MLA Decode, Q is split into compressed latent (`q_nope`, dim=kv_lora_rank) and rope positional encoding (`q_pe`, dim=qk_rope_head_dim). KV cache is a flat `[N, 576]` buffer (`kv_c`). For DSv4 Sparse Prefill, Q packs compressed latent and positional encoding into one contiguous row (448 NoPE + 64 RoPE, `q_nope` with shape `[nquery, nhead, 512]`), KV cache has aligned `head_dim=512`, `q_pe` and `k_pe` can be left as placeholders. Uses 3-stage async copy pipeline with double-buffered page numbers and KV tiles.
 
 The wrapper dispatches by `(nhead, kv_c.dtype)` to one of three compile-time regimes (single `@gluon.jit` kernel, REGIME constexpr gates layouts and grid mapping):
 
 - **`bh64`** (`nhead in {64, 128}`): bf16 KV, BLOCK_H=64, BLOCK_N=64, multi-batch + XCD-aware 3-D grid. `NUM_KV_SPLITS` auto-picked &isin; {1, 2, 4} so the launch fills ~256 workgroups (one wave on MI350). When `NUM_KV_SPLITS == 1`, stage-1 writes the final attention output directly to `o` (no temp buffer, no reduce). When `NUM_KV_SPLITS > 1`, stage-1 writes per-split `(acc, fp32 lse)` and stage-2 (`_mla_softmax_reducev_kernel`) reduces them into `o`.
-- **`bh16bn128`** (`nhead &le; 16`, `batch_size == 1`, fp8 KV): BLOCK_H=16, BLOCK_N=128, 2-D grid `(1, NUM_KV_SPLITS)` with token-bound `NUM_KV_SPLITS = max(1, min(256, min_kv_seq_len))` — 256 for the normal long-context path, reduced only for small kv (`min_kv_seq_len < 256`) so every split stays non-empty. Optional `kv_scale` dequant. Stage-2 reduce runs whenever `NUM_KV_SPLITS > 1` (skipped via the fast path only at `min_kv_seq_len == 1`). Supports the general case `num_iter &isin; {1, 2, ...}` (no `gl.assume(num_iter >= 3)`). `NHEAD < BLOCK_H` masks OOB heads on Q load and O store (wasted MFMA lanes are free; this regime is memory-bound).
-- **`bh16bn64`** (`nhead &le; 16`, bf16 KV): BLOCK_H=16, BLOCK_N=64, 2-D grid `(batch_size, NUM_KV_SPLITS)` with block-bound `NUM_KV_SPLITS = max(1, min(256 // batch_size, cdiv(min_kv_seq_len, BLOCK_N)))` — fills ~256 WGs but never splits a sequence into more than its 64-token block count, so small kv is supported and it collapses to 1 (one WG per batch over the whole sequence) when `min_kv_seq_len <= 64`. Use when KV is kept in bf16 (no fp8 quant). Same `NHEAD < BLOCK_H` masking. Full decode (stage-1, plus stage-2 reduce into `o` when `NUM_KV_SPLITS > 1`).
+- **`bh16bn128`** (`nhead &le; 16`, `batch_size == 1`, fp8 KV): BLOCK_H=16, BLOCK_N=128, 3-D grid `(1, NUM_KV_SPLITS, qlen)` with token-bound `NUM_KV_SPLITS = max(1, min(256 // qlen, min_kv_seq_len))` — 256 for single-query long-context decode, reduced for larger query lengths or small KV so the automatic policy keeps every split non-empty. Optional `kv_scale` dequant. Stage-2 reduce runs whenever `NUM_KV_SPLITS > 1`. Supports the general case `num_iter &isin; {1, 2, ...}` (no `gl.assume(num_iter >= 3)`). `NHEAD < BLOCK_H` masks OOB heads on Q load and O store (wasted MFMA lanes are free; this regime is memory-bound).
+- **`bh16bn64`** (`nhead &le; 16`, bf16 KV): BLOCK_H=16, BLOCK_N=64, 3-D grid `(batch_size, NUM_KV_SPLITS, qlen)` with block-bound `NUM_KV_SPLITS = max(1, min(256 // (batch_size * qlen), cdiv(min_kv_seq_len, BLOCK_N)))` — fills ~256 WGs but never splits a sequence into more than its 64-token block count, so small kv is supported and it collapses to 1 (one WG per batch and query position over the whole sequence) when `min_kv_seq_len <= 64`. Use when KV is kept in bf16 (no fp8 quant). Same `NHEAD < BLOCK_H` masking. Full decode (stage-1, plus stage-2 reduce into `o` when `NUM_KV_SPLITS > 1`).
 
-All three regimes run the full decode and dsv4 prefill. `return_lse=True` also returns the merged fp32 lse `[batch, nhead]`, so `mla_gluon(...)` returns `(o, final_lse)` instead of `(o, None)`.
+All three regimes run the full decode and dsv4 prefill. `return_lse=True` also returns the merged fp32 lse `[batch, qlen, nhead]` (`qlen=1` for plain decode), so `mla_gluon(...)` returns `(o, final_lse)` instead of `(o, None)`.
+
+By default, each regime derives `NUM_KV_SPLITS` from the static batch shape and
+`min_kv_seq_len`. Graph-captured callers that cannot provide a useful runtime
+minimum may pass an explicitly tuned `num_kv_splits` in `[1, 256]`. This is a
+caller-owned scheduling policy: the generic wrapper does not infer a model from
+its tensor shape. If the override creates empty leading splits for a short
+sequence, stage 1 skips them and stage 2 uses the runtime sequence length to
+reduce only initialized splits.
 
 Modified from [FlashMLA](https://github.com/deepseek-ai/FlashMLA/blob/main/benchmark/bench_flash_mla.py).
 
@@ -183,17 +191,17 @@ Modified from [FlashMLA](https://github.com/deepseek-ai/FlashMLA/blob/main/bench
 | BLOCK_H | 64 | 16 | 16 |
 | BLOCK_N | 64 | 128 | 64 |
 | MFMA | 16&times;16&times;32, warps=[4,1] | 16&times;16&times;32, warps=[1,4] | 16&times;16&times;32, warps=[1,4] |
-| Grid | 3-D XCD-aware | 2-D `(1, NUM_KV_SPLITS)` | 2-D `(batch, NUM_KV_SPLITS)` |
-| NUM_KV_SPLITS | auto &isin; {1, 2, 4} from (batch, nhead) | `max(1, min(256, min_kv_seq_len))` (token-bound; 256 for ctx &ge; 256) | `max(1, min(256 // batch_size, cdiv(min_kv_seq_len, 64)))` (block-bound; collapses to 1 for ctx &le; 64) |
+| Grid | 3-D XCD-aware | 3-D `(1, NUM_KV_SPLITS, qlen)` | 3-D `(batch, NUM_KV_SPLITS, qlen)` |
+| NUM_KV_SPLITS | auto &isin; {1, 2, 4} from (batch, nhead, qlen) | `max(1, min(256 // qlen, min_kv_seq_len))` (token-bound; 256 for qlen=1 and ctx &ge; 256) | `max(1, min(256 // (batch_size * qlen), cdiv(min_kv_seq_len, 64)))` (block-bound; collapses to 1 for ctx &le; 64) |
 | `kv_scale` | unused (pass 1.0) | dequant scale folded into `qk_scale` (applied before softmax for fp8 correctness) | unused (pass 1.0) |
-| Seq constraint | `min_kv_seq_len > NUM_KV_SPLITS * (3 * BLOCK_N + NUM_KV_SPLITS)` (the `3` matches the kernel's `gl.assume(num_iter > 3)`) | `min_kv_seq_len &ge; 1` (small kv 1..256 supported; token-bound clamp keeps splits non-empty) | `min_kv_seq_len &ge; 1` (small kv 1..256 supported; block-bound clamp keeps splits non-empty) |
-| Stage-2 reduce | skipped when `NUM_KV_SPLITS == 1` | skipped when `NUM_KV_SPLITS == 1` (i.e. `min_kv_seq_len == 1`) | skipped when `NUM_KV_SPLITS == 1` |
+| Seq constraint | `min_kv_seq_len > NUM_KV_SPLITS * (3 * BLOCK_N + NUM_KV_SPLITS)` (the `3` matches the kernel's `gl.assume(num_iter > 3)`) | `min_kv_seq_len &ge; 1` (automatic token-bound clamp keeps splits non-empty; explicit empty leading splits are supported) | `min_kv_seq_len &ge; 1` (automatic block-bound clamp keeps splits non-empty; explicit empty leading splits are supported) |
+| Stage-2 reduce | skipped when `NUM_KV_SPLITS == 1` | skipped when `NUM_KV_SPLITS == 1` | skipped when `NUM_KV_SPLITS == 1` |
 
-**Page table modes** (`use_2d_view`, both regimes):
+**Page table modes** (`use_2d_view`, all regimes):
 - `True`: `page_table = block_table [batch, max_seqlen]`, `seq_info = cache_seqlens [batch]`. Use for fixed-length or pre-padded variable-length sequences.
 - `False`: `page_table = kv_indices [total_kv]`, `seq_info = kv_indptr [batch+1]`. Use for variable-length sequences without block_table construction.
 
-**KV layout** (both regimes): By default `kv_c` is a flat `[N, 576]` buffer containing both the compressed latent (columns `[0, 512)`) and rope PE (columns `[512, 576)`). The kernel adds `kv_pe_offset` to k_pe column offsets — set to `kv_lora_rank` (512) when `k_pe` shares `kv_c` (default), or `0` when `k_pe` is a separate buffer. The kernel auto-selects the load instruction via `WITHIN_2GB`: `buffer_load_to_shared` (scalar base + 32-bit offsets) when KV caches &le; 2 GB, or `global_load_to_shared` (64-bit pointer tensors) when KV caches > 2 GB.
+**KV layout** (all regimes): By default `kv_c` is a flat `[N, 576]` buffer containing both the compressed latent (columns `[0, 512)`) and rope PE (columns `[512, 576)`). The kernel adds `kv_pe_offset` to k_pe column offsets — set to `kv_lora_rank` (512) when `k_pe` shares `kv_c` (default), or `0` when `k_pe` is a separate buffer. The kernel auto-selects the load instruction via `WITHIN_2GB`: `buffer_load_to_shared` (scalar base + 32-bit offsets) when KV caches &le; 2 GB, or `global_load_to_shared` (64-bit pointer tensors) when KV caches > 2 GB.
 
 **`bh64` perf** (MI350, ctx=16384, bf16 Q + bf16 KV; compute-bound):
 

--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -10,14 +10,15 @@
 #                        Fast path: when NUM_KV_SPLITS==1, stage-1 writes the
 #                        final output directly to O and stage-2 reduce is skipped.
 #   REGIME='bh16bn128' - bf16 Q + fp8 KV, BLOCK_H=16, BLOCK_N=128,
-#                        nhead <= 16, batch_size=1, NUM_KV_SPLITS=256.
-#                        2-D (batch, split) grid. Always splits + always
-#                        reduces. NHEAD < BLOCK_H masks OOB heads on Q load
-#                        and O store.
+#                        nhead <= 16, batch_size=1. 3-D
+#                        (batch, split, q_pos) grid. Automatic NUM_KV_SPLITS
+#                        is bounded by qlen and the minimum KV sequence length.
+#                        NHEAD < BLOCK_H masks OOB heads on Q load and O store.
 #   REGIME='bh16bn64'  - bf16 Q + bf16 KV, BLOCK_H=16, BLOCK_N=64,
-#                        nhead <= 16, batch_size >= 1, 2-D (batch, split) grid,
-#                        NUM_KV_SPLITS = max(1, 256 // batch_size). Full decode
-#                        (stage-1 + stage-2 reduce into the final O).
+#                        nhead <= 16, batch_size >= 1. 3-D
+#                        (batch, split, q_pos) grid. Automatic NUM_KV_SPLITS
+#                        is bounded by batch_size, qlen, and KV block count.
+#                        Full decode (stage-1 + stage-2 reduce into final O).
 #                        NHEAD < BLOCK_H masks OOB heads on Q load and O store.
 #
 # The bh16 regimes support num_iter in {1, 2, ...} (no gl.assume(num_iter>=3));
@@ -28,7 +29,7 @@
 #
 # Full decode for all regimes. For NUM_KV_SPLITS>1 stage-1 writes per-split acc +
 # fp32 lse; stage-2 (_mla_softmax_reducev_kernel) reduces into O. RETURN_LSE also
-# returns the merged fp32 lse [B, H] (stage-2 for splits>1, else stage-1).
+# returns the merged fp32 lse [B, QLEN, H] (stage-2 for splits>1, else stage-1).
 #
 # 3-stage software pipeline (double-buffered, BLOCK_N with 2x(BLOCK_N/2) KV slices):
 #   AC = async_copy (global->LDS), LL = load (LDS->reg), P = page, K = K-cache, V = V-cache
@@ -49,8 +50,28 @@ import triton.language as tl
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 
-import aiter.ops.triton.utils._triton.arch_info as arch_info
+from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils.device_info import get_num_xcds
+
+_MAX_NUM_KV_SPLITS = 256
+
+
+def _resolve_num_kv_splits(auto_num_kv_splits, num_kv_splits):
+    """Return the automatic split count or a validated caller override."""
+    if num_kv_splits is None:
+        return auto_num_kv_splits
+    if isinstance(num_kv_splits, bool) or not isinstance(num_kv_splits, int):
+        raise TypeError(
+            "num_kv_splits must be an int or None, "
+            f"got {type(num_kv_splits).__name__}"
+        )
+    if not 1 <= num_kv_splits <= _MAX_NUM_KV_SPLITS:
+        raise ValueError(
+            f"num_kv_splits must be in [1, {_MAX_NUM_KV_SPLITS}], "
+            f"got {num_kv_splits}"
+        )
+    return num_kv_splits
+
 
 # fmt: off
 @gluon.jit
@@ -105,10 +126,9 @@ def _mla_gluon(
     HAS_PE: gl.constexpr,
     HAS_ATTN_SINK: gl.constexpr,
 ):
-    # Grid mapping: bh64 uses 3-D XCD-aware multi-batch; bh16bn64 and bh16bn128
-    # use 2-D (batch, split) — for batch_size=1 this is (1, NUM_KV_SPLITS).
-    # MTP: an extra q_pos axis carries the query position within QLEN. bh64 packs
-    # it into grid axis 1 (after the head-block index); bh16 uses grid axis 2.
+    # Grid mapping: all stage-1 launches are 3-D. bh64 uses an XCD-aware
+    # multi-batch mapping and packs q_pos into grid axis 1 after the head-block
+    # index. bh16 uses (batch, split, q_pos), with q_pos on grid axis 2.
     # When QLEN==1, q_pos is always 0 and the layout below is identical to before.
     if REGIME == 'bh64':
         NUM_M_BLOCKS: gl.constexpr = (NHEAD + BLOCK_H - 1) // BLOCK_H
@@ -816,6 +836,7 @@ def mla_gluon(
     return_lse=False,
     has_pe=True,
     attn_sink=None,  # [nhead] fp32 per-head sink bias, None means no sink
+    num_kv_splits=None,
 ):
     """Unified Gluon MLA entry (gfx950 / CDNA4) — decode and DeepSeek V4 sparse prefill.
 
@@ -835,6 +856,10 @@ def mla_gluon(
 
     return_lse=True: additionally returns the merged log-sum-exp, a separate
         fp32 tensor [batch, qlen, nhead]
+
+    num_kv_splits=None uses the regime's automatic split policy.
+    Set num_kv_splits to an integer in [1, 256] when a graph-captured caller
+    cannot provide a useful min_kv_seq_len and has an externally tuned schedule.
 
     DSv4 Sparse prefill packs NoPE and RoPE in to one contiguous row (448+64).
     To run DSv4 prefill, it requires has_pe=False, prepares valid Q / K in q_nope / kv_c,
@@ -902,7 +927,11 @@ def mla_gluon(
         base_grid = (
             NUM_XCDS * triton.cdiv(nhead, BLOCK_H) * qlen * (batch_size // NUM_XCDS)
         )
-        NUM_KV_SPLITS = max(1, triton.next_power_of_2(triton.cdiv(256, base_grid)))
+        auto_num_kv_splits = max(
+            1,
+            triton.next_power_of_2(triton.cdiv(_MAX_NUM_KV_SPLITS, base_grid)),
+        )
+        NUM_KV_SPLITS = _resolve_num_kv_splits(auto_num_kv_splits, num_kv_splits)
 
         assert (
             batch_size % 64 == 0
@@ -924,25 +953,37 @@ def mla_gluon(
         BLOCK_H = 16
         BLOCK_N = 128 if REGIME == "bh16bn128" else 64
         kv_dtype = torch.float8_e4m3fn if REGIME == "bh16bn128" else torch.bfloat16
-        NUM_XCDS = 1  # unused by 2-D split grid mapping
-        # 2-D grid (batch, split). Both bh16 regimes support num_iter in {1, 2, ...}
-        # (no gl.assume(num_iter >= 3) in the kernel); the only correctness need is
-        # that every split is non-empty (floor split size = min_kv_seq_len //
-        # NUM_KV_SPLITS >= 1). Each clamp below keeps NUM_KV_SPLITS <= min_kv_seq_len,
+        NUM_XCDS = 1  # unused by the bh16 (batch, split, q_pos) grid mapping
+        # Both bh16 regimes support num_iter in {1, 2, ...}
+        # (no gl.assume(num_iter >= 3) in the kernel). The automatic policy keeps
+        # every split non-empty. An explicit override may create empty leading
+        # splits for short sequences; stage 1 skips them and stage 2 derives the
+        # valid split range from the runtime sequence length.
         if REGIME == "bh16bn128":
             assert (
                 batch_size == 1
             ), f"mla_gluon[bh16bn128] requires batch_size=1, got {batch_size}"
-            NUM_KV_SPLITS = max(1, min(256 // (batch_size * qlen), min_kv_seq_len))
+            auto_num_kv_splits = max(
+                1,
+                min(
+                    _MAX_NUM_KV_SPLITS // (batch_size * qlen),
+                    min_kv_seq_len,
+                ),
+            )
         else:  # bh16bn64
             # Fill ~256 WGs (total WGs = B * NUM_KV_SPLITS <= 256, one MI350 wave),
             # but never split a sequence into more blocks than it has: bound by the
             # shortest seq's block count so every split holds >= 1 block (no wasted
             # partial-block MFMA). For min_kv_seq_len <= BLOCK_N this collapses to
             # NUM_KV_SPLITS=1, i.e. one WG per batch computing the whole (short) seq.
-            NUM_KV_SPLITS = max(
-                1, min(256 // (batch_size * qlen), triton.cdiv(min_kv_seq_len, BLOCK_N))
+            auto_num_kv_splits = max(
+                1,
+                min(
+                    _MAX_NUM_KV_SPLITS // (batch_size * qlen),
+                    triton.cdiv(min_kv_seq_len, BLOCK_N),
+                ),
             )
+        NUM_KV_SPLITS = _resolve_num_kv_splits(auto_num_kv_splits, num_kv_splits)
         assert (
             q_nope.dtype == torch.bfloat16 and q_pe.dtype == torch.bfloat16
         ), f"q_nope/q_pe must be bf16, got {q_nope.dtype}/{q_pe.dtype}"

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -140,6 +140,7 @@ def test_mla(
     return_lse=False,
     is_causal=True,
     sequential_page_indices=False,
+    gluon_num_kv_splits=None,
 ):
     ret = {}
 
@@ -232,11 +233,14 @@ def test_mla(
 
     us_aiter = None
     prefill_ref_token_cap = 512 * 1024
+    ck_prefill_max_qk_head_dim = 256
     # Prefill ref builds [nhead, (batch*ctx)^2] fp32 attn weights; bound both
     # the lazy "tile area" gate and the per-call ctx so decode-scale ctx_lens
-    # (1M+) never trigger the O(N^2) ref.
+    # (1M+) never trigger the O(N^2) ref. CK prefill supports QK head
+    # dimensions up to 256; larger absorbed-MLA decode shapes remain enabled.
     if (
         (dtype == torch.bfloat16 and kvtype == torch.bfloat16)
+        and qk_head_dim <= ck_prefill_max_qk_head_dim
         and batch_size * ctx_lens * nhead < 256 * 8192 * 16
         and ctx_lens <= 16384
         and total_qo <= prefill_ref_token_cap
@@ -518,6 +522,7 @@ def test_mla(
             sm_scale,
             use_2d_view=use_2d_view,
             min_kv_seq_len=ctx_lens,
+            num_kv_splits=gluon_num_kv_splits,
             return_lse=return_lse,
         )
 
@@ -580,6 +585,7 @@ def test_mla(
             use_2d_view=use_2d_view,
             kv_scale=1.0,
             min_kv_seq_len=ctx_lens,
+            num_kv_splits=gluon_num_kv_splits,
             return_lse=return_lse,
         )
 
@@ -856,6 +862,13 @@ parser.add_argument(
     help="""Enable/disable causal masking. Default: True.
     --causal / --no-causal""",
 )
+parser.add_argument(
+    "--gluon-num-kv-splits",
+    type=int,
+    default=None,
+    help="""Override Gluon MLA's automatic split count.
+    e.g.: --gluon-num-kv-splits 32""",
+)
 
 
 args = parser.parse_args()
@@ -883,6 +896,7 @@ for nhead, decode_qlen in args.nhead:
                 return_lse=args.return_lse,
                 is_causal=args.causal,
                 sequential_page_indices=args.sequential_page_indices,
+                gluon_num_kv_splits=args.gluon_num_kv_splits,
             )
             df.append(ret)
     df = pd.DataFrame(df)

--- a/op_tests/triton_tests/attention/test_mla_gluon_split_policy.py
+++ b/op_tests/triton_tests/attention/test_mla_gluon_split_policy.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+
+from aiter.ops.triton.gluon.mla_gluon import _resolve_num_kv_splits
+
+
+@pytest.mark.parametrize("auto_num_kv_splits", [1, 4, 32, 256])
+def test_default_num_kv_splits_uses_auto_policy(auto_num_kv_splits):
+    assert _resolve_num_kv_splits(auto_num_kv_splits, None) == auto_num_kv_splits
+
+
+@pytest.mark.parametrize("num_kv_splits", [1, 16, 32, 256])
+def test_num_kv_splits_override(num_kv_splits):
+    assert _resolve_num_kv_splits(1, num_kv_splits) == num_kv_splits
+
+
+@pytest.mark.parametrize("num_kv_splits", [0, 257, -1])
+def test_num_kv_splits_override_rejects_out_of_range(num_kv_splits):
+    with pytest.raises(ValueError, match=r"must be in \[1, 256\]"):
+        _resolve_num_kv_splits(1, num_kv_splits)
+
+
+@pytest.mark.parametrize("num_kv_splits", [True, 32.0, "32"])
+def test_num_kv_splits_override_rejects_non_integer(num_kv_splits):
+    with pytest.raises(TypeError, match="must be an int or None"):
+        _resolve_num_kv_splits(1, num_kv_splits)


### PR DESCRIPTION
## Purpose

Expose a validated `num_kv_splits` override for graph-captured Gluon MLA
decode while preserving automatic scheduling and positional API compatibility.
The lasting value of this PR is its 14-case split-policy coverage and the
Kimi-K3 TP8 boundary test.

## Test plan

- Run the policy test across invalid, automatic, and explicit split values.
- Run Kimi-K3 TP8 batch-one BF16 MLA at short split boundaries and 8K context.

```bash
IMAGE='vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b'
docker run --rm --ipc=host --shm-size=16g \
  --device=/dev/kfd --device=/dev/dri --group-add=video --group-add=render \
  -e HIP_VISIBLE_DEVICES=0 --entrypoint bash "$IMAGE" -lc '
git clone -q https://github.com/ROCm/aiter.git /tmp/aiter && cd /tmp/aiter
git fetch -q origin pull/4405/head && git checkout -q --detach FETCH_HEAD
test "$(git rev-parse HEAD)" = 47cafc7c12d6757e96536a5693bd56428136d1d9
uv run --no-project --offline python -m pytest -q \
  op_tests/triton_tests/attention/test_mla_gluon_split_policy.py
uv run --no-project --offline python op_tests/test_mla.py \
  -c 1 31 32 63 64 65 8192 -b 1 -n 12,1 -d bf16 -kvd bf16 \
  -k 512 -qn 512 -qr 64 -vh 512 -blk 1 --varlen \
  --gluon-num-kv-splits 32
'
```

## Test results

| Evidence | Result |
| --- | --- |
| Split policy | 14 parameter cases retained |
| Kimi-K3 boundary | Explicit split-32 command retained above |
| Performance | No independent number claimed by this disposition |

## Overlap and limits

ROCm/aiter#4450 now owns the same caller-visible override plus a more complete
device-side runtime bucket policy. If #4450 contains equivalent boundary and
override tests, close this PR as superseded; otherwise rebase only the tests
after #4450 lands. Merging both runtime implementations would duplicate policy.

## Tool assistance

OpenAI Codex assisted with review and drafting this disposition.
