### PR TITLE
[CI] bump dawidd6/action-download-artifact to v21

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -1021,13 +1021,16 @@ jobs:
         if: steps.current.outputs.found == 'true' && github.event_name == 'pull_request'
         id: baseline_pinned
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v21
         timeout-minutes: 15
         with:
           workflow: aiter-test.yaml
           commit: ${{ github.event.pull_request.base.sha }}
           name: tuned-op-bench-${{ github.event.pull_request.base.sha }}
           path: /tmp/baseline_pinned/
+          # GHSA-5xr6-xhww-33m4: a fork run's artifact must never become a trusted
+          # baseline. false is v6+'s default, stated so a flip cannot undo it.
+          allow_forks: false
           if_no_artifact_found: warn
 
       - name: Fallback — fetch baseline from latest main
@@ -1036,7 +1039,7 @@ jobs:
           github.event_name == 'pull_request'
         id: baseline_main
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v21
         timeout-minutes: 15
         with:
           workflow: aiter-test.yaml
@@ -1044,6 +1047,7 @@ jobs:
           name_is_regexp: true
           name: ^tuned-op-bench-[a-f0-9]+$
           path: /tmp/baseline_main/
+          allow_forks: false
           if_no_artifact_found: warn
 
       - name: Compare

--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -457,25 +457,29 @@ jobs:
       - name: Fetch baseline from PR base.sha
         if: steps.current.outputs.found == 'true'
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v21
         timeout-minutes: 10
         with:
           workflow: flash_attention_integration.yaml
           commit: ${{ github.event.pull_request.base.sha }}
           name: flash-attention-triton-benchmark-MI35X
           path: /tmp/baseline_pinned/
+          # GHSA-5xr6-xhww-33m4: a fork run's artifact must never become a trusted
+          # baseline. false is v6+'s default, stated so a flip cannot undo it.
+          allow_forks: false
           if_no_artifact_found: warn
 
       - name: Fallback baseline from latest main
         if: steps.current.outputs.found == 'true'
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v21
         timeout-minutes: 10
         with:
           workflow: flash_attention_integration.yaml
           branch: main
           name: flash-attention-triton-benchmark-MI35X
           path: /tmp/baseline_main/
+          allow_forks: false
           if_no_artifact_found: warn
 
       - name: Compare


### PR DESCRIPTION
## Motivation

Fix https://github.com/ROCm/aiter/security/dependabot/2 and https://github.com/ROCm/aiter/security/dependabot/3 by bumping version for actions package.  

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
