### PR TITLE
[gfx1100] Enable RDNA3 in arch allow-list + Triton GEMM A8W8 tuning config

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx1100-GEMM-A8W8.json
+++ b/aiter/ops/triton/configs/gemm/gfx1100-GEMM-A8W8.json
@@ -1,0 +1,38 @@
+{
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "NUM_KSPLIT": 1
+    },
+    "M_GEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/csrc/cpp_itfs/utils.py
+++ b/csrc/cpp_itfs/utils.py
@@ -179,6 +179,7 @@ def validate_and_update_archs():
         "gfx941",
         "gfx942",
         "gfx950",
+        "gfx1100",
         "gfx1151",
     ]
 


### PR DESCRIPTION
## Summary

Follow-up to #4604 with the working reference implementation discussed there.

vLLM's AITER integration gate (`is_aiter_found_and_supported()`) covers CDNA3+ and RDNA4, but never gfx1100 (RDNA3) — even though AITER's README lists W7900 / gfx1100 as Experimental, and `configs/gemm/` already ships tuned A8W8 configs for gfx1151/1201/1250 but not gfx1100. This PR contributes the aiter-side half of the port (vLLM-side gate change to be submitted separately, tracked in vllm-project/vllm#51136).

## Changes

1. `csrc/cpp_itfs/utils.py` — add `gfx1100` to the `allowed_archs` list in `validate_and_update_archs()`. The stale list only covered gfx9x + gfx1151 and rejected `GPU_ARCHS=gfx1100` at compile time.
2. `aiter/ops/triton/configs/gemm/gfx1100-GEMM-A8W8.json` — new M-band tuning config for the Triton WMMA path (none existed for RDNA3), same M_LEQ_x / M_GEQ_y / any schema as sibling configs:
   - decode (M<=32): `BLOCK_SIZE_M=16, N=128, K=128, warps=4, stages=3` -> 0.071 ms/GEMM
   - prefill (M>=64): `BLOCK_SIZE_M=64, N=256, warps=8` -> 4.4 ms @ M=2048

Note: AITER's CK-based `gemm_a8w8_CK` kernels are XDL-only and compile-fail on RDNA3, so gfx1100 routes to the pure-Triton `gemm_a8w8` kernel.

## Validation (Radeon PRO W7900 48GB, ROCm 7.2.4, vLLM 0.26.0, Aug 3 2026)

Model: Qwen3.6-27B Quark W8A8-INT8, multimodal OCR workload (insurance claim agent, ~4k ctx):

| Path | Linear kernel | Throughput |
|------|--------------|:---:|
| AITER gated off (default) | TritonInt8ScaledMMLinearKernel | 12.3 tok/s |
| AITER gfx1100 (this port) | AiterInt8ScaledMMLinearKernel + GDN + causal_conv1d + sampler | 11.7 tok/s |

Functional **parity**, not speedup — reported honestly. On this workload the decode bottleneck is 140+ serialized per-layer kernels on RDNA3 WMMA, not a single GEMM. The value here is enabling the native AITER stack (quantized GEMM + GDN decode + conv1d + sampler) on RDNA3 at all; per-shape tuning is left as future work.

Enable with: `VLLM_ROCM_USE_AITER=1 GPU_ARCHS=gfx1100`; vLLM log confirms `Selected AiterInt8ScaledMMLinearKernel`.

Only gfx1100 (W7900) is tested; other RDNA3 variants (gfx1101/1102/1103) are expected to work but untested — happy to extend the allow-list if maintainers prefer.

## Related

- Aiter half of #4604
- vLLM-side gate: vllm-project/vllm#51136 (maintainer confirmed RDNA/AITER is not on vLLM roadmap)