### PR TITLE
[FlyDSL] [MoE]: reuse stage-1(gate up) scratch buffer across layers and graph captures

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -77,6 +77,29 @@ _MOE_A8W4_BYPASS_QUANT = os.environ.get("AITER_MOE_A8W4_BYPASS_QUANT", "0") == "
 # so there is no overhead.
 kernel_bench_callable = None
 
+# FlyDSL v2 stage1 produces an intermediate consumed immediately by stage2.
+# Reuse it across layers and CUDA graphs on the same stream instead of retaining
+# one allocation per layer and captured shape. Separate stream keys preserve
+# correctness for overlapping launches, while exact shape keys keep graph-baked
+# pointers stable.
+_FLYDSL_STAGE1_OUT_CACHE: dict[
+    tuple[torch.device, int, tuple[int, int]], torch.Tensor
+] = {}
+
+
+def _get_flydsl_stage1_out(
+    shape: tuple[int, int],
+    device: torch.device,
+) -> torch.Tensor:
+    stream = torch.cuda.current_stream(device=device).cuda_stream
+    key = (device, stream, shape)
+    out = _FLYDSL_STAGE1_OUT_CACHE.get(key)
+    if out is None:
+        out = torch.empty(shape, dtype=dtypes.fp8, device=device)
+        _FLYDSL_STAGE1_OUT_CACHE[key] = out
+    return out
+
+
 # FLAT 1stage asm kernels (manifest flat=1) ingest raw topk_ids /
 # topk_weights through the sorted_* kernarg slots and accumulate via
 # global_atomic_pk_add_bf16, so moe_sorting is a pass-through for them.
