### PR TITLE
[gfx1250] Fix three gluon GEMM correctness bugs and tune the Kimi-K3 a16w16 shapes

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
@@ -389,14 +389,15 @@ def _gemm_a16w16_bandwidth_bound_kernel(
     # past 2 GiB is dropped by the bounds check with nothing raised.  Fold the
     # origin into the base pointer in 64-bit and keep only tile-local offsets,
     # which the block shape bounds, so the fast path holds at every size.
-    c_ptr += (pid_m * BLOCK_M).to(gl.int64) * stride_cm + (
-        pid_n * BLOCK_N
-    ).to(gl.int64) * stride_cn
-    offs_c = stride_cm * gl.arange(
-        0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT)
-    )[:, None] + stride_cn * gl.arange(
-        0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
-    )[None, :]
+    c_ptr += (pid_m * BLOCK_M).to(gl.int64) * stride_cm + (pid_n * BLOCK_N).to(
+        gl.int64
+    ) * stride_cn
+    offs_c = (
+        stride_cm
+        * gl.arange(0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT))[:, None]
+        + stride_cn
+        * gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT))[None, :]
+    )
 
     # Store
     gl.amd.gfx1250.buffer_store(

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
@@ -222,7 +222,15 @@ def _gemm_a16w16_bandwidth_bound_kernel(
             b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
         )
 
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+        # The wait argument counts TDM *tiles* that may stay in flight, not TDM
+        # ops.  A and B are issued from two different descriptors and retire on
+        # two independent in-order streams sharing one counter, so "at most N ops
+        # outstanding" does not imply the oldest pair has landed: with T tiles in
+        # flight, one stream can still hold all T of its own ops while the other
+        # has drained.  Only N <= T-1 forces both streams below their own depth.
+        # Here the load just issued brings T to NUM_BUFFERS, so the wait is
+        # NUM_BUFFERS-1 -- not doubled.
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 1)
 
         # Walk the descriptors forward one K tile.
         if LAYOUT[0] == "T":
@@ -299,7 +307,8 @@ def _gemm_a16w16_bandwidth_bound_kernel(
         b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
     )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    # Tiles, not ops -- see the interior loop for why this count is not doubled.
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 1)
 
     load_idx += 1
 
