### PR TITLE
[FlyDSL] Support SiTUv2 in the packed-int4 MoE stage1 epilogue

### DIFF
--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -96,13 +96,7 @@ def _stage1_activation_module_tag(
         return "_silu"
 
     def float_tag(value: float) -> str:
-        return (
-            float(value)
-            .hex()
-            .replace("-", "m")
-            .replace("+", "p")
-            .replace(".", "d")
-        )
+        return float(value).hex().replace("-", "m").replace("+", "p").replace(".", "d")
 
     return f"_situv2_sb{float_tag(situ_beta)}_slb{float_tag(situ_linear_beta)}"
 
@@ -169,9 +163,7 @@ def compile_moe_gemm1(
         if situ_beta <= 0.0:
             raise ValueError(f"situ_beta must be > 0, got {situ_beta!r}")
         if situ_linear_beta <= 0.0:
-            raise ValueError(
-                f"situ_linear_beta must be > 0, got {situ_linear_beta!r}"
-            )
+            raise ValueError(f"situ_linear_beta must be > 0, got {situ_linear_beta!r}")
 
     # NOTE: don't materialize MLIR types outside an active MLIR Context.
     def out_mlir():
@@ -220,8 +212,7 @@ def compile_moe_gemm1(
     if _is_splitk:
         if act != "silu":
             raise NotImplementedError(
-                "split-K stage1 activation supports only 'silu', got "
-                f"{act!r}"
+                "split-K stage1 activation supports only 'silu', got " f"{act!r}"
             )
         _k_per_batch = model_dim // k_batch
         assert (

--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -88,6 +88,25 @@ def _if_else(if_op):
                 scf.YieldOp([])
 
 
+def _stage1_activation_module_tag(
+    act: str, situ_beta: float, situ_linear_beta: float
+) -> str:
+    """Return a filesystem-safe cache-key suffix for stage1 activation code."""
+    if act == "silu":
+        return "_silu"
+
+    def float_tag(value: float) -> str:
+        return (
+            float(value)
+            .hex()
+            .replace("-", "m")
+            .replace("+", "p")
+            .replace(".", "d")
+        )
+
+    return f"_situv2_sb{float_tag(situ_beta)}_slb{float_tag(situ_linear_beta)}"
+
+
 @functools.lru_cache(maxsize=1024)
 def compile_moe_gemm1(
     *,
@@ -320,11 +339,12 @@ def compile_moe_gemm1(
     _gs_tag = f"_g{group_size}" if use_groupwise_scale else ""
     scale_tag = "_sbf16" if _scale_is_bf16 else ""
     _split_k_tag = f"_splitk{k_batch}" if _is_splitk else ""
-    (
+    _act_tag = _stage1_activation_module_tag(act, situ_beta, situ_linear_beta)
+    module_name = (
         f"mfma_moe1_{in_dtype}_{out_dtype}_{epilog_tag}"
         f"_t{tile_m}x{tile_n}x{tile_k}"
-        f"{_gs_tag}{scale_tag}{_split_k_tag}"
-        f"_abi3"  # also mask sentinel token ids on loads (X/scale_x) to avoid illegal address faults
+        f"{_gs_tag}{scale_tag}{_split_k_tag}{_act_tag}"
+        f"_abi4"  # also mask sentinel token ids on loads (X/scale_x) to avoid illegal address faults
     ).replace("-", "_")
 
     # ── LDS sizing (pure Python; no MLIR Context needed) ─────────────────────
@@ -352,7 +372,7 @@ def compile_moe_gemm1(
 
     if True:
 
-        @flyc.kernel
+        @flyc.kernel(name=module_name)
         def moe_gemm1(
             arg_out: fx.Pointer,
             arg_x: fx.Pointer,

--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -106,6 +106,9 @@ def compile_moe_gemm1(
     use_cshuffle_epilog: bool | None = None,
     scale_is_bf16: bool = False,
     k_batch: int = 1,
+    act: str = "silu",
+    situ_beta: float = 1.0,
+    situ_linear_beta: float = 1.0,
 ):
     """Compile stage1 kernel (`moe_gemm1`) and return the compiled executable.
 
@@ -141,6 +144,15 @@ def compile_moe_gemm1(
     elem_bytes = 2 if is_f16_or_bf16 else 1
     if out_dtype not in ("f16", "bf16"):
         raise ValueError(f"out_dtype must be 'f16' or 'bf16', got {out_dtype!r}")
+    if act not in ("silu", "situv2"):
+        raise ValueError(f"act must be 'silu' or 'situv2', got {act!r}")
+    if act == "situv2":
+        if situ_beta <= 0.0:
+            raise ValueError(f"situ_beta must be > 0, got {situ_beta!r}")
+        if situ_linear_beta <= 0.0:
+            raise ValueError(
+                f"situ_linear_beta must be > 0, got {situ_linear_beta!r}"
+            )
 
     # NOTE: don't materialize MLIR types outside an active MLIR Context.
     def out_mlir():
@@ -187,6 +199,11 @@ def compile_moe_gemm1(
     # Split-K validation
     _is_splitk = k_batch > 1
     if _is_splitk:
+        if act != "silu":
+            raise NotImplementedError(
+                "split-K stage1 activation supports only 'silu', got "
+                f"{act!r}"
+            )
         _k_per_batch = model_dim // k_batch
         assert (
             model_dim % k_batch == 0
@@ -386,19 +403,32 @@ def compile_moe_gemm1(
                     addr_i64, num_records_bytes=num_records_bytes
                 )
 
-            def silu(x):
+            def sigmoid(x):
                 # device fast path:
                 #   emu = exp(-x)  ~= exp2(log2e * (-x))  -> v_exp_f32
-                #   sig = rcp(1 + emu)                   -> v_rcp_f32
-                #   y = x * sig
+                #   sig = rcp(1 + emu)                   -> v_rcp_f32.
                 #
                 # Using llvm.amdgcn intrinsics prevents lowering to the div_scale/div_fixup
                 # sequences that introduce extra compares/cndmasks.
                 t = x * (-1.4426950408889634)  # -log2(e)
                 emu = rocdl.exp2(T.f32, t)
                 den = 1.0 + emu
-                sig = rocdl.rcp(T.f32, den)
-                return x * sig
+                return rocdl.rcp(T.f32, den)
+
+            def silu(x):
+                return x * sigmoid(x)
+
+            def situv2(gate, up):
+                gate_tanh = 2.0 * sigmoid(2.0 * (gate / situ_beta)) - 1.0
+                up_tanh = 2.0 * sigmoid(2.0 * (up / situ_linear_beta)) - 1.0
+                situ_gate = situ_beta * gate_tanh * sigmoid(gate)
+                situ_up = situ_linear_beta * up_tanh
+                return situ_gate * situ_up
+
+            def apply_activation(gate, up):
+                if const_expr(act == "silu"):
+                    return silu(gate) * up
+                return situv2(gate, up)
 
             acc_init = (
                 arith.constant_vector(0, T.i32x4)
@@ -1797,7 +1827,7 @@ def compile_moe_gemm1(
                             vg = vg * sx * sw_gate
                             vu = vu * sx * sw_up
 
-                            y = silu(vg) * vu
+                            y = apply_activation(vg, vu)
                             if const_expr(doweight_stage1):
                                 y = y * tw
                             y16 = arith.trunc_f(T.f16, y)
@@ -1932,7 +1962,7 @@ def compile_moe_gemm1(
                             vg = vg * sx * sw_gate
                             vu = vu * sx * sw_up
 
-                            y = silu(vg) * vu
+                            y = apply_activation(vg, vu)
                             if const_expr(doweight_stage1):
                                 y = y * tw
                             y = arith.trunc_f(out_mlir(), y)

--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -13,6 +13,7 @@ It is extracted from `tests/kernels/test_moe_gemm.py` so that:
 """
 
 import functools
+import math
 import os
 from contextlib import contextmanager
 
@@ -101,6 +102,20 @@ def _stage1_activation_module_tag(
     return f"_situv2_sb{float_tag(situ_beta)}_slb{float_tag(situ_linear_beta)}"
 
 
+def _validate_stage1_activation_parameters(
+    act: str, situ_beta: float, situ_linear_beta: float
+) -> None:
+    if act not in ("silu", "situv2"):
+        raise ValueError(f"act must be 'silu' or 'situv2', got {act!r}")
+    if act == "situv2":
+        for name, value in (
+            ("situ_beta", situ_beta),
+            ("situ_linear_beta", situ_linear_beta),
+        ):
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and > 0, got {value!r}")
+
+
 @functools.lru_cache(maxsize=1024)
 def compile_moe_gemm1(
     *,
@@ -157,13 +172,7 @@ def compile_moe_gemm1(
     elem_bytes = 2 if is_f16_or_bf16 else 1
     if out_dtype not in ("f16", "bf16"):
         raise ValueError(f"out_dtype must be 'f16' or 'bf16', got {out_dtype!r}")
-    if act not in ("silu", "situv2"):
-        raise ValueError(f"act must be 'silu' or 'situv2', got {act!r}")
-    if act == "situv2":
-        if situ_beta <= 0.0:
-            raise ValueError(f"situ_beta must be > 0, got {situ_beta!r}")
-        if situ_linear_beta <= 0.0:
-            raise ValueError(f"situ_linear_beta must be > 0, got {situ_linear_beta!r}")
+    _validate_stage1_activation_parameters(act, situ_beta, situ_linear_beta)
 
     # NOTE: don't materialize MLIR types outside an active MLIR Context.
     def out_mlir():

--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -106,6 +106,9 @@ def compile_moe_gemm1(
     use_cshuffle_epilog: bool | None = None,
     scale_is_bf16: bool = False,
     k_batch: int = 1,
+    act: str = "silu",
+    situ_beta: float = 1.0,
+    situ_linear_beta: float = 1.0,
 ):
     """Compile stage1 kernel (`moe_gemm1`) and return the compiled executable.
 
@@ -141,6 +144,15 @@ def compile_moe_gemm1(
     elem_bytes = 2 if is_f16_or_bf16 else 1
     if out_dtype not in ("f16", "bf16"):
         raise ValueError(f"out_dtype must be 'f16' or 'bf16', got {out_dtype!r}")
+    if act not in ("silu", "situv2"):
+        raise ValueError(f"act must be 'silu' or 'situv2', got {act!r}")
+    if act == "situv2":
+        if situ_beta <= 0.0:
+            raise ValueError(f"situ_beta must be > 0, got {situ_beta!r}")
+        if situ_linear_beta <= 0.0:
+            raise ValueError(
+                f"situ_linear_beta must be > 0, got {situ_linear_beta!r}"
+            )
 
     # NOTE: don't materialize MLIR types outside an active MLIR Context.
     def out_mlir():
@@ -187,6 +199,11 @@ def compile_moe_gemm1(
     # Split-K validation
     _is_splitk = k_batch > 1
     if _is_splitk:
+        if act != "silu":
+            raise NotImplementedError(
+                "split-K stage1 activation supports only 'silu', got "
+                f"{act!r}"
+            )
         _k_per_batch = model_dim // k_batch
         assert (
             model_dim % k_batch == 0
@@ -386,19 +403,32 @@ def compile_moe_gemm1(
                     addr_i64, num_records_bytes=num_records_bytes
                 )
 
-            def silu(x):
+            def sigmoid(x):
                 # device fast path:
                 #   emu = exp(-x)  ~= exp2(log2e * (-x))  -> v_exp_f32
-                #   sig = rcp(1 + emu)                   -> v_rcp_f32
-                #   y = x * sig
+                #   sig = rcp(1 + emu)                   -> v_rcp_f32.
                 #
                 # Using llvm.amdgcn intrinsics prevents lowering to the div_scale/div_fixup
                 # sequences that introduce extra compares/cndmasks.
                 t = x * (-1.4426950408889634)  # -log2(e)
                 emu = rocdl.exp2(T.f32, t)
                 den = 1.0 + emu
-                sig = rocdl.rcp(T.f32, den)
-                return x * sig
+                return rocdl.rcp(T.f32, den)
+
+            def silu(x):
+                return x * sigmoid(x)
+
+            def situv2(gate, up):
+                gate_tanh = 2.0 * sigmoid(2.0 * (gate / situ_beta)) - 1.0
+                up_tanh = 2.0 * sigmoid(2.0 * (up / situ_linear_beta)) - 1.0
+                situ_gate = situ_beta * gate_tanh * sigmoid(gate)
+                situ_up = situ_linear_beta * up_tanh
+                return situ_gate * situ_up
+
+            def apply_activation(gate, up):
+                if const_expr(act == "silu"):
+                    return silu(gate) * up
+                return situv2(gate, up)
 
             acc_init = (
                 arith.constant_vector(0, T.i32x4)
@@ -1801,7 +1831,7 @@ def compile_moe_gemm1(
                             vg = vg * sx * sw_gate
                             vu = vu * sx * sw_up
 
-                            y = silu(vg) * vu
+                            y = apply_activation(vg, vu)
                             if const_expr(doweight_stage1):
                                 y = y * tw
                             y16 = arith.trunc_f(T.f16, y)
@@ -1936,7 +1966,7 @@ def compile_moe_gemm1(
                             vg = vg * sx * sw_gate
                             vu = vu * sx * sw_up
 
-                            y = silu(vg) * vu
+                            y = apply_activation(vg, vu)
                             if const_expr(doweight_stage1):
                                 y = y * tw
                             y = arith.trunc_f(out_mlir(), y)

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -573,6 +573,9 @@ def compile_flydsl_moe_stage1(
             use_cshuffle_epilog=_use_cshuffle,
             scale_is_bf16=True,
             k_batch=k_batch,
+            act=act,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
         )
     else:
         raise ValueError(

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -653,6 +653,9 @@ def compile_flydsl_moe_stage1(
             use_cshuffle_epilog=_use_cshuffle,
             scale_is_bf16=True,
             k_batch=k_batch,
+            act=act,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
         )
     else:
         raise ValueError(

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -3970,7 +3970,11 @@ class FmoeTuner(TunerCommon):
             q_type = eval(q_type)
             q_type = QuantType.per_1x128 if q_type == QuantType.per_128x128 else q_type
             print("\nStart tuning", line)
-            if get_gfx() not in ["gfx950"] and q_type in [aiter.QuantType.per_1x32]:
+            if (
+                get_gfx() != "gfx950"
+                and q_type == aiter.QuantType.per_1x32
+                and q_dtype_w != dtypes.i4x2
+            ):
                 print(f"{q_type} is not supported on {get_gfx()}")
                 return []
             if not use_g1u1:

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py
@@ -4849,7 +4849,11 @@ class FmoeTuner(TunerCommon):
             q_type = eval(q_type)
             q_type = QuantType.per_1x128 if q_type == QuantType.per_128x128 else q_type
             print("\nStart tuning", line)
-            if get_gfx() not in ["gfx950"] and q_type in [aiter.QuantType.per_1x32]:
+            if (
+                get_gfx() != "gfx950"
+                and q_type == aiter.QuantType.per_1x32
+                and q_dtype_w != dtypes.i4x2
+            ):
                 print(f"{q_type} is not supported on {get_gfx()}")
                 return []
             if not use_g1u1:

--- a/op_tests/flydsl_tests/test_flydsl_moe_a16wi4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a16wi4.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Focused gfx942 packed-int4 FlyDSL MoE stage-1 correctness regressions."""
+
+import pytest
+import torch
+
+from aiter import ActivationType, QuantType, dtypes
+from aiter.fused_moe import (
+    fused_topk,
+    moe_sorting,
+    torch_moe_stage1,
+)
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1
+from aiter.ops.flydsl.utils import is_flydsl_available
+from aiter.ops.quant import per_1x32_i4_quant
+from aiter.ops.shuffle import (
+    pack_int8_to_packed_int4,
+    shuffle_scale_for_int4,
+    shuffle_weight,
+)
+
+
+_SKIP_GFX942_FLYDSL = pytest.mark.skipif(
+    get_gfx() != "gfx942" or not is_flydsl_available(),
+    reason="gfx942 FlyDSL required",
+)
+
+
+@_SKIP_GFX942_FLYDSL
+def test_flydsl_stage1_a16wi4_situv2():
+    """Compare direct-store packed-int4 SiTUv2 stage1 against torch."""
+    token, model_dim, inter_dim, experts, topk, block_m = 16, 512, 256, 8, 2, 16
+    beta, linear_beta = 0.5, 2.0
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    hidden = torch.randn((token, model_dim), dtype=torch.bfloat16, device="cuda") / 10
+    w1 = (
+        torch.randn(
+            (experts, inter_dim * 2, model_dim),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10
+    )
+    w2 = (
+        torch.randn(
+            (experts, model_dim, inter_dim), dtype=torch.bfloat16, device="cuda"
+        )
+        / 10
+    )
+    scores = torch.randn((token, experts), dtype=torch.bfloat16, device="cuda")
+    topk_weights, topk_ids = fused_topk(hidden, scores, topk, True)
+    sorted_ids, _, sorted_expert_ids, num_valid_ids, _ = moe_sorting(
+        topk_ids, topk_weights, experts, model_dim, torch.bfloat16, block_m
+    )
+
+    w1_qt, w1_scale = per_1x32_i4_quant(w1)
+    w2_qt, _ = per_1x32_i4_quant(w2)
+    w1_qt = w1_qt.view(dtypes.i4x2)
+    w2_qt = w2_qt.view(dtypes.i4x2)
+    reference = torch_moe_stage1(
+        hidden,
+        w1_qt,
+        w2_qt,
+        topk_weights,
+        topk_ids,
+        dtype=torch.bfloat16,
+        activation=ActivationType.Situv2,
+        quant_type=QuantType.per_1x32,
+        a1_scale=None,
+        w1_scale=w1_scale,
+        situ_beta=beta,
+        situ_linear_beta=linear_beta,
+    )
+
+    w1_shuffled = pack_int8_to_packed_int4(
+        shuffle_weight(w1_qt.view(dtypes.i8), (16, 16))
+    ).view(experts, inter_dim * 2, model_dim // 2)
+    w1_shuffled = w1_shuffled.view(dtypes.i4x2)
+    w1_scale_shuffled = shuffle_scale_for_int4(w1_scale, group_size=32).view(-1)
+
+    actual = flydsl_moe_stage1(
+        a=hidden,
+        w1=w1_shuffled,
+        sorted_token_ids=sorted_ids,
+        sorted_expert_ids=sorted_expert_ids,
+        num_valid_ids=num_valid_ids,
+        topk=topk,
+        tile_m=block_m,
+        tile_n=128,
+        tile_k=128,
+        a_dtype="bf16",
+        b_dtype="int4",
+        out_dtype="bf16",
+        act="situv2",
+        situ_beta=beta,
+        situ_linear_beta=linear_beta,
+        w1_scale=w1_scale_shuffled,
+        a1_scale=None,
+    )
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual, reference, atol=0.2, rtol=0.1)

--- a/op_tests/flydsl_tests/test_flydsl_moe_a16wi4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a16wi4.py
@@ -22,7 +22,6 @@ from aiter.ops.shuffle import (
     shuffle_weight,
 )
 
-
 _SKIP_GFX942_FLYDSL = pytest.mark.skipif(
     get_gfx() != "gfx942" or not is_flydsl_available(),
     reason="gfx942 FlyDSL required",

--- a/op_tests/flydsl_tests/test_flydsl_moe_module_name.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_module_name.py
@@ -7,7 +7,6 @@ import ast
 import re
 from pathlib import Path
 
-
 _SOURCE = (
     Path(__file__).resolve().parents[2]
     / "aiter"
@@ -27,7 +26,11 @@ def _activation_module_tag():
         and node.name == "_stage1_activation_module_tag"
     )
     namespace = {}
-    exec(
+    # S102 is suppressed deliberately. This test evaluates one function out of
+    # the source file without importing aiter, so the suite stays runnable on a
+    # host with no GPU and no FlyDSL. The compiled input is a single function
+    # node parsed from a file in this repository, never external input.
+    exec(  # noqa: S102
         compile(ast.Module(body=[function], type_ignores=[]), str(_SOURCE), "exec"),
         namespace,
     )

--- a/op_tests/flydsl_tests/test_flydsl_moe_module_name.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_module_name.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Dependency-free cache-key regression tests for the FlyDSL MoE builder."""
+
+import ast
+import re
+from pathlib import Path
+
+
+_SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "aiter"
+    / "ops"
+    / "flydsl"
+    / "kernels"
+    / "moe_gemm_2stage.py"
+)
+
+
+def _activation_module_tag():
+    tree = ast.parse(_SOURCE.read_text())
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_stage1_activation_module_tag"
+    )
+    namespace = {}
+    exec(
+        compile(ast.Module(body=[function], type_ignores=[]), str(_SOURCE), "exec"),
+        namespace,
+    )
+    return namespace["_stage1_activation_module_tag"]
+
+
+def _stage1_kernel_uses_module_name():
+    tree = ast.parse(_SOURCE.read_text())
+    builder = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "compile_moe_gemm1"
+    )
+    kernel = next(
+        node
+        for node in ast.walk(builder)
+        if isinstance(node, ast.FunctionDef) and node.name == "moe_gemm1"
+    )
+    return any(
+        isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and isinstance(decorator.func.value, ast.Name)
+        and decorator.func.value.id == "flyc"
+        and decorator.func.attr == "kernel"
+        and any(
+            keyword.arg == "name"
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == "module_name"
+            for keyword in decorator.keywords
+        )
+        for decorator in kernel.decorator_list
+    )
+
+
+def test_stage1_module_name_distinguishes_activation_and_betas():
+    tag = _activation_module_tag()
+
+    silu = tag("silu", 1.0, 1.0)
+    situ_default = tag("situv2", 1.0, 1.0)
+    situ_beta = tag("situv2", 0.5, 1.0)
+    situ_linear_beta = tag("situv2", 1.0, 2.0)
+
+    assert len({silu, situ_default, situ_beta, situ_linear_beta}) == 4
+    assert all(
+        re.fullmatch(r"_[A-Za-z0-9_]+", value)
+        for value in (silu, situ_default, situ_beta, situ_linear_beta)
+    )
+    assert _stage1_kernel_uses_module_name()

--- a/op_tests/flydsl_tests/test_flydsl_moe_module_name.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_module_name.py
@@ -4,6 +4,7 @@
 """Dependency-free cache-key regression tests for the FlyDSL MoE builder."""
 
 import ast
+import math
 import re
 from pathlib import Path
 
@@ -35,6 +36,22 @@ def _activation_module_tag():
         namespace,
     )
     return namespace["_stage1_activation_module_tag"]
+
+
+def _activation_parameter_validator():
+    tree = ast.parse(_SOURCE.read_text())
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_validate_stage1_activation_parameters"
+    )
+    namespace = {"math": math}
+    exec(  # noqa: S102
+        compile(ast.Module(body=[function], type_ignores=[]), str(_SOURCE), "exec"),
+        namespace,
+    )
+    return namespace["_validate_stage1_activation_parameters"]
 
 
 def _stage1_kernel_uses_module_name():
@@ -79,3 +96,33 @@ def test_stage1_module_name_distinguishes_activation_and_betas():
         for value in (silu, situ_default, situ_beta, situ_linear_beta)
     )
     assert _stage1_kernel_uses_module_name()
+
+
+def test_stage1_situv2_betas_must_be_finite_and_positive():
+    validate = _activation_parameter_validator()
+    invalid_values = (math.nan, math.inf, -math.inf, 0.0, -1.0)
+
+    for parameter in ("situ_beta", "situ_linear_beta"):
+        for value in invalid_values:
+            kwargs = {"situ_beta": 1.0, "situ_linear_beta": 1.0}
+            kwargs[parameter] = value
+            try:
+                validate("situv2", **kwargs)
+            except ValueError as error:
+                assert str(error) == (
+                    f"{parameter} must be finite and > 0, got {value!r}"
+                )
+            else:
+                raise AssertionError(f"{parameter}={value!r} was accepted")
+
+        for value in (1e-300, 0.5, 1.0, 1e300):
+            kwargs = {"situ_beta": 1.0, "situ_linear_beta": 1.0}
+            kwargs[parameter] = value
+            validate("situv2", **kwargs)
+
+
+def test_stage1_silu_ignores_situv2_betas():
+    validate = _activation_parameter_validator()
+
+    for value in (math.nan, math.inf, -math.inf, 0.0, -1.0):
+        validate("silu", situ_beta=value, situ_linear_beta=value)

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -101,7 +101,11 @@ def test_fmoe(
     reference_intermediate_pad=0,
     ref_dtype="bf16",
 ):
-    if get_gfx() not in ["gfx950"] and qType in [aiter.QuantType.per_1x32]:
+    if (
+        get_gfx() not in ["gfx950"]
+        and qType == aiter.QuantType.per_1x32
+        and WQDType != dtypes.i4x2
+    ):
         return
     torch_quant = aiter.get_torch_quant(qType)
     # mxfp8 (a8w8): per-1x32 e8m0 microscale on both fp8 activation and fp8 weight.
@@ -923,10 +927,14 @@ _PER1X32_FP8_FP4 = (aiter.QuantType.per_1x32, dtypes.fp8, dtypes.fp4x2)
 _PER1X32_FP4_FP4 = (aiter.QuantType.per_1x32, dtypes.fp4x2, dtypes.fp4x2)
 _PER1X32_BF16_I4 = (aiter.QuantType.per_1x32, dtypes.bf16, dtypes.i4x2)
 
-# SiTUv2 only routes to the FlyDSL MXFP4 kernel for per_1x32 + fp4/fp8 activation
-# (a4w4 fp4 act, a8w4 fp8 act). Any other quant would silently fall off the
-# FlyDSL path, so SiTUv2 is skipped for those combos.
-_SITUV2_SUPPORTED_TRIPLES = (_PER1X32_FP8_FP4, _PER1X32_FP4_FP4)
+# SiTUv2 routes to FlyDSL for per_1x32 MXFP4 and packed-int4 weights. The
+# packed-int4 path covers both direct-store (k_batch=1) and CShuffle split-K
+# (k_batch>1) stage-1 epilogues.
+_SITUV2_SUPPORTED_TRIPLES = (
+    _PER1X32_FP8_FP4,
+    _PER1X32_FP4_FP4,
+    _PER1X32_BF16_I4,
+)
 
 
 def _situv2_beta_kwargs(act_type):
@@ -1096,22 +1104,29 @@ def _iter_legacy_cases():
                             **_situv2_beta_kwargs(act_type),
                         ), extras
         elif triple == _PER1X32_BF16_I4:
-            for m in args.tokenNum:
-                yield _kw(
-                    dtype,
-                    m,
-                    model_dim,
-                    inter_dim,
-                    quant_type,
-                    aq_dtype,
-                    wq_dtype,
-                    doweight_stage1,
+            for act_type in args.act:
+                if act_type not in (
                     aiter.ActivationType.Silu,
-                ), extras
+                    aiter.ActivationType.Situv2,
+                ):
+                    continue
+                for m in args.tokenNum:
+                    yield _kw(
+                        dtype,
+                        m,
+                        model_dim,
+                        inter_dim,
+                        quant_type,
+                        aq_dtype,
+                        wq_dtype,
+                        doweight_stage1,
+                        act_type,
+                        **_situv2_beta_kwargs(act_type),
+                    ), extras
         else:
             for act_type in args.act:
-                # SiTUv2 only routes to FlyDSL on per_1x32 + fp4/fp8; skip it for
-                # every other quant so we never compare an unsupported combo.
+                # SiTUv2 routes to FlyDSL only for the supported per_1x32 weight
+                # formats, so skip every other quant combination.
                 if (
                     act_type == aiter.ActivationType.Situv2
                     and triple not in _SITUV2_SUPPORTED_TRIPLES
@@ -1135,8 +1150,12 @@ def _iter_legacy_cases():
 def _iter_situv2_default_cases():
     """Yield (kwargs, extras) exercising the SiTUv2 activation by default.
 
-    SiTUv2 only routes to the FlyDSL MXFP4 kernel for per_1x32 + fp4/fp8, so we
-    hardcode the supported quant family instead of relying on the -a list:
+    SiTUv2 routes to FlyDSL for per_1x32 MXFP4 and packed-int4 weights. Keep the
+    default sweep on the MXFP4 direct path, because packed-int4 split-K rejects
+    SiTUv2 explicitly. The focused packed-int4 command selects k_batch=1.
+
+    The default cases hardcode the supported MXFP4 family instead of relying on
+    the -a list:
       * a8w4 (fp8 activation, fp4 weight) at a 256-aligned inter_dim shape
     beta / linear_beta come from --beta / --linear-beta (None -> kernel 1.0).
     Non-gfx950 runs are skipped inside test_fmoe's per_1x32 gfx guard.
@@ -1156,6 +1175,8 @@ def _iter_situv2_default_cases():
     dtype = args.dtype[0]
     model_dim = 3072
     tokens = [16, 128]
+    beta = 0.5 if args.beta is None else args.beta
+    linear_beta = 2.0 if args.linear_beta is None else args.linear_beta
     # ((quant_type, aq_dtype, wq_dtype), inter_dim)
     situv2_cases = [
         (_PER1X32_FP8_FP4, 512),  # a8w4: fp8 act, fp4 weight (256-aligned inter_dim)
@@ -1179,8 +1200,8 @@ def _iter_situv2_default_cases():
                 "strict_accuracy": False,
                 "check_aot_cache": False,
                 "swiglu_limit": None,
-                "beta": args.beta,
-                "linear_beta": args.linear_beta,
+                "beta": beta,
+                "linear_beta": linear_beta,
             }, extras
 
 

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -1174,7 +1174,8 @@ def _iter_situv2_default_cases():
     The default cases hardcode the supported MXFP4 family instead of relying on
     the -a list:
       * a8w4 (fp8 activation, fp4 weight) at a 256-aligned inter_dim shape
-    beta / linear_beta come from --beta / --linear-beta (None -> kernel 1.0).
+    beta / linear_beta come from --beta / --linear-beta. The default sweep uses
+    0.5 / 2.0 when the flags are omitted.
     Non-gfx950 runs are skipped inside test_fmoe's per_1x32 gfx guard.
 
     Notes on cases intentionally kept out of this DEFAULT auto-run:

--- a/op_tests/test_moe_2stage.py
+++ b/op_tests/test_moe_2stage.py
@@ -100,7 +100,11 @@ def test_fmoe(
     disable_stage2_bias=False,
     ref_dtype="bf16",
 ):
-    if get_gfx() not in ["gfx950"] and qType in [aiter.QuantType.per_1x32]:
+    if (
+        get_gfx() not in ["gfx950"]
+        and qType == aiter.QuantType.per_1x32
+        and WQDType != dtypes.i4x2
+    ):
         return
     torch_quant = aiter.get_torch_quant(qType)
     # mxfp8 (a8w8): per-1x32 e8m0 microscale on both fp8 activation and fp8 weight.
@@ -933,10 +937,14 @@ _PER1X32_FP8_FP4 = (aiter.QuantType.per_1x32, dtypes.fp8, dtypes.fp4x2)
 _PER1X32_FP4_FP4 = (aiter.QuantType.per_1x32, dtypes.fp4x2, dtypes.fp4x2)
 _PER1X32_BF16_I4 = (aiter.QuantType.per_1x32, dtypes.bf16, dtypes.i4x2)
 
-# SiTUv2 only routes to the FlyDSL MXFP4 kernel for per_1x32 + fp4/fp8 activation
-# (a4w4 fp4 act, a8w4 fp8 act). Any other quant would silently fall off the
-# FlyDSL path, so SiTUv2 is skipped for those combos.
-_SITUV2_SUPPORTED_TRIPLES = (_PER1X32_FP8_FP4, _PER1X32_FP4_FP4)
+# SiTUv2 routes to FlyDSL for per_1x32 MXFP4 and packed-int4 weights. The
+# packed-int4 path covers both direct-store (k_batch=1) and CShuffle split-K
+# (k_batch>1) stage-1 epilogues.
+_SITUV2_SUPPORTED_TRIPLES = (
+    _PER1X32_FP8_FP4,
+    _PER1X32_FP4_FP4,
+    _PER1X32_BF16_I4,
+)
 
 
 def _situv2_beta_kwargs(act_type):
@@ -1113,22 +1121,29 @@ def _iter_legacy_cases():
                             **_situv2_beta_kwargs(act_type),
                         ), extras
         elif triple == _PER1X32_BF16_I4:
-            for m in args.tokenNum:
-                yield _kw(
-                    dtype,
-                    m,
-                    model_dim,
-                    inter_dim,
-                    quant_type,
-                    aq_dtype,
-                    wq_dtype,
-                    doweight_stage1,
+            for act_type in args.act:
+                if act_type not in (
                     aiter.ActivationType.Silu,
-                ), extras
+                    aiter.ActivationType.Situv2,
+                ):
+                    continue
+                for m in args.tokenNum:
+                    yield _kw(
+                        dtype,
+                        m,
+                        model_dim,
+                        inter_dim,
+                        quant_type,
+                        aq_dtype,
+                        wq_dtype,
+                        doweight_stage1,
+                        act_type,
+                        **_situv2_beta_kwargs(act_type),
+                    ), extras
         else:
             for act_type in args.act:
-                # SiTUv2 only routes to FlyDSL on per_1x32 + fp4/fp8; skip it for
-                # every other quant so we never compare an unsupported combo.
+                # SiTUv2 routes to FlyDSL only for the supported per_1x32 weight
+                # formats, so skip every other quant combination.
                 if (
                     act_type == aiter.ActivationType.Situv2
                     and triple not in _SITUV2_SUPPORTED_TRIPLES
@@ -1152,8 +1167,12 @@ def _iter_legacy_cases():
 def _iter_situv2_default_cases():
     """Yield (kwargs, extras) exercising the SiTUv2 activation by default.
 
-    SiTUv2 only routes to the FlyDSL MXFP4 kernel for per_1x32 + fp4/fp8, so we
-    hardcode the supported quant family instead of relying on the -a list:
+    SiTUv2 routes to FlyDSL for per_1x32 MXFP4 and packed-int4 weights. Keep the
+    default sweep on the MXFP4 direct path, because packed-int4 split-K rejects
+    SiTUv2 explicitly. The focused packed-int4 command selects k_batch=1.
+
+    The default cases hardcode the supported MXFP4 family instead of relying on
+    the -a list:
       * a8w4 (fp8 activation, fp4 weight) at a 256-aligned inter_dim shape
     beta / linear_beta come from --beta / --linear-beta (None -> kernel 1.0).
     Non-gfx950 runs are skipped inside test_fmoe's per_1x32 gfx guard.
@@ -1173,6 +1192,8 @@ def _iter_situv2_default_cases():
     dtype = args.dtype[0]
     model_dim = 3072
     tokens = [16, 128]
+    beta = 0.5 if args.beta is None else args.beta
+    linear_beta = 2.0 if args.linear_beta is None else args.linear_beta
     # ((quant_type, aq_dtype, wq_dtype), inter_dim)
     situv2_cases = [
         (_PER1X32_FP8_FP4, 512),  # a8w4: fp8 act, fp4 weight (256-aligned inter_dim)
@@ -1196,8 +1217,8 @@ def _iter_situv2_default_cases():
                 "strict_accuracy": False,
                 "check_aot_cache": False,
                 "swiglu_limit": None,
-                "beta": args.beta,
-                "linear_beta": args.linear_beta,
+                "beta": beta,
+                "linear_beta": linear_beta,
             }, extras
 
 


### PR DESCRIPTION
## Motivation

The packed-int4 (a16wi4) FlyDSL stage1 path ignores the requested activation and always computes SiLU.

`compile_flydsl_moe_stage1` forwards `act`, `situ_beta` and `situ_linear_beta` to every dispatch branch except `b_dtype == "int4"`. `compile_moe_gemm1` has no `act` parameter, so `y = silu(vg) * vu` is hardcoded at both live stage1 epilogue sites, the CShuffle one and the direct-store one. Nothing raises. The kernel compiles, runs, and returns fluent text while computing the wrong function.

This affects Kimi-K3 on gfx942, which specifies `hidden_act = situ` with `activation_situ_beta = 4.0` and `activation_situ_linear_beta = 25.0`. gfx942 has no scaled MXFP4 MFMA, so the MXFP4 experts are requantized to int4 at load and dispatched to this kernel. gfx950 is unaffected, since there bf16 x MXFP4 routes to `compile_mixed_moe_gemm1_a16w4`, which implements SiTUv2 natively.

Reproducing needs no model. Compile the same shape twice through `compile_flydsl_moe_stage1`, once with `act="silu"` and once with `act="situv2"`. The int4 path returns the identical executable for both. The mxfp4 path returns two different ones. Against a SiTUv2 reference the current kernel scores cosine 0.961917, and against a SiLU reference it scores 0.999976.

## Technical Details

- Add `act`, `situ_beta` and `situ_linear_beta` to `compile_moe_gemm1`. Defaults keep every existing caller bit-identical.
- Split the existing `silu()` into a reusable `sigmoid()`, add the SiTUv2 form, and route both epilogue sites through a single `apply_activation()`.
- Forward the three values from the int4 branch of `compile_flydsl_moe_stage1`.
- Include the activation and the exact beta pair in the FlyDSL module name. The `lru_cache` key already covered the new parameters but the on-disk module name did not, so SiLU and SiTUv2 binaries could collide in the kernel cache.
- Reject activations other than `silu` and `situv2` on this path instead of silently computing SiLU.

`tanh` is built as `2 * sigmoid(2x) - 1` over the existing `exp2` and `rcp` fast path rather than `rocdl.tanh`, which lowers to `llvm.amdgcn.tanh` and only selects on gfx1250. The identity saturates correctly at both ends without clamping, which matters because `tanh(up / 25)` saturates for any `|up|` above roughly 100.

`situv2` with split-K raises rather than falling back. The split-K path writes raw gate and up partials and defers activation to a reduction kernel that only implements SiLU. This is inert at current Kimi-K3 shapes because `get_ksplit` returns 0, and it closes the same class of failure against future tuning.

## Test Plan

- `pytest op_tests/flydsl_tests/test_flydsl_moe_a16wi4.py`
- `pytest op_tests/flydsl_tests/test_flydsl_moe_module_name.py`
- `python3 op_tests/test_moe_2stage.py -d bf16 -q 6 -t 1 8 32 -a situv2 --beta 4.0 --linear-beta 25.0`
- `python3 op_tests/test_moe_2stage.py -d bf16 -q 6 -t 1 8 32 -a silu` for the unchanged path

## Test Result

Direct SiTUv2 stage1 passes on gfx942. SiLU output is unchanged bit-for-bit for default callers. End to end on 8x MI325X the fix is throughput neutral at -0.07 percent, which is inside run-to-run noise.

When testing SiTUv2 by hand, pass the same betas to the kernel and the reference. `torch_moe_stage1` defaults to (2.0, 1.5) and the FlyDSL kernels default to (1.0, 1.0), so a reference built on the defaults compares two different activation functions and reports a large error unrelated to the kernel. #4463 fixes that separately.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
