### PR TITLE
Work around all-zero fused MoE output at block_m=32

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1983,6 +1983,25 @@ def get_2stage_cfgs(
             cfg_flat = run_1stage and bool(int(cfg["flat"]))
         else:
             cfg_flat = False
+    # WORKAROUND: the CK 2-stage MoE writes nothing at block_m=32 and returns an
+    # identically zero output tensor. Reproduced on gfx942 for bf16/QuantType.No
+    # and fp8/QuantType.per_Token; see op_tests/test_moe_blockm_invariance.py.
+    # The fault depends on block_m alone, not on the token count: forcing
+    # block_m=32 at token=64, a size that is otherwise correct, also yields zeros.
+    #
+    # The clamp sits after both the heuristic and the tuned-CSV branch because
+    # either can select 32, and 469 of the 617 rows in configs/tuned_fmoe.csv pin
+    # block_m=32 with run_1stage=0. 1stage and asm paths are unaffected.
+    if not run_1stage:
+        _min_block_m = int(os.environ.get("AITER_MIN_BLOCK_M", "64"))
+        if block_m < _min_block_m:
+            logger.warning(
+                f"[fused_moe] block_m={block_m} raised to {_min_block_m}: the CK "
+                "2-stage kernel emits all-zero output below 64. Set "
+                "AITER_MIN_BLOCK_M=32 to restore the original selection."
+            )
+            block_m = _min_block_m
+
     is_opus_cfg = cfg is not None and _opus_a8w4.is_opus_a8w4_stage2_kernel(
         cfg.get("kernelName2", "")
     )

--- a/op_tests/test_moe_blockm_invariance.py
+++ b/op_tests/test_moe_blockm_invariance.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+"""fused_moe results must not depend on block_m.
+
+block_m is a tile-size / scheduling knob chosen by get_block_size_M or pinned by
+a tuned_fmoe.csv row. It must not change what the MoE computes, so the same
+inputs run at different block_m have to agree.
+
+This guards a regression where the CK 2-stage kernel silently wrote nothing at
+block_m=32 and fused_moe returned an identically zero tensor. It was invisible
+end to end because prefill uses larger tiles and stays correct while decode,
+which is where the small tiles are selected, quietly lost the entire routed
+expert contribution.
+
+Note the failure mode is an all-zero output rather than an exception or NaN, so
+a test that only checks for finiteness or for a successful launch will pass. The
+assertions below check non-zero output explicitly and compare across tiles.
+"""
+
+import pytest
+import torch
+
+import aiter
+from aiter import ActivationType, QuantType, dtypes
+from aiter import fused_moe as fm
+from aiter.ops.quant import pertoken_quant
+from aiter.test_common import checkAllclose
+
+# Tiles the 2-stage heuristic can emit (get_block_size_M support_list).
+BLOCK_SIZES = [32, 64, 128]
+REFERENCE_BLOCK_M = 128
+
+
+def _clear_dispatch_caches():
+    """Drop memoized dispatch decisions.
+
+    Kernel selection is lru_cached on shape, so without this every iteration
+    after the first silently reuses the first block_m and the test passes
+    vacuously.
+    """
+    for name in dir(fm):
+        obj = getattr(fm, name, None)
+        if hasattr(obj, "cache_clear"):
+            obj.cache_clear()
+
+
+def _run_at_block_m(block_m, hidden, w1, w2, topk_weights, topk_ids, quant_type,
+                    w1_scale=None, w2_scale=None):
+    orig = fm.get_block_size_M
+    try:
+        fm.get_block_size_M = lambda *_args, **_kw: block_m
+        _clear_dispatch_caches()
+        out = fm.fused_moe(
+            hidden,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            quant_type=quant_type,
+            activation=ActivationType.Silu,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+        )
+        torch.cuda.synchronize()
+        return out.float().clone()
+    finally:
+        fm.get_block_size_M = orig
+        _clear_dispatch_caches()
+
+
+def _build(token, model_dim, inter_dim, E, topk, quantized):
+    dev, dt = "cuda", dtypes.bf16
+    torch.manual_seed(token)
+    hidden = torch.randn(token, model_dim, dtype=dt, device=dev) / 10
+    w1 = torch.randn(E, inter_dim * 2, model_dim, dtype=dt, device=dev) / 40
+    w2 = torch.randn(E, model_dim, inter_dim, dtype=dt, device=dev) / 40
+    topk_weights = torch.softmax(
+        torch.randn(token, topk, dtype=dtypes.fp32, device=dev), -1
+    )
+    topk_ids = torch.randint(0, E, (token, topk), dtype=dtypes.i32, device=dev)
+
+    if not quantized:
+        return hidden, w1, w2, topk_weights, topk_ids, QuantType.No, None, None
+
+    w1_q, w1_scale = pertoken_quant(w1, quant_dtype=dtypes.fp8)
+    w2_q, w2_scale = pertoken_quant(w2, quant_dtype=dtypes.fp8)
+    return (
+        hidden, w1_q, w2_q, topk_weights, topk_ids,
+        QuantType.per_Token, w1_scale, w2_scale,
+    )
+
+
+# token=1 is the decode regime the regression actually broke; token=64 separates
+# "small tile" from "few tokens", since the two are otherwise confounded.
+@pytest.mark.parametrize("token", [1, 64])
+@pytest.mark.parametrize("quantized", [False, True], ids=["bf16", "fp8_per_token"])
+def test_fused_moe_is_block_m_invariant(token, quantized):
+    model_dim, inter_dim, E, topk = 4096, 512, 128, 8
+    hidden, w1, w2, tw, tid, qt, w1s, w2s = _build(
+        token, model_dim, inter_dim, E, topk, quantized
+    )
+
+    ref = _run_at_block_m(REFERENCE_BLOCK_M, hidden, w1, w2, tw, tid, qt, w1s, w2s)
+    assert ref.abs().max().item() > 0, (
+        f"reference block_m={REFERENCE_BLOCK_M} produced an all-zero output; "
+        "the test configuration itself is wrong"
+    )
+
+    for block_m in BLOCK_SIZES:
+        out = _run_at_block_m(block_m, hidden, w1, w2, tw, tid, qt, w1s, w2s)
+
+        assert out.abs().max().item() > 0, (
+            f"fused_moe returned an identically zero tensor at block_m={block_m} "
+            f"(token={token}, quantized={quantized}). The kernel silently wrote "
+            "nothing; this is the regression this test exists for."
+        )
+        assert torch.isfinite(out).all(), f"non-finite output at block_m={block_m}"
+
+        # bf16 accumulation order differs per tile, so compare loosely; the bug
+        # this guards is a total loss of signal, not a rounding difference.
+        checkAllclose(
+            ref,
+            out,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"block_m={block_m} disagrees with block_m={REFERENCE_BLOCK_M}",
+        )
+
+
+if __name__ == "__main__":
+    for quantized in (False, True):
+        for token in (1, 64):
+            test_fused_moe_is_block_m_invariant(token, quantized)
+            print(f"PASS token={token} quantized={quantized}")
+    aiter.logger.info("fused_moe block_m invariance: all passed")


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 data-pm-slice="0 0 []">Summary</h2><p>The CK 2-stage fused-MoE kernel returns an <strong>identically zero output tensor</strong> at
<code>block_m=32</code> on gfx942. It does not raise, does not produce NaNs, and logs
nothing — <code>fused_moe</code> simply returns all zeros.</p><p><code>get_block_size_M</code> selects <code>block_m=32</code> for token counts &lt;= 32, which in serving
means <strong>every decode step</strong>. Prefill uses larger tiles and is correct. The result
is a MoE model that reads context correctly and then degenerates during
generation, because the entire routed-expert contribution is silently dropped
while attention and (unfused) shared experts keep the output superficially
fluent.</p><p>This PR clamps <code>block_m</code> to &gt;= 64 on the 2-stage path and adds a regression test.
<strong>It is a workaround, not a root-cause fix</strong> — see "Open question" below.</p><h2>Reproducer</h2><p>Standalone, ~2 min, no model download. bf16 / <code>QuantType.No</code>,
<code>model_dim=4096, inter_dim=512, E=128, topk=8</code>, identical seeds on both versions:</p>
token | v0.1.18 absmax | state | v0.1.13.post1 absmax | selected block_m
-- | -- | -- | -- | --
1 | 0.000000 | all zero | 0.012573 | 32
8 | 0.000000 | all zero | 0.015259 | 32
32 | 0.000000 | all zero | 0.020142 | 32
33 | 0.022949 | ok | 0.022949 | 64
128 | 0.020752 | ok | 0.020752 | 128

<p></p><h2>Test</h2><p><code>op_tests/test_moe_blockm_invariance.py</code> asserts that <code>fused_moe</code> results do not
depend on <code>block_m</code>, which is a scheduling knob and must not change what is
computed. It covers bf16 and fp8/<code>per_Token</code> at token 1 (decode) and token 64
(to decouple tile size from token count).</p><p>Two details that matter for anyone extending it:</p><ul><li><p>The failure mode is an all-zero tensor, not an exception or a NaN, so a test
that only checks for a successful launch or for finiteness passes straight
through it. The test asserts non-zero output explicitly.</p></li><li><p>Kernel selection is <code>functools.lru_cache</code>d, so changing <code>block_m</code> in-process
without clearing those caches silently reuses the first decision and the test
passes vacuously. The helper clears them between runs.</p></li></ul><p></p><h2>Open question for maintainers (the actual root cause)</h2><p>I could not find the source-level cause, and the evidence suggests it is not in
the algorithm:</p><ul><li><p><code>csrc/py_itfs_ck/</code> (including <code>moe_ck_2stages_kernel.cu</code> and
<code>moe_ck_2stages_gemm_impl/</code>) is <strong>byte-identical</strong> between v0.1.13.post1 and
v0.1.18 — <code>diff -rq</code> reports no differences for the MoE kernels.</p></li><li><p><code>get_block_size_M</code> is byte-identical as well, so both versions select the same
tile for the same shape.</p></li><li><p>The <code>csrc/ck_gemm_moe_2stages_codegen/</code> directory differs only in
<code>gemm_moe_tune.py</code>.</p></li></ul><p>Identical sources therefore produce a working kernel in one build and a silent
no-op in the other, which points at codegen or build configuration rather than
the kernel logic. Someone familiar with the CK instantiation path can likely
find this quickly; the reproducer above should make it a short loop.</p><h2>Scope of validation</h2><p>Stated plainly so reviewers can judge:</p><ul><li><p>gfx942 only. gfx950 untested.</p></li><li><p>One shape (<code>E=128, topk=8, model_dim=4096, inter_dim=512</code>). Other shapes
untested.</p></li><li><p><code>block_m=16</code> untested — the clamp raises it to 64 on the assumption that a
smaller tile is at least as broken, which is unverified.</p></li><li><p>The clamp gives small batches a larger tile than the cost heuristic chose. A
decode-throughput A/B is in progress; numbers will be added here.</p></li></ul><p></p><!--EndFragment-->
</body>
</html>