### PR TITLE
[Bugfix] Disable cpp_itfs sampling on ROCm 10

### DIFF
--- a/csrc/cpp_itfs/sampling/__init__.py
+++ b/csrc/cpp_itfs/sampling/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""JIT-compiled sampling kernels."""
+
+import os
+import re
+
+import torch
+
+
+def _get_rocm_major_version() -> int | None:
+    version = os.environ.get("AITER_ROCM_VERSION") or getattr(
+        torch.version, "hip", None
+    )
+    match = re.match(r"\s*(\d+)", version or "")
+    return int(match.group(1)) if match else None
+
+
+_rocm_major_version = _get_rocm_major_version()
+if _rocm_major_version is not None and _rocm_major_version >= 10:
+    raise ImportError(
+        "AITER cpp_itfs sampling is disabled on ROCm 10 and later because "
+        "csrc/cpp_itfs/sampling/sampling.cuh is not compatible with this toolchain."
+    )

--- a/op_tests/test_sampling.py
+++ b/op_tests/test_sampling.py
@@ -7,7 +7,13 @@ import pytest
 import torch
 from scipy import stats
 
-from aiter.ops import sampling  # noqa: F401
+try:
+    from aiter.ops import sampling
+except ImportError as exc:
+    if "cpp_itfs sampling is disabled on ROCm 10" not in str(exc):
+        raise
+    sampling = None
+    pytestmark = pytest.mark.skip(reason=str(exc))
 
 torch.set_default_device("cuda")
 


### PR DESCRIPTION
## Summary
- disable the `cpp_itfs` sampling package on ROCm 10 and later before the incompatible `sampling.cuh` JIT path is reached
- raise `ImportError` so callers can use their existing fallback path
- skip the sampling test suite only for this expected ROCm 10 incompatibility

## Test plan
- [x] Simulate ROCm 10 with `AITER_ROCM_VERSION=10.0` (352 sampling tests skipped cleanly)
- [x] Run a ROCm 7.2 top-k renormalization smoke test (1 passed)
- [x] Run Black 26.5.1 and Ruff 0.16.0 on changed files

Made with [Cursor](https://cursor.com)