### PR TITLE
[HIP] fix(topk): add acquire fence for mb radix barrier last block

### DIFF
--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -523,10 +523,10 @@ __global__ void radix_kernel_persistent(T const* in,
                 __atomic_store_n(reinterpret_cast<volatile unsigned int*>(&counter->pass_done),
                                  static_cast<unsigned int>(pass + 1), __ATOMIC_RELEASE);
             }
-            // Waiting blocks acquire pass_done and invalidate their cache before
-            // reloading the global histogram. The elected block does not take
-            // that path, so give it equivalent device-scope visibility here.
-            __threadfence();
+            // Every wave in the elected block must acquire device-scope
+            // visibility before reloading the global histogram. Unlike
+            // __threadfence(), this omits the unnecessary release side.
+            __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
             __syncthreads();
         }
         else

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -523,6 +523,11 @@ __global__ void radix_kernel_persistent(T const* in,
                 __atomic_store_n(reinterpret_cast<volatile unsigned int*>(&counter->pass_done),
                                  static_cast<unsigned int>(pass + 1), __ATOMIC_RELEASE);
             }
+            // Waiting blocks acquire pass_done and invalidate their cache before
+            // reloading the global histogram. The elected block does not take
+            // that path, so give it equivalent device-scope visibility here.
+            __threadfence();
+            __syncthreads();
         }
         else
         {

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -507,6 +507,9 @@ __global__ void radix_kernel_persistent(T const* in,
                 atomicAdd(histogram + i, histogram_smem[i]);
             }
         }
+        // Every wave drains its own no-return histogram atomics before
+        // thread 0 participates in the cross-block arrival counter.
+        asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
         __syncthreads();
 
         // Cross-block barrier via atomicInc + spin-wait.
