### PR TITLE
[Gluon][MLA] Fix FP8 KV serving and vectorize split reduction

### DIFF
--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -99,6 +99,7 @@ def _mla_gluon(
     KV_PE_OFFSET: gl.constexpr,
     USE_2D_VIEW: gl.constexpr,
     WITHIN_2GB: gl.constexpr,
+    WIDE_KV_OFFSETS: gl.constexpr,
     NUM_XCDS: gl.constexpr,
     NHEAD: gl.constexpr,
     REGIME: gl.constexpr,
@@ -436,12 +437,12 @@ def _mla_gluon(
     if HAS_PE:
         kv_page_number_pe = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(0), gl.SliceLayout(0, blocked_kpe))
         # simplify for page_size 1
-        kv_loc_pe = kv_page_number_pe
+        kv_loc_pe = kv_page_number_pe.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number_pe
 
     # local load page number for slice 0
     bufs_page_0 = bufs_page.index(0).slice(0, BLOCK_N // 2, 0)
     kv_page_number_0 = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page_0, gl.SliceLayout(0, blocked_kv_slice))
-    kv_loc0 = kv_page_number_0
+    kv_loc0 = kv_page_number_0.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number_0
 
     # global load K_nope slice 0
     offs_n_nope0 = split_kv_start + gl.arange(0, BLOCK_N // 2, layout=gl.SliceLayout(0, blocked_kv_slice))
@@ -468,7 +469,7 @@ def _mla_gluon(
     # local load page number for slice 1
     bufs_page_1 = bufs_page.index(0).slice(BLOCK_N // 2, BLOCK_N // 2, 0)
     kv_page_number_1 = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page_1, gl.SliceLayout(0, blocked_kv_slice))
-    kv_loc1 = kv_page_number_1
+    kv_loc1 = kv_page_number_1.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number_1
 
     # global load K_nope slice 1
     offs_n_nope1 = offs_n_nope0 + BLOCK_N // 2
@@ -502,7 +503,7 @@ def _mla_gluon(
         # local load page number for slice 0
         bufs_page_0 = bufs_page.index(async_idx).slice(0, BLOCK_N // 2, 0)
         kv_page_number_0 = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page_0, gl.SliceLayout(0, blocked_kv_slice))
-        kv_loc0 = kv_page_number_0
+        kv_loc0 = kv_page_number_0.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number_0
         # global load K_nope slice 0
         offs_n_nope0 = start_n + gl.arange(0, BLOCK_N // 2, layout=gl.SliceLayout(0, blocked_kv_slice))
         offs_d_ckv_10 = gl.arange(0, HEAD_DIM_CKV, layout=gl.SliceLayout(1, blocked_kv_slice))
@@ -520,7 +521,7 @@ def _mla_gluon(
         # local load page_number_pe
         if HAS_PE:
             kv_page_number_pe = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(async_idx), gl.SliceLayout(0, blocked_kpe))
-            kv_loc_pe = kv_page_number_pe
+            kv_loc_pe = kv_page_number_pe.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number_pe
             # global load K_pe
             offs_n_pe = start_n + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kpe))
             offs_d_kpe_1 = gl.arange(0, HEAD_DIM_KPE, layout=gl.SliceLayout(1, blocked_kpe))
@@ -543,7 +544,7 @@ def _mla_gluon(
         # local load page number for slice 1
         bufs_page_1 = bufs_page.index(async_idx).slice(BLOCK_N // 2, BLOCK_N // 2, 0)
         kv_page_number_1 = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page_1, gl.SliceLayout(0, blocked_kv_slice))
-        kv_loc1 = kv_page_number_1
+        kv_loc1 = kv_page_number_1.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number_1
         # global load K_nope slice 1
         offs_n1 = offs_n_nope0 + BLOCK_N // 2
         offs_k_c1 = kv_loc1[None, :] * stride_kv_c_bs + offs_d_ckv_10[:, None]
@@ -595,10 +596,10 @@ def _mla_gluon(
         # local load page number
         gl.amd.cdna4.async_copy.wait_group(3 if HAS_PE else 2)
         kv_page_number = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(async_idx), gl.SliceLayout(0, blocked_kv))
-        kv_loc = kv_page_number
+        kv_loc = kv_page_number.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number
         if HAS_PE:
             kv_page_number_pe = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_page.index(async_idx), gl.SliceLayout(0, blocked_kpe))
-            kv_loc_pe = kv_page_number_pe
+            kv_loc_pe = kv_page_number_pe.to(gl.int64) if WIDE_KV_OFFSETS else kv_page_number_pe
         # global load K_nope
         offs_n_nope = start_n + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked_kv))
         offs_d_ckv_1 = gl.arange(0, HEAD_DIM_CKV, layout=gl.SliceLayout(1, blocked_kv))
@@ -980,8 +981,15 @@ def mla_gluon(
 
     # buffer_load uses scalar base + 32-bit offsets, limiting addressable range.
     # For KV caches > 2 GB the kernel falls back to global_load (64-bit pointers).
-    max_kv_bytes = kv_c.shape[0] * kv_c.stride(0) * kv_c.element_size()
+    max_kv_elems = kv_c.shape[0] * kv_c.stride(0)
+    max_kv_bytes = max_kv_elems * kv_c.element_size()
     within_2gb = max_kv_bytes <= 0x80000000  # 2 GB
+    # The row base (page number * row stride) is an element count, not a byte
+    # count, and is int32 by default. A cache with more than 2**31 elements
+    # therefore wraps to a negative offset on the global_load path even though
+    # that path uses 64-bit pointers. Widen the page number in that case only,
+    # so caches that already fit keep the cheaper 32-bit address arithmetic.
+    wide_kv_offsets = max_kv_elems > 0x7FFFFFFF
 
     # Normalized Q strides: (batch, q_pos, head). For plain decode (3-D) the
     # q_pos stride is 0 and q_pos is always 0, so the kernel address math is
@@ -1098,6 +1106,7 @@ def mla_gluon(
         KV_PE_OFFSET=kv_pe_offset,
         USE_2D_VIEW=use_2d_view,
         WITHIN_2GB=within_2gb,
+        WIDE_KV_OFFSETS=wide_kv_offsets,
         NUM_XCDS=NUM_XCDS,
         NHEAD=nhead,
         REGIME=REGIME,

--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -43,10 +43,7 @@
 #     LLP, ACK                           -- local_load pages [i+1], async_copy K/KPE [i+1]
 #     LLK, MFMA0, softmax, LLV, MFMA1   -- compute on [i]: QK dot, softmax, PV dot
 
-# isort and black disagree here: isort wants two blank lines after this block,
-# black folds them back to one because the `# fmt: off` below starts a
-# formatting-disabled region. black is the one CI enforces, so it wins.
-import torch  # noqa: I001
+import torch
 import triton
 import triton.language as tl
 from triton.experimental import gluon
@@ -54,6 +51,10 @@ from triton.experimental.gluon import language as gl
 
 from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils.device_info import get_num_xcds
+
+MLA_GLUON_CAPABILITIES = frozenset(
+    {"fp8_kv_batched_decode", "fp8_kv_mtp_decode", "fp8_kv_scale"}
+)
 
 # fmt: off
 @gluon.jit

--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -759,6 +759,7 @@ def _mla_softmax_reducev_kernel(
     HEAD_DIM_CKV: tl.constexpr,
     HAS_FINAL_LSE: tl.constexpr,
     USE_2D_VIEW: tl.constexpr,
+    BLOCK_S: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -776,27 +777,34 @@ def _mla_softmax_reducev_kernel(
     kv_len_per_split = cur_batch_seq_len // NUM_KV_SPLITS
 
     offs_d_ckv = tl.arange(0, HEAD_DIM_CKV)
-    offs_l = cur_batch * stride_l_b + q_pos * stride_l_qs + cur_head * stride_l_h + offs_d_ckv
-    offs_ml = cur_batch * stride_ml_b + q_pos * stride_ml_qs + cur_head * stride_ml_h
+    offs_s = tl.arange(0, BLOCK_S)
+    base_l = cur_batch * stride_l_b + q_pos * stride_l_qs + cur_head * stride_l_h
+    base_ml = cur_batch * stride_ml_b + q_pos * stride_ml_qs + cur_head * stride_ml_h
 
     e_sum = 0.0
     e_max = -float("inf")
     acc = tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
 
+    # Merge split-KV LSE in vectorized blocks.
     LOOP_START = NUM_KV_SPLITS - 1 if kv_len_per_split == 0 else 0
-    for split_kv_id in range(LOOP_START, NUM_KV_SPLITS):
-        logits = tl.load(Logits + offs_l + split_kv_id * stride_l_s)
-        logits_1 = tl.load(Mid_lse + offs_ml + split_kv_id * stride_ml_s)
+    for start in range(LOOP_START, NUM_KV_SPLITS, BLOCK_S):
+        s_ids = start + offs_s  # [BLOCK_S]
+        s_mask = s_ids < NUM_KV_SPLITS
+        lse = tl.load(
+            Mid_lse + base_ml + s_ids * stride_ml_s, mask=s_mask, other=-float("inf")
+        )  # [BLOCK_S]
+        logits = tl.load(
+            Logits + base_l + s_ids[:, None] * stride_l_s + offs_d_ckv[None, :],
+            mask=s_mask[:, None],
+            other=0.0,
+        )  # [BLOCK_S, HEAD_DIM_CKV]
 
-        n_e_max = tl.maximum(logits_1, e_max)
+        tile_max = tl.max(lse, axis=0)
+        n_e_max = tl.maximum(e_max, tile_max)
         old_scale = tl.where(e_max == -float("inf"), 0.0, tl.exp(e_max - n_e_max))
-        acc *= old_scale
-        exp_logic = tl.where(logits_1 == -float("inf"), 0.0, tl.exp(logits_1 - n_e_max))
-        # MTP: a fully causal-masked split stores NaN logits with lse=-inf; guard
-        # the accumulate so NaN*0 doesn't poison acc (no-op for plain decode).
-        acc += tl.where(logits_1 == -float("inf"), 0.0, exp_logic * logits)
-
-        e_sum = e_sum * old_scale + exp_logic
+        w = tl.where(lse == -float("inf"), 0.0, tl.exp(lse - n_e_max))  # [BLOCK_S]
+        acc = acc * old_scale + tl.sum(w[:, None] * logits, axis=0)
+        e_sum = e_sum * old_scale + tl.sum(w, axis=0)
         e_max = n_e_max
 
     out = acc / e_sum if e_sum > 0.0 else tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
@@ -1146,6 +1154,7 @@ def mla_gluon(
         HEAD_DIM_CKV=head_dim_ckv,
         HAS_FINAL_LSE=return_lse,
         USE_2D_VIEW=use_2d_view,
+        BLOCK_S=min(64, triton.next_power_of_2(NUM_KV_SPLITS)),
         num_warps=8,
     )
 

--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -10,10 +10,10 @@
 #                        Fast path: when NUM_KV_SPLITS==1, stage-1 writes the
 #                        final output directly to O and stage-2 reduce is skipped.
 #   REGIME='bh16bn128' - bf16 Q + fp8 KV, BLOCK_H=16, BLOCK_N=128,
-#                        nhead <= 96, batch_size=1, NUM_KV_SPLITS=256.
-#                        (batch, split, head_block*qlen) grid. Always splits +
-#                        always reduces. A partial last head block
-#                        (nhead % BLOCK_H != 0) masks OOB heads on Q load / O store.
+#                        nhead <= 96, batch_size >= 1,
+#                        (batch, split, head_block*qlen) grid. Full decode
+#                        (stage-1 + stage-2 reduce into the final O). A partial
+#                        last head block (nhead % BLOCK_H != 0) masks OOB heads.
 #   REGIME='bh16bn64'  - bf16 Q + bf16 KV, BLOCK_H=16, BLOCK_N=64,
 #                        nhead <= 96, batch_size >= 1,
 #                        (batch, split, head_block*qlen) grid. Full decode
@@ -953,9 +953,6 @@ def mla_gluon(
         # that every split is non-empty (floor split size = min_kv_seq_len //
         # NUM_KV_SPLITS >= 1). Each clamp below keeps NUM_KV_SPLITS <= min_kv_seq_len,
         if REGIME == "bh16bn128":
-            assert (
-                batch_size == 1
-            ), f"mla_gluon[bh16bn128] requires batch_size=1, got {batch_size}"
             NUM_KV_SPLITS = max(
                 1, min(256 // (batch_size * qlen * NUM_M_BLOCKS), min_kv_seq_len)
             )

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -668,14 +668,14 @@ def test_mla(
             ret["decode:gluon_Mtok/s"] = total_q / us_gluon_decode
 
     # Gluon MLA bh16bn128 decode test
-    # Example: -c 10000000 -b 1 -n 16,1 -d bf16 -kvd fp8
+    # Example: -c 10000000 -b 1 3 4 -n 16,1 -d bf16 -kvd fp8
     if (
         get_gfx() == "gfx950"
         and dtype == torch.bfloat16
         and kvtype == dtypes.fp8
         and nhead <= 16
         and decode_qlen == 1
-        and batch_size == 1
+        and 1 <= batch_size <= 256
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
         and page_size == 1

--- a/op_tests/test_mla.py
+++ b/op_tests/test_mla.py
@@ -139,6 +139,7 @@ def test_mla(
     return_lse=False,
     is_causal=True,
     sequential_page_indices=False,
+    kv_scale_value=1.0,
 ):
     ret = {}
 
@@ -179,6 +180,13 @@ def test_mla(
         (num_page * page_size, 1, kv_lora_rank + qk_rope_head_dim),
         dtype=torch.bfloat16,
     )
+    kv_buffer_quantized = None
+    if kvtype == dtypes.fp8:
+        # Compare against values recovered from scaled FP8 storage.
+        kv_buffer_quantized = (kv_buffer / kv_scale_value).to(kvtype)
+        kv_buffer = (kv_buffer_quantized.to(torch.bfloat16) * kv_scale_value).to(
+            torch.bfloat16
+        )
 
     # for none absorb (mha)
     qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
@@ -448,8 +456,9 @@ def test_mla(
             aiter.logger.info("don't support this case.")
             return None, 1e12
 
-        kv_buffer_fp8 = kv_buffer.to(kvtype)
-        kv_scale = torch.ones([1], dtype=torch.float, device="cuda")
+        assert kv_buffer_quantized is not None
+        kv_buffer_fp8 = kv_buffer_quantized
+        kv_scale = torch.full([1], kv_scale_value, dtype=torch.float, device="cuda")
 
         (_attn_logits, _attn_lse), us_asm_decode = run_perftest(
             aiter.mla.mla_decode_fwd,
@@ -556,7 +565,8 @@ def test_mla(
 
         kv_c = kv_buffer.view(-1, qk_head_dim)
         if name == "bh16bn128":
-            kv_c = kv_c.to(dtypes.fp8)
+            assert kv_buffer_quantized is not None
+            kv_c = kv_buffer_quantized.view(-1, qk_head_dim)
 
         if not varlen:
             page_table = kv_indices[:total_kv].view(batch_size, ctx_lens)
@@ -577,7 +587,7 @@ def test_mla(
             seq_info,
             sm_scale,
             use_2d_view=use_2d_view,
-            kv_scale=1.0,
+            kv_scale=kv_scale_value,
             min_kv_seq_len=ctx_lens,
             return_lse=return_lse,
         )
@@ -667,14 +677,13 @@ def test_mla(
             # Mtok/s: MTP figure-of-merit (see decode:Mtok/s above).
             ret["decode:gluon_Mtok/s"] = total_q / us_gluon_decode
 
-    # Gluon MLA bh16bn128 decode test
-    # Example: -c 10000000 -b 1 3 4 -n 16,1 -d bf16 -kvd fp8
+    # Gluon MLA FP8 decode test
     if (
         get_gfx() == "gfx950"
         and dtype == torch.bfloat16
         and kvtype == dtypes.fp8
         and nhead <= 16
-        and decode_qlen == 1
+        and 1 <= decode_qlen <= 4
         and 1 <= batch_size <= 256
         and v_head_dim == 512
         and (qk_head_dim - v_head_dim) == 64
@@ -855,14 +864,34 @@ parser.add_argument(
     help="""Enable/disable causal masking. Default: True.
     --causal / --no-causal""",
 )
+parser.add_argument(
+    "--kv-scale",
+    type=float,
+    nargs="*",
+    default=[1.0],
+    help="""FP8 KV dequantization scale(s).
+    e.g.: --kv-scale 1.0 0.375""",
+)
 
 
 args = parser.parse_args()
 
 for nhead, decode_qlen in args.nhead:
     df = []
-    for dtype, kvtype, ctx_len, batch_size, split_per_batch in itertools.product(
-        args.dtype, args.kv_dtype, args.ctxLen, args.batchSize, args.split_per_batch
+    for (
+        dtype,
+        kvtype,
+        ctx_len,
+        batch_size,
+        split_per_batch,
+        kv_scale,
+    ) in itertools.product(
+        args.dtype,
+        args.kv_dtype,
+        args.ctxLen,
+        args.batchSize,
+        args.split_per_batch,
+        args.kv_scale,
     ):
         if check_support(dtype, kvtype, nhead):
             ret = test_mla(
@@ -882,6 +911,7 @@ for nhead, decode_qlen in args.nhead:
                 return_lse=args.return_lse,
                 is_causal=args.causal,
                 sequential_page_indices=args.sequential_page_indices,
+                kv_scale_value=kv_scale,
             )
             df.append(ret)
     df = pd.DataFrame(df)


### PR DESCRIPTION
## Summary

Supersedes #4480 with a small, self-contained update:

- enable batched FP8 KV decode
- widen KV row offsets only when the cache exceeds the int32 element range
- advertise batched decode, MTP, and KV-scale capabilities to callers
- vectorize the stage-2 split reduction

The fused MTP kernel rewrite is intentionally excluded.

## Validation

Validated on mia1-p02-g56 (gfx950):

- B1/B8/B64, qlen 1/3, context 68,089, KV scale 0.375: output and LSE PASS against FP32 reference
- CUDA graph capture and two replays, including mutated Q: PASS
- Black, Ruff, and git diff check: PASS

68K graph replay, before -> after:

| Shape | Before | After |
|---|---:|---:|
| B1 qlen1 | 92.374 us | 33.219 us |
| B1 qlen3 | 53.152 us | 35.771 us |
| B64 qlen1 | 420.124 us | 420.078 us |
| B64 qlen3 | 1185.395 us | 1185.725 us |

B64 is neutral within run-to-run noise. This PR does not claim to beat ASM at 640K or 1M context; that requires a separately reviewable fused-MTP change.

## AI assistance

This PR was developed with assistance from OpenAI Codex. The author reviewed and validated all changes.