### PR TITLE
[HIP] [OPUS] [JIT] Chefang/pa decode opus

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -112,6 +112,7 @@ else:
     from .ops.moe_sorting import *
     from .ops.moe_sorting_opus import *
     from .ops.moe_mxfp4_aux import *
+    from .ops.pa_decode_opus import *
     from .ops.pa_sparse_prefill_opus import *
     from .ops.pos_encoding import *
     from .ops.cache import *

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -582,6 +582,26 @@
         "is_standalone": "False",
         "blob_gen_cmd": "f'{AITER_CSRC_DIR}/opus_moe/gen_instances.py --working_path {{0}}'"
     },
+    "module_pa_decode_opus": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/py_itfs_cu/pa_decode_opus_kernels.cu'",
+            "f'{AITER_CSRC_DIR}/pybind/pa_decode_opus_pybind.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-ffast-math'",
+            "'-mllvm -enable-post-misched=1'"
+        ],
+        "flags_extra_hip_per_source": {
+            "*pa_decode_opus_kernels.cu": [
+                "-mllvm -amdgpu-early-inline-all=false"
+            ]
+        },
+        "extra_ldflags": "None",
+        "extra_include": [],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_pa_sparse_prefill_opus": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/py_itfs_cu/pa_sparse_prefill_opus_kernels.cu'",

--- a/aiter/ops/pa_decode_opus.py
+++ b/aiter/ops/pa_decode_opus.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""OPUS-based paged-attention decode for gfx950.
+
+Follows the sp3 kernel ``PA_A16W16_*_1TG_4W_16mx1_64nx4``: one thread group of
+4 waves per (sequence, kv-head), 16 query rows, waves split along the KV axis
+for Q*K and along the head axis for P*V.
+
+The user-facing entry is :func:`pa_decode_opus`; it forwards to the
+JIT-compiled HIP kernel via :func:`pa_decode_opus_fwd`.
+
+The kernel currently only compiles a single configuration:
+
+* Head dim ``128``, page size ``16``, GQA ratio ``<= 16``.
+* dtype ``bf16`` for Q/K/V/O (A16W16 -- no KV quantization).
+* K cache packed as ``[num_blocks, num_kv_heads, 128/8, 16, 8]`` and V cache as
+  ``[num_blocks, num_kv_heads, 128, 16]`` (the standard vLLM layout for bf16,
+  where the pack factor ``x`` is ``16 bytes / itemsize == 8``).
+
+See ``aiter/csrc/include/pa_decode_opus.h`` for the C++ API.
+"""
+
+import torch
+
+from ..jit.core import compile_ops
+from ..jit.utils.chip_info import get_gfx_runtime
+from ..jit.utils.torch_guard import torch_compile_guard
+
+MD_NAME = "module_pa_decode_opus"
+
+_HEAD_DIM = 128
+_PAGE_SIZE = 16
+_MAX_GQA = 16
+
+
+@compile_ops("module_pa_decode_opus", develop=True)
+def pa_decode_opus_fwd(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    out: torch.Tensor,
+    softmax_scale: float,
+) -> None: ...
+
+
+def _pa_decode_opus_fake(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    softmax_scale: float,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return out if out is not None else torch.empty_like(q)
+
+
+@torch_compile_guard(mutates_args=["out"], gen_fake=_pa_decode_opus_fake)
+def pa_decode_opus(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    softmax_scale: float,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Paged-attention decode over a block table, backed by the OPUS gfx950 kernel.
+
+    The trailing ``out`` keyword is an aiter-only convenience for callers that
+    want to reuse a pre-allocated output buffer; pass ``None`` (the default) to
+    have one allocated for you.
+
+    Args:
+      q:            ``[batch, num_heads, 128]`` bf16 query. Decode only, so there
+                    is no token dim: one query token per batch row.
+      k_cache:      ``[num_blocks, num_kv_heads, D/K_PACK, PAGE, K_PACK]`` bf16 key cache.
+      v_cache:      ``[num_blocks, num_kv_heads, 128, 16]`` bf16 value cache.
+      block_tables: ``[batch, max_blocks_per_batch_row]`` int32 page indices.
+      context_lens: ``[batch]`` int32 KV length per batch row.
+      softmax_scale: float scalar applied to the QK^T scores.
+      out:          Optional ``[batch, num_heads, 128]`` output buffer.
+
+    Returns:
+      ``out`` (``[batch, num_heads, 128]`` bf16).
+    """
+    gfx = get_gfx_runtime()
+    if gfx != "gfx950":
+        raise RuntimeError(f"pa_decode_opus requires gfx950, got {gfx}")
+
+    if q.dtype != torch.bfloat16:
+        raise RuntimeError(f"pa_decode_opus expects bf16 q, got {q.dtype}")
+    if k_cache.dtype != q.dtype or v_cache.dtype != q.dtype:
+        raise RuntimeError(
+            f"KV cache dtype mismatch: k_cache={k_cache.dtype}, "
+            f"v_cache={v_cache.dtype}, q={q.dtype}"
+        )
+    if q.size(-1) != _HEAD_DIM:
+        raise RuntimeError(
+            f"pa_decode_opus only supports head_dim={_HEAD_DIM}, got {q.size(-1)}"
+        )
+    if v_cache.size(-1) != _PAGE_SIZE:
+        raise RuntimeError(
+            f"pa_decode_opus only supports page size={_PAGE_SIZE}, got {v_cache.size(-1)}"
+        )
+
+    num_heads, num_kv_heads = q.size(1), k_cache.size(1)
+    if num_heads % num_kv_heads != 0:
+        raise RuntimeError(
+            f"num_heads={num_heads} not divisible by num_kv_heads={num_kv_heads}"
+        )
+    if num_heads // num_kv_heads > _MAX_GQA:
+        raise RuntimeError(
+            f"GQA ratio must be <= {_MAX_GQA}, got {num_heads // num_kv_heads}"
+        )
+
+    if out is None:
+        out = torch.empty_like(q)
+    elif out.shape != q.shape or out.dtype != q.dtype:
+        raise RuntimeError(
+            f"out shape/dtype mismatch: got shape={tuple(out.shape)} dtype={out.dtype}, "
+            f"expected shape={tuple(q.shape)} dtype={q.dtype}"
+        )
+
+    pa_decode_opus_fwd(
+        q,
+        k_cache,
+        v_cache,
+        block_tables,
+        context_lens,
+        out,
+        float(softmax_scale),
+    )
+    return out
+
+
+__all__ = [
+    "pa_decode_opus",
+    "pa_decode_opus_fwd",
+]

--- a/csrc/include/pa_decode_opus.h
+++ b/csrc/include/pa_decode_opus.h
@@ -7,12 +7,9 @@
 // group of 4 waves per (batch, kv-head), 16 query rows, waves split along the
 // KV axis for Q*K and along the head axis for P*V.
 //
-// Self-contained, single-header:
-//   * Public API (always visible).
-//   * Host plumbing (`pa_decode_kargs` / `pa_decode_traits<...>`) inside the
-//     `PA_DECODE_OPUS_IMPL` guard.
-//   * Device kernel template inside the same guard on the `__HIP_DEVICE_COMPILE__`
-//     pass, host pass falls back to an empty stub for `__device_stub__` symbols.
+// Single header: the public API is always visible, host plumbing and the device
+// kernel sit behind PA_DECODE_OPUS_IMPL, and the host pass gets an empty stub so
+// the `__device_stub__` symbols still resolve.
 
 #pragma once
 #include "aiter_tensor.h"
