### PR TITLE
[gfx950][FlyDSL] Add direct dense A4W4 MXFP4 GEMM

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -38,6 +38,11 @@ if is_flydsl_available():
         )
 
     from .fmha_kernels import flydsl_flash_attn_func
+    from .gemm_a4w4 import (
+        PreshuffledA4W4Weight,
+        flydsl_gemm_a4w4,
+        prepare_gemm_a4w4_weight,
+    )
     from .gemm_kernels import flydsl_hgemm, flydsl_preshuffle_gemm_a8
     from .kernels.mqa_logits.fp8_mqa_logits import (
         DEFAULT_VARIANT as FP8_MQA_LOGITS_DEFAULT_VARIANT,
@@ -65,9 +70,11 @@ if is_flydsl_available():
     __all__ += [
         "FP8_MQA_LOGITS_DEFAULT_VARIANT",
         "FP8_MQA_LOGITS_VARIANTS",
+        "PreshuffledA4W4Weight",
         "compute_varqlen_windows",
         "flydsl_flash_attn_func",
         "flydsl_fp8_mqa_logits",
+        "flydsl_gemm_a4w4",
         "flydsl_hgemm",
         "flydsl_mla_reduce_v1",
         "flydsl_moe_stage1",
@@ -77,5 +84,6 @@ if is_flydsl_available():
         "flydsl_pa_mqa_logits_fp4_varqlen",
         "flydsl_preshuffle_gemm_a8",
         "flydsl_qk_norm_rope_quant",
+        "prepare_gemm_a4w4_weight",
         # "flydsl_gdr_decode",
     ]

--- a/aiter/ops/flydsl/gemm_a4w4.py
+++ b/aiter/ops/flydsl/gemm_a4w4.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""High-level gfx950 dense, inline-quantized MXFP4 x MXFP4 FlyDSL API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+from .kernels.gemm_a4w4 import compile_gemm_a4w4
+from .kernels.tensor_shim import _run_compiled
+
+__all__ = [
+    "PreshuffledA4W4Weight",
+    "flydsl_gemm_a4w4",
+    "prepare_gemm_a4w4_weight",
+]
+
+
+@dataclass(frozen=True)
+class PreshuffledA4W4Weight:
+    """Packed E2M1 weight and E8M0 scales in the gfx950 MFMA load layout."""
+
+    weight: torch.Tensor
+    scale: torch.Tensor
+    n: int
+    k: int
+
+
+def _require_gfx950() -> None:
+    arch = str(get_gfx()).split(":", 1)[0]
+    if arch != "gfx950":
+        raise RuntimeError(f"flydsl_gemm_a4w4 requires gfx950, got {arch!r}")
+
+
+def _select_bm(m: int, n: int, k: int) -> int:
+    """Select the measured BM16/BM64 crossover for K3 dense projections."""
+    thresholds = {
+        (8448, 7168): 128,
+        (7168, 4224): 512,
+        (1536, 7168): 2048,
+        (7168, 768): 512,
+    }
+    threshold = thresholds.get((n, k))
+    return 64 if threshold is not None and m >= threshold else 16
+
+
+def prepare_gemm_a4w4_weight(
+    weight: torch.Tensor, weight_scale: torch.Tensor
+) -> PreshuffledA4W4Weight:
+    """Preshuffle packed E2M1 ``[N,K/2]`` and E8M0 ``[N,K/32]``.
+
+    This preparation only rearranges the supplied packed bytes. It neither
+    creates nor caches a BF16 weight.
+    """
+    _require_gfx950()
+    if weight.ndim != 2 or weight_scale.ndim != 2:
+        raise ValueError("weight and weight_scale must both be 2D")
+    if weight.device.type != "cuda" or weight_scale.device.type != "cuda":
+        raise ValueError("weight and weight_scale must be CUDA/ROCm tensors")
+    if weight.device != weight_scale.device:
+        raise ValueError("weight and weight_scale must be on the same device")
+    if weight.element_size() != 1 or weight_scale.element_size() != 1:
+        raise TypeError("weight and weight_scale must contain packed byte payloads")
+    n, packed_k = weight.shape
+    k = packed_k * 2
+    if n <= 0 or n % 256:
+        raise ValueError(f"N must be a positive multiple of 256, got {n}")
+    if k <= 0 or k % 128:
+        raise ValueError(f"K must be a positive multiple of 128, got {k}")
+    if tuple(weight_scale.shape) != (n, k // 32):
+        raise ValueError(
+            f"weight_scale must have shape {(n, k // 32)}, "
+            f"got {tuple(weight_scale.shape)}"
+        )
+
+    weight_u8 = weight.contiguous().view(torch.uint8)
+    scale_u8 = weight_scale.contiguous().view(torch.uint8)
+    return PreshuffledA4W4Weight(
+        weight=shuffle_weight_a16w4(
+            weight_u8.unsqueeze(0), NLane=16, gate_up=False
+        ).squeeze(0),
+        scale=shuffle_scale_a16w4(scale_u8, experts_cnt=1, gate_up=False),
+        n=n,
+        k=k,
+    )
+
+
+def flydsl_gemm_a4w4(
+    a: torch.Tensor,
+    weight: torch.Tensor | PreshuffledA4W4Weight,
+    weight_scale: torch.Tensor | None = None,
+    *,
+    out: torch.Tensor | None = None,
+    stream: torch.cuda.Stream | None = None,
+    _bm: int | None = None,
+) -> torch.Tensor:
+    """Compute dense ``A @ W.T`` with in-kernel per-1x32 MXFP4 A quantization.
+
+    ``weight`` may be a prepared object for repeated calls, or the original
+    packed E2M1 ``[N,K/2]`` tensor together with its E8M0 ``[N,K/32]`` scales.
+    No global activation quantization/QDQ buffer is allocated.
+
+    ``_bm`` may explicitly force the 16- or 64-row kernel for tuning. By
+    default, measured K3 shape-specific crossover thresholds are used.
+    """
+    _require_gfx950()
+    if _bm is not None and _bm not in (16, 64):
+        raise ValueError(f"_bm must be None, 16, or 64, got {_bm}")
+    if isinstance(weight, PreshuffledA4W4Weight):
+        if weight_scale is not None:
+            raise ValueError("weight_scale must be omitted for a prepared weight")
+        prepared = weight
+    else:
+        if weight_scale is None:
+            raise ValueError("weight_scale is required with an unprepared weight")
+        prepared = prepare_gemm_a4w4_weight(weight, weight_scale)
+
+    if a.ndim != 2:
+        raise ValueError(f"a must be 2D, got a.ndim={a.ndim}")
+    if a.dtype != torch.bfloat16:
+        raise TypeError(f"a must be BF16, got {a.dtype}")
+    if a.device.type != "cuda" or not a.is_contiguous():
+        raise ValueError("a must be a contiguous CUDA/ROCm tensor")
+    m, k = a.shape
+    if m <= 0:
+        raise ValueError(f"M must be positive, got {m}")
+    if k != prepared.k:
+        raise ValueError(f"a K={k} does not match weight K={prepared.k}")
+    if a.device != prepared.weight.device:
+        raise ValueError("a and weight must be on the same device")
+    selected_bm = _select_bm(m, prepared.n, prepared.k) if _bm is None else _bm
+
+    expected = (m, prepared.n)
+    if out is None:
+        out = torch.empty(expected, dtype=torch.bfloat16, device=a.device)
+    elif (
+        tuple(out.shape) != expected
+        or out.dtype != torch.bfloat16
+        or out.device != a.device
+        or not out.is_contiguous()
+    ):
+        raise ValueError(f"out must be contiguous BF16 {expected} on {a.device}")
+
+    launch_stream = torch.cuda.current_stream(a.device) if stream is None else stream
+    if launch_stream.device != a.device:
+        raise ValueError("stream and tensors must be on the same device")
+    launcher = compile_gemm_a4w4(N=prepared.n, K=prepared.k, BM=selected_bm)
+    _run_compiled(
+        launcher,
+        a.data_ptr(),
+        prepared.weight.data_ptr(),
+        prepared.scale.data_ptr(),
+        out.data_ptr(),
+        int(m),
+        launch_stream,
+    )
+    return out

--- a/aiter/ops/flydsl/kernels/gemm_a4w4.py
+++ b/aiter/ops/flydsl/kernels/gemm_a4w4.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""gfx950 dense BF16 -> inline MXFP4 activation quantization x MXFP4 GEMM."""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import gpu, rocdl
+from flydsl.expr.typing import T
+from flydsl.runtime.device import get_rocm_arch
+
+from .mxfp4_gemm1 import _bm_constants, _gemm1_body
+
+__all__ = ["compile_gemm_a4w4"]
+
+
+@functools.cache
+def compile_gemm_a4w4(*, N: int, K: int, BM: int = 16):
+    """Compile a dense BN=256 inline-quantized launcher."""
+    arch = str(get_rocm_arch()).split(":", 1)[0]
+    if arch != "gfx950":
+        raise ValueError(f"dense a4w4 FlyDSL kernel requires gfx950, got {arch!r}")
+    if N <= 0 or N % 256:
+        raise ValueError(f"N must be a positive multiple of 256, got {N}")
+    if K <= 0 or K % 128:
+        raise ValueError(f"K must be a positive multiple of 128, got {K}")
+    if BM not in (16, 64):
+        raise ValueError(f"BM must be 16 or 64, got {BM}")
+
+    BN = 256
+    BK = 256 if K % 256 == 0 else 128
+    k_tiles = K // BK
+    if k_tiles < 3:
+        raise ValueError(f"K must contain at least three BK={BK} tiles, got K={K}")
+    k_a_stages, k_scale_subblocks, _, lds_bytes = _bm_constants(
+        BM, BN, BK // 2, k_tiles
+    )
+    if BM == 64:
+        # Dense output is written directly from accm, so unlike the shared MoE
+        # epilogue this specialization never needs a BM*BN f32 LDS accumulator.
+        # Avoid reserving 64 KiB and retain only the quantization pipeline.
+        lds_bytes = (
+            k_a_stages * BM * (BK // 2) + k_scale_subblocks * ((K + 255) // 256) * 256
+        )
+    n_blocks = N // BN
+    kernel_name = f"dense_a4w4_iq_n{N}_k{K}_bm{BM}_bn{BN}_bk{BK}"
+
+    @fx.struct
+    class SharedStorage:
+        raw: fx.Array[fx.Uint8, lds_bytes, 16]
+
+    @flyc.kernel(name=kernel_name, known_block_size=[256, 1, 1])
+    def kernel(
+        arg_a: fx.Int64,
+        arg_bq: fx.Int64,
+        arg_bscale: fx.Int64,
+        arg_out: fx.Int64,
+        i32_m: fx.Int32,
+    ):
+        lds_raw_ptr = fx.SharedAllocator().allocate(SharedStorage).peek().raw.ptr
+        tx = fx.Int32(gpu.thread_id("x"))
+        block = fx.Int32(gpu.block_id("x"))
+        lane = tx % fx.Int32(64)
+        wave = rocdl.readfirstlane(T.i32, tx // fx.Int32(64))
+
+        _gemm1_body(
+            lds_raw_ptr,
+            arg_a,
+            arg_a,
+            arg_bq,
+            arg_bscale,
+            arg_out,
+            arg_out,
+            arg_out,
+            arg_out,
+            arg_a,
+            arg_out,
+            i32_m,
+            block,
+            lane,
+            wave,
+            True,
+            i32_m,
+            (i32_m + fx.Int32(BM - 1)) // fx.Int32(BM),
+            BM=BM,
+            BN=BN,
+            BK=BK,
+            inline_quant=True,
+            K=K,
+            N_OUT=N,
+            NE=1,
+            interleave=False,
+            dense=True,
+        )
+
+    @flyc.jit
+    def launch(
+        arg_a: fx.Int64,
+        arg_bq: fx.Int64,
+        arg_bscale: fx.Int64,
+        arg_out: fx.Int64,
+        i32_m: fx.Int32,
+        stream: fx.Stream,
+    ):
+        grid = ((i32_m + BM - 1) // BM) * n_blocks
+        kernel(arg_a, arg_bq, arg_bscale, arg_out, i32_m).launch(
+            grid=(fx.Int64(grid), 1, 1),
+            block=(256, 1, 1),
+            stream=stream,
+        )
+
+    return launch

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
@@ -142,6 +142,8 @@ def _gemm1_body(
     arg_aqout,
     arg_ascaleout,
     arg_hidden,
+    arg_dense_out,
+    i32_dense_m,
     bx_i32,
     lane,
     wave,
@@ -157,8 +159,11 @@ def _gemm1_body(
     N_OUT,
     NE,
     interleave=False,
+    dense=False,
 ):
     KH_TILE = BK // 2
+    K_MFMA_HALVES = BK // 128
+    K_SCALE_CHUNKS = (K + 255) // 256
     K_HALF = k_half_for(K)
     K_TILES_TOTAL = k_tiles_total_for(K, BK)
     kUnroll = kunroll_for(K, BK)
@@ -179,7 +184,10 @@ def _gemm1_body(
 
     n_block_idx = bx_i32 % fx.Int32(NUM_N_BLOCKS)
     m_block_idx = bx_i32 // fx.Int32(NUM_N_BLOCKS)
-    e = rocdl.readfirstlane(T.i32, _raw(_global_i32_at(arg_eids, m_block_idx)))
+    if const_expr(dense):
+        e = fx.Int32(0)
+    else:
+        e = rocdl.readfirstlane(T.i32, _raw(_global_i32_at(arg_eids, m_block_idx)))
     m_row = m_block_idx * fx.Int32(BM)
 
     lane_div_16 = lane // fx.Int32(16)
@@ -243,9 +251,25 @@ def _gemm1_body(
 
     cached_actual_row = []
     cached_row_inline = None
+    cached_rows_inline_bm64 = []
     if const_expr(inline_quant):
         rcls = wave * fx.Int32(4) + lane_div_16
-        cached_row_inline = _global_i32_at(arg_mind, m_row + rcls)
+        if const_expr(dense and BM == 64):
+            for sub16 in range_constexpr(4):
+                cached_rows_inline_bm64.append(
+                    fx.Int32(
+                        arith.minsi(
+                            _raw(m_row + fx.Int32(sub16 * 16) + rcls),
+                            _raw(i32_dense_m - fx.Int32(1)),
+                        )
+                    )
+                )
+        elif const_expr(dense):
+            cached_row_inline = fx.Int32(
+                arith.minsi(_raw(m_row + rcls), _raw(i32_dense_m - fx.Int32(1)))
+            )
+        else:
+            cached_row_inline = _global_i32_at(arg_mind, m_row + rcls)
     else:
         for sub in range_constexpr(kSubBlocks):
             idx = m_row + wave * fx.Int32(BM // 4) + fx.Int32(sub * 8) + lane_div_8
@@ -284,13 +308,13 @@ def _gemm1_body(
         b_scale_s_base_hi.append(base + fx.Int32(16 * kBS_stride_k0_dw * 4))
 
     accm = [[None] * 4 for _ in range(kMChunks)]
-    b = [[[None, None] for _ in range(4)] for _ in range(kStages)]
+    b = [[[None] * K_MFMA_HALVES for _ in range(4)] for _ in range(kStages)]
     b_scale_v = [[None, None] for _ in range(kStages)]
 
     def issue_a_load_lds(slot, kt):
         for sub in range_constexpr(kSubBlocks):
             lds_row = wave * fx.Int32(BM // 4) + fx.Int32(sub * 8)
-            mask = _lds_swizzle_mask(lds_row + lane_div_8)
+            mask = _lds_swizzle_mask(lds_row + lane_div_8, KH_TILE)
             voffset = ((lane_mod_8 * fx.Int32(16)) ^ mask) + cached_actual_row[
                 sub
             ] * fx.Int32(K_HALF)
@@ -320,9 +344,9 @@ def _gemm1_body(
         return r.load()
 
     def issue_a_ds_read(slot):
-        mask = _lds_swizzle_mask(lane_mod_16)
-        a = [[None, None] for _ in range(kMChunks)]
-        for k in range_constexpr(2):
+        mask = _lds_swizzle_mask(lane_mod_16, KH_TILE)
+        a = [[None] * K_MFMA_HALVES for _ in range(kMChunks)]
+        for k in range_constexpr(K_MFMA_HALVES):
             lds_col = (lane_div_16 * fx.Int32(16) + fx.Int32(k * 64)) ^ mask
             for i in range_constexpr(kMChunks):
                 lds_row = lane_mod_16 + fx.Int32(i * 16)
@@ -372,17 +396,23 @@ def _gemm1_body(
     # s_asc as flat i32.
     s_asc_i32_flat = fx.make_view(
         fx.recast_iter(fx.Int32, fx.add_offset(lds_raw_ptr, kAStages * BM * KH_TILE)),
-        fx.make_layout(kSubBlocks * K_TILES_TOTAL * 64, 1),
+        fx.make_layout(kSubBlocks * K_SCALE_CHUNKS * 64, 1),
     )
     asc_i32_tiles = fx.logical_divide(s_asc_i32_flat, fx.make_layout(1, 1))
     asc_i32x4_tiles = fx.logical_divide(s_asc_i32_flat, fx.make_layout(4, 1))
+    s_asc_i16_flat = fx.make_view(
+        fx.recast_iter(fx.Int16, fx.add_offset(lds_raw_ptr, kAStages * BM * KH_TILE)),
+        fx.make_layout(kSubBlocks * K_SCALE_CHUNKS * 128, 1),
+    )
+    asc_i16_tiles = fx.logical_divide(s_asc_i16_flat, fx.make_layout(1, 1))
 
     def issue_a_scale_ds_read(kt):
         out = []
+        scale_chunk = (kt * BK) // 256
         for sub in range_constexpr(kSubBlocks):
             lds_dw = (
                 fx.Int32(sub * kAS_per_chunk_dw)
-                + fx.Int32(kt * 64)
+                + fx.Int32(scale_chunk * 64)
                 + lane_div_16 * fx.Int32(16)
                 + lane_mod_16
             )
@@ -413,7 +443,7 @@ def _gemm1_body(
         n = len(specs)
         h_dw = [
             [fx.Int32(_raw(h_v[j])) for j in range_constexpr(4)]
-            for (_b, _s, h_v) in specs
+            for (_b, _lds_s, _scale_s, h_v) in specs
         ]
         la = [None] * n
         for i in range_constexpr(n):
@@ -441,7 +471,7 @@ def _gemm1_body(
         a = [_umax_i32(a[i], s2[i]) for i in range_constexpr(n)]
         e8 = [_inline_e8m0(a[i]) for i in range_constexpr(n)]
         for i in range_constexpr(n):
-            B128_IDX, SUB, _hv = specs[i]
+            B128_IDX, LDS_SUB, SCALE_SUB, _hv = specs[i]
             qs_raw = _raw(fx.Float32(_raw(e8[i] << fx.Int32(23)).bitcast(T.f32)))
             pk = _raw(fx.Int32(0))
             for j in range_constexpr(4):
@@ -450,9 +480,9 @@ def _gemm1_body(
                 )
                 pk = rocdl.cvt_scalef32_pk_fp4_bf16(T.i32, pk, src_bf16x2, qs_raw, j)
             pk = fx.Int32(pk)
-            r = fx.Int32(SUB * 16) + r_in_chunk
+            r = fx.Int32(LDS_SUB * 16) + r_in_chunk
             kb_in_kt = fx.Int32(B128_IDX * 4) + lane_shr2_and3
-            mask_r = _lds_swizzle_mask(r)
+            mask_r = _lds_swizzle_mask(r, KH_TILE)
             b_off = lib * fx.Int32(4)
             off = (
                 fx.Int32(slot * (BM * KH_TILE))
@@ -461,26 +491,41 @@ def _gemm1_body(
                 + b_off
             )
             _scalar_store(s_aq_i32x1_tiles, off // fx.Int32(4), pk, fx.Int32)
-            pack_byte = B128_IDX * 2 + SUB
+            pack_byte = B128_IDX * 2 + SCALE_SUB
             scale_accum = scale_accum | (e8[i] << fx.Int32(pack_byte * 8))
         return scale_accum
 
-    def inline_quant_kt(B128_IDX, SUB, slot, kt, row_token, scale_accum):
+    def inline_quant_kt(B128_IDX, LDS_SUB, SCALE_SUB, slot, kt, row_token, scale_accum):
         h_v = inline_quant_load_kt(B128_IDX, kt, row_token)
-        return _inline_quant_core_batch([(B128_IDX, SUB, h_v)], slot, scale_accum)
+        return _inline_quant_core_batch(
+            [(B128_IDX, LDS_SUB, SCALE_SUB, h_v)], slot, scale_accum
+        )
 
-    def inline_quant_pack_write(kt, scale_accum):
+    def inline_quant_pack_write(kt, scale_subblock, scale_accum):
         lane_tgt = lane_shr2_and3 * fx.Int32(16) + r_in_chunk
-        off = fx.Int32(kt * 256) + lane_tgt * fx.Int32(4)
-        _scalar_store(asc_i32_tiles, off // fx.Int32(4), scale_accum, fx.Int32)
+        subblock_off = fx.Int32(scale_subblock * kAS_per_chunk_dw * 4)
+        if const_expr(BK == 128):
+            # Two BK=128 tiles share one 256-K shuffled-scale dword.  Store
+            # each tile's scale in its low/high 16-bit half so either tile can
+            # load the same dword and select the corresponding MFMA scale byte.
+            off = (
+                subblock_off
+                + fx.Int32((kt // 2) * 256)
+                + lane_tgt * fx.Int32(4)
+                + fx.Int32((kt % 2) * 2)
+            )
+            _scalar_store(asc_i16_tiles, off // fx.Int32(2), scale_accum, fx.Int16)
+        else:
+            off = subblock_off + fx.Int32(kt * 256) + lane_tgt * fx.Int32(4)
+            _scalar_store(asc_i32_tiles, off // fx.Int32(4), scale_accum, fx.Int32)
 
     def issue_b_load_j(b_slot, K_C, j):
         v = (
             (lane_div_16 * fx.Int32(256))
             + (lane_mod_16 * fx.Int32(16))
-            + fx.Int32(K_C * 2048)
+            + fx.Int32(K_C * (BK * 8))
         )
-        for half in range_constexpr(2):
+        for half in range_constexpr(K_MFMA_HALVES):
             tile_idx = (v + fx.Int32(half * 1024)) // fx.Int32(16)
             r = fx.make_rmem_tensor(bq_reg_lay, fx.Int32)
             fx.copy(
@@ -493,8 +538,9 @@ def _gemm1_body(
 
     def issue_b_scale_load(bs_slot, K_C):
         v = ((lane_div_16 * fx.Int32(16)) + lane_mod_16) * fx.Int32(4)
-        K_C_HI = K_C // 16
-        imm = (K_C - K_C_HI * 16) * (kBS_stride_k0_dw * 4)
+        scale_chunk = (K_C * BK) // 256
+        K_C_HI = scale_chunk // 16
+        imm = (scale_chunk - K_C_HI * 16) * (kBS_stride_k0_dw * 4)
         for mw in range_constexpr(2):
             s_off = b_scale_s_base[mw] if K_C_HI == 0 else b_scale_s_base_hi[mw]
             idx = (v + fx.Int32(imm)) // fx.Int32(4)
@@ -510,7 +556,7 @@ def _gemm1_body(
     mfma_ty = T.f32x4
     zero4 = fx.Vector.filled(4, 0.0, fx.Float32)
 
-    def mfma_cluster(b_slot, a, a_scale, bs_slot, J, init):
+    def mfma_cluster(b_slot, a, a_scale, bs_slot, J, kt, init):
         if const_expr(interleave):
             mni = J // 2
             in_b = J % 2
@@ -518,21 +564,28 @@ def _gemm1_body(
             mni = J % 2
             in_b = J // 2
         sb = bs_slot[mni]
-        bJ0, bJ1 = b_slot[J][0], b_slot[J][1]
         if const_expr(kMChunks == 1):
             sa = a_scale[0]
-            if const_expr(init):
+            scale_opsel = ((kt * BK) % 256) // 64
+            for half in range_constexpr(K_MFMA_HALVES):
+                opsel = scale_opsel + half * 2
+                accumulator = zero4 if init and half == 0 else accm[0][J]
                 accm[0][J] = rocdl.mfma_scale_f32_16x16x128_f8f6f4(
-                    mfma_ty, [a[0][0], bJ0, zero4, 4, 4, 0, sa, 0 + in_b, sb]
+                    mfma_ty,
+                    [
+                        a[0][half],
+                        b_slot[J][half],
+                        accumulator,
+                        4,
+                        4,
+                        opsel,
+                        sa,
+                        opsel + in_b,
+                        sb,
+                    ],
                 )
-            else:
-                accm[0][J] = rocdl.mfma_scale_f32_16x16x128_f8f6f4(
-                    mfma_ty, [a[0][0], bJ0, accm[0][J], 4, 4, 0, sa, 0 + in_b, sb]
-                )
-            accm[0][J] = rocdl.mfma_scale_f32_16x16x128_f8f6f4(
-                mfma_ty, [a[0][1], bJ1, accm[0][J], 4, 4, 2, sa, 2 + in_b, sb]
-            )
-        else:
+        elif const_expr(BK == 256):
+            bJ0, bJ1 = b_slot[J][0], b_slot[J][1]
             for sub in range_constexpr(kSubBlocks):
                 i0 = sub * 2 + 0
                 i1 = sub * 2 + 1
@@ -557,24 +610,69 @@ def _gemm1_body(
                 accm[i1][J] = rocdl.mfma_scale_f32_16x16x128_f8f6f4(
                     mfma_ty, [a[i1][1], bJ1, accm[i1][J], 4, 4, 3, sa, 2 + in_b, sb]
                 )
+        else:
+            # A BK=128 tile consumes one half of the four-byte scale dword.
+            # The tile parity selects bytes [0,1] or [2,3] for each 32-row
+            # activation-scale subblock.
+            scale_opsel = ((kt * BK) % 256) // 64
+            for sub in range_constexpr(kSubBlocks):
+                sa = a_scale[sub]
+                for row16 in range_constexpr(2):
+                    i = sub * 2 + row16
+                    opsel = scale_opsel + row16
+                    accumulator = zero4 if init else accm[i][J]
+                    accm[i][J] = rocdl.mfma_scale_f32_16x16x128_f8f6f4(
+                        mfma_ty,
+                        [
+                            a[i][0],
+                            b_slot[J][0],
+                            accumulator,
+                            4,
+                            4,
+                            opsel,
+                            sa,
+                            scale_opsel + in_b,
+                            sb,
+                        ],
+                    )
 
     _relax_prologue = (BM == 128) and not inline_quant
     if const_expr(not inline_quant):
         issue_a_scale_load()
     for K_C in range_constexpr(kStages):
         if const_expr(inline_quant):
-            scale_accum = fx.Int32(0)
-            scale_accum = inline_quant_kt(
-                0, 0, K_C, K_C, cached_row_inline, scale_accum
-            )
-            issue_b_load_j(b[K_C], K_C, 0)
-            issue_b_load_j(b[K_C], K_C, 1)
-            scale_accum = inline_quant_kt(
-                1, 0, K_C, K_C, cached_row_inline, scale_accum
-            )
-            issue_b_load_j(b[K_C], K_C, 2)
-            issue_b_load_j(b[K_C], K_C, 3)
-            inline_quant_pack_write(K_C, scale_accum)
+            if const_expr(dense and BM == 64):
+                for scale_subblock in range_constexpr(2):
+                    scale_accum = fx.Int32(0)
+                    for row16 in range_constexpr(2):
+                        lds_sub = scale_subblock * 2 + row16
+                        for half in range_constexpr(K_MFMA_HALVES):
+                            scale_accum = inline_quant_kt(
+                                half,
+                                lds_sub,
+                                row16,
+                                K_C,
+                                K_C,
+                                cached_rows_inline_bm64[lds_sub],
+                                scale_accum,
+                            )
+                    inline_quant_pack_write(K_C, scale_subblock, scale_accum)
+                for j in range_constexpr(4):
+                    issue_b_load_j(b[K_C], K_C, j)
+            else:
+                scale_accum = fx.Int32(0)
+                scale_accum = inline_quant_kt(
+                    0, 0, 0, K_C, K_C, cached_row_inline, scale_accum
+                )
+                issue_b_load_j(b[K_C], K_C, 0)
+                issue_b_load_j(b[K_C], K_C, 1)
+                if const_expr(K_MFMA_HALVES == 2):
+                    scale_accum = inline_quant_kt(
+                        1, 0, 0, K_C, K_C, cached_row_inline, scale_accum
+                    )
+                issue_b_load_j(b[K_C], K_C, 2)
+                issue_b_load_j(b[K_C], K_C, 3)
+                inline_quant_pack_write(K_C, 0, scale_accum)
         else:
             issue_a_load_lds(K_C, K_C)
             if const_expr(not _relax_prologue):
@@ -603,16 +701,23 @@ def _gemm1_body(
             asc_cur = issue_a_scale_ds_read(K_C - kStages)
         if const_expr(not inline_quant):
             issue_a_load_lds(write_slot, K_C)
-        if const_expr(inline_quant):
+        if const_expr(inline_quant and not (dense and BM == 64)):
             h_v0 = inline_quant_load_kt(0, K_C, cached_row_inline)
-            h_v1 = inline_quant_load_kt(1, K_C, cached_row_inline)
+            if const_expr(K_MFMA_HALVES == 2):
+                h_v1 = inline_quant_load_kt(1, K_C, cached_row_inline)
             rocdl.sched_barrier(0)
         for J in range_constexpr(4):
             if const_expr(BM != 128):
                 rocdl.sched_barrier(0)
                 rocdl.s_setprio(1)
             mfma_cluster(
-                b[slot_b], a_cur, asc_cur, b_scale_v[slot_b], J, init=(OFFSET == 0)
+                b[slot_b],
+                a_cur,
+                asc_cur,
+                b_scale_v[slot_b],
+                J,
+                OFFSET,
+                init=(OFFSET == 0),
             )
             if const_expr(BM != 128):
                 rocdl.s_setprio(0)
@@ -621,10 +726,36 @@ def _gemm1_body(
             rocdl.sched_barrier(0)
         issue_b_scale_load(b_scale_v[slot_b], K_C)
         if const_expr(inline_quant):
-            scale_accum = _inline_quant_core_batch(
-                [(0, 0, h_v0), (1, 0, h_v1)], write_slot, fx.Int32(0)
-            )
-            inline_quant_pack_write(K_C, scale_accum)
+            if const_expr(dense and BM == 64):
+                # Quantize one 16-row group at a time after the MFMA cluster,
+                # avoiding retention of eight 128-bit hidden fragments.
+                for scale_subblock in range_constexpr(2):
+                    scale_accum = fx.Int32(0)
+                    for row16 in range_constexpr(2):
+                        lds_sub = scale_subblock * 2 + row16
+                        for half in range_constexpr(K_MFMA_HALVES):
+                            scale_accum = inline_quant_kt(
+                                half,
+                                lds_sub,
+                                row16,
+                                write_slot,
+                                K_C,
+                                cached_rows_inline_bm64[lds_sub],
+                                scale_accum,
+                            )
+                    inline_quant_pack_write(K_C, scale_subblock, scale_accum)
+            elif const_expr(K_MFMA_HALVES == 2):
+                scale_accum = _inline_quant_core_batch(
+                    [(0, 0, 0, h_v0), (1, 0, 0, h_v1)],
+                    write_slot,
+                    fx.Int32(0),
+                )
+                inline_quant_pack_write(K_C, 0, scale_accum)
+            else:
+                scale_accum = _inline_quant_core_batch(
+                    [(0, 0, 0, h_v0)], write_slot, fx.Int32(0)
+                )
+                inline_quant_pack_write(K_C, 0, scale_accum)
 
     for S in range_constexpr(kStages):
         kt = K_TILES_TOTAL - kStages + S
@@ -637,10 +768,37 @@ def _gemm1_body(
             asc_cur = issue_a_scale_ds_read(kt)
         for J in range_constexpr(4):
             mfma_cluster(
-                b[kt % kStages], a_cur, asc_cur, b_scale_v[kt % kStages], J, init=False
+                b[kt % kStages],
+                a_cur,
+                asc_cur,
+                b_scale_v[kt % kStages],
+                J,
+                kt,
+                init=False,
             )
 
     gpu.barrier()
+
+    if const_expr(dense):
+        dense_out = _global_scalar_tiles(arg_dense_out, fx.BFloat16, 1 << 30)
+        for i in range_constexpr(kMChunks):
+            row_base = m_row + fx.Int32(i * 16) + lane_div_16 * fx.Int32(4)
+            for J in range_constexpr(4):
+                tile_il = n_block_idx * fx.Int32(16) + wave * fx.Int32(4) + fx.Int32(J)
+                g = tile_il & fx.Int32(1)
+                n0 = tile_il >> fx.Int32(1)
+                col = (g * fx.Int32(N_OUT // 32) + n0) * fx.Int32(16) + lane_mod_16
+                values = fx.Vector(accm[i][J])
+                for v in range_constexpr(4):
+                    row = row_base + fx.Int32(v)
+                    if row < i32_dense_m:
+                        _scalar_store(
+                            dense_out,
+                            row * fx.Int32(N_OUT) + col,
+                            values[v],
+                            fx.BFloat16,
+                        )
+        return
 
     # lds_acc reuses the s_aq region (offset 0) as an f32 accumulator.
     acc_layout = fx.make_layout((BM, BN), (BN, 1))
@@ -766,7 +924,9 @@ def _bm_constants(BM, BN, KH_TILE, K_TILES_TOTAL):
     kSubBlocks = 1 if BM < 32 else BM // 32
     kMChunks = kmchunks_for(BM)
     s_aq_bytes = kAStages * BM * KH_TILE
-    s_asc_bytes = kSubBlocks * K_TILES_TOTAL * 256
+    bk = KH_TILE * 2
+    scale_chunks = (K_TILES_TOTAL * bk + 255) // 256
+    s_asc_bytes = kSubBlocks * scale_chunks * 256
     lds_acc_bytes = lds_acc_bytes_for(BM, BN)
     lds_bytes = max(s_aq_bytes + s_asc_bytes, lds_acc_bytes)
     return kAStages, kSubBlocks, kMChunks, lds_bytes
@@ -887,6 +1047,8 @@ def compile_gemm1_a4w4_port(
                 arg_aqout,
                 arg_ascaleout,
                 arg_hidden,
+                arg_aqout,
+                i32_ntok,
                 _tile,
                 lane,
                 wave,
@@ -901,6 +1063,7 @@ def compile_gemm1_a4w4_port(
                 N_OUT=_N_OUT,
                 NE=_NE,
                 interleave=interleave,
+                dense=False,
             )
 
     @flyc.jit

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm_common.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm_common.py
@@ -174,11 +174,13 @@ def kunroll_for(k, BK):
 
 
 def kas_c_k1_for(k):
-    return (k // 32) // 4 // 2
+    # Scale shuffling groups eight 1x32 scales (K=256) and pads the final
+    # group.  Keep the accounting in sync for K values such as 4224.
+    return (k + 255) // 256
 
 
 def kbs_c_k1_for(k):
-    return (k // 32) // 4 // 2
+    return (k + 255) // 256
 
 
 def kbs_stride_n0_dw_for(k):

--- a/op_tests/flydsl_tests/test_flydsl_gemm_a4w4.py
+++ b/op_tests/flydsl_tests/test_flydsl_gemm_a4w4.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.flydsl.utils import is_flydsl_available
+
+_SKIP = pytest.mark.skipif(
+    get_gfx() != "gfx950" or not is_flydsl_available(),
+    reason="gfx950 and FlyDSL are required",
+)
+
+
+@pytest.mark.parametrize(
+    "m,n,k,expected",
+    [
+        (127, 8448, 7168, 16),
+        (128, 8448, 7168, 64),
+        (511, 7168, 4224, 16),
+        (512, 7168, 4224, 64),
+        (2047, 1536, 7168, 16),
+        (2048, 1536, 7168, 64),
+        (511, 7168, 768, 16),
+        (512, 7168, 768, 64),
+        (4096, 256, 7168, 16),
+    ],
+)
+def test_flydsl_dense_a4w4_bm_selection(m, n, k, expected):
+    from aiter.ops.flydsl.gemm_a4w4 import _select_bm
+
+    assert _select_bm(m, n, k) == expected
+
+
+@_SKIP
+@pytest.mark.parametrize(
+    "m,n,k",
+    [
+        (1, 1536, 7168),
+        (17, 1536, 7168),
+        (1, 1536, 4224),
+        (17, 1536, 4224),
+    ],
+)
+def test_flydsl_dense_a4w4_matches_triton(m, n, k):
+    from aiter.ops.flydsl.gemm_a4w4 import (
+        flydsl_gemm_a4w4,
+        prepare_gemm_a4w4_weight,
+    )
+    from aiter.ops.triton.gemm.basic.gemm_afp4wfp4 import gemm_afp4wfp4
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+    torch.manual_seed(1)
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    w_bf16 = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    w, w_scale = dynamic_mxfp4_quant(w_bf16)
+    a_quant, a_scale = dynamic_mxfp4_quant(a)
+
+    expected = gemm_afp4wfp4(a_quant, w, a_scale, w_scale, dtype=torch.bfloat16)
+    prepared = prepare_gemm_a4w4_weight(w, w_scale)
+    actual = flydsl_gemm_a4w4(a, prepared, _bm=16)
+
+    actual_f32, expected_f32 = actual.float(), expected.float()
+    assert torch.isfinite(actual_f32).all()
+    assert torch.isfinite(expected_f32).all()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_f32.flatten(), expected_f32.flatten(), dim=0
+    )
+    relative_rmse = (actual_f32 - expected_f32).square().mean().sqrt()
+    relative_rmse /= expected_f32.square().mean().sqrt().clamp_min(1e-6)
+    assert cosine > 0.998
+    assert relative_rmse < 0.06
+
+
+@_SKIP
+@pytest.mark.parametrize("k", [7168, 4224])
+@pytest.mark.parametrize("m", [1, 15, 16, 17, 63, 64, 65, 127, 128, 129])
+def test_flydsl_dense_a4w4_bm64_boundaries(m, k):
+    from aiter.ops.flydsl.gemm_a4w4 import (
+        flydsl_gemm_a4w4,
+        prepare_gemm_a4w4_weight,
+    )
+    from aiter.ops.triton.gemm.basic.gemm_afp4wfp4 import gemm_afp4wfp4
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+    n = 256
+    torch.manual_seed(2)
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    w, w_scale = dynamic_mxfp4_quant(
+        torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    )
+    a_quant, a_scale = dynamic_mxfp4_quant(a)
+    expected = gemm_afp4wfp4(a_quant, w, a_scale, w_scale, dtype=torch.bfloat16)
+
+    actual = flydsl_gemm_a4w4(a, prepare_gemm_a4w4_weight(w, w_scale), _bm=64)
+    actual_f32, expected_f32 = actual.float(), expected.float()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_f32.flatten(), expected_f32.flatten(), dim=0
+    )
+    relative_rmse = (actual_f32 - expected_f32).square().mean().sqrt()
+    relative_rmse /= expected_f32.square().mean().sqrt().clamp_min(1e-6)
+    assert torch.isfinite(actual_f32).all()
+    assert cosine > 0.998
+    assert relative_rmse < 0.06
+
+
+@_SKIP
+def test_flydsl_dense_a4w4_bm64_scale_boundaries_and_row_groups():
+    from aiter.ops.flydsl.gemm_a4w4 import (
+        flydsl_gemm_a4w4,
+        prepare_gemm_a4w4_weight,
+    )
+    from aiter.ops.triton.gemm.basic.gemm_afp4wfp4 import gemm_afp4wfp4
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+    m, n, k = 64, 256, 768
+    base = torch.linspace(-1.0625, 1.0625, 32, device="cuda")
+    rows = []
+    for row in range(m):
+        exponent = (row % 12) - 6
+        block = base * (2.0**exponent)
+        rows.append(block.repeat(k // 32))
+    a = torch.stack(rows).to(torch.bfloat16)
+    torch.manual_seed(3)
+    w, w_scale = dynamic_mxfp4_quant(
+        torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    )
+    a_quant, a_scale = dynamic_mxfp4_quant(a)
+    expected = gemm_afp4wfp4(a_quant, w, a_scale, w_scale, dtype=torch.bfloat16)
+    actual = flydsl_gemm_a4w4(a, prepare_gemm_a4w4_weight(w, w_scale), _bm=64)
+
+    actual_f32, expected_f32 = actual.float(), expected.float()
+    assert torch.isfinite(actual_f32).all()
+    assert torch.isfinite(expected_f32).all()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_f32.flatten(), expected_f32.flatten(), dim=0
+    )
+    relative_rmse = (actual_f32 - expected_f32).square().mean().sqrt()
+    relative_rmse /= expected_f32.square().mean().sqrt().clamp_min(1e-6)
+    assert cosine > 0.998
+    assert relative_rmse < 0.06
+
+
+@_SKIP
+@pytest.mark.parametrize(
+    "n,k",
+    [(8448, 7168), (7168, 4224), (1536, 7168), (7168, 768), (1536, 4224)],
+)
+def test_flydsl_dense_a4w4_required_shapes_compile_and_run(n, k):
+    from aiter.ops.flydsl.gemm_a4w4 import flydsl_gemm_a4w4
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+    a = torch.zeros((1, k), device="cuda", dtype=torch.bfloat16)
+    w, w_scale = dynamic_mxfp4_quant(
+        torch.zeros((n, k), device="cuda", dtype=torch.bfloat16)
+    )
+    out = flydsl_gemm_a4w4(a, w, w_scale)
+    assert out.shape == (1, n)
+    assert not out.isnan().any()
+
+
+@_SKIP
+def test_flydsl_dense_a4w4_k4224_scale_padding():
+    from aiter.ops.flydsl.gemm_a4w4 import prepare_gemm_a4w4_weight
+
+    weight = torch.zeros((256, 2112), device="cuda", dtype=torch.uint8)
+    weight_scale = torch.zeros((256, 132), device="cuda", dtype=torch.uint8)
+    prepared = prepare_gemm_a4w4_weight(weight, weight_scale)
+    assert prepared.weight.shape == (256, 2112)
+    assert prepared.scale.shape == (256, 136)
+
+
+@_SKIP
+def test_flydsl_dense_a4w4_rejects_non_128_aligned_k():
+    from aiter.ops.flydsl.gemm_a4w4 import prepare_gemm_a4w4_weight
+
+    weight = torch.zeros((256, 96), device="cuda", dtype=torch.uint8)
+    weight_scale = torch.zeros((256, 6), device="cuda", dtype=torch.uint8)
+    with pytest.raises(ValueError, match="positive multiple of 128"):
+        prepare_gemm_a4w4_weight(weight, weight_scale)

--- a/op_tests/op_benchmarks/flydsl/bench_gemm_a4w4.py
+++ b/op_tests/op_benchmarks/flydsl/bench_gemm_a4w4.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+
+import argparse
+
+import torch
+
+from aiter.ops.flydsl.gemm_a4w4 import (
+    flydsl_gemm_a4w4,
+    prepare_gemm_a4w4_weight,
+)
+from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Dense FlyDSL inline A4W4 benchmark")
+    parser.add_argument("--shape", default="16,1536,768")
+    parser.add_argument("--bm", type=int, choices=(16, 64), default=16)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--rep", type=int, default=50)
+    args = parser.parse_args()
+    m, n, k = map(int, args.shape.split(","))
+
+    a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    w, w_scale = dynamic_mxfp4_quant(
+        torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    )
+    prepared = prepare_gemm_a4w4_weight(w, w_scale)
+    flydsl_gemm_a4w4(a, prepared, _bm=args.bm)
+    torch.cuda.synchronize()
+
+    for _ in range(args.warmup):
+        flydsl_gemm_a4w4(a, prepared, _bm=args.bm)
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(args.rep):
+        flydsl_gemm_a4w4(a, prepared, _bm=args.bm)
+    end.record()
+    end.synchronize()
+
+    ms = start.elapsed_time(end) / args.rep
+    print(
+        f"M={m} N={n} K={k} BM={args.bm}: {ms * 1e3:.2f} us, "
+        f"{2 * m * n * k / ms * 1e-9:.2f} TFLOP/s"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a native gfx950 FlyDSL dense A4W4 GEMM that quantizes BF16 activations inline to MXFP4 and consumes packed E2M1 weights with E8M0 scales directly in scaled FP4 MFMA.

This is intentionally independent from #4772:

- this PR implements native A4W4 semantics: `BF16 activation -> inline MXFP4 quant -> MXFP4 x MXFP4 MFMA`
- #4772 implements A16WFP4 semantics: `BF16 activation x decoded MXFP4 weight -> BF16 MFMA`
- no A16WFP4 source or API dependency is included here

## Implementation

- public `prepare_gemm_a4w4_weight` / `flydsl_gemm_a4w4` API
- one-time packed E2M1 weight and E8M0 scale preshuffle
- dense direct-output path in the shared FlyDSL GEMM1 body
- BM16 for small M and BM64 for larger M
- BK128 support for K=4224; existing BK256 MoE behavior is preserved
- M-tail masking and ceil-based scale accounting
- benchmark and gfx950 regression coverage

## Kernel microbenchmark

MI355X (gfx950), latest AITER main base `878d60d77`. Median microseconds; speedup is versus existing Triton dynamic quant + A4W4. Weight preparation/JIT excluded.

| N x K | M | Direct us | Triton us | Speedup |
|---|---:|---:|---:|---:|
| 8448 x 7168 | 1 | 23.201 | 86.881 | 3.74x |
| 8448 x 7168 | 8 | 26.940 | 86.620 | 3.22x |
| 8448 x 7168 | 32 | 30.240 | 71.361 | 2.36x |
| 8448 x 7168 | 128 | 60.121 | 77.680 | 1.29x |
| 8448 x 7168 | 512 | 89.480 | 111.921 | 1.25x |
| 8448 x 7168 | 2048 | 237.863 | 184.681 | 0.78x |
| 7168 x 4224 | 1 | 15.960 | 75.121 | 4.71x |
| 7168 x 4224 | 8 | 23.041 | 76.281 | 3.31x |
| 7168 x 4224 | 32 | 23.520 | 67.040 | 2.85x |
| 7168 x 4224 | 128 | 23.280 | 67.960 | 2.92x |
| 7168 x 4224 | 512 | 50.041 | 79.881 | 1.60x |
| 7168 x 4224 | 2048 | 107.041 | 117.721 | 1.10x |
| 1536 x 7168 | 1 | 18.420 | 89.821 | 4.88x |
| 1536 x 7168 | 8 | 23.320 | 90.081 | 3.86x |
| 1536 x 7168 | 32 | 26.181 | 67.601 | 2.58x |
| 1536 x 7168 | 128 | 28.300 | 69.020 | 2.44x |
| 1536 x 7168 | 512 | 29.621 | 81.461 | 2.75x |
| 1536 x 7168 | 2048 | 65.081 | 117.481 | 1.81x |
| 7168 x 768 | 1 | 12.580 | 77.060 | 6.13x |
| 7168 x 768 | 8 | 11.921 | 76.660 | 6.43x |
| 7168 x 768 | 32 | 12.120 | 72.281 | 5.96x |
| 7168 x 768 | 128 | 12.380 | 71.401 | 5.77x |
| 7168 x 768 | 512 | 15.520 | 69.101 | 4.45x |
| 7168 x 768 | 2048 | 31.700 | 78.920 | 2.49x |

The direct output is numerically equal to the existing Triton A4W4 semantic path within the expected reduction-order error. Across these points, relative L2 was 2.42%-4.15% against the cached BF16/QDQ emulation reference, matching Triton's activation-quantization error.

The one measured crossover is `(N=8448,K=7168,M>=2048)`, where Triton is faster. The downstream vLLM integration uses a shape-aware Triton fallback for that region instead of forcing this kernel.

## ATT findings

Wave-state analysis guided the BK/BM choices:

- `(7168,4224,M=512)`, BM64/BK128: quant/decode was 4.95% of sampled latency; wait/barrier was 60.01%
- `(8448,7168,M=512)`, BM64/BK256: quant/decode was 5.59%; VMEM was 23.01%; wait/barrier was 39.26%

This indicates inline quantization is not the dominant cost; the remaining large-shape opportunity is load/wait scheduling.

## Model validation

Kimi-K3, TP8, validation image `local/k3-direct-a4w4-validation:20260815`:

- 5 x 512 decode: **59.521 s** mean E2E, **116.135 ms** TPOT
- versus #50814 cached BF16 fallback: **-2.04% E2E**
- versus tuned A16WFP4: **-3.59% E2E**
- GSM8K 8-shot, first 100: **100/100 strict**, **100/100 flexible**, zero malformed/invalid
- per-rank device memory: **190.649 GiB average**, **4.531 GiB lower** than the cached-BF16 #50814 path

The experimental downstream hybrid retained Triton weights only for `(8448,7168,M>=2048)`. That duplicated 32,169,984 bytes per affected layer, or **2.786 GiB/rank across 93 layers**; this is a downstream routing trade-off, not an allocation made by the AITER kernel itself.

## Validation

- [x] direct gfx950 A4W4: `41 passed`
- [x] K=4224 BK128, BM16/BM64, M-tail and scale-edge coverage
- [x] focused existing MXFP4 MoE regression: `11 passed`
- [x] strict existing BK256 GEMM1 execution; logits diff `4.05e-06`
- [x] latest-main 24-point microbenchmark rerun
- [x] Ruff, Black, `py_compile`, and `git diff --check`

## Scope

- gfx950 only
- N divisible by 256; K divisible by 128
- packed E2M1 weights and E8M0 scales are preshuffled once by the caller
- this PR does not change vLLM backend selection