### PR TITLE
[feat][HIP]: enable chunk-gated-delta-rule-fwd-h on gfx1201.

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1801,7 +1801,8 @@
         ],
         "flags_extra_cc": [],
         "flags_extra_hip": [
-            "'-ffast-math'"
+            "'-ffast-math'",
+            "'-mwavefrontsize64'"
         ],
         "extra_ldflags": "None",
         "extra_include": [],

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk.py
@@ -30,12 +30,15 @@ from .chunk_o import chunk_fwd_o, chunk_fwd_o_opt, chunk_fwd_o_opt_vk
 from .fused_cumsum_kkt import fused_chunk_local_cumsum_scaled_dot_kkt_fwd
 from .fused_solve_tril_recompute import fused_solve_tril_recompute_w_u
 
+_SUPPORTED_GFX12_ARCHS = frozenset({"gfx1200", "gfx1201"})
 
-def _is_gfx12_runtime(device: torch.device) -> bool:
+
+def _is_unsupported_gfx12_runtime(device: torch.device) -> bool:
     try:
         props = torch.cuda.get_device_properties(device)
         arch = getattr(props, "gcnArchName", "")
-        return arch.split(":")[0].startswith("gfx12") if arch else False
+        arch = arch.split(":")[0] if arch else ""
+        return arch.startswith("gfx12") and arch not in _SUPPORTED_GFX12_ARCHS
     except Exception:  # noqa: BLE001
         return False
 
@@ -233,6 +236,8 @@ def chunk_gated_delta_rule_fwd_opt_vk(
     num_decode_tokens: int = 0,
     seq_lens_cpu: Sequence[int] | None = None,
     prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
+    initial_state_indices: torch.Tensor | None = None,
+    inplace_final_state: bool | None = None,
 ):
     """
     Optimized chunk gated delta rule forward with h layout [V, K].
@@ -272,6 +277,11 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             shared K1--K6 schedule without device readback.
         prefill_metadata: Prebuilt reusable host/device schedule. This is the
             preferred path when multiple layers process the same batch.
+        initial_state_indices: Optional ``[N]`` state-pool slot indices. When
+            provided, K5 gathers from and writes back to ``initial_state`` in
+            place. Supported by the HIP and Triton VK K5 paths only.
+        inplace_final_state: Controls in-place K5 state-pool write-back. It
+            defaults to ``True`` when ``initial_state_indices`` is provided.
 
     Returns:
         tuple: (g_cumsum, o, final_state) where:
@@ -283,6 +293,13 @@ def chunk_gated_delta_rule_fwd_opt_vk(
         raise ValueError(
             "use_chunk_hip and use_chunk_flydsl are mutually exclusive; "
             "set at most one."
+        )
+    if use_chunk_flydsl and (
+        initial_state_indices is not None or inplace_final_state is True
+    ):
+        raise ValueError(
+            "Indexed state pools and in-place final-state write-back are not "
+            "supported by the FlyDSL K5 path."
         )
     if cu_seqlens is None:
         if seq_lens_cpu is not None or prefill_metadata is not None:
@@ -299,7 +316,8 @@ def chunk_gated_delta_rule_fwd_opt_vk(
         )
 
     if use_chunk_hip and (
-        _is_gfx12_runtime(q.device) or (num_decodes > 0 and prefill_metadata is None)
+        _is_unsupported_gfx12_runtime(q.device)
+        or (num_decodes > 0 and prefill_metadata is None)
     ):
         use_chunk_hip = False
 
@@ -346,6 +364,8 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             prefill_metadata=prefill_metadata,
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,
+            initial_state_indices=initial_state_indices,
+            inplace_final_state=inplace_final_state,
         )
     elif use_chunk_flydsl:
         # FlyDSL K5 wrapper expects ``g`` in head-major [B, H, T] layout
@@ -383,6 +403,8 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             state_dtype=state_dtype,
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,
+            initial_state_indices=initial_state_indices,
+            inplace_final_state=inplace_final_state,
             prefill_metadata=prefill_metadata,
         )
 

--- a/aiter/ops/triton/gated_delta_net/gated_delta_rule.py
+++ b/aiter/ops/triton/gated_delta_net/gated_delta_rule.py
@@ -463,6 +463,8 @@ def chunk_gated_delta_rule_opt_vk(
     num_decode_tokens: int = 0,
     seq_lens_cpu: Sequence[int] | None = None,
     prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
+    initial_state_indices: torch.Tensor | None = None,
+    inplace_final_state: bool | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     r"""
     Optimized chunk-based gated delta rule with h layout [V, K] (Forward only).
