### PR TITLE
[Attention] Expose paged MQA SplitKV override

### DIFF
--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -457,6 +457,26 @@ def deepgemm_fp8_paged_mqa_logits_schedule(
     return safe_chunks_per_cta
 
 
+def _resolve_paged_mqa_split_kv(
+    SplitKV: int | None,
+    TotalCuCount: int,
+    TileQCount: int,
+    WavePerEU: int,
+    is_gfx1250: bool,
+) -> int:
+    if SplitKV is not None:
+        if isinstance(SplitKV, bool) or not isinstance(SplitKV, int) or SplitKV <= 0:
+            raise ValueError(f"SplitKV must be a positive integer, got {SplitKV!r}")
+        return SplitKV
+    return (
+        (max(1, TotalCuCount // TileQCount) + 4)
+        // 5
+        * 5
+        * WavePerEU
+        * (2 if is_gfx1250 else 1)
+    )
+
+
 def deepgemm_fp8_paged_mqa_logits(
     q_fp8: torch.Tensor,  # dtype = float8
     kv_cache,
@@ -471,7 +491,10 @@ def deepgemm_fp8_paged_mqa_logits(
     TotalCuCount: int | None = None,
     WavePerEU: int = 2,
     VarCtxSchedule: torch.Tensor = None,
+    SplitKV: int | None = None,
 ):
+    if SplitKV is not None and VarCtxSchedule is not None:
+        raise ValueError("SplitKV cannot be used with VarCtxSchedule")
     if TotalCuCount is None:
         TotalCuCount = get_num_sms()
     batch_size, next_n, heads, hidden_dim = q_fp8.size()
@@ -485,12 +508,12 @@ def deepgemm_fp8_paged_mqa_logits(
             WavePerEU = 1
 
     TileQCount = batch_size * next_n
-    SplitKV = (
-        (max(1, TotalCuCount // TileQCount) + 4)
-        // 5
-        * 5
-        * WavePerEU
-        * (2 if get_gfx() == "gfx1250" else 1)
+    SplitKV = _resolve_paged_mqa_split_kv(
+        SplitKV,
+        TotalCuCount,
+        TileQCount,
+        WavePerEU,
+        get_gfx() == "gfx1250",
     )
 
     assert ChunkK % KVBlockSize == 0 or KVBlockSize % ChunkK == 0

--- a/op_tests/triton_tests/attention/test_pa_mqa_logits_split_kv.py
+++ b/op_tests/triton_tests/attention/test_pa_mqa_logits_split_kv.py
@@ -1,0 +1,55 @@
+import pytest
+from aiter.ops.triton.attention.pa_mqa_logits import (
+    _resolve_paged_mqa_split_kv,
+    deepgemm_fp8_paged_mqa_logits,
+)
+
+
+@pytest.mark.parametrize("split_kv", [0, -1, True, 1.5])
+def test_paged_mqa_logits_rejects_invalid_split_kv(split_kv):
+    with pytest.raises(ValueError, match="SplitKV must be a positive integer"):
+        _resolve_paged_mqa_split_kv(split_kv, 256, 8192, 2, False)
+
+
+@pytest.mark.parametrize(
+    "total_cu_count,tile_q_count,wave_per_eu,is_gfx1250,expected",
+    [
+        (256, 8192, 2, False, 10),
+        (256, 64, 2, False, 10),
+        (256, 1, 2, False, 520),
+        (256, 8192, 4, True, 40),
+    ],
+)
+def test_paged_mqa_logits_legacy_split_kv(
+    total_cu_count, tile_q_count, wave_per_eu, is_gfx1250, expected
+):
+    assert (
+        _resolve_paged_mqa_split_kv(
+            None,
+            total_cu_count,
+            tile_q_count,
+            wave_per_eu,
+            is_gfx1250,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("split_kv", [1, 2, 7, 16])
+def test_paged_mqa_logits_explicit_split_kv(split_kv):
+    assert _resolve_paged_mqa_split_kv(split_kv, 256, 8192, 2, False) == split_kv
+
+
+def test_paged_mqa_logits_rejects_split_kv_with_varctx():
+    with pytest.raises(ValueError, match="SplitKV cannot be used with VarCtxSchedule"):
+        deepgemm_fp8_paged_mqa_logits(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            1,
+            SplitKV=2,
+            VarCtxSchedule=object(),
+        )

--- a/op_tests/triton_tests/attention/test_pa_mqa_logits_split_kv.py
+++ b/op_tests/triton_tests/attention/test_pa_mqa_logits_split_kv.py
@@ -1,4 +1,5 @@
 import pytest
+
 from aiter.ops.triton.attention.pa_mqa_logits import (
     _resolve_paged_mqa_split_kv,
     deepgemm_fp8_paged_mqa_logits,


### PR DESCRIPTION
## Summary

- expose an optional `SplitKV` override on `deepgemm_fp8_paged_mqa_logits`
- preserve the existing launch heuristic exactly when the override is omitted
- validate explicit values and reject ambiguous use with `VarCtxSchedule`
- add focused regression coverage for validation, legacy resolution, and explicit pass-through

## Motivation

The paged MQA kernel already accepts a runtime split count, but the public wrapper always derives it from `TotalCuCount`, `TileQCount`, and `WavePerEU`. This prevents callers from tuning the split independently for production shapes.

On MI355X (`gfx950`), a diagnostic three-process sweep for the DSV4 shape `rows=6144`, `width=33280`, `ChunkK=256` found `SplitKV=2` consistently faster than the current automatic value of 10:

| Run | Auto 10 | Explicit 2 | Speedup |
|---:|---:|---:|---:|
| 1 | 2582.667 us | 2546.246 us | 1.01430x |
| 2 | 2590.807 us | 2558.686 us | 1.01255x |
| 3 | 2582.267 us | 2547.466 us | 1.01366x |

Aggregate producer gain was 1.382%; all tested split values passed bitwise correctness probes. This PR exposes the mechanism only. It intentionally does not hard-code a shape policy from a single diagnostic shape.

## Compatibility

`SplitKV=None` executes the exact previous formula, so existing callers and launch behavior are unchanged. The underlying Triton/Gluon kernel already accepts a dynamic split count; no kernel ABI or cache-key change is needed.

## Validation

- `13 passed` in `test_pa_mqa_logits_split_kv.py`
- public-wrapper MI355X check: zero bitwise mismatches for explicit `SplitKV=2`
- Ruff, `py_compile`, and `git diff --check` pass
