### PR TITLE
Default missing deepseek_yarn original_max_position_embeddings instead of raising

### DIFF
--- a/aiter/rotary_embedding.py
+++ b/aiter/rotary_embedding.py
@@ -36,6 +36,7 @@ from aiter import (
     dtypes,
     fused_qk_norm_mrope_3d_cache_pts_quant_shuffle,
     fused_qk_norm_rope_cache_pts_quant_shuffle,
+    logger,
 )
 
 AITER_ROPE_TRITON_BACKEND = int(os.environ.get("AITER_ROPE_TRITON_BACKEND", "0")) == 1
@@ -1696,6 +1697,26 @@ class DualChunkRotaryEmbedding(nn.Module):
         return s
 
 
+def _get_rope_param(rope_scaling, key, default, scaling_type):
+    """Get a parameter from rope_scaling dict, warn if missing.
+
+    In transformers v5, config.rope_scaling is an alias for rope_parameters
+    which may be non-None even for models with no actual scaling (rope_type=default).
+    When a required key is missing, this logs a warning instead of silently
+    defaulting, to make config mismatches easier to debug.
+    """
+    if key in rope_scaling:
+        return rope_scaling[key]
+    logger.warning(
+        "rope_scaling (type=%s) missing key '%s', defaulting to %s. "
+        "This may indicate a v5 config issue — check model accuracy.",
+        scaling_type,
+        key,
+        default,
+    )
+    return default
+
+
 _ROPE_DICT: dict[tuple, RotaryEmbedding] = {}
 
 
@@ -1869,7 +1890,12 @@ def get_rope(
                 **extra_kwargs,
             )
         elif scaling_type == "deepseek_yarn":
-            original_max_position = rope_scaling["original_max_position_embeddings"]
+            original_max_position = _get_rope_param(
+                rope_scaling,
+                "original_max_position_embeddings",
+                max_position,
+                scaling_type,
+            )
             # assert max_position == original_max_position * scaling_factor
             extra_kwargs = {
                 k: v


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

AITER's `deepseek_yarn` RoPE path requires `rope_scaling["original_max_position_embeddings"]` and raises `KeyError` when the key is missing.

This breaks GLM-4.7-Flash loading on ROCm with `SGLANG_USE_AITER=1`:

```
python3 -m sglang.launch_server --model-path zai-org/GLM-4.7-Flash --trust-remote-code --tp 1
```

```
  File "sglang/srt/models/glm4_moe_lite.py", line 544, in __init__
    self.self_attn = DeepseekV2AttentionMLA(
  File "sglang/srt/models/deepseek_v2.py", line 1717, in __init__
    self.rotary_emb = get_rope_wrapper(
  File "sglang/srt/layers/rotary_embedding/factory.py", line 437, in get_rope_wrapper
    return wrapper(
  File "aiter/rotary_embedding.py", line 1872, in get_rope
    original_max_position = rope_scaling["original_max_position_embeddings"]
KeyError: 'original_max_position_embeddings'
```

GLM-4.7-Flash does not define YaRN parameters in its config, but SGLang relabels the generated `rope_scaling` dict as `deepseek_yarn`. SGLang's own RoPE implementation already handles this case by defaulting `original_max_position_embeddings` to `max_position`; AITER does not.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

This PR ports SGLang's `_get_rope_param()` fallback to AITER and uses it for `original_max_position_embeddings` in the `deepseek_yarn` branch. SGLang added the fallback in [sgl-project/sglang#17784](https://github.com/sgl-project/sglang/pull/17784).

Related code:
1. [`factory.py::_get_rope_param()`](https://github.com/sgl-project/sglang/blob/1ebd6fab6c6cf8910bd3f8a13c69d5c6720a6703/python/sglang/srt/layers/rotary_embedding/factory.py#L34-L51)
2. [`factory.py::deepseek_yarn`](https://github.com/sgl-project/sglang/blob/1ebd6fab6c6cf8910bd3f8a13c69d5c6720a6703/python/sglang/srt/layers/rotary_embedding/factory.py#L313-L320)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

MI355X / gfx950 / ROCm 7.2.
1. Test `deepseek_yarn` with and without `original_max_position_embeddings`.
2. Launch GLM-4.7-Flash with SGLang and AITER enabled.
3. Run GLM-4.7-Flash RL training on 4x MI355X.

## Test Result

<!-- Briefly summarize test outcomes. -->

| case | before | after |
|---|---|---|
| missing `original_max_position_embeddings` | `KeyError` | fallback applied |
| DeepSeek-style config with the key present | works | unchanged |
| GLM-4.7-Flash serving | fails during model loading | server starts and serves |
| GLM-4.7-Flash RL training | cannot start | completes |

RL validation completed with TP2 / PP2 / EP2, EAGLE speculative decoding, and MTP.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.