### PR TITLE
[Gluon][MLA] Drop the batch_size == 1 constraint from the fp8 KV regime

### DIFF
--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -10,10 +10,10 @@
 #                        Fast path: when NUM_KV_SPLITS==1, stage-1 writes the
 #                        final output directly to O and stage-2 reduce is skipped.
 #   REGIME='bh16bn128' - bf16 Q + fp8 KV, BLOCK_H=16, BLOCK_N=128,
-#                        nhead <= 96, batch_size=1, NUM_KV_SPLITS=256.
-#                        (batch, split, head_block*qlen) grid. Always splits +
-#                        always reduces. A partial last head block
-#                        (nhead % BLOCK_H != 0) masks OOB heads on Q load / O store.
+#                        nhead <= 96, batch_size >= 1,
+#                        (batch, split, head_block*qlen) grid. Full decode
+#                        (stage-1 + stage-2 reduce into the final O). A partial
+#                        last head block (nhead % BLOCK_H != 0) masks OOB heads.
 #   REGIME='bh16bn64'  - bf16 Q + bf16 KV, BLOCK_H=16, BLOCK_N=64,
 #                        nhead <= 96, batch_size >= 1,
 #                        (batch, split, head_block*qlen) grid. Full decode
@@ -958,10 +958,6 @@ def mla_gluon(
         # consume part of the wave, so the budget divides by them too.
         NUM_M_BLOCKS = triton.cdiv(nhead, BLOCK_H)
         NUM_KV_SPLITS = max(1, 256 // (batch_size * qlen * NUM_M_BLOCKS))
-        if REGIME == "bh16bn128":
-            assert (
-                batch_size == 1
-            ), f"mla_gluon[bh16bn128] requires batch_size=1, got {batch_size}"
         assert (
             q_nope.dtype == torch.bfloat16 and q_pe.dtype == torch.bfloat16
         ), f"q_nope/q_pe must be bf16, got {q_nope.dtype}/{q_pe.dtype}"

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -685,14 +685,14 @@ def test_mla(
             ret["decode:gluon_Mtok/s"] = total_q / us_gluon_decode
 
     # Gluon MLA bh16bn128 decode test
-    # Example: -c 10000000 -b 1 -n 16,1 -d bf16 -kvd fp8
+    # Example: -c 10000000 -b 1 3 4 -n 16,1 -d bf16 -kvd fp8
     if (
         get_gfx() == "gfx950"
         and dtype == torch.bfloat16
         and kvtype == dtypes.fp8
         and nhead <= 16
         and decode_qlen == 1
-        and batch_size == 1
+        and 1 <= batch_size <= 256
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
         and page_size == 1


### PR DESCRIPTION
## Purpose

`mla_gluon` picks a regime from `(nhead, kv dtype)`. For `nhead <= 16` the KV
dtype alone decides: bf16 selects `bh16bn64`, fp8 selects `bh16bn128`. The fp8
regime then asserted `batch_size == 1`, so it could not serve a decode batch at
any head count, while its bf16 sibling takes any batch. There is no flag that
keeps fp8 KV and avoids the regime, since it is inferred from the tensor dtype.

This removes the assert.

## Why it is a stale constraint, not a kernel limit

The two `bh16` regimes share the same batch mapping
(`cur_batch = gl.program_id(0)`) and index Q, O, the page table and the lse
identically. The only differences inside the kernel are the fp8 register/lane
layouts for the 128-wide K tile (`blocked_kv`, `linear_v`); none of them touch
the batch axis. The grid is already 2-D/3-D over batch, and the split policy
already keeps every split non-empty for any batch, so nothing downstream of the
assert assumed a single sequence.

## Validation

gfx950 (MI355X), against an fp32 reference computed over the dequantized cache,
`nhead=12` (Kimi-K3 at TP8):

- ragged varlen, batches 1/2/8/64/256/512: max relative error **0.26%** —
  identical to `batch=1`, and identical to the bf16 `bh16bn64` path, i.e. bf16
  output rounding rather than added error
- 33 block-boundary and short-sequence cases (seq 1..257 around `BLOCK_N=128`)
  × batch 2/64/512: all pass
- `nhead` 16/32/96 at batch 2/64/256: all pass
- bf16 `bh16bn64` unchanged (regression check)

Kernel time for the two `bh16` regimes at ISL 8192 (us/call, stage 1 + stage 2).
Listed for reference, not as a claim about any deployment:

| batch | bf16 KV | fp8 KV |
|------:|--------:|-------:|
| 64    | 113.0   | 60.5   |
| 128   | 213.2   | 124.4  |
| 256   | 401.2   | 276.3  |
| 448   | 713.4   | 470.2  |

`op_tests/test_mla.py`'s `bh16bn128` gate is widened to `1 <= batch_size <= 256`
to match `bh16bn64`, so the batched shapes are actually covered.

## Scope

**This does not by itself enable fp8 KV serving**, and it is no longer on the
default Kimi-K3 path. vLLM has since routed fp8 decode away from Gluon:

- vllm-project/vllm#50578 (merged) sends non-divisor small head counts to the
  padded asm decode, so 12 heads/rank no longer reaches Gluon at `qlen == 1`.
- vllm-project/vllm#51011 takes fp8 off Gluon entirely, at every head count and
  both decode entry points, because the asm path already ships true fp8 kernels
  for this shape. That PR cites this assert as the first of the three ways the
  backend fails on fp8.

The constraint still binds wherever Gluon fp8 is reachable — head counts that
divide 16, `VLLM_ROCM_AITER_MLA_ASM_PADDING=gluon`, and the small-head verify
flatten. Removing it means the regime fails on a real batch by producing correct
output rather than by aborting, and lets the op test cover the shapes it was
silently skipping.

## Notes

An earlier revision of this PR also carried an int32 KV row-base overflow fix.
That was independently found and fixed by #4474 (merged), and has been dropped
here; the two widenings would be redundant. An earlier companion vLLM PR
(vllm-project/vllm#50563) kept the query in bf16 for this regime and has been
closed, since the routing above makes it the wrong approach.

---

*Found and validated with [ROCm Hyperloom](https://github.com/AMD-AGI/Hyperloom), an agentic system that auto-optimizes LLM inference workloads on AMD GPUs.*
