### PR TITLE
Rm sort for decode gdr

### DIFF
--- a/aiter/ops/hip/gated_delta_net/__init__.py
+++ b/aiter/ops/hip/gated_delta_net/__init__.py
@@ -2,7 +2,6 @@ from .hip_gdn_decode import (
     LAYOUT_KV,
     LAYOUT_VK,
     hip_fused_sigmoid_gating_delta_rule_update,
-    hip_gdn_decode_reset_sort_cache,
     hip_state_transpose_inplace,
     hip_state_transpose_inplace_multi_layer,
 )
@@ -11,7 +10,6 @@ __all__ = [
     "LAYOUT_KV",
     "LAYOUT_VK",
     "hip_fused_sigmoid_gating_delta_rule_update",
-    "hip_gdn_decode_reset_sort_cache",
     "hip_state_transpose_inplace",
     "hip_state_transpose_inplace_multi_layer",
 ]

--- a/aiter/ops/hip/gated_delta_net/gdn_decode_ext.cpp
+++ b/aiter/ops/hip/gated_delta_net/gdn_decode_ext.cpp
@@ -1,35 +1,5 @@
 #include <torch/extension.h>
 #include <ATen/hip/HIPContext.h>
-#include <cstdlib>
-
-static int gdn_sort_threshold() {
-    // BS=128 with sorted path under-saturates HBM (~1.62 TB/s -> 79us).
-    // The unsorted path at BS=128 hits ~2.16 TB/s -> 59us (-25% kernel time, +30% vs FlyDSL).
-    // Sort still helps at BS=256 (97us vs 103us). Setting threshold=192 keeps sort only for
-    // BS in [192, +inf), so BS=128 uses the faster unsorted kernel and BS=256 keeps sort.
-    static int t = []() {
-        const char* e = std::getenv("HIP_GDN_SORT_IDX_BS");
-        return e ? std::atoi(e) : 192;
-    }();
-    return t;
-}
-
-// Cache sorted indices + permutation across layers in a decode step.
-// All GDN layers in one step share the same indices tensor, so sorting
-// once and reusing is a ~64x reduction in sort overhead.
-static struct {
-    const void* last_ptr = nullptr;
-    int last_bs = 0;
-    torch::Tensor sorted_indices;
-    torch::Tensor perm_i32;
-} sort_cache;
-
-static void reset_sort_cache() {
-    sort_cache.last_ptr = nullptr;
-    sort_cache.last_bs = 0;
-    sort_cache.sorted_indices = torch::Tensor();
-    sort_cache.perm_i32 = torch::Tensor();
-}
 
 extern "C" {
 void launch_gdn_decode_iasm(
@@ -40,7 +10,6 @@ void launch_gdn_decode_iasm(
     int batch_size, int seq_length,
     int num_v_blocks, bool use_qk_l2norm, float scale,
     int num_k_heads, int num_v_heads,
-    const int* batch_perm,
     hipStream_t stream
 );
 
@@ -230,8 +199,6 @@ void hip_state_transpose_multi_layer(
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("hip_gdn_decode_reset_sort_cache", &reset_sort_cache,
-          "Invalidate cached sorted GDN decode indices");
     m.def("hip_gdn_decode_tuned_inplace", &hip_gdn_decode_tuned_inplace,
           "GDN decode TUNED kernel (state layout: [pool, HV, V, K])");
     m.def("hip_gdn_decode_tuned_kv_inplace", &hip_gdn_decode_tuned_kv_inplace,
@@ -297,38 +264,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         auto stream = at::hip::getCurrentHIPStream().stream();
         auto err_before = hipGetLastError();
 
-        const int* batch_perm_ptr = nullptr;
-        torch::Tensor sorted_indices, perm_i32;
-        int sort_thr = gdn_sort_threshold();
-        if (sort_thr > 0 && batch_size >= sort_thr &&
-            num_k_heads == 2 && num_v_heads == 8) {
-            const void* cur_ptr = indices.data_ptr();
-            if (sort_cache.last_ptr == cur_ptr &&
-                sort_cache.last_bs == batch_size) {
-                sorted_indices = sort_cache.sorted_indices;
-                perm_i32 = sort_cache.perm_i32;
-            } else {
-                auto perm_i64 = torch::argsort(indices, /*dim=*/int64_t(0), /*descending=*/false);
-                sorted_indices = indices.index_select(0, perm_i64);
-                perm_i32 = perm_i64.to(torch::kInt32);
-                sort_cache.last_ptr = cur_ptr;
-                sort_cache.last_bs = batch_size;
-                sort_cache.sorted_indices = sorted_indices;
-                sort_cache.perm_i32 = perm_i32;
-            }
-            batch_perm_ptr = perm_i32.data_ptr<int>();
-        }
-
         launch_gdn_decode_iasm(
             query.data_ptr(), key.data_ptr(), value.data_ptr(),
             a.data_ptr(), b.data_ptr(), dt_bias.data_ptr(),
-            A_log.data_ptr(),
-            batch_perm_ptr ? sorted_indices.data_ptr() : indices.data_ptr(),
+            A_log.data_ptr(), indices.data_ptr(),
             state.data_ptr(), output.data_ptr(),
             batch_size, seq_length,
             num_v_blocks, use_qk_l2norm, scale,
-            num_k_heads, num_v_heads,
-            batch_perm_ptr, stream);
+            num_k_heads, num_v_heads, stream);
         auto err = hipGetLastError();
         TORCH_CHECK(err == hipSuccess,
             "hip_gdn_decode_asm_inplace launch failed: ", hipGetErrorString(err),

--- a/aiter/ops/hip/gated_delta_net/gdn_decode_kernel_hip.hip
+++ b/aiter/ops/hip/gated_delta_net/gdn_decode_kernel_hip.hip
@@ -1304,7 +1304,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_opt(
     const int* __restrict__            indices,
     float* __restrict__                state,
     __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
     int batch_size, float scale
 ) {
     constexpr int TILE_V = HEAD_V_DIM / NUM_V_BLOCKS;
@@ -1331,7 +1330,7 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_opt(
     }
     const int pool_idx = indices[batch_idx];
     if (pool_idx < 0) return;
-    const int io_bid = batch_perm ? batch_perm[batch_idx] : batch_idx;
+    const int io_bid = batch_idx;
 
     const int warp_k_vec_start = k_tid * VEC_K;
     const int global_v_base = v_block_id * TILE_V + warp_id * WARP_V_THREADS + v_tid;
@@ -1545,28 +1544,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_opt(
     }
 }
 
-// Forwarding overload
-template <int NKH, int NVH, int NUM_V_BLOCKS, bool VmWaitSched = false, int FIXED_BATCH_SIZE = 0,
-          bool FUSE_POST_REDUCE = false>
-__device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_opt(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_iasm_sq1_body_opt<NKH, NVH, NUM_V_BLOCKS, VmWaitSched, FIXED_BATCH_SIZE,
-                                        FUSE_POST_REDUCE>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, (const int*)nullptr, batch_size, scale);
-}
-
 // ── dot2_opt: v_dot2_f32_bf16 for L2 + raw Q·K (NKH=2 NVH=8 NVB=2 path) ──
 template <int NKH, int NVH, int NUM_V_BLOCKS>
 __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_dot2_opt(
@@ -1580,7 +1557,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_dot2_opt(
     const int* __restrict__            indices,
     float* __restrict__                state,
     __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
     int batch_size, float scale
 ) {
     constexpr int TILE_V = HEAD_V_DIM / NUM_V_BLOCKS;
@@ -1604,7 +1580,7 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_dot2_opt(
     if (batch_idx >= batch_size) return;
     const int pool_idx = indices[batch_idx];
     if (pool_idx < 0) return;
-    const int io_bid = batch_perm ? batch_perm[batch_idx] : batch_idx;
+    const int io_bid = batch_idx;
 
     const int warp_k_vec_start = k_tid * VEC_K;
     const int global_v_base = v_block_id * TILE_V + warp_id * WARP_V_THREADS + v_tid;
@@ -1798,26 +1774,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_dot2_opt(
         }
     }
 }
-
-template <int NKH, int NVH, int NUM_V_BLOCKS>
-__device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_dot2_opt(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_iasm_sq1_body_dot2_opt<NKH, NVH, NUM_V_BLOCKS>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, (const int*)nullptr, batch_size, scale);
-}
-
 
 // ============================================================
 // TUNED kernel: Maximized ILP through restructured loops
@@ -2318,7 +2274,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_streaming(
     const int* __restrict__            indices,
     float* __restrict__                state,
     __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
     int batch_size, float scale
 ) {
     constexpr int TILE_V = HEAD_V_DIM;
@@ -2339,7 +2294,7 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_streaming(
     if (batch_idx >= batch_size) return;
     const int pool_idx = indices[batch_idx];
     if (pool_idx < 0) return;
-    const int io_bid = batch_perm ? batch_perm[batch_idx] : batch_idx;
+    const int io_bid = batch_idx;
 
     const int warp_k_vec_start = k_tid * VEC_K;
     const int global_v_base = warp_id * WARP_V_THREADS + v_tid;
@@ -2492,7 +2447,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_streaming_nvb4(
     const int* __restrict__            indices,
     float* __restrict__                state,
     __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
     int batch_size, float scale
 ) {
     constexpr int NUM_V_BLOCKS = 4;
@@ -2517,7 +2471,7 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_streaming_nvb4(
     if (batch_idx >= batch_size) return;
     const int pool_idx = indices[batch_idx];
     if (pool_idx < 0) return;
-    const int io_bid = batch_perm ? batch_perm[batch_idx] : batch_idx;
+    const int io_bid = batch_idx;
 
     const int warp_k_vec_start = k_tid * VEC_K;
     const int global_v_base = v_block_id * TILE_V + warp_id * WARP_V_THREADS + v_tid;
@@ -2627,25 +2581,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_streaming_nvb4(
     }
 }
 
-template <int NKH, int NVH>
-__device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_streaming_nvb4(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_iasm_sq1_body_streaming_nvb4<NKH, NVH>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, (const int*)nullptr, batch_size, scale);
-}
-
 // NVB=4 streaming + interleaved ds_swizzle (FlyDSL): issue 3 xor swizzles, run VALU while lgkm
 // completes, then s_waitcnt lgkmcnt(0) before consuming results — matches ultra_body SWAP pattern.
 template <int NKH, int NVH>
@@ -2660,7 +2595,6 @@ __device__ __forceinline__ void gdn_decode_kernel_interleaved_body_nvb4(
     const int* __restrict__            indices,
     float* __restrict__                state,
     __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
     int batch_size, float scale
 ) {
     constexpr int NUM_V_BLOCKS = 4;
@@ -2685,7 +2619,7 @@ __device__ __forceinline__ void gdn_decode_kernel_interleaved_body_nvb4(
     if (batch_idx >= batch_size) return;
     const int pool_idx = indices[batch_idx];
     if (pool_idx < 0) return;
-    const int io_bid = batch_perm ? batch_perm[batch_idx] : batch_idx;
+    const int io_bid = batch_idx;
 
     const int warp_k_vec_start = k_tid * VEC_K;
     const int global_v_base = v_block_id * TILE_V + warp_id * WARP_V_THREADS + v_tid;
@@ -2857,45 +2791,6 @@ __device__ __forceinline__ void gdn_decode_kernel_interleaved_body_nvb4(
     }
 }
 
-template <int NKH, int NVH>
-__device__ __forceinline__ void gdn_decode_kernel_interleaved_body_nvb4(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_interleaved_body_nvb4<NKH, NVH>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, (const int*)nullptr, batch_size, scale);
-}
-
-// Forwarding overload for streaming body: existing callers → nullptr
-template <int NKH, int NVH>
-__device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body_streaming(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_iasm_sq1_body_streaming<NKH, NVH>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, (const int*)nullptr, batch_size, scale);
-}
-
 // FIXED_BATCH_SIZE>0: BS is known at compile time (__builtin_assume for idx); omit runtime batch bound.
 template <int NKH, int NVH, int NUM_V_BLOCKS, int FIXED_BATCH_SIZE = 0>
 __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body(
@@ -2909,7 +2804,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body(
     const int* __restrict__            indices,
     float* __restrict__                state,
     __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
     int batch_size, float scale
 ) {
     constexpr int TILE_V = HEAD_V_DIM / NUM_V_BLOCKS;
@@ -2936,7 +2830,7 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body(
     }
     const int pool_idx = indices[batch_idx];
     if (pool_idx < 0) return;
-    const int io_bid = batch_perm ? batch_perm[batch_idx] : batch_idx;
+    const int io_bid = batch_idx;
 
     const int warp_k_vec_start = k_tid * VEC_K;
     const int global_v_base = v_block_id * TILE_V + warp_id * WARP_V_THREADS + v_tid;
@@ -3120,26 +3014,6 @@ __device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body(
             *reinterpret_cast<float4*>(sb + gv * HEAD_K_DIM + warp_k_vec_start + ki * WARP_TILE_K) = t;
         }
     }
-}
-
-// Forwarding overload: existing callers pass no batch_perm → nullptr
-template <int NKH, int NVH, int NUM_V_BLOCKS, int FIXED_BATCH_SIZE = 0>
-__device__ __forceinline__ void gdn_decode_kernel_iasm_sq1_body(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_iasm_sq1_body<NKH, NVH, NUM_V_BLOCKS, FIXED_BATCH_SIZE>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, (const int*)nullptr, batch_size, scale);
 }
 
 // ============================================================
@@ -7497,52 +7371,6 @@ DEFINE_BS16_NVB1_SQ1_FIXED(gdn_decode_kernel_iasm_tp8_nvh8_bs16_nvb1_lb6_fixedbs
 
 #undef DEFINE_BS16_NVB1_SQ1_FIXED
 
-// ── Sorted variants: accept batch_perm for indirect I/O indexing ──
-// indices must be pre-sorted; batch_perm maps sorted position → original batch position
-__global__
-__launch_bounds__(BLOCK_THREADS, 4)
-__attribute__((amdgpu_waves_per_eu(4, 6)))
-void gdn_decode_kernel_iasm_tp8_nvh8_sq1_sorted(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_iasm_sq1_body<2, 8, 2>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, batch_perm, batch_size, scale);
-}
-
-__global__
-__launch_bounds__(BLOCK_THREADS, 4)
-__attribute__((amdgpu_waves_per_eu(4, 6)))
-void gdn_decode_kernel_iasm_tp8_nvh8_sq1_nvb1_lb4_sorted(
-    const __hip_bfloat16* __restrict__ query,
-    const __hip_bfloat16* __restrict__ key,
-    const __hip_bfloat16* __restrict__ value,
-    const __hip_bfloat16* __restrict__ a_input,
-    const __hip_bfloat16* __restrict__ b_input,
-    const __hip_bfloat16* __restrict__ dt_bias,
-    const float* __restrict__          A_log,
-    const int* __restrict__            indices,
-    float* __restrict__                state,
-    __hip_bfloat16* __restrict__       output,
-    const int* __restrict__            batch_perm,
-    int batch_size, float scale
-) {
-    gdn_decode_kernel_iasm_sq1_body<2, 8, 1>(
-        query, key, value, a_input, b_input, dt_bias, A_log, indices,
-        state, output, batch_perm, batch_size, scale);
-}
-
 __global__
 __launch_bounds__(BLOCK_THREADS, 3)
 __attribute__((amdgpu_waves_per_eu(3, 5)))
@@ -7672,7 +7500,6 @@ void launch_gdn_decode_iasm(
     int batch_size, int seq_length,
     int num_v_blocks, bool use_qk_l2norm, float scale,
     int num_k_heads, int num_v_heads,
-    const int* batch_perm,
     hipStream_t stream
 ) {
     auto q = reinterpret_cast<const __hip_bfloat16*>(query);
@@ -7707,20 +7534,7 @@ void launch_gdn_decode_iasm(
             return;
         }
         if (num_k_heads == 2 && num_v_heads == 8) {
-            if (batch_perm) {
-                if (batch_size <= 4) {
-                    dim3 grid(batch_size * 8 * 2);
-                    dim3 block(BLOCK_THREADS);
-                    hipLaunchKernelGGL(gdn_decode_kernel_iasm_tp8_nvh8_sq1_sorted, dim3(grid), dim3(block), 0, stream,
-                        q, k, v, a, b, dt, al, idx, st, o, batch_perm, batch_size, scale);
-                } else {
-                    dim3 grid(batch_size * 8);
-                    dim3 block(BLOCK_THREADS);
-                    hipLaunchKernelGGL(gdn_decode_kernel_iasm_tp8_nvh8_sq1_nvb1_lb4_sorted, dim3(grid), dim3(block), 0, stream,
-                        q, k, v, a, b, dt, al, idx, st, o, batch_perm, batch_size, scale);
-                }
-            } else {
-                if (batch_size == 2) {
+            if (batch_size == 2) {
                     // BS=2 cache-bypass dispatch.
                     // In `online` GDN sits between in_proj/conv (heavy L2 footprint) and
                     // rmsnorm/out_proj.  Without bypass, our 1MB state read/write thrashes
@@ -7857,7 +7671,6 @@ void launch_gdn_decode_iasm(
                         hipLaunchKernelGGL(gdn_decode_kernel_iasm_tp8_nvh8_sq1_nvb1_lb4, dim3(grid), dim3(block), 0, stream,
                             q, k, v, a, b, dt, al, idx, st, o, batch_size, scale);
                     }
-                }
             }
             return;
         }

--- a/aiter/ops/hip/gated_delta_net/hip_gdn_decode.py
+++ b/aiter/ops/hip/gated_delta_net/hip_gdn_decode.py
@@ -12,8 +12,6 @@ so the decode path runs without any per-step transpose overhead.
 Kernel parameters are specialized for Qwen3.5:
   K_heads=16, V_heads=32, K=128, V=128, bf16.
 
-pool_idx sorting for L2-cache-friendly state access is handled inside
-the C++ extension (configurable via HIP_GDN_SORT_IDX_BS env var).
 """
 
 from typing import Optional
@@ -43,13 +41,6 @@ def _load_extension():
         verbose=False,
     )
     return _ext
-
-
-def hip_gdn_decode_reset_sort_cache():
-    """Invalidate C++ sorted-index cache before a new decode/graph step."""
-    ext = _load_extension()
-    ext.hip_gdn_decode_reset_sort_cache()
-
 
 def hip_fused_sigmoid_gating_delta_rule_update(
     A_log: torch.Tensor,


### PR DESCRIPTION
## Motivation

Remove the host-side GDN index sorting path, which is unsafe with CUDA Graph padding and replay when the cached permutation no longer matches the active indices.

## Technical Details

- Remove host-side `argsort` and `index_select`.
- Remove the sorted-index cache and reset API.
- Remove `HIP_GDN_SORT_IDX_BS`.
- Remove `batch_perm` and sorted HIP kernel dispatch.
- Always launch HIP GDN decode with the original state indices.

## Test Plan

- Rebuild the HIP GDN extension.
- Compare HIP output and recurrent state against Triton.
- Test CUDA Graph replay at batches 192, 256, and 512 while changing state indices before replay.

## Test Result

- B192 replay passed.
- B256 replay passed.
- B512 replay passed.
- Output and recurrent state matched Triton.
- SGLang GDN regression suite: 48 passed, 1 skipped.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.