@@ -511,12 +513,18 @@ def chunk_gated_delta_rule_opt_vk(
         prefill_metadata: Reusable schedule created by
             ``build_gated_delta_rule_prefill_metadata``. Prefer this over
             ``seq_lens_cpu`` when several GDR layers process the same batch.
+        initial_state_indices: Optional ``[N]`` indices into a larger
+            ``initial_state`` pool. K5 reads and writes those slots in place.
+            This is unsupported with ``use_chunk_flydsl=True``.
+        inplace_final_state: Controls K5 in-place state write-back. It defaults
+            to ``True`` when ``initial_state_indices`` is provided.
 
     Returns:
         tuple[torch.Tensor, torch.Tensor | None]:
             - o: Outputs of shape `[B, T, H, V]`.
             - final_state: `[N, H, V, K]` if `output_final_state=True` else `None`.
     """
+    n_prefill = q.shape[0]
     if cu_seqlens is not None:
         if q.shape[0] != 1:
             raise ValueError(
@@ -524,11 +532,21 @@ def chunk_gated_delta_rule_opt_vk(
             )
         # Prefill sequence count == len(cu_seqlens) - 1 - num_decodes.
         n_prefill = len(cu_seqlens) - 1 - num_decodes
-        if initial_state is not None and initial_state.shape[0] != n_prefill:
+
+    if initial_state_indices is not None:
+        if initial_state is None:
+            raise ValueError("`initial_state_indices` requires `initial_state`.")
+        if initial_state_indices.numel() != n_prefill:
             raise ValueError(
-                f"The number of initial states is expected to be equal to the number of input sequences, "
-                f"i.e., {n_prefill} rather than {initial_state.shape[0]}."
+                "The number of state indices must equal the number of "
+                f"prefill sequences, i.e. {n_prefill} rather than "
+                f"{initial_state_indices.numel()}."
             )
+    elif initial_state is not None and initial_state.shape[0] != n_prefill:
+        raise ValueError(
+            f"The number of initial states is expected to be equal to the number of input sequences, "
+            f"i.e., {n_prefill} rather than {initial_state.shape[0]}."
+        )
 
     if scale is None:
         scale = k.shape[-1] ** -0.5
@@ -562,5 +580,7 @@ def chunk_gated_delta_rule_opt_vk(
         num_decode_tokens=num_decode_tokens,
         seq_lens_cpu=seq_lens_cpu,
         prefill_metadata=prefill_metadata,
+        initial_state_indices=initial_state_indices,
+        inplace_final_state=inplace_final_state,
     )
     return o.to(q.dtype), final_state

--- a/csrc/kernels/chunk_gated_delta_rule_fwd_h.cu
+++ b/csrc/kernels/chunk_gated_delta_rule_fwd_h.cu
@@ -318,9 +318,25 @@ __device__ __forceinline__ floatx4 zero_floatx4()
     return {0.0f, 0.0f, 0.0f, 0.0f};
 }
 
+__device__ __forceinline__ int mma_row_group(const int lane_id)
+{
+    const int physical_row_group = lane_id >> 4;
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    // Wave64 WMMA maps physical lane groups 0..3 to result rows 0, 2, 1, 3.
+    return ((physical_row_group & 1) << 1) |
+           ((physical_row_group & 2) >> 1);
+#else
+    return physical_row_group;
+#endif
+}
+
 __device__ __forceinline__ floatx4 mfma16x16x16_bf16(const _B16x4& a, const _B16x4& b, const floatx4& c)
 {
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w64_gfx12(a, b, c);
+#else
     return __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(a, b, c, 0, 0, 0);
+#endif
 }
 
 template <bool USE_EXP2>
@@ -668,6 +684,12 @@ __device__ __forceinline__ float run_gemm1_fulltile_bvp(
         }
     }
 
+    // gated_v_panel aliases h_state_panel1. All waves must finish reading the
+    // state panel before any wave overwrites it with gated values.
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    __syncthreads();
+#endif
+
     const int row_base_local = row_base + row_group * 4;
     const int gated_row_block = row_base_local >> 2;
     float g_scale[4];
@@ -728,7 +750,7 @@ __device__ __forceinline__ void run_gemm2_fulltile_bvp(
 {
     constexpr int NUM_BV_TILES = BV_P / MFMA_N;
     const float decay = gated_exp(g_last, use_exp2);
-    const int row_group = lane_id >> 4;
+    const int row_group = mma_row_group(lane_id);
 
     for (int round = 0; round < K_DIM / (MFMA_M * WAVE_COUNT); ++round) {
         floatx4 gacc[NUM_BV_TILES];
@@ -873,7 +895,7 @@ __device__ __forceinline__ void process_tail_chunk_bvp_vk_lds_v(
     int64_t g_stride_t = 0)
 {
     constexpr int NUM_BV_TILES = BV_P / MFMA_N;
-    const int row_group = lane_id >> 4;
+    const int row_group = mma_row_group(lane_id);
     const int v_idx = lane_id & 15;
     const bf16_t zero_val = float_to_bf16(0.0f);
     const bf16_t* w_chunk = overlap2_w_ptr<IS_VARLEN>(w_bf16, i_n, H, i_h, T_flat, token_base);
@@ -927,6 +949,12 @@ __device__ __forceinline__ void process_tail_chunk_bvp_vk_lds_v(
         }
     }
     write_k_panels_to_lds(k_data, k_panel0, k_panel1);
+
+    // gated_v_panel aliases h_state_panel1. All waves must finish reading the
+    // state panel before any wave overwrites it with gated values.
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    __syncthreads();
+#endif
 
     const int row_base_local = row_base + row_group * 4;
     const int gated_row_block = row_base_local >> 2;
@@ -1080,7 +1108,7 @@ void chunk_gated_delta_rule_fwd_h_hip_kernel(
     __shared__ bf16_t h_transpose_buf[BV_P * K_DIM];
 
     const int v_idx = lane_id & 15;
-    const int row_group = lane_id >> 4;
+    const int row_group = mma_row_group(lane_id);
     const int h_row_base_lo = wave_id * MFMA_M + row_group * 4;
     const int h_row_base_hi = h_row_base_lo + 64;
     float h_reg[8 * NUM_BV_TILES];

--- a/op_tests/test_gated_delta_rule.py
+++ b/op_tests/test_gated_delta_rule.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2023-2026, Songlin Yang, Yu Zhang
 
+import importlib
 import os
 
 os.environ.setdefault("AITER_TRITON_ONLY", "1")
@@ -24,6 +25,8 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils im
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.prefill import (
     chunk_gated_delta_rule_fwd_h_opt_vk,
+    fused_chunk_local_cumsum_scaled_dot_kkt_fwd,
+    fused_solve_tril_recompute_w_u,
 )
 from aiter.ops.triton.gated_delta_net import (
     chunk_gated_delta_rule,
@@ -39,9 +42,30 @@ def _is_gfx12_runtime() -> bool:
     try:
         props = torch.cuda.get_device_properties(torch.cuda.current_device())
         arch = getattr(props, "gcnArchName", "")
-        return arch.split(":")[0].startswith("gfx12") if arch else False
+        return arch.split(":")[0] in {"gfx1200", "gfx1201"} if arch else False
     except Exception:  # noqa: BLE001
         return False
+
+
+@pytest.mark.parametrize(
+    ("arch", "expected"),
+    [
+        ("gfx1200", False),
+        ("gfx1201:sramecc+:xnack-", False),
+        ("gfx1250", True),
+        ("gfx950", False),
+    ],
+)
+def test_chunk_opt_vk_unsupported_gfx12_runtime_allowlist(
+    monkeypatch, arch: str, expected: bool
+):
+    chunk_module = importlib.import_module(
+        "aiter.ops.triton._triton_kernels.gated_delta_rule.prefill.chunk"
+    )
+    props = type("DeviceProperties", (), {"gcnArchName": arch})()
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda device: props)
+
+    assert chunk_module._is_unsupported_gfx12_runtime(torch.device("cuda")) is expected
 
 
 def recurrent_gated_delta_rule_ref(
@@ -696,10 +720,6 @@ def test_chunk_opt(
     ],
 )
 @pytest.mark.skipif(not IS_AMD, reason="Skipping HIP-only test on non-AMD backend")
-@pytest.mark.skipif(
-    _is_gfx12_runtime(),
-    reason="chunk_gated_delta_rule_fwd_h_hip_fn kernel does not support gfx12!",
-)
 def test_chunk_opt_hip(
     B: int,
     T: int,
@@ -872,10 +892,6 @@ def test_chunk_opt_varlen(
     ],
 )
 @pytest.mark.skipif(not IS_AMD, reason="Skipping HIP-only test on non-AMD backend")
-@pytest.mark.skipif(
-    _is_gfx12_runtime(),
-    reason="chunk_gated_delta_rule_fwd_h_hip_fn kernel does not support gfx12!",
-)
 def test_chunk_opt_varlen_hip(
     H: int,
     D: int,
@@ -951,11 +967,7 @@ def test_chunk_opt_varlen_hip(
             marks=[
                 pytest.mark.skipif(
                     not IS_AMD, reason="HIP backend requires an AMD device"
-                ),
-                pytest.mark.skipif(
-                    _is_gfx12_runtime(),
-                    reason="chunk_gated_delta_rule_fwd_h_hip_fn does not support gfx12!",
-                ),
+                )
             ],
         ),
     ],
@@ -1330,6 +1342,297 @@ def test_chunk_fwd_h_beyond_int32_chunk_offsets(seqlens):
         for i in range(base, base + -(-seqlen // BT)):
             assert torch.equal(h[0, i], want), f"chunk {i} of sequence {s}"
         base += -(-seqlen // BT)
+
+
+@pytest.mark.parametrize(
+    "state_dtype",
+    [
+        pytest.param(torch.float32, id="state_fp32"),
+        pytest.param(torch.bfloat16, id="state_bf16"),
+    ],
+)
+@pytest.mark.skipif(not IS_AMD, reason="HIP backend requires an AMD device")
+def test_chunk_opt_vk_full_pipeline_indexed_state_pool(state_dtype: torch.dtype):
+    """Full K1-K6 HIP path supports an indexed SGLang-style state pool."""
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    H, D = 4, 128
+    cu_seqlens = torch.tensor([0, 63, 192, 449], device=device, dtype=torch.long)
+    T = int(cu_seqlens[-1])
+    N = len(cu_seqlens) - 1
+
+    q = F.normalize(
+        torch.randn(1, T, H, D, dtype=torch.float32, device=device),
+        p=2,
+        dim=-1,
+    ).to(torch.bfloat16)
+    k = F.normalize(
+        torch.randn(1, T, H, D, dtype=torch.float32, device=device),
+        p=2,
+        dim=-1,
+    ).to(torch.bfloat16)
+    v = (torch.randn(1, T, H, D, dtype=torch.float32, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    beta = (
+        torch.rand(1, T, H, dtype=torch.float32, device=device)
+        .sigmoid()
+        .to(torch.bfloat16)
+    )
+    g = F.logsigmoid(torch.rand(1, T, H, dtype=torch.float32, device=device))
+    h0 = (torch.randn(N, H, D, D, dtype=torch.float32, device=device) * 0.02).to(
+        state_dtype
+    )
+
+    output_ref, state_ref = chunk_gated_delta_rule_opt_vk(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=h0.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_chunk_hip=True,
+        state_dtype=state_dtype,
+        use_exp2=False,
+    )
+
+    pool_size = N + 7
+    indices = torch.tensor([5, 1, 8], device=device, dtype=torch.int32)
+    pool = torch.randn(pool_size, H, D, D, dtype=state_dtype, device=device)
+    pool_before = pool.clone()
+    pool[indices.long()] = h0
+
+    output_indexed, returned_pool = chunk_gated_delta_rule_opt_vk(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=pool,
+        initial_state_indices=indices,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_chunk_hip=True,
+        state_dtype=state_dtype,
+        use_exp2=False,
+    )
+
+    assert returned_pool is pool
+    tol = 0.005 if state_dtype == torch.float32 else 0.02
+    assert_close("indexed full-pipeline output", output_ref, output_indexed, tol)
+    assert_close("indexed full-pipeline state", state_ref, pool[indices.long()], tol)
+
+    untouched = torch.ones(pool_size, dtype=torch.bool, device=device)
+    untouched[indices.long()] = False
+    assert torch.equal(pool[untouched], pool_before[untouched])
+
+
+@pytest.mark.skipif(not IS_AMD, reason="HIP backend requires an AMD device")
+def test_chunk_opt_vk_k5_hip_matches_triton_tail_gfx12():
+    if not _is_gfx12_runtime():
+        pytest.skip(reason="Tail row-group remap is specific to gfx1200/gfx1201")
+
+    torch.manual_seed(42)
+    B, T, H, D = 1, 63, 1, 128
+    k = F.normalize(
+        torch.randn(B, T, H, D, dtype=torch.float32, device=device),
+        p=2,
+        dim=-1,
+    ).to(torch.bfloat16)
+    v = (torch.randn(B, T, H, D, dtype=torch.float32, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    beta = torch.rand(B, T, H, dtype=torch.bfloat16, device=device).sigmoid()
+    raw_g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.float32, device=device))
+
+    g, A_raw = fused_chunk_local_cumsum_scaled_dot_kkt_fwd(
+        k=k,
+        beta=beta,
+        g=raw_g,
+        use_exp2=False,
+    )
+    w, u = fused_solve_tril_recompute_w_u(
+        A_raw=A_raw,
+        k=k,
+        v=v,
+        beta=beta,
+        g_cumsum=g,
+        use_exp2=False,
+    )
+    initial_state = torch.randn(B, H, D, D, dtype=torch.float32, device=device) * 0.02
+
+    h_triton, v_new_triton, final_state_triton = chunk_gated_delta_rule_fwd_h_opt_vk(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state.clone(),
+        output_final_state=True,
+        state_dtype=torch.float32,
+        use_exp2=False,
+    )
+    h_hip, v_new_hip, final_state_hip = chunk_gated_delta_rule_fwd_h_hip_fn(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state.clone(),
+        output_final_state=True,
+        state_dtype=torch.float32,
+        use_exp2=False,
+        g_head_major=True,
+    )
+
+    # T=63 means full_chunks=0, so every token exercises the tail-only path.
+    # v_new is checked directly because output/final-state aggregation can hide
+    # a local row-group cross-wire under the existing end-to-end tolerance.
+    assert_close("tail h HIP vs Triton", h_triton, h_hip, 0.005)
+    torch.testing.assert_close(
+        v_new_hip,
+        v_new_triton,
+        rtol=0,
+        atol=1e-3,
+    )
+    assert_close("tail state HIP vs Triton", final_state_triton, final_state_hip, 0.005)
+
+
+def test_chunk_opt_vk_rejects_indexed_flydsl_state_pool():
+    with pytest.raises(ValueError, match="not supported by the FlyDSL K5 path"):
+        chunk_gated_delta_rule_opt_vk(
+            q=torch.empty(1, 1, 1, 128),
+            k=torch.empty(1, 1, 1, 128),
+            v=torch.empty(1, 1, 1, 128),
+            g=torch.empty(1, 1, 1),
+            beta=torch.empty(1, 1, 1),
+            initial_state=torch.empty(1, 1, 128, 128),
+            initial_state_indices=torch.zeros(1, dtype=torch.int32),
+            use_chunk_flydsl=True,
+        )
+
+
+def test_chunk_opt_vk_rejects_dense_index_count_mismatch():
+    with pytest.raises(ValueError, match="state indices.*2 rather than 1"):
+        chunk_gated_delta_rule_opt_vk(
+            q=torch.empty(2, 1, 1, 128),
+            k=torch.empty(2, 1, 1, 128),
+            v=torch.empty(2, 1, 1, 128),
+            g=torch.empty(2, 1, 1),
+            beta=torch.empty(2, 1, 1),
+            initial_state=torch.empty(4, 1, 128, 128),
+            initial_state_indices=torch.zeros(1, dtype=torch.int32),
+        )
+
+
+def test_chunk_opt_vk_hip_downgrade_preserves_indexed_state_args(monkeypatch):
+    chunk_module = importlib.import_module(
+        "aiter.ops.triton._triton_kernels.gated_delta_rule.prefill.chunk"
+    )
+    initial_state = torch.empty(4, 1, 1, 1)
+    initial_state_indices = torch.tensor([3], dtype=torch.int32)
+    captured = {}
+
+    monkeypatch.setattr(
+        chunk_module,
+        "fused_chunk_local_cumsum_scaled_dot_kkt_fwd",
+        lambda **kwargs: (torch.empty(1, 1, 1), torch.empty(1, 1, 1, 1)),
+    )
+    monkeypatch.setattr(
+        chunk_module,
+        "fused_solve_tril_recompute_w_u",
+        lambda **kwargs: (torch.empty(1, 1, 1, 1), torch.empty(1, 1, 1, 1)),
+    )
+
+    def fake_triton_k5(**kwargs):
+        captured.update(kwargs)
+        return (
+            torch.empty(1, 1, 1, 1, 1),
+            torch.empty(1, 1, 1, 1),
+            initial_state,
+        )
+
+    monkeypatch.setattr(
+        chunk_module, "chunk_gated_delta_rule_fwd_h_opt_vk", fake_triton_k5
+    )
+    monkeypatch.setattr(
+        chunk_module,
+        "chunk_fwd_o_opt_vk",
+        lambda **kwargs: kwargs["o"],
+    )
+
+    chunk_module.chunk_gated_delta_rule_fwd_opt_vk(
+        q=torch.empty(1, 1, 1, 1),
+        k=torch.empty(1, 1, 1, 1),
+        v=torch.empty(1, 1, 1, 1),
+        g=torch.empty(1, 1, 1),
+        beta=torch.empty(1, 1, 1),
+        scale=1.0,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=torch.tensor([0, 1, 2]),
+        use_chunk_hip=True,
+        o=torch.empty(1, 1, 1, 1),
+        num_decodes=1,
+        num_decode_tokens=1,
+        initial_state_indices=initial_state_indices,
+        inplace_final_state=True,
+    )
+
+    assert captured["initial_state_indices"] is initial_state_indices
+    assert captured["inplace_final_state"] is True
+
+
+def test_chunk_opt_vk_unsupported_gfx12_downgrades_to_triton(monkeypatch):
+    chunk_module = importlib.import_module(
+        "aiter.ops.triton._triton_kernels.gated_delta_rule.prefill.chunk"
+    )
+    props = type("DeviceProperties", (), {"gcnArchName": "gfx1250"})()
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda device: props)
+    monkeypatch.setattr(
+        chunk_module,
+        "fused_chunk_local_cumsum_scaled_dot_kkt_fwd",
+        lambda **kwargs: (torch.empty(1, 1, 1), torch.empty(1, 1, 1, 1)),
+    )
+    monkeypatch.setattr(
+        chunk_module,
+        "fused_solve_tril_recompute_w_u",
+        lambda **kwargs: (torch.empty(1, 1, 1, 1), torch.empty(1, 1, 1, 1)),
+    )
+    triton_called = False
+
+    def fake_triton_k5(**kwargs):
+        nonlocal triton_called
+        triton_called = True
+        return (
+            torch.empty(1, 1, 1, 1, 1),
+            torch.empty(1, 1, 1, 1),
+            None,
+        )
+
+    monkeypatch.setattr(
+        chunk_module, "chunk_gated_delta_rule_fwd_h_opt_vk", fake_triton_k5
+    )
+    monkeypatch.setattr(
+        chunk_module,
+        "chunk_fwd_o_opt_vk",
+        lambda **kwargs: kwargs["o"],
+    )
+
+    chunk_module.chunk_gated_delta_rule_fwd_opt_vk(
+        q=torch.empty(1, 1, 1, 1),
+        k=torch.empty(1, 1, 1, 1),
+        v=torch.empty(1, 1, 1, 1),
+        g=torch.empty(1, 1, 1),
+        beta=torch.empty(1, 1, 1),
+        scale=1.0,
+        initial_state=None,
+        output_final_state=False,
+        use_chunk_hip=True,
+        o=torch.empty(1, 1, 1, 1),
+    )
+
+    assert triton_called
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Enable chunl-gated-delta-rule-fwd-h on gfx1201 to help us to improve the inference performance on Qwen3.6-35B-A3B; 
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Use the gfx12 wave64 BF16 WMMA intrinsic instead of the CDNA MFMA intrinsic on gfx1200 and gfx1201.
- Compile the kernel with -mwavefrontsize64 to preserve its existing 64-lane wave decomposition and thread mapping.
- Remap gfx12 WMMA accumulator lane groups from physical order 0,1,2,3 to result-row order 0,2,1,3.
- Enable the existing dense, variable-length, and indexed-state HIP tests on gfx12.
-  - Add indexed state-pool support to the full K1-K6 API without changing FlyDSL.
## Test Plan
<!-- Explain any relevant testing done to verify this PR. -->
op_test/test_gated_delta_rule.py
local benchmark among sglang triton kernel and hip kernel on this pr.
## Test Result

<!-- Briefly summarize test outcomes. -->
Tested on gfx1201 using Qwen3.6-35B-A3B prefill workloads. In SGLang, this kernel is guarded by a dedicated serving flag and is disabled by default. When enabled, it only replaces the K5 hidden-state update in the GDN prefill path. The existing K1-K4 and K6 stages, as well as decode, mixed prefill/decode, and verification paths, remain unchanged.
<img width="964" height="514" alt="image" src="https://github.com/user-attachments/assets/3b7bdac5-b4ef-426b-a31a-0f8a0ca01750" />
avg speedup: 1.268x

Prefill GDN bench between SGLang and Aiter:
<img width="919" height="694" alt="image" src="https://github.com/user-attachments/assets/c4488b81-0a85-4ea9-877c-ee34e44f0c17" />
avg speedup: 1.418x

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
