### PR TITLE
[HIP] [kernel] mrope cache-quant: accept strided flash KV-cache view

### DIFF
--- a/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
@@ -3,6 +3,13 @@
 #include "fused_qk_norm_mrope_cache_quant.h"
 #include "rope/rope_common.h"
 
+// The innermost dim must be dense: the kernel stores whole vectors per head, so a
+// non-unit element stride cannot be expressed by the block/token/head strides below.
+static inline bool has_unit_element_stride(const aiter_tensor_t& t)
+{
+    return t.numel() == 0 || t.stride(t.dim() - 1) == 1;
+}
+
 void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                                                     aiter_tensor_t& qw,
                                                     aiter_tensor_t& kw,
@@ -35,12 +42,22 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
     AITER_CHECK(mrope_section_.size() == 3);
     AITER_CHECK(qkv.is_contiguous() && qw.is_contiguous() && kw.is_contiguous() &&
                 cos_sin.is_contiguous());
-    // k_cache/v_cache may be a strided flash KV view (num_blocks, 2, block, heads, hs)[:, 0],
-    // which is non-contiguous but well-formed. The per-block stride is passed to the kernel
-    // below (k_block_stride/v_block_stride), so only slot_mapping must be contiguous here.
+    // k_cache/v_cache may be a strided view of a larger KV allocation -- e.g. blocks-first
+    // (num_blocks, 2, block, heads, hs)[:, 0], or a packed (blocks, heads, block, 2*hs) buffer
+    // transposed and split. Both are non-contiguous but well-formed. Every stride the kernel
+    // needs is read off the tensors below, so only slot_mapping must be contiguous here.
     AITER_CHECK(slot_mapping.is_contiguous());
-    int64_t k_block_stride_ = k_cache.stride(0);  // real per-block stride (flash: 2*block*heads*hs)
+    AITER_CHECK(has_unit_element_stride(k_cache) && has_unit_element_stride(v_cache),
+                "k_cache/v_cache must have unit element stride (innermost dim)");
+    // Block/token/head strides taken from the tensors rather than assumed: a transposed or
+    // interleaved view diverges from the contiguous (num_heads*hs, hs) layout on dims 1 and 2,
+    // not just dim 0. Missing dims pass 0, which the kernel treats as "assume contiguous".
+    int64_t k_block_stride_ = k_cache.stride(0);
     int64_t v_block_stride_ = v_cache.stride(0);
+    int64_t k_token_stride_ = k_cache.dim() >= 2 ? k_cache.stride(1) : 0;
+    int64_t v_token_stride_ = v_cache.dim() >= 2 ? v_cache.stride(1) : 0;
+    int64_t k_head_stride_  = k_cache.dim() >= 3 ? k_cache.stride(2) : 0;
+    int64_t v_head_stride_  = v_cache.dim() >= 3 ? v_cache.stride(2) : 0;
     std::array<int64_t, 3> mrope_section;
     mrope_section[0] = mrope_section_[0];
     mrope_section[1] = mrope_section_[1];
@@ -98,7 +115,11 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                     rotary_dim,
                     k_block_stride_,
                     v_block_stride_,
-                    gemma_norm);
+                    gemma_norm,
+                    k_token_stride_,
+                    k_head_stride_,
+                    v_token_stride_,
+                    v_head_stride_);
             }
             else
             {
@@ -146,7 +167,11 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                             rotary_dim,
                             k_block_stride_,
                             v_block_stride_,
-                            gemma_norm);
+                            gemma_norm,
+                            k_token_stride_,
+                            k_head_stride_,
+                            v_token_stride_,
+                            v_head_stride_);
                     }
                     else
                     {
@@ -192,7 +217,11 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                             rotary_dim,
                             k_block_stride_,
                             v_block_stride_,
-                            gemma_norm);
+                            gemma_norm,
+                            k_token_stride_,
+                            k_head_stride_,
+                            v_token_stride_,
+                            v_head_stride_);
                     }
                 }
                 else

--- a/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_mrope_cache_quant.cu
@@ -35,7 +35,12 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
     AITER_CHECK(mrope_section_.size() == 3);
     AITER_CHECK(qkv.is_contiguous() && qw.is_contiguous() && kw.is_contiguous() &&
                 cos_sin.is_contiguous());
-    AITER_CHECK(k_cache.is_contiguous() && v_cache.is_contiguous() && slot_mapping.is_contiguous());
+    // k_cache/v_cache may be a strided flash KV view (num_blocks, 2, block, heads, hs)[:, 0],
+    // which is non-contiguous but well-formed. The per-block stride is passed to the kernel
+    // below (k_block_stride/v_block_stride), so only slot_mapping must be contiguous here.
+    AITER_CHECK(slot_mapping.is_contiguous());
+    int64_t k_block_stride_ = k_cache.stride(0);  // real per-block stride (flash: 2*block*heads*hs)
+    int64_t v_block_stride_ = v_cache.stride(0);
     std::array<int64_t, 3> mrope_section;
     mrope_section[0] = mrope_section_[0];
     mrope_section[1] = mrope_section_[1];
@@ -91,6 +96,8 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                     block_size,
                     x,
                     rotary_dim,
+                    k_block_stride_,
+                    v_block_stride_,
                     gemma_norm);
             }
             else
@@ -137,6 +144,8 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                             block_size,
                             x,
                             rotary_dim,
+                            k_block_stride_,
+                            v_block_stride_,
                             gemma_norm);
                     }
                     else
@@ -181,6 +190,8 @@ void fused_qk_norm_mrope_3d_cache_pts_quant_shuffle(aiter_tensor_t& qkv,
                             block_size,
                             x,
                             rotary_dim,
+                            k_block_stride_,
+                            v_block_stride_,
                             gemma_norm);
                     }
                 }

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -8133,6 +8133,8 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             int64_t block_size       = 0,
                             int64_t x                = 0,
                             int64_t rotary_dim       = 0,
