### PR TITLE
[module_topk_*] de-torch topk_per_row / topk_plain + externalize workspaces

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -286,7 +286,7 @@ def grouped_topk_torch(
     return topk_weights.to(dtypes.fp32), topk_ids.to(dtypes.i32)
 
 
-@compile_ops("module_top_k_per_row", fc_name="top_k_per_row_prefill")
+@compile_ops("module_top_k_per_row", fc_name="top_k_per_row_prefill", develop=True)
 def _top_k_per_row_prefill(
     logits: torch.Tensor,
     rowStarts: torch.Tensor,
@@ -304,6 +304,12 @@ def _top_k_per_row_prefill(
 
 @compile_ops("module_top_k_per_row")
 def topk_mb_workspace_size(
+    numRows: int, stride0: int, k: int, is_decode: bool
+) -> int: ...
+
+
+@compile_ops("module_top_k_per_row")
+def topk_ob_workspace_size(
     numRows: int, stride0: int, k: int, is_decode: bool
 ) -> int: ...
 
@@ -343,6 +349,20 @@ def get_topk_mb_workspace(device: torch.device, size: int) -> torch.Tensor:
     return _get_topk_mb_workspace_keyed(device, stream.cuda_stream, alloc)
 
 
+def get_topk_scratch_workspace(device: torch.device, size: int) -> torch.Tensor:
+    """Return an exact-size scratch workspace for the one-block (ob) / radix
+    top-k paths.
+
+    Unlike the multi-block buffer (get_topk_mb_workspace), these kernels do their
+    own internal memset on each launch, so the buffer need not be zero-initialized
+    and need not be a persistent, reused buffer. This mirrors how the C++ side
+    originally allocated it — a plain, exactly-sized ``torch.empty`` per call —
+    only moved to the Python side so the host code never allocates device scratch
+    itself. torch's caching allocator reuses freed blocks, so no explicit cache
+    (or size bucketing) is needed here."""
+    return torch.empty(max(1, int(size)), dtype=torch.uint8, device=device)
+
+
 def top_k_per_row_prefill(
     logits: torch.Tensor,
     rowStarts: torch.Tensor,
@@ -355,17 +375,22 @@ def top_k_per_row_prefill(
     k: int = 2048,
     stable: bool = False,
 ) -> None:
-    """Per-row top-k (prefill). The multi-block path runs on a persistent,
-    zero-initialized workspace (memset-free; see get_topk_mb_workspace); the
-    one-block path allocates its own scratch internally.
+    """Per-row top-k (prefill). Both the multi-block and one-block paths run on a
+    caller-provided workspace allocated (and cached) on the Python side, so the
+    C++ kernels never allocate device scratch. The mb path needs a zeroed,
+    self-reset buffer (get_topk_mb_workspace); the ob path uses plain scratch
+    (get_topk_scratch_workspace).
 
     When stable=True, the one-block path is forced with deterministic,
     ascending-index ordered, smallest-index tie-breaking emit so every
-    tensor-parallel rank selects and orders an identical KV set."""
-    workspace = None
+    tensor-parallel rank selects and orders an identical KV set; the caller sizes
+    the workspace for the ob path in that case."""
     if not stable and topk_use_mulblocks(numRows, stride0):
         size = topk_mb_workspace_size(numRows, stride0, k, False)
         workspace = get_topk_mb_workspace(logits.device, size)
+    else:
+        size = topk_ob_workspace_size(numRows, stride0, k, False)
+        workspace = get_topk_scratch_workspace(logits.device, size)
     return _top_k_per_row_prefill(
         logits,
         rowStarts,
@@ -394,7 +419,7 @@ def top_k_per_row_prefill_fast(
 ) -> None: ...
 
 
-@compile_ops("module_top_k_per_row", fc_name="top_k_per_row_decode")
+@compile_ops("module_top_k_per_row", fc_name="top_k_per_row_decode", develop=True)
 def _top_k_per_row_decode(
     logits: torch.Tensor,
     next_n: int,
@@ -420,15 +445,31 @@ def top_k_per_row_decode(
     k: int = 2048,
     stable: bool = False,
 ) -> None:
-    """Per-row top-k (decode). Always uses the one-block kernel — the C++
-    side ignores the workspace argument for decode.
+    """Per-row top-k (decode). Always uses the one-block kernel; the scratch
+    workspace is allocated + cached on the Python side and passed in, so the C++
+    side never allocates device scratch.
 
     When stable=True, the deterministic ascending-ordered, smallest-index
     tie-break emit is used so every TP rank selects and orders an identical
     KV set."""
     # Decode always takes the ob path (see topk_per_row_kernels.cu).
+    # The original mb dispatch is commented out below for reference:
+    #   if topk_use_mulblocks(numRows, stride0):
+    #       size = topk_mb_workspace_size(numRows, stride0, k, True)
+    #       workspace = get_topk_mb_workspace(logits.device, size)
+    size = topk_ob_workspace_size(numRows, stride0, k, True)
+    workspace = get_topk_scratch_workspace(logits.device, size)
     return _top_k_per_row_decode(
-        logits, next_n, seqLens, indices, numRows, stride0, stride1, k, None, stable
+        logits,
+        next_n,
+        seqLens,
+        indices,
+        numRows,
+        stride0,
+        stride1,
+        k,
+        workspace,
+        stable,
     )
 
 

--- a/aiter/ops/topk_plain.py
+++ b/aiter/ops/topk_plain.py
@@ -8,9 +8,28 @@ import torch
 from ..jit.core import (
     compile_ops,
 )
+from .topk import get_topk_scratch_workspace
+
+
+@compile_ops("module_topk_plain", fc_name="topk_plain", develop=True)
+def _topk_plain(
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_out: torch.Tensor,
+    topk: int,
+    largest: bool = True,
+    rowStarts: torch.Tensor = None,
+    rowEnds: torch.Tensor = None,
+    stride0: int = -1,
+    stride1: int = 1,
+    workspace: torch.Tensor | None = None,
+) -> None: ...
 
 
 @compile_ops("module_topk_plain")
+def topk_plain_workspace_size(numRows: int, stride0: int, k: int) -> int: ...
+
+
 def topk_plain(
     x: torch.Tensor,
     topk_ids: torch.Tensor,
@@ -22,4 +41,28 @@ def topk_plain(
     stride0: int = -1,
     stride1: int = 1,
 ) -> None:
-    pass
+    """Plain top-k over the last dim.
+
+    The fp32 radix path needs a device scratch workspace; it is allocated (and
+    cached) here on the Python side via torch's caching allocator and passed into
+    the kernel, so the C++ side never allocates device memory itself. Non-fp32
+    inputs never reach the radix path, so no workspace is allocated for them.
+    """
+    workspace = None
+    if x.dtype == torch.float32:
+        # Mirror the C++ default: stride0 < 0 means a contiguous last dim.
+        s0 = stride0 if stride0 >= 0 else x.shape[-1]
+        size = topk_plain_workspace_size(x.shape[0], s0, topk)
+        workspace = get_topk_scratch_workspace(x.device, size)
+    return _topk_plain(
+        x,
+        topk_ids,
+        topk_out,
+        topk,
+        largest,
+        rowStarts,
+        rowEnds,
+        stride0,
+        stride1,
+        workspace,
+    )

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2178,6 +2178,7 @@ namespace py = pybind11;
     m.def("rocb_findallsols", &RocFindAllSolIdxBlas, "rocblas_find_all_sols");
 
 #define TOP_K_PER_ROW_PYBIND                     \
+    AITER_SET_STREAM_PYBIND;                      \
     m.def("top_k_per_row_prefill",               \
           &top_k_per_row_prefill,                \
           py::arg("logits"),                     \
@@ -2209,10 +2210,13 @@ namespace py = pybind11;
           py::arg("stride0"),                    \
           py::arg("k"),                          \
           py::arg("is_decode"));                 \
-    m.def("topk_use_mulblocks",                  \
-          &topk_use_mulblocks,                   \
+    m.def("topk_ob_workspace_size",              \
+          &topk_ob_workspace_size,               \
           py::arg("numRows"),                    \
-          py::arg("stride0"));
+          py::arg("stride0"),                    \
+          py::arg("k"),                          \
+          py::arg("is_decode"));                 \
+    m.def("topk_use_mulblocks", &topk_use_mulblocks, py::arg("numRows"), py::arg("stride0"));
 
 #define MLA_METADATA_PYBIND                                 \
     m.def("get_mla_metadata_v1",                            \
@@ -2306,6 +2310,7 @@ namespace py = pybind11;
           py::arg("final_lse") = std::nullopt);
 
 #define TOPK_PLAIN_PYBIND                         \
+    AITER_SET_STREAM_PYBIND;                      \
     m.def("topk_plain",                           \
           &topk_plain,                            \
           py::arg("values"),                      \
@@ -2313,10 +2318,16 @@ namespace py = pybind11;
           py::arg("topk_out"),                    \
           py::arg("topk"),                        \
           py::arg("largest")   = true,            \
-          py::arg("rowStarts") = torch::Tensor(), \
-          py::arg("rowEnds")   = torch::Tensor(), \
+          py::arg("rowStarts") = std::nullopt,    \
+          py::arg("rowEnds")   = std::nullopt,    \
           py::arg("stride0")   = -1,              \
-          py::arg("stride1")   = 1);
+          py::arg("stride1")   = 1,               \
+          py::arg("workspace") = std::nullopt);   \
+    m.def("topk_plain_workspace_size",            \
+          &topk_plain_workspace_size,             \
+          py::arg("numRows"),                     \
+          py::arg("stride0"),                     \
+          py::arg("k"));
 
 #define RMSNORM_QUANT_PYBIND                 \
     AITER_SET_STREAM_PYBIND;                 \

--- a/csrc/include/topk_per_row.h
+++ b/csrc/include/topk_per_row.h
@@ -1,30 +1,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
-#include <torch/extension.h>
+#include "aiter_tensor.h"
+#include <cstdint>
+#include <optional>
 
-void top_k_per_row_prefill(const torch::Tensor& logits,
-                           const torch::Tensor& rowStarts,
-                           const torch::Tensor& rowEnds,
-                           torch::Tensor& indices,
-                           std::optional<torch::Tensor> values,
+void top_k_per_row_prefill(const aiter_tensor_t& logits,
+                           const aiter_tensor_t& rowStarts,
+                           const aiter_tensor_t& rowEnds,
+                           aiter_tensor_t& indices,
+                           std::optional<aiter_tensor_t> values,
                            int64_t numRows,
                            int64_t stride0,
                            int64_t stride1,
-                           int64_t k                              = 2048,
-                           std::optional<torch::Tensor> workspace = std::nullopt,
-                           bool stable                            = false);
+                           int64_t k                               = 2048,
+                           std::optional<aiter_tensor_t> workspace = std::nullopt,
+                           bool stable                             = false);
 
-void top_k_per_row_decode(const torch::Tensor& logits,
+void top_k_per_row_decode(const aiter_tensor_t& logits,
                           int64_t next_n,
-                          const torch::Tensor& seqLens,
-                          torch::Tensor& indices,
+                          const aiter_tensor_t& seqLens,
+                          aiter_tensor_t& indices,
                           int64_t numRows,
                           int64_t stride0,
                           int64_t stride1,
-                          int64_t k                              = 2048,
-                          std::optional<torch::Tensor> workspace = std::nullopt,
-                          bool stable                            = false);
+                          int64_t k                               = 2048,
+                          std::optional<aiter_tensor_t> workspace = std::nullopt,
+                          bool stable                             = false);
 
 // Workspace-management queries exposed to Python (see get_topk_mb_workspace).
 int64_t topk_mb_workspace_size(int64_t numRows, int64_t stride0, int64_t k, bool is_decode);
+int64_t topk_ob_workspace_size(int64_t numRows, int64_t stride0, int64_t k, bool is_decode);
 bool topk_use_mulblocks(int64_t numRows, int64_t stride0);

--- a/csrc/include/topk_plain.h
+++ b/csrc/include/topk_plain.h
@@ -2,14 +2,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "aiter_enum.h"
-#include <torch/extension.h>
+#include "aiter_tensor.h"
+#include <cstdint>
+#include <optional>
 
-void topk_plain(torch::Tensor& values,
-                torch::Tensor& topk_ids,
-                torch::Tensor& topk_out,
+void topk_plain(aiter_tensor_t& values,
+                aiter_tensor_t& topk_ids,
+                aiter_tensor_t& topk_out,
                 int topk,
-                bool largest = true,
-                torch::Tensor rowStarts = torch::Tensor(),
-                torch::Tensor rowEnds = torch::Tensor(),
-                int64_t stride0 = -1,
-                int64_t stride1 = 1);
+                bool largest                            = true,
+                std::optional<aiter_tensor_t> rowStarts = std::nullopt,
+                std::optional<aiter_tensor_t> rowEnds   = std::nullopt,
+                int64_t stride0                         = -1,
+                int64_t stride1                         = 1,
+                std::optional<aiter_tensor_t> workspace = std::nullopt);
+
+// Workspace sizing for the fp32 radix path, exposed to Python so the scratch can
+// be allocated + cached on the Python side and passed into topk_plain.
+int64_t topk_plain_workspace_size(int64_t numRows, int64_t stride0, int64_t k);

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
-#include <torch/all.h>
-
 #include "aiter_hip_common.h"
-#include "dispatch_utils.h"
+#include "aiter_tensor.h"
+#include "aiter_stream.h"
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
 
@@ -2757,6 +2754,19 @@ int64_t topk_mb_workspace_size(int64_t numRows, int64_t stride0, int64_t k, bool
     return static_cast<int64_t>(sz);
 }
 
+// Same as topk_mb_workspace_size but for the one-block (ob) path, which Python
+// uses to size the cached scratch buffer it passes into the ob dispatch.
+int64_t topk_ob_workspace_size(int64_t numRows, int64_t stride0, int64_t k, bool is_decode)
+{
+    const int32_t batch  = static_cast<int>(numRows);
+    const int32_t stride = static_cast<int>(stride0);
+    const int kTopK      = static_cast<int>(k);
+    const size_t sz      = is_decode
+                               ? query_ob_workspace<aiter::Phase::Decode>(batch, stride, kTopK)
+                               : query_ob_workspace<aiter::Phase::Prefill>(batch, stride, kTopK);
+    return static_cast<int64_t>(sz);
+}
+
 bool topk_use_mulblocks(int64_t numRows, int64_t stride0)
 {
     return aiter::should_use_mulblocks(static_cast<int>(numRows), stride0);
@@ -2826,20 +2836,22 @@ void radix_topk_dispatch(void* buf,
 }
 
 // Prefill entry: dispatches to mb or ob based on batch size and seq_len.
-// `workspace` (optional): a caller-provided, zero-initialized persistent buffer
-// for the mb path (see get_topk_mb_workspace in topk.py). When given, the host
-// memset is skipped and the kernel self_resets it; when absent, the mb path
-// falls back to a fresh per-call buffer + memset (back-compat).
-void top_k_per_row_prefill(const torch::Tensor& logits,
-                           const torch::Tensor& rowStarts,
-                           const torch::Tensor& rowEnds,
-                           torch::Tensor& indices,
-                           std::optional<torch::Tensor> values,
+// `workspace` is a caller-provided persistent buffer, allocated + cached on the
+// Python side (get_topk_mb_workspace / get_topk_scratch_workspace in topk.py)
+// and passed in so this host code never allocates device scratch itself (torch's
+// caching allocator manages the buffer). The mb path expects a zero-initialized
+// buffer (the host memset is skipped and the kernel self_resets it); the ob path
+// uses it as plain scratch (the kernel does its own internal memset).
+void top_k_per_row_prefill(const aiter_tensor_t& logits,
+                           const aiter_tensor_t& rowStarts,
+                           const aiter_tensor_t& rowEnds,
+                           aiter_tensor_t& indices,
+                           std::optional<aiter_tensor_t> values,
                            int64_t numRows,
                            int64_t stride0,
                            int64_t /*stride1*/,
                            int64_t k = 2048,
-                           std::optional<torch::Tensor> workspace = std::nullopt,
+                           std::optional<aiter_tensor_t> workspace = std::nullopt,
                            bool stable = false)
 {
     if (numRows <= 0) return;
@@ -2848,27 +2860,30 @@ void top_k_per_row_prefill(const torch::Tensor& logits,
     static constexpr bool is_largest = true;
     size_t buf_size                  = 0;
 
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(logits.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
     const int batch          = static_cast<int>(numRows);
-    auto options             = torch::TensorOptions().dtype(torch::kUInt8).device(logits.device());
 
-    float* logits_ptr      = logits.data_ptr<float>();
-    int* indices_ptr       = indices.data_ptr<int>();
-    int* row_starts_ptr    = rowStarts.data_ptr<int>();
-    int* row_ends_ptr      = rowEnds.data_ptr<int>();
-    float* values_ptr      = values.has_value() ? values->data_ptr<float>() : nullptr;
+    float* logits_ptr      = static_cast<float*>(logits.data_ptr());
+    int* indices_ptr       = static_cast<int*>(indices.data_ptr());
+    int* row_starts_ptr    = static_cast<int*>(rowStarts.data_ptr());
+    int* row_ends_ptr      = static_cast<int*>(rowEnds.data_ptr());
+    float* values_ptr      = values.has_value() ? static_cast<float*>(values.value().data_ptr()) : nullptr;
     const bool write_vals  = values.has_value();
+
+    AITER_CHECK(workspace.has_value(),
+                "top_k_per_row_prefill requires a caller-provided workspace "
+                "(see top_k_per_row_prefill in topk.py)");
+    void* ws_ptr = workspace.value().data_ptr();
 
     // stable=true: force the one-block path with the deterministic, ascending-
     // ordered, smallest-index tie-break emit (STABLE=true). This guarantees a
     // scheduling-independent top-k so every tensor-parallel rank selects and
     // orders an identical KV set. The multi-block persistent path is bypassed
-    // (its cross-block atomic emit is inherently order-dependent).
+    // (its cross-block atomic emit is inherently order-dependent). The caller
+    // sizes `workspace` for the ob path in this case (see topk.py).
     if (stable) {
         constexpr bool select_min = !is_largest;
-        const size_t ob_ws      = query_ob_workspace<aiter::Phase::Prefill>(batch, stride0, kTopK);
-        torch::Tensor ws        = torch::empty({static_cast<int64_t>(ob_ws)}, options);
-        void* ws_ptr            = static_cast<void*>(ws.data_ptr<uint8_t>());
         if (write_vals) {
             aiter::ob::dispatch_topk_oneblock<float, int, 1024, true, aiter::ob::Phase::Prefill, /*STABLE=*/true>(
                 ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
@@ -2884,18 +2899,9 @@ void top_k_per_row_prefill(const torch::Tensor& logits,
     }
 
     if (aiter::should_use_mulblocks(batch, stride0)) {
-        // Prefer the caller's persistent zeroed buffer (memset-free + self_reset);
-        // otherwise fall back to a fresh per-call buffer + the internal memset.
-        const bool prezeroed = workspace.has_value();
-        torch::Tensor fallback;
-        void* ws_ptr;
-        if (prezeroed) {
-            ws_ptr = workspace->data_ptr();
-        } else {
-            const size_t mb_ws = query_mb_workspace<aiter::Phase::Prefill>(batch, stride0, kTopK);
-            fallback = torch::empty({static_cast<int64_t>(mb_ws)}, options);
-            ws_ptr   = static_cast<void*>(fallback.data_ptr<uint8_t>());
-        }
+        // mb path: the caller-provided buffer is zero-initialized and the kernel
+        // self_resets it, so the host memset is skipped (prezeroed=true).
+        constexpr bool prezeroed = true;
         if (write_vals) {
             aiter::mb::standalone_stable_radix_topk<float, int, true, true, aiter::mb::Phase::Prefill>(
                 ws_ptr, buf_size, logits_ptr, batch, stride0,
@@ -2911,10 +2917,7 @@ void top_k_per_row_prefill(const torch::Tensor& logits,
         }
     } else {
         constexpr bool select_min = !is_largest;
-        // ob path keeps a fresh per-call buffer + its own internal memset.
-        const size_t ob_ws      = query_ob_workspace<aiter::Phase::Prefill>(batch, stride0, kTopK);
-        torch::Tensor workspace = torch::empty({static_cast<int64_t>(ob_ws)}, options);
-        void* ws_ptr            = static_cast<void*>(workspace.data_ptr<uint8_t>());
+        // ob path: caller-provided scratch; the kernel does its own internal memset.
         if (write_vals) {
             aiter::ob::dispatch_topk_oneblock<float, int, 1024, true, aiter::ob::Phase::Prefill>(
                 ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
@@ -2945,17 +2948,18 @@ void top_k_per_row_prefill(const torch::Tensor& logits,
 // The original mb/ob dispatch logic is preserved below (commented out) for
 // reference in case multi-block decode is revisited in the future.
 //
-// `workspace` parameter is kept in the signature for API compatibility but
-// is unused on the ob-only path.
-void top_k_per_row_decode(const torch::Tensor& logits,
+// `workspace` is a caller-provided scratch buffer, allocated + cached on the
+// Python side (see top_k_per_row_decode in topk.py); the ob path uses it
+// directly so this host code never allocates device scratch itself.
+void top_k_per_row_decode(const aiter_tensor_t& logits,
                           int64_t next_n,
-                          const torch::Tensor& seqLens,
-                          torch::Tensor& indices,
+                          const aiter_tensor_t& seqLens,
+                          aiter_tensor_t& indices,
                           int64_t numRows,
                           int64_t stride0,
                           int64_t /*stride1*/,
                           int64_t k = 2048,
-                          std::optional<torch::Tensor> workspace = std::nullopt,
+                          std::optional<aiter_tensor_t> workspace = std::nullopt,
                           bool stable = false)
 {
     if (numRows <= 0) return;
@@ -2965,18 +2969,20 @@ void top_k_per_row_decode(const torch::Tensor& logits,
     constexpr bool select_min        = !is_largest;
     size_t buf_size                  = 0;
 
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(logits.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
     const int batch          = static_cast<int>(numRows);
-    auto options             = torch::TensorOptions().dtype(torch::kUInt8).device(logits.device());
 
-    float* logits_ptr = logits.data_ptr<float>();
-    int* indices_ptr  = indices.data_ptr<int>();
-    int* seq_lens_ptr = seqLens.data_ptr<int>();
+    float* logits_ptr = static_cast<float*>(logits.data_ptr());
+    int* indices_ptr  = static_cast<int*>(indices.data_ptr());
+    int* seq_lens_ptr = static_cast<int*>(seqLens.data_ptr());
+
+    AITER_CHECK(workspace.has_value(),
+                "top_k_per_row_decode requires a caller-provided workspace "
+                "(see top_k_per_row_decode in topk.py)");
+    void* ws_ptr = workspace.value().data_ptr();
 
     // Always use one-block path for decode.
-    const size_t ob_ws         = query_ob_workspace<aiter::Phase::Decode>(batch, stride0, kTopK);
-    torch::Tensor ob_workspace = torch::empty({static_cast<int64_t>(ob_ws)}, options);
-    void* ws_ptr               = static_cast<void*>(ob_workspace.data_ptr<uint8_t>());
     // stable=true: deterministic ascending-ordered, smallest-index tie-break
     // emit so every TP rank selects and orders an identical KV set.
     if (stable) {
@@ -2996,27 +3002,15 @@ void top_k_per_row_decode(const torch::Tensor& logits,
         select_min, stream, /*sorted=*/true, static_cast<int>(next_n));
 
     // --- Original mb/ob dispatch (commented out for reference) ---
+    // Both branches take the caller-provided `workspace` (no device allocation
+    // here); the mb buffer is zeroed + self_reset by the kernel (prezeroed=true).
     // if (aiter::should_use_mulblocks(batch, stride0)) {
-    //     const bool prezeroed = workspace.has_value();
-    //     torch::Tensor fallback;
-    //     void* ws_ptr;
-    //     if (prezeroed) {
-    //         ws_ptr = workspace->data_ptr();
-    //     } else {
-    //         const size_t mb_ws = query_mb_workspace<aiter::Phase::Decode>(batch, stride0, kTopK);
-    //         fallback = torch::empty({static_cast<int64_t>(mb_ws)}, options);
-    //         ws_ptr   = static_cast<void*>(fallback.data_ptr<uint8_t>());
-    //     }
     //     aiter::mb::standalone_stable_radix_topk<float, int, false, true, aiter::mb::Phase::Decode>(
     //         ws_ptr, buf_size, logits_ptr, batch, stride0,
     //         /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
     //         kTopK, /*out=*/nullptr, indices_ptr,
-    //         is_largest, stream, static_cast<int>(next_n), prezeroed);
+    //         is_largest, stream, static_cast<int>(next_n), /*prezeroed=*/true);
     // } else {
-    //     constexpr bool select_min = !is_largest;
-    //     const size_t ob_ws         = query_ob_workspace<aiter::Phase::Decode>(batch, stride0, kTopK);
-    //     torch::Tensor ob_workspace = torch::empty({static_cast<int64_t>(ob_ws)}, options);
-    //     void* ws_ptr               = static_cast<void*>(ob_workspace.data_ptr<uint8_t>());
     //     aiter::ob::dispatch_topk_oneblock<float, int, 1024, false, aiter::ob::Phase::Decode>(
     //         ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
     //         batch, stride0,

--- a/csrc/kernels/topk_plain_kernels.cu
+++ b/csrc/kernels/topk_plain_kernels.cu
@@ -31,17 +31,14 @@
 // See detailed examples and explanations inline with each strategy class.
 // ============================================================================
 
-#include <ATen/hip/HIPContext.h>
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
-#include <torch/all.h>
-
 #include <hip/hip_runtime.h>
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
 
-#include "dispatch_utils.h"
+#include "aiter_tensor.h"
+#include "aiter_stream.h"
+#include "aiter_dispatch.h"
 #include "opus/opus.hpp"
-#include "py_itfs_common.h"
 #include "quick_all_reduce_base.h"
 
 #define HIP_CHECK(val)                                \
@@ -105,6 +102,7 @@ void topk_per_row_kernel_launcher(const float* in,
                                   int stride0,
                                   int stride1,
                                   int k,
+                                  void* workspace,
                                   hipStream_t stream);
 
 // Helper function to determine if topk_per_row kernel should be used
@@ -2357,6 +2355,7 @@ void AdaptiveTopK(int batch_size,
                   const T* __restrict__ in,
                   T* __restrict__ out,
                   IdxT* __restrict__ out_idx,
+                  void* workspace,
                   hipStream_t stream = 0)
 {
     assert(k <= buffer_load_helpers::MAX_CAPACITY);
@@ -2378,11 +2377,13 @@ void AdaptiveTopK(int batch_size,
                                                static_cast<int>(len),
                                                1,
                                                k,
+                                               workspace,
                                                stream);
 
             return;
         }
     }
+    (void)workspace; // only the radix path above consumes the caller workspace
 
     const int capacity  = utils::calc_capacity(k);
     int block_per_batch = 0;
@@ -2420,6 +2421,7 @@ void AdaptiveTopK(int batch_size,
                   const IdxT* __restrict__ rowEnds,
                   int64_t stride0,
                   int64_t stride1,
+                  void* workspace,
                   hipStream_t stream = 0)
 {
     assert(k <= buffer_load_helpers::MAX_CAPACITY);
@@ -2441,6 +2443,7 @@ void AdaptiveTopK(int batch_size,
                                                static_cast<int>(stride0),
                                                static_cast<int>(stride1),
                                                k,
+                                               workspace,
                                                stream);
 
             return;
@@ -2458,13 +2461,17 @@ void AdaptiveTopK(int batch_size,
             if(len <= 0)
                 continue;
 
-            // Call the uniform length version for each batch
+            // Call the uniform length version for each batch. The single caller
+            // workspace is reused serially across batches (same stream); it is
+            // sized for the top-level (batch, stride0) call, which dominates each
+            // per-batch (1, len) size, so it is always large enough.
             AdaptiveTopK<greater, T, IdxT>(1, // single batch
                                            len,
                                            k,
                                            in + batch_id * stride0 + start * stride1,
                                            out + batch_id * k,
                                            out_idx + batch_id * k,
+                                           workspace,
                                            stream);
         }
     }
@@ -2472,7 +2479,10 @@ void AdaptiveTopK(int batch_size,
 
 } // namespace topk
 
-// Helper function to call topk_per_row kernel (outside topk namespace)
+// Helper function to call topk_per_row kernel (outside topk namespace).
+// `workspace` is a caller-provided device scratch buffer, allocated + cached on
+// the Python side (see topk_plain in topk_plain.py) and sized via
+// topk_plain_workspace_size, so this launcher never allocates device memory.
 template <typename IdxT>
 void topk_per_row_kernel_launcher(const float* in,
                                   const IdxT* rowStarts,
@@ -2483,18 +2493,17 @@ void topk_per_row_kernel_launcher(const float* in,
                                   int stride0,
                                   int stride1,
                                   int k,
+                                  void* workspace,
                                   hipStream_t stream)
 {
+    AITER_CHECK(workspace != nullptr,
+                "topk_plain: the radix top-k path requires a caller-provided workspace");
 
     size_t buf_size = 0;
     static constexpr bool is_largest = true;
 
-    int64_t workspace_size = invokeComputeTopkLastDimWorkspaceSize<float>(batch_size, stride0, k);
-    auto options            = torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA);
-    torch::Tensor workspace = torch::empty({workspace_size}, options);
-
     radix_topk_dispatch(
-        static_cast<void*>(workspace.data_ptr<uint8_t>()),
+        workspace,
         buf_size,
         in,
         batch_size,
@@ -2508,54 +2517,65 @@ void topk_per_row_kernel_launcher(const float* in,
         stream);
 }
 
-void topk_plain(torch::Tensor& values,   // [batch, len]
-                torch::Tensor& topk_ids, // [batch, k]
-                torch::Tensor& topk_out, // [batch, k]
+// Map the hip runtime element type bound by the dispatch macro to the ck_tile
+// element type the kernels expect (torch-free replacement for t2ck).
+template <typename T> struct hip2ck;
+template <> struct hip2ck<float>        { using type = ck_tile::fp32_t; };
+template <> struct hip2ck<__half>       { using type = ck_tile::fp16_t; };
+template <> struct hip2ck<hip_bfloat16> { using type = ck_tile::bf16_t; };
+
+void topk_plain(aiter_tensor_t& values,   // [batch, len]
+                aiter_tensor_t& topk_ids, // [batch, k]
+                aiter_tensor_t& topk_out, // [batch, k]
                 int topk,
                 bool largest,
-                torch::Tensor rowStarts,
-                torch::Tensor rowEnds,
+                std::optional<aiter_tensor_t> rowStarts,
+                std::optional<aiter_tensor_t> rowEnds,
                 int64_t stride0,
-                int64_t stride1)
+                int64_t stride1,
+                std::optional<aiter_tensor_t> workspace)
 {
     const int32_t max_len = values.size(-1);
     const int32_t batch   = values.size(0);
 
-    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(values.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    // Caller-provided device scratch for the radix path (fp32 only); allocated +
+    // cached on the Python side and passed in so this host code never allocates.
+    void* ws_ptr = workspace.has_value() ? workspace.value().data_ptr() : nullptr;
 
     // Check if we're using variable length mode
-    // Empty tensors have defined() = true but numel() = 0, so check both
-    const bool use_variable_length =
-        rowStarts.defined() && rowEnds.defined() && rowStarts.numel() > 0 && rowEnds.numel() > 0;
+    // Empty tensors are conveyed as nullopt or numel()==0, so check both.
+    const bool use_variable_length = rowStarts.has_value() && rowEnds.has_value() &&
+                                     rowStarts.value().numel() > 0 && rowEnds.value().numel() > 0;
 
     // Set default stride values if not specified
     if(stride0 < 0)
         stride0 = max_len;
 
     // Dispatch based on value tensor dtype
-    VLLM_DISPATCH_FLOATING_TYPES(values.scalar_type(), "topk_plain", [&] {
-        using input_dtype = typename t2ck<scalar_t>::type;
+    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(values.dtype(), "topk_plain", [&] {
+        using input_dtype = typename hip2ck<scalar_t>::type;
         // Dispatch based on index tensor dtype
-        if(topk_ids.scalar_type() != torch::kInt32)
+        if(topk_ids.dtype() != AITER_DTYPE_i32)
         {
-            AT_ERROR("Unsupported index type for topk_ids");
+            AITER_CHECK(false, "topk_plain: unsupported index type for topk_ids");
         }
 
         using IdxT = int32_t;
-        // Get raw pointers using the PyTorch scalar_t type, not input_dtype
-        const scalar_t* values_ptr = values.data_ptr<scalar_t>();
-        scalar_t* topk_out_ptr     = topk_out.data_ptr<scalar_t>();
-        IdxT* topk_ids_ptr         = topk_ids.data_ptr<IdxT>();
-
-        // Cast to input_dtype for the kernel
-        const input_dtype* values_kernel_ptr = reinterpret_cast<const input_dtype*>(values_ptr);
-        input_dtype* topk_out_kernel_ptr     = reinterpret_cast<input_dtype*>(topk_out_ptr);
+        // aiter_tensor_t::data_ptr() is void*; cast straight to the kernel element
+        // type (bit-identical layout to the hip runtime type bound above).
+        const input_dtype* values_kernel_ptr =
+            static_cast<const input_dtype*>(values.data_ptr());
+        input_dtype* topk_out_kernel_ptr = static_cast<input_dtype*>(topk_out.data_ptr());
+        IdxT* topk_ids_ptr               = static_cast<IdxT*>(topk_ids.data_ptr());
 
         if(use_variable_length)
         {
             // Variable length mode: use rowStarts/rowEnds
-            const IdxT* rowStarts_ptr = rowStarts.data_ptr<IdxT>();
-            const IdxT* rowEnds_ptr   = rowEnds.data_ptr<IdxT>();
+            const IdxT* rowStarts_ptr = static_cast<const IdxT*>(rowStarts.value().data_ptr());
+            const IdxT* rowEnds_ptr   = static_cast<const IdxT*>(rowEnds.value().data_ptr());
 
             if(largest)
             {
@@ -2569,6 +2589,7 @@ void topk_plain(torch::Tensor& values,   // [batch, len]
                                                             rowEnds_ptr,
                                                             stride0,
                                                             stride1,
+                                                            ws_ptr,
                                                             stream);
             }
             else
@@ -2583,6 +2604,7 @@ void topk_plain(torch::Tensor& values,   // [batch, len]
                                                              rowEnds_ptr,
                                                              stride0,
                                                              stride1,
+                                                             ws_ptr,
                                                              stream);
             }
         }
@@ -2596,6 +2618,7 @@ void topk_plain(torch::Tensor& values,   // [batch, len]
                                                             values_kernel_ptr,
                                                             topk_out_kernel_ptr,
                                                             topk_ids_ptr,
+                                                            ws_ptr,
                                                             stream);
             }
             else
@@ -2606,8 +2629,19 @@ void topk_plain(torch::Tensor& values,   // [batch, len]
                                                              values_kernel_ptr,
                                                              topk_out_kernel_ptr,
                                                              topk_ids_ptr,
+                                                             ws_ptr,
                                                              stream);
             }
         }
     });
+}
+
+// Exposed to Python so topk_plain's radix scratch can be sized, allocated and
+// cached on the Python side (torch caching allocator) and passed in. Returns the
+// max(mb, ob) workspace for the float radix path; only fp32 inputs reach that
+// path, so non-fp32 callers do not need to allocate a workspace at all.
+int64_t topk_plain_workspace_size(int64_t numRows, int64_t stride0, int64_t k)
+{
+    return invokeComputeTopkLastDimWorkspaceSize<float, aiter::Phase::Prefill>(
+        static_cast<int32_t>(numRows), static_cast<int32_t>(stride0), static_cast<int>(k));
 }

--- a/csrc/pybind/topk_per_row_pybind.cu
+++ b/csrc/pybind/topk_per_row_pybind.cu
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "rocm_ops.hpp"
 #include "topk_per_row.h"
+#include "aiter_stream.h"
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {

--- a/csrc/pybind/topk_plain_pybind.cu
+++ b/csrc/pybind/topk_plain_pybind.cu
@@ -3,6 +3,7 @@
 */
 #include "topk_plain.h"
 #include "rocm_ops.hpp"
+#include "aiter_stream.h"
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {


### PR DESCRIPTION
Build-time drop (rebuilt from a clean tree): `module_top_k_per_row`
~47s → ~33s, `module_topk_plain` ~127s → ~92s.



### 1. Remove torch/ATen from the compiled TUs (Strategy A, `develop=True`)
`topk_per_row_kernels.cu` and `topk_plain_kernels.cu` no longer `#include` the
torch/ATen/c10 header tree — the single biggest JIT build-time cost. The host
entry points now take POD `aiter_tensor_t` (optional args via
`std::optional<aiter_tensor_t>`); the Python `@compile_ops(..., develop=True)`
decorator auto-converts `torch.Tensor` args and sets the HIP stream
(`AITER_SET_STREAM_PYBIND`). `topk_plain` additionally gets a torch-free
`hip2ck` type map (replacing `t2ck`) and `VLLM_DISPATCH_FLOATING_TYPES_rmTorch`.



### 2. Externalize device scratch (no more in-C++ `AiterTensor::empty`)
The kernels previously self-allocated scratch. `AiterTensor::empty`/`zeros` go
through `hipMallocAsync`/`hipMalloc` with **no block reuse**, unlike
`torch.empty` (torch caching allocator). The scratch is now produced Python-side
(torch-cached) and passed in via an optional `workspace` param, backed by new
size-query ops (`topk_mb_workspace_size` / `topk_ob_workspace_size` /
`topk_plain_workspace_size`). C++ `AITER_CHECK`s a caller-provided buffer instead
of allocating. Workspace sizes exactly match the original `torch::empty({...})`
sizing; the mb path reuses a zeroed, self-reset cached buffer.

## Compatibility

This also merges with the new `stable` top-k parameter (deterministic,
ascending-ordered, smallest-index tie-break so every TP rank selects an identical
KV set): when `stable=True` the one-block path is forced and runs on the
caller-provided workspace (no device allocation in C++).

## Testing

- [x] `op_tests/test_topk_per_row.py` — PASS
- [x] `op_tests/test_topk_row_prefill.py` — PASS
- [x] `op_tests/test_topk_plain.py` — PASS

## Dependencies

- [x] No new third-party dependencies added

