### PR TITLE
[Gluon][MLA] Split-major grid and blocked stage-2 reduce for the small-nhead decode regime for kimi-k3

### DIFF
--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -758,10 +758,22 @@ def _mla_softmax_reducev_kernel(
     HEAD_DIM_CKV: tl.constexpr,
     HAS_FINAL_LSE: tl.constexpr,
     USE_2D_VIEW: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    D_SPLIT: tl.constexpr,
 ):
+    """Merge the per-split (acc, lse) partials, BLOCK_S splits at a time.
+
+    Each iteration loads BLOCK_S splits as one [BLOCK_S, BLOCK_D] tile and folds
+    it into the running online-softmax accumulator. The head dim is tiled across
+    D_SPLIT programs on grid axis 2; every slice re-derives the same scalar lse
+    statistics from the same Mid_lse vector and owns a disjoint slice of `o`, so
+    slices never communicate. BLOCK_S=1, D_SPLIT=1 is the scalar per-split walk.
+    """
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
-    q_pos = tl.program_id(2)
+    # Grid axis 2 packs (q_pos, head-dim slice).
+    q_pos = tl.program_id(2) // D_SPLIT
+    cur_d = tl.program_id(2) % D_SPLIT
 
     # Recompute this batch's seq len exactly as the decode kernel did, so we can
     # rederive which splits are empty. Stage-1 early-returns on empty splits
