### PR TITLE
fix(jit): isolate AITER extensions from HIP interposers

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -1326,7 +1326,7 @@ def _ctypes_call(func, fc_name, md_name):
                 d_args.get("third_party", []),
                 flags_extra_hip_per_source=d_args.get("flags_extra_hip_per_source", {}),
             )
-        lib = ctypes.CDLL(so_path, mode=os.RTLD_NOW | _RTLD_DEEPBIND)
+        lib = ctypes.CDLL(so_path, mode=os.RTLD_LAZY | _RTLD_DEEPBIND)
         c_func = getattr(lib, fc_name)
 
         def _opt_sym(name, argtypes=(), restype=None):

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+import ctypes
 import functools
 import importlib
+import importlib.util
 import json
 import logging
 import multiprocessing
@@ -603,13 +605,35 @@ def check_numa():
 __mds = {}
 
 
+_RTLD_DEEPBIND = (
+    0 if os.getenv("AITER_DISABLE_DEEPBIND") == "1" else getattr(os, "RTLD_DEEPBIND", 0)
+)
+_deep_handles = {}
+
+
+def _deep_import(mod_path: str) -> types.ModuleType:
+    """Import an extension deep-bound.
+
+    importlib takes no dlopen flags, so open the extension here first; glibc
+    dedupes by (st_dev, st_ino), so the import reuses this already-bound
+    handle. sys.setdlopenflags() is avoided on purpose: it is process-wide, so
+    a concurrent unrelated dlopen would inherit the flag. Handles are kept
+    because dropping a CDLL can dlclose the module out from under us.
+    """
+    spec = importlib.util.find_spec(mod_path)
+    origin = getattr(spec, "origin", None) or ""
+    if _RTLD_DEEPBIND and origin.endswith(".so") and origin not in _deep_handles:
+        _deep_handles[origin] = ctypes.CDLL(origin, mode=os.RTLD_NOW | _RTLD_DEEPBIND)
+    return importlib.import_module(mod_path)
+
+
 @torch_compile_guard()
 def get_module_custom_op(md_name: str) -> None:
     if md_name not in __mds:
         if "AITER_JIT_DIR" in os.environ:
-            __mds[md_name] = importlib.import_module(md_name)
+            __mds[md_name] = _deep_import(md_name)
         else:
-            __mds[md_name] = importlib.import_module(f"{__package__}.{md_name}")
+            __mds[md_name] = _deep_import(f"{__package__}.{md_name}")
         logger.info(f"import [{md_name}] under {__mds[md_name].__file__}")
 
 
@@ -1302,7 +1326,7 @@ def _ctypes_call(func, fc_name, md_name):
                 d_args.get("third_party", []),
                 flags_extra_hip_per_source=d_args.get("flags_extra_hip_per_source", {}),
             )
-        lib = ctypes.CDLL(so_path)
+        lib = ctypes.CDLL(so_path, mode=os.RTLD_NOW | _RTLD_DEEPBIND)
         c_func = getattr(lib, fc_name)
 
         def _opt_sym(name, argtypes=(), restype=None):

