### PR TITLE
[Bugfix] Include headers necessary for ROCm 10.0.0

### DIFF
--- a/csrc/cpp_itfs/sampling/sampling.cuh
+++ b/csrc/cpp_itfs/sampling/sampling.cuh
@@ -26,6 +26,8 @@
 #include <hipcub/block/block_reduce.hpp>
 #include <hipcub/block/block_scan.hpp>
 #include <hipcub/block/block_store.hpp>
+#include <hipcub/thread/thread_operators.hpp>
+#include <hipcub/util_type.hpp>
 #include <limits>
 #include <numeric>
 #include <tuple>


### PR DESCRIPTION
## Motivation

vLLM CI fails on the [ROCm 10.0.0rc2 release](https://rocm.prereleases.amd.com/whl-multi-arch/rocm/), partly due to missing includes in Aiter. ROCm 10.0.0rc2 uses `hipcub` 5.0.0 that does not transitively include the attributes listed below.

Fixes #4769 

## Technical Details

`hipcub::Min` and `hipcub::Max` are in [thread_operators.hpp](https://github.com/ROCm/rocm-libraries/blob/a66ba22a4ce40f703f1168d10ead0a36f9258cea/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp#L112-L133). `hipcub::Traits` is in [util_type.hpp](https://github.com/ROCm/rocm-libraries/blob/1eae5f68a435f7de4e42ad63b9bab924d2382a29/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_type.hpp#L838-L840).

## Test Plan

Reproducer for compiler fail and, with changes, compiler success:
```bash
WORKDIR="$(mktemp -d)"
trap 'rm -rf "$WORKDIR"' EXIT
cd "$WORKDIR"

echo "== Installing ROCm SDK 10.0.0rc2 into a throwaway uv venv =="
uv venv --python 3.12 .venv
source .venv/bin/activate
uv pip install --index-url https://rocm.prereleases.amd.com/whl-multi-arch "rocm[libraries,devel]==10.0.0rc2"
rocm-sdk init

echo "== Fetching upstream AITER's sampling.cuh from source (main) =="
AITER_RAW="https://raw.githubusercontent.com/ROCm/aiter/main/csrc/cpp_itfs/sampling"
mkdir -p sampling
curl -sL -o sampling/sampling.cuh "$AITER_RAW/sampling.cuh"
curl -sL -o sampling/vec_dtypes.cuh "$AITER_RAW/vec_dtypes.cuh"

SAMPLING_CUH="sampling/sampling.cuh"

ROCM_DEVEL="$(python3 -c 'import _rocm_sdk_devel, os; print(os.path.dirname(_rocm_sdk_devel.__file__))')"
CLANGXX="$ROCM_DEVEL/lib/llvm/bin/clang++"
echo "== Compiler under test: $("$CLANGXX" --version | head -1) =="

for variant in unpatched patched; do
    if [[ "$variant" == "patched" ]]; then
        sed -i '/#include <hipcub\/block\/block_store.hpp>/a\
#include <hipcub/util_type.hpp>\
#include <hipcub/thread/thread_operators.hpp>' "$SAMPLING_CUH"
    fi

    echo "== [$variant] Compiling sampling.cuh =="
    if "$CLANGXX" -w -x hip -c "$SAMPLING_CUH" -o sampling.o --offload-arch=gfx942 -I"$ROCM_DEVEL/include"; then
        echo "== [$variant] OK: sampling.cuh compiled successfully =="
    else
        echo "== [$variant] FAILED: sampling.cuh did not compile =="
    fi
done
```

## Test Result

The test succeeds when the needed headers are included.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

I didn't run the pre-commit hooks in order not to pollute this minimal change.
