### PR TITLE
Tune gfx950 GEMM A16W16 configs for Triton TOT

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=106496-K=16384.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=106496-K=16384.json
@@ -1,0 +1,111 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 8,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 8,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "kpack": 1,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_512": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_2048": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=2880-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=2880-K=4096.json
@@ -6,7 +6,7 @@
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
         "num_stages": 2,
-        "waves_per_eu": 8,
+        "waves_per_eu": 4,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg",
         "NUM_KSPLIT": 1
@@ -110,8 +110,8 @@
     "M_LEQ_2048": {
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 4,
         "num_warps": 8,
         "num_stages": 2,
         "waves_per_eu": 4,

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=2880-K=512.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=2880-K=512.json
@@ -120,8 +120,8 @@
         "NUM_KSPLIT": 1
     },
     "M_LEQ_4096": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
@@ -132,10 +132,10 @@
         "NUM_KSPLIT": 1
     },
     "M_LEQ_8192": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 4,
+        "GROUP_SIZE_M": 1,
         "num_warps": 8,
         "num_stages": 2,
         "waves_per_eu": 1,
@@ -145,7 +145,7 @@
     },
     "any": {
         "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 8,
         "num_warps": 8,

--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=5120-K=2880.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-A16W16-N=5120-K=2880.json
@@ -108,25 +108,25 @@
         "NUM_KSPLIT": 1
     },
     "M_LEQ_2048": {
-        "BLOCK_SIZE_M": 256,
-        "BLOCK_SIZE_N": 256,
-        "BLOCK_SIZE_K": 64,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 8,
-        "num_stages": 2,
-        "waves_per_eu": 1,
-        "matrix_instr_nonkdim": 16,
-        "cache_modifier": ".cg",
-        "NUM_KSPLIT": 1
-    },
-    "M_LEQ_4096": {
-        "BLOCK_SIZE_M": 256,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
         "num_stages": 2,
-        "waves_per_eu": 1,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": null,
         "NUM_KSPLIT": 1


### PR DESCRIPTION
## Motivation

This PR begins with benchmarking `gemm_a16w16` on gfx950 across a 131-shape sweep against the Golden reference (Triton 3.4.0), showing **9 shapes regressing** on the current tip-of-tree stack of TOT (Triton 3.8.0 / `aiter` main). Root cause splits into two independent problems:

**1. A Triton 3.8 register-allocation regression (7 of the 9 shapes).**
These shapes select a *byte-identical config* in both environments, so the compiler is the
only variable. Triton 3.8 allocates more VGPRs than 3.4 and **spills to scratch
where 3.4 does not**. Across the 35 shapes in the sweep that run an identical config in
both stacks, TOT spills on 12 where golden spills on **none**, and the spill size tracks
the slowdown almost monotonically:

| scratch on TOT | golden scratch | slowdown |
|---:|---:|---:|
| 124 B | 0 | +184% |
| 28–36 B | 0 | +2% … +13% |
| 16 B | 0 | not visible |

The trigger is `waves_per_eu`, which is an occupancy floor that caps the per-SIMD VGPR
budget (~512/`waves_per_eu`). The shipped M≤4 bucket asks for `waves_per_eu=8`, i.e. a
64-VGPR ceiling. Triton 3.4 met it without spilling; Triton 3.8 cannot. Sweeping **only**
that parameter with everything else held fixed at `M=1,N=2880,K=4096` shows a cliff, not a
slope:

| `waves_per_eu` | time (µs) | VGPR | scratch |
|---:|---:|---:|---:|
| **8 (shipped)** | **26.881** | 32 | **124 B** |
| 6 | 14.407 | 40 | 44 B |
| 4 | **8.607** | 52 | 0 |
| 1 | 8.556 | 48 | 0 |
| 0 (unconstrained) | 8.674 | 48 | 0 |

Time is a step function of whether the allocator spills — which is what makes this
config-fixable: easing the occupancy floor lets 3.8 keep the working set in registers.

**2. Two shapes where the shipped config is simply a poor fit for the shape.**
`N=2880,K=512` at large M and `N=106496,K=16384` at `M=256` pick tiles that leave the N
dimension badly partitioned. `N=2880` is `64 × 45` exactly but `128 × 22.5`, so a `BN=128`
or `BN=256` tile pays a partial-tile tail on every row-block.

Because problem (1) is a result of the TOT Triton compiler and not an issue with codegen, this PR tunes the
config as the lever. That has a useful side effect: the tuned configs are not merely
"back to parity" — **all 9 shapes now beat golden**, by 7.6% to 38.5%.

## Technical Details

**`gfx950-GEMM-A16W16-N=2880-K=512.json`** — 3 of 13 buckets

| Bucket | Before | After |
|---|---|---|
| `M_LEQ_4096` | BM=128, BN=128, BK=128, G=1, w=8, s=2, wpe=1 | **BM=64, BN=64**, BK=128, G=1, w=8, s=2, wpe=1 |
| `M_LEQ_8192` | BM=128, BN=128, BK=128, **G=4**, w=8, s=2, wpe=1 | **BM=64, BN=64**, BK=128, **G=1**, w=8, s=2, wpe=1 |
| `any` | BM=128, **BN=256**, BK=64, G=8, w=8, s=3, wpe=1 | BM=128, **BN=64**, BK=64, G=8, w=8, s=3, wpe=1 |

Rationale: `BLOCK_SIZE_N` must divide N. N=2880 = 64×45 exactly; BN=128 gives 22.5 tiles
and BN=256 gives 11.25. Moving to BN=64 removes the partial-tile tail and also drops VGPR
count (76→32 for the `any` bucket).

**`gfx950-GEMM-A16W16-N=2880-K=4096.json`** — 2 of 13 buckets

| Bucket | Before | After |
|---|---|---|
| `M_LEQ_4` | BM=16, BN=16, BK=512, G=1, w=8, s=2, **wpe=8**, cm=`.cg` | BM=16, BN=16, BK=512, G=1, w=8, s=2, **wpe=4**, cm=`.cg` |
| `M_LEQ_2048` | BM=128, BN=128, **BK=128**, **G=1**, w=8, s=2, wpe=4 | BM=128, BN=128, **BK=64**, **G=4**, w=8, s=2, wpe=4 |

Rationale: `M_LEQ_4` is the pure spill case — the tile is unchanged, only the occupancy
floor is relaxed, which takes scratch from 124 B to 0. `M_LEQ_2048` trades BK for a
smaller LDS working set and better L2 reuse via `GROUP_SIZE_M`.

**`gfx950-GEMM-A16W16-N=5120-K=2880.json`** — 2 of 13 buckets

| Bucket | Before | After |
|---|---|---|
| `M_LEQ_2048` | **BM=256, BN=256**, BK=64, **G=4**, w=8, s=2, **wpe=1**, cm=`.cg` | **BM=128, BN=128**, BK=64, **G=1**, w=8, s=2, **wpe=4**, cm=`None` |
| `M_LEQ_4096` | **BM=256, BN=256**, BK=64, G=1, w=8, s=2, wpe=1 | **BM=128, BN=128**, BK=64, G=1, w=8, s=2, **wpe=0** |

Rationale: the 256×256 tile is what pushes Triton 3.8 to 128 VGPRs + 28 B scratch.
Halving the tile drops it to 48–52 VGPRs with zero spill.

**`gfx950-GEMM-A16W16-N=106496-K=16384.json`** — **new file**

| Bucket | Before (inherited from base) | After |
|---|---|---|
| `M_LEQ_256` | BM=128, BN=64, BK=128, G=4, w=8, s=3, wpe=6, cm=`.cg` | BM=256, BN=128, BK=64, G=1, w=8, s=3, wpe=1, cm=`.cg`, kpack=1 |

Every other bucket (`M_LEQ_8/16/32/64/128/512/2048`, `any`) is a **verbatim copy of
`gfx950-GEMM-A16W16.json`**.

### Why a new file was required rather than editing the base config

This is the one change that needs justification, because adding a config file is heavier
than editing one.

`gemm_a16w16` resolves its config in two stages
(`aiter/ops/triton/utils/gemm_config_utils.py::get_gemm_config`):

1. **File selection — exact match on (N,K).** If
   `gfx950-GEMM-A16W16-N={N}-K={K}.json` exists it replaces the base file *wholesale*;
   otherwise `gfx950-GEMM-A16W16.json` is used.
2. **Bucket selection — range match on M.** `M_LEQ_*` ascending → `M_GEQ_*` descending →
   `any`.

The regressed shape M=256, N=106496, K=16384 has no specialised file, so it resolved to
**`gfx950-GEMM-A16W16.json::M_LEQ_256`** — the *base* bucket, which is shared by **every
(N,K) that has no specialised file**. That bucket is tuned for the common
small-to-medium-N case and is doing an excellent job there. Two shapes sitting on that
exact bucket in the sweep are already **68.5–68.9% faster than golden**:

| Shape | uses base `M_LEQ_256` | vs golden |
|---|---|---:|
| M=192, N=1280, K=8192 | yes | −68.7% |
| M=256, N=1280, K=8192 | yes | −68.9% |
| M=256, N=106496, K=16384 | yes | **+6.3% ← the regression** |

N=106496 is ~83× larger than N=1280. The tile that wins at N=1280 (BM=128, BN=64) is the
wrong shape at N=106496, where a wide BM=256/BN=128 tile with `num_stages=3` is ~25%
faster. **There is no single config that serves both**, and there is no dimension in the
dispatch other than (N,K) that can tell them apart — `M_LEQ_256` matches both shapes on M.

So editing the shared base bucket to fix N=106496 would have **destroyed two −68%
improvements** to fix one +6% regression. That is a strictly bad trade.

Creating `gfx950-GEMM-A16W16-N=106496-K=16384.json` uses the dispatcher's existing
exact-(N,K) specialisation tier to isolate the change. Because file selection is an exact
match, **no other shape in the codebase can reach this file.** And because every non-tuned
bucket is a verbatim copy of the base file, behaviour for any *other* M at this same (N,K)
is bit-for-bit unchanged — verified at runtime:

| Shape | resolves to | launch config before vs after |
|---|---|---|
| M=4096, N=106496, K=16384 | new file's `any` (copied from base) | **byte-identical**, still −13.6% vs golden |

This is the same pattern the repo already uses for the other 9 specialised `(N,K)` files
in this family (`N=2880-K=512`, `N=5120-K=2880`, …), so it introduces no new mechanism.

**Trade-off, stated plainly:** the copied buckets now duplicate the base config, so a
future retune of `gfx950-GEMM-A16W16.json` will not propagate to N=106496,K=16384. That is
the accepted cost of not regressing the shared bucket. The alternative — a `kpack`/tile
heuristic keyed on N inside the wrapper — would be a kernel-side change, which this PR
deliberately avoids.

### Config-selection audit

After the change, exactly **9 of 131** swept shapes resolve to a different launch config —
precisely the 9 regressed shapes, and nothing else. Verified by dumping
`_get_config(M,N,K)` for all 131 shapes before and after.

## Test Plan

**1. Correctness**

* `pytest op_tests/triton_tests/gemm/basic/test_gemm_a16w16.py` on golden, untouched TOT,
  and tuned TOT. Covers 25 shapes × bf16/fp16 × TT/NN/NT layouts × gelu/gelu_tanh/silu
  activations × output-tensor variants.
* A 131-shape numerical sweep comparing each environment's output against an fp32
  `F.linear` reference at the repo's own bf16 tolerances (`atol=1e-1, rtol=1e-2`),
  checking NaN/Inf counts and comparing golden-vs-TOT output fingerprints.

**2. Shape coverage — 131 unique shapes**, deduplicated from three sources:

| Source | count |
|---|---:|
| Benchmark defaults (`benchmark_utils.get_x_vals`) | 15 |
| Tester `get_x_vals` | 25 |
| Config files — one representative M per `M_LEQ_*`/`any` bucket of all 10 files | 104 |
| `model_shapes.json` (GPT-OSS 120B, DeepSeek-R1, Llama4 Maverick, Qwen3-235B, Kimi-K2) at TP=1 and TP=8 | 56 |
| Shapes with >1 source attribution | 53 |

**3. Performance measurement — `rocprofv3 --kernel-trace`**

* rocprofv3 **v1.1.0**; timings are `End_Timestamp − Start_Timestamp` per dispatch from
  `trace_kernel_trace.csv`. 71 trace files collected in total.
* Trace filtered to `_gemm_a16_w16_kernel*` **and** `_gemm_a16w16_reduce_kernel*`. The
  latter matters: with `NUM_KSPLIT > 1` the op emits **two** GPU kernels, and TOT selects
  split-K on 34 of 131 shapes where golden selects it on none. Both dispatches are summed.
* **300 iterations per shape**, fixed. 
* Chronological **10% trim**: drop the first 30 and last 30 dispatches, mean the middle
  **240 retained**.
* **3-5 repetitions per environment based on variance**, golden/TOT **interleaved**, with reps 4–5 in reversed
  order.

**Measurement caveat worth recording:** an initial 3-rep run reported 66 unstable shapes
and a large set of spurious improvements. The cause was **GPU clock ramp** — the first
process to touch an idle GPU measures its own ramp-up, inflating rep1 by up to ~2× on
small shapes while reps 2–3 agreed to <1%. Confirmed by re-running the cold environment on
a hot GPU, which reproduced reps 2–3 exactly. Fixed with an in-process clock-ramp burst
plus interleaving; unstable dropped 66 → 4, and the reversed-order control gives
first-vs-second-mover median ratios of 0.9998 (golden) / 0.9984 (TOT). Golden also
reproduces across two independent sessions to a median ratio of 1.0005.

## Test Result

### Correctness — no change, all green

| Check | golden | TOT before | TOT after |
|---|---|---|---|
| `pytest test_gemm_a16w16.py` | 240 passed, 0 failed | 240 passed, 516 skipped, 0 failed | **240 passed, 516 skipped, 0 failed** |
| 131-shape numerical check vs fp32 ref | 131/131 ok | 131/131 ok | **131/131 ok** |
| NaN / Inf | none | none | **none** |

### The 9 fixed shapes

| M | N | K | golden µs | TOT before µs | TOT after µs | before vs golden | **after vs golden** | after vs TOT before |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 4096 | 2880 | 512 | 40.218 | 41.612 | 28.617 | +2.8% | **−28.8%** | −31.2% |
| 8192 | 2880 | 512 | 75.755 | 80.321 | 51.017 | +5.6% | **−32.7%** | −36.5% |
| 16384 | 2880 | 512 | 142.124 | 149.929 | 87.337 | +5.2% | **−38.5%** | −41.7% |
| 1 | 2880 | 4096 | 9.500 | 26.900 | 8.774 | **+184.4%** | **−7.6%** | −67.4% |
| 4 | 2880 | 4096 | 9.566 | 26.513 | 8.533 | **+177.4%** | **−10.8%** | −67.8% |
| 2048 | 2880 | 4096 | 83.986 | 85.731 | 70.368 | +2.2% | **−16.2%** | −17.9% |
| 2048 | 5120 | 2880 | 90.697 | 100.515 | 77.266 | +10.9% | **−14.8%** | −23.1% |
| 4096 | 5120 | 2880 | 158.255 | 178.415 | 134.950 | +12.7% | **−14.7%** | −24.4% |
| 256 | 106496 | 16384 | 1262.518 | 1337.353 | 944.103 | +6.3% | **−25.2%** | −29.4% |

### Full final table (golden vs tuned TOT, all 131 shapes)

Classification: `regression` iff `tot_avg > 1.005 × golden_avg + 0.5`; `improvement`
symmetric; `below_threshold` when golden < 4.0 µs; `unstable` when repetition spread > 5%
over 5 reps.

See [here](https://amdcloud-my.sharepoint.com/:x:/r/personal/nidanial_amd_com/Documents/Documents/[Golden-Release-Kernel-Benchmarks.xlsx](https://amdcloud-my.sharepoint.com/:x:/r/personal/nidanial_amd_com/Documents/Documents/Golden-Release-Kernel-Benchmarks.xlsx?d=wb73024da391f40e899e235ee08b92a1e&csf=1&web=1&e=gmEcEj&nav=MTVfezc1NTkyMDI0LThEQjctNEE1Qy05Njc5LUU1ODM0QkMyQzlBRX0)?d=wb73024da391f40e899e235ee08b92a1e&csf=1&web=1&e=gmEcEj&nav=MTVfezc1NTkyMDI0LThEQjctNEE1Qy05Njc5LUU1ODM0QkMyQzlBRX0) for the full run

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
