### PR TITLE
[gfx950][Triton] Fix unified_attention num_stages > 1 crash with release_tmp3

### DIFF
--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -108,6 +108,10 @@ def select_2d_config(
         TILE_SIZE = min(64, triton.next_power_of_2(block_size))
         if arch.is_rdna:
             num_stages_2d, num_warps = 1, 4
+        elif arch.name == "gfx950":
+            # release_tmp3 Triton software-pipeliner crashes on gfx950 with
+            # num_stages > 1 ("defs don't dominate"); keep it at 1.
+            num_stages_2d, num_warps = 1, 2
         else:
             if head_size >= 512:
                 num_stages_2d, num_warps = 1, 4
@@ -161,7 +165,8 @@ def select_3d_config(
     attn_warps = 2
     waves_per_eu = 2
     num_segments = 0
-    attn_stages = 2
+    # release_tmp3 Triton software-pipeliner crashes on gfx950 with num_stages > 1
+    attn_stages = 1 if DEVICE_ARCH == "gfx950" else 2
     if IS_DEVICE_ARCH_GFX12:
         attn_warps = 1
         TILE_SIZE = block_size


### PR DESCRIPTION
`select_2d_config` (decode) and `select_3d_config` (prefill) in `unified_attention.py` returned `num_stages > 1` for gfx950, triggering the release_tmp3 Triton software-pipeliner \"defs don't dominate\" crash — the same class of bug fixed for `fwd_prefill.py`, `mla.py`, `bwd.py`, and config files by 54ce92317, but `unified_attention.py` was missed.

Fix: `num_stages=1` for gfx950 in both config selectors.

Reproduces as a memory access fault in the vLLM CI after the v0.1.19 aiter bump:
`tests/models/quantization/test_gpt_oss.py::test_gpt_oss_attention_quantization[amd/gpt-oss-20b-WFP8-AFP8-KVFP8-0.89-1]` on MI355X.