### PR TITLE
[HIP] [JIT] Fix/gfx1201 bf16 g1u1 small m moe

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -526,6 +526,42 @@ def fused_moe(
             shared_w2_scale=shared_w2_scale,
             shared_expert_id=shared_expert_id,
         )
+    out_dtype = hidden_states.dtype if dtype is None else dtype
+    if _can_use_bf16_g1u1_small_m_direct(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weight=topk_weight,
+        topk_ids=topk_ids,
+        activation=activation,
+        quant_type=quant_type,
+        dtype=out_dtype,
+        doweight_stage1=doweight_stage1,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        a1_scale=a1_scale,
+        a2_scale=a2_scale,
+        num_local_tokens=num_local_tokens,
+        moe_sorting_dispatch_policy=moe_sorting_dispatch_policy,
+        expert_mask=expert_mask,
+        hidden_pad=hidden_pad,
+        intermediate_pad=intermediate_pad,
+        bias1=bias1,
+        bias2=bias2,
+        splitk=splitk,
+        swiglu_limit=swiglu_limit,
+        beta=beta,
+        linear_beta=linear_beta,
+        gate_mode=gate_mode,
+    ):
+        return fused_moe_g1u1_bf16_small_m_direct(
+            hidden_states,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids,
+            dtype=out_dtype,
+        )
     if not block_size_M:
         block_size_M = -1
     return fused_moe_(
@@ -590,6 +626,108 @@ def fused_moe_fake(
     model_dim = w2.shape[1]
     moe_buf = torch.empty((M, model_dim), dtype=dtype, device=device)
     return moe_buf
+
+
+def fused_moe_g1u1_bf16_small_m_direct(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    M = hidden_states.shape[0]
+    topk = topk_ids.shape[1]
+    model_dim = w2.shape[1]
+    inter_dim = w2.shape[2]
+    output = torch.empty((M, model_dim), dtype=dtype, device=hidden_states.device)
+    act_workspace = torch.empty(
+        (M * topk, inter_dim), dtype=dtype, device=hidden_states.device
+    )
+    aiter.fmoe_g1u1_bf16_small_m(
+        output,
+        hidden_states.contiguous(),
+        w1.contiguous(),
+        w2.contiguous(),
+        topk_ids.contiguous(),
+        topk_weight.contiguous(),
+        act_workspace,
+        topk,
+        bool(getattr(w1, "is_shuffled", False)),
+        bool(getattr(w2, "is_shuffled", False)),
+    )
+    return output
+
+
+def _can_use_bf16_g1u1_small_m_direct(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: ActivationType,
+    quant_type: QuantType,
+    dtype: torch.dtype,
+    doweight_stage1: bool,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    a1_scale: torch.Tensor | None,
+    a2_scale: torch.Tensor | None,
+    num_local_tokens: torch.Tensor | None,
+    moe_sorting_dispatch_policy: int,
+    expert_mask: torch.Tensor | None,
+    hidden_pad: int,
+    intermediate_pad: int,
+    bias1: torch.Tensor | None,
+    bias2: torch.Tensor | None,
+    splitk: int = 0,
+    swiglu_limit: float | None = None,
+    beta: float | None = None,
+    linear_beta: float | None = None,
+    gate_mode: str | GateMode | None = GateMode.SEPARATED.value,
+) -> bool:
+    M = topk_ids.shape[0]
+    return (
+        get_gfx_runtime() == "gfx1201"
+        and quant_type == QuantType.No
+        and activation == ActivationType.Silu
+        and dtype == dtypes.bf16
+        and M in (1, 2, 3, 4, 8, 16)
+        and hidden_states.is_cuda
+        and w1.is_cuda
+        and w2.is_cuda
+        and topk_ids.is_cuda
+        and topk_weight.is_cuda
+        and w1.device == hidden_states.device
+        and w2.device == hidden_states.device
+        and topk_ids.device == hidden_states.device
+        and topk_weight.device == hidden_states.device
+        and hidden_states.dtype == dtypes.bf16
+        and w1.dtype == dtypes.bf16
+        and w2.dtype == dtypes.bf16
+        and topk_ids.dtype == dtypes.i32
+        and topk_weight.dtype == dtypes.fp32
+        and w1.shape[1] == 2 * w2.shape[2]
+        and expert_mask is None
+        and not doweight_stage1
+        and w1_scale is None
+        and w2_scale is None
+        and a1_scale is None
+        and a2_scale is None
+        and num_local_tokens is None
+        and moe_sorting_dispatch_policy == 0
+        and hidden_pad == 0
+        and intermediate_pad == 0
+        and bias1 is None
+        and bias2 is None
+        and splitk in (0, 1)
+        and swiglu_limit is None
+        and beta is None
+        and linear_beta is None
+        and gate_mode in (None, GateMode.SEPARATED, GateMode.SEPARATED.value)
+    )
 
 
 @torch_compile_guard(gen_fake=fused_moe_fake)
@@ -803,6 +941,41 @@ def _fused_moe_impl(
 
     if grouped_a8w4_out is not None:
         return grouped_a8w4_out
+
+    if _can_use_bf16_g1u1_small_m_direct(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weight=topk_weight,
+        topk_ids=topk_ids,
+        activation=activation,
+        quant_type=quant_type,
+        dtype=dtype,
+        doweight_stage1=doweight_stage1,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        a1_scale=a1_scale,
+        a2_scale=a2_scale,
+        num_local_tokens=num_local_tokens,
+        moe_sorting_dispatch_policy=moe_sorting_dispatch_policy,
+        expert_mask=expert_mask,
+        hidden_pad=hidden_pad,
+        intermediate_pad=intermediate_pad,
+        bias1=bias1,
+        bias2=bias2,
+        swiglu_limit=swiglu_limit,
+        beta=beta,
+        linear_beta=linear_beta,
+        gate_mode=gate_mode,
+    ):
+        return fused_moe_g1u1_bf16_small_m_direct(
+            hidden_states,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids,
+            dtype=dtype,
+        )
 
     # a16w4-SiTUv2 (bf16 A x MXFP4 W); SiTUv2 gate distinguishes gpt-oss (Swiglu -> cktile).
     _is_a16w4_situv2 = (

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -475,7 +475,8 @@
     "module_moe_fmoe_asm": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/py_itfs_cu/asm_fmoe.cu'",
-            "f'{AITER_CSRC_DIR}/py_itfs_cu/asm_moe_2stage.cu'"
+            "f'{AITER_CSRC_DIR}/py_itfs_cu/asm_moe_2stage.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/fmoe_g1u1_bf16_small_m.cu'"
         ],
         "flags_extra_cc": [],
         "flags_extra_hip": [],

--- a/aiter/ops/moe_op.py
+++ b/aiter/ops/moe_op.py
@@ -125,6 +125,21 @@ def fmoe(
 
 
 @compile_ops("module_moe_fmoe_asm", ffi_type="ctypes")
+def fmoe_g1u1_bf16_small_m(
+    out: Tensor,
+    input: Tensor,
+    gate: Tensor,
+    down: Tensor,
+    topk_ids: Tensor,
+    topk_weights: Tensor,
+    act_workspace: Tensor,
+    topk: int,
+    gate_is_shuffled: bool,
+    down_is_shuffled: bool,
+) -> None: ...
+
+
+@compile_ops("module_moe_fmoe_asm", ffi_type="ctypes")
 def fmoe_int8_g1u0(
     out: Tensor,
     input: Tensor,

--- a/csrc/kernels/fmoe_g1u1_bf16_small_m.cu
+++ b/csrc/kernels/fmoe_g1u1_bf16_small_m.cu
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "aiter_hip_common.h"
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+
+namespace aiter {
+
+// Direct BF16 G1U1 kernel for gfx1201 small-token-count MoE cases where
+// M <= 4 and M * topk < num_experts.
+template <int group_size, bool gate_is_shuffled>
+__global__ void fmoe_g1u1_bf16_small_m_stage1_kernel(
+    const hip_bfloat16* __restrict__ input,
+    const hip_bfloat16* __restrict__ gate,
+    const int32_t* __restrict__ topk_ids,
+    hip_bfloat16* __restrict__ act_out,
+    int token_cnt,
+    int model_dim,
+    int inter_dim,
+    int expert_cnt,
+    int topk)
+{
+    int route = blockIdx.x;
+    int i_base = blockIdx.y * group_size;
+    if(route >= token_cnt * topk || i_base >= inter_dim)
+        return;
+
+    int token = route / topk;
+    int topk_idx = route - token * topk;
+    int expert = topk_ids[token * topk + topk_idx];
+    // Treat invalid expert ids as no-op routes and avoid out-of-bounds weight reads.
+    if(expert < 0 || expert >= expert_cnt)
+    {
+        for(int g = 0; g < group_size; ++g)
+        {
+            int i = i_base + g;
+            if(i < inter_dim)
+                act_out[route * inter_dim + i] = hip_bfloat16(0.0f);
+        }
+        return;
+    }
+
+    const hip_bfloat16* x = input + token * model_dim;
+    __shared__ float gate_smem[group_size][256];
+    __shared__ float up_smem[group_size][256];
+    float gate_acc[group_size] = {};
+    float up_acc[group_size] = {};
+    int gate_nblock_stride = (model_dim / 32) * 512;
+
+    for(int k = threadIdx.x; k < model_dim; k += blockDim.x)
+    {
+        float xv = static_cast<float>(x[k]);
+        for(int g = 0; g < group_size; ++g)
+        {
+            int i = i_base + g;
+            if(i < inter_dim)
+            {
+                if constexpr(gate_is_shuffled)
+                {
+                    int kblock = k / 32;
+                    int k_in_32 = k - kblock * 32;
+                    int klane = k_in_32 / 8;
+                    int k8 = k_in_32 - klane * 8;
+                    int gate_row = expert * (2 * inter_dim) + i;
+                    int up_row = gate_row + inter_dim;
+                    int gate_nblock = gate_row / 16;
+                    int gate_nintra = gate_row - gate_nblock * 16;
+                    int up_nblock = up_row / 16;
+                    int up_nintra = up_row - up_nblock * 16;
+                    int gate_idx = gate_nblock * gate_nblock_stride + kblock * 512 +
+                                   klane * 128 + gate_nintra * 8 + k8;
+                    int up_idx = up_nblock * gate_nblock_stride + kblock * 512 +
+                                 klane * 128 + up_nintra * 8 + k8;
+                    gate_acc[g] += xv * static_cast<float>(gate[gate_idx]);
+                    up_acc[g] += xv * static_cast<float>(gate[up_idx]);
+                }
+                else
+                {
+                    const hip_bfloat16* w_gate =
+                        gate + expert * (2 * inter_dim * model_dim) + i * model_dim;
+                    const hip_bfloat16* w_up = gate + expert * (2 * inter_dim * model_dim) +
+                                               (inter_dim + i) * model_dim;
+                    gate_acc[g] += xv * static_cast<float>(w_gate[k]);
+                    up_acc[g] += xv * static_cast<float>(w_up[k]);
+                }
+            }
+        }
+    }
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        gate_smem[g][threadIdx.x] = gate_acc[g];
+        up_smem[g][threadIdx.x] = up_acc[g];
+    }
+    __syncthreads();
+
+    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
+    {
+        if(threadIdx.x < stride)
+        {
+            for(int g = 0; g < group_size; ++g)
+            {
+                gate_smem[g][threadIdx.x] += gate_smem[g][threadIdx.x + stride];
+                up_smem[g][threadIdx.x] += up_smem[g][threadIdx.x + stride];
+            }
+        }
+        __syncthreads();
+    }
+
+    if(threadIdx.x != 0)
+        return;
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        int i = i_base + g;
+        if(i < inter_dim)
+        {
+            float gate_val = gate_smem[g][0];
+            float up_val = up_smem[g][0];
+            float silu = gate_val / (1.0f + expf(-gate_val));
+            act_out[route * inter_dim + i] = hip_bfloat16(silu * up_val);
+        }
+    }
+}
+
+template <int group_size, bool down_is_shuffled>
+__global__ void fmoe_g1u1_bf16_small_m_stage2_kernel(
+    const hip_bfloat16* __restrict__ act,
+    const hip_bfloat16* __restrict__ down,
+    const int32_t* __restrict__ topk_ids,
+    const float* __restrict__ topk_weights,
+    hip_bfloat16* __restrict__ out,
+    int token_cnt,
+    int model_dim,
+    int inter_dim,
+    int expert_cnt,
+    int topk)
+{
+    int token = blockIdx.x;
+    int h_base = blockIdx.y * group_size;
+    if(token >= token_cnt || h_base >= model_dim)
+        return;
+
+    __shared__ float smem[group_size][256];
+    float acc[group_size] = {};
+    int total = topk * inter_dim;
+    int down_nblock_stride = (inter_dim / 32) * 512;
+    for(int idx = threadIdx.x; idx < total; idx += blockDim.x)
+    {
+        int topk_idx = idx / inter_dim;
+        int i = idx - topk_idx * inter_dim;
+        int route = token * topk + topk_idx;
+        int expert = topk_ids[route];
+        if(expert < 0 || expert >= expert_cnt)
+            continue;
+
+        float route_weight = topk_weights[route];
+        const hip_bfloat16* act_route = act + route * inter_dim;
+        float act_val = static_cast<float>(act_route[i]) * route_weight;
+        for(int g = 0; g < group_size; ++g)
+        {
+            int h = h_base + g;
+            if(h < model_dim)
+            {
+                if constexpr(down_is_shuffled)
+                {
+                    int iblock = i / 32;
+                    int i_in_32 = i - iblock * 32;
+                    int ilane = i_in_32 / 8;
+                    int i8 = i_in_32 - ilane * 8;
+                    int down_row = expert * model_dim + h;
+                    int down_nblock = down_row / 16;
+                    int down_nintra = down_row - down_nblock * 16;
+                    int down_idx = down_nblock * down_nblock_stride + iblock * 512 +
+                                   ilane * 128 + down_nintra * 8 + i8;
+                    acc[g] += act_val * static_cast<float>(down[down_idx]);
+                }
+                else
+                {
+                    const hip_bfloat16* w2 =
+                        down + expert * (model_dim * inter_dim) + h * inter_dim;
+                    acc[g] += act_val * static_cast<float>(w2[i]);
+                }
+            }
+        }
+    }
+
+    for(int g = 0; g < group_size; ++g)
+        smem[g][threadIdx.x] = acc[g];
+    __syncthreads();
+
+    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
+    {
+        if(threadIdx.x < stride)
+        {
+            for(int g = 0; g < group_size; ++g)
+                smem[g][threadIdx.x] += smem[g][threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+
+    if(threadIdx.x != 0)
+        return;
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        int h = h_base + g;
+        if(h < model_dim)
+            out[token * model_dim + h] = hip_bfloat16(smem[g][0]);
+    }
+}
+
+void launch_fmoe_g1u1_bf16_small_m(
+    hip_bfloat16* out,
+    const hip_bfloat16* input,
+    const hip_bfloat16* gate,
+    const hip_bfloat16* down,
+    const int32_t* topk_ids,
+    const float* topk_weights,
+    hip_bfloat16* act_workspace,
+    int token_cnt,
+    int model_dim,
+    int inter_dim,
+    int expert_cnt,
+    int topk,
+    bool gate_is_shuffled,
+    bool down_is_shuffled,
+    hipStream_t stream)
+{
+    constexpr int threads = 256;
+    constexpr int group_size = 8;
+
+    dim3 grid1(token_cnt * topk, (inter_dim + group_size - 1) / group_size);
+    if(gate_is_shuffled)
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, true>),
+                           grid1,
+                           dim3(threads),
+                           0,
+                           stream,
+                           input,
+                           gate,
+                           topk_ids,
+                           act_workspace,
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    else
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, false>),
+                           grid1,
+                           dim3(threads),
+                           0,
+                           stream,
+                           input,
+                           gate,
+                           topk_ids,
+                           act_workspace,
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    HIP_CALL_LAUNCH(hipGetLastError());
+
+    dim3 grid2(token_cnt, (model_dim + group_size - 1) / group_size);
+    if(down_is_shuffled)
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, true>),
+                           grid2,
+                           dim3(threads),
+                           0,
+                           stream,
+                           act_workspace,
+                           down,
+                           topk_ids,
+                           topk_weights,
+                           out,
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    else
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, false>),
+                           grid2,
+                           dim3(threads),
+                           0,
+                           stream,
+                           act_workspace,
+                           down,
+                           topk_ids,
+                           topk_weights,
+                           out,
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    HIP_CALL_LAUNCH(hipGetLastError());
+}
+
+} // namespace aiter

--- a/csrc/py_itfs_cu/asm_fmoe.cu
+++ b/csrc/py_itfs_cu/asm_fmoe.cu
@@ -368,207 +368,23 @@ int get_heuristic_tile(int inter_dim, int sub_X_cnt, const std::vector<int>& ava
 
 AITER_CTYPES_ERROR_DECL;
 
-// Direct BF16 G1U1 kernel for gfx1201 small-token-count MoE cases where
-// M <= 16 and M * topk < num_experts.
-template <int group_size, bool gate_is_shuffled>
-__global__ void fmoe_g1u1_bf16_small_m_stage1_kernel(const hip_bfloat16* __restrict__ input,
-                                                         const hip_bfloat16* __restrict__ gate,
-                                                         const int32_t* __restrict__ topk_ids,
-                                                         hip_bfloat16* __restrict__ act_out,
-                                                         int token_cnt,
-                                                         int model_dim,
-                                                         int inter_dim,
-                                                         int expert_cnt,
-                                                         int topk)
-{
-    int route = blockIdx.x;
-    int i_base = blockIdx.y * group_size;
-    if(route >= token_cnt * topk || i_base >= inter_dim)
-        return;
-
-    int token = route / topk;
-    int topk_idx = route - token * topk;
-    int expert = topk_ids[token * topk + topk_idx];
-    // Treat invalid expert ids as no-op routes and avoid out-of-bounds weight reads.
-    if(expert < 0 || expert >= expert_cnt)
-    {
-        for(int g = 0; g < group_size; ++g)
-        {
-            int i = i_base + g;
-            if(i < inter_dim)
-                act_out[route * inter_dim + i] = hip_bfloat16(0.0f);
-        }
-        return;
-    }
-
-    const hip_bfloat16* x = input + token * model_dim;
-    __shared__ float gate_smem[group_size][256];
-    __shared__ float up_smem[group_size][256];
-    float gate_acc[group_size] = {};
-    float up_acc[group_size] = {};
-    int gate_nblock_stride = (model_dim / 32) * 512;
-
-    for(int k = threadIdx.x; k < model_dim; k += blockDim.x)
-    {
-        float xv = static_cast<float>(x[k]);
-        for(int g = 0; g < group_size; ++g)
-        {
-            int i = i_base + g;
-            if(i < inter_dim)
-            {
-                if constexpr(gate_is_shuffled)
-                {
-                    int kblock = k / 32;
-                    int k_in_32 = k - kblock * 32;
-                    int klane = k_in_32 / 8;
-                    int k8 = k_in_32 - klane * 8;
-                    int gate_row = expert * (2 * inter_dim) + i;
-                    int up_row = gate_row + inter_dim;
-                    int gate_nblock = gate_row / 16;
-                    int gate_nintra = gate_row - gate_nblock * 16;
-                    int up_nblock = up_row / 16;
-                    int up_nintra = up_row - up_nblock * 16;
-                    int gate_idx = gate_nblock * gate_nblock_stride + kblock * 512 +
-                                   klane * 128 + gate_nintra * 8 + k8;
-                    int up_idx = up_nblock * gate_nblock_stride + kblock * 512 +
-                                 klane * 128 + up_nintra * 8 + k8;
-                    gate_acc[g] += xv * static_cast<float>(gate[gate_idx]);
-                    up_acc[g] += xv * static_cast<float>(gate[up_idx]);
-                }
-                else
-                {
-                    const hip_bfloat16* w_gate =
-                        gate + expert * (2 * inter_dim * model_dim) + i * model_dim;
-                    const hip_bfloat16* w_up = gate + expert * (2 * inter_dim * model_dim) +
-                                               (inter_dim + i) * model_dim;
-                    gate_acc[g] += xv * static_cast<float>(w_gate[k]);
-                    up_acc[g] += xv * static_cast<float>(w_up[k]);
-                }
-            }
-        }
-    }
-
-    for(int g = 0; g < group_size; ++g)
-    {
-        gate_smem[g][threadIdx.x] = gate_acc[g];
-        up_smem[g][threadIdx.x] = up_acc[g];
-    }
-    __syncthreads();
-
-    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
-    {
-        if(threadIdx.x < stride)
-        {
-            for(int g = 0; g < group_size; ++g)
-            {
-                gate_smem[g][threadIdx.x] += gate_smem[g][threadIdx.x + stride];
-                up_smem[g][threadIdx.x] += up_smem[g][threadIdx.x + stride];
-            }
-        }
-        __syncthreads();
-    }
-
-    if(threadIdx.x != 0)
-        return;
-
-    for(int g = 0; g < group_size; ++g)
-    {
-        int i = i_base + g;
-        if(i < inter_dim)
-        {
-            float gate_val = gate_smem[g][0];
-            float up_val = up_smem[g][0];
-            float silu = gate_val / (1.0f + expf(-gate_val));
-            act_out[route * inter_dim + i] = hip_bfloat16(silu * up_val);
-        }
-    }
-}
-
-template <int group_size, bool down_is_shuffled>
-__global__ void fmoe_g1u1_bf16_small_m_stage2_kernel(const hip_bfloat16* __restrict__ act,
-                                                         const hip_bfloat16* __restrict__ down,
-                                                         const int32_t* __restrict__ topk_ids,
-                                                         const float* __restrict__ topk_weights,
-                                                         hip_bfloat16* __restrict__ out,
-                                                         int token_cnt,
-                                                         int model_dim,
-                                                         int inter_dim,
-                                                         int expert_cnt,
-                                                         int topk)
-{
-    int token = blockIdx.x;
-    int h_base = blockIdx.y * group_size;
-    if(token >= token_cnt || h_base >= model_dim)
-        return;
-
-    __shared__ float smem[group_size][256];
-    float acc[group_size] = {};
-    int total = topk * inter_dim;
-    int down_nblock_stride = (inter_dim / 32) * 512;
-    for(int idx = threadIdx.x; idx < total; idx += blockDim.x)
-    {
-        int topk_idx = idx / inter_dim;
-        int i = idx - topk_idx * inter_dim;
-        int route = token * topk + topk_idx;
-        int expert = topk_ids[route];
-        if(expert < 0 || expert >= expert_cnt)
-            continue;
-
-        float route_weight = topk_weights[route];
-        const hip_bfloat16* act_route = act + route * inter_dim;
-        float act_val = static_cast<float>(act_route[i]) * route_weight;
-        for(int g = 0; g < group_size; ++g)
-        {
-            int h = h_base + g;
-            if(h < model_dim)
-            {
-                if constexpr(down_is_shuffled)
-                {
-                    int iblock = i / 32;
-                    int i_in_32 = i - iblock * 32;
-                    int ilane = i_in_32 / 8;
-                    int i8 = i_in_32 - ilane * 8;
-                    int down_row = expert * model_dim + h;
-                    int down_nblock = down_row / 16;
-                    int down_nintra = down_row - down_nblock * 16;
-                    int down_idx = down_nblock * down_nblock_stride + iblock * 512 +
-                                   ilane * 128 + down_nintra * 8 + i8;
-                    acc[g] += act_val * static_cast<float>(down[down_idx]);
-                }
-                else
-                {
-                    const hip_bfloat16* w2 =
-                        down + expert * (model_dim * inter_dim) + h * inter_dim;
-                    acc[g] += act_val * static_cast<float>(w2[i]);
-                }
-            }
-        }
-    }
-
-    for(int g = 0; g < group_size; ++g)
-        smem[g][threadIdx.x] = acc[g];
-    __syncthreads();
-
-    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
-    {
-        if(threadIdx.x < stride)
-        {
-            for(int g = 0; g < group_size; ++g)
-                smem[g][threadIdx.x] += smem[g][threadIdx.x + stride];
-        }
-        __syncthreads();
-    }
-
-    if(threadIdx.x != 0)
-        return;
-
-    for(int g = 0; g < group_size; ++g)
-    {
-        int h = h_base + g;
-        if(h < model_dim)
-            out[token * model_dim + h] = hip_bfloat16(smem[g][0]);
-    }
-}
+namespace aiter {
+void launch_fmoe_g1u1_bf16_small_m(hip_bfloat16* out,
+                                   const hip_bfloat16* input,
+                                   const hip_bfloat16* gate,
+                                   const hip_bfloat16* down,
+                                   const int32_t* topk_ids,
+                                   const float* topk_weights,
+                                   hip_bfloat16* act_workspace,
+                                   int token_cnt,
+                                   int model_dim,
+                                   int inter_dim,
+                                   int expert_cnt,
+                                   int topk,
+                                   bool gate_is_shuffled,
+                                   bool down_is_shuffled,
+                                   hipStream_t stream);
+} // namespace aiter
 
 AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
     fmoe_g1u1_bf16_small_m,
@@ -628,83 +444,21 @@ AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
                 __func__,
                 " act_workspace shape mismatch");
 
-    constexpr int threads = 256;
-    constexpr int group_size = 8;
-    dim3 grid1(token_cnt * topk, (inter_dim + group_size - 1) / group_size);
-    if(gate_is_shuffled)
-    {
-        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, true>),
-                           grid1,
-                           dim3(threads),
-                           0,
-                           stream,
-                           reinterpret_cast<const hip_bfloat16*>(input->ptr),
-                           reinterpret_cast<const hip_bfloat16*>(gate->ptr),
-                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
-                           reinterpret_cast<hip_bfloat16*>(act_workspace->ptr),
-                           token_cnt,
-                           model_dim,
-                           inter_dim,
-                           expert_cnt,
-                           topk);
-    }
-    else
-    {
-        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, false>),
-                           grid1,
-                           dim3(threads),
-                           0,
-                           stream,
-                           reinterpret_cast<const hip_bfloat16*>(input->ptr),
-                           reinterpret_cast<const hip_bfloat16*>(gate->ptr),
-                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
-                           reinterpret_cast<hip_bfloat16*>(act_workspace->ptr),
-                           token_cnt,
-                           model_dim,
-                           inter_dim,
-                           expert_cnt,
-                           topk);
-    }
-    HIP_CALL_LAUNCH(hipGetLastError());
-
-    dim3 grid2(token_cnt, (model_dim + group_size - 1) / group_size);
-    if(down_is_shuffled)
-    {
-        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, true>),
-                           grid2,
-                           dim3(threads),
-                           0,
-                           stream,
-                           reinterpret_cast<const hip_bfloat16*>(act_workspace->ptr),
-                           reinterpret_cast<const hip_bfloat16*>(down->ptr),
-                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
-                           reinterpret_cast<const float*>(topk_weights->ptr),
-                           reinterpret_cast<hip_bfloat16*>(out->ptr),
-                           token_cnt,
-                           model_dim,
-                           inter_dim,
-                           expert_cnt,
-                           topk);
-    }
-    else
-    {
-        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, false>),
-                           grid2,
-                           dim3(threads),
-                           0,
-                           stream,
-                           reinterpret_cast<const hip_bfloat16*>(act_workspace->ptr),
-                           reinterpret_cast<const hip_bfloat16*>(down->ptr),
-                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
-                           reinterpret_cast<const float*>(topk_weights->ptr),
-                           reinterpret_cast<hip_bfloat16*>(out->ptr),
-                           token_cnt,
-                           model_dim,
-                           inter_dim,
-                           expert_cnt,
-                           topk);
-    }
-    HIP_CALL_LAUNCH(hipGetLastError());
+    aiter::launch_fmoe_g1u1_bf16_small_m(reinterpret_cast<hip_bfloat16*>(out->ptr),
+                                         reinterpret_cast<const hip_bfloat16*>(input->ptr),
+                                         reinterpret_cast<const hip_bfloat16*>(gate->ptr),
+                                         reinterpret_cast<const hip_bfloat16*>(down->ptr),
+                                         reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                                         reinterpret_cast<const float*>(topk_weights->ptr),
+                                         reinterpret_cast<hip_bfloat16*>(act_workspace->ptr),
+                                         token_cnt,
+                                         model_dim,
+                                         inter_dim,
+                                         expert_cnt,
+                                         topk,
+                                         gate_is_shuffled,
+                                         down_is_shuffled,
+                                         stream);
 }
 
 AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(

--- a/csrc/py_itfs_cu/asm_fmoe.cu
+++ b/csrc/py_itfs_cu/asm_fmoe.cu
@@ -3,6 +3,7 @@
 #include "aiter_tensor.h"
 #include "aiter_ctypes_error.h"
 #include "asm_fmoe_configs.hpp"
+#include <hip/hip_bfloat16.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <memory>
@@ -366,6 +367,345 @@ int get_heuristic_tile(int inter_dim, int sub_X_cnt, const std::vector<int>& ava
 };
 
 AITER_CTYPES_ERROR_DECL;
+
+// Direct BF16 G1U1 kernel for gfx1201 small-token-count MoE cases where
+// M <= 16 and M * topk < num_experts.
+template <int group_size, bool gate_is_shuffled>
+__global__ void fmoe_g1u1_bf16_small_m_stage1_kernel(const hip_bfloat16* __restrict__ input,
+                                                         const hip_bfloat16* __restrict__ gate,
+                                                         const int32_t* __restrict__ topk_ids,
+                                                         hip_bfloat16* __restrict__ act_out,
+                                                         int token_cnt,
+                                                         int model_dim,
+                                                         int inter_dim,
+                                                         int expert_cnt,
+                                                         int topk)
+{
+    int route = blockIdx.x;
+    int i_base = blockIdx.y * group_size;
+    if(route >= token_cnt * topk || i_base >= inter_dim)
+        return;
+
+    int token = route / topk;
+    int topk_idx = route - token * topk;
+    int expert = topk_ids[token * topk + topk_idx];
+    // Treat invalid expert ids as no-op routes and avoid out-of-bounds weight reads.
+    if(expert < 0 || expert >= expert_cnt)
+    {
+        for(int g = 0; g < group_size; ++g)
+        {
+            int i = i_base + g;
+            if(i < inter_dim)
+                act_out[route * inter_dim + i] = hip_bfloat16(0.0f);
+        }
+        return;
+    }
+
+    const hip_bfloat16* x = input + token * model_dim;
+    __shared__ float gate_smem[group_size][256];
+    __shared__ float up_smem[group_size][256];
+    float gate_acc[group_size] = {};
+    float up_acc[group_size] = {};
+    int gate_nblock_stride = (model_dim / 32) * 512;
+
+    for(int k = threadIdx.x; k < model_dim; k += blockDim.x)
+    {
+        float xv = static_cast<float>(x[k]);
+        for(int g = 0; g < group_size; ++g)
+        {
+            int i = i_base + g;
+            if(i < inter_dim)
+            {
+                if constexpr(gate_is_shuffled)
+                {
+                    int kblock = k / 32;
+                    int k_in_32 = k - kblock * 32;
+                    int klane = k_in_32 / 8;
+                    int k8 = k_in_32 - klane * 8;
+                    int gate_row = expert * (2 * inter_dim) + i;
+                    int up_row = gate_row + inter_dim;
+                    int gate_nblock = gate_row / 16;
+                    int gate_nintra = gate_row - gate_nblock * 16;
+                    int up_nblock = up_row / 16;
+                    int up_nintra = up_row - up_nblock * 16;
+                    int gate_idx = gate_nblock * gate_nblock_stride + kblock * 512 +
+                                   klane * 128 + gate_nintra * 8 + k8;
+                    int up_idx = up_nblock * gate_nblock_stride + kblock * 512 +
+                                 klane * 128 + up_nintra * 8 + k8;
+                    gate_acc[g] += xv * static_cast<float>(gate[gate_idx]);
+                    up_acc[g] += xv * static_cast<float>(gate[up_idx]);
+                }
+                else
+                {
+                    const hip_bfloat16* w_gate =
+                        gate + expert * (2 * inter_dim * model_dim) + i * model_dim;
+                    const hip_bfloat16* w_up = gate + expert * (2 * inter_dim * model_dim) +
+                                               (inter_dim + i) * model_dim;
+                    gate_acc[g] += xv * static_cast<float>(w_gate[k]);
+                    up_acc[g] += xv * static_cast<float>(w_up[k]);
+                }
+            }
+        }
+    }
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        gate_smem[g][threadIdx.x] = gate_acc[g];
+        up_smem[g][threadIdx.x] = up_acc[g];
+    }
+    __syncthreads();
+
+    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
+    {
+        if(threadIdx.x < stride)
+        {
+            for(int g = 0; g < group_size; ++g)
+            {
+                gate_smem[g][threadIdx.x] += gate_smem[g][threadIdx.x + stride];
+                up_smem[g][threadIdx.x] += up_smem[g][threadIdx.x + stride];
+            }
+        }
+        __syncthreads();
+    }
+
+    if(threadIdx.x != 0)
+        return;
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        int i = i_base + g;
+        if(i < inter_dim)
+        {
+            float gate_val = gate_smem[g][0];
+            float up_val = up_smem[g][0];
+            float silu = gate_val / (1.0f + expf(-gate_val));
+            act_out[route * inter_dim + i] = hip_bfloat16(silu * up_val);
+        }
+    }
+}
+
+template <int group_size, bool down_is_shuffled>
+__global__ void fmoe_g1u1_bf16_small_m_stage2_kernel(const hip_bfloat16* __restrict__ act,
+                                                         const hip_bfloat16* __restrict__ down,
+                                                         const int32_t* __restrict__ topk_ids,
+                                                         const float* __restrict__ topk_weights,
+                                                         hip_bfloat16* __restrict__ out,
+                                                         int token_cnt,
+                                                         int model_dim,
+                                                         int inter_dim,
+                                                         int expert_cnt,
+                                                         int topk)
+{
+    int token = blockIdx.x;
+    int h_base = blockIdx.y * group_size;
+    if(token >= token_cnt || h_base >= model_dim)
+        return;
+
+    __shared__ float smem[group_size][256];
+    float acc[group_size] = {};
+    int total = topk * inter_dim;
+    int down_nblock_stride = (inter_dim / 32) * 512;
+    for(int idx = threadIdx.x; idx < total; idx += blockDim.x)
+    {
+        int topk_idx = idx / inter_dim;
+        int i = idx - topk_idx * inter_dim;
+        int route = token * topk + topk_idx;
+        int expert = topk_ids[route];
+        if(expert < 0 || expert >= expert_cnt)
+            continue;
+
+        float route_weight = topk_weights[route];
+        const hip_bfloat16* act_route = act + route * inter_dim;
+        float act_val = static_cast<float>(act_route[i]) * route_weight;
+        for(int g = 0; g < group_size; ++g)
+        {
+            int h = h_base + g;
+            if(h < model_dim)
+            {
+                if constexpr(down_is_shuffled)
+                {
+                    int iblock = i / 32;
+                    int i_in_32 = i - iblock * 32;
+                    int ilane = i_in_32 / 8;
+                    int i8 = i_in_32 - ilane * 8;
+                    int down_row = expert * model_dim + h;
+                    int down_nblock = down_row / 16;
+                    int down_nintra = down_row - down_nblock * 16;
+                    int down_idx = down_nblock * down_nblock_stride + iblock * 512 +
+                                   ilane * 128 + down_nintra * 8 + i8;
+                    acc[g] += act_val * static_cast<float>(down[down_idx]);
+                }
+                else
+                {
+                    const hip_bfloat16* w2 =
+                        down + expert * (model_dim * inter_dim) + h * inter_dim;
+                    acc[g] += act_val * static_cast<float>(w2[i]);
+                }
+            }
+        }
+    }
+
+    for(int g = 0; g < group_size; ++g)
+        smem[g][threadIdx.x] = acc[g];
+    __syncthreads();
+
+    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
+    {
+        if(threadIdx.x < stride)
+        {
+            for(int g = 0; g < group_size; ++g)
+                smem[g][threadIdx.x] += smem[g][threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+
+    if(threadIdx.x != 0)
+        return;
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        int h = h_base + g;
+        if(h < model_dim)
+            out[token * model_dim + h] = hip_bfloat16(smem[g][0]);
+    }
+}
+
+AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
+    fmoe_g1u1_bf16_small_m,
+    (
+    aiter_tensor_t* out,
+    aiter_tensor_t* input,
+    aiter_tensor_t* gate,
+    aiter_tensor_t* down,
+    aiter_tensor_t* topk_ids,
+    aiter_tensor_t* topk_weights,
+    aiter_tensor_t* act_workspace,
+    int topk,
+    bool gate_is_shuffled,
+    bool down_is_shuffled,
+    hipStream_t stream),
+    (out,
+     input,
+     gate,
+     down,
+     topk_ids,
+     topk_weights,
+     act_workspace,
+     topk,
+     gate_is_shuffled,
+     down_is_shuffled,
+     stream))
+{
+    const HipDeviceGuard device_guard(input->device_id);
+    AITER_CHECK(out->dtype() == AITER_DTYPE_bf16, __func__, " only supports bf16 output");
+    AITER_CHECK(input->dtype() == AITER_DTYPE_bf16 && gate->dtype() == AITER_DTYPE_bf16 &&
+                    down->dtype() == AITER_DTYPE_bf16,
+                __func__,
+                " only supports bf16 input and weights");
+    AITER_CHECK(topk_ids->dtype() == AITER_DTYPE_i32, __func__, " topk_ids must be int32");
+    AITER_CHECK(topk_weights->dtype() == AITER_DTYPE_fp32, __func__, " topk_weights must be fp32");
+    AITER_CHECK(act_workspace->dtype() == AITER_DTYPE_bf16,
+                __func__,
+                " act_workspace must be bf16");
+
+    int token_cnt = input->size(0);
+    int model_dim = input->size(1);
+    int expert_cnt = gate->size(0);
+    int inter_dim = down->size(2);
+    AITER_CHECK(gate->size(1) == inter_dim * 2,
+                __func__,
+                " expects G1U1 gate shape [E, 2*inter_dim, model_dim]");
+    AITER_CHECK(gate->size(2) == model_dim && down->size(1) == model_dim,
+                __func__,
+                " model_dim mismatch");
+    AITER_CHECK(topk_ids->size(0) == token_cnt && topk_ids->size(1) == topk,
+                __func__,
+                " topk_ids shape mismatch");
+    AITER_CHECK(topk_weights->size(0) == token_cnt && topk_weights->size(1) == topk,
+                __func__,
+                " topk_weights shape mismatch");
+    AITER_CHECK(act_workspace->size(0) == token_cnt * topk && act_workspace->size(1) == inter_dim,
+                __func__,
+                " act_workspace shape mismatch");
+
+    constexpr int threads = 256;
+    constexpr int group_size = 8;
+    dim3 grid1(token_cnt * topk, (inter_dim + group_size - 1) / group_size);
+    if(gate_is_shuffled)
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, true>),
+                           grid1,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(input->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(gate->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<hip_bfloat16*>(act_workspace->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    else
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, false>),
+                           grid1,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(input->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(gate->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<hip_bfloat16*>(act_workspace->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    HIP_CALL_LAUNCH(hipGetLastError());
+
+    dim3 grid2(token_cnt, (model_dim + group_size - 1) / group_size);
+    if(down_is_shuffled)
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, true>),
+                           grid2,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(act_workspace->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(down->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<const float*>(topk_weights->ptr),
+                           reinterpret_cast<hip_bfloat16*>(out->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    else
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, false>),
+                           grid2,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(act_workspace->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(down->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<const float*>(topk_weights->ptr),
+                           reinterpret_cast<hip_bfloat16*>(out->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    HIP_CALL_LAUNCH(hipGetLastError());
+}
 
 AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
     fmoe,

--- a/op_tests/test_moe_small_m_direct.py
+++ b/op_tests/test_moe_small_m_direct.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.fused_moe import fused_moe, torch_moe
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.flydsl.moe_common import GateMode
+from aiter.test_common import checkAllclose
+
+
+pytestmark = pytest.mark.skipif(
+    get_gfx() != "gfx1201",
+    reason="gfx1201 small-M direct MoE coverage",
+)
+
+
+def _make_balanced_topk(token: int, topk: int, expert: int):
+    rows = torch.arange(token, device="cuda", dtype=torch.int32)[:, None]
+    slots = torch.arange(topk, device="cuda", dtype=torch.int32)[None, :]
+    topk_ids = (rows * topk + slots) % expert
+    topk_weights = torch.rand((token, topk), dtype=torch.float32, device="cuda")
+    topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+    return topk_ids.contiguous(), topk_weights.contiguous()
+
+
+@pytest.mark.parametrize("token", [1, 2, 3, 4, 8, 16])
+@pytest.mark.parametrize("inter_dim", [128, 256])
+@pytest.mark.parametrize(
+    "preshuffle_w1,preshuffle_w2",
+    [(False, False), (True, False), (True, True)],
+)
+def test_bf16_g1u1_small_m_direct(token, inter_dim, preshuffle_w1, preshuffle_w2):
+    torch.manual_seed(2026 + token + inter_dim)
+    model_dim = 2048
+    expert = 256
+    topk = 8
+
+    hidden_states = torch.randn(
+        (token, model_dim), dtype=dtypes.bf16, device="cuda"
+    )
+    w1 = torch.randn(
+        (expert, inter_dim * 2, model_dim), dtype=dtypes.bf16, device="cuda"
+    )
+    w2 = torch.randn(
+        (expert, model_dim, inter_dim), dtype=dtypes.bf16, device="cuda"
+    )
+    topk_ids, topk_weights = _make_balanced_topk(token, topk, expert)
+    w1_input = shuffle_weight(w1, layout=(16, 16)) if preshuffle_w1 else w1
+    w2_input = shuffle_weight(w2, layout=(16, 16)) if preshuffle_w2 else w2
+
+    actual = fused_moe(
+        hidden_states,
+        w1_input,
+        w2_input,
+        topk_weights,
+        topk_ids,
+        activation=aiter.ActivationType.Silu,
+        quant_type=aiter.QuantType.No,
+        dtype=dtypes.bf16,
+        gate_mode=GateMode.SEPARATED.value,
+    )
+    expected = torch_moe(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        activation=aiter.ActivationType.Silu,
+    )
+
+    checkAllclose(actual, expected, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
## Motivation

Enable Qwen3.6 35B-A3B BF16 AITER MoE serving on gfx1201/RDNA4 systems such as Navi48/R9700S.

Currently, setting `VLLM_ROCM_USE_AITER_MOE=1` for Qwen3.6 35B-A3B on gfx1201 can route small decode MoE shapes into AITER paths that do not have a valid gfx1201 kernel, making AITER MoE unusable for this model family. The observed serving failure is:

```text
RuntimeError: wrong! device_gemm with the specified compilation parameters does not support this GEMM problem
```

This PR adds the missing BF16 G1U1 small-token-count tier with a guarded direct HIP path for:

```text
M in {1, 2, 4, 8, 16}
inter_dim in {128, 256}
model_dim = 2048
num_experts = 256
topk = 8
```

This is part of the Qwen3.6 35B-A3B gfx1201 AITER MoE enablement stack:

- Issue: <https://github.com/ROCm/aiter/issues/4492>
- Dependency: <https://github.com/ROCm/aiter/pull/4385>
- Follow-up PR2: gfx1201 Qwen3.6 35B-A3B FMoE config data, <https://github.com/ROCm/aiter/pull/4815>
- Follow-up PR3: gfx1201 BF16 G1U1 selected large-M Triton MoE path, <https://github.com/ROCm/aiter/pull/5059>

## Technical Details

This PR adds `fmoe_g1u1_bf16_small_m`, a direct two-kernel path for the narrow unquantized BF16 G1U1 case.

Source files:

- Python dispatch: `aiter/fused_moe.py`
- Python op binding: `aiter/ops/moe_op.py`
- HIP entrypoint and kernels: `csrc/py_itfs_cu/asm_fmoe.cu`
- Focused test: `op_tests/test_moe_small_m_direct.py`

Implementation summary:

- Stage 1 computes `Silu(gate) * up` into a BF16 activation workspace.
- Stage 2 applies the down projection and top-k weighted accumulation.
- The path bypasses general MoE sorting and CK grouped GEMM for this small-token-count case only.
- The path accepts canonical W1/W2 and the standard AITER `shuffle_weight(..., layout=(16,16))` W1/W2 runtime layout.
- A narrow early Python fast path avoids the generic custom-op wrapper overhead for this exact small-M case.

The guard remains limited to:

- gfx1201 only
- BF16 activations and weights
- unquantized MoE
- Silu / G1U1
- no expert parallel mask
- no bias
- no hidden/intermediate padding
- no quant scales
- no routed-weight-on-input

## Test Plan

### Correctness

Correctness coverage uses a focused gfx1201 unit test:

```bash
python3 -m pytest -q op_tests/test_moe_small_m_direct.py
```

The test covers:

- `M in {1,2,3,4,8,16}` for correctness coverage
- `inter_dim in {128,256}`
- `model_dim = 2048`
- `num_experts = 256`
- `topk = 8`
- `activation = Silu`
- `quant_type = No`
- canonical W1/W2, preshuffled W1 with canonical W2, and standard AITER preshuffled W1/W2 layout

### Kernel-Level Performance

Kernel-level performance compares this AITER path against the vLLM Triton MoE path using the same BF16 hidden states, weights, routing inputs, and top-k weights.

AITER path under test:

- The benchmark helper imports `aiter.fused_moe.fused_moe` as `aiter_fused_moe`.
- For the PR1-covered shapes, `aiter_fused_moe(...)` dispatches into the guarded PR1 fast path `fused_moe_g1u1_bf16_small_m_direct`.
- The direct HIP kernels are `fmoe_g1u1_bf16_small_m_stage1_kernel` and `fmoe_g1u1_bf16_small_m_stage2_kernel`.

Exact AITER call under test:

```python
from aiter.fused_moe import fused_moe as aiter_fused_moe

def run_aiter():
    return aiter_fused_moe(
        hidden,
        w1_aiter,
        w2_aiter,
        weights,
        ids,
        activation=aiter.ActivationType.Silu,
        quant_type=aiter.QuantType.No,
        dtype=dtypes.bf16,
    )
```

vLLM baseline path under test:

- The benchmark helper imports `vllm.model_executor.layers.fused_moe.fused_moe.fused_experts`.
- This exercises the vLLM unquantized Triton MoE path with AITER disabled.

Exact vLLM call under test:

```python
from vllm.model_executor.layers.fused_moe.activation import MoEActivation
from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts

def run_vllm():
    return fused_experts(
        hidden,
        w1,
        w2,
        weights,
        ids,
        activation=MoEActivation.SILU,
        global_num_experts=expert,
    )
```

Exact latency timing used for both paths `fn() represents the functions described above`:

```python
def bench(fn, warm: int, iters: int) -> tuple[float, float]:
    for _ in range(warm):
        fn()
    torch.cuda.synchronize()

    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)
    times = []
    for _ in range(iters):
        start.record()
        fn()
        end.record()
        torch.cuda.synchronize()
        times.append(start.elapsed_time(end) * 1000.0)
    return statistics.mean(times), statistics.median(times)
```

### End-to-End Serving

End-to-end serving coverage uses the combined AITER MoE enablement stack (current PR + <https://github.com/ROCm/aiter/pull/4815> + <https://github.com/ROCm/aiter/pull/5059>) with the native vLLM SLO-goodput benchmark, comparing:

- `VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=0`
- `VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1`

Note: 
Request goodput here means completed requests per second at a point where `p99 TTFT <= 1000 ms`; offered request rate is not used as the score.


BF16 serving workloads:

| Parallelism | Prompt -> output |
|---|---|
| TP2/PP2 | 2K -> 1K |
| TP2/PP2 | 3K -> 1K |
| TP2/PP2 | 4K -> 2K |
| TP4/PP1 | 2K -> 1K |
| TP4/PP1 | 3K -> 1K |
| TP4/PP1 | 4K -> 2K |

Representative native vLLM goodput client command used by the end-to-end benchmark driver:

```bash
vllm bench serve \
  --backend vllm \
  --model Qwen/Qwen3.6-35B-A3B \
  --base-url http://127.0.0.1:8000 \
  --dataset-name random \
  --random-input-len 3000 \
  --random-output-len 1000 \
  --request-rate 1.2 \
  --num-prompts 360 \
  --seed 0 \
  --burstiness 1.0 \
  --goodput ttft:1000 \
  --percentile-metrics ttft,tpot,itl,e2el \
  --metric-percentiles 99 \
  --save-result \
  --save-detailed
```

The actual end-to-end runs were launched through the local helper below, which creates the run, executes the adaptive request-rate search, repeats the boundary points, and records the confirmed goodput:

```bash
python3 scripts/run_slo_goodput_ab.py \
  --source-scan <existing-guidellm-scan-id> \
  --initial-rates <case-specific-rate-list> \
  --max-rate <case-specific-max-rate> \
  --overload-rate <case-specific-overload-rate>
```

## Test Result

### Correctness Result

Correctness result on gfx1201:

```text
36 passed
```

### Kernel-Level Performance Result

Kernel-level performance result from the Qwen3.6 35B-A3B BF16 small-token-count harness:

| inter_dim | M | AITER mean us | vLLM mean us | Latency improvement vs vLLM |
|---:|---:|---:|---:|---:|
| 128 | 1 | 37.200 | 66.434 | 44.0% |
| 128 | 2 | 58.512 | 73.229 | 20.1% |
| 128 | 4 | 76.748 | 86.628 | 11.4% |
| 128 | 8 | 197.776 | 244.831 | 19.2% |
| 128 | 16 | 345.678 | 396.280 | 12.8% |
| 256 | 1 | 59.573 | 71.147 | 16.3% |
| 256 | 2 | 83.714 | 86.815 | 3.6% |
| 256 | 4 | 202.990 | 243.092 | 16.5% |
| 256 | 8 | 357.258 | 408.466 | 12.5% |
| 256 | 16 | 635.275 | 688.031 | 7.7% |

All valid target rows beat the vLLM Triton `fused_experts` baseline in this kernel-level benchmark.

### End-to-End Serving Result

Current native vLLM SLO-goodput serving results for the combined AITER MoE enablement stack (current PR + <https://github.com/ROCm/aiter/pull/4815> + <https://github.com/ROCm/aiter/pull/5059>) are:

| Case | `AITER_MOE_OFF` p99 TTFT / p99 E2E (ms) | `AITER_MOE_ON` p99 TTFT / p99 E2E (ms) | `AITER_MOE_OFF` goodput (req/s) | `AITER_MOE_ON` goodput (req/s) | Delta | Winner |
|---|---:|---:|---:|---:|---:|---|
| TP2/PP2 `2K -> 1K` | 608.9 / 77315.2 | 917.6 / 94040.5 | 0.6725 | 0.8417 | +25.15% | `AITER_MOE_ON` |
| TP2/PP2 `3K -> 1K` | 765.7 / 70779.5 | 591.5 / 65365.9 | 0.5282 | 0.5388 | +2.01% | `AITER_MOE_ON` |
| TP2/PP2 `4K -> 2K` | 902.8 / 104650.2 | 323.0 / 115361.9 | 0.0965 | 0.1901 | +96.96% | `AITER_MOE_ON` |
| TP4/PP1 `2K -> 1K` | 502.6 / 63771.6 | 573.1 / 64474.9 | 1.3556 | 1.4829 | +9.39% | `AITER_MOE_ON` |
| TP4/PP1 `3K -> 1K` | 613.1 / 52366.2 | 654.0 / 52741.0 | 1.0411 | 1.1683 | +12.22% | `AITER_MOE_ON` |
| TP4/PP1 `4K -> 2K` | 758.3 / 125924.9 | 786.7 / 123351.5 | 0.4072 | 0.4537 | +11.4% | `AITER_MOE_ON` |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