+                            int64_t k_block_stride   = 0,
+                            int64_t v_block_stride   = 0,
                             bool gemma_norm          = false)
 {
     TORCH_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
@@ -8180,8 +8182,8 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         block_size,                  \
                                                         x,                           \
                                                         (int)rotary_dim,             \
-                                                        (int64_t)0,                  \
-                                                        (int64_t)0,                  \
+                                                        k_block_stride,              \
+                                                        v_block_stride,              \
                                                         gemma_norm);                 \
     }                                                                                \
     else                                                                             \
@@ -8213,8 +8215,8 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         block_size,                  \
                                                         x,                           \
                                                         (int)rotary_dim,             \
-                                                        (int64_t)0,                  \
-                                                        (int64_t)0,                  \
+                                                        k_block_stride,              \
+                                                        v_block_stride,              \
                                                         gemma_norm);                 \
     }
 

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -7322,6 +7322,9 @@ __inline__ __device__ T warp_shfl_sync(T val, int src_id)
 
 } // namespace block_utils
 
+struct fp8e4m3fn;
+struct fp8e4m3fnuz;
+
 template <typename T, int vec_size>
 struct alignas(sizeof(T) * vec_size) vec_t
 {
@@ -7389,17 +7392,43 @@ struct alignas(sizeof(T) * vec_size) vec_t
     template <typename IT>
     __device__ __forceinline__ void from_(const vec_t<IT, vec_size>& src, float scale)
     {
-#pragma unroll
-        for(int i = 0; i < vec_size; ++i)
+        if constexpr(std::is_same_v<T, IT>)
         {
-            if constexpr(std::is_same_v<T, IT>)
-            {
+#pragma unroll
+            for(int i = 0; i < vec_size; ++i)
                 data[i] = src[i];
-            }
-            else
+        }
+#if defined(__HIP_DEVICE_COMPILE__) && (defined(__HIP__MI300__) || defined(__gfx950__))
+        // Two f32 lanes convert and pack into one fp8 pair per instruction, so an
+        // even-length vector costs half as many converts as the scalar path below.
+        else if constexpr((std::is_same_v<T, fp8e4m3fnuz> || std::is_same_v<T, fp8e4m3fn>) &&
+                          (vec_size % 2 == 0))
+        {
+            constexpr float FP8_MAX = std::is_same_v<T, fp8e4m3fnuz> ? 240.0f : 448.0f;
+            const float rcp_scale   = 1.0f / scale;
+#pragma unroll
+            for(int i = 0; i < vec_size; i += 2)
             {
-                data[i] = static_cast<T>(static_cast<float>(src[i]) / scale);
+                // fmed3(x, hi, lo) is the median of three, i.e. a clamp to [lo, hi];
+                // the packed convert saturates differently, so clamp first.
+                float v0 = __builtin_amdgcn_fmed3f(
+                    static_cast<float>(src[i]) * rcp_scale, FP8_MAX, -FP8_MAX);
+                float v1 = __builtin_amdgcn_fmed3f(
+                    static_cast<float>(src[i + 1]) * rcp_scale, FP8_MAX, -FP8_MAX);
+                uint32_t packed = __builtin_amdgcn_cvt_pk_fp8_f32(v0, v1, 0u, false);
+                data[i]         = T(static_cast<uint8_t>(packed & 0xFF), T::from_bits());
+                data[i + 1]     = T(static_cast<uint8_t>((packed >> 8) & 0xFF), T::from_bits());
             }
+        }
+#endif
+        else
+        {
+            // Reciprocal once rather than a divide per element: scale is uniform
+            // across the vector, and v_rcp_f32 + multiply beats N full divides.
+            const float rcp_scale = 1.0f / scale;
+#pragma unroll
+            for(int i = 0; i < vec_size; ++i)
+                data[i] = static_cast<T>(static_cast<float>(src[i]) * rcp_scale);
         }
     }
 };
@@ -7706,6 +7735,20 @@ struct alignas(1) fp8e4m3fnuz
     }
 };
 
