### PR TITLE
[FlyDSL] Use native FP4 conversion in MoE stage1

### DIFF
--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
@@ -2582,55 +2582,29 @@ def compile_mixed_moe_gemm1_common(
                         quant_scale = (quant_exp << c23_i32).bitcast(T.f32)
 
                         if const_expr(need_fp4):
-                            if const_expr(gpu_arch == "gfx950"):
-                                # gfx950 converts and packs two scaled FP4 values in one
-                                # native instruction. Other architectures retain the
-                                # software E2M1 conversion below.
-                                packed_i32 = c0_i32
-                                native_scale = (e8m0_biased << c23_i32).bitcast(T.f32)
-                                native_scale_raw = (
-                                    native_scale._value
-                                    if hasattr(native_scale, "_value")
-                                    else native_scale
+                            packed_i32 = c0_i32
+                            native_scale = (e8m0_biased << c23_i32).bitcast(T.f32)
+                            native_scale_raw = (
+                                native_scale._value
+                                if hasattr(native_scale, "_value")
+                                else native_scale
+                            )
+                            for k in range_constexpr(e_vec // 2):
+                                old_raw = (
+                                    packed_i32._value
+                                    if hasattr(packed_i32, "_value")
+                                    else packed_i32
                                 )
-                                for k in range_constexpr(e_vec // 2):
-                                    old_raw = (
-                                        packed_i32._value
-                                        if hasattr(packed_i32, "_value")
-                                        else packed_i32
-                                    )
-                                    src0 = frag_vals[2 * k]
-                                    src1 = frag_vals[2 * k + 1]
-                                    packed_i32 = rocdl.cvt_scalef32_pk_fp4_f32(
-                                        T.i32,
-                                        old_raw,
-                                        (
-                                            src0._value
-                                            if hasattr(src0, "_value")
-                                            else src0
-                                        ),
-                                        (
-                                            src1._value
-                                            if hasattr(src1, "_value")
-                                            else src1
-                                        ),
-                                        native_scale_raw,
-                                        k,
-                                    )
-                            else:
-                                fp4_vals = []
-                                for i in range_constexpr(e_vec):
-                                    scaled_v = frag_vals[i] * quant_scale
-                                    fp4_vals.append(f32_to_e2m1(scaled_v))
-
-                                packed_i32 = fp4_vals[0] | (fp4_vals[1] << c4_i32)
-                                for k in range_constexpr(1, e_vec // 2):
-                                    byte_k = fp4_vals[2 * k] | (
-                                        fp4_vals[2 * k + 1] << c4_i32
-                                    )
-                                    packed_i32 = packed_i32 | (
-                                        byte_k << arith.constant(k * 8, type=T.i32)
-                                    )
+                                src0 = frag_vals[2 * k]
+                                src1 = frag_vals[2 * k + 1]
+                                packed_i32 = rocdl.cvt_scalef32_pk_fp4_f32(
+                                    T.i32,
+                                    old_raw,
+                                    (src0._value if hasattr(src0, "_value") else src0),
+                                    (src1._value if hasattr(src1, "_value") else src1),
+                                    native_scale_raw,
+                                    k,
+                                )
 
                             ptr_addr_idx = row_byte_base + col_g0 // arith.constant(
                                 2, index=True

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
@@ -2582,19 +2582,55 @@ def compile_mixed_moe_gemm1_common(
                         quant_scale = (quant_exp << c23_i32).bitcast(T.f32)
 
                         if const_expr(need_fp4):
-                            fp4_vals = []
-                            for i in range_constexpr(e_vec):
-                                scaled_v = frag_vals[i] * quant_scale
-                                fp4_vals.append(f32_to_e2m1(scaled_v))
+                            if const_expr(gpu_arch == "gfx950"):
+                                # gfx950 converts and packs two scaled FP4 values in one
+                                # native instruction. Other architectures retain the
+                                # software E2M1 conversion below.
+                                packed_i32 = c0_i32
+                                native_scale = (e8m0_biased << c23_i32).bitcast(T.f32)
+                                native_scale_raw = (
+                                    native_scale._value
+                                    if hasattr(native_scale, "_value")
+                                    else native_scale
+                                )
+                                for k in range_constexpr(e_vec // 2):
+                                    old_raw = (
+                                        packed_i32._value
+                                        if hasattr(packed_i32, "_value")
+                                        else packed_i32
+                                    )
+                                    src0 = frag_vals[2 * k]
+                                    src1 = frag_vals[2 * k + 1]
+                                    packed_i32 = rocdl.cvt_scalef32_pk_fp4_f32(
+                                        T.i32,
+                                        old_raw,
+                                        (
+                                            src0._value
+                                            if hasattr(src0, "_value")
+                                            else src0
+                                        ),
+                                        (
+                                            src1._value
+                                            if hasattr(src1, "_value")
+                                            else src1
+                                        ),
+                                        native_scale_raw,
+                                        k,
+                                    )
+                            else:
+                                fp4_vals = []
+                                for i in range_constexpr(e_vec):
+                                    scaled_v = frag_vals[i] * quant_scale
+                                    fp4_vals.append(f32_to_e2m1(scaled_v))
 
-                            packed_i32 = fp4_vals[0] | (fp4_vals[1] << c4_i32)
-                            for k in range_constexpr(1, e_vec // 2):
-                                byte_k = fp4_vals[2 * k] | (
-                                    fp4_vals[2 * k + 1] << c4_i32
-                                )
-                                packed_i32 = packed_i32 | (
-                                    byte_k << arith.constant(k * 8, type=T.i32)
-                                )
+                                packed_i32 = fp4_vals[0] | (fp4_vals[1] << c4_i32)
+                                for k in range_constexpr(1, e_vec // 2):
+                                    byte_k = fp4_vals[2 * k] | (
+                                        fp4_vals[2 * k + 1] << c4_i32
+                                    )
+                                    packed_i32 = packed_i32 | (
+                                        byte_k << arith.constant(k * 8, type=T.i32)
+                                    )
 
                             ptr_addr_idx = row_byte_base + col_g0 // arith.constant(
                                 2, index=True


### PR DESCRIPTION
## Summary
- replace the software E2M1 conversion and manual packing loop with the native packed scale-and-convert instruction
- apply the native conversion directly in the supported MXFP4 MoE stage1 output path
- reduce fused FP4 quantization epilogue overhead without adding a config or environment switch

## Performance
Kimi-K3 A4W4, `model_dim=3584`, `inter_dim=384`, `E=896`, `topk=16`, balanced routing on gfx950:

| M | Baseline GEMM1 (us) | Native GEMM1 (us) | Improvement |
|---:|---:|---:|---:|
| 1 | 7.744 | 7.380 | 4.70% |
| 8 | 29.620 | 29.069 | 1.86% |
| 256 | 190.313 | 189.593 | 0.38% |
| 2048 | 200.534 | 200.511 | 0.01% |
| 4096 | 315.413 | 304.373 | 3.50% |
| 8192 | 459.175 | 442.191 | 3.70% |
| 14336 | 640.716 | 619.113 | 3.37% |
| 32768 | 1138.310 | 1081.140 | 5.02% |

## Test plan
- [x] `python3 op_tests/test_moe_2stage.py -q 4 -t 1 8 256 2048 4096 8192 14336 32768 -dim 3584,384 -e 896 -k 16 -a situv2 -p t --kernel --no-flydsl-csv --no-situv2`
- [x] `python3 -m black --check aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py`
- [x] `python3 -m ruff check --ignore E402 aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py`
- [x] Python compile check and `git diff --check`