### PR TITLE
[Test] mla_gluon: regression test for the >2GB KV cache path

### DIFF
--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -4,6 +4,8 @@
 import argparse
 import itertools
 import random
+import subprocess
+import sys
 
 import pandas as pd
 import torch
@@ -714,6 +716,84 @@ def test_mla(
     return ret
 
 
+# Regression: KV addresses are kv_loc * stride_kv_c_bs + offs_d, so with a
+# 576-wide bf16 row the int32 product wraps once a page id passes 3,728,270 and
+# the load lands below the cache base. The cases above never reach that row
+# (kv_max_sz caps page ids at 2,097,151), so this needs its own >4 GiB cache.
+# The launch is a subprocess because a memory fault aborts the interpreter
+# rather than raising, which would kill the rest of the CI shard.
+LARGE_KV_FLAG = "--_large-kv-child"
+LARGE_KV_ROWS = 4_400_000  # 4.72 GiB
+LARGE_KV_BASE = 4_255_488  # past 2**31 // 576
+
+
+def _large_kv_child():
+    from aiter.ops.triton.gluon.mla_gluon import mla_gluon
+
+    lora, rope, nhead = 512, 64, 16
+    row = lora + rope
+    scale = row**-0.5
+    torch.manual_seed(0)
+    kv = torch.zeros((LARGE_KV_ROWS, row), dtype=dtypes.bf16)
+    assert kv.shape[0] * kv.stride(0) * kv.element_size() > 0x80000000
+
+    for ctx in (128, 100):  # 100 leaves a partial trailing BLOCK_N tile
+        idx = torch.arange(LARGE_KV_BASE, LARGE_KV_BASE + ctx, dtype=torch.int32)
+        kv[idx.long()] = torch.randn(ctx, row).to(dtypes.bf16)
+        q = torch.randn(1, nhead, lora).to(dtypes.bf16)
+        qpe = torch.randn(1, nhead, rope).to(dtypes.bf16)
+        out = torch.empty(1, nhead, lora, dtype=dtypes.bf16)
+        seqlen = torch.tensor([ctx], dtype=torch.int32)
+        mla_gluon(q, qpe, kv, out, idx.view(1, ctx), seqlen, scale, kv_pe_offset=lora)
+        torch.cuda.synchronize()
+
+        gathered = kv[idx.long()].float()
+        scores = (
+            q[0].float() @ gathered[:, :lora].T + qpe[0].float() @ gathered[:, lora:].T
+        ) * scale
+        ref = torch.softmax(scores, dim=-1) @ gathered[:, :lora]
+        checkAllclose(ref, out[0].float(), msg=f"mla_gluon >2GB kv ctx={ctx} ")
+
+
+def test_mla_gluon_large_kv_cache():
+    need = LARGE_KV_ROWS * 576 * 2 * 1.3
+    if get_gfx() != "gfx950" or torch.cuda.mem_get_info()[0] < need:
+        aiter.logger.info(
+            "mla_gluon >2GB kv cache: skipped, needs gfx950 and %.1fGB free",
+            need / 1e9,
+        )
+        return
+
+    cmd = [sys.executable, __file__, LARGE_KV_FLAG]
+
+    def _no_core_dump():
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+
+    # check=False: the exit code is the assertion below, not an exception
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+        preexec_fn=_no_core_dump,
+    )
+    assert proc.returncode == 0, (
+        f"mla_gluon >2GB kv cache failed (exit {proc.returncode}); "
+        f"likely an int32 KV row-offset overflow.\n{proc.stdout[-2000:]}{proc.stderr[-2000:]}"
+    )
+    # The child's output is captured, so say so here or a pass is indistinguishable
+    # from a skip -- which is the exact failure mode this test exists to fix.
+    aiter.logger.info("mla_gluon >2GB kv cache: passed")
+
+
+if LARGE_KV_FLAG in sys.argv:  # before argparse sees it
+    _large_kv_child()
+    sys.exit(0)
+
+
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description="config input of test",
@@ -858,6 +938,11 @@ parser.add_argument(
 
 
 args = parser.parse_args()
+
+# Before the sweep: this must not be hostage to it, and the VRAM gate wants a
+# clean pool. aiter_test.sh also runs this file 5x with sweep args -- skip those.
+if len(sys.argv) == 1:
+    test_mla_gluon_large_kv_cache()
 
 for nhead, decode_qlen in args.nhead:
     df = []


### PR DESCRIPTION
## Summary

Add deterministic regression coverage for the greater-than-2-GiB Gluon MLA
KV-cache offset overflow fixed by #4474. This PR is test-only and depends on
#4474; it no longer carries a competing runtime fix.

The test allocates a 4.72-GiB BF16 cache and indexes row 4,255,488, beyond the
signed 32-bit wrap point for a 576-element row. It covers both a full
`BLOCK_N=128` tile and a partial 100-token trailing tile.

## Why existing coverage missed it

The existing harness allocates 2,097,152 rows, so it selects the
`WITHIN_2GB=False` branch but cannot index past the wrap point:

| Case | Maximum row | Compared with `2**31 // 576` |
|---|---:|---:|
| existing random indices | 2,097,151 | 1.78x short |
| sequential, batch 256 x context 8,192 | about 2,107,152 | 1.77x short |
| this test | 4,255,488 | crosses the boundary |

The child process is intentional. An HSA memory fault aborts the interpreter;
subprocess isolation turns that into one actionable test failure instead of
terminating the remaining CI shard. The parent also checks that sufficient
memory is available before launching the 4.72-GiB case.

## Public-image reproduction

Hardware: AMD Instinct MI355X (`gfx950`). Public base image:
`vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b`.
Test PR head: `81e524ccb559731d5bf9ba98e62ea49ddd80b816`.
Runtime dependency #4474 head:
`1e4135b1070153135de288af87258f94351fdaba`.

Reconstruct only the two explicit PR deltas; do not merge a moving `main`:

```bash
git clone https://github.com/ROCm/aiter.git aiter-source
git -C aiter-source fetch origin \
  refs/pull/4474/head:pr-4474 \
  refs/pull/4488/head:pr-4488
test "$(git -C aiter-source rev-parse pr-4474)" = \
  1e4135b1070153135de288af87258f94351fdaba
test "$(git -C aiter-source rev-parse pr-4474^)" = \
  3a79aec3b71393a36351e2d0512414d9a1ba7813
test "$(git -C aiter-source rev-parse pr-4488)" = \
  81e524ccb559731d5bf9ba98e62ea49ddd80b816
test "$(git -C aiter-source rev-parse pr-4488^)" = \
  702aacd62c8a6e2fbbc260da338c510ab76f1b1c
git -C aiter-source diff \
  3a79aec3b71393a36351e2d0512414d9a1ba7813..pr-4474 \
  --binary > aiter-4474.patch
git -C aiter-source diff \
  702aacd62c8a6e2fbbc260da338c510ab76f1b1c..pr-4488 \
  --binary > aiter-4488.patch

git clone aiter-source aiter-fixed-tested
git -C aiter-fixed-tested checkout --detach \
  702aacd62c8a6e2fbbc260da338c510ab76f1b1c
git -C aiter-fixed-tested apply --index ../aiter-4474.patch
git -C aiter-fixed-tested apply --index ../aiter-4488.patch
git -C aiter-fixed-tested diff --cached --check
```

Save this as `Dockerfile.repro`:

```dockerfile
# syntax=docker/dockerfile:1
FROM vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b
COPY --from=aiter_source . /workspace/aiter
COPY --from=aiter_source aiter/ /usr/local/lib/python3.12/dist-packages/aiter/
COPY --from=aiter_source csrc/ /usr/local/lib/python3.12/dist-packages/aiter_meta/csrc/
COPY --from=aiter_source hsa/ /usr/local/lib/python3.12/dist-packages/aiter_meta/hsa/
COPY --from=source_manifests / /opt/repro-manifests/
WORKDIR /workspace/aiter
RUN cd /usr/local/lib/python3.12/dist-packages && \
    sha256sum --quiet --check /opt/repro-manifests/aiter.sha256 && \
    cd aiter_meta && \
    sha256sum --quiet --check /opt/repro-manifests/aiter-meta.sha256 && \
    cd /workspace/aiter && \
    sha256sum --quiet --check /opt/repro-manifests/op-tests.sha256 && \
    uv run --no-project --offline python -m compileall -q \
    aiter op_tests/test_mla.py
```

Build and run only the isolated child case:

```bash
mkdir -p manifests-4488
(cd aiter-fixed-tested && \
  find aiter -type f -print0 | sort -z | xargs -0 sha256sum) \
  >manifests-4488/aiter.sha256
(cd aiter-fixed-tested && \
  find csrc hsa -type f -print0 | sort -z | xargs -0 sha256sum) \
  >manifests-4488/aiter-meta.sha256
(cd aiter-fixed-tested && \
  find op_tests -type f -print0 | sort -z | xargs -0 sha256sum) \
  >manifests-4488/op-tests.sha256
docker build --file Dockerfile.repro \
  --build-context aiter_source=./aiter-fixed-tested \
  --build-context source_manifests=./manifests-4488 \
  --tag aiter-pr4488-large-kv-regression .
docker run --rm --ipc host --shm-size 16g \
  --device /dev/kfd --device /dev/dri \
  --group-add video --group-add render \
  --security-opt label=disable -e HIP_VISIBLE_DEVICES=0 \
  --entrypoint bash aiter-pr4488-large-kv-regression \
  -lc 'uv run --no-project --offline python op_tests/test_mla.py --_large-kv-child'
```

Observed on MI355X with #4474: both context lengths passed and the child exited
zero. On the unfixed source, the child exits via SIGABRT after the HSA memory
fault. The parent disables core dumps before starting that intentionally unsafe
control, and the large allocation runs only for the default direct invocation,
not for each of `aiter_test.sh`'s five argument sweeps. Black, Ruff, and
`git diff --check` passed.

## Dependency and duplication

#4474 owns the runtime fix. This PR contributes only the missing deterministic
boundary regression and should merge after, or together with, #4474. OpenAI
Codex assisted with testing and review; the author reviewed every changed line
and the final evidence.
