### PR TITLE
Fix gfx1250 (NPS2, DPX mode) custom all-reduce input publication

### DIFF
--- a/csrc/include/custom_all_reduce_gfx1250.cuh
+++ b/csrc/include/custom_all_reduce_gfx1250.cuh
@@ -316,11 +316,11 @@ DINLINE void start_sync(const RankSignals& sg, Signal* self_sg, int rank)
     {
         __scoped_atomic_store_n(&sg.signals[threadIdx.x]->start[blockIdx.x][rank],
                                 flag,
-                                __ATOMIC_RELAXED,
+                                __ATOMIC_RELEASE,
                                 __MEMORY_SCOPE_SYSTEM);
         while(__scoped_atomic_load_n(&self_sg->start[blockIdx.x][threadIdx.x],
-                                     __ATOMIC_RELAXED,
-                                     __MEMORY_SCOPE_DEVICE) < flag)
+                                     __ATOMIC_ACQUIRE,
+                                     __MEMORY_SCOPE_SYSTEM) < flag)
             ;
     }
     __syncthreads();

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce_barrier.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce_barrier.py
@@ -64,9 +64,7 @@ def _worker(
     graph_out = None
     if with_graph:
         graph = torch.cuda.CUDAGraph()
-        with graph_capture() as capture, torch.cuda.graph(
-            graph, stream=capture.stream
-        ):
+        with graph_capture() as capture, torch.cuda.graph(graph, stream=capture.stream):
             graph_out = tensor_model_parallel_all_reduce(inp)
         torch.cuda.synchronize()
 

--- a/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce_barrier.py
+++ b/op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce_barrier.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Regression test for gfx1250 custom-allreduce input publication.
+
+The regular correctness test synchronizes after each invocation. That hides a
+barrier bug because the registered input pool is not reused while peer reads
+are still in flight. This test queues many collectives with changing inputs
+before synchronizing, forcing repeated reuse of the same registered pool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from multiprocessing import Pool, set_start_method
+
+os.environ.setdefault("ENABLE_CK", "0")
+
+import torch
+
+from aiter.dist.utils import get_distributed_init_method, get_ip, get_open_port
+
+set_start_method("spawn", force=True)
+
+
+def _worker(
+    rank: int,
+    world_size: int,
+    init_method: str,
+    iterations: int,
+    numel: int,
+    with_graph: bool,
+) -> tuple[float, int]:
+    torch.cuda.set_device(rank)
+
+    from aiter.dist.communication_op import tensor_model_parallel_all_reduce
+    from aiter.dist.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        ensure_model_parallel_initialized,
+        get_tp_group,
+        graph_capture,
+        init_distributed_environment,
+        set_custom_all_reduce,
+    )
+
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        distributed_init_method=init_method,
+    )
+    ensure_model_parallel_initialized(world_size, 1)
+
+    ca = get_tp_group().device_communicator.ca_comm
+    assert ca is not None and not ca.disabled
+
+    inp = torch.empty(numel, dtype=torch.float16, device=f"cuda:{rank}")
+    assert ca.should_custom_ar(inp)
+    assert inp.nbytes > 4 * 1024 * 1024, "test input must bypass the LL protocol"
+
+    graph = None
+    graph_out = None
+    if with_graph:
+        graph = torch.cuda.CUDAGraph()
+        with graph_capture() as capture, torch.cuda.graph(
+            graph, stream=capture.stream
+        ):
+            graph_out = tensor_model_parallel_all_reduce(inp)
+        torch.cuda.synchronize()
+
+    outputs: list[tuple[torch.Tensor, float]] = []
+    for iteration in range(iterations):
+        local_value = float((iteration * 7 + rank * 13) % 97)
+        expected = sum(
+            float((iteration * 7 + peer_rank * 13) % 97)
+            for peer_rank in range(world_size)
+        )
+        inp.fill_(local_value)
+        if graph is None:
+            out = tensor_model_parallel_all_reduce(inp)
+        else:
+            graph.replay()
+            # The captured graph reuses one output address. Queue a D2D snapshot
+            # after every replay so every result remains independently testable.
+            assert graph_out is not None
+            out = torch.empty_like(graph_out)
+            out.copy_(graph_out)
+        outputs.append((out, expected))
+
+    # Synchronize only after all launches. Retaining every output prevents
+    # allocator reuse and lets us verify every queued collective independently.
+    torch.cuda.synchronize()
+    errors = [(out.float() - expected).abs().max() for out, expected in outputs]
+    error_values = torch.stack(errors).cpu()
+    max_error = error_values.max().item()
+    failures = torch.count_nonzero(error_values).item()
+
+    destroy_model_parallel()
+    destroy_distributed_environment()
+    print(
+        f"rank={rank} iterations={iterations} "
+        f"max_error={max_error} failures={failures}",
+        flush=True,
+    )
+    return max_error, failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, default=64)
+    parser.add_argument("--with-graph", action="store_true")
+    parser.add_argument(
+        "--numel",
+        type=int,
+        default=512 * 8192,
+        help="FP16 elements; default is 8 MiB and bypasses the 4 MiB LL path",
+    )
+    args = parser.parse_args()
+
+    world_size = 2
+    if torch.cuda.device_count() < world_size:
+        print("SKIP: two GPUs are required")
+        return 0
+
+    init_method = get_distributed_init_method(get_ip(), get_open_port())
+    with Pool(processes=world_size) as pool:
+        jobs = [
+            pool.apply_async(
+                _worker,
+                (
+                    rank,
+                    world_size,
+                    init_method,
+                    args.iterations,
+                    args.numel,
+                    args.with_graph,
+                ),
+            )
+            for rank in range(world_size)
+        ]
+        results = [job.get(timeout=600) for job in jobs]
+
+    max_error = max(error for error, _ in results)
+    failures = sum(count for _, count in results)
+    print(f"max_error={max_error} total_failures={failures}", flush=True)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Use system-scope release/acquire atomics in the gfx1250 `start_sync` barrier. This prevents the large-message custom all-reduce kernel from reading stale peer input.

