### PR TITLE
[module_ropes*] refactor and rm-torch

### DIFF
--- a/aiter/ops/rope.py
+++ b/aiter/ops/rope.py
@@ -8,7 +8,7 @@ from ..jit.core import compile_ops
 MD_NAME = "module_rope"
 
 
-@compile_ops("module_rope_1c_uncached_fwd")
+@compile_ops("module_rope_1c_uncached_fwd", develop=True)
 def rope_fwd_impl(
     output: Tensor,
     input: Tensor,
@@ -27,7 +27,7 @@ def rope_fwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_uncached_bwd")
+@compile_ops("module_rope_1c_uncached_bwd", develop=True)
 def rope_bwd_impl(
     input_grads: Tensor,
     output_grads: Tensor,
@@ -46,7 +46,7 @@ def rope_bwd_impl(
     """
 
 
-@compile_ops("module_rope_2c_uncached_fwd")
+@compile_ops("module_rope_2c_uncached_fwd", develop=True)
 def rope_2c_fwd_impl(
     output_x: Tensor,
     output_y: Tensor,
@@ -67,7 +67,7 @@ def rope_2c_fwd_impl(
     """
 
 
-@compile_ops("module_rope_2c_uncached_bwd")
+@compile_ops("module_rope_2c_uncached_bwd", develop=True)
 def rope_2c_bwd_impl(
     input_grads_x: Tensor,
     input_grads_y: Tensor,
@@ -88,7 +88,7 @@ def rope_2c_bwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_cached_fwd")
+@compile_ops("module_rope_1c_cached_fwd", develop=True)
 def rope_cached_fwd_impl(
     output: Tensor,
     input: Tensor,
@@ -108,7 +108,7 @@ def rope_cached_fwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_cached_bwd")
+@compile_ops("module_rope_1c_cached_bwd", develop=True)
 def rope_cached_bwd_impl(
     input_grads: Tensor,
     output_grads: Tensor,
@@ -128,7 +128,7 @@ def rope_cached_bwd_impl(
     """
 
 
-@compile_ops("module_rope_2c_cached_fwd")
+@compile_ops("module_rope_2c_cached_fwd", develop=True)
 def rope_cached_2c_fwd_impl(
     output_x: Tensor,
     output_y: Tensor,
@@ -150,7 +150,7 @@ def rope_cached_2c_fwd_impl(
     """
 
 
-@compile_ops("module_rope_2c_cached_bwd")
+@compile_ops("module_rope_2c_cached_bwd", develop=True)
 def rope_cached_2c_bwd_impl(
     input_grads_x: Tensor,
     input_grads_y: Tensor,
@@ -172,7 +172,7 @@ def rope_cached_2c_bwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_cached_positions_fwd")
+@compile_ops("module_rope_1c_cached_positions_fwd", develop=True)
 def rope_cached_positions_fwd_impl(
     output: Tensor,
     input: Tensor,
@@ -194,7 +194,7 @@ def rope_cached_positions_fwd_impl(
     """
 
 
-@compile_ops("module_rope_2c_cached_positions_fwd")
+@compile_ops("module_rope_2c_cached_positions_fwd", develop=True)
 def rope_cached_positions_2c_fwd_impl(
     output_x: Tensor,
     output_y: Tensor,
@@ -218,7 +218,7 @@ def rope_cached_positions_2c_fwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_cached_positions_offsets_fwd")
+@compile_ops("module_rope_1c_cached_positions_offsets_fwd", develop=True)
 def rope_cached_positions_offsets_fwd_impl(
     output: Tensor,
     input: Tensor,
@@ -241,7 +241,7 @@ def rope_cached_positions_offsets_fwd_impl(
     """
 
 
-@compile_ops("module_rope_2c_cached_positions_offsets_fwd")
+@compile_ops("module_rope_2c_cached_positions_offsets_fwd", develop=True)
 def rope_cached_positions_offsets_2c_fwd_impl(
     output_x: Tensor,
     output_y: Tensor,
@@ -266,7 +266,7 @@ def rope_cached_positions_offsets_2c_fwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_thd_fwd")
+@compile_ops("module_rope_1c_thd_fwd", develop=True)
 def rope_thd_fwd_impl(
     output: Tensor,
     input: Tensor,
@@ -287,7 +287,7 @@ def rope_thd_fwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_thd_bwd")
+@compile_ops("module_rope_1c_thd_bwd", develop=True)
 def rope_thd_bwd_impl(
     input_grads: Tensor,
     output_grads: Tensor,
@@ -308,7 +308,7 @@ def rope_thd_bwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_2d_fwd")
+@compile_ops("module_rope_1c_2d_fwd", develop=True)
 def rope_2d_fwd_impl(
     output: Tensor,
     input: Tensor,
@@ -335,7 +335,7 @@ def rope_2d_fwd_impl(
     """
 
 
-@compile_ops("module_rope_1c_2d_bwd")
+@compile_ops("module_rope_1c_2d_bwd", develop=True)
 def rope_2d_bwd_impl(
     input_grads: Tensor,
     output_grads: Tensor,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1754,21 +1754,22 @@ namespace py = pybind11;
           py::arg("handle_ptrs"));                                                         \
     m.def("qr_max_size", &aiter::qr_max_size);
 
-#define ROPE_1C_UNCACHED_FWD_PYBIND m.def("rope_fwd_impl", &rope_fwd_impl);
-#define ROPE_2C_UNCACHED_FWD_PYBIND m.def("rope_2c_fwd_impl", &rope_2c_fwd_impl);
-#define ROPE_1C_CACHED_FWD_PYBIND m.def("rope_cached_fwd_impl", &rope_cached_fwd_impl);
-#define ROPE_2C_CACHED_FWD_PYBIND m.def("rope_cached_2c_fwd_impl", &rope_cached_2c_fwd_impl);
-#define ROPE_1C_THD_FWD_PYBIND m.def("rope_thd_fwd_impl", &rope_thd_fwd_impl);
-#define ROPE_1C_2D_FWD_PYBIND m.def("rope_2d_fwd_impl", &rope_2d_fwd_impl);
+#define ROPE_1C_UNCACHED_FWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_fwd_impl", &rope_fwd_impl);
+#define ROPE_2C_UNCACHED_FWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_2c_fwd_impl", &rope_2c_fwd_impl);
+#define ROPE_1C_CACHED_FWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_cached_fwd_impl", &rope_cached_fwd_impl);
+#define ROPE_2C_CACHED_FWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_cached_2c_fwd_impl", &rope_cached_2c_fwd_impl);
+#define ROPE_1C_THD_FWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_thd_fwd_impl", &rope_thd_fwd_impl);
+#define ROPE_1C_2D_FWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_2d_fwd_impl", &rope_2d_fwd_impl);
 
-#define ROPE_1C_UNCACHED_BWD_PYBIND m.def("rope_bwd_impl", &rope_bwd_impl);
-#define ROPE_2C_UNCACHED_BWD_PYBIND m.def("rope_2c_bwd_impl", &rope_2c_bwd_impl);
-#define ROPE_1C_CACHED_BWD_PYBIND m.def("rope_cached_bwd_impl", &rope_cached_bwd_impl);
-#define ROPE_2C_CACHED_BWD_PYBIND m.def("rope_cached_2c_bwd_impl", &rope_cached_2c_bwd_impl);
-#define ROPE_1C_THD_BWD_PYBIND m.def("rope_thd_bwd_impl", &rope_thd_bwd_impl);
-#define ROPE_1C_2D_BWD_PYBIND m.def("rope_2d_bwd_impl", &rope_2d_bwd_impl);
+#define ROPE_1C_UNCACHED_BWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_bwd_impl", &rope_bwd_impl);
+#define ROPE_2C_UNCACHED_BWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_2c_bwd_impl", &rope_2c_bwd_impl);
+#define ROPE_1C_CACHED_BWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_cached_bwd_impl", &rope_cached_bwd_impl);
+#define ROPE_2C_CACHED_BWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_cached_2c_bwd_impl", &rope_cached_2c_bwd_impl);
+#define ROPE_1C_THD_BWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_thd_bwd_impl", &rope_thd_bwd_impl);
+#define ROPE_1C_2D_BWD_PYBIND AITER_SET_STREAM_PYBIND; m.def("rope_2d_bwd_impl", &rope_2d_bwd_impl);
 
 #define ROPE_1C_CACHED_POSITIONS_FWD_PYBIND  \
+    AITER_SET_STREAM_PYBIND;                  \
     m.def("rope_cached_positions_fwd_impl",  \
           &rope_cached_positions_fwd_impl,   \
           py::arg("output"),                 \
@@ -1780,6 +1781,7 @@ namespace py = pybind11;
           py::arg("reuse_freqs_front_part"), \
           py::arg("nope_first"))
 #define ROPE_2C_CACHED_POSITIONS_FWD_PYBIND    \
+    AITER_SET_STREAM_PYBIND;                    \
     m.def("rope_cached_positions_2c_fwd_impl", \
           &rope_cached_positions_2c_fwd_impl,  \
           py::arg("output_x"),                 \
@@ -1793,6 +1795,7 @@ namespace py = pybind11;
           py::arg("reuse_freqs_front_part"),   \
           py::arg("nope_first"))
 #define ROPE_1C_CACHED_POSITIONS_OFFSETS_FWD_PYBIND \
+    AITER_SET_STREAM_PYBIND;                         \
     m.def("rope_cached_positions_offsets_fwd_impl", \
           &rope_cached_positions_offsets_fwd_impl,  \
           py::arg("output"),                        \
@@ -1805,6 +1808,7 @@ namespace py = pybind11;
           py::arg("reuse_freqs_front_part"),        \
           py::arg("nope_first"))
 #define ROPE_2C_CACHED_POSITIONS_OFFSETS_FWD_PYBIND    \
+    AITER_SET_STREAM_PYBIND;                            \
     m.def("rope_cached_positions_offsets_2c_fwd_impl", \
           &rope_cached_positions_offsets_2c_fwd_impl,  \
           py::arg("output_x"),                         \

--- a/csrc/include/rope.h
+++ b/csrc/include/rope.h
@@ -3,169 +3,171 @@
 
 #pragma once
 
-#include <torch/extension.h>
+#include "aiter_stream.h"
+#include "aiter_tensor.h"
+#include <cstdint>
 
 void rope_fwd_impl(
-    torch::Tensor&       output,                    // [s, b, h, d]
-    const torch::Tensor& input,                     // [s, b, h, d]
-    const torch::Tensor& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       output,                    // [s, b, h, d]
+    const aiter_tensor_t& input,                     // [s, b, h, d]
+    const aiter_tensor_t& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_bwd_impl(
-    torch::Tensor&       input_grads,               // [s, b, h, d]
-    const torch::Tensor& output_grads,              // [s, b, h, d]
-    const torch::Tensor& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       input_grads,               // [s, b, h, d]
+    const aiter_tensor_t& output_grads,              // [s, b, h, d]
+    const aiter_tensor_t& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_2c_fwd_impl(
-    torch::Tensor&       output_x,                  // [s, b, h, d]
-    torch::Tensor&       output_y,                  // [s, b, h, d]
-    const torch::Tensor& input_x,                   // [s, b, h, d]
-    const torch::Tensor& input_y,                   // [s, b, h, d]
-    const torch::Tensor& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       output_x,                  // [s, b, h, d]
+    aiter_tensor_t&       output_y,                  // [s, b, h, d]
+    const aiter_tensor_t& input_x,                   // [s, b, h, d]
+    const aiter_tensor_t& input_y,                   // [s, b, h, d]
+    const aiter_tensor_t& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_2c_bwd_impl(
-    torch::Tensor&       input_grads_x,             // [s, b, h, d]
-    torch::Tensor&       input_grads_y,             // [s, b, h, d]
-    const torch::Tensor& output_grads_x,            // [s, b, h, d]
-    const torch::Tensor& output_grads_y,            // [s, b, h, d]
-    const torch::Tensor& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       input_grads_x,             // [s, b, h, d]
+    aiter_tensor_t&       input_grads_y,             // [s, b, h, d]
+    const aiter_tensor_t& output_grads_x,            // [s, b, h, d]
+    const aiter_tensor_t& output_grads_y,            // [s, b, h, d]
+    const aiter_tensor_t& freqs,                     // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_fwd_impl(
-    torch::Tensor&       output,                    // [s, b, h, d]
-    const torch::Tensor& input,                     // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       output,                    // [s, b, h, d]
+    const aiter_tensor_t& input,                     // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_bwd_impl(
-    torch::Tensor&       input_grads,               // [s, b, h, d]
-    const torch::Tensor& output_grads,              // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       input_grads,               // [s, b, h, d]
+    const aiter_tensor_t& output_grads,              // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_2c_fwd_impl(
-    torch::Tensor&       output_x,                  // [s, b, h, d]
-    torch::Tensor&       output_y,                  // [s, b, h, d]
-    const torch::Tensor& input_x,                   // [s, b, h, d]
-    const torch::Tensor& input_y,                   // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       output_x,                  // [s, b, h, d]
+    aiter_tensor_t&       output_y,                  // [s, b, h, d]
+    const aiter_tensor_t& input_x,                   // [s, b, h, d]
+    const aiter_tensor_t& input_y,                   // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_2c_bwd_impl(
-    torch::Tensor&       input_grads_x,             // [s, b, h, d]
-    torch::Tensor&       input_grads_y,             // [s, b, h, d]
-    const torch::Tensor& output_grads_x,            // [s, b, h, d]
-    const torch::Tensor& output_grads_y,            // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    aiter_tensor_t&       input_grads_x,             // [s, b, h, d]
+    aiter_tensor_t&       input_grads_y,             // [s, b, h, d]
+    const aiter_tensor_t& output_grads_x,            // [s, b, h, d]
+    const aiter_tensor_t& output_grads_y,            // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_positions_fwd_impl(
-    torch::Tensor&       output,                    // [s, b, h, d]
-    const torch::Tensor& input,                     // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& positions,                 // [s, b]
+    aiter_tensor_t&       output,                    // [s, b, h, d]
+    const aiter_tensor_t& input,                     // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& positions,                 // [s, b]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_positions_2c_fwd_impl(
-    torch::Tensor&       output_x,                  // [s, b, h, d]
-    torch::Tensor&       output_y,                  // [s, b, h, d]
-    const torch::Tensor& input_x,                   // [s, b, h, d]
-    const torch::Tensor& input_y,                   // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& positions,                 // [s, b]
+    aiter_tensor_t&       output_x,                  // [s, b, h, d]
+    aiter_tensor_t&       output_y,                  // [s, b, h, d]
+    const aiter_tensor_t& input_x,                   // [s, b, h, d]
+    const aiter_tensor_t& input_y,                   // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& positions,                 // [s, b]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_positions_offsets_fwd_impl(
-    torch::Tensor&       output,                    // [s, b, h, d]
-    const torch::Tensor& input,                     // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& positions,                 // [s, b]
-    const torch::Tensor& offsets,                   // [s, b]
+    aiter_tensor_t&       output,                    // [s, b, h, d]
+    const aiter_tensor_t& input,                     // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& positions,                 // [s, b]
+    const aiter_tensor_t& offsets,                   // [s, b]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_cached_positions_offsets_2c_fwd_impl(
-    torch::Tensor&       output_x,                  // [s, b, h, d]
-    torch::Tensor&       output_y,                  // [s, b, h, d]
-    const torch::Tensor& input_x,                   // [s, b, h, d]
-    const torch::Tensor& input_y,                   // [s, b, h, d]
-    const torch::Tensor& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
-    const torch::Tensor& positions,                 // [s, b]
-    const torch::Tensor& offsets,                   // [s, b]
+    aiter_tensor_t&       output_x,                  // [s, b, h, d]
+    aiter_tensor_t&       output_y,                  // [s, b, h, d]
+    const aiter_tensor_t& input_x,                   // [s, b, h, d]
+    const aiter_tensor_t& input_y,                   // [s, b, h, d]
+    const aiter_tensor_t& cos,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& sin,                       // [s, 1, 1, d // 2] if reuse_freqs_front_part else [s, 1, 1, d]
+    const aiter_tensor_t& positions,                 // [s, b]
+    const aiter_tensor_t& offsets,                   // [s, b]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_thd_fwd_impl(
-    torch::Tensor&       output,                    // [t, h, d]
-    const torch::Tensor& input,                     // [t, h, d]
-    const torch::Tensor& cu_seqlens,                // [b + 1]
-    const torch::Tensor& freqs,                     // [max_s, 1, 1, d // 2] if reuse_freqs_front_part else [max_s, 1, 1, d], where max_s = cu_seqlens[-1]
+    aiter_tensor_t&       output,                    // [t, h, d]
+    const aiter_tensor_t& input,                     // [t, h, d]
+    const aiter_tensor_t& cu_seqlens,                // [b + 1]
+    const aiter_tensor_t& freqs,                     // [max_s, 1, 1, d // 2] if reuse_freqs_front_part else [max_s, 1, 1, d], where max_s = cu_seqlens[-1]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_thd_bwd_impl(
-    torch::Tensor&       input_grads,               // [t, h, d]
-    const torch::Tensor& output_grads,              // [t, h, d]
-    const torch::Tensor& cu_seqlens,                // [b + 1]
-    const torch::Tensor& freqs,                     // [max_s, 1, 1, d // 2] if reuse_freqs_front_part else [max_s, 1, 1, d], where max_s = cu_seqlens[-1]
+    aiter_tensor_t&       input_grads,               // [t, h, d]
+    const aiter_tensor_t& output_grads,              // [t, h, d]
+    const aiter_tensor_t& cu_seqlens,                // [b + 1]
+    const aiter_tensor_t& freqs,                     // [max_s, 1, 1, d // 2] if reuse_freqs_front_part else [max_s, 1, 1, d], where max_s = cu_seqlens[-1]
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
     const bool           reuse_freqs_front_part,
     const bool           nope_first
 );
 
 void rope_2d_fwd_impl(
-    torch::Tensor&       output,                    // [b, s, h, d] where s = H * W
-    const torch::Tensor& input,                     // [b, s, h, d] where s = H * W
-    const torch::Tensor& cos_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
-    const torch::Tensor& sin_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
-    const torch::Tensor& cos_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
-    const torch::Tensor& sin_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
+    aiter_tensor_t&       output,                    // [b, s, h, d] where s = H * W
+    const aiter_tensor_t& input,                     // [b, s, h, d] where s = H * W
+    const aiter_tensor_t& cos_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
+    const aiter_tensor_t& sin_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
+    const aiter_tensor_t& cos_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
+    const aiter_tensor_t& sin_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
     const int32_t        img_height,                // H
     const int32_t        img_width,                 // W
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style
@@ -174,12 +176,12 @@ void rope_2d_fwd_impl(
 );
 
 void rope_2d_bwd_impl(
-    torch::Tensor&       input_grads,               // [b, s, h, d] where s = H * W
-    const torch::Tensor& output_grads,              // [b, s, h, d] where s = H * W
-    const torch::Tensor& cos_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
-    const torch::Tensor& sin_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
-    const torch::Tensor& cos_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
-    const torch::Tensor& sin_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
+    aiter_tensor_t&       input_grads,               // [b, s, h, d] where s = H * W
+    const aiter_tensor_t& output_grads,              // [b, s, h, d] where s = H * W
+    const aiter_tensor_t& cos_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
+    const aiter_tensor_t& sin_h,                     // [1, H', 1,  d // 4] if reuse_freqs_front_part else [1, H', 1,  d // 2], where H' >= H
+    const aiter_tensor_t& cos_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
+    const aiter_tensor_t& sin_w,                     // [1, 1,  W', d // 4] if reuse_freqs_front_part else [1, 1,  W', d // 2], where W' >= W
     const int32_t        img_height,                // H
     const int32_t        img_width,                 // W
     const int32_t        rotate_style,              // 0: NEOX style, 1: GPT-J style

--- a/csrc/kernels/rope/general_1c_2d_bwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_2d_bwd_kernels.cu
@@ -5,12 +5,12 @@
 using namespace aiter;
 
 void rope_2d_bwd_impl(
-    torch::Tensor&       input_grads,
-    const torch::Tensor& output_grads,
-    const torch::Tensor& cos_h,
-    const torch::Tensor& sin_h,
-    const torch::Tensor& cos_w,
-    const torch::Tensor& sin_w,
+    aiter_tensor_t&       input_grads,
+    const aiter_tensor_t& output_grads,
+    const aiter_tensor_t& cos_h,
+    const aiter_tensor_t& sin_h,
+    const aiter_tensor_t& cos_w,
+    const aiter_tensor_t& sin_w,
     const int32_t        img_height,
     const int32_t        img_width,
     const int32_t        rotate_style,
@@ -30,25 +30,25 @@ void rope_2d_bwd_impl(
     const int stride_i_h = input_grads.stride(2);
     const int stride_i_d = input_grads.stride(3);
 
-    TORCH_CHECK(size_s == img_height * img_width, "rope_2d_bwd_impl - input tensor shape doesn't match image size.");
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(size_s == img_height * img_width, "rope_2d_bwd_impl - input tensor shape doesn't match image size.");
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_2d_bwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_grads));
+    const HipDeviceGuard device_guard(input_grads.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        output_grads.scalar_type(),
-        cos_h.scalar_type(),
+        output_grads.dtype(),
+        cos_h.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_2d_cached<OpCachedBwd, ...>",
         dispatch_1c_2d_cached<OpCachedBwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            input_grads.data_ptr<scalar_t_0>(),
-            output_grads.data_ptr<scalar_t_0>(),
-            cos_h.data_ptr<scalar_t_1>(),
-            sin_h.data_ptr<scalar_t_1>(),
-            cos_w.data_ptr<scalar_t_1>(),
-            sin_w.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(input_grads.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads.data_ptr()),
+            static_cast<scalar_t_1*>(cos_h.data_ptr()),
+            static_cast<scalar_t_1*>(sin_h.data_ptr()),
+            static_cast<scalar_t_1*>(cos_w.data_ptr()),
+            static_cast<scalar_t_1*>(sin_w.data_ptr()),
             img_height, img_width,
             size_b, size_h, size_d,
             stride_o_b, stride_o_s, stride_o_h, stride_o_d,

--- a/csrc/kernels/rope/general_1c_2d_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_2d_fwd_kernels.cu
@@ -5,12 +5,12 @@
 using namespace aiter;
 
 void rope_2d_fwd_impl(
-    torch::Tensor&       output,
-    const torch::Tensor& input,
-    const torch::Tensor& cos_h,
-    const torch::Tensor& sin_h,
-    const torch::Tensor& cos_w,
-    const torch::Tensor& sin_w,
+    aiter_tensor_t&       output,
+    const aiter_tensor_t& input,
+    const aiter_tensor_t& cos_h,
+    const aiter_tensor_t& sin_h,
+    const aiter_tensor_t& cos_w,
+    const aiter_tensor_t& sin_w,
     const int32_t        img_height,
     const int32_t        img_width,
     const int32_t        rotate_style,
@@ -30,25 +30,25 @@ void rope_2d_fwd_impl(
     const int stride_o_h = output.stride(2);
     const int stride_o_d = output.stride(3);
 
-    TORCH_CHECK(size_s == img_height * img_width, "rope_2d_fwd_impl - input tensor shape doesn't match image size.");
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(size_s == img_height * img_width, "rope_2d_fwd_impl - input tensor shape doesn't match image size.");
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_2d_fwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
+    const HipDeviceGuard device_guard(input.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        input.scalar_type(),
-        cos_h.scalar_type(),
+        input.dtype(),
+        cos_h.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_2d_cached<OpCachedFwd, ...>",
         dispatch_1c_2d_cached<OpCachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output.data_ptr<scalar_t_0>(),
-            input.data_ptr<scalar_t_0>(),
-            cos_h.data_ptr<scalar_t_1>(),
-            sin_h.data_ptr<scalar_t_1>(),
-            cos_w.data_ptr<scalar_t_1>(),
-            sin_w.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(output.data_ptr()),
+            static_cast<scalar_t_0*>(input.data_ptr()),
+            static_cast<scalar_t_1*>(cos_h.data_ptr()),
+            static_cast<scalar_t_1*>(sin_h.data_ptr()),
+            static_cast<scalar_t_1*>(cos_w.data_ptr()),
+            static_cast<scalar_t_1*>(sin_w.data_ptr()),
             img_height, img_width,
             size_b, size_h, size_d,
             stride_i_b, stride_i_s, stride_i_h, stride_i_d,

--- a/csrc/kernels/rope/general_1c_cached_bwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_cached_bwd_kernels.cu
@@ -5,10 +5,10 @@
 using namespace aiter;
 
 void rope_cached_bwd_impl(
-    torch::Tensor&       input_grads,   // [s, b, h, d]
-    const torch::Tensor& output_grads,  // [s, b, h, d]
-    const torch::Tensor& cos,           // [s, 1, 1, d]
-    const torch::Tensor& sin,           // [s, 1, 1, d]
+    aiter_tensor_t&       input_grads,   // [s, b, h, d]
+    const aiter_tensor_t& output_grads,  // [s, b, h, d]
+    const aiter_tensor_t& cos,           // [s, 1, 1, d]
+    const aiter_tensor_t& sin,           // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -27,22 +27,22 @@ void rope_cached_bwd_impl(
     const int32_t stride_i_h = input_grads.stride(2);
     const int32_t stride_i_d = input_grads.stride(3);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_cached_bwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_grads));
+    const HipDeviceGuard device_guard(input_grads.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        output_grads.scalar_type(),
-        cos.scalar_type(),
+        output_grads.dtype(),
+        cos.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_sbhd_cached<OpCachedBwd, ...>",
         dispatch_1c_sbhd_cached<OpCachedBwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            input_grads.data_ptr<scalar_t_0>(),
-            output_grads.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(input_grads.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
             size_s, size_b, size_h, size_d,
             size_f,
             stride_o_s, stride_o_b, stride_o_h, stride_o_d,

--- a/csrc/kernels/rope/general_1c_cached_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_cached_fwd_kernels.cu
@@ -5,10 +5,10 @@
 using namespace aiter;
 
 void rope_cached_fwd_impl(
-    torch::Tensor&       output,        // [s, b, h, d]
-    const torch::Tensor& input,         // [s, b, h, d]
-    const torch::Tensor& cos,           // [s, 1, 1, d]
-    const torch::Tensor& sin,           // [s, 1, 1, d]
+    aiter_tensor_t&       output,        // [s, b, h, d]
+    const aiter_tensor_t& input,         // [s, b, h, d]
+    const aiter_tensor_t& cos,           // [s, 1, 1, d]
+    const aiter_tensor_t& sin,           // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -27,22 +27,22 @@ void rope_cached_fwd_impl(
     const int32_t stride_o_h = output.stride(2);
     const int32_t stride_o_d = output.stride(3);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_cached_fwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
+    const HipDeviceGuard device_guard(input.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        input.scalar_type(),
-        cos.scalar_type(),
+        input.dtype(),
+        cos.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_sbhd_cached<OpCachedFwd, ...>",
         dispatch_1c_sbhd_cached<OpCachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output.data_ptr<scalar_t_0>(),
-            input.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(output.data_ptr()),
+            static_cast<scalar_t_0*>(input.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
             size_s, size_b, size_h, size_d,
             size_f,
             stride_i_s, stride_i_b, stride_i_h, stride_i_d,

--- a/csrc/kernels/rope/general_1c_cached_positions_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_cached_positions_fwd_kernels.cu
@@ -19,11 +19,11 @@ using namespace aiter;
  * @param nope_first   If true, back part in last dimension of input is rotated. Otherwise, the front part is rotated.
  */
 void rope_cached_positions_fwd_impl(
-    torch::Tensor&       output,
-    const torch::Tensor& input,
-    const torch::Tensor& cos,
-    const torch::Tensor& sin,
-    const torch::Tensor& positions,
+    aiter_tensor_t&       output,
+    const aiter_tensor_t& input,
+    const aiter_tensor_t& cos,
+    const aiter_tensor_t& sin,
+    const aiter_tensor_t& positions,
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -47,28 +47,28 @@ void rope_cached_positions_fwd_impl(
     const int32_t stride_o_h = output.stride(2);
     const int32_t stride_o_d = output.stride(3);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_cached_positions_fwd_impl requires all stride_d to be 1");
 
     // Get strides of positions and offsets
     assert(1 == positions.stride(1) && 2 == positions.dim());
     const int32_t max_position = cos.size(0);
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
+    const HipDeviceGuard device_guard(input.device_id);
     DISPATCH_ROPE_TYPES_PARAMS_WITH_POSITIONS(
-        input.scalar_type(),
-        cos.scalar_type(),
-        positions.scalar_type(),
+        input.dtype(),
+        cos.dtype(),
+        positions.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_sbhd_cached_indirect<OpCachedFwd, ...>",
         dispatch_1c_sbhd_cached_indirect<OpCachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output.data_ptr<scalar_t_0>(),
-            input.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
-            positions.data_ptr<pos_t>(),
+            static_cast<scalar_t_0*>(output.data_ptr()),
+            static_cast<scalar_t_0*>(input.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
+            static_cast<pos_t*>(positions.data_ptr()),
             max_position,
             size_s, size_b, size_h, size_d,
             size_f, // size of last dimension of freqs.

--- a/csrc/kernels/rope/general_1c_cached_positions_offsets_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_cached_positions_offsets_fwd_kernels.cu
@@ -21,12 +21,12 @@ using namespace aiter;
  * @param nope_first   If true, back part in last dimension of input is rotated. Otherwise, the front part is rotated.
  */
 void rope_cached_positions_offsets_fwd_impl(
-    torch::Tensor&       output,
-    const torch::Tensor& input,
-    const torch::Tensor& cos,
-    const torch::Tensor& sin,
-    const torch::Tensor& positions,
-    const torch::Tensor& offsets,
+    aiter_tensor_t&       output,
+    const aiter_tensor_t& input,
+    const aiter_tensor_t& cos,
+    const aiter_tensor_t& sin,
+    const aiter_tensor_t& positions,
+    const aiter_tensor_t& offsets,
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -50,7 +50,7 @@ void rope_cached_positions_offsets_fwd_impl(
     const int32_t stride_o_h = output.stride(2);
     const int32_t stride_o_d = output.stride(3);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_cached_positions_offsets_fwd_impl requires all stride_d to be 1");
 
     // Get strides of positions and offsets
@@ -58,22 +58,22 @@ void rope_cached_positions_offsets_fwd_impl(
     assert(1 == offsets.stride(1)   && 2 == offsets.dim());
     const int32_t max_position = cos.size(0);
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
+    const HipDeviceGuard device_guard(input.device_id);
     DISPATCH_ROPE_TYPES_PARAMS_WITH_POSITIONS(
-        input.scalar_type(),
-        cos.scalar_type(),
-        positions.scalar_type(),
+        input.dtype(),
+        cos.dtype(),
+        positions.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_sbhd_cached_indirect2<OpCachedFwd, ...>",
         dispatch_1c_sbhd_cached_indirect2<OpCachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output.data_ptr<scalar_t_0>(),
-            input.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
-            positions.data_ptr<pos_t>(),
-            offsets.data_ptr<int64_t>(),
+            static_cast<scalar_t_0*>(output.data_ptr()),
+            static_cast<scalar_t_0*>(input.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
+            static_cast<pos_t*>(positions.data_ptr()),
+            static_cast<int64_t*>(offsets.data_ptr()),
             max_position,
             size_s, size_b, size_h, size_d,
             size_f, // size of last dimension of freqs.

--- a/csrc/kernels/rope/general_1c_thd_bwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_thd_bwd_kernels.cu
@@ -5,10 +5,10 @@
 using namespace aiter;
 
 void rope_thd_bwd_impl(
-    torch::Tensor&       input_grads,   // [t, h, d]
-    const torch::Tensor& output_grads,  // [t, h, d]
-    const torch::Tensor& cu_seqlens,    // [b + 1]
-    const torch::Tensor& freqs,         // [max_s, 1, 1, d]
+    aiter_tensor_t&       input_grads,   // [t, h, d]
+    const aiter_tensor_t& output_grads,  // [t, h, d]
+    const aiter_tensor_t& cu_seqlens,    // [b + 1]
+    const aiter_tensor_t& freqs,         // [max_s, 1, 1, d]
     const int            rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -25,22 +25,22 @@ void rope_thd_bwd_impl(
     const int32_t stride_i_h = input_grads.stride(1);
     const int32_t stride_i_d = input_grads.stride(2);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_thd_bwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_grads));
+    const HipDeviceGuard device_guard(input_grads.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        output_grads.scalar_type(),
-        freqs.scalar_type(),
+        output_grads.dtype(),
+        freqs.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_thd_uncached<OpUncachedBwd, ...>",
         dispatch_1c_thd_uncached<OpUncachedBwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            input_grads.data_ptr<scalar_t_0>(),
-            output_grads.data_ptr<scalar_t_0>(),
-            cu_seqlens.data_ptr<int32_t>(),
-            freqs.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(input_grads.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads.data_ptr()),
+            static_cast<int32_t*>(cu_seqlens.data_ptr()),
+            static_cast<scalar_t_1*>(freqs.data_ptr()),
             size_max_s, size_b, size_h, size_d,
             size_f,
             stride_o_t, stride_o_h, stride_o_d,

--- a/csrc/kernels/rope/general_1c_thd_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_thd_fwd_kernels.cu
@@ -5,10 +5,10 @@
 using namespace aiter;
 
 void rope_thd_fwd_impl(
-    torch::Tensor&       output,        // [t, h, d]
-    const torch::Tensor& input,         // [t, h, d]
-    const torch::Tensor& cu_seqlens,    // [b + 1]
-    const torch::Tensor& freqs,         // [max_s, 1, 1, d]
+    aiter_tensor_t&       output,        // [t, h, d]
+    const aiter_tensor_t& input,         // [t, h, d]
+    const aiter_tensor_t& cu_seqlens,    // [b + 1]
+    const aiter_tensor_t& freqs,         // [max_s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -25,22 +25,22 @@ void rope_thd_fwd_impl(
     const int32_t stride_o_h = output.stride(1);
     const int32_t stride_o_d = output.stride(2);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_thd_fwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
+    const HipDeviceGuard device_guard(input.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        input.scalar_type(),
-        freqs.scalar_type(),
+        input.dtype(),
+        freqs.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_thd_uncached<OpUncachedFwd, ...>",
         dispatch_1c_thd_uncached<OpUncachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output.data_ptr<scalar_t_0>(),
-            input.data_ptr<scalar_t_0>(),
-            cu_seqlens.data_ptr<int32_t>(),
-            freqs.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(output.data_ptr()),
+            static_cast<scalar_t_0*>(input.data_ptr()),
+            static_cast<int32_t*>(cu_seqlens.data_ptr()),
+            static_cast<scalar_t_1*>(freqs.data_ptr()),
             size_max_s, size_b, size_h, size_d,
             size_f,
             stride_i_t, stride_i_h, stride_i_d,

--- a/csrc/kernels/rope/general_1c_uncached_bwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_uncached_bwd_kernels.cu
@@ -5,9 +5,9 @@
 using namespace aiter;
 
 void rope_bwd_impl(
-    torch::Tensor&       input_grads,   // [s, b, h, d]
-    const torch::Tensor& output_grads,  // [s, b, h, d]
-    const torch::Tensor& freqs,         // [s, 1, 1, d]
+    aiter_tensor_t&       input_grads,   // [s, b, h, d]
+    const aiter_tensor_t& output_grads,  // [s, b, h, d]
+    const aiter_tensor_t& freqs,         // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -26,21 +26,21 @@ void rope_bwd_impl(
     const int32_t stride_i_h = input_grads.stride(2);
     const int32_t stride_i_d = input_grads.stride(3);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_bwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_grads));
+    const HipDeviceGuard device_guard(input_grads.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        output_grads.scalar_type(),
-        freqs.scalar_type(),
+        output_grads.dtype(),
+        freqs.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_sbhd_uncached<OpUncachedBwd, ...>",
         dispatch_1c_sbhd_uncached<OpUncachedBwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            input_grads.data_ptr<scalar_t_0>(),
-            output_grads.data_ptr<scalar_t_0>(),
-            freqs.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(input_grads.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads.data_ptr()),
+            static_cast<scalar_t_1*>(freqs.data_ptr()),
             size_s, size_b, size_h, size_d,
             size_f,
             stride_o_s, stride_o_b, stride_o_h, stride_o_d,

--- a/csrc/kernels/rope/general_1c_uncached_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_1c_uncached_fwd_kernels.cu
@@ -5,9 +5,9 @@
 using namespace aiter;
 
 void rope_fwd_impl(
-    torch::Tensor&       output,        // [s, b, h, d]
-    const torch::Tensor& input,         // [s, b, h, d]
-    const torch::Tensor& freqs,         // [s, 1, 1, d]
+    aiter_tensor_t&       output,        // [s, b, h, d]
+    const aiter_tensor_t& input,         // [s, b, h, d]
+    const aiter_tensor_t& freqs,         // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -26,21 +26,21 @@ void rope_fwd_impl(
     const int32_t stride_o_h = output.stride(2);
     const int32_t stride_o_d = output.stride(3);
 
-    TORCH_CHECK(stride_i_d == 1 && stride_o_d == 1,
+    AITER_CHECK(stride_i_d == 1 && stride_o_d == 1,
                 "rope_fwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input));
+    const HipDeviceGuard device_guard(input.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        input.scalar_type(),
-        freqs.scalar_type(),
+        input.dtype(),
+        freqs.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_1c_sbhd_uncached<OpUncachedFwd, ...>",
         dispatch_1c_sbhd_uncached<OpUncachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output.data_ptr<scalar_t_0>(),
-            input.data_ptr<scalar_t_0>(),
-            freqs.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(output.data_ptr()),
+            static_cast<scalar_t_0*>(input.data_ptr()),
+            static_cast<scalar_t_1*>(freqs.data_ptr()),
             size_s, size_b, size_h, size_d,
             size_f,
             stride_i_s, stride_i_b, stride_i_h, stride_i_d,

--- a/csrc/kernels/rope/general_2c_cached_bwd_kernels.cu
+++ b/csrc/kernels/rope/general_2c_cached_bwd_kernels.cu
@@ -5,12 +5,12 @@
 using namespace aiter;
 
 void rope_cached_2c_bwd_impl(
-    torch::Tensor&       input_grads_x, // [s, b, h, d]
-    torch::Tensor&       input_grads_y, // [s, b, h, d]
-    const torch::Tensor& output_grads_x,// [s, b, h, d]
-    const torch::Tensor& output_grads_y,// [s, b, h, d]
-    const torch::Tensor& cos,           // [s, 1, 1, d]
-    const torch::Tensor& sin,           // [s, 1, 1, d]
+    aiter_tensor_t&       input_grads_x, // [s, b, h, d]
+    aiter_tensor_t&       input_grads_y, // [s, b, h, d]
+    const aiter_tensor_t& output_grads_x,// [s, b, h, d]
+    const aiter_tensor_t& output_grads_y,// [s, b, h, d]
+    const aiter_tensor_t& cos,           // [s, 1, 1, d]
+    const aiter_tensor_t& sin,           // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -38,24 +38,24 @@ void rope_cached_2c_bwd_impl(
     const int32_t stride_iy_h = input_grads_y.stride(2);
     const int32_t stride_iy_d = input_grads_y.stride(3);
 
-    TORCH_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
+    AITER_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
                 "rope_cached_2c_bwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_grads_x));
+    const HipDeviceGuard device_guard(input_grads_x.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        output_grads_x.scalar_type(),
-        cos.scalar_type(),
+        output_grads_x.dtype(),
+        cos.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_2c_sbhd_cached<OpCachedBwd, ...>",
         dispatch_2c_sbhd_cached<OpCachedBwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            input_grads_x.data_ptr<scalar_t_0>(),
-            input_grads_y.data_ptr<scalar_t_0>(),
-            output_grads_x.data_ptr<scalar_t_0>(),
-            output_grads_y.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(input_grads_x.data_ptr()),
+            static_cast<scalar_t_0*>(input_grads_y.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads_x.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads_y.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
             size_s, size_b, size_h_x, size_h_y, size_d,
             size_f,
             stride_ox_s, stride_ox_b, stride_ox_h, stride_ox_d,

--- a/csrc/kernels/rope/general_2c_cached_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_2c_cached_fwd_kernels.cu
@@ -5,12 +5,12 @@
 using namespace aiter;
 
 void rope_cached_2c_fwd_impl(
-    torch::Tensor&       output_x,      // [s, b, h, d]
-    torch::Tensor&       output_y,      // [s, b, h, d]
-    const torch::Tensor& input_x,       // [s, b, h, d]
-    const torch::Tensor& input_y,       // [s, b, h, d]
-    const torch::Tensor& cos,           // [s, 1, 1, d]
-    const torch::Tensor& sin,           // [s, 1, 1, d]
+    aiter_tensor_t&       output_x,      // [s, b, h, d]
+    aiter_tensor_t&       output_y,      // [s, b, h, d]
+    const aiter_tensor_t& input_x,       // [s, b, h, d]
+    const aiter_tensor_t& input_y,       // [s, b, h, d]
+    const aiter_tensor_t& cos,           // [s, 1, 1, d]
+    const aiter_tensor_t& sin,           // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -38,24 +38,24 @@ void rope_cached_2c_fwd_impl(
     const int32_t stride_oy_h = output_y.stride(2);
     const int32_t stride_oy_d = output_y.stride(3);
 
-    TORCH_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
+    AITER_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
                 "rope_cached_2c_fwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_x));
+    const HipDeviceGuard device_guard(input_x.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        input_x.scalar_type(),
-        cos.scalar_type(),
+        input_x.dtype(),
+        cos.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_2c_sbhd_cached<OpCachedFwd, ...>",
         dispatch_2c_sbhd_cached<OpCachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output_x.data_ptr<scalar_t_0>(),
-            output_y.data_ptr<scalar_t_0>(),
-            input_x.data_ptr<scalar_t_0>(),
-            input_y.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(output_x.data_ptr()),
+            static_cast<scalar_t_0*>(output_y.data_ptr()),
+            static_cast<scalar_t_0*>(input_x.data_ptr()),
+            static_cast<scalar_t_0*>(input_y.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
             size_s, size_b, size_h_x, size_h_y, size_d,
             size_f,
             stride_ix_s, stride_ix_b, stride_ix_h, stride_ix_d,

--- a/csrc/kernels/rope/general_2c_cached_positions_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_2c_cached_positions_fwd_kernels.cu
@@ -22,13 +22,13 @@ using namespace aiter;
  * @param nope_first   If true, back part in last dimension of input is rotated. Otherwise, the front part is rotated.
  */
 void rope_cached_positions_2c_fwd_impl(
-    torch::Tensor&       output_x,
-    torch::Tensor&       output_y,
-    const torch::Tensor& input_x,
-    const torch::Tensor& input_y,
-    const torch::Tensor& cos,
-    const torch::Tensor& sin,
-    const torch::Tensor& positions,
+    aiter_tensor_t&       output_x,
+    aiter_tensor_t&       output_y,
+    const aiter_tensor_t& input_x,
+    const aiter_tensor_t& input_y,
+    const aiter_tensor_t& cos,
+    const aiter_tensor_t& sin,
+    const aiter_tensor_t& positions,
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -61,30 +61,30 @@ void rope_cached_positions_2c_fwd_impl(
     const int32_t stride_oy_h = output_y.stride(2);
     const int32_t stride_oy_d = output_y.stride(3);
 
-    TORCH_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
+    AITER_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
                 "rope_cached_positions_2c_fwd_impl requires all stride_d to be 1");
 
     // Get strides of positions and offsets
     assert(1 == positions.stride(1) && 2 == positions.dim());
     const int32_t max_position = cos.size(0);
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_x));
+    const HipDeviceGuard device_guard(input_x.device_id);
     DISPATCH_ROPE_TYPES_PARAMS_WITH_POSITIONS(
-        input_x.scalar_type(),
-        cos.scalar_type(),
-        positions.scalar_type(),
+        input_x.dtype(),
+        cos.dtype(),
+        positions.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_2c_sbhd_cached_indirect<OpCachedFwd, ...>",
         dispatch_2c_sbhd_cached_indirect<OpCachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output_x.data_ptr<scalar_t_0>(),
-            output_y.data_ptr<scalar_t_0>(),
-            input_x.data_ptr<scalar_t_0>(),
-            input_y.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
-            positions.data_ptr<pos_t>(),
+            static_cast<scalar_t_0*>(output_x.data_ptr()),
+            static_cast<scalar_t_0*>(output_y.data_ptr()),
+            static_cast<scalar_t_0*>(input_x.data_ptr()),
+            static_cast<scalar_t_0*>(input_y.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
+            static_cast<pos_t*>(positions.data_ptr()),
             max_position,
             size_s, size_b, size_h_x, size_h_y, size_d,
             size_f, // size of last dimension of freqs.

--- a/csrc/kernels/rope/general_2c_cached_positions_offsets_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_2c_cached_positions_offsets_fwd_kernels.cu
@@ -24,14 +24,14 @@ using namespace aiter;
  * @param nope_first   If true, back part in last dimension of input is rotated. Otherwise, the front part is rotated.
  */
 void rope_cached_positions_offsets_2c_fwd_impl(
-    torch::Tensor&       output_x,
-    torch::Tensor&       output_y,
-    const torch::Tensor& input_x,
-    const torch::Tensor& input_y,
-    const torch::Tensor& cos,
-    const torch::Tensor& sin,
-    const torch::Tensor& positions,
-    const torch::Tensor& offsets,
+    aiter_tensor_t&       output_x,
+    aiter_tensor_t&       output_y,
+    const aiter_tensor_t& input_x,
+    const aiter_tensor_t& input_y,
+    const aiter_tensor_t& cos,
+    const aiter_tensor_t& sin,
+    const aiter_tensor_t& positions,
+    const aiter_tensor_t& offsets,
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -64,7 +64,7 @@ void rope_cached_positions_offsets_2c_fwd_impl(
     const int32_t stride_oy_h = output_y.stride(2);
     const int32_t stride_oy_d = output_y.stride(3);
 
-    TORCH_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
+    AITER_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
                 "rope_cached_positions_offsets_2c_fwd_impl requires all stride_d to be 1");
 
     // Get strides of positions and offsets
@@ -72,24 +72,24 @@ void rope_cached_positions_offsets_2c_fwd_impl(
     assert(1 == offsets.stride(1)   && 2 == offsets.dim());
     const int32_t max_position = cos.size(0);
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_x));
+    const HipDeviceGuard device_guard(input_x.device_id);
     DISPATCH_ROPE_TYPES_PARAMS_WITH_POSITIONS(
-        input_x.scalar_type(),
-        cos.scalar_type(),
-        positions.scalar_type(),
+        input_x.dtype(),
+        cos.dtype(),
+        positions.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_2c_sbhd_cached_indirect2<OpCachedFwd, ...>",
         dispatch_2c_sbhd_cached_indirect2<OpCachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output_x.data_ptr<scalar_t_0>(),
-            output_y.data_ptr<scalar_t_0>(),
-            input_x.data_ptr<scalar_t_0>(),
-            input_y.data_ptr<scalar_t_0>(),
-            cos.data_ptr<scalar_t_1>(),
-            sin.data_ptr<scalar_t_1>(),
-            positions.data_ptr<pos_t>(),
-            offsets.data_ptr<int64_t>(),
+            static_cast<scalar_t_0*>(output_x.data_ptr()),
+            static_cast<scalar_t_0*>(output_y.data_ptr()),
+            static_cast<scalar_t_0*>(input_x.data_ptr()),
+            static_cast<scalar_t_0*>(input_y.data_ptr()),
+            static_cast<scalar_t_1*>(cos.data_ptr()),
+            static_cast<scalar_t_1*>(sin.data_ptr()),
+            static_cast<pos_t*>(positions.data_ptr()),
+            static_cast<int64_t*>(offsets.data_ptr()),
             max_position,
             size_s, size_b, size_h_x, size_h_y, size_d,
             size_f, // size of last dimension of freqs.

--- a/csrc/kernels/rope/general_2c_uncached_bwd_kernels.cu
+++ b/csrc/kernels/rope/general_2c_uncached_bwd_kernels.cu
@@ -5,11 +5,11 @@
 using namespace aiter;
 
 void rope_2c_bwd_impl(
-    torch::Tensor&       input_grads_x, // [s, b, h, d]
-    torch::Tensor&       input_grads_y, // [s, b, h, d]
-    const torch::Tensor& output_grads_x,// [s, b, h, d]
-    const torch::Tensor& output_grads_y,// [s, b, h, d]
-    const torch::Tensor& freqs,         // [s, 1, 1, d]
+    aiter_tensor_t&       input_grads_x, // [s, b, h, d]
+    aiter_tensor_t&       input_grads_y, // [s, b, h, d]
+    const aiter_tensor_t& output_grads_x,// [s, b, h, d]
+    const aiter_tensor_t& output_grads_y,// [s, b, h, d]
+    const aiter_tensor_t& freqs,         // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -37,23 +37,23 @@ void rope_2c_bwd_impl(
     const int32_t stride_iy_h = input_grads_y.stride(2);
     const int32_t stride_iy_d = input_grads_y.stride(3);
 
-    TORCH_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
+    AITER_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
                 "rope_2c_bwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_grads_x));
+    const HipDeviceGuard device_guard(input_grads_x.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        output_grads_x.scalar_type(),
-        freqs.scalar_type(),
+        output_grads_x.dtype(),
+        freqs.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_2c_sbhd_uncached<OpUncachedBwd, ...>",
         dispatch_2c_sbhd_uncached<OpUncachedBwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            input_grads_x.data_ptr<scalar_t_0>(),
-            input_grads_y.data_ptr<scalar_t_0>(),
-            output_grads_x.data_ptr<scalar_t_0>(),
-            output_grads_y.data_ptr<scalar_t_0>(),
-            freqs.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(input_grads_x.data_ptr()),
+            static_cast<scalar_t_0*>(input_grads_y.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads_x.data_ptr()),
+            static_cast<scalar_t_0*>(output_grads_y.data_ptr()),
+            static_cast<scalar_t_1*>(freqs.data_ptr()),
             size_s, size_b, size_h_x, size_h_y, size_d,
             size_f,
             stride_ox_s, stride_ox_b, stride_ox_h, stride_ox_d,

--- a/csrc/kernels/rope/general_2c_uncached_fwd_kernels.cu
+++ b/csrc/kernels/rope/general_2c_uncached_fwd_kernels.cu
@@ -5,11 +5,11 @@
 using namespace aiter;
 
 void rope_2c_fwd_impl(
-    torch::Tensor&       output_x,      // [s, b, h, d]
-    torch::Tensor&       output_y,      // [s, b, h, d]
-    const torch::Tensor& input_x,       // [s, b, h, d]
-    const torch::Tensor& input_y,       // [s, b, h, d]
-    const torch::Tensor& freqs,         // [s, 1, 1, d]
+    aiter_tensor_t&       output_x,      // [s, b, h, d]
+    aiter_tensor_t&       output_y,      // [s, b, h, d]
+    const aiter_tensor_t& input_x,       // [s, b, h, d]
+    const aiter_tensor_t& input_y,       // [s, b, h, d]
+    const aiter_tensor_t& freqs,         // [s, 1, 1, d]
     const int32_t        rotate_style,
     const bool           reuse_freqs_front_part,
     const bool           nope_first)
@@ -37,23 +37,23 @@ void rope_2c_fwd_impl(
     const int32_t stride_oy_h = output_y.stride(2);
     const int32_t stride_oy_d = output_y.stride(3);
 
-    TORCH_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
+    AITER_CHECK(stride_ix_d == 1 && stride_iy_d == 1 && stride_ox_d == 1 && stride_oy_d == 1,
                 "rope_2c_fwd_impl requires all stride_d to be 1");
 
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(input_x));
+    const HipDeviceGuard device_guard(input_x.device_id);
     DISPATCH_ROPE_TYPES_PARAMS(
-        input_x.scalar_type(),
-        freqs.scalar_type(),
+        input_x.dtype(),
+        freqs.dtype(),
         rotate_style,
         reuse_freqs_front_part,
         nope_first,
         "dispatch_2c_sbhd_uncached<OpUncachedFwd, ...>",
         dispatch_2c_sbhd_uncached<OpUncachedFwd, RotateStyle, ReuseFreqsFrontPart, NopeFirst, true>(
-            output_x.data_ptr<scalar_t_0>(),
-            output_y.data_ptr<scalar_t_0>(),
-            input_x.data_ptr<scalar_t_0>(),
-            input_y.data_ptr<scalar_t_0>(),
-            freqs.data_ptr<scalar_t_1>(),
+            static_cast<scalar_t_0*>(output_x.data_ptr()),
+            static_cast<scalar_t_0*>(output_y.data_ptr()),
+            static_cast<scalar_t_0*>(input_x.data_ptr()),
+            static_cast<scalar_t_0*>(input_y.data_ptr()),
+            static_cast<scalar_t_1*>(freqs.data_ptr()),
             size_s, size_b, size_h_x, size_h_y, size_d,
             size_f,
             stride_ix_s, stride_ix_b, stride_ix_h, stride_ix_d,

--- a/csrc/kernels/rope/rope_common.h
+++ b/csrc/kernels/rope/rope_common.h
@@ -4,9 +4,12 @@
 #pragma once
 
 #include "aiter_hip_common.h"
-#include "dispatch_utils.h"
+#include "aiter_dispatch.h"
+#include "aiter_stream.h"
+#include "aiter_tensor.h"
 #include "hip_float8.h"
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <numeric>
+#include <string>
 #include <type_traits>
 
 #ifdef __HIP_DEVICE_COMPILE__
@@ -43,7 +46,7 @@
 
 // When ENABLE_ROPE_POSITIONS_INT32 is non-zero at compile time (e.g. -DENABLE_ROPE_POSITIONS_INT32=1),
 // RoPE cached-indirect kernels are also built for int32 positions tensors; dispatch switches on
-// positions.scalar_type() at runtime. When zero, only int64 (torch.long) positions are accepted.
+// the positions dtype at runtime. When zero, only int64 (long) positions are accepted.
 
 namespace aiter {
 // =====================================================================================================================
@@ -283,26 +286,26 @@ __device__ __forceinline__ void store_payload(o_scalar_t* p_buffer,
 }
 
 #ifdef __HIP_DEVICE_COMPILE__
-// Map torch/c10 types to opus-compatible types for ext_vector_type
+// Map aiter/hip scalar types to opus-compatible types for ext_vector_type
 template <typename T>
 struct opus_type_map
 {
     using type = T;
 };
 template <>
-struct opus_type_map<c10::Half>
+struct opus_type_map<__half>
 {
     using type = opus::fp16_t;
 };
 template <>
-struct opus_type_map<c10::BFloat16>
+struct opus_type_map<hip_bfloat16>
 {
     using type = opus::bf16_t;
 };
 template <typename T>
 using opus_type_t = typename opus_type_map<T>::type;
 
-// Helper to create opus gmem accessor with automatic pointer cast from c10 types to opus types
+// Helper to create opus gmem accessor with automatic pointer cast from hip types to opus types
 template <typename T>
 __device__ __forceinline__ auto opus_gmem(const T* ptr)
 {
@@ -4556,7 +4559,7 @@ void dispatch_1c_sbhd_uncached(scalar_t* __restrict__ p_output,
                                const int32_t stride_o_h,
                                const int32_t stride_o_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 = (stride_i_d == 1) && (stride_o_d == 1);
     auto [grid, block, vec_pairs, threads_per_sb] =
@@ -4714,7 +4717,7 @@ void dispatch_2c_sbhd_uncached(scalar_t* __restrict__ p_output_x,
                                const int32_t stride_oy_h,
                                const int32_t stride_oy_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 =
         (stride_ix_d == 1) && (stride_iy_d == 1) && (stride_ox_d == 1) && (stride_oy_d == 1);
@@ -4920,7 +4923,7 @@ void dispatch_1c_sbhd_cached(scalar_t* __restrict__ p_output,
                              const int32_t stride_o_h,
                              const int32_t stride_o_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 = (stride_i_d == 1) && (stride_o_d == 1);
     auto [grid, block, vec_pairs, threads_per_sb] =
@@ -5082,7 +5085,7 @@ void dispatch_2c_sbhd_cached(scalar_t* __restrict__ p_output_x,
                              const int32_t stride_oy_h,
                              const int32_t stride_oy_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 =
         (stride_ix_d == 1) && (stride_iy_d == 1) && (stride_ox_d == 1) && (stride_oy_d == 1);
@@ -5294,7 +5297,7 @@ void dispatch_1c_sbhd_cached_indirect(scalar_t* __restrict__ p_output,
                                       const int32_t stride_o_h,
                                       const int32_t stride_o_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 = (stride_i_d == 1) && (stride_o_d == 1);
     auto [grid, block, vec_pairs, threads_per_sb] =
@@ -5469,7 +5472,7 @@ void dispatch_2c_sbhd_cached_indirect(scalar_t* __restrict__ p_output_x,
                                       const int32_t stride_oy_h,
                                       const int32_t stride_oy_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 =
         (stride_ix_d == 1) && (stride_iy_d == 1) && (stride_ox_d == 1) && (stride_oy_d == 1);
@@ -5692,7 +5695,7 @@ void dispatch_1c_sbhd_cached_indirect2(scalar_t* __restrict__ p_output,
                                        const int32_t stride_o_h,
                                        const int32_t stride_o_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 = (stride_i_d == 1) && (stride_o_d == 1);
     auto [grid, block, vec_pairs, threads_per_sb] =
@@ -5874,7 +5877,7 @@ void dispatch_2c_sbhd_cached_indirect2(scalar_t* __restrict__ p_output_x,
                                        const int32_t stride_oy_h,
                                        const int32_t stride_oy_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 =
         (stride_ix_d == 1) && (stride_iy_d == 1) && (stride_ox_d == 1) && (stride_oy_d == 1);
@@ -6097,7 +6100,7 @@ void dispatch_1c_thd_uncached(scalar_t* __restrict__ p_output,
                               const int32_t stride_o_h,
                               const int32_t stride_o_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 = (stride_i_d == 1) && (stride_o_d == 1);
     auto [grid, block, vec_pairs, threads_per_sb] =
@@ -6243,7 +6246,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                            const int32_t stride_o_h,
                            const int32_t stride_o_d)
 {
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    const hipStream_t stream = aiter::getCurrentHIPStream();
 
     const bool all_stride_d_eq_1 = (stride_i_d == 1) && (stride_o_d == 1);
     auto [grid, block, vec_pairs, threads_per_sb] =
@@ -6378,11 +6381,11 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
 }
 } // namespace aiter
 
-// Call sites use positions.data_ptr<pos_t>() inside __VA_ARGS__; pos_t is a local alias.
+// Call sites use the positions pointer (typed pos_t) inside __VA_ARGS__; pos_t is a local alias.
 #if ENABLE_ROPE_POSITIONS_INT32
 #define DISPATCH_ROPE_TYPES_PARAMS_WITH_POSITIONS(                                \
     TYPE0, TYPE1, POSITIONS_ST, ROTATE_STYLE, REUSE_FREQS_FRONT_PART, NOPE_FIRST, NAME, ...) \
-    if((POSITIONS_ST) == at::ScalarType::Int)                                      \
+    if((POSITIONS_ST) == AITER_DTYPE_i32)                                      \
     {                                                                             \
         using pos_t = int32_t;                                                    \
         DISPATCH_ROPE_TYPES_PARAMS(                                               \
@@ -6396,17 +6399,17 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
     }                                                                             \
     else                                                                          \
     {                                                                             \
-        TORCH_CHECK(false,                                                        \
+        AITER_CHECK(false,                                                        \
                     NAME,                                                         \
                     " does not support positions dtype ",                         \
-                    toString((POSITIONS_ST)),                                     \
+                    AiterDtype_to_str((POSITIONS_ST)),                                     \
                     " (compile RoPE sources with -DENABLE_ROPE_POSITIONS_INT32=1 for int32 positions", \
                     " and -DENABLE_ROPE_POSITIONS_INT32=0 for int64/Long positions)."); \
     }
 #else
 #define DISPATCH_ROPE_TYPES_PARAMS_WITH_POSITIONS(                                \
     TYPE0, TYPE1, POSITIONS_ST, ROTATE_STYLE, REUSE_FREQS_FRONT_PART, NOPE_FIRST, NAME, ...) \
-    if((POSITIONS_ST) == at::ScalarType::Long)                                    \
+    if((POSITIONS_ST) == AITER_DTYPE_i64)                                    \
     {                                                                             \
         using pos_t = int64_t;                                                    \
         DISPATCH_ROPE_TYPES_PARAMS(                                               \
@@ -6420,10 +6423,10 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
     }                                                                             \
     else                                                                          \
     {                                                                             \
-        TORCH_CHECK(false,                                                        \
+        AITER_CHECK(false,                                                        \
                     NAME,                                                         \
                     " does not support positions dtype ",                         \
-                    toString((POSITIONS_ST)),                                     \
+                    AiterDtype_to_str((POSITIONS_ST)),                                     \
                     " (compile RoPE sources with -DENABLE_ROPE_POSITIONS_INT32=1 for int32 positions", \
                     " and -DENABLE_ROPE_POSITIONS_INT32=0 for int64/Long positions)."); \
     }
@@ -6433,11 +6436,11 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
     TYPE0, TYPE1, ROTATE_STYLE, REUSE_FREQS_FRONT_PART, NOPE_FIRST, NAME, ...)    \
     switch((TYPE0))                                                               \
     {                                                                             \
-    case at::ScalarType::Float: {                                                 \
+    case AITER_DTYPE_fp32: {                                                 \
         using scalar_t_0 = float;                                                 \
         switch((TYPE1))                                                           \
         {                                                                         \
-        case at::ScalarType::Float: {                                             \
+        case AITER_DTYPE_fp32: {                                             \
             using scalar_t_1 = float;                                             \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
@@ -6472,7 +6475,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6511,7 +6514,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6519,8 +6522,8 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             }                                                                     \
             break;                                                                \
         }                                                                         \
-        case at::ScalarType::Half: {                                              \
-            using scalar_t_1 = at::Half;                                          \
+        case AITER_DTYPE_fp16: {                                              \
+            using scalar_t_1 = __half;                                          \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
                 constexpr bool ReuseFreqsFrontPart = true;                        \
@@ -6554,7 +6557,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6593,7 +6596,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6601,8 +6604,8 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             }                                                                     \
             break;                                                                \
         }                                                                         \
-        case at::ScalarType::BFloat16: {                                          \
-            using scalar_t_1 = at::BFloat16;                                      \
+        case AITER_DTYPE_bf16: {                                          \
+            using scalar_t_1 = hip_bfloat16;                                      \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
                 constexpr bool ReuseFreqsFrontPart = true;                        \
@@ -6636,7 +6639,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6675,7 +6678,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6684,20 +6687,20 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             break;                                                                \
         }                                                                         \
         default:                                                                  \
-            TORCH_CHECK(false,                                                    \
+            AITER_CHECK(false,                                                    \
                         NAME " does't support ",                                  \
-                        toString((TYPE0)),                                        \
+                        AiterDtype_to_str((TYPE0)),                                        \
                         " with ",                                                 \
-                        toString((TYPE1)),                                        \
+                        AiterDtype_to_str((TYPE1)),                                        \
                         ".");                                                     \
         }                                                                         \
         break;                                                                    \
     }                                                                             \
-    case at::ScalarType::Half: {                                                  \
-        using scalar_t_0 = at::Half;                                              \
+    case AITER_DTYPE_fp16: {                                                  \
+        using scalar_t_0 = __half;                                              \
         switch((TYPE1))                                                           \
         {                                                                         \
-        case at::ScalarType::Float: {                                             \
+        case AITER_DTYPE_fp32: {                                             \
             using scalar_t_1 = float;                                             \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
@@ -6732,7 +6735,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6771,7 +6774,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6779,8 +6782,8 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             }                                                                     \
             break;                                                                \
         }                                                                         \
-        case at::ScalarType::Half: {                                              \
-            using scalar_t_1 = at::Half;                                          \
+        case AITER_DTYPE_fp16: {                                              \
+            using scalar_t_1 = __half;                                          \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
                 constexpr bool ReuseFreqsFrontPart = true;                        \
@@ -6814,7 +6817,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6853,7 +6856,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6861,8 +6864,8 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             }                                                                     \
             break;                                                                \
         }                                                                         \
-        case at::ScalarType::BFloat16: {                                          \
-            using scalar_t_1 = at::BFloat16;                                      \
+        case AITER_DTYPE_bf16: {                                          \
+            using scalar_t_1 = hip_bfloat16;                                      \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
                 constexpr bool ReuseFreqsFrontPart = true;                        \
@@ -6896,7 +6899,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6935,7 +6938,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -6944,20 +6947,20 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             break;                                                                \
         }                                                                         \
         default:                                                                  \
-            TORCH_CHECK(false,                                                    \
+            AITER_CHECK(false,                                                    \
                         NAME " does't support ",                                  \
-                        toString((TYPE0)),                                        \
+                        AiterDtype_to_str((TYPE0)),                                        \
                         " with ",                                                 \
-                        toString((TYPE1)),                                        \
+                        AiterDtype_to_str((TYPE1)),                                        \
                         ".");                                                     \
         }                                                                         \
         break;                                                                    \
     }                                                                             \
-    case at::ScalarType::BFloat16: {                                              \
-        using scalar_t_0 = at::BFloat16;                                          \
+    case AITER_DTYPE_bf16: {                                              \
+        using scalar_t_0 = hip_bfloat16;                                          \
         switch((TYPE1))                                                           \
         {                                                                         \
-        case at::ScalarType::Float: {                                             \
+        case AITER_DTYPE_fp32: {                                             \
             using scalar_t_1 = float;                                             \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
@@ -6992,7 +6995,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -7031,7 +7034,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -7039,8 +7042,8 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             }                                                                     \
             break;                                                                \
         }                                                                         \
-        case at::ScalarType::Half: {                                              \
-            using scalar_t_1 = at::Half;                                          \
+        case AITER_DTYPE_fp16: {                                              \
+            using scalar_t_1 = __half;                                          \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
                 constexpr bool ReuseFreqsFrontPart = true;                        \
@@ -7074,7 +7077,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -7113,7 +7116,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -7121,8 +7124,8 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             }                                                                     \
             break;                                                                \
         }                                                                         \
-        case at::ScalarType::BFloat16: {                                          \
-            using scalar_t_1 = at::BFloat16;                                      \
+        case AITER_DTYPE_bf16: {                                          \
+            using scalar_t_1 = hip_bfloat16;                                      \
             if((REUSE_FREQS_FRONT_PART))                                          \
             {                                                                     \
                 constexpr bool ReuseFreqsFrontPart = true;                        \
@@ -7156,7 +7159,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -7195,7 +7198,7 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
                 }                                                                 \
                 else                                                              \
                 {                                                                 \
-                    TORCH_CHECK(false,                                            \
+                    AITER_CHECK(false,                                            \
                                 NAME " does't support rotate type ",              \
                                 std::to_string((ROTATE_STYLE)),                   \
                                 ".");                                             \
@@ -7204,16 +7207,16 @@ void dispatch_1c_2d_cached(scalar_t* __restrict__ p_output,
             break;                                                                \
         }                                                                         \
         default:                                                                  \
-            TORCH_CHECK(false,                                                    \
+            AITER_CHECK(false,                                                    \
                         NAME " does't support ",                                  \
-                        toString((TYPE0)),                                        \
+                        AiterDtype_to_str((TYPE0)),                                        \
                         " with ",                                                 \
-                        toString((TYPE1)),                                        \
+                        AiterDtype_to_str((TYPE1)),                                        \
                         ".");                                                     \
         }                                                                         \
         break;                                                                    \
     }                                                                             \
-    default: TORCH_CHECK(false, NAME " does't support ", toString((TYPE0)), "."); \
+    default: AITER_CHECK(false, NAME " does't support ", AiterDtype_to_str((TYPE0)), "."); \
     }
 
 namespace mrope_utils {
@@ -8135,10 +8138,10 @@ void fused_mrope_rms_set_kv(const T* qkv,
                             int64_t rotary_dim       = 0,
                             bool gemma_norm          = false)
 {
-    TORCH_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
+    AITER_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
     auto dim           = std::accumulate(mrope_section.begin(), mrope_section.end(), 0);
     auto expected_half = rotary_dim > 0 ? rotary_dim / 2 : head_size / 2;
-    TORCH_CHECK(dim == expected_half,
+    AITER_CHECK(dim == expected_half,
                 "mrope_section sum (",
                 dim,
                 ") must equal rotary_dim/2 (",
@@ -8275,7 +8278,7 @@ void fused_rope_rms_set_kv(const T* qkv,
                            int64_t v_token_stride   = 0,
                            int64_t v_head_stride    = 0)
 {
-    TORCH_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
+    AITER_CHECK(head_size == 64 || head_size == 128 || head_size == 256);
     constexpr int THREAD_BLOCK_SIZE = 256;
     auto total_warps                = num_tokens * (num_heads_q + num_heads_k + num_heads_v);
     auto num_warps_per_block        = THREAD_BLOCK_SIZE / WARP_SIZE;


### PR DESCRIPTION
## What

Remove all torch/ATen entry points from the **rope** kernel translation units so the JIT no longer parses the torch/ATen header tree on every build. C++ kernels now take POD `aiter_tensor_t`; the Python side uses `@compile_ops(..., develop=True)` to auto-convert `torch.Tensor` args and set the HIP stream. 

**Compute is unchanged** — pure type/pointer plumbing (`__half`≡`c10::Half`, `hip_bfloat16`≡`c10::BFloat16` in memory), kernels are bit-identical.


Every module drops a **fixed ~30s** of torch-header parse. Realized speedup scales inversely with each module's own kernel-compile weight:

| module | BEFORE | AFTER | speedup |
|---|--:|--:|--:|
| rope_1c_cached_bwd | 47.9s | 17.1s | **2.80x** |
| rope_1c_cached_fwd | 47.8s | 17.3s | 2.77x |
| rope_1c_cached_positions_fwd | 49.8s | 18.1s | 2.75x |
| rope_1c_cached_positions_offsets_fwd | 49.3s | 18.4s | 2.68x |
| rope_1c_2d_fwd / bwd | 53.2s / 53.5s | 21.4s / 21.5s | 2.49x |
| rope_1c_uncached_bwd | 65.3s | 33.8s | 1.93x |
| rope_1c_thd_fwd / bwd | 65.4s | 33.9s | 1.93x |
| rope_1c_uncached_fwd | 69.8s | 38.1s | 1.83x |
| rope_2c_cached_bwd | 119.1s | 88.5s | 1.35x |
| rope_2c_cached_fwd | 118.9s | 88.8s | 1.34x |
| rope_2c_cached_positions_fwd | 120.5s | 90.6s | 1.33x |
| rope_2c_cached_positions_offsets_fwd | 121.7s | 93.7s | 1.30x |
| rope_2c_uncached_fwd | 154.9s | 122.4s | 1.27x |
| rope_2c_uncached_bwd | 155.0s | 125.7s | 1.23x |
| fused_qk_norm_rope_cache_quant_shuffle | 170.5s | 141.2s | 1.21x |
| fused_qk_norm_mrope_cache_quant_shuffle | 44.4s | 13.8s | **3.22x** |

- Light-kernel modules (1c_cached, mrope fused) → the ~30s is the bulk → **2.7x–3.2x**, matching the `module_aiter_unary` reference win (~2.7x).
- Heavy-kernel modules (2c_* template blowup, 90–150s of real compile) → smaller ratio but the same absolute saving.

**Why the 2 fused modules speed up without touching their `.cu`:** they `#include "rope/rope_common.h"`, which previously pulled the whole torch tree in transitively. De-torching the header cuts that chain, so they each shed ~30s too.
