### PR TITLE
[HIP] [CK] [MoE] Added Gelu with tanh approx for CK XDL 2-stage MoE

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -2388,11 +2388,24 @@ def get_2stage_cfgs(
                     f"[fused_moe] Opus stage2 config unsupported ({opus_reason}); "
                     "using default heuristics"
                 )
+
     bypass_tuned_config = int(os.environ.get("AITER_BYPASS_TUNE_CONFIG", "0"))
     if config_file is not None and (cfg is None or bypass_tuned_config):
         raise NotImplementedError(
             "The dedicated FHMoE path requires an exact tuned config row for "
             f"{keys} in {tune_file}"
+        )
+
+    # The asm 1-stage kernels are compiled only for Silu/Gelu
+    if (
+        cfg is not None
+        and cfg.get("run_1stage", False)
+        and activation not in (ActivationType.Silu, ActivationType.Gelu)
+    ):
+        cfg = None
+        logger.warning(
+            f"[fused_moe] discarding 1-stage tuned config for unsupported "
+            f"activation {activation}; using default heuristics"
         )
 
     use_non_temporal_load = False

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -81,6 +81,33 @@ _MOE_A8W4_BYPASS_QUANT = os.environ.get("AITER_MOE_A8W4_BYPASS_QUANT", "0") == "
 # so there is no overhead.
 kernel_bench_callable = None
 
