### PR TITLE
[Triton/Gluon] [GFX1250] add triton support for gfx1250 MoE a8w4 and a4w4

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
@@ -4,7 +4,26 @@ from triton._C.libtriton.gluon_ir import make_cga_layout
 from triton.experimental import gluon
 
 from aiter.ops.triton._triton_kernels.moe.activations import _swiglu
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
+
+_MOE_GEMM_A4W4_REPR_KEYS = [
+    "BLOCK_M",
+    "BLOCK_N",
+    "BLOCK_K",
+    "SWIZZLE_MX_SCALE",
+    "APPLY_SWIGLU",
+    "num_warps",
+    "NUM_BUFFERS",
+]
+
+_moe_gemm_a4w4_prefill_repr = make_kernel_repr(
+    "_moe_gemm_a4w4_prefill", _MOE_GEMM_A4W4_REPR_KEYS
+)
+
+_moe_gemm_a4w4_decode_repr = make_kernel_repr(
+    "_moe_gemm_a4w4_decode", _MOE_GEMM_A4W4_REPR_KEYS
+)
 
 
 def matmul_launch_metadata(grid, kernel, args):
@@ -517,7 +536,7 @@ def unshuffle_weights_gfx1250(
     )
 
 
-@gluon.jit(launch_metadata=matmul_launch_metadata)
+@gluon.jit(launch_metadata=matmul_launch_metadata, repr=_moe_gemm_a4w4_prefill_repr)
 def _moe_gemm_a4w4_prefill(
     Y,
     stride_y_m,
@@ -1171,6 +1190,7 @@ def _moe_gemm_a4w4_prefill(
 @gluon.jit(
     launch_metadata=matmul_launch_metadata,
     do_not_specialize=["num_tokens"],
+    repr=_moe_gemm_a4w4_decode_repr,
 )
 def _moe_gemm_a4w4_decode(
     Y,

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
@@ -8,7 +8,31 @@ from triton.experimental.gluon.language.amd.gfx1250 import async_copy
 from aiter.ops.triton._triton_kernels.moe.activations import _swiglu
 from aiter.ops.triton._triton_kernels.moe.quant_moe import _compute_static_fp8_quant
 from aiter.ops.triton._triton_kernels.quant.quant import _mxfp8_quant_op
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
+
+_MOE_GEMM_A8W4_REPR_KEYS = [
+    "BLOCK_M",
+    "BLOCK_N",
+    "BLOCK_K",
+    "SWIZZLE_MX_SCALE",
+    "APPLY_SWIGLU",
+    "num_warps",
+    "NUM_BUFFERS",
+    "HAS_MX_OUT",
+]
+
+_moe_gemm_a8w4_prefill_repr = make_kernel_repr(
+    "_moe_gemm_a8w4_prefill", _MOE_GEMM_A8W4_REPR_KEYS
+)
+
+_moe_gemm_a8w4_decode_repr = make_kernel_repr(
+    "_moe_gemm_a8w4_decode", _MOE_GEMM_A8W4_REPR_KEYS
+)
+
+_moe_gemm_a8w4_decode_persistent_repr = make_kernel_repr(
+    "_moe_gemm_a8w4_decode_persistent", _MOE_GEMM_A8W4_REPR_KEYS
+)
 
 
 def matmul_launch_metadata(grid, kernel, args):
@@ -101,6 +125,7 @@ def unshuffle_weight_gfx1250(w_buffer_slice, BLOCK_N, NATIVE_BLOCK_K_W):
 @gluon.jit(
     launch_metadata=matmul_launch_metadata,
     do_not_specialize=["num_tokens"],
+    repr=_moe_gemm_a8w4_decode_persistent_repr,
 )
 def _moe_gemm_a8w4_decode_persistent(
     Y,
@@ -845,6 +870,7 @@ def _moe_gemm_a8w4_decode_persistent(
 @gluon.jit(
     launch_metadata=matmul_launch_metadata,
     do_not_specialize=["num_tokens"],
+    repr=_moe_gemm_a8w4_decode_repr,
 )
 def _moe_gemm_a8w4_decode(
     Y,
@@ -1806,7 +1832,7 @@ def get_moe_a8w4_layouts(
     return layouts
 
 
-@gluon.jit(launch_metadata=matmul_launch_metadata)
+@gluon.jit(launch_metadata=matmul_launch_metadata, repr=_moe_gemm_a8w4_prefill_repr)
 def _moe_gemm_a8w4_prefill(
     Y,
     stride_y_m,

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
@@ -103,6 +103,30 @@ def unswizzle_mx_scale_cdna4(
 
 
 @triton.jit
+def unswizzle_mx_scale_gfx1250(
+    scale_buffer_slice,
+    BLOCK_N: tl.constexpr,
+    MX_SCALE_BLOCK_K: tl.constexpr,
+    PRESHUFFLE_FACTOR: tl.constexpr,
+    SCALE_KWIDTH: tl.constexpr,
+):
+    scale_buffer_slice = (
+        scale_buffer_slice.reshape(
+            (
+                BLOCK_N // PRESHUFFLE_FACTOR,
+                MX_SCALE_BLOCK_K // SCALE_KWIDTH,
+                PRESHUFFLE_FACTOR,
+                SCALE_KWIDTH,
+            )
+        )
+        .permute((0, 2, 1, 3))
+        .reshape((BLOCK_N, MX_SCALE_BLOCK_K))
+    )
+
+    return scale_buffer_slice
+
+
+@triton.jit
 def _mxfp4_quant_kernel(
     x_ptr,
     x_fp4_ptr,
@@ -333,10 +357,17 @@ def _moe_gemm_a4w4(
     )
 
     WMxScale += expt_id * stride_w_mx_e
-    if SWIZZLE_MX_SCALE == "CDNA4_SCALE":
+    tl.static_assert(
+        SWIZZLE_MX_SCALE is None
+        or SWIZZLE_MX_SCALE == "CDNA4_SCALE"
+        or SWIZZLE_MX_SCALE == "GFX1250_SCALE",
+        "SWIZZLE_MX_SCALE must be None, 'CDNA4_SCALE' or 'GFX1250_SCALE'",
+    )
+    if SWIZZLE_MX_SCALE is not None:
         tl.static_assert(stride_w_mx_k is not None)
         tl.static_assert(stride_w_mx_n is not None)
         NON_K_PRESHUFFLE_BLOCK_SIZE: tl.constexpr = 32
+        GFX1250_SCALE_KWIDTH: tl.constexpr = 8
         PACKED_MX_BLOCK: tl.constexpr = MX_SCALE_BLOCK_K * NON_K_PRESHUFFLE_BLOCK_SIZE
         SCALE_BLOCK_N: tl.constexpr = BLOCK_N // NON_K_PRESHUFFLE_BLOCK_SIZE
     else:
@@ -397,6 +428,14 @@ def _moe_gemm_a4w4(
                 BLOCK_N,
                 MX_SCALE_BLOCK_K,
             )
+        elif SWIZZLE_MX_SCALE == "GFX1250_SCALE":
+            w_scales = unswizzle_mx_scale_gfx1250(
+                tl.load(WMxScalePtrs, cache_modifier=W_CACHE_MODIFIER),
+                BLOCK_N,
+                MX_SCALE_BLOCK_K,
+                NON_K_PRESHUFFLE_BLOCK_SIZE,
+                GFX1250_SCALE_KWIDTH,
+            )
         else:
             w_scales = tl.load(WMxScalePtrs)
 
@@ -433,6 +472,14 @@ def _moe_gemm_a4w4(
                 tl.load(WMxScalePtrs, cache_modifier=W_CACHE_MODIFIER),
                 BLOCK_N,
                 MX_SCALE_BLOCK_K,
+            )
+        elif SWIZZLE_MX_SCALE == "GFX1250_SCALE":
+            w_scales = unswizzle_mx_scale_gfx1250(
+                tl.load(WMxScalePtrs, cache_modifier=W_CACHE_MODIFIER),
+                BLOCK_N,
+                MX_SCALE_BLOCK_K,
+                NON_K_PRESHUFFLE_BLOCK_SIZE,
+                GFX1250_SCALE_KWIDTH,
             )
         else:
             w_scales = tl.load(WMxScalePtrs, mask=mask_w_k_scale[None, :])

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
@@ -200,11 +200,6 @@ _moe_gemm_a4w4_repr = make_kernel_repr(
         "EVEN_K",
         "SWIZZLE_MX_SCALE",
         "APPLY_SWIGLU",
-        "num_warps",
-        "num_stages",
-        "waves_per_eu",
-        "matrix_instr_nonkdim",
-        "kpack",
     ],
 )
 

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
@@ -383,7 +383,7 @@ def _moe_gemm_a4w4(
         tl.static_assert(stride_w_mx_k is not None)
         tl.static_assert(stride_w_mx_n is not None)
         NON_K_PRESHUFFLE_BLOCK_SIZE: tl.constexpr = 32
-        GFX1250_SCALE_KWIDTH: tl.constexpr = 8
+        GFX1250_SCALE_KWIDTH: tl.constexpr = 4
         PACKED_MX_BLOCK: tl.constexpr = MX_SCALE_BLOCK_K * NON_K_PRESHUFFLE_BLOCK_SIZE
         SCALE_BLOCK_N: tl.constexpr = BLOCK_N // NON_K_PRESHUFFLE_BLOCK_SIZE
     else:

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a4w4.py
@@ -7,6 +7,7 @@ import triton.language as tl
 
 from aiter.ops.triton._triton_kernels.moe.activations import _swiglu
 from aiter.ops.triton._triton_kernels.quant.quant import _mxfp4_quant_op
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid
 
 
@@ -188,7 +189,27 @@ def _mxfp4_quant_kernel(
         )
 
 
-@triton.jit(launch_metadata=matmul_launch_metadata)
+_moe_gemm_a4w4_repr = make_kernel_repr(
+    "_moe_gemm_a4w4",
+    [
+        "BLOCK_M",
+        "BLOCK_N",
+        "BLOCK_K",
+        "GROUP_M",
+        "SPLIT_K",
+        "EVEN_K",
+        "SWIZZLE_MX_SCALE",
+        "APPLY_SWIGLU",
+        "num_warps",
+        "num_stages",
+        "waves_per_eu",
+        "matrix_instr_nonkdim",
+        "kpack",
+    ],
+)
+
+
+@triton.jit(launch_metadata=matmul_launch_metadata, repr=_moe_gemm_a4w4_repr)
 def _moe_gemm_a4w4(
     Y,
     stride_y_k,

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
@@ -8,6 +8,7 @@ import triton.language as tl
 from aiter.ops.triton._triton_kernels.moe.activations import _swiglu
 from aiter.ops.triton._triton_kernels.moe.quant_moe import _compute_static_fp8_quant
 from aiter.ops.triton._triton_kernels.quant.quant import _mxfp8_quant_op
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid
 
 
@@ -129,7 +130,28 @@ def unswizzle_mx_scale_gfx1250(
     return scale_buffer_slice
 
 
-@triton.jit(launch_metadata=matmul_launch_metadata)
+_moe_gemm_a8w4_repr = make_kernel_repr(
+    "_moe_gemm_a8w4",
+    [
+        "BLOCK_M",
+        "BLOCK_N",
+        "BLOCK_K",
+        "GROUP_M",
+        "SPLIT_K",
+        "EVEN_K",
+        "SWIZZLE_MX_SCALE",
+        "APPLY_SWIGLU",
+        "num_warps",
+        "num_stages",
+        "waves_per_eu",
+        "matrix_instr_nonkdim",
+        "kpack",
+        "HAS_MX_OUT",
+    ],
+)
+
+
+@triton.jit(launch_metadata=matmul_launch_metadata, repr=_moe_gemm_a8w4_repr)
 def _moe_gemm_a8w4(
     Y,
     stride_y_k,

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
@@ -308,13 +308,9 @@ def _moe_gemm_a8w4(
         "SWIZZLE_MX_SCALE must be None, 'CDNA4_SCALE' or 'GFX1250_SCALE'",
     )
     if SWIZZLE_MX_SCALE is not None:
-        # CDNA4_SCALE (gfx950, kwidth 8) and GFX1250_SCALE (n32k4, kwidth 4)
-        # both fold 32 N-lanes into one scale row; only the intra-tile order
-        # differs, so the block geometry is shared and the decode is not.
         tl.static_assert(stride_w_mx_k is not None)
         tl.static_assert(stride_w_mx_n is not None)
         NON_K_PRESHUFFLE_BLOCK_SIZE: tl.constexpr = 32
-        # n32k4: must stay in step with SCALE_KWIDTH in the gfx1250 gluon kernel
         GFX1250_SCALE_KWIDTH: tl.constexpr = 4
         PACKED_MX_BLOCK: tl.constexpr = MX_SCALE_BLOCK_K * NON_K_PRESHUFFLE_BLOCK_SIZE
         SCALE_BLOCK_N: tl.constexpr = BLOCK_N // NON_K_PRESHUFFLE_BLOCK_SIZE

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
@@ -105,6 +105,30 @@ def unswizzle_mx_scale_cdna4(
     return x
 
 
+@triton.jit
+def unswizzle_mx_scale_gfx1250(
+    scale_buffer_slice,
+    BLOCK_N: tl.constexpr,
+    MX_SCALE_BLOCK_K: tl.constexpr,
+    PRESHUFFLE_FACTOR: tl.constexpr,
+    SCALE_KWIDTH: tl.constexpr,
+):
+    scale_buffer_slice = (
+        scale_buffer_slice.reshape(
+            (
+                BLOCK_N // PRESHUFFLE_FACTOR,
+                MX_SCALE_BLOCK_K // SCALE_KWIDTH,
+                PRESHUFFLE_FACTOR,
+                SCALE_KWIDTH,
+            )
+        )
+        .permute((0, 2, 1, 3))
+        .reshape((BLOCK_N, MX_SCALE_BLOCK_K))
+    )
+
+    return scale_buffer_slice
+
+
 @triton.jit(launch_metadata=matmul_launch_metadata)
 def _moe_gemm_a8w4(
     Y,
@@ -277,10 +301,21 @@ def _moe_gemm_a8w4(
     MX_SCALE_BLOCK_K: tl.constexpr = BLOCK_K // MX_PACK_DIVISOR
 
     WMxScale += expt_id * stride_w_mx_e
-    if SWIZZLE_MX_SCALE == "CDNA4_SCALE":
+    tl.static_assert(
+        SWIZZLE_MX_SCALE is None
+        or SWIZZLE_MX_SCALE == "CDNA4_SCALE"
+        or SWIZZLE_MX_SCALE == "GFX1250_SCALE",
+        "SWIZZLE_MX_SCALE must be None, 'CDNA4_SCALE' or 'GFX1250_SCALE'",
+    )
+    if SWIZZLE_MX_SCALE is not None:
+        # CDNA4_SCALE (gfx950, kwidth 8) and GFX1250_SCALE (n32k4, kwidth 4)
+        # both fold 32 N-lanes into one scale row; only the intra-tile order
+        # differs, so the block geometry is shared and the decode is not.
         tl.static_assert(stride_w_mx_k is not None)
         tl.static_assert(stride_w_mx_n is not None)
         NON_K_PRESHUFFLE_BLOCK_SIZE: tl.constexpr = 32
+        # n32k4: must stay in step with SCALE_KWIDTH in the gfx1250 gluon kernel
+        GFX1250_SCALE_KWIDTH: tl.constexpr = 4
         PACKED_MX_BLOCK: tl.constexpr = MX_SCALE_BLOCK_K * NON_K_PRESHUFFLE_BLOCK_SIZE
         SCALE_BLOCK_N: tl.constexpr = BLOCK_N // NON_K_PRESHUFFLE_BLOCK_SIZE
     else:
@@ -341,6 +376,14 @@ def _moe_gemm_a8w4(
                 BLOCK_N,
                 MX_SCALE_BLOCK_K,
             )
+        elif SWIZZLE_MX_SCALE == "GFX1250_SCALE":
+            w_scales = unswizzle_mx_scale_gfx1250(
+                tl.load(WMxScalePtrs, cache_modifier=W_CACHE_MODIFIER),
+                BLOCK_N,
+                MX_SCALE_BLOCK_K,
+                NON_K_PRESHUFFLE_BLOCK_SIZE,
+                GFX1250_SCALE_KWIDTH,
+            )
         else:
             w_scales = tl.load(WMxScalePtrs)
 
@@ -377,6 +420,14 @@ def _moe_gemm_a8w4(
                 tl.load(WMxScalePtrs, cache_modifier=W_CACHE_MODIFIER),
                 BLOCK_N,
                 MX_SCALE_BLOCK_K,
+            )
+        elif SWIZZLE_MX_SCALE == "GFX1250_SCALE":
+            w_scales = unswizzle_mx_scale_gfx1250(
+                tl.load(WMxScalePtrs, cache_modifier=W_CACHE_MODIFIER),
+                BLOCK_N,
+                MX_SCALE_BLOCK_K,
+                NON_K_PRESHUFFLE_BLOCK_SIZE,
+                GFX1250_SCALE_KWIDTH,
             )
         else:
             w_scales = tl.load(WMxScalePtrs, mask=mask_w_k_scale[None, :])

--- a/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_op_gemm_a8w4.py
@@ -141,11 +141,6 @@ _moe_gemm_a8w4_repr = make_kernel_repr(
         "EVEN_K",
         "SWIZZLE_MX_SCALE",
         "APPLY_SWIGLU",
-        "num_warps",
-        "num_stages",
-        "waves_per_eu",
-        "matrix_instr_nonkdim",
-        "kpack",
         "HAS_MX_OUT",
     ],
 )

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -264,13 +264,21 @@ def moe_gemm_a4w4(
     swiglu_add_residual=True,
     unpadded_N=None,
     unpadded_K=None,
+    backend=None,
 ):
     """
     Y[:, :] = 0.
     for e in num_experts:
         Y[idxs_y_m(e), :] += matmul(X[idxs_x_m(e), :], W[e, :, :])
     """
-    use_gluon = get_arch() == "gfx1250"
+    if backend is None:
+        backend = "gluon" if get_arch() == "gfx1250" else "triton"
+    assert backend in ("triton", "gluon"), f"Invalid backend: {backend}"
+    if backend == "gluon":
+        assert (
+            get_arch() == "gfx1250"
+        ), f"Gluon backend requires gfx1250, got {get_arch()}"
+    use_gluon = backend == "gluon"
     if preshuffle_weights:
         assert (
             use_gluon

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -25,13 +25,6 @@ from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH
 from aiter.ops.triton.utils.gemm_config_utils import pick_gemm_num_stages
 
-GLUON_SUPPORTED_ARCHS = {"gfx1250"}
-
-
-def is_gluon_supported():
-    arch = get_arch()
-    return arch in GLUON_SUPPORTED_ARCHS
-
 
 @functools.lru_cache
 def _get_a4w4_dispatch(arch: str) -> dict:
@@ -271,26 +264,17 @@ def moe_gemm_a4w4(
     swiglu_add_residual=True,
     unpadded_N=None,
     unpadded_K=None,
-    backend=None,  # "triton" | "gluon"
 ):
     """
     Y[:, :] = 0.
     for e in num_experts:
         Y[idxs_y_m(e), :] += matmul(X[idxs_x_m(e), :], W[e, :, :])
     """
-    if backend is None:
-        # default to gluon backend if supported
-        backend = "gluon" if is_gluon_supported() else "triton"
-    assert backend in ["triton", "gluon"], f"Invalid backend: {backend}"
-    if backend == "gluon":
-        # make sure gluon backend is supported on this architecture
-        assert (
-            is_gluon_supported()
-        ), f"Gluon backend is not supported on this architecture: {get_arch()}"
-    use_gluon = backend == "gluon"
-
+    use_gluon = get_arch() == "gfx1250"
     if preshuffle_weights:
-        assert use_gluon, "Preshuffled weights are only supported on gluon backend"
+        assert (
+            use_gluon
+        ), "preshuffled weights are only supported by the gluon (gfx1250) kernel"
 
     assert w.stride(-2) == 1, "`w` must be column-major when it has data-type mxfp"
     assert x.stride(-1) == 1, "'x' must be row-major when it has data-type mxfp"
@@ -372,7 +356,7 @@ def moe_gemm_a4w4(
     grid = grid_m * grid_n * split_k
 
     # launch kernel
-    if use_gluon and get_arch() == "gfx1250" and block_m == 16:
+    if use_gluon and block_m == 16:
         layouts = get_moe_a4w4_layouts_decode(
             BLOCK_M=config["block_m"],
             BLOCK_N=config["block_n"],
@@ -435,7 +419,7 @@ def moe_gemm_a4w4(
             **layouts,
             num_warps=config["num_warps"],
         )
-    elif use_gluon and get_arch() == "gfx1250":
+    elif use_gluon:
         # layouts
         layouts = get_moe_a4w4_layouts_prefill(
             BLOCK_M=config["block_m"],

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -359,13 +359,21 @@ def moe_gemm_a8w4(
     # External residual to fold into reduce_grouped writeback (saves the
     # standalone routed+shared elementwise add).
     residual=None,
+    backend=None,
 ):
     """
     Y[:, :] = 0.
     for e in num_experts:
         Y[idxs_y_m(e), :] += matmul(X[idxs_x_m(e), :], W[e, :, :])
     """
-    use_gluon = get_arch() == "gfx1250"
+    if backend is None:
+        backend = "gluon" if get_arch() == "gfx1250" else "triton"
+    assert backend in ("triton", "gluon"), f"Invalid backend: {backend}"
+    if backend == "gluon":
+        assert (
+            get_arch() == "gfx1250"
+        ), f"Gluon backend requires gfx1250, got {get_arch()}"
+    use_gluon = backend == "gluon"
     if preshuffled:
         assert (
             use_gluon

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
@@ -31,10 +31,11 @@ that feeds each layer -- is built once outside the timed region, mirroring the
 build()/fn() split in mi450-scripts/run_moe_a4w4.py so the numbers are
 comparable to that runner (which benches one projection per invocation).
 
-`moe_gemm_a4w4` picks its kernel from the arch: the gluon kernels on gfx1250 --
+`moe_gemm_a4w4` defaults to the gluon kernels on gfx1250 --
 _moe_gemm_a4w4_decode when routing picks block_m == 16 and _moe_gemm_a4w4_prefill
-otherwise -- and the triton kernel on gfx950. --preshuffle enables the
-gluon-only gfx1250 WMMA weight preshuffle.
+otherwise -- and the triton kernel elsewhere. --backend pins one instead (gluon
+needs gfx1250). --preshuffle enables the gluon-only gfx1250 WMMA weight
+preshuffle.
 """
 
 import argparse
@@ -241,15 +242,17 @@ def pin_routed_experts(logits, n_routed, n_expts_act):
     return masked, n_pinned
 
 
-def backend_name():
-    """Backend moe_gemm_a4w4 runs here -- it derives this from the arch."""
+def backend_name(backend=None):
+    """Backend moe_gemm_a4w4 runs, resolving None the way the op does."""
+    if backend is not None:
+        return backend
     return "gluon" if get_arch() == "gfx1250" else "triton"
 
 
-def kernel_variant(block_m):
+def kernel_variant(block_m, backend=None):
     """Compiled kernel moe_gemm_a4w4 dispatches to -- same rule as
     run_moe_a4w4.py's `name` subcommand."""
-    if backend_name() != "gluon":
+    if backend_name(backend) != "gluon":
         return "_moe_gemm_a4w4"
     return "_moe_gemm_a4w4_decode" if block_m == 16 else "_moe_gemm_a4w4_prefill"
 
@@ -264,6 +267,7 @@ def bench_mlp_single_weight_init(
     w_dtype,
     TP,
     preshuffle,
+    backend,
     routed_experts,
     rep,
     layers=LAYERS,
@@ -336,6 +340,7 @@ def bench_mlp_single_weight_init(
             swizzle_mx_scale=swizzle_mx_scale1,
             preshuffle_weights=preshuffle,
             apply_swiglu=True,
+            backend=backend,
         )
 
     # layer 2 reads layer 1's swiglu output; quantize it once here so the timed
@@ -356,6 +361,7 @@ def bench_mlp_single_weight_init(
             scatter_indx=scatter_indx,
             swizzle_mx_scale=swizzle_mx_scale2,
             preshuffle_weights=preshuffle,
+            backend=backend,
         )
 
     y2 = layer2()
@@ -412,7 +418,7 @@ def bench_mlp_single_weight_init(
 
     return {
         "layers": measured,
-        "kernel": kernel_variant(rdata.block_m),
+        "kernel": kernel_variant(rdata.block_m, backend),
         "block_m": rdata.block_m,
         "routed_experts": routed,
     }
@@ -428,6 +434,7 @@ def bench_mlp(
     w_dtype,
     TP,
     preshuffle,
+    backend,
     routed_experts,
     rep,
     layers=LAYERS,
@@ -445,6 +452,7 @@ def bench_mlp(
             w_dtype,
             TP,
             preshuffle,
+            backend,
             routed_experts,
             rep,
             layers,
@@ -479,6 +487,7 @@ def roofline_mlp(
     w_dtype,
     TP,
     preshuffle,
+    backend,
     routed_experts,
     rep,
     layers=LAYERS,
@@ -497,7 +506,7 @@ def roofline_mlp(
     )
     if routed_experts is not None:
         stem += f"-routed={routed_experts}"
-    stem += f"-{backend_name()}"
+    stem += f"-{backend_name(backend)}"
     if preshuffle:
         stem += "-preshuffled"
     if tuple(layers) != LAYERS:
@@ -514,6 +523,7 @@ def roofline_mlp(
         w_dtype,
         TP,
         preshuffle,
+        backend,
         routed_experts,
         rep,  # fixed args
         layers,
@@ -559,6 +569,13 @@ def parse_args(args: list[str] | None = None):
         "dim, TOPK multiplies the row count each GEMM sees (batch * TOPK "
         "routed rows). Use --routed-experts to pin how many of the TOTAL "
         "actually receive tokens.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["triton", "gluon"],
+        default=None,
+        help="Kernel backend for moe_gemm_a4w4. Default: unset, i.e. the arch "
+        "default (gluon on gfx1250, triton elsewhere). gluon requires gfx1250.",
     )
     parser.add_argument(
         "--preshuffle",
@@ -634,6 +651,7 @@ def main(args: list[str] | None = None) -> None:
         quantized_dtypes[1],
         TP=1,
         preshuffle=parsed_args.preshuffle,
+        backend=parsed_args.backend,
         routed_experts=parsed_args.routed_experts,
         rep=parsed_args.rep,
         # dedupe, keeping the canonical report order rather than argv order

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
@@ -31,10 +31,10 @@ that feeds each layer -- is built once outside the timed region, mirroring the
 build()/fn() split in mi450-scripts/run_moe_a4w4.py so the numbers are
 comparable to that runner (which benches one projection per invocation).
 
-On gfx1250 `moe_gemm_a4w4` defaults to the gluon backend, which dispatches to
-_moe_gemm_a4w4_decode when routing picks block_m == 16 and to
-_moe_gemm_a4w4_prefill otherwise. --backend pins the backend, and --preshuffle
-enables the gluon-only gfx1250 WMMA weight preshuffle.
+`moe_gemm_a4w4` picks its kernel from the arch: the gluon kernels on gfx1250 --
+_moe_gemm_a4w4_decode when routing picks block_m == 16 and _moe_gemm_a4w4_prefill
+otherwise -- and the triton kernel on gfx950. --preshuffle enables the
+gluon-only gfx1250 WMMA weight preshuffle.
 """
 
 import argparse
@@ -49,7 +49,6 @@ import triton
 from aiter.ops.shuffle import moe_shuffle_scale, moe_shuffle_weight
 from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
 from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
-    is_gluon_supported,
     moe_gemm_a4w4,
     mxfp4_quant,
 )
@@ -242,17 +241,15 @@ def pin_routed_experts(logits, n_routed, n_expts_act):
     return masked, n_pinned
 
 
-def resolve_backend(backend):
-    """`None` lets moe_gemm_a4w4 pick per arch; resolve it the way it does."""
-    if backend is None:
-        return "gluon" if is_gluon_supported() else "triton"
-    return backend
+def backend_name():
+    """Backend moe_gemm_a4w4 runs here -- it derives this from the arch."""
+    return "gluon" if get_arch() == "gfx1250" else "triton"
 
 
-def kernel_variant(block_m, backend):
+def kernel_variant(block_m):
     """Compiled kernel moe_gemm_a4w4 dispatches to -- same rule as
     run_moe_a4w4.py's `name` subcommand."""
-    if resolve_backend(backend) != "gluon":
+    if backend_name() != "gluon":
         return "_moe_gemm_a4w4"
     return "_moe_gemm_a4w4_decode" if block_m == 16 else "_moe_gemm_a4w4_prefill"
 
@@ -266,7 +263,6 @@ def bench_mlp_single_weight_init(
     x_dtype,
     w_dtype,
     TP,
-    backend,
     preshuffle,
     routed_experts,
     rep,
@@ -340,7 +336,6 @@ def bench_mlp_single_weight_init(
             swizzle_mx_scale=swizzle_mx_scale1,
             preshuffle_weights=preshuffle,
             apply_swiglu=True,
-            backend=backend,
         )
 
     # layer 2 reads layer 1's swiglu output; quantize it once here so the timed
@@ -361,7 +356,6 @@ def bench_mlp_single_weight_init(
             scatter_indx=scatter_indx,
             swizzle_mx_scale=swizzle_mx_scale2,
             preshuffle_weights=preshuffle,
-            backend=backend,
         )
 
     y2 = layer2()
@@ -418,7 +412,7 @@ def bench_mlp_single_weight_init(
 
     return {
         "layers": measured,
-        "kernel": kernel_variant(rdata.block_m, backend),
+        "kernel": kernel_variant(rdata.block_m),
         "block_m": rdata.block_m,
         "routed_experts": routed,
     }
@@ -433,7 +427,6 @@ def bench_mlp(
     x_dtype,
     w_dtype,
     TP,
-    backend,
     preshuffle,
     routed_experts,
     rep,
@@ -451,7 +444,6 @@ def bench_mlp(
             x_dtype,
             w_dtype,
             TP,
-            backend,
             preshuffle,
             routed_experts,
             rep,
@@ -486,7 +478,6 @@ def roofline_mlp(
     x_dtype,
     w_dtype,
     TP,
-    backend,
     preshuffle,
     routed_experts,
     rep,
@@ -506,7 +497,7 @@ def roofline_mlp(
     )
     if routed_experts is not None:
         stem += f"-routed={routed_experts}"
-    stem += f"-{resolve_backend(backend)}"
+    stem += f"-{backend_name()}"
     if preshuffle:
         stem += "-preshuffled"
     if tuple(layers) != LAYERS:
@@ -522,7 +513,6 @@ def roofline_mlp(
         x_dtype,
         w_dtype,
         TP,
-        backend,
         preshuffle,
         routed_experts,
         rep,  # fixed args
@@ -569,12 +559,6 @@ def parse_args(args: list[str] | None = None):
         "dim, TOPK multiplies the row count each GEMM sees (batch * TOPK "
         "routed rows). Use --routed-experts to pin how many of the TOTAL "
         "actually receive tokens.",
-    )
-    parser.add_argument(
-        "--backend",
-        choices=["auto", "triton", "gluon"],
-        default="auto",
-        help="moe_gemm_a4w4 backend (default: auto, which is gluon on gfx1250).",
     )
     parser.add_argument(
         "--preshuffle",
@@ -649,7 +633,6 @@ def main(args: list[str] | None = None) -> None:
         quantized_dtypes[0],
         quantized_dtypes[1],
         TP=1,
-        backend=None if parsed_args.backend == "auto" else parsed_args.backend,
         preshuffle=parsed_args.preshuffle,
         routed_experts=parsed_args.routed_experts,
         rep=parsed_args.rep,

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_proton.py
@@ -234,6 +234,7 @@ def bench_mlp_single_weight_init(
     op_regex,
     routed_experts=None,
     preshuffle=False,
+    backend=None,
 ):
     rank = 0
     dev = f"cuda:{rank}"
@@ -318,6 +319,7 @@ def bench_mlp_single_weight_init(
             swizzle_mx_scale=swizzle_mx_scale1,
             preshuffle_weights=preshuffle,
             apply_swiglu=True,
+            backend=backend,
         )
         x, x_scale = mxfp4_quant(x)
         x = moe_gemm_a4w4(
@@ -330,6 +332,7 @@ def bench_mlp_single_weight_init(
             scatter_indx=scatter_indx,
             swizzle_mx_scale=swizzle_mx_scale2,
             preshuffle_weights=preshuffle,
+            backend=backend,
         )
     proton.finalize()
     return parse_profile(
@@ -350,6 +353,7 @@ def bench_mlp(
     routed_experts=None,
     num_weight_inits=1,
     preshuffle=False,
+    backend=None,
 ):
     all_results = []
     for _ in range(num_weight_inits):
@@ -365,6 +369,7 @@ def bench_mlp(
             op_regex,
             routed_experts=routed_experts,
             preshuffle=preshuffle,
+            backend=backend,
         )
         all_results.append(result)
 
@@ -394,6 +399,7 @@ def roofline_mlp(
     name="",
     num_weight_inits=1,
     preshuffle=False,
+    backend=None,
 ):
     # Put all outputs under logs/<name>/ and write a CSV file (not a directory-as-stem).
     out_dir = Path("logs") / name
@@ -421,6 +427,7 @@ def roofline_mlp(
         routed_experts,  # fixed args
         num_weight_inits,
         preshuffle,
+        backend,
         bench_fn=bench_mlp,  # function to benchmark
         intensity_proxy_name="batch",  # intensity proxy name
         intensity_proxy_values=batch_sizes,  # intensity proxy values to sweep
@@ -469,6 +476,13 @@ def parse_args(args: list[str] | None = None):
         "routed rows cannot reach more experts than there are rows, so a batch "
         "that small pins fewer. Default: unset, i.e. random routing over all "
         "experts.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["triton", "gluon"],
+        default=None,
+        help="Kernel backend for moe_gemm_a4w4. Default: unset, i.e. the arch "
+        "default (gluon on gfx1250, triton elsewhere). gluon requires gfx1250.",
     )
     parser.add_argument(
         "--num-weight-inits",
@@ -521,6 +535,7 @@ def main(args: list[str] | None = None) -> None:
         name="gpt-oss-x2",
         num_weight_inits=parsed_args.num_weight_inits,
         preshuffle=parsed_args.preshuffle,
+        backend=parsed_args.backend,
     )
 
 

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w4_cudagraph.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w4_cudagraph.py
@@ -44,13 +44,13 @@ Everything except the GEMMs -- gating, routing, and the activation quantization
 that feeds each layer -- is built once outside the timed region, so the numbers
 cover the two projections and nothing else.
 
-Unlike moe_gemm_a4w4 there is no backend switch: moe_gemm_a8w4 runs the gluon
-kernels on gfx1250 and the triton kernel everywhere else. On gfx1250 the
-variant follows routing's block_m *and* the projection's K -- persistent decode
-for block_m == 16 with K <= 768, plain decode for the rest of block_m == 16,
-prefill otherwise -- so the two projections can land on different kernels and
-the `kernel` column is per layer. --preshuffle enables the gluon-only gfx1250
-WMMA weight preshuffle.
+moe_gemm_a8w4 defaults to the gluon kernels on gfx1250 and the triton kernel
+everywhere else; --backend pins one instead (gluon needs gfx1250). Under gluon
+the variant follows routing's block_m *and* the projection's K -- persistent
+decode for block_m == 16 with K <= 768, plain decode for the rest of
+block_m == 16, prefill otherwise -- so the two projections can land on different
+kernels and the `kernel` column is per layer. --preshuffle enables the
+gluon-only gfx1250 WMMA weight preshuffle.
 """
 
 import argparse
@@ -254,14 +254,20 @@ def pin_routed_experts(logits, n_routed, n_expts_act):
     return masked, n_pinned
 
 
-def kernel_variant(block_m, K):
+def backend_name(backend=None):
+    """Backend moe_gemm_a8w4 runs, resolving None the way the op does."""
+    if backend is not None:
+        return backend
+    return "gluon" if get_arch() == "gfx1250" else "triton"
+
+
+def kernel_variant(block_m, K, backend=None):
     """Compiled kernel moe_gemm_a8w4 dispatches to for a K-deep projection.
 
-    There is no backend argument: the op takes the gluon path iff the arch is
-    gfx1250. Within gluon, get_kernel_config_gluon() turns on the persistent
-    decode variant for shallow K, so moe1 and moe2 can differ.
+    Within gluon, get_kernel_config_gluon() turns on the persistent decode
+    variant for shallow K, so moe1 and moe2 can differ.
     """
-    if get_arch() != "gfx1250":
+    if backend_name(backend) != "gluon":
         return "_moe_gemm_a8w4"
     if block_m != 16:
         return "_moe_gemm_a8w4_prefill"
@@ -278,6 +284,7 @@ def bench_mlp_single_weight_init(
     w_dtype,
     TP,
     preshuffle,
+    backend,
     routed_experts,
     rep,
     layers=LAYERS,
@@ -292,6 +299,9 @@ def bench_mlp_single_weight_init(
         assert (
             get_arch() == "gfx1250"
         ), f"--preshuffle needs the gfx1250 gluon kernel, got {get_arch()}"
+        assert (
+            backend_name(backend) == "gluon"
+        ), "--preshuffle needs the gluon kernel, which --backend triton excludes"
     if routed_experts is not None:
         # every token needs n_expts_act distinct experts, so the pool can't be smaller
         assert n_expts_act <= routed_experts <= n_expts_tot, (
@@ -361,6 +371,7 @@ def bench_mlp_single_weight_init(
             out_dtype=out_dtype,
             apply_swiglu=True,
             preshuffled=preshuffle,
+            backend=backend,
         )
 
     if static_fp8:
@@ -404,6 +415,7 @@ def bench_mlp_single_weight_init(
             scatter_indx=scatter_indx,
             swizzle_mx_scale=swizzle_mx_scale2,
             preshuffled=preshuffle,
+            backend=backend,
         )
 
     y2 = layer2()
@@ -442,8 +454,8 @@ def bench_mlp_single_weight_init(
 
     # the two projections have the same block_m but different K, so they can
     # land on different gluon variants
-    kernel1 = kernel_variant(rdata.block_m, dim1)
-    kernel2 = kernel_variant(rdata.block_m, dim2 // TP // 2)
+    kernel1 = kernel_variant(rdata.block_m, dim1, backend)
+    kernel2 = kernel_variant(rdata.block_m, dim2 // TP // 2, backend)
     kernels = {
         "moe1": kernel1,
         "moe2": kernel2,
@@ -487,6 +499,7 @@ def bench_mlp(
     w_dtype,
     TP,
     preshuffle,
+    backend,
     routed_experts,
     rep,
     layers=LAYERS,
@@ -504,6 +517,7 @@ def bench_mlp(
             w_dtype,
             TP,
             preshuffle,
+            backend,
             routed_experts,
             rep,
             layers,
@@ -542,6 +556,7 @@ def roofline_mlp(
     w_dtype,
     TP,
     preshuffle,
+    backend,
     routed_experts,
     rep,
     layers=LAYERS,
@@ -560,6 +575,7 @@ def roofline_mlp(
     )
     if routed_experts is not None:
         stem += f"-routed={routed_experts}"
+    stem += f"-{backend_name(backend)}"
     if preshuffle:
         stem += "-preshuffled"
     if tuple(layers) != LAYERS:
@@ -576,6 +592,7 @@ def roofline_mlp(
         w_dtype,
         TP,
         preshuffle,
+        backend,
         routed_experts,
         rep,  # fixed args
         layers,
@@ -630,6 +647,13 @@ def parse_args(args: list[str] | None = None):
         "layer 1 emitting layer 2's input directly) or mx8 (mxfp8, one ue8m0 "
         "scale per 32 values along K). Weights are mxfp4 either way. "
         "Default: fp8.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["triton", "gluon"],
+        default=None,
+        help="Kernel backend for moe_gemm_a8w4. Default: unset, i.e. the arch "
+        "default (gluon on gfx1250, triton elsewhere). gluon requires gfx1250.",
     )
     parser.add_argument(
         "--preshuffle",
@@ -705,6 +729,7 @@ def main(args: list[str] | None = None) -> None:
         quantized_dtypes[1],
         TP=1,
         preshuffle=parsed_args.preshuffle,
+        backend=parsed_args.backend,
         routed_experts=parsed_args.routed_experts,
         rep=parsed_args.rep,
         # dedupe, keeping the canonical report order rather than argv order

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w4_proton.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a8w4_proton.py
@@ -234,6 +234,7 @@ def bench_mlp_single_weight_init(
     op_regex,
     routed_experts=None,
     preshuffle=False,
+    backend=None,
 ):
     rank = 0
     dev = f"cuda:{rank}"
@@ -321,6 +322,7 @@ def bench_mlp_single_weight_init(
                 out_dtype=x_dtype,
                 apply_swiglu=True,
                 preshuffled=preshuffle,
+                backend=backend,
             )
             x = moe_gemm_a8w4(
                 x,
@@ -334,6 +336,7 @@ def bench_mlp_single_weight_init(
                 scatter_indx=scatter_indx,
                 swizzle_mx_scale=swizzle_mx_scale2,
                 preshuffled=preshuffle,
+                backend=backend,
             )
         else:
             assert x_dtype_str == "mx8"
@@ -351,6 +354,7 @@ def bench_mlp_single_weight_init(
                 swizzle_mx_scale=swizzle_mx_scale1,
                 apply_swiglu=True,
                 preshuffled=preshuffle,
+                backend=backend,
             )
             x, x_scale = quantize(x, x_dtype_str)
             x = moe_gemm_a8w4(
@@ -365,6 +369,7 @@ def bench_mlp_single_weight_init(
                 scatter_indx=scatter_indx,
                 swizzle_mx_scale=swizzle_mx_scale2,
                 preshuffled=preshuffle,
+                backend=backend,
             )
     proton.finalize()
     return parse_profile(
@@ -385,6 +390,7 @@ def bench_mlp(
     routed_experts=None,
     num_weight_inits=1,
     preshuffle=False,
+    backend=None,
 ):
     all_results = []
     for _ in range(num_weight_inits):
@@ -400,6 +406,7 @@ def bench_mlp(
             op_regex,
             routed_experts=routed_experts,
             preshuffle=preshuffle,
+            backend=backend,
         )
         all_results.append(result)
 
@@ -429,6 +436,7 @@ def roofline_mlp(
     name="",
     num_weight_inits=1,
     preshuffle=False,
+    backend=None,
 ):
     # Avoid creating an empty directory named like the output CSV stem.
     out_dir = Path("logs") / name
@@ -448,6 +456,7 @@ def roofline_mlp(
         routed_experts,  # fixed args
         num_weight_inits,
         preshuffle,
+        backend,
         bench_fn=bench_mlp,  # function to benchmark
         intensity_proxy_name="batch",  # intensity proxy name
         intensity_proxy_values=batch_sizes,  # intensity proxy values to sweep
@@ -504,6 +513,13 @@ def parse_args(args: list[str] | None = None):
         "experts.",
     )
     parser.add_argument(
+        "--backend",
+        choices=["triton", "gluon"],
+        default=None,
+        help="Kernel backend for moe_gemm_a8w4. Default: unset, i.e. the arch "
+        "default (gluon on gfx1250, triton elsewhere). gluon requires gfx1250.",
+    )
+    parser.add_argument(
         "--num-weight-inits",
         type=int,
         default=1,
@@ -554,6 +570,7 @@ def main(args: list[str] | None = None) -> None:
         name="gpt-oss-x2",
         num_weight_inits=parsed_args.num_weight_inits,
         preshuffle=parsed_args.preshuffle,
+        backend=parsed_args.backend,
     )
 
 

--- a/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
@@ -240,6 +240,7 @@ class Case:
 )
 @pytest.mark.parametrize("has_y_gammas", [False, True])
 @pytest.mark.parametrize("apply_swiglu", [False, True])
+@pytest.mark.parametrize("backend", ["gluon", "triton"])
 def test_op(
     m,
     n,
@@ -252,12 +253,16 @@ def test_op(
     n_expts_act,
     hbm_swizzling,
     preshuffle_weights,
+    backend,
     device="cuda",
 ):
     if get_arch() != "gfx950" and get_arch() != "gfx1250":
         pytest.skip("Kernel not supported on this GPU.")
     if not is_fp4_avail():
         pytest.skip(f"FP4 kernels are not supported on {get_arch()}.")
+
+    if backend == "gluon" and get_arch() != "gfx1250":
+        pytest.skip(f"Gluon backend requires gfx1250, got {get_arch()}.")
     if hbm_swizzling:
         if get_arch() == "gfx950" and (n % 32 != 0 or k % (32 * 8) != 0):
             pytest.skip(
@@ -273,6 +278,8 @@ def test_op(
     if preshuffle_weights:
         if get_arch() != "gfx1250":
             pytest.skip("Preshuffling weights is only supported on gfx1250")
+        if backend == "triton":
+            pytest.skip("Preshuffled weights are decoded by the gluon kernel only")
         if n % 16 != 0 or (k // 2) % 32 != 0:
             pytest.skip(
                 f"Preshuffling weights requires n divisible by 16 and k//2 divisible "
@@ -347,5 +354,6 @@ def test_op(
         preshuffle_weights,
         out_dtype,
         apply_swiglu,
+        backend=backend,
     )
     assert_close(ref_y, tri_y, maxtol=maxtol, rmstol=rmstol)

--- a/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
@@ -10,7 +10,6 @@ from aiter.ops.shuffle import moe_shuffle_scale, moe_shuffle_weight
 
 # matmul utilities
 from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
-    is_gluon_supported,
     moe_gemm_a4w4,
     moe_gemm_torch,
     mxfp4_quant,
@@ -241,7 +240,6 @@ class Case:
 )
 @pytest.mark.parametrize("has_y_gammas", [False, True])
 @pytest.mark.parametrize("apply_swiglu", [False, True])
-@pytest.mark.parametrize("backend", ["triton", "gluon"])
 def test_op(
     m,
     n,
@@ -254,9 +252,10 @@ def test_op(
     n_expts_act,
     hbm_swizzling,
     preshuffle_weights,
-    backend,
     device="cuda",
 ):
+    if get_arch() != "gfx950" and get_arch() != "gfx1250":
+        pytest.skip("Kernel not supported on this GPU.")
     if not is_fp4_avail():
         pytest.skip(f"FP4 kernels are not supported on {get_arch()}.")
     if hbm_swizzling:
@@ -274,17 +273,11 @@ def test_op(
     if preshuffle_weights:
         if get_arch() != "gfx1250":
             pytest.skip("Preshuffling weights is only supported on gfx1250")
-        if backend != "gluon":
-            pytest.skip("Preshuffling weights is only supported on gluon backend")
         if n % 16 != 0 or (k // 2) % 32 != 0:
             pytest.skip(
                 f"Preshuffling weights requires n divisible by 16 and k//2 divisible "
                 f"by 32, got n={n}, k//2={k // 2}"
             )
-
-    # skip gluon backend if not supported
-    if backend == "gluon" and not is_gluon_supported():
-        pytest.skip(f"Gluon backend is not supported on {get_arch()}")
 
     torch.manual_seed(0)
 
@@ -354,6 +347,5 @@ def test_op(
         preshuffle_weights,
         out_dtype,
         apply_swiglu,
-        backend=backend,
     )
     assert_close(ref_y, tri_y, maxtol=maxtol, rmstol=rmstol)

--- a/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a8w4.py
@@ -241,6 +241,7 @@ class Case:
 @pytest.mark.parametrize("fused_quant", [False, True])
 @pytest.mark.parametrize("out_mx_quant", [False, True])
 @pytest.mark.parametrize("preshuffled", [False, True])
+@pytest.mark.parametrize("backend", ["gluon", "triton"])
 def test_op(
     m,
     n,
@@ -252,6 +253,7 @@ def test_op(
     fused_quant,
     out_mx_quant,
     preshuffled,
+    backend,
     n_expts_tot,
     n_expts_act,
     act_dtype_str,
@@ -262,8 +264,14 @@ def test_op(
     if get_arch() != "gfx950" and get_arch() != "gfx1250":
         pytest.skip("Kernel not supported on this GPU.")
 
+    if backend == "gluon" and get_arch() != "gfx1250":
+        pytest.skip(f"Gluon backend requires gfx1250, got {get_arch()}.")
+
     if preshuffled and get_arch() != "gfx1250":
         pytest.skip("Preshuffled weights are only supported on gfx1250.")
+
+    if preshuffled and backend == "triton":
+        pytest.skip("Preshuffled weights are decoded by the gluon kernel only.")
 
     if preshuffled and ((k // 2) % 32 != 0 or n % 16 != 0):
         pytest.skip(
@@ -271,7 +279,7 @@ def test_op(
             f"got k//2={k // 2}, N={n}."
         )
 
-    if get_arch() == "gfx1250":
+    if get_arch() == "gfx1250" and backend == "gluon":
         # temporary
         if do_gather and m > 1024 and act_dtype_str == "mxfloat8_e4m3fn":
             pytest.skip("do_gather (TDM async_gather) is not supported on gfx1250.")
@@ -388,6 +396,7 @@ def test_op(
         apply_swiglu,
         preshuffled=preshuffled,
         out_mx_quant=out_mx_quant,
+        backend=backend,
     )
     if out_mx_quant:
         tri_y, tri_y_scale = tri_y


### PR DESCRIPTION
- Support triton backend for both a8w4 and a4w4 MoE kernels in gfx1250
    - by default use gluon kernel for 1250 and triton kernel for 950
    - 1250 can use both triton or gluon kernel by passing in `--backend` arg but 950 can only use triton backend
- Added repr to both a8w4 and a4w4 MoE

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
