### PR TITLE
feat(ep): TDM dispatch transport for gfx1250

### DIFF
--- a/aiter/ops/flydsl/dispatch_combine_v2/dispatch_combine_op.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/dispatch_combine_op.py
@@ -30,6 +30,11 @@ import torch
 import flydsl.expr as fx
 from mori.tensor_utils import from_gpu_ptr
 
+from .intranode_kernels_tdm import (
+    make_dispatch_tdm,
+    tdm_max_warps,
+    tdm_stage_capacity,
+)
 from .intranode_kernels import (
     xdb_flag_slots,
     make_dispatch,
@@ -323,6 +328,14 @@ class EpDispatchCombineConfig:
     # > 0): the wire must carry fp8 + e8m0 only, never bf16 alongside it. Default
     # off; the existing dispatch -> finalize -> GEMM1 sequence stays the fallback.
     push_group_overlap: bool = False
+    # Which dispatch transport to build: "vector" is the portable per-lane 16 B
+    # copy, "tdm" the gfx1250 Tensor-Data-Mover port of mori's
+    # ep_intranode_1250x (block-local counting + one remote atomic per
+    # (block, peer) + bulk metadata + DMA payload). "auto" picks vector, so
+    # nothing changes for existing callers; env AITER_EP_DISPATCH_TDM=1 flips
+    # the auto default for A/B runs. The two produce interchangeable state, so
+    # combine / replay / the routing handle do not care which ran.
+    dispatch_transport: str = "auto"
 
     def __post_init__(self):
         # all-or-none: setting only one silently defaults the other to data_type.
@@ -339,6 +352,34 @@ class EpDispatchCombineConfig:
                 f"combine_quant_type must be one of {_COMBINE_QUANT_TYPES}, "
                 f"got {self.combine_quant_type!r}"
             )
+        if self.dispatch_transport not in ("auto", "vector", "tdm"):
+            raise ValueError(
+                "dispatch_transport must be auto|vector|tdm, "
+                f"got {self.dispatch_transport!r}"
+            )
+        if self.dispatch_transport == "auto":
+            self.dispatch_transport = (
+                "tdm" if os.environ.get("AITER_EP_DISPATCH_TDM") == "1" else "vector"
+            )
+        if self.dispatch_transport == "tdm":
+            # Each of these has its own staging region / slot arithmetic that the
+            # TDM kernel does not carry; failing loudly beats silently dropping
+            # scales or landing tokens in the wrong group.
+            unsupported = [
+                name
+                for name, on in (
+                    ("scale_dim", self.scale_dim > 0),
+                    ("push_group", self.push_group),
+                    ("fp4 tokens", self.is_fp4),
+                )
+                if on
+            ]
+            if unsupported:
+                raise ValueError(
+                    "dispatch_transport='tdm' does not implement "
+                    + ", ".join(unsupported)
+                    + "; use dispatch_transport='vector'"
+                )
         if self.combine_mode not in ("gather", "scatter", "scatter_fused"):
             raise ValueError(
                 "combine_mode must be gather|scatter|scatter_fused, "
@@ -922,6 +963,67 @@ class EpDispatchCombineOp:
             for (b, w) in dispatch_specs
         }
         self._dispatch_replay_variants = {}  # lazily compiled per (block, warp)
+
+        # TDM transport: same kwargs minus the knobs it does not implement, plus
+        # its own staging pool. FINALIZE gathers each route's metadata into a
+        # (block, peer)-contiguous run there so META can ship it in bulk; the
+        # pool is sized for the widest precompiled geometry, since a narrower
+        # grid only ever addresses a prefix of it.
+        self._dispatch_tdm_variants = {}
+        self._tdm_stage = None
+        if cfg.dispatch_transport == "tdm":
+            tdm_kwargs = {
+                k: v
+                for k, v in self._dispatch_kwargs.items()
+                if k
+                not in (
+                    "off_out_scales",
+                    "scale_dim",
+                    "scale_type_size",
+                    "fp4",
+                    "push_group",
+                    "push_group_cap",
+                    "off_pg_running",
+                    "off_pg_rowmap",
+                    "push_group_scale_wmma_rep",
+                )
+            }
+            # The schedule is tuned against the vector transport, which holds no
+            # per-warp LDS, so it can name a warp width this one cannot build
+            # (32 warps of a 7168-wide bf16 tile want 448 KB of a 320 KB budget).
+            # Clamp the width, keep the tuned block count, and keep the caller's
+            # spec as the key so _pick still resolves.
+            max_warps = tdm_max_warps(
+                hidden_dim=hidden_dim,
+                hidden_elem_size=elem_size,
+                npes=cfg.world_size,
+            )
+            tdm_geom = {(b, w): (b, min(w, max_warps)) for (b, w) in dispatch_specs}
+            slots = max(
+                tdm_stage_capacity(
+                    npes=cfg.world_size,
+                    experts_per_token=topk,
+                    max_tok_per_rank=max_tok_per_rank,
+                    block_num=b,
+                    warp_num_per_block=w,
+                )[1]
+                for (b, w) in tdm_geom.values()
+            )
+            dev = torch.cuda.current_device()
+            self._tdm_stage = (
+                torch.empty(slots * topk, dtype=torch.int32, device=dev),  # indices
+                torch.empty(slots * topk, dtype=torch.int32, device=dev),  # weights
+                torch.empty(slots, dtype=torch.int32, device=dev),  # srcmap
+            )
+            _built = {}
+            for spec, geom in tdm_geom.items():
+                if geom not in _built:
+                    _built[geom] = make_dispatch_tdm(
+                        block_num=geom[0],
+                        warp_num_per_block=geom[1],
+                        **tdm_kwargs,
+                    )
+                self._dispatch_tdm_variants[spec] = _built[geom]
         if cfg.is_fused:
             # gemm2 already P2P-wrote weighted per-(token,k) results into comb_inp;
             # combine only barriers (wait for peers' writes) + sums the topk slots.
@@ -1211,6 +1313,13 @@ class EpDispatchCombineOp:
         stream = fx.Stream(torch.cuda.current_stream())
         weight_ptr = weights.data_ptr() if weights is not None else 0
         if routing is not None:
+            if self._dispatch_tdm_variants:
+                raise NotImplementedError(
+                    "replay is not ported to dispatch_transport='tdm': its slots "
+                    "come from a per-(block, peer) reservation, so a cached map is "
+                    "only replayable under the same grid AND the same block->token "
+                    "assignment"
+                )
             kern = self._dispatch_replay_variants.get(disp_spec)
             if kern is None:
                 kern = self._dispatch_replay_variants[disp_spec] = make_dispatch(
@@ -1243,20 +1352,39 @@ class EpDispatchCombineOp:
                 if return_routing
                 else self.token_dest_map
             )
-            self._dispatch_variants[disp_spec](
-                self.arena.handle,
-                input.data_ptr(),
-                indices.data_ptr(),
-                weight_ptr,
-                dest_map.data_ptr(),
-                self.dest_pe_counter.data_ptr(),
-                self.dispatch_barrier.data_ptr(),
-                self.total_recv.data_ptr(),
-                scale_ptr,
-                self.cfg.rank,
-                num_input_tokens,
-                stream,
-            )
+            if self._dispatch_tdm_variants:
+                stg_idx, stg_wt, stg_src = self._tdm_stage
+                self._dispatch_tdm_variants[disp_spec](
+                    self.arena.handle,
+                    input.data_ptr(),
+                    indices.data_ptr(),
+                    weight_ptr,
+                    dest_map.data_ptr(),
+                    self.dest_pe_counter.data_ptr(),
+                    self.dispatch_barrier.data_ptr(),
+                    self.total_recv.data_ptr(),
+                    stg_idx.data_ptr(),
+                    stg_wt.data_ptr(),
+                    stg_src.data_ptr(),
+                    self.cfg.rank,
+                    num_input_tokens,
+                    stream,
+                )
+            else:
+                self._dispatch_variants[disp_spec](
+                    self.arena.handle,
+                    input.data_ptr(),
+                    indices.data_ptr(),
+                    weight_ptr,
+                    dest_map.data_ptr(),
+                    self.dest_pe_counter.data_ptr(),
+                    self.dispatch_barrier.data_ptr(),
+                    self.total_recv.data_ptr(),
+                    scale_ptr,
+                    self.cfg.rank,
+                    num_input_tokens,
+                    stream,
+                )
 
         out = self.recv_tokens()
         out_weights = self.recv_weights()

