### PR TITLE
[Bugfix][Triton] Fix int32 KV-offset overflow in _mla_gluon >2GB path

### DIFF
--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -164,6 +164,11 @@ def _mla_gluon(
     num_iter = gl.cdiv(split_kv_end - split_kv_start, BLOCK_N)
     start_n = split_kv_start
 
+    # >2GB KV cache (global_load path): widen strides to int64 so kv offsets don't overflow int32.
+    if not WITHIN_2GB:
+        stride_kv_c_bs = stride_kv_c_bs.to(gl.int64)
+        stride_k_pe_bs = stride_k_pe_bs.to(gl.int64)
+
     # early return with empty kv slice to save compute
     if split_kv_start >= split_kv_end:
         return


### PR DESCRIPTION
On the WITHIN_2GB=False path the KV offset kv_loc * stride_kv_c_bs is computed in int32 and overflows (that overflow is precisely why this branch exists), yielding a wild 64-bit pointer in the global_load fallback and a SIGSEGV in _mla_gluon.

Promote stride_kv_c_bs and stride_k_pe_bs to int64 when not WITHIN_2GB so the whole offset computes in 64-bit. The buffer_load path (WITHIN_2GB=True) keeps 32-bit offsets by hardware requirement; the guard is constexpr so it folds out there.

## Motivation

`_mla_gluon` crashes with a SIGSEGV when the KV cache exceeds 2GB. In that case the kernel selects the `WITHIN_2GB=False` code path, but the KV offset `kv_loc * stride_kv_c_bs` is still computed in int32. For a >2GB cache this multiplication overflows, and the overflowed offset is added to the 64-bit base pointer in the `global_load` fallback, producing an out-of-bounds pointer and a segfault. The overflow is precisely the condition that selects this branch, so the offset must be computed in 64-bit.

## Technical Details

Promote `stride_kv_c_bs` and `stride_k_pe_bs` to `gl.int64` when `not WITHIN_2GB`, so every downstream offset computation (`kv_loc * stride_kv_c_bs + ...` for the KV cache, and the corresponding `stride_k_pe_bs` expressions for K_pe) is evaluated in 64-bit and no longer overflows. The reassignment happens before the first offset is built, so all load sites pick up the widened strides. The `buffer_load` path (`WITHIN_2GB=True`) intentionally keeps 32-bit offsets, which is a hardware requirement of `buffer_load_to_shared`; since `WITHIN_2GB` is a `gl.constexpr`, the guard folds out entirely on that path and there is no runtime or performance impact.

## Test Plan

Ran the MLA gluon kernel with a KV cache sized above 2GB to force the `WITHIN_2GB=False` / `global_load` path, and confirmed the same configuration crashed before the change. Also exercised the `WITHIN_2GB=True` path to confirm no behavioral or performance change (the guard folds out at compile time).

## Test Result

Before: SIGSEGV in `_mla_gluon` on the >2GB KV-cache configuration. After: the kernel runs correctly and produces expected output; the `WITHIN_2GB=True` path is unchanged. No new unit test is added because reproducing this reliably requires allocating a >2GB KV cache, which is impractical in the standard op_test harness.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.