### PR TITLE
[FMHA] Fix mha_varlen_fwd paged codegen branch

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -771,7 +771,9 @@ def cmdGenFunc_mha_varlen_fwd(
         dropout_zero = dropout_p == 0
         skip_zero = min_seqlen_q == 0
         has_qscale = q_descale is None or k_descale is None or v_descale is None
-        suffix, filter_fwd = compose_mha_fwd_variant_suffix_and_filter(
+        # The filter is unused here: this branch resolves its blob_gen_cmd from
+        # the prebuilt variant table rather than driving the CK generator.
+        suffix, _ = compose_mha_fwd_variant_suffix_and_filter(
             dtype=dtype_token,
             logits_positive=logits_positive,
             has_bias=has_bias,
@@ -799,10 +801,10 @@ def cmdGenFunc_mha_varlen_fwd(
             filter_fwd_splitkv2 += "_bf16*"
         if 0.0 < logits_soft_cap:
             md_name += "_logits"
-            filter_fwd += "_logits*"
+            filter_fwd_splitkv2 += "_logits*"
         else:
             md_name += "_nlogits"
-            filter_fwd += "_nlogits*"
+            filter_fwd_splitkv2 += "_nlogits*"
         if bias is not None:
             md_name += "_bias"
             filter_fwd_splitkv2 += "_bias*"
@@ -818,14 +820,15 @@ def cmdGenFunc_mha_varlen_fwd(
         else:
             md_name += "_mask"
             filter_fwd_splitkv2 += "_m*"
+        # Neither filter may be narrowed by lse: split-kv kernels are always
+        # generated with lse=true, and the generated API instantiates both the
+        # lse and the nlse combine kernel unconditionally (it picks between them
+        # at runtime on args.has_lse), so both must be built or the module fails
+        # to link with an undefined fmha_fwd_splitkv_combine_oneshot_ symbol.
         if return_softmax_lse:
             md_name += "_lse"
-            filter_fwd_splitkv1 += "_lse*"
-            filter_fwd_splitkv2 += "_lse*"
         else:
             md_name += "_nlse"
-            filter_fwd_splitkv1 += "_nlse*"
-            filter_fwd_splitkv2 += "_nlse*"
         md_name += "_pagedkv"
         filter_fwd_splitkv2 += "_pagedkv*"
         filter_fwd_splitkv = f"{filter_fwd_splitkv1}@{filter_fwd_splitkv2}"

--- a/op_tests/test_mha_varlen_paged.py
+++ b/op_tests/test_mha_varlen_paged.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+import aiter
+from aiter import dtypes
+
+# CK requires the paged KV cache block size to be a multiple of 128.
+PAGE_SIZE = 128
+
+
+def build_paged_kv(k, v, seqlens_k, page_size):
+    """Scatter a packed varlen KV buffer into a paged cache.
+
+    Physical block ids are shuffled and every slot the block table does not
+    reference is filled with garbage, so a kernel that ignores the block table
+    (or over-reads past the last valid token of a page) produces wrong numbers
+    instead of accidentally passing.
+    """
+    batch_size = len(seqlens_k)
+    blocks_per_seq = [(s + page_size - 1) // page_size for s in seqlens_k]
+    max_blocks_per_seq = max(blocks_per_seq)
+    # Over-allocate so that some physical blocks stay unreferenced.
+    num_blocks = sum(blocks_per_seq) + batch_size
+
+    _, num_heads_k, head_size_q = k.shape
+    head_size_v = v.shape[-1]
+    k_cache = torch.full(
+        (num_blocks, page_size, num_heads_k, head_size_q),
+        100.0,
+        dtype=k.dtype,
+        device=k.device,
+    )
+    v_cache = torch.full(
+        (num_blocks, page_size, num_heads_k, head_size_v),
+        -100.0,
+        dtype=v.dtype,
+        device=v.device,
+    )
+    block_table = torch.zeros(
+        (batch_size, max_blocks_per_seq), dtype=torch.int32, device=k.device
+    )
+
+    physical = torch.randperm(num_blocks, device=k.device)
+    next_block = 0
+    offset = 0
+    for b, seqlen_k in enumerate(seqlens_k):
+        for i in range(blocks_per_seq[b]):
+            block_id = physical[next_block].item()
+            next_block += 1
+            block_table[b, i] = block_id
+            begin = i * page_size
+            end = min(begin + page_size, seqlen_k)
+            k_cache[block_id, : end - begin] = k[offset + begin : offset + end]
+            v_cache[block_id, : end - begin] = v[offset + begin : offset + end]
+        offset += seqlen_k
+
+    return k_cache, v_cache, block_table
+
+
+@pytest.mark.parametrize("dtype", [dtypes.fp16, dtypes.bf16])
+@pytest.mark.parametrize("head_dim", [64, 96])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("return_lse", [False, True])
+def test_flash_attn_varlen_func_paged(dtype, head_dim, causal, return_lse):
+    """flash_attn_varlen_func(block_table=...) must match the non-paged path.
+
+    head_dim is kept below 128 so that the CK split-kv kernels are exercised;
+    bf16 with head_dim=128 dispatches to the ASM v3 kernel instead.
+    """
+    torch.manual_seed(0)
+    device = "cuda"
+
+    num_heads, num_heads_k = 8, 2
+    # Deliberately not aligned to PAGE_SIZE, so the last page of every sequence
+    # is partially filled.
+    seqlens_q = [7, 1, 64, 130]
+    seqlens_k = [200, 1, 129, 383]
+
+    def cu_seqlens(seqlens):
+        out = [0]
+        for s in seqlens:
+            out.append(out[-1] + s)
+        return torch.tensor(out, dtype=torch.int32, device=device)
+
+    cu_seqlens_q = cu_seqlens(seqlens_q)
+    cu_seqlens_k = cu_seqlens(seqlens_k)
+
+    q = torch.randn(sum(seqlens_q), num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(sum(seqlens_k), num_heads_k, head_dim, dtype=dtype, device=device)
+    v = torch.randn(sum(seqlens_k), num_heads_k, head_dim, dtype=dtype, device=device)
+
+    k_cache, v_cache, block_table = build_paged_kv(k, v, seqlens_k, PAGE_SIZE)
+
+    common = {
+        "cu_seqlens_q": cu_seqlens_q,
+        "cu_seqlens_k": cu_seqlens_k,
+        "max_seqlen_q": max(seqlens_q),
+        "max_seqlen_k": max(seqlens_k),
+        "causal": causal,
+        "return_lse": return_lse,
+    }
+    dense = aiter.flash_attn_varlen_func(q, k, v, **common)
+    paged = aiter.flash_attn_varlen_func(
+        q, k_cache, v_cache, block_table=block_table, **common
+    )
+
+    if return_lse:
+        dense, dense_lse = dense[0], dense[1]
+        paged, paged_lse = paged[0], paged[1]
+        torch.testing.assert_close(paged_lse, dense_lse, atol=1e-3, rtol=1e-3)
+
+    torch.testing.assert_close(paged, dense, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
## Purpose

The `block_table` branch of `cmdGenFunc_mha_varlen_fwd` has never produced a loadable module. Any
`flash_attn_varlen_func(..., block_table=...)` call that routes to the CK path dies in the JIT
codegen step, before reaching a kernel:

```
  File "aiter/ops/mha.py", line 576, in cmdGenFunc_mha_varlen_fwd
    filter_fwd += "_nlogits*"
UnboundLocalError: cannot access local variable 'filter_fwd' where it is not associated with a value
```

(captured on 0.1.16.post5, so the line number is that release's, not `main`'s)

`filter_fwd` is only assigned on the `block_table is None` branch. The paged branch builds
`filter_fwd_splitkv1` / `filter_fwd_splitkv2` instead — these two `logits` lines were carried over
from the dense version without being renamed.

Renaming them is not enough: the branch also narrows both split-kv filters by `lse`, and neither may
be narrowed.

- **Split-kv kernels are always generated with lse on** (`fmha_fwd_splitkv.py` asserts the flag is
  `"t"`), so `_nlse` on `filter_fwd_splitkv2` matches nothing and `return_lse=False` yields a module
  with zero attention kernels.
- **The generated API instantiates both combine variants unconditionally**, emitting
  `fmha_fwd_splitkv_combine_traits_<..., true, ...>` under `if (t.has_lse)` with the `false` variant
  as fallthrough, and choosing between them at runtime. Filtering out either leaves the other
  unresolved:

```
undefined symbol: fmha_fwd_splitkv_combine_oneshot_<
    fmha_fwd_splitkv_combine_traits_<64, FmhaFwdBf16, true, 32, true, false, true, false>, gfx9_t>
```

  (`kStoreLse` is the `true` there, wanted while only `nlse` combine blobs had been generated.)

So: route the `logits` tag to `filter_fwd_splitkv2`, and drop the `lse` tag from both split-kv
filters. `md_name` keeps its `_lse` / `_nlse` distinction — see *Follow-up*.

All three are on current `main` (`1aeb91bad`), and the first means the branch can never have run to
completion, so this is not a regression. It went unnoticed because `cmdGenFunc_*` only runs on a JIT
cache miss, and because **no test in the repository passes `block_table` to
`flash_attn_varlen_func`** — `op_tests/test_mha_varlen.py` covers that entry point, never with a
paged cache.

This PR adds `op_tests/test_mha_varlen_paged.py`, asserting the paged path matches the dense one on
a deliberately hostile fixture: KV lengths straddle page boundaries, physical block ids are
shuffled, and every unreferenced cache slot holds garbage, so ignoring the block table or
over-reading past a page's last valid token shows up as a large error rather than a plausible
number.

`head_dim` stays below 128 there: bf16 at 128 satisfies `can_impl_fmha_v3_fwd()`, so it dispatches
to the ASM v3 kernel instead of the CK path this PR fixes — and that kernel memory-faults on gfx950
([#4455](https://github.com/ROCm/aiter/issues/4455)).

## Test Plan

```bash
pytest -q op_tests/test_mha_varlen_paged.py
```

16 cases: `dtype ∈ {fp16, bf16} × head_dim ∈ {64, 96} × causal ∈ {False, True} × return_lse ∈
{False, True}`. The dtype, `causal` and `return_lse` axes each select a different `md_name`, so the
run builds eight distinct paged modules; those last two axes are what exercise the two filter
defects above.

## Test Result

```
16 passed in 691.64s (0:11:31)
```

MI350X (gfx950), ROCm 7.1.1 host, `vllm/vllm-openai-rocm:nightly-49f31d7cee425a...` (HIP 7.2.53211),
torch 2.11.0+gitd0c8b1f, aiter 0.1.16.post5.

Before the fix, the same test raises `UnboundLocalError` on the first paged call.

Disclosure: I validated by applying these exact three edits to the aiter installed in that container
(0.1.16.post5) rather than by building this branch from source; the patched region is
character-identical to the diff here. I have only run this on gfx950.

## Follow-up (not in this PR)

With both filters no longer depending on `return_softmax_lse`, the `_lse` and `_nlse` paged modules
are now byte-identical, so a caller using both values builds the same module twice. Dropping the tag
from `md_name` would fix that, but it renames modules and invalidates existing JIT caches, which
seems out of scope for a bug fix. Happy to fold it in if you would rather have it here.

