### PR TITLE
[cpp_itfs] Harden the C++ JIT loader: no shell, validated paths, trusted-file dlopen

### DIFF
--- a/csrc/cpp_itfs/mla/asm_mla_decode_fwd.cpp
+++ b/csrc/cpp_itfs/mla/asm_mla_decode_fwd.cpp
@@ -58,20 +58,13 @@ void asm_mla_decode_fwd(std::optional<std::string> folder,
     }
     if(not_built(folder.value()))
     {
-        std::string cmd = fmt::format(
-            R"(python3 -m csrc.cpp_itfs.mla.asm_mla_decode_fwd --gqa_ratio={gqa_ratio} \
-                                    --page_size={page_size} \
-                                    --q_dtype={q_dtype} \
-                                    --kv_dtype={kv_dtype} \
-                                    --num_kv_splits={num_kv_splits} \
-                                    --v_head_dim={v_head_dim})",
-            fmt::arg("gqa_ratio", gqa_ratio),
-            fmt::arg("page_size", page_size),
-            fmt::arg("q_dtype", q_dtype),
-            fmt::arg("kv_dtype", kv_dtype),
-            fmt::arg("num_kv_splits", num_kv_splits),
-            fmt::arg("v_head_dim", v_head_dim));
-        execute_cmd(cmd);
+        run_codegen("csrc.cpp_itfs.mla.asm_mla_decode_fwd",
+                    {{"gqa_ratio", std::to_string(gqa_ratio)},
+                     {"page_size", std::to_string(page_size)},
+                     {"q_dtype", q_dtype},
+                     {"kv_dtype", kv_dtype},
+                     {"num_kv_splits", std::to_string(num_kv_splits)},
+                     {"v_head_dim", std::to_string(v_head_dim)}});
     }
     run_lib(func_name,
             folder.value(),

--- a/csrc/cpp_itfs/pa/pa_ragged.cpp
+++ b/csrc/cpp_itfs/pa/pa_ragged.cpp
@@ -59,18 +59,17 @@ void paged_attention_ragged(std::optional<std::string> folder,
 
     if(not_built(folder.value()))
     {
-        args.push_back(func_name);
-        execute_cmd(R"(python3 -m csrc.cpp_itfs.pa.pa_ragged \
-                                    --gqa_ratio={} \
-                                    --head_size={} \
-                                    --npar_loops={} \
-                                    --dtype={} \
-                                    --kv_dtype={} \
-                                    --fp8_kv_dtype={} \
-                                    --out_dtype={} \
-                                    --block_size={} \
-                                    --alibi_enabled={} \
-                                    --func_name={})", args);
+        run_codegen("csrc.cpp_itfs.pa.pa_ragged",
+                    {{"gqa_ratio", std::to_string(gqa_ratio)},
+                     {"head_size", std::to_string(head_size)},
+                     {"npar_loops", std::to_string(npar_loops)},
+                     {"dtype", dtype},
+                     {"kv_dtype", kv_dtype},
+                     {"fp8_kv_dtype", kv_cache_dtype},
+                     {"out_dtype", out_dtype},
+                     {"block_size", std::to_string(block_size)},
+                     {"alibi_enabled", alibi_enabled},
+                     {"func_name", func_name}});
     }
     run_lib(func_name,
             folder.value(),

--- a/csrc/cpp_itfs/utils.h
+++ b/csrc/cpp_itfs/utils.h
@@ -1,20 +1,37 @@
 #pragma once
 
 #include <dlfcn.h>
+#include <spawn.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include <stdexcept>
 #include <filesystem>
 #include <sstream>
 #include "lru_cache.h"
 #include <memory>
+#include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <openssl/evp.h>
 #include <iomanip>
 #include <fmt/ranges.h>
-#include <fmt/args.h>
 #include <mutex>
 #include <cctype>
 #include <algorithm>
+#include <array>
+#include <string_view>
+#include <utility>
+#include <vector>
 
+extern "C" char** environ;
+
+// Set -DAITER_ENABLE_JIT=0 to build without the runtime code-generation path.
+// Packaged builds should do this and ship prebuilt libraries under
+// -DAITER_INSTALL_LIBDIR="<prefix>" instead.
+#ifndef AITER_ENABLE_JIT
+#define AITER_ENABLE_JIT 1
+#endif
 
 namespace aiter{
 
@@ -32,14 +49,100 @@ __inline__ void init_lru_cache(std::unique_ptr<LRUCache<K, V>>& lru_cache){
     lru_cache = std::make_unique<LRUCache<K, V>>(aiter_max_cache_size);
 }
 
+// Every value that reaches a command line or a cache path is a kernel
+// identifier: a dtype spelling, an integer, a bool, or a hashed function name.
+// Restricting them to this charset keeps path separators and "." out of file
+// paths, so a folder name can never escape its parent directory.
+__inline__ bool is_safe_token(std::string_view token){
+    if(token.empty() || token.size() > 64){
+        return false;
+    }
+    return std::all_of(token.begin(), token.end(), [](unsigned char c){
+        return std::isalnum(c) != 0 || c == '_' || c == '-';
+    });
+}
+
+// Rejected values are deliberately not echoed back: they are attacker-influenced
+// and would land in logs verbatim.
+__inline__ const std::string& check_token(const std::string& token, const char* what){
+    if(!is_safe_token(token)){
+        throw std::invalid_argument(
+            fmt::format("aiter: invalid {} (expected [A-Za-z0-9_-]{{1,64}})", what));
+    }
+    return token;
+}
+
+__inline__ bool is_safe_module(std::string_view name){
+    if(name.empty() || name.size() > 128){
+        return false;
+    }
+    if(name.front() == '.' || name.back() == '.' || name.find("..") != std::string_view::npos){
+        return false;
+    }
+    return std::all_of(name.begin(), name.end(), [](unsigned char c){
+        return std::isalnum(c) != 0 || c == '_' || c == '.';
+    });
+}
+
+// A directory or library owned by another unprivileged user, or writable by
+// group/other, lets a co-tenant swap in code that we would then dlopen().
+__inline__ bool is_writable_by_others(const struct stat& st){
+    return (st.st_mode & (S_IWGRP | S_IWOTH)) != 0;
+}
+
+__inline__ bool is_foreign_owner(const struct stat& st){
+    return st.st_uid != ::geteuid() && st.st_uid != 0;
+}
+
+__inline__ void check_trusted_dir(const std::filesystem::path& dir){
+    struct stat st{};
+    if(::stat(dir.c_str(), &st) != 0){
+        return; // Does not exist yet; it will be created with our own umask.
+    }
+    if(is_foreign_owner(st) || is_writable_by_others(st)){
+        throw std::runtime_error(
+            fmt::format("aiter: refusing to use \"{}\": not owned by the current user "
+                        "or writable by group/other", dir.string()));
+    }
+}
+
+__inline__ void check_trusted_file(const std::filesystem::path& file){
+    struct stat st{};
+    if(::lstat(file.c_str(), &st) != 0){
+        throw std::runtime_error(fmt::format("aiter: cannot stat \"{}\"", file.string()));
+    }
+    if(S_ISLNK(st.st_mode)){
+        throw std::runtime_error(
+            fmt::format("aiter: refusing to load \"{}\": symlink", file.string()));
+    }
+    if(is_foreign_owner(st) || is_writable_by_others(st)){
+        throw std::runtime_error(
+            fmt::format("aiter: refusing to load \"{}\": not owned by the current user "
+                        "or writable by group/other", file.string()));
+    }
+}
+
 static std::filesystem::path aiter_root_dir;
 
 __inline__ void init_root_dir(){
-    char* AITER_ROOT_DIR = std::getenv("AITER_ROOT_DIR");
-    if (!AITER_ROOT_DIR){
-        AITER_ROOT_DIR = std::getenv("HOME");
+    const char* root = nullptr;
+    // A setuid/setgid process must not take its library search root from the
+    // environment of whoever invoked it.
+    const bool privileged = ::geteuid() != ::getuid() || ::getegid() != ::getgid();
+    if(!privileged){
+        root = std::getenv("AITER_ROOT_DIR");
+        if(!root){
+            root = std::getenv("HOME");
+        }
     }
-    aiter_root_dir=std::filesystem::path(AITER_ROOT_DIR)/".aiter";
+    if(!root || *root == '\0'){
+        throw std::runtime_error(
+            "aiter: cannot determine the JIT cache root; set AITER_ROOT_DIR "
+            "(ignored for setuid/setgid processes)");
+    }
+    std::filesystem::path candidate = std::filesystem::path(root) / ".aiter";
+    check_trusted_dir(candidate);
+    aiter_root_dir = std::move(candidate);
 }
 
 __inline__ std::filesystem::path get_root_dir(){
@@ -47,51 +150,98 @@ __inline__ std::filesystem::path get_root_dir(){
     return aiter_root_dir;
 }
 
-
-__inline__ const std::pair<std::string, int> execute_cmd(const std::string& cmd) {
-    std::array<char, 128> buffer;
-    std::string result;
-    int exitCode;
-
-    FILE* pipe = popen(cmd.c_str(), "r");
-
-    if (!pipe) {
-        throw std::runtime_error("popen() failed!");
-    }
-
-    try {
-        while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
-            result += buffer.data();
-        }
-    } catch (...) {
-        pclose(pipe);
-        throw;
-    }
-
-    exitCode = pclose(pipe);
-    return {result, exitCode};
+__inline__ std::filesystem::path get_build_dir(){
+    return get_root_dir() / "build";
 }
 
-
-__inline__ const std::pair<std::string, int> execute_cmd(const std::string& cmd, const std::list<std::string>& args) {
-    fmt::dynamic_format_arg_store<fmt::format_context> store;
-    for (const auto& arg : args) {
-        store.push_back(arg);
+// Runs argv[0] directly. There is no shell, so no argument can be interpreted
+// as a metacharacter regardless of its contents.
+__inline__ const std::pair<std::string, int> execute_argv(const std::vector<std::string>& argv){
+    if(argv.empty()){
+        throw std::invalid_argument("aiter: empty argv");
     }
-    std::string cmd_with_args = fmt::vformat(cmd, store);
-    AITER_LOG_INFO(cmd_with_args);
-    const auto results = execute_cmd(cmd_with_args);
-    AITER_LOG_INFO(results.first);
-    return results;
+
+    int fds[2];
+    if(::pipe(fds) != 0){
+        throw std::runtime_error("aiter: pipe() failed");
+    }
+
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_addclose(&actions, fds[0]);
+    posix_spawn_file_actions_adddup2(&actions, fds[1], STDOUT_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, fds[1], STDERR_FILENO);
+    posix_spawn_file_actions_addclose(&actions, fds[1]);
+
+    std::vector<char*> cargv;
+    cargv.reserve(argv.size() + 1);
+    for(const auto& arg : argv){
+        cargv.push_back(const_cast<char*>(arg.c_str()));
+    }
+    cargv.push_back(nullptr);
+
+    pid_t pid          = 0;
+    const int spawn_rc = ::posix_spawnp(&pid, cargv[0], &actions, nullptr, cargv.data(), environ);
+    posix_spawn_file_actions_destroy(&actions);
+    ::close(fds[1]);
+
+    if(spawn_rc != 0){
+        ::close(fds[0]);
+        throw std::runtime_error(
+            fmt::format("aiter: failed to run \"{}\": {}", argv[0], std::strerror(spawn_rc)));
+    }
+
+    std::string output;
+    std::array<char, 4096> buffer{};
+    ssize_t nread;
+    while((nread = ::read(fds[0], buffer.data(), buffer.size())) > 0){
+        output.append(buffer.data(), static_cast<size_t>(nread));
+    }
+    ::close(fds[0]);
+
+    int status = 0;
+    while(::waitpid(pid, &status, 0) < 0 && errno == EINTR){
+    }
+    return {output, WIFEXITED(status) ? WEXITSTATUS(status) : -1};
 }
 
+// Invokes "python3 -m <module> --<key>=<value> ...".
+__inline__ void run_codegen(const std::string& module,
+                            const std::vector<std::pair<std::string, std::string>>& options){
+#if !AITER_ENABLE_JIT
+    (void)options;
+    throw std::runtime_error(
+        fmt::format("aiter: no prebuilt library for \"{}\" and JIT is disabled "
+                    "(built with AITER_ENABLE_JIT=0)", module));
+#else
+    if(!is_safe_module(module)){
+        throw std::invalid_argument("aiter: invalid codegen module name");
+    }
+
+    std::vector<std::string> argv{"python3", "-m", module};
+    argv.reserve(options.size() + 3);
+    for(const auto& [key, value] : options){
+        argv.push_back(fmt::format("--{}={}",
+                                   check_token(key, "codegen option name"),
+                                   check_token(value, "codegen option value")));
+    }
+
+    AITER_LOG_INFO(fmt::format("{}", fmt::join(argv, " ")));
+    const auto [output, exit_code] = execute_argv(argv);
+    AITER_LOG_INFO(output);
+    if(exit_code != 0){
+        throw std::runtime_error(
+            fmt::format("aiter: codegen for \"{}\" failed with exit code {}", module, exit_code));
+    }
+#endif
+}
 
 class SharedLibrary {
 private:
     void* handle;
 
 public:
-    SharedLibrary(std::string& path) {
+    SharedLibrary(const std::string& path) {
         handle = dlopen(path.c_str(), RTLD_LAZY);
         if (!handle) {
             throw std::runtime_error(dlerror());
@@ -117,11 +267,52 @@ public:
 
     // Template to call function with any return type and arguments
     template<typename ReturnType = void, typename... Args>
-    ReturnType call(std::string& func_name, Args... args) {
+    ReturnType call(const std::string& func_name, Args... args) {
         auto func = reinterpret_cast<ReturnType(*)(Args...)>(getRawFunction(func_name.c_str()));
         return func(std::forward<Args>(args)...);
     }
 };
+
+// Resolves <base>/<folder>/lib.so and proves the result is still under <base>
+// after symlinks are resolved. Containment is compared component-wise; a string
+// prefix test would accept a sibling such as "<base>-attacker".
+__inline__ std::filesystem::path resolve_lib_path(const std::filesystem::path& base,
+                                                  const std::string& folder){
+    check_token(folder, "folder");
+
+    std::error_code ec;
+    const auto base_canon = std::filesystem::weakly_canonical(base, ec);
+    if(ec){
+        throw std::runtime_error(fmt::format("aiter: cannot resolve \"{}\"", base.string()));
+    }
+    const auto full = std::filesystem::weakly_canonical(base_canon / folder / "lib.so", ec);
+    if(ec){
+        throw std::runtime_error(fmt::format("aiter: cannot resolve a library under \"{}\"",
+                                             base_canon.string()));
+    }
+
+    const auto mismatched =
+        std::mismatch(base_canon.begin(), base_canon.end(), full.begin(), full.end());
+    if(mismatched.first != base_canon.end()){
+        throw std::runtime_error(
+            fmt::format("aiter: refusing to load a library outside \"{}\"", base_canon.string()));
+    }
+    return full;
+}
+
+// Prefers a read-only packaged library over the per-user JIT cache.
+__inline__ std::filesystem::path resolve_lib(const std::string& folder){
+#ifdef AITER_INSTALL_LIBDIR
+    {
+        std::error_code ec;
+        auto packaged = resolve_lib_path(AITER_INSTALL_LIBDIR, folder);
+        if(std::filesystem::exists(packaged, ec)){
+            return packaged;
+        }
+    }
+#endif
+    return resolve_lib_path(get_build_dir(), folder);
+}
 
 static std::unique_ptr<LRUCache<std::string, std::shared_ptr<SharedLibrary>>> libs;
 static std::unique_ptr<LRUCache<std::string, std::string>> func_names;
@@ -131,8 +322,9 @@ __inline__ void run_lib(std::string func_name, std::string folder, Args... args)
     std::call_once(init_libs_lru_cache, init_lru_cache<std::string, std::shared_ptr<SharedLibrary>>, libs);
     auto func_lib = libs->get(func_name);
     if(!func_lib){
-        std::string lib_path = (get_root_dir()/"build"/folder/"lib.so").string();
-        libs->put(func_name, std::make_shared<SharedLibrary>(lib_path));
+        const auto lib_path = resolve_lib(folder);
+        check_trusted_file(lib_path);
+        libs->put(func_name, std::make_shared<SharedLibrary>(lib_path.string()));
         func_lib = libs->get(func_name);
     }
     (*func_lib)->call(func_name, std::forward<Args>(args)...);
@@ -172,6 +364,20 @@ __inline__ std::string get_default_func_name(const std::string& md_name, std::li
 
 
 __inline__ bool not_built(const std::string& folder) {
-    return !std::filesystem::exists(get_root_dir() / "build" / folder / "lib.so");
+    std::error_code ec;
+#ifdef AITER_INSTALL_LIBDIR
+    if(std::filesystem::exists(resolve_lib_path(AITER_INSTALL_LIBDIR, folder), ec)){
+        return false;
+    }
+#endif
+#if !AITER_ENABLE_JIT
+    // Nothing packaged, and there is no cache to consult; let the caller's
+    // codegen path report that JIT is disabled.
+    (void)ec;
+    check_token(folder, "folder");
+    return true;
+#else
+    return !std::filesystem::exists(resolve_lib_path(get_build_dir(), folder), ec);
+#endif
 }
 }


### PR DESCRIPTION
## Summary

`csrc/cpp_itfs/utils.h` builds a shell command string and `popen()`s it, then
`dlopen()`s the resulting `$HOME/.aiter/build/<folder>/lib.so`. Neither the
command arguments nor `<folder>` are validated, and the loaded library's
ownership and permissions are never checked.

This is the torch-free C++ interface used by embedders (vLLM, SGLang), so the
values flowing into these paths come from the calling application rather than
from AITER's own Python layer. That makes the lack of validation worth fixing
even though the current in-tree callers only pass safe values.

Addresses SWSPLAT-23900

## What this changes

**1. No shell.** `execute_cmd()` (both overloads) is replaced by
`execute_argv()`, which uses `posix_spawnp()` with an explicit `argv[]`. There
is no `/bin/sh` in the chain, so no argument can be reinterpreted as a
metacharacter regardless of its contents. Callers now use a small
`run_codegen(module, {{key, value}, ...})` wrapper instead of formatting a
command line.

**2. Argument allowlist.** Every codegen option name and value must match
`[A-Za-z0-9_-]{1,64}`; the module name must be a dotted identifier with no
`..`. This is not a restriction in practice — the values are dtype spellings
from a closed map (`__hip_bfloat16`, `_Float16`, `uint8_t`,
`__hip_fp8_e4m3_fnuz`, ...), integers, booleans, and an MD5-derived function
name.

**3. Constrained library path.** `resolve_lib_path()` validates `<folder>`,
canonicalises the result, and verifies containment **component-wise** with
`std::mismatch` over path iterators. A string-prefix test would wrongly accept
a sibling directory such as `<base>-attacker`; comparing components does not.
Previously a caller-supplied `folder` containing `../` gave a direct arbitrary
`dlopen()`.

**4. Trusted-file check before `dlopen()`.** `check_trusted_file()` refuses
symlinks, files owned by another unprivileged user, and files writable by group
or other. `check_trusted_dir()` applies the same rule to the cache root.

There is an unavoidable window between `not_built()` and `dlopen()`. Rather
than reach for fd-based loading via `/proc/self/fd` (fragile, and it changes
how the loader resolves `DT_NEEDED`), this closes the race by making it
unwinnable: an attacker who cannot write into a directory we own, and cannot
present a file we would accept, has nothing to swap in.

**5. Environment handling.** `init_root_dir()` ignores `AITER_ROOT_DIR` and
`HOME` when `geteuid() != getuid()` or `getegid() != getgid()`, so a
setuid/setgid process does not take its library search root from its invoker's
environment. It also throws a clear error when no root can be determined —
previously an unset `HOME` produced a null pointer dereference.

To be explicit about scope: for an ordinary same-UID process, control over
`$HOME` is **not** a privilege boundary — anyone who can set it can also edit
`~/.bashrc` or `LD_PRELOAD`. The boundaries this actually defends are
co-tenancy, foreign file ownership, and setuid execution.

**6. Build-time opt-out.** Two new options for packagers:

- `-DAITER_ENABLE_JIT=0` compiles out the runtime codegen path entirely;
  `run_codegen()` then throws instead of spawning anything.
- `-DAITER_INSTALL_LIBDIR=<prefix>` makes the loader prefer a read-only
  packaged library over the per-user JIT cache.

A distribution that ships prebuilt kernels can set both and remove the
`popen`/`dlopen`-a-freshly-built-`.so` behaviour from its binaries.

## Callers

`mla/asm_mla_decode_fwd.cpp` and `pa/pa_ragged.cpp` are updated to
`run_codegen()`. They are the only C++ consumers of this header; the Python
path uses the separate `csrc/cpp_itfs/utils.py` and is untouched.

## Not in scope

- `csrc/cpp_itfs/utils.py` still uses `subprocess(..., shell=True)` in several
  places, including an `rm -rf {BUILD_DIR}/*` at import time. Separate fix.
- `csrc/include/aiter_hip_common.h` loads `$AITER_ASM_DIR/<arch>/<hsaco>`
  without canonicalisation. Separate fix.

## Behaviour changes to be aware of

- **Group-writable JIT artifacts are now refused.** This follows the OpenSSH
  `StrictModes` convention, but a site running `umask 002` will produce mode
  `0664` libraries and hit a hard error. Happy to downgrade group-write to a
  warning (keeping world-write fatal) if maintainers prefer.
- Codegen failure now raises instead of being silently ignored — the previous
  code discarded the exit status, so a failed build surfaced later as a
  confusing `dlopen` error.
- An unset `HOME` with no `AITER_ROOT_DIR` now throws instead of invoking
  undefined behaviour.

## Test plan

- [ ] Build `csrc/cpp_itfs` and confirm both callers compile.
- [ ] `pa_ragged_test.cpp` and the MLA decode test: cold cache (triggers
      codegen) and warm cache (loads existing `lib.so`).
- [ ] Verify a `folder` containing `../` is rejected rather than loaded.
- [ ] Verify a group-writable `lib.so` is refused.
- [ ] Build once with `-DAITER_ENABLE_JIT=0` and confirm the codegen path is
      absent from the binary.

> Opened as a draft: I have not been able to compile this locally, so every box
> above is still unticked.
