### PR TITLE
[Triton] Optimize chunk_delta_attn performance.

### DIFF
--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/__init__.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/__init__.py
@@ -15,10 +15,14 @@ recompute_w_u_fwd             W/U recompute from Akk inverse.
 chunk_gate_cumsum             Fused gate (A_log/softplus/sigmoid) + chunk cumsum.
 beta_sigmoid_fwd              Elementwise sigmoid for beta gate.
 chunk_delta_attn_gate_fwd     Per-token gate without cumsum (forward only).
+flash_kda_fwd                 Two-kernel fused forward (opt-in, narrower shapes).
 """
 
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_fwd import (
     chunk_delta_attn_fwd,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.flash_kda import (
+    flash_kda_fwd,
 )
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.gate import (
     beta_sigmoid_fwd,
@@ -44,5 +48,6 @@ __all__ = [
     "chunk_delta_attn_gate_fwd",
     "chunk_gate_cumsum",
     "chunk_gla_fwd_o",
+    "flash_kda_fwd",
     "recompute_w_u_fwd",
 ]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_delta_attn_utils.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_delta_attn_utils.py
@@ -4,6 +4,7 @@
 
 """Shared utilities for chunk_delta_attn kernels."""
 
+import functools
 import inspect
 import math
 import os
@@ -48,6 +49,43 @@ def chunk_delta_attn_tuned_config(
 RCP_LN2: float = math.log2(math.e)  # 1/ln(2), for log2-space gate arithmetic
 
 
+def _same_arg(a, b) -> bool:
+    if isinstance(a, torch.Tensor) or isinstance(b, torch.Tensor):
+        return a is b
+    return type(a) is type(b) and a == b
+
+
+def _same_call(prev_args, prev_kwargs, args, kwargs) -> bool:
+    return (
+        len(args) == len(prev_args)
+        and kwargs.keys() == prev_kwargs.keys()
+        and all(_same_arg(a, b) for a, b in zip(args, prev_args, strict=True))
+        and all(_same_arg(v, prev_kwargs[k]) for k, v in kwargs.items())
+    )
+
+
+def tensor_cache(fn):
+    """Cache the single most recent result of a function taking tensors.
+
+    Tensor arguments match on identity, not contents: reading contents would
+    need the device-to-host copy this exists to avoid. A caller that rebuilds
+    an equal tensor therefore misses, which is fine for the hit that matters --
+    one ``cu_seqlens`` shared by every layer of a forward pass. Mutating a
+    cached tensor in place is not detected.
+    """
+    last: list = []
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if last and _same_call(last[0], last[1], args, kwargs):
+            return last[2]
+        result = fn(*args, **kwargs)
+        last[:] = [args, kwargs, result]
+        return result
+
+    return wrapper
+
+
 def _get_available_device() -> str:
     try:
         return triton.runtime.driver.active.get_current_target().backend
@@ -79,7 +117,6 @@ def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
         return False
 
 
-import functools
 import os
 from collections.abc import Callable
 from typing import Any

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_fwd.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_fwd.py
@@ -18,6 +18,12 @@ import torch
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     RCP_LN2,
 )
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.flash_kda import (
+    CHUNK_DELTA_ATTN_USE_FLASH_KDA,
+    FLASH_KDA_CHUNK,
+    flash_kda_fwd,
+    flash_kda_supported,
+)
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.gate import beta_sigmoid_fwd
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.gla_output import (
     chunk_gla_fwd_o,
@@ -36,6 +42,10 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.prefill.chunk_delta_h imp
     chunk_gated_delta_rule_fwd_h,
 )
 
+# What an unset `chunk_size` falls back to when the FlashKDA path cannot serve
+# the call.
+_DEFAULT_CHUNK_SIZE = 64
+
 
 def chunk_delta_attn_fwd(
     q: torch.Tensor,
@@ -48,7 +58,7 @@ def chunk_delta_attn_fwd(
     output_final_state: bool,
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
-    chunk_size: int = 64,
+    chunk_size: int | None = None,
     safe_gate: bool = False,
     lower_bound: float | None = None,
     use_gate_in_kernel: bool = False,
@@ -79,7 +89,9 @@ def chunk_delta_attn_fwd(
         output_final_state: Whether to return the final recurrent state.
         cu_seqlens:         Cumulative sequence lengths for variable-length mode.
         chunk_indices:      Pre-computed chunk index pairs (computed if None).
-        chunk_size:         Chunk size BT, either 32 or 64 (default 64).
+        chunk_size:         Chunk size BT, either 32 or 64. ``None`` lets this
+                            function choose: 32 when that lets the FlashKDA path
+                            serve the call, 64 otherwise.
         safe_gate:          Use the sub-chunk intra kernel (more stable at boundaries).
         lower_bound:        If set, use sigmoid gating; else softplus gating.
         use_gate_in_kernel: If True, fuse A_log / dt_bias into the gate cumsum.
@@ -101,6 +113,36 @@ def chunk_delta_attn_fwd(
           Akk         ``[B, T, HV, BT]``
           w, u, qg, kg or None depending on disable_recompute
     """
