### PR TITLE
[opus_moe] Unify A8W4 Stage2 with a runtime-K decode pipeline

### DIFF
--- a/aiter/ops/opus/moe_stage1_a8w4.py
+++ b/aiter/ops/opus/moe_stage1_a8w4.py
@@ -12,6 +12,20 @@ from ..enum import ActivationType
 _OPUS_MOE_STAGE1_A8W4_SCALE_GROUP = 32
 
 
+def _opus_runtime_swiglu_limit(
+    swiglu_limit: float | None,
+    activation: int,
+) -> float:
+    """Normalize the clamp bound passed to Opus stage1 kernels.
+
+    ``None`` and ``0.0`` mean no configured clamp. SwiGLU retains its 7.0
+    default; Silu and Situv2 encode no clamp as positive infinity.
+    """
+    if activation == ActivationType.Swiglu.value:
+        return float(swiglu_limit) if swiglu_limit else 7.0
+    return float(swiglu_limit) if swiglu_limit else float("inf")
+
+
 def _contiguous(tensor: Tensor) -> Tensor:
     return tensor if tensor.is_contiguous() else tensor.contiguous()
 
@@ -105,10 +119,7 @@ def opus_moe_stage1_a8w4_fwd(
     block_m = int(block_m)
     kernelName = str(kernelName)
     activation = int(getattr(activation, "value", activation))
-    if swiglu_limit is None:
-        swiglu_limit = (
-            7.0 if activation == ActivationType.Swiglu.value else float("inf")
-        )
+    swiglu_limit = _opus_runtime_swiglu_limit(swiglu_limit, activation)
     inter_dim = int(w1.shape[1]) // 2
     if out is None:
         out_shape = (

--- a/aiter/ops/opus/moe_stage2_a8w4_fused_adapter.py
+++ b/aiter/ops/opus/moe_stage2_a8w4_fused_adapter.py
@@ -85,24 +85,19 @@ def stage2_cfg_values(cfg: dict, block_m) -> dict[str, object]:
         opus_a8w4_kid_reduce_block_n,
         opus_a8w4_kid_sort_block_m,
         opus_a8w4_kid_uses_route,
-        opus_a8w4_reduce_block_n_from_name,
     )
 
     sort_block_m = _cfg_int(block_m, _DEFAULT_SORT_BLOCK_M)
-    # Preferred path: explicit per-kid name encodes mode (atomic/bf16/fp8) + block_m,
-    # so a single kernelName2 column fully selects the kernel (FlyDSL-style).
+    # Exact kernelName2 lookup selects one kid and its fixed launch settings.
     name = _cfg_str(_cfg_first(cfg, "kernelName2", "kernel_name2", "stage2_kernel"))
     kid = opus_a8w4_kid_from_name(name)
     if kid is not None:
-        reduce_block_n = opus_a8w4_reduce_block_n_from_name(name)
-        if reduce_block_n is None:
-            reduce_block_n = opus_a8w4_kid_reduce_block_n(kid)
         return {
             "kernel_id": kid,
             "stage2_block_m": opus_a8w4_kid_block_m(kid),
             "stage2_sort_block_m": opus_a8w4_kid_sort_block_m(kid),
             "route_out": opus_a8w4_kid_uses_route(kid),
-            "stage2_reduce_block_n": reduce_block_n,
+            "stage2_reduce_block_n": opus_a8w4_kid_reduce_block_n(kid),
         }
     # Legacy fallback: explicit numeric columns.
     kernel_id = _cfg_int(

--- a/aiter/ops/opus/moe_stage2_a8w4_meta.py
+++ b/aiter/ops/opus/moe_stage2_a8w4_meta.py
@@ -9,16 +9,13 @@ kids without pulling in JIT registration or opus arch dispatch.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 
 OPUS_A8W4_OUT_MODE_ATOMIC = 0
 OPUS_A8W4_OUT_MODE_BF16 = 1
 OPUS_A8W4_OUT_MODE_FP8 = 2
 
-# Kid layout:
-# - 2000-2099: A8W4 decode algorithm candidates. K is selected by runtime
-#   effective inter dim at dispatch time, not encoded into the public kid.
+# Kids 2000-2099 select fixed launch settings while effective K remains runtime.
 OPUS_A8W4_KID_ATOMIC_BM16_BN64_B3_WS2 = 2000
 OPUS_A8W4_KID_ROUTE_FP8_BM32_OCC4_RBN2240 = 2001
 OPUS_A8W4_KID_ROUTE_FP8_BM32_OCC5_RBN2304 = 2002
@@ -32,8 +29,13 @@ OPUS_A8W4_KID_ATOMIC_BM16_BN256_B3_WS2 = 2009
 OPUS_A8W4_KID_ROUTE_FP8_BM64_SBM128_RBN3072 = 2010
 OPUS_A8W4_KID_ATOMIC_BM16_BN128_B3_WS2_BT256 = 2011
 OPUS_A8W4_KID_ATOMIC_BM32_BN128_OCC1_B2_WS2 = 2012
+OPUS_A8W4_KID_ROUTE_FP8_BM64_SBM64_RBN3584 = 2013
+OPUS_A8W4_KID_ROUTE_FP8_BM64_SBM128_RBN3584 = 2014
+OPUS_A8W4_KID_ROUTE_FP8_BM64_BT128_SBM64_RBN3072 = 2015
+OPUS_A8W4_KID_ROUTE_FP8_BM64_BT128_SBM128_RBN3584 = 2016
+OPUS_A8W4_KID_ROUTE_FP8_BM64_BT128_SBM128_RBN3072 = 2017
+OPUS_A8W4_KID_ATOMIC_BM32_BN128_OCC1_B3_WS2_RING4 = 2018
 
-_OPUS_A8W4_REDUCE_BLOCK_N_RE = re.compile(r"_rbn(\d+)$")
 _OPUS_A8W4_STAGE2_PREFIX = "opus_moe2_"
 _OPUS_A8W4_STAGE2_LAYOUT_PREFIX = "opus_moe2_layout_"
 
@@ -69,6 +71,8 @@ class OpusA8W4Stage2Instance:
     pace_route_blocks_to_pow2: bool = False
     block_threads: int = 0
     min_blocks_per_cu: int = 0
+    pair_slots: int = 1
+    steady_pair_slots: int = 1
     cachectl_b: int = 0
     cachectl_wscale: int = 0
     route_reduce: str | None = None
@@ -83,13 +87,6 @@ class OpusA8W4Stage2Instance:
     @property
     def route_out_fp8(self) -> bool:
         return self.out_mode == OPUS_A8W4_OUT_MODE_FP8
-
-    @property
-    def tuner_name(self) -> str:
-        route_reduce = opus_a8w4_route_reduce(self.route_reduce)
-        if route_reduce is None or route_reduce.suffix is None:
-            return self.name
-        return f"{self.name}_{route_reduce.suffix}"
 
     def tuner_params(self) -> dict[str, object]:
         route_reduce = opus_a8w4_route_reduce(self.route_reduce)
@@ -120,8 +117,6 @@ class OpusA8W4RouteReduceInstance:
     name: str
     block_n: int
     threads: int
-    suffix: str | None = None
-    auto_model_dims: tuple[int, ...] = ()
 
 
 OPUS_A8W4_GFX950_DECODE_KERNEL_CONTRACT = OpusA8W4KernelContract(
@@ -141,9 +136,6 @@ OPUS_A8W4_GFX950_DECODE_KERNEL_CONTRACT = OpusA8W4KernelContract(
     c_vec=4,
     c_values_per_atomic=2,
 )
-
-
-OPUS_A8W4_CODEGEN_SEED_EFFECTIVE_INTER_DIMS = (384, 512)
 
 
 def _opus_a8w4_k_step_packed() -> int:
@@ -166,42 +158,40 @@ OPUS_A8W4_ROUTE_REDUCE_INSTANCES = (
         name="rbn2240",
         block_n=2240,
         threads=280,
-        suffix="rbn2240",
     ),
     OpusA8W4RouteReduceInstance(
         name="rbn2304",
         block_n=2304,
         threads=288,
-        suffix="rbn2304",
     ),
     OpusA8W4RouteReduceInstance(
         name="rbn2816",
         block_n=2816,
         threads=176,
-        suffix="rbn2816",
     ),
     OpusA8W4RouteReduceInstance(
         name="rbn3072",
         block_n=3072,
         threads=384,
-        suffix="rbn3072",
     ),
     OpusA8W4RouteReduceInstance(
         name="rbn3584",
         block_n=3584,
         threads=448,
-        suffix="rbn3584",
     ),
 )
 
 OPUS_A8W4_ROUTE_REDUCE_BY_NAME = {
     inst.name: inst for inst in OPUS_A8W4_ROUTE_REDUCE_INSTANCES
 }
-OPUS_A8W4_ROUTE_REDUCE_BY_SUFFIX = {
-    inst.suffix: inst
-    for inst in OPUS_A8W4_ROUTE_REDUCE_INSTANCES
-    if inst.suffix is not None
-}
+
+
+def opus_a8w4_route_reduce(
+    name: str | None,
+) -> OpusA8W4RouteReduceInstance | None:
+    if name is None:
+        return None
+    return OPUS_A8W4_ROUTE_REDUCE_BY_NAME.get(str(name))
 
 
 def _atomic_stage2_instance(
@@ -213,6 +203,8 @@ def _atomic_stage2_instance(
     sort_block_m: int,
     block_threads: int = 0,
     min_blocks_per_cu: int = 0,
+    pair_slots: int = 1,
+    steady_pair_slots: int = 1,
     cachectl_b: int = 0,
     cachectl_wscale: int = 0,
     pace_route_blocks_to_pow2: bool = False,
@@ -231,6 +223,8 @@ def _atomic_stage2_instance(
         pace_route_blocks_to_pow2=pace_route_blocks_to_pow2,
         block_threads=block_threads,
         min_blocks_per_cu=min_blocks_per_cu,
+        pair_slots=pair_slots,
+        steady_pair_slots=steady_pair_slots,
         cachectl_b=cachectl_b,
         cachectl_wscale=cachectl_wscale,
         min_tuner_token=min_tuner_token,
@@ -247,7 +241,10 @@ def _route_stage2_instance(
     block_m: int,
     sort_block_m: int,
     route_reduce: str,
+    block_threads: int = 0,
     min_blocks_per_cu: int = 0,
+    pair_slots: int = 1,
+    steady_pair_slots: int = 1,
     cachectl_b: int = 0,
     min_tuner_token: int | None = None,
     max_tuner_token: int | None = None,
@@ -261,7 +258,10 @@ def _route_stage2_instance(
         block_n=256,
         sort_block_m=sort_block_m,
         direct_atomic=False,
+        block_threads=block_threads,
         min_blocks_per_cu=min_blocks_per_cu,
+        pair_slots=pair_slots,
+        steady_pair_slots=steady_pair_slots,
         cachectl_b=cachectl_b,
         route_reduce=route_reduce,
         min_tuner_token=min_tuner_token,
@@ -278,6 +278,8 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
         block_n=64,
         sort_block_m=16,
         block_threads=128,
+        pair_slots=2,
+        steady_pair_slots=2,
         cachectl_b=3,
         cachectl_wscale=2,
         max_tuner_token=1024,
@@ -290,6 +292,8 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
         block_n=128,
         sort_block_m=16,
         block_threads=128,
+        pair_slots=2,
+        steady_pair_slots=2,
         cachectl_b=3,
         cachectl_wscale=2,
         max_tuner_token=1024,
@@ -301,6 +305,8 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
         block_n=128,
         sort_block_m=16,
         block_threads=256,
+        pair_slots=2,
+        steady_pair_slots=2,
         cachectl_b=3,
         cachectl_wscale=2,
         max_tuner_token=1024,
@@ -312,13 +318,15 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
         block_n=256,
         sort_block_m=16,
         block_threads=128,
+        pair_slots=2,
+        steady_pair_slots=2,
         cachectl_b=3,
         cachectl_wscale=2,
         max_tuner_token=1024,
     ),
     _route_stage2_instance(
         kid=OPUS_A8W4_KID_ROUTE_FP8_BM32_OCC4_RBN2240,
-        name="opus_moe2_afp8_wfp4_fp8_t32x256x256_sbm32_occ4",
+        name="opus_moe2_afp8_wfp4_fp8_t32x256x256_sbm32_occ4_rbn2240",
         out_mode=OPUS_A8W4_OUT_MODE_FP8,
         block_m=32,
         sort_block_m=32,
@@ -329,7 +337,7 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
     ),
     _route_stage2_instance(
         kid=OPUS_A8W4_KID_ROUTE_FP8_BM32_OCC5_RBN2304,
-        name="opus_moe2_afp8_wfp4_fp8_t32x256x256_sbm32_occ5",
+        name="opus_moe2_afp8_wfp4_fp8_t32x256x256_sbm32_occ5_rbn2304",
         out_mode=OPUS_A8W4_OUT_MODE_FP8,
         block_m=32,
         sort_block_m=32,
@@ -340,21 +348,29 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
     ),
     _route_stage2_instance(
         kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_RBN3072,
-        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64",
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64_rbn3072",
         out_mode=OPUS_A8W4_OUT_MODE_FP8,
         block_m=64,
         sort_block_m=64,
         route_reduce="rbn3072",
+        block_threads=256,
+        min_blocks_per_cu=4,
+        pair_slots=2,
+        steady_pair_slots=1,
         min_tuner_token=128,
         mode_default=True,
     ),
     _route_stage2_instance(
         kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_RBN3584,
-        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64",
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64_bt128_rbn3584",
         out_mode=OPUS_A8W4_OUT_MODE_FP8,
         block_m=64,
         sort_block_m=64,
         route_reduce="rbn3584",
+        block_threads=128,
+        min_blocks_per_cu=2,
+        pair_slots=2,
+        steady_pair_slots=2,
         min_tuner_token=128,
     ),
     _atomic_stage2_instance(
@@ -378,6 +394,8 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
         sort_block_m=32,
         block_threads=128,
         min_blocks_per_cu=1,
+        pair_slots=2,
+        steady_pair_slots=2,
         cachectl_b=2,
         cachectl_wscale=2,
         min_tuner_token=1,
@@ -385,11 +403,15 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
     ),
     _route_stage2_instance(
         kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_RBN3072_B3,
-        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64_cache_b3",
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64_cache_b3_rbn3072",
         out_mode=OPUS_A8W4_OUT_MODE_FP8,
         block_m=64,
         sort_block_m=64,
         route_reduce="rbn3072",
+        block_threads=128,
+        min_blocks_per_cu=2,
+        pair_slots=2,
+        steady_pair_slots=2,
         cachectl_b=3,
         min_tuner_token=128,
     ),
@@ -405,13 +427,96 @@ OPUS_A8W4_DECODE_STAGE2_INSTANCES = (
     ),
     _route_stage2_instance(
         kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_SBM128_RBN3072,
-        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm128",
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm128_rbn3072",
         out_mode=OPUS_A8W4_OUT_MODE_FP8,
         block_m=64,
         sort_block_m=128,
         route_reduce="rbn3072",
-        min_tuner_token=4096,
-        max_tuner_token=32768,
+        block_threads=256,
+        min_blocks_per_cu=4,
+        pair_slots=2,
+        steady_pair_slots=1,
+        min_tuner_token=128,
+    ),
+    _route_stage2_instance(
+        kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_SBM64_RBN3584,
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64_rbn3584",
+        out_mode=OPUS_A8W4_OUT_MODE_FP8,
+        block_m=64,
+        sort_block_m=64,
+        route_reduce="rbn3584",
+        block_threads=256,
+        min_blocks_per_cu=4,
+        pair_slots=2,
+        steady_pair_slots=1,
+        min_tuner_token=128,
+    ),
+    _route_stage2_instance(
+        kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_SBM128_RBN3584,
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm128_rbn3584",
+        out_mode=OPUS_A8W4_OUT_MODE_FP8,
+        block_m=64,
+        sort_block_m=128,
+        route_reduce="rbn3584",
+        block_threads=256,
+        min_blocks_per_cu=4,
+        pair_slots=2,
+        steady_pair_slots=1,
+        min_tuner_token=128,
+    ),
+    _route_stage2_instance(
+        kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_BT128_SBM64_RBN3072,
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm64_bt128_rbn3072",
+        out_mode=OPUS_A8W4_OUT_MODE_FP8,
+        block_m=64,
+        sort_block_m=64,
+        route_reduce="rbn3072",
+        block_threads=128,
+        min_blocks_per_cu=2,
+        pair_slots=2,
+        steady_pair_slots=2,
+        min_tuner_token=128,
+    ),
+    _route_stage2_instance(
+        kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_BT128_SBM128_RBN3584,
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm128_bt128_rbn3584",
+        out_mode=OPUS_A8W4_OUT_MODE_FP8,
+        block_m=64,
+        sort_block_m=128,
+        route_reduce="rbn3584",
+        block_threads=128,
+        min_blocks_per_cu=2,
+        pair_slots=2,
+        steady_pair_slots=2,
+        min_tuner_token=128,
+    ),
+    _route_stage2_instance(
+        kid=OPUS_A8W4_KID_ROUTE_FP8_BM64_BT128_SBM128_RBN3072,
+        name="opus_moe2_afp8_wfp4_fp8_t64x256x256_sbm128_bt128_rbn3072",
+        out_mode=OPUS_A8W4_OUT_MODE_FP8,
+        block_m=64,
+        sort_block_m=128,
+        route_reduce="rbn3072",
+        block_threads=128,
+        min_blocks_per_cu=2,
+        pair_slots=2,
+        steady_pair_slots=2,
+        min_tuner_token=128,
+    ),
+    _atomic_stage2_instance(
+        kid=OPUS_A8W4_KID_ATOMIC_BM32_BN128_OCC1_B3_WS2_RING4,
+        name="opus_moe2_afp8_wfp4_atomic_t32x128x256_sbm32_occ1_cache_b3_ws2_ring4",
+        block_m=32,
+        block_n=128,
+        sort_block_m=32,
+        block_threads=128,
+        min_blocks_per_cu=1,
+        pair_slots=2,
+        steady_pair_slots=2,
+        cachectl_b=3,
+        cachectl_wscale=2,
+        min_tuner_token=1,
+        max_tuner_token=2048,
     ),
 )
 
@@ -426,10 +531,9 @@ OPUS_A8W4_STAGE2_INSTANCES = tuple(
 def _build_stage2_by_name() -> dict[str, OpusA8W4Stage2Instance]:
     by_name: dict[str, OpusA8W4Stage2Instance] = {}
     for inst in OPUS_A8W4_STAGE2_INSTANCES:
-        route_reduce = OPUS_A8W4_ROUTE_REDUCE_BY_NAME.get(inst.route_reduce)
-        if route_reduce is not None and route_reduce.suffix is not None:
-            by_name[f"{inst.name}_{route_reduce.suffix}"] = inst
-        by_name.setdefault(inst.name, inst)
+        if inst.name in by_name:
+            raise ValueError(f"duplicate Opus A8W4 stage2 name: {inst.name}")
+        by_name[inst.name] = inst
     return by_name
 
 
@@ -456,14 +560,6 @@ def _build_mode_default_by_mode_block_m() -> dict[tuple[int, int], int]:
 
 
 OPUS_A8W4_MODE_DEFAULT_BY_MODE_BLOCK_M = _build_mode_default_by_mode_block_m()
-
-
-def opus_a8w4_route_reduce(
-    name: str | None,
-) -> OpusA8W4RouteReduceInstance | None:
-    if name is None:
-        return None
-    return OPUS_A8W4_ROUTE_REDUCE_BY_NAME.get(str(name))
 
 
 def opus_a8w4_effective_inter_dim(
@@ -505,23 +601,9 @@ def _opus_a8w4_stage2_instance(kid: int) -> OpusA8W4Stage2Instance | None:
     return OPUS_A8W4_STAGE2_BY_KID.get(int(kid))
 
 
-def opus_a8w4_base_name(name: str) -> str:
-    return _OPUS_A8W4_REDUCE_BLOCK_N_RE.sub("", str(name).strip())
-
-
-def opus_a8w4_reduce_block_n_from_name(name) -> int | None:
-    m = _OPUS_A8W4_REDUCE_BLOCK_N_RE.search(str(name).strip())
-    if m is None:
-        return None
-    route_reduce = OPUS_A8W4_ROUTE_REDUCE_BY_SUFFIX.get(f"rbn{int(m.group(1))}")
-    return int(m.group(1)) if route_reduce is None else route_reduce.block_n
-
-
 def opus_a8w4_kid_from_name(name) -> int | None:
     name = opus_a8w4_dispatch_name(name)
     inst = OPUS_A8W4_STAGE2_BY_NAME.get(name)
-    if inst is None:
-        inst = OPUS_A8W4_STAGE2_BY_NAME.get(opus_a8w4_base_name(name))
     return None if inst is None else inst.kid
 
 
@@ -595,7 +677,7 @@ def get_opus_a8w4_stage2_kernels(
     token: int | None = None,
 ) -> dict[str, dict[str, object]]:
     return {
-        inst.tuner_name: inst.tuner_params()
+        inst.name: inst.tuner_params()
         for inst in OPUS_A8W4_STAGE2_INSTANCES
         if inst.supports_tuner_token(token)
     }

--- a/csrc/opus_moe/README.md
+++ b/csrc/opus_moe/README.md
@@ -104,12 +104,13 @@ Host and shared code:
   metadata helpers.
 - `include/opus_moe_arch.cuh`: runtime architecture probe wrapper.
 - `include/opus_moe_host_impl.cuh`: host validation and launch selection.
-- `opus_moe.cu`: pybind-facing translation unit.
+- `opus_moe.cu`: pybind-facing host-only translation unit. It deliberately
+  does not include any device pipeline in its device pass.
 
 gfx950 code:
 
-- `include/gfx950/opus_moe_arch_gfx950.cuh`: gfx950 launch wrappers and BF16
-  generated manifest dispatch.
+- `include/gfx950/opus_moe_arch_gfx950.cuh`: lightweight gfx950 BF16 host
+  launch and dispatch.
 - `include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh`: shared
   token/topk route-output reduction.
 - `include/gfx950/opus_moe_stage2_utils_gfx950.cuh`: small gfx950 device
@@ -133,7 +134,7 @@ Python/JIT code:
   reduce wrapper.
 - `aiter/ops/opus/moe_stage2_a8w4_fused_adapter.py`: fused MoE CSV parsing and
   stage2 wrapper glue for A8W4.
-- `gen_instances.py`: JIT-time private BF16 and A8W4 manifest generator.
+- `gen_instances.py`: JIT-time private BF16 and A8W4 manifest/TU generator.
 - `opus_moe_common.py`: private BF16 metadata plus the A8W4 metadata bridge for
   manifest codegen.
 
@@ -143,7 +144,15 @@ Python/JIT code:
 `opus_moe_stage2_a8w4_manifest.h` into the JIT build blob. The first generated
 header is consumed by private BF16 dispatch source; the second is consumed by
 the A8W4 dispatch wrapper for
-`kid -> OpusMoeStage2A8W4DecodeShape -> launcher` cases.
+`kid -> effective_inter_dim -> launch specialization` cases.
+
+Host launch templates stay in their C++ dispatch headers and see only kernel
+forward declarations. The generator emits device-only shards: one A8W4 stage2
+shard per effective inter dim, one Stage1 shard per pipeline family, one
+route-reduce shard per specialized topk, and one private BF16 shard. Each shard
+uses explicit kernel instantiation. This keeps the exact specialization set and
+GPU ISA while allowing Ninja to compile the otherwise independent device work
+in parallel; do not include device pipelines from `opus_moe.cu`.
 
 A8W4 production selection should be done through the fused MoE tuned
 configuration by adding `opus_...` stage2 kernel names only for measured cases

--- a/csrc/opus_moe/gen_instances.py
+++ b/csrc/opus_moe/gen_instances.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
-"""Generate Opus MoE dispatch headers.
+"""Generate Opus MoE dispatch headers and device-instantiation shards.
 
 This is intentionally smaller than ``csrc/opus_gemm/gen_instances.py`` today:
 several kernels still live in hand-written headers, but the generated
@@ -13,6 +13,7 @@ import argparse
 import csv
 import glob
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -34,7 +35,7 @@ from opus_moe_common import (
     opus_a8w4_stage1_shape_requirements,
 )
 
-MANIFEST_HEADER = """#pragma once
+BF16_MANIFEST_HEADER = """#pragma once
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 //
@@ -105,22 +106,18 @@ STAGE1_A8W4_MANIFEST_HEADER = """#pragma once
 
 
 def _emit_bf16_manifest_header() -> str:
-    lines = [MANIFEST_HEADER]
+    lines = [BF16_MANIFEST_HEADER]
     bf16_kernels = [STAGE2_BF16_KERNELS[kid] for kid in sorted(STAGE2_BF16_KERNELS)]
 
-    lines.append(f"#define OPUS_MOE_STAGE2_BF16_TUNE_LOOKUP_SIZE {len(bf16_kernels)}\n")
     if not bf16_kernels:
-        lines.append("#define GENERATE_OPUS_MOE_STAGE2_BF16_TUNE_LOOKUP\n\n")
+        lines.append("#define GENERATE_OPUS_MOE_STAGE2_BF16_DISPATCH_CASES\n\n")
     else:
-        lines.append("#define GENERATE_OPUS_MOE_STAGE2_BF16_TUNE_LOOKUP \\\n")
+        lines.append("#define GENERATE_OPUS_MOE_STAGE2_BF16_DISPATCH_CASES \\\n")
         for idx, inst in enumerate(bf16_kernels):
             suffix = " \\\n" if idx != len(bf16_kernels) - 1 else "\n"
             lines.append(
-                "    {"
-                f"{inst.kid}, "
-                f"&{inst.launcher}<"
-                f"{inst.trait}>"
-                "}," + suffix
+                f"    case {inst.kid}: return &{inst.launcher}<{inst.trait}>;"
+                + suffix
             )
     lines.append("\n")
 
@@ -148,6 +145,33 @@ def _cpp_name_suffix(name: str) -> str:
 
 def _cpp_effective_contract_alias(effective_inter_dim: int) -> str:
     return f"OpusMoeStage2A8W4Eff{effective_inter_dim}Contract"
+
+
+def _stage2_a8w4_traits_alias(kid: int, effective_inter_dim: int) -> str:
+    return (
+        f"OpusMoeStage2A8W4DecodeKid{int(kid)}" f"Eff{int(effective_inter_dim)}Traits"
+    )
+
+
+def _stage2_a8w4_traits_type(inst, effective_inter_dim: int) -> str:
+    return (
+        "OpusMoeStage2A8W4DecodeShape<"
+        f"opus_moe::{_cpp_effective_contract_alias(effective_inter_dim)}, "
+        f"{inst.block_m}, "
+        f"{inst.block_n}, "
+        f"{inst.sort_block_m}, "
+        f"{_cpp_bool(inst.direct_atomic)}, "
+        f"{_cpp_bool(inst.pace_route_blocks_to_pow2)}, "
+        f"{inst.block_threads}, "
+        f"{inst.min_blocks_per_cu}, "
+        f"{inst.cachectl_b}, "
+        f"{inst.cachectl_wscale}"
+        ">"
+    )
+
+
+def _stage1_a8w4_traits_alias(kid: int) -> str:
+    return f"OpusMoeStage1A8W4Kid{int(kid)}Traits"
 
 
 def _expand_tune_paths(spec: str | None) -> list[Path]:
@@ -413,9 +437,6 @@ def _emit_stage2_a8w4_manifest_header(effective_inter_dims: tuple[int, ...]) -> 
     lines = [A8W4_MANIFEST_HEADER]
     a8w4_kernels = [STAGE2_A8W4_KERNELS[kid] for kid in sorted(STAGE2_A8W4_KERNELS)]
 
-    lines.append(
-        f"#define OPUS_MOE_STAGE2_A8W4_DECODE_LOOKUP_SIZE {len(a8w4_kernels)}\n"
-    )
     if not a8w4_kernels:
         lines.append("#define GENERATE_OPUS_MOE_STAGE2_A8W4_DECODE_DISPATCH_CASES\n")
         return "".join(lines)
@@ -428,18 +449,8 @@ def _emit_stage2_a8w4_manifest_header(effective_inter_dims: tuple[int, ...]) -> 
             contract_cases.append(
                 f"case {effective_dim}: "
                 "return opus_moe_stage2_a8w4_decode_launch_gfx950<"
-                "OpusMoeStage2A8W4DecodeShape<"
-                f"opus_moe::{_cpp_effective_contract_alias(effective_dim)}, "
-                f"{inst.block_m}, "
-                f"{inst.block_n}, "
-                f"{inst.sort_block_m}, "
-                f"{_cpp_bool(inst.direct_atomic)}, "
-                f"{_cpp_bool(inst.pace_route_blocks_to_pow2)}, "
-                f"{inst.block_threads}, "
-                f"{inst.min_blocks_per_cu}, "
-                f"{inst.cachectl_b}, "
-                f"{inst.cachectl_wscale}"
-                ">>(kargs, stream);"
+                f"{_stage2_a8w4_traits_type(inst, effective_dim)}>"
+                "(kargs, stream);"
             )
         lines.append(
             f"    case {inst.kid}: switch(effective_inter_dim) {{ "
@@ -586,18 +597,174 @@ def _emit_stage1_a8w4_manifest_header() -> str:
         suffix = " \\\n" if idx != len(kernels) - 1 else "\n"
         lines.append(
             f"    case {inst.kid}: "
-            f"return launch<{_stage1_cpp_shape(inst)}>("
+            f"return launch_gfx950<{_stage1_cpp_shape(inst)}>("
             "effective_inter_dim, sorted_blocks, kargs, stream);" + suffix
         )
     lines.append("\n")
     return "".join(lines)
 
 
+# ---- Device translation-unit generation -----------------------------------
+
+
+def _route_reduce_instantiation_rows() -> list[tuple[int, int]]:
+    rows = [
+        (2048, 256),
+        (4096, 256),
+        *(
+            (int(inst.block_n), int(inst.threads))
+            for inst in OPUS_A8W4_ROUTE_REDUCE_INSTANCES
+        ),
+    ]
+    return list(dict.fromkeys(rows))
+
+
+class OpusMoeDeviceCodegen:
+    """Emit independently compilable device-instantiation shards."""
+
+    def __init__(self, working_path: Path, effective_inter_dims: tuple[int, ...]):
+        self.instances_path = working_path / "instances"
+        self.effective_inter_dims = effective_inter_dims
+
+    def _prepare_dirs(self) -> None:
+        if self.instances_path.exists():
+            shutil.rmtree(self.instances_path)
+        self.instances_path.mkdir(parents=True, exist_ok=True)
+
+    def _emit_stage2_device_tus(self) -> None:
+        for effective_dim in self.effective_inter_dims:
+            lines = [
+                "// SPDX-License-Identifier: MIT\n",
+                "// Auto-generated A8W4 stage2 device shard; do not edit.\n",
+                '#include "gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh"\n',
+            ]
+            seen_traits: set[str] = set()
+            for inst in (
+                STAGE2_A8W4_KERNELS[kid] for kid in sorted(STAGE2_A8W4_KERNELS)
+            ):
+                traits_type = _stage2_a8w4_traits_type(inst, effective_dim)
+                if traits_type in seen_traits:
+                    continue
+                seen_traits.add(traits_type)
+                alias = _stage2_a8w4_traits_alias(inst.kid, effective_dim)
+                lines.extend(
+                    [
+                        f"using {alias} = {traits_type};\n",
+                        "template __global__ void opus_moe_stage2_a8w4_decode_kernel_gfx950<",
+                        f"{alias}>(opus_moe_stage2_a8w4_kargs);\n",
+                    ]
+                )
+            path = (
+                self.instances_path
+                / f"opus_moe_stage2_a8w4_k_{effective_dim}.device.cu"
+            )
+            path.write_text("".join(lines), encoding="utf-8")
+
+    def _emit_stage1_device_tus(self) -> None:
+        families = (
+            (
+                True,
+                "group_split",
+                "opus_moe_stage1_a8w4_pipeline_group_split_gfx950.cuh",
+                "opus_moe_stage1_a8w4_kernel_group_split_gfx950",
+            ),
+            (
+                False,
+                "pair_kwave",
+                "opus_moe_stage1_a8w4_pipeline_pair_kwave_gfx950.cuh",
+                "opus_moe_stage1_a8w4_kernel_pair_kwave_gfx950",
+            ),
+        )
+        for group_split, namespace, header, kernel in families:
+            instances = [
+                STAGE1_A8W4_KERNELS[kid]
+                for kid in sorted(STAGE1_A8W4_KERNELS)
+                if bool(STAGE1_A8W4_KERNELS[kid].gate_up_group_split) == group_split
+            ]
+            if not instances:
+                continue
+            lines = [
+                "// SPDX-License-Identifier: MIT\n",
+                "// Auto-generated A8W4 stage1 device shard; do not edit.\n",
+                f'#include "gfx950/a8w4/stage1/{header}"\n',
+                "namespace opus_moe\n{\nnamespace stage1_a8w4\n{\n",
+            ]
+            for inst in instances:
+                lines.append(
+                    f"using {_stage1_a8w4_traits_alias(inst.kid)} = {_stage1_cpp_shape(inst)};\n"
+                )
+            lines.append(f"namespace pipeline_{namespace}\n{{\n")
+            for inst in instances:
+                alias = _stage1_a8w4_traits_alias(inst.kid)
+                lines.extend(
+                    [
+                        f"template __global__ void {kernel}<",
+                        f"{alias}>(OpusMoeStage1A8W4Kargs);\n",
+                    ]
+                )
+            lines.extend(
+                [
+                    f"}} // namespace pipeline_{namespace}\n",
+                    "} // namespace stage1_a8w4\n",
+                    "} // namespace opus_moe\n",
+                ]
+            )
+            path = self.instances_path / f"opus_moe_stage1_a8w4_{namespace}.device.cu"
+            path.write_text("".join(lines), encoding="utf-8")
+
+    def _emit_route_reduce_device_tus(self) -> None:
+        for topk in (0, 4, 6, 8):
+            lines = [
+                "// SPDX-License-Identifier: MIT\n",
+                "// Auto-generated route-reduce device shard; do not edit.\n",
+                "#define OPUS_MOE_ROUTE_REDUCE_DEVICE_TU 1\n",
+                '#include "gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh"\n',
+            ]
+            for block_n, threads in _route_reduce_instantiation_rows():
+                for route_fp8 in (False, True):
+                    lines.extend(
+                        [
+                            "template __global__ void ",
+                            "opus_moe_stage2_reduce_token_slot_route_output_kernel_gfx950<",
+                            f"{block_n}, {threads}, {topk}, {_cpp_bool(route_fp8)}>(",
+                            "opus_moe_stage2_route_reduce_kargs);\n",
+                        ]
+                    )
+            path = self.instances_path / f"opus_moe_route_reduce_topk_{topk}.device.cu"
+            path.write_text("".join(lines), encoding="utf-8")
+
+    def _emit_bf16_device_tu(self) -> None:
+        lines = [
+            "// SPDX-License-Identifier: MIT\n",
+            "// Auto-generated BF16 stage2 device shard; do not edit.\n",
+            '#include "gfx950/a16w16/opus_moe_pipeline_stage2_gemmstyle_gfx950.cuh"\n',
+        ]
+        for inst in (STAGE2_BF16_KERNELS[kid] for kid in sorted(STAGE2_BF16_KERNELS)):
+            lines.extend(
+                [
+                    "template __global__ void opus_moe_stage2_gemmstyle_kernel_gfx950<",
+                    f"{inst.trait}>(opus_moe_stage2_bf16_kargs);\n",
+                ]
+            )
+        (self.instances_path / "opus_moe_stage2_bf16.device.cu").write_text(
+            "".join(lines), encoding="utf-8"
+        )
+
+    def gen_instances(self) -> None:
+        self._prepare_dirs()
+        self._emit_stage2_device_tus()
+        self._emit_stage1_device_tus()
+        self._emit_route_reduce_device_tus()
+        self._emit_bf16_device_tu()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate Opus MoE dispatch headers")
     parser.add_argument("--working_path", required=True)
     parser.add_argument(
-        "--tune_files", default="", help="Accepted for JIT compatibility."
+        "--tune_files",
+        default="",
+        help="Colon-separated tuned FMoE CSV paths/globs used to collect shapes.",
     )
     parser.add_argument(
         "--tune_file", default=None, help="Deprecated alias for --tune_files."
@@ -632,6 +799,7 @@ def main() -> None:
     stage1_a8w4_manifest_path.write_text(
         _emit_stage1_a8w4_manifest_header(), encoding="utf-8"
     )
+    OpusMoeDeviceCodegen(out_dir, effective_inter_dims).gen_instances()
 
     print(
         f"[opus_moe gen_instances] wrote {bf16_manifest_path} with "
@@ -648,6 +816,10 @@ def main() -> None:
         f"{len(STAGE1_A8W4_KERNELS)} A8W4 stage1 kid(s)"
     )
     print(f"[opus_moe gen_instances] wrote {stage1_a8w4_meta_path}")
+    print(
+        f"[opus_moe gen_instances] wrote {len(effective_inter_dims)} stage2 device shard(s), "
+        "2 stage1 shard(s), 4 route-reduce shard(s), and 1 BF16 shard"
+    )
 
 
 if __name__ == "__main__":

--- a/csrc/opus_moe/gen_instances.py
+++ b/csrc/opus_moe/gen_instances.py
@@ -10,9 +10,6 @@ manifests are the single source of truth for kid -> launcher mapping.
 from __future__ import annotations
 
 import argparse
-import csv
-import glob
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -22,16 +19,13 @@ if str(THIS_DIR) not in sys.path:
     sys.path.insert(0, str(THIS_DIR))
 
 from opus_moe_common import (
-    OPUS_A8W4_CODEGEN_SEED_EFFECTIVE_INTER_DIMS,
     OPUS_A8W4_GFX950_DECODE_KERNEL_CONTRACT,
-    OPUS_A8W4_OUT_MODE_ATOMIC,
     OPUS_A8W4_ROUTE_REDUCE_INSTANCES,
     OPUS_A8W4_STAGE1_MFMA_K,
     OPUS_A8W4_STAGE1_SCALE_GROUP_LOGICAL_K,
     STAGE1_A8W4_KERNELS,
     STAGE2_A8W4_KERNELS,
     STAGE2_BF16_KERNELS,
-    opus_a8w4_decode_kid,
     opus_a8w4_stage1_shape_requirements,
 )
 
@@ -116,8 +110,7 @@ def _emit_bf16_manifest_header() -> str:
         for idx, inst in enumerate(bf16_kernels):
             suffix = " \\\n" if idx != len(bf16_kernels) - 1 else "\n"
             lines.append(
-                f"    case {inst.kid}: return &{inst.launcher}<{inst.trait}>;"
-                + suffix
+                f"    case {inst.kid}: return &{inst.launcher}<{inst.trait}>;" + suffix
             )
     lines.append("\n")
 
@@ -143,29 +136,23 @@ def _cpp_name_suffix(name: str) -> str:
     )
 
 
-def _cpp_effective_contract_alias(effective_inter_dim: int) -> str:
-    return f"OpusMoeStage2A8W4Eff{effective_inter_dim}Contract"
+def _stage2_a8w4_traits_alias(kid: int) -> str:
+    return f"OpusMoeStage2A8W4DecodeKid{int(kid)}Traits"
 
 
-def _stage2_a8w4_traits_alias(kid: int, effective_inter_dim: int) -> str:
-    return (
-        f"OpusMoeStage2A8W4DecodeKid{int(kid)}" f"Eff{int(effective_inter_dim)}Traits"
-    )
-
-
-def _stage2_a8w4_traits_type(inst, effective_inter_dim: int) -> str:
+def _stage2_a8w4_traits_type(inst) -> str:
     return (
         "OpusMoeStage2A8W4DecodeShape<"
-        f"opus_moe::{_cpp_effective_contract_alias(effective_inter_dim)}, "
         f"{inst.block_m}, "
         f"{inst.block_n}, "
-        f"{inst.sort_block_m}, "
         f"{_cpp_bool(inst.direct_atomic)}, "
         f"{_cpp_bool(inst.pace_route_blocks_to_pow2)}, "
         f"{inst.block_threads}, "
         f"{inst.min_blocks_per_cu}, "
         f"{inst.cachectl_b}, "
-        f"{inst.cachectl_wscale}"
+        f"{inst.cachectl_wscale}, "
+        f"{inst.pair_slots}, "
+        f"{inst.steady_pair_slots}"
         ">"
     )
 
@@ -174,100 +161,16 @@ def _stage1_a8w4_traits_alias(kid: int) -> str:
     return f"OpusMoeStage1A8W4Kid{int(kid)}Traits"
 
 
-def _expand_tune_paths(spec: str | None) -> list[Path]:
-    if spec:
-        patterns = [pattern.strip() for pattern in str(spec).split(os.pathsep)]
-    else:
-        configs_dir = THIS_DIR.parents[1] / "aiter" / "configs"
-        patterns = [
-            str(configs_dir / "tuned_fmoe.csv"),
-            str(configs_dir / "model_configs" / "*tuned_fmoe*.csv"),
-        ]
-    out: list[Path] = []
-    seen: set[Path] = set()
-    for pattern in patterns:
-        if not pattern:
-            continue
-        for raw_path in sorted(glob.glob(pattern)):
-            path = Path(raw_path)
-            if "untuned" in path.name or path in seen:
-                continue
-            seen.add(path)
-            out.append(path)
-    return out
-
-
-def _is_a8w4_tuned_row(row: dict[str, str]) -> bool:
-    return (
-        (row.get("q_dtype_a") or "").strip() == "torch.float8_e4m3fn"
-        and (row.get("q_dtype_w") or "").strip() == "torch.float4_e2m1fn_x2"
-        and (row.get("q_type") or "").strip() == "QuantType.per_1x32"
-    )
-
-
-def _validate_effective_inter_dims(effective_inter_dims: set[int]) -> tuple[int, ...]:
-    k = OPUS_A8W4_GFX950_DECODE_KERNEL_CONTRACT
-    if k.bk_logical % k.fp4_values_per_byte != 0:
-        raise ValueError(
-            "Opus A8W4 kernel contract requires bk_logical divisible by "
-            "fp4_values_per_byte"
-        )
-    k_step_packed = k.bk_logical // k.fp4_values_per_byte
-    dims = tuple(sorted({int(dim) for dim in effective_inter_dims}))
-    for dim in dims:
-        if dim <= 0 or dim % k_step_packed != 0:
-            raise ValueError(
-                "Opus A8W4 effective inter dims must be positive and divisible "
-                f"by K_STEP_PACKED={k_step_packed}, got {dim}"
-            )
-    return dims
-
-
-def _collect_a8w4_effective_inter_dims(tune_files: str | None) -> tuple[int, ...]:
-    effective_inter_dims = set(OPUS_A8W4_CODEGEN_SEED_EFFECTIVE_INTER_DIMS)
-    for path in _expand_tune_paths(tune_files):
-        with path.open(newline="") as f:
-            for row in csv.DictReader(f):
-                if _is_a8w4_tuned_row(row):
-                    effective_inter_dims.add(int(row["inter_dim"]))
-    return _validate_effective_inter_dims(effective_inter_dims)
-
-
 # ---- A8W4 stage2 metadata and dispatch manifests ---------------------------
 
 
-def _emit_stage2_a8w4_meta_header(effective_inter_dims: tuple[int, ...]) -> str:
+def _emit_stage2_a8w4_meta_header() -> str:
     lines = [A8W4_META_HEADER]
     k = OPUS_A8W4_GFX950_DECODE_KERNEL_CONTRACT
     a8w4_kernels = [STAGE2_A8W4_KERNELS[kid] for kid in sorted(STAGE2_A8W4_KERNELS)]
     block_ms = sorted({inst.block_m for inst in a8w4_kernels})
-    sort_block_ms = sorted({inst.sort_block_m for inst in a8w4_kernels})
     block_ns = sorted({inst.block_n for inst in a8w4_kernels})
 
-    lines.extend(
-        [
-            "template<int EffectiveInterDim>\n",
-            "struct OpusMoeStage2A8W4DecodeContract\n{\n",
-            "    static constexpr int DECODE_LOGICAL_INTER_DIM = EffectiveInterDim;\n",
-            "    static constexpr int DECODE_INTER_DIM_PAD = 0;\n",
-            "    static constexpr int DECODE_EFFECTIVE_INTER_DIM = EffectiveInterDim;\n",
-            "};\n\n",
-        ]
-    )
-    for effective_inter_dim in effective_inter_dims:
-        lines.append(
-            f"using {_cpp_effective_contract_alias(effective_inter_dim)} = "
-            "OpusMoeStage2A8W4DecodeContract<"
-            f"{effective_inter_dim}>;\n"
-        )
-    lines.extend(
-        [
-            (
-                "using OpusMoeStage2A8W4DefaultContract = "
-                f"{_cpp_effective_contract_alias(effective_inter_dims[0])};\n\n"
-            ),
-        ]
-    )
     for block_m in block_ms:
         lines.append(f"constexpr int kStage2A8W4DecodeBlockM{block_m} = {block_m};\n")
     for block_n in block_ns:
@@ -289,10 +192,6 @@ def _emit_stage2_a8w4_meta_header(effective_inter_dims: tuple[int, ...]) -> str:
             f"constexpr int kStage2A8W4DecodeMfmaK = {k.mfma_k};\n",
             f"constexpr int kStage2A8W4DecodeFp4ValuesPerByte = {k.fp4_values_per_byte};\n",
             f"constexpr int kStage2A8W4DecodeVectorBytes = {k.vector_bytes};\n",
-            (
-                "constexpr int kStage2A8W4DecodeScaleGroupLogicalK = "
-                f"{k.scale_group_logical_k};\n"
-            ),
             (
                 "constexpr int kStage2A8W4DecodeScaleGroupsPerRowPack = "
                 f"{k.scale_groups_per_row_pack};\n"
@@ -338,20 +237,11 @@ def _emit_stage2_a8w4_meta_header(effective_inter_dims: tuple[int, ...]) -> str:
     lines.append("\n")
 
     lines.append(
-        "constexpr int stage2_a8w4_route_reduce_auto_block_n(int model_dim)\n{\n    switch(model_dim)\n    {\n"
+        "constexpr int stage2_a8w4_kid_sort_block_m(int kid)\n"
+        "{\n    switch(kid)\n    {\n"
     )
-    for inst in OPUS_A8W4_ROUTE_REDUCE_INSTANCES:
-        suffix = _cpp_name_suffix(inst.name)
-        for auto_model_dim in inst.auto_model_dims:
-            model_dim = (
-                f"kStage2A8W4RouteReduce{suffix}BlockN"
-                if auto_model_dim == inst.block_n
-                else str(auto_model_dim)
-            )
-            lines.append(
-                f"    case {model_dim}: "
-                f"return kStage2A8W4RouteReduce{suffix}BlockN;\n"
-            )
+    for inst in a8w4_kernels:
+        lines.append(f"    case {inst.kid}: return {inst.sort_block_m};\n")
     lines.append("    default: return -1;\n    }\n}\n\n")
 
     lines.append(
@@ -362,20 +252,6 @@ def _emit_stage2_a8w4_meta_header(effective_inter_dims: tuple[int, ...]) -> str:
     lines.append("        return true;\n    default: return false;\n    }\n}\n\n")
 
     lines.append(
-        "constexpr int stage2_a8w4_kid_block_m(int kid)\n{\n    switch(kid)\n    {\n"
-    )
-    for inst in a8w4_kernels:
-        lines.append(f"    case {inst.kid}: return {inst.block_m};\n")
-    lines.append("    default: return -1;\n    }\n}\n\n")
-
-    lines.append(
-        "constexpr int stage2_a8w4_kid_sort_block_m(int kid)\n{\n    switch(kid)\n    {\n"
-    )
-    for inst in a8w4_kernels:
-        lines.append(f"    case {inst.kid}: return {inst.sort_block_m};\n")
-    lines.append("    default: return -1;\n    }\n}\n\n")
-
-    lines.append(
         "constexpr int stage2_a8w4_kid_block_n(int kid)\n{\n    switch(kid)\n    {\n"
     )
     for inst in a8w4_kernels:
@@ -383,12 +259,15 @@ def _emit_stage2_a8w4_meta_header(effective_inter_dims: tuple[int, ...]) -> str:
     lines.append("    default: return -1;\n    }\n}\n\n")
 
     lines.append(
-        "constexpr bool stage2_a8w4_effective_inter_dim_is_supported(int effective_inter_dim)\n"
-        "{\n    switch(effective_inter_dim)\n    {\n"
+        "constexpr bool stage2_a8w4_effective_inter_dim_is_supported(\n"
+        "    int effective_inter_dim)\n"
+        "{\n"
+        "    constexpr int kStepPacked =\n"
+        "        kStage2A8W4DecodeBKLogical / kStage2A8W4DecodeFp4ValuesPerByte;\n"
+        "    return effective_inter_dim >= 2 * kStepPacked &&\n"
+        "           effective_inter_dim % kStepPacked == 0;\n"
+        "}\n\n"
     )
-    for effective_inter_dim in effective_inter_dims:
-        lines.append(f"    case {effective_inter_dim}:\n")
-    lines.append("        return true;\n    default: return false;\n    }\n}\n\n")
 
     lines.append(
         "constexpr bool stage2_a8w4_kid_uses_route_out(int kid)\n{\n    switch(kid)\n    {\n"
@@ -412,28 +291,19 @@ def _emit_stage2_a8w4_meta_header(effective_inter_dims: tuple[int, ...]) -> str:
     lines.append('    default: return "unknown";\n    }\n}\n\n')
 
     lines.append(
-        "constexpr int stage2_a8w4_auto_direct_atomic_kid("
-        "int effective_inter_dim, int block_m)\n{\n"
-        "    if(!stage2_a8w4_effective_inter_dim_is_supported(effective_inter_dim))\n"
-        "        return -1;\n"
+        "constexpr int stage2_a8w4_auto_direct_atomic_kid(int block_m)\n{\n"
         "    switch(block_m)\n"
         "    {\n"
     )
-    for block_m in sort_block_ms:
-        try:
-            kid = opus_a8w4_decode_kid(
-                OPUS_A8W4_OUT_MODE_ATOMIC,
-                block_m,
-            )
-        except ValueError:
-            continue
-        lines.append(f"    case {block_m}: return {kid};\n")
+    for inst in a8w4_kernels:
+        if inst.direct_atomic and inst.mode_default:
+            lines.append(f"    case {inst.sort_block_m}: return {inst.kid};\n")
     lines.append("    default: return -1;\n    }\n}\n")
     lines.append(A8W4_META_FOOTER)
     return "".join(lines)
 
 
-def _emit_stage2_a8w4_manifest_header(effective_inter_dims: tuple[int, ...]) -> str:
+def _emit_stage2_a8w4_manifest_header() -> str:
     lines = [A8W4_MANIFEST_HEADER]
     a8w4_kernels = [STAGE2_A8W4_KERNELS[kid] for kid in sorted(STAGE2_A8W4_KERNELS)]
 
@@ -444,19 +314,10 @@ def _emit_stage2_a8w4_manifest_header(effective_inter_dims: tuple[int, ...]) -> 
     lines.append("#define GENERATE_OPUS_MOE_STAGE2_A8W4_DECODE_DISPATCH_CASES \\\n")
     for idx, inst in enumerate(a8w4_kernels):
         suffix = " \\\n" if idx != len(a8w4_kernels) - 1 else "\n"
-        contract_cases = []
-        for effective_dim in effective_inter_dims:
-            contract_cases.append(
-                f"case {effective_dim}: "
-                "return opus_moe_stage2_a8w4_decode_launch_gfx950<"
-                f"{_stage2_a8w4_traits_type(inst, effective_dim)}>"
-                "(kargs, stream);"
-            )
         lines.append(
-            f"    case {inst.kid}: switch(effective_inter_dim) {{ "
-            + " ".join(contract_cases)
-            + " default: break; } break;"
-            + suffix
+            f"    case {inst.kid}: "
+            "return opus_moe_stage2_a8w4_decode_launch_gfx950<"
+            f"{_stage2_a8w4_traits_type(inst)}>(kargs, stream);" + suffix
         )
     lines.append("\n")
     return "".join(lines)
@@ -622,9 +483,8 @@ def _route_reduce_instantiation_rows() -> list[tuple[int, int]]:
 class OpusMoeDeviceCodegen:
     """Emit independently compilable device-instantiation shards."""
 
-    def __init__(self, working_path: Path, effective_inter_dims: tuple[int, ...]):
+    def __init__(self, working_path: Path):
         self.instances_path = working_path / "instances"
-        self.effective_inter_dims = effective_inter_dims
 
     def _prepare_dirs(self) -> None:
         if self.instances_path.exists():
@@ -632,33 +492,28 @@ class OpusMoeDeviceCodegen:
         self.instances_path.mkdir(parents=True, exist_ok=True)
 
     def _emit_stage2_device_tus(self) -> None:
-        for effective_dim in self.effective_inter_dims:
-            lines = [
-                "// SPDX-License-Identifier: MIT\n",
-                "// Auto-generated A8W4 stage2 device shard; do not edit.\n",
-                '#include "gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh"\n',
-            ]
-            seen_traits: set[str] = set()
-            for inst in (
-                STAGE2_A8W4_KERNELS[kid] for kid in sorted(STAGE2_A8W4_KERNELS)
-            ):
-                traits_type = _stage2_a8w4_traits_type(inst, effective_dim)
-                if traits_type in seen_traits:
-                    continue
-                seen_traits.add(traits_type)
-                alias = _stage2_a8w4_traits_alias(inst.kid, effective_dim)
-                lines.extend(
-                    [
-                        f"using {alias} = {traits_type};\n",
-                        "template __global__ void opus_moe_stage2_a8w4_decode_kernel_gfx950<",
-                        f"{alias}>(opus_moe_stage2_a8w4_kargs);\n",
-                    ]
-                )
-            path = (
-                self.instances_path
-                / f"opus_moe_stage2_a8w4_k_{effective_dim}.device.cu"
+        lines = [
+            "// SPDX-License-Identifier: MIT\n",
+            "// Auto-generated runtime-K A8W4 stage2 device shard; do not edit.\n",
+            '#include "gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh"\n',
+        ]
+        seen_traits: set[str] = set()
+        for inst in (STAGE2_A8W4_KERNELS[kid] for kid in sorted(STAGE2_A8W4_KERNELS)):
+            traits_type = _stage2_a8w4_traits_type(inst)
+            if traits_type in seen_traits:
+                continue
+            seen_traits.add(traits_type)
+            alias = _stage2_a8w4_traits_alias(inst.kid)
+            lines.extend(
+                [
+                    f"using {alias} = {traits_type};\n",
+                    "template __global__ void opus_moe_stage2_a8w4_decode_kernel_gfx950<",
+                    f"{alias}>(opus_moe_stage2_a8w4_kargs);\n",
+                ]
             )
-            path.write_text("".join(lines), encoding="utf-8")
+        (self.instances_path / "opus_moe_stage2_a8w4.device.cu").write_text(
+            "".join(lines), encoding="utf-8"
+        )
 
     def _emit_stage1_device_tus(self) -> None:
         families = (
@@ -761,37 +616,18 @@ class OpusMoeDeviceCodegen:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate Opus MoE dispatch headers")
     parser.add_argument("--working_path", required=True)
-    parser.add_argument(
-        "--tune_files",
-        default="",
-        help="Colon-separated tuned FMoE CSV paths/globs used to collect shapes.",
-    )
-    parser.add_argument(
-        "--tune_file", default=None, help="Deprecated alias for --tune_files."
-    )
-    parser.add_argument(
-        "--arch", default=None, help="Optional arch filter, e.g. gfx950"
-    )
-    parser.add_argument(
-        "--cu-num", type=int, default=None, help="Optional CU-count filter"
-    )
     args = parser.parse_args()
-    if not args.tune_files and args.tune_file:
-        args.tune_files = args.tune_file
 
     out_dir = Path(args.working_path)
     out_dir.mkdir(parents=True, exist_ok=True)
-    effective_inter_dims = _collect_a8w4_effective_inter_dims(args.tune_files)
 
     bf16_manifest_path = out_dir / "opus_moe_stage2_manifest.h"
     bf16_manifest_path.write_text(_emit_bf16_manifest_header(), encoding="utf-8")
     stage2_a8w4_meta_path = out_dir / "opus_moe_stage2_a8w4_meta.h"
-    stage2_a8w4_meta_path.write_text(
-        _emit_stage2_a8w4_meta_header(effective_inter_dims), encoding="utf-8"
-    )
+    stage2_a8w4_meta_path.write_text(_emit_stage2_a8w4_meta_header(), encoding="utf-8")
     stage2_a8w4_manifest_path = out_dir / "opus_moe_stage2_a8w4_manifest.h"
     stage2_a8w4_manifest_path.write_text(
-        _emit_stage2_a8w4_manifest_header(effective_inter_dims), encoding="utf-8"
+        _emit_stage2_a8w4_manifest_header(), encoding="utf-8"
     )
     stage1_a8w4_meta_path = out_dir / "opus_moe_stage1_a8w4_meta.h"
     stage1_a8w4_meta_path.write_text(_emit_stage1_a8w4_meta_header(), encoding="utf-8")
@@ -799,7 +635,7 @@ def main() -> None:
     stage1_a8w4_manifest_path.write_text(
         _emit_stage1_a8w4_manifest_header(), encoding="utf-8"
     )
-    OpusMoeDeviceCodegen(out_dir, effective_inter_dims).gen_instances()
+    OpusMoeDeviceCodegen(out_dir).gen_instances()
 
     print(
         f"[opus_moe gen_instances] wrote {bf16_manifest_path} with "
@@ -807,8 +643,7 @@ def main() -> None:
     )
     print(
         f"[opus_moe gen_instances] wrote {stage2_a8w4_manifest_path} with "
-        f"{len(STAGE2_A8W4_KERNELS)} A8W4 stage2 kid(s), "
-        f"effective_inter_dims={effective_inter_dims}"
+        f"{len(STAGE2_A8W4_KERNELS)} runtime-K A8W4 stage2 kid(s)"
     )
     print(f"[opus_moe gen_instances] wrote {stage2_a8w4_meta_path}")
     print(
@@ -817,7 +652,7 @@ def main() -> None:
     )
     print(f"[opus_moe gen_instances] wrote {stage1_a8w4_meta_path}")
     print(
-        f"[opus_moe gen_instances] wrote {len(effective_inter_dims)} stage2 device shard(s), "
+        "[opus_moe gen_instances] wrote 1 runtime-K stage2 device shard, "
         "2 stage1 shard(s), 4 route-reduce shard(s), and 1 BF16 shard"
     )
 

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
@@ -206,298 +206,222 @@ inline __device__ bool opus_moe_stage2_a8w4_decode_load_route_metadata(
     }
 }
 
+// Runtime-K pipeline with a fixed-size LDS ring and compile-time slot indices.
 template<typename T,
-         typename V_A,
-         typename V_B,
          typename IssueAPayload,
          typename WaitAPayload,
-         typename LoadAPayload,
-         typename LoadBHalf,
          typename LoadBScale,
          typename LoadAScale,
-         typename ComputeHalf,
          typename ComputeTile>
-inline __device__ void opus_moe_stage2_a8w4_decode_run_k_scheduler_gfx950(
+inline __device__ void opus_moe_stage2_a8w4_decode_run_k_pipeline_gfx950(
+    int k_tiles,
     int col_base,
     int b_payload_row_stride_bytes,
     IssueAPayload& issue_a_payload,
     WaitAPayload& wait_a_payload,
-    LoadAPayload& load_a_payload,
-    LoadBHalf& load_b_half,
     LoadBScale& load_b_scale,
     LoadAScale& load_a_scale,
-    ComputeHalf& compute_half,
     ComputeTile& compute_tile)
 {
     using namespace opus;
 
-    static_assert(T::K_TILES >= 2);
-    using Schedule = OpusMoeStage2A8W4DecodeSchedule<T>;
-    using MainloopSchedule = OpusMoeStage2A8W4DecodeMainloopSchedule;
+    static_assert(T::A_LDS_STAGES == 2 * T::PAIR_SLOTS);
+    constexpr int TILES_PER_CHUNK = T::A_LDS_STAGES;
+    constexpr int B_TILE_BYTE_STEP =
+        T::K_STEP_PACKED * T::B_PAYLOAD_K_STRIDE_BYTES;
 
-    constexpr bool HasOddTail = (T::K_TILES & 1) != 0;
-    constexpr int PairCount = T::K_TILES / 2;
-    static_assert(PairCount >= 1);
-
-    constexpr int k0 = 0;
-    constexpr int k1 = T::K_STEP_PACKED;
-    constexpr int k2 = 2 * T::K_STEP_PACKED;
-    const int b_tile_base0 = opus_moe_stage2_a8w4_b_payload_tile_base_byte_offset<T>(
-        col_base, k0, b_payload_row_stride_bytes);
-    const int b_tile_base1 = opus_moe_stage2_a8w4_b_payload_tile_base_byte_offset<T>(
-        col_base, k1, b_payload_row_stride_bytes);
-    const int b_tile_base2 = opus_moe_stage2_a8w4_b_payload_tile_base_byte_offset<T>(
-        col_base, k2, b_payload_row_stride_bytes);
-
-    auto b_tile_base_for = [&](auto stage) {
-        constexpr int Stage = decltype(stage)::value;
-        if constexpr(Stage == 0)
-            return b_tile_base0;
-        else if constexpr(Stage == 1)
-            return b_tile_base1;
-        else if constexpr(Stage == 2)
-            return b_tile_base2;
-        else
-            return static_cast<int>(opus_moe_stage2_a8w4_b_payload_tile_base_byte_offset<T>(
-                col_base,
-                Stage * T::K_STEP_PACKED,
-                b_payload_row_stride_bytes));
-    };
-
-    auto load_scale_pair = [&](auto pair,
-                               int (&b_scale)[T::HALF_N_MFMA_PER_WAVE],
-                               int (&a_scale)[T::M_MFMA_PER_WAVE]) {
-        constexpr int scale_word_base =
-            decltype(pair)::value * T::SCALE_WORDS_PER_GROUP_PACK;
-        load_b_scale(scale_word_base, b_scale);
-        load_a_scale(scale_word_base, a_scale);
-    };
-
-    auto wait_a_tile_and_pending_b = [&]() {
-        if constexpr(Schedule::Mainloop == MainloopSchedule::SplitALoadByNWave)
-            wait_a_payload(1_I);
-        else
-            wait_a_payload(0_I);
-        s_waitcnt_vmcnt(number<T::HALF_N_MFMA_PER_WAVE>{});
-    };
-
-    auto compute_prefetched_even_tile = [&](int tile_base,
-                                            const V_A (&v_a_even)[T::M_MFMA_PER_WAVE],
-                                            const int (&a_scale)[T::M_MFMA_PER_WAVE],
-                                            const int (&b_scale)[T::HALF_N_MFMA_PER_WAVE]) {
-        V_B v_b_half0[T::HALF_N_MFMA_PER_WAVE];
-        V_B v_b_half1[T::HALF_N_MFMA_PER_WAVE];
-        load_b_half(0, tile_base, v_b_half0);
-        load_b_half(1, tile_base, v_b_half1);
-
-        __builtin_amdgcn_s_setprio(1);
-        compute_half(0_I, 0_I, v_a_even, a_scale, b_scale, v_b_half0);
-        s_waitcnt_vmcnt(0_I);
-        compute_half(0_I, 1_I, v_a_even, a_scale, b_scale, v_b_half1);
-        __builtin_amdgcn_s_setprio(0);
-    };
-
-    if constexpr(T::A_LDS_STAGES < T::K_TILES)
+    // Seed the guaranteed first K pair, then predicate optional ring slots.
+    issue_a_payload(0_I, 0);
+    issue_a_payload(1_I, T::K_STEP_PACKED);
+    if constexpr(T::A_LDS_STAGES == 4)
     {
-        static_assert(T::A_LDS_STAGES == T::A_LDS_STREAM_STAGES);
-
-        auto issue_streamed_a_tile = [&](auto stage_slot, int k_tile) {
-            const int k_base = k_tile * T::K_STEP_PACKED;
-            issue_a_payload(stage_slot, k_base);
-        };
-
-        auto compute_streamed_tile = [&](auto scale_pair,
-                                         auto stage_slot,
-                                         int k_tile,
-                                         const int (&b_scale)[T::HALF_N_MFMA_PER_WAVE],
-                                         const int (&a_scale)[T::M_MFMA_PER_WAVE]) {
-            const int k_base = k_tile * T::K_STEP_PACKED;
-            const int b_tile_base =
-                opus_moe_stage2_a8w4_b_payload_tile_base_byte_offset<T>(
-                    col_base, k_base, b_payload_row_stride_bytes);
-            compute_tile(
-                scale_pair,
-                0_I,
-                stage_slot,
-                b_tile_base,
-                b_scale,
-                a_scale);
-            __builtin_amdgcn_s_barrier();
-        };
-
-        #pragma unroll 1
-        for(int pair = 0; pair < T::K_TILES / 2; ++pair)
+        if(k_tiles > 2)
         {
-            int b_scale[T::HALF_N_MFMA_PER_WAVE];
-            int a_scale[T::M_MFMA_PER_WAVE];
-            const int scale_word_base = pair * T::SCALE_WORDS_PER_GROUP_PACK;
-            issue_streamed_a_tile(0_I, 2 * pair);
-            issue_streamed_a_tile(1_I, 2 * pair + 1);
-            load_b_scale(scale_word_base, b_scale);
-            load_a_scale(scale_word_base, a_scale);
-            wait_a_payload(0_I);
-            compute_streamed_tile(0_I, 0_I, 2 * pair, b_scale, a_scale);
-            compute_streamed_tile(1_I, 1_I, 2 * pair + 1, b_scale, a_scale);
-        }
-
-        if constexpr(HasOddTail)
-        {
-            constexpr int TailTile = T::K_TILES - 1;
-            constexpr int TailPair = TailTile / 2;
-            int b_scale[T::HALF_N_MFMA_PER_WAVE];
-            int a_scale[T::M_MFMA_PER_WAVE];
-            issue_streamed_a_tile(0_I, TailTile);
-            load_scale_pair(number<TailPair>{}, b_scale, a_scale);
-            wait_a_payload(0_I);
-            compute_streamed_tile(0_I, 0_I, TailTile, b_scale, a_scale);
+            issue_a_payload(2_I, 2 * T::K_STEP_PACKED);
+            if(k_tiles > 3)
+                issue_a_payload(3_I, 3 * T::K_STEP_PACKED);
         }
     }
 
-    if constexpr(T::A_LDS_STAGES >= T::K_TILES)
+    // Drain directly when K fits the ring and no slot is reused.
+    if(__builtin_expect(k_tiles <= TILES_PER_CHUNK, 1))
     {
-        V_A v_a_prefetched_even[T::M_MFMA_PER_WAVE];
-
-        static_for<T::K_TILES>([&](auto kt) {
-            issue_a_payload(kt, kt.value * T::K_STEP_PACKED);
-        });
-
-        auto run_odd_tile = [&](auto stage,
-                                auto prefetch_next,
-                                auto wait_for_pending_b_half0,
-                                int tile_base,
-                                const int (&a_scale)[T::M_MFMA_PER_WAVE],
-                                const int (&b_scale)[T::HALF_N_MFMA_PER_WAVE]) {
-            constexpr int Stage = decltype(stage)::value;
-            constexpr bool PrefetchNext = decltype(prefetch_next)::value != 0;
-            constexpr bool WaitForPendingBHalf0 =
-                decltype(wait_for_pending_b_half0)::value != 0;
-            static_assert((Stage & 1) == 1);
-            static_assert(!PrefetchNext || Stage + 1 < T::K_TILES);
-
-            V_A v_a_odd[T::M_MFMA_PER_WAVE];
-            V_B v_b_half0[T::HALF_N_MFMA_PER_WAVE];
-            V_B v_b_half1[T::HALF_N_MFMA_PER_WAVE];
-            wait_a_tile_and_pending_b();
-
-            load_a_payload(stage, v_a_odd);
-            load_b_half(0, tile_base, v_b_half0);
-            load_b_half(1, tile_base, v_b_half1);
-
-            if constexpr(WaitForPendingBHalf0)
-                s_waitcnt_vmcnt(number<T::HALF_N_MFMA_PER_WAVE>{});
-
-            __builtin_amdgcn_s_setprio(1);
-            compute_half(1_I, 0_I, v_a_odd, a_scale, b_scale, v_b_half0);
-            s_waitcnt_vmcnt(0_I);
-            if constexpr(PrefetchNext)
-            {
-                load_a_payload(number<Stage + 1>{}, v_a_prefetched_even);
-                if constexpr(Schedule::Mainloop == MainloopSchedule::SplitALoadByNWave)
-                    __builtin_amdgcn_s_barrier();
-            }
-            compute_half(1_I, 1_I, v_a_odd, a_scale, b_scale, v_b_half1);
-            __builtin_amdgcn_s_setprio(0);
-        };
-
-        auto run_first_pair = [&](auto prefetch_next) {
-            constexpr bool PrefetchNext = decltype(prefetch_next)::value != 0;
-            int b_scale[T::HALF_N_MFMA_PER_WAVE];
-            int a_scale[T::M_MFMA_PER_WAVE];
-
-            if constexpr(Schedule::Mainloop == MainloopSchedule::SplitALoadByNWave)
-            {
-                V_B v_b_half0[T::HALF_N_MFMA_PER_WAVE];
-                V_B v_b_half1[T::HALF_N_MFMA_PER_WAVE];
-                load_b_half(0, b_tile_base0, v_b_half0);
-                load_b_half(1, b_tile_base0, v_b_half1);
-
-                load_scale_pair(0_I, b_scale, a_scale);
-                if constexpr(PrefetchNext)
-                    wait_a_payload(number<T::A_LDS_BUFFER_LOAD_INSTS +
-                                          T::HALF_N_MFMA_PER_WAVE +
-                                          T::M_MFMA_PER_WAVE +
-                                          2 * T::HALF_N_MFMA_PER_WAVE>{});
-                else
-                    wait_a_payload(0_I);
-
-                V_A v_a_even[T::M_MFMA_PER_WAVE];
-                load_a_payload(0_I, v_a_even);
-
-                if constexpr(!PrefetchNext)
-                    s_waitcnt_vmcnt(0_I);
-
-                __builtin_amdgcn_s_setprio(1);
-                compute_half(0_I, 0_I, v_a_even, a_scale, b_scale, v_b_half0);
-                compute_half(0_I, 1_I, v_a_even, a_scale, b_scale, v_b_half1);
-                __builtin_amdgcn_s_setprio(0);
-            }
-            else
-            {
-                if constexpr(PrefetchNext)
-                    wait_a_payload(number<T::A_LDS_BUFFER_LOAD_INSTS>{});
-                else
-                    wait_a_payload(0_I);
-                load_scale_pair(0_I, b_scale, a_scale);
-                compute_tile(
-                    0_I,
-                    number<!PrefetchNext>{},
-                    0_I,
-                    b_tile_base0,
-                    b_scale,
-                    a_scale);
-            }
-
-            run_odd_tile(
-                1_I,
-                number<PrefetchNext>{},
-                number<!PrefetchNext>{},
-                b_tile_base1,
-                a_scale,
-                b_scale);
-        };
-
-        auto run_middle_pair = [&](auto pair) {
-            constexpr int Pair = decltype(pair)::value;
-            constexpr int EvenStage = 2 * Pair;
+        const int first_b_tile_base = col_base * b_payload_row_stride_bytes;
+        static_for<T::PAIR_SLOTS>([&](auto pair_slot) {
+            constexpr int EvenStage = 2 * pair_slot.value;
             constexpr int OddStage = EvenStage + 1;
-            constexpr bool PrefetchNext = OddStage + 1 < T::K_TILES;
-            static_assert(Pair > 0);
-            static_assert(OddStage < T::K_TILES);
+            if(k_tiles <= EvenStage)
+                return;
 
             int b_scale[T::HALF_N_MFMA_PER_WAVE];
             int a_scale[T::M_MFMA_PER_WAVE];
-            load_scale_pair(pair, b_scale, a_scale);
-            compute_prefetched_even_tile(
-                b_tile_base_for(number<EvenStage>{}),
-                v_a_prefetched_even,
-                a_scale,
-                b_scale);
-            run_odd_tile(
-                number<OddStage>{},
-                number<PrefetchNext>{},
-                0_I,
-                b_tile_base_for(number<OddStage>{}),
-                a_scale,
-                b_scale);
-        };
+            constexpr int ScaleWordBase =
+                pair_slot.value * T::SCALE_WORDS_PER_GROUP_PACK;
+            if constexpr(T::OVERLAP_SHORT_A_STAGES && pair_slot.value == 0)
+            {
+                constexpr int PendingAStageLoads =
+                    (T::A_LDS_STAGES - 1) * T::M_MFMA_PER_WAVE;
+                if(k_tiles < TILES_PER_CHUNK)
+                    wait_a_payload(0_I);
+                else
+                    wait_a_payload(number<PendingAStageLoads>{});
+            }
+            load_b_scale(ScaleWordBase, b_scale);
+            load_a_scale(ScaleWordBase, a_scale);
+            if constexpr(pair_slot.value == 0 && !T::OVERLAP_SHORT_A_STAGES)
+            {
+                constexpr int PendingScaleLoads =
+                    T::HALF_N_MFMA_PER_WAVE + T::M_MFMA_PER_WAVE;
+                wait_a_payload(number<PendingScaleLoads>{});
+            }
 
-        constexpr bool HasRemainingAfterFirstPair = T::K_TILES > 2;
-        run_first_pair(number<HasRemainingAfterFirstPair>{});
-        static_for<PairCount - 1>([&](auto local_pair) {
-            run_middle_pair(number<local_pair.value + 1>{});
+            compute_tile(0_I,
+                         number<pair_slot.value == 0>{},
+                         0_I,
+                         number<EvenStage>{},
+                         first_b_tile_base + EvenStage * B_TILE_BYTE_STEP,
+                         b_scale,
+                         a_scale);
+            if constexpr(T::OVERLAP_SHORT_A_STAGES && pair_slot.value == 0)
+                wait_a_payload(0_I);
+            if(k_tiles > OddStage)
+            {
+                compute_tile(1_I,
+                             0_I,
+                             0_I,
+                             number<OddStage>{},
+                             first_b_tile_base + OddStage * B_TILE_BYTE_STEP,
+                             b_scale,
+                             a_scale);
+            }
         });
-        if constexpr(HasOddTail)
+        return;
+    }
+
+    if constexpr(T::STEADY_PAIR_SLOTS == 1)
+    {
+        const int pair_count = (k_tiles + 1) / 2;
+        int b_tile_base = col_base * b_payload_row_stride_bytes;
+        int scale_word_base = 0;
+        #pragma unroll 1
+        for(int pair = 0; pair < pair_count;
+            ++pair,
+            b_tile_base += 2 * B_TILE_BYTE_STEP,
+            scale_word_base += T::SCALE_WORDS_PER_GROUP_PACK)
         {
-            constexpr int TailStage = 2 * PairCount;
-            constexpr int TailPair = PairCount;
             int b_scale[T::HALF_N_MFMA_PER_WAVE];
             int a_scale[T::M_MFMA_PER_WAVE];
-            load_scale_pair(number<TailPair>{}, b_scale, a_scale);
-            compute_prefetched_even_tile(
-                b_tile_base_for(number<TailStage>{}),
-                v_a_prefetched_even,
-                a_scale,
-                b_scale);
+            load_b_scale(scale_word_base, b_scale);
+            load_a_scale(scale_word_base, a_scale);
+            constexpr int PendingScaleLoads =
+                T::HALF_N_MFMA_PER_WAVE + T::M_MFMA_PER_WAVE;
+            wait_a_payload(number<PendingScaleLoads>{});
+
+            compute_tile(0_I, 0_I, 0_I, 0_I, b_tile_base, b_scale, a_scale);
+            const int next_even_tile = 2 * pair + 2;
+            if(next_even_tile < k_tiles)
+            {
+                __builtin_amdgcn_s_barrier();
+                issue_a_payload(0_I, next_even_tile * T::K_STEP_PACKED);
+            }
+
+            const int odd_tile = 2 * pair + 1;
+            if(odd_tile < k_tiles)
+            {
+                compute_tile(1_I,
+                             0_I,
+                             0_I,
+                             1_I,
+                             b_tile_base + B_TILE_BYTE_STEP,
+                             b_scale,
+                             a_scale);
+                const int next_odd_tile = next_even_tile + 1;
+                if(next_odd_tile < k_tiles)
+                {
+                    __builtin_amdgcn_s_barrier();
+                    issue_a_payload(1_I, next_odd_tile * T::K_STEP_PACKED);
+                }
+            }
+        }
+    }
+    else
+    {
+        int chunk_tile_base = 0;
+        int chunk_k_base = 0;
+        int chunk_b_tile_base = col_base * b_payload_row_stride_bytes;
+        int chunk_scale_word_base = 0;
+
+        #pragma unroll 1
+        for(; chunk_tile_base < k_tiles;
+            chunk_tile_base += TILES_PER_CHUNK,
+            chunk_k_base += TILES_PER_CHUNK * T::K_STEP_PACKED,
+            chunk_b_tile_base += TILES_PER_CHUNK * B_TILE_BYTE_STEP,
+            chunk_scale_word_base +=
+                T::PAIR_SLOTS * T::SCALE_WORDS_PER_GROUP_PACK)
+        {
+            static_for<T::PAIR_SLOTS>([&](auto pair_slot) {
+                constexpr int EvenStage = 2 * pair_slot.value;
+                constexpr int OddStage = EvenStage + 1;
+                const int even_tile = chunk_tile_base + EvenStage;
+                if(even_tile >= k_tiles)
+                    return;
+
+                int b_scale[T::HALF_N_MFMA_PER_WAVE];
+                int a_scale[T::M_MFMA_PER_WAVE];
+                const int scale_word_base =
+                    chunk_scale_word_base +
+                    pair_slot.value * T::SCALE_WORDS_PER_GROUP_PACK;
+                load_b_scale(scale_word_base, b_scale);
+                load_a_scale(scale_word_base, a_scale);
+                if constexpr(pair_slot.value == 0)
+                {
+                    constexpr int PendingScaleLoads =
+                        T::HALF_N_MFMA_PER_WAVE + T::M_MFMA_PER_WAVE;
+                    wait_a_payload(number<PendingScaleLoads>{});
+                }
+
+                const int even_b_tile_base =
+                    chunk_b_tile_base + EvenStage * B_TILE_BYTE_STEP;
+                compute_tile(0_I,
+                             0_I,
+                             0_I,
+                             number<EvenStage>{},
+                             even_b_tile_base,
+                             b_scale,
+                             a_scale);
+                const int next_even_tile = even_tile + TILES_PER_CHUNK;
+                if(next_even_tile < k_tiles)
+                {
+                    __builtin_amdgcn_s_barrier();
+                    issue_a_payload(number<EvenStage>{},
+                                    chunk_k_base +
+                                        (TILES_PER_CHUNK + EvenStage) *
+                                            T::K_STEP_PACKED);
+                }
+
+                const int odd_tile = even_tile + 1;
+                if(odd_tile < k_tiles)
+                {
+                    const int odd_b_tile_base =
+                        chunk_b_tile_base + OddStage * B_TILE_BYTE_STEP;
+                    compute_tile(1_I,
+                                 0_I,
+                                 0_I,
+                                 number<OddStage>{},
+                                 odd_b_tile_base,
+                                 b_scale,
+                                 a_scale);
+                    const int next_odd_tile = odd_tile + TILES_PER_CHUNK;
+                    if(next_odd_tile < k_tiles)
+                    {
+                        __builtin_amdgcn_s_barrier();
+                        issue_a_payload(number<OddStage>{},
+                                        chunk_k_base +
+                                            (TILES_PER_CHUNK + OddStage) *
+                                                T::K_STEP_PACKED);
+                    }
+                }
+            });
         }
     }
 }
@@ -537,21 +461,10 @@ inline __device__ void opus_moe_stage2_a8w4_decode_unpack_b_mfma_reg(
     reg = __builtin_bit_cast(opus::remove_cvref_t<Reg>, packed);
 }
 
-template<typename D_A, int StageElems, int... Stages>
-inline __device__ auto opus_moe_stage2_a8w4_decode_make_smem_a_stages(
-    char* smem_scratch,
-    opus::seq<Stages...>)
-{
-    return opus::make_array(
-        opus::make_smem(reinterpret_cast<D_A*>(
-            smem_scratch + Stages * StageElems * static_cast<int>(sizeof(D_A))))...);
-}
-
 template<typename T,
          typename Mma,
          typename LayoutA,
          typename LayoutASmem,
-         typename SmemA,
          typename LayoutB,
          typename GmemA,
          typename GmemAScale,
@@ -561,7 +474,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
     Mma& mma,
     const LayoutA& u_ga,
     const LayoutASmem& u_sa,
-    SmemA& s_a,
+    char* smem_a_scratch,
     const LayoutB& u_gb,
     GmemA& g_a,
     GmemAScale& g_a_scale,
@@ -574,6 +487,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
     int wave_id_m,
     int wave_id_n,
     int scale_row_col_base,
+    const opus_moe_stage2_a8w4_kargs& kargs,
     typename Mma::vtype_c (&v_c)[T::M_MFMA_PER_WAVE][T::N_MFMA_PER_WAVE])
 {
     using namespace opus;
@@ -581,8 +495,8 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
 
     using V_A = typename Mma::mfma_type::vtype_a;
     using V_B = typename Mma::mfma_type::vtype_b;
+    using D_A = typename T::D_A;
 
-    static_assert(T::DECODE_EFFECTIVE_INTER_DIM == T::K_TILES * T::K_STEP_PACKED);
     static_assert(T::N_MFMA_PER_WAVE >= 2 && (T::N_MFMA_PER_WAVE % 2) == 0);
     using Schedule = OpusMoeStage2A8W4DecodeSchedule<T>;
     using MainloopSchedule = OpusMoeStage2A8W4DecodeMainloopSchedule;
@@ -596,6 +510,13 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
     auto sa_offset = [&](auto mi, auto half) {
         return static_cast<int>(u_sa(mi, half, 0_I));
     };
+    auto make_smem_a_stage = [&](auto stage) {
+        constexpr int Stage = decltype(stage)::value;
+        static_assert(Stage >= 0 && Stage < T::A_LDS_STAGES);
+        return opus::make_smem(reinterpret_cast<D_A*>(
+            smem_a_scratch + Stage * T::A_LDS_STAGE_ELEMS *
+                static_cast<int>(sizeof(D_A))));
+    };
 
     auto a_base_for_ga = [&](int ga) {
         const int local_m = opus_moe_stage2_a8w4_a_local_m<T>(ga);
@@ -608,12 +529,17 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
         const int ga = ga_offset(mi);
         a_base[mi.value] = a_base_for_ga(ga);
         a_scale_base_word[mi.value] =
-            opus_moe_stage2_a8w4_a_scale_base_word_offset<T>(route_base, ga_offset(mi));
+            opus_moe_stage2_a8w4_a_scale_base_word_offset<T>(
+                route_base,
+                ga,
+                kargs.a_scale_words_per_row_pack);
     });
     const int b_scale_base_word =
-        opus_moe_stage2_a8w4_b_scale_base_word_offset<T>(scale_row_col_base,
-                                                         gb_offset(0_I),
-                                                         wave_id_n);
+        opus_moe_stage2_a8w4_b_scale_base_word_offset<T>(
+            scale_row_col_base,
+            gb_offset(0_I),
+            wave_id_n,
+            kargs.w_scale_words_per_row_pack);
     const int b_ni_stride_bytes = T::MMA_N * b_payload_row_stride_bytes;
     constexpr int b_lane_offset_mask = T::B_THREADGROUP_STRIDE_BYTES - 1;
     const int b_lane_offset = gb_offset(0_I) & b_lane_offset_mask;
@@ -628,12 +554,23 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
             return;
 
         auto issue_one_mi = [&](auto mi) {
-            auto* smem_lo = s_a[Stage].ptr + sa_offset(mi, 0_I);
-            auto* smem_hi = s_a[Stage].ptr + sa_offset(mi, 1_I);
+            auto s_a_stage = make_smem_a_stage(stage);
+            auto* smem_lo = s_a_stage.ptr + sa_offset(mi, 0_I);
+            auto* smem_hi = s_a_stage.ptr + sa_offset(mi, 1_I);
+            if constexpr(T::IS_BM64_BN256 && T::BLOCK_SIZE == 256)
+            {
+                // Materialize BM64's lane-0 LDS base directly to avoid runtime-K address spills.
+                constexpr int HalfStrideBytes =
+                    opus::get_warp_size() * T::VEC_A * sizeof(D_A);
+                constexpr int MiStrideBytes = 2 * HalfStrideBytes;
+                smem_lo = s_a_stage.ptr + mi.value * MiStrideBytes;
+                smem_hi = smem_lo + HalfStrideBytes;
+            }
+            const int ga = ga_offset(mi);
             const int a_offset_lo = opus_moe_stage2_a8w4_a_payload_byte_offset<T>(
                 a_base[mi.value],
                 k_base,
-                ga_offset(mi));
+                ga);
             if constexpr(Schedule::Mainloop ==
                          MainloopSchedule::SplitALoadByNWave)
             {
@@ -691,17 +628,22 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
         __builtin_amdgcn_s_barrier();
     };
 
-    auto load_a_payload = [&](auto stage, V_A (&v_a)[T::M_MFMA_PER_WAVE]) {
+    auto load_a_fragment = [&](auto stage, auto mi, V_A& v_a) {
         constexpr int Stage = decltype(stage)::value;
         static_assert(Stage >= 0 && Stage < T::A_LDS_STAGES);
+        auto s_a_stage = make_smem_a_stage(stage);
 
+        auto lo = s_a_stage.template load<T::VEC_A>(sa_offset(mi, 0_I));
+        auto hi = s_a_stage.template load<T::VEC_A>(sa_offset(mi, 1_I));
+        opus_moe_stage2_a8w4_decode_pack_a_mfma_reg(
+            __builtin_bit_cast(opus_moe_stage2_a8w4_decode_u32x4_t, lo),
+            __builtin_bit_cast(opus_moe_stage2_a8w4_decode_u32x4_t, hi),
+            v_a);
+    };
+
+    auto load_a_payload = [&](auto stage, V_A (&v_a)[T::M_MFMA_PER_WAVE]) {
         static_for<T::M_MFMA_PER_WAVE>([&](auto mi) {
-            auto lo = s_a[Stage].template load<T::VEC_A>(sa_offset(mi, 0_I));
-            auto hi = s_a[Stage].template load<T::VEC_A>(sa_offset(mi, 1_I));
-            opus_moe_stage2_a8w4_decode_pack_a_mfma_reg(
-                __builtin_bit_cast(opus_moe_stage2_a8w4_decode_u32x4_t, lo),
-                __builtin_bit_cast(opus_moe_stage2_a8w4_decode_u32x4_t, hi),
-                v_a[mi.value]);
+            load_a_fragment(stage, mi, v_a[mi.value]);
         });
     };
 
@@ -721,10 +663,26 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
         });
     };
 
+    auto load_b_packed_fragment = [&](auto n_half,
+                                      auto local_ni,
+                                      int tile_base) {
+        constexpr int NHalf = decltype(n_half)::value;
+        constexpr int LocalNi = decltype(local_ni)::value;
+        static_assert(NHalf == 0 || NHalf == 1);
+        static_assert(LocalNi >= 0 && LocalNi < T::HALF_N_MFMA_PER_WAVE);
+        constexpr int ni = NHalf * T::HALF_N_MFMA_PER_WAVE + LocalNi;
+        const int b_scalar_offset =
+            tile_base + b_wave_scalar_base + ni * b_ni_stride_bytes;
+        auto value = g_b.template load<T::B_BYTES_PER_VEC>(
+            b_lane_offset, b_scalar_offset, opus::number<T::CACHECTL_B>{});
+        return __builtin_bit_cast(opus_moe_stage2_a8w4_decode_u32x4_t, value);
+    };
+
     auto load_a_scale = [&](int k_group_word_base,
                             int (&a_scale)[T::M_MFMA_PER_WAVE]) {
         static_for<T::M_MFMA_PER_WAVE>([&](auto mi) {
-            const int word_offset = a_scale_base_word[mi.value] + k_group_word_base;
+            const int word_offset =
+                a_scale_base_word[mi.value] + k_group_word_base;
             const auto word = g_a_scale.template load<sizeof(uint32_t)>(
                 word_offset * static_cast<int>(sizeof(uint32_t)),
                 0,
@@ -739,7 +697,8 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
             const int word_offset = opus_moe_stage2_a8w4_b_scale_word_offset<T>(
                 b_scale_base_word,
                 k_group_word_base,
-                pair.value);
+                pair.value,
+                kargs.w_scale_words_per_row_pack);
             const auto word = g_w_scale.template load<sizeof(uint32_t)>(
                 word_offset * static_cast<int>(sizeof(uint32_t)),
                 0,
@@ -749,12 +708,15 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
     };
 
     auto compute_half = [&](auto scale_pair,
+                            auto initialize_acc,
                             auto n_half,
                             const V_A (&v_a)[T::M_MFMA_PER_WAVE],
                             const int (&a_scale)[T::M_MFMA_PER_WAVE],
                             const int (&b_scale)[T::HALF_N_MFMA_PER_WAVE],
                             const V_B (&v_b)[T::HALF_N_MFMA_PER_WAVE]) {
         constexpr int ScalePair = decltype(scale_pair)::value;
+        constexpr bool InitializeAcc =
+            decltype(initialize_acc)::value != 0;
         constexpr int NHalf = decltype(n_half)::value;
         static_assert(ScalePair == 0 || ScalePair == 1);
         static_assert(NHalf == 0 || NHalf == 1);
@@ -767,19 +729,83 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
                 opus_moe_stage2_a8w4_decode_with_a_selector<
                     T, ScalePair, mi.value>(
                     route_base, wave_id_m, [&](auto a_sel) {
-                        v_c[mi.value][ni] = mma(v_a[mi.value],
-                                                v_b[local_ni.value],
-                                                v_c[mi.value][ni],
-                                                a_scale[mi.value],
-                                                b_scale[b_scale_index],
-                                                a_sel,
-                                                number<b_sel>{});
+                        if constexpr(InitializeAcc)
+                        {
+                            typename Mma::vtype_c zero_acc{};
+                            v_c[mi.value][ni] = mma(v_a[mi.value],
+                                                    v_b[local_ni.value],
+                                                    zero_acc,
+                                                    a_scale[mi.value],
+                                                    b_scale[b_scale_index],
+                                                    a_sel,
+                                                    number<b_sel>{});
+                        }
+                        else
+                        {
+                            v_c[mi.value][ni] = mma(v_a[mi.value],
+                                                    v_b[local_ni.value],
+                                                    v_c[mi.value][ni],
+                                                    a_scale[mi.value],
+                                                    b_scale[b_scale_index],
+                                                    a_sel,
+                                                    number<b_sel>{});
+                        }
                     });
             });
         });
     };
 
+    auto compute_fragment = [&](auto scale_pair,
+                                auto initialize_acc,
+                                auto n_half,
+                                auto local_ni,
+                                auto mi,
+                                const V_A& v_a,
+                                const int (&a_scale)[T::M_MFMA_PER_WAVE],
+                                const int (&b_scale)[T::HALF_N_MFMA_PER_WAVE],
+                                const V_B& v_b) {
+        constexpr int ScalePair = decltype(scale_pair)::value;
+        constexpr bool InitializeAcc =
+            decltype(initialize_acc)::value != 0;
+        constexpr int NHalf = decltype(n_half)::value;
+        constexpr int LocalNi = decltype(local_ni)::value;
+        constexpr int Mi = decltype(mi)::value;
+        static_assert(ScalePair == 0 || ScalePair == 1);
+        static_assert(NHalf == 0 || NHalf == 1);
+        static_assert(LocalNi >= 0 && LocalNi < T::HALF_N_MFMA_PER_WAVE);
+        static_assert(Mi >= 0 && Mi < T::M_MFMA_PER_WAVE);
+        constexpr int ni = NHalf * T::HALF_N_MFMA_PER_WAVE + LocalNi;
+        constexpr int b_sel = ScalePair * 2 + (ni & 1);
+        constexpr int b_scale_index = ni / 2;
+
+        opus_moe_stage2_a8w4_decode_with_a_selector<T, ScalePair, Mi>(
+            route_base, wave_id_m, [&](auto a_sel) {
+                if constexpr(InitializeAcc)
+                {
+                    typename Mma::vtype_c zero_acc{};
+                    v_c[Mi][ni] = mma(v_a,
+                                      v_b,
+                                      zero_acc,
+                                      a_scale[Mi],
+                                      b_scale[b_scale_index],
+                                      a_sel,
+                                      number<b_sel>{});
+                }
+                else
+                {
+                    v_c[Mi][ni] = mma(v_a,
+                                      v_b,
+                                      v_c[Mi][ni],
+                                      a_scale[Mi],
+                                      b_scale[b_scale_index],
+                                      a_sel,
+                                      number<b_sel>{});
+                }
+            });
+    };
+
     auto compute_tile = [&](auto scale_pair,
+                            auto initialize_acc,
                             auto wait_for_pending_b_half1,
                             auto stage,
                             int b_tile_base,
@@ -788,38 +814,88 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
         constexpr bool WaitForPendingBHalf1 =
             decltype(wait_for_pending_b_half1)::value != 0;
 
-        V_A v_a[T::M_MFMA_PER_WAVE];
-        V_B v_b_half0[T::HALF_N_MFMA_PER_WAVE];
-        V_B v_b_half1[T::HALF_N_MFMA_PER_WAVE];
+        if constexpr(T::IS_BM64_BN256)
+        {
+            // Reuse one expanded BM64 B operand to reduce VGPR pressure.
+            V_A v_a[T::M_MFMA_PER_WAVE];
+            opus_moe_stage2_a8w4_decode_u32x4_t
+                b_packed[2][T::HALF_N_MFMA_PER_WAVE];
+            V_B v_b_fragment;
+            static_for<2>([&](auto n_half) {
+                static_for<T::HALF_N_MFMA_PER_WAVE>([&](auto local_ni) {
+                    b_packed[n_half.value][local_ni.value] =
+                        load_b_packed_fragment(n_half, local_ni, b_tile_base);
+                });
+            });
+            load_a_payload(stage, v_a);
+            __builtin_amdgcn_s_setprio(1);
+            static_for<2>([&](auto n_half) {
+                static_for<T::HALF_N_MFMA_PER_WAVE>([&](auto local_ni) {
+                    opus_moe_stage2_a8w4_decode_unpack_b_mfma_reg(
+                        b_packed[n_half.value][local_ni.value], v_b_fragment);
+                    static_for<T::M_MFMA_PER_WAVE>([&](auto mi) {
+                        compute_fragment(scale_pair,
+                                         initialize_acc,
+                                         n_half,
+                                         local_ni,
+                                         mi,
+                                         v_a[mi.value],
+                                         a_scale,
+                                         b_scale,
+                                         v_b_fragment);
+                    });
+                });
+                __builtin_amdgcn_sched_barrier(0);
+            });
+            __builtin_amdgcn_s_setprio(0);
+        }
+        else
+        {
+            V_A v_a[T::M_MFMA_PER_WAVE];
+            V_B v_b_half0[T::HALF_N_MFMA_PER_WAVE];
+            V_B v_b_half1[T::HALF_N_MFMA_PER_WAVE];
+            load_a_payload(stage, v_a);
+            load_b_half(0, b_tile_base, v_b_half0);
+            load_b_half(1, b_tile_base, v_b_half1);
 
-        load_a_payload(stage, v_a);
-        load_b_half(0, b_tile_base, v_b_half0);
-        load_b_half(1, b_tile_base, v_b_half1);
+            if constexpr(WaitForPendingBHalf1)
+                s_waitcnt_vmcnt(number<T::HALF_N_MFMA_PER_WAVE>{});
 
-        if constexpr(WaitForPendingBHalf1)
-            s_waitcnt_vmcnt(number<T::HALF_N_MFMA_PER_WAVE>{});
+            __builtin_amdgcn_s_setprio(1);
+            compute_half(
+                scale_pair, initialize_acc, 0_I, v_a, a_scale, b_scale, v_b_half0);
 
-        __builtin_amdgcn_s_setprio(1);
-        compute_half(scale_pair, 0_I, v_a, a_scale, b_scale, v_b_half0);
+            if constexpr(WaitForPendingBHalf1)
+                s_waitcnt_vmcnt(0_I);
 
-        if constexpr(WaitForPendingBHalf1)
-            s_waitcnt_vmcnt(0_I);
-
-        compute_half(scale_pair, 1_I, v_a, a_scale, b_scale, v_b_half1);
-        __builtin_amdgcn_s_setprio(0);
+            compute_half(
+                scale_pair, initialize_acc, 1_I, v_a, a_scale, b_scale, v_b_half1);
+            __builtin_amdgcn_s_setprio(0);
+        }
     };
 
-    opus_moe_stage2_a8w4_decode_run_k_scheduler_gfx950<T, V_A, V_B>(
+    // Streaming paths require explicit accumulator initialization.
+    if(kargs.k_tiles > T::A_LDS_STAGES)
+    {
+        static_for<T::M_MFMA_PER_WAVE>([&](auto mi) {
+            static_for<T::N_MFMA_PER_WAVE>([&](auto ni) {
+                clear(v_c[mi.value][ni.value]);
+            });
+        });
+    }
+
+    opus_moe_stage2_a8w4_decode_run_k_pipeline_gfx950<T>(
+        kargs.k_tiles,
         col_base,
         b_payload_row_stride_bytes,
         issue_a_payload,
         wait_a_payload,
-        load_a_payload,
-        load_b_half,
         load_b_scale,
         load_a_scale,
-        compute_half,
         compute_tile);
+
+    // Synchronize before reusing the A-ring LDS allocation for the C-shuffle epilogue.
+    __builtin_amdgcn_s_barrier();
 }
 
 // Epilogue: direct atomic output or route-out store.
@@ -1140,7 +1216,8 @@ inline __device__ void opus_moe_stage2_a8w4_decode_route_out_fp8_epilogue(
 // Kernel entry.
 template<typename Traits>
 __global__ __launch_bounds__(Traits::BLOCK_SIZE, Traits::MIN_BLOCKS_PER_CU) void
-opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
+opus_moe_stage2_a8w4_decode_kernel_gfx950(
+    opus_moe_stage2_a8w4_kargs kargs)
 {
 #ifdef __HIP_DEVICE_COMPILE__
 #if defined(__gfx950__)
@@ -1160,7 +1237,9 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
     if(route_base >= sorted_rows)
         return;
     const int token_num = kargs.token_num;
-    const int sorted_block_id = route_base / T::SORT_BLOCK_M;
+    // Use shifts for the supported power-of-two sort blocks.
+    const int sorted_block_id =
+        route_base >> __builtin_ctz(static_cast<unsigned>(kargs.sort_block_m));
     const int expert_id = kargs.sorted_expert_ids[sorted_block_id];
 
     const int tid = static_cast<int>(thread_id_x());
@@ -1184,11 +1263,6 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
         (A_LDS_BYTES > C_LDS_BYTES) ? A_LDS_BYTES : C_LDS_BYTES;
     __shared__ __align__(T::BYTES_PER_VEC) char smem_scratch[SCRATCH_BYTES];
     auto* smem_c_pair = reinterpret_cast<uint32_t*>(smem_scratch);
-    auto s_a = opus_moe_stage2_a8w4_decode_make_smem_a_stages<
-        D_A,
-        T::A_LDS_STAGE_ELEMS>(smem_scratch,
-                              opus::make_index_seq<T::A_LDS_STAGES>{});
-
     const bool has_route = opus_moe_stage2_a8w4_decode_load_route_metadata<T>(
         kargs,
         route_base,
@@ -1229,19 +1303,13 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
     const int b_payload_row_stride_bytes = static_cast<int>(kargs.stride_w_h);
     auto u_gb = opus_moe_stage2_a8w4_layout_gb<T>(
         lane_id, wave_id_n, b_payload_row_stride_bytes);
-    auto u_c = opus_moe_stage2_a8w4_layout_c<T>(wave_id_m, wave_id_n);
 
     typename decltype(mma)::vtype_c v_c[T::M_MFMA_PER_WAVE][T::N_MFMA_PER_WAVE];
-    static_for<T::M_MFMA_PER_WAVE>([&](auto mi) {
-        static_for<T::N_MFMA_PER_WAVE>([&](auto ni) {
-            clear(v_c[mi.value][ni.value]);
-        });
-    });
 
     opus_moe_stage2_a8w4_decode_mainloop<T>(mma,
                                             u_ga,
                                             u_sa,
-                                            s_a,
+                                            smem_scratch,
                                             u_gb,
                                             g_a,
                                             g_a_scale,
@@ -1254,12 +1322,14 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
                                             wave_id_m,
                                             wave_id_n,
                                             scale_row_col_base,
+                                            kargs,
                                             v_c);
 
     if constexpr(!Schedule::MainloopEndsWithSmemBarrier)
     {
         __syncthreads();
     }
+    auto u_c = opus_moe_stage2_a8w4_layout_c<T>(wave_id_m, wave_id_n);
     if constexpr(T::DIRECT_ATOMIC_OUT)
     {
         constexpr int output_rows_per_token = 1;

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh
@@ -640,7 +640,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
                 if(wave_id_n == 0)
                 {
                     g_a.template async_load<T::VEC_A>(
-                        reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_lo)),
+                        smem_lo,
                         a_offset_lo,
                         0,
                         opus::number<T::CACHECTL_A>{});
@@ -648,7 +648,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
                 else
                 {
                     g_a.template async_load<T::VEC_A>(
-                        reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_hi)),
+                        smem_hi,
                         a_offset_lo + T::K_STEP_PACKED / 2,
                         0,
                         opus::number<T::CACHECTL_A>{});
@@ -657,12 +657,12 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
             else
             {
                 g_a.template async_load<T::VEC_A>(
-                    reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_lo)),
+                    smem_lo,
                     a_offset_lo,
                     0,
                     opus::number<T::CACHECTL_A>{});
                 g_a.template async_load<T::VEC_A>(
-                    reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_hi)),
+                    smem_hi,
                     a_offset_lo + T::K_STEP_PACKED / 2,
                     0,
                     opus::number<T::CACHECTL_A>{});
@@ -826,24 +826,8 @@ inline __device__ void opus_moe_stage2_a8w4_decode_mainloop(
 typedef uint32_t opus_moe_stage2_a8w4_decode_u32x4_store_t
     __attribute__((ext_vector_type(4)));
 
-inline __device__ void opus_moe_stage2_a8w4_decode_atomic_add_bf16x2(
-    opus::bf16x2_t data,
-    opus::i32x4_t out_rsrc,
-    int byte_offset)
-{
-#if OPUS_HAS_BUFFER_ATOMIC_PK_ADD_BF16
-    (void)opus::llvm_amdgcn_raw_buffer_atomic_fadd_v2bf16(
-        data, out_rsrc, byte_offset, 0, 0);
-#else
-    (void)data;
-    (void)out_rsrc;
-    (void)byte_offset;
-    __builtin_trap();
-#endif
-}
-
-template<typename T, typename CAcc>
-inline __device__ void opus_moe_stage2_a8w4_decode_write_direct_acc_to_smem(
+template<typename T, bool CheckRoute, typename CAcc>
+inline __device__ void opus_moe_stage2_a8w4_decode_write_acc_to_smem(
     CAcc (&v_c)[T::M_MFMA_PER_WAVE][T::N_MFMA_PER_WAVE],
     const OpusMoeStage2A8W4CShuffleLayout<T>& c_layout,
     const int32_t* __restrict__ smem_route_base,
@@ -852,44 +836,16 @@ inline __device__ void opus_moe_stage2_a8w4_decode_write_direct_acc_to_smem(
 {
     using namespace opus;
 
-    static_assert(T::DIRECT_ATOMIC_OUT);
-
     auto* smem_c_bf16 = reinterpret_cast<hip_bfloat16*>(smem_c_pair);
 
     static_for<T::M_MFMA_PER_WAVE>([&](auto mi) {
         static_for<T::VEC_C>([&](auto ii) {
             const int local_m = c_layout.acc_local_m(mi.value, ii.value);
-            if(smem_route_base[local_m] >= 0)
+            if constexpr(CheckRoute)
             {
-                const float weight = smem_weight[local_m];
-                static_for<T::N_MFMA_PER_WAVE>([&](auto ni) {
-                    const int local_col = c_layout.acc_local_col(ni.value);
-                    smem_c_bf16[c_layout.smem_scalar_index(local_m, local_col)] =
-                        opus_moe_gfx950_cvt_bf16_f32(
-                            static_cast<float>(v_c[mi.value][ni.value][ii.value]) *
-                            weight);
-                });
+                if(smem_route_base[local_m] < 0)
+                    return;
             }
-        });
-    });
-}
-
-template<typename T, typename CAcc>
-inline __device__ void opus_moe_stage2_a8w4_decode_write_route_out_acc_to_smem(
-    CAcc (&v_c)[T::M_MFMA_PER_WAVE][T::N_MFMA_PER_WAVE],
-    const OpusMoeStage2A8W4CShuffleLayout<T>& c_layout,
-    const float* __restrict__ smem_weight,
-    uint32_t* __restrict__ smem_c_pair)
-{
-    using namespace opus;
-
-    static_assert(!T::DIRECT_ATOMIC_OUT);
-
-    auto* smem_c_bf16 = reinterpret_cast<hip_bfloat16*>(smem_c_pair);
-
-    static_for<T::M_MFMA_PER_WAVE>([&](auto mi) {
-        static_for<T::VEC_C>([&](auto ii) {
-            const int local_m = c_layout.acc_local_m(mi.value, ii.value);
             const float weight = smem_weight[local_m];
             static_for<T::N_MFMA_PER_WAVE>([&](auto ni) {
                 const int local_col = c_layout.acc_local_col(ni.value);
@@ -933,15 +889,17 @@ inline __device__ void opus_moe_stage2_a8w4_decode_atomic_smem_to_out(
         {
             const int token = smem_route_base[local_m];
             const int pair_base = c_layout.smem_pair_index(local_m, col0);
-            const int byte_offset =
-                c_layout.output_byte_offset(token, output_row_stride, col_base, col0);
+            const int byte0 =
+                c_layout.output_elem_offset(token, output_row_stride, col_base, col0) *
+                static_cast<int>(sizeof(opus::bf16_t));
             opus::static_for<ATOMIC_GROUPS>([&](auto group) {
                 constexpr int pair_delta = group.value * CSHUFFLE_NLANE;
-                constexpr int byte_delta = pair_delta * static_cast<int>(sizeof(uint32_t));
+                constexpr int byte_delta =
+                    pair_delta * T::ELEM_PER_ATOMIC * static_cast<int>(sizeof(opus::bf16_t));
                 const auto data = __builtin_bit_cast(
                     opus::bf16x2_t, smem_c_pair[pair_base + pair_delta]);
-                opus_moe_stage2_a8w4_decode_atomic_add_bf16x2(
-                    data, out_rsrc, byte_offset + byte_delta);
+                opus::llvm_amdgcn_raw_buffer_atomic_fadd_v2bf16(
+                    data, out_rsrc, byte0 + byte_delta, 0, 0);
             });
         }
     }
@@ -1081,7 +1039,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_direct_epilogue(
     uint32_t* __restrict__ smem_c_pair,
     int col_base,
     int64_t output_row_stride,
-    opus::i32x4_t output_rsrc)
+    opus::i32x4_t out_rsrc)
 {
     using namespace opus;
     using opus::operator""_I;
@@ -1089,7 +1047,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_direct_epilogue(
     static_assert(T::B_N == T::C_LDS_N);
     static_assert(T::DIRECT_ATOMIC_OUT);
 
-    opus_moe_stage2_a8w4_decode_write_direct_acc_to_smem<T>(
+    opus_moe_stage2_a8w4_decode_write_acc_to_smem<T, true>(
         v_c,
         c_layout,
         smem_route_base,
@@ -1103,7 +1061,7 @@ inline __device__ void opus_moe_stage2_a8w4_decode_direct_epilogue(
         c_layout,
         col_base,
         output_row_stride,
-        output_rsrc);
+        out_rsrc);
 }
 
 template<typename T, typename CAcc>
@@ -1123,9 +1081,10 @@ inline __device__ void opus_moe_stage2_a8w4_decode_route_out_epilogue(
     static_assert(T::B_N == T::C_LDS_N);
     static_assert(!T::DIRECT_ATOMIC_OUT);
 
-    opus_moe_stage2_a8w4_decode_write_route_out_acc_to_smem<T>(
+    opus_moe_stage2_a8w4_decode_write_acc_to_smem<T, false>(
         v_c,
         c_layout,
+        smem_route_base,
         smem_weight,
         smem_c_pair);
     s_waitcnt_lgkmcnt(0_I);
@@ -1137,6 +1096,42 @@ inline __device__ void opus_moe_stage2_a8w4_decode_route_out_epilogue(
         col_base,
         out,
         output_row_stride);
+}
+
+template<typename T, typename CAcc>
+inline __device__ void opus_moe_stage2_a8w4_decode_route_out_fp8_epilogue(
+    CAcc (&v_c)[T::M_MFMA_PER_WAVE][T::N_MFMA_PER_WAVE],
+    const OpusMoeStage2A8W4CShuffleLayout<T>& c_layout,
+    const int32_t* __restrict__ smem_route_base,
+    const float* __restrict__ smem_weight,
+    uint32_t* __restrict__ smem_c_pair,
+    int col_base,
+    uint8_t* __restrict__ out_base,
+    int64_t row_stride_bytes,
+    int scale_col_off)
+{
+    using namespace opus;
+    using opus::operator""_I;
+
+    static_assert(T::B_N == T::C_LDS_N);
+    static_assert(!T::DIRECT_ATOMIC_OUT);
+
+    opus_moe_stage2_a8w4_decode_write_acc_to_smem<T, false>(
+        v_c,
+        c_layout,
+        smem_route_base,
+        smem_weight,
+        smem_c_pair);
+    s_waitcnt_lgkmcnt(0_I);
+    __syncthreads();
+    opus_moe_stage2_a8w4_decode_store_smem_to_route_out_fp8<T>(
+        smem_c_pair,
+        smem_route_base,
+        c_layout,
+        col_base,
+        out_base,
+        row_stride_bytes,
+        scale_col_off);
 }
 
 #endif // __gfx950__
@@ -1205,10 +1200,10 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
     if(!has_route)
         return;
 
-    auto mma = make_mfma<D_MFMA_A, D_MFMA_B, D_ACC>(
-        number<T::MMA_M>{},
-        number<T::MMA_N>{},
-        number<T::MMA_K>{});
+    auto mma = make_tiled_mma<D_MFMA_A, D_MFMA_B, D_ACC>(
+        seq<1, 1, 1>{},
+        seq<1, 1, 1>{},
+        seq<T::MMA_M, T::MMA_N, T::MMA_K>{});
 
     const D_A* __restrict__ inter_states =
         reinterpret_cast<const D_A*>(kargs.inter_states_fp8);
@@ -1273,8 +1268,14 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
             static_cast<unsigned long long>(output_rows_per_token) *
             static_cast<unsigned long long>(kargs.stride_o_t) *
             static_cast<unsigned long long>(sizeof(hip_bfloat16)));
+        // Build the output buffer descriptor as a plain i32x4 rather than via
+        // make_gmem/make_buffer_rsrc: the __builtin_amdgcn_make_buffer_rsrc
+        // intrinsic result is held across the atomic loop at +2 VGPR, which tips
+        // the zero-headroom atomic decode kernels into 32 B/lane scratch (~4-7%
+        // regression). The plain descriptor packs into cheap registers. The
+        // atomic itself still uses the opus raw-buffer primitive.
         const auto output_ptr_bits = reinterpret_cast<__UINTPTR_TYPE__>(kargs.out_bf16);
-        const opus::i32x4_t output_rsrc{
+        const opus::i32x4_t out_rsrc{
             static_cast<int>(static_cast<unsigned int>(output_ptr_bits)),
             static_cast<int>((static_cast<unsigned long long>(output_ptr_bits) >> 32) &
                              0xffffu),
@@ -1288,18 +1289,20 @@ opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs kargs)
             smem_c_pair,
             col_base,
             kargs.stride_o_t,
-            output_rsrc);
+            out_rsrc);
     }
     else if(kargs.route_out_fp8)
     {
-        opus_moe_stage2_a8w4_decode_write_route_out_acc_to_smem<T>(
-            v_c, u_c, smem_weight, smem_c_pair);
-        s_waitcnt_lgkmcnt(0_I);
-        __syncthreads();
-        opus_moe_stage2_a8w4_decode_store_smem_to_route_out_fp8<T>(
-            smem_c_pair, smem_route_base, u_c, col_base,
+        opus_moe_stage2_a8w4_decode_route_out_fp8_epilogue<T>(
+            v_c,
+            u_c,
+            smem_route_base,
+            smem_weight,
+            smem_c_pair,
+            col_base,
             reinterpret_cast<uint8_t*>(kargs.out_bf16),
-            kargs.route_out_row_bytes, kargs.model_dim);
+            kargs.route_out_row_bytes,
+            kargs.model_dim);
     }
     else
     {

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_policy_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_policy_gfx950.cuh
@@ -101,21 +101,7 @@ inline __device__ int opus_moe_stage2_a8w4_a_payload_byte_offset(int a_base,
                                                                  int k_base,
                                                                  int ga_offset)
 {
-    constexpr auto block_shape = opus::make_tuple(
-        opus::number<1>{},
-        opus::number<1>{},
-        opus::number<T::K_STEP_PACKED>{});
-    constexpr auto block_dim = opus::make_tuple(
-        opus::make_tuple(opus::p_dim{}),
-        opus::make_tuple(opus::p_dim{}),
-        opus::make_tuple(opus::p_dim{}));
-    constexpr auto u = opus::make_layout<-1>(
-        block_shape,
-        opus::unfold_x_stride(
-            block_dim,
-            block_shape,
-            opus::tuple{opus::number<1>{}, opus::number<1>{}, opus::number<1>{}}));
-    return static_cast<int>(u(a_base, k_base, opus_moe_stage2_a8w4_a_k_byte<T>(ga_offset)));
+    return a_base + k_base + opus_moe_stage2_a8w4_a_k_byte<T>(ga_offset);
 }
 
 template<typename T>
@@ -255,23 +241,8 @@ inline __device__ int opus_moe_stage2_a8w4_b_scale_word_offset(int base_word_off
                                                                int k_group_word_base,
                                                                int pair)
 {
-    constexpr auto block_shape = opus::make_tuple(
-        opus::number<1>{},
-        opus::number<1>{},
-        opus::number<T::HALF_N_MFMA_PER_WAVE>{});
-    constexpr auto block_dim = opus::make_tuple(
-        opus::make_tuple(opus::p_dim{}),
-        opus::make_tuple(opus::p_dim{}),
-        opus::make_tuple(opus::p_dim{}));
-    constexpr auto u = opus::make_layout<-1>(
-        block_shape,
-        opus::unfold_x_stride(
-            block_dim,
-            block_shape,
-            opus::tuple{opus::number<1>{},
-                        opus::number<1>{},
-                        opus::number<T::SCALE_WORDS_PER_ROW_PACK>{}}));
-    return static_cast<int>(u(base_word_offset, k_group_word_base, pair));
+    return base_word_offset + k_group_word_base +
+           pair * T::SCALE_WORDS_PER_ROW_PACK;
 }
 
 template<typename T>
@@ -315,11 +286,10 @@ struct OpusMoeStage2A8W4CShuffleLayout
     }
 
     inline __device__ static int
-    output_byte_offset(int token, int64_t row_stride, int col_base, int col)
+    output_elem_offset(int token, int64_t row_stride, int col_base, int col)
     {
-        return static_cast<int>((static_cast<int64_t>(token) * row_stride +
-                                 col_base + col) *
-                                static_cast<int>(sizeof(hip_bfloat16)));
+        return static_cast<int>(static_cast<int64_t>(token) * row_stride +
+                                col_base + col);
     }
 
     inline __device__ int acc_local_m(int mi, int elem_in_vec) const

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_policy_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_pipeline_stage2_a8w4_decode_policy_gfx950.cuh
@@ -105,39 +105,18 @@ inline __device__ int opus_moe_stage2_a8w4_a_payload_byte_offset(int a_base,
 }
 
 template<typename T>
-inline __device__ constexpr auto opus_moe_stage2_a8w4_layout_scale_word()
-{
-    constexpr auto block_shape = opus::make_tuple(
-        opus::number<1>{},
-        opus::number<T::THREADS_K>{},
-        opus::number<T::MMA_M>{});
-
-    constexpr auto block_dim = opus::make_tuple(
-        opus::make_tuple(opus::p_dim{}),
-        opus::make_tuple(opus::p_dim{}),
-        opus::make_tuple(opus::p_dim{}));
-
-    return opus::make_layout<-1>(
-        block_shape,
-        opus::unfold_x_stride(
-            block_dim,
-            block_shape,
-            opus::tuple{opus::number<T::SCALE_WORDS_PER_ROW_PACK>{},
-                        opus::number<T::MMA_M>{},
-                        opus::number<1>{}}));
-}
-
-template<typename T>
 inline __device__ int opus_moe_stage2_a8w4_a_scale_base_word_offset(int route_base,
-                                                                    int ga_offset)
+                                                                    int ga_offset,
+                                                                    int scale_words_per_row_pack)
 {
     const int local_m = opus_moe_stage2_a8w4_a_local_m<T>(ga_offset);
     const int row_pack =
         route_base / T::SCALE_ROWS_PER_ROW_PACK +
         local_m / T::SCALE_ROWS_PER_ROW_PACK;
     const int row_lane = local_m % T::MMA_M;
-    constexpr auto u = opus_moe_stage2_a8w4_layout_scale_word<T>();
-    return static_cast<int>(u(row_pack, opus_moe_stage2_a8w4_a_lane_k<T>(ga_offset), row_lane));
+    return row_pack * scale_words_per_row_pack +
+           opus_moe_stage2_a8w4_a_lane_k<T>(ga_offset) * T::MMA_M +
+           row_lane;
 }
 
 template<typename T>
@@ -225,24 +204,25 @@ inline __device__ int opus_moe_stage2_a8w4_b_lane_k(int gb_offset)
 template<typename T>
 inline __device__ int opus_moe_stage2_a8w4_b_scale_base_word_offset(int scale_row_col_base,
                                                                     int gb_offset,
-                                                                    int wave_id_n)
+                                                                    int wave_id_n,
+                                                                    int scale_words_per_row_pack)
 {
     const int row_pack =
         scale_row_col_base / T::SCALE_ROWS_PER_ROW_PACK +
         wave_id_n * T::HALF_N_MFMA_PER_WAVE;
-    constexpr auto u = opus_moe_stage2_a8w4_layout_scale_word<T>();
-    return static_cast<int>(u(row_pack,
-                              opus_moe_stage2_a8w4_b_lane_k<T>(gb_offset),
-                              opus_moe_stage2_a8w4_b_lane_m<T>(gb_offset)));
+    return row_pack * scale_words_per_row_pack +
+           opus_moe_stage2_a8w4_b_lane_k<T>(gb_offset) * T::MMA_M +
+           opus_moe_stage2_a8w4_b_lane_m<T>(gb_offset);
 }
 
 template<typename T>
 inline __device__ int opus_moe_stage2_a8w4_b_scale_word_offset(int base_word_offset,
                                                                int k_group_word_base,
-                                                               int pair)
+                                                               int pair,
+                                                               int scale_words_per_row_pack)
 {
     return base_word_offset + k_group_word_base +
-           pair * T::SCALE_WORDS_PER_ROW_PACK;
+           pair * scale_words_per_row_pack;
 }
 
 template<typename T>

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_stage2_a8w4_decode_dispatch_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_stage2_a8w4_decode_dispatch_gfx950.cuh
@@ -2,8 +2,41 @@
 // Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
 
-#include "../opus_moe_arch_gfx950.cuh"
+#include "opus_moe_traits_stage2_a8w4_decode_gfx950.cuh"
 #include "opus_moe_stage2_a8w4_manifest.h"
+
+#include "aiter_hip_common.h"
+
+template<typename Traits>
+__global__ void
+opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs);
+
+template<typename Traits>
+inline void opus_moe_stage2_a8w4_decode_launch_gfx950(
+    const opus_moe_stage2_a8w4_kargs& kargs,
+    hipStream_t stream)
+{
+    int route_blocks =
+        (kargs.sorted_blocks * Traits::SORT_BLOCK_M + Traits::B_M - 1) / Traits::B_M;
+    opus_moe_stage2_a8w4_kargs launch_kargs = kargs;
+    if constexpr(Traits::DECODE_PACE_ROUTE_BLOCKS_TO_POW2)
+    {
+        int paced_route_blocks = 1;
+        while(paced_route_blocks < route_blocks)
+            paced_route_blocks <<= 1;
+        route_blocks = paced_route_blocks;
+    }
+    launch_kargs.sorted_blocks = route_blocks;
+    AITER_CHECK(kargs.model_dim % Traits::B_N == 0,
+                "Opus A8W4 stage2 requires model_dim to be a multiple of block_n=",
+                Traits::B_N,
+                ", got ",
+                kargs.model_dim);
+    const dim3 grid(kargs.model_dim / Traits::B_N, route_blocks);
+    const dim3 block(Traits::BLOCK_SIZE);
+    opus_moe_stage2_a8w4_decode_kernel_gfx950<Traits>
+        <<<grid, block, 0, stream>>>(launch_kargs);
+}
 
 inline void opus_moe_stage2_a8w4_decode_dispatch_gfx950(
     int kid,

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_stage2_a8w4_decode_dispatch_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_stage2_a8w4_decode_dispatch_gfx950.cuh
@@ -9,7 +9,8 @@
 
 template<typename Traits>
 __global__ void
-opus_moe_stage2_a8w4_decode_kernel_gfx950(opus_moe_stage2_a8w4_kargs);
+opus_moe_stage2_a8w4_decode_kernel_gfx950(
+    opus_moe_stage2_a8w4_kargs);
 
 template<typename Traits>
 inline void opus_moe_stage2_a8w4_decode_launch_gfx950(
@@ -17,7 +18,7 @@ inline void opus_moe_stage2_a8w4_decode_launch_gfx950(
     hipStream_t stream)
 {
     int route_blocks =
-        (kargs.sorted_blocks * Traits::SORT_BLOCK_M + Traits::B_M - 1) / Traits::B_M;
+        (kargs.sorted_blocks * kargs.sort_block_m + Traits::B_M - 1) / Traits::B_M;
     opus_moe_stage2_a8w4_kargs launch_kargs = kargs;
     if constexpr(Traits::DECODE_PACE_ROUTE_BLOCKS_TO_POW2)
     {
@@ -40,7 +41,6 @@ inline void opus_moe_stage2_a8w4_decode_launch_gfx950(
 
 inline void opus_moe_stage2_a8w4_decode_dispatch_gfx950(
     int kid,
-    int effective_inter_dim,
     const opus_moe_stage2_a8w4_kargs& kargs,
     hipStream_t stream)
 {
@@ -51,7 +51,5 @@ inline void opus_moe_stage2_a8w4_decode_dispatch_gfx950(
     }
     AITER_CHECK(false,
                 "unreachable A8W4 kernel dispatch for kid=",
-                kid,
-                " effective_inter_dim=",
-                effective_inter_dim);
+                kid);
 }

--- a/csrc/opus_moe/include/gfx950/a8w4/opus_moe_traits_stage2_a8w4_decode_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/opus_moe_traits_stage2_a8w4_decode_gfx950.cuh
@@ -5,16 +5,16 @@
 #include "../../opus_moe_common.cuh"
 #include "opus/opus.hpp"
 
-template<typename Contract = opus_moe::OpusMoeStage2A8W4DefaultContract,
-         int BlockM = opus_moe::kStage2A8W4DecodeDefaultBlockM,
+template<int BlockM = opus_moe::kStage2A8W4DecodeDefaultBlockM,
          int BlockN = opus_moe::kStage2A8W4DecodeDefaultBlockN,
-         int SortBlockM = BlockM,
          bool DirectAtomicOut = true,
          bool PaceRouteBlocksToPow2 = false,
          int BlockThreadsOverride = 0,
          int MinBlocksPerCuOverride = 0,
          int CachectlBOverride = 0,
-         int CachectlWScaleOverride = 0>
+         int CachectlWScaleOverride = 0,
+         int PairSlots = 1,
+         int SteadyPairSlots = PairSlots>
 struct OpusMoeStage2A8W4DecodeShape
 {
     // Atomic vs MXFP8 route-out is a structural compile-time choice.
@@ -43,33 +43,27 @@ struct OpusMoeStage2A8W4DecodeShape
     static constexpr int THREADS_K = opus::get_warp_size() / MMA_M;
     static constexpr int T_M = IS_BM32_BN256 ? 2 : 1;
 
-    static constexpr int DECODE_LOGICAL_INTER_DIM = Contract::DECODE_LOGICAL_INTER_DIM;
-    static constexpr int DECODE_INTER_DIM_PAD = Contract::DECODE_INTER_DIM_PAD;
-    static constexpr int DECODE_EFFECTIVE_INTER_DIM = Contract::DECODE_EFFECTIVE_INTER_DIM;
-    static constexpr int SORT_BLOCK_M = SortBlockM;
     static constexpr int ROUTE_M_STRIDE = B_M;
     // route_out XCD swizzle (gfx950=8 XCDs).
     static constexpr int NUM_XCD = DIRECT_ATOMIC_OUT ? 1 : 8;
     static constexpr int SWIZZLE_W = 2;
     static constexpr int SWIZZLE_C =
         (!DIRECT_ATOMIC_OUT && (IS_BM32_BN256 || IS_BM64_BN256))
-            ? (IS_BM64_BN256 && DECODE_EFFECTIVE_INTER_DIM / K_STEP_PACKED >= 4 ? 24 : 32)
+            ? (IS_BM64_BN256 && BlockThreadsOverride != 256 ? 24 : 32)
             : 0;
     static constexpr bool DECODE_PACE_ROUTE_BLOCKS_TO_POW2 = PaceRouteBlocksToPow2;
-    static constexpr int K_TILES = DECODE_EFFECTIVE_INTER_DIM / K_STEP_PACKED;
     static constexpr int DEFAULT_BLOCK_SIZE =
-        !DIRECT_ATOMIC_OUT && IS_BM64_BN256 && K_TILES >= 4
+        !DIRECT_ATOMIC_OUT && IS_BM64_BN256
             ? 128
             : opus_moe::kStage2A8W4DecodeDefaultCtaThreads;
     static constexpr int BLOCK_SIZE =
         BlockThreadsOverride > 0 ? BlockThreadsOverride : DEFAULT_BLOCK_SIZE;
     static constexpr int T_N = (BLOCK_SIZE / opus::get_warp_size()) / T_M;
-    // Route-out K>=4 BM64 variants need looser launch resources to avoid
-    // pressure from the wider decode mainloop; K3 keeps the tuned resources.
-    static constexpr int ROUTE_OUT_MAX_MIN_BLOCKS_PER_CU =
-        IS_BM64_BN256 && K_TILES >= 4 ? 2 : 4;
+    static constexpr int ROUTE_OUT_MAX_MIN_BLOCKS_PER_CU = 4;
     static constexpr int DEFAULT_ROUTE_OUT_MIN_BLOCKS_PER_CU =
-        ROUTE_OUT_MAX_MIN_BLOCKS_PER_CU;
+        (!DIRECT_ATOMIC_OUT && IS_BM64_BN256)
+            ? 2
+            : ROUTE_OUT_MAX_MIN_BLOCKS_PER_CU;
     static constexpr int DEFAULT_MIN_BLOCKS_PER_CU =
         !DIRECT_ATOMIC_OUT ? DEFAULT_ROUTE_OUT_MIN_BLOCKS_PER_CU : (IS_BM16 ? 4 : 2);
     static constexpr int REQUESTED_MIN_BLOCKS_PER_CU =
@@ -79,19 +73,15 @@ struct OpusMoeStage2A8W4DecodeShape
             ? ROUTE_OUT_MAX_MIN_BLOCKS_PER_CU
             : REQUESTED_MIN_BLOCKS_PER_CU;
     static constexpr int A_LDS_STAGE_ELEMS = B_M * K_STEP_PACKED;
-    static constexpr int A_LDS_FULL_BYTES =
-        K_TILES * A_LDS_STAGE_ELEMS * static_cast<int>(sizeof(D_A));
-    static constexpr int A_LDS_STREAM_STAGES = 2;
-    // Stream A through two LDS buffers above 64 KiB to preserve CTA residency.
-    static constexpr int A_LDS_STAGES =
-        A_LDS_FULL_BYTES <= 64 * 1024
-            ? K_TILES
-            : A_LDS_STREAM_STAGES;
-    static constexpr int SCALE_GROUP_LOGICAL_K = opus_moe::kStage2A8W4DecodeScaleGroupLogicalK;
-    static constexpr int DECODE_SCALE_GROUPS = DECODE_LOGICAL_INTER_DIM / SCALE_GROUP_LOGICAL_K;
-    static constexpr int SCALE_GROUPS_PER_ROW_PACK = (K_TILES + 1) / 2;
+    // PairSlots is a static resource setting independent of runtime K.
+    static constexpr int PAIR_SLOTS = PairSlots;
+    static constexpr int A_LDS_STAGES = 2 * PAIR_SLOTS;
+    // SteadyPairSlots is a static resource setting independent of runtime K.
+    static constexpr int STEADY_PAIR_SLOTS = SteadyPairSlots;
+    // The two-wave BM64 schedule may overlap unused A-ring stages with the first tile.
+    static constexpr bool OVERLAP_SHORT_A_STAGES =
+        IS_BM64_BN256 && BLOCK_SIZE == 128;
     static constexpr int SCALE_WORDS_PER_GROUP_PACK = opus_moe::kStage2A8W4DecodeScaleWordsPerGroupPack;
-    static constexpr int SCALE_WORDS_PER_ROW_PACK = SCALE_GROUPS_PER_ROW_PACK * SCALE_WORDS_PER_GROUP_PACK;
     static constexpr int SCALE_ROWS_PER_ROW_PACK = 2 * MMA_M;
     static constexpr int B_PAYLOAD_KLANE_STRIDE_BYTES = B_K_LOGICAL;
     static constexpr int B_PAYLOAD_K_STRIDE_BYTES = BYTES_PER_VEC / opus_moe::kStage2A8W4DecodeFp4ValuesPerByte;
@@ -100,7 +90,6 @@ struct OpusMoeStage2A8W4DecodeShape
     static constexpr int M_MFMA_PER_WAVE = B_M / (T_M * MMA_M);
     static constexpr int N_MFMA_PER_WAVE = B_N / (T_N * MMA_N);
     static constexpr int HALF_N_MFMA_PER_WAVE = N_MFMA_PER_WAVE / 2;
-    static constexpr int A_LDS_BUFFER_LOAD_INSTS = (K_TILES - 1) * M_MFMA_PER_WAVE;
     static constexpr int C_LDS_N = B_N, VEC_C = opus_moe::kStage2A8W4DecodeCVec;
     static constexpr int ELEM_PER_ATOMIC = opus_moe::kStage2A8W4DecodeCValuesPerAtomic;
 
@@ -113,17 +102,10 @@ struct OpusMoeStage2A8W4DecodeShape
     static_assert(BLOCK_SIZE / opus::get_warp_size() == T_M * T_N);
     static_assert(THREADS_K == K_STEP_PACKED / (2 * VEC_A));
     static_assert(THREADS_K == K_STEP_PACKED / (2 * B_BYTES_PER_VEC));
-    static_assert(DECODE_LOGICAL_INTER_DIM % opus_moe::kStage2A8W4DecodeFp4ValuesPerByte == 0);
     static_assert((B_PAYLOAD_KLANE_STRIDE_BYTES & (B_PAYLOAD_KLANE_STRIDE_BYTES - 1)) == 0);
     static_assert((B_THREADGROUP_STRIDE_BYTES & (B_THREADGROUP_STRIDE_BYTES - 1)) == 0);
     static_assert(B_M % (T_M * MMA_M) == 0);
     static_assert(B_N % (T_N * MMA_N) == 0);
-    static_assert(SORT_BLOCK_M > 0);
-    static_assert(SORT_BLOCK_M % B_M == 0);
-    static_assert(DECODE_EFFECTIVE_INTER_DIM == K_TILES * K_STEP_PACKED);
-    static_assert(K_TILES > 0);
-    static_assert(DECODE_LOGICAL_INTER_DIM % SCALE_GROUP_LOGICAL_K == 0);
-    static_assert(DECODE_SCALE_GROUPS <=
-                  SCALE_GROUPS_PER_ROW_PACK *
-                      opus_moe::kStage2A8W4DecodeScaleGroupsPerRowPack);
+    static_assert(PAIR_SLOTS == 1 || PAIR_SLOTS == 2);
+    static_assert(STEADY_PAIR_SLOTS >= 1 && STEADY_PAIR_SLOTS <= PAIR_SLOTS);
 };

--- a/csrc/opus_moe/include/gfx950/a8w4/stage1/opus_moe_stage1_a8w4_dispatch_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/a8w4/stage1/opus_moe_stage1_a8w4_dispatch_gfx950.cuh
@@ -2,27 +2,38 @@
 // Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
 
-#include "opus_moe_stage1_a8w4_pipeline_group_split_gfx950.cuh"
-#include "opus_moe_stage1_a8w4_pipeline_pair_kwave_gfx950.cuh"
+#include "opus_moe_stage1_a8w4_traits_gfx950.cuh"
 #include "opus_moe_stage1_a8w4_manifest.h"
 
-#include "opus/hip_minimal.hpp"
+#include "aiter_hip_common.h"
 
 namespace opus_moe
 {
 namespace stage1_a8w4
 {
 
-template<typename Traits>
-inline void launch(int effective_inter_dim,
-                   int sorted_blocks,
-                   const OpusMoeStage1A8W4Kargs& kargs,
-                   hipStream_t stream)
+namespace pipeline_group_split
 {
-    const int col_tiles =
-        effective_inter_dim / Traits::OUTPUT_COLS_PER_TILE;
-    dim3 grid(col_tiles, sorted_blocks, 1);
-    dim3 block(Traits::BLOCK_SIZE);
+template<typename Traits>
+__global__ void
+opus_moe_stage1_a8w4_kernel_group_split_gfx950(OpusMoeStage1A8W4Kargs);
+}
+
+namespace pipeline_pair_kwave
+{
+template<typename Traits>
+__global__ void
+opus_moe_stage1_a8w4_kernel_pair_kwave_gfx950(OpusMoeStage1A8W4Kargs);
+}
+
+template<typename Traits>
+inline void launch_gfx950(int effective_inter_dim,
+                          int sorted_blocks,
+                          const OpusMoeStage1A8W4Kargs& kargs,
+                          hipStream_t stream)
+{
+    const dim3 grid(effective_inter_dim / Traits::OUTPUT_COLS_PER_TILE, sorted_blocks);
+    const dim3 block(Traits::BLOCK_SIZE);
     if constexpr(Traits::GATE_UP_GROUP_SPLIT)
     {
         pipeline_group_split::opus_moe_stage1_a8w4_kernel_group_split_gfx950<Traits>
@@ -35,20 +46,20 @@ inline void launch(int effective_inter_dim,
     }
 }
 
-inline void dispatch(int kernel_id,
+inline void dispatch(int kid,
                      int effective_inter_dim,
                      int sorted_blocks,
                      const OpusMoeStage1A8W4Kargs& kargs,
                      hipStream_t stream)
 {
-    switch(kernel_id)
+    switch(kid)
     {
     GENERATE_OPUS_MOE_STAGE1_A8W4_DISPATCH_CASES
     default: break;
     }
     AITER_CHECK(false,
-                "unreachable A8W4 stage1 kernel dispatch for kernel_id=",
-                kernel_id);
+                "unreachable A8W4 stage1 kernel dispatch for kid=",
+                kid);
 }
 
 } // namespace stage1_a8w4

--- a/csrc/opus_moe/include/gfx950/opus_moe_arch_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/opus_moe_arch_gfx950.cuh
@@ -4,17 +4,14 @@
 // gfx950-specific Opus MoE dispatch implementations.
 #pragma once
 
-#include "../opus_moe_arch.cuh"
 #include "../opus_moe_common.cuh"
+#include "a16w16/opus_moe_traits_stage2_gfx950.cuh"
 #include "opus_moe_stage2_route_output_reduce_gfx950.cuh"
-#include "a16w16/opus_moe_pipeline_stage2_gemmstyle_gfx950.cuh"
-#include "a8w4/opus_moe_pipeline_stage2_a8w4_decode_main_gfx950.cuh"
-#include "opus_moe_stage2_manifest.h"
 
 #include "aiter_hip_common.h"
+#include "opus_moe_stage2_manifest.h"
 
 #include <algorithm>
-#include <cstddef>
 #include <hip/hip_runtime.h>
 
 using OpusMoeStage2Bf16Kernel = void (*)(const opus_moe_stage2_bf16_kargs&,
@@ -22,9 +19,14 @@ using OpusMoeStage2Bf16Kernel = void (*)(const opus_moe_stage2_bf16_kargs&,
                                          hipStream_t);
 
 template<typename Traits>
-inline void opus_moe_stage2_gemmstyle_launch_gfx950(const opus_moe_stage2_bf16_kargs& kargs,
-                                                    int sorted_blocks,
-                                                    hipStream_t stream)
+__global__ void
+opus_moe_stage2_gemmstyle_kernel_gfx950(opus_moe_stage2_bf16_kargs);
+
+template<typename Traits>
+inline void opus_moe_stage2_gemmstyle_launch_gfx950(
+    const opus_moe_stage2_bf16_kargs& kargs,
+    int sorted_blocks,
+    hipStream_t stream)
 {
     AITER_CHECK(kargs.block_m % Traits::B_M == 0,
                 "opus_moe stage2 gemmstyle kernel requires block_m to be a multiple of ",
@@ -45,75 +47,24 @@ inline void opus_moe_stage2_gemmstyle_launch_gfx950(const opus_moe_stage2_bf16_k
     const int route_tiles =
         (kargs.token_num * kargs.topk + Traits::B_M - 1) / Traits::B_M;
     const int m_tiles = std::min(metadata_tiles, route_tiles);
-    const int n_tiles = (kargs.model_dim + Traits::B_N - 1) / Traits::B_N;
-    dim3 grid(n_tiles, m_tiles, 1);
-    dim3 block(Traits::BLOCK_SIZE);
-    opus_moe_stage2_gemmstyle_kernel_gfx950<Traits><<<grid, block, 0, stream>>>(kargs);
+    const dim3 grid(kargs.model_dim / Traits::B_N, m_tiles);
+    const dim3 block(Traits::BLOCK_SIZE);
+    opus_moe_stage2_gemmstyle_kernel_gfx950<Traits>
+        <<<grid, block, 0, stream>>>(kargs);
 }
 
-template<typename Traits>
-inline void opus_moe_stage2_a8w4_decode_launch_gfx950(
-    const opus_moe_stage2_a8w4_kargs& kargs,
-    hipStream_t stream)
+inline OpusMoeStage2Bf16Kernel opus_moe_stage2_bf16_tune_dispatch_gfx950(int kid)
 {
-    int route_blocks =
-        (kargs.sorted_blocks * Traits::SORT_BLOCK_M + Traits::B_M - 1) /
-        Traits::B_M;
-    opus_moe_stage2_a8w4_kargs launch_kargs = kargs;
-    launch_kargs.sorted_blocks = route_blocks;
-    if constexpr(Traits::DECODE_PACE_ROUTE_BLOCKS_TO_POW2)
+    switch(kid)
     {
-        int paced_route_blocks = 1;
-        while(paced_route_blocks < route_blocks)
-            paced_route_blocks <<= 1;
-        route_blocks = paced_route_blocks;
-        launch_kargs.sorted_blocks = route_blocks;
+    GENERATE_OPUS_MOE_STAGE2_BF16_DISPATCH_CASES
+    default: break;
     }
-    AITER_CHECK(kargs.model_dim % Traits::B_N == 0,
-                "Opus A8W4 stage2 requires model_dim to be a multiple of block_n=",
-                Traits::B_N,
-                ", got ",
-                kargs.model_dim);
-    const int n_tiles = kargs.model_dim / Traits::B_N;
-    dim3 grid(n_tiles, route_blocks, 1);
-    dim3 block(Traits::BLOCK_SIZE);
-    opus_moe_stage2_a8w4_decode_kernel_gfx950<Traits><<<grid, block, 0, stream>>>(
-        launch_kargs);
-}
-
-namespace opus_moe_gfx950_detail
-{
-struct OpusMoeStage2TuneEntry
-{
-    int kid;
-    OpusMoeStage2Bf16Kernel func;
-};
-
-struct TuneEntryLess
-{
-    template<typename Entry>
-    constexpr bool operator()(const Entry& a, const Entry& b) const noexcept
-    {
-        return a.kid < b.kid;
-    }
-};
-} // namespace opus_moe_gfx950_detail
-
-inline OpusMoeStage2Bf16Kernel opus_moe_stage2_bf16_tune_dispatch_gfx950(int id)
-{
-    using namespace opus_moe_gfx950_detail;
-    static constexpr OpusMoeStage2TuneEntry kTune[] = {
-        GENERATE_OPUS_MOE_STAGE2_BF16_TUNE_LOOKUP
-    };
-    constexpr size_t kSize = OPUS_MOE_STAGE2_BF16_TUNE_LOOKUP_SIZE;
-    static_assert(kSize == sizeof(kTune) / sizeof(kTune[0]));
-    const OpusMoeStage2TuneEntry needle{id, nullptr};
-    const auto it = std::lower_bound(kTune, kTune + kSize, needle, TuneEntryLess{});
-    AITER_CHECK(it != kTune + kSize && it->kid == id,
+    AITER_CHECK(false,
                 "Kernel id ",
-                id,
+                kid,
                 " (",
-                opus_moe::stage2_bf16_kid_name(id),
+                opus_moe::stage2_bf16_kid_name(kid),
                 ") not found in gfx950 Opus MoE stage2 BF16 tune table");
-    return it->func;
+    return nullptr;
 }

--- a/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
@@ -3,14 +3,16 @@
 #pragma once
 
 #include "../opus_moe_common.cuh"
+#ifdef OPUS_MOE_ROUTE_REDUCE_DEVICE_TU
 #include "opus_moe_stage2_utils_gfx950.cuh"
-
-#include "aiter_hip_common.h"
-
 #include <cstdint>
 #include <hip/hip_bfloat16.h>
+#else
+#include "aiter_hip_common.h"
 #include <hip/hip_runtime.h>
+#endif
 
+#ifndef OPUS_MOE_ROUTE_REDUCE_DEVICE_TU
 constexpr int kOpusMoeStage2RouteOutputReduceAutoBlockN = -1;
 constexpr int kOpusMoeStage2RouteOutputReduceBf16BlockN = 2048;
 constexpr int kOpusMoeStage2RouteOutputReduceDefaultBlockN = 4096;
@@ -25,7 +27,9 @@ inline int opus_moe_stage2_reduce_token_slot_route_output_select_block_n(
     const int auto_block_n = opus_moe::stage2_a8w4_route_reduce_auto_block_n(model_dim);
     return auto_block_n > 0 ? auto_block_n : kOpusMoeStage2RouteOutputReduceDefaultBlockN;
 }
+#endif
 
+#ifdef OPUS_MOE_ROUTE_REDUCE_DEVICE_TU
 #ifdef __HIP_DEVICE_COMPILE__
 static __device__ __forceinline__ void
 opus_moe_stage2_route_reduce_accum_bf16x4(float* acc, int base, uint64_t packed)
@@ -267,7 +271,14 @@ opus_moe_stage2_reduce_token_slot_route_output_kernel_gfx950(opus_moe_stage2_rou
 #endif
 #endif
 }
+#else
+template<int BLOCK_N, int BLOCK_THREADS, int TOPK = 0, bool ROUTE_FP8 = false>
+__global__ __launch_bounds__(BLOCK_THREADS, ROUTE_FP8 ? 2 : 4) void
+opus_moe_stage2_reduce_token_slot_route_output_kernel_gfx950(
+    opus_moe_stage2_route_reduce_kargs kargs);
+#endif
 
+#ifndef OPUS_MOE_ROUTE_REDUCE_DEVICE_TU
 template<int BLOCK_N, int BLOCK_THREADS, int TOPK, bool ROUTE_FP8>
 inline void opus_moe_stage2_reduce_token_slot_route_output_launch_variant_gfx950(
     const opus_moe_stage2_route_reduce_kargs& kargs,
@@ -366,3 +377,4 @@ inline void opus_moe_stage2_reduce_token_slot_route_output_launch_gfx950(
         break;
     }
 }
+#endif

--- a/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
@@ -197,43 +197,6 @@ opus_moe_stage2_reduce_token_slot_route_output_kernel_gfx950(opus_moe_stage2_rou
             }
         }
 
-        if(scalar_tail == 0)
-        {
-#pragma unroll
-            for(int slot = 0; slot < topk_loop; ++slot)
-            {
-                const int route_row = route_row_base + slot;
-#pragma unroll
-                for(int group = 0; group < groups_per_thread; ++group)
-                {
-                    if(group < valid_groups4)
-                    {
-                        const int col = col_base + group * 4;
-                        const uint64_t packed =
-                            *reinterpret_cast<const uint64_t*>(
-                                route_out_bf16 +
-                                static_cast<int64_t>(route_row) * kargs.stride_route_out_t + col);
-                        opus_moe_stage2_route_reduce_accum_bf16x4(acc, group * 4, packed);
-                    }
-                }
-            }
-
-#pragma unroll
-            for(int group = 0; group < groups_per_thread; ++group)
-            {
-                if(group < valid_groups4)
-                {
-                    const int col = col_base + group * 4;
-                    *reinterpret_cast<uint64_t*>(kargs.out_bf16 +
-                                                 static_cast<int64_t>(token) *
-                                                     kargs.stride_o_t +
-                                                 col) =
-                        opus_moe_stage2_route_reduce_pack_bf16x4(acc, group * 4);
-                }
-            }
-            return;
-        }
-
 #pragma unroll
         for(int tail = 0; tail < max_scalar_tail; ++tail)
         {

--- a/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
+++ b/csrc/opus_moe/include/gfx950/opus_moe_stage2_route_output_reduce_gfx950.cuh
@@ -13,20 +13,9 @@
 #endif
 
 #ifndef OPUS_MOE_ROUTE_REDUCE_DEVICE_TU
-constexpr int kOpusMoeStage2RouteOutputReduceAutoBlockN = -1;
 constexpr int kOpusMoeStage2RouteOutputReduceBf16BlockN = 2048;
 constexpr int kOpusMoeStage2RouteOutputReduceDefaultBlockN = 4096;
 constexpr int kOpusMoeStage2RouteOutputReduceDefaultThreads = 256;
-
-inline int opus_moe_stage2_reduce_token_slot_route_output_select_block_n(
-    int model_dim,
-    int requested_block_n)
-{
-    if(requested_block_n > 0)
-        return requested_block_n;
-    const int auto_block_n = opus_moe::stage2_a8w4_route_reduce_auto_block_n(model_dim);
-    return auto_block_n > 0 ? auto_block_n : kOpusMoeStage2RouteOutputReduceDefaultBlockN;
-}
 #endif
 
 #ifdef OPUS_MOE_ROUTE_REDUCE_DEVICE_TU
@@ -351,8 +340,9 @@ inline void opus_moe_stage2_reduce_token_slot_route_output_launch_gfx950(
     hipStream_t stream,
     int requested_block_n)
 {
-    const int block_n = opus_moe_stage2_reduce_token_slot_route_output_select_block_n(
-        kargs.model_dim, requested_block_n);
+    const int block_n = requested_block_n > 0
+                            ? requested_block_n
+                            : kOpusMoeStage2RouteOutputReduceDefaultBlockN;
     dim3 grid(kargs.token_num, (kargs.model_dim + block_n - 1) / block_n, 1);
     // Specialize for common topk values (unrolls the slot loop -> all loads
     // issued up front, hiding latency); otherwise fall back to the runtime-topk

--- a/csrc/opus_moe/include/opus_moe_common.cuh
+++ b/csrc/opus_moe/include/opus_moe_common.cuh
@@ -96,8 +96,12 @@ struct opus_moe_stage2_a8w4_kargs
     int num_experts;
     int model_dim;
     int sorted_blocks;
+    int sort_block_m;
     int a_scale_rows;
     int route_out_fp8;          // Runtime guard for the MXFP8 route-out path.
+    int k_tiles;
+    int a_scale_words_per_row_pack;
+    int w_scale_words_per_row_pack;
     int64_t route_out_row_bytes;  // fp8 route_out row stride bytes (= model_dim + model_dim/8).
 };
 

--- a/csrc/opus_moe/include/opus_moe_host_impl.cuh
+++ b/csrc/opus_moe/include/opus_moe_host_impl.cuh
@@ -713,19 +713,11 @@ void opus_moe_stage1_a8w4_fwd(
                 "Opus A8W4 stage1 activation must be Silu (0), Swiglu (2), or "
                 "Situv2 (3), got ",
                 activation);
+    AITER_CHECK(swiglu_limit > 0.0f, "swiglu_limit must be positive");
     if(activation_type == ActivationType::Situv2)
     {
-        // Situv2 must not be SwiGLU-clamped; the non-sparse stage1 kernel clamps
-        // every activation, so pass +inf (no-op) if a stray non-positive limit
-        // reaches this path from warmup (Python passes +inf).
-        if(!(swiglu_limit > 0.0f))
-            swiglu_limit = std::numeric_limits<float>::infinity();
         AITER_CHECK(situ_beta > 0.0f, "situ_beta must be positive");
         AITER_CHECK(situ_linear_beta > 0.0f, "situ_linear_beta must be positive");
-    }
-    else
-    {
-        AITER_CHECK(swiglu_limit > 0.0f, "swiglu_limit must be positive");
     }
     AITER_CHECK(kernel_id != opus_moe::kStage1A8W4KidInvalid,
                 "Invalid Opus A8W4 stage1 kernel name: ",

--- a/csrc/opus_moe/include/opus_moe_host_impl.cuh
+++ b/csrc/opus_moe/include/opus_moe_host_impl.cuh
@@ -190,9 +190,7 @@ int select_bf16_kernel_id(int requested_kernel_id)
     return selected_kernel_id;
 }
 
-int select_a8w4_kernel_id(int requested_kernel_id,
-                          int block_m,
-                          int effective_inter_dim)
+int select_a8w4_kernel_id(int requested_kernel_id, int block_m)
 {
     int selected_kernel_id = requested_kernel_id;
     if(selected_kernel_id == opus_moe::kStage2KidAuto)
@@ -200,8 +198,8 @@ int select_a8w4_kernel_id(int requested_kernel_id,
         // Auto selects a direct-atomic kernel by sort block_m. Route-out kernels
         // must be requested explicitly because they require a different output
         // layout and follow-up reduce.
-        selected_kernel_id = opus_moe::stage2_a8w4_auto_direct_atomic_kid(
-            effective_inter_dim, block_m);
+        selected_kernel_id =
+            opus_moe::stage2_a8w4_auto_direct_atomic_kid(block_m);
     }
     AITER_CHECK(opus_moe::stage2_a8w4_kid_is_valid(selected_kernel_id),
                 "opus_moe_stage2_a8w4_decode_fwd got unsupported kernel_id=",
@@ -209,8 +207,8 @@ int select_a8w4_kernel_id(int requested_kernel_id,
                 " (",
                 opus_moe::stage2_a8w4_kid_name(selected_kernel_id),
                 ")");
-    // Validate that the caller sorted with the block_m required by the selected kid.
-    const int sort_block_m = opus_moe::stage2_a8w4_kid_sort_block_m(selected_kernel_id);
+    const int sort_block_m =
+        opus_moe::stage2_a8w4_kid_sort_block_m(selected_kernel_id);
     AITER_CHECK(sort_block_m == block_m,
                 "kernel_id=",
                 selected_kernel_id,
@@ -465,17 +463,15 @@ void opus_moe_stage2_a8w4_decode_fwd(
                 logical_inter_dim,
                 " inter_dim_pad=",
                 inter_dim_pad);
-    AITER_CHECK(effective_inter_dim % packed_k_tile_width == 0,
-                "Opus A8W4 stage2 effective_inter_dim must be divisible by ",
+    AITER_CHECK(opus_moe::stage2_a8w4_effective_inter_dim_is_supported(effective_inter_dim),
+                "Opus A8W4 stage2 effective_inter_dim must be at least ",
+                2 * packed_k_tile_width,
+                " and divisible by ",
                 packed_k_tile_width,
                 ", got ",
                 effective_inter_dim);
-    AITER_CHECK(opus_moe::stage2_a8w4_effective_inter_dim_is_supported(effective_inter_dim),
-                "Opus A8W4 stage2 effective_inter_dim is not compiled: ",
-                effective_inter_dim);
 
-    const int selected_kernel_id =
-        select_a8w4_kernel_id(kernel_id, block_m, effective_inter_dim);
+    const int selected_kernel_id = select_a8w4_kernel_id(kernel_id, block_m);
     const int kernel_block_n = opus_moe::stage2_a8w4_kid_block_n(selected_kernel_id);
     const int expected_scale_cols =
         (((effective_inter_dim / packed_k_tile_width) + 1) / 2) *
@@ -538,11 +534,19 @@ void opus_moe_stage2_a8w4_decode_fwd(
     kargs.stride_a_scale_route = a2_scale.stride(0);
     kargs.stride_w_scale_row = w2_scale.stride(0);
     kargs.stride_o_t = route_out_fp8 ? 0 : out.stride(0);
+    kargs.k_tiles = effective_inter_dim / packed_k_tile_width;
+    kargs.a_scale_words_per_row_pack = static_cast<int>(
+        kargs.stride_a_scale_route *
+        (2 * opus_moe::kStage2A8W4DecodeMfmaM) / sizeof(uint32_t));
+    kargs.w_scale_words_per_row_pack = static_cast<int>(
+        kargs.stride_w_scale_row *
+        (2 * opus_moe::kStage2A8W4DecodeMfmaM) / sizeof(uint32_t));
     kargs.token_num = token_num;
     kargs.topk = actual_topk;
     kargs.num_experts = num_experts;
     kargs.model_dim = model_dim;
     kargs.sorted_blocks = sorted_blocks;
+    kargs.sort_block_m = block_m;
     kargs.a_scale_rows = static_cast<int>(a2_scale.size(0));
     // Keep a runtime route-out guard: the MXFP8 path codegen is measurably more
     // stable than making route-out a pure compile-time else branch.
@@ -553,7 +557,7 @@ void opus_moe_stage2_a8w4_decode_fwd(
     const hipStream_t stream = aiter::getCurrentHIPStream();
 
     opus_moe_stage2_a8w4_decode_dispatch_gfx950(
-        selected_kernel_id, effective_inter_dim, kargs, stream);
+        selected_kernel_id, kargs, stream);
     HIP_CALL_LAUNCH(hipGetLastError());
 }
 

--- a/csrc/opus_moe/opus_moe.cu
+++ b/csrc/opus_moe/opus_moe.cu
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 
+#ifndef __HIP_DEVICE_COMPILE__
 #include "opus_moe_host_impl.cuh"
+#endif

--- a/csrc/opus_moe/opus_moe_common.py
+++ b/csrc/opus_moe/opus_moe_common.py
@@ -39,9 +39,6 @@ _a8w4_meta = _load_ops_meta_module(
     Path("aiter") / "ops" / "opus" / "moe_stage2_a8w4_meta.py",
     "_opus_moe_stage2_a8w4_meta",
 )
-OPUS_A8W4_CODEGEN_SEED_EFFECTIVE_INTER_DIMS = (
-    _a8w4_meta.OPUS_A8W4_CODEGEN_SEED_EFFECTIVE_INTER_DIMS
-)
 OPUS_A8W4_GFX950_DECODE_KERNEL_CONTRACT = (
     _a8w4_meta.OPUS_A8W4_GFX950_DECODE_KERNEL_CONTRACT
 )


### PR DESCRIPTION
  ## Motivation

  Opus MoE A8W4 Stage2 previously encoded the effective intermediate dimension
  into its kernel traits. `gen_instances.py` collected K values from tuned CSVs
  and emitted a complete set of Stage2 specializations for every collected K.

  This had several drawbacks:

  - valid but previously unseen effective-K values required new code generation
    and recompilation;
  - non-Opus tuned rows could unnecessarily increase the Opus specialization set;
  - binary size and compile work scaled with the number of intermediate dimensions;
  - host dispatch, device instantiation, K scheduling, tile operations, and
    epilogue behavior were spread across tightly coupled headers;
  - one public kernel configuration could be difficult to trace from its tuned
    name to its exact decode and route-reduce behavior.

  The goal of this PR is to make effective K runtime-selectable while preserving
  compile-time launch/resource policies and the performance of the existing
  K384/K512 production paths. It also reorganizes the implementation so that
  metadata, codegen, mainloop operations, and epilogue operations have explicit
  and one-directional responsibilities.

  ## Technical Details

  ### Runtime-K Stage2 pipeline

  - Move the effective K tile count and scale row-pack strides into
    `opus_moe_stage2_a8w4_kargs`.
  - Accept any effective intermediate dimension that is:
    - at least two packed K tiles;
    - divisible by the packed K tile width.
  - Replace per-intermediate-dimension traits with fixed-size two-tile and
    four-tile LDS rings driven by a runtime K loop.
  - Keep launch-sensitive settings compile-time, including:
    - block M/N;
    - block threads and minimum blocks per CU;
    - cache policies;
    - atomic versus route-output mode;
    - K pipeline schedule.
  - Keep the public kernel kids K-independent. Each kid now selects one fixed
    launch and pipeline policy, while effective K remains a runtime argument.
  - Validate that the selected kid's required sorting block size matches the
    runtime sorting configuration.

  The available K schedules are represented explicitly:

  - `TwoTileLdsRing`
  - `FourTileLdsRing`
  - `FourTileLdsRingWithShortKLoadOverlap`
  - `FourTileResidentWithTwoTileStreaming`

  ### Pipeline structure

  - Introduce `OpusMoeStage2A8W4DecodeTileOperations` to own:
    - A payload movement into the LDS ring;
    - A/B scale loading;
    - B payload loading;
    - per-tile MFMA accumulation.
  - Keep the K schedule orchestration in the Stage2 decode main header, with one
    clearly named function per schedule.
  - Introduce `OpusMoeStage2A8W4DecodeEpilogueOperations` to own:
    - weighted accumulator shuffle into LDS;
    - direct BF16 atomic output;
    - BF16 route output;
    - MXFP8 route output and scale storage.
  - Modernize the epilogue to use Opus primitives while retaining the plain
    buffer descriptor required to keep direct-atomic kernels scratch-free.
  - Remove the generic `OpusMoeStage2A8W4KPipeline<...>::run()` layer and the
    separate K-schedule/K-runner headers.

  ### Code generation and dispatch

  - Separate lightweight host dispatch from device kernel instantiation.
  - Generate independently compilable device translation units by functional
    kernel family:
    - one runtime-K A8W4 Stage2 shard;
    - two Stage1 pipeline-family shards;
    - four route-reduce shards;
    - one BF16 Stage2 shard.
  - Stop collecting intermediate dimensions from tuned CSVs for A8W4 Stage2
    code generation.
  - Remove the effective-K switch from host dispatch.
  - Generate only the manifests, metadata helpers, and explicit kernel
    instantiations required by runtime dispatch.
  - Keep kernel names, kids, sorting block sizes, output modes, and route-reduce
    configurations in the shared torch-free metadata.

  ### Stage1 clamp handling

  - Normalize the Stage1 activation clamp before entering C++:
    - SwiGLU retains the default clamp of `7.0`;
    - Silu and Situv2 use positive infinity when no clamp is configured.
  - Treat both `None` and `0.0` as an unspecified runtime clamp.
  - Keep the C++ host path responsible only for validating that the normalized
    limit is positive.

  ## Test Plan

  - Run Black over the full repository.
  - Run Ruff over all changed Python files.
  - Regenerate all Opus MoE manifests and device-instantiation shards.
  - Clean-build `module_moe_opus` for:
    - `gfx950`;
    - `gfx942;gfx950` with `PREBUILD_KERNELS=1`.
  - Verify that the multiarch module contains both gfx942 and gfx950 offload
    bundles.
  - Verify module import and the Stage2 decode/route-reduce exports.
  - Run an Opus-only A8W4 model-config performance sweep through
    `gemm_moe_tune.py`, covering:
    - K384 and K512 production configurations;
    - direct-atomic and route-output paths;
    - BF16 and MXFP8 route output;
    - SBM16/SBM32/SBM64/SBM128 sorting layouts;
    - representative small-, medium-, and large-token cases;
    - padded effective-K paths such as `512 - 128 -> 384`.
  - Compare generated gfx950 kernel resource usage and disassembly before and
    after the final structure-only refactor.

  ## Test Result

  - Black passes over the full repository.
  - Ruff passes for all changed Python files.
  - Clean single-gfx950 `module_moe_opus` build passes.
  - CI-equivalent `gfx942;gfx950` multiarch build passes.
  - The generated module contains both gfx942 and gfx950 offload bundles.
  - Module import and Stage2 decode/route-reduce symbol checks pass.
  - Opus-only tuned model-config regression shows no material performance
    regression for the retained K384/K512 production paths.
  - The final mainloop/epilogue structure refactor produces identical normalized
    gfx950 GPU disassembly to the pre-refactor implementation.
  - The runtime-K Stage2 device shard compiles in approximately 6 seconds in the
    current environment.
  - The complete single-gfx950 module clean build takes approximately 16 seconds.
  - The single-gfx950 module size is approximately 1.8 MiB, compared with
    approximately 3.2 MiB for the initial sharded fixed-K implementation.

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.