### PR TITLE
[Triton][FMHA] Fused paged-prefill kernel for page_size=1, head_dim 64/256

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -3913,6 +3913,7 @@ def mha_batch_prefill_func(
         _ok, _ = _fpp.is_supported(
             q,
             k,
+            v,
             causal=causal,
             logits_soft_cap=logits_soft_cap,
             alibi_slopes=alibi_slopes,
@@ -3920,12 +3921,18 @@ def mha_batch_prefill_func(
             return_attn_probs=return_attn_probs,
             window_size=window_size,
             sink_ptr=sink_ptr,
+            sink_size=sink_size,
             q_descale=q_descale,
             k_descale=k_descale,
             v_descale=v_descale,
+            kv_block_descale=kv_block_descale,
+            dropout_p=dropout_p,
+            kv_last_page_lens=kv_last_page_lens,
+            block_table=block_table,
+            seqlen_k=seqlen_k,
         )
-        # dropout and the block_table/vectorized layouts are CK-only entry points
-        if _ok and not dropout_p and block_table is None and kv_last_page_lens is None:
+        if _ok:
+            # every other argument is at its default here, guaranteed by is_supported
             return _fpp.mha_batch_prefill_func(
                 q,
                 k,
@@ -3935,16 +3942,7 @@ def mha_batch_prefill_func(
                 kv_page_indices,
                 max_seqlen_q,
                 max_seqlen_k,
-                causal=causal,
-                logits_soft_cap=logits_soft_cap,
-                alibi_slopes=alibi_slopes,
-                return_lse=return_lse,
-                return_attn_probs=return_attn_probs,
-                window_size=window_size,
-                sink_ptr=sink_ptr,
-                q_descale=q_descale,
-                k_descale=k_descale,
-                v_descale=v_descale,
+                causal=True,
                 out=out,
                 softmax_scale=softmax_scale,
             )

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -3898,6 +3898,57 @@ def mha_batch_prefill_func(
 ):
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
+
+    # Triton fused paged-prefill fast path.
+    #
+    # Only taken for the narrow set of calls where it is both correct and measured
+    # faster than the CK-tile kernel below (causal, page_size=1, one kv head, head
+    # dim 64 or 256) -- see fused_paged_prefill.is_supported() for why each
+    # condition is load-bearing. Everything else falls through unchanged.
+    #
+    # Set AITER_FUSED_PAGED_PREFILL=0 to disable.
+    if os.environ.get("AITER_FUSED_PAGED_PREFILL", "1") != "0":
+        from aiter.ops.triton.attention import fused_paged_prefill as _fpp
+
+        _ok, _ = _fpp.is_supported(
+            q,
+            k,
+            causal=causal,
+            logits_soft_cap=logits_soft_cap,
+            alibi_slopes=alibi_slopes,
+            return_lse=return_lse,
+            return_attn_probs=return_attn_probs,
+            window_size=window_size,
+            sink_ptr=sink_ptr,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
+        )
+        # dropout and the block_table/vectorized layouts are CK-only entry points
+        if _ok and not dropout_p and block_table is None and kv_last_page_lens is None:
+            return _fpp.mha_batch_prefill_func(
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                kv_indptr,
+                kv_page_indices,
+                max_seqlen_q,
+                max_seqlen_k,
+                causal=causal,
+                logits_soft_cap=logits_soft_cap,
+                alibi_slopes=alibi_slopes,
+                return_lse=return_lse,
+                return_attn_probs=return_attn_probs,
+                window_size=window_size,
+                sink_ptr=sink_ptr,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                out=out,
+                softmax_scale=softmax_scale,
+            )
+
     if sink_ptr is not None:
         assert sink_ptr.device == q.device, "sink_ptr must be on the same device as q"
         assert sink_ptr.shape[0] == q.size(1), "sink_ptr has incorrect shape"

--- a/aiter/ops/triton/attention/fused_paged_prefill.py
+++ b/aiter/ops/triton/attention/fused_paged_prefill.py
@@ -42,11 +42,11 @@ _DEFAULT_CFG = {
     "matrix_instr_nonkdim": 16,
     # How the softmax scale reaches the QK product. 2 folds only the power-of-two part
     # of sm_scale*log2e into q, which is exact in bf16, and applies the small remainder
-    # to the product. Mode 1 folds the whole thing and is 3.4% faster, but its rounding
-    # error is data-dependent: on a distribution with large late kv values it measured
-    # 7.0x the CK-tile path's error against an fp32 reference (6.8e-3 vs 9.7e-4), where
-    # mode 2 matches CK-tile to 1.00x. Not worth 3.4% on a path that silently replaces
-    # a more accurate kernel.
+    # to the product. Mode 1 folds the whole thing for at most ~2% of kernel time (1.8%
+    # and 0.0% in two processes), but its rounding error is data-dependent: on a
+    # distribution with large late kv values it measured 8.0x the CK-tile path's error
+    # against an fp32 reference (7.8e-3 vs 9.8e-4), where mode 2 matches CK-tile to
+    # 1.00x. Not worth ~2% on a path that silently replaces a more accurate kernel.
     "PRESCALE_Q": 2,
     "DOT_ACC": 0,
     "SWAP_GRID": 1,  # head-major grid: 8 GQA heads of one (req, m-tile) dispatch together

--- a/aiter/ops/triton/attention/fused_paged_prefill.py
+++ b/aiter/ops/triton/attention/fused_paged_prefill.py
@@ -254,10 +254,12 @@ def is_supported(
 ):
     """Return (supported, reason). Callers MUST gate on this before dispatching.
 
-    This is deliberately exhaustive over every argument of
-    `aiter.ops.mha.mha_batch_prefill_func` that changes what the op computes, so that
-    adding an argument there and forgetting it here fails closed rather than open.
-    Arguments the CK-tile path itself ignores (`deterministic`) are not listed.
+    This covers every argument of `aiter.ops.mha.mha_batch_prefill_func` that changes
+    what the op computes, as of that function's current signature. Arguments the
+    CK-tile path itself ignores (`deterministic`) are not listed. Note that the caller
+    names these explicitly, so an argument added to that function later will not reach
+    this predicate: it has to be added here in the same change, or calls using it will
+    be dispatched with it silently ignored.
 
     Most conditions describe a feature this kernel does not implement, and getting
     one wrong would be loud. The four that would be SILENT are:

--- a/aiter/ops/triton/attention/fused_paged_prefill.py
+++ b/aiter/ops/triton/attention/fused_paged_prefill.py
@@ -40,7 +40,14 @@ _DEFAULT_CFG = {
     "waves_per_eu": 2,
     "kpack": 2,
     "matrix_instr_nonkdim": 16,
-    "PRESCALE_Q": 1,  # fold sm_scale*log2e into q (measured margin 0.28 of the 2e-2 budget)
+    # How the softmax scale reaches the QK product. 2 folds only the power-of-two part
+    # of sm_scale*log2e into q, which is exact in bf16, and applies the small remainder
+    # to the product. Mode 1 folds the whole thing and is 3.4% faster, but its rounding
+    # error is data-dependent: on a distribution with large late kv values it measured
+    # 7.0x the CK-tile path's error against an fp32 reference (6.8e-3 vs 9.7e-4), where
+    # mode 2 matches CK-tile to 1.00x. Not worth 3.4% on a path that silently replaces
+    # a more accurate kernel.
+    "PRESCALE_Q": 2,
     "DOT_ACC": 0,
     "SWAP_GRID": 1,  # head-major grid: 8 GQA heads of one (req, m-tile) dispatch together
     "CONTIG": 0,  # contiguous-page fast path measured SLOWER (11.6 vs 10.5 ms) -> off
@@ -226,6 +233,7 @@ Restricted rather than "any power of two" on purpose:
 def is_supported(
     q,
     k_cache,
+    v_cache=None,
     *,
     causal=True,
     logits_soft_cap=0.0,
@@ -234,26 +242,40 @@ def is_supported(
     return_attn_probs=False,
     window_size=(-1, -1),
     sink_ptr=None,
+    sink_size=0,
     q_descale=None,
     k_descale=None,
     v_descale=None,
+    kv_block_descale=None,
+    dropout_p=0.0,
+    kv_last_page_lens=None,
+    block_table=None,
+    seqlen_k=None,
 ):
     """Return (supported, reason). Callers MUST gate on this before dispatching.
 
-    The two tensor-shape conditions are the dangerous ones, because unlike the
-    feature flags they do not fail loudly:
+    This is deliberately exhaustive over every argument of
+    `aiter.ops.mha.mha_batch_prefill_func` that changes what the op computes, so that
+    adding an argument there and forgetting it here fails closed rather than open.
+    Arguments the CK-tile path itself ignores (`deterministic`) are not listed.
 
-    * ``k_cache`` must present exactly ONE kv head. The kernel addresses K/V as
-      ``base + page * stride(0) + offs_d`` with no kv-head term, so with more than
-      one kv head every query head would silently read kv head 0 and return a
-      plausible-looking wrong answer (measured rms error ~1.0 vs a reference at
-      num_kv_heads=2). This is not a limitation that can be detected downstream.
-    * ``head_dim`` must be in :data:`SUPPORTED_HEAD_DIMS`.
+    Most conditions describe a feature this kernel does not implement, and getting
+    one wrong would be loud. The four that would be SILENT are:
+
+    * ``k_cache``/``v_cache`` must present exactly ONE kv head. K/V are addressed as
+      ``base + page * stride(0) + offs_d`` with no kv-head term, so with more than one
+      kv head every query head reads kv head 0 and the kernel returns a
+      plausible-looking wrong answer (measured rms error ~1.0 at num_kv_heads=2).
+    * ``kv_block_descale`` is a per-page K/V scale the kernel never applies.
+    * the head dim of V must equal that of Q, since one ``HEAD_DIM`` serves both.
+    * the last dim of q/k/v must be unit-stride, because ``offs_d`` is added to the
+      base pointer directly rather than multiplied by a stride.
 
     One kv head is the normal case for a GQA model whose kv heads are replicated
-    across tensor-parallel ranks (e.g. 4 kv heads at TP8 gives 1 per rank), which is
-    the configuration this was developed and measured against.
+    across tensor-parallel ranks (4 kv heads at TP8 gives 1 per rank), which is the
+    configuration this was developed and measured against.
     """
+    # --- features not implemented (all would be loud, but must not dispatch) ---
     if not causal:
         return False, "non-causal not implemented"
     if logits_soft_cap:
@@ -264,22 +286,48 @@ def is_supported(
         return False, "return_lse / return_attn_probs not implemented"
     if tuple(window_size) != (-1, -1):
         return False, "sliding window not implemented"
-    if sink_ptr is not None:
+    if sink_ptr is not None or sink_size:
         return False, "attention sinks not implemented"
     if q_descale is not None or k_descale is not None or v_descale is not None:
         return False, "fp8 descales not implemented"
+    if dropout_p:
+        return False, "dropout not implemented"
+    # block_table / kv_last_page_lens / seqlen_k select CK-only paged layouts
+    if block_table is not None:
+        return False, "block_table layout not implemented"
+    if kv_last_page_lens is not None:
+        return False, "kv_last_page_lens not implemented"
+    if seqlen_k is not None:
+        return False, "seqlen_k not implemented"
+
+    # --- conditions that would be SILENT if they were not checked here ---
+    if kv_block_descale is not None:
+        return False, "kv_block_descale (per-page K/V scale) not applied by this kernel"
     if q.dim() != 3:
         return False, f"expected q of rank 3 (tokens, heads, dim), got {q.dim()}"
-    if k_cache.dim() != 3 or k_cache.shape[1] != 1:
+    for name, t in (("k_cache", k_cache), ("v_cache", v_cache)):
+        if t is None:
+            continue
         # rank 3 == the page_size=1 linear layout; shape[1] is the kv-head count
-        return (
-            False,
-            f"requires page_size=1 with a single kv head, got k_cache {tuple(k_cache.shape)}",
+        if t.dim() != 3 or t.shape[1] != 1:
+            return False, (
+                f"requires page_size=1 with a single kv head, got "
+                f"{name} {tuple(t.shape)}"
+            )
+    if v_cache is not None and v_cache.shape[-1] != q.shape[-1]:
+        return False, (
+            f"head dim of V ({v_cache.shape[-1]}) must equal that of Q "
+            f"({q.shape[-1]})"
         )
+    for name, t in (("q", q), ("k_cache", k_cache), ("v_cache", v_cache)):
+        if t is not None and t.stride(-1) != 1:
+            return False, f"{name} must be unit-stride in its last dim"
     if q.shape[-1] not in SUPPORTED_HEAD_DIMS:
         return False, f"head_dim {q.shape[-1]} not in {SUPPORTED_HEAD_DIMS}"
     if q.dtype not in (torch.bfloat16, torch.float16):
         return False, f"dtype {q.dtype} not supported"
+    if k_cache.dtype != q.dtype or (v_cache is not None and v_cache.dtype != q.dtype):
+        return False, "q/k/v dtypes must match"
     return True, ""
 
 
@@ -311,6 +359,7 @@ def mha_batch_prefill_func(
     ok, why = is_supported(
         q,
         k_cache,
+        v_cache,
         causal=causal,
         logits_soft_cap=logits_soft_cap,
         alibi_slopes=alibi_slopes,
@@ -347,7 +396,12 @@ def mha_batch_prefill_func(
     else:
         _q_pre, _qk_scale = 1.0, _full
 
-    o = torch.empty_like(q)
+    if out is None:
+        o = torch.empty_like(q)
+    else:
+        if out.shape != q.shape or out.dtype != q.dtype or out.stride(-1) != 1:
+            raise ValueError("out must match q in shape/dtype and be unit-stride")
+        o = out
     bs = cu_seqlens_q.shape[0] - 1
     num_m = triton.cdiv(int(max_seqlen_q), BLOCK_M)
 

--- a/aiter/ops/triton/attention/fused_paged_prefill.py
+++ b/aiter/ops/triton/attention/fused_paged_prefill.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fused paged flash-attention prefill (extend) kernel for page_size=1 KV pools.
+
+A single Triton kernel serving the same seam as the CK-tile
+`mha_batch_prefill_func`: it walks each request's FULL kv range directly out of the
+paged pool via `kv_page_indices`, with bottom-right aligned causal masking, and
+splits the KV loop into a fully-unmasked BULK range (no `tl.where` at all) and a
+masked diagonal TAIL range. There is no prefix/extend split, no materialized
+K_Extend/V_Extend gather, and no host sync.
+
+It uses no LDS: K and V tiles stay in registers, which is the main structural
+difference from the CK-tile pipeline (`qr_ks_vs_async`, which stages K/V through
+LDS). On gfx950 at head_dim 256 that is worth ~1.4x on the kernel and +5.71%
+end-to-end on an SGLang Qwen3.8-MoE TP8 server; see the PR body for the full
+measurement.
+
+Scope is deliberately narrow and enforced by `is_supported()`: causal only,
+page_size 1, ONE kv head in the cache view, and a power-of-two head dim from
+`SUPPORTED_HEAD_DIMS`. Anything else must fall back to the CK-tile path -- see the
+note on `is_supported()` for why each condition is load-bearing.
+"""
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+# --------------------------------------------------------------------------- config
+# One static config. Deliberately not @triton.autotune: autotuning at runtime
+# re-benchmarks inside the serving path, which is exactly what the
+# do_not_specialize note below exists to avoid.
+_DEFAULT_CFG = {
+    "BLOCK_M": 128,
+    "BLOCK_N": 64,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "kpack": 2,
+    "matrix_instr_nonkdim": 16,
+    "PRESCALE_Q": 1,  # fold sm_scale*log2e into q (measured margin 0.28 of the 2e-2 budget)
+    "DOT_ACC": 0,
+    "SWAP_GRID": 1,  # head-major grid: 8 GQA heads of one (req, m-tile) dispatch together
+    "CONTIG": 0,  # contiguous-page fast path measured SLOWER (11.6 vs 10.5 ms) -> off
+    "NUM_XCDS": 8,
+}
+
+
+def _cfg():
+    env = os.environ.get("AITER_FPP_CFG", "")
+    if not env:
+        return dict(_DEFAULT_CFG)
+    import json
+
+    c = dict(_DEFAULT_CFG)
+    c.update(json.loads(env))
+    return c
+
+
+# NUM_M / BS are RUNTIME scalars, never tl.constexpr and never specialized: they are derived from
+# (max_seqlen_q, batch_size), which the live chunked-prefill scheduler varies call-to-call.  Baking
+# them into the JIT key forces a fresh compile per ragged shape (elevated live TTFT).  They are only
+# read by the SWAP_GRID==2 flat-grid path; the default SWAP_GRID==1 grid never touches them.
+@triton.jit(do_not_specialize=["NUM_M", "BS"])
+def _fused_paged_prefill_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    CU_Q,
+    KV_INDPTR,
+    KV_PAGE,
+    qk_scale,
+    q_pre_scale,
+    stride_qt,
+    stride_qh,
+    stride_ot,
+    stride_oh,
+    stride_kp,
+    stride_vp,
+    NUM_M,
+    BS,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    CONTIG: tl.constexpr,
+    SWAP_GRID: tl.constexpr,
+    H_Q: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    PRESCALE_Q: tl.constexpr,
+    DOT_ACC: tl.constexpr,
+):
+    if SWAP_GRID == 2:
+        pid = tl.program_id(0)
+        n_tot = NUM_M * H_Q * BS
+        chunk = (n_tot + NUM_XCDS - 1) // NUM_XCDS
+        rid = (pid % NUM_XCDS) * chunk + pid // NUM_XCDS
+        if rid >= n_tot:
+            return
+        cur_head = rid % H_Q
+        pid_m = (rid // H_Q) % NUM_M
+        cur_b = rid // (H_Q * NUM_M)
+    elif SWAP_GRID == 1:
+        cur_head = tl.program_id(0)
+        pid_m = tl.program_id(1)
+        cur_b = tl.program_id(2)
+    else:
+        pid_m = tl.program_id(0)
+        cur_head = tl.program_id(1)
+        cur_b = tl.program_id(2)
+
+    q_start = tl.load(CU_Q + cur_b).to(tl.int32)
+    q_end = tl.load(CU_Q + cur_b + 1).to(tl.int32)
+    q_len = q_end - q_start
+
+    m_start = pid_m * BLOCK_M
+    if m_start >= q_len:
+        return
+
+    kv_start = tl.load(KV_INDPTR + cur_b).to(tl.int32)
+    kv_end = tl.load(KV_INDPTR + cur_b + 1).to(tl.int32)
+    kv_len = kv_end - kv_start
+    delta = kv_len - q_len
+
+    offs_m = m_start + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_DIM)
+    offs_n = tl.arange(0, BLOCK_N)
+
+    mask_m = offs_m < q_len
+    q_ptrs = (
+        Q
+        + (q_start + offs_m)[:, None] * stride_qt
+        + cur_head * stride_qh
+        + offs_d[None, :]
+    )
+    q = tl.load(q_ptrs, mask=mask_m[:, None], other=0.0)
+    if PRESCALE_Q > 0:
+        q = (q * q_pre_scale).to(q.dtype)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    # fully unmasked range: every row m in the tile can see kv j < m_start + delta + 1
+    n_bulk = ((m_start + delta + 1) // BLOCK_N) * BLOCK_N
+    # last kv position any row in this tile can see (exclusive)
+    n_end = tl.minimum(m_start + BLOCK_M + delta, kv_len)
+
+    page_base = KV_PAGE + kv_start
+    pg0 = tl.load(KV_PAGE + kv_start).to(tl.int32)
+
+    # ---------------- BULK: no mask at all ----------------
+    for start_n in range(0, n_bulk, BLOCK_N):
+        if CONTIG:
+            pg = pg0 + start_n + offs_n
+        else:
+            pg = tl.load(page_base + start_n + offs_n).to(tl.int32)
+        k = tl.load(K + pg[None, :] * stride_kp + offs_d[:, None])
+        qk = tl.dot(q, k)
+        if PRESCALE_Q != 1:
+            qk = qk * qk_scale
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        p = tl.math.exp2(qk - m_ij[:, None])
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+        v = tl.load(V + pg[:, None] * stride_vp + offs_d[None, :])
+        if DOT_ACC:
+            acc = tl.dot(p.to(v.dtype), v, acc)
+        else:
+            acc += tl.dot(p.to(v.dtype), v)
+        m_i = m_ij
+
+    # ---------------- TAIL: causal diagonal ----------------
+    for start_n in range(n_bulk, n_end, BLOCK_N):
+        n_idx = start_n + offs_n
+        mask_n = n_idx < kv_len
+        if CONTIG:
+            pg = pg0 + tl.where(mask_n, n_idx, 0)
+        else:
+            pg = tl.load(page_base + n_idx, mask=mask_n, other=0).to(tl.int32)
+        k = tl.load(K + pg[None, :] * stride_kp + offs_d[:, None])
+        qk = tl.dot(q, k)
+        if PRESCALE_Q != 1:
+            qk = qk * qk_scale
+        causal = n_idx[None, :] <= (offs_m[:, None] + delta)
+        qk = tl.where(causal & mask_n[None, :], qk, float("-inf"))
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        p = tl.math.exp2(qk - m_ij[:, None])
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+        v = tl.load(V + pg[:, None] * stride_vp + offs_d[None, :])
+        if DOT_ACC:
+            acc = tl.dot(p.to(v.dtype), v, acc)
+        else:
+            acc += tl.dot(p.to(v.dtype), v)
+        m_i = m_ij
+
+    acc = acc / l_i[:, None]
+    o_ptrs = (
+        Out
+        + (q_start + offs_m)[:, None] * stride_ot
+        + cur_head * stride_oh
+        + offs_d[None, :]
+    )
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=mask_m[:, None])
+
+
+SUPPORTED_HEAD_DIMS = (64, 256)
+"""Head dims this kernel is both CORRECT and FASTER on, measured on gfx950.
+
+Restricted rather than "any power of two" on purpose:
+
+* 192 (and any non-power-of-two) fails to COMPILE -- `tl.arange(0, HEAD_DIM)`
+  requires a power of two. Loud, but still must not be dispatched.
+* 128 is correct but SLOWER than CK-tile: measured 0.930x (CK reaches 863 TFLOP/s
+  at that head dim, versus 663 at 256). CK's tiling is tuned for 128, which is the
+  head dim most models use; there is nothing to win there.
+* 64 (1.445x) and 256 (1.277x) are where CK leaves throughput on the table.
+"""
+
+
+def is_supported(
+    q,
+    k_cache,
+    *,
+    causal=True,
+    logits_soft_cap=0.0,
+    alibi_slopes=None,
+    return_lse=False,
+    return_attn_probs=False,
+    window_size=(-1, -1),
+    sink_ptr=None,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+):
+    """Return (supported, reason). Callers MUST gate on this before dispatching.
+
+    The two tensor-shape conditions are the dangerous ones, because unlike the
+    feature flags they do not fail loudly:
+
+    * ``k_cache`` must present exactly ONE kv head. The kernel addresses K/V as
+      ``base + page * stride(0) + offs_d`` with no kv-head term, so with more than
+      one kv head every query head would silently read kv head 0 and return a
+      plausible-looking wrong answer (measured rms error ~1.0 vs a reference at
+      num_kv_heads=2). This is not a limitation that can be detected downstream.
+    * ``head_dim`` must be in :data:`SUPPORTED_HEAD_DIMS`.
+
+    One kv head is the normal case for a GQA model whose kv heads are replicated
+    across tensor-parallel ranks (e.g. 4 kv heads at TP8 gives 1 per rank), which is
+    the configuration this was developed and measured against.
+    """
+    if not causal:
+        return False, "non-causal not implemented"
+    if logits_soft_cap:
+        return False, "logits_soft_cap not implemented"
+    if alibi_slopes is not None:
+        return False, "alibi_slopes not implemented"
+    if return_lse or return_attn_probs:
+        return False, "return_lse / return_attn_probs not implemented"
+    if tuple(window_size) != (-1, -1):
+        return False, "sliding window not implemented"
+    if sink_ptr is not None:
+        return False, "attention sinks not implemented"
+    if q_descale is not None or k_descale is not None or v_descale is not None:
+        return False, "fp8 descales not implemented"
+    if q.dim() != 3:
+        return False, f"expected q of rank 3 (tokens, heads, dim), got {q.dim()}"
+    if k_cache.dim() != 3 or k_cache.shape[1] != 1:
+        # rank 3 == the page_size=1 linear layout; shape[1] is the kv-head count
+        return (
+            False,
+            f"requires page_size=1 with a single kv head, got k_cache {tuple(k_cache.shape)}",
+        )
+    if q.shape[-1] not in SUPPORTED_HEAD_DIMS:
+        return False, f"head_dim {q.shape[-1]} not in {SUPPORTED_HEAD_DIMS}"
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        return False, f"dtype {q.dtype} not supported"
+    return True, ""
+
+
+_LOG2E = 1.4426950408889634
+
+
+def mha_batch_prefill_func(
+    q,
+    k_cache,
+    v_cache,
+    cu_seqlens_q,
+    kv_indptr,
+    kv_page_indices,
+    max_seqlen_q,
+    max_seqlen_k,
+    causal=True,
+    logits_soft_cap=0.0,
+    alibi_slopes=None,
+    return_lse=False,
+    return_attn_probs=False,
+    window_size=(-1, -1),
+    sink_ptr=None,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+    out=None,
+    softmax_scale=None,
+):
+    ok, why = is_supported(
+        q,
+        k_cache,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        alibi_slopes=alibi_slopes,
+        return_lse=return_lse,
+        return_attn_probs=return_attn_probs,
+        window_size=window_size,
+        sink_ptr=sink_ptr,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    if not ok:
+        raise NotImplementedError(
+            f"fused_paged_prefill does not support this call: {why}"
+        )
+
+    _, H, D = q.shape
+    sm_scale = softmax_scale if softmax_scale is not None else D**-0.5
+    cfg = _cfg()
+    BLOCK_M = cfg["BLOCK_M"]
+    BLOCK_N = cfg["BLOCK_N"]
+
+    _mode = int(cfg.get("PRESCALE_Q", 0))
+    _full = sm_scale * _LOG2E
+    if _mode == 1:
+        _q_pre, _qk_scale = _full, 1.0
+    elif _mode == 2:
+        # split into an EXACT power-of-two prescale (bit-exact in bf16) + a residual on qk
+        import math as _m
+
+        _e = _m.floor(_m.log2(_full))
+        _q_pre = 2.0**_e
+        _qk_scale = _full / _q_pre
+    else:
+        _q_pre, _qk_scale = 1.0, _full
+
+    o = torch.empty_like(q)
+    bs = cu_seqlens_q.shape[0] - 1
+    num_m = triton.cdiv(int(max_seqlen_q), BLOCK_M)
+
+    _swap = int(cfg.get("SWAP_GRID", 0))
+    if _swap == 2:
+        _grid = (num_m * H * bs, 1, 1)
+    elif _swap == 1:
+        _grid = (H, num_m, bs)
+    else:
+        _grid = (num_m, H, bs)
+    _fused_paged_prefill_kernel[_grid](
+        q,
+        k_cache,
+        v_cache,
+        o,
+        cu_seqlens_q,
+        kv_indptr,
+        kv_page_indices,
+        _qk_scale,
+        _q_pre,
+        q.stride(0),
+        q.stride(1),
+        o.stride(0),
+        o.stride(1),
+        k_cache.stride(0),
+        v_cache.stride(0),
+        HEAD_DIM=D,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        CONTIG=bool(cfg.get("CONTIG", 0)),
+        SWAP_GRID=_swap,
+        NUM_M=num_m,
+        H_Q=H,
+        BS=bs,
+        NUM_XCDS=int(cfg.get("NUM_XCDS", 8)),
+        PRESCALE_Q=int(_mode),
+        DOT_ACC=bool(cfg.get("DOT_ACC", 1)),
+        num_warps=cfg["num_warps"],
+        num_stages=cfg["num_stages"],
+        waves_per_eu=cfg["waves_per_eu"],
+        kpack=cfg["kpack"],
+        matrix_instr_nonkdim=cfg["matrix_instr_nonkdim"],
+    )
+    return o

--- a/aiter/ops/triton/attention/fused_paged_prefill.py
+++ b/aiter/ops/triton/attention/fused_paged_prefill.py
@@ -12,9 +12,9 @@ K_Extend/V_Extend gather, and no host sync.
 
 It uses no LDS: K and V tiles stay in registers, which is the main structural
 difference from the CK-tile pipeline (`qr_ks_vs_async`, which stages K/V through
-LDS). On gfx950 at head_dim 256 that is worth ~1.4x on the kernel and +5.71%
-end-to-end on an SGLang Qwen3.8-MoE TP8 server; see the PR body for the full
-measurement.
+LDS). On gfx950 at head_dim 256 that is worth 1.40-1.50x on the kernel and +8.6%
+to +8.9% end-to-end on an SGLang Qwen3.8-MoE TP8 server; see the PR body for the
+full measurement.
 
 Scope is deliberately narrow and enforced by `is_supported()`: causal only,
 page_size 1, ONE kv head in the cache view, and a power-of-two head dim from
@@ -35,24 +35,47 @@ import triton.language as tl
 _DEFAULT_CFG = {
     "BLOCK_M": 128,
     "BLOCK_N": 64,
-    "num_warps": 8,
-    "num_stages": 2,
-    "waves_per_eu": 2,
+    # num_warps 4 rather than 8 because 8 caps the budget at 256 VGPR/thread and this
+    # kernel does not fit: at head_dim 256 it spills 113 registers. At 4 warps the cap
+    # doubles, the kernel settles at 419 VGPR with no spills, and occupancy stays at
+    # 1 wave/SIMD either way. Worth 5.6% of kernel time on the captured live shapes.
+    # num_stages/waves_per_eu/matrix_instr_nonkdim were re-picked together with it: the
+    # 5.6% is the set, not num_warps alone, and only the register count is explained.
+    "num_warps": 4,
+    "num_stages": 3,
+    "waves_per_eu": 1,
     "kpack": 2,
-    "matrix_instr_nonkdim": 16,
+    "matrix_instr_nonkdim": 32,
     # How the softmax scale reaches the QK product. 2 folds only the power-of-two part
     # of sm_scale*log2e into q, which is exact in bf16, and applies the small remainder
-    # to the product. Mode 1 folds the whole thing for at most ~2% of kernel time (1.8%
-    # and 0.0% in two processes), but its rounding error is data-dependent: on a
+    # to the product. Mode 1 folds the whole thing for at most ~1% of kernel time (0.7%
+    # in each of two processes), but its rounding error is data-dependent: on a
     # distribution with large late kv values it measured 8.0x the CK-tile path's error
     # against an fp32 reference (7.8e-3 vs 9.8e-4), where mode 2 matches CK-tile to
-    # 1.00x. Not worth ~2% on a path that silently replaces a more accurate kernel.
+    # 1.00x. Not worth ~1% on a path that silently replaces a more accurate kernel.
     "PRESCALE_Q": 2,
     "DOT_ACC": 0,
     "SWAP_GRID": 1,  # head-major grid: 8 GQA heads of one (req, m-tile) dispatch together
     "CONTIG": 0,  # contiguous-page fast path measured SLOWER (11.6 vs 10.5 ms) -> off
     "NUM_XCDS": 8,
 }
+
+
+# AMD instruction-scheduling hint: `attention` inserts the FA-aware sched barriers and
+# `memory-bound-attention` sets amdgpu-sched-strategy=iterative-ilp. Worth ~2% here.
+# Guarded because it is an AMD-backend option that older Triton does not accept, and
+# this kernel must still compile there.
+_SCHED_HINT = "attention,memory-bound-attention"
+try:
+    import dataclasses as _dc
+
+    from triton.backends.amd.compiler import HIPOptions as _HIPOptions
+
+    _HAS_SCHED = any(f.name == "schedule_hint" for f in _dc.fields(_HIPOptions))
+except (ImportError, TypeError):
+    # ImportError: no AMD backend (or an older layout). TypeError: HIPOptions is not
+    # a dataclass in this version, so its fields cannot be inspected.
+    _HAS_SCHED = False
 
 
 def _cfg():
@@ -68,8 +91,9 @@ def _cfg():
 
 # NUM_M / BS are RUNTIME scalars, never tl.constexpr and never specialized: they are derived from
 # (max_seqlen_q, batch_size), which the live chunked-prefill scheduler varies call-to-call.  Baking
-# them into the JIT key forces a fresh compile per ragged shape (elevated live TTFT).  They are only
-# read by the SWAP_GRID==2 flat-grid path; the default SWAP_GRID==1 grid never touches them.
+# them into the JIT key forces a fresh compile per ragged shape (elevated live TTFT).  NUM_M is read
+# by the default grid to reverse the tile order (see below) and by the SWAP_GRID==2 flat grid; BS
+# only by the latter.  Reversing with a runtime NUM_M is what keeps that free of respecialization.
 @triton.jit(do_not_specialize=["NUM_M", "BS"])
 def _fused_paged_prefill_kernel(
     Q,
@@ -111,7 +135,11 @@ def _fused_paged_prefill_kernel(
         cur_b = rid // (H_Q * NUM_M)
     elif SWAP_GRID == 1:
         cur_head = tl.program_id(0)
-        pid_m = tl.program_id(1)
+        # Longest tile first. Tile m scans kv up to delta + m + BLOCK_M, so work grows
+        # with m, and dim 0 (the head) is dispatched fastest -- ascending m therefore
+        # hands the hardware its shortest tiles first and leaves the longest ones to
+        # straggle at the end. Reversing shortens that tail by ~2% of kernel time.
+        pid_m = NUM_M - 1 - tl.program_id(1)
         cur_b = tl.program_id(2)
     else:
         pid_m = tl.program_id(0)
@@ -223,10 +251,10 @@ Restricted rather than "any power of two" on purpose:
 
 * 192 (and any non-power-of-two) fails to COMPILE -- `tl.arange(0, HEAD_DIM)`
   requires a power of two. Loud, but still must not be dispatched.
-* 128 is correct but SLOWER than CK-tile: measured 0.930x (CK reaches 863 TFLOP/s
-  at that head dim, versus 663 at 256). CK's tiling is tuned for 128, which is the
+* 128 is correct but only reaches parity: measured 1.040x (CK reaches 812 TFLOP/s
+  at that head dim, versus 618 at 256). CK's tiling is tuned for 128, which is the
   head dim most models use; there is nothing to win there.
-* 64 (1.445x) and 256 (1.277x) are where CK leaves throughput on the table.
+* 64 (1.55-1.61x) and 256 (1.46-1.48x) are where CK leaves throughput on the table.
 """
 
 
@@ -446,5 +474,6 @@ def mha_batch_prefill_func(
         waves_per_eu=cfg["waves_per_eu"],
         kpack=cfg["kpack"],
         matrix_instr_nonkdim=cfg["matrix_instr_nonkdim"],
+        **({"schedule_hint": _SCHED_HINT} if _HAS_SCHED else {}),
     )
     return o

--- a/op_tests/test_batch_prefill_triton_dispatch.py
+++ b/op_tests/test_batch_prefill_triton_dispatch.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Non-interference tests for the Triton fused-paged-prefill fast path in
+`mha_batch_prefill_func`.
+
+The kernel has its own correctness tests under
+`op_tests/triton_tests/attention/test_fused_paged_prefill.py`. This file tests the
+*dispatch*: that adding the fast path changed nothing for any call it does not take.
+
+`AITER_FUSED_PAGED_PREFILL=0` skips the fast path entirely and is read per call, so
+each case runs both legs in one process against the same allocations. For every call
+shape the predicate rejects, the two legs must be **bit-identical** -- not close, equal
+-- and the Triton kernel must not be entered at all.
+"""
+
+import os
+
+import pytest
+import torch
+
+import aiter.ops.mha as mha
+from aiter.ops.triton.attention import fused_paged_prefill as fpp
+
+POOL_PAGES = 20000
+ENV = "AITER_FUSED_PAGED_PREFILL"
+
+
+@pytest.fixture(autouse=True)
+def _restore_env():
+    old = os.environ.get(ENV)
+    yield
+    if old is None:
+        os.environ.pop(ENV, None)
+    else:
+        os.environ[ENV] = old
+
+
+def make(bs=2, q_len=256, kv_len=1024, H=8, Hkv=1, D=256, dtype=torch.bfloat16,
+         seed=0, device="cuda"):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    prefix = kv_len - q_len
+    perm = torch.randperm(POOL_PAGES, generator=g)
+    shared, tails = perm[:prefix], perm[prefix : prefix + bs * q_len]
+    pages = torch.cat(
+        [torch.cat([shared, tails[i * q_len : (i + 1) * q_len]]) for i in range(bs)]
+    )
+    mk = lambda *sh: (torch.randn(*sh, generator=g) * 0.5).to(dtype).to(device)
+    return dict(
+        q=mk(bs * q_len, H, D),
+        k=mk(POOL_PAGES, Hkv, D),
+        v=mk(POOL_PAGES, Hkv, D),
+        cu_seqlens_q=(torch.arange(bs + 1, dtype=torch.int32) * q_len).to(device),
+        kv_indptr=(torch.arange(bs + 1, dtype=torch.int32) * kv_len).to(device),
+        kv_page_indices=pages.to(torch.int32).to(device),
+        max_seqlen_q=q_len,
+        max_seqlen_k=kv_len,
+    )
+
+
+def run(inp, **kwargs):
+    """Call the op, returning ('ok', outputs) or ('raised', 'ExcType: msg')."""
+    kwargs.setdefault("causal", True)
+    try:
+        out = mha.mha_batch_prefill_func(
+            inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
+            inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"], **kwargs
+        )
+        torch.cuda.synchronize()
+    except Exception as e:  # noqa: BLE001 - the exception IS the observable behaviour
+        return "raised", f"{type(e).__name__}: {e}"
+    return "ok", tuple(out) if isinstance(out, tuple) else (out,)
+
+
+def both_legs(inp, **kwargs):
+    """Run with the fast path on and off, counting entries into the Triton kernel.
+
+    The off leg runs twice so each case carries its own control for whether the
+    CK-tile path is even reproducible for that call shape -- it is not always, and
+    without the control a CK nondeterminism looks identical to interference from the
+    patch. A warm-up call first keeps JIT/allocator effects out of both legs.
+    """
+    os.environ[ENV] = "0"
+    run(inp, **kwargs)  # warm-up, discarded
+    off1 = run(inp, **kwargs)
+    off2 = run(inp, **kwargs)
+
+    hits = {"n": 0}
+    orig = fpp.mha_batch_prefill_func
+
+    def counting(*a, **k):
+        hits["n"] += 1
+        return orig(*a, **k)
+
+    fpp.mha_batch_prefill_func = counting
+    try:
+        os.environ[ENV] = "1"
+        on = run(inp, **kwargs)
+    finally:
+        fpp.mha_batch_prefill_func = orig
+    return on, off1, off2, hits["n"]
+
+
+def _rms_rel(x, y):
+    d = (x.float() - y.float()).pow(2).mean().sqrt()
+    n = y.float().pow(2).mean().sqrt()
+    return (d / n).item() if n > 0 else d.item()
+
+
+def assert_no_interference(on, off1, off2, what):
+    """The fast path must not change a call it does not take.
+
+    Bit-identical is the assertion wherever CK-tile is itself reproducible. Where it
+    is not, the most that can be asserted is that the on-leg sits inside CK-tile's
+    own run-to-run spread, and the case says so rather than quietly weakening.
+    """
+    assert on[0] == off1[0], (
+        f"{what}: outcome differs, on={on[0]} off={off1[0]}\n  on: {on[1]}\n off: {off1[1]}"
+    )
+    if on[0] == "raised":
+        assert on[1] == off1[1], f"{what}: different exception\n  on: {on[1]}\n off: {off1[1]}"
+        return "raised identically"
+
+    a, b, c = on[1], off1[1], off2[1]
+    assert len(a) == len(b), f"{what}: returned {len(a)} vs {len(b)} tensors"
+    notes = []
+    for i, (x, y, z) in enumerate(zip(a, b, c)):
+        if x is None and y is None:
+            continue
+        assert x.shape == y.shape and x.dtype == y.dtype, f"{what}[{i}]: shape/dtype differ"
+        ck_reproducible = torch.equal(y, z)
+        if ck_reproducible:
+            assert torch.equal(x, y), (
+                f"{what}[{i}]: CK-tile is bit-reproducible for this call, but the fast "
+                f"path being enabled changed the result -- max|delta|="
+                f"{(x.float() - y.float()).abs().max().item():.3e}"
+            )
+            notes.append("bit-identical")
+        else:
+            ck_spread = _rms_rel(y, z)
+            delta = _rms_rel(x, y)
+            assert delta <= max(ck_spread * 4, 1e-6), (
+                f"{what}[{i}]: differs from the CK-tile leg by rms {delta:.3e}, which "
+                f"exceeds CK-tile's own run-to-run spread of {ck_spread:.3e}"
+            )
+            notes.append(
+                f"CK-tile not reproducible here (spread {ck_spread:.2e}); "
+                f"on-leg within it ({delta:.2e})"
+            )
+    return "; ".join(notes)
+
+
+# --------------------------------------------------------------------------------
+# Every call shape the predicate rejects. Each must be bit-identical with the fast
+# path on and off, and must not enter the Triton kernel.
+# --------------------------------------------------------------------------------
+
+def _alibi(H=8):
+    return torch.zeros(H, device="cuda", dtype=torch.float32)
+
+
+def _scale():
+    return torch.ones(1, device="cuda", dtype=torch.float32)
+
+
+REJECTED = {
+    "non_causal":            (dict(), dict(causal=False)),
+    "logits_soft_cap":       (dict(), dict(logits_soft_cap=30.0)),
+    "sliding_window":        (dict(), dict(window_size=(1024, 0))),
+    "return_lse":            (dict(), dict(return_lse=True)),
+    "return_attn_probs":     (dict(), dict(return_attn_probs=True)),
+    "alibi_slopes":          (dict(), dict(alibi_slopes=_alibi)),
+    "sink_size":             (dict(), dict(sink_size=4)),
+    "q_descale":             (dict(), dict(q_descale=_scale)),
+    "k_descale":             (dict(), dict(k_descale=_scale)),
+    "v_descale":             (dict(), dict(v_descale=_scale)),
+    "dropout":               (dict(), dict(dropout_p=0.1)),
+    "seqlen_k":              (dict(), dict(seqlen_k=1024)),
+    # tensor-shape rejections, the ones that would be silent
+    "two_kv_heads":          (dict(Hkv=2), dict()),
+    "four_kv_heads":         (dict(Hkv=4), dict()),
+    "head_dim_128":          (dict(D=128), dict()),
+    "head_dim_64_ok":        (dict(D=64), None),   # sanity: this one IS taken
+}
+
+
+@pytest.mark.parametrize("name", [k for k, v in REJECTED.items() if v[1] is not None])
+def test_rejected_calls_are_untouched(name):
+    mk_kwargs, call_kwargs = REJECTED[name]
+    inp = make(**mk_kwargs)
+    # some values need a device tensor built after cuda is up
+    call_kwargs = {k: (v() if callable(v) else v) for k, v in call_kwargs.items()}
+    on, off1, off2, hits = both_legs(inp, **call_kwargs)
+    assert hits == 0, f"{name}: Triton kernel entered {hits}x for a rejected call"
+    print(f"\n  {name}: {assert_no_interference(on, off1, off2, name)}")
+
+
+def test_non_unit_stride_q_falls_back():
+    """A q whose head dim is not unit-stride must not be dispatched: the kernel adds
+    offs_d to the base pointer without a stride."""
+    inp = make()
+    q = inp["q"]
+    # [T, H, D] -> a view with a non-unit last-dim stride
+    inp["q"] = q.transpose(1, 2).contiguous().transpose(1, 2)
+    assert inp["q"].stride(-1) != 1
+    on, off1, off2, hits = both_legs(inp)
+    assert hits == 0, "non-unit-stride q was dispatched"
+    assert_no_interference(on, off1, off2, "non_unit_stride_q")
+
+
+def test_float32_falls_back():
+    inp = make(dtype=torch.float32)
+    on, off1, off2, hits = both_legs(inp)
+    assert hits == 0, "fp32 was dispatched"
+    assert_no_interference(on, off1, off2, "float32")
+
+
+def test_kv_block_descale_falls_back():
+    inp = make()
+    ok, why = fpp.is_supported(
+        inp["q"], inp["k"], inp["v"],
+        kv_block_descale=torch.ones(POOL_PAGES, 1, 2, device="cuda"),
+    )
+    assert not ok and "kv_block_descale" in why
+
+
+# --------------------------------------------------------------------------------
+# Calls the predicate accepts
+# --------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("D", fpp.SUPPORTED_HEAD_DIMS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_accepted_calls_are_dispatched_and_agree(D, dtype):
+    inp = make(D=D, dtype=dtype)
+    on, off1, _off2, hits = both_legs(inp)
+    assert hits == 1, f"D={D} {dtype}: expected 1 Triton entry, got {hits}"
+    assert on[0] == "ok" and off1[0] == "ok", f"unexpected raise: {on[1]} / {off1[1]}"
+    got, ref = on[1][0], off1[1][0]
+    assert torch.isfinite(got).all()
+    # different accumulation order than CK-tile; bf16 rounding floor is ~2e-3
+    rel = _rms_rel(got, ref)
+    assert rel < 2e-2, f"D={D} {dtype}: rms_rel vs CK-tile = {rel:.3e}"
+
+
+def test_out_is_written_not_ignored():
+    """`out=` is an aliasing contract in the CK path -- the caller may read its buffer
+    rather than the return value, so the fast path has to write it."""
+    inp = make()
+    buf = torch.full_like(inp["q"], float("nan"))
+    os.environ[ENV] = "1"
+    ret = mha.mha_batch_prefill_func(
+        inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
+        inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"],
+        causal=True, out=buf,
+    )
+    torch.cuda.synchronize()
+    assert torch.isfinite(buf).all(), "out buffer was left untouched by the fast path"
+    assert ret.data_ptr() == buf.data_ptr(), "return value does not alias out"
+
+    os.environ[ENV] = "0"
+    ref = torch.empty_like(inp["q"])
+    mha.mha_batch_prefill_func(
+        inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
+        inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"],
+        causal=True, out=ref,
+    )
+    torch.cuda.synchronize()
+    rel = _rms_rel(buf, ref)
+    assert rel < 2e-2, f"out= content disagrees with CK-tile: {rel:.3e}"
+
+
+def _fp32_reference(inp, sm_scale):
+    q, k, v = inp["q"], inp["k"], inp["v"]
+    cu_q, kv_indptr, pages = inp["cu_seqlens_q"], inp["kv_indptr"], inp["kv_page_indices"]
+    out = torch.empty_like(q)
+    for b in range(cu_q.shape[0] - 1):
+        qs, qe = int(cu_q[b]), int(cu_q[b + 1])
+        ks, ke = int(kv_indptr[b]), int(kv_indptr[b + 1])
+        pg = pages[ks:ke].long()
+        kk, vv = k[pg, 0].float(), v[pg, 0].float()
+        delta = (ke - ks) - (qe - qs)
+        pos = torch.arange(qe - qs, device=q.device)[:, None] + delta
+        mask = torch.arange(ke - ks, device=q.device)[None, :] <= pos
+        qi = q[qs:qe].float()
+        for h in range(q.shape[1]):
+            s = (qi[:, h] @ kk.T) * sm_scale
+            p = torch.softmax(s.masked_fill(~mask, float("-inf")), dim=-1)
+            out[qs:qe, h] = (p @ vv).to(out.dtype)
+    return out
+
+
+@pytest.mark.parametrize("dist", ["normal", "spikes"])
+def test_accuracy_is_no_worse_than_ck(dist):
+    """Both paths measured against the same fp32 reference on the same inputs.
+
+    The claim that matters for a drop-in replacement is not an absolute tolerance but
+    that it is not WORSE than what it replaces.
+    """
+    inp = make(bs=2, q_len=512, kv_len=8192, D=256)
+    if dist == "spikes":
+        for t in ("k", "v"):
+            n = inp[t].shape[0]
+            inp[t][int(n * 0.9) :] *= 12.0
+    sm_scale = 256**-0.5
+    ref = _fp32_reference(inp, sm_scale)
+
+    os.environ[ENV] = "1"
+    got = run(inp, softmax_scale=sm_scale)
+    os.environ[ENV] = "0"
+    ck = run(inp, softmax_scale=sm_scale)
+    assert got[0] == "ok" and ck[0] == "ok"
+
+    e_triton, e_ck = _rms_rel(got[1][0], ref), _rms_rel(ck[1][0], ref)
+    print(f"\n  {dist}: triton {e_triton:.3e} vs ck-tile {e_ck:.3e} "
+          f"(ratio {e_triton / e_ck:.3f})")
+    assert e_triton < 2e-2, f"triton rms vs fp32 = {e_triton:.3e}"
+    # The default scaling mode is exact in bf16, so the error should track CK-tile's
+    # rather than merely stay inside a loose budget. This pins that: an earlier default
+    # passed a 2e-2 budget while carrying 7x CK-tile's error on the spiked case.
+    assert e_triton <= e_ck * 1.25, (
+        f"{dist}: triton error {e_triton:.3e} is more than 1.25x CK-tile's {e_ck:.3e}"
+    )
+
+
+def test_kill_switch_prevents_dispatch():
+    """A supported call must NOT reach the Triton kernel when the switch is off."""
+    inp = make()
+    hits = {"n": 0}
+    orig = fpp.mha_batch_prefill_func
+
+    def counting(*a, **k):
+        hits["n"] += 1
+        return orig(*a, **k)
+
+    fpp.mha_batch_prefill_func = counting
+    try:
+        os.environ[ENV] = "0"
+        assert run(inp)[0] == "ok"
+        assert hits["n"] == 0, "kill switch did not prevent dispatch"
+        os.environ[ENV] = "1"
+        assert run(inp)[0] == "ok"
+        assert hits["n"] == 1, "switch on: expected exactly one dispatch"
+    finally:
+        fpp.mha_batch_prefill_func = orig
+
+
+def test_default_causal_false_is_not_dispatched():
+    """The op's own default is causal=False, so a caller that does not ask for causal
+    must keep the CK path."""
+    inp = make()
+    hits = {"n": 0}
+    orig = fpp.mha_batch_prefill_func
+
+    def counting(*a, **k):
+        hits["n"] += 1
+        return orig(*a, **k)
+
+    fpp.mha_batch_prefill_func = counting
+    try:
+        os.environ[ENV] = "1"
+        mha.mha_batch_prefill_func(
+            inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
+            inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"],
+        )
+        torch.cuda.synchronize()
+    finally:
+        fpp.mha_batch_prefill_func = orig
+    assert hits["n"] == 0, "default (causal=False) call was dispatched"

--- a/op_tests/test_batch_prefill_triton_dispatch.py
+++ b/op_tests/test_batch_prefill_triton_dispatch.py
@@ -205,6 +205,9 @@ REJECTED = {
     "two_kv_heads": ({"Hkv": 2}, {}),
     "four_kv_heads": ({"Hkv": 4}, {}),
     "head_dim_128": ({"D": 128}, {}),
+    # non-power-of-two: tl.arange(0, HEAD_DIM) would not compile, so the predicate must
+    # reject it rather than the allowlist being replaced by is_power_of_two()
+    "head_dim_192": ({"D": 192}, {}),
 }
 
 

--- a/op_tests/test_batch_prefill_triton_dispatch.py
+++ b/op_tests/test_batch_prefill_triton_dispatch.py
@@ -363,7 +363,7 @@ def test_accuracy_is_no_worse_than_ck(dist):
     assert e_triton < 2e-2, f"triton rms vs fp32 = {e_triton:.3e}"
     # The default scaling mode is exact in bf16, so the error should track CK-tile's
     # rather than merely stay inside a loose budget. This pins that: an earlier default
-    # passed a 2e-2 budget while carrying 7x CK-tile's error on the spiked case.
+    # passed a 2e-2 budget while carrying 8x CK-tile's error on the spiked case.
     assert (
         e_triton <= e_ck * 1.25
     ), f"{dist}: triton error {e_triton:.3e} is more than 1.25x CK-tile's {e_ck:.3e}"

--- a/op_tests/test_batch_prefill_triton_dispatch.py
+++ b/op_tests/test_batch_prefill_triton_dispatch.py
@@ -19,7 +19,7 @@ import os
 import pytest
 import torch
 
-import aiter.ops.mha as mha
+from aiter.ops import mha
 from aiter.ops.triton.attention import fused_paged_prefill as fpp
 
 POOL_PAGES = 20000
@@ -36,8 +36,17 @@ def _restore_env():
         os.environ[ENV] = old
 
 
-def make(bs=2, q_len=256, kv_len=1024, H=8, Hkv=1, D=256, dtype=torch.bfloat16,
-         seed=0, device="cuda"):
+def make(
+    bs=2,
+    q_len=256,
+    kv_len=1024,
+    H=8,
+    Hkv=1,
+    D=256,
+    dtype=torch.bfloat16,
+    seed=0,
+    device="cuda",
+):
     g = torch.Generator(device="cpu").manual_seed(seed)
     prefix = kv_len - q_len
     perm = torch.randperm(POOL_PAGES, generator=g)
@@ -45,17 +54,20 @@ def make(bs=2, q_len=256, kv_len=1024, H=8, Hkv=1, D=256, dtype=torch.bfloat16,
     pages = torch.cat(
         [torch.cat([shared, tails[i * q_len : (i + 1) * q_len]]) for i in range(bs)]
     )
-    mk = lambda *sh: (torch.randn(*sh, generator=g) * 0.5).to(dtype).to(device)
-    return dict(
-        q=mk(bs * q_len, H, D),
-        k=mk(POOL_PAGES, Hkv, D),
-        v=mk(POOL_PAGES, Hkv, D),
-        cu_seqlens_q=(torch.arange(bs + 1, dtype=torch.int32) * q_len).to(device),
-        kv_indptr=(torch.arange(bs + 1, dtype=torch.int32) * kv_len).to(device),
-        kv_page_indices=pages.to(torch.int32).to(device),
-        max_seqlen_q=q_len,
-        max_seqlen_k=kv_len,
-    )
+
+    def mk(*sh):
+        return (torch.randn(*sh, generator=g) * 0.5).to(dtype).to(device)
+
+    return {
+        "q": mk(bs * q_len, H, D),
+        "k": mk(POOL_PAGES, Hkv, D),
+        "v": mk(POOL_PAGES, Hkv, D),
+        "cu_seqlens_q": (torch.arange(bs + 1, dtype=torch.int32) * q_len).to(device),
+        "kv_indptr": (torch.arange(bs + 1, dtype=torch.int32) * kv_len).to(device),
+        "kv_page_indices": pages.to(torch.int32).to(device),
+        "max_seqlen_q": q_len,
+        "max_seqlen_k": kv_len,
+    }
 
 
 def run(inp, **kwargs):
@@ -63,8 +75,15 @@ def run(inp, **kwargs):
     kwargs.setdefault("causal", True)
     try:
         out = mha.mha_batch_prefill_func(
-            inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
-            inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"], **kwargs
+            inp["q"],
+            inp["k"],
+            inp["v"],
+            inp["cu_seqlens_q"],
+            inp["kv_indptr"],
+            inp["kv_page_indices"],
+            inp["max_seqlen_q"],
+            inp["max_seqlen_k"],
+            **kwargs,
         )
         torch.cuda.synchronize()
     except Exception as e:  # noqa: BLE001 - the exception IS the observable behaviour
@@ -114,11 +133,13 @@ def assert_no_interference(on, off1, off2, what):
     is not, the most that can be asserted is that the on-leg sits inside CK-tile's
     own run-to-run spread, and the case says so rather than quietly weakening.
     """
-    assert on[0] == off1[0], (
-        f"{what}: outcome differs, on={on[0]} off={off1[0]}\n  on: {on[1]}\n off: {off1[1]}"
-    )
+    assert (
+        on[0] == off1[0]
+    ), f"{what}: outcome differs, on={on[0]} off={off1[0]}\n  on: {on[1]}\n off: {off1[1]}"
     if on[0] == "raised":
-        assert on[1] == off1[1], f"{what}: different exception\n  on: {on[1]}\n off: {off1[1]}"
+        assert (
+            on[1] == off1[1]
+        ), f"{what}: different exception\n  on: {on[1]}\n off: {off1[1]}"
         return "raised identically"
 
     a, b, c = on[1], off1[1], off2[1]
@@ -127,7 +148,9 @@ def assert_no_interference(on, off1, off2, what):
     for i, (x, y, z) in enumerate(zip(a, b, c)):
         if x is None and y is None:
             continue
-        assert x.shape == y.shape and x.dtype == y.dtype, f"{what}[{i}]: shape/dtype differ"
+        assert (
+            x.shape == y.shape and x.dtype == y.dtype
+        ), f"{what}[{i}]: shape/dtype differ"
         ck_reproducible = torch.equal(y, z)
         if ck_reproducible:
             assert torch.equal(x, y), (
@@ -155,6 +178,7 @@ def assert_no_interference(on, off1, off2, what):
 # path on and off, and must not enter the Triton kernel.
 # --------------------------------------------------------------------------------
 
+
 def _alibi(H=8):
     return torch.zeros(H, device="cuda", dtype=torch.float32)
 
@@ -164,27 +188,27 @@ def _scale():
 
 
 REJECTED = {
-    "non_causal":            (dict(), dict(causal=False)),
-    "logits_soft_cap":       (dict(), dict(logits_soft_cap=30.0)),
-    "sliding_window":        (dict(), dict(window_size=(1024, 0))),
-    "return_lse":            (dict(), dict(return_lse=True)),
-    "return_attn_probs":     (dict(), dict(return_attn_probs=True)),
-    "alibi_slopes":          (dict(), dict(alibi_slopes=_alibi)),
-    "sink_size":             (dict(), dict(sink_size=4)),
-    "q_descale":             (dict(), dict(q_descale=_scale)),
-    "k_descale":             (dict(), dict(k_descale=_scale)),
-    "v_descale":             (dict(), dict(v_descale=_scale)),
-    "dropout":               (dict(), dict(dropout_p=0.1)),
-    "seqlen_k":              (dict(), dict(seqlen_k=1024)),
-    # tensor-shape rejections, the ones that would be silent
-    "two_kv_heads":          (dict(Hkv=2), dict()),
-    "four_kv_heads":         (dict(Hkv=4), dict()),
-    "head_dim_128":          (dict(D=128), dict()),
-    "head_dim_64_ok":        (dict(D=64), None),   # sanity: this one IS taken
+    # name: (kwargs for make(), kwargs for the op call)
+    "non_causal": ({}, {"causal": False}),
+    "logits_soft_cap": ({}, {"logits_soft_cap": 30.0}),
+    "sliding_window": ({}, {"window_size": (1024, 0)}),
+    "return_lse": ({}, {"return_lse": True}),
+    "return_attn_probs": ({}, {"return_attn_probs": True}),
+    "alibi_slopes": ({}, {"alibi_slopes": _alibi}),
+    "sink_size": ({}, {"sink_size": 4}),
+    "q_descale": ({}, {"q_descale": _scale}),
+    "k_descale": ({}, {"k_descale": _scale}),
+    "v_descale": ({}, {"v_descale": _scale}),
+    "dropout": ({}, {"dropout_p": 0.1}),
+    "seqlen_k": ({}, {"seqlen_k": 1024}),
+    # tensor-shape rejections: the ones that would otherwise be silent
+    "two_kv_heads": ({"Hkv": 2}, {}),
+    "four_kv_heads": ({"Hkv": 4}, {}),
+    "head_dim_128": ({"D": 128}, {}),
 }
 
 
-@pytest.mark.parametrize("name", [k for k, v in REJECTED.items() if v[1] is not None])
+@pytest.mark.parametrize("name", list(REJECTED))
 def test_rejected_calls_are_untouched(name):
     mk_kwargs, call_kwargs = REJECTED[name]
     inp = make(**mk_kwargs)
@@ -218,7 +242,9 @@ def test_float32_falls_back():
 def test_kv_block_descale_falls_back():
     inp = make()
     ok, why = fpp.is_supported(
-        inp["q"], inp["k"], inp["v"],
+        inp["q"],
+        inp["k"],
+        inp["v"],
         kv_block_descale=torch.ones(POOL_PAGES, 1, 2, device="cuda"),
     )
     assert not ok and "kv_block_descale" in why
@@ -227,6 +253,7 @@ def test_kv_block_descale_falls_back():
 # --------------------------------------------------------------------------------
 # Calls the predicate accepts
 # --------------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("D", fpp.SUPPORTED_HEAD_DIMS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
@@ -249,9 +276,16 @@ def test_out_is_written_not_ignored():
     buf = torch.full_like(inp["q"], float("nan"))
     os.environ[ENV] = "1"
     ret = mha.mha_batch_prefill_func(
-        inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
-        inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"],
-        causal=True, out=buf,
+        inp["q"],
+        inp["k"],
+        inp["v"],
+        inp["cu_seqlens_q"],
+        inp["kv_indptr"],
+        inp["kv_page_indices"],
+        inp["max_seqlen_q"],
+        inp["max_seqlen_k"],
+        causal=True,
+        out=buf,
     )
     torch.cuda.synchronize()
     assert torch.isfinite(buf).all(), "out buffer was left untouched by the fast path"
@@ -260,9 +294,16 @@ def test_out_is_written_not_ignored():
     os.environ[ENV] = "0"
     ref = torch.empty_like(inp["q"])
     mha.mha_batch_prefill_func(
-        inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
-        inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"],
-        causal=True, out=ref,
+        inp["q"],
+        inp["k"],
+        inp["v"],
+        inp["cu_seqlens_q"],
+        inp["kv_indptr"],
+        inp["kv_page_indices"],
+        inp["max_seqlen_q"],
+        inp["max_seqlen_k"],
+        causal=True,
+        out=ref,
     )
     torch.cuda.synchronize()
     rel = _rms_rel(buf, ref)
@@ -271,7 +312,11 @@ def test_out_is_written_not_ignored():
 
 def _fp32_reference(inp, sm_scale):
     q, k, v = inp["q"], inp["k"], inp["v"]
-    cu_q, kv_indptr, pages = inp["cu_seqlens_q"], inp["kv_indptr"], inp["kv_page_indices"]
+    cu_q, kv_indptr, pages = (
+        inp["cu_seqlens_q"],
+        inp["kv_indptr"],
+        inp["kv_page_indices"],
+    )
     out = torch.empty_like(q)
     for b in range(cu_q.shape[0] - 1):
         qs, qe = int(cu_q[b]), int(cu_q[b + 1])
@@ -311,15 +356,17 @@ def test_accuracy_is_no_worse_than_ck(dist):
     assert got[0] == "ok" and ck[0] == "ok"
 
     e_triton, e_ck = _rms_rel(got[1][0], ref), _rms_rel(ck[1][0], ref)
-    print(f"\n  {dist}: triton {e_triton:.3e} vs ck-tile {e_ck:.3e} "
-          f"(ratio {e_triton / e_ck:.3f})")
+    print(
+        f"\n  {dist}: triton {e_triton:.3e} vs ck-tile {e_ck:.3e} "
+        f"(ratio {e_triton / e_ck:.3f})"
+    )
     assert e_triton < 2e-2, f"triton rms vs fp32 = {e_triton:.3e}"
     # The default scaling mode is exact in bf16, so the error should track CK-tile's
     # rather than merely stay inside a loose budget. This pins that: an earlier default
     # passed a 2e-2 budget while carrying 7x CK-tile's error on the spiked case.
-    assert e_triton <= e_ck * 1.25, (
-        f"{dist}: triton error {e_triton:.3e} is more than 1.25x CK-tile's {e_ck:.3e}"
-    )
+    assert (
+        e_triton <= e_ck * 1.25
+    ), f"{dist}: triton error {e_triton:.3e} is more than 1.25x CK-tile's {e_ck:.3e}"
 
 
 def test_kill_switch_prevents_dispatch():
@@ -359,8 +406,14 @@ def test_default_causal_false_is_not_dispatched():
     try:
         os.environ[ENV] = "1"
         mha.mha_batch_prefill_func(
-            inp["q"], inp["k"], inp["v"], inp["cu_seqlens_q"], inp["kv_indptr"],
-            inp["kv_page_indices"], inp["max_seqlen_q"], inp["max_seqlen_k"],
+            inp["q"],
+            inp["k"],
+            inp["v"],
+            inp["cu_seqlens_q"],
+            inp["kv_indptr"],
+            inp["kv_page_indices"],
+            inp["max_seqlen_q"],
+            inp["max_seqlen_k"],
         )
         torch.cuda.synchronize()
     finally:

--- a/op_tests/triton_tests/attention/test_fused_paged_prefill.py
+++ b/op_tests/triton_tests/attention/test_fused_paged_prefill.py
@@ -149,10 +149,10 @@ def test_prescale_modes_agree(prescale, monkeypatch):
 def test_default_scaling_mode_is_exact():
     """The default must stay on a bf16-exact scaling mode.
 
-    Mode 1 is 3.4% faster but its rounding error is data-dependent: on a distribution
-    with large late kv values it measured 7.0x the CK-tile path's error against fp32
-    while still passing the 2e-2 budget above, so that budget alone does not protect
-    this choice.
+    Mode 1 buys at most ~2% of kernel time (1.8% and 0.0% in two processes) and its
+    rounding error is data-dependent: on a distribution with large late kv values it
+    measured 8.0x the CK-tile path's error against fp32 while still passing the 2e-2
+    budget above, so that budget alone does not protect this choice.
     """
     from aiter.ops.triton.attention.fused_paged_prefill import _DEFAULT_CFG
 
@@ -162,7 +162,7 @@ def test_default_scaling_mode_is_exact():
 @pytest.mark.parametrize("prescale", [1, 2])
 def test_exact_mode_is_robust_to_late_kv_spikes(prescale, monkeypatch):
     """Pins the measurement behind the default: on the spiked distribution the exact
-    mode holds near the bf16 floor while the folded mode degrades by ~7x."""
+    mode holds at CK-tile's own error (9.7e-4) while the folded mode degrades ~8x."""
     import json
 
     monkeypatch.setenv("AITER_FPP_CFG", json.dumps({"PRESCALE_Q": prescale}))

--- a/op_tests/triton_tests/attention/test_fused_paged_prefill.py
+++ b/op_tests/triton_tests/attention/test_fused_paged_prefill.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter.ops.triton.attention.fused_paged_prefill import (
+    SUPPORTED_HEAD_DIMS,
+    is_supported,
+    mha_batch_prefill_func,
+)
+
+POOL_PAGES = 50000
+
+# (batch, q_len, kv_len) -- kv_len > q_len is the extend/chunked-prefill case, where
+# the causal diagonal is bottom-right aligned by delta = kv_len - q_len.
+SHAPES = [
+    (1, 128, 128),  # delta 0: the whole tile is on the diagonal
+    (1, 128, 256),
+    (2, 256, 1024),
+    (2, 1024, 4096),
+    (3, 300, 1500),  # nothing divides BLOCK_M/BLOCK_N
+    (1, 512, 32768),  # long shared prefix, the shape this was written for
+]
+
+# delta = kv_len - q_len straddling BLOCK_N. A sibling implementation of this kernel
+# returned NaN for every delta < BLOCK_N - 1, because the unmasked BULK range is empty
+# there and the first tile was flushed without ever being masked. Cheap to keep pinned.
+DELTAS = [0, 1, 16, 32, 62, 63, 64, 65, 128, 1024]
+
+
+def ref_attention(q, k_cache, v_cache, cu_q, kv_indptr, kv_pages, sm_scale):
+    """fp32 reference, one (request, head) at a time, chunked over kv to bound memory."""
+    out = torch.empty_like(q)
+    bs = cu_q.shape[0] - 1
+    H = q.shape[1]
+    for b in range(bs):
+        qs, qe = int(cu_q[b]), int(cu_q[b + 1])
+        ks, ke = int(kv_indptr[b]), int(kv_indptr[b + 1])
+        q_len, kv_len = qe - qs, ke - ks
+        pages = kv_pages[ks:ke].long()
+        k = k_cache[pages, 0].float()  # [kv_len, D]
+        v = v_cache[pages, 0].float()
+        delta = kv_len - q_len
+        qi = q[qs:qe].float()  # [q_len, H, D]
+        pos = torch.arange(q_len, device=q.device)[:, None] + delta
+        mask = torch.arange(kv_len, device=q.device)[None, :] <= pos
+        for h in range(H):
+            s = (qi[:, h] @ k.T) * sm_scale
+            s = s.masked_fill(~mask, float("-inf"))
+            p = torch.softmax(s, dim=-1)
+            out[qs:qe, h] = (p @ v).to(out.dtype)
+    return out
+
+
+def make_inputs(bs, q_len, kv_len, H, D, Hkv=1, seed=0, device="cuda"):
+    """Shared-prefix page layout: every request shares the first (kv_len - q_len)
+    pages and owns a unique tail, which is what prefix caching produces."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    prefix = kv_len - q_len
+    perm = torch.randperm(POOL_PAGES, generator=g)
+    shared = perm[:prefix]
+    tails = perm[prefix : prefix + bs * q_len]
+    idx = [torch.cat([shared, tails[i * q_len : (i + 1) * q_len]]) for i in range(bs)]
+    cu_q = torch.arange(bs + 1, dtype=torch.int32) * q_len
+    kv_indptr = torch.arange(bs + 1, dtype=torch.int32) * kv_len
+    return (
+        (torch.randn(bs * q_len, H, D, generator=g) * 0.5).bfloat16().to(device),
+        (torch.randn(POOL_PAGES, Hkv, D, generator=g) * 0.5).bfloat16().to(device),
+        (torch.randn(POOL_PAGES, Hkv, D, generator=g) * 0.5).bfloat16().to(device),
+        cu_q.to(device),
+        kv_indptr.to(device),
+        torch.cat(idx).to(torch.int32).to(device),
+    )
+
+
+def rms_rel(got, ref):
+    got, ref = got.float(), ref.float()
+    return ((got - ref).pow(2).mean().sqrt() / ref.pow(2).mean().sqrt()).item()
+
+
+@pytest.mark.parametrize("bs,q_len,kv_len", SHAPES)
+@pytest.mark.parametrize("D", SUPPORTED_HEAD_DIMS)
+def test_correctness(bs, q_len, kv_len, D):
+    H = 8
+    q, k, v, cu_q, kv_indptr, pages = make_inputs(bs, q_len, kv_len, H, D)
+    sm_scale = D**-0.5
+    got = mha_batch_prefill_func(
+        q, k, v, cu_q, kv_indptr, pages, q_len, kv_len, softmax_scale=sm_scale
+    )
+    assert torch.isfinite(got).all(), "output contains NaN/Inf"
+    ref = ref_attention(q, k, v, cu_q, kv_indptr, pages, sm_scale)
+    # bf16 inputs and a bf16 output: ~2e-3 is the rounding floor, not slack
+    assert rms_rel(got, ref) < 2e-2
+
+
+@pytest.mark.parametrize("delta", DELTAS)
+def test_delta_boundary_is_finite(delta):
+    """delta < BLOCK_N must not poison the first tile. Regression pin."""
+    q_len, D, H = 128, 256, 4
+    q, k, v, cu_q, kv_indptr, pages = make_inputs(1, q_len, q_len + delta, H, D)
+    sm_scale = D**-0.5
+    got = mha_batch_prefill_func(
+        q, k, v, cu_q, kv_indptr, pages, q_len, q_len + delta, softmax_scale=sm_scale
+    )
+    assert torch.isfinite(got).all(), f"NaN/Inf at delta={delta}"
+    ref = ref_attention(q, k, v, cu_q, kv_indptr, pages, sm_scale)
+    assert rms_rel(got, ref) < 2e-2
+
+
+@pytest.mark.parametrize("prescale", [0, 1, 2])
+def test_prescale_modes_agree(prescale, monkeypatch):
+    """All three q-scaling modes must land inside the same tolerance. Mode 1 folds the
+    full sm_scale*log2e into q (inexact in bf16), mode 2 folds only a power of two."""
+    import json
+
+    monkeypatch.setenv("AITER_FPP_CFG", json.dumps({"PRESCALE_Q": prescale}))
+    q_len, kv_len, D, H = 512, 4096, 256, 8
+    q, k, v, cu_q, kv_indptr, pages = make_inputs(2, q_len, kv_len, H, D)
+    sm_scale = D**-0.5
+    got = mha_batch_prefill_func(
+        q, k, v, cu_q, kv_indptr, pages, q_len, kv_len, softmax_scale=sm_scale
+    )
+    ref = ref_attention(q, k, v, cu_q, kv_indptr, pages, sm_scale)
+    assert rms_rel(got, ref) < 2e-2
+
+
+def test_unsupported_calls_are_rejected():
+    """Every condition in is_supported() must actually be reported, in particular the
+    two that would otherwise be SILENT: >1 kv head and an unsupported head dim."""
+    q, k, *_ = make_inputs(1, 128, 256, 8, 256)
+
+    assert is_supported(q, k)[0]
+
+    # more than one kv head: the kernel has no kv-head offset, so this must be refused
+    _, k2, *_ = make_inputs(1, 128, 256, 8, 256, Hkv=2)
+    ok, why = is_supported(q, k2)
+    assert not ok and "kv head" in why
+
+    # head dim 128 is correct but slower than CK-tile, so it is out of scope by policy
+    q128, k128, *_ = make_inputs(1, 128, 256, 8, 128)
+    ok, why = is_supported(q128, k128)
+    assert not ok and "head_dim" in why
+
+    for kwargs, expect in [
+        ({"causal": False}, "causal"),
+        ({"logits_soft_cap": 30.0}, "soft_cap"),
+        ({"window_size": (1024, 0)}, "window"),
+        ({"return_lse": True}, "return_lse"),
+        ({"alibi_slopes": torch.zeros(8, device=q.device)}, "alibi"),
+        ({"sink_ptr": torch.zeros(8, device=q.device)}, "sink"),
+        ({"k_descale": torch.ones(1, device=q.device)}, "descale"),
+    ]:
+        ok, why = is_supported(q, k, **kwargs)
+        assert not ok and expect in why, f"{kwargs} -> ({ok}, {why!r})"

--- a/op_tests/triton_tests/attention/test_fused_paged_prefill.py
+++ b/op_tests/triton_tests/attention/test_fused_paged_prefill.py
@@ -53,8 +53,18 @@ def ref_attention(q, k_cache, v_cache, cu_q, kv_indptr, kv_pages, sm_scale):
     return out
 
 
-def make_inputs(bs, q_len, kv_len, H, D, Hkv=1, seed=0, device="cuda",
-                dtype=torch.bfloat16, dist="normal"):
+def make_inputs(
+    bs,
+    q_len,
+    kv_len,
+    H,
+    D,
+    Hkv=1,
+    seed=0,
+    device="cuda",
+    dtype=torch.bfloat16,
+    dist="normal",
+):
     """Shared-prefix page layout: every request shares the first (kv_len - q_len)
     pages and owns a unique tail, which is what prefix caching produces."""
     g = torch.Generator(device="cpu").manual_seed(seed)

--- a/op_tests/triton_tests/attention/test_fused_paged_prefill.py
+++ b/op_tests/triton_tests/attention/test_fused_paged_prefill.py
@@ -53,7 +53,8 @@ def ref_attention(q, k_cache, v_cache, cu_q, kv_indptr, kv_pages, sm_scale):
     return out
 
 
-def make_inputs(bs, q_len, kv_len, H, D, Hkv=1, seed=0, device="cuda"):
+def make_inputs(bs, q_len, kv_len, H, D, Hkv=1, seed=0, device="cuda",
+                dtype=torch.bfloat16, dist="normal"):
     """Shared-prefix page layout: every request shares the first (kv_len - q_len)
     pages and owns a unique tail, which is what prefix caching produces."""
     g = torch.Generator(device="cpu").manual_seed(seed)
@@ -64,10 +65,19 @@ def make_inputs(bs, q_len, kv_len, H, D, Hkv=1, seed=0, device="cuda"):
     idx = [torch.cat([shared, tails[i * q_len : (i + 1) * q_len]]) for i in range(bs)]
     cu_q = torch.arange(bs + 1, dtype=torch.int32) * q_len
     kv_indptr = torch.arange(bs + 1, dtype=torch.int32) * kv_len
+
+    def mk(*sh):
+        t = torch.randn(*sh, generator=g) * 0.5
+        if dist == "spikes":
+            # large-magnitude values in the LAST tenth of the pool, so the running
+            # softmax max is revised late and the rescale path is exercised hard
+            t[int(t.shape[0] * 0.9) :] *= 12.0
+        return t.to(dtype).to(device)
+
     return (
-        (torch.randn(bs * q_len, H, D, generator=g) * 0.5).bfloat16().to(device),
-        (torch.randn(POOL_PAGES, Hkv, D, generator=g) * 0.5).bfloat16().to(device),
-        (torch.randn(POOL_PAGES, Hkv, D, generator=g) * 0.5).bfloat16().to(device),
+        mk(bs * q_len, H, D),
+        mk(POOL_PAGES, Hkv, D),
+        mk(POOL_PAGES, Hkv, D),
         cu_q.to(device),
         kv_indptr.to(device),
         torch.cat(idx).to(torch.int32).to(device),
@@ -81,9 +91,10 @@ def rms_rel(got, ref):
 
 @pytest.mark.parametrize("bs,q_len,kv_len", SHAPES)
 @pytest.mark.parametrize("D", SUPPORTED_HEAD_DIMS)
-def test_correctness(bs, q_len, kv_len, D):
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_correctness(bs, q_len, kv_len, D, dtype):
     H = 8
-    q, k, v, cu_q, kv_indptr, pages = make_inputs(bs, q_len, kv_len, H, D)
+    q, k, v, cu_q, kv_indptr, pages = make_inputs(bs, q_len, kv_len, H, D, dtype=dtype)
     sm_scale = D**-0.5
     got = mha_batch_prefill_func(
         q, k, v, cu_q, kv_indptr, pages, q_len, kv_len, softmax_scale=sm_scale
@@ -125,6 +136,41 @@ def test_prescale_modes_agree(prescale, monkeypatch):
     assert rms_rel(got, ref) < 2e-2
 
 
+def test_default_scaling_mode_is_exact():
+    """The default must stay on a bf16-exact scaling mode.
+
+    Mode 1 is 3.4% faster but its rounding error is data-dependent: on a distribution
+    with large late kv values it measured 7.0x the CK-tile path's error against fp32
+    while still passing the 2e-2 budget above, so that budget alone does not protect
+    this choice.
+    """
+    from aiter.ops.triton.attention.fused_paged_prefill import _DEFAULT_CFG
+
+    assert _DEFAULT_CFG["PRESCALE_Q"] in (0, 2)
+
+
+@pytest.mark.parametrize("prescale", [1, 2])
+def test_exact_mode_is_robust_to_late_kv_spikes(prescale, monkeypatch):
+    """Pins the measurement behind the default: on the spiked distribution the exact
+    mode holds near the bf16 floor while the folded mode degrades by ~7x."""
+    import json
+
+    monkeypatch.setenv("AITER_FPP_CFG", json.dumps({"PRESCALE_Q": prescale}))
+    q_len, kv_len, D, H = 512, 8192, 256, 8
+    q, k, v, cu_q, kv_indptr, pages = make_inputs(2, q_len, kv_len, H, D, dist="spikes")
+    sm_scale = D**-0.5
+    got = mha_batch_prefill_func(
+        q, k, v, cu_q, kv_indptr, pages, q_len, kv_len, softmax_scale=sm_scale
+    )
+    ref = ref_attention(q, k, v, cu_q, kv_indptr, pages, sm_scale)
+    err = rms_rel(got, ref)
+    assert torch.isfinite(got).all()
+    if prescale == 2:
+        assert err < 2e-3, f"exact mode degraded on spiked kv: {err:.3e}"
+    else:
+        assert err < 2e-2
+
+
 def test_unsupported_calls_are_rejected():
     """Every condition in is_supported() must actually be reported, in particular the
     two that would otherwise be SILENT: >1 kv head and an unsupported head dim."""
@@ -153,3 +199,33 @@ def test_unsupported_calls_are_rejected():
     ]:
         ok, why = is_supported(q, k, **kwargs)
         assert not ok and expect in why, f"{kwargs} -> ({ok}, {why!r})"
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_adversarial_distribution(dtype):
+    """Large-magnitude values late in the kv range force the online-softmax running
+    max to be revised on a late tile, which is where a rescale bug would show."""
+    bs, q_len, kv_len, H, D = 2, 512, 8192, 8, 256
+    q, k, v, cu_q, kv_indptr, pages = make_inputs(
+        bs, q_len, kv_len, H, D, dtype=dtype, dist="spikes"
+    )
+    sm_scale = D**-0.5
+    got = mha_batch_prefill_func(
+        q, k, v, cu_q, kv_indptr, pages, q_len, kv_len, softmax_scale=sm_scale
+    )
+    assert torch.isfinite(got).all(), "non-finite output on the spiked distribution"
+    ref = ref_attention(q, k, v, cu_q, kv_indptr, pages, sm_scale)
+    assert rms_rel(got, ref) < 2e-2
+
+
+def test_large_shape():
+    """One shape at the scale this kernel is actually for: a long shared prefix."""
+    bs, q_len, kv_len, H, D = 2, 2048, 40960, 8, 256
+    q, k, v, cu_q, kv_indptr, pages = make_inputs(bs, q_len, kv_len, H, D)
+    sm_scale = D**-0.5
+    got = mha_batch_prefill_func(
+        q, k, v, cu_q, kv_indptr, pages, q_len, kv_len, softmax_scale=sm_scale
+    )
+    assert torch.isfinite(got).all()
+    ref = ref_attention(q, k, v, cu_q, kv_indptr, pages, sm_scale)
+    assert rms_rel(got, ref) < 2e-2


### PR DESCRIPTION
A Triton kernel for the `mha_batch_prefill_func` seam, taken only for causal page_size=1 calls
with one kv head and head dim 64 or 256. On that envelope it is **1.40–1.50× the CK-tile
kernel**, worth **+8.64% end-to-end** on an SGLang Qwen3.8-2.4T-A95B TP8 server at 68k context on
8× MI355X, and **+8.93%** on that same server when the 68k prompts share no prefix. Everything
outside the envelope falls through to CK-tile bit-identically.

One finding deserves more attention than the headline: **a kernel benchmark cannot see either effect that
decided this PR** — the JIT compile stalls `do_not_specialize` prevents are host-side (§3), and CK-tile's
own baseline is bimodal between processes (§2), enough on its own to reorder two variants timed apart.

## Motivation

At 68k context with a shared prefix this workload is 81.8% prefill by GPU time, and
`FmhaBatchPrefillWithPagedKVCache` (ck_tile) was the largest kernel in the profile at **33.07% of GPU
time**. CK-tile stages K and V through LDS (`qr_ks_vs_async`), which at head dim 256 with page_size=1
costs more than it buys: the pages are already scattered, so the round-trip buys no reuse registers miss,
and it caps occupancy. Keeping K/V tiles in registers and never touching LDS — plus dropping the
prefix/extend split and the `K_Extend`/`V_Extend` gather — reaches **902–943 TFLOP/s against CK-tile's
616–622** at the dominant live shape.

## Technical details

**1. Bulk/tail split of the KV loop.** Causal masking with a paged extend is bottom-right aligned by
`delta = kv_len - q_len`, so an m-tile at `m_start` sees every kv position below `m_start + delta + 1`.
The loop splits at `((m_start + delta + 1) // BLOCK_N) * BLOCK_N`: a bulk range with **no `tl.where`
and no mask arithmetic at all**, then a masked tail over the diagonal. At `delta = 63,240` and
`q_len = 16,384` the tail is at most two tiles out of ~2,220.

**2. Head-major grid** `(H, num_m, batch)`, so the 8 GQA heads sharing one (request, m-tile)
dispatch consecutively, read *identical* K/V pages and hit one XCD's L2 instead of each pulling
the same pages. Pure relabeling: same kv range per program, same reduction order per row.

**3. `do_not_specialize=["NUM_M", "BS"]` holds the JIT to one kernel.** Both derive from `max_seqlen_q`
and batch size, which a live scheduler varies call-to-call; left in the JIT key, ragged traffic
compiles a kernel per specialization bucket *inside the serving path*, at ~0.5 s of host stall each
and no steady-state gain (§3). Same reason the config is a static dict, not `@triton.autotune`.

**4. `PRESCALE_Q` defaults to the exact mode.** Mode 1 folds the full `sm_scale * log2e` into q,
inexact in bf16; mode 2 folds only the power-of-two part and puts the remainder on the qk product.
Mode 1 buys **≤1%** of kernel time (0.7% in each of two processes) but its error is **data-dependent**:
with large late kv values it measured **8.0× CK-tile's error** against fp32 (7.8e-3 vs 9.8e-4) while
still passing a 2e-2 budget, where mode 2 matches CK-tile at 1.00×.

**5. Register budget and tile order, worth 12% together.** `num_warps=4` rather than 8, because 8 caps
the budget at 256 VGPR/thread and this kernel **spills 113 registers** at head dim 256, where 4 warps let
it settle at 419 with none, occupancy staying 1 wave/SIMD either way (+5.6%). Tiles issue **longest-first**:
tile `m` scans kv up to `delta + m + BLOCK_M`, so ascending `m` runs the shortest tiles first and lets the
longest straggle, and reversing via the runtime `NUM_M` shortens that tail (+2%). Plus a guarded
`schedule_hint="attention,memory-bound-attention"` (+2%).

## Scope: two conditions guard against silent wrongness

`mha_batch_prefill_func` calls `is_supported()` and falls through unchanged when it fails;
`AITER_FUSED_PAGED_PREFILL=0` disables the path. Default-on because every dispatched case is one I
measured faster, but that is a policy call, not a measurement — **happy to invert it to opt-in.**

The predicate accounts for all 27 parameters of the current signature: 19 gated here, 7 forwarded into
the kernel, and `deterministic` unused by this CK path. Most rejections — non-causal, sliding window,
soft cap, `return_lse`, alibi, sinks, fp8 descales, dropout — are unimplemented features that would
fail loudly. These would not, and each is pinned by a test:

- **More than one kv head is silently wrong.** K/V are addressed as `base + page * stride(0) + offs_d`
  with **no kv-head term**, so at `num_kv_heads=2` every query head reads kv head 0 and the kernel returns
  a plausible tensor with **rms error ≈ 1.0** — no NaN, no fault. One kv head is normal for a GQA model
  whose kv heads are replicated across TP ranks (4 at TP8), but nothing downstream detects the bad case.
- **`kv_block_descale`, `seqlen_k`, `sink_size`, and a V head dim differing from Q's** would be
  honoured by CK-tile and silently ignored here, as would a non-unit-stride last dim, which the
  kernel assumes when it adds `offs_d` to the base pointer.
- **Head dim 128 is correct but only reaches parity** (1.04×, CK-tile being tuned for the head dim most
  models use). Excluding it on that basis is why `SUPPORTED_HEAD_DIMS` is a list rather than
  `is_power_of_two()`; 192 fails to compile, loud but still not something to dispatch.
- **`out=` is an aliasing contract** here: CK-tile passes the caller's buffer down to be written,
  so a caller may read it rather than the return value. The kernel now writes it.

## Test plan

```bash
python3 -m pytest op_tests/triton_tests/attention/test_fused_paged_prefill.py -q  # 44 passed
python3 -m pytest op_tests/test_batch_prefill_triton_dispatch.py -q               # 28 passed
```

**End-to-end A/B (primary).** 8× MI355X (gfx950), SGLang TP8, Qwen3.8-2.4T-A95B-Quark-MXFP4,
`--attention-backend aiter`, page_size 1, bf16 KV; 68,000-token prompts, 350 output tokens, concurrency 8,
40 requests, seed 42; two back-to-back A/B blocks, 4 repeats per leg, deltas formed **only within a pair**;
run once with a 63,240-token shared prefix and once with no prefix reuse. Engagement was proven rather
than assumed — a banner and call counter showed all 8 ranks engaged, **0 fallbacks** per leg.

**Non-interference.** For every call shape the predicate rejects, the op runs with the fast path on
and off and the outputs must be **bit-identical**, with zero Triton entries. Each case first runs the
off-leg twice as its own control, so CK's own nondeterminism cannot look like interference.

**Existing suite.** `op_tests/test_batch_prefill.py` collects 41,144 cases and aborts on the stock
container build *before* this change, so it is unusable whole; a deterministic 301-case sample stands in.

**Isolated kernel.** An independent harness — own inputs, timing loop and chunked fp32 reference, no
shared code with the tooling that produced the kernel — replays the captured live shapes, sweeps one
axis at a time, streams ragged shapes past both JIT variants (§3), and **cross-checks every timed point
against CK-tile** so a "win" that is a wrong answer cannot be reported as one.

## Test result

MI355X (gfx950, 256 CU), `rocm/sgl-dev@sha256:95a93389`, ROCm 7.2, torch 2.9.1.

### 1. End-to-end

| workload | ref | candidate | delta | paired positions |
| ---- | ---- | ---- | ---- | ---- |
| 63,240-token shared prefix + 4,760 unique | 248.75 tok/s | **270.24 tok/s** | **+8.64%** | 8/8 positive, +5.45 … +11.45 |
| 68k prompts, no prefix reuse | 71.74 tok/s | **78.15 tok/s** | **+8.93%** | 8/8 positive, +8.85 … +10.63 |

Both rows are the shipped default: four fresh-server legs each, ordered ref, cand, ref2, cand2, deltas
formed only within a pair. 16 of 16 paired positions positive is the part I would rely on — a distribution
that never crosses zero is a different claim from one with spread on both sides — and removing prefix
reuse makes every request pay a full 68k prefill, so the mechanism calls the second row in advance.
Median TTFT falls in both regimes (2479→2351 ms, 16723→15117 ms). GSM8K, 200 problems per leg: ref
0.970/0.965 against cand 0.960/0.965, and 0.970/0.970 against 0.970/0.960 — inside the 0.03 tolerance
and inside the 0.945–0.975 spread the reference legs show among themselves.

### 2. Isolated kernel vs CK-tile, shipped default

The four captured live shapes in **10 fresh processes**. CK-tile's time here is **bimodal and sticky
within a process** — all four shapes shift together, 1 of the 10 landed in its fast cluster — so each
row carries both CK clusters and the speedup against each:

| captured live shape (bs, total q, total kv) | share of live prefill | CK-tile fast / slow | this kernel | speedup |
| ---- | ---- | ---- | ---- | ---- |
| 2, 16,384, 142,155 | 34% | 13.57 / 14.55 ms | 9.50–9.68 ms | 1.43× / 1.53× |
| 3, 16,384, 212,565 | 29% | 17.17 / 18.39 ms | 12.49–12.52 ms | 1.37× / 1.47× |
| 3, 14,949, 218,211 | 25% | 14.22 / 15.22 ms | 10.56–10.70 ms | 1.34× / 1.44× |
| 1, 7,066, 72,858 | 12% | 7.08 / 7.58 ms | 4.55–4.82 ms | 1.51× / 1.66× |
| **weighted by share** | | | | **1.40× / 1.50×** |

This kernel is the stable side: 9.50–9.68 ms at the dominant shape across all 10 processes, a 1.9%
spread, 902–943 TFLOP/s against CK-tile's 616–622, every point agreeing with CK-tile's own output to
2.4–2.6e-3. What selects CK's cluster is unidentified; it cannot affect §1, a whole-server A/B, but two
variants timed in *different* processes mostly report which cluster each landed in (§3). One axis at a time
from `bs2 q8192 kv71077 D256`: head dim 64 **1.55–1.61×** against 1.46–1.48× at 256, flat in kv_len
(1.50× at 2,048, 1.46× at 131,072), shrinking with q_len (1.76× at 256 → 1.45× at 16,384).

### 3. What `do_not_specialize` buys

Same kernel with and without the annotation, 64 calls over ragged shapes, each point in its own
process with a cold Triton cache (sharing one turns every later "cold" stream into a deserialize):

| distinct ragged shapes | kernels compiled, with / without | extra host stall, without |
| ---- | ---- | ---- |
| 1 | 1 / 1 | +7 ms |
| 2 | 1 / 2 | +1638 ms |
| 16 | 1 / 4 | +4968 ms |

Triton specializes both on `==1` and `%16==0`, so the count is bounded by bucket rather than one per
shape; with the annotation it stays at **one kernel** whatever the scheduler feeds it. This is not a speed
change — paired in the same 10 processes the two variants measure 1.400–1.500× and 1.407–1.505× against
CK-tile, a −0.6% … +0.7% per-process gap. What it removes is a ~1.6 s **host-side** stall
per new bucket from live requests, which HIP-event timing cannot see.

### 4. Correctness

| check | result |
| ---- | ---- |
| vs chunked fp32 ref, 6 shapes × head dim 64/256 × bf16/fp16 | 2.2–2.4e-3, matching CK-tile on the same inputs |
| error ratio vs CK-tile, benign / spiked-kv distributions | **1.000× / 0.997×** |
| `delta` boundary: 0, 1, 16, 32, 62, 63, 64, 65, 128, 1024 | all finite, all 2.0–2.4e-3 |
| rejected calls, fast path on vs off (28 cases) | **bit-identical**, 0 kernel entries |
| `out=` buffer written, return value aliases it | pass |
| 301-case sample of `test_batch_prefill.py`, patched vs not | identical (170 passed / 131 skipped) |

The `delta` boundary is pinned because a sibling implementation from the same tooling **returned NaN for
every `delta < BLOCK_N - 1`**, the region a shared-prefix workload never exercises. That 301-case sample
enters the fast path **zero times** — upstream tests head dim 128 at page_size 1, and 256 only at
page_size 16/1024 — so this envelope is untested upstream.

## Known gaps

- **Head dim coverage is three points** — 64/256 good, 128 parity, 192 non-power-of-two. Only 64/256
  dispatch; `SUPPORTED_HEAD_DIMS` is an allowlist, so the other two are rejected and tested as rejected.
- **No backward pass** and no `return_lse`, so this cannot serve training.
- **Not bit-identical to CK-tile** on calls it takes (accumulation order); it *is* on calls it does not.
- **`kpack=2` is silently ignored on gfx950** (Triton overwrites it to 1); left in as-measured.
- **Kernel and wrapper share one file**, where most of `attention/` splits the `@triton.jit` half into `_triton_kernels/`: it has a single caller and the predicate reads beside it, as in `mla_decode.py`. Happy to match the split.

## AI assistance

This came out of [GEAK](https://github.com/AMD-AGI/GEAK), AMD's agentic GPU-kernel optimization
framework, running an end-to-end pass against a live SGLang Qwen3.8 TP8 server; the kernel body is GEAK's.
Changes were measured and re-gated by hand. Every number was measured or reproduced before being written down.

## Submission checklist

- [x] Contributing guidelines: [ROCm/CONTRIBUTING.md](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests)