@@ -327,9 +336,10 @@ def _gemm_a16w16_bandwidth_bound_kernel(
 
     compute_idx += 1
 
-    # Epilogue: no more loads
+    # Epilogue: no more loads.  NUM_BUFFERS-1-i tiles are still in flight on entry
+    # to iteration i, so the wait is one less than that -- tiles, not ops.
     for i in gl.static_range(NUM_BUFFERS - 1):
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2 - i) * 2)
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2 - i)
 
         if LAYOUT[0] == "T":
             cur_a = gl.amd.cdna4.async_copy.load_shared_relaxed(
@@ -543,9 +553,19 @@ def _gemm_a16w16_compute_bound_kernel(
     num_k_tiles = gl.cdiv(K, BLOCK_K)
 
     # Register pre-load prologue: wait for tile 0 then read it into cur_a/cur_b.
-    # After TDM prologue there are (NUM_BUFFERS-1)*2 ops in-flight; waiting for
-    # (NUM_BUFFERS-2)*2 lets exactly one tile (tile 0) complete.
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+    #
+    # The wait argument counts TDM *tiles* that may stay in flight, not TDM ops.
+    # A and B are issued from two different descriptors and retire on two
+    # independent in-order streams sharing one counter, so "at most N ops
+    # outstanding" does not imply the oldest pair has landed: with T tiles in
+    # flight, one stream can still hold all T of its own ops while the other has
+    # drained. Only N <= T-1 forces both streams below their own depth and so
+    # retires the oldest A *and* the oldest B. Doubling the count to (T-1)*2
+    # reads LDS the DMA has not filled yet.
+    #
+    # After the TDM prologue T = NUM_BUFFERS-1 tiles are in flight, so waiting
+    # for NUM_BUFFERS-2 lets exactly tile 0 complete.
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
     if LAYOUT[0] == "T":
         cur_a = gl.amd.cdna4.async_copy.load_shared_relaxed(
@@ -602,10 +622,11 @@ def _gemm_a16w16_compute_bound_kernel(
             b_desc, add_offsets=[0, BLOCK_K]
         )
 
-    # Tighter wait: after issuing the new TDM there are (NUM_BUFFERS-1)*2
-    # ops in-flight.  Waiting for (NUM_BUFFERS-2)*2 guarantees that tile
-    # compute_idx+1 has landed in LDS.
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+    # Tighter wait: after issuing the new TDM there are NUM_BUFFERS-1 tiles in
+    # flight.  Waiting for NUM_BUFFERS-2 guarantees that tile compute_idx+1 has
+    # landed in LDS.  Tiles, not ops -- see the register pre-load prologue for
+    # why this count must not be doubled.
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
     load_idx += 1
 
@@ -673,10 +694,11 @@ def _gemm_a16w16_compute_bound_kernel(
                 b_desc, add_offsets=[0, BLOCK_K]
             )
 
-        # Tighter wait: after issuing the new TDM there are (NUM_BUFFERS-1)*2
-        # ops in-flight.  Waiting for (NUM_BUFFERS-2)*2 guarantees that tile
-        # compute_idx+1 has landed in LDS.
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+        # Tighter wait: after issuing the new TDM there are NUM_BUFFERS-1 tiles
+        # in flight.  Waiting for NUM_BUFFERS-2 guarantees that tile
+        # compute_idx+1 has landed in LDS.  Tiles, not ops -- see the register
+        # pre-load prologue for why this count must not be doubled.
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
         load_idx += 1
 
@@ -740,7 +762,7 @@ def _gemm_a16w16_compute_bound_kernel(
         b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
     )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
     load_idx += 1
 
@@ -771,7 +793,7 @@ def _gemm_a16w16_compute_bound_kernel(
     # Epilogue: no more TDM loads; drain the remaining NUM_BUFFERS-1 tiles.
     # The first NUM_BUFFERS-2 iterations still use the pre-load / WMMA pattern.
     for i in gl.static_range(NUM_BUFFERS - 2):
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 3 - i) * 2)
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 3 - i)
 
         if LAYOUT[0] == "T":
             next_a = gl.amd.cdna4.async_copy.load_shared_relaxed(
@@ -825,6 +847,7 @@ def _gemm_a16w16_compute_bound_kernel(
         shape=[BLOCK_M, BLOCK_N],
         layout=SHARED_LAYOUT_C,
     )
+
     c_buffer.store(accumulator.to(c_ptr.type.element_ty))
 
     # Ensure all wavefronts have finished writing to LDS before TDM reads it.

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
@@ -373,9 +373,20 @@ def _gemm_a16w16_bandwidth_bound_kernel(
         0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
     )
 
-    offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-
     mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+
+    # buffer_store addresses through a 32-bit byte offset, so a C tile starting
+    # past 2 GiB is dropped by the bounds check with nothing raised.  Fold the
+    # origin into the base pointer in 64-bit and keep only tile-local offsets,
+    # which the block shape bounds, so the fast path holds at every size.
+    c_ptr += (pid_m * BLOCK_M).to(gl.int64) * stride_cm + (
+        pid_n * BLOCK_N
+    ).to(gl.int64) * stride_cn
+    offs_c = stride_cm * gl.arange(
+        0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT)
+    )[:, None] + stride_cn * gl.arange(
+        0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
+    )[None, :]
 
     # Store
     gl.amd.gfx1250.buffer_store(

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/basic/gemm_a16w16.py
@@ -500,7 +500,7 @@ def _gemm_a16w16_compute_bound_kernel(
     accumulator = gl.zeros((BLOCK_M, BLOCK_N), dtype=gl.float32, layout=WMMA_LAYOUT)
 
     # TDM prologue: fill the pipeline with NUM_BUFFERS-1 tiles
-    for _ in gl.static_range(NUM_BUFFERS):
+    for _ in gl.static_range(NUM_BUFFERS - 1):
         gl.amd.gfx1250.tdm.async_load(
             a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
         )
@@ -534,7 +534,7 @@ def _gemm_a16w16_compute_bound_kernel(
     # Register pre-load prologue: wait for tile 0 then read it into cur_a/cur_b.
     # After TDM prologue there are (NUM_BUFFERS-1)*2 ops in-flight; waiting for
     # (NUM_BUFFERS-2)*2 lets exactly one tile (tile 0) complete.
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
     if LAYOUT[0] == "T":
         cur_a = gl.amd.cdna4.async_copy.load_shared_relaxed(
@@ -594,7 +594,7 @@ def _gemm_a16w16_compute_bound_kernel(
     # Tighter wait: after issuing the new TDM there are (NUM_BUFFERS-1)*2
     # ops in-flight.  Waiting for (NUM_BUFFERS-2)*2 guarantees that tile
     # compute_idx+1 has landed in LDS.
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
     load_idx += 1
 
@@ -629,7 +629,7 @@ def _gemm_a16w16_compute_bound_kernel(
     # The final K tile is peeled out after this loop so its (possibly partial)
     # TDM load can be bounds-checked with set_bounds; the interior iterations
     # use the fast add_offsets path that leaves the OOB bound untouched.
-    for _ in range(num_k_tiles - NUM_BUFFERS - 2):
+    for _ in range(num_k_tiles - NUM_BUFFERS - 1):
 
         # WMMA for the current tile — uses operands pre-loaded in the
         # *previous* iteration so no ds_read stall before the matrix op.
@@ -665,7 +665,7 @@ def _gemm_a16w16_compute_bound_kernel(
         # Tighter wait: after issuing the new TDM there are (NUM_BUFFERS-1)*2
         # ops in-flight.  Waiting for (NUM_BUFFERS-2)*2 guarantees that tile
         # compute_idx+1 has landed in LDS.
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
         load_idx += 1
 
@@ -729,7 +729,7 @@ def _gemm_a16w16_compute_bound_kernel(
         b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
     )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
     load_idx += 1
 
@@ -759,8 +759,8 @@ def _gemm_a16w16_compute_bound_kernel(
 
     # Epilogue: no more TDM loads; drain the remaining NUM_BUFFERS-1 tiles.
     # The first NUM_BUFFERS-2 iterations still use the pre-load / WMMA pattern.
-    for i in gl.static_range(NUM_BUFFERS - 1):
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2 - i) * 2)
+    for i in gl.static_range(NUM_BUFFERS - 2):
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 3 - i) * 2)
 
         if LAYOUT[0] == "T":
             next_a = gl.amd.cdna4.async_copy.load_shared_relaxed(

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
@@ -367,11 +367,12 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
         + (pid_m * BLOCK_M).to(gl.int64) * stride_cm
         + (pid_n * BLOCK_N).to(gl.int64) * stride_cn
     )
-    offs_c = stride_cm * gl.arange(
-        0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT)
-    )[:, None] + stride_cn * gl.arange(
-        0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
-    )[None, :]
+    offs_c = (
+        stride_cm
+        * gl.arange(0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT))[:, None]
+        + stride_cn
+        * gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT))[None, :]
+    )
 
     gl.amd.gfx1250.buffer_store(
         accumulator.to(c_ptr.type.element_ty), c_ptr, offs_c, mask=mask_c
@@ -806,11 +807,12 @@ def _batched_gemm_bf16_compute_bound_kernel(
         + (pid_m * BLOCK_M).to(gl.int64) * stride_cm
         + (pid_n * BLOCK_N).to(gl.int64) * stride_cn
     )
-    offs_c = stride_cm * gl.arange(
-        0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT)
-    )[:, None] + stride_cn * gl.arange(
-        0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
-    )[None, :]
+    offs_c = (
+        stride_cm
+        * gl.arange(0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT))[:, None]
+        + stride_cn
+        * gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT))[None, :]
+    )
 
     gl.amd.gfx1250.buffer_store(
         accumulator.to(c_ptr.type.element_ty), c_ptr, offs_c, mask=mask_c

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
@@ -197,7 +197,15 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
             b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
         )
 
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+        # The wait argument counts TDM *tiles* that may stay in flight, not TDM
+        # ops.  A and B are issued from two different descriptors and retire on
+        # two independent in-order streams sharing one counter, so "at most N ops
+        # outstanding" does not imply the oldest pair has landed: with T tiles in
+        # flight, one stream can still hold all T of its own ops while the other
+        # has drained.  Only N <= T-1 forces both streams below their own depth.
+        # Here the load just issued brings T to NUM_BUFFERS, so the wait is
+        # NUM_BUFFERS-1 -- not doubled.
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 1)
 
         if LAYOUT[0] == "T":
             a_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
