### PR TITLE
[FlyDSL] Fused online Hadamard rotation + MXFP4 quantization (flydsl_rot_quant)

### DIFF
--- a/.github/scripts/split_tests.sh
+++ b/.github/scripts/split_tests.sh
@@ -87,6 +87,7 @@ if [[ "$TEST_TYPE" == "aiter" ]]; then
     FILE_TIMES[op_tests/test_gemm_a8w8_blockscale_cktile_aq_rowmajor.py]=96
     FILE_TIMES[op_tests/test_activation.py]=88
     FILE_TIMES[op_tests/test_flydsl_qk_norm_rope_quant.py]=83
+    FILE_TIMES[op_tests/test_flydsl_rot_quant.py]=150
     FILE_TIMES[op_tests/test_moe_topk_gating.py]=83
     FILE_TIMES[op_tests/test_kvcache.py]=68
     FILE_TIMES[op_tests/test_topk_plain.py]=65

--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -57,6 +57,7 @@ if is_flydsl_available():
         flydsl_pa_mqa_logits_fp4_varqlen,
     )
     from .kernels.qk_norm_rope_quant import flydsl_qk_norm_rope_quant
+    from .kernels.rot_quant import flydsl_rot_quant
     from .moe_kernels import flydsl_moe_stage1, flydsl_moe_stage2
 
     # from .linear_attention_kernels import flydsl_gdr_decode
@@ -75,5 +76,6 @@ if is_flydsl_available():
         "flydsl_pa_mqa_logits_fp4_varqlen",
         "flydsl_preshuffle_gemm_a8",
         "flydsl_qk_norm_rope_quant",
+        "flydsl_rot_quant",
         # "flydsl_gdr_decode",
     ]

