### PR TITLE
[HIP] Enable chunk gated delta rule fwd-h on gfx1201

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1780,7 +1780,8 @@
         ],
         "flags_extra_cc": [],
         "flags_extra_hip": [
-            "'-ffast-math'"
+            "'-ffast-math'",
+            "'-mwavefrontsize64'"
         ],
         "extra_ldflags": "None",
         "extra_include": [],

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk.py
@@ -274,7 +274,7 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             "use_chunk_hip and use_chunk_flydsl are mutually exclusive; "
             "set at most one."
         )
-    if use_chunk_hip and (_is_gfx12_runtime() or num_decodes > 0):
+    if use_chunk_hip and num_decodes > 0:
         use_chunk_hip = False
 
     g_cumsum, A_raw = fused_chunk_local_cumsum_scaled_dot_kkt_fwd(

--- a/csrc/kernels/chunk_gated_delta_rule_fwd_h.cu
+++ b/csrc/kernels/chunk_gated_delta_rule_fwd_h.cu
@@ -320,7 +320,11 @@ __device__ __forceinline__ floatx4 zero_floatx4()
 
 __device__ __forceinline__ floatx4 mfma16x16x16_bf16(const _B16x4& a, const _B16x4& b, const floatx4& c)
 {
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w64_gfx12(a, b, c);
+#else
     return __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(a, b, c, 0, 0, 0);
+#endif
 }
 
 template <bool USE_EXP2>
@@ -1080,7 +1084,14 @@ void chunk_gated_delta_rule_fwd_h_hip_kernel(
     __shared__ bf16_t h_transpose_buf[BV_P * K_DIM];
 
     const int v_idx = lane_id & 15;
-    const int row_group = lane_id >> 4;
+    const int physical_row_group = lane_id >> 4;
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    // Wave64 WMMA maps lane groups 0..3 to result-row chunks 0, 2, 1, 3.
+    const int row_group = ((physical_row_group & 1) << 1) |
+                          ((physical_row_group & 2) >> 1);
+#else
+    const int row_group = physical_row_group;
+#endif
     const int h_row_base_lo = wave_id * MFMA_M + row_group * 4;
     const int h_row_base_hi = h_row_base_lo + 64;
     float h_reg[8 * NUM_BV_TILES];

--- a/op_tests/test_gated_delta_rule.py
+++ b/op_tests/test_gated_delta_rule.py
@@ -696,10 +696,6 @@ def test_chunk_opt(
     ],
 )
 @pytest.mark.skipif(not IS_AMD, reason="Skipping HIP-only test on non-AMD backend")
-@pytest.mark.skipif(
-    _is_gfx12_runtime(),
-    reason="chunk_gated_delta_rule_fwd_h_hip_fn kernel does not support gfx12!",
-)
 def test_chunk_opt_hip(
     B: int,
     T: int,
@@ -872,10 +868,6 @@ def test_chunk_opt_varlen(
     ],
 )
 @pytest.mark.skipif(not IS_AMD, reason="Skipping HIP-only test on non-AMD backend")
-@pytest.mark.skipif(
-    _is_gfx12_runtime(),
-    reason="chunk_gated_delta_rule_fwd_h_hip_fn kernel does not support gfx12!",
-)
 def test_chunk_opt_varlen_hip(
     H: int,
     D: int,
@@ -948,15 +940,7 @@ def test_chunk_opt_varlen_hip(
         pytest.param(
             "hip",
             id="hip",
-            marks=[
-                pytest.mark.skipif(
-                    not IS_AMD, reason="HIP backend requires an AMD device"
-                ),
-                pytest.mark.skipif(
-                    _is_gfx12_runtime(),
-                    reason="chunk_gated_delta_rule_fwd_h_hip_fn does not support gfx12!",
-                ),
-            ],
+            marks=[pytest.mark.skipif(not IS_AMD, reason="HIP backend requires an AMD device")],
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Enable the HIP hidden-state kernel used by chunk gated delta rule prefill on gfx1201.

- use the gfx12 wave64 BF16 WMMA intrinsic on gfx1200 and gfx1201
- compile the K5 JIT module with `-mwavefrontsize64` to preserve its existing 64-lane decomposition
- remap gfx12 WMMA accumulator lane groups from physical order `0,1,2,3` to result-row order `0,2,1,3`
- allow the HIP K5 path on gfx12 for prefill while keeping it disabled when decode tokens are present
- enable the existing dense, variable-length, and indexed-state HIP tests on gfx12

## Why

The kernel is organized around four 64-lane waves and originally uses the CDNA wave64 MFMA intrinsic. gfx1201 defaults to wave32 and does not support that MFMA instruction. The gfx12 wave64 WMMA intrinsic plus the explicit wave64 compilation mode preserves the kernel decomposition, while the accumulator row-group remap accounts for the gfx12 WMMA lane layout.

## Validation

Validated on gfx1201 with the Qwen3.6-35B TP4 GDN shape (`Hk=4`, `Hv=8`, `K=V=128`):

- dense and variable-length HIP K5 paths
- indexed hidden-state pool updates
- complete variable-length prefill pipeline at 1024 and 4096 packed tokens
- native and HIP outputs, hidden snapshots, and final states matched within the existing K5 tolerance (`atol=rtol=5e-2`)

Decode and mixed prefill/decode execution continue to use the existing non-HIP path.