### PR TITLE
fix(flydsl): a16w4 follow-up — SEPARATED route regression, two silent-wrong guards, config test coverage

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -2290,51 +2290,6 @@ def get_2stage_cfgs(
             **route_bucket_metadata,
         )
     if (
-        not kernelName1  # only fire when CSV produced no match; a CSV hit returns above
-        and q_type == QuantType.per_1x32
-        and q_dtype_w == dtypes.fp4x2
-        and q_dtype_a in [dtypes.bf16, dtypes.fp16]
-        and gate_mode
-        == GateMode.SEPARATED  # INTERLEAVE falls through to ck2stages below
-        and is_flydsl_available()
-    ):
-        # fp4_bf16 SEPARATED: MXFP4 weights (FP4 E2M1 + E8M0 scales) with bf16 activations.
-        # INTERLEAVE shapes always use CSV rows; unmatched INTERLEAVE falls through to ck2stages.
-        _out_str = "bf16"
-        _tile_m = 16 if token < 2048 else 32 if token < 16384 else 64
-        _tile_n = 128
-        _tile_k = 128
-        _gui_tag = ""
-        from aiter.ops.flydsl.moe_kernels import flydsl_kernel_name
-
-        kn1 = (
-            flydsl_kernel_name(
-                1, "bf16", "fp4bf16", _out_str, _tile_m, _tile_n, _tile_k
-            )
-            + _gui_tag
-        )
-        kn2 = flydsl_kernel_name(
-            2, "bf16", "fp4bf16", _out_str, _tile_m, _tile_n, _tile_k, "atomic"
-        )
-        return MOEMetadata(
-            functools.partial(
-                _flydsl_stage1_wrapper,
-                kernelName=kn1,
-                activation=activation,
-                inter_dim_pad=intermediate_pad,
-                model_dim_pad=hidden_pad,
-            ),
-            functools.partial(
-                _flydsl_stage2_wrapper,
-                kernelName=kn2,
-                inter_dim_pad=intermediate_pad,
-                model_dim_pad=hidden_pad,
-            ),
-            _tile_m,
-            1,  # no split-K for fp4_bf16 (not yet tuned)
-            False,
-        )
-    if (
         gate_mode != GateMode.SEPARATED
         and dtype in [dtypes.bf16, dtypes.fp16]
         and q_type == QuantType.per_1x32

--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -162,6 +162,13 @@ def compile_moe_gemm1(
     elem_bytes = 2 if is_f16_or_bf16 else 1
     if out_dtype not in ("f16", "bf16"):
         raise ValueError(f"out_dtype must be 'f16' or 'bf16', got {out_dtype!r}")
+    if is_fp4_bf16 and gate_mode != "interleave":
+        raise ValueError(
+            "in_dtype='fp4_bf16' stage1 is INTERLEAVE-only, got "
+            f"gate_mode={gate_mode!r}. "
+            "Preshuffle w13/w13_scale with gate_up=True and request an interleaved "
+            "('_gui') kernel."
+        )
 
     # NOTE: don't materialize MLIR types outside an active MLIR Context.
     def out_mlir():

--- a/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
+++ b/aiter/ops/flydsl/kernels/moe_gemm_2stage.py
@@ -2518,6 +2518,12 @@ def compile_moe_gemm2(
         raise ValueError(
             "compile_moe_gemm2(accumulate=False) only supports out_dtype in {'f16','bf16'}"
         )
+    if klane_inner:
+        raise ValueError(
+            "compile_moe_gemm2 does not support klane_inner=True: the klane_inner w2 "
+            "scale layout is unvalidated and produces incorrect results. Preshuffle "
+            "w2/w2_scale with klane_inner=False."
+        )
     is_int4 = in_dtype == "int4"
     # w_is_int4: True for any variant where weights are packed nibbles (INT4 or FP4).
     w_is_int4 = is_int4 or is_int4_bf16 or is_fp4_bf16

--- a/aiter/ops/flydsl/test_flydsl_moe_a16w4.py
+++ b/aiter/ops/flydsl/test_flydsl_moe_a16w4.py
@@ -144,13 +144,6 @@ def _generate_a16w4_data(
         topk_ids, topk_weights, E, model_dim, dtype, block_m
     )
 
-    if doweight_stage1:
-        sorted_weights_s1 = sorted_weights
-        sorted_weights_s2 = None
-    else:
-        sorted_weights_s1 = None
-        sorted_weights_s2 = sorted_weights
-
     # Pad sorted_ids if needed
     needed = sorted_expert_ids.shape[0] * block_m
     if sorted_ids.shape[0] < needed:
@@ -171,6 +164,13 @@ def _generate_a16w4_data(
                 ),
             ]
         )
+
+    if doweight_stage1:
+        sorted_weights_s1 = sorted_weights
+        sorted_weights_s2 = None
+    else:
+        sorted_weights_s1 = None
+        sorted_weights_s2 = sorted_weights
 
     # Shuffle weights for INTERLEAVE (klane_inner) or SEPARATED.
     # w1 (gate+up) uses klane_inner when gate_mode=interleave.

--- a/op_tests/flydsl_tests/test_flydsl_moe_a16w4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a16w4.py
@@ -96,6 +96,52 @@ SHAPES = [
     (7168, 256, 256, 8, 4),  # DSR1-like tok=4 decode
 ]
 
+A16W4_TUNED_CONFIGS = [
+    "gptoss_a16w4_tuned_fmoe.csv",
+    "qwen3_5_397b_a16w4_tuned_fmoe.csv",
+]
+
+
+def _a16w4_tuned_rows():
+    """Yield (config, row_index, kernelName1, kernelName2) for shipped a16w4 configs."""
+    import csv
+    from pathlib import Path
+
+    cfg_dir = Path(aiter.__file__).parent / "configs" / "model_configs"
+    for cfg in A16W4_TUNED_CONFIGS:
+        path = cfg_dir / cfg
+        if not path.exists():
+            continue
+        with open(path, newline="") as fh:
+            for i, row in enumerate(csv.DictReader(fh)):
+                kn1 = (row.get("kernelName1") or "").strip()
+                kn2 = (row.get("kernelName2") or "").strip()
+                if kn1.startswith("flydsl_") or kn2.startswith("flydsl_"):
+                    yield cfg, i, kn1, kn2
+
+
+@pytest.mark.parametrize("cfg,row,kn1,kn2", list(_a16w4_tuned_rows()))
+def test_a16w4_tuned_config_kernels_are_valid(cfg, row, kn1, kn2):
+    """Every flydsl kernel a shipped a16w4 config selects must exist and be buildable."""
+    from aiter.ops.flydsl.moe_kernels import get_flydsl_kernel_params
+
+    for kn in (kn1, kn2):
+        if not kn.startswith("flydsl_"):
+            continue
+        params = get_flydsl_kernel_params(kn)
+        assert params is not None, f"{cfg} row {row}: unknown flydsl kernel {kn!r}"
+
+        if params["stage"] == 1 and params.get("b_dtype") == "fp4bf16":
+            assert kn.endswith("_gui") or "_gui_" in kn, (
+                f"{cfg} row {row}: {kn!r} is a SEPARATED fp4_bf16 stage1 kernel, but "
+                "flydsl fp4_bf16 stage1 is INTERLEAVE-only"
+            )
+            tile_n = params["tile_n"]
+            assert tile_n % 128 == 0, (
+                f"{cfg} row {row}: {kn!r} has tile_n={tile_n}; INTERLEAVE needs "
+                "tile_n >= 128 so each wave holds at least one gate+up pair"
+            )
+
 
 @pytest.mark.skipif(get_gfx() not in ["gfx950"], reason="fp4_bf16 requires gfx950")
 @pytest.mark.parametrize("model_dim,inter_dim,E,topk,tokens", SHAPES)


### PR DESCRIPTION
## Motivation

Follow-up to #4398. That PR's latest commit (`db2f0f77`) fixes the four a16w4 correctness bugs I reported — I re-validated all four on this branch and they are good. This PR covers what is left over after them: one regression the PR introduces on a path that works on `main`, two silently-wrong parameters that are still reachable, and the test gap that let the original bugs ship green.

Based on `apicciau/a16w4_interleave`, not `main` — these changes only make sense stacked on #4398.

## Modifications

**1. `fix(fused_moe)`: drop the unreachable fp4_bf16 SEPARATED flydsl route**

`get_2stage_cfgs` had a fallback building a non-`_gui` stage1 kernel name for SEPARATED a16w4 shapes. flydsl fp4_bf16 stage1 is INTERLEAVE-only — `get_flydsl_stage1_kernels_fp4_bf16` registers only `_gui` names — so every shape reaching it died with:

```
ValueError: Invalid FlyDSL kernel name: flydsl_moe1_abf16_wfp4bf16_bf16_t16x128x128
```

It also shadowed the mixed-MoE routing that SEPARATED bf16xfp4 shapes used before. `test_flydsl_a16wfp4_situv2_fused_moe` passes on `origin/main` and fails on this branch without the change — the flydsl moe suites go from **58 passed / 2 failed → 60 passed**. Unmatched SEPARATED shapes now fall through to `ck2stages`, same as unmatched INTERLEAVE.

> I flagged this SiTUv2 failure earlier as pre-existing. That was wrong — I measured it on a base that already contained this PR's earlier commits, and the symptom then was numeric (`rel_l2=0.6049`), not this `ValueError`. It is a regression from #4398.

**2. `fix(flydsl)`: reject `klane_inner=True` in `compile_moe_gemm2`**

Removing the `extra_stage2_args` override left the branch reachable through the public stage2 API with nothing to stop a caller re-selecting it. On real Qwen3.5-397B-A17B-MXFP4 weights: w2 preshuffled `klane_inner=True` gives cosine **0.225** with the kernel on the default layout and **0.049** with both on klane_inner, vs **0.999990** for the default. It is only a dwordx4 scale-load width optimisation — w2 is the down projection and has no gate/up split — so raise until the layout is fixed and validated. A later opt-in perf change can lift the guard with numbers attached.

**3. `fix(flydsl)`: reject SEPARATED `gate_mode` for fp4_bf16 stage1**

Same class of trap. `compile_moe_gemm1` still takes `gate_mode` but no longer reads it, so a caller passing `gate_mode="separated"` (the default on `flydsl_moe_stage1`) gets its SEPARATED weight layout misread with no diagnostic: cosine **0.0006** on real checkpoint weights vs **1.000000** for INTERLEAVE. The SiTUv2 / mixed-MoE SEPARATED path uses a different builder and is unaffected.

**4. `test(flydsl)`: validate shipped a16w4 tuned configs; pad `sorted_weights`**

- Nothing checked that the kernels a tuned config selects actually exist. The tile_n=64 INTERLEAVE bug and the unregistered SEPARATED name were both config-selected kernels no test ever compiled. New test walks every flydsl row of the shipped a16w4 CSVs and asserts the name resolves, that fp4_bf16 stage1 rows are `_gui`, and that `tile_n % 128 == 0`. 75 rows, no GPU allocation — it catches both original names as MISSING.
- `_generate_a16w4_data` bound `sorted_weights_s1/s2` before the padding block, so the kernel got a weights tensor shorter than `sorted_ids` (9462 vs 9472 at E=512/topk=10/token=128). Bind after the pad. Numerically neutral — the shift is inside run-to-run atomic-ordering noise — but the harness should not hand the kernel a short buffer.

## Accuracy Tests

Real **Qwen3.5-397B-A17B-MXFP4** checkpoint weights, layer 0, TP2 shard, 32 tokens, E=512, topk=10, cosine vs torch reference:

| stage | cosine | rel_rms |
|---|---|---|
| stage1 interleave | 1.000000 | 9.09e-10 |
| stage2 interleave | 0.999990 | 4.53e-03 |
| e2e interleave | 0.999990 | 4.54e-03 |

SEPARATED now raises a clear `ValueError` instead of returning cosine 0.0006.

Suites, all on this branch:

- `op_tests/flydsl_tests/` a16w4 + a8w4 + a16wfp4 — **135 passed** (was 58 passed / 2 failed at `db2f0f77`)
- `aiter/ops/flydsl/test_flydsl_moe_a16w4.py --spread-exponents`, E=512 / topk=10 / tokens 1–128 — **12/12**, cosine 0.999988–0.999990

## Benchmarking

Perf-neutral, as expected — the changes are a compile-time raise, a test file, and a branch that could only raise. `fused_moe` at the Qwen3.5 TP2 shape (4096×512, E=512, topk=10), INTERLEAVE, µs/iter over 20 iters:

| tokens | `moe_gemm1_0` before → after | `moe_gemm2_0` before → after |
|---|---|---|
| 4 | 23.65 → 23.54 | 15.69 → 15.66 |
| 128 | 201.22 → 200.50 | 155.51 → 146.44 |

Profiling also confirms the intended kernels are the ones dispatched at this shape — `moe_gemm1_0` / `moe_gemm2_0`, not a CK fallback.

## Checklist

- [x] Pre-commit style followed (no linters available in this container; lines kept ≤88 chars, black-compatible formatting)
- [x] Tests added for the new behaviour
- [x] No perf regression
