### PR TITLE
[fused_qk_norm_rope_cache_quant] remove in-C++ scratch allocation

### DIFF
--- a/aiter/ops/fused_qk_norm_rope_cache_quant.py
+++ b/aiter/ops/fused_qk_norm_rope_cache_quant.py
@@ -535,6 +535,8 @@ def _fused_qk_norm_rope_2way_fp8_perhead_quant_kernel(
     k_descale: Tensor,
     q_unquantized: Tensor,
     k_unquantized: Tensor,
+    q_partial_amax: Tensor,
+    k_partial_amax: Tensor,
 ) -> None: ...
 
 
@@ -606,6 +608,17 @@ def fused_qk_norm_rope_2way_fp8_perhead_quant(
         )
     )
 
+    # Per-warp amax scratch (written once per warp, no atomics) allocated here on
+    # the Python side (torch caching allocator) and passed into the kernel, so the
+    # C++ side never allocates device memory itself.
+    total_warps = total_tokens * (num_heads_q + num_heads_k)
+    q_partial_amax = torch.empty(
+        (batch_size, total_warps), dtype=torch.float32, device=q0.device
+    )
+    k_partial_amax = torch.empty(
+        (batch_size, total_warps), dtype=torch.float32, device=q0.device
+    )
+
     _fused_qk_norm_rope_2way_fp8_perhead_quant_kernel(
         q0,
         k0,
@@ -631,6 +644,8 @@ def fused_qk_norm_rope_2way_fp8_perhead_quant(
         k_descale,
         q_unquantized,
         k_unquantized,
+        q_partial_amax,
+        k_partial_amax,
     )
 
     if not want_bf16:
@@ -664,6 +679,8 @@ def _fused_qk_norm_rope_1way_fp8_perhead_quant_kernel(
     k_descale: Tensor,
     q_unquantized: Tensor,
     k_unquantized: Tensor,
+    q_partial_amax: Tensor,
+    k_partial_amax: Tensor,
 ) -> None: ...
 
 
@@ -722,6 +739,17 @@ def fused_qk_norm_rope_1way_fp8_perhead_quant(
         )
     )
 
+    # Per-warp amax scratch (written once per warp, no atomics) allocated here on
+    # the Python side (torch caching allocator) and passed into the kernel, so the
+    # C++ side never allocates device memory itself.
+    total_warps = num_tokens * (num_heads_q + num_heads_k)
+    q_partial_amax = torch.empty(
+        (batch_size, total_warps), dtype=torch.float32, device=q.device
+    )
+    k_partial_amax = torch.empty(
+        (batch_size, total_warps), dtype=torch.float32, device=q.device
+    )
+
     _fused_qk_norm_rope_1way_fp8_perhead_quant_kernel(
         q,
         k,
@@ -741,6 +769,8 @@ def fused_qk_norm_rope_1way_fp8_perhead_quant(
         k_descale,
         q_unquantized,
         k_unquantized,
+        q_partial_amax,
+        k_partial_amax,
     )
 
     if not want_bf16:
@@ -876,6 +906,7 @@ def _v_2way_per_head_fp8_quant_kernel(
     v1: Tensor,
     v_fp8: Tensor,
     v_descale: Tensor,
+    v_amax: Tensor,
 ) -> None: ...
 
 
@@ -894,7 +925,10 @@ def v_2way_per_head_fp8_quant(v0: Tensor, v1: Tensor) -> tuple[Tensor, Tensor]:
     v_descale = torch.empty(
         (batch_size, num_heads), dtype=torch.float32, device=v0.device
     )
-    _v_2way_per_head_fp8_quant_kernel(v0, v1, v_fp8, v_descale)
+    # v_amax is accumulated with atomic max in the kernel, so it must be
+    # zero-initialized. Allocated here (torch caching allocator) and passed in.
+    v_amax = torch.zeros((batch_size, num_heads), dtype=torch.float32, device=v0.device)
+    _v_2way_per_head_fp8_quant_kernel(v0, v1, v_fp8, v_descale, v_amax)
     return v_fp8, v_descale
 
 
@@ -907,6 +941,7 @@ def _v_1way_per_head_fp8_quant_kernel(
     v: Tensor,
     v_fp8: Tensor,
     v_descale: Tensor,
+    v_amax: Tensor,
 ) -> None: ...
 
 
@@ -925,5 +960,8 @@ def v_1way_per_head_fp8_quant(v: Tensor) -> tuple[Tensor, Tensor]:
     v_descale = torch.empty(
         (batch_size, num_heads), dtype=torch.float32, device=v.device
     )
-    _v_1way_per_head_fp8_quant_kernel(v, v_fp8, v_descale)
+    # v_amax is accumulated with atomic max in the kernel, so it must be
+    # zero-initialized. Allocated here (torch caching allocator) and passed in.
+    v_amax = torch.zeros((batch_size, num_heads), dtype=torch.float32, device=v.device)
+    _v_1way_per_head_fp8_quant_kernel(v, v_fp8, v_descale, v_amax)
     return v_fp8, v_descale

--- a/csrc/include/fused_qk_norm_rope_cache_quant.h
+++ b/csrc/include/fused_qk_norm_rope_cache_quant.h
@@ -109,7 +109,9 @@ void fused_qk_norm_rope_1way_fp8_perhead_quant(aiter_tensor_t& q,
                                                aiter_tensor_t& q_descale,
                                                aiter_tensor_t& k_descale,
                                                aiter_tensor_t& q_unquantized,
-                                               aiter_tensor_t& k_unquantized);
+                                               aiter_tensor_t& k_unquantized,
+                                               aiter_tensor_t& q_partial_amax,
+                                               aiter_tensor_t& k_partial_amax);
 
 // Same signature as the pertensor variant, but writes per-(batch, head) descales:
 //   q_descale shape [batch_size, num_heads_q]
