### PR TITLE
Removed block pointers in `lean_atten_paged.py` and fix large-KV indexing

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/lean_atten_paged.py
+++ b/aiter/ops/triton/_triton_kernels/attention/lean_atten_paged.py
@@ -40,7 +40,6 @@ def la_persistent_paged(
     Op,
     Out,
     kv_block_tables,
-    kv_shape,
     batch_num_block_n,
     locks,
     stride_qh,
@@ -118,7 +117,9 @@ def la_persistent_paged(
             finishing_block = False
 
         KV_block_tables_ptr = kv_block_tables + iter
-        kv_offset = tile_head_idx * stride_kh
+        # 64-bit: this reaches H * CTX * HEAD_DIM, which overflows int32 past 2**31
+        # elements (e.g. H=96, CTX=524288, HEAD_DIM=64). Scalar, so no VGPR cost.
+        kv_offset = tile_head_idx.to(tl.int64) * stride_kh.to(tl.int64)
 
         K_base = K + kv_offset
         V_base = V + kv_offset
@@ -136,7 +137,6 @@ def la_persistent_paged(
             Q_base,
             stride_qm,
             stride_qk,
-            kv_shape,
             K_base,
             V_base,
             KV_block_tables_ptr,
@@ -259,7 +259,6 @@ def _attn_lean_tile(
     Q_base,
     stride_qm,
     stride_qk,
-    kv_shape,
     K_base,
     V_base,
     KV_block_tables_ptr,
@@ -275,42 +274,25 @@ def _attn_lean_tile(
     local_iter,
     local_iter_end,
 ):
-    Q_block_ptr = tl.make_block_ptr(
-        base=Q_base,
-        shape=(BLOCK_M, HEAD_DIM),
-        strides=(stride_qm, stride_qk),
-        offsets=(0, 0),
-        block_shape=(BLOCK_M, HEAD_DIM),
-        order=(1, 0),
-    )
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, HEAD_DIM)
 
-    q = tl.load(Q_block_ptr)
+    q = tl.load(Q_base + offs_m[:, None] * stride_qm + offs_k[None, :] * stride_qk)
 
-    K_block_ptr = tl.make_block_ptr(
-        base=K_base,
-        shape=(HEAD_DIM, kv_shape),
-        strides=(stride_kk, stride_kn),
-        offsets=(0, 0),
-        block_shape=(HEAD_DIM, BLOCK_N),
-        order=(0, 1),  # K parent tensor shape [Z, H, CTX, HEAD_DIM]
-    )
-    V_block_ptr = tl.make_block_ptr(
-        base=V_base,
-        shape=(kv_shape, HEAD_DIM),
-        strides=(stride_vn, stride_vk),
-        offsets=(0, 0),
-        block_shape=(BLOCK_N, HEAD_DIM),
-        order=(1, 0),
-    )
+    # Offsets of a K/V tile relative to the start of the KV page holding it.
+    # K is loaded transposed as [HEAD_DIM, BLOCK_N].
+    k_offs = offs_k[:, None] * stride_kk + offs_n[None, :] * stride_kn
+    v_offs = offs_n[:, None] * stride_vn + offs_k[None, :] * stride_vk
 
     for iter in range(local_iter, local_iter_end):
-        # update k/v pointer
+        # The block table maps this lean tile onto a physical KV page.
         kv_block_id = tl.load(KV_block_tables_ptr, cache_modifier=".cg")
-        V_bptr = tl.advance(V_block_ptr, (kv_block_id * BLOCK_N, 0))
-        K_bptr = tl.advance(K_block_ptr, (0, kv_block_id * BLOCK_N))
+        k_ptrs = K_base + kv_block_id * BLOCK_N * stride_kn + k_offs
+        v_ptrs = V_base + kv_block_id * BLOCK_N * stride_vn + v_offs
 
         # -- compute qk ----
-        k = tl.load(K_bptr, cache_modifier=".cg")
+        k = tl.load(k_ptrs, cache_modifier=".cg")
         qk = tl.dot(q, k)
         qk = qk * qk_scale
 
@@ -322,7 +304,7 @@ def _attn_lean_tile(
         acc = (
             acc * alpha[:, None]
         )  # Scale each row of acc by the corresponding elements in alpha
-        v = tl.load(V_bptr, cache_modifier=".cg")  # v.shape = [BLOCK_N, HEAD_DIM]
+        v = tl.load(v_ptrs, cache_modifier=".cg")  # v.shape = [BLOCK_N, HEAD_DIM]
         acc = tl.dot(p.to(v.dtype), v, acc=acc)  # acc.shape = [BLOCK_M, HEAD_DIM]
         # -- update l_i
         l_ij = tl.sum(p, 1)  # rowsum(p)

--- a/aiter/ops/triton/attention/lean_atten_paged.py
+++ b/aiter/ops/triton/attention/lean_atten_paged.py
@@ -71,8 +71,6 @@ def persistent_lean_attention_paged(
         N_CTX_Q, N_CTX_K, H, H, HEAD_DIM_Q, BLOCK_M, BLOCK_N, total_programs
     )
 
-    kv_shape = k.shape[1] // BLOCK_N + (1 if k.shape[1] % BLOCK_N != 0 else 0)
-
     grid = (total_programs, 1, 1)
 
     o = torch.empty_like(q, dtype=v.dtype)
@@ -87,7 +85,6 @@ def persistent_lean_attention_paged(
         Op,
         o,
         kv_block_tables,
-        kv_shape,
         batch_num_block_n,
         locks,
         q.stride(0),

--- a/op_tests/triton_tests/attention/test_la_paged.py
+++ b/op_tests/triton_tests/attention/test_la_paged.py
@@ -18,7 +18,9 @@ from aiter.ops.triton.attention.lean_atten_paged import persistent_lean_attentio
         (1, 96, 16, [65536], 64, 912, torch.float16, 16, 64, 2, 4),
         (1, 96, 16, [131072], 64, 912, torch.float16, 16, 64, 2, 4),
         (1, 96, 16, [262144], 64, 912, torch.float16, 16, 64, 2, 4),
-        (1, 96, 16, [524288], 16, 912, torch.float16, 16, 256, 1, 4),
+        # h * n_ctx * d == 3.22e9 elements, past INT32_MAX. Guards the 64-bit
+        # widening of the per-head K/V offset in la_persistent_paged.
+        (1, 96, 16, [524288], 64, 912, torch.float16, 16, 256, 2, 4),
         (1, 96, 16, [1048576], 16, 912, torch.float16, 16, 256, 1, 4),
         (1, 128, 16, [32768], 64, 912, torch.float16, 16, 64, 2, 4),
         (1, 128, 16, [65536], 64, 912, torch.float16, 16, 64, 2, 4),
@@ -59,11 +61,6 @@ def test_persistent_lean_attention(
 
     torch.manual_seed(20)
     random.seed(20)
-    # Long seqlen (>512K) can hit memory access fault. Suspect compiler issue
-    # WA with shorter d and longer BLOCK_N
-    if any(item > 524288 for item in n_ctx):
-        BLOCK_N = 256
-        d = 16
 
     assert batch == len(n_ctx)
 


### PR DESCRIPTION
## Motivation

Triton 3.8 removes `tl.make_block_ptr()` and `tl.advance()` functions, which prevented `lean_atten_paged` from compiling:

`NotImplementedError: Block pointers have been removed in favor of the tensor descriptor API.`

This PR restores Triton 3.8 compatibility on `gfx950` while preserving the existing paged lean attention behavior and performance.

Raw stride-based pointer arithmetic is used instead of tensor descriptors because this kernel: 
- consumes K as a transposed `[HEAD_DIM, BLOCK_N]` tile;
- relies on `.cg` cache modifiers for K/V and block-table loads
- targets gfx950 so required AMD tensor descriptor path is not applicable

This change also exposed a pre-existing int32 overflow in the per-head K/V base offset for tensors larger than `2^31` elements. That correctness fix is included in this PR. Instead of adding a test case, I replaced the existing test case: 
line 21: 
`(1, 96, 16, [524288], 16, 912, torch.float16, 16, 256, 1, 4),`
with line 23: 
`(1, 96, 16, [524288], 64, 912, torch.float16, 16, 256, 2, 4),`

`waves_per_eu` (second last variable) was changed from 1 to 2 to match the established `HEAD_DIM=64` launch configuration used by the rest of the test matrix; it is not part of the overflow fix itself.

The important distinction is:

- `d: 16 → 64` is what makes the tensor exceed the int32 indexing limit.
- `waves_per_eu: 1 → 2` only changes how the kernel is launched (inteded).

## Technical Details

### 1. Replace block pointers with raw stride arithmetic

The Q/K/V block-pointer construction and `tl.advance()` calls are replaced with the equivalent base-pointer plus stride calculations:

```bash
q = tl.load(
    Q_base
    + offs_m[:, None] * stride_qm
    + offs_k[None, :] * stride_qk
)

k_offs = (
    offs_k[:, None] * stride_kk
    + offs_n[None, :] * stride_kn
)
v_offs = (
    offs_n[:, None] * stride_vn
    + offs_k[None, :] * stride_vk
)

kv_block_id = tl.load(KV_block_tables_ptr, cache_modifier=".cg")
k_ptrs = K_base + kv_block_id * BLOCK_N * stride_kn + k_offs
v_ptrs = V_base + kv_block_id * BLOCK_N * stride_vn + v_offs
```

This preserves: 
- original Q/K/V index decomposition
- K's `[HEAD_DIM, BLOCK_N]` transposed tile layout
- V's `[BLOCK_N, HEAD_DIM]` tile layout
- physical page selection through `kv_block_tables`
- one block-table entry consumed per Lean tile
- existing `.cg` cache modifiers
- unmasked load behaviour
- operations that remained unchanged

### 2. Remove dead `kv_shape` plumbing

kv_shape was only used as the block-pointer `shape=` metadata

The original K/V loads did not use `boundary_check`, so `kv_shape` did not mask or change loaded addresses. After removing the block pointers, it had no remaining effect so it was removed from the Triton kernel file and it's wrapper file. The paged lean attention loads were already unmasked, so no explicit masks were added.

### 3. Fix large-K/V int32 offset overflow

K and V are laid out as `[H, CTX, HEAD_DIM]`. The per-head base offset was previously calculated with int32 arithmetic: 
`kv_offset = tile_head_idx * stride_kh`

When `H * CTX * HEAD_DIM` exceeds `2^31` elements, this offset can wrap and cause a GPU memory-access fault

The scalar offset is now widened explicitly: 
```bash
kv_offset = (
    tile_head_idx.to(tl.int64)
    * stride_kh.to(tl.int64)
)
```

Only the once-per-output-tile scalar is widened. Per-lane K/V offsets remain32-bit, avoiding the register cost of widening every lane address

## Test Plan

1. Run the full `test_la_paged` suite on gfx950 with Triton 3.8.0 and `TRITON_HIP_USE_ASYNC_COPY`
2. Add a correctness test case whose K/V tensor exceeds the int32 element-index boundary
3. Run `bench_la_paged_decode.py`, the benchmark that exercises `persistent_lean_attention_paged`
4. Compare the shipped Triton 3.4 stack against the final Triton 3.8 stack
5. Compare code and run ruff and black checks

## Test Result

### Correctness and Code Quality

Check | Result
-- | --
Triton 3.8 correctness suite | 18/18 passed
New H=96, CTX=524288, D=64 overflow guard | Passed
ruff check | Passed
black --check | Passed

### Comparison between Block Pointers and Stride Arithmetic

Method: 42 runs, 10,500 measured dispatches, 250 dispatches per cell, 10%</span><br><span>two-sided trim, and 3 paired order-alternated repetitions.
SEQ_LEN | Block pointers (ms) | Stride arithmetic (ms) | Delta | 95% CI | Status
-- | -- | -- | -- | -- | --
512 | 0.039643 | 0.039661 | +0.05% | [-4.20%, +4.31%] | No difference
1024 | 0.026509 | 0.027021 | +1.94% | [-0.91%, +4.79%] | No difference
2048 | 0.034653 | 0.034423 | -0.65% | [-4.44%, +3.13%] | No difference
4096 | 0.055099 | 0.054515 | -1.00% | [-9.35%, +7.36%] | No difference
8192 | 0.089249 | 0.088049 | -1.31% | [-6.55%, +3.92%] | No difference
16384 | 0.155630 | 0.156773 | +0.73% | [-2.89%, +4.35%] | No difference
32768 | 0.293819 | 0.290178 | -1.20% | [-8.51%, +6.11%] | No difference

Pooled over 21 paired comparisons: -0.21%, 95% CI [-1.18%, +0.77%]. There is no detectable kernel-time regression from replacing block pointers. The experiment resolves pooled effects to approximately +/-0.98%.

### Runtime inspection

Metric | Block pointers | Stride arithmetic
-- | -- | --
Instruction count | 1076 | 1075
VGPRs | Baseline | 4 fewer
Spills | None | None
TTGIR layouts | Same | Same
Memory/MFMA/s_waitcnt ordering | Same | Same

### Shipped stack vs final Triton 3.8 stack

Measured via `rocprofv3`. Kernel-only time on gfx950 / ROCm 7.2.0.
Intended config: `BS=1, HQ=HK=32, HEAD_DIM=128, KV_BLK_SZ=16`

SEQ_LEN | Golden Triton 3.4 (ms) | Triton 3.8 + change (ms) | Delta | Status
-- | -- | -- | -- | --
512 | 0.039789 | 0.034928 | -12.2% | Improvement
1024 | 0.026827 | 0.025036 | -6.7% | Improvement
2048 | 0.034697 | 0.031825 | -8.3% | Improvement
4096 | 0.054631 | 0.045058 | -17.5% | Improvement
8192 | 0.087461 | 0.068750 | -21.4% | Improvement
16384 | 0.155051 | 0.118195 | -23.8% | Improvement
32768 | 0.296909 | 0.212780 | -28.3% | Improvement

The improvement is due to progressive codegen and Triton improvements, so these gains are not attributed to this PR. However, it is worth comparing results and noting that, with these changes done to fix and allow compilation and benchmarking of `lean_atten_paged.py`, there are **no regressions** that remain.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
