### PR TITLE
[CI] ci: centralize docker login config

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -117,7 +117,11 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') }}
 
 jobs:
+  ci_config:
+    uses: ./.github/workflows/ci-config.yaml
+
   build_whl_package:
+    needs: ci_config
     runs-on: ${{ inputs.runner || github.event.inputs.runner }}
     permissions:
       id-token: write
@@ -143,8 +147,8 @@ jobs:
       USE_MANYLINUX: ${{ inputs.use_manylinux || github.event.inputs.use_manylinux || (startsWith(matrix.docker_image, 'pytorch/manylinux') && 'true') || 'false' }}
       TORCH_PIN: ${{ inputs.torch_pin || '' }}
       TORCH_INDEX_URL: ${{ inputs.torch_index_url || '' }}
-      DOCKER_PASSWORD_SECRET: ${{ github.event_name == 'workflow_dispatch' && 'DOCKER_PASSWORD' || '' }}
-      DOCKER_USERNAME: ${{ github.event_name == 'workflow_dispatch' && 'rocmshared' || '' }}
+      DOCKER_USERNAME_SECRET: ${{ github.event_name == 'workflow_dispatch' && needs.ci_config.outputs.docker_username_secret || '' }}
+      DOCKER_PASSWORD_SECRET: ${{ github.event_name == 'workflow_dispatch' && needs.ci_config.outputs.docker_password_secret || '' }}
 
     steps:
       - name: Checkout aiter repo
@@ -174,10 +178,17 @@ jobs:
           git submodule update --init --recursive --depth 1 --jobs 4
 
       - name: Docker login
-        if: ${{ matrix.build_enabled && env.DOCKER_PASSWORD_SECRET != '' }}
+        if: ${{ matrix.build_enabled && env.DOCKER_USERNAME_SECRET != '' && env.DOCKER_PASSWORD_SECRET != '' }}
+        env:
+          DOCKER_USERNAME: ${{ secrets[env.DOCKER_USERNAME_SECRET] }}
+          DOCKER_PASSWORD: ${{ secrets[env.DOCKER_PASSWORD_SECRET] }}
         run: |
-          set -ex
-          echo "${{ secrets[env.DOCKER_PASSWORD_SECRET] }}" | docker login -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+          set -euo pipefail
+          if [ -z "${DOCKER_USERNAME}" ] || [ -z "${DOCKER_PASSWORD}" ]; then
+            echo "::error::Missing Docker Hub credentials"
+            exit 1
+          fi
+          echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 
       - name: Generate version with date stamp
         if: ${{ matrix.build_enabled && env.ADD_DATE_STAMP == 'true' }}

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -158,10 +158,11 @@ jobs:
       - name: Docker login
         if: ${{ matrix.build_enabled && (!github.event.pull_request || !github.event.pull_request.head.repo.fork) }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi
@@ -636,10 +637,11 @@ jobs:
       - name: Docker login
         if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi
@@ -916,10 +918,11 @@ jobs:
       - name: Docker login
         if: ${{ !github.event.pull_request || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -27,6 +27,15 @@ env:
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
 
 jobs:
+  ci_config:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      (contains(github.event.pull_request.labels.*.name, 'ci:atom') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:atom_full') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:all')))
+    uses: ./.github/workflows/ci-config.yaml
+
   check-signal:
     if: >-
       github.event_name != 'pull_request' ||
@@ -195,7 +204,7 @@ jobs:
       (contains(github.event.pull_request.labels.*.name, 'ci:atom') ||
       contains(github.event.pull_request.labels.*.name, 'ci:atom_full') ||
       contains(github.event.pull_request.labels.*.name, 'ci:all')))
-    needs: [check-signal, load-atom-models]
+    needs: [check-signal, load-atom-models, ci_config]
     name: Accuracy (${{ matrix.display_name }}, ${{ matrix.runner }})
     strategy:
       fail-fast: false
@@ -212,7 +221,10 @@ jobs:
           ref: ${{ env.ATOM_BRANCH }}
 
       - name: Docker login
