### PR TITLE
parallelize gather_kv_b_proj context chunks

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
+++ b/aiter/ops/triton/_triton_kernels/gather_kv_b_proj.py
@@ -414,7 +414,10 @@ def _triton_gather_kv_b_proj_impl(
     # ===---------------------------------------------------
     # Workload Partition
     # ===---------------------------------------------------
-    pid = tl.program_id(0)
+    flat_pid = tl.program_id(0)
+    num_batch_heads = batch_size * TpNumHeads
+    pid = flat_pid % num_batch_heads
+    chunk_id = flat_pid // num_batch_heads
     pid_batch = pid // TpNumHeads
     pid_head = pid % TpNumHeads
 
@@ -608,7 +611,7 @@ def _triton_gather_kv_b_proj_impl(
     else:
         CHUNK_STRIDE: tl.constexpr = ScaleKGranularity
 
-    for chunk_id in range((total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK):
+    if chunk_id < (total_kv_block + KBlocksPerChunkK - 1) // KBlocksPerChunkK:
         block_lane_valid = (
             chunk_id * KBlocksPerChunkK + tl.arange(0, ChunkK) // KBlockSize
             < total_kv_block

--- a/aiter/ops/triton/gather_kv_b_proj.py
+++ b/aiter/ops/triton/gather_kv_b_proj.py
@@ -103,7 +103,11 @@ def gather_kv_b_proj(
     elif is_fp4_weight:
         ChunkK = 64
     else:
-        ChunkK = 16 if k_buffer.dtype in [torch.float16, torch.bfloat16] else 32
+        ChunkK = (
+            64
+            if no_scale and k_buffer.dtype in [torch.float16, torch.bfloat16]
+            else 16 if k_buffer.dtype in [torch.float16, torch.bfloat16] else 32
+        )
 
     assert total_kv_k == total_kv_v
     assert tp_k_head_num_k == tp_k_head_num_v
@@ -112,17 +116,16 @@ def gather_kv_b_proj(
     padded_k = _next_pow2(qk_nope_head_dim)
     padded_v = _next_pow2(v_head_dim)
 
-    num_stages = 3
+    num_stages = 2
     # To avoid out of LDS limit for gfx942
     if arch_info.get_arch() in ("gfx942",) and ChunkK > 64:
         num_stages = 1
 
-    grid = (batch_size * tp_k_head_num_k,)
+    max_kv_chunks = max(1, (total_kv_k + ChunkK - 1) // ChunkK)
     if is_fp4_weight:
         # Use the actual output token count, not kv_indices capacity. Serving
         # paths may pass a preallocated kv_indices buffer that is much larger
         # than the valid range described by kv_indptr/k_prefix.
-        max_kv_chunks = max(1, (total_kv_k + ChunkK - 1) // ChunkK)
         fp4_scale_k_granularity = 32 if weight_preshuffle else 128
         fp4_grid = (batch_size * tp_k_head_num_k * max_kv_chunks,)
         _triton_gather_kv_b_proj[fp4_grid](
@@ -154,6 +157,7 @@ def gather_kv_b_proj(
         )
         return
 
+    grid = (batch_size * tp_k_head_num_k * max_kv_chunks,)
     _triton_gather_kv_b_proj[grid](
         batch_size,
         k_buffer,


### PR DESCRIPTION
## Motivation

`gather_kv_b_proj` previously processed long-context chunks sequentially inside each `(batch, TP head)` program, resulting in low GPU occupancy for small batches.

This change exposes context chunks through the launch grid to increase parallelism.

## Technical Details

- Flatten the launch grid across batch, TP head, and context chunk.
- Recover `batch`, `head`, and `chunk_id` from the program ID.
- Replace the sequential chunk loop with one chunk per Triton program.
- Expand the host grid by `max_kv_chunks`.
- Use `ChunkK=64` for unscaled BF16/FP16 inputs.
- Reduce `num_stages` from 3 to 2.
- Preserve the existing FP4 path behavior.

## Test Plan

```bash
python3 -m pytest -q op_tests/triton_tests/test_gather_kv_b_proj.py

python3 op_tests/triton_tests/test_gather_kv_b_proj.py \
  -B 1 --blocksize 16 -num_tp 8 -kv_length 16384 -ktype bf16

python3 op_tests/triton_tests/test_gather_kv_b_proj.py \
  -B 1 --blocksize 16 -num_tp 8 -kv_length 16384 -ktype fp8
```

## Test Result

```text
Correctness: 38 passed

MI355X/gfx950, batch=1, TP8, KV length=16384

BF16 per-row:
  1754.73 us -> 244.43 us
  7.18x speedup, 86.1% reduction

BF16 block:
  1324.04 us -> 244.79 us
  5.41x speedup, 81.5% reduction

FP8 per-row:
  822.36 us -> 202.31 us
  4.06x speedup, 75.4% reduction

FP8 block:
  757.14 us -> 198.78 us
  3.81x speedup, 73.7% reduction
```

All BF16 and FP8 reference comparisons passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.