+# CK 2-stage kernel-instance names embed the activation token (see
+# gemm_moe_ck2stages_common.ACT_OP_NAME). Used to detect when the act-disabled
+# tuned-config fallback tier handed us another activation's CK kernel name.
+_CK2STAGES_ACT_TOKENS = {
+    int(_member): _token
+    for _name, _token in (
+        ("Silu", "silu"),
+        ("Gelu", "gelu"),
+        ("Swiglu", "swiglu"),
+        ("GeluTanh", "gelutanh"),
+    )
+    if (_member := getattr(ActivationType, _name, None)) is not None
+}
+
+
+def _ck2stages_kname_act_token(kname: str) -> str | None:
+    """Return the activation token embedded in a CK 2-stage kernel name, if any.
+
+    Order matters: check ``gelutanh`` before ``gelu`` so the shorter token does
+    not shadow the longer one.
+    """
+    for tok in ("gelutanh", "swiglu", "silu", "gelu"):
+        if f"_{tok}_" in kname:
+            return tok
+    return None
+
+
 # FLAT 1stage asm kernels (manifest flat=1) ingest raw topk_ids /
 # topk_weights through the sorted_* kernarg slots and accumulate via
 # global_atomic_pk_add_bf16, so moe_sorting is a pass-through for them.

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -2312,9 +2312,7 @@ def get_2stage_cfgs(
         if not c2s:
             return None
         primary, fallback = c2s
-        lookup_keys = keys
-        if config_file is not None:
-            lookup_keys = keys[:7] + (str(activation),) + keys[8:]
+        lookup_keys = keys[:7] + (str(activation),) + keys[8:]
         result = primary.get(lookup_keys, None)
         if result is None and config_file is None:
             result = fallback.get(keys_disabled, None)
@@ -2323,7 +2321,7 @@ def get_2stage_cfgs(
             tier_idx = _PADDED_M_TIERS.index(token) if token in _PADDED_M_TIERS else -1
             for fallback_tier in reversed(_PADDED_M_TIERS[:tier_idx]):
                 # keys layout: (gfx, cu_num, token, ...); replace token (idx 2).
-                keys_fb = keys[:2] + (fallback_tier,) + keys[3:]
+                keys_fb = lookup_keys[:2] + (fallback_tier,) + lookup_keys[3:]
                 keys_fb_disabled = (
                     keys_disabled[:2] + (fallback_tier,) + keys_disabled[3:]
                 )

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -81,32 +81,6 @@ _MOE_A8W4_BYPASS_QUANT = os.environ.get("AITER_MOE_A8W4_BYPASS_QUANT", "0") == "
 # so there is no overhead.
 kernel_bench_callable = None
 
-# CK 2-stage kernel-instance names embed the activation token (see
-# gemm_moe_ck2stages_common.ACT_OP_NAME). Used to detect when the act-disabled
-# tuned-config fallback tier handed us another activation's CK kernel name.
-_CK2STAGES_ACT_TOKENS = {
-    int(_member): _token
-    for _name, _token in (
-        ("Silu", "silu"),
-        ("Gelu", "gelu"),
-        ("Swiglu", "swiglu"),
-        ("GeluTanh", "gelutanh"),
-    )
-    if (_member := getattr(ActivationType, _name, None)) is not None
-}
-
-
-def _ck2stages_kname_act_token(kname: str) -> str | None:
-    """Return the activation token embedded in a CK 2-stage kernel name, if any.
-
-    Order matters: check ``gelutanh`` before ``gelu`` so the shorter token does
-    not shadow the longer one.
-    """
-    for tok in ("gelutanh", "swiglu", "silu", "gelu"):
-        if f"_{tok}_" in kname:
-            return tok
-    return None
-
 
 # FLAT 1stage asm kernels (manifest flat=1) ingest raw topk_ids /
 # topk_weights through the sorted_* kernarg slots and accumulate via
@@ -1472,8 +1446,10 @@ def _flydsl_stage1_wrapper(
         act = "swiglu"
     elif activation == ActivationType.Situv2:
         act = "situv2"
-    else:
+    elif activation == ActivationType.Silu:
         act = "silu"
+    else:
+        raise ValueError(f"Unsupported activation for FlyDSL MoE stage1: {activation}")
     _a_scale_one = parsed.get("a_scale_one", False)
     return aiter.ops.flydsl.flydsl_moe_stage1(
         a=hidden_states,
@@ -2233,6 +2209,14 @@ def get_2stage_cfgs(
 
         # Fallback dict: disable act_type so any activation can match.
         df_fallback = df.copy()
+        if "kernelName1" in df_fallback.columns:
+            is_ck2stages = (
+                df_fallback["kernelName1"]
+                .fillna("")
+                .astype(str)
+                .str.contains("moe_ck2stages")
+            )
+            df_fallback = df_fallback.loc[~is_ck2stages]
         if "act_type" in df_fallback.columns:
             df_fallback["act_type"] = _ACT_TYPE_DISABLED_KEY
         dup_mask = df_fallback.duplicated(subset=_INDEX_COLS, keep="first")
@@ -3475,8 +3459,12 @@ def asm_stage1(
             aiter.silu_and_mul(out, tmp_out.view(dtypes.fp32))
         elif activation == ActivationType.Swiglu:
             aiter.swiglu_and_mul(out, tmp_out.view(dtypes.fp32))
-        else:
+        elif activation == ActivationType.Gelu:
             aiter.gelu_and_mul(out, tmp_out.view(dtypes.fp32))
+        else:
+            raise ValueError(
+                f"Unsupported activation for split-k post-activation: {activation}"
+            )
     return out
 
 
@@ -3903,8 +3891,12 @@ def ck_moe_stage1(
         valid_out = tmp_out[: token_num * topk, :]
         if activation == ActivationType.Silu:
             aiter.silu_and_mul(out, valid_out.view(dtypes.fp32))
-        else:
+        elif activation == ActivationType.Gelu:
             aiter.gelu_and_mul(out, valid_out.view(dtypes.fp32))
+        else:
+            raise ValueError(
+                f"Unsupported activation for split-k post-activation: {activation}"
+            )
     return out
 
 
@@ -4022,13 +4014,18 @@ def cktile_moe_stage1(
                     token_num,
                     topk,
                 )
-            else:
+            elif activation == ActivationType.Gelu:
                 NLane = 16
                 N0 = inter_dim // NLane
                 flat = valid_out.view(-1, N0, 2, NLane)
                 gate = flat[:, :, 0, :].reshape(-1, inter_dim)
                 up = flat[:, :, 1, :].reshape(-1, inter_dim)
                 out.view(-1, inter_dim).copy_(torch.nn.functional.gelu(gate) * up)
+            else:
+                raise ValueError(
+                    f"Unsupported activation for interleaved split-k "
+                    f"post-activation: {activation}"
+                )
         else:
             if bias1 is not None and topk_ids is None:
                 raise ValueError(
@@ -4039,14 +4036,23 @@ def cktile_moe_stage1(
                 aiter.silu_and_mul_bias(out, valid_out, expert_ids, bias1)
             elif bias1 is not None and activation == ActivationType.Swiglu:
                 aiter.swiglu_and_mul_bias(out, valid_out, expert_ids, bias1)
-            elif bias1 is not None:
+            elif bias1 is not None and activation == ActivationType.Gelu:
                 aiter.gelu_and_mul_bias(out, valid_out, expert_ids, bias1)
+            elif bias1 is not None:
+                raise ValueError(
+                    f"Unsupported activation for split-k post-activation "
+                    f"with bias: {activation}"
+                )
             elif activation == ActivationType.Silu:
                 aiter.silu_and_mul(out, valid_out)
             elif activation == ActivationType.Swiglu:
                 aiter.swiglu_and_mul(out, valid_out)
-            else:
+            elif activation == ActivationType.Gelu:
                 aiter.gelu_and_mul(out, valid_out)
+            else:
+                raise ValueError(
+                    f"Unsupported activation for split-k post-activation: {activation}"
+                )
     return out
 
 

--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -682,6 +682,7 @@ def get_torch_act(aType):
         ActivationType.No: lambda *a, **k: a[0],
         ActivationType.Silu: F.silu,
         ActivationType.Gelu: F.gelu,
+        ActivationType.GeluTanh: lambda x: F.gelu(x, approximate="tanh"),
     }
     return tmp.get(aType, NotImplementedError)
 

--- a/aiter/utility/dtypes.py
+++ b/aiter/utility/dtypes.py
@@ -181,5 +181,11 @@ def str2Dtype(v):
 
 
 def str2ActivationType(s):
-    """Convert string to ActivationType."""
+    members = getattr(ActivationType, "__members__", None)
+    if members is not None:
+        s_lower = s.lower()
+        for name, member in members.items():
+            if name.lower() == s_lower:
+                return member
+        raise argparse.ArgumentTypeError(f"invalid activation type: {s}")
     return getattr(ActivationType, s.capitalize())

--- a/aiter/utility/dtypes.py
+++ b/aiter/utility/dtypes.py
@@ -181,6 +181,7 @@ def str2Dtype(v):
 
 
 def str2ActivationType(s):
+    s = str(s)
     members = getattr(ActivationType, "__members__", None)
     if members is not None:
         s_lower = s.lower()
@@ -188,4 +189,7 @@ def str2ActivationType(s):
             if name.lower() == s_lower:
                 return member
         raise argparse.ArgumentTypeError(f"invalid activation type: {s}")
-    return getattr(ActivationType, s.capitalize())
+    try:
+        return getattr(ActivationType, s.capitalize())
+    except AttributeError as e:
+        raise argparse.ArgumentTypeError(f"invalid activation type: {s}") from e

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu
@@ -14,7 +14,8 @@
 using MoeKernelMap = std::unordered_map<std::string, MoeKernel>;
 
 // Map aiter ActivationType (stage1) to the CK stage1 activation op value.
-// CK act values: gelu=0, silu=1, swiglu(OAI swiglu_oai)=3. Value 2 is reserved.
+// CK act values: gelu=0, silu=1, swiglu(OAI swiglu_oai)=3, gelu_tanh_and_mul=4.
+// Value 2 is reserved.
 static inline int map_activation_to_ck_stage1(int activation)
 {
     switch (static_cast<ActivationType>(activation))
@@ -25,6 +26,8 @@ static inline int map_activation_to_ck_stage1(int activation)
         return 0;
     case ActivationType::Swiglu:
         return 3;
+    case ActivationType::GeluTanh:
+        return 4;
     default:
         TORCH_CHECK(false, "Unsupported activation for ck_moe_stage1: ", activation);
         return -1;

--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.py
@@ -18,8 +18,9 @@ sys.path.insert(0, AITER_CORE_DIR)
 from chip_info import get_gfx
 
 # CK stage1 activation op values. swiglu (OAI swiglu_oai) maps to CK act value 3;
-# value 2 is intentionally skipped (reserved for a future activation variant).
-ACT_OP_MAP = {"gelu": 0, "silu": 1, "swiglu": 3}
+# gelutanh (gelu_tanh_and_mul) maps to CK act value 4; value 2 is intentionally
+# skipped (reserved for a future activation variant).
+ACT_OP_MAP = {"gelu": 0, "silu": 1, "swiglu": 3, "gelutanh": 4}
 ACT_OP_NAME = {v: k for k, v in ACT_OP_MAP.items()}
 
 

--- a/csrc/ck_gemm_moe_2stages_codegen/gen_instances.py
+++ b/csrc/ck_gemm_moe_2stages_codegen/gen_instances.py
@@ -1074,7 +1074,7 @@ if __name__ == "__main__":
         default="silu",
         required=False,
         type=str,
-        choices=["silu", "gelu", "swiglu"],
+        choices=["silu", "gelu", "swiglu", "gelutanh"],
         help="select activation",
     )
 
@@ -1238,6 +1238,41 @@ if __name__ == "__main__":
                 c_dtype,
                 quant_dict[quant],
                 "swiglu",
+                routed_weight,
+                True,  # preshuffle (plain f8 forced True, mirrors general loop)
+                False,  # splitk
+            )
+            codegen.generate_instance_and_lookUpTable()
+
+        # gelutanh (gelu_tanh_and_mul) plain-f8 quant moe (per_tensor / per_token = PTPC).
+        # Same rationale as the swiglu loop above: the general quant loop uses
+        # acts=["silu","gelu"] and so ships 0 gelutanh x plain-f8 instances in the
+        # AOT/wheel prebuild. Runtime JIT (Path B, gen_func passes -b f8) already
+        # generates them on demand, so this loop only extends the AOT prebuild set
+        # and removes the ~first-run cold compile -- it is NOT required for
+        # correctness. Mirrors the general loop's plain-f8 path (f8 x f8, tag=a8w8,
+        # CDEElementOp=MulABScale, plain gridwise_moe_gemm.hpp). act="gelutanh" ->
+        # CK ActOP=4. preshuffle forced True for plain f8. Targets Gemma-family MoE
+        # experts that use the tanh-approx GELU. Independent loop so existing
+        # silu/gelu/swiglu/no-quant coverage is untouched.
+        gelutanh_plain_c_dtypes = ["f16", "b16"]
+        gelutanh_plain_quant_l = ["per_tensor", "per_token"]
+        for (
+            c_dtype,
+            routed_weight,
+            quant,
+        ) in itertools.product(
+            gelutanh_plain_c_dtypes,
+            routed_weight_l,
+            gelutanh_plain_quant_l,
+        ):
+            codegen = ck_moe_2stage_gemm_codegen(
+                args.working_path,
+                "f8",  # a_dtype
+                "f8",  # b_dtype
+                c_dtype,
+                quant_dict[quant],
+                "gelutanh",
                 routed_weight,
                 True,  # preshuffle (plain f8 forced True, mirrors general loop)
                 False,  # splitk

--- a/csrc/include/aiter_enum.h
+++ b/csrc/include/aiter_enum.h
@@ -6,11 +6,12 @@
 
 enum class ActivationType : int
 {
-    No     = -1,
-    Silu   = 0,
-    Gelu   = 1,
-    Swiglu = 2,
-    Situv2 = 3,
+    No       = -1,
+    Silu     = 0,
+    Gelu     = 1,
+    Swiglu   = 2,
+    Situv2   = 3,
+    GeluTanh = 4,
 };
 
 enum class QuantType : int

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -32,6 +32,7 @@ namespace py = pybind11;
         .value("Gelu", ActivationType::Gelu)                                                \
         .value("Swiglu", ActivationType::Swiglu)                                            \
         .value("Situv2", ActivationType::Situv2)                                            \
+        .value("GeluTanh", ActivationType::GeluTanh)                                         \
         .export_values();                                                                   \
     pybind11::enum_<MlaVersion>(m, "MlaVersion")                                            \
         .value("V32", MlaVersion::V32)                                                      \


### PR DESCRIPTION
## Motivation

Enable the tanh-approximation GELU activation (`gelu_tanh`, `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))))`) in the AITER Composable Kernel XDL 2-stage MoE path. The MoE gridwise epilogue supports only `silu/gelu/swiglu`; this ports CK's `gelu_tanh_and_mul` (ROCm/rocm-libraries#9396) into AITER so models whose MoE experts use the GELU tanh approximation (e.g. Gemma-family MoE) can run on this path.

**JIRA ID : ROCM-27619**

## Technical Details

Wires a new `GeluTanh` activation end-to-end into the CK 2-stage MoE codegen, following the existing `swiglu_oai` port (`78e45124`):

- `csrc/include/aiter_enum.h`: add `ActivationType::GeluTanh = 4`.
- `csrc/include/rocm_ops.hpp`: expose `GeluTanh` on the pybind `ActivationType` enum.
- `csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu`: map `ActivationType::GeluTanh -> 4` (CK `gelu_tanh_and_mul`) in `map_activation_to_ck_stage1`.
- `gemm_moe_ck2stages_common.py`: add `"gelutanh": 4` to `ACT_OP_MAP` (drives CK `ActOP` codegen and kernel-instance naming).
- `gen_instances.py`: add `gelutanh` to the `-act` choices and a targeted plain-f8 AOT prebuild loop (mirrors the swiglu loop; not required for correctness since runtime JIT generates on demand).

CK submodule bump

- Bumps `3rdparty/composable_kernel` to the merged ROCm/rocm-libraries#9396, which provides the CK-side gelu with tanh approx epilogue. This PR must be built / merged together with that CK commit.

Test/reference support so the change can be validated:

- `aiter/ops/quant.py` (`get_torch_act`): add the `GeluTanh` reference using the tanh-approx GELU (`F.gelu(x, approximate="tanh")`) to match CK's `FastGelu` epilogue.
- `aiter/utility/dtypes.py` (`str2ActivationType`): case-insensitive enum lookup so mixed-case members like `GeluTanh` resolve from CLI (`-a gelutanh`).

The activation is applied in fp32 in the stage-1 epilogue; GEMM compute and quantization are untouched. CK-side support comes from ROCm/rocm-libraries#9396 (`gelu_tanh_and_mul = 4`).

## Test Plan

Run the CK 2-stage MoE test with the new activation on the plain-f8 (a8w8) path:

```bash
python3 op_tests/test_moe_2stage.py -a gelutanh -q 0  # bf16
python3 op_tests/test_moe_2stage.py -a gelutanh -q 1 --no-flydsl-csv   # per_tensor fp8
python3 op_tests/test_moe_2stage.py -a gelutanh -q 2 --no-flydsl-csv   # per_token  fp8