### PR TITLE
[TRITON] Make RNG deterministic in KV cache unit test

### DIFF
--- a/op_tests/triton_tests/test_kv_cache.py
+++ b/op_tests/triton_tests/test_kv_cache.py
@@ -219,6 +219,8 @@ def test_cat_and_cache_mla(
     ):
         pytest.skip("FP4 KV cache is only supported in GFX950 and GFX1250")
 
+    torch.manual_seed(0)
+
     dtype = torch.bfloat16
     k_lora = torch.randn((T, KH, D_lora), dtype=torch.float32, device="cuda") / (
         20 if cache_dtype != torch.bfloat16 else 1


### PR DESCRIPTION
## Motivation

Triton unit test `op_tests/triton_tests/test_kv_cache.py` was failing in a non-deterministic way in MI300X CI runners (i.e. **Triton Tests (MI300X) / Shard 3**). This PR fixes this issue.

## Technical Details

The fix it to deterministically set the RNG seed in `test_cat_and_cache_mla`:

```python
torch.manual_seed(0)
```

## Test Plan

Run `op_tests/triton_tests/test_kv_cache.py` on `gfx942` and `gfx950`, through CI AITER runners.

## Test Result

`op_tests/triton_tests/test_kv_cache.py` passed on both `gfx942` and `gfx950`. ✅

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
