### PR TITLE
[HIP] [GFX950]Fix OPUS MHA TypeError Issue

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -352,7 +352,6 @@ def gen_fmha_fwd_bf16_opus_fwd_fake(
     "module_fmha_fwd_bf16_opus",
     fc_name="fmha_fwd_bf16_opus_fwd",
     gen_fake=gen_fmha_fwd_bf16_opus_fwd_fake,
-    develop=True,
 )
 def _fmha_fwd_bf16_opus_fwd(
     q: Tensor,

--- a/csrc/include/torch/fmha_fwd_bf16_opus.h
+++ b/csrc/include/torch/fmha_fwd_bf16_opus.h
@@ -9,7 +9,7 @@
 // This replaces the former per-hd `fmha_fwd_hd128_bf16_opus_fwd`. The kernel/launch
 // logic for D=128 is unchanged (only moved under this shared entry point).
 #pragma once
-#include "aiter_tensor.h"
+#include <torch/extension.h>
 #include <optional>
 
 // Dense (batch) & varlen (group) GQA/MHA scaled-dot-product attention, bf16, gfx950.
@@ -31,15 +31,15 @@
 //   seqstart_q_pad / seqstart_k_pad  : cumulative PHYSICAL row offsets (KV-padding variant;
 //                                      equal to the non-pad arrays when there is no padding)
 //   max_seqlen_q / max_seqlen_k      : upper bounds driving the grid (group mode only)
-void fmha_fwd_bf16_opus_fwd(aiter_tensor_t& q,
-                            aiter_tensor_t& k,
-                            aiter_tensor_t& v,
-                            aiter_tensor_t& out,
+void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
+                            at::Tensor& k,
+                            at::Tensor& v,
+                            at::Tensor& out,
                             bool causal,
                             float softmax_scale,
-                            std::optional<aiter_tensor_t> seqstart_q     = std::nullopt,
-                            std::optional<aiter_tensor_t> seqstart_k     = std::nullopt,
-                            std::optional<aiter_tensor_t> seqstart_q_pad = std::nullopt,
-                            std::optional<aiter_tensor_t> seqstart_k_pad = std::nullopt,
+                            std::optional<at::Tensor> seqstart_q     = std::nullopt,
+                            std::optional<at::Tensor> seqstart_k     = std::nullopt,
+                            std::optional<at::Tensor> seqstart_q_pad = std::nullopt,
+                            std::optional<at::Tensor> seqstart_k_pad = std::nullopt,
                             int max_seqlen_q = 0,
                             int max_seqlen_k = 0);

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -89,7 +89,7 @@ void launch_d128(at::Tensor& q,
     kargs.softmax_scale = softmax_scale;  // kernel applies scale * log2(e) to Q
 
     HipDeviceGuard guard(q.device().index());
-    const hipStream_t stream = at::hip::getCurrentHIPStream(q.device().index());
+    const hipStream_t stream = at::hip::getCurrentHIPStream();
 
     using TraitsCausal    = opus_gqa_traits<32, 64, 128, 8, true>;
     using TraitsNonCausal = opus_gqa_traits<32, 64, 128, 8, false>;
@@ -147,7 +147,7 @@ void launch_d192_v128(at::Tensor& q,
     kargs.softmax_scale = softmax_scale;
 
     HipDeviceGuard guard(q.device().index());
-    const hipStream_t stream = at::hip::getCurrentHIPStream(q.device().index());
+    const hipStream_t stream = at::hip::getCurrentHIPStream();
 
     int B, N, N_KV, H, H_KV;
     int num_q_blocks;   // for grid / merge decision

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -14,11 +14,10 @@
 #define FMHA_FWD_HD192_V128_BF16_OPUS_IMPL
 #include "fmha_fwd_hd192_v128_bf16_opus.h"
 
-#include "fmha_fwd_bf16_opus.h"
+#include "torch/fmha_fwd_bf16_opus.h"
 #include "aiter_hip_common.h"
-#include "aiter_stream.h"
-#include "aiter_tensor.h"
 
+#include <ATen/hip/HIPContext.h>
 #include <cmath>
 #include <type_traits>
 
@@ -26,10 +25,10 @@ namespace {
 
 // ─── D_QK=128 / D_V=128 (symmetric) launch — logic unchanged from the original
 //     fmha_fwd_hd128_bf16_opus_fwd, only moved under the shared entry point. ───
-void launch_d128(aiter_tensor_t& q,
-                 aiter_tensor_t& k,
-                 aiter_tensor_t& v,
-                 aiter_tensor_t& out,
+void launch_d128(at::Tensor& q,
+                 at::Tensor& k,
+                 at::Tensor& v,
+                 at::Tensor& out,
                  bool causal,
                  float softmax_scale)
 {
@@ -89,8 +88,8 @@ void launch_d128(aiter_tensor_t& q,
     }
     kargs.softmax_scale = softmax_scale;  // kernel applies scale * log2(e) to Q
 
-    HipDeviceGuard guard(q.device_id);
-    const hipStream_t stream = aiter::getCurrentHIPStream();
+    HipDeviceGuard guard(q.device().index());
+    const hipStream_t stream = at::hip::getCurrentHIPStream(q.device().index());
 
     using TraitsCausal    = opus_gqa_traits<32, 64, 128, 8, true>;
     using TraitsNonCausal = opus_gqa_traits<32, 64, 128, 8, false>;
@@ -113,16 +112,16 @@ void launch_d128(aiter_tensor_t& q,
 }
 
 // ─── D_QK=192 / D_V=128 (asymmetric) launch — batch + group (varlen). ───
-void launch_d192_v128(aiter_tensor_t& q,
-                      aiter_tensor_t& k,
-                      aiter_tensor_t& v,
-                      aiter_tensor_t& out,
+void launch_d192_v128(at::Tensor& q,
+                      at::Tensor& k,
+                      at::Tensor& v,
+                      at::Tensor& out,
                       bool causal,
                       float softmax_scale,
-                      std::optional<aiter_tensor_t>& seqstart_q,
-                      std::optional<aiter_tensor_t>& seqstart_k,
-                      std::optional<aiter_tensor_t>& seqstart_q_pad,
-                      std::optional<aiter_tensor_t>& seqstart_k_pad,
+                      std::optional<at::Tensor>& seqstart_q,
+                      std::optional<at::Tensor>& seqstart_k,
+                      std::optional<at::Tensor>& seqstart_q_pad,
+                      std::optional<at::Tensor>& seqstart_k_pad,
                       int max_seqlen_q,
                       int max_seqlen_k)
 {
@@ -147,8 +146,8 @@ void launch_d192_v128(aiter_tensor_t& q,
     // Plumbed into the kernel via kargs; the kernel folds in log2(e) for its exp2 softmax.
     kargs.softmax_scale = softmax_scale;
 
-    HipDeviceGuard guard(q.device_id);
-    const hipStream_t stream = aiter::getCurrentHIPStream();
+    HipDeviceGuard guard(q.device().index());
+    const hipStream_t stream = at::hip::getCurrentHIPStream(q.device().index());
 
     int B, N, N_KV, H, H_KV;
     int num_q_blocks;   // for grid / merge decision
@@ -181,8 +180,8 @@ void launch_d192_v128(aiter_tensor_t& q,
         // Validate the cumulative-length arrays before reinterpreting their storage as
         // int32: a wrong dtype (e.g. int64), non-contiguous layout, or wrong length would
         // otherwise silently corrupt the per-group offsets or fault.
-        auto check_seqstart = [&](const aiter_tensor_t& s, const char* name) {
-            AITER_CHECK(s.dtype() == AITER_DTYPE_i32, name, " must be int32");
+        auto check_seqstart = [&](const at::Tensor& s, const char* name) {
+            AITER_CHECK(s.scalar_type() == at::kInt, name, " must be int32");
             AITER_CHECK(s.dim() == 1, name, " must be 1-D");
             AITER_CHECK(s.is_contiguous(), name, " must be contiguous");
             AITER_CHECK(static_cast<int>(s.numel()) == B + 1, name, " length must be num_groups+1");
@@ -294,22 +293,25 @@ void launch_d192_v128(aiter_tensor_t& q,
 
 } // namespace
 
-void fmha_fwd_bf16_opus_fwd(aiter_tensor_t& q,
-                            aiter_tensor_t& k,
-                            aiter_tensor_t& v,
-                            aiter_tensor_t& out,
+void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
+                            at::Tensor& k,
+                            at::Tensor& v,
+                            at::Tensor& out,
                             bool causal,
                             float softmax_scale,
-                            std::optional<aiter_tensor_t> seqstart_q,
-                            std::optional<aiter_tensor_t> seqstart_k,
-                            std::optional<aiter_tensor_t> seqstart_q_pad,
-                            std::optional<aiter_tensor_t> seqstart_k_pad,
+                            std::optional<at::Tensor> seqstart_q,
+                            std::optional<at::Tensor> seqstart_k,
+                            std::optional<at::Tensor> seqstart_q_pad,
+                            std::optional<at::Tensor> seqstart_k_pad,
                             int max_seqlen_q,
                             int max_seqlen_k)
 {
-    AITER_CHECK(q.dtype() == k.dtype() && q.dtype() == v.dtype() && q.dtype() == out.dtype(),
+    AITER_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda() && out.is_cuda(),
+                "q/k/v/out must be GPU tensors");
+    AITER_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type() &&
+                    q.scalar_type() == out.scalar_type(),
                 "q/k/v/out must share dtype");
-    AITER_CHECK(q.dtype() == AITER_DTYPE_bf16, "fmha_fwd_bf16_opus_fwd only supports bf16");
+    AITER_CHECK(q.scalar_type() == at::kBFloat16, "fmha_fwd_bf16_opus_fwd only supports bf16");
 
     const int D_QK = static_cast<int>(q.size(-1));
     const int D_V  = static_cast<int>(v.size(-1));

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -32,10 +32,10 @@ void launch_d128(at::Tensor& q,
                  bool causal,
                  float softmax_scale)
 {
-    AITER_CHECK(q.dim() == 4, "q must be 4-D [B, N, H, D], got ndim=", q.dim());
-    AITER_CHECK(k.dim() == 4, "k must be 4-D [B, N, H_KV, D], got ndim=", k.dim());
-    AITER_CHECK(v.dim() == 4, "v must be 4-D [B, N, H_KV, D], got ndim=", v.dim());
-    AITER_CHECK(out.dim() == 4, "out must be 4-D [B, N, H, D], got ndim=", out.dim());
+    TORCH_CHECK(q.dim() == 4, "q must be 4-D [B, N, H, D], got ndim=", q.dim());
+    TORCH_CHECK(k.dim() == 4, "k must be 4-D [B, N, H_KV, D], got ndim=", k.dim());
+    TORCH_CHECK(v.dim() == 4, "v must be 4-D [B, N, H_KV, D], got ndim=", v.dim());
+    TORCH_CHECK(out.dim() == 4, "out must be 4-D [B, N, H, D], got ndim=", out.dim());
 
     const int B    = static_cast<int>(q.size(0));
     const int N    = static_cast<int>(q.size(1));      // seqlen_q
@@ -44,22 +44,22 @@ void launch_d128(at::Tensor& q,
     const int H_KV = static_cast<int>(k.size(2));
     const int N_KV = static_cast<int>(k.size(1));      // seqlen_kv (cross-attn: may != N)
 
-    AITER_CHECK(D == 128, "launch_d128 only compiles D=128, got D=", D);
-    AITER_CHECK(k.size(0) == B && v.size(0) == B, "k/v batch must equal q batch B");
-    AITER_CHECK(v.size(1) == N_KV, "k/v seqlen must match (v seqlen != k seqlen)");
-    AITER_CHECK(v.size(2) == H_KV, "k/v must share H_KV");
-    AITER_CHECK(k.size(3) == D && v.size(3) == D, "k/v head dim must equal D=128");
-    AITER_CHECK(H_KV > 0 && (H % H_KV) == 0, "H must be divisible by H_KV (GQA group)");
-    AITER_CHECK(out.size(0) == B && out.size(1) == N && out.size(2) == H && out.size(3) == D,
+    TORCH_CHECK(D == 128, "launch_d128 only compiles D=128, got D=", D);
+    TORCH_CHECK(k.size(0) == B && v.size(0) == B, "k/v batch must equal q batch B");
+    TORCH_CHECK(v.size(1) == N_KV, "k/v seqlen must match (v seqlen != k seqlen)");
+    TORCH_CHECK(v.size(2) == H_KV, "k/v must share H_KV");
+    TORCH_CHECK(k.size(3) == D && v.size(3) == D, "k/v head dim must equal D=128");
+    TORCH_CHECK(H_KV > 0 && (H % H_KV) == 0, "H must be divisible by H_KV (GQA group)");
+    TORCH_CHECK(out.size(0) == B && out.size(1) == N && out.size(2) == H && out.size(3) == D,
                 "out shape must match q [B, N, H, D]");
 
-    AITER_CHECK(q.stride(3) == 1 && k.stride(3) == 1 && v.stride(3) == 1 && out.stride(3) == 1,
+    TORCH_CHECK(q.stride(3) == 1 && k.stride(3) == 1 && v.stride(3) == 1 && out.stride(3) == 1,
                 "q/k/v/out must be contiguous along the head dim D");
 
     // 32-bit KV buffer-offset guard: extent >= 2^32 wraps the async-load soffset (silent
     // wrong output), reject instead.
     const long long kv_slice_bytes = (long long)N_KV * (long long)k.stride(1) * 2LL;  // bf16
-    AITER_CHECK(kv_slice_bytes < (1LL << 32),
+    TORCH_CHECK(kv_slice_bytes < (1LL << 32),
                 "OPUS D=128: KV byte extent ", kv_slice_bytes,
                 " reaches the 32-bit buffer-offset limit (2^32); reduce seqlen_kv or use another backend");
 
@@ -156,35 +156,37 @@ void launch_d192_v128(at::Tensor& q,
     if (is_group) {
         // Packed / varlen: q [total_q, H, D_QK], k [total_k, H_KV, D_QK],
         // v [total_k, H_KV, D_V], out [total_q, H, D_V]. group = num sequences.
-        AITER_CHECK(q.dim() == 3 && k.dim() == 3 && v.dim() == 3 && out.dim() == 3,
+        TORCH_CHECK(q.dim() == 3 && k.dim() == 3 && v.dim() == 3 && out.dim() == 3,
                     "group mode expects packed 3-D q/k/v/out [total, H, D]");
-        AITER_CHECK(static_cast<int>(q.size(2)) == D_QK && static_cast<int>(k.size(2)) == D_QK,
+        TORCH_CHECK(static_cast<int>(q.size(2)) == D_QK && static_cast<int>(k.size(2)) == D_QK,
                     "group mode q/k head dim must be 192");
-        AITER_CHECK(static_cast<int>(v.size(2)) == D_V && static_cast<int>(out.size(2)) == D_V,
+        TORCH_CHECK(static_cast<int>(v.size(2)) == D_V && static_cast<int>(out.size(2)) == D_V,
                     "group mode v/out head dim must be 128");
-        AITER_CHECK(seqstart_q.has_value() && seqstart_k.has_value(),
+        TORCH_CHECK(seqstart_q.has_value() && seqstart_k.has_value(),
                     "group mode requires seqstart_q and seqstart_k");
         H    = static_cast<int>(q.size(1));
         H_KV = static_cast<int>(k.size(1));
-        AITER_CHECK(static_cast<int>(v.size(1)) == H_KV, "group mode k/v must share H_KV");
-        AITER_CHECK(static_cast<int>(out.size(0)) == static_cast<int>(q.size(0)) &&
+        TORCH_CHECK(static_cast<int>(v.size(1)) == H_KV, "group mode k/v must share H_KV");
+        TORCH_CHECK(static_cast<int>(out.size(0)) == static_cast<int>(q.size(0)) &&
                     static_cast<int>(out.size(1)) == H,
                     "group mode out must be [total_q, H, D_V]");
         B    = static_cast<int>(seqstart_q->numel()) - 1;   // num groups
-        AITER_CHECK(B > 0, "group mode requires seqstart_q length >= 2");
-        AITER_CHECK(max_seqlen_q > 0 && max_seqlen_k > 0,
+        TORCH_CHECK(B > 0, "group mode requires seqstart_q length >= 2");
+        TORCH_CHECK(max_seqlen_q > 0 && max_seqlen_k > 0,
                     "group mode requires max_seqlen_q / max_seqlen_k > 0");
         N    = max_seqlen_q;
         N_KV = max_seqlen_k;
 
         // Validate the cumulative-length arrays before reinterpreting their storage as
-        // int32: a wrong dtype (e.g. int64), non-contiguous layout, or wrong length would
-        // otherwise silently corrupt the per-group offsets or fault.
+        // int32: a wrong dtype (e.g. int64), non-contiguous layout, wrong length or a
+        // host/foreign-device buffer would otherwise silently corrupt the per-group
+        // offsets, or hand the kernel a pointer it cannot dereference.
         auto check_seqstart = [&](const at::Tensor& s, const char* name) {
-            AITER_CHECK(s.scalar_type() == at::kInt, name, " must be int32");
-            AITER_CHECK(s.dim() == 1, name, " must be 1-D");
-            AITER_CHECK(s.is_contiguous(), name, " must be contiguous");
-            AITER_CHECK(static_cast<int>(s.numel()) == B + 1, name, " length must be num_groups+1");
+            TORCH_CHECK(s.device() == q.device(), name, " must be on the same device as q");
+            TORCH_CHECK(s.scalar_type() == at::kInt, name, " must be int32");
+            TORCH_CHECK(s.dim() == 1, name, " must be 1-D");
+            TORCH_CHECK(s.is_contiguous(), name, " must be contiguous");
+            TORCH_CHECK(static_cast<int>(s.numel()) == B + 1, name, " length must be num_groups+1");
         };
         check_seqstart(*seqstart_q, "seqstart_q");
         check_seqstart(*seqstart_k, "seqstart_k");
@@ -208,20 +210,20 @@ void launch_d192_v128(at::Tensor& q,
         num_q_blocks = ceil_div(N, Q_BLOCK);          // nqb_cap from max_seqlen_q
     } else {
         // Dense batch: q/k/v/out 4-D [B, N, H, D]. Cross-attention allowed (N != N_KV).
-        AITER_CHECK(q.dim() == 4 && k.dim() == 4 && v.dim() == 4 && out.dim() == 4,
+        TORCH_CHECK(q.dim() == 4 && k.dim() == 4 && v.dim() == 4 && out.dim() == 4,
                     "batch mode expects 4-D q/k/v/out [B, N, H, D]");
         B    = static_cast<int>(q.size(0));
         N    = static_cast<int>(q.size(1));
         H    = static_cast<int>(q.size(2));
         H_KV = static_cast<int>(k.size(2));
         N_KV = static_cast<int>(k.size(1));
-        AITER_CHECK(v.size(0) == B && v.size(1) == N_KV && v.size(2) == H_KV,
+        TORCH_CHECK(v.size(0) == B && v.size(1) == N_KV && v.size(2) == H_KV,
                     "k/v must share [B, N_KV, H_KV]");
-        AITER_CHECK(static_cast<int>(q.size(3)) == D_QK && static_cast<int>(k.size(3)) == D_QK,
+        TORCH_CHECK(static_cast<int>(q.size(3)) == D_QK && static_cast<int>(k.size(3)) == D_QK,
                     "q/k head dim must be 192");
-        AITER_CHECK(static_cast<int>(v.size(3)) == D_V && static_cast<int>(out.size(3)) == D_V,
+        TORCH_CHECK(static_cast<int>(v.size(3)) == D_V && static_cast<int>(out.size(3)) == D_V,
                     "v/out head dim must be 128");
-        AITER_CHECK(out.size(0) == B && out.size(1) == N && out.size(2) == H,
+        TORCH_CHECK(out.size(0) == B && out.size(1) == N && out.size(2) == H,
                     "out shape must match q [B, N, H, D_V]");
 
         kargs.stride_q_b = static_cast<int>(q.stride(0));   kargs.stride_q_n = static_cast<int>(q.stride(1));   kargs.stride_q_h = static_cast<int>(q.stride(2));
@@ -232,8 +234,8 @@ void launch_d192_v128(at::Tensor& q,
         num_q_blocks = ceil_div(N, Q_BLOCK);
     }
 
-    AITER_CHECK(H_KV > 0 && (H % H_KV) == 0, "H must be divisible by H_KV (GQA group)");
-    AITER_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1 && out.stride(-1) == 1,
+    TORCH_CHECK(H_KV > 0 && (H % H_KV) == 0, "H must be divisible by H_KV (GQA group)");
+    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1 && out.stride(-1) == 1,
                 "q/k/v/out must be contiguous along the head dim");
     if (B == 0 || H == 0) return;
 
@@ -306,26 +308,28 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
                             int max_seqlen_q,
                             int max_seqlen_k)
 {
-    AITER_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda() && out.is_cuda(),
-                "q/k/v/out must be GPU tensors");
-    AITER_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type() &&
+    TORCH_CHECK(q.is_cuda(), "q must be a GPU tensor");
+    TORCH_CHECK(k.device() == q.device() && v.device() == q.device() &&
+                    out.device() == q.device(),
+                "q/k/v/out must be on the same device");
+    TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type() &&
                     q.scalar_type() == out.scalar_type(),
                 "q/k/v/out must share dtype");
-    AITER_CHECK(q.scalar_type() == at::kBFloat16, "fmha_fwd_bf16_opus_fwd only supports bf16");
+    TORCH_CHECK(q.scalar_type() == at::kBFloat16, "fmha_fwd_bf16_opus_fwd only supports bf16");
 
     const int D_QK = static_cast<int>(q.size(-1));
     const int D_V  = static_cast<int>(v.size(-1));
     const bool is_group = seqstart_q.has_value() && seqstart_q->numel() > 0;
 
     if (D_QK == 128 && D_V == 128) {
-        AITER_CHECK(!is_group, "OPUS D=128 kernel supports batch mode only (no varlen)");
+        TORCH_CHECK(!is_group, "OPUS D=128 kernel supports batch mode only (no varlen)");
         launch_d128(q, k, v, out, causal, softmax_scale);
     } else if (D_QK == 192 && D_V == 128) {
         launch_d192_v128(q, k, v, out, causal, softmax_scale,
                          seqstart_q, seqstart_k, seqstart_q_pad, seqstart_k_pad,
                          max_seqlen_q, max_seqlen_k);
     } else {
-        AITER_CHECK(false, "OPUS fwd supports (D_QK,D_V) in {(128,128),(192,128)}, got (",
+        TORCH_CHECK(false, "OPUS fwd supports (D_QK,D_V) in {(128,128),(192,128)}, got (",
                     D_QK, ",", D_V, ")");
     }
 }

--- a/csrc/pybind/fmha_fwd_bf16_opus_pybind.cu
+++ b/csrc/pybind/fmha_fwd_bf16_opus_pybind.cu
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #include "rocm_ops.hpp"
-#include "aiter_stream.h"
-#include "fmha_fwd_bf16_opus.h"
+#include "torch/fmha_fwd_bf16_opus.h"
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
-    AITER_SET_STREAM_PYBIND
     FMHA_FWD_BF16_OPUS_PYBIND;
 }


### PR DESCRIPTION
## Motivation

The OPUS (192,128) forward is enabled by default on gfx950 and crashes under vLLM with `TypeError: fmha_fwd_bf16_opus_fwd(): incompatible function arguments` (reported on #4205). `aiter_tensor_t` is a pybind11-registered class owned by `module_aiter_core`, but `module_fmha_fwd_bf16_opus` is excluded from the wheel prebuild and JIT-built at runtime — when the two `.so` files end up with different `PYBIND11_INTERNALS_ID` they no longer share a pybind type registry, the registration is invisible, and every tensor argument is rejected.

## Technical Details

Switch the entry point to `at::Tensor` / `std::optional<at::Tensor>` and drop `develop=True`, matching every other JIT-built pybind module in aiter: torch's own type caster only does a `THPVariable_Check()` and never touches the pybind registry, so it cannot break across a toolchain boundary. The declaration moves to `csrc/include/torch/`, and the device guard / stream now come from the tensor (`at::hip::getCurrentHIPStream`), which makes `AITER_SET_STREAM_PYBIND` unnecessary; no kernel or launch-logic changes.

## Test Plan

* `pytest op_tests/test_mha.py -k opus`.
* The reporter's repro (`flash_attn_varlen_func`, bf16 D_QK=192/D_V=128, causal) in `vllm/vllm-openai-rocm` on the stock `amd-aiter 0.1.19` wheel — i.e. prebuilt `module_aiter_core.so` plus a runtime-JIT OPUS module — additionally with a deliberately mismatched pybind ABI (`-DPYBIND11_COMPILER_TYPE=\"_gcc\"` on this module only) to force the two `.so` files into separate type registries.

## Test Result

* **50 passed**, no numerical change.
* Repro passes. With the injected mismatch (`..._v11_gcc_...` vs `..._v11_system_...`) it reproduced the reported `TypeError` verbatim before this change and passes after. Env: gfx950 (MI355), ROCm 7.2.2.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
