### PR TITLE
Replace block_ptr in HSTU attn kernel

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -23,7 +23,6 @@ import triton.language as tl
 
 from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
-from aiter.ops.triton.utils._triton.pid_preprocessing import remap_xcd
 from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH, load_config_json
 
 try:

--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -178,7 +178,6 @@ def _hstu_attn_fwd_compute(
 
         # initialize offsets
         offs_m = start_m + tl.arange(0, BLOCK_M)
-        offs_n = tl.arange(0, BLOCK_N)
         offs_d_q = tl.arange(0, BLOCK_D_Q)
         K_base = K + off_h * stride_kh + seq_start * stride_kn
         V_base = V + off_h * stride_vh + seq_start * stride_vn
@@ -341,7 +340,6 @@ def _hstu_attn_fwd(
     stride_om,
     stride_oh,
     alpha,
-    # Z,
     H,
     MAX_SEQ_LEN,
     DeltaSize,

--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -48,9 +48,9 @@ def _hstu_attn_fwd_one_block(
     start_n,
     seq_len,
     offs_m,
-    offs_n,
-    mask_m,
-    mask_n,
+    # offs_n,
+    # mask_m,
+    # mask_n,
     q,
     K_base,
     V_base,
@@ -71,7 +71,8 @@ def _hstu_attn_fwd_one_block(
     BLOCK_D_V: tl.constexpr,
 ):
     start_n = tl.multiple_of(start_n, BLOCK_N)
-    
+    offs_n = tl.arange(0, BLOCK_N) + start_n
+    mask_n = offs_n < seq_len
     # -- compute qk ----
     offs_d_q = tl.arange(0, BLOCK_D_Q)
     offs_d_v = tl.arange(0, BLOCK_D_V)
@@ -163,14 +164,14 @@ def _hstu_attn_fwd_compute(
     HAS_MAX_ATTN_LEN: tl.constexpr,
 ):
     # add assumption to use buffer load and store
-    tl.assume(stride_qm > 0)
-    tl.assume(stride_qh > 0)
-    tl.assume(stride_kn > 0)
-    tl.assume(stride_kh > 0)
-    tl.assume(stride_vn > 0)
-    tl.assume(stride_vh > 0)
-    tl.assume(stride_om > 0)
-    tl.assume(stride_oh > 0)
+    # tl.assume(stride_qm > 0)
+    # tl.assume(stride_qh > 0)
+    # tl.assume(stride_kn > 0)
+    # tl.assume(stride_kh > 0)
+    # tl.assume(stride_vn > 0)
+    # tl.assume(stride_vh > 0)
+    # tl.assume(stride_om > 0)
+    # tl.assume(stride_oh > 0)
     
     seq_start = tl.load(seq_offsets + off_z).to(tl.int64)
     off_h = off_h.to(tl.int64)
@@ -276,15 +277,15 @@ def _hstu_attn_fwd_compute(
         #     V_block_ptr = tl.advance(V_block_ptr, (low, 0))
         # end_n = low
         for start_n in range(low, high, BLOCK_N):
-            cur_offs_n = offs_n + start_n
-            mask_n = cur_offs_n < seq_len
+            # cur_offs_n = offs_n + start_n
+            # mask_n = cur_offs_n < seq_len
             acc += _hstu_attn_fwd_one_block(
                 start_n=start_n,
                 seq_len=seq_len,
                 offs_m=offs_m,
-                offs_n=cur_offs_n,
-                mask_m=mask_m,
-                mask_n=mask_n,
+                # offs_n=cur_offs_n,
+                # mask_m=mask_m,
+                # mask_n=mask_n,
                 q=q,
                 K_base=K_base,
                 V_base=V_base,
@@ -320,15 +321,15 @@ def _hstu_attn_fwd_compute(
                 for start_delta in tl.range(
                     low_delta, high_delta, BLOCK_N, num_stages=0
                 ):
-                    cur_offs_n = offs_n + start_delta
-                    mask_n = cur_offs_n < seq_len
+                    # cur_offs_n = offs_n + start_delta
+                    # mask_n = cur_offs_n < seq_len
                     acc += _hstu_attn_fwd_one_block(
                         start_n=start_delta,
                         seq_len=seq_len,
                         offs_m=offs_m,
-                        offs_n=cur_offs_n,
-                        mask_m=mask_m,
-                        mask_n=mask_n,
+                        # offs_n=cur_offs_n,
+                        # mask_m=mask_m,
+                        # mask_n=mask_n,
                         q=q,
                         K_base=K_base,
                         V_base=V_base,
@@ -402,7 +403,7 @@ def _hstu_attn_fwd(
     stride_om,
     stride_oh,
     alpha,
-    Z,
+    # Z,
     H,
     MAX_SEQ_LEN,
     DeltaSize,
@@ -420,19 +421,27 @@ def _hstu_attn_fwd(
     HAS_MAX_ATTN_LEN: tl.constexpr,
     HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
 ):
-    tpid = tl.program_id(0)
+    # tpid = tl.program_id(0)
 
-    num_tiles = tl.cdiv(MAX_SEQ_LEN, BLOCK_M)
-    tpid = remap_xcd(tpid, num_tiles * Z * H, 8)
+    # num_tiles = tl.cdiv(MAX_SEQ_LEN, BLOCK_M)
+    # tpid = remap_xcd(tpid, num_tiles * Z * H, 8)
 
-    off_h = tpid % H
-    off_nz = tpid // H
-    pid = off_nz % num_tiles
-    off_z = off_nz // num_tiles
+    # off_h = tpid % H
+    # off_nz = tpid // H
+    # pid = off_nz % num_tiles
+    # off_z = off_nz // num_tiles
 
+    # if HAS_SORT_BY_LENGTH_INDICES:
+    #     off_z = tl.load(sort_by_length_indices + off_z)
+
+
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
     if HAS_SORT_BY_LENGTH_INDICES:
         off_z = tl.load(sort_by_length_indices + off_z)
-
+    off_h = off_hz % H
+    pid = tl.program_id(0)
+            
     _hstu_attn_fwd_compute(
         Q=Q,
         K=K,

--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -48,9 +48,6 @@ def _hstu_attn_fwd_one_block(
     start_n,
     seq_len,
     offs_m,
-    # offs_n,
-    # mask_m,
-    # mask_n,
     q,
     K_base,
     V_base,
@@ -163,16 +160,6 @@ def _hstu_attn_fwd_compute(
     HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
     HAS_MAX_ATTN_LEN: tl.constexpr,
 ):
-    # add assumption to use buffer load and store
-    # tl.assume(stride_qm > 0)
-    # tl.assume(stride_qh > 0)
-    # tl.assume(stride_kn > 0)
-    # tl.assume(stride_kh > 0)
-    # tl.assume(stride_vn > 0)
-    # tl.assume(stride_vh > 0)
-    # tl.assume(stride_om > 0)
-    # tl.assume(stride_oh > 0)
-    
     seq_start = tl.load(seq_offsets + off_z).to(tl.int64)
     off_h = off_h.to(tl.int64)
     off_z = off_z.to(tl.int64)
@@ -206,42 +193,6 @@ def _hstu_attn_fwd_compute(
             q_ptrs = Q_base + offs_m[:, None] * stride_qm + offs_d_q[None, :]
             q = tl.load(q_ptrs, mask=mask_m[:, None], other=0.0)
 
-        # if IS_DELTA_Q:
-        #     Q_block_ptr = tl.make_block_ptr(
-        #         base=Q + off_h * stride_qh + off_z * DeltaSize * stride_qm,
-        #         shape=(DeltaSize, BLOCK_D_Q),
-        #         strides=(stride_qm, 1),
-        #         offsets=(start_m_delta, 0),
-        #         block_shape=(BLOCK_M, BLOCK_D_Q),
-        #         order=(1, 0),
-        #     )
-        # else:
-        #     Q_block_ptr = tl.make_block_ptr(
-        #         base=Q + off_h * stride_qh + seq_start * stride_qm,
-        #         shape=(seq_len, BLOCK_D_Q),
-        #         strides=(stride_qm, 1),
-        #         offsets=(start_m, 0),
-        #         block_shape=(BLOCK_M, BLOCK_D_Q),
-        #         order=(1, 0),
-        #     )
-        # K_block_ptr = tl.make_block_ptr(
-        #     base=K + off_h * stride_kh + seq_start * stride_kn,
-        #     shape=(BLOCK_D_Q, seq_len),
-        #     strides=(1, stride_kn),
-        #     offsets=(0, 0),
-        #     block_shape=(BLOCK_D_Q, BLOCK_N),
-        #     order=(0, 1),
-        # )
-        # V_block_ptr = tl.make_block_ptr(
-        #     base=V + off_h * stride_vh + seq_start * stride_vn,
-        #     shape=(seq_len, BLOCK_D_V),
-        #     strides=(stride_vn, 1),
-        #     offsets=(0, 0),
-        #     block_shape=(BLOCK_N, BLOCK_D_V),
-        #     order=(1, 0),
-        # )
-
-        # q = tl.load(Q_block_ptr, boundary_check=(0,), padding_option="zero")
         acc = tl.zeros([BLOCK_M, BLOCK_D_V], dtype=tl.float32)
         if CAUSAL:
             if HAS_MULTIPLE_TARGETS:
@@ -272,20 +223,11 @@ def _hstu_attn_fwd_compute(
             low = 0
             high = seq_len
 
-        # if low > 0:
-        #     K_block_ptr = tl.advance(K_block_ptr, (0, low))
-        #     V_block_ptr = tl.advance(V_block_ptr, (low, 0))
-        # end_n = low
         for start_n in range(low, high, BLOCK_N):
-            # cur_offs_n = offs_n + start_n
-            # mask_n = cur_offs_n < seq_len
             acc += _hstu_attn_fwd_one_block(
                 start_n=start_n,
                 seq_len=seq_len,
                 offs_m=offs_m,
-                # offs_n=cur_offs_n,
-                # mask_m=mask_m,
-                # mask_n=mask_n,
                 q=q,
                 K_base=K_base,
                 V_base=V_base,
@@ -305,9 +247,6 @@ def _hstu_attn_fwd_compute(
                 BLOCK_D_Q=BLOCK_D_Q,
                 BLOCK_D_V=BLOCK_D_V,
             )
-            # K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-            # V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            # end_n += BLOCK_N
 
         # Not merged: the `# pyre-ignore[61]` between the two ifs applies to the inner one; merging would silently drop that suppression.
         if HAS_MULTIPLE_TARGETS and CAUSAL:  # noqa: SIM102
@@ -315,21 +254,13 @@ def _hstu_attn_fwd_compute(
             if uih_end < start_m:
                 low_delta = start_m
                 high_delta = start_m + BLOCK_M
-                # offset = (low_delta - end_n).to(tl.int32)
-                # K_block_ptr = tl.advance(K_block_ptr, (0, offset))
-                # V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
                 for start_delta in tl.range(
                     low_delta, high_delta, BLOCK_N, num_stages=0
                 ):
-                    # cur_offs_n = offs_n + start_delta
-                    # mask_n = cur_offs_n < seq_len
                     acc += _hstu_attn_fwd_one_block(
                         start_n=start_delta,
                         seq_len=seq_len,
                         offs_m=offs_m,
-                        # offs_n=cur_offs_n,
-                        # mask_m=mask_m,
-                        # mask_n=mask_n,
                         q=q,
                         K_base=K_base,
                         V_base=V_base,
@@ -421,20 +352,6 @@ def _hstu_attn_fwd(
     HAS_MAX_ATTN_LEN: tl.constexpr,
     HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
 ):
-    # tpid = tl.program_id(0)
-
-    # num_tiles = tl.cdiv(MAX_SEQ_LEN, BLOCK_M)
-    # tpid = remap_xcd(tpid, num_tiles * Z * H, 8)
-
-    # off_h = tpid % H
-    # off_nz = tpid // H
-    # pid = off_nz % num_tiles
-    # off_z = off_nz // num_tiles
-
-    # if HAS_SORT_BY_LENGTH_INDICES:
-    #     off_z = tl.load(sort_by_length_indices + off_z)
-
-
     off_hz = tl.program_id(1)
     off_z = off_hz // H
     if HAS_SORT_BY_LENGTH_INDICES:

--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -23,6 +23,7 @@ import triton.language as tl
 
 from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+from aiter.ops.triton.utils._triton.pid_preprocessing import remap_xcd
 from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH, load_config_json
 
 try:
@@ -48,9 +49,13 @@ def _hstu_attn_fwd_one_block(
     seq_len,
     offs_m,
     offs_n,
+    mask_m,
+    mask_n,
     q,
-    K_block_ptr,
-    V_block_ptr,
+    K_base,
+    V_base,
+    stride_kn,
+    stride_vn,
     n_targets,
     alpha,
     MAX_SEQ_LEN,
@@ -62,10 +67,19 @@ def _hstu_attn_fwd_one_block(
     HAS_MAX_ATTN_LEN: tl.constexpr,
     ALLOW_TF32: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
 ):
     start_n = tl.multiple_of(start_n, BLOCK_N)
+    
     # -- compute qk ----
-    k = tl.load(K_block_ptr, boundary_check=(1,), padding_option="zero")
+    offs_d_q = tl.arange(0, BLOCK_D_Q)
+    offs_d_v = tl.arange(0, BLOCK_D_V)
+    k_ptrs = K_base + offs_d_q[:, None] + offs_n[None, :] * stride_kn
+    v_ptrs = V_base + offs_n[:, None] * stride_vn + offs_d_v[None, :]
+    
+    # -- compute qk ----
+    k = tl.load(k_ptrs, mask=mask_n[None, :], other=0.0)
     qk = tl.dot(q, k, allow_tf32=ALLOW_TF32) * alpha
     invalid_mask = offs_m[:, None] == offs_n[None, :]
     max_ids = seq_len
@@ -108,7 +122,7 @@ def _hstu_attn_fwd_one_block(
     # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
     silu = fast_dividef(qk, 1.0 + fast_expf(-qk)) * (1.0 / MAX_SEQ_LEN)
     silu = tl.where(invalid_mask, silu, 0)
-    v = tl.load(V_block_ptr, boundary_check=(0,), padding_option="zero")
+    v = tl.load(v_ptrs, mask=mask_n[:, None], other=0.0)
     silu = silu.to(v.dtype)
     return tl.dot(silu, v, allow_tf32=ALLOW_TF32)
 
@@ -148,6 +162,16 @@ def _hstu_attn_fwd_compute(
     HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
     HAS_MAX_ATTN_LEN: tl.constexpr,
 ):
+    # add assumption to use buffer load and store
+    tl.assume(stride_qm > 0)
+    tl.assume(stride_qh > 0)
+    tl.assume(stride_kn > 0)
+    tl.assume(stride_kh > 0)
+    tl.assume(stride_vn > 0)
+    tl.assume(stride_vh > 0)
+    tl.assume(stride_om > 0)
+    tl.assume(stride_oh > 0)
+    
     seq_start = tl.load(seq_offsets + off_z).to(tl.int64)
     off_h = off_h.to(tl.int64)
     off_z = off_z.to(tl.int64)
@@ -168,42 +192,55 @@ def _hstu_attn_fwd_compute(
         # initialize offsets
         offs_m = start_m + tl.arange(0, BLOCK_M)
         offs_n = tl.arange(0, BLOCK_N)
+        offs_d_q = tl.arange(0, BLOCK_D_Q)
+        K_base=K + off_h * stride_kh + seq_start * stride_kn,
+        V_base=V + off_h * stride_vh + seq_start * stride_vn,
+        mask_m = offs_m < seq_len
         if IS_DELTA_Q:
-            Q_block_ptr = tl.make_block_ptr(
-                base=Q + off_h * stride_qh + off_z * DeltaSize * stride_qm,
-                shape=(DeltaSize, BLOCK_D_Q),
-                strides=(stride_qm, 1),
-                offsets=(start_m_delta, 0),
-                block_shape=(BLOCK_M, BLOCK_D_Q),
-                order=(1, 0),
-            )
+            Q_base = Q + off_h * stride_qh + off_z * DeltaSize * stride_qm
+            q_ptrs = Q_base + (start_m_delta + tl.arange(0, BLOCK_M))[:, None] * stride_qm + offs_d_q[None, :]
+            q = tl.load(q_ptrs, mask=((start_m_delta + tl.arange(0, BLOCK_M)) < DeltaSize)[:, None], other=0.0)
         else:
-            Q_block_ptr = tl.make_block_ptr(
-                base=Q + off_h * stride_qh + seq_start * stride_qm,
-                shape=(seq_len, BLOCK_D_Q),
-                strides=(stride_qm, 1),
-                offsets=(start_m, 0),
-                block_shape=(BLOCK_M, BLOCK_D_Q),
-                order=(1, 0),
-            )
-        K_block_ptr = tl.make_block_ptr(
-            base=K + off_h * stride_kh + seq_start * stride_kn,
-            shape=(BLOCK_D_Q, seq_len),
-            strides=(1, stride_kn),
-            offsets=(0, 0),
-            block_shape=(BLOCK_D_Q, BLOCK_N),
-            order=(0, 1),
-        )
-        V_block_ptr = tl.make_block_ptr(
-            base=V + off_h * stride_vh + seq_start * stride_vn,
-            shape=(seq_len, BLOCK_D_V),
-            strides=(stride_vn, 1),
-            offsets=(0, 0),
-            block_shape=(BLOCK_N, BLOCK_D_V),
-            order=(1, 0),
-        )
+            Q_base = Q + off_h * stride_qh + seq_start * stride_qm
+            q_ptrs = Q_base + offs_m[:, None] * stride_qm + offs_d_q[None, :]
+            q = tl.load(q_ptrs, mask=mask_m[:, None], other=0.0)
 
-        q = tl.load(Q_block_ptr, boundary_check=(0,), padding_option="zero")
+        # if IS_DELTA_Q:
+        #     Q_block_ptr = tl.make_block_ptr(
+        #         base=Q + off_h * stride_qh + off_z * DeltaSize * stride_qm,
+        #         shape=(DeltaSize, BLOCK_D_Q),
+        #         strides=(stride_qm, 1),
+        #         offsets=(start_m_delta, 0),
+        #         block_shape=(BLOCK_M, BLOCK_D_Q),
+        #         order=(1, 0),
+        #     )
+        # else:
+        #     Q_block_ptr = tl.make_block_ptr(
+        #         base=Q + off_h * stride_qh + seq_start * stride_qm,
+        #         shape=(seq_len, BLOCK_D_Q),
+        #         strides=(stride_qm, 1),
+        #         offsets=(start_m, 0),
+        #         block_shape=(BLOCK_M, BLOCK_D_Q),
+        #         order=(1, 0),
+        #     )
+        # K_block_ptr = tl.make_block_ptr(
+        #     base=K + off_h * stride_kh + seq_start * stride_kn,
+        #     shape=(BLOCK_D_Q, seq_len),
+        #     strides=(1, stride_kn),
+        #     offsets=(0, 0),
+        #     block_shape=(BLOCK_D_Q, BLOCK_N),
+        #     order=(0, 1),
+        # )
+        # V_block_ptr = tl.make_block_ptr(
+        #     base=V + off_h * stride_vh + seq_start * stride_vn,
+        #     shape=(seq_len, BLOCK_D_V),
+        #     strides=(stride_vn, 1),
+        #     offsets=(0, 0),
+        #     block_shape=(BLOCK_N, BLOCK_D_V),
+        #     order=(1, 0),
+        # )
+
+        # q = tl.load(Q_block_ptr, boundary_check=(0,), padding_option="zero")
         acc = tl.zeros([BLOCK_M, BLOCK_D_V], dtype=tl.float32)
         if CAUSAL:
             if HAS_MULTIPLE_TARGETS:
@@ -234,19 +271,25 @@ def _hstu_attn_fwd_compute(
             low = 0
             high = seq_len
 
-        if low > 0:
-            K_block_ptr = tl.advance(K_block_ptr, (0, low))
-            V_block_ptr = tl.advance(V_block_ptr, (low, 0))
-        end_n = low
+        # if low > 0:
+        #     K_block_ptr = tl.advance(K_block_ptr, (0, low))
+        #     V_block_ptr = tl.advance(V_block_ptr, (low, 0))
+        # end_n = low
         for start_n in range(low, high, BLOCK_N):
+            cur_offs_n = offs_n + start_n
+            mask_n = cur_offs_n < seq_len
             acc += _hstu_attn_fwd_one_block(
                 start_n=start_n,
                 seq_len=seq_len,
                 offs_m=offs_m,
-                offs_n=offs_n + start_n,
+                offs_n=cur_offs_n,
+                mask_m=mask_m,
+                mask_n=mask_n,
                 q=q,
-                K_block_ptr=K_block_ptr,
-                V_block_ptr=V_block_ptr,
+                K_base=K_base,
+                V_base=V_base,
+                stride_kn=stride_kn,
+                stride_vn=stride_vn,
                 n_targets=n_targets if HAS_MULTIPLE_TARGETS else None,
                 alpha=alpha,
                 MAX_SEQ_LEN=MAX_SEQ_LEN,
@@ -258,10 +301,12 @@ def _hstu_attn_fwd_compute(
                 HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
                 ALLOW_TF32=ALLOW_TF32,
                 BLOCK_N=BLOCK_N,
+                BLOCK_D_Q=BLOCK_D_Q,
+                BLOCK_D_V=BLOCK_D_V,
             )
             K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
             V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            end_n += BLOCK_N
+            # end_n += BLOCK_N
 
         # Not merged: the `# pyre-ignore[61]` between the two ifs applies to the inner one; merging would silently drop that suppression.
         if HAS_MULTIPLE_TARGETS and CAUSAL:  # noqa: SIM102
@@ -269,20 +314,26 @@ def _hstu_attn_fwd_compute(
             if uih_end < start_m:
                 low_delta = start_m
                 high_delta = start_m + BLOCK_M
-                offset = (low_delta - end_n).to(tl.int32)
-                K_block_ptr = tl.advance(K_block_ptr, (0, offset))
-                V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
+                # offset = (low_delta - end_n).to(tl.int32)
+                # K_block_ptr = tl.advance(K_block_ptr, (0, offset))
+                # V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
                 for start_delta in tl.range(
                     low_delta, high_delta, BLOCK_N, num_stages=0
                 ):
+                    cur_offs_n = offs_n + start_delta
+                    mask_n = cur_offs_n < seq_len
                     acc += _hstu_attn_fwd_one_block(
                         start_n=start_delta,
                         seq_len=seq_len,
                         offs_m=offs_m,
-                        offs_n=offs_n + start_delta,
+                        offs_n=cur_offs_n,
+                        mask_m=mask_m,
+                        mask_n=mask_n,
                         q=q,
-                        K_block_ptr=K_block_ptr,
-                        V_block_ptr=V_block_ptr,
+                        K_base=K_base,
+                        V_base=V_base,
+                        stride_kn=stride_kn,
+                        stride_vn=stride_vn,
                         n_targets=n_targets if HAS_MULTIPLE_TARGETS else None,
                         alpha=alpha,
                         MAX_SEQ_LEN=MAX_SEQ_LEN,
@@ -294,9 +345,9 @@ def _hstu_attn_fwd_compute(
                         HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
                         ALLOW_TF32=ALLOW_TF32,
                         BLOCK_N=BLOCK_N,
+                        BLOCK_D_Q=BLOCK_D_Q,
+                        BLOCK_D_V=BLOCK_D_V,
                     )
-                    K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-                    V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
 
         if IS_DELTA_Q:
             start_m_delta = pid * BLOCK_M
@@ -351,6 +402,7 @@ def _hstu_attn_fwd(
     stride_om,
     stride_oh,
     alpha,
+    Z,
     H,
     MAX_SEQ_LEN,
     DeltaSize,
@@ -368,12 +420,19 @@ def _hstu_attn_fwd(
     HAS_MAX_ATTN_LEN: tl.constexpr,
     HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
 ):
-    off_hz = tl.program_id(1)
-    off_z = off_hz // H
+    tpid = tl.program_id(0)
+
+    num_tiles = tl.cdiv(MAX_SEQ_LEN, BLOCK_M)
+    tpid = remap_xcd(tpid, num_tiles * Z * H, 8)
+
+    off_h = tpid % H
+    off_nz = tpid // H
+    pid = off_nz % num_tiles
+    off_z = off_nz // num_tiles
+
     if HAS_SORT_BY_LENGTH_INDICES:
         off_z = tl.load(sort_by_length_indices + off_z)
-    off_h = off_hz % H
-    pid = tl.program_id(0)
+
     _hstu_attn_fwd_compute(
         Q=Q,
         K=K,

--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -193,8 +193,8 @@ def _hstu_attn_fwd_compute(
         offs_m = start_m + tl.arange(0, BLOCK_M)
         offs_n = tl.arange(0, BLOCK_N)
         offs_d_q = tl.arange(0, BLOCK_D_Q)
-        K_base=K + off_h * stride_kh + seq_start * stride_kn,
-        V_base=V + off_h * stride_vh + seq_start * stride_vn,
+        K_base=K + off_h * stride_kh + seq_start * stride_kn
+        V_base=V + off_h * stride_vh + seq_start * stride_vn
         mask_m = offs_m < seq_len
         if IS_DELTA_Q:
             Q_base = Q + off_h * stride_qh + off_z * DeltaSize * stride_qm
@@ -304,8 +304,8 @@ def _hstu_attn_fwd_compute(
                 BLOCK_D_Q=BLOCK_D_Q,
                 BLOCK_D_V=BLOCK_D_V,
             )
-            K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-            V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+            # K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+            # V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
             # end_n += BLOCK_N
 
         # Not merged: the `# pyre-ignore[61]` between the two ifs applies to the inner one; merging would silently drop that suppression.

--- a/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/hstu_attention.py
@@ -74,7 +74,7 @@ def _hstu_attn_fwd_one_block(
     offs_d_v = tl.arange(0, BLOCK_D_V)
     k_ptrs = K_base + offs_d_q[:, None] + offs_n[None, :] * stride_kn
     v_ptrs = V_base + offs_n[:, None] * stride_vn + offs_d_v[None, :]
-    
+
     # -- compute qk ----
     k = tl.load(k_ptrs, mask=mask_n[None, :], other=0.0)
     qk = tl.dot(q, k, allow_tf32=ALLOW_TF32) * alpha
@@ -180,13 +180,21 @@ def _hstu_attn_fwd_compute(
         offs_m = start_m + tl.arange(0, BLOCK_M)
         offs_n = tl.arange(0, BLOCK_N)
         offs_d_q = tl.arange(0, BLOCK_D_Q)
-        K_base=K + off_h * stride_kh + seq_start * stride_kn
-        V_base=V + off_h * stride_vh + seq_start * stride_vn
+        K_base = K + off_h * stride_kh + seq_start * stride_kn
+        V_base = V + off_h * stride_vh + seq_start * stride_vn
         mask_m = offs_m < seq_len
         if IS_DELTA_Q:
             Q_base = Q + off_h * stride_qh + off_z * DeltaSize * stride_qm
-            q_ptrs = Q_base + (start_m_delta + tl.arange(0, BLOCK_M))[:, None] * stride_qm + offs_d_q[None, :]
-            q = tl.load(q_ptrs, mask=((start_m_delta + tl.arange(0, BLOCK_M)) < DeltaSize)[:, None], other=0.0)
+            q_ptrs = (
+                Q_base
+                + (start_m_delta + tl.arange(0, BLOCK_M))[:, None] * stride_qm
+                + offs_d_q[None, :]
+            )
+            q = tl.load(
+                q_ptrs,
+                mask=((start_m_delta + tl.arange(0, BLOCK_M)) < DeltaSize)[:, None],
+                other=0.0,
+            )
         else:
             Q_base = Q + off_h * stride_qh + seq_start * stride_qm
             q_ptrs = Q_base + offs_m[:, None] * stride_qm + offs_d_q[None, :]
@@ -357,7 +365,7 @@ def _hstu_attn_fwd(
         off_z = tl.load(sort_by_length_indices + off_z)
     off_h = off_hz % H
     pid = tl.program_id(0)
-            
+
     _hstu_attn_fwd_compute(
         Q=Q,
         K=K,

--- a/aiter/ops/triton/attention/hstu_attention.py
+++ b/aiter/ops/triton/attention/hstu_attention.py
@@ -96,7 +96,7 @@ def triton_hstu_attention_fwd(
         )
 
     grid = lambda meta: (
-        triton.cdiv(N, meta["BLOCK_M"]) *
+        triton.cdiv(N, meta["BLOCK_M"]),
         Z * H,
     )
 
@@ -117,7 +117,7 @@ def triton_hstu_attention_fwd(
         stride_om=out.stride(0),
         stride_oh=out.stride(1),
         alpha=alpha,
-        Z=Z,
+        # Z=Z,
         H=H,
         MAX_SEQ_LEN=N,
         DeltaSize=DeltaSize,

--- a/aiter/ops/triton/attention/hstu_attention.py
+++ b/aiter/ops/triton/attention/hstu_attention.py
@@ -96,7 +96,7 @@ def triton_hstu_attention_fwd(
         )
 
     grid = lambda meta: (
-        triton.cdiv(N, meta["BLOCK_M"]),
+        triton.cdiv(N, meta["BLOCK_M"]) *
         Z * H,
     )
 
@@ -117,6 +117,7 @@ def triton_hstu_attention_fwd(
         stride_om=out.stride(0),
         stride_oh=out.stride(1),
         alpha=alpha,
+        Z=Z,
         H=H,
         MAX_SEQ_LEN=N,
         DeltaSize=DeltaSize,

--- a/aiter/ops/triton/attention/hstu_attention.py
+++ b/aiter/ops/triton/attention/hstu_attention.py
@@ -117,7 +117,6 @@ def triton_hstu_attention_fwd(
         stride_om=out.stride(0),
         stride_oh=out.stride(1),
         alpha=alpha,
-        # Z=Z,
         H=H,
         MAX_SEQ_LEN=N,
         DeltaSize=DeltaSize,

--- a/aiter/ops/triton/attention/hstu_attention.py
+++ b/aiter/ops/triton/attention/hstu_attention.py
@@ -313,7 +313,9 @@ class _AttentionFunction(torch.autograd.Function):
 
     @staticmethod
     # pyre-ignore[14]
-    def backward(ctx, dout: torch.Tensor) -> tuple[
+    def backward(
+        ctx, dout: torch.Tensor
+    ) -> tuple[
         None,
         None,
         torch.Tensor,

--- a/aiter/ops/triton/attention/hstu_attention.py
+++ b/aiter/ops/triton/attention/hstu_attention.py
@@ -312,9 +312,7 @@ class _AttentionFunction(torch.autograd.Function):
 
     @staticmethod
     # pyre-ignore[14]
-    def backward(
-        ctx, dout: torch.Tensor
-    ) -> tuple[
+    def backward(ctx, dout: torch.Tensor) -> tuple[
         None,
         None,
         torch.Tensor,

--- a/aiter/ops/triton/configs/hstu_attn/gfx950-HSTU_ATTN_FWD.json
+++ b/aiter/ops/triton/configs/hstu_attn/gfx950-HSTU_ATTN_FWD.json
@@ -1,9 +1,9 @@
 {
     "small_batch": {
         "BLOCK_M": 64,
-        "BLOCK_N": 32,
+        "BLOCK_N": 64,
         "num_warps": 4,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 0,
         "matrix_instr_nonkdim": 16
     },
@@ -11,7 +11,7 @@
         "BLOCK_M": 128,
         "BLOCK_N": 32,
         "num_warps": 4,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 0,
         "matrix_instr_nonkdim": 16
     },
@@ -19,7 +19,7 @@
         "BLOCK_M": 128,
         "BLOCK_N": 32,
         "num_warps": 4,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 0,
         "matrix_instr_nonkdim": 16
     }


### PR DESCRIPTION
## Motivation

block pointer was deprecated from Triton 3.8, this PR is to replace the block pointer in the HSTU attention kernel with normal pointers.

## Technical Details

None

## Test Plan

Existing correctness test can pass and no performance regression

## Test Result

Correctness test passed, saw perf uplift with some tuning parameter changes, see the following table:
```
  ┌────────────┬─────────────┬──────────┬───────┬──────────┬────────────┬─────────────┬────────────┬────────────┐ 
  │ batch_size │ max_seq_len │ sparsity │ heads │ attn_dim │ hidden_dim │ Triton 3.7  │ Triton 3.7 │ Triton 3.8 │
  │            │             │          │       │          │            │(noPR)TFLOPS │ (PR)TFLOPS │ (PR)TFLOPS │
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤ 
  │         32 │        1024 │    0.500 │     4 │      128 │        128 │     130.309 │    156.241 │    160.427 │
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤
  │         32 │        2048 │    0.500 │     4 │      128 │        128 │     218.606 │    252.746 │    261.425 │ 
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤
  │         32 │        4096 │    0.500 │     4 │      128 │        128 │     344.016 │    382.364 │    393.997 │ 
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤ 
  │         32 │        8192 │    0.500 │     4 │      128 │        128 │     427.342 │    462.575 │    478.822 │
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤ 
  │         32 │       16384 │    0.500 │     4 │      128 │        128 │     450.008 │    493.805 │    512.873 │
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤ 
  │        512 │         512 │    0.970 │     4 │      128 │        128 │     200.882 │    253.690 │    252.419 │
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤ 
  │        512 │        3072 │    0.366 │     4 │      128 │        128 │     393.988 │    450.191 │    447.854 │
  ├────────────┼─────────────┼──────────┼───────┼──────────┼────────────┼─────────────┼────────────┼────────────┤ 
  │       1024 │        1024 │    0.768 │     4 │      128 │        128 │     200.937 │    258.980 │    257.411 │
  └────────────┴─────────────┴──────────┴───────┴──────────┴────────────┴─────────────┴────────────┴────────────┘ 

```


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
