### PR TITLE
fix(v4): stop turning row and block numbers into 32-bit addresses; add a direct-row SWA write

### DIFF
--- a/aiter/ops/flydsl/kernels/fused_compress_attn.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn.py
@@ -1138,19 +1138,20 @@ def _build_kernel(
                         dword = (p0, p1)
 
                     # Compute store address (in BYTES from kv_cache base).
-                    # Both layouts use the same base (= phys * block_stride);
-                    # the offset within the block differs.
+                    # Both layouts share the same block base, which rides on
+                    # the descriptor rather than the 32-bit offset -- see
+                    # `block_base_bytes_i64`. Only the in-block offset differs.
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
-                    )
-                    block_byte_base = ArithValue(physical_block) * ArithValue(
-                        kv_cache_block_stride
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 1
+                        ),
                     )
 
                     if const_expr(preshuffle):
                         # MFMA 16x16 tile layout
-                        # offset = block_base
-                        #        + token_tile_id * (TILE * D)
+                        # offset = token_tile_id * (TILE * D)
                         #        + col_tile_id * (TILE * TILE)
                         #        + token_in_tile * TILE
                         #        + col_in_tile
@@ -1172,12 +1173,13 @@ def _build_kernel(
                             + ArithValue(col_in_tile)
                         )
                     else:
-                        # Linear layout: phys * block_stride + slot * D + tid * VEC
+                        # Linear layout: slot * D + tid * VEC (block base folded
+                        # into the descriptor above).
                         in_block_off = ArithValue(slot_in_block) * arith.constant(
                             D, type=i32
                         ) + ArithValue(tid) * arith.constant(VEC, type=i32)
 
-                    byte_off = block_byte_base + in_block_off
+                    byte_off = in_block_off
 
                     if const_expr(VEC == 2):
                         # Only even tid stores (its dword covers peer's bytes too).
@@ -1204,15 +1206,19 @@ def _build_kernel(
                             offset_is_bytes=True,
                         )
 
-                    # (f) lane-0 writes fp32 scale at cache_scale[phys, slot]
+                    # (f) lane-0 writes fp32 scale at cache_scale[phys, slot].
+                    # Block term on the descriptor base, as above.
                     if tid == 0:
                         cs_rsrc = buffer_ops.create_buffer_resource(
-                            cache_scale, max_size=True
+                            cache_scale,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, cache_scale_block_stride, 4
+                            ),
                         )
-                        cs_off = fx.Int32(physical_block) * fx.Int32(
-                            cache_scale_block_stride
-                        ) + fx.Int32(slot_in_block)
-                        buffer_ops.buffer_store(scale_v, cs_rsrc, cs_off)
+                        buffer_ops.buffer_store(
+                            scale_v, cs_rsrc, fx.Int32(slot_in_block)
+                        )
                 else:
                     # ── QUANT=1, FP4: per-group(32) e8m0 scale + E2M1 write ──
                     # Mirrors dsv4_rotate_quant.cu's FP4 KV writer + the shared
@@ -1274,15 +1280,24 @@ def _build_kernel(
                         for i in range_constexpr(VEC)
                     ]
 
+                    # The block term rides on the descriptor's base, not on the
+                    # 32-bit offset -- see `block_base_bytes_i64`. Both fp4
+                    # layouts pack a block into a compile-time constant number
+                    # of bytes, so the base is that constant times the block.
+                    _fp4_block_bytes = (
+                        K_TILES * 4 * KVBS * 16
+                        if preshuffle
+                        else k_per_block * (D // 2)
+                    )
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, _fp4_block_bytes, 1
+                        ),
                     )
                     # packed byte index within the row = (tid*VEC) / 2.
                     packed_start = ArithValue(tid_x_vec) >> arith.constant(1, type=i32)
