### PR TITLE
[Trition] Add chunk_delta_attn triton kernels

### DIFF
--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/__init__.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+"""
+chunk_delta_attn – Triton kernels for the chunk-based delta-attention
+forward pass (prefill / training).
+
+Public API
+----------
+chunk_delta_attn_fwd          Top-level forward: gate cumsum → intra → inter → output.
+chunk_delta_attn_fwd_intra    Intra-chunk attention (Aqk/Akk + W/U recompute).
+chunk_gla_fwd_o               GLA output kernel (q*exp2(g)*h + A*v).
+recompute_w_u_fwd             W/U recompute from Akk inverse.
+chunk_gate_cumsum             Fused gate (A_log/softplus/sigmoid) + chunk cumsum.
+beta_sigmoid_fwd              Elementwise sigmoid for beta gate.
+chunk_delta_attn_gate_fwd     Per-token gate without cumsum (forward only).
+"""
+
+from .chunk_fwd import chunk_delta_attn_fwd
+from .gate import beta_sigmoid_fwd, chunk_delta_attn_gate_fwd
+from .gla_output import chunk_gla_fwd_o
+from .intra_attn import chunk_delta_attn_fwd_intra
+from .utils.cumsum import chunk_gate_cumsum
+from .wy_fast import recompute_w_u_fwd
+
+__all__ = [
+    "beta_sigmoid_fwd",
+    "chunk_delta_attn_fwd",
+    "chunk_delta_attn_fwd_intra",
+    "chunk_delta_attn_gate_fwd",
+    "chunk_gate_cumsum",
+    "chunk_gla_fwd_o",
+    "recompute_w_u_fwd",
+]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_fwd.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_fwd.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""
+Top-level forward function for chunk_delta_attn.
+
+Pipeline:
+  1. Gate cumsum:  apply fused A_log / dt_bias / softplus (or sigmoid) gating
+                   and chunk-local prefix sum to produce gk (in log2 space).
+  2. Intra-chunk:  compute Aqk, Akk inverse, and auxiliary W/U/KG tensors.
+  3. Inter-chunk:  update recurrent hidden state H via chunk_gated_delta_rule_fwd_h.
+  4. Output:       compute final output via chunk_gla_fwd_o (gated q * h + A * v).
+"""
+
+import torch
+
+from ..gated_delta_rule.prefill.chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from .gate import beta_sigmoid_fwd
+from .gla_output import chunk_gla_fwd_o
+from .intra_attn import chunk_delta_attn_fwd_intra
+from .utils import (
+    RCP_LN2,
+    chunk_gate_cumsum,
+    l2norm_fwd,
+    prepare_chunk_indices,
+)
+
+
+def chunk_delta_attn_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    safe_gate: bool = False,
+    lower_bound: float | None = None,
+    use_gate_in_kernel: bool = False,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    disable_recompute: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
+    state_v_first: bool = False,
+) -> tuple:
+    """
+    Forward pass for chunk_delta_attn.
+
+    Args:
+        q:                  Query      ``[B, T, H, K]``.
+        k:                  Key        ``[B, T, H, K]``.
+        v:                  Value      ``[B, T, HV, V]``.
+        g:                  Gate input ``[B, T, HV, K]``.
+                            If ``use_gate_in_kernel=True`` this is raw gate
+                            (A_log / softplus / sigmoid applied inside the kernel).
+                            If ``use_gate_in_kernel=False`` this is a pre-computed
+                            gate (only chunk-local cumsum is applied).
+        beta:               Beta gate  ``[B, T, HV]``. Raw logits if
+                            ``use_beta_sigmoid_in_kernel=True``, post-sigmoid otherwise.
+        scale:              Attention scale (1 / sqrt(K) or similar).
+        initial_state:      Initial recurrent state ``[N, HV, K, V]`` or None
+                            (``[N, HV, V, K]`` when ``state_v_first=True``).
+        output_final_state: Whether to return the final recurrent state.
+        cu_seqlens:         Cumulative sequence lengths for variable-length mode.
+        chunk_indices:      Pre-computed chunk index pairs (computed if None).
+        chunk_size:         Chunk size BT, either 32 or 64 (default 64).
+        safe_gate:          Use the sub-chunk intra kernel (more stable at boundaries).
+        lower_bound:        If set, use sigmoid gating; else softplus gating.
+        use_gate_in_kernel: If True, fuse A_log / dt_bias into the gate cumsum.
+        A_log:              Per-head log-scale ``[HV]`` (needed when use_gate_in_kernel).
+        dt_bias:            Per-head dt bias ``[HV * K]`` (optional).
+        disable_recompute:  If True, store QG/KG/W/U for reuse (not freed early).
+        use_qk_l2norm_in_kernel: If True, apply L2 normalization to q and k.
+        use_beta_sigmoid_in_kernel: If True, apply sigmoid to beta.
+        state_v_first:      Store the recurrent state V-first (``[V, K]``) instead
+                            of the default ``[K, V]``. Matches fla's option of the
+                            same name.
+
+    Returns:
+        (o, final_state, g_cumsum, Aqk, Akk, w, u, qg, kg)
+          o           ``[B, T, HV, V]``
+          final_state ``[N, HV, K, V]`` (or ``[N, HV, V, K]``) or None
+          g_cumsum    ``[B, T, HV, K]`` (gate in log2 space)
+          Aqk         ``[B, T, HV, BT]``
+          Akk         ``[B, T, HV, BT]``
+          w, u, qg, kg or None depending on disable_recompute
+    """
+    if chunk_size not in (32, 64):
+        raise ValueError(
+            f"`chunk_size` must be either 32 or 64 for chunk_delta_attn, got {chunk_size}."
+        )
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    # ------------------------------------------------------------------
+    # Step 0 — Optional QK L2 normalization (matches FLA API)
+    # ------------------------------------------------------------------
+    if use_qk_l2norm_in_kernel:
+        q, _ = l2norm_fwd(q)
+        k, _ = l2norm_fwd(k)
+
+    if use_beta_sigmoid_in_kernel:
+        beta = beta_sigmoid_fwd(beta)
+
+    # ------------------------------------------------------------------
+    # Step 1 — Gate cumsum
+    # ------------------------------------------------------------------
+    if use_gate_in_kernel:
+        assert A_log is not None, "A_log required when use_gate_in_kernel=True"
+        g_cumsum = chunk_gate_cumsum(
+            g=g,
+            A_log=A_log,
+            chunk_size=chunk_size,
+            scale=RCP_LN2,
+            dt_bias=dt_bias,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            lower_bound=lower_bound,
+        )
+    else:
+        from ..gated_delta_rule.utils import chunk_local_cumsum
+
+        g_cumsum = chunk_local_cumsum(
+            g=g,
+            chunk_size=chunk_size,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    # ------------------------------------------------------------------
+    # Step 2 — Intra-chunk (sub_chunk + inter_solve + recompute_w_u)
+    # ------------------------------------------------------------------
+    w, u, qg, kg, Aqk, Akk = chunk_delta_attn_fwd_intra(
+        q=q,
+        k=k,
+        v=v,
+        gk=g_cumsum,
+        beta=beta,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        safe_gate=safe_gate,
+        disable_recompute=disable_recompute,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3 — Inter-chunk hidden state update
+    # ------------------------------------------------------------------
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=kg,
+        w=w,
+        u=u,
+        gk=g_cumsum,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        transpose_state=state_v_first,
+        use_exp2=True,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 4 — Output
+    # ------------------------------------------------------------------
+    o = chunk_gla_fwd_o(
+        q=q,
+        v=v_new,
+        g=g_cumsum,
+        A=Aqk,
+        h=h,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        use_exp2=True,
+    )
+
+    if not disable_recompute:
+        w, u, qg, kg, v_new = None, None, None, None, None
+        h = None
+
+    return o, final_state, g_cumsum, Aqk, Akk, w, u, qg, kg

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gate.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gate.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""
+Gate activation kernels for chunk_delta_attn.
+
+Provides:
+  - beta_sigmoid_fwd: elementwise sigmoid for the beta gate (forward only).
+  - chunk_delta_attn_gate_fwd: per-token fused gate (-exp(A)*softplus or
+    lower_bound*sigmoid(exp(A)*g)) without cumsum (forward only).
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import autotune_cache_kwargs, exp, input_guard, softplus
+
+_BETA_SIGMOID_BLOCK_SIZE = 2048
+_BETA_SIGMOID_NUM_WARPS = 8
+
+BT_LIST = [32, 64, 128]
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16]
+
+
+@triton.jit
+def beta_sigmoid_fwd_kernel(
+    x,
+    y,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    mask = offs < n_elements
+    b_x = tl.load(x + offs, mask=mask, other=0).to(tl.float32)
+    b_y = tl.sigmoid(b_x)
+    tl.store(y + offs, b_y.to(y.dtype.element_ty), mask=mask)
+
+
+@input_guard
+def beta_sigmoid_fwd(x: torch.Tensor) -> torch.Tensor:
+    """Elementwise sigmoid of ``x``, output in float32."""
+    y = torch.empty_like(x, dtype=torch.float32)
+    n = x.numel()
+    grid = (triton.cdiv(n, _BETA_SIGMOID_BLOCK_SIZE),)
+    beta_sigmoid_fwd_kernel[grid](
+        x,
+        y,
+        n,
+        BLOCK_SIZE=_BETA_SIGMOID_BLOCK_SIZE,
+        num_warps=_BETA_SIGMOID_NUM_WARPS,
+    )
+    return y
+
+
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": BT}, num_warps=nw, num_stages=ns)
+        for BT in BT_LIST
+        for nw in NUM_WARPS_AUTOTUNE
+        for ns in [2, 3]
+    ],
+    key=["H", "D"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_delta_attn_gate_fwd_kernel(
+    g,
+    A_log,
+    dt_bias,
+    yg,
+    lower_bound,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    """Per-token gate: yg = -exp(A) * softplus(g + bias)  OR  lb * sigmoid(exp(A) * g)."""
+    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
+
+    b_A = tl.load(A_log + i_h).to(tl.float32)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_g = m_t[:, None] & (o_d[None, :] < D)
+    p_g = g + i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
+    p_yg = yg + i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
+
+    b_g = tl.load(p_g, mask=m_g, other=0.0).to(tl.float32)
+
+    if HAS_BIAS:
+        o_b = i_h * D + tl.arange(0, BD)
+        b_g = b_g + tl.load(dt_bias + o_b, mask=o_b < H * D, other=0.0).to(tl.float32)
+
+    if not USE_LOWER_BOUND:
+        b_yg = -exp(b_A) * softplus(b_g)
+    else:
+        b_yg = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+
+    tl.store(p_yg, b_yg.to(p_yg.dtype.element_ty), mask=m_g)
+
+
+@input_guard
+def chunk_delta_attn_gate_fwd(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """
+    Per-token gate (no cumsum).
+
+    Args:
+        g:            Gate input ``[..., H, D]``.
+        A_log:        Per-head log-scale ``[H]``.
+        dt_bias:      Optional per-head bias ``[H * D]``.
+        lower_bound:  If set, use sigmoid gating; else softplus gating.
+        output_dtype: Output dtype (default float32).
+
+    Returns:
+        Gated tensor, same shape as ``g``.
+    """
+    H, D = g.shape[-2:]
+    T = g.numel() // (H * D)
+
+    yg = torch.empty_like(g, dtype=output_dtype)
+
+    def grid(meta):
+        return (triton.cdiv(T, meta["BT"]), H)
+
+    chunk_delta_attn_gate_fwd_kernel[grid](
+        g=g,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        yg=yg,
+        lower_bound=lower_bound,
+        T=T,
+        H=H,
+        D=D,
+        BD=triton.next_power_of_2(D),
+    )
+    return yg

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gla_output.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gla_output.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang
+
+"""
+GLA output computation for chunk_delta_attn forward pass.
+
+``chunk_gla_fwd_o`` computes the final attention output:
+    o = (q * exp2(gk)) @ h * scale  +  A @ v_new
+where h is the recurrent hidden state and A is the local intra-chunk attention
+matrix (Aqk).
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import (
+    autotune_cache_kwargs,
+    chunk_delta_attn_autotune_configs,
+    exp,
+    exp2,
+    input_guard,
+    prepare_chunk_indices,
+)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=chunk_delta_attn_autotune_configs(
+        [
+            triton.Config({"BK": BK, "BV": BV}, num_warps=nw, num_stages=ns)
+            for BK in [32, 64]
+            for BV in [64, 128]
+            for nw in [2, 4, 8]
+            for ns in [2, 3, 4]
+        ],
+        default_config=triton.Config({"BK": 64, "BV": 128}, num_warps=8, num_stages=3),
+    ),
+    key=["BT", "HV", "TRANSPOSE_STATE"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_kernel_o(
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = (
+        tl.program_id(0),
+        tl.program_id(1).to(tl.int64),
+        tl.program_id(2).to(tl.int64),
+    )
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_tg = i_t.to(tl.int64)
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = (i_b * NT + i_t).to(tl.int64)
+        bos = (i_b * T).to(tl.int64)
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    q += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    v += (bos * HV + i_hv) * V
+    o += (bos * HV + i_hv) * V
+    h += (i_tg * HV + i_hv).to(tl.int64) * K * V
+    A += (bos * HV + i_hv) * BT
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_tk = m_t[:, None] & m_k[None, :]
+        p_q = q + o_t[:, None] * (H * K) + o_k[None, :]
+        p_g = g + o_t[:, None] * (HV * K) + o_k[None, :]
+        if TRANSPOSE_STATE:
+            p_h = h + o_v[:, None] * K + o_k[None, :]
+            m_h = m_v[:, None] & m_k[None, :]
+        else:
+            p_h = h + o_k[:, None] * V + o_v[None, :]
+            m_h = m_k[:, None] & m_v[None, :]
+
+        b_q = tl.load(p_q, mask=m_tk, other=0.0)
+        b_g = tl.load(p_g, mask=m_tk, other=0.0).to(tl.float32)
+        if USE_EXP2:
+            b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+        else:
+            b_qg = (b_q * exp(b_g)).to(b_q.dtype)
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
+        if TRANSPOSE_STATE:
+            b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+        else:
+            b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+
+    b_o *= scale
+
+    o_A = tl.arange(0, BT)
+    m_tv = m_t[:, None] & m_v[None, :]
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_v = v + o_t[:, None] * (HV * V) + o_v[None, :]
+    p_o = o + o_t[:, None] * (HV * V) + o_v[None, :]
+    p_A = A + o_t[:, None] * (HV * BT) + o_A[None, :]
+
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
+    b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+    b_o += tl.dot(b_A, b_v)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tv)
+
+
+@input_guard
+def chunk_gla_fwd_o(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.Tensor | None = None,
+    use_exp2: bool = True,
+    transpose_state: bool = False,
+) -> torch.Tensor:
+    """
+    Compute the final output for chunk_delta_attn (Triton path).
+
+    Args:
+        q:              Query ``[B, T, H, K]``.
+        v:              (Modified) value ``[B, T, HV, V]``.
+        g:              Gate cumsum ``[B, T, HV, K]``.
+        A:              Aqk attention matrix ``[B, T, HV, BT]``.
+        h:              Recurrent hidden state ``[NT, B, HV, K, V]`` (or transposed).
+        scale:          Attention scale.
+        cu_seqlens:     Variable-length cumulative sequence lengths.
+        chunk_size:     Chunk size BT.
+        chunk_indices:  Pre-computed chunk index pairs for varlen mode.
+        use_exp2:       Whether g is in log2 space (True) or natural log (False).
+        transpose_state: Whether h has shape ``[..., V, K]`` (True) or ``[..., K, V]``.
+
+    Returns:
+        Output tensor ``[B, T, HV, V]``.
+    """
+    B, T, H, K = q.shape
+    HV = v.shape[2]
+    V = v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    o = torch.zeros_like(v)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * HV)
+
+    chunk_gla_fwd_kernel_o[grid](
+        q=q,
+        v=v,
+        g=g,
+        h=h,
+        o=o,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        USE_EXP2=use_exp2,
+        TRANSPOSE_STATE=transpose_state,
+    )
+    return o

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/intra_attn.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/intra_attn.py
@@ -1,0 +1,780 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""
+Intra-chunk attention kernels for chunk_delta_attn forward pass.
+
+Three-step pipeline:
+  1. Token-parallel kernel: computes diagonal Akk blocks + full Aqk row-by-row.
+  2. Sub-chunk intra kernel (safe-gate path): alternative diagonal-block kernel.
+  3. Fused inter + solve_tril kernel: computes off-diagonal Akk, then solves
+     the full chunk triangular system in one pass → writes Akk_inv.
+
+The Python dispatch ``chunk_delta_attn_fwd_intra`` orchestrates all three steps
+and returns w, u, qg, kg, Aqk, Akk as required by the top-level forward.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import (
+    IS_GATHER_SUPPORTED,
+    IS_TF32_SUPPORTED,
+    autotune_cache_kwargs,
+    chunk_delta_attn_autotune_configs,
+    exp2,
+    input_guard,
+    prepare_chunk_indices,
+)
+from .wy_fast import recompute_w_u_fwd
+
+if IS_TF32_SUPPORTED:
+    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")
+else:
+    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("ieee")
+
+
+# Fall back to a no-op gather if tl.gather is unavailable
+if IS_GATHER_SUPPORTED:
+    _gather = tl.gather
+else:
+
+    @triton.jit
+    def _gather(src, index, axis, _builder=None):
+        """Row-gather fallback: broadcasts the selected row across the output."""
+        return tl.sum(src * (tl.arange(0, src.shape[0]) == index)[:, None], 0)[None, :]
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=chunk_delta_attn_autotune_configs(
+        [
+            triton.Config({"BH": BH, "BK": BK}, num_warps=nw)
+            for BH in [1, 2, 4, 8]
+            for BK in [32, 64]
+            for nw in [1, 2, 4, 8]
+        ],
+        default_config=triton.Config({"BH": 1, "BK": 64}, num_warps=4),
+    ),
+    key=["K", "H", "HV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "N"])
+def chunk_delta_attn_fwd_kernel_intra_token_parallel(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    N,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BH: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Token-parallel: each thread-block handles one output token (i_tg) and
+    a BH-wide head stripe (i_hg).  Writes directly to Aqk and Akk.
+    """
+    i_tg, i_hg = tl.program_id(0).to(tl.int64), tl.program_id(1)
+
+    if IS_VARLEN:
+        i_n = 0
+        left, right = 0, N
+        for _ in range(20):
+            if left < right:
+                mid = (left + right) // 2
+                if i_tg < tl.load(cu_seqlens + mid + 1).to(tl.int32):
+                    right = mid
+                else:
+                    left = mid + 1
+        i_n = left
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+        i_t = i_tg - bos
+    else:
+        bos = (i_tg // T) * T
+        i_t = i_tg % T
+
+    if i_t >= T:
+        return
+
+    i_c = i_t // BT
+    i_s = (i_t % BT) // BC
+    i_tc = i_c * BT
+    i_ts = i_tc + i_s * BC
+
+    G: tl.constexpr = HV // H
+
+    q += bos * H * K
+    k += bos * H * K
+    g += bos * HV * K
+    Aqk += bos * HV * BT
+    Akk += bos * HV * BC
+    beta += bos * HV
+
+    o_hv = i_hg * BH + tl.arange(0, BH)
+    o_h = o_hv // G
+    m_hv = o_hv < HV
+
+    p_beta = beta + i_t * HV + o_hv
+    b_beta = tl.load(p_beta, mask=m_hv, other=0.0).to(tl.float32)
+
+    # Accumulate dot products across K-tiles (BK ≤ 64 to avoid slow tl.dot / huge scatter loads)
+    for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
+        b_Aqk_j = tl.zeros([BH], dtype=tl.float32)
+        b_Akk_j = tl.zeros([BH], dtype=tl.float32)
+        for i_k in range(tl.cdiv(K, BK)):
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            m_hk = m_hv[:, None] & m_k[None, :]
+            p_qk = o_h[:, None] * K + o_k[None, :]
+
+            b_q = tl.load(q + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+            b_k = tl.load(k + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+            b_kj = tl.load(k + j * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+
+            p_g = g + i_t * HV * K + o_hv[:, None] * K + o_k[None, :]
+            p_gj = g + j * HV * K + o_hv[:, None] * K + o_k[None, :]
+            b_g = tl.load(p_g, mask=m_hk, other=0.0).to(tl.float32)
+            b_gj = tl.load(p_gj, mask=m_hk, other=0.0).to(tl.float32)
+
+            b_kgj = tl.where(m_k[None, :], b_kj * exp2(b_g - b_gj), 0.0)
+            b_Aqk_j += tl.sum(b_q * b_kgj, axis=1)
+            b_Akk_j += tl.sum(b_k * b_beta[:, None] * b_kgj, axis=1)
+
+        b_Aqk_j *= scale
+        b_Akk_j *= tl.where(j < i_t, 1.0, 0.0)
+        tl.store(
+            Aqk + i_t * HV * BT + o_hv * BT + j % BT,
+            b_Aqk_j.to(Aqk.dtype.element_ty),
+            mask=m_hv,
+        )
+        tl.store(
+            Akk + i_t * HV * BC + o_hv * BC + j - i_ts,
+            b_Akk_j.to(Akk.dtype.element_ty),
+            mask=m_hv,
+        )
+
+
+def _chunk_delta_attn_fwd_intra_token_parallel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    sub_chunk_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K = q.shape
+    HV = gk.shape[2]
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BT = chunk_size
+    BC = sub_chunk_size
+
+    def grid(meta):
+        return (B * T, triton.cdiv(HV, meta["BH"]))
+
+    chunk_delta_attn_fwd_kernel_intra_token_parallel[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        N=N,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+    )
+    return Aqk, Akk
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=chunk_delta_attn_autotune_configs(
+        [
+            triton.Config({}, num_warps=nw, num_stages=ns)
+            for nw in [1, 2, 4, 8]
+            for ns in [2, 3, 4]
+        ],
+        default_config=triton.Config({}, num_warps=1, num_stages=3),
+    ),
+    key=["BT", "BC", "HV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_delta_attn_fwd_kernel_intra_sub_chunk(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_GATHER: tl.constexpr,
+):
+    i_t, i_i, i_bh = (
+        tl.program_id(0).to(tl.int64),
+        tl.program_id(1),
+        tl.program_id(2).to(tl.int64),
+    )
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_c = i_ti + tl.arange(0, BC)
+    m_c = o_c < T
+
+    q = q + (bos * H + i_h) * K
+    k = k + (bos * H + i_h) * K
+    g = g + (bos * HV + i_hv) * K
+    beta = beta + bos * HV + i_hv
+    Aqk = Aqk + (bos * HV + i_hv) * BT
+    Akk = Akk + (bos * HV + i_hv) * BC
+
+    p_beta = beta + o_c * HV
+    b_beta = tl.load(p_beta, mask=m_c, other=0.0)
+
+    # Reference gate at the mid-point of this sub-chunk (same for all K tiles)
+    i_gn = i_ti + min(BC // 2, T - i_ti - 1)
+
+    # Accumulate Aqk and Akk over K tiles (BK ≤ 64 to keep tl.dot shape small)
+    b_Aqk = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk = tl.zeros([BC, BC], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_ck = m_c[:, None] & m_k[None, :]
+        p_q = q + o_c[:, None] * (H * K) + o_k[None, :]
+        p_k = k + o_c[:, None] * (H * K) + o_k[None, :]
+        p_g = g + o_c[:, None] * (HV * K) + o_k[None, :]
+        b_q = tl.load(p_q, mask=m_ck, other=0.0)
+        b_k = tl.load(p_k, mask=m_ck, other=0.0)
+        b_g = tl.load(p_g, mask=m_ck, other=0.0)
+
+        if USE_GATHER:
+            b_gn = _gather(
+                b_g,
+                tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16),
+                axis=0,
+            )
+        else:
+            p_gn = g + i_gn * HV * K + o_k
+            b_gn = tl.load(p_gn, mask=m_k, other=0.0)
+            b_gn = b_gn[None, :]
+
+        b_gm = (b_g - b_gn).to(tl.float32)
+        b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.0)
+        b_gk = tl.where(m_c[:, None], exp2(-b_gm), 0.0)
+
+        b_kgt = tl.trans(b_k * b_gk)
+        b_Aqk += tl.dot(b_q * b_gq, b_kgt)
+        b_Akk += tl.dot(b_k * b_gq, b_kgt)
+
+    b_Aqk *= scale
+    b_Akk *= b_beta[:, None]
+
+    o_i = tl.arange(0, BC)
+    m_Aqk = o_i[:, None] >= o_i[None, :]
+    m_Akk = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
+    b_Akk = tl.where(m_Akk, b_Akk, 0.0)
+
+    m_Aqk_st = m_c[:, None] & (o_i[None, :] < BT)
+    m_Akk_st = m_c[:, None] & (o_i[None, :] < BC)
+    p_Aqk = Aqk + o_c[:, None] * (HV * BT) + (i_i * BC + o_i)[None, :]
+    p_Akk = Akk + o_c[:, None] * (HV * BC) + o_i[None, :]
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), mask=m_Aqk_st)
+
+    # Forward substitution (in-place into register, then store)
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), mask=m_Akk_st)
+    tl.debug_barrier()
+
+    b_Ai = -b_Akk
+    for i in range(2, min(BC, T - i_ti)):
+        b_a = -tl.load(Akk + (i_ti + i) * HV * BC + o_i)
+        b_a = tl.where(o_i < i, b_a, 0.0)
+        b_a += tl.sum(b_a[:, None] * b_Ai, 0)
+        b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
+    b_Ai += m_I
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), mask=m_Akk_st)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=chunk_delta_attn_autotune_configs(
+        [
+            triton.Config({"BK": BK}, num_warps=nw)
+            for BK in [32, 64]
+            for nw in [1, 2, 4]
+        ],
+        default_config=triton.Config({"BK": 32}, num_warps=1),
+    ),
+    key=["H", "HV", "K", "BT", "BC", "NC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_delta_attn_fwd_kernel_inter_solve_fused(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akkd,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    NC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_SAFE_GATE: tl.constexpr,
+):
+    """
+    Fused kernel:
+      1. Compute off-diagonal Aqk and Akk blocks (cross-sub-chunk).
+      2. Load diagonal Akkd blocks (fp32) computed by the previous kernel.
+      3. Forward-substitute diagonals → block-level Akk_inv.
+      4. Compute merged cross-diagonal Akk_inv blocks.
+      5. Write full Akk_inv to Akk.
+    """
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    Aqk += (bos * HV + i_hv) * BT
+    Akk += (bos * HV + i_hv) * BT
+    Akkd += (bos * HV + i_hv) * BC
+
+    o_i = tl.arange(0, BC)
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+    o_c0 = i_tc0 + o_i
+    o_c1 = i_tc1 + o_i
+    o_c2 = i_tc2 + o_i
+    o_c3 = i_tc3 + o_i
+    m_tc0 = o_c0 < T
+    m_A0 = m_tc0[:, None] & (o_i[None, :] < BT)
+    m_A1 = m_tc1[:, None] & (o_i[None, :] < BT)
+    m_A2 = m_tc2[:, None] & (o_i[None, :] < BT)
+    m_A3 = m_tc3[:, None] & (o_i[None, :] < BT)
+
+    b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk21 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        m_ck0 = m_tc0[:, None] & m_k[None, :]
+        p_k0 = k + o_c0[:, None] * (H * K) + o_k[None, :]
+        p_g0 = g + o_c0[:, None] * (HV * K) + o_k[None, :]
+        b_k0 = tl.load(p_k0, mask=m_ck0, other=0.0).to(tl.float32)
+        b_g0 = tl.load(p_g0, mask=m_ck0, other=0.0).to(tl.float32)
+
+        if i_tc1 < T:
+            m_ck1 = m_tc1[:, None] & m_k[None, :]
+            p_q1 = q + o_c1[:, None] * (H * K) + o_k[None, :]
+            p_k1 = k + o_c1[:, None] * (H * K) + o_k[None, :]
+            p_g1 = g + o_c1[:, None] * (HV * K) + o_k[None, :]
+            b_q1 = tl.load(p_q1, mask=m_ck1, other=0.0).to(tl.float32)
+            b_k1 = tl.load(p_k1, mask=m_ck1, other=0.0).to(tl.float32)
+            b_g1 = tl.load(p_g1, mask=m_ck1, other=0.0).to(tl.float32)
+            b_gn1 = tl.load(g + i_tc1 * HV * K + o_k, mask=m_k, other=0).to(tl.float32)
+            b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
+            b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0))
+            b_Aqk10 += tl.dot(b_q1 * b_gqn, b_kgt)
+            b_Akk10 += tl.dot(b_k1 * b_gqn, b_kgt)
+
+            if NC >= 3 and i_tc2 < T:
+                m_ck2 = m_tc2[:, None] & m_k[None, :]
+                p_q2 = q + o_c2[:, None] * (H * K) + o_k[None, :]
+                p_k2 = k + o_c2[:, None] * (H * K) + o_k[None, :]
+                p_g2 = g + o_c2[:, None] * (HV * K) + o_k[None, :]
+                b_q2 = tl.load(p_q2, mask=m_ck2, other=0.0).to(tl.float32)
+                b_k2 = tl.load(p_k2, mask=m_ck2, other=0.0).to(tl.float32)
+                b_g2 = tl.load(p_g2, mask=m_ck2, other=0.0).to(tl.float32)
+                b_gn2 = tl.load(g + i_tc2 * HV * K + o_k, mask=m_k, other=0).to(
+                    tl.float32
+                )
+                b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
+                b_qg2 = b_q2 * b_gqn2
+                b_kg2 = b_k2 * b_gqn2
+                b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0))
+                b_Aqk20 += tl.dot(b_qg2, b_kgt)
+                b_Akk20 += tl.dot(b_kg2, b_kgt)
+                b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1))
+                b_Aqk21 += tl.dot(b_qg2, b_kgt)
+                b_Akk21 += tl.dot(b_kg2, b_kgt)
+
+                if NC >= 4 and i_tc3 < T:
+                    m_ck3 = m_tc3[:, None] & m_k[None, :]
+                    p_q3 = q + o_c3[:, None] * (H * K) + o_k[None, :]
+                    p_k3 = k + o_c3[:, None] * (H * K) + o_k[None, :]
+                    p_g3 = g + o_c3[:, None] * (HV * K) + o_k[None, :]
+                    b_q3 = tl.load(p_q3, mask=m_ck3, other=0.0).to(tl.float32)
+                    b_k3 = tl.load(p_k3, mask=m_ck3, other=0.0).to(tl.float32)
+                    b_g3 = tl.load(p_g3, mask=m_ck3, other=0.0).to(tl.float32)
+                    b_gn3 = tl.load(g + i_tc3 * HV * K + o_k, mask=m_k, other=0).to(
+                        tl.float32
+                    )
+                    b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
+                    b_qg3 = b_q3 * b_gqn3
+                    b_kg3 = b_k3 * b_gqn3
+                    b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0))
+                    b_Aqk30 += tl.dot(b_qg3, b_kgt)
+                    b_Akk30 += tl.dot(b_kg3, b_kgt)
+                    b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1))
+                    b_Aqk31 += tl.dot(b_qg3, b_kgt)
+                    b_Akk31 += tl.dot(b_kg3, b_kgt)
+                    b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2))
+                    b_Aqk32 += tl.dot(b_qg3, b_kgt)
+                    b_Akk32 += tl.dot(b_kg3, b_kgt)
+
+    if i_tc1 < T:
+        p_Aqk10 = Aqk + o_c1[:, None] * (HV * BT) + o_i[None, :]
+        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), mask=m_A1)
+        p_b1 = beta + bos * HV + i_hv + o_c1 * HV
+        b_b1 = tl.load(p_b1, mask=m_tc1, other=0.0).to(tl.float32)
+        b_Akk10 *= b_b1[:, None]
+    if NC >= 3 and i_tc2 < T:
+        p_Aqk20 = Aqk + o_c2[:, None] * (HV * BT) + o_i[None, :]
+        p_Aqk21 = Aqk + o_c2[:, None] * (HV * BT) + (o_i + BC)[None, :]
+        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), mask=m_A2)
+        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), mask=m_A2)
+        p_b2 = beta + bos * HV + i_hv + o_c2 * HV
+        b_b2 = tl.load(p_b2, mask=m_tc2, other=0.0).to(tl.float32)
+        b_Akk20 *= b_b2[:, None]
+        b_Akk21 *= b_b2[:, None]
+    if NC >= 4 and i_tc3 < T:
+        p_Aqk30 = Aqk + o_c3[:, None] * (HV * BT) + o_i[None, :]
+        p_Aqk31 = Aqk + o_c3[:, None] * (HV * BT) + (o_i + BC)[None, :]
+        p_Aqk32 = Aqk + o_c3[:, None] * (HV * BT) + (o_i + 2 * BC)[None, :]
+        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), mask=m_A3)
+        p_b3 = beta + bos * HV + i_hv + o_c3 * HV
+        b_b3 = tl.load(p_b3, mask=m_tc3, other=0.0).to(tl.float32)
+        b_Akk30 *= b_b3[:, None]
+        b_Akk31 *= b_b3[:, None]
+        b_Akk32 *= b_b3[:, None]
+
+    p_Akk00 = Akkd + o_c0[:, None] * (HV * BC) + o_i[None, :]
+    p_Akk11 = Akkd + o_c1[:, None] * (HV * BC) + o_i[None, :]
+    b_Ai00 = tl.load(p_Akk00, mask=m_A0, other=0.0).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, mask=m_A1, other=0.0).to(tl.float32)
+    if NC >= 3:
+        p_Akk22 = Akkd + o_c2[:, None] * (HV * BC) + o_i[None, :]
+        b_Ai22 = tl.load(p_Akk22, mask=m_A2, other=0.0).to(tl.float32)
+    if NC >= 4:
+        p_Akk33 = Akkd + o_c3[:, None] * (HV * BC) + o_i[None, :]
+        b_Ai33 = tl.load(p_Akk33, mask=m_A3, other=0.0).to(tl.float32)
+
+    if not USE_SAFE_GATE:
+        m_A = o_i[:, None] > o_i[None, :]
+        m_I = o_i[:, None] == o_i[None, :]
+
+        b_Ai00 = -tl.where(m_A, b_Ai00, 0)
+        b_Ai11 = -tl.where(m_A, b_Ai11, 0)
+        if NC >= 3:
+            b_Ai22 = -tl.where(m_A, b_Ai22, 0)
+        if NC >= 4:
+            b_Ai33 = -tl.where(m_A, b_Ai33, 0)
+
+        for i in range(2, min(BC, T - i_tc0)):
+            b_a00 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a00 = tl.where(o_i < i, b_a00, 0.0)
+            b_a00 += tl.sum(b_a00[:, None] * b_Ai00, 0)
+            b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+        for i in range(BC + 2, min(2 * BC, T - i_tc0)):
+            b_a11 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a11 = tl.where(o_i < i - BC, b_a11, 0.0)
+            b_a11 += tl.sum(b_a11[:, None] * b_Ai11, 0)
+            b_Ai11 = tl.where((o_i == i - BC)[:, None], b_a11, b_Ai11)
+        if NC >= 3:
+            for i in range(2 * BC + 2, min(3 * BC, T - i_tc0)):
+                b_a22 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+                b_a22 = tl.where(o_i < i - 2 * BC, b_a22, 0.0)
+                b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
+                b_Ai22 = tl.where((o_i == i - 2 * BC)[:, None], b_a22, b_Ai22)
+        if NC >= 4:
+            for i in range(3 * BC + 2, min(4 * BC, T - i_tc0)):
+                b_a33 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+                b_a33 = tl.where(o_i < i - 3 * BC, b_a33, 0.0)
+                b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
+                b_Ai33 = tl.where((o_i == i - 3 * BC)[:, None], b_a33, b_Ai33)
+
+        b_Ai00 += m_I
+        b_Ai11 += m_I
+        if NC >= 3:
+            b_Ai22 += m_I
+        if NC >= 4:
+            b_Ai33 += m_I
+
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_Akk10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    if NC >= 3:
+        b_Ai21 = -tl.dot(
+            tl.dot(b_Ai22, b_Akk21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            b_Ai11,
+            input_precision=SOLVE_TRIL_DOT_PRECISION,
+        )
+        b_Ai20 = -tl.dot(
+            b_Ai22,
+            tl.dot(b_Akk20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+            + tl.dot(b_Akk21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            input_precision=SOLVE_TRIL_DOT_PRECISION,
+        )
+    if NC >= 4:
+        b_Ai32 = -tl.dot(
+            tl.dot(b_Ai33, b_Akk32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            b_Ai22,
+            input_precision=SOLVE_TRIL_DOT_PRECISION,
+        )
+        b_Ai31 = -tl.dot(
+            b_Ai33,
+            tl.dot(b_Akk31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
+            + tl.dot(b_Akk32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            input_precision=SOLVE_TRIL_DOT_PRECISION,
+        )
+        b_Ai30 = -tl.dot(
+            b_Ai33,
+            tl.dot(b_Akk30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+            + tl.dot(b_Akk31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
+            + tl.dot(b_Akk32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+            input_precision=SOLVE_TRIL_DOT_PRECISION,
+        )
+
+    p_Akk00 = Akk + o_c0[:, None] * (HV * BT) + o_i[None, :]
+    p_Akk10 = Akk + o_c1[:, None] * (HV * BT) + o_i[None, :]
+    p_Akk11 = Akk + o_c1[:, None] * (HV * BT) + (o_i + BC)[None, :]
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), mask=m_A0)
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), mask=m_A1)
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), mask=m_A1)
+    if NC >= 3:
+        p_Akk20 = Akk + o_c2[:, None] * (HV * BT) + o_i[None, :]
+        p_Akk21 = Akk + o_c2[:, None] * (HV * BT) + (o_i + BC)[None, :]
+        p_Akk22 = Akk + o_c2[:, None] * (HV * BT) + (o_i + 2 * BC)[None, :]
+        tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), mask=m_A2)
+        tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), mask=m_A2)
+        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), mask=m_A2)
+    if NC >= 4:
+        p_Akk30 = Akk + o_c3[:, None] * (HV * BT) + o_i[None, :]
+        p_Akk31 = Akk + o_c3[:, None] * (HV * BT) + (o_i + BC)[None, :]
+        p_Akk32 = Akk + o_c3[:, None] * (HV * BT) + (o_i + 2 * BC)[None, :]
+        p_Akk33 = Akk + o_c3[:, None] * (HV * BT) + (o_i + 3 * BC)[None, :]
+        tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), mask=m_A3)
+        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), mask=m_A3)
+
+
+@input_guard
+def chunk_delta_attn_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.Tensor | None = None,
+    safe_gate: bool = False,
+    disable_recompute: bool = False,
+) -> tuple:
+    """Intra-chunk attention (base Triton sub-chunk kernel)."""
+    B, T, H, K = k.shape
+    HV = gk.shape[2]
+    BT = chunk_size
+    if BT not in (32, 64):
+        raise ValueError(
+            f"chunk_delta_attn intra kernel only supports chunk_size 32 or 64, got {BT}."
+        )
+    BC = 16
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+
+    Aqk = torch.empty(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    Akk = torch.zeros(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    Akkd = torch.empty(B, T, HV, BC, device=k.device, dtype=torch.float32)
+
+    if safe_gate:
+        BK = min(64, triton.next_power_of_2(K))
+        grid = (NT, NC, B * HV)
+        chunk_delta_attn_fwd_kernel_intra_sub_chunk[grid](
+            q=q,
+            k=k,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            USE_GATHER=IS_GATHER_SUPPORTED,
+        )
+    else:
+        _chunk_delta_attn_fwd_intra_token_parallel(
+            q=q,
+            k=k,
+            gk=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=BT,
+            sub_chunk_size=BC,
+        )
+
+    grid = (NT, B * HV)
+    chunk_delta_attn_fwd_kernel_inter_solve_fused[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akkd=Akkd,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+        NC=NC,
+        USE_SAFE_GATE=safe_gate,
+    )
+
+    w, u, qg, kg = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=Akk,
+        gk=gk,
+        q=q if disable_recompute else None,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    return w, u, qg, kg, Aqk, Akk

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/__init__.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+from .cumsum import chunk_gate_cumsum
+from .index import prepare_chunk_indices
+from .l2norm import l2norm_fwd
+from .utils import (
+    IS_GATHER_SUPPORTED,
+    IS_TF32_SUPPORTED,
+    RCP_LN2,
+    autotune_cache_kwargs,
+    check_shared_mem,
+    chunk_delta_attn_autotune_configs,
+    exp,
+    exp2,
+    input_guard,
+    softplus,
+)
+
+__all__ = [
+    "IS_GATHER_SUPPORTED",
+    "IS_TF32_SUPPORTED",
+    "RCP_LN2",
+    "autotune_cache_kwargs",
+    "check_shared_mem",
+    "chunk_delta_attn_autotune_configs",
+    "chunk_gate_cumsum",
+    "exp",
+    "exp2",
+    "input_guard",
+    "l2norm_fwd",
+    "prepare_chunk_indices",
+    "softplus",
+]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/cumsum.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/cumsum.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+"""Gate chunk cumsum for chunk_delta_attn."""
+
+import torch
+import triton
+import triton.language as tl
+
+from .index import prepare_chunk_indices
+from .utils import (
+    autotune_cache_kwargs,
+    check_shared_mem,
+    chunk_delta_attn_autotune_configs,
+    exp,
+    input_guard,
+    softplus,
+)
+
+BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.autotune(
+    configs=chunk_delta_attn_autotune_configs(
+        [triton.Config({"BS": BS}, num_warps=nw) for BS in BS_LIST for nw in [2, 4, 8]],
+        default_config=triton.Config({"BS": 64}, num_warps=2),
+    ),
+    key=["H", "S", "BT", "IS_VARLEN"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gate_cumsum_kernel(
+    s,
+    A_log,
+    dt_bias,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    lower_bound,
+    T,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_s, i_t, i_bh = (
+        tl.program_id(0),
+        tl.program_id(1).to(tl.int64),
+        tl.program_id(2).to(tl.int64),
+    )
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_s = i_s * BS + tl.arange(0, BS)
+    m_s = (o_t[:, None] < T) & (o_s[None, :] < S)
+    p_s = s + (bos * H + i_h) * S + o_t[:, None] * (H * S) + o_s[None, :]
+    p_o = o + (bos * H + i_h) * S + o_t[:, None] * (H * S) + o_s[None, :]
+
+    b_s = tl.load(p_s, mask=m_s, other=0.0).to(tl.float32)
+
+    if HAS_BIAS:
+        b_bias = tl.load(dt_bias + i_h * S + o_s, mask=o_s < S, other=0.0).to(
+            tl.float32
+        )
+        b_s = b_s + b_bias[None, :]
+
+    b_A = tl.load(A_log + i_h).to(tl.float32)
+    if not USE_LOWER_BOUND:
+        b_gate = -exp(b_A) * softplus(b_s)
+    else:
+        b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
+
+    b_o = tl.cumsum(b_gate, axis=0)
+
+    if HAS_SCALE:
+        b_o *= scale
+
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_s)
+
+
+@input_guard
+def chunk_gate_cumsum(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    chunk_size: int,
+    scale: float | None = None,
+    dt_bias: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    output_dtype: torch.dtype | None = torch.float,
+) -> torch.Tensor:
+    """Chunk-local gate cumsum with fused A_log / softplus-or-sigmoid gating."""
+    if cu_seqlens is not None:
+        assert g.shape[0] == 1, "Varlen mode requires B=1"
+    assert g.dim() == 4, f"Expected g.dim()==4, got {g.dim()}"
+    B, T, H, S = g.shape
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    g_out = torch.empty_like(g, dtype=output_dtype or g.dtype)
+
+    def grid(meta):
+        return (triton.cdiv(S, meta["BS"]), NT, B * H)
+
+    chunk_gate_cumsum_kernel[grid](
+        s=g,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        o=g_out,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        lower_bound=lower_bound,
+        T=T,
+        H=H,
+        S=S,
+        BT=BT,
+    )
+    return g_out

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/index.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/index.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+"""Index preparation utilities for variable-length sequence processing."""
+
+import torch
+import triton
+
+
+def prepare_chunk_indices(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int,
+) -> torch.LongTensor:
+    """
+    Prepare chunk indices for variable-length sequences.
+
+    Args:
+        cu_seqlens: Cumulative sequence lengths [N+1]
+        chunk_size: Size of each chunk
+
+    Returns:
+        Tensor of shape [num_chunks, 2] where each row is
+        [sequence_id, chunk_idx_in_seq]
+    """
+    lens = torch.diff(cu_seqlens)
+    indices = torch.cat(
+        [torch.arange(n) for n in triton.cdiv(lens, chunk_size).tolist()]
+    )
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/l2norm.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/l2norm.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+"""L2 normalization utilities for chunk_delta_attn kernels."""
+
+import torch
+import triton
+import triton.language as tl
+
+# Default forward-kernel tile config (MBLOCK=32, num_warps=4): a robust
+# choice across the supported head dimensions D in {64, 128, 256, 512}.
+_L2NORM_FWD_BT = 32
+_L2NORM_FWD_NUM_WARPS = 4
+
+
+@triton.jit
+def l2norm_fwd_kernel1(
+    X,
+    Y,
+    Rstd,
+    eps,
+    D,
+    BD: tl.constexpr,
+    STORE_RSTD: tl.constexpr,
+):
+    """L2 normalize per row, D > 512 (one row per program)."""
+    i_t = tl.program_id(0)
+    X += i_t * D
+    Y += i_t * D
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    b_x = tl.load(X + cols, mask=mask, other=0.0).to(tl.float32)
+    b_rstd = tl.rsqrt(tl.sum(b_x * b_x) + eps)
+    b_y = b_x * b_rstd
+    tl.store(Y + cols, b_y.to(Y.dtype.element_ty), mask=mask)
+    if STORE_RSTD:
+        tl.store(Rstd + i_t, b_rstd)
+
+
+@triton.jit
+def l2norm_fwd_kernel(
+    X,
+    Y,
+    Rstd,
+    eps,
+    T,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    BT: tl.constexpr,
+    STORE_RSTD: tl.constexpr,
+):
+    """L2 normalize per row, D <= 512 (BT rows per program)."""
+    # int64 before the `D *` scale below: q/k arrive flattened to [B*T*H, D], so
+    # the element index passes 2**31 at roughly 262k tokens for a 64-head model
+    # with D=128, and an int32 product wraps to a negative offset.
+    xoffset = tl.program_id(0).to(tl.int64) * BT
+    row_idx = xoffset + tl.arange(0, BT)[:, None]
+    xmask = row_idx < T
+    col_idx = tl.arange(0, BD)[None, :]
+    cmask = col_idx < D
+    mask = xmask & cmask
+    x = tl.load(X + col_idx + D * row_idx, mask=mask, other=0.0).to(tl.float32)
+    sumsq = tl.sum(tl.where(xmask, x * x, 0.0), axis=1)
+    rstd = tl.rsqrt(sumsq + eps)
+    y = x * rstd[:, None]
+    tl.store(Y + col_idx + D * row_idx, y.to(Y.dtype.element_ty), mask=mask)
+    if STORE_RSTD:
+        row1d = xoffset + tl.arange(0, BT)
+        tl.store(Rstd + row1d, rstd, mask=row1d < T)
+
+
+def l2norm_fwd(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: torch.dtype | None = None,
+    *,
+    need_rstd: bool = False,
+):
+    """
+    Forward pass for L2 normalization.
+
+    Args:
+        x: Input tensor of shape ``[..., D]``.
+        eps: Numerical-stability constant. Default ``1e-6``.
+        output_dtype: Output dtype. ``None`` (default) keeps input dtype.
+        need_rstd: If ``True``, also return the per-row reciprocal-std
+            tensor. Default ``False`` (inference path).
+
+    Returns:
+        ``(y, rstd)`` where ``rstd`` is ``None`` when ``need_rstd=False``.
+    """
+    x_shape_og = x.shape
+    x = x.view(-1, x.shape[-1])
+    if output_dtype is None:
+        y = torch.empty_like(x)
+    else:
+        y = torch.empty_like(x, dtype=output_dtype)
+    assert y.stride(-1) == 1
+    T, D = x.shape[0], x.shape[-1]
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+
+    if need_rstd:
+        rstd = torch.empty((T,), dtype=torch.float32, device=x.device)
+    else:
+        rstd = y  # placeholder; STORE_RSTD=False → never dereferenced
+
+    if D <= 512:
+        BT = _L2NORM_FWD_BT
+        l2norm_fwd_kernel[(triton.cdiv(T, BT),)](
+            x,
+            y,
+            rstd,
+            eps,
+            T,
+            D,
+            BD,
+            BT,
+            STORE_RSTD=need_rstd,
+            num_warps=_L2NORM_FWD_NUM_WARPS,
+        )
+    else:
+        l2norm_fwd_kernel1[(T,)](
+            x,
+            y,
+            rstd,
+            eps,
+            D,
+            BD,
+            STORE_RSTD=need_rstd,
+        )
+
+    if need_rstd:
+        return y.view(x_shape_og), rstd.view(x_shape_og[:-1])
+    return y.view(x_shape_og), None

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/utils.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/utils.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+"""Shared utilities for chunk_delta_attn kernels."""
+
+import inspect
+import math
+import os
+
+import torch
+import triton
+
+SUPPORTS_AUTOTUNE_CACHE = (
+    "cache_results" in inspect.signature(triton.autotune).parameters
+)
+_FLA_CACHE_RESULTS = os.getenv("FLA_CACHE_RESULTS", "1") == "1"
+autotune_cache_kwargs: dict = (
+    {"cache_results": _FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
+)
+
+CHUNK_DELTA_ATTN_TRITON_AUTOTUNE: bool = os.getenv(
+    "CHUNK_DELTA_ATTN_TRITON_AUTOTUNE", "0"
+).lower() in ("1", "true", "yes", "on")
+
+
+def chunk_delta_attn_autotune_configs(
+    configs: list,
+    default_config=None,
+) -> list:
+    """Return configs for @triton.autotune."""
+    if CHUNK_DELTA_ATTN_TRITON_AUTOTUNE:
+        return configs
+    return [default_config if default_config is not None else configs[0]]
+
+
+RCP_LN2: float = math.log2(math.e)  # 1/ln(2), for log2-space gate arithmetic
+
+
+def _get_available_device() -> str:
+    try:
+        return triton.runtime.driver.active.get_current_target().backend
+    except (ImportError, RuntimeError):
+        return "cpu"
+
+
+_device_platform = _get_available_device()
+
+IS_TF32_SUPPORTED: bool = (
+    _device_platform == "cuda" and torch.cuda.get_device_capability(0)[0] >= 8
+)
+IS_GATHER_SUPPORTED: bool = hasattr(triton.language, "gather")
+
+
+def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
+    """Return True if the device has enough shared memory for large tile configs."""
+    try:
+        props = torch.cuda.get_device_properties(tensor_idx)
+        gc_arch = getattr(props, "gcnArchName", "").split(":")[0]
+        _LARGE_SHMEM = {"gfx95", "gfx94", "gfx90"}
+        if any(gc_arch.startswith(a) for a in _LARGE_SHMEM):
+            return True
+        if arch == "ampere":
+            cap = torch.cuda.get_device_capability(tensor_idx)
+            return cap[0] >= 8
+        return False
+    except (ImportError, RuntimeError):
+        return False
+
+
+import functools
+import os
+from collections.abc import Callable
+from typing import Any
+
+import triton.language as tl
+import triton.language.extra.libdevice as tldevice
+
+# The fp32 cast lives inside the wrapper, as it does in fla. Every call site
+# today already passes fp32, but a bf16 gate reaching a bare tl.math.exp2 would
+# exponentiate at bf16 precision and diverge from fla with nothing to flag it.
+if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
+
+    @triton.jit
+    def exp(x):
+        return tldevice.fast_expf(x.to(tl.float32))
+
+    @triton.jit
+    def exp2(x):
+        return tldevice.exp2(x.to(tl.float32))
+
+else:
+
+    @triton.jit
+    def exp(x):
+        return tl.exp(x.to(tl.float32))
+
+    @triton.jit
+    def exp2(x):
+        return tl.math.exp2(x.to(tl.float32))
+
+
+@triton.jit
+def softplus(x):
+    """log(1 + exp(x)), falling back to the identity above x=20.
+
+    The two agree to fp32 precision past x=20, and the switch keeps exp(x) from
+    overflowing to inf around x=89. That matters more than it looks: the gate
+    this feeds is cumulatively summed, so a single overflowing token turns every
+    later cumsum into -inf and the gate differences into NaN, wiping out the rest
+    of the sequence and the recurrent state carried out of it.
+    """
+    return tl.where(x < 20.0, tl.log(1.0 + tl.exp(x)), x)
+
+
+def input_guard(fn: Callable) -> Callable:
+    """Ensure all tensor arguments are contiguous before kernel launch."""
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        args = tuple(a.contiguous() if isinstance(a, torch.Tensor) else a for a in args)
+        kwargs = {
+            k: v.contiguous() if isinstance(v, torch.Tensor) else v
+            for k, v in kwargs.items()
+        }
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/wy_fast.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/wy_fast.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""
+Recompute W and U tensors for chunk_delta_attn forward pass.
+
+``recompute_w_u_fwd`` takes the chunk Akk inverse matrix (A), key (k), value
+(v), gate-cumsum (gk) and beta scalar to produce:
+  - w = A @ (k * beta * exp2(gk))   [chunk-gated key correction]
+  - u = A @ (v * beta)               [chunk-gated value target]
+  - qg = q * exp2(gk)               [gated query, optional]
+  - kg = k * exp2(gk_last - gk)     [boundary-normalised key]
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import (
+    autotune_cache_kwargs,
+    chunk_delta_attn_autotune_configs,
+    exp2,
+    input_guard,
+    prepare_chunk_indices,
+)
+
+_BK_DEFAULT = 64
+_BV_DEFAULT = 64
+
+
+@triton.heuristics(
+    {
+        "STORE_QG": lambda args: args["qg"] is not None,
+        "STORE_KG": lambda args: args["kg"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=chunk_delta_attn_autotune_configs(
+        [
+            triton.Config({}, num_warps=nw, num_stages=ns)
+            for nw in [2, 4, 8]
+            for ns in [2, 3, 4]
+        ],
+        default_config=triton.Config({}, num_warps=4, num_stages=3),
+    ),
+    key=["H", "HV", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def recompute_w_u_fwd_kernel(
+    q,
+    k,
+    qg,
+    kg,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    gk,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    STORE_QG: tl.constexpr,
+    STORE_KG: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    k += (bos * H + i_h) * K
+    v += (bos * HV + i_hv) * V
+    u += (bos * HV + i_hv) * V
+    w += (bos * HV + i_hv) * K
+    gk += (bos * HV + i_hv) * K
+    beta += bos * HV + i_hv
+    A += (bos * HV + i_hv) * BT
+    if STORE_QG:
+        q += (bos * H + i_h) * K
+        qg += (bos * HV + i_hv) * K
+    if STORE_KG:
+        kg += (bos * HV + i_hv) * K
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_b = beta + o_t * HV
+    b_b = tl.load(p_b, mask=m_t, other=0.0)
+
+    o_A = tl.arange(0, BT)
+    m_A = m_t[:, None] & (o_A[None, :] < BT)
+    p_A = A + o_t[:, None] * (HV * BT) + o_A[None, :]
+    b_A = tl.load(p_A, mask=m_A, other=0.0)
+
+    # u = A @ (v * beta)
+    for i_v in range(tl.cdiv(V, BV)):
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = m_t[:, None] & (o_v[None, :] < V)
+        p_v = v + o_t[:, None] * (HV * V) + o_v[None, :]
+        p_u = u + o_t[:, None] * (HV * V) + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_v, other=0.0)
+        b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
+        b_u = tl.dot(b_A, b_vb)
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), mask=m_v)
+
+    # w = A @ (k * beta * exp2(gk));  optionally qg, kg
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_tk = m_t[:, None] & m_k[None, :]
+        p_w = w + o_t[:, None] * (HV * K) + o_k[None, :]
+        p_k = k + o_t[:, None] * (H * K) + o_k[None, :]
+        p_gk = gk + o_t[:, None] * (HV * K) + o_k[None, :]
+
+        b_k = tl.load(p_k, mask=m_tk, other=0.0)
+        b_gk = tl.load(p_gk, mask=m_tk, other=0.0).to(tl.float32)
+        b_kb = b_k * b_b[:, None]
+        b_kb *= exp2(b_gk)
+
+        if STORE_QG:
+            p_q = q + o_t[:, None] * (H * K) + o_k[None, :]
+            p_qg = qg + o_t[:, None] * (HV * K) + o_k[None, :]
+            b_q = tl.load(p_q, mask=m_tk, other=0.0)
+            b_qg = b_q * exp2(b_gk)
+            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), mask=m_tk)
+
+        if STORE_KG:
+            last_idx = min(i_t * BT + BT, T) - 1
+            b_gn = tl.load(gk + last_idx * HV * K + o_k, mask=m_k, other=0.0).to(
+                tl.float32
+            )
+            b_kg = b_k * tl.where(
+                (i_t * BT + tl.arange(0, BT) < T)[:, None],
+                exp2(b_gn[None, :] - b_gk),
+                0,
+            )
+            p_kg = kg + o_t[:, None] * (HV * K) + o_k[None, :]
+            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), mask=m_tk)
+
+        b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), mask=m_tk)
+
+
+@input_guard
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    gk: torch.Tensor,
+    q: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
+    """
+    Recompute W, U (and optionally QG) from the chunk Akk inverse.
+
+    Args:
+        k:             Key tensor ``[B, T, H, K]``.
+        v:             Value tensor ``[B, T, HV, V]``.
+        beta:          (Sigmoided) beta gate ``[B, T, HV]``.
+        A:             Chunk Akk inverse ``[B, T, HV, BT]``.
+        gk:            Gate cumsum (exp2 space) ``[B, T, HV, K]``.
+        q:             Optional query ``[B, T, H, K]`` to produce QG.
+        cu_seqlens:    Variable-length cumulative sequence lengths.
+        chunk_indices: Pre-computed chunk index pairs for varlen mode.
+
+    Returns:
+        (w, u, qg, kg):
+          w   ``[B, T, HV, K]``
+          u   ``[B, T, HV, V]``
+          qg  ``[B, T, HV, K]`` or None
+          kg  ``[B, T, HV, K]``
+    """
+    B, T, H, K = k.shape
+    V = v.shape[-1]
+    HV = v.shape[2]
+    BT = A.shape[-1]
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    w = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype)
+    u = torch.empty_like(v)
+    qg = (
+        torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype)
+        if q is not None
+        else None
+    )
+    kg = torch.empty(B, T, HV, K, device=k.device, dtype=k.dtype)
+
+    recompute_w_u_fwd_kernel[(NT, B * HV)](
+        q=q,
+        k=k,
+        qg=qg,
+        kg=kg,
+        v=v,
+        beta=beta,
+        w=w,
+        u=u,
+        A=A,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=_BK_DEFAULT,
+        BV=_BV_DEFAULT,
+    )
+    return w, u, qg, kg

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
@@ -36,6 +36,12 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
 NUM_STAGES_FWD = [2, 3] if IS_AMD else [2, 3, 4]
 
 
+@triton.jit
+def _gate_exp(x, USE_EXP2: tl.constexpr):
+    """Exponentiate a cumulative gate held in log2 space (USE_EXP2) or natural log."""
+    return tl.math.exp2(x) if USE_EXP2 else exp(x)
+
+
 @triton.heuristics(
     {
         "USE_G": lambda args: args["g"] is not None,
@@ -55,7 +61,7 @@ NUM_STAGES_FWD = [2, 3] if IS_AMD else [2, 3, 4]
             for BV in [32, 64]
         ]
     ),
-    key=["H", "K", "V", "BT"],
+    key=["H", "K", "V", "BT", "TRANSPOSE_STATE"],
     use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
@@ -84,6 +90,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     STORE_FINAL_STATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
+    USE_EXP2: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -109,106 +117,117 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         b_h4 = tl.zeros([64, BV], dtype=tl.float32)
 
     # calculate offset
-    h += ((boh * H + i_h) * K * V).to(tl.int64)
-    v += ((bos * H + i_h) * V).to(tl.int64)
-    k += ((bos * H + i_h) * K).to(tl.int64)
-    w += ((bos * H + i_h) * K).to(tl.int64)
+    #
+    # Widen to int64 *before* scaling by K/V: a 64-head K=V=128 model overflows
+    # int32 at ~131k tokens, and the wrapped negative offset corrupts memory in
+    # front of the buffer rather than failing loudly.
+    h += (boh * H + i_h).to(tl.int64) * K * V
+    v += (bos * H + i_h).to(tl.int64) * V
+    k += (bos * H + i_h).to(tl.int64) * K
+    w += (bos * H + i_h).to(tl.int64) * K
     if SAVE_NEW_VALUE:
-        v_new += ((bos * H + i_h) * V).to(tl.int64)
+        v_new += (bos * H + i_h).to(tl.int64) * V
     stride_v = H * V
     stride_h = H * K * V
     stride_k = H * K
     if USE_INITIAL_STATE:
-        h0 = h0 + i_nh * K * V
+        h0 = h0 + i_nh.to(tl.int64) * K * V
     if STORE_FINAL_STATE:
-        ht = ht + i_nh * K * V
+        ht = ht + i_nh.to(tl.int64) * K * V
+
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    o_k1 = tl.arange(0, 64)
+    m_k1 = o_k1 < K
+    o_k2 = 64 + o_k1
+    m_k2 = o_k2 < K
+    o_k3 = 128 + o_k1
+    m_k3 = o_k3 < K
+    o_k4 = 192 + o_k1
+    m_k4 = o_k4 < K
+    m_h1 = m_k1[:, None] & m_v[None, :]
+    m_h2 = m_k2[:, None] & m_v[None, :]
+    m_h3 = m_k3[:, None] & m_v[None, :]
+    m_h4 = m_k4[:, None] & m_v[None, :]
 
     # load initial state
+    #
+    # TRANSPOSE_STATE describes the state buffer as V-first ``[V, K]`` instead of
+    # ``[K, V]``.
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        if TRANSPOSE_STATE:
+            p_h0_1 = h0 + o_k1[:, None] + o_v[None, :] * K
+        else:
+            p_h0_1 = h0 + o_k1[:, None] * V + o_v[None, :]
+        b_h1 += tl.load(p_h0_1, mask=m_h1, other=0.0).to(tl.float32)
         if K > 64:
-            p_h0_2 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            if TRANSPOSE_STATE:
+                p_h0_2 = h0 + o_k2[:, None] + o_v[None, :] * K
+            else:
+                p_h0_2 = h0 + o_k2[:, None] * V + o_v[None, :]
+            b_h2 += tl.load(p_h0_2, mask=m_h2, other=0.0).to(tl.float32)
         if K > 128:
-            p_h0_3 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            if TRANSPOSE_STATE:
+                p_h0_3 = h0 + o_k3[:, None] + o_v[None, :] * K
+            else:
+                p_h0_3 = h0 + o_k3[:, None] * V + o_v[None, :]
+            b_h3 += tl.load(p_h0_3, mask=m_h3, other=0.0).to(tl.float32)
         if K > 192:
-            p_h0_4 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+            if TRANSPOSE_STATE:
+                p_h0_4 = h0 + o_k4[:, None] + o_v[None, :] * K
+            else:
+                p_h0_4 = h0 + o_k4[:, None] * V + o_v[None, :]
+            b_h4 += tl.load(p_h0_4, mask=m_h4, other=0.0).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
-        p_h1 = tl.make_block_ptr(
-            h + i_t * stride_h, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
-        )
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
-            p_h2 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
-            p_h3 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
-            p_h4 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_tk1 = m_t[:, None] & m_k1[None, :]
+        m_tv = m_t[:, None] & m_v[None, :]
 
-        p_w = tl.make_block_ptr(
-            w, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0)
-        )
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        h_t = h + i_t.to(tl.int64) * stride_h
+        p_h1 = h_t + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), mask=m_h1)
+        if K > 64:
+            p_h2 = h_t + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), mask=m_h2)
+        if K > 128:
+            p_h3 = h_t + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), mask=m_h3)
+        if K > 192:
+            p_h4 = h_t + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), mask=m_h4)
+
+        p_w = w + o_t[:, None] * stride_k + o_k1[None, :]
+        b_w = tl.load(p_w, mask=m_tk1, other=0.0)
         b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
         if K > 64:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_k + o_k2[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k2[None, :], other=0.0)
             b_v = tl.dot(b_w, b_h2.to(b_w.dtype), acc=b_v)
         if K > 128:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_k + o_k3[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k3[None, :], other=0.0)
             b_v = tl.dot(b_w, b_h3.to(b_w.dtype), acc=b_v)
         if K > 192:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_k + o_k4[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k4[None, :], other=0.0)
             b_v = tl.dot(b_w, b_h4.to(b_w.dtype), acc=b_v)
-        p_v = tl.make_block_ptr(
-            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
-        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+        p_v = v + o_t[:, None] * stride_v + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_tv, other=0.0) - b_v
 
         if SAVE_NEW_VALUE:
-            p_v = tl.make_block_ptr(
-                v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-            )
-            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+            p_v = v_new + o_t[:, None] * stride_v + o_v[None, :]
+            tl.store(p_v, b_v.to(p_v.dtype.element_ty), mask=m_tv)
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
-            m_t = (i_t * BT + tl.arange(0, BT)) < T
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = tl.make_block_ptr(
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-            )
-            b_g = tl.load(p_g, boundary_check=(0,))
-            b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
-            b_g_last = exp(b_g_last)
+            p_g = g + bos * H + i_h + o_t * H
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
+            b_v = b_v * tl.where(m_t, _gate_exp(b_g_last - b_g, USE_EXP2), 0)[:, None]
+            b_g_last = _gate_exp(b_g_last, USE_EXP2)
             b_h1 *= b_g_last
             if K > 64:
                 b_h2 *= b_g_last
@@ -218,81 +237,75 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 b_h4 *= b_g_last
 
         if USE_GK:
-            o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(
                 gk + (bos + last_idx) * H * K + i_h * K + o_k1,
-                mask=(o_k1 < K),
+                mask=m_k1,
                 other=0.0,
             )
-            b_h1 *= exp(b_gk_last1)[:, None]
+            b_h1 *= _gate_exp(b_gk_last1, USE_EXP2)[:, None]
             if K > 64:
-                o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k2,
-                    mask=(o_k2 < K),
+                    mask=m_k2,
                     other=0.0,
                 )
-                b_h2 *= exp(b_gk_last2)[:, None]
+                b_h2 *= _gate_exp(b_gk_last2, USE_EXP2)[:, None]
             if K > 128:
-                o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k3,
-                    mask=(o_k3 < K),
+                    mask=m_k3,
                     other=0.0,
                 )
-                b_h3 *= exp(b_gk_last3)[:, None]
+                b_h3 *= _gate_exp(b_gk_last3, USE_EXP2)[:, None]
             if K > 192:
-                o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k4,
-                    mask=(o_k4 < K),
+                    mask=m_k4,
                     other=0.0,
                 )
-                b_h4 *= exp(b_gk_last4)[:, None]
+                b_h4 *= _gate_exp(b_gk_last4, USE_EXP2)[:, None]
         b_v = b_v.to(k.dtype.element_ty)
 
-        p_k = tl.make_block_ptr(
-            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_k1[:, None] + o_t[None, :] * stride_k
+        b_k = tl.load(p_k, mask=m_k1[:, None] & m_t[None, :], other=0.0)
         b_h1 = tl.dot(b_k, b_v, acc=b_h1)
         if K > 64:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k2[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k2[:, None] & m_t[None, :], other=0.0)
             b_h2 = tl.dot(b_k, b_v, acc=b_h2)
         if K > 128:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k3[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k3[:, None] & m_t[None, :], other=0.0)
             b_h3 = tl.dot(b_k, b_v, acc=b_h3)
         if K > 192:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k4[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k4[:, None] & m_t[None, :], other=0.0)
             b_h4 = tl.dot(b_k, b_v, acc=b_h4)
     # epilogue
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if TRANSPOSE_STATE:
+            p_ht = ht + o_k1[:, None] + o_v[None, :] * K
+        else:
+            p_ht = ht + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if TRANSPOSE_STATE:
+                p_ht = ht + o_k2[:, None] + o_v[None, :] * K
+            else:
+                p_ht = ht + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if TRANSPOSE_STATE:
+                p_ht = ht + o_k3[:, None] + o_v[None, :] * K
+            else:
+                p_ht = ht + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if TRANSPOSE_STATE:
+                p_ht = ht + o_k4[:, None] + o_v[None, :] * K
+            else:
+                p_ht = ht + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), mask=m_h4)
 
 
 @triton.heuristics(
@@ -371,149 +384,123 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
         b_dh4 = tl.zeros([64, BV], dtype=tl.float32)
 
     # calculate offset
-    q += ((bos * H + i_h) * K).to(tl.int64)
-    k += ((bos * H + i_h) * K).to(tl.int64)
-    w += ((bos * H + i_h) * K).to(tl.int64)
-    do += ((bos * H + i_h) * V).to(tl.int64)
-    dv += ((bos * H + i_h) * V).to(tl.int64)
-    dv2 += ((bos * H + i_h) * V).to(tl.int64)
-    dh += ((boh * H + i_h) * K * V).to(tl.int64)
+    q += (bos * H + i_h).to(tl.int64) * K
+    k += (bos * H + i_h).to(tl.int64) * K
+    w += (bos * H + i_h).to(tl.int64) * K
+    do += (bos * H + i_h).to(tl.int64) * V
+    dv += (bos * H + i_h).to(tl.int64) * V
+    dv2 += (bos * H + i_h).to(tl.int64) * V
+    dh += (boh * H + i_h).to(tl.int64) * K * V
     if USE_GK:
-        gk += ((bos * H + i_h) * K).to(tl.int64)
+        gk += (bos * H + i_h).to(tl.int64) * K
 
     stride_v = H * V
     stride_h = H * K * V
     stride_k = H * K
     if USE_INITIAL_STATE:
-        dh0 += i_nh * K * V
+        dh0 += i_nh.to(tl.int64) * K * V
     if USE_FINAL_STATE_GRADIENT:
-        dht += i_nh * K * V
+        dht += i_nh.to(tl.int64) * K * V
+
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    o_k1 = tl.arange(0, 64)
+    m_k1 = o_k1 < K
+    o_k2 = 64 + o_k1
+    m_k2 = o_k2 < K
+    o_k3 = 128 + o_k1
+    m_k3 = o_k3 < K
+    o_k4 = 192 + o_k1
+    m_k4 = o_k4 < K
+    m_h1 = m_k1[:, None] & m_v[None, :]
+    m_h2 = m_k2[:, None] & m_v[None, :]
+    m_h3 = m_k3[:, None] & m_v[None, :]
+    m_h4 = m_k4[:, None] & m_v[None, :]
 
     if USE_FINAL_STATE_GRADIENT:
-        p_dht1 = tl.make_block_ptr(dht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_dh1 += tl.load(p_dht1, boundary_check=(0, 1))
+        p_dht1 = dht + o_k1[:, None] * V + o_v[None, :]
+        b_dh1 += tl.load(p_dht1, mask=m_h1, other=0.0)
         if K > 64:
-            p_dht2 = tl.make_block_ptr(
-                dht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            b_dh2 += tl.load(p_dht2, boundary_check=(0, 1))
+            p_dht2 = dht + o_k2[:, None] * V + o_v[None, :]
+            b_dh2 += tl.load(p_dht2, mask=m_h2, other=0.0)
         if K > 128:
-            p_dht3 = tl.make_block_ptr(
-                dht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            b_dh3 += tl.load(p_dht3, boundary_check=(0, 1))
+            p_dht3 = dht + o_k3[:, None] * V + o_v[None, :]
+            b_dh3 += tl.load(p_dht3, mask=m_h3, other=0.0)
         if K > 192:
-            p_dht4 = tl.make_block_ptr(
-                dht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            b_dh4 += tl.load(p_dht4, boundary_check=(0, 1))
+            p_dht4 = dht + o_k4[:, None] * V + o_v[None, :]
+            b_dh4 += tl.load(p_dht4, mask=m_h4, other=0.0)
 
     for i_t in range(NT - 1, -1, -1):
-        p_dh1 = tl.make_block_ptr(
-            dh + i_t * stride_h, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
-        )
-        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_tv = m_t[:, None] & m_v[None, :]
+
+        dh_t = dh + i_t.to(tl.int64) * stride_h
+        p_dh1 = dh_t + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_dh2 = tl.make_block_ptr(
-                dh + i_t * stride_h, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+            p_dh2 = dh_t + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_dh3 = tl.make_block_ptr(
-                dh + i_t * stride_h, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+            p_dh3 = dh_t + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_dh4 = tl.make_block_ptr(
-                dh + i_t * stride_h, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+            p_dh4 = dh_t + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), mask=m_h4)
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
             bg_last = tl.load(g + (bos + last_idx) * H + i_h)
             bg_last_exp = exp(bg_last)
-            p_g = tl.make_block_ptr(
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-            )
-            b_g = tl.load(p_g, boundary_check=(0,))
+            p_g = g + bos * H + i_h + o_t * H
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
             b_g_exp = exp(b_g)
 
-        p_dv = tl.make_block_ptr(
-            dv, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
-        p_dv2 = tl.make_block_ptr(
-            dv2, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
-        p_do = tl.make_block_ptr(
-            do, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
+        p_dv = dv + o_t[:, None] * stride_v + o_v[None, :]
+        p_dv2 = dv2 + o_t[:, None] * stride_v + o_v[None, :]
+        p_do = do + o_t[:, None] * stride_v + o_v[None, :]
 
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(p_do, mask=m_tv, other=0.0)
 
         # Update dv
-        p_k = tl.make_block_ptr(
-            k, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0)
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_t[:, None] * stride_k + o_k1[None, :]
+        b_k = tl.load(p_k, mask=m_t[:, None] & m_k1[None, :], other=0.0)
         if USE_GK:
-            o_k1 = tl.arange(0, 64)
-            b_gk_last1 = tl.load(
-                gk + last_idx * H * K + o_k1, mask=(o_k1 < K), other=0.0
-            )
+            b_gk_last1 = tl.load(gk + last_idx * H * K + o_k1, mask=m_k1, other=0.0)
         b_dv = tl.dot(b_k, b_dh1.to(b_k.dtype))
 
         if K > 64:
-            p_k = tl.make_block_ptr(
-                k, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_k + o_k2[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k2[None, :], other=0.0)
             if USE_GK:
-                o_k2 = 64 + o_k1
-                b_gk_last2 = tl.load(
-                    gk + last_idx * H * K + o_k2, mask=(o_k2 < K), other=0.0
-                )
+                b_gk_last2 = tl.load(gk + last_idx * H * K + o_k2, mask=m_k2, other=0.0)
             b_dv = tl.dot(b_k, b_dh2.to(b_k.dtype), acc=b_dv)
 
         if K > 128:
-            p_k = tl.make_block_ptr(
-                k, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_k + o_k3[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k3[None, :], other=0.0)
             if USE_GK:
-                o_k3 = 128 + o_k1
-                b_gk_last3 = tl.load(
-                    gk + last_idx * H * K + o_k3, mask=(o_k3 < K), other=0.0
-                )
+                b_gk_last3 = tl.load(gk + last_idx * H * K + o_k3, mask=m_k3, other=0.0)
             b_dv = tl.dot(b_k, b_dh3.to(b_k.dtype), acc=b_dv)
 
         if K > 192:
-            p_k = tl.make_block_ptr(
-                k, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_t[:, None] * stride_k + o_k4[None, :]
+            b_k = tl.load(p_k, mask=m_t[:, None] & m_k4[None, :], other=0.0)
             if USE_GK:
-                o_k4 = 192 + o_k1
-                b_gk_last4 = tl.load(
-                    gk + last_idx * H * K + o_k4, mask=(o_k4 < K), other=0.0
-                )
+                b_gk_last4 = tl.load(gk + last_idx * H * K + o_k4, mask=m_k4, other=0.0)
             b_dv = tl.dot(b_k, b_dh4.to(b_k.dtype), acc=b_dv)
 
         if USE_G:
-            m_t = (i_t * BT + tl.arange(0, BT)) < T
             b_dv *= tl.where(m_t, exp(bg_last - b_g), 0)[:, None]
-        b_dv += tl.load(p_dv, boundary_check=(0, 1))
+        b_dv += tl.load(p_dv, mask=m_tv, other=0.0)
 
-        tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dv2, b_dv.to(p_dv.dtype.element_ty), mask=m_tv)
         # Update dh
-        p_w = tl.make_block_ptr(
-            w, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        p_q = tl.make_block_ptr(
-            q, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        b_w = tl.load(p_w, boundary_check=(0, 1))
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_w = w + o_k1[:, None] + o_t[None, :] * stride_k
+        p_q = q + o_k1[:, None] + o_t[None, :] * stride_k
+        m_kt1 = m_k1[:, None] & m_t[None, :]
+        b_w = tl.load(p_w, mask=m_kt1, other=0.0)
+        b_q = tl.load(p_q, mask=m_kt1, other=0.0)
         if USE_G:
             b_dh1 *= bg_last_exp
             b_q = b_q * b_g_exp[None, :]
@@ -523,14 +510,11 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             b_w, b_dv.to(b_w.dtype)
         )
         if K > 64:
-            p_q = tl.make_block_ptr(
-                q, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
-            )
-            p_w = tl.make_block_ptr(
-                w, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
-            )
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k2[:, None] + o_t[None, :] * stride_k
+            p_w = w + o_k2[:, None] + o_t[None, :] * stride_k
+            m_kt2 = m_k2[:, None] & m_t[None, :]
+            b_q = tl.load(p_q, mask=m_kt2, other=0.0)
+            b_w = tl.load(p_w, mask=m_kt2, other=0.0)
             if USE_G:
                 b_dh2 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -540,14 +524,11 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_w, b_dv.to(b_w.dtype)
             )
         if K > 128:
-            p_q = tl.make_block_ptr(
-                q, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            p_w = tl.make_block_ptr(
-                w, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k3[:, None] + o_t[None, :] * stride_k
+            p_w = w + o_k3[:, None] + o_t[None, :] * stride_k
+            m_kt3 = m_k3[:, None] & m_t[None, :]
+            b_q = tl.load(p_q, mask=m_kt3, other=0.0)
+            b_w = tl.load(p_w, mask=m_kt3, other=0.0)
             if USE_G:
                 b_dh3 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -557,14 +538,11 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
                 b_w, b_dv.to(b_w.dtype)
             )
         if K > 192:
-            p_q = tl.make_block_ptr(
-                q, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            p_w = tl.make_block_ptr(
-                w, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            b_q = tl.load(p_q, boundary_check=(0, 1))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_q = q + o_k4[:, None] + o_t[None, :] * stride_k
+            p_w = w + o_k4[:, None] + o_t[None, :] * stride_k
+            m_kt4 = m_k4[:, None] & m_t[None, :]
+            b_q = tl.load(p_q, mask=m_kt4, other=0.0)
+            b_w = tl.load(p_w, mask=m_kt4, other=0.0)
             if USE_G:
                 b_dh4 *= bg_last_exp
                 b_q = b_q * b_g_exp[None, :]
@@ -575,23 +553,17 @@ def chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64(
             )
 
     if USE_INITIAL_STATE:
-        p_dh0 = tl.make_block_ptr(dh0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+        p_dh0 = dh0 + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh1.to(p_dh0.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_dh1 = tl.make_block_ptr(
-                dh0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+            p_dh1 = dh0 + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_dh1, b_dh2.to(p_dh1.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_dh2 = tl.make_block_ptr(
-                dh0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+            p_dh2 = dh0 + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_dh2, b_dh3.to(p_dh2.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_dh3 = tl.make_block_ptr(
-                dh0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+            p_dh3 = dh0 + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_dh3, b_dh4.to(p_dh3.dtype.element_ty), mask=m_h4)
 
 
 def chunk_gated_delta_rule_fwd_h(
@@ -606,7 +578,21 @@ def chunk_gated_delta_rule_fwd_h(
     save_new_value: bool = True,
     cu_seqlens: torch.LongTensor | None = None,
     chunk_indices: torch.LongTensor | None = None,
+    transpose_state: bool = False,
+    use_exp2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute the per-chunk hidden states and the recomputed value tensor.
+
+    ``transpose_state`` selects the V-first ``[N, H, V, K]`` layout for
+    ``initial_state`` / ``final_state`` instead of the default ``[N, H, K, V]``,
+    matching fla's ``state_v_first``. Only the recurrent state boundary is
+    affected; the per-chunk ``h`` stays ``[B, NT, H, K, V]``.
+
+    ``use_exp2`` must match the space the cumulative gate was accumulated in:
+    callers that scale the cumsum by ``RCP_LN2`` (log2 space) need it set,
+    otherwise the inter-chunk decay is applied as ``exp(g/ln2)`` instead of
+    ``exp(g)``, over-decaying the state carried across every chunk boundary.
+    """
     B, T, H, K, V = *k.shape, u.shape[-1]
     BT = chunk_size
 
@@ -623,9 +609,16 @@ def chunk_gated_delta_rule_fwd_h(
         )
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
+    state_shape = (N, H, V, K) if transpose_state else (N, H, K, V)
+    if initial_state is not None and tuple(initial_state.shape) != state_shape:
+        raise ValueError(
+            f"`initial_state` must have shape {state_shape} for "
+            f"transpose_state={transpose_state}, got {tuple(initial_state.shape)}."
+        )
+
     h = k.new_empty(B, NT, H, K, V)
     final_state = (
-        k.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
+        k.new_empty(*state_shape, dtype=torch.float32) if output_final_state else None
     )
 
     v_new = torch.empty_like(u) if save_new_value else None
@@ -650,6 +643,8 @@ def chunk_gated_delta_rule_fwd_h(
         K=K,
         V=V,
         BT=BT,
+        TRANSPOSE_STATE=transpose_state,
+        USE_EXP2=use_exp2,
     )
     return h, v_new, final_state
 
@@ -728,110 +723,102 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt(
     if K > 192:
         b_h4 = tl.zeros([64, BV], dtype=tl.float32)
 
-    h += ((boh * H + i_h) * K * V).to(tl.int64)
-    k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
+    h += (boh * H + i_h).to(tl.int64) * K * V
+    k += (bos * Hg + i_h // (H // Hg)).to(tl.int64) * K
     if IS_VARLEN:
-        v += ((i_h * T_flat + bos) * V).to(tl.int64)
-        w += ((i_h * T_flat + bos) * K).to(tl.int64)
+        v += (i_h * T_flat + bos).to(tl.int64) * V
+        w += (i_h * T_flat + bos).to(tl.int64) * K
     else:
-        v += (((i_n * H + i_h) * T_flat) * V).to(tl.int64)
-        w += (((i_n * H + i_h) * T_flat) * K).to(tl.int64)
+        v += ((i_n * H + i_h) * T_flat).to(tl.int64) * V
+        w += ((i_n * H + i_h) * T_flat).to(tl.int64) * K
     stride_v = V
     stride_w = K
     if SAVE_NEW_VALUE:
         if IS_VARLEN:
-            v_new += ((i_h * T_flat + bos) * V).to(tl.int64)
+            v_new += (i_h * T_flat + bos).to(tl.int64) * V
         else:
-            v_new += (((i_n * H + i_h) * T_flat) * V).to(tl.int64)
+            v_new += ((i_n * H + i_h) * T_flat).to(tl.int64) * V
     stride_h = H * K * V
     stride_k = Hg * K
     if USE_INITIAL_STATE:
-        h0 = h0 + i_nh * K * V
+        h0 = h0 + i_nh.to(tl.int64) * K * V
     if STORE_FINAL_STATE:
-        ht = ht + i_nh * K * V
+        ht = ht + i_nh.to(tl.int64) * K * V
+
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    o_k1 = tl.arange(0, 64)
+    m_k1 = o_k1 < K
+    o_k2 = 64 + o_k1
+    m_k2 = o_k2 < K
+    o_k3 = 128 + o_k1
+    m_k3 = o_k3 < K
+    o_k4 = 192 + o_k1
+    m_k4 = o_k4 < K
+    m_h1 = m_k1[:, None] & m_v[None, :]
+    m_h2 = m_k2[:, None] & m_v[None, :]
+    m_h3 = m_k3[:, None] & m_v[None, :]
+    m_h4 = m_k4[:, None] & m_v[None, :]
 
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        p_h0_1 = h0 + o_k1[:, None] * V + o_v[None, :]
+        b_h1 += tl.load(p_h0_1, mask=m_h1, other=0.0).to(tl.float32)
         if K > 64:
-            p_h0_2 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_2 = h0 + o_k2[:, None] * V + o_v[None, :]
+            b_h2 += tl.load(p_h0_2, mask=m_h2, other=0.0).to(tl.float32)
         if K > 128:
-            p_h0_3 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_3 = h0 + o_k3[:, None] * V + o_v[None, :]
+            b_h3 += tl.load(p_h0_3, mask=m_h3, other=0.0).to(tl.float32)
         if K > 192:
-            p_h0_4 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_4 = h0 + o_k4[:, None] * V + o_v[None, :]
+            b_h4 += tl.load(p_h0_4, mask=m_h4, other=0.0).to(tl.float32)
 
     for i_t in range(NT):
-        p_h1 = tl.make_block_ptr(
-            h + i_t * stride_h, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
-        )
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
-            p_h2 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
-            p_h3 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
-            p_h4 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_tv = m_t[:, None] & m_v[None, :]
 
-        p_w = tl.make_block_ptr(
-            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
-        )
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        h_t = h + i_t.to(tl.int64) * stride_h
+        p_h1 = h_t + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), mask=m_h1)
+        if K > 64:
+            p_h2 = h_t + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), mask=m_h2)
+        if K > 128:
+            p_h3 = h_t + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), mask=m_h3)
+        if K > 192:
+            p_h4 = h_t + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), mask=m_h4)
+
+        p_w = w + o_t[:, None] * stride_w + o_k1[None, :]
+        b_w = tl.load(p_w, mask=m_t[:, None] & m_k1[None, :], other=0.0)
         b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
         if K > 64:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_w + o_k2[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k2[None, :], other=0.0)
             b_v = tl.dot(b_w, b_h2.to(b_w.dtype), acc=b_v)
         if K > 128:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_w + o_k3[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k3[None, :], other=0.0)
             b_v = tl.dot(b_w, b_h3.to(b_w.dtype), acc=b_v)
         if K > 192:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_w + o_k4[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k4[None, :], other=0.0)
             b_v = tl.dot(b_w, b_h4.to(b_w.dtype), acc=b_v)
