### PR TITLE
[HIP] [module_fused_ar_mhc] detorch fused_ar_mhc_post + pybind

### DIFF
--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -376,7 +376,7 @@ def end_sync_latency_gfx1250(_fa: int, blocks: int) -> None: ...
 def two_sync_latency_gfx1250(_fa: int, blocks: int) -> None: ...
 
 
-@compile_ops(FUSED_AR_MHC_MD_NAME)
+@compile_ops(FUSED_AR_MHC_MD_NAME, develop=True)
 def fused_allreduce_mhc_post_only(
     _fa: int,
     inp: torch.Tensor,
@@ -391,7 +391,7 @@ def fused_allreduce_mhc_post_only(
 ) -> None: ...
 
 
-@compile_ops(FUSED_AR_MHC_MD_NAME)
+@compile_ops(FUSED_AR_MHC_MD_NAME, develop=True)
 def fused_allreduce_mhc_post_one_stage(
     _fa: int,
     inp: torch.Tensor,
@@ -406,7 +406,7 @@ def fused_allreduce_mhc_post_one_stage(
 ) -> None: ...
 
 
-@compile_ops(FUSED_AR_MHC_MD_NAME)
+@compile_ops(FUSED_AR_MHC_MD_NAME, develop=True)
 def fused_allreduce_mhc_post_split(
     _fa: int,
     inp: torch.Tensor,

--- a/csrc/include/fused_ar_mhc_post.h
+++ b/csrc/include/fused_ar_mhc_post.h
@@ -3,39 +3,39 @@
 
 #pragma once
 
-#include <torch/extension.h>
+#include "aiter_tensor.h"
 #include "custom_all_reduce.h"
 
 namespace aiter {
 
 void fused_allreduce_mhc_post_only(fptr_t _fa,
-                                   torch::Tensor& inp,
-                                   torch::Tensor& next_residual,
-                                   torch::Tensor& residual_in,
-                                   torch::Tensor& post_layer_mix,
-                                   torch::Tensor& comb_res_mix,
+                                   aiter_tensor_t& inp,
+                                   aiter_tensor_t& next_residual,
+                                   aiter_tensor_t& residual_in,
+                                   aiter_tensor_t& post_layer_mix,
+                                   aiter_tensor_t& comb_res_mix,
                                    bool use_new,
                                    bool open_fp8_quant,
                                    int64_t reg_ptr,
                                    int64_t reg_bytes);
 
 void fused_allreduce_mhc_post_one_stage(fptr_t _fa,
-                                        torch::Tensor& inp,
-                                        torch::Tensor& next_residual,
-                                        torch::Tensor& residual_in,
-                                        torch::Tensor& post_layer_mix,
-                                        torch::Tensor& comb_res_mix,
+                                        aiter_tensor_t& inp,
+                                        aiter_tensor_t& next_residual,
+                                        aiter_tensor_t& residual_in,
+                                        aiter_tensor_t& post_layer_mix,
+                                        aiter_tensor_t& comb_res_mix,
                                         bool use_new,
                                         bool open_fp8_quant,
                                         int64_t reg_ptr,
                                         int64_t reg_bytes);
 
 void fused_allreduce_mhc_post_split(fptr_t _fa,
-                                    torch::Tensor& inp,
-                                    torch::Tensor& next_residual,
-                                    torch::Tensor& residual_in,
-                                    torch::Tensor& post_layer_mix,
-                                    torch::Tensor& comb_res_mix,
+                                    aiter_tensor_t& inp,
+                                    aiter_tensor_t& next_residual,
+                                    aiter_tensor_t& residual_in,
+                                    aiter_tensor_t& post_layer_mix,
+                                    aiter_tensor_t& comb_res_mix,
                                     bool use_new,
                                     bool open_fp8_quant,
                                     int64_t reg_ptr,

--- a/csrc/kernels/fused_ar_mhc_post.cu
+++ b/csrc/kernels/fused_ar_mhc_post.cu
@@ -6,37 +6,11 @@
 #include "mhc.h"
 #include "aiter_enum.h"
 #include "aiter_hip_common.h"
-#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
-#include <c10/core/ScalarType.h>
+#include "aiter_stream.h"
 
 namespace aiter {
 
 namespace {
-
-aiter_tensor_t make_aiter_tensor(const torch::Tensor& t)
-{
-    AITER_CHECK(t.is_cuda(), "fused AR+MHC requires CUDA tensors");
-    AITER_CHECK(t.dim() <= 8, "tensor rank too large for aiter_tensor_t");
-
-    aiter_tensor_t at{};
-    at.ptr     = t.data_ptr();
-    at.numel_  = static_cast<size_t>(t.numel());
-    at.ndim    = t.dim();
-    for(int i = 0; i < t.dim(); ++i)
-    {
-        at.shape[i]   = t.size(i);
-        at.strides[i] = t.stride(i);
-    }
-    at.device_id = static_cast<int>(t.device().index());
-    switch(t.scalar_type())
-    {
-    case at::ScalarType::Float: at.dtype_ = AITER_DTYPE_fp32; break;
-    case at::ScalarType::Half: at.dtype_ = AITER_DTYPE_fp16; break;
-    case at::ScalarType::BFloat16: at.dtype_ = AITER_DTYPE_bf16; break;
-    default: throw std::runtime_error("fused AR+MHC only supports fp32/fp16/bf16");
-    }
-    return at;
-}
 
 void copy_input_to_registered_buffer(const aiter_tensor_t& inp,
                                      int m,
@@ -205,11 +179,11 @@ void run_ar_mhc_post_1stage(CustomAllreduce* fa,
 } // namespace
 
 void fused_allreduce_mhc_post_only(fptr_t _fa,
-                                   torch::Tensor& inp,
-                                   torch::Tensor& next_residual,
-                                   torch::Tensor& residual_in,
-                                   torch::Tensor& post_layer_mix,
-                                   torch::Tensor& comb_res_mix,
+                                   aiter_tensor_t& inp,
+                                   aiter_tensor_t& next_residual,
+                                   aiter_tensor_t& residual_in,
+                                   aiter_tensor_t& post_layer_mix,
+                                   aiter_tensor_t& comb_res_mix,
                                    bool use_new,
                                    bool open_fp8_quant,
                                    int64_t reg_ptr,
@@ -217,21 +191,20 @@ void fused_allreduce_mhc_post_only(fptr_t _fa,
 {
     (void)use_new;
     (void)open_fp8_quant;
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
-    hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa            = reinterpret_cast<CustomAllreduce*>(_fa);
-    auto inp_at        = make_aiter_tensor(inp);
 
-    const int m       = static_cast<int>(inp_at.numel() / inp_at.size(-1));
-    const int input_n = static_cast<int>(inp_at.size(-1));
+    const int m       = static_cast<int>(inp.numel() / inp.size(-1));
+    const int input_n = static_cast<int>(inp.size(-1));
     const int hidden  = static_cast<int>(residual_in.size(-1));
     const int stride  = static_cast<int>(residual_in.stride(0));
 
-    copy_input_to_registered_buffer(inp_at, m, input_n, stream, reg_ptr, reg_bytes);
+    copy_input_to_registered_buffer(inp, m, input_n, stream, reg_ptr, reg_bytes);
 
-    switch(inp.scalar_type())
+    switch(inp.dtype())
     {
-    case at::ScalarType::BFloat16: {
+    case AITER_DTYPE_bf16: {
         run_ar_mhc_post_large_m<opus::bf16_t>(
             fa,
             stream,
@@ -248,7 +221,7 @@ void fused_allreduce_mhc_post_only(fptr_t _fa,
             reg_bytes);
         break;
     }
-    case at::ScalarType::Half: {
+    case AITER_DTYPE_fp16: {
         run_ar_mhc_post_large_m<opus::fp16_t>(
             fa,
             stream,
@@ -271,11 +244,11 @@ void fused_allreduce_mhc_post_only(fptr_t _fa,
 }
 
 void fused_allreduce_mhc_post_one_stage(fptr_t _fa,
-                                        torch::Tensor& inp,
-                                        torch::Tensor& next_residual,
-                                        torch::Tensor& residual_in,
-                                        torch::Tensor& post_layer_mix,
-                                        torch::Tensor& comb_res_mix,
+                                        aiter_tensor_t& inp,
+                                        aiter_tensor_t& next_residual,
+                                        aiter_tensor_t& residual_in,
+                                        aiter_tensor_t& post_layer_mix,
+                                        aiter_tensor_t& comb_res_mix,
                                         bool use_new,
                                         bool open_fp8_quant,
                                         int64_t reg_ptr,
@@ -283,21 +256,20 @@ void fused_allreduce_mhc_post_one_stage(fptr_t _fa,
 {
     (void)use_new;
     (void)open_fp8_quant;
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
-    hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa            = reinterpret_cast<CustomAllreduce*>(_fa);
-    auto inp_at        = make_aiter_tensor(inp);
 
-    const int m       = static_cast<int>(inp_at.numel() / inp_at.size(-1));
-    const int input_n = static_cast<int>(inp_at.size(-1));
+    const int m       = static_cast<int>(inp.numel() / inp.size(-1));
+    const int input_n = static_cast<int>(inp.size(-1));
     const int hidden  = static_cast<int>(residual_in.size(-1));
     const int stride  = static_cast<int>(residual_in.stride(0));
 
-    copy_input_to_registered_buffer(inp_at, m, input_n, stream, reg_ptr, reg_bytes);
+    copy_input_to_registered_buffer(inp, m, input_n, stream, reg_ptr, reg_bytes);
 
-    switch(inp.scalar_type())
+    switch(inp.dtype())
     {
-    case at::ScalarType::BFloat16: {
+    case AITER_DTYPE_bf16: {
         run_ar_mhc_post_1stage<opus::bf16_t>(
             fa,
             stream,
@@ -314,7 +286,7 @@ void fused_allreduce_mhc_post_one_stage(fptr_t _fa,
             reg_bytes);
         break;
     }
-    case at::ScalarType::Half: {
+    case AITER_DTYPE_fp16: {
         run_ar_mhc_post_1stage<opus::fp16_t>(
             fa,
             stream,
@@ -337,11 +309,11 @@ void fused_allreduce_mhc_post_one_stage(fptr_t _fa,
 }
 
 void fused_allreduce_mhc_post_split(fptr_t _fa,
-                                    torch::Tensor& inp,
-                                    torch::Tensor& next_residual,
-                                    torch::Tensor& residual_in,
-                                    torch::Tensor& post_layer_mix,
-                                    torch::Tensor& comb_res_mix,
+                                    aiter_tensor_t& inp,
+                                    aiter_tensor_t& next_residual,
+                                    aiter_tensor_t& residual_in,
+                                    aiter_tensor_t& post_layer_mix,
+                                    aiter_tensor_t& comb_res_mix,
                                     bool use_new,
                                     bool open_fp8_quant,
                                     int64_t reg_ptr,
@@ -349,21 +321,20 @@ void fused_allreduce_mhc_post_split(fptr_t _fa,
 {
     (void)use_new;
     (void)open_fp8_quant;
-    const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(inp));
-    hipStream_t stream = at::hip::getCurrentHIPStream();
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
     auto fa            = reinterpret_cast<CustomAllreduce*>(_fa);
-    auto inp_at        = make_aiter_tensor(inp);
 
-    const int m       = static_cast<int>(inp_at.numel() / inp_at.size(-1));
-    const int input_n = static_cast<int>(inp_at.size(-1));
+    const int m       = static_cast<int>(inp.numel() / inp.size(-1));
+    const int input_n = static_cast<int>(inp.size(-1));
     const int hidden  = static_cast<int>(residual_in.size(-1));
     const int stride  = static_cast<int>(residual_in.stride(0));
 
-    copy_input_to_registered_buffer(inp_at, m, input_n, stream, reg_ptr, reg_bytes);
+    copy_input_to_registered_buffer(inp, m, input_n, stream, reg_ptr, reg_bytes);
 
-    switch(inp.scalar_type())
+    switch(inp.dtype())
     {
-    case at::ScalarType::BFloat16: {
+    case AITER_DTYPE_bf16: {
         run_ar_mhc_post_split<opus::bf16_t>(
             fa,
             stream,
@@ -381,7 +352,7 @@ void fused_allreduce_mhc_post_split(fptr_t _fa,
             reg_bytes);
         break;
     }
-    case at::ScalarType::Half: {
+    case AITER_DTYPE_fp16: {
         run_ar_mhc_post_split<opus::fp16_t>(
             fa,
             stream,

--- a/csrc/pybind/fused_ar_mhc_post_pybind.cu
+++ b/csrc/pybind/fused_ar_mhc_post_pybind.cu
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <torch/extension.h>
 #include "aiter_stream.h"
 #include "fused_ar_mhc_post.h"
 #include "rocm_ops.hpp"


### PR DESCRIPTION
## What

Removes the remaining PyTorch dependency from `module_fused_ar_mhc`. The module was **already half-converted** — two of its four TUs (`custom_all_reduce.cu`, `mhc_kernels.cu`) were torch-free, and `custom_all_reduce.cu` in the *same module* is the exact reference pattern (takes `const aiter_tensor_t&`, uses `HipDeviceGuard(inp.device_id)` + `aiter::getCurrentHIPStream()` + `switch(inp.dtype())`). This PR finishes the other two TUs to match.

### `csrc/include/fused_ar_mhc_post.h`
- `<torch/extension.h>` → `aiter_tensor.h`; all `torch::Tensor&` params → `aiter_tensor_t&`. (`custom_all_reduce.h`'s `fptr_t = int64_t` is already torch-free.)

### `csrc/kernels/fused_ar_mhc_post.cu`
- Dropped `<ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>` / `<c10/core/ScalarType.h>`; added `aiter_stream.h`.
- Deleted the `make_aiter_tensor(const torch::Tensor&)` helper (params are `aiter_tensor_t` now).
- Replaced the per-function torch idioms with the aiter ones already used by `all_reduce` next door: `device_of(inp)` guard → `HipDeviceGuard(inp.device_id)`; `at::hip::getCurrentHIPStream()` → `aiter::getCurrentHIPStream()`; `switch(inp.scalar_type())` + `at::ScalarType::BFloat16/Half` → `switch(inp.dtype())` + `AITER_DTYPE_bf16/fp16`.

### `csrc/pybind/fused_ar_mhc_post_pybind.cu`
- Dropped `<torch/extension.h>`; `rocm_ops.hpp` supplies pybind11 and the `module_aiter_core`-registered `aiter_tensor_t` type. `AITER_SET_STREAM_PYBIND` + the `m.def`s are unchanged.

### `aiter/ops/custom_all_reduce.py`
- The 3 `fused_allreduce_mhc_post_*` ops gain `develop=True`, so `aiter/jit/core.py` marshals `torch.Tensor → aiter_tensor_t` (`torch_to_aiter_pybind`) and sets the current HIP stream before the pybind call — the same path as `module_custom_all_reduce` / `module_mla_reduce`.

`torch_exclude` is intentionally **not** added to `optCompilerConfig.json` (matching those sibling modules); it is used only as a verification gate below.

## Verification (in-container, gfx942 / MI308X, 8 GPU)
- **torch-free** grep (incl. uppercase `TORCH_` macros) clean on all 3 C++ files.
- **Correctness gate:** clean rebuild with `torch_exclude=True` succeeds — the TUs compile with pytorch's `-isystem .../torch/include` stripped, proving true torch-freeness.
- `op_tests/multigpu_tests/test_fused_ar_mhc_post_only.py`: all 8 real parametrized cases **PASS** (tp2 smoke + tp2/tp4 auto-dispatch, `err==0`). (The lone pytest failure is the `@benchmark` profile fn collected as a test — pre-existing, unrelated.)
- `black` + `ruff check` clean.
- Build wall for `module_fused_ar_mhc` (clean rebuild, 4 TUs): ~43s torch-included → ~40s de-torched → 39.5s under `torch_exclude=True` (~7%; small module, device codegen of the custom_all_reduce/mhc kernels dominates and only 2 of 4 TUs changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)