### PR TITLE
Optimize A8W4 stage2 route reduction

### DIFF
--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage.py
@@ -116,6 +116,7 @@ def compile_mixed_moe_gemm2(
     cu_num_mul: int = 1,
     b_nt: int = 0,
     xcd_swizzle: int = 0,
+    route_fp8: bool = False,
 ):
     """Compile an ordinary stage2 MoE kernel."""
     return compile_mixed_moe_gemm2_common(
@@ -142,4 +143,5 @@ def compile_mixed_moe_gemm2(
         cu_num_mul=cu_num_mul,
         b_nt=b_nt,
         xcd_swizzle=xcd_swizzle,
+        route_fp8=route_fp8,
     )

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
@@ -3405,8 +3405,14 @@ def compile_mixed_moe_gemm2_common(
     b_nt: int = 0,
     xcd_swizzle: int = 0,
     shared_expert_id: int | None = None,
+    route_fp8: bool = False,
 ):
-    """Compile stage2 kernel (moe_gemm2): A2 @ W2.T -> [tokens, model_dim], atomic-add."""
+    """Compile the stage2 down-projection kernel.
+
+    ``route_fp8`` stores each token-slot row as FP8 payload plus one E8M0 scale
+    per 8 columns. This reduces the non-atomic route buffer from 2 bytes to
+    1.125 bytes per value before the top-k reduction.
+    """
     heterogeneous_b = shared_expert_id is not None
     if heterogeneous_b and shared_expert_id != experts - 1:
         raise ValueError(
@@ -3494,6 +3500,14 @@ def compile_mixed_moe_gemm2_common(
         )
     out_is_f32 = out_s in ("f32", "fp32", "float")
     out_is_bf16 = out_s in ("bf16", "bfloat16")
+    if const_expr(route_fp8 and (bool(accumulate) or not out_is_bf16)):
+        raise ValueError("route_fp8 requires accumulate=False and out_dtype='bf16'")
+    if const_expr(
+        route_fp8 and (model_dim % 8 != 0 or tile_n < 128 or tile_n % 128 != 0)
+    ):
+        raise ValueError(
+            "route_fp8 requires model_dim % 8 == 0 and tile_n divisible by 128"
+        )
     if const_expr((not bool(accumulate)) and out_is_f32):
         raise ValueError(
             "compile_moe_gemm2(accumulate=False) only supports out_dtype in {'f16','bf16'}"
@@ -3566,6 +3580,7 @@ def compile_mixed_moe_gemm2_common(
     async_tag = "_async" if use_async_copy else ""
     cumul_tag = f"_cumul{int(cu_num_mul)}" if int(cu_num_mul) != 1 else ""
     acc_tag = "" if accumulate else "_acc0"
+    route_fp8_tag = "_routefp8" if route_fp8 else ""
     xcd_tag = f"_xcd{xcd_swizzle}" if xcd_swizzle > 0 else ""
     heterogeneous_tag = f"_shared_fp8_e{shared_expert_id}" if heterogeneous_b else ""
     serial_n_tag = "_serialn128" if serial_shared_n else ""
@@ -3577,14 +3592,17 @@ def compile_mixed_moe_gemm2_common(
     else:
         variant_tags = (
             f"_vscale_fix3_fp4opt_v1{pm_tag}{sbm_tag}{wpe_tag}{async_tag}"
-            f"{cumul_tag}{xcd_tag}{acc_tag}"
+            f"{cumul_tag}{xcd_tag}{acc_tag}{route_fp8_tag}"
         )
     module_name = (
         f"mfma_moe2_a{a_dtype}_w{b_dtype}_{out_s}_{epilog_tag}"
         f"_t{tile_m}x{tile_n}x{tile_k}{variant_tags}"
     ).replace("-", "_")
     lds_x_bytes = 2 * int(tile_m) * int(lds_stride) * int(a_elem_bytes)
-    lds_out_bytes = 2 * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
+    lds_out_elem_bytes = 2
+    lds_out_bytes = (
+        lds_out_elem_bytes * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
+    )
     lds_tid_bytes = int(tile_m) * 4
     lds_tw_bytes = (int(tile_m) * 4) if bool(doweight_stage2) else 0
     lds_total_bytes = max(lds_x_bytes, lds_out_bytes) + lds_tid_bytes + lds_tw_bytes
@@ -3737,7 +3755,11 @@ def compile_mixed_moe_gemm2_common(
             )
 
             lds_x_b = 2 * int(tile_m) * int(lds_stride) * int(a_elem_bytes)
-            lds_out_b = 2 * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
+            lds_out_b = (
+                lds_out_elem_bytes * int(tile_m) * int(tile_n)
+                if _use_cshuffle_epilog
+                else 0
+            )
             lds_tid_off = max(lds_x_b, lds_out_b)
             lds_tid = SmemPtr(
                 base_ptr, lds_x_ptr.byte_offset + lds_tid_off, T.i32, shape=(tile_m,)
@@ -3769,16 +3791,24 @@ def compile_mixed_moe_gemm2_common(
             shared_w_rsrc = ptr_buffer_resource(arg_shared_w, shared_w_nbytes)
 
             out_elem_bytes = 4 if out_is_f32 else 2
+            route_row_bytes = model_dim + model_dim // 8
             out_nbytes_idx = (
                 tokens_in * n_in * arith.constant(out_elem_bytes, index=True)
             )
             if const_expr(not bool(accumulate)):
-                out_nbytes_idx = (
-                    tokens_in
-                    * arith.index(topk)
-                    * n_in
-                    * arith.constant(out_elem_bytes, index=True)
-                )
+                if const_expr(route_fp8):
+                    out_nbytes_idx = (
+                        tokens_in
+                        * arith.index(topk)
+                        * arith.constant(route_row_bytes, index=True)
+                    )
+                else:
+                    out_nbytes_idx = (
+                        tokens_in
+                        * arith.index(topk)
+                        * n_in
+                        * arith.constant(out_elem_bytes, index=True)
+                    )
             out_nbytes_i32 = arith.index_cast(T.i32, out_nbytes_idx)
             out_rsrc = ptr_buffer_resource(arg_out, out_nbytes_i32)
 
@@ -5074,6 +5104,12 @@ def compile_mixed_moe_gemm2_common(
                 topk_i32_v = topk_i32
 
                 zero_i32 = arith.constant(0)
+                c0_f32 = arith.constant(0.0, type=T.f32)
+                c8_i32 = arith.constant(8, type=T.i32)
+                c23_i32 = arith.constant(23, type=T.i32)
+                c254_i32 = arith.constant(254, type=T.i32)
+                c0x400000_i32 = arith.constant(0x400000, type=T.i32)
+                c0xFF800000_i32 = arith.constant(0xFF800000, type=T.i32)
 
                 def atomic_add_f16x2(val_f16x2, byte_off_i32):
                     rocdl.raw_ptr_buffer_atomic_fadd(
@@ -5129,7 +5165,12 @@ def compile_mixed_moe_gemm2_common(
                         vec1_out = T.vec(1, out_elem())
                         v1 = vector.from_elements(vec1_out, [v_out])
 
-                        vector.store(v1, lds_out, [lds_idx], alignment=2)
+                        vector.store(
+                            v1,
+                            lds_out,
+                            [lds_idx],
+                            alignment=2,
+                        )
 
                 row_stride_bytes_py = int(model_dim) * int(out_elem_bytes)
                 use_buf_atomic = bool(accumulate) and (row_stride_bytes_py <= 16384)
@@ -5162,8 +5203,11 @@ def compile_mixed_moe_gemm2_common(
                             model_dim * out_elem_bytes, index=True
                         )
                     else:
+                        row_stride = (
+                            route_row_bytes if route_fp8 else model_dim * out_elem_bytes
+                        )
                         row_byte_base = out_base_idx + ts_idx * arith.constant(
-                            model_dim * out_elem_bytes, index=True
+                            row_stride, index=True
                         )
                     row_byte_off_i32 = None
                     return ((fused2, row_byte_base, row_byte_off_i32), row_valid)
@@ -5178,7 +5222,94 @@ def compile_mixed_moe_gemm2_common(
 
                 def store_pair(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
                     _fused, row_byte_base, row_byte_off_i32 = row_ctx
-                    if const_expr(not bool(accumulate)):
+                    if const_expr(route_fp8):
+                        frag_vals = []
+                        for i in range_constexpr(8):
+                            frag_bf16 = vector.extract(
+                                frag, static_position=[i], dynamic_position=[]
+                            )
+                            frag_vals.append(arith.extf(T.f32, frag_bf16))
+
+                        local_max = c0_f32
+                        for i in range_constexpr(8):
+                            abs_v = llvm.call_intrinsic(
+                                T.f32, "llvm.fabs.f32", [frag_vals[i]], [], []
+                            )
+                            local_max = arith.maximumf(local_max, abs_v)
+
+                        max_i32 = local_max.bitcast(T.i32)
+                        max_rounded = (max_i32 + c0x400000_i32) & c0xFF800000_i32
+                        exp_field = max_rounded >> c23_i32
+                        e8m0_biased = arith.maxsi(exp_field - c8_i32, zero_i32)
+                        quant_exp = c254_i32 - e8m0_biased
+                        quant_scale = (quant_exp << c23_i32).bitcast(T.f32)
+                        scaled_vals = []
+                        for i in range_constexpr(8):
+                            scaled_vals.append(frag_vals[i] * quant_scale)
+
+                        packed = []
+                        for group in range_constexpr(2):
+                            base = group * 4
+                            word = zero_i32
+                            word = rocdl.cvt_pk_fp8_f32(
+                                T.i32,
+                                scaled_vals[base],
+                                scaled_vals[base + 1],
+                                word,
+                                0,
+                            )
+                            word = rocdl.cvt_pk_fp8_f32(
+                                T.i32,
+                                scaled_vals[base + 2],
+                                scaled_vals[base + 3],
+                                word,
+                                1,
+                            )
+                            packed.append(word)
+
+                        data_ptr = idx_to_llvm_ptr(row_byte_base + col_g0)
+                        packed0_raw = (
+                            packed[0]._value
+                            if hasattr(packed[0], "_value")
+                            else packed[0]
+                        )
+                        llvm.StoreOp(
+                            packed0_raw,
+                            data_ptr,
+                            alignment=4,
+                            nontemporal=True,
+                        )
+                        data_ptr_hi = idx_to_llvm_ptr(
+                            row_byte_base + col_g0 + arith.constant(4, index=True)
+                        )
+                        packed1_raw = (
+                            packed[1]._value
+                            if hasattr(packed[1], "_value")
+                            else packed[1]
+                        )
+                        llvm.StoreOp(
+                            packed1_raw,
+                            data_ptr_hi,
+                            alignment=4,
+                            nontemporal=True,
+                        )
+
+                        scale_ptr = idx_to_llvm_ptr(
+                            row_byte_base
+                            + arith.constant(model_dim, index=True)
+                            + col_g0 // arith.constant(8, index=True)
+                        )
+                        scale_i8 = arith.TruncIOp(T.i8, e8m0_biased)
+                        scale_raw = (
+                            scale_i8._value if hasattr(scale_i8, "_value") else scale_i8
+                        )
+                        llvm.StoreOp(
+                            scale_raw,
+                            scale_ptr,
+                            alignment=1,
+                            nontemporal=True,
+                        )
+                    elif const_expr(not bool(accumulate)):
                         col_idx = col_g0
                         byte_off_col = col_idx * arith.constant(
                             out_elem_bytes, index=True
@@ -5220,7 +5351,9 @@ def compile_mixed_moe_gemm2_common(
                             alignment=e_vec * out_elem_bytes,
                         )
 
-                e_vec = 2 if accumulate else min(body_tile_n // 32, 8)
+                e_vec = (
+                    8 if route_fp8 else (2 if accumulate else min(body_tile_n // 32, 8))
+                )
                 rocdl.s_setprio(3)
                 c_shuffle_epilog(
                     arith=arith,
@@ -5231,6 +5364,7 @@ def compile_mixed_moe_gemm2_common(
                     tile_m=tile_m,
                     tile_n=body_tile_n,
                     e_vec=e_vec,
+                    cshuffle_nlane=(min(32, body_tile_n // 8) if route_fp8 else 32),
                     m_repeat=m_repeat,
                     num_acc_n=body_num_acc_n,
                     tx=tx,

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -116,6 +116,45 @@ def requires_flydsl_stage2_reduce(
     return int(token_num) * int(model_dim) * int(element_size) > 0xFFFFFFFF
 
 
+def _use_flydsl_stage2_route_fp8(
+    *,
+    token_num: int,
+    mode: str,
+    return_per_slot: bool,
+    compile_kernel,
+    expert_mask,
+    a_dtype: str,
+    b_dtype: str,
+    out_dtype: str,
+    model_dim: int,
+    tile_n: int,
+) -> bool:
+    """Whether the generic A8W4 reduce path can use compressed route output."""
+    if os.environ.get("AITER_FLYDSL_STAGE2_ROUTE_FP8", "0") != "1":
+        return False
+    min_tokens = int(os.environ.get("AITER_FLYDSL_STAGE2_ROUTE_FP8_MIN_TOKENS", "4096"))
+    if token_num < min_tokens or mode != "reduce" or return_per_slot:
+        return False
+    return (
+        compile_kernel is compile_flydsl_moe_stage2
+        and expert_mask is None
+        and (a_dtype, b_dtype, out_dtype) == ("fp8", "fp4", "bf16")
+        and model_dim % 8 == 0
+        and tile_n >= 128
+        and tile_n % 128 == 0
+    )
+
+
+def _route_fp8_reduce_block_n(model_dim: int) -> int | None:
+    """Prefer an exact registered reducer tile, otherwise use Opus auto-select."""
+    from aiter.ops.opus.moe_stage2_a8w4_meta import (
+        OPUS_A8W4_ROUTE_REDUCE_INSTANCES,
+    )
+
+    registered = {instance.block_n for instance in OPUS_A8W4_ROUTE_REDUCE_INSTANCES}
+    return model_dim if model_dim in registered else None
+
+
 def resolve_flydsl_stage2_tile_k(inter_dim: int, tile_k: int) -> int:
     """Return a ``tile_k`` that divides ``inter_dim``, preferring the caller value.
 
@@ -603,6 +642,7 @@ def compile_flydsl_moe_stage2(
     inter_dim_pad: int = 0,
     xcd_swizzle: int = 0,
     enable_bias: bool = False,
+    route_fp8: bool = False,
 ):
     """Compile stage2 kernel (cached via underlying lru_cache)."""
     if a_dtype == "bf16" and b_dtype in ("fp4", "mxfp4"):
@@ -660,6 +700,7 @@ def compile_flydsl_moe_stage2(
             model_dim_pad=model_dim_pad,
             inter_dim_pad=inter_dim_pad,
             enable_bias=enable_bias,
+            route_fp8=route_fp8,
         )
     elif a_dtype == "bf16" and b_dtype == "int4":
         # a16wi4: bf16 activations, int4 weights with groupwise scale
@@ -1819,6 +1860,18 @@ def _flydsl_moe_stage2_impl(
         mode = "reduce"
 
     accumulate = mode != "reduce" and not return_per_slot
+    route_fp8 = _use_flydsl_stage2_route_fp8(
+        token_num=token_num,
+        mode=mode,
+        return_per_slot=return_per_slot,
+        compile_kernel=_compile_kernel,
+        expert_mask=expert_mask,
+        a_dtype=a_dtype,
+        b_dtype=b_dtype,
+        out_dtype=out_dtype,
+        model_dim=model_dim,
+        tile_n=tile_n,
+    )
 
     if a_dtype == "fp4":
         inter_dim = inter_dim * 2
@@ -1887,7 +1940,14 @@ def _flydsl_moe_stage2_impl(
 
     target = out
     if not accumulate:
-        if return_per_slot:
+        if route_fp8:
+            alloc_route = torch.zeros if model_dim_pad else torch.empty
+            target = alloc_route(
+                (token_num * topk, model_dim + model_dim // 8),
+                device=out.device,
+                dtype=torch.uint8,
+            )
+        elif return_per_slot:
             target = out.view(-1)
         else:
             target = torch.empty(
@@ -1931,6 +1991,7 @@ def _flydsl_moe_stage2_impl(
             m_blocks,
         )
 
+    route_fp8_compile_kwargs = {"route_fp8": True} if route_fp8 else {}
     exe = _compile_kernel(
         model_dim=model_dim,
         inter_dim=inter_dim,
@@ -1954,6 +2015,7 @@ def _flydsl_moe_stage2_impl(
         inter_dim_pad=inter_dim_pad,
         xcd_swizzle=xcd_swizzle,
         enable_bias=(bias is not None),
+        **route_fp8_compile_kwargs,
     )
     _run_compiled(exe, args)
 
@@ -1963,7 +2025,18 @@ def _flydsl_moe_stage2_impl(
             raise ValueError(
                 "topk_ids is required when expert_mask is provided for reduce mode"
             )
-    if not accumulate and not return_per_slot:
+    if route_fp8:
+        from aiter.ops.opus.moe_stage2_a8w4 import (
+            opus_moe_stage2_reduce_token_slot_route_output_fwd,
+        )
+
+        opus_moe_stage2_reduce_token_slot_route_output_fwd(
+            target,
+            out=out,
+            topk=topk,
+            block_n=_route_fp8_reduce_block_n(model_dim),
+        )
+    elif not accumulate and not return_per_slot:
         _run_moe_reduction(
             target, out, token_num, topk, model_dim, expert_mask, topk_ids
         )

--- a/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
@@ -238,6 +238,60 @@ def test_flydsl_stage2_a8w4_gui(inter_dim, seed):
     _check_close(data["ref_stage2"], out, f"stage2_a8w4_gui_i{inter_dim}")
 
 
+@_SKIP_GFX950_FLYDSL
+@pytest.mark.parametrize(
+    "model_dim,model_dim_pad",
+    [(512, 0), (640, 128), (3584, 0)],
+)
+@pytest.mark.parametrize("tile_n", [128, 256])
+def test_flydsl_stage2_a8w4_route_fp8(monkeypatch, model_dim, model_dim_pad, tile_n):
+    """Route-FP8 output stays close to BF16 reduce across model dimensions."""
+    from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage2
+
+    token, inter_dim, E, topk, block_m = 4, 384, 16, 16, 32
+    data = _generate_a8w4_gui_data(
+        token, model_dim, inter_dim, E, topk, block_m, seed=103
+    )
+    kwargs = dict(
+        inter_states=data["a2_q"],
+        w2=data["w2_shuf"],
+        sorted_token_ids=data["sorted_ids"],
+        sorted_expert_ids=data["sorted_expert_ids"],
+        num_valid_ids=data["num_valid_ids"],
+        topk=topk,
+        tile_m=32,
+        tile_n=tile_n,
+        tile_k=128,
+        a_dtype="fp8",
+        b_dtype="fp4",
+        out_dtype="bf16",
+        mode="reduce",
+        w2_scale=data["w2_scale_shuf"],
+        a2_scale=data["a2_scale_sort"],
+        sorted_weights=data["sorted_weights"],
+        model_dim_pad=model_dim_pad,
+        inter_dim_pad=data["inter_pad"],
+    )
+
+    monkeypatch.delenv("AITER_FLYDSL_STAGE2_ROUTE_FP8", raising=False)
+    baseline = flydsl_moe_stage2(**kwargs)
+    monkeypatch.setenv("AITER_FLYDSL_STAGE2_ROUTE_FP8", "1")
+    monkeypatch.setenv("AITER_FLYDSL_STAGE2_ROUTE_FP8_MIN_TOKENS", "0")
+    route_fp8 = flydsl_moe_stage2(**kwargs)
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(route_fp8).all()
+    valid_dim = model_dim - model_dim_pad
+    baseline_f = baseline[:, :valid_dim].float()
+    route_f = route_fp8[:, :valid_dim].float()
+    cosine_diff = 1.0 - 2.0 * (baseline_f * route_f).sum() / (
+        baseline_f.square().sum() + route_f.square().sum()
+    )
+    assert cosine_diff.item() < 1e-3
+    if model_dim_pad:
+        assert torch.count_nonzero(route_fp8[:, valid_dim:]) == 0
+
+
 @pytest.mark.parametrize("inter_dim", [256, 384, 640])
 @_SKIP_GFX950_FLYDSL
 def test_flydsl_e2e_a8w4_gui(inter_dim):

--- a/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
@@ -252,26 +252,26 @@ def test_flydsl_stage2_a8w4_route_fp8(monkeypatch, model_dim, model_dim_pad, til
     data = _generate_a8w4_gui_data(
         token, model_dim, inter_dim, E, topk, block_m, seed=103
     )
-    kwargs = dict(
-        inter_states=data["a2_q"],
-        w2=data["w2_shuf"],
-        sorted_token_ids=data["sorted_ids"],
-        sorted_expert_ids=data["sorted_expert_ids"],
-        num_valid_ids=data["num_valid_ids"],
-        topk=topk,
-        tile_m=32,
-        tile_n=tile_n,
-        tile_k=128,
-        a_dtype="fp8",
-        b_dtype="fp4",
-        out_dtype="bf16",
-        mode="reduce",
-        w2_scale=data["w2_scale_shuf"],
-        a2_scale=data["a2_scale_sort"],
-        sorted_weights=data["sorted_weights"],
-        model_dim_pad=model_dim_pad,
-        inter_dim_pad=data["inter_pad"],
-    )
+    kwargs = {
+        "inter_states": data["a2_q"],
+        "w2": data["w2_shuf"],
+        "sorted_token_ids": data["sorted_ids"],
+        "sorted_expert_ids": data["sorted_expert_ids"],
+        "num_valid_ids": data["num_valid_ids"],
+        "topk": topk,
+        "tile_m": 32,
+        "tile_n": tile_n,
+        "tile_k": 128,
+        "a_dtype": "fp8",
+        "b_dtype": "fp4",
+        "out_dtype": "bf16",
+        "mode": "reduce",
+        "w2_scale": data["w2_scale_shuf"],
+        "a2_scale": data["a2_scale_sort"],
+        "sorted_weights": data["sorted_weights"],
+        "model_dim_pad": model_dim_pad,
+        "inter_dim_pad": data["inter_pad"],
+    }
 
     monkeypatch.delenv("AITER_FLYDSL_STAGE2_ROUTE_FP8", raising=False)
     baseline = flydsl_moe_stage2(**kwargs)


### PR DESCRIPTION
## Summary

- add an opt-in FP8 route-output format for FlyDSL A8W4 stage2 reduce kernels
- compress weighted per-slot expert outputs before top-k reduction, while preserving the final BF16 MoE output
- reuse the existing Opus route reducer and support registered exact reducer tiles, `tile_n` 128/256, and padded dimensions

## Problem

The non-atomic stage2 path materializes `[token, topk, model_dim]` in BF16 before reducing top-k expert contributions. Large prefill batches are HBM-bound by this buffer. For the Kimi-K3 TP8 shape (`model_dim=3584`, `inter_dim=384`, `topk=16`) at 16,384 tokens, the intermediate buffer is about 1.879 GB.

## Solution

When `AITER_FLYDSL_STAGE2_ROUTE_FP8=1` and the token threshold is met, the CShuffle epilogue stores each weighted token-slot contribution as:

```text
[model_dim FP8 payload | model_dim / 8 E8M0 scale bytes]
```

This lowers storage from 2 bytes to 1.125 bytes per value (43.75% reduction). The Opus reducer dequantizes, accumulates top-k contributions, and writes the same BF16 final output. Unsupported dtypes and layouts continue to use the existing path.

The default threshold is controlled by `AITER_FLYDSL_STAGE2_ROUTE_FP8_MIN_TOKENS` and defaults to 4096.

## Performance

Repeated median measurements on MI355X/gfx950, Kimi-K3 A8W4 TP8 (`M × 3584 × 384`, 896 experts, top-k 16):

| Tokens | BF16 stage2 | FP8 route stage2 | Speedup |
|---:|---:|---:|---:|
| 4,096 | 406.77 us | 377.40 us | 1.078x |
| 8,192 | 666.96 us | 603.49 us | 1.105x |
| 16,384 | 1,186.02 us | 977.33 us | 1.214x |

At 16,384 tokens, the full two-stage MoE improved from 2,304.79 us to 2,090.27 us (1.103x).

## Accuracy

Kimi-K3 A8W4 was run with the required gate/up-interleaved layout:

```bash
AITER_SITUV2_A8W4=1
ATOM_MOE_GU_ITLV=1
AITER_FLYDSL_STAGE2_ROUTE_FP8=1
AITER_FLYDSL_STAGE2_ROUTE_FP8_MIN_TOKENS=4096
```

Full GSM8K validation (1,319 questions, 5-shot, seed 42):

- flexible-extract: **0.9568**
- strict-match: **0.9560**

Both results are within the documented Kimi-K3 validation range.

## Test plan

- [x] `pytest -q op_tests/flydsl_tests/test_flydsl_moe_a8w4.py` (31 passed)
- [x] route-output coverage for model dimensions 512, padded 640, and 3584
- [x] route-output coverage for `tile_n` 128 and 256 and padded K dimensions
- [x] Black formatting and `git diff --check`
- [x] full Kimi-K3 GSM8K accuracy validation

Made with [Cursor](https://cursor.com)