### PR TITLE
[Bug] pa_mqa_logits: guard all OutLogits stores

### DIFF
--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -309,9 +309,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
                 context_idx
                 + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
-            >= 0,
+            mask=(
+                context_idx
+                + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+                >= 0
+            )
+            & (
+                context_idx
+                + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
 
     context_idx = split_context_start + split_context_length - ChunkK
@@ -342,8 +349,14 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
         offsets=(
             context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
         ),
-        mask=context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
-        >= 0,
+        mask=(
+            context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+            >= 0
+        )
+        & (
+            context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
+            < max_model_len
+        ),
     )
 
 
@@ -810,9 +823,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 context_idx
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
 
         for context_idx in range(
@@ -878,10 +898,22 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
-                mask=context_idx
-                + ChunkKPerStage
-                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-                >= split_context_start,
+                mask=(
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
+                    >= split_context_start
+                )
+                & (
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
+                    < max_model_len
+                ),
             )
 
             # =======================================================================================
@@ -992,10 +1024,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 + ChunkKPerStage
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + ChunkKPerStage
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
     else:
         context_idx = split_context_start
@@ -1659,9 +1699,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 context_idx
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
 
         for context_idx in range(
@@ -1727,10 +1774,22 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                         0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
                     )
                 ),
-                mask=context_idx
-                + ChunkKPerStage
-                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-                >= split_context_start,
+                mask=(
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
+                    >= split_context_start
+                )
+                & (
+                    context_idx
+                    + ChunkKPerStage
+                    + gl.arange(
+                        0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout)
+                    )
+                    < max_model_len
+                ),
             )
 
             # =======================================================================================
@@ -1841,10 +1900,18 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 + ChunkKPerStage
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
             ),
-            mask=context_idx
-            + ChunkKPerStage
-            + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            >= split_context_start,
+            mask=(
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                >= split_context_start
+            )
+            & (
+                context_idx
+                + ChunkKPerStage
+                + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
+                < max_model_len
+            ),
         )
     else:
         context_idx = split_context_start

--- a/op_tests/test_pa_mqa_logits_store_bounds.py
+++ b/op_tests/test_pa_mqa_logits_store_bounds.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 
@@ -94,15 +93,16 @@ def test_preshuffle_does_not_write_past_max_model_len(use_varctx: bool) -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires a ROCm GPU")
 
-    from aiter import dtypes
     from aiter.ops.triton.pa_mqa_logits import (
         deepgemm_fp8_paged_mqa_logits,
     )
 
+    from aiter import dtypes
+
     context_len = 2300
     block_size = 64
     chunk_k = 256
-    guard_size = block_size
+    guard_size = chunk_k
     hidden_dim = 128
     heads = 128
     sentinel = 12345.0

