### PR TITLE
Fix lean attention for gfx950

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/lean_atten.py
+++ b/aiter/ops/triton/_triton_kernels/attention/lean_atten.py
@@ -27,14 +27,27 @@ from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH, load_config_j
 # Support tensor in [B, Seqlen, H, d] format. Taking tensors in [B*Seqlen, H, d] as inputs
 
 
-def _get_config():
+def _get_config(causal: bool = True, n_ctx_q: int | None = None):
     # No lru_cache here: load_config_json already caches the parse, and
     # caching the .copy() would hand every caller the same mutable object.
     dev = arch_info.get_arch()
     config = load_config_json(
         f"{AITER_TRITON_CONFIGS_PATH}/{dev}-LEANATTN-DEFAULT.json"
     )
-    return config["any"].copy()  # fresh copy per call — safe for callers to mutate
+    # Decode and prefill want different tilings; arch files without the split just
+    # have "any". Keyed on n_ctx_q, not causal: BLOCK_M must fit the query (Mp/Lp are
+    # validated against it) and causal needs BLOCK_M % BLOCK_N == 0.
+    prefill = config.get("causal", config["any"])
+    decode = config.get("decode")
+    if (
+        not causal
+        and decode is not None
+        and n_ctx_q is not None
+        and n_ctx_q < prefill["BLOCK_SIZE_M"]
+        and decode["BLOCK_SIZE_M"] <= n_ctx_q
+    ):
+        return decode.copy()
+    return prefill.copy()  # fresh copy per call
 
 
 @triton.jit

--- a/aiter/ops/triton/attention/lean_atten.py
+++ b/aiter/ops/triton/attention/lean_atten.py
@@ -27,11 +27,24 @@ from aiter.ops.triton._triton_kernels.attention.lean_atten import (
     _get_config,
     la_persistent,
 )
-from aiter.ops.triton.utils._triton import arch_info
-from aiter.ops.triton.utils.device_info import get_num_xcds
+from aiter.ops.triton.utils.device_info import get_num_sms, get_num_xcds
 from aiter.ops.triton.utils.logger import AiterTritonLogger
 
 _LOGGER = AiterTritonLogger()
+
+# Config keys the wrapper already consumes or passes to the launch by name, so they
+# must not be splatted a second time.
+explicit_config_keys_handler = frozenset(
+    {
+        "BLOCK_SIZE_M",
+        "BLOCK_SIZE_N",
+        "SM_CNT_FACTOR",
+        "XCD_REMAP",
+        "num_warps",
+        "num_stages",
+        "waves_per_eu",
+    }
+)
 
 # Support tensor in [B, Seqlen, H, d] format. Taking tensors in [B*Seqlen, H, d] as inputs
 
@@ -83,8 +96,9 @@ def persistent_lean_attention(
         f"LEAN_ATTEN: q={tuple(q.shape)}  k={tuple(k.shape)}  v={tuple(v.shape)} Mp={tuple(Mp.shape)} Lp={tuple(Lp.shape)}  Op={tuple(Op.shape)}"
     )
     if config is None:
-        config = _get_config()
-    sm_count = arch_info.get_num_sms()
+        # n_ctx_q distinguishes decode from prefill
+        config = _get_config(causal=causal, n_ctx_q=q.shape[0] // batch_size)
+    sm_count = get_num_sms()
     total_programs = (
         program_count
         if program_count is not None
@@ -163,6 +177,11 @@ def _persistent_lean_attention(
     """
     if config is None:
         config = {}
+    # Forward only the keys not already passed explicitly below; splatting the whole
+    # config collides ("got multiple values for keyword argument 'XCD_REMAP'").
+    launch_options = {
+        k: v for k, v in config.items() if k not in explicit_config_keys_handler
+    }
     DEBUG = False
 
     NUM_XCDS = get_num_xcds()
@@ -375,7 +394,7 @@ def _persistent_lean_attention(
             or (q.stride(0) * N_CTX_Q) >= (1 << 31)
         ),
         RAGGED_BATCH=RAGGED_BATCH,
-        **config,
+        **launch_options,
     )
 
     """

--- a/aiter/ops/triton/configs/gfx950-LEANATTN-DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950-LEANATTN-DEFAULT.json
@@ -1,0 +1,29 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "XCD_REMAP": true,
+        "SM_CNT_FACTOR": 2,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 2
+    },
+    "causal": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "XCD_REMAP": true,
+        "SM_CNT_FACTOR": 2,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 2
+    },
+    "decode": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "XCD_REMAP": true,
+        "SM_CNT_FACTOR": 2,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 4
+    }
+}

