### PR TITLE
docs: align Ruff version with CI

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -92,7 +92,7 @@ pip install -e .
 AITER uses `pre-commit` to maintain code quality. Install it before making changes:
 
 ```bash
-pip install black==26.3.0 ruff==0.15.7
+pip install black==26.3.0 ruff==0.16.0
 apt install clang-format-18
 
 # Install pre-commit hooks


### PR DESCRIPTION
Documentation-only fix: `CONTRIBUTE.md` now instructs `pip install black==26.3.0 ruff==0.16.0`, matching CI's `pip3 install ruff==0.16.0` pin and resolving the contributor/CI ruff version drift reported in gh-aiter-4423.

Closes #4423.

Changed files:

- `CONTRIBUTE.md`

Validation:

- Target architecture `gfx1100`: `True`
- Baseline failed: `True`
- Fixed run passed: `True`
- Tests passed: `True`
- Fix confirmed: `True`

This change was prepared with assistance from the radeon-issue automation and independently checked by a separately configured validation model. Maintainer review is still required.