### PR TITLE
[Triton/Gluon] [Config] Tune mla_decode_rope fp32 config for gfx950

### DIFF
--- a/aiter/ops/triton/configs/gfx950-MLA_DECODE_ROPE-DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950-MLA_DECODE_ROPE-DEFAULT.json
@@ -10,9 +10,9 @@
     "fwd_grouped_kernel_stage1_rope_fp32": {
         "BLOCK_N": 32,
         "BLOCK_H": 16,
-        "num_warps": 8,
+        "num_warps": 4,
         "num_stages": 1,
-        "waves_per_eu": 0,
+        "waves_per_eu": 1,
         "matrix_instr_nonkdim": 16
     },
     "fwd_kernel_stage2": {


### PR DESCRIPTION
## Motivation

`mla_decode_rope` on gfx950 shows a small set of reproducible regressions on the fp32 path when comparing our old triton 3.4.0 compiler (aka Golden release) against Triton 3.8.0 (aka TOT)

A controlled golden-vs-tot rocprofv3 sweep found:
- 26/26 bf16 shapes improved on TOT
- 4 definitive fp32 regressions
- 1 unstable fp32 shape whose Golden baseline was bimodal
- 1 fp32 shape classified as ok

The regression is caused by register spilling in the shipped fp32 configuration. The `fwd_grouped_kernel_stage1_rope_fp32` entry uses `num_warps=8`, which compiles to 128 VGPRs and spills 120 B to scratch.

The selected config uses `num_warps=4`, which increases the register allocation to 176 VGPRs and eliminates scratch spilling. LDS usage remains unchanged at 64 KB. The tuned candidate also uses `waves_per_eu=1`.

This is a config-only change. No kernel or wrapper source is modified, and no shape buckets are added.


## Technical Details

The change is confined to a few changes in:

`aiter/ops/triton/configs/gfx950-MLA_DECODE_ROPE-DEFAULT.json`

```bash
 "fwd_grouped_kernel_stage1_rope_fp32": {
     "BLOCK_N": 32,
     "BLOCK_H": 16,
-    "num_warps": 8,
+    "num_warps": 4,
     "num_stages": 1,
-    "waves_per_eu": 0,
+    "waves_per_eu": 1,
     "matrix_instr_nonkdim": 16
 },
```
#### Scope and isolation
The wrapper selects the fp32 stage-1 config only when the input tensors use fp32. The bf16/fp16 path reads `fwd_grouped_kernel_stage1_rope` instead and does not read `fwd_grouped_kernel_stage1_rope_fp32`.


#### Compiled resource impact: 
Stage 1, `B4 H32 S1024` fp32, gfx950:
config | shared (LDS) | VGPR | SGPR | scratch
-- | -- | -- | -- | --
before (num_warps: 8) | 64.0 KB | 128 | 80 | 120 B
after (num_warps: 4) | 64.0 KB | 176 | 112 | 0 B

The primary resource effect is the removal of register spilling while keeping LDS usage unchanged.

68 candidates were evaluated across:
- BLOCK_N
- BLOCK_H
- num_warps
- num_stages
- waves_per_eu
- matrix_instr_nonkdim

Runtime tracks the spill behavior closely:
num_warps | VGPR | scratch | B4 H32 S1024 fp32 | vs Golden
-- | -- | -- | -- | --
2 | 248 | 0 B | 177.7 µs | 0.785
**4** | 176 | 0 B | **155.1 µs** | **0.685**
8 (shipped) | 128 | 120 B | 229.0 µs | 1.011
16 | 64 | 480 B | 421.7 µs | 1.862

Additional findings:
- `matrix_instr_nonkdim=32` was ~12% slower and reintroduced 148 B of scratch
- `waves_per_eu=4` reduced available VGPRs to 64, spilled up to 2428 B, and was ~4.2× slower
- 12 candidates with `num_stages=2` and `BLOCK_N >= 32` failed compilation with `OutOfResources` because they required 270-540 KB shared memory against a 160 KB budget

## Test Plan
Correctness was tested with `pytest op_tests/triton_tests/attention/test_mla_decode_rope.py -v`. Passes with no issues:
`240 passed, 66 warnings in 35.74s`

### Performance coverage

The gfx950 manifest contains 32 primary Golden-vs-TOT shapes:
- 12 shipped `bench_mla_decode_rope.py::nonvarlen_benchmark_configs` shapes, preserving the shipped ragged-sequence behavior
- 10 `model_shapes.json` "mla" shapes for DeepSeek-R1 and Kimi-K2 Thinking, including `TP ∈ {1,2,4,8}` modeled as head sharding
- 2 NeoX coverage shapes
- 2 no-rope coverage shapes
- 6 fp32 shapes

An additional 3 fp16 spot-checks were run after tuning, for 35 total post-change validation shapes

### Measurement Methodology
- gfx950 only
- rocprofv3 --kernel-trace
- 250 iterations per repeition
- 10% of head / 10% of tail numbers trimmed
- middle 80% is averaged
- Golden vs Tot

Regression classification:
```bash
golden_us_avg < 4.0                             - below_threshold
tot_us_avg > 1.005 * golden_us_avg + 0.5        - regression
golden_us_avg > 1.005 * tot_us_avg + 0.5        - improvement
otherwise                                       - ok
```

## Test Result

note: bf16 path is unchanged by this PR. No regressions in that realm

### Baseline fp32 results
These are the shipped-config measurements used to decide what to tune.

shape | Golden (µs) | TOT before (µs) | delta | baseline status
-- | -- | -- | -- | --
B4_H32_S8192_fp32_eq | 1708.64 | 1727.94 | +1.13% | regression
B4_H128_S8192_fp32_eq | 1702.86 | 1716.14 | +0.78% | regression
B4_H48_S8192_fp32_varlen | 1206.17 | 1213.78 | +0.63% | regression
B4_H32_S1024_fp32_eq | 226.51 | 229.93 | +1.51% | regression
B1_H16_S163_fp32_varlen | 23.34 | 24.11 | +3.30% | unstable / not definitive
B4_H128_S1024_fp32_eq | 226.26 | 226.85 | +0.26% | ok

The `B1_H16_S163_fp32_varlen` Golden baseline was bimodal after five repetitions, so it was not treated as a definitive regression.

### Final fp32 results with tuned config
All six fp32 validation shapes improve relative to Golden after tuning.

shape | Golden (µs) | TOT after (µs) | delta | final status
-- | -- | -- | -- | --
B4_H128_S8192_fp32_eq | 1708.25 | 1167.22 | -31.67% | improvement
B4_H32_S8192_fp32_eq | 1709.83 | 1166.35 | -31.79% | improvement
B4_H48_S8192_fp32_varlen | 1207.31 | 821.68 | -31.94% | improvement
B4_H32_S1024_fp32_eq | 226.82 | 155.65 | -31.38% | improvement
B1_H16_S163_fp32_varlen | 24.24 | 20.33 | -16.12% | improvement*
B4_H128_S1024_fp32_eq | 226.57 | 156.24 | -31.04% | improvement

* Golden remains noisy on `B1_H16_S163_fp32_varlen`, but TOT is steady around 20.3 µs and remains comfortably below the manager threshold across the observed Golden modes.

### Final full-shape performance numbers: 
### Full per-shape results

| Group | Coverage | SHAPE | golden_runs_us (3-5 reps) | tot_runs_us (3-5 reps) | golden_us | tot_us | delta_us | delta_% | threshold_us | status |
|---|---|---|---|---|---:|---:|---:|---:|---:|---|
| A | Shipped bench default | `B1_H16_S163_bf16_varlen` | 12.78, 12.91, 12.98 | 12.19, 12.12, 12.12 | 12.89 | 12.14 | -0.75 | -5.80% | 13.45 | improvement |
| A | Shipped bench default | `B1_H48_S163_bf16_varlen` | 13.25, 13.28, 13.29 | 12.42, 12.42, 12.44 | 13.27 | 12.43 | -0.84 | -6.36% | 13.84 | improvement |
| A | Shipped bench default | `B4_H16_S163_bf16_varlen` | 14.36, 14.33, 14.33 | 13.24, 13.29, 13.20 | 14.34 | 13.24 | -1.10 | -7.67% | 14.91 | improvement |
| A | Shipped bench default | `B4_H48_S163_bf16_varlen` | 14.61, 14.63, 14.63 | 13.32, 13.46, 13.26 | 14.62 | 13.35 | -1.28 | -8.74% | 15.20 | improvement |
| A | Shipped bench default | `B16_H16_S163_bf16_varlen` | 16.87, 16.86, 16.79 | 14.86, 14.90, 14.67 | 16.84 | 14.81 | -2.03 | -12.07% | 17.43 | improvement |
| A | Shipped bench default | `B16_H48_S163_bf16_varlen` | 17.85, 17.84, 17.81, 17.70, 17.79 | 17.58, 18.65, 18.14, 17.99, 18.07 | 17.80 | 18.08 | +0.29 | +1.61% | 18.39 | ok (unstable) |
| A | Shipped bench default | `B1_H16_S8192_bf16_varlen` | 96.17, 96.28, 96.21 | 72.00, 71.90, 71.99 | 96.22 | 71.96 | -24.26 | -25.21% | 97.20 | improvement |
| A | Shipped bench default | `B1_H48_S8192_bf16_varlen` | 96.42, 96.38, 96.42 | 71.61, 71.59, 71.72 | 96.41 | 71.64 | -24.77 | -25.69% | 97.39 | improvement |
| A | Shipped bench default | `B4_H16_S8192_bf16_varlen` | 222.62, 222.33, 222.72 | 180.74, 181.00, 180.92 | 222.56 | 180.88 | -41.67 | -18.73% | 224.17 | improvement |
| A | Shipped bench default | `B4_H48_S8192_bf16_varlen` | 224.82, 225.54, 224.75 | 182.65, 182.71, 183.12 | 225.04 | 182.83 | -42.21 | -18.76% | 226.66 | improvement |
| A | Shipped bench default | `B16_H16_S8192_bf16_varlen` | 305.09, 304.43, 305.47 | 245.04, 244.30, 244.50 | 305.00 | 244.61 | -60.39 | -19.80% | 307.02 | improvement |
| A | Shipped bench default | `B16_H48_S8192_bf16_varlen` | 306.37, 305.89, 306.03 | 249.90, 250.27, 250.23 | 306.10 | 250.13 | -55.97 | -18.28% | 308.13 | improvement |
| B | `model_shapes.json` MLA | `B4_H8_S1024_bf16_eq` | 48.75, 48.78, 48.83 | 37.51, 37.48, 37.55 | 48.78 | 37.52 | -11.27 | -23.10% | 49.53 | improvement |
| B | `model_shapes.json` MLA | `B4_H32_S1024_bf16_eq` | 49.00, 49.37, 49.36 | 38.95, 38.63, 38.75 | 49.24 | 38.78 | -10.46 | -21.25% | 49.98 | improvement |
| B | `model_shapes.json` MLA | `B4_H16_S1024_bf16_eq` | 49.34, 49.37, 49.31 | 38.78, 38.83, 38.74 | 49.34 | 38.78 | -10.56 | -21.40% | 50.09 | improvement |
| B | `model_shapes.json` MLA | `B4_H128_S1024_bf16_eq` | 50.09, 50.25, 50.18 | 41.67, 41.51, 41.42 | 50.17 | 41.53 | -8.64 | -17.22% | 50.92 | improvement |
| B | `model_shapes.json` MLA | `B4_H64_S1024_bf16_eq` | 50.27, 50.30, 50.40 | 41.81, 41.81, 43.10 | 50.32 | 42.24 | -8.09 | -16.07% | 51.08 | improvement |
| B | `model_shapes.json` MLA | `B4_H128_S8192_bf16_eq` | 312.93, 313.78, 312.59 | 249.88, 250.03, 250.58 | 313.10 | 250.17 | -62.93 | -20.10% | 315.16 | improvement |
| B | `model_shapes.json` MLA | `B4_H16_S8192_bf16_eq` | 313.95, 314.02, 314.09 | 253.46, 253.66, 253.69 | 314.02 | 253.60 | -60.42 | -19.24% | 316.09 | improvement |
| B | `model_shapes.json` MLA | `B4_H32_S8192_bf16_eq` | 314.88, 315.74, 314.99 | 254.30, 254.43, 254.73 | 315.20 | 254.48 | -60.72 | -19.26% | 317.28 | improvement |
| B | `model_shapes.json` MLA | `B4_H64_S8192_bf16_eq` | 316.43, 316.44, 316.61 | 255.29, 255.55, 254.55 | 316.50 | 255.13 | -61.37 | -19.39% | 318.58 | improvement |
| B | `model_shapes.json` MLA | `B4_H8_S8192_bf16_eq` | 316.85, 316.88, 316.84 | 227.74, 227.65, 227.76 | 316.86 | 227.72 | -89.14 | -28.13% | 318.94 | improvement |
| C | NeoX coverage | `B4_H16_S1024_bf16_neox_eq` | 49.68, 49.68, 49.75 | 38.97, 39.00, 39.01 | 49.70 | 38.99 | -10.71 | -21.54% | 50.45 | improvement |
| C | NeoX coverage | `B4_H128_S8192_bf16_neox_eq` | 316.39, 315.62, 316.95 | 250.76, 251.08, 251.31 | 316.32 | 251.05 | -65.27 | -20.63% | 318.40 | improvement |
| D | No-rope coverage | `B4_H16_S1024_bf16_norope_eq` | 48.03, 47.97, 48.06 | 38.68, 38.68, 38.79 | 48.02 | 38.72 | -9.31 | -19.38% | 48.76 | improvement |
| D | No-rope coverage | `B4_H128_S8192_bf16_norope_eq` | 310.71, 312.23, 311.11 | 257.60, 258.17, 258.09 | 311.35 | 257.95 | -53.40 | -17.15% | 313.41 | improvement |
| E | fp32 tuned config | `B1_H16_S163_fp32_varlen` | 23.37, 24.99, 23.29, 24.91, 24.62 | 20.42, 20.45, 20.07, 20.28, 20.43 | 24.24 | 20.33 | -3.91 | -16.12% | 24.86 | improvement (unstable) |
| E | fp32 tuned config | `B4_H128_S1024_fp32_eq` | 225.97, 227.19, 226.56 | 156.20, 156.39, 156.12 | 226.57 | 156.24 | -70.34 | -31.04% | 228.21 | improvement |
| E | fp32 tuned config | `B4_H32_S1024_fp32_eq` | 226.79, 226.82, 226.87 | 155.33, 155.74, 155.87 | 226.82 | 155.65 | -71.18 | -31.38% | 228.46 | improvement |
| E | fp32 tuned config | `B4_H48_S8192_fp32_varlen` | 1208.15, 1208.11, 1205.68 | 820.53, 823.00, 821.52 | 1207.31 | 821.68 | -385.63 | -31.94% | 1213.85 | improvement |
| E | fp32 tuned config | `B4_H128_S8192_fp32_eq` | 1705.62, 1702.98, 1716.16 | 1167.97, 1166.12, 1167.56 | 1708.25 | 1167.22 | -541.03 | -31.67% | 1717.30 | improvement |
| E | fp32 tuned config | `B4_H32_S8192_fp32_eq` | 1708.88, 1710.88, 1709.72 | 1166.92, 1165.40, 1166.72 | 1709.83 | 1166.35 | -543.48 | -31.79% | 1718.88 | improvement |
| F | fp16 spot-check | `B4_H48_S163_fp16_varlen` | 14.16, 14.23, 14.27 | 13.21, 13.27, 13.20 | 14.22 | 13.23 | -0.99 | -6.98% | 14.79 | improvement |
| F | fp16 spot-check | `B4_H16_S1024_fp16_eq` | 49.04, 49.22, 49.13 | 38.53, 38.50, 38.54 | 49.13 | 38.52 | -10.61 | -21.59% | 49.87 | improvement |
| F | fp16 spot-check | `B4_H128_S8192_fp16_eq` | 312.18, 312.09, 312.60 | 250.16, 250.27, 250.24 | 312.29 | 250.22 | -62.07 | -19.87% | 314.35 | improvement |

Notes on `unstable` flagged rows
- `B16_H48_S163_bf16_varlen`: unchanged bf16 path. The final sweep is still ok under the regression rule, but the TOT repetitions span ~6.1%. It is not a regression and does not read the config entry changed by this PR.
- `B1_H16_S163_fp32_varlen`: Golden remains bimodal, while tuned TOT is steady around 20.3 µs and remains below threshold across the observed Golden modes.

### Correctness summary
run | result
-- | --
test_mla_decode_rope.py before | 240 passed
test_mla_decode_rope.py after | 240 passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