-        p_v = tl.make_block_ptr(
-            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
-        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+        p_v = v + o_t[:, None] * stride_v + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_tv, other=0.0) - b_v
 
         if SAVE_NEW_VALUE:
-            p_vn = tl.make_block_ptr(
-                v_new, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-            )
-            tl.store(p_vn, b_v.to(p_vn.dtype.element_ty), boundary_check=(0, 1))
+            p_vn = v_new + o_t[:, None] * V + o_v[None, :]
+            tl.store(p_vn, b_v.to(p_vn.dtype.element_ty), mask=m_tv)
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = tl.make_block_ptr(
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-            )
-            b_g = tl.load(p_g, boundary_check=(0,))
+            p_g = g + bos * H + i_h + o_t * H
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
             b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
             b_g_last = exp(b_g_last)
             b_h1 *= b_g_last
@@ -843,81 +830,63 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt(
                 b_h4 *= b_g_last
 
         if USE_GK:
-            o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(
                 gk + (bos + last_idx) * H * K + i_h * K + o_k1,
-                mask=(o_k1 < K),
+                mask=m_k1,
                 other=0.0,
             )
             b_h1 *= exp(b_gk_last1)[:, None]
             if K > 64:
-                o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k2,
-                    mask=(o_k2 < K),
+                    mask=m_k2,
                     other=0.0,
                 )
                 b_h2 *= exp(b_gk_last2)[:, None]
             if K > 128:
