### PR TITLE
Fix NaN in MLA Gluon MTP decode by zeroing fully causal-masked KV spl…

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -169,7 +169,8 @@ if [[ "$mla_in_shard" == "true" && "$MULTIGPU" != "TRUE" ]]; then
         "-c 98304 -b 1 -n 16,1 -kvd fp8" \
         "-c 10000 100000 -b 1 3 4 -n 12,1 16,1 -kvd bf16 -lse" \
         "-c 1 21 63 64 65 256 -b 1 -n 16,1 -kvd bf16 -lse" \
-        "-c 16384 -b 4 -n 16,8 16,17 -kvd bf16"; do
+        "-c 16384 -b 4 -n 16,8 16,17 -kvd bf16" \
+        "-c 260 388 -b 1 2 -n 16,8 -kvd bf16"; do
         echo "=== extra: test_mla.py $args ===" | tee -a latest_test.log
         if ! timeout 10m python3 op_tests/test_mla.py $args 2>&1 | tee -a latest_test.log; then
             testFailed=true

--- a/aiter/ops/triton/gluon/mla_gluon.py
+++ b/aiter/ops/triton/gluon/mla_gluon.py
@@ -801,8 +801,8 @@ def _mla_softmax_reducev_kernel(
         tile_max = tl.max(lse, axis=0)  # scalar; masked/empty splits are -inf
         n_e_max = tl.maximum(e_max, tile_max)
         old_scale = tl.where(e_max == -float("inf"), 0.0, tl.exp(e_max - n_e_max))
-        # w=0 for empty/causal-masked splits (lse=-inf) so NaN logits never poison acc.
         w = tl.where(lse == -float("inf"), 0.0, tl.exp(lse - n_e_max))  # [BLOCK_S]
+        logits = tl.where(lse[:, None] == -float("inf"), 0.0, logits)
         acc = acc * old_scale + tl.sum(w[:, None] * logits, axis=0)
         e_sum = e_sum * old_scale + tl.sum(w, axis=0)
         e_max = n_e_max


### PR DESCRIPTION
## Motivation

Fix a NaN in the Gluon MLA decode kernel that corrupts MTP / speculative decode output (e.g. ctx=260, qlen=8, nhead=16 returned 50% NaN).

## Technical Details

Under MTP a KV split can be fully causal-masked for a query position, so stage-1 stores NaN logits with `lse=-inf`, and the stage-2 reduce's `0 * NaN = NaN` still poisoned `acc`; the fix zeroes such splits' logits before the weighted sum so they contribute exactly 0.

## Test Plan

Added a regression case (`-c 260 388 -b 1 2 -n 16,8 -kvd bf16`) to `aiter_test.sh`, which fails via `cal_diff`'s NaN assert without the fix and passes with it.

## Test Result

Reproduced 50% → 0% NaN at ctx=260/qlen=8/nhead=16, with output matching the torch reference across qlen 1–8, ctx {256, 260, 264, 388, 452}, and batch {1, 2, 4, 8}.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.