### PR TITLE
[feat] Reuse GDN prefill metadata

### DIFF
--- a/aiter/ops/chunk_gated_delta_rule_fwd_h.py
+++ b/aiter/ops/chunk_gated_delta_rule_fwd_h.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Optional
 
@@ -9,6 +10,10 @@ import triton
 from torch import Tensor
 
 from ..jit.core import compile_ops
+from .triton._triton_kernels.gated_delta_rule.utils.prefill_metadata import (
+    GatedDeltaRulePrefillMetadata,
+    build_gated_delta_rule_prefill_metadata,
+)
 
 MD_NAME = "module_chunk_gdr_fwd_h"
 RCP_LN2 = 1.4426950408889634
@@ -76,18 +81,15 @@ def _select_bv(
     return bv
 
 
-def _select_bv_for_dense(
-    batch_size: int, seq_len: int, chunk_size: int, num_heads: int, device: torch.device
-) -> int:
-    nt = (seq_len + chunk_size - 1) // chunk_size
-    return _select_bv(device, num_heads, batch_size * nt, nt)
+def _get_varlen_host_metadata(chunk_offsets: torch.Tensor) -> tuple[int, int]:
+    """Return total and maximum per-sequence chunk counts.
 
-
-def _select_bv_for_varlen(chunk_offsets: torch.Tensor, num_heads: int) -> int:
+    Reading CUDA offsets requires one device-to-host transfer.
+    """
     offsets = chunk_offsets.tolist()
     total_chunks = offsets[-1]
     max_seq_chunks = max(offsets[i + 1] - offsets[i] for i in range(len(offsets) - 1))
-    return _select_bv(chunk_offsets.device, num_heads, total_chunks, max_seq_chunks)
+    return total_chunks, max_seq_chunks
 
 
 @compile_ops(MD_NAME, develop=True)
@@ -204,6 +206,10 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     state_dtype: Optional[torch.dtype] = None,
     use_exp2: bool = True,
     g_head_major: bool = False,
+    seq_lens_cpu: Sequence[int] | None = None,
+    prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
+    num_decodes: int = 0,
+    num_decode_tokens: int = 0,
 ) -> tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
     """
     HIP hidden-state forward with h layout [V, K].
@@ -217,6 +223,18 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     `g` is expected as a 3-D tensor in token-major [B, T, H] or
     head-major [B, H, T] layout according to `g_head_major`.
     use_exp2 selects whether cumulative gates are interpreted in log2 space.
+    In varlen mode, pass ``prefill_metadata`` (preferred for reuse) or
+    ``seq_lens_cpu`` to avoid reading chunk scheduling values back from the GPU.
+
+    State handling:
+      * Dense (default): ``initial_state`` is ``[N, H, V, K]`` (``slot == i_n``)
+        and ``final_state`` is a freshly allocated ``[N, H, V, K]`` tensor.
+      * Indexed pool: pass ``initial_state`` as the pool ``[pool_size, H, V, K]``
+        plus ``initial_state_indices`` ``[N]`` (int32); each sequence's slot is
+        gathered from the index array.
+      * ``inplace_final_state`` (default: ``True`` when ``initial_state_indices``
+        is given) writes the final state back into ``initial_state`` in place and
+        returns that same buffer as ``final_state`` (no extra allocation).
     """
     if chunk_size != 64:
         raise ValueError("HIP kernel requires chunk_size=64.")
@@ -231,6 +249,16 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     T_flat = w.shape[2]
     is_varlen = cu_seqlens is not None
     NT = triton.cdiv(T, chunk_size)
+
+    if is_varlen and prefill_metadata is None and seq_lens_cpu is not None:
+        prefill_metadata = build_gated_delta_rule_prefill_metadata(
+            seq_lens_cpu,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+        )
+
     has_indices = initial_state_indices is not None
     inplace = has_indices if inplace_final_state is None else inplace_final_state
     if inplace and initial_state is None:
@@ -257,25 +285,51 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     if is_varlen:
         from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
             prepare_chunk_offsets,
+            prepare_rebased_cu_seqlens,
         )
 
         assert B == 1, "Varlen mode expects B=1 (flattened input)."
-        cu_seqlens_int32 = cu_seqlens.to(torch.int32)
-        chunk_offsets_int32 = prepare_chunk_offsets(
-            cu_seqlens_int32, chunk_size
-        ).to(torch.int32)
+        if prefill_metadata is not None:
+            prefill_metadata.validate(
+                cu_seqlens=cu_seqlens,
+                chunk_size=chunk_size,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+                total_prefill_tokens=T_flat,
+                num_sequences=len(cu_seqlens) - 1,
+            )
+            schedule = prefill_metadata.get_chunk_schedule(
+                chunk_size,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+            )
+            cu_seqlens_int32 = schedule.kernel_cu_seqlens
+            chunk_offsets_int32 = schedule.chunk_offsets
+            N = schedule.n_prefill
+            total_chunks = schedule.total_chunks
+            max_seq_chunks = schedule.max_seq_chunks
+        else:
+            cu_seqlens_int32 = prepare_rebased_cu_seqlens(
+                cu_seqlens, num_decodes, num_decode_tokens
+            ).to(torch.int32)
+            chunk_offsets_int32 = prepare_chunk_offsets(
+                cu_seqlens, chunk_size, num_decodes, num_decode_tokens
+            ).to(torch.int32)
+            N = len(cu_seqlens_int32) - 1
+            total_chunks, max_seq_chunks = _get_varlen_host_metadata(
+                chunk_offsets_int32
+            )
     else:
         cu_seqlens_int32 = torch.empty(0, device=k.device, dtype=torch.int32)
         chunk_offsets_int32 = torch.arange(
             0, (B + 1) * NT, NT, dtype=torch.int32, device=k.device
         )
+        N = B
+        total_chunks = B * NT
+        max_seq_chunks = NT
 
-    N = int(cu_seqlens_int32.numel() - 1) if is_varlen else B
     if selected_bv is None:
-        if is_varlen and N != 1:
-            selected_bv = _select_bv_for_varlen(chunk_offsets_int32, H)
-        else:
-            selected_bv = _select_bv_for_dense(B, T_flat, chunk_size, H, k.device)
+        selected_bv = _select_bv(k.device, H, total_chunks, max_seq_chunks)
 
     if gk is not None:
         total_gk_tokens = T_flat if is_varlen else B * T_flat