+// Power-of-2 integer division/modulo via shift/mask. block_size and x are kernel
+// parameters, hence warp-uniform, so __builtin_ctz lowers to a single s_ff1_i32_b32
+// and the per-lane operation becomes a shift instead of the ~30-cycle integer
+// division emulation. The power-of-2 precondition is enforced host-side in
+// fused_mrope_rms_set_kv / fused_mrope_rms_set_kv_pts.
+__device__ __forceinline__ int po2_div(int64_t val, int po2)
+{
+    return static_cast<int>(val >> __builtin_ctz(po2));
+}
+__device__ __forceinline__ int po2_mod(int64_t val, int po2)
+{
+    return static_cast<int>(val & (po2 - 1));
+}
+
 template <int HEAD_SIZE>
 __device__ __forceinline__ int64_t get_shuffle_layout_k_base(const int64_t slot_id,
                                                              const int block_size,
@@ -7716,18 +7759,18 @@ __device__ __forceinline__ int64_t get_shuffle_layout_k_base(const int64_t slot_
                                                              const int64_t k_block_stride)
 {
     // Shuffle layout: [num_blocks, num_kv_heads, head_size // x, block_size, x]
-    const int block_id      = static_cast<int>(slot_id / block_size);
-    const int block_offset  = static_cast<int>(slot_id % block_size);
+    const int block_id      = po2_div(slot_id, block_size);
+    const int block_offset  = po2_mod(slot_id, block_size);
     const int k_head_stride = HEAD_SIZE * block_size;
     const int64_t k_per_block =
         (k_block_stride != 0) ? k_block_stride : static_cast<int64_t>(num_heads_k) * k_head_stride;
     const int64_t dst_base = static_cast<int64_t>(block_id) * k_per_block + head_id_k * k_head_stride;
     // Pre-compute K base offset: since VEC_SIZE <= x, all elements are in the same
     // chunk
-    const int chunk_id     = access_id_in_head / x;
+    const int chunk_id     = po2_div(access_id_in_head, x);
     const int block_size_x = block_size * x;
     const int64_t k_base =
-        dst_base + chunk_id * block_size_x + block_offset * x + (access_id_in_head % x);
+        dst_base + chunk_id * block_size_x + block_offset * x + po2_mod(access_id_in_head, x);
     return k_base;
 }
 
@@ -7741,15 +7784,15 @@ __device__ __forceinline__ int64_t get_shuffle_layout_v_base(const int64_t slot_
                                                              const int64_t v_block_stride)
 {
     // Shuffle layout: [num_blocks, num_kv_heads, block_size // x, head_size, x]
-    const int block_id      = static_cast<int>(slot_id / block_size);
-    const int block_offset  = static_cast<int>(slot_id % block_size);
-    const int v_head_stride = (block_size / x) * HEAD_SIZE * x;
+    const int block_id      = po2_div(slot_id, block_size);
+    const int block_offset  = po2_mod(slot_id, block_size);
+    const int v_head_stride = po2_div(block_size, x) * HEAD_SIZE * x;
     const int64_t v_per_block =
         (v_block_stride != 0) ? v_block_stride : static_cast<int64_t>(num_heads_v) * v_head_stride;
     const int64_t dst_base = static_cast<int64_t>(block_id) * v_per_block + head_id_v * v_head_stride;
     // Pre-compute V base offset (fixed for this token)
-    const int v_slot_chunk    = block_offset / x;
-    const int v_slot_in_chunk = block_offset % x;
+    const int v_slot_chunk    = po2_div(block_offset, x);
+    const int v_slot_in_chunk = po2_mod(block_offset, x);
     const int64_t v_base      = dst_base + v_slot_chunk * HEAD_SIZE * x + v_slot_in_chunk;
     return v_base;
 }
@@ -8026,8 +8069,8 @@ __global__ void fused_mrope_rms_kv_kernel(const T* qkv,
                 }
                 else
                 {
-                    const int block_id         = static_cast<int>(slot_id / block_size);
-                    const int block_offset     = static_cast<int>(slot_id % block_size);
+                    const int block_id         = po2_div(slot_id, block_size);
+                    const int block_offset     = po2_mod(slot_id, block_size);
                     const int64_t block_stride = (k_block_stride != 0)
                                                      ? k_block_stride
                                                      : static_cast<int64_t>(block_size) * slot_size;
@@ -8081,8 +8124,8 @@ __global__ void fused_mrope_rms_kv_kernel(const T* qkv,
             }
             else
             {
-                const int block_id         = static_cast<int>(slot_id / block_size);
-                const int block_offset     = static_cast<int>(slot_id % block_size);
+                const int block_id         = po2_div(slot_id, block_size);
+                const int block_offset     = po2_mod(slot_id, block_size);
                 const int64_t block_stride = (v_block_stride != 0)
                                                  ? v_block_stride
                                                  : static_cast<int64_t>(block_size) * slot_size;
@@ -8142,6 +8185,13 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             int64_t v_head_stride    = 0)
 {
     TORCH_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
+    // po2_div/po2_mod in the paged and shuffle-layout address math assume these are
+    // powers of two. Every vLLM block_size and every x = 16 / sizeof(elem) satisfies
+    // it, but check rather than corrupt the cache silently if that ever changes.
+    TORCH_CHECK(block_size == 0 || (block_size & (block_size - 1)) == 0,
+                "block_size must be a power of 2, got ", block_size);
+    TORCH_CHECK(!use_shuffle_layout || (x > 0 && (x & (x - 1)) == 0),
+                "x must be a power of 2 when use_shuffle_layout is set, got ", x);
     auto dim           = std::accumulate(mrope_section.begin(), mrope_section.end(), 0);
     auto expected_half = rotary_dim > 0 ? rotary_dim / 2 : head_size / 2;
     TORCH_CHECK(dim == expected_half,
@@ -8290,6 +8340,13 @@ void fused_rope_rms_set_kv(const T* qkv,
                            int64_t v_head_stride    = 0)
 {
     TORCH_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
+    // po2_div/po2_mod in the paged and shuffle-layout address math assume these are
+    // powers of two. Every vLLM block_size and every x = 16 / sizeof(elem) satisfies
+    // it, but check rather than corrupt the cache silently if that ever changes.
+    TORCH_CHECK(block_size == 0 || (block_size & (block_size - 1)) == 0,
+                "block_size must be a power of 2, got ", block_size);
+    TORCH_CHECK(!use_shuffle_layout || (x > 0 && (x & (x - 1)) == 0),
+                "x must be a power of 2 when use_shuffle_layout is set, got ", x);
     constexpr int THREAD_BLOCK_SIZE = 256;
     auto total_warps                = num_tokens * (num_heads_q + num_heads_k + num_heads_v);
     auto num_warps_per_block        = THREAD_BLOCK_SIZE / WARP_SIZE;

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -8135,7 +8135,11 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             int64_t rotary_dim       = 0,
                             int64_t k_block_stride   = 0,
                             int64_t v_block_stride   = 0,
-                            bool gemma_norm          = false)
+                            bool gemma_norm          = false,
+                            int64_t k_token_stride   = 0,
+                            int64_t k_head_stride    = 0,
+                            int64_t v_token_stride   = 0,
+                            int64_t v_head_stride    = 0)
 {
     TORCH_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
     auto dim           = std::accumulate(mrope_section.begin(), mrope_section.end(), 0);
@@ -8184,7 +8188,11 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         (int)rotary_dim,             \
                                                         k_block_stride,              \
                                                         v_block_stride,              \
-                                                        gemma_norm);                 \
+                                                        gemma_norm,                  \
+                                                        k_token_stride,              \
+                                                        k_head_stride,               \
+                                                        v_token_stride,              \
+                                                        v_head_stride);              \
     }                                                                                \
     else                                                                             \
     {                                                                                \
@@ -8217,7 +8225,11 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         (int)rotary_dim,             \
                                                         k_block_stride,              \
                                                         v_block_stride,              \
-                                                        gemma_norm);                 \
+                                                        gemma_norm,                  \
+                                                        k_token_stride,              \
+                                                        k_head_stride,               \
+                                                        v_token_stride,              \
+                                                        v_head_stride);              \
     }
 
     if(is_interleaved)

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -13,7 +13,7 @@
 #include <type_traits>
 
 #ifdef __HIP_DEVICE_COMPILE__
