### PR TITLE
[HIP] Support mixed-dtype inputs in biased grouped top-k

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -213,6 +213,28 @@ def biased_grouped_topk(
         )
 
 
+def biased_grouped_topk_mixed_dtype(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    need_renorm: bool,
+    routed_scaling_factor: float = 1.0,
+) -> None:
+    return biased_grouped_topk(
+        gating_output,
+        correction_bias,
+        topk_weights,
+        topk_ids,
+        num_expert_group,
+        topk_group,
+        need_renorm,
+        routed_scaling_factor,
+    )
+
+
 # this one copied from sglang
 def biased_grouped_topk_torch(
     gating_output: torch.Tensor,

--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -308,6 +308,7 @@ __device__ void blockReduceMax(float& val, int& idx)
 }
 
 template <typename DTYPE_I,
+          typename DTYPE_B,
           typename f32vec,
           int NUM_GRP,
           bool need_renorm,
@@ -315,7 +316,7 @@ template <typename DTYPE_I,
           bool isSoftmax>
 __global__ void
 grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens, hidden_size]
-                    const DTYPE_I* __restrict__ correction_bias, // [num_expert]
+                    const DTYPE_B* __restrict__ correction_bias, // [num_expert]
                     float* __restrict__ topk_weights,            // [num_tokens, topk]
                     int* __restrict__ topk_ids,                  // [num_tokens, topk]
                     const size_t stride_gating,
@@ -360,8 +361,10 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
     f32vec* scores_vec            = reinterpret_cast<f32vec*>(scores);
     f32vec* sig_vec               = reinterpret_cast<f32vec*>(sig_scores);
     using cktype_i                = typename aiter::hip2opus<DTYPE_I>::type;
+    using cktype_b                = typename aiter::hip2opus<DTYPE_B>::type;
     static constexpr int vec_size = opus::vector_traits<f32vec>::size();
     using vec_i                   = opus::vector_t<cktype_i, vec_size>;
+    using vec_b                   = opus::vector_t<cktype_b, vec_size>;
     const int num_experts_vec     = num_experts / vec_size;
 
     if constexpr(!isSoftmax)
@@ -370,10 +373,10 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
         for(int e = threadIdx.x; e < num_experts_vec; e += blockDim.x)
         {
             vec_i tmp = reinterpret_cast<vec_i const*>(input_ptr)[e];
-            vec_i tmp2;
+            vec_b tmp2;
             f32vec tmp2_f32;
             if constexpr(isBiased)
-                tmp2 = reinterpret_cast<vec_i const*>(correction_bias)[e];
+                tmp2 = reinterpret_cast<vec_b const*>(correction_bias)[e];
             f32vec gating;
             f32vec sig;
 #pragma unroll
@@ -1145,33 +1148,43 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
         }                                                                                          \
     }
 
