### PR TITLE
Fix large-token FlyDSL MoE launch and output limits

### DIFF
--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -14,6 +14,9 @@ from aiter.ops.flydsl.kernels.tensor_shim import ptr_arg
 
 _KERNEL_PARAMS: Dict[str, Dict] = {}
 
+# HIP permits a much larger grid.x, but grid.y/grid.z are limited to 65535.
+_HIP_MAX_GRID_DIM_Y = 65535
+
 
 def _get_dtypes():
     from aiter.utility import dtypes
@@ -93,6 +96,33 @@ def pick_flydsl_stage1_tile_n(inter_dim: int) -> int:
     """
     inter_dim = int(inter_dim)
     return 256 if (inter_dim % 256 == 0) else 128
+
+
+def resolve_flydsl_grid_y_persist_m(
+    num_m_blocks: int, requested_persist_m: int = 0
+) -> int:
+    """Choose enough M blocks per workgroup to keep grid.y legal.
+
+    FlyDSL MoE maps sorted route blocks to grid.y. Large prefill requests can
+    have more than 65535 route blocks even though their tuning key is capped at
+    131072 tokens, causing ``hipModuleLaunchKernel`` to return
+    ``hipErrorInvalidValue``. Kernels with a positive ``persist_m`` loop can
+    process multiple route blocks per workgroup, so increase that loop count
+    only when needed to fit HIP's grid.y limit.
+    """
+    num_m_blocks = max(int(num_m_blocks), 0)
+    requested_persist_m = max(int(requested_persist_m), 1)
+    required_persist_m = max(
+        1, (num_m_blocks + _HIP_MAX_GRID_DIM_Y - 1) // _HIP_MAX_GRID_DIM_Y
+    )
+    return max(requested_persist_m, required_persist_m)
+
+
+def requires_flydsl_stage2_reduce(
+    token_num: int, model_dim: int, element_size: int
+) -> bool:
+    """Whether atomic stage2 output exceeds buffer atomics' 32-bit byte range."""
+    return int(token_num) * int(model_dim) * int(element_size) > 0xFFFFFFFF
 
 
 def resolve_flydsl_stage2_tile_k(inter_dim: int, tile_k: int) -> int:
@@ -1404,7 +1434,7 @@ def flydsl_moe_stage1(
     )
     _grid_y = min(_dense_blks, _all_blks)
 
-    _persist_m = persist_m if persist_m > 0 else 1
+    _persist_m = resolve_flydsl_grid_y_persist_m(_grid_y, persist_m)
 
     # Allocate sorted-scale buffer with padding for tiled layout
     scale_cols = inter_dim // 32