--- a/aiter/ops/flydsl/kernels/rot_quant.py
+++ b/aiter/ops/flydsl/kernels/rot_quant.py
@@ -1,0 +1,525 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fused online Hadamard rotation + MXFP4 quantization (FlyDSL).
+
+Entry point: ``flydsl_rot_quant(x, RS, ...)`` -- one kernel that block-diagonally
+rotates a bf16 activation, quantizes it to MXFP4 and writes the e8m0 scales,
+optionally already in the CK-gemm swizzle that ``aiter.gemm_a4w4`` consumes.
+
+This is the activation-side counterpart of a rotated (QuaRot/SpinQuant-style) MXFP4
+checkpoint: the offline rotation is folded into the weights, and the matching online
+rotation of the activation has to happen at every layer, every token. Doing it as
+rotate -> pack -> swizzle in three passes costs three round trips through HBM on a
+purely memory-bound op; this fuses all three into one.
+
+Relation to the existing aiter ops:
+  - ``rotate_activation_fp4quant_inplace`` (csrc/kernels/dsv4_rotate_quant.cu) rotates,
+    fp4-quantizes and **dequantizes back to bf16 in place** at a fixed ``dim`` of 128
+    or 256. That is the simulation path; it does not produce a gemm input.
+  - ``dynamic_mxfp4_quant`` produces packed fp4 + e8m0, but does not rotate.
+  - ``shuffle_scale`` re-lays-out the scales in a separate pass.
+This op is the fusion of all three, and is the only one that emits the CK scale
+swizzle from inside the quantizing kernel.
+
+Mapping: work = M * (K//COLS) independent thread-blocks; one thread per COLS-wide
+chunk, which holds COLS//RS independent RS-wide Hadamard blocks (no cross-lane comms).
+The FWHT is scalar-unrolled in registers (Sylvester, ``(a+b, a-b)`` pairing).
+RS=64, COLS=64 => 64 f32 regs/thread.
+
+Requires gfx950: the quantizer is a single ``v_cvt_scalef32_pk_fp4_f32`` per byte.
+
+The e8m0 block scale is the shared ``quant_utils.emit_mx_e8m0_scale`` builder in
+aiter's default ``MxScaleRoundMode.RoundUp`` -- no bespoke scale convention here.
+
+Correctness is covered by ``op_tests/test_flydsl_rot_quant.py``, which checks the
+packed fp4 and the e8m0 scales byte-for-byte against a torch reference, the fused
+swizzle against ``aiter.ops.shuffle.shuffle_scale``, and the whole thing end-to-end
+through ``gemm_a4w4``.
+"""
+
+# NOTE: do NOT add `from __future__ import annotations` to this file.
+# PEP 563 turns all annotations into strings, which defeats flydsl's
+# JitFunction._make_cache_key runtime detection:
+#   is_runtime = hasattr(ann, "__get_c_pointers__")
+# A string like 'fx.Int32' fails that check, so flydsl would treat the
+# `total_blocks` Int32 parameter as a compile-time constant and embed its
+# VALUE in the cache key -- every distinct M would then trigger a fresh
+# JIT compile instead of hitting the in-memory CallState cache.
+
+import math
+from functools import lru_cache
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+import torch
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import arith as A
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith, const_expr, range_constexpr
+from flydsl.expr.arith import ArithValue, CmpIPredicate
+from flydsl.expr.typing import BFloat16, Float32, Int32, T, Vector
+from flydsl.runtime.device import get_rocm_arch
+
+from aiter.ops.flydsl.kernels import buffer_ops, vector
+
+# Only the bare-int mirrors are imported here: the pybind11 MxScaleRoundMode /
+# MxDtype in the same module lazy-load module_aiter_core on attribute access,
+# which is incompatible with the FlyDSL AOT pass in setup.py (see quant_utils).
+from aiter.ops.flydsl.kernels.quant_utils import emit_mx_e8m0_scale
+from aiter.utility.mx_types import MX_DEFAULT_ROUND_MODE as _DEFAULT_MODE
+from aiter.utility.mx_types import MxDtypeInt as _D
+
+from .tensor_shim import _run_compiled, _to_raw
+
+QG = 32  # mxfp4 group size
+LVEC = 8  # bf16 buffer_load width (128-bit loads)
+SUPPORTED_RS = (32, 64, 128)
+
+
+def _ic(v):
+    return A.ConstantOp(T.i32, ir.IntegerAttr.get(T.i32, v)).result
+
+
+def _fabs_raw(x):
+    xi = A.BitcastOp(T.i32, _to_raw(x)).result
+    m = A.AndIOp(xi, _ic(0x7FFFFFFF)).result
+    return A.BitcastOp(T.f32, m).result
+
+
+def _amax_raw(nums, tree=False):
+    """abs-max over a group. ``tree`` uses a balanced reduction (shorter dep
+    chain -> lower latency); bit-exact vs the chain form because max over the
+    non-negative |v| is associative/commutative (no NaN, +0 only)."""
+    absv = [_fabs_raw(t) for t in nums]
+    if not tree:
+        acc = absv[0]
+        for t in absv[1:]:
+            acc = A.MaximumFOp(acc, t).result
+        return acc
+    level = absv
+    while len(level) > 1:
+        nxt = []
+        for i in range(0, len(level) - 1, 2):
+            nxt.append(A.MaximumFOp(level[i], level[i + 1]).result)
+        if len(level) & 1:
+            nxt.append(level[-1])
+        level = nxt
+    return level[0]
+
+
+def _e8m0_and_scale(amax_raw, fold_k=0):
+    """Return (e8m0_i8_raw, hw_scale_f32_raw) for one mxfp4 group.
+
+    The scale itself is the shared ``emit_mx_e8m0_scale`` builder in aiter's
+    default ``RoundUp`` mode (``ceil_pow2(amax / 6)``) -- this op has no scale
+    convention of its own.
+
+    ``fold_k`` folds a global 2**(-fold_k) activation scale (the 1/sqrt(RS) FWHT
+    normalization, when it is an exact power of two) into the exponent instead of a
+    per-element float multiply. RoundUp is exponent-linear, so scaling the input by
+    a power of two is exactly a shift of the result:
+      stored e8m0 = max(e8m0(amax) - fold_k, 0)
+      pack scale  = 2**(stored_e8m0 + fold_k - 127)     (so cvt(v, scale) ==
+                                                         cvt(v * 2**-fold_k, 2**e8m0))
+    fold_k=0 is the unfolded form (values pre-scaled by a float multiply instead).
+    """
+    e8 = _to_raw(
+        emit_mx_e8m0_scale(ArithValue(amax_raw), mode=_DEFAULT_MODE, dtype=_D.FP4_E2M1)
+    )
+    if fold_k:
+        e8 = A.MaxSIOp(A.SubIOp(e8, _ic(fold_k)).result, _ic(0)).result
+        hs = A.ShLIOp(A.AddIOp(e8, _ic(fold_k)).result, _ic(23)).result
+    else:
+        hs = A.ShLIOp(e8, _ic(23)).result
+    e8_i8 = A.TruncIOp(T.i8, e8).result
+    hw = A.BitcastOp(T.f32, hs).result
+    return e8_i8, hw
+
+
+def _bits(v, shift, mask=None):
+    """(v >> shift) & mask on raw i32 values; ``mask=None`` skips the AND (the
+    high bits are already known zero), so no extra op is emitted."""
+    if shift:
+        v = A.ShRUIOp(v, _ic(shift)).result
+    return A.AndIOp(v, _ic(mask)).result if mask is not None else v
+
+
+def _horner(acc, terms):
+    """acc = ((acc*m0 + a0)*m1 + a1)... over ``terms`` = [(mul, add), ...]."""
+    for mul, add in terms:
+        acc = A.AddIOp(A.MulIOp(acc, _ic(mul)).result, add).result
+    return acc
+
+
+def _pack4_i32(bytes4):
+    """Pack 4 i8 raw values into one i32 (little-endian: b0 | b1<<8 | ...)."""
+    acc = A.AndIOp(A.ExtUIOp(T.i32, bytes4[0]).result, _ic(0xFF)).result
+    for k in range(1, 4):
+        bk = A.AndIOp(A.ExtUIOp(T.i32, bytes4[k]).result, _ic(0xFF)).result
+        bk = A.ShLIOp(bk, _ic(8 * k)).result
+        acc = A.OrIOp(acc, bk).result
+    return acc
+
+
+def _pack_fp4(even_raw, odd_raw, hw_scale_raw):
+    """v_cvt_scalef32_pk_fp4_f32: pack (even,odd) f32 -> byte (2x fp4), given scale."""
+    packed = _llvm.inline_asm(
+        T.i32,
+        [even_raw, odd_raw, hw_scale_raw],
+        "v_cvt_scalef32_pk_fp4_f32 $0, $1, $2, $3",
+        "=v,v,v,v",
+        has_side_effects=False,
+    )
+    return A.TruncIOp(T.i8, packed).result
+
+
+def _fwht_stage(vals, G, H):
+    """One Sylvester FWHT stage: pair (lo, lo+H) -> (a+b, a-b)."""
+    W = G * 2 * H
+    out = [None] * W
+    for g in range(G):
+        base = g * 2 * H
+        for h in range(H):
+            lo = base + h
+            hi = lo + H
+            a, b = vals[lo], vals[hi]
+            out[lo] = a + b
+            out[hi] = a - b
+    return out
+
+
+def _fwht(vals, RS):
+    stages = {
+        32: [(16, 1), (8, 2), (4, 4), (2, 8), (1, 16)],
+        64: [(32, 1), (16, 2), (8, 4), (4, 8), (2, 16), (1, 32)],
+        128: [(64, 1), (32, 2), (16, 4), (8, 8), (4, 16), (2, 32), (1, 64)],
+    }[RS]
+    for G, H in stages:
+        vals = _fwht_stage(vals, G, H)
+    return vals
+
+
+def _vec_i32(words):
+    """Build a vector<len x i32> MLIR value from a list of i32 raw values."""
+    vty = T.vec(len(words), T.i32)
+    return vector.from_elements(vty, [_to_raw(w) for w in words])
+
+
+def _build_rot_quant(
+    K: int,
+    RS: int,
+    BLOCK: int,
+    COLS: int | None = None,
+    SVEC: int = 1,
+    AMAX: str = "tree",
+    SHUF: bool = False,
+):
+    # Each thread owns COLS contiguous cols = NG independent RS-blocks (COLS batching
+    # -> longer HBM bursts). COLS must be a multiple of RS, QG and LVEC.
+    if COLS is None:
+        COLS = RS
+    assert COLS % RS == 0 and COLS % QG == 0 and COLS % LVEC == 0 and K % COLS == 0
+    NG = COLS // RS  # RS-blocks per thread
+    NUM_QG = COLS // QG  # mxfp4 groups per thread
+    HALF = COLS // 2  # fp4 bytes per thread
+    NW = HALF // 4  # i32 store words
+    NLOAD = COLS // LVEC  # vec8 loads per thread
+    assert NW % SVEC == 0, f"NW={NW} not divisible by SVEC={SVEC}"
+    # SHUF: write e8m0 scales directly at the canonical CK-gemm shuffle offset
+    # (see aiter.ops.shuffle.shuffle_scale) instead of the natural [M, K/32] layout,
+    # fusing the scale swizzle into this kernel -- no separate shuffle pass and no
+    # padding-tile zeroing, since the pad cells are don't-care (the CK gemm slices
+    # its output back to [:M]).
+    NBCOL = K // COLS  # COLS-wide col-chunks per row (== scale-col/NUM_QG)
+    SN = ((K // QG) + 7) // 8 * 8  # padded scale-col count (ceil8), constexpr
+    SN8 = SN // 8
+    rs_scale = 1.0 / math.sqrt(RS)
+    _hl = 0.5 * math.log2(RS)
+    fold = float(_hl).is_integer()
+    fold_k = int(_hl) if fold else 0
+
+    @flyc.kernel(known_block_size=[BLOCK, 1, 1])
+    def rq_kernel(
+        x_ptr: fx.Tensor,
+        fp4_ptr: fx.Tensor,
+        sc_ptr: fx.Tensor,
+        total_blocks: Int32,
+    ):
+        i32 = T.i32
+        bid = ArithValue(fx.block_idx.x)
+        tid = ArithValue(fx.thread_idx.x)
+        gid = bid * arith.constant(BLOCK, type=i32) + tid
+
+        tb = _to_raw(total_blocks)
+        x_nb = A.MulIOp(tb, _ic(COLS * 2)).result  # bf16 bytes
+        fp4_nb = A.MulIOp(tb, _ic(HALF)).result  # fp4 bytes
+        if const_expr(SHUF):
+            # padded [sm, sn] scale buffer: bound to sm*sn bytes (sm=ceil256(M), sn
+            # constexpr) so out-of-range lanes' scattered stores are dropped by the
+            # buffer descriptor. M = total_blocks // NBCOL.
+            m_tot = A.DivUIOp(tb, _ic(NBCOL)).result
+            m_pad = A.ShLIOp(
+                A.ShRUIOp(A.AddIOp(m_tot, _ic(255)).result, _ic(8)).result, _ic(8)
+            ).result
+            sc_nb = A.MulIOp(m_pad, _ic(SN)).result
+        else:
+            sc_nb = A.MulIOp(tb, _ic(NUM_QG)).result  # natural [M, K/32] e8m0 bytes
+        x_rsrc = buffer_ops.create_buffer_resource(
+            x_ptr, max_size=False, num_records_bytes=x_nb
+        )
+        fp4_rsrc = buffer_ops.create_buffer_resource(
+            fp4_ptr, max_size=False, num_records_bytes=fp4_nb
+        )
+        sc_rsrc = buffer_ops.create_buffer_resource(
+            sc_ptr, max_size=False, num_records_bytes=sc_nb
+        )
+
+        in_range = arith.cmpi(CmpIPredicate.slt, gid, total_blocks)
+        blk_off = gid * arith.constant(COLS, type=i32)
+
+        # wide vec8 loads of COLS contiguous bf16 -> f32 scalars
+        vals = []
+        for v in range_constexpr(NLOAD):
+            off = blk_off + arith.constant(v * LVEC, type=i32)
+            off = arith.select(in_range, off, arith.constant(0, type=i32))
+            vec = buffer_ops.buffer_load(x_rsrc, off, vec_width=LVEC, dtype=T.bf16)
+            vecw = Vector(vec, (LVEC,), BFloat16)
+            for e in range_constexpr(LVEC):
+                vals.append(vecw[e].to(Float32))
+
+        # FWHT per RS sub-block (block-diagonal Hadamard)
+        for n in range_constexpr(NG):
+            vals[n * RS : (n + 1) * RS] = _fwht(vals[n * RS : (n + 1) * RS], RS)
+
+        if const_expr(fold):
+            vals = [x.to(BFloat16).to(Float32) for x in vals]
+        else:
+            sc = Float32(rs_scale)
+            vals = [(x * sc).to(BFloat16).to(Float32) for x in vals]
+
+        # per-group quant -> fp4 bytes + e8m0 scales
+        fp4_bytes = []
+        sc_bytes = []
+        for g in range_constexpr(NUM_QG):
+            grp = vals[g * QG : (g + 1) * QG]
+            amax = _amax_raw(grp, tree=(AMAX == "tree"))
+            e8_i8, hw = _e8m0_and_scale(amax, fold_k)
+            sc_bytes.append(e8_i8)
+            for p in range_constexpr(QG // 2):
+                even = _to_raw(grp[2 * p])
+                odd = _to_raw(grp[2 * p + 1])
+                fp4_bytes.append(_pack_fp4(even, odd, hw))
+
+        rng = _to_raw(in_range)
+        words = [
+            _pack4_i32(fp4_bytes[c * 4 : (c + 1) * 4]) for c in range_constexpr(NW)
+        ]
+        fp4_base = gid * arith.constant(NW, type=i32)
+        for s in range_constexpr(NW // SVEC):
+            off = fp4_base + arith.constant(s * SVEC, type=i32)
+            if const_expr(SVEC == 1):
+                buffer_ops.buffer_store(words[s], fp4_rsrc, off, mask=rng)
+            else:
+                vec = _vec_i32(words[s * SVEC : (s + 1) * SVEC])
+                buffer_ops.buffer_store(vec, fp4_rsrc, off, mask=rng)
+
+        if const_expr(SHUF):
+            # Scatter each e8m0 byte to its canonical shuffle_scale offset:
+            #   m = gid // NBCOL ; cb = gid % NBCOL ; n = cb*NUM_QG + q
+            #   m0=m>>5, ma=(m>>4)&1, m2=m&15 ; k0=n>>3, ka=(n>>2)&1, k2=n&3
+            #   dest = ((((m0*SN8 + k0)*4 + k2)*16 + m2)*2 + ka)*2 + ma
+            gidr = _to_raw(gid)
+            m_idx = A.DivUIOp(gidr, _ic(NBCOL)).result
+            cb = A.RemUIOp(gidr, _ic(NBCOL)).result
+            m0, ma, m2 = _bits(m_idx, 5), _bits(m_idx, 4, 1), _bits(m_idx, 0, 15)
+            for q in range_constexpr(NUM_QG):
+                n = A.AddIOp(A.MulIOp(cb, _ic(NUM_QG)).result, _ic(q)).result
+                k0, ka, k2 = _bits(n, 3), _bits(n, 2, 1), _bits(n, 0, 3)
+                off = _horner(m0, [(SN8, k0), (4, k2), (16, m2), (2, ka), (2, ma)])
+                buffer_ops.buffer_store(sc_bytes[q], sc_rsrc, ArithValue(off), mask=rng)
+        else:
+            sc_base = gid * arith.constant(NUM_QG, type=i32)
+            for q in range_constexpr(NUM_QG):
+                off = sc_base + arith.constant(q, type=i32)
+                buffer_ops.buffer_store(sc_bytes[q], sc_rsrc, off, mask=rng)
+
+    @flyc.jit
+    def launch(
+        x_ptr: fx.Tensor,
+        fp4_ptr: fx.Tensor,
+        sc_ptr: fx.Tensor,
+        total_blocks: fx.Int32,
+        grid_x: fx.Int32,
+        stream: fx.Stream = fx.Stream(  # noqa: B008  framework idiom: default is evaluated once at import on purpose
+            None
+        ),
+    ):
+        gx = arith.index_cast(T.index, grid_x)
+        rq_kernel(x_ptr, fp4_ptr, sc_ptr, total_blocks).launch(
+            grid=(gx, 1, 1), block=(BLOCK, 1, 1), stream=stream
+        )
+
+    return launch
+
+
+@lru_cache(maxsize=32)
+def compile_flydsl_rot_quant(
+    *,
+    K: int,
+    RS: int,
+    BLOCK: int,
+    COLS: int,
+    SVEC: int,
+    AMAX: str,
+    shuffle_scales: bool,
+    WAVES: int | None = None,
+    MAXNREG: int | None = None,
+):
+    """Compile (and cache) the launcher for one kernel config.
+
+    Returns the ``@flyc.jit`` launcher; call it directly if you have already
+    allocated the outputs and want to skip the torch-side work in
+    :func:`flydsl_rot_quant`.
+    """
+    launcher = _build_rot_quant(K, RS, BLOCK, COLS, SVEC, AMAX, SHUF=shuffle_scales)
+    hints = {}
+    if WAVES:
+        hints["waves_per_eu"] = WAVES
+    if MAXNREG:
+        hints["maxnreg"] = MAXNREG
+    if hints:
+        launcher.compile_hints = hints
+    return launcher
+
+
+def _pick_svec(COLS):
+    """Widest i32 store vector (4 -> 128-bit) that divides the per-thread word count."""
+    nw = (COLS // 2) // 4
+    return next(s for s in (4, 2, 1) if nw % s == 0)
+
+
+def _pick_block(M, K):
+    """CTA size (threads/block) as a function of M, swept on MI350X gfx950.
+
+    At prefill/mid batch (M>=1024) a 4-warp BLOCK=256 is a consistent 10-14% win
+    over the single-warp BLOCK=64: larger CTAs keep more wide loads in flight and
+    amortize launch/setup on this load-bound kernel. Decode / small prefill
+    (M<=512) still prefers BLOCK=64 (more, smaller CTAs -> better memory-latency
+    hiding). Large prefill (M>=4096) squeezes a further ~1-3% with an 8-warp
+    BLOCK=512. These are gfx950 numbers; pass ``BLOCK=`` explicitly to override.
+    """
+    if M >= 4096:
+        return 512
+    if M >= 1024:
+        return 256
+    return 64
+
+
+def flydsl_rot_quant(
+    x,
+    RS=64,
+    BLOCK=None,
+    COLS=None,
+    SVEC=None,
+    AMAX="tree",
+    WAVES=None,
+    MAXNREG=None,
+    shuffle_scales=False,
+):
+    """Fused online Hadamard rotation + MXFP4 quantization.
+
+    Args:
+      x: bf16, **contiguous**, [M, K] (2D only -- reshape 3D activations first).
+         Both are load-bearing: the kernel hardcodes bf16 buffer loads and computes
+         element offsets linearly, so a fp16 or strided input would silently yield
+         garbage. Both are checked below.
+      RS: rotation size, one of {32, 64, 128}; K must be a multiple of it. The
+         rotation is block-diagonal: K//RS independent RS-wide Hadamard blocks,
+         each normalized by 1/sqrt(RS).
+      shuffle_scales: emit the e8m0 scales already in the CK-gemm swizzle
+         (``aiter.ops.shuffle.shuffle_scale`` layout) instead of the natural one.
+         See the return contract below -- this changes the scale tensor's shape.
+      BLOCK/COLS/SVEC/AMAX/WAVES/MAXNREG: tuning knobs; ``None`` picks the gfx950
+         defaults (BLOCK adaptive per M -- see _pick_block; COLS=RS; SVEC=4 for
+         128-bit stores; AMAX="tree", a balanced abs-max reduction with a shorter
+         dep chain, ~2-3% over the chain form and bit-identical to it).
+         WAVES/MAXNREG are compile hints (--amdgpu-waves-per-eu / --amdgpu-num-vgpr);
+         measured to give no gain on gfx950 (the kernel already saturates HBM with
+         many small CTAs) but kept for other shapes/hardware.
+
+    Returns:
+      (fp4, scales).
+      fp4: uint8 [M, K//2], two fp4 (e2m1) values per byte, low nibble first.
+      scales: uint8 e8m0.
+        shuffle_scales=False -> [M, K//32], the natural per-32-element layout.
+        shuffle_scales=True  -> **[ceil256(M), ceil8(K//32)]**, CK swizzle. The
+          padding cells are *uninitialized* (torch.empty, same as
+          ``shuffle_scale``): the CK gemm reads them but slices its output back to
+          [:M], so they are don't-care. Do not compare, print or reuse them.
+
+    Example:
+        >>> xq, xs = flydsl_rot_quant(x, RS=64, shuffle_scales=True)
+        >>> y = gemm_a4w4(xq, shuffle_weight(wq, layout=(16, 16)), xs,
+        ...               shuffle_scale(ws), dtype=torch.bfloat16)[:M]
+    """
+    if RS not in SUPPORTED_RS:
+        raise ValueError(f"RS must be one of {SUPPORTED_RS}, got {RS}")
+    if x.dim() != 2:
+        raise ValueError(f"x must be 2D [M, K], got shape {tuple(x.shape)}")
+    M, K = x.shape
+    if K % RS:
+        raise ValueError(f"K={K} must be a multiple of RS={RS}")
+    # The kernel hardcodes bf16 loads and linear (contiguous) element offsets.
+    # Without these two checks a wrong dtype/layout produces garbage silently --
+    # no error, no warning, and the fp4 output still "looks" plausible.
+    if x.dtype is not torch.bfloat16:
+        raise ValueError(f"x must be bf16, got {x.dtype}")
+    if not x.is_contiguous():
+        raise ValueError("x must be contiguous")
+    if AMAX not in ("tree", "chain"):
+        raise ValueError(f"AMAX must be 'tree' or 'chain', got {AMAX!r}")
+    arch = get_rocm_arch()
+    if not str(arch).startswith("gfx950"):
+        raise RuntimeError(
+            "flydsl_rot_quant requires gfx950 (v_cvt_scalef32_pk_fp4_f32 MXFP4 "
+            f"microscaling); got {arch}"
+        )
+    if BLOCK is None:
+        BLOCK = _pick_block(M, K)
+    if COLS is None:
+        # COLS batching (>1 RS-block per thread) was measured to give no benefit on
+        # gfx950: the kernel is load-bound and the vec8 loads already saturate the
+        # burst, so COLS=RS with many small CTAs wins. _build_rot_quant still takes
+        # COLS for other hardware.
+        COLS = RS
+    if SVEC is None:
+        SVEC = _pick_svec(COLS)
+    total_blocks = M * (K // COLS)
+    grid_x = (total_blocks + BLOCK - 1) // BLOCK
+    fp4 = torch.empty((M, K // 2), dtype=torch.uint8, device=x.device)
+    if shuffle_scales:
+        # Fused in-kernel CK-gemm scale swizzle: allocate the padded [sm, sn]
+        # buffer the kernel scatters into. Padding cells are don't-care
+        # (torch.empty, like shuffle_scale) -- the CK gemm slices output to [:M].
+        n = K // QG
+        sm = (M + 255) // 256 * 256
+        sn = (n + 7) // 8 * 8
+        sc = torch.empty((sm, sn), dtype=torch.uint8, device=x.device)
+    else:
+        sc = torch.empty((M, K // QG), dtype=torch.uint8, device=x.device)
+    launcher = compile_flydsl_rot_quant(
+        K=K,
+        RS=RS,
+        BLOCK=BLOCK,
+        COLS=COLS,
+        SVEC=SVEC,
+        AMAX=AMAX,
+        shuffle_scales=shuffle_scales,
+        WAVES=WAVES,
+        MAXNREG=MAXNREG,
+    )
+    _run_compiled(
+        launcher, x, fp4, sc, total_blocks, grid_x, torch.cuda.current_stream()
+    )
+    return fp4, sc

--- a/op_tests/test_flydsl_rot_quant.py
+++ b/op_tests/test_flydsl_rot_quant.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for ``flydsl_rot_quant`` -- fused online Hadamard rotation + MXFP4 quant.
+
+Three independent things are checked, because each has its own failure mode and
+all three fail *silently* (plausible-looking numbers, no exception):
+
+1. ``test_rot_quant_bitexact`` -- packed fp4 and e8m0 scales byte-for-byte against
+   a pure-torch reference (``_ref_rot_quant`` below). Byte equality, not allclose:
+   the kernel's claim is bit-exactness, and allclose would hide a systematic
+   off-by-one-binade scale bug.
+2. ``test_rot_quant_fused_shuffle`` -- the in-kernel CK scale swizzle against
+   ``aiter.ops.shuffle.shuffle_scale`` applied to the natural-layout output.
+   Compared only on the unpadded region; the padding cells are ``torch.empty``.
+3. ``test_rot_quant_gemm_a4w4`` -- end-to-end through ``gemm_a4w4``, the consumer
+   the swizzle exists for. A layout mismatch between quantizer and gemm produces
+   garbage output with no error, so unit-level parity alone is not sufficient
+   evidence that the op works.
+
+Plus ``test_rot_quant_rejects_bad_input``: the input contract is load-bearing
+(fp16 or a strided view would be read as contiguous bf16 and silently yield
+garbage), so the guards must raise rather than compute.
+"""
+
+import argparse
+import math
+
+import torch
+
+from aiter import dtypes
+from aiter.ops.flydsl import flydsl_rot_quant
+from aiter.ops.shuffle import shuffle_scale, shuffle_weight
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+from aiter.utility.fp4_utils import (
+    f32_to_mx_e8m0_scale,
+    f32_to_mxfp4,
+    mxfp4_to_f32,
+)
+from aiter.utility.mx_types import MX_DEFAULT_ROUND_MODE, MxDtypeInt
+
+QG = 32  # mxfp4 group size
+
+# aiter's CK asm gemm_a4w4 is numerically wrong below this N (rel err ~0.94 at
+# N=64, exact at N>=512), so it is not usable as a reference there. The op itself
+# is fine at any N -- this bound is a property of the gemm, not the quantizer.
+CK_MIN_N = 512
+
+
+def _ref_rot_quant(x, RS):
+    """Pure-torch reference for ``flydsl_rot_quant(..., shuffle_scales=False)``.
+
+    Mirrors the kernel step for step so the comparison can be exact:
+
+    * Sylvester FWHT over each RS-wide block, stage order ``h = 1, 2, ... RS/2``,
+      pairing ``(lo, lo+h) -> (a+b, a-b)``. Same op order => same f32 rounding.
+    * The ``1/sqrt(RS)`` normalization is folded into the e8m0 exponent when
+      ``log2(RS)/2`` is an integer (i.e. RS=64), and applied as an f32 multiply
+      otherwise (RS=32, 128). Either way the result is round-tripped through
+      bf16, matching the kernel's ``.to(BFloat16).to(Float32)``.
+    * The block scale is aiter's default MXFP4 convention, taken from the shared
+      ``f32_to_mx_e8m0_scale(mode=RoundUp, dtype=FP4_E2M1)`` = ``ceil_pow2(amax/6)``
+      helper -- the CPU mirror of the ``emit_mx_e8m0_scale`` IR builder the kernel
+      itself uses. ``fold_k`` is then subtracted from the exponent (clamped at 0),
+      which is exact because RoundUp is exponent-linear.
+    """
+    M, K = x.shape
+    v = x.float().view(M, K // RS, RS)
+    h = 1
+    while h < RS:
+        t = v.reshape(M, K // RS, RS // (2 * h), 2, h)
+        a, b = t[..., 0, :], t[..., 1, :]
+        v = torch.stack([a + b, a - b], dim=-2).reshape(M, K // RS, RS)
+        h *= 2
+
+    hl = 0.5 * math.log2(RS)
+    fold_k = int(hl) if float(hl).is_integer() else 0
+    if not fold_k:
+        v = v * (1.0 / math.sqrt(RS))
+    v = v.to(torch.bfloat16).float().reshape(M, K)
+
+    g = v.reshape(M, K // QG, QG)
+    amax = g.abs().amax(dim=-1).float()
+    e8 = (
+        f32_to_mx_e8m0_scale(
+            amax, mode=MX_DEFAULT_ROUND_MODE, dtype=MxDtypeInt.FP4_E2M1
+        )
+        .view(torch.uint8)
+        .to(torch.int32)
+    )
+    if fold_k:
+        e8 = torch.clamp(e8 - fold_k, min=0)
+    hw = ((e8 + fold_k) << 23).view(torch.float32)
+
+    fp4 = f32_to_mxfp4((g / hw.unsqueeze(-1)).reshape(M, K)).view(torch.uint8)
+    return fp4, e8.to(torch.uint8)
+
+
+def _dequant(fp4, scales):
+    """Unpack (fp4, natural-layout e8m0) back to f32 for the gemm reference."""
+    vals = mxfp4_to_f32(fp4).float()
+    exp = scales.to(torch.int32).repeat_interleave(QG, dim=-1)
+    return vals * torch.exp2((exp - 127).float())
+
+
+def _inputs(M, K, seed=0, outliers=False):
+    torch.manual_seed(seed)
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16) * 0.5
+    if outliers:
+        # Force the top of the fp4 range: RoundUp puts amax at (3, 6], so a group
+        # whose rounding lands high drives elements right up against the 6.0
+        # saturation point, which is where an encoder that clamps differently
+        # from the hardware would diverge.
+        x[:, ::37] *= 64
+    return x
+
+
+@benchmark()
+def test_rot_quant_bitexact(M, K, RS, outliers=False):
+    """fp4 bytes and e8m0 scales must match the torch reference exactly."""
+    x = _inputs(M, K, outliers=outliers)
+    (fp4, scales), us = run_perftest(flydsl_rot_quant, x, RS)
+    ref_fp4, ref_scales = _ref_rot_quant(x, RS)
+
+    n_fp4 = (fp4 != ref_fp4).sum().item()
+    n_sc = (scales != ref_scales).sum().item()
+    assert n_fp4 == 0, f"{n_fp4}/{fp4.numel()} fp4 bytes differ (M={M} K={K} RS={RS})"
+    assert (
+        n_sc == 0
+    ), f"{n_sc}/{scales.numel()} scale bytes differ (M={M} K={K} RS={RS})"
+    assert fp4.shape == (M, K // 2) and scales.shape == (M, K // QG)
+
+    gbps = (x.numel() * 2 + fp4.numel() + scales.numel()) / us / 1e3
+    return {"us": us, "GB/s": gbps}
+
+
+def test_rot_quant_fused_shuffle(M, K, RS):
+    """The in-kernel CK swizzle must equal shuffle_scale() of the natural layout.
+
+    Only the unpadded ``[M, K//QG]`` region is compared: the kernel allocates the
+    padded buffer with ``torch.empty`` and never writes the pad cells (the gemm
+    slices its output to ``[:M]``), so a full-tensor compare would read
+    uninitialized memory and flake.
+    """
+    x = _inputs(M, K)
+    fp4_nat, sc_nat = flydsl_rot_quant(x, RS, shuffle_scales=False)
+    fp4_shf, sc_shf = flydsl_rot_quant(x, RS, shuffle_scales=True)
+
+    assert torch.equal(
+        fp4_nat, fp4_shf
+    ), "fp4 output must not depend on the scale layout"
+
+    n = K // QG
+    sm, sn = (M + 255) // 256 * 256, (n + 7) // 8 * 8
+    assert sc_shf.shape == (
+        sm,
+        sn,
+    ), f"expected padded {(sm, sn)}, got {tuple(sc_shf.shape)}"
+
+    ref = shuffle_scale(sc_nat).view(sm, sn)
+    # Which destination cells carry real data. ``shuffle_scale`` pads with
+    # ``torch.empty``, so the mask cannot be recovered from its output -- push a
+    # deterministic 0/1 mask through the same reshape/permute instead.
+    mask = torch.zeros((sm, sn), dtype=torch.uint8, device=sc_nat.device)
+    mask[:M, :n] = 1
+    live = (
+        mask.view(sm // 32, 2, 16, sn // 8, 2, 4)
+        .permute(0, 3, 5, 2, 4, 1)
+        .reshape(sm, sn)
+        != 0
+    )
+    assert live.sum().item() == M * n, "mask permutation does not preserve the payload"
+    n_diff = ((sc_shf != ref) & live).sum().item()
+    assert n_diff == 0, f"{n_diff}/{live.sum().item()} live scale bytes differ"
+    print(f"✓ fused swizzle == shuffle_scale (M={M} K={K} RS={RS})")
+
+
+def test_rot_quant_gemm_a4w4(M, N, K, RS):
+    """End-to-end: quantize with the fused swizzle, feed the CK asm gemm."""
+    if N < CK_MIN_N:
+        print(f"skip N={N}: gemm_a4w4 is not a valid reference below N={CK_MIN_N}")
+        return
+    from aiter import gemm_a4w4
+    from aiter.utility.fp4_utils import dynamic_mxfp4_quant
+
+    x = _inputs(M, K)
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16) * 0.1
+    wq, ws = dynamic_mxfp4_quant(w)
+
+    xq, xs = flydsl_rot_quant(x, RS, shuffle_scales=True)
+    out = gemm_a4w4(
+        xq,
+        shuffle_weight(wq, layout=(16, 16)),
+        xs,
+        shuffle_scale(ws),
+        dtype=dtypes.bf16,
+    )[:M]
+
+    # Reference: dequantize the same bytes the gemm consumed and matmul in f32.
+    # This isolates the gemm/layout contract -- quantization error is already
+    # accounted for because both sides start from the identical fp4 payload.
+    xq_nat, xs_nat = flydsl_rot_quant(x, RS, shuffle_scales=False)
+    ref = (
+        _dequant(xq_nat, xs_nat)
+        @ _dequant(wq.view(torch.uint8), ws.view(torch.uint8)).T
+    )
+
+    checkAllclose(
+        out.float(), ref, rtol=1e-2, atol=1e-2, msg=f"M={M} N={N} K={K} RS={RS}"
+    )
+
+
+def test_rot_quant_rejects_bad_input():
+    """Guards must raise. Each of these would otherwise be read as contiguous
+    bf16 and produce plausible garbage."""
+    K = 4096
+    good = torch.randn(64, K, device="cuda", dtype=torch.bfloat16)
+    cases = [
+        ("fp16 input", lambda: flydsl_rot_quant(good.half(), 64)),
+        ("fp32 input", lambda: flydsl_rot_quant(good.float(), 64)),
+        ("non-contiguous", lambda: flydsl_rot_quant(good.t().contiguous().t(), 64)),
+        ("3D input", lambda: flydsl_rot_quant(good.view(2, 32, K), 64)),
+        ("K % RS != 0", lambda: flydsl_rot_quant(good[:, :100].contiguous(), 64)),
+        ("unsupported RS", lambda: flydsl_rot_quant(good, 16)),
+        ("bad AMAX", lambda: flydsl_rot_quant(good, 64, AMAX="fastest")),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except (ValueError, RuntimeError):
+            continue
+        raise AssertionError(f"{name}: expected a raise, got a result")
+    print(f"✓ all {len(cases)} input guards raise")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="flydsl_rot_quant: fused Hadamard rotation + MXFP4 quant"
+    )
+    parser.add_argument("-m", type=int, default=None, help="M dimension (rows)")
+    parser.add_argument("-n", type=int, default=None, help="N dimension (gemm test)")
+    parser.add_argument("-k", type=int, default=None, help="K dimension (cols)")
+    parser.add_argument("-r", "--rs", type=int, default=None, help="rotation size")
+    args = parser.parse_args()
+
+    l_m = [args.m] if args.m else [1, 32, 256, 1024, 4096, 16384]
+    l_k = [args.k] if args.k else [2048, 4096]
+    l_rs = [args.rs] if args.rs else [32, 64, 128]
+    l_n = [args.n] if args.n else [512, 4096, 4608]
+
+    for RS in l_rs:
+        for K in l_k:
+            for M in l_m:
+                test_rot_quant_bitexact(M, K, RS)
+    # Outlier pass: drives the saturating top of the fp4 range.
+    for RS in l_rs:
+        test_rot_quant_bitexact(1024, 4096, RS, outliers=True)
+
+    for RS in l_rs:
+        for M in [1, 32, 256, 1024, 4096]:
+            test_rot_quant_fused_shuffle(M, 4096, RS)
+
+    for N in l_n:
+        for M in [1, 32, 1024]:
+            test_rot_quant_gemm_a4w4(M, N, 4096, 64)
+
+    test_rot_quant_rejects_bad_input()


### PR DESCRIPTION
# [FlyDSL] Fused online Hadamard rotation + MXFP4 quantization (`flydsl_rot_quant`)

## What

Adds `aiter.ops.flydsl.flydsl_rot_quant(x, RS, shuffle_scales=)` — a single gfx950
kernel that takes a bf16 activation, applies a block-diagonal Hadamard rotation,
quantizes to MXFP4, and writes the e8m0 scales, optionally already in the CK-gemm
swizzle that `gemm_a4w4` consumes.

```python
from aiter.ops.flydsl import flydsl_rot_quant

xq, xs = flydsl_rot_quant(x, RS=64, shuffle_scales=True)
y = gemm_a4w4(xq, shuffle_weight(wq, layout=(16, 16)), xs,
              shuffle_scale(ws), dtype=torch.bfloat16)[:M]
```

## Why

Rotated MXFP4 checkpoints (QuaRot / SpinQuant style, as produced by Quark) fold the
offline rotation into the weights. The matching **online** rotation of the activation
then has to run at every projection, every layer, every token. Written with today's
aiter ops that is three passes over HBM on a purely memory-bound op:

| step | today | this PR |
|---|---|---|
| rotate | (no aiter op at RS=64 — a torch blockwise Hadamard matmul) | fused |
| pack MXFP4 + e8m0 | `dynamic_mxfp4_quant` | fused |
| scale swizzle for `gemm_a4w4` | `shuffle_scale` | fused |

### Relation to existing ops — this is a gap, not a duplicate

- `rotate_activation_fp4quant_inplace` (`csrc/kernels/dsv4_rotate_quant.cu`) rotates,
  fp4-quantizes and **dequantizes back to bf16 in place**, at a fixed `dim` of 128 or
  256. That is the simulation/QAT path; it does not produce a gemm input.
- `dynamic_mxfp4_quant` produces packed fp4 + e8m0, but does not rotate.
- `shuffle_scale` re-lays-out the scales in a separate pass.

Nothing currently produces *rotated, packed fp4 + e8m0 scales* in one launch, and
nothing emits the CK scale swizzle from inside the quantizing kernel.

## Performance

MI350X (gfx950), K=4096, RS=64, CUDA-graph timed, 50 launches per replay.
Baseline is the three-pass path above (torch blockwise Hadamard +
`dynamic_mxfp4_quant` + `shuffle_scale`).

| M | 3-pass (µs) | fused (µs) | speedup | fused GB/s |
|---:|---:|---:|---:|---:|
| 1 | 12.46 | 2.80 | 4.46× | 4 |
| 32 | 12.79 | 3.09 | 4.13× | 107 |
| 256 | 15.31 | 3.26 | 4.69× | 814 |
| 1024 | 17.92 | 4.49 | 3.99× | 2365 |
| 4096 | 42.60 | 11.61 | 3.67× | 3657 |
| 16384 | 117.05 | 36.72 | 3.19× | 4626 |

At small M both sides are launch-bound (three launches vs one); the win there is
kernel count, not bandwidth. At large M the kernel reaches ~4.5 TB/s of moved bytes
(read 2 B + write 0.53 B per element), which is where a rotate+quant+swizzle fusion
should land on this part.

**Arithmetic intensity**: 2.53 bytes moved per element for `log2(RS)` f32 add/sub
(6 per element at RS=64) plus one `v_cvt_scalef32_pk_fp4_f32` per pair — ~2.4
FLOP/byte against a ~575 FLOP/byte machine balance. Firmly memory-bound, which is
exactly why the three passes are worth collapsing into one.

**Scope of the claim**: the numbers above are the claim being made. This op is one of
several per-projection steps in a decode iteration, so the end-to-end serving effect
is model-, shape- and gemm-tuning-dependent and is a small fraction of the
microbenchmark ratio — in our own measurements it is a low single-digit percentage of
total throughput, positive but not the 3–4× above.

## Implementation

Work = `M * (K//COLS)` independent thread-blocks; one thread owns a COLS-wide chunk
holding `COLS//RS` independent RS-wide Hadamard blocks, so the FWHT needs **no
cross-lane communication** — it is scalar-unrolled in registers (Sylvester,
`(a+b, a-b)` pairing). At RS=COLS=64 that is 64 f32 registers per thread. Loads are
128-bit (`vec8` bf16); fp4 stores are 128-bit (4× packed i32).

Written against the post-#4501 stable FlyDSL interface: `buffer_ops` / `vector` from
`aiter.ops.flydsl.kernels`, `tensor_shim._run_compiled` / `_to_raw` for the launch
path, and `quant_utils.emit_mx_e8m0_scale` for the block scale. No new dependency floor:
verified on `flydsl 0.3.0` (the version `requirements.txt` pins) and on `0.2.4`
(the floor `aiter/ops/flydsl/__init__.py` enforces), identical results on both.

Two details worth calling out for review:

1. **The `1/sqrt(RS)` normalization is folded into the e8m0 exponent** when
   `log2(RS)/2` is an integer (RS=64), replacing a per-element f32 multiply with an
   integer subtract on the shared group exponent. RS=32 and RS=128 take the
   multiply path.
2. **`shuffle_scales=True` scatters each e8m0 byte directly to its
   `shuffle_scale` destination**, computed by bit-slicing the global thread id. This
   removes the separate swizzle pass *and* its padding-tile zeroing: the padded cells
   are `torch.empty` and never written, exactly as `shuffle_scale` itself leaves them,
   because the gemm slices its output back to `[:M]`.

### Scale convention

No bespoke convention here: the e8m0 block scale is built by the shared
`quant_utils.emit_mx_e8m0_scale` IR helper in aiter's default
`MxScaleRoundMode::RoundUp` (`ceil_pow2(amax / 6)`), and the torch reference in the
test uses its CPU mirror `fp4_utils.f32_to_mx_e8m0_scale` with the same mode. The
`fold_k` exponent fold in (1) is exact on top of it because RoundUp is
exponent-linear: `e8m0(amax · 2⁻ᵏ) = e8m0(amax) − k`.

## Testing

`op_tests/test_flydsl_rot_quant.py`. All three checks matter independently, because
all three failure modes are **silent** — wrong numbers, no exception:

1. **Bit-exactness** — packed fp4 and e8m0 scales compared byte-for-byte against a
   pure-torch reference (`_ref_rot_quant`, in the test file — no external dependency).
   Byte equality, not `allclose`: `allclose` would hide a systematic off-by-one-binade
   scale bug. Covers RS ∈ {32, 64, 128} × K ∈ {2048, 4096} × M ∈ {1, 32, 256, 1024,
   4096, 16384}, plus an outlier pass that drives elements into the saturating
   `[6, 8)` band where an encoder that clamps differently from the hardware would
   diverge. **All 39 configurations are exact.**
2. **Fused swizzle parity** — the in-kernel scatter vs `shuffle_scale()` of the
   natural-layout output, compared only on the live cells (a deterministic 0/1 mask
   pushed through the same reshape/permute; `shuffle_scale` pads with `torch.empty`,
   so the mask cannot be recovered from its output).
3. **End-to-end through `gemm_a4w4`** — the consumer the swizzle exists for. A
   quantizer/gemm layout mismatch produces garbage with no error, so unit-level parity
   is not sufficient evidence that the op works. Gated at N ≥ 512: aiter's CK asm
   `gemm_a4w4` is numerically wrong below that (rel err ~0.94 at N=64, exact at
   N ≥ 512), so it is not a valid reference there. That is a property of the gemm,
   not of this op.

Plus `test_rot_quant_rejects_bad_input`: 7 guards (fp16/fp32 input, non-contiguous,
3D, `K % RS != 0`, unsupported RS, bad `AMAX`) must raise rather than compute. The
kernel hardcodes bf16 buffer loads and linear element offsets, so every one of these
would otherwise be read as contiguous bf16 and yield plausible garbage.

Registered in `.github/scripts/split_tests.sh` (`FILE_TIMES=150`; ~9 s warm, the
rest is cold FlyDSL JIT for the 27 kernel variants the matrix compiles). Peak GPU
memory 812 MiB — below the level that would warrant a `MEMORY_WEIGHT_FLOOR` entry.

## Scope / limits

- **gfx950 only** — the quantizer is `v_cvt_scalef32_pk_fp4_f32`. Raises on other
  architectures.
- Input must be **bf16, 2D, contiguous**; RS ∈ {32, 64, 128}; `K % RS == 0`.
- `_pick_block` / `_pick_svec` defaults are swept on MI350X. They are overridable
  per call; other parts should re-sweep.
- No new dependency: `flydsl` is already a hard requirement of `amd-aiter`, and the
  export sits inside the existing `is_flydsl_available()` guard in
  `aiter/ops/flydsl/__init__.py`.

## Files

| file | change |
|---|---|
| `aiter/ops/flydsl/kernels/rot_quant.py` | new, 523 lines — the kernel |
| `aiter/ops/flydsl/__init__.py` | +2 — import and `__all__` entry |
| `op_tests/test_flydsl_rot_quant.py` | new, 267 lines — the tests |
| `.github/scripts/split_tests.sh` | +1 — CI scheduling weight |
