### PR TITLE
tune Kimi-K3 prefill GEMMs for gfx950

### DIFF
--- a/aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv
+++ b/aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv
@@ -99,6 +99,12 @@ gfx950,256,256,8448,7168,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,
 gfx950,256,512,8448,7168,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,4056,1,98.4493,flydsl_gemm3_abf16_wbf16_bf16_t80x128x64_split_k1_block_m_warp1_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950,0.0,629.85,1392.61
 gfx950,256,1024,8448,7168,False,torch.bfloat16,torch.bfloat16,False,False,torch,0,0,125.2133,native,0.0,990.45,1222.65
 gfx950,256,512,2112,7168,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,2374,1,40.8847,flydsl_gemm4_abf16_wbf16_bf16_t96x64x64_split_k1_block_m_warp2_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950,0.0,379.17,972.99
+gfx950,256,10240,7168,768,False,torch.bfloat16,torch.bfloat16,False,False,asm,10,1,121.7956,_ZN5aiter24bf16gemm_bf16_tn_256x256E,0.0,925.67,1424.84
+gfx950,256,10240,7168,1536,False,torch.bfloat16,torch.bfloat16,False,False,asm,10,1,197.2829,_ZN5aiter24bf16gemm_bf16_tn_256x256E,0.0,1142.96,1015.18
+gfx950,256,10240,7168,3584,False,torch.bfloat16,torch.bfloat16,False,False,asm,10,1,395.8499,_ZN5aiter24bf16gemm_bf16_tn_256x256E,0.0,1329.12,686.07
+gfx950,256,10240,7168,4224,False,torch.bfloat16,torch.bfloat16,False,False,asm,10,1,454.1129,_ZN5aiter24bf16gemm_bf16_tn_256x256E,0.0,1365.49,647.12
+gfx950,256,10240,8448,7168,False,torch.bfloat16,torch.bfloat16,False,False,asm,10,1,866.4881,_ZN5aiter24bf16gemm_bf16_tn_256x256E,0.0,1431.26,508.87
+gfx950,256,10240,20480,7168,False,torch.bfloat16,torch.bfloat16,False,False,asm,10,1,2015.5622,_ZN5aiter24bf16gemm_bf16_tn_256x256E,0.0,1491.63,426.6
 gfx1250,256,1,24,7168,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,0,auto,0.0,0.0,0.0
 gfx1250,256,1,128,7168,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,0,auto,0.0,0.0,0.0
 gfx1250,256,1,576,7168,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,0,auto,0.0,0.0,0.0


### PR DESCRIPTION
```markdown
Add validated large-M ASM selections to reduce 10K-token prefill latency on MI355X.

## Motivation

Kimi-K3 uses an `M=10240` chunk size during long-context prefill, but its gfx950 BF16 GEMM configuration did not cover these shapes. This caused them to fall back to native Torch GEMMs.

This PR adds tuned configurations for the shapes where the AITER ASM kernel outperformed the native fallback.

## Technical Details

Updated:

- `aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv`

Added six gfx950 configurations using:

- Kernel: `bf16gemm_bf16_tn_256x256`
- `solidx=10`
- `splitK=1`
- Input/output dtype: BF16
- `M=10240`

Tuned shapes and kernel-level results:

- `(10240, 7168, 768)`: `134.52 → 121.80 us` (`9.46%` faster)
- `(10240, 7168, 1536)`: `211.33 → 197.28 us` (`6.65%` faster)
- `(10240, 7168, 3584)`: `403.18 → 395.85 us` (`1.82%` faster)
- `(10240, 7168, 4224)`: `467.71 → 454.11 us` (`2.91%` faster)
- `(10240, 8448, 7168)`: `899.43 → 866.49 us` (`3.66%` faster)
- `(10240, 20480, 7168)`: `2112.67 → 2015.56 us` (`4.60%` faster)

All selected ASM configurations reported `err_ratio=0.0`.

## Test Plan

- Run the A16W16 tuner on MI355X/gfx950 using ASM, Opus, Skinny, and Torch backends.
- Validate every selected configuration through the production AITER GEMM operator.
- Run AITER CSV schema validation.
- Start Kimi-K3 with TP8 and verify config merging and model initialization.
- Compare deterministic generation against the untuned baseline.
- Run a 100K input / 1K output, concurrency-1 serving benchmark.

## Test Result

Environment:

- GPU: `8 × AMD Instinct MI355X` (`gfx950`)
- Model: Kimi-K3
- TP: 8
- Context/output: `100000 / 1000`
- Requests: 3
- Prefix caching: disabled
- Speculative decoding: disabled

Validation results:

- Production GEMM operator: all selected shapes passed `checkAllclose`
- CSV validation: `13 passed`, including `33` subtests
- TP8 server startup: passed with no duplicate config entries
- Deterministic generation: output matched the untuned baseline
- Serving benchmark: `3/3` requests succeeded

End-to-end comparison against the same AITER + MLA optimization baseline without these CSV rows:

- Mean TTFT: `7305.74 → 7273.99 ms` (`0.43%` lower)
- Mean TPOT: `22.99 → 22.94 ms`
- Mean E2EL: `30275.19 → 30187.60 ms` (`0.29%` lower)
- Total token throughput: `3336.05 → 3345.73 tok/s`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
```