-                    # flat paged slot (for the linear fallback).
-                    flat_slot = ArithValue(physical_block) * arith.constant(
-                        k_per_block, type=i32
-                    ) + ArithValue(slot_in_block)
                     for b in range_constexpr(PACKED_BYTES):
                         byte_val = ArithValue(nibs[2 * b]) | (
                             ArithValue(nibs[2 * b + 1]) << c4_i32
@@ -1295,9 +1310,7 @@ def _build_kernel(
                             group4 = arith.divsi(rem, c16_i32)
                             sub16 = arith.remui(rem, c16_i32)
                             byte_off = (
-                                ArithValue(physical_block)
-                                * arith.constant(K_TILES * 4 * KVBS * 16, type=i32)
-                                + ArithValue(k_tile)
+                                ArithValue(k_tile)
                                 * arith.constant(4 * KVBS * 16, type=i32)
                                 + ArithValue(group4)
                                 * arith.constant(KVBS * 16, type=i32)
@@ -1305,7 +1318,7 @@ def _build_kernel(
                                 + ArithValue(sub16)
                             )
                         else:
-                            byte_off = ArithValue(flat_slot) * arith.constant(
+                            byte_off = ArithValue(slot_in_block) * arith.constant(
                                 D // 2, type=i32
                             ) + ArithValue(packed_idx)
                         buffer_ops.buffer_store(
@@ -1318,8 +1331,19 @@ def _build_kernel(
                     # (e) group-rep lane writes the e8m0 scale byte.
                     scale_group_idx = arith.divsi(tid_x_vec, c32_i32)
                     if tid % NTG == 0:
+                        # Block term on the descriptor base, as above; the u8
+                        # scale plane packs a block into a constant byte count.
+                        _fp4_scale_block_bytes = (
+                            K_TILES * 4 * KVBS
+                            if preshuffle
+                            else k_per_block * (D // _FP4_GROUP_SIZE)
+                        )
                         cs_rsrc = buffer_ops.create_buffer_resource(
-                            cache_scale, max_size=True
+                            cache_scale,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, _fp4_scale_block_bytes, 1
+                            ),
                         )
                         if const_expr(preshuffle):
                             # scale [NB, k_tiles, 4, kvbs] u8, with the slot axis
@@ -1337,15 +1361,13 @@ def _build_kernel(
                                 arith.divsi(_to_raw(slot_in_block), c16_i32)
                             )
                             cs_off = (
-                                ArithValue(physical_block)
-                                * arith.constant(K_TILES * 4 * KVBS, type=i32)
-                                + ArithValue(k_tile_s)
+                                ArithValue(k_tile_s)
                                 * arith.constant(4 * KVBS, type=i32)
                                 + ArithValue(group4_s) * arith.constant(KVBS, type=i32)
                                 + sflat
                             )
                         else:
-                            cs_off = ArithValue(flat_slot) * arith.constant(
+                            cs_off = ArithValue(slot_in_block) * arith.constant(
                                 D // _FP4_GROUP_SIZE, type=i32
                             ) + ArithValue(scale_group_idx)
                         buffer_ops.buffer_store(
@@ -2188,11 +2210,14 @@ def _build_kernel_ksplit(
                         )
                         dword = (p0, p1)
 
+                    # Block base on the descriptor, not on the 32-bit offset
+                    # -- see `block_base_bytes_i64`.
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
-                    )
-                    block_byte_base = ArithValue(physical_block) * ArithValue(
-                        kv_cache_block_stride
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 1
+                        ),
                     )
 
                     if const_expr(preshuffle):
@@ -2217,7 +2242,7 @@ def _build_kernel_ksplit(
                             D, type=i32
                         ) + ArithValue(lid) * arith.constant(VEC, type=i32)
 
-                    byte_off = block_byte_base + in_block_off
+                    byte_off = in_block_off
 
                     if const_expr(VEC == 2):
                         if (lid & 1) == 0:
@@ -2236,15 +2261,19 @@ def _build_kernel_ksplit(
                             store_vec, out_rsrc, byte_off, offset_is_bytes=True
                         )
 
-                    # (f) lane-0 writes fp32 scale at cache_scale[phys, slot]
+                    # (f) lane-0 writes fp32 scale at cache_scale[phys, slot].
+                    # Block term on the descriptor base, as above.
                     if lid == 0:
                         cs_rsrc = buffer_ops.create_buffer_resource(
-                            cache_scale, max_size=True
+                            cache_scale,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, cache_scale_block_stride, 4
+                            ),
                         )
-                        cs_off = fx.Int32(physical_block) * fx.Int32(
-                            cache_scale_block_stride
-                        ) + fx.Int32(slot_in_block)
-                        buffer_ops.buffer_store(scale_v, cs_rsrc, cs_off)
+                        buffer_ops.buffer_store(
+                            scale_v, cs_rsrc, fx.Int32(slot_in_block)
+                        )
                 else:
                     # ── FP4: per-group(32) e8m0 scale + E2M1 write (mirror
                     # legacy _build_kernel). Emitted in wave 0 where ``lid``
@@ -2300,15 +2329,23 @@ def _build_kernel_ksplit(
                         for i in range_constexpr(VEC)
                     ]
 
+                    # Block term on the descriptor base, not on the 32-bit
+                    # offset -- see `block_base_bytes_i64`.
+                    _fp4_block_bytes = (
+                        K_TILES * 4 * KVBS * 16
+                        if preshuffle
+                        else k_per_block * (D // 2)
+                    )
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, _fp4_block_bytes, 1
+                        ),
                     )
                     packed_start = ArithValue(lid_x_vec_i) >> arith.constant(
                         1, type=i32
                     )
-                    flat_slot = ArithValue(physical_block) * arith.constant(
-                        k_per_block, type=i32
-                    ) + ArithValue(slot_in_block)
                     for b in range_constexpr(PACKED_BYTES):
                         byte_val = ArithValue(nibs[2 * b]) | (
                             ArithValue(nibs[2 * b + 1]) << c4_i32
@@ -2320,9 +2357,7 @@ def _build_kernel_ksplit(
                             group4 = arith.divsi(rem, c16_i32)
                             sub16 = arith.remui(rem, c16_i32)
                             byte_off = (
-                                ArithValue(physical_block)
-                                * arith.constant(K_TILES * 4 * KVBS * 16, type=i32)
-                                + ArithValue(k_tile)
+                                ArithValue(k_tile)
                                 * arith.constant(4 * KVBS * 16, type=i32)
                                 + ArithValue(group4)
                                 * arith.constant(KVBS * 16, type=i32)
@@ -2330,7 +2365,7 @@ def _build_kernel_ksplit(
                                 + ArithValue(sub16)
                             )
                         else:
-                            byte_off = ArithValue(flat_slot) * arith.constant(
+                            byte_off = ArithValue(slot_in_block) * arith.constant(
                                 D // 2, type=i32
                             ) + ArithValue(packed_idx)
                         buffer_ops.buffer_store(
@@ -2343,8 +2378,18 @@ def _build_kernel_ksplit(
                     # (e) group-rep lane writes the e8m0 scale byte.
                     scale_group_idx = arith.divsi(lid_x_vec_i, c32_i32)
                     if lid % NTG == 0:
+                        # Block term on the descriptor base, as above.
+                        _fp4_scale_block_bytes = (
+                            K_TILES * 4 * KVBS
+                            if preshuffle
+                            else k_per_block * (D // _FP4_GROUP_SIZE)
+                        )
                         cs_rsrc = buffer_ops.create_buffer_resource(
-                            cache_scale, max_size=True
+                            cache_scale,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, _fp4_scale_block_bytes, 1
+                            ),
                         )
                         if const_expr(preshuffle):
                             # scale [NB, k_tiles, 4, kvbs] u8, slot axis
@@ -2360,15 +2405,13 @@ def _build_kernel_ksplit(
                                 arith.divsi(_to_raw(slot_in_block), c16_i32)
                             )
                             cs_off = (
-                                ArithValue(physical_block)
-                                * arith.constant(K_TILES * 4 * KVBS, type=i32)
-                                + ArithValue(k_tile_s)
+                                ArithValue(k_tile_s)
                                 * arith.constant(4 * KVBS, type=i32)
                                 + ArithValue(group4_s) * arith.constant(KVBS, type=i32)
                                 + sflat
                             )
                         else:
-                            cs_off = ArithValue(flat_slot) * arith.constant(
+                            cs_off = ArithValue(slot_in_block) * arith.constant(
                                 D // _FP4_GROUP_SIZE, type=i32
                             ) + ArithValue(scale_group_idx)
                         buffer_ops.buffer_store(
@@ -2833,6 +2876,33 @@ def flydsl_fused_compress_attn(
             if preshuffle and k_per_block % _PRESHUFFLE_TILE != 0:
                 raise ValueError(
                     f"fp4 preshuffle requires k_per_block%16==0, got {k_per_block}"
+                )
+            # The fp4 scatter derives its per-block byte base from these shape
+            # constants, not from the caller's stride (see `_fp4_block_bytes` in
+            # the kernel), so a pool whose blocks are NOT packed back-to-back --
+            # e.g. the V4 envelope layout that interleaves layers within a block
+            # -- would have every write land in the wrong block. Enforce the
+            # assumption instead of leaving it in a comment.
+            _blk_bytes = (
+                (head_dim // _FP4_K_TILE) * 4 * k_per_block * _PRESHUFFLE_TILE
+                if preshuffle
+                else k_per_block * (head_dim // 2)
+            )
+            if kv_cache.stride(0) != _blk_bytes:
+                raise ValueError(
+                    f"fp4 kv_cache block stride {kv_cache.stride(0)} != packed "
+                    f"{_blk_bytes} bytes/block; the fp4 scatter assumes blocks "
+                    "are contiguous in the pool"
+                )
+            _scale_blk = (
+                (head_dim // _FP4_K_TILE) * 4 * k_per_block
+                if preshuffle
+                else k_per_block * (head_dim // _FP4_GROUP_SIZE)
+            )
+            if cache_scale.stride(0) != _scale_blk:
+                raise ValueError(
+                    f"fp4 cache_scale block stride {cache_scale.stride(0)} != "
+                    f"packed {_scale_blk} bytes/block"
                 )
 
     # cos/sin row stride must equal RD/2 (caller's [max_pos, ..., RD/2] view).

--- a/aiter/ops/flydsl/kernels/fused_compress_attn.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn.py
@@ -92,6 +92,7 @@ from aiter.utility.mx_types import (
 # Shared FP8 group_fp8 (V4 nm-asm) scatter emitter (single source of truth across
 # the CSA single-kernel + HCA 2-kernel paths). See fused_compress_attn_common.
 from .fused_compress_attn_common import (
+    block_base_bytes_i64,
     emit_group_fp8_nm_asm_scatter,
     state_slot_byte_offset,
 )
@@ -947,9 +948,10 @@ def _build_kernel(
                     # BF16 paged write. kv_cache layout: [NB, k_per_block, D].
                     # cache_addr = physical_block * block_stride + slot_in_block * token_stride + tid*VEC
                     # (strides are in bf16 elements; caller passes elements.)
+                    # The block term rides on the descriptor's base, not on
+                    # the 32-bit offset -- see `block_base_bytes_i64`.
                     cache_off = (
-                        ArithValue(physical_block) * ArithValue(kv_cache_block_stride)
-                        + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
+                        ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
                         + tid_x_vec
                     )
                     # Build a per-block GTensor and store VEC bf16 via dword path.
@@ -958,7 +960,11 @@ def _build_kernel(
                     raw_vec = vector.from_elements(vecVf32, out_lane)
                     bf16_vec = raw_vec.truncf(out_vec_t)
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 2
+                        ),
                     )
                     # cache_off is in bf16 elements; convert to dword for the i32-vec store.
                     cache_off_dw = ArithValue(cache_off) >> arith.constant(1, type=i32)
@@ -975,12 +981,14 @@ def _build_kernel(
                 elif const_expr(nm_asm):
                     # -- group_fp8 (V4 nm-asm): nope fp8 + inline dup e8m0; rope bf16
                     # -> separate k_rope_buff. Shared emitter (byte-identical to HCA). --
-                    _nm_cache_base = ArithValue(physical_block) * ArithValue(
-                        kv_cache_block_stride
-                    ) + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
-                    _nm_krope_base = ArithValue(physical_block) * ArithValue(
-                        krope_block_stride
-                    ) + ArithValue(slot_in_block) * ArithValue(krope_token_stride)
+                    # The block term rides on each descriptor's base, not on
+                    # the 32-bit offset -- see `block_base_bytes_i64`.
+                    _nm_cache_base = ArithValue(slot_in_block) * ArithValue(
+                        kv_cache_token_stride
+                    )
+                    _nm_krope_base = ArithValue(slot_in_block) * ArithValue(
+                        krope_token_stride
+                    )
                     emit_group_fp8_nm_asm_scatter(
                         normed_lane=normed_lane,
                         rotated_lane=rotated_lane,
@@ -988,11 +996,19 @@ def _build_kernel(
                         is_rope_t=is_rope_t,
                         cache_base=_to_raw(_nm_cache_base),
                         out_rsrc=buffer_ops.create_buffer_resource(
-                            kv_cache, max_size=True
+                            kv_cache,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, kv_cache_block_stride, 1
+                            ),
                         ),
                         krope_base=_to_raw(_nm_krope_base),
                         krope_rsrc=buffer_ops.create_buffer_resource(
-                            k_rope_buff, max_size=True
+                            k_rope_buff,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, krope_block_stride, 2
+                            ),
                         ),
                         VEC=VEC,
                         NOPE=NOPE,
@@ -2010,16 +2026,21 @@ def _build_kernel_ksplit(
                 )
 
                 if const_expr(not quant):
+                    # The block term rides on the descriptor's base, not on
+                    # the 32-bit offset -- see `block_base_bytes_i64`.
                     cache_off = (
-                        ArithValue(physical_block) * ArithValue(kv_cache_block_stride)
-                        + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
+                        ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
                         + lid_x_vec
                     )
                     out_vec_t = T.vec(VEC, T.bf16)
                     raw_vec = vector.from_elements(vecVf32, out_lane)
                     bf16_vec = raw_vec.truncf(out_vec_t)
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 2
+                        ),
                     )
                     cache_off_dw = ArithValue(cache_off) >> c_one_i32
                     dwords = (VEC + 1) // 2
@@ -2035,12 +2056,14 @@ def _build_kernel_ksplit(
                     # -- group_fp8 (V4 nm-asm): nope fp8 + inline dup e8m0; rope
                     # bf16 -> separate k_rope_buff. Shared emitter, byte-identical
                     # to the legacy single-wave / HCA paths (lane == wave-0 lid). --
-                    _nm_cache_base = ArithValue(physical_block) * ArithValue(
-                        kv_cache_block_stride
-                    ) + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
-                    _nm_krope_base = ArithValue(physical_block) * ArithValue(
-                        krope_block_stride
-                    ) + ArithValue(slot_in_block) * ArithValue(krope_token_stride)
+                    # The block term rides on each descriptor's base, not on
+                    # the 32-bit offset -- see `block_base_bytes_i64`.
+                    _nm_cache_base = ArithValue(slot_in_block) * ArithValue(
+                        kv_cache_token_stride
+                    )
+                    _nm_krope_base = ArithValue(slot_in_block) * ArithValue(
+                        krope_token_stride
+                    )
                     emit_group_fp8_nm_asm_scatter(
                         normed_lane=normed_lane,
                         rotated_lane=rotated_lane,
@@ -2048,11 +2071,19 @@ def _build_kernel_ksplit(
                         is_rope_t=is_rope_t,
                         cache_base=_to_raw(_nm_cache_base),
                         out_rsrc=buffer_ops.create_buffer_resource(
-                            kv_cache, max_size=True
+                            kv_cache,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, kv_cache_block_stride, 1
+                            ),
                         ),
                         krope_base=_to_raw(_nm_krope_base),
                         krope_rsrc=buffer_ops.create_buffer_resource(
-                            k_rope_buff, max_size=True
+                            k_rope_buff,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, krope_block_stride, 2
+                            ),
                         ),
                         VEC=VEC,
                         NOPE=NOPE,

--- a/aiter/ops/flydsl/kernels/fused_compress_attn.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn.py
@@ -91,7 +91,10 @@ from aiter.utility.mx_types import (
 
 # Shared FP8 group_fp8 (V4 nm-asm) scatter emitter (single source of truth across
 # the CSA single-kernel + HCA 2-kernel paths). See fused_compress_attn_common.
-from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .fused_compress_attn_common import (
+    emit_group_fp8_nm_asm_scatter,
+    state_slot_byte_offset,
+)
 from .quant_utils import emit_f32_to_e2m1, emit_mx_e8m0_scale
 from .tensor_shim import _run_compiled, _to_raw
 
@@ -512,9 +515,22 @@ def _build_kernel(
             # Buffer resources reused across K iters.
             kv_in_rsrc = buffer_ops.create_buffer_resource(kv_in, max_size=True)
             score_in_rsrc = buffer_ops.create_buffer_resource(score_in, max_size=True)
-            kv_state_rsrc = buffer_ops.create_buffer_resource(kv_state, max_size=True)
+            # State descriptors are rebased onto THIS program's slot. A buffer
+            # offset is a 32-bit byte offset, so one descriptor can only reach
+            # 4 GiB from its base; a state tensor whose slot stride is a
+            # per-request arena entry (rather than the field's own size) spans
+            # far more than that across all slots. Folding the slot term into
+            # the base — 64-bit pointer arithmetic, done once per program —
+            # leaves the offset covering a single entry.
+            kv_state_rsrc = buffer_ops.create_buffer_resource(
+                kv_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, kv_state_slot_stride),
+            )
             score_state_rsrc = buffer_ops.create_buffer_resource(
-                score_state, max_size=True
+                score_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, score_state_slot_stride),
             )
             ape_rsrc = buffer_ops.create_buffer_resource(ape, max_size=True)
 
@@ -561,15 +577,14 @@ def _build_kernel(
                 ring = arith.remui(s_safe, c_state_size)
                 col_off = _col_off_for_k(k_i32)
 
+                # Slot term already folded into the descriptor base.
                 base_kv_off = (
-                    ArithValue(slot) * ArithValue(kv_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(kv_state_pos_stride)
+                    ArithValue(ring) * ArithValue(kv_state_pos_stride)
                     + ArithValue(col_off)
                     + tid_x_vec
                 )
                 base_sc_off = (
-                    ArithValue(slot) * ArithValue(score_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(score_state_pos_stride)
+                    ArithValue(ring) * ArithValue(score_state_pos_stride)
                     + ArithValue(col_off)
                     + tid_x_vec
                 )
@@ -1622,9 +1637,16 @@ def _build_kernel_ksplit(
 
             kv_in_rsrc = buffer_ops.create_buffer_resource(kv_in, max_size=True)
             score_in_rsrc = buffer_ops.create_buffer_resource(score_in, max_size=True)
-            kv_state_rsrc = buffer_ops.create_buffer_resource(kv_state, max_size=True)
+            # Rebased onto this program's slot — see `state_slot_byte_offset`.
+            kv_state_rsrc = buffer_ops.create_buffer_resource(
+                kv_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, kv_state_slot_stride),
+            )
             score_state_rsrc = buffer_ops.create_buffer_resource(
-                score_state, max_size=True
+                score_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, score_state_slot_stride),
             )
             ape_rsrc = buffer_ops.create_buffer_resource(ape, max_size=True)
 
@@ -1725,15 +1747,14 @@ def _build_kernel_ksplit(
                 s_safe = arith.select(is_pad, c_zero_i32, s)
                 ring = arith.remui(s_safe, c_state_size)
                 col_off = _col_off_for_k(k_i32)
+                # Slot term already folded into the descriptor base.
                 base_kv = (
-                    ArithValue(slot) * ArithValue(kv_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(kv_state_pos_stride)
+                    ArithValue(ring) * ArithValue(kv_state_pos_stride)
                     + ArithValue(col_off)
                     + lid_x_vec
                 )
                 base_sc = (
-                    ArithValue(slot) * ArithValue(score_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(score_state_pos_stride)
+                    ArithValue(ring) * ArithValue(score_state_pos_stride)
                     + ArithValue(col_off)
                     + lid_x_vec
                 )
@@ -2696,8 +2717,13 @@ def flydsl_fused_compress_attn(
         raise ValueError("score_state shape != kv_state")
     if kv_state.dtype != torch.float32 or score_state.dtype != torch.float32:
         raise TypeError("kv_state/score_state must be fp32")
-    if not (kv_state.is_contiguous() and score_state.is_contiguous()):
-        raise ValueError("kv_state/score_state must be contiguous")
+    # Slot and ring strides are passed to the kernel and the descriptor is
+    # rebased per slot, so the states may be strided views — a per-request
+    # arena hands out a view whose slot stride is a whole entry. Only the
+    # innermost dim must be unit stride: the kernel addresses it as
+    # `col_off + lane`.
+    if kv_state.stride(-1) != 1 or score_state.stride(-1) != 1:
+        raise ValueError("kv_state/score_state inner stride must be 1")
     if ape.shape != (ratio, dim_full) or ape.dtype != torch.float32:
         raise ValueError(
             f"ape shape {tuple(ape.shape)} dtype {ape.dtype} != ({ratio}, {dim_full}) f32"

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
@@ -71,6 +71,32 @@ def state_slot_byte_offset(slot, slot_stride_f32_elems):
     )
 
 
+def block_base_bytes_i64(physical_block, block_stride, elem_bytes: int = 1):
+    """Byte offset of one physical block, computed in 64 bits.
+
+    A buffer descriptor addresses through a 32-bit offset inside a 32-bit
+    ``num_records`` window, so one fixed base cannot reach past 4 GiB: the
+    offset wraps at 2 GiB and the hardware drops the access at 4 GiB, both
+    silently. Shifting the descriptor's BASE per block instead leaves the
+    32-bit field holding one block's worth of offset, which no layout makes big.
+
+    How soon that mattered scales with how many layers a block spans.
+    DeepSeek-V4's envelope layout puts every layer's rows for one block
+    together, so consecutive blocks sit 708 KB apart and block 3,031 wraps; the
+    layer-major predecessor still wrapped at block 65,536 for a CSA layer, well
+    inside a pool that routinely holds 150,000.
+
+    ``block_stride`` is in elements of the cache's own dtype; ``elem_bytes``
+    converts (1 for the fp8 entry cache, 2 for a bf16 one).
+    """
+    blk_i64 = arith.extsi(T.i64, buffer_ops._unwrap_value(physical_block))
+    stride_i64 = arith.extsi(T.i64, buffer_ops._unwrap_value(block_stride))
+    base = arith.muli(blk_i64, stride_i64)
+    if elem_bytes == 1:
+        return base
+    return arith.muli(base, arith.constant(elem_bytes, type=T.i64))
+
+
 def emit_group_fp8_nm_asm_scatter(
     *,
     normed_lane,  # list[VEC] f32: post-norm nope values (this lane's slice)

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
@@ -51,6 +51,26 @@ def group_fp8_mx_dtype():
     return _MxD.FP8_E4M3_FNUZ if get_rocm_arch() == "gfx942" else _MxD.FP8_E4M3
 
 
+def state_slot_byte_offset(slot, slot_stride_f32_elems):
+    """`slot * slot_stride` in bytes, computed in 64 bits.
+
+    Both compress-attn kernels rebase their `kv_state` / `score_state` buffer
+    descriptors onto the program's own slot instead of carrying the slot term
+    in the load offset. A buffer offset is a 32-bit BYTE offset, so one
+    descriptor reaches at most 4 GiB from its base — which the slot term
+    alone can exceed once the caller's state tensor is a view whose slot
+    stride is a whole per-request arena entry rather than the field's own
+    size. `get_element_ptr` adds this in 64-bit pointer arithmetic, so only
+    the multiply needs widening, and the remaining offset covers one entry.
+    """
+    slot_i64 = arith.extsi(T.i64, buffer_ops._unwrap_value(slot))
+    stride_i64 = arith.extsi(T.i64, buffer_ops._unwrap_value(slot_stride_f32_elems))
+    return arith.muli(
+        arith.muli(slot_i64, stride_i64),
+        arith.constant(4, type=T.i64),  # sizeof(f32)
+    )
+
+
 def emit_group_fp8_nm_asm_scatter(
     *,
     normed_lane,  # list[VEC] f32: post-norm nope values (this lane's slice)

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_common.py
@@ -54,9 +54,11 @@ def group_fp8_mx_dtype():
 def state_slot_byte_offset(slot, slot_stride_f32_elems):
     """`slot * slot_stride` in bytes, computed in 64 bits.
 
-    Both compress-attn kernels rebase their `kv_state` / `score_state` buffer
-    descriptors onto the program's own slot instead of carrying the slot term
-    in the load offset. A buffer offset is a 32-bit BYTE offset, so one
+    All four compress-attn kernels (CSA and HCA, wave64 and gfx1250) rebase
+    their `kv_state` / `score_state` buffer descriptors onto the program's own
+    slot instead of carrying the slot term in the load offset, so a caller may
+    hand any of them a strided per-request arena view. A buffer offset is a
+    32-bit BYTE offset, so one
     descriptor reaches at most 4 GiB from its base — which the slot term
     alone can exceed once the caller's state tensor is a view whose slot
     stride is a whole per-request arena entry rather than the field's own
@@ -86,11 +88,17 @@ def block_base_bytes_i64(physical_block, block_stride, elem_bytes: int = 1):
     layer-major predecessor still wrapped at block 65,536 for a CSA layer, well
     inside a pool that routinely holds 150,000.
 
-    ``block_stride`` is in elements of the cache's own dtype; ``elem_bytes``
-    converts (1 for the fp8 entry cache, 2 for a bf16 one).
+    ``block_stride`` is in elements of the cache's own dtype and may be either
+    a runtime value (the caller passed the tensor's stride) or a Python int
+    (the packed fp4/preshuffle layouts derive it from compile-time shape
+    constants). ``elem_bytes`` converts: 1 for the fp8/uint8 entry caches, 2
+    for a bf16 one, 4 for the fp32 per-token scale.
     """
     blk_i64 = arith.extsi(T.i64, buffer_ops._unwrap_value(physical_block))
-    stride_i64 = arith.extsi(T.i64, buffer_ops._unwrap_value(block_stride))
+    if isinstance(block_stride, int):
+        stride_i64 = arith.constant(block_stride, type=T.i64)
+    else:
+        stride_i64 = arith.extsi(T.i64, buffer_ops._unwrap_value(block_stride))
     base = arith.muli(blk_i64, stride_i64)
     if elem_bytes == 1:
         return base

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
@@ -43,6 +43,7 @@ from aiter.ops.flydsl.kernels import buffer_ops, vector
 from .fused_compress_attn_common import (
     block_base_bytes_i64,
     emit_group_fp8_nm_asm_scatter,
+    state_slot_byte_offset,
 )
 from .tensor_shim import _run_compiled, _to_raw
 
@@ -482,9 +483,16 @@ def _build_kernel(
             # Buffer resources reused across K iters.
             kv_in_rsrc = buffer_ops.create_buffer_resource(kv_in, max_size=True)
             score_in_rsrc = buffer_ops.create_buffer_resource(score_in, max_size=True)
-            kv_state_rsrc = buffer_ops.create_buffer_resource(kv_state, max_size=True)
+            # Rebased onto this program's slot — see `state_slot_byte_offset`.
+            kv_state_rsrc = buffer_ops.create_buffer_resource(
+                kv_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, kv_state_slot_stride),
+            )
             score_state_rsrc = buffer_ops.create_buffer_resource(
-                score_state, max_size=True
+                score_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, score_state_slot_stride),
             )
             ape_rsrc = buffer_ops.create_buffer_resource(ape, max_size=True)
 
@@ -531,15 +539,14 @@ def _build_kernel(
                 ring = arith.remui(s_safe, c_state_size)
                 col_off = _col_off_for_k(k_i32)
 
+                # Slot term already folded into the descriptor base.
                 base_kv_off = (
-                    ArithValue(slot) * ArithValue(kv_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(kv_state_pos_stride)
+                    ArithValue(ring) * ArithValue(kv_state_pos_stride)
                     + ArithValue(col_off)
                     + tid_x_vec
                 )
                 base_sc_off = (
-                    ArithValue(slot) * ArithValue(score_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(score_state_pos_stride)
+                    ArithValue(ring) * ArithValue(score_state_pos_stride)
                     + ArithValue(col_off)
                     + tid_x_vec
                 )
@@ -1132,19 +1139,21 @@ def _build_kernel(
                         dword = tuple(dword_list)
 
                     # Compute store address (in BYTES from kv_cache base).
-                    # Both layouts use the same base (= phys * block_stride);
-                    # the offset within the block differs.
+                    # Both layouts share the same block base, folded into the
+                    # descriptor above; only the in-block offset differs.
+                    # Block base on the descriptor, not on the 32-bit offset
+                    # -- see `block_base_bytes_i64`.
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
-                    )
-                    block_byte_base = ArithValue(physical_block) * ArithValue(
-                        kv_cache_block_stride
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 1
+                        ),
                     )
 
                     if const_expr(preshuffle):
                         # MFMA 16x16 tile layout
-                        # offset = block_base
-                        #        + token_tile_id * (TILE * D)
+                        # offset = token_tile_id * (TILE * D)
                         #        + col_tile_id * (TILE * TILE)
                         #        + token_in_tile * TILE
                         #        + col_in_tile
@@ -1166,12 +1175,12 @@ def _build_kernel(
                             + ArithValue(col_in_tile)
                         )
                     else:
-                        # Linear layout: phys * block_stride + slot * D + tid * VEC
+                        # Linear layout: slot * D + tid * VEC
                         in_block_off = ArithValue(slot_in_block) * arith.constant(
                             D, type=i32
                         ) + ArithValue(tid) * arith.constant(VEC, type=i32)
 
-                    byte_off = block_byte_base + in_block_off
+                    byte_off = in_block_off
 
                     if const_expr(VEC == 2):
                         # Only even tid stores (its dword covers peer's bytes too).
@@ -1231,12 +1240,15 @@ def _build_kernel(
                     _if_l0 = scf.IfOp(is_lane0)
                     with _if_then(_if_l0):
                         cs_rsrc = buffer_ops.create_buffer_resource(
-                            cache_scale, max_size=True
+                            cache_scale,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, cache_scale_block_stride, 4
+                            ),
                         )
-                        cs_off = ArithValue(physical_block) * ArithValue(
-                            cache_scale_block_stride
-                        ) + ArithValue(slot_in_block)
-                        buffer_ops.buffer_store(scale_v, cs_rsrc, cs_off)
+                        buffer_ops.buffer_store(
+                            scale_v, cs_rsrc, ArithValue(slot_in_block)
+                        )
             # else: warmup -- no scatter, just consume compute.
 
     @flyc.jit
@@ -1492,9 +1504,16 @@ def _build_kernel_ksplit(
 
             kv_in_rsrc = buffer_ops.create_buffer_resource(kv_in, max_size=True)
             score_in_rsrc = buffer_ops.create_buffer_resource(score_in, max_size=True)
-            kv_state_rsrc = buffer_ops.create_buffer_resource(kv_state, max_size=True)
+            # Rebased onto this program's slot — see `state_slot_byte_offset`.
+            kv_state_rsrc = buffer_ops.create_buffer_resource(
+                kv_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, kv_state_slot_stride),
+            )
             score_state_rsrc = buffer_ops.create_buffer_resource(
-                score_state, max_size=True
+                score_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, score_state_slot_stride),
             )
             ape_rsrc = buffer_ops.create_buffer_resource(ape, max_size=True)
 
@@ -1621,15 +1640,14 @@ def _build_kernel_ksplit(
                 s_safe = arith.select(is_pad, c_zero_i32, s)
                 ring = arith.remui(s_safe, c_state_size)
                 col_off = _col_off_for_k(k_i32)
+                # Slot term already folded into the descriptor base.
                 base_kv = (
-                    ArithValue(slot) * ArithValue(kv_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(kv_state_pos_stride)
+                    ArithValue(ring) * ArithValue(kv_state_pos_stride)
                     + ArithValue(col_off)
                     + lid_x_vec
                 )
                 base_sc = (
-                    ArithValue(slot) * ArithValue(score_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(score_state_pos_stride)
+                    ArithValue(ring) * ArithValue(score_state_pos_stride)
                     + ArithValue(col_off)
                     + lid_x_vec
                 )
@@ -2042,11 +2060,14 @@ def _build_kernel_ksplit(
                             dword_list.append(pk)
                         dword = tuple(dword_list)
 
+                    # Block base on the descriptor, not on the 32-bit offset
+                    # -- see `block_base_bytes_i64`.
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
-                    )
-                    block_byte_base = ArithValue(physical_block) * ArithValue(
-                        kv_cache_block_stride
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 1
+                        ),
                     )
 
                     if const_expr(preshuffle):
@@ -2071,7 +2092,7 @@ def _build_kernel_ksplit(
                             D, type=i32
                         ) + ArithValue(lid) * arith.constant(VEC, type=i32)
 
-                    byte_off = block_byte_base + in_block_off
+                    byte_off = in_block_off
 
                     if const_expr(VEC == 2):
                         is_even = arith.cmpi(
@@ -2125,12 +2146,15 @@ def _build_kernel_ksplit(
                     _if_l0 = scf.IfOp(is_lane0)
                     with _if_then(_if_l0):
                         cs_rsrc = buffer_ops.create_buffer_resource(
-                            cache_scale, max_size=True
+                            cache_scale,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, cache_scale_block_stride, 4
+                            ),
                         )
-                        cs_off = ArithValue(physical_block) * ArithValue(
-                            cache_scale_block_stride
-                        ) + ArithValue(slot_in_block)
-                        buffer_ops.buffer_store(scale_v, cs_rsrc, cs_off)
+                        buffer_ops.buffer_store(
+                            scale_v, cs_rsrc, ArithValue(slot_in_block)
+                        )
 
     @flyc.jit
     def launch_fused_compress_attn_ksplit(
@@ -2379,8 +2403,13 @@ def flydsl_fused_compress_attn_gfx1250(
         raise ValueError("score_state shape != kv_state")
     if kv_state.dtype != torch.float32 or score_state.dtype != torch.float32:
         raise TypeError("kv_state/score_state must be fp32")
-    if not (kv_state.is_contiguous() and score_state.is_contiguous()):
-        raise ValueError("kv_state/score_state must be contiguous")
+    # Slot and ring strides are passed to the kernel and the descriptor is
+    # rebased per slot, so the states may be strided views — a per-request
+    # arena hands out a view whose slot stride is a whole entry. Only the
+    # innermost dim must be unit stride: the kernel addresses it as
+    # `col_off + lane`.
+    if kv_state.stride(-1) != 1 or score_state.stride(-1) != 1:
+        raise ValueError("kv_state/score_state inner stride must be 1")
     if ape.shape != (ratio, dim_full) or ape.dtype != torch.float32:
         raise ValueError(
             f"ape shape {tuple(ape.shape)} dtype {ape.dtype} != ({ratio}, {dim_full}) f32"

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_gfx1250.py
@@ -40,7 +40,10 @@ from flydsl.expr.typing import Int32, Stream, T
 
 from aiter.ops.flydsl.kernels import buffer_ops, vector
 
-from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .fused_compress_attn_common import (
+    block_base_bytes_i64,
+    emit_group_fp8_nm_asm_scatter,
+)
 from .tensor_shim import _run_compiled, _to_raw
 
 # --- shape constants --------------------------------------------------------
@@ -909,9 +912,10 @@ def _build_kernel(
                     # BF16 paged write. kv_cache layout: [NB, k_per_block, D].
                     # cache_addr = physical_block * block_stride + slot_in_block * token_stride + tid*VEC
                     # (strides are in bf16 elements; caller passes elements.)
+                    # The block term rides on the descriptor's base, not on
+                    # the 32-bit offset -- see `block_base_bytes_i64`.
                     cache_off = (
-                        ArithValue(physical_block) * ArithValue(kv_cache_block_stride)
-                        + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
+                        ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
                         + tid_x_vec
                     )
                     # Build a per-block GTensor and store VEC bf16 via dword path.
@@ -920,7 +924,11 @@ def _build_kernel(
                     raw_vec = vector.from_elements(vecVf32, out_lane)
                     bf16_vec = raw_vec.truncf(out_vec_t)
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 2
+                        ),
                     )
                     # cache_off is in bf16 elements; convert to dword for the i32-vec store.
                     cache_off_dw = ArithValue(cache_off) >> arith.constant(1, type=i32)
@@ -958,12 +966,14 @@ def _build_kernel(
                 elif const_expr(nm_asm):
                     # -- group_fp8 (V4 nm-asm) via shared emitter (wave32; same layout
                     # as wave64 -- single source of truth). --
-                    _nm_cache_base = ArithValue(physical_block) * ArithValue(
-                        kv_cache_block_stride
-                    ) + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
-                    _nm_krope_base = ArithValue(physical_block) * ArithValue(
-                        krope_block_stride
-                    ) + ArithValue(slot_in_block) * ArithValue(krope_token_stride)
+                    # The block term rides on each descriptor's base, not on
+                    # the 32-bit offset -- see `block_base_bytes_i64`.
+                    _nm_cache_base = ArithValue(slot_in_block) * ArithValue(
+                        kv_cache_token_stride
+                    )
+                    _nm_krope_base = ArithValue(slot_in_block) * ArithValue(
+                        krope_token_stride
+                    )
                     emit_group_fp8_nm_asm_scatter(
                         normed_lane=normed_lane,
                         rotated_lane=rotated_lane,
@@ -971,11 +981,19 @@ def _build_kernel(
                         is_rope_t=is_rope_t,
                         cache_base=_to_raw(_nm_cache_base),
                         out_rsrc=buffer_ops.create_buffer_resource(
-                            kv_cache, max_size=True
+                            kv_cache,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, kv_cache_block_stride, 1
+                            ),
                         ),
                         krope_base=_to_raw(_nm_krope_base),
                         krope_rsrc=buffer_ops.create_buffer_resource(
-                            k_rope_buff, max_size=True
+                            k_rope_buff,
+                            max_size=True,
+                            base_byte_offset=block_base_bytes_i64(
+                                physical_block, krope_block_stride, 2
+                            ),
                         ),
                         VEC=VEC,
                         NOPE=NOPE,
@@ -1873,16 +1891,21 @@ def _build_kernel_ksplit(
                 )
 
                 if const_expr(not quant):
+                    # The block term rides on the descriptor's base, not on
+                    # the 32-bit offset -- see `block_base_bytes_i64`.
                     cache_off = (
-                        ArithValue(physical_block) * ArithValue(kv_cache_block_stride)
-                        + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
+                        ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
                         + lid_x_vec
                     )
                     out_vec_t = T.vec(VEC, T.bf16)
                     raw_vec = vector.from_elements(vecVf32, out_lane)
                     bf16_vec = raw_vec.truncf(out_vec_t)
                     out_rsrc = buffer_ops.create_buffer_resource(
-                        kv_cache, max_size=True
+                        kv_cache,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, kv_cache_block_stride, 2
+                        ),
                     )
                     cache_off_dw = ArithValue(cache_off) >> c_one_i32
                     dwords = (VEC + 1) // 2

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
@@ -53,7 +53,10 @@ from flydsl.expr.typing import Int32, Stream, T
 
 from aiter.ops.flydsl.kernels import buffer_ops, vector
 
-from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .fused_compress_attn_common import (
+    emit_group_fp8_nm_asm_scatter,
+    state_slot_byte_offset,
+)
 from .tensor_shim import _run_compiled, _to_raw
 
 BLOCK_THREADS = 64  # 1 wave64
@@ -219,9 +222,16 @@ def _build_compress_forward_kernel(
 
             kv_in_rsrc = buffer_ops.create_buffer_resource(kv_in, max_size=True)
             score_in_rsrc = buffer_ops.create_buffer_resource(score_in, max_size=True)
-            kv_state_rsrc = buffer_ops.create_buffer_resource(kv_state, max_size=True)
+            # Rebased onto this program's slot — see `state_slot_byte_offset`.
+            kv_state_rsrc = buffer_ops.create_buffer_resource(
+                kv_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, kv_state_slot_stride),
+            )
             score_state_rsrc = buffer_ops.create_buffer_resource(
-                score_state, max_size=True
+                score_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, score_state_slot_stride),
             )
             ape_rsrc = buffer_ops.create_buffer_resource(ape, max_size=True)
 
@@ -340,15 +350,12 @@ def _build_compress_forward_kernel(
                 is_pad = arith.cmpi(CmpIPredicate.slt, s, c_zero_i32)
                 s_safe = arith.select(is_pad, c_zero_i32, s)
                 ring = arith.remui(s_safe, c_state_size)
+                # Slot term already folded into the descriptor base.
                 base_kv_off = (
-                    ArithValue(slot) * ArithValue(kv_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(kv_state_pos_stride)
-                    + col_off_base
+                    ArithValue(ring) * ArithValue(kv_state_pos_stride) + col_off_base
                 )
                 base_sc_off = (
-                    ArithValue(slot) * ArithValue(score_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(score_state_pos_stride)
-                    + col_off_base
+                    ArithValue(ring) * ArithValue(score_state_pos_stride) + col_off_base
                 )
                 kv_list = _load_f32_vec(kv_state_rsrc, base_kv_off)
                 sc_list = _load_f32_vec(score_state_rsrc, base_sc_off)
@@ -1225,8 +1232,13 @@ def flydsl_hca_compress_attn(
         raise ValueError("score_state shape != kv_state")
     if kv_state.dtype != torch.float32 or score_state.dtype != torch.float32:
         raise TypeError("kv_state/score_state must be fp32")
-    if not (kv_state.is_contiguous() and score_state.is_contiguous()):
-        raise ValueError("kv_state/score_state must be contiguous")
+    # Slot and ring strides are passed to the kernel and the descriptor is
+    # rebased per slot, so the states may be strided views — a per-request
+    # arena hands out a view whose slot stride is a whole entry. Only the
+    # innermost dim must be unit stride: the kernel addresses it as
+    # `col_off + lane`.
+    if kv_state.stride(-1) != 1 or score_state.stride(-1) != 1:
+        raise ValueError("kv_state/score_state inner stride must be 1")
     if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
         raise ValueError("state_slot_mapping must be 1D int32")
 

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca.py
@@ -54,6 +54,7 @@ from flydsl.expr.typing import Int32, Stream, T
 from aiter.ops.flydsl.kernels import buffer_ops, vector
 
 from .fused_compress_attn_common import (
+    block_base_bytes_i64,
     emit_group_fp8_nm_asm_scatter,
     state_slot_byte_offset,
 )
@@ -909,17 +910,22 @@ def _build_norm_rope_scatter_kernel(
             physical_block = buffer_ops.buffer_load(
                 bt_rsrc, bt_off, vec_width=1, dtype=i32
             )
-            cache_base = ArithValue(physical_block) * ArithValue(
-                kv_cache_block_stride
-            ) + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
-            out_rsrc = buffer_ops.create_buffer_resource(kv_cache, max_size=True)
+            # The block term rides on the descriptor's base, not on the
+            # 32-bit offset -- see `block_base_bytes_i64`. What is left is one
+            # block's worth, which fits by construction.
+            out_rsrc = buffer_ops.create_buffer_resource(
+                kv_cache,
+                max_size=True,
+                base_byte_offset=block_base_bytes_i64(
+                    physical_block, kv_cache_block_stride, 1 if quant else 2
+                ),
+            )
+            cache_base = ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
 
             if const_expr(quant):
                 # -- group_fp8 (V4 nm-asm) via shared emitter (single source of truth
                 # shared with the CSA single-kernel; fp8 entry layout stays identical). --
-                _krope_base = ArithValue(physical_block) * ArithValue(
-                    krope_block_stride
-                ) + ArithValue(slot_in_block) * ArithValue(krope_token_stride)
+                _krope_base = ArithValue(slot_in_block) * ArithValue(krope_token_stride)
                 emit_group_fp8_nm_asm_scatter(
                     normed_lane=normed_lane,
                     rotated_lane=rotated_lane,
@@ -929,7 +935,11 @@ def _build_norm_rope_scatter_kernel(
                     out_rsrc=out_rsrc,
                     krope_base=_to_raw(_krope_base),
                     krope_rsrc=buffer_ops.create_buffer_resource(
-                        k_rope_buff, max_size=True
+                        k_rope_buff,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, krope_block_stride, 2
+                        ),
                     ),
                     VEC=VEC,
                     NOPE=NOPE,
@@ -1257,8 +1267,8 @@ def flydsl_hca_compress_attn(
             raise ValueError(
                 f"k_rope_cache shape {tuple(k_rope_cache.shape)} != [NB, k_per_block, {rope_head_dim}]"
             )
-        if not k_rope_cache.is_contiguous():
-            raise ValueError("k_rope_cache must be contiguous")
+        if k_rope_cache.stride(2) != 1:
+            raise ValueError("k_rope_cache must be dense in the last dim")
     else:
         if kv_cache.dtype != torch.bfloat16:
             raise TypeError(f"HCA 2-kernel kv_cache must be bf16; got {kv_cache.dtype}")

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
@@ -30,7 +30,10 @@ from flydsl.expr.typing import Int32, Stream, T
 
 from aiter.ops.flydsl.kernels import buffer_ops, vector
 
-from .fused_compress_attn_common import emit_group_fp8_nm_asm_scatter
+from .fused_compress_attn_common import (
+    block_base_bytes_i64,
+    emit_group_fp8_nm_asm_scatter,
+)
 from .tensor_shim import _run_compiled, _to_raw
 
 BLOCK_THREADS = 32  # 1 wave32 (RDNA4 / gfx1250)
@@ -900,17 +903,23 @@ def _build_norm_rope_scatter_kernel(
             physical_block = buffer_ops.buffer_load(
                 bt_rsrc, bt_off, vec_width=1, dtype=i32
             )
-            cache_base = ArithValue(physical_block) * ArithValue(
-                kv_cache_block_stride
-            ) + ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
-            out_rsrc = buffer_ops.create_buffer_resource(kv_cache, max_size=True)
+            # The block term rides on the descriptor's base, not on the
+            # 32-bit offset -- see `block_base_bytes_i64`.
+            cache_base = ArithValue(slot_in_block) * ArithValue(kv_cache_token_stride)
+            out_rsrc = buffer_ops.create_buffer_resource(
+                kv_cache,
+                max_size=True,
+                base_byte_offset=block_base_bytes_i64(
+                    physical_block, kv_cache_block_stride, 1 if quant else 2
+                ),
+            )
 
             if const_expr(quant):
                 # -- group_fp8 (V4 nm-asm) via shared emitter (wave32; same layout
                 # as wave64 CSA/HCA -- single source of truth). --
-                _krope_base = ArithValue(physical_block) * ArithValue(
-                    krope_block_stride
-                ) + ArithValue(slot_in_block) * ArithValue(krope_token_stride)
+                _krope_base = ArithValue(slot_in_block) * ArithValue(
+                    krope_token_stride
+                )
                 emit_group_fp8_nm_asm_scatter(
                     normed_lane=normed_lane,
                     rotated_lane=rotated_lane,
@@ -920,7 +929,11 @@ def _build_norm_rope_scatter_kernel(
                     out_rsrc=out_rsrc,
                     krope_base=_to_raw(_krope_base),
                     krope_rsrc=buffer_ops.create_buffer_resource(
-                        k_rope_buff, max_size=True
+                        k_rope_buff,
+                        max_size=True,
+                        base_byte_offset=block_base_bytes_i64(
+                            physical_block, krope_block_stride, 2
+                        ),
                     ),
                     VEC=VEC,
                     NOPE=NOPE,
@@ -1217,8 +1230,8 @@ def flydsl_hca_compress_attn_gfx1250(
             raise ValueError(
                 f"k_rope_cache shape {tuple(k_rope_cache.shape)} != [NB, k_per_block, {rope_head_dim}]"
             )
-        if not k_rope_cache.is_contiguous():
-            raise ValueError("k_rope_cache must be contiguous")
+        if k_rope_cache.stride(2) != 1:
+            raise ValueError("k_rope_cache must be dense in the last dim")
     else:
         if kv_cache.dtype != torch.bfloat16:
             raise TypeError(f"HCA 2-kernel kv_cache must be bf16; got {kv_cache.dtype}")

--- a/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/fused_compress_attn_hca_gfx1250.py
@@ -33,6 +33,7 @@ from aiter.ops.flydsl.kernels import buffer_ops, vector
 from .fused_compress_attn_common import (
     block_base_bytes_i64,
     emit_group_fp8_nm_asm_scatter,
+    state_slot_byte_offset,
 )
 from .tensor_shim import _run_compiled, _to_raw
 
@@ -211,9 +212,16 @@ def _build_compress_forward_kernel(
 
             kv_in_rsrc = buffer_ops.create_buffer_resource(kv_in, max_size=True)
             score_in_rsrc = buffer_ops.create_buffer_resource(score_in, max_size=True)
-            kv_state_rsrc = buffer_ops.create_buffer_resource(kv_state, max_size=True)
+            # Rebased onto this program's slot — see `state_slot_byte_offset`.
+            kv_state_rsrc = buffer_ops.create_buffer_resource(
+                kv_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, kv_state_slot_stride),
+            )
             score_state_rsrc = buffer_ops.create_buffer_resource(
-                score_state, max_size=True
+                score_state,
+                max_size=True,
+                base_byte_offset=state_slot_byte_offset(slot, score_state_slot_stride),
             )
             ape_rsrc = buffer_ops.create_buffer_resource(ape, max_size=True)
 
@@ -332,15 +340,12 @@ def _build_compress_forward_kernel(
                 is_pad = arith.cmpi(CmpIPredicate.slt, s, c_zero_i32)
                 s_safe = arith.select(is_pad, c_zero_i32, s)
                 ring = arith.remui(s_safe, c_state_size)
+                # Slot term already folded into the descriptor base.
                 base_kv_off = (
-                    ArithValue(slot) * ArithValue(kv_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(kv_state_pos_stride)
-                    + col_off_base
+                    ArithValue(ring) * ArithValue(kv_state_pos_stride) + col_off_base
                 )
                 base_sc_off = (
-                    ArithValue(slot) * ArithValue(score_state_slot_stride)
-                    + ArithValue(ring) * ArithValue(score_state_pos_stride)
-                    + col_off_base
+                    ArithValue(ring) * ArithValue(score_state_pos_stride) + col_off_base
                 )
                 kv_list = _load_f32_vec(kv_state_rsrc, base_kv_off)
                 sc_list = _load_f32_vec(score_state_rsrc, base_sc_off)
@@ -917,9 +922,7 @@ def _build_norm_rope_scatter_kernel(
             if const_expr(quant):
                 # -- group_fp8 (V4 nm-asm) via shared emitter (wave32; same layout
                 # as wave64 CSA/HCA -- single source of truth). --
-                _krope_base = ArithValue(slot_in_block) * ArithValue(
-                    krope_token_stride
-                )
+                _krope_base = ArithValue(slot_in_block) * ArithValue(krope_token_stride)
                 emit_group_fp8_nm_asm_scatter(
                     normed_lane=normed_lane,
                     rotated_lane=rotated_lane,
@@ -1210,8 +1213,13 @@ def flydsl_hca_compress_attn_gfx1250(
         raise ValueError("score_state shape != kv_state")
     if kv_state.dtype != torch.float32 or score_state.dtype != torch.float32:
         raise TypeError("kv_state/score_state must be fp32")
-    if not (kv_state.is_contiguous() and score_state.is_contiguous()):
-        raise ValueError("kv_state/score_state must be contiguous")
+    # Slot and ring strides are passed to the kernel and the descriptor is
+    # rebased per slot, so the states may be strided views — a per-request
+    # arena hands out a view whose slot stride is a whole entry. Only the
+    # innermost dim must be unit stride: the kernel addresses it as
+    # `col_off + lane`.
+    if kv_state.stride(-1) != 1 or score_state.stride(-1) != 1:
+        raise ValueError("kv_state/score_state inner stride must be 1")
     if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
         raise ValueError("state_slot_mapping must be 1D int32")
 

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -296,6 +296,7 @@ def _build_kernel(
         batch_id_per_token: fx.Pointer,  # [T] i32, -1 sentinel (dummy if not kv_write)
         swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
         swa_pos_stride: Int32,  # bf16 elements (= D)
+        swa_num_rows: Int32,  # rows in the SWA pool; bounds the final row
         swa_cache_size: Int32,  # ring slot count
     ):
         f32 = T.f32
@@ -637,16 +638,35 @@ def _build_kernel(
                             32,
                         )
                     )
-                    do_swa = bid_i32 >= fx.Int32(0)
+                    # A stale token carries a negative position. `divsi`/`remsi`
+                    # truncate toward zero, so pos=-300 with block_size=128 gives
+                    # blk=-2 and in_blk=-44: the block index passes an upper-bound
+                    # test, reads the PREVIOUS request's table entry, and lands the
+                    # write 44 rows before that block. The C++ sibling's first gate
+                    # is `bid < 0 || pos < 0`; match it, in both modes.
+                    pos_ok = pos_i32 >= fx.Int32(0)
+                    do_swa = (bid_i32 >= fx.Int32(0)) & pos_ok
                     bid_safe = (bid_i32 >= fx.Int32(0)).select(bid_i32, fx.Int32(0))
+                    pos_safe = pos_ok.select(pos_i32, fx.Int32(0))
                     if const_expr(paged):
                         # paged / content-addressed SWA (DeepSeek-V4 #1417):
                         # swa_kv is the FLAT [num_pages, D] pool; `swa_index` is
                         # block_tables[bs, max_blocks], swa_slot_stride=max_blocks,
                         # swa_cache_size=block_size, swa_pos_stride=D. Physical row
                         # = block_tables[bid, pos//bs]*bs + pos%bs.
-                        blk = pos_i32 // swa_cache_size
-                        bt_off = bid_safe * swa_slot_stride + blk
+                        blk = pos_safe // swa_cache_size
+                        # The other two gates the C++ sibling applies (see
+                        # `swa_row_for_token`): a position past the table's last
+                        # block would read the NEXT request's entry, and `-1`
+                        # marks a block outside the window. Clamp for the load,
+                        # gate the store on the unclamped test. The wrapper
+                        # pins stride(0) == max_blocks, so the row stride is
+                        # both the table width and the distance between two
+                        # requests' rows.
+                        blk_ok = blk < swa_slot_stride
+                        bt_off = bid_safe * swa_slot_stride + blk_ok.select(
+                            blk, fx.Int32(0)
+                        )
                         phys = fx.Int32(
                             _scalar_load(
                                 fx.Int64(ptrtoint(swa_index)),
@@ -655,8 +675,18 @@ def _build_kernel(
                                 32,
                             )
                         )
-                        in_blk = pos_i32 % swa_cache_size
-                        row = phys * swa_cache_size + in_blk
+                        in_blk = pos_safe % swa_cache_size
+                        row_raw = phys * swa_cache_size + in_blk
+                        # Bound the final row against the pool, as the C++ does:
+                        # a phys id left over from a larger pool would otherwise
+                        # write past the end of swa_kv.
+                        row_ok = (
+                            blk_ok & (phys >= fx.Int32(0)) & (row_raw < swa_num_rows)
+                        )
+                        do_swa = do_swa & row_ok
+                        # Clamp too: a negative row would move the descriptor
+                        # base backwards, out of this tensor entirely.
+                        row = row_ok.select(row_raw, fx.Int32(0))
                     else:
                         # Direct: the caller already resolved this token's row.
                         # A -1 row means "skip", same as a -1 batch id -- a caller
@@ -670,8 +700,11 @@ def _build_kernel(
                                 32,
                             )
                         )
-                        do_swa = do_swa & (dest >= fx.Int32(0))
-                        row = (dest >= fx.Int32(0)).select(dest, fx.Int32(0))
+                        # Bounded against the pool as well: the caller owns the
+                        # row, but a stale entry must not write past swa_kv.
+                        dest_ok = (dest >= fx.Int32(0)) & (dest < swa_num_rows)
+                        do_swa = do_swa & dest_ok
+                        row = dest_ok.select(dest, fx.Int32(0))
                     # Fold the row's byte offset into the base ptr; the per-token
                     # row is then a plain (1, D) tiled-copy store like kv_out.
                     # Widen BEFORE the element product: a unified V4 pool runs to
@@ -717,6 +750,7 @@ def _build_kernel(
         batch_id_per_token: fx.Pointer,
         swa_slot_stride: fx.Int32,
         swa_pos_stride: fx.Int32,
+        swa_num_rows: fx.Int32,
         swa_cache_size: fx.Int32,
         num_tokens: fx.Int32,
         stream: fx.Stream,
@@ -740,6 +774,7 @@ def _build_kernel(
             batch_id_per_token,
             swa_slot_stride,
             swa_pos_stride,
+            swa_num_rows,
             swa_cache_size,
         )
         k.launch(
@@ -1028,8 +1063,24 @@ def flydsl_qk_norm_rope_quant(
             )
         if swa_block_tables.dim() != 2 or swa_block_tables.dtype != torch.int32:
             raise TypeError("swa_block_tables must be 2-D [bs, max_blocks] int32")
-        swa_slot_stride = swa_block_tables.stride(0)  # = max_blocks
+        # The kernel indexes the table as `bid * stride(0) + blk` and bounds
+        # `blk` against stride(0). For that bound to be the table WIDTH (what
+        # the C++ sibling checks, via size(1)) and not merely the distance
+        # between rows, the table must be dense: a `full[:, :n]` view would
+        # leave stride(0) > n, letting a far-future position read a stale
+        # padding column instead of being skipped.
+        if swa_block_tables.stride(1) != 1:
+            raise ValueError("swa_block_tables must be contiguous in the last dim")
+        if swa_block_tables.stride(0) != swa_block_tables.shape[1]:
+            raise ValueError(
+                "swa_block_tables must be densely packed "
+                f"(stride(0)={swa_block_tables.stride(0)} != "
+                f"max_blocks={swa_block_tables.shape[1]}); a padded view would "
+                "widen the in-kernel block-index bound past the real table"
+            )
+        swa_slot_stride = swa_block_tables.stride(0)  # == max_blocks
         swa_pos_stride = swa_kv.stride(0)  # = D (flat pool row stride)
+        swa_num_rows = swa_kv.shape[0]
         swa_cache_size = swa_block_size
         swa_kv_arg = swa_kv
         ssm_arg = swa_block_tables
@@ -1051,6 +1102,7 @@ def flydsl_qk_norm_rope_quant(
             )
         swa_slot_stride = 0
         swa_pos_stride = swa_kv.stride(0)
+        swa_num_rows = swa_kv.shape[0]
         swa_cache_size = 1
         swa_kv_arg = swa_kv
         ssm_arg = swa_dest_rows
@@ -1059,6 +1111,7 @@ def flydsl_qk_norm_rope_quant(
         # 1-elem dummies so the kernel param binding has valid pointers.
         swa_slot_stride = 0
         swa_pos_stride = 0
+        swa_num_rows = 0
         swa_cache_size = 1
         swa_kv_arg = kv_out  # bf16 dummy
         ssm_arg = q.new_empty(1, dtype=torch.int32)
@@ -1113,6 +1166,7 @@ def flydsl_qk_norm_rope_quant(
             _ptr_arg(bid_arg[start:end] if kv_write else bid_arg),
             swa_slot_stride,
             swa_pos_stride,
+            swa_num_rows,
             swa_cache_size,
             n,
             fx_stream,

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant.py
@@ -312,7 +312,7 @@ def _build_kernel(
         kv_scale: fx.Pointer,  # [T, NG]           f32 or uint8 (e8m0)
         kv_in_row_stride: Int32,  # KV row stride in bf16 elements
         swa_kv: fx.Pointer,  # [num_slots, cache_size, D] bf16 (dummy if not kv_write)
-        state_slot_mapping: fx.Pointer,  # [bs] i32 (dummy if not kv_write)
+        swa_index: fx.Pointer,  # paged: block_tables; direct: [T] dest rows
         batch_id_per_token: fx.Pointer,  # [T] i32, -1 sentinel (dummy if not kv_write)
         swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
         swa_pos_stride: Int32,  # bf16 elements (= D)
@@ -694,11 +694,11 @@ def _build_kernel(
                 )
 
                 # ---- Fused SWA scatter setup (kv_write only) ----
-                # Target swa_kv[slot, pos % cache_size, :] where
-                # slot = state_slot_mapping[batch_id_per_token[bid_t]].
+                # Target row comes from `swa_index`, whose meaning `paged`
+                # selects: a block table to walk, or this token's row outright.
                 # batch_id is i32 with -1 sentinel on CG-pad tokens; clamp it to
-                # 0 for the (predicated-off) slot load to keep the load in-bounds,
-                # and gate the actual store on do_swa = batch_id>=0.
+                # 0 for the (predicated-off) load to keep it in-bounds, and gate
+                # the actual store on do_swa.
                 swa_out_g = None
                 do_swa = None
                 if const_expr(kv_write):
@@ -709,22 +709,18 @@ def _build_kernel(
                     do_swa = bid_i32 >= fx.Int32(0)
                     bid_safe = arith.maxsi(bid_i32, arith.constant(0, type=i32))
                     if const_expr(paged):
-                        # paged / content-addressed SWA (DeepSeek-V4 #1417):
-                        # swa_kv is the FLAT [num_pages, D] pool; the ring params
-                        # are repurposed — state_slot_mapping is block_tables
-                        # [bs, max_blocks], swa_slot_stride is max_blocks (its row
-                        # stride), swa_cache_size is block_size, swa_pos_stride is
-                        # D. Physical row =
+                        # paged / content-addressed SWA: swa_kv is the FLAT
+                        # [num_pages, D] pool, swa_index is block_tables
+                        # [bs, max_blocks], swa_slot_stride is max_blocks (its
+                        # row stride), swa_cache_size is block_size,
+                        # swa_pos_stride is D. Physical row =
                         #   block_tables[bid, pos//block_size]*block_size
                         #   + pos % block_size
-                        # (identical addressing to the standalone _swa_write_kernel;
-                        # fuses it into this launch so decode drops a per-layer
-                        # kernel launch).
                         blk = arith.divsi(pos_i32, _to_raw(swa_cache_size))
                         bt_off = ArithValue(bid_safe) * ArithValue(
                             swa_slot_stride
                         ) + ArithValue(blk)
-                        bt_rsrc = _ptr_buffer_resource(state_slot_mapping)
+                        bt_rsrc = _ptr_buffer_resource(swa_index)
                         phys = buffer_ops.buffer_load(
                             bt_rsrc, _to_raw(bt_off), vec_width=1, dtype=i32
                         )
@@ -732,19 +728,35 @@ def _build_kernel(
                         row = ArithValue(phys) * ArithValue(
                             swa_cache_size
                         ) + ArithValue(in_blk)
-                        swa_off_elems = ArithValue(row) * ArithValue(swa_pos_stride)
+                        row_safe = _to_raw(row)
                     else:
-                        slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
-                        slot = buffer_ops.buffer_load(
-                            slot_rsrc, bid_safe, vec_width=1, dtype=i32
+                        # Direct: the caller already resolved this token's row.
+                        # A `-1` row means "skip", same as a `-1` batch id --
+                        # a caller whose window is not expressible here needs a
+                        # way to say so per token, not just per request.
+                        row_rsrc = _ptr_buffer_resource(swa_index)
+                        row = buffer_ops.buffer_load(
+                            row_rsrc, bid_t, vec_width=1, dtype=i32
                         )
-                        ring = arith.remsi(pos_i32, _to_raw(swa_cache_size))
-                        swa_off_elems = ArithValue(slot) * ArithValue(
-                            swa_slot_stride
-                        ) + ArithValue(ring) * ArithValue(swa_pos_stride)
+                        do_swa = arith.andi(do_swa, ArithValue(row) >= 0)
+                        row_safe = arith.maxsi(row, arith.constant(0, type=i32))
+                    # The row index fits 32 bits; `row * D * 2` does not. A
+                    # unified V4 pool runs to ~150M rows, so a 32-bit byte
+                    # offset wraps 3% of the way in, and the sliding windows
+                    # this writes live at the far end. Widen before either
+                    # multiply, and let it reach the descriptor through the
+                    # base address (`static_bytes_offset_i64`) rather than
+                    # through the 32-bit offset field, whose window is 4 GiB.
                     swa_off_bytes = arith.index_cast(
-                        T.index, _to_raw(swa_off_elems)
-                    ) * arith.constant(2, type=T.index)
+                        T.index,
+                        arith.muli(
+                            arith.muli(
+                                arith.extsi(T.i64, row_safe),
+                                arith.extsi(T.i64, _to_raw(swa_pos_stride)),
+                            ),
+                            arith.constant(2, type=T.i64),
+                        ),
+                    )
                     swa_out_g = GTensor(
                         swa_kv,
                         dtype=T.bf16,
@@ -784,7 +796,7 @@ def _build_kernel(
         kv_scale: fx.Pointer,
         kv_in_row_stride: fx.Int32,
         swa_kv: fx.Pointer,
-        state_slot_mapping: fx.Pointer,
+        swa_index: fx.Pointer,
         batch_id_per_token: fx.Pointer,
         swa_slot_stride: fx.Int32,
         swa_pos_stride: fx.Int32,
@@ -807,7 +819,7 @@ def _build_kernel(
             kv_scale,
             kv_in_row_stride,
             swa_kv,
-            state_slot_mapping,
+            swa_index,
             batch_id_per_token,
             swa_slot_stride,
             swa_pos_stride,
@@ -895,7 +907,7 @@ def flydsl_qk_norm_rope_quant(
     q_scale: torch.Tensor | None = None,
     kv_scale: torch.Tensor | None = None,
     swa_kv: torch.Tensor | None = None,
-    state_slot_mapping: torch.Tensor | None = None,
+    swa_dest_rows: torch.Tensor | None = None,
     batch_id_per_token: torch.Tensor | None = None,
     swa_block_tables: torch.Tensor | None = None,
     swa_block_size: int | None = None,
@@ -947,14 +959,18 @@ def flydsl_qk_norm_rope_quant(
             stream. **Must NOT be left at ``fx.Stream(None)`` default in
             caller code unless you accept the default-stream pitfall under
             CUDA-graph capture** (NULL stream -> empty captured graph).
-        swa_kv: optional ``[num_slots, cache_size, D]`` bf16 SWA ring buffer.
-            When provided (BF16 only; incompatible with ``quant``), the
-            post-norm/rope KV row is additionally scattered into
-            ``swa_kv[slot, pos % cache_size, :] = kv_out[t]`` in the same
-            launch (``slot = state_slot_mapping[batch_id_per_token[t]]``),
-            fusing the standalone ``swa_write``.
-        state_slot_mapping: ``[bs]`` int32 -- per-seq SWA ring slot. Required
-            when ``swa_kv`` is set.
+        swa_kv: optional bf16 SWA pool. When provided (BF16 only;
+            incompatible with ``quant``), the post-norm/rope KV row is
+            additionally scattered into it in the same launch, fusing the
+            standalone ``swa_write``. Flat ``[num_rows, D]`` with
+            ``swa_dest_rows``; flat ``[num_pages, D]`` with
+            ``swa_block_tables``.
+        swa_dest_rows: ``[T]`` int32 -- the row THIS TOKEN's KV goes to, one
+            entry per token (not per request: with speculation a request
+            writes several positions in one launch and they do not share a
+            row). ``-1`` skips the token. Lets a caller whose window layout
+            this kernel cannot express resolve the row itself. Required when
+            ``swa_kv`` is set and ``swa_block_tables`` is not.
         batch_id_per_token: ``[T]`` int32, ``-1`` on CG-pad tokens -- token->seq
             map for the fused SWA scatter (store gated off on ``-1``). Required
             when ``swa_kv`` is set.
@@ -988,7 +1004,7 @@ def flydsl_qk_norm_rope_quant(
             q_scale=q_scale,
             kv_scale=kv_scale,
             swa_kv=swa_kv,
-            state_slot_mapping=state_slot_mapping,
+            swa_dest_rows=swa_dest_rows,
             batch_id_per_token=batch_id_per_token,
             swa_block_tables=swa_block_tables,
             swa_block_size=swa_block_size,
@@ -1097,12 +1113,11 @@ def flydsl_qk_norm_rope_quant(
     # ---- Fused SWA cache-write (BF16 only) ----
     # Two modes (both write the post-norm/rope KV row in the same launch,
     # avoiding a separate swa_write launch + kv HBM round-trip; bf16 only):
-    #   ring  (swa_kv 3-D):   swa_kv[slot, pos % cache_size, :],
-    #                         slot = state_slot_mapping[batch_id_per_token[t]]
-    #   paged (swa_block_tables given): content-addressed flat pool
-    #                         swa_kv[block_tables[bid, pos//bs]*bs + pos%bs, :]
-    #                         (DeepSeek-V4 #1417). Repurposes the ring scalars:
-    #                         ssm_arg=block_tables, swa_slot_stride=max_blocks,
+    #   direct (swa_dest_rows given): swa_kv[swa_dest_rows[t], :]
+    #   paged  (swa_block_tables given): content-addressed flat pool
+    #                         swa_kv[block_tables[bid, pos//bs]*bs + pos%bs, :].
+    #                         Repurposes the scalars: ssm_arg=block_tables,
+    #                         swa_slot_stride=max_blocks,
     #                         swa_cache_size=block_size, swa_pos_stride=D.
     paged = swa_block_tables is not None
     kv_write = swa_kv is not None
@@ -1137,17 +1152,25 @@ def flydsl_qk_norm_rope_quant(
         ssm_arg = swa_block_tables
         bid_arg = batch_id_per_token
     elif kv_write:
-        if state_slot_mapping is None:
-            raise ValueError("ring kv_write requires state_slot_mapping")
-        if swa_kv.dim() != 3 or swa_kv.shape[2] != D:
-            raise ValueError(f"swa_kv must be [S, C, D={D}], got {tuple(swa_kv.shape)}")
-        if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
-            raise TypeError("state_slot_mapping must be 1-D int32")
-        swa_slot_stride = swa_kv.stride(0)
-        swa_pos_stride = swa_kv.stride(1)
-        swa_cache_size = swa_kv.shape[1]
+        if swa_dest_rows is None:
+            raise ValueError("direct kv_write requires swa_dest_rows")
+        if swa_kv.dim() != 2 or swa_kv.shape[1] != D:
+            raise ValueError(
+                f"direct swa_kv must be flat [num_rows, D={D}], "
+                f"got {tuple(swa_kv.shape)}"
+            )
+        if swa_dest_rows.dim() != 1 or swa_dest_rows.dtype != torch.int32:
+            raise TypeError("swa_dest_rows must be 1-D int32")
+        if swa_dest_rows.shape[0] < T_tok:
+            raise ValueError(
+                f"swa_dest_rows len {swa_dest_rows.shape[0]} < T={T_tok}; it is "
+                "indexed by token, not by request"
+            )
+        swa_slot_stride = 0
+        swa_pos_stride = swa_kv.stride(0)
+        swa_cache_size = 1
         swa_kv_arg = swa_kv
-        ssm_arg = state_slot_mapping
+        ssm_arg = swa_dest_rows
         bid_arg = batch_id_per_token
     else:
         # 1-elem dummies so the kernel param binding has valid pointers.
@@ -1204,11 +1227,12 @@ def flydsl_qk_norm_rope_quant(
             _ptr_arg(q_scale_arg[start:end] if quant else q_scale_arg),
             _ptr_arg(kv_scale_arg[start:end] if quant else kv_scale_arg),
             kv.stride(0),
-            # swa_kv / state_slot_mapping are global (indexed by absolute slot /
-            # batch_id), so pass unsliced; batch_id_per_token is [T], sliced
-            # like positions.
+            # swa_kv is global (absolute rows), so unsliced. `swa_index` is
+            # sliced iff it is indexed by token: block tables are per request
+            # and stay whole, destination rows are per token and must follow
+            # the chunk exactly as positions and batch_id_per_token do.
             _ptr_arg(swa_kv_arg),
-            _ptr_arg(ssm_arg),
+            _ptr_arg(ssm_arg[start:end] if (kv_write and not paged) else ssm_arg),
             _ptr_arg(bid_arg[start:end] if kv_write else bid_arg),
             swa_slot_stride,
             swa_pos_stride,

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
@@ -378,6 +378,7 @@ def _build_kernel(
         batch_id_per_token: fx.Pointer,  # [T] i32, -1 sentinel (dummy if not kv_write)
         swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
         swa_pos_stride: Int32,  # bf16 elements (= D)
+        swa_num_rows: Int32,  # rows in the SWA pool; bounds the final row
         swa_cache_size: Int32,  # ring slot count
         num_tokens: Int32,  # valid tokens in this launch chunk (for tail clamp)
     ):
@@ -816,22 +817,57 @@ def _build_kernel(
                     bid_i32 = buffer_ops.buffer_load(
                         bid_rsrc, bid_t, vec_width=1, dtype=i32
                     )
-                    do_swa = ArithValue(bid_i32) >= 0
+                    # A stale token carries a negative position. `divsi`/`remsi`
+                    # truncate toward zero, so pos=-300 with block_size=128 gives
+                    # blk=-2 and in_blk=-44: the block index passes an upper-bound
+                    # test, reads the PREVIOUS request's table entry, and lands
+                    # the write 44 rows before that block. The C++ sibling's first
+                    # gate is `bid < 0 || pos < 0`; match it, in both modes.
+                    pos_ok = ArithValue(pos_i32) >= 0
+                    do_swa = arith.andi(
+                        _to_raw(ArithValue(bid_i32) >= 0), _to_raw(pos_ok)
+                    )
                     bid_safe = arith.maxsi(bid_i32, arith.constant(0, type=i32))
+                    pos_safe = arith.select(
+                        _to_raw(pos_ok), pos_i32, arith.constant(0, type=i32)
+                    )
                     if const_expr(paged):
-                        blk = arith.divsi(pos_i32, _to_raw(swa_cache_size))
+                        blk = arith.divsi(pos_safe, _to_raw(swa_cache_size))
+                        # The other two gates the C++ sibling applies (see
+                        # `swa_row_for_token`): a position past the table's last
+                        # block would read the NEXT request's entry, and `-1`
+                        # marks a block outside the window. Clamp for the load,
+                        # gate the store on the unclamped test. The wrapper pins
+                        # stride(0) == max_blocks, so the row stride is both the
+                        # table width and the distance between two requests' rows.
+                        blk_ok = ArithValue(blk) < ArithValue(swa_slot_stride)
+                        blk_safe = arith.select(
+                            _to_raw(blk_ok), _to_raw(blk), arith.constant(0, type=i32)
+                        )
                         bt_off = ArithValue(bid_safe) * ArithValue(
                             swa_slot_stride
-                        ) + ArithValue(blk)
+                        ) + ArithValue(blk_safe)
                         bt_rsrc = _ptr_buffer_resource(swa_index)
                         phys = buffer_ops.buffer_load(
                             bt_rsrc, _to_raw(bt_off), vec_width=1, dtype=i32
                         )
-                        in_blk = arith.remsi(pos_i32, _to_raw(swa_cache_size))
+                        in_blk = arith.remsi(pos_safe, _to_raw(swa_cache_size))
                         row = ArithValue(phys) * ArithValue(
                             swa_cache_size
                         ) + ArithValue(in_blk)
-                        row_safe = _to_raw(row)
+                        # Bound the final row against the pool, as the C++ does:
+                        # a phys id left over from a larger pool would otherwise
+                        # write past the end of swa_kv.
+                        row_ok = arith.andi(
+                            arith.andi(_to_raw(blk_ok), _to_raw(ArithValue(phys) >= 0)),
+                            _to_raw(ArithValue(row) < ArithValue(swa_num_rows)),
+                        )
+                        do_swa = arith.andi(do_swa, row_ok)
+                        # Clamp too: a negative row would move the descriptor
+                        # base backwards, out of this tensor entirely.
+                        row_safe = arith.select(
+                            row_ok, _to_raw(row), arith.constant(0, type=i32)
+                        )
                     else:
                         # Direct: the caller already resolved this token's row.
                         # A `-1` row means "skip", same as a `-1` batch id --
@@ -841,8 +877,16 @@ def _build_kernel(
                         row = buffer_ops.buffer_load(
                             row_rsrc, bid_t, vec_width=1, dtype=i32
                         )
-                        do_swa = arith.andi(do_swa, ArithValue(row) >= 0)
-                        row_safe = arith.maxsi(row, arith.constant(0, type=i32))
+                        # Bounded against the pool as well: the caller owns the
+                        # row, but a stale entry must not write past swa_kv.
+                        dest_ok = arith.andi(
+                            _to_raw(ArithValue(row) >= 0),
+                            _to_raw(ArithValue(row) < ArithValue(swa_num_rows)),
+                        )
+                        do_swa = arith.andi(do_swa, dest_ok)
+                        row_safe = arith.select(
+                            dest_ok, _to_raw(row), arith.constant(0, type=i32)
+                        )
                     # The row index fits 32 bits; `row * D * 2` does not. A
                     # unified V4 pool runs to ~150M rows, so a 32-bit byte
                     # offset wraps 3% of the way in, and the sliding windows
@@ -902,6 +946,7 @@ def _build_kernel(
         batch_id_per_token: fx.Pointer,
         swa_slot_stride: fx.Int32,
         swa_pos_stride: fx.Int32,
+        swa_num_rows: fx.Int32,
         swa_cache_size: fx.Int32,
         num_tokens: fx.Int32,
         stream: fx.Stream,
@@ -932,6 +977,7 @@ def _build_kernel(
             batch_id_per_token,
             swa_slot_stride,
             swa_pos_stride,
+            swa_num_rows,
             swa_cache_size,
             num_tokens,
         )
@@ -1129,7 +1175,23 @@ def flydsl_qk_norm_rope_quant_gfx1250(
             )
         if swa_block_tables.dim() != 2 or swa_block_tables.dtype != torch.int32:
             raise TypeError("swa_block_tables must be 2-D [bs, max_blocks] int32")
+        # The kernel indexes the table as `bid * stride(0) + blk` and bounds
+        # `blk` against stride(0). For that bound to be the table WIDTH (what
+        # the C++ sibling checks, via size(1)) and not merely the distance
+        # between rows, the table must be dense: a `full[:, :n]` view would
+        # leave stride(0) > n, letting a far-future position read a stale
+        # padding column instead of being skipped.
+        if swa_block_tables.stride(1) != 1:
+            raise ValueError("swa_block_tables must be contiguous in the last dim")
+        if swa_block_tables.stride(0) != swa_block_tables.shape[1]:
+            raise ValueError(
+                "swa_block_tables must be densely packed "
+                f"(stride(0)={swa_block_tables.stride(0)} != "
+                f"max_blocks={swa_block_tables.shape[1]}); a padded view would "
+                "widen the in-kernel block-index bound past the real table"
+            )
         swa_slot_stride = swa_block_tables.stride(0)
+        swa_num_rows = swa_kv.shape[0]
         swa_pos_stride = swa_kv.stride(0)
         swa_cache_size = swa_block_size
         swa_kv_arg = swa_kv
@@ -1152,6 +1214,7 @@ def flydsl_qk_norm_rope_quant_gfx1250(
             )
         swa_slot_stride = 0
         swa_pos_stride = swa_kv.stride(0)
+        swa_num_rows = swa_kv.shape[0]
         swa_cache_size = 1
         swa_kv_arg = swa_kv
         ssm_arg = swa_dest_rows
@@ -1159,6 +1222,7 @@ def flydsl_qk_norm_rope_quant_gfx1250(
     else:
         swa_slot_stride = 0
         swa_pos_stride = 0
+        swa_num_rows = 0
         swa_cache_size = 1
         swa_kv_arg = kv_out  # bf16 dummy
         ssm_arg = q.new_empty(1, dtype=torch.int32)
@@ -1229,6 +1293,7 @@ def flydsl_qk_norm_rope_quant_gfx1250(
             _ptr_arg(bid_arg[start:end] if kv_write else bid_arg),
             swa_slot_stride,
             swa_pos_stride,
+            swa_num_rows,
             swa_cache_size,
             n,
             _stream_arg(),

--- a/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/qk_norm_rope_quant_gfx1250.py
@@ -374,7 +374,7 @@ def _build_kernel(
         kv_scale: fx.Pointer,  # [T, NG]           f32 or uint8 (e8m0)
         kv_in_row_stride: Int32,  # KV row stride in bf16 elements
         swa_kv: fx.Pointer,  # [num_slots, cache_size, D] bf16 (dummy if not kv_write)
-        state_slot_mapping: fx.Pointer,  # [bs] i32 (dummy if not kv_write)
+        swa_index: fx.Pointer,  # paged: block_tables; direct: [T] dest rows
         batch_id_per_token: fx.Pointer,  # [T] i32, -1 sentinel (dummy if not kv_write)
         swa_slot_stride: Int32,  # bf16 elements (= cache_size * D)
         swa_pos_stride: Int32,  # bf16 elements (= D)
@@ -823,7 +823,7 @@ def _build_kernel(
                         bt_off = ArithValue(bid_safe) * ArithValue(
                             swa_slot_stride
                         ) + ArithValue(blk)
-                        bt_rsrc = _ptr_buffer_resource(state_slot_mapping)
+                        bt_rsrc = _ptr_buffer_resource(swa_index)
                         phys = buffer_ops.buffer_load(
                             bt_rsrc, _to_raw(bt_off), vec_width=1, dtype=i32
                         )
@@ -831,19 +831,35 @@ def _build_kernel(
                         row = ArithValue(phys) * ArithValue(
                             swa_cache_size
                         ) + ArithValue(in_blk)
-                        swa_off_elems = ArithValue(row) * ArithValue(swa_pos_stride)
+                        row_safe = _to_raw(row)
                     else:
-                        slot_rsrc = _ptr_buffer_resource(state_slot_mapping)
-                        slot = buffer_ops.buffer_load(
-                            slot_rsrc, bid_safe, vec_width=1, dtype=i32
+                        # Direct: the caller already resolved this token's row.
+                        # A `-1` row means "skip", same as a `-1` batch id --
+                        # a caller whose window is not expressible here needs a
+                        # way to say so per token, not just per request.
+                        row_rsrc = _ptr_buffer_resource(swa_index)
+                        row = buffer_ops.buffer_load(
+                            row_rsrc, bid_t, vec_width=1, dtype=i32
                         )
-                        ring = arith.remsi(pos_i32, _to_raw(swa_cache_size))
-                        swa_off_elems = ArithValue(slot) * ArithValue(
-                            swa_slot_stride
-                        ) + ArithValue(ring) * ArithValue(swa_pos_stride)
+                        do_swa = arith.andi(do_swa, ArithValue(row) >= 0)
+                        row_safe = arith.maxsi(row, arith.constant(0, type=i32))
+                    # The row index fits 32 bits; `row * D * 2` does not. A
+                    # unified V4 pool runs to ~150M rows, so a 32-bit byte
+                    # offset wraps 3% of the way in, and the sliding windows
+                    # this writes live at the far end. Widen before either
+                    # multiply, and let it reach the descriptor through the
+                    # base address (`static_bytes_offset_i64`) rather than
+                    # through the 32-bit offset field, whose window is 4 GiB.
                     swa_off_bytes = arith.index_cast(
-                        T.index, _to_raw(swa_off_elems)
-                    ) * arith.constant(2, type=T.index)
+                        T.index,
+                        arith.muli(
+                            arith.muli(
+                                arith.extsi(T.i64, row_safe),
+                                arith.extsi(T.i64, _to_raw(swa_pos_stride)),
+                            ),
+                            arith.constant(2, type=T.i64),
+                        ),
+                    )
                     swa_g_tmp = GTensor(
                         swa_kv,
                         dtype=T.bf16,
@@ -882,7 +898,7 @@ def _build_kernel(
         kv_scale: fx.Pointer,
         kv_in_row_stride: fx.Int32,
         swa_kv: fx.Pointer,
-        state_slot_mapping: fx.Pointer,
+        swa_index: fx.Pointer,
         batch_id_per_token: fx.Pointer,
         swa_slot_stride: fx.Int32,
         swa_pos_stride: fx.Int32,
@@ -912,7 +928,7 @@ def _build_kernel(
             kv_scale,
             kv_in_row_stride,
             swa_kv,
-            state_slot_mapping,
+            swa_index,
             batch_id_per_token,
             swa_slot_stride,
             swa_pos_stride,
@@ -990,7 +1006,7 @@ def flydsl_qk_norm_rope_quant_gfx1250(
     q_scale: torch.Tensor | None = None,
     kv_scale: torch.Tensor | None = None,
     swa_kv: torch.Tensor | None = None,
-    state_slot_mapping: torch.Tensor | None = None,
+    swa_dest_rows: torch.Tensor | None = None,
     batch_id_per_token: torch.Tensor | None = None,
     swa_block_tables: torch.Tensor | None = None,
     swa_block_size: int | None = None,
@@ -1120,17 +1136,25 @@ def flydsl_qk_norm_rope_quant_gfx1250(
         ssm_arg = swa_block_tables
         bid_arg = batch_id_per_token
     elif kv_write:
-        if state_slot_mapping is None:
-            raise ValueError("ring kv_write requires state_slot_mapping")
-        if swa_kv.dim() != 3 or swa_kv.shape[2] != D:
-            raise ValueError(f"swa_kv must be [S, C, D={D}], got {tuple(swa_kv.shape)}")
-        if state_slot_mapping.dim() != 1 or state_slot_mapping.dtype != torch.int32:
-            raise TypeError("state_slot_mapping must be 1-D int32")
-        swa_slot_stride = swa_kv.stride(0)
-        swa_pos_stride = swa_kv.stride(1)
-        swa_cache_size = swa_kv.shape[1]
+        if swa_dest_rows is None:
+            raise ValueError("direct kv_write requires swa_dest_rows")
+        if swa_kv.dim() != 2 or swa_kv.shape[1] != D:
+            raise ValueError(
+                f"direct swa_kv must be flat [num_rows, D={D}], "
+                f"got {tuple(swa_kv.shape)}"
+            )
+        if swa_dest_rows.dim() != 1 or swa_dest_rows.dtype != torch.int32:
+            raise TypeError("swa_dest_rows must be 1-D int32")
+        if swa_dest_rows.shape[0] < T_tok:
+            raise ValueError(
+                f"swa_dest_rows len {swa_dest_rows.shape[0]} < T={T_tok}; it is "
+                "indexed by token, not by request"
+            )
+        swa_slot_stride = 0
+        swa_pos_stride = swa_kv.stride(0)
+        swa_cache_size = 1
         swa_kv_arg = swa_kv
-        ssm_arg = state_slot_mapping
+        ssm_arg = swa_dest_rows
         bid_arg = batch_id_per_token
     else:
         swa_slot_stride = 0
@@ -1197,8 +1221,11 @@ def flydsl_qk_norm_rope_quant_gfx1250(
             _ptr_arg(q_scale_arg[start:end] if quant else q_scale_arg),
             _ptr_arg(kv_scale_arg[start:end] if quant else kv_scale_arg),
             kv.stride(0),
+            # `swa_index` is sliced iff it is indexed by token: block tables
+            # are per request and stay whole, destination rows are per token
+            # and must follow the chunk exactly as positions do.
             _ptr_arg(swa_kv_arg),
-            _ptr_arg(ssm_arg),
+            _ptr_arg(ssm_arg[start:end] if (kv_write and not paged) else ssm_arg),
             _ptr_arg(bid_arg[start:end] if kv_write else bid_arg),
             swa_slot_stride,
             swa_pos_stride,

--- a/aiter/ops/fused_qk_norm_rope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_rope_cache_quant.py
@@ -340,11 +340,14 @@ def _fused_qk_norm_rope_group_quant_kernel(
     q_rope_buff: Tensor | None = None,
     # --- Optional fused SWA write (decode-only) ---
     # swa_nope_scale_buff [num_rows, entry] / swa_rope_buff [num_rows, pe_dim],
-    # addressed by swa_block_tables[bid, positions[t] // swa_block_size].
+    # addressed either by swa_block_tables[bid, positions[t] // swa_block_size]
+    # (paged) or by swa_dest_row[t] (rows the caller computed itself, for a
+    # window whose layout this kernel need not know). Pass exactly one.
     # batch_id_per_token maps token->seq (-1 = CG-pad, skipped).
     swa_nope_scale_buff: Tensor | None = None,
     swa_rope_buff: Tensor | None = None,
     swa_block_tables: Tensor | None = None,
+    swa_dest_row: Tensor | None = None,
     swa_block_size: int = 0,
     batch_id_per_token: Tensor | None = None,
 ) -> None: ...
@@ -379,11 +382,14 @@ def fused_qk_norm_rope_group_quant(
     scale_dtype: str = "e8m0",
     # --- Optional fused SWA write (decode-only) ---
     # swa_nope_scale_buff [num_rows, entry] / swa_rope_buff [num_rows, rot_dim],
-    # addressed by swa_block_tables[bid, positions[t] // swa_block_size].
+    # addressed either by swa_block_tables[bid, positions[t] // swa_block_size]
+    # (paged) or by swa_dest_row[t] (rows the caller computed itself, for a
+    # window whose layout this kernel need not know). Pass exactly one.
     # batch_id_per_token maps token->seq (-1 = skip).
     swa_nope_scale_buff: Tensor | None = None,
     swa_rope_buff: Tensor | None = None,
     swa_block_tables: Tensor | None = None,
+    swa_dest_row: Tensor | None = None,
     swa_block_size: int | None = None,
     batch_id_per_token: Tensor | None = None,
 ):
@@ -488,6 +494,7 @@ def fused_qk_norm_rope_group_quant(
         swa_nope_scale_buff=swa_nope_scale_buff,
         swa_rope_buff=swa_rope_buff,
         swa_block_tables=swa_block_tables,
+        swa_dest_row=swa_dest_row,
         swa_block_size=0 if swa_block_size is None else swa_block_size,
         batch_id_per_token=batch_id_per_token,
     )

--- a/aiter/ops/fused_qk_norm_rope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_rope_cache_quant.py
@@ -343,6 +343,8 @@ def _fused_qk_norm_rope_group_quant_kernel(
     # addressed either by swa_block_tables[bid, positions[t] // swa_block_size]
     # (paged) or by swa_dest_row[t] (rows the caller computed itself, for a
     # window whose layout this kernel need not know). Pass exactly one.
+    # Both modes still skip a token whose positions[t] is negative: the caller
+    # owns the row, not the staleness test.
     # batch_id_per_token maps token->seq (-1 = CG-pad, skipped).
     swa_nope_scale_buff: Tensor | None = None,
     swa_rope_buff: Tensor | None = None,
@@ -385,6 +387,8 @@ def fused_qk_norm_rope_group_quant(
     # addressed either by swa_block_tables[bid, positions[t] // swa_block_size]
     # (paged) or by swa_dest_row[t] (rows the caller computed itself, for a
     # window whose layout this kernel need not know). Pass exactly one.
+    # Both modes still skip a token whose positions[t] is negative: the caller
+    # owns the row, not the staleness test.
     # batch_id_per_token maps token->seq (-1 = skip).
     swa_nope_scale_buff: Tensor | None = None,
     swa_rope_buff: Tensor | None = None,

--- a/aiter/ops/triton/_triton_kernels/attention/pa_decode_sparse.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_decode_sparse.py
@@ -183,16 +183,23 @@ def _pa_decode_sparse(
         else:
             valid = in_range
 
+        # 64-bit before the multiply: a slot index fits 32 bits (the index
+        # buffer is int32 by ABI) but `slot * kv_stride_n` does not. A unified
+        # V4 pool runs to ~150M rows, so at a 512-element row the product
+        # passes 2^31 only 2.8% of the way in and every row above that is read
+        # from a wrapped address -- silently, since the wrapped offset still
+        # lands inside the same allocation.
+        slot_off = slot.to(tl.int64)
         kv_raw = tl.load(
             unified_kv_ptr
-            + slot[:, None] * kv_stride_n
+            + slot_off[:, None] * kv_stride_n
             + d_offs[None, :] * kv_stride_d,
             mask=valid[:, None] & d_mask[None, :],
             other=0.0,
         )
         if QUANT_KV:
             scales_full = tl.load(
-                kv_scales_ptr + slot[:, None] * ks_stride_n + g_idx_per_d[None, :],
+                kv_scales_ptr + slot_off[:, None] * ks_stride_n + g_idx_per_d[None, :],
                 mask=valid[:, None] & d_mask[None, :],
                 other=0.0,
             )

--- a/aiter/ops/triton/_triton_kernels/attention/sparse_attention_dsv4.py
+++ b/aiter/ops/triton/_triton_kernels/attention/sparse_attention_dsv4.py
@@ -327,8 +327,17 @@ def _sparse_attn_prefill_kernel(
         in_range = k_pos < kv_len
         valid = in_range & (slot >= 0) & (slot < num_kv)
 
+        # 64-bit before the multiply, same as the decode kernel: a slot index
+        # fits 32 bits (the index buffer is int32 by ABI) but `slot *
+        # kv_stride_n` does not once the unified V4 pool runs to ~150M rows.
+        # The wrapped offset still lands inside the same allocation, so the
+        # bad read is silent.
+        slot_off = slot.to(tl.int64)
+
         kv = tl.load(
-            kv_ptr + slot[:, None] * kv_stride_n + dim_offsets[None, :] * kv_stride_d,
+            kv_ptr
+            + slot_off[:, None] * kv_stride_n
+            + dim_offsets[None, :] * kv_stride_d,
             mask=valid[:, None] & dim_mask[None, :],
             other=0.0,
         )

--- a/csrc/include/fused_qk_norm_rope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_rope_cache_quant.h
@@ -224,12 +224,15 @@ void fused_qk_norm_rope_group_quant(
     // (Q mirrors K: nope fp8 + inline scale in q_nope_scale_buff, PE bf16 here). Unused for bf16 Q.
     std::optional<aiter_tensor_t> q_rope_buff = std::nullopt,
     // --- Optional fused SWA write (decode-only) ---
-    // swa_nope_scale_buff [num_rows, entry] and swa_rope_buff
-    // [num_rows, pe_dim] are addressed by swa_block_tables[bid, pos/swa_block_size].
+    // swa_nope_scale_buff [num_rows, entry] and swa_rope_buff [num_rows, pe_dim]
+    // are addressed either by swa_block_tables[bid, pos/swa_block_size] (paged)
+    // or by swa_dest_row[token] (rows the caller computed itself, for a window
+    // whose layout this kernel need not know). Pass exactly one of the two.
     // batch_id_per_token maps token->seq (-1 = CG-pad, skipped).
     std::optional<aiter_tensor_t> swa_nope_scale_buff = std::nullopt,
     std::optional<aiter_tensor_t> swa_rope_buff = std::nullopt,
     std::optional<aiter_tensor_t> swa_block_tables = std::nullopt,
+    std::optional<aiter_tensor_t> swa_dest_row = std::nullopt,
     int64_t swa_block_size = 0,
     std::optional<aiter_tensor_t> batch_id_per_token = std::nullopt);
 

--- a/csrc/include/fused_qk_norm_rope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_rope_cache_quant.h
@@ -228,6 +228,7 @@ void fused_qk_norm_rope_group_quant(
     // are addressed either by swa_block_tables[bid, pos/swa_block_size] (paged)
     // or by swa_dest_row[token] (rows the caller computed itself, for a window
     // whose layout this kernel need not know). Pass exactly one of the two.
+    // Either way a token with a negative position is skipped.
     // batch_id_per_token maps token->seq (-1 = CG-pad, skipped).
     std::optional<aiter_tensor_t> swa_nope_scale_buff = std::nullopt,
     std::optional<aiter_tensor_t> swa_rope_buff = std::nullopt,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1995,6 +1995,7 @@ namespace py = pybind11;
           py::arg("swa_nope_scale_buff") = std::nullopt,               \
           py::arg("swa_rope_buff")       = std::nullopt,               \
           py::arg("swa_block_tables")    = std::nullopt,               \
+          py::arg("swa_dest_row")        = std::nullopt,               \
           py::arg("swa_block_size")      = 0,                          \
           py::arg("batch_id_per_token")  = std::nullopt);               \
     m.def("fused_kv_norm_rope_group_quant",                            \

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -4323,16 +4323,66 @@ namespace aiter {
         int compress_ratio;
         int block_table_seq_stride;
         // --- Fused SWA write (decode-only, QK kernel) ---
-        // Paged SWA (M2): dest row is content-addressed through the SWA block table:
-        //   blk  = pos / swa_block_size
-        //   phys = swa_block_tables[bid, blk]
-        //   row  = phys*swa_block_size + pos%swa_block_size
-        //   swa_*[row*swa_*_row_stride + :]
-        // Strides are in element units (cache_t for nope, scalar_t for rope). Unused
-        // (0) when SWA pointers are null. Ignored by the K-only kernel.
+        // Two addressing modes, selected by which of the two index tensors the
+        // host passed:
+        //   direct (swa_dest_row != nullptr):
+        //     row = swa_dest_row[token_idx]
+        //   paged  (swa_block_tables != nullptr):
+        //     blk = pos/swa_block_size
+        //     row = swa_block_tables[bid, blk]*swa_block_size + pos%swa_block_size
+        // then swa_*[row*swa_*_row_stride + :].
+        //
+        // The direct mode exists because a caller's window need not be
+        // expressible here at all. ATOM's DeepSeek-V4 pool interleaves each
+        // request's window rows across a shared row space, by a stride that
+        // depends on the layer's compress class -- it computes the row where it
+        // owns that layout and hands the result over per token, so a change to
+        // it never reaches this file. It is also strictly more general than the
+        // ring it replaced (`slot*cache_size + pos%cache_size`), which a
+        // degenerate paged table could not emulate either: `blk` grows with
+        // position, so a long context ran past swa_block_tables_blocks and the
+        // write was silently skipped.
+        //
+        // Strides are in element units (cache_t for nope, scalar_t for rope).
+        // Unused (0) when SWA pointers are null. Ignored by the K-only kernel.
         int swa_block_size, swa_block_tables_stride, swa_block_tables_blocks;
         int swa_nope_row_stride, swa_rope_row_stride;
+        // Rows in the SWA pool. Both modes bound the final row against this --
+        // paged only ever checked the block index, and a ring has no equivalent
+        // of that check at all, so a stale slot would scatter anywhere.
+        int swa_num_rows;
     };
+
+    // Destination row for one token's fused SWA write, or -1 to skip it.
+    // Skipped: CG-pad tokens (bid < 0), stale positions, out-of-window sentinel
+    // blocks (phys < 0), rows the caller marked -1, and any row the pool does
+    // not have. Shared by the QK and K-only kernels so the two addressing modes
+    // are written down once.
+    template <typename params_t>
+    __device__ __forceinline__ int64_t swa_row_for_token(
+        const params_t& params,
+        const int32_t* __restrict__ swa_block_tables,
+        const int32_t* __restrict__ swa_dest_row,
+        int64_t token_idx,
+        int32_t bid,
+        int64_t pos)
+    {
+      if (bid < 0 || pos < 0) return -1;
+      int64_t row;
+      if (swa_dest_row != nullptr) {
+        row = static_cast<int64_t>(swa_dest_row[token_idx]);
+        if (row < 0) return -1;
+      } else {
+        const int32_t blk = static_cast<int32_t>(pos / params.swa_block_size);
+        if (blk >= params.swa_block_tables_blocks) return -1;
+        const int32_t phys = swa_block_tables[
+            static_cast<int64_t>(bid) * params.swa_block_tables_stride + blk];
+        if (phys < 0) return -1;
+        row = static_cast<int64_t>(phys) * params.swa_block_size +
+              (pos % params.swa_block_size);
+      }
+      return (row < params.swa_num_rows) ? row : -1;
+    }
 
 
     // ============================================================================
@@ -4692,6 +4742,7 @@ namespace aiter {
         cache_t*  __restrict__ swa_nope = nullptr,           // nope+scale pool, mirrors kv_cache
         scalar_t* __restrict__ swa_rope = nullptr,           // rope bf16 pool, mirrors k_pe_out
         const int32_t* __restrict__ swa_block_tables = nullptr,    // [bs, max_blocks] paged SWA table
+        const int32_t* __restrict__ swa_dest_row = nullptr,        // [T] plane row per token
         const int32_t* __restrict__ batch_id_per_token = nullptr   // [T] token->seq, -1 = skip
     ) {
       // ---- All compile-time constants ----
@@ -4768,28 +4819,18 @@ namespace aiter {
             static_cast<int64_t>(token_idx) * params.token_stride;
         const int64_t out_rope_offset =
             static_cast<int64_t>(token_idx) * params.k_pe_out_stride_0;
-        // Optional fused SWA scatter (decode-only): write the same post-norm/rope K
-        // row into the paged SWA pool using swa_block_tables. CG-pad tokens (bid < 0),
-        // stale/OOB positions, and window-outside sentinel blocks (phys < 0) are skipped.
+        // Optional fused SWA scatter (decode-only): write the same post-norm/rope
+        // K row into the SWA pool, ring- or block-table-addressed.
         bool write_swa = false;
         int64_t swa_cache_offset = 0, swa_rope_offset = 0;
         if (swa_nope != nullptr) {
-          const int32_t bid = batch_id_per_token[token_idx];
-          if (bid >= 0) {
-            const int64_t pos = positions[token_idx];
-            const int32_t blk = static_cast<int32_t>(pos / params.swa_block_size);
-            if (pos >= 0 && blk >= 0 && blk < params.swa_block_tables_blocks) {
-              const int32_t phys =
-                  swa_block_tables[static_cast<int64_t>(bid) * params.swa_block_tables_stride + blk];
-              if (phys >= 0) {
-                const int32_t off = static_cast<int32_t>(pos % params.swa_block_size);
-                const int64_t dst_row =
-                    static_cast<int64_t>(phys) * params.swa_block_size + off;
-                write_swa = true;
-                swa_cache_offset = dst_row * params.swa_nope_row_stride;
-                swa_rope_offset  = dst_row * params.swa_rope_row_stride;
-              }
-            }
+          const int64_t dst_row =
+              swa_row_for_token(params, swa_block_tables, swa_dest_row, token_idx,
+                                batch_id_per_token[token_idx], positions[token_idx]);
+          if (dst_row >= 0) {
+            write_swa = true;
+            swa_cache_offset = dst_row * params.swa_nope_row_stride;
+            swa_rope_offset  = dst_row * params.swa_rope_row_stride;
           }
         }
         if (swa_nope != nullptr) {
@@ -5091,6 +5132,7 @@ namespace aiter {
         cache_t*  __restrict__ swa_nope = nullptr,           // nope+scale pool, mirrors kv_cache
         scalar_t* __restrict__ swa_rope = nullptr,           // rope bf16 pool, mirrors k_pe_out
         const int32_t* __restrict__ swa_block_tables = nullptr,    // [bs, max_blocks] paged SWA table
+        const int32_t* __restrict__ swa_dest_row = nullptr,        // [T] plane row per token
         const int32_t* __restrict__ batch_id_per_token = nullptr   // [T] token->seq, -1 = skip
     ) {
       // ---- compile-time constants (identical to the coarse kernel) ----
@@ -5166,30 +5208,20 @@ namespace aiter {
         compute_rope_ptrs(cos_ptr, sin_ptr);
 
         // Optional fused SWA scatter (decode-only): mirror this post-norm/rope K row
-        // (nope fp8 + inline dup e8m0 scale, and rope bf16) into the paged SWA pool
-        // addressed by swa_block_tables[bid, pos/block_size]. CG-pad tokens (bid < 0),
-        // stale/OOB positions, and window-outside sentinel blocks (phys < 0) are skipped.
+        // (nope fp8 + inline dup e8m0 scale, and rope bf16) into the SWA pool, ring-
+        // or block-table-addressed.
         // Only the K wave scatters (the SWA pool is K-only); Q waves never reach here.
         cache_t*  ptr_swa_o    = nullptr;
         scalar_t* swa_out_rope = nullptr;
         bool write_swa = false;
         if (swa_nope != nullptr) {
-          const int32_t bid = batch_id_per_token[token_idx];
-          if (bid >= 0) {
-            const int64_t pos = positions[token_idx];
-            const int32_t blk = static_cast<int32_t>(pos / params.swa_block_size);
-            if (pos >= 0 && blk >= 0 && blk < params.swa_block_tables_blocks) {
-              const int32_t phys =
-                  swa_block_tables[static_cast<int64_t>(bid) * params.swa_block_tables_stride + blk];
-              if (phys >= 0) {
-                const int32_t off = static_cast<int32_t>(pos % params.swa_block_size);
-                const int64_t dst_row =
-                    static_cast<int64_t>(phys) * params.swa_block_size + off;
-                write_swa    = true;
-                ptr_swa_o    = swa_nope + dst_row * params.swa_nope_row_stride + nope_offset;
-                swa_out_rope = swa_rope + dst_row * params.swa_rope_row_stride;
-              }
-            }
+          const int64_t dst_row =
+              swa_row_for_token(params, swa_block_tables, swa_dest_row, token_idx,
+                                batch_id_per_token[token_idx], positions[token_idx]);
+          if (dst_row >= 0) {
+            write_swa    = true;
+            ptr_swa_o    = swa_nope + dst_row * params.swa_nope_row_stride + nope_offset;
+            swa_out_rope = swa_rope + dst_row * params.swa_rope_row_stride;
           }
         }
         auto buffer_swa_o = opus::make_gmem<cache_t>(
@@ -5469,6 +5501,7 @@ namespace aiter {
         cache_t*  __restrict__ swa_nope = nullptr,
         scalar_t* __restrict__ swa_rope = nullptr,
         const int32_t* __restrict__ swa_block_tables = nullptr,
+        const int32_t* __restrict__ swa_dest_row = nullptr,
         const int32_t* __restrict__ batch_id_per_token = nullptr
     ) {
       constexpr int HEADS_PER_BLOCK = TOKENS_PER_BLOCK;
@@ -5482,7 +5515,7 @@ namespace aiter {
             Q_GROUP_SIZE, Q_SCALE_FP32, HAS_Q_WEIGHT, HEAD_DIM>( \
             q, kv, k_pe_out, k_weight, q_weight, kv_cache, q_out, q_scale_raw, q_rope_out, positions, \
             cos_cache, sin_cache, eps, params, token_idx, combined_head_idx, tid, \
-            swa_nope, swa_rope, swa_block_tables, batch_id_per_token)
+            swa_nope, swa_rope, swa_block_tables, swa_dest_row, batch_id_per_token)
       if (is_neox) { DISPATCH_NEOX_FG(true); }
       else         { DISPATCH_NEOX_FG(false); }
       #undef DISPATCH_NEOX_FG
@@ -5514,6 +5547,7 @@ namespace aiter {
         cache_t*  __restrict__ swa_nope = nullptr,
         scalar_t* __restrict__ swa_rope = nullptr,
         const int32_t* __restrict__ swa_block_tables = nullptr,
+        const int32_t* __restrict__ swa_dest_row = nullptr,
         const int32_t* __restrict__ batch_id_per_token = nullptr
     ) {
       #define DISPATCH_NEOX(NEOX) \
@@ -5521,7 +5555,7 @@ namespace aiter {
             Q_GROUP_SIZE, Q_SCALE_FP32, HAS_Q_WEIGHT, HEAD_DIM, TOKENS_PER_BLOCK>( \
             q, kv, k_pe_out, k_weight, q_weight, kv_cache, q_out, q_scale_raw, q_rope_out, positions, \
             cos_cache, sin_cache, eps, params, \
-            swa_nope, swa_rope, swa_block_tables, batch_id_per_token)
+            swa_nope, swa_rope, swa_block_tables, swa_dest_row, batch_id_per_token)
 
       if (is_neox) { DISPATCH_NEOX(true); }
       else         { DISPATCH_NEOX(false); }
@@ -5558,6 +5592,7 @@ namespace aiter {
                  reinterpret_cast<CACHE_T*>(swa_nope_ptr),                                               \
                  reinterpret_cast<KV_T*>(swa_rope_ptr),                                                  \
                  reinterpret_cast<const int32_t*>(swa_block_tables_ptr),                                 \
+                 reinterpret_cast<const int32_t*>(swa_dest_row_ptr),                                    \
                  reinterpret_cast<const int32_t*>(swa_bid_ptr));
 
 // Fine-grained launcher (1 wave / (token,head); grid=(num_tokens,num_heads+1), block=64).
@@ -5584,6 +5619,7 @@ namespace aiter {
                  reinterpret_cast<CACHE_T*>(swa_nope_ptr),                                               \
                  reinterpret_cast<KV_T*>(swa_rope_ptr),                                                  \
                  reinterpret_cast<const int32_t*>(swa_block_tables_ptr),                                 \
+                 reinterpret_cast<const int32_t*>(swa_dest_row_ptr),                                    \
                  reinterpret_cast<const int32_t*>(swa_bid_ptr));
 
 namespace aiter {
@@ -5606,12 +5642,14 @@ void fused_qk_norm_rope_group_quant(
     const std::string& scale_dtype,
     std::optional<aiter_tensor_t> q_rope_buff,
     // --- Optional fused SWA write (decode-only) ---
-    // Paged mode: swa_nope_scale_buff [num_swa_rows, entry] and swa_rope_buff
-    // [num_swa_rows, pe_dim] are addressed by swa_block_tables[bid, pos/block_size].
-    // Tokens with batch_id < 0 (CG-pad) are skipped.
+    // swa_nope_scale_buff [num_swa_rows, entry] and swa_rope_buff
+    // [num_swa_rows, pe_dim] are addressed either by swa_dest_row[token] or by
+    // swa_block_tables[bid, pos/block_size]. Tokens with batch_id < 0 (CG-pad)
+    // are skipped.
     std::optional<aiter_tensor_t> swa_nope_scale_buff,
     std::optional<aiter_tensor_t> swa_rope_buff,
     std::optional<aiter_tensor_t> swa_block_tables,
+    std::optional<aiter_tensor_t> swa_dest_row,
     int64_t swa_block_size,
     std::optional<aiter_tensor_t> batch_id_per_token)
 {
@@ -5735,12 +5773,17 @@ void fused_qk_norm_rope_group_quant(
   void* swa_nope_ptr     = nullptr;
   void* swa_rope_ptr     = nullptr;
   void* swa_block_tables_ptr = nullptr;
+  void* swa_dest_row_ptr     = nullptr;
   void* swa_bid_ptr      = nullptr;
   if (has_swa) {
-    AITER_CHECK(swa_rope_buff.has_value() && batch_id_per_token.has_value()
-                && swa_block_tables.has_value(),
+    // Exactly one index tensor picks the addressing mode. Both would be
+    // ambiguous; neither leaves the destination undefined.
+    AITER_CHECK(swa_block_tables.has_value() != swa_dest_row.has_value(),
+                "SWA write needs exactly one of swa_block_tables (paged) or "
+                "swa_dest_row (caller-supplied rows), not both and not neither");
+    AITER_CHECK(swa_rope_buff.has_value() && batch_id_per_token.has_value(),
                 "SWA write requires swa_nope_scale_buff, swa_rope_buff, "
-                "swa_block_tables, swa_block_size, and batch_id_per_token");
+                "swa_block_size, and batch_id_per_token");
     AITER_CHECK(swa_nope_scale_buff->dtype() == k_nope_scale_buff.dtype(),
                 "swa_nope_scale_buff dtype must match k_nope_scale_buff");
     AITER_CHECK(swa_rope_buff->dtype() == k_rope_buff.dtype(),
@@ -5749,24 +5792,37 @@ void fused_qk_norm_rope_group_quant(
                 "batch_id_per_token must be int32");
     AITER_CHECK(batch_id_per_token->size(0) >= num_tokens,
                 "batch_id_per_token length must be >= num_tokens");
-    // Paged SWA pool is flat: [num_swa_blocks * block_size, entry/pe_dim].
+    // Either way the pool is flat: [num_rows, entry/pe_dim]; only who computes
+    // a row differs.
     AITER_CHECK(swa_nope_scale_buff->dim() == 2 && swa_rope_buff->dim() == 2,
-                "paged SWA buffers must be 2D [num_rows, entry/pe_dim]");
+                "SWA buffers must be 2D [num_rows, entry/pe_dim]");
     AITER_CHECK(swa_nope_scale_buff->size(0) == swa_rope_buff->size(0),
-                "paged swa_nope_scale_buff and swa_rope_buff must share num_rows");
-    AITER_CHECK(swa_block_tables->dim() == 2 && swa_block_tables->dtype() == AITER_DTYPE_i32,
-                "swa_block_tables must be 2D [bs, max_blocks] int32");
-    AITER_CHECK(swa_block_tables->stride(1) == 1,
-                "swa_block_tables must be contiguous in last dim (stride(1) == 1)");
+                "swa_nope_scale_buff and swa_rope_buff must share num_rows");
     AITER_CHECK(swa_nope_scale_buff->stride(1) == 1 && swa_rope_buff->stride(1) == 1,
-                "paged SWA buffers must be contiguous in last dim (stride(1) == 1)");
-    AITER_CHECK(swa_block_size > 0, "swa_block_size must be > 0 for paged SWA");
+                "SWA buffers must be contiguous in last dim (stride(1) == 1)");
+    if (swa_block_tables.has_value()) {
+      AITER_CHECK(swa_block_size > 0, "paged SWA write needs swa_block_size > 0");
+      AITER_CHECK(swa_block_tables->dim() == 2 && swa_block_tables->dtype() == AITER_DTYPE_i32,
+                  "swa_block_tables must be 2D [bs, max_blocks] int32");
+      AITER_CHECK(swa_block_tables->stride(1) == 1,
+                  "swa_block_tables must be contiguous in last dim (stride(1) == 1)");
+      mla_params.swa_block_tables_stride = static_cast<int>(swa_block_tables->stride(0));
+      mla_params.swa_block_tables_blocks = static_cast<int>(swa_block_tables->size(1));
+      swa_block_tables_ptr = swa_block_tables->data_ptr();
+    } else {
+      AITER_CHECK(swa_dest_row->dim() == 1 && swa_dest_row->dtype() == AITER_DTYPE_i32,
+                  "swa_dest_row must be 1D [num_tokens] int32");
+      AITER_CHECK(swa_dest_row->stride(0) == 1, "swa_dest_row must be contiguous");
+      // Indexed by token, not by request: with speculation a request writes
+      // several positions in one launch, and they do not share a row.
+      AITER_CHECK(swa_dest_row->size(0) >= num_tokens,
+                  "swa_dest_row length must be >= num_tokens");
+      swa_dest_row_ptr = swa_dest_row->data_ptr();
+    }
     mla_params.swa_block_size = static_cast<int>(swa_block_size);
-    mla_params.swa_block_tables_stride = static_cast<int>(swa_block_tables->stride(0));
-    mla_params.swa_block_tables_blocks = static_cast<int>(swa_block_tables->size(1));
+    mla_params.swa_num_rows = static_cast<int>(swa_nope_scale_buff->size(0));
     mla_params.swa_nope_row_stride = static_cast<int>(swa_nope_scale_buff->stride(0));
     mla_params.swa_rope_row_stride = static_cast<int>(swa_rope_buff->stride(0));
-    swa_block_tables_ptr = swa_block_tables->data_ptr();
     swa_nope_ptr     = swa_nope_scale_buff->data_ptr();
     swa_rope_ptr     = swa_rope_buff->data_ptr();
     swa_bid_ptr      = batch_id_per_token->data_ptr();

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -4356,8 +4356,13 @@ namespace aiter {
     // Destination row for one token's fused SWA write, or -1 to skip it.
     // Skipped: CG-pad tokens (bid < 0), stale positions, out-of-window sentinel
     // blocks (phys < 0), rows the caller marked -1, and any row the pool does
-    // not have. Shared by the QK and K-only kernels so the two addressing modes
-    // are written down once.
+    // not have. Shared by the coarse and fine-grained QK kernels so the two
+    // addressing modes are written down once. (The K-only entry point does not
+    // expose an SWA write at all.)
+    //
+    // Note the `pos < 0` gate applies in BOTH modes: a direct-mode caller owns
+    // the row but not the staleness test, so a negative position still skips
+    // even when swa_dest_row[token] names a valid row.
     template <typename params_t>
     __device__ __forceinline__ int64_t swa_row_for_token(
         const params_t& params,
@@ -4820,7 +4825,8 @@ namespace aiter {
         const int64_t out_rope_offset =
             static_cast<int64_t>(token_idx) * params.k_pe_out_stride_0;
         // Optional fused SWA scatter (decode-only): write the same post-norm/rope
-        // K row into the SWA pool, ring- or block-table-addressed.
+        // K row into the SWA pool, block-table-addressed (paged) or at a row the
+        // caller resolved (direct). See `swa_row_for_token`.
         bool write_swa = false;
         int64_t swa_cache_offset = 0, swa_rope_offset = 0;
         if (swa_nope != nullptr) {
@@ -5208,8 +5214,8 @@ namespace aiter {
         compute_rope_ptrs(cos_ptr, sin_ptr);
 
         // Optional fused SWA scatter (decode-only): mirror this post-norm/rope K row
-        // (nope fp8 + inline dup e8m0 scale, and rope bf16) into the SWA pool, ring-
-        // or block-table-addressed.
+        // (nope fp8 + inline dup e8m0 scale, and rope bf16) into the SWA pool,
+        // block-table-addressed (paged) or at a caller-resolved row (direct).
         // Only the K wave scatters (the SWA pool is K-only); Q waves never reach here.
         cache_t*  ptr_swa_o    = nullptr;
         scalar_t* swa_out_rope = nullptr;
@@ -5781,9 +5787,11 @@ void fused_qk_norm_rope_group_quant(
     AITER_CHECK(swa_block_tables.has_value() != swa_dest_row.has_value(),
                 "SWA write needs exactly one of swa_block_tables (paged) or "
                 "swa_dest_row (caller-supplied rows), not both and not neither");
+    // swa_block_size is checked in the paged branch only; direct mode never
+    // divides by it.
     AITER_CHECK(swa_rope_buff.has_value() && batch_id_per_token.has_value(),
-                "SWA write requires swa_nope_scale_buff, swa_rope_buff, "
-                "swa_block_size, and batch_id_per_token");
+                "SWA write requires swa_nope_scale_buff, swa_rope_buff, and "
+                "batch_id_per_token");
     AITER_CHECK(swa_nope_scale_buff->dtype() == k_nope_scale_buff.dtype(),
                 "swa_nope_scale_buff dtype must match k_nope_scale_buff");
     AITER_CHECK(swa_rope_buff->dtype() == k_rope_buff.dtype(),

--- a/op_tests/test_flydsl_qk_norm_rope_quant.py
+++ b/op_tests/test_flydsl_qk_norm_rope_quant.py
@@ -28,10 +28,16 @@ import torch
 
 import aiter
 from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.flydsl import flydsl_qk_norm_rope_quant
 from aiter.test_common import benchmark, checkAllclose, run_perftest
 
 torch.set_default_device("cuda")
+
+# The public wrapper dispatches wave64 (gfx942/gfx950) vs wave32 (gfx1250)
+# internally, so one test covers every card. Positive allow-list: an unknown
+# new card must not silently run an unbuilt kernel.
+SUPPORTED_GFX = ["gfx942", "gfx950", "gfx1250"]
 
 # Shared constants (independent of attention shape).
 _EPS = 1e-6
@@ -182,6 +188,11 @@ def _dequant(out_fp8, scale, *, D, quant_group_size, scale_dtype):
 
 # MI355X HBM3e peak. Used only for the "%peak" perf column.
 _PEAK_BW_GBPS = 8000.0
+# Pin the arg-rotation count. Left to itself, run_perftest derives it from
+# `free_memory` at call time, so two rows timed in one process rotate a
+# different number of times and land in different L2 states -- their `us`
+# columns then are not comparable with each other.
+_ROTATE = 4
 
 
 @benchmark()
@@ -253,6 +264,7 @@ def test_flydsl_qk_norm_rope_quant(
         quant=quant,
         quant_group_size=quant_group_size,
         scale_dtype=scale_dtype,
+        num_rotate_args=_ROTATE,
     )
 
     # Accuracy
@@ -368,30 +380,144 @@ def test_flydsl_qk_norm_rope_quant_cos_sin_4d():
     torch.testing.assert_close(out_2d[1], out_4d[1], atol=0.0, rtol=0.0)
 
 
-def test_flydsl_qk_norm_rope_quant_kv_write():
-    """Cover the fused SWA cache-write path (BF16 only).
+# ============================================================================
+# Fused SWA cache-write (BF16 only)
+# ============================================================================
+#
+# With ``swa_kv`` provided, the kernel scatters each token's post-norm/rope KV
+# row into a second pool in the same launch, fusing what used to be a separate
+# ``swa_write`` kernel. Two addressing modes, one per value of ``mode``:
+#
+#   direct : row = swa_dest_rows[t]                       (caller resolved it)
+#   paged  : row = block_tables[bid, pos//B]*B + pos%B    (content-addressed)
+#
+# The scatter stores the SAME bytes the kernel writes to ``kv_out``, so the
+# pool must be bit-exact against a gather built from ``kv_out`` -- no separate
+# torch reference is needed or meaningful for the scatter itself.
+#
+# Every skip path the kernel implements gets a token, because each is a
+# distinct gate and a regression in one is invisible to the others:
+#
+#   both   : batch_id_per_token[t] == -1   CG-pad token
+#   both   : row past the pool             stale row from a larger pool
+#   direct : swa_dest_rows[t] == -1        caller declined this token
+#   paged  : block_tables[...] == -1       block outside the window
+#   paged  : blk >= max_blocks             position past the table's end
+#
+# Not covered: the kernel's ``pos < 0`` gate. A negative position is not a
+# legal input to this op -- the main path indexes cos/sin with the raw position
+# long before the scatter -- so that gate is defence-in-depth mirroring the C++
+# sibling, and feeding one in would make the whole launch undefined rather than
+# exercise the gate.
 
-    With ``swa_kv`` provided, the kernel scatters each token's post-norm/rope
-    KV row into ``swa_kv[slot, pos % cache_size, :]`` where
-    ``slot = state_slot_mapping[batch_id_per_token[t]]``. Since the scatter
-    stores the SAME bytes the kernel writes to ``kv_out``, the result must be
-    bit-exact against a gather built from ``kv_out``. A ``-1`` sentinel in
-    ``batch_id_per_token`` (CG-pad tokens) must be skipped, leaving those
-    ring slots untouched.
+_SWA_BLOCK_SIZE = 8  # small, so a block-index overrun is reachable at modest T
+_SWA_MAX_BLOCKS = 4
+_SWA_BS = 4  # sequences in the paged block table
+_SWA_GUARD_ROWS = 16
+
+
+def _build_swa_case(T, mode, *, device):
+    """Batch layout for the fused SWA scatter, one token per skip path.
+
+    Returns ``(bid, pos, index_tensor, num_rows, dest)`` where ``dest[t]`` is
+    the pool row token ``t`` must land on, or ``-1`` if the kernel must skip
+    it. ``index_tensor`` is what the caller passes: ``swa_dest_rows`` in direct
+    mode, ``swa_block_tables`` in paged mode.
     """
+    # Reserve the last three tokens for skip paths; the rest are plain writes.
+    n_special = 3 if T >= 6 else 0
+    n_write = T - n_special
+    bid_l = [t % _SWA_BS for t in range(n_write)]
+    pos_l = [t // _SWA_BS for t in range(n_write)]
+
+    if mode == "paged":
+        # Plain writes are confined to blocks [0, max_blocks-1), leaving the
+        # LAST block free for the out-of-window sentinel. Without that reserve,
+        # a large enough T has a plain token allocate the very block the
+        # sentinel wants, the sentinel stops being a sentinel, and two tokens
+        # land on one row -- which breaks the collision-free premise the
+        # replay-and-compare depends on.
+        cap = (_SWA_MAX_BLOCKS - 1) * _SWA_BLOCK_SIZE
+        assert n_write <= _SWA_BS * cap, f"T={T} exceeds the paged table capacity"
+        # t_sent: a block deliberately left at the -1 out-of-window sentinel.
+        # t_over: blk past the table. Its overrun lands on flat index
+        # bid*max_blocks + blk, i.e. a LATER sequence's row -- point it at an
+        # ALLOCATED entry, else the phys<0 gate catches it first and the block
+        # bound is never actually exercised.
+        if n_special:
+            bid_l += [-1, 0, 1]
+            pos_l += [
+                0,
+                (_SWA_MAX_BLOCKS - 1) * _SWA_BLOCK_SIZE,  # the reserved block
+                _SWA_MAX_BLOCKS * _SWA_BLOCK_SIZE + 3,  # blk past the table
+            ]
+        t_sent = n_write + 1 if n_special else -1
+
+        bt = torch.full((_SWA_BS, _SWA_MAX_BLOCKS), -1, dtype=torch.int32)
+        nxt = 0
+        for t in range(len(bid_l)):
+            b, pv = bid_l[t], pos_l[t]
+            if b < 0 or t == t_sent:
+                continue
+            blk = pv // _SWA_BLOCK_SIZE
+            if blk >= _SWA_MAX_BLOCKS:
+                continue
+            if int(bt[b, blk]) < 0:
+                bt[b, blk] = nxt
+                nxt += 1
+        # The overrun token reads table[flat // max_blocks, flat % max_blocks];
+        # make sure that entry is real so only the blk bound can stop it.
+        if n_special:
+            flat = bid_l[-1] * _SWA_MAX_BLOCKS + pos_l[-1] // _SWA_BLOCK_SIZE
+            r, c = flat // _SWA_MAX_BLOCKS, flat % _SWA_MAX_BLOCKS
+            if r < _SWA_BS and int(bt[r, c]) < 0:
+                bt[r, c] = nxt
+                nxt += 1
+        num_rows = max(nxt, 1) * _SWA_BLOCK_SIZE
+
+        dest = []
+        for t in range(len(bid_l)):
+            b, pv = bid_l[t], pos_l[t]
+            blk = pv // _SWA_BLOCK_SIZE
+            if b < 0 or blk >= _SWA_MAX_BLOCKS:
+                dest.append(-1)
+                continue
+            phys = int(bt[b, blk])
+            row = phys * _SWA_BLOCK_SIZE + pv % _SWA_BLOCK_SIZE
+            dest.append(-1 if phys < 0 or row >= num_rows else row)
+        index_t = bt.to(device)
+    else:
+        if n_special:
+            bid_l += [-1, 0, 1]
+            pos_l += [0, 0, 0]
+        num_rows = max(T + _SWA_GUARD_ROWS, 32)
+        # Scattered, NOT identity: a kernel that used the token index instead of
+        # the supplied row would still pass an identity mapping.
+        rows = torch.randperm(num_rows, device=device)[:T].to(torch.int32)
+        dest = [int(r) for r in rows.tolist()]
+        if n_special:
+            dest[-3] = -1  # bid == -1
+            dest[-2] = -1  # caller declined this token
+            dest[-1] = num_rows + 5  # stale row past the pool
+            rows[-2] = -1
+            rows[-1] = num_rows + 5
+        for t in range(T):
+            if bid_l[t] < 0 or dest[t] < 0 or dest[t] >= num_rows:
+                dest[t] = -1
+        index_t = rows
+
+    bid = torch.tensor(bid_l, dtype=torch.int32, device=device)
+    pos = torch.tensor(pos_l, dtype=torch.int64, device=device)
+    return bid, pos, index_t, num_rows, dest
+
+
+@benchmark()
+def test_flydsl_swa_write(T, H, D, RD, mode):
     torch.manual_seed(0)
     device = torch.device("cuda")
-    H, D, RD = 16, 512, 64
-    bs = 5
-    mtp = 1  # MTP-1: 2 tokens/seq -> token->seq is NOT identity
-    tok_per_seq = 1 + mtp
-    T_valid = bs * tok_per_seq
-    pad = 3  # CG-pad sentinel tokens
-    T = T_valid + pad
-    cache_size = 129  # window 128 + 1 spec
-    num_slots = 8
 
-    max_pos = max(cache_size, 64)
+    bid, pos, index_t, num_rows, dest = _build_swa_case(T, mode, device=device)
+    max_pos = int(pos.max().item()) + 4
     inv_freq = 1.0 / (10000 ** (torch.arange(0, RD, 2, device=device).float() / RD))
     freqs = torch.einsum(
         "i,j->ij", torch.arange(max_pos, device=device).float(), inv_freq
@@ -400,22 +526,32 @@ def test_flydsl_qk_norm_rope_quant_kv_write():
     sin = freqs.sin().to(torch.bfloat16).contiguous()
 
     q = torch.randn(T, H * D, dtype=torch.bfloat16, device=device) * 0.1
+    # Mimic the V4 KV split: kv is a strided view into a wider tensor, exactly
+    # as the model hands it over.
     Q_LORA = 1536
     qkv_a = torch.randn(T, Q_LORA + D, dtype=torch.bfloat16, device=device) * 0.1
     _, kv = torch.split(qkv_a, [Q_LORA, D], dim=-1)
     kv_w = torch.randn(D, dtype=torch.bfloat16, device=device).abs() + 0.5
-    pos = torch.randint(0, max_pos - 1, (T,), dtype=torch.int64, device=device)
 
-    # batch_id_per_token: valid tokens map to seqs round-robin; pad tail = -1.
-    bid = torch.full((T,), -1, dtype=torch.int32, device=device)
-    bid[:T_valid] = (torch.arange(T_valid, device=device) // tok_per_seq).to(
-        torch.int32
+    # Carve the pool out of a larger allocation. The out-of-bounds gates prevent
+    # a write; they change no in-pool byte, so only a dirtied guard row can show
+    # that one regressed.
+    G = _SWA_GUARD_ROWS
+    pool = torch.zeros(G + num_rows + G, D, dtype=torch.bfloat16, device=device)
+    swa_kv = pool[G : G + num_rows]
+    mode_kw = (
+        {"swa_dest_rows": index_t}
+        if mode == "direct"
+        else {"swa_block_tables": index_t, "swa_block_size": _SWA_BLOCK_SIZE}
     )
-    # random per-seq state slot (distinct so collisions don't mask bugs)
-    state_slot = torch.randperm(num_slots, device=device)[:bs].to(torch.int32)
 
-    swa_kv = torch.zeros(num_slots, cache_size, D, dtype=torch.bfloat16, device=device)
-
+    # Correctness and perf are measured SEPARATELY on purpose. The scatter
+    # writes in place, and run_perftest rotates its args across several deep
+    # copies of every tensor -- so the guarded pool inspected below would be
+    # written by some subset of the iterations while the returned tensors come
+    # from another, which made err intermittently non-zero. One untimed launch
+    # owns the correctness check; the timed launch writes a throwaway pool and
+    # its output is discarded.
     got_q, got_kv, _, _ = flydsl_qk_norm_rope_quant(
         q,
         kv,
@@ -427,35 +563,88 @@ def test_flydsl_qk_norm_rope_quant_kv_write():
         head_dim=D,
         rope_head_dim=RD,
         swa_kv=swa_kv,
-        state_slot_mapping=state_slot,
         batch_id_per_token=bid,
+        **mode_kw,
+    )
+    _, us = run_perftest(
+        flydsl_qk_norm_rope_quant,
+        q,
+        kv,
+        kv_w,
+        cos,
+        sin,
+        pos,
+        num_q_heads=H,
+        head_dim=D,
+        rope_head_dim=RD,
+        swa_kv=torch.zeros_like(swa_kv),
+        batch_id_per_token=bid,
+        **mode_kw,
+        num_rotate_args=_ROTATE,
     )
 
-    # Expected ring: for each valid token, swa_kv[slot, pos%cache] == kv_out.
+    # The scatter is a verbatim copy of kv_out, so the reference IS kv_out
+    # gathered onto the rows the addressing mode selects.
     expected = torch.zeros_like(swa_kv)
+    n_written = 0
     for t in range(T):
-        b = int(bid[t].item())
-        if b < 0:
+        if dest[t] < 0:
             continue
-        slot = int(state_slot[b].item())
-        ring = int(pos[t].item()) % cache_size
-        expected[slot, ring] = got_kv[t]
+        expected[dest[t]] = got_kv[t]
+        n_written += 1
+    # The point of the layout is that some tokens are skipped; if every token
+    # landed, the gates below would be vacuously satisfied.
+    assert (
+        n_written < T or T < 6
+    ), f"{mode}: no skip path exercised at T={T} ({n_written}/{T} written)"
 
-    torch.testing.assert_close(swa_kv, expected, atol=0.0, rtol=0.0)
+    err_swa = checkAllclose(
+        expected.to(dtypes.fp32),
+        swa_kv.to(dtypes.fp32),
+        rtol=0,
+        atol=0,  # pure byte copy: must be exact
+        msg=f"SWA pool ({mode})",
+    )
+    # A skipped token must reach NO row, not merely the right one.
+    assert (
+        int((swa_kv != 0).any(dim=1).sum()) == n_written
+    ), f"{mode}: a skipped token still reached the pool"
+    assert not pool[:G].any(), f"{mode}: scatter wrote BEFORE the pool"
+    assert not pool[G + num_rows :].any(), f"{mode}: scatter wrote PAST the pool"
 
-    # kv_out itself must match the no-kv_write path bit-for-bit (scatter is a
-    # pure side write; it must not perturb the primary output).
+    # The scatter must not perturb the primary outputs.
     ref_q, ref_kv, _, _ = flydsl_qk_norm_rope_quant(
         q, kv, kv_w, cos, sin, pos, num_q_heads=H, head_dim=D, rope_head_dim=RD
     )
-    torch.testing.assert_close(got_kv, ref_kv, atol=0.0, rtol=0.0)
-    torch.testing.assert_close(got_q, ref_q, atol=0.0, rtol=0.0)
-    print("[kv_write] fused SWA scatter bit-exact; pad sentinel skipped — PASS")
+    err_q = checkAllclose(
+        ref_q.to(dtypes.fp32), got_q.to(dtypes.fp32), rtol=0, atol=0, msg="Q vs no-SWA"
+    )
+    err_kv = checkAllclose(
+        ref_kv.to(dtypes.fp32),
+        got_kv.to(dtypes.fp32),
+        rtol=0,
+        atol=0,
+        msg="KV vs no-SWA",
+    )
 
+    # RMSNorm ~4 flop/elem (square, accumulate, mul rstd, mul weight); GPT-J
+    # RoPE ~3 flop/elem over the RD tail. Q and KV rows both do both.
+    rows = T * H + T
+    flops = rows * D * 4 + rows * RD * 3
+    # Read q+kv, write q_out+kv_out, plus the scattered rows. bf16 throughout.
+    nbytes = (rows * D * 2) * 2 + n_written * D * 2
 
-# ============================================================================
-# argparse + matrix sweep
-# ============================================================================
+    return {
+        "gfx": get_gfx(),
+        "rows_written": n_written,
+        "us": round(us, 3),
+        "TFLOPS": round(flops / us / 1e6, 2),
+        "TB/s": round(nbytes / us / 1e6, 3),
+        "err_swa": err_swa,
+        "err_q": err_q,
+        "err_kv": err_kv,
+    }
+
 
 _QUANT_OPTIONS = {
     "bf16": (False, None, "fp32", False),  # quant_q,kv off
@@ -470,75 +659,89 @@ _QUANT_OPTIONS = {
 }
 
 
-parser = argparse.ArgumentParser(
-    formatter_class=argparse.RawTextHelpFormatter,
-    description="aiter test for flydsl_qk_norm_rope_quant (V4-Pro decode shape).",
-)
-parser.add_argument(
-    "-T",
-    "--T",
-    type=int,
-    nargs="*",
-    default=[1, 2, 16, 32, 64, 128, 192, 256, 512, 1024, 16384, 65540],
-    help="token-count sweep. e.g. -T 4 64 1024",
-)
-parser.add_argument(
-    "--H",
-    type=int,
-    nargs="*",
-    default=[16, 64, 128],
-    help="num-Q-heads-per-rank sweep. e.g. --H 16 128",
-)
-parser.add_argument(
-    "--D",
-    type=int,
-    nargs="*",
-    default=[512],
-    help=(
-        "head_dim sweep. Current kernel MVP only supports D=512 (VEC=8); "
-        "other D values are rejected with a clear assert until atom-widths + "
-        "fp8 packing are generalised."
-    ),
-)
-parser.add_argument(
-    "--RD",
-    type=int,
-    default=64,
-    help="rope_head_dim (RoPE tail size, single value)",
-)
-parser.add_argument(
-    "-q",
-    "--quant",
-    type=str,
-    choices=list(_QUANT_OPTIONS.keys()),
-    nargs="*",
-    default=list(_QUANT_OPTIONS.keys()),
-    help="quant config(s). bf16 = no quant, fp8_<group>_<scale> = quant.",
-)
-parser.add_argument(
-    "--qweight",
-    action="store_true",
-    help="also run each config with optional q_weight=enabled.",
-)
-parser.add_argument(
-    "--no-quant",
-    action="store_true",
-    help="bf16 only (ignore -q).",
-)
-args = parser.parse_args()
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning(
+            "flydsl_qk_norm_rope_quant unsupported on %s; skipping", get_gfx()
+        )
+        return
 
-# Smoke-test the advertised 4D cos/sin layout once before sweeping.
-test_flydsl_qk_norm_rope_quant_cos_sin_4d()
-# Smoke-test the fused SWA cache-write path.
-test_flydsl_qk_norm_rope_quant_kv_write()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="aiter test for flydsl_qk_norm_rope_quant (V4-Pro decode shape).",
+    )
+    parser.add_argument(
+        "-T",
+        "--T",
+        type=int,
+        nargs="*",
+        default=[1, 2, 16, 32, 64, 128, 192, 256, 512, 1024, 16384, 65540],
+        help="token-count sweep. e.g. -T 4 64 1024",
+    )
+    parser.add_argument(
+        "--H",
+        type=int,
+        nargs="*",
+        default=[16, 64, 128],
+        help="num-Q-heads-per-rank sweep. e.g. --H 16 128",
+    )
+    parser.add_argument(
+        "--D",
+        type=int,
+        nargs="*",
+        default=[512],
+        help=(
+            "head_dim sweep. Current kernel MVP only supports D=512 (VEC=8); "
+            "other D values are rejected with a clear assert until atom-widths + "
+            "fp8 packing are generalised."
+        ),
+    )
+    parser.add_argument(
+        "--RD",
+        type=int,
+        default=64,
+        help="rope_head_dim (RoPE tail size, single value)",
+    )
+    parser.add_argument(
+        "-q",
+        "--quant",
+        type=str,
+        choices=list(_QUANT_OPTIONS.keys()),
+        nargs="*",
+        default=list(_QUANT_OPTIONS.keys()),
+        help="quant config(s). bf16 = no quant, fp8_<group>_<scale> = quant.",
+    )
+    parser.add_argument(
+        "--qweight",
+        action="store_true",
+        help="also run each config with optional q_weight=enabled.",
+    )
+    parser.add_argument(
+        "--swa-mode",
+        type=str,
+        nargs="*",
+        default=["direct", "paged"],
+        choices=["direct", "paged"],
+        help="SWA scatter addressing mode(s) to sweep.",
+    )
+    parser.add_argument(
+        "--no-quant",
+        action="store_true",
+        help="bf16 only (ignore -q).",
+    )
+    args = parser.parse_args()
 
-quant_keys = ["bf16"] if args.no_quant else args.quant
-qweight_modes = [False, True] if args.qweight else [False]
+    # Smoke-test the advertised 4D cos/sin layout once before sweeping.
+    test_flydsl_qk_norm_rope_quant_cos_sin_4d()
 
-rows = []
-for key, qw_mode, H, D in itertools.product(quant_keys, qweight_modes, args.H, args.D):
-    quant, group_size, scale_dtype, _ = _QUANT_OPTIONS[key]
-    for T in args.T:
+    quant_keys = ["bf16"] if args.no_quant else args.quant
+    qweight_modes = [False, True] if args.qweight else [False]
+
+    rows = []
+    for key, qw_mode, H, D, T in itertools.product(
+        quant_keys, qweight_modes, args.H, args.D, args.T
+    ):
+        quant, group_size, scale_dtype, _ = _QUANT_OPTIONS[key]
         rows.append(
             test_flydsl_qk_norm_rope_quant(
                 T,
@@ -551,8 +754,29 @@ for key, qw_mode, H, D in itertools.product(quant_keys, qweight_modes, args.H, a
                 quant=quant,
             )
         )
+    aiter.logger.info(
+        "flydsl_qk_norm_rope_quant summary (markdown):\n%s",
+        pd.DataFrame(rows).to_markdown(index=False),
+    )
 
-df = pd.DataFrame(rows)
-aiter.logger.info(
-    "flydsl_qk_norm_rope_quant summary (markdown):\n%s", df.to_markdown(index=False)
-)
+    # Separate arg signature -> its own table (merging would scatter NaNs).
+    # The scatter is decode-only and bf16-only; keep T in the decode range.
+    swa_rows = []
+    for mode, H, D, T in itertools.product(
+        args.swa_mode,
+        args.H,
+        args.D,
+        # decode range: the scatter is decode-only, and the paged layout holds
+        # _SWA_BS * (max_blocks-1) * block_size == 96 tokens (the last block is
+        # reserved for the out-of-window sentinel).
+        [t for t in args.T if 8 <= t <= 96] or [16, 64],
+    ):
+        swa_rows.append(test_flydsl_swa_write(T, H, D, args.RD, mode))
+    aiter.logger.info(
+        "flydsl_qk_norm_rope_quant fused SWA write summary (markdown):\n%s",
+        pd.DataFrame(swa_rows).to_markdown(index=False),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/test_fused_qk_norm_rope_group_quant.py
+++ b/op_tests/test_fused_qk_norm_rope_group_quant.py
@@ -59,9 +59,19 @@ _FP8_MX_DTYPE = (
     MxDtypeInt.FP8_E4M3_FNUZ if get_gfx() == "gfx942" else MxDtypeInt.FP8_E4M3
 )
 _DEV = "cuda"
+# Positive allow-list: an unknown new card must not silently run an unbuilt
+# kernel. The fused SWA scatter rides the same HIP op, so no extra gate.
+SUPPORTED_GFX = ["gfx942", "gfx950"]
 PE_BYTE_OFFSET = 464
 # MI355X HBM3e peak. Used only for the "%peak" perf column.
 _PEAK_BW_GBPS = 8000.0
+# Pin the arg-rotation count. Left to itself, run_perftest derives it from
+# `free_memory` at call time, so two candidates timed in one process rotate a
+# different number of times, land in different L2 states, and their `us`
+# columns stop being comparable -- on a box whose VRAM is mostly held by other
+# processes this reached 1.4x of pure artefact between the paged and direct
+# SWA modes, whose real GPU-side durations are within 4% of each other.
+_ROTATE = 4
 
 
 # ============================================================================
@@ -221,6 +231,7 @@ def test_fused_qk_norm_rope_group_quant(
         k_rope_buff=k_rope_buff,
         quant_group_size=G,
         scale_dtype="e8m0",
+        num_rotate_args=_ROTATE,
     )
 
     # --- Accuracy ---
@@ -334,6 +345,7 @@ def test_fused_qk_norm_rope_group_quant(
                 quant=q_fp8,
                 quant_group_size=(G if q_fp8 else None),
                 scale_dtype=("e8m0" if q_fp8 else "fp32"),
+                num_rotate_args=_ROTATE,
             )
         except Exception:  # noqa: BLE001
             fly_us = float("nan")
@@ -383,10 +395,15 @@ def test_fused_qk_norm_rope_group_quant(
 #   swa_rope[row, :] = k_rope_buff[t]         (rope bf16)
 # batch_id == -1 (CG-pad) or phys == -1 (outside SWA window) skips.
 #
+# The same scatter also has a DIRECT mode, where the caller resolves the row itself
+# and passes swa_dest_row[t] instead of a block table (row == -1 skips that token).
+#
 # Verification strategy: run the kernel, then REPLAY the scatter in python from the
 # kernel's own main K outputs and compare byte-exact to the SWA pool. This validates
 # the paged addressing + the verbatim entry copy (incl. the duplicated scale + pad)
 # independently of the quant math (which the main test above already checks vs ref).
+# Direct mode is then fed the rows paged mode just computed and must land the same
+# bytes, plus one token dropped via -1 to cover the per-token skip.
 
 
 def _build_swa_batch(T, block_size):
@@ -467,7 +484,38 @@ def test_fused_qk_norm_rope_group_quant_swa(T, H, D, RD, *, is_neox, q_fp8, G, G
     swa_nope = torch.zeros(num_rows, entry, dtype=_FP8, device=_DEV)
     swa_rope = torch.zeros(num_rows, RD, dtype=torch.bfloat16, device=_DEV)
 
-    (q_nope_scale_buff, q_rope_buff, k_nope_scale_buff, k_rope_buff), us = run_perftest(
+    # Correctness and perf are measured SEPARATELY. The SWA pools are written
+    # in place, and run_perftest rotates its args across deep copies of every
+    # tensor -- the pool inspected below would then be written by some subset
+    # of the iterations while the returned buffers come from another, which
+    # makes the byte-exact comparison intermittently fail. One untimed launch
+    # owns correctness; the timed launches below scatter into scratch pools and
+    # their outputs are discarded.
+    q_nope_scale_buff, q_rope_buff, k_nope_scale_buff, k_rope_buff = (
+        aiter.fused_qk_norm_rope_group_quant(
+            q,
+            kv,
+            kw,
+            pos,
+            cos,
+            sin,
+            eps,
+            is_neox=is_neox,
+            q_out_dtype=(_FP8 if q_fp8 else torch.bfloat16),
+            q_nope_scale_buff=q_nope_scale_buff,
+            q_rope_buff=q_rope_buff,
+            k_nope_scale_buff=k_nope_scale_buff,
+            k_rope_buff=k_rope_buff,
+            quant_group_size=G,
+            scale_dtype="e8m0",
+            swa_nope_scale_buff=swa_nope,
+            swa_rope_buff=swa_rope,
+            swa_block_tables=swa_block_tables,
+            swa_block_size=block_size,
+            batch_id_per_token=bid,
+        )
+    )
+    _, us = run_perftest(
         aiter.fused_qk_norm_rope_group_quant,
         q,
         kv,
@@ -478,17 +526,18 @@ def test_fused_qk_norm_rope_group_quant_swa(T, H, D, RD, *, is_neox, q_fp8, G, G
         eps,
         is_neox=is_neox,
         q_out_dtype=(_FP8 if q_fp8 else torch.bfloat16),
-        q_nope_scale_buff=q_nope_scale_buff,
-        q_rope_buff=q_rope_buff,
-        k_nope_scale_buff=k_nope_scale_buff,
-        k_rope_buff=k_rope_buff,
+        q_nope_scale_buff=torch.empty_like(q_nope_scale_buff),
+        q_rope_buff=(None if q_rope_buff is None else torch.empty_like(q_rope_buff)),
+        k_nope_scale_buff=torch.empty_like(k_nope_scale_buff),
+        k_rope_buff=torch.empty_like(k_rope_buff),
         quant_group_size=G,
         scale_dtype="e8m0",
-        swa_nope_scale_buff=swa_nope,
-        swa_rope_buff=swa_rope,
+        swa_nope_scale_buff=torch.zeros_like(swa_nope),
+        swa_rope_buff=torch.zeros_like(swa_rope),
         swa_block_tables=swa_block_tables,
         swa_block_size=block_size,
         batch_id_per_token=bid,
+        num_rotate_args=_ROTATE,
     )
 
     # --- Main K cache still correct (sanity vs reference) ---
@@ -549,6 +598,99 @@ def test_fused_qk_norm_rope_group_quant_swa(T, H, D, RD, *, is_neox, q_fp8, G, G
         msg="SWA rope bf16 (exact)",
     )
 
+    # --- Direct mode (swa_dest_row) must reproduce the paged result ---
+    # Same batch, but the host resolves each token's row itself -- exactly the
+    # row paged mode just computed -- and hands it over per token. The two
+    # addressing modes must put identical bytes in identical places. One
+    # otherwise-valid token is then marked -1 to exercise the per-token skip,
+    # which paged mode cannot express at all (its only skip is per block).
+    dest_cpu = [-1] * T
+    for t in range(T):
+        b = bid_cpu[t]
+        if b < 0:
+            continue
+        phys = int(block_tables_cpu[b, pos_cpu[t] // block_size])
+        if phys < 0:
+            continue
+        dest_cpu[t] = phys * block_size + pos_cpu[t] % block_size
+    written_ts = [t for t in range(T) if dest_cpu[t] >= 0]
+    skipped_t = written_ts[-1] if written_ts else -1
+    skipped_row = dest_cpu[skipped_t] if skipped_t >= 0 else -1
+    if skipped_t >= 0:
+        dest_cpu[skipped_t] = -1
+    dest_row = torch.tensor(dest_cpu, dtype=torch.int32, device=_DEV)
+
+    swa_nope_d = torch.zeros_like(swa_nope)
+    swa_rope_d = torch.zeros_like(swa_rope)
+    # Untimed launch owns the byte-exact comparison (see the paged call above
+    # for why rotation and an in-place pool cannot share one launch).
+    aiter.fused_qk_norm_rope_group_quant(
+        q,
+        kv,
+        kw,
+        pos,
+        cos,
+        sin,
+        eps,
+        is_neox=is_neox,
+        q_out_dtype=(_FP8 if q_fp8 else torch.bfloat16),
+        q_nope_scale_buff=torch.zeros_like(q_nope_scale_buff),
+        q_rope_buff=(None if q_rope_buff is None else torch.empty_like(q_rope_buff)),
+        k_nope_scale_buff=torch.zeros_like(k_nope_scale_buff),
+        k_rope_buff=torch.empty_like(k_rope_buff),
+        quant_group_size=G,
+        scale_dtype="e8m0",
+        swa_nope_scale_buff=swa_nope_d,
+        swa_rope_buff=swa_rope_d,
+        swa_dest_row=dest_row,
+        batch_id_per_token=bid,
+    )
+    _, us_direct = run_perftest(
+        aiter.fused_qk_norm_rope_group_quant,
+        q,
+        kv,
+        kw,
+        pos,
+        cos,
+        sin,
+        eps,
+        is_neox=is_neox,
+        q_out_dtype=(_FP8 if q_fp8 else torch.bfloat16),
+        q_nope_scale_buff=torch.zeros_like(q_nope_scale_buff),
+        q_rope_buff=(None if q_rope_buff is None else torch.empty_like(q_rope_buff)),
+        k_nope_scale_buff=torch.zeros_like(k_nope_scale_buff),
+        k_rope_buff=torch.empty_like(k_rope_buff),
+        quant_group_size=G,
+        scale_dtype="e8m0",
+        swa_nope_scale_buff=torch.zeros_like(swa_nope_d),
+        swa_rope_buff=torch.zeros_like(swa_rope_d),
+        swa_dest_row=dest_row,
+        batch_id_per_token=bid,
+        num_rotate_args=_ROTATE,
+    )
+    # The collision-free layout gives each row at most one writer, so dropping
+    # one token means exactly one row reverts to zero.
+    exp_nope_d, exp_rope_d = exp_nope.clone(), exp_rope.clone()
+    if skipped_row >= 0:
+        exp_nope_d[skipped_row] = 0
+        exp_rope_d[skipped_row] = 0
+    err_swa_direct = max(
+        checkAllclose(
+            swa_nope_d.view(torch.uint8).float(),
+            exp_nope_d.view(torch.uint8).float(),
+            atol=0.0,
+            rtol=0.0,
+            msg="SWA nope+scale, direct rows (byte-exact)",
+        ),
+        checkAllclose(
+            swa_rope_d.float(),
+            exp_rope_d.float(),
+            atol=0.0,
+            rtol=0.0,
+            msg="SWA rope bf16, direct rows (exact)",
+        ),
+    )
+
     # --- flydsl bf16 paged-SWA write comparison ---
     # flydsl's fused SWA scatter is BF16-only (fp8+SWA is rejected), so this is the
     # only apples-ish "both fuse the SWA write" comparison: flydsl writes the full KV
@@ -577,29 +719,43 @@ def test_fused_qk_norm_rope_group_quant_swa(T, H, D, RD, *, is_neox, q_fp8, G, G
                 batch_id_per_token=bid,
                 swa_block_tables=swa_block_tables,
                 swa_block_size=block_size,
+                num_rotate_args=_ROTATE,
             )
         except Exception:  # noqa: BLE001
             fly_us = float("nan")
-    ratio = (
-        (us / fly_us)
-        if fly_us == fly_us and fly_us > 0  # noqa: PLR0124
-        else float("nan")
-    )
+    # RMSNorm ~4 flop/elem + GPT-J RoPE ~3 flop/elem over the RD tail, on the Q
+    # and K rows alike. Bytes: read q+kv, write the fp8 entry (+dup e8m0) and
+    # the bf16 rope buffer, plus the scattered SWA rows.
+    rows = T * H + T
+    flops = rows * D * 4 + rows * RD * 3
+    nbytes = rows * D * 2 + rows * entry + rows * RD * 2 + n_written * (entry + RD * 2)
+
+    def _tf(u):
+        return round(flops / u / 1e6, 2) if u == u and u > 0 else None  # noqa: PLR0124
+
+    def _tb(u):
+        return round(nbytes / u / 1e6, 3) if u == u and u > 0 else None  # noqa: PLR0124
 
     return {
-        "hip_us": round(us, 3),
-        "flydsl_bf16_us": (
-            round(fly_us, 3) if fly_us == fly_us else None  # noqa: PLR0124
-        ),
-        "hip/flydsl": (round(ratio, 3) if ratio == ratio else None),  # noqa: PLR0124
+        "gfx": get_gfx(),
         "bs": bs,
         "num_phys_blocks": num_phys_blocks,
         "n_pad": n_pad,
         "n_written": n_written,
+        "hip_paged us": round(us, 3),
+        "hip_paged TFLOPS": _tf(us),
+        "hip_paged TB/s": _tb(us),
+        "hip_direct us": round(us_direct, 3),
+        "hip_direct TFLOPS": _tf(us_direct),
+        "hip_direct TB/s": _tb(us_direct),
+        "flydsl_bf16 us": (
+            round(fly_us, 3) if fly_us == fly_us else None  # noqa: PLR0124
+        ),
         "err_k": err_k,
         "err_kpe": err_kpe,
         "err_swa_nope": err_swa_nope,
         "err_swa_rope": err_swa_rope,
+        "err_swa_direct": err_swa_direct,
     }
 
 
@@ -607,98 +763,109 @@ def test_fused_qk_norm_rope_group_quant_swa(T, H, D, RD, *, is_neox, q_fp8, G, G
 # argparse + matrix sweep
 # ============================================================================
 
-parser = argparse.ArgumentParser(
-    formatter_class=argparse.RawTextHelpFormatter,
-    description="aiter test for fused_qk_norm_rope_group_quant (V4, token-contiguous, no cache).",
-)
-parser.add_argument(
-    "-T",
-    "--T",
-    type=int,
-    nargs="*",
-    default=[4, 16, 64, 256, 1024, 4096, 16384],
-    help="token-count sweep. e.g. -T 4 64 1024",
-)
-parser.add_argument(
-    "--H",
-    type=int,
-    nargs="*",
-    default=[16, 128],
-    help="num-Q-heads-per-rank sweep. e.g. --H 16 128",
-)
-parser.add_argument("--D", type=int, default=512, help="head_dim (kernel MVP: 512)")
-parser.add_argument("--RD", type=int, default=64, help="rope_head_dim (RoPE tail size)")
-parser.add_argument(
-    "--G",
-    type=int,
-    nargs="*",
-    default=[32, 64],
-    choices=[32, 64],
-    help="Q quant_group_size sweep (K is always 64). e.g. --G 64",
-)
-parser.add_argument(
-    "--neox", action="store_true", help="also sweep is_neox=True (default: GPT-J only)."
-)
-parser.add_argument(
-    "--no-flydsl", action="store_true", help="skip the flydsl perf comparison."
-)
-parser.add_argument(
-    "--q-bf16", action="store_true", help="use bf16 Q (default: fp8 Q)."
-)
-parser.add_argument(
-    "--swa",
-    action="store_true",
-    help="run ONLY the fused paged-SWA write test (decode-only).",
-)
-parser.add_argument(
-    "--no-swa",
-    action="store_true",
-    help="skip the fused paged-SWA write test.",
-)
-args = parser.parse_args()
 
-if not args.no_flydsl and _FLYDSL_IMPORT_ERROR is not None:
-    aiter.logger.warning(
-        "flydsl comparison disabled: %s. Use --no-flydsl to silence this warning.",
-        _FLYDSL_IMPORT_ERROR,
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning(
+            "fused_qk_norm_rope_group_quant unsupported on %s; skipping", get_gfx()
+        )
+        return
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="aiter test for fused_qk_norm_rope_group_quant (V4, token-contiguous, no cache).",
     )
+    parser.add_argument(
+        "-T",
+        "--T",
+        type=int,
+        nargs="*",
+        default=[4, 16, 64, 256, 1024, 4096, 16384],
+        help="token-count sweep. e.g. -T 4 64 1024",
+    )
+    parser.add_argument(
+        "--H",
+        type=int,
+        nargs="*",
+        default=[16, 128],
+        help="num-Q-heads-per-rank sweep. e.g. --H 16 128",
+    )
+    parser.add_argument("--D", type=int, default=512, help="head_dim (kernel MVP: 512)")
+    parser.add_argument(
+        "--RD", type=int, default=64, help="rope_head_dim (RoPE tail size)"
+    )
+    parser.add_argument(
+        "--G",
+        type=int,
+        nargs="*",
+        default=[32, 64],
+        choices=[32, 64],
+        help="Q quant_group_size sweep (K is always 64). e.g. --G 64",
+    )
+    parser.add_argument(
+        "--neox",
+        action="store_true",
+        help="also sweep is_neox=True (default: GPT-J only).",
+    )
+    parser.add_argument(
+        "--no-flydsl", action="store_true", help="skip the flydsl perf comparison."
+    )
+    parser.add_argument(
+        "--q-bf16", action="store_true", help="use bf16 Q (default: fp8 Q)."
+    )
+    parser.add_argument(
+        "--swa",
+        action="store_true",
+        help="run ONLY the fused paged-SWA write test (decode-only).",
+    )
+    parser.add_argument(
+        "--no-swa",
+        action="store_true",
+        help="skip the fused paged-SWA write test.",
+    )
+    args = parser.parse_args()
 
-neox_modes = [False, True] if args.neox else [False]
+    if not args.no_flydsl and _FLYDSL_IMPORT_ERROR is not None:
+        aiter.logger.warning(
+            "flydsl comparison disabled: %s. Use --no-flydsl to silence this warning.",
+            _FLYDSL_IMPORT_ERROR,
+        )
 
-rows = []
-q_fp8 = not args.q_bf16
-if not args.swa:
-    for G, H, neox in itertools.product(args.G, args.H, neox_modes):
-        for T in args.T:
-            rows.append(
-                test_fused_qk_norm_rope_group_quant(
-                    T,
-                    H,
-                    args.D,
-                    args.RD,
-                    is_neox=neox,
-                    q_fp8=q_fp8,
-                    G=G,
-                    GK=64,
-                    compare_flydsl=not args.no_flydsl,
+    neox_modes = [False, True] if args.neox else [False]
+
+    rows = []
+    q_fp8 = not args.q_bf16
+    if not args.swa:
+        for G, H, neox in itertools.product(args.G, args.H, neox_modes):
+            for T in args.T:
+                rows.append(
+                    test_fused_qk_norm_rope_group_quant(
+                        T,
+                        H,
+                        args.D,
+                        args.RD,
+                        is_neox=neox,
+                        q_fp8=q_fp8,
+                        G=G,
+                        GK=64,
+                        compare_flydsl=not args.no_flydsl,
+                    )
                 )
-            )
 
-    df = pd.DataFrame(rows)
-    aiter.logger.info(
-        "fused_qk_norm_rope_group_quant (V4) summary (markdown):\n%s",
-        df.to_markdown(index=False),
-    )
+        df = pd.DataFrame(rows)
+        aiter.logger.info(
+            "fused_qk_norm_rope_group_quant (V4) summary (markdown):\n%s",
+            df.to_markdown(index=False),
+        )
 
-# --- SWA fused paged-cache write sweep (decode-only; small T to stay off the
-# fine-grained xlarge path which does not carry the SWA scatter) ---
-if args.swa or not args.no_swa:
-    # cap T to the decode/med range (<= 1024) so the coarse kernel (shared K-wave
-    # body) runs; the fine-grained xlarge path asserts out SWA by design.
-    swa_T = [t for t in args.T if t <= 1024] or [16, 64, 256]
-    swa_rows = []
-    for G, H, neox in itertools.product(args.G, args.H, neox_modes):
-        for T in swa_T:
+    # --- SWA fused paged-cache write sweep (decode-only; small T to stay off the
+    # fine-grained xlarge path which does not carry the SWA scatter) ---
+    if args.swa or not args.no_swa:
+        # cap T to the decode/med range (<= 1024) so the coarse kernel (shared K-wave
+        # body) runs; the fine-grained xlarge path asserts out SWA by design.
+        swa_T = [t for t in args.T if t <= 1024] or [16, 64, 256]
+        swa_rows = []
+        for G, H, neox, T in itertools.product(args.G, args.H, neox_modes, swa_T):
             swa_rows.append(
                 test_fused_qk_norm_rope_group_quant_swa(
                     T,
@@ -711,8 +878,12 @@ if args.swa or not args.no_swa:
                     GK=64,
                 )
             )
-    swa_df = pd.DataFrame(swa_rows)
-    aiter.logger.info(
-        "fused_qk_norm_rope_group_quant paged-SWA write summary (markdown):\n%s",
-        swa_df.to_markdown(index=False),
-    )
+        swa_df = pd.DataFrame(swa_rows)
+        aiter.logger.info(
+            "fused_qk_norm_rope_group_quant paged-SWA write summary (markdown):\n%s",
+            swa_df.to_markdown(index=False),
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

DeepSeek-V4's unified KV pool runs to ~150M rows, and several V4 paths turn a
row or block number into an address in 32 bits. Every one of these fails
silently: the wrapped offset still lands inside the same allocation, so the
kernel reads or writes the wrong row rather than faulting.

Three distinct instances, all on the V4 decode/prefill path:

1. **FlyDSL compress-attn scatter.** A buffer descriptor addresses through a
   32-bit byte offset, so one fixed base cannot reach past 4 GiB (and the
   offset itself wraps at 2 GiB). `physical_block * block_stride` was carried
   in that field. With V4's envelope layout — every layer's rows for one block
   stored together — consecutive blocks sit 708 KB apart and block 3,031 wraps;
   even the layer-major predecessor wrapped at block 65,536 for a CSA layer,
   well inside a pool that routinely holds 150,000.

2. **Compress-attn state descriptors.** `kv_state` / `score_state` carried a
   per-slot term in the same 32-bit offset. A caller whose state tensor is a
   view into a per-request arena has a slot stride of a whole arena entry, which
   alone exceeds the window.

3. **Triton sparse attention.** `slot * kv_stride_n` is an int32 product. At a
   512-element row it passes 2^31 only 2.8% into the pool.

Separately, the fused SWA write could only be addressed through a paged block
table, and that could not express ATOM's V4 window at all: the pool interleaves
each request's window rows across a shared row space by a stride that depends on
the layer's compress class. The ring it replaced (`slot*cache_size + pos%cache_size`)
could not either — `blk` grows with position, so a long context ran past
`swa_block_tables_blocks` and the write was silently skipped.

## What this does

**64-bit addressing.** Fold the block/slot term into the descriptor *base*
(64-bit pointer arithmetic, once per program) so the 32-bit offset field only
ever holds one block's worth. Applied across all scatter branches of the
CSA/HCA kernels — bf16, group_fp8 (nm-asm), mx-fp8 preshuffle/linear, fp4
packed/preshuffle — on wave64 and gfx1250, legacy and ksplit, plus the fp32 and
uint8 scale planes. `slot.to(tl.int64)` in the sparse decode and prefill Triton
kernels. (`unified_attention_sparse_mla.py` needed nothing: its stride params
are already `tl.int64`.)

Where the fp4 layouts derive the per-block byte count from compile-time shape
constants rather than the caller's stride, the wrapper now *enforces* that
assumption instead of only documenting it.

**A second SWA addressing mode.** `swa_dest_row[token]` lets the caller resolve
the destination row itself, for a window whose layout this kernel need not know.
Indexed by token, not by request: with speculation a request writes several
positions in one launch and they do not share a row. `-1` skips a token. The
host requires exactly one of `swa_block_tables` / `swa_dest_row`.

**Gate parity.** The HIP `swa_row_for_token` drops a token on four conditions;
the FlyDSL twins implemented one. Both now apply all four — `pos < 0`,
`blk >= max_blocks`, `phys < 0`, `row < num_rows` — with the destination row
clamped before it reaches the descriptor base. The block bound was previously
`stride(0)` rather than `size(1)`, which let a padded `full[:, :n]` view read a
stale column instead of skipping; the wrapper now pins `stride(0) == shape[1]`.

## Test plan

- [x] `op_tests/test_flydsl_compress_attn.py` — 204 checks, err 0%, covering
      every rebased branch (bf16 / fp8+preshuffle / group_fp8 / fp4, legacy and
      ksplit)
- [x] `op_tests/test_fused_qk_norm_rope_group_quant.py --swa` — paged and direct
      produce byte-identical pools; direct additionally drops one token via `-1`
- [x] `op_tests/test_flydsl_qk_norm_rope_quant.py` — both modes, each skip path
      covered, guard rows on both sides of the pool
- [x] Mutation-tested: neutering any of the three new gates makes the tests fail
- [x] Sparse prefill kernel checked directly against a torch reference (it only
      dispatches on non-gfx950/1250 arch, so the op-test cannot reach it here)
- [x] All runs repeated against a clean FlyDSL cache (`FLYDSL_RUNTIME_CACHE_DIR`)
- [x] `black` / `ruff check` clean
- [ ] **gfx1250 not hardware-verified** — this work was done on gfx950. The
      gfx1250 changes mirror the wave64 ones site-for-site and were checked by
      inspection only. Worth one run of `test_flydsl_compress_attn.py` on a
      gfx1250 box before merge.

## Notes for reviewers

The op-tests were also rebuilt to `.claude/skills/aiter-op-test` (`@benchmark`,
`run_perftest`, TFLOPS/TB-s, summary tables, `__main__` guard, arch allow-list).
Two test defects surfaced while doing so and are fixed here:

- correctness and perf shared one `run_perftest` call, but the scatter writes
  in place and `run_perftest` rotates args across deep copies, so the inspected
  pool and the returned tensors came from different iterations — `err` was
  intermittently non-zero
- the paged test layout self-destructed at T=128, when plain tokens allocated
  the block the out-of-window sentinel needed

One measurement caveat worth knowing: `run_perftest` sizes its arg rotation from
free memory at call time, so on a machine whose VRAM is largely held by other
processes two candidates rotate differently and their `us` columns are not
comparable — this produced a 1.4x paged-vs-direct gap that profiler device-side
timing showed to be under 4%. `num_rotate_args` is now pinned in these tests.
