### PR TITLE
Plumb split-K through the a8w8 blockscale bpreshuffle GEMM

### DIFF
--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -294,6 +294,7 @@ def gemm_a8w8_blockscale_bpreshuffle_ck(
     x_scale: torch.Tensor,
     w_scale: torch.Tensor,
     Out: torch.Tensor,
+    splitK: int = 0,
     kernelName: str = "",
 ) -> torch.Tensor: ...
 
@@ -952,7 +953,13 @@ def gemm_a8w8_blockscale_bpreshuffle(
             )
         elif libtype == "ck":
             return gemm_a8w8_blockscale_bpreshuffle_ck(
-                XQ, WQ, x_scale, w_scale, Y, kernelName=kernelName
+                XQ,
+                WQ,
+                x_scale,
+                w_scale,
+                Y,
+                splitK=int(config.get("splitK", 0)),
+                kernelName=kernelName,
             )
         elif libtype == "asm":
             splitK = config["splitK"]

--- a/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py
+++ b/csrc/ck_gemm_a8w8_blockscale/gemm_a8w8_blockscale_tune.py
@@ -411,20 +411,16 @@ class GemmA8W8BlockScaleTuner(GemmCommonTuner):
         for i in range(kernels_num):
             kernel = kernel_list[i]
             maxsplitK = (
-                0
-                if preshuffleB
-                else (
-                    aiter.compute_gemm_SplitK(
-                        M,
-                        N,
-                        K,
-                        kernel.MPerBLOCK,
-                        kernel.NPerBLOCK,
-                        kernel.KPerBLOCK,
-                    )
-                    if useSplitK
-                    else 0
+                aiter.compute_gemm_SplitK(
+                    M,
+                    N,
+                    K,
+                    kernel.MPerBLOCK,
+                    kernel.NPerBLOCK,
+                    kernel.KPerBLOCK,
                 )
+                if useSplitK
+                else 0
             )
             for splitK in range(maxsplitK + 1):
                 info = (info_keys, i, splitK, "", "ck", preshuffleB)

--- a/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gemm_a8w8_blockscale_bpreshuffle.cu
+++ b/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gemm_a8w8_blockscale_bpreshuffle.cu
@@ -12,7 +12,7 @@
 #include "gemm_a8w8_blockscale_bpreshuffle_manifest.h"
 
 using BlockwiseKernel = torch::Tensor (*)(
-    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&);
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
 
 // Name-keyed dispatch table; see gemm_a8w8_blockscale.cu for the rationale
 // behind std::string_view keys + raw fn-ptr values (constant-init into
@@ -67,18 +67,22 @@ torch::Tensor gemm_a8w8_blockscale_bpreshuffle(torch::Tensor& XQ,
                                                torch::Tensor& x_scale,
                                                torch::Tensor& w_scale,
                                                torch::Tensor& Y,
+                                               int splitK,
                                                std::string kernelName)
 {
     TORCH_CHECK(XQ.dtype() == WQ.dtype(), "Weights and activations should have the same dtype!");
     TORCH_CHECK(x_scale.dtype() == w_scale.dtype(), "Scales should have the same dtype!");
+    TORCH_CHECK(splitK >= 0 && splitK <= 30, "splitK must be in the range [0, 30], got ", splitK);
+
+    int KBatch = 1 << splitK;
 
     if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::Half)
     {
-        blockscale_bpreshuffle_dispatch<F32, F16>(kernelName)(XQ, WQ, x_scale, w_scale, Y);
+        blockscale_bpreshuffle_dispatch<F32, F16>(kernelName)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::BFloat16)
     {
-        blockscale_bpreshuffle_dispatch<F32, B16>(kernelName)(XQ, WQ, x_scale, w_scale, Y);
+        blockscale_bpreshuffle_dispatch<F32, B16>(kernelName)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else
     {

--- a/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gemm_a8w8_blockscale_bpreshuffle_tune.cu
+++ b/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gemm_a8w8_blockscale_bpreshuffle_tune.cu
@@ -7,7 +7,7 @@
 #include <string>
 
 using BlockwiseKernel = std::function<torch::Tensor(
-    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&)>;
+    torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int)>;
 
 // For certain high priority shapes, we directly use the best kernel rather
 // than use heuristics.
@@ -74,7 +74,7 @@ torch::Tensor gemm_a8w8_blockscale_bpreshuffle_tune(torch::Tensor& XQ,
 
     if(Y.dtype() == at::ScalarType::BFloat16)
     {
-        blockwise_dispatch<F32, B16>(kernelId)(XQ, WQ, x_scale, w_scale, Y);
+        blockwise_dispatch<F32, B16>(kernelId)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else
     {

--- a/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gen_instances.py
+++ b/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/gen_instances.py
@@ -57,7 +57,8 @@ torch::Tensor
     torch::Tensor &WQ,
     torch::Tensor &x_scale,
     torch::Tensor &w_scale,
-    torch::Tensor &Y
+    torch::Tensor &Y,
+    int KBatch
     )
 {{{{
     // The smallest kernel we have available. Works well for memory bound shapes.
@@ -101,7 +102,7 @@ torch::Tensor
             ck::BlockGemmPipelineVersion::v{k.PIPELINE_VERSION},
             ck::tensor_operation::device::GemmSpecialization::{{GemmSpec}}>;
         // Run kernel instance.
-        return gemm_a8w8_blockscale_bpreshuffle_impl<DDataType, EDataType, DeviceGemmInstance>(XQ, WQ, x_scale, w_scale, Y);
+        return gemm_a8w8_blockscale_bpreshuffle_impl<DDataType, EDataType, DeviceGemmInstance>(XQ, WQ, x_scale, w_scale, Y, KBatch);
 """
         if self.istune:
             INSTANCE_IMPL_str = INSTANCE_IMPL.format(
@@ -137,7 +138,8 @@ template torch::Tensor
     torch::Tensor &WQ,
     torch::Tensor &x_scale,
     torch::Tensor &w_scale,
-    torch::Tensor &Y
+    torch::Tensor &Y,
+    int KBatch
     );
 
 """
@@ -241,7 +243,8 @@ torch::Tensor
     torch::Tensor &WQ,
     torch::Tensor &x_scale,
     torch::Tensor &w_scale,
-    torch::Tensor &Y);
+    torch::Tensor &Y,
+    int KBatch);
 """
         MAINFEST_end = """
 

--- a/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/include/gemm_a8w8_blockscale_bpreshuffle.h
+++ b/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/include/gemm_a8w8_blockscale_bpreshuffle.h
@@ -10,6 +10,7 @@ torch::Tensor gemm_a8w8_blockscale_bpreshuffle(
     torch::Tensor &x_scale,
     torch::Tensor &w_scale,
     torch::Tensor &Y,
+    int splitK = 0,
     std::string kernelName = "");
 
 torch::Tensor gemm_a8w8_blockscale_bpreshuffle_tune(

--- a/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/include/gemm_a8w8_blockscale_bpreshuffle_common.cuh
+++ b/csrc/ck_gemm_a8w8_blockscale_bpreshuffle/include/gemm_a8w8_blockscale_bpreshuffle_common.cuh
@@ -119,8 +119,11 @@ __forceinline__ torch::Tensor gemm_a8w8_blockscale_bpreshuffle_impl(torch::Tenso
                                                                     torch::Tensor& WQ,
                                                                     torch::Tensor& x_scale,
                                                                     torch::Tensor& w_scale,
-                                                                    torch::Tensor& Y)
+                                                                    torch::Tensor& Y,
+                                                                    int KBatch = 1)
 {
+    TORCH_CHECK(KBatch >= 1, "KBatch must be >= 1, got ", KBatch);
+
     int M = XQ.size(0);
     int N = WQ.size(0);
     int K = XQ.size(1);
@@ -155,7 +158,8 @@ __forceinline__ torch::Tensor gemm_a8w8_blockscale_bpreshuffle_impl(torch::Tenso
         reinterpret_cast<DDataType*>(w_scale.data_ptr()),
         a_element_op,
         b_element_op,
-        cde_element_op);
+        cde_element_op,
+        KBatch);
 
     TORCH_CHECK(device_gemm.IsSupportedArgument(argument), "This GEMM is not supported!");
 

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -754,6 +754,7 @@ namespace py = pybind11;
           py::arg("x_scale"),                   \
           py::arg("w_scale"),                   \
           py::arg("Out"),                       \
+          py::arg("splitK")     = 0,            \
           py::arg("kernelName") = "");
 
 #define GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_TUNE_PYBIND \

--- a/op_tests/test_gemm_a8w8_blockscale.py
+++ b/op_tests/test_gemm_a8w8_blockscale.py
@@ -13,7 +13,11 @@ import pandas as pd
 import torch
 import torch.nn.functional as F
 from aiter import dtypes
-from aiter.ops.gemm_op_a8w8 import gemm_a8w8_blockscale_ck, gemm_a8w8_blockscale_cktile
+from aiter.ops.gemm_op_a8w8 import (
+    gemm_a8w8_blockscale_bpreshuffle_ck,
+    gemm_a8w8_blockscale_ck,
+    gemm_a8w8_blockscale_cktile,
+)
 from aiter.ops.shuffle import shuffle_weight
 from aiter.test_common import benchmark, checkAllclose, perftest
 from einops import rearrange
@@ -207,9 +211,41 @@ def test_splitk_correctness(m=4, n=2112, k=7168, dtype=dtypes.bf16, splitK=1):
         catastrophic_check=True,
     )
 
+    # CK bpreshuffle path: same comparison, with the preshuffled weight and the
+    # transposed x_scale that this entry point expects.
+    weight_shuffled = shuffle_weight(weight, layout=(16, 16))
+    x_scale_t = x_scale.transpose(0, 1).contiguous().view(*x_scale.shape)
+    Y_base_bps = torch.empty((m, n), dtype=dtype, device="cuda")
+    Y_split_bps = torch.empty((m, n), dtype=dtype, device="cuda")
+    gemm_a8w8_blockscale_bpreshuffle_ck(
+        x, weight_shuffled, x_scale_t, w_scale, Y_base_bps, splitK=0
+    )
+    gemm_a8w8_blockscale_bpreshuffle_ck(
+        x, weight_shuffled, x_scale_t, w_scale, Y_split_bps, splitK=splitK
+    )
+    bps_err = checkAllclose(
+        Y_base_bps,
+        Y_split_bps,
+        msg=f"ck bpreshuffle splitK={splitK} vs splitK=0",
+        rtol=1e-2,
+        atol=1e-2,
+        catastrophic_check=True,
+    )
+
+    # Matching outputs alone would also hold for an entry point that accepted a
+    # splitK and ignored it, so check that the value reaches the kernel layer.
+    try:
+        gemm_a8w8_blockscale_bpreshuffle_ck(
+            x, weight_shuffled, x_scale_t, w_scale, Y_split_bps, splitK=31
+        )
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("bpreshuffle entry accepted an out-of-range splitK")
+
     print(
         f"test_splitk_correctness(m={m}, n={n}, k={k}, splitK={splitK}): "
-        f"ck_err={ck_err:.4g}, cktile_err={cktile_err:.4g}"
+        f"ck_err={ck_err:.4g}, cktile_err={cktile_err:.4g}, bpreshuffle_err={bps_err:.4g}"
     )
 
 


### PR DESCRIPTION
## Motivation

`gemm_a8w8_blockscale_bpreshuffle_tune` computes `KBatch = 1 << splitK` and then drops it: no layer below it accepts a `KBatch`, so every tuned row for this op was measured at `KBatch = 1` and the tuner's split-K sweep was dead. The tuner even had an explicit `maxsplitK = 0 if preshuffleB else ...` gate, because the kernel could not honour a split anyway.

Split-K matters here at small M, where a single K pass leaves most CUs idle. At M = 4 on gfx950 it is worth 10% on a 4096x2048 shape (7.09 -> 6.36 us) and 15% on 6144x4096 (12.79 -> 10.82 us).

**Depends on ROCm/rocm-libraries#10146**, which implements the split-K path in the CK device op this calls (`DeviceGemmMultiD_BlockScale_Xdl_CShuffle_V3_BPreshuffle`, whose `MakeArgument` had no `KBatch` parameter). The `3rdparty/composable_kernel` submodule has to point at a `develop` commit containing that change before this path builds, so this PR does not bump it.

## Technical Details

`KBatch` now travels from both entry points down to the device op:

* `gemm_a8w8_blockscale_bpreshuffle` takes a `splitK` (default 0, so existing callers are unchanged), validates it, and passes `KBatch = 1 << splitK` through the dispatch table. `gemm_a8w8_blockscale_bpreshuffle_tune` passes the `KBatch` it already computed.
* The dispatch typedefs, the generated instance signatures in `gen_instances.py`, and `gemm_a8w8_blockscale_bpreshuffle_impl` all gain the parameter, and the impl forwards it to `MakeArgument`.
* The Python entry reads `splitK` from the tuned config row, so a tuned row can select a split.
* The tuner's `preshuffleB` split-K gate is removed, so `--splitK` now sweeps this op.

## Test Plan

Extended `test_splitk_correctness` in `op_tests/test_gemm_a8w8_blockscale.py`, which already covered the non-preshuffle CK and CKTile paths, to cover the bpreshuffle path the same way: run `splitK` in {1, 2} against `splitK = 0` on identical inputs and compare, plus assert that an out-of-range `splitK` is rejected. The rejection check matters because matching outputs alone would also hold for an entry point that accepted a `splitK` and ignored it, which is exactly the prior behavior.

```
python3 op_tests/test_gemm_a8w8_blockscale.py -m 4 -nk 512,16384 --ck_preshuffle True
```

## Test Result

Passes on MI355X (gfx950) against a build carrying ROCm/rocm-libraries#10146:

```
test_splitk_correctness(m=4, n=512, k=16384, splitK=1): ck_err=0, cktile_err=0, bpreshuffle_err=0
test_splitk_correctness(m=4, n=512, k=16384, splitK=2): ck_err=0, cktile_err=0, bpreshuffle_err=0
```

Retuning the two shapes above with split-K enabled gives the per-call numbers in the motivation section.

Note for review: #3457 touches the same six bpreshuffle files to thread `y_is_zeroed`, so whichever of the two lands second will need a rebase.
