### PR TITLE
[Triton/Gluon] [GFX1250] Use new preshuffling API for a4w4 MoE

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
@@ -712,7 +712,7 @@ def _moe_gemm_a4w4_prefill(
         PRESHUFFLE_FACTOR_WS: gl.constexpr = 32
         SHUFFLED_BLOCK_K_WS: gl.constexpr = MX_SCALE_BLOCK_K * PRESHUFFLE_FACTOR_WS
         SHUFFLED_BLOCK_N_WS: gl.constexpr = BLOCK_N // PRESHUFFLE_FACTOR_WS
-        SCALE_KWIDTH: gl.constexpr = 8
+        SCALE_KWIDTH: gl.constexpr = 4
     else:
         PRESHUFFLE_FACTOR_WS: gl.constexpr = 1
         SHUFFLED_BLOCK_K_WS: gl.constexpr = MX_SCALE_BLOCK_K
@@ -1374,7 +1374,7 @@ def _moe_gemm_a4w4_decode(
         PRESHUFFLE_FACTOR_WS: gl.constexpr = 32
         SHUFFLED_BLOCK_K_WS: gl.constexpr = MX_SCALE_BLOCK_K * PRESHUFFLE_FACTOR_WS
         SHUFFLED_BLOCK_N_WS: gl.constexpr = BLOCK_N // PRESHUFFLE_FACTOR_WS
-        SCALE_KWIDTH: gl.constexpr = 8
+        SCALE_KWIDTH: gl.constexpr = 4
     else:
         PRESHUFFLE_FACTOR_WS: gl.constexpr = 1
         SHUFFLED_BLOCK_K_WS: gl.constexpr = MX_SCALE_BLOCK_K

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
@@ -46,7 +46,7 @@ from pathlib import Path
 import torch
 import triton
 
-from aiter.ops.shuffle import shuffle_weight_gfx1250
+from aiter.ops.shuffle import moe_shuffle_scale, moe_shuffle_weight
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     is_gluon_supported,
@@ -56,7 +56,7 @@ from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
 from aiter.ops.triton.moe.moe_routing.routing import _USE_HERD, routing
 from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
 from aiter.ops.triton.utils._triton.arch_info import get_arch
-from aiter.ops.triton.utils.shuffle import shuffle_scale_moe
+from aiter.ops.triton.utils.shuffle import moe_weight_decode_view, shuffle_scale_moe
 
 # measurable layers, in report order; see the module docstring
 LAYERS = ("moe1", "moe2", "total")
@@ -147,29 +147,40 @@ def compute_roofline(
                 )
 
 
+def preshuffle_moe_wscale(s):
+    """``(E, K//32, N)`` B-scale -> gfx1250 n32k4 layout, same orientation back.
+
+    ``moe_shuffle_scale`` is the n32k4 tile (preshuffle 32, scale kwidth 4) and
+    takes the ``(E, N, K//32)`` orientation, so transpose in and back out. Must
+    stay in step with ``SCALE_KWIDTH`` in the gfx1250 gluon kernels.
+    """
+    return moe_shuffle_scale(s.transpose(-1, -2)).transpose(-1, -2)
+
+
 def check_and_shuffle_scales(scale, N, K):
     if get_arch() == "gfx950" and N % 32 == 0 and K % (32 * 8) == 0:
         scale = shuffle_scale_moe(
             scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
         )
         return scale, "CDNA4_SCALE"
-    elif get_arch() == "gfx1250" and N % 32 == 0 and K % (32 * 8) == 0:
-        scale = shuffle_scale_moe(
-            scale, arch="gfx1250", preshuffle_factor=32, scale_kwidth=8
-        )
+    elif get_arch() == "gfx1250" and N % 32 == 0 and K % (32 * 4) == 0:
+        # n32k4 layout (scale kwidth 4), so K//32 only needs to divide by 4.
+        scale = preshuffle_moe_wscale(scale)
         return scale, "GFX1250_SCALE"
     else:
         return scale, None
 
 
-def preshuffle_weight(w):
+def preshuffle_moe_weight(w):
     """gfx1250 WMMA weight preshuffle.
 
     `w` is the mxfp4 weight [E, K // 2, N]; the result is the TDM view
     [E, (K // 2) * 16, N // 16] the gluon kernel reads with PRESHUFFLED=True.
-    shuffle_weight_gfx1250() asserts K // 2 % 32 and N % 16.
+    ``moe_shuffle_weight`` takes the ``(E, N, K // 2)`` orientation and asserts
+    K // 2 % 32 and N % 16; ``moe_weight_decode_view`` then reinterprets the
+    result (zero-copy) as the flattened view the kernel loads.
     """
-    return shuffle_weight_gfx1250(w)
+    return moe_weight_decode_view(moe_shuffle_weight(w.transpose(-1, -2)))
 
 
 def quantize(x, dtype):
@@ -305,8 +316,8 @@ def bench_mlp_single_weight_init(
         w2_scale, dim1, dim2 // TP // 2
     )
     if preshuffle:
-        w1 = preshuffle_weight(w1)
-        w2 = preshuffle_weight(w2)
+        w1 = preshuffle_moe_weight(w1)
+        w2 = preshuffle_moe_weight(w2)
 
     # -- routing + layer-1 activations: built once, outside the timed region --
     x = torch.randn((batch, dim1), dtype=torch.bfloat16, device=dev)

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
@@ -175,7 +175,7 @@ def preshuffle_moe_weight(w):
     """gfx1250 WMMA weight preshuffle.
 
     `w` is the mxfp4 weight [E, K // 2, N]; the result is the TDM view
-    [E, (K // 2) * 16, N // 16] the gluon kernel reads with PRESHUFFLED=True.
+    [E, (K // 2) * 16, N // 16] the gluon kernel reads with PRESHUFFLE_WEIGHTS=True.
     ``moe_shuffle_weight`` takes the ``(E, N, K // 2)`` orientation and asserts
     K // 2 % 32 and N % 16; ``moe_weight_decode_view`` then reinterprets the
     result (zero-copy) as the flattened view the kernel loads.

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
@@ -34,7 +34,7 @@ def parse_profile(profile_path, useful_op_regex, reps):
     useful = gf.filter(
         f"MATCH ('*', c) WHERE c.'name' =~ '{useful_op_regex}' AND c IS LEAF"
     ).dataframe
-    bytes = int(useful["bytes"].sum())
+    bytes_ = int(useful["bytes"].sum())
     flops = int(
         sum(useful[[c for c in ["flops8", "flops16"] if c in useful.columns]].sum())
     )
@@ -46,7 +46,7 @@ def parse_profile(profile_path, useful_op_regex, reps):
         "total_time_ns": total_time_ns,
         "kernel_time_ns": kernel_time_ns,
         "flops": flops,
-        "bytes": bytes,
+        "bytes": bytes_,
         "reps": reps,
     }
 
@@ -59,6 +59,7 @@ def compute_roofline(
         raise TypeError(
             "intensity_proxy must be a string naming a parameter in target_fn"
         )
+
     # determine position of intensity_proxy in target_fn signature
     sig = inspect.signature(bench_fn)
     params = list(sig.parameters.values())
@@ -69,82 +70,80 @@ def compute_roofline(
     pos_index = [p.name for p in params].index(intensity_proxy_name)
 
     # wrapper to inject intensity proxy into target_fn and call it
-    def inject_proxy_and_call(val, args, kwargs):
-        args_list = list(args)
+    def inject_proxy_and_call(val, args_, kwargs_):
+        args_list = list(args_)
         args_list.insert(pos_index, val)
-        return bench_fn(*args_list, **kwargs)
+        return bench_fn(*args_list, **kwargs_)
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
 
     # collect performance data
-    perfs = []
+    results: list[tuple[str, dict[str, int | float]]] = []
     print("=========================================")
     print(f"{out_path}...")
     print("=========================================")
 
     for val in intensity_proxy_values:
         perf = inject_proxy_and_call(val, args, kwargs)
-        perfs.append((val, perf))
+        results.append((val, perf))
 
         tflops = perf["flops"] / perf["kernel_time_ns"] * 1e-3
         tbps = perf["bytes"] / perf["kernel_time_ns"] * 1e-3
-        total_latency = perf["total_time_ns"] / 1e3 / perf["reps"]
-        kernel_latency = perf["kernel_time_ns"] / 1e3 / perf["reps"]
+        total_latency_us = perf["total_time_ns"] / 1e3 / perf["reps"]
+        kernel_latency_us = perf["kernel_time_ns"] / 1e3 / perf["reps"]
         print(
             f"{intensity_proxy_name}: {val:5d} | "
-            f"Total latency (us): {total_latency:.2f} | "
-            f"Kernel latency (us): {kernel_latency:.2f} | "
+            f"Total latency (us): {total_latency_us:.2f} | "
+            f"Kernel latency (us): {kernel_latency_us:.2f} | "
             f"TFLOPS: {tflops:#.4g} | "
             f"TBPS: {tbps:.2f}"
         )
 
-    out_path = Path(out_path)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-
+    # write CSV
     fieldnames = [
         intensity_proxy_name,  # e.g. "batch"
         "total_latency_us",
         "kernel_latency_us",
         "tflops",
         "tbps",
-        # raw counters from proton:
         "total_time_ns",
         "kernel_time_ns",
         "flops",
         "bytes",
         "reps",
     ]
-
     with out_path.open("w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=fieldnames)
         w.writeheader()
-        for val, perf in perfs:
-            row = {
-                intensity_proxy_name: val,
-                "total_latency_us": perf["total_time_ns"] / 1e3 / perf["reps"],
-                "kernel_latency_us": perf["kernel_time_ns"] / 1e3 / perf["reps"],
-                "tflops": perf["flops"] / perf["kernel_time_ns"] * 1e-3,
-                "tbps": perf["bytes"] / perf["kernel_time_ns"] * 1e-3,
-                "total_time_ns": perf["total_time_ns"],
-                "kernel_time_ns": perf["kernel_time_ns"],
-                "flops": perf["flops"],
-                "bytes": perf["bytes"],
-                "reps": perf["reps"],
-            }
-            w.writerow(row)
+        for val, perf in results:
+            w.writerow(
+                {
+                    intensity_proxy_name: val,
+                    "total_latency_us": perf["total_time_ns"] / 1e3 / perf["reps"],
+                    "kernel_latency_us": perf["kernel_time_ns"] / 1e3 / perf["reps"],
+                    "tflops": perf["flops"] / perf["kernel_time_ns"] * 1e-3,
+                    "tbps": perf["bytes"] / perf["kernel_time_ns"] * 1e-3,
+                    "total_time_ns": perf["total_time_ns"],
+                    "kernel_time_ns": perf["kernel_time_ns"],
+                    "flops": perf["flops"],
+                    "bytes": perf["bytes"],
+                    "reps": perf["reps"],
+                }
+            )
 
 
-def preshuffle_moe_weight(w):
-    """gfx1250 WMMA weight preshuffle.
+def preshuffle_moe_weight(w: torch.Tensor) -> torch.Tensor:
+    """``(E, K, N)`` -> the gfx1250 WMMA TDM view ``(E, K*16, N//16)``.
 
-    `w` is the mxfp4 weight [E, K // 2, N]; the result is the TDM view
-    [E, (K // 2) * 16, N // 16] the gluon kernel reads with PRESHUFFLE_WEIGHTS=True.
-    ``moe_shuffle_weight`` takes the ``(E, N, K // 2)`` orientation and asserts
-    K // 2 % 32 and N % 16; ``moe_weight_decode_view`` then reinterprets the
-    result (zero-copy) as the flattened view the kernel loads.
+    ``moe_shuffle_weight`` takes the ``(E, N, K)`` MoE weight orientation and
+    returns the shuffled buffer in that same shape; ``moe_weight_decode_view``
+    then reinterprets it (zero-copy) as the flattened view the kernel loads.
     """
     return moe_weight_decode_view(moe_shuffle_weight(w.transpose(-1, -2)))
 
 
-def preshuffle_moe_wscale(s):
+def preshuffle_moe_wscale(s: torch.Tensor) -> torch.Tensor:
     """``(E, K//32, N)`` B-scale -> gfx1250 n32k4 layout, same orientation back.
 
     ``moe_shuffle_scale`` is the n32k4 tile (preshuffle 32, scale kwidth 4) and
@@ -233,8 +232,8 @@ def bench_mlp_single_weight_init(
     w_dtype,
     TP,
     op_regex,
-    preshuffle=False,
     routed_experts=None,
+    preshuffle=False,
 ):
     rank = 0
     dev = f"cuda:{rank}"
@@ -297,10 +296,11 @@ def bench_mlp_single_weight_init(
                 f"  batch={batch}: pinned {n_pinned} experts, not {routed_experts} "
                 f"-- batch * top-k is only {batch * n_expts_act} routed rows"
             )
+
     # run layer
     fpath = Path(tempfile.mktemp())
     proton.start(str(fpath), hook="triton")
-    for i in range(reps):
+    for _ in range(reps):
         logits = gemm_a16w16(xg, wg.T, bg)
         if pin_mask is not None:
             logits.masked_fill_(pin_mask, float("-inf"))
@@ -347,12 +347,12 @@ def bench_mlp(
     w_dtype,
     TP,
     op_regex,
-    preshuffle=False,
     routed_experts=None,
     num_weight_inits=1,
+    preshuffle=False,
 ):
     all_results = []
-    for i in range(num_weight_inits):
+    for _ in range(num_weight_inits):
         result = bench_mlp_single_weight_init(
             batch,
             dim1,
@@ -363,8 +363,8 @@ def bench_mlp(
             w_dtype,
             TP,
             op_regex,
-            preshuffle,
-            routed_experts,
+            routed_experts=routed_experts,
+            preshuffle=preshuffle,
         )
         all_results.append(result)
 
@@ -390,18 +390,21 @@ def roofline_mlp(
     w_dtype,
     TP,
     op_regex,
-    preshuffle=False,
     routed_experts=None,
-    num_weight_inits=1,
     name="",
+    num_weight_inits=1,
+    preshuffle=False,
 ):
     # Put all outputs under logs/<name>/ and write a CSV file (not a directory-as-stem).
     out_dir = Path("logs") / name
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # --preshuffle changes what is measured, so it gets its own file rather
-    # than overwriting the unshuffled sweep.
-    stem = f"{x_dtype}x-{w_dtype}w-TP{TP}"
+    stem = (
+        f"{x_dtype}x-{w_dtype}w-TP{TP}-dim1={dim1}-dim2={dim2}"
+        f"-E={n_expts_tot}-topk={n_expts_act}"
+    )
+    if routed_experts is not None:
+        stem += f"-routed={routed_experts}"
     if preshuffle:
         stem += "-preshuffled"
     out_csv = out_dir / f"{stem}.csv"
@@ -415,13 +418,13 @@ def roofline_mlp(
         w_dtype,
         TP,
         op_regex,
-        preshuffle,
         routed_experts,  # fixed args
         num_weight_inits,
+        preshuffle,
         bench_fn=bench_mlp,  # function to benchmark
         intensity_proxy_name="batch",  # intensity proxy name
         intensity_proxy_values=batch_sizes,  # intensity proxy values to sweep
-        out_path=out_csv,  # output path
+        out_path=out_csv,
     )
 
 
@@ -457,12 +460,6 @@ def parse_args(args: list[str] | None = None):
         help="Regex to find perf for specific operation by its kernel name.",
     )
     parser.add_argument(
-        "--preshuffle",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Preshuffle the mxfp4 weights for the gfx1250 gluon kernel (default: False).",
-    )
-    parser.add_argument(
         "--routed-experts",
         type=int,
         default=None,
@@ -480,8 +477,13 @@ def parse_args(args: list[str] | None = None):
         help="Number of different weight initializations to run for more stable results (default: 1). "
         "Each initialization runs 100 iterations. Use higher values (e.g., 10) for more stable benchmarks.",
     )
-    args = parser.parse_args(args=args)
-    return args
+    parser.add_argument(
+        "--preshuffle",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Preshuffle the mxfp4 weights for the gfx1250 gluon kernel (default: False).",
+    )
+    return parser.parse_args(args=args)
 
 
 def main(args: list[str] | None = None) -> None:
@@ -502,6 +504,7 @@ def main(args: list[str] | None = None) -> None:
         batch_sizes_moe = list(chain(*[range(*r) for r in batch_ranges_moe]))
     else:
         batch_sizes_moe = parsed_args.M
+
     quantized_dtypes = ["mx4", "mx4"]
 
     roofline_mlp(
@@ -514,10 +517,10 @@ def main(args: list[str] | None = None) -> None:
         quantized_dtypes[1],
         TP=1,
         op_regex=parsed_args.op_regex,
-        preshuffle=parsed_args.preshuffle,
         routed_experts=parsed_args.routed_experts,
-        num_weight_inits=parsed_args.num_weight_inits,
         name="gpt-oss-x2",
+        num_weight_inits=parsed_args.num_weight_inits,
+        preshuffle=parsed_args.preshuffle,
     )
 
 

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 import triton.profiler as proton
 
-from aiter.ops.shuffle import moe_shuffle_scale
+from aiter.ops.shuffle import moe_shuffle_scale, moe_shuffle_weight
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     moe_gemm_a4w4,
@@ -20,7 +20,7 @@ from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
 from aiter.ops.triton.moe.moe_routing.routing import _USE_HERD, routing
 from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
 from aiter.ops.triton.utils._triton.arch_info import get_arch
-from aiter.ops.triton.utils.shuffle import shuffle_scale_moe
+from aiter.ops.triton.utils.shuffle import moe_weight_decode_view, shuffle_scale_moe
 
 
 def parse_profile(profile_path, useful_op_regex, reps):
@@ -132,6 +132,18 @@ def compute_roofline(
             w.writerow(row)
 
 
+def preshuffle_moe_weight(w):
+    """gfx1250 WMMA weight preshuffle.
+
+    `w` is the mxfp4 weight [E, K // 2, N]; the result is the TDM view
+    [E, (K // 2) * 16, N // 16] the gluon kernel reads with PRESHUFFLE_WEIGHTS=True.
+    ``moe_shuffle_weight`` takes the ``(E, N, K // 2)`` orientation and asserts
+    K // 2 % 32 and N % 16; ``moe_weight_decode_view`` then reinterprets the
+    result (zero-copy) as the flattened view the kernel loads.
+    """
+    return moe_weight_decode_view(moe_shuffle_weight(w.transpose(-1, -2)))
+
+
 def preshuffle_moe_wscale(s):
     """``(E, K//32, N)`` B-scale -> gfx1250 n32k4 layout, same orientation back.
 
@@ -221,6 +233,7 @@ def bench_mlp_single_weight_init(
     w_dtype,
     TP,
     op_regex,
+    preshuffle=False,
     routed_experts=None,
 ):
     rank = 0
@@ -229,6 +242,10 @@ def bench_mlp_single_weight_init(
     assert dim2 % TP == 0, f"{dim2=}, {TP=}, dim2 must be divisible by TP"
     assert x_dtype == "mx4", f"FP4 (E2M1) is disabled for x_dtype, got {x_dtype}"
     assert w_dtype == "mx4", f"FP4 (E2M1) is disabled for x_dtype, got {w_dtype}"
+    if preshuffle:
+        assert (
+            get_arch() == "gfx1250"
+        ), f"--preshuffle needs the gfx1250 gluon kernel, got {get_arch()}"
     if routed_experts is not None:
         # every token needs n_expts_act distinct experts, so the pool can't be smaller
         assert n_expts_act <= routed_experts <= n_expts_tot, (
@@ -260,6 +277,9 @@ def bench_mlp_single_weight_init(
     w2_scale, swizzle_mx_scale2 = check_and_shuffle_scales(
         w2_scale, dim1, dim2 // TP // 2
     )
+    if preshuffle:
+        w1 = preshuffle_moe_weight(w1)
+        w2 = preshuffle_moe_weight(w2)
 
     # -- benchmark --
     x_dtype_str = x_dtype
@@ -296,6 +316,7 @@ def bench_mlp_single_weight_init(
             rdata,
             gather_indx=gather_indx,
             swizzle_mx_scale=swizzle_mx_scale1,
+            preshuffle_weights=preshuffle,
             apply_swiglu=True,
         )
         x, x_scale = mxfp4_quant(x)
@@ -308,6 +329,7 @@ def bench_mlp_single_weight_init(
             rdata,
             scatter_indx=scatter_indx,
             swizzle_mx_scale=swizzle_mx_scale2,
+            preshuffle_weights=preshuffle,
         )
     proton.finalize()
     return parse_profile(
@@ -325,6 +347,7 @@ def bench_mlp(
     w_dtype,
     TP,
     op_regex,
+    preshuffle=False,
     routed_experts=None,
     num_weight_inits=1,
 ):
@@ -340,6 +363,7 @@ def bench_mlp(
             w_dtype,
             TP,
             op_regex,
+            preshuffle,
             routed_experts,
         )
         all_results.append(result)
@@ -366,6 +390,7 @@ def roofline_mlp(
     w_dtype,
     TP,
     op_regex,
+    preshuffle=False,
     routed_experts=None,
     num_weight_inits=1,
     name="",
@@ -374,7 +399,12 @@ def roofline_mlp(
     out_dir = Path("logs") / name
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    out_csv = out_dir / f"{x_dtype}x-{w_dtype}w-TP{TP}.csv"
+    # --preshuffle changes what is measured, so it gets its own file rather
+    # than overwriting the unshuffled sweep.
+    stem = f"{x_dtype}x-{w_dtype}w-TP{TP}"
+    if preshuffle:
+        stem += "-preshuffled"
+    out_csv = out_dir / f"{stem}.csv"
 
     compute_roofline(
         dim1,
@@ -385,6 +415,7 @@ def roofline_mlp(
         w_dtype,
         TP,
         op_regex,
+        preshuffle,
         routed_experts,  # fixed args
         num_weight_inits,
         bench_fn=bench_mlp,  # function to benchmark
@@ -424,6 +455,12 @@ def parse_args(args: list[str] | None = None):
         type=str,
         default=".*moe_gemm.*",
         help="Regex to find perf for specific operation by its kernel name.",
+    )
+    parser.add_argument(
+        "--preshuffle",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Preshuffle the mxfp4 weights for the gfx1250 gluon kernel (default: False).",
     )
     parser.add_argument(
         "--routed-experts",
@@ -477,6 +514,7 @@ def main(args: list[str] | None = None) -> None:
         quantized_dtypes[1],
         TP=1,
         op_regex=parsed_args.op_regex,
+        preshuffle=parsed_args.preshuffle,
         routed_experts=parsed_args.routed_experts,
         num_weight_inits=parsed_args.num_weight_inits,
         name="gpt-oss-x2",

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import torch
 import triton.profiler as proton
 
+from aiter.ops.shuffle import moe_shuffle_scale
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     moe_gemm_a4w4,
@@ -131,16 +132,25 @@ def compute_roofline(
             w.writerow(row)
 
 
+def preshuffle_moe_wscale(s):
+    """``(E, K//32, N)`` B-scale -> gfx1250 n32k4 layout, same orientation back.
+
+    ``moe_shuffle_scale`` is the n32k4 tile (preshuffle 32, scale kwidth 4) and
+    takes the ``(E, N, K//32)`` orientation, so transpose in and back out. Must
+    stay in step with ``SCALE_KWIDTH`` in the gfx1250 gluon kernels.
+    """
+    return moe_shuffle_scale(s.transpose(-1, -2)).transpose(-1, -2)
+
+
 def check_and_shuffle_scales(scale, N, K):
     if get_arch() == "gfx950" and N % 32 == 0 and K % (32 * 8) == 0:
         scale = shuffle_scale_moe(
             scale, arch="gfx950", preshuffle_factor=32, scale_kwidth=8
         )
         return scale, "CDNA4_SCALE"
-    elif get_arch() == "gfx1250" and N % 32 == 0 and K % (32 * 8) == 0:
-        scale = shuffle_scale_moe(
-            scale, arch="gfx1250", preshuffle_factor=32, scale_kwidth=8
-        )
+    elif get_arch() == "gfx1250" and N % 32 == 0 and K % (32 * 4) == 0:
+        # n32k4 layout (scale kwidth 4), so K//32 only needs to divide by 4.
+        scale = preshuffle_moe_wscale(scale)
         return scale, "GFX1250_SCALE"
     else:
         return scale, None

--- a/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, fields
 import pytest
 import torch
 
+from aiter.ops.shuffle import moe_shuffle_scale, moe_shuffle_weight
+
 # matmul utilities
 from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     is_gluon_supported,
@@ -25,7 +27,29 @@ from aiter.ops.triton.moe.quant_moe import (
 
 # target-specific utilities
 from aiter.ops.triton.utils._triton.arch_info import get_arch, is_fp4_avail
-from aiter.ops.triton.utils.shuffle import shuffle_scale_moe, shuffle_weight
+from aiter.ops.triton.utils.shuffle import moe_weight_decode_view, shuffle_scale_moe
+
+
+def preshuffle_moe_weight(w: torch.Tensor) -> torch.Tensor:
+    """``(E, K, N)`` -> the gfx1250 WMMA TDM view ``(E, K*16, N//16)``.
+
+    ``moe_shuffle_weight`` takes the ``(E, N, K)`` MoE weight orientation and
+    returns the shuffled buffer in that same shape; ``moe_weight_decode_view``
+    then reinterprets it (zero-copy) as the flattened view the kernel loads.
+    """
+    return moe_weight_decode_view(moe_shuffle_weight(w.transpose(-1, -2)))
+
+
+def preshuffle_moe_wscale(s: torch.Tensor) -> torch.Tensor:
+    """``(E, K//32, N)`` B-scale -> gfx1250 n32k4 layout, same orientation back.
+
+    ``moe_shuffle_scale`` is the n32k4 tile (preshuffle 32, scale kwidth 4) and
+    takes the ``(E, N, K//32)`` orientation, so transpose in and back out. This
+    is the kwidth-4 counterpart of ``shuffle_scale_moe(..., scale_kwidth=4)``
+    and must stay in step with ``SCALE_KWIDTH`` in the gfx1250 gluon kernels.
+    """
+    return moe_shuffle_scale(s.transpose(-1, -2)).transpose(-1, -2)
+
 
 # ---------------
 # initialize data
@@ -235,10 +259,17 @@ def test_op(
 ):
     if not is_fp4_avail():
         pytest.skip(f"FP4 kernels are not supported on {get_arch()}.")
-    if hbm_swizzling and (n % 32 != 0 or k % (32 * 8) != 0):
-        pytest.skip(
-            f"Shape {m}x{n}x{k} is not supported for scale swizzling on AMD GPU"
-        )
+    if hbm_swizzling:
+        if get_arch() == "gfx950" and (n % 32 != 0 or k % (32 * 8) != 0):
+            pytest.skip(
+                f"Shape {m}x{n}x{k} is not supported for scale swizzling on gfx950."
+            )
+        # gfx1250 uses the n32k4 layout (scale kwidth 4), so K only needs
+        # K//32 divisible by 4; gfx950 still needs 8.
+        if get_arch() == "gfx1250" and (n % 32 != 0 or k % (32 * 4) != 0):
+            pytest.skip(
+                f"Shape {m}x{n}x{k} is not supported for scale swizzling on gfx1250."
+            )
 
     if preshuffle_weights:
         if get_arch() != "gfx1250":
@@ -285,9 +316,7 @@ def test_op(
     if hbm_swizzling:
         if get_arch() == "gfx1250":
             swizzle_mx_scale = "GFX1250_SCALE"
-            w_scale_tri = shuffle_scale_moe(
-                w_scale_tri, arch="gfx1250", preshuffle_factor=32, scale_kwidth=8
-            )
+            w_scale_tri = preshuffle_moe_wscale(w_scale_tri)
         elif get_arch() == "gfx950":
             swizzle_mx_scale = "CDNA4_SCALE"
             w_scale_tri = shuffle_scale_moe(
@@ -298,12 +327,7 @@ def test_op(
     else:
         swizzle_mx_scale = None
     if preshuffle_weights:
-        E, K, N = w_tri.shape
-        w_tri = (
-            shuffle_weight(w_tri, arch="gfx1250")
-            .view(E, N // 16, K * 16)
-            .transpose(-1, -2)
-        )
+        w_tri = preshuffle_moe_weight(w_tri)
 
     x_tri, x_mx_scales_tri = mxfp4_quant(x_tri)
     x_ref = upcast_from_mxfp(x_tri, x_mx_scales_tri, torch.bfloat16, axis=-1)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

New shuffling scheme for MoE was added in `aiter/ops/shuffle`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Changed SCALE_KWIDTH to 4 from 8.
- Updated UT and ubench to follow new shuffle scheme.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

```
pytest op_tests/triton_tests/moe/test_moe_gemm_a4w4.py -k "gluon"
```

## Test Result

<!-- Briefly summarize test outcomes. -->

Passes gluon UT.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