@@ -1707,6 +1737,14 @@ def flydsl_moe_stage2(
     # accumulate. Enabled by default; set AITER_FLYDSL_FORCE_REDUCE=0 to opt out.
     if os.environ.get("AITER_FLYDSL_FORCE_REDUCE", "0") == "1":
         mode = "reduce"
+    elif mode != "reduce" and not return_per_slot and requires_flydsl_stage2_reduce(
+        token_num, model_dim, 2
+    ):
+        # Atomic output uses a single buffer resource with 32-bit byte offsets.
+        # Route through per-slot output + reduction once the final [M, N]
+        # destination exceeds 4 GiB, otherwise high token rows are silently
+        # dropped. Both supported output dtypes (bf16/f16) are two bytes.
+        mode = "reduce"
 
     accumulate = mode != "reduce" and not return_per_slot
 
@@ -1765,7 +1803,9 @@ def flydsl_moe_stage2(
         _persist_m = -1 if m_blocks > 256 else 1
 
     if a_dtype == "fp8":
-        _persist_m = 1
+        # The fp8 path does not use the CU-persistent implementation, but its
+        # positive persist_m loop can still keep grid.y within HIP's limit.
+        _persist_m = resolve_flydsl_grid_y_persist_m(m_blocks)
 
     if bias is not None and bias.dtype != torch.float32:
         bias = bias.to(torch.float32)

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -6,13 +6,13 @@
 import functools
 import os
 import re
-from typing import Dict, Optional
+from typing import Optional
 
 import torch
 
 from aiter.ops.flydsl.kernels.tensor_shim import ptr_arg
 
-_KERNEL_PARAMS: Dict[str, Dict] = {}
+_KERNEL_PARAMS: dict[str, dict] = {}
 
 # HIP permits a much larger grid.x, but grid.y/grid.z are limited to 65535.
 _HIP_MAX_GRID_DIM_Y = 65535
@@ -181,7 +181,7 @@ def get_flydsl_kernel_params(name: str) -> dict | None:
         base_name = name[: m.start()]
         params = _KERNEL_PARAMS.get(base_name)
         if params is not None:
-            extra: Dict = {}
+            extra: dict = {}
             if m.group("kw") is not None:
                 extra["k_wave"] = int(m.group("kw"))
             if m.group("fp4"):
@@ -196,7 +196,7 @@ def get_flydsl_kernel_params(name: str) -> dict | None:
 
 def get_flydsl_stage1_kernels(
     a_dtype: str, b_dtype: str, out_dtype: str
-) -> Dict[str, Dict]:
+) -> dict[str, dict]:
     """Return {kernelName: params} for all supported stage1 configs."""
     kernels = {}
     is_fp4_a = a_dtype == "fp4"
@@ -291,7 +291,7 @@ def get_flydsl_stage1_kernels(
 
 def get_flydsl_stage2_kernels(
     a_dtype: str, b_dtype: str, out_dtype: str
-) -> Dict[str, Dict]:
+) -> dict[str, dict]:
     """Return {kernelName: params} for all supported stage2 configs."""
     kernels = {}
     is_fp4 = b_dtype == "fp4"
@@ -344,7 +344,7 @@ def get_flydsl_stage2_kernels(
 
 
 def _register_production_variants_stage2(
-    kernels: Dict[str, Dict], a_dtype: str, b_dtype: str, out_dtype: str
+    kernels: dict[str, dict], a_dtype: str, b_dtype: str, out_dtype: str
 ) -> None:
     """Append hand-tuned stage2 variants to ``kernels`` in-place."""
     # (a, b, out, tile_m, tile_n, tile_k, mode, suffix, overrides)
@@ -375,7 +375,7 @@ def _register_production_variants_stage2(
         kernels[_base + psuffix] = {**kernels[_base], **povr}
 
 
-def get_flydsl_stage1_kernels_int4_bf16(out_dtype: str) -> Dict[str, Dict]:
+def get_flydsl_stage1_kernels_int4_bf16(out_dtype: str) -> dict[str, dict]:
     """Return {kernelName: params} for all supported int4_bf16 stage1 configs."""
     kernels = {}
     a_dtype = "bf16"
@@ -409,7 +409,7 @@ def get_flydsl_stage1_kernels_int4_bf16(out_dtype: str) -> Dict[str, Dict]:
     return kernels
 
 
-def get_flydsl_stage2_kernels_int4_bf16(out_dtype: str) -> Dict[str, Dict]:
+def get_flydsl_stage2_kernels_int4_bf16(out_dtype: str) -> dict[str, dict]:
     """Return {kernelName: params} for all supported int4_bf16 stage2 configs."""
     kernels = {}
     a_dtype = "bf16"
@@ -1737,8 +1737,10 @@ def flydsl_moe_stage2(
     # accumulate. Enabled by default; set AITER_FLYDSL_FORCE_REDUCE=0 to opt out.
     if os.environ.get("AITER_FLYDSL_FORCE_REDUCE", "0") == "1":
         mode = "reduce"
-    elif mode != "reduce" and not return_per_slot and requires_flydsl_stage2_reduce(
-        token_num, model_dim, 2
+    elif (
+        mode != "reduce"
+        and not return_per_slot
+        and requires_flydsl_stage2_reduce(token_num, model_dim, 2)
     ):
         # Atomic output uses a single buffer resource with 32-bit byte offsets.
         # Route through per-slot output + reduction once the final [M, N]

--- a/op_tests/flydsl_tests/test_flydsl_moe_launch_config.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_launch_config.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from aiter.ops.flydsl.moe_kernels import (
+    requires_flydsl_stage2_reduce,
+    resolve_flydsl_grid_y_persist_m,
+)
+
+
+def test_stage1_persist_m_keeps_grid_y_within_hip_limit():
+    assert resolve_flydsl_grid_y_persist_m(0) == 1
+    assert resolve_flydsl_grid_y_persist_m(65535) == 1
+    assert resolve_flydsl_grid_y_persist_m(65536) == 2
+    assert resolve_flydsl_grid_y_persist_m(131070) == 2
+    assert resolve_flydsl_grid_y_persist_m(131071) == 3
+
+
+def test_stage1_persist_m_preserves_larger_requested_value():
+    assert resolve_flydsl_grid_y_persist_m(65536, requested_persist_m=4) == 4
+
+
+def test_stage2_large_output_avoids_32bit_atomic_offsets():
+    assert not requires_flydsl_stage2_reduce(349525, 6144, 2)
+    assert requires_flydsl_stage2_reduce(349526, 6144, 2)


### PR DESCRIPTION
## Summary

- Keep FlyDSL MoE route-block launches within HIP's `grid.y <= 65535` limit by automatically increasing `persist_m` from the actual runtime block count.
- Apply the same bounded-grid logic to non-persistent FP8 stage2 kernels instead of forcing `persist_m=1`.
- Route stage2 outputs larger than 4 GiB through per-slot reduction because the atomic path uses a single buffer resource with 32-bit byte offsets.
- Add boundary regression tests for both the HIP grid limit and the 4 GiB atomic-output limit.

## Problem

The [Atomesh 1M benchmark failure](https://github.com/ROCm/ATOM/actions/runs/30325181528/job/90169043709) selected the heuristic A4W4 fallback for:

`gfx950, M-tier=131072, hidden=6144, inter=256, experts=256, topk=8, BF16/A4W4 per_1x32`

The `131072` value in the lookup key is capped by `get_padded_M`; it is not the true runtime token count. At 1M-context scale, the real sorted route-block count can exceed 65535. Stage1 mapped those blocks directly to `grid.y`, so `hipModuleLaunchKernel` rejected the launch with `hipErrorInvalidValue` on every rank.

A second issue appears after making the launch legal: for `M=524288, hidden=6144`, the BF16 stage2 output is 6 GiB. The atomic kernel addresses it through one buffer resource with 32-bit byte offsets, causing high token rows to be silently dropped. FP8/A8W4 stage2 also forced `persist_m=1`, exposing the same grid overflow for large route counts.

## Solution

1. Compute the minimum positive `persist_m` required by the actual M-block count:

   `persist_m = max(requested, ceil(num_m_blocks / 65535))`

   Normal shapes retain `persist_m=1`; only oversized launches process multiple M blocks per workgroup.

2. Use this resolver in generic FlyDSL stage1 and FP8 stage2 so all generated `grid.y` values remain legal.

3. Detect final stage2 outputs above `UINT32_MAX` bytes and select the existing reduce mode. The reduction kernel maps tokens to `grid.x`, avoiding both 32-bit atomic output offsets and the restricted HIP grid dimensions.

## Validation

- [x] `pytest -q op_tests/flydsl_tests/test_flydsl_moe_launch_config.py` — 3 passed
- [x] Reproduced the pre-fix `hipErrorInvalidValue` at `M=524288, topk=8, block_m=64`
- [x] A4W4 fallback passes at `M=524288` and `M=1048576`
- [x] Full GLM shape `M=524288, hidden=6144, inter=256, E=256, topk=8` writes matching first/middle/last rows
- [x] A8W4/FP8 stage2 large-grid reproduction passes with automatic `persist_m`
- [x] Existing `M=131072, hidden=6144, inter=256` fallback remains launchable

## Scope

This fixes the generic mixed FlyDSL A4W4/A8W4 paths used by the reported fallback. A16W4 and INT4 kernels have separate single-M-tile launch implementations and are intentionally left for follow-up changes rather than broadening this fix.

Made with [Cursor](https://cursor.com)