### PR TITLE
[BUGFIX] Avoid CustomAllreduce when expandable_segments:True

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -38,6 +38,30 @@ def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
 
 
+def _expandable_segments_enabled() -> bool:
+    """Return the active PyTorch expandable-segments allocator setting."""
+    try:
+        snapshot = torch.cuda.memory._snapshot()
+        return bool(snapshot["allocator_settings"]["expandable_segments"])
+    except (AttributeError, KeyError, RuntimeError):
+        pass
+
+    for name in (
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "PYTORCH_HIP_ALLOC_CONF",
+        "PYTORCH_ALLOC_CONF",
+    ):
+        if name not in os.environ:
+            continue
+        enabled = False
+        for setting in os.environ[name].split(","):
+            key, separator, value = setting.partition(":")
+            if separator and key.strip() == "expandable_segments":
+                enabled = value.strip().lower() == "true"
+        return enabled
+    return False
+
+
 def _detect_gfx1250() -> bool:
     # Escape hatch for validating the old-arch (IPC + old kernel) path on gfx1250
     # hardware: forces the non-gfx1250 code path end to end.
@@ -721,6 +745,14 @@ class CustomAllreduce:
         if not custom_ar:
             # disable because of missing custom allreduce library
             # e.g. in a non-cuda environment
+            return
+
+        if not self._use_vmm and _expandable_segments_enabled():
+            logger.warning(
+                "Custom allreduce is disabled because PyTorch expandable-segment "
+                "allocations cannot be exported with hipIpcGetMemHandle; falling "
+                "back to RCCL."
+            )
             return
 
         self.group = group

--- a/op_tests/test_custom_all_reduce_allocator.py
+++ b/op_tests/test_custom_all_reduce_allocator.py
@@ -1,0 +1,78 @@
+import pytest
+
+from aiter.dist.device_communicators import custom_all_reduce
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_expandable_segments_uses_allocator_snapshot(monkeypatch, value):
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:False")
+    monkeypatch.setattr(
+        custom_all_reduce.torch.cuda.memory,
+        "_snapshot",
+        lambda: {"allocator_settings": {"expandable_segments": value}},
+    )
+
+    assert custom_all_reduce._expandable_segments_enabled() is value
+
+
+@pytest.mark.parametrize(
+    ("name", "config", "expected"),
+    [
+        ("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True", True),
+        (
+            "PYTORCH_HIP_ALLOC_CONF",
+            "max_split_size_mb:64, expandable_segments:True",
+            True,
+        ),
+        ("PYTORCH_ALLOC_CONF", "expandable_segments:False", False),
+        (
+            "PYTORCH_ALLOC_CONF",
+            "expandable_segments:False,expandable_segments:True",
+            True,
+        ),
+    ],
+)
+def test_expandable_segments_falls_back_to_environment(
+    monkeypatch, name, config, expected
+):
+    for variable in (
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "PYTORCH_HIP_ALLOC_CONF",
+        "PYTORCH_ALLOC_CONF",
+    ):
+        monkeypatch.delenv(variable, raising=False)
+    monkeypatch.setenv(name, config)
+    monkeypatch.setattr(
+        custom_all_reduce.torch.cuda.memory,
+        "_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError),
+    )
+
+    assert custom_all_reduce._expandable_segments_enabled() is expected
+
+
+def test_cuda_allocator_config_has_pytorch_precedence(monkeypatch):
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:False")
+    monkeypatch.setenv("PYTORCH_HIP_ALLOC_CONF", "expandable_segments:True")
+    monkeypatch.setattr(
+        custom_all_reduce.torch.cuda.memory,
+        "_snapshot",
+        lambda: (_ for _ in ()).throw(RuntimeError),
+    )
+
+    assert custom_all_reduce._expandable_segments_enabled() is False
+
+
+def test_custom_allreduce_stays_disabled_for_expandable_segments(monkeypatch, caplog):
+    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
+    monkeypatch.setattr(custom_all_reduce, "_is_gfx1250", False)
+    monkeypatch.setattr(custom_all_reduce, "_use_vmm", False)
+    monkeypatch.setattr(custom_all_reduce, "_expandable_segments_enabled", lambda: True)
+    monkeypatch.setattr(
+        custom_all_reduce.CustomAllreduce, "_select_ops", lambda self: None
+    )
+
+    communicator = custom_all_reduce.CustomAllreduce(group=None, device=0)
+
+    assert communicator.disabled is True
+    assert "falling back to RCCL" in caplog.text


### PR DESCRIPTION
## Motivation

Fixes #4174.

AITER CustomAllreduce aborts during initialization when PyTorch uses `expandable_segments:True`. PyTorch expandable-segment allocations use HIP virtual memory management and cannot be exported through AITER's classic `hipIpcGetMemHandle` path.

The goal is to preserve correctness and avoid terminating TP workers. In this configuration, collectives fall back to RCCL instead of using CustomAllreduce.

## Technical Details

Before initializing the classic HIP IPC transport, CustomAllreduce now checks whether PyTorch expandable segments are enabled.

The active setting is read from PyTorch's allocator snapshot, allowing programmatic allocator changes to be detected. Environment-variable parsing is used as a fallback and follows PyTorch's precedence:

1. `PYTORCH_CUDA_ALLOC_CONF`
2. `PYTORCH_HIP_ALLOC_CONF`
3. `PYTORCH_ALLOC_CONF`

When expandable segments are enabled for the classic IPC transport, CustomAllreduce remains disabled and emits an actionable warning. Existing callers then use their RCCL fallback. AITER's VMM transport is unaffected.

Regression tests cover allocator snapshot detection, environment fallback, variable precedence, repeated settings, and disabled communicator behavior.

## Test Plan

- Run focused regression tests on an AMD Instinct MI355X.
- Run Ruff and Black against the changed files.
- Compile the changed Python files.
- Check the diff for whitespace errors.

## Test Result

- `pytest op_tests/test_custom_all_reduce_allocator.py -q`: **8 passed** on MI355X, Slurm job `37581`.
- `ruff check aiter/dist/device_communicators/custom_all_reduce.py op_tests/test_custom_all_reduce_allocator.py`: passed.
- `black --check aiter/dist/device_communicators/custom_all_reduce.py op_tests/test_custom_all_reduce_allocator.py`: passed.
- `python3 -m py_compile aiter/dist/device_communicators/custom_all_reduce.py op_tests/test_custom_all_reduce_allocator.py`: passed.
- `git diff --check`: passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.