### PR TITLE
[FlyDSL] [gfx950] Add dense BF16 x MXFP4 GEMM

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -38,6 +38,13 @@ if is_flydsl_available():
         )
 
     from .fmha_kernels import flydsl_flash_attn_func
+    from .gemm_a16wfp4 import (
+        DenseGemmConfig,
+        PreshuffledA16WFP4Weight,
+        a16wfp4_shape_supported,
+        flydsl_gemm_a16wfp4,
+        prepare_gemm_a16wfp4_weight,
+    )
     from .gemm_kernels import flydsl_hgemm, flydsl_preshuffle_gemm_a8
     from .kernels.mqa_logits.fp8_mqa_logits import (
         DEFAULT_VARIANT as FP8_MQA_LOGITS_DEFAULT_VARIANT,
@@ -65,9 +72,13 @@ if is_flydsl_available():
     __all__ += [
         "FP8_MQA_LOGITS_DEFAULT_VARIANT",
         "FP8_MQA_LOGITS_VARIANTS",
+        "DenseGemmConfig",
+        "PreshuffledA16WFP4Weight",
+        "a16wfp4_shape_supported",
         "compute_varqlen_windows",
         "flydsl_flash_attn_func",
         "flydsl_fp8_mqa_logits",
+        "flydsl_gemm_a16wfp4",
         "flydsl_hgemm",
         "flydsl_mla_reduce_v1",
         "flydsl_moe_stage1",
@@ -77,5 +88,6 @@ if is_flydsl_available():
         "flydsl_pa_mqa_logits_fp4_varqlen",
         "flydsl_preshuffle_gemm_a8",
         "flydsl_qk_norm_rope_quant",
+        "prepare_gemm_a16wfp4_weight",
         # "flydsl_gdr_decode",
     ]

--- a/aiter/ops/flydsl/gemm_a16wfp4.py
+++ b/aiter/ops/flydsl/gemm_a16wfp4.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""High-level gfx950 dense BF16 x MXFP4 FlyDSL API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import torch
+
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+from .kernels.gemm_a16wfp4 import compile_gemm_a16wfp4
+from .kernels.tensor_shim import _run_compiled
+
+__all__ = [
+    "DenseGemmConfig",
+    "PreshuffledA16WFP4Weight",
+    "a16wfp4_config_legal",
+    "a16wfp4_shape_supported",
+    "flydsl_gemm_a16wfp4",
+    "prepare_gemm_a16wfp4_weight",
+]
+
+_TILE_K = 256
+_N_ALIGN = 256
+_K_ALIGN = 256
+_MAX_LDS_BYTES = 163840
+
+
+class DenseGemmConfig(NamedTuple):
+    """Tile and occupancy knobs for one dense A16WFP4 launch."""
+
+    block_m: int
+    tile_n: int
+    tile_k: int
+    k_wave: int
+    waves_per_eu: int | None
+
+
+@dataclass(frozen=True)
+class PreshuffledA16WFP4Weight:
+    """One-time prepared dense MXFP4 weight and E8M0 scale buffers."""
+
+    weight: torch.Tensor
+    scale: torch.Tensor
+    n: int
+    k: int
+
+
+def _require_gfx950() -> None:
+    arch = str(get_gfx()).split(":", 1)[0]
+    if arch != "gfx950":
+        raise RuntimeError(f"flydsl_gemm_a16wfp4 requires gfx950, got {arch!r}")
+
+
+def a16wfp4_shape_supported(n: int, k: int) -> bool:
+    """Return whether packed ``[N, K]`` can run the fused gfx950 kernel."""
+    return n > 0 and k > 0 and n % _N_ALIGN == 0 and k % _K_ALIGN == 0
+
+
+def a16wfp4_config_legal(n: int, k: int, cfg: DenseGemmConfig) -> bool:
+    """Return whether ``cfg`` can compile for packed ``[N, K]`` without overflowing LDS."""
+    if cfg.block_m <= 0 or cfg.block_m % 16:
+        return False
+    if cfg.tile_k <= 0 or cfg.tile_k % 128 or k % cfg.tile_k:
+        return False
+    if cfg.k_wave not in (1, 2, 4):
+        return False
+    if k % (cfg.k_wave * cfg.tile_k):
+        return False
+    n_tile_align = 16 * (4 // cfg.k_wave)
+    if cfg.tile_n < n_tile_align or cfg.tile_n % n_tile_align or n % cfg.tile_n:
+        return False
+    from .kernels.gemm_a16wfp4_helpers import DenseGemmTraits
+
+    try:
+        traits = DenseGemmTraits(
+            n,
+            k,
+            cfg.block_m,
+            cfg.tile_n,
+            cfg.tile_k,
+            2,
+            k_wave=cfg.k_wave,
+            waves_per_eu=cfg.waves_per_eu,
+        )
+    except ValueError:
+        return False
+    return traits.lds_bytes <= _MAX_LDS_BYTES
+
+
+def _select_tile_n(n: int, prefer: int) -> int:
+    if n % prefer == 0:
+        return prefer
+    if n % 256 == 0:
+        return 256
+    if n % 128 == 0:
+        return 128
+    raise ValueError(f"N={n} is not divisible by 128 or 256")
+
+
+def _select_k_wave(k: int, tile_k: int, max_k_wave: int = 4) -> int:
+    for k_wave in (4, 2, 1):
+        if k_wave <= max_k_wave and k % (k_wave * tile_k) == 0:
+            return k_wave
+    return 1
+
+
+_TARGET_BLOCKS = 256  # gfx950 CU count
+
+
+def _decode_tile_n(m: int, n: int, k_wave: int) -> int:
+    """Widest N tile that still puts a workgroup on every CU."""
+    align = 16 * (4 // k_wave)
+    grid_m = (m + 15) // 16
+    legal = [
+        tile_n
+        for tile_n in (256, 128, 64, 32, 16)
+        if tile_n >= align and tile_n % align == 0 and n % tile_n == 0
+    ]
+    for tile_n in legal:
+        if grid_m * (n // tile_n) >= _TARGET_BLOCKS:
+            return tile_n
+    return legal[-1]
+
+
+def _decode_config(m: int, n: int, k: int) -> DenseGemmConfig:
+    """Decode is grid-bound, not bandwidth-bound: size the tile to fill the GPU.
+
+    Measured on MI355X at M=1: the fused kernel sustains ~17 GB/s per resident
+    workgroup, so time scales with 1/workgroups until every CU has one. Halving
+    TILE_N from the compute-optimal 128 down to the grid-optimal width measured
+    1.56x on (8448,7168) and 3.09x on (1536,7168).
+    """
+    k_wave = _select_k_wave(k, _TILE_K, max_k_wave=4)
+    if k_wave == 1:
+        # K too short for split-K: its K loop cannot hide the extra dispatch of
+        # a narrower tile, so keep the wide one.
+        return DenseGemmConfig(16, _select_tile_n(n, 128), _TILE_K, 1, 2)
+    return DenseGemmConfig(
+        block_m=16,
+        tile_n=_decode_tile_n(m, n, k_wave),
+        tile_k=_TILE_K,
+        k_wave=k_wave,
+        waves_per_eu=4 if n >= 4096 else 1,
+    )
+
+
+# Measured gfx950 winners for Kimi-K3 production (N, K), as ascending M
+# breakpoints; the last entry with ``m_min <= M`` wins. A wider tile decodes
+# fewer MXFP4 blocks per MFMA but launches fewer workgroups, and that trade only
+# pays when the resulting tile count still fills whole 256-CU waves, so the
+# winner moves with M rather than with a single size class.
+_K3_MEASURED: dict[tuple[int, int], tuple[tuple[int, DenseGemmConfig], ...]] = {
+    (8448, 7168): (
+        (64, DenseGemmConfig(32, 128, 256, 1, 1)),
+        (512, DenseGemmConfig(48, 192, 256, 1, 2)),
+        (1024, DenseGemmConfig(64, 192, 128, 1, 2)),
+    ),
+    (1536, 7168): (
+        (64, DenseGemmConfig(16, 96, 128, 4, 2)),
+        (768, DenseGemmConfig(32, 128, 256, 1, 2)),
+        (2048, DenseGemmConfig(32, 256, 128, 1, 1)),
+    ),
+    (7168, 768): (
+        (64, DenseGemmConfig(32, 128, 256, 1, 2)),
+        (1024, DenseGemmConfig(64, 256, 128, 1, 2)),
+    ),
+    (3584, 512): (
+        (64, DenseGemmConfig(32, 128, 256, 1, 2)),
+        (1024, DenseGemmConfig(32, 256, 128, 1, 1)),
+    ),
+}
+
+
+def _select_gemm_config(m: int, n: int, k: int) -> DenseGemmConfig:
+    """Grid-filling decode rule, then measured K3 breakpoints, then a heuristic."""
+    if m < 64:
+        return _decode_config(m, n, k)
+    measured = _K3_MEASURED.get((n, k))
+    if measured is not None:
+        return next(cfg for m_min, cfg in reversed(measured) if m >= m_min)
+
+    tile_k = _TILE_K
+    if m >= 4096 or (k <= 512 and m >= 2048):
+        return DenseGemmConfig(
+            block_m=32,
+            tile_n=_select_tile_n(n, 256),
+            tile_k=tile_k,
+            k_wave=1,
+            waves_per_eu=1,
+        )
+    return DenseGemmConfig(
+        block_m=16,
+        tile_n=_select_tile_n(n, 128),
+        tile_k=tile_k,
+        k_wave=1,
+        waves_per_eu=2,
+    )
+
+
+def prepare_gemm_a16wfp4_weight(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+) -> PreshuffledA16WFP4Weight:
+    """Preshuffle packed E2M1 ``[N,K/2]`` and E8M0 ``[N,K/32]`` once."""
+    _require_gfx950()
+    if weight.ndim != 2 or scale.ndim != 2:
+        raise ValueError(
+            "weight and scale must be 2D; "
+            f"got weight.ndim={weight.ndim}, scale.ndim={scale.ndim}"
+        )
+    if weight.device.type != "cuda" or scale.device.type != "cuda":
+        raise ValueError("weight and scale must be CUDA/ROCm tensors")
+    if weight.device != scale.device:
+        raise ValueError(
+            f"weight and scale must be on the same device, got {weight.device} and {scale.device}"
+        )
+    if weight.element_size() != 1 or scale.element_size() != 1:
+        raise TypeError(
+            "weight must be byte-packed E2M1 and scale must be byte E8M0; "
+            f"got element sizes {weight.element_size()} and {scale.element_size()}"
+        )
+
+    n, packed_k = weight.shape
+    k = packed_k * 2
+    if n % 256:
+        raise ValueError(f"N must be divisible by 256, got {n}")
+    if k % 256:
+        raise ValueError(f"K must be divisible by 256, got {k}")
+    if tuple(scale.shape) != (n, k // 32):
+        raise ValueError(
+            f"scale must have shape {(n, k // 32)}, got {tuple(scale.shape)}"
+        )
+
+    weight_u8 = weight.contiguous().view(torch.uint8)
+    scale_u8 = scale.contiguous().view(torch.uint8)
+    shuffled_weight = shuffle_weight_a16w4(
+        weight_u8.unsqueeze(0), NLane=16, gate_up=False
+    ).squeeze(0)
+    shuffled_scale = shuffle_scale_a16w4(scale_u8, experts_cnt=1, gate_up=False)
+    return PreshuffledA16WFP4Weight(
+        weight=shuffled_weight,
+        scale=shuffled_scale,
+        n=n,
+        k=k,
+    )
+
+
+def flydsl_gemm_a16wfp4(
+    a: torch.Tensor,
+    prepared_weight: PreshuffledA16WFP4Weight,
+    *,
+    out: torch.Tensor | None = None,
+    stream: torch.cuda.Stream | None = None,
+    config: DenseGemmConfig | None = None,
+) -> torch.Tensor:
+    """Compute ``A @ W.T`` without quantizing or otherwise transforming ``A``."""
+    _require_gfx950()
+    if not isinstance(prepared_weight, PreshuffledA16WFP4Weight):
+        raise TypeError("prepared_weight must come from prepare_gemm_a16wfp4_weight()")
+    if a.ndim != 2:
+        raise ValueError(f"a must be 2D, got a.ndim={a.ndim}")
+    if a.dtype != torch.bfloat16:
+        raise TypeError(f"a must be BF16, got {a.dtype}")
+    if a.device.type != "cuda":
+        raise ValueError("a must be a CUDA/ROCm tensor")
+    if not a.is_contiguous():
+        raise ValueError("a must be contiguous")
+
+    m, k = a.shape
+    if m <= 0:
+        raise ValueError(f"M must be positive, got {m}")
+    if k != prepared_weight.k:
+        raise ValueError(
+            f"a K={k} does not match prepared weight K={prepared_weight.k}"
+        )
+    if a.device != prepared_weight.weight.device:
+        raise ValueError(
+            f"a and prepared weight must share a device, got {a.device} and "
+            f"{prepared_weight.weight.device}"
+        )
+
+    expected_shape = (m, prepared_weight.n)
+    if out is None:
+        out = torch.empty(expected_shape, dtype=torch.bfloat16, device=a.device)
+    else:
+        if tuple(out.shape) != expected_shape:
+            raise ValueError(
+                f"out must have shape {expected_shape}, got {tuple(out.shape)}"
+            )
+        if out.dtype != torch.bfloat16 or out.device != a.device:
+            raise ValueError(
+                f"out must be BF16 on {a.device}, got dtype={out.dtype}, device={out.device}"
+            )
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
+
+    launch_stream = torch.cuda.current_stream(a.device) if stream is None else stream
+    if launch_stream.device != a.device:
+        raise ValueError(
+            f"stream must be on {a.device}, got stream device {launch_stream.device}"
+        )
+
+    cfg = _select_gemm_config(m, prepared_weight.n, k) if config is None else config
+    if not isinstance(cfg, DenseGemmConfig):
+        raise TypeError(f"config must be DenseGemmConfig, got {type(cfg)!r}")
+    launcher = compile_gemm_a16wfp4(
+        N=prepared_weight.n,
+        K=prepared_weight.k,
+        BM=cfg.block_m,
+        TILE_N=cfg.tile_n,
+        TILE_K=cfg.tile_k,
+        k_wave=cfg.k_wave,
+        waves_per_eu=cfg.waves_per_eu,
+    )
+    _run_compiled(
+        launcher,
+        a.data_ptr(),
+        prepared_weight.weight.data_ptr(),
+        prepared_weight.scale.data_ptr(),
+        out.data_ptr(),
+        int(m),
+        launch_stream,
+    )
+    return out

--- a/aiter/ops/flydsl/kernels/gemm_a16wfp4.py
+++ b/aiter/ops/flydsl/kernels/gemm_a16wfp4.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""gfx950 dense BF16 x MXFP4 GEMM kernel.
+
+The activation is consumed as BF16 without quantization. Preshuffled packed
+E2M1 weights and E8M0 block scales are loaded directly into registers, where
+``v_cvt_scalef32_pk_bf16_fp4`` produces transient BF16 fragments for
+``mfma_f32_16x16x32_bf16``. A dequantized weight matrix is never written to
+global memory.
+
+The K loop double-buffers A-LDS. Prefill (``k_wave=1``) still issues the next
+A/B tile before MFMA. Decode (``k_wave>1``) issues after MFMA so only one B
+tile is live in the cvt cluster and occupancy can rise above 1.
+"""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+from flydsl.runtime.device import get_rocm_arch
+
+from .gemm_a16wfp4_helpers import (
+    DenseGemmTraits,
+    advance_k_tile,
+    compute_dense_tile,
+    load_a_frags,
+    load_b_tile,
+    make_dense_accumulators,
+    make_dense_operand_loaders,
+    make_dense_store,
+    reduce_dense_k_wave,
+    store_dense_bf16,
+)
+
+__all__ = ["compile_gemm_a16wfp4"]
+
+
+@functools.cache
+def compile_gemm_a16wfp4(
+    *,
+    N: int,
+    K: int,
+    BM: int = 16,
+    TILE_N: int = 256,
+    TILE_K: int = 256,
+    b_cache_mod: int = 0,
+    k_wave: int = 1,
+    waves_per_eu: int | None = None,
+):
+    """Compile a cached gfx950 launcher; B loads default to cache reuse."""
+    arch = str(get_rocm_arch()).split(":", 1)[0]
+    if arch != "gfx950":
+        raise ValueError(f"dense a16wfp4 FlyDSL kernel requires gfx950, got {arch!r}")
+    if BM <= 0 or BM % 16:
+        raise ValueError(f"BM must be a positive multiple of 16, got {BM}")
+    if TILE_K <= 0 or TILE_K % 128 or K % TILE_K:
+        raise ValueError(
+            f"TILE_K must be a multiple of 128 dividing K; got TILE_K={TILE_K}, K={K}"
+        )
+    if K % 256:
+        raise ValueError(f"K must be divisible by 256 for the scale layout, got {K}")
+    if k_wave not in (1, 2, 4):
+        raise ValueError(f"k_wave must be 1, 2, or 4, got {k_wave}")
+    if K % (k_wave * TILE_K):
+        raise ValueError(f"K={K} must be divisible by k_wave*TILE_K={k_wave * TILE_K}")
+    # The N tile is split across 4//k_wave waves, each owning whole 16-wide MFMA
+    # N blocks. Split-K decode therefore admits tiles below 64 to widen the grid.
+    n_tile_align = 16 * (4 // k_wave)
+    if TILE_N < n_tile_align or TILE_N % n_tile_align or N % TILE_N:
+        raise ValueError(
+            f"TILE_N must be a multiple of {n_tile_align} dividing N; "
+            f"got TILE_N={TILE_N}, N={N}, k_wave={k_wave}"
+        )
+
+    traits = DenseGemmTraits(
+        N,
+        K,
+        BM,
+        TILE_N,
+        TILE_K,
+        b_cache_mod,
+        k_wave=k_wave,
+        waves_per_eu=waves_per_eu,
+    )
+    cache_tag = traits.cache_key
+    block_m = traits.block_m
+    n_blocks = traits.n_blocks
+    a_lds_stages = traits.a_lds_stages
+
+    @fx.struct
+    class SharedStorage:
+        raw: fx.Array[fx.Uint8, traits.lds_bytes, 16]
+
+    @flyc.kernel(name=traits.kernel_name, known_block_size=[256, 1, 1])
+    def kernel(
+        arg_a: fx.Int64,
+        arg_bq: fx.Int64,
+        arg_bscale: fx.Int64,
+        arg_out: fx.Int64,
+        i32_m: fx.Int32,
+    ):
+        const_expr(cache_tag)
+        lds_raw_ptr = fx.SharedAllocator().allocate(SharedStorage).peek().raw.ptr
+        tx = fx.Int32(gpu.thread_id("x"))
+        lane = tx % 64
+        wave = rocdl.readfirstlane(T.i32, tx // 64)
+
+        # X varies fastest, so consecutive workgroups reuse one cached B tile
+        # across M blocks without runtime div/mod in the kernel prologue.
+        m_block = fx.Int32(gpu.block_id("x"))
+        n_block = fx.Int32(gpu.block_id("y"))
+        m_row = m_block * traits.block_m
+        n_row = n_block * traits.tile_n
+
+        a_loader, b_loader, columns, wave_n_id, wave_k_id = make_dense_operand_loaders(
+            traits,
+            lds_raw_ptr,
+            arg_a,
+            arg_bq,
+            arg_bscale,
+            i32_m,
+            m_row,
+            n_row,
+            lane,
+            wave,
+        )
+
+        accumulators = make_dense_accumulators(traits)
+        mma_atom = fx.make_mma_atom(fx.rocdl.MFMA(16, 16, 32, fx.BFloat16))
+        k_base = (
+            wave_k_id * fx.Int32(traits.k_len) if traits.k_wave > 1 else fx.Int32(0)
+        )
+
+        a_loader.store_tile(k_base, slot=0)
+        b_cur = load_b_tile(traits, b_loader, columns, k_base)
+        for kt in range_constexpr(traits.k_tiles):
+            rocdl.s_waitcnt(lgkmcnt=0)
+            gpu.barrier()
+            a_frags = load_a_frags(traits, a_loader, kt % a_lds_stages)
+            if const_expr(traits.k_wave > 1):
+                # Split-K keeps a single B tile live so occupancy can rise;
+                # prefill issues the next tile first to keep the pipeline full.
+                compute_dense_tile(
+                    traits, mma_atom, accumulators, b_loader, b_cur, a_frags
+                )
+                if const_expr(kt + 1 < traits.k_tiles):
+                    b_cur = advance_k_tile(
+                        traits, a_loader, b_loader, columns, k_base, kt
+                    )
+            else:
+                if const_expr(kt + 1 < traits.k_tiles):
+                    b_nxt = advance_k_tile(
+                        traits, a_loader, b_loader, columns, k_base, kt
+                    )
+                compute_dense_tile(
+                    traits, mma_atom, accumulators, b_loader, b_cur, a_frags
+                )
+                if const_expr(kt + 1 < traits.k_tiles):
+                    b_cur = b_nxt
+            if const_expr(traits.k_tiles == 1):
+                gpu.barrier()
+
+        if const_expr(traits.k_wave > 1):
+            reduce_dense_k_wave(
+                traits, accumulators, lds_raw_ptr, wave, wave_n_id, lane
+            )
+
+        store = make_dense_store(arg_out, traits.n)
+        is_store_wave = wave_k_id == fx.Int32(0) if traits.k_wave > 1 else True
+        lane_div_16 = lane // 16
+        lane_mod_16 = lane % 16
+        for mi in range_constexpr(traits.m_repeats):
+            row_base = m_row + mi * 16 + lane_div_16 * 4
+            for ni in range_constexpr(traits.n_repeats):
+                col = n_row + wave_n_id * traits.n_per_wave + ni * 16 + lane_mod_16
+                values = Vec(accumulators[mi][ni].load())
+                for vi in range_constexpr(4):
+                    row = row_base + vi
+                    if const_expr(traits.k_wave > 1):
+                        store_ok = (row < i32_m) & is_store_wave
+                    else:
+                        store_ok = row < i32_m
+                    if store_ok:
+                        store_dense_bf16(store, values[vi], row * traits.n + col)
+
+    @flyc.jit
+    def launch(
+        arg_a: fx.Int64,
+        arg_bq: fx.Int64,
+        arg_bscale: fx.Int64,
+        arg_out: fx.Int64,
+        i32_m: fx.Int32,
+        stream: fx.Stream,
+    ):
+        const_expr(cache_tag)
+        grid_m = (i32_m + block_m - 1) // block_m
+        kernel(
+            arg_a,
+            arg_bq,
+            arg_bscale,
+            arg_out,
+            i32_m,
+            value_attrs={"rocdl.waves_per_eu": waves_per_eu} if waves_per_eu else None,
+        ).launch(
+            grid=(fx.Int64(grid_m), n_blocks, 1),
+            block=(256, 1, 1),
+            stream=stream,
+        )
+
+    return launch

--- a/aiter/ops/flydsl/kernels/gemm_a16wfp4_helpers.py
+++ b/aiter/ops/flydsl/kernels/gemm_a16wfp4_helpers.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Components for the gfx950 dense BF16 x MXFP4 GEMM."""
+
+from dataclasses import dataclass
+
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+
+from .moe_2stage_a16wmix.utils import make_a_loader, make_b_loader
+from .mxfp4_gemm_common import lds_typed_ptr
+
+_NUM_WAVES = 4
+
+
+@dataclass(frozen=True)
+class DenseGemmTraits:
+    n: int
+    k: int
+    block_m: int
+    tile_n: int
+    tile_k: int
+    b_cache_mod: int
+    k_wave: int = 1
+    waves_per_eu: int | None = None
+
+    def __post_init__(self):
+        if self.k_wave not in (1, 2, 4):
+            raise ValueError(f"k_wave must be 1, 2, or 4, got {self.k_wave}")
+        if _NUM_WAVES % self.k_wave:
+            raise ValueError(f"4 waves cannot be split by k_wave={self.k_wave}")
+        if self.k % (self.k_wave * self.tile_k):
+            raise ValueError(
+                f"K={self.k} must be divisible by k_wave*TILE_K="
+                f"{self.k_wave * self.tile_k}"
+            )
+
+    @property
+    def a_tile_bytes(self):
+        return self.tile_k * 2
+
+    @property
+    def num_n_waves(self):
+        return _NUM_WAVES // self.k_wave
+
+    @property
+    def k_len(self):
+        return self.k // self.k_wave
+
+    @property
+    def k_tiles(self):
+        return self.k_len // self.tile_k
+
+    @property
+    def a_lds_stages(self):
+        return 2 if self.k_tiles > 1 else 1
+
+    @property
+    def a_slot_bytes(self):
+        return self.block_m * self.a_tile_bytes
+
+    @property
+    def m_repeats(self):
+        return self.block_m // 16
+
+    @property
+    def k_repeats(self):
+        return self.a_tile_bytes // 64
+
+    @property
+    def n_per_wave(self):
+        return self.tile_n // self.num_n_waves
+
+    @property
+    def n_repeats(self):
+        return self.n_per_wave // 16
+
+    @property
+    def n_blocks(self):
+        return self.n // self.tile_n
+
+    @property
+    def a_lds_bytes(self):
+        return self.k_wave * self.a_lds_stages * self.a_slot_bytes
+
+    @property
+    def k_reduce_bytes(self):
+        if self.k_wave == 1:
+            return 0
+        nm = self.n_repeats * self.m_repeats
+        return _NUM_WAVES * 64 * nm * 4 * 4
+
+    @property
+    def lds_bytes(self):
+        return max(self.a_lds_bytes, self.k_reduce_bytes)
+
+    @property
+    def kernel_name(self):
+        wpe = 0 if self.waves_per_eu is None else self.waves_per_eu
+        return (
+            f"dense_a16wfp4_bf16_gfx950_m{self.block_m}_n{self.n}_k{self.k}"
+            f"_tn{self.tile_n}_tk{self.tile_k}_kw{self.k_wave}_wpe{wpe}"
+        )
+
+    @property
+    def cache_key(self):
+        return (
+            self.n,
+            self.k,
+            self.block_m,
+            self.tile_n,
+            self.tile_k,
+            self.b_cache_mod,
+            self.k_wave,
+            self.waves_per_eu,
+        )
+
+
+def make_dense_operand_loaders(
+    traits,
+    lds,
+    arg_a,
+    arg_bq,
+    arg_bscale,
+    m,
+    m_row,
+    n_row,
+    lane,
+    wave,
+):
+    lane_div_16 = lane // 16
+    lane_mod_16 = lane % 16
+    num_n_waves = traits.num_n_waves
+    if const_expr(traits.k_wave > 1):
+        wave_n_id = wave % fx.Int32(num_n_waves)
+        wave_k_id = rocdl.readfirstlane(T.i32, wave // fx.Int32(num_n_waves))
+        k_grp_base_bytes = wave_k_id * fx.Int32(
+            traits.a_lds_stages * traits.a_slot_bytes
+        )
+    else:
+        wave_n_id = wave
+        wave_k_id = fx.Int32(0)
+        k_grp_base_bytes = fx.Int32(0)
+
+    b_loader = make_b_loader(
+        arg_bq,
+        arg_bscale,
+        N_OUT=traits.n,
+        K=traits.k,
+        NE=1,
+        e=fx.Int32(0),
+        lane_div_16=lane_div_16,
+        lane_mod_16=lane_mod_16,
+        TILE_K=traits.tile_k,
+        w_dtype="fp4",
+        b_cache_mod=traits.b_cache_mod,
+        use_k16=False,
+    )
+    a_loader = make_a_loader(
+        lds,
+        num_i32=traits.lds_bytes // 4,
+        BM=traits.block_m,
+        TILE_K=traits.tile_k,
+        KH_TILE_BYTES=traits.a_tile_bytes,
+        k_blocks16=traits.a_tile_bytes // 16,
+        lane_div_16=lane_div_16,
+        lane_mod_16=lane_mod_16,
+        swizzle=True,
+        a_ptr=arg_a,
+        a_num_bytes=fx.Int64(m) * fx.Int64(traits.k * 2),
+        a_load_threads=num_n_waves * 64,
+        row_base_dwords=lambda row: (m_row + row) * fx.Int32(traits.k // 2),
+        dma_cache_mod=0,
+        dma_via_vgpr=False,
+        k_grp_base_bytes=k_grp_base_bytes,
+        A_SLOT_BYTES=traits.a_slot_bytes,
+    )
+    columns = [
+        b_loader.col(
+            n_row,
+            wave_n_id * traits.n_per_wave,
+            ni * 16,
+        )
+        for ni in range_constexpr(traits.n_repeats)
+    ]
+    return a_loader, b_loader, columns, wave_n_id, wave_k_id
+
+
+def make_dense_accumulators(traits):
+    layout = fx.make_layout(4, 1)
+    accumulators = [
+        [fx.make_rmem_tensor(layout, fx.Float32) for _ in range(traits.n_repeats)]
+        for _ in range(traits.m_repeats)
+    ]
+    zero = Vec.filled(4, 0.0, fx.Float32)
+    for mi in range_constexpr(traits.m_repeats):
+        for ni in range_constexpr(traits.n_repeats):
+            accumulators[mi][ni].store(zero)
+    return accumulators
+
+
+def load_b_tile(traits, b_loader, columns, base_k):
+    """Packed weight + E8M0 scales for one K tile."""
+    if const_expr(traits.block_m >= 64):
+        # Issue the small scale loads first so they age while packed-weight VMEM runs.
+        b_scale = [b_loader.load_scale(base_k, col) for col in columns]
+        b_raw = [b_loader.load_raw(base_k, col) for col in columns]
+    else:
+        b_raw = [b_loader.load_raw(base_k, col) for col in columns]
+        b_scale = [b_loader.load_scale(base_k, col) for col in columns]
+    return b_raw, b_scale
+
+
+def advance_k_tile(traits, a_loader, b_loader, columns, k_base, kt):
+    """Stage the next A tile in LDS and issue the next B tile."""
+    next_k = k_base + fx.Int32((kt + 1) * traits.tile_k)
+    a_loader.store_tile(next_k, slot=(kt + 1) % traits.a_lds_stages)
+    return load_b_tile(traits, b_loader, columns, next_k)
+
+
+def load_a_frags(traits, a_loader, slot):
+    """Read the staged A tile out of LDS into MFMA fragments."""
+    return [
+        [a_loader.load(mi, ku, slot=slot) for ku in range_constexpr(traits.k_repeats)]
+        for mi in range_constexpr(traits.m_repeats)
+    ]
+
+
+def _mma_order(traits):
+    """(n, k) visit order. Wide tiles cross N before advancing K, which stretches
+    each accumulator's MFMA dependency distance from m_repeats to
+    m_repeats * n_repeats."""
+    if traits.block_m >= 64:
+        return [
+            (ni, ku) for ku in range(traits.k_repeats) for ni in range(traits.n_repeats)
+        ]
+    return [
+        (ni, ku) for ni in range(traits.n_repeats) for ku in range(traits.k_repeats)
+    ]
+
+
+def compute_dense_tile(traits, mma, accumulators, b_loader, b_tile, a_frags):
+    """Decode one B tile to BF16 and accumulate it into the FP32 tile."""
+    b_raw, b_scale = b_tile
+    a_fragment = fx.make_rmem_tensor(fx.make_layout(8, 1), fx.BFloat16)
+    b_fragment = fx.make_rmem_tensor(fx.make_layout(8, 1), fx.BFloat16)
+    for ni, ku in _mma_order(traits):
+        b_fragment.store(b_loader.upconvert(b_raw[ni], ku, b_scale[ni][ku]))
+        for mi in range_constexpr(traits.m_repeats):
+            a_fragment.store(a_frags[mi][ku])
+            fx.gemm(
+                mma, accumulators[mi][ni], a_fragment, b_fragment, accumulators[mi][ni]
+            )
+
+
+def reduce_dense_k_wave(traits, accumulators, lds, wave, wave_n_id, lane):
+    """Sum intra-block K-slice partials through the A-LDS region, now free."""
+    nm = traits.n_repeats * traits.m_repeats
+    grp_stride = 64 * nm * 4
+    lds_base = fx.Int32(fx.ptrtoint(lds))
+    scratch = lds_typed_ptr(lds_base, T.f32, align=4)
+    peers = lds_typed_ptr(lds_base, T.f32, align=16)
+    gpu.barrier()
+    my_base = wave * fx.Int32(grp_stride) + lane * fx.Int32(4)
+    for ai in range_constexpr(nm):
+        acc = accumulators[ai // traits.n_repeats][ai % traits.n_repeats]
+        v = Vec(fx.memref_load_vec(acc))
+        sidx = my_base + fx.Int32(ai * 64 * 4)
+        for vv in range_constexpr(4):
+            fx.ptr_store(v[vv], scratch + (sidx + fx.Int32(vv)))
+    gpu.barrier()
+    for ai in range_constexpr(nm):
+        acc = accumulators[ai // traits.n_repeats][ai % traits.n_repeats]
+        s = Vec(fx.memref_load_vec(acc))
+        ai_off = fx.Int32(ai * 64 * 4) + lane * fx.Int32(4)
+        for g in range_constexpr(1, traits.k_wave):
+            peer = fx.Int32(g * traits.num_n_waves) + wave_n_id
+            pv = Vec(
+                fx.ptr_load(
+                    peers + (peer * fx.Int32(grp_stride) + ai_off),
+                    result_type=T.vec(4, T.f32),
+                )
+            )
+            s = Vec.from_elements(
+                [s[vv] + pv[vv] for vv in range_constexpr(4)], fx.Float32
+            )
+        acc.store(s)
+
+
+def make_dense_store(arg_out, n):
+    """Buffer-copy state for the BF16 epilogue: (output, atom, fragment).
+
+    The guarded store itself stays in the kernel body, where the flyc rewriter
+    can turn its runtime row predicate into an scf.if.
+    """
+    pointer = fx.PointerType.get(
+        fx.BFloat16.ir_type,
+        address_space=fx.AddressSpace.Global,
+        alignment=2,
+    )
+    view = fx.make_view(
+        fx.inttoptr(pointer, arg_out),
+        fx.make_layout((1 << 30, 1), (1, 1)),
+    )
+    output = fx.logical_divide(
+        fx.rocdl.make_buffer_tensor(view, max_size=True),
+        fx.make_layout(1, 1),
+    )
+    atom = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), fx.BFloat16)
+    fragment = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.BFloat16)
+    return output, atom, fragment
+
+
+def store_dense_bf16(store, value, index):
+    output, atom, fragment = store
+    fragment.store(Vec.filled(1, value.to(fx.BFloat16), fx.BFloat16))
+    fx.copy(atom, fragment, fx.slice(output, (None, fx.Int32(index))))

--- a/op_tests/flydsl_tests/bench_flydsl_gemm_a16wfp4.py
+++ b/op_tests/flydsl_tests/bench_flydsl_gemm_a16wfp4.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Microbench and config sweep for dense gfx950 FlyDSL BF16 x MXFP4 GEMM.
+
+Not collected by pytest (no test_ prefix). Examples:
+
+    python op_tests/flydsl_tests/bench_flydsl_gemm_a16wfp4.py --mode default
+    python op_tests/flydsl_tests/bench_flydsl_gemm_a16wfp4.py --mode sweep
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import traceback
+
+import torch
+
+from aiter.ops.flydsl.gemm_a16wfp4 import (
+    DenseGemmConfig,
+    _select_gemm_config,
+    a16wfp4_config_legal,
+    flydsl_gemm_a16wfp4,
+    prepare_gemm_a16wfp4_weight,
+)
+from aiter.test_common import run_perftest
+
+_K3_SHAPES = ((8448, 7168), (1536, 7168), (7168, 768))
+_TP2_SHAPES = ((1024, 3584), (3584, 512))
+_AB_SHAPES = _K3_SHAPES + _TP2_SHAPES
+_AB_MS = (1, 4096)
+_SWEEP_MS = (1, 128, 4096)
+
+
+def _make_inputs(m: int, n: int, k: int, seed: int = 0):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16, generator=generator)
+    packed = torch.randint(
+        0,
+        256,
+        (n, k // 2),
+        device="cuda",
+        dtype=torch.uint8,
+        generator=generator,
+    )
+    scale = torch.full((n, k // 32), 0x7F, device="cuda", dtype=torch.uint8)
+    return a, packed, scale
+
+
+def _metrics(m: int, n: int, k: int, us: float):
+    flops = 2.0 * m * n * k
+    tflops = flops / (us * 1e-6) / 1e12 if us > 0 else 0.0
+    bytes_moved = m * k * 2 + n * (k / 2) + n * (k / 32) + m * n * 2
+    tb_s = bytes_moved / (us * 1e-6) / 1e12 if us > 0 else 0.0
+    return tflops, tb_s
+
+
+def _bench(m: int, n: int, k: int, config: DenseGemmConfig | None = None):
+    a, packed, scale = _make_inputs(m, n, k, seed=m + n + k)
+    prepared = prepare_gemm_a16wfp4_weight(packed, scale)
+    kwargs = {} if config is None else {"config": config}
+    flydsl_gemm_a16wfp4(a, prepared, **kwargs)
+    torch.cuda.synchronize()
+    _, us = run_perftest(
+        flydsl_gemm_a16wfp4,
+        a,
+        prepared,
+        num_iters=21,
+        num_warmup=2,
+        num_rotate_args=1,
+        use_cuda_event=True,
+        **kwargs,
+    )
+    tflops, tb_s = _metrics(m, n, k, us)
+    cfg = config if config is not None else _select_gemm_config(m, n, k)
+    row = {
+        "m": m,
+        "n": n,
+        "k": k,
+        "block_m": cfg.block_m,
+        "tile_n": cfg.tile_n,
+        "tile_k": cfg.tile_k,
+        "k_wave": cfg.k_wave,
+        "waves_per_eu": cfg.waves_per_eu,
+        "us": float(us),
+        "tflops": tflops,
+        "tb_s": tb_s,
+        "status": "ok",
+    }
+    return row
+
+
+def _print_row(row: dict):
+    if row.get("status") != "ok":
+        print(
+            f"SKIP M={row['m']} N={row['n']} K={row['k']} "
+            f"BM={row.get('block_m')} TN={row.get('tile_n')} TK={row.get('tile_k')} "
+            f"kw={row.get('k_wave')} wpe={row.get('waves_per_eu')}: {row.get('error')}"
+        )
+        return
+    print(
+        f"a16wfp4 M={row['m']} N={row['n']} K={row['k']} "
+        f"BM={row['block_m']} TN={row['tile_n']} TK={row['tile_k']} "
+        f"k_wave={row['k_wave']} wpe={row['waves_per_eu']}: "
+        f"{row['us']:.2f} us, {row['tflops']:.2f} TFLOPS, {row['tb_s']:.2f} TB/s"
+    )
+
+
+def _iter_sweep_configs(m: int, n: int, k: int):
+    block_ms = (16,) if m == 1 else (16, 32)
+    tile_ns = tuple(tn for tn in (128, 256) if n % tn == 0)
+    tile_ks = (256, 512) if k % 512 == 0 else (256,)
+    for block_m in block_ms:
+        for tile_n in tile_ns:
+            for tile_k in tile_ks:
+                for k_wave in (1, 2, 4):
+                    for waves_per_eu in (1, 2, 4):
+                        cfg = DenseGemmConfig(
+                            block_m, tile_n, tile_k, k_wave, waves_per_eu
+                        )
+                        if a16wfp4_config_legal(n, k, cfg):
+                            yield cfg
+
+
+def _write(path: str | None, row: dict):
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row) + "\n")
+
+
+def _run_default(out: str | None):
+    rows = []
+    for n, k in _AB_SHAPES:
+        for m in _AB_MS:
+            row = _bench(m, n, k)
+            _print_row(row)
+            _write(out, row)
+            rows.append(row)
+    return rows
+
+
+def _run_sweep(out: str | None):
+    rows = []
+    for n, k in _K3_SHAPES:
+        for m in _SWEEP_MS:
+            for cfg in _iter_sweep_configs(m, n, k):
+                try:
+                    row = _bench(m, n, k, config=cfg)
+                except Exception as exc:  # noqa: BLE001
+                    row = {
+                        "m": m,
+                        "n": n,
+                        "k": k,
+                        "block_m": cfg.block_m,
+                        "tile_n": cfg.tile_n,
+                        "tile_k": cfg.tile_k,
+                        "k_wave": cfg.k_wave,
+                        "waves_per_eu": cfg.waves_per_eu,
+                        "status": "skip",
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                    traceback.print_exc()
+                _print_row(row)
+                _write(out, row)
+                rows.append(row)
+    winners = _pick_winners(rows)
+    print("\nWinners (lowest us; tie -> smaller k_wave, tile_k, tile_n, block_m):")
+    for key, row in sorted(winners.items()):
+        print(f"  {key}: {row}")
+    if out:
+        with open(out + ".winners.json", "w", encoding="utf-8") as handle:
+            json.dump({str(k): v for k, v in winners.items()}, handle, indent=2)
+    return rows, winners
+
+
+def _pick_winners(rows: list[dict]) -> dict[tuple[int, int, int], dict]:
+    winners: dict[tuple[int, int, int], dict] = {}
+    for row in rows:
+        if row.get("status") != "ok":
+            continue
+        key = (row["m"], row["n"], row["k"])
+        cur = winners.get(key)
+        cand = (
+            row["us"],
+            row["k_wave"],
+            row["tile_k"],
+            row["tile_n"],
+            row["block_m"],
+        )
+        if cur is None:
+            winners[key] = row
+            continue
+        best = (
+            cur["us"],
+            cur["k_wave"],
+            cur["tile_k"],
+            cur["tile_n"],
+            cur["block_m"],
+        )
+        if cand < best:
+            winners[key] = row
+    return winners
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("default", "sweep"), default="default")
+    parser.add_argument("--out", default=None, help="JSONL path for per-config rows")
+    args = parser.parse_args(argv)
+    if args.mode == "default":
+        _run_default(args.out)
+    else:
+        _run_sweep(args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/op_tests/flydsl_tests/test_flydsl_gemm_a16wfp4.py
+++ b/op_tests/flydsl_tests/test_flydsl_gemm_a16wfp4.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Correctness coverage for dense gfx950 FlyDSL BF16 x MXFP4 GEMM."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("flydsl")
+
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.flydsl.gemm_a16wfp4 import (
+    DenseGemmConfig,
+    _select_gemm_config,
+    a16wfp4_config_legal,
+    a16wfp4_shape_supported,
+    flydsl_gemm_a16wfp4,
+    prepare_gemm_a16wfp4_weight,
+)
+from aiter.ops.flydsl.utils import is_flydsl_available
+from aiter.test_common import run_perftest
+from aiter.utility import fp4_utils
+
+_SKIP = pytest.mark.skipif(
+    get_gfx() != "gfx950" or not is_flydsl_available(),
+    reason="gfx950 and FlyDSL are required",
+)
+
+_E8M0_EDGE_CODES = (0x00, 0x01, 0x7E, 0x7F, 0x80, 0xFE, 0xFF)
+_K3_SHAPES = ((8448, 7168), (1536, 7168), (7168, 768))
+
+
+def _oracle(
+    a: torch.Tensor, packed_weight: torch.Tensor, scale: torch.Tensor
+) -> torch.Tensor:
+    n, packed_k = packed_weight.shape
+    k = packed_k * 2
+    decoded = fp4_utils.mxfp4_to_f32(packed_weight)
+    scale_f32 = fp4_utils.e8m0_to_f32(scale).float().unsqueeze(-1)
+    weight_bf16 = (
+        (decoded.float().view(n, k // 32, 32) * scale_f32)
+        .reshape(n, k)
+        .to(torch.bfloat16)
+    )
+    return F.linear(a, weight_bf16)
+
+
+def _make_inputs(m: int, n: int, k: int, seed: int = 0):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16, generator=generator)
+    packed = torch.randint(
+        0,
+        256,
+        (n, k // 2),
+        device="cuda",
+        dtype=torch.uint8,
+        generator=generator,
+    )
+    scale = torch.full((n, k // 32), 0x7F, device="cuda", dtype=torch.uint8)
+    return a, packed, scale
+
+
+def _assert_close_to_oracle(m: int, n: int, k: int, seed: int):
+    a, packed, scale = _make_inputs(m, n, k, seed=seed)
+    a_before = a.clone()
+    prepared = prepare_gemm_a16wfp4_weight(packed, scale)
+
+    actual = flydsl_gemm_a16wfp4(a, prepared)
+    expected = _oracle(a, packed, scale)
+
+    torch.testing.assert_close(a, a_before, rtol=0, atol=0)
+    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=1.0)
+
+
+@_SKIP
+@pytest.mark.parametrize("n,k", [(1024, 3584), (3584, 512)])
+@pytest.mark.parametrize("m", [1, 16, 128, 512, 4096])
+def test_kimi_tp2_shapes(m: int, n: int, k: int):
+    _assert_close_to_oracle(m, n, k, seed=m + n + k)
+
+
+@_SKIP
+@pytest.mark.parametrize("n,k", list(_K3_SHAPES))
+@pytest.mark.parametrize("m", [1, 128])
+def test_kimi_k3_shapes(m: int, n: int, k: int):
+    _assert_close_to_oracle(m, n, k, seed=m + n + k)
+
+
+@_SKIP
+def test_k3_qkvo_fallback_shape_is_rejected():
+    assert a16wfp4_shape_supported(7168, 4224) is False
+    n, k = 7168, 4224
+    packed = torch.zeros((n, k // 2), device="cuda", dtype=torch.uint8)
+    scale = torch.zeros((n, k // 32), device="cuda", dtype=torch.uint8)
+    with pytest.raises(ValueError, match="K must be divisible by 256"):
+        prepare_gemm_a16wfp4_weight(packed, scale)
+
+
+@_SKIP
+@pytest.mark.parametrize("n,k", list(_K3_SHAPES))
+@pytest.mark.parametrize("m", [1, 4096])
+def test_kimi_k3_microbench(m: int, n: int, k: int):
+    a, packed, scale = _make_inputs(m, n, k, seed=m + n + k)
+    prepared = prepare_gemm_a16wfp4_weight(packed, scale)
+    flydsl_gemm_a16wfp4(a, prepared)
+    torch.cuda.synchronize()
+
+    _, us = run_perftest(
+        flydsl_gemm_a16wfp4,
+        a,
+        prepared,
+        num_iters=21,
+        num_warmup=2,
+        num_rotate_args=1,
+        use_cuda_event=True,
+    )
+    flops = 2.0 * m * n * k
+    tflops = flops / (us * 1e-6) / 1e12 if us > 0 else 0.0
+    bytes_moved = m * k * 2 + n * (k / 2) + n * (k / 32) + m * n * 2
+    tb_s = bytes_moved / (us * 1e-6) / 1e12 if us > 0 else 0.0
+    cfg = _select_gemm_config(m, n, k)
+    print(
+        f"a16wfp4 M={m} N={n} K={k} BM={cfg.block_m} TN={cfg.tile_n} "
+        f"k_wave={cfg.k_wave} wpe={cfg.waves_per_eu}: "
+        f"{us:.2f} us, {tflops:.2f} TFLOPS, {tb_s:.2f} TB/s"
+    )
+    assert us > 0
+
+
+@_SKIP
+def test_exact_e8m0_edge_classification_against_canonical_oracle():
+    m, n, k = 1, 1024, 512
+    a = torch.zeros((m, k), device="cuda", dtype=torch.bfloat16)
+    a[0, 0] = 1
+    packed = torch.zeros((n, k // 2), device="cuda", dtype=torch.uint8)
+    scale = torch.full((n, k // 32), 0x7F, device="cuda", dtype=torch.uint8)
+
+    row_codes = torch.tensor(_E8M0_EDGE_CODES, device="cuda", dtype=torch.uint8)
+    repeats = (n + len(_E8M0_EDGE_CODES) - 1) // len(_E8M0_EDGE_CODES)
+    row_codes = row_codes.repeat(repeats)[:n]
+    scale[:, 0] = row_codes
+
+    # Low nibble is W[:, 0]. Use E2M1 1.0 normally and 6.0 with scale 0xfe,
+    # which overflows BF16 to inf. Scale 0xff produces canonical NaNs.
+    weight_codes = torch.full((n,), 0x2, device="cuda", dtype=torch.uint8)
+    weight_codes[row_codes == 0xFE] = 0x7
+    packed[:, 0] = weight_codes
+
+    prepared = prepare_gemm_a16wfp4_weight(packed, scale)
+    actual = flydsl_gemm_a16wfp4(a, prepared)
+    expected = _oracle(a, packed, scale)
+
+    torch.testing.assert_close(torch.isnan(actual), torch.isnan(expected))
+    torch.testing.assert_close(torch.isinf(actual), torch.isinf(expected))
+    finite = torch.isfinite(expected)
+    torch.testing.assert_close(actual[finite], expected[finite], rtol=0, atol=0)
+
+    for code in _E8M0_EDGE_CODES:
+        rows = row_codes == code
+        assert rows.any()
+        torch.testing.assert_close(
+            torch.isnan(actual[0, rows]), torch.isnan(expected[0, rows])
+        )
+        torch.testing.assert_close(
+            torch.isinf(actual[0, rows]), torch.isinf(expected[0, rows])
+        )
+
+
+@_SKIP
+def test_prepared_storage_and_warmed_launch_do_not_materialize_bf16_weight():
+    m, n, k = 16, 1024, 3584
+    a, packed, scale = _make_inputs(m, n, k, seed=7)
+    prepared = prepare_gemm_a16wfp4_weight(packed, scale)
+
+    assert prepared.weight.dtype == torch.uint8
+    assert prepared.scale.dtype == torch.uint8
+    assert prepared.weight.element_size() == packed.element_size() == 1
+    assert prepared.scale.element_size() == scale.element_size() == 1
+    assert prepared.weight.numel() == packed.numel()
+    assert prepared.scale.numel() == scale.numel()
+    assert prepared.weight.untyped_storage().nbytes() == packed.numel()
+    assert prepared.scale.untyped_storage().nbytes() == scale.numel()
+    assert prepared.weight.numel() + prepared.scale.numel() == (
+        packed.numel() + scale.numel()
+    )
+
+    out = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+    returned = flydsl_gemm_a16wfp4(a, prepared, out=out)
+    torch.cuda.synchronize()
+    assert returned.data_ptr() == out.data_ptr()
+
+    torch.cuda.reset_peak_memory_stats(a.device)
+    baseline = torch.cuda.memory_allocated(a.device)
+    returned = flydsl_gemm_a16wfp4(a, prepared, out=out)
+    torch.cuda.synchronize()
+    peak_delta = torch.cuda.max_memory_allocated(a.device) - baseline
+
+    assert returned.data_ptr() == out.data_ptr()
+    assert peak_delta < n * k * torch.bfloat16.itemsize, (
+        f"warmed launch allocated {peak_delta} bytes, enough for a full "
+        f"BF16 [{n}, {k}] weight"
+    )
+
+
+@_SKIP
+def test_shape_and_dtype_validation():
+    assert a16wfp4_shape_supported(1024, 3584)
+    assert a16wfp4_shape_supported(8448, 7168)
+    assert a16wfp4_shape_supported(1536, 7168)
+    assert a16wfp4_shape_supported(7168, 768)
+    assert not a16wfp4_shape_supported(7168, 4224)
+
+    assert _select_gemm_config(4095, 1024, 3584) == (16, 128, 256, 1, 2)
+    assert _select_gemm_config(4096, 1024, 3584) == (32, 256, 256, 1, 1)
+    assert _select_gemm_config(2047, 1024, 512) == (16, 128, 256, 1, 2)
+    assert _select_gemm_config(2048, 1024, 512) == (32, 256, 256, 1, 1)
+    assert _select_gemm_config(4095, 1024, 768) == (16, 128, 256, 1, 2)
+    assert _select_gemm_config(1, 1024, 3584) == (16, 32, 256, 2, 1)
+    assert _select_gemm_config(1, 8448, 7168) == (16, 32, 256, 4, 4)
+    assert _select_gemm_config(32, 8448, 7168) == (16, 64, 256, 4, 4)
+    assert _select_gemm_config(1, 1536, 7168) == (16, 16, 256, 4, 1)
+    assert _select_gemm_config(1, 7168, 768) == (16, 128, 256, 1, 2)
+    assert _select_gemm_config(128, 8448, 7168) == (32, 128, 256, 1, 1)
+    assert _select_gemm_config(512, 8448, 7168) == (48, 192, 256, 1, 2)
+    assert _select_gemm_config(1024, 8448, 7168) == (64, 192, 128, 1, 2)
+    assert _select_gemm_config(4096, 8448, 7168) == (64, 192, 128, 1, 2)
+    assert _select_gemm_config(128, 1536, 7168) == (16, 96, 128, 4, 2)
+    assert _select_gemm_config(767, 1536, 7168) == (16, 96, 128, 4, 2)
+    assert _select_gemm_config(768, 1536, 7168) == (32, 128, 256, 1, 2)
+    assert _select_gemm_config(2048, 1536, 7168) == (32, 256, 128, 1, 1)
+    assert _select_gemm_config(4096, 1536, 7168) == (32, 256, 128, 1, 1)
+    assert _select_gemm_config(128, 7168, 768) == (32, 128, 256, 1, 2)
+    assert _select_gemm_config(512, 7168, 768) == (32, 128, 256, 1, 2)
+    assert _select_gemm_config(1024, 7168, 768) == (64, 256, 128, 1, 2)
+    assert _select_gemm_config(4096, 7168, 768) == (64, 256, 128, 1, 2)
+    assert _select_gemm_config(512, 3584, 512) == (32, 128, 256, 1, 2)
+    assert _select_gemm_config(1024, 3584, 512) == (32, 256, 128, 1, 1)
+
+    _, packed, scale = _make_inputs(1, 1024, 512)
+    prepared = prepare_gemm_a16wfp4_weight(packed, scale)
+
+    with pytest.raises(TypeError, match="BF16"):
+        flydsl_gemm_a16wfp4(torch.randn(1, 512, device="cuda"), prepared)
+    with pytest.raises(ValueError, match="does not match"):
+        flydsl_gemm_a16wfp4(
+            torch.randn(1, 256, device="cuda", dtype=torch.bfloat16), prepared
+        )
+    with pytest.raises(ValueError, match="scale must have shape"):
+        prepare_gemm_a16wfp4_weight(packed, scale[:, :-1])
+
+
+@_SKIP
+def test_decode_configs_fill_the_grid():
+    """Decode is grid-bound: never idle a CU while a narrower legal tile exists."""
+    for n, k in ((8448, 7168), (1536, 7168), (7168, 768), (1024, 3584), (3584, 512)):
+        for m in (1, 8, 16, 17, 32, 63):
+            cfg = _select_gemm_config(m, n, k)
+            assert a16wfp4_config_legal(n, k, cfg)
+            blocks = ((m + cfg.block_m - 1) // cfg.block_m) * (n // cfg.tile_n)
+            if cfg.k_wave == 1:
+                continue  # short K cannot hide the dispatch of a narrower tile
+            if blocks >= 256:
+                continue
+            narrower = cfg._replace(tile_n=cfg.tile_n // 2)
+            assert not a16wfp4_config_legal(n, k, narrower), (
+                f"({n},{k}) M={m} leaves {blocks} tiles for 256 CUs while "
+                f"TILE_N={narrower.tile_n} is legal"
+            )
+
+
+@_SKIP
+def test_explicit_config_override_matches_oracle():
+    m, n, k = 1, 1024, 512
+    a, packed, scale = _make_inputs(m, n, k, seed=3)
+    prepared = prepare_gemm_a16wfp4_weight(packed, scale)
+    cfg = DenseGemmConfig(16, 128, 256, 1, 1)
+    actual = flydsl_gemm_a16wfp4(a, prepared, config=cfg)
+    expected = _oracle(a, packed, scale)
+    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=1.0)


### PR DESCRIPTION
## Summary

Add a gfx950 FlyDSL dense GEMM for BF16 activations and packed MXFP4 weights.

- consumes BF16 activations without requantization
- decodes packed E2M1 weights with E8M0 scales into transient BF16 fragments
- uses BF16 MFMA with FP32 accumulation
- avoids both per-call full-weight dequantization and a persistent BF16 weight cache
- preshuffles packed weights and scales once at model load
- pipelines A/B loads with MFMA and dispatches measured Kimi-K3 tile configurations
- uses a two-dimensional workgroup grid so adjacent M blocks reuse cached B tiles

```text
BF16 activation --------------------> BF16 MFMA -> BF16 output
packed MXFP4 weight -> BF16 decode --^
```

This fused weight-dequant + BF16 GEMM path preserves emulation semantics. Direct A4W4 is intentionally out of scope and will be proposed separately.

## Design and scope

The K loop double-buffers A in LDS. Prefill issues the next A/B tile before MFMA to preserve software-pipeline overlap. Split-K decode issues the next tile after MFMA, keeping one B tile live at a time and raising compiled occupancy for the 8448 x 7168 decode kernel from 1 to 2 waves/EU. The measured 1536 x 7168 decode configuration avoids split-K and its LDS reduction.

- gfx950 only
- packed MXFP4 weights and E8M0 scales are preshuffled once by the caller
- N and K must be divisible by 256
- downstream vLLM integration selects this path before falling back to cached BF16 emulation
- the unaligned `(N,K)=(7168,4224)` projection remains on the designed fallback

Packed weights plus scales use **73.44% less storage** than cached BF16 weights. Warmed launches with preallocated output add zero bytes of peak PyTorch allocation.

## Complete kernel benchmark matrix

Environment: MI355X (gfx950), PyTorch `2.11.0+gitd0c8b1f`, HIP `7.2.53211`, FlyDSL `0.3.0`. Every cell is the median of three runs with 101 timed launches per run and 10 warmups. Inputs and packed weights are identical, outputs are preallocated, and weight preparation/JIT compilation are excluded.

`Existing best` is selected independently per row from the two existing AITER Triton implementations: integrated `gemm_a16wfp4` (`A16WFP4`) and `dynamic_mxfp4_quant + gemm_afp4wfp4` (`Q+A4W4`). Accuracy is relative L2 against canonical MXFP4 weight decode to BF16 followed by BF16 `F.linear` on the original BF16 activation.

| N x K | M | Existing winner | Existing best | This PR | Speedup | Existing rel. L2 | This PR rel. L2 |
|---|---:|---|---:|---:|---:|---:|---:|
| 8448 x 7168 | 1 | A16WFP4 | 52.512 us | 17.896 us | **2.93x** | 11.216% | 0.000006% |
| 8448 x 7168 | 512 | Q+A4W4 | 106.706 us | 65.249 us | **1.64x** | 11.186% | 0.001859% |
| 8448 x 7168 | 4096 | Q+A4W4 | 239.519 us | 391.940 us | **0.61x** | 11.192% | 0.001618% |
| 1536 x 7168 | 1 | A16WFP4 | 50.264 us | 13.219 us | **3.80x** | 11.422% | 0.000000% |
| 1536 x 7168 | 512 | Q+A4W4 | 75.929 us | 29.155 us | **2.60x** | 11.195% | 0.000920% |
| 1536 x 7168 | 4096 | Q+A4W4 | 141.399 us | 86.897 us | **1.63x** | 11.197% | 0.001721% |
| 7168 x 768 | 1 | A16WFP4 | 30.201 us | 9.153 us | **3.30x** | 11.377% | 0.000000% |
| 7168 x 768 | 512 | Q+A4W4 | 63.515 us | 15.541 us | **4.09x** | 11.166% | 0.000664% |
| 7168 x 768 | 4096 | Q+A4W4 | 84.421 us | 46.722 us | **1.81x** | 11.183% | 0.000448% |
| 1024 x 3584 | 1 | A16WFP4 | 35.319 us | 11.399 us | **3.10x** | 11.006% | 0.000000% |
| 1024 x 3584 | 512 | A16WFP4 | 50.789 us | 15.731 us | **3.23x** | 11.218% | 0.001980% |
| 1024 x 3584 | 4096 | Q+A4W4 | 86.756 us | 35.120 us | **2.47x** | 11.188% | 0.001851% |
| 3584 x 512 | 1 | A16WFP4 | 31.312 us | 9.785 us | **3.20x** | 12.066% | 0.000000% |
| 3584 x 512 | 512 | A16WFP4 | 44.491 us | 10.482 us | **4.24x** | 11.219% | 0.000005% |
| 3584 x 512 | 4096 | Q+A4W4 | 100.584 us | 24.744 us | **4.06x** | 11.189% | 0.000397% |

This PR is faster on 14 of 15 measured points, by **1.63x-4.24x**. The exception is the largest layer-0 gate/up prefill point `(M,N,K)=(4096,8448,7168)`, where it is **0.61x** as fast as the existing Q+A4W4 path; this regression is reported rather than hidden.

Weight scales are fixed at 1.0 in this table so the two Triton baselines see identical inputs. Re-running the accuracy check with scales drawn from the full E8M0 exponent range over 25 points (`M` in `{1, 8, 512, 1024, 4096}`) gives a worst-case relative L2 of **0.0046%** and no NaN/Inf output.

The final implementation combines cached B loads with a two-dimensional `(M blocks, N blocks, 1)` workgroup grid. The grid only remaps independent output tiles: MXFP4 decode, MFMA sequence, FP32 accumulation order, and BF16 conversion within each tile are unchanged.

The final `(8448,7168)` prefill configuration is `BM=64, TILE_N=192, TILE_K=128, k_wave=1, waves_per_eu=2`; an interleaved six-run A/B measured **417.017 us** versus **451.670 us** for the previous configuration (**1.083x**) with bitwise-identical output.

ATT on the final prefill tile showed that MFMA, waitcnt, LDS, and FP4 conversion accounted for 28.3%, 23.1%, 14.4%, and 13.3% of sampled latency. Reordering the loop to visit independent N accumulators before advancing K lengthens the MFMA dependency distance; issuing the small scale loads before packed-weight loads targets the remaining VMEM waits. A controlled six-run benchmark improved **411.716 us to 389.104 us (1.058x)**. The reordered ATT launches were typically **394-407 us**, versus **431-453 us** before reordering. The optimization is compile-time-gated to `BM >= 64`, so decode and mid-size configurations retain their previous instruction order.

## Distance to the hardware limit

Every point is re-measured in one session against a hipBLASLt BF16 GEMM on the identical `M x N x K`, same protocol as the matrix above. hipBLASLt consumes an unquantized BF16 weight, so it reads 4x the weight bytes and performs no decode at all: at the compute-bound end it is the BF16 MFMA ceiling, and elsewhere it is the same-shape BF16 reference. `% of BF16 peak` is against the 2506 TFLOPS gfx950 dense BF16 datasheet peak.

| N x K | M | This PR | This PR TFLOPS | hipBLASLt BF16 | hipBLASLt TFLOPS | vs hipBLASLt | This PR % of BF16 peak | hipBLASLt % of BF16 peak |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 8448 x 7168 | 1 | 17.896 us | 6.8 | 33.135 us | 3.7 | **185.1%** | 0.27% | 0.15% |
| 8448 x 7168 | 512 | 65.249 us | 950.3 | 142.364 us | 435.6 | **218.2%** | 37.92% | 17.38% |
| 8448 x 7168 | 4096 | 391.940 us | 1265.7 | 377.735 us | 1313.3 | **96.4%** | 50.51% | 52.41% |
| 1536 x 7168 | 1 | 13.219 us | 1.7 | 23.467 us | 0.9 | **177.5%** | 0.07% | 0.04% |
| 1536 x 7168 | 512 | 29.155 us | 386.7 | 33.364 us | 337.9 | **114.4%** | 15.43% | 13.48% |
| 1536 x 7168 | 4096 | 86.897 us | 1037.9 | 95.509 us | 944.4 | **109.9%** | 41.42% | 37.68% |
| 7168 x 768 | 1 | 9.153 us | 1.2 | 14.414 us | 0.8 | **157.5%** | 0.05% | 0.03% |
| 7168 x 768 | 512 | 15.541 us | 362.7 | 19.745 us | 285.5 | **127.1%** | 14.47% | 11.39% |
| 7168 x 768 | 4096 | 46.722 us | 965.2 | 55.391 us | 814.2 | **118.6%** | 38.52% | 32.49% |
| 1024 x 3584 | 1 | 11.399 us | 0.6 | 18.172 us | 0.4 | **159.4%** | 0.03% | 0.02% |
| 1024 x 3584 | 512 | 15.731 us | 238.9 | 22.345 us | 168.2 | **142.0%** | 9.53% | 6.71% |
| 1024 x 3584 | 4096 | 35.120 us | 856.1 | 44.669 us | 673.1 | **127.2%** | 34.16% | 26.86% |
| 3584 x 512 | 1 | 9.785 us | 0.4 | 13.427 us | 0.3 | **137.2%** | 0.01% | 0.01% |
| 3584 x 512 | 512 | 10.482 us | 179.3 | 16.782 us | 112.0 | **160.1%** | 7.15% | 4.47% |
| 3584 x 512 | 4096 | 24.744 us | 607.5 | 27.599 us | 544.7 | **111.5%** | 24.24% | 21.73% |

**Prefill sits at the BF16 MFMA ceiling.** The single compute-bound point `(4096,8448,7168)` reaches 1266 TFLOPS, 50.5% of dense BF16 peak, against 1313 TFLOPS (52.4%) for hipBLASLt: **96.4%** of a tuned BF16 library on the same MFMA instruction, while additionally decoding MXFP4 inline. Remaining prefill headroom is therefore not schedulable; it requires native FP4 MFMA, which is the separate direct-A4W4 proposal.

**Everywhere else the fused kernel beats the BF16 library**, 110%-218%, because packed weights cut weight traffic 4x and the decode is hidden under MFMA. The two columns are not the same workload at small M: hipBLASLt must stream a full BF16 weight, so those rows measure the real alternative rather than a ceiling.

**Decode is grid-bound.** `TILE_N=128` over `N=8448` dispatches 66 workgroups onto 256 CUs. Measured per-workgroup throughput is ~17 GB/s and nearly independent of tile width, so decode latency scales with 1/workgroups until the grid covers the GPU. The N tile is split across `4//k_wave` waves that each own whole 16-wide MFMA N blocks, so split-K decode can legally go below `TILE_N=64`; `_decode_config` now picks the widest N tile that still yields at least one tile per CU.

| N x K, M=1 | Before | After | Speedup |
|---|---:|---:|---:|
| 8448 x 7168 | 66 tiles, 20.82 us | 264 tiles, 13.39 us | **1.56x** |
| 1536 x 7168 | 12 tiles, 32.44 us | 96 tiles, 10.51 us | **3.09x** |
| 7168 x 768 | 28 tiles, 6.75 us | 56 tiles, 4.93 us | **1.37x** |

Six-round interleaved A/B, medians, repeated across `M` in `{1, 8, 32, 63}`. The `(8448,7168)` and `(7168,768)` rows are **bitwise identical** to the previous configuration; `(1536,7168)` also moves `k_wave` from 1 to 4, which reorders FP32 K accumulation. `K=768` keeps the wide tile because its K loop is too short to hide the extra dispatch, and the rule reproduces that measured choice rather than special-casing it.

Bandwidth efficiency on gfx950 is strongly working-set dependent, so peak HBM is not the yardstick for a ~32 MB decode weight. Measured on the same GPU: a device-to-device copy reaches 5.28 TB/s at 28 MB and 7.74 TB/s at 119 MB; a hipBLASLt BF16 GEMV reaches 1.16 TB/s against a 28 MB weight and 3.54 TB/s against a 119 MB one. This kernel moves its 32.2 MB at 1.65 TB/s, **1.42x the bandwidth hipBLASLt sustains at a matched working-set size**. The residual gap is to the streaming-copy ceiling (~6 us for 32.2 MB), which no GEMV in this comparison approaches.

**Mid-M is tail-wave bound.** A wider tile decodes fewer MXFP4 blocks per MFMA but launches fewer workgroups, so the trade only pays when the resulting tile count still fills whole 256-CU waves. Wave fill is `tiles / (ceil(tiles/256) * 256)`, and it predicts every measured winner: on `(1536,7168)` at `M=1536` the `BM=48 TN=192` tile lands on exactly 256 tiles (100% fill) and wins, at `M=2048` `BM=32 TN=128` lands on exactly 768 (100%) and wins, and at `M=4096` `BM=32 TN=256` wins on the wider tile once both fill. The measured table therefore carries per-shape M breakpoints instead of one config per size class, chosen to be robust across each interval rather than optimal at a sampled point.

| N x K | M | Previous config | New config | Speedup |
|---|---:|---|---|---:|
| 8448 x 7168 | 512 | `BM=32 TN=128 TK=256` | `BM=48 TN=192 TK=256` | **1.17x** |
| 8448 x 7168 | 768 | `BM=32 TN=128 TK=256` | `BM=48 TN=192 TK=256` | **1.13x** |
| 8448 x 7168 | 1024 | `BM=32 TN=128 TK=256` | `BM=64 TN=192 TK=128` | **1.20x** |
| 8448 x 7168 | 2048 | `BM=32 TN=128 TK=256` | `BM=64 TN=192 TK=128` | **1.17x** |
| 1536 x 7168 | 512 | `BM=16 TN=128 TK=256 kw=4` | `BM=16 TN=96 TK=128 kw=4` | **1.17x** |
| 1536 x 7168 | 1024 | `BM=16 TN=128 TK=256 kw=4` | `BM=32 TN=128 TK=256` | **1.32x** |
| 1536 x 7168 | 1536 | `BM=16 TN=128 TK=256 kw=4` | `BM=32 TN=128 TK=256` | **1.34x** |
| 1536 x 7168 | 2048 | `BM=16 TN=128 TK=256 kw=4` | `BM=32 TN=256 TK=128` | **1.39x** |
| 7168 x 768 | 4096 | `BM=32 TN=256 TK=256` | `BM=64 TN=256 TK=128` | **1.14x** |

Eight-round interleaved A/B, medians, run with the same resident buffers as the matrix above so cache pressure matches. Candidates whose gain did not survive that alternation were reverted rather than shipped: `(7168,768)` at `M=512` measured 1.22x in an isolated A/B but 0.96x-1.06x here, and `(1024,3584)` measured 1.46x isolated but lost at every M here, so both keep their previous tiles.

## Validation

- [x] final build: `22 passed` correctness + `6 passed` microbench
- [x] arbitrary BF16 activations against canonical decode + BF16 `F.linear`
- [x] all E2M1 codes and E8M0 edge classifications
- [x] packed-storage and no-full-BF16-allocation checks
- [x] grid remap preserves per-tile arithmetic and passes all K3/TP2 M-boundary cases
- [x] decode tile selection leaves no CU idle while a narrower legal tile exists
- [x] Ruff, Black, `py_compile`, and `git diff --check`

## Known deviations from the FlyDSL cleanup guide

Checked against `ROCm/FlyDSL@main/.claude/skills/kernel-code-cleanup/SKILL.md`.
Sections 1-6 and 9 are clean with zero hits across all five files: no
`ArithValue`, `arith.index_cast` or `fx.Index`; no `buffer_ops`; no raw
`arith`/`scf`/`vector`/`llvm`/`memref`/`math` dialect imports or calls; no
`create_llvm_ptr` or hand-built `IntToPtrOp` address spaces; no hand-encoded
`s_waitcnt` bitfields (the keyword form `rocdl.s_waitcnt(lgkmcnt=0)` is used);
no `SmemPtr`/`SmemAllocator`/`finalize()`; no raw `rocdl.mfma_*`,
`copy_atom_call` or `mma_atom_call`; and the op layer dispatches through
`_run_compiled`. Two deviations are deliberate, per SKILL section 10.6.

**Section 7 tiled copy / tiled MMA is not used.** The A and B operand paths call
the existing `make_a_loader` / `make_b_loader` in
`aiter/ops/flydsl/kernels/moe_2stage_a16wmix/utils.py`, which are already in the
tree and shared verbatim with `moe_2stage_a16wmix/gemm1.py` and `gemm2.py`.
Those loaders address lanes directly and expose no TV layout, so this kernel
consumes them the same way and keeps hand-computed lane indices for the MFMA
fragments rather than `make_tiled_copy_A/B/C` + `partition_S` + `retile`.
Adopting section 7 here would mean either duplicating the shared loaders into a
dense-only copy or rewriting a module two upstream MoE kernels depend on;
neither belongs in this PR. `fx.gemm` and `fx.copy` are used for issue (section
7b) even though their operands are hand-built register fragments.

**Raw pointer construction in the epilogue.** `fx.inttoptr` / `fx.ptrtoint` in
`gemm_a16wfp4_helpers.py` sit on the exemption section 3b grants to a raw
integer address with no pointer form: the kernel receives `arg_out` as
`fx.Int64` because the shared loaders take pointers rather than tensors. The
address space is named (`fx.AddressSpace.Global`), not a hardcoded number.

Both fall away if the shared operand loaders move to a layout-API form upstream,
which is the natural follow-up rather than a change to make here.

## Kimi-K3 model-level validation

Re-measured end to end after the tuning above, with the shipped kernel and the
kernel as first proposed both benchmarked in the same session so the delta is
attributable to the tile selection alone.

### Setup

- 8x AMD Instinct MI355X (gfx950), TP8/EP8, eager mode, TRITON_MLA, FP8 KV-cache, SiTUv2 routed MoE
- `amd/Kimi-K3-Quark-MXFP4-AttnFP8` (`quant_method=quark`, weights FP4 per-group-32, `*self_attn*` FP8_E4M3), 96 shards / 1506 GB
- FlyDSL 0.3.0 in every variant, matching this branch's pin, so the routed-MoE FlyDSL kernels are identical across rows
- official GSM8K test set: 1,319 questions, 8-shot, temperature 0, seed `20260813`, max output 512
- 32 concurrent workers, `max_num_seqs=32`, `max_num_batched_tokens=8192`
- three dense/shared linear paths: load-time cached BF16 weight; this PR as first proposed (`e489b19b1`); this PR at head

The fused route was selected on all eight ranks for `(N,K)=(8448,7168)`, `(1536,7168)` and `(7168,768)`; the unaligned `(7168,4224)` projection used the designed cached-BF16 fallback.

### Run-to-run spread has to be established first

At 32-way concurrency the batch composition varies between runs, which reorders FP accumulation in MoE and attention and flips greedy decoding wherever logits are near-tied. **Cached BF16 and the fused path already produce different text on 783 of 1,319 questions** (18 lost, 20 won), so a single GSM8K run cannot resolve differences of a few answers.

Repeating the identical configuration four times bounds that noise:

| Run | Strict | Accuracy | Malformed | Output throughput |
|---|---:|---:|---:|---:|
| head, run 1 | 1253/1319 | 95.00% | 2 | 191.1 tok/s |
| head, run 2 | 1257/1319 | 95.30% | 0 | 200.0 tok/s |
| head, run 3 | 1270/1319 | 96.29% | 0 | 213.2 tok/s |
| head, run 4 | 1268/1319 | 96.13% | 0 | 213.5 tok/s |

The spread is **17 answers (1.3%)** and **22 tok/s (11%)** for one unchanged configuration. The two malformed answers in run 1 are degenerate repetition loops that hit the 512-token cap; they did not recur.

### Accuracy

| Dense/shared linear path | Strict | Accuracy | Malformed | Wall time | Output throughput |
|---|---:|---:|---:|---:|---:|
| Cached BF16 emulation | 1263/1319 | 95.75% | 0 | 653.9 s | 203.1 tok/s |
| PR #4772 as first proposed | 1265/1319 | 95.91% | 0 | 655.8 s | 203.3 tok/s |
| PR #4772 at head (4-run range) | 1253-1270/1319 | 95.00-96.29% | 0-2 | 619.7-700.2 s | 191.1-213.5 tok/s |

Strict counts include the 15 answers the harness flags on a raw `nan` substring (words such as `financial`); the same 15 indices appear in every run and none is a true NaN/Inf output.

The head range covers both single-run references, so the tuning introduces no accuracy regression. Equally, none of these differences supports an accuracy claim in either direction.

### Fixed-token decode

Concurrency 1, one warmup, five measured requests, 401-token prompt, exactly 512 generated tokens, temperature 0, seed `20260813`.

| Dense/shared linear path | Mean TTFT | Mean TPOT | TPOT min-max | Mean E2E |
|---|---:|---:|---:|---:|
| Cached BF16 emulation | 182.51 ms | 120.548 ms | 119.13-122.89 | 61.78 s |
| PR #4772 as first proposed | 179.18 ms | 120.145 ms | 119.59-121.00 | 61.57 s |
| PR #4772 at head, run 1 | 178.32 ms | 120.793 ms | 120.05-123.38 | 61.90 s |
| PR #4772 at head, run 2 | 183.61 ms | 120.641 ms | 119.62-121.60 | 61.83 s |

Within-configuration spread is 1.4-3.8 ms; the largest gap between configuration means is 0.65 ms. Two independent sessions of the same configuration reproduce to 0.09-0.15 ms. **TPOT, TTFT and E2E are indistinguishable across all three paths.**

### What this does and does not show

The kernel-level gains reported above do not surface end to end, and the measurements say why rather than leaving it open: at TPOT 120 ms the dense/shared linears contribute tens of microseconds per layer per rank, against MoE and attention which dominate. A 1.4-3x kernel speedup on that slice is below the run-to-run noise of the serving stack.

The model-level result is therefore a **no-regression** result, which is what this PR needs: packed MXFP4 weights are retained with no persistent BF16 weight cache (73.44% less weight storage) at accuracy indistinguishable from cached BF16 emulation, while the kernel-level tables show the fused path is 1.58x-3.85x faster than the existing MXFP4 GEMM implementations it replaces.