@@ -1412,6 +1435,22 @@ def _flydsl_stage1_wrapper(
         raise ValueError(f"Invalid FlyDSL kernel name: {kernelName}")
     if out_dtype is not None:
         parsed = {**parsed, "out_dtype": out_dtype}
+    if (
+        out is None
+        and v2_output_layout
+        and parsed["out_dtype"] == "fp8"
+        and parsed.get("k_batch", 1) == 1
+        # a16w4 allocates and returns its own sorted intermediate before it
+        # looks at `out`, so a buffer handed to it is silently dropped.
+        and not (parsed["a_dtype"] == "bf16" and parsed["b_dtype"] == "fp4")
+    ):
+        device = hidden_states.device
+        inter_dim = w1.shape[1] // 2
+        sorted_rows = max(
+            sorted_token_ids.shape[0],
+            sorted_expert_ids.shape[0] * parsed["tile_m"],
+        )
+        out = _get_flydsl_stage1_out((sorted_rows, inter_dim), device)
     if activation == ActivationType.Swiglu:
         act = "swiglu"
     elif activation == ActivationType.Situv2:

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -81,6 +81,28 @@ _MOE_A8W4_BYPASS_QUANT = os.environ.get("AITER_MOE_A8W4_BYPASS_QUANT", "0") == "
 # so there is no overhead.
 kernel_bench_callable = None
 
+# FlyDSL v2 stage1 produces an intermediate consumed immediately by stage2.
+# Reuse it across layers and CUDA graphs on the same stream instead of retaining
+# one allocation per layer and captured shape. Separate stream keys preserve
+# correctness for overlapping launches, while exact shape keys keep graph-baked
+# pointers stable.
+_FLYDSL_STAGE1_OUT_CACHE: dict[
+    tuple[torch.device, int, tuple[int, int]], torch.Tensor
+] = {}
+
+
+def _get_flydsl_stage1_out(
+    shape: tuple[int, int],
+    device: torch.device,
+) -> torch.Tensor:
+    stream = torch.cuda.current_stream(device=device).cuda_stream
+    key = (device, stream, shape)
+    out = _FLYDSL_STAGE1_OUT_CACHE.get(key)
+    if out is None:
+        out = torch.empty(shape, dtype=dtypes.fp8, device=device)
+        _FLYDSL_STAGE1_OUT_CACHE[key] = out
+    return out
+
 
 # FLAT 1stage asm kernels (manifest flat=1) ingest raw topk_ids /
 # topk_weights through the sorted_* kernarg slots and accumulate via
@@ -1448,6 +1470,22 @@ def _flydsl_stage1_wrapper(
         raise ValueError(f"Invalid FlyDSL kernel name: {kernelName}")
     if out_dtype is not None:
         parsed = {**parsed, "out_dtype": out_dtype}
+    if (
+        out is None
+        and v2_output_layout
+        and parsed["out_dtype"] == "fp8"
+        and parsed.get("k_batch", 1) == 1
+        # a16w4 allocates and returns its own sorted intermediate before it
+        # looks at `out`, so a buffer handed to it is silently dropped.
+        and not (parsed["a_dtype"] == "bf16" and parsed["b_dtype"] == "fp4")
+    ):
+        device = hidden_states.device
+        inter_dim = w1.shape[1] // 2
+        sorted_rows = max(
+            sorted_token_ids.shape[0],
+            sorted_expert_ids.shape[0] * parsed["tile_m"],
+        )
+        out = _get_flydsl_stage1_out((sorted_rows, inter_dim), device)
     if activation == ActivationType.Swiglu:
         act = "swiglu"
     elif activation == ActivationType.Situv2:

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1530,6 +1530,20 @@ def _flydsl_moe_stage1_impl(
             out = torch.empty(
                 (token_num, topk, inter_dim), dtype=torch_out_dtype, device=dev
             )
+    elif _v2_output_layout:
+        # Nothing downstream re-checks a caller-provided buffer -- the kernel
+        # takes out.view(-1) -- so an undersized one is an out-of-bounds write
+        # rather than an error. Callers that size their own buffer duplicate
+        # the padding rule above; fail loudly if the two ever diverge.
+        _expected_shape = (
+            max(sorted_token_ids.shape[0], sorted_expert_ids.shape[0] * tile_m),
+            inter_dim // 2 if _need_fp4 else inter_dim,
+        )
+        if tuple(out.shape) != _expected_shape:
+            raise ValueError(
+                f"stage1 out has shape {tuple(out.shape)}, "
+                f"but the v2 output layout requires {_expected_shape}"
+            )
 
     if _is_splitk:
         torch_tmp_out_dtype = dtypes.bf16 if _base_out_dtype == "bf16" else dtypes.fp16

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1597,6 +1597,20 @@ def _flydsl_moe_stage1_impl(
             out = torch.empty(
                 (token_num, topk, inter_dim), dtype=torch_out_dtype, device=dev
             )
+    elif _v2_output_layout:
+        # Nothing downstream re-checks a caller-provided buffer -- the kernel
+        # takes out.view(-1) -- so an undersized one is an out-of-bounds write
+        # rather than an error. Callers that size their own buffer duplicate
+        # the padding rule above; fail loudly if the two ever diverge.
+        _expected_shape = (
+            max(sorted_token_ids.shape[0], sorted_expert_ids.shape[0] * tile_m),
+            inter_dim // 2 if _need_fp4 else inter_dim,
+        )
+        if tuple(out.shape) != _expected_shape:
+            raise ValueError(
+                f"stage1 out has shape {tuple(out.shape)}, "
+                f"but the v2 output layout requires {_expected_shape}"
+            )
 
     if _is_splitk:
         torch_tmp_out_dtype = dtypes.bf16 if _base_out_dtype == "bf16" else dtypes.fp16

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -1606,6 +1606,11 @@ def _flydsl_moe_stage1_impl(
             max(sorted_token_ids.shape[0], sorted_expert_ids.shape[0] * tile_m),
             inter_dim // 2 if _need_fp4 else inter_dim,
         )
+        if out.dtype != torch_out_dtype:
+            raise ValueError(
+                f"stage1 out has dtype {out.dtype}, "
+                f"but the v2 output layout requires {torch_out_dtype}"
+            )
         if tuple(out.shape) != _expected_shape:
             raise ValueError(
                 f"stage1 out has shape {tuple(out.shape)}, "

--- a/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
@@ -940,3 +940,63 @@ def test_flydsl_e2e_a8w4_situv2(inter_dim, seed, gate_mode):
     _check_close(
         d["ref_stage2"].float(), out.float(), f"situv2_{gate_mode}_e2e_i{inter_dim}"
     )
+
+
+@_SKIP_GFX950_FLYDSL
+def test_flydsl_v2_stage1_result_independent_of_buffer_contents():
+    """A caller-provided v2 stage1 buffer must not leak its prior contents.
+
+    fused_moe hands one buffer to every MoE layer, so whatever the kernel
+    leaves untouched carries the previous layer's output rather than the
+    fresh-allocation garbage a per-call torch.empty produced. Run the same
+    problem twice against differently poisoned buffers: every byte the kernel
+    writes has to agree, and every byte that disagrees has to still hold its
+    own poison, i.e. was never written and is not read downstream.
+    """
+    from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1
+
+    torch.set_default_device("cuda")
+    token, model_dim, inter_dim, E, topk, block_m = 64, 512, 256, 16, 4, 32
+    tile_m = 32
+    d = _generate_a8w4_situv2_vec4_data(
+        token, model_dim, inter_dim, E, topk, block_m, seed=21
+    )
+    sorted_rows = max(
+        d["sorted_ids"].shape[0], d["sorted_expert_ids"].shape[0] * tile_m
+    )
+
+    def run(poison: int) -> torch.Tensor:
+        buf = torch.full(
+            (sorted_rows, inter_dim), poison, dtype=torch.uint8, device="cuda"
+        ).view(dtypes.fp8)
+        out, _scale = flydsl_moe_stage1(
+            a=d["a_q"],
+            w1=d["w1_q_shuf"],
+            sorted_token_ids=d["sorted_ids"],
+            sorted_expert_ids=d["sorted_expert_ids"],
+            num_valid_ids=d["num_valid_ids"],
+            out=buf,
+            topk=d["topk"],
+            tile_m=tile_m,
+            tile_n=256,
+            tile_k=256,
+            a_dtype="fp8",
+            b_dtype="fp4",
+            out_dtype="fp8",
+            act="situv2",
+            situ_beta=SITUV2_BETA,
+            situ_linear_beta=SITUV2_LINEAR_BETA,
+            w1_scale=d["w1_scale_shuf"],
+            a1_scale=d["a_scale_sort"],
+            v2_output_layout=True,
+        )
+        torch.cuda.synchronize()
+        return out.view(torch.uint8)
+
+    first = run(0xA5).clone()
+    second = run(0x5A)
+
+    untouched = first != second
+    assert not bool(untouched.all()), "kernel wrote nothing; the test is vacuous"
+    assert torch.equal(first[untouched], torch.full_like(first[untouched], 0xA5))
+    assert torch.equal(second[untouched], torch.full_like(second[untouched], 0x5A))

--- a/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
@@ -941,3 +941,63 @@ def test_flydsl_e2e_a8w4_situv2(inter_dim, seed, gate_mode):
     _check_close(
         d["ref_stage2"].float(), out.float(), f"situv2_{gate_mode}_e2e_i{inter_dim}"
     )
+
+
+@_SKIP_GFX950_FLYDSL
+def test_flydsl_v2_stage1_result_independent_of_buffer_contents():
+    """A caller-provided v2 stage1 buffer must not leak its prior contents.
+
+    fused_moe hands one buffer to every MoE layer, so whatever the kernel
+    leaves untouched carries the previous layer's output rather than the
+    fresh-allocation garbage a per-call torch.empty produced. Run the same
+    problem twice against differently poisoned buffers: every byte the kernel
+    writes has to agree, and every byte that disagrees has to still hold its
+    own poison, i.e. was never written and is not read downstream.
+    """
+    from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1
+
+    torch.set_default_device("cuda")
+    token, model_dim, inter_dim, E, topk, block_m = 64, 512, 256, 16, 4, 32
+    tile_m = 32
+    d = _generate_a8w4_situv2_vec4_data(
+        token, model_dim, inter_dim, E, topk, block_m, seed=21
+    )
+    sorted_rows = max(
+        d["sorted_ids"].shape[0], d["sorted_expert_ids"].shape[0] * tile_m
+    )
+
+    def run(poison: int) -> torch.Tensor:
+        buf = torch.full(
+            (sorted_rows, inter_dim), poison, dtype=torch.uint8, device="cuda"
+        ).view(dtypes.fp8)
+        out, _scale = flydsl_moe_stage1(
+            a=d["a_q"],
+            w1=d["w1_q_shuf"],
+            sorted_token_ids=d["sorted_ids"],
+            sorted_expert_ids=d["sorted_expert_ids"],
+            num_valid_ids=d["num_valid_ids"],
+            out=buf,
+            topk=d["topk"],
+            tile_m=tile_m,
+            tile_n=256,
+            tile_k=256,
+            a_dtype="fp8",
+            b_dtype="fp4",
+            out_dtype="fp8",
+            act="situv2",
+            situ_beta=SITUV2_BETA,
+            situ_linear_beta=SITUV2_LINEAR_BETA,
+            w1_scale=d["w1_scale_shuf"],
+            a1_scale=d["a_scale_sort"],
+            v2_output_layout=True,
+        )
+        torch.cuda.synchronize()
+        return out.view(torch.uint8)
+
+    first = run(0xA5).clone()
+    second = run(0x5A)
+
+    untouched = first != second
+    assert not bool(untouched.all()), "kernel wrote nothing; the test is vacuous"
+    assert torch.equal(first[untouched], torch.full_like(first[untouched], 0xA5))
+    assert torch.equal(second[untouched], torch.full_like(second[untouched], 0x5A))

--- a/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
@@ -1001,3 +1001,42 @@ def test_flydsl_v2_stage1_result_independent_of_buffer_contents():
     assert not bool(untouched.all()), "kernel wrote nothing; the test is vacuous"
     assert torch.equal(first[untouched], torch.full_like(first[untouched], 0xA5))
     assert torch.equal(second[untouched], torch.full_like(second[untouched], 0x5A))
+
+
+@_SKIP_GFX950_FLYDSL
+def test_flydsl_v2_stage1_rejects_wrong_output_dtype():
+    """A caller-provided v2 stage1 buffer must match the expected output dtype."""
+    from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1
+
+    torch.set_default_device("cuda")
+    token, model_dim, inter_dim, E, topk, block_m = 64, 512, 256, 16, 4, 32
+    tile_m = 32
+    d = _generate_a8w4_situv2_vec4_data(
+        token, model_dim, inter_dim, E, topk, block_m, seed=22
+    )
+    sorted_rows = max(
+        d["sorted_ids"].shape[0], d["sorted_expert_ids"].shape[0] * tile_m
+    )
+    bad_buf = torch.empty((sorted_rows, inter_dim), dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(ValueError, match="stage1 out has dtype"):
+        flydsl_moe_stage1(
+            a=d["a_q"],
+            w1=d["w1_q_shuf"],
+            sorted_token_ids=d["sorted_ids"],
+            sorted_expert_ids=d["sorted_expert_ids"],
+            num_valid_ids=d["num_valid_ids"],
+            out=bad_buf,
+            topk=d["topk"],
+            tile_m=tile_m,
+            tile_n=256,
+            tile_k=256,
+            a_dtype="fp8",
+            b_dtype="fp4",
+            out_dtype="fp8",
+            act="situv2",
+            situ_beta=SITUV2_BETA,
+            situ_linear_beta=SITUV2_LINEAR_BETA,
+            w1_scale=d["w1_scale_shuf"],
+            a1_scale=d["a_scale_sort"],
+            v2_output_layout=True,
+        )

--- a/op_tests/test_flydsl_stage1_out_cache.py
+++ b/op_tests/test_flydsl_stage1_out_cache.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter.fused_moe import (
+    _FLYDSL_STAGE1_OUT_CACHE,
+    _get_flydsl_stage1_out,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_stage1_out_cache():
+    _FLYDSL_STAGE1_OUT_CACHE.clear()
+    yield
+    _FLYDSL_STAGE1_OUT_CACHE.clear()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+def test_flydsl_stage1_out_is_reused_per_stream():
+    device = torch.device("cuda:0")
+    shape = (1024, 1536)
+
+    output = _get_flydsl_stage1_out(shape, device)
+    reused = _get_flydsl_stage1_out(shape, device)
+
+    other_stream = torch.cuda.Stream(device=device)
+    with torch.cuda.stream(other_stream):
+        other_stream_output = _get_flydsl_stage1_out(shape, device)
+
+    assert reused.data_ptr() == output.data_ptr()
+    assert other_stream_output.data_ptr() != output.data_ptr()
+    assert len(_FLYDSL_STAGE1_OUT_CACHE) == 2


### PR DESCRIPTION
A MoE layer runs in two steps: stage 1(gate+up) writes a small intermediate tensor,
stage 2(activation+down) reads it immediately, and nothing else needs it. During CUDA 
graph capture, each captured graph kept its own copy of that buffer (~6.7 GiB/GPU
on Kimi-K3, 652 live allocations in one snapshot).

Reuse one buffer per GPU, CUDA stream, and size from the internal
stage1→stage2 path in fused_moe.py. Standalone flydsl_moe_stage1() callers
are unchanged. Different streams get separate buffers so overlapping work
cannot clobber each other.

When a caller passes its own buffer, check the size in moe_kernels.py —
the kernel does not validate dimensions, so a too-small buffer would
corrupt memory silently.

**Tests**: same-stream reuse vs stream isolation; stage-1 output must not
depend on whatever was left in the buffer from the previous use.