### PR TITLE
[cache] cover int32 slot_mapping in test_kvcache

### DIFF
--- a/csrc/kernels/cache_kernels.cu
+++ b/csrc/kernels/cache_kernels.cu
@@ -20,6 +20,44 @@
 
 namespace aiter {
 
+// slot_mapping arrives as int64 from the torch stacks -- vLLM allocates it as
+// torch.int64 and SGLang's out_cache_loc is likewise int64 -- and as int32 from
+// JAX front ends, which emit 32-bit integers unless jax_enable_x64 is set at
+// startup, process-wide. The cache kernels therefore have to accept both.
+//
+// The pointer is passed untyped with a width flag rather than templating the
+// kernels on the index type. Templating would double every instantiation
+// produced by DISPATCH_BY_KV_CACHE_DTYPE_OPUS_rmTorch, and this translation unit
+// is a long compile already. The runtime cost is nil: each kernel reads exactly
+// one slot per thread block, and the flag is a kernel argument and therefore
+// uniform across the grid, so it compiles to a scalar branch rather than a
+// divergent one.
+enum class SlotIndexWidth : int
+{
+    kInt32 = 0,
+    kInt64 = 1,
+};
+
+__device__ __forceinline__ int64_t load_slot_index(const void* __restrict__ slot_mapping,
+                                                   int64_t token_idx,
+                                                   SlotIndexWidth width)
+{
+    return width == SlotIndexWidth::kInt64
+               ? static_cast<const int64_t*>(slot_mapping)[token_idx]
+               : static_cast<int64_t>(
+                     static_cast<const int32_t*>(slot_mapping)[token_idx]);
+}
+
+inline SlotIndexWidth slot_index_width(const aiter_tensor_t& slot_mapping)
+{
+    AITER_CHECK(slot_mapping.dtype() == AITER_DTYPE_i32 ||
+                    slot_mapping.dtype() == AITER_DTYPE_i64,
+                "slot_mapping must be int32 or int64, got ",
+                AiterDtype_to_str(slot_mapping.dtype()));
+    return slot_mapping.dtype() == AITER_DTYPE_i32 ? SlotIndexWidth::kInt32
+                                                   : SlotIndexWidth::kInt64;
+}
+
 void swap_blocks(aiter_tensor_t& src, aiter_tensor_t& dst, const aiter_tensor_t& block_mapping)
 {
     bool src_is_gpu = src.is_gpu();
@@ -163,8 +201,7 @@ namespace aiter {
 template <typename scalar_t,
           typename cache_t,
           vllm::Fp8KVCacheDataType kv_dt,
-          bool asmLayout          = false,
-          typename slot_mapping_t = int64_t>
+          bool asmLayout = false>
 __global__ void
 reshape_and_cache_kernel(const scalar_t* __restrict__ key,   // [num_tokens, num_heads, head_size]
                          const scalar_t* __restrict__ value, // [num_tokens, num_heads, head_size]
@@ -172,7 +209,8 @@ reshape_and_cache_kernel(const scalar_t* __restrict__ key,   // [num_tokens, num
                                                              // block_size, x]
                          cache_t* __restrict__ value_cache,  // [num_blocks, num_heads, head_size,
                                                              // block_size]
-                         const slot_mapping_t* __restrict__ slot_mapping, // [num_tokens]
+                         const void* __restrict__ slot_mapping, // [num_tokens], int32 or int64
+                         const SlotIndexWidth slot_width,
                          const int key_stride,
                          const int value_stride,
                          const int num_heads,
@@ -182,16 +220,16 @@ reshape_and_cache_kernel(const scalar_t* __restrict__ key,   // [num_tokens, num
                          const float* k_scale,
                          const float* v_scale)
 {
-    const int64_t token_idx       = blockIdx.x;
-    const slot_mapping_t slot_idx = slot_mapping[token_idx];
+    const int64_t token_idx = blockIdx.x;
+    const int64_t slot_idx  = load_slot_index(slot_mapping, token_idx, slot_width);
     if(slot_idx < 0)
     {
         // Padding token that should be ignored.
         return;
     }
 
-    const int64_t block_idx    = static_cast<int64_t>(slot_idx) / block_size;
-    const int64_t block_offset = static_cast<int64_t>(slot_idx) % block_size;
+    const int64_t block_idx    = slot_idx / block_size;
+    const int64_t block_offset = slot_idx % block_size;
 
     const int n                 = num_heads * head_size;
     const float inverted_kscale = k_scale == nullptr ? 1.0f : 1 / (*k_scale);
@@ -247,9 +285,10 @@ __global__ void reshape_and_cache_flash_kernel(
     const scalar_t* __restrict__ value,       // [num_tokens, num_heads, head_size]
     cache_t* __restrict__ key_cache,          // [num_blocks, block_size, num_heads,
                                               // head_size]
-    cache_t* __restrict__ value_cache,        // [num_blocks, block_size, num_heads,
-                                              // head_size]
-    const int64_t* __restrict__ slot_mapping, // [num_tokens]
+    cache_t* __restrict__ value_cache,     // [num_blocks, block_size, num_heads,
+                                           // head_size]
+    const void* __restrict__ slot_mapping, // [num_tokens], int32 or int64
+    const SlotIndexWidth slot_width,
     const int block_stride,
     const int key_stride,
     const int value_stride,
@@ -260,7 +299,7 @@ __global__ void reshape_and_cache_flash_kernel(
     const float* v_scale)
 {
     const int64_t token_idx = blockIdx.x;
-    const int64_t slot_idx  = slot_mapping[token_idx];
+    const int64_t slot_idx  = load_slot_index(slot_mapping, token_idx, slot_width);
     // NOTE: slot_idx can be -1 if the token is padded
     if(slot_idx < 0)
     {
@@ -3145,7 +3184,8 @@ __global__ void fused_qk_rope_concat_and_cache_mla_seg_kernel(
                                      reinterpret_cast<KV_T*>(value.data_ptr()),                  \
                                      reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),           \
                                      reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),         \
-                                     reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),                           \
+                                     slot_mapping.data_ptr(),                                    \
+                                     slot_width,                                                 \
                                      key_stride,                                                 \
                                      value_stride,                                               \
                                      num_heads,                                                  \
@@ -3161,7 +3201,8 @@ __global__ void fused_qk_rope_concat_and_cache_mla_seg_kernel(
                                      reinterpret_cast<KV_T*>(value.data_ptr()),                  \
                                      reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),           \
                                      reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),         \
-                                     reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),                           \
+                                     slot_mapping.data_ptr(),                                    \
+                                     slot_width,                                                 \
                                      key_stride,                                                 \
                                      value_stride,                                               \
                                      num_heads,                                                  \
@@ -3197,6 +3238,7 @@ void reshape_and_cache(
     dim3 block(std::min(num_heads * head_size, 512));
     HipDeviceGuard device_guard(key.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
+    const SlotIndexWidth slot_width = slot_index_width(slot_mapping);
 
     if(asm_layout)
     {
@@ -3219,7 +3261,8 @@ void reshape_and_cache(
                                      reinterpret_cast<KV_T*>(value.data_ptr()),          \
                                      reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),   \
                                      reinterpret_cast<CACHE_T*>(value_cache.data_ptr()), \
-                                     reinterpret_cast<int64_t*>(slot_mapping.data_ptr()),                   \
+                                     slot_mapping.data_ptr(),                            \
+                                     slot_width,                                         \
                                      block_stride,                                       \
                                      key_stride,                                         \
                                      value_stride,                                       \
@@ -3255,6 +3298,7 @@ void reshape_and_cache_flash(
     dim3 block(std::min(num_heads * head_size, 512));
     HipDeviceGuard device_guard(key.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
+    const SlotIndexWidth slot_width = slot_index_width(slot_mapping);
 
     DISPATCH_BY_KV_CACHE_DTYPE_OPUS_rmTorch(key.dtype(), kv_cache_dtype, CALL_RESHAPE_AND_CACHE_FLASH);
 }

--- a/op_tests/test_kvcache.py
+++ b/op_tests/test_kvcache.py
@@ -130,6 +130,7 @@ def test_reshape_and_cache(
     block_size: int,
     DType_KV: torch.dtype,
     DType_KVCache: torch.dtype,
+    DType_Slot: torch.dtype = torch.int64,
 ):
     ret = {}
     quantCfg = (
@@ -172,6 +173,11 @@ def test_reshape_and_cache(
             for i in range(ctx_lens)
         ]
     ).cuda()
+    # The kernels accept int32 as well as int64: the torch stacks keep
+    # slot_mapping in int64, while JAX front ends produce int32. The torch
+    # reference keeps its own int64 copy, since advanced indexing has its own
+    # index-dtype rules and this test is about the kernel, not about torch.
+    slot_mapping_kernel = slot_mapping.to(DType_Slot)
 
     k_cache_ref = k_cache.clone()
     v_cache_ref = v_cache.clone()
@@ -197,7 +203,7 @@ def test_reshape_and_cache(
         value,
         k_cache_a,
         v_cache_a,
-        slot_mapping,
+        slot_mapping_kernel,
         block_size,
         x,
         asm_layout,
@@ -226,6 +232,7 @@ def test_reshape_and_cache(
     slot_mapping = torch.tensor(
         [bsID * max_token_num_support + ctx_lens for bsID in range(bs)]
     ).cuda()
+    slot_mapping_kernel = slot_mapping.to(DType_Slot)
 
     k_cache_ref = k_cache.clone()
     v_cache_ref = v_cache.clone()
@@ -251,7 +258,7 @@ def test_reshape_and_cache(
         value,
         k_cache_a,
         v_cache_a,
-        slot_mapping,
+        slot_mapping_kernel,
         block_size,
         x,
         asm_layout,
@@ -270,7 +277,7 @@ def test_reshape_and_cache(
             msg=f"{names[i]} {el.shape}",
         )
     print(
-        f"finish test {ctx_lens=} {bs=} {num_heads=} {head_size=} {block_size=} {DType_KV=} {DType_KVCache=}"
+        f"finish test {ctx_lens=} {bs=} {num_heads=} {head_size=} {block_size=} {DType_KV=} {DType_KVCache=} {DType_Slot=}"
     )
     return ret
 
@@ -283,8 +290,14 @@ parser.add_argument(
     "-t",
     "--test",
     type=str,
-    choices=["bf16tobf16", "fp16tofp8", "fp16toi8", "bf16toi8"],
-    default=["bf16tobf16", "fp16tofp8", "fp16toi8", "bf16toi8"],
+    choices=["bf16tobf16", "bf16tobf16_slot_i32", "fp16tofp8", "fp16toi8", "bf16toi8"],
+    default=[
+        "bf16tobf16",
+        "bf16tobf16_slot_i32",
+        "fp16tofp8",
+        "fp16toi8",
+        "bf16toi8",
+    ],
     nargs="*",
     help="""select which test to run, default is all
     e.g.: -t fp16tofp8""",
@@ -325,6 +338,20 @@ for (
             16,
             dtypes.bf16,
             dtypes.bf16,
+        )
+    elif test == "bf16tobf16_slot_i32":
+        # Same case as bf16tobf16 with an int32 slot_mapping, which is what JAX
+        # front ends produce.
+        print("\nstart quant bf16->bf16, int32 slot_mapping")
+        ret = test_reshape_and_cache(
+            ctx,
+            bs,
+            (8, 1),
+            128,
+            16,
+            dtypes.bf16,
+            dtypes.bf16,
+            torch.int32,
         )
     elif test == "fp16tofp8":
         print("\nstart quant fp16->fp8")


### PR DESCRIPTION
## Motivation

`reshape_and_cache` and `reshape_and_cache_flash` hardcode `reinterpret_cast<int64_t*>` on `slot_mapping.data_ptr()` , so callers holding `int32` indices must convert first.

The motivation is JAX front ends. JAX emits 32-bit integers unless `jax_enable_x64` is set, and [that flag must be set at startup and applies process-wide](https://docs.jax.dev/en/latest/notebooks/Common_Gotchas_in_JAX.html#double-64bit-precision) — it changes the dtype of every array in the program. 

Requiring it so a KV index can be 64 bits is a heavy trade for a serving stack, and the alternative is a widening pass per layer per step. [sglang-jax meets the same constraint and keeps its slot mapping as jnp.int32](https://github.com/sgl-project/sglang-jax/blob/main/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py).

---------------------------------------------------------------
This is **additive** rather than a correction. 

**The torch stacks are consistent and stay on `int64`**: vLLM allocates `slot_mapping` as `torch.int64` (with `block_table` in `int32`), and SGLang's `out_cache_loc` is likewise int64. 

Both keep working unchanged.

---------------------------------------------------------------



## Technical Details

Adds a `DType_Slot` parameter to `test_reshape_and_cache`, defaulting to int64 so every existing call site is unchanged, and a `bf16tobf16_slot_i32` case that runs the same comparison with an `int32` `slot_mapping`.
    
The torch reference keeps its own `int64` copy and only the aiter call takes the parametrised dtype. Advanced indexing has its own index-dtype rules and this test is about the kernel, so there is no reason to drag them in.

## Test Plan

new int32 coverage
`python3 op_tests/test_kvcache.py -t bf16tobf16_slot_i32`

existing int64 cases, unchanged behaviour
`python3 op_tests/test_kvcache.py -t bf16tobf16 -t fp16tofp8 -t fp16toi8 -t bf16toi8`

## Test Result

| Test                    | slot dtype  | Result |
|-------------------------|-------------|--------|
| reshape_and_cache_flash | torch.int64 | pass   |
| reshape_and_cache_flash | torch.int32 | pass   |
| reshape_and_cache       | torch.int64 | pass   |
| reshape_and_cache       | torch.int32 | pass   |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
