### PR TITLE
fix(build): resolve gfx1100 targets across JIT paths

### DIFF
--- a/aiter/jit/utils/build_targets.py
+++ b/aiter/jit/utils/build_targets.py
@@ -38,6 +38,7 @@ GFX_MAP = {
 # Extend this table when adding support for new GPU targets.
 GFX_CU_NUM_MAP = {
     "gfx942": 304,  # MI300X (SPX, full GPU); MI308X shares gfx942 — use CU_NUM override
+    "gfx1100": 96,  # Radeon PRO W7900; other gfx1100 variants use CU_NUM override
     "gfx950": 256,  # MI350
     "gfx1250": 256,  # Gfx1250
 }

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -159,6 +159,7 @@ def validate_and_update_archs():
         "gfx941",
         "gfx942",
         "gfx950",
+        "gfx1100",
         "gfx1151",
     ]
 

--- a/op_tests/test_gemm_codegen.py
+++ b/op_tests/test_gemm_codegen.py
@@ -59,6 +59,7 @@ REPRO_BPRESHUFFLE_CSV = os.path.join(
 TARGET_A = ("gfx942", 304)  # MI300X
 TARGET_B = ("gfx950", 256)  # MI350
 TARGET_C = ("gfx942", 80)  # MI308X — gfx942 with CU_NUM override
+TARGET_D = ("gfx1100", 96)  # Radeon PRO W7900
 
 # ---------------------------------------------------------------------------
 # Minimal test harness (no external test framework required)
@@ -152,7 +153,12 @@ def test_get_build_targets():
             "gfx942" in GFX_CU_NUM_MAP and "gfx950" in GFX_CU_NUM_MAP,
         )
 
-        # 1.8 Live GPU fallback — requires torch and a GPU; skipped otherwise
+        # 1.8 Radeon PRO W7900 (gfx1100) headless build target
+        os.environ["GPU_ARCHS"] = TARGET_D[0]
+        t = get_build_targets_env()
+        _check(f"GPU_ARCHS={TARGET_D[0]} → [{TARGET_D}]", t == [TARGET_D], str(t))
+
+        # 1.9 Live GPU fallback — requires torch and a GPU; skipped otherwise
         del os.environ["GPU_ARCHS"]
         try:
             from aiter.jit.utils.chip_info import get_build_targets


### PR DESCRIPTION
## Summary

- add the Radeon PRO W7900 default of 96 CUs to the env-only build target map
- allow gfx1100 in the `cpp_itfs` template-JIT architecture validation
- cover `GPU_ARCHS=gfx1100` in the existing torch-free GEMM codegen test
- retain `CU_NUM` as the documented override for other gfx1100 variants

## Motivation

AITER already lists the W7900/gfx1100 as experimentally supported, recognizes gfx1100 in `GFX_MAP`, and runs an optional gfx1100 CI job. Two target-resolution paths remain inconsistent:

1. An explicit headless or cross-build fails before code generation:

```text
RuntimeError: Unknown gfx 'gfx1100' in GPU_ARCHS ...
```

2. Portable HIP operators using the older `cpp_itfs` template-JIT path hard-assert on a live W7900:

```text
AssertionError: One of GPU archs of ['gfx1100'] is invalid or not supported
```

The first failure comes from gfx1100 being absent from `GFX_CU_NUM_MAP`. The second comes from a separate architecture allow-list that already admits gfx1151 but not gfx1100. This patch makes both paths consistent with AITER's declared experimental W7900 support.

## Validation

- CPU-only target-selection section: 8 passed, 0 failed
- Black 26.1.0 and Ruff 0.16.0 on all three modified files: passed
- `py_compile` and `git diff --check`: passed
- Radeon PRO W7900 host with 8 gfx1100 devices: rocminfo reports 96 CUs per device
- same test section in a ROCm container on that host: 9 passed, 0 failed, including the live-device fallback
- explicit and live paths both resolve to `[('gfx1100', 96)]`
- real `cpp_itfs` baseline: joint top-k/top-p sampling reaches the assertion above before JIT compilation
- patched real-device suite with PyTorch 2.9.1 and ROCm 7.2 (`gfx1100`), shape `[4, 129280]`, `k=20`, `p=0.9`, 256 trials:
  - top-p: all 1,024 samples are in the reference nucleus; 1,021 unique tokens
  - top-k renormalization: matches the Torch reference with max absolute error `7.45e-09`
  - joint top-k/top-p: all 1,024 samples are in the reference intersection; 80 unique tokens

## Why this matters

`get_build_targets_env()` gates headless code generation, while the `cpp_itfs` allow-list gates portable template-compiled operators such as top-p, joint top-k/top-p, and top-k renormalization. Keeping gfx1100 out of either path means a supported W7900 installation can still fail at build time or when non-greedy sampling is first requested. This change removes those target-identification failures without introducing an architecture spoof or a model-specific path.

## Scope

This only fixes build-target admission and validation for gfx1100. It does not claim broader CK or ASM kernel support, change sampling semantics, or make a performance claim on RDNA3.
