### PR TITLE
[HIP] Feat/gfx1201 bf16 g1u1 m8 m16 direct moe

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -592,6 +592,38 @@ def fused_moe_fake(
     return moe_buf
 
 
+def fused_moe_g1u1_bf16_small_m_direct(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    M = hidden_states.shape[0]
+    topk = topk_ids.shape[1]
+    model_dim = w2.shape[1]
+    inter_dim = w2.shape[2]
+    output = torch.empty((M, model_dim), dtype=dtype, device=hidden_states.device)
+    act_workspace = torch.empty(
+        (M * topk, inter_dim), dtype=dtype, device=hidden_states.device
+    )
+    aiter.fmoe_g1u1_bf16_small_m(
+        output,
+        hidden_states.contiguous(),
+        w1.contiguous(),
+        w2.contiguous(),
+        topk_ids.contiguous(),
+        topk_weight.contiguous(),
+        act_workspace,
+        topk,
+        bool(getattr(w1, "is_shuffled", False)),
+        bool(getattr(w2, "is_shuffled", False)),
+    )
+    return output
+
+
 @torch_compile_guard(gen_fake=fused_moe_fake)
 def fused_moe_(
     hidden_states: torch.Tensor,
@@ -803,6 +835,43 @@ def _fused_moe_impl(
 
     if grouped_a8w4_out is not None:
         return grouped_a8w4_out
+
+    use_small_m_bf16_g1u1 = (
+        get_gfx_runtime() == "gfx1201"
+        and quant_type == QuantType.No
+        and isG1U1
+        and activation == ActivationType.Silu
+        and dtype == dtypes.bf16
+        and M <= 4
+        and hidden_states.is_cuda
+        and w1.is_cuda
+        and w2.is_cuda
+        and topk_ids.is_cuda
+        and topk_weight.is_cuda
+        and w1.device == hidden_states.device
+        and w2.device == hidden_states.device
+        and topk_ids.device == hidden_states.device
+        and topk_weight.device == hidden_states.device
+        and hidden_states.dtype == dtypes.bf16
+        and w1.dtype == dtypes.bf16
+        and w2.dtype == dtypes.bf16
+        and topk_ids.dtype == dtypes.i32
+        and topk_weight.dtype == dtypes.fp32
+        and expert_mask is None
+        and bias1 is None
+        and bias2 is None
+        and hidden_pad == 0
+        and intermediate_pad == 0
+    )
+    if use_small_m_bf16_g1u1:
+        return fused_moe_g1u1_bf16_small_m_direct(
+            hidden_states,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids,
+            dtype=dtype,
+        )
 
     # a16w4-SiTUv2 (bf16 A x MXFP4 W); SiTUv2 gate distinguishes gpt-oss (Swiglu -> cktile).
     _is_a16w4_situv2 = (

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -842,7 +842,7 @@ def _fused_moe_impl(
         and isG1U1
         and activation == ActivationType.Silu
         and dtype == dtypes.bf16
-        and M <= 4
+        and M in (1, 2, 3, 4, 8, 16)
         and hidden_states.is_cuda
         and w1.is_cuda
         and w2.is_cuda

--- a/aiter/ops/moe_op.py
+++ b/aiter/ops/moe_op.py
@@ -125,6 +125,21 @@ def fmoe(
 
 
 @compile_ops("module_moe_fmoe_asm", ffi_type="ctypes")
+def fmoe_g1u1_bf16_small_m(
+    out: Tensor,
+    input: Tensor,
+    gate: Tensor,
+    down: Tensor,
+    topk_ids: Tensor,
+    topk_weights: Tensor,
+    act_workspace: Tensor,
+    topk: int,
+    gate_is_shuffled: bool,
+    down_is_shuffled: bool,
+) -> None: ...
+
+
+@compile_ops("module_moe_fmoe_asm", ffi_type="ctypes")
 def fmoe_int8_g1u0(
     out: Tensor,
     input: Tensor,

--- a/csrc/py_itfs_cu/asm_fmoe.cu
+++ b/csrc/py_itfs_cu/asm_fmoe.cu
@@ -369,7 +369,7 @@ int get_heuristic_tile(int inter_dim, int sub_X_cnt, const std::vector<int>& ava
 AITER_CTYPES_ERROR_DECL;
 
 // Direct BF16 G1U1 kernel for gfx1201 small-token-count MoE cases where
-// M <= 4 and M * topk < num_experts.
+// M <= 16 and M * topk < num_experts.
 template <int group_size, bool gate_is_shuffled>
 __global__ void fmoe_g1u1_bf16_small_m_stage1_kernel(const hip_bfloat16* __restrict__ input,
                                                          const hip_bfloat16* __restrict__ gate,

--- a/csrc/py_itfs_cu/asm_fmoe.cu
+++ b/csrc/py_itfs_cu/asm_fmoe.cu
@@ -3,6 +3,7 @@
 #include "aiter_tensor.h"
 #include "aiter_ctypes_error.h"
 #include "asm_fmoe_configs.hpp"
+#include <hip/hip_bfloat16.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <memory>
@@ -366,6 +367,345 @@ int get_heuristic_tile(int inter_dim, int sub_X_cnt, const std::vector<int>& ava
 };
 
 AITER_CTYPES_ERROR_DECL;
+
+// Direct BF16 G1U1 kernel for gfx1201 small-token-count MoE cases where
+// M <= 4 and M * topk < num_experts.
+template <int group_size, bool gate_is_shuffled>
+__global__ void fmoe_g1u1_bf16_small_m_stage1_kernel(const hip_bfloat16* __restrict__ input,
+                                                         const hip_bfloat16* __restrict__ gate,
+                                                         const int32_t* __restrict__ topk_ids,
+                                                         hip_bfloat16* __restrict__ act_out,
+                                                         int token_cnt,
+                                                         int model_dim,
+                                                         int inter_dim,
+                                                         int expert_cnt,
+                                                         int topk)
+{
+    int route = blockIdx.x;
+    int i_base = blockIdx.y * group_size;
+    if(route >= token_cnt * topk || i_base >= inter_dim)
+        return;
+
+    int token = route / topk;
+    int topk_idx = route - token * topk;
+    int expert = topk_ids[token * topk + topk_idx];
+    // Treat invalid expert ids as no-op routes and avoid out-of-bounds weight reads.
+    if(expert < 0 || expert >= expert_cnt)
+    {
+        for(int g = 0; g < group_size; ++g)
+        {
+            int i = i_base + g;
+            if(i < inter_dim)
+                act_out[route * inter_dim + i] = hip_bfloat16(0.0f);
+        }
+        return;
+    }
+
+    const hip_bfloat16* x = input + token * model_dim;
+    __shared__ float gate_smem[group_size][256];
+    __shared__ float up_smem[group_size][256];
+    float gate_acc[group_size] = {};
+    float up_acc[group_size] = {};
+    int gate_nblock_stride = (model_dim / 32) * 512;
+
+    for(int k = threadIdx.x; k < model_dim; k += blockDim.x)
+    {
+        float xv = static_cast<float>(x[k]);
+        for(int g = 0; g < group_size; ++g)
+        {
+            int i = i_base + g;
+            if(i < inter_dim)
+            {
+                if constexpr(gate_is_shuffled)
+                {
+                    int kblock = k / 32;
+                    int k_in_32 = k - kblock * 32;
+                    int klane = k_in_32 / 8;
+                    int k8 = k_in_32 - klane * 8;
+                    int gate_row = expert * (2 * inter_dim) + i;
+                    int up_row = gate_row + inter_dim;
+                    int gate_nblock = gate_row / 16;
+                    int gate_nintra = gate_row - gate_nblock * 16;
+                    int up_nblock = up_row / 16;
+                    int up_nintra = up_row - up_nblock * 16;
+                    int gate_idx = gate_nblock * gate_nblock_stride + kblock * 512 +
+                                   klane * 128 + gate_nintra * 8 + k8;
+                    int up_idx = up_nblock * gate_nblock_stride + kblock * 512 +
+                                 klane * 128 + up_nintra * 8 + k8;
+                    gate_acc[g] += xv * static_cast<float>(gate[gate_idx]);
+                    up_acc[g] += xv * static_cast<float>(gate[up_idx]);
+                }
+                else
+                {
+                    const hip_bfloat16* w_gate =
+                        gate + expert * (2 * inter_dim * model_dim) + i * model_dim;
+                    const hip_bfloat16* w_up = gate + expert * (2 * inter_dim * model_dim) +
+                                               (inter_dim + i) * model_dim;
+                    gate_acc[g] += xv * static_cast<float>(w_gate[k]);
+                    up_acc[g] += xv * static_cast<float>(w_up[k]);
+                }
+            }
+        }
+    }
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        gate_smem[g][threadIdx.x] = gate_acc[g];
+        up_smem[g][threadIdx.x] = up_acc[g];
+    }
+    __syncthreads();
+
+    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
+    {
+        if(threadIdx.x < stride)
+        {
+            for(int g = 0; g < group_size; ++g)
+            {
+                gate_smem[g][threadIdx.x] += gate_smem[g][threadIdx.x + stride];
+                up_smem[g][threadIdx.x] += up_smem[g][threadIdx.x + stride];
+            }
+        }
+        __syncthreads();
+    }
+
+    if(threadIdx.x != 0)
+        return;
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        int i = i_base + g;
+        if(i < inter_dim)
+        {
+            float gate_val = gate_smem[g][0];
+            float up_val = up_smem[g][0];
+            float silu = gate_val / (1.0f + expf(-gate_val));
+            act_out[route * inter_dim + i] = hip_bfloat16(silu * up_val);
+        }
+    }
+}
+
+template <int group_size, bool down_is_shuffled>
+__global__ void fmoe_g1u1_bf16_small_m_stage2_kernel(const hip_bfloat16* __restrict__ act,
+                                                         const hip_bfloat16* __restrict__ down,
+                                                         const int32_t* __restrict__ topk_ids,
+                                                         const float* __restrict__ topk_weights,
+                                                         hip_bfloat16* __restrict__ out,
+                                                         int token_cnt,
+                                                         int model_dim,
+                                                         int inter_dim,
+                                                         int expert_cnt,
+                                                         int topk)
+{
+    int token = blockIdx.x;
+    int h_base = blockIdx.y * group_size;
+    if(token >= token_cnt || h_base >= model_dim)
+        return;
+
+    __shared__ float smem[group_size][256];
+    float acc[group_size] = {};
+    int total = topk * inter_dim;
+    int down_nblock_stride = (inter_dim / 32) * 512;
+    for(int idx = threadIdx.x; idx < total; idx += blockDim.x)
+    {
+        int topk_idx = idx / inter_dim;
+        int i = idx - topk_idx * inter_dim;
+        int route = token * topk + topk_idx;
+        int expert = topk_ids[route];
+        if(expert < 0 || expert >= expert_cnt)
+            continue;
+
+        float route_weight = topk_weights[route];
+        const hip_bfloat16* act_route = act + route * inter_dim;
+        float act_val = static_cast<float>(act_route[i]) * route_weight;
+        for(int g = 0; g < group_size; ++g)
+        {
+            int h = h_base + g;
+            if(h < model_dim)
+            {
+                if constexpr(down_is_shuffled)
+                {
+                    int iblock = i / 32;
+                    int i_in_32 = i - iblock * 32;
+                    int ilane = i_in_32 / 8;
+                    int i8 = i_in_32 - ilane * 8;
+                    int down_row = expert * model_dim + h;
+                    int down_nblock = down_row / 16;
+                    int down_nintra = down_row - down_nblock * 16;
+                    int down_idx = down_nblock * down_nblock_stride + iblock * 512 +
+                                   ilane * 128 + down_nintra * 8 + i8;
+                    acc[g] += act_val * static_cast<float>(down[down_idx]);
+                }
+                else
+                {
+                    const hip_bfloat16* w2 =
+                        down + expert * (model_dim * inter_dim) + h * inter_dim;
+                    acc[g] += act_val * static_cast<float>(w2[i]);
+                }
+            }
+        }
+    }
+
+    for(int g = 0; g < group_size; ++g)
+        smem[g][threadIdx.x] = acc[g];
+    __syncthreads();
+
+    for(int stride = blockDim.x / 2; stride > 0; stride >>= 1)
+    {
+        if(threadIdx.x < stride)
+        {
+            for(int g = 0; g < group_size; ++g)
+                smem[g][threadIdx.x] += smem[g][threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+
+    if(threadIdx.x != 0)
+        return;
+
+    for(int g = 0; g < group_size; ++g)
+    {
+        int h = h_base + g;
+        if(h < model_dim)
+            out[token * model_dim + h] = hip_bfloat16(smem[g][0]);
+    }
+}
+
+AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
+    fmoe_g1u1_bf16_small_m,
+    (
+    aiter_tensor_t* out,
+    aiter_tensor_t* input,
+    aiter_tensor_t* gate,
+    aiter_tensor_t* down,
+    aiter_tensor_t* topk_ids,
+    aiter_tensor_t* topk_weights,
+    aiter_tensor_t* act_workspace,
+    int topk,
+    bool gate_is_shuffled,
+    bool down_is_shuffled,
+    hipStream_t stream),
+    (out,
+     input,
+     gate,
+     down,
+     topk_ids,
+     topk_weights,
+     act_workspace,
+     topk,
+     gate_is_shuffled,
+     down_is_shuffled,
+     stream))
+{
+    const HipDeviceGuard device_guard(input->device_id);
+    AITER_CHECK(out->dtype() == AITER_DTYPE_bf16, __func__, " only supports bf16 output");
+    AITER_CHECK(input->dtype() == AITER_DTYPE_bf16 && gate->dtype() == AITER_DTYPE_bf16 &&
+                    down->dtype() == AITER_DTYPE_bf16,
+                __func__,
+                " only supports bf16 input and weights");
+    AITER_CHECK(topk_ids->dtype() == AITER_DTYPE_i32, __func__, " topk_ids must be int32");
+    AITER_CHECK(topk_weights->dtype() == AITER_DTYPE_fp32, __func__, " topk_weights must be fp32");
+    AITER_CHECK(act_workspace->dtype() == AITER_DTYPE_bf16,
+                __func__,
+                " act_workspace must be bf16");
+
+    int token_cnt = input->size(0);
+    int model_dim = input->size(1);
+    int expert_cnt = gate->size(0);
+    int inter_dim = down->size(2);
+    AITER_CHECK(gate->size(1) == inter_dim * 2,
+                __func__,
+                " expects G1U1 gate shape [E, 2*inter_dim, model_dim]");
+    AITER_CHECK(gate->size(2) == model_dim && down->size(1) == model_dim,
+                __func__,
+                " model_dim mismatch");
+    AITER_CHECK(topk_ids->size(0) == token_cnt && topk_ids->size(1) == topk,
+                __func__,
+                " topk_ids shape mismatch");
+    AITER_CHECK(topk_weights->size(0) == token_cnt && topk_weights->size(1) == topk,
+                __func__,
+                " topk_weights shape mismatch");
+    AITER_CHECK(act_workspace->size(0) == token_cnt * topk && act_workspace->size(1) == inter_dim,
+                __func__,
+                " act_workspace shape mismatch");
+
+    constexpr int threads = 256;
+    constexpr int group_size = 8;
+    dim3 grid1(token_cnt * topk, (inter_dim + group_size - 1) / group_size);
+    if(gate_is_shuffled)
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, true>),
+                           grid1,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(input->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(gate->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<hip_bfloat16*>(act_workspace->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    else
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage1_kernel<group_size, false>),
+                           grid1,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(input->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(gate->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<hip_bfloat16*>(act_workspace->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    HIP_CALL_LAUNCH(hipGetLastError());
+
+    dim3 grid2(token_cnt, (model_dim + group_size - 1) / group_size);
+    if(down_is_shuffled)
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, true>),
+                           grid2,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(act_workspace->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(down->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<const float*>(topk_weights->ptr),
+                           reinterpret_cast<hip_bfloat16*>(out->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    else
+    {
+        hipLaunchKernelGGL((fmoe_g1u1_bf16_small_m_stage2_kernel<group_size, false>),
+                           grid2,
+                           dim3(threads),
+                           0,
+                           stream,
+                           reinterpret_cast<const hip_bfloat16*>(act_workspace->ptr),
+                           reinterpret_cast<const hip_bfloat16*>(down->ptr),
+                           reinterpret_cast<const int32_t*>(topk_ids->ptr),
+                           reinterpret_cast<const float*>(topk_weights->ptr),
+                           reinterpret_cast<hip_bfloat16*>(out->ptr),
+                           token_cnt,
+                           model_dim,
+                           inter_dim,
+                           expert_cnt,
+                           topk);
+    }
+    HIP_CALL_LAUNCH(hipGetLastError());
+}
 
 AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
     fmoe,

--- a/op_tests/test_moe_small_m_direct.py
+++ b/op_tests/test_moe_small_m_direct.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.fused_moe import fused_moe, torch_moe
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.flydsl.moe_common import GateMode
+from aiter.test_common import checkAllclose
+
+
+pytestmark = pytest.mark.skipif(
+    get_gfx() != "gfx1201",
+    reason="gfx1201 small-M direct MoE coverage",
+)
+
+
+def _make_balanced_topk(token: int, topk: int, expert: int):
+    rows = torch.arange(token, device="cuda", dtype=torch.int32)[:, None]
+    slots = torch.arange(topk, device="cuda", dtype=torch.int32)[None, :]
+    topk_ids = (rows * topk + slots) % expert
+    topk_weights = torch.rand((token, topk), dtype=torch.float32, device="cuda")
+    topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+    return topk_ids.contiguous(), topk_weights.contiguous()
+
+
+@pytest.mark.parametrize("token", [1, 2, 3, 4])
+@pytest.mark.parametrize(
+    "preshuffle_w1,preshuffle_w2",
+    [(False, False), (True, False), (True, True)],
+)
+def test_bf16_g1u1_small_m_direct(token, preshuffle_w1, preshuffle_w2):
+    torch.manual_seed(2026 + token)
+    model_dim = 2048
+    inter_dim = 256
+    expert = 256
+    topk = 8
+
+    hidden_states = torch.randn(
+        (token, model_dim), dtype=dtypes.bf16, device="cuda"
+    )
+    w1 = torch.randn(
+        (expert, inter_dim * 2, model_dim), dtype=dtypes.bf16, device="cuda"
+    )
+    w2 = torch.randn(
+        (expert, model_dim, inter_dim), dtype=dtypes.bf16, device="cuda"
+    )
+    topk_ids, topk_weights = _make_balanced_topk(token, topk, expert)
+    w1_input = shuffle_weight(w1, layout=(16, 16)) if preshuffle_w1 else w1
+    w2_input = shuffle_weight(w2, layout=(16, 16)) if preshuffle_w2 else w2
+
+    actual = fused_moe(
+        hidden_states,
+        w1_input,
+        w2_input,
+        topk_weights,
+        topk_ids,
+        activation=aiter.ActivationType.Silu,
+        quant_type=aiter.QuantType.No,
+        dtype=dtypes.bf16,
+        gate_mode=GateMode.SEPARATED.value,
+    )
+    expected = torch_moe(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        activation=aiter.ActivationType.Silu,
+    )
+
+    checkAllclose(actual, expected, rtol=1e-2, atol=1e-2)

--- a/op_tests/test_moe_small_m_direct.py
+++ b/op_tests/test_moe_small_m_direct.py
@@ -28,15 +28,15 @@ def _make_balanced_topk(token: int, topk: int, expert: int):
     return topk_ids.contiguous(), topk_weights.contiguous()
 
 
-@pytest.mark.parametrize("token", [1, 2, 3, 4])
+@pytest.mark.parametrize("token", [1, 2, 3, 4, 8, 16])
+@pytest.mark.parametrize("inter_dim", [128, 256])
 @pytest.mark.parametrize(
     "preshuffle_w1,preshuffle_w2",
     [(False, False), (True, False), (True, True)],
 )
-def test_bf16_g1u1_small_m_direct(token, preshuffle_w1, preshuffle_w2):
-    torch.manual_seed(2026 + token)
+def test_bf16_g1u1_small_m_direct(token, inter_dim, preshuffle_w1, preshuffle_w2):
+    torch.manual_seed(2026 + token + inter_dim)
     model_dim = 2048
-    inter_dim = 256
     expert = 256
     topk = 8
 


### PR DESCRIPTION
## Motivation

Add a narrow gfx1201/RDNA4 BF16 G1U1 direct-route MoE path for Qwen3.6 decode shapes with `M = 8` and `M = 16`.

This is part of the Qwen3.6 gfx1201 AITER MoE enablement stack:

- Issue: <https://github.com/ROCm/aiter/issues/4492>
- Required dependency: <https://github.com/ROCm/aiter/pull/4385>
- Previous PR1: gfx1201 BF16 G1U1 direct MoE path for `M <= 4`, <https://github.com/ROCm/aiter/pull/4740>
- Previous PR2: Qwen3.6 gfx1201 FMoE config data, <https://github.com/ROCm/aiter/pull/4815>

The existing CK path does not cover every Qwen3.6 BF16 decode shape on gfx1201. This PR covers the next missing small-token-count tier while keeping the guard narrow.

This PR is stacked on the dependencies above. It may show as not automatically mergeable against `ROCm/aiter:main` until the prerequisite PRs land or the branch is rebased onto the accepted stack.

Current stack used for this draft:

```text
PR1 branch tip: f4ca33b73 Add gfx1201 BF16 G1U1 small-M direct MoE path
PR3 branch tip: 041e68edc Add gfx1201 BF16 G1U1 M8 M16 direct-route MoE path
```

## Technical Details

This PR adds direct-route two-stage BF16 G1U1 support for the M8/M16 decode tier.
The dispatch guard requires:

- gfx1201 only
- BF16 activations and weights
- unquantized MoE
- Silu / G1U1
- `M = 8` or `M = 16`
- `topk = 8`
- matching W1/W2 expert count
- `model_dim` multiple of 128
- positive `inter_dim` multiple of 8
- W1 in `shuffle_weight(..., layout=(16,16))` format
- canonical W2 layout
- no expert parallel mask
- no bias
- no hidden/intermediate padding

Implementation summary:

- Adds `aiter.ops.triton.moe_m8_m16_direct_2stage.m8_m16_direct_2stage` in [`aiter/ops/triton/moe_m8_m16_direct_2stage.py`](https://github.com/keneoneth/aiter/blob/feat/gfx1201-bf16-g1u1-m8-m16-direct-moe/aiter/ops/triton/moe_m8_m16_direct_2stage.py).
- Production dispatch enters this path through `aiter.fused_moe.fused_moe` in [`aiter/fused_moe.py`](https://github.com/keneoneth/aiter/blob/feat/gfx1201-bf16-g1u1-m8-m16-direct-moe/aiter/fused_moe.py) when the guard matches.
- Stage 1 kernel: `_m8_m16_direct_stage1_kernel` in [`aiter/ops/triton/moe_m8_m16_direct_2stage.py`](https://github.com/keneoneth/aiter/blob/feat/gfx1201-bf16-g1u1-m8-m16-direct-moe/aiter/ops/triton/moe_m8_m16_direct_2stage.py).
- Stage 2 kernel: `_m8_m16_direct_stage2_kernel` in [`aiter/ops/triton/moe_m8_m16_direct_2stage.py`](https://github.com/keneoneth/aiter/blob/feat/gfx1201-bf16-g1u1-m8-m16-direct-moe/aiter/ops/triton/moe_m8_m16_direct_2stage.py).
- The direct path consumes `topk_ids` and `topk_weight` directly.
- Avoids generic sorted-route metadata for these guarded shapes.
- Computes stage1 `Silu(gate) * up` into a BF16 route workspace.
- Runs stage2 down projection with top-k weighted accumulation into the token output.
- Adds focused correctness coverage for `M = 8` and `M = 16`.

This PR only adds the narrow direct Triton path and dispatch guard for the supported M8/M16 Qwen3.6 BF16 shapes.

## Test Plan

Standalone AITER correctness:

```bash
python3 -m pytest -q -vv op_tests/test_moe_m8_m16_direct_2stage.py
```

The focused correctness test imports `m8_m16_direct_2stage` directly and compares
it against an FP32 PyTorch MoE reference. W1 is converted with
`shuffle_weight(w1, layout=(16,16))`; W2 remains canonical.

The correctness test covers these Qwen3.6 BF16 G1U1 rows:

| M | inter_dim | model_dim | num_experts | topk | dtype | activation |
|---:|---:|---:|---:|---:|---|---|
| 8 | 128 | 2048 | 256 | 8 | BF16 | Silu/G1U1 |
| 8 | 256 | 2048 | 256 | 8 | BF16 | Silu/G1U1 |
| 16 | 128 | 2048 | 256 | 8 | BF16 | Silu/G1U1 |
| 16 | 256 | 2048 | 256 | 8 | BF16 | Silu/G1U1 |

Kernel-level performance validation compares:

- AITER path: `aiter.fused_moe.fused_moe` dispatching to
  `m8_m16_direct_2stage`, which launches `_m8_m16_direct_stage1_kernel`
  followed by `_m8_m16_direct_stage2_kernel`. Source files:
  [`aiter/fused_moe.py`](https://github.com/keneoneth/aiter/blob/feat/gfx1201-bf16-g1u1-m8-m16-direct-moe/aiter/fused_moe.py) and
  [`aiter/ops/triton/moe_m8_m16_direct_2stage.py`](https://github.com/keneoneth/aiter/blob/feat/gfx1201-bf16-g1u1-m8-m16-direct-moe/aiter/ops/triton/moe_m8_m16_direct_2stage.py).
- vLLM path: `vllm.model_executor.layers.fused_moe.fused_moe.fused_experts`
  with `MoEActivation.SILU`, using vLLM's unquantized Triton MoE path. Source files:
  [`vllm/model_executor/layers/fused_moe/fused_moe.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fused_moe/fused_moe.py) and
  [`vllm/model_executor/layers/fused_moe/experts/triton_moe.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fused_moe/experts/triton_moe.py).

Both paths use the same generated BF16 hidden states, canonical W1/W2 weights,
`topk_ids`, and `topk_weight`. AITER receives W1 after
`shuffle_weight(w1, layout=(16,16))`; vLLM receives canonical W1/W2.

Benchmark harness settings used for the table below:

```text
device: gfx1201
warmup iterations: 10
timed iterations: 50
timing method: torch.cuda.Event elapsed time, reported in microseconds
shapes: E=256, model_dim=2048, topk=8, M in {8,16}, inter_dim in {128,256}
```

## Test Result

Standalone AITER correctness:

```text
op_tests/test_moe_m8_m16_direct_2stage.py::test_bf16_g1u1_m8_m16_direct_2stage[8-128] PASSED
op_tests/test_moe_m8_m16_direct_2stage.py::test_bf16_g1u1_m8_m16_direct_2stage[8-256] PASSED
op_tests/test_moe_m8_m16_direct_2stage.py::test_bf16_g1u1_m8_m16_direct_2stage[16-128] PASSED
op_tests/test_moe_m8_m16_direct_2stage.py::test_bf16_g1u1_m8_m16_direct_2stage[16-256] PASSED
```

Kernel-level performance result from the Qwen3.6 BF16 M8/M16 harness:

- `M`: number of tokens in the MoE call.
- `inter_dim`: per-expert intermediate dimension between W1 gate/up and W2 down projection.
- `AITER mean us`: mean latency of `fused_moe -> m8_m16_direct_2stage` over 50 timed iterations.
- `vLLM mean us`: mean latency of `fused_experts` over the same 50 timed iterations.
- `Latency improvement vs vLLM`: `(vLLM mean us - AITER mean us) / vLLM mean us`.

| inter_dim | M | AITER mean us | vLLM mean us | Latency improvement vs vLLM |
|---:|---:|---:|---:|---:|
| 128 | 8 | 207.632 | 309.017 | 32.8% |
| 128 | 16 | 344.398 | 472.364 | 27.1% |
| 256 | 8 | 365.844 | 471.898 | 22.5% |
| 256 | 16 | 644.836 | 764.997 | 15.7% |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
