### PR TITLE
[Triton][DSV4] Fix non-stage1 paged MQA logits for KV block size > 1

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
@@ -367,9 +367,11 @@ def _deepgemm_fp8_paged_mqa_logits(
     stride_q_next_n,
     stride_q_heads,
     KV_buffer,
-    stride_k_seq,
+    stride_k_block,
+    stride_k_token,
     scale_buffer,
-    stride_scale_seq,
+    stride_scale_block,
+    stride_scale_token,
     context_len_ptr,
     kv_indices,
     weights,
@@ -381,6 +383,7 @@ def _deepgemm_fp8_paged_mqa_logits(
     ChunkQ: tl.constexpr,
     ChunkK: tl.constexpr,
     HiddenDim: tl.constexpr,
+    KVBlockSize: tl.constexpr,
     SplitKV: tl.constexpr = 1,
 ):
     pid = tl.program_id(0)
@@ -417,21 +420,31 @@ def _deepgemm_fp8_paged_mqa_logits(
     for context_idx in range(
         split_context_start, split_context_start + split_context_length, ChunkK
     ):
-        mask_kv = context_idx + tl.arange(0, ChunkK) < context_length
-        context_kv_idx = tl.load(
-            kv_indices + pid_batch * max_blk_len + context_idx + tl.arange(0, ChunkK),
+        logical_kv_idx = context_idx + tl.arange(0, ChunkK)
+        logical_block_idx = logical_kv_idx // KVBlockSize
+        mask_kv = (logical_kv_idx < context_length) & (logical_block_idx < max_blk_len)
+        physical_block_idx = tl.load(
+            kv_indices + pid_batch * max_blk_len + logical_block_idx,
             mask=mask_kv,
             other=0,
         )
+        block_offset = logical_kv_idx % KVBlockSize
 
         k = tl.load(
             KV_buffer
-            + context_kv_idx[:, None] * stride_k_seq
+            + physical_block_idx[:, None] * stride_k_block
+            + block_offset[:, None] * stride_k_token
             + tl.arange(0, HiddenDim)[None, :],
             mask=mask_kv[:, None],
             other=0.0,
         )
-        k_scale_f = tl.load(scale_buffer + context_kv_idx[:, None] * stride_scale_seq)
+        k_scale_f = tl.load(
+            scale_buffer
+            + physical_block_idx[:, None] * stride_scale_block
+            + block_offset[:, None] * stride_scale_token,
+            mask=mask_kv[:, None],
+            other=0.0,
+        )
 
         o = tl.dot(q, k.T)
         o = o * k_scale_f.T

--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -40,6 +40,7 @@ enable_aot_gluon_pa_mqa_logits = os.environ.get(
 )
 enable_aot_gluon_pa_mqa_logits = enable_aot_gluon_pa_mqa_logits == "1"
 triton_version = Version(Version(triton.__version__).base_version)
+_GLUON_PA_MQA_LOGITS_ARCHS = ("gfx942", "gfx950", "gfx1250")
 if triton_version >= Version("3.5.0"):
     from triton.experimental.gluon._runtime import GluonASTSource as ASTSource
 
@@ -57,7 +58,7 @@ if triton_version >= Version("3.5.0"):
         _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx,
     )
 
-    enable_gluon_pa_mqa_logits = True
+    enable_gluon_pa_mqa_logits = get_gfx() in _GLUON_PA_MQA_LOGITS_ARCHS
     enable_jit_gluon_pa_mqa_logits_kernel = not enable_aot_gluon_pa_mqa_logits
 else:
     from triton.compiler import ASTSource
@@ -73,7 +74,9 @@ else:
         _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx,
     )
 
-    enable_gluon_pa_mqa_logits = enable_aot_gluon_pa_mqa_logits
+    enable_gluon_pa_mqa_logits = (
+        enable_aot_gluon_pa_mqa_logits and get_gfx() in _GLUON_PA_MQA_LOGITS_ARCHS
+    )
     enable_jit_gluon_pa_mqa_logits_kernel = False
 
 
@@ -265,7 +268,7 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
     VarCtxOpt: bool = False,
 ):
     gfx_version = get_gfx()
