### PR TITLE
[CI] Fix SGLang downstream setup and enable DSV3.2 accuracy

### DIFF
--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -87,7 +87,7 @@ TESTS = [
         "test_type": "Accuracy",
         "timeout_minutes": 120,
         "extra_exec_args": "",
-        "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v32 --nightly --timeout-per-file 3600",
+        "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v32 --nightly --timeout-per-file 5400",
         "run_on_pr": True,
         "run_on_schedule": True,
     },

--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -85,9 +85,9 @@ TESTS = [
         "model_id": "deepseek-ai/DeepSeek-V3.2",
         "model_path_env": "DEEPSEEK_V32_MODEL_PATH",
         "test_type": "Accuracy",
-        "timeout_minutes": 120,
+        "timeout_minutes": 150,
         "extra_exec_args": "",
-        "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v32 --nightly --timeout-per-file 5400",
+        "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v32 --nightly --timeout-per-file 7200",
         "run_on_pr": True,
         "run_on_schedule": True,
     },
@@ -153,6 +153,11 @@ SGLANG_CI_PATCHES = [
         "path": "test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py",
         "old": 'model_path="deepseek-ai/DeepSeek-V3.2",',
         "new": 'model_path=os.environ.get("DEEPSEEK_V32_MODEL_PATH", "deepseek-ai/DeepSeek-V3.2"),',
+    },
+    {
+        "path": "test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py",
+        "old": '        timeout=5400,\n        variant="basic",',
+        "new": '        timeout=7200,\n        variant="basic",',
     },
 ]
 

--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -85,7 +85,7 @@ TESTS = [
         "model_id": "deepseek-ai/DeepSeek-V3.2",
         "model_path_env": "DEEPSEEK_V32_MODEL_PATH",
         "test_type": "Accuracy",
-        "timeout_minutes": 70,
+        "timeout_minutes": 120,
         "extra_exec_args": "",
         "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v32 --nightly --timeout-per-file 3600",
         "run_on_pr": True,

--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -88,8 +88,7 @@ TESTS = [
         "timeout_minutes": 70,
         "extra_exec_args": "",
         "test_command": "python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v32 --nightly --timeout-per-file 3600",
-        "run_on_pr": False,
-        "comment": "Run in nightly first while failures are investigated.",
+        "run_on_pr": True,
         "run_on_schedule": True,
     },
     {

--- a/.github/scripts/sglang_downstream.py
+++ b/.github/scripts/sglang_downstream.py
@@ -126,6 +126,11 @@ SGLANG_CI_PATCHES = [
     },
     {
         "path": "scripts/ci/amd/amd_ci_install_dependency.sh",
+        "old": "docker cp human-eval ci_sglang:/",
+        "new": "docker cp human-eval ci_sglang:/\n  docker exec ci_sglang git config --global --add safe.directory /human-eval",
+    },
+    {
+        "path": "scripts/ci/amd/amd_ci_install_dependency.sh",
         "old": "install_with_retry docker exec -w /human-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .",
         "new": "install_with_retry docker exec -w /human-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache --no-build-isolation -e .",
     },

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -116,7 +116,7 @@ jobs:
           set -ex
           docker rm -f ci_sglang || true
           cd "${SGLANG_WORKSPACE}"
-          GITHUB_WORKSPACE="${SGLANG_WORKSPACE}" HF_TOKEN="${{ secrets.HF_TOKEN_TEST }}" bash scripts/ci/amd/amd_ci_start_container.sh
+          GITHUB_WORKSPACE="${SGLANG_WORKSPACE}" HF_TOKEN="${{ secrets.HF_TOKEN_TEST }}" bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
           docker exec ci_sglang bash -lc 'pwd; ls -la /sglang-checkout; test -d /sglang-checkout/python/sglang/kernels/aot; test -d /sglang-checkout/python; test -d /models'
 
       - name: Setup pip config

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -86,7 +86,7 @@ jobs:
           SGLANG_WORKSPACE="${RUNNER_TEMP}/sglang-downstream"
           rm -rf "${SGLANG_WORKSPACE}"
           git clone --depth 1 -b ${SGL_BRANCH} https://github.com/sgl-project/sglang.git "${SGLANG_WORKSPACE}"
-          test -d "${SGLANG_WORKSPACE}/sgl-kernel"
+          test -d "${SGLANG_WORKSPACE}/python/sglang/kernels/aot"
           test -d "${SGLANG_WORKSPACE}/python"
           echo "SGLANG_WORKSPACE=${SGLANG_WORKSPACE}" >> "${GITHUB_ENV}"
 
@@ -117,7 +117,7 @@ jobs:
           docker rm -f ci_sglang || true
           cd "${SGLANG_WORKSPACE}"
           GITHUB_WORKSPACE="${SGLANG_WORKSPACE}" HF_TOKEN="${{ secrets.HF_TOKEN_TEST }}" bash scripts/ci/amd/amd_ci_start_container.sh
-          docker exec ci_sglang bash -lc 'pwd; ls -la /sglang-checkout; test -d /sglang-checkout/sgl-kernel; test -d /sglang-checkout/python; test -d /models'
+          docker exec ci_sglang bash -lc 'pwd; ls -la /sglang-checkout; test -d /sglang-checkout/python/sglang/kernels/aot; test -d /sglang-checkout/python; test -d /models'
 
       - name: Setup pip config
         run: |


### PR DESCRIPTION
## Summary
- update SGLang kernel preflight checks for the `python/sglang/kernels/aot` layout
- enable DeepSeek-V3.2 accuracy coverage for PR and per-commit runs
- use the ROCm 7.2 MI35x image for downstream validation
- extend DSV3.2 server and per-file timeouts to 7200 seconds, with a 150-minute job timeout
- mark the `human-eval` checkout as a safe Git directory for editable installation

## Validation
- SGLang DeepSeek-R1-MXFP4 Accuracy (8 GPU): passed in 35m22s
- SGLang DeepSeek-V3.2 Accuracy (8 GPU): passed in 2h3m29s
- Actionlint, Black, Ruff, repository dependency, Kimi, and OPUS checks passed