### PR TITLE
[Bugfix] Fix two build failures: hipify qualifier loss and std::min

### DIFF
--- a/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.cuh
+++ b/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages_common.cuh
@@ -70,7 +70,7 @@ void ck_moe_stage1_gemm(const hipStream_t& stream,
     static constexpr ck::index_t NXDLPerWave = NPerBlock / (MNPerXDL * NWaves);
     // static constexpr ck::index_t NPerBlock = PipelineVer == ck::BlockGemmPipelineVersion::v1 ? 64
     // : 128;
-    static constexpr ck::index_t CShuffleMXDLPerWave = std::min(2, MXDLPerWave);
+    static constexpr ck::index_t CShuffleMXDLPerWave = (2 < MXDLPerWave ? 2 : MXDLPerWave);
     static constexpr ck::index_t CShuffleNXDLPerWave =
         ck::is_same_v<B0DataType, I4> ? 1 : NXDLPerWave;
     // Note: some fp8 instances didn't compile with AK1/BK1=16
@@ -258,7 +258,7 @@ void ck_moe_stage2_gemm(const hipStream_t& stream,
     static constexpr ck::index_t MNPerXDL            = 16;
     static constexpr ck::index_t MXDLPerWave         = MPerBlock / (MNPerXDL * MWaves);
     static constexpr ck::index_t NXDLPerWave         = NPerBlock / (MNPerXDL * NWaves);
-    static constexpr ck::index_t CShuffleMXDLPerWave = std::min(2, MXDLPerWave);
+    static constexpr ck::index_t CShuffleMXDLPerWave = (2 < MXDLPerWave ? 2 : MXDLPerWave);
     static constexpr ck::index_t CShuffleNXDLPerWave =
         ck::is_same_v<B0DataType, I4> ? 2 : NXDLPerWave;
     static constexpr ck::index_t CShuffleNLane =

--- a/csrc/include/binary_operator.cuh
+++ b/csrc/include/binary_operator.cuh
@@ -1581,10 +1581,13 @@ struct BinaryOperationPattern<2, Operation, _T0, _T1>
             {
                 VLLM_DISPATCH_FLOATING_TYPES_rmTorch(
                     output.dtype(), "operator_bcast_tile_kernel", [&] {
-                        aiter::
-                            operator_bcast_tile_kernel<scalar_t, rows, Operation, false, _T1, _T0>
+                        // Do not reformat: `aiter::` must stay on the same line as the
+                        // kernel name, otherwise PyTorch fails to hipify this file.
+                        // clang-format off
+                        aiter::operator_bcast_tile_kernel<scalar_t, rows, Operation, false, _T1, _T0>
                             <<<grid_dim, block_dim, 0, stream>>>(
                                 buf_b, buf_a, buf_c, M, N, K, types_match);
+                        // clang-format on
                     });
             }
         }
@@ -2204,10 +2207,13 @@ struct BinaryOperationPattern<4, Operation, _T0, _T1>
             const dim3 block_dim(wg, 1, 1);
             VLLM_DISPATCH_FLOATING_TYPES_rmTorch(
                 output.dtype(), "operator_contiguous_kernel_naive", [&] {
-                    aiter::
-                        operator_contiguous_kernel_naive<scalar_t, rows, Operation, true, _T0, _T1>
+                    // Do not reformat: `aiter::` must stay on the same line as the
+                    // kernel name, otherwise PyTorch fails to hipify this file.
+                    // clang-format off
+                    aiter::operator_contiguous_kernel_naive<scalar_t, rows, Operation, true, _T0, _T1>
                         <<<grid_dim, block_dim, 0, stream>>>(
                             buf_a, buf_b, buf_c, num_elements, types_match);
+                    // clang-format on
                 });
         }
         else if(N % rows == 0 && K % vec == 0)