-                o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k3,
-                    mask=(o_k3 < K),
+                    mask=m_k3,
                     other=0.0,
                 )
                 b_h3 *= exp(b_gk_last3)[:, None]
             if K > 192:
-                o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k4,
-                    mask=(o_k4 < K),
+                    mask=m_k4,
                     other=0.0,
                 )
                 b_h4 *= exp(b_gk_last4)[:, None]
         b_v = b_v.to(k.dtype.element_ty)
 
-        p_k = tl.make_block_ptr(
-            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_k1[:, None] + o_t[None, :] * stride_k
+        b_k = tl.load(p_k, mask=m_k1[:, None] & m_t[None, :], other=0.0)
         b_h1 = tl.dot(b_k, b_v, acc=b_h1)
         if K > 64:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k2[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k2[:, None] & m_t[None, :], other=0.0)
             b_h2 = tl.dot(b_k, b_v, acc=b_h2)
         if K > 128:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k3[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k3[:, None] & m_t[None, :], other=0.0)
             b_h3 = tl.dot(b_k, b_v, acc=b_h3)
         if K > 192:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k4[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k4[:, None] & m_t[None, :], other=0.0)
             b_h4 = tl.dot(b_k, b_v, acc=b_h4)
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + o_k1[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k2[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k3[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_k4[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), mask=m_h4)
 
 
 def chunk_gated_delta_rule_fwd_h_opt(
@@ -1078,21 +1047,21 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
     if K > 192:
         b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
 
-    h += ((boh * H + i_h) * V * K).to(tl.int64)
-    k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
+    h += (boh * H + i_h).to(tl.int64) * V * K
+    k += (bos * Hg + i_h // (H // Hg)).to(tl.int64) * K
     if IS_VARLEN:
-        v += ((i_h * T_flat + bos) * V).to(tl.int64)
-        w += ((i_h * T_flat + bos) * K).to(tl.int64)
+        v += (i_h * T_flat + bos).to(tl.int64) * V
+        w += (i_h * T_flat + bos).to(tl.int64) * K
     else:
-        v += (((i_n * H + i_h) * T_flat) * V).to(tl.int64)
-        w += (((i_n * H + i_h) * T_flat) * K).to(tl.int64)
+        v += ((i_n * H + i_h) * T_flat).to(tl.int64) * V
+        w += ((i_n * H + i_h) * T_flat).to(tl.int64) * K
     stride_v = V
     stride_w = K
     if SAVE_NEW_VALUE:
         if IS_VARLEN:
-            v_new += ((i_h * T_flat + bos) * V).to(tl.int64)
+            v_new += (i_h * T_flat + bos).to(tl.int64) * V
         else:
-            v_new += (((i_n * H + i_h) * T_flat) * V).to(tl.int64)
+            v_new += ((i_n * H + i_h) * T_flat).to(tl.int64) * V
     stride_h = H * V * K
     stride_k = Hg * K
     # `i_ss * H + i_h` == `i_nh` on the dense path; the int64 cast happens before
@@ -1108,88 +1077,82 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
         else:
             g += ((i_n * H + i_h) * T_flat).to(tl.int64)
 
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+    o_k1 = tl.arange(0, 64)
+    m_k1 = o_k1 < K
+    o_k2 = 64 + o_k1
+    m_k2 = o_k2 < K
+    o_k3 = 128 + o_k1
+    m_k3 = o_k3 < K
+    o_k4 = 192 + o_k1
+    m_k4 = o_k4 < K
+    m_h1 = m_v[:, None] & m_k1[None, :]
+    m_h2 = m_v[:, None] & m_k2[None, :]
+    m_h3 = m_v[:, None] & m_k3[None, :]
+    m_h4 = m_v[:, None] & m_k4[None, :]
+
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        p_h0_1 = h0 + o_v[:, None] * K + o_k1[None, :]
+        b_h1 += tl.load(p_h0_1, mask=m_h1, other=0.0).to(tl.float32)
         if K > 64:
-            p_h0_2 = tl.make_block_ptr(
-                h0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
-            )
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_2 = h0 + o_v[:, None] * K + o_k2[None, :]
+            b_h2 += tl.load(p_h0_2, mask=m_h2, other=0.0).to(tl.float32)
         if K > 128:
-            p_h0_3 = tl.make_block_ptr(
-                h0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
-            )
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_3 = h0 + o_v[:, None] * K + o_k3[None, :]
+            b_h3 += tl.load(p_h0_3, mask=m_h3, other=0.0).to(tl.float32)
         if K > 192:
-            p_h0_4 = tl.make_block_ptr(
-                h0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
-            )
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_4 = h0 + o_v[:, None] * K + o_k4[None, :]
+            b_h4 += tl.load(p_h0_4, mask=m_h4, other=0.0).to(tl.float32)
 
     for i_t in range(NT):
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_tv = m_t[:, None] & m_v[None, :]
+
         # Store h snapshot [V, K]
-        p_h1 = tl.make_block_ptr(
-            h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
-        )
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        h_t = h + i_t.to(tl.int64) * stride_h
+        p_h1 = h_t + o_v[:, None] * K + o_k1[None, :]
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_h2 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
-            )
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+            p_h2 = h_t + o_v[:, None] * K + o_k2[None, :]
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_h3 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
-            )
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+            p_h3 = h_t + o_v[:, None] * K + o_k3[None, :]
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_h4 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
-            )
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+            p_h4 = h_t + o_v[:, None] * K + o_k4[None, :]
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), mask=m_h4)
 
         # b_v = u - w @ h^T  (h is [BV,64], need [64,BV] for dot with w[BT,64])
