### PR TITLE
tune: default --timeout to 100s so a dead worker gets reaped

### DIFF
--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -42,7 +42,7 @@ class TunerCommon:
         "errRatio": 0.05,
         "batch": 100,
         "profile_file": "",  # for all results
-        "timeout": None,  # 100s timeout for per test
+        "timeout": 100,  # per task group; without it a lost worker is never reaped
         "warmup": 5,  # 5 warmup iters for profiling
         "iters": 101,  # 101 run iters for profiling
         "min_improvement_pct": 3.0,  # only write shapes improved by >= N%

--- a/aiter/utility/mp_tuner.py
+++ b/aiter/utility/mp_tuner.py
@@ -500,7 +500,7 @@ def mp_tuner(
                     if elapsed > timeout:
                         consecutive_timeouts += 1
 
-                        error_msg = f"[!] Task {k} timed out after {elapsed:.1f}s (limit: {timeout}s) - likely GPU hang or infinite loop"
+                        error_msg = f"[!] Task {k} produced no result within {elapsed:.1f}s (limit: {timeout}s) - its worker is wedged or died"
                         print(error_msg)
                         failed_tasks.append((k, "timeout"))
 
@@ -650,7 +650,7 @@ def mp_tuner(
             f"  Total tasks: {len(rets)}\n"
             f"  Successful: {len(rets) - len(failed_tasks)}\n"
             f"  Failed: {len(failed_tasks)}\n"
-            f"    - Timeouts (GPU hang): {timeout_count}\n"
+            f"    - No result within timeout (wedged or dead worker): {timeout_count}\n"
             f"    - Crashes (memory fault): {crash_count}\n"
             f"{'=' * 60}"
         )


### PR DESCRIPTION
A pool worker that dies never returns its task, so mp_tuner polled it forever unless the caller passed --timeout, which defaulted to off even though its comment already described a 100s limit. With the default in place a worker death during a real hipblaslt tune recovers in ~120s and keeps the other 399 of 400 solutions, instead of hanging indefinitely with no results at all.

The timeout is also the only way a dead worker is ever noticed, so its messages no longer claim the cause was a GPU hang.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