-    assert gfx_version in ("gfx942", "gfx950", "gfx1250")
+    assert gfx_version in _GLUON_PA_MQA_LOGITS_ARCHS
     is_gfx1250 = gfx_version == "gfx1250"
     if is_gfx1250:
         if Preshuffle:
@@ -605,8 +608,9 @@ def deepgemm_fp8_paged_mqa_logits(
                 hidden_dim,
             )
     else:
-        assert KVBlockSize == 1
         assert not Preshuffle, "Preshuffle mode is only supported on gluon kernel."
+        kv_cache_values = kv_cache_fp8.view(num_block, KVBlockSize, hidden_dim)
+        kv_cache_scales = kv_cache_scale.view(num_block, KVBlockSize)
         kernel = _deepgemm_fp8_paged_mqa_logits[grid](
             batch_size,
             next_n,
@@ -615,10 +619,12 @@ def deepgemm_fp8_paged_mqa_logits(
             q_fp8.stride(0),
             q_fp8.stride(1),
             q_fp8.stride(2),
-            kv_cache_fp8,
-            kv_cache_fp8.stride(0),
-            kv_cache_scale,
-            kv_cache_scale.stride(0),
+            kv_cache_values,
+            kv_cache_values.stride(0),
+            kv_cache_values.stride(1),
+            kv_cache_scales,
+            kv_cache_scales.stride(0),
+            kv_cache_scales.stride(1),
             context_lens,
             kv_indices,
             weights,
@@ -632,5 +638,6 @@ def deepgemm_fp8_paged_mqa_logits(
             ChunkK=ChunkK,
             SplitKV=SplitKV,
             HiddenDim=hidden_dim,
+            KVBlockSize=KVBlockSize,
         )
     return triton.runtime.cache.get_cache_manager(kernel.hash).key


### PR DESCRIPTION
## Summary

  This change is similar to #4440, which added block-paged KV-cache indexing to the stage1 paged MQA logits kernel, but applies the same fix to the fused-reduction Triton path.

  The fused-reduction kernel reduces the per-head contributions directly into the output logits instead of storing the per-head intermediate results produced by the stage1 path.

The Gluon implementation was previously enabled by default with supported Triton versions, including on architectures unsupported by the Gluon kernel.

 Gluon is now enabled only on:
  - gfx942
  - gfx950
  - gfx1250

  Other architectures, including RDNA4, use the fused-reduction Triton implementation instead of reaching the Gluon architecture assertion.

  ## Technical details

  The corrected indexing maps each logical token to its logical block and its offset within that block:

  ```python
  logical_block_idx = logical_kv_idx // KVBlockSize
  block_offset = logical_kv_idx % KVBlockSize
  physical_block_idx = kv_indices[batch, logical_block_idx]
```

  FP8 values and FP32 scales are then loaded using both the physical block index and the in-block token offset.

  After the existing packed value/scale split, the wrapper reshapes the value and scale tensors using the configured KV block size and passes their block and token strides to the Triton kernel.


## GSM8K

Tested on 8xgfx1201:
 ```python
lm_eval \
    --model local-completions \
    --tasks gsm8k \
    --model_args "model=deepseek-v4-flash-0731,tokenizer=deepseek-ai/DeepSeek-V4-Flash,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
    --batch_size auto
```

| Tasks | Version | Filter | n-shot | Metric |   | Value |   | Stderr |
|---|---:|---|---:|---|---|---:|---|---:|
| gsm8k | 3 | flexible-extract | 5 | exact_match | ↑ | 0.9522 | ± | 0.0059 |
|  |  | strict-match | 5 | exact_match | ↑ | 0.9522 | ± | 0.0059 |



  