@@ -774,36 +786,46 @@ def _mla_softmax_reducev_kernel(
         cur_batch_seq_len = tl.load(B_seq_len + cur_batch + 1) - batch_page_start
     kv_len_per_split = cur_batch_seq_len // NUM_KV_SPLITS
 
-    offs_d_ckv = tl.arange(0, HEAD_DIM_CKV)
+    BLOCK_D: tl.constexpr = HEAD_DIM_CKV // D_SPLIT
+    offs_d_ckv = cur_d * BLOCK_D + tl.arange(0, BLOCK_D)
     offs_l = cur_batch * stride_l_b + q_pos * stride_l_qs + cur_head * stride_l_h + offs_d_ckv
     offs_ml = cur_batch * stride_ml_b + q_pos * stride_ml_qs + cur_head * stride_ml_h
+    offs_s = tl.arange(0, BLOCK_S)
 
     e_sum = 0.0
     e_max = -float("inf")
-    acc = tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
 
     LOOP_START = NUM_KV_SPLITS - 1 if kv_len_per_split == 0 else 0
-    for split_kv_id in range(LOOP_START, NUM_KV_SPLITS):
-        logits = tl.load(Logits + offs_l + split_kv_id * stride_l_s)
-        logits_1 = tl.load(Mid_lse + offs_ml + split_kv_id * stride_ml_s)
+    # Start on a block boundary at or below LOOP_START and mask the uninitialised
+    # slots off inside the block, so stage-1's untouched slots are never read.
+    BLK_START = (LOOP_START // BLOCK_S) * BLOCK_S
+    for split_kv_id in range(BLK_START, NUM_KV_SPLITS, BLOCK_S):
+        s = split_kv_id + offs_s
+        s_ok = (s >= LOOP_START) & (s < NUM_KV_SPLITS)
+        # [BLOCK_S] per-split lse; a masked slot carries no weight.
+        logits_1 = tl.load(Mid_lse + offs_ml + s * stride_ml_s, mask=s_ok, other=-float("inf"))
+        # [BLOCK_S, BLOCK_D] per-split partial numerators.
+        logits = tl.load(Logits + offs_l[None, :] + s[:, None] * stride_l_s, mask=s_ok[:, None], other=0.0)
 
-        n_e_max = tl.maximum(logits_1, e_max)
+        n_e_max = tl.maximum(tl.max(logits_1, 0), e_max)
         old_scale = tl.where(e_max == -float("inf"), 0.0, tl.exp(e_max - n_e_max))
-        acc *= old_scale
         exp_logic = tl.where(logits_1 == -float("inf"), 0.0, tl.exp(logits_1 - n_e_max))
-        # MTP: a fully causal-masked split stores NaN logits with lse=-inf; guard
-        # the accumulate so NaN*0 doesn't poison acc (no-op for plain decode).
-        acc += tl.where(logits_1 == -float("inf"), 0.0, exp_logic * logits)
+        # MTP: a fully causal-masked split stores NaN logits with lse=-inf; drop
+        # the whole row so NaN*0 doesn't poison acc (no-op for plain decode).
+        contrib = tl.where(logits_1[:, None] == -float("inf"), 0.0, exp_logic[:, None] * logits)
 
-        e_sum = e_sum * old_scale + exp_logic
+        acc = acc * old_scale + tl.sum(contrib, 0)
+        e_sum = e_sum * old_scale + tl.sum(exp_logic, 0)
         e_max = n_e_max
 
-    out = acc / e_sum if e_sum > 0.0 else tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
+    out = acc / e_sum if e_sum > 0.0 else tl.zeros([BLOCK_D], dtype=tl.float32)
     tl.store(
         O + cur_batch * stride_o_b + q_pos * stride_o_qs + cur_head * stride_o_h + offs_d_ckv,
         out,
     )
-    if HAS_FINAL_LSE:
+    # Every head-dim slice derived the same lse; slice 0 owns the one store.
+    if HAS_FINAL_LSE and cur_d == 0:
         tl.store(
             Final_lse + cur_batch * stride_fl_b + q_pos * stride_fl_qs + cur_head * stride_fl_h,
             e_max + tl.log(e_sum),
@@ -1132,8 +1154,20 @@ def mla_gluon(
         return o, final_lse
 
     # Stage-2: reduce per-split (acc, lse) into o (and lse when return_lse).
-    # grid axis 2 is q_pos (qlen). o uses the caller's layout (3-D or 4-D).
-    grid_reduce = (batch_size, nhead, qlen)
+    #
+    # Merge BLOCK_S splits per iteration, which shortens the serial rescale chain
+    # and gives the memory system BLOCK_S independent loads, and tile the head dim
+    # across D_SPLIT programs to widen a grid that is otherwise only
+    # batch*nhead*qlen. D_SPLIT backs off while the head dim does not divide
+    # evenly or the slice would fall under 16 elements.
+    RED_D_SPLIT = 8
+    while RED_D_SPLIT > 1 and (
+        head_dim_ckv % RED_D_SPLIT or head_dim_ckv // RED_D_SPLIT < 16
+    ):
+        RED_D_SPLIT //= 2
+    RED_BLOCK_S = min(256, triton.next_power_of_2(NUM_KV_SPLITS))
+    # grid axis 2 packs (q_pos, head-dim slice). o uses the caller's layout.
+    grid_reduce = (batch_size, nhead, qlen * RED_D_SPLIT)
     sl_b, sl_qs, sl_h, sl_split, _ = logits_buf.stride()
     _mla_softmax_reducev_kernel[grid_reduce](
         logits_buf,
@@ -1159,7 +1193,9 @@ def mla_gluon(
         HEAD_DIM_CKV=head_dim_ckv,
         HAS_FINAL_LSE=return_lse,
         USE_2D_VIEW=use_2d_view,
-        num_warps=8,
+        BLOCK_S=RED_BLOCK_S,
+        D_SPLIT=RED_D_SPLIT,
+        num_warps=4,
     )
 
     return o, final_lse

--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -490,7 +490,13 @@ def _mla_gluon(
     for i in range(num_iter - 2):
         async_idx = (buf_idx + 1) % 2
 
-        gl.amd.cdna4.async_copy.wait_group(0)
+        # Retire only the oldest outstanding group, the previous trip's page copy,
+        # which is all the local load just below needs. Outstanding here, oldest
+        # first, are the four (three without PE) that trip committed: page, then
+        # kv0, kpe and kv1, which stay in flight for the loads further down so two
+        # KV blocks are resident at no extra LDS. The prologue leaves the same set
+        # outstanding, so trip 0 accounts the same way.
+        gl.amd.cdna4.async_copy.wait_group(3 if HAS_PE else 2)
         #### global load page number
         offs_n_page = start_n + BLOCK_N + offs_page_raw
         offs_page = batch_page_start + offs_n_page // PAGE_SIZE
@@ -534,6 +540,12 @@ def _mla_gluon(
             gl.amd.cdna4.async_copy.commit_group()
 
         #### dot, softmax, dot (part0)
+        # Retire the previous trip's kv0 / kpe / kv1, which these local loads read.
+        # Outstanding here, oldest first: prev kv0, prev kpe, prev kv1, this page,
+        # this kv0, this kpe -- so leaving three pending (two without PE) retires
+        # exactly those three and keeps this trip's prefetches in flight through
+        # the MFMA and softmax block.
+        gl.amd.cdna4.async_copy.wait_group(3 if HAS_PE else 2)
         k_c = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_kv.index(buf_idx), mfma_layout_b)
         zeros = gl.zeros([BLOCK_H, BLOCK_N], dtype=gl.float32, layout=mfma_layout)
         qk = gl.amd.cdna4.mfma(q_nope, k_c.to(dtype), zeros)

--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -107,6 +107,8 @@ def _mla_gluon(
     # --- dsv4-prefill knobs ---
     HAS_PE: gl.constexpr,
     HAS_ATTN_SINK: gl.constexpr,
+    # bh16 only: grid axes 0 and 1 carry (split, batch) rather than (batch, split).
+    SPLIT_MAJOR: gl.constexpr = False,
 ):
     # Grid mapping: bh64 uses 3-D XCD-aware multi-batch; bh16bn64 and bh16bn128
     # use 2-D (batch, split) — for batch_size=1 this is (1, NUM_KV_SPLITS).
@@ -125,8 +127,12 @@ def _mla_gluon(
         # identical to the original 2-D+qlen mapping. For nhead > 16 (e.g. 96) the
         # head range is tiled into NUM_M_BLOCKS = cdiv(NHEAD, BLOCK_H) blocks of 16.
         NUM_M_BLOCKS: gl.constexpr = (NHEAD + BLOCK_H - 1) // BLOCK_H
-        cur_batch = gl.program_id(0)
-        split_kv_id = gl.program_id(1)
+        if SPLIT_MAJOR:
+            split_kv_id = gl.program_id(0)
+            cur_batch = gl.program_id(1)
+        else:
+            cur_batch = gl.program_id(0)
+            split_kv_id = gl.program_id(1)
         cur_head_id = gl.program_id(2) % NUM_M_BLOCKS
         q_pos = gl.program_id(2) // NUM_M_BLOCKS
 
@@ -1038,6 +1044,7 @@ def mla_gluon(
         final_lse = None
         stride_final_lse_b, stride_final_lse_s, stride_final_lse_h = 0, 0, 0
 
+    split_major = False
     if REGIME == "bh64":
         grid = (
             NUM_XCDS,
@@ -1048,7 +1055,24 @@ def mla_gluon(
         # Grid axis 2 carries (head_block, q_pos): cdiv(nhead, BLOCK_H) head blocks
         # times qlen query positions. For nhead <= 16 this is just qlen (one head
         # block), i.e. the original grid-axis MTP mapping.
-        grid = (batch_size, NUM_KV_SPLITS, triton.cdiv(nhead, BLOCK_H) * qlen)
+        #
+        # Axes 0 and 1 carry (split, batch) when the split count is a multiple of
+        # the XCD count. Triton linearizes axis 0 fastest, so that ordering gives
+        # workgroup id `split + NUM_KV_SPLITS * batch + ...`, and the hardware
+        # round-robins the id over the XCDs; the multiple-of-NUM_XCD condition is
+        # what keeps the id congruent mod NUM_XCD for every batch, so all requests'
+        # workgroups for one split land on the same XCD and share its L2. Under
+        # prefix caching those workgroups read the same KV pages. Relabeling only:
+        # each program covers the same KV range either way.
+        num_xcds = get_num_xcds()
+        split_major = (
+            batch_size > 1 and NUM_KV_SPLITS > 1 and NUM_KV_SPLITS % num_xcds == 0
+        )
+        head_q_axis = triton.cdiv(nhead, BLOCK_H) * qlen
+        if split_major:
+            grid = (NUM_KV_SPLITS, batch_size, head_q_axis)
+        else:
+            grid = (batch_size, NUM_KV_SPLITS, head_q_axis)
     stride_page_bs = page_table.stride(0) if use_2d_view else 0
 
     _mla_gluon[grid](
@@ -1100,6 +1124,7 @@ def mla_gluon(
         QLEN=qlen,
         HAS_PE=has_pe,
         HAS_ATTN_SINK=has_attn_sink,
+        SPLIT_MAJOR=split_major,
     )
 
     if NUM_KV_SPLITS == 1:


### PR DESCRIPTION
**On top of #4507, this PR is worth 6.22% of inter-token latency at batch 1 and decays to nothing by
batch 48**, because what it shortens is a serial chain whose depth *is* the split count — and the
split count is `num_CUs / batch`. A small, split-count-dependent win on the stage that becomes the
next bottleneck, not a second large one.

## Motivation

Once split parallelism is restored by #4507, the stage-2 reduce becomes the next constraint in the small-batch
corner. `_mla_softmax_reducev_kernel` walks the splits serially, each step's rescale depending on the
previous `e_max`, on a `(batch, nhead, qlen)` grid that is only 12 workgroups at `batch=1, nhead=12`.
Its cost therefore grows with the split count, reaching **a third of the batch-1 decode budget at 256
splits** — which is what made raising `NUM_KV_SPLITS` look like a bad trade before this.

Stage-1 has two smaller issues in the same regime. Its grid is `(batch, split, head_block*q_pos)` and
Triton linearizes axis 0 fastest, so one split's workgroups scatter across all 8 XCDs, each pulling
its own copy of KV pages that a prefix-cached decode batch shares ~94% of. Separately, the loop body
opened with a full `wait_group(0)` drain, serializing the page-number prefetch behind the KV stream.

## Technical Details

**1. Split-major stage-1 grid.** Swap grid axes 0 and 1 for the `bh16` regimes, so the linear
workgroup id is `split + NUM_KV_SPLITS*batch + ...`. All requests' workgroups for a given split then
land on the same XCD and share its L2, and under prefix caching they are reading the same rows. The
swap is taken only when `NUM_KV_SPLITS % NUM_XCD == 0`, which is exactly the condition under which
the id stays congruent mod `NUM_XCD` for every batch; otherwise the ordering is left alone. It is a
relabeling of which workgroup computes which `(batch, split)` item — same KV range per program, same
reduction order, bit-identical output.

**2. Blocked, head-dim-tiled stage-2 reduce.** Two re-associations of the same online-softmax merge:
merge `BLOCK_S` splits per iteration as one `[BLOCK_S, BLOCK_D]` tile (shortens the serial chain by
`BLOCK_S`, gives the memory system `BLOCK_S` independent loads), and tile the 512-wide head dim
across `D_SPLIT` programs packed into grid axis 2 alongside `q_pos`. Each head-dim slice re-derives
the same scalar lse statistics from the same `Mid_lse` vector — a few hundred duplicated bytes — and
owns a disjoint slice of `o`, so slices never communicate. `BLOCK_S=1, D_SPLIT=1` is exactly the
kernel as it stands today; the launcher picks `BLOCK_S = min(256, next_pow2(NUM_KV_SPLITS))` and
`D_SPLIT = 8`, backing `D_SPLIT` off when the head dim does not divide evenly or the slice would be
under 16 elements.

Two invariants carry over. The empty-split guard keeps its semantics: the loop starts on the block
boundary at or below `LOOP_START` and masks the uninitialised slots off inside the block, so
stage-1's untouched slots are never read. The MTP NaN guard is applied per row of the tile, so a
fully causal-masked split (NaN logits with `lse=-inf`) contributes exactly zero.

**3. Two partial waits in the stage-1 loop.** At the top of the loop body the outstanding groups are
exactly the four the previous trip committed — page, kv0, kpe, kv1 — and only the page copy is
needed there. Retire just the oldest (`wait_group(3 if HAS_PE else 2)`) and move the rest of the wait
down to the `k_c` local load, which retires exactly the three groups it depends on. Two KV blocks are
then resident at once at no extra LDS. This is the same granularity the two epilogues already use.
The prologue leaves the same set outstanding as a steady-state trip, so trip 0 accounts identically,
and the set outstanding at loop exit is unchanged, so epilogue 1 is unaffected.

## Test Plan

**End-to-end, concurrency sweep (primary).** 8x MI355X (gfx950), Kimi-K3 TP8, bf16 KV, 12 heads/rank.
aiperf, mean measured ISL 68,088.7 / OSL 350.0, concurrency 1/8/16/24/48 at 5/40/80/120/240 requests,
4 profile runs per point with a 15 s cooldown, seed 42, prefix caching on,
`cudagraph_mode=FULL_AND_PIECEWISE`. Three legs — stock, #4507, #4507 + this PR — each a fresh server
on the same node in the same container, each confirmed by server-log grep to have actually loaded (or
not loaded) the patched module.

**End-to-end, long context (secondary).** Same hardware, 327,600-token context, batch 8. vLLM serving
benchmark: ISL 18,264 plus a 308,736-token shared random prefix, OSL 1,200, concurrency 8, 16 prompts,
seed 42. Reference leg is #4507 alone; candidate is #4507 plus this change. Both legs serialized on a
GPU lock, both to completion, cudagraph captured on both (est. graph memory 1.22 GiB each), engagement
8/8 workers on both.

**Kernel-level.** Frozen, implementation-independent fp32 online-softmax reference at tol 2e-2 under
capture-once / replay-many, including ragged batches
(`seq_lens = [1, 63, 64, 65, 4096, 4097, 65536, 327600]`) and prefix-boundary batches
(`[308736, 308737, 312831, 312832, 312833, 320000, 327599, 327600]`).

**aiter's own MLA tests.** Both configs pass on the rebased branch, with identical verdicts to
unpatched `main` run back to back in the same container:

```bash
python op_tests/test_mla.py -c 327600 -b 8 -n 12,1 -d bf16 -kvd bf16
python op_tests/test_mla.py -c 16384 -b 64 128 -n 64,1 128,1 -d bf16 -kvd bf16
```

All three changes are exercised, 1/1 verdict on both legs. The
second config lands in the `bh64` regime, the regression surface for the wait change since the
stage-1 loop is shared by every regime: 10/10 verdicts on both legs.

**Isolation.** The stage-2 knob flip described above, to separate the two levers.

**Accuracy.** GSM8K, 200 problems, on both legs of the same paired session.

**Style.** `ruff check` (0.16.0, the pinned version) and `black --check` pass on the changed file.

## Test Result

### 1. Concurrency sweep at 68k context — this PR's increment over #4507

Reference leg is #4507 alone, candidate is #4507 plus this PR, 4 trials each, ratios formed within a
trial index so prefix-cache history is matched on both sides. `splits` is what #4507 selects
(`num_CUs / batch`) and is also the depth of the chain this PR shortens.

| conc | splits | split-major grid | #4507 ITL P50 | + this PR | delta | per-trial deltas |
|---|---|---|---|---|---|---|
| 1 | 256 | off — batch 1 | 26.26 ms | 24.73 ms | **+6.22%** | +6.4, +6.4, +5.3, +6.7 |
| 8 | 32 | on | 39.73 ms | 38.75 ms | **+2.54%** | +3.2, +4.9, +1.9, +0.4 |
| 16 | 16 | on | 54.84 ms | 54.08 ms | +1.40% | +2.0, +1.7, +2.1, −0.2 |
| 24 | 10 | off — 10 % 8 ≠ 0 | 65.53 ms | 64.91 ms | +0.96% | −0.4, +4.0, +1.1, −0.8 |
| 48 | 5 | off — 5 % 8 ≠ 0 | 101.11 ms | 101.17 ms | −0.06% | −1.1, +2.0, −0.9, −0.2 |

The shape is what the mechanism predicts: the win tracks the split count, and by 5 splits there is no
chain left to shorten. Only the top two rows have every trial on the same side of zero, and at 32
splits one trial is just +0.4%, so I would defend +6.22% at 256 splits and treat everything from 16
splits down as within noise.

Work parity: completed requests, mean ISL and mean OSL identical across all three legs at every
point, zero errors. The candidate range is disjoint from stock at every concurrency.

The grid order is gated off at batch 1, so it was checked on its own rather than through the sweep:
flipping only that axis at batch 8, 32 splits and 327,600 tokens moves the decode kernel 0.4568 →
0.3655 ms, with L2 hit 0.71% → 82.18% and HBM traffic 3.033 → 0.544 GB (`rocprofv3`, 5 dispatches).
L2→CU request volume is identical either way; only the order changes. The analytic ceiling for that
page table is 82.46% hit, leaving 0.28 pp on the axis.

### 2. Long context, single point — 327,600 tokens

The original measurement, at 4.8x the context and 2 repeats per leg:

| | ref (#4507 only) | candidate (+ this PR) | delta |
|---|---|---|---|
| **End-to-end throughput, median** | 155.47 tok/s | **172.35 tok/s** | **+10.86%** |
| End-to-end, run 1 (cold prefix) | 114.04 tok/s | 125.95 tok/s | +10.4% |
| End-to-end, run 2 (warm prefix) | 196.90 tok/s | 218.75 tok/s | +11.1% |
| Median TPOT (cold / warm) | 49.07 / 39.32 ms | 40.64 / 34.46 ms | — |
| Stage-2 reduce, per call | 87.8 µs | 4.0 µs | **22x** |
| Isolated geomean vs unpatched | — | 39.15x | — |
| GSM8K (200 problems) | 0.905 | 0.910 | within tolerance |
| KV footprint | 71.32 GiB / 2,731,470 tok | identical | parity |

The larger number here is consistent with the sweep rather than in tension with it: this point runs
at batch 8 over a 327,600-token context, so stage-2 is a far larger share of a much longer decode
than it is at 68k. The binary it was measured on also carried a stage-1 tail-mask peel that is held
back from this PR, since MTP on `main` makes that mask live for `QLEN > 1`, so some of the +10.86%
belongs to the peel. It also rests on 2 repeats against the sweep's 4, which is why the sweep leads.

The reduction order changes relative to the reference leg, so bitwise equality is not expected;
GSM8K moved 0.905 → 0.910, inside the 0.05 tolerance.

## AI assistance

This came out of [GEAK](https://github.com/AMD-AGI/GEAK), AMD's agentic GPU-kernel optimization
framework, running an end-to-end optimization pass against a live Kimi-K3 TP8 server on 8x MI355X.

Everything in this PR was verified manually before submission.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
