### PR TITLE
[Gluon][MLA] Deeper async-copy pipeline in the bh16 stage-1 decode loop

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx950/attention/mla.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx950/attention/mla.py
@@ -478,7 +478,10 @@ def _mla_gluon(
     for i in range(num_iter - 2):
         async_idx = (buf_idx + 1) % 2
 
-        gl.amd.cdna4.async_copy.wait_group(0)
+        # Retire just the oldest group, the previous trip's page copy, which is all
+        # the local load below reads. That trip's kv0 / kpe / kv1 stay in flight for
+        # the loads further down, so two KV blocks are resident at no extra LDS.
+        gl.amd.cdna4.async_copy.wait_group(3 if HAS_PE else 2)
         #### global load page number
         offs_n_page = start_n + BLOCK_N + offs_page_raw
         offs_page = batch_page_start + offs_n_page // PAGE_SIZE
@@ -522,6 +525,10 @@ def _mla_gluon(
             gl.amd.cdna4.async_copy.commit_group()
 
         #### dot, softmax, dot (part0)
+        # Retire the previous trip's kv0 / kpe / kv1, which these local loads read.
+        # Leaving three pending (two without PE) keeps this trip's own page and KV
+        # prefetches in flight through the MFMA and softmax block.
+        gl.amd.cdna4.async_copy.wait_group(3 if HAS_PE else 2)
         k_c = gl.amd.cdna4.async_copy.load_shared_relaxed(bufs_kv.index(buf_idx), mfma_layout_b)
         zeros = gl.zeros([BLOCK_H, BLOCK_N], dtype=gl.float32, layout=mfma_layout)
         qk = gl.amd.cdna4.mfma(q_nope, k_c.to(dtype), zeros)

--- a/aiter/ops/triton/_gluon_kernels/gfx950/attention/mla.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx950/attention/mla.py
@@ -53,7 +53,7 @@ from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 
 from aiter.ops.triton.utils._triton import arch_info
-from aiter.ops.triton.utils.device_info import get_num_xcds
+from aiter.ops.triton.utils.device_info import get_num_sms, get_num_xcds
 
 # fmt: off
 @gluon.jit
@@ -761,10 +761,13 @@ def _mla_softmax_reducev_kernel(
     USE_2D_VIEW: tl.constexpr,
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    D_SPLIT: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
-    q_pos = tl.program_id(2)
+    # Grid axis 2 packs (q_pos, head-dim slice).
+    q_pos = tl.program_id(2) // D_SPLIT
+    cur_d = tl.program_id(2) % D_SPLIT
 
     # Recompute this batch's seq len exactly as the decode kernel did, so we can
     # rederive which splits are empty. Stage-1 early-returns on empty splits
@@ -783,14 +786,18 @@ def _mla_softmax_reducev_kernel(
         tl.cdiv(cur_batch_seq_len, kv_len_per_split), NUM_KV_SPLITS
     )
 
-    offs_d_ckv = tl.arange(0, HEAD_DIM_CKV)
+    # Each program owns a disjoint BLOCK_D slice of the head dim and re-derives the
+    # same scalar lse statistics from the same Mid_lse vector, so slices never
+    # communicate. D_SPLIT=1 is the full-width kernel.
+    BLOCK_D: tl.constexpr = HEAD_DIM_CKV // D_SPLIT
+    offs_d_ckv = cur_d * BLOCK_D + tl.arange(0, BLOCK_D)
     offs_s = tl.arange(0, BLOCK_S)
     base_l = cur_batch * stride_l_b + q_pos * stride_l_qs + cur_head * stride_l_h
     base_ml = cur_batch * stride_ml_b + q_pos * stride_ml_qs + cur_head * stride_ml_h
 
     e_sum = 0.0
     e_max = -float("inf")
-    acc = tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
 
     # The split-KV LSE merge is associative, so instead of a serial dependent loop
     # over NUM_KV_SPLITS (latency-bound on ~batch*nhead workgroups), reduce BLOCK_S
@@ -809,7 +816,7 @@ def _mla_softmax_reducev_kernel(
             Logits + base_l + s_ids[:, None] * stride_l_s + offs_d_ckv[None, :],
             mask=s_mask[:, None],
             other=0.0,
-        )  # [BLOCK_S, HEAD_DIM_CKV]
+        )  # [BLOCK_S, BLOCK_D]
 
         tile_max = tl.max(lse, axis=0)  # scalar; masked/empty splits are -inf
         n_e_max = tl.maximum(e_max, tile_max)
@@ -820,12 +827,13 @@ def _mla_softmax_reducev_kernel(
         e_sum = e_sum * old_scale + tl.sum(w, axis=0)
         e_max = n_e_max
 
-    out = acc / e_sum if e_sum > 0.0 else tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
+    out = acc / e_sum if e_sum > 0.0 else tl.zeros([BLOCK_D], dtype=tl.float32)
     tl.store(
         O + cur_batch * stride_o_b + q_pos * stride_o_qs + cur_head * stride_o_h + offs_d_ckv,
         out,
     )
-    if HAS_FINAL_LSE:
+    # Every head-dim slice derived the same lse; slice 0 owns the single store.
+    if HAS_FINAL_LSE and cur_d == 0:
         tl.store(
             Final_lse + cur_batch * stride_fl_b + q_pos * stride_fl_qs + cur_head * stride_fl_h,
             e_max + tl.log(e_sum),
@@ -1132,8 +1140,22 @@ def mla_gluon(
         return o, final_lse
 
     # Stage-2: reduce per-split (acc, lse) into o (and lse when return_lse).
-    # grid axis 2 is q_pos (qlen). o uses the caller's layout (3-D or 4-D).
-    grid_reduce = (batch_size, nhead, qlen)
+    #
+    # The reduce grid is otherwise batch*nhead*qlen, which for plain decode at batch
+    # 1 is 12 workgroups on a 256-CU part, so tile the head dim across D_SPLIT
+    # programs while that grid is narrower than the machine. Every slice repeats the
+    # same lse derivation, so grid width is what pays: +8.6% of the decode op at
+    # batch 1, +3.0% at batch 2, +0.6% at batch 4. Back off when the head dim does
+    # not divide evenly or the slice would fall under 16 elements.
+    RED_D_SPLIT = 1
+    while RED_D_SPLIT < 8 and batch_size * nhead * qlen * RED_D_SPLIT < get_num_sms():
+        RED_D_SPLIT *= 2
+    while RED_D_SPLIT > 1 and (
+        head_dim_ckv % RED_D_SPLIT or head_dim_ckv // RED_D_SPLIT < 16
+    ):
+        RED_D_SPLIT //= 2
+    # grid axis 2 packs (q_pos, head-dim slice). o keeps the caller's layout.
+    grid_reduce = (batch_size, nhead, qlen * RED_D_SPLIT)
     sl_b, sl_qs, sl_h, sl_split, _ = logits_buf.stride()
     _mla_softmax_reducev_kernel[grid_reduce](
         logits_buf,
@@ -1161,7 +1183,8 @@ def mla_gluon(
         USE_2D_VIEW=use_2d_view,
         BLOCK_S=min(64, triton.next_power_of_2(NUM_KV_SPLITS)),
         BLOCK_N=BLOCK_N,
-        num_warps=8,
+        D_SPLIT=RED_D_SPLIT,
+        num_warps=8 if RED_D_SPLIT == 1 else 4,
     )
 
     return o, final_lse

--- a/aiter/ops/triton/_gluon_kernels/gfx950/attention/mla.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx950/attention/mla.py
@@ -107,6 +107,8 @@ def _mla_gluon(
     # --- dsv4-prefill knobs ---
     HAS_PE: gl.constexpr,
     HAS_ATTN_SINK: gl.constexpr,
+    # bh16 only: grid axes 0 and 1 carry (split, batch) rather than (batch, split).
+    SPLIT_MAJOR: gl.constexpr = False,
 ):
     # Grid mapping: bh64 uses 3-D XCD-aware multi-batch; bh16bn64 and bh16bn128
     # use 2-D (batch, split) — for batch_size=1 this is (1, NUM_KV_SPLITS).
@@ -125,8 +127,12 @@ def _mla_gluon(
         # identical to the original 2-D+qlen mapping. For nhead > 16 (e.g. 96) the
         # head range is tiled into NUM_M_BLOCKS = cdiv(NHEAD, BLOCK_H) blocks of 16.
         NUM_M_BLOCKS: gl.constexpr = (NHEAD + BLOCK_H - 1) // BLOCK_H
-        cur_batch = gl.program_id(0)
-        split_kv_id = gl.program_id(1)
+        if SPLIT_MAJOR:
+            split_kv_id = gl.program_id(0)
+            cur_batch = gl.program_id(1)
+        else:
+            cur_batch = gl.program_id(0)
+            split_kv_id = gl.program_id(1)
         cur_head_id = gl.program_id(2) % NUM_M_BLOCKS
         q_pos = gl.program_id(2) // NUM_M_BLOCKS
 
@@ -1041,6 +1047,7 @@ def mla_gluon(
         final_lse = None
         stride_final_lse_b, stride_final_lse_s, stride_final_lse_h = 0, 0, 0
 
+    split_major = False
     if REGIME == "bh64":
         grid = (
             NUM_XCDS,
@@ -1051,7 +1058,21 @@ def mla_gluon(
         # Grid axis 2 carries (head_block, q_pos): cdiv(nhead, BLOCK_H) head blocks
         # times qlen query positions. For nhead <= 16 this is just qlen (one head
         # block), i.e. the original grid-axis MTP mapping.
-        grid = (batch_size, NUM_KV_SPLITS, triton.cdiv(nhead, BLOCK_H) * qlen)
+        #
+        # Axes 0 and 1 carry (split, batch) when the split count is a multiple of the
+        # XCD count, which is what keeps the linearized workgroup id congruent mod
+        # NUM_XCD for every batch: all requests' workgroups for one split then land
+        # on the same XCD and share its L2, which pays under prefix caching where
+        # they read the same KV pages. Relabeling only, same KV range per program.
+        num_xcds = get_num_xcds()
+        split_major = (
+            batch_size > 1 and NUM_KV_SPLITS > 1 and NUM_KV_SPLITS % num_xcds == 0
+        )
+        head_q_axis = triton.cdiv(nhead, BLOCK_H) * qlen
+        if split_major:
+            grid = (NUM_KV_SPLITS, batch_size, head_q_axis)
+        else:
+            grid = (batch_size, NUM_KV_SPLITS, head_q_axis)
     stride_page_bs = page_table.stride(0) if use_2d_view else 0
 
     _mla_gluon[grid](
@@ -1103,6 +1124,7 @@ def mla_gluon(
         QLEN=qlen,
         HAS_PE=has_pe,
         HAS_ATTN_SINK=has_attn_sink,
+        SPLIT_MAJOR=split_major,
     )
 
     if NUM_KV_SPLITS == 1:


### PR DESCRIPTION
This is a follow-up PR to PR #4555, #4509, #4507.

**On this baseline the PR is worth about +10% of the MLA decode kernel at concurrency 1, 24 and 48** —
commit 3 carries the first, the wait change carries the other two at +10.5% each — **and it costs 2.2%
at concurrency 8.** Every one of those figures reproduces in every round of every run. The regression is
the more important half of that sentence and is quantified in section 3.

**Every number here is kernel-level — one decode op, device time, cold.** 

## Motivation

PR #4555 restored split parallelism and shortened the stage-2 merge, which moved the bottleneck rather
than removing it. Its policy gives each request roughly `256/batch` splits, trading split count against
how far each stage-1 program has to walk, and that leaves a gap at each end of the trade. One PR covers
both because each gap only appears at its own end of the split range.

**High concurrency: few splits, so a long loop, and stage-1 waiting on memory.** At 48 requests each gets
5 splits, so one program walks 213 KV blocks — and that loop drained every outstanding copy on every
iteration when only one of them was needed yet. Only one KV block is ever in flight, so a 213-iteration
loop runs latency-bound instead of bandwidth-bound. Commit 1 closes this, the larger of the two gaps.

**Batch 1: splits are plentiful, but stage-2 has almost nothing to run them on.** Its grid is one
workgroup per request, head and query position — 12 of them on a 256-CU part at nhead 12 — so shortening
the merge chain cannot help when the idle machine is what costs the time. Commit 3 widens that grid
instead, but only while the machine is in fact idle, which is why it is gated: tiling unconditionally
made nhead-64/128 shapes, whose grid already runs into the thousands of programs, 4.2% slower.

## Technical Details

**1. Two partial waits in the stage-1 loop.** The top of the loop needs only one of the four copies the
previous iteration issued, the page number, but it drained all four. Retire just that one there and defer
the rest to the point where their data is actually read. Two KV blocks are then in flight at no extra LDS,
which is the granularity both epilogues already use. The prologue leaves the same copies outstanding as a
steady-state iteration, and the set at loop exit is unchanged, so neither the first iteration nor the
epilogues change behaviour. This is the one change in code that every regime runs, `bh64` included.

**2. Split-major stage-1 grid.** Swap two grid axes for `bh16` so that all requests' workgroups for a
given split get consecutive ids. They then land on one XCD and share its L2, and under prefix caching
they are reading the same KV rows. Only taken when batch > 1 and the split count is a multiple of the XCD
count, which is what makes that hold for every request rather than some. Pure relabelling — same KV range
per program, same reduction order, bit-identical output.

**3. Head-dim-tiled stage-2 reduce.** Split the 512-wide head dimension across several programs, each
owning a disjoint slice of the output and re-deriving the same scalar statistics independently, so slices
never communicate and the untiled case is today's kernel. Because each slice repeats that derivation,
tiling buys occupancy by duplicating work, so the launcher tiles only while the grid would otherwise
leave CUs idle — up to 8 ways, and less when the head dimension will not divide evenly. Stage-2's warp
count follows the tiling, with the untiled path keeping `main`'s 8. That coupling matters: at batch 1 the
warp count is the difference between +33.6% and +18.5% of stage-2, and at concurrency 48 between −4.5%
and −19.1%.


## Test Plan

**One process, one kernel file.** All three commits are switches on a single generated kernel, so every
leg runs against the same allocations — no JIT-cache or allocator drift of the kind that swapping whole
files between processes invites. Both endpoints are checked against the real kernel files every run:
everything off reproduces `main` to within 1 ulp, everything on reproduces #4509 rebased bitwise.

**Timing.** Device time from CUDA events over a captured graph, with a 512 MB cache flush before each cold
sample. 5 rounds, legs rotated between them, each ratio formed inside its own round; the reported value is
the median, and every number quoted had all 5 rounds on the same side of zero.

**Workload.** 68,000 tokens, a 63,240-token prefix shared across 8 requests, nhead 12 (96 at TP8), page
size 1, and a full-size KV pool so the 64-bit addressing path is taken. Concurrency 1–48 at whatever split
count the policy picks, plus a sweep that sets the split count independently of batch.

**aiter's own MLA tests**, both configs, against unpatched `main` back to back in the same container:

```bash
python op_tests/test_mla.py -c 327600 -b 8 -n 12,1 -d bf16 -kvd bf16
python op_tests/test_mla.py -c 16384 -b 64 128 -n 64,1 128,1 -d bf16 -kvd bf16
```

Both pass, 6 of 6 Gluon verdicts on each leg of the second config.

**Which regime gets what.** Commit 2 applies to `bh16` only. Commits 1 and 3 are in code every regime
runs, so the second command above is the one that covers `bh64` (nhead 64/128) — and there commit 3's gate
leaves stage-2 exactly as `main` has it, with timings level against unpatched `main`. That gate is the
whole point: tiling unconditionally, as this PR was first written, ran `bh64` 4.2% slower. Commit 1 is not
implicated, since reverting its waits leaves `bh64` where it was. Attributed by reverting one commit at a
time, with a second `main` process as the control for what this test's timing can resolve.

## Test Result

MI355X (gfx950, 256 CU), `rocm/vllm-dev@sha256:5aa7e626`.

### 1. Per-lever, whole decode op, 5-round median

`trips` is loop iterations per stage-1 program, `SEQ_LEN/splits/BLOCK_N` — the variable that governs
commit 1. The commit 3 column was measured before its occupancy guard, which keeps the full 8-way tiling
at concurrency 1–4 and reduces it above that, where the column is already ≤ +0.12%.


| conc | splits | trips | commit 3   | commit 1    | commit 2         | all three |
| ---- | ------ | ----- | ---------- | ----------- | ---------------- | --------- |
| 1    | 256    | 5     | **+8.60%** | +1.12%      | off — batch 1    | +10.08%   |
| 2    | 128    | 9     | +2.99%     | −0.05%      | +0.10%           | +3.05%    |
| 4    | 64     | 17    | +0.63%     | −0.35%      | +0.41%           | +1.15%    |
| 8    | 32     | 34    | +0.07%     | **−2.16%**  | +0.51%           | −0.36%    |
| 16   | 16     | 67    | +0.12%     | +5.47%      | −0.68%           | +5.23%    |
| 24   | 10     | 107   | +0.08%     | **+10.54%** | off — 10 % 8 ≠ 0 | +10.45%   |
| 48   | 5      | 213   | +0.02%     | **+10.54%** | off — 5 % 8 ≠ 0  | +10.30%   |


Two levers, active at opposite ends for unrelated reasons. Commit 3 is worth +8.6% at one request and
is spent by 4, since the split count halves with every doubling of concurrency and there is no merge
cost to attack below ~128 splits. Commit 1 is flat-to-negative low and +10.5% high, and nothing helps
at concurrency 4–8. The two ~10% ends differ 8× in absolute terms: 58.1 → 52.8 µs at concurrency 1
versus 436.8 → 396.0 µs at 48. Commit 1 at concurrency 24 / 48 across three independent runs:
+10.54 / +10.54%, +10.07 / +10.39%, +11.33 / +10.94%; concurrency 8 regressed in all three at
−2.16%, −2.56%, −2.07%.

### 2. Mechanism: the gain tracks loop depth, not concurrency

Split count forced at fixed batch, commit 1 only — the commit message's claim tested rather than
restated:


| splits | tok/split | trips | batch 8     | batch 48    |
| ------ | --------- | ----- | ----------- | ----------- |
| 2      | 34,000    | 532   | +12.03%     | +6.11%      |
| 4      | 17,000    | 266   | +13.97%     | +9.13%      |
| 8      | 8,500     | 133   | **+15.95%** | +9.54%      |
| 16     | 4,250     | 67    | +6.99%      | **+11.24%** |
| 32     | 2,125     | 34    | **−1.68%**  | +7.46%      |
| 64     | 1,062     | 17    | −1.38%      | +4.89%      |
| 128    | 531       | 9     | +0.64%      | +5.05%      |
| 256    | 265       | 5     | +1.79%      | +4.54%      |


The gain appears where the theory says it should and collapses where it says it should, and it is not a
function of batch: at 34 trips batch 8 loses 1.7% while batch 48 gains 7.5%. Batch 8 at 32 splits is
exactly one wave — 8 × 32 = 256 workgroups on 256 CUs — so there is neither trip depth nor a second wave
to hide the pipeline ramp behind, and the production policy happens to place concurrency 8 in that
pocket; the forced sweep reproduces −1.68% where the policy run measures −2.16%. I would rather a
reviewer judge this table than the headline, since a single point estimate could be a scheduling
accident while a dose-response curve with a sign flip where the mechanism predicts one is harder to
explain away.

### 3. Why commit 2 is in this PR

Commit 2 is here to make commit 1's concurrency-8 regression tolerable, and paired with it that is what
happens: commit 1 alone measures −2.56% there (per-round −2.1 −2.8 −2.7 −1.7 −1.6), with commit 2 −0.33%
(+0.1 −1.0 −0.4 −0.1 +0.2), so commit 2 recovers 2.2 of the 2.6 points. All three together read −0.46%.
The trade is 0.8 points at concurrency 16 (+5.7% → +4.9%), which I took because a regression at a
production point is worth more than an equal gain elsewhere — but it is a judgement call.

## AI assistance

This came out of [GEAK](https://github.com/AMD-AGI/GEAK), AMD's agentic GPU-kernel optimization
framework, running an end-to-end pass against a live Kimi-K3 TP8 server on 8× MI355X. The
measurements above were produced by and reviewed manually.

## Submission Checklist

- [x] Look over the contributing guidelines at [https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests).