### PR TITLE
fix: LL proto ar dispatch

### DIFF
--- a/csrc/include/custom_all_reduce_gfx1250.cuh
+++ b/csrc/include/custom_all_reduce_gfx1250.cuh
@@ -110,10 +110,10 @@ DINLINE opus::fp32_t downcast_s<opus::fp32_t>(opus::fp32_t val)
 // gfx1250 AR supports world_size <= 4; size scratch for the max.
 constexpr int    kLLMaxRanks       = 4;
 // Route to LL when bytes <= this (matches RCCL DDA_ALLREDUCE_LL_THRESHOLD).
-constexpr size_t kLLArMaxBytes     = 131072;            // 128 KiB
+constexpr size_t kLLArMaxBytes     = 4194304;           // 4 MiB
 // Hard per-message payload cap (one slot). Comfortably above the routing
 // threshold so all dtypes at <=128 KiB fit.
-constexpr size_t kLLScratchCapBytes = 262144;           // 256 KiB
+constexpr size_t kLLScratchCapBytes = 4194304;          // 4 MiB
 // Per-rank staging slot capacity, in 8-byte packets.
 constexpr size_t kLLPackCapacity   = kLLScratchCapBytes / 8;  // 32768
 
@@ -219,7 +219,7 @@ DINLINE void ll_load_b128(
 // double-buffered (bank = epoch & 1); the per-epoch flag disambiguates stale
 // lines, so no clearing is needed and it survives CUDA-graph replay.
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(256, 2) ar_ll_gfx1250(
+__global__ void __launch_bounds__(512, 1) ar_ll_gfx1250(
     T* const* __restrict__ peer_scratch, // ngpus scratch bases (device table)
     T* __restrict__ recvbuff,
     const T* __restrict__ sendbuff,
@@ -1082,7 +1082,7 @@ public:
         const size_t bytes = (size_t)numel * sizeof(T);
         const size_t nPk   = bytes >> 3; // 8 payload bytes per packet
 
-        constexpr int threads = 256;
+        const int threads = (bytes < 65536) ? 512 : 256;
         int blocks = std::min<int>(kMaxBlocks, (int)((nPk + threads - 1) / threads));
         if(blocks < 1)
             blocks = 1;

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce.py
@@ -224,8 +224,9 @@ parser.add_argument(
     "-s",
     "--shape",
     type=dtypes.str2tuple,
+    action="append",
     default=None,
-    help="shape, e.g. -s 128,8192",
+    help="shape (repeatable), e.g. -s 16,7168 -s 32,7168",
 )
 parser.add_argument(
     "-t",
@@ -269,7 +270,7 @@ if __name__ == "__main__":
     else:
         test_dtypes = [dtypes.d_dtypes[args.dtype]]
     if args.shape is not None:
-        test_shapes = [args.shape]
+        test_shapes = args.shape
     else:
         test_shapes = l_shape
     if args.tp_size is not None:


### PR DESCRIPTION
  ## Motivation

  DeepSeek decode uses allreduce shapes `(16, 7168)` and `(32, 7168)` bf16 (224/448 KB). These fell through to the barrier-based `ar_gfx1250_naive_unroll4`
  because the LL threshold was only 128 KiB. Raise it so these cases route to the faster flag-in-data `ar_ll_gfx1250` kernel.

  ## Technical Details

  Changes in `csrc/include/custom_all_reduce_gfx1250.cuh`:

  - `kLLArMaxBytes`: 128 KiB → 4 MiB
  - `kLLScratchCapBytes`: 256 KiB → 4 MiB (scratch capacity to match)
  - `allreduce_ll` block size: `bytes < 65536` → 512 threads, otherwise 256
  - `ar_ll_gfx1250` `__launch_bounds__`: `(256, 2)` → `(512, 1)`

  ## Test Plan

  python op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce.py
    -s 16,7168 -s 32,7168 -d bf16 -g true -t 4 --check-arch

  ## Test Result

  | tp_size | shape      | dtype          | size_kb | min_us  | max_us  | err         |
  |--------:|:-----------|:---------------|--------:|--------:|--------:|------------:|
  |       4 | (16, 7168) | torch.bfloat16 |     224 |  8.884  |  9.172  | 0.000183    |
  |       4 | (32, 7168) | torch.bfloat16 |     448 | 10.066  | 10.415  | 0.000166    |

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.