-#include "opus/opus.hpp"
+#include "aiter_opus_plus.h"
 #endif
 
 // =====================================================================================================================
@@ -7401,26 +7401,22 @@ struct alignas(sizeof(T) * vec_size) vec_t
             for(int i = 0; i < vec_size; ++i)
                 data[i] = src[i];
         }
-#if defined(__HIP_DEVICE_COMPILE__) && (defined(__HIP__MI300__) || defined(__gfx950__))
-        // Two f32 lanes convert and pack into one fp8 pair per instruction, so an
-        // even-length vector costs half as many converts as the scalar path below.
+#if defined(__HIP_DEVICE_COMPILE__) && (defined(__gfx942__) || defined(__gfx950__))
         else if constexpr((std::is_same_v<T, fp8e4m3fnuz> || std::is_same_v<T, fp8e4m3fn>) &&
                           (vec_size % 2 == 0))
         {
-            constexpr float FP8_MAX = std::is_same_v<T, fp8e4m3fnuz> ? 240.0f : 448.0f;
-            const float rcp_scale   = 1.0f / scale;
+            const float inverted_scale = 1.0f / scale;
 #pragma unroll
             for(int i = 0; i < vec_size; i += 2)
             {
-                // fmed3(x, hi, lo) is the median of three, i.e. a clamp to [lo, hi];
-                // the packed convert saturates differently, so clamp first.
-                float v0 = __builtin_amdgcn_fmed3f(
-                    static_cast<float>(src[i]) * rcp_scale, FP8_MAX, -FP8_MAX);
-                float v1 = __builtin_amdgcn_fmed3f(
-                    static_cast<float>(src[i + 1]) * rcp_scale, FP8_MAX, -FP8_MAX);
-                uint32_t packed = __builtin_amdgcn_cvt_pk_fp8_f32(v0, v1, 0u, false);
-                data[i]         = T(static_cast<uint8_t>(packed & 0xFF), T::from_bits());
-                data[i + 1]     = T(static_cast<uint8_t>((packed >> 8) & 0xFF), T::from_bits());
+                const opus::fp32x2_t values{static_cast<float>(src[i]),
+                                            static_cast<float>(src[i + 1])};
+                const auto converted =
+                    aiter::scaled_cast<opus::fp8_t>(values, inverted_scale);
+                const uint16_t packed = __builtin_bit_cast(uint16_t, converted);
+                data[i] = T(static_cast<uint8_t>(packed), T::from_bits());
+                data[i + 1] =
+                    T(static_cast<uint8_t>(packed >> 8), T::from_bits());
             }
         }
 #endif

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -7325,6 +7325,9 @@ __inline__ __device__ T warp_shfl_sync(T val, int src_id)
 
 } // namespace block_utils
 
+struct fp8e4m3fn;
+struct fp8e4m3fnuz;
+
 template <typename T, int vec_size>
 struct alignas(sizeof(T) * vec_size) vec_t
 {
@@ -7392,17 +7395,43 @@ struct alignas(sizeof(T) * vec_size) vec_t
     template <typename IT>
     __device__ __forceinline__ void from_(const vec_t<IT, vec_size>& src, float scale)
     {
-#pragma unroll
-        for(int i = 0; i < vec_size; ++i)
+        if constexpr(std::is_same_v<T, IT>)
         {
-            if constexpr(std::is_same_v<T, IT>)
-            {
+#pragma unroll
+            for(int i = 0; i < vec_size; ++i)
                 data[i] = src[i];
-            }
-            else
+        }
+#if defined(__HIP_DEVICE_COMPILE__) && (defined(__HIP__MI300__) || defined(__gfx950__))
+        // Two f32 lanes convert and pack into one fp8 pair per instruction, so an
+        // even-length vector costs half as many converts as the scalar path below.
+        else if constexpr((std::is_same_v<T, fp8e4m3fnuz> || std::is_same_v<T, fp8e4m3fn>) &&
+                          (vec_size % 2 == 0))
+        {
+            constexpr float FP8_MAX = std::is_same_v<T, fp8e4m3fnuz> ? 240.0f : 448.0f;
+            const float rcp_scale   = 1.0f / scale;
+#pragma unroll
+            for(int i = 0; i < vec_size; i += 2)
             {
-                data[i] = static_cast<T>(static_cast<float>(src[i]) / scale);
+                // fmed3(x, hi, lo) is the median of three, i.e. a clamp to [lo, hi];
+                // the packed convert saturates differently, so clamp first.
+                float v0 = __builtin_amdgcn_fmed3f(
+                    static_cast<float>(src[i]) * rcp_scale, FP8_MAX, -FP8_MAX);
+                float v1 = __builtin_amdgcn_fmed3f(
+                    static_cast<float>(src[i + 1]) * rcp_scale, FP8_MAX, -FP8_MAX);
+                uint32_t packed = __builtin_amdgcn_cvt_pk_fp8_f32(v0, v1, 0u, false);
+                data[i]         = T(static_cast<uint8_t>(packed & 0xFF), T::from_bits());
+                data[i + 1]     = T(static_cast<uint8_t>((packed >> 8) & 0xFF), T::from_bits());
             }
+        }
+#endif
+        else
+        {
+            // Reciprocal once rather than a divide per element: scale is uniform
+            // across the vector, and v_rcp_f32 + multiply beats N full divides.
+            const float rcp_scale = 1.0f / scale;
+#pragma unroll
+            for(int i = 0; i < vec_size; ++i)
+                data[i] = static_cast<T>(static_cast<float>(src[i]) * rcp_scale);
         }
     }
 };
