### PR TITLE
[dtype] Map FP8 to torch.float8_e4m3fn on RDNA3

### DIFF
--- a/aiter/utility/dtypes.py
+++ b/aiter/utility/dtypes.py
@@ -14,6 +14,7 @@ defaultDtypes = {
     "gfx1100": {"fp8": torch.float8_e4m3fn},
     "gfx1101": {"fp8": torch.float8_e4m3fn},
     "gfx1102": {"fp8": torch.float8_e4m3fn},
+    "gfx1151": {"fp8": torch.float8_e4m3fn},
     "gfx1200": {"fp8": torch.float8_e4m3fn},
     "gfx1201": {"fp8": torch.float8_e4m3fn},
     "gfx1250": {"fp8": torch.float8_e4m3fn},

--- a/aiter/utility/dtypes.py
+++ b/aiter/utility/dtypes.py
@@ -11,6 +11,9 @@ from .aiter_types import aiter_dtypes, aiter_tensor_t
 defaultDtypes = {
     "gfx942": {"fp8": torch.float8_e4m3fnuz},
     "gfx950": {"fp8": torch.float8_e4m3fn},
+    "gfx1100": {"fp8": torch.float8_e4m3fn},
+    "gfx1101": {"fp8": torch.float8_e4m3fn},
+    "gfx1102": {"fp8": torch.float8_e4m3fn},
     "gfx1200": {"fp8": torch.float8_e4m3fn},
     "gfx1201": {"fp8": torch.float8_e4m3fn},
     "gfx1250": {"fp8": torch.float8_e4m3fn},


### PR DESCRIPTION
## Summary

Add `gfx1100`, `gfx1101`, `gfx1102`, and `gfx1151` to AITER's FP8 dtype map with `torch.float8_e4m3fn`.

Without these entries, AITER falls back to `torch.uint8`. FP8 tensors produced by vLLM are then interpreted as byte tensors, which can produce invalid mixed FP8/uint8 operands in Triton kernels such as the DeepSeek-V4 paged MQA-logits path.

This follows the same dtype-map change made for gfx1200/gfx1201 in #3332.

## Test

Tested on gfx1100 and gfx1151.

| Test | Command | Result |
|---|---|---|
| Direct FP8 tgemm check | Command below | **PASS** — 3/3 shapes; worst max absolute difference `0.03125` on gfx1100 and `0.25` on gfx1151 with threshold `5.0` |
| Triton contiguous FP8 MQA logits | `pytest -q op_tests/triton_tests/attention/test_fp8_mqa_logits.py` | **PASS** — `144 passed` |
| Triton fused FP8 quant | `pytest -q op_tests/triton_tests/quant/test_fused_fp8_quant.py` | **PASS** — `393 passed` |
| Triton fused RMS-gated FP8 group quant | `pytest -q op_tests/triton_tests/quant/test_fused_rms_gated_fp8_group_quant.py` | **PASS** — `121 passed` |


It passed these shapes:

```text
4x64x128       max_abs_diff=0
16x4096x4096   max_abs_diff=0
128x1536x4096 max_abs_diff=0.03125
```


```bash
python3 - <<'PY'
import torch
import torch.nn.functional as F

from aiter import dtypes
from aiter.tuned_gemm import tgemm

assert dtypes.fp8 == torch.float8_e4m3fn
torch.manual_seed(0)
one = torch.ones(1, device="cuda", dtype=torch.float32)

for m, n, k in ((4, 64, 128), (16, 4096, 4096), (128, 1536, 4096)):
    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16).to(dtypes.fp8)
    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16).to(dtypes.fp8)
    ref = F.linear(x.to(torch.bfloat16), w.to(torch.bfloat16)).float()
    out = tgemm.mm(
        x, w, otype=torch.bfloat16, scale_a=one, scale_b=one
    ).float()
    max_abs_diff = (out - ref).abs().max().item()
    print(f"{m}x{n}x{k}: max_abs_diff={max_abs_diff}")
    assert max_abs_diff <= 5.0
PY
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