-        p_w = tl.make_block_ptr(
-            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
-        )
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        p_w = w + o_t[:, None] * stride_w + o_k1[None, :]
+        b_w = tl.load(p_w, mask=m_t[:, None] & m_k1[None, :], other=0.0)
         b_v = tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))
         if K > 64:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_w + o_k2[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k2[None, :], other=0.0)
             b_v = tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype), acc=b_v)
         if K > 128:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_w + o_k3[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k3[None, :], other=0.0)
             b_v = tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype), acc=b_v)
         if K > 192:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            p_w = w + o_t[:, None] * stride_w + o_k4[None, :]
+            b_w = tl.load(p_w, mask=m_t[:, None] & m_k4[None, :], other=0.0)
             b_v = tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype), acc=b_v)
-        p_v = tl.make_block_ptr(
-            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
-        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+        p_v = v + o_t[:, None] * stride_v + o_v[None, :]
+        b_v = tl.load(p_v, mask=m_tv, other=0.0) - b_v
 
         if SAVE_NEW_VALUE:
-            p_vn = tl.make_block_ptr(
-                v_new, (T, V), (V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-            )
-            tl.store(p_vn, b_v.to(p_vn.dtype.element_ty), boundary_check=(0, 1))
+            p_vn = v_new + o_t[:, None] * V + o_v[None, :]
+            tl.store(p_vn, b_v.to(p_vn.dtype.element_ty), mask=m_tv)
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
             m_t = (i_t * BT + tl.arange(0, BT)) < T
             b_g_last = tl.load(g + last_idx)
-            p_g = tl.make_block_ptr(g, (T,), (1,), (i_t * BT,), (BT,), (0,))
-            b_g = tl.load(p_g, boundary_check=(0,))
+            p_g = g + o_t
+            b_g = tl.load(p_g, mask=m_t, other=0.0)
             if USE_EXP2:
                 b_v = b_v * tl.where(m_t, tl.math.exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = tl.math.exp2(b_g_last)
@@ -1205,38 +1168,34 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
                 b_h4 *= b_g_last
 
         if USE_GK:
-            o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(
                 gk + (bos + last_idx) * H * K + i_h * K + o_k1,
-                mask=(o_k1 < K),
+                mask=m_k1,
                 other=0.0,
             )
             b_h1 *= (tl.math.exp2(b_gk_last1) if USE_EXP2 else exp(b_gk_last1))[None, :]
             if K > 64:
-                o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k2,
-                    mask=(o_k2 < K),
+                    mask=m_k2,
                     other=0.0,
                 )
                 b_h2 *= (tl.math.exp2(b_gk_last2) if USE_EXP2 else exp(b_gk_last2))[
                     None, :
                 ]
             if K > 128:
-                o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k3,
-                    mask=(o_k3 < K),
+                    mask=m_k3,
                     other=0.0,
                 )
                 b_h3 *= (tl.math.exp2(b_gk_last3) if USE_EXP2 else exp(b_gk_last3))[
                     None, :
                 ]
             if K > 192:
-                o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(
                     gk + (bos + last_idx) * H * K + i_h * K + o_k4,
-                    mask=(o_k4 < K),
+                    mask=m_k4,
                     other=0.0,
                 )
                 b_h4 *= (tl.math.exp2(b_gk_last4) if USE_EXP2 else exp(b_gk_last4))[
@@ -1245,48 +1204,34 @@ def chunk_gated_delta_rule_fwd_kernel_h_opt_vk(
         b_v = b_v.to(k.dtype.element_ty)
 
         # h[V,K] += v_new^T @ k  →  [BV,64] += trans(dot(k[64,BT], v[BT,BV]))
-        p_k = tl.make_block_ptr(
-            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        p_k = k + o_k1[:, None] + o_t[None, :] * stride_k
+        b_k = tl.load(p_k, mask=m_k1[:, None] & m_t[None, :], other=0.0)
         b_h1 += tl.trans(tl.dot(b_k, b_v))
         if K > 64:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k2[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k2[:, None] & m_t[None, :], other=0.0)
             b_h2 += tl.trans(tl.dot(b_k, b_v))
         if K > 128:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k3[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k3[:, None] & m_t[None, :], other=0.0)
             b_h3 += tl.trans(tl.dot(b_k, b_v))
         if K > 192:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            p_k = k + o_k4[:, None] + o_t[None, :] * stride_k
+            b_k = tl.load(p_k, mask=m_k4[:, None] & m_t[None, :], other=0.0)
             b_h4 += tl.trans(tl.dot(b_k, b_v))
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = ht + o_v[:, None] * K + o_k1[None, :]
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), mask=m_h1)
         if K > 64:
-            p_ht = tl.make_block_ptr(
-                ht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
-            )
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_v[:, None] * K + o_k2[None, :]
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), mask=m_h2)
         if K > 128:
-            p_ht = tl.make_block_ptr(
-                ht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
-            )
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_v[:, None] * K + o_k3[None, :]
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), mask=m_h3)
         if K > 192:
-            p_ht = tl.make_block_ptr(
-                ht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
-            )
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = ht + o_v[:, None] * K + o_k4[None, :]
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), mask=m_h4)
 
 
 def chunk_gated_delta_rule_fwd_h_opt_vk(

--- a/aiter/ops/triton/kimi_delta_attn/__init__.py
+++ b/aiter/ops/triton/kimi_delta_attn/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Kimi Delta Attention Operations (Forward Only).
+
+Public Triton entry points for the KDA linear-attention mixer used by
+Kimi-Linear / Kimi-K3. The chunked prefill op mirrors ``fla.ops.kda.chunk_kda``.
+"""
+
+from .chunk_delta_attn import chunk_kimi_delta_attn
+
+__all__ = [
+    "chunk_kimi_delta_attn",
+]

--- a/aiter/ops/triton/kimi_delta_attn/chunk_delta_attn.py
+++ b/aiter/ops/triton/kimi_delta_attn/chunk_delta_attn.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""
+Kimi Delta Attention (KDA) chunked forward pass (Forward Only).
+
+This is the public entry point for the ``chunk_delta_attn`` Triton kernels. The
+signature mirrors ``fla.ops.kda.chunk_kda`` so serving stacks can swap the two
+backends without reshaping tensors or re-deriving the gate.
+
+Important Note:
+    Only the forward pass is implemented. These functions do NOT support
+    gradient computation. For training, use the flash-linear-attention library.
+
+Notes on the fla-compatible surface:
+    * ``state_v_first`` is spelled as fla spells it from 0.5.1 onward. fla's
+      pre-0.5.1 name ``transpose_state_layout`` is deliberately not accepted, so
+      a shared argument dict requires fla >= 0.5.1 on the other side.
+    * ``disable_recompute`` is accepted for signature parity but has no effect.
+      In both libraries it only decides whether the gated query ``qg`` is
+      materialized for a backward pass to reuse -- neither forward output
+      kernel reads it. Since this path is forward-only and returns no scratch,
+      honouring ``True`` would allocate and write a ``T x HV x K`` tensor that
+      nothing can observe, so the flag is pinned off internally.
+    * ``allow_neg_eigval`` / ``return_intermediate_states`` / ``cp_context`` /
+      ``cu_seqlens_cpu`` have no counterpart yet and are rejected rather than
+      silently ignored.
+    * Tensor arguments are made contiguous here, as fla's ``@input_guard``
+      does, because some kernels below assume contiguous strides.
+    * This path is forward-only, so the output carries no ``grad_fn`` even
+      when the inputs require grad, whereas fla returns a differentiable
+      tensor.
+"""
+
+import torch
+
+from aiter.ops.triton._triton_kernels.chunk_delta_attn import chunk_delta_attn_fwd
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+_LOGGER = AiterTritonLogger()
+
+
+def chunk_kimi_delta_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    use_gate_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
+    safe_gate: bool = False,
+    lower_bound: float | None = None,
+    state_v_first: bool = False,
+    disable_recompute: bool = False,
+    chunk_size: int = 64,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    r"""
+    Chunked Kimi Delta Attention forward pass using Triton (Forward only).
+
+    Warning:
+        Forward only; this function does NOT compute gradients.
+
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, HV, V]`. GVA is applied if `HV > H`, in which
+            case `HV` must be divisible by `H`.
+        g (torch.Tensor):
+            (forget) gate of shape `[B, T, HV, K]`.
+            When `use_gate_in_kernel=False` this is the pre-computed decay in log
+            space; when `True` it is the raw pre-activation input and the kernel
+            fuses the `A_log` / `dt_bias` activation plus the chunk cumsum.
+        A_log (torch.Tensor, optional):
+            per-head log-scale of shape `[HV]`. Required when
+            `use_gate_in_kernel=True`.
+        dt_bias (torch.Tensor, optional):
+            per-K-channel bias of shape `[HV * K]`, added to `g` before the gate
+            activation. Default: `None`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, HV]`. Raw logits when
+            `use_beta_sigmoid_in_kernel=True`, post-sigmoid otherwise. Pass this
+            in fp32 to keep the delta-rule write strength from being rounded to
+            the input dtype.
+        scale (float, optional):
+            Scale factor for the attention scores. Default: `1 / sqrt(K)`.
+        initial_state (torch.Tensor, optional):
+            Initial state of shape `[N, HV, K, V]` (`[N, HV, V, K]` when
+            `state_v_first=True`) and dtype fp32, for `N` input sequences. For
+            equal-length inputs `N` equals the batch size `B`. Default: `None`.
+        output_final_state (bool):
+            Whether to return the final state, same shape and dtype as
+            `initial_state`. Default: `False`.
+        use_qk_l2norm_in_kernel (bool):
+            Whether to L2-normalize `q` and `k` before the recurrence.
+        use_gate_in_kernel (bool):
+            Whether to compute the log-space decay from `g` internally.
+        use_beta_sigmoid_in_kernel (bool):
+            Whether to apply `sigmoid` to `beta` before the recurrence.
+        safe_gate (bool):
+            Whether to use the sub-chunk intra kernel, which keeps the gate
+            bounded across sub-chunk boundaries. Requires `lower_bound`.
+        lower_bound (float, optional):
+            Lower bound of the forget gate in log space. When set, the gate
+            activation becomes `lower_bound * sigmoid(exp(A_log) * (g + dt_bias))`
+            instead of `-exp(A_log) * softplus(g + dt_bias)`. Kimi uses `-5.0`.
+        state_v_first (bool):
+            Store the recurrent state V-first (`[V, K]`) instead of `[K, V]`.
+        disable_recompute (bool):
+            Ignored. In fla this keeps the gated query `qg` alive for the
+            backward pass; this path is forward-only and returns no scratch,
+            so the flag is accepted for signature parity only.
+        chunk_size (int):
+            Chunk size, either 32 or 64. Default: `64`.
+        cu_seqlens (torch.LongTensor, optional):
+            Cumulative sequence lengths of shape `[N+1]` for variable-length
+            inputs, consistent with the FlashAttention API. Default: `None`.
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor | None]:
+            - o (torch.Tensor): Outputs of shape `[B, T, HV, V]`.
+            - final_state (torch.Tensor | None): Final state if
+              `output_final_state=True` else `None`.
+
+    Examples:
+        >>> import torch
+        >>> from aiter.ops.triton.kimi_delta_attn import chunk_kimi_delta_attn
+        >>> B, T, H, K, V = 1, 2048, 8, 128, 128
+        >>> q = torch.randn(B, T, H, K, device='cuda', dtype=torch.bfloat16)
+        >>> k = torch.randn(B, T, H, K, device='cuda', dtype=torch.bfloat16)
+        >>> v = torch.randn(B, T, H, V, device='cuda', dtype=torch.bfloat16)
+        >>> g = torch.randn(B, T, H, K, device='cuda', dtype=torch.bfloat16)
+        >>> beta = torch.randn(B, T, H, device='cuda', dtype=torch.float32)
+        >>> A_log = torch.randn(H, device='cuda', dtype=torch.float32)
+        >>> dt_bias = torch.randn(H * K, device='cuda', dtype=torch.float32)
+        >>> h0 = torch.zeros(B, H, K, V, device='cuda', dtype=torch.float32)
+        >>> o, ht = chunk_kimi_delta_attn(
+        ...     q, k, v, g, beta, A_log=A_log, dt_bias=dt_bias,
+        ...     use_qk_l2norm_in_kernel=True,
+        ...     use_gate_in_kernel=True,
+        ...     use_beta_sigmoid_in_kernel=True,
+        ...     safe_gate=True, lower_bound=-5.0,
+        ...     initial_state=h0, output_final_state=True,
+        ... )
+    """
+    B, T, H, K = q.shape
+    HV = v.shape[2]
+
+    if q.shape != k.shape:
+        raise ValueError(
+            f"q and k must have the same shape, got {q.shape} vs {k.shape}."
+        )
+    if K > 256:
+        raise ValueError(f"Only key head dim <= 256 is supported, got {K}.")
+    if HV % H != 0:
+        raise ValueError(
+            f"For GVA, num_v_heads (HV={HV}) must be divisible by num_qk_heads (H={H})."
+        )
+    if tuple(g.shape) != (B, T, HV, K):
+        raise ValueError(f"g must have shape {(B, T, HV, K)}, got {tuple(g.shape)}.")
+    if tuple(beta.shape) != (B, T, HV):
+        raise ValueError(f"beta must have shape {(B, T, HV)}, got {tuple(beta.shape)}.")
+
+    if cu_seqlens is not None:
+        if B != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {B} when using "
+                "`cu_seqlens`. Please flatten variable-length inputs before processing."
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                "The number of initial states is expected to be equal to the number "
+                f"of input sequences, i.e., {len(cu_seqlens) - 1} rather than "
+                f"{initial_state.shape[0]}."
+            )
+    if initial_state is not None and initial_state.dtype != torch.float32:
+        raise ValueError(
+            f"`initial_state` must be fp32, got {initial_state.dtype}. The recurrence "
+            "accumulates in fp32 and the state is read back verbatim."
+        )
+
+    if use_gate_in_kernel and A_log is None:
+        raise ValueError("`A_log` must be provided when `use_gate_in_kernel=True`.")
+    if safe_gate and use_gate_in_kernel:
+        if lower_bound is None:
+            raise ValueError(
+                "`lower_bound` must be specified when `safe_gate=True` and "
+                "`use_gate_in_kernel=True`."
+            )
+        if not -5 <= lower_bound < 0:
+            raise ValueError(
+                f"`lower_bound` must be in the safe range [-5, 0), got {lower_bound}."
+            )
+
+    if scale is None:
+        scale = K**-0.5
+    elif scale <= 0:
+        raise ValueError(f"`scale` must be positive, got {scale}.")
+
+    _LOGGER.info(
+        f"CHUNK_KIMI_DELTA_ATTN: q={tuple(q.shape)}, v={tuple(v.shape)}, "
+        f"scale={scale}, chunk_size={chunk_size}, safe_gate={safe_gate}, "
+        f"lower_bound={lower_bound}, state_v_first={state_v_first}, "
+        f"varlen={cu_seqlens is not None}"
+    )
+
+    # Match fla, which puts `@input_guard` on its autograd Function. Several
+    # kernels below index their operands with contiguous strides rather than
+    # reading the tensor's own, so a view would be read as garbage instead of
+    # raising: `q`/`k` reach the unguarded l2norm, `initial_state` the
+    # unguarded state kernel. No-op for the contiguous inputs serving stacks
+    # normally pass.
+    q, k, v, g, beta = (t.contiguous() for t in (q, k, v, g, beta))
+    if A_log is not None:
+        A_log = A_log.contiguous()
+    if dt_bias is not None:
+        dt_bias = dt_bias.contiguous()
+    if initial_state is not None:
+        initial_state = initial_state.contiguous()
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.contiguous()
+
+    o, final_state, *_ = chunk_delta_attn_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        safe_gate=safe_gate,
+        lower_bound=lower_bound,
+        use_gate_in_kernel=use_gate_in_kernel,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        # Pinned off: it would only materialize `qg` for a backward that does
+        # not exist here, and the scratch is discarded below either way.
+        disable_recompute=False,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
+        state_v_first=state_v_first,
+    )
+    return o.to(q.dtype), final_state

