### PR TITLE
fix(fused_moe): restore gfx942 FLAT kernel support

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -836,9 +836,10 @@ def _fused_moe_impl(
         and stage1_func in (_flydsl_stage1_wrapper, cktile_moe_stage1)
         and expert_mask is not None
     )
-    assert (
-        not metadata.flat or get_gfx() == "gfx950"
-    ), f"FLAT fmoe asm kernels are gfx950-only; refusing to launch on {get_gfx()}. "
+    assert not metadata.flat or get_gfx() in (
+        "gfx942",
+        "gfx950",
+    ), f"FLAT fmoe asm kernels require gfx942/gfx950; got {get_gfx()}. "
 
     sort_m_indices = None
     sort_reverse_sorted = None


### PR DESCRIPTION
## Summary
- restore `gfx942` to the FLAT FMoE architecture allowlist while retaining the unsupported-architecture guard
- allow GLM-5.x FP8 low-token decode to load the shipped `gfx942` `flat_pf3` kernel again

## Root cause
AITER #4040 added the `gfx942` FLAT kernel, tuned GLM rows, and the `gfx942`/`gfx950` allowlist. #4394 later narrowed only the guard back to `gfx950`, while leaving the `gfx942` kernel and config in place. SGLang GLM-5.1 therefore selects the valid `gfx942` kernel but fails before launch.

Observed in both SGLang jobs:
- https://github.com/sgl-project/sglang/actions/runs/30716848145/job/91730352050
- https://github.com/sgl-project/sglang/actions/runs/30716848145/job/91730351399

## Test plan
- [x] `git diff --check`
- [ ] Run the targeted `gfx942` FLAT FMoE case for M=4/8, model_dim=6144, inter_dim=256, E=257, topk=9
- [ ] Rerun SGLang `nightly-8-gpu-glm51`
- [ ] Rerun SGLang `nightly-8-gpu-glm51-rocm720`

Local Python/ROCm tests were not run because the authoring environment is Windows without Python or AMD GPUs.