### PR TITLE
feat(moe): add SharedEP MXFP4 kernels

### DIFF
--- a/aiter/ops/triton/__init__.py
+++ b/aiter/ops/triton/__init__.py
@@ -124,6 +124,7 @@ _BACKWARD_COMPAT_MAP = {
     "moe_routing_sigmoid_top1_fused": "moe.moe_routing_sigmoid_top1_fused",
     "moe_routing": "moe.moe_routing",
     "quant_moe": "moe.quant_moe",
+    "shared_ep_mxfp4": "moe.shared_ep_mxfp4",
     # Normalization modules (normalization/)
     "fused_add_rmsnorm_pad": "normalization.fused_add_rmsnorm_pad",
     "fused_rmsnorm_add": "normalization.fused_rmsnorm_add",

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4.py
@@ -199,7 +199,7 @@ def _fused_moe_kernel_mxfp4(
     # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
     offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
     offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
-    token_mask = offs_token < num_valid_tokens
+    token_mask = (offs_token >= 0) & (offs_token < num_valid_tokens)
 
     off_expert = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
     if off_expert == -1:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4.py
@@ -4,6 +4,7 @@
 import triton
 import triton.language as tl
 
+from aiter.ops.triton._triton_kernels.quant.quant import _mxfp4_quant_op
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.moe_common import _write_zeros_to_output
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
@@ -32,6 +33,8 @@ _fused_moe_kernel_mxfp4_repr = make_kernel_repr(
         "EVEN_K",
         "MUL_ROUTED_WEIGHT",
         "top_k",
+        "A_ROW_DIVISOR",
+        "QUANTIZE_A_TO_MXFP4",
         "compute_type",
         "SWIZZLE_MX_A",
         "SWIZZLE_MX_B",
@@ -86,6 +89,8 @@ def _fused_moe_kernel_mxfp4(
     EVEN_K: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
     top_k: tl.constexpr,
+    A_ROW_DIVISOR: tl.constexpr,
+    QUANTIZE_A_TO_MXFP4: tl.constexpr,
     compute_type: tl.constexpr,
     SWIZZLE_MX_A: tl.constexpr,  # TODO add swizzle support
     SWIZZLE_MX_B: tl.constexpr,  # TODO add swizzle support
@@ -120,6 +125,29 @@ def _fused_moe_kernel_mxfp4(
     is_a_microscaled_format: tl.constexpr = a_mx_scale_ptr is not None
     is_b_microscaled_format: tl.constexpr = b_mx_scale_ptr is not None
     MX_PACK_DIVISOR: tl.constexpr = 32
+    tl.static_assert(A_ROW_DIVISOR > 0, "A_ROW_DIVISOR must be positive")
+    if QUANTIZE_A_TO_MXFP4:
+        tl.static_assert(
+            not is_a_microscaled_format,
+            "on-the-fly activation quantization requires unquantized A",
+        )
+        tl.static_assert(
+            is_b_microscaled_format,
+            "on-the-fly activation quantization requires microscaled B",
+        )
+        tl.static_assert(
+            a_ptr.dtype.element_ty == tl.bfloat16
+            or a_ptr.dtype.element_ty == tl.float16,
+            "on-the-fly MXFP4 activation quantization requires BF16/FP16 A",
+        )
+        tl.static_assert(
+            b_ptr.dtype.element_ty == tl.uint8,
+            "on-the-fly MXFP4 activation quantization requires E2M1 B",
+        )
+        tl.static_assert(
+            BLOCK_SIZE_K % MX_PACK_DIVISOR == 0,
+            "BLOCK_SIZE_K must be a multiple of the MX scale group",
+        )
     if is_a_microscaled_format:
         a_type: tl.constexpr = a_ptr.dtype.element_ty
         tl.static_assert(
@@ -231,7 +259,7 @@ def _fused_moe_kernel_mxfp4(
             a_mx_scale_ptrs = (
                 a_mx_scale_ptr
                 + offs_scale_ak.to(tl.int64)[None, :] * stride_amxk
-                + offs_scale_m.to(tl.int64)[:, None] // top_k * stride_amxm
+                + offs_scale_m.to(tl.int64)[:, None] // A_ROW_DIVISOR * stride_amxm
             )
     else:
         a_mx_scale_ptrs = None
@@ -285,7 +313,7 @@ def _fused_moe_kernel_mxfp4(
     offs_a_k = tl.arange(0, PACKED_BLOCK_K_A)
     offs_b_k = tl.arange(0, PACKED_BLOCK_K_B)
     a_ptrs = a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_a_k[None, :] * stride_ak
+        offs_token[:, None] // A_ROW_DIVISOR * stride_am + offs_a_k[None, :] * stride_ak
     )
     b_ptrs = (
         b_ptr
@@ -345,16 +373,31 @@ def _fused_moe_kernel_mxfp4(
                 b_mx_scale_ptrs, mask=mask_bk_scale[None, :], other=0.0
             )
 
-            accumulator = tl.dot_scaled(
-                a,
-                a_mx_scales,
-                A_DTYPE_FORMAT,
-                b,
-                b_mx_scales,
-                B_DTYPE_FORMAT,
-                acc=accumulator,
-                fast_math=True,
-            )
+            if QUANTIZE_A_TO_MXFP4:
+                a_fp4, a_fp4_scales = _mxfp4_quant_op(
+                    a, BLOCK_SIZE_K, BLOCK_SIZE_M, MX_PACK_DIVISOR
+                )
+                accumulator = tl.dot_scaled(
+                    a_fp4,
+                    a_fp4_scales,
+                    "e2m1",
+                    b,
+                    b_mx_scales,
+                    B_DTYPE_FORMAT,
+                    acc=accumulator,
+                    fast_math=True,
+                )
+            else:
+                accumulator = tl.dot_scaled(
+                    a,
+                    a_mx_scales,
+                    A_DTYPE_FORMAT,
+                    b,
+                    b_mx_scales,
+                    B_DTYPE_FORMAT,
+                    acc=accumulator,
+                    fast_math=True,
+                )
 
             if is_a_microscaled_format:
                 if SWIZZLE_MX_A:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from aiter.ops.triton._triton_kernels.activation import _silu_exp2
+from aiter.ops.triton._triton_kernels.quant.quant import _mxfp4_quant_op
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.moe_common import _write_zeros_to_output
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
@@ -33,6 +34,8 @@ _fused_moe_kernel_mxfp4_silu_repr = make_kernel_repr(
         "EVEN_K",
         "MUL_ROUTED_WEIGHT",
         "top_k",
+        "A_ROW_DIVISOR",
+        "QUANTIZE_A_TO_MXFP4",
         "compute_type",
         "SWIZZLE_MX_A",
         "SWIZZLE_MX_B",
@@ -86,6 +89,9 @@ def _fused_moe_kernel_mxfp4_silu(
     EVEN_K: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
     top_k: tl.constexpr,
+    A_ROW_DIVISOR: tl.constexpr,
+    QUANTIZE_A_TO_MXFP4: tl.constexpr,
+    SWIGLU_LIMIT: tl.constexpr,
     compute_type: tl.constexpr,
     SWIZZLE_MX_A: tl.constexpr,  # TODO add swizzle support
     SWIZZLE_MX_B: tl.constexpr,  # TODO add swizzle support
@@ -119,6 +125,29 @@ def _fused_moe_kernel_mxfp4_silu(
     is_a_microscaled_format: tl.constexpr = a_mx_scale_ptr is not None
     is_b_microscaled_format: tl.constexpr = b_mx_scale_ptr is not None
     MX_PACK_DIVISOR: tl.constexpr = 32
+    tl.static_assert(A_ROW_DIVISOR > 0, "A_ROW_DIVISOR must be positive")
+    if QUANTIZE_A_TO_MXFP4:
+        tl.static_assert(
+            not is_a_microscaled_format,
+            "on-the-fly activation quantization requires unquantized A",
+        )
+        tl.static_assert(
+            is_b_microscaled_format,
+            "on-the-fly activation quantization requires microscaled B",
+        )
+        tl.static_assert(
+            a_ptr.dtype.element_ty == tl.bfloat16
+            or a_ptr.dtype.element_ty == tl.float16,
+            "on-the-fly MXFP4 activation quantization requires BF16/FP16 A",
+        )
+        tl.static_assert(
+            b_ptr.dtype.element_ty == tl.uint8,
+            "on-the-fly MXFP4 activation quantization requires E2M1 B",
+        )
+        tl.static_assert(
+            BLOCK_SIZE_K % MX_PACK_DIVISOR == 0,
+            "BLOCK_SIZE_K must be a multiple of the MX scale group",
+        )
     if is_a_microscaled_format:
         a_type: tl.constexpr = a_ptr.dtype.element_ty
         tl.static_assert(
@@ -240,7 +269,7 @@ def _fused_moe_kernel_mxfp4_silu(
             a_mx_scale_ptrs = (
                 a_mx_scale_ptr
                 + offs_scale_ak.to(tl.int64)[None, :] * stride_amxk
-                + offs_scale_m.to(tl.int64)[:, None] // top_k * stride_amxm
+                + offs_scale_m.to(tl.int64)[:, None] // A_ROW_DIVISOR * stride_amxm
             )
     else:
         a_mx_scale_ptrs = None
@@ -294,7 +323,7 @@ def _fused_moe_kernel_mxfp4_silu(
     offs_a_k = tl.arange(0, PACKED_BLOCK_K_A)
     offs_b_k = tl.arange(0, PACKED_BLOCK_K_B)
     a_ptrs = a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_a_k[None, :] * stride_ak
+        offs_token[:, None] // A_ROW_DIVISOR * stride_am + offs_a_k[None, :] * stride_ak
     )
     b_ptrs = (
         b_ptr
@@ -354,16 +383,31 @@ def _fused_moe_kernel_mxfp4_silu(
                 b_mx_scale_ptrs, mask=mask_bk_scale[None, :], other=0.0
             )
 
-            accumulator = tl.dot_scaled(
-                a,
-                a_mx_scales,
-                A_DTYPE_FORMAT,
-                b,
-                b_mx_scales,
-                B_DTYPE_FORMAT,
-                acc=accumulator,
-                fast_math=True,
-            )
+            if QUANTIZE_A_TO_MXFP4:
+                a_fp4, a_fp4_scales = _mxfp4_quant_op(
+                    a, BLOCK_SIZE_K, BLOCK_SIZE_M, MX_PACK_DIVISOR
+                )
+                accumulator = tl.dot_scaled(
+                    a_fp4,
+                    a_fp4_scales,
+                    "e2m1",
+                    b,
+                    b_mx_scales,
+                    B_DTYPE_FORMAT,
+                    acc=accumulator,
+                    fast_math=True,
+                )
+            else:
+                accumulator = tl.dot_scaled(
+                    a,
+                    a_mx_scales,
+                    A_DTYPE_FORMAT,
+                    b,
+                    b_mx_scales,
+                    B_DTYPE_FORMAT,
+                    acc=accumulator,
+                    fast_math=True,
+                )
 
             if is_a_microscaled_format:
                 if SWIZZLE_MX_A:
@@ -389,6 +433,9 @@ def _fused_moe_kernel_mxfp4_silu(
         accumulator.to(tl.float32).reshape(BLOCK_SIZE_M, BLOCK_SIZE_HALF, 2).split()
     )
 
+    if SWIGLU_LIMIT > 0.0:
+        silu_acc = tl.minimum(silu_acc, SWIGLU_LIMIT)
+        mul_acc = tl.maximum(tl.minimum(mul_acc, SWIGLU_LIMIT), -SWIGLU_LIMIT)
     silu_acc = _silu_exp2(silu_acc)
     accumulator = (silu_acc * mul_acc).to(compute_type)
     # -----------------------------------------------------------

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py
@@ -200,7 +200,7 @@ def _fused_moe_kernel_mxfp4_silu(
     # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
     offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
     offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
-    token_mask = offs_token < num_valid_tokens
+    token_mask = (offs_token >= 0) & (offs_token < num_valid_tokens)
 
     off_expert = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
     if off_expert == -1:

--- a/aiter/ops/triton/moe/moe_op_mxfp4.py
+++ b/aiter/ops/triton/moe/moe_op_mxfp4.py
@@ -37,6 +37,10 @@ def fused_moe_mxfp4(
     swizzle_mx_b: bool,
     config: dict[str, Any],
     compute_type: tl.dtype,
+    *,
+    input_row_divisor: int | None = None,
+    num_valid_routes: int | None = None,
+    quantize_a_to_mxfp4: bool = False,
 ) -> None:
     """
     Fused MoE computation with MXFP4 (microscale FP4) quantization.
@@ -61,6 +65,12 @@ def fused_moe_mxfp4(
         config (Dict[str, Any]): Kernel tuning parameters (BLOCK_SIZE_M, BLOCK_SIZE_N,
             BLOCK_SIZE_K, GROUP_SIZE_M).
         compute_type (tl.dtype): Computation dtype for accumulation.
+        input_row_divisor (Optional[int]): Maps a route ID to an A row with
+            ``route_id // input_row_divisor``. Defaults to ``top_k``.
+        num_valid_routes (Optional[int]): Exclusive upper bound for valid route IDs.
+            Defaults to ``topk_ids.numel()``.
+        quantize_a_to_mxfp4 (bool): Quantize BF16/FP16 A tiles to MXFP4 in the
+            kernel before the scaled dot product.
 
     Returns:
         None. Results written in-place to C.
@@ -75,6 +85,12 @@ def fused_moe_mxfp4(
     )
     assert topk_weights.stride(1) == 1
     assert sorted_token_ids.stride(0) == 1
+    if input_row_divisor is None:
+        input_row_divisor = top_k
+    assert input_row_divisor > 0
+    if num_valid_routes is None:
+        num_valid_routes = topk_ids.numel()
+    assert num_valid_routes >= 0
 
     assert A_scale is not None
     assert B_scale is not None
@@ -93,7 +109,10 @@ def fused_moe_mxfp4(
         # We assume that top_ids of each token is unique, so
         # so num_valid_experts <= batch_size <= BLOCK_SIZE_M,
         # and we can skip some invalid blocks.
-        EM = min(sorted_token_ids.shape[0], A.shape[0] * top_k * config["BLOCK_SIZE_M"])
+        EM = min(
+            sorted_token_ids.shape[0],
+            A.shape[0] * input_row_divisor * config["BLOCK_SIZE_M"],
+        )
 
     A_tl_dtype = torch_to_triton_dtype[A.dtype]
     A_DTYPE_FORMAT = get_scaled_dot_format_string(A_tl_dtype)
@@ -118,7 +137,7 @@ def fused_moe_mxfp4(
         num_tokens_post_padded,
         B.shape[1],
         A.shape[1],
-        topk_ids.numel(),
+        num_valid_routes,
         A.stride(0),
         A.stride(1),
         B.stride(0),
@@ -135,6 +154,8 @@ def fused_moe_mxfp4(
         B_DTYPE_FORMAT=B_DTYPE_FORMAT,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         top_k=top_k,
+        A_ROW_DIVISOR=input_row_divisor,
+        QUANTIZE_A_TO_MXFP4=quantize_a_to_mxfp4,
         compute_type=compute_type,
         SWIZZLE_MX_A=swizzle_mx_a,  # TODO add swizzle support
         SWIZZLE_MX_B=swizzle_mx_b,  # TODO add swizzle support

--- a/aiter/ops/triton/moe/moe_op_mxfp4_silu_fused.py
+++ b/aiter/ops/triton/moe/moe_op_mxfp4_silu_fused.py
@@ -36,6 +36,11 @@ def fused_moe_mxfp4_silu(
     swizzle_mx_b: bool,
     config: dict[str, Any],
     compute_type: tl.dtype,
+    *,
+    input_row_divisor: int | None = None,
+    num_valid_routes: int | None = None,
+    quantize_a_to_mxfp4: bool = False,
+    swiglu_limit: float | None = None,
 ) -> None:
     """
     Fused MoE computation with MXFP4 quantization and SiLU activation.
@@ -60,6 +65,14 @@ def fused_moe_mxfp4_silu(
         config (Dict[str, Any]): Kernel tuning parameters (BLOCK_SIZE_M, BLOCK_SIZE_N,
             BLOCK_SIZE_K, GROUP_SIZE_M).
         compute_type (tl.dtype): Computation dtype for accumulation.
+        input_row_divisor (Optional[int]): Maps a route ID to an A row with
+            ``route_id // input_row_divisor``. Defaults to ``top_k``.
+        num_valid_routes (Optional[int]): Exclusive upper bound for valid route IDs.
+            Defaults to ``topk_ids.numel()``.
+        quantize_a_to_mxfp4 (bool): Quantize BF16/FP16 A tiles to MXFP4 in the
+            kernel before the scaled dot product.
+        swiglu_limit (Optional[float]): If positive, clamp gate to ``limit`` and
+            up to ``[-limit, limit]`` before applying SwiGLU.
 
     Returns:
         None. Results written in-place to C with SiLU activation applied.
@@ -74,6 +87,12 @@ def fused_moe_mxfp4_silu(
     )
     assert topk_weights.stride(1) == 1
     assert sorted_token_ids.stride(0) == 1
+    if input_row_divisor is None:
+        input_row_divisor = top_k
+    assert input_row_divisor > 0
+    if num_valid_routes is None:
+        num_valid_routes = topk_ids.numel()
+    assert num_valid_routes >= 0
 
     assert A_scale is not None
     assert B_scale is not None
@@ -92,7 +111,10 @@ def fused_moe_mxfp4_silu(
         # We assume that top_ids of each token is unique, so
         # so num_valid_experts <= batch_size <= BLOCK_SIZE_M,
         # and we can skip some invalid blocks.
-        EM = min(sorted_token_ids.shape[0], A.shape[0] * top_k * config["BLOCK_SIZE_M"])
+        EM = min(
+            sorted_token_ids.shape[0],
+            A.shape[0] * input_row_divisor * config["BLOCK_SIZE_M"],
+        )
 
     A_tl_dtype = torch_to_triton_dtype[A.dtype]
     A_DTYPE_FORMAT = get_scaled_dot_format_string(A_tl_dtype)
@@ -117,7 +139,7 @@ def fused_moe_mxfp4_silu(
         num_tokens_post_padded,
         B.shape[1],
         A.shape[1],
-        topk_ids.numel(),
+        num_valid_routes,
         A.stride(0),
         A.stride(1),
         B.stride(0),
@@ -134,6 +156,9 @@ def fused_moe_mxfp4_silu(
         B_DTYPE_FORMAT=B_DTYPE_FORMAT,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         top_k=top_k,
+        A_ROW_DIVISOR=input_row_divisor,
+        QUANTIZE_A_TO_MXFP4=quantize_a_to_mxfp4,
+        SWIGLU_LIMIT=0.0 if swiglu_limit is None else float(swiglu_limit),
         compute_type=compute_type,
         SWIZZLE_MX_A=swizzle_mx_a,  # TODO add swizzle support
         SWIZZLE_MX_B=swizzle_mx_b,  # TODO add swizzle support

--- a/aiter/ops/triton/moe/shared_ep_mxfp4.py
+++ b/aiter/ops/triton/moe/shared_ep_mxfp4.py
@@ -1,0 +1,846 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Safe gfx950 MXFP4 compute adapter for SharedEP.
+
+SharedEP route IDs are canonical global route slots.  This adapter keeps that
+identity throughout both projections:
+
+* W13 reads owner row ``route_id // top_k`` and writes the fused
+  ``silu(gate) * up`` result to row ``route_id``.
+* W2 reads intermediate row ``route_id``, applies the canonical (unsorted)
+  route weight, and writes row ``route_id`` directly to the owner route slot.
+
+Only canonical ``[expert, output, packed_k]`` MXFP4 weights and canonical
+``[expert, output, k // 32]`` E8M0 scales are accepted.  Preshuffled or
+swizzled layouts intentionally fail closed.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Callable, ContextManager, Literal, Mapping, Optional, Union
+
+import torch
+
+
+SharedEPMXFP4Stage = Literal["w13", "w2"]
+
+
+class SharedEPMXFP4WeightLayout(str, Enum):
+    """Weight layouts understood by the SharedEP adapter."""
+
+    CANONICAL = "canonical"
+
+
+class SharedEPMXFP4ScaleLayout(str, Enum):
+    """E8M0 scale layouts understood by the SharedEP adapter."""
+
+    CANONICAL = "canonical"
+
+
+@dataclass(frozen=True)
+class SharedEPMXFP4Profile:
+    """Shape and routing metadata passed to config/profile hooks."""
+
+    stage: SharedEPMXFP4Stage
+    num_owner_rows: int
+    route_capacity: int
+    num_active_routes: Optional[int]
+    num_padded_routes: int
+    route_block_size: int
+    num_experts: int
+    input_dim: int
+    output_dim: int
+    top_k: int
+
+
+SharedEPMXFP4ConfigHook = Callable[[SharedEPMXFP4Profile], Optional[Mapping[str, Any]]]
+SharedEPMXFP4ProfileHook = Callable[
+    [SharedEPMXFP4Profile, Mapping[str, Any]], Optional[ContextManager[Any]]
+]
+
+_FP4_PACKED_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
+_E8M0_DTYPE = getattr(torch, "float8_e8m0fnu", None)
+_INTEGER_DTYPES = (torch.int32, torch.int64)
+_ROUTE_WEIGHT_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+_REQUIRED_CONFIG_KEYS = (
+    "BLOCK_SIZE_M",
+    "BLOCK_SIZE_N",
+    "BLOCK_SIZE_K",
+    "GROUP_SIZE_M",
+    "num_warps",
+    "num_stages",
+)
+
+
+def _normalize_stage(stage: str) -> SharedEPMXFP4Stage:
+    normalized = stage.lower()
+    if normalized not in ("w13", "w2"):
+        raise ValueError(f"stage must be 'w13' or 'w2', got {stage!r}")
+    return normalized  # type: ignore[return-value]
+
+
+def _normalize_layout(
+    layout: Union[str, SharedEPMXFP4WeightLayout],
+) -> SharedEPMXFP4WeightLayout:
+    try:
+        normalized = SharedEPMXFP4WeightLayout(layout)
+    except ValueError as exc:
+        raise ValueError(
+            "SharedEP MXFP4 only supports canonical unswizzled weights; "
+            f"got weight_layout={layout!r}"
+        ) from exc
+    if normalized is not SharedEPMXFP4WeightLayout.CANONICAL:
+        raise ValueError("SharedEP MXFP4 only supports canonical unswizzled weights")
+    return normalized
+
+
+def _normalize_scale_layout(
+    layout: Union[str, SharedEPMXFP4ScaleLayout],
+) -> SharedEPMXFP4ScaleLayout:
+    try:
+        normalized = SharedEPMXFP4ScaleLayout(layout)
+    except ValueError as exc:
+        raise ValueError(
+            "SharedEP MXFP4 only supports canonical unswizzled E8M0 scales; "
+            f"got scale_layout={layout!r}"
+        ) from exc
+    if normalized is not SharedEPMXFP4ScaleLayout.CANONICAL:
+        raise ValueError(
+            "SharedEP MXFP4 only supports canonical unswizzled E8M0 scales"
+        )
+    return normalized
+
+
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and value & (value - 1) == 0
+
+
+def _require_positive_int(value: int, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+def _require_tensor(tensor: torch.Tensor, name: str) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+
+
+def _owner_rows_view(
+    activations: torch.Tensor, stage: SharedEPMXFP4Stage
+) -> torch.Tensor:
+    _require_tensor(activations, "activations")
+    if activations.ndim < 2:
+        raise ValueError(
+            f"{stage} activations must have at least 2 dimensions, got "
+            f"shape={tuple(activations.shape)}"
+        )
+    if stage == "w2" and activations.ndim != 2:
+        raise ValueError(
+            "W2 intermediate storage must be the 2D route-indexed tensor "
+            f"[route_capacity, K], got shape={tuple(activations.shape)}"
+        )
+    if activations.shape[-1] <= 0:
+        raise ValueError("activations must have a non-empty feature dimension")
+    rows = activations.numel() // activations.shape[-1]
+    try:
+        view = activations.view(rows, activations.shape[-1])
+    except RuntimeError as exc:
+        raise ValueError(
+            "rank-major activations must be viewable as [owner_rows, K] "
+            "without a copy"
+        ) from exc
+    if view.stride(1) != 1 or view.stride(0) < view.shape[1]:
+        raise ValueError(
+            "activations must have contiguous K and non-overlapping row-major rows; "
+            f"got stride={view.stride()}"
+        )
+    return view
+
+
+def _route_weights_view(route_weights: torch.Tensor, top_k: int) -> torch.Tensor:
+    _require_tensor(route_weights, "route_weights")
+    if route_weights.ndim < 2 or route_weights.shape[-1] != top_k:
+        raise ValueError(
+            "route_weights must use canonical rank-major owner layout "
+            f"[..., top_k={top_k}], got shape={tuple(route_weights.shape)}"
+        )
+    owner_rows = route_weights.numel() // top_k
+    try:
+        view = route_weights.view(owner_rows, top_k)
+    except RuntimeError as exc:
+        raise ValueError(
+            "route_weights must be viewable as [owner_rows, top_k] without a copy"
+        ) from exc
+    if not view.is_contiguous():
+        raise ValueError("route_weights must be contiguous in canonical route order")
+    return view
+
+
+def _valid_fp4_dtype(dtype: torch.dtype) -> bool:
+    return dtype == torch.uint8 or (
+        _FP4_PACKED_DTYPE is not None and dtype == _FP4_PACKED_DTYPE
+    )
+
+
+def _valid_e8m0_dtype(dtype: torch.dtype) -> bool:
+    return dtype == torch.uint8 or (_E8M0_DTYPE is not None and dtype == _E8M0_DTYPE)
+
+
+def _as_uint8(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor if tensor.dtype == torch.uint8 else tensor.view(torch.uint8)
+
+
+def shared_ep_mxfp4_route_rows(
+    route_ids: torch.Tensor,
+    *,
+    stage: SharedEPMXFP4Stage,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return ``(input_rows, output_rows)`` for canonical SharedEP route IDs.
+
+    This helper is device agnostic and is also the executable CPU contract for
+    route indexing.  W13 maps its input through ``route_id // top_k``; W2 and
+    both outputs use ``route_id`` unchanged.
+    """
+
+    normalized_stage = _normalize_stage(stage)
+    _require_positive_int(top_k, "top_k")
+    _require_tensor(route_ids, "route_ids")
+    if route_ids.dtype not in _INTEGER_DTYPES:
+        raise TypeError(f"route_ids must have int32/int64 dtype, got {route_ids.dtype}")
+    if route_ids.numel() and bool((route_ids < 0).any().item()):
+        raise ValueError("route_ids must be non-negative")
+    input_rows = route_ids // top_k if normalized_stage == "w13" else route_ids
+    return input_rows, route_ids
+
+
+def validate_shared_ep_mxfp4_contract(
+    activations: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scales: torch.Tensor,
+    sorted_route_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    *,
+    stage: SharedEPMXFP4Stage,
+    top_k: int,
+    route_block_size: int,
+    route_weights: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    weight_layout: Union[
+        str, SharedEPMXFP4WeightLayout
+    ] = SharedEPMXFP4WeightLayout.CANONICAL,
+    scale_layout: Union[
+        str, SharedEPMXFP4ScaleLayout
+    ] = SharedEPMXFP4ScaleLayout.CANONICAL,
+    check_route_values: bool = True,
+    require_cuda: bool = False,
+) -> SharedEPMXFP4Profile:
+    """Validate the complete SharedEP MXFP4 tensor and route contract.
+
+    ``check_route_values=True`` performs a synchronizing validation of route
+    bounds, canonical padding, uniqueness, and local expert ranges.  Launch
+    APIs enable it by default so malformed remote-write metadata fails before
+    a kernel can access memory.
+    """
+
+    normalized_stage = _normalize_stage(stage)
+    _normalize_layout(weight_layout)
+    _normalize_scale_layout(scale_layout)
+    top_k = _require_positive_int(top_k, "top_k")
+    route_block_size = _require_positive_int(route_block_size, "route_block_size")
+    if not _is_power_of_two(route_block_size):
+        raise ValueError(
+            f"route_block_size must be a power of two, got {route_block_size}"
+        )
+
+    activations_2d = _owner_rows_view(activations, normalized_stage)
+    if activations_2d.dtype != torch.bfloat16:
+        raise TypeError(
+            "the functional SharedEP MXFP4 path requires BF16 activations, "
+            f"got {activations_2d.dtype}"
+        )
+
+    _require_tensor(weight, "weight")
+    _require_tensor(weight_scales, "weight_scales")
+    if weight.ndim != 3:
+        raise ValueError(
+            "weight must have canonical shape [experts, output, packed_k], "
+            f"got shape={tuple(weight.shape)}"
+        )
+    if not _valid_fp4_dtype(weight.dtype):
+        raise TypeError(
+            "weight must be packed OCP E2M1 (torch.uint8 or "
+            f"torch.float4_e2m1fn_x2), got {weight.dtype}"
+        )
+    if not weight.is_contiguous():
+        raise ValueError(
+            "weight must be contiguous canonical [expert, output, packed_k]; "
+            "shuffled/strided weights are unsupported"
+        )
+    if weight_scales.ndim != 3:
+        raise ValueError(
+            "weight_scales must have canonical shape [experts, output, k // 32], "
+            f"got shape={tuple(weight_scales.shape)}"
+        )
+    if not _valid_e8m0_dtype(weight_scales.dtype):
+        raise TypeError(
+            "weight_scales must contain E8M0 bytes (torch.uint8 or "
+            f"torch.float8_e8m0fnu), got {weight_scales.dtype}"
+        )
+    if not weight_scales.is_contiguous():
+        raise ValueError(
+            "weight_scales must be contiguous canonical E8M0 scales; "
+            "swizzled scales are unsupported"
+        )
+
+    num_experts, kernel_output_dim, packed_k = weight.shape
+    input_dim = activations_2d.shape[1]
+    if num_experts <= 0 or kernel_output_dim <= 0:
+        raise ValueError("weight expert and output dimensions must be non-empty")
+    if input_dim % 32 != 0:
+        raise ValueError(
+            f"input K={input_dim} must be divisible by the MXFP4 group size 32"
+        )
+    if packed_k != input_dim // 2:
+        raise ValueError(
+            f"weight packed K must be K/2={input_dim // 2}, got {packed_k}"
+        )
+    expected_scale_shape = (num_experts, kernel_output_dim, input_dim // 32)
+    if tuple(weight_scales.shape) != expected_scale_shape:
+        raise ValueError(
+            "weight_scales must provide one E8M0 byte per 32 logical K values: "
+            f"expected {expected_scale_shape}, got {tuple(weight_scales.shape)}"
+        )
+    if normalized_stage == "w13":
+        if kernel_output_dim % 2:
+            raise ValueError(
+                f"W13 packed gate/up output dimension must be even, got {kernel_output_dim}"
+            )
+        output_dim = kernel_output_dim // 2
+        num_owner_rows = activations_2d.shape[0]
+        route_capacity = num_owner_rows * top_k
+        if route_weights is not None:
+            raise ValueError("W13 does not consume route weights")
+    else:
+        output_dim = kernel_output_dim
+        route_capacity = activations_2d.shape[0]
+        if route_capacity % top_k:
+            raise ValueError(
+                f"W2 route capacity {route_capacity} must be divisible by top_k={top_k}"
+            )
+        num_owner_rows = route_capacity // top_k
+        if route_weights is None:
+            raise ValueError("W2 requires canonical unsorted route_weights")
+        route_weights_2d = _route_weights_view(route_weights, top_k)
+        if tuple(route_weights_2d.shape) != (num_owner_rows, top_k):
+            raise ValueError(
+                "route_weights capacity does not match W2 intermediate rows: "
+                f"expected {(num_owner_rows, top_k)}, "
+                f"got {tuple(route_weights_2d.shape)}"
+            )
+        if route_weights_2d.dtype not in _ROUTE_WEIGHT_DTYPES:
+            raise TypeError(
+                "route_weights must be BF16/FP16/FP32, " f"got {route_weights_2d.dtype}"
+            )
+
+    if route_capacity <= 0:
+        raise ValueError("route capacity must be positive")
+
+    _require_tensor(sorted_route_ids, "sorted_route_ids")
+    _require_tensor(expert_ids, "expert_ids")
+    _require_tensor(num_tokens_post_padded, "num_tokens_post_padded")
+    if sorted_route_ids.ndim != 1 or sorted_route_ids.dtype != torch.int32:
+        raise TypeError(
+            "sorted_route_ids must be a 1D int32 tensor of canonical route IDs"
+        )
+    if sorted_route_ids.stride(0) != 1:
+        raise ValueError("sorted_route_ids must be contiguous")
+    if expert_ids.ndim != 1 or expert_ids.dtype != torch.int32:
+        raise TypeError("expert_ids must be a 1D int32 tensor of local expert IDs")
+    if expert_ids.stride(0) != 1:
+        raise ValueError("expert_ids must be contiguous")
+    if (
+        num_tokens_post_padded.numel() != 1
+        or num_tokens_post_padded.dtype != torch.int32
+    ):
+        raise TypeError("num_tokens_post_padded must contain one int32 value")
+
+    tensors = [
+        activations,
+        weight,
+        weight_scales,
+        sorted_route_ids,
+        expert_ids,
+        num_tokens_post_padded,
+    ]
+    if route_weights is not None:
+        tensors.append(route_weights)
+    if out is not None:
+        _require_tensor(out, "out")
+        tensors.append(out)
+    expected_device = activations.device
+    for tensor in tensors:
+        if tensor.device != expected_device:
+            raise ValueError(
+                "all SharedEP MXFP4 tensors must be on one device; "
+                f"activations are on {expected_device}, got {tensor.device}"
+            )
+        if require_cuda and not tensor.is_cuda:
+            raise ValueError("SharedEP MXFP4 launch tensors must be on a ROCm device")
+
+    if out is not None:
+        if out.ndim != 2 or out.shape[1] != output_dim:
+            raise ValueError(
+                f"out must have shape [route_capacity, {output_dim}], "
+                f"got {tuple(out.shape)}"
+            )
+        if out.shape[0] < route_capacity:
+            raise ValueError(
+                f"out has {out.shape[0]} rows but route capacity is {route_capacity}"
+            )
+        if out.dtype != torch.bfloat16:
+            raise TypeError(f"out must be BF16, got {out.dtype}")
+        if not out.is_contiguous():
+            raise ValueError(
+                "out must be contiguous route-major storage for direct route writes"
+            )
+
+    # Avoid a device-to-host read during HIP Graph capture. The launch grid is
+    # allowed to cover the static route buffer; the kernel reads the device
+    # scalar and returns for blocks beyond the realized padded route count.
+    num_padded_routes = (
+        int(num_tokens_post_padded.item())
+        if check_route_values
+        else sorted_route_ids.numel()
+    )
+    num_active_routes: Optional[int] = None
+    if check_route_values:
+        if num_padded_routes < 0 or num_padded_routes > sorted_route_ids.numel():
+            raise ValueError(
+                "num_tokens_post_padded must be within sorted_route_ids capacity; "
+                f"got {num_padded_routes} for {sorted_route_ids.numel()} entries"
+            )
+        if num_padded_routes % route_block_size:
+            raise ValueError(
+                f"num_tokens_post_padded={num_padded_routes} is not divisible by "
+                f"route_block_size={route_block_size}"
+            )
+        num_route_blocks = num_padded_routes // route_block_size
+        if expert_ids.numel() < num_route_blocks:
+            raise ValueError(
+                f"expert_ids needs at least {num_route_blocks} entries, "
+                f"got {expert_ids.numel()}"
+            )
+        launched_routes = sorted_route_ids[:num_padded_routes]
+        if launched_routes.numel():
+            if bool((launched_routes < 0).any().item()):
+                raise ValueError("launched route IDs must be non-negative")
+            valid_mask = launched_routes < route_capacity
+            padding = launched_routes[~valid_mask]
+            if padding.numel() and bool((padding != route_capacity).any().item()):
+                raise ValueError(
+                    "padded route IDs must use the canonical route-capacity sentinel "
+                    f"{route_capacity}"
+                )
+            valid_routes = launched_routes[valid_mask]
+            num_active_routes = valid_routes.numel()
+            if valid_routes.numel() != torch.unique(valid_routes).numel():
+                raise ValueError(
+                    "valid route IDs must be unique to guarantee deterministic writes"
+                )
+        else:
+            num_active_routes = 0
+
+        launched_experts = expert_ids[:num_route_blocks]
+        if launched_experts.numel() and bool(
+            ((launched_experts < 0) | (launched_experts >= num_experts)).any().item()
+        ):
+            raise ValueError(
+                "expert_ids must contain local weight indices in "
+                f"[0, {num_experts}); -1/non-local blocks are unsafe for SharedEP"
+            )
+
+    return SharedEPMXFP4Profile(
+        stage=normalized_stage,
+        num_owner_rows=num_owner_rows,
+        route_capacity=route_capacity,
+        num_active_routes=num_active_routes,
+        num_padded_routes=num_padded_routes,
+        route_block_size=route_block_size,
+        num_experts=num_experts,
+        input_dim=input_dim,
+        output_dim=output_dim,
+        top_k=top_k,
+    )
+
+
+def get_shared_ep_mxfp4_config(
+    profile: SharedEPMXFP4Profile,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+    config_hook: Optional[SharedEPMXFP4ConfigHook] = None,
+) -> dict[str, Any]:
+    """Resolve and validate a gfx950 kernel config for a SharedEP profile.
+
+    An explicit ``config`` or per-profile ``config_hook`` can supply tuned
+    values.  With neither, AITER's ``gfx950-MOE-MX_FP4.json`` selector is used.
+    The selected ``BLOCK_SIZE_M`` must equal the block size used by route
+    preparation.
+    """
+
+    if not isinstance(profile, SharedEPMXFP4Profile):
+        raise TypeError("profile must be SharedEPMXFP4Profile")
+    if config is not None and config_hook is not None:
+        raise ValueError("pass either config or config_hook, not both")
+
+    selected: Optional[Mapping[str, Any]] = config
+    if config_hook is not None:
+        selected = config_hook(profile)
+    if selected is None:
+        from aiter.ops.triton.utils.moe_config_utils import get_optimal_moe_config
+
+        selected = get_optimal_moe_config(
+            torch.bfloat16,
+            use_mxfp4=True,
+            M=max(1, profile.num_owner_rows),
+        )
+    if selected is None:
+        raise RuntimeError("no gfx950 MXFP4 MoE config is available")
+
+    resolved = dict(selected)
+    missing = [key for key in _REQUIRED_CONFIG_KEYS if key not in resolved]
+    if missing:
+        raise ValueError(f"SharedEP MXFP4 config is missing keys: {missing}")
+    for key in _REQUIRED_CONFIG_KEYS:
+        value = resolved[key]
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"config[{key!r}] must be a positive integer")
+    for key in ("BLOCK_SIZE_M", "BLOCK_SIZE_N", "BLOCK_SIZE_K"):
+        if not _is_power_of_two(resolved[key]):
+            raise ValueError(f"config[{key!r}] must be a power of two")
+    if resolved["BLOCK_SIZE_M"] != profile.route_block_size:
+        raise ValueError(
+            "route preparation block size must match config BLOCK_SIZE_M: "
+            f"{profile.route_block_size} != {resolved['BLOCK_SIZE_M']}"
+        )
+    if resolved["BLOCK_SIZE_K"] % 32:
+        raise ValueError("config BLOCK_SIZE_K must be divisible by 32")
+    if profile.input_dim % resolved["BLOCK_SIZE_K"]:
+        raise ValueError(
+            f"functional BF16->MXFP4 path requires K={profile.input_dim} to be "
+            f"divisible by BLOCK_SIZE_K={resolved['BLOCK_SIZE_K']}"
+        )
+    kernel_output_dim = (
+        2 * profile.output_dim if profile.stage == "w13" else profile.output_dim
+    )
+    if kernel_output_dim % resolved["BLOCK_SIZE_N"]:
+        raise ValueError(
+            f"kernel output N={kernel_output_dim} must be divisible by "
+            f"BLOCK_SIZE_N={resolved['BLOCK_SIZE_N']}"
+        )
+    if profile.stage == "w13" and resolved["BLOCK_SIZE_N"] % 2:
+        raise ValueError("W13 config BLOCK_SIZE_N must be even")
+    return resolved
+
+
+def _require_gfx950() -> None:
+    from aiter.ops.triton.utils._triton import arch_info
+
+    arch = str(arch_info.get_arch()).split(":", 1)[0]
+    if arch != "gfx950":
+        raise RuntimeError(f"SharedEP MXFP4 requires gfx950, got {arch}")
+
+
+def _profile_context(
+    profile_hook: Optional[SharedEPMXFP4ProfileHook],
+    profile: SharedEPMXFP4Profile,
+    config: Mapping[str, Any],
+) -> ContextManager[Any]:
+    if profile_hook is None:
+        return nullcontext()
+    context = profile_hook(profile, MappingProxyType(dict(config)))
+    if context is None:
+        return nullcontext()
+    if not hasattr(context, "__enter__") or not hasattr(context, "__exit__"):
+        raise TypeError("profile_hook must return a context manager or None")
+    return context
+
+
+def _launch_shared_ep_mxfp4(
+    activations: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scales: torch.Tensor,
+    sorted_route_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    route_weights: Optional[torch.Tensor],
+    out: torch.Tensor,
+    profile: SharedEPMXFP4Profile,
+    config: Mapping[str, Any],
+    swiglu_limit: Optional[float] = None,
+) -> None:
+    from aiter.ops.triton.utils.types import torch_to_triton_dtype
+
+    activations_2d = _owner_rows_view(activations, profile.stage)
+    weight_u8 = _as_uint8(weight)
+    weight_scales_u8 = _as_uint8(weight_scales)
+    unit_a_scale = torch.ones((1,), dtype=torch.float32, device=activations.device)
+    unit_weight_scale = torch.ones(
+        (profile.num_experts,), dtype=torch.float32, device=activations.device
+    )
+
+    if profile.stage == "w13":
+        from aiter.ops.triton.moe.moe_op_mxfp4_silu_fused import (
+            fused_moe_mxfp4_silu,
+        )
+
+        # Neither legacy argument is read for W13.  The route-capacity bound is
+        # passed explicitly, and routed-weight multiplication is disabled.
+        route_metadata_proxy = out[:, :1]
+        fused_moe_mxfp4_silu(
+            activations_2d,
+            weight_u8,
+            out,
+            unit_a_scale,
+            unit_weight_scale,
+            None,
+            weight_scales_u8,
+            route_metadata_proxy,
+            route_metadata_proxy,
+            sorted_route_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            False,
+            profile.top_k,
+            False,
+            False,
+            dict(config),
+            torch_to_triton_dtype[torch.bfloat16],
+            input_row_divisor=profile.top_k,
+            num_valid_routes=profile.route_capacity,
+            quantize_a_to_mxfp4=True,
+            swiglu_limit=swiglu_limit,
+        )
+    else:
+        from aiter.ops.triton.moe.moe_op_mxfp4 import fused_moe_mxfp4
+
+        assert route_weights is not None
+        route_weights_2d = _route_weights_view(route_weights, profile.top_k)
+        fused_moe_mxfp4(
+            activations_2d,
+            weight_u8,
+            out.unsqueeze(1),
+            unit_a_scale,
+            unit_weight_scale,
+            None,
+            weight_scales_u8,
+            route_weights_2d,
+            route_weights_2d,
+            sorted_route_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            True,
+            profile.top_k,
+            False,
+            False,
+            dict(config),
+            torch_to_triton_dtype[torch.bfloat16],
+            input_row_divisor=1,
+            num_valid_routes=profile.route_capacity,
+            quantize_a_to_mxfp4=True,
+        )
+
+
+def shared_ep_mxfp4_w13(
+    activations: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scales: torch.Tensor,
+    sorted_route_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    *,
+    top_k: int,
+    route_block_size: int,
+    out: Optional[torch.Tensor] = None,
+    weight_layout: Union[
+        str, SharedEPMXFP4WeightLayout
+    ] = SharedEPMXFP4WeightLayout.CANONICAL,
+    scale_layout: Union[
+        str, SharedEPMXFP4ScaleLayout
+    ] = SharedEPMXFP4ScaleLayout.CANONICAL,
+    config: Optional[Mapping[str, Any]] = None,
+    config_hook: Optional[SharedEPMXFP4ConfigHook] = None,
+    profile_hook: Optional[SharedEPMXFP4ProfileHook] = None,
+    check_route_values: bool = True,
+    swiglu_limit: Optional[float] = None,
+) -> torch.Tensor:
+    """Run SharedEP W13 and return route-indexed BF16 intermediates.
+
+    ``activations`` may have rank-major leading dimensions and must be viewable
+    as ``[global_owner_rows, hidden]`` without a copy.  Canonical route
+    ``r`` reads activation row ``r // top_k``.  The canonical W13 weight stores
+    gate channels followed by up channels in its output dimension.  The result
+    is ``[global_owner_rows * top_k, intermediate]`` and row ``r`` contains
+    ``silu(gate_r) * up_r``.
+
+    Only valid local routes are overwritten when ``out`` is supplied; other
+    route slots are left untouched so disjoint SharedEP writers can share the
+    owner buffer.
+    """
+
+    normalized_stage: SharedEPMXFP4Stage = "w13"
+    _normalize_layout(weight_layout)
+    _normalize_scale_layout(scale_layout)
+    activations_2d = _owner_rows_view(activations, normalized_stage)
+    _require_tensor(weight, "weight")
+    if weight.ndim != 3 or weight.shape[1] % 2:
+        raise ValueError("W13 weight must have shape [experts, 2 * intermediate, K/2]")
+    route_capacity = activations_2d.shape[0] * _require_positive_int(top_k, "top_k")
+    output_dim = weight.shape[1] // 2
+    if out is None:
+        out = torch.zeros(
+            (route_capacity, output_dim),
+            dtype=torch.bfloat16,
+            device=activations.device,
+        )
+    profile = validate_shared_ep_mxfp4_contract(
+        activations,
+        weight,
+        weight_scales,
+        sorted_route_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        stage=normalized_stage,
+        top_k=top_k,
+        route_block_size=route_block_size,
+        out=out,
+        weight_layout=weight_layout,
+        scale_layout=scale_layout,
+        check_route_values=check_route_values,
+        require_cuda=True,
+    )
+    _require_gfx950()
+    resolved_config = get_shared_ep_mxfp4_config(
+        profile, config=config, config_hook=config_hook
+    )
+    with _profile_context(profile_hook, profile, resolved_config):
+        if profile.num_padded_routes:
+            _launch_shared_ep_mxfp4(
+                activations,
+                weight,
+                weight_scales,
+                sorted_route_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                None,
+                out,
+                profile,
+                resolved_config,
+                swiglu_limit,
+            )
+    return out
+
+
+def shared_ep_mxfp4_w2(
+    intermediate: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scales: torch.Tensor,
+    route_weights: torch.Tensor,
+    sorted_route_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    *,
+    top_k: int,
+    route_block_size: int,
+    out: Optional[torch.Tensor] = None,
+    weight_layout: Union[
+        str, SharedEPMXFP4WeightLayout
+    ] = SharedEPMXFP4WeightLayout.CANONICAL,
+    scale_layout: Union[
+        str, SharedEPMXFP4ScaleLayout
+    ] = SharedEPMXFP4ScaleLayout.CANONICAL,
+    config: Optional[Mapping[str, Any]] = None,
+    config_hook: Optional[SharedEPMXFP4ConfigHook] = None,
+    profile_hook: Optional[SharedEPMXFP4ProfileHook] = None,
+    check_route_values: bool = True,
+) -> torch.Tensor:
+    """Run SharedEP W2 directly into canonical global owner route slots.
+
+    ``intermediate`` is the W13 route-indexed tensor.  ``route_weights`` must
+    be the canonical unsorted rank-major owner tensor ``[..., top_k]``; it is
+    indexed by the global route ID, not by sorted position.  Route ``r`` reads
+    intermediate row ``r``, multiplies by ``route_weights.view(-1)[r]``, and
+    writes output row ``r``.  The returned tensor is an uncombined route
+    payload ``[route_capacity, hidden]``; no local combine buffer is produced.
+    """
+
+    normalized_stage: SharedEPMXFP4Stage = "w2"
+    _normalize_layout(weight_layout)
+    _normalize_scale_layout(scale_layout)
+    intermediate_2d = _owner_rows_view(intermediate, normalized_stage)
+    _require_tensor(weight, "weight")
+    if weight.ndim != 3:
+        raise ValueError("W2 weight must have shape [experts, hidden, K/2]")
+    if out is None:
+        out = torch.zeros(
+            (intermediate_2d.shape[0], weight.shape[1]),
+            dtype=torch.bfloat16,
+            device=intermediate.device,
+        )
+    profile = validate_shared_ep_mxfp4_contract(
+        intermediate,
+        weight,
+        weight_scales,
+        sorted_route_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        stage=normalized_stage,
+        top_k=top_k,
+        route_block_size=route_block_size,
+        route_weights=route_weights,
+        out=out,
+        weight_layout=weight_layout,
+        scale_layout=scale_layout,
+        check_route_values=check_route_values,
+        require_cuda=True,
+    )
+    _require_gfx950()
+    resolved_config = get_shared_ep_mxfp4_config(
+        profile, config=config, config_hook=config_hook
+    )
+    with _profile_context(profile_hook, profile, resolved_config):
+        if profile.num_padded_routes:
+            _launch_shared_ep_mxfp4(
+                intermediate,
+                weight,
+                weight_scales,
+                sorted_route_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                route_weights,
+                out,
+                profile,
+                resolved_config,
+            )
+    return out
+
+
+__all__ = [
+    "SharedEPMXFP4ConfigHook",
+    "SharedEPMXFP4Profile",
+    "SharedEPMXFP4ProfileHook",
+    "SharedEPMXFP4ScaleLayout",
+    "SharedEPMXFP4Stage",
+    "SharedEPMXFP4WeightLayout",
+    "get_shared_ep_mxfp4_config",
+    "shared_ep_mxfp4_route_rows",
+    "shared_ep_mxfp4_w13",
+    "shared_ep_mxfp4_w2",
+    "validate_shared_ep_mxfp4_contract",
+]

--- a/aiter/ops/triton/moe/shared_ep_mxfp4.py
+++ b/aiter/ops/triton/moe/shared_ep_mxfp4.py
@@ -17,14 +17,14 @@ swizzled layouts intentionally fail closed.
 
 from __future__ import annotations
 
-from contextlib import nullcontext
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from enum import Enum
 from types import MappingProxyType
-from typing import Any, Callable, ContextManager, Literal, Mapping, Optional, Union
+from typing import Any, Literal
 
 import torch
-
 
 SharedEPMXFP4Stage = Literal["w13", "w2"]
 
@@ -48,7 +48,7 @@ class SharedEPMXFP4Profile:
     stage: SharedEPMXFP4Stage
     num_owner_rows: int
     route_capacity: int
-    num_active_routes: Optional[int]
+    num_active_routes: int | None
     num_padded_routes: int
     route_block_size: int
     num_experts: int
@@ -57,9 +57,9 @@ class SharedEPMXFP4Profile:
     top_k: int
 
 
-SharedEPMXFP4ConfigHook = Callable[[SharedEPMXFP4Profile], Optional[Mapping[str, Any]]]
+SharedEPMXFP4ConfigHook = Callable[[SharedEPMXFP4Profile], Mapping[str, Any] | None]
 SharedEPMXFP4ProfileHook = Callable[
-    [SharedEPMXFP4Profile, Mapping[str, Any]], Optional[ContextManager[Any]]
+    [SharedEPMXFP4Profile, Mapping[str, Any]], AbstractContextManager[Any] | None
 ]
 
 _FP4_PACKED_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
@@ -84,7 +84,7 @@ def _normalize_stage(stage: str) -> SharedEPMXFP4Stage:
 
 
 def _normalize_layout(
-    layout: Union[str, SharedEPMXFP4WeightLayout],
+    layout: str | SharedEPMXFP4WeightLayout,
 ) -> SharedEPMXFP4WeightLayout:
     try:
         normalized = SharedEPMXFP4WeightLayout(layout)
@@ -99,7 +99,7 @@ def _normalize_layout(
 
 
 def _normalize_scale_layout(
-    layout: Union[str, SharedEPMXFP4ScaleLayout],
+    layout: str | SharedEPMXFP4ScaleLayout,
 ) -> SharedEPMXFP4ScaleLayout:
     try:
         normalized = SharedEPMXFP4ScaleLayout(layout)
@@ -230,14 +230,12 @@ def validate_shared_ep_mxfp4_contract(
     stage: SharedEPMXFP4Stage,
     top_k: int,
     route_block_size: int,
-    route_weights: Optional[torch.Tensor] = None,
-    out: Optional[torch.Tensor] = None,
-    weight_layout: Union[
-        str, SharedEPMXFP4WeightLayout
-    ] = SharedEPMXFP4WeightLayout.CANONICAL,
-    scale_layout: Union[
-        str, SharedEPMXFP4ScaleLayout
-    ] = SharedEPMXFP4ScaleLayout.CANONICAL,
+    route_weights: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+    weight_layout: (
+        str | SharedEPMXFP4WeightLayout
+    ) = SharedEPMXFP4WeightLayout.CANONICAL,
+    scale_layout: str | SharedEPMXFP4ScaleLayout = SharedEPMXFP4ScaleLayout.CANONICAL,
     check_route_values: bool = True,
     require_cuda: bool = False,
 ) -> SharedEPMXFP4Profile:
@@ -419,7 +417,7 @@ def validate_shared_ep_mxfp4_contract(
         if check_route_values
         else sorted_route_ids.numel()
     )
-    num_active_routes: Optional[int] = None
+    num_active_routes: int | None = None
     if check_route_values:
         if num_padded_routes < 0 or num_padded_routes > sorted_route_ids.numel():
             raise ValueError(
@@ -483,8 +481,8 @@ def validate_shared_ep_mxfp4_contract(
 def get_shared_ep_mxfp4_config(
     profile: SharedEPMXFP4Profile,
     *,
-    config: Optional[Mapping[str, Any]] = None,
-    config_hook: Optional[SharedEPMXFP4ConfigHook] = None,
+    config: Mapping[str, Any] | None = None,
+    config_hook: SharedEPMXFP4ConfigHook | None = None,
 ) -> dict[str, Any]:
     """Resolve and validate a gfx950 kernel config for a SharedEP profile.
 
@@ -499,7 +497,7 @@ def get_shared_ep_mxfp4_config(
     if config is not None and config_hook is not None:
         raise ValueError("pass either config or config_hook, not both")
 
-    selected: Optional[Mapping[str, Any]] = config
+    selected: Mapping[str, Any] | None = config
     if config_hook is not None:
         selected = config_hook(profile)
     if selected is None:
@@ -558,10 +556,10 @@ def _require_gfx950() -> None:
 
 
 def _profile_context(
-    profile_hook: Optional[SharedEPMXFP4ProfileHook],
+    profile_hook: SharedEPMXFP4ProfileHook | None,
     profile: SharedEPMXFP4Profile,
     config: Mapping[str, Any],
-) -> ContextManager[Any]:
+) -> AbstractContextManager[Any]:
     if profile_hook is None:
         return nullcontext()
     context = profile_hook(profile, MappingProxyType(dict(config)))
@@ -579,11 +577,11 @@ def _launch_shared_ep_mxfp4(
     sorted_route_ids: torch.Tensor,
     expert_ids: torch.Tensor,
     num_tokens_post_padded: torch.Tensor,
-    route_weights: Optional[torch.Tensor],
+    route_weights: torch.Tensor | None,
     out: torch.Tensor,
     profile: SharedEPMXFP4Profile,
     config: Mapping[str, Any],
-    swiglu_limit: Optional[float] = None,
+    swiglu_limit: float | None = None,
 ) -> None:
     from aiter.ops.triton.utils.types import torch_to_triton_dtype
 
@@ -667,18 +665,16 @@ def shared_ep_mxfp4_w13(
     *,
     top_k: int,
     route_block_size: int,
-    out: Optional[torch.Tensor] = None,
-    weight_layout: Union[
-        str, SharedEPMXFP4WeightLayout
-    ] = SharedEPMXFP4WeightLayout.CANONICAL,
-    scale_layout: Union[
-        str, SharedEPMXFP4ScaleLayout
-    ] = SharedEPMXFP4ScaleLayout.CANONICAL,
-    config: Optional[Mapping[str, Any]] = None,
-    config_hook: Optional[SharedEPMXFP4ConfigHook] = None,
-    profile_hook: Optional[SharedEPMXFP4ProfileHook] = None,
+    out: torch.Tensor | None = None,
+    weight_layout: (
+        str | SharedEPMXFP4WeightLayout
+    ) = SharedEPMXFP4WeightLayout.CANONICAL,
+    scale_layout: str | SharedEPMXFP4ScaleLayout = SharedEPMXFP4ScaleLayout.CANONICAL,
+    config: Mapping[str, Any] | None = None,
+    config_hook: SharedEPMXFP4ConfigHook | None = None,
+    profile_hook: SharedEPMXFP4ProfileHook | None = None,
     check_route_values: bool = True,
-    swiglu_limit: Optional[float] = None,
+    swiglu_limit: float | None = None,
 ) -> torch.Tensor:
     """Run SharedEP W13 and return route-indexed BF16 intermediates.
 
@@ -758,16 +754,14 @@ def shared_ep_mxfp4_w2(
     *,
     top_k: int,
     route_block_size: int,
-    out: Optional[torch.Tensor] = None,
-    weight_layout: Union[
-        str, SharedEPMXFP4WeightLayout
-    ] = SharedEPMXFP4WeightLayout.CANONICAL,
-    scale_layout: Union[
-        str, SharedEPMXFP4ScaleLayout
-    ] = SharedEPMXFP4ScaleLayout.CANONICAL,
-    config: Optional[Mapping[str, Any]] = None,
-    config_hook: Optional[SharedEPMXFP4ConfigHook] = None,
-    profile_hook: Optional[SharedEPMXFP4ProfileHook] = None,
+    out: torch.Tensor | None = None,
+    weight_layout: (
+        str | SharedEPMXFP4WeightLayout
+    ) = SharedEPMXFP4WeightLayout.CANONICAL,
+    scale_layout: str | SharedEPMXFP4ScaleLayout = SharedEPMXFP4ScaleLayout.CANONICAL,
+    config: Mapping[str, Any] | None = None,
+    config_hook: SharedEPMXFP4ConfigHook | None = None,
+    profile_hook: SharedEPMXFP4ProfileHook | None = None,
     check_route_values: bool = True,
 ) -> torch.Tensor:
     """Run SharedEP W2 directly into canonical global owner route slots.
@@ -840,7 +834,7 @@ __all__ = [
     "SharedEPMXFP4WeightLayout",
     "get_shared_ep_mxfp4_config",
     "shared_ep_mxfp4_route_rows",
-    "shared_ep_mxfp4_w13",
     "shared_ep_mxfp4_w2",
+    "shared_ep_mxfp4_w13",
     "validate_shared_ep_mxfp4_contract",
 ]

--- a/op_tests/test_shared_ep_mxfp4_contract.py
+++ b/op_tests/test_shared_ep_mxfp4_contract.py
@@ -11,7 +11,6 @@ from aiter.ops.triton.moe.shared_ep_mxfp4 import (
     validate_shared_ep_mxfp4_contract,
 )
 
-
 TOP_K = 2
 BLOCK_M = 64
 K = 128
@@ -149,21 +148,112 @@ def test_shared_ep_w13_w2_contract_and_config_hook() -> None:
     assert w2_profile.route_capacity == 6
 
 
+def test_dsv4_pro_production_shapes_validate_without_materialization() -> None:
+    device = torch.device("meta")
+    owners = 8
+    tokens_per_owner = 32
+    top_k = 6
+    hidden_size = 7168
+    intermediate_size = 3072
+    num_local_experts = 48
+    block_m = 128
+    owner_rows = owners * tokens_per_owner
+    route_capacity = owner_rows * top_k
+    sorted_capacity = route_capacity + num_local_experts * (block_m - 1)
+    route_blocks = (sorted_capacity + block_m - 1) // block_m
+
+    routes = torch.empty(sorted_capacity, dtype=torch.int32, device=device)
+    experts = torch.empty(route_blocks, dtype=torch.int32, device=device)
+    num_padded = torch.empty(1, dtype=torch.int32, device=device)
+
+    w13_profile = validate_shared_ep_mxfp4_contract(
+        torch.empty(
+            (owners, tokens_per_owner, hidden_size), dtype=torch.bfloat16, device=device
+        ),
+        torch.empty(
+            (num_local_experts, 2 * intermediate_size, hidden_size // 2),
+            dtype=torch.uint8,
+            device=device,
+        ),
+        torch.empty(
+            (num_local_experts, 2 * intermediate_size, hidden_size // 32),
+            dtype=torch.uint8,
+            device=device,
+        ),
+        routes,
+        experts,
+        num_padded,
+        stage="w13",
+        top_k=top_k,
+        route_block_size=block_m,
+        out=torch.empty(
+            (route_capacity, intermediate_size),
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        check_route_values=False,
+    )
+    assert w13_profile.num_owner_rows == owner_rows
+    assert w13_profile.route_capacity == route_capacity
+    assert w13_profile.num_padded_routes == sorted_capacity
+    assert w13_profile.input_dim == hidden_size
+    assert w13_profile.output_dim == intermediate_size
+
+    w2_profile = validate_shared_ep_mxfp4_contract(
+        torch.empty(
+            (route_capacity, intermediate_size),
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        torch.empty(
+            (num_local_experts, hidden_size, intermediate_size // 2),
+            dtype=torch.uint8,
+            device=device,
+        ),
+        torch.empty(
+            (num_local_experts, hidden_size, intermediate_size // 32),
+            dtype=torch.uint8,
+            device=device,
+        ),
+        routes,
+        experts,
+        num_padded,
+        stage="w2",
+        top_k=top_k,
+        route_block_size=block_m,
+        route_weights=torch.empty(
+            (owners, tokens_per_owner, top_k),
+            dtype=torch.float32,
+            device=device,
+        ),
+        out=torch.empty(
+            (route_capacity, hidden_size),
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        check_route_values=False,
+    )
+    assert w2_profile.num_owner_rows == owner_rows
+    assert w2_profile.route_capacity == route_capacity
+    assert w2_profile.input_dim == intermediate_size
+    assert w2_profile.output_dim == hidden_size
+
+
 def test_shared_ep_contract_fails_closed() -> None:
     routes, experts, num_padded = _route_metadata()
     weight, scales = _weight_and_scales(256)
     activations = torch.ones((3, K), dtype=torch.bfloat16)
-    common = dict(
-        activations=activations,
-        weight=weight,
-        weight_scales=scales,
-        sorted_route_ids=routes,
-        expert_ids=experts,
-        num_tokens_post_padded=num_padded,
-        stage="w13",
-        top_k=TOP_K,
-        route_block_size=BLOCK_M,
-    )
+    common = {
+        "activations": activations,
+        "weight": weight,
+        "weight_scales": scales,
+        "sorted_route_ids": routes,
+        "expert_ids": experts,
+        "num_tokens_post_padded": num_padded,
+        "stage": "w13",
+        "top_k": TOP_K,
+        "route_block_size": BLOCK_M,
+    }
 
     with pytest.raises(ValueError, match="canonical unswizzled"):
         validate_shared_ep_mxfp4_contract(

--- a/op_tests/test_shared_ep_mxfp4_contract.py
+++ b/op_tests/test_shared_ep_mxfp4_contract.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""CPU-only contract tests for the SharedEP MXFP4 adapter."""
+
+import pytest
+import torch
+
+from aiter.ops.triton.moe.shared_ep_mxfp4 import (
+    get_shared_ep_mxfp4_config,
+    shared_ep_mxfp4_route_rows,
+    validate_shared_ep_mxfp4_contract,
+)
+
+
+TOP_K = 2
+BLOCK_M = 64
+K = 128
+NUM_EXPERTS = 2
+CONFIG = {
+    "BLOCK_SIZE_M": BLOCK_M,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": K,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+}
+
+
+def _route_metadata() -> tuple[torch.Tensor, ...]:
+    route_capacity = 6
+    routes = torch.full((2 * BLOCK_M,), route_capacity, dtype=torch.int32)
+    routes[:3] = torch.tensor([0, 3, 4], dtype=torch.int32)
+    routes[BLOCK_M : BLOCK_M + 3] = torch.tensor([1, 2, 5], dtype=torch.int32)
+    experts = torch.tensor([0, 1], dtype=torch.int32)
+    num_padded = torch.tensor([2 * BLOCK_M], dtype=torch.int32)
+    return routes, experts, num_padded
+
+
+def _weight_and_scales(output_dim: int) -> tuple[torch.Tensor, torch.Tensor]:
+    weight = torch.full((NUM_EXPERTS, output_dim, K // 2), 0x22, dtype=torch.uint8)
+    scales = torch.empty((NUM_EXPERTS, output_dim, K // 32), dtype=torch.uint8)
+    scales[0] = torch.tensor([127, 128, 126, 127], dtype=torch.uint8)
+    scales[1] = torch.tensor([128, 127, 129, 126], dtype=torch.uint8)
+    return weight, scales
+
+
+def _dequant_mxfp4(weight: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+    packed = weight.view(torch.uint8)
+    nibbles = torch.empty((*packed.shape[:-1], packed.shape[-1] * 2), dtype=torch.uint8)
+    nibbles[..., ::2] = packed & 0xF
+    nibbles[..., 1::2] = packed >> 4
+    lut = torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ]
+    )
+    values = lut[nibbles.long()]
+    scale_values = torch.exp2(scales.view(torch.uint8).float() - 127.0)
+    return values * scale_values.repeat_interleave(32, dim=-1)
+
+
+def test_shared_ep_route_rows_are_canonical() -> None:
+    route_ids = torch.tensor([5, 0, 3, 2], dtype=torch.int32)
+    w13_input, w13_output = shared_ep_mxfp4_route_rows(
+        route_ids, stage="w13", top_k=TOP_K
+    )
+    torch.testing.assert_close(w13_input, torch.tensor([2, 0, 1, 1], dtype=torch.int32))
+    torch.testing.assert_close(w13_output, route_ids)
+
+    w2_input, w2_output = shared_ep_mxfp4_route_rows(route_ids, stage="w2", top_k=TOP_K)
+    torch.testing.assert_close(w2_input, route_ids)
+    torch.testing.assert_close(w2_output, route_ids)
+
+
+def test_shared_ep_w13_w2_contract_and_config_hook() -> None:
+    routes, experts, num_padded = _route_metadata()
+    w13_weight, w13_scales = _weight_and_scales(256)
+    w13_profile = validate_shared_ep_mxfp4_contract(
+        torch.ones((1, 3, K), dtype=torch.bfloat16),
+        w13_weight,
+        w13_scales,
+        routes,
+        experts,
+        num_padded,
+        stage="w13",
+        top_k=TOP_K,
+        route_block_size=BLOCK_M,
+        out=torch.empty((6, 128), dtype=torch.bfloat16),
+    )
+    assert w13_profile.route_capacity == 6
+    assert w13_profile.num_active_routes == 6
+
+    fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if fp4_dtype is not None and e8m0_dtype is not None:
+        tagged_profile = validate_shared_ep_mxfp4_contract(
+            torch.ones((1, 3, K), dtype=torch.bfloat16),
+            w13_weight.view(fp4_dtype),
+            w13_scales.view(e8m0_dtype),
+            routes,
+            experts,
+            num_padded,
+            stage="w13",
+            top_k=TOP_K,
+            route_block_size=BLOCK_M,
+        )
+        assert tagged_profile.route_capacity == 6
+
+    seen = []
+
+    def config_hook(profile):
+        seen.append(profile)
+        return CONFIG
+
+    selected = get_shared_ep_mxfp4_config(w13_profile, config_hook=config_hook)
+    assert selected["BLOCK_SIZE_M"] == BLOCK_M
+    assert seen == [w13_profile]
+
+    w2_weight, w2_scales = _weight_and_scales(128)
+    w2_profile = validate_shared_ep_mxfp4_contract(
+        torch.ones((6, K), dtype=torch.bfloat16),
+        w2_weight,
+        w2_scales,
+        routes,
+        experts,
+        num_padded,
+        stage="w2",
+        top_k=TOP_K,
+        route_block_size=BLOCK_M,
+        route_weights=torch.arange(6, dtype=torch.float32).view(3, TOP_K),
+        out=torch.empty((6, 128), dtype=torch.bfloat16),
+    )
+    assert w2_profile.num_owner_rows == 3
+    assert w2_profile.route_capacity == 6
+
+
+def test_shared_ep_contract_fails_closed() -> None:
+    routes, experts, num_padded = _route_metadata()
+    weight, scales = _weight_and_scales(256)
+    activations = torch.ones((3, K), dtype=torch.bfloat16)
+    common = dict(
+        activations=activations,
+        weight=weight,
+        weight_scales=scales,
+        sorted_route_ids=routes,
+        expert_ids=experts,
+        num_tokens_post_padded=num_padded,
+        stage="w13",
+        top_k=TOP_K,
+        route_block_size=BLOCK_M,
+    )
+
+    with pytest.raises(ValueError, match="canonical unswizzled"):
+        validate_shared_ep_mxfp4_contract(
+            **common,
+            weight_layout="swizzled",
+        )
+
+    with pytest.raises(ValueError, match="unswizzled E8M0"):
+        validate_shared_ep_mxfp4_contract(
+            **common,
+            scale_layout="swizzled",
+        )
+
+    duplicate_routes = routes.clone()
+    duplicate_routes[1] = duplicate_routes[0]
+    with pytest.raises(ValueError, match="unique"):
+        validate_shared_ep_mxfp4_contract(
+            **{**common, "sorted_route_ids": duplicate_routes}
+        )
+
+    with pytest.raises(TypeError, match="E8M0"):
+        validate_shared_ep_mxfp4_contract(**{**common, "weight_scales": scales.float()})
+
+    with pytest.raises(ValueError, match="one E8M0 byte"):
+        validate_shared_ep_mxfp4_contract(
+            **{**common, "weight_scales": scales[..., :-1].contiguous()}
+        )
+
+    with pytest.raises(ValueError, match="route capacity"):
+        validate_shared_ep_mxfp4_contract(
+            **common,
+            out=torch.empty((5, 128), dtype=torch.bfloat16),
+        )
+
+    with pytest.raises(ValueError, match="contiguous route-major"):
+        validate_shared_ep_mxfp4_contract(
+            **common,
+            out=torch.empty((6, 256), dtype=torch.bfloat16)[:, ::2],
+        )
+
+
+def test_shared_ep_fp4_reference_uses_e8m0_per_group() -> None:
+    weight, scales = _weight_and_scales(1)
+    dequant = _dequant_mxfp4(weight, scales)
+    torch.testing.assert_close(dequant[0, 0, ::32], torch.tensor([1.0, 2.0, 0.5, 1.0]))
+    torch.testing.assert_close(dequant[1, 0, ::32], torch.tensor([2.0, 1.0, 4.0, 0.5]))

--- a/op_tests/triton_tests/moe/test_shared_ep_mxfp4.py
+++ b/op_tests/triton_tests/moe/test_shared_ep_mxfp4.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter.ops.triton.moe.shared_ep_mxfp4 import (
+    get_shared_ep_mxfp4_config,
+    shared_ep_mxfp4_route_rows,
+    shared_ep_mxfp4_w13,
+    shared_ep_mxfp4_w2,
+    validate_shared_ep_mxfp4_contract,
+)
+
+
+_TOP_K = 2
+_BLOCK_M = 64
+_K = 128
+_NUM_EXPERTS = 2
+_ROUTE_EXPERT = {0: 0, 3: 0, 4: 0, 1: 1, 2: 1, 5: 1}
+_CONFIG = {
+    "BLOCK_SIZE_M": _BLOCK_M,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": _K,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 1,
+}
+
+
+def _route_metadata(device: torch.device) -> tuple[torch.Tensor, ...]:
+    route_capacity = 6
+    sorted_route_ids = torch.full(
+        (2 * _BLOCK_M,), route_capacity, dtype=torch.int32, device=device
+    )
+    sorted_route_ids[:3] = torch.tensor([0, 3, 4], dtype=torch.int32, device=device)
+    sorted_route_ids[_BLOCK_M : _BLOCK_M + 3] = torch.tensor(
+        [1, 2, 5], dtype=torch.int32, device=device
+    )
+    expert_ids = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    num_tokens_post_padded = torch.tensor(
+        [2 * _BLOCK_M], dtype=torch.int32, device=device
+    )
+    return sorted_route_ids, expert_ids, num_tokens_post_padded
+
+
+def _weight_and_scales(
+    output_dim: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # Packed nibble 0x2 is E2M1 +1.0.  Distinct E8M0 exponents exercise
+    # non-unit scales in every 32-wide logical K group.
+    weight = torch.full(
+        (_NUM_EXPERTS, output_dim, _K // 2),
+        0x22,
+        dtype=torch.uint8,
+        device=device,
+    )
+    scales = torch.empty(
+        (_NUM_EXPERTS, output_dim, _K // 32),
+        dtype=torch.uint8,
+        device=device,
+    )
+    scales[0] = torch.tensor([127, 128, 126, 127], dtype=torch.uint8, device=device)
+    scales[1] = torch.tensor([128, 127, 129, 126], dtype=torch.uint8, device=device)
+    return weight, scales
+
+
+def _dequant_mxfp4(weight: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+    packed = weight.view(torch.uint8)
+    nibbles = torch.empty(
+        (*packed.shape[:-1], packed.shape[-1] * 2),
+        dtype=torch.uint8,
+        device=packed.device,
+    )
+    nibbles[..., ::2] = packed & 0xF
+    nibbles[..., 1::2] = packed >> 4
+    lut = torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+        device=packed.device,
+    )
+    values = lut[nibbles.long()]
+    scale_values = torch.exp2(scales.view(torch.uint8).float() - 127.0)
+    return values * scale_values.repeat_interleave(32, dim=-1)
+
+
+def _require_gfx950() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("ROCm device is not available")
+    try:
+        from aiter.ops.triton.utils._triton import arch_info
+
+        arch = str(arch_info.get_arch()).split(":", 1)[0]
+    except Exception as exc:  # pragma: no cover - depends on host runtime
+        pytest.skip(f"unable to query ROCm architecture: {exc}")
+    if arch != "gfx950":
+        pytest.skip(f"SharedEP MXFP4 GPU test requires gfx950, got {arch}")
+
+
+def test_route_indexing_contract() -> None:
+    route_ids = torch.tensor([5, 0, 3, 2], dtype=torch.int32)
+
+    w13_input, w13_output = shared_ep_mxfp4_route_rows(route_ids, stage="w13", top_k=2)
+    torch.testing.assert_close(w13_input, torch.tensor([2, 0, 1, 1], dtype=torch.int32))
+    torch.testing.assert_close(w13_output, route_ids)
+
+    w2_input, w2_output = shared_ep_mxfp4_route_rows(route_ids, stage="w2", top_k=2)
+    torch.testing.assert_close(w2_input, route_ids)
+    torch.testing.assert_close(w2_output, route_ids)
+
+
+def test_cpu_contract_w13_w2_and_config_hook() -> None:
+    device = torch.device("cpu")
+    routes, experts, num_padded = _route_metadata(device)
+    w13_weight, w13_scales = _weight_and_scales(256, device)
+    activations = torch.ones((3, _K), dtype=torch.bfloat16)
+    w13_out = torch.empty((6, 128), dtype=torch.bfloat16)
+
+    w13_profile = validate_shared_ep_mxfp4_contract(
+        activations,
+        w13_weight,
+        w13_scales,
+        routes,
+        experts,
+        num_padded,
+        stage="w13",
+        top_k=_TOP_K,
+        route_block_size=_BLOCK_M,
+        out=w13_out,
+    )
+    assert w13_profile.route_capacity == 6
+    assert w13_profile.num_active_routes == 6
+    assert w13_profile.output_dim == 128
+
+    seen = []
+
+    def config_hook(profile):
+        seen.append(profile)
+        return _CONFIG
+
+    assert (
+        get_shared_ep_mxfp4_config(w13_profile, config_hook=config_hook)["BLOCK_SIZE_M"]
+        == _BLOCK_M
+    )
+    assert seen == [w13_profile]
+
+    w2_weight, w2_scales = _weight_and_scales(128, device)
+    intermediate = torch.ones((6, _K), dtype=torch.bfloat16)
+    route_weights = torch.arange(6, dtype=torch.float32).view(3, _TOP_K)
+    w2_out = torch.empty((6, 128), dtype=torch.bfloat16)
+    w2_profile = validate_shared_ep_mxfp4_contract(
+        intermediate,
+        w2_weight,
+        w2_scales,
+        routes,
+        experts,
+        num_padded,
+        stage="w2",
+        top_k=_TOP_K,
+        route_block_size=_BLOCK_M,
+        route_weights=route_weights,
+        out=w2_out,
+    )
+    assert w2_profile.num_owner_rows == 3
+    assert w2_profile.route_capacity == 6
+
+
+def test_cpu_contract_rejects_unsafe_layout_routes_and_scales() -> None:
+    device = torch.device("cpu")
+    routes, experts, num_padded = _route_metadata(device)
+    weight, scales = _weight_and_scales(256, device)
+    activations = torch.ones((3, _K), dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="canonical unswizzled"):
+        validate_shared_ep_mxfp4_contract(
+            activations,
+            weight,
+            scales,
+            routes,
+            experts,
+            num_padded,
+            stage="w13",
+            top_k=_TOP_K,
+            route_block_size=_BLOCK_M,
+            weight_layout="swizzled",
+        )
+
+    with pytest.raises(ValueError, match="unswizzled E8M0"):
+        validate_shared_ep_mxfp4_contract(
+            activations,
+            weight,
+            scales,
+            routes,
+            experts,
+            num_padded,
+            stage="w13",
+            top_k=_TOP_K,
+            route_block_size=_BLOCK_M,
+            scale_layout="swizzled",
+        )
+
+    duplicate_routes = routes.clone()
+    duplicate_routes[1] = duplicate_routes[0]
+    with pytest.raises(ValueError, match="unique"):
+        validate_shared_ep_mxfp4_contract(
+            activations,
+            weight,
+            scales,
+            duplicate_routes,
+            experts,
+            num_padded,
+            stage="w13",
+            top_k=_TOP_K,
+            route_block_size=_BLOCK_M,
+        )
+
+    with pytest.raises(TypeError, match="E8M0"):
+        validate_shared_ep_mxfp4_contract(
+            activations,
+            weight,
+            scales.float(),
+            routes,
+            experts,
+            num_padded,
+            stage="w13",
+            top_k=_TOP_K,
+            route_block_size=_BLOCK_M,
+        )
+
+    with pytest.raises(ValueError, match="one E8M0 byte"):
+        validate_shared_ep_mxfp4_contract(
+            activations,
+            weight,
+            scales[..., :-1].contiguous(),
+            routes,
+            experts,
+            num_padded,
+            stage="w13",
+            top_k=_TOP_K,
+            route_block_size=_BLOCK_M,
+        )
+
+
+def test_fp4_e8m0_reference_has_per_group_scales() -> None:
+    weight, scales = _weight_and_scales(1, torch.device("cpu"))
+    dequant = _dequant_mxfp4(weight, scales)
+    torch.testing.assert_close(
+        dequant[0, 0, ::32],
+        torch.tensor([1.0, 2.0, 0.5, 1.0]),
+    )
+    torch.testing.assert_close(
+        dequant[1, 0, ::32],
+        torch.tensor([2.0, 1.0, 4.0, 0.5]),
+    )
+
+
+def test_gfx950_shared_ep_w13_w2_reference() -> None:
+    _require_gfx950()
+    device = torch.device("cuda")
+    routes, experts, num_padded = _route_metadata(device)
+
+    activations = (
+        torch.tensor(
+            [1.0 / 64, 1.0 / 32, 1.0 / 16],
+            dtype=torch.bfloat16,
+            device=device,
+        )[:, None]
+        .expand(3, _K)
+        .contiguous()
+    )
+    w13_weight, w13_scales = _weight_and_scales(256, device)
+    fp4_dtype = getattr(torch, "float4_e2m1fn_x2", torch.uint8)
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", torch.uint8)
+    w13_out = shared_ep_mxfp4_w13(
+        activations,
+        w13_weight.view(fp4_dtype),
+        w13_scales.view(e8m0_dtype),
+        routes,
+        experts,
+        num_padded,
+        top_k=_TOP_K,
+        route_block_size=_BLOCK_M,
+        config=_CONFIG,
+        swiglu_limit=0.05,
+    )
+
+    dense_w13 = _dequant_mxfp4(w13_weight, w13_scales)
+    w13_ref = torch.empty_like(w13_out)
+    for route_id, expert_id in _ROUTE_EXPERT.items():
+        projected = torch.mv(
+            dense_w13[expert_id], activations[route_id // _TOP_K].float()
+        ).to(torch.bfloat16)
+        gate, up = projected.float().chunk(2)
+        gate = gate.clamp(max=0.05)
+        up = up.clamp(min=-0.05, max=0.05)
+        w13_ref[route_id] = (torch.nn.functional.silu(gate) * up).to(torch.bfloat16)
+    torch.testing.assert_close(w13_out, w13_ref, rtol=5e-2, atol=2e-1)
+
+    intermediate = (
+        torch.tensor(
+            [1.0 / 64, 1.0 / 32, 1.0 / 16, 1.0 / 8, 1.0 / 4, 1.0 / 2],
+            dtype=torch.bfloat16,
+            device=device,
+        )[:, None]
+        .expand(6, _K)
+        .contiguous()
+    )
+    w2_weight, w2_scales = _weight_and_scales(128, device)
+    route_weights = torch.tensor(
+        [[0.10, 0.20], [0.30, 0.40], [0.50, 0.60]],
+        dtype=torch.float32,
+        device=device,
+    )
+    w2_out = shared_ep_mxfp4_w2(
+        intermediate,
+        w2_weight,
+        w2_scales,
+        route_weights,
+        routes,
+        experts,
+        num_padded,
+        top_k=_TOP_K,
+        route_block_size=_BLOCK_M,
+        config=_CONFIG,
+    )
+
+    dense_w2 = _dequant_mxfp4(w2_weight, w2_scales)
+    w2_ref = torch.empty_like(w2_out)
+    flat_route_weights = route_weights.view(-1)
+    for route_id, expert_id in _ROUTE_EXPERT.items():
+        projected = torch.mv(dense_w2[expert_id], intermediate[route_id].float())
+        w2_ref[route_id] = (projected * flat_route_weights[route_id]).to(torch.bfloat16)
+    torch.testing.assert_close(w2_out, w2_ref, rtol=5e-2, atol=2e-1)

--- a/op_tests/triton_tests/moe/test_shared_ep_mxfp4.py
+++ b/op_tests/triton_tests/moe/test_shared_ep_mxfp4.py
@@ -7,11 +7,10 @@ import torch
 from aiter.ops.triton.moe.shared_ep_mxfp4 import (
     get_shared_ep_mxfp4_config,
     shared_ep_mxfp4_route_rows,
-    shared_ep_mxfp4_w13,
     shared_ep_mxfp4_w2,
+    shared_ep_mxfp4_w13,
     validate_shared_ep_mxfp4_contract,
 )
-
 
 _TOP_K = 2
 _BLOCK_M = 64
@@ -111,7 +110,7 @@ def _require_gfx950() -> None:
         from aiter.ops.triton.utils._triton import arch_info
 
         arch = str(arch_info.get_arch()).split(":", 1)[0]
-    except Exception as exc:  # pragma: no cover - depends on host runtime
+    except (AttributeError, ImportError, RuntimeError) as exc:  # pragma: no cover
         pytest.skip(f"unable to query ROCm architecture: {exc}")
     if arch != "gfx950":
         pytest.skip(f"SharedEP MXFP4 GPU test requires gfx950, got {arch}")
@@ -351,3 +350,217 @@ def test_gfx950_shared_ep_w13_w2_reference() -> None:
         projected = torch.mv(dense_w2[expert_id], intermediate[route_id].float())
         w2_ref[route_id] = (projected * flat_route_weights[route_id]).to(torch.bfloat16)
     torch.testing.assert_close(w2_out, w2_ref, rtol=5e-2, atol=2e-1)
+
+
+def test_gfx950_dsv4_pro_shape_graph_replay_and_invalid_route_guard() -> None:
+    _require_gfx950()
+    device = torch.device("cuda")
+    hidden_size = 7168
+    intermediate_size = 3072
+    top_k = 6
+    owner_rows = 32
+    route_capacity = owner_rows * top_k
+    block_m = 128
+    padded_routes = 2 * block_m
+    config = {
+        "BLOCK_SIZE_M": block_m,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+    }
+
+    routes = torch.full(
+        (padded_routes,),
+        route_capacity,
+        dtype=torch.int32,
+        device=device,
+    )
+    routes[:route_capacity] = torch.arange(
+        route_capacity,
+        dtype=torch.int32,
+        device=device,
+    )
+    experts = torch.zeros(
+        (padded_routes // block_m,),
+        dtype=torch.int32,
+        device=device,
+    )
+    num_padded = torch.tensor([padded_routes], dtype=torch.int32, device=device)
+    activations = torch.full(
+        (owner_rows, hidden_size),
+        1.0 / 4096,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    w13_weight = torch.full(
+        (1, 2 * intermediate_size, hidden_size // 2),
+        0x22,
+        dtype=torch.uint8,
+        device=device,
+    )
+    w13_scales = torch.full(
+        (1, 2 * intermediate_size, hidden_size // 32),
+        127,
+        dtype=torch.uint8,
+        device=device,
+    )
+    w2_weight = torch.full(
+        (1, hidden_size, intermediate_size // 2),
+        0x22,
+        dtype=torch.uint8,
+        device=device,
+    )
+    w2_scales = torch.full(
+        (1, hidden_size, intermediate_size // 32),
+        127,
+        dtype=torch.uint8,
+        device=device,
+    )
+    route_weights = (
+        torch.arange(1, top_k + 1, dtype=torch.float32, device=device)
+        .div_(top_k)
+        .expand(owner_rows, -1)
+        .contiguous()
+    )
+
+    eager_w13 = torch.empty(
+        (route_capacity, intermediate_size),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    assert (
+        shared_ep_mxfp4_w13(
+            activations,
+            w13_weight,
+            w13_scales,
+            routes,
+            experts,
+            num_padded,
+            top_k=top_k,
+            route_block_size=block_m,
+            out=eager_w13,
+            config=config,
+            swiglu_limit=0.05,
+        ).data_ptr()
+        == eager_w13.data_ptr()
+    )
+    projected = torch.tensor(
+        hidden_size / 4096,
+        dtype=torch.bfloat16,
+        device=device,
+    ).float()
+    expected_w13 = (
+        torch.nn.functional.silu(projected.clamp(max=0.05))
+        * projected.clamp(min=-0.05, max=0.05)
+    ).to(torch.bfloat16)
+    torch.testing.assert_close(
+        eager_w13,
+        torch.ones_like(eager_w13) * expected_w13,
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+    eager_w2 = torch.empty(
+        (route_capacity, hidden_size),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    assert (
+        shared_ep_mxfp4_w2(
+            eager_w13,
+            w2_weight,
+            w2_scales,
+            route_weights,
+            routes,
+            experts,
+            num_padded,
+            top_k=top_k,
+            route_block_size=block_m,
+            out=eager_w2,
+            config=config,
+        ).data_ptr()
+        == eager_w2.data_ptr()
+    )
+    expected_w2_rows = (
+        eager_w13[:, 0].float() * intermediate_size * route_weights.view(-1)
+    ).to(torch.bfloat16)
+    torch.testing.assert_close(
+        eager_w2,
+        expected_w2_rows[:, None].expand_as(eager_w2),
+        # W13 and W2 each quantize BF16 activations to E2M1. The production
+        # multi-tile path compounds the representable E2M1 rounding error.
+        rtol=1.6e-1,
+        atol=6e-1,
+    )
+
+    graph_w13 = torch.empty_like(eager_w13)
+    graph_w2 = torch.empty_like(eager_w2)
+    graph = torch.cuda.CUDAGraph()
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        shared_ep_mxfp4_w13(
+            activations,
+            w13_weight,
+            w13_scales,
+            routes,
+            experts,
+            num_padded,
+            top_k=top_k,
+            route_block_size=block_m,
+            out=graph_w13,
+            config=config,
+            swiglu_limit=0.05,
+            check_route_values=False,
+        )
+        shared_ep_mxfp4_w2(
+            graph_w13,
+            w2_weight,
+            w2_scales,
+            route_weights,
+            routes,
+            experts,
+            num_padded,
+            top_k=top_k,
+            route_block_size=block_m,
+            out=graph_w2,
+            config=config,
+            check_route_values=False,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(graph_w13, eager_w13, rtol=0, atol=0)
+    torch.testing.assert_close(graph_w2, eager_w2, rtol=0, atol=0)
+
+    graph_w13.fill_(7)
+    graph_w2.fill_(7)
+    num_padded.zero_()
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.all(graph_w13 == 7)
+    assert torch.all(graph_w2 == 7)
+
+    routes[0] = -1
+    num_padded.fill_(padded_routes)
+    guarded_w13 = torch.full_like(eager_w13, 7)
+    shared_ep_mxfp4_w13(
+        activations,
+        w13_weight,
+        w13_scales,
+        routes,
+        experts,
+        num_padded,
+        top_k=top_k,
+        route_block_size=block_m,
+        out=guarded_w13,
+        config=config,
+        swiglu_limit=0.05,
+        check_route_values=False,
+    )
+    torch.cuda.synchronize()
+    assert torch.all(guarded_w13[0] == 7)
+    torch.testing.assert_close(guarded_w13[1:], eager_w13[1:], rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Add the gfx950 MXFP4 compute adapter used by SharedEP direct decode:

- W13 reads canonical owner rows (`route_id // top_k`), quantizes BF16 activations to MXFP4 on the fly, and supports bounded SwiGLU.
- W2 reads route-indexed intermediates and writes weighted contributions to canonical owner route slots.
- Canonical unswizzled E2M1 weights and E8M0 scales are validated fail-closed.
- Negative and out-of-range route rows are masked before any input/output access.

This PR intentionally keeps the canonical direct-decode ABI. Sorted-cache MXFP4 prefill is not included; SGLang #32619 uses the MoRI+AITER materialized fallback for DSV4-Pro prefill.

## Integration

- Consumer: https://github.com/sgl-project/sglang/pull/32619
- Validated consumer head: `b15187545e190104a0607a75c086045ce20ebd4b`

## Test Plan / Results

Local static checks:

- `ruff==0.16.0`: passed
- Black: passed
- Python compile checks: passed

ROCm 7.2 / 8x MI355X (gfx950), Slurm-gated with pre/post VRAM checks:

- Aiter contract + Triton tests: **11 passed**
- Production DSV4-Pro dimensions: K=7168 W13, K=3072 W2, BM128, multi-K-tile
- Empty padded work, skew/padding sentinels, output canaries, and invalid negative routes
- HIP Graph capture/replay, including dynamic zero-work replay
- SGLang EP8 integration: production-shape MXFP4 direct return, idle ranks, and 80 consecutive epoch reuses passed on all 8 ranks

## Scope Boundary

- Supported: gfx950 SharedEP MXFP4 direct decode.
- Deferred: sorted-local-cache input ABI for native MXFP4 prefill.

## Submission Checklist

- [x] Code formatted with Black and checked with Ruff.
- [x] CPU contract and gfx950 numerical/graph tests added.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.