### PR TITLE
fix(opus_gemm): use __align__ instead of alignas after __shared__ on …

### DIFF
--- a/csrc/include/opus/hip_minimal.hpp
+++ b/csrc/include/opus/hip_minimal.hpp
@@ -44,6 +44,9 @@
 #ifndef __shared__
 #define __shared__      __attribute__((shared))
 #endif
+#ifndef __align__
+#define __align__(x)    __attribute__((aligned(x)))
+#endif
 #ifndef __device__
 #define __device__      __attribute__((device))
 #endif

--- a/csrc/opus_gemm/include/gfx950/opus_bmm_pipeline_a8w8_mxscale_gfx950.cuh
+++ b/csrc/opus_gemm/include/gfx950/opus_bmm_pipeline_a8w8_mxscale_gfx950.cuh
@@ -223,7 +223,7 @@ __device__ __forceinline__ void gemm_a8w8_scale_kernel_impl(opus_gemm_scale_karg
         PRELOAD_SFA_LDS ? (SFA_ROWS * SFA_K_TILES_MAX * (int)sizeof(D_SF)) : 1;
     // 16B-aligned so the panel fill below can land ds_write_b128; a bare char
     // array is only byte-aligned as far as the language is concerned.
-    __shared__ alignas(16) char smem_sfa[SFA_LDS_BYTES];
+    __shared__ __align__(16) char smem_sfa[SFA_LDS_BYTES];
     D_SF* s_sfa_ptr = reinterpret_cast<D_SF*>(smem_sfa);
     // Runtime packed K-tile count (== loops); used as the compact LDS M-row
     // stride so the read layout reuses make_layout_sfa with stride_sfa replaced.

--- a/csrc/opus_gemm/include/gfx950/opus_gemm_pipeline_a8w8_mxscale_flatmm_splitk_gfx950.cuh
+++ b/csrc/opus_gemm/include/gfx950/opus_gemm_pipeline_a8w8_mxscale_flatmm_splitk_gfx950.cuh
@@ -485,7 +485,7 @@ void gemm_a8w8_mxscale_flatmm_splitk_kernel(opus_gemm_scale_splitk_kargs_gfx950 
         PRELOAD_SF_LDS ? ((SFA_ROWS + T::N_SCALE_GROUPS) * SF_SCALES_MAX) : 1;
     // 16B-aligned so the panel fill below can land ds_write_b128; a byte array is
     // only byte-aligned as far as the language is concerned.
-    __shared__ alignas(16) D_SF smem_sf[SF_LDS_ELEMS];
+    __shared__ __align__(16) D_SF smem_sf[SF_LDS_ELEMS];
 
     auto smem_a_at = [&](int slot_k, int m_block, int k_group) -> D_A* {
         return reinterpret_cast<D_A*>(smem_a


### PR DESCRIPTION
…gfx950

__shared__ expands to __attribute__((shared)), and a C++11 alignas that follows a GNU attribute is parsed as appertaining to the type by the clang shipped in ROCm 7.1.1:

  opus_gemm_pipeline_a8w8_mxscale_flatmm_splitk_gfx950.cuh:488:16: error:
  'alignas' attribute cannot be applied to types
      __shared__ alignas(16) D_SF smem_sf[SF_LDS_ELEMS];

Newer clang accepts the mixed form, so CI never caught it. Switch both sites to __align__ -- i.e. __attribute__((aligned(16))) -- which composes with __attribute__((shared)) on every version and is what the rest of the tree already uses. The emitted LDS globals are still `align 16`, so the ds_write_b128 these panels rely on is unaffected.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
