### PR TITLE
[OPUS][ATOM] Disable amdgpu-early-inline-all for DSv4 sparse prefill

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -591,6 +591,11 @@
             "'-ffast-math'",
             "'-mllvm -enable-post-misched=1'"
         ],
+        "flags_extra_hip_per_source": {
+            "*pa_sparse_prefill_opus_kernels.cu": [
+                "-mllvm -amdgpu-early-inline-all=false"
+            ]
+        },
         "extra_ldflags": "None",
         "extra_include": [],
         "verbose": "False",

--- a/csrc/include/pa_sparse_prefill_opus.h
+++ b/csrc/include/pa_sparse_prefill_opus.h
@@ -476,6 +476,7 @@ __global__ void pa_prefill_16mx1_16nx4_fp8_kernel(pa_fp8_kargs)
 // =============================================================================
 #include <opus/opus.hpp>
 #include <bit>
+#include <cstdint>
 
 using opus::operator""_I;
 


### PR DESCRIPTION
## Problem

The JIT-built `module_pa_sparse_prefill_opus` runs ~10% slower than the exact same kernel source compiled standalone. On gfx950, `H=128, N=4096, total_pages=16384, total_tokens=4096, dense, bf16`: 20.86 ms / 1054 TFLOPS vs 18.85 ms / 1166 TFLOPS.

## Root cause

aiter's global default `-mllvm -amdgpu-early-inline-all=true` (which only takes effect together with `-amdgpu-function-calls=false`) hurts this kernel badly — it roughly doubles spill traffic:

| | instrs | scratch ops | s_waitcnt |
|---|---|---|---|
| with early-inline-all | 14828 | 46 | 978 |
| without | 14672 | 24 | 932 |

Isolated by building identical source in one harness and varying only the flags: 18.82 ms (without) vs 20.57 ms (with).

## Fix

Turn the flag off for the kernel TU only. It has to go through `flags_extra_hip_per_source`, not `flags_extra_hip`: `flags_hip` is `sorted(set(...))`-ed before use, so a later `=false` sorts *before* the global `=true` and loses. Per-source flags are appended to `$cuda_post_cflags`, which is unsorted and last on the command line, so last-wins works.

(The existing `-mllvm -enable-post-misched=1` override in `flags_extra_hip` is unaffected — `'0' < '1'`, so it still wins the sort.)

Also adds the `<cstdint>` that `pa_sparse_prefill_opus.h` needs for `int64_t`; it currently only compiles via a transitive include from `aiter_tensor.h`.

## Result

18.87 ms / 1166 TFLOPS, matching the standalone build. No source or ABI change; scope is limited to this one module's kernel TU.

## Test

`op_tests/test_pa_sparse_prefill_opus.py` — all passed.
