### PR TITLE
[Triton][gfx1151] Enable GEMM-A16W16

### DIFF
--- a/aiter/ops/triton/configs/gfx1151/triton/gemm/gemm_a16w16/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx1151/triton/gemm/gemm_a16w16/DEFAULT.json
@@ -1,0 +1,38 @@
+{
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}


### PR DESCRIPTION
## Motivation

Enable the Triton `GEMM-A16W16` path on `gfx1151`.

Before this change, calling `gemm_a16w16` on a gfx1151 device failed during config resolution because no architecture-specific default config existed:

```text
AssertionError: Required config file doesn't exist:
.../aiter/ops/triton/configs/gemm/gfx1151-GEMM-A16W16.json
```

This prevented BF16 A16W16 GEMMs from using the existing Triton kernel on gfx1151. The goal of this PR is to provide a robust generic default config so the public wrapper works without adding architecture-specific kernel code.

Related gfx1151 enablement precedent: #3917.

## Technical Details

Added the gfx1151 Triton default config using the current nested config layout:

```text
aiter/ops/triton/configs/gfx1151/triton/gemm/gemm_a16w16/DEFAULT.json
```

The default is split into three M ranges based on correctness and performance screening across synthetic and representative LLM shapes:

| M range | Tile `(BM, BN, BK)` | Warps | Waves/EU | B-load cache policy |
|---|---:|---:|---:|---|
| `M <= 256` | `(32, 16, 256)` | 2 | 1 | default |
| `257 <= M <= 1024` | `(32, 32, 256)` | 4 | 1 | default |
| fallback | `(64, 64, 256)` | 4 | 2 | `.cg` |

All entries use `GROUP_SIZE_M=1`, `num_stages=2`, `matrix_instr_nonkdim=16`, and `NUM_KSPLIT=1`.

The small-M config favors decode and small-batch projection workloads. The middle bucket avoids regressions observed when extending the small tile to `M=512/1024`. The fallback prioritizes stable performance across larger M and mixed N/K shapes.

This PR changes only JSON tuning data. It does not modify the kernel, config resolver, dispatcher, or public API.

## Test Plan

Test environment:

- GPU: AMD Radeon 8060S (`gfx1151`, 40 CUs)
- ROCm: 7.2
- PyTorch: `2.12.1+rocm7.2`
- Triton: `3.7.1`
- Input/output dtype: BF16
 
Run the existing real-shape GEMM correctness coverage for the Triton backend:

```bash
pytest -q \
  op_tests/triton_tests/gemm/basic/test_gemm_a16w16.py::test_gemm_a16_w16 \
  -k 'bandwidth_bound and triton and (7168 or 2880)'
```

Run representative performance measurements through the existing benchmark:

```bash
python op_tests/op_benchmarks/triton/bench_gemm_a16w16.py \
  --shape M N K --metric time --backend triton
```

Performance screening used `triton.testing.do_bench` with 25 warmup iterations and 100 measured iterations. AITER and `torch.addmm` both used preallocated BF16 outputs and included bias. Each candidate config was checked against `torch.nn.functional.linear` before timing.

Representative shapes were taken from GPT-OSS 120B, DeepSeek-R1/Kimi-K2, and Llama 3 8B projection/FFN layers, covering decode, small-batch, and prefill M ranges.

## Test Result

Existing pytest coverage:

```text
16 passed, 16 skipped, 68 deselected in 5.20s
```

Additional public-wrapper correctness validation passed for all 16 tested model shapes, including both config boundaries and the fallback range.

Representative BF16 latency results:

| Workload | Shape `(M, N, K)` | AITER | `torch.addmm` | Speedup |
|---|---:|---:|---:|---:|
| GPT-OSS attention projection | `(1, 128, 2880)` | 21.96 us | 78.24 us | 3.56x |
| GPT-OSS dense projection | `(256, 2880, 4096)` | 488.18 us | 846.07 us | 1.73x |
| DeepSeek/Kimi projection | `(64, 256, 7168)` | 65.90 us | 361.01 us | 5.48x |
| DeepSeek/Kimi projection | `(1024, 256, 7168)` | 388.73 us | 455.06 us | 1.17x |
| Llama 3 8B FFN down | `(64, 4096, 14336)` | 1.167 ms | 1.842 ms | 1.58x |
| Llama 3 8B FFN down | `(1024, 4096, 14336)` | 8.535 ms | 10.471 ms | 1.23x |
| Llama 3 8B FFN down | `(2048, 4096, 14336)` | 13.771 ms | 14.796 ms | 1.07x |

AITER was faster than `torch.addmm` on 12 of the 16 representative model shapes, with up to 5.69x speedup on small-M projection workloads. This config is intended as a robust generic default; additional N/K-specific tuning can be added separately for workloads that benefit from specialized configs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