--- a/op_tests/op_benchmarks/triton/bench_la.py
+++ b/op_tests/op_benchmarks/triton/bench_la.py
@@ -1,12 +1,22 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+import argparse
 import sys
 
 import torch
 import triton
 
-from aiter.ops.triton.attention.lean_atten import _persistent_lean_attention
+from aiter.ops.triton._triton_kernels.attention.lean_atten import _get_config
+from aiter.ops.triton.attention.lean_atten import (
+    _persistent_lean_attention,
+    persistent_lean_attention,
+)
+from aiter.ops.triton.utils.device_info import get_num_sms
+
+# Take the launch params from the arch config and call the public entry point, so we
+# measure what ships instead of a swept point. Needs a config for the current GPU.
+USE_CONFIG = False
 
 configs = []
 configs.append(
@@ -315,6 +325,16 @@ def bench_lean_attention(
     provider,
     device="cuda",
 ):
+    if USE_CONFIG:
+        # Before BLOCK_N builds batch_num_block_n and total_programs sizes the
+        # buffers, which the public entry point then validates against.
+        cfg = _get_config(causal=causal, n_ctx_q=n_ctx_q)
+        BLOCK_M = cfg["BLOCK_SIZE_M"]
+        BLOCK_N = cfg["BLOCK_SIZE_N"]
+        num_warps = cfg["num_warps"]
+        waves_per_eu = cfg["waves_per_eu"]
+        total_programs = get_num_sms() * cfg["SM_CNT_FACTOR"]
+
     n_ctx = n_ctx_k * batch
     assert batch == len(n_ctx)
 
@@ -358,25 +378,41 @@ def bench_lean_attention(
     XCD_REMAP = True
 
     # Triton LeanAttention output
-    fn = lambda: _persistent_lean_attention(
-        q,
-        k,
-        v,
-        Mp,
-        Lp,
-        Op,
-        locks,
-        batch_num_block_n,
-        total_programs,
-        BLOCK_M,
-        BLOCK_N,
-        XCD_REMAP,
-        causal,
-        batch,
-        RAGGED_BATCH,
-        num_warps,
-        waves_per_eu,
-    )
+    if USE_CONFIG:
+        fn = lambda: persistent_lean_attention(
+            q,
+            k,
+            v,
+            Mp,
+            Lp,
+            Op,
+            locks,
+            batch_num_block_n,
+            batch,
+            sm_scale=d**-0.5,
+            causal=causal,
+            RAGGED_BATCH=RAGGED_BATCH,
+        )
+    else:
+        fn = lambda: _persistent_lean_attention(
+            q,
+            k,
+            v,
+            Mp,
+            Lp,
+            Op,
+            locks,
+            batch_num_block_n,
+            total_programs,
+            BLOCK_M,
+            BLOCK_N,
+            XCD_REMAP,
+            causal,
+            batch,
+            RAGGED_BATCH,
+            num_warps,
+            waves_per_eu,
+        )
 
     warmup = 1
     rep = 1
@@ -387,6 +423,18 @@ def bench_lean_attention(
 
 
 def main():
+    global USE_CONFIG
+    parser = argparse.ArgumentParser(
+        prog="Benchmark Lean Attention", allow_abbrev=False
+    )
+    parser.add_argument(
+        "--use-config",
+        action="store_true",
+        help="Take launch parameters from the arch's tuned config and call the "
+        "public persistent_lean_attention(), instead of sweeping the tuning "
+        "columns of x_vals. Requires a <arch>-LEANATTN-DEFAULT.json.",
+    )
+    USE_CONFIG = parser.parse_args().use_config
     bench_lean_attention.run(save_path=".", print_data=True)
 
 

--- a/op_tests/triton_tests/attention/test_la.py
+++ b/op_tests/triton_tests/attention/test_la.py
@@ -13,8 +13,12 @@ from aiter.ops.triton.attention.lean_atten import (
     persistent_lean_attention,
 )
 from aiter.ops.triton.utils._triton import arch_info
+from aiter.ops.triton.utils.device_info import get_num_sms
 
 DEBUG_MODE = False
+
+# Heads per chunk in the torch reference; bounds its peak score-matrix memory.
+ref_head_chunk = 8
 
 
 def get_lean_attn_inputs(
@@ -91,15 +95,22 @@ def reference_attention(q, k, v, n_ctx, n_ctx_q, causal):
             group_size = qb_reshaped.shape[0] // kb_reshaped.shape[0]
             kb_reshaped = kb_reshaped.repeat_interleave(group_size, dim=0)
             vb_reshaped = vb_reshaped.repeat_interleave(group_size, dim=0)
-        p = torch.matmul(qb_reshaped, kb_reshaped.transpose(-2, -1)) / math.sqrt(d)
+        inv_mask = None
         if causal:
-            M = torch.tril(torch.ones((n_ctx_q, b), device="cuda"))
-            mask = M == 0
-            p[:, mask] = float("-inf")
-        # print(f"p shape: {p.shape}")
-        p = torch.softmax(p.float(), dim=-1).to(q.dtype)
-        refb = torch.matmul(p, vb_reshaped)
-        ref_out[start_q : (start_q + int(n_ctx_q)), :, :] = refb.transpose(0, 1)
+            inv_mask = torch.tril(torch.ones((n_ctx_q, b), device="cuda")) == 0
+        # Chunk over heads: independent, and doing all at once materialises
+        # hq x n_ctx_q x b scores -- 16 GiB in fp32 for 64 heads at 8192 x 8192, which OOMs
+        for h0 in range(0, qb_reshaped.shape[0], ref_head_chunk):
+            h1 = min(h0 + ref_head_chunk, qb_reshaped.shape[0])
+            p = torch.matmul(
+                qb_reshaped[h0:h1], kb_reshaped[h0:h1].transpose(-2, -1)
+            ) / math.sqrt(d)
+            if inv_mask is not None:
+                p.masked_fill_(inv_mask, float("-inf"))
+            p = torch.softmax(p.float(), dim=-1).to(q.dtype)
+            refb = torch.matmul(p, vb_reshaped[h0:h1])
+            ref_out[start_q : (start_q + int(n_ctx_q)), h0:h1, :] = refb.transpose(0, 1)
+            del p, refb
         start += b
         start_q += n_ctx_q
     return ref_out
@@ -499,6 +510,73 @@ def test_persistent_lean_attention_outer(
     atol = 1.4e-1 if init_dtype == "fp8" else 1e-2
     rtol = 1e-2 if init_dtype == "fp8" else 3e-3
     torch.testing.assert_close(ref_out, la_out, atol=atol, rtol=rtol)
+
+
+# Covers the config path: the public entry point is the only reader of
+# <arch>-LEANATTN-DEFAULT.json, and nothing else exercised it. One case per entry,
+# since each is only legal in its own regime (BLOCK_M has to fit n_ctx_q).
+@pytest.mark.parametrize(
+    "causal, batch, hq, hk, n_ctx_q, n_ctx, d",
+    [
+        (True, 1, 64, 64, 1024, [1024], 128),  # -> prefill/"causal" entry
+        (False, 1, 64, 64, 16, [8192], 128),  # -> "decode" entry
+    ],
+)
+def test_persistent_lean_attention_config_path(
+    causal, batch, hq, hk, n_ctx_q, n_ctx, d
+):
+    torch.cuda.empty_cache()
+    torch.manual_seed(20)
+
+    dev = arch_info.get_arch()
+    try:
+        config = _get_config(causal=causal, n_ctx_q=n_ctx_q)
+    except FileNotFoundError:
+        pytest.skip(f"no {dev}-LEANATTN-DEFAULT.json to exercise the config path")
+
+    # An arch file with only "any" (gfx942) has no decode entry, so the decode case
+    # gets the prefill tile and Mp/Lp validation would fail.
+    if config["BLOCK_SIZE_M"] > n_ctx_q:
+        pytest.skip(
+            f"{dev} config has no entry legal here: "
+            f"BLOCK_SIZE_M={config['BLOCK_SIZE_M']} > n_ctx_q={n_ctx_q}"
+        )
+
+    # Caller sizes the buffers by total_programs, which the entry point re-derives
+    # and validates against.
+    total_programs = get_num_sms() * config["SM_CNT_FACTOR"]
+
+    q, k, v, Mp, Lp, Op, locks, batch_num_block_n = get_lean_attn_inputs(
+        batch,
+        n_ctx_q,
+        n_ctx,
+        config["BLOCK_SIZE_N"],
+        hq,
+        hk,
+        d,
+        total_programs,
+        torch.float16,
+    )
+
+    la_out = persistent_lean_attention(
+        q,
+        k,
+        v,
+        Mp,
+        Lp,
+        Op,
+        locks,
+        batch_num_block_n,
+        batch,
+        sm_scale=d**-0.5,
+        causal=causal,
+        RAGGED_BATCH=False,
+    )
+    if isinstance(la_out, tuple):
+        la_out = la_out[0]
+
+    ref_out = reference_attention(q, k, v, n_ctx, n_ctx_q, causal)
+    torch.testing.assert_close(ref_out, la_out, atol=1e-2, rtol=3e-3)
 
 
 def print_mismatches(ref_out, la_out, atol=1e-8, rtol=1e-5):


### PR DESCRIPTION
## Motivation

`persistent_lean_attention()`, the public entry point, and the only caller of `_get_config()`, did not execute on any architecture. Three defects fired before the kernel launched:

|  | defect | symptom | fix |
|---|---|---|---|
| 1 | `arch_info.get_num_sms()` does not exist — it lives in `utils.device_info` | `AttributeError`, every arch | import from where it lives |
| 2 | `**config` splatted into a launch that already passes those keys by name | `TypeError: got multiple values for keyword argument 'XCD_REMAP'` | filter consumed keys, forward the rest |
| 3 | no `gfx950-LEANATTN-DEFAULT.json` (only `gfx942` exists) | `FileNotFoundError` on gfx950 | add a tuned gfx950 config |

Defects 1 and 2 are present identically in the pinned reference clone, so neither is a regression. They survived because nothing exercised the path: `bench_la.py` passes launch parameters that were hand-picked straight to the internal `_persistent_lean_attention` and never reads a config, and the only tests touching the public entry point are `@pytest.mark.skip`.

The benchmark also hardcodes `total_programs=608` — `2 × 304`, a **gfx942** CU count. gfx950 has 256 CUs, so that grid is wrong for this GPU: correcting it is worth 20–29% on Triton 3.8 and 24–35% on Triton 3.4, and it penalizes both compilers, so it is not a compiler issue.

## Technical Details

4 files were changed and a config file was introduced

- **`attention/lean_atten.py`** - import `get_num_sms` from `utils.device_info`; drop the unused `arch_info` import. Filter config keys the wrapper already handles via `explicit_config_keys_handler`. Everything else is forwarded as `**launch_options`.
- **`_triton_kernels/attention/lean_atten.py`** - `_get_config(causal, n_ctx_q)` selects a `"decode"` or `"causal"` entry, falling back to `"any"` so existing arch files are unaffected. It keys on `n_ctx_q`, not `causal`, because the wrong entry is *illegal*, not just slow: `Mp`/`Lp` are validated against `BLOCK_M` (so `BLOCK_M ≤ n_ctx_q`), and causal asserts `BLOCK_M % BLOCK_N == 0`, which `BLOCK_M=16` with `BLOCK_N=64` violates. An earlier revision keyed on `causal` and crashed the GPU on non-causal prefill; the new test caught it.
- **New `configs/gfx950-LEANATTN-DEFAULT.json`** - Needed separate tuning for causal and decode.
- **`bench_la.py`** - opt-in `--use-config` so the shipped path is measurable. Without the flag the benchmark takes the same `x_vals` branch and builds an identical launch (same `total_programs`, `BLOCK_M/N`, `num_warps`, `waves_per_eu`,  XCD_REMAP`)
- **`test_la.py`** - new `test_persistent_lean_attention_config_path`, the first *executable* caller of the public entry point (the pre-existing one is skipped). There was an issue where it bounds the torch reference's peak memory: it materialised the whole score matrix - 8 GiB of fp16 scores plus two live 16 GiB fp32 buffers (the `.float()` copy and the softmax output), a measured **40.9 GiB peak for one test**, which OOMs when anything shares the GPU — and now chunks over heads. Tests go 22 → 24 collected.

Two config values were chosen from measurement, not copied from gfx942:

- **`BLOCK_N=64` and `waves_per_eu=4` are both required for decode.** Changing only
  `waves_per_eu` is catastrophic at `BLOCK_N=128` (+295% / +256%), and the grid is sharply
  non-monotonic (`BLOCK_N=256, num_warps=8, waves_per_eu=4` measured +1031%), so it cannot
  be tuned one axis at a time.
- **`matrix_instr_nonkdim` is omitted.** gfx942 sets it to 16, pinning MFMA to 16×16; on
  gfx950 that made shape 0 **2.39× slower** - 0.82 -> 1.97 ms kernel-only, trimmed mean of
  50 dispatches (`measurements/nonkdim_{with,without}`). Only shape 0 was measured.

### Deliberately not in this PR

- **`sm_scale` is accepted and ignored** - the wrapper never forwards it and
  `_persistent_lean_attention` hardcodes `q.shape[-1] ** -0.5`. This is out of scope.

## Test Plan

1. **Correctness** - full `test_la.py`.
2. **Routing** - each of the 12 benchmark shapes selects the intended config entry, and the launched grid is the 512 the config asks for wherever the workload fills it.
3. **gfx942 back-compat** - with `arch_info` reporting gfx942: config resolution for all three regimes, the launch-option filter, the new test's skip logic, and an end-to-end run using gfx942's config values.
4. **Benchmark default mode** - `bench_la.py` builds an identical launch without `--use-config`.
5. **Reference-memory equivalence** - all-heads vs chunked, peak allocation and checksum.
6. **Performance** - `rocprofv3 --kernel-trace`, kernel-only time for `la_persistent` over all 12 shapes. **250 dispatches per cell, bottom and top 10% discarded, mean of the middle 80%**, from per-dispatch timestamps. Variants run **adjacent in time per shape** with **order alternated** across 3 reps, deltas computed within each pair - 72 runs / 18,000 dispatches. A sweep-per-variant layout produced a spurious result that reversed sign under interleaving.
7. **Lint** - `ruff check`, `black --check`.

## Test Result

- Correctness: 22 passed, 2 skipped

- Routing: 12/12 shapes select the intended entry. Shapes 0–8 get the prefill tiling
(`BLOCK_M=128, BLOCK_N=64`), shapes 9–11 the decode tiling (`BLOCK_M=16, BLOCK_N=64`).
Launched `total_programs` is 512 everywhere except shape 3, where the workload clamps both
variants to 144.

- gfx942 back-compat: 7 static checks plus 2 GPU checks pass
(driver run on gfx950 with `arch_info` reporting gfx942 given that there's no hardware for gfx942 accessible):

| check | result |
|---|---|
| `_get_config` on the real gfx942 JSON, all 3 regimes | falls back to `"any"`, no `KeyError` |
| `"any"` is load-bearing | removing it raises `KeyError`, as claimed |
| launch-option filter | `launch_options={'matrix_instr_nonkdim': 16}` — forwarded, no consumed key leaked |
| new test, gfx942 decode case | **skips**, does not `ValueError` (guard present, `BLOCK_SIZE_M=128 > 16`) |
| new test, gfx942 prefill case | legal by inspection (`128 ≤ 1024`, `128 % 64 == 0`); not run as a test |
| gfx942 config values end-to-end (GPU) | runs with `nonkdim=16` forwarded |
| numerics with `nonkdim=16` (GPU) | matches the torch reference at `atol=1e-2, rtol=3e-3` |

**Performance — baseline = `bench_la.py`'s hardcoded `x_vals`; config = public entry point
reading the new gfx950 file. Both on Triton 3.8.**

| # | mode | batch | hq | hk | n_ctx_q | n_ctx_k | d | baseline (ms) | config (ms) | delta | 95% CI | verdict |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 0 | causal | 1 | 32 | 8 | 8192 | 8192 | 128 | 0.9829 | 0.7901 | −19.62% | [−19.97, −19.26] | improvement |
| 1 | causal | 1 | 64 | 8 | 8192 | 8192 | 128 | 2.0010 | 1.5632 | −21.88% | [−22.32, −21.44] | improvement |
| 2 | causal | 1 | 128 | 8 | 8192 | 8192 | 128 | 4.4271 | 3.1706 | −28.37% | [−30.64, −26.10] | improvement |
| 3 | causal | 1 | 32 | 16 | 1024 | 1024 | 128 | 0.0543 | 0.0543 | +0.01% | [−2.05, +2.08] | okay |
| 4 | causal | 1 | 64 | 16 | 1024 | 1024 | 128 | 0.0784 | 0.0512 | −34.69% | [−35.72, −33.66] | improvement |
| 5 | causal | 1 | 128 | 16 | 1024 | 1024 | 128 | 0.0997 | 0.0752 | −24.55% | [−26.88, −22.22] | improvement |
| 6 | causal | 1 | 32 | 32 | 2048 | 2048 | 128 | 0.0938 | 0.0753 | −19.66% | [−21.46, −17.86] | improvement |
| 7 | causal | 1 | 64 | 32 | 2048 | 2048 | 128 | 0.1621 | 0.1253 | −22.73% | [−24.09, −21.37] | improvement |
| 8 | causal | 1 | 128 | 32 | 2048 | 2048 | 128 | 0.2997 | 0.2422 | −19.18% | [−20.39, −17.96] | improvement |
| 9 | decode | 512 | 32 | 8 | 16 | 8192 | 128 | 13.0404 | 7.1403 | **−45.25%** | [−45.66, −44.83] | improvement |
| 10 | decode | 512 | 64 | 8 | 16 | 8192 | 128 | 25.5451 | 13.6942 | **−46.39%** | [−46.58, −46.21] | improvement |
| 11 | decode | 512 | 128 | 8 | 16 | 8192 | 128 | 50.2278 | 26.7873 | **−46.67%** | [−47.06, −46.28] | improvement |

**11 improvements, 0 regressions.** This replaces the three decode regressions
(+44.21% / +11.03% / +2.97%) that motivated the retune. Two campaigns run days apart
agree on decode to within 0.9pp (−20.97 / −40.94 / −45.97 vs −21.43 / −40.88 / −45.10).

**Numerics.** `waves_per_eu` is a scheduling hint and cannot change results — shape 9,
where it is the only change, is bitwise identical across `wpe=2` and `wpe=4`. Shapes 10 and
11 also move `BLOCK_N`, reassociating the softmax accumulation; the archived evidence for
those two is the suite passing at `atol=1e-2, rtol=3e-3`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