--- a/csrc/cpp_itfs/utils.h
+++ b/csrc/cpp_itfs/utils.h
@@ -20,6 +20,18 @@ namespace aiter{
 
 #define DIVIDE_ROUND_UP(a, b) (((a) + (b)-1) / (b))
 
+__inline__ int aiter_dlopen_mode(int resolution_mode)
+{
+#ifdef RTLD_DEEPBIND
+    const char* disable_deepbind = std::getenv("AITER_DISABLE_DEEPBIND");
+    if(disable_deepbind == nullptr || std::string(disable_deepbind) != "1")
+    {
+        return resolution_mode | RTLD_DEEPBIND;
+    }
+#endif
+    return resolution_mode;
+}
+
 static std::once_flag init_libs_lru_cache, init_func_names_lru_cache, init_root_dir_flag;
 
 template<typename K, typename V>
@@ -92,7 +104,7 @@ private:
 
 public:
     SharedLibrary(std::string& path) {
-        handle = dlopen(path.c_str(), RTLD_LAZY);
+        handle = dlopen(path.c_str(), aiter_dlopen_mode(RTLD_LAZY));
         if (!handle) {
             throw std::runtime_error(dlerror());
         }

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -280,7 +280,14 @@ def compile_lib(src_file, folder, includes=None, sources=None, cxxflags=None):
 def run_lib(func_name, folder=None):
     if folder is None:
         folder = func_name
-    lib = ctypes.CDLL(f"{BUILD_DIR}/{folder}/lib.so", os.RTLD_LAZY)
+    # Same HIP interposition guard as aiter.jit.core._RTLD_DEEPBIND. Recomputed
+    # rather than imported so this module stays standalone.
+    deepbind = (
+        0
+        if os.getenv("AITER_DISABLE_DEEPBIND") == "1"
+        else getattr(os, "RTLD_DEEPBIND", 0)
+    )
+    lib = ctypes.CDLL(f"{BUILD_DIR}/{folder}/lib.so", mode=os.RTLD_LAZY | deepbind)
     return getattr(lib, func_name)
 
 

--- a/op_tests/test_jit_loader.py
+++ b/op_tests/test_jit_loader.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import os
+import shutil
+import subprocess
+import sys
+import types
+
+import pytest
+
+from aiter.jit import core
+
+pytestmark = pytest.mark.skipif(
+    getattr(os, "RTLD_DEEPBIND", 0) == 0, reason="RTLD_DEEPBIND is a glibc extension"
+)
+
+# Stand-in for TileLang's libhip_stub.so, built with plain gcc so this does not
+# depend on TileLang being installed. It reproduces the real defect: the
+# exported symbol carries the R0600 name but resolves the unversioned one, so
+# the legacy implementation writes a differently laid out struct into an R0600
+# destination. Forwarding to the real runtime, rather than scribbling a fixed
+# pattern, keeps the write inside the caller's buffer -- so an unprotected
+# AITER fails the way it does in production, with hipErrorInvalidConfiguration,
+# instead of by SIGSEGV.
+_STUB_C = """
+#include <dlfcn.h>
+#include <stddef.h>
+typedef int (*legacy_fn)(void *, int);
+int hipGetDevicePropertiesR0600(void *prop, int device) {
+    static legacy_fn legacy = NULL;
+    if (legacy == NULL) {
+        const char *names[] = {
+            "libamdhip64.so", "libamdhip64.so.7",
+            "libamdhip64.so.6", "libamdhip64.so.5"
+        };
+        void *h = NULL;
+        for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); ++i) {
+            h = dlopen(names[i], RTLD_NOW | RTLD_LOCAL);
+            if (h != NULL) break;
+        }
+        if (h == NULL) return 1;
+        legacy = (legacy_fn)dlsym(h, "hipGetDeviceProperties");
+        if (legacy == NULL) return 1;
+    }
+    return legacy(prop, device);
+}
+"""
+
+_INTERPOSE_SCRIPT = """
+import ctypes, math, sys, torch
+ctypes.CDLL(sys.argv[1], mode=ctypes.RTLD_GLOBAL)   # before AITER loads anything
+
+import aiter
+n, e, k = 16384, 128, 8
+gate = torch.randn(n, e, dtype=torch.float32, device="cuda")
+w = torch.empty(n, k, dtype=torch.float32, device="cuda")
+i = torch.empty(n, k, dtype=torch.int32, device="cuda")
+t = torch.empty(n, k, dtype=torch.int32, device="cuda")
+
+aiter.topk_softmax(w, i, t, gate, False)            # pybind extension path
+torch.cuda.synchronize()
+want = torch.topk(torch.softmax(gate, -1), k, dim=-1)[0]
+assert torch.allclose(w, want, atol=1e-5), "topk_softmax corrupted by interposed HIP"
+
+from aiter.ops.moe_op import topk_softmax_asm       # standalone ctypes path
+w_asm = torch.empty_like(w)
+i_asm = torch.empty_like(i)
+t_asm = torch.empty_like(t)
+topk_softmax_asm(w_asm, i_asm, t_asm, gate, False)
+torch.cuda.synchronize()
+assert torch.allclose(w_asm, want, atol=1e-5), "ctypes topk corrupted by interposed HIP"
+
+from aiter.fused_moe import moe_sorting             # sizes its grid from device props
+moe_sorting(i, w, e, 1024, torch.bfloat16)
+torch.cuda.synchronize()
+
+from aiter.ops.mha import fmha_v3_varlen_fwd        # Kimi-K3 failure path
+q = torch.randn((128, 8, 128), device="cuda", dtype=torch.bfloat16)
+cu = torch.tensor([0, 128], device="cuda", dtype=torch.int32)
+fmha_v3_varlen_fwd(
+    q, q, q, cu, cu, 128, 128, 0, 0.0, 1.0 / math.sqrt(128), 0.0,
+    False, False, -1, -1, False, False, 1,
+)
+torch.cuda.synchronize()
+print("OK")
+"""
+
+
+def test_deep_import_leaves_process_dlopen_flags_alone():
+    """A process-wide flag would be inherited by unrelated concurrent dlopens."""
+    handles = dict(core._deep_handles)
+    before = sys.getdlopenflags()
+    core._deep_import("json")  # pure Python: nothing to pre-open
+    assert sys.getdlopenflags() == before
+    assert core._deep_handles == handles
+
+
+def test_deep_import_predlopens_extension(monkeypatch):
+    origin = "/tmp/module_deepbind_test.so"
+    handle = object()
+    module = object()
+    seen = {}
+
+    monkeypatch.setattr(core, "_RTLD_DEEPBIND", os.RTLD_DEEPBIND)
+    monkeypatch.setattr(
+        core.importlib.util,
+        "find_spec",
+        lambda name: types.SimpleNamespace(origin=origin),
+    )
+
+    def fake_cdll(path, mode):
+        seen["path"] = path
+        seen["mode"] = mode
+        return handle
+
+    monkeypatch.setattr(core.ctypes, "CDLL", fake_cdll)
+    monkeypatch.setattr(core.importlib, "import_module", lambda name: module)
+    core._deep_handles.pop(origin, None)
+    try:
+        assert core._deep_import("module_deepbind_test") is module
+        assert seen == {"path": origin, "mode": os.RTLD_NOW | os.RTLD_DEEPBIND}
+        assert core._deep_handles[origin] is handle
+    finally:
+        core._deep_handles.pop(origin, None)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("0", os.RTLD_LAZY | os.RTLD_DEEPBIND), ("1", os.RTLD_LAZY)],
+)
+def test_generated_python_loader_mode(monkeypatch, value, expected):
+    """The standalone generated-library loader follows the same opt-out."""
+    from csrc.cpp_itfs import utils
+
+    symbol = object()
+    seen = {}
+
+    def fake_cdll(path, mode):
+        seen.update(path=path, mode=mode)
+        return types.SimpleNamespace(test_symbol=symbol)
+
+    monkeypatch.setenv("AITER_DISABLE_DEEPBIND", value)
+    monkeypatch.setattr(utils, "BUILD_DIR", "/tmp/aiter-loader-test")
+    monkeypatch.setattr(utils.ctypes, "CDLL", fake_cdll)
+    utils.run_lib.cache_clear()
+    try:
+        assert utils.run_lib("test_symbol", "test_folder") is symbol
+        assert seen == {
+            "path": "/tmp/aiter-loader-test/test_folder/lib.so",
+            "mode": expected,
+        }
+    finally:
+        utils.run_lib.cache_clear()
+
+
+def test_core_loader_optout_is_applied_at_import():
+    """The documented process-start opt-out must affect the actual mode flag."""
+    script = "from aiter.jit import core; print(core._RTLD_DEEPBIND)"
+    for value, expected in (("0", os.RTLD_DEEPBIND), ("1", 0)):
+        env = os.environ.copy()
+        env["AITER_DISABLE_DEEPBIND"] = value
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert int(proc.stdout.strip().splitlines()[-1]) == expected
+
+
+def test_aiter_survives_a_global_hip_interposer(tmp_path):
+    """AITER must stay correct with an interposer loaded first.
+
+    Runs in a subprocess: loaded objects and their global ordering cannot be
+    reset in-process, so the failing order has to be built from scratch.
+    """
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("no GPU")
+    cc = shutil.which("gcc") or shutil.which("cc")
+    if cc is None:
+        pytest.skip("no C compiler for the interposer")
+
+    src = tmp_path / "interposer.c"
+    src.write_text(_STUB_C)
+    stub = tmp_path / "libinterposer.so"
+    build = subprocess.run(
+        [cc, "-shared", "-fPIC", "-o", str(stub), str(src), "-ldl"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if build.returncode != 0:
+        pytest.skip(f"could not build interposer: {build.stderr}")
+
+    script = tmp_path / "interpose.py"
+    script.write_text(_INTERPOSE_SCRIPT)
+    env = os.environ.copy()
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env["PYTHONPATH"] = os.pathsep.join(
+        path for path in (repo_root, env.get("PYTHONPATH")) if path
+    )
+    proc = subprocess.run(
+        [sys.executable, str(script), str(stub)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert "OK" in proc.stdout
+
+    # Prove that the interposer is effective, so the protected run above
+    # cannot pass merely because the test setup failed to reproduce the bug.
+    unprotected_env = env.copy()
+    unprotected_env["AITER_DISABLE_DEEPBIND"] = "1"
+    unprotected = subprocess.run(
+        [sys.executable, str(script), str(stub)],
+        env=unprotected_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert unprotected.returncode != 0, "interposer did not reproduce the bug"
+    failure = f"{unprotected.stdout}\n{unprotected.stderr}".lower()
+    assert "invalid argument" in failure or "invalid configuration" in failure
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Load AITER-owned native objects with per-object `RTLD_DEEPBIND` where it is available. This prevents a HIP compatibility stub that was loaded earlier into the ELF global scope from interposing incompatible HIP symbols in AITER JIT extensions.

Related to [AITER issue #4585](https://github.com/ROCm/aiter/issues/4585), which contains the standalone real-library reproducer, controlled loader results, and the full TileLang/vLLM root-cause analysis.

The loader covers all native-library paths currently used by AITER:

- pybind extensions imported by `aiter.jit.core`;
- standalone libraries loaded with `ctypes`;
- generated Python loaders; and
- nested libraries opened by the C++ `SharedLibrary` helper.

The implementation does not change the process-wide `sys.setdlopenflags()` state. `AITER_DISABLE_DEEPBIND=1` provides a process-start opt-out for ASan, intentional `LD_PRELOAD` interposition, or tools that are incompatible with deep binding.

This PR is intended as a reference implementation and regression test, depends on how necessary of the protection is needed. 

## Problem

This is an ELF symbol-interposition failure caused by the interaction of a TileLang 0.1.10 HIP stub, TVM's global loading policy, and AITER extensions that are loaded later. It is not an invalid FMHA input. The vLLM regression, import chain, CI failures, and original AITER MoE reproducer are tracked in [vLLM issue #51151](https://github.com/vllm-project/vllm/issues/51151).

### What TileLang's HIP stub is intended to do

[TileLang #1867](https://github.com/tile-ai/tilelang/pull/1867) added `libhip_stub.so` so TileLang/TVM can be imported without eagerly linking the real HIP runtime. The stub exports drop-in HIP wrapper functions. On first use, it locates `libamdhip64.so` and resolves the real functions with `dlopen`/`dlsym`.

That implementation creates two separate cross-library problems in TileLang 0.1.10.

### 1. The private stub enters the process-global symbol scope

Importing TileLang imports its bundled TVM Python package. [TVM deliberately opens `libtvm_runtime.so` with `RTLD_GLOBAL`](https://github.com/tile-ai/tvm/blob/8df8ebd61659505dd7005f4820b030e983e2c005/python/tvm/base.py#L51-L53):

```python
_LIB_RUNTIME = libinfo.load_lib_ctypes(
    "tvm", "tvm_runtime", "RTLD_GLOBAL", extra_lib_paths=_extra_lib_paths
)
```

The packaged `libtvm_runtime.so` has a `DT_NEEDED` dependency on `libhip_stub.so`:

```text
$ readelf -d tilelang/lib/libtvm_runtime.so | grep hip_stub
NEEDED  Shared library: [libhip_stub.so]
```

The global loading mode applies to that dependency group. Consequently, the stub's standard `hip*` wrapper names become eligible to satisfy symbol references from unrelated libraries loaded later in the process. In the pinned image, the installed stub exports 30 HIP functions, including `hipMalloc`, `hipFree`, `hipGetDevice`, `hipModuleLaunchKernel`, and:

```text
$ readelf -Ws tilelang/lib/libhip_stub.so | grep hipGetDeviceProperties
FUNC GLOBAL ... hipGetDevicePropertiesR0600
```

An AITER JIT extension normally loaded afterward can therefore resolve a HIP reference to TileLang's stub even though the extension itself has a dependency on the real `libamdhip64.so`.

### 2. `hipGetDeviceProperties` crosses an incompatible ABI boundary

With current ROCm headers, the source-level API and type are macros:

```c
#define hipGetDeviceProperties hipGetDevicePropertiesR0600
#define hipDeviceProp_t hipDeviceProp_tR0600
```

The wrapper in [TileLang v0.1.10 `hip.cc`](https://github.com/tile-ai/tilelang/blob/v0.1.10/src/backend/rocm/stubs/hip.cc) is written with those source-level names:

```cpp
hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int device_id) {
  return HIPDriverAPI::get()->hipGetDeviceProperties_(prop, device_id);
}
```

The preprocessor therefore compiles this as a wrapper exported under `hipGetDevicePropertiesR0600` and taking an `hipDeviceProp_tR0600*`. However, the dispatch table resolves a hard-coded string:

```cpp
LOOKUP(hipGetDeviceProperties_, "hipGetDeviceProperties")
```

Macro expansion does not happen inside a string literal. The R0600 wrapper therefore calls the legacy, unversioned function. The callee writes a different device-properties layout into memory that the caller interprets as `hipDeviceProp_tR0600`. The call can return without an obvious loader error, but fields used for device selection and kernel launch sizing are invalid.

### How this reaches AITER and Kimi-K3

The failing order in vLLM is:

```text
vLLM probes an optional TileLang kernel
  -> import tilelang
  -> TVM loads libtvm_runtime.so with RTLD_GLOBAL
  -> DT_NEEDED loads libhip_stub.so into global scope

AITER later imports module_fmha_v3_varlen_fwd.so
  -> its hipGetDevicePropertiesR0600 reference binds to TileLang's stub
  -> the stub forwards to legacy hipGetDeviceProperties
  -> AITER reads an R0600 structure populated with the wrong layout
  -> a valid FMHA call is rejected
```

`LD_DEBUG=bindings` confirms the critical binding in the Kimi-K3 process:

```text
module_fmha_v3_varlen_fwd.so -> tilelang/lib/libhip_stub.so:
hipGetDevicePropertiesR0600 [hip_6.0]
```

A valid BF16/head-size-128 invocation then fails with the misleading error:

```text
RuntimeError: invalid argument for fmha_v3_varlen_fwd
```

The same mechanism also explains the `invalid configuration argument` failures seen in AITER MoE paths: corrupted device properties are cached and later used to calculate a kernel launch grid. This was the initially reported failure in [vLLM issue #51151](https://github.com/vllm-project/vllm/issues/51151), which shows the TileLang import chain and a minimal `topk_softmax`/`moe_sorting` reproducer.

The following controls use the same image, tensors, AITER operation, and real TileLang library. They isolate global visibility as the condition that changes the result:

| State before the AITER extension is loaded | Result |
| --- | --- |
| Do not load `libhip_stub.so` | PASS |
| Load the same stub with `RTLD_LOCAL` | PASS |
| Load the same stub with `RTLD_GLOBAL` | FAIL: `invalid argument` |
| Load the stub globally, then promote `libamdhip64.so` globally | FAIL |

### Why vLLM #50879 exposed it

[vLLM #50879](https://github.com/vllm-project/vllm/pull/50879) changed optional expert-parallel imports from eager to selected-branch imports. Before that change, the guarded Mori import happened early and opened the real HIP runtime with `RTLD_GLOBAL` before TileLang. That favorable load order accidentally masked the TileLang interposer. The resulting ROCm regression was reported and analyzed in [vLLM issue #51151](https://github.com/vllm-project/vllm/issues/51151).

After Mori became lazy, Kimi-K3—which does not select Mori—could import TileLang first. The PR exposed an existing load-order dependency; it did not create the TileLang ABI bug. [vLLM #51110](https://github.com/vllm-project/vllm/pull/51110) restores the guarded eager Mori import as a compatibility hotfix, but it only restores the masking order. [vLLM #51159](https://github.com/vllm-project/vllm/pull/51159) instead defers the TileLang import on ROCm and fixes the reported vLLM startup path, but it also avoids the trigger by changing import timing rather than correcting TileLang's exported symbols or protecting AITER's loader.

### Permanent TileLang correction

The originating corrections belong in TileLang:

1. resolve the ABI-selected symbol, for example by stringifying the expanded `hipGetDeviceProperties` macro rather than using an unversioned literal; and
2. avoid exporting standard HIP compatibility symbols through a globally loaded dependency, for example by using hidden visibility or TileLang-prefixed wrapper names.

This AITER change is independent defensive hardening. Even after TileLang fixes this specific stub, an AITER extension can encounter other global interposers. AITER's native objects should not accidentally bind their HIP dependencies to an unrelated optional backend solely because that backend was imported first.

## Why promoting libamdhip64 with RTLD_GLOBAL is insufficient

The previous version of this PR promoted the real `libamdhip64.so` handle into the global scope. That does not fix a process in which the incompatible stub is already earlier in ELF global lookup order; reopening the real HIP runtime does not reorder that scope. The controlled reproduction still fails in this order:

```text
RTLD_GLOBAL TileLang stub -> RTLD_GLOBAL libamdhip64 -> import AITER extension
```

Likewise, eagerly importing AITER before TileLang only changes load order. It can mask the problem, but it does not protect later or lazily compiled AITER extensions.

## Fix

For a pybind extension, `_deep_import()` first resolves the extension path and opens that exact object with:

```python
os.RTLD_NOW | os.RTLD_DEEPBIND
```

The normal Python import then reuses the already loaded object. AITER retains the `ctypes.CDLL` handle for process lifetime. This is scoped to the AITER object and avoids a temporary process-global flag change, which would be racy with unrelated imports in other threads.

The same policy is applied directly to AITER's other `ctypes` and C++ `dlopen` paths. On platforms where `RTLD_DEEPBIND` is unavailable, the added flag is zero and the existing loader behavior is preserved.

Set the following before importing AITER to disable the policy:

```bash
export AITER_DISABLE_DEEPBIND=1
```

This opt-out is necessary for AddressSanitizer because ASan explicitly rejects objects opened with `RTLD_DEEPBIND`. It is also useful when HIP interposition is deliberate. Disabling it restores the original loader behavior and therefore also re-exposes AITER to this TileLang failure.
## Reproduction

This deterministic reproducer explicitly places TileLang's real HIP stub in the
global ELF scope before AITER loads its FMHA extension. It does not depend on
vLLM's current optional-kernel import order.

```text
Image: vllm/vllm-openai-rocm:nightly-cb8104839c141609d99f1254459ef3a4f1bd4263
Digest: sha256:d22922d540810d90c5a3eafe91d3b4a62c2b881f3e990d0b7180b2875a5d176d
AITER 0.1.19, TileLang 0.1.10, ROCm 7.2.3, gfx950
```

```bash
IMAGE=vllm/vllm-openai-rocm:nightly-cb8104839c141609d99f1254459ef3a4f1bd4263
DIGEST=sha256:d22922d540810d90c5a3eafe91d3b4a62c2b881f3e990d0b7180b2875a5d176d

docker run --rm -i \
  --device=/dev/kfd --device=/dev/dri --group-add video --ipc=host \
  --entrypoint python3 "${IMAGE}@${DIGEST}" - <<'PY'
import ctypes
import importlib.util
import math
from pathlib import Path

import torch

spec = importlib.util.find_spec("tilelang")
root = Path(next(iter(spec.submodule_search_locations)))
ctypes.CDLL(str(root / "lib" / "libhip_stub.so"), mode=ctypes.RTLD_GLOBAL)

from aiter.ops.mha import fmha_v3_varlen_fwd

q = torch.randn((128, 8, 128), device="cuda", dtype=torch.bfloat16)
cu = torch.tensor([0, 128], device="cuda", dtype=torch.int32)
fmha_v3_varlen_fwd(
    q, q, q, cu, cu, 128, 128, 0, 0.0, 1.0 / math.sqrt(128), 0.0,
    False, False, -1, -1, False, False, 1,
)
torch.cuda.synchronize()
print("PASS")
PY
```

The existing loader fails with:

```text
RuntimeError: invalid argument for fmha_v3_varlen_fwd
```

With this PR, the same invocation prints `PASS`. Setting
`AITER_DISABLE_DEEPBIND=1` restores the failure, confirming that the result
comes from loader isolation. Full controls and loader evidence are in
[AITER issue #4585](https://github.com/ROCm/aiter/issues/4585).

## Validation

The regression test covers pybind, standalone `ctypes`, generated-library,
MoE sorting, and Kimi-K3 FMHA loading paths.

```text
pytest -q -p no:cacheprovider op_tests/test_jit_loader.py
6 passed

ruff check --no-cache <changed Python files>
All checks passed!

black --check <changed Python files>
All done!
```

The C++ loader change also passes a syntax-only compile in the same container.

### Kimi-K3 model A/B

The real Kimi-K3 MXFP4 checkpoint was tested on 8x MI355X with TP8 and a 1M
maximum context. The test used the immutable image above, vLLM source at
`d31de3c421c0281a959ac1a3cbe1a7f354bae179`, and a controlled
Torch -> global TileLang stub -> AITER load order.

```text
Existing loader:
  encoder profiling fails with invalid argument for fmha_v3_varlen_fwd

This PR:
  gfx950 BF16 FMHA loads
  19/19 decode graphs complete
  API health and a real chat completion return HTTP 200
  invalid argument/configuration errors: 0
```

The pinned nightly has an unrelated Gluon API mismatch: Triton expects
`block_bases`, while the tested AITER MLA source passes `cga_layout`. The
end-to-end run therefore used `VLLM_ROCM_USE_AITER_MLA=0`. The affected ViT
FMHA path remained AITER-backed and exercised the loader changed by this PR.

No documentation file is included in this PR.

## Related

- [AITER issue #4585](https://github.com/ROCm/aiter/issues/4585)
- [vLLM #50879](https://github.com/vllm-project/vllm/pull/50879)
- [vLLM #51110](https://github.com/vllm-project/vllm/pull/51110)
- [vLLM #51151](https://github.com/vllm-project/vllm/issues/51151)
- [vLLM #51159](https://github.com/vllm-project/vllm/pull/51159)
- [TileLang #1867](https://github.com/tile-ai/tilelang/pull/1867)

Prepared with OpenAI Codex assistance.