### PR TITLE
Add gfx90a to GFX_CU_NUM_MAP

### DIFF
--- a/aiter/jit/utils/build_targets.py
+++ b/aiter/jit/utils/build_targets.py
@@ -37,6 +37,7 @@ GFX_MAP = {
 # explicitly alongside GPU_ARCHS to override the default here.
 # Extend this table when adding support for new GPU targets.
 GFX_CU_NUM_MAP = {
+    "gfx90a": 104,  # MI210; MI250 is also 104 per GCD. MI250X is 110 per GCD — use CU_NUM override
     "gfx942": 304,  # MI300X (SPX, full GPU); MI308X shares gfx942 — use CU_NUM override
     "gfx950": 256,  # MI350
     "gfx1250": 256,  # Gfx1250

--- a/op_tests/test_gemm_codegen.py
+++ b/op_tests/test_gemm_codegen.py
@@ -59,6 +59,7 @@ REPRO_BPRESHUFFLE_CSV = os.path.join(
 TARGET_A = ("gfx942", 304)  # MI300X
 TARGET_B = ("gfx950", 256)  # MI350
 TARGET_C = ("gfx942", 80)  # MI308X — gfx942 with CU_NUM override
+TARGET_D = ("gfx90a", 104)  # MI210 / MI250 (per GCD); MI250X is 110 — CU_NUM override
 
 # ---------------------------------------------------------------------------
 # Minimal test harness (no external test framework required)
@@ -118,6 +119,24 @@ def test_get_build_targets():
         os.environ["GPU_ARCHS"] = TARGET_B[0]
         t = get_build_targets_env()
         _check(f"GPU_ARCHS={TARGET_B[0]} → [{TARGET_B}]", t == [TARGET_B], str(t))
+
+        # 1.3b CDNA2. gfx90a is listed in GFX_MAP but was absent from
+        # GFX_CU_NUM_MAP, so an explicit GPU_ARCHS=gfx90a build raised
+        # "Unknown gfx" before any kernel could be generated.
+        os.environ["GPU_ARCHS"] = TARGET_D[0]
+        t = get_build_targets_env()
+        _check(f"GPU_ARCHS={TARGET_D[0]} → [{TARGET_D}]", t == [TARGET_D], str(t))
+
+        # 1.3c CU_NUM override on gfx90a (MI250X is 110 CUs per GCD)
+        os.environ["GPU_ARCHS"] = TARGET_D[0]
+        os.environ["CU_NUM"] = "110"
+        t = get_build_targets_env()
+        _check(
+            f"GPU_ARCHS={TARGET_D[0]} + CU_NUM=110 → [('{TARGET_D[0]}', 110)]",
+            t == [(TARGET_D[0], 110)],
+            str(t),
+        )
+        del os.environ["CU_NUM"]
 
         # 1.4 Multi-arch (semicolon-separated)
         os.environ["GPU_ARCHS"] = f"{TARGET_A[0]};{TARGET_B[0]}"


### PR DESCRIPTION
> **Related:** ROCm/aiter#4524 — a separate gfx90a request (shipping official builds of the `fmha_v3_fwd` ASM kernels). Independent of this PR; both came out of the same effort to run AITER on CDNA2. This one is a build blocker and stands alone.

## The problem

`gfx90a` (MI210 / MI250) is enumerated in `GFX_MAP` but has no entry in `GFX_CU_NUM_MAP`, so any build that sets an explicit target fails before a kernel is generated:

```console
$ GPU_ARCHS=gfx90a python -c "from aiter.jit.utils.build_targets import get_build_targets_env; get_build_targets_env()"
RuntimeError: Unknown gfx 'gfx90a' in GPU_ARCHS — add it to GFX_CU_NUM_MAP in
build_targets.py. Known targets: ['gfx942', 'gfx950', 'gfx1250']
```

## Scope — who this affects

**Live-GPU builds are unaffected.** `chip_info.get_build_targets()` consults this table only when `GPU_ARCHS` names an explicit target; otherwise it resolves through `get_gfx()` / `get_cu_num()`, which correctly reflect partition mode and binned variants.

So this hits **container and CI builds that pin `GPU_ARCHS`** — the common way to build for one specific card.

## Why it is worth a table entry rather than a caller-side workaround

The lookup runs *before* the tuning CSV is filtered, so it fires even for an architecture with **no rows in the CSV**. A target that would otherwise fall through to default kernels gets a hard error instead of the fallback.

That is the case for gfx90a today: `a8w8_tuned_gemm.csv` has zero gfx90a rows. With the entry present, `gen_instances` emits default instances and the CK GEMM templates compile and run on CDNA2.

## The value

104 matches **MI210** and **MI250** (per GCD). **MI250X** is 110 per GCD and uses the `CU_NUM` override this table already documents — the same arrangement as MI308X against the `gfx942` entry.

## Verification

```
gfx90a in GFX_MAP : True
CU map keys       : ['gfx90a', 'gfx942', 'gfx950', 'gfx1250']
  MI210 default            gfx90a         -> [('gfx90a', 104)]
  MI250X via CU_NUM        gfx90a         -> [('gfx90a', 110)]
  multi-arch               gfx90a;gfx942  -> [('gfx90a', 104), ('gfx942', 304)]
  unknown arch             gfx999         -> RuntimeError: Unknown gfx 'gfx999'...
```

Unknown architectures still raise, so the guard is intact.

Adds coverage in `op_tests/test_gemm_codegen.py` for the gfx90a target and for the `CU_NUM` override on it, alongside the existing gfx942 / gfx950 cases.

## Related but distinct

`ROCm/aiter#1415` and `#1552` report the same *class* of issue — a missing architecture in a mapping dict — and `#179` covers gfx90a build failures in fp8 kernels. I did not find this specific path reported. The distinguishing detail is the one above: it defeats the no-tuned-config fallback rather than merely failing to find tuned kernels.

## Not included

`gfx908`, `gfx940`, `gfx941`, `gfx945`, `gfx1100` and others are also in `GFX_MAP` and absent from `GFX_CU_NUM_MAP`. I have only gfx90a hardware, and adding CU counts I cannot verify on a device seemed worse than leaving the gap visible. Flagging it in case maintainers want to close the set.
