### PR TITLE
perf: optimize MXFP4 MoE decode with fused sorting, quantization, and compact scales

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -128,10 +128,14 @@ def _is_fused_decode_sort_quant_enabled(
     """
     if not _fused_decode_sort_quant_requested():
         return False
+    try:
+        runtime_is_gfx950 = get_gfx_runtime() == "gfx950"
+    except (KeyError, OSError, RuntimeError):
+        return False
     tokens = hidden_states.shape[0] if hidden_states.ndim == 2 else 0
     topk = topk_ids.shape[1] if topk_ids.ndim == 2 else 0
     return (
-        get_gfx() == "gfx950"
+        runtime_is_gfx950
         and hidden_states.dtype == dtypes.bf16
         and 1 <= tokens <= _FUSED_DECODE_SORT_QUANT_MAX_M
         and hidden_states.shape[1] == 7168
@@ -2819,8 +2823,15 @@ def fused_moe_2stages(
         has_stage2_bias=bias2 is not None,
     )
     if prequantized_a1 is not None:
-        assert quant_type == QuantType.per_1x32
-        assert prequantized_a1_scale is not None
+        if quant_type != QuantType.per_1x32:
+            raise ValueError(
+                "prequantized_a1 is only supported for QuantType.per_1x32, "
+                f"got {quant_type}"
+            )
+        if prequantized_a1_scale is None:
+            raise ValueError(
+                "prequantized_a1_scale must be supplied alongside prequantized_a1"
+            )
         a1 = prequantized_a1
         a1_scale = prequantized_a1_scale
     elif not metadata.prequant:

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -70,6 +70,7 @@ _ACT_TYPE_DISABLED_KEY = "__ignore__"
 _SWIGLU_MXFP4_BF16_BOUND = int(os.environ.get("GPTOSS_SWIGLU_MXFP4_BF16_BOUND", "256"))
 _MOE_A8W4_BYPASS_QUANT = os.environ.get("AITER_MOE_A8W4_BYPASS_QUANT", "0") == "1"
 _FUSED_DECODE_SORT_QUANT_ENV = "SGLANG_AITER_FUSED_DECODE_SORT_QUANT"
+_FUSED_DECODE_COMPACT_SCALE_ENV = "SGLANG_AITER_FUSED_DECODE_COMPACT_SCALE"
 # (num_experts, topk) pairs the HIP kernel is instantiated for; must stay in
 # sync with AITER_MXFP4_SORT_QUANT_ROUTES in moe_sorting_opus_kernels.cu.
 _FUSED_DECODE_SORT_QUANT_ROUTES = {(256, 8), (384, 8), (385, 9)}
@@ -170,6 +171,7 @@ def _fused_decode_sort_quant(
     block_m: int,
     moebuf_dtype: torch.dtype,
     accumulate: bool,
+    compact_scale: bool = False,
 ):
     """Return standard sorted metadata plus the pre-quantized stage-1 input."""
     device = hidden_states.device
@@ -210,13 +212,15 @@ def _fused_decode_sort_quant(
         activation_scale_token,
         global_experts,
     )
-    activation_scale = mxfp4_moe_sort_fwd(
-        activation_scale_token,
-        sorted_ids=sorted_ids,
-        num_valid_ids=num_valid_ids,
-        token_num=tokens,
-        cols=model_dim,
-    )
+    activation_scale = activation_scale_token
+    if not compact_scale:
+        activation_scale = mxfp4_moe_sort_fwd(
+            activation_scale_token,
+            sorted_ids=sorted_ids,
+            num_valid_ids=num_valid_ids,
+            token_num=tokens,
+            cols=model_dim,
+        )
     return (
         sorted_ids,
         sorted_weights,
@@ -225,6 +229,33 @@ def _fused_decode_sort_quant(
         moe_buf,
         activation_quant,
         activation_scale,
+    )
+
+
+def _is_fused_decode_compact_scale_enabled(
+    metadata: "MOEMetadata", tokens: int
+) -> bool:
+    mode = os.environ.get(_FUSED_DECODE_COMPACT_SCALE_ENV, "").strip().lower()
+    if not mode:
+        mode = os.environ.get(_FUSED_DECODE_SORT_QUANT_ENV, "").strip().lower()
+    if mode not in ("auto", "1", "true", "on", "yes"):
+        return False
+    stage1 = getattr(metadata.stage1, "func", metadata.stage1)
+    if stage1 is not _flydsl_stage1_wrapper:
+        return False
+    kernel_name = getattr(metadata.stage1, "keywords", {}).get("kernelName", "")
+    parsed = aiter.ops.flydsl.moe_kernels.get_flydsl_kernel_params(kernel_name)
+    return bool(
+        parsed is not None
+        and 1 <= tokens <= _FUSED_DECODE_SORT_QUANT_MAX_M
+        and parsed.get("a_dtype") == "fp4"
+        and parsed.get("tile_m") == 32
+        and parsed.get("tile_k") == 256
+        and parsed.get("k_batch", 1) == 1
+        # Any k_wave is eligible. Compact addressing costs 5-12% in stage 1 on
+        # the multi-K-wave rows (which the tuner picks at M <= 8), but dropping
+        # the ~4us mxfp4_moe_sort_fwd launch more than pays for it against a
+        # 30-65us layer -- see the k_wave table in the PR description.
     )
 
 
@@ -906,6 +937,9 @@ def fused_moe_(
         hidden_pad=hidden_pad,
         ksplit=metadata.ksplit,
     )
+    fused_compact_scale = fused_sort_quant and _is_fused_decode_compact_scale_enabled(
+        metadata, hidden_states.shape[0]
+    )
     if metadata.output_aux:
         # The a4w4 FlyDSL port routes through the adaptive/aux sort, which does
         # not thread expert_mask into moe_sorting below -- EP masking would be
@@ -955,6 +989,7 @@ def fused_moe_(
             block_m=block_size_M,
             moebuf_dtype=dtype,
             accumulate=not stage2_uses_route_reduce(metadata.stage2),
+            compact_scale=fused_compact_scale,
         )
         local_topk_ids = None
     else:
@@ -1056,6 +1091,7 @@ def fused_moe_(
             reverse_sorted=sort_reverse_sorted,
             prequantized_a1=prequantized_a1,
             prequantized_a1_scale=prequantized_a1_scale,
+            prequantized_a1_scale_compact=fused_compact_scale,
         )
 
 
@@ -1390,6 +1426,7 @@ def _flydsl_stage1_wrapper(
     out_scale_sorted=None,
     bias1=None,
     topk_ids=None,
+    a1_scale_compact: bool = False,
     swiglu_limit: float | None = None,
     situ_beta: float = 1.0,
     situ_linear_beta: float = 1.0,
@@ -1410,6 +1447,30 @@ def _flydsl_stage1_wrapper(
     else:
         act = "silu"
     _a_scale_one = parsed.get("a_scale_one", False)
+    tile_n = parsed["tile_n"]
+    waves_per_eu = parsed.get("waves_per_eu", 3)
+    b_nt = parsed.get("b_nt", 2)
+    xcd_swizzle = parsed.get("xcd_swizzle", 0)
+    if a1_scale_compact and parsed.get("k_wave", 1) == 1:
+        tokens = hidden_states.shape[0]
+        # Compact-scale variants need a different balance between N-wave
+        # parallelism and scale-gather latency for the original single-K-wave
+        # kernels. Multi-K-wave rows are already explicitly tuned; preserve
+        # their tile/wave parameters while enabling compact scale addressing.
+        if tokens == 8:
+            waves_per_eu = 2
+            b_nt = 2
+            xcd_swizzle = 0
+        elif tokens in (16, 32):
+            tile_n = 128
+            waves_per_eu = 2
+            b_nt = 2
+            xcd_swizzle = 0
+        elif tokens == 64:
+            tile_n = 128
+            waves_per_eu = 4
+            b_nt = 2
+            xcd_swizzle = 0
     return aiter.ops.flydsl.flydsl_moe_stage1(
         a=hidden_states,
         w1=w1,
@@ -1419,7 +1480,7 @@ def _flydsl_stage1_wrapper(
         out=out,
         topk=topk,
         tile_m=parsed["tile_m"],
-        tile_n=parsed["tile_n"],
+        tile_n=tile_n,
         tile_k=parsed["tile_k"],
         a_dtype=parsed["a_dtype"],
         b_dtype=parsed["b_dtype"],
@@ -1432,15 +1493,16 @@ def _flydsl_stage1_wrapper(
         sorted_weights=sorted_weights,
         use_async_copy=True,
         k_batch=parsed.get("k_batch", 1),
-        waves_per_eu=parsed.get("waves_per_eu", 3),
-        b_nt=parsed.get("b_nt", 2),
+        waves_per_eu=waves_per_eu,
+        b_nt=b_nt,
         gate_mode=parsed.get("gate_mode", "separated"),
         inter_dim_pad=inter_dim_pad,
         model_dim_pad=model_dim_pad,
         bias=_normalize_bias_for_kernel(bias1),
         topk_ids=topk_ids,
         a_scale_one=_a_scale_one,
-        xcd_swizzle=parsed.get("xcd_swizzle", 0),
+        a_scale_compact=a1_scale_compact,
+        xcd_swizzle=xcd_swizzle,
         swiglu_limit=swiglu_limit,
         k_wave=parsed.get("k_wave", 1),
     )
@@ -2724,6 +2786,7 @@ def fused_moe_2stages(
     reverse_sorted=None,
     prequantized_a1: torch.Tensor | None = None,
     prequantized_a1_scale: torch.Tensor | None = None,
+    prequantized_a1_scale_compact: bool = False,
 ):
     quant_func = get_quant(quant_type)
     gate_mode = GateMode(gate_mode)
@@ -2881,6 +2944,7 @@ def fused_moe_2stages(
         extra_stage1_args["situ_linear_beta"] = (
             1.0 if linear_beta is None else float(linear_beta)
         )
+        extra_stage1_args["a1_scale_compact"] = prequantized_a1_scale_compact
     # EP: forward expert_mask + topk_ids to the flydsl stage2 wrapper so it can
     # switch to reduce mode and fuse the validity gather in compile_moe_reduction.
     if stage2_func is _flydsl_stage2_wrapper and expert_mask is not None:

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -69,6 +69,164 @@ _MOE_SORT_BACKEND = os.environ.get("AITER_MOE_SORT_BACKEND", "auto").lower()
 _ACT_TYPE_DISABLED_KEY = "__ignore__"
 _SWIGLU_MXFP4_BF16_BOUND = int(os.environ.get("GPTOSS_SWIGLU_MXFP4_BF16_BOUND", "256"))
 _MOE_A8W4_BYPASS_QUANT = os.environ.get("AITER_MOE_A8W4_BYPASS_QUANT", "0") == "1"
+_FUSED_DECODE_SORT_QUANT_ENV = "SGLANG_AITER_FUSED_DECODE_SORT_QUANT"
+# (num_experts, topk) pairs the HIP kernel is instantiated for; must stay in
+# sync with AITER_MXFP4_SORT_QUANT_ROUTES in moe_sorting_opus_kernels.cu.
+_FUSED_DECODE_SORT_QUANT_ROUTES = {(256, 8), (384, 8), (385, 9)}
+_FUSED_DECODE_SORT_QUANT_MAX_M = 128
+
+
+def _fused_decode_sort_quant_requested() -> bool:
+    mode = os.environ.get(_FUSED_DECODE_SORT_QUANT_ENV, "").strip().lower()
+    return mode in ("auto", "1", "true", "on", "yes")
+
+
+_fused_decode_sort_quant_warned = False
+
+
+def _warn_fused_decode_sort_quant_bypassed() -> None:
+    global _fused_decode_sort_quant_warned
+    if _fused_decode_sort_quant_warned or not _fused_decode_sort_quant_requested():
+        return
+    _fused_decode_sort_quant_warned = True
+    logger.warning(
+        f"[fused_moe] {_FUSED_DECODE_SORT_QUANT_ENV} is set but the tuned stage-1 "
+        "kernel uses the aux-sort a4w4 path, which already fuses activation "
+        "quantization into GEMM1; the fused sort+quant kernel is not used."
+    )
+
+
+def _is_fused_decode_sort_quant_enabled(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    global_experts: int,
+    block_m: int,
+    quant_type: QuantType,
+    q_dtype_a: torch.dtype,
+    q_dtype_w: torch.dtype,
+    activation: ActivationType,
+    is_g1u1: bool,
+    expert_mask: torch.Tensor | None,
+    num_local_tokens: torch.Tensor | None,
+    need_local_topk_ids: bool,
+    run_1stage: bool,
+    stage1_is_flydsl: bool,
+    hidden_pad: int,
+    ksplit: int,
+) -> bool:
+    """Gate the direct-scale HIP route-sort/quant kernel to supported decode.
+
+    The shape bounds mirror the kernel's own contract (``model_dim=7168``,
+    ``block_m=32``, ``M`` in ``[1, 128]``, an instantiated ``(E, topk)``
+    route). The remaining conditions are integration requirements: they
+    describe the stage-1 path whose activation quantization this kernel
+    replaces. ``1``/``true``/``on``/``yes`` behave like ``auto`` so a
+    microbenchmark can pin the path; none of them widen it.
+    """
+    if not _fused_decode_sort_quant_requested():
+        return False
+    tokens = hidden_states.shape[0] if hidden_states.ndim == 2 else 0
+    topk = topk_ids.shape[1] if topk_ids.ndim == 2 else 0
+    return (
+        get_gfx() == "gfx950"
+        and hidden_states.dtype == dtypes.bf16
+        and 1 <= tokens <= _FUSED_DECODE_SORT_QUANT_MAX_M
+        and hidden_states.shape[1] == 7168
+        and hidden_states.is_contiguous()
+        and topk_ids.dtype == dtypes.i32
+        and (global_experts, topk) in _FUSED_DECODE_SORT_QUANT_ROUTES
+        and topk_ids.shape[0] == tokens
+        and topk_ids.is_contiguous()
+        and topk_weights.dtype == dtypes.fp32
+        and topk_weights.is_contiguous()
+        and block_m == 32
+        and quant_type == QuantType.per_1x32
+        and q_dtype_a == dtypes.fp4x2
+        and q_dtype_w == dtypes.fp4x2
+        and activation == ActivationType.Silu
+        and is_g1u1
+        and expert_mask is None
+        and num_local_tokens is None
+        and not need_local_topk_ids
+        and not run_1stage
+        and stage1_is_flydsl
+        and hidden_pad == 0
+        # ksplit > 1 makes fused_moe_2stages hand stage 1 unquantized BF16
+        # activations (the kernel quantizes inline), so prequantizing here
+        # would feed the wrong dtype.
+        and ksplit <= 1
+    )
+
+
+def _fused_decode_sort_quant(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    model_dim: int,
+    global_experts: int,
+    block_m: int,
+    moebuf_dtype: torch.dtype,
+    accumulate: bool,
+):
+    """Return standard sorted metadata plus the pre-quantized stage-1 input."""
+    device = hidden_states.device
+    tokens = hidden_states.shape[0]
+    route_count = topk_ids.numel()
+    active_experts = min(global_experts, route_count)
+    max_sorted = (
+        (route_count + active_experts * (block_m - 1) + block_m - 1)
+        // block_m
+        * block_m
+    )
+    max_blocks = (max_sorted + block_m - 1) // block_m
+    sorted_ids = torch.empty(max_sorted, dtype=dtypes.i32, device=device)
+    sorted_weights = torch.empty(max_sorted, dtype=dtypes.fp32, device=device)
+    sorted_expert_ids = torch.empty(max_blocks, dtype=dtypes.i32, device=device)
+    num_valid_ids = torch.empty(2, dtype=dtypes.i32, device=device)
+    moe_buf = (
+        torch.empty((tokens, model_dim), dtype=moebuf_dtype, device=device)
+        if accumulate
+        else torch.empty((0, 0), dtype=moebuf_dtype, device=device)
+    )
+    activation_quant = torch.empty(
+        (tokens, model_dim // 2), dtype=dtypes.fp4x2, device=device
+    )
+    activation_scale_token = torch.empty(
+        (tokens, model_dim // 32), dtype=dtypes.fp8_e8m0, device=device
+    )
+    aiter.mxfp4_moe_sort_quant_fwd(
+        hidden_states,
+        topk_ids,
+        topk_weights,
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        moe_buf,
+        activation_quant,
+        activation_scale_token,
+        global_experts,
+    )
+    activation_scale = mxfp4_moe_sort_fwd(
+        activation_scale_token,
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=tokens,
+        cols=model_dim,
+    )
+    return (
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        moe_buf,
+        activation_quant,
+        activation_scale,
+    )
+
 
 # Opt-in kernel-bench hook: a caller sets a list here to collect (name, callable)
 # per-kernel launches in fused_moe_2stages ("stage1"/"stage2"); None in production
@@ -722,6 +880,32 @@ def fused_moe_(
 
     sort_m_indices = None
     sort_reverse_sorted = None
+    prequantized_a1 = None
+    prequantized_a1_scale = None
+    if metadata.output_aux:
+        # The a4w4 aux-sort families already fuse activation quantization into
+        # GEMM1, so the fused sort+quant kernel has nothing left to save. Say so
+        # once: otherwise enabling the env var looks like it did nothing.
+        _warn_fused_decode_sort_quant_bypassed()
+    fused_sort_quant = not metadata.output_aux and _is_fused_decode_sort_quant_enabled(
+        hidden_states,
+        topk_ids,
+        topk_weight,
+        global_experts=global_E,
+        block_m=block_size_M,
+        quant_type=quant_type,
+        q_dtype_a=q_dtype_a,
+        q_dtype_w=q_dtype_w,
+        activation=activation,
+        is_g1u1=isG1U1,
+        expert_mask=expert_mask,
+        num_local_tokens=num_local_tokens,
+        need_local_topk_ids=need_local_topk_ids,
+        run_1stage=metadata.run_1stage,
+        stage1_is_flydsl=stage1_func is _flydsl_stage1_wrapper,
+        hidden_pad=hidden_pad,
+        ksplit=metadata.ksplit,
+    )
     if metadata.output_aux:
         # The a4w4 FlyDSL port routes through the adaptive/aux sort, which does
         # not thread expert_mask into moe_sorting below -- EP masking would be
@@ -751,6 +935,26 @@ def fused_moe_(
             block_size_M,
             accumulate=_atomic,
             output_aux=True,
+        )
+        local_topk_ids = None
+    elif fused_sort_quant:
+        (
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            num_valid_ids,
+            moe_buf,
+            prequantized_a1,
+            prequantized_a1_scale,
+        ) = _fused_decode_sort_quant(
+            hidden_states,
+            topk_ids,
+            topk_weight,
+            model_dim=model_dim,
+            global_experts=global_E,
+            block_m=block_size_M,
+            moebuf_dtype=dtype,
+            accumulate=not stage2_uses_route_reduce(metadata.stage2),
         )
         local_topk_ids = None
     else:
@@ -850,6 +1054,8 @@ def fused_moe_(
             expert_mask=expert_mask,
             m_indices=sort_m_indices,
             reverse_sorted=sort_reverse_sorted,
+            prequantized_a1=prequantized_a1,
+            prequantized_a1_scale=prequantized_a1_scale,
         )
 
 
@@ -2516,6 +2722,8 @@ def fused_moe_2stages(
     expert_mask=None,
     m_indices=None,
     reverse_sorted=None,
+    prequantized_a1: torch.Tensor | None = None,
+    prequantized_a1_scale: torch.Tensor | None = None,
 ):
     quant_func = get_quant(quant_type)
     gate_mode = GateMode(gate_mode)
@@ -2547,7 +2755,12 @@ def fused_moe_2stages(
         is_ep=expert_mask is not None,
         has_stage2_bias=bias2 is not None,
     )
-    if not metadata.prequant:
+    if prequantized_a1 is not None:
+        assert quant_type == QuantType.per_1x32
+        assert prequantized_a1_scale is not None
+        a1 = prequantized_a1
+        a1_scale = prequantized_a1_scale
+    elif not metadata.prequant:
         a1 = hidden_states
         a1_scale = None
     elif (

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
@@ -1093,9 +1093,7 @@ def compile_mixed_moe_gemm1(
                     as1_vec = vector.from_elements(T.vec(1, T.i32), [as1_const])
 
                 def load_compact_a_scale_dword(base_k, ku):
-                    row0_vec = vector.load_op(
-                        T.vec(1, T.i32), lds_tid, [lane_mod_16]
-                    )
+                    row0_vec = vector.load_op(T.vec(1, T.i32), lds_tid, [lane_mod_16])
                     row1_vec = vector.load_op(
                         T.vec(1, T.i32),
                         lds_tid,
@@ -1109,12 +1107,8 @@ def compile_mixed_moe_gemm1(
                     )
                     token0_raw = arith.andi(fused0, mask24)
                     token1_raw = arith.andi(fused1, mask24)
-                    token0_valid = arith.cmpi(
-                        CmpIPredicate.ult, token0_raw, tokens_i32
-                    )
-                    token1_valid = arith.cmpi(
-                        CmpIPredicate.ult, token1_raw, tokens_i32
-                    )
+                    token0_valid = arith.cmpi(CmpIPredicate.ult, token0_raw, tokens_i32)
+                    token1_valid = arith.cmpi(CmpIPredicate.ult, token1_raw, tokens_i32)
                     token0 = arith.select(
                         token0_valid, token0_raw, arith.constant(0, type=T.i32)
                     )
@@ -1203,9 +1197,7 @@ def compile_mixed_moe_gemm1(
                                 )
                     return a_scale_tile
 
-                def prefetch_b_scale_tile(
-                    base_k, ku_packed_limit=k_unroll_packed
-                ):
+                def prefetch_b_scale_tile(base_k, ku_packed_limit=k_unroll_packed):
                     gate_b_scale = []
                     up_b_scale = (
                         [] if (not mock_gate_only and not gate_up_interleave) else None
@@ -2111,8 +2103,7 @@ def compile_mixed_moe_gemm1(
                         )
                         if const_expr(a_scale_compact):
                             gate_bs_ping, up_bs_ping = prefetch_b_scale_tile(
-                                k_tail1
-                                // arith.constant(pack_K * 128, index=True)
+                                k_tail1 // arith.constant(pack_K * 128, index=True)
                             )
                             a_scale_ping = None
                         else:
@@ -2121,8 +2112,7 @@ def compile_mixed_moe_gemm1(
                                 gate_bs_ping,
                                 up_bs_ping,
                             ) = prefetch_ab_scale_tile(
-                                k_tail1
-                                // arith.constant(pack_K * 128, index=True)
+                                k_tail1 // arith.constant(pack_K * 128, index=True)
                             )
                     acc_gate, acc_up, _ = compute_tile(
                         acc_gate,
@@ -2148,9 +2138,7 @@ def compile_mixed_moe_gemm1(
                         a_scale_ping = prefetch_a_scale_tile(
                             k_tail1 // arith.constant(pack_K * 128, index=True),
                             ku_packed_limit=(
-                                tail_ku_packed
-                                if pad_ku_skip > 0
-                                else k_unroll_packed
+                                tail_ku_packed if pad_ku_skip > 0 else k_unroll_packed
                             ),
                         )
                     acc_gate, acc_up, epilogue_pf = compute_tile(

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
@@ -171,6 +171,7 @@ def compile_mixed_moe_gemm1(
     b_nt: int = 0,
     gate_mode: GateMode = GateMode.SEPARATED,
     a_scale_one: bool = False,
+    a_scale_compact: bool = False,
     xcd_swizzle: int = 0,
     k_wave: int = 1,
 ):
@@ -244,6 +245,18 @@ def compile_mixed_moe_gemm1(
     gate_only = gate_mode is GateMode.GATE_ONLY
 
     is_splitk = k_batch > 1
+    if a_scale_compact:
+        if not is_f4_a:
+            raise ValueError("compact A scales are only supported for FP4 activations")
+        if a_scale_one:
+            raise ValueError("compact A scales are incompatible with a_scale_one")
+        if is_splitk:
+            raise ValueError("compact A scales are not supported with split-K")
+        if tile_m != 32 or tile_k != 256 or sort_block_m != 32:
+            raise ValueError(
+                "compact A-scale gathering currently requires "
+                "tile_m=32, tile_k=256, and sort_block_m=32"
+            )
     if mock_gate_only and not is_splitk:
         raise ValueError("mock_gate_only requires k_batch > 1 (split-K)")
     if is_splitk:
@@ -295,6 +308,7 @@ def compile_mixed_moe_gemm1(
     go_tag = "_go" if mock_gate_only else ""
     gui_tag = "_gui" if gate_up_interleave else ""
     as1_tag = "_as1" if a_scale_one else ""
+    asc_tag = "_asc4" if a_scale_compact else ""
     xcd_tag = f"_xcd{xcd_swizzle}" if xcd_swizzle > 0 else ""
     # Keep the historical name for silu (no cache churn); swiglu/situv2 get a
     # distinct symbol so they can't alias the silu kernel on disk. beta is
@@ -311,7 +325,7 @@ def compile_mixed_moe_gemm1(
         act_tag += f"_sb{_beta_tag(situ_beta)}_slb{_beta_tag(situ_linear_beta)}"
     module_name = (
         f"mfma_moe1_silu_mul_a{a_dtype}_w{b_dtype}_{out_s}"
-        f"_t{tile_m}x{tile_n}x{tile_k}_pm{persist_m}{fp4q_tag}{fp8q_tag}{sort_tag}{async_tag}{sk_tag}{kw_tag}{go_tag}{gui_tag}{as1_tag}{xcd_tag}{act_tag}_v32"
+        f"_t{tile_m}x{tile_n}x{tile_k}_pm{persist_m}{fp4q_tag}{fp8q_tag}{sort_tag}{async_tag}{sk_tag}{kw_tag}{go_tag}{gui_tag}{as1_tag}{asc_tag}{xcd_tag}{act_tag}_v32"
     ).replace("-", "_")
 
     cshuffle_elem_bytes = 4 if need_quant else (4 if out_is_f32 else 2)
@@ -651,7 +665,8 @@ def compile_mixed_moe_gemm1(
             if const_expr(not a_scale_one):
                 c32 = arith.constant(32, index=True)
                 kblk = k_in // c32
-                sx_nbytes_idx = sorted_m * kblk
+                sx_rows = tokens_in if a_scale_compact else sorted_m
+                sx_nbytes_idx = sx_rows * kblk
                 sx_nbytes_i32 = arith.index_cast(T.i32, sx_nbytes_idx)
                 sx_rsrc = ptr_buffer_resource(arg_scale_x, sx_nbytes_i32)
 
@@ -1077,17 +1092,103 @@ def compile_mixed_moe_gemm1(
                     as1_const = arith.constant(0x7F7F7F7F, type=T.i32)
                     as1_vec = vector.from_elements(T.vec(1, T.i32), [as1_const])
 
-                def prefetch_ab_scale_tile(base_k, ku_packed_limit=k_unroll_packed):
-                    a_scale_tile = []
-                    gate_b_scale = []
-                    up_b_scale = (
-                        [] if (not mock_gate_only and not gate_up_interleave) else None
+                def load_compact_a_scale_dword(base_k, ku):
+                    row0_vec = vector.load_op(
+                        T.vec(1, T.i32), lds_tid, [lane_mod_16]
                     )
+                    row1_vec = vector.load_op(
+                        T.vec(1, T.i32),
+                        lds_tid,
+                        [lane_mod_16 + arith.constant(16, index=True)],
+                    )
+                    fused0 = vector.extract(
+                        row0_vec, static_position=[0], dynamic_position=[]
+                    )
+                    fused1 = vector.extract(
+                        row1_vec, static_position=[0], dynamic_position=[]
+                    )
+                    token0_raw = arith.andi(fused0, mask24)
+                    token1_raw = arith.andi(fused1, mask24)
+                    token0_valid = arith.cmpi(
+                        CmpIPredicate.ult, token0_raw, tokens_i32
+                    )
+                    token1_valid = arith.cmpi(
+                        CmpIPredicate.ult, token1_raw, tokens_i32
+                    )
+                    token0 = arith.select(
+                        token0_valid, token0_raw, arith.constant(0, type=T.i32)
+                    )
+                    token1 = arith.select(
+                        token1_valid, token1_raw, arith.constant(0, type=T.i32)
+                    )
+                    scale_dwords_per_token = arith.constant(
+                        (model_dim // 32) // 4, type=T.i32
+                    )
+                    scale_ku = arith.index_cast(
+                        T.i32, base_k + arith.constant(ku, index=True)
+                    )
+                    dword_in_row = scale_ku * arith.constant(2, type=T.i32)
+                    dword0 = token0 * scale_dwords_per_token + dword_in_row
+                    dword1 = token1 * scale_dwords_per_token + dword_in_row
+                    pair0 = buffer_ops.buffer_load(
+                        sx_rsrc,
+                        arith.index_cast(ir.IndexType.get(), dword0),
+                        vec_width=2,
+                        dtype=T.i32,
+                        cache_modifier=0,
+                    )
+                    pair1 = buffer_ops.buffer_load(
+                        sx_rsrc,
+                        arith.index_cast(ir.IndexType.get(), dword1),
+                        vec_width=2,
+                        dtype=T.i32,
+                        cache_modifier=0,
+                    )
+                    row0_lo = vector.extract(
+                        pair0, static_position=[0], dynamic_position=[]
+                    )
+                    row0_hi = vector.extract(
+                        pair0, static_position=[1], dynamic_position=[]
+                    )
+                    row1_lo = vector.extract(
+                        pair1, static_position=[0], dynamic_position=[]
+                    )
+                    row1_hi = vector.extract(
+                        pair1, static_position=[1], dynamic_position=[]
+                    )
+                    shift = arith.index_cast(T.i32, lane_div_16) * arith.constant(
+                        8, type=T.i32
+                    )
+                    b0 = arith.andi(arith.shrui(row0_lo, shift), scale_mask_lo)
+                    b1 = arith.andi(arith.shrui(row1_lo, shift), scale_mask_lo)
+                    b2 = arith.andi(arith.shrui(row0_hi, shift), scale_mask_lo)
+                    b3 = arith.andi(arith.shrui(row1_hi, shift), scale_mask_lo)
+                    packed = arith.ori(
+                        arith.ori(
+                            b0,
+                            arith.shli(b1, arith.constant(8, type=T.i32)),
+                        ),
+                        arith.ori(
+                            arith.shli(b2, arith.constant(16, type=T.i32)),
+                            arith.shli(b3, arith.constant(24, type=T.i32)),
+                        ),
+                    )
+                    return vector.from_elements(T.vec(1, T.i32), [packed])
+
+                def prefetch_a_scale_tile(
+                    base_k,
+                    ku_packed_limit=k_unroll_packed,
+                ):
+                    a_scale_tile = []
                     for ku in range_constexpr(ku_packed_limit):
                         k_off = (ku + base_k) * layout_b_scale.stride_k0
                         for mi in range_constexpr(m_repeat_packed):
                             if const_expr(a_scale_one):
                                 a_scale_tile.append(as1_vec)
+                            elif const_expr(a_scale_compact):
+                                a_scale_tile.append(
+                                    load_compact_a_scale_dword(base_k, ku)
+                                )
                             else:
                                 s = buffer_ops.buffer_load(
                                     sx_rsrc,
@@ -1100,6 +1201,17 @@ def compile_mixed_moe_gemm1(
                                 a_scale_tile.append(
                                     vector.from_elements(T.vec(1, T.i32), [s])
                                 )
+                    return a_scale_tile
+
+                def prefetch_b_scale_tile(
+                    base_k, ku_packed_limit=k_unroll_packed
+                ):
+                    gate_b_scale = []
+                    up_b_scale = (
+                        [] if (not mock_gate_only and not gate_up_interleave) else None
+                    )
+                    for ku in range_constexpr(ku_packed_limit):
+                        k_off = (ku + base_k) * layout_b_scale.stride_k0
                         for ni in range_constexpr(num_acc_n_packed):
                             gs = buffer_ops.buffer_load(
                                 sw_rsrc,
@@ -1126,6 +1238,19 @@ def compile_mixed_moe_gemm1(
                                 up_b_scale.append(
                                     vector.from_elements(T.vec(1, T.i32), [us])
                                 )
+                    return gate_b_scale, up_b_scale
+
+                def prefetch_ab_scale_tile(
+                    base_k,
+                    ku_packed_limit=k_unroll_packed,
+                ):
+                    a_scale_tile = prefetch_a_scale_tile(
+                        base_k,
+                        ku_packed_limit=ku_packed_limit,
+                    )
+                    gate_b_scale, up_b_scale = prefetch_b_scale_tile(
+                        base_k, ku_packed_limit=ku_packed_limit
+                    )
                     return [a_scale_tile, gate_b_scale, up_b_scale]
 
                 lds_base_zero = arith.index(0)
@@ -1598,7 +1723,6 @@ def compile_mixed_moe_gemm1(
                         prefetch_x_to_lds(abs_k_dma, lds_write)
                     if const_expr(not use_async_copy):
                         x_regs = load_x_tile(abs_k_dma)
-
                     prev_asvs = []
                     for i_as in range_constexpr(len(prev_a_scale)):
                         prev_asvs.append(
@@ -1646,6 +1770,17 @@ def compile_mixed_moe_gemm1(
                                 for mi_p in range_constexpr(m_repeat_packed):
                                     if const_expr(a_scale_one):
                                         new_as_list.append(as1_const)
+                                    elif const_expr(a_scale_compact):
+                                        direct_vec = load_compact_a_scale_dword(
+                                            sk, ku_s
+                                        )
+                                        new_as_list.append(
+                                            vector.extract(
+                                                direct_vec,
+                                                static_position=[0],
+                                                dynamic_position=[],
+                                            )
+                                        )
                                     else:
                                         raw_as = buffer_ops.buffer_load(
                                             sx_rsrc,
@@ -1817,9 +1952,13 @@ def compile_mixed_moe_gemm1(
                     store_x_tile_to_lds(x_regs0, lds_x_pong)
                 rocdl.sched_barrier(0)
                 k0_scale = k_base_idx // arith.constant(pack_K * 128, index=True)
-                a_scale_pong, gate_bs_pong, up_bs_pong = prefetch_ab_scale_tile(
-                    k0_scale
-                )
+                if const_expr(a_scale_compact):
+                    gate_bs_pong, up_bs_pong = prefetch_b_scale_tile(k0_scale)
+                    a_scale_pong = None
+                else:
+                    a_scale_pong, gate_bs_pong, up_bs_pong = prefetch_ab_scale_tile(
+                        k0_scale
+                    )
                 c_tile_m_idx = arith.constant(tile_m, index=True)
                 tid_in_range = arith.cmpi(CmpIPredicate.ult, tx, c_tile_m_idx)
                 if_tid = scf.IfOp(tid_in_range)
@@ -1852,6 +1991,8 @@ def compile_mixed_moe_gemm1(
                 gpu.barrier()
                 rocdl.sched_barrier(0)
                 a_tile_pong = prefetch_full_a_from_lds(lds_x_pong)
+                if const_expr(a_scale_compact):
+                    a_scale_pong = prefetch_a_scale_tile(k0_scale)
 
                 rocdl.sched_barrier(0)
                 rocdl.s_waitcnt(6)
@@ -1949,17 +2090,40 @@ def compile_mixed_moe_gemm1(
                             k_tail1 // arith.constant(b_byte_div, index=True),
                             ku_limit=tail_ku,
                         )
-                        a_scale_ping, gate_bs_ping, up_bs_ping = prefetch_ab_scale_tile(
-                            k_tail1 // arith.constant(pack_K * 128, index=True),
-                            ku_packed_limit=tail_ku_packed,
-                        )
+                        if const_expr(a_scale_compact):
+                            gate_bs_ping, up_bs_ping = prefetch_b_scale_tile(
+                                k_tail1 // arith.constant(pack_K * 128, index=True),
+                                ku_packed_limit=tail_ku_packed,
+                            )
+                            a_scale_ping = None
+                        else:
+                            (
+                                a_scale_ping,
+                                gate_bs_ping,
+                                up_bs_ping,
+                            ) = prefetch_ab_scale_tile(
+                                k_tail1 // arith.constant(pack_K * 128, index=True),
+                                ku_packed_limit=tail_ku_packed,
+                            )
                     else:
                         gate_w_ping, up_w_ping = load_b_tile(
                             k_tail1 // arith.constant(b_byte_div, index=True)
                         )
-                        a_scale_ping, gate_bs_ping, up_bs_ping = prefetch_ab_scale_tile(
-                            k_tail1 // arith.constant(pack_K * 128, index=True)
-                        )
+                        if const_expr(a_scale_compact):
+                            gate_bs_ping, up_bs_ping = prefetch_b_scale_tile(
+                                k_tail1
+                                // arith.constant(pack_K * 128, index=True)
+                            )
+                            a_scale_ping = None
+                        else:
+                            (
+                                a_scale_ping,
+                                gate_bs_ping,
+                                up_bs_ping,
+                            ) = prefetch_ab_scale_tile(
+                                k_tail1
+                                // arith.constant(pack_K * 128, index=True)
+                            )
                     acc_gate, acc_up, _ = compute_tile(
                         acc_gate,
                         acc_up,
@@ -1980,6 +2144,15 @@ def compile_mixed_moe_gemm1(
                         )
                     else:
                         a_tile_ping = prefetch_full_a_from_lds(lds_x_ping)
+                    if const_expr(a_scale_compact):
+                        a_scale_ping = prefetch_a_scale_tile(
+                            k_tail1 // arith.constant(pack_K * 128, index=True),
+                            ku_packed_limit=(
+                                tail_ku_packed
+                                if pad_ku_skip > 0
+                                else k_unroll_packed
+                            ),
+                        )
                     acc_gate, acc_up, epilogue_pf = compute_tile(
                         acc_gate,
                         acc_up,
@@ -2994,6 +3167,7 @@ def compile_mixed_moe_gemm1(
         k_batch,
         gate_mode,
         a_scale_one,
+        a_scale_compact,
         xcd_swizzle,
     )
 

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -461,6 +461,7 @@ def compile_flydsl_moe_stage1(
     inter_dim_pad: int = 0,
     enable_bias: bool = False,
     a_scale_one: bool = False,
+    a_scale_compact: bool = False,
     xcd_swizzle: int = 0,
     k_wave: int = 1,
 ):
@@ -526,6 +527,7 @@ def compile_flydsl_moe_stage1(
             inter_dim_pad=inter_dim_pad,
             enable_bias=enable_bias,
             a_scale_one=a_scale_one,
+            a_scale_compact=a_scale_compact,
             xcd_swizzle=xcd_swizzle,
             k_wave=k_wave,
         )
@@ -1290,6 +1292,7 @@ def flydsl_moe_stage1(
     bias: torch.Tensor | None = None,
     topk_ids: torch.Tensor | None = None,
     a_scale_one: bool = False,
+    a_scale_compact: bool = False,
     xcd_swizzle: int = 0,
     swiglu_limit: float | None = None,
     k_wave: int = 1,
@@ -1499,6 +1502,7 @@ def flydsl_moe_stage1(
         inter_dim_pad=inter_dim_pad,
         enable_bias=(kernel_bias is not None),
         a_scale_one=a_scale_one,
+        a_scale_compact=a_scale_compact,
         xcd_swizzle=xcd_swizzle,
         k_wave=k_wave,
     )

--- a/aiter/ops/moe_sorting_opus.py
+++ b/aiter/ops/moe_sorting_opus.py
@@ -36,3 +36,25 @@ def moe_sorting_opus_fwd(
     m_indices: torch.Tensor | None = None,
     reverse_sorted: torch.Tensor | None = None,
 ) -> None: ...
+
+
+@compile_ops("module_moe_sorting_opus", develop=True)
+def mxfp4_moe_sort_quant_fwd(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    sorted_weights: torch.Tensor,
+    sorted_expert_ids: torch.Tensor,
+    num_valid_ids: torch.Tensor,
+    moe_buf: torch.Tensor,
+    activation_quant: torch.Tensor,
+    activation_scale_token: torch.Tensor,
+    num_experts: int,
+) -> None:
+    """Fused route sort + compact MXFP4 activation quantization.
+
+    gfx950 only, ``model_dim=7168``, ``block_m=32``, ``M`` in ``[1, 128]``.
+    ``(num_experts, topk)`` must be one of ``(256, 8)``, ``(384, 8)`` or
+    ``(385, 9)`` -- the expert histogram is a kernel template parameter.
+    """

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -156,6 +156,75 @@ def cosine_diff_compare(ref, res, msg="", printLog=True):
     return cos_diff
 
 
+# Suffixes marking FlyDSL stage-1 kernels that fuse the intermediate
+# quantization consumed by stage 2. Kernels without one of these suffixes need a
+# separate quant+sort launch and are charged for it by
+# ``add_intermediate_quant_cost``.
+FUSED_INTERMEDIATE_SUFFIXES = ("_fp4", "_fp8")
+
+
+def dedupe_objective_candidates(profile_df: pd.DataFrame) -> pd.DataFrame:
+    """Keep the raw-fastest candidate per distinct runtime objective path.
+
+    Fused (``_fp4``/``_fp8``) and non-fused kernels must survive raw-kernel
+    deduplication independently: the fairness penalty applied by
+    ``add_intermediate_quant_cost`` only charges non-fused kernels, so deduping
+    on raw ``us`` alone would discard the fused candidate before the penalty
+    ever runs.
+    """
+    if profile_df.empty:
+        return profile_df
+
+    work = profile_df.copy()
+    work["_is_fused"] = (
+        work["kernelName"].astype(str).str.endswith(FUSED_INTERMEDIATE_SUFFIXES)
+    )
+    return (
+        work.sort_values("us")
+        .drop_duplicates(["stage", "block_m", "flat", "_is_fused"], keep="first")
+        .drop(columns=["_is_fused"])
+    )
+
+
+def add_intermediate_quant_cost(
+    profile_df: pd.DataFrame, suffix: str, us_by_block_m: dict
+) -> pd.DataFrame:
+    """Charge non-fused stage-1 candidates for their quant+sort launch.
+
+    ``suffix`` is the fused marker for the active activation dtype (``_fp4`` or
+    ``_fp8``); rows whose stage-1 kernel ends with it already fuse the work and
+    are left untouched. Every other row has the measured per-``block_m`` cost in
+    ``us_by_block_m`` added to its ``us1``.
+    """
+    if profile_df.empty or not us_by_block_m:
+        return profile_df
+
+    work = profile_df.copy()
+    quant_us = work["block_m"].map(us_by_block_m).fillna(0)
+    is_fused = work["kernelName1"].astype(str).str.endswith(suffix)
+    work.loc[~is_fused, "us1"] = work.loc[~is_fused, "us1"] + quant_us[~is_fused]
+    return work
+
+
+def select_fastest_stage_combination(profile_df: pd.DataFrame) -> pd.Series:
+    """Return the row with the shortest adjusted Stage1 + Stage2 latency.
+
+    ``us1`` already includes any launch costs needed to compare fused and
+    non-fused Stage1 kernels fairly. One-stage kernels use ``us2=0``, so they
+    participate in the same end-to-end objective. Select before display
+    rounding so near-equal candidates cannot tie at four decimal places.
+    """
+    if profile_df.empty:
+        raise ValueError("cannot select a stage combination from an empty frame")
+    missing = {"us1", "us2"} - set(profile_df.columns)
+    if missing:
+        raise ValueError(
+            f"stage combination candidates are missing columns: {sorted(missing)}"
+        )
+    combined_us = profile_df["us1"] + profile_df["us2"]
+    return profile_df.loc[combined_us.idxmin()].copy()
+
+
 def tensor_compare_diagnostics(
     ref, res, rtol=1e-2, atol=1e-2, max_items=3, sample_elements=4096
 ):
@@ -4224,16 +4293,7 @@ class FmoeTuner(TunerCommon):
             # Dedup fused (_fp4/_fp8) and non-fused stage1 separately: the fairness
             # penalty below is applied only to non-fused, so dedup must not drop the
             # fused kernel by raw us before that penalty runs.
-            profileDF["_is_fused"] = (
-                profileDF["kernelName"].astype(str).str.endswith(("_fp4", "_fp8"))
-            )
-            profileDF = (
-                profileDF.sort_values("us")
-                .drop_duplicates(
-                    ["stage", "block_m", "flat", "_is_fused"], keep="first"
-                )
-                .drop(columns=["_is_fused"])
-            )
+            profileDF = dedupe_objective_candidates(profileDF)
             stage1_profileDF = profileDF[profileDF["stage"] == "stage1"].drop(
                 columns=["stage", "flat"]
             )
@@ -4403,14 +4463,10 @@ class FmoeTuner(TunerCommon):
                         print(
                             f"  quant_sort benchmark: blockM={bm_int}, us={us_qs_cache[bm]}"
                         )
-                    profileDF["us_quant_sort"] = profileDF["block_m"].map(us_qs_cache)
                     # _fp4 kernels already fuse the fp4-quant+sort; skip cost addition
-                    is_fp4 = profileDF["kernelName1"].astype(str).str.endswith("_fp4")
-                    profileDF.loc[~is_fp4, "us1"] = (
-                        profileDF.loc[~is_fp4, "us1"]
-                        + profileDF.loc[~is_fp4, "us_quant_sort"]
+                    profileDF = add_intermediate_quant_cost(
+                        profileDF, "_fp4", us_qs_cache
                     )
-                    profileDF.drop(columns=["us_quant_sort"], inplace=True)
                 elif q_dtype_a == dtypes.fp8:
                     from aiter.test_common import run_perftest
 
@@ -4432,13 +4488,9 @@ class FmoeTuner(TunerCommon):
                     us_qs_cache = {}
                     for bm in profileDF["block_m"].unique():
                         us_qs_cache[bm] = us_fp8_cast
-                    profileDF["us_quant_sort"] = profileDF["block_m"].map(us_qs_cache)
-                    is_fp8 = profileDF["kernelName1"].astype(str).str.endswith("_fp8")
-                    profileDF.loc[~is_fp8, "us1"] = (
-                        profileDF.loc[~is_fp8, "us1"]
-                        + profileDF.loc[~is_fp8, "us_quant_sort"]
+                    profileDF = add_intermediate_quant_cost(
+                        profileDF, "_fp8", us_qs_cache
                     )
-                    profileDF.drop(columns=["us_quant_sort"], inplace=True)
 
             has_xbf16 = "xbf16" in profileDF.columns and profileDF["xbf16"].any()
             if q_type == QuantType.per_1x128 and has_xbf16:
@@ -4735,7 +4787,7 @@ class FmoeTuner(TunerCommon):
                     old_df = pd.DataFrame(columns=self.columns)
                 tmpprofileDF = pd.concat([old_df, profileDF], ignore_index=True)
                 tmpprofileDF.to_csv(args.profile_file, index=False)
-            best_one = profileDF.loc[profileDF["us"].idxmin()].copy()
+            best_one = select_fastest_stage_combination(profileDF)
             print(
                 f"Tuning result for {key} is {best_one['block_m'], best_one['kernelName1'], best_one['kernelName2'], best_one['err1'], best_one['err2'], best_one['run_1stage']} {best_one['us']} us, {best_one['tflops']} TFLOPS, {best_one['bw']} GB/s"
             )

--- a/csrc/include/moe_sorting_opus.h
+++ b/csrc/include/moe_sorting_opus.h
@@ -28,6 +28,24 @@ void moe_sorting_opus_fwd(aiter_tensor_t& topk_ids,
                           std::optional<aiter_tensor_t> m_indices        = std::nullopt,
                           std::optional<aiter_tensor_t> reverse_sorted   = std::nullopt);
 
+// Narrow gfx950 decode helper. It fuses route sorting, BF16->MXFP4 activation
+// quantization and routed-output zeroing for H=7168, block_m=32 batches of
+// M in [1, 128]. (num_experts, topk) must be one of (256,8), (384,8) or
+// (385,9) -- the expert histogram is a template parameter. Emits compact
+// per-token E8M0 scales, which FlyDSL GEMM1 can consume directly; callers that
+// need the sorted-row layout run the conventional conversion afterwards.
+void mxfp4_moe_sort_quant_fwd(aiter_tensor_t& hidden_states,
+                              aiter_tensor_t& topk_ids,
+                              aiter_tensor_t& topk_weights,
+                              aiter_tensor_t& sorted_token_ids,
+                              aiter_tensor_t& sorted_weights,
+                              aiter_tensor_t& sorted_expert_ids,
+                              aiter_tensor_t& num_valid_ids,
+                              aiter_tensor_t& moe_buf,
+                              aiter_tensor_t& activation_quant,
+                              aiter_tensor_t& activation_scale_token,
+                              int num_experts);
+
 #ifdef MOE_SORTING_OPUS_IMPL
 // ============================================================================
 // Implementation section - only compiled in the .cu translation unit

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1417,7 +1417,20 @@ namespace py = pybind11;
           py::arg("dispatch_policy")   = 0,            \
           py::arg("local_topk_ids")    = std::nullopt, \
           py::arg("m_indices")         = std::nullopt, \
-          py::arg("reverse_sorted")    = std::nullopt);
+          py::arg("reverse_sorted")    = std::nullopt); \
+    m.def("mxfp4_moe_sort_quant_fwd",                  \
+          &mxfp4_moe_sort_quant_fwd,                   \
+          py::arg("hidden_states"),                    \
+          py::arg("topk_ids"),                         \
+          py::arg("topk_weights"),                     \
+          py::arg("sorted_token_ids"),                 \
+          py::arg("sorted_weights"),                   \
+          py::arg("sorted_expert_ids"),                \
+          py::arg("num_valid_ids"),                    \
+          py::arg("moe_buf"),                          \
+          py::arg("activation_quant"),                 \
+          py::arg("activation_scale_token"),           \
+          py::arg("num_experts"));
 
 #define PA_SPARSE_PREFILL_OPUS_PYBIND                  \
     m.def("pa_sparse_prefill_opus_fwd",                \

--- a/csrc/py_itfs_cu/moe_sorting_opus_kernels.cu
+++ b/csrc/py_itfs_cu/moe_sorting_opus_kernels.cu
@@ -10,6 +10,7 @@
 #include "aiter_hip_common.h"
 #include "aiter_stream.h"
 #include "aiter_tensor.h"
+#include "mx_quant_utils.h"
 
 void moe_sorting_opus_fwd(aiter_tensor_t& topk_ids,
                           aiter_tensor_t& topk_weights,
@@ -81,4 +82,399 @@ void moe_sorting_opus_fwd(aiter_tensor_t& topk_ids,
          static_cast<int>(moe_buf.size(-1)),
          static_cast<int>(moe_buf.element_size())},
         {stream});
+}
+
+namespace aiter::mxfp4_moe {
+
+constexpr int kHiddenSize    = 7168;
+constexpr int kBlockM        = 32;
+constexpr int kThreads       = 1024;
+constexpr int kSortQuantCtas = 16;
+constexpr int kScaleCols     = kHiddenSize / 32;
+
+// Routed-MoE shapes the sort kernel is instantiated for. NumExperts and TopK
+// are template parameters (the expert histogram lives in LDS), so widening the
+// support surface means adding a row here.
+#define AITER_MXFP4_SORT_QUANT_ROUTES(_) \
+    _(256, 8)                            \
+    _(384, 8)                            \
+    _(385, 9)
+
+__device__ __forceinline__ int pack_token_topk_id(int token_id, int topk_id)
+{
+    return (token_id & 0x00ffffff) | ((topk_id & 0xff) << 24);
+}
+
+__device__ __forceinline__ int round_up_to_block(int value)
+{
+    return (value + kBlockM - 1) & ~(kBlockM - 1);
+}
+
+__device__ __forceinline__ int dpp_inclusive_scan_wave(int value)
+{
+    int tmp = __builtin_amdgcn_mov_dpp(value, 0x111, 0xF, 0xF, true);
+    value += tmp;
+    tmp = __builtin_amdgcn_mov_dpp(value, 0x112, 0xF, 0xF, true);
+    value += tmp;
+    tmp = __builtin_amdgcn_mov_dpp(value, 0x114, 0xF, 0xF, true);
+    value += tmp;
+    tmp = __builtin_amdgcn_mov_dpp(value, 0x118, 0xF, 0xF, true);
+    value += tmp;
+    tmp = __builtin_amdgcn_update_dpp(0, value, 0x142, 0xA, 0xF, true);
+    value += tmp;
+    tmp = __builtin_amdgcn_update_dpp(0, value, 0x143, 0xC, 0xF, true);
+    return value + tmp;
+}
+
+template <int NumCtas>
+__device__ __forceinline__ void zero_moe_output(void* output, int tokens)
+{
+    if(output == nullptr)
+        return;
+
+    constexpr long long row_bytes = static_cast<long long>(kHiddenSize) * 2;
+    const long long total_vecs = (static_cast<long long>(tokens) * row_bytes) / sizeof(int4);
+    const long long global_thread =
+        static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+    constexpr long long stride = static_cast<long long>(NumCtas) * kThreads;
+    auto* output_vec = reinterpret_cast<int4*>(output);
+    const int4 zero = {0, 0, 0, 0};
+
+    for(long long i = global_thread; i < total_vecs; i += stride)
+        output_vec[i] = zero;
+}
+
+template <int NumExperts, int TopK>
+__device__ __forceinline__ void build_sorted_metadata(
+    const int32_t* topk_ids,
+    const float* topk_weights,
+    int32_t* sorted_token_ids,
+    float* sorted_weights,
+    int32_t* sorted_expert_ids,
+    int32_t* num_valid_ids,
+    int tokens)
+{
+    // Experts are scanned as complete 64-lane waves; a trailing partial wave
+    // (E=385) is covered by the running prefix of the last full wave.
+    constexpr int kFullExpertWaves = NumExperts / 64;
+    __shared__ int expert_counts[NumExperts];
+    __shared__ int expert_offsets[NumExperts + 1];
+    __shared__ int expert_cursors[NumExperts];
+    __shared__ int wave_totals[16];
+
+    const int tid = threadIdx.x;
+    for(int expert = tid; expert < NumExperts; expert += kThreads)
+    {
+        expert_counts[expert] = 0;
+        expert_cursors[expert] = 0;
+    }
+    __syncthreads();
+
+    const int total_pairs = tokens * TopK;
+    for(int index = tid; index < total_pairs; index += kThreads)
+    {
+        const int expert = topk_ids[index];
+        if(expert >= 0 && expert < NumExperts)
+            atomicAdd(expert_counts + expert, 1);
+    }
+    __syncthreads();
+
+    // At decode expert counts a small shared-memory prefix scan is cheaper
+    // than the generic Opus one-shot bookkeeping.
+    const int lane = tid & 63;
+    const int wave = tid >> 6;
+    int value = tid < NumExperts ? round_up_to_block(expert_counts[tid]) : 0;
+    value = dpp_inclusive_scan_wave(value);
+    if(lane == 63 && wave < kFullExpertWaves)
+        wave_totals[wave] = value;
+    __syncthreads();
+    if(wave == 0)
+    {
+        int wave_value = lane < kFullExpertWaves ? wave_totals[lane] : 0;
+        wave_value = dpp_inclusive_scan_wave(wave_value);
+        if(lane < kFullExpertWaves)
+            wave_totals[lane] = wave_value;
+    }
+    __syncthreads();
+
+    const int wave_prefix = wave == 0 ? 0 : wave_totals[wave - 1];
+    if(tid < NumExperts)
+    {
+        expert_offsets[tid + 1] = value + wave_prefix;
+        expert_cursors[tid] = 0;
+    }
+    if(tid == 0)
+        expert_offsets[0] = 0;
+    __syncthreads();
+
+    if(tid == 0)
+    {
+        num_valid_ids[0] = expert_offsets[NumExperts];
+        num_valid_ids[1] = tokens;
+    }
+    __syncthreads();
+
+    for(int index = tid; index < total_pairs; index += kThreads)
+    {
+        const int expert = topk_ids[index];
+        if(expert < 0 || expert >= NumExperts)
+            continue;
+
+        const int token = index / TopK;
+        const int topk = index - token * TopK;
+        const int position = expert_offsets[expert] + atomicAdd(expert_cursors + expert, 1);
+        sorted_token_ids[position] = pack_token_topk_id(token, topk);
+        sorted_weights[position] = topk_weights[index];
+    }
+    __syncthreads();
+
+    const int sentinel = pack_token_topk_id(tokens, 0);
+    for(int expert = tid; expert < NumExperts; expert += kThreads)
+    {
+        const int count = expert_counts[expert];
+        const int start = expert_offsets[expert];
+        const int end = expert_offsets[expert + 1];
+
+        for(int position = start + count; position < end; ++position)
+        {
+            sorted_token_ids[position] = sentinel;
+            sorted_weights[position] = 0.0f;
+        }
+        for(int block = start / kBlockM; block < end / kBlockM; ++block)
+            sorted_expert_ids[block] = expert;
+    }
+}
+
+template <int QuantCtas>
+__device__ __forceinline__ void quantize_activations_compact(
+    const hip_bfloat16* hidden_states,
+    uint8_t* activation_quant,
+    uint8_t* activation_scale_token,
+    int tokens)
+{
+    using bf16x2_t = __bf16 __attribute__((ext_vector_type(2)));
+    constexpr int groups_per_token = kHiddenSize / 32;
+    constexpr int groups_per_wave = 16;
+    constexpr int groups_per_cta = (kThreads / 64) * groups_per_wave;
+
+    const int tid = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int group_in_wave = lane >> 2;
+    const int lane_in_group = lane & 3;
+    const int total_groups = tokens * groups_per_token;
+    const int total_batches = (total_groups + groups_per_cta - 1) / groups_per_cta;
+    const int quant_cta = blockIdx.x - 1;
+    const int batches_per_cta = (total_batches + QuantCtas - 1) / QuantCtas;
+    const int batch_begin = quant_cta * batches_per_cta;
+    const int batch_end = min(batch_begin + batches_per_cta, total_batches);
+
+    for(int batch = batch_begin; batch < batch_end; ++batch)
+    {
+        const int group = batch * groups_per_cta + wave * groups_per_wave + group_in_wave;
+        if(group >= total_groups)
+            continue;
+
+        const int element_offset = group * 32 + lane_in_group * 8;
+        uint32_t raw[4];
+        *reinterpret_cast<int4*>(raw) =
+            *reinterpret_cast<const int4*>(hidden_states + element_offset);
+
+        uint16_t local_amax = 0;
+#pragma unroll
+        for(int i = 0; i < 4; ++i)
+        {
+            const uint16_t lo = static_cast<uint16_t>(raw[i] & 0xffffu) & 0x7fffu;
+            const uint16_t hi = static_cast<uint16_t>(raw[i] >> 16) & 0x7fffu;
+            local_amax = max(local_amax, max(lo, hi));
+        }
+
+        uint32_t max_bits = local_amax;
+        max_bits = max(
+            max_bits,
+            static_cast<uint32_t>(
+                __builtin_amdgcn_mov_dpp(static_cast<int>(max_bits), 0xB1, 0xF, 0xF, true)));
+        max_bits = max(
+            max_bits,
+            static_cast<uint32_t>(
+                __builtin_amdgcn_mov_dpp(static_cast<int>(max_bits), 0x4E, 0xF, 0xF, true)));
+        const float amax =
+            __uint_as_float(static_cast<uint32_t>(max_bits & 0xffffu) << 16);
+        const float dequant_scale = aiter::fp4_f32_to_e8m0_scale(amax);
+        const uint8_t scale =
+            (static_cast<uint32_t>(__builtin_bit_cast(uint32_t, dequant_scale)) >> 23) & 0xff;
+
+        uint32_t packed = 0;
+#if defined(__gfx950__)
+        packed = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(
+            packed, *reinterpret_cast<const bf16x2_t*>(&raw[0]), dequant_scale, 0);
+        packed = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(
+            packed, *reinterpret_cast<const bf16x2_t*>(&raw[1]), dequant_scale, 1);
+        packed = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(
+            packed, *reinterpret_cast<const bf16x2_t*>(&raw[2]), dequant_scale, 2);
+        packed = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(
+            packed, *reinterpret_cast<const bf16x2_t*>(&raw[3]), dequant_scale, 3);
+#else
+        __builtin_trap();
+#endif
+
+        *reinterpret_cast<uint32_t*>(
+            activation_quant + static_cast<size_t>(group) * 16 + lane_in_group * 4) = packed;
+        if(lane_in_group == 0)
+            activation_scale_token[group] = scale;
+    }
+}
+
+template <int NumExperts, int TopK>
+__global__ void __launch_bounds__(kThreads) moe_sort_quant_kernel(
+    const hip_bfloat16* hidden_states,
+    const int32_t* topk_ids,
+    const float* topk_weights,
+    int32_t* sorted_token_ids,
+    float* sorted_weights,
+    int32_t* sorted_expert_ids,
+    int32_t* num_valid_ids,
+    void* moe_buf,
+    uint8_t* activation_quant,
+    uint8_t* activation_scale_token,
+    int tokens)
+{
+    zero_moe_output<kSortQuantCtas>(moe_buf, tokens);
+    if(blockIdx.x == 0)
+    {
+        build_sorted_metadata<NumExperts, TopK>(
+            topk_ids,
+            topk_weights,
+            sorted_token_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            num_valid_ids,
+            tokens);
+    }
+    else
+    {
+        quantize_activations_compact<kSortQuantCtas - 1>(
+            hidden_states, activation_quant, activation_scale_token, tokens);
+    }
+}
+
+} // namespace aiter::mxfp4_moe
+
+void mxfp4_moe_sort_quant_fwd(aiter_tensor_t& hidden_states,
+                              aiter_tensor_t& topk_ids,
+                              aiter_tensor_t& topk_weights,
+                              aiter_tensor_t& sorted_token_ids,
+                              aiter_tensor_t& sorted_weights,
+                              aiter_tensor_t& sorted_expert_ids,
+                              aiter_tensor_t& num_valid_ids,
+                              aiter_tensor_t& moe_buf,
+                              aiter_tensor_t& activation_quant,
+                              aiter_tensor_t& activation_scale_token,
+                              int num_experts)
+{
+    using namespace aiter::mxfp4_moe;
+
+    AITER_CHECK(hidden_states.dtype() == AITER_DTYPE_bf16,
+                __func__,
+                ": hidden_states must be BF16");
+    AITER_CHECK(topk_ids.dtype() == AITER_DTYPE_i32 &&
+                    topk_weights.dtype() == AITER_DTYPE_fp32,
+                __func__,
+                ": expected int32 topk_ids and fp32 topk_weights");
+    const int topk = topk_ids.dim() == 2 ? static_cast<int>(topk_ids.size(1)) : 0;
+
+#define AITER_MXFP4_SORT_QUANT_MATCH(NUM_EXPERTS, TOPK) \
+    || (num_experts == (NUM_EXPERTS) && topk == (TOPK))
+    const bool route_supported =
+        false AITER_MXFP4_SORT_QUANT_ROUTES(AITER_MXFP4_SORT_QUANT_MATCH);
+#undef AITER_MXFP4_SORT_QUANT_MATCH
+
+    AITER_CHECK(hidden_states.dim() == 2 && hidden_states.size(1) == kHiddenSize &&
+                    topk_ids.dim() == 2 && topk_ids.size(0) == hidden_states.size(0) &&
+                    route_supported,
+                __func__,
+                ": only H=7168 with (num_experts, topk) in "
+                "{(256,8), (384,8), (385,9)} is supported");
+    AITER_CHECK(hidden_states.is_contiguous() && topk_ids.is_contiguous() &&
+                    topk_weights.is_contiguous() && sorted_token_ids.is_contiguous() &&
+                    sorted_weights.is_contiguous() && sorted_expert_ids.is_contiguous() &&
+                    num_valid_ids.is_contiguous() && moe_buf.is_contiguous() &&
+                    activation_quant.is_contiguous() &&
+                    activation_scale_token.is_contiguous(),
+                __func__,
+                ": all tensors must be contiguous");
+    AITER_CHECK(activation_quant.dtype() == AITER_DTYPE_fp4x2 ||
+                    activation_quant.dtype() == AITER_DTYPE_u8,
+                __func__,
+                ": activation_quant must be packed FP4");
+    AITER_CHECK(activation_scale_token.dtype() == AITER_DTYPE_fp8_e8m0 ||
+                    activation_scale_token.dtype() == AITER_DTYPE_u8,
+                __func__,
+                ": activation_scale_token must hold e8m0 bytes");
+
+    const int tokens = static_cast<int>(hidden_states.size(0));
+    AITER_CHECK(tokens > 0 && tokens <= 128,
+                __func__,
+                ": only decode M in [1, 128] is supported");
+    const int64_t route_count = topk_ids.numel();
+    const int64_t active_experts =
+        route_count < static_cast<int64_t>(num_experts) ? route_count : num_experts;
+    const int64_t required_sorted =
+        ((route_count + active_experts * (kBlockM - 1) + kBlockM - 1) /
+         kBlockM) *
+        kBlockM;
+    AITER_CHECK(topk_weights.numel() == topk_ids.numel() &&
+                    activation_quant.numel() == hidden_states.numel() / 2 &&
+                    activation_scale_token.numel() ==
+                        hidden_states.size(0) * kScaleCols &&
+                    num_valid_ids.numel() >= 2,
+                __func__,
+                ": incompatible fused sort/quant tensor sizes");
+
+    AITER_CHECK(sorted_token_ids.numel() >= required_sorted &&
+                    sorted_weights.numel() >= required_sorted &&
+                    sorted_expert_ids.numel() >= required_sorted / kBlockM,
+                __func__,
+                ": output routing buffers are too small");
+
+    HipDeviceGuard device_guard(hidden_states.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    const hip_bfloat16* hidden_ptr =
+        static_cast<const hip_bfloat16*>(hidden_states.data_ptr());
+    const int32_t* topk_ids_ptr = static_cast<const int32_t*>(topk_ids.data_ptr());
+    const float* topk_weights_ptr = static_cast<const float*>(topk_weights.data_ptr());
+    int32_t* sorted_ids_ptr = static_cast<int32_t*>(sorted_token_ids.data_ptr());
+    float* sorted_weights_ptr = static_cast<float*>(sorted_weights.data_ptr());
+    int32_t* sorted_experts_ptr = static_cast<int32_t*>(sorted_expert_ids.data_ptr());
+    int32_t* num_valid_ptr = static_cast<int32_t*>(num_valid_ids.data_ptr());
+    void* moe_buf_ptr = moe_buf.numel() == 0 ? nullptr : moe_buf.data_ptr();
+    uint8_t* activation_quant_ptr = static_cast<uint8_t*>(activation_quant.data_ptr());
+    uint8_t* activation_scale_token_ptr =
+        static_cast<uint8_t*>(activation_scale_token.data_ptr());
+#define AITER_MXFP4_SORT_QUANT_LAUNCH(NUM_EXPERTS, TOPK)                            \
+    if(num_experts == (NUM_EXPERTS) && topk == (TOPK))                              \
+    {                                                                               \
+        aiter::mxfp4_moe::moe_sort_quant_kernel<(NUM_EXPERTS), (TOPK)>              \
+            <<<dim3(kSortQuantCtas), dim3(kThreads), 0, stream>>>(                  \
+                hidden_ptr,                                                         \
+                topk_ids_ptr,                                                       \
+                topk_weights_ptr,                                                   \
+                sorted_ids_ptr,                                                     \
+                sorted_weights_ptr,                                                 \
+                sorted_experts_ptr,                                                 \
+                num_valid_ptr,                                                      \
+                moe_buf_ptr,                                                        \
+                activation_quant_ptr,                                               \
+                activation_scale_token_ptr,                                         \
+                tokens);                                                            \
+    }
+    AITER_MXFP4_SORT_QUANT_ROUTES(AITER_MXFP4_SORT_QUANT_LAUNCH)
+#undef AITER_MXFP4_SORT_QUANT_LAUNCH
+
+    const hipError_t launch_status = hipGetLastError();
+    AITER_CHECK(
+        launch_status == hipSuccess,
+        __func__,
+        ": fused sort+quant launch failed");
 }

--- a/csrc/py_itfs_cu/moe_sorting_opus_kernels.cu
+++ b/csrc/py_itfs_cu/moe_sorting_opus_kernels.cu
@@ -12,6 +12,9 @@
 #include "aiter_tensor.h"
 #include "mx_quant_utils.h"
 
+#include <string>
+#include <vector>
+
 void moe_sorting_opus_fwd(aiter_tensor_t& topk_ids,
                           aiter_tensor_t& topk_weights,
                           aiter_tensor_t& sorted_token_ids,
@@ -358,6 +361,36 @@ __global__ void __launch_bounds__(kThreads) moe_sort_quant_kernel(
     }
 }
 
+// The activation quantization above lowers to v_cvt_scalef32_pk_fp4_bf16, which
+// is part of the fp4-cvt-scale instruction set introduced with gfx950 (CDNA4).
+// Earlier CDNA parts have no FP4 convert instruction at all, so there is no
+// gfx942 equivalent to substitute -- and the MXFP4 MoE GEMM that consumes this
+// kernel's output is gfx950-only for the same reason, so a software-emulated
+// fallback would produce bytes nothing downstream could use. Reject other
+// architectures on the host instead, so an unsupported call reports an error
+// rather than executing the __builtin_trap() the device path compiles to.
+//
+// Cached per device: this sits on the decode path and hipGetDeviceProperties is
+// not cheap enough to call per launch.
+inline bool is_fp4_cvt_capable(int device_id)
+{
+    static const std::vector<char> capable = [] {
+        int count = 0;
+        HIP_CALL(hipGetDeviceCount(&count));
+        std::vector<char> caps(static_cast<size_t>(count), 0);
+        for(int i = 0; i < count; ++i)
+        {
+            hipDeviceProp_t prop;
+            HIP_CALL(hipGetDeviceProperties(&prop, i));
+            caps[static_cast<size_t>(i)] =
+                std::string(prop.gcnArchName).find("gfx950") != std::string::npos;
+        }
+        return caps;
+    }();
+    return device_id >= 0 && device_id < static_cast<int>(capable.size()) &&
+           capable[static_cast<size_t>(device_id)] != 0;
+}
+
 } // namespace aiter::mxfp4_moe
 
 void mxfp4_moe_sort_quant_fwd(aiter_tensor_t& hidden_states,
@@ -374,6 +407,25 @@ void mxfp4_moe_sort_quant_fwd(aiter_tensor_t& hidden_states,
 {
     using namespace aiter::mxfp4_moe;
 
+    const int device_id = hidden_states.device_id;
+    AITER_CHECK(is_fp4_cvt_capable(device_id),
+                __func__,
+                ": requires gfx950; the fp4 activation quantization uses the "
+                "scalef32 fp4-cvt instructions, which no earlier architecture has");
+    // An off-device tensor would otherwise be dereferenced by the kernel under
+    // this call's HipDeviceGuard and fault, or silently read another device's
+    // memory. moe_buf is exempt when empty: the zeroing pass skips it entirely.
+    AITER_CHECK(topk_ids.device_id == device_id && topk_weights.device_id == device_id &&
+                    sorted_token_ids.device_id == device_id &&
+                    sorted_weights.device_id == device_id &&
+                    sorted_expert_ids.device_id == device_id &&
+                    num_valid_ids.device_id == device_id &&
+                    (moe_buf.numel() == 0 || moe_buf.device_id == device_id) &&
+                    activation_quant.device_id == device_id &&
+                    activation_scale_token.device_id == device_id,
+                __func__,
+                ": all tensors must be on the same device");
+
     AITER_CHECK(hidden_states.dtype() == AITER_DTYPE_bf16,
                 __func__,
                 ": hidden_states must be BF16");
@@ -381,6 +433,13 @@ void mxfp4_moe_sort_quant_fwd(aiter_tensor_t& hidden_states,
                     topk_weights.dtype() == AITER_DTYPE_fp32,
                 __func__,
                 ": expected int32 topk_ids and fp32 topk_weights");
+    AITER_CHECK(sorted_token_ids.dtype() == AITER_DTYPE_i32 &&
+                    sorted_weights.dtype() == AITER_DTYPE_fp32 &&
+                    sorted_expert_ids.dtype() == AITER_DTYPE_i32 &&
+                    num_valid_ids.dtype() == AITER_DTYPE_i32,
+                __func__,
+                ": expected int32 sorted_token_ids, fp32 sorted_weights, int32 "
+                "sorted_expert_ids, and int32 num_valid_ids");
     const int topk = topk_ids.dim() == 2 ? static_cast<int>(topk_ids.size(1)) : 0;
 
 #define AITER_MXFP4_SORT_QUANT_MATCH(NUM_EXPERTS, TOPK) \
@@ -430,6 +489,13 @@ void mxfp4_moe_sort_quant_fwd(aiter_tensor_t& hidden_states,
                     num_valid_ids.numel() >= 2,
                 __func__,
                 ": incompatible fused sort/quant tensor sizes");
+    AITER_CHECK(moe_buf.numel() == 0 ||
+                    ((moe_buf.dtype() == AITER_DTYPE_bf16 ||
+                      moe_buf.dtype() == AITER_DTYPE_fp16) &&
+                     moe_buf.numel() >=
+                         static_cast<int64_t>(tokens) * kHiddenSize),
+                __func__,
+                ": moe_buf must be empty or contain at least M*7168 BF16/FP16 elements");
 
     AITER_CHECK(sorted_token_ids.numel() >= required_sorted &&
                     sorted_weights.numel() >= required_sorted &&

--- a/op_tests/op_benchmarks/hip/bench_mxfp4_moe_compact_scale_gemm1.py
+++ b/op_tests/op_benchmarks/hip/bench_mxfp4_moe_compact_scale_gemm1.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Benchmark for MXFP4 MoE stage-1 GEMM with compact activation scales.
+
+Separates the two effects of letting GEMM1 read compact per-token E8M0 scales
+instead of a sorted-row scale tensor:
+
+    (a) tuned params + conventional sorted scales   <- baseline
+    (b) tuned params + compact scales, no retune    <- cost of compact addressing
+    (c) branch's compact tile/wave overrides        <- what `auto` mode ships
+
+(a) and (b) call flydsl_moe_stage1 directly with the tuned row's parameters, so
+they differ only in scale layout. (c) goes through _flydsl_stage1_wrapper, which
+applies the compact-specific tile_n / waves_per_eu / b_nt / xcd_swizzle
+overrides. Each variant is CUDA-graph captured and replayed.
+
+Note this measures GEMM1 in isolation. It does not include the scale-layout
+conversion that (a) would need in a real decode step, so the (b)/(c) ratios are
+a lower bound on the end-to-end benefit -- see bench_mxfp4_moe_decode_layer.py
+for the full-layer picture.
+
+Usage:
+    # Run with default parameters (Kimi decode shape)
+    python bench_mxfp4_moe_compact_scale_gemm1.py
+
+    # Run selected token counts
+    python bench_mxfp4_moe_compact_scale_gemm1.py -t 16 32
+
+    # Save results to CSV
+    python bench_mxfp4_moe_compact_scale_gemm1.py -o results.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.fused_moe import _flydsl_stage1_wrapper, moe_sorting
+from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1, get_flydsl_kernel_params
+from aiter.ops.quant import mxfp4_moe_sort_fwd, per_1x32_f4_quant_hip
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+DEVICE = "cuda"
+
+# Default sweep parameters (Kimi K2 TP8 shard, E=384/topk=8)
+MODEL_DIM = 7168
+INTER_DIM = 256
+EXPERTS = 384
+TOPK = 8
+BLOCK_M = 32
+
+# Tuned block_m=32 stage-1 rows this shape dispatches to, per token count.
+TUNED_KERNELS = {
+    1: "flydsl_moe1_afp4_wfp4_bf16_t32x32x256_w3_kw4",
+    2: "flydsl_moe1_afp4_wfp4_bf16_t32x32x256_w3_bnt0_kw4",
+    4: "flydsl_moe1_afp4_wfp4_bf16_t32x32x256_w2_kw4",
+    8: "flydsl_moe1_afp4_wfp4_bf16_t32x32x256_w4_xcd4_kw4_fp4",
+    16: "flydsl_moe1_afp4_wfp4_bf16_t32x128x256_w4_fp4",
+    32: "flydsl_moe1_afp4_wfp4_bf16_t32x64x256_w4",
+    64: "flydsl_moe1_afp4_wfp4_bf16_t32x32x256_w3",
+    128: "flydsl_moe1_afp4_wfp4_bf16_t32x128x256_w3_fp4",
+}
+
+
+def time_graph(fn, iters: int, warmup: int, reps: int) -> float:
+    """CUDA-graph capture `fn`, then return the best per-replay time in us."""
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fn()
+
+    best = float("inf")
+    for _ in range(reps):
+        for _ in range(warmup):
+            graph.replay()
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            graph.replay()
+        end.record()
+        torch.cuda.synchronize()
+        best = min(best, start.elapsed_time(end) / iters * 1000.0)
+    return best
+
+
+def _prepare_weights(experts: int, inter_dim: int, model_dim: int):
+    """Quantize and pre-shuffle the gate/up weight for the a4w4 stage-1 kernel."""
+    quantize = aiter.get_torch_quant(aiter.QuantType.per_1x32)
+    w1 = (
+        torch.randn(
+            (experts, 2 * inter_dim, model_dim), dtype=dtypes.bf16, device=DEVICE
+        )
+        * 0.1
+    )
+    w1_qt, w1_scale = quantize(w1, quant_dtype=dtypes.fp4x2)
+    del w1
+    torch.cuda.empty_cache()
+    w1_qt = shuffle_weight_a16w4(
+        w1_qt.view(experts, 2 * inter_dim, model_dim // 2), 16, True
+    )
+    w1_scale = shuffle_scale_a16w4(w1_scale, experts, True)
+    return w1_qt, w1_scale
+
+
+def bench_compact_scale_gemm1_latency(
+    tokens: int,
+    kernel_name: str,
+    w1_qt: torch.Tensor,
+    w1_scale: torch.Tensor,
+    experts: int = EXPERTS,
+    topk: int = TOPK,
+    model_dim: int = MODEL_DIM,
+    block_m: int = BLOCK_M,
+    iters: int = 300,
+    warmup: int = 30,
+    reps: int = 3,
+) -> tuple[float, float, float]:
+    """
+    Benchmark the three stage-1 GEMM variants for one token count.
+
+    Returns:
+        Tuple of (tuned+conventional, tuned+compact, override+compact)
+        latencies in microseconds.
+    """
+    torch.manual_seed(1000 + tokens)
+    hidden = torch.randn((tokens, model_dim), dtype=dtypes.bf16, device=DEVICE) * 0.1
+    topk_ids = torch.stack(
+        [
+            torch.randperm(experts, dtype=dtypes.i32, device=DEVICE)[:topk]
+            for _ in range(tokens)
+        ]
+    )
+    topk_weights = torch.rand((tokens, topk), dtype=dtypes.fp32, device=DEVICE)
+    sorted_ids, _sorted_weights, sorted_expert_ids, num_valid_ids, _buf = moe_sorting(
+        topk_ids, topk_weights, experts, model_dim, dtypes.bf16, block_m
+    )
+
+    act_quant, compact_scale = per_1x32_f4_quant_hip(hidden, shuffle=False)
+    sorted_scale = mxfp4_moe_sort_fwd(
+        compact_scale,
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=tokens,
+        cols=model_dim,
+    )
+
+    params = get_flydsl_kernel_params(kernel_name)
+    raw_kwargs = {
+        "a": act_quant,
+        "w1": w1_qt,
+        "sorted_token_ids": sorted_ids,
+        "sorted_expert_ids": sorted_expert_ids,
+        "num_valid_ids": num_valid_ids,
+        "out": None,
+        "topk": topk,
+        "tile_m": params["tile_m"],
+        "tile_n": params["tile_n"],
+        "tile_k": params["tile_k"],
+        "a_dtype": params["a_dtype"],
+        "b_dtype": params["b_dtype"],
+        "out_dtype": params["out_dtype"],
+        "act": "silu",
+        "w1_scale": w1_scale,
+        "sorted_weights": None,
+        "use_async_copy": True,
+        "k_batch": params.get("k_batch", 1),
+        "waves_per_eu": params.get("waves_per_eu", 3),
+        "b_nt": params.get("b_nt", 2),
+        "gate_mode": params.get("gate_mode", "separated"),
+        "xcd_swizzle": params.get("xcd_swizzle", 0),
+        "k_wave": params.get("k_wave", 1),
+    }
+    wrapper_kwargs = {
+        "w2": None,
+        "sorted_token_ids": sorted_ids,
+        "sorted_expert_ids": sorted_expert_ids,
+        "num_valid_ids": num_valid_ids,
+        "out": None,
+        "topk": topk,
+        "kernelName": kernel_name,
+        "w1_scale": w1_scale,
+        "sorted_weights": None,
+    }
+
+    conventional_us = time_graph(
+        lambda: flydsl_moe_stage1(
+            a1_scale=sorted_scale, a_scale_compact=False, **raw_kwargs
+        ),
+        iters,
+        warmup,
+        reps,
+    )
+    compact_us = time_graph(
+        lambda: flydsl_moe_stage1(
+            a1_scale=compact_scale, a_scale_compact=True, **raw_kwargs
+        ),
+        iters,
+        warmup,
+        reps,
+    )
+    override_us = time_graph(
+        lambda: _flydsl_stage1_wrapper(
+            hidden_states=act_quant,
+            w1=w1_qt,
+            a1_scale=compact_scale,
+            a1_scale_compact=True,
+            **wrapper_kwargs,
+        ),
+        iters,
+        warmup,
+        reps,
+    )
+    return conventional_us, compact_us, override_us
+
+
+def run_benchmark(args):
+    """Run the GEMM1 benchmark across every requested token count."""
+    print(f"arch: {torch.cuda.get_device_properties(0).gcnArchName}")
+    print(
+        f"E={args.experts} topk={args.topk} model_dim={args.model_dim} "
+        f"inter_dim={args.inter_dim} block_m={args.block_m}"
+    )
+
+    w1_qt, w1_scale = _prepare_weights(args.experts, args.inter_dim, args.model_dim)
+
+    results = []
+    header = (
+        f"{'M':>8} {'(a) tuned+conv':>16} {'(b) tuned+compact':>19} "
+        f"{'(c) override+compact':>22} {'b/a':>8} {'c/a':>8}"
+    )
+    print()
+    print(header)
+    print("-" * len(header))
+
+    for tokens in args.tokens:
+        kernel_name = TUNED_KERNELS.get(tokens)
+        if kernel_name is None:
+            print(
+                f"{tokens:>8}  no tuned block_m=32 kernel recorded; "
+                f"add one to TUNED_KERNELS to benchmark this token count"
+            )
+            continue
+        conv_us, compact_us, override_us = bench_compact_scale_gemm1_latency(
+            tokens,
+            kernel_name,
+            w1_qt,
+            w1_scale,
+            experts=args.experts,
+            topk=args.topk,
+            model_dim=args.model_dim,
+            block_m=args.block_m,
+            iters=args.iters,
+            warmup=args.warmup,
+            reps=args.reps,
+        )
+        results.append((tokens, kernel_name, conv_us, compact_us, override_us))
+        print(
+            f"{tokens:>8} {conv_us:>16.2f} {compact_us:>19.2f} "
+            f"{override_us:>22.2f} {conv_us / compact_us:>7.2f}x "
+            f"{conv_us / override_us:>7.2f}x"
+        )
+
+    if args.o:
+        _save_results_csv(args.o, results)
+
+
+def _save_results_csv(filepath: str, results: list):
+    """Save benchmark results to CSV file."""
+    path = Path(filepath)
+    with open(path, "w") as f:
+        f.write(
+            "tokens,kernel_name,tuned_conventional_us,tuned_compact_us,"
+            "override_compact_us,speedup_compact,speedup_override\n"
+        )
+        f.writelines(
+            f"{tokens},{kernel_name},{conv_us:.4f},{compact_us:.4f},"
+            f"{override_us:.4f},{conv_us / compact_us:.4f},"
+            f"{conv_us / override_us:.4f}\n"
+            for tokens, kernel_name, conv_us, compact_us, override_us in results
+        )
+    print(f"\nResults saved to {path.resolve()}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark MXFP4 MoE Compact-Scale GEMM1",
+        description=(
+            "Benchmark MXFP4 MoE stage-1 GEMM reading compact per-token scales "
+            "against the conventional sorted-row scale layout."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-t",
+        "--tokens",
+        type=int,
+        nargs="+",
+        default=sorted(TUNED_KERNELS),
+        help="Token counts to sweep.",
+    )
+    parser.add_argument(
+        "-e",
+        "--experts",
+        type=int,
+        default=EXPERTS,
+        help="Number of experts.",
+    )
+    parser.add_argument(
+        "-k",
+        "--topk",
+        type=int,
+        default=TOPK,
+        help="Experts routed per token.",
+    )
+    parser.add_argument(
+        "--model-dim",
+        type=int,
+        dest="model_dim",
+        default=MODEL_DIM,
+        help="Model hidden dimension.",
+    )
+    parser.add_argument(
+        "--inter-dim",
+        type=int,
+        dest="inter_dim",
+        default=INTER_DIM,
+        help="Expert intermediate dimension.",
+    )
+    parser.add_argument(
+        "--block-m",
+        type=int,
+        dest="block_m",
+        default=BLOCK_M,
+        help="Sort block size M.",
+    )
+    parser.add_argument(
+        "-o",
+        type=str,
+        metavar="FILE",
+        help="Output CSV file path for results.",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=300,
+        help="Number of graph replays per timed rep.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=30,
+        help="Number of warmup replays before each timed rep.",
+    )
+    parser.add_argument(
+        "--reps",
+        type=int,
+        default=3,
+        help="Number of timed reps; the best is reported.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    run_benchmark(parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/op_benchmarks/hip/bench_mxfp4_moe_decode_layer.py
+++ b/op_tests/op_benchmarks/hip/bench_mxfp4_moe_decode_layer.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+End-to-end benchmark for an MXFP4 MoE decode layer with fused sort+quant.
+
+Times a full `fused_moe` call (stage 1 + stage 2) at decode batch sizes, with
+and without the fused route-sort + MXFP4 quant path:
+
+    A  baseline    conventional sort, quant and sorted-row scale expansion
+    C  fused       fused sort+quant kernel, GEMM1 reads compact per-token scales
+
+Both arms are driven through `op_tests/test_moe_2stage.py`, which validates the
+layer output on every case, so the reported `logits_diff` doubles as an accuracy
+check across arms. Each arm runs in its own subprocess because the feature is
+selected by environment variable.
+
+Unlike the component benchmarks (bench_mxfp4_moe_sort_quant.py and
+bench_mxfp4_moe_compact_scale_gemm1.py) this measures the real dispatch path.
+Prefer it when deciding whether the feature pays off: summing the isolated
+components over-weights the plumbing and does not predict the layer result.
+
+Note `SGLANG_AITER_FUSED_DECODE_COMPACT_SCALE` falls back to
+`SGLANG_AITER_FUSED_DECODE_SORT_QUANT` when unset, so both arms set both
+variables explicitly.
+
+Usage:
+    # Run with default parameters (Kimi decode shape, E=384/topk=8)
+    python bench_mxfp4_moe_decode_layer.py
+
+    # Run selected token counts, averaged over 2 runs per arm
+    python bench_mxfp4_moe_decode_layer.py -t 1 8 32 --reps 2
+
+    # Save results to CSV
+    python bench_mxfp4_moe_decode_layer.py -o results.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Default sweep parameters (Kimi K2 TP8 shard, separate shared expert)
+MODEL_DIM = 7168
+INTER_DIM = 256
+EXPERTS = 384
+TOPK = 8
+TOKENS = [1, 2, 4, 8, 16, 32, 64, 128]
+
+SORT_QUANT_ENV = "SGLANG_AITER_FUSED_DECODE_SORT_QUANT"
+COMPACT_SCALE_ENV = "SGLANG_AITER_FUSED_DECODE_COMPACT_SCALE"
+
+ARMS = {
+    "A": ("baseline", {SORT_QUANT_ENV: "0", COMPACT_SCALE_ENV: "0"}),
+    "C": ("fused+compact", {SORT_QUANT_ENV: "auto", COMPACT_SCALE_ENV: "auto"}),
+}
+
+HARNESS = Path(__file__).resolve().parents[2] / "test_moe_2stage.py"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _parse_harness_table(stdout: str) -> dict[int, tuple[float, float]]:
+    """Extract {tokens: (us, logits_diff)} from the harness markdown summary.
+
+    Columns are located by name rather than position so the mapping survives the
+    harness gaining or reordering columns.
+    """
+    columns: list[str] | None = None
+    results: dict[int, tuple[float, float]] = {}
+
+    for line in stdout.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if columns is None:
+            if "us" in cells and "token" in cells:
+                columns = cells
+            continue
+        if len(cells) != len(columns):
+            continue
+        row = dict(zip(columns, cells))
+        try:
+            tokens = int(row["token"])
+            us = float(row["us"])
+        except (KeyError, ValueError):
+            continue
+        try:
+            logits_diff = float(row["logits_diff"])
+        except (KeyError, ValueError):
+            logits_diff = float("nan")
+        results[tokens] = (us, logits_diff)
+
+    return results
+
+
+def run_arm(arm: str, args) -> dict[int, tuple[float, float]]:
+    """Run one arm of the sweep in a subprocess and return its parsed results."""
+    _label, arm_env = ARMS[arm]
+    env = dict(os.environ, **arm_env)
+    # The harness must import the aiter package from this checkout, not from any
+    # other copy that happens to sit earlier on the default import path.
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT), env["PYTHONPATH"]]
+        if env.get("PYTHONPATH")
+        else [str(REPO_ROOT)]
+    )
+
+    cmd = [
+        sys.executable,
+        str(HARNESS),
+        "-q",
+        "4",
+        "-e",
+        str(args.experts),
+        "-k",
+        str(args.topk),
+        "-dim",
+        f"{args.model_dim},{args.inter_dim}",
+        "-hip",
+        "0,0",
+        "--no-flydsl-csv",
+        "--no-situv2",
+        "-t",
+        *[str(t) for t in args.tokens],
+    ]
+    # The harness emits its summary table through the logger, i.e. on stderr.
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        # A non-zero exit is reported via the parse failure below, which can
+        # also show the harness output that explains it.
+        check=False,
+    )
+    parsed = _parse_harness_table(proc.stdout)
+    if not parsed:
+        sys.stderr.write(proc.stdout[-4000:])
+        raise RuntimeError(
+            f"arm {arm}: harness produced no parseable results "
+            f"(exit code {proc.returncode})"
+        )
+    return parsed
+
+
+def run_benchmark(args):
+    """Sweep both arms and print the comparison table."""
+    print(
+        f"E={args.experts} topk={args.topk} model_dim={args.model_dim} "
+        f"inter_dim={args.inter_dim}"
+    )
+    print(f"harness: {HARNESS}")
+
+    # best[arm][tokens] = (us, logits_diff) of the fastest rep
+    best: dict[str, dict[int, tuple[float, float]]] = {arm: {} for arm in ARMS}
+    for rep in range(1, args.reps + 1):
+        for arm, (label, _env) in ARMS.items():
+            print(f"  running rep {rep}/{args.reps}, arm {arm} ({label}) ...")
+            for tokens, (us, diff) in run_arm(arm, args).items():
+                prior = best[arm].get(tokens)
+                if prior is None or us < prior[0]:
+                    best[arm][tokens] = (us, diff)
+
+    header = (
+        f"\n{'M':>8} {'A baseline':>13} {'C fused+compact':>18} {'C/A':>8} "
+        f"{'A diff':>12} {'C diff':>12}"
+    )
+    print(header)
+    print("-" * (len(header) - 1))
+
+    results = []
+    for tokens in args.tokens:
+        if tokens not in best["A"] or tokens not in best["C"]:
+            continue
+        a_us, a_diff = best["A"][tokens]
+        c_us, c_diff = best["C"][tokens]
+        results.append((tokens, a_us, c_us, a_diff, c_diff))
+        print(
+            f"{tokens:>8} {a_us:>13.2f} {c_us:>18.2f} {a_us / c_us:>7.2f}x "
+            f"{a_diff:>12.2e} {c_diff:>12.2e}"
+        )
+
+    print(f"\nBest of {args.reps} run(s) per arm. Times are us for the full layer.")
+
+    if args.o:
+        _save_results_csv(args.o, results)
+
+
+def _save_results_csv(filepath: str, results: list):
+    """Save benchmark results to CSV file."""
+    path = Path(filepath)
+    with open(path, "w") as f:
+        f.write(
+            "tokens,baseline_us,fused_compact_us,speedup,"
+            "baseline_logits_diff,fused_compact_logits_diff\n"
+        )
+        f.writelines(
+            f"{tokens},{a_us:.4f},{c_us:.4f},{a_us / c_us:.4f},"
+            f"{a_diff:.6e},{c_diff:.6e}\n"
+            for tokens, a_us, c_us, a_diff, c_diff in results
+        )
+    print(f"Results saved to {path.resolve()}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark MXFP4 MoE Decode Layer",
+        description=(
+            "Benchmark a full MXFP4 MoE decode layer with and without the fused "
+            "route-sort + quant path."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-t",
+        "--tokens",
+        type=int,
+        nargs="+",
+        default=TOKENS,
+        help="Token counts to sweep.",
+    )
+    parser.add_argument(
+        "-e",
+        "--experts",
+        type=int,
+        default=EXPERTS,
+        help="Number of experts.",
+    )
+    parser.add_argument(
+        "-k",
+        "--topk",
+        type=int,
+        default=TOPK,
+        help="Experts routed per token.",
+    )
+    parser.add_argument(
+        "--model-dim",
+        type=int,
+        dest="model_dim",
+        default=MODEL_DIM,
+        help="Model hidden dimension.",
+    )
+    parser.add_argument(
+        "--inter-dim",
+        type=int,
+        dest="inter_dim",
+        default=INTER_DIM,
+        help="Expert intermediate dimension.",
+    )
+    parser.add_argument(
+        "-o",
+        type=str,
+        metavar="FILE",
+        help="Output CSV file path for results.",
+    )
+    parser.add_argument(
+        "--reps",
+        type=int,
+        default=2,
+        help="Number of runs per arm; the fastest is reported.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    run_benchmark(parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/op_benchmarks/hip/bench_mxfp4_moe_sort_quant.py
+++ b/op_tests/op_benchmarks/hip/bench_mxfp4_moe_sort_quant.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Benchmark for the fused MoE route-sort + MXFP4 activation-quant kernel.
+
+Measures the pre-GEMM plumbing of an MXFP4 MoE decode step, comparing the
+conventional two-launch sequence against the fused kernel:
+
+    baseline    moe_sorting + fused_dynamic_mxfp4_quant_moe_sort
+    fused       mxfp4_moe_sort_quant_fwd (compact per-token scales)
+    fused+ss    the above + mxfp4_moe_sort_fwd (sorted-row scale layout)
+
+Each variant is CUDA-graph captured and replayed, so the numbers are launch
+cost inclusive and free of Python overhead.
+
+Usage:
+    # Run with default parameters (Kimi decode shape)
+    python bench_mxfp4_moe_sort_quant.py
+
+    # Run a single route variant at selected token counts
+    python bench_mxfp4_moe_sort_quant.py --routes 384,8 -t 1 8 32
+
+    # Save results to CSV
+    python bench_mxfp4_moe_sort_quant.py -o results.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.fused_moe import (
+    _USE_CK_MOE_SORTING,
+    _USE_FLYDSL_MOE_SORTING,
+    moe_sorting,
+)
+from aiter.ops.quant import fused_dynamic_mxfp4_quant_moe_sort, mxfp4_moe_sort_fwd
+
+DEVICE = "cuda"
+
+# Default sweep parameters (Kimi K2 TP8 shard)
+MODEL_DIM = 7168
+BLOCK_M = 32
+TOKENS = [1, 2, 4, 8, 16, 32, 64, 128]
+ROUTES = [(384, 8), (385, 9)]
+
+
+def time_graph(fn, iters: int, warmup: int, reps: int) -> float:
+    """CUDA-graph capture `fn`, then return the best per-replay time in us."""
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fn()
+
+    best = float("inf")
+    for _ in range(reps):
+        for _ in range(warmup):
+            graph.replay()
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            graph.replay()
+        end.record()
+        torch.cuda.synchronize()
+        best = min(best, start.elapsed_time(end) / iters * 1000.0)
+    return best
+
+
+def make_inputs(tokens: int, experts: int, topk: int, model_dim: int):
+    """Build hidden states and a route assignment for `experts`/`topk`.
+
+    When `experts` exceeds the 384 routed experts the last slot is pinned to the
+    fused shared expert, matching how the Kimi E=385/topk=9 config routes.
+    """
+    torch.manual_seed(1000 + tokens)
+    hidden = torch.randn((tokens, model_dim), dtype=dtypes.bf16, device=DEVICE)
+    routed = 384
+    if experts == routed:
+        topk_ids = torch.stack(
+            [
+                torch.randperm(experts, dtype=dtypes.i32, device=DEVICE)[:topk]
+                for _ in range(tokens)
+            ]
+        )
+        topk_weights = torch.rand((tokens, topk), dtype=dtypes.fp32, device=DEVICE)
+    else:
+        routed_ids = torch.stack(
+            [
+                torch.randperm(routed, dtype=dtypes.i32, device=DEVICE)[: topk - 1]
+                for _ in range(tokens)
+            ]
+        )
+        shared_id = torch.full((tokens, 1), routed, dtype=dtypes.i32, device=DEVICE)
+        topk_ids = torch.cat((routed_ids, shared_id), dim=1)
+        topk_weights = torch.cat(
+            (
+                torch.rand((tokens, topk - 1), dtype=dtypes.fp32, device=DEVICE),
+                torch.ones((tokens, 1), dtype=dtypes.fp32, device=DEVICE),
+            ),
+            dim=1,
+        )
+    return hidden, topk_ids, topk_weights
+
+
+def bench_sort_quant_latency(
+    tokens: int,
+    experts: int,
+    topk: int,
+    model_dim: int = MODEL_DIM,
+    block_m: int = BLOCK_M,
+    iters: int = 300,
+    warmup: int = 30,
+    reps: int = 3,
+) -> tuple[float, float, float, float]:
+    """
+    Benchmark the pre-GEMM plumbing variants.
+
+    Returns:
+        Tuple of (sort only, baseline sort+quant, fused, fused+sorted scale)
+        latencies in microseconds.
+    """
+    hidden, topk_ids, topk_weights = make_inputs(tokens, experts, topk, model_dim)
+
+    def baseline_sort():
+        return moe_sorting(
+            topk_ids, topk_weights, experts, model_dim, dtypes.bf16, block_m
+        )
+
+    def baseline_sort_quant():
+        _ids, weights, _exp, num_valid, _buf = baseline_sort()
+        fused_dynamic_mxfp4_quant_moe_sort(
+            hidden,
+            sorted_ids=_ids,
+            num_valid_ids=num_valid,
+            token_num=tokens,
+            topk=topk,
+            block_size=block_m,
+            sorted_weights=weights,
+        )
+
+    # Output buffers for the fused kernel, laid out as aiter.fused_moe allocates them.
+    route_count = tokens * topk
+    active_experts = min(experts, route_count)
+    max_sorted = (
+        (route_count + active_experts * (block_m - 1) + block_m - 1)
+        // block_m
+        * block_m
+    )
+    sorted_ids = torch.empty(max_sorted, dtype=dtypes.i32, device=DEVICE)
+    sorted_weights = torch.empty(max_sorted, dtype=dtypes.fp32, device=DEVICE)
+    sorted_expert_ids = torch.empty(
+        max_sorted // block_m, dtype=dtypes.i32, device=DEVICE
+    )
+    num_valid_ids = torch.empty(2, dtype=dtypes.i32, device=DEVICE)
+    moe_buf = torch.empty((tokens, model_dim), dtype=dtypes.bf16, device=DEVICE)
+    act_quant = torch.empty((tokens, model_dim // 2), dtype=dtypes.fp4x2, device=DEVICE)
+    act_scale = torch.empty(
+        (tokens, model_dim // 32), dtype=dtypes.fp8_e8m0, device=DEVICE
+    )
+
+    def fused():
+        aiter.mxfp4_moe_sort_quant_fwd(
+            hidden,
+            topk_ids,
+            topk_weights,
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            num_valid_ids,
+            moe_buf,
+            act_quant,
+            act_scale,
+            experts,
+        )
+
+    fused()
+    torch.cuda.synchronize()
+
+    def fused_sorted_scale():
+        fused()
+        mxfp4_moe_sort_fwd(
+            act_scale,
+            sorted_ids=sorted_ids,
+            num_valid_ids=num_valid_ids,
+            token_num=tokens,
+            cols=model_dim,
+        )
+
+    return (
+        time_graph(baseline_sort, iters, warmup, reps),
+        time_graph(baseline_sort_quant, iters, warmup, reps),
+        time_graph(fused, iters, warmup, reps),
+        time_graph(fused_sorted_scale, iters, warmup, reps),
+    )
+
+
+def run_benchmark(args):
+    """Run the plumbing benchmark across every route variant and token count."""
+    print(f"arch: {torch.cuda.get_device_properties(0).gcnArchName}")
+    print(f"flydsl_sorting={_USE_FLYDSL_MOE_SORTING} ck_sorting={_USE_CK_MOE_SORTING}")
+
+    results = []
+    for experts, topk in args.routes:
+        print(
+            f"\n=== E={experts} topk={topk} model_dim={args.model_dim} "
+            f"block_m={args.block_m} (us) ==="
+        )
+        header = (
+            f"{'M':>8} {'sort':>10} {'sort+quant':>12} {'fused':>10} "
+            f"{'fused+ss':>10} {'fused':>8} {'fused+ss':>10}"
+        )
+        print(header)
+        print("-" * len(header))
+
+        for tokens in args.tokens:
+            sort_us, base_us, fused_us, ss_us = bench_sort_quant_latency(
+                tokens,
+                experts,
+                topk,
+                model_dim=args.model_dim,
+                block_m=args.block_m,
+                iters=args.iters,
+                warmup=args.warmup,
+                reps=args.reps,
+            )
+            results.append((experts, topk, tokens, sort_us, base_us, fused_us, ss_us))
+            print(
+                f"{tokens:>8} {sort_us:>10.2f} {base_us:>12.2f} {fused_us:>10.2f} "
+                f"{ss_us:>10.2f} {base_us / fused_us:>7.2f}x "
+                f"{base_us / ss_us:>9.2f}x"
+            )
+
+    if args.o:
+        _save_results_csv(args.o, results)
+
+
+def _save_results_csv(filepath: str, results: list):
+    """Save benchmark results to CSV file."""
+    path = Path(filepath)
+    with open(path, "w") as f:
+        f.write(
+            "experts,topk,tokens,sort_us,baseline_sort_quant_us,fused_us,"
+            "fused_sorted_scale_us,speedup_fused,speedup_fused_sorted_scale\n"
+        )
+        f.writelines(
+            f"{experts},{topk},{tokens},{sort_us:.4f},{base_us:.4f},"
+            f"{fused_us:.4f},{ss_us:.4f},"
+            f"{base_us / fused_us:.4f},{base_us / ss_us:.4f}\n"
+            for experts, topk, tokens, sort_us, base_us, fused_us, ss_us in results
+        )
+    print(f"\nResults saved to {path.resolve()}")
+
+
+def _route(value: str) -> tuple[int, int]:
+    experts, topk = value.split(",")
+    return int(experts), int(topk)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark MXFP4 MoE Fused Sort+Quant",
+        description=(
+            "Benchmark the fused MoE route-sort + MXFP4 activation-quant kernel "
+            "against the conventional two-launch sequence."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-t",
+        "--tokens",
+        type=int,
+        nargs="+",
+        default=TOKENS,
+        help="Token counts to sweep.",
+    )
+    parser.add_argument(
+        "--routes",
+        type=_route,
+        nargs="+",
+        metavar="E,TOPK",
+        default=ROUTES,
+        help="Route variants as comma-separated expert/topk pairs.",
+    )
+    parser.add_argument(
+        "--model-dim",
+        type=int,
+        dest="model_dim",
+        default=MODEL_DIM,
+        help="Model hidden dimension.",
+    )
+    parser.add_argument(
+        "--block-m",
+        type=int,
+        dest="block_m",
+        default=BLOCK_M,
+        help="Sort block size M.",
+    )
+    parser.add_argument(
+        "-o",
+        type=str,
+        metavar="FILE",
+        help="Output CSV file path for results.",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=300,
+        help="Number of graph replays per timed rep.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=30,
+        help="Number of warmup replays before each timed rep.",
+    )
+    parser.add_argument(
+        "--reps",
+        type=int,
+        default=3,
+        help="Number of timed reps; the best is reported.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    run_benchmark(parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/test_mxfp4_fused_sort_quant.py
+++ b/op_tests/test_mxfp4_fused_sort_quant.py
@@ -12,7 +12,13 @@ from aiter.fused_moe import (
     _is_fused_decode_sort_quant_enabled,
     moe_sorting,
 )
-from aiter.ops.quant import fused_dynamic_mxfp4_quant_moe_sort, per_1x32_f4_quant_hip
+from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1
+from aiter.ops.quant import (
+    fused_dynamic_mxfp4_quant_moe_sort,
+    mxfp4_moe_sort_fwd,
+    per_1x32_f4_quant_hip,
+)
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="ROCm/CUDA device is required"
@@ -267,3 +273,140 @@ def test_fused_sort_quant_is_cuda_graph_replay_safe(experts, topk):
 
     assert int(fused[3][1].item()) == 4
     torch.testing.assert_close(fused[4], torch.zeros_like(fused[4]))
+
+
+@pytest.mark.parametrize("out_dtype", ["bf16", "fp4"])
+@pytest.mark.parametrize("k_wave", [1, 2, 4])
+def test_flydsl_compact_scale_consumer_matches_conventional_layout(k_wave, out_dtype):
+    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "").split(":")[0]
+    if arch != "gfx950":
+        pytest.skip("compact-scale FlyDSL consumer is currently gfx950-only")
+
+    # Use Kimi's production K dimension. In particular, kw4 traverses seven
+    # K tiles per wave and exercises the compact-scale main loop plus odd tail.
+    tokens, hidden_size, inter_dim, experts, topk = 8, HIDDEN, 128, 16, 4
+    torch.manual_seed(20260715)
+    hidden = (
+        torch.randn((tokens, hidden_size), dtype=torch.bfloat16, device="cuda") * 0.1
+    )
+    topk_ids = torch.stack(
+        [
+            torch.randperm(experts, dtype=torch.int32, device="cuda")[:topk]
+            for _ in range(tokens)
+        ]
+    )
+    topk_weights = torch.rand((tokens, topk), dtype=torch.float32, device="cuda")
+    sorted_ids, _, sorted_experts, num_valid_ids, _ = moe_sorting(
+        topk_ids,
+        topk_weights,
+        experts,
+        hidden_size,
+        dtypes.bf16,
+        BLOCK_M,
+    )
+
+    activation_quant, compact_scale = per_1x32_f4_quant_hip(hidden, shuffle=False)
+    conventional_scale = mxfp4_moe_sort_fwd(
+        compact_scale,
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=tokens,
+        cols=hidden_size,
+    )
+
+    quantize = aiter.get_torch_quant(aiter.QuantType.per_1x32)
+    weight = (
+        torch.randn(
+            (experts, 2 * inter_dim, hidden_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        * 0.1
+    )
+    weight_quant, weight_scale = quantize(weight, quant_dtype=dtypes.fp4x2)
+    weight_quant = weight_quant.view(experts, 2 * inter_dim, hidden_size // 2)
+    weight_quant = shuffle_weight_a16w4(weight_quant, 16, True)
+    weight_scale = shuffle_scale_a16w4(weight_scale, experts, True)
+
+    kwargs = {
+        "a": activation_quant,
+        "w1": weight_quant,
+        "sorted_token_ids": sorted_ids,
+        "sorted_expert_ids": sorted_experts,
+        "num_valid_ids": num_valid_ids,
+        "out": None,
+        "topk": topk,
+        "tile_m": 32,
+        "tile_n": 32,
+        "tile_k": 256,
+        "a_dtype": "fp4",
+        "b_dtype": "fp4",
+        "out_dtype": out_dtype,
+        "act": "silu",
+        "w1_scale": weight_scale,
+        "sorted_weights": None,
+        "use_async_copy": True,
+        "waves_per_eu": 3,
+        "b_nt": 2,
+        "gate_mode": "separated",
+        "k_wave": k_wave,
+    }
+    reference = flydsl_moe_stage1(
+        a1_scale=conventional_scale,
+        a_scale_compact=False,
+        **kwargs,
+    )
+    compact = flydsl_moe_stage1(
+        a1_scale=compact_scale,
+        a_scale_compact=True,
+        **kwargs,
+    )
+    torch.cuda.synchronize()
+
+    def assert_outputs_equal(actual, expected):
+        if out_dtype == "bf16":
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+            return
+
+        actual_out, actual_scale = actual
+        expected_out, expected_scale = expected
+        torch.testing.assert_close(
+            actual_out.view(torch.uint8),
+            expected_out.view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        num_sorted = int(num_valid_ids[0].item())
+        valid_rows = sorted_ids[:num_sorted].bitwise_and(0x00FFFFFF) != tokens
+        scale_cols = inter_dim // 32
+        padded_scale_cols = (scale_cols + 7) // 8 * 8
+        row = valid_rows.nonzero().flatten().unsqueeze(1)
+        col = torch.arange(scale_cols, device="cuda").unsqueeze(0)
+        scale_positions = (
+            (row >> 5) * (padded_scale_cols * 32)
+            + (col >> 3) * 256
+            + (col & 3) * 64
+            + (row & 15) * 4
+            + ((col >> 2) & 1) * 2
+            + ((row >> 4) & 1)
+        ).flatten()
+        torch.testing.assert_close(
+            actual_scale.view(torch.uint8).flatten()[scale_positions],
+            expected_scale.view(torch.uint8).flatten()[scale_positions],
+            rtol=0,
+            atol=0,
+        )
+
+    assert_outputs_equal(compact, reference)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        replayed = flydsl_moe_stage1(
+            a1_scale=compact_scale,
+            a_scale_compact=True,
+            **kwargs,
+        )
+    graph.replay()
+    graph.replay()
+    torch.cuda.synchronize()
+    assert_outputs_equal(replayed, reference)

--- a/op_tests/test_mxfp4_fused_sort_quant.py
+++ b/op_tests/test_mxfp4_fused_sort_quant.py
@@ -7,7 +7,11 @@ import torch
 
 import aiter
 from aiter import dtypes
-from aiter.fused_moe import moe_sorting
+from aiter.fused_moe import (
+    _fused_decode_sort_quant,
+    _is_fused_decode_sort_quant_enabled,
+    moe_sorting,
+)
 from aiter.ops.quant import fused_dynamic_mxfp4_quant_moe_sort, per_1x32_f4_quant_hip
 
 pytestmark = pytest.mark.skipif(
@@ -181,6 +185,68 @@ def test_fused_sort_quant_matches_opus_and_generic_quant(tokens, experts, topk):
         compact_scale.view(torch.uint8),
         rtol=0,
         atol=0,
+    )
+
+
+@pytest.mark.parametrize("tokens", [2, 4])
+def test_fused_decode_sort_quant_returns_sorted_scale(tokens):
+    hidden, topk_ids, topk_weights = _make_inputs(tokens, 384, 8)
+    result = _fused_decode_sort_quant(
+        hidden,
+        topk_ids,
+        topk_weights,
+        model_dim=HIDDEN,
+        global_experts=384,
+        block_m=BLOCK_M,
+        moebuf_dtype=torch.bfloat16,
+        accumulate=True,
+    )
+    activation_scale = result[-1]
+    assert activation_scale.shape[0] == result[0].shape[0]
+    assert activation_scale.shape[1] == HIDDEN // 32
+
+
+@pytest.mark.parametrize(
+    "experts, topk, tokens, expected",
+    [
+        pytest.param(384, 8, 100, True, id="non_power_of_2_m_accepted"),
+        pytest.param(256, 8, 8, True, id="e256_route_accepted"),
+        pytest.param(384, 6, 8, False, id="uninstantiated_topk"),
+        pytest.param(512, 8, 8, False, id="uninstantiated_experts"),
+        pytest.param(384, 8, 129, False, id="m_above_kernel_contract"),
+    ],
+)
+def test_fused_decode_sort_quant_gate(monkeypatch, experts, topk, tokens, expected):
+    """The gate must reject anything the kernel is not instantiated for.
+
+    ``AITER_CHECK`` aborts the process instead of raising, so an unsupported
+    shape reaching the op is fatal -- this gate is the only guard.
+    """
+    if aiter.get_gfx() != "gfx950":
+        pytest.skip("fused sort+quant is gfx950-only")
+    monkeypatch.setenv("SGLANG_AITER_FUSED_DECODE_SORT_QUANT", "auto")
+    hidden, topk_ids, topk_weights = _make_inputs(tokens, min(experts, 384), topk)
+    assert (
+        _is_fused_decode_sort_quant_enabled(
+            hidden,
+            topk_ids,
+            topk_weights,
+            global_experts=experts,
+            block_m=BLOCK_M,
+            quant_type=aiter.QuantType.per_1x32,
+            q_dtype_a=dtypes.fp4x2,
+            q_dtype_w=dtypes.fp4x2,
+            activation=aiter.ActivationType.Silu,
+            is_g1u1=True,
+            expert_mask=None,
+            num_local_tokens=None,
+            need_local_topk_ids=False,
+            run_1stage=False,
+            stage1_is_flydsl=True,
+            hidden_pad=0,
+            ksplit=0,
+        )
+        is expected
     )
 
 

--- a/op_tests/test_mxfp4_fused_sort_quant.py
+++ b/op_tests/test_mxfp4_fused_sort_quant.py
@@ -22,8 +22,28 @@ from aiter.ops.quant import (
 )
 from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
 
+
+def _running_on_gfx950() -> bool:
+    """True only on a live ROCm gfx950 device.
+
+    Everything under test lowers to the scalef32 fp4-cvt instructions, which
+    exist only on gfx950 and trap elsewhere -- so gating on
+    ``torch.cuda.is_available()`` alone would let this suite run, and fault, on
+    NVIDIA or on an earlier CDNA part. ``get_gfx_runtime`` rather than
+    ``get_gfx`` because the latter honours ``GPU_ARCHS`` and can name an arch
+    that is not the one installed.
+    """
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        return False
+    try:
+        return aiter.get_gfx_runtime() == "gfx950"
+    except (KeyError, OSError, RuntimeError):
+        # Unrecognized arch, or no rocminfo to ask -- either way, not gfx950.
+        return False
+
+
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="ROCm/CUDA device is required"
+    not _running_on_gfx950(), reason="a ROCm gfx950 device is required"
 )
 
 HIDDEN = 7168
@@ -239,8 +259,6 @@ def test_compact_scale_gate_covers_every_tuned_decode_row(
     because the sorted-scale expansion launch disappears -- so the gate must not
     exclude them.
     """
