### PR TITLE
Revert "Add CODEOWNERS for aiter/ops/triton"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners for aiter.
-# Each line is a file pattern followed by one or more owners.
-# The last matching pattern takes precedence.
-
-/aiter/ops/triton/ @Dewei-Wang-sh @vgokhale @azaidy


### PR DESCRIPTION
Reverts ROCm/aiter#4678

Reverting to unblock the org-wide CODEOWNERS convergence.

#4678 landed with **individual** owners for `/aiter/ops/triton/`, while @azaidy had asked on that PR to align with the team-based approach from #1940. That request wasn't resolved before I approved and merged it — my mistake, apologies to @Dewei-Wang-sh for the churn.

Reverting to a clean slate so that #4699 can land the fine-grained, team-based version in one go:
- `TEAM_AITER` as default owner
- `ROCm/Triton_Kernels_Team` for the Triton paths
- `@coderfeli` additionally for gluon

Note #4699 is blocked until `ROCm/Triton_Kernels_Team` is granted **write** access on this repo — CODEOWNERS entries referencing a team without write access are silently ignored by GitHub, so landing it early would produce a file that looks like governance but is a no-op.

No functional impact: CODEOWNERS only, no code or CI changes.
