### PR TITLE
[FlyDSL] flydsl_gdr_decode: read strided q/k/v directly (qkv_contiguous=False)

### DIFF
--- a/aiter/ops/flydsl/kernels/gdr_decode.py
+++ b/aiter/ops/flydsl/kernels/gdr_decode.py
@@ -37,6 +37,9 @@ def create_vk_gdr_decode_kernel(
     a_strides: tuple,
     b_strides: tuple,
     use_qk_l2norm: bool,
+    q_strides: tuple | None = None,
+    k_strides: tuple | None = None,
+    v_strides: tuple | None = None,
     softplus_beta: float = 1.0,
     softplus_threshold: float = 20.0,
     NUM_BLOCKS_PER_V_DIM: int = 1,
@@ -131,14 +134,38 @@ def create_vk_gdr_decode_kernel(
         indices_tensor = GTensor(indices, dtype=T.i32, shape=(-1,))
         pool_idx = fx.Int32(indices_tensor[b_i])
 
+        _qk_contig = (
+            seq_length * num_k_heads * head_k_dim,
+            num_k_heads * head_k_dim,
+            head_k_dim,
+            1,
+        )
+        _v_contig = (
+            seq_length * num_v_heads * head_v_dim,
+            num_v_heads * head_v_dim,
+            head_v_dim,
+            1,
+        )
+        _q_str = q_strides if q_strides is not None else _qk_contig
+        _k_str = k_strides if k_strides is not None else _qk_contig
+        _v_str = v_strides if v_strides is not None else _v_contig
         q_tensor = GTensor(
-            query, dtype=dtype_, shape=(-1, seq_length, num_k_heads, head_k_dim)
+            query,
+            dtype=dtype_,
+            stride=_q_str,
+            shape=(-1, seq_length, num_k_heads, head_k_dim),
         )
         k_tensor = GTensor(
-            key, dtype=dtype_, shape=(-1, seq_length, num_k_heads, head_k_dim)
+            key,
+            dtype=dtype_,
+            stride=_k_str,
+            shape=(-1, seq_length, num_k_heads, head_k_dim),
         )
         v_tensor = GTensor(
-            value, dtype=dtype_, shape=(-1, seq_length, num_v_heads, head_v_dim)
+            value,
+            dtype=dtype_,
+            stride=_v_str,
+            shape=(-1, seq_length, num_v_heads, head_v_dim),
         )
         a_tensor = GTensor(
             a,

--- a/aiter/ops/flydsl/linear_attention_kernels.py
+++ b/aiter/ops/flydsl/linear_attention_kernels.py
@@ -96,6 +96,7 @@ def flydsl_gdr_decode(
     use_qk_l2norm: bool,
     need_shuffle_state: bool,
     stream: torch.cuda.Stream = None,
+    qkv_contiguous: bool = True,
 ):
     if stream is None:
         stream = torch.cuda.current_stream()
@@ -127,6 +128,19 @@ def flydsl_gdr_decode(
         head_k_dim,
         head_v_dim,
     )
+    if qkv_contiguous:
+        q_strides = k_strides = v_strides = None
+        q_arg, k_arg, v_arg = (
+            query.contiguous(),
+            key.contiguous(),
+            value.contiguous(),
+        )
+    else:
+        # Read strided (e.g. packed mixed_qkv) q/k/v directly -- no copy.
+        q_strides = tuple(int(x) for x in query.stride())
+        k_strides = tuple(int(x) for x in key.stride())
+        v_strides = tuple(int(x) for x in value.stride())
+        q_arg, k_arg, v_arg = query, key, value
     exe = create_vk_gdr_decode_kernel(
         get_dtype_str(query.dtype),
         get_dtype_str(A_log.dtype),
@@ -140,14 +154,17 @@ def flydsl_gdr_decode(
         a.stride(),
         b.stride(),
         use_qk_l2norm,
+        q_strides=q_strides,
+        k_strides=k_strides,
+        v_strides=v_strides,
         **kwargs_,
     )
     with torch.cuda.device(query.device.index):
         _run_compiled(
             exe,
-            query.contiguous(),
-            key.contiguous(),
-            value.contiguous(),
+            q_arg,
+            k_arg,
+            v_arg,
             a,
             b,
             dt_bias.contiguous(),

--- a/aiter/ops/flydsl/test_flydsl_linear_attention.py
+++ b/aiter/ops/flydsl/test_flydsl_linear_attention.py
@@ -371,6 +371,119 @@ def func(args, query, key, value, a, b, dt_bias, A_log, indices, state, out):
     )
 
 
+def _pack_qkv(args, query, key, value):
+    """Re-materialize q/k/v as views into one packed ``mixed_qkv`` tensor.
+
+    This is the layout a GDN linear-attention layer actually produces: the qkv
+    projection writes a single ``[b, sq, 2*num_k_heads*head_k_dim +
+    num_v_heads*head_v_dim]`` tensor and q/k/v are last-dim slices of it. Each
+    slice is non-contiguous (its row stride spans the whole packed width), so
+    ``qkv_contiguous=True`` has to copy all three.
+    """
+    kd = args.num_k_heads * args.head_k_dim
+    vd = args.num_v_heads * args.head_v_dim
+    mixed = torch.empty((args.b, args.sq, 2 * kd + vd), dtype=args.dtype, device="cuda")
+    mixed[..., :kd] = query.reshape(args.b, args.sq, kd)
+    mixed[..., kd : 2 * kd] = key.reshape(args.b, args.sq, kd)
+    mixed[..., 2 * kd :] = value.reshape(args.b, args.sq, vd)
+    q = mixed[..., :kd].view(args.b, args.sq, args.num_k_heads, args.head_k_dim)
+    k = mixed[..., kd : 2 * kd].view(args.b, args.sq, args.num_k_heads, args.head_k_dim)
+    v = mixed[..., 2 * kd :].view(args.b, args.sq, args.num_v_heads, args.head_v_dim)
+    # Every slice keeps the packed row stride somewhere in its strides, so none
+    # is a dense [b, sq, heads, dim] tensor. (b == sq == 1 is degenerate: there
+    # is only one row, so the slices really are dense -- the explicit-stride path
+    # is still exercised, just with contiguous strides.)
+    if args.b * args.sq > 1:
+        packed = 2 * kd + vd
+        assert packed in q.stride() and packed in k.stride()
+        assert packed in v.stride()
+    return q, k, v
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        Args(
+            dtype=torch.bfloat16,
+            b=1,
+            sq=1,
+            num_k_heads=2,
+            num_v_heads=8,
+            head_k_dim=128,
+            head_v_dim=128,
+        ),
+        Args(
+            dtype=torch.bfloat16,
+            b=128,
+            sq=1,
+            num_k_heads=2,
+            num_v_heads=8,
+            head_k_dim=128,
+            head_v_dim=128,
+        ),
+        Args(
+            dtype=torch.float16,
+            b=2,
+            sq=2,
+            num_k_heads=16,
+            num_v_heads=32,
+            head_k_dim=128,
+            head_v_dim=128,
+        ),
+    ],
+)
+def test_flydsl_gdr_decode_strided(args):
+    """``qkv_contiguous=False`` on packed q/k/v must be bit-identical to copying.
+
+    Reading the strided views directly is a pure layout change -- the kernel does
+    the same arithmetic in the same order -- so this asserts byte equality of both
+    outputs, not ``allclose``. A stride miscomputation would read the wrong
+    elements and produce plausible garbage with no error.
+    """
+    _, query, key, value, a, b, dt_bias, A_log, indices, state = create_inputs(args)
+    q, k, v = _pack_qkv(args, query, key, value)
+
+    out_copy, out_view = create_outputs(args)[0], create_outputs(args)[0]
+    state_copy, state_view = state.clone(), state.clone()
+
+    common = {"use_qk_l2norm": args.use_qk_l2norm, "need_shuffle_state": True}
+    flydsl_gdr_decode(
+        q,
+        k,
+        v,
+        a,
+        b,
+        dt_bias,
+        A_log,
+        indices,
+        state_copy,
+        out_copy,
+        qkv_contiguous=True,
+        **common,
+    )
+    flydsl_gdr_decode(
+        q,
+        k,
+        v,
+        a,
+        b,
+        dt_bias,
+        A_log,
+        indices,
+        state_view,
+        out_view,
+        qkv_contiguous=False,
+        **common,
+    )
+
+    assert torch.equal(
+        out_view, out_copy
+    ), f"strided out differs at {(out_view != out_copy).sum().item()} elements"
+    assert torch.equal(
+        state_view, state_copy
+    ), f"strided state differs at {(state_view != state_copy).sum().item()} elements"
+
+
 def ref_func(args, query, key, value, a, b, dt_bias, A_log, indices, state, out):
     run_triton_kernel(
         out,


### PR DESCRIPTION
# [FlyDSL] `flydsl_gdr_decode`: read strided q/k/v directly (`qkv_contiguous=False`)

## What

Adds an opt-in `qkv_contiguous: bool = True` argument to
`aiter.ops.flydsl.linear_attention_kernels.flydsl_gdr_decode`. When set to `False`,
the kernel reads `query` / `key` / `value` through their actual strides instead of
forcing three `.contiguous()` copies.

Default behaviour is unchanged: `qkv_contiguous=True` takes exactly the code path
that exists today.

## Why

In a gated-delta-rule (GDN) linear-attention layer, the qkv projection produces one
packed tensor

```
mixed_qkv : [batch, seq, 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim]
```

and q / k / v are last-dim slices of it. Every slice carries the packed row stride,
so none of them is dense — today `flydsl_gdr_decode` calls `.contiguous()` on all
three, i.e. three extra kernel launches plus three extra HBM round-trips per layer
per decode step, purely to undo a layout the caller never wanted to change.

The kernel already builds its `GTensor`s from explicit shapes; passing explicit
strides is a small generalization of the same code.

## Performance

MI350X (gfx950), bf16, `num_k_heads=2`, `num_v_heads=8`, `head_k_dim=head_v_dim=128`,
`seq=1` (decode), CUDA-graph timed, 50 launches per replay.

| batch | `qkv_contiguous=True` (µs) | `False` (µs) | saved |
|---:|---:|---:|---:|
| 1 | 12.54 | 12.75 | −0.2 µs (wash) |
| 32 | 72.68 | 63.49 | 9.2 µs (13%) |
| 128 | 216.41 | 207.33 | 9.1 µs (4%) |
| 256 | 422.87 | 413.37 | 9.5 µs (2%) |

The saving is roughly flat at ~9 µs — it is dominated by the three eliminated
launches, not by the bytes copied — so as a fraction it matters most at the
small-to-medium batch sizes where the main kernel is itself cheap. At `batch=1` it is
a wash.

Per call this is small, but the call is per GDN layer per decode step, so it scales
with layer count: for a model with a few dozen linear-attention layers the flat ~9 µs
aggregates to a few hundred µs per decode step. Measured numbers above are per call
only; the aggregate is arithmetic, not a measurement.

Verified on `flydsl 0.3.0` (the version `requirements.txt` pins) and on `0.2.4` (the
floor `aiter/ops/flydsl/__init__.py` enforces) — same results and same timings.

## Testing

Extends the existing `aiter/ops/flydsl/test_flydsl_linear_attention.py` with
`test_flydsl_gdr_decode_strided` (3 configs: bf16 b=1/b=128 with `seq=1`, fp16 b=2
with `seq=2`).

The new test rebuilds q/k/v as genuine views into one packed `mixed_qkv` buffer —
the real caller layout, asserted non-dense — and requires the `qkv_contiguous=False`
result to be **bit-identical** (`torch.equal`, on both `out` and the in-place
`state`) to the copying path. Byte equality rather than `allclose` is the right bar
here: reading through strides is a pure layout change, the kernel does the same
arithmetic in the same order, and the failure mode of a miscomputed stride is
plausible garbage with no exception.

Full file: 7 passed (4 pre-existing + 3 new), on flydsl 0.3.0 and 0.2.4 alike.

## Files

| file | change |
|---|---|
| `aiter/ops/flydsl/kernels/gdr_decode.py` | +25/−8 — optional `q/k/v_strides` on `create_vk_gdr_decode_kernel`, defaulting to the contiguous strides |
| `aiter/ops/flydsl/linear_attention_kernels.py` | +19/−4 — the `qkv_contiguous` argument |
| `aiter/ops/flydsl/test_flydsl_linear_attention.py` | +113 — `test_flydsl_gdr_decode_strided` |

Note `flydsl_gdr_decode` is not currently re-exported from `aiter/ops/flydsl/__init__.py`
(commented out in #2840); this PR does not change that — callers import it from
`aiter.ops.flydsl.linear_attention_kernels`.
