### PR TITLE
[CI] fix: lazily dequantize moe reference weights

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -35,7 +35,6 @@ else
 fi
 
 skip_tests=(
-    "op_tests/test_moe_2stage.py"
     "op_tests/multigpu_tests/test_dispatch_combine.py"
     "op_tests/multigpu_tests/test_communication.py"
     "op_tests/multigpu_tests/test_mori_all2all.py"

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1265,6 +1265,16 @@ fused_moe_1stage_dict = {
 quant_remap = {QuantType.per_128x128: QuantType.per_1x128}
 
 
+def _mxfp4_per_1x32_weight_expert_to_f32(weight, scale, expert_id, rows, cols):
+    from aiter.utility import fp4_utils
+
+    weight_e = fp4_utils.mxfp4_to_f32(weight[expert_id])
+    return (
+        weight_e.view(rows, cols // 32, 32)
+        * scale[expert_id].view(rows, cols // 32, 1)
+    ).view(rows, cols)
+
+
 def nextPow2(n):
     if n <= 1:
         return 1
@@ -3453,6 +3463,7 @@ def torch_moe_stage1(
     topk = topk_weight.shape[1]
     N = w1.shape[1]
     E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+    lazy_w1_mxfp4_dequant = False
     if quant_type == QuantType.per_1x32 and w1.dtype == dtypes.i4x2:
         # a16wi4: int4 weights viewed as int8 for compute
         hidden_states = hidden_states.to(ctype)
@@ -3463,7 +3474,7 @@ def torch_moe_stage1(
         if w1.dtype == dtypes.fp8:  # mxfp8 weight
             w1 = w1.to(ctype)
         else:
-            w1 = fp4_utils.mxfp4_to_f32(w1)
+            lazy_w1_mxfp4_dequant = True
         w1_scale = fp4_utils.e8m0_to_f32(w1_scale)
         if a1_scale is not None:  # skip a16w4 / mxfp8-bf16-activation ref
             if hidden_states.dtype == dtypes.fp8:  # a8w4 mxfp8 activation
@@ -3512,11 +3523,12 @@ def torch_moe_stage1(
         w1 = w1.reshape(w1_shape)
         # activations are bf16, no scaling needed
     elif quant_type == QuantType.per_1x32:
-        w1_shape = w1.shape
-        w1 = w1.view(E, N, model_dim // 32, 32) * w1_scale.view(
-            E, N, model_dim // 32, 1
-        )
-        w1 = w1.view(w1_shape)
+        if not lazy_w1_mxfp4_dequant:
+            w1_shape = w1.shape
+            w1 = w1.view(E, N, model_dim // 32, 32) * w1_scale.view(
+                E, N, model_dim // 32, 1
+            )
+            w1 = w1.view(w1_shape)
 
         a1_shape = hidden_states.shape
         hidden_states = hidden_states.view(a1_shape[0], a1_shape[1] // 32, 32)
@@ -3540,7 +3552,13 @@ def torch_moe_stage1(
         mask = topk_ids == E_id
         if mask.sum():
             sub_tokens = hidden_states[mask]
-            act_input = sub_tokens @ (w1[E_id].transpose(0, 1))
+            if lazy_w1_mxfp4_dequant:
+                w1_e = _mxfp4_per_1x32_weight_expert_to_f32(
+                    w1, w1_scale, E_id, N, model_dim
+                )
+            else:
+                w1_e = w1[E_id]
+            act_input = sub_tokens @ (w1_e.transpose(0, 1))
             if doweight:
                 act_input = act_input * topk_weight[mask].view(-1, 1)
             out[mask] = act_input
@@ -3581,6 +3599,7 @@ def torch_moe_stage2(
 ):
     ctype = dtypes.fp32  # compute type
     E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+    lazy_w2_mxfp4_dequant = False
     if quant_type == QuantType.per_1x32 and w2.dtype == dtypes.i4x2:
         # a16wi4: int4 weights viewed as int8 for compute
         hidden_states = hidden_states.to(ctype)
@@ -3591,7 +3610,7 @@ def torch_moe_stage2(
         if w2.dtype == dtypes.fp8:  # mxfp8 weight
             w2 = w2.to(ctype)
         else:
-            w2 = fp4_utils.mxfp4_to_f32(w2)
+            lazy_w2_mxfp4_dequant = True
         w2_scale = fp4_utils.e8m0_to_f32(w2_scale)
         if a2_scale is not None:
             if hidden_states.dtype == dtypes.fp8:  # a8w4 mxfp8 activation
@@ -3650,11 +3669,12 @@ def torch_moe_stage2(
             )
         hidden_states = hidden_states.view(a2_shape)
 
-        w2_shape = w2.shape
-        w2 = w2.view(E, model_dim, inter_dim // 32, 32) * w2_scale.view(
-            E, model_dim, inter_dim // 32, 1
-        )
-        w2 = w2.view(w2_shape)
+        if not lazy_w2_mxfp4_dequant:
+            w2_shape = w2.shape
+            w2 = w2.view(E, model_dim, inter_dim // 32, 32) * w2_scale.view(
+                E, model_dim, inter_dim // 32, 1
+            )
+            w2 = w2.view(w2_shape)
 
     out = torch.zeros(
         (token_num, topk, model_dim),
@@ -3665,7 +3685,13 @@ def torch_moe_stage2(
         mask = topk_ids == E_id
         if mask.sum():
             sub_tokens = hidden_states[mask]
-            act_input = sub_tokens @ (w2[E_id].transpose(0, 1))
+            if lazy_w2_mxfp4_dequant:
+                w2_e = _mxfp4_per_1x32_weight_expert_to_f32(
+                    w2, w2_scale, E_id, model_dim, inter_dim
+                )
+            else:
+                w2_e = w2[E_id]
+            act_input = sub_tokens @ (w2_e.transpose(0, 1))
             out[mask] = act_input
             if w2_bias is not None:
                 out[mask] = out[mask] + w2_bias[E_id].view(1, -1)

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1269,8 +1269,9 @@ def _mxfp4_per_1x32_weight_expert_to_f32(weight, scale, expert_id, rows, cols):
     from aiter.utility import fp4_utils
 
     weight_e = fp4_utils.mxfp4_to_f32(weight[expert_id])
+    scale_e = scale.reshape(weight.shape[0], rows, cols // 32)[expert_id]
     return (
-        weight_e.view(rows, cols // 32, 32) * scale[expert_id].view(rows, cols // 32, 1)
+        weight_e.view(rows, cols // 32, 32) * scale_e.view(rows, cols // 32, 1)
     ).view(rows, cols)
 
 

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1270,8 +1270,7 @@ def _mxfp4_per_1x32_weight_expert_to_f32(weight, scale, expert_id, rows, cols):
 
     weight_e = fp4_utils.mxfp4_to_f32(weight[expert_id])
     return (
-        weight_e.view(rows, cols // 32, 32)
-        * scale[expert_id].view(rows, cols // 32, 1)
+        weight_e.view(rows, cols // 32, 32) * scale[expert_id].view(rows, cols // 32, 1)
     ).view(rows, cols)
 
 

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -1275,6 +1275,14 @@ def _mxfp4_per_1x32_weight_expert_to_f32(weight, scale, expert_id, rows, cols):
     ).view(rows, cols)
 
 
+def _int4_per_1x32_weight_expert_to_f32(weight, scale, expert_id, rows, cols):
+    scale_e = scale.reshape(weight.shape[0], cols // 32, rows)[expert_id]
+    return (
+        weight[expert_id].to(dtypes.fp32).reshape(rows, cols // 32, 32)
+        * scale_e.permute(1, 0).unsqueeze(-1)
+    ).reshape(rows, cols)
+
+
 def nextPow2(n):
     if n <= 1:
         return 1
@@ -3463,11 +3471,13 @@ def torch_moe_stage1(
     topk = topk_weight.shape[1]
     N = w1.shape[1]
     E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+    lazy_w1_int4_dequant = False
     lazy_w1_mxfp4_dequant = False
     if quant_type == QuantType.per_1x32 and w1.dtype == dtypes.i4x2:
         # a16wi4: int4 weights viewed as int8 for compute
         hidden_states = hidden_states.to(ctype)
-        w1 = w1.view(dtypes.i8).to(ctype)
+        w1 = w1.view(dtypes.i8)
+        lazy_w1_int4_dequant = True
     elif quant_type == QuantType.per_1x32:
         from aiter.utility import fp4_utils
 
@@ -3516,11 +3526,12 @@ def torch_moe_stage1(
         # a16wi4: groupwise dequant int4 weights with scale [E, K//32, N]
         group_size = 32
         num_groups = model_dim // group_size
-        w1_shape = w1.shape
-        # w1: [E, N, K] -> apply scale per group of K
-        w1 = w1.reshape(E, N, num_groups, group_size)
-        w1.mul_(w1_scale.reshape(E, num_groups, N).permute(0, 2, 1).unsqueeze(-1))
-        w1 = w1.reshape(w1_shape)
+        if not lazy_w1_int4_dequant:
+            w1_shape = w1.shape
+            # w1: [E, N, K] -> apply scale per group of K
+            w1 = w1.reshape(E, N, num_groups, group_size)
+            w1.mul_(w1_scale.reshape(E, num_groups, N).permute(0, 2, 1).unsqueeze(-1))
+            w1 = w1.reshape(w1_shape)
         # activations are bf16, no scaling needed
     elif quant_type == QuantType.per_1x32:
         if not lazy_w1_mxfp4_dequant:
@@ -3552,7 +3563,11 @@ def torch_moe_stage1(
         mask = topk_ids == E_id
         if mask.sum():
             sub_tokens = hidden_states[mask]
-            if lazy_w1_mxfp4_dequant:
+            if lazy_w1_int4_dequant:
+                w1_e = _int4_per_1x32_weight_expert_to_f32(
+                    w1, w1_scale, E_id, N, model_dim
+                )
+            elif lazy_w1_mxfp4_dequant:
                 w1_e = _mxfp4_per_1x32_weight_expert_to_f32(
                     w1, w1_scale, E_id, N, model_dim
                 )
@@ -3599,11 +3614,13 @@ def torch_moe_stage2(
 ):
     ctype = dtypes.fp32  # compute type
     E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+    lazy_w2_int4_dequant = False
     lazy_w2_mxfp4_dequant = False
     if quant_type == QuantType.per_1x32 and w2.dtype == dtypes.i4x2:
         # a16wi4: int4 weights viewed as int8 for compute
         hidden_states = hidden_states.to(ctype)
-        w2 = w2.view(dtypes.i8).to(ctype)
+        w2 = w2.view(dtypes.i8)
+        lazy_w2_int4_dequant = True
     elif quant_type == QuantType.per_1x32:
         from aiter.utility import fp4_utils
 
@@ -3651,13 +3668,14 @@ def torch_moe_stage2(
         # w2: [E, model_dim, inter_dim], w2_scale is [E, inter_dim//32, model_dim]
         group_size = 32
         num_groups = inter_dim // group_size
-        w2_shape = w2.shape
-        # w2: [E, model_dim, inter_dim] -> apply scale per group of inter_dim
-        w2 = w2.reshape(E, model_dim, num_groups, group_size)
-        w2.mul_(
-            w2_scale.reshape(E, num_groups, model_dim).permute(0, 2, 1).unsqueeze(-1)
-        )
-        w2 = w2.reshape(w2_shape)
+        if not lazy_w2_int4_dequant:
+            w2_shape = w2.shape
+            # w2: [E, model_dim, inter_dim] -> apply scale per group of inter_dim
+            w2 = w2.reshape(E, model_dim, num_groups, group_size)
+            w2.mul_(
+                w2_scale.reshape(E, num_groups, model_dim).permute(0, 2, 1).unsqueeze(-1)
+            )
+            w2 = w2.reshape(w2_shape)
         # activations are bf16, no scaling
     elif quant_type == QuantType.per_1x32:
         a2_shape = hidden_states.shape
@@ -3685,7 +3703,11 @@ def torch_moe_stage2(
         mask = topk_ids == E_id
         if mask.sum():
             sub_tokens = hidden_states[mask]
-            if lazy_w2_mxfp4_dequant:
+            if lazy_w2_int4_dequant:
+                w2_e = _int4_per_1x32_weight_expert_to_f32(
+                    w2, w2_scale, E_id, model_dim, inter_dim
+                )
+            elif lazy_w2_mxfp4_dequant:
                 w2_e = _mxfp4_per_1x32_weight_expert_to_f32(
                     w2, w2_scale, E_id, model_dim, inter_dim
                 )

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -3673,7 +3673,9 @@ def torch_moe_stage2(
             # w2: [E, model_dim, inter_dim] -> apply scale per group of inter_dim
             w2 = w2.reshape(E, model_dim, num_groups, group_size)
             w2.mul_(
-                w2_scale.reshape(E, num_groups, model_dim).permute(0, 2, 1).unsqueeze(-1)
+                w2_scale.reshape(E, num_groups, model_dim)
+                .permute(0, 2, 1)
+                .unsqueeze(-1)
             )
             w2 = w2.reshape(w2_shape)
         # activations are bf16, no scaling


### PR DESCRIPTION
## Summary
- Lazily dequantize per-expert MXFP4 weights in the MoE torch reference path
- Avoid materializing all expert weights as fp32 at once in torch_moe_stage1 and torch_moe_stage2
- Preserve the existing dequant formula and only change when each expert weight is materialized

## Testing
- python3 -m py_compile aiter/fused_moe.py
- git diff --check