### PR TITLE
feat(moe): consume prepared stage1 activation scales

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1380,14 +1380,33 @@ def _normalize_bias_for_kernel(
     return bias
 
 
+_PREPARED_STAGE1_SCALE_LAYOUT = "mx_e8m0_route_sbm32_preshuffled_v1"
+
+
 def _is_prepared_stage1_input(
     metadata: MOEMetadata,
     hidden_states: torch.Tensor,
     q_dtype_a: torch.dtype | None,
     a1_scale: torch.Tensor | None,
+    sorted_ids: torch.Tensor,
+    a1_scale_layout: str | None,
 ) -> bool:
+    """Recognize the sorted, 32-row-swizzled E8M0 stage-1 scale contract."""
+    if sorted_ids.ndim != 1:
+        return False
+    required_scale_rows = (sorted_ids.shape[0] + 31) // 32 * 32
+    for sorted_blocks in (
+        metadata.expected_sorted_blocks,
+        metadata.min_sorted_blocks,
+    ):
+        if sorted_blocks is not None:
+            required_scale_rows = max(
+                required_scale_rows,
+                sorted_blocks * metadata.block_m,
+            )
     return (
         metadata.prequant
+        and a1_scale_layout == _PREPARED_STAGE1_SCALE_LAYOUT
         and q_dtype_a == dtypes.fp8
         and hidden_states.dtype == dtypes.fp8
         and hidden_states.ndim == 2
@@ -1397,6 +1416,7 @@ def _is_prepared_stage1_input(
         and a1_scale.dtype == dtypes.fp8_e8m0
         and a1_scale.device == hidden_states.device
         and a1_scale.ndim == 2
+        and a1_scale.shape[0] >= required_scale_rows
         and a1_scale.shape[1] == hidden_states.shape[1] // 32
         and a1_scale.is_contiguous()
     )
@@ -2998,6 +3018,7 @@ def fused_moe_2stages(
     _metadata_transform: Callable | None = None,
     _stage1_extra_args: dict | None = None,
     _stage2_extra_args: dict | None = None,
+    _a1_scale_layout: str | None = None,
 ):
     quant_func = get_quant(quant_type)
     gate_mode = GateMode(gate_mode)
@@ -3033,7 +3054,14 @@ def fused_moe_2stages(
     )
     if _metadata_transform is not None:
         metadata = _metadata_transform(metadata)
-    if _is_prepared_stage1_input(metadata, hidden_states, q_dtype_a, a1_scale):
+    if _is_prepared_stage1_input(
+        metadata,
+        hidden_states,
+        q_dtype_a,
+        a1_scale,
+        sorted_ids,
+        _a1_scale_layout,
+    ):
         # The caller already prepared the stage-1 activation and its sorted
         # scale layout; consuming it directly avoids quantizing the same input
         # a second time.

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1380,7 +1380,28 @@ def _normalize_bias_for_kernel(
     return bias
 
 
-# TODO: remove this function once kernel handles padding in the runtime
+def _is_prepared_stage1_input(
+    metadata: MOEMetadata,
+    hidden_states: torch.Tensor,
+    q_dtype_a: torch.dtype | None,
+    a1_scale: torch.Tensor | None,
+) -> bool:
+    return (
+        metadata.prequant
+        and q_dtype_a == dtypes.fp8
+        and hidden_states.dtype == dtypes.fp8
+        and hidden_states.ndim == 2
+        and hidden_states.shape[1] % 32 == 0
+        and hidden_states.is_contiguous()
+        and a1_scale is not None
+        and a1_scale.dtype == dtypes.fp8_e8m0
+        and a1_scale.device == hidden_states.device
+        and a1_scale.ndim == 2
+        and a1_scale.shape[1] == hidden_states.shape[1] // 32
+        and a1_scale.is_contiguous()
+    )
+
+
 def _get_padding_for_flydsl(
     inter_dim_pad,
     model_dim_pad,
@@ -3012,7 +3033,12 @@ def fused_moe_2stages(
     )
     if _metadata_transform is not None:
         metadata = _metadata_transform(metadata)
-    if not metadata.prequant:
+    if _is_prepared_stage1_input(metadata, hidden_states, q_dtype_a, a1_scale):
+        # The caller already prepared the stage-1 activation and its sorted
+        # scale layout; consuming it directly avoids quantizing the same input
+        # a second time.
+        a1 = hidden_states
+    elif not metadata.prequant:
         a1 = hidden_states
         a1_scale = None
     elif (

--- a/op_tests/test_fused_moe_prequant.py
+++ b/op_tests/test_fused_moe_prequant.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from aiter import dtypes
+from aiter.fused_moe import MOEMetadata, _is_prepared_stage1_input
+
+
+@pytest.mark.parametrize(
+    (
+        "prequant",
+        "input_dtype",
+        "q_dtype",
+        "hidden_cols",
+        "scale_dtype",
+        "scale_cols",
+        "expected",
+    ),
+    [
+        (True, dtypes.fp8, dtypes.fp8, 32, dtypes.fp8_e8m0, 1, True),
+        (False, dtypes.fp8, dtypes.fp8, 32, dtypes.fp8_e8m0, 1, False),
+        (True, torch.bfloat16, dtypes.fp8, 32, dtypes.fp8_e8m0, 1, False),
+        (True, torch.bfloat16, torch.bfloat16, 32, dtypes.fp8_e8m0, 1, False),
+        (True, dtypes.fp8, dtypes.fp8, 32, None, 0, False),
+        (True, dtypes.fp8, dtypes.fp8, 32, torch.uint8, 1, False),
+        (True, dtypes.fp8, dtypes.fp8, 32, torch.float32, 1, False),
+        (True, dtypes.fp8, dtypes.fp8, 64, dtypes.fp8_e8m0, 1, False),
+    ],
+)
+def test_prepared_stage1_input_gate(
+    prequant: bool,
+    input_dtype: torch.dtype,
+    q_dtype: torch.dtype,
+    hidden_cols: int,
+    scale_dtype: torch.dtype | None,
+    scale_cols: int,
+    expected: bool,
+):
+    metadata = replace(
+        MOEMetadata(stage1=None, stage2=None, block_m=32, ksplit=0),
+        prequant=prequant,
+    )
+    hidden_states = torch.empty((3, hidden_cols), dtype=input_dtype)
+    scale = (
+        torch.empty((3, scale_cols), dtype=scale_dtype)
+        if scale_dtype is not None
+        else None
+    )
+
+    assert (
+        _is_prepared_stage1_input(metadata, hidden_states, q_dtype, scale) is expected
+    )

--- a/op_tests/test_fused_moe_prequant.py
+++ b/op_tests/test_fused_moe_prequant.py
@@ -1,56 +1,77 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-from dataclasses import replace
-
 import pytest
 import torch
 
 from aiter import dtypes
-from aiter.fused_moe import MOEMetadata, _is_prepared_stage1_input
+from aiter.fused_moe import (
+    _PREPARED_STAGE1_SCALE_LAYOUT,
+    MOEMetadata,
+    _is_prepared_stage1_input,
+)
+
+
+def _accepts_prepared_input(
+    *,
+    prequant=True,
+    input_dtype=dtypes.fp8,
+    q_dtype=dtypes.fp8,
+    hidden_cols=32,
+    scale_dtype=dtypes.fp8_e8m0,
+    scale_shape=(32, 1),
+    sorted_shape=(32,),
+    scale_layout=_PREPARED_STAGE1_SCALE_LAYOUT,
+    expected_sorted_blocks=None,
+):
+    metadata = MOEMetadata(
+        stage1=None,
+        stage2=None,
+        block_m=32,
+        ksplit=0,
+        prequant=prequant,
+        expected_sorted_blocks=expected_sorted_blocks,
+    )
+    scale = (
+        torch.empty(scale_shape, dtype=scale_dtype) if scale_dtype is not None else None
+    )
+    return _is_prepared_stage1_input(
+        metadata,
+        torch.empty((3, hidden_cols), dtype=input_dtype),
+        q_dtype,
+        scale,
+        torch.empty(sorted_shape, dtype=torch.int32),
+        scale_layout,
+    )
 
 
 @pytest.mark.parametrize(
-    (
-        "prequant",
-        "input_dtype",
-        "q_dtype",
-        "hidden_cols",
-        "scale_dtype",
-        "scale_cols",
-        "expected",
-    ),
+    "overrides,expected",
     [
-        (True, dtypes.fp8, dtypes.fp8, 32, dtypes.fp8_e8m0, 1, True),
-        (False, dtypes.fp8, dtypes.fp8, 32, dtypes.fp8_e8m0, 1, False),
-        (True, torch.bfloat16, dtypes.fp8, 32, dtypes.fp8_e8m0, 1, False),
-        (True, torch.bfloat16, torch.bfloat16, 32, dtypes.fp8_e8m0, 1, False),
-        (True, dtypes.fp8, dtypes.fp8, 32, None, 0, False),
-        (True, dtypes.fp8, dtypes.fp8, 32, torch.uint8, 1, False),
-        (True, dtypes.fp8, dtypes.fp8, 32, torch.float32, 1, False),
-        (True, dtypes.fp8, dtypes.fp8, 64, dtypes.fp8_e8m0, 1, False),
+        pytest.param({}, True, id="valid"),
+        pytest.param({"prequant": False}, False, id="not-prequant"),
+        pytest.param({"input_dtype": torch.bfloat16}, False, id="bf16-input"),
+        pytest.param({"q_dtype": torch.bfloat16}, False, id="bf16-q-dtype"),
+        pytest.param({"scale_dtype": None}, False, id="no-scale"),
+        pytest.param({"scale_dtype": torch.uint8}, False, id="wrong-scale-dtype"),
+        pytest.param({"hidden_cols": 64}, False, id="wrong-scale-cols"),
+        pytest.param({"scale_layout": None}, False, id="missing-layout"),
+        pytest.param({"scale_layout": "token_major"}, False, id="wrong-layout"),
+        pytest.param({"scale_shape": (31, 1)}, False, id="undersized-scale"),
+        pytest.param({"scale_shape": (3, 1)}, False, id="token-major-scale"),
+        pytest.param({"scale_shape": (64, 1)}, True, id="extra-scale-rows"),
+        pytest.param({"sorted_shape": (8, 4)}, False, id="non-vector-sorted-ids"),
+        pytest.param(
+            {"scale_shape": (32, 1), "expected_sorted_blocks": 2},
+            False,
+            id="undersized-metadata-extent",
+        ),
+        pytest.param(
+            {"scale_shape": (64, 1), "expected_sorted_blocks": 2},
+            True,
+            id="metadata-extent",
+        ),
     ],
 )
-def test_prepared_stage1_input_gate(
-    prequant: bool,
-    input_dtype: torch.dtype,
-    q_dtype: torch.dtype,
-    hidden_cols: int,
-    scale_dtype: torch.dtype | None,
-    scale_cols: int,
-    expected: bool,
-):
-    metadata = replace(
-        MOEMetadata(stage1=None, stage2=None, block_m=32, ksplit=0),
-        prequant=prequant,
-    )
-    hidden_states = torch.empty((3, hidden_cols), dtype=input_dtype)
-    scale = (
-        torch.empty((3, scale_cols), dtype=scale_dtype)
-        if scale_dtype is not None
-        else None
-    )
-
-    assert (
-        _is_prepared_stage1_input(metadata, hidden_states, q_dtype, scale) is expected
-    )
+def test_prepared_stage1_input_gate(overrides, expected):
+    assert _accepts_prepared_input(**overrides) is expected


### PR DESCRIPTION
## Why

`fused_moe_2stages` always quantizes an A8W4 stage-1 input when the selected
kernel declares `prequant=True`. That prevents a caller-owned producer from
passing an already-quantized activation and its consumer-ready, route-sorted
E8M0 scale layout: the same activation is quantized and materialized again.

The prepared path must also fail closed. Dtype, contiguity, and scale column
count alone do not prove that a scale tensor has the route-SBM32 preshuffled
layout or enough rows for the selected metadata. Accepting an undersized or
token-major tensor could otherwise cause invalid reads or incorrect output.

## What changed

Consume the caller-provided activation directly only when the complete
prepared-stage1 contract agrees:

- selected kernel metadata requires prequantization;
- activation is contiguous 2D FP8 and matches `q_dtype_a`;
- scale is same-device, contiguous 2D E8M0 with the expected columns;
- the caller supplies the recognized
  `mx_e8m0_route_sbm32_preshuffled_v1` layout tag;
- scale rows cover both the sorted-ID extent and metadata-required blocks.

Missing/wrong layout tags, undersized or token-major scales, BF16 callers,
non-prequant kernels, and callers without scales retain the existing path.
This PR deliberately contains no model-specific selector or producer.

## Tests

```bash
python3 -m py_compile \
  aiter/fused_moe.py \
  op_tests/test_fused_moe_prequant.py

ruff check \
  aiter/fused_moe.py \
  op_tests/test_fused_moe_prequant.py

pytest -q op_tests/test_fused_moe_prequant.py
# 15 passed

git diff --check origin/main...HEAD
```

The negative cases cover missing and wrong tags, undersized and token-major
scales, non-vector sorted IDs, and metadata-driven extents. On gfx950, the
consumer was also exercised with a prepared FP8 activation and sorted E8M0
scales through the production two-stage A8W4 kernels. Output and repeated HIP
Graph replay were bit-exact against the existing path.

This PR makes no standalone performance claim; the producer that removes the
redundant work is intentionally split into a follow-up.
