### PR TITLE
[topk_per_row] support per-row KV ends for DeepSeek-V4 CSA decode

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -398,6 +398,7 @@ def _top_k_per_row_decode(
     stride1: int,
     k: int = 2048,
     workspace: torch.Tensor | None = None,
+    rowEndsPerRow: torch.Tensor | None = None,
 ) -> None: ...
 
 
@@ -410,9 +411,16 @@ def top_k_per_row_decode(
     stride0: int,
     stride1: int,
     k: int = 2048,
+    rowEndsPerRow: torch.Tensor | None = None,
 ) -> None:
     """Per-row top-k (decode). Always uses the one-block kernel — the C++
-    side ignores the workspace argument for decode."""
+    side ignores the workspace argument for decode.
+
+    `seqLens` is per-SEQUENCE and bounds row `r` by
+    `seqLens[r // next_n] - next_n + (r % next_n) + 1` — one KV row per query
+    token. Callers whose index cache packs several tokens into one entry
+    (DeepSeek-V4 CSA) must pass `rowEndsPerRow` instead: one end per ROW, taken
+    as is, with `seqLens` then unused."""
     # Decode always takes the ob path (see topk_per_row_kernels.cu).
     # The original mb dispatch is commented out below for reference:
     #   workspace = None
@@ -420,7 +428,16 @@ def top_k_per_row_decode(
     #       size = topk_mb_workspace_size(numRows, stride0, k, True)
     #       workspace = get_topk_mb_workspace(logits.device, size)
     return _top_k_per_row_decode(
-        logits, next_n, seqLens, indices, numRows, stride0, stride1, k, None
+        logits,
+        next_n,
+        seqLens,
+        indices,
+        numRows,
+        stride0,
+        stride1,
+        k,
+        None,
+        rowEndsPerRow,
     )
 
 

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2176,37 +2176,41 @@ namespace py = pybind11;
     m.def("rocb_mm", &RocSolIdxBlas, "mm");                                        \
     m.def("rocb_findallsols", &RocFindAllSolIdxBlas, "rocblas_find_all_sols");
 
-#define TOP_K_PER_ROW_PYBIND                    \
-    m.def("top_k_per_row_prefill",              \
-          &top_k_per_row_prefill,               \
-          py::arg("logits"),                    \
-          py::arg("rowStarts"),                 \
-          py::arg("rowEnds"),                   \
-          py::arg("indices"),                   \
-          py::arg("values"),                    \
-          py::arg("numRows"),                   \
-          py::arg("stride0"),                   \
-          py::arg("stride1"),                   \
-          py::arg("k")         = 2048,          \
-          py::arg("workspace") = std::nullopt); \
-    m.def("top_k_per_row_decode",               \
-          &top_k_per_row_decode,                \
-          py::arg("logits"),                    \
-          py::arg("next_n"),                    \
-          py::arg("seqLens"),                   \
-          py::arg("indices"),                   \
-          py::arg("numRows"),                   \
-          py::arg("stride0"),                   \
-          py::arg("stride1"),                   \
-          py::arg("k")         = 2048,          \
-          py::arg("workspace") = std::nullopt); \
-    m.def("topk_mb_workspace_size",             \
-          &topk_mb_workspace_size,              \
-          py::arg("numRows"),                   \
-          py::arg("stride0"),                   \
-          py::arg("k"),                         \
-          py::arg("is_decode"));                \
-    m.def("topk_use_mulblocks", &topk_use_mulblocks, py::arg("numRows"), py::arg("stride0"));
+#define TOP_K_PER_ROW_PYBIND                     \
+    m.def("top_k_per_row_prefill",               \
+          &top_k_per_row_prefill,                \
+          py::arg("logits"),                     \
+          py::arg("rowStarts"),                  \
+          py::arg("rowEnds"),                    \
+          py::arg("indices"),                    \
+          py::arg("values"),                     \
+          py::arg("numRows"),                    \
+          py::arg("stride0"),                    \
+          py::arg("stride1"),                    \
+          py::arg("k")         = 2048,           \
+          py::arg("workspace") = std::nullopt);  \
+    m.def("top_k_per_row_decode",                \
+          &top_k_per_row_decode,                 \
+          py::arg("logits"),                     \
+          py::arg("next_n"),                     \
+          py::arg("seqLens"),                    \
+          py::arg("indices"),                    \
+          py::arg("numRows"),                    \
+          py::arg("stride0"),                    \
+          py::arg("stride1"),                    \
+          py::arg("k")             = 2048,       \
+          py::arg("workspace")     = std::nullopt, \
+          py::arg("rowEndsPerRow") = std::nullopt); \
+    m.def("topk_mb_workspace_size",              \
+          &topk_mb_workspace_size,               \
+          py::arg("numRows"),                    \
+          py::arg("stride0"),                    \
+          py::arg("k"),                          \
+          py::arg("is_decode"));                 \
+    m.def("topk_use_mulblocks",                  \
+          &topk_use_mulblocks,                   \
+          py::arg("numRows"),                    \
+          py::arg("stride0"));
 
 #define MLA_METADATA_PYBIND                                 \
     m.def("get_mla_metadata_v1",                            \

--- a/csrc/include/topk_per_row.h
+++ b/csrc/include/topk_per_row.h
@@ -13,6 +13,11 @@ void top_k_per_row_prefill(const torch::Tensor& logits,
                            int64_t k                              = 2048,
                            std::optional<torch::Tensor> workspace = std::nullopt);
 
+// `seqLens` is per-SEQUENCE: row r of sequence b = r / next_n is bounded by
+// `seqLens[b] - next_n + (r % next_n) + 1`, i.e. one KV row per query token.
+// That holds for an index cache with one entry per token; a compressed one
+// (DeepSeek-V4's CSA packs `ratio` tokens into an entry) needs a bound its
+// caller computes. Pass `rowEndsPerRow` for that: one end per ROW, used as is.
 void top_k_per_row_decode(const torch::Tensor& logits,
                           int64_t next_n,
                           const torch::Tensor& seqLens,
@@ -20,8 +25,9 @@ void top_k_per_row_decode(const torch::Tensor& logits,
                           int64_t numRows,
                           int64_t stride0,
                           int64_t stride1,
-                          int64_t k                              = 2048,
-                          std::optional<torch::Tensor> workspace = std::nullopt);
+                          int64_t k                                    = 2048,
+                          std::optional<torch::Tensor> workspace       = std::nullopt,
+                          std::optional<torch::Tensor> rowEndsPerRow   = std::nullopt);
 
 // Workspace-management queries exposed to Python (see get_topk_mb_workspace).
 int64_t topk_mb_workspace_size(int64_t numRows, int64_t stride0, int64_t k, bool is_decode);

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -386,6 +386,9 @@ __global__ void radix_kernel_persistent(T const* in,
     }
     else
     {
+        // One KV row per query token. A caller whose index cache packs several
+        // tokens into an entry passes per-ROW ends and next_n == 1, which
+        // collapses this to `rowEnds[batch_id]` — see top_k_per_row_decode.
         row_len = rowEnds[batch_id / next_n] - next_n + (batch_id % next_n) + 1;
     }
 
@@ -1974,6 +1977,8 @@ __global__ void radix_topk_one_block_kernel(T const* in,
     }
     else
     {
+        // One KV row per query token; per-ROW ends arrive as next_n == 1, which
+        // collapses this to `rowEnds[batch_id]` — see top_k_per_row_decode.
         rowEnd   = rowEnds[batch_id / next_n] - next_n + (batch_id % next_n) + 1;
         rowStart = 0;
     }
@@ -2623,7 +2628,8 @@ void top_k_per_row_decode(const torch::Tensor& logits,
                           int64_t stride0,
                           int64_t /*stride1*/,
                           int64_t k = 2048,
-                          std::optional<torch::Tensor> workspace = std::nullopt)
+                          std::optional<torch::Tensor> workspace = std::nullopt,
+                          std::optional<torch::Tensor> rowEndsPerRow = std::nullopt)
 {
     if (numRows <= 0) return;
 
@@ -2638,7 +2644,19 @@ void top_k_per_row_decode(const torch::Tensor& logits,
 
     float* logits_ptr = logits.data_ptr<float>();
     int* indices_ptr  = indices.data_ptr<int>();
-    int* seq_lens_ptr = seqLens.data_ptr<int>();
+
+    // A caller that computed its own per-ROW ends passes them here, and the
+    // per-sequence expression must not be applied on top. `next_n = 1` is
+    // exactly that identity:
+    //     rowEnds[r / 1] - 1 + (r % 1) + 1  ==  rowEnds[r]
+    // so the ends array goes in the rowEnds slot unchanged and no kernel needs
+    // a second code path. `next_n` reaches nothing but that expression (see
+    // radix_kernel_persistent / radix_topk_one_block_kernel) — keep it that
+    // way, or this collapse stops holding and the row bound silently reverts
+    // to the one-KV-row-per-token rule.
+    const bool per_row = rowEndsPerRow.has_value();
+    int* seq_lens_ptr  = per_row ? rowEndsPerRow->data_ptr<int>() : seqLens.data_ptr<int>();
+    if (per_row) next_n = 1;
 
     // Always use one-block path for decode.
     const size_t ob_ws         = query_ob_workspace<aiter::Phase::Decode>(batch, stride0, kTopK);

--- a/op_tests/test_topk_per_row.py
+++ b/op_tests/test_topk_per_row.py
@@ -312,6 +312,146 @@ def test_top_k_per_row_decode(
     return ret
 
 
+def _decode_row_ends_logits(row_ends: torch.Tensor, width: int, seed: int):
+    """Logits whose out-of-range tail is *attractive*, plus the -inf reference.
+
+    Padding the tail with -inf (as create_random_logits does) makes a too-large
+    row bound invisible: the kernel would scan the tail, pick nothing from it,
+    and still match. Here the tail holds the largest values in the row, so a
+    bound that overshoots pulls them in and the comparison fails. The reference
+    is the same tensor with the tail masked to -inf, i.e. the answer for a
+    kernel that respects the bound exactly.
+    """
+    torch.manual_seed(seed)
+    logits = torch.randn(row_ends.shape[0], width, dtype=torch.float32, device="cuda")
+    cols = torch.arange(width, device="cuda")
+    out_of_range = cols[None, :] >= row_ends[:, None]
+    logits = logits + out_of_range * 100.0
+    return logits, logits.masked_fill(out_of_range, float("-inf"))
+
+
+def test_decode_row_ends_per_row():
+    """Regression for `top_k_per_row_decode(..., rowEndsPerRow=...)`.
+
+    `seqLens` is per-SEQUENCE and bounds row r by
+    `seqLens[r // next_n] - next_n + (r % next_n) + 1` -- one KV row per query
+    token. A caller whose index cache packs several tokens into one entry
+    (DeepSeek-V4 CSA) computes its own per-ROW ends and passes them here; the
+    C++ side routes them into the rowEnds slot and forces next_n = 1, which
+    collapses that expression to `rowEnds[r]`.
+
+    So this asserts three things:
+      1. the ends are honoured verbatim, for ends no per-sequence seqLens could
+         produce (irregular, non-monotonic);
+      2. `seqLens` and `next_n` are ignored -- both are passed deliberately
+         wrong, so dropping the `next_n = 1` collapse silently reverts every
+         bound to the one-KV-row-per-token rule and this fails;
+      3. it selects the same elements as the seqLens path when the ends agree.
+    """
+    top_k, width = 512, 4096
+    # Short rows (end <= top_k) and long rows straddle the kernel's two code
+    # paths; the ends are deliberately non-monotonic and not a fixed stride
+    # apart, so no (seqLens, next_n) pair could generate them.
+    row_ends = torch.tensor(
+        [1, 2048, 17, 513, 4096, 128, 3000, 511, 2049, 512, 4095, 1000],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    num_rows = row_ends.numel()
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device="cuda")
+    logits, logits_ref = _decode_row_ends_logits(row_ends, width, seed=7)
+
+    # Wrong on purpose, and in range: if a regression made the kernel read
+    # these, the bound would be wrong rather than out of bounds -- a mismatch,
+    # not a segfault.
+    bogus_seq_lens = torch.full((num_rows,), width, dtype=torch.int32, device="cuda")
+    bogus_next_n = 3
+
+    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device="cuda")
+    aiter.top_k_per_row_decode(
+        logits,
+        bogus_next_n,
+        bogus_seq_lens,
+        indices,
+        num_rows,
+        logits.stride(0),
+        logits.stride(1),
+        k=top_k,
+        rowEndsPerRow=row_ends,
+    )
+    torch.cuda.synchronize()
+
+    # A row with end <= top_k takes the kernel's fill path, which emits the
+    # identity 0..end-1 padded with -1 -- independent of the values, so it
+    # pins the bound exactly. Comparing the whole row matters: an overshooting
+    # bound keeps the same leading entries and only shows up in the padding.
+    for row_idx in range(num_rows):
+        end = int(row_ends[row_idx])
+        if end > top_k:
+            continue
+        expected = torch.full((top_k,), -1, dtype=torch.int32, device="cuda")
+        expected[:end] = torch.arange(end, dtype=torch.int32, device="cuda")
+        assert torch.equal(indices[row_idx], expected), (
+            f"[row_ends_per_row] row {row_idx} (end={end}) took the fill path "
+            f"but did not emit 0..{end - 1} padded with -1; got "
+            f"{indices[row_idx][: end + 4].tolist()}"
+        )
+
+    # Long rows run the real radix top-k, so compare against torch on the
+    # masked logits.
+    ref = logits_ref.topk(min(top_k, int(row_ends.max())), dim=-1)[1]
+    assert compare_topk_results(
+        logits_ref, indices, ref, row_starts, row_ends, top_k
+    ), "[row_ends_per_row] per-row ends did not match torch.topk over the bounded region"
+
+    # Same bound expressed both ways must select the same elements. Here the
+    # ends DO follow the per-sequence rule, so the seqLens path is the oracle.
+    # Compared as sets, not bytes: the kernel returns a row in index order
+    # rather than value order, and its tail is not stable across launches, so
+    # even two identical calls differ elementwise. That is what
+    # compare_topk_results is set-based for.
+    next_n, batch_size, context_len = 4, 3, 2600
+    eq_rows = batch_size * next_n
+    seq_lens = torch.full((batch_size,), context_len, dtype=torch.int32, device="cuda")
+    rows = torch.arange(eq_rows, device="cuda")
+    eq_ends = (seq_lens[rows // next_n] - next_n + (rows % next_n) + 1).to(torch.int32)
+    eq_starts = torch.zeros(eq_rows, dtype=torch.int32, device="cuda")
+    eq_logits, eq_logits_ref = _decode_row_ends_logits(eq_ends, width, seed=13)
+
+    idx_seq_lens = torch.empty((eq_rows, top_k), dtype=torch.int32, device="cuda")
+    idx_per_row = torch.empty((eq_rows, top_k), dtype=torch.int32, device="cuda")
+    # The per-row call still gets a wrong seqLens, so it can only agree by
+    # actually reading eq_ends.
+    wrong_seq_lens = torch.full((batch_size,), width, dtype=torch.int32, device="cuda")
+    for out, lens, extra in (
+        (idx_seq_lens, seq_lens, {}),
+        (idx_per_row, wrong_seq_lens, {"rowEndsPerRow": eq_ends}),
+    ):
+        aiter.top_k_per_row_decode(
+            eq_logits,
+            next_n,
+            lens,
+            out,
+            eq_rows,
+            eq_logits.stride(0),
+            eq_logits.stride(1),
+            k=top_k,
+            **extra,
+        )
+    torch.cuda.synchronize()
+    assert compare_topk_results(
+        eq_logits_ref, idx_per_row, idx_seq_lens, eq_starts, eq_ends, top_k
+    ), (
+        "[row_ends_per_row] per-row ends selected different elements than the "
+        "equivalent seqLens path -- the next_n = 1 collapse no longer holds"
+    )
+    print(
+        f"[row_ends_per_row] PASS: {num_rows} irregular per-row ends honoured "
+        f"verbatim (bogus seqLens/next_n={bogus_next_n} ignored), and "
+        f"{eq_rows} rows agreed with the seqLens path"
+    )
+
+
 def test_mb_workspace_reuse():
     """Regression for the persistent multi-block workspace + kernel self-reset.
 
@@ -423,8 +563,9 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-# Self-reset / persistent-workspace regression (runs in CI via `python3 <file>`).
+# Correctness regressions (run in CI via `python3 <file>`).
 test_mb_workspace_reuse()
+test_decode_row_ends_per_row()
 
 
 df = []


### PR DESCRIPTION
## Summary

`top_k_per_row_decode` derives each row's KV bound from a per-SEQUENCE `seqLens`:

```
seqLens[r / next_n] - next_n + (r % next_n) + 1
```

i.e. one KV row per query token. DeepSeek-V4 compressed sparse attention packs
`ratio` tokens into a single index-cache entry, so that rule yields the wrong
bound for those callers. This adds an optional `rowEndsPerRow`: one end per ROW,
used as is.

## Changes

- `top_k_per_row_decode` gains an optional `rowEndsPerRow` across all layers —
  `csrc/kernels/topk_per_row_kernels.cu`, `csrc/include/topk_per_row.h`, the
  pybind signature in `csrc/include/rocm_ops.hpp`, and the wrapper in
  `aiter/ops/topk.py`. It defaults to `nullopt`/`None`, so existing callers are
  unaffected.
- When present, the array is routed into the `rowEnds` slot and `next_n` is
  forced to `1`, which collapses the per-sequence expression to `rowEnds[r]`.
  No second kernel code path is introduced.
