### PR TITLE
chore(aot/flydsl): drop per-kernel "[OK] compile" log; silence false-positive mxmoe warning

### DIFF
--- a/aiter/aot/flydsl/chunk_gdn_h.py
+++ b/aiter/aot/flydsl/chunk_gdn_h.py
@@ -343,7 +343,6 @@ def compile_one_config(
 
         elapsed = time.time() - t0
         result["compile_time"] = elapsed
-        print(f"  [OK] compile  {elapsed:6.1f}s  {shape_str}  arch={aot_arch}")
     except Exception as e:  # noqa: BLE001
         print(f"  [FAIL] compile  {shape_str}  arch={aot_arch}: {e}")
 

--- a/aiter/aot/flydsl/gemm.py
+++ b/aiter/aot/flydsl/gemm.py
@@ -540,7 +540,6 @@ def compile_one_config(
 
         elapsed = time.time() - t0
         result["compile_time"] = elapsed
-        print(f"  [OK] compile  {elapsed:6.1f}s  {shape_str}  arch={aot_arch}")
     except Exception as e:  # noqa: BLE001
         print(f"  [FAIL] compile  {shape_str}  arch={aot_arch}: {e}")
 

--- a/aiter/aot/flydsl/grouped_moe.py
+++ b/aiter/aot/flydsl/grouped_moe.py
@@ -413,7 +413,6 @@ def compile_one_config(**job):
                 contiguous=contiguous,
             )
         elapsed = time.time() - t0
-        print(f"  [OK] compile  {elapsed:6.1f}s  {shape_str}  arch={aot_arch}")
         return {**job, "compile_time": elapsed, "compile_arch": aot_arch}
     except Exception as e:  # noqa: BLE001
         # Catch everything and return cleanly with compile_time=None: the AOT pool

--- a/aiter/aot/flydsl/moe.py
+++ b/aiter/aot/flydsl/moe.py
@@ -974,7 +974,6 @@ def compile_one_config(
                 )
         elapsed = time.time() - t0
         result["compile_time"] = elapsed
-        print(f"  [OK] compile  {elapsed:6.1f}s  {shape_str}  arch={aot_arch}")
     except Exception as e:  # noqa: BLE001
         print(f"  [FAIL] compile  {shape_str}  arch={aot_arch}: {e}")
 

--- a/aiter/aot/flydsl/moe.py
+++ b/aiter/aot/flydsl/moe.py
@@ -147,6 +147,12 @@ def parse_csv(csv_path: str):
                     continue
                 if name.startswith("flydsl_moe2_layout_"):
                     continue
+                # a4w4 mxmoe-port kernels are precompiled by mxfp4_moe.py; they
+                # share the flydsl_ prefix but are absent from this module's
+                # registry, so without this guard every CSV row naming one is
+                # reported as an unknown kernel.
+                if name.startswith("flydsl_mxmoe_"):
+                    continue
 
                 params = get_flydsl_kernel_params(name)
                 if params is None:

--- a/aiter/aot/flydsl/mxfp4_moe.py
+++ b/aiter/aot/flydsl/mxfp4_moe.py
@@ -360,7 +360,6 @@ def compile_one_config(**job):
                 _compile_stage2(job)
         elapsed = time.time() - t0
         result["compile_time"] = elapsed
-        print(f"  [OK] compile  {elapsed:6.1f}s  stage{stage}  {shape_str}")
     except Exception as e:  # noqa: BLE001
         print(f"  [FAIL] compile  stage{stage}  {shape_str}: {e}")
 


### PR DESCRIPTION
## What

Two log changes in the FlyDSL AOT precompile path.

**1. Delete the five per-kernel `[OK] compile` prints.**

One line per compiled kernel. In [CI run 31106316215](https://github.com/ROCm/aiter/actions/runs/31106316215/job/92632655091) that is **4,675 lines out of a 13,476-line job log**; a MoE-only precompile emits 2,631.

The lines are not readable even in principle: 64 worker processes share one stdout, so they interleave arbitrarily and cannot be scanned in order. What the log needs is already there — the throttled `... N/M kernels done` progress line and the per-category `compiled N ok, M failed` summary.

The cost is concrete. In that CI run the one line that mattered

```
[FAIL] compile  cktile_epilogue_swiglu ...: PtrToIntOp: expected PointerType
```

was buried under 12,600 lines of `[OK]` / `succeeded`.

No data is lost: each worker still sets `result["compile_time"] = elapsed` and returns it to the parent, so an aggregate view (slowest-N, per-category totals) can be added later without touching the workers. `[FAIL] compile` is untouched in all five files — failures propagate as exceptions and were never signalled by the `[OK]` line.

**2. Stop `moe.py` warning about mxmoe kernels it does not own.**

`moe.py`'s CSV loop admitted every name starting with `flydsl_`, so a4w4 mxmoe-port kernels reached `get_flydsl_kernel_params()`, whose registry holds only `flydsl_moe1_*` / `flydsl_moe2_*`. Every miss printed `[WARN] Unknown kernel name` — **130 lines over 11 distinct names**, one name repeated 39 times.

Nothing was missing. 10 of the 11 are precompiled by `mxfp4_moe.py` (the `MXFP4_MOE` category, `compiled 39 ok`); the remaining `flydsl_mxmoe_g2_a4w4_128x256x256_f4out` is skipped there on purpose (`mxfp4_moe.py:171`, gated behind `AITER_MXFP4_INTERMEDIATE`, matching the `_f4out` strip in `fused_moe.py:1683`). A too-wide prefix test, fixed the same way `flydsl_moe2_layout_` already is. Job count unchanged at 2631.

## Measured

gfx950, cold cache, MoE only (2,631 kernels), with FlyDSL #961 + the `COMPILE_ONLY succeeded` removal already in the local build:

| | lines | result |
|---|---:|---|
| before | 2,840 | 2631 ok, 0 failed |
| after `[OK]` removal | 209 | 2631 ok, 0 failed |
| after mxmoe guard | **79** | 2631 ok, 0 failed |

## Deliberately NOT silenced: the GEMM warning

`gemm.py:176` emits a sibling `[WARN] Unknown FlyDSL GEMM kernel name` (185 lines in CI). It looks like the same class of noise. **It is not — it is a true positive, and this PR leaves it loud.**

The names differ by one field:

```
628 rows  flydsl_bpreshuflle_32x64x512_F8_F8_B16_2x1x0x4_default      4 fields  -> compiles
185 rows  flydsl_bpreshuflle_32x64x512_F8_F8_B16_2x1x0x0x4_default    5 fields  -> skipped
```

Both the AOT regex (`gemm.py:80`) and the **runtime** parser (`gemm_op_a8w8.py:149`) cap at four fields, and the current name generator (`flydsl_gemm_a8w8_bpreshuffle_common.py:68`) emits four. On a parse miss the runtime does:

```python
parsed = _parse_flydsl_kernel_name(kernel_name)
if parsed is None:
    return gemm_a8w8_bpreshuffle_ck(...)   # silent fallback to CK
```

So those 185 tuned entries are not merely un-precompiled — **at runtime they silently fall back to the CK kernel and the tuning result is discarded**. They live in:

- `aiter/configs/model_configs/a8w8_bpreshuffle_tuned_gemm_qwen3_5_397b_a17b_mxfp4_attnfp8.csv` (136)
- `aiter/configs/model_configs/a8w8_bpreshuffle_tuned_gemm_glm5.2.csv` (49)

Either the CSVs carry a naming format no current code produces, or the parsers need a fifth field. Out of scope here, and worth its own issue — but this is exactly the kind of signal the log noise was hiding, so the warning stays.

## Related, not in this PR

The other two thirds of the CI log come from FlyDSL and need a wheel release + a `requirements.txt` pin bump before CI sees them:

- `hipModuleLoadData failed with hipErrorNoDevice` — 3,208 lines. Fixed by ROCm/FlyDSL#961 (merged 2026-08-04). Verified locally after a rebuild: 3,169 → 0, no runtime regression (34.0s vs 33.3s warm).
- `[flydsl] COMPILE_ONLY=1, compilation succeeded` — 4,719 lines. Removed on the matching FlyDSL branch. Worth noting this line was never trustworthy: it fires on only one of `compile_only`'s three exits and prints "compilation succeeded" on a cross-process cache hit, so its count tracks cache state, not work done (2,649 cold vs 0 warm for the same 2,631 successful kernels).

Note for reviewers: bumping the flydsl pin invalidates every existing FlyDSL disk cache (the key is a fingerprint over all `flydsl.compiler.*` sources and native libs), so the first AOT run after the bump is a full recompile.

Still deferred: the `tile_k does not divide inter_dim` notice repeats 32 identical times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)