### PR TITLE
Fix 32-bit KV block offsets in gluon paged-MQA logits kernel (silent zero logits past 2 GiB)

### DIFF
--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -725,13 +725,14 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
         mfma_q = gl.convert_layout(q, mfma_layout_a)
 
         context_kv_idx_next_0 = tl.where(mask_kv_next_0, context_kv_idx_next_0, 0)
-        k_next_0 = gl.amd.cdna3.buffer_load(
-            ptr=KV_buffer,
-            offsets=offset_k_fixed + context_kv_idx_next_0[None, :] * stride_k_seq,
+        k_next_0 = gl.load(
+            KV_buffer
+            + offset_k_fixed
+            + context_kv_idx_next_0.to(gl.int64)[None, :] * stride_k_seq
         )
-        k_scale_f_next_0 = gl.amd.cdna3.buffer_load(
-            ptr=scale_buffer,
-            offsets=context_kv_idx_next_0 * stride_scale_seq
+        k_scale_f_next_0 = gl.load(
+            scale_buffer
+            + context_kv_idx_next_0.to(gl.int64) * stride_scale_seq
             + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
             % KVBlockSize,
         )
@@ -767,13 +768,14 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
         #!=----------------------------
 
         context_kv_idx_next_1 = tl.where(mask_kv_next_1, context_kv_idx_next_1, 0)
-        k_next_1 = gl.amd.cdna3.buffer_load(
-            ptr=KV_buffer,
-            offsets=offset_k_fixed + context_kv_idx_next_1[None, :] * stride_k_seq,
+        k_next_1 = gl.load(
+            KV_buffer
+            + offset_k_fixed
+            + context_kv_idx_next_1.to(gl.int64)[None, :] * stride_k_seq
         )
-        k_scale_f_next_1 = gl.amd.cdna3.buffer_load(
-            ptr=scale_buffer,
-            offsets=context_kv_idx_next_1 * stride_scale_seq
+        k_scale_f_next_1 = gl.load(
+            scale_buffer
+            + context_kv_idx_next_1.to(gl.int64) * stride_scale_seq
             + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
             % KVBlockSize,
         )
@@ -834,13 +836,14 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
                 // KVBlockSize,
             )
-            k_next_0 = gl.amd.cdna3.buffer_load(
-                ptr=KV_buffer,
-                offsets=offset_k_fixed + context_kv_idx_next_0[None, :] * stride_k_seq,
+            k_next_0 = gl.load(
+                KV_buffer
+                + offset_k_fixed
+                + context_kv_idx_next_0.to(gl.int64)[None, :] * stride_k_seq
             )
-            k_scale_f_next_0 = gl.amd.cdna3.buffer_load(
-                ptr=scale_buffer,
-                offsets=context_kv_idx_next_0 * stride_scale_seq
+            k_scale_f_next_0 = gl.load(
+                scale_buffer
+                + context_kv_idx_next_0.to(gl.int64) * stride_scale_seq
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
                 % KVBlockSize,
             )
@@ -905,13 +908,14 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                     )
                     // KVBlockSize,
                 )
-            k_next_1 = gl.amd.cdna3.buffer_load(
-                ptr=KV_buffer,
-                offsets=offset_k_fixed + context_kv_idx_next_1[None, :] * stride_k_seq,
+            k_next_1 = gl.load(
+                KV_buffer
+                + offset_k_fixed
+                + context_kv_idx_next_1.to(gl.int64)[None, :] * stride_k_seq
             )
-            k_scale_f_next_1 = gl.amd.cdna3.buffer_load(
-                ptr=scale_buffer,
-                offsets=context_kv_idx_next_1 * stride_scale_seq
+            k_scale_f_next_1 = gl.load(
+                scale_buffer
+                + context_kv_idx_next_1.to(gl.int64) * stride_scale_seq
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
                 % KVBlockSize,
             )
@@ -1060,9 +1064,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
             + context_kv_idx_next_0 * stride_k_seq
             + context_idx % KVBlockSize * HiddenDim,
         )
-        k_scale_f_next_0 = gl.amd.cdna3.buffer_load(
-            ptr=scale_buffer,
-            offsets=context_kv_idx_next_0 * stride_scale_seq
+        k_scale_f_next_0 = gl.load(
+            scale_buffer
+            + context_kv_idx_next_0.to(gl.int64) * stride_scale_seq
             + (
                 context_idx
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
@@ -1097,9 +1101,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
             + context_kv_idx_next_0 * stride_k_seq
             + (context_idx + ChunkKPerStage) % KVBlockSize * HiddenDim,
         )
-        k_scale_f_next_1 = gl.amd.cdna3.buffer_load(
-            ptr=scale_buffer,
-            offsets=context_kv_idx_next_0 * stride_scale_seq
+        k_scale_f_next_1 = gl.load(
+            scale_buffer
+            + context_kv_idx_next_0.to(gl.int64) * stride_scale_seq
             + (
                 context_idx
                 + ChunkKPerStage
@@ -1182,9 +1186,9 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 + context_kv_idx_next_0 * stride_k_seq
                 + (context_idx_ + ChunkK) % KVBlockSize * HiddenDim,
             )
-            k_scale_f_next_0 = gl.amd.cdna3.buffer_load(
-                ptr=scale_buffer,
-                offsets=context_kv_idx_next_0 * stride_scale_seq
+            k_scale_f_next_0 = gl.load(
+                scale_buffer
+                + context_kv_idx_next_0.to(gl.int64) * stride_scale_seq
                 + (
                     context_idx_
                     + ChunkK


### PR DESCRIPTION
## The 2 GiB boundary

`deepgemm_fp8_paged_mqa_logits` forms KV addresses as `block_id * stride` in
32-bit. Callers that hand it a strided view into a shared per-group KV
allocation (as vLLM does for the DeepSeek-V4 DSA indexer cache) pass a *group
page size* as the stride, so the product crosses `INT32_MAX` at a modest block
index — and **every block past it returns logits of exactly 0.0, silently**,
with intact cache contents. Downstream top-k then degenerates into
`atomicAdd`-order tie-breaking: the sparse indexer selects at random, and
long-context retrieval collapses per-request depending on which physical blocks
the allocator hands out.

Reproduction, one block per trial, no model needed (production stride
1,002,240 B):

| physical block | byte offset | > 2³¹ | non-zero logits |
|---|---|---|---|
| 2142 | 2,146,798,080 | no | 64 |
| **2143** | **2,147,800,320** | **yes** | **0** |

Full field investigation: vllm-project/vllm#52109.

## Why a cast is not the fix

The gathers use `gl.amd.cdna3.buffer_load`, whose offsets are 32-bit by
construction (`_verify_buffer_ops` asserts int32/uint32). This kernel already
casts its **output** offsets to `tl.int64` — ordinary pointer arithmetic can
express 64 bits, `buffer_load` cannot. Folding the block base into the scalar
pointer does not help either: one `buffer_load` gathers `ChunkK` arbitrary
per-lane block indices, so there is no common base to hoist. That leaves
`gl.load` with 64-bit pointer vectors, which is what this PR does.

## No explicit mask is needed

Every converted gather is preceded by
`idx = tl.where(mask, idx, 0)` — invalid lanes are already clamped to block 0
and every load is in range. The hardware OOB masking of `buffer_load` is not
load-bearing on this path, which is what keeps the change small.

## Two thresholds, one defect

`stride_k_seq` is in **bytes**; `stride_scale_seq` is in **float32 elements**.
The same physical block therefore overflows four times later on the scale path
(2,142 vs 8,570 blocks at our strides). Fixing only the K gathers produces a
system that looks healthy until the KV pool grows past the second threshold, at
which point the *scales* come back wrong while the keys are correct — we
shipped exactly that intermediate state locally and it resurfaced as a fresh
failure at a larger `max_model_len`. Both paths are converted together here.

## Performance

Whole-machine A/B on 8× MI325X (gfx942), cudagraphs on, decode throughput
(DeepSeek-V4-Flash, TP=8):

| context | baseline | this PR |
|---|---|---|
| 2k | 45.3 tok/s | 45.3 tok/s |
| 12k | 45.9 tok/s | 45.8 tok/s |
| 30k | 45.5 tok/s | 45.9 tok/s |

Zero regression, despite `gl.load` needing two VGPRs per lane address where
`buffer_load` needed one.

One number worth pre-empting: on DeepSeek-V4-Pro, code-shaped decode with
DSpark runs 91.2 tok/s at `max_model_len=131072` and 77.6 at 600000 — ~~that is
the pre-existing cost of a wider decode scan at a larger model length, present
with and without this change~~. The A/B above holds `max_model_len` fixed.

**Correction (2026-08-20):** the struck-through attribution was wrong. A
controlled A/B on a single image varying only `max_model_len` (131072 vs
600000; 6 short-context + 3×100k-context runs per arm, each arm freshly
restarted) shows no measurable effect from `max_model_len` itself:
100k-context TTFT — the most reproducible metric on this host,
±0.01–0.03 s — identical at 7.62 s; code-shaped decode medians 122.9 vs
119.1 tok/s with fully overlapping ranges (117.9–131.7 vs 112.2–130.0);
100k-context decode 33.2 vs 33.3 tok/s. An earlier 350000-vs-600000 pair
under greedy sampling was output-bit-identical with no timing change. The
91.2-vs-77.6 pair came from two deployment snapshots taken days apart, not
from a controlled pair, so the delta belongs to other differences between
those deployments — consistent with the kernel itself, whose scan is
bounded by the request's actual KV length, not by `max_model_len`. The
zero-regression A/B above (fixed `max_model_len`) is unaffected.

## Verification

* below the boundary, baseline vs this PR on identical inputs:
  **bit-identical** (`torch.equal`, max abs diff 0.0)
* above the boundary: all blocks score non-zero
* end to end, two models and two scales: DeepSeek-V4-Flash at
  `max_model_len=1M`, needle-in-haystack 2k–100k all 3/3; DeepSeek-V4-Pro at
  600k with DSpark (`next_n=6`), **518k-token needle 3/3**

## Scope, stated precisely

`_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle` selects between two pipelines
on `LoadBlockIndiceForEachStage = ChunkKPerStage % KVBlockSize == 0`. Our
configuration takes the first, and **all 11 gathers in it are converted and
tested. Every changed line in this diff has been executed and verified on
gfx942.**

**Not converted, deliberately:** 25 further sites carry the identical defect
but sit on paths our hardware and configuration never execute:

| kernel | remaining 32-bit sites | why unreachable for us |
|---|---|---|
| `_gluon_deepgemm_fp8_paged_mqa_logits` (non-preshuffle) | 4 — K at 227, 277; scales at 235, 288 | vLLM callers pass `Preshuffle=True` |
| `..._preshuffle`, second pipeline | 5 | `ChunkKPerStage % KVBlockSize == 0` holds |
| `..._preshuffle_varctx` | 16 (8 K + 8 scale) | vLLM never passes `VarCtxSchedule` |

Counted by parsing every `buffer_load(` call and testing whether that call's own
`offsets=` / `strides=` expression references `stride_k_seq` or
`stride_scale_seq`, so adjacent K/scale pairs are not conflated: 27 textual
matches, less a commented-out block at line 534 and a `gfx1250`
`make_tensor_descriptor` at line 510, leaves 25.

*(This table first read 16 / 2-5-12; corrected after an independent recount — see
the comment below. The diff itself is unchanged.)*

A mechanical rewrite of a hand-pipelined kernel on paths nobody here can run is
how the two-threshold mistake above happened in the first place, so those are
enumerated rather than converted blind — the fix is identical in shape, and
whoever has test coverage for those paths can convert them with a test behind
each one. Happy to do it under your CI if that is preferred, and happy to
adjust this PR to a different addressing scheme if the kernel authors have one
in mind — we can run correctness/perf A/B on our gfx942 rig on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


