### PR TITLE
[FlyDSL MoE] Enable persistent stage2 grid for large-M mxfp8

### DIFF
--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1580,8 +1580,30 @@ def flydsl_moe_stage2(
     else:
         _persist_m = -1 if m_blocks > 256 else 1
 
+    # fp8 (mxfp8 a8w8) stage2 historically force-disabled the persistent grid
+    # (always persist_m=1). For large M this is the dominant cost: a
+    # one-tile-per-workgroup grid launches O(m_blocks * n_tiles) workgroups
+    # (tens of thousands at M>=4k) and re-derives the per-tile expert base in
+    # every block, instead of a persistent round-robin grid (grid_y=cu_num)
+    # that amortizes launch overhead and reuses the expert base across tiles.
+    # The persistent stage2 path in compile_mixed_moe_gemm2 is dtype-agnostic
+    # (only the fp4 async-copy micro-opt is gated on b_dtype), so fp8 can use
+    # the same m_blocks heuristic as fp4. Behavior is gated so the legacy path
+    # stays one env-var away, and small/medium M (m_blocks<=256) is unchanged:
+    #   AITER_FLYDSL_FP8_STAGE2_PERSIST=
+    #     "auto" (default) -> persistent when m_blocks>256, else persist_m=1
+    #     "0"/"off"        -> legacy: always persist_m=1
+    #     "1"/"on"         -> always persistent (persist_m=-1)
     if a_dtype == "fp8":
-        _persist_m = 1
+        _fp8_persist = os.environ.get(
+            "AITER_FLYDSL_FP8_STAGE2_PERSIST", "auto"
+        ).lower()
+        if _fp8_persist in ("0", "off", "false"):
+            _persist_m = 1
+        elif _fp8_persist in ("1", "on", "true"):
+            _persist_m = -1
+        else:  # "auto": match fp4's large-M heuristic, leave small M as-is
+            _persist_m = -1 if m_blocks > 256 else 1
 
     if bias is not None and bias.dtype != torch.float32:
         bias = bias.to(torch.float32)

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -182,7 +182,13 @@ def get_flydsl_stage2_kernels(
 
     b_nts = [0, 2]
 
-    xcd_swizzles = [0, 4]
+    # xcd_swizzle doubles as the L2-locality M-group width (WGM_S) in the
+    # stage2 kernel: the swizzle remaps workgroups onto XCDs *and* groups
+    # WGM_S consecutive M-tiles together so a shared A tile stays resident in
+    # L2 across N-tiles instead of being re-fetched from HBM. Offer a larger
+    # group (8) in addition to {0,4} so large-M shapes (where the A re-fetch /
+    # low-L2-hit cost dominates) can tune a wider L2 group.
+    xcd_swizzles = [0, 4, 8]
 
     for tm in tile_ms:
         for tn in tile_ns:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

FlyDSL MXFP8 (a8w8, `per_1x32` e8m0) fused-MoE shows poor throughput at large M (prefill, M=4096..32768) for MiniMax M3, despite a tuned `minimax_m3_mxfp8_tuned_fmoe.csv`.

## Changes

### 1. Enable persistent stage2 grid for large-M fp8

`flydsl_moe_stage2` unconditionally forced `persist_m = 1` for `a_dtype == "fp8"`, disabling the persistent round-robin grid for all fp8 stage2 launches. At large M this is the dominant cost:

- A one-tile-per-workgroup grid launches `O(m_blocks * n_tiles)` workgroups (tens of thousands at M≥4k) instead of `grid_y = cu_num` persistent workers.
- Each workgroup re-derives the per-tile expert base instead of carrying it across tiles.
- With the forced non-persistent grid, the A (`inter_states`) tile gets re-fetched from HBM across N-tiles → low L2 hit rate.

Critically, **both the runtime dispatch and the fmoe tuner go through `flydsl_moe_stage2`**, so this cap also prevented the tuner from ever *measuring* persistent (and persistent × `xcd_swizzle`) fp8 stage2 candidates.

The persistent stage2 kernel in `compile_mixed_moe_gemm2` is dtype-agnostic (only the fp4 `r139_xdma_first` async-copy micro-opt is `b_dtype`-gated), so fp8 can safely use the same `m_blocks > 256` heuristic as fp4. Gated via `AITER_FLYDSL_FP8_STAGE2_PERSIST` (`auto`=default / `0` legacy / `1` force). Small/medium M (`m_blocks <= 256`) is unchanged; fp4 untouched.

### 2. Add `xcd_swizzle=8` to the stage2 candidate set

`xcd_swizzle` doubles as the L2-locality M-group width (`WGM_S`): it remaps workgroups onto XCDs and groups `WGM_S` consecutive M-tiles so a shared A tile stays L2-resident across N-tiles instead of being re-fetched from HBM. Widening the candidate set `{0,4} → {0,4,8}` lets large-M shapes (dominated by A re-fetch / low L2 hit) tune a larger L2 group. Names parse through the existing registry, so `_xcd8` (incl. `_persist`/`_sbm` combos) needs no extra plumbing and is JIT-compiled on demand — only the tuning candidate space grows.

These two changes are complementary: removing the persist cap re-opens the persist axis to the tuner, and `xcd8` widens the L2-locality axis, so a re-tune can search persist × xcd combos that were previously unreachable.

## Validation

> [!WARNING]
> This environment has no GPU/ROCm/FlyDSL, so these changes are **not** hardware-validated. Verified only via `py_compile`, a unit test of the new persist dispatch branches (small-M unchanged, large-M → persistent, env escape hatches, fp4 untouched), and a registration/name-parsing test confirming the new `_xcd8` candidates (incl. `_persist`/`_sbm128`) resolve correctly.

Required follow-up on a gfx950 (MI355X) box:

1. **Re-tune** so the CSV reflects the newly reachable persist + `xcd{4,8}` candidates:
   ```bash
   python3 csrc/ck_gemm_moe_2stages_codegen/gemm_moe_tune.py \
     -i aiter/configs/model_configs/minimax_m3_mxfp8_untuned_fmoe.csv \
     -o aiter/configs/model_configs/minimax_m3_mxfp8_tuned_fmoe.csv \
     -o2 profile_fmoe.csv
   ```
2. **Benchmark** large-M (M=4096..32768) stage2 us before/after; A/B against `AITER_FLYDSL_FP8_STAGE2_PERSIST=0`.
3. **rocprof** large-M stage2 L2 hit / HBM read traffic to confirm the A re-fetch drops with the wider xcd group.
4. **Correctness**: run `op_tests/test_moe_2stage.py` for the mxfp8 shapes.

## Follow-up ideas (need GPU profiling)

- **Pipeline / LDS access pattern for A**: stage1/stage2 prologue + LDS layout/async-copy depth tuning — profiling-driven kernel work, intentionally not attempted blind.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f5ba3f-e081-4c7b-b9aa-22252f1586b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f5ba3f-e081-4c7b-b9aa-22252f1586b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

