### PR TITLE
[Triton] Fix LDS OOM issue on MI300

### DIFF
--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/__init__.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/__init__.py
@@ -17,12 +17,25 @@ beta_sigmoid_fwd              Elementwise sigmoid for beta gate.
 chunk_delta_attn_gate_fwd     Per-token gate without cumsum (forward only).
 """
 
-from .chunk_fwd import chunk_delta_attn_fwd
-from .gate import beta_sigmoid_fwd, chunk_delta_attn_gate_fwd
-from .gla_output import chunk_gla_fwd_o
-from .intra_attn import chunk_delta_attn_fwd_intra
-from .utils.cumsum import chunk_gate_cumsum
-from .wy_fast import recompute_w_u_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_fwd import (
+    chunk_delta_attn_fwd,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.gate import (
+    beta_sigmoid_fwd,
+    chunk_delta_attn_gate_fwd,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.gla_output import (
+    chunk_gla_fwd_o,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.intra_attn import (
+    chunk_delta_attn_fwd_intra,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.cumsum import (
+    chunk_gate_cumsum,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.wy_fast import (
+    recompute_w_u_fwd,
+)
 
 __all__ = [
     "beta_sigmoid_fwd",

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_delta_attn_utils.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_delta_attn_utils.py
@@ -11,6 +11,8 @@ import os
 import torch
 import triton
 
+from aiter.ops.triton.utils.tuned_config_utils import get_tuned_kernel_config
+
 SUPPORTS_AUTOTUNE_CACHE = (
     "cache_results" in inspect.signature(triton.autotune).parameters
 )
@@ -32,6 +34,15 @@ def chunk_delta_attn_autotune_configs(
     if CHUNK_DELTA_ATTN_TRITON_AUTOTUNE:
         return configs
     return [default_config if default_config is not None else configs[0]]
+
+
+def chunk_delta_attn_tuned_config(
+    kernel_name: str, fallback: triton.Config
+) -> triton.Config:
+    """This family's tile for the current device, from its published config."""
+    return get_tuned_kernel_config(
+        "attention", "CHUNK_DELTA_ATTN", kernel_name, fallback
+    )
 
 
 RCP_LN2: float = math.log2(math.e)  # 1/ln(2), for log2-space gate arithmetic

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_fwd.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_fwd.py
@@ -15,15 +15,25 @@ Pipeline:
 
 import torch
 
