### PR TITLE
fix(gemm_a8w8_blockscale): prevent scale OOB and support Triton 3.6

### DIFF
--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -988,6 +988,7 @@ def gemm_a8w8_blockscale_bpreshuffle(
             w_scale,
             dtype=dtype,
             config=_fallback_cfg,
+            is_x_scale_tranposed=x_scale.stride(0) != 1,
         )
     config = get_CKGEMM_config(
         m, n, k, AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE
@@ -1015,6 +1016,7 @@ def gemm_a8w8_blockscale_bpreshuffle(
             w_scale,
             dtype=dtype,
             backend=backend,
+            is_x_scale_tranposed=x_scale.stride(0) != 1,
         )
     if config is not None:
         libtype = config["libtype"]

--- a/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
@@ -6,6 +6,7 @@ import os
 
 import torch
 import triton
+from packaging.version import Version
 
 from aiter.ops.triton._triton_kernels.common.splitk_reduce import (
     _gemm_splitk_reduce_kernel,
@@ -25,6 +26,7 @@ from aiter.ops.triton.utils.logger import AiterTritonLogger
 
 _LOGGER = AiterTritonLogger()
 _FORCE_GFX1250_EX = os.environ.get("AITER_FORCE_GFX1250_EX", "0") == "1"
+_TRITON_GE_37 = Version(triton.__version__) >= Version("3.7.0")
 
 _GLUON_SUPPORTED_ARCHS = ("gfx1250",)
 
@@ -304,6 +306,16 @@ def gemm_a8w8_blockscale_preshuffle(
 
     if config is None:
         config, _ = _get_config(M, N, K, True, backend=backend)
+
+    # Triton 3.6 fails TritonAMDGPUConvertToBufferOps for gfx950 preshuffle
+    # configs with three pipeline stages. Keep the tuned tile and split-K.
+    if (
+        backend == "triton"
+        and get_arch() == "gfx950"
+        and not _TRITON_GE_37
+        and config.get("num_stages", 1) > 2
+    ):
+        config["num_stages"] = 2
 
     kernel_type_from_config = config.pop("kernel_type", None)
     if kernel_type_from_config is not None:

--- a/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/gemm/basic/gemm_a8w8_blockscale.py
@@ -26,7 +26,7 @@ from aiter.ops.triton.utils.logger import AiterTritonLogger
 
 _LOGGER = AiterTritonLogger()
 _FORCE_GFX1250_EX = os.environ.get("AITER_FORCE_GFX1250_EX", "0") == "1"
-_TRITON_GE_37 = Version(triton.__version__) >= Version("3.7.0")
+_TRITON_VERSION = Version(triton.__version__)
 
 _GLUON_SUPPORTED_ARCHS = ("gfx1250",)
 
@@ -312,7 +312,7 @@ def gemm_a8w8_blockscale_preshuffle(
     if (
         backend == "triton"
         and get_arch() == "gfx950"
-        and not _TRITON_GE_37
+        and _TRITON_VERSION < Version("3.7.0")
         and config.get("num_stages", 1) > 2
     ):
         config["num_stages"] = 2

--- a/op_tests/test_gemm_a8w8_blockscale.py
+++ b/op_tests/test_gemm_a8w8_blockscale.py
@@ -110,7 +110,8 @@ def test_gemm(dtype, m, n, k, ck_preshuffle=True, use_flydsl=False):
     a, _ = run_torch(x, weight, x_scale, w_scale, dtype)
 
     x_scale_t = x_scale.transpose(0, 1).contiguous().view(*x_scale.shape)
-    gemm_x_scale = x_scale_t if ck_preshuffle else x_scale
+    x_scale_sglang = x_scale.transpose(0, 1).contiguous().transpose(0, 1)
+    gemm_x_scale = x_scale_sglang if ck_preshuffle else x_scale
     gemm_weight = shuffle_weight(weight, layout=(16, 16)) if ck_preshuffle else weight
     run_func = run_gemm_bpreshuffle if ck_preshuffle else run_gemm
     b, avg_b = run_func(x, gemm_weight, gemm_x_scale, w_scale, dtype)

--- a/op_tests/test_gemm_a8w8_blockscale.py
+++ b/op_tests/test_gemm_a8w8_blockscale.py
@@ -110,13 +110,23 @@ def test_gemm(dtype, m, n, k, ck_preshuffle=True, use_flydsl=False):
     a, _ = run_torch(x, weight, x_scale, w_scale, dtype)
 
     x_scale_t = x_scale.transpose(0, 1).contiguous().view(*x_scale.shape)
-    x_scale_sglang = x_scale.transpose(0, 1).contiguous().transpose(0, 1)
-    gemm_x_scale = x_scale_sglang if ck_preshuffle else x_scale
+    gemm_x_scale = x_scale_t if ck_preshuffle else x_scale
     gemm_weight = shuffle_weight(weight, layout=(16, 16)) if ck_preshuffle else weight
     run_func = run_gemm_bpreshuffle if ck_preshuffle else run_gemm
     b, avg_b = run_func(x, gemm_weight, gemm_x_scale, w_scale, dtype)
 
     err_ck = checkAllclose(a, b, msg="ck", catastrophic_check=True)
+    if ck_preshuffle:
+        x_scale_strided = x_scale.transpose(0, 1).contiguous().transpose(0, 1)
+        b_strided = aiter.gemm_a8w8_blockscale_bpreshuffle(
+            x, gemm_weight, x_scale_strided, w_scale, dtype
+        )
+        checkAllclose(
+            a,
+            b_strided,
+            msg="ck strided x_scale",
+            catastrophic_check=True,
+        )
     ret["ck us"] = avg_b
     ret["ck TFLOPS"] = m * n * k * 2 / avg_b / 1e6
     ret["ck TB/s"] = (x.nbytes + weight.nbytes) / avg_b / 1e6


### PR DESCRIPTION
## Summary

- Correctly dispatch both flattened-transpose and strided-transpose `x_scale` layouts.
- Prevent out-of-bounds scale reads that caused NaNs and GPU memory-access faults.
- On gfx950 with Triton `<3.7`, cap preshuffle configs at two pipeline stages to avoid `TritonAMDGPUConvertToBufferOps` failures.
- Preserve existing routing, tile sizes, split-K configs, and benchmark measurements.

AITER-pinned Triton 3.7+ keeps its existing three-stage tuned configs unchanged.

## Regression Test

The existing benchmark path remains unchanged. An additional unmeasured public-API call validates the strided scale representation against the Torch reference.

## Validation

- Triton 3.6 routed shapes for `(2048,7168)`, `(7168,4096)`, and `(7168,16384)`: pass.
- Flattened and strided scale layouts match bitwise on Triton 3.7.
- CUDA graph capture plus 10 replays pass for:
  - `M=32,N=2048,K=7168`
  - `M=144,N=8192,K=1536`
- DeepSeek-V3.2 E2E: pass.
- DeepSeek-V4-Pro E2E: pass after prewarming an unrelated CKTile cold-JIT module.

No CK/ASM fallback or CSV routing changes.

Addresses #4323.