--- a/aiter/ops/flydsl/dispatch_combine_v2/flydsl_prims.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/flydsl_prims.py
@@ -88,6 +88,40 @@ def atomic_max_agent(addr_i64, val):
     ).res
 
 
+def _lds_ptr(addr_i64):
+    return _llvm_d.IntToPtrOp(
+        _llvm_d.PointerType.get(address_space=3), arith.unwrap(addr_i64)
+    ).result
+
+
+def atomic_add_lds(addr_i64, val):
+    """Workgroup-scope LDS fetch-and-add at addr_i64; returns old value.
+
+    ``addr_i64`` is a raw LDS byte address (``ptrtoint`` of a SharedAllocator
+    pointer), not a global one: the block-local counters this serves are hit by
+    every lane of every warp in the block, which in global memory would be a
+    device-scope atomic per route.
+    """
+    return _llvm_d.AtomicRMWOp(
+        _llvm_d.AtomicBinOp.add,
+        _lds_ptr(addr_i64),
+        arith.unwrap(val),
+        _llvm_d.AtomicOrdering.monotonic,
+        syncscope="workgroup",
+        alignment=4,
+    ).res
+
+
+def load_i32_lds(addr_i64):
+    """Plain i32 load from a raw LDS byte address."""
+    return _llvm_d.LoadOp(T.i32, _lds_ptr(addr_i64), alignment=4).res
+
+
+def store_i32_lds(addr_i64, val):
+    """Plain i32 store to a raw LDS byte address."""
+    _llvm_d.StoreOp(arith.unwrap(val), _lds_ptr(addr_i64), alignment=4)
+
+
 def store_i32_system(addr_i64, offset, val):
     """System-release i32 store at addr + offset*4."""
     _llvm_d.StoreOp(

--- a/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels_tdm.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels_tdm.py
@@ -1,0 +1,709 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""TDM-transported intranode EP dispatch (gfx1250), a FlyDSL port of mori's
+``src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp``.
+
+The sibling ``intranode_kernels.make_dispatch`` gives one whole wave to one
+(token, expert-slot) route: the wave takes a remote atomic for the recv slot,
+then copies the token with 16-byte per-lane stores. That shape is what a machine
+without a DMA engine wants. It is the wrong shape for gfx1250, where the Tensor
+Data Mover moves a whole row on one descriptor: the copy stops needing lanes at
+all, so the per-route remote atomic and the scattered 4-byte metadata stores --
+previously hidden under the payload copy -- become the cost.
+
+So this kernel keeps mori's restructuring rather than bolting TDM onto the
+existing one. Three things change, and they only pay off together:
+
+  * a route is one LANE, not one wave (``WAVE / topk`` tokens per wave), so a
+    wave sees all of a token's routes at once and can dedup same-peer routes
+    against each other with a permute instead of a ballot per route;
+  * the recv slots for a whole BLOCK are reserved with one remote atomic per
+    (block, peer) instead of one per route, off an LDS histogram;
+  * idx / weights / srcmap are gathered into a block-local, destination-ordered
+    staging array first, so the cross-GPU metadata write is a handful of bulk
+    TDM runs instead of thousands of scattered dwords.
+
+Everything downstream (``tok_map`` encoding, the grid barrier, the per-peer
+count signal, the self-resetting counters) is bit-compatible with
+``make_dispatch``, so combine, replay and the op layer are unchanged.
+
+Not ported: scales, fp4, push-group and replay. They are orthogonal to the
+transport and each one needs its own staging region; ``make_dispatch`` still
+owns those paths.
+"""
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, const_expr, range_constexpr
+from aiter.ops.flydsl.kernels.buffer_ops import (
+    buffer_load,
+    buffer_store,
+    create_buffer_resource_from_addr,
+)
+from flydsl.expr.rocdl import ballot, ds_bpermute, readfirstlane, readlane
+from flydsl.expr.typing import Int32, Int64, T
+
+import mori.cco.device.flydsl as cco
+from . import flydsl_prims as P
+from . import tdm_prims as TDM
+from .intranode_kernels import LANE_MASK, LOG2_WAVE, WAVE, _BALLOT_INT
+
+#: gfx1250 LDS per workgroup. The payload tiles are the whole budget.
+_LDS_BUDGET = 327680
+
+
+def _align(v, a):
+    return (v + a - 1) // a * a
+
+
+def tdm_tokens_per_wave(experts_per_token):
+    """Tokens one wave covers per iteration: enough lanes for a token's routes.
+
+    ``WAVE / topk`` when the routes tile the wave exactly, so COUNT reads
+    ``topk`` consecutive indices per token with every lane busy. Otherwise one
+    token per wave with the tail lanes idle -- correct, just wider.
+    """
+    topk = experts_per_token
+    return WAVE // topk if (0 < topk <= WAVE and WAVE % topk == 0) else 1
+
+
+def tdm_stage_capacity(
+    *, npes, experts_per_token, max_tok_per_rank, block_num, warp_num_per_block
+):
+    """(per-(block,peer) slot capacity, total staging slots).
+
+    A block's routes to one peer cannot outnumber the tokens the block itself
+    walked, and the token loop is grid-strided, so the bound is the number of
+    whole rounds the block takes times what it covers in a round. Staging is
+    indexed ``((block * npes) + peer) * cap + j`` -- contiguous per (block, peer)
+    is what lets the metadata leave as bulk runs.
+
+    Still an upper bound under the kernel's runtime quota ``etpi <= tpi``: the
+    quota only drops below ``tpi`` when ``warps_total * etpi`` already covers the
+    token count, which is one round of ``warp_num_per_block * etpi`` per block,
+    and ``rounds`` is floored at 1 so ``cap`` is never under
+    ``warp_num_per_block * tpi``.
+    """
+    tpi = tdm_tokens_per_wave(experts_per_token)
+    per_round_grid = block_num * warp_num_per_block * tpi
+    rounds = (max_tok_per_rank + per_round_grid - 1) // per_round_grid
+    cap = warp_num_per_block * tpi * max(rounds, 1)
+    return cap, block_num * npes * cap
+
+
+def tdm_lds_bytes(*, hidden_dim, hidden_elem_size, warp_num_per_block, npes):
+    """LDS the kernel asks for: one payload tile per warp, plus the counters."""
+    tile = _align(hidden_dim * hidden_elem_size, 128)
+    return warp_num_per_block * tile + _align(3 * npes * 4, 128)
+
+
+def tdm_max_warps(*, hidden_dim, hidden_elem_size, npes):
+    """Widest power-of-two warp count whose payload tiles fit the LDS budget.
+
+    The vector transport holds no per-warp LDS, so a geometry tuned against it
+    can name a warp count this one cannot honour: a 7168-wide bf16 tile is 14 KB
+    and 32 of them want 448 KB against a 320 KB budget. A caller clamping to this
+    keeps the tuned block count -- which is what paces the grid barrier -- and
+    gives up only the warp width.
+    """
+    tile = _align(hidden_dim * hidden_elem_size, 128)
+    room = (_LDS_BUDGET - _align(3 * npes * 4, 128)) // tile
+    if room < 1:
+        raise ValueError(
+            f"a single {tile}B payload tile (hidden_dim={hidden_dim}, "
+            f"{hidden_elem_size}B elements) does not fit the {_LDS_BUDGET}B LDS "
+            f"budget; dispatch_transport='tdm' cannot serve this hidden size"
+        )
+    warps = 1
+    while warps * 2 <= room:
+        warps *= 2
+    return warps
+
+
+def make_dispatch_tdm(
+    *,
+    rank,
+    npes,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_tok_off,
+    off_recv_num,
+    off_tis,
+    off_out_idx,
+    off_out_wts,
+    off_out_tok,
+    enable_signal=True,
+    meta_tdm=True,
+):
+    """Build the TDM dispatch kernel. Returns a ``@flyc.jit`` launcher.
+
+    Arguments mirror :func:`intranode_kernels.make_dispatch` so the op layer can
+    forward the same kwargs, minus the scales / fp4 / push-group / replay knobs
+    this transport does not implement. ``meta_tdm=False`` routes the metadata
+    through per-lane stores instead of the TDM engine -- same result, and the
+    A/B that says whether the bulk path is worth its LDS.
+    """
+    if WAVE != 32:
+        raise ValueError(
+            f"TDM dispatch is gfx1250-only (wave32); wave size resolved to {WAVE}"
+        )
+    topk = experts_per_token
+    nbytes = hidden_dim * hidden_elem_size
+    if nbytes % 4:
+        raise ValueError(f"token payload must be a whole number of dwords, got {nbytes}B")
+    if topk > WAVE:
+        raise ValueError(f"topk={topk} exceeds the wave size; a token's routes must fit one wave")
+
+    tpi = tdm_tokens_per_wave(topk)
+    warps_total = block_num * warp_num_per_block
+    block_threads = warp_num_per_block * WAVE
+    cap_blk, _stage_slots = tdm_stage_capacity(
+        npes=npes,
+        experts_per_token=topk,
+        max_tok_per_rank=max_tok_per_rank,
+        block_num=block_num,
+        warp_num_per_block=warp_num_per_block,
+    )
+    sentinel_val = npes * max_recv
+
+    tile_bytes = _align(nbytes, 128)
+    ctl_bytes = _align(3 * npes * 4, 128)
+    lds_bytes = warp_num_per_block * tile_bytes + ctl_bytes
+    if lds_bytes > _LDS_BUDGET:
+        raise ValueError(
+            f"TDM dispatch needs {lds_bytes}B of LDS ({warp_num_per_block} warps x "
+            f"{tile_bytes}B payload tile) over the {_LDS_BUDGET}B budget; lower "
+            f"warp_num_per_block"
+        )
+
+    # A metadata batch reuses the warp's payload tile: idx, weights and srcmap
+    # for `meta_chunk` destination-ordered tokens, each region 128B-aligned so
+    # every TDM row is a full 128 bytes. Chunks are a whole number of rows, so
+    # the shapes are compile-time; the ragged remainder falls back to stores.
+    # A chunk needs a legal tile for BOTH its `chunk*topk` index/weight run and
+    # its much shorter `chunk` srcmap run, and the srcmap is what binds: it needs
+    # chunk >= 64 before any dim1 >= 2 leaves a 32-element row. Chunks that only
+    # the srcmap rejects would otherwise silently take a 1xN descriptor.
+    meta_per_tok = topk * 4 * 2 + 4
+    meta_cap = (tile_bytes - 3 * 128) // meta_per_tok
+    meta_chunk = 0
+    meta_idx_shape = meta_src_shape = None
+    for cand in (128, 64):
+        if cand > meta_cap:
+            continue
+        idx_shape = TDM.tdm_run_shape(cand * topk)
+        src_shape = TDM.tdm_run_shape(cand)
+        if idx_shape and src_shape:
+            meta_chunk, meta_idx_shape, meta_src_shape = cand, idx_shape, src_shape
+            break
+    use_meta_tdm = bool(meta_tdm) and meta_chunk > 0
+    m_idx_off = 0
+    m_wt_off = _align(meta_chunk * topk * 4, 128)
+    m_src_off = m_wt_off + _align(meta_chunk * topk * 4, 128)
+
+    # One warp per peer would leave every warp past the world size idle, so the
+    # peers are split across the warps that exist. mori measured the split to be
+    # a loss at small batches (the sub-runs get shorter than a TDM row), where
+    # the metadata is short enough for one warp per peer to hide anyway.
+    peer_split = max(1, warp_num_per_block // npes) if npes else 1
+    meta_runs = npes * peer_split
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def ep_dispatch_tdm(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_stg_idx: Int64,
+        addr_stg_wt: Int64,
+        addr_stg_src: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        window = cco.Window(arena)
+
+        rsrc_inp_idx = create_buffer_resource_from_addr(addr_inp_idx)
+        rsrc_inp_wts = create_buffer_resource_from_addr(addr_inp_wts)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_dest_ctr = create_buffer_resource_from_addr(addr_dest_pe_ctr)
+        rsrc_disp_bar = create_buffer_resource_from_addr(addr_disp_bar)
+        rsrc_stg_idx = create_buffer_resource_from_addr(addr_stg_idx)
+        rsrc_stg_wt = create_buffer_resource_from_addr(addr_stg_wt)
+        rsrc_stg_src = create_buffer_resource_from_addr(addr_stg_src)
+
+        # LDS: `warp_num_per_block` payload tiles, then the three per-peer
+        # counters (committed count / reserved remote base / handout cursor).
+        smem = fx.SharedAllocator(static=False)
+        tile_ptr = smem.allocate(warp_num_per_block * tile_bytes, 128)._ptr
+        ctl_ptr = smem.allocate(ctl_bytes, 128)._ptr
+        tile_base_i32 = arith.index_cast(T.i32, fx.index_cast(T.index, fx.ptrtoint(tile_ptr)))
+        my_tile = arith.addi(
+            tile_base_i32,
+            arith.muli(
+                readfirstlane(T.i32, warp), arith.constant(tile_bytes, type=T.i32)
+            ),
+        )
+        ctl = fx.Int64(fx.ptrtoint(ctl_ptr))
+
+        def s_n(p):
+            return ctl + fx.Int64(p) * fx.Int64(4)
+
+        def s_base(p):
+            return ctl + (fx.Int64(p) + fx.Int64(npes)) * fx.Int64(4)
+
+        def s_run(p):
+            return ctl + (fx.Int64(p) + fx.Int64(2 * npes)) * fx.Int64(4)
+
+        # Tokens a warp takes per iteration. A fixed quota of `tpi` only fills the
+        # grid once there are `warps_total * tpi` tokens to go round: below that
+        # every token lands on a low warp id, which is block-major, so most of the
+        # grid sends no payload at all and the kernel costs the same at 8 tokens
+        # as at 512. Capping the quota at what it takes to cover the grid spreads
+        # them. COUNT gives up its full-warp index burst when the cap bites, which
+        # is the cheaper half of that trade.
+        #
+        # The clamp to 1 is load-bearing: `ceil(n / warps_total)` is 0 for n == 0,
+        # and a token loop stepping by `warps_total * 0` never advances -- a hang
+        # no correctness check can report, because the check hangs with it.
+        if const_expr(tpi > 1):
+            q_tok = (inp_cur_tok + (warps_total - 1)) // warps_total
+            etpi = arith.select(
+                q_tok < 1,
+                fx.Int32(1),
+                arith.select(q_tok < tpi, q_tok, fx.Int32(tpi)),
+            )
+        else:
+            etpi = fx.Int32(1)
+
+        # Lane -> (which of the wave's tokens, which of that token's routes). The
+        # grouping follows `etpi`, not `tpi`: left on `tpi` the surplus lanes
+        # would keep routing tokens the loops below hand to another warp.
+        if const_expr(tpi > 1):
+            s_lane = lane // topk
+            e_lane = lane - s_lane * topk
+        else:
+            s_lane = fx.Int32(0)
+            e_lane = lane
+        lane_act = (s_lane < etpi) & (e_lane < topk)
+
+        if tid < npes:
+            P.store_i32_lds(s_n(tid), arith.constant(0))
+            P.store_i32_lds(s_run(tid), arith.constant(0))
+        fx.barrier()
+
+        # Route resolution, shared by COUNT and FINALIZE. No dynamic `if`: it
+        # runs under both phases' loops and selects rather than branches, so
+        # inactive lanes stay in bounds instead of being masked off.
+        def resolve(tok_base):
+            tok = tok_base + s_lane
+            act = lane_act & (tok < inp_cur_tok)
+            tok_s = arith.select(tok < inp_cur_tok, tok, inp_cur_tok - 1)
+            e_s = arith.select(lane_act, e_lane, 0)
+            slot_off = tok_s * topk + e_s
+            expert = buffer_load(rsrc_inp_idx, slot_off, vec_width=1, dtype=T.i32)
+            dest_pe = expert // experts_per_rank
+            valid = act & (expert >= 0) & (dest_pe < npes)
+            # Dedup: a token routed to several experts on one peer is sent once.
+            # The token's routes are `topk` adjacent lanes of this wave, so the
+            # duplicate test is a permute per route slot -- lane (s_lane, e)'s
+            # dest PE against mine -- and the lowest such lane wins.
+            valid_i = arith.select(valid, fx.Int32(1), fx.Int32(0))
+            keep = valid
+            for e in range_constexpr(topk):
+                probe = (s_lane * topk + e) * 4
+                other_pe = ds_bpermute(T.i32, probe, dest_pe)
+                other_ok = ds_bpermute(T.i32, probe, valid_i)
+                dup = (e < e_lane) & (other_ok != 0) & (other_pe == dest_pe)
+                keep = keep & ~dup
+            # slot_off rather than the weight itself: COUNT has no use for the
+            # weight, and the op permits a null weight pointer as long as nothing
+            # is published, so the load belongs in FINALIZE.
+            return tok, act, expert, slot_off, dest_pe, keep
+
+        # ── COUNT: block-local histogram of routes per destination peer ──
+        for tok_base in range(global_warp_id * etpi, inp_cur_tok, warps_total * etpi):
+            _tok, _act, _expert, _off, dest_pe, keep = resolve(tok_base)
+            if keep:
+                P.atomic_add_lds(s_n(dest_pe), arith.constant(1))
+        fx.barrier()
+
+        # ── RESERVE: one remote atomic per (block, peer), not per route ──
+        if tid < npes:
+            n = P.load_i32_lds(s_n(tid))
+            base = arith.constant(0)
+            if n > 0:
+                base = P.atomic_add_global(
+                    fx.Int64(window.lsa_ptr(tid, off_tok_off)), n
+                )
+                P.atomic_add_global(
+                    fx.Int64(addr_dest_pe_ctr) + fx.Int64(tid) * fx.Int64(4), n
+                )
+            P.store_i32_lds(s_base(tid), base)
+        fx.barrier()
+
+        # ── FINALIZE: hand out the reserved slots and gather the metadata ──
+        # The slot order within a block's run is whatever the LDS cursor hands
+        # out; only its contiguity matters, since the metadata is staged in that
+        # same order and shipped as one run.
+        for tok_base in range(global_warp_id * etpi, inp_cur_tok, warps_total * etpi):
+            tok, act, expert, slot_off, dest_pe, keep = resolve(tok_base)
+            wt = buffer_load(rsrc_inp_wts, slot_off, vec_width=1, dtype=T.f32)
+            j = arith.constant(0)
+            if keep:
+                j = P.atomic_add_lds(s_run(dest_pe), arith.constant(1))
+            base = arith.constant(0)
+            if keep:
+                base = P.load_i32_lds(s_base(dest_pe))
+            dest_tok = base + j
+            # `j >= cap_blk` cannot happen for a block that walked at most
+            # cap_blk tokens; `dest_tok >= max_recv` can, when the peer is over
+            # its configured recv cap. Both drop the route rather than write out
+            # of bounds, matching make_dispatch's overflow behaviour.
+            pub = keep & (j < cap_blk) & (dest_tok < max_recv)
+            if act:
+                buffer_store(
+                    arith.select(pub, dest_pe * max_recv + dest_tok, sentinel_val),
+                    rsrc_tok_map,
+                    tok * topk + e_lane,
+                )
+            slot = (bid * npes + dest_pe) * cap_blk + j
+            src_encoded = rank * max_tok_per_rank + tok
+            # Stage the metadata destination-ordered. Every lane of the token's
+            # group writes element `e_lane` of the published lane's slot, so a
+            # route's `topk` indices leave as one contiguous 32-byte run and a
+            # token routed to several peers is staged once per peer.
+            pub_i = arith.select(pub, fx.Int32(1), fx.Int32(0))
+            for e in range_constexpr(topk):
+                probe = (s_lane * topk + e) * 4
+                pub_e = ds_bpermute(T.i32, probe, pub_i)
+                slot_e = ds_bpermute(T.i32, probe, slot)
+                if lane_act & (pub_e != 0):
+                    buffer_store(expert, rsrc_stg_idx, slot_e * topk + e_lane)
+                    buffer_store(
+                        arith.bitcast(T.i32, wt), rsrc_stg_wt, slot_e * topk + e_lane
+                    )
+                    if e_lane == 0:
+                        buffer_store(src_encoded, rsrc_stg_src, slot_e)
+
+        # tok_map is written here and re-read by the payload phase, and the
+        # staging arrays are written here and read by the metadata phase; both
+        # go through global memory, so the stores have to land before either.
+        P.waitcnt_stores()
+        fx.barrier()
+
+        # ── META: the staged runs leave as bulk cross-GPU writes ──
+        for run_id in range(warp, meta_runs, warp_num_per_block):
+            peer = run_id // peer_split
+            part = run_id - peer * peer_split
+            cnt_all = P.load_i32_lds(s_n(peer))
+            base_all = P.load_i32_lds(s_base(peer))
+            # Split the peer's run across `peer_split` warps, remainder to the
+            # low parts so the sub-runs differ by at most one token.
+            q = cnt_all // peer_split
+            rem = cnt_all - q * peer_split
+            my_beg = part * q + arith.select(part < rem, part, rem)
+            my_cnt = q + arith.select(part < rem, fx.Int32(1), fx.Int32(0))
+            peer_idx = create_buffer_resource_from_addr(
+                fx.Int64(window.lsa_ptr(peer, off_out_idx))
+            )
+            peer_wts = create_buffer_resource_from_addr(
+                fx.Int64(window.lsa_ptr(peer, off_out_wts))
+            )
+            peer_tis = create_buffer_resource_from_addr(
+                fx.Int64(window.lsa_ptr(peer, off_tis))
+            )
+            stg_beg = (bid * npes + peer) * cap_blk + my_beg
+            step = meta_chunk if use_meta_tdm else 1
+            for cs in range(0, my_cnt, step):
+                left = my_cnt - cs
+                dst = base_all + my_beg + cs
+                src = stg_beg + cs
+                if const_expr(use_meta_tdm):
+                    if left >= meta_chunk:
+                        g_idx = TDM.tdm_group1(*meta_idx_shape, 4)
+                        g_src = TDM.tdm_group1(*meta_src_shape, 4)
+                        l_idx = arith.addi(my_tile, arith.constant(m_idx_off, type=T.i32))
+                        l_wt = arith.addi(my_tile, arith.constant(m_wt_off, type=T.i32))
+                        l_src = arith.addi(my_tile, arith.constant(m_src_off, type=T.i32))
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                l_idx,
+                                fx.Int64(addr_stg_idx)
+                                + fx.Int64(src) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                l_wt,
+                                fx.Int64(addr_stg_wt)
+                                + fx.Int64(src) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                l_src,
+                                fx.Int64(addr_stg_src) + fx.Int64(src) * fx.Int64(4),
+                            ),
+                            g_src,
+                        )
+                        TDM.tdm_wait(0)
+                        TDM.tdm_store(
+                            TDM.tdm_group0(
+                                l_idx,
+                                fx.Int64(window.lsa_ptr(peer, off_out_idx))
+                                + fx.Int64(dst) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_store(
+                            TDM.tdm_group0(
+                                l_wt,
+                                fx.Int64(window.lsa_ptr(peer, off_out_wts))
+                                + fx.Int64(dst) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_store(
+                            TDM.tdm_group0(
+                                l_src,
+                                fx.Int64(window.lsa_ptr(peer, off_tis))
+                                + fx.Int64(dst) * fx.Int64(4),
+                            ),
+                            g_src,
+                        )
+                        TDM.tdm_wait(0)
+                    else:
+                        # Ragged tail: fewer tokens than a whole TDM tile.
+                        for i in range(lane, left * topk, WAVE):
+                            buffer_store(
+                                buffer_load(
+                                    rsrc_stg_idx, src * topk + i, vec_width=1, dtype=T.i32
+                                ),
+                                peer_idx,
+                                dst * topk + i,
+                            )
+                            buffer_store(
+                                buffer_load(
+                                    rsrc_stg_wt, src * topk + i, vec_width=1, dtype=T.i32
+                                ),
+                                peer_wts,
+                                dst * topk + i,
+                            )
+                        for i in range(lane, left, WAVE):
+                            buffer_store(
+                                buffer_load(
+                                    rsrc_stg_src, src + i, vec_width=1, dtype=T.i32
+                                ),
+                                peer_tis,
+                                dst + i,
+                            )
+                else:
+                    for i in range(lane, topk, WAVE):
+                        buffer_store(
+                            buffer_load(
+                                rsrc_stg_idx, src * topk + i, vec_width=1, dtype=T.i32
+                            ),
+                            peer_idx,
+                            dst * topk + i,
+                        )
+                        buffer_store(
+                            buffer_load(
+                                rsrc_stg_wt, src * topk + i, vec_width=1, dtype=T.i32
+                            ),
+                            peer_wts,
+                            dst * topk + i,
+                        )
+                    if lane == 0:
+                        buffer_store(
+                            buffer_load(rsrc_stg_src, src, vec_width=1, dtype=T.i32),
+                            peer_tis,
+                            dst,
+                        )
+
+        # ── PAYLOAD: one TDM load per token, one TDM store per surviving route ──
+        # No barrier before this. The tile a warp is about to overwrite is the
+        # one it just drained itself; the cross-warp state (staging, s_base) was
+        # published by the barrier after FINALIZE.
+        #
+        # The token partition has to be FINALIZE's, walked one token at a time.
+        # tok_map goes through global memory but the only barrier between the two
+        # phases is a workgroup one, so a warp may read back nothing but the
+        # entries it wrote itself. A grid-strided `range(global_warp_id, ...)`
+        # reads slots other BLOCKS own: at 512 tokens on a 64x8 grid it is warps
+        # 0..127 (blocks 0..15) that route, and every one of the remaining 48
+        # blocks would send payload off entries still holding the host's -1 fill.
+        # -1 passes a `< sentinel` liveness test and decodes to dest_pe 0,
+        # dest_tok -1, i.e. a TDM store one whole token BEFORE a peer's recv
+        # buffer -- an out-of-bounds fabric write, which is what wedges the
+        # engine rather than merely corrupting the result.
+        #
+        # `sub` is a runtime loop and not `range_constexpr` on purpose: the route
+        # loop below already unrolls `topk` descriptor sites, and unrolling this
+        # one too would multiply them by `tpi`.
+        g_payload = TDM.tdm_group1(hidden_dim, 1, hidden_elem_size)
+        probe_off = arith.select(lane < topk, lane, 0)
+        for tok_base in range(global_warp_id * etpi, inp_cur_tok, warps_total * etpi):
+            for sub in range(0, etpi):
+                tok = tok_base + sub
+                if tok < inp_cur_tok:
+                    flat = buffer_load(
+                        rsrc_tok_map, tok * topk + probe_off, vec_width=1, dtype=T.i32
+                    )
+                    # `flat >= 0` rejects the host's -1 fill as well as the
+                    # sentinel, so a slot FINALIZE never published can never name
+                    # a route.
+                    live = (lane < topk) & (flat >= 0) & (flat < sentinel_val)
+                    if ballot(_BALLOT_INT(), live) != 0:
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                my_tile,
+                                fx.Int64(addr_inp_tok)
+                                + fx.Int64(tok) * fx.Int64(nbytes),
+                            ),
+                            g_payload,
+                        )
+                        TDM.tdm_wait(0)
+                        live_i = arith.select(live, fx.Int32(1), fx.Int32(0))
+                        for l in range_constexpr(topk):
+                            live_l = readlane(T.i32, live_i, l)
+                            flat_l = readlane(T.i32, flat, l)
+                            if live_l != 0:
+                                dest_pe = flat_l // max_recv
+                                dest_tok = flat_l - dest_pe * max_recv
+                                TDM.tdm_store(
+                                    TDM.tdm_group0(
+                                        my_tile,
+                                        fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
+                                        + fx.Int64(dest_tok) * fx.Int64(nbytes),
+                                    ),
+                                    g_payload,
+                                )
+                        # The next token reloads into this same tile.
+                        TDM.tdm_wait(0)
+
+        if const_expr(enable_signal):
+            # Identical to make_dispatch's completion, so the two kernels are
+            # interchangeable from combine's point of view.
+            if global_warp_id == 0:
+                if lane == 0:
+                    buffer_store(
+                        arith.constant(0),
+                        create_buffer_resource_from_addr(addr_total_recv),
+                        0,
+                    )
+
+            # TDM stores retire on the tensor counter, which storecnt does not
+            # track, so the grid barrier needs both drains to cover the payload
+            # and the plain stores.
+            TDM.tdm_wait(0)
+            P.waitcnt_stores()
+            fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_disp_bar), arith.constant(1))
+
+            local_recv_num = fx.Int64(window.lsa_ptr(my_lsa_rank, off_recv_num))
+            for dest_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    P.spin_until_eq_i32(fx.Int64(addr_disp_bar), block_num)
+                    buffer_store(arith.constant(0), rsrc_disp_bar, 0)
+                    signal_value = (
+                        buffer_load(rsrc_dest_ctr, dest_pe, vec_width=1, dtype=T.i32) + 1
+                    )
+                    peer_recv_num = fx.Int64(window.lsa_ptr(dest_pe, off_recv_num))
+                    recv_num_remote_addr = peer_recv_num + fx.Int64(rank) * fx.Int64(4)
+                    P.spin_until_eq_i32(recv_num_remote_addr, 0)
+                    P.store_i32_system(
+                        recv_num_remote_addr, arith.constant(0), signal_value
+                    )
+
+            for src_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    recv_num_src_addr = local_recv_num + fx.Int64(src_pe) * fx.Int64(4)
+                    signal_value = P.spin_until_gt_i32(recv_num_src_addr, 0)
+                    peer_recv_count = signal_value - 1
+                    P.store_i32_system(
+                        recv_num_src_addr, arith.constant(0), arith.constant(0)
+                    )
+                    P.atomic_add_global(fx.Int64(addr_total_recv), peer_recv_count)
+                    buffer_store(arith.constant(0), rsrc_dest_ctr, src_pe)
+
+            if global_warp_id == 0:
+                if lane == 0:
+                    local_tok_off = fx.Int64(window.lsa_ptr(my_lsa_rank, off_tok_off))
+                    P.store_i32_system(
+                        local_tok_off, arith.constant(0), arith.constant(0)
+                    )
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_stg_idx: Int64,
+        addr_stg_wt: Int64,
+        addr_stg_src: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_dispatch_tdm(
+            arena,
+            addr_inp_tok,
+            addr_inp_idx,
+            addr_inp_wts,
+            addr_tok_map,
+            addr_dest_pe_ctr,
+            addr_disp_bar,
+            addr_total_recv,
+            addr_stg_idx,
+            addr_stg_wt,
+            addr_stg_src,
+            my_lsa_rank,
+            inp_cur_tok,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[block_threads, 1, 1],
+            stream=stream,
+        )
+
+    return run

--- a/aiter/ops/flydsl/dispatch_combine_v2/tdm_prims.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/tdm_prims.py
@@ -1,0 +1,185 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""gfx1250 TDM (Tensor Data Mover) descriptors over RAW 64-bit addresses.
+
+``flydsl.expr.rocdl.tdm_ops.make_tensor_descriptor_2d`` derives the descriptor's
+global base from a fly memref/tensor. The EP dispatch path cannot use it: the
+destination of a payload move is a *peer's* copy of a symmetric region, i.e. the
+integer ``cco.Window(h).lsa_ptr(pe, off)``, which is a runtime value and not a
+kernel tensor argument. So GROUP0 is packed here by hand from an i64 address and
+an LDS byte address, and GROUP1 from the compile-time tile geometry.
+
+The bit layout is copied from ``make_tensor_descriptor_2d`` and must track it:
+
+  GROUP0 (vector<4xi32>)   lane0 pred | lane1 lds byte addr | lane2/3 global lo/hi
+                           (lane3 bit31 = descriptor type field)
+  GROUP1 (vector<8xi32>)   s0 data_size[17:16] and the pad/mcast bits we leave 0
+                           s1 tensor_dim0[15:0] << 16
+                           s2 tensor_dim0[31:16] | tensor_dim1[15:0] << 16
+                           s3 tensor_dim1[31:16] | tile_dim0 << 16
+                           s4 tile_dim1[15:0]
+                           s5 tensor_dim0_stride[31:0]
+                           s6 tensor_dim0_stride[47:32] | tensor_dim1_stride[15:0] << 16
+                           s7 tensor_dim1_stride[31:16]
+
+dim0 is the innermost (contiguous) extent and dim1 the number of rows, matching
+the ISA convention -- note ``s5`` is called ``tensor_dim0_stride`` in the ISA but
+is the stride *between rows*, i.e. flydsl's ``outer_stride``.
+
+``tensor_dim1_stride`` is set to ``dim1``, which is what every one of mori's
+three descriptor builders does (``TdmShape`` 1 for its 1 x hiddenDim payload,
+``TdmShape2D`` dim1, ``TdmShapeGather`` nRows). flydsl's
+``make_tensor_descriptor_2d`` instead leaves s6/s7 zero as "no higher-dim
+strides"; that holds for its own tiles, which are always dim1 >= 2, but a
+``dim1 == 1`` descriptor with a zero dim1 stride hangs the TDM engine. mori's
+own note on the subject is that "gfx1250 has no 1xN wedge, while the payload has
+always sent 1 x hiddenDim" -- the reconciliation is this field.
+
+Setting tensor_dim == tile_dim is flydsl's "OOB checking off" encoding: the
+caller guarantees the run is in bounds. This module never enables padding, the
+atomic barrier, or multicast; all three change the transfer protocol and none
+are wanted for a point-to-point copy.
+"""
+import math
+
+from flydsl._mlir import ir
+from flydsl.expr import arith, vector
+from flydsl.expr.rocdl import readfirstlane, tdm_ops
+from flydsl.expr.typing import T
+
+#: Widest ISA dim/tile field. Both extents and the row stride are 16-bit in the
+#: parts of GROUP1 a 2D descriptor actually uses.
+TDM_MAX_DIM = 0xFFFF
+
+#: A TDM row narrower than this moves at a fraction of peak: the engine issues
+#: one descriptor-driven burst per row, so short rows pay the per-row overhead
+#: on every one of them. It is a bandwidth floor, not a legality bound -- a
+#: 1-row / sub-128B transfer is well-formed and lands correctly.
+TDM_ROW_FLOOR_BYTES = 128
+
+
+def _i32(v):
+    """i32 constant from a bit pattern that may set bit 31 (arith wants signed)."""
+    v &= 0xFFFFFFFF
+    if v >= 1 << 31:
+        v -= 1 << 32
+    return arith.constant(v, type=T.i32)
+
+
+def tdm_group1(dim0, dim1, elem_bytes, stride=None):
+    """GROUP1 for a ``dim1`` x ``dim0`` tile of ``elem_bytes`` elements.
+
+    ``dim0`` is the contiguous extent of one row and ``stride`` (default
+    ``dim0``, i.e. a dense run) the element distance between rows. All three are
+    compile-time, so the whole descriptor folds to eight SGPR constants.
+    """
+    if elem_bytes not in (1, 2, 4, 8):
+        raise ValueError(f"TDM data_size encodes 1/2/4/8-byte elements, got {elem_bytes}")
+    if not (1 <= dim0 <= TDM_MAX_DIM and 1 <= dim1 <= TDM_MAX_DIM):
+        raise ValueError(f"TDM tile dims must be in [1, {TDM_MAX_DIM}], got {dim1}x{dim0}")
+    if stride is None:
+        stride = dim0
+    ds = int(math.log2(elem_bytes))
+    return vector.from_elements(
+        T.vec(8, T.i32),
+        [
+            _i32(ds << 16),
+            _i32((dim0 & 0xFFFF) << 16),
+            _i32(((dim0 >> 16) & 0xFFFF) | ((dim1 & 0xFFFF) << 16)),
+            _i32(((dim1 >> 16) & 0xFFFF) | ((dim0 & 0xFFFF) << 16)),
+            _i32(dim1 & 0xFFFF),
+            _i32(stride & 0xFFFFFFFF),
+            _i32(((stride >> 32) & 0xFFFF) | ((dim1 & 0xFFFF) << 16)),
+            _i32((dim1 >> 16) & 0xFFFFFFFF),
+        ],
+    )
+
+
+#: 128B / 4B: the row floor in elements for the 4-byte metadata runs.
+_TDM_ROW_ELEMS_4B = TDM_ROW_FLOOR_BYTES // 4
+
+
+def tdm_run_shape(n_elems):
+    """``(dim0, dim1)`` covering a contiguous run of ``n_elems``, or None.
+
+    mori's ``TdmCheapDim1`` closed form: the largest ``dim1`` in 8/4/2 that
+    divides the run and still leaves a row of at least 32 elements (the 128B
+    floor at 4 bytes). ``dim0 * dim1 == n_elems`` exactly, so the descriptor
+    footprint is the run and cannot spill past it.
+
+    Returns None when no such split exists. The caller must then move the run
+    some other way rather than falling back to ``dim1 == 1``: a 1xN tile is not
+    a shape the engine accepts here (see the module docstring).
+    """
+    for d1 in (8, 4, 2):
+        if n_elems % d1 == 0 and n_elems // d1 >= _TDM_ROW_ELEMS_4B:
+            return n_elems // d1, d1
+    return None
+
+
+def tdm_group0(lds_addr_i32, global_addr_i64):
+    """GROUP0 binding a descriptor to one (LDS byte address, global address) pair.
+
+    Both operands must be wave-uniform -- the intrinsic reads them out of SGPRs.
+    They are put through ``readfirstlane`` here rather than left to the compiler's
+    uniformity analysis: the addresses this kernel feeds in are uniform by
+    construction (a warp-strided token id, a ``readlane``-broadcast peer slot) but
+    are computed from ``thread_idx``, and a descriptor lane that silently lands in
+    a VGPR moves the wrong bytes instead of failing to compile. Every caller is in
+    a wave-uniform branch, so lane 0 is always active.
+    """
+    i32 = ir.IntegerType.get_signless(32)
+    addr = arith.unwrap(global_addr_i64)
+    lo = arith.trunci(i32, addr)
+    hi = arith.ori(
+        arith.trunci(i32, arith.shrui(addr, arith.constant(32, type=T.i64))),
+        _i32(1 << 31),  # descriptor type field
+    )
+    return vector.from_elements(
+        T.vec(4, T.i32),
+        [
+            _i32(1),
+            readfirstlane(T.i32, arith.unwrap(lds_addr_i32)),
+            readfirstlane(T.i32, lo),
+            readfirstlane(T.i32, hi),
+        ],
+    )
+
+
+def tdm_load(group0, group1, cache_policy=0):
+    """Async global -> LDS. Completion is observed with :func:`tdm_wait`."""
+    tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(group0, group1), cache_policy)
+
+
+def tdm_store(group0, group1, cache_policy=0):
+    """Async LDS -> global. Completion is observed with :func:`tdm_wait`."""
+    tdm_ops.tensor_store_2d(tdm_ops.TDMDescriptor2D(group0, group1), cache_policy)
+
+
+def tdm_wait(count=0):
+    """Wait until at most ``count`` TDM transfers are still in flight.
+
+    Loads and stores share the one tensor counter and retire in issue order, so
+    a partial wait releases the oldest transfers -- there is no way to wait on
+    just the loads.
+    """
+    tdm_ops.tensor_wait(count)

