### PR TITLE
fix(quant): use saturating RNE for scaled int8 casts

### DIFF
--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -61,6 +61,14 @@ def get_dtype_max(dtype):
     return dtypeMax
 
 
+def _scaled_quant_cast(x, quant_dtype):
+    # INT8 scales use symmetric qmax=127; leave floating-point formats unchanged.
+    if quant_dtype == dtypes.i8:
+        dtype_max = get_dtype_max(quant_dtype)
+        x = torch.round(x).clamp(-dtype_max, dtype_max)
+    return x.to(dtype=quant_dtype)
+
+
 def pertoken_quant(
     x,
     scale=None,
@@ -89,7 +97,7 @@ def pertoken_quant(
         per_token_scale[per_token_scale == 0] = 1
 
     # quant hidden_states
-    y = (hidden_states / per_token_scale).to(dtype=quant_dtype)
+    y = _scaled_quant_cast(hidden_states / per_token_scale, quant_dtype)
     y_scale = per_token_scale.to(scale_dtype)
     return y, y_scale
 
@@ -319,13 +327,13 @@ def per_tensor_quant(
     x, scale=None, scale_dtype=dtypes.fp32, quant_dtype=dtypes.i8, dtypeMax=None
 ):
     x = x.to(dtypes.fp32)
+    if dtypeMax is None:
+        dtypeMax = get_dtype_max(quant_dtype)
     if scale is None:
-        if dtypeMax is None:
-            dtypeMax = get_dtype_max(quant_dtype)
         scale = torch.abs(x).max() / dtypeMax
     y = x / scale
 
-    return y.to(quant_dtype), scale.view(1).to(scale_dtype)
+    return _scaled_quant_cast(y, quant_dtype), scale.view(1).to(scale_dtype)
 
 
 def per_block_quant_wrapper(block_shape=(1, 128)):

--- a/aiter/ops/triton/_triton_kernels/normalization/norm.py
+++ b/aiter/ops/triton/_triton_kernels/normalization/norm.py
@@ -4,6 +4,8 @@
 import triton
 import triton.language as tl
 
+from aiter.ops.triton._triton_kernels.quant.quant import _int8_rne_sat
+
 
 @triton.jit
 def _per_token_quant(
@@ -21,6 +23,9 @@ def _per_token_quant(
     scale_recip = 1 / scale_out
 
     qx = x * scale_recip
+
+    if DTYPE_MAX == 127:
+        qx = _int8_rne_sat(qx)
 
     return qx, scale_out
 

--- a/aiter/ops/triton/_triton_kernels/normalization/rmsnorm.py
+++ b/aiter/ops/triton/_triton_kernels/normalization/rmsnorm.py
@@ -4,6 +4,8 @@
 import triton
 import triton.language as tl
 
+from aiter.ops.triton._triton_kernels.quant.quant import _int8_rne_sat
+
 
 @triton.jit
 def _per_token_quant(
@@ -32,7 +34,9 @@ def _per_token_quant(
 
     qx = x * scale_recip
 
-    if CLAMP_OUT:
+    if DTYPE_MAX == 127:
+        qx = _int8_rne_sat(qx)
+    elif CLAMP_OUT:
         qx = tl.clamp(qx, -DTYPE_MAX, DTYPE_MAX)
 
     tl.store(y_scale_ptr + row_idx, scale_out.to(y_scale_ptr.dtype.element_ty))

--- a/aiter/ops/triton/_triton_kernels/quant/quant.py
+++ b/aiter/ops/triton/_triton_kernels/quant/quant.py
@@ -3,6 +3,12 @@
 
 import triton
 import triton.language as tl
+from triton.language.extra import libdevice
+
+
+@triton.jit
+def _int8_rne_sat(x):
+    return tl.clamp(libdevice.nearbyint(x), min=-127.0, max=127.0)
 
 
 @triton.jit
@@ -25,7 +31,10 @@ def _static_per_tensor_quant_fp8_i8_kernel(
     scale = tl.load(scale_in_ptr)
     scale_recip = 1 / scale
 
-    qx = (x * scale_recip).to(qx_ptr.dtype.element_ty)
+    qx = x * scale_recip
+    if qx_ptr.dtype.element_ty == tl.int8:
+        qx = _int8_rne_sat(qx)
+    qx = qx.to(qx_ptr.dtype.element_ty)
 
     tl.store(qx_ptr + offs, qx, mask=mask)
 
@@ -74,6 +83,8 @@ def _dynamic_per_token_quant_fp8_i8_kernel(
     scale_recip = 1 / scale_out
 
     qx = x * scale_recip
+    if qx_ptr.dtype.element_ty == tl.int8:
+        qx = _int8_rne_sat(qx)
     qx = qx.to(qx_ptr.dtype.element_ty)
 
     scale_offs = pid

--- a/csrc/include/aiter_opus_plus.h
+++ b/csrc/include/aiter_opus_plus.h
@@ -110,14 +110,24 @@ OPUS_D decltype(auto) fp32_to_bf8_scaled_x4(const S& s, float inverted_scale)
     return bf8x4_t{lo[0], lo[1], hi[0], hi[1]};
 }
 
+// fp32 -> i8 with round-to-nearest-even and symmetric saturation.
+// Keep the signed range symmetric with the qmax=127 scale contract.
+OPUS_D i8_t fp32_to_i8_rne_sat(float x)
+{
+    x                  = __builtin_rintf(x);
+    constexpr float lo = -127.0f;
+    constexpr float hi = 127.0f;
+    asm volatile("v_med3_f32 %0, %0, %1, %2" : "+v"(x) : "v"(lo), "v"(hi));
+    return static_cast<i8_t>(x);
+}
+
 // fp32x2 -> i8x2 with scale
-// ISA: v_pk_mul_f32 + round-to-nearest-even conversion x2
+// ISA: v_pk_mul_f32 + v_rndne_f32 x2 + v_med3_f32 x2 + v_cvt_i32_f32 x2
 template <typename S, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
 OPUS_D decltype(auto) fp32_to_i8_scaled_x2(const S& s, float inverted_scale)
 {
     fp32x2_t tmp = pk_mul_f32(s, fp32x2_t{inverted_scale, inverted_scale});
-    return i8x2_t{static_cast<i8_t>(__builtin_rintf(tmp[0])),
-                  static_cast<i8_t>(__builtin_rintf(tmp[1]))};
+    return i8x2_t{fp32_to_i8_rne_sat(tmp[0]), fp32_to_i8_rne_sat(tmp[1])};
 }
 
 template <typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
@@ -125,10 +135,10 @@ OPUS_D decltype(auto) fp32_to_i8_scaled_x4(const S& s, float inverted_scale)
 {
     fp32x2_t tmp0 = pk_mul_f32(fp32x2_t{s[0], s[1]}, fp32x2_t{inverted_scale, inverted_scale});
     fp32x2_t tmp1 = pk_mul_f32(fp32x2_t{s[2], s[3]}, fp32x2_t{inverted_scale, inverted_scale});
-    return i8x4_t{static_cast<i8_t>(__builtin_rintf(tmp0[0])),
-                  static_cast<i8_t>(__builtin_rintf(tmp0[1])),
-                  static_cast<i8_t>(__builtin_rintf(tmp1[0])),
-                  static_cast<i8_t>(__builtin_rintf(tmp1[1]))};
+    return i8x4_t{fp32_to_i8_rne_sat(tmp0[0]),
+                  fp32_to_i8_rne_sat(tmp0[1]),
+                  fp32_to_i8_rne_sat(tmp1[0]),
+                  fp32_to_i8_rne_sat(tmp1[1])};
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/include/aiter_opus_plus.h
+++ b/csrc/include/aiter_opus_plus.h
@@ -111,12 +111,13 @@ OPUS_D decltype(auto) fp32_to_bf8_scaled_x4(const S& s, float inverted_scale)
 }
 
 // fp32x2 -> i8x2 with scale
-// ISA: v_pk_mul_f32 + v_cvt_i32_f32 x2
+// ISA: v_pk_mul_f32 + round-to-nearest-even conversion x2
 template <typename S, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
 OPUS_D decltype(auto) fp32_to_i8_scaled_x2(const S& s, float inverted_scale)
 {
     fp32x2_t tmp = pk_mul_f32(s, fp32x2_t{inverted_scale, inverted_scale});
-    return i8x2_t{static_cast<i8_t>(tmp[0]), static_cast<i8_t>(tmp[1])};
+    return i8x2_t{static_cast<i8_t>(__builtin_rintf(tmp[0])),
+                  static_cast<i8_t>(__builtin_rintf(tmp[1]))};
 }
 
 template <typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
@@ -124,10 +125,10 @@ OPUS_D decltype(auto) fp32_to_i8_scaled_x4(const S& s, float inverted_scale)
 {
     fp32x2_t tmp0 = pk_mul_f32(fp32x2_t{s[0], s[1]}, fp32x2_t{inverted_scale, inverted_scale});
     fp32x2_t tmp1 = pk_mul_f32(fp32x2_t{s[2], s[3]}, fp32x2_t{inverted_scale, inverted_scale});
-    return i8x4_t{static_cast<i8_t>(tmp0[0]),
-                  static_cast<i8_t>(tmp0[1]),
-                  static_cast<i8_t>(tmp1[0]),
-                  static_cast<i8_t>(tmp1[1])};
+    return i8x4_t{static_cast<i8_t>(__builtin_rintf(tmp0[0])),
+                  static_cast<i8_t>(__builtin_rintf(tmp0[1])),
+                  static_cast<i8_t>(__builtin_rintf(tmp1[0])),
+                  static_cast<i8_t>(__builtin_rintf(tmp1[1]))};
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/include/aiter_opus_plus.h
+++ b/csrc/include/aiter_opus_plus.h
@@ -114,15 +114,11 @@ OPUS_D decltype(auto) fp32_to_bf8_scaled_x4(const S& s, float inverted_scale)
 // Keep the signed range symmetric with the qmax=127 scale contract.
 OPUS_D i8_t fp32_to_i8_rne_sat(float x)
 {
-    x                  = __builtin_rintf(x);
-    constexpr float lo = -127.0f;
-    constexpr float hi = 127.0f;
-    asm volatile("v_med3_f32 %0, %0, %1, %2" : "+v"(x) : "v"(lo), "v"(hi));
-    return static_cast<i8_t>(x);
+    return static_cast<i8_t>(fminf(fmaxf(__builtin_rintf(x), -127.0f), 127.0f));
 }
 
 // fp32x2 -> i8x2 with scale
-// ISA: v_pk_mul_f32 + v_rndne_f32 x2 + v_med3_f32 x2 + v_cvt_i32_f32 x2
+// The compiler selects the ISA lowering for the standard min/max saturation.
 template <typename S, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
 OPUS_D decltype(auto) fp32_to_i8_scaled_x2(const S& s, float inverted_scale)
 {

--- a/csrc/include/opus/rmsnorm_opus_kernel.hpp
+++ b/csrc/include/opus/rmsnorm_opus_kernel.hpp
@@ -74,12 +74,19 @@ __global__ void rmsnorm_quant_opus(
 {
 }
 #else
-// fp32 -> quant element. int8: round-to-nearest; fp8: hardware e4m3 cvt.
+// fp32 -> quant element. int8: round-to-nearest-even with symmetric saturation;
+// fp8: hardware e4m3 cvt.
 template <typename out_t>
 __device__ inline out_t quant_cast(float v)
 {
     if constexpr(std::is_same_v<out_t, signed char>)
-        return static_cast<signed char>(__builtin_rintf(v));
+    {
+        v                  = __builtin_rintf(v);
+        constexpr float lo = -127.0f;
+        constexpr float hi = 127.0f;
+        asm volatile("v_med3_f32 %0, %0, %1, %2" : "+v"(v) : "v"(lo), "v"(hi));
+        return static_cast<signed char>(v);
+    }
     else
         return opus::fp32_to_fp8(v);
 }

--- a/csrc/include/opus/rmsnorm_opus_kernel.hpp
+++ b/csrc/include/opus/rmsnorm_opus_kernel.hpp
@@ -81,11 +81,7 @@ __device__ inline out_t quant_cast(float v)
 {
     if constexpr(std::is_same_v<out_t, signed char>)
     {
-        v                  = __builtin_rintf(v);
-        constexpr float lo = -127.0f;
-        constexpr float hi = 127.0f;
-        asm volatile("v_med3_f32 %0, %0, %1, %2" : "+v"(v) : "v"(lo), "v"(hi));
-        return static_cast<signed char>(v);
+        return static_cast<signed char>(fminf(fmaxf(__builtin_rintf(v), -127.0f), 127.0f));
     }
     else
         return opus::fp32_to_fp8(v);

--- a/op_tests/test_quant.py
+++ b/op_tests/test_quant.py
@@ -18,6 +18,41 @@ from aiter.test_common import (
 torch.set_default_device("cuda")
 
 
+def test_i8_static_quant_uses_rne_and_saturates():
+    values = torch.tensor(
+        [
+            -200.0,
+            -127.6,
+            -127.5,
+            -2.5,
+            -1.5,
+            -0.5,
+            0.5,
+            1.5,
+            2.5,
+            126.5,
+            127.5,
+            127.6,
+            200.0,
+        ],
+        dtype=torch.bfloat16,
+    ).repeat(2, 1)
+    scale = torch.ones(1, dtype=torch.float32)
+    expected = torch.round(values).clamp(-127, 127).to(torch.int8)
+
+    backends = {
+        "torch": get_torch_quant(aiter.QuantType.per_Tensor),
+        "triton": get_triton_quant(aiter.QuantType.per_Tensor),
+        "hip": get_hip_quant(aiter.QuantType.per_Tensor),
+    }
+    for name, quant in backends.items():
+        actual, _ = quant(values, scale=scale, quant_dtype=dtypes.i8)
+        assert torch.equal(actual, expected), (
+            f"{name} static INT8 quant must use round-to-nearest-even and "
+            "saturate to [-127, 127]"
+        )
+
+
 @benchmark()
 def test_quant(m, n, q_type, q_dtype, h_dtype):
     dim = (m, n)
@@ -117,6 +152,8 @@ parser.add_argument(
 
 args = parser.parse_args()
 list_quant = [d_quant[key] for key in args.quant]
+if any(q_dtype == dtypes.i8 for _, q_dtype in list_quant):
+    test_i8_static_quant_uses_rne_and_saturates()
 
 for (
     (q_type, q_dtype),

--- a/op_tests/test_rmsnorm2dFusedAddQuant.py
+++ b/op_tests/test_rmsnorm2dFusedAddQuant.py
@@ -176,6 +176,49 @@ def run_hip(
     return output, residual_out, scale, None
 
 
+def test_i8_group_quant_rounds_to_nearest():
+    group_size = 64
+    target_ratios = torch.tensor(
+        [
+            -15.75,
+            -15.25,
+            -7.75,
+            -7.25,
+            -3.75,
+            -3.25,
+            -2.75,
+            -2.25,
+            -1.75,
+            -1.25,
+            -0.75,
+            -0.25,
+            0.25,
+            0.75,
+            1.25,
+            127.0,
+        ],
+        dtype=torch.float32,
+    )
+    group_weight = (target_ratios / 127.0).to(torch.bfloat16).repeat(4)
+    hidden_size = 1024
+    groups = hidden_size // group_size
+    weight = group_weight.repeat(groups)
+    input = torch.ones((1, hidden_size), dtype=torch.bfloat16)
+    output = torch.empty_like(input, dtype=torch.int8)
+    scale = torch.empty((1, groups), dtype=torch.float32)
+
+    aiter.rmsnorm_quant(output, input, scale, weight, 1e-6, group_size)
+
+    realized_weight = weight.float().reshape(groups, group_size)
+    realized_ratio = (
+        realized_weight / realized_weight.abs().amax(dim=-1, keepdim=True) * 127.0
+    )
+    expected = torch.round(realized_ratio).clamp(-127, 127).to(torch.int8)
+    assert torch.equal(
+        output.reshape_as(expected), expected
+    ), "rmsnorm_quant INT8 output must use round-to-nearest conversion"
+
+
 @benchmark()
 def test_rmsnorm(
     m,
@@ -331,6 +374,8 @@ if __name__ == "__main__":
         choices=[dtypes.d_dtypes["bf16"], dtypes.d_dtypes["fp16"]],
     )
     args = parser.parse_args()
+    if args.quant_dtype == dtypes.i8:
+        test_i8_group_quant_rounds_to_nearest()
     if args.mode == 1:
         test_rmsnorm_func = partial(
             test_rmsnorm, quant_type=QuantType.No, add_residual=False

--- a/op_tests/triton_tests/quant/test_quant.py
+++ b/op_tests/triton_tests/quant/test_quant.py
@@ -14,8 +14,14 @@ from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
 DEBUG = False
 
 
+def torch_scaled_quant_cast(x, dtype_quant):
+    if dtype_quant == torch.int8:
+        x = torch.round(x).clamp(-127, 127)
+    return x.to(dtype_quant)
+
+
 def torch_static_per_tensor_quant_fp8_i8(out, x, scale, dtype_quant):
-    out = (x / scale).to(dtype_quant)
+    out = torch_scaled_quant_cast(x / scale, dtype_quant)
 
     return out
 
@@ -66,7 +72,7 @@ def torch_dynamic_per_tensor_quant_fp8_i8(x, dtype_quant):
     )
     scale_out = x_max.to(torch.float32) / dtype_max
 
-    out = (x_f32 / scale_out).to(dtype=dtype_quant)
+    out = torch_scaled_quant_cast(x_f32 / scale_out, dtype_quant)
 
     return out, torch.tensor([scale_out], dtype=torch.float32, device=x.device)
 
@@ -115,7 +121,7 @@ def torch_dynamic_per_token_quant_fp8_i8(x, dtype_quant):
 
     scale_recip = 1 / scale_out[:, None]
     out = x * scale_recip
-    out = out.to(dtype_quant)
+    out = torch_scaled_quant_cast(out, dtype_quant)
 
     return out, scale_out
 


### PR DESCRIPTION
## Summary

- make the shared scaled FP32-to-INT8 x2/x4 helpers use round-to-nearest-even (RNE) followed by standard `fminf`/`fmaxf` symmetric saturation to `[-127, 127]`;
- give the OPUS RMSNorm INT8 cast the same finite-value contract;
- align the INT8-only Torch path, direct Triton quant kernels, Triton RMSNorm/LayerNorm output helpers, and independent in-tree PyTorch test oracles with that contract, while leaving FP8/BF8 behavior unchanged;
- add a deterministic cross-backend static boundary regression, in addition to the grouped fused-RMSNorm regression.

This closes the pre-existing split between AITER's shared HIP and OPUS RMSNorm INT8 paths without replacing it with a HIP-vs-reference split. It also prevents static/smooth quantization values such as `127.6` from wrapping to `-128`.

## Review follow-up: controlled W7900 comparison

I reproduced both issues reported in the first review with the same seed, BF16 input, shape `128x4096`, and seven hot timing samples on native `gfx1100`:

| implementation | HIP vs Torch | HIP vs Triton | HIP dequant MAE | 26-value finite boundary |
|---|---:|---:|---:|---:|
| base truncation | 27 / 524,288 (0.00515%) | 11 / 524,288 (0.00210%) | 0.0149471 | 8 differ from RNE+saturate |
| first PR revision: RNE, no clamp | 260,095 / 524,288 (49.6092%) | 260,121 / 524,288 (49.6141%) | 0.0075071 | 12 differ; `127.5/127.6` can flip sign |
| RNE + symmetric saturation | 143 / 524,288 (0.02728%) | 39 / 524,288 (0.00744%) | 0.0075071 | **0 differ across HIP/Torch/Triton** |

All remaining dynamic mismatches have maximum delta 1. Torch, Triton, and HIP have the same dequant MAE (`0.0075070988`) in the revised run; the small value mismatches come from scale/reciprocal evaluation differences rather than different finite integer-rounding rules.

The latest review suggested replacing gfx-specific `v_med3_f32` inline assembly with `fminf(fmaxf(__builtin_rintf(x), -127.f), 127.f)` because NaN results can differ. Commit `2277d85f` applies that standard expression to both in-scope device helpers.

A direct special-value probe on W7900/gfx1100 found that the old `v_med3` and new min/max expressions both map positive/negative quiet and signalling NaNs to `-127`; infinities saturate to `+/-127`, and all finite ties and boundaries are unchanged. A separate BF16 backend probe found that Torch currently maps NaN to `0`, while HIP and Triton map it to `-127`. Therefore this PR preserves and tests the finite RNE+saturation contract but does **not** claim to establish a global cross-backend NaN policy.

## W7900 correctness gates

Environment: Radeon PRO W7900, native `gfx1100`, process-level `HSA_OVERRIDE_GFX_VERSION` explicitly unset, PyTorch `2.9.1+gitff65f5b`, HIP `7.2.53211-e1a6bc5663`, Triton `3.5.1`.

After the final source adjustment, all candidate-owned JIT modules were moved into named recoverable stale-cache directories and rebuilt from scratch on exact public head `2277d85f`:

- `test_quant.py -q i8_token -m 128 -n 4096 -d bf16`: exit 0; HIP/Torch differs in 91 / 524,288 values and Triton/Torch in 86 / 524,288, all by 1;
- explicit OPUS RMSNorm boundary fixture: exact expected RNE+saturation output, exit 0;
- `test_rmsnorm2dFusedAddQuant.py --mode 5 -q i8 -m 1 8 16 128 -n 1024 4096 -d bf16`: exit 0; all eight HIP and CK output/scale checks pass;
- `test_kvcache.py -t bf16toi8 -b 8 -c 128`: exit 0; remaining cache differences are one INT8 level rather than the approximately 50% semantic split;
- real generated quant and OPUS RMSNorm translation units rebuild from zero object/shared-library outputs for `gfx942` and `gfx950`, four builds at exit 0. These are compile gates, not Instinct runtime claims; upstream accelerator CI remains authoritative.

## CI follow-up: direct Triton and normalization coverage

After workflow approval, public [Triton run 31598318902](https://github.com/ROCm/aiter/actions/runs/31598318902) exposed two candidate-owned gaps in head `2277d85f`:

- MI35X shard 4 had 67 INT8-only direct-quant failures because the local PyTorch oracles in `op_tests/triton_tests/quant/test_quant.py` still used truncating `.to(int8)` while the candidate Triton kernels used RNE+saturation;
- MI35X shard 5 had 43 BF16 RMSNorm quantization failures, all with maximum delta 2, because the Triton normalization helpers still relied on the output store's truncating cast.

Commit `971cece9` fixes those gaps without changing FP8 behavior: the test-local oracle now explicitly uses `torch.round(...).clamp(-127, 127)` only for INT8, and both Triton RMSNorm and LayerNorm reuse the existing `_int8_rne_sat` primitive. The single shard-7 MXFP4 mismatch and the OPUS jobs' missing `libamdhip64.so.7` loader error are outside the changed INT8 paths.

On native W7900/gfx1100, the old source deterministically reproduced 388/1,024 direct-quant mismatches and 3/262,144 fused-RMSNorm mismatches. The same two nodes pass on physical GPU0 and GPU7 after the fix. On exact current AITER main `a50a62aa` (merge tree `d326412f`), the GitHub-run wheelhouse—Triton `3.7.0+amd.rocm7.2.0.git89002410` and triton-kernels `1.0.0+amd.rocm7.2.0.git89002410`—passes:

- direct INT8 quantization: 69/69;
- RMSNorm dynamic/smooth INT8 quantization: 216/216;
- LayerNorm dynamic/smooth INT8 quantization: 96/96.

The downloaded GitHub artifact and the wheelhouse independently downloaded by AITER's pinned-index contract have identical SHA-256 values (`45710096...7504` and `452b7a3d...e1d5`). Both test containers exited 0, were not OOM-killed, and ran without `HSA_OVERRIDE_GFX_VERSION`. New public workflows for `971cece9` are awaiting repository approval; they are not represented as green yet.

## Performance non-regression

An eight-round interleaved A/B/B/A comparison used the same BF16 `128x4096` input, 100 warmups, 500 launches per sample and seven samples per round. Taking the median of four round-p50 values per implementation:

| implementation | median round p50 |
|---|---:|
| old `v_med3` | `20.7393 us` |
| standard `fminf`/`fmaxf` | `20.6306 us` |
| relative | `-0.52%` |

This difference is within run noise and supports only a no-observed-regression conclusion. The extracted gfx1100 special-value probe shows the compiler lowering the standard min/max expression to `v_maxmin_f32`; the old comparison branch retains `v_med3_f32`.

## DeepSeek V4 relevance

The official DeepSeek V4 Flash paper, Hugging Face/ModelScope card and config, ModelScope `deepseek-ai/DeepSeek-V4-Flash-0731` checkpoint and bundled `inference/`, and official TileKernels define the model shapes and dynamic FP8/FP4 route. They do not define this optional INT8 NaN policy and are algorithmic/model references rather than executable INT8 semantics on W7900. This PR hardens AITER's optional INT8/W8A8 foundation; it does not claim to alter the official V4 numerical path.

For the earlier layer-local screen, official 0731 layer-0 weights were used with calibrated group-64 INT8 weights and the same W8A8 GEMM on both sides. The fused/current hot p50 geomean was `1.289x` to `1.313x` across local `wqkv_a`, TP8-rank-0 `wq_b`, and shared gate/up shapes; all nine quality rows met cosine `>= 0.9995` and relative L2 `<= 0.01`. The dynamic scale bounds values to `|q| <= 127`; the finite saturation change does not alter that path's output or MAE.

## Scope boundary

This PR normalizes the shared scaled quantization path, its Torch/Triton references, and the directly related OPUS RMSNorm cast. It does **not** claim that every FP32-to-INT8 conversion in AITER now has one global policy. Generic `opus::cast<i8_t>`, third-party CK smoothquant/MoE conversions, and separate Triton MoE half-away-from-zero conversions remain pre-existing semantics debt. Pulling those independent/vendor paths into this correctness fix would broaden both ownership and validation requirements, so they are intentionally left for separately justified work.

## Source state and checks

The public head consists of four signed-off commits and remains on its older ancestor; the update is a normal fast-forward from `2277d85f` to `971cece9`, with no rebase or force-push. It merges without conflict into current AITER main `a50a62aaa292427e00190dd7ba58e39a6db4e61e` as exact tree `d326412ff06a0a31cecf3a8d703fb0c53b39fb45`.

- Black `25.11.0`: pass on the three-file follow-up (the repository's stable-Black workflow rerun is pending approval);
- Ruff `0.16.0` (the CI-pinned version): pass on the three-file follow-up;
- changed-line clang-format checks: pass on the final C++ revision;
- Python byte-compile and `git diff --check`: pass;
- DCO sign-offs: present on all four commits.


