### PR TITLE
[Qwen3.5_dev] Upgrade flydsl to 0.2.4

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -8,29 +8,30 @@ Kernel compilation and public APIs are only available when a compatible
 whether the optional dependency exists before relying on FlyDSL kernels.
 """
 
-from importlib.metadata import PackageNotFoundError, version
+from packaging.version import Version
 
 from .utils import is_flydsl_available
 
-_REQUIRED_FLYDSL_VERSION = "0.1.2"
+_MIN_FLYDSL_VERSION = Version("0.2.4")
 
 __all__ = [
     "is_flydsl_available",
 ]
 
 if is_flydsl_available():
-    try:
-        installed_flydsl_version = version("flydsl")
-    except PackageNotFoundError as exc:
-        raise ImportError(
-            "`flydsl` is importable but package metadata is unavailable, "
-            "so its version cannot be validated."
-        ) from exc
+    import flydsl as _flydsl
 
-    if installed_flydsl_version != _REQUIRED_FLYDSL_VERSION:
+    installed_flydsl_version = getattr(_flydsl, "__version__", None)
+    if installed_flydsl_version is None:
+        raise ImportError(
+            "`flydsl` is importable but its version cannot be determined."
+        )
+
+    _base_version = Version(installed_flydsl_version.split("+")[0])
+    if _base_version < _MIN_FLYDSL_VERSION:
         raise ImportError(
             "Unsupported `flydsl` version: "
-            f"expected `{_REQUIRED_FLYDSL_VERSION}`, "
+            f"expected >=`{_MIN_FLYDSL_VERSION}`, "
             f"got `{installed_flydsl_version}`."
         )
 

--- a/aiter/ops/flydsl/kernels/splitk_hgemm.py
+++ b/aiter/ops/flydsl/kernels/splitk_hgemm.py
@@ -11,7 +11,10 @@ import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import fly, llvm, memref, scf
 from flydsl.compiler.kernel_function import CompilationContext
-from flydsl.compiler.protocol import fly_values
+try:
+    from flydsl.compiler.protocol import fly_values
+except ImportError:  # flydsl >= 0.2.0 renamed it
+    from flydsl.compiler.protocol import extract_to_ir_values as fly_values
 from flydsl.expr import arith, gpu, range_constexpr, rocdl, vector
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch

--- a/aiter/ops/flydsl/kernels/tensor_shim.py
+++ b/aiter/ops/flydsl/kernels/tensor_shim.py
@@ -1,15 +1,60 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+import os
+
 import torch
 import numpy as np
+import flydsl.compiler as flyc
 from itertools import product
 from abc import ABC, abstractmethod
 
+from flydsl._mlir.dialects import fly, llvm
+from flydsl.compiler.protocol import extract_to_ir_values
 from flydsl._mlir import ir
 from flydsl.expr.typing import T
 
-from flydsl.expr import buffer_ops, range_constexpr, vector
+from flydsl.expr import buffer_ops, range_constexpr, vector, arith, ptrtoint
+
+# Global toggle for the amdgpu-kernarg-preload compile hint used by the flydsl
+# kernels. Enabled by default; set AITER_FLYDSL_KERNARG_PRELOAD=0 to disable it
+# globally for all kernels. AITER_FLYDSL_KERNARG_PRELOAD_COUNT overrides the
+# number of kernel arguments to preload.
+AITER_FLYDSL_KERNARG_PRELOAD = bool(
+    int(os.environ.get("AITER_FLYDSL_KERNARG_PRELOAD", "1"))
+)
+AITER_FLYDSL_KERNARG_PRELOAD_COUNT = int(
+    os.environ.get("AITER_FLYDSL_KERNARG_PRELOAD_COUNT", "32")
+)
+
+
+def ptr_rsrc(ptr):
+    """Convert an fx.Pointer kernel arg to a buffer resource for buffer_load/store."""
+    addr_i64 = arith.index_cast(T.i64, ptrtoint(ptr))
+    return buffer_ops.create_buffer_resource_from_addr(addr_i64)
+
+
+def ptr_arg(t: torch.Tensor):
+    """Wrap a torch.Tensor as an fx.Pointer (PointerJitArg) for kernel launch."""
+    import flydsl.expr as fx
+
+    type_name = type(t).__name__
+    module_name = type(t).__module__
+    if type_name == "FakeTensor" or "fake_tensor" in module_name:
+        return flyc.from_c_void_p(fx.Uint8, 0)
+    return flyc.from_c_void_p(fx.Uint8, t.data_ptr())
+
+
+def _run_compiled(exe, *args):
+    """First call: ``flyc.compile(exe, *args)`` compiles **and** executes the kernel.
+    Subsequent calls: fast dispatch via the cached ``CompiledFunction``.
+    """
+    cf = getattr(exe, "_cf", None)
+    if cf is None:
+        cf = flyc.compile(exe, *args)
+        exe._cf = cf
+    else:
+        cf(*args)
 
 
 def _to_raw(v):
@@ -46,6 +91,15 @@ def get_dtype_vec_size(dtype: str):
         return 8
     elif dtype == "bf16":
         return 8
+
+
+def get_dtype_bytes(dtype: str):
+    if dtype == "f32":
+        return 4
+    elif dtype == "f16":
+        return 2
+    elif dtype == "bf16":
+        return 2
 
 
 class TensorView:
@@ -258,9 +312,28 @@ class TorchTensor(TensorBase):
 
 
 class GTensor(TensorBase):
-    def __init__(self, memref, dtype, shape, stride=None, base_offset=0):
+    def __init__(
+        self,
+        memref,
+        dtype,
+        shape,
+        stride=None,
+        base_offset=0,
+        cache_modifier=0,
+        static_bytes_offset_i64=None,
+    ):
         super().__init__(dtype, shape, stride, base_offset)
-        self.rsrc = buffer_ops.create_buffer_resource(memref, max_size=True)
+        raw = extract_to_ir_values(memref)[0]
+        if static_bytes_offset_i64 is None:
+            if str(raw.type).startswith("!fly.ptr"):
+                base_i64 = arith.index_cast(T.i64, ptrtoint(memref))
+                self.rsrc = buffer_ops.create_buffer_resource_from_addr(base_i64)
+            else:
+                self.rsrc = buffer_ops.create_buffer_resource(memref, max_size=True)
+        else:
+            array_base_i64 = self.get_llvm_ptr(memref, (static_bytes_offset_i64))
+            self.rsrc = buffer_ops.create_buffer_resource_from_addr(array_base_i64)
+        self.cache_modifier = cache_modifier
 
     def load(self, offset, vec_size=1):
         return buffer_ops.buffer_load(
@@ -268,7 +341,23 @@ class GTensor(TensorBase):
         )
 
     def store(self, offset, value, vec_size=1):
-        buffer_ops.buffer_store(value, self.rsrc, offset)
+        buffer_ops.buffer_store(
+            value, self.rsrc, offset, cache_modifier=self.cache_modifier
+        )
+
+    def get_llvm_ptr(self, ptr, bytes_offset_i64, ptr_type="!llvm.ptr<1>"):
+        bytes_offset_i64 = arith.index_cast(T.i64, bytes_offset_i64)
+        _ptr_type = ir.Type.parse(ptr_type)
+        raw = extract_to_ir_values(ptr)[0]
+        if str(raw.type).startswith("!fly.ptr"):
+            base_ptr = arith.index_cast(T.i64, ptrtoint(ptr))
+        else:
+            base_ptr = fly.extract_aligned_pointer_as_index(_ptr_type, raw)
+            base_ptr = llvm.PtrToIntOp(T.i64, base_ptr).result
+        llvm_ptr = llvm.AddOp(
+            base_ptr, bytes_offset_i64, llvm.IntegerOverflowFlags(0)
+        ).result
+        return llvm_ptr
 
 
 class STensor(TensorBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "psutil",
     "ninja",
     "pandas",
-    "flydsl==0.1.2"
+    "flydsl==0.2.4"
 ]
 
 [tool.setuptools_scm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyyaml
 einops
 pybind11>=3.0.1
 ninja
-flydsl==0.1.2
+flydsl==0.2.4

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.build_ext import build_ext
 this_dir = os.path.dirname(os.path.abspath(__file__))
 PACKAGE_NAME = "amd-aiter"
 
-FLYDSL_VERSION = "flydsl==0.1.2"
+FLYDSL_VERSION = "flydsl==0.2.4"
 
 BUILD_TARGET = os.environ.get("BUILD_TARGET", "auto")
 PREBUILD_KERNELS = int(os.environ.get("PREBUILD_KERNELS", 0))


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Some changes differ from main for compatibility reasons.

This PR aligns the Flyds version with the main branch, including change

- **update flydsl version to 0.2.4**
- ported some function in aiter/ops/flydsl/kernels/tensor_shim.py from main branch
- added compatibility try-cache handling for unrelated/unused kernels such as aiter/ops/flydsl/kernels/splitk_hgemm.py

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
