### PR TITLE
feat(gemm): add tuned bf16 GEMM config for Qwen3-8B (gfx950)

### DIFF
--- a/aiter/configs/model_configs/qwen3_8b_bf16_tuned_gemm.csv
+++ b/aiter/configs/model_configs/qwen3_8b_bf16_tuned_gemm.csv
@@ -1,0 +1,11 @@
+gfx,cu_num,M,N,K,bias,dtype,outdtype,scaleAB,bpreshuffle,libtype,solidx,splitK,us,kernelName,err_ratio,tflops,bw
+gfx950,256,1,24576,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,34.1279,auto,0.0,5.9,5900.86
+gfx950,256,2,24576,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,33.5058,auto,0.0,12.02,6012.13
+gfx950,256,4,24576,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,32.9163,auto,0.0,24.47,6123.29
+gfx950,256,8,24576,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,32.1489,auto,0.0,50.1,6276.59
+gfx950,256,16,24576,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,35.4337,auto,0.0,90.91,5707.68
+gfx950,256,1,151936,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,182.8682,auto,0.0,6.81,6808.03
+gfx950,256,2,151936,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,182.3328,auto,0.0,13.65,6829.73
+gfx950,256,4,151936,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,183.6787,auto,0.0,27.11,6783.08
+gfx950,256,8,151936,4096,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,183.7932,auto,0.0,54.18,6785.65
+gfx950,256,16,151936,4096,False,torch.bfloat16,torch.bfloat16,False,False,torch,0,0,195.536,native,0.0,101.85,6390.91


### PR DESCRIPTION
Adds a standalone model_config with tuned bf16 GEMM solutions for the Qwen3-8B decode shapes on gfx950 (cu_num=256): gate_up (24576x4096) and lm_head (151936x4096) for M in {1,2,4,8,16}. qkv (6144x4096) and o_proj (4096x4096) are already covered by existing glm5/qwen3_5 model_configs; down_proj (4096x12288) is intentionally omitted since the skinny-GEMM default already runs near HBM peak.

Kept as a separate file (not merged into bf16_tuned_gemm.csv) to avoid the first-load dedup writeback that would perturb other model configs.

Measured on MI355X (gfx950), Qwen3-8B, TP=1, bs=8, 4096-token decode, interleaved A/B (thermal-controlled): +1.7% decode throughput (1383.5 -> 1407.2 tok/s).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
