### PR TITLE
Refactor bench_mha to use -o as boolean flag

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_mha.py
+++ b/op_tests/op_benchmarks/triton/bench_mha.py
@@ -919,11 +919,7 @@ def parse_args(args: list[str] | None = None) -> BenchRun:
         help="Enable persistent kernels. Use '-persistent dynamic' for dynamic scheduling of the tiles.",
     )
     parser.add_argument(
-        "-o",
-        type=str,
-        default=None,
-        metavar="DIR",
-        help="Write performance results to CSV in DIR",
+        "-o", action="store_true", help="Write performance results to CSV file"
     )
     parser.add_argument(
         "--profile",
@@ -1052,7 +1048,7 @@ def parse_args(args: list[str] | None = None) -> BenchRun:
         plot_name=get_caller_name_no_ext(),
         sink=parsed.sink,
         equal_seqlens=parsed.equal_seqlens,
-        save_path=parsed.o,
+        save_path="." if parsed.o else None,
         profile_dir=parsed.profile,
         print_vgpr=parsed.print_vgpr,
         bench_torch=parsed.bench_torch,


### PR DESCRIPTION
## Motivation

Make command line interface of all `op_benchmark/triton` benchmarks consistent.

## Technical Details

Before: `-o DIR` (writes CSV to specified directory)
After: `-o` (writes CSV to current directory when flag is present)

## Test Plan

Run the affected benchmark with and without the `-o` argument: make sure that there are no errors and `.csv` file can be correctly generated.

## Test Result

Planned checks passed successfully 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