@@ -270,7 +278,8 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
         b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
     )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    # Tiles, not ops -- see the interior loop for why this count is not doubled.
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 1)
 
     load_idx += 1
 
@@ -298,9 +307,10 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
 
     compute_idx += 1
 
-    # Epilogue: no more loads
+    # Epilogue: no more loads.  NUM_BUFFERS-1-i tiles are still in flight on entry
+    # to iteration i, so the wait is one less than that -- tiles, not ops.
     for i in gl.static_range(NUM_BUFFERS - 1):
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2 - i) * 2)
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2 - i)
 
         if LAYOUT[0] == "T":
             cur_a = gl.amd.cdna4.async_copy.load_shared_relaxed(
@@ -531,8 +541,16 @@ def _batched_gemm_bf16_compute_bound_kernel(
 
         load_idx += 1
 
-    # Register pre-load prologue
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+    # Register pre-load prologue.
+    #
+    # The wait argument counts TDM *tiles* that may stay in flight, not TDM ops.
+    # A and B are issued from two different descriptors and retire on two
+    # independent in-order streams sharing one counter, so "at most N ops
+    # outstanding" does not imply the oldest pair has landed: with T tiles in
+    # flight, one stream can still hold all T of its own ops while the other has
+    # drained. Only N <= T-1 forces both streams below their own depth. Here
+    # T = NUM_BUFFERS-1, so the wait is NUM_BUFFERS-2 -- not doubled.
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
     if LAYOUT[0] == "T":
         cur_a = gl.amd.cdna4.async_copy.load_shared_relaxed(
@@ -582,7 +600,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
             b_desc, add_offsets=[0, BLOCK_K]
         )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
     load_idx += 1
 
@@ -639,7 +657,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
                 b_desc, add_offsets=[0, BLOCK_K]
             )
 
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
         load_idx += 1
 
@@ -696,7 +714,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
         b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
     )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
