### PR TITLE
fix(torch_guard): drop redundant aiter:: prefix from define schema for torch 2.13

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
+  DOCKER_IMAGE: "rocm/pytorch:latest"
   GPU_ARCH_LIST: "gfx942;gfx950"
   AITER_TEST: "op_tests"
   AITER_WHEEL_ARTIFACT_NAME: aiter-whl-${{ github.run_id }}
@@ -62,7 +62,7 @@ jobs:
             docker_image: "rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0"
             build_enabled: ${{ github.ref == 'refs/heads/main' }}
           - python_version: "3.12"
-            docker_image: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
+            docker_image: "rocm/pytorch:latest"
             build_enabled: true
     steps:
       # ---- Common steps (fork and non-fork) ----
@@ -354,7 +354,7 @@ jobs:
     needs: check-signal
     uses: ./.github/workflows/prepare-triton-wheel.yaml
     with:
-      docker-image: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
+      docker-image: rocm/pytorch:latest
       artifact-name: triton_wheelhouse
       retention-days: 3
 

--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -35,7 +35,7 @@ env:
   # Keep on upstream (Dao-AILab) main; do not re-point at a personal fork/branch.
   FA_BRANCH: main
   FA_REPOSITORY_URL: https://github.com/Dao-AILab/flash-attention.git
-  BASE_IMAGE: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
+  BASE_IMAGE: rocm/pytorch:latest
   AITER_SUBMODULE_PATH: third_party/aiter
   DOCKER_PULL_MAX_ATTEMPTS: "3"
   DOCKER_PULL_RETRY_DELAY_SECONDS: "10"

--- a/.github/workflows/operators-tuning.yaml
+++ b/.github/workflows/operators-tuning.yaml
@@ -52,7 +52,7 @@ jobs:
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \
           --name operators_tuning_test \
-          rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
+          rocm/pytorch:latest
 
       - name: Setup Aiter and Triton
         run: |

--- a/.github/workflows/opus-test.yaml
+++ b/.github/workflows/opus-test.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
+  DOCKER_IMAGE: "rocm/pytorch:latest"
 
 jobs:
   check-signal:

--- a/.github/workflows/prepare-triton-wheel.yaml
+++ b/.github/workflows/prepare-triton-wheel.yaml
@@ -7,7 +7,7 @@ on:
         description: Docker image used to resolve and download the matching Triton wheel.
         required: false
         type: string
-        default: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
+        default: rocm/pytorch:latest
       artifact-name:
         description: Name of the Triton wheel artifact uploaded for the caller workflow run.
         required: false

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -66,7 +66,7 @@ jobs:
     needs: [check-signal]
     uses: ./.github/workflows/prepare-triton-wheel.yaml
     with:
-      docker-image: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
+      docker-image: rocm/pytorch:latest
       artifact-name: triton_wheelhouse
       retention-days: 3
 
@@ -82,7 +82,7 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
-      DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
+      DOCKER_IMAGE: "rocm/pytorch:latest"
       TRITON_TEST: "op_tests/triton_tests/"
 
     steps:
@@ -221,7 +221,7 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
-      DOCKER_IMAGE: "rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
+      DOCKER_IMAGE: "rocm/pytorch:latest"
       TRITON_TEST: "op_tests/triton_tests/"
 
     steps:

--- a/.github/workflows/tuning-tests.yaml
+++ b/.github/workflows/tuning-tests.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOCKER_IMAGE: rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e
+  DOCKER_IMAGE: rocm/pytorch:latest
   GPU_ARCHS: gfx950
   REPORT_DIR: tuning_test_reports
   LOG_DIR: .github/test-logs/tuning-tests

--- a/aiter/jit/utils/torch_guard.py
+++ b/aiter/jit/utils/torch_guard.py
@@ -347,10 +347,11 @@ def torch_compile_guard(
                 tags = ()
             else:
                 tags = (torch.Tag.needs_fixed_stride_order,)
-            op_schema = f"aiter::{loadName}" + schema
+            # no ns prefix: aiter_lib adds it (torch>=2.13 won't strip dup)
+            op_schema = f"{loadName}" + schema
             aiter_lib.define(op_schema, tags=tags)
-            aiter_lib.impl(f"aiter::{loadName}", custom_func, dispatch_key="CUDA")
-            aiter_lib.impl(f"aiter::{loadName}", custom_func, dispatch_key="CPU")
+            aiter_lib.impl(f"{loadName}", custom_func, dispatch_key="CUDA")
+            aiter_lib.impl(f"{loadName}", custom_func, dispatch_key="CPU")
             aiter_lib._register_fake(f"{loadName}", fake_func)
 
         return wrapper_custom

--- a/docs/aiter_container_nonroot_setup.md
+++ b/docs/aiter_container_nonroot_setup.md
@@ -4,7 +4,7 @@
 ## Build a container with Aiter installed and add a non-root user using the Dockerfile provided below:
 
 ```
-ARG BASE_DOCKER="rocm/pytorch:latest@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e"
+ARG BASE_DOCKER="rocm/pytorch:latest"
 FROM $BASE_DOCKER
 RUN pip install pandas zmq einops && \
     pip install numpy==1.26.2


### PR DESCRIPTION
aiter_lib=Library("aiter",...) already adds the ns, so a schema of "aiter::<op>" makes torch>=2.13 store a doubled "aiter::aiter::<op>" in _op_defs in 2.13.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
