### PR TITLE
[Misc] Harden AITER_ASM_DIR code-object loading

### DIFF
--- a/csrc/include/aiter_hip_common.h
+++ b/csrc/include/aiter_hip_common.h
@@ -380,44 +380,113 @@ class AiterAsmKernel : private AiterAsmKernelFast
         }
     }
 
+    // Largest .co we are willing to map. The shipped objects are a few hundred KB;
+    // this only exists so a corrupt or bogus tellg() cannot turn into a huge new[].
+    static constexpr std::streamoff kMaxHsacoBytes = 64ll << 20;
+
+    // hsaco_path is a build-generated relative name (e.g. "fmha_v3_bwd/foo.co"). It is
+    // joined onto a configured directory, so it must not be able to walk out of it.
+    static void validate_relative_hsaco_path(const char* hsaco_path)
+    {
+        std::string_view rel(hsaco_path);
+        AITER_CHECK(!rel.empty(), "empty hsaco path");
+        AITER_CHECK(rel.front() != '/', "hsaco path must be relative, got ", hsaco_path);
+        size_t pos = 0;
+        while(true)
+        {
+            size_t next = rel.find('/', pos);
+            size_t len  = (next == std::string_view::npos ? rel.size() : next) - pos;
+            AITER_CHECK(
+                rel.substr(pos, len) != "..", "hsaco path must not contain '..', got ", hsaco_path);
+            if(next == std::string_view::npos)
+                break;
+            pos = next + 1;
+        }
+    }
+
+    const void* load_hsaco_from_dir(const char* kernel_name,
+                                    const char* asm_dir,
+                                    const std::string& arch_name,
+                                    const char* hsaco_path)
+    {
+        validate_relative_hsaco_path(hsaco_path);
+
+        std::string full_path = std::string(asm_dir) + "/" + arch_name + "/" + hsaco_path;
+        AITER_LOG_INFO("LoadKernel: " << kernel_name << " hsaco: " << full_path);
+
+        std::ifstream file(full_path, std::ios::binary | std::ios::ate);
+
+        AITER_CHECK(file.is_open(), "failed to open ", full_path.c_str());
+
+        // tellg() returns -1 on failure; assigning that straight into a size_t used to
+        // produce a SIZE_MAX allocation.
+        std::streamoff size_off = file.tellg();
+        AITER_CHECK(size_off > 0, "empty or unseekable hsaco ", full_path.c_str());
+        AITER_CHECK(size_off <= kMaxHsacoBytes,
+                    "hsaco ",
+                    full_path.c_str(),
+                    " is ",
+                    static_cast<long long>(size_off),
+                    " bytes, above the ",
+                    static_cast<long long>(kMaxHsacoBytes),
+                    " byte limit");
+
+        size_t file_size = static_cast<size_t>(size_off);
+        hsaco_data.reset(new char[file_size]);
+
+        file.seekg(0, std::ios::beg);
+        AITER_CHECK(file.read(hsaco_data.get(), file_size), "failed to read ", full_path.c_str());
+
+        // Reject anything that is not an ELF up front, so a truncated or wrong-format
+        // file fails here instead of somewhere inside the HIP loader.
+        const unsigned char* magic = reinterpret_cast<const unsigned char*>(hsaco_data.get());
+        AITER_CHECK(file_size >= 4 && magic[0] == 0x7f && magic[1] == 'E' && magic[2] == 'L' &&
+                        magic[3] == 'F',
+                    full_path.c_str(),
+                    " is not an ELF code object");
+
+        validate_hsaco_lds(kernel_name, full_path, hsaco_data.get(), file_size);
+
+        return hsaco_data.get();
+    }
+
     const void* load_hsaco_file(const char* kernel_name, const char* hsaco_path)
     {
         const char* AITER_ASM_DIR = std::getenv("AITER_ASM_DIR");
         std::string arch_name     = get_gpu_arch();
+
+#if defined(AITER_EMBEDDED_HSA_HEADER) && defined(AITER_EMBEDDED_HSA_MAP)
+        // This build embedded its code objects at compile time, so they -- not the
+        // environment -- are the trusted source. Redirecting the loader to an arbitrary
+        // directory is a debug facility and has to be opted into by the builder
+        // (-DAITER_ALLOW_ASM_DIR_OVERRIDE), otherwise AITER_ASM_DIR is ignored.
         if(AITER_ASM_DIR != nullptr)
         {
-            std::string full_path = std::string(AITER_ASM_DIR) + "/" + arch_name + "/" + hsaco_path;
-            AITER_LOG_INFO("LoadKernel: " << kernel_name << " hsaco: " << full_path);
-
-            std::ifstream file(full_path, std::ios::binary | std::ios::ate);
-
-            AITER_CHECK(file.is_open(), "failed to open ", full_path.c_str());
-
-            size_t file_size = file.tellg();
-            hsaco_data.reset(new char[file_size]);
-
-            file.seekg(0, std::ios::beg);
-            AITER_CHECK(
-                file.read(hsaco_data.get(), file_size), "failed to read ", full_path.c_str());
-
-            validate_hsaco_lds(kernel_name, full_path, hsaco_data.get(), file_size);
-
-            return hsaco_data.get();
-        }
-        else
-        {
-#if defined(AITER_EMBEDDED_HSA_HEADER) && defined(AITER_EMBEDDED_HSA_MAP)
-            std::string fname = "hsa/" + arch_name + "/" + hsaco_path;
-            auto hasco_obj    = AITER_EMBEDDED_HSA_MAP.find(fname);
-            AITER_CHECK(hasco_obj != AITER_EMBEDDED_HSA_MAP.end(), "hasco_obj not found");
-            AITER_CHECK(hasco_obj->second.data() != nullptr, "hasco_obj is nullptr");
-            AITER_LOG_INFO("LoadKernel: " << kernel_name << " hsaco: [embedded] " << fname);
-            return hasco_obj->second.data();
+#if defined(AITER_ALLOW_ASM_DIR_OVERRIDE)
+            AITER_LOG_WARNING("AITER_ASM_DIR=" << AITER_ASM_DIR
+                                               << " overrides the embedded code objects for '"
+                                               << kernel_name << "'; loading unverified GPU code");
+            return load_hsaco_from_dir(kernel_name, AITER_ASM_DIR, arch_name, hsaco_path);
 #else
-            AITER_CHECK(AITER_ASM_DIR != nullptr, "AITER_ASM_DIR not set");
-            return nullptr;
+            AITER_LOG_WARNING("ignoring AITER_ASM_DIR="
+                              << AITER_ASM_DIR
+                              << "; this build uses embedded code objects. Rebuild with "
+                                 "AITER_ALLOW_ASM_DIR_OVERRIDE to allow the override.");
 #endif
         }
+
+        std::string fname = "hsa/" + arch_name + "/" + hsaco_path;
+        auto hasco_obj    = AITER_EMBEDDED_HSA_MAP.find(fname);
+        AITER_CHECK(hasco_obj != AITER_EMBEDDED_HSA_MAP.end(), "hasco_obj not found");
+        AITER_CHECK(hasco_obj->second.data() != nullptr, "hasco_obj is nullptr");
+        AITER_LOG_INFO("LoadKernel: " << kernel_name << " hsaco: [embedded] " << fname);
+        return hasco_obj->second.data();
+#else
+        // No embedded objects in this build, so loading from disk is the only mechanism.
+        // aiter.jit sets AITER_ASM_DIR to the packaged hsa/ directory on import.
+        AITER_CHECK(AITER_ASM_DIR != nullptr, "AITER_ASM_DIR not set");
+        return load_hsaco_from_dir(kernel_name, AITER_ASM_DIR, arch_name, hsaco_path);
+#endif
     }
 
     public:


### PR DESCRIPTION
# [Misc] Harden AITER_ASM_DIR code-object loading

> **Note:** this change and this description were drafted with the assistance of an AI coding assistant, and reviewed by me before opening. Opened as a draft — see the unchecked hardware-testing box under Testing.

## Summary

`AiterAsmKernel` resolves its `.co` from `$AITER_ASM_DIR` and hands the bytes to `__hipRegisterFatBinary`. In builds that embed their code objects at compile time, that environment variable silently took precedence over the embedded copy. This makes the embedded objects authoritative where they exist, and adds the validation the disk path was missing.

## Motivation

A security scan flagged the env-to-code-object flow in `aiter_hip_common.h` as CWE-426 (untrusted search path). The concrete gap is the precedence order rather than the existence of the env var:

- A build that went to the trouble of embedding vetted code objects would still discard them the moment `AITER_ASM_DIR` was set in the environment, with no warning, and load an arbitrary file from the named directory instead.
- The consumer this affects today is PyTorch's `ck_sdpa` target, which compiles this header with `-DAITER_EMBEDDED_HSA_HEADER` and generates the embedded map from `third_party/aiter/hsa` at build time. Nothing in PyTorch sets `AITER_ASM_DIR`, so the variable is purely an external input there.

I want to be precise about the severity, because I do not think this is critical: setting an environment variable in the victim process already implies at least as much control as `LD_PRELOAD` or `PYTHONPATH` would give. No privilege boundary is crossed and aiter offers no env sandbox. This is defence in depth — the useful property is that a build which ships vetted binaries cannot be silently redirected away from them — not the closing of a live escalation path.