+    gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 2)
 
     load_idx += 1
 
@@ -726,7 +744,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
 
     # Epilogue: drain remaining tiles
     for i in gl.static_range(NUM_BUFFERS - 2):
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 3 - i) * 2)
+        gl.amd.gfx1250.tdm.async_wait(NUM_BUFFERS - 3 - i)
 
         if LAYOUT[0] == "T":
             next_a = gl.amd.cdna4.async_copy.load_shared_relaxed(

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
@@ -345,14 +345,23 @@ def _batched_gemm_bf16_bandwidth_bound_kernel(
         0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
     )
 
-    offs_c = (
-        pid_k * stride_ck
-        + batch_id * stride_cb
-        + stride_cm * offs_cm[:, None]
-        + stride_cn * offs_cn[None, :]
-    )
-
     mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+
+    # buffer_store addresses through a 32-bit byte offset, so a C tile starting
+    # past 2 GiB is dropped by the bounds check with nothing raised.  Fold the
+    # origin into the base pointer in 64-bit and keep only tile-local offsets,
+    # which the block shape bounds, so the fast path holds at every size.
+    c_ptr += (
+        pid_k.to(gl.int64) * stride_ck
+        + batch_id.to(gl.int64) * stride_cb
+        + (pid_m * BLOCK_M).to(gl.int64) * stride_cm
+        + (pid_n * BLOCK_N).to(gl.int64) * stride_cn
+    )
+    offs_c = stride_cm * gl.arange(
+        0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT)
+    )[:, None] + stride_cn * gl.arange(
+        0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
+    )[None, :]
 
     gl.amd.gfx1250.buffer_store(
         accumulator.to(c_ptr.type.element_ty), c_ptr, offs_c, mask=mask_c
@@ -767,14 +776,23 @@ def _batched_gemm_bf16_compute_bound_kernel(
         0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
     )
 
-    offs_c = (
-        pid_k * stride_ck
-        + batch_id * stride_cb
-        + stride_cm * offs_cm[:, None]
-        + stride_cn * offs_cn[None, :]
-    )
-
     mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+
+    # buffer_store addresses through a 32-bit byte offset, so a C tile starting
+    # past 2 GiB is dropped by the bounds check with nothing raised.  Fold the
+    # origin into the base pointer in 64-bit and keep only tile-local offsets,
+    # which the block shape bounds, so the fast path holds at every size.
+    c_ptr += (
+        pid_k.to(gl.int64) * stride_ck
+        + batch_id.to(gl.int64) * stride_cb
+        + (pid_m * BLOCK_M).to(gl.int64) * stride_cm
+        + (pid_n * BLOCK_N).to(gl.int64) * stride_cn
+    )
+    offs_c = stride_cm * gl.arange(
+        0, BLOCK_M, layout=gl.SliceLayout(1, WMMA_LAYOUT)
+    )[:, None] + stride_cn * gl.arange(
+        0, BLOCK_N, layout=gl.SliceLayout(0, WMMA_LAYOUT)
+    )[None, :]
 
     gl.amd.gfx1250.buffer_store(
         accumulator.to(c_ptr.type.element_ty), c_ptr, offs_c, mask=mask_c

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/gemm/batched/batched_gemm_bf16.py
@@ -494,7 +494,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
     num_k_tiles = gl.cdiv(k_span, BLOCK_K)
 
     # TDM prologue: fill the pipeline
-    for _ in gl.static_range(NUM_BUFFERS):
+    for _ in gl.static_range(NUM_BUFFERS - 1):
         gl.amd.gfx1250.tdm.async_load(
             a_desc, [0, 0], a_buffer.index(load_idx % NUM_BUFFERS)
         )
@@ -523,7 +523,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
         load_idx += 1
 
     # Register pre-load prologue
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
     if LAYOUT[0] == "T":
         cur_a = gl.amd.cdna4.async_copy.load_shared_relaxed(
@@ -573,7 +573,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
             b_desc, add_offsets=[0, BLOCK_K]
         )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
     load_idx += 1
 
@@ -602,7 +602,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
     compute_idx += 1
 
     # Remaining main-loop iterations
-    for _ in range(num_k_tiles - NUM_BUFFERS - 2):
+    for _ in range(num_k_tiles - NUM_BUFFERS - 1):
         accumulator = gl.amd.gfx1250.wmma(cur_a, cur_b, accumulator)
 
         gl.amd.gfx1250.tdm.async_load(
@@ -630,7 +630,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
                 b_desc, add_offsets=[0, BLOCK_K]
             )
 
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
         load_idx += 1
 
@@ -687,7 +687,7 @@ def _batched_gemm_bf16_compute_bound_kernel(
         b_desc, [0, 0], b_buffer.index(load_idx % NUM_BUFFERS)
     )
 
-    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * 2)
+    gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2) * 2)
 
     load_idx += 1
 
