### PR TITLE
[dist] forward transpose_scale through fused AR+RMSNorm per-group quant

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -1618,6 +1618,7 @@ class CustomAllreduce:
         registered: bool = False,
         use_1stage: bool = False,
         emit_bf16: bool = False,
+        transpose_scale: bool = False,
     ):
         K = inp.shape[-1]
         # Fail fast on bad ``group_size`` at the Python boundary. Mirrors
@@ -1629,9 +1630,15 @@ class CustomAllreduce:
         res_out = torch.empty_like(inp)
         num_groups = K // group_size
         out = torch.empty(inp.shape, dtype=fp8, device=inp.device)
-        scale_out = torch.empty(
-            inp.shape[:-1] + (num_groups,), dtype=torch.float32, device=inp.device
-        )
+        if transpose_scale:
+            M = inp.shape[0]
+            scale_out = torch.empty(
+                (num_groups, M), dtype=torch.float32, device=inp.device
+            ).transpose(0, 1)
+        else:
+            scale_out = torch.empty(
+                inp.shape[:-1] + (num_groups,), dtype=torch.float32, device=inp.device
+            )
         # Optional bf16/fp16 mirror of the pre-quantization normed output.
         # Requested by GDN-style layers that also need an unquantized view
         # (e.g. Qwen3.5 in_proj_ba). Zero-overhead when not requested
@@ -1657,6 +1664,7 @@ class CustomAllreduce:
             reg_bytes,
             use_1stage,
             bf16_ptr,
+            transpose_scale,
         )
         if emit_bf16:
             return out, res_out, scale_out, bf16_out
@@ -1924,6 +1932,7 @@ class CustomAllreduce:
         group_size: int = 128,
         use_1stage: bool = False,
         emit_bf16: bool = False,
+        transpose_scale: bool = False,
     ):
         if self.disabled or not self.should_custom_ar(input):
             return None
@@ -1938,16 +1947,23 @@ class CustomAllreduce:
                     registered=True,
                     use_1stage=use_1stage,
                     emit_bf16=emit_bf16,
+                    transpose_scale=transpose_scale,
                 )
             else:
                 K = input.shape[-1]
                 num_groups = K // group_size
                 dummy_out = torch.zeros(input.shape, dtype=fp8, device=input.device)
-                dummy_scale = torch.zeros(
-                    input.shape[:-1] + (num_groups,),
-                    dtype=torch.float32,
-                    device=input.device,
-                )
+                if transpose_scale:
+                    M = input.shape[0]
+                    dummy_scale = torch.zeros(
+                        (num_groups, M), dtype=torch.float32, device=input.device
+                    ).transpose(0, 1)
+                else:
+                    dummy_scale = torch.zeros(
+                        input.shape[:-1] + (num_groups,),
+                        dtype=torch.float32,
+                        device=input.device,
+                    )
                 if emit_bf16:
                     return (
                         dummy_out,
@@ -1966,6 +1982,7 @@ class CustomAllreduce:
                 registered=False,
                 use_1stage=use_1stage,
                 emit_bf16=emit_bf16,
+                transpose_scale=transpose_scale,
             )
 
     def custom_fused_ar_rms_mxfp4_quant(

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -134,6 +134,7 @@ def fused_allreduce_rmsnorm_quant_per_group(
     reg_bytes: int,
     use_1stage: bool,
     bf16_out_ptr: int = 0,
+    transpose_scale: bool = False,
 ) -> None: ...
 
 


### PR DESCRIPTION
## Summary

- Forward the existing `transpose_scale` flag through the legacy `CustomAllreduce` fused AR + RMSNorm + per-group-FP8-quant Python path so callers can ask the kernel to emit the per-group scale directly in the column-major (bpreshuffle) layout.
- The C++ op and pybind binding already support `transpose_scale` (from #3652); only the Python `CustomAllreduce` methods and the ops stub were missing the parameter, so this path always emitted a row-major scale and forced consumers to run a separate transpose.

## Details

`gemm_a8w8_blockscale_preshuffle` on gfx95 consumes the per-group activation scale in a column-major layout: storage `(num_groups, M)` viewed transposed to `(M, num_groups)` with stride `(1, M)`. The fused `fused_allreduce_rmsnorm_quant_per_group` C++ kernel already has a compile-time `TRANSPOSE_SCALE` template that writes exactly that layout at no extra cost, and the pybind binding exposes `transpose_scale` (default `false`). However, the Python wrappers that most callers use — `CustomAllreduce.custom_fused_ar_rms_per_group_quant` and `CustomAllreduce.fused_ar_rms_per_group_quant` — did not accept or forward the flag (the ops stub in `aiter/ops/custom_all_reduce.py` also omitted it), so this path could only ever produce a row-major scale. Callers therefore had to append an explicit transpose (`scale.t().contiguous().t()`), launching a redundant copy kernel per call.

Changes:

- `aiter/ops/custom_all_reduce.py`: add `transpose_scale: bool = False` to the `fused_allreduce_rmsnorm_quant_per_group` op stub (the compiled binding already accepts it).
- `aiter/dist/device_communicators/custom_all_reduce.py`: `fused_ar_rms_per_group_quant` now accepts `transpose_scale`, allocates `scale_out` with the matching column-major stride (`torch.empty((num_groups, M)).transpose(0, 1)`) when set, and forwards the flag to the C++ op; `custom_fused_ar_rms_per_group_quant` accepts and forwards it, including allocating the CUDA-graph capture-mode dummy scale with the same stride so capture and replay layouts agree.

This is purely additive and backward-compatible: `transpose_scale` defaults to `false`, so existing callers are unchanged. When set to `true` the returned scale is byte-for-byte the column-major layout the bpreshuffle GEMM consumes (identical to a post-hoc `.t().contiguous().t()`), letting downstream callers (e.g. SGLang's fused AR + RMSNorm + per-group quant path for Qwen3.5 FP8) drop their redundant transpose kernel.

Validated end to end in SGLang on Qwen3.5-397B-A17B-FP8, TP4 (MI35x): gsm8k 0.955 (numerics-preserving), the per-call transpose copy kernel eliminated (confirmed in a conc4 trace: the fused kernel flips to the `TRANSPOSE_SCALE=true` template variant and the extra copy kernels disappear one-for-one), with a small end-to-end decode-latency / throughput improvement.