Separately, the disk path had a genuine crash: `tellg()` returns `-1` on failure and was assigned straight into a `size_t`, so an unseekable file asked `new[]` for `SIZE_MAX`.

## Changes

**Precedence.** In a build with an embedded map, the embedded object is used. `AITER_ASM_DIR` is honoured only if the builder opts in with `-DAITER_ALLOW_ASM_DIR_OVERRIDE`; taking the override logs a warning naming the directory and the kernel. Without the opt-in, a set `AITER_ASM_DIR` is ignored and logs a warning saying so, rather than being silently dropped.

**No behaviour change for standalone aiter.** Builds with no embedded map load from disk exactly as before, including the existing fail-closed `AITER_CHECK` when the variable is unset. This is the path the aiter package itself uses — `aiter/jit/core.py` sets `AITER_ASM_DIR` to the packaged `hsa/` directory on import — so the normal `pip install aiter` flow is untouched. Gating the env var off by default would have broken it.

**Disk-path validation**, applied on both the standalone and opted-in override paths:
- `validate_relative_hsaco_path()` rejects a hsaco name that is empty, absolute, or contains a `..` component, so the join onto the configured directory cannot escape it. `..` as a *prefix* (`..foo.co`) is still fine; only a whole component is rejected.
- ELF magic is required, so a truncated or wrong-format file fails here with a clear message instead of somewhere inside the HIP loader.
- Size is bounded at 64 MiB (shipped objects are a few hundred KB), which is also what fixes the `SIZE_MAX` allocation above.

**Refactor.** The disk-loading body moved into `load_hsaco_from_dir()` so both paths share it; `load_hsaco_file()` is now just the source-selection policy.

### Deliberate omissions

- **No `realpath`/`std::filesystem` canonicalisation against an install prefix.** This header is included from HIP TUs, and there is no install prefix known to the C++ layer in a standalone build — the directory comes from Python. Rejecting `..` in the relative part gets the containment property that is actually available here without adding a `<filesystem>` dependency to a widely-included header.
- **No signature verification.** That would need a key-distribution story that does not exist today, and would not match how every other `.so` in the stack is loaded.

## Testing

- [x] Header syntax-checked in all three configurations it now has (standalone; embedded; embedded + `AITER_ALLOW_ASM_DIR_OVERRIDE`), `-std=c++20 --offload-arch=gfx942`, no warnings from the changed code.
- [x] `validate_relative_hsaco_path()` and the load checks extracted into a standalone harness, 19 cases, all passing — accepts `fmha_v3_bwd/foo.co`, `..foo.co`, `a/..b/c.co`; rejects `""`, `/abs/foo.co`, `..`, `../foo.co`, `a/../../etc/passwd`, `a/b/../c.co`; accepts a well-formed ELF and rejects empty, truncated, wrong-magic and missing files.
- [x] `clang-format` clean over the changed region.
- [ ] **Not run on hardware — no GPU on this machine.** A maintainer should confirm an ordinary standalone aiter run still loads kernels normally, since that path is the one most people exercise.

No unit tests added: the logic is in a header-only private member of a class that requires a live HIP device to instantiate, and there is no existing C++ test target here to hang it off. Happy to add one if you would like it wired up.

## Documentation

- [ ] Not updated. If `AITER_ALLOW_ASM_DIR_OVERRIDE` looks right to you, it should probably be mentioned wherever `AITER_ASM_DIR` is documented for downstream embedders — `op_tests/cpp/mha/README.md` is the only place the variable appears in-tree today, and that flow is unaffected.

## Dependencies

- [x] No new third-party dependencies.

## Breaking Changes

None for standalone aiter or for any build without an embedded map.

For a build that embeds code objects **and** relied on `AITER_ASM_DIR` to override them, the override now requires `-DAITER_ALLOW_ASM_DIR_OVERRIDE` at compile time. I believe PyTorch is the only such consumer today and it does not set the variable, so I expect no downstream fallout — but this is the part worth a maintainer's eye, since you will know of embedders I do not.