-    if aiter.get_gfx() != "gfx950":
-        pytest.skip("fused sort+quant is gfx950-only")
     monkeypatch.setenv("SGLANG_AITER_FUSED_DECODE_COMPACT_SCALE", "auto")
     metadata = get_2stage_cfgs(
         tokens,
@@ -277,8 +295,6 @@ def test_fused_decode_sort_quant_gate(monkeypatch, experts, topk, tokens, expect
     ``AITER_CHECK`` aborts the process instead of raising, so an unsupported
     shape reaching the op is fatal -- this gate is the only guard.
     """
-    if aiter.get_gfx() != "gfx950":
-        pytest.skip("fused sort+quant is gfx950-only")
     monkeypatch.setenv("SGLANG_AITER_FUSED_DECODE_SORT_QUANT", "auto")
     hidden, topk_ids, topk_weights = _make_inputs(tokens, min(experts, 384), topk)
     assert (
@@ -305,6 +321,46 @@ def test_fused_decode_sort_quant_gate(monkeypatch, experts, topk, tokens, expect
     )
 
 
+@pytest.mark.parametrize(
+    "runtime_arch", ["gfx942", None], ids=["unsupported", "detection_failure"]
+)
+def test_fused_decode_sort_quant_gate_uses_runtime_arch(monkeypatch, runtime_arch):
+    """Runtime dispatch must ignore a potentially different build target."""
+    monkeypatch.setenv("SGLANG_AITER_FUSED_DECODE_SORT_QUANT", "auto")
+    if runtime_arch is None:
+
+        def detect_runtime_arch():
+            raise RuntimeError("runtime architecture unavailable")
+
+    else:
+
+        def detect_runtime_arch():
+            return runtime_arch
+
+    monkeypatch.setattr("aiter.fused_moe.get_gfx_runtime", detect_runtime_arch)
+    hidden, topk_ids, topk_weights = _make_inputs(8, 384, 8)
+
+    assert not _is_fused_decode_sort_quant_enabled(
+        hidden,
+        topk_ids,
+        topk_weights,
+        global_experts=384,
+        block_m=BLOCK_M,
+        quant_type=aiter.QuantType.per_1x32,
+        q_dtype_a=dtypes.fp4x2,
+        q_dtype_w=dtypes.fp4x2,
+        activation=aiter.ActivationType.Silu,
+        is_g1u1=True,
+        expert_mask=None,
+        num_local_tokens=None,
+        need_local_topk_ids=False,
+        run_1stage=False,
+        stage1_is_flydsl=True,
+        hidden_pad=0,
+        ksplit=0,
+    )
+
+
 @pytest.mark.parametrize("experts, topk", ROUTE_VARIANTS)
 def test_fused_sort_quant_is_cuda_graph_replay_safe(experts, topk):
     hidden, topk_ids, topk_weights = _make_inputs(4, experts, topk)
@@ -327,10 +383,6 @@ def test_fused_sort_quant_is_cuda_graph_replay_safe(experts, topk):
 @pytest.mark.parametrize("out_dtype", ["bf16", "fp4"])
 @pytest.mark.parametrize("k_wave", [1, 2, 4])
 def test_flydsl_compact_scale_consumer_matches_conventional_layout(k_wave, out_dtype):
-    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "").split(":")[0]
-    if arch != "gfx950":
-        pytest.skip("compact-scale FlyDSL consumer is currently gfx950-only")
-
     # Use Kimi's production K dimension. In particular, kw4 traverses seven
     # K tiles per wave and exercises the compact-scale main loop plus odd tail.
     tokens, hidden_size, inter_dim, experts, topk = 8, HIDDEN, 128, 16, 4

--- a/op_tests/test_mxfp4_fused_sort_quant.py
+++ b/op_tests/test_mxfp4_fused_sort_quant.py
@@ -9,7 +9,9 @@ import aiter
 from aiter import dtypes
 from aiter.fused_moe import (
     _fused_decode_sort_quant,
+    _is_fused_decode_compact_scale_enabled,
     _is_fused_decode_sort_quant_enabled,
+    get_2stage_cfgs,
     moe_sorting,
 )
 from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1
@@ -210,6 +212,53 @@ def test_fused_decode_sort_quant_returns_sorted_scale(tokens):
     activation_scale = result[-1]
     assert activation_scale.shape[0] == result[0].shape[0]
     assert activation_scale.shape[1] == HIDDEN // 32
+    compact_result = _fused_decode_sort_quant(
+        hidden,
+        topk_ids,
+        topk_weights,
+        model_dim=HIDDEN,
+        global_experts=384,
+        block_m=BLOCK_M,
+        moebuf_dtype=torch.bfloat16,
+        accumulate=True,
+        compact_scale=True,
+    )
+    compact_scale = compact_result[-1]
+    assert compact_scale.shape == (tokens, HIDDEN // 32)
+
+
+@pytest.mark.parametrize("experts, topk", [(384, 8), (256, 8)])
+@pytest.mark.parametrize("tokens", [1, 2, 4, 8, 16, 32, 64, 128])
+def test_compact_scale_gate_covers_every_tuned_decode_row(
+    monkeypatch, experts, topk, tokens
+):
+    """Compact scales must engage on the tuned row for every decode M.
+
+    The tuner picks multi-K-wave (``k_wave`` 2/4) stage-1 rows at M <= 8. Those
+    rows are slower in isolation with compact scales but faster end to end,
+    because the sorted-scale expansion launch disappears -- so the gate must not
+    exclude them.
+    """
+    if aiter.get_gfx() != "gfx950":
+        pytest.skip("fused sort+quant is gfx950-only")
+    monkeypatch.setenv("SGLANG_AITER_FUSED_DECODE_COMPACT_SCALE", "auto")
+    metadata = get_2stage_cfgs(
+        tokens,
+        HIDDEN,
+        256,
+        experts,
+        topk,
+        dtypes.bf16,
+        dtypes.fp4x2,
+        dtypes.fp4x2,
+        aiter.QuantType.per_1x32,
+        True,
+        aiter.ActivationType.Silu,
+        False,
+        0,
+        0,
+    )
+    assert _is_fused_decode_compact_scale_enabled(metadata, tokens)
 
 
 @pytest.mark.parametrize(

--- a/op_tests/test_mxfp4_fused_sort_quant.py
+++ b/op_tests/test_mxfp4_fused_sort_quant.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Regression tests for the fused route-sort + MXFP4 input quant kernel."""
+
+import pytest
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.fused_moe import moe_sorting
+from aiter.ops.quant import fused_dynamic_mxfp4_quant_moe_sort, per_1x32_f4_quant_hip
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="ROCm/CUDA device is required"
+)
+
+HIDDEN = 7168
+BLOCK_M = 32
+# The last expert of the (385, 9) route is a fused shared expert every token
+# is routed to; the other routes dispatch shared experts separately.
+FUSED_SHARED_ROUTE = (385, 9)
+ROUTE_VARIANTS = (
+    pytest.param(385, 9, id="fused_shared_e385_topk9"),
+    pytest.param(384, 8, id="separate_shared_e384_topk8"),
+    pytest.param(256, 8, id="separate_shared_e256_topk8"),
+)
+# Includes non-power-of-2 counts: the kernel's contract is M in [1, 128], not
+# a whitelist, and the tail handling differs for partial 32-row blocks.
+TOKEN_COUNTS = [1, 2, 3, 4, 8, 16, 17, 32, 64, 100, 127, 128]
+
+
+def _make_inputs(tokens: int, experts: int, topk: int):
+    torch.manual_seed(1000 + tokens)
+    hidden = torch.randn((tokens, HIDDEN), dtype=torch.bfloat16, device="cuda")
+    if (experts, topk) != FUSED_SHARED_ROUTE:
+        topk_ids = torch.stack(
+            [
+                torch.randperm(experts, dtype=torch.int32, device="cuda")[:topk]
+                for _ in range(tokens)
+            ]
+        )
+        topk_weights = torch.rand((tokens, topk), dtype=torch.float32, device="cuda")
+    else:
+        shared = experts - 1
+        routed_ids = torch.stack(
+            [
+                torch.randperm(shared, dtype=torch.int32, device="cuda")[: topk - 1]
+                for _ in range(tokens)
+            ]
+        )
+        topk_ids = torch.cat(
+            (
+                routed_ids,
+                torch.full((tokens, 1), shared, dtype=torch.int32, device="cuda"),
+            ),
+            dim=1,
+        )
+        topk_weights = torch.cat(
+            (
+                torch.rand((tokens, topk - 1), dtype=torch.float32, device="cuda"),
+                torch.ones((tokens, 1), dtype=torch.float32, device="cuda"),
+            ),
+            dim=1,
+        )
+    return hidden, topk_ids, topk_weights
+
+
+def _canonical_entries(sorted_ids, sorted_weights, sorted_experts, num_valid_ids):
+    valid, tokens = [int(v) for v in num_valid_ids.cpu().tolist()]
+    entries = []
+    for block, expert in enumerate(sorted_experts[: valid // BLOCK_M].cpu().tolist()):
+        for row in range(block * BLOCK_M, block * BLOCK_M + BLOCK_M):
+            packed = int(sorted_ids[row].item())
+            token = packed & 0x00FFFFFF
+            if token != tokens:
+                entries.append(
+                    (
+                        expert,
+                        token,
+                        (packed >> 24) & 0xFF,
+                        float(sorted_weights[row].item()),
+                    )
+                )
+    return sorted(entries)
+
+
+def _run_fused(hidden, topk_ids, topk_weights, experts):
+    tokens = hidden.shape[0]
+    route_count = topk_ids.numel()
+    active_experts = min(experts, route_count)
+    max_sorted = (
+        (route_count + active_experts * (BLOCK_M - 1) + BLOCK_M - 1)
+        // BLOCK_M
+        * BLOCK_M
+    )
+    sorted_ids = torch.empty(max_sorted, dtype=torch.int32, device="cuda")
+    sorted_weights = torch.empty(max_sorted, dtype=torch.float32, device="cuda")
+    sorted_experts = torch.empty(
+        (max_sorted + BLOCK_M - 1) // BLOCK_M, dtype=torch.int32, device="cuda"
+    )
+    num_valid_ids = torch.empty(2, dtype=torch.int32, device="cuda")
+    moe_buf = torch.empty((tokens, HIDDEN), dtype=torch.bfloat16, device="cuda")
+    activation_quant = torch.empty(
+        (tokens, HIDDEN // 2), dtype=dtypes.fp4x2, device="cuda"
+    )
+    activation_scale_token = torch.empty(
+        (tokens, HIDDEN // 32), dtype=dtypes.fp8_e8m0, device="cuda"
+    )
+    aiter.mxfp4_moe_sort_quant_fwd(
+        hidden,
+        topk_ids,
+        topk_weights,
+        sorted_ids,
+        sorted_weights,
+        sorted_experts,
+        num_valid_ids,
+        moe_buf,
+        activation_quant,
+        activation_scale_token,
+        experts,
+    )
+    return (
+        sorted_ids,
+        sorted_weights,
+        sorted_experts,
+        num_valid_ids,
+        moe_buf,
+        activation_quant,
+        activation_scale_token,
+    )
+
+
+@pytest.mark.parametrize("experts, topk", ROUTE_VARIANTS)
+@pytest.mark.parametrize("tokens", TOKEN_COUNTS)
+def test_fused_sort_quant_matches_opus_and_generic_quant(tokens, experts, topk):
+    hidden, topk_ids, topk_weights = _make_inputs(tokens, experts, topk)
+
+    ref_ids, ref_weights, ref_experts, ref_valid, _ = moe_sorting(
+        topk_ids,
+        topk_weights,
+        experts,
+        HIDDEN,
+        dtypes.bf16,
+        BLOCK_M,
+    )
+    ref_quant, _ = fused_dynamic_mxfp4_quant_moe_sort(
+        hidden,
+        sorted_ids=ref_ids,
+        num_valid_ids=ref_valid,
+        token_num=tokens,
+        topk=topk,
+        block_size=BLOCK_M,
+        sorted_weights=ref_weights,
+    )
+    compact_quant, compact_scale = per_1x32_f4_quant_hip(hidden, shuffle=False)
+    fused = _run_fused(hidden, topk_ids, topk_weights, experts)
+    torch.cuda.synchronize()
+
+    (
+        fused_ids,
+        fused_weights,
+        fused_experts,
+        fused_valid,
+        fused_moe_buf,
+        fused_quant,
+        fused_scale_token,
+    ) = fused
+    assert _canonical_entries(
+        ref_ids, ref_weights, ref_experts, ref_valid
+    ) == _canonical_entries(fused_ids, fused_weights, fused_experts, fused_valid)
+    torch.testing.assert_close(fused_valid, ref_valid, rtol=0, atol=0)
+    torch.testing.assert_close(fused_moe_buf, torch.zeros_like(fused_moe_buf))
+    torch.testing.assert_close(
+        fused_quant.view(torch.uint8), ref_quant.view(torch.uint8), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        fused_quant.view(torch.uint8), compact_quant.view(torch.uint8), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        fused_scale_token.view(torch.uint8),
+        compact_scale.view(torch.uint8),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("experts, topk", ROUTE_VARIANTS)
+def test_fused_sort_quant_is_cuda_graph_replay_safe(experts, topk):
+    hidden, topk_ids, topk_weights = _make_inputs(4, experts, topk)
+    # Compile/warm up before capture. The graph itself only records the
+    # fixed-address operator launch; all buffers are preallocated.
+    _run_fused(hidden, topk_ids, topk_weights, experts)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fused = _run_fused(hidden, topk_ids, topk_weights, experts)
+    graph.replay()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert int(fused[3][1].item()) == 4
+    torch.testing.assert_close(fused[4], torch.zeros_like(fused[4]))

--- a/op_tests/tuning_tests/test_fmoe_tune_objective.py
+++ b/op_tests/tuning_tests/test_fmoe_tune_objective.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Regression tests for the two-stage FMoE tuning objective.
+
+Stage-1 FlyDSL kernels whose name ends in ``_fp4``/``_fp8`` fuse the
+intermediate quantization that stage 2 consumes; every other stage-1 kernel
+needs a separate quant+sort launch. The tuner must therefore (a) dedupe the two
+paths independently, (b) charge the non-fused path for that extra launch, and
+(c) minimize the adjusted Stage1 + Stage2 latency. These tests pin that
+contract.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "csrc" / "ck_gemm_moe_2stages_codegen"))
+
+from gemm_moe_tune import (
+    FUSED_INTERMEDIATE_SUFFIXES,
+    FmoeTuner,
+    add_intermediate_quant_cost,
+    dedupe_objective_candidates,
+    select_fastest_stage_combination,
+)
+
+
+def _candidate(kernel_name, us, stage="stage1", block_m=32, flat=0):
+    return {
+        "stage": stage,
+        "block_m": block_m,
+        "flat": flat,
+        "kernelName": kernel_name,
+        "us": us,
+    }
+
+
+class TestDedupeObjectiveCandidates(unittest.TestCase):
+    def test_fused_and_non_fused_paths_survive_independently(self):
+        candidates = pd.DataFrame(
+            [
+                _candidate("flydsl_moe1_t32x32x256_fp4", 12.0),
+                _candidate("flydsl_moe1_t32x64x256_fp4", 15.0),
+                _candidate("flydsl_moe1_t32x128x256", 9.0),
+                _candidate("flydsl_moe1_t32x256x256", 11.0),
+            ]
+        )
+
+        kept = set(dedupe_objective_candidates(candidates)["kernelName"])
+
+        # Fastest of each path survives, even though the non-fused kernel is
+        # faster on raw us than either fused candidate.
+        self.assertEqual(
+            kept, {"flydsl_moe1_t32x32x256_fp4", "flydsl_moe1_t32x128x256"}
+        )
+
+    def test_dedupe_is_per_stage_and_block_m(self):
+        candidates = pd.DataFrame(
+            [
+                _candidate("k_a_fp4", 12.0, block_m=32),
+                _candidate("k_b_fp4", 10.0, block_m=64),
+                _candidate("k_c_fp4", 14.0, stage="stage2"),
+            ]
+        )
+
+        kept = dedupe_objective_candidates(candidates)
+
+        # Different (stage, block_m) groups are independent, so nothing is
+        # dropped here despite all three being fused kernels.
+        self.assertEqual(len(kept), 3)
+
+    def test_empty_frame_is_passed_through(self):
+        empty = pd.DataFrame(columns=["stage", "block_m", "flat", "kernelName", "us"])
+        self.assertTrue(dedupe_objective_candidates(empty).empty)
+
+    def test_helper_column_is_not_leaked(self):
+        candidates = pd.DataFrame([_candidate("k_a_fp4", 12.0)])
+        self.assertNotIn("_is_fused", dedupe_objective_candidates(candidates).columns)
+
+
+class TestAddIntermediateQuantCost(unittest.TestCase):
+    def _frame(self):
+        return pd.DataFrame(
+            [
+                {"block_m": 32, "kernelName1": "flydsl_moe1_a_fp4", "us1": 12.0},
+                {"block_m": 32, "kernelName1": "flydsl_moe1_b", "us1": 9.0},
+                {"block_m": 64, "kernelName1": "flydsl_moe1_c", "us1": 20.0},
+            ]
+        )
+
+    def test_only_non_fused_rows_are_charged(self):
+        charged = add_intermediate_quant_cost(self._frame(), "_fp4", {32: 4.0, 64: 5.0})
+
+        # Fused row untouched; non-fused rows pay their block_m's measured cost.
+        self.assertAlmostEqual(charged.loc[0, "us1"], 12.0)
+        self.assertAlmostEqual(charged.loc[1, "us1"], 13.0)
+        self.assertAlmostEqual(charged.loc[2, "us1"], 25.0)
+
+    def test_penalty_can_flip_the_winner(self):
+        charged = add_intermediate_quant_cost(self._frame(), "_fp4", {32: 4.0})
+        block32 = charged[charged["block_m"] == 32]
+        winner = block32.sort_values("us1").iloc[0]["kernelName1"]
+
+        # Non-fused wins on raw us (9.0 < 12.0) but loses once its separate
+        # quant+sort launch is accounted for.
+        self.assertEqual(winner, "flydsl_moe1_a_fp4")
+
+    def test_fp8_suffix_is_honoured(self):
+        frame = pd.DataFrame(
+            [
+                {"block_m": 32, "kernelName1": "flydsl_moe1_a_fp8", "us1": 12.0},
+                {"block_m": 32, "kernelName1": "flydsl_moe1_b", "us1": 9.0},
+            ]
+        )
+        charged = add_intermediate_quant_cost(frame, "_fp8", {32: 4.0})
+
+        self.assertAlmostEqual(charged.loc[0, "us1"], 12.0)
+        self.assertAlmostEqual(charged.loc[1, "us1"], 13.0)
+
+    def test_unmeasured_block_m_is_not_charged(self):
+        charged = add_intermediate_quant_cost(self._frame(), "_fp4", {32: 4.0})
+
+        # block_m=64 has no measurement; it must not become NaN.
+        self.assertAlmostEqual(charged.loc[2, "us1"], 20.0)
+
+    def test_missing_measurements_are_a_no_op(self):
+        frame = self._frame()
+        pd.testing.assert_frame_equal(
+            add_intermediate_quant_cost(frame, "_fp4", {}), frame
+        )
+
+    def test_input_frame_is_not_mutated(self):
+        frame = self._frame()
+        add_intermediate_quant_cost(frame, "_fp4", {32: 4.0})
+        self.assertAlmostEqual(frame.loc[1, "us1"], 9.0)
+
+
+class TestObjectiveContract(unittest.TestCase):
+    def test_shortest_stage_combination_wins(self):
+        candidates = pd.DataFrame(
+            [
+                {
+                    "kernelName1": "fast_stage1",
+                    "kernelName2": "slow_stage2",
+                    "us1": 5.0,
+                    "us2": 20.0,
+                },
+                {
+                    "kernelName1": "balanced_stage1",
+                    "kernelName2": "fast_stage2",
+                    "us1": 8.0,
+                    "us2": 10.0,
+                },
+                {
+                    "kernelName1": "one_stage",
+                    "kernelName2": None,
+                    "us1": 19.0,
+                    "us2": 0.0,
+                },
+            ]
+        )
+
+        winner = select_fastest_stage_combination(candidates)
+
+        self.assertEqual(winner["kernelName1"], "balanced_stage1")
+        self.assertEqual(winner["kernelName2"], "fast_stage2")
+        self.assertAlmostEqual(winner["us1"] + winner["us2"], 18.0)
+
+    def test_combination_selection_precedes_display_rounding(self):
+        candidates = pd.DataFrame(
+            [
+                {"kernelName1": "rounds_to_tie", "us1": 1.00004, "us2": 1.0},
+                {"kernelName1": "actually_fastest", "us1": 1.0, "us2": 1.0},
+            ]
+        )
+
+        winner = select_fastest_stage_combination(candidates)
+
+        self.assertEqual(winner["kernelName1"], "actually_fastest")
+
+    def test_fused_suffixes_cover_both_quant_dtypes(self):
+        self.assertEqual(set(FUSED_INTERMEDIATE_SUFFIXES), {"_fp4", "_fp8"})
+
+    def test_error_ratio_default_matches_cosine_gate(self):
+        # errRatio is a max accepted cosine_diff; 0.1 rejects broken kernels
+        # while tolerating lossy-but-correct fp4/fp8 MoE paths.
+        self.assertEqual(FmoeTuner.ARG_DEFAULTS["errRatio"], 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The gfx950 `flydsl_moe1_afp4_wfp4_*` decode path launches separate kernels to
sort routes, quantize BF16 activations, and expand per-token scales for GEMM1.
At small batches, this plumbing is launch-bound.

This PR adds an opt-in path that fuses sorting with activation quantization and
lets GEMM1 consume compact scales directly, removing two launches. It is
default-off and falls back to the existing path when ineligible.

## Technical Details

- Add `mxfp4_moe_sort_quant_fwd`, which fuses route sorting, BF16-to-MXFP4
  quantization, and routed-output zeroing.
- Add FlyDSL `a_scale_compact` support so GEMM1 reads per-token E8M0 scales
  without `mxfp4_moe_sort_fwd`.
- Preserve compact and conventional kernels under distinct cache names, with
  support for `k_wave` 1, 2, and 4.
- Make the tuner select the shortest adjusted Stage1 + Stage2 combination,
  including intermediate quantization costs for non-fused Stage1 kernels.
- Validate the live architecture, device placement, dtypes, and output-buffer
  sizes before launching the fused kernel.

The fused kernel is limited to gfx950, `model_dim=7168`, `block_m=32`,
`M in [1, 128]`, and `(num_experts, topk)` in `{(256, 8), (384, 8), (385, 9)}`.
The default dispatch uses it for `(256, 8)` and `(384, 8)`.

The newer MXMOE family selected for `(385, 9)` already performs inline
activation quantization and consumes compact scales in GEMM1, so it bypasses
this optimization. The `(385, 9)` kernel instantiation remains available to
callers that pin a compatible legacy config, but this PR makes no performance
claim for MXMOE.

Set `SGLANG_AITER_FUSED_DECODE_SORT_QUANT=auto` to enable the fused path.
`SGLANG_AITER_FUSED_DECODE_COMPACT_SCALE` controls compact scale consumption and
inherits the sort/quant setting when unset.

## Test Plan

```bash
pytest op_tests/test_mxfp4_fused_sort_quant.py -v
pytest op_tests/tuning_tests/test_fmoe_tune_objective.py -v
python op_tests/op_benchmarks/hip/bench_mxfp4_moe_decode_layer.py --reps 2
```

The GPU suite compares routing metadata and quantized outputs with the existing
operators, checks compact-scale GEMM1 for `k_wave` 1/2/4, exercises CUDA Graph
replay, and covers the Python dispatch gates.

## Test Result

- `op_tests/test_mxfp4_fused_sort_quant.py`: 70 passed on gfx950.
- `op_tests/tuning_tests/test_fmoe_tune_objective.py`: 14 passed.
- `ruff` and `black`: clean.

The end-to-end results below are only for `(E, topk) = (384, 8)`. Dispatch
inspection confirmed that every row used this PR's fused kernel and compact
scale consumer; MXMOE results are intentionally excluded.

| M | Baseline (us) | Fused + compact (us) | Speedup |
|---:|---:|---:|---:|
| 1 | 35.76 | 27.00 | 1.32x |
| 2 | 41.61 | 31.30 | 1.33x |
| 4 | 49.63 | 40.04 | 1.24x |
| 8 | 65.20 | 51.93 | 1.26x |
| 16 | 86.19 | 77.46 | 1.11x |
| 32 | 115.00 | 108.21 | 1.06x |
| 64 | 161.75 | 163.78 | 0.99x |
| 128 | 193.85 | 189.09 | 1.03x |

This is a 1.06-1.33x improvement for `M <= 32`; `M=64/128` is neutral within
run-to-run noise. Accuracy remained in the same range as the baseline.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