@@ -292,9 +346,6 @@ def chunk_gated_delta_rule_fwd_h_hip_fn(
     else:
         gk_arg = torch.empty(0, device=k.device, dtype=torch.float32)
 
-    total_chunks = NT if is_varlen and N == 1 else (
-        int(chunk_offsets_int32[-1].item()) if is_varlen else B * NT
-    )
     h = torch.empty(
         (1, total_chunks, H, V, K) if is_varlen else (B, NT, H, V, K),
         device=k.device,

--- a/aiter/ops/prefill_batch_metadata.py
+++ b/aiter/ops/prefill_batch_metadata.py
@@ -1,0 +1,476 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Operator-specific metadata built from shared prefill batch primitives."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import torch
+
+__all__ = [
+    "CausalConvPrefillMetadata",
+    "ChunkGrid",
+    "GatedDeltaRuleChunkSchedule",
+    "GatedDeltaRulePrefillMetadata",
+    "PrefillBatchLayout",
+    "build_causal_conv_prefill_metadata",
+    "build_gated_delta_rule_prefill_metadata",
+]
+
+
+def _tensor_version(tensor: torch.Tensor) -> int | None:
+    try:
+        return tensor._version
+    except (AttributeError, RuntimeError):
+        return None
+
+
+def _normalize_seq_lens(
+    seq_lens_cpu: Sequence[int], cu_seqlens: torch.Tensor
+) -> tuple[int, ...]:
+    seq_lens = tuple(int(length) for length in seq_lens_cpu)
+    if not seq_lens:
+        raise ValueError("`seq_lens_cpu` must contain at least one sequence.")
+    if any(length < 0 for length in seq_lens):
+        raise ValueError("`seq_lens_cpu` must contain non-negative lengths.")
+    if cu_seqlens.dim() != 1:
+        raise ValueError(
+            "The cumulative sequence-length tensor must be one-dimensional."
+        )
+    if cu_seqlens.numel() != len(seq_lens) + 1:
+        raise ValueError(
+            f"The cumulative sequence-length tensor describes "
+            f"{cu_seqlens.numel() - 1} sequences, but `seq_lens_cpu` has "
+            f"{len(seq_lens)}."
+        )
+    return seq_lens
+
+
+def _host_cu_seqlens(seq_lens_cpu: Sequence[int]) -> list[int]:
+    cumulative = [0]
+    for length in seq_lens_cpu:
+        cumulative.append(cumulative[-1] + length)
+    return cumulative
+
+
+def _assert_layout_matches(
+    cu_seqlens: torch.Tensor, kernel_cu_seqlens: torch.Tensor
+) -> None:
+    message = "`seq_lens_cpu` does not match the cumulative sequence lengths."
+    expected = kernel_cu_seqlens.to(cu_seqlens.dtype)
+    matches = torch.all(cu_seqlens == expected)
+    assert_async = getattr(torch, "_assert_async", None)
+    if cu_seqlens.device.type == "cuda" and assert_async is not None:
+        assert_async(matches, message)
+    elif not bool(matches):
+        raise ValueError(message)
+
+
+def _normalize_layout(
+    seq_lens_cpu: Sequence[int],
+    cu_seqlens: torch.Tensor,
+    *,
+    kernel_cu_seqlens: torch.Tensor | None = None,
+) -> PrefillBatchLayout:
+    seq_lens = _normalize_seq_lens(seq_lens_cpu, cu_seqlens)
+    if kernel_cu_seqlens is None:
+        kernel_cu_seqlens = torch.tensor(
+            _host_cu_seqlens(seq_lens),
+            dtype=torch.int32,
+            device=cu_seqlens.device,
+        )
+    _assert_layout_matches(cu_seqlens, kernel_cu_seqlens)
+    return PrefillBatchLayout(
+        seq_lens_cpu=seq_lens,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_version=_tensor_version(cu_seqlens),
+        kernel_cu_seqlens=kernel_cu_seqlens,
+    )
+
+
+@dataclass(frozen=True)
+class PrefillBatchLayout:
+    """One sequence view used by an individual prefill operator.
+
+    Typed metadata is layout-specific and cannot be built or used while
+    HIP/CUDA graph capture is active.
+    """
+
+    seq_lens_cpu: tuple[int, ...]
+    cu_seqlens: torch.Tensor
+    cu_seqlens_version: int | None
+    kernel_cu_seqlens: torch.Tensor
+
+    def validate(
+        self,
+        cu_seqlens: torch.Tensor,
+        *,
+        total_tokens: int | None = None,
+        num_sequences: int | None = None,
+    ) -> None:
+        if (
+            cu_seqlens.device.type == "cuda"
+            and torch.cuda.is_current_stream_capturing()
+        ):
+            raise RuntimeError(
+                "Typed prefill metadata cannot be used during HIP/CUDA graph capture."
+            )
+        if self.cu_seqlens is not cu_seqlens:
+            raise ValueError(
+                "Prefill metadata is bound to the exact sequence-offset tensor "
+                "used to build it; reuse that tensor or rebuild the metadata."
+            )
+        if (
+            self.cu_seqlens_version is not None
+            and _tensor_version(cu_seqlens) != self.cu_seqlens_version
+        ):
+            raise ValueError(
+                "The sequence-offset tensor was modified after its metadata was "
+                "built; rebuild the metadata."
+            )
+        if num_sequences is not None and len(self.seq_lens_cpu) != num_sequences:
+            raise ValueError(
+                f"The metadata describes {len(self.seq_lens_cpu)} sequences, "
+                f"expected {num_sequences}."
+            )
+        if total_tokens is not None and sum(self.seq_lens_cpu) != total_tokens:
+            raise ValueError(
+                f"The metadata describes {sum(self.seq_lens_cpu)} tokens, "
+                f"expected {total_tokens}."
+            )
+
+
+@dataclass(frozen=True)
+class ChunkGrid:
+    """Generic flattened ``(sequence_id, chunk_id)`` launch grid."""
+
+    block_size: int
+    total_chunks: int
+    max_seq_chunks: int
+    chunk_counts: tuple[int, ...]
+    sequence_ids: torch.Tensor
+    chunk_ids: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CausalConvPrefillMetadata:
+    """Eager causal-conv schedules for one ``query_start_loc`` layout."""
+
+    layout: PrefillBatchLayout
+    chunk_grids: Mapping[int, ChunkGrid]
+
+    def get_chunk_grid(self, block_size: int) -> ChunkGrid:
+        try:
+            return self.chunk_grids[block_size]
+        except KeyError as error:
+            raise ValueError(
+                f"No causal-conv schedule was prebuilt for block size {block_size}. "
+                f"Available block sizes: {sorted(self.chunk_grids)}."
+            ) from error
+
+    def validate(
+        self,
+        query_start_loc: torch.Tensor,
+        *,
+        total_tokens: int,
+        num_sequences: int,
+    ) -> None:
+        self.layout.validate(
+            query_start_loc,
+            total_tokens=total_tokens,
+            num_sequences=num_sequences,
+        )
+
+
+@dataclass(frozen=True)
+class GatedDeltaRuleChunkSchedule:
+    """GDR launch grid plus hidden-state sequence offsets."""
+
+    chunk_size: int
+    num_decodes: int
+    num_decode_tokens: int
+    n_prefill: int
+    total_prefill_tokens: int
+    grid: ChunkGrid
+    chunk_offsets: torch.Tensor
+    kernel_cu_seqlens: torch.Tensor
+
+    @property
+    def total_chunks(self) -> int:
+        return self.grid.total_chunks
+
+    @property
+    def max_seq_chunks(self) -> int:
+        return self.grid.max_seq_chunks
+
+    @property
+    def sequence_ids(self) -> torch.Tensor:
+        return self.grid.sequence_ids
+
+    @property
+    def chunk_ids(self) -> torch.Tensor:
+        return self.grid.chunk_ids
+
+
+@dataclass(frozen=True)
+class GatedDeltaRulePrefillMetadata:
+    """Reusable, eagerly built metadata shared by GDR K1--K6."""
+
+    layout: PrefillBatchLayout
+    schedule: GatedDeltaRuleChunkSchedule
+
+    def get_chunk_schedule(
+        self,
+        chunk_size: int,
+        *,
+        num_decodes: int = 0,
+        num_decode_tokens: int = 0,
+    ) -> GatedDeltaRuleChunkSchedule:
+        schedule = self.schedule
+        if (
+            chunk_size != schedule.chunk_size
+            or num_decodes != schedule.num_decodes
+            or num_decode_tokens != schedule.num_decode_tokens
+        ):
+            raise ValueError(
+                "The GDR metadata was built with "
+                f"chunk_size={schedule.chunk_size}, "
+                f"num_decodes={schedule.num_decodes}, and "
+                f"num_decode_tokens={schedule.num_decode_tokens}, but the call "
+                f"requested chunk_size={chunk_size}, num_decodes={num_decodes}, "
+                f"and num_decode_tokens={num_decode_tokens}; rebuild the metadata "
+                "for the requested schedule."
+            )
+        return schedule
+
+    def validate(
+        self,
+        *,
+        cu_seqlens: torch.Tensor,
+        chunk_size: int,
+        num_decodes: int,
+        num_decode_tokens: int,
+        total_prefill_tokens: int | None = None,
+        num_sequences: int | None = None,
+    ) -> None:
+        self.layout.validate(cu_seqlens, num_sequences=num_sequences)
+        schedule = self.get_chunk_schedule(
+            chunk_size,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+        )
+        if (
+            total_prefill_tokens is not None
+            and schedule.total_prefill_tokens != total_prefill_tokens
+        ):
+            raise ValueError(
+                f"The GDR metadata describes {schedule.total_prefill_tokens} "
+                f"prefill tokens, expected {total_prefill_tokens}."
+            )
+
+
+def _chunk_counts(
+    seq_lens_cpu: Sequence[int], block_size: int
+) -> tuple[tuple[int, ...], int, int]:
+    if block_size <= 0:
+        raise ValueError(f"`block_size` must be positive, got {block_size}.")
+    counts = tuple((length + block_size - 1) // block_size for length in seq_lens_cpu)
+    return counts, sum(counts), max(counts)
+
+
+def _build_chunk_grid(
+    seq_lens_cpu: Sequence[int],
+    *,
+    block_size: int,
+    device: torch.device,
+) -> ChunkGrid:
+    counts, total_chunks, max_seq_chunks = _chunk_counts(seq_lens_cpu, block_size)
+    sequence_ids_cpu: list[int] = []
+    chunk_ids_cpu: list[int] = []
+    for sequence_id, num_chunks in enumerate(counts):
+        sequence_ids_cpu.extend([sequence_id] * num_chunks)
+        chunk_ids_cpu.extend(range(num_chunks))
+
+    packed = torch.tensor(
+        sequence_ids_cpu + chunk_ids_cpu,
+        dtype=torch.int32,
+        device=device,
+    )
+    return ChunkGrid(
+        block_size=block_size,
+        total_chunks=total_chunks,
+        max_seq_chunks=max_seq_chunks,
+        chunk_counts=counts,
+        sequence_ids=packed[:total_chunks],
+        chunk_ids=packed[total_chunks:],
+    )
+
+
+def build_causal_conv_prefill_metadata(
+    seq_lens_cpu: Sequence[int],
+    *,
+    query_start_loc: torch.Tensor,
+    block_sizes: Sequence[int] = (8, 16, 32, 64),
+    shared_chunk_grids: Mapping[int, ChunkGrid] | None = None,
+) -> CausalConvPrefillMetadata:
+    """Eagerly build causal-conv schedules outside the forward hot path."""
+    if (
+        query_start_loc.device.type == "cuda"
+        and torch.cuda.is_current_stream_capturing()
+    ):
+        raise RuntimeError(
+            "Causal-conv metadata cannot be built during HIP/CUDA graph capture."
+        )
+    layout = _normalize_layout(seq_lens_cpu, query_start_loc)
+    grids = dict(shared_chunk_grids or {})
+    for block_size, existing in grids.items():
+        counts, total_chunks, max_seq_chunks = _chunk_counts(
+            layout.seq_lens_cpu, block_size
+        )
+        mismatches = []
+        if existing.block_size != block_size:
+            mismatches.append(
+                f"block_size={existing.block_size}, expected {block_size}"
+            )
+        if existing.chunk_counts != counts:
+            mismatches.append("chunk_counts differ")
+        if existing.total_chunks != total_chunks:
+            mismatches.append(
+                f"total_chunks={existing.total_chunks}, expected {total_chunks}"
+            )
+        if existing.max_seq_chunks != max_seq_chunks:
+            mismatches.append(
+                f"max_seq_chunks={existing.max_seq_chunks}, "
+                f"expected {max_seq_chunks}"
+            )
+        if existing.sequence_ids.device != query_start_loc.device:
+            mismatches.append(
+                f"sequence_ids.device={existing.sequence_ids.device}, "
+                f"expected {query_start_loc.device}"
+            )
+        if existing.chunk_ids.device != query_start_loc.device:
+            mismatches.append(
+                f"chunk_ids.device={existing.chunk_ids.device}, "
+                f"expected {query_start_loc.device}"
+            )
+        if existing.sequence_ids.dtype != torch.int32:
+            mismatches.append(
+                f"sequence_ids.dtype={existing.sequence_ids.dtype}, "
+                "expected torch.int32"
+            )
+        if existing.chunk_ids.dtype != torch.int32:
+            mismatches.append(
+                f"chunk_ids.dtype={existing.chunk_ids.dtype}, expected torch.int32"
+            )
+        if existing.sequence_ids.numel() != total_chunks:
+            mismatches.append(
+                f"sequence_ids.numel()={existing.sequence_ids.numel()}, "
+                f"expected {total_chunks}"
+            )
+        if existing.chunk_ids.numel() != total_chunks:
+            mismatches.append(
+                f"chunk_ids.numel()={existing.chunk_ids.numel()}, "
+                f"expected {total_chunks}"
+            )
+        if mismatches:
+            raise ValueError(
+                f"The shared chunk grid for block size {block_size} does not "
+                f"match the causal-conv sequence layout: {'; '.join(mismatches)}. "
+                "Omit it or rebuild it for this layout and device."
+            )
+    for block_size in dict.fromkeys(int(size) for size in block_sizes):
+        existing = grids.get(block_size)
+        if existing is not None:
+            continue
+        grids[block_size] = _build_chunk_grid(
+            layout.seq_lens_cpu,
+            block_size=block_size,
+            device=query_start_loc.device,
+        )
+    return CausalConvPrefillMetadata(
+        layout=layout,
+        chunk_grids=MappingProxyType(grids),
+    )
+
+
+def build_gated_delta_rule_prefill_metadata(
+    seq_lens_cpu: Sequence[int],
+    *,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int = 64,
+    num_decodes: int = 0,
+    num_decode_tokens: int = 0,
+) -> GatedDeltaRulePrefillMetadata:
+    """Build reusable GDR prefill metadata on the ``cu_seqlens`` device."""
+    if cu_seqlens.device.type == "cuda" and torch.cuda.is_current_stream_capturing():
+        raise RuntimeError(
+            "GDR metadata cannot be built during HIP/CUDA graph capture."
+        )
+    normalized_seq_lens = _normalize_seq_lens(seq_lens_cpu, cu_seqlens)
+    if not 0 <= num_decodes < len(normalized_seq_lens):
+        raise ValueError(
+            f"`num_decodes` must be in [0, {len(normalized_seq_lens) - 1}], "
+            f"got {num_decodes}."
+        )
+    expected_decode_tokens = sum(normalized_seq_lens[:num_decodes])
+    if expected_decode_tokens != num_decode_tokens:
+        raise ValueError(
+            "`num_decode_tokens` must equal the sum of the leading decode "
+            f"sequence lengths: expected {expected_decode_tokens}, "
+            f"got {num_decode_tokens}."
+        )
+
+    prefill_lens = normalized_seq_lens[num_decodes:]
+    counts, total_chunks, max_seq_chunks = _chunk_counts(prefill_lens, chunk_size)
+    sequence_ids_cpu: list[int] = []
+    chunk_ids_cpu: list[int] = []
+    chunk_offsets_cpu = [0]
+    kernel_cu_seqlens_cpu = [0]
+    for sequence_id, (length, num_chunks) in enumerate(
+        zip(prefill_lens, counts, strict=True)
+    ):
+        sequence_ids_cpu.extend([sequence_id] * num_chunks)
+        chunk_ids_cpu.extend(range(num_chunks))
+        chunk_offsets_cpu.append(chunk_offsets_cpu[-1] + num_chunks)
+        kernel_cu_seqlens_cpu.append(kernel_cu_seqlens_cpu[-1] + length)
+
+    packed = torch.tensor(
+        sequence_ids_cpu
+        + chunk_ids_cpu
+        + chunk_offsets_cpu
+        + _host_cu_seqlens(normalized_seq_lens)
+        + kernel_cu_seqlens_cpu,
+        dtype=torch.int32,
+        device=cu_seqlens.device,
+    )
+    chunk_ids_end = 2 * total_chunks
+    offsets_end = chunk_ids_end + len(chunk_offsets_cpu)
+    source_cu_end = offsets_end + len(normalized_seq_lens) + 1
+    grid = ChunkGrid(
+        block_size=chunk_size,
+        total_chunks=total_chunks,
+        max_seq_chunks=max_seq_chunks,
+        chunk_counts=counts,
+        sequence_ids=packed[:total_chunks],
+        chunk_ids=packed[total_chunks:chunk_ids_end],
+    )
+    layout = _normalize_layout(
+        normalized_seq_lens,
+        cu_seqlens,
+        kernel_cu_seqlens=packed[offsets_end:source_cu_end],
+    )
+    schedule = GatedDeltaRuleChunkSchedule(
+        chunk_size=chunk_size,
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decode_tokens,
+        n_prefill=len(prefill_lens),
+        total_prefill_tokens=sum(prefill_lens),
+        grid=grid,
+        chunk_offsets=packed[chunk_ids_end:offsets_end],
+        kernel_cu_seqlens=packed[source_cu_end:],
+    )
+    return GatedDeltaRulePrefillMetadata(layout=layout, schedule=schedule)

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk.py
@@ -9,6 +9,8 @@ This module implements the chunk-based parallel computation for the gated delta 
 Note: Only forward pass is implemented. Backward pass is not supported in aiter.
 """
 
+from collections.abc import Sequence
+
 import torch
 
 from .chunk_delta_h import (
@@ -20,6 +22,8 @@ from .chunk_o import chunk_fwd_o, chunk_fwd_o_opt, chunk_fwd_o_opt_vk
 from .fused_cumsum_kkt import fused_chunk_local_cumsum_scaled_dot_kkt_fwd
 from .fused_solve_tril_recompute import fused_solve_tril_recompute_w_u
 from ..utils import (
+    GatedDeltaRulePrefillMetadata,
+    build_gated_delta_rule_prefill_metadata,
     chunk_local_cumsum,
     chunk_scaled_dot_kkt_fwd,
     recompute_w_u_fwd,
@@ -27,9 +31,9 @@ from ..utils import (
 )
 
 
-def _is_gfx12_runtime() -> bool:
+def _is_gfx12_runtime(device: torch.device) -> bool:
     try:
-        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        props = torch.cuda.get_device_properties(device)
         arch = getattr(props, "gcnArchName", "")
         return arch.split(":")[0].startswith("gfx12") if arch else False
     except Exception:
@@ -231,6 +235,8 @@ def chunk_gated_delta_rule_fwd_opt_vk(
     o: torch.Tensor | None = None,
     num_decodes: int = 0,
     num_decode_tokens: int = 0,
+    seq_lens_cpu: Sequence[int] | None = None,
+    prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
 ):
     """
     Optimized chunk gated delta rule forward with h layout [V, K].
@@ -269,6 +275,10 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             prepare_rebased_cu_seqlens) key on the original cu_seqlens identity,
             so chunk-index / offset builds stay cache-warm across forwards
             (no per-forward .tolist() D2H).
+        seq_lens_cpu: Host-resident original sequence lengths. Builds one
+            shared K1--K6 schedule without device readback.
+        prefill_metadata: Prebuilt reusable host/device schedule. This is the
+            preferred path when multiple layers process the same batch.
 
     Returns:
         tuple: (g_cumsum, o, final_state) where:
@@ -283,7 +293,23 @@ def chunk_gated_delta_rule_fwd_opt_vk(
         )
     if initial_state_indices is not None and use_chunk_flydsl:
         use_chunk_flydsl = False
-    if use_chunk_hip and (_is_gfx12_runtime() or num_decodes > 0):
+    if cu_seqlens is None:
+        if seq_lens_cpu is not None or prefill_metadata is not None:
+            raise ValueError(
+                "`seq_lens_cpu` and `prefill_metadata` require `cu_seqlens`."
+            )
+    elif prefill_metadata is None and seq_lens_cpu is not None:
+        prefill_metadata = build_gated_delta_rule_prefill_metadata(
+            seq_lens_cpu,
+            cu_seqlens=cu_seqlens,
+            chunk_size=64,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+        )
+
+    if use_chunk_hip and (
+        _is_gfx12_runtime(q.device) or (num_decodes > 0 and prefill_metadata is None)
+    ):
         use_chunk_hip = False
 
     g_cumsum, A_raw = fused_chunk_local_cumsum_scaled_dot_kkt_fwd(
@@ -294,6 +320,7 @@ def chunk_gated_delta_rule_fwd_opt_vk(
         use_exp2=use_exp2,
         num_decodes=num_decodes,
         num_decode_tokens=num_decode_tokens,
+        prefill_metadata=prefill_metadata,
     )
 
     w, u = fused_solve_tril_recompute_w_u(
@@ -306,6 +333,7 @@ def chunk_gated_delta_rule_fwd_opt_vk(
         use_exp2=use_exp2,
         num_decodes=num_decodes,
         num_decode_tokens=num_decode_tokens,
+        prefill_metadata=prefill_metadata,
     )
 
     if use_chunk_hip:
@@ -326,6 +354,9 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             state_dtype=state_dtype,
             use_exp2=use_exp2,
             g_head_major=True,
+            prefill_metadata=prefill_metadata,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
         )
     elif use_chunk_flydsl:
         # FlyDSL K5 wrapper expects ``g`` in head-major [B, H, T] layout
@@ -348,6 +379,7 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             use_exp2=use_exp2,
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,
+            prefill_metadata=prefill_metadata,
         )
     else:
         h, v_new, final_state = chunk_gated_delta_rule_fwd_h_opt_vk(
@@ -364,6 +396,7 @@ def chunk_gated_delta_rule_fwd_opt_vk(
             state_dtype=state_dtype,
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,
+            prefill_metadata=prefill_metadata,
         )
 
     if o is None:
@@ -382,6 +415,7 @@ def chunk_gated_delta_rule_fwd_opt_vk(
         use_exp2=use_exp2,
         num_decodes=num_decodes,
         num_decode_tokens=num_decode_tokens,
+        prefill_metadata=prefill_metadata,
     )
 
     return g_cumsum, o, final_state

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
@@ -15,6 +15,7 @@ import triton
 import triton.language as tl
 
 from ..utils import (
+    GatedDeltaRulePrefillMetadata,
     prepare_chunk_indices,
     prepare_chunk_offsets,
     prepare_rebased_cu_seqlens,
@@ -1299,6 +1300,7 @@ def chunk_gated_delta_rule_fwd_h_opt_vk(
     num_decodes: int = 0,
     num_decode_tokens: int = 0,
     inplace_final_state: bool | None = None,
+    prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     """
     Optimized hidden state forward with h layout [V, K].
@@ -1326,22 +1328,41 @@ def chunk_gated_delta_rule_fwd_h_opt_vk(
     T_flat = w.shape[2]
 
     if cu_seqlens is not None:
-        # Pass the ORIGINAL (cache-stable) cu_seqlens + decode ints into the
-        # cached prologue helpers so chunk_indices / chunk_offsets are built
-        # once per (cu_seqlens_id, BT, num_decodes, num_decode_tokens) tuple
-        # (no per-forward .tolist() D2H). The kernel walks the pre-sliced
-        # prefill data via the rebased cu_seqlens.
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, chunk_size, num_decodes, num_decode_tokens
-        )
-        chunk_offsets = prepare_chunk_offsets(
-            cu_seqlens, BT, num_decodes, num_decode_tokens
-        )
-        kernel_cu_seqlens = prepare_rebased_cu_seqlens(
-            cu_seqlens, num_decodes, num_decode_tokens
-        )
+        if prefill_metadata is not None:
+            prefill_metadata.validate(
+                cu_seqlens=cu_seqlens,
+                chunk_size=BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+                total_prefill_tokens=T,
+                num_sequences=len(cu_seqlens) - 1,
+            )
+            schedule = prefill_metadata.get_chunk_schedule(
+                BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+            )
+            chunk_indices = schedule.sequence_ids
+            chunk_offsets = schedule.chunk_offsets
+            kernel_cu_seqlens = schedule.kernel_cu_seqlens
+        else:
+            # Pass the ORIGINAL (cache-stable) cu_seqlens + decode ints into the
+            # cached prologue helpers so repeated calls avoid host synchronization.
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens, chunk_size, num_decodes, num_decode_tokens
+            )
+            chunk_offsets = prepare_chunk_offsets(
+                cu_seqlens, BT, num_decodes, num_decode_tokens
+            )
+            kernel_cu_seqlens = prepare_rebased_cu_seqlens(
+                cu_seqlens, num_decodes, num_decode_tokens
+            )
         N = len(kernel_cu_seqlens) - 1
-        NT = len(chunk_indices)
+        NT = (
+            schedule.total_chunks
+            if prefill_metadata is not None
+            else len(chunk_indices)
+        )
     else:
         N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
         kernel_cu_seqlens = None

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_o.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_o.py
@@ -18,7 +18,11 @@ from ..gated_delta_rule_utils import (
     check_shared_mem,
     gated_delta_rule_autotune_configs,
 )
-from ..utils import prepare_chunk_indices, prepare_rebased_cu_seqlens
+from ..utils import (
+    GatedDeltaRulePrefillMetadata,
+    prepare_chunk_indices,
+    prepare_rebased_cu_seqlens,
+)
 from ..utils.op import exp
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
@@ -847,7 +851,8 @@ def chunk_fwd_kernel_o_opt_vk(
     g,
     o,
     cu_seqlens,
-    chunk_indices,
+    sequence_ids,
+    chunk_ids,
     scale,
     T,
     T_flat,
@@ -860,6 +865,7 @@ def chunk_fwd_kernel_o_opt_vk(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    INDEX_STRIDE: tl.constexpr,
     USE_EXP2: tl.constexpr = False,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -868,8 +874,8 @@ def chunk_fwd_kernel_o_opt_vk(
     if IS_VARLEN:
         i_tg = i_t
         i_n, i_t = (
-            tl.load(chunk_indices + i_t * 2).to(tl.int32),
-            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+            tl.load(sequence_ids + i_t * INDEX_STRIDE).to(tl.int32),
+            tl.load(chunk_ids + i_t * INDEX_STRIDE).to(tl.int32),
         )
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int32),
@@ -956,6 +962,7 @@ def chunk_fwd_o_opt_vk(
     use_exp2: bool = True,
     num_decodes: int = 0,
     num_decode_tokens: int = 0,
+    prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
 ) -> torch.Tensor:
     """
     Optimized output forward with h layout [V, K].
@@ -983,16 +990,41 @@ def chunk_fwd_o_opt_vk(
     # (cached, no per-forward D2H); the kernel walks pre-sliced prefill data
     # via the rebased cu_seqlens.
     if cu_seqlens is not None:
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, BT, num_decodes, num_decode_tokens
-        )
-        kernel_cu_seqlens = prepare_rebased_cu_seqlens(
-            cu_seqlens, num_decodes, num_decode_tokens
-        )
+        if prefill_metadata is not None:
+            prefill_metadata.validate(
+                cu_seqlens=cu_seqlens,
+                chunk_size=BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+                total_prefill_tokens=T,
+                num_sequences=len(cu_seqlens) - 1,
+            )
+            schedule = prefill_metadata.get_chunk_schedule(
+                BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+            )
+            sequence_ids = schedule.sequence_ids
+            chunk_ids = schedule.chunk_ids
+            kernel_cu_seqlens = schedule.kernel_cu_seqlens
+            index_stride = 1
+        else:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens, BT, num_decodes, num_decode_tokens
+            )
+            flat_chunk_indices = chunk_indices.reshape(-1)
+            sequence_ids = flat_chunk_indices
+            chunk_ids = flat_chunk_indices[1:]
+            kernel_cu_seqlens = prepare_rebased_cu_seqlens(
+                cu_seqlens, num_decodes, num_decode_tokens
+            )
+            index_stride = 2
     else:
-        chunk_indices = None
+        sequence_ids = None
+        chunk_ids = None
         kernel_cu_seqlens = None
-    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+        index_stride = 1
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(sequence_ids) // index_stride
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
@@ -1009,7 +1041,8 @@ def chunk_fwd_o_opt_vk(
         g=g,
         o=o,
         cu_seqlens=kernel_cu_seqlens,
-        chunk_indices=chunk_indices,
+        sequence_ids=sequence_ids,
+        chunk_ids=chunk_ids,
         scale=scale,
         T=T,
         T_flat=T_flat,
@@ -1018,6 +1051,7 @@ def chunk_fwd_o_opt_vk(
         K=K,
         V=V,
         BT=BT,
+        INDEX_STRIDE=index_stride,
         USE_EXP2=use_exp2,
     )
     return o

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_cumsum_kkt.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_cumsum_kkt.py
@@ -8,7 +8,11 @@ from ..gated_delta_rule_utils import (
     autotune_cache_kwargs,
     gated_delta_rule_autotune_configs,
 )
-from ..utils import prepare_chunk_indices, prepare_rebased_cu_seqlens
+from ..utils import (
+    GatedDeltaRulePrefillMetadata,
+    prepare_chunk_indices,
+    prepare_rebased_cu_seqlens,
+)
 from ..utils.op import exp
 
 
@@ -179,7 +183,8 @@ def fused_chunk_local_cumsum_scaled_dot_kkt_fwd_kernel(
     g_cumsum_out,
     A_out,
     cu_seqlens,
-    chunk_indices,
+    sequence_ids,
+    chunk_ids,
     T,
     H: tl.constexpr,
     Hg: tl.constexpr,
@@ -187,6 +192,7 @@ def fused_chunk_local_cumsum_scaled_dot_kkt_fwd_kernel(
     BT: tl.constexpr,
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    INDEX_STRIDE: tl.constexpr,
     USE_EXP2: tl.constexpr = False,
     G_SCALE: tl.constexpr = 1.0,
 ):
@@ -195,8 +201,8 @@ def fused_chunk_local_cumsum_scaled_dot_kkt_fwd_kernel(
     T_flat = T
     if IS_VARLEN:
         i_n, i_t = (
-            tl.load(chunk_indices + i_t * 2).to(tl.int32),
-            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+            tl.load(sequence_ids + i_t * INDEX_STRIDE).to(tl.int32),
+            tl.load(chunk_ids + i_t * INDEX_STRIDE).to(tl.int32),
         )
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int32),
@@ -276,6 +282,7 @@ def fused_chunk_local_cumsum_scaled_dot_kkt_fwd(
     use_exp2: bool = True,
     num_decodes: int = 0,
     num_decode_tokens: int = 0,
+    prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Fused cumsum + scaled dot KKT (optimized, with autotuning).
@@ -305,16 +312,41 @@ def fused_chunk_local_cumsum_scaled_dot_kkt_fwd(
     # D2H across forward calls. The kernel walks the pre-sliced prefill data
     # via the rebased cu_seqlens.
     if cu_seqlens is not None:
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, BT, num_decodes, num_decode_tokens
-        )
-        kernel_cu_seqlens = prepare_rebased_cu_seqlens(
-            cu_seqlens, num_decodes, num_decode_tokens
-        )
-        NT = len(chunk_indices)
+        if prefill_metadata is not None:
+            prefill_metadata.validate(
+                cu_seqlens=cu_seqlens,
+                chunk_size=BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+                total_prefill_tokens=T,
+                num_sequences=len(cu_seqlens) - 1,
+            )
+            schedule = prefill_metadata.get_chunk_schedule(
+                BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+            )
+            sequence_ids = schedule.sequence_ids
+            chunk_ids = schedule.chunk_ids
+            kernel_cu_seqlens = schedule.kernel_cu_seqlens
+            index_stride = 1
+        else:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens, BT, num_decodes, num_decode_tokens
+            )
+            flat_chunk_indices = chunk_indices.reshape(-1)
+            sequence_ids = flat_chunk_indices
+            chunk_ids = flat_chunk_indices[1:]
+            kernel_cu_seqlens = prepare_rebased_cu_seqlens(
+                cu_seqlens, num_decodes, num_decode_tokens
+            )
+            index_stride = 2
+        NT = len(sequence_ids) // index_stride
     else:
-        chunk_indices = None
+        sequence_ids = None
+        chunk_ids = None
         kernel_cu_seqlens = None
+        index_stride = 1
         NT = triton.cdiv(T, BT)
 
     g_cumsum_out = torch.empty(B, H, T, device=g.device, dtype=g_output_dtype)
@@ -327,12 +359,14 @@ def fused_chunk_local_cumsum_scaled_dot_kkt_fwd(
         g_cumsum_out,
         A_out,
         kernel_cu_seqlens,
-        chunk_indices,
+        sequence_ids,
+        chunk_ids,
         T=T,
         H=H,
         Hg=Hg,
         K=K,
         BT=BT,
+        INDEX_STRIDE=index_stride,
         USE_EXP2=use_exp2,
         G_SCALE=RCP_LN2 if use_exp2 else 1.0,
     )

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_solve_tril_recompute.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_solve_tril_recompute.py
@@ -20,7 +20,11 @@ from ..gated_delta_rule_utils import (
     autotune_cache_kwargs,
     gated_delta_rule_autotune_configs,
 )
-from ..utils import prepare_chunk_indices, prepare_rebased_cu_seqlens
+from ..utils import (
+    GatedDeltaRulePrefillMetadata,
+    prepare_chunk_indices,
+    prepare_rebased_cu_seqlens,
+)
 from ..utils.op import exp
 from ..utils.solve_tril import FLA_TRIL_PRECISION, solve_tril
 
@@ -81,7 +85,8 @@ def fused_solve_tril_recompute_w_u_kernel(
     w,
     u,
     cu_seqlens,
-    chunk_indices,
+    sequence_ids,
+    chunk_ids,
     T,
     H: tl.constexpr,
     Hg: tl.constexpr,
@@ -91,6 +96,7 @@ def fused_solve_tril_recompute_w_u_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    INDEX_STRIDE: tl.constexpr,
     DOT_PRECISION: tl.constexpr,
     USE_EXP2: tl.constexpr = False,
     LOWP_DTYPE_IS_BF16: tl.constexpr = False,
@@ -112,8 +118,8 @@ def fused_solve_tril_recompute_w_u_kernel(
 
     if IS_VARLEN:
         i_n, i_t = (
-            tl.load(chunk_indices + i_t * 2).to(tl.int32),
-            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+            tl.load(sequence_ids + i_t * INDEX_STRIDE).to(tl.int32),
+            tl.load(chunk_ids + i_t * INDEX_STRIDE).to(tl.int32),
         )
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int32),
@@ -441,7 +447,8 @@ def recompute_w_u_head_major_kernel(
     w,
     u,
     cu_seqlens,
-    chunk_indices,
+    sequence_ids,
+    chunk_ids,
     T,
     H: tl.constexpr,
     Hg: tl.constexpr,
@@ -451,6 +458,7 @@ def recompute_w_u_head_major_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    INDEX_STRIDE: tl.constexpr,
     USE_EXP2: tl.constexpr = False,
 ):
     """
@@ -468,8 +476,8 @@ def recompute_w_u_head_major_kernel(
 
     if IS_VARLEN:
         i_n, i_t = (
-            tl.load(chunk_indices + i_t * 2).to(tl.int32),
-            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+            tl.load(sequence_ids + i_t * INDEX_STRIDE).to(tl.int32),
+            tl.load(chunk_ids + i_t * INDEX_STRIDE).to(tl.int32),
         )
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int32),
@@ -549,7 +557,9 @@ def _run_split_path(
     beta: torch.Tensor,
     g_cumsum: torch.Tensor,
     cu_seqlens: torch.LongTensor | None,
-    chunk_indices: torch.LongTensor | None,
+    sequence_ids: torch.LongTensor | None,
+    chunk_ids: torch.LongTensor | None,
+    index_stride: int,
     NT: int,
     B: int,
     T: int,
@@ -568,7 +578,9 @@ def _run_split_path(
     Ai = solve_tril(
         A_raw,
         cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
+        sequence_ids=sequence_ids,
+        chunk_ids=chunk_ids,
+        index_stride=index_stride,
         output_dtype=k.dtype,
     )
     u_out = v.new_empty(B, H, T, V)
@@ -582,13 +594,15 @@ def _run_split_path(
         w_out,
         u_out,
         cu_seqlens,
-        chunk_indices,
+        sequence_ids,
+        chunk_ids,
         T=T,
         H=H,
         Hg=Hg,
         K=K,
         V=V,
         BT=BT,
+        INDEX_STRIDE=index_stride,
         USE_EXP2=use_exp2,
     )
     return w_out, u_out
@@ -604,6 +618,7 @@ def fused_solve_tril_recompute_w_u(
     use_exp2: bool = True,
     num_decodes: int = 0,
     num_decode_tokens: int = 0,
+    prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Fused triangular solve + recompute w, u in a single kernel.
@@ -629,16 +644,41 @@ def fused_solve_tril_recompute_w_u(
     # decode ints (cached, no per-forward D2H); the kernels walk the
     # pre-sliced prefill data via the rebased cu_seqlens.
     if cu_seqlens is not None:
-        chunk_indices = prepare_chunk_indices(
-            cu_seqlens, BT, num_decodes, num_decode_tokens
-        )
-        kernel_cu_seqlens = prepare_rebased_cu_seqlens(
-            cu_seqlens, num_decodes, num_decode_tokens
-        )
-        NT = len(chunk_indices)
+        if prefill_metadata is not None:
+            prefill_metadata.validate(
+                cu_seqlens=cu_seqlens,
+                chunk_size=BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+                total_prefill_tokens=T,
+                num_sequences=len(cu_seqlens) - 1,
+            )
+            schedule = prefill_metadata.get_chunk_schedule(
+                BT,
+                num_decodes=num_decodes,
+                num_decode_tokens=num_decode_tokens,
+            )
+            sequence_ids = schedule.sequence_ids
+            chunk_ids = schedule.chunk_ids
+            kernel_cu_seqlens = schedule.kernel_cu_seqlens
+            index_stride = 1
+        else:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens, BT, num_decodes, num_decode_tokens
+            )
+            flat_chunk_indices = chunk_indices.reshape(-1)
+            sequence_ids = flat_chunk_indices
+            chunk_ids = flat_chunk_indices[1:]
+            kernel_cu_seqlens = prepare_rebased_cu_seqlens(
+                cu_seqlens, num_decodes, num_decode_tokens
+            )
+            index_stride = 2
+        NT = len(sequence_ids) // index_stride
     else:
-        chunk_indices = None
+        sequence_ids = None
+        chunk_ids = None
         kernel_cu_seqlens = None
+        index_stride = 1
         NT = triton.cdiv(T, BT)
 
     # Decide fused vs split.
@@ -666,7 +706,9 @@ def fused_solve_tril_recompute_w_u(
             beta,
             g_cumsum,
             kernel_cu_seqlens,
-            chunk_indices,
+            sequence_ids,
+            chunk_ids,
+            index_stride,
             NT,
             B,
             T,
@@ -690,13 +732,15 @@ def fused_solve_tril_recompute_w_u(
         w_out,
         u_out,
         kernel_cu_seqlens,
-        chunk_indices,
+        sequence_ids,
+        chunk_ids,
         T=T,
         H=H,
         Hg=Hg,
         K=K,
         V=V,
         BT=BT,
+        INDEX_STRIDE=index_stride,
         DOT_PRECISION=FLA_TRIL_PRECISION,
         USE_EXP2=use_exp2,
         LOWP_DTYPE_IS_BF16=k.dtype == torch.bfloat16,

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/__init__.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/__init__.py
@@ -14,10 +14,16 @@ from .index import (
     prepare_rebased_cu_seqlens,
 )
 from .l2norm import l2norm_bwd, l2norm_fwd
+from .prefill_metadata import (
+    GatedDeltaRulePrefillMetadata,
+    build_gated_delta_rule_prefill_metadata,
+)
 from .solve_tril import solve_tril
 from .wy_representation import chunk_scaled_dot_kkt_fwd, recompute_w_u_fwd
 
 __all__ = [
+    "GatedDeltaRulePrefillMetadata",
+    "build_gated_delta_rule_prefill_metadata",
     "chunk_local_cumsum",
     "chunk_local_cumsum_scalar",
     "chunk_local_cumsum_vector",

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/prefill_metadata.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/prefill_metadata.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Compatibility exports for shared prefill batch metadata."""
+
+from aiter.ops.prefill_batch_metadata import (
+    CausalConvPrefillMetadata,
+    ChunkGrid,
+    GatedDeltaRuleChunkSchedule,
+    GatedDeltaRulePrefillMetadata,
+    PrefillBatchLayout,
+    build_causal_conv_prefill_metadata,
+    build_gated_delta_rule_prefill_metadata,
+)
+
+__all__ = [
+    "CausalConvPrefillMetadata",
+    "ChunkGrid",
+    "GatedDeltaRuleChunkSchedule",
+    "GatedDeltaRulePrefillMetadata",
+    "PrefillBatchLayout",
+    "build_causal_conv_prefill_metadata",
+    "build_gated_delta_rule_prefill_metadata",
+]

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/solve_tril.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/solve_tril.py
@@ -54,19 +54,21 @@ def solve_tril_16x16_kernel(
     A,
     Ai,
     cu_seqlens,
-    chunk_indices,
+    sequence_ids,
+    chunk_ids,
     T,
     H: tl.constexpr,
     BT: tl.constexpr,
     USE_TMA: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    INDEX_STRIDE: tl.constexpr,
     DOT_PRECISION: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
-            chunk_indices + i_t * 2 + 1
+        i_n, i_t = tl.load(sequence_ids + i_t * INDEX_STRIDE).to(tl.int32), tl.load(
+            chunk_ids + i_t * INDEX_STRIDE
         ).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
             cu_seqlens + i_n + 1
@@ -138,19 +140,21 @@ def merge_16x16_to_32x32_inverse_kernel(
     A,
     Ai,
     cu_seqlens,
-    chunk_indices,
+    sequence_ids,
+    chunk_ids,
     T,
     H: tl.constexpr,
     BT: tl.constexpr,
     USE_TMA: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    INDEX_STRIDE: tl.constexpr,
     DOT_PRECISION: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
-            chunk_indices + i_t * 2 + 1
+        i_n, i_t = tl.load(sequence_ids + i_t * INDEX_STRIDE).to(tl.int32), tl.load(
+            chunk_ids + i_t * INDEX_STRIDE
         ).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
             cu_seqlens + i_n + 1
@@ -269,19 +273,21 @@ def merge_16x16_to_64x64_inverse_kernel(
     A,
     Ai,
     cu_seqlens,
-    chunk_indices,
+    sequence_ids,
+    chunk_ids,
     T,
     H: tl.constexpr,
     BT: tl.constexpr,
     USE_TMA: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    INDEX_STRIDE: tl.constexpr,
     DOT_PRECISION: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
-            chunk_indices + i_t * 2 + 1
+        i_n, i_t = tl.load(sequence_ids + i_t * INDEX_STRIDE).to(tl.int32), tl.load(
+            chunk_ids + i_t * INDEX_STRIDE
         ).to(tl.int32)
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
             cu_seqlens + i_n + 1
@@ -539,8 +545,12 @@ def merge_16x16_to_64x64_inverse_kernel(
 def solve_tril(
     A: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
-    chunk_indices: torch.LongTensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
     output_dtype: torch.dtype = torch.float,
+    *,
+    sequence_ids: torch.Tensor | None = None,
+    chunk_ids: torch.Tensor | None = None,
+    index_stride: int = 1,
 ) -> torch.Tensor:
     """
     Compute the inverse of the matrix I + A where A is strictly lower triangular.
@@ -550,12 +560,25 @@ def solve_tril(
             [B, T, H, BT], where BT should only be 16, 32, or 64.
             A should be strictly lower triangular, i.e., A.triu() == 0.
         cu_seqlens (torch.Tensor):
-            The cumulative sequence lengths of the input tensor. Default: `None`.
-        chunk_indices (torch.LongTensor):
-            Pre-computed chunk indices. Default: `None`.
+            Integer cumulative sequence lengths with shape `[N+1]`. Supplying
+            it enables variable-length indexing. Default: `None`.
+        chunk_indices (torch.Tensor):
+            Integer `[num_chunks, 2]` tensor containing interleaved sequence
+            and local chunk IDs. Used only for variable-length inputs when
+            separate IDs are not supplied. Default: `None`.
         output_dtype (torch.dtype):
             The dtype of the output tensor. Default: `torch.float`.
             If `None`, the output dtype will be the same as the input dtype.
+        sequence_ids (torch.Tensor):
+            One-dimensional integer sequence IDs on the same device as `A`.
+            Must be passed together with `chunk_ids` for variable-length input.
+        chunk_ids (torch.Tensor):
+            One-dimensional integer local chunk IDs on the same device as `A`.
+            Must be passed together with `sequence_ids`.
+        index_stride (int):
+            Element stride between IDs. Use `1` for separate contiguous ID
+            tensors and `2` for flattened interleaved chunk indices.
+            Default: `1`.
 
     Returns:
         (I + A)^-1 with the same shape as A
@@ -564,9 +587,22 @@ def solve_tril(
     output_dtype = A.dtype if output_dtype is None else output_dtype
 
     B, T, H, BT = A.shape
-    if chunk_indices is None and cu_seqlens is not None:
-        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
+    if (sequence_ids is None) != (chunk_ids is None):
+        raise ValueError("`sequence_ids` and `chunk_ids` must be provided together.")
+    if index_stride <= 0:
+        raise ValueError(f"`index_stride` must be positive, got {index_stride}.")
+    if cu_seqlens is not None and sequence_ids is None:
+        if chunk_indices is None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+        flat_chunk_indices = chunk_indices.reshape(-1)
+        sequence_ids = flat_chunk_indices
+        chunk_ids = flat_chunk_indices[1:]
+        index_stride = 2
+    NT = (
+        len(sequence_ids) // index_stride
+        if cu_seqlens is not None
+        else triton.cdiv(T, BT)
+    )
 
     Ai = torch.zeros_like(A, dtype=output_dtype)
     if BT == 16:
@@ -580,10 +616,12 @@ def solve_tril(
         A=A,
         Ai=Ai,
         cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
+        sequence_ids=sequence_ids,
+        chunk_ids=chunk_ids,
         T=T,
         H=H,
         BT=BT,
+        INDEX_STRIDE=index_stride,
         USE_TMA=IS_TMA_SUPPORTED,
     )
     return Ai

--- a/aiter/ops/triton/gated_delta_net/__init__.py
+++ b/aiter/ops/triton/gated_delta_net/__init__.py
@@ -8,12 +8,21 @@ Gated Delta Net Operations (Forward Only).
 This module provides high-level Triton implementations for gated delta rule.
 """
 
+from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
+    GatedDeltaRulePrefillMetadata,
+    build_gated_delta_rule_prefill_metadata,
+)
+
 from .gated_delta_rule import (
     chunk_gated_delta_rule,
+    chunk_gated_delta_rule_opt_vk,
     fused_recurrent_gated_delta_rule,
 )
 
 __all__ = [
-    "fused_recurrent_gated_delta_rule",
+    "GatedDeltaRulePrefillMetadata",
+    "build_gated_delta_rule_prefill_metadata",
     "chunk_gated_delta_rule",
+    "chunk_gated_delta_rule_opt_vk",
+    "fused_recurrent_gated_delta_rule",
 ]

--- a/aiter/ops/triton/gated_delta_net/gated_delta_rule.py
+++ b/aiter/ops/triton/gated_delta_net/gated_delta_rule.py
@@ -16,6 +16,8 @@ Important Note:
     These implementations are optimized for inference and forward-only operations.
 """
 
+from collections.abc import Sequence
+
 import torch
 import triton
 
@@ -25,6 +27,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule import (
     chunk_gated_delta_rule_fwd_opt_vk,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
+    GatedDeltaRulePrefillMetadata,
     l2norm_fwd,
 )
 from aiter.ops.triton.utils.logger import AiterTritonLogger
@@ -356,11 +359,62 @@ def chunk_gated_delta_rule_opt_vk(
     use_exp2: bool = True,
     num_decodes: int = 0,
     num_decode_tokens: int = 0,
+    seq_lens_cpu: Sequence[int] | None = None,
+    prefill_metadata: GatedDeltaRulePrefillMetadata | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Optimized forward-only GDN prefill with state layout [N, H, V, K].
 
     This mirrors the aiter main high-level API and also supports SGLang's
     pool-indexed state contract via initial_state_indices.
+    Same fused kernels as chunk_gated_delta_rule_opt, but with
+    transposed hidden state layout [V, K] instead of [K, V].
+
+    The signature mirrors
+    ``aiter.ops.flydsl.linear_attention_prefill_kernels.flydsl_gdr_prefill`` so
+    the two can be used interchangeably as drop-in backends, including the
+    optional in-place ``o`` buffer and the ``num_decodes`` /
+    ``num_decode_tokens`` decode-prefix arguments.
+
+    Args:
+        q (torch.Tensor): queries of shape `[B, T, H, K]`.
+        k (torch.Tensor): keys of shape `[B, T, H, K]`.
+        v (torch.Tensor): values of shape `[B, T, H, V]`.
+        o (torch.Tensor, optional): pre-allocated `[B, T, H, V]` output buffer
+            written in place by K6. If None, a fresh buffer is allocated.
+        g (torch.Tensor): g (decays in log space) of shape `[B, T, H]`.
+        beta (torch.Tensor): betas of shape `[B, T, H]`.
+        scale (float, optional): Scale factor. Default: `1 / sqrt(K)`.
+        initial_state (torch.Tensor, optional):
+            Initial state of shape `[N, H, V, K]` — note transposed layout.
+        output_final_state (bool): Whether to output final state `[N, H, V, K]`.
+        use_qk_l2norm_in_kernel (bool): Whether to use L2 normalization.
+        cu_seqlens (torch.LongTensor, optional): Cumulative sequence lengths `[N+1]`.
+        use_chunk_hip (bool): Use HIP kernel for hidden state (K5).
+        use_chunk_flydsl (bool): Use FlyDSL kernel for hidden state (K5).
+            Mutually exclusive with ``use_chunk_hip``.
+        state_dtype (torch.dtype, optional): Initial/final state dtype
+            (`fp32` or `bf16`), supported by both the HIP and Triton paths.
+        use_exp2 (bool): Use exp2 instead of exp for gate computation.
+        num_decodes (int): number of leading decode-only sequences to skip in
+            ``cu_seqlens``. When nonzero, the caller passes the ORIGINAL,
+            cache-stable ``cu_seqlens`` (decode prefix included) and the data
+            tensors (`q/k/v/g/beta/o`) pre-sliced to the prefill region; the
+            offsets are rebased internally by the cached prologue helpers, so
+            the chunk-index / offset builds stay cache-warm across forward
+            calls (no per-forward `.tolist()` D2H).
+        num_decode_tokens (int): number of leading decode tokens stripped from
+            the data tensors; subtracted from the rebased offsets.
+        seq_lens_cpu: Original sequence lengths on the host, including any
+            leading decode-only sequences. When supplied, one shared metadata
+            schedule is built for K1--K6 without reading device values.
+        prefill_metadata: Reusable schedule created by
+            ``build_gated_delta_rule_prefill_metadata``. Prefer this over
+            ``seq_lens_cpu`` when several GDR layers process the same batch.
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor | None]:
+            - o: Outputs of shape `[B, T, H, V]`.
+            - final_state: `[N, H, V, K]` if `output_final_state=True` else `None`.
     """
     if cu_seqlens is not None:
         if q.shape[0] != 1:
@@ -415,5 +469,7 @@ def chunk_gated_delta_rule_opt_vk(
         o=o,
         num_decodes=num_decodes,
         num_decode_tokens=num_decode_tokens,
+        seq_lens_cpu=seq_lens_cpu,
+        prefill_metadata=prefill_metadata,
     )
     return o.to(q.dtype), final_state


### PR DESCRIPTION
## Motivation

GDN variable-length prefill kernels repeatedly derived identical scheduling metadata from `cu_seqlens` for every layer and kernel stage.

This introduced redundant metadata copies and device-to-host synchronization. This PR adds reusable prefill metadata that can be constructed once per batch and shared across all GDN layers and K1-K6 stages.

## Modifications

- Cherry-pick and adapt the reusable GDR prefill metadata changes from [#4532](https://github.com/ROCm/aiter/pull/4532).
- Preserve the `Qwen3.5_dev` indexed-state and in-place update behavior.
- Cache chunk schedules containing:
  - rebased sequence lengths
  - sequence and chunk IDs
  - chunk offsets
  - prefill sequence and token counts
- Thread optional reusable metadata through:
  - fused cumsum/KKT
  - triangular solve and recompute
  - HIP and Triton hidden-state kernels
  - output kernels
- Eliminate repeated `.tolist()` device readbacks and `CatArrayBatchedCopy_contig`.
- Preserve the legacy path when metadata is not supplied.
- Preserve indexed state pools, in-place final-state updates, and decode-prefix handling.

## Accuracy Tests

- Compared legacy and reusable-metadata paths using BF16 inputs and indexed FP32 state.
- Output and final state matched with:
  - `rtol=1e-3`
  - `atol=2e-3`
- Companion SGLang GDN suite:

  `28 passed`

## Speed Tests and Profiling

Configuration:

- Model: Qwen3.5-397B-A17B-PTPC
- Tensor parallelism: TP8
- Input length: 8000
- Output length: 1
- Concurrency: 32

Profiling results with the companion SGLang integration:

- `CatArrayBatchedCopy_contig`: `4 -> 0`
- D2H copies before GDN cumsum: `4 -> 0`
- No residual first-layer GDN bubble with a warm allocator:
  - cumsum gap: at most `0.001 us`
  - recompute gap: at most `0.001 us`
  - chunk-h gap: at most `0.001 us`
- Measured input throughput: `25,463 tokens/s`

## Checklist

- [x] Format code with pre-commit.
- [x] Add permanent unit tests.
- [x] Update documentation where required.
- [x] Provide accuracy and profiling results.
- [x] Follow the project code-style guidance.