@@ -7709,6 +7738,20 @@ struct alignas(1) fp8e4m3fnuz
     }
 };
 
+// Power-of-2 integer division/modulo via shift/mask. block_size and x are kernel
+// parameters, hence warp-uniform, so __builtin_ctz lowers to a single s_ff1_i32_b32
+// and the per-lane operation becomes a shift instead of the ~30-cycle integer
+// division emulation. The power-of-2 precondition is enforced host-side in
+// fused_mrope_rms_set_kv / fused_mrope_rms_set_kv_pts.
+__device__ __forceinline__ int po2_div(int64_t val, int po2)
+{
+    return static_cast<int>(val >> __builtin_ctz(po2));
+}
+__device__ __forceinline__ int po2_mod(int64_t val, int po2)
+{
+    return static_cast<int>(val & (po2 - 1));
+}
+
 template <int HEAD_SIZE>
 __device__ __forceinline__ int64_t get_shuffle_layout_k_base(const int64_t slot_id,
                                                              const int block_size,
@@ -7719,18 +7762,18 @@ __device__ __forceinline__ int64_t get_shuffle_layout_k_base(const int64_t slot_
                                                              const int64_t k_block_stride)
 {
     // Shuffle layout: [num_blocks, num_kv_heads, head_size // x, block_size, x]
-    const int block_id      = static_cast<int>(slot_id / block_size);
-    const int block_offset  = static_cast<int>(slot_id % block_size);
+    const int block_id      = po2_div(slot_id, block_size);
+    const int block_offset  = po2_mod(slot_id, block_size);
     const int k_head_stride = HEAD_SIZE * block_size;
     const int64_t k_per_block =
         (k_block_stride != 0) ? k_block_stride : static_cast<int64_t>(num_heads_k) * k_head_stride;
     const int64_t dst_base = static_cast<int64_t>(block_id) * k_per_block + head_id_k * k_head_stride;
     // Pre-compute K base offset: since VEC_SIZE <= x, all elements are in the same
     // chunk
-    const int chunk_id     = access_id_in_head / x;
+    const int chunk_id     = po2_div(access_id_in_head, x);
     const int block_size_x = block_size * x;
     const int64_t k_base =
-        dst_base + chunk_id * block_size_x + block_offset * x + (access_id_in_head % x);
+        dst_base + chunk_id * block_size_x + block_offset * x + po2_mod(access_id_in_head, x);
     return k_base;
 }
 
@@ -7744,15 +7787,15 @@ __device__ __forceinline__ int64_t get_shuffle_layout_v_base(const int64_t slot_
                                                              const int64_t v_block_stride)
 {
     // Shuffle layout: [num_blocks, num_kv_heads, block_size // x, head_size, x]
-    const int block_id      = static_cast<int>(slot_id / block_size);
-    const int block_offset  = static_cast<int>(slot_id % block_size);
-    const int v_head_stride = (block_size / x) * HEAD_SIZE * x;
+    const int block_id      = po2_div(slot_id, block_size);
+    const int block_offset  = po2_mod(slot_id, block_size);
+    const int v_head_stride = po2_div(block_size, x) * HEAD_SIZE * x;
     const int64_t v_per_block =
         (v_block_stride != 0) ? v_block_stride : static_cast<int64_t>(num_heads_v) * v_head_stride;
     const int64_t dst_base = static_cast<int64_t>(block_id) * v_per_block + head_id_v * v_head_stride;
     // Pre-compute V base offset (fixed for this token)
-    const int v_slot_chunk    = block_offset / x;
-    const int v_slot_in_chunk = block_offset % x;
+    const int v_slot_chunk    = po2_div(block_offset, x);
+    const int v_slot_in_chunk = po2_mod(block_offset, x);
     const int64_t v_base      = dst_base + v_slot_chunk * HEAD_SIZE * x + v_slot_in_chunk;
     return v_base;
 }
@@ -8029,8 +8072,8 @@ __global__ void fused_mrope_rms_kv_kernel(const T* qkv,
                 }
                 else
                 {
-                    const int block_id         = static_cast<int>(slot_id / block_size);
-                    const int block_offset     = static_cast<int>(slot_id % block_size);
+                    const int block_id         = po2_div(slot_id, block_size);
+                    const int block_offset     = po2_mod(slot_id, block_size);
                     const int64_t block_stride = (k_block_stride != 0)
                                                      ? k_block_stride
                                                      : static_cast<int64_t>(block_size) * slot_size;
@@ -8084,8 +8127,8 @@ __global__ void fused_mrope_rms_kv_kernel(const T* qkv,
             }
             else
             {
-                const int block_id         = static_cast<int>(slot_id / block_size);
-                const int block_offset     = static_cast<int>(slot_id % block_size);
+                const int block_id         = po2_div(slot_id, block_size);
+                const int block_offset     = po2_mod(slot_id, block_size);
                 const int64_t block_stride = (v_block_stride != 0)
                                                  ? v_block_stride
                                                  : static_cast<int64_t>(block_size) * slot_size;
@@ -8145,6 +8188,13 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             int64_t v_head_stride    = 0)
 {
     AITER_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
+    // po2_div/po2_mod in the paged and shuffle-layout address math assume these are
+    // powers of two. Every vLLM block_size and every x = 16 / sizeof(elem) satisfies
+    // it, but check rather than corrupt the cache silently if that ever changes.
+    AITER_CHECK(block_size == 0 || (block_size & (block_size - 1)) == 0,
+                "block_size must be a power of 2, got ", block_size);
+    AITER_CHECK(!use_shuffle_layout || (x > 0 && (x & (x - 1)) == 0),
+                "x must be a power of 2 when use_shuffle_layout is set, got ", x);
     auto dim           = std::accumulate(mrope_section.begin(), mrope_section.end(), 0);
     auto expected_half = rotary_dim > 0 ? rotary_dim / 2 : head_size / 2;
     AITER_CHECK(dim == expected_half,
@@ -8293,6 +8343,13 @@ void fused_rope_rms_set_kv(const T* qkv,
                            int64_t v_head_stride    = 0)
 {
     AITER_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
+    // po2_div/po2_mod in the paged and shuffle-layout address math assume these are
+    // powers of two. Every vLLM block_size and every x = 16 / sizeof(elem) satisfies
+    // it, but check rather than corrupt the cache silently if that ever changes.
+    AITER_CHECK(block_size == 0 || (block_size & (block_size - 1)) == 0,
+                "block_size must be a power of 2, got ", block_size);
+    AITER_CHECK(!use_shuffle_layout || (x > 0 && (x & (x - 1)) == 0),
+                "x must be a power of 2 when use_shuffle_layout is set, got ", x);
     constexpr int THREAD_BLOCK_SIZE = 256;
     auto total_warps                = num_tokens * (num_heads_q + num_heads_k + num_heads_v);
     auto num_warps_per_block        = THREAD_BLOCK_SIZE / WARP_SIZE;

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -8136,6 +8136,8 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             int64_t block_size       = 0,
                             int64_t x                = 0,
                             int64_t rotary_dim       = 0,
+                            int64_t k_block_stride   = 0,
+                            int64_t v_block_stride   = 0,
                             bool gemma_norm          = false)
 {
     AITER_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
@@ -8183,8 +8185,8 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         block_size,                  \
                                                         x,                           \
                                                         (int)rotary_dim,             \
-                                                        (int64_t)0,                  \
-                                                        (int64_t)0,                  \
+                                                        k_block_stride,              \
+                                                        v_block_stride,              \
                                                         gemma_norm);                 \
     }                                                                                \
     else                                                                             \
@@ -8216,8 +8218,8 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         block_size,                  \
                                                         x,                           \
                                                         (int)rotary_dim,             \
-                                                        (int64_t)0,                  \
-                                                        (int64_t)0,                  \
+                                                        k_block_stride,              \
+                                                        v_block_stride,              \
                                                         gemma_norm);                 \
     }
 

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -8138,7 +8138,11 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             int64_t rotary_dim       = 0,
                             int64_t k_block_stride   = 0,
                             int64_t v_block_stride   = 0,
-                            bool gemma_norm          = false)
+                            bool gemma_norm          = false,
+                            int64_t k_token_stride   = 0,
+                            int64_t k_head_stride    = 0,
+                            int64_t v_token_stride   = 0,
+                            int64_t v_head_stride    = 0)
 {
     AITER_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
     auto dim           = std::accumulate(mrope_section.begin(), mrope_section.end(), 0);
@@ -8187,7 +8191,11 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         (int)rotary_dim,             \
                                                         k_block_stride,              \
                                                         v_block_stride,              \
-                                                        gemma_norm);                 \
+                                                        gemma_norm,                  \
+                                                        k_token_stride,              \
+                                                        k_head_stride,               \
+                                                        v_token_stride,              \
+                                                        v_head_stride);              \
     }                                                                                \
     else                                                                             \
     {                                                                                \
@@ -8220,7 +8228,11 @@ void fused_mrope_rms_set_kv(const T* qkv,
                                                         (int)rotary_dim,             \
                                                         k_block_stride,              \
                                                         v_block_stride,              \
-                                                        gemma_norm);                 \
+                                                        gemma_norm,                  \
+                                                        k_token_stride,              \
+                                                        k_head_stride,               \
+                                                        v_token_stride,              \
+                                                        v_head_stride);              \
     }
 
     if(is_interleaved)