--- a/op_tests/test_pa_mqa_logits_store_bounds.py
+++ b/op_tests/test_pa_mqa_logits_store_bounds.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression coverage for OutLogits_buffer upper-bound store masks."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+KERNEL_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "aiter"
+    / "ops"
+    / "triton"
+    / "gluon"
+    / "pa_mqa_logits.py"
+)
+KERNEL_NAMES = (
+    "_gluon_deepgemm_fp8_paged_mqa_logits",
+    "_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle",
+    "_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx",
+)
+
+
+def _keyword(call: ast.Call, name: str) -> ast.expr | None:
+    return next(
+        (keyword.value for keyword in call.keywords if keyword.arg == name), None
+    )
+
+
+def _references_name(node: ast.AST | None, name: str) -> bool:
+    return node is not None and any(
+        isinstance(child, ast.Name) and child.id == name for child in ast.walk(node)
+    )
+
+
+def _is_out_logits_store(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "buffer_store"
+        and _references_name(_keyword(node, "ptr"), "OutLogits_buffer")
+    )
+
+
+def _has_max_model_len_upper_bound(
+    mask: ast.AST | None, offsets: ast.AST | None
+) -> bool:
+    if mask is None or offsets is None:
+        return False
+    offsets_ast = ast.dump(offsets, include_attributes=False)
+    return any(
+        isinstance(node, ast.Compare)
+        and ast.dump(node.left, include_attributes=False) == offsets_ast
+        and any(
+            isinstance(operator, ast.Lt)
+            and isinstance(comparator, ast.Name)
+            and comparator.id == "max_model_len"
+            for operator, comparator in zip(node.ops, node.comparators)
+        )
+        for node in ast.walk(mask)
+    )
+
+
+@pytest.mark.parametrize("kernel_name", KERNEL_NAMES)
+def test_out_logits_stores_guard_max_model_len_boundary(kernel_name: str) -> None:
+    tree = ast.parse(KERNEL_SOURCE.read_text(encoding="utf-8"))
+    kernel = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == kernel_name
+    )
+    stores = [node for node in ast.walk(kernel) if _is_out_logits_store(node)]
+
+    assert stores, f"{kernel_name} has no OutLogits_buffer stores"
+    unbounded_lines = [
+        store.lineno
+        for store in stores
+        if not _has_max_model_len_upper_bound(
+            _keyword(store, "mask"), _keyword(store, "offsets")
+        )
+    ]
+    assert not unbounded_lines, (
+        f"{kernel_name} has OutLogits_buffer stores without "
+        f"'offset < max_model_len' masks at lines {unbounded_lines}"
+    )
+
+
+@pytest.mark.parametrize("use_varctx", [False, True], ids=["fixed-context", "varctx"])
+def test_preshuffle_does_not_write_past_max_model_len(use_varctx: bool) -> None:
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires a ROCm GPU")
+
+    from aiter import dtypes
+    from aiter.ops.triton.pa_mqa_logits import (
+        deepgemm_fp8_paged_mqa_logits,
+    )
+
+    context_len = 2300
+    block_size = 64
+    chunk_k = 256
+    guard_size = block_size
+    hidden_dim = 128
+    heads = 128
+    sentinel = 12345.0
+    num_blocks = (context_len + block_size - 1) // block_size
+
+    q_bits = torch.randint(
+        1, 64, (1, 1, heads, hidden_dim), dtype=torch.uint8, device="cuda"
+    )
+    kv_bits = torch.randint(
+        1,
+        64,
+        (num_blocks, block_size, 1, hidden_dim + 4),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    q_fp8 = q_bits.view(dtypes.fp8)
+    kv_cache = kv_bits.view(dtypes.fp8)
+    weights = torch.ones((1, heads), dtype=torch.float32, device="cuda")
+    context_lens = torch.tensor([context_len], dtype=torch.int32, device="cuda")
+    block_tables = torch.arange(num_blocks, dtype=torch.int32, device="cuda")[None, :]
+    out = torch.full(
+        (1, context_len + guard_size),
+        sentinel,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    varctx_schedule = (
+        torch.ones((1,), dtype=torch.int32, device="cuda") if use_varctx else None
+    )
+
+    deepgemm_fp8_paged_mqa_logits(
+        q_fp8,
+        kv_cache,
+        weights,
+        out,
+        context_lens,
+        block_tables,
+        context_len,
+        Preshuffle=True,
+        KVBlockSize=block_size,
+        ChunkK=chunk_k,
+        TotalCuCount=8,
+        WavePerEU=2,
+        VarCtxSchedule=varctx_schedule,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.all(out[:, context_len:] == sentinel), (
+        f"{'varctx' if use_varctx else 'fixed-context'} kernel wrote into "
+        "the guard region past max_model_len"
+    )


### PR DESCRIPTION
## Summary

- Add `offset < max_model_len` to the eight `OutLogits_buffer` stores that remained lower-bound-only after #2866 landed through #3005.
- Cover the two non-preshuffle stores, three fixed-context preshuffle stores, and three varctx preshuffle stores.
- Add structural coverage for every OutLogits store and ROCm guard-region regression cases for fixed-context and varctx kernels.

This replaces #2936 with a minimal diff against current main.

## Test plan

- [x] `python -m pytest -q op_tests/test_pa_mqa_logits_store_bounds.py` (`3 passed, 2 skipped` locally because ROCm is unavailable)
- [x] `python -m black --check aiter/ops/triton/gluon/pa_mqa_logits.py op_tests/test_pa_mqa_logits_store_bounds.py`
- [x] `python -m ruff check aiter/ops/triton/gluon/pa_mqa_logits.py op_tests/test_pa_mqa_logits_store_bounds.py`
- [ ] Run the fixed-context and varctx guard-region cases on ROCm CI