### PR TITLE
[FlyDSL] registering ops in pytorch

### DIFF
--- a/aiter/ops/flydsl/fmha_kernels.py
+++ b/aiter/ops/flydsl/fmha_kernels.py
@@ -272,3 +272,49 @@ def flydsl_flash_attn_varlen_func(
         out=out,
         return_lse=return_lse,
     )
+
+
+# ---------------------------------------------------------------------------
+# Expose flydsl_flash_attn_func to the PyTorch dispatcher
+# (torch.ops.aiter.flydsl_flash_attn_func).
+# ---------------------------------------------------------------------------
+import functools as _ft
+import inspect as _insp
+
+from csrc.cpp_itfs.torch_utils import direct_register_custom_op
+
+_orig_flydsl_flash_attn_func = flydsl_flash_attn_func
+_faf_sig = _insp.signature(_orig_flydsl_flash_attn_func)
+
+
+@_ft.wraps(_orig_flydsl_flash_attn_func)
+def _flydsl_flash_attn_func_op(*args, **kwargs):
+    kwargs.pop("stream", None)
+    bound = _flydsl_flash_attn_func_op.__signature__.bind(*args, **kwargs)
+    bound.apply_defaults()
+    return _orig_flydsl_flash_attn_func(**bound.arguments)
+
+
+_flydsl_flash_attn_func_op.__signature__ = _faf_sig.replace(
+    parameters=[p for n, p in _faf_sig.parameters.items() if n != "stream"]
+)
+_flydsl_flash_attn_func_op.__annotations__ = {
+    k: v
+    for k, v in _orig_flydsl_flash_attn_func.__annotations__.items()
+    if k != "stream"
+}
+
+if not hasattr(torch.ops.aiter, "flydsl_flash_attn_func"):
+    direct_register_custom_op(
+        "flydsl_flash_attn_func",
+        _flydsl_flash_attn_func_op,
+        mutates_args=[],
+        fake_impl=lambda q, k, v, *a_, **k_: torch.empty_like(q),
+    )
+
+
+def flydsl_flash_attn_func(*args, **kwargs):
+    if kwargs.get("stream") is not None:
+        return _orig_flydsl_flash_attn_func(*args, **kwargs)
+    kwargs.pop("stream", None)
+    return torch.ops.aiter.flydsl_flash_attn_func(*args, **kwargs)

