### PR TITLE
Cache the paged_attention_v1 launch plan to fix batch=1 decode latency

### DIFF
--- a/csrc/cpp_itfs/pa/pa_v1.py
+++ b/csrc/cpp_itfs/pa/pa_v1.py
@@ -1,5 +1,6 @@
 import ctypes
 import math
+from functools import cache, lru_cache
 
 from jinja2 import Template
 
@@ -55,6 +56,72 @@ def compile(
     )
 
 
+def _validate_shapes(
+    block_tables_shape,
+    num_context_lens,
+    num_heads,
+    head_size,
+    block_size,
+    max_context_len,
+    partition_size,
+    mtp,
+    q_elem_size,
+):
+    """Check the launch shapes and return the minimum workspace size in bytes.
+
+    Takes plain shape scalars rather than tensors so that the result can be
+    memoized per launch signature instead of recomputed on every call.
+    """
+    op_name = "paged_attention_v1"
+    max_num_partitions = math.ceil(max_context_len / partition_size)
+    # Use the launch-time upper bound rather than reading context_lens data.
+    # context_lens may live on GPU, and scalar extraction would force a sync
+    # and introduce tensor-data-dependent Python in torch.compile paths.
+    min_blocks_per_seq = math.ceil(max_context_len / block_size)
+
+    if len(block_tables_shape) != 2:
+        raise ValueError(
+            f"{op_name}: block_tables must be 2D "
+            f"[num_seqs, max_num_blocks_per_seq], got {tuple(block_tables_shape)}"
+        )
+    num_seqs, max_num_blocks_per_seq = block_tables_shape
+    if max_num_blocks_per_seq < min_blocks_per_seq:
+        raise ValueError(
+            f"{op_name}: block_tables.size(1)={max_num_blocks_per_seq} is too small "
+            f"for max_context_len={max_context_len} and block_size={block_size}; "
+            f"need at least {min_blocks_per_seq} block-table entries per sequence"
+        )
+    if num_context_lens != num_seqs:
+        raise ValueError(
+            f"{op_name}: context_lens.size(0)={num_context_lens} must match "
+            f"block_tables.size(0)={num_seqs}"
+        )
+
+    return (
+        num_seqs * mtp * num_heads * max_num_partitions * head_size * q_elem_size
+        + 2 * num_seqs * mtp * num_heads * max_num_partitions * 4
+    )
+
+
+def _raise_workspace_too_small(
+    workspace_bytes,
+    required_bytes,
+    max_context_len,
+    partition_size,
+    num_seqs,
+    num_heads,
+    head_size,
+    mtp,
+):
+    raise ValueError(
+        f"paged_attention_v1: workspace_buffer is too small ({workspace_bytes} bytes) "
+        f"for max_context_len={max_context_len}, partition_size={partition_size}, "
+        f"num_seqs={num_seqs}, num_heads={num_heads}, head_size={head_size}, mtp={mtp}; "
+        f"need at least {required_bytes} bytes "
+        f"({math.ceil(max_context_len / partition_size)} partition slots)"
+    )
+
+
 def validate_paged_attention_v1_workspace(
     workspace_buffer,
     query,
@@ -65,47 +132,166 @@ def validate_paged_attention_v1_workspace(
     partition_size,
     mtp=1,
 ):
-    op_name = "paged_attention_v1"
-    max_num_partitions = math.ceil(max_context_len / partition_size)
-    # Use the launch-time upper bound rather than reading context_lens data.
-    # context_lens may live on GPU, and scalar extraction would force a sync
-    # and introduce tensor-data-dependent Python in torch.compile paths.
-    min_blocks_per_seq = math.ceil(max_context_len / block_size)
-
-    if block_tables.dim() != 2:
-        raise ValueError(
-            f"{op_name}: block_tables must be 2D "
-            f"[num_seqs, max_num_blocks_per_seq], got {tuple(block_tables.shape)}"
-        )
-    if block_tables.size(1) < min_blocks_per_seq:
-        raise ValueError(
-            f"{op_name}: block_tables.size(1)={block_tables.size(1)} is too small "
-            f"for max_context_len={max_context_len} and block_size={block_size}; "
-            f"need at least {min_blocks_per_seq} block-table entries per sequence"
-        )
-    if context_lens.size(0) != block_tables.size(0):
-        raise ValueError(
-            f"{op_name}: context_lens.size(0)={context_lens.size(0)} must match "
-            f"block_tables.size(0)={block_tables.size(0)}"
-        )
-
-    num_seqs = block_tables.size(0)
     num_heads = query.size(1)
     head_size = query.size(2)
-    tmp_out_elem_bytes = query.element_size()
-    required_bytes = (
-        num_seqs * mtp * num_heads * max_num_partitions * head_size * tmp_out_elem_bytes
-        + 2 * num_seqs * mtp * num_heads * max_num_partitions * 4
+    required_bytes = _validate_shapes(
+        tuple(block_tables.shape),
+        context_lens.size(0),
+        num_heads,
+        head_size,
+        block_size,
+        max_context_len,
+        partition_size,
+        mtp,
+        query.element_size(),
     )
     workspace_bytes = workspace_buffer.numel() * workspace_buffer.element_size()
     if workspace_bytes < required_bytes:
-        raise ValueError(
-            f"{op_name}: workspace_buffer is too small ({workspace_bytes} bytes) for "
-            f"max_context_len={max_context_len}, partition_size={partition_size}, "
-            f"num_seqs={num_seqs}, num_heads={num_heads}, head_size={head_size}, mtp={mtp}; "
-            f"need at least {required_bytes} bytes "
-            f"({max_num_partitions} partition slots)"
+        _raise_workspace_too_small(
+            workspace_bytes,
+            required_bytes,
+            max_context_len,
+            partition_size,
+            block_tables.size(0),
+            num_heads,
+            head_size,
+            mtp,
         )
+
+
+_NULL = ctypes.c_void_p(0)
+
+# kv_cache_dtype -> query dtype -> (compute type, kv cache type) that the kernel
+# template is instantiated with, plus out dtype -> output type. Built lazily so
+# that importing this module (e.g. for ahead-of-time compilation) needs no torch.
+_HIP_TYPES = None
+_HIP_OUT_TYPES = None
+_get_raw_stream = None
+
+
+def _init_torch_tables():
+    global _HIP_TYPES, _HIP_OUT_TYPES, _get_raw_stream
+    import torch
+
+    _HIP_TYPES = {
+        "auto": {
+            torch.bfloat16: ("__hip_bfloat16", "__hip_bfloat16"),
+            torch.float16: ("_Float16", "_Float16"),
+        },
+        "fp8": {
+            torch.bfloat16: ("__hip_bfloat16", "uint8_t"),
+            torch.float16: ("_Float16", "uint8_t"),
+        },
+    }
+    _HIP_TYPES["fp8_e4m3"] = _HIP_TYPES["fp8"]
+    _HIP_OUT_TYPES = {
+        torch.bfloat16: "__hip_bfloat16",
+        torch.float16: "_Float16",
+    }
+    _get_raw_stream = torch._C._cuda_getCurrentRawStream
+
+
+@cache
+def _warp_size(device_index):
+    import torch
+
+    return torch.cuda.get_device_properties(device_index).warp_size
+
+
+@lru_cache(maxsize=1024)
+def _plan(
+    q_dtype,
+    out_dtype,
+    kv_cache_dtype,
+    gqa_ratio,
+    head_size,
+    block_size,
+    alibi_enabled,
+    logits_soft_cap_enabled,
+    sliding_window_enabled,
+    partition_size,
+    mtp,
+    scale,
+    logits_soft_cap,
+    sliding_window,
+    block_tables_shape,
+    num_context_lens,
+    num_heads,
+    num_kv_heads,
+    q_stride,
+    kv_block_stride,
+    kv_head_stride,
+    kv_seq_stride,
+    max_context_len,
+    q_elem_size,
+    device_index,
+):
+    """Resolve the kernel and pre-build the by-value arguments for a call shape.
+
+    Everything here is a function of shapes, strides and dtypes only, so it is
+    done once per distinct launch signature. At batch=1 the host-side work used
+    to cost more than the kernels themselves, which made single-request decode
+    launch-bound; see ROCm/aiter#2495.
+    """
+    if _HIP_TYPES is None:
+        _init_torch_tables()
+
+    try:
+        dtype, kv_dtype = _HIP_TYPES[kv_cache_dtype][q_dtype]
+    except KeyError:
+        raise ValueError(
+            f"paged_attention_v1: unsupported kv_cache_dtype/query dtype "
+            f"combination: {kv_cache_dtype}/{q_dtype}"
+        ) from None
+    try:
+        out_hip_dtype = _HIP_OUT_TYPES[out_dtype]
+    except KeyError:
+        raise ValueError(f"Unsupported data type: {out_dtype}") from None
+
+    required_bytes = _validate_shapes(
+        block_tables_shape,
+        num_context_lens,
+        num_heads,
+        head_size,
+        block_size,
+        max_context_len,
+        partition_size,
+        mtp,
+        q_elem_size,
+    )
+
+    max_num_partitions = math.ceil(max_context_len / partition_size)
+    func = compile(
+        gqa_ratio,
+        head_size,
+        math.ceil(max_num_partitions / _warp_size(device_index)),
+        dtype,
+        kv_dtype,
+        kv_cache_dtype,
+        out_hip_dtype,
+        block_size,
+        alibi_enabled,
+        logits_soft_cap_enabled,
+        partition_size,
+        mtp,
+        sliding_window_enabled=sliding_window_enabled,
+    )
+    num_seqs, max_num_blocks_per_seq = block_tables_shape
+    scalars = (
+        ctypes.c_float(scale),
+        ctypes.c_int(max_num_blocks_per_seq),
+        ctypes.c_int(max_num_partitions),
+        ctypes.c_float(logits_soft_cap),
+        ctypes.c_int(num_seqs),
+        ctypes.c_int(num_kv_heads),
+        ctypes.c_int(num_heads),
+        ctypes.c_int(q_stride),
+        ctypes.c_int(kv_block_stride),
+        ctypes.c_int(kv_head_stride),
+        ctypes.c_int(kv_seq_stride),
+        ctypes.c_int(sliding_window),
+    )
+    return func, scalars, required_bytes
 
 
 def paged_attention_v1(
@@ -131,178 +317,77 @@ def paged_attention_v1(
     q_scale=None,
     sliding_window: int = 0,
 ):
-    import torch
-
-    from csrc.cpp_itfs.torch_utils import torch_to_c_types
-
-    warpSize = torch.cuda.get_device_properties(out.device).warp_size
-    if kv_cache_dtype == "auto":
-        if query.dtype == torch.bfloat16:
-            dtype = "__hip_bfloat16"
-            kv_dtype = "__hip_bfloat16"
-        elif query.dtype == torch.float16:
-            dtype = "_Float16"
-            kv_dtype = "_Float16"
-        else:
-            raise ValueError(f"Unsupported data type: {query.dtype}")
-    elif kv_cache_dtype == "fp8" or kv_cache_dtype == "fp8_e4m3":
-        if query.dtype == torch.bfloat16:
-            dtype = "__hip_bfloat16"
-            kv_dtype = "uint8_t"
-        elif query.dtype == torch.float16:
-            dtype = "_Float16"
-            kv_dtype = "uint8_t"
-        else:
-            raise ValueError(f"Unsupported data type: {query.dtype}")
+    q_shape = query.shape
+    kv_shape = key_cache.shape
+    kv_stride = key_cache.stride()
+    if kv_cache_layout == "HND":
+        num_kv_heads, block_size = kv_shape[1], kv_shape[2]
+        kv_head_stride, kv_seq_stride = kv_stride[1], kv_stride[2]
     else:
-        raise ValueError(f"Unsupported kv_cache_dtype: {kv_cache_dtype}")
+        block_size, num_kv_heads = kv_shape[1], kv_shape[2]
+        kv_head_stride, kv_seq_stride = kv_stride[2], kv_stride[1]
+    num_heads = q_shape[1]
+    head_size = q_shape[2]
+    device_index = query.get_device()
 
-    if out.dtype == torch.bfloat16:
-        out_dtype = "__hip_bfloat16"
-    elif out.dtype == torch.float16:
-        out_dtype = "_Float16"
-    else:
-        raise ValueError(f"Unsupported data type: {out.dtype}")
-
-    num_kv_heads = key_cache.size(1) if kv_cache_layout == "HND" else key_cache.size(2)
-    num_seqs = block_tables.size(0)
-    num_heads = query.size(1)
-    head_size = query.size(2)
-    q_stride = query.stride(0)
-    block_size = key_cache.size(2) if kv_cache_layout == "HND" else key_cache.size(1)
-    validate_paged_attention_v1_workspace(
-        workspace_buffer,
-        query,
-        block_tables,
-        context_lens,
-        block_size,
-        max_context_len,
-        partition_size,
-        mtp,
-    )
-    max_num_blocks_per_seq = block_tables.size(1)
-    kv_block_stride = key_cache.stride(0)
-    kv_head_stride = (
-        key_cache.stride(1) if kv_cache_layout == "HND" else key_cache.stride(2)
-    )
-    kv_seq_stride = (
-        key_cache.stride(2) if kv_cache_layout == "HND" else key_cache.stride(1)
-    )
-    gqa_ratio = int(num_heads / num_kv_heads)
-    max_num_partitions = math.ceil(max_context_len / partition_size)
-    npar_loops = math.ceil(max_num_partitions / warpSize)
-    logits_soft_cap_enabled = logits_soft_cap > 0
-    alibi_enabled = alibi_slopes is not None
-    sliding_window_enabled = sliding_window > 0
-    func = compile(
-        gqa_ratio,
-        head_size,
-        npar_loops,
-        dtype,
-        kv_dtype,
+    func, scalars, required_bytes = _plan(
+        query.dtype,
+        out.dtype,
         kv_cache_dtype,
-        out_dtype,
+        num_heads // num_kv_heads,
+        head_size,
         block_size,
-        alibi_enabled,
-        logits_soft_cap_enabled,
+        alibi_slopes is not None,
+        logits_soft_cap > 0,
+        sliding_window > 0,
         partition_size,
         mtp,
-        sliding_window_enabled=sliding_window_enabled,
-    )
-
-    alibi_slopes_ptr = (
-        ctypes.cast(alibi_slopes.data_ptr(), ctypes.POINTER(ctypes.c_float))
-        if alibi_enabled
-        else ctypes.POINTER(ctypes.c_int)()
-    )
-
-    context_lens_ptr = ctypes.cast(
-        context_lens.data_ptr(), ctypes.POINTER(ctypes.c_int)
-    )
-    block_tables_ptr = ctypes.cast(
-        block_tables.data_ptr(), ctypes.POINTER(ctypes.c_int)
-    )
-    cu_query_lens_ptr = (
-        ctypes.cast(cu_query_lens.data_ptr(), ctypes.POINTER(ctypes.c_int))
-        if cu_query_lens is not None
-        else ctypes.POINTER(ctypes.c_int)()
-    )
-
-    fp8_out_scale_ptr = (
-        ctypes.cast(fp8_out_scale.data_ptr(), ctypes.POINTER(ctypes.c_float))
-        if fp8_out_scale is not None
-        else ctypes.POINTER(ctypes.c_int)()
-    )
-
-    (
-        out_ptr,
-        query_ptr,
-        key_cache_ptr,
-        value_cache_ptr,
-        workspace_buffer_ptr,
         scale,
-        num_seqs,
-        num_kv_heads,
-        num_heads,
-        max_num_blocks_per_seq,
-        max_num_partitions,
         logits_soft_cap,
-        q_stride,
-        kv_block_stride,
-        kv_head_stride,
-        kv_seq_stride,
-        stream,
-    ) = torch_to_c_types(
-        out,
-        query,
-        key_cache,
-        value_cache,
-        workspace_buffer,
-        scale,
-        num_seqs,
-        num_kv_heads,
-        num_heads,
-        max_num_blocks_per_seq,
-        max_num_partitions,
-        logits_soft_cap,
-        q_stride,
-        kv_block_stride,
-        kv_head_stride,
-        kv_seq_stride,
-        torch.cuda.current_stream(),
-    )
-    q_scale_ptr = (
-        ctypes.cast(q_scale.data_ptr(), ctypes.POINTER(ctypes.c_float))
-        if q_scale is not None
-        else ctypes.POINTER(ctypes.c_float)()
-    )
-    func(
-        out_ptr,
-        workspace_buffer_ptr,
-        query_ptr,
-        key_cache_ptr,
-        value_cache_ptr,
-        block_tables_ptr,
-        cu_query_lens_ptr,
-        context_lens_ptr,
-        alibi_slopes_ptr,
-        q_scale_ptr,
-        ctypes.cast(k_scale.data_ptr(), ctypes.POINTER(ctypes.c_float)),
-        ctypes.cast(v_scale.data_ptr(), ctypes.POINTER(ctypes.c_float)),
-        fp8_out_scale_ptr,
-        scale,
-        max_num_blocks_per_seq,
-        max_num_partitions,
-        logits_soft_cap,
-        num_seqs,
-        num_kv_heads,
-        num_heads,
-        q_stride,
-        kv_block_stride,
-        kv_head_stride,
-        kv_seq_stride,
         sliding_window,
-        stream,
+        block_tables.shape,
+        context_lens.shape[0],
+        num_heads,
+        num_kv_heads,
+        query.stride(0),
+        kv_stride[0],
+        kv_head_stride,
+        kv_seq_stride,
+        max_context_len,
+        query.element_size(),
+        device_index,
+    )
+
+    workspace_bytes = workspace_buffer.numel() * workspace_buffer.element_size()
+    if workspace_bytes < required_bytes:
+        _raise_workspace_too_small(
+            workspace_bytes,
+            required_bytes,
+            max_context_len,
+            partition_size,
+            block_tables.shape[0],
+            num_heads,
+            head_size,
+            mtp,
+        )
+
+    c_void_p = ctypes.c_void_p
+    func(
+        c_void_p(out.data_ptr()),
+        c_void_p(workspace_buffer.data_ptr()),
+        c_void_p(query.data_ptr()),
+        c_void_p(key_cache.data_ptr()),
+        c_void_p(value_cache.data_ptr()),
+        c_void_p(block_tables.data_ptr()),
+        _NULL if cu_query_lens is None else c_void_p(cu_query_lens.data_ptr()),
+        c_void_p(context_lens.data_ptr()),
+        _NULL if alibi_slopes is None else c_void_p(alibi_slopes.data_ptr()),
+        _NULL if q_scale is None else c_void_p(q_scale.data_ptr()),
+        c_void_p(k_scale.data_ptr()),
+        c_void_p(v_scale.data_ptr()),
+        _NULL if fp8_out_scale is None else c_void_p(fp8_out_scale.data_ptr()),
+        *scalars,
+        c_void_p(_get_raw_stream(device_index)),
     )
     return out
 

--- a/op_tests/test_pa_v1.py
+++ b/op_tests/test_pa_v1.py
@@ -590,6 +590,139 @@ def test_paged_attention(
     #     f"[test] dim: {str((ctx_lens, num_seqs, num_heads, head_size)):<20}, dtype: {dtype}, finished)\n")
 
 
+def _valid_pa_v1_args(
+    num_seqs=2,
+    num_heads=8,
+    num_kv_heads=1,
+    head_size=128,
+    ctx_lens=512,
+    block_size=16,
+    partition_size=256,
+    seed=0,
+):
+    """A launch that paged_attention_v1 accepts, as a dict the caller can perturb.
+
+    Seeded, so that the same arguments produce the same inputs on every call.
+    """
+    torch.manual_seed(seed)
+    num_blocks_per_seq = (ctx_lens + block_size - 1) // block_size
+    num_blocks = num_seqs * num_blocks_per_seq
+    max_num_partitions = (ctx_lens + partition_size - 1) // partition_size
+    query = torch.randn(num_seqs, num_heads, head_size, dtype=dtypes.bf16)
+    kv_shape = (num_blocks, block_size, num_kv_heads, head_size)
+    scale = torch.tensor([1.0], dtype=dtypes.fp32)
+    return {
+        "out": torch.empty_like(query),
+        "workspace_buffer": torch.empty(
+            num_seqs * num_heads * max_num_partitions * head_size * query.element_size()
+            + 2 * num_seqs * num_heads * max_num_partitions * 4,
+            dtype=torch.uint8,
+        ),
+        "query": query,
+        "key_cache": torch.randn(kv_shape, dtype=dtypes.bf16),
+        "value_cache": torch.randn(kv_shape, dtype=dtypes.bf16),
+        "scale": head_size**-0.5,
+        "block_tables": torch.arange(num_blocks, dtype=dtypes.i32).reshape(
+            num_seqs, num_blocks_per_seq
+        ),
+        "cu_query_lens": None,
+        "context_lens": torch.full((num_seqs,), ctx_lens, dtype=dtypes.i32),
+        "max_context_len": ctx_lens,
+        "alibi_slopes": None,
+        "kv_cache_dtype": "auto",
+        "kv_cache_layout": "NHD",
+        "logits_soft_cap": 0.0,
+        "k_scale": scale,
+        "v_scale": scale,
+        "fp8_out_scale": None,
+        "partition_size": partition_size,
+    }
+
+
+def _call_pa_v1(kwargs):
+    torch.ops.aiter.paged_attention_v1(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "perturb, match",
+    [
+        # The workspace check is the only one that depends on a per-call value
+        # rather than the launch shape, so it must survive plan caching.
+        (
+            lambda a: a.update(workspace_buffer=a["workspace_buffer"][:16]),
+            "workspace_buffer is too small",
+        ),
+        (
+            lambda a: a.update(block_tables=a["block_tables"].flatten()),
+            "block_tables must be 2D",
+        ),
+        (
+            lambda a: a.update(block_tables=a["block_tables"][:, :1]),
+            "is too small for max_context_len",
+        ),
+        (
+            lambda a: a.update(context_lens=a["context_lens"][:1]),
+            "must match block_tables",
+        ),
+        (
+            lambda a: a.update(kv_cache_dtype="not_a_dtype"),
+            "unsupported kv_cache_dtype",
+        ),
+    ],
+)
+def test_paged_attention_rejects_bad_args(perturb, match):
+    torch.set_default_device("cuda:0")
+    args = _valid_pa_v1_args()
+    _call_pa_v1(args)  # the unperturbed launch must succeed
+    perturb(args)
+    with pytest.raises(ValueError, match=match):
+        _call_pa_v1(args)
+
+
+def test_paged_attention_plan_cache_tracks_shape_changes():
+    """Consecutive launches of differing shapes must not reuse a stale kernel plan.
+
+    Every field the launch depends on is varied while the process (and therefore
+    the plan cache) is shared, and each result is checked against the reference.
+    """
+    torch.set_default_device("cuda:0")
+    shapes = [
+        (2, 8, 1, 512),
+        (5, 32, 4, 512),
+        (2, 8, 1, 1024),  # more partitions, same heads
+        (2, 32, 4, 512),  # different gqa_ratio, context back to 512
+        (2, 8, 1, 512),  # the very first shape again
+    ]
+    for num_seqs, num_heads, num_kv_heads, ctx_lens in shapes:
+        args = _valid_pa_v1_args(num_seqs, num_heads, num_kv_heads, ctx_lens=ctx_lens)
+        _call_pa_v1(args)
+        golden, _ = run_torch(
+            args["query"],
+            args["key_cache"].permute(0, 2, 1, 3),
+            args["value_cache"].permute(0, 2, 1, 3),
+            args["block_tables"],
+            args["context_lens"],
+            ctx_lens,
+            "auto",
+            num_kv_heads,
+            args["scale"],
+            None,
+            0.0,
+            args["k_scale"],
+            args["v_scale"],
+            num_heads // num_kv_heads,
+            0,
+        )
+        assert (
+            checkAllclose(
+                golden,
+                args["out"],
+                msg=f"{num_seqs=} {num_heads=} {num_kv_heads=} {ctx_lens=}",
+            )
+            < 0.01
+        )
+
+
 @pytest.mark.parametrize("ctx_lens", [1, 26, 128, 4097])
 @pytest.mark.parametrize("num_seqs", [1, 3, 31, 128])
 @pytest.mark.parametrize("num_heads", [(8, 1), (32, 4)])


### PR DESCRIPTION
## Summary

Fixes #2495.

At batch=1 the bottleneck is not the kernel, it is the Python that launches it. Timing the enqueue loop without synchronizing (host cost) against a captured CUDA-graph replay (pure GPU cost) on MI350X at B=1, HQ=32, SK=4096: the kernel takes **15.4us**, but `paged_attention_v1` spent **35.9us of host time** getting to it. Wall time was 35.9us, so the GPU sat idle waiting for the host.

`paged_attention_v1` rebuilt its entire launch configuration on every call:

- a chain of `if query.dtype == ...` to pick HIP type strings;
- `compile(...)`, which hashes the template kwargs and `stat()`s the build directory before handing back the cached function;
- sixteen scalar conversions through `torch_to_c_types`;
- roughly twenty individual `.size(i)` / `.stride(i)` pybind calls;
- `torch.cuda.current_stream()`, which allocates a Python `Stream` object and costs **3.4us on its own** (the raw handle costs 0.09us).

None of that depends on tensor *data*, only on shapes, strides and dtypes. It now happens once per distinct launch signature in a memoized `_plan()`, which returns the resolved kernel plus the twelve by-value arguments pre-built as ctypes objects. The per-call path is reduced to pointer marshalling and the foreign call.

Two details worth a reviewer's attention:

- **The workspace-capacity check deliberately stays on the per-call path**, because it depends on the buffer the caller actually passed rather than on the launch shape. Folding it into the cache key would make every distinct workspace size a new cache entry and could mask an undersized buffer. The shape checks did move into the plan, but they are shared with the public `validate_paged_attention_v1_workspace` through one helper, so each rule still exists in exactly one place.
- The lazily-built dtype tables keep this module importable without torch, which the ahead-of-time `__main__` compile path relies on.

## Results (MI350X, gfx950, ROCm 7.2)

Host dispatch drops from 35.9us to 12.4us, and B=1 becomes kernel-bound instead of Python-bound. All times in us.

| model | B | host before | host after | wall before | wall after | kernel | speedup |
|---|---|---|---|---|---|---|---|
| Llama3-8B | 1 | 35.9 | 12.3 | 35.9 | 12.8 | 15.4 | 2.80x |
| Llama3-8B | 4 | 36.3 | 12.4 | 36.3 | 19.7 | 23.5 | 1.84x |
| Llama3-8B | 16 | 37.2 | 12.7 | 53.4 | 53.5 | 57.3 | 1.00x |
| Llama3-8B | 64 | 37.0 | 12.4 | 232.8 | 232.5 | 236.7 | 1.00x |
| Mistral-Small-4 | 1 | 35.9 | 12.5 | 36.1 | 19.6 | 23.5 | 1.84x |
| Qwen3-Coder-480B | 1 | 35.7 | 12.4 | 36.1 | 12.7 | 15.5 | 2.83x |
| Step-3.5-Flash | 1 | 35.5 | 12.6 | 35.9 | 12.9 | 15.4 | 2.79x |
| GLM-5 | 1 | 35.9 | 11.7 | 36.6 | 30.5 | 34.4 | 1.20x |

B >= 16 is unchanged, which is the expected outcome: those launches were already GPU-bound, so this confirms the change adds no regression rather than trading one batch regime for another.

The remaining 12.4us is not more Python to remove. The bare ctypes call measures ~9us, and setting `argtypes` or passing raw ints does not move it; that is the two `hipLaunchKernel` calls the generated C function makes (the QKV kernel plus the reduce kernel). Going below that means changing the C++ side, not the wrapper.

This therefore closes the launch-overhead half of #2495. The issue's B=1 target of 12us total is now roughly our kernel time alone, so any remaining gap is kernel work and a separate, much larger scope.

## Test plan

- [x] **Bitwise equivalence vs. the previous implementation.** 3456 configurations (batch x head counts x head size x context length x block size x NHD/HND x fp16/bf16 x soft cap x alibi x sliding window) produce bit-identical output; all six error paths still raise `ValueError`.
- [x] **Full existing suite.** All 13,952 cases in `op_tests/test_pa_v1.py` pass (4,742 passed, remainder are the pre-existing quant-variant skips), run in three batches since the long-context cases take 39 minutes on their own.
- [x] **New regression tests.** Because the refactor moved validation into a cached path, this adds tests that every rejection still fires and that varying shapes within one process never reuse a stale plan (each result checked against the torch reference).
- [x] **Mutation-tested the plan-cache test.** Deliberately dropped `max_context_len` from the cache key, confirmed the new test caught it (81.9% of elements wrong), then reverted.
- [x] `ruff==0.16.0` and `black` clean, matching the pinned versions in `.github/workflows/pre-checks.yaml`.
