### PR TITLE
feat(triton): enable gfx1100 MXFP4 MoE

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -737,6 +737,29 @@ def _fused_moe_impl(
         else:
             q_dtype_a = dtypes.fp4x2
 
+    # RDNA3 has no executable CK per-1x32 path. Keep BF16 activations for the
+    # narrowly supported Triton A16W4 route instead of quantizing them to FP4.
+    if _is_gfx1100_triton_mxfp4_contract(
+        M,
+        model_dim,
+        inter_dim,
+        E,
+        topk,
+        dtype,
+        q_dtype_w,
+        quant_type,
+        isG1U1,
+        activation,
+        doweight_stage1,
+        hidden_pad,
+        intermediate_pad,
+        isShuffled,
+        gate_mode,
+        expert_mask is not None,
+        bias2 is not None,
+    ):
+        q_dtype_a = dtypes.bf16
+
     if get_gfx() == "gfx1250":
         if os.environ.get("AITER_FORCE_A8W4", "0") in ("1"):
             q_dtype_a = dtypes.fp8
@@ -1259,6 +1282,298 @@ class MOEMetadata:
 
 def _needs_swiglu_bias_support(dtype, quant_type):
     return dtype in [dtypes.bf16, dtypes.fp16] and quant_type == QuantType.per_1x32
+
+
+def _require_ck_2stage_quant_arch(quant_type):
+    """Reject MX quant dispatch that would reach an architecture-empty CK kernel.
+
+    The CK two-stage per-1x32 implementation uses gfx950-only MX matrix
+    instructions. Other backends are selected before this guard, so reaching
+    it means that no portable implementation was found for this dispatch.
+    """
+    gfx = get_gfx()
+    if quant_type == QuantType.per_1x32 and gfx != "gfx950":
+        raise RuntimeError(
+            "CK two-stage per_1x32 MoE is only executable on gfx950; "
+            f"refusing to launch its architecture-empty kernel on {gfx}. "
+            "Select a supported Triton, FlyDSL, Opus, or CK-Tile backend."
+        )
+
+
+# SGLang's DSV4 chunked-prefill contract is 4096 tokens. The same Triton
+# kernels and sorting ABI used for decode remain valid through that boundary;
+# only their launch grid grows with the padded route count.
+_GFX1100_TRITON_MXFP4_MAX_TOKENS = 4096
+_GFX1100_TRITON_MXFP4_SHAPES = {
+    (2048, 256, 0),  # unsharded/full-shape correctness gate
+    (256, 256, 0),  # DeepSeek-V4 TP8: global I2048 sharded to local I256
+}
+_GFX1100_TRITON_MXFP4_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 1,
+}
+
+
+def _is_gfx1100_triton_mxfp4_contract(
+    token,
+    model_dim,
+    inter_dim,
+    expert,
+    topk,
+    dtype,
+    q_dtype_w,
+    q_type,
+    use_g1u1,
+    activation,
+    doweight_stage1,
+    hidden_pad,
+    intermediate_pad,
+    is_shuffled,
+    gate_mode,
+    is_ep,
+    has_stage2_bias,
+):
+    return (
+        get_gfx() == "gfx1100"
+        and 0 < token <= _GFX1100_TRITON_MXFP4_MAX_TOKENS
+        and model_dim == 4096
+        and (inter_dim, expert, intermediate_pad) in _GFX1100_TRITON_MXFP4_SHAPES
+        and topk == 6
+        and dtype == dtypes.bf16
+        and q_dtype_w == dtypes.fp4x2
+        and q_type == QuantType.per_1x32
+        and use_g1u1
+        and activation == ActivationType.Silu
+        and not doweight_stage1
+        and hidden_pad == 0
+        and not is_shuffled
+        and gate_mode == GateMode.SEPARATED
+        and not is_ep
+        and not has_stage2_bias
+    )
+
+
+def _gfx1100_triton_mxfp4_metadata(
+    token,
+    model_dim,
+    inter_dim,
+    expert,
+    topk,
+    dtype,
+    q_dtype_a,
+    q_dtype_w,
+    q_type,
+    use_g1u1,
+    activation,
+    doweight_stage1,
+    hidden_pad,
+    intermediate_pad,
+    is_shuffled,
+    gate_mode,
+    is_ep,
+    has_stage2_bias,
+):
+    """Return the narrowly qualified gfx1100 Triton MXFP4 route, if any."""
+    if not (
+        q_dtype_a == dtypes.bf16
+        and _is_gfx1100_triton_mxfp4_contract(
+            token,
+            model_dim,
+            inter_dim,
+            expert,
+            topk,
+            dtype,
+            q_dtype_w,
+            q_type,
+            use_g1u1,
+            activation,
+            doweight_stage1,
+            hidden_pad,
+            intermediate_pad,
+            is_shuffled,
+            gate_mode,
+            is_ep,
+            has_stage2_bias,
+        )
+    ):
+        return None
+    return MOEMetadata(
+        stage1=functools.partial(
+            _triton_mxfp4_a16w4_stage1,
+            config=_GFX1100_TRITON_MXFP4_CONFIG,
+        ),
+        stage2=functools.partial(
+            _triton_mxfp4_a16w4_stage2,
+            config=_GFX1100_TRITON_MXFP4_CONFIG,
+        ),
+        block_m=_GFX1100_TRITON_MXFP4_CONFIG["BLOCK_SIZE_M"],
+        ksplit=1,
+        prequant=False,
+        skip_inter_quant=True,
+    )
+
+
+_TRITON_MXFP4_UNIT_SCALES: dict[
+    tuple[torch.device, int], tuple[torch.Tensor, torch.Tensor]
+] = {}
+
+
+def _triton_mxfp4_unit_scales(tensor, num_experts):
+    """Reuse immutable unit scales instead of launching fills for every MoE stage."""
+    device = tensor.device
+    if device.type == "cuda" and device.index is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    key = (device, int(num_experts))
+    scales = _TRITON_MXFP4_UNIT_SCALES.get(key)
+    if scales is None:
+        scales = (
+            torch.ones((1,), dtype=dtypes.fp32, device=device),
+            torch.ones((num_experts,), dtype=dtypes.fp32, device=device),
+        )
+        _TRITON_MXFP4_UNIT_SCALES[key] = scales
+    return scales
+
+
+def _triton_mxfp4_a16w4_stage1(
+    hidden_states,
+    w1,
+    w2,
+    sorted_token_ids,
+    sorted_expert_ids,
+    num_valid_ids,
+    out,
+    topk,
+    block_m,
+    a1_scale,
+    w1_scale,
+    sorted_weights=None,
+    topk_weights=None,
+    topk_ids=None,
+    swiglu_limit=None,
+    *,
+    config,
+    **_kwargs,
+):
+    from aiter.ops.triton.moe.moe_op_mxfp4_silu_fused import (
+        fused_moe_mxfp4_silu,
+    )
+    from aiter.ops.triton.utils.types import torch_to_triton_dtype
+
+    del w2, block_m, a1_scale
+    token_num = hidden_states.shape[0]
+    inter_dim = w1.shape[1] // 2
+    if out is None or tuple(out.shape) != (token_num, topk, inter_dim):
+        out = torch.empty(
+            (token_num, topk, inter_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+    if w1_scale is None:
+        raise ValueError("gfx1100 Triton MXFP4 stage1 requires E8M0 weight scales")
+    if getattr(w1, "is_shuffled", False):
+        raise ValueError("gfx1100 Triton MXFP4 stage1 requires unshuffled weights")
+    if topk_weights is None or topk_ids is None:
+        raise ValueError("gfx1100 Triton MXFP4 stage1 requires route-order metadata")
+
+    route_count = token_num * topk
+    a_scale, b_scale = _triton_mxfp4_unit_scales(w1, w1.shape[0])
+    fused_moe_mxfp4_silu(
+        hidden_states,
+        w1.view(torch.uint8),
+        out.view(route_count, inter_dim),
+        a_scale,
+        b_scale,
+        None,
+        w1_scale.view(torch.uint8),
+        topk_weights,
+        topk_ids,
+        sorted_token_ids,
+        sorted_expert_ids,
+        num_valid_ids,
+        False,
+        topk,
+        False,
+        False,
+        config,
+        torch_to_triton_dtype[out.dtype],
+        sorted_token_ids_are_packed=True,
+        sorted_top_k=topk,
+        swiglu_limit=0.0 if swiglu_limit is None else float(swiglu_limit),
+    )
+    return out
+
+
+def _triton_mxfp4_a16w4_stage2(
+    inter_states,
+    w1,
+    w2,
+    sorted_token_ids,
+    sorted_expert_ids,
+    num_valid_ids,
+    moe_out,
+    topk,
+    w2_scale=None,
+    a2_scale=None,
+    block_m=None,
+    sorted_weights=None,
+    topk_weights=None,
+    *,
+    config,
+    **_kwargs,
+):
+    from aiter.ops.triton.moe.moe_op_mxfp4 import fused_moe_mxfp4
+    from aiter.ops.triton.moe.reduce import reduce_topk
+    from aiter.ops.triton.utils.types import torch_to_triton_dtype
+
+    del w1, a2_scale, block_m, sorted_weights
+    if w2_scale is None:
+        raise ValueError("gfx1100 Triton MXFP4 stage2 requires E8M0 weight scales")
+    if topk_weights is None:
+        raise ValueError("gfx1100 Triton MXFP4 stage2 requires route-order weights")
+    if getattr(w2, "is_shuffled", False):
+        raise ValueError("gfx1100 Triton MXFP4 stage2 requires unshuffled weights")
+
+    token_num = moe_out.shape[0]
+    model_dim = w2.shape[1]
+    inter_dim = inter_states.shape[-1]
+    route_count = token_num * topk
+    route_weights = topk_weights.reshape(route_count, 1).contiguous()
+    route_ids_placeholder = sorted_token_ids[:route_count].view(route_count, 1)
+    route_out = torch.empty(
+        (route_count, 1, model_dim), dtype=moe_out.dtype, device=moe_out.device
+    )
+    a_scale, b_scale = _triton_mxfp4_unit_scales(w2, w2.shape[0])
+    fused_moe_mxfp4(
+        inter_states.view(route_count, inter_dim),
+        w2.view(torch.uint8),
+        route_out,
+        a_scale,
+        b_scale,
+        None,
+        w2_scale.view(torch.uint8),
+        route_weights,
+        route_ids_placeholder,
+        sorted_token_ids,
+        sorted_expert_ids,
+        num_valid_ids,
+        True,
+        1,
+        False,
+        False,
+        config,
+        torch_to_triton_dtype[moe_out.dtype],
+        sorted_token_ids_are_packed=True,
+        sorted_top_k=topk,
+    )
+    reduce_topk(route_out.view(token_num, topk, model_dim), moe_out)
+    return moe_out
 
 
 def _normalize_bias_for_kernel(
@@ -1876,6 +2191,29 @@ def get_2stage_cfgs(
     has_stage2_bias=False,
 ):
     gate_mode = GateMode(gate_mode)
+    gfx1100_triton_metadata = _gfx1100_triton_mxfp4_metadata(
+        token,
+        model_dim,
+        inter_dim,
+        expert,
+        topk,
+        dtype,
+        q_dtype_a,
+        q_dtype_w,
+        q_type,
+        use_g1u1,
+        activation,
+        doweight_stage1,
+        hidden_pad,
+        intermediate_pad,
+        is_shuffled,
+        gate_mode,
+        is_ep,
+        has_stage2_bias,
+    )
+    if gfx1100_triton_metadata is not None:
+        return gfx1100_triton_metadata
+
     # Configs are keyed on (gfx, cu_num, ...) so archs that share a cu_num
     # (e.g. gfx950 vs gfx1250, both report 256 CU) don't collide. Legacy CSVs
     # without a `gfx` column are backfilled from cu_num at load time via
@@ -2551,6 +2889,7 @@ def get_2stage_cfgs(
             ]
         )
     ):
+        _require_ck_2stage_quant_arch(q_type)
         if kernelName2 and kernelName2.startswith("flydsl_") and is_flydsl_available():
             stage2_func = functools.partial(
                 _flydsl_stage2_wrapper,
@@ -2820,6 +3159,12 @@ def fused_moe_2stages(
     need_bias_support = _needs_swiglu_bias_support(dtype, quant_type)
     stage1_func = getattr(metadata.stage1, "func", metadata.stage1)
     stage2_func = getattr(metadata.stage2, "func", metadata.stage2)
+    if stage1_func is _triton_mxfp4_a16w4_stage1:
+        extra_stage1_args["topk_weights"] = topk_weights
+        extra_stage1_args["topk_ids"] = topk_ids
+        extra_stage1_args["swiglu_limit"] = swiglu_limit
+    if stage2_func is _triton_mxfp4_a16w4_stage2:
+        extra_stage2_args["topk_weights"] = topk_weights
     if not metadata.run_1stage and need_bias_support:
         if metadata.has_bias:
             extra_stage1_args["bias1"] = _normalize_bias_for_kernel(bias1)
@@ -2879,6 +3224,8 @@ def fused_moe_2stages(
     a2 = _stage1_call()
     if m_indices is not None and isinstance(a2, tuple):
         a2, a2_scale = a2[0], a2[1]
+    elif metadata.skip_inter_quant:
+        a2_scale = None
     elif metadata.fuse_quant == "fp4" and isinstance(a2, tuple):
         a2_raw, a2_scale = a2[0], a2[1]
         _fp4_bytes = token_num * topk * (inter_dim // 2)

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4.py
@@ -32,6 +32,8 @@ _fused_moe_kernel_mxfp4_repr = make_kernel_repr(
         "EVEN_K",
         "MUL_ROUTED_WEIGHT",
         "top_k",
+        "SORTED_IDS_PACKED",
+        "SORTED_TOP_K",
         "compute_type",
         "SWIZZLE_MX_A",
         "SWIZZLE_MX_B",
@@ -86,6 +88,8 @@ def _fused_moe_kernel_mxfp4(
     EVEN_K: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
     top_k: tl.constexpr,
+    SORTED_IDS_PACKED: tl.constexpr,
+    SORTED_TOP_K: tl.constexpr,
     compute_type: tl.constexpr,
     SWIZZLE_MX_A: tl.constexpr,  # TODO add swizzle support
     SWIZZLE_MX_B: tl.constexpr,  # TODO add swizzle support
@@ -171,6 +175,10 @@ def _fused_moe_kernel_mxfp4(
     # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
     offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
     offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    if SORTED_IDS_PACKED:
+        token_id = offs_token & 0xFFFFFF
+        topk_slot = offs_token >> 24
+        offs_token = token_id * SORTED_TOP_K + topk_slot
     token_mask = offs_token < num_valid_tokens
 
     off_expert = tl.load(expert_ids_ptr + pid_m).to(tl.int64)

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py
@@ -33,6 +33,9 @@ _fused_moe_kernel_mxfp4_silu_repr = make_kernel_repr(
         "EVEN_K",
         "MUL_ROUTED_WEIGHT",
         "top_k",
+        "SORTED_IDS_PACKED",
+        "SORTED_TOP_K",
+        "SWIGLU_LIMIT",
         "compute_type",
         "SWIZZLE_MX_A",
         "SWIZZLE_MX_B",
@@ -86,6 +89,9 @@ def _fused_moe_kernel_mxfp4_silu(
     EVEN_K: tl.constexpr,
     MUL_ROUTED_WEIGHT: tl.constexpr,
     top_k: tl.constexpr,
+    SORTED_IDS_PACKED: tl.constexpr,
+    SORTED_TOP_K: tl.constexpr,
+    SWIGLU_LIMIT: tl.constexpr,
     compute_type: tl.constexpr,
     SWIZZLE_MX_A: tl.constexpr,  # TODO add swizzle support
     SWIZZLE_MX_B: tl.constexpr,  # TODO add swizzle support
@@ -171,6 +177,10 @@ def _fused_moe_kernel_mxfp4_silu(
     # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
     offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
     offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    if SORTED_IDS_PACKED:
+        token_id = offs_token & 0xFFFFFF
+        topk_slot = offs_token >> 24
+        offs_token = token_id * SORTED_TOP_K + topk_slot
     token_mask = offs_token < num_valid_tokens
 
     off_expert = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
@@ -389,6 +399,9 @@ def _fused_moe_kernel_mxfp4_silu(
         accumulator.to(tl.float32).reshape(BLOCK_SIZE_M, BLOCK_SIZE_HALF, 2).split()
     )
 
+    if SWIGLU_LIMIT > 0.0:
+        silu_acc = tl.minimum(silu_acc, SWIGLU_LIMIT)
+        mul_acc = tl.maximum(tl.minimum(mul_acc, SWIGLU_LIMIT), -SWIGLU_LIMIT)
     silu_acc = _silu_exp2(silu_acc)
     accumulator = (silu_acc * mul_acc).to(compute_type)
     # -----------------------------------------------------------

--- a/aiter/ops/triton/_triton_kernels/moe/reduce.py
+++ b/aiter/ops/triton/_triton_kernels/moe/reduce.py
@@ -43,7 +43,9 @@ def _reduce_grouped(
     start = pid_t * K
     # load indices into a tuple
     if InIndx is None:
-        indxs = (pid_t,)
+        indxs = ()
+        for i in tl.static_range(0, K):
+            indxs = indxs + (pid_t * K + i,)
     else:
         indxs = ()
         for i in tl.static_range(0, K):

--- a/aiter/ops/triton/moe/moe_op_mxfp4.py
+++ b/aiter/ops/triton/moe/moe_op_mxfp4.py
@@ -37,6 +37,8 @@ def fused_moe_mxfp4(
     swizzle_mx_b: bool,
     config: dict[str, Any],
     compute_type: tl.dtype,
+    sorted_token_ids_are_packed: bool = False,
+    sorted_top_k: int | None = None,
 ) -> None:
     """
     Fused MoE computation with MXFP4 (microscale FP4) quantization.
@@ -61,6 +63,10 @@ def fused_moe_mxfp4(
         config (Dict[str, Any]): Kernel tuning parameters (BLOCK_SIZE_M, BLOCK_SIZE_N,
             BLOCK_SIZE_K, GROUP_SIZE_M).
         compute_type (tl.dtype): Computation dtype for accumulation.
+        sorted_token_ids_are_packed (bool): Decode AITER's packed
+            ``(topk_slot << 24) | token`` sorting format when true.
+        sorted_top_k (int | None): Original routing top-k used by the packed
+            format. Defaults to ``top_k`` for backward compatibility.
 
     Returns:
         None. Results written in-place to C.
@@ -100,10 +106,14 @@ def fused_moe_mxfp4(
     B_tl_dtype = torch_to_triton_dtype[B.dtype]
     B_DTYPE_FORMAT = get_scaled_dot_format_string(B_tl_dtype)
 
-    grid = lambda META: (
-        triton.cdiv(EM, META["BLOCK_SIZE_M"])
-        * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
-    )
+    def grid(meta):
+        return (
+            triton.cdiv(EM, meta["BLOCK_SIZE_M"])
+            * triton.cdiv(B.shape[1], meta["BLOCK_SIZE_N"]),
+        )
+
+    if sorted_top_k is None:
+        sorted_top_k = top_k
     _fused_moe_kernel_mxfp4[grid](
         A,
         B,
@@ -135,6 +145,8 @@ def fused_moe_mxfp4(
         B_DTYPE_FORMAT=B_DTYPE_FORMAT,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         top_k=top_k,
+        SORTED_IDS_PACKED=sorted_token_ids_are_packed,
+        SORTED_TOP_K=sorted_top_k,
         compute_type=compute_type,
         SWIZZLE_MX_A=swizzle_mx_a,  # TODO add swizzle support
         SWIZZLE_MX_B=swizzle_mx_b,  # TODO add swizzle support

--- a/aiter/ops/triton/moe/moe_op_mxfp4_silu_fused.py
+++ b/aiter/ops/triton/moe/moe_op_mxfp4_silu_fused.py
@@ -36,6 +36,9 @@ def fused_moe_mxfp4_silu(
     swizzle_mx_b: bool,
     config: dict[str, Any],
     compute_type: tl.dtype,
+    sorted_token_ids_are_packed: bool = False,
+    sorted_top_k: int | None = None,
+    swiglu_limit: float = 0.0,
 ) -> None:
     """
     Fused MoE computation with MXFP4 quantization and SiLU activation.
@@ -60,6 +63,12 @@ def fused_moe_mxfp4_silu(
         config (Dict[str, Any]): Kernel tuning parameters (BLOCK_SIZE_M, BLOCK_SIZE_N,
             BLOCK_SIZE_K, GROUP_SIZE_M).
         compute_type (tl.dtype): Computation dtype for accumulation.
+        sorted_token_ids_are_packed (bool): Decode AITER's packed
+            ``(topk_slot << 24) | token`` sorting format when true.
+        sorted_top_k (int | None): Original routing top-k used by the packed
+            format. Defaults to ``top_k`` for backward compatibility.
+        swiglu_limit (float): Optional DeepSeek-style SwiGLU clamp. Positive
+            values clamp gate from above and up symmetrically before SiLU.
 
     Returns:
         None. Results written in-place to C with SiLU activation applied.
@@ -99,10 +108,14 @@ def fused_moe_mxfp4_silu(
     B_tl_dtype = torch_to_triton_dtype[B.dtype]
     B_DTYPE_FORMAT = get_scaled_dot_format_string(B_tl_dtype)
 
-    grid = lambda META: (
-        triton.cdiv(EM, META["BLOCK_SIZE_M"])
-        * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
-    )
+    def grid(meta):
+        return (
+            triton.cdiv(EM, meta["BLOCK_SIZE_M"])
+            * triton.cdiv(B.shape[1], meta["BLOCK_SIZE_N"]),
+        )
+
+    if sorted_top_k is None:
+        sorted_top_k = top_k
     _fused_moe_kernel_mxfp4_silu[grid](
         A,
         B,
@@ -134,6 +147,9 @@ def fused_moe_mxfp4_silu(
         B_DTYPE_FORMAT=B_DTYPE_FORMAT,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         top_k=top_k,
+        SORTED_IDS_PACKED=sorted_token_ids_are_packed,
+        SORTED_TOP_K=sorted_top_k,
+        SWIGLU_LIMIT=swiglu_limit,
         compute_type=compute_type,
         SWIZZLE_MX_A=swizzle_mx_a,  # TODO add swizzle support
         SWIZZLE_MX_B=swizzle_mx_b,  # TODO add swizzle support

--- a/aiter/ops/triton/moe/reduce.py
+++ b/aiter/ops/triton/moe/reduce.py
@@ -149,3 +149,50 @@ def reduce_grouped(
         num_warps=2,
     )
     return out
+
+
+def reduce_topk(x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+    """Sum contiguous ``[tokens, topk, hidden]`` route output in fp32."""
+    assert x.ndim == 3
+    assert out.ndim == 2
+    assert x.is_contiguous()
+    assert out.is_contiguous()
+    token_num, topk, hidden_dim = x.shape
+    assert out.shape == (token_num, hidden_dim)
+    assert out.dtype == x.dtype
+    assert out.device == x.device
+    if token_num == 0:
+        return out
+
+    flat = x.view(1, token_num * topk, hidden_dim)
+    block_n = 512
+    num_blocks = triton.cdiv(hidden_dim, block_n)
+    _reduce_grouped[(num_blocks * token_num,)](
+        flat,
+        flat.stride(0),
+        flat.stride(1),
+        flat.stride(2),
+        out,
+        out.stride(0),
+        out.stride(1),
+        None,
+        flat.shape[0],
+        flat.shape[1],
+        flat.shape[2],
+        num_blocks,
+        False,
+        1.0,
+        1.0,
+        1,
+        BLOCK_N=block_n,
+        EVEN_N=(hidden_dim % block_n == 0),
+        K=topk,
+        SWIGLU_ADD_RESIDUAL=True,
+        USE_TDM=False,
+        Residual=out,
+        stride_extres_m=0,
+        stride_extres_n=0,
+        HAS_EXT_RESIDUAL=False,
+        num_warps=2,
+    )
+    return out

--- a/op_tests/test_fused_moe_arch_dispatch.py
+++ b/op_tests/test_fused_moe_arch_dispatch.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from importlib import import_module
+
+import pytest
+import torch
+
+from aiter import ActivationType, QuantType, dtypes
+
+fused_moe = import_module("aiter.fused_moe")
+
+
+def _dsv4_mxfp4_cfg(**overrides):
+    cfg = {
+        "token": 1,
+        "model_dim": 4096,
+        "inter_dim": 2048,
+        "expert": 256,
+        "topk": 6,
+        "dtype": dtypes.bf16,
+        "q_dtype_a": dtypes.bf16,
+        "q_dtype_w": dtypes.fp4x2,
+        "q_type": QuantType.per_1x32,
+        "use_g1u1": True,
+        "activation": ActivationType.Silu,
+        "doweight_stage1": False,
+        "hidden_pad": 0,
+        "intermediate_pad": 0,
+        "is_shuffled": False,
+        "gate_mode": fused_moe.GateMode.SEPARATED,
+        "is_ep": False,
+        "has_stage2_bias": False,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+@pytest.mark.parametrize("gfx", ["gfx942", "gfx1100", "gfx1201", "gfx1250"])
+def test_ck_2stage_per_1x32_fails_closed(monkeypatch, gfx):
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: gfx)
+
+    with pytest.raises(
+        RuntimeError,
+        match=rf"only executable on gfx950.*architecture-empty kernel on {gfx}",
+    ):
+        fused_moe._require_ck_2stage_quant_arch(QuantType.per_1x32)
+
+
+def test_ck_2stage_per_1x32_admits_gfx950(monkeypatch):
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: "gfx950")
+
+    fused_moe._require_ck_2stage_quant_arch(QuantType.per_1x32)
+
+
+@pytest.mark.parametrize("gfx", ["gfx942", "gfx1100", "gfx1201", "gfx1250"])
+def test_ck_2stage_other_quantization_is_unchanged(monkeypatch, gfx):
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: gfx)
+
+    fused_moe._require_ck_2stage_quant_arch(QuantType.per_128x128)
+
+
+@pytest.mark.parametrize("inter_dim", [2048, 256])
+@pytest.mark.parametrize("token", [1, 64, 65, 2048, 4096])
+def test_dsv4_unshuffled_mxfp4_dispatch_selects_gfx1100_triton(
+    monkeypatch, inter_dim, token
+):
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: "gfx1100")
+    fused_moe.get_2stage_cfgs.cache_clear()
+
+    metadata = fused_moe.get_2stage_cfgs(
+        **_dsv4_mxfp4_cfg(token=token, inter_dim=inter_dim)
+    )
+
+    assert metadata.stage1.func is fused_moe._triton_mxfp4_a16w4_stage1
+    assert metadata.stage2.func is fused_moe._triton_mxfp4_a16w4_stage2
+    assert metadata.block_m == 16
+    assert metadata.ksplit == 1
+    assert metadata.prequant is False
+    assert metadata.skip_inter_quant is True
+    assert metadata.stage1.keywords["config"] == fused_moe._GFX1100_TRITON_MXFP4_CONFIG
+    assert metadata.stage2.keywords["config"] == fused_moe._GFX1100_TRITON_MXFP4_CONFIG
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"token": 0},
+        {"token": 4097},
+        {"model_dim": 7168},
+        {"inter_dim": 1024},
+        {"expert": 8},
+        {"expert": 32},
+        {"topk": 5},
+        {"dtype": dtypes.fp16},
+        {"q_dtype_a": dtypes.fp4x2},
+        {"q_dtype_w": dtypes.fp8},
+        {"q_type": QuantType.per_1x128},
+        {"use_g1u1": False},
+        {"activation": ActivationType.Gelu},
+        {"doweight_stage1": True},
+        {"hidden_pad": 64},
+        {"intermediate_pad": 128},
+        {"inter_dim": 256, "intermediate_pad": 64},
+        {"is_shuffled": True},
+        {"gate_mode": fused_moe.GateMode.INTERLEAVE},
+        {"is_ep": True},
+        {"has_stage2_bias": True},
+    ],
+)
+def test_gfx1100_triton_mxfp4_contract_rejects_nonmatching_inputs(
+    monkeypatch, override
+):
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: "gfx1100")
+
+    assert (
+        fused_moe._gfx1100_triton_mxfp4_metadata(**_dsv4_mxfp4_cfg(**override)) is None
+    )
+
+
+def test_gfx1100_triton_mxfp4_contract_does_not_claim_gfx950(monkeypatch):
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: "gfx950")
+
+    assert fused_moe._gfx1100_triton_mxfp4_metadata(**_dsv4_mxfp4_cfg()) is None
+
+
+def test_dsv4_unshuffled_mxfp4_dispatch_still_rejects_a4w4_gfx1100(monkeypatch):
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: "gfx1100")
+    monkeypatch.setattr(fused_moe, "get_cu_num", lambda: 96)
+    monkeypatch.setattr(fused_moe, "is_flydsl_available", lambda: False)
+    fused_moe.get_2stage_cfgs.cache_clear()
+    fused_moe.get_block_size_M.cache_clear()
+
+    with pytest.raises(RuntimeError, match="architecture-empty kernel on gfx1100"):
+        fused_moe.get_2stage_cfgs(**_dsv4_mxfp4_cfg(q_dtype_a=dtypes.fp4x2))
+
+
+def test_dsv4_gfx1100_entrypoint_selects_bf16_activation(monkeypatch):
+    class FakeTensor:
+        def __init__(self, shape, dtype):
+            self.shape = shape
+            self.dtype = dtype
+
+    captured = {}
+
+    def capture_cfg(*args, **_kwargs):
+        captured["q_dtype_a"] = args[6]
+        raise LookupError("dispatch captured")
+
+    monkeypatch.setattr(fused_moe, "get_gfx", lambda: "gfx1100")
+    monkeypatch.setattr(fused_moe, "is_flydsl_available", lambda: False)
+    monkeypatch.setattr(fused_moe, "get_2stage_cfgs", capture_cfg)
+
+    with pytest.raises(LookupError, match="dispatch captured"):
+        fused_moe._fused_moe_impl(
+            hidden_states=FakeTensor((1, 4096), dtypes.bf16),
+            w1=FakeTensor((256, 4096, 2048), dtypes.fp4x2),
+            w2=FakeTensor((256, 4096, 1024), dtypes.fp4x2),
+            topk_weight=FakeTensor((1, 6), dtypes.fp32),
+            topk_ids=FakeTensor((1, 6), dtypes.i32),
+            quant_type=QuantType.per_1x32.value,
+        )
+
+    assert captured["q_dtype_a"] == dtypes.bf16
+
+
+def test_triton_mxfp4_unit_scales_are_cached_per_device_and_expert_count():
+    fused_moe._TRITON_MXFP4_UNIT_SCALES.clear()
+    tensor = torch.empty(1)
+
+    a_scale_1, b_scale_1 = fused_moe._triton_mxfp4_unit_scales(tensor, 256)
+    a_scale_2, b_scale_2 = fused_moe._triton_mxfp4_unit_scales(tensor, 256)
+    _, b_scale_3 = fused_moe._triton_mxfp4_unit_scales(tensor, 8)
+
+    assert a_scale_1 is a_scale_2
+    assert b_scale_1 is b_scale_2
+    assert a_scale_1.shape == (1,)
+    assert b_scale_1.shape == (256,)
+    assert b_scale_3.shape == (8,)
+    assert torch.equal(a_scale_1, torch.ones_like(a_scale_1))
+    assert torch.equal(b_scale_1, torch.ones_like(b_scale_1))
+
+
+@pytest.mark.parametrize(
+    "extra_kwargs, expected",
+    [
+        ({}, (False, 1, 0.0)),
+        (
+            {
+                "sorted_token_ids_are_packed": True,
+                "sorted_top_k": 6,
+                "swiglu_limit": 10.0,
+            },
+            (True, 6, 10.0),
+        ),
+    ],
+)
+def test_triton_mxfp4_silu_forwards_sorting_and_clamp_contract(
+    monkeypatch, extra_kwargs, expected
+):
+    triton_moe = import_module("aiter.ops.triton.moe.moe_op_mxfp4_silu_fused")
+    captured = {}
+
+    class FakeKernel:
+        def __getitem__(self, _grid):
+            def launch(*_args, **kwargs):
+                captured.update(kwargs)
+
+            return launch
+
+    monkeypatch.setattr(triton_moe, "_fused_moe_kernel_mxfp4_silu", FakeKernel())
+    triton_moe.fused_moe_mxfp4_silu(
+        torch.empty((1, 128), dtype=torch.bfloat16),
+        torch.empty((1, 64, 64), dtype=torch.uint8),
+        torch.empty((1, 32), dtype=torch.bfloat16),
+        torch.ones((1,), dtype=torch.float32),
+        torch.ones((1,), dtype=torch.float32),
+        None,
+        torch.ones((1, 64, 4), dtype=torch.uint8),
+        torch.ones((1, 1), dtype=torch.float32),
+        torch.zeros((1, 1), dtype=torch.int64),
+        torch.zeros((16,), dtype=torch.int32),
+        torch.zeros((1,), dtype=torch.int32),
+        torch.tensor([16], dtype=torch.int32),
+        False,
+        1,
+        False,
+        False,
+        fused_moe._GFX1100_TRITON_MXFP4_CONFIG,
+        triton_moe.tl.bfloat16,
+        **extra_kwargs,
+    )
+
+    assert captured["SORTED_IDS_PACKED"] is expected[0]
+    assert captured["SORTED_TOP_K"] == expected[1]
+    assert captured["SWIGLU_LIMIT"] == expected[2]
+
+
+@pytest.mark.parametrize(
+    "extra_kwargs, expected",
+    [
+        ({}, (False, 1)),
+        (
+            {"sorted_token_ids_are_packed": True, "sorted_top_k": 6},
+            (True, 6),
+        ),
+    ],
+)
+def test_triton_mxfp4_forwards_sorting_contract(monkeypatch, extra_kwargs, expected):
+    triton_moe = import_module("aiter.ops.triton.moe.moe_op_mxfp4")
+    captured = {}
+
+    class FakeKernel:
+        def __getitem__(self, _grid):
+            def launch(*_args, **kwargs):
+                captured.update(kwargs)
+
+            return launch
+
+    monkeypatch.setattr(triton_moe, "_fused_moe_kernel_mxfp4", FakeKernel())
+    triton_moe.fused_moe_mxfp4(
+        torch.empty((1, 128), dtype=torch.bfloat16),
+        torch.empty((1, 64, 64), dtype=torch.uint8),
+        torch.empty((1, 1, 64), dtype=torch.bfloat16),
+        torch.ones((1,), dtype=torch.float32),
+        torch.ones((1,), dtype=torch.float32),
+        None,
+        torch.ones((1, 64, 4), dtype=torch.uint8),
+        torch.ones((1, 1), dtype=torch.float32),
+        torch.zeros((1, 1), dtype=torch.int64),
+        torch.zeros((16,), dtype=torch.int32),
+        torch.zeros((1,), dtype=torch.int32),
+        torch.tensor([16], dtype=torch.int32),
+        True,
+        1,
+        False,
+        False,
+        fused_moe._GFX1100_TRITON_MXFP4_CONFIG,
+        triton_moe.tl.bfloat16,
+        **extra_kwargs,
+    )
+
+    assert captured["SORTED_IDS_PACKED"] is expected[0]
+    assert captured["SORTED_TOP_K"] == expected[1]
+
+
+def test_reduce_topk_launches_contiguous_fp32_group_reduction(monkeypatch):
+    triton_reduce = import_module("aiter.ops.triton.moe.reduce")
+    captured = {}
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            captured["grid"] = grid
+
+            def launch(*args, **kwargs):
+                captured["args"] = args
+                captured["kwargs"] = kwargs
+
+            return launch
+
+    monkeypatch.setattr(triton_reduce, "_reduce_grouped", FakeKernel())
+    x = torch.empty((3, 6, 1024), dtype=torch.bfloat16)
+    out = torch.empty((3, 1024), dtype=torch.bfloat16)
+
+    returned = triton_reduce.reduce_topk(x, out)
+
+    assert returned is out
+    assert captured["grid"] == (6,)
+    assert captured["args"][8:12] == (1, 18, 1024, 2)
+    assert captured["kwargs"]["K"] == 6
+    assert captured["kwargs"]["EVEN_N"] is True
+    assert captured["kwargs"]["USE_TDM"] is False
+    assert captured["kwargs"]["HAS_EXT_RESIDUAL"] is False


### PR DESCRIPTION
## Motivation

AITER's two-stage `per_1x32` MXFP4 MoE fallback reaches a gfx950-only CK kernel when no earlier backend claims gfx1100. On Navi 31 this is an architecture-empty launch, so the DeepSeek-V4-Flash separated-SiLU MoE contract has no executable AITER route.

This PR adds one narrowly gated Triton A16W4 route for gfx1100. It reuses AITER's existing MXFP4 kernels instead of adding a second GEMM implementation.

## Contract and implementation

The new dispatch only claims:

- gfx1100, `1 <= tokens <= 4096`
- hidden size 4096
- MoE intermediate size 2048, or local size 256 for TP8
- 256 routed experts, top-k 6
- BF16 activation/output, MXFP4 weights, `per_1x32`
- G1U1, separated SiLU, unshuffled weights
- no EP mask, stage-2 bias, or hidden/intermediate padding

Everything else continues through existing dispatch, and non-gfx950 CK `per_1x32` launches now fail closed with an actionable error.

The Triton path:

- decodes AITER's packed sorted-route ABI behind opt-in wrapper flags whose defaults preserve existing callers;
- applies the official DeepSeek SwiGLU clamp (gate upper clamp, up symmetric clamp) before SiLU;
- keeps the stage-1 intermediate in BF16;
- applies routing weights in stage 2 and reduces the six contiguous routes in FP32;
- caches immutable unit scales per device/expert count.

The shape and activation contract was checked against the official [DeepSeek-V4-Flash-0731 ModelScope checkpoint](https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Flash-0731), the official model config/inference code, and [deepseek-ai/TileKernels](https://github.com/deepseek-ai/TileKernels). The official inference code is the numerical contract; TileKernels is an algorithmic reference here and is not executable on gfx1100.

## W7900 validation

Environment: 8 x gfx1100 (Radeon PRO W7900), ROCm 7.2.1, PyTorch `2.9.1+gitff65f5b`, Triton 3.5.1, and AITER main `7e08acdbbe2ce0fceb74caac1629331894423565`. No `HSA_OVERRIDE_GFX_VERSION` was used.

Latest-main unit/static gates:

```text
pytest -q op_tests/test_fused_moe_arch_dispatch.py
49 passed, 4 warnings in 10.64s

black 26.3.0 --check <8 changed files>
8 files would be left unchanged

ruff 0.15.7 check <8 changed files>
All checks passed
```

The pre-existing `op_tests/triton_tests/moe/test_moe_mx.py` suite reports `56 skipped` on gfx1100, so this PR adds explicit architecture/ABI/dispatch coverage rather than claiming existing Navi coverage.

The operator matrix replays expert IDs captured from formal-checkpoint serving. Activations, route weights, and packed MXFP4 weights are deterministic synthetic fixtures; this is real routing, not a claim that checkpoint tensors were exported into the microbenchmark.

Route-aware stage1 + stage2 results (median):

| tokens | worst tested layer ms | logical TF/s |
|---:|---:|---:|
| 1 | 0.388 | 0.097 |
| 64 | 0.902 | 2.678 |
| 65 | 1.361 | 1.803 |
| 512 | 2.160 | 8.948 |
| 2048 | 4.121 | 18.762 |
| 4096 | 7.192 | 21.499 |

Across the full decode/prefill and representative/worst-route matrices: close fraction `0.9995-0.99975`, relative L2 `0.00388-0.00413`, cosine `>=0.999991`, finite output, and bitwise-identical repeat output. Boundary canaries pass at 1/64/65/4096 tokens; 4097 fails closed.

These are aggregate numerical gates, not a strict elementwise-allclose claim: `torch.allclose(atol=0.1, rtol=0.1)` is false for a small tail of elements. The reported close-fraction, relative-L2, cosine, max-absolute, canary, and repeat thresholds all pass.

There is no before/after speedup claim: before this change the gfx1100 path is not executable. The table is an absolute correctness/performance baseline.

## Full-system boundary

The exact latest-main candidate also completed three cache-flushed TP8 B1/S2048/T1 requests against the formal checkpoint: `6.895 / 6.982 / 6.694 s`, all HTTP 200 with `cached_tokens=0` (median about 297 prompt tok/s).

That system test required a separate, temporary guard outside this PR: current `tuned_gemm.py` selects `wv_splitk_small_fp16_bf16_kernel` on gfx1100, while the Navi branch in `csrc/kernels/custom_kernels.cu` is `UNREACHABLE_CODE`. Without the guard the full model device-asserts at that independent GEMM. The temporary guard only makes gfx1100 fall back to Torch for those skinny BF16 GEMMs; it is deliberately not included here and the full-system number is not attributed to this MoE change.

That independent whole-stack gap remains explicit and outside this PR. The MoE
operator route itself was tested without that workaround. The narrow operator
contract is now current-main qualified, so this PR is ready for focused review
without adding the unrelated skinny-BF16 fallback.

## 2026-08-12 current-main readiness refresh

- Public head `293b8f24` merges without conflict into AITER main `49960c1e`;
  exact W7900D-tested merge tree `1ac72881`, still the original eight files
  and `+767/-9`.
- Black 26.3.0, Ruff 0.16.0 and byte compilation pass; the focused suite is
  49/49 on native gfx1100 with no HSA override.
- Three independent processes cover 51 decode/prefill/worst-padding cases.
  Every correctness and bitwise-repeat gate passes, all 18 guard canaries pass,
  and all nine M4097 probes fail closed.
- Median-of-three-process medians stay within `-3.21%` to `+2.97%` of the
  prior exact-source compatibility run. This is compatibility evidence, not a
  speedup claim.
- The matched unmodified-main M65 control still selects CK and writes all-zero
  output (`0/266240`, relative L2 `1.0`). The candidate selects the Triton
  route and passes (`266220/266240`, relative L2 `0.00410422`, cosine
  `0.99999154`). The all-zero baseline timing is not used as a denominator.

Raw JSON, exact source identities, three-process aggregation and the harness:
https://gist.github.com/skyguan92/3ed9f6f7267aec01e91a70007e5af4fa

## Compatibility

- No new dependency.
- Existing Triton MXFP4 wrapper behavior is unchanged by default.
- The dispatch is fail-closed outside the listed contract.
- Related historical Navi work: #2056. Open #4400 (gfx950 emsort), #4398 (gfx950 INTERLEAVE), and #4502 (gfx942/gfx950 SiTUv2) target different architectures/contracts.

## Submission checklist

- [x] Based on current AITER main
- [x] DCO sign-off present
- [x] Black, Ruff, byte-compilation, and diff checks pass
- [x] Real gfx1100 operator correctness/performance matrix captured
- [x] Exact-source TP8 full-model integration exercised with the independent GEMM boundary disclosed above
