### PR TITLE
fix: generate CK FMHA kernels for gfx1250

### DIFF
--- a/aiter/jit/utils/mha_recipes.py
+++ b/aiter/jit/utils/mha_recipes.py
@@ -7,9 +7,9 @@ def _ck_targets_flag() -> str:
     keep the default (covers both gfx942 and gfx950 like before).
     """
     try:
-        from chip_info import get_gfx
+        from chip_info import get_gfx_runtime
 
-        gfx = get_gfx()
+        gfx = get_gfx_runtime()
     except Exception:  # noqa: BLE001
         return ""
     if gfx.startswith("gfx9"):

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -10,6 +10,7 @@ from torch import Generator, Tensor
 from ..jit.core import AITER_META_DIR, CK_DIR, ENABLE_CK, compile_ops
 from ..jit.utils.chip_info import get_cu_num, get_gfx
 from ..jit.utils.mha_recipes import (
+    _ck_targets_flag,
     compose_mha_fwd_variant_suffix_and_filter,
     get_mha_varlen_prebuild_variants_by_names,
 )
@@ -110,7 +111,9 @@ def cmdGenFunc_mha_fwd(
 
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d fwd "
-        "--receipt 100 --filter {} --output_dir {{}}".format(filter),
+        "--receipt 100 --filter {} --output_dir {{}}{}".format(
+            filter, _ck_targets_flag()
+        ),
     ]
     return {
         "md_name": md_name,
@@ -1136,7 +1139,9 @@ def cmdGenFunc_mha_bwd(
 
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d bwd "
-        "--receipt 300 --filter {} --output_dir {{}}".format(filter),
+        "--receipt 300 --filter {} --output_dir {{}}{}".format(
+            filter, _ck_targets_flag()
+        ),
         f"{AITER_META_DIR}/hsa/codegen.py -m fmha_v3_bwd --output_dir {{}}",
     ]
     return {
@@ -1394,7 +1399,9 @@ def cmdGenFunc_mha_varlen_bwd(
 
     blob_gen_cmd = [
         f"{CK_DIR}/example/ck_tile/01_fmha/generate.py -d bwd "
-        "--receipt 400 --filter {} --output_dir {{}}".format(filter),
+        "--receipt 400 --filter {} --output_dir {{}}{}".format(
+            filter, _ck_targets_flag()
+        ),
         f"{AITER_META_DIR}/hsa/codegen.py -m fmha_v3_bwd --output_dir {{}}",
     ]
     return {


### PR DESCRIPTION
## Summary
- Pass the runtime gfx target to CK dense forward and backward code generation.
- Pass the same target to CK varlen backward code generation.
- Enable gfx1250 CK dispatch instead of falling back with an invalid-argument error.

## Manual validation
- Validated dense and varlen FlashAttention forward/backward on gfx1250 using downstream captured workloads.
- Compared outputs and Q/K/V gradients with PyTorch math SDPA.
- Confirmed CK forward and backward kernels launch in Torch Profiler.