@@ -138,19 +140,25 @@ void fused_qk_norm_rope_2way_fp8_perhead_quant(aiter_tensor_t& q0,
                                                aiter_tensor_t& q_descale,
                                                aiter_tensor_t& k_descale,
                                                aiter_tensor_t& q_unquantized,
-                                               aiter_tensor_t& k_unquantized);
+                                               aiter_tensor_t& k_unquantized,
+                                               aiter_tensor_t& q_partial_amax,
+                                               aiter_tensor_t& k_partial_amax);
 
 // Per-(batch, head) FP8 quant for concatenated [v0, v1] without a bf16 cat.
 // v0/v1: [B, T0/T1, H, D]; v_fp8: [B, T0+T1, H, D]; v_descale: [B, H].
+// v_amax: zero-initialized fp32 [B, H] scratch (accumulated via atomic_fmax_pos).
 void v_2way_per_head_fp8_quant(aiter_tensor_t& v0,
                                aiter_tensor_t& v1,
                                aiter_tensor_t& v_fp8,
-                               aiter_tensor_t& v_descale);
+                               aiter_tensor_t& v_descale,
+                               aiter_tensor_t& v_amax);
 
 // Per-(batch, head) FP8 quant for single-stream V [B, T, H, D].
+// v_amax: zero-initialized fp32 [B, H] scratch (accumulated via atomic_fmax_pos).
 void v_1way_per_head_fp8_quant(aiter_tensor_t& v,
                                aiter_tensor_t& v_fp8,
-                               aiter_tensor_t& v_descale);
+                               aiter_tensor_t& v_descale,
+                               aiter_tensor_t& v_amax);
 
 void fused_qk_rmsnorm(aiter_tensor_t& q,
                       aiter_tensor_t& q_weight,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2055,7 +2055,9 @@ namespace py = pybind11;
           py::arg("q_descale"),                                        \
           py::arg("k_descale"),                                        \
           py::arg("q_unquantized"),                                    \
-          py::arg("k_unquantized"));                                   \
+          py::arg("k_unquantized"),                                    \
+          py::arg("q_partial_amax"),                                   \
+          py::arg("k_partial_amax"));                                  \
     m.def("fused_qk_norm_rope_2way_fp8_perhead_quant",                 \
           &aiter::fused_qk_norm_rope_2way_fp8_perhead_quant,           \
           py::arg("q0"),                                               \
@@ -2081,18 +2083,22 @@ namespace py = pybind11;
           py::arg("q_descale"),                                        \
           py::arg("k_descale"),                                        \
           py::arg("q_unquantized"),                                    \
-          py::arg("k_unquantized"));                                   \
+          py::arg("k_unquantized"),                                    \
+          py::arg("q_partial_amax"),                                   \
+          py::arg("k_partial_amax"));                                  \
     m.def("v_2way_per_head_fp8_quant",                                 \
           &aiter::v_2way_per_head_fp8_quant,                           \
           py::arg("v0"),                                               \
           py::arg("v1"),                                               \
           py::arg("v_fp8"),                                            \
-          py::arg("v_descale"));                                       \
+          py::arg("v_descale"),                                        \
+          py::arg("v_amax"));                                          \
     m.def("v_1way_per_head_fp8_quant",                                 \
           &aiter::v_1way_per_head_fp8_quant,                           \
           py::arg("v"),                                                \
           py::arg("v_fp8"),                                            \
-          py::arg("v_descale"));
+          py::arg("v_descale"),                                        \
+          py::arg("v_amax"));
 
 #define INVERSE_ROPE_GROUP_QUANT_PYBIND                \
     m.def("inverse_rope_group_quant",                  \

--- a/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
+++ b/csrc/kernels/fused_qk_norm_rope_cache_quant.cu
@@ -3633,7 +3633,9 @@ void fused_qk_norm_rope_1way_fp8_perhead_quant(aiter_tensor_t& q,
                                                aiter_tensor_t& q_descale,
                                                aiter_tensor_t& k_descale,
                                                aiter_tensor_t& q_unquantized,
-                                               aiter_tensor_t& k_unquantized)
+                                               aiter_tensor_t& k_unquantized,
+                                               aiter_tensor_t& q_partial_amax,
+                                               aiter_tensor_t& k_partial_amax)
 {
     AITER_CHECK(q.is_contiguous() && k.is_contiguous());
     AITER_CHECK(w_q.is_contiguous() && w_k.is_contiguous());
@@ -3647,6 +3649,9 @@ void fused_qk_norm_rope_1way_fp8_perhead_quant(aiter_tensor_t& q,
     AITER_CHECK(q.dtype() == q_unquantized.dtype() && k.dtype() == k_unquantized.dtype());
     AITER_CHECK(q_fp8.dtype() == AITER_DTYPE_fp8 && k_fp8.dtype() == AITER_DTYPE_fp8);
     AITER_CHECK(q_descale.dtype() == AITER_DTYPE_fp32 && k_descale.dtype() == AITER_DTYPE_fp32);
+    AITER_CHECK(q_partial_amax.dtype() == AITER_DTYPE_fp32 &&
+                    k_partial_amax.dtype() == AITER_DTYPE_fp32,
+                "q/k_partial_amax scratch must be float32");
     AITER_CHECK(get_gpu_arch() == "gfx942",
                 "fused_qk_norm_rope_1way_fp8_perhead_quant is validated only on gfx942/MI308 "
                 "because this path uses fp8_e4m3fnuz with fp8_max=240");
@@ -3675,11 +3680,6 @@ void fused_qk_norm_rope_1way_fp8_perhead_quant(aiter_tensor_t& q,
     const int num_warps_per_block = block_size / warp_size;
     dim3 threadsPerBlock(block_size);
     dim3 numBlocks((total_warps + num_warps_per_block - 1) / num_warps_per_block, batch_size);
-
-    AiterTensor q_partial_amax =
-        AiterTensor::empty({batch_size, total_warps}, AITER_DTYPE_fp32, q.device_id, stream);
-    AiterTensor k_partial_amax =
-        AiterTensor::empty({batch_size, total_warps}, AITER_DTYPE_fp32, q.device_id, stream);
 
     AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
         q.dtype(), "fused_qk_norm_rope_1way_fp8_perhead_amax", [&] {
@@ -3847,7 +3847,9 @@ void fused_qk_norm_rope_2way_fp8_perhead_quant(aiter_tensor_t& q0,
                                                aiter_tensor_t& q_descale,
                                                aiter_tensor_t& k_descale,
                                                aiter_tensor_t& q_unquantized,
-                                               aiter_tensor_t& k_unquantized)
+                                               aiter_tensor_t& k_unquantized,
+                                               aiter_tensor_t& q_partial_amax,
+                                               aiter_tensor_t& k_partial_amax)
 {
     AITER_CHECK(q0.is_contiguous() && k0.is_contiguous() && q1.is_contiguous() &&
                 k1.is_contiguous());
@@ -3863,6 +3865,9 @@ void fused_qk_norm_rope_2way_fp8_perhead_quant(aiter_tensor_t& q0,
     AITER_CHECK(q0.dtype() == q_unquantized.dtype() && k0.dtype() == k_unquantized.dtype());
     AITER_CHECK(q_fp8.dtype() == AITER_DTYPE_fp8 && k_fp8.dtype() == AITER_DTYPE_fp8);
     AITER_CHECK(q_descale.dtype() == AITER_DTYPE_fp32 && k_descale.dtype() == AITER_DTYPE_fp32);
+    AITER_CHECK(q_partial_amax.dtype() == AITER_DTYPE_fp32 &&
+                    k_partial_amax.dtype() == AITER_DTYPE_fp32,
+                "q/k_partial_amax scratch must be float32");
 
     HipDeviceGuard device_guard(q0.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
@@ -3871,11 +3876,6 @@ void fused_qk_norm_rope_2way_fp8_perhead_quant(aiter_tensor_t& q0,
     constexpr int block_size = 256;
     constexpr int warp_size  = 32;
     int num_warps_per_block  = block_size / warp_size;
-
-    AiterTensor q_partial_amax =
-        AiterTensor::empty({batch_size, total_warps}, AITER_DTYPE_fp32, q0.device_id, stream);
-    AiterTensor k_partial_amax =
-        AiterTensor::empty({batch_size, total_warps}, AITER_DTYPE_fp32, q0.device_id, stream);
 
     dim3 threadsPerBlock(block_size);
     dim3 numBlocks((total_warps + num_warps_per_block - 1) / num_warps_per_block, batch_size);
@@ -4091,7 +4091,8 @@ __global__ void __launch_bounds__(256) v_2way_per_head_quant_tiled_kernel(
 void v_2way_per_head_fp8_quant(aiter_tensor_t& v0,
                                aiter_tensor_t& v1,
                                aiter_tensor_t& v_fp8,
-                               aiter_tensor_t& v_descale)
+                               aiter_tensor_t& v_descale,
+                               aiter_tensor_t& v_amax)
 {
     AITER_CHECK(v0.is_contiguous() && v1.is_contiguous());
     AITER_CHECK(v_fp8.is_contiguous() && v_descale.is_contiguous());
@@ -4109,12 +4110,12 @@ void v_2way_per_head_fp8_quant(aiter_tensor_t& v0,
     AITER_CHECK(v0.dtype() == v1.dtype(), "v0/v1 dtype must match");
     AITER_CHECK(v_fp8.dtype() == AITER_DTYPE_fp8, "v_fp8 must be fp8");
     AITER_CHECK(v_descale.dtype() == AITER_DTYPE_fp32, "v_descale must be fp32");
+    // v_amax is accumulated with atomic_fmax_pos, so the caller must pass a
+    // zero-initialized fp32 [batch_size, num_heads] scratch buffer.
+    AITER_CHECK(v_amax.dtype() == AITER_DTYPE_fp32, "v_amax scratch must be float32");
 
     HipDeviceGuard device_guard(v0.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
-
-    AiterTensor v_amax =
-        AiterTensor::empty({batch_size, num_heads}, AITER_DTYPE_fp32, v0.device_id, stream);
 
     constexpr int TILE_T    = 128;
     constexpr int HEAD_SIZE = 128;
@@ -4224,7 +4225,8 @@ __global__ void __launch_bounds__(256) v_1way_per_head_quant_tiled_kernel(
 
 void v_1way_per_head_fp8_quant(aiter_tensor_t& v,
                                aiter_tensor_t& v_fp8,
-                               aiter_tensor_t& v_descale)
+                               aiter_tensor_t& v_descale,
+                               aiter_tensor_t& v_amax)
 {
     AITER_CHECK(v.is_contiguous() && v_fp8.is_contiguous() && v_descale.is_contiguous());
     AITER_CHECK(v.ndim == 4, "v must be 4D [B, T, H, D]");
@@ -4238,12 +4240,12 @@ void v_1way_per_head_fp8_quant(aiter_tensor_t& v,
     AITER_CHECK(get_gpu_arch() == "gfx942",
                 "v_1way_per_head_fp8_quant is validated only on gfx942/MI308 because this path "
                 "uses fp8_e4m3fnuz with fp8_max=240");
+    // v_amax is accumulated with atomic_fmax_pos, so the caller must pass a
+    // zero-initialized fp32 [batch_size, num_heads] scratch buffer.
+    AITER_CHECK(v_amax.dtype() == AITER_DTYPE_fp32, "v_amax scratch must be float32");
 
     HipDeviceGuard device_guard(v.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
-
-    AiterTensor v_amax =
-        AiterTensor::zeros({batch_size, num_heads}, AITER_DTYPE_fp32, v.device_id, stream);
 
     constexpr int TILE_T    = 128;
     constexpr int HEAD_SIZE = 128;


### PR DESCRIPTION
## What

Remove all in-C++ device scratch allocations (`AiterTensor::empty` / `AiterTensor::zeros`) from `fused_qk_norm_rope_cache_quant.cu`. The scratch buffers are now allocated on the Python side via torch's caching allocator and passed into the kernels as trailing tensor params, so the C++ side never self-allocates device memory.

This is the same principle already applied to the topk module in #4702: **produce the workspace outside (Python, torch-cached) and pass the pointer in; the C++ side only `AITER_CHECK`s the caller-provided buffer.**

## Why

`AiterTensor::empty`/`zeros` go through `hipMallocAsync`/`hipMalloc` with **no block reuse**, unlike `torch.empty`/`torch.zeros` which reuse freed blocks from torch's caching allocator. A per-call malloc for these intermediate buffers is a regression; moving the allocation to Python eliminates it.

## Changes

Six scratch sites across four entry functions, in four files each (`.cu` kernel / `.h` decl / `rocm_ops.hpp` pybind / ops `.py` wrapper):

| Function | Scratch | Python alloc |
|----------|---------|--------------|
| `fused_qk_norm_rope_1way_fp8_perhead_quant` | `q_partial_amax`, `k_partial_amax` `{B, num_tokens*(Hq+Hk)}` | `torch.empty` (each warp writes its own slot, no atomics) |
| `fused_qk_norm_rope_2way_fp8_perhead_quant` | same, `{B, (T0+T1)*(Hq+Hk)}` | `torch.empty` |
| `v_2way_per_head_fp8_quant` | `v_amax` `{B, H}` | `torch.zeros` (accumulated via `atomic_fmax_pos`) |
| `v_1way_per_head_fp8_quant` | `v_amax` `{B, H}` | `torch.zeros` (accumulated via `atomic_fmax_pos`) |

Scratch sizes are kept exactly as the original C++ code computed them (closed-form from the explicit params; no pow2 rounding).

Also fixes a latent bug: `v_2way_per_head_fp8_quant`'s `v_amax` was allocated with `AiterTensor::empty`, but the kernel accumulates it via `atomic_fmax_pos`, which requires zero-initialization — now `torch.zeros`.

## Test

`op_tests/test_fused_qk_norm_rope_1way_perhead.py` and `op_tests/test_fused_qk_norm_rope_2way_perhead.py` both pass on gfx942 (exit 0), covering all four paths (1way qk, 2way qk, v_1way, v_2way) — q/k/v dequant, descale, and bf16-baseline checks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