--- a/csrc/kernels/activation_kernels.cu
+++ b/csrc/kernels/activation_kernels.cu
@@ -871,8 +871,12 @@ static constexpr int nextPow2(unsigned int num)
             using output_dtype = input_dtype;                                                     \
             AITER_DISPATCH_CASE_VEC_SIZE_rmTorch(                                                         \
                 vec_size,                                                                         \
-                aiter::                                                                           \
-                    act_and_mul_kernel<input_dtype, output_dtype, KERNEL<input_dtype>, VEC_SIZE, HAS_LIMIT_VAL, GROUP_NT> \
+                aiter::act_and_mul_kernel<input_dtype,                                            \
+                                          output_dtype,                                           \
+                                          KERNEL<input_dtype>,                                    \
+                                          VEC_SIZE,                                               \
+                                          HAS_LIMIT_VAL,                                          \
+                                          GROUP_NT>                                               \
                 <<<grid, block, 0, stream>>>(reinterpret_cast<output_dtype*>(out.data_ptr()),     \
                                              reinterpret_cast<input_dtype*>(input.data_ptr()),    \
                                              d, limit_val);)                                      \

--- a/csrc/kernels/cache_kernels.cu
+++ b/csrc/kernels/cache_kernels.cu
@@ -3461,8 +3461,12 @@ void reshape_and_cache_flash(
 
 // Macro to dispatch the kernel based on the data type.
 #define CALL_INDEXER_K_QUANT_AND_CACHE(KV_T, CACHE_T, KV_DTYPE)                                   \
-    aiter::                                                                                       \
-        indexer_k_quant_and_cache_kernel<KV_T, CACHE_T, KV_DTYPE, blockDimx, blockDimy, vec_size> \
+    aiter::indexer_k_quant_and_cache_kernel<KV_T,                                                 \
+                                            CACHE_T,                                              \
+                                            KV_DTYPE,                                             \
+                                            blockDimx,                                            \
+                                            blockDimy,                                            \
+                                            vec_size>                                             \
         <<<grid, block, 0, stream>>>(reinterpret_cast<KV_T*>(k.data_ptr()),                       \
                                      reinterpret_cast<CACHE_T*>(kv_cache.data_ptr()),             \
                                      reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),                            \


### PR DESCRIPTION
Two independent problems that make AITER fail to build under toolchains other than the one CI happens to use. Neither changes generated code on a configuration that already builds.

1. hipify silently drops `aiter::` from kernel launches -------------------------------------------------------

hipify recovers the launched symbol by scanning backwards from `<<<` (grab_method_and_template in torch/utils/hipify/hipify_python.py, also vendored here as aiter/jit/utils/hipify/). That scan accepts only alphanumerics and { ( ) _ : # }, so it stops at the first whitespace. When the namespace qualifier is left on its own line:

    aiter::
        act_and_mul_kernel<...>
        <<<grid, block, 0, stream>>>(...)

it terminates before `aiter::`, the qualifier is dropped, and the translated source names a bare `act_and_mul_kernel`. That does not resolve, because these launch sites sit outside namespace aiter (it closes at binary_operator.cuh:1339).

hipify does carry a workaround, but it is hardcoded to one namespace and so never applies to aiter::

    RE_KERNEL_LAUNCH = re.compile(r"([ ]+)(detail?)::[ ]+\\\n[ ]+")

Reproduced by running hipify's own processKernelLaunches() over each file. Before, these launches are emitted unqualified:

    binary_operator.cuh    operator_bcast_tile_kernel
                           operator_contiguous_kernel_naive
    activation_kernels.cu  act_and_mul_kernel
    cache_kernels.cu       indexer_k_quant_and_cache_kernel

After, every launch is aiter::-qualified. All of csrc/ was swept for the pattern; those four were the only sites and the sweep is clean now.

The two in binary_operator.cuh run 101 and 102 columns once joined, past the ColumnLimit of 100, and clang-format splits them straight back, so they are pinned with clang-format off/on and a comment recording why. The .cu sites instead wrap their template arguments, which keeps the qualifier attached and brings both macros inside the column limit (they were 123 and 118 columns). .cu is not covered by the clang-format sweep in .githooks/pre-commit, so no guard is needed there.

2. std::min used without including <algorithm> ----------------------------------------------

gemm_moe_ck2stages_common.cuh initializes a static constexpr with std::min() in both ck_moe_stage1_gemm (line 73) and ck_moe_stage2_gemm (line 261), but the file never includes <algorithm>; it has only <iostream>, gemm_moe_ck2stages.h, and two CK headers. It compiles today purely because <algorithm> arrives transitively, which is a property of the standard library implementation rather than of the source. Where it does not, both functions fail with "no member named 'min' in namespace 'std'".

A ternary removes the header dependency outright, which is more robust than adding the include and costs nothing: MXDLPerWave is a compile-time constant, so both forms fold to the same value.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