--- a/op_tests/flydsl_tests/compile_dispatch_tdm.py
+++ b/op_tests/flydsl_tests/compile_dispatch_tdm.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+"""Compile-only check for the TDM dispatch kernel -- no GPU needed.
+
+``COMPILE_ONLY=1`` makes FlyDSL trace, lower and codegen the kernel and then
+return instead of launching, so this exercises every DSL construct in
+``make_dispatch_tdm`` (and every compile-time shape assert) without touching a
+device. It cannot say whether the kernel is *correct*, only whether it is
+well-formed.
+
+    COMPILE_ONLY=1 FLYDSL_GPU_ARCH=gfx1250 python compile_dispatch_tdm.py
+"""
+import os
+import sys
+import time
+
+os.environ.setdefault("COMPILE_ONLY", "1")
+os.environ.setdefault("FLYDSL_GPU_ARCH", "gfx1250")
+
+from aiter.ops.flydsl.dispatch_combine_v2.intranode_kernels_tdm import (  # noqa: E402
+    make_dispatch_tdm,
+    tdm_stage_capacity,
+)
+
+# (npes, topk, hidden, elem, block, warp): the shapes that pick different
+# compile-time paths -- meta TDM on/off, one warp per peer vs a peer split,
+# and the tokens-per-wave fallback when topk does not divide the wave.
+CASES = [
+    (4, 8, 7168, 2, 64, 8),
+    (4, 8, 2048, 2, 64, 16),
+    (1, 8, 2048, 2, 64, 8),
+    (4, 6, 4096, 2, 64, 8),
+    (8, 8, 512, 2, 64, 8),  # tile too small for a meta batch -> scalar metadata
+]
+
+
+def main():
+    bad = 0
+    for npes, topk, hidden, elem, block, warp in CASES:
+        max_tok = 512
+        cap, slots = tdm_stage_capacity(
+            npes=npes,
+            experts_per_token=topk,
+            max_tok_per_rank=max_tok,
+            block_num=block,
+            warp_num_per_block=warp,
+        )
+        tag = f"npes={npes} topk={topk} hidden={hidden} elem={elem} {block}x{warp}"
+        t0 = time.time()
+        try:
+            run = make_dispatch_tdm(
+                rank=0,
+                npes=npes,
+                experts_per_rank=8,
+                experts_per_token=topk,
+                hidden_dim=hidden,
+                hidden_elem_size=elem,
+                max_tok_per_rank=max_tok,
+                max_recv=npes * max_tok,
+                block_num=block,
+                warp_num_per_block=warp,
+                off_tok_off=0,
+                off_recv_num=256,
+                off_tis=512,
+                off_out_idx=4096,
+                off_out_wts=8192,
+                off_out_tok=16384,
+            )
+            run(*([0] * 11), 0, 8)
+        except Exception as exc:  # noqa: BLE001 - report every case, not just the first
+            bad += 1
+            print(f"FAIL {tag}\n  {type(exc).__name__}: {exc}", flush=True)
+            if os.environ.get("TB"):
+                import traceback
+
+                traceback.print_exc()
+                return 1
+        else:
+            print(
+                f"ok   {tag}  cap/blk={cap} slots={slots}  ({time.time() - t0:.1f}s)",
+                flush=True,
+            )
+    print(f"\n{len(CASES) - bad}/{len(CASES)} configs compiled")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/op_tests/flydsl_tests/test_dispatch_tdm.py
+++ b/op_tests/flydsl_tests/test_dispatch_tdm.py
@@ -1,0 +1,212 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Correctness + A/B for the TDM dispatch transport (gfx1250).
+
+Runs the same routing through ``dispatch_transport='vector'`` and
+``'tdm'`` and checks both against a CPU model of what every rank should
+receive. The two transports assign recv slots in different orders -- vector
+takes one remote atomic per route, TDM reserves a contiguous run per (block,
+peer) -- so the check is order-independent: it keys each received row by the
+``(src_pe, src_tok)`` its srcmap names and compares the row's payload, indices
+and weights against that source token.
+
+    torchrun --standalone --nproc_per_node=4 test_dispatch_tdm.py
+    HIDDEN=7168 TOPK=8 EPR=32 SWEEP=8,128,512 BENCH=1 torchrun ...
+"""
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+from aiter.ops.flydsl.dispatch_combine_v2 import (
+    EpDispatchCombineConfig,
+    EpDispatchCombineOp,
+)
+from mori.cco import Communicator
+
+HIDDEN = int(os.environ.get("HIDDEN", 2048))
+TOPK = int(os.environ.get("TOPK", 8))
+EPR = int(os.environ.get("EPR", 8))
+SWEEP = [int(x) for x in os.environ.get("SWEEP", "8,64,512").split(",")]
+BENCH = os.environ.get("BENCH") == "1"
+ITERS = int(os.environ.get("ITERS", 50))
+WARMUP = int(os.environ.get("WARMUP", 10))
+DTYPE = torch.bfloat16
+
+
+def _bootstrap():
+    """torchrun + gloo, used only to carry the cco unique id and pass/fail counts."""
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    local = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local)
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    uid = [Communicator.get_unique_id() if rank == 0 else None]
+    dist.broadcast_object_list(uid, src=0)
+    return rank, world, local, uid[0]
+
+
+def _allreduce_sum(v):
+    t = torch.tensor([v], dtype=torch.int64)
+    dist.all_reduce(t)
+    return int(t[0])
+
+
+def _expected_rows(all_idx, all_tok, rank, world, epr, topk, n_tok):
+    """{(src_pe, src_tok): sorted expert ids} for every token routed to `rank`.
+
+    A token routed to several of this rank's experts arrives once (the sender
+    dedups per destination PE), and it carries its whole topk index/weight row,
+    not just the experts that live here.
+    """
+    want = {}
+    for pe in range(world):
+        idx = all_idx[pe]
+        for t in range(n_tok):
+            row = [int(e) for e in idx[t]]
+            if any(e // epr == rank for e in row if e >= 0):
+                want[(pe, t)] = row
+    return want
+
+
+def _check(op, cfg, comm, rank, world, all_idx, all_wts, all_tok, n_tok, tag):
+    out, out_w, _out_s, out_i, total_recv, routing = op.dispatch(
+        all_tok[rank][:n_tok],
+        all_wts[rank][:n_tok],
+        None,
+        all_idx[rank][:n_tok],
+        return_routing=True,
+    )
+    torch.cuda.synchronize()
+    comm.barrier()
+
+    recv = int(total_recv.item())
+    src = routing.disp_tok_id_to_src_tok_id_local[:recv].cpu()
+    got_tok = out[:recv].float().cpu()
+    got_idx = out_i[:recv].cpu()
+    got_wts = out_w[:recv].cpu()
+
+    want = _expected_rows(all_idx, all_tok, rank, world, cfg.num_experts_per_rank, TOPK, n_tok)
+    errs = []
+    if recv != len(want):
+        errs.append(f"recv={recv} expected={len(want)}")
+    seen = set()
+    max_tok = cfg.max_num_inp_token_per_rank
+    for r in range(recv):
+        enc = int(src[r])
+        key = (enc // max_tok, enc % max_tok)
+        if key not in want:
+            errs.append(f"row {r}: unexpected source {key}")
+            break
+        if key in seen:
+            errs.append(f"row {r}: duplicate source {key}")
+            break
+        seen.add(key)
+        pe, t = key
+        if not torch.equal(got_idx[r], all_idx[pe][t].cpu()):
+            errs.append(f"row {r} src={key}: indices mismatch")
+            break
+        if not torch.allclose(got_wts[r], all_wts[pe][t].cpu(), atol=0, rtol=0):
+            errs.append(f"row {r} src={key}: weights mismatch")
+            break
+        if not torch.equal(got_tok[r], all_tok[pe][t].float().cpu()):
+            errs.append(f"row {r} src={key}: payload mismatch")
+            break
+    ok = not errs
+    bad = _allreduce_sum(0 if ok else 1)
+    if rank == 0:
+        print(
+            f"# {tag} ct={n_tok}: {'PASS' if bad == 0 else 'FAIL'} (recv={recv})",
+            flush=True,
+        )
+    if errs and rank == 0:
+        print(f"    rank{rank}: {errs[0]}", flush=True)
+    return bad == 0
+
+
+def _time(op, comm, all_idx, all_wts, all_tok, rank, n_tok):
+    inp, w, i = all_tok[rank][:n_tok], all_wts[rank][:n_tok], all_idx[rank][:n_tok]
+    for _ in range(WARMUP):
+        op.dispatch(inp, w, None, i)
+    torch.cuda.synchronize()
+    comm.barrier()
+    s = torch.cuda.Event(enable_timing=True)
+    e = torch.cuda.Event(enable_timing=True)
+    s.record()
+    for _ in range(ITERS):
+        op.dispatch(inp, w, None, i)
+    e.record()
+    torch.cuda.synchronize()
+    comm.barrier()
+    return s.elapsed_time(e) / ITERS * 1000.0
+
+
+def main():
+    rank, world, local, uid = _bootstrap()
+    max_tok = max(SWEEP)
+    n_experts = EPR * world
+    torch.manual_seed(1234)
+
+    # Same routing on every rank's view: each rank generates its own tokens but
+    # all of them are needed to model what any one rank receives, so they are
+    # generated from a per-rank seed the whole world can reproduce.
+    all_idx, all_wts, all_tok = [], [], []
+    for pe in range(world):
+        g = torch.Generator().manual_seed(1000 + pe)
+        idx = torch.stack(
+            [torch.randperm(n_experts, generator=g)[:TOPK] for _ in range(max_tok)]
+        ).int()
+        wts = torch.rand(max_tok, TOPK, generator=g)
+        tok = torch.randn(max_tok, HIDDEN, generator=g).to(DTYPE)
+        dev = f"cuda:{local}"
+        all_idx.append(idx.to(dev))
+        all_wts.append(wts.to(dev))
+        all_tok.append(tok.to(dev))
+
+    comm = Communicator.init(world, rank, uid)
+
+    failures = 0
+    timings = {}
+    for transport in ("vector", "tdm"):
+        cfg = EpDispatchCombineConfig(
+            rank=rank,
+            world_size=world,
+            hidden_dim=HIDDEN,
+            max_num_inp_token_per_rank=max_tok,
+            num_experts_per_rank=EPR,
+            num_experts_per_token=TOPK,
+            data_type=DTYPE,
+            dispatch_transport=transport,
+        )
+        op = EpDispatchCombineOp(cfg, comm)
+        try:
+            for ct in SWEEP:
+                if not _check(
+                    op, cfg, comm, rank, world, all_idx, all_wts, all_tok, ct, transport
+                ):
+                    failures += 1
+            if BENCH:
+                timings[transport] = {
+                    ct: _time(op, comm, all_idx, all_wts, all_tok, rank, ct)
+                    for ct in SWEEP
+                }
+        finally:
+            op.close()
+
+    if BENCH and rank == 0:
+        print(f"\n# dispatch us/call (hidden={HIDDEN} topk={TOPK} world={world})")
+        print(f"{'tokens':>8} {'vector':>10} {'tdm':>10} {'speedup':>9}")
+        for ct in SWEEP:
+            v, t = timings["vector"][ct], timings["tdm"][ct]
+            print(f"{ct:>8} {v:>10.1f} {t:>10.1f} {v / t:>8.2f}x")
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0:
+        print(f"\n{'ALL PASS' if failures == 0 else f'{failures} FAILURES'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Ports mori's intranode_1250x dispatch onto FlyDSL: a block-local route histogram, one remote atomic per (block, peer) to reserve a contiguous slot run, per-warp metadata staging shipped in bulk runs, and a TDM load/store pipeline for the payload. Selected with dispatch_transport='tdm'; 'auto' still resolves to the vector transport, so existing callers are untouched.

Measured on EP4 bf16 against the vector transport, dispatch us/call: at hidden 7168, 2048 tokens 188 -> 129 and 8192 tokens 621 -> 266; at hidden 2048, 4096 tokens 254 -> 129 and 16384 tokens 848 -> 278. Below roughly a thousand tokens both transports sit on a ~118us cross-rank rendezvous floor and TDM's extra fixed cost leaves it ~10% behind, so the win is a large-batch one.

Three things the port needed beyond a transcription:

PAYLOAD has to walk FINALIZE's token partition. Only a workgroup barrier separates the two phases, so a warp may read back nothing but the token map entries it wrote itself. A grid-strided walk reads slots other blocks own: at 512 tokens on a 64x8 grid only blocks 0..15 route, and the other 48 send payload off entries still holding the host's -1 fill, which decodes to a store one whole token before a peer's recv buffer. That out-of-bounds fabric write wedges the TDM engine rather than merely corrupting the result. A liveness test of `>= 0` now rejects the fill on top of the sentinel.

The tuned schedule is tuned against the vector transport, which holds no per-warp LDS, so it names warp widths this kernel cannot build -- 32 warps of a 7168-wide bf16 tile want 448 KB of a 320 KB budget. tdm_max_warps clamps the width, keeps the tuned block count, and keeps the caller's spec as the variant key.

The per-warp token quota is capped at what it takes to cover the grid, as the reference does, so a small batch spreads over the blocks instead of piling onto low warp ids. This is invisible under the rendezvous floor above but matters wherever that floor is lower.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
