### PR TITLE
perf(flydsl): fuse Kimi-K3 B1 BF16 pre-route projections on gfx950

### DIFF
--- a/aiter/ops/flydsl/kernels/kimi_k3_dual_projection_bf16_gfx950.py
+++ b/aiter/ops/flydsl/kernels/kimi_k3_dual_projection_bf16_gfx950.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fixed-shape Kimi-K3 B1 dual-output BF16 projection for gfx950."""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, scf
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, vector
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import T
+
+from aiter.ops.flydsl.kernels.tensor_shim import (
+    AITER_FLYDSL_KERNARG_PRELOAD,
+    AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
+)
+
+_HIDDEN_SIZE = 7168
+_ROUTED_SIZE = 3584
+_SHARED_GATE_UP_SIZE = 1536
+_TOTAL_OUTPUT_SIZE = _ROUTED_SIZE + _SHARED_GATE_UP_SIZE
+_WAVE_SIZE = 64
+_ELEMENTS_PER_LOAD = 8
+
+
+def _raw(value):
+    return value.ir_value() if hasattr(value, "ir_value") else value
+
+
+def build_kimi_k3_b1_dual_projection_bf16_module(
+    rows_per_wave: int = 3,
+    cu_count: int = 256,
+    waves_per_eu: int = 0,
+    weight_cache_modifier: int = 2,
+    hidden_to_lds: bool = True,
+):
+    """Build the Kimi-K3 B1 routed-down and shared gate/up projection."""
+
+    if rows_per_wave not in (1, 2, 3, 4, 5, 6, 8):
+        raise ValueError("rows_per_wave must be 1, 2, 3, 4, 5, 6, or 8")
+    if not 1 <= cu_count <= 256:
+        raise ValueError("cu_count must be between 1 and 256")
+    if waves_per_eu < 0:
+        raise ValueError("waves_per_eu must be non-negative")
+    if weight_cache_modifier not in (0, 1, 2, 3):
+        raise ValueError("weight_cache_modifier must be between 0 and 3")
+
+    output_groups = (_TOTAL_OUTPUT_SIZE + rows_per_wave - 1) // rows_per_wave
+    waves_per_block = min(16, (output_groups + cu_count - 1) // cu_count)
+    block_threads = waves_per_block * _WAVE_SIZE
+    groups_per_grid = cu_count * waves_per_block
+    persistent_iterations = (output_groups + groups_per_grid - 1) // groups_per_grid
+    hidden_load_iterations = (
+        _HIDDEN_SIZE + block_threads * _ELEMENTS_PER_LOAD - 1
+    ) // (block_threads * _ELEMENTS_PER_LOAD)
+
+    @fx.struct
+    class SharedStorage:
+        hidden: fx.Array[fx.BFloat16, _HIDDEN_SIZE, 16]
+
+    kernel_name = (
+        "kimi_k3_b1_dual_projection_bf16_gfx950"
+        f"_rpw{rows_per_wave}_cu{cu_count}_wpb{waves_per_block}"
+        f"_wpe{waves_per_eu}_wcm{weight_cache_modifier}"
+        f"_hlds{int(hidden_to_lds)}"
+    )
+
+    @flyc.kernel(
+        name=kernel_name,
+        known_block_size=[block_threads, 1, 1],
+    )
+    def dual_projection_kernel(
+        hidden: fx.Pointer,
+        routed_weight: fx.Pointer,
+        shared_weight: fx.Pointer,
+        routed_output: fx.Pointer,
+        shared_output: fx.Pointer,
+    ):
+        i32 = T.i32
+        f32 = T.f32
+        i1 = ir.IntegerType.get_signless(1)
+        fm_fast = arith.FastMathFlags.fast
+        tid = ArithValue(gpu.thread_idx.x)
+        lane = tid % arith.constant(_WAVE_SIZE, type=i32)
+        wave = tid // arith.constant(_WAVE_SIZE, type=i32)
+
+        hidden_rsrc = ptr_rsrc(hidden)
+        routed_weight_rsrc = ptr_rsrc(routed_weight)
+        shared_weight_rsrc = ptr_rsrc(shared_weight)
+        routed_output_rsrc = ptr_rsrc(routed_output)
+        shared_output_rsrc = ptr_rsrc(shared_output)
+        hidden_lds = fx.SharedAllocator().allocate(SharedStorage).peek().hidden.ptr
+
+        vec8_bf16 = T.vec(_ELEMENTS_PER_LOAD, T.bf16)
+        zero_f32 = arith.constant(0.0, type=f32)
+
+        def load_bf16x8(resource, element_index, cache_modifier=0):
+            dwords = buffer_ops.buffer_load(
+                resource,
+                element_index // arith.constant(2, type=i32),
+                vec_width=4,
+                dtype=i32,
+                cache_modifier=cache_modifier,
+            )
+            return vector.bitcast(vec8_bf16, dwords)
+
+        def dot_bf16x8(left, right):
+            dot = zero_f32
+            for pair_index in range_constexpr(4):
+                left_pair = vector.from_elements(
+                    T.vec(2, T.bf16),
+                    [
+                        vector.extract(
+                            left,
+                            static_position=[pair_index * 2],
+                            dynamic_position=[],
+                        ),
+                        vector.extract(
+                            left,
+                            static_position=[pair_index * 2 + 1],
+                            dynamic_position=[],
+                        ),
+                    ],
+                )
+                right_pair = vector.from_elements(
+                    T.vec(2, T.bf16),
+                    [
+                        vector.extract(
+                            right,
+                            static_position=[pair_index * 2],
+                            dynamic_position=[],
+                        ),
+                        vector.extract(
+                            right,
+                            static_position=[pair_index * 2 + 1],
+                            dynamic_position=[],
+                        ),
+                    ],
+                )
+                dot = llvm.call_intrinsic(
+                    f32,
+                    "llvm.amdgcn.fdot2.f32.bf16",
+                    [
+                        left_pair,
+                        right_pair,
+                        dot,
+                        arith.constant(False, type=i1),
+                    ],
+                    [],
+                    [],
+                )
+            return dot
+
+        def wave_reduce_add(value):
+            reduced = _raw(value)
+            for offset in (32, 16, 8, 4, 2, 1):
+                peer = _raw(
+                    ArithValue(reduced).shuffle_xor(
+                        arith.constant(offset, type=i32),
+                        arith.constant(_WAVE_SIZE, type=i32),
+                    )
+                )
+                reduced = arith.AddFOp(
+                    reduced,
+                    peer,
+                    fastmath=fm_fast,
+                ).result
+            return reduced
+
+        if const_expr(hidden_to_lds):
+            for load_iteration in range_constexpr(hidden_load_iterations):
+                element_index = (
+                    tid
+                    + arith.constant(
+                        load_iteration * block_threads,
+                        type=i32,
+                    )
+                ) * arith.constant(_ELEMENTS_PER_LOAD, type=i32)
+                can_load = arith.cmpi(
+                    CmpIPredicate.ult,
+                    element_index,
+                    arith.constant(_HIDDEN_SIZE, type=i32),
+                )
+                load_if = scf.IfOp(can_load)
+                with ir.InsertionPoint(load_if.then_block):
+                    hidden_vector = load_bf16x8(hidden_rsrc, element_index)
+                    fx.ptr_store(hidden_vector, hidden_lds + element_index)
+                    scf.YieldOp([])
+            gpu.barrier()
+
+        first_group = (
+            ArithValue(gpu.block_idx.x) * arith.constant(waves_per_block, type=i32)
+            + wave
+        )
+        for persistent_index in range_constexpr(persistent_iterations):
+            group = first_group + arith.constant(
+                persistent_index * groups_per_grid,
+                type=i32,
+            )
+            row_base = group * arith.constant(rows_per_wave, type=i32)
+            for row_offset in range_constexpr(rows_per_wave):
+                row = row_base + arith.constant(row_offset, type=i32)
+                row_in_range = arith.cmpi(
+                    CmpIPredicate.ult,
+                    row,
+                    arith.constant(_TOTAL_OUTPUT_SIZE, type=i32),
+                )
+                row_if = scf.IfOp(row_in_range)
+                with ir.InsertionPoint(row_if.then_block):
+                    is_routed = arith.cmpi(
+                        CmpIPredicate.ult,
+                        row,
+                        arith.constant(_ROUTED_SIZE, type=i32),
+                    )
+                    shared_row = row - arith.constant(_ROUTED_SIZE, type=i32)
+                    local_dot = ArithValue(zero_f32)
+                    for k_iteration in range_constexpr(
+                        _HIDDEN_SIZE // (_WAVE_SIZE * _ELEMENTS_PER_LOAD)
+                    ):
+                        k_element = (
+                            lane
+                            + arith.constant(
+                                k_iteration * _WAVE_SIZE,
+                                type=i32,
+                            )
+                        ) * arith.constant(_ELEMENTS_PER_LOAD, type=i32)
+                        if const_expr(hidden_to_lds):
+                            hidden_vector = fx.ptr_load(
+                                hidden_lds + k_element,
+                                result_type=vec8_bf16,
+                            )
+                        else:
+                            hidden_vector = load_bf16x8(
+                                hidden_rsrc,
+                                k_element,
+                            )
+                        weight_if = scf.IfOp(
+                            is_routed,
+                            results_=[vec8_bf16],
+                            has_else=True,
+                        )
+                        with ir.InsertionPoint(weight_if.then_block):
+                            weight_element = (
+                                row * arith.constant(_HIDDEN_SIZE, type=i32) + k_element
+                            )
+                            weight_vector = load_bf16x8(
+                                routed_weight_rsrc,
+                                weight_element,
+                                weight_cache_modifier,
+                            )
+                            scf.YieldOp([_raw(weight_vector)])
+                        with ir.InsertionPoint(weight_if.else_block):
+                            weight_element = (
+                                shared_row * arith.constant(_HIDDEN_SIZE, type=i32)
+                                + k_element
+                            )
+                            weight_vector = load_bf16x8(
+                                shared_weight_rsrc,
+                                weight_element,
+                                weight_cache_modifier,
+                            )
+                            scf.YieldOp([_raw(weight_vector)])
+                        local_dot = local_dot + dot_bf16x8(
+                            hidden_vector,
+                            weight_if.results[0],
+                        )
+                    reduced = wave_reduce_add(local_dot)
+                    is_lane_zero = arith.cmpi(
+                        CmpIPredicate.eq,
+                        lane,
+                        arith.constant(0, type=i32),
+                    )
+                    write_if = scf.IfOp(is_lane_zero)
+                    with ir.InsertionPoint(write_if.then_block):
+                        result = arith.trunc_f(T.bf16, reduced)
+                        output_if = scf.IfOp(
+                            is_routed,
+                            results_=[],
+                            has_else=True,
+                        )
+                        with ir.InsertionPoint(output_if.then_block):
+                            buffer_ops.buffer_store(
+                                result,
+                                routed_output_rsrc,
+                                row,
+                            )
+                            scf.YieldOp([])
+                        with ir.InsertionPoint(output_if.else_block):
+                            buffer_ops.buffer_store(
+                                result,
+                                shared_output_rsrc,
+                                shared_row,
+                            )
+                            scf.YieldOp([])
+                        scf.YieldOp([])
+                    scf.YieldOp([])
+
+    @flyc.jit
+    def launch_dual_projection(
+        hidden: fx.Pointer,
+        routed_weight: fx.Pointer,
+        shared_weight: fx.Pointer,
+        routed_output: fx.Pointer,
+        shared_output: fx.Pointer,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        ctx = CompilationContext.get_current()
+        if const_expr(waves_per_eu > 0):
+            for operation in ctx.gpu_module_body.operations:
+                if (
+                    hasattr(operation, "attributes")
+                    and operation.OPERATION_NAME == "gpu.func"
+                ):
+                    operation.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                        T.i32, int(waves_per_eu)
+                    )
+        dual_projection_kernel(
+            hidden,
+            routed_weight,
+            shared_weight,
+            routed_output,
+            shared_output,
+        ).launch(
+            grid=(cu_count, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    launch_dual_projection.compile_hints = {
+        "llvm_options": {
+            "amdgpu-kernarg-preload": AITER_FLYDSL_KERNARG_PRELOAD,
+            "amdgpu-kernarg-preload-count": AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+        },
+    }
+    return launch_dual_projection

--- a/aiter/ops/flydsl/kernels/kimi_k3_shared_down_bf16_gfx950.py
+++ b/aiter/ops/flydsl/kernels/kimi_k3_shared_down_bf16_gfx950.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fused Kimi-K3 B1 SiTU and BF16 shared-down projection for gfx950."""
+
+import math
+import os
+from pathlib import Path
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import arith as arith_dialect
+from flydsl._mlir.dialects import scf
+from flydsl.compiler.extern_link import ExternFunction
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, vector
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import T
+from flydsl.expr.vector import ReductionOp
+
+from aiter.ops.flydsl.kernels.tensor_shim import (
+    AITER_FLYDSL_KERNARG_PRELOAD,
+    AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+    ptr_rsrc,
+)
+
+_SHARED_INTERMEDIATE_SIZE = 768
+_SHARED_GATE_UP_SIZE = 2 * _SHARED_INTERMEDIATE_SIZE
+_HIDDEN_SIZE = 7168
+_WAVE_SIZE = 64
+_ELEMENTS_PER_LOAD = 4
+
+
+def _find_ocml_bitcode() -> str:
+    """Find ROCm's device math library without pinning a ROCm release."""
+
+    roots = [
+        Path(value)
+        for value in (
+            os.environ.get("ROCM_PATH"),
+            os.environ.get("ROCM_HOME"),
+            "/opt/rocm",
+        )
+        if value
+    ]
+    patterns = (
+        "amdgcn/bitcode/ocml.bc",
+        "lib/llvm/lib/clang/*/lib/amdgcn/bitcode/ocml.bc",
+    )
+    for root in roots:
+        for pattern in patterns:
+            matches = sorted(root.glob(pattern), reverse=True)
+            if matches:
+                return str(matches[0])
+    raise RuntimeError("unable to locate ROCm OCML bitcode")
+
+
+def _raw(value):
+    return value.ir_value() if hasattr(value, "ir_value") else value
+
+
+def build_kimi_k3_b1_shared_down_bf16_module(
+    rows_per_wave: int = 1,
+    cu_count: int = 256,
+    waves_per_eu: int = 0,
+    weight_cache_modifier: int = 2,
+    situ_beta: float = 4.0,
+    situ_linear_beta: float = 25.0,
+):
+    """Build the Kimi-K3 B1 fused SiTU and shared-down projection."""
+
+    if rows_per_wave not in (1, 2, 3, 4, 5, 6, 8):
+        raise ValueError("rows_per_wave must be 1, 2, 3, 4, 5, 6, or 8")
+    if not 1 <= cu_count <= 256:
+        raise ValueError("cu_count must be between 1 and 256")
+    if waves_per_eu < 0:
+        raise ValueError("waves_per_eu must be non-negative")
+    if weight_cache_modifier not in (0, 1, 2, 3):
+        raise ValueError("weight_cache_modifier must be between 0 and 3")
+    if (
+        not math.isfinite(situ_beta)
+        or not math.isfinite(situ_linear_beta)
+        or situ_beta <= 0.0
+        or situ_linear_beta <= 0.0
+    ):
+        raise ValueError("SiTU beta values must be finite and positive")
+
+    output_groups = (_HIDDEN_SIZE + rows_per_wave - 1) // rows_per_wave
+    waves_per_block = min(16, (output_groups + cu_count - 1) // cu_count)
+    block_threads = waves_per_block * _WAVE_SIZE
+    groups_per_grid = cu_count * waves_per_block
+    persistent_iterations = (output_groups + groups_per_grid - 1) // groups_per_grid
+
+    ocml_bitcode = _find_ocml_bitcode()
+    ocml_exp_f32 = ExternFunction(
+        "__ocml_exp_f32",
+        ["float32"],
+        "float32",
+        is_pure=True,
+        bitcode_path=ocml_bitcode,
+    )
+    ocml_tanh_f32 = ExternFunction(
+        "__ocml_tanh_f32",
+        ["float32"],
+        "float32",
+        is_pure=True,
+        bitcode_path=ocml_bitcode,
+    )
+
+    @fx.struct
+    class SharedStorage:
+        activated: fx.Array[fx.BFloat16, _SHARED_INTERMEDIATE_SIZE, 16]
+
+    beta_tag = f"{situ_beta:g}".replace(".", "p")
+    linear_beta_tag = f"{situ_linear_beta:g}".replace(".", "p")
+    kernel_name = (
+        "kimi_k3_b1_situ_shared_down_bf16_bf16_gfx950"
+        f"_rpw{rows_per_wave}_cu{cu_count}_wpb{waves_per_block}"
+        f"_wpe{waves_per_eu}_wcm{weight_cache_modifier}"
+        f"_sb{beta_tag}_slb{linear_beta_tag}"
+    )
+
+    @flyc.kernel(
+        name=kernel_name,
+        known_block_size=[block_threads, 1, 1],
+    )
+    def shared_down_bf16_kernel(
+        gate_up: fx.Pointer,
+        weight: fx.Pointer,
+        output: fx.Pointer,
+    ):
+        i32 = T.i32
+        f32 = T.f32
+        fm_fast = arith.FastMathFlags.fast
+        tid = ArithValue(gpu.thread_idx.x)
+        lane = tid % arith.constant(_WAVE_SIZE, type=i32)
+        wave = tid // arith.constant(_WAVE_SIZE, type=i32)
+
+        gate_up_rsrc = ptr_rsrc(gate_up)
+        weight_rsrc = ptr_rsrc(weight)
+        output_rsrc = ptr_rsrc(output)
+        activated_lds = (
+            fx.SharedAllocator().allocate(SharedStorage).peek().activated.ptr
+        )
+
+        vec4_bf16 = T.vec(_ELEMENTS_PER_LOAD, T.bf16)
+        vec4_f32 = T.vec(_ELEMENTS_PER_LOAD, f32)
+        zero_f32 = arith.constant(0.0, type=f32)
+        one_f32 = arith.constant(1.0, type=f32)
+        zero_i32 = arith.constant(0, type=i32)
+        beta = arith.constant(float(situ_beta), type=f32)
+        inv_beta = arith.constant(1.0 / float(situ_beta), type=f32)
+        linear_beta = arith.constant(float(situ_linear_beta), type=f32)
+        inv_linear_beta = arith.constant(
+            1.0 / float(situ_linear_beta),
+            type=f32,
+        )
+
+        def sigmoid(value):
+            # Match vLLM's production 1 / (1 + expf(-x)) evaluation.
+            exponent = ocml_exp_f32(-value)
+            return one_f32 / (one_f32 + exponent)
+
+        def load_bf16x4_as_f32(resource, element_index):
+            packed = buffer_ops.buffer_load(
+                resource,
+                element_index // arith.constant(2, type=i32),
+                vec_width=2,
+                dtype=i32,
+                cache_modifier=weight_cache_modifier,
+            )
+            weight_bf16 = vector.bitcast(vec4_bf16, packed)
+            return ArithValue(weight_bf16).extf(vec4_f32)
+
+        def wave_reduce_add(value):
+            reduced = _raw(value)
+            for offset in (32, 16, 8, 4, 2, 1):
+                peer = _raw(
+                    ArithValue(reduced).shuffle_xor(
+                        arith.constant(offset, type=i32),
+                        arith.constant(_WAVE_SIZE, type=i32),
+                    )
+                )
+                reduced = arith_dialect.AddFOp(
+                    reduced,
+                    peer,
+                    fastmath=fm_fast,
+                ).result
+            return reduced
+
+        # Every resident block computes the 768-element SiTU vector once
+        # and retains it in LDS while processing its output-row tile.
+        activation_iterations = (
+            _SHARED_INTERMEDIATE_SIZE + block_threads - 1
+        ) // block_threads
+        for activation_iteration in range_constexpr(activation_iterations):
+            element = tid + arith.constant(
+                activation_iteration * block_threads,
+                type=i32,
+            )
+            valid = arith.cmpi(
+                CmpIPredicate.ult,
+                element,
+                arith.constant(_SHARED_INTERMEDIATE_SIZE, type=i32),
+            )
+            activation_if = scf.IfOp(valid)
+            with ir.InsertionPoint(activation_if.then_block):
+                gate_bf16 = buffer_ops.buffer_load(
+                    gate_up_rsrc,
+                    element,
+                    vec_width=1,
+                    dtype=T.bf16,
+                )
+                up_bf16 = buffer_ops.buffer_load(
+                    gate_up_rsrc,
+                    element
+                    + arith.constant(
+                        _SHARED_INTERMEDIATE_SIZE,
+                        type=i32,
+                    ),
+                    vec_width=1,
+                    dtype=T.bf16,
+                )
+                gate = ArithValue(arith.extf(f32, gate_bf16))
+                up = ArithValue(arith.extf(f32, up_bf16))
+                activated = (
+                    beta
+                    * ocml_tanh_f32(gate * inv_beta)
+                    * sigmoid(gate)
+                    * linear_beta
+                    * ocml_tanh_f32(up * inv_linear_beta)
+                )
+                fx.ptr_store(
+                    arith.trunc_f(T.bf16, _raw(activated)),
+                    activated_lds + element,
+                )
+                scf.YieldOp([])
+        gpu.barrier()
+
+        first_group = (
+            ArithValue(gpu.block_idx.x) * arith.constant(waves_per_block, type=i32)
+            + wave
+        )
+        for persistent_index in range_constexpr(persistent_iterations):
+            group = first_group + arith.constant(
+                persistent_index * groups_per_grid,
+                type=i32,
+            )
+            row_base = group * arith.constant(rows_per_wave, type=i32)
+            for row_offset in range_constexpr(rows_per_wave):
+                row = row_base + arith.constant(row_offset, type=i32)
+                row_in_range = arith.cmpi(
+                    CmpIPredicate.ult,
+                    row,
+                    arith.constant(_HIDDEN_SIZE, type=i32),
+                )
+                row_if = scf.IfOp(row_in_range)
+                with ir.InsertionPoint(row_if.then_block):
+                    local_dot = ArithValue(zero_f32)
+                    for k_iteration in range_constexpr(
+                        _SHARED_INTERMEDIATE_SIZE // (_WAVE_SIZE * _ELEMENTS_PER_LOAD)
+                    ):
+                        k_element = (
+                            lane
+                            + arith.constant(
+                                k_iteration * _WAVE_SIZE,
+                                type=i32,
+                            )
+                        ) * arith.constant(_ELEMENTS_PER_LOAD, type=i32)
+                        activated_bf16 = fx.ptr_load(
+                            activated_lds + k_element,
+                            result_type=vec4_bf16,
+                        )
+                        activated_f32 = ArithValue(activated_bf16).extf(vec4_f32)
+                        weight_element = (
+                            row
+                            * arith.constant(
+                                _SHARED_INTERMEDIATE_SIZE,
+                                type=i32,
+                            )
+                            + k_element
+                        )
+                        weight_f32 = load_bf16x4_as_f32(
+                            weight_rsrc,
+                            weight_element,
+                        )
+                        local_dot = local_dot + (activated_f32 * weight_f32).reduce(
+                            ReductionOp.ADD,
+                            fastmath=fm_fast,
+                        )
+
+                    reduced = wave_reduce_add(local_dot)
+                    is_lane_zero = arith.cmpi(
+                        CmpIPredicate.eq,
+                        lane,
+                        zero_i32,
+                    )
+                    write_if = scf.IfOp(is_lane_zero)
+                    with ir.InsertionPoint(write_if.then_block):
+                        buffer_ops.buffer_store(
+                            arith.trunc_f(T.bf16, reduced),
+                            output_rsrc,
+                            row,
+                        )
+                        scf.YieldOp([])
+                    scf.YieldOp([])
+
+    @flyc.jit
+    def launch_shared_down_bf16(
+        gate_up: fx.Pointer,
+        weight: fx.Pointer,
+        output: fx.Pointer,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        ctx = CompilationContext.get_current()
+        if const_expr(waves_per_eu > 0):
+            for operation in ctx.gpu_module_body.operations:
+                if (
+                    hasattr(operation, "attributes")
+                    and operation.OPERATION_NAME == "gpu.func"
+                ):
+                    operation.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                        T.i32, int(waves_per_eu)
+                    )
+        shared_down_bf16_kernel(
+            gate_up,
+            weight,
+            output,
+        ).launch(
+            grid=(cu_count, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    launch_shared_down_bf16.compile_hints = {
+        "llvm_options": {
+            "amdgpu-kernarg-preload": AITER_FLYDSL_KERNARG_PRELOAD,
+            "amdgpu-kernarg-preload-count": AITER_FLYDSL_KERNARG_PRELOAD_COUNT,
+        },
+    }
+    return launch_shared_down_bf16

--- a/aiter/ops/flydsl/kimi_k3_moe_preroute_bf16.py
+++ b/aiter/ops/flydsl/kimi_k3_moe_preroute_bf16.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Exact-BF16 Kimi-K3 B1 MoE pre-route fusion for gfx950."""
+
+import functools
+import math
+
+import torch
+
+from aiter.jit.utils.chip_info import get_gfx_runtime
+from aiter.ops.flydsl.utils import is_flydsl_available
+
+_BATCH_SIZE = 1
+_HIDDEN_SIZE = 7168
+_ROUTED_SIZE = 3584
+_SHARED_GATE_UP_SIZE = 1536
+_SHARED_INTERMEDIATE_SIZE = 768
+
+# Frozen from the MI355X shape sweep. Keeping these values here makes the
+# production dispatch deterministic; builder-level parameters remain
+# available for future architecture-specific tuning.
+_DUAL_ROWS_PER_WAVE = 3
+_DUAL_CU_COUNT = 256
+_DUAL_WAVES_PER_EU = 0
+_DUAL_WEIGHT_CACHE_MODIFIER = 2
+_DUAL_HIDDEN_TO_LDS = True
+_SHARED_ROWS_PER_WAVE = 1
+_SHARED_CU_COUNT = 256
+_SHARED_WAVES_PER_EU = 0
+_SHARED_WEIGHT_CACHE_MODIFIER = 2
+
+
+def is_kimi_k3_moe_preroute_bf16_available() -> bool:
+    """Return whether the fixed-shape gfx950 backend can be compiled."""
+
+    return is_flydsl_available() and get_gfx_runtime() == "gfx950"
+
+
+def supports_kimi_k3_moe_preroute_bf16(
+    hidden: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+) -> bool:
+    """Return whether tensors satisfy the fixed Kimi-K3 B1 contract."""
+
+    tensors = (
+        hidden,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    )
+    return (
+        all(tensor.is_cuda for tensor in tensors)
+        and all(tensor.dtype == torch.bfloat16 for tensor in tensors)
+        and all(tensor.is_contiguous() for tensor in tensors)
+        and len({tensor.device for tensor in tensors}) == 1
+        and hidden.shape == (_BATCH_SIZE, _HIDDEN_SIZE)
+        and routed_weight.shape == (_ROUTED_SIZE, _HIDDEN_SIZE)
+        and shared_gate_up_weight.shape == (_SHARED_GATE_UP_SIZE, _HIDDEN_SIZE)
+        and shared_down_weight.shape == (_HIDDEN_SIZE, _SHARED_INTERMEDIATE_SIZE)
+        and is_kimi_k3_moe_preroute_bf16_available()
+    )
+
+
+@functools.cache
+def _compiled_dual_projection():
+    from aiter.ops.flydsl.kernels.kimi_k3_dual_projection_bf16_gfx950 import (
+        build_kimi_k3_b1_dual_projection_bf16_module,
+    )
+
+    return build_kimi_k3_b1_dual_projection_bf16_module(
+        rows_per_wave=_DUAL_ROWS_PER_WAVE,
+        cu_count=_DUAL_CU_COUNT,
+        waves_per_eu=_DUAL_WAVES_PER_EU,
+        weight_cache_modifier=_DUAL_WEIGHT_CACHE_MODIFIER,
+        hidden_to_lds=_DUAL_HIDDEN_TO_LDS,
+    )
+
+
+@functools.cache
+def _compiled_shared_down(
+    situ_beta: float,
+    situ_linear_beta: float,
+):
+    from aiter.ops.flydsl.kernels.kimi_k3_shared_down_bf16_gfx950 import (
+        build_kimi_k3_b1_shared_down_bf16_module,
+    )
+
+    return build_kimi_k3_b1_shared_down_bf16_module(
+        rows_per_wave=_SHARED_ROWS_PER_WAVE,
+        cu_count=_SHARED_CU_COUNT,
+        waves_per_eu=_SHARED_WAVES_PER_EU,
+        weight_cache_modifier=_SHARED_WEIGHT_CACHE_MODIFIER,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
+    )
+
+
+def kimi_k3_moe_preroute_bf16(
+    hidden: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    situ_beta: float = 4.0,
+    situ_linear_beta: float = 25.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return routed latent output and the shared-expert partial output."""
+
+    if (
+        not math.isfinite(situ_beta)
+        or not math.isfinite(situ_linear_beta)
+        or situ_beta <= 0.0
+        or situ_linear_beta <= 0.0
+    ):
+        raise ValueError("SiTU beta values must be finite and positive")
+    if not supports_kimi_k3_moe_preroute_bf16(
+        hidden,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    ):
+        raise ValueError("unsupported Kimi-K3 B1 pre-route BF16 inputs")
+
+    from aiter.ops.flydsl.kernels.tensor_shim import ptr_arg
+
+    routed_output = torch.empty(
+        (_BATCH_SIZE, _ROUTED_SIZE),
+        dtype=hidden.dtype,
+        device=hidden.device,
+    )
+    shared_gate_up = torch.empty(
+        (_BATCH_SIZE, _SHARED_GATE_UP_SIZE),
+        dtype=hidden.dtype,
+        device=hidden.device,
+    )
+    shared_output = torch.empty(
+        (_BATCH_SIZE, _HIDDEN_SIZE),
+        dtype=hidden.dtype,
+        device=hidden.device,
+    )
+    stream = torch.cuda.current_stream(hidden.device)
+
+    _compiled_dual_projection()(
+        ptr_arg(hidden),
+        ptr_arg(routed_weight),
+        ptr_arg(shared_gate_up_weight),
+        ptr_arg(routed_output),
+        ptr_arg(shared_gate_up),
+        stream=stream,
+    )
+    _compiled_shared_down(
+        float(situ_beta),
+        float(situ_linear_beta),
+    )(
+        ptr_arg(shared_gate_up),
+        ptr_arg(shared_down_weight),
+        ptr_arg(shared_output),
+        stream=stream,
+    )
+    return routed_output, shared_output

--- a/op_tests/flydsl_tests/test_kimi_k3_moe_preroute_bf16.py
+++ b/op_tests/flydsl_tests/test_kimi_k3_moe_preroute_bf16.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from aiter.jit.utils.chip_info import get_gfx_runtime
+from aiter.ops.flydsl.kimi_k3_moe_preroute_bf16 import (
+    is_kimi_k3_moe_preroute_bf16_available,
+    kimi_k3_moe_preroute_bf16,
+    supports_kimi_k3_moe_preroute_bf16,
+)
+from aiter.ops.flydsl.utils import is_flydsl_available
+
+
+def _relative_rmse(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+) -> float:
+    error = (actual.float() - expected.float()).square().mean().sqrt()
+    reference = expected.float().square().mean().sqrt().clamp_min(1e-12)
+    return (error / reference).item()
+
+
+def test_support_predicate_fails_closed_on_cpu():
+    hidden = torch.empty((1, 7168), dtype=torch.bfloat16)
+    routed_weight = torch.empty((3584, 7168), dtype=torch.bfloat16)
+    shared_gate_up_weight = torch.empty((1536, 7168), dtype=torch.bfloat16)
+    shared_down_weight = torch.empty((7168, 768), dtype=torch.bfloat16)
+
+    assert not supports_kimi_k3_moe_preroute_bf16(
+        hidden,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="requires a GPU runtime",
+)
+def test_backend_availability_matches_flydsl_and_architecture():
+    assert is_kimi_k3_moe_preroute_bf16_available() == (
+        is_flydsl_available() and get_gfx_runtime() == "gfx950"
+    )
+
+
+@pytest.mark.parametrize(
+    ("situ_beta", "situ_linear_beta"),
+    [
+        (0.0, 25.0),
+        (4.0, -1.0),
+        (float("nan"), 25.0),
+    ],
+)
+def test_preroute_rejects_invalid_situ_parameters(
+    situ_beta: float,
+    situ_linear_beta: float,
+):
+    tensor = torch.empty((1,), dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        kimi_k3_moe_preroute_bf16(
+            tensor,
+            tensor,
+            tensor,
+            tensor,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
+        )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not is_flydsl_available()
+    or get_gfx_runtime() != "gfx950",
+    reason="requires FlyDSL on gfx950",
+)
+def test_kimi_k3_preroute_bf16_matches_reference():
+    torch.manual_seed(20260729)
+    device = torch.device("cuda")
+    hidden = torch.randn(
+        (1, 7168),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    routed_weight = torch.randn(
+        (3584, 7168),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    shared_gate_up_weight = torch.randn(
+        (1536, 7168),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    shared_down_weight = torch.randn(
+        (7168, 768),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    original_hidden = hidden.clone()
+
+    routed, shared = kimi_k3_moe_preroute_bf16(
+        hidden,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+
+    routed_reference = F.linear(
+        hidden.float(),
+        routed_weight.float(),
+    ).to(torch.bfloat16)
+    gate_up_reference = F.linear(
+        hidden.float(),
+        shared_gate_up_weight.float(),
+    ).to(torch.bfloat16)
+    gate, up = gate_up_reference.float().chunk(2, dim=-1)
+    activated = (
+        4.0
+        * torch.tanh(gate / 4.0)
+        * torch.sigmoid(gate)
+        * 25.0
+        * torch.tanh(up / 25.0)
+    ).to(torch.bfloat16)
+    shared_reference = F.linear(
+        activated.float(),
+        shared_down_weight.float(),
+    ).to(torch.bfloat16)
+
+    assert _relative_rmse(routed, routed_reference) < 2e-4
+    assert _relative_rmse(shared, shared_reference) < 2e-4
+    torch.testing.assert_close(
+        hidden,
+        original_hidden,
+        atol=0,
+        rtol=0,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not is_flydsl_available()
+    or get_gfx_runtime() != "gfx950",
+    reason="requires FlyDSL on gfx950",
+)
+def test_preroute_support_predicate_rejects_contract_families():
+    device = torch.device("cuda")
+    hidden = torch.empty((1, 7168), device=device, dtype=torch.bfloat16)
+    routed_weight = torch.empty(
+        (3584, 7168),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    shared_gate_up_weight = torch.empty(
+        (1536, 7168),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    shared_down_weight = torch.empty(
+        (7168, 768),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    def supports(
+        hidden_arg=hidden,
+        routed_weight_arg=routed_weight,
+        shared_gate_up_weight_arg=shared_gate_up_weight,
+        shared_down_weight_arg=shared_down_weight,
+    ):
+        return supports_kimi_k3_moe_preroute_bf16(
+            hidden_arg,
+            routed_weight_arg,
+            shared_gate_up_weight_arg,
+            shared_down_weight_arg,
+        )
+
+    assert supports()
+    assert not supports(hidden_arg=hidden.expand(2, -1))
+    assert not supports(hidden_arg=hidden.half())
+    assert not supports(routed_weight_arg=routed_weight.transpose(0, 1))
+    assert not supports(shared_gate_up_weight_arg=shared_gate_up_weight.transpose(0, 1))
+    assert not supports(shared_down_weight_arg=shared_down_weight.transpose(0, 1))
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not is_flydsl_available()
+    or get_gfx_runtime() != "gfx950",
+    reason="requires FlyDSL on gfx950",
+)
+def test_kimi_k3_preroute_bf16_graph_capture_and_replay():
+    device = torch.device("cuda")
+    hidden = torch.randn((1, 7168), device=device, dtype=torch.bfloat16)
+    routed_weight = torch.zeros(
+        (3584, 7168),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    shared_gate_up_weight = torch.zeros(
+        (1536, 7168),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    shared_down_weight = torch.zeros(
+        (7168, 768),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    for _ in range(2):
+        kimi_k3_moe_preroute_bf16(
+            hidden,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+        )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        routed, shared = kimi_k3_moe_preroute_bf16(
+            hidden,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+        )
+    graph.replay()
+    expected_routed = routed.clone()
+    expected_shared = shared.clone()
+    graph.replay()
+
+    torch.testing.assert_close(routed, expected_routed, atol=0, rtol=0)
+    torch.testing.assert_close(shared, expected_shared, atol=0, rtol=0)


### PR DESCRIPTION
# Proposed AITER PR

Title:

`perf(flydsl): fuse Kimi-K3 B1 BF16 pre-route projections on gfx950`

## Summary

Add an exact-BF16 gfx950 specialization for the Kimi-K3 batch-1 MoE
pre-route projection cluster.

The specialization replaces:

- routed-down `wvSplitK`;
- shared gate/up `wvSplitK`;
- SiTU;
- shared-down `wvSplitK`;

with two fixed-shape FlyDSL launches. The first shares the `[1, 7168]` input
load between the routed-down and shared gate/up projections. The second fuses
SiTU with the shared-down projection.

## Why

In the TP8 Kimi-K3 decode trace this cluster executes in all 92 MoE layers.
The accepted candidate removes 184 launches/token and saves 0.8596 ms/token
end to end:

- control: 60.9086 tok/s;
- candidate mean: 64.2744 tok/s;
- uplift: +5.53%.

## Numerical contract

- input/weight/output: BF16;
- accumulation: FP32;
- SiTU beta: 4.0;
- SiTU linear beta: 25.0;
- routed output: `[1, 3584]`;
- shared output: `[1, 7168]`.

The API fails closed unless every tensor is contiguous, on one gfx950 device,
and has the exact production shape and dtype. Invalid SiTU parameters are
rejected.

## Implementation

- `kimi_k3_dual_projection_bf16_gfx950.py`
  - common-input routed and shared gate/up projection;
  - frozen production config: rows/wave 3, 256 CUs, WCM 2, hidden in LDS.
- `kimi_k3_shared_down_bf16_gfx950.py`
  - fused SiTU and shared-down projection;
  - frozen production config: rows/wave 1, 256 CUs, WCM 2.
- `kimi_k3_moe_preroute_bf16.py`
  - one support predicate;
  - cached compilation;
  - explicit two-output API;
  - no environment-variable tuning surface.

## Validation

- [x] ruff
- [x] format
- [x] Python compilation
- [x] diff check
- [x] focused gfx950 correctness test in pinned ROCm image (8 passed)
- [x] graph capture/replay in pinned ROCm image
- [x] frozen GSM8K gate: 0.943139 accuracy, 0.001516 invalid rate

The focused correctness test uses FP32 reference accumulation, requires
BF16-rounded references with relative RMSE below `2e-4` for both outputs, and
verifies input immutability.

The frozen gate uses all 1319 GSM8K questions, 5-shot prompts, temperature 0,
seed 42, max concurrency 1, and the completion API. The result SHA-256 is
`dc402c40c86bd8dd863ff3dbbb26e2c6295151cca6a557027729a2e561b70dfc`.

## Scope

This PR adds an AITER primitive only. It does not alter generic MoE dispatch,
NVIDIA code, weight precision, or unsupported shapes.