@@ -716,8 +716,8 @@ def _batched_gemm_bf16_compute_bound_kernel(
     compute_idx += 1
 
     # Epilogue: drain remaining tiles
-    for i in gl.static_range(NUM_BUFFERS - 1):
-        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 2 - i) * 2)
+    for i in gl.static_range(NUM_BUFFERS - 2):
+        gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 3 - i) * 2)
 
         if LAYOUT[0] == "T":
             next_a = gl.amd.cdna4.async_copy.load_shared_relaxed(

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=12-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=12-K=7168.json
@@ -1,0 +1,42 @@
+{
+    "M_LEQ_1024": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 16,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=12440-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=12440-K=7168.json
@@ -1,0 +1,58 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=128-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=128-K=7168.json
@@ -1,0 +1,42 @@
+{
+    "M_LEQ_512": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=1536-K=128.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=1536-K=128.json
@@ -1,0 +1,90 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 256,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=1536-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=1536-K=7168.json
@@ -1,0 +1,82 @@
+{
+    "M_LEQ_32": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=16896-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=16896-K=7168.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=20480-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=20480-K=7168.json
@@ -1,0 +1,66 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=2112-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=2112-K=7168.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=2304-K=1536.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=2304-K=1536.json
@@ -1,0 +1,106 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=24-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=24-K=7168.json
@@ -1,0 +1,50 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=3072-K=128.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=3072-K=128.json
@@ -1,0 +1,90 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=3072-K=512.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=3072-K=512.json
@@ -1,0 +1,98 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=3072-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=3072-K=7168.json
@@ -1,0 +1,90 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 8,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=40960-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=40960-K=7168.json
@@ -1,0 +1,82 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=4608-K=1536.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=4608-K=1536.json
@@ -1,0 +1,90 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=576-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=576-K=7168.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_64": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=6144-K=512.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=6144-K=512.json
@@ -1,0 +1,106 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=1536.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=1536.json
@@ -1,0 +1,98 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 8,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 2,
+        "num_warps": 8,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=3072.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=3072.json
@@ -1,0 +1,98 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 8,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=4224.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=4224.json
@@ -1,0 +1,98 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 32,
+        "NUM_BUFFERS": 3,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=768.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=768.json
@@ -1,0 +1,98 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 32,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 8,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 32,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=8448.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=7168-K=8448.json
@@ -1,0 +1,106 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 3,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 3,
+        "num_warps": 8,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=8448-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=8448-K=7168.json
@@ -1,0 +1,98 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_16": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_32": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_64": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 2,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_4096": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_8192": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 2,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 256,
+        "BLOCK_N": 256,
+        "BLOCK_K": 64,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=896-K=7168.json
+++ b/aiter/ops/triton/configs/gemm/gfx1250-GEMM-A16W16-N=896-K=7168.json
@@ -1,0 +1,58 @@
+{
+    "M_LEQ_64": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 16,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_128": {
+        "BLOCK_M": 16,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 5,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_256": {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_K": 512,
+        "NUM_BUFFERS": 4,
+        "num_warps": 2,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_512": {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 256,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    },
+    "M_LEQ_1024": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 5,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "M_LEQ_2048": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "bandwidth_bound"
+    },
+    "any": {
+        "BLOCK_M": 128,
+        "BLOCK_N": 128,
+        "BLOCK_K": 128,
+        "NUM_BUFFERS": 4,
+        "num_warps": 4,
+        "kernel_type": "compute_bound"
+    }
+}

--- a/aiter/ops/triton/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/gemm/basic/gemm_a16w16.py
@@ -167,7 +167,10 @@ def gemm_a16w16_(
         #   bandwidth_bound : peels the last tile (needs num_k_tiles >= NB)
         #                     -> cap = num_k_tiles
         #   compute_bound : preloads one tile ahead AND peels the last tile
-        #                   (needs num_k_tiles >= NB + 2) -> cap = num_k_tiles - 2
+        #                   (needs num_k_tiles >= NB + 1). The prologue now fills
+        #                   NB-1 slots rather than NB, so one tile of reach came
+        #                   back; _DEPTH_SLACK stays at 2, which is one deeper
+        #                   than required and therefore still safe.
         num_k_tiles = triton.cdiv(K, BLOCK_K)
         _MIN_BUFFERS = {"bandwidth_bound": 1, "compute_bound": 2}
         _DEPTH_SLACK = {"compute_bound": 2}


### PR DESCRIPTION
Four commits, in dependency order: three correctness fixes in the gfx1250 gluon
GEMM kernels, then the tuned configs, which are only safe to ship on top of
them. Scope is a16w16 (basic + batched) only.

## 1. compute_bound prologue over-fills the TDM ring

The compute_bound pipelines issue `NUM_BUFFERS` `async_load` pairs into a ring
of `NUM_BUFFERS` slots, then read tile `compute_idx + 1` -- one ahead of the
slot they are about to overwrite. So the write target `load_idx % NUM_BUFFERS`
*is* the slot the next iteration reads, and nothing orders the two: the LDS
reads go through `gl.amd.cdna4.async_copy.load_shared_relaxed`, which sets
`ttg.amdg.syncedViaAsyncWait` and suppresses the barrier `MembarPass` would
otherwise insert. A wave that has not drained its read sees the tile
overwritten under it. Wrong results, silently.

Fix: fill to `NUM_BUFFERS - 1`, leaving one slot free, and shift the
`async_wait` counts and trip counts to match.

a16w16 N=7168 K=3072 M=16384, random bf16 vs chunked fp32 at 2e-2, one variant
per process, 8 processes per config crossed over 4 GPUs, 10 trials each,
counting processes with any bad trial:

| tile config | before | after |
|---|---|---|
| 64-64-128-4-4 | 8/8 | 0/8 |
| 128-128-128-3-4 | 6/8 | 0/8 |
| 128-256-64-5-4 | 8/8 | 0/8 |
| 256-256-64-3-4 | 2/8 | 0/8 |

`batched_gemm_bf16` compute_bound behaves identically (8/8, 8/8, 6/8, 6/8, 1/8
before; 0/8 after at all six configs tried).

This commit alone regressed `256-256-64-3-8` from 0/8 to 5-6/8. That was
originally filed here as an unexplained residual; it is the subject of commit 3
and is fixed.

Note on method, in case it saves someone else the trip: the sampling unit has
to be the **process**. A variant holds one behaviour for a process's lifetime
and draws again in the next -- the same variant/config gave 0/20, 8/20 and
7/20 in three processes, far wider than binomial. And variant must be
**crossed with the physical GPU**, not assigned one per device: on this box
GPU 1 suppresses these races, so a variant-per-device layout makes "depth
fails, shipped doesn't" and "GPU 3 fails, GPU 1 doesn't" the same measurement.
An earlier pass of this work got a conclusion backwards that way.

## 2. `buffer_store` drops C tiles past 2 GiB

`gl.amd.gfx1250.buffer_store` addresses through the 32-bit byte offset of a
buffer resource descriptor. The a16w16 and batched bf16 stores build `offs_c`
as a full linear index from the tile origin, so once C exceeds 2 GiB every tile
whose origin is past 2^31 bytes fails the bounds check and is discarded.
Nothing raises -- the output just comes back with a zero tail.

Fix: fold the tile origin into `c_ptr` in int64, keep only tile-local offsets
in `offs_c`. Those are bounded by the block shape, so the 32-bit fast path
stays valid at every size and nothing changes below the cap.

At N=40960 K=7168 M=32768 (C = 2.50 GiB), all-ones operands so every element
must equal K exactly:

| kernel_type | before | after |
|---|---|---|
| bandwidth_bound | 268435460 elements wrong, first bad row 26214, max rel err 1.0 | 0 wrong |
| compute_bound | 0 wrong | 0 wrong |

Row 26214 is exactly the cap: `2^31 / (40960 * 2) = 26214.4`. compute_bound is
unaffected because it stores through a TDM descriptor, whose base is 64-bit.

The same pattern exists at `_gluon_kernels/gfx1250/moe/reduce.py:77` and
`_gluon_kernels/gfx1250/attention/unified_attention_reduce.py:116`. Left alone
here -- they need their own reachability analysis and test.

## 3. TDM ring wait counts ops instead of tiles

Every wait site gated compute on `tdm.async_wait(N)` -- `s_wait_tensorcnt N`,
"block until at most N TDM ops are outstanding" -- with `N` doubled to cover
the two ops (one A, one B) that make up a tile. That doubling is wrong.

A and B are issued from two different tensor descriptors and retire on **two
independent in-order streams that share one counter**. With `T` tiles in flight
each stream holds `T` of its own ops, and "at most N outstanding" only implies
the oldest A *and* the oldest B have landed when `N <= T-1`: at any larger `N`
one stream can still hold all `T` of its ops while the other has drained. So
the argument counts *tiles*, not ops, and `(T-1)*2` lets a wave read a ring
slot the DMA has not filled.

The defect predates this series. Commit 1 did not introduce the doubling -- it
only narrowed `(NUM_BUFFERS-1)*2` to `(NUM_BUFFERS-2)*2` -- but by dropping the
prologue from `NUM_BUFFERS` to `NUM_BUFFERS-1` tiles it removed the one tile of
slack that had been hiding the hazard, which is why `256-256-64-3-8` regressed.

Established by sweeping a slack term `D` into every wait argument of the
compute_bound kernel and measuring `256-256-64-3-8` at 12 processes x 20 trials
over 4 devices, with the emitted `s_wait_tensorcnt` arguments read back from the
disassembly so the source change is confirmed to have reached the machine code:

| slack | emitted | bad |
|---|---|---|
| D=0 | `0x2` | 8/12 |
| D=1 | `0x1` | 0/12 |
| D=2 | `0x0` | 0/12 |
| D=99 | `0x0` | 0/12 |

Barrier count is 10 in every variant, so nothing was serialized by side effect,
and D=1 retains pipelining. That D=1 suffices refutes fully out-of-order
retirement; that D=0 fails refutes in-order retirement, under which waiting to 2
of 4 outstanding ops would provably have retired the oldest pair. Two in-order
streams keyed by descriptor is the only model consistent with both.

An operand-content discriminator identifies the hazard as a read of **unfilled
LDS**, not a stale-but-valid tile: with both operands all ones every K tile is
byte-identical, so a wrong or stale slot cannot change the result, yet the
config still fails 9/12. A-only and B-only variants both fail, so either stream
can be the one that lags.

Verified after the fix, 12 processes x 20 trials over 4 devices:

| kernel | configs | result |
|---|---|---|
| a16w16 compute_bound | 256-256-64-3-8, 256-256-64-3-4, 64-64-128-4-4, 128-128-128-3-4, 128-256-64-5-4, 128-128-64-4-4 | all 0/12 |
| batched compute_bound | same, plus 256-256-64-4-8 | all 0/12 |

`num_warps=8` on the batched kernel had no coverage before and is included.

bandwidth_bound is corrected on the same argument (`T = NUM_BUFFERS` there, so
the wait is `NUM_BUFFERS-1`) but **on the model, not on a reproduced failure**:
25 configs x 4 processes x 10 trials are 0 both before and after. Flagging that
explicitly -- if a reviewer would rather see bandwidth_bound left alone until it
can be made to fail, that hunk is separable.

### Cost

Correctness is not free where the ring is shallow. At `NUM_BUFFERS=3` the ring
holds 2 tiles = 4 TDM ops and the correct wait leaves 1 outstanding, which is
nearly a full drain. a16w16 compute_bound, M=16384 N=7168 K=3072, min of 5
alternating runs:

| config | before | after | delta |
|---|---|---|---|
| 256-256-64-**3**-8 | 0.805 ms | 1.003 ms | **+24.6%** |
| 256-256-64-**3**-4 | 0.700 | 0.881 | **+25.9%** |
| 128-128-128-**3**-4 | 0.985 | 1.108 | +12.5% |
| 128-256-64-**5**-4 | 0.826 | 0.885 | +7.2% |
| 128-128-64-**4**-4 | 0.984 | 0.989 | +0.5% |
| 64-64-128-**4**-4 | 1.594 | 1.572 | -1.4% |

bandwidth_bound is unaffected at the depths the tuned set uses (-0.7% at
256-256-64-3-8, +0.8% at 128-128-64-4-4, +4.3% at 256-128-64-4-8) and pays the
same shallow-ring cost only at `NUM_BUFFERS=2` (+24.2%). `compute_bound` at
`NUM_BUFFERS=2` is unchanged -- its wait was already 0.

Commit 4 re-picks the configs on top of this and gets most of it back; see
below.

## 4. Tuned a16w16 configs for the Kimi-K3 shapes

All 24 a16w16 shapes Kimi-K3 hits on gfx1250 tp4 were running the untuned
default tile (32/64/64, `NUM_BUFFERS` 5, `num_warps` 2, bandwidth_bound).
Tuned over M = 1, 2, 4 ... 32768.

Tuned on the kernel this PR ships, i.e. with the three preceding fixes applied.
That matters more than it sounds: an earlier revision of this PR carried configs
ranked against the pre-fix kernel and reported **3.59x** over the default tile.
That kernel was not really waiting on its TDM ring, so tiles that skipped a wait
ranked as fast, and the number could not be carried forward.

Re-timed on the shipped kernel, every point in its own process with the three
config sources alternating inside it and the min taken over three rounds:

| source | total over 384 points | |
|---|---:|---|
| untuned default tile | 440752us | |
| configs ranked pre-fix | 165392us | 2.66x vs default |
| **these configs** | **143433us** | **3.07x vs default** |

The pre-fix set still works -- it is 2.66x over the default -- but it lost
ground once the wait it had been ranked against became real. Re-tuning recovers
**13.3%** of that. **3.07x is the honest replacement for the earlier 3.59x.**

Selection is deliberately conservative, because a tile holds one speed for a
process's lifetime and draws a different one in the next:

- six independent tuner runs, one sample each, ranked on the median across
  runs, not on any single run;
- ranked on median + spread/2, not the median alone -- a few tiles are bimodal
  and their median can win while their slow mode is worse than the default;
- a candidate must beat the default at *every* M in the bucket, not on average.

Where nothing cleared that bar the default tile is kept: **18 of the 384
points**, in 10 buckets before collapsing. An untuned point costs nothing, a
regressed one costs real time. There are no points where the default is faster
than what is shipped here.

Every emitted config was then screened for correctness on the shipped kernel --
not on a patched copy -- at the largest M its bucket governs, with one operand
all ones so the expected result is an exact 1-D fp32 sum: no reference GEMM, and
no dependence on hipBLASLt, which was itself off by 5.3e-02 on one of these
shapes. Both operand roles are covered by running the pass twice with the roles
swapped, which matters here because the bug fixed in commit 3 is a two-stream
wait and a single-pattern screen would exercise one stream. **240/240 bucket
entries pass**, 3 trials each.

Two of the 24, N=2112 K=7168 and N=12440 K=7168 (the fused KDA in_proj GEMM),
reach the triton path only once they have a routing row in
`kimik3_bf16_tuned_gemm.csv`. Those 15 rows are **#4552**, split out so this PR
stays kernel fixes plus tuned config JSONs. Neither PR blocks the other: the
configs here sit unused for those two shapes until #4552 lands, and #4552 on its
own routes them to the default tile, which is the configuration its -24.7% TTFT
was measured in.

## Not done yet

- No perf-parity measurement of the commit-2 store change below the 2 GiB cap.
  It should be free -- the arithmetic moves out of the inner path -- but it is
  unmeasured.
- The two `buffer_store` sites named in commit 2 (`moe/reduce.py`,
  `attention/unified_attention_reduce.py`) are untouched.
- The bandwidth_bound half of commit 3 is model-backed only, as noted there, and
  is separable if a reviewer prefers.

Tested on gfx1250, 256 CU, SPX, 4 GPUs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)