@@ -44,19 +41,15 @@ void pa_decode_opus_fwd(aiter_tensor_t& q,
 
 using bf16_t = __bf16;
 
-// KV tile depth, i.e. how many KV tokens one main-loop iteration consumes.
+// KV tile depth: how many KV tokens one main-loop iteration consumes.
 //
 // K and V go straight from the cache into the matrix-core fragments, so the tile
-// is paid for in registers, not LDS: the fragment count scales with it and
-// occupancy follows. On gfx950 (VGPR+AGPR, waves/SIMD):
-//   64 -> 89+8, 4    128 -> 129+8, 3    256 -> 217+16, 2    512 -> 256+161, 1
-// 512 caps out the VGPR file and starts parking values in AGPRs. LDS stays under
-// 17KB throughout and never binds.
-//
-// Streaming from HBM is flat over 64..256 -- two waves already saturate it --
-// while a cache-resident working set tracks occupancy directly (81.7 / 83.8 /
-// 89.3 / 116.5 us at bs=128, kvh=8, ctx=4097). 128 is the compromise: fastest of
-// the four when streaming, within 2.5% of the best when cache-resident.
+// is paid for in registers, not LDS, and occupancy tracks it directly. On gfx950
+// (VGPR+AGPR, waves/SIMD): 64 -> 89+8, 4;  128 -> 129+8, 3;  256 -> 217+16, 2;
+// 512 -> 256+161, 1; LDS stays under 17KB throughout and never binds. HBM
+// streaming is flat over 64..256 (two waves already saturate it) while a
+// cache-resident working set follows occupancy, so 128 is the compromise:
+// fastest of the four streaming, within 2.5% of the best cache-resident.
 // Re-measure with op_tests/sweep_kv_tile.sh and op_tests/kv_tile_resources.sh.
 #ifndef PA_DECODE_KV_TILE
 #define PA_DECODE_KV_TILE 128
@@ -96,9 +89,23 @@ struct pa_decode_kargs
 
 // Tile shape / MFMA configuration.
 //
-// Naming mirrors the sp3 kernel: `16mx1` = 16 query rows handled by a single wave
-// along M, `16nx4` = each wave owns W_N=16 KV columns and 4 waves cover the tile.
-template<int D_HEAD_ = 128, int KV_TILE_ = 64, int PAGE_SIZE_ = 16, int NUM_WARPS_ = 4>
+// A workgroup owns one (batch, kv-head), or one split of its context, and walks
+// that range one KV_TILE at a time. Per tile, with M the query rows throughout:
+//
+//   S [Q_TILE, KV_TILE] = Q [Q_TILE, D_HEAD] * K^T    GEMM0, contracts D_HEAD
+//   P [Q_TILE, KV_TILE] = softmax(S)                  also rescales the running O
+//   O [Q_TILE, D_HEAD] += P * V^T                     GEMM1, contracts KV_TILE
+//
+// Q is loaded once and O accumulates across tiles, so only K and V stream. Q_TILE
+// is the MFMA's M and also the largest GQA ratio supported, so one tile carries
+// every query head that shares this kv-head.
+//
+// The `16mx1_16nx4` namespace names GEMM0's wave tiling: `16mx1` = W_M=16 query
+// rows by T_M=1 wave, the whole Q_TILE; `16nx4` = W_N=16 tokens by T_N=4 waves,
+// one 64-token step along KV repeated GEMM0_E_N = KV_TILE/(W_N*T_N) times. The
+// name is thus independent of KV_TILE, unlike sp3's `64nx4`, which counts a
+// wave's KV columns.
+template<int D_HEAD_ = 128, int KV_TILE_ = 128, int PAGE_SIZE_ = 16, int NUM_WARPS_ = 4>
 struct pa_decode_traits
 {
     using D_ATTN = bf16_t;
@@ -112,8 +119,10 @@ struct pa_decode_traits
     static constexpr int BLOCK_SIZE = NUM_WARPS * WARP_SIZE;
     static constexpr int Q_TILE     = 16; // MFMA M, also the max supported GQA ratio
 
-    // Upper bound on KV splits, i.e. how far a single (batch, kv-head) may be
-    // spread across workgroups. Bounds the reduce kernel's LDS and the scratch.
+    // Upper bound on KV splits: num_splits is a runtime value, but the fused
+    // merge indexes LDS by split, so this statically sizes that buffer. Raising
+    // it past the point where smem_reduce_bytes() overtakes the attention side
+    // grows LDS for every shape, including the ones that never split.
     static constexpr int MAX_SPLITS = 64;
 
     // Wave tiling: 1 wave along M, all waves along N.
@@ -145,24 +154,31 @@ struct pa_decode_traits
     static constexpr int K_PACK = 16 / sizeof(D_ATTN);
     static constexpr int VEC    = 16 / sizeof(D_ATTN); // widest global vector, 8 bf16
 
-    // Lanes of one MFMA operand split N ways across the wave, each covering
-    // GRP_K positions along the contraction dim.
-    static constexpr int GRP_N = W_N;
-    static constexpr int GRP_K = WARP_SIZE / W_N;
+    // Lane counts, not thread groups: GRP is opus's name for the dims of an MFMA
+    // operand spread across lanes (the <p> dims of
+    // `B:[(grpn_b<p>), (rept_b, grpk_b<p>, pack_b)]` in opus.hpp). These restate
+    // mfma_adaptor::grpn_b/::grpk_b, unreachable here because the static_asserts
+    // below run before any mma object exists. The 64 lanes form a GRP_K by GRP_N
+    // grid: lane % GRP_N picks the N position, lane / GRP_N the contraction
+    // slice, VEC elements each, so the slices span W_K.
+    static constexpr int GRP_N = W_N;             // == mfma_adaptor::grpn_b
+    static constexpr int GRP_K = WARP_SIZE / W_N; // == mfma_adaptor::grpk_b
     // How many lane groups share one page when walking V along tokens.
     static constexpr int KGRP_PER_PAGE = PAGE_SIZE / VEC;
 
-    // Only P is staged through LDS. K and V go straight from global into the
-    // matrix-core fragments, and S never leaves registers -- LDS is needed only
-    // where a wave must read data another wave produced, which for P is every
-    // element because GEMM1 contracts over the token dim that splits the waves.
-    static constexpr int PAD   = 8;
-    static constexpr int S_ROW = KV_TILE + PAD; // P tile is [Q_TILE][KV_TILE]
+    // Only P is staged through LDS: K and V go straight from global into the
+    // matrix-core fragments and S never leaves registers, so LDS is needed only
+    // where a wave reads what another wave produced -- for P that is every
+    // element, since GEMM1 contracts the token dim that splits the waves. The
+    // tile is [Q_TILE][KV_TILE]; PAD staggers rows off each other's banks.
+    static constexpr int PAD          = 8;
+    static constexpr int P_ROW_STRIDE = KV_TILE + PAD;
 
-    static constexpr int smem_p_elems = Q_TILE * S_ROW;
+    static constexpr int smem_p_elems = Q_TILE * P_ROW_STRIDE;
     // Cross-wave row reduction scratch, laid out [row][wave] so a row's T_N
-    // contributions are contiguous and fold with a single 16B LDS read.
-    static constexpr int smem_red_elems = Q_TILE * T_N;
+    // contributions fold with one 16B LDS read. Used twice at the same
+    // addresses: each tile's max fold, then the final l sum.
+    static constexpr int smem_row_reduce_elems = Q_TILE * T_N;
 
     static_assert(Q_TILE == W_M, "one MFMA tile along M");
     static_assert(KV_TILE % (W_N * T_N) == 0);
@@ -188,10 +204,9 @@ struct pa_decode_traits
     static_assert(GEMM1_E_K * (GRP_K / KGRP_PER_PAGE) == PAGES_PER_TILE,
                   "V's K steps must walk exactly the tile's pages");
 
-    // The split-KV merge reuses this same allocation: by the time it runs, the P
-    // tile and the row-reduction scratch are both dead. Taking the union keeps
-    // the merge from costing any LDS at all -- at KV_TILE=128 the attention side
-    // is the larger of the two, so the footprint is unchanged.
+    // The split-KV merge reuses this allocation -- the P tile and the row-reduce
+    // scratch are both dead by the time it runs -- so the union costs it no LDS.
+    // At KV_TILE=128 the attention side is the larger.
     static constexpr size_t smem_reduce_bytes()
     {
         return static_cast<size_t>(MAX_SPLITS * Q_TILE + Q_TILE) * sizeof(D_ACC);
@@ -199,10 +214,10 @@ struct pa_decode_traits
 
     static constexpr size_t smem_size_bytes()
     {
-        const size_t attn = smem_p_elems * sizeof(D_ATTN)     // bf16 P handed to GEMM1
-                            + smem_red_elems * sizeof(D_ACC); // cross-wave row reduction
-        const size_t red  = smem_reduce_bytes();
-        return attn > red ? attn : red;
+        const size_t attn = smem_p_elems * sizeof(D_ATTN) // bf16 P handed to GEMM1
+                            + smem_row_reduce_elems * sizeof(D_ACC); // cross-wave row fold
+        const size_t reduce = smem_reduce_bytes();
+        return attn > reduce ? attn : reduce;
     }
 };
 
@@ -243,20 +258,18 @@ __device__ inline float* partial_o_ptr(const pa_decode_kargs& kargs, int b, int 
     return kargs.partial_o + partial_slot<T>(kargs, b, kvh, split) * T::Q_TILE * T::D_HEAD;
 }
 
-// Where this lane's K and V fragments sit inside a page.
+// Where this lane's K and V fragments sit inside a page. Only the page base
+// moves per tile, so this is computed once.
 //
-// The cache layouts hand the matrix cores exactly what they want. A B fragment
-// needs lane l to hold column l%16 of the operand and 8 consecutive positions
-// along the contraction dim, and both caches store precisely those 8 values in
-// 16 contiguous bytes: K is [D/K_PACK][PAGE][K_PACK], so a lane walks the
-// K_PACK head dims of one token; V is [D][PAGE], so a lane walks 8 tokens of
-// one head dim. Every fragment is therefore a single dwordx4 read straight from
-// the cache, and the KV tile never has to be staged through LDS.
-//
-// K additionally lines up one MFMA tile with one page (GRP_N == PAGE_SIZE), so
-// its page index is uniform across the wave. V spans PAGE_SIZE/VEC lane groups
-// per page, so its page index alternates on the upper half of the wave.
-// Loop invariant: only the page base changes from tile to tile.
+// The cache layouts hand the matrix cores exactly what they want: a B fragment
+// needs lane l to hold column l%16 and 8 consecutive contraction positions, and
+// both caches store those 8 values in 16 contiguous bytes (K is
+// [D/K_PACK][PAGE][K_PACK], a lane walks one token's head dims; V is [D][PAGE],
+// a lane walks 8 tokens of one head dim). Every fragment is one dwordx4 straight
+// from the cache, and the KV tile never goes through LDS. K lines one MFMA tile
+// up with one page (GRP_N == PAGE_SIZE) so its page index is wave-uniform; V
+// spans PAGE_SIZE/VEC lane groups per page, so its index alternates on the upper
+// half of the wave.
 template<class T>
 struct kv_frag_slice
 {
@@ -287,22 +300,17 @@ struct page_ids_t
 
 // Read one tile's worth of block-table entries.
 //
-// The table is addressed through a buffer resource whose num_records stops at
-// this split's last page, so a slot past the end reads 0 with no bounds check in
-// the instruction stream. Page 0 is a valid index, and the tokens it stands in
-// for sit past the context length, so the tail tile masks their scores anyway.
+// The buffer's num_records stops at this split's last page, so a slot past the
+// end reads 0 with no bounds check in the instruction stream. Page 0 is a valid
+// index, but the tokens it stands in for sit past the context length, so the
+// tail tile masks their scores anyway. The buffer (rather than a raw pointer) is
+// what keeps the reads wide: an explicit guard -- branch or clamp -- makes every
+// slot its own expression, costing a dword load plus a 64-bit address chain per
+// page against two dwordx4 for the whole tile here.
 //
-// Going through the buffer rather than a raw pointer is what keeps the reads
-// wide. An explicit guard -- branch or clamp -- makes every slot its own
-// expression, and the compiler then has to emit one dword load per page plus a
-// 64-bit address chain for each; here the whole tile is two dwordx4 with the
-// offset folded into the instruction.
-//
-// The ids are wave-uniform, so pulling them into SGPRs with readfirstlane looks
-// free and moves the page-base half of every KV address onto the scalar unit.
-// Measured, it is a wash at best: readfirstlane has to wait on the load, which
-// anchors the whole block-table round trip in front of GEMM0 instead of letting
-// the address arithmetic sink in among the MFMAs.
+// Hoisting the wave-uniform ids into SGPRs with readfirstlane measured as a wash:
+// readfirstlane has to wait on the load, which anchors the block-table round trip
+// in front of GEMM0 instead of letting the address math sink in among the MFMAs.
 template<class T, class G>
 __device__ inline page_ids_t<T> load_page_ids(G& g_bt, int tile_idx)
 {
@@ -316,12 +324,10 @@ __device__ inline page_ids_t<T> load_page_ids(G& g_bt, int tile_idx)
     return pid;
 }
 
-// Page indices for the K fragments of one wave.
-//
-// A K MFMA tile is exactly one page, so wave w only ever reads pages
-// {i_n * T_N + w} of the tile. Reading just those keeps the array indices
-// compile-time constant; indexing the whole-tile array by a runtime wave id
-// would turn into an s_cselect chain or spill the array to scratch.
+// Page indices for the K fragments of one wave. A K MFMA tile is exactly one
+// page, so wave w only ever reads pages {i_n * T_N + w}. Reading just those
+// keeps the array indices compile-time constant; indexing the whole-tile array
+// by a runtime wave id becomes an s_cselect chain or spills to scratch.
 template<class T>
 struct k_page_ids_t
 {
@@ -342,15 +348,13 @@ __device__ inline k_page_ids_t<T> load_k_page_ids(G& g_bt, int tile_idx, int war
 
 // Read one tile's K fragments straight from the cache into the matrix-core
 // operand. Deliberately does not wait on the results: the caller issues these
-// right after the GEMM that consumed the previous tile, so the latency is
-// hidden behind the rest of the loop body.
+// right after the GEMM that consumed the previous tile, so the latency hides
+// behind the rest of the loop body.
 //
-// Addressed by pointer rather than through a buffer. A buffer offset is 32-bit,
-// which would cap a cache at 4GiB, and a page cannot move into the descriptor
-// base to lift that: pages come from the block table, and V's page index varies
-// per lane (the halves of a wave read adjacent pages), so no scalar base spans
-// one wave's reads. Buffer addressing was measured on shapes that fit -- same
-// runtime, same VGPR count, since the widening multiply and 64-bit add per page
+// Addressed by pointer, not buffer: a buffer offset is 32-bit and would cap the
+// cache at 4GiB, and no scalar base can lift that since V's page index varies
+// per lane (the halves of a wave read adjacent pages). Buffer addressing measured
+// identical where it fits -- the widening multiply and 64-bit add per page
 // disappear into the memory latency.
 template<class T, class VB>
 __device__ inline void load_k_frags(const typename T::D_ATTN* __restrict__ p_k,
@@ -413,24 +417,21 @@ __device__ inline void load_v_frags(const typename T::D_ATTN* __restrict__ p_v,
 // All-reduce a query row inside one wave.
 //
 // After swap_ab the C fragment puts query row r on lanes {r, r+16, r+32, r+48},
-// so folding a row is exactly a pair swap at distance 32 followed by one at
-// distance 16. Both are single gfx950 VALU ops that touch neither LDS nor a
-// barrier, which is why the score tile can stay in registers.
+// so folding a row is a pair swap at distance 32 then one at distance 16 -- two
+// gfx950 VALU ops, no LDS and no barrier, which is what lets the score tile stay
+// in registers. A lane covers only a quarter of a row, so every row-wide
+// quantity has to pass through here to mean anything.
 //
-// A lane's own elements cover only a quarter of the row, so every row-wide
-// quantity has to pass through here before it means anything.
+// Must be inline asm, not __builtin_amdgcn_permlane*_swap: the intrinsic returns
+// both halves as one vector, and when both operands hold the same value -- how an
+// all-reduce uses it -- the compiler folds them into one register. The second
+// half is lost and the fold collapses to op(v, v): invisible for max, badly
+// wrong for a sum.
 //
-// The swaps have to be inline asm rather than __builtin_amdgcn_permlane*_swap.
-// The intrinsic returns both halves of the exchange as one vector, and when
-// both operands hold the same value -- which is exactly how an all-reduce uses
-// it -- the compiler folds the two results into one register. The second half
-// is then lost and the fold silently collapses to op(v, v): invisible for an
-// idempotent op like max, and badly wrong for a sum.
-//
-// Inline asm costs us the hazard recognizer, so the wait states are supplied
-// here. Per LLVM's GCNHazardRecognizer for gfx950, a VALU write to an operand
-// needs 2 wait states before the swap reads it and a v_cmpx writing exec needs
-// 4; s_nop 3 covers both. Reading the result afterwards needs none.
+// Inline asm also costs us the hazard recognizer, so the wait states are supplied
+// here. Per LLVM's GCNHazardRecognizer for gfx950 a VALU write to an operand
+// needs 2 wait states before the swap reads it and a v_cmpx writing exec needs 4;
+// s_nop 3 covers both. Reading the result afterwards needs none.
 #define PA_SWAP_HAZARD "s_nop 3\n\t"
 
 __device__ inline void permlane32_swap(float& a, float& b)
@@ -454,60 +455,58 @@ __device__ inline float wave_row_fold(float v, OP op)
     return op(a, b);
 }
 
-// Publish this wave's row value and fold the T_N of them, through LDS.
+// Publish this wave's row value and fold the T_N of them, through LDS. Each wave
+// holds a partial for every query row, so the exchange is T_N contiguous floats
+// per row -- one 16B read. This barrier is the only one the whole softmax needs.
 //
-// Each wave holds a partial result for every query row, so the exchange is only
-// T_N floats per row. They sit contiguously, which makes the read a single 16B
-// LDS access. The barrier here is the only one the whole softmax needs.
-// s_red is deliberately not __restrict__, and the barrier is the fenced
-// __syncthreads rather than a bare s_barrier: this scratch is written by every
-// wave and read back by every wave, twice per kernel at the same addresses.
-// A plain s_barrier only synchronizes execution, so the compiler is free to
-// carry the first fold's loaded values across it and reuse them for the second.
+// s_row_reduce is deliberately not __restrict__, and the barrier is the fenced
+// __syncthreads rather than a bare s_barrier: every wave writes and reads this
+// scratch, twice per kernel at the same addresses, and a plain s_barrier only
+// orders execution -- the compiler would be free to carry the first fold's
+// loaded values across it and reuse them for the second.
 template<class T, class OP>
 __device__ inline typename T::D_ACC
-fold_across_waves(typename T::D_ACC* s_red,
+fold_across_waves(typename T::D_ACC* s_row_reduce,
                   typename T::D_ACC v,
                   int q_row,
                   int warp_id,
                   OP op)
 {
-    s_red[q_row * T::T_N + warp_id] = v;
+    s_row_reduce[q_row * T::T_N + warp_id] = v;
     __syncthreads();
 
-    typename T::D_ACC acc = s_red[q_row * T::T_N];
+    typename T::D_ACC acc = s_row_reduce[q_row * T::T_N];
     opus::static_for<T::T_N - 1>(
-        [&](auto iw) { acc = op(acc, s_red[q_row * T::T_N + iw.value + 1]); });
+        [&](auto iw) { acc = op(acc, s_row_reduce[q_row * T::T_N + iw.value + 1]); });
     return acc;
 }
 
-// Masked online softmax over the GEMM0 C fragment, in registers.
+// Masked online softmax over the GEMM0 C fragment, in registers. Returns the
+// rescale factor for the caller's O accumulator.
 //
-// S never reaches LDS. Lane l of wave w owns query row l % W_M and, per N
+// S never reaches LDS: lane l of wave w owns query row l % W_M and, per N
 // fragment, ELEM_C consecutive tokens, so folding a row is a permlane pair
-// inside the wave plus one float exchanged between waves -- against a full
-// [Q_TILE][KV_TILE] fp32 round trip if the tile went through LDS instead.
+// inside the wave plus one float between waves -- against a full
+// [Q_TILE][KV_TILE] fp32 round trip if the tile went through LDS.
 //
 // m_run must stay identical across waves, since the P they all write feeds one
-// GEMM and therefore needs one common scale. l_run needs no such agreement, so
-// it stays an unfolded per-lane partial and is reduced once after the last tile.
+// GEMM and needs one common scale. l_run needs no such agreement, so it stays an
+// unfolded per-lane partial, reduced once after the last tile.
 //
-// MASKED is false for every tile but the last: only the tail can run past the
-// context, so the interior tiles skip the per-token bound check entirely. That
-// check is 3 VALU per element of the C fragment, which is why it is worth
-// specialising rather than letting a uniform branch cover it.
-//
-// Returns the rescale factor for the caller's O accumulator.
+// MASKED is false for every tile but the last, the only one that can run past the
+// context. The check is 3 VALU per C fragment element, worth specialising rather
+// than covering with a uniform branch.
 template<class T, bool MASKED, class VC>
-__device__ inline typename T::D_ACC online_softmax_frag(VC& v_s,
-                                                        typename T::D_ACC* __restrict__ s_red,
-                                                        typename T::D_ACC& m_run,
-                                                        typename T::D_ACC& l_run,
-                                                        typename T::D_ACC scale,
-                                                        int valid_kv,
-                                                        int tile_idx,
-                                                        int lane_id,
-                                                        int warp_id)
+__device__ inline typename T::D_ACC
+online_softmax_frag(VC& v_s,
+                    typename T::D_ACC* __restrict__ s_row_reduce,
+                    typename T::D_ACC& m_run,
+                    typename T::D_ACC& l_run,
+                    typename T::D_ACC scale,
+                    int valid_kv,
+                    int tile_idx,
+                    int lane_id,
+                    int warp_id)
 {
     using D_ACC       = typename T::D_ACC;
     constexpr int E_N = T::GEMM0_E_N;
@@ -531,7 +530,7 @@ __device__ inline typename T::D_ACC online_softmax_frag(VC& v_s,
     });
 
     const D_ACC tile_max =
-        fold_across_waves<T>(s_red,
+        fold_across_waves<T>(s_row_reduce,
                              wave_row_fold(local_max, [](D_ACC a, D_ACC b) { return a > b ? a : b; }),
                              q_row,
                              warp_id,
@@ -555,28 +554,20 @@ __device__ inline typename T::D_ACC online_softmax_frag(VC& v_s,
 
 // Announce that this split is done, and report whether it was the last one.
 //
-// The reduction used to be a second kernel. It moved in here because its cost
-// was almost entirely the dispatch: measured across bs=4..16 it sat at 4-5us
-// while the work it did grew fourfold, and one launch of it cost more than the
-// whole split-KV path was buying back. Whichever workgroup arrives last already
-// has the machine, so it does the merge instead of a new grid being stood up.
-//
-// No workgroup ever waits: the counter only tells the last arrival that every
-// partial is now in memory, so there is no spin and nothing to deadlock on.
+// The merge is fused rather than a second kernel: that launch cost 4-5us of
+// almost pure dispatch, more than the split-KV path was buying back. Nothing
+// ever waits on the counter -- it only tells the last arrival, which already
+// has the machine, that every partial is in memory.
 template<class T>
 __device__ inline bool split_arrive_is_last(const pa_decode_kargs& kargs, int b, int kvh, int tid)
 {
     __shared__ int s_last;
 
     // Release for the whole block: the barrier orders every thread's partial
-    // stores ahead of the counter bump, and the waitcnt makes sure they have
-    // actually retired first.
-    //
-    // A __threadfence() here would be the textbook answer and is what this cost
-    // 28us of a 41us kernel: on a multi-XCD part an agent-scope release writes
-    // back the whole L2, in every split, evicting the KV stream along with it.
-    // The scratch is allocated uncached instead, so the stores are already at
-    // the coherence point once they retire and only the wait is needed.
+    // stores ahead of the counter bump, the waitcnt makes sure they retired.
+    // The textbook __threadfence() cost 28us of a 41us kernel -- on a multi-XCD
+    // part an agent-scope release writes back all of L2, evicting the KV stream.
+    // Uncached scratch removes the need: the stores retire at the coherence point.
     __syncthreads();
     __builtin_amdgcn_s_waitcnt(0);
 
@@ -636,9 +627,9 @@ __device__ inline void reduce_splits(const pa_decode_kargs& kargs, int b, int kv
                 + static_cast<int64_t>(b) * kargs.stride_o_b
                 + static_cast<int64_t>(kvh) * kargs.gqa_ratio * kargs.stride_o_h;
 
-    // Four dims per thread, and only over the rows the GQA group actually has:
-    // the partials are contiguous along the head dim, and bounding the walk by
-    // gqa_ratio keeps gqa<16 from spending iterations on rows it then discards.
+    // Four dims per thread, over only the rows the GQA group has: the partials are
+    // contiguous along the head dim, and bounding by gqa_ratio keeps gqa<16 from
+    // spending iterations on rows it would then discard.
     constexpr int VEC      = 4;
     constexpr int ROW_VECS = T::D_HEAD / VEC;
     const int vec_total    = kargs.gqa_ratio * ROW_VECS;
@@ -687,14 +678,11 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
 
     // ── LDS layout: bf16 P | cross-wave reduction scratch ──
     //
-    // Everything else lives in registers. K and V go straight from the cache into
-    // the matrix-core fragments, and S is reduced in place on the C fragment. P
-    // is the one operand that genuinely has to cross lanes: GEMM0 produces it in
-    // the C layout while GEMM1 consumes it in the A layout, and it contracts over
-    // the token dim, which is exactly the dim split across the waves.
-    //
-    // Declared up here because the split-KV merge borrows it too, and an empty
-    // split can reach the merge without ever running the attention body.
+    // Everything else stays in registers. P is the one operand that genuinely has
+    // to cross lanes: GEMM0 produces it in the C layout, GEMM1 consumes it in the
+    // A layout, and it contracts the token dim -- exactly the dim split across
+    // the waves. Declared this early because the split-KV merge borrows it too,
+    // and an empty split can reach the merge without running the attention body.
     __shared__ __align__(16) char smem[T::smem_size_bytes()];
 
     // Split-KV: each workgroup owns a contiguous run of whole tiles. Splitting on
@@ -702,9 +690,9 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
     // can simply be re-based and the rest of the kernel stays split-agnostic.
     const int context_len = kargs.context_lens[batch_idx];
     const int tiles_total = (context_len + T::KV_TILE - 1) / T::KV_TILE;
-    const int tiles_split = (tiles_total + kargs.num_splits - 1) / kargs.num_splits;
-    const int tile_begin  = split_idx * tiles_split;
-    const int tile_end    = min(tile_begin + tiles_split, tiles_total);
+    const int tiles_per_split = (tiles_total + kargs.num_splits - 1) / kargs.num_splits;
+    const int tile_begin      = split_idx * tiles_per_split;
+    const int tile_end        = min(tile_begin + tiles_per_split, tiles_total);
 
     if(tile_begin >= tile_end)
     {
@@ -733,7 +721,7 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
     auto* p_smem  = reinterpret_cast<char*>(smem);
     auto* s_p_raw = reinterpret_cast<D_ATTN*>(p_smem);
     p_smem += T::smem_p_elems * sizeof(D_ATTN);
-    auto* s_red = reinterpret_cast<D_ACC*>(p_smem);
+    auto* s_row_reduce = reinterpret_cast<D_ACC*>(p_smem);
 
     auto s_p = make_smem(s_p_raw);
 
@@ -755,13 +743,13 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
     auto u_q  = partition_layout_a<T::ELEM_A>(
         mma0, opus::make_tuple(kargs.stride_q_h, 1_I),
         opus::make_tuple(0_I, lane_id % mma0.grpm_a, 0_I, lane_id / mma0.grpm_a));
-    // Writes P out of the C fragment. Same mapping the score tile used to be
-    // stored with, now applied once, to bf16, after softmax has run in registers.
+    // Writes P out of the C fragment: the mapping the score tile used to be stored
+    // with, now applied once, to bf16, after softmax has run in registers.
     auto u_p  = partition_layout_c(
-        mma0, opus::make_tuple(number<T::S_ROW>{}, 1_I),
+        mma0, opus::make_tuple(number<T::P_ROW_STRIDE>{}, 1_I),
         opus::make_tuple(0_I, lane_id % mma0.grpn_c, warp_id, lane_id / mma0.grpn_c));
     auto u_rp = partition_layout_a<T::ELEM_A>(
-        mma1, opus::make_tuple(number<T::S_ROW>{}, 1_I),
+        mma1, opus::make_tuple(number<T::P_ROW_STRIDE>{}, 1_I),
         opus::make_tuple(0_I, lane_id % mma1.grpm_a, 0_I, lane_id / mma1.grpm_a));
     auto u_o  = partition_layout_c(
         mma1, opus::make_tuple(kargs.stride_o_h, 1_I),
@@ -798,32 +786,19 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
                               + kv_start / T::PAGE_SIZE,
                           num_pages * static_cast<unsigned int>(sizeof(int)));
 
-    // Single-buffered KV, double-buffered page ids.
+    // Single-buffered KV and page ids, both prefetched one tile ahead. Each KV
+    // operand is refetched right after the GEMM that consumed it, so its load
+    // stays in flight for the rest of the body: K hides behind softmax and GEMM1,
+    // V behind the next tile's GEMM0. A fragment dies as its GEMM issues, so
+    // deeper buffering only buys occupancy loss -- prefetch distance two
+    // (+64 VGPRs) and double-buffered ids (+53, from unrolling by two, not from
+    // the 10 the ids need) both drop 3 waves/SIMD to 2 and measured slower.
     //
-    // Each KV operand is refetched right after the GEMM that consumed it, so the
-    // next tile's loads stay in flight across the rest of the body: K's latency
-    // hides behind softmax and GEMM1, V's behind the next tile's GEMM0 and
-    // softmax. The fragments themselves need no second buffer, because one is
-    // dead as soon as its GEMM has issued -- a prefetch distance of two was
-    // measured and is worse everywhere, since the extra 64 VGPRs drop occupancy
-    // from 3 waves per SIMD to 2 and split-KV keeps enough workgroups in flight
-    // that losing a wave costs more than the extra distance pays.
-    //
-    // Double-buffering the ids was measured too, to break the dependent pair of
-    // HBM round trips they sit in front of (ids land, only then can the KV
-    // addresses be formed). It needs the loop unrolled by two to keep the buffer
-    // index compile time, and that costs 53 VGPRs -- not for the ids themselves,
-    // which are 10, but because two bodies' worth of temporaries are live at
-    // once. Occupancy drops to 2 and everything gets slower.
-    //
-    // The last tile is peeled out. Only it can run past the context, so the
-    // interior body needs neither the per-token mask nor a `has_next` guard.
-    // Both used to sit in the hot loop, and the guard was the more expensive:
-    // with the loads issued on one path only, the compiler cannot know how many
-    // are in flight at the loop header, so it fell back to vmcnt(0) before the
-    // last GEMM0 MFMA, draining V's prefetch in front of a GEMM that never
-    // needed V. Reads past the table are harmless -- num_records returns 0, and
-    // page 0's tokens are masked by the tail tile anyway.
+    // The last tile is peeled out: only it can run past the context, so the
+    // interior body needs neither the per-token mask nor a `has_next` guard. The
+    // guard cost more -- with the loads on one path only, the compiler cannot know
+    // how many are in flight at the loop header, and fell back to vmcnt(0) before
+    // the last GEMM0 MFMA, draining V's prefetch.
     const kv_frag_slice<T> kv_slice(lane_id, warp_id);
     k_page_ids_t<T> k_pid = load_k_page_ids<T>(g_bt, 0, warp_id);
     page_ids_t<T>   v_pid = load_page_ids<T>(g_bt, 0);
@@ -841,10 +816,10 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
             k_pid = load_k_page_ids<T>(g_bt, tile_idx + 1, warp_id);
             v_pid = load_page_ids<T>(g_bt, tile_idx + 1);
         }
-        // Keep the block-table reads ahead of GEMM0 rather than letting the
-        // scheduler sink them among the MFMAs: every KV address for the next
-        // tile depends on them, and left alone the first address computation
-        // ends up a dozen instructions behind the load, stalling on it.
+        // Keep the block-table reads ahead of GEMM0 instead of letting the
+        // scheduler sink them among the MFMAs: every KV address for the next tile
+        // depends on them, and left alone the first address computation lands a
+        // dozen instructions behind the load and stalls on it.
         __builtin_amdgcn_sched_barrier(0);
 
         v_s = mma0(v_q, v_k);
@@ -854,7 +829,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
         // Softmax happens in place on v_s, so this is also the P the store below
         // hands to GEMM1. The one barrier inside is the cross-wave max fold.
         const D_ACC rescale = online_softmax_frag<T, MASKED>(
-            v_s, s_red, m_run, l_run, temperature_scale, split_len, tile_idx, lane_id, warp_id);
+            v_s, s_row_reduce, m_run, l_run, temperature_scale, split_len, tile_idx,
+            lane_id, warp_id);
         opus::static_for<vector_traits<decltype(v_o)>::size()>(
             [&](auto i) { v_o[i.value] *= rescale; });
 
@@ -868,20 +844,20 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
         if constexpr(PREFETCH)
             load_v_frags<T>(p_v, v_pid, kargs.stride_v_blk, kv_slice, v_v);
 
-        // No trailing barrier: the next tile cannot overwrite s_p or s_red before
-        // its own max fold, and every wave has already issued its P reads by then.
+        // No trailing barrier: the next tile cannot overwrite s_p or s_row_reduce
+        // before its own max fold, by which point every wave has issued its P reads.
     };
 
     for (int tile_idx = 0; tile_idx + 1 < num_tiles; ++tile_idx)
         run_tile(tile_idx, 0_I, 1_I);
     run_tile(num_tiles - 1, 1_I, 0_I);
 
-    // l is still a per-lane partial: a lane only summed its own quarter of the
-    // row, and only its own wave's tokens. Both folds can wait until here
-    // because summing is linear and a row's rescale is common to all its lanes.
-    // Reusing s_red is safe: the last tile read it before that tile's P barrier.
+    // l is still a per-lane partial: a lane summed only its own quarter of the row
+    // and only its own wave's tokens. Both folds can wait until here because
+    // summing is linear and a row's rescale is common to all its lanes. Reusing
+    // s_row_reduce is safe -- the last tile read it before that tile's P barrier.
     const D_ACC l_final = fold_across_waves<T>(
-        s_red,
+        s_row_reduce,
         wave_row_fold(l_run, [](D_ACC a, D_ACC b) { return a + b; }),
         lane_id % T::W_M,
         warp_id,
@@ -916,7 +892,6 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
     const D_ACC o_scale = l_final > D_ACC(0.0f) ? D_ACC(1.0f) / l_final : D_ACC(0.0f);
     opus::static_for<vector_traits<decltype(v_o)>::size()>(
         [&](auto i) { v_o[i.value] *= o_scale; });
-
 
     const int64_t o_offset = static_cast<int64_t>(batch_idx) * kargs.stride_o_b
                              + static_cast<int64_t>(q_head_base) * kargs.stride_o_h;

--- a/csrc/include/pa_decode_opus.h
+++ b/csrc/include/pa_decode_opus.h
@@ -1,0 +1,940 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// OPUS-based paged-attention decode for gfx950.
+//
+// Algorithm follows the sp3 kernel PA_A16W16_*_1TG_4W_16mx1_64nx4: one thread
+// group of 4 waves per (batch, kv-head), 16 query rows, waves split along the
+// KV axis for Q*K and along the head axis for P*V.
+//
+// Self-contained, single-header:
+//   * Public API (always visible).
+//   * Host plumbing (`pa_decode_kargs` / `pa_decode_traits<...>`) inside the
+//     `PA_DECODE_OPUS_IMPL` guard.
+//   * Device kernel template inside the same guard on the `__HIP_DEVICE_COMPILE__`
+//     pass, host pass falls back to an empty stub for `__device_stub__` symbols.
+
+#pragma once
+#include "aiter_tensor.h"
+
+// Public API: paged-attention decode over a block table.
+//
+// Tensor expectations (row-major, last dim contiguous):
+//   q            : [batch, num_heads, 128]                          bf16
+//   k_cache      : [num_blocks, num_kv_heads, 128/8, 16, 8]         bf16 (vLLM packing, x=8)
+//   v_cache      : [num_blocks, num_kv_heads, 128, 16]              bf16
+//   block_tables : [batch, max_blocks_per_batch_row]                int32
+//   context_lens : [batch]                                          int32
+//   out          : [batch, num_heads, 128]                          bf16 (caller-allocated)
+//
+// `softmax_scale` is forwarded as-is (no implicit 1/sqrt(D)).
+// Requires head_dim == 128, page size == 16, and num_heads/num_kv_heads <= 16.
+void pa_decode_opus_fwd(aiter_tensor_t& q,
+                        aiter_tensor_t& k_cache,
+                        aiter_tensor_t& v_cache,
+                        aiter_tensor_t& block_tables,
+                        aiter_tensor_t& context_lens,
+                        aiter_tensor_t& out,
+                        float softmax_scale);
+
+#ifdef PA_DECODE_OPUS_IMPL
+// ============================================================================
+// Implementation section - only compiled in the .cu translation unit
+// ============================================================================
+
+using bf16_t = __bf16;
+
+// KV tile depth, i.e. how many KV tokens one main-loop iteration consumes.
+//
+// K and V go straight from the cache into the matrix-core fragments, so the tile
+// is paid for in registers, not LDS: the fragment count scales with it and
+// occupancy follows. On gfx950 (VGPR+AGPR, waves/SIMD):
+//   64 -> 89+8, 4    128 -> 129+8, 3    256 -> 217+16, 2    512 -> 256+161, 1
+// 512 caps out the VGPR file and starts parking values in AGPRs. LDS stays under
+// 17KB throughout and never binds.
+//
+// Streaming from HBM is flat over 64..256 -- two waves already saturate it --
+// while a cache-resident working set tracks occupancy directly (81.7 / 83.8 /
+// 89.3 / 116.5 us at bs=128, kvh=8, ctx=4097). 128 is the compromise: fastest of
+// the four when streaming, within 2.5% of the best when cache-resident.
+// Re-measure with op_tests/sweep_kv_tile.sh and op_tests/kv_tile_resources.sh.
+#ifndef PA_DECODE_KV_TILE
+#define PA_DECODE_KV_TILE 128
+#endif
+
+// Kernel arguments.
+struct pa_decode_kargs
+{
+    const void* __restrict__ q_ptr;       // [batch, num_heads, D]
+    const void* __restrict__ k_ptr;       // [num_blocks, num_kv_heads, D/K_PACK, PAGE, K_PACK]
+    const void* __restrict__ v_ptr;       // [num_blocks, num_kv_heads, D, PAGE]
+    void* __restrict__ out_ptr;           // [batch, num_heads, D]
+    const int* __restrict__ block_tables; // [batch, max_blocks_per_batch_row]
+    const int* __restrict__ context_lens; // [batch]
+    // Split-KV scratch, only used when num_splits > 1.
+    float* __restrict__ partial_o;  // [batch][num_kv_heads][num_splits][Q_TILE][D]
+    float* __restrict__ partial_ml; // [batch][num_kv_heads][num_splits][2][Q_TILE]
+    // One arrival counter per (batch, kv-head). Zeroed at allocation, and left
+    // zeroed by whichever split arrives last, so no per-call memset is needed.
+    unsigned int* __restrict__ split_counters;
+    int num_splits;
+    int batch;
+    int num_heads;
+    int num_kv_heads;
+    int gqa_ratio; // num_heads / num_kv_heads
+    int max_blocks_per_batch_row;
+    int stride_q_b; // elements, one batch row of q ([batch, num_heads, D])
+    int stride_q_h; // elements, one q head
+    int stride_o_b;
+    int stride_o_h;
+    int stride_k_blk; // elements, one page of all kv heads
+    int stride_k_h;   // elements, one kv head inside a page
+    int stride_v_blk;
+    int stride_v_h;
+    float softmax_scale;
+};
+
+// Tile shape / MFMA configuration.
+//
+// Naming mirrors the sp3 kernel: `16mx1` = 16 query rows handled by a single wave
+// along M, `16nx4` = each wave owns W_N=16 KV columns and 4 waves cover the tile.
+template<int D_HEAD_ = 128, int KV_TILE_ = 64, int PAGE_SIZE_ = 16, int NUM_WARPS_ = 4>
+struct pa_decode_traits
+{
+    using D_ATTN = bf16_t;
+    using D_ACC  = float;
+
+    static constexpr int D_HEAD    = D_HEAD_;
+    static constexpr int KV_TILE   = KV_TILE_;
+    static constexpr int PAGE_SIZE = PAGE_SIZE_;
+    static constexpr int NUM_WARPS = NUM_WARPS_;
+    static constexpr int WARP_SIZE = 64;
+    static constexpr int BLOCK_SIZE = NUM_WARPS * WARP_SIZE;
+    static constexpr int Q_TILE     = 16; // MFMA M, also the max supported GQA ratio
+
+    // Upper bound on KV splits, i.e. how far a single (batch, kv-head) may be
+    // spread across workgroups. Bounds the reduce kernel's LDS and the scratch.
+    static constexpr int MAX_SPLITS = 64;
+
+    // Wave tiling: 1 wave along M, all waves along N.
+    static constexpr int T_M = 1;
+    static constexpr int T_N = NUM_WARPS;
+    static constexpr int T_K = 1;
+
+    // gfx950 native bf16 matrix core.
+    static constexpr int W_M = 16;
+    static constexpr int W_N = 16;
+    static constexpr int W_K = 32;
+
+    static constexpr int ELEM_A = W_M * W_K / WARP_SIZE; // 8
+    static constexpr int ELEM_B = W_N * W_K / WARP_SIZE; // 8
+    static constexpr int ELEM_C = W_M * W_N / WARP_SIZE; // 4, consecutive along N
+
+    // GEMM0: S[Q_TILE, KV_TILE] = Q[Q_TILE, D_HEAD] * K^T
+    static constexpr int GEMM0_E_M = Q_TILE / (W_M * T_M);
+    static constexpr int GEMM0_E_N = KV_TILE / (W_N * T_N);
+    static constexpr int GEMM0_E_K = D_HEAD / (W_K * T_K);
+
+    // GEMM1: O[Q_TILE, D_HEAD] = P[Q_TILE, KV_TILE] * V^T
+    static constexpr int GEMM1_E_M = Q_TILE / (W_M * T_M);
+    static constexpr int GEMM1_E_N = D_HEAD / (W_N * T_N);
+    static constexpr int GEMM1_E_K = KV_TILE / (W_K * T_K);
+
+    static constexpr int PAGES_PER_TILE = KV_TILE / PAGE_SIZE;
+    // vLLM packs the K cache as [D/x, PAGE, x] with x = 16 bytes / sizeof(dtype).
+    static constexpr int K_PACK = 16 / sizeof(D_ATTN);
+    static constexpr int VEC    = 16 / sizeof(D_ATTN); // widest global vector, 8 bf16
+
+    // Lanes of one MFMA operand split N ways across the wave, each covering
+    // GRP_K positions along the contraction dim.
+    static constexpr int GRP_N = W_N;
+    static constexpr int GRP_K = WARP_SIZE / W_N;
+    // How many lane groups share one page when walking V along tokens.
+    static constexpr int KGRP_PER_PAGE = PAGE_SIZE / VEC;
+
+    // Only P is staged through LDS. K and V go straight from global into the
+    // matrix-core fragments, and S never leaves registers -- LDS is needed only
+    // where a wave must read data another wave produced, which for P is every
+    // element because GEMM1 contracts over the token dim that splits the waves.
+    static constexpr int PAD   = 8;
+    static constexpr int S_ROW = KV_TILE + PAD; // P tile is [Q_TILE][KV_TILE]
+
+    static constexpr int smem_p_elems = Q_TILE * S_ROW;
+    // Cross-wave row reduction scratch, laid out [row][wave] so a row's T_N
+    // contributions are contiguous and fold with a single 16B LDS read.
+    static constexpr int smem_red_elems = Q_TILE * T_N;
+
+    static_assert(Q_TILE == W_M, "one MFMA tile along M");
+    static_assert(KV_TILE % (W_N * T_N) == 0);
+    static_assert(KV_TILE % PAGE_SIZE == 0);
+    static_assert(D_HEAD % (W_N * T_N) == 0);
+    static_assert(KV_TILE % W_K == 0);
+    static_assert(D_HEAD % W_K == 0);
+    // Softmax runs on the GEMM0 C fragment, where a query row is spread over the
+    // lanes {r, r+16, r+32, r+48} of each wave. That is exactly the reach of a
+    // permlane32/permlane16 swap pair, which is what lets S stay in registers.
+    static_assert(W_M == 16, "a C fragment row must span four 16-lane groups");
+    static_assert(WARP_SIZE == 64);
+
+    // Contract that lets the KV fragments be read straight from the cache:
+    // one K MFMA tile must cover exactly one page, and one lane's slice of the
+    // contraction dim must be exactly the 16B the cache stores contiguously.
+    static_assert(GRP_N == PAGE_SIZE, "a K MFMA tile must line up with one page");
+    static_assert(GRP_K * VEC == W_K, "a lane's K slice must be one 16B vector");
+    static_assert(K_PACK == VEC);
+    static_assert(PAGE_SIZE % VEC == 0);
+    static_assert(ELEM_B == VEC, "one B fragment is one 16B global vector");
+    static_assert(GEMM0_E_N * T_N == PAGES_PER_TILE, "K's N tiles must cover the tile's pages");
+    static_assert(GEMM1_E_K * (GRP_K / KGRP_PER_PAGE) == PAGES_PER_TILE,
+                  "V's K steps must walk exactly the tile's pages");
+
+    // The split-KV merge reuses this same allocation: by the time it runs, the P
+    // tile and the row-reduction scratch are both dead. Taking the union keeps
+    // the merge from costing any LDS at all -- at KV_TILE=128 the attention side
+    // is the larger of the two, so the footprint is unchanged.
+    static constexpr size_t smem_reduce_bytes()
+    {
+        return static_cast<size_t>(MAX_SPLITS * Q_TILE + Q_TILE) * sizeof(D_ACC);
+    }
+
+    static constexpr size_t smem_size_bytes()
+    {
+        const size_t attn = smem_p_elems * sizeof(D_ATTN)     // bf16 P handed to GEMM1
+                            + smem_red_elems * sizeof(D_ACC); // cross-wave row reduction
+        const size_t red  = smem_reduce_bytes();
+        return attn > red ? attn : red;
+    }
+};
+
+using pa_decode_traits_d128 = pa_decode_traits<128, PA_DECODE_KV_TILE, 16, 4>;
+
+template<class Traits>
+__global__ void pa_decode_opus_kernel(pa_decode_kargs kargs);
+
+#ifdef __HIP_DEVICE_COMPILE__
+// ---------------------------------------------------------------------------
+// Device pass
+// ---------------------------------------------------------------------------
+#include "opus/opus.hpp"
+
+#if defined(__gfx950__)
+
+namespace pa_decode_16mx1_16nx4 {
+
+using opus::operator""_I;
+
+// Scratch addressing for the split-KV path: one (Q_TILE x D) accumulator plus a
+// (m, l) pair per query row, for every (batch, kv-head, split).
+template<class T>
+__device__ inline int64_t partial_slot(const pa_decode_kargs& kargs, int b, int kvh, int split)
+{
+    return (static_cast<int64_t>(b) * kargs.num_kv_heads + kvh) * kargs.num_splits + split;
+}
+
+template<class T>
+__device__ inline float* partial_ml_ptr(const pa_decode_kargs& kargs, int b, int kvh, int split)
+{
+    return kargs.partial_ml + partial_slot<T>(kargs, b, kvh, split) * 2 * T::Q_TILE;
+}
+
+template<class T>
+__device__ inline float* partial_o_ptr(const pa_decode_kargs& kargs, int b, int kvh, int split)
+{
+    return kargs.partial_o + partial_slot<T>(kargs, b, kvh, split) * T::Q_TILE * T::D_HEAD;
+}
+
+// Where this lane's K and V fragments sit inside a page.
+//
+// The cache layouts hand the matrix cores exactly what they want. A B fragment
+// needs lane l to hold column l%16 of the operand and 8 consecutive positions
+// along the contraction dim, and both caches store precisely those 8 values in
+// 16 contiguous bytes: K is [D/K_PACK][PAGE][K_PACK], so a lane walks the
+// K_PACK head dims of one token; V is [D][PAGE], so a lane walks 8 tokens of
+// one head dim. Every fragment is therefore a single dwordx4 read straight from
+// the cache, and the KV tile never has to be staged through LDS.
+//
+// K additionally lines up one MFMA tile with one page (GRP_N == PAGE_SIZE), so
+// its page index is uniform across the wave. V spans PAGE_SIZE/VEC lane groups
+// per page, so its page index alternates on the upper half of the wave.
+// Loop invariant: only the page base changes from tile to tile.
+template<class T>
+struct kv_frag_slice
+{
+    int k_off;      // element offset of the K fragment inside its page
+    int v_off;      // element offset of the V fragment inside its page
+    int v_page_odd; // 0/1: which page of the pair this lane reads V from
+
+    __device__ kv_frag_slice(int lane_id, int warp_id)
+    {
+        const int n_lane = lane_id % T::GRP_N; // token for K, head dim for V
+        const int k_grp  = lane_id / T::GRP_N; // slice of the contraction dim
+
+        k_off = k_grp * T::PAGE_SIZE * T::K_PACK + n_lane * T::K_PACK;
+
+        v_off = (warp_id * T::GRP_N + n_lane) * T::PAGE_SIZE
+                + (k_grp % T::KGRP_PER_PAGE) * T::VEC;
+        v_page_odd = k_grp / T::KGRP_PER_PAGE;
+    }
+};
+
+// Page indices for one KV tile, kept in registers a full iteration ahead of the
+// KV loads that consume them.
+template<class T>
+struct page_ids_t
+{
+    int id[T::PAGES_PER_TILE];
+};
+
+// Read one tile's worth of block-table entries.
+//
+// The table is addressed through a buffer resource whose num_records stops at
+// this split's last page, so a slot past the end reads 0 with no bounds check in
+// the instruction stream. Page 0 is a valid index, and the tokens it stands in
+// for sit past the context length, so the tail tile masks their scores anyway.
+//
+// Going through the buffer rather than a raw pointer is what keeps the reads
+// wide. An explicit guard -- branch or clamp -- makes every slot its own
+// expression, and the compiler then has to emit one dword load per page plus a
+// 64-bit address chain for each; here the whole tile is two dwordx4 with the
+// offset folded into the instruction.
+//
+// The ids are wave-uniform, so pulling them into SGPRs with readfirstlane looks
+// free and moves the page-base half of every KV address onto the scalar unit.
+// Measured, it is a wash at best: readfirstlane has to wait on the load, which
+// anchors the whole block-table round trip in front of GEMM0 instead of letting
+// the address arithmetic sink in among the MFMAs.
+template<class T, class G>
+__device__ inline page_ids_t<T> load_page_ids(G& g_bt, int tile_idx)
+{
+    static_assert(T::PAGES_PER_TILE % 4 == 0, "block-table reads are dwordx4");
+    page_ids_t<T> pid;
+    const int base = tile_idx * T::PAGES_PER_TILE * static_cast<int>(sizeof(int));
+    opus::static_for<T::PAGES_PER_TILE / 4>([&](auto ig) {
+        const auto v = g_bt.template _load<4>(base + ig.value * 16);
+        opus::static_for<4>([&](auto j) { pid.id[ig.value * 4 + j.value] = v[j.value]; });
+    });
+    return pid;
+}
+
+// Page indices for the K fragments of one wave.
+//
+// A K MFMA tile is exactly one page, so wave w only ever reads pages
+// {i_n * T_N + w} of the tile. Reading just those keeps the array indices
+// compile-time constant; indexing the whole-tile array by a runtime wave id
+// would turn into an s_cselect chain or spill the array to scratch.
+template<class T>
+struct k_page_ids_t
+{
+    int id[T::GEMM0_E_N];
+};
+
+template<class T, class G>
+__device__ inline k_page_ids_t<T> load_k_page_ids(G& g_bt, int tile_idx, int warp_id)
+{
+    k_page_ids_t<T> pid;
+    const int base = (tile_idx * T::PAGES_PER_TILE + warp_id) * static_cast<int>(sizeof(int));
+    opus::static_for<T::GEMM0_E_N>([&](auto in) {
+        const auto v     = g_bt.template _load<1>(base + in.value * T::T_N * static_cast<int>(sizeof(int)));
+        pid.id[in.value] = v[0];
+    });
+    return pid;
+}
+
+// Read one tile's K fragments straight from the cache into the matrix-core
+// operand. Deliberately does not wait on the results: the caller issues these
+// right after the GEMM that consumed the previous tile, so the latency is
+// hidden behind the rest of the loop body.
+//
+// Addressed by pointer rather than through a buffer. A buffer offset is 32-bit,
+// which would cap a cache at 4GiB, and a page cannot move into the descriptor
+// base to lift that: pages come from the block table, and V's page index varies
+// per lane (the halves of a wave read adjacent pages), so no scalar base spans
+// one wave's reads. Buffer addressing was measured on shapes that fit -- same
+// runtime, same VGPR count, since the widening multiply and 64-bit add per page
+// disappear into the memory latency.
+template<class T, class VB>
+__device__ inline void load_k_frags(const typename T::D_ATTN* __restrict__ p_k,
+                                    const k_page_ids_t<T>& pid,
+                                    int stride_k_blk,
+                                    const kv_frag_slice<T>& s,
+                                    VB& v_k)
+{
+    using D_ATTN      = typename T::D_ATTN;
+    using vec_t       = opus::vector_t<D_ATTN, T::VEC>;
+    constexpr int E_N = T::GEMM0_E_N;
+    constexpr int E_K = T::GEMM0_E_K;
+
+    opus::static_for<E_N>([&](auto in) {
+        constexpr int i_n = in.value;
+        const D_ATTN* g_n = p_k + static_cast<int64_t>(pid.id[i_n]) * stride_k_blk + s.k_off;
+
+        opus::static_for<E_K>([&](auto ik) {
+            constexpr int i_k   = ik.value;
+            constexpr int d_off = i_k * T::GRP_K * T::PAGE_SIZE * T::K_PACK;
+            const vec_t frag    = *reinterpret_cast<const vec_t*>(g_n + d_off);
+            opus::static_for<T::ELEM_B>(
+                [&](auto j) { v_k[(i_n * E_K + i_k) * T::ELEM_B + j.value] = frag[j.value]; });
+        });
+    });
+}
+
+// Same for V. Here the contraction dim is tokens, so a K step walks pages while
+// N walks head dims. Each step of GRP_K lane groups spans GRP_K/KGRP_PER_PAGE
+// pages, and the upper lane groups sit on the odd page of that span.
+template<class T, class VB>
+__device__ inline void load_v_frags(const typename T::D_ATTN* __restrict__ p_v,
+                                    const page_ids_t<T>& pid,
+                                    int stride_v_blk,
+                                    const kv_frag_slice<T>& s,
+                                    VB& v_v)
+{
+    using D_ATTN      = typename T::D_ATTN;
+    using vec_t       = opus::vector_t<D_ATTN, T::VEC>;
+    constexpr int E_N = T::GEMM1_E_N;
+    constexpr int E_K = T::GEMM1_E_K;
+
+    opus::static_for<E_K>([&](auto ik) {
+        constexpr int i_k       = ik.value;
+        constexpr int page_base = i_k * (T::GRP_K / T::KGRP_PER_PAGE);
+        // Both indices stay compile time; the runtime part is a lane select.
+        const int page    = s.v_page_odd ? pid.id[page_base + 1] : pid.id[page_base];
+        const D_ATTN* g_k = p_v + static_cast<int64_t>(page) * stride_v_blk + s.v_off;
+
+        opus::static_for<E_N>([&](auto in) {
+            constexpr int i_n   = in.value;
+            constexpr int d_off = i_n * T::T_N * T::GRP_N * T::PAGE_SIZE;
+            const vec_t frag    = *reinterpret_cast<const vec_t*>(g_k + d_off);
+            opus::static_for<T::ELEM_B>(
+                [&](auto j) { v_v[(i_n * E_K + i_k) * T::ELEM_B + j.value] = frag[j.value]; });
+        });
+    });
+}
+
+// All-reduce a query row inside one wave.
+//
+// After swap_ab the C fragment puts query row r on lanes {r, r+16, r+32, r+48},
+// so folding a row is exactly a pair swap at distance 32 followed by one at
+// distance 16. Both are single gfx950 VALU ops that touch neither LDS nor a
+// barrier, which is why the score tile can stay in registers.
+//
+// A lane's own elements cover only a quarter of the row, so every row-wide
+// quantity has to pass through here before it means anything.
+//
+// The swaps have to be inline asm rather than __builtin_amdgcn_permlane*_swap.
+// The intrinsic returns both halves of the exchange as one vector, and when
+// both operands hold the same value -- which is exactly how an all-reduce uses
+// it -- the compiler folds the two results into one register. The second half
+// is then lost and the fold silently collapses to op(v, v): invisible for an
+// idempotent op like max, and badly wrong for a sum.
+//
+// Inline asm costs us the hazard recognizer, so the wait states are supplied
+// here. Per LLVM's GCNHazardRecognizer for gfx950, a VALU write to an operand
+// needs 2 wait states before the swap reads it and a v_cmpx writing exec needs
+// 4; s_nop 3 covers both. Reading the result afterwards needs none.
+#define PA_SWAP_HAZARD "s_nop 3\n\t"
+
+__device__ inline void permlane32_swap(float& a, float& b)
+{
+    asm volatile(PA_SWAP_HAZARD "v_permlane32_swap_b32 %0, %1" : "+v"(a), "+v"(b));
+}
+
+__device__ inline void permlane16_swap(float& a, float& b)
+{
+    asm volatile(PA_SWAP_HAZARD "v_permlane16_swap_b32 %0, %1" : "+v"(a), "+v"(b));
+}
+
+template<class OP>
+__device__ inline float wave_row_fold(float v, OP op)
+{
+    float a = v, b = v;
+    permlane32_swap(a, b);
+    a = op(a, b);
+    b = a;
+    permlane16_swap(a, b);
+    return op(a, b);
+}
+
+// Publish this wave's row value and fold the T_N of them, through LDS.
+//
+// Each wave holds a partial result for every query row, so the exchange is only
+// T_N floats per row. They sit contiguously, which makes the read a single 16B
+// LDS access. The barrier here is the only one the whole softmax needs.
+// s_red is deliberately not __restrict__, and the barrier is the fenced
+// __syncthreads rather than a bare s_barrier: this scratch is written by every
+// wave and read back by every wave, twice per kernel at the same addresses.
+// A plain s_barrier only synchronizes execution, so the compiler is free to
+// carry the first fold's loaded values across it and reuse them for the second.
+template<class T, class OP>
+__device__ inline typename T::D_ACC
+fold_across_waves(typename T::D_ACC* s_red,
+                  typename T::D_ACC v,
+                  int q_row,
+                  int warp_id,
+                  OP op)
+{
+    s_red[q_row * T::T_N + warp_id] = v;
+    __syncthreads();
+
+    typename T::D_ACC acc = s_red[q_row * T::T_N];
+    opus::static_for<T::T_N - 1>(
+        [&](auto iw) { acc = op(acc, s_red[q_row * T::T_N + iw.value + 1]); });
+    return acc;
+}
+
+// Masked online softmax over the GEMM0 C fragment, in registers.
+//
+// S never reaches LDS. Lane l of wave w owns query row l % W_M and, per N
+// fragment, ELEM_C consecutive tokens, so folding a row is a permlane pair
+// inside the wave plus one float exchanged between waves -- against a full
+// [Q_TILE][KV_TILE] fp32 round trip if the tile went through LDS instead.
+//
+// m_run must stay identical across waves, since the P they all write feeds one
+// GEMM and therefore needs one common scale. l_run needs no such agreement, so
+// it stays an unfolded per-lane partial and is reduced once after the last tile.
+//
+// MASKED is false for every tile but the last: only the tail can run past the
+// context, so the interior tiles skip the per-token bound check entirely. That
+// check is 3 VALU per element of the C fragment, which is why it is worth
+// specialising rather than letting a uniform branch cover it.
+//
+// Returns the rescale factor for the caller's O accumulator.
+template<class T, bool MASKED, class VC>
+__device__ inline typename T::D_ACC online_softmax_frag(VC& v_s,
+                                                        typename T::D_ACC* __restrict__ s_red,
+                                                        typename T::D_ACC& m_run,
+                                                        typename T::D_ACC& l_run,
+                                                        typename T::D_ACC scale,
+                                                        int valid_kv,
+                                                        int tile_idx,
+                                                        int lane_id,
+                                                        int warp_id)
+{
+    using D_ACC       = typename T::D_ACC;
+    constexpr int E_N = T::GEMM0_E_N;
+    constexpr int E_C = T::ELEM_C;
+
+    const int q_row    = lane_id % T::W_M;
+    const int tok_lane = (lane_id / T::W_M) * E_C;
+
+    D_ACC local_max = opus::numeric_limits<D_ACC>::lowest();
+    opus::static_for<E_N>([&](auto in) {
+        constexpr int i_n = in.value;
+        const int kv_base = tile_idx * T::KV_TILE + (i_n * T::T_N + warp_id) * T::W_N + tok_lane;
+        opus::static_for<E_C>([&](auto ic) {
+            constexpr int c = ic.value;
+            D_ACC s         = v_s[i_n * E_C + c] * scale;
+            if constexpr(MASKED)
+                s = (kv_base + c) < valid_kv ? s : opus::numeric_limits<D_ACC>::lowest();
+            v_s[i_n * E_C + c] = s;
+            local_max          = s > local_max ? s : local_max;
+        });
+    });
+
+    const D_ACC tile_max =
+        fold_across_waves<T>(s_red,
+                             wave_row_fold(local_max, [](D_ACC a, D_ACC b) { return a > b ? a : b; }),
+                             q_row,
+                             warp_id,
+                             [](D_ACC a, D_ACC b) { return a > b ? a : b; });
+
+    const D_ACC m_prev  = m_run;
+    m_run               = tile_max > m_prev ? tile_max : m_prev;
+    const D_ACC rescale = __builtin_amdgcn_exp2f(m_prev - m_run);
+
+    D_ACC local_sum = 0.0f;
+    opus::static_for<E_N * E_C>([&](auto i) {
+        // exp2 of lowest() underflows to 0, which is exactly the mask we want.
+        const D_ACC e = __builtin_amdgcn_exp2f(v_s[i.value] - m_run);
+        v_s[i.value]  = e;
+        local_sum += e;
+    });
+    l_run = l_run * rescale + local_sum;
+
+    return rescale;
+}
+
+// Announce that this split is done, and report whether it was the last one.
+//
+// The reduction used to be a second kernel. It moved in here because its cost
+// was almost entirely the dispatch: measured across bs=4..16 it sat at 4-5us
+// while the work it did grew fourfold, and one launch of it cost more than the
+// whole split-KV path was buying back. Whichever workgroup arrives last already
+// has the machine, so it does the merge instead of a new grid being stood up.
+//
+// No workgroup ever waits: the counter only tells the last arrival that every
+// partial is now in memory, so there is no spin and nothing to deadlock on.
+template<class T>
+__device__ inline bool split_arrive_is_last(const pa_decode_kargs& kargs, int b, int kvh, int tid)
+{
+    __shared__ int s_last;
+
+    // Release for the whole block: the barrier orders every thread's partial
+    // stores ahead of the counter bump, and the waitcnt makes sure they have
+    // actually retired first.
+    //
+    // A __threadfence() here would be the textbook answer and is what this cost
+    // 28us of a 41us kernel: on a multi-XCD part an agent-scope release writes
+    // back the whole L2, in every split, evicting the KV stream along with it.
+    // The scratch is allocated uncached instead, so the stores are already at
+    // the coherence point once they retire and only the wait is needed.
+    __syncthreads();
+    __builtin_amdgcn_s_waitcnt(0);
+
+    if(tid == 0)
+    {
+        unsigned int* slot = kargs.split_counters + b * kargs.num_kv_heads + kvh;
+        const unsigned int prev = atomicAdd(slot, 1u);
+        const bool last = prev + 1u == static_cast<unsigned int>(kargs.num_splits);
+        // The buffer is zeroed once at allocation and never again, so the last
+        // arrival is what leaves it clean for the next launch.
+        if(last) atomicExch(slot, 0u);
+        s_last = last ? 1 : 0;
+    }
+    __syncthreads();
+    return s_last != 0;
+}
+
+// Merge this (batch, kv-head)'s per-split partials into the final output.
+template<class T>
+__device__ inline void reduce_splits(const pa_decode_kargs& kargs, int b, int kvh, int tid,
+                                     char* smem)
+{
+    using D_ATTN = typename T::D_ATTN;
+    using D_ACC  = typename T::D_ACC;
+
+    const int splits  = kargs.num_splits;
+    const D_ACC* p_ml = partial_ml_ptr<T>(kargs, b, kvh, 0);
+    const D_ACC* p_o  = partial_o_ptr<T>(kargs, b, kvh, 0);
+
+    // Carved out of the attention body's buffer, which is dead by now.
+    auto* s_scale = reinterpret_cast<D_ACC*>(smem);
+    auto* s_inv_l = s_scale + T::MAX_SPLITS * T::Q_TILE;
+
+    if(tid < T::Q_TILE)
+    {
+        D_ACC m_max = -opus::numeric_limits<D_ACC>::max();
+        for(int i = 0; i < splits; ++i)
+        {
+            const D_ACC m = p_ml[static_cast<int64_t>(i) * 2 * T::Q_TILE + tid];
+            if(m > m_max) m_max = m;
+        }
+
+        // The softmax runs in log2 space, so the cross-split rescale is exp2 too.
+        D_ACC l_sum = 0.0f;
+        for(int i = 0; i < splits; ++i)
+        {
+            const int64_t base = static_cast<int64_t>(i) * 2 * T::Q_TILE;
+            const D_ACC c      = __builtin_amdgcn_exp2f(p_ml[base + tid] - m_max);
+            s_scale[i * T::Q_TILE + tid] = c;
+            l_sum += p_ml[base + T::Q_TILE + tid] * c;
+        }
+        s_inv_l[tid] = l_sum > D_ACC(0.0f) ? D_ACC(1.0f) / l_sum : D_ACC(0.0f);
+    }
+    __syncthreads();
+
+    auto* out = reinterpret_cast<D_ATTN*>(kargs.out_ptr)
+                + static_cast<int64_t>(b) * kargs.stride_o_b
+                + static_cast<int64_t>(kvh) * kargs.gqa_ratio * kargs.stride_o_h;
+
+    // Four dims per thread, and only over the rows the GQA group actually has:
+    // the partials are contiguous along the head dim, and bounding the walk by
+    // gqa_ratio keeps gqa<16 from spending iterations on rows it then discards.
+    constexpr int VEC      = 4;
+    constexpr int ROW_VECS = T::D_HEAD / VEC;
+    const int vec_total    = kargs.gqa_ratio * ROW_VECS;
+
+    for(int idx = tid; idx < vec_total; idx += T::BLOCK_SIZE)
+    {
+        const int row       = idx / ROW_VECS;
+        const int dim       = (idx - row * ROW_VECS) * VEC;
+        const int64_t o_row = static_cast<int64_t>(row) * T::D_HEAD + dim;
+
+        D_ACC acc[VEC] = {0.0f, 0.0f, 0.0f, 0.0f};
+        for(int i = 0; i < splits; ++i)
+        {
+            const D_ACC c = s_scale[i * T::Q_TILE + row];
+            const auto v  = *reinterpret_cast<const opus::vector_t<D_ACC, VEC>*>(
+                p_o + static_cast<int64_t>(i) * T::Q_TILE * T::D_HEAD + o_row);
+            opus::static_for<VEC>([&](auto j) { acc[j.value] += v[j.value] * c; });
+        }
+
+        // Adjacent by construction, so these fold into one wide store.
+        const D_ACC inv_l = s_inv_l[row];
+        auto* dst = out + static_cast<int64_t>(row) * kargs.stride_o_h + dim;
+        opus::static_for<VEC>(
+            [&](auto j) { dst[j.value] = static_cast<D_ATTN>(acc[j.value] * inv_l); });
+    }
+}
+
+} // namespace pa_decode_16mx1_16nx4
+
+template<class Traits>
+__global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(pa_decode_kargs kargs)
+{
+    using namespace opus;
+    using namespace pa_decode_16mx1_16nx4;
+    using T      = opus::remove_cvref_t<Traits>;
+    using D_ATTN = typename T::D_ATTN;
+    using D_ACC  = typename T::D_ACC;
+
+    const int kv_head_idx = block_id_x();
+    const int batch_idx   = block_id_y();
+    const int split_idx   = block_id_z();
+
+    const int tid     = thread_id_x();
+    const int lane_id = tid % T::WARP_SIZE;
+    const int warp_id = __builtin_amdgcn_readfirstlane(tid / T::WARP_SIZE);
+
+    // ── LDS layout: bf16 P | cross-wave reduction scratch ──
+    //
+    // Everything else lives in registers. K and V go straight from the cache into
+    // the matrix-core fragments, and S is reduced in place on the C fragment. P
+    // is the one operand that genuinely has to cross lanes: GEMM0 produces it in
+    // the C layout while GEMM1 consumes it in the A layout, and it contracts over
+    // the token dim, which is exactly the dim split across the waves.
+    //
+    // Declared up here because the split-KV merge borrows it too, and an empty
+    // split can reach the merge without ever running the attention body.
+    __shared__ __align__(16) char smem[T::smem_size_bytes()];
+
+    // Split-KV: each workgroup owns a contiguous run of whole tiles. Splitting on
+    // tile (not token) boundaries keeps kv_start page-aligned, so the block table
+    // can simply be re-based and the rest of the kernel stays split-agnostic.
+    const int context_len = kargs.context_lens[batch_idx];
+    const int tiles_total = (context_len + T::KV_TILE - 1) / T::KV_TILE;
+    const int tiles_split = (tiles_total + kargs.num_splits - 1) / kargs.num_splits;
+    const int tile_begin  = split_idx * tiles_split;
+    const int tile_end    = min(tile_begin + tiles_split, tiles_total);
+
+    if(tile_begin >= tile_end)
+    {
+        if(kargs.num_splits > 1)
+        {
+            // Empty split: publish an identity partial so the reduction can ignore it.
+            if(tid < T::Q_TILE)
+            {
+                float* p_ml = partial_ml_ptr<T>(kargs, batch_idx, kv_head_idx, split_idx);
+                p_ml[tid]             = -opus::numeric_limits<float>::max();
+                p_ml[T::Q_TILE + tid] = 0.0f;
+            }
+            // Still has to arrive, or the split that does finish last would be
+            // waiting on a count that never completes.
+            if(split_arrive_is_last<T>(kargs, batch_idx, kv_head_idx, tid))
+                reduce_splits<T>(kargs, batch_idx, kv_head_idx, tid, smem);
+        }
+        return;
+    }
+
+    const int kv_start    = tile_begin * T::KV_TILE;
+    const int split_len   = min(context_len - kv_start, (tile_end - tile_begin) * T::KV_TILE);
+    const int num_pages   = (split_len + T::PAGE_SIZE - 1) / T::PAGE_SIZE;
+    const int num_tiles   = tile_end - tile_begin;
+
+    auto* p_smem  = reinterpret_cast<char*>(smem);
+    auto* s_p_raw = reinterpret_cast<D_ATTN*>(p_smem);
+    p_smem += T::smem_p_elems * sizeof(D_ATTN);
+    auto* s_red = reinterpret_cast<D_ACC*>(p_smem);
+
+    auto s_p = make_smem(s_p_raw);
+
+    // ── Matrix cores. swap_ab keeps the query row on `lane % W_M` for both GEMMs. ──
+    auto mma0 = make_tiled_mma<D_ATTN, D_ATTN, D_ACC>(
+        seq<T::GEMM0_E_M, T::GEMM0_E_N, T::GEMM0_E_K>{},
+        seq<T::T_M, T::T_N, T::T_K>{},
+        seq<T::W_M, T::W_N, T::W_K>{},
+        mfma_adaptor_swap_ab{});
+    auto mma1 = make_tiled_mma<D_ATTN, D_ATTN, D_ACC>(
+        seq<T::GEMM1_E_M, T::GEMM1_E_N, T::GEMM1_E_K>{},
+        seq<T::T_M, T::T_N, T::T_K>{},
+        seq<T::W_M, T::W_N, T::W_K>{},
+        mfma_adaptor_swap_ab{});
+
+    // Every operand is a plain row-major matrix, so the register fragment layout
+    // comes straight from the mma adaptor instead of being hand-derived.
+    const int q_head_base = kv_head_idx * kargs.gqa_ratio;
+    auto u_q  = partition_layout_a<T::ELEM_A>(
+        mma0, opus::make_tuple(kargs.stride_q_h, 1_I),
+        opus::make_tuple(0_I, lane_id % mma0.grpm_a, 0_I, lane_id / mma0.grpm_a));
+    // Writes P out of the C fragment. Same mapping the score tile used to be
+    // stored with, now applied once, to bf16, after softmax has run in registers.
+    auto u_p  = partition_layout_c(
+        mma0, opus::make_tuple(number<T::S_ROW>{}, 1_I),
+        opus::make_tuple(0_I, lane_id % mma0.grpn_c, warp_id, lane_id / mma0.grpn_c));
+    auto u_rp = partition_layout_a<T::ELEM_A>(
+        mma1, opus::make_tuple(number<T::S_ROW>{}, 1_I),
+        opus::make_tuple(0_I, lane_id % mma1.grpm_a, 0_I, lane_id / mma1.grpm_a));
+    auto u_o  = partition_layout_c(
+        mma1, opus::make_tuple(kargs.stride_o_h, 1_I),
+        opus::make_tuple(0_I, lane_id % mma1.grpn_c, warp_id, lane_id / mma1.grpn_c));
+
+    // ── Load Q once. Rows past the GQA group fall outside the buffer and read 0. ──
+    const int64_t q_offset = static_cast<int64_t>(batch_idx) * kargs.stride_q_b
+                             + static_cast<int64_t>(q_head_base) * kargs.stride_q_h;
+    auto g_q = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.q_ptr) + q_offset,
+                         kargs.gqa_ratio * kargs.stride_q_h * sizeof(D_ATTN));
+    typename decltype(mma0)::vtype_a v_q = load<T::ELEM_A>(g_q, u_q);
+
+    typename decltype(mma0)::vtype_b v_k;
+    typename decltype(mma0)::vtype_c v_s;
+    typename decltype(mma1)::vtype_a v_p;
+    typename decltype(mma1)::vtype_b v_v;
+    typename decltype(mma1)::vtype_c v_o;
+    clear(v_o);
+
+    constexpr D_ACC LOG2_E = 1.44269504089f;
+    const D_ACC temperature_scale = kargs.softmax_scale * LOG2_E;
+
+    // Online softmax state, per lane rather than per LDS row. m is held equal
+    // across waves by the per-tile fold; l is this wave's own partial sum.
+    D_ACC m_run = opus::numeric_limits<D_ACC>::lowest();
+    D_ACC l_run = 0.0f;
+
+    const D_ATTN* p_k = reinterpret_cast<const D_ATTN*>(kargs.k_ptr) + kv_head_idx * kargs.stride_k_h;
+    const D_ATTN* p_v = reinterpret_cast<const D_ATTN*>(kargs.v_ptr) + kv_head_idx * kargs.stride_v_h;
+    // Rebased on this split's first page, and bounded to its last one so that
+    // the tail tile's over-read comes back as 0 instead of needing a guard.
+    auto g_bt = make_gmem(kargs.block_tables
+                              + static_cast<int64_t>(batch_idx) * kargs.max_blocks_per_batch_row
+                              + kv_start / T::PAGE_SIZE,
+                          num_pages * static_cast<unsigned int>(sizeof(int)));
+
+    // Single-buffered KV, double-buffered page ids.
+    //
+    // Each KV operand is refetched right after the GEMM that consumed it, so the
+    // next tile's loads stay in flight across the rest of the body: K's latency
+    // hides behind softmax and GEMM1, V's behind the next tile's GEMM0 and
+    // softmax. The fragments themselves need no second buffer, because one is
+    // dead as soon as its GEMM has issued -- a prefetch distance of two was
+    // measured and is worse everywhere, since the extra 64 VGPRs drop occupancy
+    // from 3 waves per SIMD to 2 and split-KV keeps enough workgroups in flight
+    // that losing a wave costs more than the extra distance pays.
+    //
+    // Double-buffering the ids was measured too, to break the dependent pair of
+    // HBM round trips they sit in front of (ids land, only then can the KV
+    // addresses be formed). It needs the loop unrolled by two to keep the buffer
+    // index compile time, and that costs 53 VGPRs -- not for the ids themselves,
+    // which are 10, but because two bodies' worth of temporaries are live at
+    // once. Occupancy drops to 2 and everything gets slower.
+    //
+    // The last tile is peeled out. Only it can run past the context, so the
+    // interior body needs neither the per-token mask nor a `has_next` guard.
+    // Both used to sit in the hot loop, and the guard was the more expensive:
+    // with the loads issued on one path only, the compiler cannot know how many
+    // are in flight at the loop header, so it fell back to vmcnt(0) before the
+    // last GEMM0 MFMA, draining V's prefetch in front of a GEMM that never
+    // needed V. Reads past the table are harmless -- num_records returns 0, and
+    // page 0's tokens are masked by the tail tile anyway.
+    const kv_frag_slice<T> kv_slice(lane_id, warp_id);
+    k_page_ids_t<T> k_pid = load_k_page_ids<T>(g_bt, 0, warp_id);
+    page_ids_t<T>   v_pid = load_page_ids<T>(g_bt, 0);
+    load_k_frags<T>(p_k, k_pid, kargs.stride_k_blk, kv_slice, v_k);
+    load_v_frags<T>(p_v, v_pid, kargs.stride_v_blk, kv_slice, v_v);
+
+    // MASKED and PREFETCH are compile time, so the tail instantiation shares no
+    // code with the loop body and neither branch survives into either.
+    auto run_tile = [&](int tile_idx, auto masked, auto prefetch) {
+        constexpr bool MASKED   = decltype(masked)::value != 0;
+        constexpr bool PREFETCH = decltype(prefetch)::value != 0;
+
+        if constexpr(PREFETCH)
+        {
+            k_pid = load_k_page_ids<T>(g_bt, tile_idx + 1, warp_id);
+            v_pid = load_page_ids<T>(g_bt, tile_idx + 1);
+        }
+        // Keep the block-table reads ahead of GEMM0 rather than letting the
+        // scheduler sink them among the MFMAs: every KV address for the next
+        // tile depends on them, and left alone the first address computation
+        // ends up a dozen instructions behind the load, stalling on it.
+        __builtin_amdgcn_sched_barrier(0);
+
+        v_s = mma0(v_q, v_k);
+        if constexpr(PREFETCH)
+            load_k_frags<T>(p_k, k_pid, kargs.stride_k_blk, kv_slice, v_k);
+
+        // Softmax happens in place on v_s, so this is also the P the store below
+        // hands to GEMM1. The one barrier inside is the cross-wave max fold.
+        const D_ACC rescale = online_softmax_frag<T, MASKED>(
+            v_s, s_red, m_run, l_run, temperature_scale, split_len, tile_idx, lane_id, warp_id);
+        opus::static_for<vector_traits<decltype(v_o)>::size()>(
+            [&](auto i) { v_o[i.value] *= rescale; });
+
+        auto v_p_out = cast<D_ATTN>(v_s);
+        store<4>(s_p, v_p_out, u_p);
+        opus::s_waitcnt_lgkmcnt(opus::number<0>{});
+        __builtin_amdgcn_s_barrier();
+
+        v_p = load<T::ELEM_A>(s_p, u_rp);
+        v_o = mma1(v_p, v_v, v_o);
+        if constexpr(PREFETCH)
+            load_v_frags<T>(p_v, v_pid, kargs.stride_v_blk, kv_slice, v_v);
+
+        // No trailing barrier: the next tile cannot overwrite s_p or s_red before
+        // its own max fold, and every wave has already issued its P reads by then.
+    };
+
+    for (int tile_idx = 0; tile_idx + 1 < num_tiles; ++tile_idx)
+        run_tile(tile_idx, 0_I, 1_I);
+    run_tile(num_tiles - 1, 1_I, 0_I);
+
+    // l is still a per-lane partial: a lane only summed its own quarter of the
+    // row, and only its own wave's tokens. Both folds can wait until here
+    // because summing is linear and a row's rescale is common to all its lanes.
+    // Reusing s_red is safe: the last tile read it before that tile's P barrier.
+    const D_ACC l_final = fold_across_waves<T>(
+        s_red,
+        wave_row_fold(l_run, [](D_ACC a, D_ACC b) { return a + b; }),
+        lane_id % T::W_M,
+        warp_id,
+        [](D_ACC a, D_ACC b) { return a + b; });
+
+    if(kargs.num_splits > 1)
+    {
+        // Publish the unnormalized accumulator with its (m, l) so the reducer can
+        // rescale across splits. Rows past the GQA group fall outside the bound.
+        auto u_po = partition_layout_c(
+            mma1, opus::make_tuple(number<T::D_HEAD>{}, 1_I),
+            opus::make_tuple(0_I, lane_id % mma1.grpn_c, warp_id, lane_id / mma1.grpn_c));
+        auto g_po = make_gmem(partial_o_ptr<T>(kargs, batch_idx, kv_head_idx, split_idx),
+                              kargs.gqa_ratio * T::D_HEAD * sizeof(D_ACC));
+        store<4>(g_po, v_o, u_po);
+
+        // Lanes 0..Q_TILE-1 of wave 0 sit on query rows 0..Q_TILE-1, so their
+        // register copies of m/l are exactly the per-row values to publish.
+        if(tid < T::Q_TILE)
+        {
+            float* p_ml           = partial_ml_ptr<T>(kargs, batch_idx, kv_head_idx, split_idx);
+            p_ml[tid]             = m_run;
+            p_ml[T::Q_TILE + tid] = l_final;
+        }
+
+        if(split_arrive_is_last<T>(kargs, batch_idx, kv_head_idx, tid))
+            reduce_splits<T>(kargs, batch_idx, kv_head_idx, tid, smem);
+        return;
+    }
+
+    // ── Normalize and write back. Rows past the GQA group are dropped by the buffer bound. ──
+    const D_ACC o_scale = l_final > D_ACC(0.0f) ? D_ACC(1.0f) / l_final : D_ACC(0.0f);
+    opus::static_for<vector_traits<decltype(v_o)>::size()>(
+        [&](auto i) { v_o[i.value] *= o_scale; });
+
+
+    const int64_t o_offset = static_cast<int64_t>(batch_idx) * kargs.stride_o_b
+                             + static_cast<int64_t>(q_head_base) * kargs.stride_o_h;
+    auto g_o = make_gmem(reinterpret_cast<D_ATTN*>(kargs.out_ptr) + o_offset,
+                         kargs.gqa_ratio * kargs.stride_o_h * sizeof(D_ATTN));
+    auto v_o_attn = cast<D_ATTN>(v_o);
+    store<4>(g_o, v_o_attn, u_o);
+}
+
+#else // !__gfx950__
+template<class Traits>
+__global__ void pa_decode_opus_kernel(pa_decode_kargs kargs) {}
+#endif
+
+#else // !__HIP_DEVICE_COMPILE__
+// Host pass only needs the launch stub; opus.hpp stays out of this translation pass.
+template<class Traits>
+__global__ void pa_decode_opus_kernel(pa_decode_kargs kargs) {}
+#endif // __HIP_DEVICE_COMPILE__
+
+#endif // PA_DECODE_OPUS_IMPL

--- a/csrc/include/pa_decode_opus.h
+++ b/csrc/include/pa_decode_opus.h
@@ -41,16 +41,9 @@ void pa_decode_opus_fwd(aiter_tensor_t& q,
 
 using bf16_t = __bf16;
 
-// KV tile depth: how many KV tokens one main-loop iteration consumes.
-//
-// K and V go straight from the cache into the matrix-core fragments, so the tile
-// is paid for in registers, not LDS, and occupancy tracks it directly. On gfx950
-// (VGPR+AGPR, waves/SIMD): 64 -> 89+8, 4;  128 -> 129+8, 3;  256 -> 217+16, 2;
-// 512 -> 256+161, 1; LDS stays under 17KB throughout and never binds. HBM
-// streaming is flat over 64..256 (two waves already saturate it) while a
-// cache-resident working set follows occupancy, so 128 is the compromise:
-// fastest of the four streaming, within 2.5% of the best cache-resident.
-// Re-measure with op_tests/sweep_kv_tile.sh and op_tests/kv_tile_resources.sh.
+// KV tile depth: how many KV tokens one main-loop iteration consumes. K and V go
+// straight into the MFMA fragments, so the tile is paid for in registers and sets
+// occupancy directly. Tune with op_tests/sweep_kv_tile.sh.
 #ifndef PA_DECODE_KV_TILE
 #define PA_DECODE_KV_TILE 128
 #endif
@@ -67,8 +60,8 @@ struct pa_decode_kargs
     // Split-KV scratch, only used when num_splits > 1.
     float* __restrict__ partial_o;  // [batch][num_kv_heads][num_splits][Q_TILE][D]
     float* __restrict__ partial_ml; // [batch][num_kv_heads][num_splits][2][Q_TILE]
-    // One arrival counter per (batch, kv-head). Zeroed at allocation, and left
-    // zeroed by whichever split arrives last, so no per-call memset is needed.
+    // One arrival counter per (batch, kv-head), left zeroed by whichever split
+    // arrives last, so no per-call memset is needed.
     unsigned int* __restrict__ split_counters;
     int num_splits;
     int batch;
@@ -99,12 +92,6 @@ struct pa_decode_kargs
 // Q is loaded once and O accumulates across tiles, so only K and V stream. Q_TILE
 // is the MFMA's M and also the largest GQA ratio supported, so one tile carries
 // every query head that shares this kv-head.
-//
-// The `16mx1_16nx4` namespace names GEMM0's wave tiling: `16mx1` = W_M=16 query
-// rows by T_M=1 wave, the whole Q_TILE; `16nx4` = W_N=16 tokens by T_N=4 waves,
-// one 64-token step along KV repeated GEMM0_E_N = KV_TILE/(W_N*T_N) times. The
-// name is thus independent of KV_TILE, unlike sp3's `64nx4`, which counts a
-// wave's KV columns.
 template<int D_HEAD_ = 128, int KV_TILE_ = 128, int PAGE_SIZE_ = 16, int NUM_WARPS_ = 4>
 struct pa_decode_traits
 {
@@ -119,10 +106,8 @@ struct pa_decode_traits
     static constexpr int BLOCK_SIZE = NUM_WARPS * WARP_SIZE;
     static constexpr int Q_TILE     = 16; // MFMA M, also the max supported GQA ratio
 
-    // Upper bound on KV splits: num_splits is a runtime value, but the fused
-    // merge indexes LDS by split, so this statically sizes that buffer. Raising
-    // it past the point where smem_reduce_bytes() overtakes the attention side
-    // grows LDS for every shape, including the ones that never split.
+    // Upper bound on KV splits: the fused merge indexes LDS by split, so this
+    // statically sizes that buffer.
     static constexpr int MAX_SPLITS = 64;
 
     // Wave tiling: 1 wave along M, all waves along N.
@@ -154,30 +139,24 @@ struct pa_decode_traits
     static constexpr int K_PACK = 16 / sizeof(D_ATTN);
     static constexpr int VEC    = 16 / sizeof(D_ATTN); // widest global vector, 8 bf16
 
-    // Lane counts, not thread groups: GRP is opus's name for the dims of an MFMA
-    // operand spread across lanes (the <p> dims of
-    // `B:[(grpn_b<p>), (rept_b, grpk_b<p>, pack_b)]` in opus.hpp). These restate
-    // mfma_adaptor::grpn_b/::grpk_b, unreachable here because the static_asserts
-    // below run before any mma object exists. The 64 lanes form a GRP_K by GRP_N
-    // grid: lane % GRP_N picks the N position, lane / GRP_N the contraction
-    // slice, VEC elements each, so the slices span W_K.
+    // Lane counts, not thread groups. The 64 lanes form a GRP_K by GRP_N grid:
+    // lane % GRP_N picks the N position, lane / GRP_N the contraction slice of VEC
+    // elements. Restates mfma_adaptor::grpn_b/::grpk_b, which the static_asserts
+    // below cannot reach because they run before any mma object exists.
     static constexpr int GRP_N = W_N;             // == mfma_adaptor::grpn_b
     static constexpr int GRP_K = WARP_SIZE / W_N; // == mfma_adaptor::grpk_b
     // How many lane groups share one page when walking V along tokens.
     static constexpr int KGRP_PER_PAGE = PAGE_SIZE / VEC;
 
-    // Only P is staged through LDS: K and V go straight from global into the
-    // matrix-core fragments and S never leaves registers, so LDS is needed only
-    // where a wave reads what another wave produced -- for P that is every
-    // element, since GEMM1 contracts the token dim that splits the waves. The
-    // tile is [Q_TILE][KV_TILE]; PAD staggers rows off each other's banks.
+    // Only P is staged through LDS: GEMM1 contracts the token dim that splits the
+    // waves, so every element crosses lanes. K, V and S never leave registers.
+    // The tile is [Q_TILE][KV_TILE]; PAD staggers rows off each other's banks.
     static constexpr int PAD          = 8;
     static constexpr int P_ROW_STRIDE = KV_TILE + PAD;
 
     static constexpr int smem_p_elems = Q_TILE * P_ROW_STRIDE;
-    // Cross-wave row reduction scratch, laid out [row][wave] so a row's T_N
-    // contributions fold with one 16B LDS read. Used twice at the same
-    // addresses: each tile's max fold, then the final l sum.
+    // Cross-wave row reduction scratch, [row][wave] so a row's T_N values fold in
+    // one 16B LDS read: each tile's max fold, then the final l sum.
     static constexpr int smem_row_reduce_elems = Q_TILE * T_N;
 
     static_assert(Q_TILE == W_M, "one MFMA tile along M");
@@ -186,9 +165,9 @@ struct pa_decode_traits
     static_assert(D_HEAD % (W_N * T_N) == 0);
     static_assert(KV_TILE % W_K == 0);
     static_assert(D_HEAD % W_K == 0);
-    // Softmax runs on the GEMM0 C fragment, where a query row is spread over the
-    // lanes {r, r+16, r+32, r+48} of each wave. That is exactly the reach of a
-    // permlane32/permlane16 swap pair, which is what lets S stay in registers.
+    // A query row lands on lanes {r, r+16, r+32, r+48} of the GEMM0 C fragment,
+    // exactly the reach of a permlane32/permlane16 pair -- what lets S stay in
+    // registers.
     static_assert(W_M == 16, "a C fragment row must span four 16-lane groups");
     static_assert(WARP_SIZE == 64);
 
@@ -204,12 +183,12 @@ struct pa_decode_traits
     static_assert(GEMM1_E_K * (GRP_K / KGRP_PER_PAGE) == PAGES_PER_TILE,
                   "V's K steps must walk exactly the tile's pages");
 
-    // The split-KV merge reuses this allocation -- the P tile and the row-reduce
-    // scratch are both dead by the time it runs -- so the union costs it no LDS.
-    // At KV_TILE=128 the attention side is the larger.
+    // Reused by the split-KV merge -- the P tile and row-reduce scratch are dead by
+    // then. Holds every split's (m, l) plus one reciprocal per query row; the
+    // per-split scale overwrites m in place.
     static constexpr size_t smem_reduce_bytes()
     {
-        return static_cast<size_t>(MAX_SPLITS * Q_TILE + Q_TILE) * sizeof(D_ACC);
+        return static_cast<size_t>(2 * MAX_SPLITS * Q_TILE + Q_TILE) * sizeof(D_ACC);
     }
 
     static constexpr size_t smem_size_bytes()
@@ -258,18 +237,12 @@ __device__ inline float* partial_o_ptr(const pa_decode_kargs& kargs, int b, int 
     return kargs.partial_o + partial_slot<T>(kargs, b, kvh, split) * T::Q_TILE * T::D_HEAD;
 }
 
-// Where this lane's K and V fragments sit inside a page. Only the page base
-// moves per tile, so this is computed once.
-//
-// The cache layouts hand the matrix cores exactly what they want: a B fragment
-// needs lane l to hold column l%16 and 8 consecutive contraction positions, and
-// both caches store those 8 values in 16 contiguous bytes (K is
-// [D/K_PACK][PAGE][K_PACK], a lane walks one token's head dims; V is [D][PAGE],
-// a lane walks 8 tokens of one head dim). Every fragment is one dwordx4 straight
-// from the cache, and the KV tile never goes through LDS. K lines one MFMA tile
-// up with one page (GRP_N == PAGE_SIZE) so its page index is wave-uniform; V
-// spans PAGE_SIZE/VEC lane groups per page, so its index alternates on the upper
-// half of the wave.
+// Where this lane's K and V fragments sit inside a page; only the page base moves
+// per tile, so this is computed once. Both caches already store a lane's 8
+// contraction values in 16 contiguous bytes (K is [D/K_PACK][PAGE][K_PACK], a lane
+// walks one token's head dims; V is [D][PAGE], a lane walks 8 tokens of one head
+// dim), so every fragment is one dwordx4 and the KV tile never goes through LDS.
+// K's page index is wave-uniform; V's alternates on the upper half of the wave.
 template<class T>
 struct kv_frag_slice
 {
@@ -290,27 +263,17 @@ struct kv_frag_slice
     }
 };
 
-// Page indices for one KV tile, kept in registers a full iteration ahead of the
-// KV loads that consume them.
+// Page indices for one KV tile, kept in registers an iteration ahead of the loads.
 template<class T>
 struct page_ids_t
 {
     int id[T::PAGES_PER_TILE];
 };
 
-// Read one tile's worth of block-table entries.
-//
-// The buffer's num_records stops at this split's last page, so a slot past the
-// end reads 0 with no bounds check in the instruction stream. Page 0 is a valid
-// index, but the tokens it stands in for sit past the context length, so the
-// tail tile masks their scores anyway. The buffer (rather than a raw pointer) is
-// what keeps the reads wide: an explicit guard -- branch or clamp -- makes every
-// slot its own expression, costing a dword load plus a 64-bit address chain per
-// page against two dwordx4 for the whole tile here.
-//
-// Hoisting the wave-uniform ids into SGPRs with readfirstlane measured as a wash:
-// readfirstlane has to wait on the load, which anchors the block-table round trip
-// in front of GEMM0 instead of letting the address math sink in among the MFMAs.
+// Read one tile's worth of block-table entries. The buffer's num_records stops at
+// this split's last page, so a slot past the end reads 0 with no bounds check in
+// the instruction stream; page 0 is a valid index, but the tail tile masks the
+// scores of the tokens it stands in for. Two dwordx4 cover the whole tile.
 template<class T, class G>
 __device__ inline page_ids_t<T> load_page_ids(G& g_bt, int tile_idx)
 {
@@ -324,10 +287,9 @@ __device__ inline page_ids_t<T> load_page_ids(G& g_bt, int tile_idx)
     return pid;
 }
 
-// Page indices for the K fragments of one wave. A K MFMA tile is exactly one
-// page, so wave w only ever reads pages {i_n * T_N + w}. Reading just those
-// keeps the array indices compile-time constant; indexing the whole-tile array
-// by a runtime wave id becomes an s_cselect chain or spills to scratch.
+// Page indices for the K fragments of one wave. A K MFMA tile is exactly one page,
+// so wave w only ever reads pages {i_n * T_N + w}; reading just those keeps the
+// array indices compile-time constant instead of an s_cselect chain.
 template<class T>
 struct k_page_ids_t
 {
@@ -346,16 +308,11 @@ __device__ inline k_page_ids_t<T> load_k_page_ids(G& g_bt, int tile_idx, int war
     return pid;
 }
 
-// Read one tile's K fragments straight from the cache into the matrix-core
-// operand. Deliberately does not wait on the results: the caller issues these
-// right after the GEMM that consumed the previous tile, so the latency hides
-// behind the rest of the loop body.
-//
-// Addressed by pointer, not buffer: a buffer offset is 32-bit and would cap the
-// cache at 4GiB, and no scalar base can lift that since V's page index varies
-// per lane (the halves of a wave read adjacent pages). Buffer addressing measured
-// identical where it fits -- the widening multiply and 64-bit add per page
-// disappear into the memory latency.
+// Read one tile's K fragments straight from the cache into the matrix-core operand.
+// Deliberately does not wait on the results: the caller issues these right after the
+// GEMM that consumed the previous tile, so the latency hides in the loop body.
+// Pointer-addressed, not buffer: a buffer offset is 32-bit and would cap the cache
+// at 4GiB, and V's per-lane page index leaves no scalar base to lift it.
 template<class T, class VB>
 __device__ inline void load_k_frags(const typename T::D_ATTN* __restrict__ p_k,
                                     const k_page_ids_t<T>& pid,
@@ -414,24 +371,18 @@ __device__ inline void load_v_frags(const typename T::D_ATTN* __restrict__ p_v,
     });
 }
 
-// All-reduce a query row inside one wave.
-//
-// After swap_ab the C fragment puts query row r on lanes {r, r+16, r+32, r+48},
-// so folding a row is a pair swap at distance 32 then one at distance 16 -- two
-// gfx950 VALU ops, no LDS and no barrier, which is what lets the score tile stay
-// in registers. A lane covers only a quarter of a row, so every row-wide
-// quantity has to pass through here to mean anything.
+// All-reduce a query row inside one wave: a swap at distance 32 then one at 16,
+// which reaches the whole row since it sits on lanes {r, r+16, r+32, r+48}. A lane
+// covers only a quarter of a row, so every row-wide quantity passes through here.
 //
 // Must be inline asm, not __builtin_amdgcn_permlane*_swap: the intrinsic returns
 // both halves as one vector, and when both operands hold the same value -- how an
-// all-reduce uses it -- the compiler folds them into one register. The second
-// half is lost and the fold collapses to op(v, v): invisible for max, badly
-// wrong for a sum.
+// all-reduce uses it -- the compiler folds them into one register, collapsing the
+// fold to op(v, v). Invisible for max, wrong for a sum.
 //
-// Inline asm also costs us the hazard recognizer, so the wait states are supplied
-// here. Per LLVM's GCNHazardRecognizer for gfx950 a VALU write to an operand
-// needs 2 wait states before the swap reads it and a v_cmpx writing exec needs 4;
-// s_nop 3 covers both. Reading the result afterwards needs none.
+// Inline asm also loses the hazard recognizer. Per LLVM's GCNHazardRecognizer for
+// gfx950, a VALU write needs 2 wait states before the swap reads it and a v_cmpx
+// writing exec needs 4; s_nop 3 covers both.
 #define PA_SWAP_HAZARD "s_nop 3\n\t"
 
 __device__ inline void permlane32_swap(float& a, float& b)
@@ -455,14 +406,12 @@ __device__ inline float wave_row_fold(float v, OP op)
     return op(a, b);
 }
 
-// Publish this wave's row value and fold the T_N of them, through LDS. Each wave
-// holds a partial for every query row, so the exchange is T_N contiguous floats
-// per row -- one 16B read. This barrier is the only one the whole softmax needs.
+// Publish this wave's row value and fold the T_N of them through LDS -- T_N
+// contiguous floats per row, one 16B read, and the only barrier softmax needs.
 //
-// s_row_reduce is deliberately not __restrict__, and the barrier is the fenced
-// __syncthreads rather than a bare s_barrier: every wave writes and reads this
-// scratch, twice per kernel at the same addresses, and a plain s_barrier only
-// orders execution -- the compiler would be free to carry the first fold's
+// s_row_reduce is deliberately not __restrict__ and the barrier is the fenced
+// __syncthreads, not a bare s_barrier: both call sites hit the same addresses, and
+// s_barrier only orders execution, so the compiler could carry the first fold's
 // loaded values across it and reuse them for the second.
 template<class T, class OP>
 __device__ inline typename T::D_ACC
@@ -482,20 +431,14 @@ fold_across_waves(typename T::D_ACC* s_row_reduce,
 }
 
 // Masked online softmax over the GEMM0 C fragment, in registers. Returns the
-// rescale factor for the caller's O accumulator.
-//
-// S never reaches LDS: lane l of wave w owns query row l % W_M and, per N
-// fragment, ELEM_C consecutive tokens, so folding a row is a permlane pair
-// inside the wave plus one float between waves -- against a full
-// [Q_TILE][KV_TILE] fp32 round trip if the tile went through LDS.
+// rescale factor for the caller's O accumulator. Lane l of wave w owns query row
+// l % W_M and, per N fragment, ELEM_C consecutive tokens.
 //
 // m_run must stay identical across waves, since the P they all write feeds one
 // GEMM and needs one common scale. l_run needs no such agreement, so it stays an
 // unfolded per-lane partial, reduced once after the last tile.
 //
-// MASKED is false for every tile but the last, the only one that can run past the
-// context. The check is 3 VALU per C fragment element, worth specialising rather
-// than covering with a uniform branch.
+// MASKED is true only for the last tile, the only one that can run past the context.
 template<class T, bool MASKED, class VC>
 __device__ inline typename T::D_ACC
 online_softmax_frag(VC& v_s,
@@ -552,22 +495,18 @@ online_softmax_frag(VC& v_s,
     return rescale;
 }
 
-// Announce that this split is done, and report whether it was the last one.
-//
-// The merge is fused rather than a second kernel: that launch cost 4-5us of
-// almost pure dispatch, more than the split-KV path was buying back. Nothing
-// ever waits on the counter -- it only tells the last arrival, which already
-// has the machine, that every partial is in memory.
+// Announce that this split is done, and report whether it was the last one. Nothing
+// ever waits on the counter -- it only tells that last arrival, which already has
+// the machine, that every partial is in memory.
 template<class T>
 __device__ inline bool split_arrive_is_last(const pa_decode_kargs& kargs, int b, int kvh, int tid)
 {
     __shared__ int s_last;
 
-    // Release for the whole block: the barrier orders every thread's partial
-    // stores ahead of the counter bump, the waitcnt makes sure they retired.
-    // The textbook __threadfence() cost 28us of a 41us kernel -- on a multi-XCD
-    // part an agent-scope release writes back all of L2, evicting the KV stream.
-    // Uncached scratch removes the need: the stores retire at the coherence point.
+    // Release for the whole block: the barrier orders every thread's partial stores
+    // ahead of the counter bump, the waitcnt makes sure they retired. An agent-scope
+    // release (__threadfence) would write back all of L2 on a multi-XCD part; the
+    // scratch is uncached instead, so the stores retire at the coherence point.
     __syncthreads();
     __builtin_amdgcn_s_waitcnt(0);
 
@@ -576,8 +515,7 @@ __device__ inline bool split_arrive_is_last(const pa_decode_kargs& kargs, int b,
         unsigned int* slot = kargs.split_counters + b * kargs.num_kv_heads + kvh;
         const unsigned int prev = atomicAdd(slot, 1u);
         const bool last = prev + 1u == static_cast<unsigned int>(kargs.num_splits);
-        // The buffer is zeroed once at allocation and never again, so the last
-        // arrival is what leaves it clean for the next launch.
+        // Zeroed once at allocation; the last arrival leaves it clean for the next.
         if(last) atomicExch(slot, 0u);
         s_last = last ? 1 : 0;
     }
@@ -597,16 +535,24 @@ __device__ inline void reduce_splits(const pa_decode_kargs& kargs, int b, int kv
     const D_ACC* p_ml = partial_ml_ptr<T>(kargs, b, kvh, 0);
     const D_ACC* p_o  = partial_o_ptr<T>(kargs, b, kvh, 0);
 
-    // Carved out of the attention body's buffer, which is dead by now.
-    auto* s_scale = reinterpret_cast<D_ACC*>(smem);
-    auto* s_inv_l = s_scale + T::MAX_SPLITS * T::Q_TILE;
+    // Carved out of the attention body's buffer, dead by now. Mirrors the scratch
+    // layout [split][2][Q_TILE], so the staging below is a straight copy.
+    auto* s_ml    = reinterpret_cast<D_ACC*>(smem);
+    auto* s_inv_l = s_ml + 2 * T::MAX_SPLITS * T::Q_TILE;
+
+    // Stage with the whole block: read straight out of global this would be a
+    // quarter wave walking 2*splits dependent loads through uncached scratch.
+    const int ml_elems = splits * 2 * T::Q_TILE;
+    for(int i = tid; i < ml_elems; i += T::BLOCK_SIZE)
+        s_ml[i] = p_ml[i];
+    __syncthreads();
 
     if(tid < T::Q_TILE)
     {
         D_ACC m_max = -opus::numeric_limits<D_ACC>::max();
         for(int i = 0; i < splits; ++i)
         {
-            const D_ACC m = p_ml[static_cast<int64_t>(i) * 2 * T::Q_TILE + tid];
+            const D_ACC m = s_ml[i * 2 * T::Q_TILE + tid];
             if(m > m_max) m_max = m;
         }
 
@@ -614,10 +560,10 @@ __device__ inline void reduce_splits(const pa_decode_kargs& kargs, int b, int kv
         D_ACC l_sum = 0.0f;
         for(int i = 0; i < splits; ++i)
         {
-            const int64_t base = static_cast<int64_t>(i) * 2 * T::Q_TILE;
-            const D_ACC c      = __builtin_amdgcn_exp2f(p_ml[base + tid] - m_max);
-            s_scale[i * T::Q_TILE + tid] = c;
-            l_sum += p_ml[base + T::Q_TILE + tid] * c;
+            const int base   = i * 2 * T::Q_TILE;
+            const D_ACC c    = __builtin_amdgcn_exp2f(s_ml[base + tid] - m_max);
+            l_sum           += s_ml[base + T::Q_TILE + tid] * c;
+            s_ml[base + tid] = c; // only this thread owns the slot
         }
         s_inv_l[tid] = l_sum > D_ACC(0.0f) ? D_ACC(1.0f) / l_sum : D_ACC(0.0f);
     }
@@ -627,9 +573,8 @@ __device__ inline void reduce_splits(const pa_decode_kargs& kargs, int b, int kv
                 + static_cast<int64_t>(b) * kargs.stride_o_b
                 + static_cast<int64_t>(kvh) * kargs.gqa_ratio * kargs.stride_o_h;
 
-    // Four dims per thread, over only the rows the GQA group has: the partials are
-    // contiguous along the head dim, and bounding by gqa_ratio keeps gqa<16 from
-    // spending iterations on rows it would then discard.
+    // Four dims per thread, bounded by gqa_ratio so gqa<16 spends no iterations on
+    // rows it would discard. The partials are contiguous along the head dim.
     constexpr int VEC      = 4;
     constexpr int ROW_VECS = T::D_HEAD / VEC;
     const int vec_total    = kargs.gqa_ratio * ROW_VECS;
@@ -640,12 +585,30 @@ __device__ inline void reduce_splits(const pa_decode_kargs& kargs, int b, int kv
         const int dim       = (idx - row * ROW_VECS) * VEC;
         const int64_t o_row = static_cast<int64_t>(row) * T::D_HEAD + dim;
 
-        D_ACC acc[VEC] = {0.0f, 0.0f, 0.0f, 0.0f};
-        for(int i = 0; i < splits; ++i)
-        {
-            const D_ACC c = s_scale[i * T::Q_TILE + row];
-            const auto v  = *reinterpret_cast<const opus::vector_t<D_ACC, VEC>*>(
+        using vec_t = opus::vector_t<D_ACC, VEC>;
+        auto slice  = [&](int i) {
+            return reinterpret_cast<const vec_t*>(
                 p_o + static_cast<int64_t>(i) * T::Q_TILE * T::D_HEAD + o_row);
+        };
+
+        // Unrolled so several splits' loads are in flight: the trip count is a
+        // runtime value, and the accumulate chain otherwise lets only one issue.
+        constexpr int UNROLL = 4;
+        D_ACC acc[VEC]       = {0.0f, 0.0f, 0.0f, 0.0f};
+        int i                = 0;
+        for(; i + UNROLL <= splits; i += UNROLL)
+        {
+            vec_t v[UNROLL];
+            opus::static_for<UNROLL>([&](auto u) { v[u.value] = *slice(i + u.value); });
+            opus::static_for<UNROLL>([&](auto u) {
+                const D_ACC c = s_ml[(i + u.value) * 2 * T::Q_TILE + row];
+                opus::static_for<VEC>([&](auto j) { acc[j.value] += v[u.value][j.value] * c; });
+            });
+        }
+        for(; i < splits; ++i)
+        {
+            const D_ACC c = s_ml[i * 2 * T::Q_TILE + row];
+            const vec_t v = *slice(i);
             opus::static_for<VEC>([&](auto j) { acc[j.value] += v[j.value] * c; });
         }
 
@@ -676,18 +639,14 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
     const int lane_id = tid % T::WARP_SIZE;
     const int warp_id = __builtin_amdgcn_readfirstlane(tid / T::WARP_SIZE);
 
-    // ── LDS layout: bf16 P | cross-wave reduction scratch ──
-    //
-    // Everything else stays in registers. P is the one operand that genuinely has
-    // to cross lanes: GEMM0 produces it in the C layout, GEMM1 consumes it in the
-    // A layout, and it contracts the token dim -- exactly the dim split across
-    // the waves. Declared this early because the split-KV merge borrows it too,
-    // and an empty split can reach the merge without running the attention body.
+    // LDS layout: bf16 P | cross-wave reduction scratch. Everything else stays in
+    // registers. Declared this early because the split-KV merge borrows the same
+    // allocation, and an empty split reaches the merge without running the body.
     __shared__ __align__(16) char smem[T::smem_size_bytes()];
 
-    // Split-KV: each workgroup owns a contiguous run of whole tiles. Splitting on
-    // tile (not token) boundaries keeps kv_start page-aligned, so the block table
-    // can simply be re-based and the rest of the kernel stays split-agnostic.
+    // Split-KV: each workgroup owns a contiguous run of whole tiles. Tile-aligned
+    // splits keep kv_start page-aligned, so the block table is simply re-based and
+    // the rest of the kernel stays split-agnostic.
     const int context_len = kargs.context_lens[batch_idx];
     const int tiles_total = (context_len + T::KV_TILE - 1) / T::KV_TILE;
     const int tiles_per_split = (tiles_total + kargs.num_splits - 1) / kargs.num_splits;
@@ -705,8 +664,7 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
                 p_ml[tid]             = -opus::numeric_limits<float>::max();
                 p_ml[T::Q_TILE + tid] = 0.0f;
             }
-            // Still has to arrive, or the split that does finish last would be
-            // waiting on a count that never completes.
+            // Still has to arrive, or the last split waits on a count that never completes.
             if(split_arrive_is_last<T>(kargs, batch_idx, kv_head_idx, tid))
                 reduce_splits<T>(kargs, batch_idx, kv_head_idx, tid, smem);
         }
@@ -737,14 +695,12 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
         seq<T::W_M, T::W_N, T::W_K>{},
         mfma_adaptor_swap_ab{});
 
-    // Every operand is a plain row-major matrix, so the register fragment layout
-    // comes straight from the mma adaptor instead of being hand-derived.
+    // Every operand is plain row-major, so the fragment layouts come from the adaptor.
     const int q_head_base = kv_head_idx * kargs.gqa_ratio;
     auto u_q  = partition_layout_a<T::ELEM_A>(
         mma0, opus::make_tuple(kargs.stride_q_h, 1_I),
         opus::make_tuple(0_I, lane_id % mma0.grpm_a, 0_I, lane_id / mma0.grpm_a));
-    // Writes P out of the C fragment: the mapping the score tile used to be stored
-    // with, now applied once, to bf16, after softmax has run in registers.
+    // Writes P out of the C fragment, to bf16, after softmax has run in registers.
     auto u_p  = partition_layout_c(
         mma0, opus::make_tuple(number<T::P_ROW_STRIDE>{}, 1_I),
         opus::make_tuple(0_I, lane_id % mma0.grpn_c, warp_id, lane_id / mma0.grpn_c));
@@ -786,27 +742,19 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
                               + kv_start / T::PAGE_SIZE,
                           num_pages * static_cast<unsigned int>(sizeof(int)));
 
-    // Single-buffered KV and page ids, both prefetched one tile ahead. Each KV
-    // operand is refetched right after the GEMM that consumed it, so its load
-    // stays in flight for the rest of the body: K hides behind softmax and GEMM1,
-    // V behind the next tile's GEMM0. A fragment dies as its GEMM issues, so
-    // deeper buffering only buys occupancy loss -- prefetch distance two
-    // (+64 VGPRs) and double-buffered ids (+53, from unrolling by two, not from
-    // the 10 the ids need) both drop 3 waves/SIMD to 2 and measured slower.
-    //
-    // The last tile is peeled out: only it can run past the context, so the
-    // interior body needs neither the per-token mask nor a `has_next` guard. The
-    // guard cost more -- with the loads on one path only, the compiler cannot know
-    // how many are in flight at the loop header, and fell back to vmcnt(0) before
-    // the last GEMM0 MFMA, draining V's prefetch.
+    // Single-buffered KV and page ids, prefetched one tile ahead. Each KV operand is
+    // refetched right after the GEMM that consumed it, so its load stays in flight
+    // for the rest of the body: K hides behind softmax and GEMM1, V behind the next
+    // tile's GEMM0. The last tile is peeled out -- only it can run past the context,
+    // so the interior body needs neither the mask nor a `has_next` guard.
     const kv_frag_slice<T> kv_slice(lane_id, warp_id);
     k_page_ids_t<T> k_pid = load_k_page_ids<T>(g_bt, 0, warp_id);
     page_ids_t<T>   v_pid = load_page_ids<T>(g_bt, 0);
     load_k_frags<T>(p_k, k_pid, kargs.stride_k_blk, kv_slice, v_k);
     load_v_frags<T>(p_v, v_pid, kargs.stride_v_blk, kv_slice, v_v);
 
-    // MASKED and PREFETCH are compile time, so the tail instantiation shares no
-    // code with the loop body and neither branch survives into either.
+    // MASKED and PREFETCH are compile time, so neither branch survives into either
+    // instantiation.
     auto run_tile = [&](int tile_idx, auto masked, auto prefetch) {
         constexpr bool MASKED   = decltype(masked)::value != 0;
         constexpr bool PREFETCH = decltype(prefetch)::value != 0;
@@ -816,10 +764,9 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
             k_pid = load_k_page_ids<T>(g_bt, tile_idx + 1, warp_id);
             v_pid = load_page_ids<T>(g_bt, tile_idx + 1);
         }
-        // Keep the block-table reads ahead of GEMM0 instead of letting the
-        // scheduler sink them among the MFMAs: every KV address for the next tile
-        // depends on them, and left alone the first address computation lands a
-        // dozen instructions behind the load and stalls on it.
+        // Keep the block-table reads ahead of GEMM0: every KV address for the next
+        // tile depends on them, so letting the scheduler sink them among the MFMAs
+        // puts the first address computation right behind the load.
         __builtin_amdgcn_sched_barrier(0);
 
         v_s = mma0(v_q, v_k);
@@ -852,10 +799,10 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 1) void pa_decode_opus_kernel(p
         run_tile(tile_idx, 0_I, 1_I);
     run_tile(num_tiles - 1, 1_I, 0_I);
 
-    // l is still a per-lane partial: a lane summed only its own quarter of the row
-    // and only its own wave's tokens. Both folds can wait until here because
-    // summing is linear and a row's rescale is common to all its lanes. Reusing
-    // s_row_reduce is safe -- the last tile read it before that tile's P barrier.
+    // l is still a per-lane partial: a lane summed only its own quarter of the row,
+    // and only its own wave's tokens. Both folds can wait until here because summing
+    // is linear. Reusing s_row_reduce is safe -- the last tile read it before that
+    // tile's P barrier.
     const D_ACC l_final = fold_across_waves<T>(
         s_row_reduce,
         wave_row_fold(l_run, [](D_ACC a, D_ACC b) { return a + b; }),

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1471,6 +1471,17 @@ namespace py = pybind11;
           py::arg("m_indices")         = std::nullopt, \
           py::arg("reverse_sorted")    = std::nullopt);
 
+#define PA_DECODE_OPUS_PYBIND          \
+    m.def("pa_decode_opus_fwd",        \
+          &pa_decode_opus_fwd,         \
+          py::arg("q"),                \
+          py::arg("k_cache"),          \
+          py::arg("v_cache"),          \
+          py::arg("block_tables"),     \
+          py::arg("context_lens"),     \
+          py::arg("out"),              \
+          py::arg("softmax_scale"));
+
 #define PA_SPARSE_PREFILL_OPUS_PYBIND       \
     m.def("pa_sparse_prefill_opus_fwd",     \
           &pa_sparse_prefill_opus_fwd,      \

--- a/csrc/py_itfs_cu/pa_decode_opus_kernels.cu
+++ b/csrc/py_itfs_cu/pa_decode_opus_kernels.cu
@@ -179,8 +179,8 @@ void pa_decode_opus_fwd(aiter_tensor_t& q,
     // a second pass to merge the per-split softmax partials. Large batches already
     // fill the machine, so they keep the single-pass path.
     //
-    // The second pass is not free: it costs a workspace allocation, an extra launch
-    // and a round trip through global memory, which measures at roughly 2us. Short
+    // The second pass is not free: even fused into the last arriving workgroup it
+    // costs a workspace allocation and a round trip through global memory. Short
     // contexts have to be kept off this path or the merge outweighs the parallelism
     // it buys, so every split is required to carry a few tiles of its own.
     constexpr int min_tiles_per_split = 4;

--- a/csrc/py_itfs_cu/pa_decode_opus_kernels.cu
+++ b/csrc/py_itfs_cu/pa_decode_opus_kernels.cu
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// OPUS-based paged-attention decode.
+// Hosts launcher + validation on top of the device kernel template in
+// `pa_decode_opus.h` (single-header, IMPL-guarded).
+
+#define PA_DECODE_OPUS_IMPL
+#include "pa_decode_opus.h"
+
+#include "aiter_hip_common.h"
+#include "aiter_stream.h"
+#include "aiter_tensor.h"
+
+#include <mutex>
+#include <unordered_map>
+
+// Split-KV scratch, allocated once per stream and kept for the process.
+//
+// A per-call hipMallocAsync/hipFreeAsync pair is not affordable here. At small
+// batch the kernel itself takes only a few microseconds, so the launch path --
+// two stream-ordered allocator calls on top of the launch itself -- is what the
+// benchmark actually measures. Even against a primed pool, the two API calls
+// stay on the critical path of every decode step.
+//
+// A fixed buffer works because the slot count is structurally bounded: splits
+// are chosen so that base_wgs * num_splits <= num_cu, so no batch shape can ask
+// for more slots than the device has CUs. That caps the scratch at a couple of
+// MB, which is worth holding onto permanently. Since it never grows, there is
+// also no allocation to trip over during HIP graph capture.
+//
+// Keyed by stream, like the opus_gemm splitk workspace: concurrent streams must
+// not share one buffer or their partials would overwrite each other.
+namespace {
+struct SplitScratchRegistry
+{
+    std::mutex mu;
+    std::unordered_map<hipStream_t, void*> map;
+};
+SplitScratchRegistry& split_scratch_registry()
+{
+    static SplitScratchRegistry r;
+    return r;
+}
+} // namespace
+
+static void* split_scratch_get(hipStream_t stream, size_t bytes)
+{
+    auto& reg = split_scratch_registry();
+    std::lock_guard<std::mutex> lock(reg.mu);
+
+    auto it = reg.map.find(stream);
+    if(it != reg.map.end()) return it->second;
+
+    hipStreamCaptureStatus capture = hipStreamCaptureStatusNone;
+    HIP_CALL(hipStreamIsCapturing(stream, &capture));
+    AITER_CHECK(capture == hipStreamCaptureStatusNone,
+                "pa_decode_opus split-KV scratch cannot be created during HIP graph "
+                "capture (hipMalloc is capture-illegal). Run one split-KV decode "
+                "eagerly on this stream before capturing.");
+
+    void* ptr = nullptr;
+    // Uncached, so the partials are visible device-wide as soon as the stores
+    // retire. This buffer is the one place the split workgroups hand data to
+    // each other, and on a multi-XCD part the L2s are not coherent between them,
+    // so the alternative is a __threadfence() in every split -- which writes back
+    // the whole L2 and measured at 28us of the 41us kernel. Bypassing the cache
+    // for these few KB is far cheaper than flushing it for everything else.
+    HIP_CALL(hipExtMallocWithFlags(&ptr, bytes, hipDeviceMallocUncached));
+    // The arrival counters at the tail have to start at zero. This is the only
+    // time they are cleared: the kernel's last split resets its own counter, so
+    // the buffer comes back clean after every launch.
+    HIP_CALL(hipMemset(ptr, 0, bytes));
+    reg.map[stream] = ptr;
+    return ptr;
+}
+
+void pa_decode_opus_fwd(aiter_tensor_t& q,
+                        aiter_tensor_t& k_cache,
+                        aiter_tensor_t& v_cache,
+                        aiter_tensor_t& block_tables,
+                        aiter_tensor_t& context_lens,
+                        aiter_tensor_t& out,
+                        float softmax_scale)
+{
+    using Traits = pa_decode_traits_d128;
+
+    // ---- Shape / dtype validation -----------------------------------------
+    AITER_CHECK(q.dim() == 3, "q must be 3-D [batch, num_heads, D], got ndim=", q.dim());
+    AITER_CHECK(out.dim() == 3, "out must be 3-D [batch, num_heads, D], got ndim=", out.dim());
+    AITER_CHECK(k_cache.dim() == 5,
+                "k_cache must be 5-D [num_blocks, num_kv_heads, D/x, page, x], got ndim=",
+                k_cache.dim());
+    AITER_CHECK(v_cache.dim() == 4,
+                "v_cache must be 4-D [num_blocks, num_kv_heads, D, page], got ndim=",
+                v_cache.dim());
+    AITER_CHECK(block_tables.dim() == 2,
+                "block_tables must be 2-D [batch, max_blocks_per_batch_row]");
+    AITER_CHECK(context_lens.dim() == 1, "context_lens must be 1-D [batch]");
+
+    AITER_CHECK(q.dtype() == AITER_DTYPE_bf16 && out.dtype() == AITER_DTYPE_bf16,
+                "pa_decode_opus_fwd currently compiles bf16 only");
+    AITER_CHECK(k_cache.dtype() == AITER_DTYPE_bf16 && v_cache.dtype() == AITER_DTYPE_bf16,
+                "k_cache/v_cache must be bf16 (A16W16)");
+    AITER_CHECK(block_tables.dtype() == AITER_DTYPE_i32, "block_tables must be int32");
+    AITER_CHECK(context_lens.dtype() == AITER_DTYPE_i32, "context_lens must be int32");
+
+    const int batch        = static_cast<int>(q.size(0));
+    const int num_heads    = static_cast<int>(q.size(1));
+    const int head_size    = static_cast<int>(q.size(2)); //head_dim
+    const int num_kv_heads = static_cast<int>(k_cache.size(1));
+    const int page_size    = static_cast<int>(v_cache.size(3));
+
+    AITER_CHECK(head_size == Traits::D_HEAD,
+                "Only head_size=", Traits::D_HEAD, " is compiled, got ", head_size);
+    AITER_CHECK(page_size == Traits::PAGE_SIZE,
+                "Only page size=", Traits::PAGE_SIZE, " is compiled, got ", page_size);
+    AITER_CHECK(static_cast<int>(k_cache.size(4)) == Traits::K_PACK,
+                "k_cache pack factor x must be ", Traits::K_PACK, " for bf16");
+    AITER_CHECK(static_cast<int>(k_cache.size(2)) == Traits::D_HEAD / Traits::K_PACK,
+                "k_cache dim-group count must be D/x");
+    AITER_CHECK(static_cast<int>(k_cache.size(3)) == Traits::PAGE_SIZE,
+                "k_cache page dim mismatch");
+    AITER_CHECK(static_cast<int>(v_cache.size(2)) == Traits::D_HEAD, "v_cache head dim mismatch");
+    AITER_CHECK(static_cast<int>(v_cache.size(1)) == num_kv_heads,
+                "k_cache/v_cache must agree on num_kv_heads");
+
+    AITER_CHECK(num_kv_heads > 0 && num_heads % num_kv_heads == 0,
+                "num_heads must be divisible by num_kv_heads");
+    const int gqa_ratio = num_heads / num_kv_heads;
+    AITER_CHECK(gqa_ratio <= Traits::Q_TILE,
+                "GQA ratio must be <= ", Traits::Q_TILE, ", got ", gqa_ratio);
+
+    AITER_CHECK(out.size(0) == batch && out.size(1) == num_heads && out.size(2) == head_size,
+                "out shape must match q");
+    AITER_CHECK(block_tables.size(0) == batch, "block_tables first dim must be batch");
+    AITER_CHECK(context_lens.size(0) == batch, "context_lens length must be batch");
+
+    AITER_CHECK(q.stride(2) == 1 && out.stride(2) == 1,
+                "q/out must be contiguous along the head dim");
+    AITER_CHECK(k_cache.is_contiguous() && v_cache.is_contiguous(),
+                "k_cache/v_cache must be contiguous");
+    AITER_CHECK(block_tables.is_contiguous() && context_lens.is_contiguous(),
+                "block_tables/context_lens must be contiguous");
+
+    if(batch == 0) return;
+
+    // ---- Build kernel args -------------------------------------------------
+    pa_decode_kargs kargs{};
+    kargs.q_ptr                    = q.data_ptr();
+    kargs.k_ptr                    = k_cache.data_ptr();
+    kargs.v_ptr                    = v_cache.data_ptr();
+    kargs.out_ptr                  = out.data_ptr();
+    kargs.block_tables             = reinterpret_cast<const int*>(block_tables.data_ptr());
+    kargs.context_lens             = reinterpret_cast<const int*>(context_lens.data_ptr());
+    kargs.batch                    = batch;
+    kargs.num_heads                = num_heads;
+    kargs.num_kv_heads             = num_kv_heads;
+    kargs.gqa_ratio                = gqa_ratio;
+    kargs.max_blocks_per_batch_row = static_cast<int>(block_tables.size(1));
+    kargs.stride_q_b               = static_cast<int>(q.stride(0));
+    kargs.stride_q_h               = static_cast<int>(q.stride(1));
+    kargs.stride_o_b               = static_cast<int>(out.stride(0));
+    kargs.stride_o_h               = static_cast<int>(out.stride(1));
+    kargs.stride_k_blk             = static_cast<int>(k_cache.stride(0));
+    kargs.stride_k_h               = static_cast<int>(k_cache.stride(1));
+    kargs.stride_v_blk             = static_cast<int>(v_cache.stride(0));
+    kargs.stride_v_h               = static_cast<int>(v_cache.stride(1));
+    kargs.softmax_scale            = softmax_scale;
+
+    HipDeviceGuard guard(q.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+
+    // ---- Pick a split count --------------------------------------------------
+    //
+    // The natural grid is one workgroup per (kv head, batch), which leaves the
+    // GPU mostly idle at small batch: a single sequence with 8 kv heads occupies 8
+    // of 256 CUs. Splitting the KV axis buys back that parallelism, at the cost of
+    // a second pass to merge the per-split softmax partials. Large batches already
+    // fill the machine, so they keep the single-pass path.
+    //
+    // The second pass is not free: it costs a workspace allocation, an extra launch
+    // and a round trip through global memory, which measures at roughly 2us. Short
+    // contexts have to be kept off this path or the merge outweighs the parallelism
+    // it buys, so every split is required to carry a few tiles of its own.
+    constexpr int min_tiles_per_split = 4;
+    int num_cu = 0;
+    HIP_CALL(hipDeviceGetAttribute(&num_cu, hipDeviceAttributeMultiprocessorCount, q.device_id));
+
+    const int base_wgs  = num_kv_heads * batch; //base workgroups
+    const int max_tiles = (kargs.max_blocks_per_batch_row * Traits::PAGE_SIZE + Traits::KV_TILE - 1)
+                            / Traits::KV_TILE;
+    int num_splits = 1;
+    if(base_wgs < num_cu && max_tiles >= 2 * min_tiles_per_split)
+    {
+        num_splits = num_cu / base_wgs;
+        if(num_splits > max_tiles / min_tiles_per_split) num_splits = max_tiles / min_tiles_per_split;
+        if(num_splits > Traits::MAX_SPLITS) num_splits = Traits::MAX_SPLITS;
+        if(num_splits < 1) num_splits = 1;
+    }
+    kargs.num_splits = num_splits;
+
+    // ---- Launch --------------------------------------------------------------
+    dim3 block(Traits::BLOCK_SIZE);
+
+    if(num_splits == 1)
+    {
+        pa_decode_opus_kernel<Traits><<<dim3(num_kv_heads, batch, 1), block, 0, stream>>>(kargs);
+        HIP_CALL_LAUNCH(hipGetLastError());
+        return;
+    }
+
+    // One slot holds a split's partial O plus its (m, l) pair. The buffer is
+    // cached per stream and never resized, so it is sized for the widest launch
+    // the heuristic can ask for rather than for this one: num_splits is capped at
+    // num_cu / base_wgs, which bounds the slot count by num_cu.
+    const size_t slot_max  = static_cast<size_t>(num_cu);
+    const size_t slots     = static_cast<size_t>(batch) * num_kv_heads * num_splits;
+    const size_t o_bytes   = slots * Traits::Q_TILE * Traits::D_HEAD * sizeof(float);
+    const size_t ml_bytes  = slot_max * Traits::Q_TILE * 2 * sizeof(float);
+    const size_t o_max     = slot_max * Traits::Q_TILE * Traits::D_HEAD * sizeof(float);
+    // One counter per (batch, kv-head); those are bounded by the slot count too.
+    const size_t ctr_bytes = slot_max * sizeof(unsigned int);
+    const size_t bytes_max = o_max + ml_bytes + ctr_bytes;
+    AITER_CHECK(slots <= slot_max, "split-KV slot count ", slots, " exceeds the CU bound ", slot_max);
+
+    char* scratch          = static_cast<char*>(split_scratch_get(stream, bytes_max));
+    kargs.partial_o        = reinterpret_cast<float*>(scratch);
+    kargs.partial_ml       = reinterpret_cast<float*>(scratch + o_bytes);
+    kargs.split_counters   = reinterpret_cast<unsigned int*>(scratch + o_max + ml_bytes);
+
+    // One launch: the split that arrives last merges the partials in place,
+    // rather than a second grid being stood up to do it. That pass measured
+    // 4-5us on every shape it ran for, essentially all of it dispatch cost.
+    pa_decode_opus_kernel<Traits>
+        <<<dim3(num_kv_heads, batch, num_splits), block, 0, stream>>>(kargs);
+    HIP_CALL_LAUNCH(hipGetLastError());
+}

--- a/csrc/py_itfs_cu/pa_decode_opus_kernels.cu
+++ b/csrc/py_itfs_cu/pa_decode_opus_kernels.cu
@@ -8,6 +8,18 @@
 #define PA_DECODE_OPUS_IMPL
 #include "pa_decode_opus.h"
 
+// Smallest run of KV tiles a split may own. On a short context this, not the CU
+// count, is what caps the split count. Tune with op_tests/sweep_min_tiles_per_split.sh.
+#ifndef PA_DECODE_MIN_TILES_PER_SPLIT
+#define PA_DECODE_MIN_TILES_PER_SPLIT 4
+#endif
+
+// Resident workgroups per CU the split heuristic aims for. Also bounds the split
+// scratch below, which is why it is one constant and not two.
+#ifndef PA_DECODE_WGS_PER_CU
+#define PA_DECODE_WGS_PER_CU 1
+#endif
+
 #include "aiter_hip_common.h"
 #include "aiter_stream.h"
 #include "aiter_tensor.h"
@@ -15,22 +27,14 @@
 #include <mutex>
 #include <unordered_map>
 
-// Split-KV scratch, allocated once per stream and kept for the process.
+// Split-KV scratch, allocated once per stream and kept for the process: at small
+// batch the kernel runs in a few microseconds, so a per-call allocate/free pair
+// would sit on the critical path of every decode step.
 //
-// A per-call hipMallocAsync/hipFreeAsync pair is not affordable here. At small
-// batch the kernel itself takes only a few microseconds, so the launch path --
-// two stream-ordered allocator calls on top of the launch itself -- is what the
-// benchmark actually measures. Even against a primed pool, the two API calls
-// stay on the critical path of every decode step.
-//
-// A fixed buffer works because the slot count is structurally bounded: splits
-// are chosen so that base_wgs * num_splits <= num_cu, so no batch shape can ask
-// for more slots than the device has CUs. That caps the scratch at a couple of
-// MB, which is worth holding onto permanently. Since it never grows, there is
-// also no allocation to trip over during HIP graph capture.
-//
-// Keyed by stream, like the opus_gemm splitk workspace: concurrent streams must
-// not share one buffer or their partials would overwrite each other.
+// A fixed buffer works because the slot count is bounded -- splits are chosen so
+// that base_wgs * num_splits <= num_cu * PA_DECODE_WGS_PER_CU -- which caps the
+// scratch at a few MB and leaves no allocation to trip over during graph capture.
+// Keyed by stream: concurrent streams must not share one buffer.
 namespace {
 struct SplitScratchRegistry
 {
@@ -60,16 +64,13 @@ static void* split_scratch_get(hipStream_t stream, size_t bytes)
                 "eagerly on this stream before capturing.");
 
     void* ptr = nullptr;
-    // Uncached, so the partials are visible device-wide as soon as the stores
-    // retire. This buffer is the one place the split workgroups hand data to
-    // each other, and on a multi-XCD part the L2s are not coherent between them,
-    // so the alternative is a __threadfence() in every split -- which writes back
-    // the whole L2 and measured at 28us of the 41us kernel. Bypassing the cache
-    // for these few KB is far cheaper than flushing it for everything else.
+            // Uncached, so the partials are visible device-wide as soon as the stores
+            // retire. This is the one place the split workgroups hand data to each
+            // other, and a multi-XCD part's L2s are not coherent; the alternative is
+            // a __threadfence() per split, which writes back the whole L2.
     HIP_CALL(hipExtMallocWithFlags(&ptr, bytes, hipDeviceMallocUncached));
-    // The arrival counters at the tail have to start at zero. This is the only
-    // time they are cleared: the kernel's last split resets its own counter, so
-    // the buffer comes back clean after every launch.
+        // The arrival counters at the tail start at zero and are cleared only here:
+        // the kernel's last split resets its own counter after every launch.
     HIP_CALL(hipMemset(ptr, 0, bytes));
     reg.map[stream] = ptr;
     return ptr;
@@ -173,27 +174,22 @@ void pa_decode_opus_fwd(aiter_tensor_t& q,
 
     // ---- Pick a split count --------------------------------------------------
     //
-    // The natural grid is one workgroup per (kv head, batch), which leaves the
-    // GPU mostly idle at small batch: a single sequence with 8 kv heads occupies 8
-    // of 256 CUs. Splitting the KV axis buys back that parallelism, at the cost of
-    // a second pass to merge the per-split softmax partials. Large batches already
-    // fill the machine, so they keep the single-pass path.
-    //
-    // The second pass is not free: even fused into the last arriving workgroup it
-    // costs a workspace allocation and a round trip through global memory. Short
-    // contexts have to be kept off this path or the merge outweighs the parallelism
-    // it buys, so every split is required to carry a few tiles of its own.
-    constexpr int min_tiles_per_split = 4;
+    // One workgroup per (kv head, batch) leaves the GPU mostly idle at small batch,
+    // so the KV axis is split and the per-split partials merged afterwards. Large
+    // batches already fill the machine and keep the single-pass path; short contexts
+    // are kept off it by requiring min_tiles_per_split tiles per split.
+    constexpr int min_tiles_per_split = PA_DECODE_MIN_TILES_PER_SPLIT;
     int num_cu = 0;
     HIP_CALL(hipDeviceGetAttribute(&num_cu, hipDeviceAttributeMultiprocessorCount, q.device_id));
 
     const int base_wgs  = num_kv_heads * batch; //base workgroups
+    const int wg_budget = num_cu * PA_DECODE_WGS_PER_CU;
     const int max_tiles = (kargs.max_blocks_per_batch_row * Traits::PAGE_SIZE + Traits::KV_TILE - 1)
                             / Traits::KV_TILE;
     int num_splits = 1;
-    if(base_wgs < num_cu && max_tiles >= 2 * min_tiles_per_split)
+    if(base_wgs < wg_budget && max_tiles >= 2 * min_tiles_per_split)
     {
-        num_splits = num_cu / base_wgs;
+        num_splits = wg_budget / base_wgs;
         if(num_splits > max_tiles / min_tiles_per_split) num_splits = max_tiles / min_tiles_per_split;
         if(num_splits > Traits::MAX_SPLITS) num_splits = Traits::MAX_SPLITS;
         if(num_splits < 1) num_splits = 1;
@@ -210,11 +206,10 @@ void pa_decode_opus_fwd(aiter_tensor_t& q,
         return;
     }
 
-    // One slot holds a split's partial O plus its (m, l) pair. The buffer is
-    // cached per stream and never resized, so it is sized for the widest launch
-    // the heuristic can ask for rather than for this one: num_splits is capped at
-    // num_cu / base_wgs, which bounds the slot count by num_cu.
-    const size_t slot_max  = static_cast<size_t>(num_cu);
+    // One slot holds a split's partial O plus its (m, l) pair. Never resized, so it
+    // is sized for the widest launch the heuristic can ask for: num_splits is capped
+    // at wg_budget / base_wgs, which bounds the slot count by wg_budget.
+    const size_t slot_max  = static_cast<size_t>(wg_budget);
     const size_t slots     = static_cast<size_t>(batch) * num_kv_heads * num_splits;
     const size_t o_bytes   = slots * Traits::Q_TILE * Traits::D_HEAD * sizeof(float);
     const size_t ml_bytes  = slot_max * Traits::Q_TILE * 2 * sizeof(float);
@@ -229,9 +224,8 @@ void pa_decode_opus_fwd(aiter_tensor_t& q,
     kargs.partial_ml       = reinterpret_cast<float*>(scratch + o_bytes);
     kargs.split_counters   = reinterpret_cast<unsigned int*>(scratch + o_max + ml_bytes);
 
-    // One launch: the split that arrives last merges the partials in place,
-    // rather than a second grid being stood up to do it. That pass measured
-    // 4-5us on every shape it ran for, essentially all of it dispatch cost.
+        // One launch: the split that arrives last merges the partials in place,
+        // rather than a second grid being stood up to do it.
     pa_decode_opus_kernel<Traits>
         <<<dim3(num_kv_heads, batch, num_splits), block, 0, stream>>>(kargs);
     HIP_CALL_LAUNCH(hipGetLastError());

--- a/csrc/pybind/pa_decode_opus_pybind.cu
+++ b/csrc/pybind/pa_decode_opus_pybind.cu
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "rocm_ops.hpp"
+#include "aiter_stream.h"
+#include "pa_decode_opus.h"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    PA_DECODE_OPUS_PYBIND;
+}

--- a/op_tests/test_pa.py
+++ b/op_tests/test_pa.py
@@ -406,6 +406,20 @@ def run_aiter_asm(
 
 
 @perftest()
+def run_aiter_opus(
+    query,
+    k_cache,
+    v_cache,
+    block_tables,
+    seq_lens,
+    scale,
+):
+    # Unlike the asm path this one is handed `query` as-is, so the non-contiguous
+    # stride that test_paged_attention builds is part of what gets exercised.
+    return aiter.pa_decode_opus(query, k_cache, v_cache, block_tables, seq_lens, scale)
+
+
+@perftest()
 def run_aiter_common(
     query,
     k_cache,
@@ -670,6 +684,7 @@ def test_paged_attention(
     # tensor_dump(out_aiter, 'out_aiter')
 
     time_aiter_asm = None
+    time_aiter_asm_bf16 = None
     if dtype == dtypes.bf16:
         out_aiter_asm, time_aiter_asm = run_aiter_asm(
             query.contiguous(),  # this kernel need contiguous buffer
@@ -690,7 +705,35 @@ def test_paged_attention(
             out_aiter_asm,
             msg=f"golden vs aiter_asm:{time_aiter_asm:>8.2f} us......",
         )
+        # time_aiter_asm is reassigned by the quantized-cache runs below, so the
+        # summary would otherwise report an fp8/int8 time next to the bf16 ones.
+        time_aiter_asm_bf16 = time_aiter_asm
         # tensor_dump(out_aiter, 'out_aiter')
+
+    # OPUS decode kernel: bf16 / head_size 128 / page 16 / GQA <= 16 only, and it
+    # has no alibi path, so everything outside that envelope is skipped.
+    time_aiter_opus = None
+    if (
+        dtype == dtypes.bf16
+        and kv_cache_dtype == "auto"
+        and head_size == 128
+        and block_size == 16
+        and num_queries_per_kv <= 16
+        and alibi_slopes is None
+    ):
+        out_aiter_opus, time_aiter_opus = run_aiter_opus(
+            query,
+            k_cache,
+            v_cache,
+            block_tables,
+            seq_lens,
+            scale,
+        )
+        checkAllclose(
+            out_golden,
+            out_aiter_opus,
+            msg=f"golden vs aiter_opus:{time_aiter_opus:>8.2f} us......",
+        )
 
     # Test paged_attention_common which automatically switches between ASM and HIP
     # The routing is internal, so we just test the common API regardless of which path it takes
@@ -968,6 +1011,8 @@ def test_paged_attention(
     return {
         "aiter_shomy": time_aiter,
         "aiter_asm": time_aiter_asm,
+        "aiter_asm_bf16": time_aiter_asm_bf16,
+        "aiter_opus": time_aiter_opus,
         "aiter_common": time_aiter_common,
     }
 

--- a/op_tests/test_pa.py
+++ b/op_tests/test_pa.py
@@ -19,6 +19,15 @@ from aiter.test_common import (
     tensor_load,
 )
 
+# gfx950-only: aiter.pa_decode_opus raises on anything else, so the arch has to
+# gate the call. Mirrors the op's own check so the two cannot disagree.
+try:
+    from aiter.jit.utils.chip_info import get_gfx_runtime
+
+    HAS_OPUS_PA_DECODE = torch.cuda.is_available() and get_gfx_runtime() == "gfx950"
+except Exception:  # noqa: BLE001
+    HAS_OPUS_PA_DECODE = False
+
 uniform_range = (-1, 1)
 STR_DTYPE_TO_TORCH_DTYPE = {
     "half": torch.half,
@@ -710,11 +719,12 @@ def test_paged_attention(
         time_aiter_asm_bf16 = time_aiter_asm
         # tensor_dump(out_aiter, 'out_aiter')
 
-    # OPUS decode kernel: bf16 / head_size 128 / page 16 / GQA <= 16 only, and it
-    # has no alibi path, so everything outside that envelope is skipped.
+    # OPUS decode kernel: gfx950, bf16, head_size 128, page 16, GQA <= 16, no
+    # alibi -- everything outside that envelope is skipped.
     time_aiter_opus = None
     if (
-        dtype == dtypes.bf16
+        HAS_OPUS_PA_DECODE
+        and dtype == dtypes.bf16
         and kv_cache_dtype == "auto"
         and head_size == 128
         and block_size == 16

--- a/setup.py
+++ b/setup.py
@@ -448,11 +448,7 @@ setup_requires = [
     "psutil",
     "ninja",
     "setuptools_scm",
-    # Transitive dep of setuptools_scm>=10. The lower bound matters: setuptools_scm
-    # 10.2 imports vcs_versioning._environment, which only exists from 2.0 on, and
-    # an unpinned requirement lets fetch_build_eggs keep a stale 1.x already in
-    # site-packages, failing at import time rather than at resolution time.
-    "vcs_versioning>=2.0.0",
+    "vcs_versioning",  # transitive dep of setuptools_scm>=10
 ]
 if PREBUILD_KERNELS != 0:
     setup_requires.append("pandas")

--- a/setup.py
+++ b/setup.py
@@ -448,7 +448,11 @@ setup_requires = [
     "psutil",
     "ninja",
     "setuptools_scm",
-    "vcs_versioning",  # transitive dep of setuptools_scm>=10
+    # Transitive dep of setuptools_scm>=10. The lower bound matters: setuptools_scm
+    # 10.2 imports vcs_versioning._environment, which only exists from 2.0 on, and
+    # an unpinned requirement lets fetch_build_eggs keep a stale 1.x already in
+    # site-packages, failing at import time rather than at resolution time.
+    "vcs_versioning>=2.0.0",
 ]
 if PREBUILD_KERNELS != 0:
     setup_requires.append("pandas")


### PR DESCRIPTION
## Motivation

bf16 paged-attention decode on gfx950 currently runs an ASM kernel recompiled from the
MI300 sp3 kernel `PA_A16W16_*_1TG_4W_16mx1_64nx4`. It predates the part and does not use
its native matrix-core or cross-lane instructions.

The bigger gap is parallelism. `aiter.pa_fwd_asm` exposes no split-KV descriptor, so its
grid is one workgroup per (kv head, batch) whatever the context length. A single sequence
with one kv head therefore occupies 1 of 256 CUs, and long-context decode serving lives in
exactly that regime: at batch 1, kv_heads 1, ctx 32768 the
ASM kernel spends 169 us moving
17 MB of KV, which is
0.1 TB/s against an 8 TB/s part.

## Technical Details
**Shape.** `grid = dim3(num_kv_heads, batch, num_splits)`, 256 threads = 4 wave64. Each
workgroup owns one `(kv head, batch)` -- or one KV-axis slice of it -- and walks its context
one 128-token tile at a time. Per tile: `S = Q·Kᵀ` contracting head_dim, online softmax in
registers, `O += P·Vᵀ` contracting the token axis. Q is loaded once and O accumulates across
tiles, so only K and V stream. `Q_TILE = 16` is both the MFMA M dimension and the largest
GQA ratio supported.

**KV never touches LDS.** `load_k_frags` / `load_v_frags` read the paged cache straight into
the matrix-core B fragments, one `dwordx4` per fragment. Two static_asserts hold that
contract: `GRP_N == PAGE_SIZE` makes a K MFMA tile cover exactly one page so its page index
is wave-uniform, and `GRP_K * VEC == W_K` makes a lane's slice of the contraction dim exactly
the 16 bytes the cache stores contiguously. K's `[D/x][PAGE][x]` and V's `[D][PAGE]` layouts
differ but both satisfy it, so no `asm_V_shuffle`-style repacking is needed.

**S stays in registers.** Both GEMMs use `mfma_adaptor_swap_ab`, which puts the query row on
`lane % 16` in the accumulator. That has three consequences: a query row's 32 elements land
on 4 lanes with 8 accumulators each, so the softmax row fold is 7 in-register VALU ops plus
one `permlane32_swap` / `permlane16_swap` pair; P leaves the C fragment as 4 adjacent KV
tokens, one `ds_write_b64` instead of 4 strided `ds_write_b16`; and O leaves GEMM1 as 4
adjacent head dims, folding into one wide store. Only P goes through LDS, because GEMM1
contracts the token axis that splits the waves.

The permlane pair must be inline asm. `__builtin_amdgcn_permlane*_swap` returns both halves
as one vector, and an all-reduce passes the same value as both operands, so the compiler
folds them into one register and the reduction silently degrades to `op(v, v)` -- invisible
for max, wrong for the sum.

**Split-KV with a fused merge.** When `kv_heads * batch` is below the CU count the launcher
splits the KV axis, requiring at least `min_tiles_per_split = 4` tiles per split. The merge
is not a second dispatch -- that cost 4-5 us of nearly pure launch overhead -- but is done by
whichever split arrives last, detected with an atomic counter that nobody waits on. The
partial buffer is uncached rather than fenced: an agent-scope release writes back all of L2
on a multi-XCD part and evicted the KV stream.

**LDS.** 8256 B per workgroup, the union of the attention side (bf16 P tile plus cross-wave
reduction scratch) and the merge side, which reuses the same allocation since both attention
buffers are dead by then.

**Envelope.** gfx950, bf16, head_dim 128, page_size 16, GQA ratio <= 16, no alibi. Anything
outside routes to the existing paths unchanged; `aiter/ops/pa_decode_opus.py` raises rather
than silently mis-dispatching, and `op_tests/test_pa.py` gates the OPUS comparison on the
live arch so MI300 runs skip it instead of failing.


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

## Summary by KV head count

Median speedup over batch 1..32.

| kv heads | ctx=2048 | ctx=8192 | ctx=32768 | overall |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 0.93x | 2.76x | 6.74x | 2.76x |
| 2 | 0.93x | 2.66x | 5.25x | 2.26x |
| 4 | 0.93x | 2.26x | 3.82x | 1.59x |
| 8 | 0.94x | 1.69x | 2.51x | 1.08x |
| **all** | **0.93x** | **2.60x** | **4.34x** | **1.85x** |

## Peak bandwidth reached, GB/s (OPUS / ASM)

Against a nominal 8 TB/s HBM peak.

| kv heads | ctx=2048 | ctx=8192 | ctx=32768 |
| ---: | ---: | ---: | ---: |
| 1 | 2072 / 2221 | 5612 / 2912 | 6281 / 1792 |
| 2 | 4111 / 4378 | 6528 / 5103 | 6314 / 3344 |
| 4 | 5788 / 6243 | 6494 / 5353 | 6414 / 5971 |
| 8 | 6733 / 6343 | 6512 / 5998 | 6346 / 6169 |

## Detailed results

### kv_heads = 1 (MHA-like / TP-split KV)

| batch | ctx | OPUS splits | OPUS wgs | ASM wgs | OPUS (us) | ASM (us) | OPUS GB/s | ASM GB/s | speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 2048 | 4 | 4 | 1 | 16.4 | 15.2 | 64 | 69 | 0.93x |
| 2 | 2048 | 4 | 8 | 2 | 16.3 | 14.9 | 128 | 141 | 0.91x |
| 4 | 2048 | 4 | 16 | 4 | 16.2 | 14.9 | 259 | 281 | 0.92x |
| 8 | 2048 | 4 | 32 | 8 | 16.2 | 14.9 | 519 | 562 | 0.92x |
| 16 | 2048 | 4 | 64 | 16 | 16.1 | 15.0 | 1044 | 1118 | 0.93x |
| 32 | 2048 | 4 | 128 | 32 | 16.2 | 15.1 | 2072 | 2221 | 0.93x |
| 1 | 8192 | 16 | 16 | 1 | 16.1 | 45.0 | 260 | 93 | 2.80x |
| 2 | 8192 | 16 | 32 | 2 | 16.3 | 45.3 | 514 | 185 | 2.78x |
| 4 | 8192 | 16 | 64 | 4 | 16.5 | 45.4 | 1020 | 370 | 2.75x |
| 8 | 8192 | 16 | 128 | 8 | 16.5 | 45.8 | 2031 | 733 | 2.78x |
| 16 | 8192 | 16 | 256 | 16 | 17.7 | 45.7 | 3795 | 1467 | 2.58x |
| 32 | 8192 | 8 | 256 | 32 | 23.9 | 46.1 | 5612 | 2912 | 1.93x |
| 1 | 32768 | 64 | 64 | 1 | 16.7 | 168.7 | 1004 | 99 | 10.10x |
| 2 | 32768 | 64 | 128 | 2 | 17.8 | 169.2 | 1890 | 198 | 9.51x |
| 4 | 32768 | 64 | 256 | 4 | 23.2 | 169.6 | 2892 | 396 | 7.31x |
| 8 | 32768 | 32 | 256 | 8 | 27.6 | 170.4 | 4855 | 787 | 6.17x |
| 16 | 32768 | 16 | 256 | 16 | 42.7 | 179.5 | 6281 | 1495 | 4.20x |
| 32 | 32768 | 8 | 256 | 32 | 93.6 | 299.6 | 5738 | 1792 | 3.20x |

### kv_heads = 2

| batch | ctx | OPUS splits | OPUS wgs | ASM wgs | OPUS (us) | ASM (us) | OPUS GB/s | ASM GB/s | speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 2048 | 4 | 8 | 2 | 16.0 | 15.0 | 131 | 140 | 0.94x |
| 2 | 2048 | 4 | 16 | 4 | 16.1 | 15.0 | 260 | 280 | 0.93x |
| 4 | 2048 | 4 | 32 | 8 | 16.2 | 15.0 | 518 | 558 | 0.93x |
| 8 | 2048 | 4 | 64 | 16 | 16.3 | 15.1 | 1030 | 1113 | 0.93x |
| 16 | 2048 | 4 | 128 | 32 | 16.2 | 15.1 | 2067 | 2220 | 0.93x |
| 32 | 2048 | 4 | 256 | 64 | 16.3 | 15.3 | 4111 | 4378 | 0.94x |
| 1 | 8192 | 16 | 32 | 2 | 16.6 | 45.3 | 506 | 185 | 2.73x |
| 2 | 8192 | 16 | 64 | 4 | 16.7 | 45.4 | 1004 | 369 | 2.72x |
| 4 | 8192 | 16 | 128 | 8 | 16.6 | 45.6 | 2020 | 737 | 2.75x |
| 8 | 8192 | 16 | 256 | 16 | 17.6 | 45.8 | 3808 | 1467 | 2.60x |
| 16 | 8192 | 8 | 256 | 32 | 23.9 | 46.0 | 5616 | 2920 | 1.92x |
| 32 | 8192 | 4 | 256 | 64 | 41.1 | 52.6 | 6528 | 5103 | 1.28x |
| 1 | 32768 | 64 | 128 | 2 | 17.8 | 169.2 | 1890 | 198 | 9.51x |
| 2 | 32768 | 64 | 256 | 4 | 22.8 | 169.7 | 2948 | 395 | 7.44x |
| 4 | 32768 | 32 | 256 | 8 | 27.2 | 170.2 | 4930 | 788 | 6.26x |
| 8 | 32768 | 16 | 256 | 16 | 42.5 | 180.2 | 6314 | 1490 | 4.24x |
| 16 | 32768 | 8 | 256 | 32 | 93.4 | 298.0 | 5746 | 1802 | 3.19x |
| 32 | 32768 | 4 | 256 | 64 | 179.3 | 321.1 | 5987 | 3344 | 1.79x |

### kv_heads = 4

| batch | ctx | OPUS splits | OPUS wgs | ASM wgs | OPUS (us) | ASM (us) | OPUS GB/s | ASM GB/s | speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 2048 | 4 | 16 | 4 | 16.3 | 15.1 | 258 | 278 | 0.93x |
| 2 | 2048 | 4 | 32 | 8 | 16.2 | 15.2 | 518 | 554 | 0.94x |
| 4 | 2048 | 4 | 64 | 16 | 16.2 | 15.1 | 1034 | 1108 | 0.93x |
| 8 | 2048 | 4 | 128 | 32 | 16.3 | 15.3 | 2054 | 2200 | 0.94x |
| 16 | 2048 | 4 | 256 | 64 | 16.5 | 15.3 | 4063 | 4389 | 0.93x |
| 32 | 2048 | 2 | 256 | 128 | 23.2 | 21.5 | 5788 | 6243 | 0.93x |
| 1 | 8192 | 16 | 64 | 4 | 16.6 | 45.5 | 1012 | 369 | 2.74x |
| 2 | 8192 | 16 | 128 | 8 | 16.6 | 45.7 | 2025 | 735 | 2.75x |
| 4 | 8192 | 16 | 256 | 16 | 17.5 | 45.6 | 3826 | 1472 | 2.61x |
| 8 | 8192 | 8 | 256 | 32 | 24.0 | 45.9 | 5595 | 2925 | 1.91x |
| 16 | 8192 | 4 | 256 | 64 | 41.3 | 56.8 | 6494 | 4729 | 1.38x |
| 32 | 8192 | 2 | 256 | 128 | 92.7 | 100.3 | 5794 | 5353 | 1.08x |
| 1 | 32768 | 64 | 256 | 4 | 23.0 | 170.0 | 2917 | 395 | 7.39x |
| 2 | 32768 | 32 | 256 | 8 | 27.4 | 170.1 | 4897 | 789 | 6.21x |
| 4 | 32768 | 16 | 256 | 16 | 42.4 | 188.3 | 6326 | 1426 | 4.44x |
| 8 | 32768 | 8 | 256 | 32 | 93.6 | 298.5 | 5734 | 1799 | 3.19x |
| 16 | 32768 | 4 | 256 | 64 | 178.2 | 321.3 | 6026 | 3342 | 1.80x |
| 32 | 32768 | 2 | 256 | 128 | 334.8 | 359.7 | 6414 | 5971 | 1.07x |

### kv_heads = 8 (typical GQA serving)

| batch | ctx | OPUS splits | OPUS wgs | ASM wgs | OPUS (us) | ASM (us) | OPUS GB/s | ASM GB/s | speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 2048 | 4 | 32 | 8 | 16.3 | 15.1 | 515 | 554 | 0.93x |
| 2 | 2048 | 4 | 64 | 16 | 16.1 | 15.2 | 1041 | 1107 | 0.94x |
| 4 | 2048 | 4 | 128 | 32 | 16.2 | 15.2 | 2068 | 2210 | 0.94x |
| 8 | 2048 | 4 | 256 | 64 | 16.3 | 15.3 | 4110 | 4385 | 0.94x |
| 16 | 2048 | 2 | 256 | 128 | 23.1 | 21.5 | 5813 | 6253 | 0.93x |
| 32 | 2048 | 1 | 256 | 256 | 39.9 | 42.3 | 6733 | 6343 | 1.06x |
| 1 | 8192 | 16 | 128 | 8 | 16.4 | 45.4 | 2048 | 740 | 2.77x |
| 2 | 8192 | 16 | 256 | 16 | 17.5 | 45.7 | 3834 | 1469 | 2.61x |
| 4 | 8192 | 8 | 256 | 32 | 23.9 | 45.8 | 5625 | 2932 | 1.92x |
| 8 | 8192 | 4 | 256 | 64 | 41.2 | 59.8 | 6512 | 4487 | 1.45x |
| 16 | 8192 | 2 | 256 | 128 | 92.4 | 100.3 | 5810 | 5352 | 1.09x |
| 32 | 8192 | 1 | 256 | 256 | 177.1 | 179.0 | 6063 | 5998 | 1.01x |
| 1 | 32768 | 32 | 256 | 8 | 27.4 | 170.4 | 4891 | 788 | 6.22x |
| 2 | 32768 | 16 | 256 | 16 | 42.3 | 200.9 | 6346 | 1336 | 4.75x |
| 4 | 32768 | 8 | 256 | 32 | 92.6 | 298.2 | 5797 | 1801 | 3.22x |
| 8 | 32768 | 4 | 256 | 64 | 178.6 | 321.0 | 6013 | 3345 | 1.80x |
| 16 | 32768 | 2 | 256 | 128 | 349.3 | 358.6 | 6147 | 5988 | 1.03x |
| 32 | 32768 | 1 | 256 | 256 | 692.5 | 696.2 | 6202 | 6169 | 1.01x |
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
