### PR TITLE
fused_moe: add moe_output param for combine zero-copy

### DIFF
--- a/aiter/fhmoe.py
+++ b/aiter/fhmoe.py
@@ -355,6 +355,7 @@ def fhmoe_fake(
     shared_w1_scale: torch.Tensor | None = None,
     shared_w2_scale: torch.Tensor | None = None,
     shared_expert_id: int = -1,
+    moe_output: torch.Tensor | None = None,
 ) -> torch.Tensor:
     del (
         w1,
@@ -382,6 +383,8 @@ def fhmoe_fake(
         shared_w2_scale,
         shared_expert_id,
     )
+    if moe_output is not None:
+        return moe_output
     output_dtype = hidden_states.dtype if dtype is None else dtype
     return torch.empty(
         (topk_ids.shape[0], w2.shape[1]),
@@ -420,6 +423,7 @@ def fhmoe_(
     shared_w1_scale: torch.Tensor | None = None,
     shared_w2_scale: torch.Tensor | None = None,
     shared_expert_id: int = -1,
+    moe_output: torch.Tensor | None = None,
 ) -> torch.Tensor:
     from aiter.fused_moe import _fused_moe_impl
 
@@ -482,6 +486,7 @@ def fhmoe_(
             "shared_w2_scale": shared_w2_scale,
             "shared_expert_id": shared_expert_id,
         },
+        _moe_output=moe_output,
     )
 
 

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -486,6 +486,7 @@ def fused_moe(
     shared_w1_scale: torch.Tensor | None = None,
     shared_w2_scale: torch.Tensor | None = None,
     shared_expert_id: int = -1,
+    moe_output: torch.Tensor | None = None,
 ):
     if (
         any(
@@ -525,6 +526,7 @@ def fused_moe(
             shared_w1_scale=shared_w1_scale,
             shared_w2_scale=shared_w2_scale,
             shared_expert_id=shared_expert_id,
+            moe_output=moe_output,
         )
     if not block_size_M:
         block_size_M = -1
@@ -554,6 +556,7 @@ def fused_moe(
         beta=beta,
         linear_beta=linear_beta,
         gate_mode=gate_mode,
+        moe_output=moe_output,
     )
 
 
@@ -583,7 +586,10 @@ def fused_moe_fake(
     bias2: torch.Tensor | None = None,
     swiglu_limit: float | None = None,
     gate_mode: str = GateMode.SEPARATED.value,
+    moe_output: torch.Tensor | None = None,
 ) -> torch.Tensor:
+    if moe_output is not None:
+        return moe_output
     device = topk_ids.device
     M, _topk = topk_ids.shape
     dtype = hidden_states.dtype if dtype is None else dtype
@@ -621,6 +627,7 @@ def fused_moe_(
     beta: float | None = None,
     linear_beta: float | None = None,
     gate_mode: str = GateMode.SEPARATED.value,
+    moe_output: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return _fused_moe_impl(
         hidden_states=hidden_states,
@@ -648,6 +655,7 @@ def fused_moe_(
         beta=beta,
         linear_beta=linear_beta,
         gate_mode=gate_mode,
+        _moe_output=moe_output,
     )
 
 
@@ -682,6 +690,7 @@ def _fused_moe_impl(
     _metadata_transform: Callable | None = None,
     _stage1_extra_args: dict | None = None,
     _stage2_extra_args: dict | None = None,
+    _moe_output: torch.Tensor | None = None,
 ) -> torch.Tensor:
     # We do such convert since custom_op schema restriction on block_size_M, and Enum type
     activation = ActivationType(activation)
@@ -708,6 +717,11 @@ def _fused_moe_impl(
         dtypes.fp16,
         dtypes.bf16,
     ], f"Fused_moe unsupported out dtype: {dtype}"
+    if _moe_output is not None:
+        assert _moe_output.shape == (M, model_dim) and _moe_output.dtype == dtype, (
+            f"moe_output must be ({M}, {model_dim}) {dtype}, "
+            f"got {tuple(_moe_output.shape)} {_moe_output.dtype}"
+        )
     quant_type = quant_remap.get(quant_type, quant_type)
     q_dtype_w = w1.dtype
     q_dtype_a = w1.dtype if w1.dtype != torch.uint32 else dtypes.fp8
@@ -799,6 +813,7 @@ def _fused_moe_impl(
                 num_local_tokens=num_local_tokens,
                 situ_beta=1.0 if beta is None else float(beta),
                 situ_linear_beta=1.0 if linear_beta is None else float(linear_beta),
+                moe_output=_moe_output,
             )
 
     if grouped_a8w4_out is not None:
@@ -891,6 +906,7 @@ def _fused_moe_impl(
             )
         _kn2 = metadata.stage2.keywords.get("kernelName2", "")
         _atomic = parse_g2_kname_any(_kn2)["atomic"]
+        _use_accumulate = _atomic
         (
             sorted_ids,
             sorted_weights,
@@ -911,6 +927,7 @@ def _fused_moe_impl(
         )
         local_topk_ids = None
     else:
+        _use_accumulate = not stage2_uses_route_reduce(metadata.stage2)
         sorting_ret = moe_sorting(
             topk_ids,
             topk_weight,
@@ -922,7 +939,7 @@ def _fused_moe_impl(
             num_local_tokens,
             moe_sorting_dispatch_policy,
             return_local_topk_ids=need_local_topk_ids,
-            accumulate=not stage2_uses_route_reduce(metadata.stage2),
+            accumulate=_use_accumulate,
             flat=metadata.flat,
         )
         if need_local_topk_ids:
@@ -940,6 +957,12 @@ def _fused_moe_impl(
             )
             local_topk_ids = None
     _opus_a8w4.check_route_bucket_metadata(metadata, sorted_expert_ids, logger)
+
+    _use_external_output = _moe_output is not None and not metadata.flat
+    if _use_external_output:
+        if _use_accumulate:
+            _moe_output.zero_()
+        moe_buf = _moe_output
 
     if metadata.run_1stage:
         _stage1_call = functools.partial(
@@ -968,9 +991,9 @@ def _fused_moe_impl(
         )
         if kernel_bench_callable is not None:
             kernel_bench_callable.append(("stage1", _stage1_call))
-        return _stage1_call()
+        result = _stage1_call()
     else:
-        return fused_moe_2stages(
+        result = fused_moe_2stages(
             hidden_states,
             w1,
             w2,
@@ -1011,6 +1034,10 @@ def _fused_moe_impl(
             _stage1_extra_args=_stage1_extra_args,
             _stage2_extra_args=_stage2_extra_args,
         )
+
+    if _moe_output is not None and result.data_ptr() != _moe_output.data_ptr():
+        _moe_output.copy_(result)
+    return result
 
 
 def fused_moe_1stage(

--- a/aiter/ops/flydsl/grouped_moe_gfx1250.py
+++ b/aiter/ops/flydsl/grouped_moe_gfx1250.py
@@ -400,6 +400,7 @@ def _grouped_a8w4_tdm_moe(
     num_local_tokens=None,
     situ_beta=1.0,
     situ_linear_beta=1.0,
+    moe_output=None,
 ):
     import functools
 
@@ -722,7 +723,7 @@ def _grouped_a8w4_tdm_moe(
             )
         )
 
-    moe_out = torch.empty((token_num, model_dim), dtype=dtype, device=device)
+    moe_out = moe_output if moe_output is not None else torch.empty((token_num, model_dim), dtype=dtype, device=device)
     if _is_ep:
         # Route kernel already produced gather weights (dropped routes zeroed);
         # the dead-tail (tokens >= total_recv) is skipped via num_valid_tokens.
@@ -772,6 +773,7 @@ def grouped_gemm_gfx1250_a8w4(
     num_local_tokens: torch.Tensor | None = None,
     situ_beta: float = 1.0,
     situ_linear_beta: float = 1.0,
+    moe_output: torch.Tensor | None = None,
 ):
     """Grouped a8w4/a4w4 MoE on the felix TDM batched GEMM (gfx1250).
 
@@ -1016,6 +1018,7 @@ def grouped_gemm_gfx1250_a8w4(
             num_local_tokens=num_local_tokens,
             situ_beta=situ_beta,
             situ_linear_beta=situ_linear_beta,
+            moe_output=moe_output,
             **_tdm_kw,
         )
 


### PR DESCRIPTION
Allow callers to pass a pre-allocated output buffer (e.g. alltoall combine workspace) so the MoE kernel writes directly into it, eliminating the D2D copy between MoE output and combine input.

- Thread moe_output through fused_moe/fused_moe_/fhmoe_/fhmoe_fake and _fused_moe_impl
- Non-FLAT paths: substitute moe_buf with external buffer (true zero-copy)
- FLAT paths: copy fallback via data_ptr() check
- Conditionally zero_() only for atomic-accumulate stage2 kernels
- gfx1250 grouped GEMM: thread moe_output to _grouped_a8w4_tdm_moe