@@ -520,27 +523,26 @@ __global__ void radix_kernel_persistent(T const* in,
         {
             if(threadIdx.x == 0)
             {
-                __atomic_store_n(reinterpret_cast<volatile unsigned int*>(&counter->pass_done),
-                                 static_cast<unsigned int>(pass + 1), __ATOMIC_RELEASE);
+                __hip_atomic_store(&counter->pass_done,
+                                   static_cast<unsigned int>(pass + 1),
+                                   __ATOMIC_RELEASE,
+                                   __HIP_MEMORY_SCOPE_AGENT);
             }
-            // Every wave in the elected block must acquire device-scope
-            // visibility before reloading the global histogram. Unlike
-            // __threadfence(), this omits the unnecessary release side.
-            __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
-            __syncthreads();
         }
-        else
+        if(threadIdx.x == 0)
         {
-            if(threadIdx.x == 0)
+            unsigned int target = static_cast<unsigned int>(pass + 1);
+            while(__hip_atomic_load(&counter->pass_done,
+                                    __ATOMIC_RELAXED,
+                                    __HIP_MEMORY_SCOPE_AGENT) < target)
             {
-                unsigned int target = static_cast<unsigned int>(pass + 1);
-                while(__atomic_load_n(reinterpret_cast<volatile unsigned int*>(&counter->pass_done), __ATOMIC_ACQUIRE) < target)
-                {
-                    __builtin_amdgcn_s_sleep(1);
-                }
+                __builtin_amdgcn_s_sleep(1);
             }
-            __syncthreads();
+            // One acquire/invalidate per block after relaxed polling observes
+            // the released pass value.
+            __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
         }
+        __syncthreads();
 
         // Each block independently computes scan + choose_bucket (same result, no sync needed).
         for(int i = threadIdx.x; i < num_buckets; i += blockDim.x)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`radix_kernel_persistent` uses a per-row cross-block barrier in the multi-block radix top-k path. Correct synchronization requires both producer-side completion of the global histogram updates and consumer-side visibility before the histogram is reloaded.

On gfx942/gfx950, the histogram `atomicAdd` operations are emitted as no-return VMEM atomics whose completion is tracked independently by each wave's `VM_CNT`. A CTA barrier does not drain those outstanding operations. Therefore, thread 0 could increment the cross-block arrival counter while other waves in the same block still had pending histogram updates. An acquire operation executed only by thread 0 cannot close this race.

A block may consequently reload an incomplete or stale histogram and compute a different `local_len` or `local_k` from its peers. Blocks can then execute different numbers of radix passes, allowing one block to leave the loop while another enters the next barrier. This can produce a permanent GPU wedge in the GLM-5.2 DSA indexer path and stall the complete DP-attention service while `/health` remains responsive.

This PR separates completion from visibility:

- Every wave executes `s_waitcnt vmcnt(0)` after flushing its histogram updates and before thread 0 participates in the arrival counter.
- The last block publishes `pass_done` with an agent-scope release store.
- Thread 0 in every block polls `pass_done` with relaxed loads and executes one agent-scope acquire fence after observing the target value.
- A final CTA synchronization makes the acquired visibility available before all threads reload the histogram.

This ensures that all histogram updates are complete before the barrier is released and that every block observes them before starting the next pass, without the cost of a block-wide acquire fence.

Validation on MI355X/gfx950:

- The unified thread-0 acquire-load variant reproduced 7 `STUCK` events in 292,889,600 detector row-launches.
- VM_CNT + acquire completed 311,936,000 detector row-launches with 0 `STUCK` and 0 `DIVERGE`.
- All 32 tested shapes matched `torch.topk`; the largest shape also passed 20 repeated checks.
- Performance remained effectively baseline-level, with only +0.38% latency at the production shape
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->



## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->
Performance was measured on an MI355X (gfx950) using FP32 inputs and `k=2048` across 32 shapes: rows `{1, 2, 4, 8, 16, 32, 64, 128}` and KV lengths `{256K, 512K, 1M, 2M}`. For every shape, each round consisted of 100 warm-up iterations followed by 100 timed iterations. We ran two rounds and computed the median latency of each round; the reported latency is the arithmetic mean of those two medians. Performance deltas are calculated relative to the corresponding baseline value. Each variant used an isolated worktree and JIT cache, and detector instrumentation was excluded from performance builds.

* `threadfence` uses `__threadfence() + __syncthreads()` 
* `acquire-fence` uses `__builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent") + __syncthreads()` 
* `Unified acquire-load` and `VM_CNT + acquire` are described in this PR's comments



| rows | kv_len | grid | Baseline (ms) | acquire-fence (ms, delta) | `__threadfence` (ms, delta) | Unified acquire-load (ms, delta) | VM_CNT + acquire (ms, delta) |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 262,144 | 64 | 0.0602 | 0.0652 (+8.18%) | 0.0704 (+16.82%) | **0.0598 (-0.73%)** | 0.0622 (+3.17%) |
| 2 | 262,144 | 64 | 0.0740 | 0.0873 (+18.00%) | 0.1006 (+35.98%) | 0.0739 (-0.05%) | **0.0721 (-2.58%)** |
| 4 | 262,144 | 64 | 0.0789 | 0.1214 (+53.76%) | 0.1790 (+126.77%) | **0.0788 (-0.13%)** | 0.0816 (+3.35%) |
| 8 | 262,144 | 32 | 0.0800 | 0.1184 (+48.07%) | 0.1765 (+120.62%) | **0.0795 (-0.63%)** | 0.0795 (-0.56%) |
| 16 | 262,144 | 16 | 0.0797 | 0.1185 (+48.58%) | 0.1799 (+125.60%) | 0.0794 (-0.46%) | **0.0783 (-1.83%)** |
| 32 | 262,144 | 8 | 0.0807 | 0.1351 (+67.35%) | 0.2370 (+193.55%) | **0.0793 (-1.82%)** | 0.0798 (-1.14%) |
| 64 | 262,144 | 4 | 0.1023 | 0.1509 (+47.57%) | 0.2648 (+158.89%) | 0.1022 (-0.04%) | **0.1001 (-2.12%)** |
| 128 | 262,144 | 2 | 0.1515 | 0.2006 (+32.43%) | 0.3632 (+139.73%) | **0.1510 (-0.32%)** | 0.1514 (-0.11%) |
| 1 | 524,288 | 128 | 0.0675 | 0.0767 (+13.50%) | 0.0849 (+25.75%) | **0.0666 (-1.42%)** | 0.0681 (+0.76%) |
| 2 | 524,288 | 128 | 0.0839 | 0.1118 (+33.19%) | 0.1389 (+65.54%) | 0.0825 (-1.74%) | **0.0809 (-3.65%)** |
| 4 | 524,288 | 64 | 0.0848 | 0.1167 (+37.61%) | 0.1606 (+89.43%) | **0.0839 (-1.01%)** | 0.0841 (-0.85%) |
| 8 | 524,288 | 32 | 0.0869 | 0.1245 (+43.25%) | 0.1861 (+114.16%) | **0.0856 (-1.52%)** | 0.0856 (-1.47%) |
| 16 | 524,288 | 16 | 0.0869 | 0.1275 (+46.73%) | 0.2086 (+140.17%) | 0.0860 (-1.05%) | **0.0851 (-1.99%)** |
| 32 | 524,288 | 8 | 0.1023 | 0.1529 (+49.56%) | 0.2701 (+164.11%) | 0.1020 (-0.29%) | **0.1018 (-0.49%)** |
| 64 | 524,288 | 4 | 0.1402 | 0.1775 (+26.61%) | 0.3512 (+150.55%) | 0.1400 (-0.14%) | **0.1372 (-2.11%)** |
| 128 | 524,288 | 2 | **0.2276** | 0.2697 (+18.50%) | 0.4459 (+95.94%) | 0.2283 (+0.33%) | 0.2299 (+1.02%) |
| 1 | 1,048,576 | 256 | 0.0801 | 0.1016 (+26.90%) | 0.1101 (+37.56%) | 0.0789 (-1.40%) | **0.0783 (-2.25%)** |
| 2 | 1,048,576 | 128 | 0.0684 | 0.0934 (+36.59%) | 0.1046 (+52.98%) | 0.0672 (-1.78%) | **0.0670 (-2.05%)** |
| 4 | 1,048,576 | 64 | 0.0898 | 0.1241 (+38.15%) | 0.1743 (+94.09%) | **0.0883 (-1.69%)** | 0.0920 (+2.43%) |
| 8 | 1,048,576 | 32 | 0.0929 | 0.1280 (+37.77%) | 0.1842 (+98.14%) | 0.0923 (-0.66%) | **0.0922 (-0.79%)** |
| 16 | 1,048,576 | 16 | 0.1065 | 0.1418 (+33.13%) | 0.2609 (+144.87%) | 0.1061 (-0.43%) | **0.1031 (-3.26%)** |
| 32 | 1,048,576 | 8 | 0.1339 | 0.1777 (+32.75%) | 0.3110 (+132.27%) | 0.1327 (-0.89%) | **0.1311 (-2.11%)** |
| 64 | 1,048,576 | 4 | 0.2210 | 0.2570 (+16.29%) | 0.4510 (+104.07%) | 0.2214 (+0.19%) | **0.2178 (-1.46%)** |
| 128 | 1,048,576 | 2 | **0.4151** | 0.4600 (+10.82%) | 0.6630 (+59.73%) | 0.4162 (+0.26%) | 0.4153 (+0.05%) |
| 1 | 2,097,152 | 256 | 0.0825 | 0.1038 (+25.87%) | 0.1151 (+39.55%) | 0.0813 (-1.39%) | **0.0803 (-2.67%)** |
| 2 | 2,097,152 | 128 | 0.0943 | 0.1165 (+23.54%) | 0.1320 (+40.03%) | 0.0924 (-1.95%) | **0.0902 (-4.30%)** |
| 4 | 2,097,152 | 64 | 0.0967 | 0.1286 (+32.97%) | 0.1701 (+75.83%) | 0.0955 (-1.28%) | **0.0946 (-2.19%)** |
| 8 | 2,097,152 | 32 | 0.1106 | 0.1331 (+20.36%) | 0.1896 (+71.47%) | 0.1095 (-0.96%) | **0.1080 (-2.31%)** |
| 16 | 2,097,152 | 16 | 0.1395 | 0.1662 (+19.11%) | 0.2871 (+105.78%) | 0.1383 (-0.90%) | **0.1324 (-5.13%)** |
| 32 | 2,097,152 | 8 | 0.2105 | 0.2459 (+16.82%) | 0.4516 (+114.52%) | 0.2095 (-0.47%) | **0.2053 (-2.48%)** |
| 64 | 2,097,152 | 4 | 0.4085 | 0.4487 (+9.84%) | 0.7426 (+81.78%) | 0.4085 (-0.01%) | **0.4068 (-0.41%)** |
| 128 | 2,097,152 | 2 | 0.7469 | 0.7957 (+6.54%) | 0.9634 (+28.99%) | **0.7459 (-0.13%)** | 0.7497 (+0.38%) |
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
