### PR TITLE
feat: Support LoongArch64, LoongArch64 not support CodeModel=Large

### DIFF
--- a/aiter/jit/utils/cpp_extension.py
+++ b/aiter/jit/utils/cpp_extension.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import sysconfig
 import warnings
+import platform
 
 import setuptools
 from _cpp_extension_versioner import ExtensionVersioner
@@ -37,6 +38,9 @@ SHARED_FLAG = "-shared"
 SUBPROCESS_DECODE_ARGS = ()
 MINIMUM_GCC_VERSION = (5, 0, 0)
 MINIMUM_MSVC_VERSION = (19, 0, 24215)
+CMODEL = 'large'
+if platform.machine() == 'loongarch64':
+    CMODEL = 'extreme'
 
 VersionRange = tuple[tuple[int, ...], tuple[int, ...]]
 VersionMap = dict[str, VersionRange]
@@ -300,7 +304,7 @@ COMMON_HIPCC_FLAGS = [
     "-DCUDA_HAS_FP16=1",
     "-D__HIP_NO_HALF_OPERATORS__=1",
     "-D__HIP_NO_HALF_CONVERSIONS__=1",
-    "-mcmodel=large",
+    "-mcmodel=" + CMODEL,
     "-fno-unique-section-names",
     "-ffunction-sections",
     "-fdata-sections",
@@ -1470,7 +1474,7 @@ def verify_ninja_availability():
 
 
 def _prepare_ldflags(extra_ldflags, with_cuda, verbose, is_standalone, torch_exclude):
-    extra_ldflags.append("-mcmodel=large")
+    extra_ldflags.append("-mcmodel=" + CMODEL)
     extra_ldflags.append("-ffunction-sections")
     extra_ldflags.append("-fdata-sections ")
     extra_ldflags.append("-Wl,--gc-sections")


### PR DESCRIPTION
## Motivation

This ensures that the project generates the correct compilation commands when running on the LoongArch64 platform (with an AMD discrete graphics card).


## Technical Details

[llvm-project clang/lib/Sema/SemaDeclAttr.cpp](https://github.com/llvm/llvm-project/blob/17a2349c06b931d1692e26e98492ff5e1a7035a5/clang/lib/Sema/SemaDeclAttr.cpp#L3558)

## Test Plan

For currently supported architectures, such as amd64, there will be no behavioral difference before and after the current modification.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
