### PR TITLE
[Bugfix][Kernel][Hardware][AMD] Add gfx1201 RDNA4 architecture to allowed_archs in aiter_meta

### DIFF
--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -160,6 +160,7 @@ def validate_and_update_archs():
         "gfx942",
         "gfx950",
         "gfx1151",
+        "gfx1201",
     ]
 
     # Validate if each element in archs is in allowed_archs


### PR DESCRIPTION
## Purpose

Fixes an engine initialization crash (`AssertionError: One of GPU archs of ['gfx1201'] is invalid or not supported`) during sampling setup when running vLLM with AITER enabled on AMD RDNA4 GPUs (`gfx1201`, e.g., Radeon AI PRO R9700).

### Root Cause
When vLLM executes AITER sampling kernels (`top_k_top_p_sampling_from_probs`), `aiter_meta` invokes `validate_and_update_archs()` to validate `GPU_ARCHS` against an `allowed_archs` whitelist.
In `csrc/cpp_itfs/utils.py`, `allowed_archs` listed `gfx90a`, `gfx940-950`, `gfx1151`, but missed `gfx1201`. As a result, running sampling on `gfx1201` threw an unhandled assertion failure and failed vLLM's `EngineCore` startup.

### Fix
- Added `"gfx1201"` architecture to `allowed_archs` in `csrc/cpp_itfs/utils.py`.

---

## Test Plan

1. **Unit Verification:**
   Tested `validate_and_update_archs()` under Python with `GPU_ARCHS="gfx1201"`:
   ```bash
   python -c "import aiter_meta.csrc.cpp_itfs.utils as u; print(u.validate_and_update_archs())"
   ```
   Output: `['gfx1201']`

2. **Integration / E2E Test on AMD GPU (`gfx1201`):**
   Launched `louismuk/gemma-4-26B-A4B-heretic-AWQ` with AITER sampling enabled:
   ```bash
   vllm serve louismuk/gemma-4-26B-A4B-heretic-AWQ --quantization compressed-tensors --port 8888
   ```

---

## Test Result

- **Sampling JIT Compile:** AITER top-k / top-p sampling template compiled cleanly without assertion errors.
- **Engine Initialization:** `EngineCore` initialized and started serving HTTP requests.

---

## AI Assistance Disclosure

This pull request includes code modifications refined with assistance from an AI assistant (Gemini). All changes have been manually reviewed, validated, and verified end-to-end on hardware (`gfx1201`).

Co-authored-by: Gemini
Signed-off-by: Christopher Lange <chris@lowbob.de>