### PR TITLE
[fix] add missing <optional> header in topk_plain_kernels.cu

### DIFF
--- a/csrc/kernels/topk_plain_kernels.cu
+++ b/csrc/kernels/topk_plain_kernels.cu
@@ -33,9 +33,8 @@
 
 #include <hip/hip_runtime.h>
 
-#include <optional>
+#include "topk_plain.h"
 
-#include "aiter_tensor.h"
 #include "aiter_stream.h"
 #include "aiter_dispatch.h"
 #include "opus/opus.hpp"

--- a/csrc/kernels/topk_plain_kernels.cu
+++ b/csrc/kernels/topk_plain_kernels.cu
@@ -33,6 +33,8 @@
 
 #include <hip/hip_runtime.h>
 
+#include <optional>
+
 #include "aiter_tensor.h"
 #include "aiter_stream.h"
 #include "aiter_dispatch.h"


### PR DESCRIPTION
## Problem

`csrc/kernels/topk_plain_kernels.cu` uses `std::optional<aiter_tensor_t>` in the `topk` entry point (lines 2532-2536) but does not include `<optional>`.

Since #4702 removed the torch dependency from `module_topk_*`, the header is no longer pulled in transitively, so the translation unit relies on an incidental include from another header. That is fragile and breaks compilation on toolchains/libstdc++ versions where nothing else drags `<optional>` in.

## Fix

Include `<optional>` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)