### PR TITLE
fix(flydsl-aot): map Situv2 activation in MoE AOT parse_csv

### DIFF
--- a/aiter/aot/flydsl/moe.py
+++ b/aiter/aot/flydsl/moe.py
@@ -84,11 +84,19 @@ def parse_csv(csv_path: str):
             cu_num = int(row.get("cu_num", "0"))
             block_m = int(row.get("block_m", "0") or "0")
             act_type = row.get("act_type", "")
-            act = (
-                "swiglu"
-                if act_type.strip().split(".")[-1].lower() == "swiglu"
-                else "silu"
-            )
+            # Mirror the runtime activation mapping in
+            # ``fused_moe._flydsl_stage1_wrapper`` (Swiglu -> "swiglu",
+            # Situv2 -> "situv2", else "silu"). ``act`` feeds the FlyDSL stage1
+            # compile cache key, so collapsing Situv2 into "silu" here would
+            # write an AOT artifact under a key the runtime never looks up,
+            # causing a FLYDSL_RUNTIME_RUN_ONLY cache miss.
+            act_name = act_type.strip().split(".")[-1].lower()
+            if act_name == "swiglu":
+                act = "swiglu"
+            elif act_name == "situv2":
+                act = "situv2"
+            else:
+                act = "silu"
             q_type = row.get("q_type", "")
             dtype = row.get("dtype", "")
             q_dtype_w = row.get("q_dtype_w", "")

--- a/aiter/aot/flydsl/moe.py
+++ b/aiter/aot/flydsl/moe.py
@@ -84,19 +84,8 @@ def parse_csv(csv_path: str):
             cu_num = int(row.get("cu_num", "0"))
             block_m = int(row.get("block_m", "0") or "0")
             act_type = row.get("act_type", "")
-            # Mirror the runtime activation mapping in
-            # ``fused_moe._flydsl_stage1_wrapper`` (Swiglu -> "swiglu",
-            # Situv2 -> "situv2", else "silu"). ``act`` feeds the FlyDSL stage1
-            # compile cache key, so collapsing Situv2 into "silu" here would
-            # write an AOT artifact under a key the runtime never looks up,
-            # causing a FLYDSL_RUNTIME_RUN_ONLY cache miss.
             act_name = act_type.strip().split(".")[-1].lower()
-            if act_name == "swiglu":
-                act = "swiglu"
-            elif act_name == "situv2":
-                act = "situv2"
-            else:
-                act = "silu"
+            act = act_name if act_name in ("swiglu", "situv2") else "silu"
             q_type = row.get("q_type", "")
             dtype = row.get("dtype", "")
             q_dtype_w = row.get("q_dtype_w", "")

--- a/aiter/aot/flydsl/moe.py
+++ b/aiter/aot/flydsl/moe.py
@@ -48,6 +48,7 @@ from aiter.ops.flydsl.moe_kernels import (
     compile_flydsl_moe_stage1,
     compile_flydsl_moe_stage2,
     get_flydsl_kernel_params,
+    resolve_flydsl_stage1_tile_n,
     resolve_flydsl_stage2_tile_k,
     runtime_swiglu_limit,
 )
