### PR TITLE
[PERF] Add opt-in atomic stage2 override

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -431,6 +431,33 @@ def stage2_uses_route_reduce(stage2: Callable) -> bool:
     return False
 
 
+def _maybe_force_atomic_flydsl_stage2(kernel_name: str) -> str:
+    """Use an available atomic variant of a tuned FlyDSL reduce kernel."""
+    if (
+        os.environ.get("AITER_FLYDSL_FORCE_ATOMIC", "0") != "1"
+        or os.environ.get("AITER_FLYDSL_FORCE_REDUCE", "0") == "1"
+        or not kernel_name.startswith("flydsl_moe2_")
+        or "_reduce" not in kernel_name
+    ):
+        return kernel_name
+
+    atomic_kernel = kernel_name.replace("_reduce", "_atomic", 1)
+    params = aiter.ops.flydsl.moe_kernels.get_flydsl_kernel_params(atomic_kernel)
+    if params is None or params.get("mode", "atomic") != "atomic":
+        logger.warning(
+            "[fused_moe] cannot force atomic stage2; kernel is unavailable: %s",
+            atomic_kernel,
+        )
+        return kernel_name
+
+    logger.warning(
+        "[fused_moe] forcing atomic stage2: %s -> %s",
+        kernel_name,
+        atomic_kernel,
+    )
+    return atomic_kernel
+
+
 # Lru cache will using hash to create key, which makes error when w1,w2 shape is symint.
 # We can use torch.compile(dynamic=False) to avoid
 @functools.lru_cache(maxsize=2048)