-from ..gated_delta_rule.prefill.chunk_delta_h import chunk_gated_delta_rule_fwd_h
-from .gate import beta_sigmoid_fwd
-from .gla_output import chunk_gla_fwd_o
-from .intra_attn import chunk_delta_attn_fwd_intra
-from .utils import (
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     RCP_LN2,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.gate import beta_sigmoid_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.gla_output import (
+    chunk_gla_fwd_o,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.intra_attn import (
+    chunk_delta_attn_fwd_intra,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.cumsum import (
     chunk_gate_cumsum,
-    l2norm_fwd,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.l2norm import l2norm_fwd
+from aiter.ops.triton._triton_kernels.gated_delta_rule.prefill.chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_h,
 )
 
 
@@ -125,7 +135,9 @@ def chunk_delta_attn_fwd(
             lower_bound=lower_bound,
         )
     else:
-        from ..gated_delta_rule.utils import chunk_local_cumsum
+        from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
+            chunk_local_cumsum,
+        )
 
         g_cumsum = chunk_local_cumsum(
             g=g,

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gate.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gate.py
@@ -15,7 +15,12 @@ import torch
 import triton
 import triton.language as tl
 
-from .utils import autotune_cache_kwargs, exp, input_guard, softplus
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
+    autotune_cache_kwargs,
+    exp,
+    input_guard,
+    softplus,
+)
 
 _BETA_SIGMOID_BLOCK_SIZE = 2048
 _BETA_SIGMOID_NUM_WARPS = 8

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gla_output.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gla_output.py
@@ -15,14 +15,24 @@ import torch
 import triton
 import triton.language as tl
 
-from .utils import (
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     autotune_cache_kwargs,
     chunk_delta_attn_autotune_configs,
+    chunk_delta_attn_tuned_config,
     exp,
     exp2,
     input_guard,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
 )
+
+# The BV=128 / num_stages=3 tile this kernel came with wants up to 123KB of LDS,
+# which a 64KB device (gfx942, gfx90a) cannot launch at all. Unpipelined, this one
+# compiles to 16KB for every shape measured, so it runs anywhere, at 3% on long
+# prefills and 9% at low occupancy. Devices with the budget for a wider tile keep
+# it by pinning one in configs/<arch>/triton/attention/chunk_delta_attn/DEFAULT.json.
+_FALLBACK_O_CONFIG = triton.Config({"BK": 64, "BV": 64}, num_warps=4, num_stages=1)
 
 
 @triton.heuristics(
@@ -39,9 +49,13 @@ from .utils import (
             for nw in [2, 4, 8]
             for ns in [2, 3, 4]
         ],
-        default_config=triton.Config({"BK": 64, "BV": 128}, num_warps=8, num_stages=3),
+        default_config=chunk_delta_attn_tuned_config(
+            "chunk_gla_fwd_kernel_o", _FALLBACK_O_CONFIG
+        ),
     ),
-    key=["BT", "HV", "TRANSPOSE_STATE"],
+    # K and V belong in the key alongside BT: they set how much LDS a tile needs,
+    # so a choice made for one head dim can be unlaunchable at the next one.
+    key=["BT", "HV", "K", "V", "TRANSPOSE_STATE"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/intra_attn.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/intra_attn.py
@@ -19,16 +19,20 @@ import torch
 import triton
 import triton.language as tl
 
-from .utils import (
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     IS_GATHER_SUPPORTED,
     IS_TF32_SUPPORTED,
     autotune_cache_kwargs,
     chunk_delta_attn_autotune_configs,
     exp2,
     input_guard,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
 )
-from .wy_fast import recompute_w_u_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.wy_fast import (
+    recompute_w_u_fwd,
+)
 
 if IS_TF32_SUPPORTED:
     SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/__init__.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/__init__.py
@@ -1,35 +1,3 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 # Adapted from flash-linear-attention: Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
-
-from .cumsum import chunk_gate_cumsum
-from .index import prepare_chunk_indices
-from .l2norm import l2norm_fwd
-from .utils import (
-    IS_GATHER_SUPPORTED,
-    IS_TF32_SUPPORTED,
-    RCP_LN2,
-    autotune_cache_kwargs,
-    check_shared_mem,
-    chunk_delta_attn_autotune_configs,
-    exp,
-    exp2,
-    input_guard,
-    softplus,
-)
-
-__all__ = [
-    "IS_GATHER_SUPPORTED",
-    "IS_TF32_SUPPORTED",
-    "RCP_LN2",
-    "autotune_cache_kwargs",
-    "check_shared_mem",
-    "chunk_delta_attn_autotune_configs",
-    "chunk_gate_cumsum",
-    "exp",
-    "exp2",
-    "input_guard",
-    "l2norm_fwd",
-    "prepare_chunk_indices",
-    "softplus",
-]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/cumsum.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/cumsum.py
@@ -8,14 +8,16 @@ import torch
 import triton
 import triton.language as tl
 
-from .index import prepare_chunk_indices
-from .utils import (
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     autotune_cache_kwargs,
     check_shared_mem,
     chunk_delta_attn_autotune_configs,
     exp,
     input_guard,
     softplus,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
+    prepare_chunk_indices,
 )
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/wy_fast.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/wy_fast.py
@@ -17,11 +17,13 @@ import torch
 import triton
 import triton.language as tl
 
-from .utils import (
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     autotune_cache_kwargs,
     chunk_delta_attn_autotune_configs,
     exp2,
     input_guard,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
 )
 

--- a/aiter/ops/triton/configs/gfx942/triton/attention/chunk_delta_attn/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx942/triton/attention/chunk_delta_attn/DEFAULT.json
@@ -1,0 +1,8 @@
+{
+    "chunk_gla_fwd_kernel_o": {
+        "BK": 32,
+        "BV": 128,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/attention/chunk_delta_attn/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950/triton/attention/chunk_delta_attn/DEFAULT.json
@@ -1,0 +1,8 @@
+{
+    "chunk_gla_fwd_kernel_o": {
+        "BK": 64,
+        "BV": 128,
+        "num_warps": 8,
+        "num_stages": 3
+    }
+}

--- a/aiter/ops/triton/kimi_delta_attn/__init__.py
+++ b/aiter/ops/triton/kimi_delta_attn/__init__.py
@@ -8,7 +8,7 @@ Public Triton entry points for the KDA linear-attention mixer used by
 Kimi-Linear / Kimi-K3. The chunked prefill op mirrors ``fla.ops.kda.chunk_kda``.
 """
 
-from .chunk_delta_attn import chunk_kimi_delta_attn
+from aiter.ops.triton.kimi_delta_attn.chunk_delta_attn import chunk_kimi_delta_attn
 
 __all__ = [
     "chunk_kimi_delta_attn",

--- a/aiter/ops/triton/utils/tuned_config_utils.py
+++ b/aiter/ops/triton/utils/tuned_config_utils.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Per-arch tuned tiles for kernels that carry a Python autotune search space.
+
+The GEMM and MOE families resolve a tuned entry per shape at launch time. These
+kernels need less: their search is opt-in, so all that has to be decided is the
+one config registered when it is off. Keeping that in a config file rather than
+in Python means pinning a tile for a new device is a file and not a branch.
+"""
+
+import functools
+
+import triton
+
+from aiter.ops.triton.utils._triton import arch_info
+from aiter.ops.triton.utils.core import (
+    AITER_TRITON_CONFIGS_PATH,
+    USE_LRU_CACHE,
+    load_config_json,
+)
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+logger = AiterTritonLogger()
+
+
+@functools.lru_cache(maxsize=1024 if USE_LRU_CACHE else 0)
+def _get_tuned_kernel_entry(
+    op: str, config_name: str, kernel_name: str, backend: str
+) -> tuple[str, dict | None]:
+    """Internal cached lookup returning ``(config path, entry or None)``.
+
+    Do NOT use this directly — the entry is the shared cached object, so
+    ``get_tuned_kernel_config()`` copies it before handing it out.
+    """
+    arch = arch_info.get_arch()
+    # Nested layout of configs/CLAUDE.md: <arch>/<backend>/<op>/<d_type>/DEFAULT.json,
+    # <d_type> being the config name lowercased with dashes folded to underscores.
+    dtype_dir = config_name.lower().replace("-", "_")
+    config_path = (
+        f"{AITER_TRITON_CONFIGS_PATH}/{arch}/{backend}/{op}/{dtype_dir}/DEFAULT.json"
+    )
+    published = load_config_json(config_path, required=False) or {}
+    return config_path, published.get(kernel_name)
+
+
+def get_tuned_kernel_config(
+    op: str,
+    config_name: str,
+    kernel_name: str,
+    fallback: triton.Config,
+    backend: str = "triton",
+) -> triton.Config:
+    """The tile pinned for this device, or ``fallback`` where none is published.
+
+    What fits is not portable: the same tile can compile to 16KB of LDS on one
+    arch and to more than the 64KB another one has. A device nobody has measured
+    therefore gets the fallback, which has to be launchable anywhere rather than
+    fastest somewhere, and stays on it until a measured entry is published.
+
+    Args:
+        op: Op family directory, e.g. ``"attention"``.
+        config_name: Config family, e.g. ``"CHUNK_DELTA_ATTN"``.
+        kernel_name: Key of the kernel's entry within the config file.
+        fallback: Config to register when this device has no published entry.
+        backend: ``"triton"`` or ``"gluon"``.
+    """
+    try:
+        config_path, entry = _get_tuned_kernel_entry(
+            op, config_name, kernel_name, backend
+        )
+    except BaseException as error:  # noqa: BLE001 -- no accelerator/unreadable file
+        logger.warning(
+            f"Unable to load tuned Triton config '{config_name}' for "
+            f"kernel '{kernel_name}'; using fallback {fallback}: {error}"
+        )
+        return fallback
+    if not entry:
+        logger.warning(
+            f"No tuned Triton config for kernel '{kernel_name}' in "
+            f"'{config_path}'; using fallback {fallback}"
+        )
+        return fallback
+    entry = dict(entry)
+    num_warps = entry.pop("num_warps", fallback.num_warps)
+    num_stages = entry.pop("num_stages", fallback.num_stages)
+    return triton.Config(entry, num_warps=num_warps, num_stages=num_stages)

--- a/op_tests/triton_tests/chunk_delta_attn/test_chunk_delta_attn_fwd.py
+++ b/op_tests/triton_tests/chunk_delta_attn/test_chunk_delta_attn_fwd.py
@@ -17,22 +17,13 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-# Attempt to import the FLA reference; skip if unavailable.
-# Install flash-linear-attention (`pip install -e /path/to/fla`) to enable
-# the consistency tests against the upstream reference.
-try:
-    from fla.ops.kda.chunk import chunk_kda
-
-    HAS_FLA = True
-except (ImportError, ModuleNotFoundError):
-    HAS_FLA = False
-
 from aiter.ops.triton._triton_kernels.chunk_delta_attn import chunk_delta_attn_fwd
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.gate import beta_sigmoid_fwd
-from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils import l2norm_fwd
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.cumsum import (
     chunk_gate_cumsum,
 )
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.l2norm import l2norm_fwd
+from op_tests.triton_tests.utils.kda_ref import chunk_kda_ref
 
 device = "cuda"
 dtype = torch.bfloat16
@@ -437,8 +428,8 @@ class TestStateVFirst:
             )
 
 
-@pytest.mark.skipif(not HAS_FLA, reason="flash-linear-attention not available")
-class TestChunkDeltaAttnFwdVsFLA:
+class TestChunkDeltaAttnFwdVsReference:
+    """Compare against the token-at-a-time fp32 recurrence the kernels blockify."""
 
     @pytest.mark.parametrize(
         "B,T,H,K,V",
@@ -448,11 +439,11 @@ class TestChunkDeltaAttnFwdVsFLA:
             (1, 64, 64, 128, 128),
         ],
     )
-    def test_output_matches_fla(self, B, T, H, K, V):
+    def test_output_matches_reference(self, B, T, H, K, V):
         HV = H
         q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H, HV, K, V)
 
-        o_ref, _ = chunk_kda(
+        o_ref, _ = chunk_kda_ref(
             q=q,
             k=k,
             v=v,

--- a/op_tests/triton_tests/utils/kda_ref.py
+++ b/op_tests/triton_tests/utils/kda_ref.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""Pure-PyTorch reference for Kimi Delta Attention (KDA).
+
+The entry point mirrors the signature of
+``aiter.ops.triton.kimi_delta_attn.chunk_kimi_delta_attn`` so a test can drive
+both from a single argument dict.
+
+The recurrence is evaluated one token at a time in fp32 -- the definition the
+chunked kernels approximate -- so a disagreement points at the blocked
+formulation rather than at a second copy of it. It is O(T) Python-level
+iterations, so keep the sequence lengths passed here small.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import torch
+import torch.nn.functional as F
+
+__all__ = ["chunk_kda_ref", "kda_gate_ref", "l2norm_ref"]
+
+
+def l2norm_ref(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """L2-normalize the last dimension in fp32. ``eps`` matches ``l2norm_fwd``."""
+    x = x.float()
+    return x * torch.rsqrt(x.pow(2).sum(-1, keepdim=True) + eps)
+
+
+def kda_gate_ref(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+) -> torch.Tensor:
+    """Per-token log-space forget gate, shape ``[..., H, K]`` in, same out.
+
+    Without ``lower_bound``: ``-exp(A_log) * softplus(g + dt_bias)``.
+    With one: ``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``, which is
+    bounded by construction.
+
+    ``F.softplus`` falls back to the identity past ``x = 20``, which is what
+    keeps a gate outlier from overflowing fp32 and poisoning the cumsum of
+    every later token.
+    """
+    H = g.shape[-2]
+    g = g.float()
+    if dt_bias is not None:
+        g = g + dt_bias.view(H, -1)
+    A = A_log.float().view(H, 1).exp()
+    if lower_bound is None:
+        return -A * F.softplus(g)
+    return lower_bound * torch.sigmoid(A * g)
+
+
+def _recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Token-by-token gated delta rule.
+
+    ``q``/``k`` are ``[B, T, H, K]``, ``v`` is ``[B, T, HV, V]``, ``g`` is the
+    per-token log decay ``[B, T, HV, K]`` and ``beta`` is ``[B, T, HV]``. The
+    state is K-first ``[B, HV, K, V]``.
+    """
+    B, T, H, K = q.shape
+    HV, V = v.shape[2], v.shape[-1]
+    G = HV // H
+
+    q, k, v, g, beta = (x.float() for x in (q, k, v, g, beta))
+    # GVA: every value head reads the qk head it is grouped under.
+    q = q.repeat_interleave(G, dim=2) * scale
+    k = k.repeat_interleave(G, dim=2)
+
+    S = q.new_zeros(B, HV, K, V)
+    if initial_state is not None:
+        S = S + initial_state.float()
+    o = q.new_zeros(B, T, HV, V)
+    for i in range(T):
+        q_i, k_i, v_i = q[:, i], k[:, i], v[:, i]
+        g_i, beta_i = g[:, i], beta[:, i]
+        S = S * g_i[..., None].exp()
+        # Delta rule: write the residual against what the state already holds.
+        delta = beta_i[..., None] * (v_i - (k_i[..., None] * S).sum(-2))
+        S = S + k_i[..., None] * delta[..., None, :]
+        o[:, i] = (q_i[..., None] * S).sum(-2)
+    return o, S
+
+
+def chunk_kda_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    use_gate_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
+    safe_gate: bool = False,
+    lower_bound: float | None = None,
+    state_v_first: bool = False,
+    disable_recompute: bool = False,
+    chunk_size: int = 64,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Reference KDA forward pass.
+
+    ``safe_gate``, ``disable_recompute`` and ``chunk_size`` pick a kernel
+    schedule rather than a result, so they are accepted and ignored here.
+
+    Returns ``(o, final_state)`` with ``o`` of shape ``[B, T, HV, V]`` in the
+    dtype of ``q``, and an fp32 final state laid out like ``initial_state``.
+    """
+    del safe_gate, disable_recompute, chunk_size
+
+    out_dtype = q.dtype
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    if use_qk_l2norm_in_kernel:
+        q, k = l2norm_ref(q), l2norm_ref(k)
+    if use_beta_sigmoid_in_kernel:
+        beta = torch.sigmoid(beta.float())
+    if use_gate_in_kernel:
+        if A_log is None:
+            raise ValueError("`A_log` is required when `use_gate_in_kernel=True`.")
+        g = kda_gate_ref(g, A_log, dt_bias, lower_bound)
+
+    h0 = initial_state
+    if h0 is not None:
+        h0 = h0.float()
+        if state_v_first:
+            h0 = h0.transpose(-1, -2)
+
+    if cu_seqlens is None:
+        o, final_state = _recurrent_kda(q, k, v, g, beta, scale, h0)
+    else:
+        # Packed sequences: each one carries its own state, so they cannot share
+        # a single pass.
+        bounds = cu_seqlens.tolist()
+        outs, states = [], []
+        for n, (bos, eos) in enumerate(itertools.pairwise(bounds)):
+            o_n, s_n = _recurrent_kda(
+                q[:, bos:eos],
+                k[:, bos:eos],
+                v[:, bos:eos],
+                g[:, bos:eos],
+                beta[:, bos:eos],
+                scale,
+                None if h0 is None else h0[n : n + 1],
+            )
+            outs.append(o_n)
+            states.append(s_n)
+        o = torch.cat(outs, dim=1)
+        final_state = torch.cat(states, dim=0)
+
+    if not output_final_state:
+        final_state = None
+    elif state_v_first:
+        final_state = final_state.transpose(-1, -2).contiguous()
+    return o.to(out_dtype), final_state


### PR DESCRIPTION
## Motivation
`chunk_kimi_delta_attn` cannot launch on MI300.

## Technical Details
1. Update chunk_delta_attn reference implementation to use torch
2. Reduce num-stages for other architectures to lower LDS consumption

## Test Plan

- `pytest op_tests/triton_tests/chunk_delta_attn/` on gfx1250/gfx950/gfx942

## Test Result

pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