@@ -396,6 +397,9 @@ def _precompile_to_cache(
         sorted_token_ids, sorted_expert_ids, num_valid_ids = _make_routing()
 
         if stage == 1:
+            if b_dtype in ("fp4", "mxfp4") and a_dtype in ("bf16", "fp8"):
+                tile_n = resolve_flydsl_stage1_tile_n(inter_dim, tile_n)
+
             a = _make_a_user(_user_a_shape())
             w1_shape = _user_w1_shape()
             w1 = _alloc(w1_shape, _storage_dtype(b_dtype))

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -3151,7 +3151,10 @@ def torch_moe_stage2(
             w2 = fp4_utils.mxfp4_to_f32(w2)
         w2_scale = fp4_utils.e8m0_to_f32(w2_scale)
         if a2_scale is not None:
-            hidden_states = fp4_utils.mxfp4_to_f32(hidden_states)
+            if hidden_states.dtype == dtypes.fp8:  # a8w4 mxfp8 activation
+                hidden_states = hidden_states.to(ctype)
+            else:
+                hidden_states = fp4_utils.mxfp4_to_f32(hidden_states)
             a2_scale = fp4_utils.e8m0_to_f32(a2_scale)
         else:  # a16w4 / mxfp8 (bf16 reference activation)
             hidden_states = hidden_states.to(ctype)

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -972,9 +972,7 @@ def _runtime_situv2_mxfp4_q_dtype_a(token, gate_mode, q_type, wq_dtype):
         return dtypes.bf16 if get_gfx() != "gfx950" or token < bound else dtypes.fp8
 
     return (
-        dtypes.fp8
-        if os.environ.get("AITER_SITUV2_A8W4", "0") == "1"
-        else dtypes.bf16
+        dtypes.fp8 if os.environ.get("AITER_SITUV2_A8W4", "0") == "1" else dtypes.bf16
     )
 
 

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -226,6 +226,16 @@ def test_fmoe(
         w1_qt = w1_qt_aiter = w1_qt.view(w1.shape)
         w2_qt = w2_qt_aiter = w2_qt.view(w2.shape)
 
+    # Match fused_moe's runtime activation dtype. SiTUv2 can be requested as
+    # a16w4 by the caller but dispatched as a8w4 on gfx950.
+    reference_aq_dtype = AQDType
+    if actType == aiter.ActivationType.Situv2:
+        runtime_aq_dtype = _runtime_situv2_mxfp4_q_dtype_a(
+            token, gateMode, qType, WQDType
+        )
+        if runtime_aq_dtype is not None:
+            reference_aq_dtype = runtime_aq_dtype
+
     # Quant-ing a
     if qType == aiter.QuantType.per_128x128:
         a1_qt, a1_scale = aiter.pertoken_quant(
@@ -233,6 +243,14 @@ def test_fmoe(
         )
         a1_qt = a1_qt.view(token, model_dim)
         a1_scale = a1_scale.squeeze(-1)
+    elif (
+        qType == aiter.QuantType.per_1x32
+        and reference_aq_dtype == dtypes.fp8
+        and WQDType == dtypes.fp4x2
+    ):
+        a1_qt, a1_scale = per_1x32_f8_scale_f8_quant(
+            input, quant_dtype=dtypes.fp8, scale_type=dtypes.fp8_e8m0
+        )
     elif (
         (
             qType == aiter.QuantType.per_1x32
@@ -393,6 +411,14 @@ def test_fmoe(
             out1_ref.view(token, -1, 128), quant_dtype=AQDType
         )
         a2_scale = a2_scale.view(token, topk, -1)
+    elif (
+        qType == aiter.QuantType.per_1x32
+        and reference_aq_dtype == dtypes.fp8
+        and WQDType == dtypes.fp4x2
+    ):
+        a2_qt, a2_scale = per_1x32_f8_scale_f8_quant(
+            out1_ref, quant_dtype=dtypes.fp8, scale_type=dtypes.fp8_e8m0
+        )
     elif (
         qType == aiter.QuantType.per_1x32
         and (AQDType in [dtypes.bf16, dtypes.fp16, dtypes.fp8])
@@ -927,6 +953,29 @@ def _effective_swiglu_limit(quant_type, aq_dtype, wq_dtype, swiglu_limit):
     if (quant_type, aq_dtype, wq_dtype) in (_PER1X32_BF16_FP4, _PER1X32_FP8_FP4):
         return swiglu_limit
     return None
+
+
+def _runtime_situv2_mxfp4_q_dtype_a(token, gate_mode, q_type, wq_dtype):
+    """Mirror fused_moe's SiTUv2 MXFP4 activation-dtype routing."""
+    if q_type != aiter.QuantType.per_1x32 or wq_dtype != dtypes.fp4x2:
+        return None
+
+    if get_gfx() == "gfx1250":
+        return (
+            dtypes.fp8
+            if os.environ.get("AITER_FORCE_A8W4", "0") == "1"
+            else dtypes.fp4x2
+        )
+
+    if GateMode(gate_mode) == GateMode.INTERLEAVE:
+        bound = int(os.environ.get("AITER_BF16_FP8_MOE_BOUND", "256"))
+        return dtypes.bf16 if get_gfx() != "gfx950" or token < bound else dtypes.fp8
+
+    return (
+        dtypes.fp8
+        if os.environ.get("AITER_SITUV2_A8W4", "0") == "1"
+        else dtypes.bf16
+    )
 
 
 def _runtime_swiglu_mxfp4_q_dtype_a(


### PR DESCRIPTION
The FlyDSL MoE AOT precompiler collapsed every non-Swiglu activation to "silu" when building compile jobs. ActivationType.Situv2 (used by the new kimik3_a8w4_tuned_fmoe.csv) therefore compiled its stage1 kernel under an act="silu" cache key, while runtime (fused_moe._flydsl_stage1_wrapper) looks it up under act="situv2". Under FLYDSL_RUNTIME_RUN_ONLY=1 that mismatch surfaces as "no usable AOT cache for launch_mixed_moe_gemm1", failing test_moe_2stage.

Mirror the runtime three-way mapping (and the existing grouped_moe AOT parser): Swiglu -> "swiglu", Situv2 -> "situv2", else "silu".

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
