### PR TITLE
[FlyDSL] split-K hgemm: make semaphore/signal workspace CUDA-graph-capture safe

### DIFF
--- a/aiter/ops/flydsl/gemm_kernels.py
+++ b/aiter/ops/flydsl/gemm_kernels.py
@@ -697,8 +697,13 @@ def _register_all_configs():
 _register_all_configs()
 
 
+# Captured split-K semaphore/signal workspaces are kept alive for the process
+# lifetime so the graph-recorded zero-fill has valid backing storage on replay.
+_captured_split_k_keepalive: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+
 @functools.lru_cache(maxsize=128)
-def _get_split_k_tensors(
+def _get_split_k_tensors_cached(
     device: torch.device,
     stream: torch.cuda.Stream,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -707,6 +712,31 @@ def _get_split_k_tensors(
     )
     signal = torch.zeros((SPLIT_K_SEMAPHORE_MAX_LEN,), dtype=torch.int32, device=device)
     return semaphore, signal
+
+
+def _get_split_k_tensors(
+    device: torch.device,
+    stream: torch.cuda.Stream,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # During CUDA-graph capture the stream-cached buffers are unsafe: their
+    # zero-init ran once, eagerly, before capture, so it is not part of the graph.
+    # The split-K reduction decrements these counters as workgroups retire; on
+    # graph *replay* they are never re-zeroed, so the "last workgroup" reduction
+    # handshake never re-arms and the kernel hangs (the same failure mode fixed
+    # for the a16w16 ASM GEMM path in ROCm/aiter#4494). Allocate a fresh, zeroed
+    # workspace per capture so the zero-fill is recorded as a graph node and
+    # re-establishes the initial state on every replay; keep it alive for the
+    # process lifetime.
+    if torch.cuda.is_current_stream_capturing():
+        semaphore = torch.zeros(
+            (SPLIT_K_SEMAPHORE_MAX_LEN,), dtype=torch.int32, device=device
+        )
+        signal = torch.zeros(
+            (SPLIT_K_SEMAPHORE_MAX_LEN,), dtype=torch.int32, device=device
+        )
+        _captured_split_k_keepalive.append((semaphore, signal))
+        return semaphore, signal
+    return _get_split_k_tensors_cached(device, stream)
 
 
 def _check_split_k_semaphore_capacity(


### PR DESCRIPTION
## Summary
  The FlyDSL split-K GEMM path uses a per-`(device, stream)` semaphore/signal
  workspace from `_get_split_k_tensors`, memoized with `functools.lru_cache` and
  zero-initialized **once, eagerly**. The split-K reduction kernel treats these as
  atomic counters: each workgroup decrements as it retires and the "last workgroup"
  performs the cross-split reduction, which requires the counters to start at their
  zeroed state on **every** launch.

  Under **CUDA-graph capture + replay** this invariant breaks. The one-time
  `torch.zeros(...)` ran before capture, so it is **not recorded as a node in the
  graph**. On replay the workspace is never re-zeroed, the counters never return to
  their initial state, the last-workgroup handshake never re-arms, and the kernel
  **hangs**. This is the same failure mode fixed for the a16w16 ASM GEMM path in
  **#4494** — this PR applies the same remedy to the FlyDSL split-K path.

  Any split-K FlyDSL GEMM captured in a full CUDA graph is affected. In practice it
  shows up on skinny decode shapes that select `split_k` 4–8 (e.g. `N=1024/384,
  K=7168` at small M) inside a FULL decode cudagraph.

  ## Fix
  Mirror #4494:
  - Keep the eager fast path unchanged — the memoized allocator is renamed to
    `_get_split_k_tensors_cached` (still `lru_cache`d on `(device, stream)`).
  - In `_get_split_k_tensors`, when `torch.cuda.is_current_stream_capturing()` is
    true, allocate a **fresh, zeroed** workspace for that launch so the zero-fill is
    recorded as a graph node and re-establishes the initial counter state on every
    replay. Distinct captured launches therefore never alias one another's counters.
  - Keep captured workspaces alive for the process lifetime
    (`_captured_split_k_keepalive`) so the graph-recorded zero-fill always has valid
    backing storage.

  Call sites are unchanged — `_get_split_k_tensors(device, stream)` keeps its name
  and signature.