### PR TITLE
[Bugfix][Triton] Set the _get_config memo only after the config JSON loads

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/extend_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/extend_attention.py
@@ -323,7 +323,6 @@ def _fwd_kernel(
 def _get_config(HEAD_SIZE, dtype):
     if not hasattr(_get_config, "_config_dict"):
         dev = arch_info.get_arch()
-        _get_config._config_dict = {}
         fpath = f"{AITER_TRITON_CONFIGS_PATH}/{dev}-EXTEND_ATTENTION.json"
         with open(fpath, "r") as file:
             config = json.load(file)

--- a/aiter/ops/triton/_triton_kernels/attention/mha.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha.py
@@ -938,11 +938,10 @@ def _get_config(
 ):
     if not hasattr(_get_config, "_config_dict"):
         dev = arch_info.get_arch()
-        _get_config._config_dict = {}
         fpath = f"{AITER_TRITON_CONFIGS_PATH}/{dev}-MHA-DEFAULT.json"
         with open(fpath, "r") as file:
             config = json.load(file)
-        _get_config._config_dict["default"] = config
+        _get_config._config_dict = {"default": config}
     fwd_cfg = _get_config._config_dict["default"]["fwd"]
     has_dropout_or_fp32 = enable_dropout or dtype == torch.float32
     # TODO: pe + dropout is not tuned

--- a/aiter/ops/triton/_triton_kernels/attention/mha_fused_bwd.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha_fused_bwd.py
@@ -1064,7 +1064,6 @@ def _bwd_kernel_dkdvdq_noncausal(
 def _get_config():
     if not hasattr(_get_config, "_config_dict"):
         dev = arch_info.get_arch()
-        _get_config._config_dict = {}
         fpath = f"{AITER_TRITON_CONFIGS_PATH}/{dev}-MHA-DEFAULT.json"
         with open(fpath, "r") as file:
             config = json.load(file)

--- a/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py
@@ -1771,7 +1771,6 @@ def bwd_kernel_noncausal(
 def _get_config():
     if not hasattr(_get_config, "_config_dict"):
         dev = arch_info.get_arch()
-        _get_config._config_dict = {}
         fpath = f"{AITER_TRITON_CONFIGS_PATH}/{dev}-MHA-DEFAULT.json"
         with open(fpath, "r") as file:
             config = json.load(file)

--- a/aiter/ops/triton/_triton_kernels/attention/mla_decode_rope.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mla_decode_rope.py
@@ -406,7 +406,6 @@ def _fwd_kernel_stage2(
 def _get_config():
     if not hasattr(_get_config, "_config_dict"):
         dev = arch_info.get_arch()
-        _get_config._config_dict = {}
         fpath = f"{AITER_TRITON_CONFIGS_PATH}/{dev}-MLA_DECODE_ROPE-DEFAULT.json"
         with open(fpath, "r") as file:
             config = json.load(file)

--- a/aiter/ops/triton/_triton_kernels/moe/moe_routing_sigmoid_top1_fused.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_routing_sigmoid_top1_fused.py
@@ -129,7 +129,6 @@ def _routing_sigmoid_top1_kernel(
 def _get_config(M, N, K):
     if not hasattr(_get_config, "_config_dict"):
         dev = arch_info.get_arch()
-        _get_config._config_dict = {}
         fpath = f"{AITER_TRITON_CONFIGS_PATH}/moe/{dev}-MOE_ROUTING_SIGMOID_TOPK1.json"
         with open(fpath, "r") as file:
             config = json.load(file)

--- a/aiter/ops/triton/gluon/gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/gluon/gemm_a8w8_blockscale.py
@@ -993,13 +993,12 @@ def _get_config(
             raise ValueError(
                 "Gluon implementation is not supported on this device (requires CDNA4)."
             )
-        _get_config._config_dict = {}
         fpath = (
             f"{AITER_TRITON_CONFIGS_PATH}/gemm/gluon/{dev}-GEMM-A8W8_BLOCKSCALE.json"
         )
         with open(fpath, "r") as file:
             config = json.load(file)
-        _get_config._config_dict["default"] = config
+        _get_config._config_dict = {"default": config}
 
     key = f"{N}_{K}"
     if key not in _get_config._config_dict:

--- a/op_tests/triton_tests/test_config_load_failure.py
+++ b/op_tests/triton_tests/test_config_load_failure.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+"""A failed config load must not leave ``_get_config`` memoized in a partial state.
+
+These ``_get_config`` helpers cache the parsed JSON on the function object and guard the
+load with ``hasattr``. If the attribute is created before the file is read, a failed read
+leaves an empty memo behind, ``lru_cache`` does not cache the exception, and every later
+call skips the load and raises something unrelated -- hiding which file was missing.
+
+Needs no tuned config and no particular GPU: the configs directory is redirected to an
+empty temporary directory, so the load fails for the arch actually under test.
+"""
+
+import importlib
+
+import pytest
+import torch
+
+# module -> arguments its _get_config takes
+CONFIG_LOADERS = {
+    "aiter.ops.triton._triton_kernels.attention.mha": (False, torch.float16),
+    "aiter.ops.triton._triton_kernels.attention.mha_fused_bwd": (),
+    "aiter.ops.triton._triton_kernels.attention.mha_onekernel_bwd": (),
+    "aiter.ops.triton._triton_kernels.attention.extend_attention": (128, torch.float16),
+    "aiter.ops.triton._triton_kernels.attention.mla_decode_rope": (),
+    "aiter.ops.triton._triton_kernels.moe.moe_routing_sigmoid_top1_fused": (
+        128,
+        16,
+        128,
+    ),
+}
+
+
+@pytest.mark.parametrize("module_name", CONFIG_LOADERS)
+def test_missing_config_raises_the_same_error_every_call(
+    module_name, tmp_path, monkeypatch
+):
+    module = importlib.import_module(module_name)
+    args = CONFIG_LOADERS[module_name]
+
+    monkeypatch.setattr(module, "AITER_TRITON_CONFIGS_PATH", str(tmp_path))
+    try:
+        if hasattr(module._get_config, "_config_dict"):
+            del module._get_config._config_dict
+        module._get_config.cache_clear()
+
+        with pytest.raises(FileNotFoundError) as first:
+            module._get_config(*args)
+        with pytest.raises(FileNotFoundError) as second:
+            module._get_config(*args)
+
+        assert str(first.value) == str(second.value)
+    finally:
+        # Never leave a memo built against tmp_path behind for the rest of the session.
+        if hasattr(module._get_config, "_config_dict"):
+            del module._get_config._config_dict
+        module._get_config.cache_clear()


### PR DESCRIPTION
## Motivation

When a Triton op has no config JSON for the running architecture, the first call reports the real error and every call after it reports a misleading one.

```
call 1: FileNotFoundError: .../aiter/ops/triton/configs/gfx1101-MHA-DEFAULT.json
call 2: KeyError: 'default'
```

The second message is the one users see and report, because retries, later layers and test suites rarely stop at the first exception. It names an internal dict key instead of the missing file, so it sends people looking in the wrong place.

This is not specific to one architecture or to a missing file: it happens on any arch, for any op whose config file cannot be read or parsed.

## Technical Details

Seven `_get_config` helpers memoize their parsed config on the function object and guard the load with `hasattr`:

```python
@functools.lru_cache(maxsize=1024)
def _get_config(enable_dropout, dtype, has_pe=False):
    if not hasattr(_get_config, "_config_dict"):
        dev = arch_info.get_arch()
        _get_config._config_dict = {}          # published before the load
        fpath = f"{AITER_TRITON_CONFIGS_PATH}/{dev}-MHA-DEFAULT.json"
        with open(fpath, "r") as file:         # may raise
            config = json.load(file)
        _get_config._config_dict["default"] = config
    fwd_cfg = _get_config._config_dict["default"]["fwd"]
```

`functools.lru_cache` does not cache exceptions, so the next call re-enters the body — but
`hasattr` is now `True`, the load block is skipped, and the caller reads an empty dict.

Affected sites and what the second call reports today:

| File | Second call raises |
| --- | --- |
| `aiter/ops/triton/_triton_kernels/attention/mha.py` | `KeyError: 'default'` |
| `aiter/ops/triton/_triton_kernels/attention/mha_fused_bwd.py` | `KeyError: 'bkwd_fused'` |
| `aiter/ops/triton/_triton_kernels/attention/mha_onekernel_bwd.py` | `KeyError: 'bkwd_onekernel'` |
| `aiter/ops/triton/_triton_kernels/attention/extend_attention.py` | `KeyError: 'default'` |
| `aiter/ops/triton/_triton_kernels/attention/mla_decode_rope.py` | nothing — returns `{}` |
| `aiter/ops/triton/_triton_kernels/moe/moe_routing_sigmoid_top1_fused.py` | `KeyError: 'N16'` |
| `aiter/ops/triton/gluon/gemm_a8w8_blockscale.py` | `KeyError: 'default'` |

`mla_decode_rope` is the one worth a second look: it hands an empty config back to the caller without raising, so the failure surfaces later as a missing kernel parameter.

The fix publishes the memo only once there is something to publish. Two shapes, `+2/-9` in total:

* Five of the sites already end with a whole-dict assignment (`_get_config._config_dict = config`),   which means the earlier `= {}` is dead code on the success path — it is overwritten three lines later. Those lines are simply removed.
* `mha.py` and `gluon/gemm_a8w8_blockscale.py` build into the dict, so the two statements fold into one: `_get_config._config_dict = {"default": config}`.

No behaviour changes on any path where the config loads.

This is the same family as #2169 (merged), which stopped `get_gemm_config` from leaking cached state into callers. That one was about a caller mutating the cached dict; this one is about an exception leaving a half-built memo behind.

## Test Plan

New test: `op_tests/triton_tests/test_config_load_failure.py`, parametrised over the six sites whose failure path is arch-independent. For each one it points `AITER_TRITON_CONFIGS_PATH` at pytest's `tmp_path` and asserts that **two consecutive calls raise the same `FileNotFoundError`**.

It needs no tuned config and no particular GPU — the load fails for whichever architecture is running, so it exercises the fix on CDNA as well. It also clears the memo in a `finally` block so it cannot affect later tests in the same session.

`gluon/gemm_a8w8_blockscale.py` is fixed but not covered by the test: its load sits behind a `gfx < 950` check, so whether the failure path is reachable depends on the running architecture, and a test whose outcome depends on that does not belong in the suite.

Also run: a standalone reproducer that calls each of the seven `_get_config` helpers twice in a fresh subprocess, with an option to override the reported architecture so the missing-config condition can be produced on **any** GPU, including ones that ship every config.

## Test Result

Environment: Radeon RX 7800 XT (gfx1101), Windows, `torch 2.10.0+rocm7.14.0a20260611`, `triton 3.7.1`, `AITER_TRITON_ONLY` (implicit on win32). CDNA hardware was not available to me.

New test, with the fix:

```
$ python -m pytest op_tests/triton_tests/test_config_load_failure.py -q
......                                                                   [100%]
6 passed in 2.79s
```

Same test with the fix reverted — 5 sites raise the wrong error, 1 raises none:

```
$ git checkout -- <the 7 files> && python -m pytest op_tests/triton_tests/test_config_load_failure.py -q
E       KeyError: 'default'
aiter\ops\triton\_triton_kernels\attention\mha.py:946: KeyError
E       KeyError: 'bkwd_fused'
aiter\ops\triton\_triton_kernels\attention\mha_fused_bwd.py:1073: KeyError
E       KeyError: 'bkwd_onekernel'
aiter\ops\triton\_triton_kernels\attention\mha_onekernel_bwd.py:1780: KeyError
E       KeyError: 'default'
aiter\ops\triton\_triton_kernels\attention\extend_attention.py:336: KeyError
E           Failed: DID NOT RAISE FileNotFoundError
E       KeyError: 'N16'
6 failed in 2.83s
```

Reproducer, all seven sites, before and after. `--arch` overrides the reported architecture; the `gfx942` run is the control, since those config files do exist:

```
before, real arch (gfx1101, no configs):        7/7 sites diverge on the second call
before, --arch gfx9999 (no configs):            7/7 sites diverge on the second call
before, --arch gfx942  (configs present):       0/7   <- control
after,  real arch (gfx1101, no configs):        0/7
after,  --arch gfx942  (configs present):       0/7
```

End to end through the public API, `flash_attn_func` called twice in one process:

```
before:  call 1: FileNotFoundError: ...configs/gfx1101-MHA-DEFAULT.json
         call 2: KeyError: 'default'
after:   call 1: FileNotFoundError: ...configs/gfx1101-MHA-DEFAULT.json
         call 2: FileNotFoundError: ...configs/gfx1101-MHA-DEFAULT.json
```

Style checks on the changed files: `black --check` clean (and clean repo-wide, 972 files, with black 26.5.1); `ruff check` with the CI-pinned 0.16.0 reports `All checks passed!`.

I could not run the existing MHA op_tests on this platform: `op_tests/triton_tests/attention/test_mha.py` imports `aiter.test_mha_common`, which does `from aiter import dtypes`, and that attribute is not bound on the `AITER_TRITON_ONLY` path. Supplying it from outside then fails on the missing `aiter.jit.module_aiter_core` prebuilt, which sends architecture detection to `rocminfo`. That is why the new test is written not to depend on those helpers.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.