### PR TITLE
Fix LDS allocation for B-to-LDS FlyDSL Split-K HGEMM

### DIFF
--- a/aiter/ops/flydsl/gemm_kernels.py
+++ b/aiter/ops/flydsl/gemm_kernels.py
@@ -232,19 +232,18 @@ def _estimate_hgemm_lds_bytes(
     tile_n: int,
     tile_k: int,
     stages: int,
+    block_k_warps: int,
     b_to_lds: bool,
 ) -> int:
     if dtype not in {"f16", "bf16"}:
         raise ValueError(f"`dtype` must be 'f16' or 'bf16', got {dtype!r}")
 
     dtype_bytes = 2
-    a_lds_bytes = max(
-        stages * tile_m * tile_k * dtype_bytes,
-        tile_m * tile_n * dtype_bytes,
-    )
-    if not b_to_lds:
-        return a_lds_bytes
-    return _align_up(a_lds_bytes, 16) + stages * tile_n * tile_k * dtype_bytes
+    pipeline_lds_bytes = stages * tile_m * tile_k * dtype_bytes
+    if b_to_lds:
+        pipeline_lds_bytes += stages * tile_n * tile_k * dtype_bytes
+    c_lds_bytes = block_k_warps * tile_m * tile_n * dtype_bytes
+    return max(pipeline_lds_bytes, c_lds_bytes)
 
 
 def _validate_hgemm_inputs(
@@ -474,6 +473,7 @@ def _validate_hgemm_tiling(
         tile_n=tile_n,
         tile_k=tile_k,
         stages=stages,
+        block_k_warps=block_k_warps,
         b_to_lds=b_to_lds,
     )
     lds_limit = get_shared_memory_per_block(fallback_gfx=get_gfx())

--- a/aiter/ops/flydsl/kernels/splitk_hgemm.py
+++ b/aiter/ops/flydsl/kernels/splitk_hgemm.py
@@ -187,16 +187,15 @@ def compile_hgemm_kernel(
     BLOCK_K_BYTES = BLOCK_K * DTYPE_BYTES
 
     # LDS parameters:
-    # C output reuses A's LDS region (aliasing the A tile). When C overflows the
-    # A field it continues into the B field, which is why B is sized to hold the
-    # larger of the B tile or the C-tile overflow. Static shared leaves are laid
-    # out consecutively, so the A and B fields form one contiguous C region.
+    # C output reuses A's LDS field after the GEMM pipeline is complete.
+    # SharedAllocator emits struct leaves as independent static LDS globals, so
+    # C must fit entirely in a_lds; it cannot spill into the b_lds field.
     AS_ELEMS = STAGES * BLOCK_M * BLOCK_K
     BS_ELEMS = STAGES * BLOCK_N * BLOCK_K
     CMN_ELEMS = BLOCK_K_WARPS * BLOCK_M * BLOCK_N
     if B_TO_LDS:
-        A_FIELD_ELEMS = AS_ELEMS
-        B_FIELD_ELEMS = max(BS_ELEMS, CMN_ELEMS - AS_ELEMS)
+        A_FIELD_ELEMS = max(AS_ELEMS, CMN_ELEMS)
+        B_FIELD_ELEMS = BS_ELEMS
         assert ASYNC_COPY
     else:
         A_FIELD_ELEMS = max(AS_ELEMS, CMN_ELEMS)

--- a/aiter/ops/flydsl/kernels/splitk_hgemm.py
+++ b/aiter/ops/flydsl/kernels/splitk_hgemm.py
@@ -186,33 +186,32 @@ def compile_hgemm_kernel(
     assert BLOCK_MN_SIZE % BLOCK_VECS == 0
     BLOCK_K_BYTES = BLOCK_K * DTYPE_BYTES
 
-    # LDS parameters:
-    # C output reuses A's LDS field after the GEMM pipeline is complete.
-    # SharedAllocator emits struct leaves as independent static LDS globals, so
-    # C must fit entirely in a_lds; it cannot spill into the b_lds field.
+    # LDS parameters: the A/B pipeline and C scratch are live at disjoint times,
+    # so model their storage overlap explicitly with a union. SharedAllocator
+    # emits one static LDS symbol for a union, preserving the old contiguous
+    # A-then-B layout without relying on separate struct leaves being adjacent.
     AS_ELEMS = STAGES * BLOCK_M * BLOCK_K
     BS_ELEMS = STAGES * BLOCK_N * BLOCK_K
     CMN_ELEMS = BLOCK_K_WARPS * BLOCK_M * BLOCK_N
-    if B_TO_LDS:
-        A_FIELD_ELEMS = max(AS_ELEMS, CMN_ELEMS)
-        B_FIELD_ELEMS = BS_ELEMS
-        assert ASYNC_COPY
-    else:
-        A_FIELD_ELEMS = max(AS_ELEMS, CMN_ELEMS)
-        B_FIELD_ELEMS = 0
     fx_dtype = fx.Float16 if dtype == "f16" else fx.BFloat16
     if B_TO_LDS:
+        assert ASYNC_COPY
 
         @fx.struct
-        class SharedStorage:
-            a_lds: fx.Array[fx_dtype, A_FIELD_ELEMS, 16]
-            b_lds: fx.Array[fx_dtype, B_FIELD_ELEMS, 16]
+        class PipelineStorage:
+            a_lds: fx.Array[fx_dtype, AS_ELEMS, 16]
+            b_lds: fx.Array[fx_dtype, BS_ELEMS, 16]
 
     else:
 
         @fx.struct
-        class SharedStorage:
-            a_lds: fx.Array[fx_dtype, A_FIELD_ELEMS, 16]
+        class PipelineStorage:
+            a_lds: fx.Array[fx_dtype, AS_ELEMS, 16]
+
+    @fx.union
+    class SharedStorage:
+        pipeline: PipelineStorage
+        c_lds: fx.Array[fx_dtype, CMN_ELEMS, 16]
 
     LDG_ASYNC_VEC_SIZE = DMA_BYTES // DTYPE_BYTES
     LDG_A_X_THREADS_AS = BLOCK_K // LDG_ASYNC_VEC_SIZE
@@ -263,11 +262,12 @@ def compile_hgemm_kernel(
         C_ = GTensor(C, dtype=dtype_, shape=(-1, n))
         if const_expr(HAS_BIAS):
             BIAS_ = GTensor(BIAS, dtype=dtype_, shape=(n,))
-        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
-        a_lds_ptr = lds.a_lds.ptr
+        lds = fx.SharedAllocator().allocate(SharedStorage)
+        a_lds_ptr = lds.pipeline.a_lds.peek().ptr
+        c_lds_ptr = lds.c_lds.peek().ptr
         a_lds_i64 = fx.Int64(fx.ptrtoint(a_lds_ptr))
         if const_expr(B_TO_LDS):
-            b_lds_ptr = lds.b_lds.ptr
+            b_lds_ptr = lds.pipeline.b_lds.peek().ptr
             b_lds_i64 = fx.Int64(fx.ptrtoint(b_lds_ptr))
 
         def _lds_a3_ptr(base_i64, elem_off):
@@ -281,7 +281,7 @@ def compile_hgemm_kernel(
         # LDS accessors: linear element offsets mirroring the old STensor shapes
         # as_/bs_ = (stage, row, col) over (STAGES, BLOCK*, BLOCK_K);
         # cs_ = (k_slice, row, col) over (BLOCK_K_WARPS, BLOCK_M, BLOCK_N),
-        # aliasing the A field.
+        # using the C variant of the pipeline/C union.
         def as_store(stage, row, col, value):
             elem_off = (
                 fx.Int64(stage) * (BLOCK_M * BLOCK_K)
@@ -326,7 +326,7 @@ def compile_hgemm_kernel(
                 + fx.Int64(row) * BLOCK_N
                 + fx.Int64(col)
             )
-            fx.ptr_store(value, a_lds_ptr + elem_off)
+            fx.ptr_store(value, c_lds_ptr + elem_off)
 
         def cs_load_vec(k_slice, row, col, vec_size):
             elem_off = (
@@ -335,7 +335,7 @@ def compile_hgemm_kernel(
                 + fx.Int64(col)
             )
             return fx.ptr_load(
-                a_lds_ptr + elem_off,
+                c_lds_ptr + elem_off,
                 result_type=fx.Vector.make_type(vec_size, fx_dtype),
             )
 


### PR DESCRIPTION
Test script:

```bash
python op_tests/test_gemm_a16w16.py -d bf16 -o bf16 -mnk 56,129280,4096
```