### PR TITLE
[detorch] remove vestigial py_itfs_common.h includes (non-CK); top_k_per_row now torch-free

### DIFF
--- a/csrc/kernels/fused_ar_mhc_post.cu
+++ b/csrc/kernels/fused_ar_mhc_post.cu
@@ -6,7 +6,6 @@
 #include "mhc.h"
 #include "aiter_enum.h"
 #include "aiter_hip_common.h"
-#include "py_itfs_common.h"
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <c10/core/ScalarType.h>
 

--- a/csrc/py_itfs_cu/asm_mha_bwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_bwd.cu
@@ -3,7 +3,6 @@
 
 #include <torch/all.h>
 #include <ATen/hip/HIPContext.h>
-#include "py_itfs_common.h"
 #include "mha_common.h"
 #include "mha_bwd.h"
 

--- a/csrc/py_itfs_cu/asm_mha_fwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_fwd.cu
@@ -3,7 +3,6 @@
 
 #include <torch/all.h>
 #include <ATen/hip/HIPContext.h>
-#include "py_itfs_common.h"
 #include "mha_common.h"
 
 #include "mha_fwd.h"

--- a/csrc/py_itfs_cu/asm_mha_varlen_bwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_varlen_bwd.cu
@@ -3,7 +3,6 @@
 
 #include <torch/all.h>
 #include <ATen/hip/HIPContext.h>
-#include "py_itfs_common.h"
 #include "mha_common.h"
 
 #include "mha_bwd.h"

--- a/csrc/py_itfs_cu/asm_mha_varlen_fwd.cu
+++ b/csrc/py_itfs_cu/asm_mha_varlen_fwd.cu
@@ -3,7 +3,6 @@
 
 #include <torch/all.h>
 #include <ATen/hip/HIPContext.h>
-#include "py_itfs_common.h"
 #include "mha_common.h"
 
 #include "mha_fwd.h"

--- a/csrc/py_itfs_cu/asm_topk_per_row_decode.cu
+++ b/csrc/py_itfs_cu/asm_topk_per_row_decode.cu
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #include "aiter_tensor.h"
-#include "py_itfs_common.h"
 
 struct __attribute__((packed)) TopKDecodeKernelArgs
 {

--- a/csrc/py_itfs_cu/asm_topk_per_row_prefill.cu
+++ b/csrc/py_itfs_cu/asm_topk_per_row_prefill.cu
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #include "aiter_tensor.h"
-#include "py_itfs_common.h"
 
 struct __attribute__((packed)) TopKPrefillKernelArgs
 {


### PR DESCRIPTION
## Summary

Removes every **vestigial** `#include "py_itfs_common.h"` from the **non-CK** TUs
that include it but reference **none** of its exported symbols. That header carries
an unguarded `#include <torch/all.h>`, so a stray include silently drags the whole
torch/ATen header tree into a module's JIT build.

Two kinds of benefit:

1. **Immediate torch-free win — `module_top_k_per_row`.** Its kernel TU was
   de-torched in #4702, but the two ASM sibling TUs
   (`asm_topk_per_row_{decode,prefill}.cu`) were missed — each included only
   `aiter_tensor.h` + `py_itfs_common.h`, so the header was their *sole* torch
   source. Removing it makes the entire module closure (13 headers) torch-free.
2. **Latent-regression removal — the rest.** `asm_mha_{fwd,bwd,varlen_fwd,varlen_bwd}.cu`
   and `fused_ar_mhc_post.cu` keep their own direct torch includes (they are still
   torch-bound), so this is not a compile-time win *today*. But it deletes the exact
   trap that left topk half-de-torched: once those modules are de-torched later, a
   leftover `py_itfs_common.h` would silently re-introduce `<torch/all.h>`.

## Why each removal is safe

| file | py_itfs_common symbols used | how it still gets what it needs |
|---|---|---|
| `asm_topk_per_row_{decode,prefill}.cu` | none | `aiter_tensor.h` (already included, line 3) pulls `aiter_hip_common.h` → `AITER_CHECK`/`HIP_CALL`/`HipDeviceGuard` + HIP runtime; **now torch-free** |
| `asm_mha_{fwd,bwd,varlen_fwd,varlen_bwd}.cu` | none | `torch/all.h` + `ATen/hip/HIPContext.h` remain (load-bearing); `getCurrentHIPStream` here is `at::hip::`, so no aiter_hip_common symbol was in play |
| `fused_ar_mhc_post.cu` | none | already `#include "aiter_hip_common.h"` directly (line 8); ATen/c10 includes remain |

`py_itfs_common.h`'s torch-typed exports (`torch_fp8` / `torch_fp4x2` / `t2ck` /
`torchDTypeToStr`) are used only by CK TUs that need torch at the boundary anyway;
those includes are left untouched (out of scope).

## Validation (in-container, gfx942 / ROCm 7.2.3)

- **`module_top_k_per_row`** — fresh JIT rebuild from a cleared build dir compiles clean; recursive include closure = 0 torch/ATen/c10 headers.
  - `op_tests/test_topk_per_row.py` (decode): all shapes match `torch.topk`; `[mb_workspace_reuse] PASS`.
  - `op_tests/test_topk_row_prefill.py` (prefill): standard **and** fast kernels `Passed`, `all_close_standard/all_close_fast == True`.
- **`module_fmha_v3_fwd`** — fresh rebuild clean (39.4s). `asm_mha_fwd.cu` is include-identical to the other three `asm_mha` TUs.
- **`module_fused_ar_mhc`** — fresh rebuild clean (36.5s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