@@ -2287,6 +2314,8 @@ def get_2stage_cfgs(
             cfg_flat = run_1stage and bool(int(cfg["flat"]))
         else:
             cfg_flat = False
+    if not run_1stage:
+        kernelName2 = _maybe_force_atomic_flydsl_stage2(kernelName2)
     is_opus_cfg = cfg is not None and _opus_a8w4.is_opus_a8w4_stage2_kernel(
         cfg.get("kernelName2", "")
     )

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -439,6 +439,33 @@ def stage2_uses_route_reduce(stage2: Callable) -> bool:
     return False
 
 
+def _maybe_force_atomic_flydsl_stage2(kernel_name: str) -> str:
+    """Use an available atomic variant of a tuned FlyDSL reduce kernel."""
+    if (
+        os.environ.get("AITER_FLYDSL_FORCE_ATOMIC", "0") != "1"
+        or os.environ.get("AITER_FLYDSL_FORCE_REDUCE", "0") == "1"
+        or not kernel_name.startswith("flydsl_moe2_")
+        or "_reduce" not in kernel_name
+    ):
+        return kernel_name
+
+    atomic_kernel = kernel_name.replace("_reduce", "_atomic", 1)
+    params = aiter.ops.flydsl.moe_kernels.get_flydsl_kernel_params(atomic_kernel)
+    if params is None or params.get("mode", "atomic") != "atomic":
+        logger.warning(
+            "[fused_moe] cannot force atomic stage2; kernel is unavailable: %s",
+            atomic_kernel,
+        )
+        return kernel_name
+
+    logger.warning(
+        "[fused_moe] forcing atomic stage2: %s -> %s",
+        kernel_name,
+        atomic_kernel,
+    )
+    return atomic_kernel
+
+
 # Lru cache will using hash to create key, which makes error when w1,w2 shape is symint.
 # We can use torch.compile(dynamic=False) to avoid
 @functools.lru_cache(maxsize=2048)
@@ -2399,6 +2426,8 @@ def get_2stage_cfgs(
             cfg_flat = int(cfg["flat"]) if run_1stage else 0
         else:
             cfg_flat = 0
+    if not run_1stage:
+        kernelName2 = _maybe_force_atomic_flydsl_stage2(kernelName2)
     is_opus_cfg = cfg is not None and _opus_a8w4.is_opus_a8w4_stage2_kernel(
         cfg.get("kernelName2", "")
     )

--- a/op_tests/test_fused_moe_kernel_selection.py
+++ b/op_tests/test_fused_moe_kernel_selection.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+
+import aiter
+from aiter.fused_moe import _maybe_force_atomic_flydsl_stage2
+
+REDUCE_KERNEL = "flydsl_moe2_afp4_wfp4_bf16_t128x256x128_reduce"
+ATOMIC_KERNEL = "flydsl_moe2_afp4_wfp4_bf16_t128x256x128_atomic"
+
+
+def test_force_atomic_stage2_uses_available_variant(monkeypatch):
+    monkeypatch.setenv("AITER_FLYDSL_FORCE_ATOMIC", "1")
+    monkeypatch.delenv("AITER_FLYDSL_FORCE_REDUCE", raising=False)
+    monkeypatch.setattr(
+        aiter.ops.flydsl.moe_kernels,
+        "get_flydsl_kernel_params",
+        lambda name: {"mode": "atomic"} if name == ATOMIC_KERNEL else None,
+    )
+
+    assert _maybe_force_atomic_flydsl_stage2(REDUCE_KERNEL) == ATOMIC_KERNEL
+
+
+def test_force_atomic_stage2_keeps_reduce_when_variant_is_unavailable(monkeypatch):
+    monkeypatch.setenv("AITER_FLYDSL_FORCE_ATOMIC", "1")
+    monkeypatch.delenv("AITER_FLYDSL_FORCE_REDUCE", raising=False)
+    monkeypatch.setattr(
+        aiter.ops.flydsl.moe_kernels,
+        "get_flydsl_kernel_params",
+        lambda _name: None,
+    )
+
+    assert _maybe_force_atomic_flydsl_stage2(REDUCE_KERNEL) == REDUCE_KERNEL
+
+
+@pytest.mark.parametrize(
+    "kernel_name",
+    [
+        "",
+        "flydsl_moe2_afp4_wfp4_bf16_t128x256x128_atomic",
+        "cktile_moe2_afp4_wfp4_bf16_reduce",
+    ],
+)
+def test_force_atomic_stage2_ignores_ineligible_kernels(monkeypatch, kernel_name):
+    monkeypatch.setenv("AITER_FLYDSL_FORCE_ATOMIC", "1")
+    monkeypatch.delenv("AITER_FLYDSL_FORCE_REDUCE", raising=False)
+    monkeypatch.setattr(
+        aiter.ops.flydsl.moe_kernels,
+        "get_flydsl_kernel_params",
+        lambda _name: pytest.fail("ineligible kernels must not be looked up"),
+    )
+
+    assert _maybe_force_atomic_flydsl_stage2(kernel_name) == kernel_name
+
+
+def test_force_reduce_takes_precedence(monkeypatch):
+    monkeypatch.setenv("AITER_FLYDSL_FORCE_ATOMIC", "1")
+    monkeypatch.setenv("AITER_FLYDSL_FORCE_REDUCE", "1")
+    monkeypatch.setattr(
+        aiter.ops.flydsl.moe_kernels,
+        "get_flydsl_kernel_params",
+        lambda _name: pytest.fail("force-reduce must prevent atomic lookup"),
+    )
+
+    assert _maybe_force_atomic_flydsl_stage2(REDUCE_KERNEL) == REDUCE_KERNEL

--- a/op_tests/test_fused_moe_kernel_selection.py
+++ b/op_tests/test_fused_moe_kernel_selection.py
@@ -2,8 +2,10 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 
 import pytest
+import torch
 
 import aiter
+import aiter.fused_moe as fused_moe
 from aiter.fused_moe import _maybe_force_atomic_flydsl_stage2
 
 REDUCE_KERNEL = "flydsl_moe2_afp4_wfp4_bf16_t128x256x128_reduce"
@@ -64,3 +66,98 @@ def test_force_reduce_takes_precedence(monkeypatch):
     )
 
     assert _maybe_force_atomic_flydsl_stage2(REDUCE_KERNEL) == REDUCE_KERNEL
+
+
+def test_tuned_lookup_threads_atomic_mode_to_moe_sorting(monkeypatch):
+    token = 2
+    model_dim = 4096
+    inter_dim = 1536
+    num_experts = 32
+    topk = 7
+    activation = aiter.ActivationType.Silu
+    q_type = aiter.QuantType.per_1x32
+    q_dtype = aiter.dtypes.fp4x2
+    stage1 = "flydsl_moe1_afp4_wfp4_bf16_t32x128x256_w2"
+    stage2_reduce = "flydsl_moe2_afp4_wfp4_bf16_t32x128x256_reduce_bnt2"
+    stage2_atomic = stage2_reduce.replace("_reduce", "_atomic")
+    key = (
+        "gfx950",
+        256,
+        token,
+        model_dim,
+        inter_dim,
+        num_experts,
+        topk,
+        activation,
+        str(torch.bfloat16),
+        str(q_dtype),
+        str(q_dtype),
+        str(q_type),
+        True,
+        False,
+    )
+    config = {
+        "block_m": 32,
+        "ksplit": 0,
+        "kernelName1": stage1,
+        "kernelName2": stage2_reduce,
+        "run_1stage": False,
+    }
+
+    monkeypatch.setenv("AITER_FLYDSL_FORCE_ATOMIC", "1")
+    monkeypatch.delenv("AITER_FLYDSL_FORCE_REDUCE", raising=False)
+    monkeypatch.setattr(fused_moe, "get_cu_num", lambda: 256)
+    monkeypatch.setattr(fused_moe, "get_gfx_runtime", lambda: "gfx950")
+    monkeypatch.setattr(fused_moe, "cfg_2stages", ({key: config}, {}))
+    monkeypatch.setattr(
+        aiter.ops.flydsl.moe_kernels,
+        "get_flydsl_kernel_params",
+        lambda name: {"mode": "atomic"} if name == stage2_atomic else None,
+    )
+    fused_moe.get_2stage_cfgs.cache_clear()
+
+    metadata = fused_moe.get_2stage_cfgs(
+        token,
+        model_dim,
+        inter_dim,
+        num_experts,
+        topk,
+        torch.bfloat16,
+        q_dtype,
+        q_dtype,
+        q_type,
+        True,
+        activation,
+        False,
+        0,
+        0,
+    )
+
+    selected_stage2 = metadata.stage2.keywords["kernelName"]
+    assert selected_stage2 == stage2_atomic
+    assert not fused_moe.stage2_uses_route_reduce(metadata.stage2)
+
+    recorded = {}
+
+    def record_sort(*args, **kwargs):
+        recorded.update(kwargs)
+        return ("sorted",)
+
+    monkeypatch.setattr(fused_moe, "_moe_sorting_impl", record_sort)
+    result = fused_moe.moe_sorting(
+        torch.zeros((token, topk), dtype=torch.int64),
+        torch.zeros((token, topk), dtype=torch.float32),
+        num_experts,
+        model_dim,
+        torch.bfloat16,
+        metadata.block_m,
+        None,
+        None,
+        accumulate=not fused_moe.stage2_uses_route_reduce(metadata.stage2),
+        output_aux=metadata.output_aux,
+    )
+
+    assert result == ("sorted",)
+    assert recorded["accumulate"] is True
+    assert recorded["output_aux"] is False
+    fused_moe.get_2stage_cfgs.cache_clear()

--- a/op_tests/test_fused_moe_kernel_selection.py
+++ b/op_tests/test_fused_moe_kernel_selection.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 import aiter
-import aiter.fused_moe as fused_moe
+from aiter import fused_moe
 from aiter.fused_moe import _maybe_force_atomic_flydsl_stage2
 
 REDUCE_KERNEL = "flydsl_moe2_afp4_wfp4_bf16_t128x256x128_reduce"


### PR DESCRIPTION
## Summary

Add an opt-in `AITER_FLYDSL_FORCE_ATOMIC=1` override that replaces an eligible tuned FlyDSL stage-2 `_reduce` kernel with its registered `_atomic` sibling while constructing MoE metadata.

Safety and precedence are explicit:

- unchanged when the override is unset;
- unchanged when no registered atomic sibling exists;
- ignored for non-FlyDSL, already-atomic, or otherwise ineligible kernels;
- `AITER_FLYDSL_FORCE_REDUCE=1` takes precedence when both variables are set;
- output allocation and MoE sorting use the final metadata, so accumulation semantics match the selected epilogue.

## Motivation and measured result

Using [#4554](https://github.com/ROCm/aiter/pull/4554)'s Qwen3-VL tuning rows on 8× MI355X, 1024 input/output tokens, concurrency 4:

- tuned `_reduce`: **375.19 output tok/s**, 889.47 total tok/s;
- forced `_atomic`: **391.46 output tok/s**, 928.27 total tok/s;
- reference range: 389.48–391.05 output tok/s, 924.04–928.77 total tok/s.

The opt-in override recovers approximately **4.3% output throughput** for this point while retaining safe fallback behavior.

## Qwen3-VL integration stack

- [vLLM #50212](https://github.com/vllm-project/vllm/pull/50212): fused attention prologue; requires AITER main containing the strided-cache support merged via #4531.
- [AITER #4531](https://github.com/ROCm/aiter/pull/4531): **merged** into AITER main as [`b0cc5392`](https://github.com/ROCm/aiter/commit/b0cc5392dd838a4bec46a5553e7fbeed60218ab5); provides full strided MRoPE KV-cache support.
- [AITER #4554](https://github.com/ROCm/aiter/pull/4554): tuning rows used by the measurement above.
- **This PR — [AITER #4556](https://github.com/ROCm/aiter/pull/4556):** optional atomic stage-2 override.
- [AITER #4761](https://github.com/ROCm/aiter/pull/4761): independent Triton unified-attention prefill/decode optimization used by the later Image C stack.

## Rebase provenance

- Frozen AITER `main`: `fc2e5d57fb5b8ad8e7e23f7103071dde798ea618`
- Current PR head: `5390e8912bcfd58f6132a30428dcb5a2bf7744de`

## Validation

- `pytest -q op_tests/test_fused_moe_kernel_selection.py` — **7 passed**.
- Coverage includes available/unavailable sibling behavior, ineligible kernels, `FORCE_REDUCE` precedence, and the full tuned-config lookup → metadata rewrite → MoE-sorting accumulation path.
- Black and Ruff checks — **passed**.
- Python compile and `git diff --check` — **passed**.
- TP8 one-point serving benchmark completed **32/32 requests** successfully.
- Upstream CI completed except for an unrelated MI35X `test_moe_2stage.py` shard that exhausted GPU memory with the opt-in override unset; a maintainer rerun has been requested.

> This PR was developed with AI assistance. The human author reviewed the changes, ran the listed validation, and owns the final implementation. Commit metadata contains only human attribution and DCO trailers.
