### PR TITLE
CI: move multi-GPU tests to DO MI350X runner

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -725,6 +725,8 @@ jobs:
         include:
           - runner: linux-aiter-mi35x-8
             label: MI35X
+          - runner: linux-aiter-do-mi350x-8
+            label: MI350X
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -723,8 +723,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: linux-aiter-mi35x-8
-            label: MI35X
           - runner: linux-aiter-do-mi350x-8
             label: MI350X
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
## Summary
- Add linux-aiter-do-mi350x-8 to the multi-GPU test matrix
- Keep the existing linux-aiter-mi35x-8 run in place

## Testing
- python3 YAML parse of .github/workflows/aiter-test.yaml
- git diff --check