--- a/op_tests/op_benchmarks/triton/bench_chunk_delta_attn.py
+++ b/op_tests/op_benchmarks/triton/bench_chunk_delta_attn.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Performance benchmark for chunk_delta_attn forward pass.
+
+Sweeps over sequence length (T) by default; supports custom shapes via --shape.
+
+Usage examples
+--------------
+# Sweep default shapes, report time / TFLOPS / BW
+python bench_chunk_delta_attn.py
+
+# Single shape: B=2 T=4096 H=16 K=64 V=64
+python bench_chunk_delta_attn.py --shape 2 4096 16 64 64
+
+# Save CSV
+python bench_chunk_delta_attn.py -o
+"""
+
+import argparse
+import math
+import os
+import sys
+
+# Skip CK/HIP native .so loading – Triton kernels only
+os.environ.setdefault("AITER_TRITON_ONLY", "1")
+os.environ.setdefault("AITER_USE_SYSTEM_TRITON", "1")
+
+
+# Ensure repo root is on the path when running this script directly
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.chunk_delta_attn import chunk_delta_attn_fwd
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import get_caller_name_no_ext
+
+# (B, T, H, K, V)  – representative prefill shapes
+DEFAULT_SHAPES = [
+    (1, 512, 16, 64, 64),
+    (1, 1024, 16, 64, 64),
+    (1, 2048, 16, 64, 64),
+    (1, 4096, 16, 64, 64),
+    (1, 8192, 16, 64, 64),
+    (1, 16384, 16, 64, 64),
+    (2, 2048, 16, 64, 64),
+    (2, 4096, 16, 64, 64),
+    (4, 2048, 16, 64, 64),
+    (4, 4096, 16, 64, 64),
+    # K=V=128, sweep H and T
+    (1, 8192, 32, 128, 128),
+    (1, 8192, 64, 128, 128),
+    (1, 8192, 96, 128, 128),
+    (1, 8192, 128, 128, 128),
+    (1, 16384, 32, 128, 128),
+    (1, 16384, 64, 128, 128),
+    (1, 16384, 96, 128, 128),
+    (1, 16384, 128, 128, 128),
+]
+
+CHUNK_SIZE = 64
+DTYPE = torch.bfloat16
+DEVICE = "cuda"
+
+
+def _make_inputs(B, T, H, K, V, HV=None):
+    """Create raw benchmark inputs (l2norm + beta sigmoid applied inside fn)."""
+    if HV is None:
+        HV = H
+    scale = 1.0 / math.sqrt(K)
+    torch.manual_seed(0)
+    q = torch.randn(B, T, H, K, device=DEVICE, dtype=DTYPE)
+    k = torch.randn(B, T, H, K, device=DEVICE, dtype=DTYPE)
+    v = torch.randn(B, T, HV, V, device=DEVICE, dtype=DTYPE)
+    g = torch.randn(B, T, HV, K, device=DEVICE, dtype=DTYPE) * 0.1
+    beta = torch.randn(B, T, HV, device=DEVICE, dtype=DTYPE)
+    A_log = torch.randn(HV, device=DEVICE, dtype=torch.float32).abs() * 0.5
+    dt_bias = torch.randn(HV * K, device=DEVICE, dtype=torch.float32) * 0.1
+    return q, k, v, g, beta, A_log, dt_bias, scale
+
+
+def _flops(B, T, H, K, V, chunk_size):
+    """
+    Approximate FLOPs for the chunk_delta_attn forward pass.
+
+    Dominant terms:
+      - Intra-chunk QK:       B * T * H * chunk_size * K * 2
+      - Intra-chunk AV:       B * T * H * chunk_size * V * 2
+      - Inter-chunk KV state: B * T * H * K * V * 2
+      - Output QH:            B * T * H * K * V * 2
+    """
+    return B * T * H * 2 * (chunk_size * K + chunk_size * V + 2 * K * V)
+
+
+def _bytes(B, T, H, K, V, HV, elem_bytes=2):
+    """Approximate memory traffic (inputs read + output written)."""
+    read = (
+        B * T * H * K * elem_bytes  # q
+        + B * T * H * K * elem_bytes  # k
+        + B * T * HV * V * elem_bytes  # v
+        + B * T * HV * K * elem_bytes  # g
+        + B * T * HV * elem_bytes  # beta
+    )
+    write = B * T * HV * V * elem_bytes  # o
+    return read + write
+
+
+def run_benchmark(args):
+    if args.shape is not None:
+        B, T, H, K, V = args.shape
+        x_vals_list = [(B, T, H, K, V)]
+    else:
+        x_vals_list = DEFAULT_SHAPES
+
+    header = f"{'B':>4} {'T':>6} {'H':>4} {'K':>4} {'V':>4}  {'Time(ms)':>10}  {'TFLOPS':>8}  {'BW(GB/s)':>10}"
+    print(header)
+    print("-" * len(header))
+
+    rows = []
+    for B, T, H, K, V in x_vals_list:
+        HV = H
+        q, k, v, g, beta, A_log, dt_bias, scale = _make_inputs(B, T, H, K, V, HV)
+
+        def fn(
+            q=q, k=k, v=v, g=g, beta=beta, scale=scale, A_log=A_log, dt_bias=dt_bias
+        ):
+            return chunk_delta_attn_fwd(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                scale=scale,
+                initial_state=None,
+                output_final_state=False,
+                chunk_size=CHUNK_SIZE,
+                use_gate_in_kernel=True,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=-5.0,
+                safe_gate=True,
+                use_qk_l2norm_in_kernel=True,
+                use_beta_sigmoid_in_kernel=True,
+            )
+
+        # Time-based warmup: run until WARMUP_MS elapsed so JIT/autotune completes.
+        _elapsed = 0.0
+        while _elapsed < args.warmup_ms:
+            _t0 = torch.cuda.Event(enable_timing=True)
+            _t1 = torch.cuda.Event(enable_timing=True)
+            _t0.record()
+            fn()
+            _t1.record()
+            torch.cuda.synchronize()
+            _elapsed += _t0.elapsed_time(_t1)
+
+        ms = triton.testing.do_bench(fn, warmup=0, rep=args.rep_ms)
+        tflops = _flops(B, T, H, K, V, CHUNK_SIZE) / ms * 1e-9
+        bw = _bytes(B, T, H, K, V, HV) / (ms * 1e-3) * 1e-9
+
+        print(
+            f"{B:>4} {T:>6} {H:>4} {K:>4} {V:>4}  {ms:>10.4f}  {tflops:>8.2f}  {bw:>10.1f}"
+        )
+        rows.append((B, T, H, K, V, ms, tflops, bw))
+
+    if args.o:
+        import csv
+
+        fname = f"{get_caller_name_no_ext()}.csv"
+        with open(fname, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["B", "T", "H", "K", "V", "Time_ms", "TFLOPS", "BW_GBs"])
+            w.writerows(rows)
+        print(f"\nSaved to {fname}")
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(
+        prog="Benchmark chunk_delta_attn forward",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--shape",
+        type=int,
+        nargs=5,
+        metavar=("B", "T", "H", "K", "V"),
+        help="Single shape to benchmark instead of the default sweep.",
+    )
+    parser.add_argument(
+        "-o",
+        action="store_true",
+        help="Write results to a CSV file in the current directory.",
+    )
+    parser.add_argument(
+        "--warmup-ms",
+        type=float,
+        default=300.0,
+        help="Warmup budget in ms (time-based, ensures JIT/Gluon compile completes).",
+    )
+    parser.add_argument(
+        "--rep-ms",
+        type=float,
+        default=500.0,
+        help="Measurement budget in ms passed to triton.testing.do_bench.",
+    )
+    return parser.parse_args(args=args)
+
+
+def main(args=None):
+    run_benchmark(parse_args(args=args))
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/test_gated_delta_rule.py
+++ b/op_tests/test_gated_delta_rule.py
@@ -1271,5 +1271,66 @@ def test_chunk_opt_vk_varlen(
     assert_close("ht", ref_ht, tri_ht.transpose(-1, -2), 0.005)
 
 
+def _free_gib() -> float:
+    if not torch.cuda.is_available():
+        return 0.0
+    return torch.cuda.mem_get_info()[0] / 2**30
+
+
+@pytest.mark.skipif(_free_gib() < 24, reason="needs ~12 GiB of free device memory")
+@pytest.mark.parametrize(
+    "seqlens",
+    [
+        pytest.param([134400], id="single-2100-chunks"),
+        pytest.param([45000, 45000, 45000], id="varlen-2112-chunks"),
+    ],
+)
+def test_chunk_fwd_h_beyond_int32_chunk_offsets(seqlens):
+    """Chunk offsets past 2**31 elements must not wrap.
+
+    With H*K*V == 2**20 the per-chunk stride into ``h`` overflows int32 at chunk
+    2048; before the offsets were widened this wrote behind the buffer and
+    faulted the GPU. Zero k/w/u and no gate leave the state untouched, so every
+    chunk snapshot must come back exactly equal to the initial state.
+    """
+    from aiter.ops.triton._triton_kernels.gated_delta_rule.prefill import (
+        chunk_gated_delta_rule_fwd_h,
+    )
+
+    H, K, V, BT = 64, 128, 128, 64
+    T = sum(seqlens)
+    zero = torch.zeros(1, T, H, K, device=device, dtype=torch.bfloat16)
+    u = torch.zeros(1, T, H, V, device=device, dtype=torch.bfloat16)
+    h0 = torch.randn(len(seqlens), H, K, V, device=device, dtype=torch.float32)
+    cu_seqlens = None
+    if len(seqlens) > 1:
+        cu_seqlens = torch.tensor(
+            [0] + torch.tensor(seqlens).cumsum(0).tolist(),
+            device=device,
+            dtype=torch.int32,
+        )
+
+    h, _, ht = chunk_gated_delta_rule_fwd_h(
+        k=zero,
+        w=zero,
+        u=u,
+        g=None,
+        gk=None,
+        initial_state=h0,
+        output_final_state=True,
+        chunk_size=BT,
+        save_new_value=False,
+        cu_seqlens=cu_seqlens,
+    )
+
+    assert torch.equal(ht, h0)
+    base = 0
+    for s, seqlen in enumerate(seqlens):
+        want = h0[s].to(h.dtype)
+        for i in range(base, base + -(-seqlen // BT)):
+            assert torch.equal(h[0, i], want), f"chunk {i} of sequence {s}"
+        base += -(-seqlen // BT)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/op_tests/triton_tests/chunk_delta_attn/test_chunk_delta_attn_fwd.py
+++ b/op_tests/triton_tests/chunk_delta_attn/test_chunk_delta_attn_fwd.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Tests for chunk_delta_attn forward pass and constituent kernels.
+
+"""
+
+import os
+
+os.environ.setdefault("AITER_TRITON_ONLY", "1")
+os.environ.setdefault("AITER_USE_SYSTEM_TRITON", "1")
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+# Attempt to import the FLA reference; skip if unavailable.
+# Install flash-linear-attention (`pip install -e /path/to/fla`) to enable
+# the consistency tests against the upstream reference.
+try:
+    from fla.ops.kda.chunk import chunk_kda
+
+    HAS_FLA = True
+except (ImportError, ModuleNotFoundError):
+    HAS_FLA = False
+
+from aiter.ops.triton._triton_kernels.chunk_delta_attn import chunk_delta_attn_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.gate import beta_sigmoid_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils import l2norm_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.cumsum import (
+    chunk_gate_cumsum,
+)
+
+device = "cuda"
+dtype = torch.bfloat16
+
+
+def make_inputs(B, T, H, HV, K, V, seed=42):
+    torch.manual_seed(seed)
+    scale = 1.0 / math.sqrt(K)
+    q = torch.randn(B, T, H, K, device=device, dtype=dtype)
+    k = torch.randn(B, T, H, K, device=device, dtype=dtype)
+    v = torch.randn(B, T, HV, V, device=device, dtype=dtype)
+    g = torch.randn(B, T, HV, K, device=device, dtype=dtype) * 0.1
+    beta = torch.randn(B, T, HV, device=device, dtype=dtype)
+    A_log = torch.randn(HV, device=device, dtype=torch.float32).abs() * 0.5
+    dt_bias = torch.randn(HV * K, device=device, dtype=torch.float32) * 0.1
+    return q, k, v, g, beta, A_log, dt_bias, scale
+
+
+def _ref_gate_cumsum_softplus(g, A_log, chunk_size, scale=None, dt_bias=None):
+    """Pure-torch reference: -exp(A) * softplus(g + bias), then chunk cumsum."""
+    B, T, H, S = g.shape
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(H, S)
+    gate = -A_log.exp().view(H, 1) * F.softplus(g.view(B * T, H, S)).view(B, T, H, S)
+    out = torch.zeros_like(gate)
+    for b in range(B):
+        for h in range(H):
+            for t_start in range(0, T, chunk_size):
+                t_end = min(t_start + chunk_size, T)
+                chunk = gate[b, t_start:t_end, h, :]
+                out[b, t_start:t_end, h, :] = torch.cumsum(chunk, dim=0)
+    if scale is not None:
+        out = out * scale
+    return out
+
+
+def _ref_gate_cumsum_sigmoid(
+    g, A_log, chunk_size, lower_bound, scale=None, dt_bias=None
+):
+    """Pure-torch reference: lower_bound * sigmoid(exp(A) * (g + bias)), then chunk cumsum."""
+    B, T, H, S = g.shape
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(H, S)
+    gate = lower_bound * torch.sigmoid(A_log.exp().view(H, 1) * g.view(B, T, H, S))
+    out = torch.zeros_like(gate)
+    for b in range(B):
+        for h in range(H):
+            for t_start in range(0, T, chunk_size):
+                t_end = min(t_start + chunk_size, T)
+                chunk = gate[b, t_start:t_end, h, :]
+                out[b, t_start:t_end, h, :] = torch.cumsum(chunk, dim=0)
+    if scale is not None:
+        out = out * scale
+    return out
+
+
+@pytest.fixture(params=[(1, 64, 4, 32), (2, 128, 8, 64)])
+def cumsum_inputs(request):
+    B, T, H, S = request.param
+    torch.manual_seed(42)
+    g = torch.randn(B, T, H, S, device=device, dtype=dtype)
+    A_log = torch.randn(H, device=device, dtype=torch.float32).abs() * 0.5
+    return g, A_log, B, T, H, S
+
+
+class TestChunkGateCumsum:
+
+    def test_softplus_no_bias(self, cumsum_inputs):
+        g, A_log, B, T, H, S = cumsum_inputs
+        ref = _ref_gate_cumsum_softplus(g, A_log, 32)
+        out = chunk_gate_cumsum(g, A_log, chunk_size=32, output_dtype=torch.float32)
+        assert out.shape == (B, T, H, S)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+    def test_softplus_with_bias(self, cumsum_inputs):
+        g, A_log, _B, _T, H, S = cumsum_inputs
+        dt_bias = torch.randn(H * S, device=device, dtype=torch.float32) * 0.1
+        ref = _ref_gate_cumsum_softplus(g, A_log, 32, dt_bias=dt_bias)
+        out = chunk_gate_cumsum(
+            g, A_log, chunk_size=32, dt_bias=dt_bias, output_dtype=torch.float32
+        )
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+    def test_softplus_with_scale(self, cumsum_inputs):
+        g, A_log, *_ = cumsum_inputs
+        scale = 1.4426950408889634  # RCP_LN2
+        ref = _ref_gate_cumsum_softplus(g, A_log, 32, scale=scale)
+        out = chunk_gate_cumsum(
+            g, A_log, chunk_size=32, scale=scale, output_dtype=torch.float32
+        )
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+    def test_sigmoid_lower_bound(self, cumsum_inputs):
+        g, A_log, *_ = cumsum_inputs
+        lower_bound = -5.0
+        ref = _ref_gate_cumsum_sigmoid(g, A_log, 32, lower_bound)
+        out = chunk_gate_cumsum(
+            g, A_log, chunk_size=32, lower_bound=lower_bound, output_dtype=torch.float32
+        )
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize("chunk_size", [32, 64])
+    def test_chunk_size_variants(self, chunk_size):
+        B, T, H, S = 1, 128, 4, 32
+        torch.manual_seed(0)
+        g = torch.randn(B, T, H, S, device=device, dtype=dtype)
+        A_log = torch.randn(H, device=device, dtype=torch.float32).abs() * 0.5
+        ref = _ref_gate_cumsum_softplus(g, A_log, chunk_size)
+        out = chunk_gate_cumsum(
+            g, A_log, chunk_size=chunk_size, output_dtype=torch.float32
+        )
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+    def test_output_dtype_bfloat16(self, cumsum_inputs):
+        g, A_log, *_ = cumsum_inputs
+        out = chunk_gate_cumsum(g, A_log, chunk_size=32, output_dtype=torch.bfloat16)
+        assert out.dtype == torch.bfloat16
+
+    def test_output_dtype_float32(self, cumsum_inputs):
+        g, A_log, *_ = cumsum_inputs
+        out = chunk_gate_cumsum(g, A_log, chunk_size=32, output_dtype=torch.float32)
+        assert out.dtype == torch.float32
+
+    def test_triton_opt_disabled(self, cumsum_inputs, monkeypatch):
+        """Non-optimised Triton kernel path also produces correct results."""
+        monkeypatch.setenv("DA_TRITON_OPT", "0")
+        g, A_log, *_ = cumsum_inputs
+        ref = _ref_gate_cumsum_softplus(g, A_log, 32)
+        out = chunk_gate_cumsum(g, A_log, chunk_size=32, output_dtype=torch.float32)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+class TestChunkDeltaAttnFwdSmoke:
+
+    @pytest.mark.parametrize(
+        "B,T,H,HV,K,V",
+        [
+            (1, 64, 4, 4, 64, 64),
+            (2, 128, 8, 8, 64, 64),
+            (1, 64, 2, 4, 64, 64),  # GVA: HV > H
+            (1, 64, 64, 64, 128, 128),  # K=V=128, H=64
+        ],
+    )
+    def test_output_shape(self, B, T, H, HV, K, V):
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+        q, _ = l2norm_fwd(q)
+        k, _ = l2norm_fwd(k)
+        beta = beta_sigmoid_fwd(beta)
+        o, final_state, *_ = chunk_delta_attn_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=None,
+            output_final_state=True,
+            chunk_size=64,
+            use_gate_in_kernel=True,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+        )
+        assert o.shape == (B, T, HV, V)
+        assert final_state is not None
+        assert final_state.shape == (B, HV, K, V)
+        assert not torch.isnan(o).any()
+
+    def test_no_gate_in_kernel(self):
+        B, T, H, HV, K, V = 1, 64, 4, 4, 64, 64
+        q, k, v, g, beta, _A_log, _dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+        q, _ = l2norm_fwd(q)
+        k, _ = l2norm_fwd(k)
+        beta = beta_sigmoid_fwd(beta)
+        o, _, *_ = chunk_delta_attn_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=None,
+            output_final_state=False,
+            chunk_size=64,
+            use_gate_in_kernel=False,
+        )
+        assert o.shape == (B, T, HV, V)
+        assert not torch.isnan(o).any()
+
+    def test_with_initial_state(self):
+        B, T, H, HV, K, V = 1, 64, 4, 4, 64, 64
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+        q, _ = l2norm_fwd(q)
+        k, _ = l2norm_fwd(k)
+        beta = beta_sigmoid_fwd(beta)
+        h0 = torch.zeros(B, HV, K, V, device=device, dtype=torch.float32)
+        o, fs, *_ = chunk_delta_attn_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=h0,
+            output_final_state=True,
+            chunk_size=64,
+            use_gate_in_kernel=True,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+        )
+        assert o.shape == (B, T, HV, V)
+        assert fs.shape == (B, HV, K, V)
+
+
+class TestChunkSize32:
+    """The operator is chunking-invariant, so BT=32 and BT=64 must agree.
+
+    Guards the inter_solve kernel, which used to load the Akk22/Akk33 diagonal
+    blocks unconditionally and silently pulled data from the neighbouring chunk
+    when NC < 3.
+    """
+
+    @pytest.mark.parametrize(
+        "B,T,H,HV,K,V",
+        [
+            (1, 64, 4, 4, 64, 64),
+            (2, 128, 8, 8, 64, 64),
+            (1, 256, 4, 8, 128, 128),
+        ],
+    )
+    @pytest.mark.parametrize("safe_gate", [False, True])
+    def test_matches_chunk_size_64(self, B, T, H, HV, K, V, safe_gate):
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+
+        def run(chunk_size):
+            q2, _ = l2norm_fwd(q.clone())
+            k2, _ = l2norm_fwd(k.clone())
+            beta2 = beta_sigmoid_fwd(beta.clone())
+            o, fs, *_ = chunk_delta_attn_fwd(
+                q=q2,
+                k=k2,
+                v=v.clone(),
+                g=g.clone(),
+                beta=beta2,
+                scale=scale,
+                initial_state=None,
+                output_final_state=True,
+                chunk_size=chunk_size,
+                safe_gate=safe_gate,
+                use_gate_in_kernel=True,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=-5.0,
+            )
+            return o.float(), fs.float()
+
+        o32, s32 = run(32)
+        o64, s64 = run(64)
+        assert not torch.isnan(o32).any()
+        torch.testing.assert_close(o32, o64, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(s32, s64, atol=2e-2, rtol=2e-2)
+
+    @pytest.mark.parametrize("safe_gate", [False, True])
+    def test_varlen_matches_chunk_size_64(self, safe_gate):
+        B, T, H, HV, K, V = 1, 384, 4, 4, 64, 64
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+        cu_seqlens = torch.tensor([0, 96, 224, 384], device=device, dtype=torch.int32)
+
+        def run(chunk_size):
+            q2, _ = l2norm_fwd(q.clone())
+            k2, _ = l2norm_fwd(k.clone())
+            beta2 = beta_sigmoid_fwd(beta.clone())
+            o, *_ = chunk_delta_attn_fwd(
+                q=q2,
+                k=k2,
+                v=v.clone(),
+                g=g.clone(),
+                beta=beta2,
+                scale=scale,
+                initial_state=None,
+                output_final_state=False,
+                chunk_size=chunk_size,
+                safe_gate=safe_gate,
+                cu_seqlens=cu_seqlens,
+                use_gate_in_kernel=True,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=-5.0,
+            )
+            return o.float()
+
+        torch.testing.assert_close(run(32), run(64), atol=2e-2, rtol=2e-2)
+
+    def test_unsupported_chunk_size_rejected(self):
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(1, 64, 4, 4, 64, 64)
+        with pytest.raises(ValueError, match="32 or 64"):
+            chunk_delta_attn_fwd(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                scale=scale,
+                initial_state=None,
+                output_final_state=False,
+                chunk_size=48,
+                use_gate_in_kernel=True,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=-5.0,
+            )
+
+
+class TestStateVFirst:
+    """``state_v_first`` only changes how the recurrent state is laid out.
+
+    The kernel accumulates the same registers either way and only the epilogue
+    store (and the h0 load) is re-strided, so the results must agree bitwise --
+    not just within tolerance.
+    """
+
+    @pytest.mark.parametrize("with_initial_state", [False, True])
+    @pytest.mark.parametrize("varlen", [False, True])
+    def test_matches_k_first_layout(self, with_initial_state, varlen):
+        B, T, H, HV, K, V = (1, 384, 4, 4, 64, 64) if varlen else (2, 256, 4, 4, 64, 64)
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+        cu_seqlens = (
+            torch.tensor([0, 96, 224, 384], device=device, dtype=torch.int32)
+            if varlen
+            else None
+        )
+        N = B if cu_seqlens is None else len(cu_seqlens) - 1
+
+        h0 = None
+        if with_initial_state:
+            torch.manual_seed(7)
+            h0 = torch.randn(N, HV, K, V, device=device, dtype=torch.float32)
+
+        def run(state_v_first):
+            # h0 is expressed in whichever layout the call expects; both describe
+            # the same mathematical state.
+            init = None
+            if h0 is not None:
+                init = (
+                    h0.transpose(-1, -2).contiguous() if state_v_first else h0.clone()
+                )
+            o, fs, *_ = chunk_delta_attn_fwd(
+                q=q.clone(),
+                k=k.clone(),
+                v=v.clone(),
+                g=g.clone(),
+                beta=beta.clone(),
+                scale=scale,
+                initial_state=init,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                chunk_size=64,
+                safe_gate=True,
+                use_gate_in_kernel=True,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=-5.0,
+                use_qk_l2norm_in_kernel=True,
+                use_beta_sigmoid_in_kernel=True,
+                state_v_first=state_v_first,
+            )
+            return o, fs
+
+        o_kv, fs_kv = run(False)
+        o_vk, fs_vk = run(True)
+
+        assert fs_kv.shape == (N, HV, K, V)
+        assert fs_vk.shape == (N, HV, V, K)
+        assert not torch.isnan(fs_vk).any()
+        torch.testing.assert_close(o_vk, o_kv, atol=0, rtol=0)
+        torch.testing.assert_close(fs_vk, fs_kv.transpose(-1, -2), atol=0, rtol=0)
+
+    def test_rejects_mismatched_initial_state_shape(self):
+        B, T, H, HV, K, V = 1, 128, 4, 4, 64, 64
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+        # [N, HV, K, V] is the K-first layout, rejected when state_v_first is on
+        # (it is square here only if K == V, so use a non-square head dim pair).
+        h0 = torch.zeros(B, HV, K, V + 64, device=device, dtype=torch.float32)
+        with pytest.raises(ValueError, match="initial_state"):
+            chunk_delta_attn_fwd(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                scale=scale,
+                initial_state=h0,
+                output_final_state=True,
+                chunk_size=64,
+                use_gate_in_kernel=True,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=-5.0,
+            )
+
+
+@pytest.mark.skipif(not HAS_FLA, reason="flash-linear-attention not available")
+class TestChunkDeltaAttnFwdVsFLA:
+
+    @pytest.mark.parametrize(
+        "B,T,H,K,V",
+        [
+            (1, 64, 4, 64, 64),
+            (2, 128, 8, 64, 64),
+            (1, 64, 64, 128, 128),
+        ],
+    )
+    def test_output_matches_fla(self, B, T, H, K, V):
+        HV = H
+        q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
+
+        o_ref, _ = chunk_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=None,
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            use_gate_in_kernel=True,
+            lower_bound=-5.0,
+        )
+
+        q2, _ = l2norm_fwd(q.clone())
+        k2, _ = l2norm_fwd(k.clone())
+        beta2 = beta_sigmoid_fwd(beta.clone())
+        o_ait, *_ = chunk_delta_attn_fwd(
+            q=q2,
+            k=k2,
+            v=v.clone(),
+            g=g.clone(),
+            beta=beta2,
+            scale=scale,
+            initial_state=None,
+            output_final_state=False,
+            chunk_size=64,
+            use_gate_in_kernel=True,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+        )
+
+        torch.testing.assert_close(
+            o_ait.float(),
+            o_ref.float(),
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"Output mismatch for B={B} T={T} H={H} K={K} V={V}",
+        )