+    # ------------------------------------------------------------------
+    # Fast path — two-kernel FlashKDA split
+    # ------------------------------------------------------------------
+    # Returns None for every intermediate: the fused kernels never materialize
+    # g_cumsum / Aqk / Akk / w / u, so this can only serve callers that discard
+    # them, which is why `disable_recompute` gates it too.
+    #
+    # The dispatch and an unset `chunk_size` are decided together because the
+    # only reason to prefer 32 is that it is this path's entry ticket: inside
+    # the default pipeline 64 is faster at every shape measured, so resolving
+    # the two apart risks landing on the default pipeline at 32, the slowest
+    # combination of the three.
+    use_flash_kda = (
+        CHUNK_DELTA_ATTN_USE_FLASH_KDA
+        and not disable_recompute
+        and flash_kda_supported(
+            q=q,
+            v=v,
+            chunk_size=FLASH_KDA_CHUNK if chunk_size is None else chunk_size,
+            safe_gate=safe_gate,
+            use_gate_in_kernel=use_gate_in_kernel,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
+            lower_bound=lower_bound,
+            A_log=A_log,
+        )
+    )
+    if chunk_size is None:
+        chunk_size = FLASH_KDA_CHUNK if use_flash_kda else _DEFAULT_CHUNK_SIZE
+
     if chunk_size not in (32, 64):
         raise ValueError(
             f"`chunk_size` must be either 32 or 64 for chunk_delta_attn, got {chunk_size}."
@@ -108,6 +150,25 @@ def chunk_delta_attn_fwd(
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    if use_flash_kda:
+        o, final_state = flash_kda_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            lower_bound=lower_bound,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            state_v_first=state_v_first,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+        return o, final_state, None, None, None, None, None, None, None
 
     # ------------------------------------------------------------------
     # Step 0 — Optional QK L2 normalization (matches FLA API)

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
@@ -275,12 +275,17 @@ def _flash_kda_prepare_kernel(
     # flat doubling comes out 400% wrong even in fp32, 1e5 wrong in bf16, and
     # overflows fp16. Confined to BC = 16 rows the same powers peak at 2e3 and
     # the result lands within 2e-4, at an identical matmul count.
+    #
+    # input_precision is spelled out because an unannotated fp32 dot is not fp32
+    # everywhere: tl.dot resolves it to "tf32" on any target that allows it, and
+    # gfx942 then selects v_mfma_f32_32x32x4_xf32, which truncates to 19 bits
+    # without rounding. On a doubling this cancellation-prone that is 2e1 off.
     b_D = tl.where(o_i[:, None] // BC == o_i[None, :] // BC, b_L, 0.0)
     b_INV = tl.where(o_i[:, None] == o_i[None, :], 1.0, 0.0) + b_D
-    b_Dp = tl.dot(b_D, b_D)
+    b_Dp = tl.dot(b_D, b_D, input_precision="ieee")
     for _ in tl.static_range(NUM_DOUBLING):
-        b_INV = b_INV + tl.dot(b_INV, b_Dp)
-        b_Dp = tl.dot(b_Dp, b_Dp)
+        b_INV = b_INV + tl.dot(b_INV, b_Dp, input_precision="ieee")
+        b_Dp = tl.dot(b_Dp, b_Dp, input_precision="ieee")
 
     # fp32 throughout: the partial sums here are what the split keeps small, and
     # narrowing the matmuls to fp16 puts the ill-conditioned case back at 100%
@@ -292,7 +297,11 @@ def _flash_kda_prepare_kernel(
             o_i[:, None] // w != o_i[None, :] // w
         )
         b_off = tl.where(m_off, b_L, 0.0)
-        b_INV = b_INV + tl.dot(b_INV, tl.dot(b_off, b_INV))
+        b_INV = b_INV + tl.dot(
+            b_INV,
+            tl.dot(b_off, b_INV, input_precision="ieee"),
+            input_precision="ieee",
+        )
         w = 2 * w
 
     tl.store(ws_inv_mqk + cc_off, b_INV)

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
@@ -84,6 +84,12 @@ FLASH_KDA_K: int = 128
 # See the pivot comment in the prepare kernel.
 FLASH_KDA_CHUNK: int = 32
 
+# Width of the diagonal blocks the WY inverse is built from. The Neumann powers
+# used to invert them grow with the block width, so this bounds how far the
+# intermediates can run ahead of the O(1) result; 16 is also what the fla and
+# CUTLASS kernels use.
+FLASH_KDA_INV_BLOCK: int = 16
+
 
 @triton.heuristics(
     {
@@ -126,7 +132,9 @@ def _flash_kda_prepare_kernel(
     H: tl.constexpr,
     K: tl.constexpr,
     C: tl.constexpr,
+    BC: tl.constexpr,
     NUM_DOUBLING: tl.constexpr,
+    NUM_MERGE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HAS_BIAS: tl.constexpr,
 ):
@@ -194,9 +202,25 @@ def _flash_kda_prepare_kernel(
     # state, which enters the chunk at row 0, so a row whose gate has decayed past
     # fp32 range genuinely contributes nothing and flushing it to zero is correct.
     b_exp_g = exp2(b_gcum)
-    b_kd = tl.where(m_ck, b_k * b_exp_g, 0.0).to(tl.bfloat16)
-    b_qd = tl.where(m_ck, b_q * b_exp_g * scale, 0.0).to(tl.bfloat16)
-    b_kr = tl.where(m_ck, b_k * exp2(b_g_last[None, :] - b_gcum), 0.0).to(tl.bfloat16)
+
+    # Stored here rather than at the end of the kernel: these are three C x K
+    # tiles, and holding them live across the inversion below costs more
+    # registers than K1 has to spare. At H = 64 that alone decided whether the
+    # kernel fit in 256 VGPRs, i.e. whether it ran at one or two waves per SIMD.
+    #
+    # Workspace is [H, TOTAL_TILES, ...] so one sequence's chunks stay contiguous
+    # for K2's sequential walk. Tail rows are zeroed rather than left unwritten:
+    # K2 accumulates k_restored^T @ U over all C rows, so garbage there would
+    # corrupt the recurrent state, not just the masked output rows.
+    ws_idx = i_h * TOTAL_TILES + g_tile
+    ck_off = ws_idx * C * K + o_c[:, None] * K + o_k[None, :]
+    tl.store(ws_kd + ck_off, tl.where(m_ck, b_k * b_exp_g, 0.0).to(tl.bfloat16))
+    tl.store(ws_qd + ck_off, tl.where(m_ck, b_q * b_exp_g * scale, 0.0).to(tl.bfloat16))
+    tl.store(
+        ws_kr + ck_off,
+        tl.where(m_ck, b_k * exp2(b_g_last[None, :] - b_gcum), 0.0).to(tl.bfloat16),
+    )
+    tl.store(ws_gt + ws_idx * K + o_k, b_g_total)
 
     p_beta = beta_raw + (bos + t_off) * H + i_h + o_c * H
     b_beta = tl.sigmoid(tl.load(p_beta, mask=m_c, other=0.0).to(tl.float32))
@@ -230,37 +254,48 @@ def _flash_kda_prepare_kernel(
     b_L = tl.dot(b_k_piv, tl.trans(b_k_inv))
     b_L = tl.where(o_i[:, None] > o_i[None, :], -b_L * b_beta[:, None], 0.0)
 
-    b_Mqk = tl.dot(b_q_piv, tl.trans(b_k_inv))
-    b_Mqk = tl.where(o_i[:, None] >= o_i[None, :], b_Mqk, 0.0).to(tl.bfloat16)
-
-    # Invert via (I+L)(I+L^2)(I+L^4)...(I+L^(C/2)). L is strictly lower
-    # triangular, hence nilpotent with L^C = 0, so this is exact in exact
-    # arithmetic.
-    # Summing I + L + L^2 + L^4 + ... instead would silently drop L^3, L^5, L^6,
-    # and every other non-power-of-two term; that is not the inverse, and on this
-    # L it is off by the magnitude of the matrix itself.
-    b_INV = tl.where(o_i[:, None] == o_i[None, :], 1.0, 0.0) + b_L
-    b_Lp = tl.dot(b_L.to(tl.bfloat16), b_L.to(tl.bfloat16))
-    for _ in tl.static_range(NUM_DOUBLING):
-        b_INV = b_INV + tl.dot(b_INV.to(tl.bfloat16), b_Lp.to(tl.bfloat16))
-        b_Lp = tl.dot(b_Lp.to(tl.bfloat16), b_Lp.to(tl.bfloat16))
-    b_INV = b_INV.to(tl.bfloat16)
-
-    # Workspace is [H, TOTAL_TILES, ...] so one sequence's chunks stay contiguous
-    # for K2's sequential walk. Tail rows were zeroed above rather than left
-    # unwritten: K2 accumulates k_restored^T @ U over all C rows, so garbage
-    # there would corrupt the recurrent state, not just the masked output rows.
-    ws_idx = i_h * TOTAL_TILES + g_tile
-    ck_off = ws_idx * C * K + o_c[:, None] * K + o_k[None, :]
-    tl.store(ws_kd + ck_off, b_kd)
-    tl.store(ws_qd + ck_off, b_qd)
-    tl.store(ws_kr + ck_off, b_kr)
-
-    tl.store(ws_gt + ws_idx * K + o_k, b_g_total)
-
     cc_off = ws_idx * 2 * C * C + o_i[:, None] * C + o_i[None, :]
-    tl.store(ws_inv_mqk + cc_off, b_INV)
+    b_Mqk = tl.dot(b_q_piv, tl.trans(b_k_inv))
+    b_Mqk = tl.where(o_i[:, None] >= o_i[None, :], b_Mqk, 0.0)
     tl.store(ws_inv_mqk + cc_off + C * C, b_Mqk)
+
+    # Invert the BC-wide diagonal blocks via (I+D)(I+D^2)(I+D^4)...(I+D^(BC/2)),
+    # then fold the sub-diagonal blocks back in, doubling the block width each
+    # round. D is strictly lower triangular, hence nilpotent, and so is
+    # INV @ L_off at every merge level (it maps one sub-block into the one below
+    # and no further), so both halves are exact in exact arithmetic.
+    # Summing I + D + D^2 + D^4 + ... instead would silently drop D^3, D^5, D^6,
+    # and every other non-power-of-two term; that is not the inverse, and on this
+    # D it is off by the magnitude of the matrix itself.
+    #
+    # The block split is not about the answer but about the intermediates. L^k
+    # counts paths down the chunk, so across all C = 32 rows its entries reach
+    # 5e7 once the keys correlate and the gate stops damping L, while the inverse
+    # they sum to stays bounded by 1. Nothing survives that cancellation: the
+    # flat doubling comes out 400% wrong even in fp32, 1e5 wrong in bf16, and
+    # overflows fp16. Confined to BC = 16 rows the same powers peak at 2e3 and
+    # the result lands within 2e-4, at an identical matmul count.
+    b_D = tl.where(o_i[:, None] // BC == o_i[None, :] // BC, b_L, 0.0)
+    b_INV = tl.where(o_i[:, None] == o_i[None, :], 1.0, 0.0) + b_D
+    b_Dp = tl.dot(b_D, b_D)
+    for _ in tl.static_range(NUM_DOUBLING):
+        b_INV = b_INV + tl.dot(b_INV, b_Dp)
+        b_Dp = tl.dot(b_Dp, b_Dp)
+
+    # fp32 throughout: the partial sums here are what the split keeps small, and
+    # narrowing the matmuls to fp16 puts the ill-conditioned case back at 100%
+    # error. This is the parallel kernel, so the width is nearly free; only the
+    # fp16 store below is seen by K2's serial walk.
+    w = BC
+    for _ in tl.static_range(NUM_MERGE):
+        m_off = (o_i[:, None] // (2 * w) == o_i[None, :] // (2 * w)) & (
+            o_i[:, None] // w != o_i[None, :] // w
+        )
+        b_off = tl.where(m_off, b_L, 0.0)
+        b_INV = b_INV + tl.dot(b_INV, tl.dot(b_off, b_INV))
+        w = 2 * w
+
+    tl.store(ws_inv_mqk + cc_off, b_INV)
 
 
 # K2 keeps three configs even with the global autotune flag off, where the other
@@ -415,20 +450,24 @@ def _flash_kda_segment_kernel(
 
         cc = ws_idx * 2 * C * C + o_c[:, None] * C + o_c[None, :]
         b_inv = tl.load(ws_inv_mqk + cc)
-        b_U = tl.dot(b_inv, b_u.to(tl.bfloat16)).to(tl.float32)
-        b_U_bf = b_U.to(tl.bfloat16)
+        b_U = tl.dot(b_inv, b_u.to(ws_inv_mqk.dtype.element_ty))
 
         if COMPUTE_OUTPUT:
             b_mqk = tl.load(ws_inv_mqk + cc + C * C)
             b_qd1 = tl.load(ws_qd + ck + o_c[:, None] * K + o_k1[None, :])
             b_qd2 = tl.load(ws_qd + ck + o_c[:, None] * K + o_k2[None, :])
             b_o = tl.dot(b_qd1, b_h1_bf) + tl.dot(b_qd2, b_h2_bf)
-            b_o += tl.dot(b_mqk, b_U_bf)
+            b_o += tl.dot(b_mqk, b_U.to(b_mqk.dtype))
             tl.store(out + vo_off, b_o.to(out.dtype.element_ty), mask=m_cw)
 
         b_gt1 = tl.load(ws_gt + ws_idx * K + o_k1).to(tl.float32)
         b_gt2 = tl.load(ws_gt + ws_idx * K + o_k2).to(tl.float32)
 
+        # The recurrence's own matmuls stay in bf16: widening them costs about
+        # 40% of the kernel and moved no error bound measurably, since the state
+        # they feed is accumulated in fp32 either way and U already carries
+        # whatever the inverse above lost.
+        b_U_bf = b_U.to(tl.bfloat16)
         b_kr1_t = tl.load(ws_kr + ck + o_k1[:, None] + o_c[None, :] * K)
         b_kr2_t = tl.load(ws_kr + ck + o_k2[:, None] + o_c[None, :] * K)
 
@@ -701,6 +740,7 @@ def flash_kda_fwd(
     B, T, H, K = q.shape
     V = v.shape[-1]
     C = FLASH_KDA_CHUNK
+    inv_block = min(FLASH_KDA_INV_BLOCK, C)
     dev = q.device
 
     if cu_seqlens is not None:
@@ -721,9 +761,16 @@ def flash_kda_fwd(
     ws_qd = torch.empty(ws_shape, dtype=torch.bfloat16, device=dev)
     ws_kr = torch.empty(ws_shape, dtype=torch.bfloat16, device=dev)
     ws_gt = torch.empty(H * total_tiles, K, dtype=torch.float32, device=dev)
-    ws_inv_mqk = torch.empty(
-        H * total_tiles, 2 * C, C, dtype=torch.bfloat16, device=dev
-    )
+    # fp16 rather than bf16, for the mantissa and not the range: the inverse the
+    # prepare kernel writes here is bounded by 1, and K2 walks it through a
+    # recurrence as long as the sequence, so the 8 mantissa bits of bf16 are what
+    # ends up limiting the fused path. On correlated keys with a weak gate, bf16
+    # here scores 1.1e-2 against an fp32 recurrence where fp16 scores 2.3e-3,
+    # which is the difference between losing to the default pipeline and beating
+    # it by 5x. Both are two bytes, and fp32 would cost 1.3-1.5x, since this is
+    # read twice per chunk on K2's serial path. The CUTLASS FlashKDA picks fp16
+    # here for the same reason.
+    ws_inv_mqk = torch.empty(H * total_tiles, 2 * C, C, dtype=torch.float16, device=dev)
 
     _flash_kda_prepare_kernel[(total_tiles if cu_seqlens is not None else NT, B * H)](
         q=q,
@@ -747,7 +794,9 @@ def flash_kda_fwd(
         H=H,
         K=K,
         C=C,
-        NUM_DOUBLING=C.bit_length() - 2,
+        BC=inv_block,
+        NUM_DOUBLING=inv_block.bit_length() - 2,
+        NUM_MERGE=(C // inv_block).bit_length() - 1,
     )
 
     if cu_seqlens is not None:

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
@@ -1,0 +1,868 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# Adapted from flash-linear-attention: Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""
+Two-kernel fused KDA forward, following the FlashKDA kernel split.
+
+The default ``chunk_delta_attn_fwd`` pipeline runs five kernels (l2norm, beta
+sigmoid, gate cumsum, intra, delta_h, gla_o) and materializes ``g_cumsum``,
+``Aqk``, ``Akk``, ``w``, ``u`` and ``h`` in HBM between them. This path collapses
+the same math into two:
+
+  K1 (``_flash_kda_prepare_kernel``), token-parallel over chunks:
+      q/k L2 norm, gate activation + chunk cumsum, beta sigmoid, the decayed
+      q/k tiles, the per-chunk gate total, ``Mqk``, and the triangular inverse
+      ``(I - L)^-1``. Everything lands in a per-chunk workspace.
+
+  K2 (``_flash_kda_segment_kernel``), sequential over chunks within one
+      segment: the delta-rule recurrence and the output projection, reading
+      only the K1 workspace plus ``v``/``beta``.
+
+The recurrent state stays in registers across the whole segment in K2, which is
+the point of the split: the baseline writes ``h`` for every chunk to HBM and
+reads it back in the output kernel.
+
+A segment defaults to the whole sequence. When that leaves the device idle --
+K2's block count is only ``n_segments * H * (V / BW)``, so a 12-head model gets
+96 blocks against 256 CUs -- the sequence is instead cut into fixed-length
+segments that run concurrently. Each segment's state update is affine in its
+incoming state, ``h' = A_seg h + b_seg``, and both parts are produced by this
+same kernel: seeding it with ``h = 0`` gives ``b_seg``, and seeding it with
+``h = I`` and ``v = 0`` propagates a basis whose result is ``A_seg``, avoiding
+any explicit per-chunk operator product. A short scan (``n_segments`` steps
+instead of ``n_chunks``) then recovers each segment's true incoming state, and a
+final pass re-runs the segments to write outputs.
+
+Restrictions (the caller is expected to check these and fall back):
+    * ``K == V == 128`` and ``HV == H`` (no GVA).
+    * ``chunk_size == 32`` (see ``FLASH_KDA_CHUNK``).
+    * The fused-gate sigmoid path only, i.e. ``use_gate_in_kernel`` with
+      ``lower_bound`` set, plus in-kernel qk l2norm and beta sigmoid.
+    * ``safe_gate``. K1 bounds the intra-chunk decay with a midpoint pivot
+      rather than the sub-chunk pivot ``safe_gate`` selects in the default
+      intra kernel, so it answers that request by a different route and has no
+      unpivoted mode to offer a caller who declined it.
+    * Forward only, and no intermediates for a backward pass.
+"""
+
+import functools
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
+    CHUNK_DELTA_ATTN_TRITON_AUTOTUNE,
+    autotune_cache_kwargs,
+    chunk_delta_attn_autotune_configs,
+    exp,
+    exp2,
+    input_guard,
+    tensor_cache,
+)
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
+    prepare_chunk_indices,
+)
+
+# On by default. `flash_kda_supported` decides per call and anything outside the
+# restrictions above keeps the default pipeline, so this switch only exists to
+# force that pipeline anyway -- to A/B the two, or to back out if the fused path
+# regresses on a shape the admission check still accepts.
+CHUNK_DELTA_ATTN_USE_FLASH_KDA: bool = os.getenv(
+    "CHUNK_DELTA_ATTN_USE_FLASH_KDA", "1"
+).lower() in ("1", "true", "yes", "on")
+
+# The K-dimension is consumed as two 64-wide halves so the recurrent state fits
+# a pair of [64, BW] register tiles in K2. Relaxing this means reworking K2's
+# state blocking, not just the loop bound.
+FLASH_KDA_K: int = 128
+# C = 32, not 64. The intra-chunk decay factors are re-centered on the chunk
+# midpoint, which keeps them in fp32 for a span of about +-70 log2 units; the
+# Kimi gate spends roughly 3.6 of those per token, so 32 rows fit and 64 do not.
+# See the pivot comment in the prepare kernel.
+FLASH_KDA_CHUNK: int = 32
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
+    }
+)
+@triton.autotune(
+    configs=chunk_delta_attn_autotune_configs(
+        [
+            triton.Config({}, num_warps=nw, num_stages=ns)
+            for nw in [2, 4]
+            for ns in [1, 2]
+        ],
+        default_config=triton.Config({}, num_warps=2, num_stages=1),
+    ),
+    key=["H", "K", "C"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def _flash_kda_prepare_kernel(
+    q,
+    k,
+    g_raw,
+    beta_raw,
+    A_log,
+    dt_bias,
+    ws_kd,
+    ws_qd,
+    ws_kr,
+    ws_gt,
+    ws_inv_mqk,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    lower_bound,
+    T,
+    NT,
+    TOTAL_TILES,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    C: tl.constexpr,
+    NUM_DOUBLING: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    """Per-chunk prepare: decayed q/k, gate total, Mqk, and (I - L)^-1."""
+    i_t = tl.program_id(0).to(tl.int64)
+    i_bh = tl.program_id(1).to(tl.int64)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        # program_id(0) is already the global chunk index; chunk_indices maps it
+        # to (sequence, chunk-within-sequence).
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int64)
+        i_tl = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T_seq = eos - bos
+        g_tile = i_t
+    else:
+        i_tl = i_t
+        bos = i_b * T
+        T_seq = T
+        g_tile = i_b * NT + i_t
+
+    t_off = i_tl * C
+    if t_off >= T_seq:
+        return
+    actual_len = tl.minimum(C, T_seq - t_off)
+
+    o_c = tl.arange(0, C)
+    o_k = tl.arange(0, K)
+    m_c = o_c < actual_len
+    m_ck = m_c[:, None]
+
+    base = (bos + t_off) * H + i_h
+    qk_off = base * K + o_c[:, None] * (H * K) + o_k[None, :]
+
+    b_q = tl.load(q + qk_off, mask=m_ck, other=0.0).to(tl.float32)
+    b_k = tl.load(k + qk_off, mask=m_ck, other=0.0).to(tl.float32)
+
+    # L2 normalize rows, matching l2norm_fwd's eps placement.
+    b_q = b_q * (1.0 / tl.sqrt(tl.sum(b_q * b_q, axis=1) + 1e-6))[:, None]
+    b_k = b_k * (1.0 / tl.sqrt(tl.sum(b_k * b_k, axis=1) + 1e-6))[:, None]
+
+    # Gate: lower_bound * sigmoid(exp(A_log) * (g + dt_bias)), then chunk-local
+    # cumsum into log2 space. Same expression as chunk_gate_cumsum so the two
+    # paths agree bit-for-bit on the gate.
+    b_g = tl.load(g_raw + qk_off, mask=m_ck, other=0.0).to(tl.float32)
+    if HAS_BIAS:
+        b_g = b_g + tl.load(dt_bias + i_h * K + o_k).to(tl.float32)[None, :]
+    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_g)
+    LOG2_E: tl.constexpr = 1.4426950408889634
+    b_gcum = tl.cumsum(b_gate, axis=0) * LOG2_E
+    b_gcum = tl.where(m_ck, b_gcum, 0.0)
+
+    # gcum is non-positive and monotonically decreasing down the chunk, so every
+    # exponent below is <= 0 and exp2 cannot overflow. gcum itself reaches about
+    # -460 at C=64 with lower_bound=-5, which is why nothing here forms
+    # exp2(-gcum) unclamped.
+    last_row = actual_len - 1
+    b_g_last = tl.sum(tl.where(o_c[:, None] == last_row, b_gcum, 0.0), axis=0)
+    b_g_total = exp2(b_g_last)
+
+    # Decay measured from the chunk start. These only ever multiply the recurrent
+    # state, which enters the chunk at row 0, so a row whose gate has decayed past
+    # fp32 range genuinely contributes nothing and flushing it to zero is correct.
+    b_exp_g = exp2(b_gcum)
+    b_kd = tl.where(m_ck, b_k * b_exp_g, 0.0).to(tl.bfloat16)
+    b_qd = tl.where(m_ck, b_q * b_exp_g * scale, 0.0).to(tl.bfloat16)
+    b_kr = tl.where(m_ck, b_k * exp2(b_g_last[None, :] - b_gcum), 0.0).to(tl.bfloat16)
+
+    p_beta = beta_raw + (bos + t_off) * H + i_h + o_c * H
+    b_beta = tl.sigmoid(tl.load(p_beta, mask=m_c, other=0.0).to(tl.float32))
+
+    # The intra-chunk matrices need decay *differences* between two rows of the
+    # same chunk. Those are O(1) near the diagonal even when each row's decay from
+    # the chunk start is not, so they cannot be factored as
+    # exp2(gcum[i]) * exp2(-gcum[j]): with the Kimi gate the cumsum drops about
+    # 3.6 log2 units per token, so one factor underflows while the other overflows
+    # and the product that should have been O(1) collapses. Re-centering on the
+    # chunk midpoint halves the span each factor has to cover, which keeps both
+    # inside fp32 for C <= 32. C = 64 spans ~280 log2 units and needs a per
+    # sub-chunk pivot instead, as the default intra kernel uses.
+    o_mid = tl.minimum(C // 2, actual_len - 1)
+    b_gp = tl.sum(tl.where(o_c[:, None] == o_mid, b_gcum, 0.0), axis=0)
+    b_gm = b_gcum - b_gp[None, :]
+    b_dec = exp2(b_gm)
+    b_inc = exp2(-b_gm)
+    b_k_piv = tl.where(m_ck, b_k * b_dec, 0.0).to(tl.bfloat16)
+    b_q_piv = tl.where(m_ck, b_q * b_dec * scale, 0.0).to(tl.bfloat16)
+    b_k_inv = tl.where(m_ck, b_k * b_inc, 0.0).to(tl.bfloat16)
+
+    # The WY form needs (I + tril(diag(beta) K K^T, -1))^-1. L is negated here so
+    # the doubling below can be written as the plain Neumann series in L; folding
+    # the sign in anywhere later would need alternating signs per term.
+    # Getting this wrong is nearly invisible at the Kimi default lower_bound=-5:
+    # the decay damps L to almost nothing, so (I + L)^-1 and (I - L)^-1 agree to
+    # well inside bf16. It only shows up as the gate weakens, which is what the
+    # lower_bound sweep in the tests is guarding.
+    o_i = tl.arange(0, C)
+    b_L = tl.dot(b_k_piv, tl.trans(b_k_inv))
+    b_L = tl.where(o_i[:, None] > o_i[None, :], -b_L * b_beta[:, None], 0.0)
+
+    b_Mqk = tl.dot(b_q_piv, tl.trans(b_k_inv))
+    b_Mqk = tl.where(o_i[:, None] >= o_i[None, :], b_Mqk, 0.0).to(tl.bfloat16)
+
+    # Invert via (I+L)(I+L^2)(I+L^4)...(I+L^(C/2)). L is strictly lower
+    # triangular, hence nilpotent with L^C = 0, so this is exact in exact
+    # arithmetic.
+    # Summing I + L + L^2 + L^4 + ... instead would silently drop L^3, L^5, L^6,
+    # and every other non-power-of-two term; that is not the inverse, and on this
+    # L it is off by the magnitude of the matrix itself.
+    b_INV = tl.where(o_i[:, None] == o_i[None, :], 1.0, 0.0) + b_L
+    b_Lp = tl.dot(b_L.to(tl.bfloat16), b_L.to(tl.bfloat16))
+    for _ in tl.static_range(NUM_DOUBLING):
+        b_INV = b_INV + tl.dot(b_INV.to(tl.bfloat16), b_Lp.to(tl.bfloat16))
+        b_Lp = tl.dot(b_Lp.to(tl.bfloat16), b_Lp.to(tl.bfloat16))
+    b_INV = b_INV.to(tl.bfloat16)
+
+    # Workspace is [H, TOTAL_TILES, ...] so one sequence's chunks stay contiguous
+    # for K2's sequential walk. Tail rows were zeroed above rather than left
+    # unwritten: K2 accumulates k_restored^T @ U over all C rows, so garbage
+    # there would corrupt the recurrent state, not just the masked output rows.
+    ws_idx = i_h * TOTAL_TILES + g_tile
+    ck_off = ws_idx * C * K + o_c[:, None] * K + o_k[None, :]
+    tl.store(ws_kd + ck_off, b_kd)
+    tl.store(ws_qd + ck_off, b_qd)
+    tl.store(ws_kr + ck_off, b_kr)
+
+    tl.store(ws_gt + ws_idx * K + o_k, b_g_total)
+
+    cc_off = ws_idx * 2 * C * C + o_i[:, None] * C + o_i[None, :]
+    tl.store(ws_inv_mqk + cc_off, b_INV)
+    tl.store(ws_inv_mqk + cc_off + C * C, b_Mqk)
+
+
+# K2 keeps three configs even with the global autotune flag off, where the other
+# kernels here fall back to one. Its parallelism is only num_segments * H *
+# (W / BW), so the best BW swings with head count: a pinned BW=32 costs ~1.4x at
+# H=16 and turns the path into a regression against the default pipeline. Three
+# configs is a cheap first-call sweep, and the result is cached.
+_K2_CONFIGS: list = (
+    [
+        triton.Config({"BW": BW}, num_warps=nw, num_stages=ns)
+        for BW in [16, 32, 64]
+        for nw in [2, 4]
+        for ns in [1, 2]
+    ]
+    if CHUNK_DELTA_ATTN_TRITON_AUTOTUNE
+    else [
+        triton.Config({"BW": 16}, num_warps=2, num_stages=2),
+        triton.Config({"BW": 32}, num_warps=2, num_stages=2),
+        triton.Config({"BW": 64}, num_warps=4, num_stages=2),
+    ]
+)
+
+
+def _seg_occupancy_class(num_segs: int) -> int:
+    """Bucket of ``num_segs`` for K2's autotune key.
+
+    The grid is ``cdiv(W, BW) * num_segs * H``, so the best BW moves with the
+    segment count: one segment per sequence leaves BW=64 with a quarter of the
+    blocks BW=16 gets, and picking 64 there costs 2.3x. Keying on the exact
+    count would re-tune per batch, and a power-of-two bucket already separates
+    the schedules that differ.
+    """
+    return max(1, num_segs).bit_length()
+
+
+@triton.autotune(
+    configs=_K2_CONFIGS,
+    # HAS_V / COMPUTE_OUTPUT are in the key because the three passes below have
+    # very different per-iteration cost and must not share a tuned config, and
+    # NUM_SEGS_CLASS is there for the same reason -- without it the segmented
+    # and unsegmented schedules collide and whichever runs first sets the
+    # config for both, a result the on-disk cache then keeps.
+    key=["H", "K", "W", "C", "HAS_V", "COMPUTE_OUTPUT", "NUM_SEGS_CLASS"],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def _flash_kda_segment_kernel(
+    ws_kd,
+    ws_qd,
+    ws_kr,
+    ws_gt,
+    ws_inv_mqk,
+    v_input,
+    beta_raw,
+    out,
+    h_in,
+    h_out,
+    final_state,
+    seg_chunk_base,
+    seg_nchunks,
+    seg_tok_base,
+    seg_tok_end,
+    seg_seq,
+    seg_is_last,
+    TOTAL_TILES,
+    NUM_SEGS_CLASS,  # tuning discriminator only; see _seg_occupancy_class
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    W: tl.constexpr,
+    C: tl.constexpr,
+    BW: tl.constexpr,
+    INIT_IDENTITY: tl.constexpr,
+    HAS_H_IN: tl.constexpr,
+    HAS_V: tl.constexpr,
+    COMPUTE_OUTPUT: tl.constexpr,
+    STORE_H_OUT: tl.constexpr,
+    STORE_FINAL: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    """Delta-rule recurrence over one segment of chunks.
+
+    The state update is affine in the incoming state, ``h' = A_seg h + b_seg``,
+    so the same kernel serves all three passes of the segmented (context
+    parallel) schedule by varying only how it is seeded and what it stores:
+
+      * ``h=0``, real ``v``            -> ``b_seg``   (the affine part)
+      * ``h=I``, ``v=0`` (``W = K``)   -> ``A_seg``   (the linear part, one
+        column block per program, so the operator is obtained by propagating a
+        basis rather than by multiplying out per-chunk operators)
+      * ``h=h_in`` from the scan, real ``v``, ``COMPUTE_OUTPUT`` -> the output
+
+    With one segment per sequence this degenerates to a plain sequential scan
+    and only the third form runs.
+    """
+    i_w = tl.program_id(0).to(tl.int64)
+    i_sh = tl.program_id(1).to(tl.int64)
+    i_seg, i_h = i_sh // H, i_sh % H
+
+    chunk_base = tl.load(seg_chunk_base + i_seg).to(tl.int64)
+    n_chunks = tl.load(seg_nchunks + i_seg)
+    tok_base = tl.load(seg_tok_base + i_seg).to(tl.int64)
+    tok_end = tl.load(seg_tok_end + i_seg).to(tl.int64)
+
+    o_c = tl.arange(0, C)
+    o_k1 = tl.arange(0, 64)
+    o_k2 = 64 + tl.arange(0, 64)
+    o_w = i_w * BW + tl.arange(0, BW)
+    m_w = o_w < W
+
+    # The state is [K, W]; K is split into two 64-row halves so each tile is a
+    # [64, BW] fp32 register block.
+    if INIT_IDENTITY:
+        b_h1 = tl.where(o_k1[:, None] == o_w[None, :], 1.0, 0.0)
+        b_h2 = tl.where(o_k2[:, None] == o_w[None, :], 1.0, 0.0)
+    elif HAS_H_IN:
+        s_off = (i_seg * H + i_h) * K * W + o_w[None, :]
+        b_h1 = tl.load(h_in + s_off + o_k1[:, None] * W, mask=m_w[None, :], other=0.0)
+        b_h2 = tl.load(h_in + s_off + o_k2[:, None] * W, mask=m_w[None, :], other=0.0)
+        b_h1 = b_h1.to(tl.float32)
+        b_h2 = b_h2.to(tl.float32)
+    else:
+        b_h1 = tl.zeros([64, BW], dtype=tl.float32)
+        b_h2 = tl.zeros([64, BW], dtype=tl.float32)
+
+    for j in range(n_chunks):
+        ws_idx = i_h * TOTAL_TILES + chunk_base + j
+        ck = ws_idx * C * K
+        t0 = tok_base + j * C
+        m_c = (t0 + o_c) < tok_end
+        m_cw = m_c[:, None] & m_w[None, :]
+
+        b_h1_bf = b_h1.to(tl.bfloat16)
+        b_h2_bf = b_h2.to(tl.bfloat16)
+
+        b_kd1 = tl.load(ws_kd + ck + o_c[:, None] * K + o_k1[None, :])
+        b_kd2 = tl.load(ws_kd + ck + o_c[:, None] * K + o_k2[None, :])
+        b_tmp = tl.dot(b_kd1, b_h1_bf) + tl.dot(b_kd2, b_h2_bf)
+
+        vo_off = t0 * H * V + i_h * V + o_c[:, None] * (H * V) + o_w[None, :]
+        if HAS_V:
+            b_v = tl.load(v_input + vo_off, mask=m_cw, other=0.0).to(tl.float32)
+        else:
+            b_v = tl.zeros([C, BW], dtype=tl.float32)
+
+        p_beta = beta_raw + t0 * H + i_h + o_c * H
+        b_beta = tl.sigmoid(tl.load(p_beta, mask=m_c, other=0.0).to(tl.float32))
+
+        # Tail rows must stay zero: U feeds the state update, which sums over all
+        # C rows regardless of how many are real.
+        b_u = tl.where(m_c[:, None], (b_v - b_tmp) * b_beta[:, None], 0.0)
+
+        cc = ws_idx * 2 * C * C + o_c[:, None] * C + o_c[None, :]
+        b_inv = tl.load(ws_inv_mqk + cc)
+        b_U = tl.dot(b_inv, b_u.to(tl.bfloat16)).to(tl.float32)
+        b_U_bf = b_U.to(tl.bfloat16)
+
+        if COMPUTE_OUTPUT:
+            b_mqk = tl.load(ws_inv_mqk + cc + C * C)
+            b_qd1 = tl.load(ws_qd + ck + o_c[:, None] * K + o_k1[None, :])
+            b_qd2 = tl.load(ws_qd + ck + o_c[:, None] * K + o_k2[None, :])
+            b_o = tl.dot(b_qd1, b_h1_bf) + tl.dot(b_qd2, b_h2_bf)
+            b_o += tl.dot(b_mqk, b_U_bf)
+            tl.store(out + vo_off, b_o.to(out.dtype.element_ty), mask=m_cw)
+
+        b_gt1 = tl.load(ws_gt + ws_idx * K + o_k1).to(tl.float32)
+        b_gt2 = tl.load(ws_gt + ws_idx * K + o_k2).to(tl.float32)
+
+        b_kr1_t = tl.load(ws_kr + ck + o_k1[:, None] + o_c[None, :] * K)
+        b_kr2_t = tl.load(ws_kr + ck + o_k2[:, None] + o_c[None, :] * K)
+
+        b_h1 = b_h1 * b_gt1[:, None] + tl.dot(b_kr1_t, b_U_bf).to(tl.float32)
+        b_h2 = b_h2 * b_gt2[:, None] + tl.dot(b_kr2_t, b_U_bf).to(tl.float32)
+
+    if STORE_H_OUT:
+        s_off = (i_seg * H + i_h) * K * W + o_w[None, :]
+        e_ty = h_out.dtype.element_ty
+        tl.store(h_out + s_off + o_k1[:, None] * W, b_h1.to(e_ty), mask=m_w[None, :])
+        tl.store(h_out + s_off + o_k2[:, None] * W, b_h2.to(e_ty), mask=m_w[None, :])
+
+    # Not merged into one condition: the outer test is a constexpr, and when it
+    # is false final_state is a null pointer and seg_is_last must not be read.
+    if STORE_FINAL:  # noqa: SIM102
+        if tl.load(seg_is_last + i_seg) == 1:
+            i_n = tl.load(seg_seq + i_seg).to(tl.int64)
+            if STATE_V_FIRST:
+                f_off = (i_n * H + i_h) * V * K + o_w[None, :] * K
+                tl.store(final_state + f_off + o_k1[:, None], b_h1, mask=m_w[None, :])
+                tl.store(final_state + f_off + o_k2[:, None], b_h2, mask=m_w[None, :])
+            else:
+                f_off = (i_n * H + i_h) * K * V + o_w[None, :]
+                tl.store(
+                    final_state + f_off + o_k1[:, None] * V, b_h1, mask=m_w[None, :]
+                )
+                tl.store(
+                    final_state + f_off + o_k2[:, None] * V, b_h2, mask=m_w[None, :]
+                )
+
+
+@triton.heuristics({"HAS_H0": lambda args: args["h0"] is not None})
+@triton.jit
+def _flash_kda_seg_scan_kernel(
+    A_seg,
+    b_seg,
+    h_in,
+    h0,
+    seq_seg_off,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BV: tl.constexpr,
+    HAS_H0: tl.constexpr,
+):
+    """Serial scan across a sequence's segments: ``h <- A_seg h + b_seg``.
+
+    Only runs once per segment rather than once per chunk, so its serial depth
+    is the segment count (single digits) instead of the chunk count.
+    """
+    i_v = tl.program_id(0).to(tl.int64)
+    i_nh = tl.program_id(1).to(tl.int64)
+    i_n, i_h = i_nh // H, i_nh % H
+
+    s0 = tl.load(seq_seg_off + i_n).to(tl.int64)
+    s1 = tl.load(seq_seg_off + i_n + 1).to(tl.int64)
+
+    o_k1 = tl.arange(0, 64)
+    o_k2 = 64 + tl.arange(0, 64)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_v = o_v < V
+
+    if HAS_H0:
+        base = (i_n * H + i_h) * K * V + o_v[None, :]
+        b_h1 = tl.load(h0 + base + o_k1[:, None] * V, mask=m_v[None, :], other=0.0)
+        b_h2 = tl.load(h0 + base + o_k2[:, None] * V, mask=m_v[None, :], other=0.0)
+    else:
+        b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+        b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+
+    for s in range(s0, s1):
+        hb = (s * H + i_h) * K * V + o_v[None, :]
+        tl.store(h_in + hb + o_k1[:, None] * V, b_h1, mask=m_v[None, :])
+        tl.store(h_in + hb + o_k2[:, None] * V, b_h2, mask=m_v[None, :])
+
+        # A_seg is stored bf16: the dots below consume it as bf16 anyway, and at
+        # this block count the scan is bound by how fast it can pull the
+        # operator in, not by arithmetic.
+        ab = (s * H + i_h) * K * K
+        b_A11 = tl.load(A_seg + ab + o_k1[:, None] * K + o_k1[None, :])
+        b_A12 = tl.load(A_seg + ab + o_k1[:, None] * K + o_k2[None, :])
+        b_A21 = tl.load(A_seg + ab + o_k2[:, None] * K + o_k1[None, :])
+        b_A22 = tl.load(A_seg + ab + o_k2[:, None] * K + o_k2[None, :])
+
+        b_h1_bf = b_h1.to(tl.bfloat16)
+        b_h2_bf = b_h2.to(tl.bfloat16)
+        b_n1 = tl.dot(b_A11, b_h1_bf) + tl.dot(b_A12, b_h2_bf)
+        b_n2 = tl.dot(b_A21, b_h1_bf) + tl.dot(b_A22, b_h2_bf)
+
+        b_h1 = b_n1 + tl.load(
+            b_seg + hb + o_k1[:, None] * V, mask=m_v[None, :], other=0.0
+        )
+        b_h2 = b_n2 + tl.load(
+            b_seg + hb + o_k2[:, None] * V, mask=m_v[None, :], other=0.0
+        )
+
+
+def flash_kda_supported(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    chunk_size: int,
+    safe_gate: bool,
+    use_gate_in_kernel: bool,
+    use_qk_l2norm_in_kernel: bool,
+    use_beta_sigmoid_in_kernel: bool,
+    lower_bound: float | None,
+    A_log: torch.Tensor | None,
+) -> bool:
+    """Whether ``flash_kda_fwd`` can serve this call (see the module docstring)."""
+    K = q.shape[-1]
+    HV, V = v.shape[2], v.shape[-1]
+    return (
+        chunk_size == FLASH_KDA_CHUNK
+        and safe_gate
+        and K == FLASH_KDA_K
+        and V == FLASH_KDA_K
+        and HV == q.shape[2]
+        and q.dtype == torch.bfloat16
+        and v.dtype == torch.bfloat16
+        and use_gate_in_kernel
+        and use_qk_l2norm_in_kernel
+        and use_beta_sigmoid_in_kernel
+        and lower_bound is not None
+        and A_log is not None
+    )
+
+
+@functools.cache
+def _num_cus(device_index: int = 0) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+_SEG_TARGET_COUNT = 16
+_SEG_MAX_CHUNKS = 64
+_SEG_MIN_DEPTH = 256
+
+
+def _choose_chunks_per_seg(n_chunks_max: int, n_seqs: int, H: int, V: int) -> int:
+    """Segment length in chunks, or ``n_chunks_max`` to disable segmentation.
+
+    The recurrence kernel gets ``n_segments * H * (V / BW)`` blocks, so with one
+    segment per sequence a low head count leaves most of the device idle: at
+    H=12, V=128 that is 48 blocks against 256 CUs. Segmenting costs two extra
+    passes over the workspace, so it only pays when both of the following hold.
+    """
+    override = os.getenv("CHUNK_DELTA_ATTN_FLASH_KDA_SEG", "").strip()
+    if override:
+        val = int(override)
+        return n_chunks_max if val <= 0 else val
+    # There has to be idle capacity to absorb the extra passes. The measured
+    # crossover on MI355 (256 CUs) is at about half the CUs busy; BW=32 is the
+    # config the tuner usually lands on.
+    if 2 * n_seqs * H * max(1, V // 32) >= _num_cus():
+        return n_chunks_max
+    # And the sequence has to be deep enough to be worth cutting. Below a few
+    # hundred chunks the extra launches and the scan dominate: at 64 chunks the
+    # segmented path costs 197us against 113us for a plain scan.
+    if n_chunks_max < _SEG_MIN_DEPTH:
+        return n_chunks_max
+    # What matters is the segment count, not the length, so scale the length
+    # with the sequence. Past ~64 chunks a segment is long enough that its own
+    # serial depth starts to show, so keep splitting instead.
+    return min(_SEG_MAX_CHUNKS, n_chunks_max // _SEG_TARGET_COUNT)
+
+
+@tensor_cache
+def _seq_bounds(cu_seqlens: torch.Tensor) -> tuple[tuple[int, int], ...]:
+    """``(bos, eos)`` per sequence.
+
+    Cached because reading it is a device-to-host copy issued after the prepare
+    kernel has been queued, so an uncached call stalls the host on that kernel
+    on every invocation rather than only on the first.
+    """
+    bounds = cu_seqlens.tolist()
+    return tuple((bounds[i], bounds[i + 1]) for i in range(len(bounds) - 1))
+
+
+@functools.lru_cache(maxsize=64)
+def _build_segments(
+    seqs: tuple[tuple[int, int], ...],
+    C: int,
+    chunks_per_seg: int,
+    device: torch.device,
+):
+    """Descriptors for the segmented recurrence.
+
+    Returns ``(desc, seq_seg_off, num_segs, max_segs_per_seq)`` where ``desc`` is
+    a ``[6, num_segs]`` int32 tensor holding, per segment: the global chunk index
+    it starts at (indexing the K1 workspace), its chunk count, its first and
+    one-past-last token, its sequence, and whether it ends that sequence.
+
+    Cached on the sequence bounds: building these costs a Python loop and a host
+    to device copy, which at this kernel's runtime is not noise, and a serving
+    loop repeats the same shapes.
+    """
+    chunk_base, nchunks, tok_base, tok_end, seq_id, is_last = [], [], [], [], [], []
+    seq_seg_off = [0]
+    g_chunk = 0
+    for i, (bos, eos) in enumerate(seqs):
+        nch = triton.cdiv(eos - bos, C)
+        nseg = max(1, triton.cdiv(nch, chunks_per_seg))
+        for s in range(nseg):
+            c0 = s * chunks_per_seg
+            m = min(chunks_per_seg, nch - c0)
+            chunk_base.append(g_chunk + c0)
+            nchunks.append(m)
+            tok_base.append(bos + c0 * C)
+            tok_end.append(min(bos + (c0 + m) * C, eos))
+            seq_id.append(i)
+            is_last.append(1 if s == nseg - 1 else 0)
+        seq_seg_off.append(len(chunk_base))
+        g_chunk += nch
+
+    desc = torch.tensor(
+        [chunk_base, nchunks, tok_base, tok_end, seq_id, is_last],
+        dtype=torch.int32,
+        device=device,
+    )
+    off = torch.tensor(seq_seg_off, dtype=torch.int32, device=device)
+    max_per_seq = max(
+        seq_seg_off[i + 1] - seq_seg_off[i] for i in range(len(seq_seg_off) - 1)
+    )
+    return desc, off, len(chunk_base), max_per_seq
+
+
+@input_guard
+def flash_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    scale: float,
+    lower_bound: float,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    state_v_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunks_per_seg: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """
+    Two-kernel KDA forward, with an optional segmented (context parallel) scan.
+
+    Args:
+        q, k:               ``[B, T, H, 128]`` bf16.
+        v:                  ``[B, T, H, 128]`` bf16.
+        g:                  Raw gate ``[B, T, H, 128]``; activation and cumsum
+                            happen in K1.
+        beta:               Raw beta logits ``[B, T, H]``; sigmoid in-kernel.
+        A_log:              ``[H]`` fp32.
+        dt_bias:            ``[H * 128]`` fp32 or None.
+        scale:              Attention scale, folded into the decayed q.
+        lower_bound:        Gate lower bound (Kimi uses -5.0).
+        initial_state:      ``[N, H, K, V]`` fp32, or ``[N, H, V, K]`` when
+                            ``state_v_first``. None starts from zero.
+        output_final_state: Allocate and return the final state.
+        state_v_first:      V-first state layout.
+        cu_seqlens:         ``[N + 1]`` for varlen; ``B`` must be 1.
+        chunk_indices:      Output of ``prepare_chunk_indices``; computed here
+                            when omitted.
+        chunks_per_seg:     Segment length for the parallel scan. None picks a
+                            value from the head count; <= 0 disables it.
+
+    Returns:
+        ``(o, final_state)`` with ``o`` shaped like ``v``.
+    """
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    C = FLASH_KDA_CHUNK
+    dev = q.device
+
+    if cu_seqlens is not None:
+        if B != 1:
+            raise ValueError(f"Varlen mode requires B=1, got {B}.")
+        if chunk_indices is None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, C)
+        N = cu_seqlens.numel() - 1
+        NT = 0
+        total_tiles = chunk_indices.shape[0]
+    else:
+        N = B
+        NT = triton.cdiv(T, C)
+        total_tiles = B * NT
+
+    ws_shape = (H * total_tiles, C, K)
+    ws_kd = torch.empty(ws_shape, dtype=torch.bfloat16, device=dev)
+    ws_qd = torch.empty(ws_shape, dtype=torch.bfloat16, device=dev)
+    ws_kr = torch.empty(ws_shape, dtype=torch.bfloat16, device=dev)
+    ws_gt = torch.empty(H * total_tiles, K, dtype=torch.float32, device=dev)
+    ws_inv_mqk = torch.empty(
+        H * total_tiles, 2 * C, C, dtype=torch.bfloat16, device=dev
+    )
+
+    _flash_kda_prepare_kernel[(total_tiles if cu_seqlens is not None else NT, B * H)](
+        q=q,
+        k=k,
+        g_raw=g,
+        beta_raw=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        ws_kd=ws_kd,
+        ws_qd=ws_qd,
+        ws_kr=ws_kr,
+        ws_gt=ws_gt,
+        ws_inv_mqk=ws_inv_mqk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        lower_bound=lower_bound,
+        T=T,
+        NT=NT,
+        TOTAL_TILES=total_tiles,
+        H=H,
+        K=K,
+        C=C,
+        NUM_DOUBLING=C.bit_length() - 2,
+    )
+
+    if cu_seqlens is not None:
+        seqs = _seq_bounds(cu_seqlens)
+    else:
+        seqs = tuple((b * T, b * T + T) for b in range(B))
+
+    # Longest sequence in chunks: segmentation is judged per sequence, and
+    # passing it as the segment length is what disables segmentation.
+    n_chunks_max = max(triton.cdiv(eos - bos, C) for bos, eos in seqs)
+    if chunks_per_seg is None:
+        chunks_per_seg = _choose_chunks_per_seg(n_chunks_max, N, H, V)
+    elif chunks_per_seg <= 0:
+        chunks_per_seg = n_chunks_max
+    desc, seq_seg_off, num_segs, max_segs = _build_segments(
+        seqs, C, chunks_per_seg, dev
+    )
+    seg_chunk_base, seg_nchunks, seg_tok_base, seg_tok_end, seg_seq, seg_is_last = desc
+
+    # The kernel indexes h_in by segment, so normalize a V-first initial state
+    # once here instead of carrying the layout through three passes.
+    h0 = initial_state
+    if h0 is not None:
+        if state_v_first:
+            h0 = h0.transpose(-1, -2)
+        h0 = h0.to(torch.float32).contiguous()
+
+    o = torch.empty_like(v)
+    final_state = None
+    if output_final_state:
+        shape = (N, H, V, K) if state_v_first else (N, H, K, V)
+        final_state = torch.empty(shape, dtype=torch.float32, device=dev)
+
+    common = {
+        "ws_kd": ws_kd,
+        "ws_qd": ws_qd,
+        "ws_kr": ws_kr,
+        "ws_gt": ws_gt,
+        "ws_inv_mqk": ws_inv_mqk,
+        "beta_raw": beta,
+        "seg_chunk_base": seg_chunk_base,
+        "seg_nchunks": seg_nchunks,
+        "seg_tok_base": seg_tok_base,
+        "seg_tok_end": seg_tok_end,
+        "seg_seq": seg_seq,
+        "seg_is_last": seg_is_last,
+        "TOTAL_TILES": total_tiles,
+        "NUM_SEGS_CLASS": _seg_occupancy_class(num_segs),
+        "H": H,
+        "K": K,
+        "V": V,
+        "C": C,
+        "STATE_V_FIRST": state_v_first,
+    }
+
+    if max_segs > 1:
+        # Pass A: b_seg (affine part) and A_seg (linear part), both fully
+        # parallel across segments. Neither writes outputs.
+        b_seg = torch.empty(num_segs, H, K, V, dtype=torch.float32, device=dev)
+        A_seg = torch.empty(num_segs, H, K, K, dtype=torch.bfloat16, device=dev)
+        for buf, width, identity, has_v in (
+            (b_seg, V, False, True),
+            (A_seg, K, True, False),
+        ):
+            _flash_kda_segment_kernel[
+                lambda meta, _w=width: (triton.cdiv(_w, meta["BW"]), num_segs * H)
+            ](
+                v_input=v,
+                out=None,
+                h_in=None,
+                h_out=buf,
+                final_state=None,
+                W=width,
+                INIT_IDENTITY=identity,
+                HAS_H_IN=False,
+                HAS_V=has_v,
+                COMPUTE_OUTPUT=False,
+                STORE_H_OUT=True,
+                STORE_FINAL=False,
+                **common,
+            )
+
+        # Pass B: propagate across segments. Depth is the segment count.
+        h_in = torch.empty(num_segs, H, K, V, dtype=torch.float32, device=dev)
+        BV_SCAN = 32
+        _flash_kda_seg_scan_kernel[(triton.cdiv(V, BV_SCAN), N * H)](
+            A_seg=A_seg,
+            b_seg=b_seg,
+            h_in=h_in,
+            h0=h0,
+            seq_seg_off=seq_seg_off,
+            H=H,
+            K=K,
+            V=V,
+            BV=BV_SCAN,
+            num_warps=4,
+        )
+    else:
+        h_in = h0
+
+    # Pass C: re-run each segment from its true incoming state, writing outputs.
+    _flash_kda_segment_kernel[lambda meta: (triton.cdiv(V, meta["BW"]), num_segs * H)](
+        v_input=v,
+        out=o,
+        h_in=h_in,
+        h_out=None,
+        final_state=final_state,
+        W=V,
+        INIT_IDENTITY=False,
+        HAS_H_IN=h_in is not None,
+        HAS_V=True,
+        COMPUTE_OUTPUT=True,
+        STORE_H_OUT=False,
+        STORE_FINAL=output_final_state,
+        **common,
+    )
+
+    return o, final_state

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/index.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/index.py
@@ -7,7 +7,12 @@
 import torch
 import triton
 
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
+    tensor_cache,
+)
 
+
+@tensor_cache
 def prepare_chunk_indices(
     cu_seqlens: torch.LongTensor,
     chunk_size: int,
@@ -22,6 +27,9 @@ def prepare_chunk_indices(
     Returns:
         Tensor of shape [num_chunks, 2] where each row is
         [sequence_id, chunk_idx_in_seq]
+
+    Building this reads ``cu_seqlens`` back to the host and ships a new tensor
+    out, so it is cached on the argument identity; see ``tensor_cache``.
     """
     lens = torch.diff(cu_seqlens)
     indices = torch.cat(

--- a/aiter/ops/triton/kimi_delta_attn/chunk_delta_attn.py
+++ b/aiter/ops/triton/kimi_delta_attn/chunk_delta_attn.py
@@ -59,7 +59,7 @@ def chunk_kimi_delta_attn(
     lower_bound: float | None = None,
     state_v_first: bool = False,
     disable_recompute: bool = False,
-    chunk_size: int = 64,
+    chunk_size: int | None = None,
     cu_seqlens: torch.LongTensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     r"""
@@ -120,8 +120,21 @@ def chunk_kimi_delta_attn(
             Ignored. In fla this keeps the gated query `qg` alive for the
             backward pass; this path is forward-only and returns no scratch,
             so the flag is accepted for signature parity only.
-        chunk_size (int):
-            Chunk size, either 32 or 64. Default: `64`.
+        chunk_size (int, optional):
+            Chunk size, either 32 or 64. Default: `None`, which lets the
+            library choose. fla has no counterpart and pins 64 internally, so
+            nothing on the shared surface sets this.
+
+            The choice is really which kernel runs. 32 is the two-kernel
+            FlashKDA path's entry ticket, and it is picked when the rest of the
+            call also qualifies for it: the fused gate, in-kernel l2norm and
+            beta sigmoid, `safe_gate`, and `K = V = 128` without GVA. Anything
+            else gets 64, which is the faster of the two inside the default
+            pipeline. Passing 32 or 64 explicitly is honoured as given.
+
+            FlashKDA agrees with the default pipeline to bf16 rather than
+            exactly, as does 32 against 64 within the default pipeline itself.
+            Set `CHUNK_DELTA_ATTN_USE_FLASH_KDA=0` to pin the default pipeline.
         cu_seqlens (torch.LongTensor, optional):
             Cumulative sequence lengths of shape `[N+1]` for variable-length
             inputs, consistent with the FlashAttention API. Default: `None`.
@@ -209,7 +222,7 @@ def chunk_kimi_delta_attn(
 
     _LOGGER.info(
         f"CHUNK_KIMI_DELTA_ATTN: q={tuple(q.shape)}, v={tuple(v.shape)}, "
-        f"scale={scale}, chunk_size={chunk_size}, safe_gate={safe_gate}, "
+        f"scale={scale}, chunk_size={chunk_size or 'auto'}, safe_gate={safe_gate}, "
         f"lower_bound={lower_bound}, state_v_first={state_v_first}, "
         f"varlen={cu_seqlens is not None}"
     )

--- a/op_tests/op_benchmarks/triton/bench_flash_kda.py
+++ b/op_tests/op_benchmarks/triton/bench_flash_kda.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Performance benchmark for the FlashKDA two-kernel forward pass.
+
+Sweeps sequence length and head count by default; supports custom shapes via
+--shape. Only FlashKDA is timed -- run bench_chunk_delta_attn.py for the default
+pipeline and compare the Time(ms) column. TFLOPS uses the same approximation as
+that script but at C=32, the chunk size FlashKDA requires, so the two TFLOPS
+columns count different amounts of intra-chunk work.
+
+Usage examples
+--------------
+# Sweep default shapes, report time / TFLOPS / BW
+python bench_flash_kda.py
+
+# Single shape: B=1 T=16384 H=12 K=128 V=128
+python bench_flash_kda.py --shape 1 16384 12 128 128
+
+# Pin segment lengths instead of letting the heuristic choose
+python bench_flash_kda.py --seg-sweep
+
+# Save CSV
+python bench_flash_kda.py -o
+"""
+
+import argparse
+import math
+import os
+import sys
+
+# Skip CK/HIP native .so loading – Triton kernels only
+os.environ.setdefault("AITER_TRITON_ONLY", "1")
+
+
+# Ensure repo root is on the path when running this script directly
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.flash_kda import (
+    FLASH_KDA_CHUNK,
+    flash_kda_fwd,
+)
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import get_caller_name_no_ext
+
+# (B, T, H, K, V) – H=12 is the Kimi K3 shape this path was built for; the rest
+# bracket it so a regression in the segmentation heuristic shows up as well as a
+# kernel one. K and V are fixed at 128, the only width FlashKDA supports.
+DEFAULT_SHAPES = [
+    (1, 16384, 8, 128, 128),
+    (1, 16384, 12, 128, 128),
+    (1, 16384, 64, 128, 128),
+    (1, 16384, 96, 128, 128),
+    (1, 8192, 12, 128, 128),
+    (1, 8192, 16, 128, 128),
+    (1, 8192, 32, 128, 128),
+    (1, 8192, 64, 128, 128),
+    (1, 32768, 128, 128, 128),
+    (1, 65536, 12, 128, 128),
+    (2, 16384, 32, 128, 128),
+    (4, 4096, 16, 128, 128),
+    (8, 2048, 16, 128, 128),
+]
+# Segment lengths in chunks; 0 means one segment, i.e. segmentation off.
+SEG_SWEEP = [0, 16, 32, 64, 128]
+
+K_DIM = 128
+LOWER_BOUND = -5.0
+DTYPE = torch.bfloat16
+DEVICE = "cuda"
+
+
+def _make_inputs(B, T, H, seed=42):
+    """Create raw benchmark inputs (gate, l2norm and beta sigmoid are in-kernel)."""
+    torch.manual_seed(seed)
+    K = V = K_DIM
+    return {
+        "q": torch.randn(B, T, H, K, device=DEVICE, dtype=DTYPE),
+        "k": torch.randn(B, T, H, K, device=DEVICE, dtype=DTYPE),
+        "v": torch.randn(B, T, H, V, device=DEVICE, dtype=DTYPE),
+        "g": torch.randn(B, T, H, K, device=DEVICE, dtype=DTYPE) * 0.1,
+        "beta": torch.randn(B, T, H, device=DEVICE, dtype=torch.float32),
+        "A_log": torch.randn(H, device=DEVICE, dtype=torch.float32).abs() * 0.5,
+        "dt_bias": torch.randn(H * K, device=DEVICE, dtype=torch.float32) * 0.1,
+        "scale": 1.0 / math.sqrt(K),
+    }
+
+
+def _flops(B, T, H, K, V, chunk_size):
+    """
+    Approximate FLOPs for the chunk_delta_attn forward pass.
+
+    Dominant terms:
+      - Intra-chunk QK:       B * T * H * chunk_size * K * 2
+      - Intra-chunk AV:       B * T * H * chunk_size * V * 2
+      - Inter-chunk KV state: B * T * H * K * V * 2
+      - Output QH:            B * T * H * K * V * 2
+    """
+    return B * T * H * 2 * (chunk_size * K + chunk_size * V + 2 * K * V)
+
+
+def _bytes(B, T, H, K, V, HV, elem_bytes=2):
+    """Approximate memory traffic (inputs read + output written)."""
+    read = (
+        B * T * H * K * elem_bytes  # q
+        + B * T * H * K * elem_bytes  # k
+        + B * T * HV * V * elem_bytes  # v
+        + B * T * HV * K * elem_bytes  # g
+        + B * T * HV * elem_bytes  # beta
+    )
+    write = B * T * HV * V * elem_bytes  # o
+    return read + write
+
+
+def _seg_label(chunks_per_seg):
+    if chunks_per_seg is None:
+        return "auto"
+    return "1seg" if chunks_per_seg <= 0 else str(chunks_per_seg)
+
+
+def run_benchmark(args):
+    if args.shape is not None:
+        B, T, H, K, V = args.shape
+        if K != K_DIM or V != K_DIM:
+            raise SystemExit(f"flash_kda only supports K=V={K_DIM}, got K={K} V={V}")
+        x_vals_list = [(B, T, H, K, V)]
+    else:
+        x_vals_list = DEFAULT_SHAPES
+
+    header = f"{'B':>4} {'T':>6} {'H':>4} {'K':>4} {'V':>4}  {'Time(ms)':>10}  {'TFLOPS':>8}  {'BW(GB/s)':>10}"
+    if args.seg_sweep:
+        header += f"  {'seg':>6}"
+    print(header)
+    print("-" * len(header))
+
+    rows = []
+    for B, T, H, K, V in x_vals_list:
+        HV = H
+        t = _make_inputs(B, T, H)
+
+        if args.seg_sweep:
+            # A segment longer than the sequence would leave the grid empty.
+            segs = [None] + [m for m in SEG_SWEEP if not m or m * FLASH_KDA_CHUNK <= T]
+        else:
+            segs = [None]
+
+        for m in segs:
+
+            def fn(t=t, m=m):
+                return flash_kda_fwd(**t, lower_bound=LOWER_BOUND, chunks_per_seg=m)
+
+            # Time-based warmup: run until WARMUP_MS elapsed so JIT/autotune completes.
+            _elapsed = 0.0
+            while _elapsed < args.warmup_ms:
+                _t0 = torch.cuda.Event(enable_timing=True)
+                _t1 = torch.cuda.Event(enable_timing=True)
+                _t0.record()
+                fn()
+                _t1.record()
+                torch.cuda.synchronize()
+                _elapsed += _t0.elapsed_time(_t1)
+
+            ms = triton.testing.do_bench(fn, warmup=0, rep=args.rep_ms)
+            tflops = _flops(B, T, H, K, V, FLASH_KDA_CHUNK) / ms * 1e-9
+            bw = _bytes(B, T, H, K, V, HV) / (ms * 1e-3) * 1e-9
+
+            line = f"{B:>4} {T:>6} {H:>4} {K:>4} {V:>4}  {ms:>10.4f}  {tflops:>8.2f}  {bw:>10.1f}"
+            row = [B, T, H, K, V, ms, tflops, bw]
+            if args.seg_sweep:
+                line += f"  {_seg_label(m):>6}"
+                row.append(_seg_label(m))
+            print(line)
+            rows.append(tuple(row))
+
+    if args.o:
+        import csv
+
+        fname = f"{get_caller_name_no_ext()}.csv"
+        cols = ["B", "T", "H", "K", "V", "Time_ms", "TFLOPS", "BW_GBs"]
+        if args.seg_sweep:
+            cols.append("seg")
+        with open(fname, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(cols)
+            w.writerows(rows)
+        print(f"\nSaved to {fname}")
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(
+        prog="Benchmark FlashKDA forward",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--shape",
+        type=int,
+        nargs=5,
+        metavar=("B", "T", "H", "K", "V"),
+        help=f"Single shape to benchmark instead of the default sweep. K and V must be {K_DIM}.",
+    )
+    parser.add_argument(
+        "--seg-sweep",
+        action="store_true",
+        help="Also time pinned segment lengths, which is how the defaults in "
+        "_choose_chunks_per_seg were calibrated. Rerun after changing anything "
+        "that moves the crossover: segment cost, the recurrence kernel's block "
+        "count, or the hardware.",
+    )
+    parser.add_argument(
+        "-o",
+        action="store_true",
+        help="Write results to a CSV file in the current directory.",
+    )
+    parser.add_argument(
+        "--warmup-ms",
+        type=float,
+        default=300.0,
+        help="Warmup budget in ms (time-based, ensures JIT/autotune completes).",
+    )
+    parser.add_argument(
+        "--rep-ms",
+        type=float,
+        default=500.0,
+        help="Measurement budget in ms passed to triton.testing.do_bench.",
+    )
+    return parser.parse_args(args=args)
+
+
+def main(args=None):
+    run_benchmark(parse_args(args=args))
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/triton_tests/chunk_delta_attn/test_flash_kda.py
+++ b/op_tests/triton_tests/chunk_delta_attn/test_flash_kda.py
@@ -366,6 +366,29 @@ def test_weak_gate(lower_bound, chunks_per_seg):
     assert rel_err(o_fkda, o_ref) < 2e-2
 
 
+# Gaussian keys in 128 dimensions are near-orthogonal, so L's off-diagonal
+# entries sit at ~0.02 and every inverse of it looks accurate -- which is the
+# regime every other case here feeds. Repeated tokens in real text correlate the
+# keys instead, and with beta near 1 and a gate that barely decays L's entries
+# approach 1. The powers the inverse is built from then run to 5e7 across a
+# 32-wide chunk before cancelling back to a result bounded by 1, which no
+# storage precision survives: this case reached the model as 0.2% on gsm8k while
+# the rest of this file passed.
+@pytest.mark.parametrize("rho", [0.9, 1.0])
+def test_correlated_keys_weak_gate(rho):
+    q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(1, 512, 4)
+    # rho=1 is a token repeated verbatim for the whole sequence.
+    k = (rho * k[:, :1] + (1.0 - rho) * k).to(dtype)
+    beta = torch.full_like(beta, 4.0)  # sigmoid(4) = 0.98, so L is barely shrunk
+    args = (q, k, v, g, beta, A_log, dt_bias, scale)
+    kw = {"lower_bound": -0.01}
+    gold, _ = fp32_gold(*args, **kw)
+    e_fkda = rel_err(run_flash(*args, **kw)[0], gold)
+    e_ref = rel_err(run_reference(*args, **kw)[0], gold)
+    assert e_fkda < 5e-2, f"flash_kda {e_fkda:.2e} against the fp32 recurrence"
+    assert e_fkda < 1.3 * e_ref, f"flash_kda {e_fkda:.2e} vs default {e_ref:.2e}"
+
+
 @pytest.mark.parametrize("lower_bound", [-5.0, -1.0, -0.01])
 def test_matches_fp32_recurrence(lower_bound):
     """Against the token-at-a-time fp32 recurrence both paths blockify.

--- a/op_tests/triton_tests/chunk_delta_attn/test_flash_kda.py
+++ b/op_tests/triton_tests/chunk_delta_attn/test_flash_kda.py
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Tests for the two-kernel FlashKDA path against the default chunk_delta_attn
+pipeline.
+
+Both compute the same forward, so the default pipeline is the reference. They
+are not bit-identical: the fused path keeps the recurrent state in registers
+across the whole sequence and inverts (I - L) with bf16 multiplicative doubling,
+where the default path materializes the state per chunk and uses an exact
+forward substitution. The gap is bf16-level, so the checks are on relative
+error rather than allclose.
+"""
+
+import contextlib
+import math
+
+import pytest
+import torch
+
+from aiter.ops.triton._triton_kernels.chunk_delta_attn import chunk_delta_attn_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn import chunk_fwd as _chunk_fwd
+from aiter.ops.triton._triton_kernels.chunk_delta_attn import flash_kda as _flash_kda
+from aiter.ops.triton._triton_kernels.chunk_delta_attn.flash_kda import (
+    FLASH_KDA_CHUNK,
+    flash_kda_fwd,
+    flash_kda_supported,
+)
+from aiter.ops.triton.kimi_delta_attn import chunk_kimi_delta_attn
+from op_tests.triton_tests.utils.kda_ref import chunk_kda_ref
+
+device = "cuda"
+dtype = torch.bfloat16
+
+LOWER_BOUND = -5.0
+K_DIM = 128
+
+
+def make_inputs(B, T, H, seed=42):
+    torch.manual_seed(seed)
+    K = V = K_DIM
+    scale = 1.0 / math.sqrt(K)
+    q = torch.randn(B, T, H, K, device=device, dtype=dtype)
+    k = torch.randn(B, T, H, K, device=device, dtype=dtype)
+    v = torch.randn(B, T, H, V, device=device, dtype=dtype)
+    g = torch.randn(B, T, H, K, device=device, dtype=dtype) * 0.1
+    beta = torch.randn(B, T, H, device=device, dtype=torch.float32)
+    A_log = torch.randn(H, device=device, dtype=torch.float32).abs() * 0.5
+    dt_bias = torch.randn(H * K, device=device, dtype=torch.float32) * 0.1
+    return q, k, v, g, beta, A_log, dt_bias, scale
+
+
+@contextlib.contextmanager
+def _force_default_pipeline():
+    """Pin the reference to the five-kernel path.
+
+    ``chunk_delta_attn_fwd`` dispatches to ``flash_kda_fwd`` whenever
+    CHUNK_DELTA_ATTN_USE_FLASH_KDA is set. Without this, running the suite
+    with that variable exported makes every comparison here flash_kda
+    against itself, which passes unconditionally.
+    """
+    saved = _chunk_fwd.CHUNK_DELTA_ATTN_USE_FLASH_KDA
+    _chunk_fwd.CHUNK_DELTA_ATTN_USE_FLASH_KDA = False
+    try:
+        yield
+    finally:
+        _chunk_fwd.CHUNK_DELTA_ATTN_USE_FLASH_KDA = saved
+
+
+def run_reference(q, k, v, g, beta, A_log, dt_bias, scale, **kw):
+    """Default five-kernel pipeline."""
+    with _force_default_pipeline():
+        o, final_state, *_ = chunk_delta_attn_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            chunk_size=FLASH_KDA_CHUNK,
+            safe_gate=True,
+            lower_bound=kw.get("lower_bound", LOWER_BOUND),
+            use_gate_in_kernel=True,
+            use_qk_l2norm_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            disable_recompute=False,
+            initial_state=kw.get("initial_state"),
+            output_final_state=kw.get("output_final_state", False),
+            state_v_first=kw.get("state_v_first", False),
+            cu_seqlens=kw.get("cu_seqlens"),
+        )
+    return o, final_state
+
+
+def run_flash(q, k, v, g, beta, A_log, dt_bias, scale, **kw):
+    return flash_kda_fwd(
+        chunks_per_seg=kw.get("chunks_per_seg"),
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        lower_bound=kw.get("lower_bound", LOWER_BOUND),
+        initial_state=kw.get("initial_state"),
+        output_final_state=kw.get("output_final_state", False),
+        state_v_first=kw.get("state_v_first", False),
+        cu_seqlens=kw.get("cu_seqlens"),
+    )
+
+
+def fp32_gold(q, k, v, g, beta, A_log, dt_bias, scale, **kw):
+    """Token-at-a-time fp32 recurrence, driven by the same kw dict as the others.
+
+    bf16 inputs upcast exactly, so this is the same call in fp32. A bf16 gold
+    would round away the gap the ratio assertions below measure.
+    """
+    return chunk_kda_ref(
+        q=q.float(),
+        k=k.float(),
+        v=v.float(),
+        g=g.float(),
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        use_beta_sigmoid_in_kernel=True,
+        safe_gate=True,
+        lower_bound=kw.get("lower_bound", LOWER_BOUND),
+        initial_state=kw.get("initial_state"),
+        output_final_state=kw.get("output_final_state", False),
+        state_v_first=kw.get("state_v_first", False),
+        cu_seqlens=kw.get("cu_seqlens"),
+    )
+
+
+def rel_err(a, b):
+    a, b = a.float(), b.float()
+    return ((a - b).norm() / (b.norm() + 1e-6)).item()
+
+
+@pytest.mark.parametrize("B,T,H", [(1, 256, 4), (2, 512, 8), (1, 1024, 2)])
+def test_batched_matches_reference(B, T, H):
+    args = make_inputs(B, T, H)
+    o_ref, _ = run_reference(*args)
+    o_fkda, _ = run_flash(*args)
+    assert rel_err(o_fkda, o_ref) < 2e-2
+
+
+@pytest.mark.parametrize("T", [192, 200, 65, 320])
+def test_tail_chunk(T):
+    """T not a multiple of 64 exercises the partial trailing chunk."""
+    args = make_inputs(1, T, 4)
+    o_ref, _ = run_reference(*args)
+    o_fkda, _ = run_flash(*args)
+    assert rel_err(o_fkda, o_ref) < 2e-2
+
+
+@pytest.mark.parametrize(
+    "lens",
+    [
+        [128, 64],
+        [100, 156, 33],  # all three end mid-chunk
+        [64, 1, 191],  # single-token sequence next to a long one
+        [512],
+    ],
+)
+def test_varlen_matches_reference(lens):
+    total = sum(lens)
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.tensor(lens).cumsum(0)), device=device, dtype=torch.long
+    )
+    args = make_inputs(1, total, 4)
+    o_ref, _ = run_reference(*args, cu_seqlens=cu_seqlens)
+    o_fkda, _ = run_flash(*args, cu_seqlens=cu_seqlens)
+    assert rel_err(o_fkda, o_ref) < 2e-2
+
+
+@pytest.mark.parametrize("state_v_first", [False, True])
+def test_final_state(state_v_first):
+    B, T, H = 2, 256, 4
+    args = make_inputs(B, T, H)
+    kw = {"output_final_state": True, "state_v_first": state_v_first}
+    o_ref, ht_ref = run_reference(*args, **kw)
+    o_fkda, ht_fkda = run_flash(*args, **kw)
+    assert ht_fkda is not None and ht_fkda.shape == ht_ref.shape
+    assert rel_err(o_fkda, o_ref) < 2e-2
+    assert rel_err(ht_fkda, ht_ref) < 2e-2
+
+
+@pytest.mark.parametrize("state_v_first", [False, True])
+def test_initial_state_roundtrip(state_v_first):
+    """Carrying a state in and back out, as chunked prefill does."""
+    B, T, H = 2, 192, 4
+    args = make_inputs(B, T, H)
+    shape = (B, H, K_DIM, K_DIM)
+    h0 = torch.randn(*shape, device=device, dtype=torch.float32) * 0.1
+    kw = {
+        "initial_state": h0,
+        "output_final_state": True,
+        "state_v_first": state_v_first,
+    }
+    o_ref, ht_ref = run_reference(*args, **kw)
+    o_fkda, ht_fkda = run_flash(*args, **kw)
+    assert rel_err(o_fkda, o_ref) < 2e-2
+    assert rel_err(ht_fkda, ht_ref) < 2e-2
+
+
+@pytest.mark.parametrize("state_v_first", [False, True])
+def test_varlen_initial_state(state_v_first):
+    """Packed sequences threading a state, in both state layouts.
+
+    varlen and a V-first state are covered apart above but only together in the
+    serving path, where prefill carries a state per sequence and hands it to
+    decode in that layout.
+    """
+    lens = [128, 100, 64]
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.tensor(lens).cumsum(0)), device=device, dtype=torch.long
+    )
+    args = make_inputs(1, sum(lens), 4)
+    h0 = (
+        torch.randn(len(lens), 4, K_DIM, K_DIM, device=device, dtype=torch.float32)
+        * 0.1
+    )
+    kw = {
+        "cu_seqlens": cu_seqlens,
+        "initial_state": h0,
+        "output_final_state": True,
+        "state_v_first": state_v_first,
+    }
+    o_ref, ht_ref = run_reference(*args, **kw)
+    o_fkda, ht_fkda = run_flash(*args, **kw)
+    assert rel_err(o_fkda, o_ref) < 2e-2
+    assert rel_err(ht_fkda, ht_ref) < 2e-2
+
+
+def test_chunked_prefill_equivalence():
+    """Splitting a sequence and threading the state must match one shot."""
+    B, T, H = 1, 256, 4
+    q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(B, T, H)
+    o_full, ht_full = run_flash(
+        q, k, v, g, beta, A_log, dt_bias, scale, output_final_state=True
+    )
+
+    split = 128
+    o1, ht1 = run_flash(
+        q[:, :split],
+        k[:, :split],
+        v[:, :split],
+        g[:, :split],
+        beta[:, :split],
+        A_log,
+        dt_bias,
+        scale,
+        output_final_state=True,
+    )
+    o2, ht2 = run_flash(
+        q[:, split:],
+        k[:, split:],
+        v[:, split:],
+        g[:, split:],
+        beta[:, split:],
+        A_log,
+        dt_bias,
+        scale,
+        initial_state=ht1,
+        output_final_state=True,
+    )
+    o_split = torch.cat([o1, o2], dim=1)
+    assert rel_err(o_split, o_full) < 2e-2
+    assert rel_err(ht2, ht_full) < 2e-2
+
+
+# The shapes above are far too short for the heuristic to segment, so the
+# segmented path is pinned explicitly here. chunks_per_seg=1 is the extreme
+# case: every chunk becomes its own segment, so the scan carries the entire
+# recurrence and any error in the affine decomposition shows up immediately.
+@pytest.mark.parametrize("chunks_per_seg", [1, 2, 3, 8])
+def test_segmented_matches_reference(chunks_per_seg):
+    args = make_inputs(2, 512, 4)
+    o_ref, _ = run_reference(*args)
+    o_seg, _ = run_flash(*args, chunks_per_seg=chunks_per_seg)
+    assert rel_err(o_seg, o_ref) < 2e-2
+
+
+@pytest.mark.parametrize("chunks_per_seg", [1, 3])
+def test_segmented_states(chunks_per_seg):
+    """Segmenting must not disturb either end of the state threading."""
+    B, T, H = 2, 384, 4
+    args = make_inputs(B, T, H)
+    h0 = torch.randn(B, H, K_DIM, K_DIM, device=device, dtype=torch.float32) * 0.1
+    kw = {"initial_state": h0, "output_final_state": True}
+    o_ref, ht_ref = run_reference(*args, **kw)
+    o_seg, ht_seg = run_flash(*args, **kw, chunks_per_seg=chunks_per_seg)
+    assert rel_err(o_seg, o_ref) < 2e-2
+    assert rel_err(ht_seg, ht_ref) < 2e-2
+
+
+def test_segmented_varlen_uneven():
+    """Sequences whose last segment is short, and one shorter than a segment."""
+    lens = [500, 33, 257, 64]
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.tensor(lens).cumsum(0)), device=device, dtype=torch.long
+    )
+    args = make_inputs(1, sum(lens), 4)
+    h0 = torch.randn(len(lens), 4, K_DIM, K_DIM, device=device, dtype=torch.float32)
+    kw = {
+        "cu_seqlens": cu_seqlens,
+        "initial_state": h0 * 0.1,
+        "output_final_state": True,
+    }
+    o_ref, ht_ref = run_reference(*args, **kw)
+    o_seg, ht_seg = run_flash(*args, **kw, chunks_per_seg=3)
+    assert rel_err(o_seg, o_ref) < 2e-2
+    assert rel_err(ht_seg, ht_ref) < 2e-2
+
+
+def test_segmented_agrees_with_unsegmented():
+    """The segment count is a scheduling choice and must not change the result."""
+    args = make_inputs(1, 1024, 4)
+    o_plain, ht_plain = run_flash(*args, output_final_state=True, chunks_per_seg=0)
+    for m in (2, 7, 16):
+        o_seg, ht_seg = run_flash(*args, output_final_state=True, chunks_per_seg=m)
+        assert rel_err(o_seg, o_plain) < 5e-3, m
+        assert rel_err(ht_seg, ht_plain) < 5e-3, m
+
+
+def test_tuner_keeps_the_two_schedules_apart():
+    """A segmented run must not hand its config to a later unsegmented one.
+
+    K2's grid is ``cdiv(W, BW) * num_segs * H``, so the wide BW that suits a
+    segmented sweep leaves the unsegmented scan a quarter of the blocks: at
+    H=12 that pick costs 2.3x. The two collide unless the segment count reaches
+    the autotune key, and `cache_results` then persists whichever won.
+    """
+    kern = _flash_kda._flash_kda_segment_kernel
+    args = make_inputs(1, 1024, 4)
+    # An incoming state is what makes the two output passes otherwise identical:
+    # without it the unsegmented one passes h_in=None and the key picks up the
+    # difference through the dtypes it appends, hiding the collision.
+    kw = {"initial_state": torch.zeros(1, 4, K_DIM, K_DIM, device=device)}
+    kern.cache.clear()
+    run_flash(*args, chunks_per_seg=4, **kw)
+    segmented_keys = set(kern.cache)
+    run_flash(*args, chunks_per_seg=0, **kw)
+    assert set(kern.cache) - segmented_keys, "unsegmented reused a segmented config"
+
+
+# A weak gate is the only setting that exposes the intra-chunk inverse. At the
+# Kimi default lower_bound=-5 the decay damps L to almost nothing, so even an
+# outright wrong inverse stays inside bf16 noise; these three catch it.
+@pytest.mark.parametrize("lower_bound", [-1.0, -0.1, -0.01])
+@pytest.mark.parametrize("chunks_per_seg", [0, 3])
+def test_weak_gate(lower_bound, chunks_per_seg):
+    args = make_inputs(1, 512, 4)
+    o_ref, _ = run_reference(*args, lower_bound=lower_bound)
+    o_fkda, _ = run_flash(*args, lower_bound=lower_bound, chunks_per_seg=chunks_per_seg)
+    assert rel_err(o_fkda, o_ref) < 2e-2
+
+
+@pytest.mark.parametrize("lower_bound", [-5.0, -1.0, -0.01])
+def test_matches_fp32_recurrence(lower_bound):
+    """Against the token-at-a-time fp32 recurrence both paths blockify.
+
+    The default pipeline is the reference everywhere else here, which cannot
+    show the two paths drifting the same way; the absolute bound catches that.
+    The second assertion keeps a merely noisier fused path from passing it, and
+    covers a gap in the default path's own reference check, which pins
+    chunk_size=64 -- a size flash_kda rejects.
+    """
+    args = make_inputs(1, 512, 4)
+    gold, _ = fp32_gold(*args, lower_bound=lower_bound)
+    e_fkda = rel_err(run_flash(*args, lower_bound=lower_bound)[0], gold)
+    e_ref = rel_err(run_reference(*args, lower_bound=lower_bound)[0], gold)
+    assert e_fkda < 2e-2, f"flash_kda {e_fkda:.2e} against the fp32 recurrence"
+    assert e_fkda < 1.3 * e_ref, f"flash_kda {e_fkda:.2e} vs default {e_ref:.2e}"
+
+
+@pytest.mark.parametrize("lower_bound", [-5.0, -1.0, -0.01])
+def test_final_state_matches_fp32_recurrence(lower_bound):
+    """The same absolute bound as above, on the state rather than the output.
+
+    Decode continues the recurrence from this tensor, so a state that drifts the
+    same way in both chunked paths passes every default-pipeline comparison here
+    and still ruins generation. varlen with a V-first state is what the serving
+    path asks for, and it is the combination the checks above split apart.
+    """
+    lens = [200, 100, 156]
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.tensor(lens).cumsum(0)), device=device, dtype=torch.long
+    )
+    args = make_inputs(1, sum(lens), 4)
+    kw = {
+        "cu_seqlens": cu_seqlens,
+        "output_final_state": True,
+        "state_v_first": True,
+        "lower_bound": lower_bound,
+    }
+    _, gold = fp32_gold(*args, **kw)
+    e_fkda = rel_err(run_flash(*args, **kw)[1], gold)
+    e_ref = rel_err(run_reference(*args, **kw)[1], gold)
+    assert e_fkda < 2e-2, f"flash_kda state {e_fkda:.2e} against the fp32 recurrence"
+    assert e_fkda < 1.3 * e_ref, f"flash_kda state {e_fkda:.2e} vs default {e_ref:.2e}"
+
+
+def test_supported_rejects_unsupported():
+    q = torch.randn(1, 64, 4, 64, device=device, dtype=dtype)
+    v = torch.randn(1, 64, 4, 64, device=device, dtype=dtype)
+    A_log = torch.randn(4, device=device, dtype=torch.float32)
+    base = {
+        "chunk_size": FLASH_KDA_CHUNK,
+        "safe_gate": True,
+        "use_gate_in_kernel": True,
+        "use_qk_l2norm_in_kernel": True,
+        "use_beta_sigmoid_in_kernel": True,
+        "lower_bound": LOWER_BOUND,
+        "A_log": A_log,
+    }
+    # K = V = 64 is not supported.
+    assert not flash_kda_supported(q=q, v=v, **base)
+
+    q128 = torch.randn(1, 64, 4, 128, device=device, dtype=dtype)
+    v128 = torch.randn(1, 64, 4, 128, device=device, dtype=dtype)
+    assert flash_kda_supported(q=q128, v=v128, **base)
+    assert not flash_kda_supported(q=q128, v=v128, **{**base, "chunk_size": 64})
+    assert not flash_kda_supported(q=q128, v=v128, **{**base, "lower_bound": None})
+    assert not flash_kda_supported(q=q128, v=v128, **{**base, "safe_gate": False})
+    assert not flash_kda_supported(
+        q=q128, v=v128, **{**base, "use_gate_in_kernel": False}
+    )
+    # GVA (HV != H) is not supported.
+    v_gva = torch.randn(1, 64, 8, 128, device=device, dtype=dtype)
+    assert not flash_kda_supported(q=q128, v=v_gva, **base)
+
+
+def test_public_wrapper_routes_to_flash_kda(monkeypatch):
+    """``chunk_kimi_delta_attn`` must actually reach the fast path.
+
+    Every other test here drives the internal functions, so nothing would catch
+    the public wrapper pinning an argument that disqualifies the dispatch: the
+    fast path would silently stop being used and the suite would stay green.
+    """
+    q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(1, 512, 4)
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "scale": scale,
+        "chunk_size": FLASH_KDA_CHUNK,
+        "safe_gate": True,
+        "lower_bound": LOWER_BOUND,
+        "use_gate_in_kernel": True,
+        "use_qk_l2norm_in_kernel": True,
+        "use_beta_sigmoid_in_kernel": True,
+        "output_final_state": True,
+    }
+
+    calls = []
+    real = _chunk_fwd.flash_kda_fwd
+
+    def counting(**kw):
+        calls.append(1)
+        return real(**kw)
+
+    monkeypatch.setattr(_chunk_fwd, "flash_kda_fwd", counting)
+
+    monkeypatch.setattr(_chunk_fwd, "CHUNK_DELTA_ATTN_USE_FLASH_KDA", False)
+    o_ref, ht_ref = chunk_kimi_delta_attn(**kwargs)
+    assert not calls, "the flag is off, the default pipeline should have served this"
+
+    monkeypatch.setattr(_chunk_fwd, "CHUNK_DELTA_ATTN_USE_FLASH_KDA", True)
+    o_fkda, ht_fkda = chunk_kimi_delta_attn(**kwargs)
+    assert len(calls) == 1, "the wrapper never reached flash_kda_fwd"
+
+    chunk_kimi_delta_attn(**{**kwargs, "safe_gate": False})
+    assert len(calls) == 1, "safe_gate=False must stay on the default intra kernel"
+
+    assert rel_err(o_fkda, o_ref) < 2e-2
+    assert rel_err(ht_fkda, ht_ref) < 2e-2
+
+
+def test_unset_chunk_size_follows_the_dispatch(monkeypatch):
+    """``chunk_size=None`` has to resolve the way the dispatch goes.
+
+    Picking 32 without reaching flash_kda would leave the call on the default
+    pipeline at 32, which is the slowest of the three configurations rather
+    than the fastest, and nothing about the result would reveal it.
+    """
+    q, k, v, g, beta, A_log, dt_bias, scale = make_inputs(1, 512, 4)
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "scale": scale,
+        "safe_gate": True,
+        "lower_bound": LOWER_BOUND,
+        "use_gate_in_kernel": True,
+        "use_qk_l2norm_in_kernel": True,
+        "use_beta_sigmoid_in_kernel": True,
+    }
+
+    calls = []
+    real = _chunk_fwd.flash_kda_fwd
+
+    def counting(**kw):
+        calls.append(1)
+        return real(**kw)
+
+    monkeypatch.setattr(_chunk_fwd, "flash_kda_fwd", counting)
+    monkeypatch.setattr(_chunk_fwd, "CHUNK_DELTA_ATTN_USE_FLASH_KDA", True)
+
+    chunk_kimi_delta_attn(chunk_size=None, **kwargs)
+    assert len(calls) == 1, "an eligible call should have resolved to FLASH_KDA_CHUNK"
+
+    # Ineligible, so it must fall back to 64 rather than to FLASH_KDA_CHUNK.
+    # Same pipeline and same chunk size means the two agree bit for bit.
+    o_auto, _ = chunk_kimi_delta_attn(chunk_size=None, **{**kwargs, "safe_gate": False})
+    o_64, _ = chunk_kimi_delta_attn(chunk_size=64, **{**kwargs, "safe_gate": False})
+    assert len(calls) == 1
+    assert torch.equal(o_auto, o_64), "an ineligible call should have resolved to 64"


### PR DESCRIPTION
## Motivation

Optimize chunk delta attn performance.

## Technical Details

1. Add the fused two-kernel forward path, on by default for the varlen prefill
   shapes flash_kda_supported() admits and falling back to the default pipeline
   for every other shape or flag combination
2. Cache the cu_seqlens readback and the chunk index tensor on argument identity,
   and add the segment count to K2's autotune key so the segmented and
   unsegmented schedules stop sharing one tuned config


## Test Plan

- UT test -- op_tests/triton_tests/chunk_delta_attn/test_flash_kda.py
- Microbench -- op_tests/op_benchmarks/triton/bench_flash_kda.py

## Test Result

All correctness tests pass (bfloat16, atol=1e-2, rtol=1e-2). Precision verification passed on GFX1250/GFX950/GFX942.
Kimi-K3 accuracy pass.
<img width="621" height="149" alt="image" src="https://github.com/user-attachments/assets/3a3eb45f-661e-410f-a39e-0eb046120f9c" />

https://github.com/ROCm/ATOM/actions/runs/31656616128/job/94313083167


GFX950 Perf Data:
| B | T | H | K | V | chunk_delta_attn (ms) | FlashKDA (ms) | speedup |
|---|---|---|---|---|---|---|---|
| 1 |  8192 | 32 | 128 | 128 | 1.0031 | 0.6091 | 1.65x |
| 1 |  8192 | 64 | 128 | 128 | 1.6186 | 0.9148 | 1.77x |
| 1 |  8192 | 96 | 128 | 128 | 2.3558 | 1.2243 | 1.92x |
| 1 | 16384 | 32 | 128 | 128 | 1.9047 | 1.1722 | 1.62x |
| 1 | 16384 | 64 | 128 | 128 | 3.1407 | 1.7967 | 1.75x |
| 1 | 16384 | 96 | 128 | 128 | 4.6134 | 2.4802 | 1.86x |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
