### PR TITLE
Make AITER prebuild thread count configurable

### DIFF
--- a/.github/scripts/aiter_prebuild_summary.py
+++ b/.github/scripts/aiter_prebuild_summary.py
@@ -59,6 +59,9 @@ def main() -> int:
     print(f"GPU_ARCHS: {os.environ.get('GPU_ARCHS', 'unknown')}")
     print(f"PREBUILD_KERNELS: {os.environ.get('PREBUILD_KERNELS', 'unknown')}")
     print(f"MAX_JOBS: {os.environ.get('MAX_JOBS', 'unknown')}")
+    print(
+        f"AITER_PREBUILD_THREAD_NUM: {os.environ.get('AITER_PREBUILD_THREAD_NUM', 'unknown')}"
+    )
     print(f"Build status: {args.build_status}")
     print(f"Prebuild wall time: {wall_seconds}s ({wall_seconds / 60:.1f} min)")
     print(f"Kernel count: {len(kernels)}")

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -31,6 +31,7 @@ env:
   AITER_TEST: "op_tests"
   AITER_WHEEL_ARTIFACT_NAME: aiter-whl-${{ github.run_id }}
   AITER_PREBUILD_MAX_JOBS: "64"
+  AITER_PREBUILD_THREAD_NUM: "6"
   TRITON_WHEEL_ARTIFACT_NAME: triton_wheelhouse
 
 jobs:
@@ -113,6 +114,7 @@ jobs:
           docker run --rm \
             --network=host \
             -e AITER_PREBUILD_MAX_JOBS="${{ env.AITER_PREBUILD_MAX_JOBS }}" \
+            -e AITER_PREBUILD_THREAD_NUM="${{ env.AITER_PREBUILD_THREAD_NUM }}" \
             -e AITER_RUNNER_NAME="${RUNNER_NAME:-unknown}" \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
@@ -129,7 +131,7 @@ jobs:
               pip install --upgrade "ninja>=1.11.1" &&
               pip install --upgrade setuptools_scm &&
               pip install tabulate &&
-              echo "Prebuilding kernels with GPU_ARCHS: ${{ env.GPU_ARCH_LIST }}, PREBUILD_KERNELS: 1, and MAX_JOBS: ${AITER_PREBUILD_MAX_JOBS}" &&
+              echo "Prebuilding kernels with GPU_ARCHS: ${{ env.GPU_ARCH_LIST }}, PREBUILD_KERNELS: 1, MAX_JOBS: ${AITER_PREBUILD_MAX_JOBS}, and AITER_PREBUILD_THREAD_NUM: ${AITER_PREBUILD_THREAD_NUM}" &&
               export PREBUILD_KERNELS=1 &&
               export MAX_JOBS="${AITER_PREBUILD_MAX_JOBS}" &&
               export GPU_ARCHS="${{ env.GPU_ARCH_LIST }}" &&
@@ -163,6 +165,7 @@ jobs:
           GPU_ARCHS="${{ env.GPU_ARCH_LIST }}" \
           PREBUILD_KERNELS=1 \
           MAX_JOBS="${{ env.AITER_PREBUILD_MAX_JOBS }}" \
+          AITER_PREBUILD_THREAD_NUM="${{ env.AITER_PREBUILD_THREAD_NUM }}" \
           python3 .github/scripts/aiter_prebuild_summary.py \
             --log .aiter-prebuild.log \
             --build-status "${BUILD_STATUS}" \

--- a/setup.py
+++ b/setup.py
@@ -379,12 +379,21 @@ if PREBUILD_KERNELS != 0:
                 third_party=one_opt_args["third_party"],
             )
 
-        prebuid_thread_num = 5
+        prebuild_thread_num_env = os.environ.get("AITER_PREBUILD_THREAD_NUM")
+        if (
+            prebuild_thread_num_env is not None
+            and prebuild_thread_num_env.isdigit()
+            and int(prebuild_thread_num_env) > 0
+        ):
+            prebuild_thread_num = int(prebuild_thread_num_env)
+        else:
+            prebuild_thread_num = 5
         max_jobs = os.environ.get("MAX_JOBS")
         if max_jobs is not None and max_jobs.isdigit() and int(max_jobs) > 0:
-            prebuid_thread_num = min(prebuid_thread_num, int(max_jobs))
+            prebuild_thread_num = min(prebuild_thread_num, int(max_jobs))
         else:
-            prebuid_thread_num = min(prebuid_thread_num, getMaxJobs())
+            prebuild_thread_num = min(prebuild_thread_num, getMaxJobs())
+        prebuid_thread_num = prebuild_thread_num
         os.environ["PREBUILD_THREAD_NUM"] = str(prebuid_thread_num)
 
         # --- FlyDSL AOT pre-compilation (MOE + GEMM, before CK) ---


### PR DESCRIPTION
Make the AITER prebuild module thread count configurable through AITER_PREBUILD_THREAD_NUM and set the build wheel workflow to try 6 module workers while keeping AITER_PREBUILD_MAX_JOBS at 64. This keeps the total compile worker budget aligned with the dind 64 CPU limit while reducing low parallelism tail phases.