### PR TITLE
[Bugfix] Handle GroupNorm autocast safely

### DIFF
--- a/aiter/ops/groupnorm.py
+++ b/aiter/ops/groupnorm.py
@@ -56,15 +56,13 @@ def _groupnorm_workspace(ws_slots: int, device: torch.device) -> Tensor:
     return ws
 
 
-def groupnorm_run(
+def _groupnorm_run_impl(
     input: Tensor,
     num_groups: int,
     weight: Tensor,
     bias: Tensor,
     eps: float,
 ) -> Tensor:
-    """Group Normalization. Allocates output and reuses a cached scratch
-    workspace, then calls the HIP kernel. Returns the normalized output."""
     input = input.contiguous()
     weight = weight.contiguous()
     bias = bias.contiguous()
@@ -76,6 +74,26 @@ def groupnorm_run(
 
     _groupnorm_run(y, workspace, input, num_groups, weight, bias, eps)
     return y
+
+
+def groupnorm_run(
+    input: Tensor,
+    num_groups: int,
+    weight: Tensor,
+    bias: Tensor,
+    eps: float,
+) -> Tensor:
+    """Group Normalization. Allocates output and reuses a cached scratch
+    workspace, then calls the HIP kernel. CUDA autocast follows PyTorch's FP32
+    policy for GroupNorm. Returns the normalized output."""
+    device_type = input.device.type
+    if torch.is_autocast_enabled(device_type):
+        with torch.amp.autocast(device_type, enabled=False):
+            return _groupnorm_run_impl(
+                input.float(), num_groups, weight.float(), bias.float(), eps
+            )
+
+    return _groupnorm_run_impl(input, num_groups, weight, bias, eps)
 
 
 class GroupNorm(torch.nn.Module):

--- a/csrc/include/groupnorm.hpp
+++ b/csrc/include/groupnorm.hpp
@@ -15,7 +15,9 @@ namespace aiter {
 //   bias:      affine bias   [num_channels], contiguous
 //   epsilon:   numerical stability term
 //
-// Supported dtypes for x/y/weight/bias: fp32, fp16, bf16.
+// Supported dtypes for x/y/weight/bias: fp32, fp16, bf16. These four tensors
+// must have the same dtype. The Python wrapper casts them to fp32 under CUDA
+// autocast to match PyTorch GroupNorm.
 void groupnorm_run(aiter_tensor_t& y,
                    aiter_tensor_t& workspace,
                    const aiter_tensor_t& x,

--- a/csrc/kernels/groupnorm.cu
+++ b/csrc/kernels/groupnorm.cu
@@ -361,6 +361,11 @@ void groupnorm_run(
 
     AITER_CHECK(weights.numel() > 0 && bias.numel() > 0,
                 "groupnorm requires non-empty affine weight and bias");
+    AITER_CHECK(y.dtype() == x.dtype() && weights.dtype() == x.dtype() &&
+                    bias.dtype() == x.dtype(),
+                "groupnorm requires input, output, weight, and bias to have the same dtype");
+    AITER_CHECK(workspace.dtype() == AITER_DTYPE_fp32,
+                "groupnorm workspace must have dtype fp32");
     // x/weights/bias contiguity is guaranteed by the Python wrapper; check defensively.
     AITER_CHECK(x.is_contiguous(), "groupnorm input x must be contiguous");
 
@@ -380,4 +385,3 @@ void groupnorm_run(
 }
 
 } // namespace aiter
-

--- a/op_tests/test_groupnorm.py
+++ b/op_tests/test_groupnorm.py
@@ -4,15 +4,85 @@ import random
 import numpy as np
 import torch
 
-from aiter.ops.groupnorm import GroupNorm
+from aiter.ops.groupnorm import GroupNorm, groupnorm_run
+from aiter.test_common import checkAllclose, perftest
 
 random.seed(0)
 torch.manual_seed(0)
 np.random.seed(0)
 
 
-class GroupNormTimer:
+@perftest(num_iters=25, num_warmup=5, use_cuda_event=True)
+def run_torch_autocast(norm, x):
+    with torch.inference_mode(), torch.amp.autocast("cuda", dtype=torch.float16):
+        return norm(x, use_torch=True)
 
+
+@perftest(num_iters=25, num_warmup=5, use_cuda_event=True)
+def run_aiter_autocast(norm, x):
+    with torch.inference_mode(), torch.amp.autocast("cuda", dtype=torch.float16):
+        return norm(x)
+
+
+def test_autocast_matches_torch(spatial_size=64):
+    device = torch.device("cuda")
+    num_groups = 32
+    num_channels = 128
+    norm = GroupNorm(
+        num_groups,
+        num_channels,
+        eps=1e-6,
+        affine=True,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    norm.weight = torch.nn.Parameter(
+        torch.randn(num_channels, dtype=torch.bfloat16, device=device)
+    )
+    norm.bias = torch.nn.Parameter(
+        torch.randn(num_channels, dtype=torch.bfloat16, device=device)
+    )
+    x = torch.randn(
+        (1, num_channels, 4, spatial_size, spatial_size),
+        dtype=torch.float16,
+        device=device,
+    )
+
+    expected, torch_us = run_torch_autocast(norm, x)
+    actual, aiter_us = run_aiter_autocast(norm, x)
+
+    assert expected.dtype == torch.float32
+    assert actual.dtype == expected.dtype
+    message = (
+        f"[perf] shape: {tuple(x.shape)}, torch: {torch_us:.2f} us, "
+        f"aiter: {aiter_us:.2f} us, speedup: {torch_us / aiter_us:.2f}x "
+    )
+    mismatch_ratio = checkAllclose(
+        actual,
+        expected,
+        rtol=1e-3,
+        atol=1e-2,
+        tol_err_ratio=0,
+        msg=message,
+    )
+    assert mismatch_ratio == 0
+
+
+def test_mixed_dtype_without_autocast_is_rejected():
+    device = torch.device("cuda")
+    x = torch.randn((1, 8, 4, 4), dtype=torch.float16, device=device)
+    weight = torch.randn(8, dtype=torch.bfloat16, device=device)
+    bias = torch.randn(8, dtype=torch.bfloat16, device=device)
+
+    try:
+        groupnorm_run(x, 4, weight, bias, 1e-6)
+    except RuntimeError as error:
+        assert "same dtype" in str(error)
+    else:
+        raise AssertionError("mixed dtype GroupNorm call did not raise")
+
+
+class GroupNormTimer:
     def __init__(self, num_groups, num_channels, device, dtype):
         self.norm = GroupNorm(
             num_groups, num_channels, eps=1e-6, affine=True, device=device, dtype=dtype
@@ -197,7 +267,17 @@ if __name__ == "__main__":
         help="Number of measurement iterations (default: 25)",
     )
 
+    parser.add_argument(
+        "--autocast-spatial-size",
+        type=int,
+        default=64,
+        help="Spatial size for the Hunyuan autocast regression (default: 64)",
+    )
+
     args = parser.parse_args()
+
+    test_autocast_matches_torch(args.autocast_spatial_size)
+    test_mixed_dtype_without_autocast_is_rejected()
 
     print("=== GroupNorm Performance Benchmark ===", flush=True)
     print(f"Device: {args.device}", flush=True)

--- a/op_tests/test_groupnorm.py
+++ b/op_tests/test_groupnorm.py
@@ -1,10 +1,14 @@
 import argparse
+import os
 import random
+import resource
+import subprocess
+import sys
 
 import numpy as np
 import torch
 
-from aiter.ops.groupnorm import GroupNorm, groupnorm_run
+from aiter.ops.groupnorm import GroupNorm
 from aiter.test_common import checkAllclose, perftest
 
 random.seed(0)
@@ -69,17 +73,36 @@ def test_autocast_matches_torch(spatial_size=64):
 
 
 def test_mixed_dtype_without_autocast_is_rejected():
-    device = torch.device("cuda")
-    x = torch.randn((1, 8, 4, 4), dtype=torch.float16, device=device)
-    weight = torch.randn(8, dtype=torch.bfloat16, device=device)
-    bias = torch.randn(8, dtype=torch.bfloat16, device=device)
+    code = """
+import torch
+from aiter.ops.groupnorm import groupnorm_run
 
-    try:
-        groupnorm_run(x, 4, weight, bias, 1e-6)
-    except RuntimeError as error:
-        assert "same dtype" in str(error)
-    else:
-        raise AssertionError("mixed dtype GroupNorm call did not raise")
+x = torch.randn((1, 8, 4, 4), dtype=torch.float16, device="cuda")
+weight = torch.randn(8, dtype=torch.bfloat16, device="cuda")
+bias = torch.randn(8, dtype=torch.bfloat16, device="cuda")
+groupnorm_run(x, 4, weight, bias, 1e-6)
+"""
+    env = os.environ.copy()
+    env.pop("AITER_REBUILD", None)
+
+    def disable_core_dump():
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+
+    process = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        preexec_fn=disable_core_dump,
+        check=False,
+    )
+    output = process.stdout + process.stderr
+    assert process.returncode != 0
+    assert (
+        "groupnorm requires input, output, weight, and bias to have the same dtype"
+        in output
+    )
 
 
 class GroupNormTimer:

--- a/op_tests/test_groupnorm.py
+++ b/op_tests/test_groupnorm.py
@@ -16,13 +16,13 @@ torch.manual_seed(0)
 np.random.seed(0)
 
 
-@perftest(num_iters=25, num_warmup=5, use_cuda_event=True)
+@perftest(num_iters=25, num_warmup=5, num_rotate_args=1, use_cuda_event=True)
 def run_torch_autocast(norm, x):
     with torch.inference_mode(), torch.amp.autocast("cuda", dtype=torch.float16):
         return norm(x, use_torch=True)
 
 
-@perftest(num_iters=25, num_warmup=5, use_cuda_event=True)
+@perftest(num_iters=25, num_warmup=5, num_rotate_args=1, use_cuda_event=True)
 def run_aiter_autocast(norm, x):
     with torch.inference_mode(), torch.amp.autocast("cuda", dtype=torch.float16):
         return norm(x)

--- a/op_tests/test_groupnorm.py
+++ b/op_tests/test_groupnorm.py
@@ -163,7 +163,8 @@ class GroupNormTimer:
             print("z :")
             print(z)
 
-        is_equal = torch.allclose(y, z, rtol=1e-3, atol=1e-2)
+        rtol = 1e-2 if self.dtype == torch.bfloat16 else 1e-3
+        is_equal = torch.allclose(y, z, rtol=rtol, atol=1e-2)
         return (time_elapsed_torch, time_elapsed_opt, is_equal)
 
 


### PR DESCRIPTION
## Summary

Make AITER GroupNorm follow PyTorch's FP32 autocast policy. Add dtype checks before the HIP kernel reads the input and affine parameter pointers.

Fixes #4780

## Motivation

Hunyuan Image 3.0 calls GroupNorm under CUDA autocast with an FP16 input and BF16 weight and bias tensors. PyTorch registers GroupNorm as an FP32 autocast operation, but AITER calls its HIP kernel directly and does not pass through that dispatcher rule.

The AITER kernel selects its pointer type from the input dtype. Before this change, it treated the BF16 weight and bias storage as FP16 when the input was FP16. In the Hunyuan VAE, the AITER output was FP16 while the PyTorch output was FP32. The mean error was 1.0778 and the maximum error was 6.1785.

## Changes

- Cast the input, weight, and bias to FP32 when CUDA autocast is active, then call the existing FP32 GroupNorm kernel with autocast disabled.
- Keep the existing FP16, BF16, and FP32 paths unchanged when autocast is disabled.
- Check that the input, output, weight, and bias have the same dtype before launching the kernel.
- Check that the scratch workspace uses FP32.
- Add the exact Hunyuan GroupNorm shape to the standalone test and include correctness and performance measurements.
- Use a BF16 tolerance for the existing BF16 benchmark.

## Performance

Tests ran on one MI300X with gfx942, ROCm 7.2, and PyTorch 2.11. The autocast measurement includes the FP32 tensor conversions.

| Configuration | PyTorch | AITER | Speedup | Correctness |
|---|---:|---:|---:|---|
| Hunyuan autocast, shape `(1, 128, 4, 1024, 1024)` | 15,613.13 us | 2,722.52 us | 5.73x | Passed with `rtol=0.001`, `atol=0.01` |
| Direct FP32, shape `(1, 128, 4, 64, 64)` | 31.1 us | 42.3 us | 0.74x | Passed |
| Direct BF16, shape `(1, 512, 3, 64, 64)` | 98.3 us | 38.7 us | 2.54x | Passed |

The change does not alter the HIP GroupNorm arithmetic or memory access pattern. Bandwidth and roofline analysis do not apply to this correctness fix.

## Testing

- [x] Unit tests added or updated
- [x] Performance benchmarks run
- [ ] Tested on MI250X
- [x] Tested on MI300X

```bash
python3 op_tests/test_groupnorm.py --dtype float32 -b 32,1,128,4,64,64 --autocast-spatial-size 1024
python3 op_tests/test_groupnorm.py --dtype bfloat16 -b 32,1,512,3,64,64 --autocast-spatial-size 64
ruff check aiter/ops/groupnorm.py op_tests/test_groupnorm.py
ruff format --check aiter/ops/groupnorm.py op_tests/test_groupnorm.py
```

## Documentation

- [x] Docstrings updated
- [ ] User guide updated because no user guide change is needed
- [ ] Performance guide updated because no performance guide change is needed

## Dependencies

- [x] No new third party dependencies added

## PyTorch compatibility question

AITER documentation currently lists PyTorch 2.0 and later as supported. The `device_type` argument for `torch.is_autocast_enabled` was added in PyTorch 2.4, while PyTorch 2.0 to 2.3 accept no arguments.

Maintainers, should GroupNorm preserve PyTorch 2.0 to 2.3 compatibility by using `torch.is_autocast_enabled()` without an argument, or is the current AITER baseline PyTorch 2.4 or later?

## Breaking changes

A direct mixed dtype call without autocast now stops with a clear error instead of launching a kernel that interprets the affine parameter storage using the input dtype.
