### PR TITLE
Restore RNG seed in test_fused_rms_quant (fix flaky mxfp4 quant CI)

### DIFF
--- a/op_tests/triton_tests/quant/test_fused_mxfp4_quant.py
+++ b/op_tests/triton_tests/quant/test_fused_mxfp4_quant.py
@@ -175,6 +175,8 @@ def test_fused_rms_quant(
     if not (arch_info.is_fp4_avail()):
         pytest.skip("MXFP4 not supported on this architecture")
 
+    torch.manual_seed(0)
+
     if inargs == "gluon" and arch_info.get_arch() != "gfx1250":
         pytest.skip("Gluon kernel only supported on gfx1250 hardware")
 


### PR DESCRIPTION
## Problem

`op_tests/triton_tests/quant/test_fused_mxfp4_quant.py::test_fused_rms_quant` fails intermittently in CI (**Triton Tests (MI35X) / Shard 7**) with a single dequantized MXFP4 element off by one quantum:

```
Mismatched elements: 1 / 26400
Greatest absolute difference: 0.25 (up to 1e-05 allowed)
Greatest relative difference: 0.5  (up to 1.3e-06 allowed)
```

The final assertion is a bare `torch.testing.assert_close` on dequantized MXFP4. MXFP4 quanta are coarse (0.25 is one representable step), so when an input element lands on a quantization boundary the torch reference and the Triton kernel break the tie differently and the near-exact float32 tolerance fails.

## Root cause

`test_fused_rms_quant` runs **unseeded**, so it draws fresh random data every invocation and only occasionally hits a boundary tie. This is a regression: #2562 fixed exactly this nondeterminism by seeding every test in the file, but #3093 (which added the `inargs` parameter and the gluon-skip guard to this test) removed its `torch.manual_seed(0)` in the same edit. The other four tests in the file are still seeded.

## Fix

Restore `torch.manual_seed(0)` at the top of `test_fused_rms_quant`, matching the other four tests in the file.

## Verification (gfx950 / MI355X)

Ran the full `test_fused_rms_quant` parametrization (576 cases) 10× on device:

- **Before** (unseeded, `main`): 6/10 of runs fail with the 0.25 boundary flip.
- **After** (this PR): 10/10 runs pass, 0 failures.

Stability across identical seeded runs also confirms the Triton kernel itself is deterministic — the seed was the sole cause.