The change also adds a regression test that covers eager execution and graph replay with back-to-back, changing inputs.

## Problem

The eager gfx1250 path copies each rank's input into a reusable IPC-registered buffer before launching the collective kernel. The kernel then signals that the input is ready and reads the peer buffers.

The existing barrier uses a relaxed store and a device-scope relaxed load. A peer can therefore observe the ready flag before the producer's input copy is visible system-wide. The collective completes normally but returns incorrect results.

This affects the registered-buffer kernel used above the 4 MiB LL threshold. The LL protocol is not affected.

## Changes

- Change the `start_sync` store to `__ATOMIC_RELEASE` at system scope.
- Change the matching load to `__ATOMIC_ACQUIRE` at system scope.
- Add a TP=2 regression test using 8 MiB FP16 inputs.

The regression queues 64 collectives with changing values before synchronizing, then checks every output. This makes stale reads observable and mirrors repeated registered-buffer reuse during serving.

## Reproduction

```bash
rm -rf \
  aiter/jit/module_custom_all_reduce_gfx1250.so \
  aiter/jit/build/module_custom_all_reduce_gfx1250

HIP_VISIBLE_DEVICES=0,1 \
python op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce_barrier.py

HIP_VISIBLE_DEVICES=0,1 \
python op_tests/multigpu_tests/gfx1250_poc/test_gfx1250_allreduce_barrier.py \
  --with-graph
```

Results on gfx1250, TP=2, ROCm 7.15, HIP IPC:

- Without the fix:
  - Eager: 127/128 outputs incorrect, max error 93.
  - Graph: 126/128 outputs incorrect, max error 94.
- With the fix:
  - Eager: 0/128 outputs incorrect.
  - Graph: 0/128 outputs incorrect.

## Caveat
This accuracy fix (for NPS2?) may introduce expensive overheads. We may need to explore other ways to fix the issue.

cc: @HaiShaw @sogalin 