### PR TITLE
[Triton] Fix gfx950 small-M AFP4WFP4 correctness

### DIFF
--- a/aiter/ops/triton/configs/gfx950/triton/gemm/GEMM-AFP4WFP4.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/GEMM-AFP4WFP4.json
@@ -2,7 +2,7 @@
     "M_LEQ_8": {
         "BLOCK_SIZE_M": 8,
         "BLOCK_SIZE_N": 64,
-        "BLOCK_SIZE_K": 512,
+        "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 2,

--- a/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
@@ -141,6 +141,37 @@ def get_x_vals():
     return x_vals
 
 
+@pytest.mark.parametrize(
+    "M,N,K",
+    [
+        (1, 1536, 7168),
+        (1, 7168, 768),
+        (1, 8448, 7168),
+        (1, 7168, 4224),
+    ],
+)
+def test_small_m_short_k_gemm_afp4_wfp4(M: int, N: int, K: int):
+    """Cover small-M decode shapes, including split-K tails."""
+    dtype = torch.bfloat16
+    (
+        x,
+        w,
+        _,
+        x_scales,
+        w_scales,
+        _,
+        _,
+        _,
+        y,
+    ) = generate_gemm_afp4wfp4_inputs(M, N, K, dtype, layout="TN", output=True)
+
+    expected = run_torch(x, w, x_scales, w_scales, dtype)
+    actual = triton_gemm_afp4wfp4(x, w, x_scales, w_scales, dtype, y)
+
+    assert torch.isfinite(actual).all()
+    triton.testing.assert_close(expected, actual)
+
+
 def mxfp4_to_f32(x):
     # 2 because we pack fp4 in uint8.
     x = x.repeat_interleave(2, dim=1)


### PR DESCRIPTION
## Summary

- Reduce the gfx950 Triton AFP4WFP4 `M_LEQ_8` K tile from 512 to 256.
- Add finite-output and BF16-reference regression coverage for four small-M decode shapes, including the short-K case that previously returned non-finite values.

## Motivation

The gfx950 `M_LEQ_8` configuration reproducibly failed for `(M=1, N=7168, K=768)` when `BLOCK_SIZE_K=512`. The same test passed after reducing the tile to 256. Three additional representative shared/dense decode shapes remained finite and reference-close.

This PR fixes the observed configuration-level correctness failure. It deliberately does not claim that a specific out-of-bounds load, split-K race, compiler bug, or hardware mechanism has been proven.

## Technical approach

For `M <= 8`, the current configuration uses four K splits. Reducing `BLOCK_SIZE_K` from 512 to 256 changes only the gfx950 small-M schedule; larger-M configurations are untouched.

The regression computes an independent FP32/BF16 reference by:

1. unpacking E2M1 values from the packed uint8 inputs;
2. expanding E8M0 scales over 32-element scale groups;
3. applying the scales in FP32;
4. running the reference matrix multiplication;
5. checking the kernel result is finite before checking numerical closeness.

## Correctness coverage

The test covers:

- `(1, 1536, 7168)` — shared gate/up;
- `(1, 7168, 768)` — short-K shared down and the original failure;
- `(1, 8448, 7168)` — dense gate/up;
- `(1, 7168, 4224)` — dense down with a K tail relative to the selected tile.

Observed on gfx950:

- BK=512: `3 passed, 1 failed`; `(1,7168,768)` returned non-finite output.
- BK=256: `4 passed`, `0 NaN/Inf`, all outputs reference-close.
- End-to-end smoke after the fix: all top-5 logprobs were finite for 64 generated tokens.

No GSM8K score is attributed to this config-only PR because it is not an end-to-end quantization-path change and no isolated GSM8K A/B was run for this single configuration edit.

## Test plan

```bash
pytest -q op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py \
  -k test_small_m_short_k_gemm_afp4_wfp4

python3 -m py_compile \
  op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py

python3 -m json.tool \
  aiter/ops/triton/configs/gfx950/triton/gemm/GEMM-AFP4WFP4.json >/dev/null
```

Results:

- Exact-shape regression after the fix: `4 passed`, no NaN/Inf.
- Python syntax check: passed.
- JSON syntax check: passed.

## Performance boundary

This is a correctness PR, not a performance claim. A shorter K tile can affect other `M <= 8` shapes, so broader small-M performance testing should be considered during review and CI. No result from a different attention runtime is presented as an isolated benchmark of this change.

## Risks

- Other small-M shapes may have a different performance optimum.
- The underlying low-level failure mechanism remains unproven.
- The test intentionally protects finite/reference-close behavior rather than asserting a model-specific implementation detail.

## Reviewer notes

Please focus on whether BK=256 is the preferred gfx950 configuration-level fix and whether more generic small-M/short-K shapes should be added to the regression matrix.