--- a/aiter/ops/flydsl/gemm_kernels.py
+++ b/aiter/ops/flydsl/gemm_kernels.py
@@ -1066,3 +1066,46 @@ def flydsl_preshuffle_gemm_a8(
         Out.copy_(out_contig)
 
     return Out
+
+
+# ---------------------------------------------------------------------------
+# Expose flydsl_preshuffle_gemm_a8 to the PyTorch dispatcher
+# (torch.ops.aiter.flydsl_preshuffle_gemm_a8).
+# ---------------------------------------------------------------------------
+import functools as _ft
+import inspect as _insp
+
+from csrc.cpp_itfs.torch_utils import direct_register_custom_op
+
+_orig_flydsl_preshuffle_gemm_a8 = flydsl_preshuffle_gemm_a8
+_psg_sig = _insp.signature(_orig_flydsl_preshuffle_gemm_a8)
+
+
+@_ft.wraps(_orig_flydsl_preshuffle_gemm_a8)
+def _flydsl_preshuffle_gemm_a8_op(*args, **kwargs):
+    bound = _flydsl_preshuffle_gemm_a8_op.__signature__.bind(*args, **kwargs)
+    bound.apply_defaults()
+    _orig_flydsl_preshuffle_gemm_a8(**bound.arguments)  # writes Out; return discarded
+
+
+# Register annotation: mutating op returns None (schema `-> ()`).
+_flydsl_preshuffle_gemm_a8_op.__signature__ = _psg_sig.replace(return_annotation=None)
+_flydsl_preshuffle_gemm_a8_op.__annotations__ = {
+    **_orig_flydsl_preshuffle_gemm_a8.__annotations__,
+    "return": None,
+}
+
+if not hasattr(torch.ops.aiter, "flydsl_preshuffle_gemm_a8"):
+    direct_register_custom_op(
+        "flydsl_preshuffle_gemm_a8",
+        _flydsl_preshuffle_gemm_a8_op,
+        mutates_args=["Out"],
+        fake_impl=lambda *a_, **k_: None,
+    )
+
+
+def flydsl_preshuffle_gemm_a8(*args, **kwargs):
+    bound = _psg_sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+    torch.ops.aiter.flydsl_preshuffle_gemm_a8(**bound.arguments)
+    return bound.arguments["Out"]

--- a/aiter/ops/flydsl/mla_reduce_kernels.py
+++ b/aiter/ops/flydsl/mla_reduce_kernels.py
@@ -485,9 +485,7 @@ _flydsl_mla_reduce_v1_op.__signature__ = _mlar_sig.replace(
     parameters=[p for n, p in _mlar_sig.parameters.items() if n != "stream"]
 )
 _flydsl_mla_reduce_v1_op.__annotations__ = {
-    k: v
-    for k, v in _orig_flydsl_mla_reduce_v1.__annotations__.items()
-    if k != "stream"
+    k: v for k, v in _orig_flydsl_mla_reduce_v1.__annotations__.items() if k != "stream"
 }
 
 if not hasattr(torch.ops.aiter, "flydsl_mla_reduce_v1"):

--- a/aiter/ops/flydsl/mla_reduce_kernels.py
+++ b/aiter/ops/flydsl/mla_reduce_kernels.py
@@ -458,3 +458,49 @@ def flydsl_mla_reduce_v1(
         int(final_output.size(0)),
         fx.Stream(stream),
     )
+
+
+# ---------------------------------------------------------------------------
+# Expose flydsl_mla_reduce_v1 to the PyTorch dispatcher
+# (torch.ops.aiter.flydsl_mla_reduce_v1).
+# ---------------------------------------------------------------------------
+import functools as _ft
+import inspect as _insp
+
+from csrc.cpp_itfs.torch_utils import direct_register_custom_op
+
+_orig_flydsl_mla_reduce_v1 = flydsl_mla_reduce_v1
+_mlar_sig = _insp.signature(_orig_flydsl_mla_reduce_v1)
+
+
+@_ft.wraps(_orig_flydsl_mla_reduce_v1)
+def _flydsl_mla_reduce_v1_op(*args, **kwargs):
+    kwargs.pop("stream", None)
+    bound = _flydsl_mla_reduce_v1_op.__signature__.bind(*args, **kwargs)
+    bound.apply_defaults()
+    _orig_flydsl_mla_reduce_v1(**bound.arguments)  # writes final_output/final_lse
+
+
+_flydsl_mla_reduce_v1_op.__signature__ = _mlar_sig.replace(
+    parameters=[p for n, p in _mlar_sig.parameters.items() if n != "stream"]
+)
+_flydsl_mla_reduce_v1_op.__annotations__ = {
+    k: v
+    for k, v in _orig_flydsl_mla_reduce_v1.__annotations__.items()
+    if k != "stream"
+}
+
+if not hasattr(torch.ops.aiter, "flydsl_mla_reduce_v1"):
+    direct_register_custom_op(
+        "flydsl_mla_reduce_v1",
+        _flydsl_mla_reduce_v1_op,
+        mutates_args=["final_output", "final_lse"],
+        fake_impl=lambda *a_, **k_: None,
+    )
+
+
+def flydsl_mla_reduce_v1(*args, **kwargs):
+    if kwargs.get("stream") is not None:
+        return _orig_flydsl_mla_reduce_v1(*args, **kwargs)
+    kwargs.pop("stream", None)
+    return torch.ops.aiter.flydsl_mla_reduce_v1(*args, **kwargs)


### PR DESCRIPTION
[Feature] Register FlyDSL ops as torch custom ops (dispatcher + torch.compile visibility)

## Summary
Register three FlyDSL host launchers as `torch.library` custom ops under the
`aiter` namespace so they become visible to the PyTorch dispatcher:
`flydsl_flash_attn_func`, `flydsl_preshuffle_gemm_a8`, and `flydsl_mla_reduce_v1`
(now callable as `torch.ops.aiter.<name>`).

## Motivation
FlyDSL kernels are JIT-compiled via `flyc.compile` and launched directly, so they
**bypass the PyTorch dispatcher**. Consequently they:
- show up in `torch.profiler(record_shapes=True)` traces with **no `Input Dims`**
  (blocking shape-aware/roofline analysis), and
- are **opaque/untraceable under `torch.compile`** (Dynamo cannot trace the JIT
  kernel).

Registering them as custom ops (with a fake/meta impl) fixes both — the same
reason aiter already wraps many HIP/Triton kernels via `direct_register_custom_op`.

## Changes
- Wrap each op's public entry point and register it via
  `csrc.cpp_itfs.torch_utils.direct_register_custom_op` (idempotent `hasattr`
  guard; original kept as `_orig_*`; kernel bodies unchanged).
- Drop the `stream` argument from the schema where present (`torch.cuda.Stream`
  is not a legal schema type); a caller passing a real `stream` bypasses the op.
- Provide a `fake_impl` for shape/dtype propagation under `torch.compile`.
- In-place ops deliberately return `None` (pure side-effect) rather than
  returning the mutated tensor, which keeps the schema truthful **and** avoids the
  `auto_functionalized` return-value `getitem` that Inductor rejects.

Files: `aiter/ops/flydsl/{fmha_kernels,gemm_kernels,mla_reduce_kernels}.py`
(+135 lines, no changes to kernel logic).

## Performance (if applicable)
N/A — thin registration wrappers around unchanged kernels. Dispatcher overhead
applies only to the wrapped call path (unused unless the op is invoked); no
steady-state serving impact expected.

## Testing
- [x] Registered schemas validated with `torch.library.infer_schema`
## Documentation
- [x] Explanatory comments added at each registration block.

## Dependencies
- [x] No new third-party dependencies added.

## Breaking Changes
None. Public function signatures and return values are preserved
(`flydsl_flash_attn_func` → Tensor, `flydsl_preshuffle_gemm_a8` → `Out`,
`flydsl_mla_reduce_v1` → `None`); a real `stream` argument still works via the
bypass path.