- Comments at each site that depends on that collapse, since it holds only as
  long as `next_n` feeds nothing but that one expression on the decode path
  (currently true: decode dispatches only to `radix_topk_one_block_kernel`).
- New regression `test_decode_row_ends_per_row` in `op_tests/test_topk_per_row.py`.

## Test plan

All run on gfx950 (MI355X):

- Full default sweep, `python3 op_tests/test_topk_per_row.py` (what CI runs):
  **561/561 rows `all_close=True`** (33 prefill + 528 decode), exit code 0, and
  both regressions pass:
  ```
  [mb_workspace_reuse] PASS: 3 reused-buffer mb calls matched torch.topk
  [row_ends_per_row]   PASS: 12 irregular per-row ends honoured verbatim
                             (bogus seqLens/next_n=3 ignored), and 12 rows
                             agreed with the seqLens path
  ```
- Negative control: re-running the same case with `rowEndsPerRow` omitted makes
  5 short rows violate the bound check, so the new test genuinely fails when the
  feature is bypassed rather than passing vacuously.
- `black --check` clean; `ruff check` clean.

The new test asserts three things: the ends are honoured verbatim (using 12
irregular, non-monotonic ends that no `(seqLens, next_n)` pair could generate);
`seqLens` and `next_n` are ignored (both passed deliberately wrong, so dropping
the `next_n = 1` line makes it fail); and it selects the same elements as the
`seqLens` path when the two agree.

Two details that make the test sensitive, worth knowing if it ever needs editing:

- Out-of-range logits are filled with the *largest* values in the row, not
  `-inf`. With `-inf` padding (what `create_random_logits` does) an overshooting
  bound is invisible — the kernel scans the tail, selects nothing from it, and
  still matches.
- Rows with `end <= top_k` take the kernel's fill path, which emits
  `0..end-1` padded with `-1`; those are compared over the *whole* row, because
  an overshooting bound leaves the leading entries identical and only shows up
  in the padding. That is what the negative control above trips.

## Notes / possible follow-ups

Not addressed here, flagging for reviewers:

- `top_k_per_row_decode_fast` (the ASM path, gfx942 + `k=2048`) has no
  `rowEndsPerRow`, so CSA callers cannot use it.
- `rowEndsPerRow` is unvalidated: a non-int32 tensor throws inside
  `data_ptr<int>()`, and `numel() != numRows` reads out of bounds. A
  `TORCH_CHECK` on dtype and length would be cheap.

Unrelated pre-existing behaviour observed while testing: decode passes
`sorted=true`, but the output comes back in index order rather than value order,
and its tail is not stable across identical launches. `compare_topk_results` is
set-based, so this does not affect the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
