### PR TITLE
Temporarily pin rocm/pytorch:latest image digest

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  DOCKER_IMAGE: "rocm/pytorch:latest"
+  DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
   GPU_ARCH_LIST: "gfx942;gfx950"
   AITER_TEST: "op_tests"
   AITER_WHEEL_ARTIFACT_NAME: aiter-whl-${{ github.run_id }}
@@ -62,7 +62,7 @@ jobs:
             docker_image: "rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0"
             build_enabled: ${{ github.ref == 'refs/heads/main' }}
           - python_version: "3.12"
-            docker_image: "rocm/pytorch:latest"
+            docker_image: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
             build_enabled: true
     steps:
       # ---- Common steps (fork and non-fork) ----
@@ -354,7 +354,7 @@ jobs:
     needs: check-signal
     uses: ./.github/workflows/prepare-triton-wheel.yaml
     with:
-      docker-image: rocm/pytorch:latest
+      docker-image: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
       artifact-name: triton_wheelhouse
       retention-days: 3
 

--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -35,7 +35,7 @@ env:
   # Keep on upstream (Dao-AILab) main; do not re-point at a personal fork/branch.
   FA_BRANCH: main
   FA_REPOSITORY_URL: https://github.com/Dao-AILab/flash-attention.git
-  BASE_IMAGE: rocm/pytorch:latest@sha256:683765a52c61341e1674fe730ab3be861a444a45a36c0a8caae7653a08a0e208
+  BASE_IMAGE: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
   AITER_SUBMODULE_PATH: third_party/aiter
   DOCKER_PULL_MAX_ATTEMPTS: "3"
   DOCKER_PULL_RETRY_DELAY_SECONDS: "10"

--- a/.github/workflows/operators-tuning.yaml
+++ b/.github/workflows/operators-tuning.yaml
@@ -52,7 +52,7 @@ jobs:
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \
           --name operators_tuning_test \
-          rocm/pytorch:latest
+          rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
 
       - name: Setup Aiter and Triton
         run: |

--- a/.github/workflows/opus-test.yaml
+++ b/.github/workflows/opus-test.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  DOCKER_IMAGE: "rocm/pytorch:latest"
+  DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
 
 jobs:
   check-signal:

--- a/.github/workflows/prepare-triton-wheel.yaml
+++ b/.github/workflows/prepare-triton-wheel.yaml
@@ -7,7 +7,7 @@ on:
         description: Docker image used to resolve and download the matching Triton wheel.
         required: false
         type: string
-        default: rocm/pytorch:latest
+        default: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
       artifact-name:
         description: Name of the Triton wheel artifact uploaded for the caller workflow run.
         required: false

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -66,7 +66,7 @@ jobs:
     needs: [check-signal]
     uses: ./.github/workflows/prepare-triton-wheel.yaml
     with:
-      docker-image: rocm/pytorch:latest
+      docker-image: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
       artifact-name: triton_wheelhouse
       retention-days: 3
 
@@ -82,7 +82,7 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
-      DOCKER_IMAGE: "rocm/pytorch:latest"
+      DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
       TRITON_TEST: "op_tests/triton_tests/"
 
     steps:
@@ -221,7 +221,7 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
-      DOCKER_IMAGE: "rocm/pytorch:latest"
+      DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
       TRITON_TEST: "op_tests/triton_tests/"
 
     steps:

--- a/.github/workflows/tuning-tests.yaml
+++ b/.github/workflows/tuning-tests.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOCKER_IMAGE: rocm/pytorch:latest
+  DOCKER_IMAGE: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
   GPU_ARCHS: gfx950
   REPORT_DIR: tuning_test_reports
   LOG_DIR: .github/test-logs/tuning-tests

--- a/docs/aiter_container_nonroot_setup.md
+++ b/docs/aiter_container_nonroot_setup.md
@@ -4,7 +4,7 @@
 ## Build a container with Aiter installed and add a non-root user using the Dockerfile provided below:
 
 ```
-ARG BASE_DOCKER="rocm/pytorch:latest"
+ARG BASE_DOCKER="rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
 FROM $BASE_DOCKER
 RUN pip install pandas zmq einops && \
     pip install numpy==1.26.2


### PR DESCRIPTION
## Summary
- Temporarily pin all rocm/pytorch:latest references to sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
- Update CI workflows and the non-root container setup doc to use the same image digest

## Testing
- rg --pcre2 -n --hidden --glob '!.git' 'pytorch:latest(?!@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e)'
- git diff --check