-#define LAUNCHER_biased_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)      \
-    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(gating_output.dtype(), "biased_grouped_topk_kernel", [&] {  \
-        hipLaunchKernelGGL(                                                                        \
-            (aiter::                                                                               \
-                 grouped_topk_kernel<scalar_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>), \
-            dim3(grid),                                                                            \
-            dim3(block),                                                                           \
-            shared_mem_size,                                                                       \
-            stream,                                                                                \
-            reinterpret_cast<scalar_t*>(gating_output.data_ptr()),                                                    \
-            reinterpret_cast<scalar_t*>(correction_bias.data_ptr()),                                                  \
-            reinterpret_cast<float*>(topk_weights.data_ptr()),                                                        \
-            reinterpret_cast<int*>(topk_ids.data_ptr()),                                                              \
-            stride_gating,                                                                         \
-            stride_tk,                                                                             \
-            num_experts,                                                                           \
-            topk,                                                                                  \
-            topk_grp,                                                                              \
-            num_tokens,                                                                            \
-            routed_scaling_factor);                                                                \
+#define LAUNCHER_biased_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)       \
+    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(gating_output.dtype(), "biased_grouped_topk_kernel", [&] {   \
+        using input_t = scalar_t;                                                                   \
+        VLLM_DISPATCH_FLOATING_TYPES_rmTorch(                                                        \
+            correction_bias.dtype(), "biased_grouped_topk_bias", [&] {                              \
+                using bias_t = scalar_t;                                                            \
+                hipLaunchKernelGGL(                                                                 \
+                    (aiter::grouped_topk_kernel<input_t,                                             \
+                                                       bias_t,                                      \
+                                                       VEC_F,                                       \
+                                                       NUM_GRP,                                     \
+                                                       need_renorm,                                 \
+                                                       isBiased,                                    \
+                                                       isSoftmax>),                                 \
+                    dim3(grid),                                                                     \
+                    dim3(block),                                                                    \
+                    shared_mem_size,                                                                \
+                    stream,                                                                         \
+                    reinterpret_cast<input_t*>(gating_output.data_ptr()),                            \
+                    reinterpret_cast<bias_t*>(correction_bias.data_ptr()),                           \
+                    reinterpret_cast<float*>(topk_weights.data_ptr()),                               \
+                    reinterpret_cast<int*>(topk_ids.data_ptr()),                                     \
+                    stride_gating,                                                                  \
+                    stride_tk,                                                                      \
+                    num_experts,                                                                    \
+                    topk,                                                                           \
+                    topk_grp,                                                                       \
+                    num_tokens,                                                                     \
+                    routed_scaling_factor);                                                         \
+            });                                                                                     \
     });
 
 #define LAUNCHER_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)             \
     VLLM_DISPATCH_FLOATING_TYPES_rmTorch(gating_output.dtype(), "grouped_topk_kernel", [&] {         \
         hipLaunchKernelGGL(                                                                        \
             (aiter::                                                                               \
-                 grouped_topk_kernel<scalar_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>), \
+                 grouped_topk_kernel<scalar_t, scalar_t, VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax>), \
             dim3(grid),                                                                            \
             dim3(block),                                                                           \
             shared_mem_size,                                                                       \
@@ -1242,7 +1255,8 @@ void biased_grouped_topk(const aiter_tensor_t& gating_output,   // [num_tokens, 
     // TODO: expand usage in the future
     // bool use_opt_sort = false;
     bool use_opt_sort = (topk == 8) && (num_expert_group == 8) && (num_experts == 256) &&
-                        (topk_grp == 4) && (isBiased == true) && (get_warp_size_func() == 64);
+                        (topk_grp == 4) && (isBiased == true) && (get_warp_size_func() == 64) &&
+                        (gating_output.dtype() == correction_bias.dtype());
 
     dim3 grid(num_tokens);
     dim3 block(get_warp_size_func());

--- a/op_tests/test_moeTopkSoftmax.py
+++ b/op_tests/test_moeTopkSoftmax.py
@@ -271,11 +271,14 @@ def test_biased_grouped_topk(
     num_iters=101,
     num_warmup=2,
     gating_output=None,
+    correction_bias_dtype=None,
 ):
     ret = {}
     if gating_output is None:
         gating_output = torch.randn((token, expert), dtype=dtype)
-    correction_bias = torch.randn((expert,), dtype=dtype)
+    if correction_bias_dtype is None:
+        correction_bias_dtype = dtype
+    correction_bias = torch.randn((expert,), dtype=correction_bias_dtype)
 
     (w_ref, id_ref, score_ref), us_ref = run_perftest(
         aiter.biased_grouped_topk_torch,
@@ -292,8 +295,11 @@ def test_biased_grouped_topk(
     w_ref = w_ref * scale_factor
     w_aiter = torch.empty_strided((token, topk), (topk + 10, 1), dtype=dtypes.fp32)
     id_aiter = torch.empty_strided((token, topk), (topk + 10, 1), dtype=dtypes.i32)
+    topk_op = aiter.biased_grouped_topk_hip
+    if gating_output.dtype != correction_bias.dtype:
+        topk_op = aiter.biased_grouped_topk_mixed_dtype
     _, us_aiter = run_perftest(
-        aiter.biased_grouped_topk_hip,
+        topk_op,
         gating_output,
         correction_bias,
         w_aiter,
@@ -717,6 +723,7 @@ for token in args.token:
         True,  # need_renorm
         dtypes.bf16,
         gating_output=gating_output,
+        correction_bias_dtype=dtypes.fp32,
         num_iters=args.iters,
         num_warmup=args.warmup,
     )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Kimi-K3 produces BF16 router logits while keeping the correction bias in FP32. AITER’s existing biased grouped top-k kernel assumes both tensors have the same dtype, requiring vLLM to convert the bias to BF16 before routing.

This change independently dispatches the logits and bias types, allowing the kernel to consume BF16 logits with FP32 bias directly. It preserves bias precision and removes the separate dtype-conversion operation from the routing path.

## Technical Details

## Test Plan
Extended `op_tests/test_moeTopkSoftmax.py` to cover mixed-dtype biased grouped top-k.

## Test Result

All explicitly reported mixed-dtype cases from 1 through 65,536 tokens passed the weight and expert-index correctness checks.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