-        run: docker login -u rocmshared -p ${{ secrets.DOCKER_PASSWORD }} || true
+        env:
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
+        run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true
 
       - name: Download the ATOM base image
         if: matrix.run_on_pr == true || github.event_name != 'pull_request'

--- a/.github/workflows/ci-config.yaml
+++ b/.github/workflows/ci-config.yaml
@@ -12,6 +12,12 @@ on:
       triton_wheel_artifact_name:
         description: Shared Triton wheel artifact name.
         value: ${{ jobs.config.outputs.triton_wheel_artifact_name }}
+      docker_username_secret:
+        description: Secret name containing the Docker Hub username used by CI jobs.
+        value: ${{ jobs.config.outputs.docker_username_secret }}
+      docker_password_secret:
+        description: Secret name containing the Docker Hub password used by CI jobs.
+        value: ${{ jobs.config.outputs.docker_password_secret }}
 
 jobs:
   config:
@@ -20,9 +26,13 @@ jobs:
       pytorch_py310_image: ${{ steps.values.outputs.pytorch_py310_image }}
       pytorch_py312_image: ${{ steps.values.outputs.pytorch_py312_image }}
       triton_wheel_artifact_name: ${{ steps.values.outputs.triton_wheel_artifact_name }}
+      docker_username_secret: ${{ steps.values.outputs.docker_username_secret }}
+      docker_password_secret: ${{ steps.values.outputs.docker_password_secret }}
     steps:
       - id: values
         run: |
           echo "pytorch_py310_image=rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0" >> "${GITHUB_OUTPUT}"
           echo "pytorch_py312_image=rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0" >> "${GITHUB_OUTPUT}"
           echo "triton_wheel_artifact_name=triton_wheelhouse" >> "${GITHUB_OUTPUT}"
+          echo "docker_username_secret=DOCKERHUB_USERNAME" >> "${GITHUB_OUTPUT}"
+          echo "docker_password_secret=DOCKERHUB_PASSWORD" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ffm-bringup.yaml
+++ b/.github/workflows/ffm-bringup.yaml
@@ -38,6 +38,16 @@ env:
   FFM_TRITON_COMMIT: 6cf030fe7bffce12a5712e20fb507a51d5123f10
 
 jobs:
+  ci_config:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'ci:gfx1250-ffm-triton' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    uses: ./.github/workflows/ci-config.yaml
+
   ffm-triton-tests:
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -46,6 +56,7 @@ jobs:
         github.event.label.name == 'ci:gfx1250-ffm-triton' &&
         github.event.pull_request.head.repo.full_name == github.repository
       )
+    needs: ci_config
     name: FFM Triton Tests (${{ inputs.runner || 'linux-aiter-do-mi350x-1' }}) / Shard ${{ matrix.shard }}
     runs-on: ${{ inputs.runner || 'linux-aiter-do-mi350x-1' }}
     timeout-minutes: 7200
@@ -79,17 +90,17 @@ jobs:
 
       - name: Docker login
         env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD_SECRET: ${{ needs.ci_config.outputs.docker_password_secret }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           set -euo pipefail
           if [ -z "${DOCKER_PASSWORD}" ]; then
-            echo "::error::Missing DOCKER_PASSWORD secret required to pull ${FFM_IMAGE}"
+            echo "::error::Missing ${DOCKER_PASSWORD_SECRET} secret required to pull ${FFM_IMAGE}"
             exit 1
           fi
-          DOCKER_USER="${DOCKERHUB_USERNAME:-rocmshared}"
           for attempt in 1 2 3; do
-            if echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USER}" --password-stdin; then
+            if echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi

--- a/.github/workflows/flash_attention_integration.yaml
+++ b/.github/workflows/flash_attention_integration.yaml
@@ -133,10 +133,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi
@@ -626,10 +627,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi

--- a/.github/workflows/opus-test.yaml
+++ b/.github/workflows/opus-test.yaml
@@ -64,10 +64,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -20,6 +20,14 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  ci_config:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      (contains(github.event.pull_request.labels.*.name, 'ci:sglang') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:all')))
+    uses: ./.github/workflows/ci-config.yaml
+
   check-signal:
     if: >-
       github.event_name != 'pull_request' ||
@@ -61,7 +69,7 @@ jobs:
   sglang:
     if: needs.select-sglang-tests.outputs.has_tests == 'true'
     name: Sglang ${{ matrix.model }} ${{ matrix.test_type }} (8 GPU)
-    needs: [check-signal, select-sglang-tests]
+    needs: [check-signal, select-sglang-tests, ci_config]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -93,10 +101,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi

--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -182,10 +182,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi
@@ -322,10 +323,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi

--- a/.github/workflows/vllm-disagg-ci-smoke-workflow.yaml
+++ b/.github/workflows/vllm-disagg-ci-smoke-workflow.yaml
@@ -46,12 +46,20 @@ env:
   AITER_WHEEL_ARTIFACT_NAME: aiter-vllm-disagg-wheel-${{ github.run_id }}
 
 jobs:
+  ci_config:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'ci:vllm-di'))
+    uses: ./.github/workflows/ci-config.yaml
+
   build_aiter_wheel:
     name: Build gfx950 Aiter overlay wheels
     if: >-
       github.event_name != 'pull_request' ||
       (github.event.pull_request.draft == false &&
       contains(github.event.pull_request.labels.*.name, 'ci:vllm-di'))
+    needs: ci_config
     runs-on: build-only-aiter
     steps:
       - name: Checkout AITER
@@ -66,10 +74,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi

--- a/.github/workflows/vllm_benchmark.yaml
+++ b/.github/workflows/vllm_benchmark.yaml
@@ -23,6 +23,14 @@ env:
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
+  ci_config:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      (contains(github.event.pull_request.labels.*.name, 'ci:vllm') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:all')))
+    uses: ./.github/workflows/ci-config.yaml
+
   check-signal:
     if: >-
       github.event_name != 'pull_request' ||
@@ -47,7 +55,7 @@ jobs:
       (github.event.pull_request.draft == false &&
       (contains(github.event.pull_request.labels.*.name, 'ci:vllm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:all')))
-    needs: check-signal
+    needs: [check-signal, ci_config]
     runs-on: build-only-aiter
     steps:
       - name: Checkout aiter repo
@@ -65,10 +73,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi
@@ -123,7 +132,7 @@ jobs:
       (github.event.pull_request.draft == false &&
       (contains(github.event.pull_request.labels.*.name, 'ci:vllm') ||
       contains(github.event.pull_request.labels.*.name, 'ci:all')))
-    needs: build_aiter_wheel
+    needs: [build_aiter_wheel, ci_config]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -180,10 +189,11 @@ jobs:
       - name: Docker login
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets[needs.ci_config.outputs.docker_username_secret] }}
+          DOCKER_PASSWORD: ${{ secrets[needs.ci_config.outputs.docker_password_secret] }}
         run: |
           for attempt in 1 2 3; do
-            if echo "$DOCKER_PASSWORD" | docker login -u rocmshared --password-stdin; then
+            if echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; then
               echo "Docker login succeeded on attempt ${attempt}"
               exit 0
             fi


### PR DESCRIPTION
## Summary
- add shared Docker Hub credential secret-name outputs to ci-config
- use DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD secrets for Docker login in CI workflows
- keep actual Docker Hub username and password values inside GitHub Secrets; only secret names are present in workflow files
- wire ci_config into Docker-login workflows that did not already consume it

## Validation
- /tmp/actionlint-1.7.7/actionlint .github/workflows/ci-config.yaml .github/workflows/aiter-test.yaml .github/workflows/opus-test.yaml .github/workflows/triton-test.yaml .github/workflows/flash_attention_integration.yaml .github/workflows/vllm_benchmark.yaml .github/workflows/sglang_downstream.yaml .github/workflows/vllm-disagg-ci-smoke-workflow.yaml .github/workflows/atom-test.yaml .github/workflows/ffm-bringup.yaml .github/workflows/aiter-release.yaml
- python3 YAML parse for the modified workflows
- git diff --check