### PR DESCRIPTION
 ## Motivation

 Add `chunk_delta_attn` (chunked delta-attention operator with gated recurrence) as a first-class Triton op in aiter.

  ## Technical Details

  **Triton dispatch layer** (`aiter/ops/triton/_triton_kernels/chunk_delta_attn/`)  ported from flash-linear-attention v0.5.2 commit 9c8e42e.

  - `chunk_fwd.py` — top-level entry point
  - `gate.py` — beta sigmoid preprocessing
  - `intra_attn.py` — intra-chunk attention (sub-chunk diagonal + inter-solve + W/U recompute)
  - `wy_fast.py` — recompute W and U tensors from Akk inverse
  - `gla_output.py` — GLA output computation
  - `utils/cumsum.py` — fused gate + chunk-local prefix sum
  - `utils/index.py` — variable-length sequence chunk index preparation
  - `utils/l2norm.py` — L2 normalization (forward only)
  - `utils/utils.py` — shared constants, autotune helpers, `input_guard` decorator


  ## Test Plan

  - Correctness:
    ```bash
    pytest op_tests/triton_tests/chunk_delta_attn/ -v
    ```
  - Performance:
  
``` bash
   python op_tests/op_benchmarks/triton/bench_chunk_delta_attn.py
```

  ## Test Result
  All correctness tests pass (bfloat16, atol=1e-2, rtol=1e-2). KDA E2E Precision verification passed on GFX1250/GFX950 with Triton 3.7.0 + commit efbae9a33c. 
 AMD MI350X：
