### PR TITLE
[DSV4][Triton] Support block sizes > 1 in paged MQA logits

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
@@ -267,9 +267,7 @@ def _deepgemm_fp8_paged_mqa_logits_stage1(
     ):
         logical_kv_idx = context_idx + tl.arange(0, ChunkK)
         logical_block_idx = logical_kv_idx // KVBlockSize
-        mask_kv = (logical_kv_idx < context_length) & (
-            logical_block_idx < max_blk_len
-        )
+        mask_kv = (logical_kv_idx < context_length) & (logical_block_idx < max_blk_len)
         physical_block_idx = tl.load(
             kv_indices + pid_batch * max_blk_len + logical_block_idx,
             mask=mask_kv,

--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
@@ -211,9 +211,11 @@ def _deepgemm_fp8_paged_mqa_logits_stage1(
     stride_q_next_n: tl.int64,
     stride_q_heads: tl.int64,
     KV_buffer,
-    stride_k_seq: tl.int64,
+    stride_k_block: tl.int64,
+    stride_k_token: tl.int64,
     scale_buffer,
-    stride_scale_seq: tl.int64,
+    stride_scale_block: tl.int64,
+    stride_scale_token: tl.int64,
     context_len_ptr,
     kv_indices,
     weights,
@@ -226,6 +228,7 @@ def _deepgemm_fp8_paged_mqa_logits_stage1(
     ChunkQ: tl.constexpr,
     ChunkK: tl.constexpr,
     HiddenDim: tl.constexpr,
+    KVBlockSize: tl.constexpr,
     SplitKV: tl.constexpr = 1,
 ):
     pid = tl.program_id(0)
@@ -262,21 +265,33 @@ def _deepgemm_fp8_paged_mqa_logits_stage1(
     for context_idx in range(
         split_context_start, split_context_start + split_context_length, ChunkK
     ):
-        mask_kv = context_idx + tl.arange(0, ChunkK) < context_length
-        context_kv_idx = tl.load(
-            kv_indices + pid_batch * max_blk_len + context_idx + tl.arange(0, ChunkK),
+        logical_kv_idx = context_idx + tl.arange(0, ChunkK)
+        logical_block_idx = logical_kv_idx // KVBlockSize
+        mask_kv = (logical_kv_idx < context_length) & (
+            logical_block_idx < max_blk_len
+        )
+        physical_block_idx = tl.load(
+            kv_indices + pid_batch * max_blk_len + logical_block_idx,
             mask=mask_kv,
             other=0,
         )
+        block_offset = logical_kv_idx % KVBlockSize
 
         k = tl.load(
             KV_buffer
-            + context_kv_idx[:, None] * stride_k_seq
+            + physical_block_idx[:, None] * stride_k_block
+            + block_offset[:, None] * stride_k_token
             + tl.arange(0, HiddenDim)[None, :],
             mask=mask_kv[:, None],
             other=0.0,
         )
-        k_scale_f = tl.load(scale_buffer + context_kv_idx[:, None] * stride_scale_seq)
+        k_scale_f = tl.load(
+            scale_buffer
+            + physical_block_idx[:, None] * stride_scale_block
+            + block_offset[:, None] * stride_scale_token,
+            mask=mask_kv[:, None],
+            other=0.0,
+        )
 
         o = tl.dot(q, k.T)
         o = o * k_scale_f.T

--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -181,7 +181,7 @@ def deepgemm_fp8_paged_mqa_logits_stage1_ragged_k(
 
 def deepgemm_fp8_paged_mqa_logits_stage1(
     q_fp8: torch.Tensor,  # dtype = float8
-    kv_cache_fp8: torch.Tensor,  # dtype = float8 [num_blocks, 1, 1, D+4]
+    kv_cache_fp8: torch.Tensor,  # dtype = float8 [num_blocks, block_size, 1, D+4]
     weights: torch.Tensor,  # dtype = float32
     out_qk: torch.Tensor,  # dtype = float32
     context_lens: torch.Tensor,
@@ -195,18 +195,25 @@ def deepgemm_fp8_paged_mqa_logits_stage1(
     if TotalCuCount is None:
         TotalCuCount = get_num_sms()
     batch_size, next_n, heads, hidden_dim = q_fp8.size()
+    num_blocks, block_size, num_kv_heads, packed_dim = kv_cache_fp8.size()
     _, max_blk_len = kv_indices.size()
+
+    assert num_kv_heads == 1
+    assert packed_dim == hidden_dim + 4, (
+        "The stage1 kernel expects one fp32 scale after each packed FP8 token; "
+        f"got q hidden_dim={hidden_dim} and packed KV dim={packed_dim}."
+    )
 
     TileQCount = batch_size * next_n * (heads // ChunkQ)
     SplitKV = (max(1, TotalCuCount // TileQCount) + 4) // 5 * 5 * WavePerEU
 
-    kv_cache_fp8, kv_cache_scale = (
-        kv_cache_fp8[..., :hidden_dim],
-        kv_cache_fp8[..., hidden_dim:],
+    packed_kv_cache = kv_cache_fp8.view(num_blocks, -1)
+    value_elements = block_size * hidden_dim
+    kv_cache_values = packed_kv_cache[:, :value_elements].view(
+        num_blocks, block_size, hidden_dim
     )
-    # Since triton doesn't have the reinterpret_cast, we slice the scale out and view it as float
-    kv_cache_scale = kv_cache_scale.view(torch.float32)
-    kv_cache_fp8 = kv_cache_fp8.view(dtypes.fp8)
+    kv_cache_scale = packed_kv_cache[:, value_elements:].view(torch.float32)
+    kv_cache_fp8 = kv_cache_values.view(dtypes.fp8)
 
     config = {
         "ChunkQ": ChunkQ,
@@ -227,8 +234,10 @@ def deepgemm_fp8_paged_mqa_logits_stage1(
         q_fp8.stride(2),
         kv_cache_fp8,
         kv_cache_fp8.stride(0),
+        kv_cache_fp8.stride(1),
         kv_cache_scale,
         kv_cache_scale.stride(0),
+        kv_cache_scale.stride(1),
         context_lens,
         kv_indices,
         weights,
@@ -240,6 +249,7 @@ def deepgemm_fp8_paged_mqa_logits_stage1(
         max_blk_len,
         waves_per_eu=WavePerEU,
         **config,
+        KVBlockSize=block_size,
     )
 
 


### PR DESCRIPTION
## Motivation

When serving DeepSeek-V4-Flash with vLLM and AITER on 8 × `gfx1201` GPUs, decode uses AITER's paged MQA logits stage-1 Triton kernel (since the Gluon path is CDNA-only).

The stage-1 kernel assumed that each KV-cache block contained one token. vLLM uses a block size of 256 for this model, so the kernel incorrectly used each logical token position as an index into the block table. Once the logical token position exceeded the actual block-table width, it could read an invalid physical block ID and access memory outside the KV cache.

Because `--max-num-seqs` changes scheduler buffers, CUDA graph capture shapes, and the surrounding allocation layout, the invalid read did not fail identically for every value. Some configurations happened to read mapped memory, while others terminated workers with `HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION`.

This PR generalizes the stage-1 path to support KV-cache block sizes greater than one.

## Technical details

The corrected indexing maps each logical token to its logical block and its offset within that block:

```text
logical_block_idx = logical_token_idx // block_size
block_offset      = logical_token_idx % block_size
physical_block    = block_table[batch, logical_block_idx]
```

FP8 values and FP32 scales are loaded using both the physical block index and the in-block token offset. The wrapper also splits the block-packed KV-cache storage at the actual value/scale boundary and passes the value/scale block and token strides into the Triton kernel.

## Test plan

I ran the same vLLM serving benchmarks before and after the fix on 8 × `gfx1201`, using 10 requests, concurrency 1, and two warm-up requests. I tested `--max-num-seqs` values `1`, `4`, `8`, `32`, and the vLLM default (`256`). For the default case, the `--max-num-seqs` option was omitted.

### Server command

```bash
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_RMSNORM=0 \
vllm serve deepseek-ai/DeepSeek-V4-Flash \
    --served-model-name deepseek-v4-flash \
    --host 0.0.0.0 \
    --port 8000 \
    --tensor-parallel-size 8 \
    --max-model-len 4096 \
    --gpu-memory-utilization 0.95 \
    --dtype auto \
    --kv-cache-dtype fp8 \
    --trust-remote-code \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}'
```

For each non-default test, I appended one of:

```bash
--max-num-seqs 1
--max-num-seqs 4
--max-num-seqs 8
--max-num-seqs 32
```

### Benchmark command

```bash
vllm bench serve \
    --backend openai \
    --base-url http://localhost:8000 \
    --endpoint /v1/completions \
    --model deepseek-ai/DeepSeek-V4-Flash \
    --served-model-name deepseek-v4-flash \
    --dataset-name random \
    --random-input-len 1024 \
    --random-output-len 1024 \
    --num-prompts 10 \
    --max-concurrency 1 \
    --num-warmups 2 \
    --request-rate inf \
    --ignore-eos \
    --percentile-metrics 'ttft,tpot,itl,e2el'
```

The same command was repeated for input/output lengths `512/128`, `1024/1024`, and `2048/512`.

### Accuracy

GSM8K : 

```bash
lm_eval \
    --model local-completions \
    --tasks gsm8k \
    --model_args "model=deepseek-v4-flash,tokenizer=deepseek-ai/DeepSeek-V4-Flash,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
    --batch_size auto
```

## Test Results

### Serving results

| Max sequences | Input → output tokens | Before: TTFT (ms) | Before: TPOT (ms) | After: TTFT (ms) | After: TPOT (ms) |
|---:|---:|---:|---:|---:|---:|
| 1 | 512 → 128 | **Fail** | **Fail** | 185.10 | 36.95 |
| 1 | 1024 → 1024 | **Fail** | **Fail** | 289.96 | 53.62 |
| 1 | 2048 → 512 | **Fail** | **Fail** | 474.03 | 38.87 |
| 4 | 512 → 128 | **Fail** | **Fail** | 187.96 | 37.07 |
| 4 | 1024 → 1024 | **Fail** | **Fail** | 239.34 | 38.02 |
| 4 | 2048 → 512 | **Fail** | **Fail** | 479.21 | 39.13 |
| 8 | 512 → 128 | 185.04 | 36.86 | 186.75 | 36.86 |
| 8 | 1024 → 1024 | 237.54 | 38.01 | 222.50 | 38.01 |
| 8 | 2048 → 512 | 485.67 | 39.68 | 488.76 | 38.90 |
| 32 | 512 → 128 | 185.07 | 37.01 | 185.85 | 36.91 |
| 32 | 1024 → 1024 | 226.37 | 38.13 | 227.67 | 37.89 |
| 32 | 2048 → 512 | 483.60 | 39.78 | 482.02 | 38.87 |
| 256 (default) | 512 → 128 | 138.80 | 35.20 | 138.17 | 35.11 |
| 256 (default) | 1024 → 1024 | 226.39 | 36.12 | 225.96 | 36.12 |
| 256 (default) | 2048 → 512 | 444.99 | 37.72 | 442.00 | 36.70 |


## GSM8K
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.95|±  | 0.006|
|     |       |strict-match    |     5|exact_match|↑  | 0.95|±  | 0.006|

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