--- a/op_tests/test_fused_qk_norm_mrope_cache_quant.py
+++ b/op_tests/test_fused_qk_norm_mrope_cache_quant.py
@@ -343,6 +343,7 @@ def run_fused_mrope_3d_rms_set_kv_shuffle(
     v_out: Tensor = None,  # Optional output buffer for v
     return_kv: bool = False,  # Whether to return k_out and v_out
     use_shuffle_layout: bool = False,  # Whether to use shuffle layout
+    use_strided_layout: bool = False,  # Whether to use vLLM's unified layout
     page_size: int = 0,  # Page size (block_size) for shuffle layout
     rotary_dim: int = 0,  # Partial rotary dim (0 = full rotary = head_size)
     gemma_norm: bool = False,
@@ -350,7 +351,7 @@ def run_fused_mrope_3d_rms_set_kv_shuffle(
     # qkv = qkv.clone()  # inplace op
     # Calculate x for shuffle layout: x = 16 // k_cache.element_size()
     x = 0
-    block_size = page_size
+    block_size = page_size if use_shuffle_layout or use_strided_layout else 0
     if use_shuffle_layout:
         x = 16 // k_cache.element_size()
 
@@ -431,6 +432,7 @@ def test_mrope_3d_rms_set_kv_shuffle(
     kv_cache_dtype=None,  # Optional: specify KV cache dtype (e.g., torch.float8_e4m3fn)
     test_return_kv=False,  # Whether to test k_out and v_out return
     use_shuffle_layout=False,  # Whether to test shuffle layout
+    use_strided_layout=False,  # Whether to test vLLM's unified layout
     page_size=0,  # Page size (block_size) for shuffle layout
     max_positions=10000,
     rotary_dim=0,  # Partial rotary dim (0 = full rotary = head_size)
@@ -490,6 +492,28 @@ def test_mrope_3d_rms_set_kv_shuffle(
         v_cache_ref_flat = v_cache_ref.view(
             num_blocks * page_size, num_heads_v, head_size
         )
+    elif use_strided_layout:
+        assert num_heads_k == num_heads_v
+        num_blocks = (max_positions + page_size - 1) // page_size
+        num_slots = num_blocks * page_size
+        k_cache_ref = torch.rand(num_slots, num_heads_k, head_size, device="cuda").to(
+            kv_cache_dtype
+        )
+        v_cache_ref = torch.rand(num_slots, num_heads_v, head_size, device="cuda").to(
+            kv_cache_dtype
+        )
+        kv_cache = torch.rand(
+            num_blocks,
+            num_heads_k,
+            page_size,
+            2 * head_size,
+            device="cuda",
+        ).to(kv_cache_dtype)
+        k_cache, v_cache = kv_cache.transpose(1, 2).split(head_size, dim=-1)
+        assert not k_cache.is_contiguous()
+        assert not v_cache.is_contiguous()
+        k_cache_ref_flat = k_cache_ref
+        v_cache_ref_flat = v_cache_ref
     else:
         k_cache_ref = torch.rand(
             max_positions, num_heads_k, head_size, device="cuda"
@@ -582,10 +606,59 @@ def test_mrope_3d_rms_set_kv_shuffle(
         v_out,
         test_return_kv,
         use_shuffle_layout,
+        use_strided_layout,
         page_size,
         rotary_dim,
         gemma_norm,
     )
+
+    if use_strided_layout:
+        q_out_contiguous = torch.empty_like(q_out)
+        k_cache_contiguous = torch.empty_like(k_cache_ref)
+        v_cache_contiguous = torch.empty_like(v_cache_ref)
+        run_fused_mrope_3d_rms_set_kv_shuffle(
+            qkv,
+            qw,
+            kw,
+            cos_sin,
+            positions,
+            num_tokens,
+            num_heads_q,
+            num_heads_k,
+            num_heads_v,
+            head_size,
+            is_neox_style,
+            mrope_section,
+            is_interleaved,
+            eps,
+            q_out_contiguous,
+            k_cache_contiguous,
+            v_cache_contiguous,
+            kv_loc,
+            k_scale,
+            v_scale,
+            is_mrope,
+            None,
+            None,
+            False,
+            False,
+            False,
+            0,
+            rotary_dim,
+            gemma_norm,
+        )
+        torch.testing.assert_close(
+            k_cache.reshape(-1, num_heads_k, head_size)[kv_loc].float(),
+            k_cache_contiguous[kv_loc].float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            v_cache.reshape(-1, num_heads_v, head_size)[kv_loc].float(),
+            v_cache_contiguous[kv_loc].float(),
+            rtol=0,
+            atol=0,
+        )
 
     info = f"dtype:{dtype}, kv_cache_dtype:{kv_cache_dtype}, num_tokens:{num_tokens}, num_heads_q:{num_heads_q}, num_heads_k:{num_heads_k}, num_heads_v:{num_heads_v}, head_size:{head_size}, is_neox_style:{is_neox_style}"
     if is_mrope:
@@ -594,6 +667,8 @@ def test_mrope_3d_rms_set_kv_shuffle(
         info += f", return_kv:{test_return_kv}"
     if use_shuffle_layout:
         info += f", use_shuffle_layout:{use_shuffle_layout}, page_size:{page_size}"
+    if use_strided_layout:
+        info += f", use_strided_layout:{use_strided_layout}, page_size:{page_size}"
     if rotary_dim > 0:
         info += f", rotary_dim:{rotary_dim}"
     msg = f"[perf] === {info} === torch avg: {avg_torch:<8.2f} us, cu avg: {avg_cu:<8.2f} us, uplift: {avg_torch/avg_cu-1:<5.1%}"
@@ -605,6 +680,23 @@ def test_mrope_3d_rms_set_kv_shuffle(
         # Reshape shuffle cache back to flat format for comparison
         k_cache_flat = k_cache.view(-1, num_heads_k, head_size)
         v_cache_flat = v_cache.view(-1, num_heads_v, head_size)
+        checkAllclose(
+            k_cache_ref_flat[kv_loc].float(),
+            k_cache_flat[kv_loc].float(),
+            msg="k_cache",
+            rtol=1e-2,
+            atol=0.05,
+        )
+        checkAllclose(
+            v_cache_ref_flat[kv_loc].float(),
+            v_cache_flat[kv_loc].float(),
+            msg="v_cache",
+            rtol=1e-2,
+            atol=0.05,
+        )
+    elif use_strided_layout:
+        k_cache_flat = k_cache.reshape(-1, num_heads_k, head_size)
+        v_cache_flat = v_cache.reshape(-1, num_heads_v, head_size)
         checkAllclose(
             k_cache_ref_flat[kv_loc].float(),
             k_cache_flat[kv_loc].float(),
@@ -747,6 +839,26 @@ if __name__ == "__main__":
     page_sizes = [16]  # Test two page sizes for shuffle layout
     partial_rotary_configs = [(256, 64), (128, 32)]
     partial_rotary_heads = [(32, 4), (8, 2)]
+
+    print("\n=== vLLM unified-attention strided KV layout ===", flush=True)
+    for kv_cache_dtype in args.kv_cache_dtypes:
+        test_mrope_3d_rms_set_kv_shuffle(
+            args.dtype,
+            min(127, args.max_positions),
+            32,
+            1,
+            1,
+            128,
+            True,
+            mrope_sections_dict[128],
+            True,
+            eps=1e-6,
+            is_mrope=True,
+            kv_cache_dtype=kv_cache_dtype,
+            use_strided_layout=True,
+            page_size=16,
+            max_positions=args.max_positions,
+        )
 
     for kv_cache_dtype in args.kv_cache_dtypes:
         for test_return_kv in test_return_kv_flags:


### PR DESCRIPTION
## Motivation

Allow `fused_qk_norm_mrope_3d_cache_pts_quant_shuffle` to write correctly into non-contiguous paged KV-cache views used by vLLM unified attention.

The current vLLM view is produced by:

```python
kv_cache.transpose(1, 2).split(head_size, dim=-1)
```

It has logical shape `[num_blocks, block_size, num_heads, head_size]` and strides `(H*N*2hs, 2hs, N*2hs, 1)`. Forwarding only `stride(0)` is not sufficient: token and head strides also differ from contiguous layout and incorrect addressing can silently corrupt the cache.

## Changes

This PR contains four focused commits:

1. Accept a flash-layout view and forward the K/V block strides.
2. Forward all six K/V block, token, and head strides required by the unified-attention transpose/split view.
3. Optimize the same kernel with AITER's shared packed FP8 conversion path and power-of-two address arithmetic; launch-time checks enforce the address-math preconditions.
4. Add an operator regression covering the exact vLLM view and compare its cache writes bit-for-bit with the contiguous path.

The innermost head-size dimension must remain dense. Contiguous callers retain the existing zero-stride fallback behavior.

## Dependency and integration

- [vLLM #50212](https://github.com/vllm-project/vllm/pull/50212): **hard-depends on this PR** for its fused Qwen3-VL attention prologue.
- **This PR — [AITER #4531](https://github.com/ROCm/aiter/pull/4531):** full strided MRoPE KV-cache correctness.
- [AITER #4554](https://github.com/ROCm/aiter/pull/4554): gfx950 Qwen3-VL MXFP4 tuning rows; not required for the public FP8 reproduction below.
- [AITER #4556](https://github.com/ROCm/aiter/pull/4556): optional MXFP4 FlyDSL stage-2 override; not exercised by the FP8 checkpoint below.
- [AITER #4761](https://github.com/ROCm/aiter/pull/4761): independent Triton unified-attention prefill/decode optimization; not required by this stride fix.

## Rebase provenance

- Frozen AITER `main`: `fc2e5d57fb5b8ad8e7e23f7103071dde798ea618`
- Current PR head: `7c9e637ee070c2daf573a12dd66cc518fe7cc91c`

## Validation

- Targeted gfx950 MRoPE/FP8 operator tests using AITER's shared `scaled_cast` conversion, the vLLM transpose/split cache view, and returned K/V buffers — **passed**.
- The test performs a strict bit-for-bit comparison of strided and contiguous cache writes for the same inputs.
- BF16 query output and FP8 value-cache reference checks passed; the existing reference harness's normal FP8 key quantization tolerance is unchanged from the contiguous case.
- Black and Ruff checks on the operator test — **passed**.
- Python compile and `git diff --check` — **passed**.
- GitHub reports the branch mergeable.

## Public FP8 downstream reproduction

This PR and vLLM #50212 were reproduced without MXFP4 weights using the public checkpoint [`Qwen/Qwen3-VL-30B-A3B-Instruct-FP8`](https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct-FP8), revision `d9748a51ae66354c4dad665aab2c71f26cf2c8cd`.

Test configuration: MI355X (`gfx950`), vLLM 0.26.0 plus the two PR heads above, TP1, `ROCM_AITER_UNIFIED_ATTN`, FP8 model weights, FP8 E4M3 KV cache, one 512×512 image per request, random input/output lengths 256/128, max concurrency 4, 16 requests and 4 warmups per repeat.

- The PR's operator regression passed with the exact unified-attention strided view and FP8 cache, including strict bit-for-bit strided-vs-contiguous cache writes.
- vLLM #50212's focused safety/layout suite passed: **3/3 tests**.
- The end-to-end server resolved `Qwen3VLMoeForConditionalGeneration` with `quantization=fp8`; the fused attention-prologue log was observed only in the enabled arm.
- All 96 measured requests succeeded. Paired runs used the same seeds and generated-token counts and differed only by `VLLM_Q3VL_FUSE_ATTN_PROLOGUE={0,1}`.

Warm median of three paired repeats:

| metric | fusion on | fusion off | delta |
|---|---:|---:|---:|
| output throughput | 568.36 tok/s | 500.20 tok/s | **+13.6%** |
| mean TPOT | 5.97 ms | 6.93 ms | **-13.8%** |
| mean end-to-end latency | 798.65 ms | 920.30 ms | **-13.2%** |

All three paired throughput results improved: +10.0%, +13.6%, and +18.4%. This is downstream validation of the safe fused stack, not an isolated performance claim for the stride fix. It demonstrates that MXFP4 weights are not required to validate this PR or its vLLM integration.

## Submission checklist

- [x] Reviewed the ROCm contribution guidelines.
- [x] Added coverage for the actual downstream layout.
- [x] Preserved contiguous behavior.
- [x] Documented both correctness and included optimizations.
- [x] Reproduced downstream integration with a public FP8 checkpoint.

> This PR was developed with AI assistance. The human author reviewed the changes, ran the listed validation, and owns the final implementation. Commit metadata contains only human attribution and DCO trailers.