| B | T     | H   | K   | V   | Time(ms) | TFLOPS | BW(GB/s) |
|---|-------|-----|-----|-----|----------|--------|----------|
| 1 | 512   | 16  | 64  | 64  | 0.2923   | 0.92   | 18.0     |
| 1 | 1024  | 16  | 64  | 64  | 0.2805   | 1.91   | 37.5     |
| 1 | 2048  | 16  | 64  | 64  | 0.2862   | 3.75   | 73.5     |
| 1 | 4096  | 16  | 64  | 64  | 0.2927   | 7.34   | 143.8    |
| 1 | 8192  | 16  | 64  | 64  | 0.3403   | 12.62  | 247.3    |
| 1 | 16384 | 16  | 64  | 64  | 0.7183   | 11.96  | 234.3    |
| 2 | 2048  | 16  | 64  | 64  | 0.2898   | 7.41   | 145.2    |
| 2 | 4096  | 16  | 64  | 64  | 0.2994   | 14.35  | 281.1    |
| 4 | 2048  | 16  | 64  | 64  | 0.2995   | 14.34  | 280.9    |
| 4 | 4096  | 16  | 64  | 64  | 0.4492   | 19.12  | 374.6    |
| 1 | 8192  | 32  | 128 | 128 | 0.9621   | 26.78  | 349.3    |
| 1 | 8192  | 64  | 128 | 128 | 1.5373   | 33.53  | 437.2    |
| 1 | 8192  | 96  | 128 | 128 | 2.2912   | 33.74  | 440.0    |
| 1 | 8192  | 128 | 128 | 128 | 2.9169   | 35.34  | 460.9    |
| 1 | 16384 | 32  | 128 | 128 | 1.7696   | 29.13  | 379.8    |
| 1 | 16384 | 64  | 128 | 128 | 3.0030   | 34.33  | 447.6    |
| 1 | 16384 | 96  | 128 | 128 | 4.5886   | 33.70  | 439.4    |
| 1 | 16384 | 128 | 128 | 128 | 5.6478   | 36.50  | 476.0    |

  
  
